### PR TITLE
fix(notifications): emit ask Telegram notification at invocation, not on resolve

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -78,6 +78,12 @@ export const DAEMON_VERSION = 1;
 
 const nodeFs: TelegramDaemonFs = fs.promises as unknown as TelegramDaemonFs;
 const RATE_LIMIT_FLUSH_INTERVAL_MS = 1_000;
+// How often the daemon rescans for newly-started sessions. This MUST run
+// independently of the Telegram getUpdates long-poll (up to 25s): otherwise a
+// session that starts mid-poll is not connected until the poll returns, so its
+// buffered ask is delivered up to 25s late — or never, if the user answers the
+// local ask first (which clears the buffered ask).
+const SESSION_SCAN_INTERVAL_MS = 1_000;
 
 export function daemonPaths(agentDir: string): DaemonPaths {
 	const dir = path.join(agentDir, "notifications");
@@ -390,6 +396,7 @@ export interface TelegramDaemonOptions {
 	setIntervalImpl?: typeof setInterval;
 	clearIntervalImpl?: typeof clearInterval;
 	idleTimeoutMs?: number;
+	scanIntervalMs?: number;
 	pid?: number;
 	botApi?: BotApi;
 }
@@ -413,6 +420,8 @@ export class TelegramNotificationDaemon {
 	private readonly pool: RateLimitPool<{ send: ThreadedSend; topicId: string }>;
 	private readonly seenUpdateIds = new Set<number>();
 	private flushTimer: ReturnType<typeof setInterval> | undefined;
+	private scanTimer: ReturnType<typeof setInterval> | undefined;
+	private scanning = false;
 
 	constructor(private readonly opts: TelegramDaemonOptions) {
 		this.fsImpl = opts.fs ?? nodeFs;
@@ -623,6 +632,33 @@ export class TelegramNotificationDaemon {
 		this.flushTimer = undefined;
 	}
 
+	/** Run a root scan, guarding against overlapping scans from the timer + loop. */
+	private async runScan(): Promise<void> {
+		if (this.scanning) return;
+		this.scanning = true;
+		try {
+			await this.scanRoots();
+		} finally {
+			this.scanning = false;
+		}
+	}
+
+	private startScanTimer(): void {
+		if (this.scanTimer) return;
+		const setIntervalImpl = this.opts.setIntervalImpl ?? setInterval;
+		this.scanTimer = setIntervalImpl(() => {
+			if (!this.running) return;
+			void this.runScan();
+		}, this.opts.scanIntervalMs ?? SESSION_SCAN_INTERVAL_MS);
+	}
+
+	private stopScanTimer(): void {
+		if (!this.scanTimer) return;
+		const clearIntervalImpl = this.opts.clearIntervalImpl ?? clearInterval;
+		clearIntervalImpl(this.scanTimer);
+		this.scanTimer = undefined;
+	}
+
 	async handleSessionMessage(session: SessionSocket, msg: any): Promise<void> {
 		if (typeof msg?.type === "string" && TelegramNotificationDaemon.THREADED_FRAMES.has(msg.type)) {
 			const send = renderThreadedFrame(msg);
@@ -831,11 +867,12 @@ export class TelegramNotificationDaemon {
 		});
 		if (!this.running) return;
 		this.startFlushTimer();
+		this.startScanTimer();
 		try {
 			await this.registerBotCommands();
 			await this.loadAliases();
 			await this.loadTopics();
-			await this.scanRoots();
+			await this.runScan();
 			let idleSince = (this.opts.now ?? Date.now)();
 			while (this.running) {
 				if (
@@ -848,7 +885,7 @@ export class TelegramNotificationDaemon {
 					}))
 				)
 					break;
-				await this.scanRoots();
+				await this.runScan();
 				if (this.sessions.size === 0) {
 					if ((this.opts.now ?? Date.now)() - idleSince >= (this.opts.idleTimeoutMs ?? 60_000)) break;
 				} else {
@@ -859,6 +896,7 @@ export class TelegramNotificationDaemon {
 			}
 		} finally {
 			this.stopFlushTimer();
+			this.stopScanTimer();
 			await releaseDaemonOwnership({
 				settings: this.opts.settings,
 				ownerId: this.opts.ownerId,

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { Settings } from "../src/config/settings";
 import {
 	acquireDaemonOwnership,
+	DAEMON_VERSION,
 	daemonPaths,
 	ensureTelegramDaemonRunning,
 	registerNotificationRoot,
@@ -432,6 +433,87 @@ describe("telegram daemon", () => {
 		expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(true);
 		await releaseDaemonOwnership({ settings: s, ownerId: "owner" });
 		expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(false);
+	});
+
+	test("scan timer connects new sessions while a getUpdates long-poll is in flight", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "fp",
+			chatId: "42",
+			pid: process.pid,
+			randomId: () => "owner",
+		});
+
+		// Endpoint discovery files live at <cwd>/.gjc/state/notifications/<sessionId>.json.
+		const writeEndpoint = async (cwd: string, sessionId: string, url: string) => {
+			await registerNotificationRoot({ settings: s, cwd, sessionId });
+			const dir = path.join(cwd, ".gjc", "state", "notifications");
+			fs.mkdirSync(dir, { recursive: true });
+			fs.writeFileSync(path.join(dir, `${sessionId}.json`), JSON.stringify({ url, token: "tok" }));
+		};
+
+		// Session A exists from the start so the run loop reaches the long-poll branch.
+		await writeEndpoint(path.join(agentDir, "cwd-a"), "A", "ws://a");
+
+		// getUpdates blocks (simulating the 25s long-poll) until released, so the
+		// run loop's own scanRoots call cannot pick up session B.
+		let releasePoll: () => void = () => {};
+		const pollGate = new Promise<void>(resolve => {
+			releasePoll = resolve;
+		});
+		const inner = new FakeBotApi();
+		const gatedBot = {
+			get calls() {
+				return inner.calls;
+			},
+			async call(method: string, body: unknown): Promise<unknown> {
+				if (method === "getUpdates") {
+					await pollGate;
+					return { ok: true, result: [] };
+				}
+				return inner.call(method, body);
+			},
+		};
+
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: gatedBot,
+			WebSocketImpl: FakeWs as any,
+			scanIntervalMs: 5,
+			idleTimeoutMs: 60_000,
+		});
+
+		const until = async (pred: () => boolean, ms = 2000) => {
+			const start = Date.now();
+			while (!pred()) {
+				if (Date.now() - start > ms) throw new Error("condition not met in time");
+				await new Promise(r => setTimeout(r, 5));
+			}
+		};
+
+		const runPromise = daemon.run();
+		await until(() => daemon.sessions.has("A"));
+
+		// Session B starts AFTER the loop is blocked in the long-poll. The scan timer
+		// (not the long-poll-gated loop scan) must connect it promptly.
+		await writeEndpoint(path.join(agentDir, "cwd-b"), "B", "ws://b");
+		await until(() => daemon.sessions.has("B"));
+		expect(daemon.sessions.has("B")).toBe(true);
+
+		// Stop: hand ownership to another owner so the next heartbeat renew fails,
+		// then release the long-poll so the loop can observe it and exit.
+		fs.writeFileSync(
+			daemonPaths(agentDir).state,
+			JSON.stringify({ version: DAEMON_VERSION, ownerId: "other", pid: 1, heartbeatAt: 0 }),
+		);
+		releasePoll();
+		await runPromise;
 	});
 });
 


### PR DESCRIPTION
## Problem

The `ask` tool did not emit a Telegram notification when invoked — a message only appeared *after* the ask was answered or cancelled locally, making it impossible to answer asks through Telegram.

## Root cause

The notification daemon's run loop ran `scanRoots()` (discovers/connects new agent sessions) and `pollOnce()` **serially**, where `pollOnce()` issues a `getUpdates` long-poll with `timeout: 25`s:

```
while (running) {
  await scanRoots();
  ...
  await pollOnce();   // blocks up to 25s
}
```

When the `ask` tool runs, the notifications extension's answer source calls `registerAsk()`, which broadcasts `action_needed` and buffers it for replay to late-connecting clients. But a session that started while the daemon was blocked in the 25s long-poll wasn't connected until the poll returned — so the buffered ask was delivered up to 25s late, **or never**, because answering/cancelling locally calls `resolveLocal()` which clears the buffer. The user only ever saw Telegram traffic *after* the ask was resolved.

## Fix

Decouple session discovery from the Telegram long-poll with an independent scan timer (mirroring the existing flush-timer pattern):

- `SESSION_SCAN_INTERVAL_MS = 1_000` + `scanIntervalMs` option (for tests)
- `runScan()` re-entrancy guard so the timer and loop never double-connect a session
- `startScanTimer()` / `stopScanTimer()` started in `run()`, stopped in its `finally`
- Loop scans now route through `runScan()`

New sessions (and their buffered ask) connect within ~1s regardless of an in-flight long-poll.

## Verification

- New regression test `scan timer connects new sessions while a getUpdates long-poll is in flight` — confirmed it **fails** without the timer and **passes** with it.
- All 21 daemon tests + 132 notification tests pass; changed files typecheck and format clean.