### PR TITLE
feat(notifications): typing indicator + native double-check acks for Telegram

### DIFF
--- a/crates/gjc-notifications/src/protocol.rs
+++ b/crates/gjc-notifications/src/protocol.rs
@@ -170,6 +170,10 @@ pub enum ServerMessage {
 	ConfigUpdate(ConfigUpdate),
 	/// Server capability/version advertisement for negotiation.
 	Hello(ServerHello),
+	/// Live agent-activity signal driving the client typing indicator.
+	Activity(Activity),
+	/// Inbound user-message delivery acknowledgement (native double-check UX).
+	InboundAck(InboundAck),
 	/// Forward-compat: an unrecognized frame type. Tolerated, never emitted.
 	#[serde(other)]
 	Unknown,
@@ -355,6 +359,51 @@ pub struct ConfigCommand {
 	pub redact:     Option<bool>,
 }
 
+/// Agent loop activity state, driving the client's live typing indicator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityState {
+	/// The agent loop is running (thinking/streaming); show typing.
+	Busy,
+	/// The agent loop has settled, awaiting input; clear typing.
+	Idle,
+}
+
+/// A live agent-activity signal. Emitted on agent loop start/settle so a client
+/// can show/clear a native typing indicator while the agent is thinking.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Activity {
+	/// The session this activity belongs to.
+	pub session_id: String,
+	/// Whether the agent is currently busy or idle.
+	pub state:      ActivityState,
+}
+
+/// Delivery state of a previously-injected inbound user message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InboundAckState {
+	/// Received and queued (agent busy / message held as a steer).
+	Queued,
+	/// Consumed by a turn (the agent has picked the message up).
+	Consumed,
+}
+
+/// Acknowledges progress of an inbound [`UserMessage`] (matched by `update_id`)
+/// so the client can reflect a native double-check delivery state on the
+/// originating message.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InboundAck {
+	/// The session that received the inbound message.
+	pub session_id: String,
+	/// The Telegram update id this acknowledgement refers to.
+	pub update_id:  i64,
+	/// The delivery state now reached.
+	pub state:      InboundAckState,
+}
+
 /// Current protocol version emitted in [`ServerHello`].
 pub const PROTOCOL_VERSION: u32 = 2;
 
@@ -370,6 +419,10 @@ pub mod capabilities {
 	pub const IMAGES: &str = "images";
 	/// Config push/commands.
 	pub const CONFIG: &str = "config";
+	/// Live typing indicator driven by activity signals.
+	pub const TYPING: &str = "typing";
+	/// Inbound user-message delivery acknowledgements (double-check UX).
+	pub const INBOUND_ACK: &str = "inbound_ack";
 }
 
 #[cfg(test)]
@@ -735,5 +788,28 @@ mod tests {
 			serde_json::from_str(r#"{"type":"future_client","payload":1}"#).unwrap();
 		assert_eq!(server, ServerMessage::Unknown);
 		assert_eq!(client, ClientMessage::Unknown);
+	}
+
+	#[test]
+	fn activity_serializes_snake_type_and_state() {
+		let msg = ServerMessage::Activity(Activity {
+			session_id: "sess-1".into(),
+			state:      ActivityState::Busy,
+		});
+		let v = serde_json::to_value(&msg).unwrap();
+		assert_eq!(v["type"], "activity");
+		assert_eq!(v["sessionId"], "sess-1");
+		assert_eq!(v["state"], "busy");
+	}
+
+	#[test]
+	fn inbound_ack_roundtrips_consumed() {
+		let raw = r#"{"type":"inbound_ack","sessionId":"sess-1","updateId":42,"state":"consumed"}"#;
+		let ServerMessage::InboundAck(ack) = serde_json::from_str(raw).unwrap() else {
+			panic!("expected inbound_ack")
+		};
+		assert_eq!(ack.session_id, "sess-1");
+		assert_eq!(ack.update_id, 42);
+		assert_eq!(ack.state, InboundAckState::Consumed);
 	}
 }

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -138,6 +138,10 @@ interface SessionRuntime {
 	disposeAnswerSource: () => void;
 	redact: boolean;
 	sessionTag: string;
+	/** Whether the agent loop is currently running (drives the typing indicator). */
+	busy: boolean;
+	/** Inbound Telegram update ids injected but not yet consumed by a turn. */
+	pendingInbound: Set<number>;
 }
 
 interface ResolvedSettings {
@@ -311,8 +315,12 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 			if (inbound.kind === "user_message" && inbound.text) {
 				// Inject as a user turn (steers/continues the agent; the resulting
 				// turn streams back via the turn_end handler even when not idle).
+				// Record the update id so it can be acked as "consumed" on the next
+				// turn_start, and steer (vs start a fresh turn) when already busy.
+				const rt = runtimes.get(id);
+				if (rt && typeof inbound.updateId === "number") rt.pendingInbound.add(inbound.updateId);
 				try {
-					api.sendUserMessage(inbound.text);
+					api.sendUserMessage(inbound.text, rt?.busy ? { deliverAs: "steer" } : undefined);
 				} catch (e) {
 					logger.warn(`notifications: sendUserMessage failed: ${String(e)}`);
 				}
@@ -367,6 +375,8 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 				disposeAnswerSource,
 				redact,
 				sessionTag: tag,
+				busy: false,
+				pendingInbound: new Set<number>(),
 			});
 			logger.info(`notifications: serving session ${id} at ${endpoint.url} (unattended=${unattended})`);
 
@@ -497,6 +507,38 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		await startSession(ctx);
 	});
 
+	// Drive the live typing indicator: mark busy when the agent loop starts so
+	// the daemon shows "typing…" in the thread while the agent is thinking,
+	// before any turn output exists. Cleared on `agent_end` below.
+	api.on("agent_start", (_event, ctx) => {
+		const id = sessionId(ctx);
+		const rt = runtimes.get(id);
+		if (!rt) return;
+		rt.busy = true;
+		try {
+			rt.server.pushFrame(JSON.stringify({ type: "activity", sessionId: id, state: "busy" }));
+		} catch (e) {
+			logger.warn(`notifications: activity (busy) failed: ${String(e)}`);
+		}
+	});
+
+	// Each turn that starts has absorbed any messages injected from the thread,
+	// so ack them as "consumed": the daemon flips the queued reaction on the
+	// originating Telegram message to the consumed (double-check) reaction.
+	api.on("turn_start", (_event, ctx) => {
+		const id = sessionId(ctx);
+		const rt = runtimes.get(id);
+		if (!rt || rt.pendingInbound.size === 0) return;
+		for (const updateId of rt.pendingInbound) {
+			try {
+				rt.server.pushFrame(JSON.stringify({ type: "inbound_ack", sessionId: id, updateId, state: "consumed" }));
+			} catch (e) {
+				logger.warn(`notifications: inbound_ack failed: ${String(e)}`);
+			}
+		}
+		rt.pendingInbound.clear();
+	});
+
 	// Idle fires on `agent_end` (the agent loop settling to await the user), NOT
 	// per `turn_end`. turn_end fires once per turn iteration, so a single
 	// user-visible idle previously produced many idle pings (the flood); agent_end
@@ -506,6 +548,13 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		const rt = runtimes.get(id);
 		if (!rt) return;
 		const seq = rt.idleSeq++;
+		// Clear the typing indicator: the agent loop has settled.
+		rt.busy = false;
+		try {
+			rt.server.pushFrame(JSON.stringify({ type: "activity", sessionId: id, state: "idle" }));
+		} catch (e) {
+			logger.warn(`notifications: activity (idle) failed: ${String(e)}`);
+		}
 		// Re-assert the identity header so the daemon renames the topic once the
 		// session title has been auto-generated ("{repo}/{branch} - {title}"). The
 		// daemon only renames when the title actually changed.

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -89,6 +89,13 @@ const BOT_API_RETRY_ATTEMPTS = 3;
 // Backoff after a failed getUpdates long-poll so a persistent outage does not
 // busy-loop the daemon.
 const POLL_BACKOFF_MS = 1_000;
+// Telegram clears a chat action after ~5s; refresh slightly sooner to keep the
+// typing indicator alive while the agent is busy.
+const TYPING_REFRESH_INTERVAL_MS = 4_000;
+// Native reactions used as a two-stage delivery double-check on inbound thread
+// messages: queued on receipt, consumed once a turn picks the message up.
+const QUEUED_REACTION = "👀";
+const CONSUMED_REACTION = "✅";
 
 /**
  * Whether `err` is a transient network failure worth retrying. Telegram API
@@ -480,6 +487,11 @@ export class TelegramNotificationDaemon {
 	private flushTimer: ReturnType<typeof setInterval> | undefined;
 	private scanTimer: ReturnType<typeof setInterval> | undefined;
 	private scanning = false;
+	private typingTimer: ReturnType<typeof setInterval> | undefined;
+	/** Sessions whose agent loop is currently busy (drives the typing indicator). */
+	private readonly busy = new Set<string>();
+	/** Inbound update id → originating Telegram message, for delivery reactions. */
+	private readonly inboundReactions = new Map<number, { messageId: number }>();
 
 	constructor(private readonly opts: TelegramDaemonOptions) {
 		this.fsImpl = opts.fs ?? nodeFs;
@@ -575,6 +587,7 @@ export class TelegramNotificationDaemon {
 		});
 		ws.addEventListener("close", () => {
 			this.sessions.delete(sessionId);
+			this.busy.delete(sessionId);
 		});
 	}
 
@@ -724,7 +737,72 @@ export class TelegramNotificationDaemon {
 		this.scanTimer = undefined;
 	}
 
+	/** Send a single `typing` chat action into a busy session's topic (best-effort). */
+	private async sendTyping(sessionId: string): Promise<void> {
+		const topicId = this.topics.get(sessionId)?.topicId;
+		if (!topicId) return;
+		try {
+			await this.botApi.call("sendChatAction", {
+				chat_id: this.opts.chatId,
+				message_thread_id: Number(topicId),
+				action: "typing",
+			});
+		} catch {
+			// Best-effort: a failed chat action must never stop the daemon.
+		}
+	}
+
+	/** Set a native reaction on an inbound thread message (best-effort). */
+	private async setReaction(messageId: number, emoji: string): Promise<void> {
+		try {
+			await this.botApi.call("setMessageReaction", {
+				chat_id: this.opts.chatId,
+				message_id: messageId,
+				reaction: [{ type: "emoji", emoji }],
+			});
+		} catch {
+			// Best-effort: reactions may be disallowed in the chat; never throw.
+		}
+	}
+
+	private startTypingTimer(): void {
+		if (this.typingTimer) return;
+		const setIntervalImpl = this.opts.setIntervalImpl ?? setInterval;
+		this.typingTimer = setIntervalImpl(() => {
+			if (!this.running || this.busy.size === 0) return;
+			for (const sessionId of this.busy) void this.sendTyping(sessionId);
+		}, TYPING_REFRESH_INTERVAL_MS);
+	}
+
+	private stopTypingTimer(): void {
+		if (!this.typingTimer) return;
+		const clearIntervalImpl = this.opts.clearIntervalImpl ?? clearInterval;
+		clearIntervalImpl(this.typingTimer);
+		this.typingTimer = undefined;
+	}
+
 	async handleSessionMessage(session: SessionSocket, msg: any): Promise<void> {
+		// Live typing indicator: track busy/idle per session and push an immediate
+		// chat action so "typing…" appears without waiting for the refresh tick.
+		if (msg?.type === "activity") {
+			if (msg.state === "busy") {
+				this.busy.add(session.sessionId);
+				await this.sendTyping(session.sessionId);
+			} else {
+				this.busy.delete(session.sessionId);
+			}
+			return;
+		}
+		// Inbound delivery double-check: flip the queued reaction to the consumed
+		// reaction once the session reports a turn picked the message up.
+		if (msg?.type === "inbound_ack" && typeof msg.updateId === "number") {
+			const target = this.inboundReactions.get(msg.updateId);
+			if (target && msg.state === "consumed") {
+				this.inboundReactions.delete(msg.updateId);
+				await this.setReaction(target.messageId, CONSUMED_REACTION);
+			}
+			return;
+		}
 		if (typeof msg?.type === "string" && TelegramNotificationDaemon.THREADED_FRAMES.has(msg.type)) {
 			const send = renderThreadedFrame(msg);
 			if (!send) return;
@@ -867,6 +945,13 @@ export class TelegramNotificationDaemon {
 									},
 						),
 					);
+					// User turns get a native delivery double-check: queued on receipt,
+					// flipped to consumed when the session acks the turn that picks it
+					// up. Config commands are not user turns and get no reaction.
+					if (!cfg && inbound.messageId !== undefined) {
+						this.inboundReactions.set(inbound.updateId, { messageId: inbound.messageId });
+						await this.setReaction(inbound.messageId, QUEUED_REACTION);
+					}
 				}
 				return;
 			}
@@ -947,6 +1032,7 @@ export class TelegramNotificationDaemon {
 		if (!this.running) return;
 		this.startFlushTimer();
 		this.startScanTimer();
+		this.startTypingTimer();
 		try {
 			await this.registerBotCommands();
 			await this.loadAliases();
@@ -976,6 +1062,7 @@ export class TelegramNotificationDaemon {
 		} finally {
 			this.stopFlushTimer();
 			this.stopScanTimer();
+			this.stopTypingTimer();
 			await releaseDaemonOwnership({
 				settings: this.opts.settings,
 				ownerId: this.opts.ownerId,

--- a/packages/coding-agent/src/notifications/threaded-inbound.ts
+++ b/packages/coding-agent/src/notifications/threaded-inbound.ts
@@ -19,6 +19,7 @@
 export interface InboundUpdate {
 	update_id?: unknown;
 	message?: {
+		message_id?: unknown;
 		text?: unknown;
 		chat?: { id?: unknown };
 		message_thread_id?: unknown;
@@ -37,7 +38,7 @@ export interface ThreadedInboundCtx {
 
 /** Outcome of routing an inbound update. */
 export type ThreadedInboundDecision =
-	| { kind: "inject"; sessionId: string; text: string; updateId: number; threadId: string }
+	| { kind: "inject"; sessionId: string; text: string; updateId: number; threadId: string; messageId?: number }
 	| { kind: "duplicate"; updateId: number }
 	| { kind: "ignore"; reason: string };
 
@@ -74,5 +75,6 @@ export function decideThreadedInbound(update: InboundUpdate, ctx: ThreadedInboun
 	const text = typeof message.text === "string" ? message.text.trim() : "";
 	if (!text) return { kind: "ignore", reason: "empty_text" };
 
-	return { kind: "inject", sessionId, text, updateId, threadId };
+	const messageId = typeof message.message_id === "number" ? message.message_id : undefined;
+	return { kind: "inject", sessionId, text, updateId, threadId, messageId };
 }

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -737,3 +737,74 @@ test("identity_header without title or repo falls back to the GJC session label"
 	expect(createTopic).toBeTruthy();
 	expect(createTopic!.body.name).toBe("GJC 123456");
 });
+test("activity busy frame sends a typing chat action into the session topic", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	// Create the topic first so the typing action has somewhere to go.
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	await daemon.handleSessionMessage(session as any, { type: "activity", sessionId: "S", state: "busy" });
+	const typing = bot.calls.find(c => c.method === "sendChatAction");
+	expect(typing).toBeTruthy();
+	expect(typing!.body.action).toBe("typing");
+	expect(Number(typing!.body.message_thread_id)).toBeGreaterThan(0);
+	// Idle clears busy; activity idle itself sends no chat action.
+	bot.calls = [];
+	await daemon.handleSessionMessage(session as any, { type: "activity", sessionId: "S", state: "idle" });
+	expect(bot.calls.some(c => c.method === "sendChatAction")).toBe(false);
+});
+
+test("inbound thread message gets a queued reaction, flipped to consumed on ack", async () => {
+	FakeWs.instances = [];
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+	});
+	daemon.connectSession("S", "ws://s", "ts");
+	const session = daemon.sessions.get("S")!;
+	// Create the topic and learn its thread id from the pinned identity message.
+	await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
+	const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
+	bot.calls = [];
+
+	await daemon.handleTelegramUpdate({
+		update_id: 7,
+		message: { chat: { id: 42 }, message_thread_id: threadId, message_id: 555, text: "steer me" },
+	});
+	// The user turn is forwarded to the session…
+	expect(JSON.parse(FakeWs.instances[0]!.sent[0]!)).toMatchObject({
+		type: "user_message",
+		text: "steer me",
+		updateId: 7,
+	});
+	// …and the originating message gets the queued reaction.
+	const queued = bot.calls.find(c => c.method === "setMessageReaction");
+	expect(queued).toBeTruthy();
+	expect(queued!.body.message_id).toBe(555);
+	expect(queued!.body.reaction[0].emoji).toBe("👀");
+
+	bot.calls = [];
+	await daemon.handleSessionMessage(session, { type: "inbound_ack", sessionId: "S", updateId: 7, state: "consumed" });
+	const consumed = bot.calls.find(c => c.method === "setMessageReaction");
+	expect(consumed).toBeTruthy();
+	expect(consumed!.body.message_id).toBe(555);
+	expect(consumed!.body.reaction[0].emoji).toBe("✅");
+});


### PR DESCRIPTION
## Summary

Improves the Telegram notifications SDK with three additions requested for message-state UX:

1. **Typing / thinking indicator** — the session emits an `activity` busy/idle signal on `agent_start`/`agent_end`; the daemon sends `sendChatAction("typing")` into the session's forum topic on a ~4s refresh loop (Telegram clears the action at ~5s) while the agent is busy, so "typing…" appears during thinking, before any output exists.

2. **Sent-confirmation double-check (native reactions)** — inbound thread messages get a two-stage native `setMessageReaction`: **queued** (👀) on receipt, flipped to **consumed** (✅) once a turn actually picks the message up.

3. **Steering queued / consumed** — inbound messages **steer** the running turn when the agent is busy and **start a fresh turn** when idle; the session acks consumption on the next `turn_start`, which drives the consumed reaction.

## Implementation

- **Protocol** (`crates/gjc-notifications`): new `Activity` and `InboundAck` `ServerMessage` variants (+ `typing`/`inbound_ack` capability tokens). Native rebuilt — `pushFrame` validates against the typed enum, so unknown frame types collapse to `Unknown` without the variants.
- **Session** (`notifications/index.ts`): busy/idle activity frames, inbound `updateId` tracking, `deliverAs: "steer"` when busy, and `inbound_ack: consumed` on `turn_start`.
- **Daemon** (`notifications/telegram-daemon.ts`): busy-set + typing refresh timer, queued reaction on inbound forward, consumed reaction on ack. All chat-action/reaction/send calls are best-effort (never stall the daemon).
- **Inbound routing** (`threaded-inbound.ts`): surfaces inbound `message_id` for reactions.

## Tests
- Rust: `activity` serialization + `inbound_ack` roundtrip unit tests (`cargo test -p gjc-notifications`, 58 pass).
- TS: new daemon tests for typing chat action and queued→consumed reactions; full notifications suites (daemon, reference, threaded-inbound/render, e2e, topic-registry, config-commands, compiled-daemon smoke) pass.
- `tsgo` typecheck + biome clean.

## Notes
- Consumed reaction is `✅`; if a forum supergroup restricts reactions to the default set it may be silently rejected (best-effort). Emojis are constants (`QUEUED_REACTION`/`CONSUMED_REACTION`) at the top of `telegram-daemon.ts`.
- Native addon rebuilt for `darwin-arm64`; CI/other platforms rebuild from the updated crate automatically.