### PR TITLE
fix(notifications): recover in-flight session after connection drop

### DIFF
--- a/crates/gjc-notifications/src/protocol.rs
+++ b/crates/gjc-notifications/src/protocol.rs
@@ -174,6 +174,8 @@ pub enum ServerMessage {
 	Activity(Activity),
 	/// Inbound user-message delivery acknowledgement (native double-check UX).
 	InboundAck(InboundAck),
+	/// Application-level liveness response to a client ping.
+	Pong(Pong),
 	/// Forward-compat: an unrecognized frame type. Tolerated, never emitted.
 	#[serde(other)]
 	Unknown,
@@ -191,6 +193,8 @@ pub enum ClientMessage {
 	UserMessage(UserMessage),
 	/// An in-thread configuration command (verbosity/redact toggles).
 	ConfigCommand(ConfigCommand),
+	/// Application-level liveness ping from a client.
+	Ping(Ping),
 	/// Forward-compat: an unrecognized frame type. Tolerated, ignored.
 	#[serde(other)]
 	Unknown,
@@ -325,6 +329,22 @@ pub struct ClientHello {
 	pub capabilities:     Vec<String>,
 }
 
+/// Application-level liveness ping.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Ping {
+	/// Opaque client nonce echoed in the response.
+	pub nonce: String,
+}
+
+/// Application-level liveness pong.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Pong {
+	/// Opaque client nonce from the ping.
+	pub nonce: String,
+}
+
 /// An inbound free-text user message injecting/steering a session turn.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -423,6 +443,8 @@ pub mod capabilities {
 	pub const TYPING: &str = "typing";
 	/// Inbound user-message delivery acknowledgements (double-check UX).
 	pub const INBOUND_ACK: &str = "inbound_ack";
+	/// Application-level client ping/server pong.
+	pub const CLIENT_PING_PONG: &str = "client_ping_pong";
 }
 
 #[cfg(test)]
@@ -624,6 +646,38 @@ mod tests {
 		assert_eq!(v["type"], "hello");
 		assert_eq!(v["protocolVersion"], 2);
 		assert_eq!(v["capabilities"][0], "threaded");
+	}
+
+	#[test]
+	fn ping_roundtrips() {
+		let raw = r#"{"type":"ping","nonce":"n1"}"#;
+		let msg: ClientMessage = serde_json::from_str(raw).unwrap();
+		assert_eq!(msg, ClientMessage::Ping(Ping { nonce: "n1".into() }));
+		assert_eq!(serde_json::to_string(&msg).unwrap(), raw);
+	}
+
+	#[test]
+	fn pong_serializes() {
+		let msg = ServerMessage::Pong(Pong { nonce: "n1".into() });
+		assert_eq!(serde_json::to_string(&msg).unwrap(), r#"{"type":"pong","nonce":"n1"}"#);
+	}
+
+	#[test]
+	fn server_hello_serializes_client_ping_pong_capability() {
+		let msg = ServerMessage::Hello(ServerHello {
+			protocol_version: PROTOCOL_VERSION,
+			capabilities:     vec![capabilities::CLIENT_PING_PONG.into()],
+		});
+		let v: serde_json::Value = serde_json::to_value(&msg).unwrap();
+		assert_eq!(v["type"], "hello");
+		assert_eq!(v["protocolVersion"], 2);
+		assert!(
+			v["capabilities"]
+				.as_array()
+				.unwrap()
+				.iter()
+				.any(|cap| cap == capabilities::CLIENT_PING_PONG)
+		);
 	}
 
 	#[test]

--- a/crates/gjc-notifications/src/server.rs
+++ b/crates/gjc-notifications/src/server.rs
@@ -37,7 +37,8 @@ use crate::{
 	actions::{ActionRegistry, ReplyClassification, ReplyOutcome},
 	discovery::EndpointRecord,
 	protocol::{
-		ActionNeeded, ClientMessage, RejectReason, Reply, ReplyAnswer, ReplyRejected, ServerMessage,
+		ActionNeeded, ClientMessage, PROTOCOL_VERSION, Pong, RejectReason, Reply, ReplyAnswer,
+		ReplyRejected, ServerHello, ServerMessage, capabilities,
 	},
 };
 
@@ -331,6 +332,20 @@ async fn handle_conn(stream: TcpStream, state: Arc<ServerState>, cancel: Cancell
 
 	let mut rx = state.tx.subscribe();
 	let (mut write, mut read) = ws.split();
+	let hello = ServerMessage::Hello(ServerHello {
+		protocol_version: PROTOCOL_VERSION,
+		capabilities:     vec![
+			capabilities::THREADED.into(),
+			capabilities::CONTEXT.into(),
+			capabilities::TURN_STREAM.into(),
+			capabilities::IMAGES.into(),
+			capabilities::CONFIG.into(),
+			capabilities::CLIENT_PING_PONG.into(),
+		],
+	});
+	if send_msg(&mut write, &hello).await.is_err() {
+		return;
+	}
 
 	// Replay the buffered ask (if any) to this freshly-connected client.
 	let replay = state.registry.lock().replay_for_new_client().cloned();
@@ -401,6 +416,11 @@ where
 				let _ = state.inbound_tx.send(ClientMessage::ConfigCommand(c));
 			}
 			return true;
+		},
+		ClientMessage::Ping(p) => {
+			return send_msg(write, &ServerMessage::Pong(Pong { nonce: p.nonce }))
+				.await
+				.is_ok();
 		},
 		// Capability handshake / forward-compat: nothing to do server-side yet.
 		ClientMessage::Hello(_) | ClientMessage::Unknown => return true,
@@ -485,7 +505,7 @@ mod tests {
 	use tokio_tungstenite::connect_async;
 
 	use super::*;
-	use crate::protocol::{ActionKind, Reply};
+	use crate::protocol::{ActionKind, Ping, Reply};
 
 	fn ask(id: &str) -> ActionNeeded {
 		ActionNeeded {
@@ -511,6 +531,24 @@ mod tests {
 			if let Message::Text(t) = msg {
 				return serde_json::from_str(t.as_str()).expect("valid server message");
 			}
+		}
+	}
+
+	async fn next_server_hello<S>(read: &mut S) -> ServerHello
+	where
+		S: StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
+	{
+		match next_server_msg(read).await {
+			ServerMessage::Hello(hello) => {
+				assert_eq!(hello.protocol_version, PROTOCOL_VERSION);
+				assert!(
+					hello
+						.capabilities
+						.contains(&capabilities::CLIENT_PING_PONG.into())
+				);
+				hello
+			},
+			other => panic!("expected hello, got {other:?}"),
 		}
 	}
 
@@ -543,6 +581,7 @@ mod tests {
 	async fn ask_broadcast_then_reply_resolves() {
 		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
 		let mut ws = connect(&handle, "secret").await;
+		next_server_hello(&mut ws).await;
 		// wait for the client to be subscribed before broadcasting
 		wait_for_clients(&handle, 1).await;
 
@@ -578,6 +617,7 @@ mod tests {
 		use crate::protocol::{IdentityHeader, TurnPhase, TurnStream};
 		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
 		let mut ws = connect(&handle, "secret").await;
+		next_server_hello(&mut ws).await;
 		wait_for_clients(&handle, 1).await;
 
 		handle.push_frame(ServerMessage::IdentityHeader(IdentityHeader {
@@ -619,6 +659,7 @@ mod tests {
 	async fn unknown_action_reply_is_rejected_to_sender() {
 		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
 		let mut ws = connect(&handle, "secret").await;
+		next_server_hello(&mut ws).await;
 		wait_for_clients(&handle, 1).await;
 
 		let reply = Reply {
@@ -649,8 +690,59 @@ mod tests {
 		handle.register_ask(ask("a1"), true);
 		// connect afterwards: should receive the buffered ask on connect
 		let mut ws = connect(&handle, "secret").await;
+		next_server_hello(&mut ws).await;
 		let got = next_server_msg(&mut ws).await;
 		assert!(matches!(got, ServerMessage::ActionNeeded(a) if a.id == "a1"));
+		handle.stop();
+	}
+
+	#[tokio::test]
+	async fn hello_before_replay() {
+		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
+		handle.register_ask(ask("a1"), true);
+
+		let mut ws = connect(&handle, "secret").await;
+		let hello = next_server_hello(&mut ws).await;
+		assert_eq!(hello.capabilities, vec![
+			capabilities::THREADED,
+			capabilities::CONTEXT,
+			capabilities::TURN_STREAM,
+			capabilities::IMAGES,
+			capabilities::CONFIG,
+			capabilities::CLIENT_PING_PONG,
+		]);
+
+		match next_server_msg(&mut ws).await {
+			ServerMessage::ActionNeeded(a) => assert_eq!(a.id, "a1"),
+			other => panic!("expected replayed action_needed, got {other:?}"),
+		}
+		handle.stop();
+	}
+
+	#[tokio::test]
+	async fn ping_gets_pong() {
+		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
+		let mut sender = connect(&handle, "secret").await;
+		next_server_hello(&mut sender).await;
+		let mut other = connect(&handle, "secret").await;
+		next_server_hello(&mut other).await;
+		wait_for_clients(&handle, 2).await;
+
+		sender
+			.send(Message::Text(
+				serde_json::to_string(&ClientMessage::Ping(Ping { nonce: "n1".into() })).unwrap(),
+			))
+			.await
+			.unwrap();
+
+		match next_server_msg(&mut sender).await {
+			ServerMessage::Pong(p) => assert_eq!(p.nonce, "n1"),
+			other => panic!("expected pong, got {other:?}"),
+		}
+		let broadcast =
+			tokio::time::timeout(std::time::Duration::from_millis(300), next_server_msg(&mut other))
+				.await;
+		assert!(broadcast.is_err(), "pong must not be broadcast");
 		handle.stop();
 	}
 
@@ -658,6 +750,7 @@ mod tests {
 	async fn resolve_local_broadcasts_resolved() {
 		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
 		let mut ws = connect(&handle, "secret").await;
+		next_server_hello(&mut ws).await;
 		wait_for_clients(&handle, 1).await;
 		handle.register_ask(ask("a1"), true);
 		let _needed = next_server_msg(&mut ws).await;
@@ -691,6 +784,7 @@ mod tests {
 		assert!(handle.take_reply_receiver().is_none(), "receiver is take-once");
 
 		let mut ws = connect(&handle, "secret").await;
+		next_server_hello(&mut ws).await;
 		wait_for_clients(&handle, 1).await;
 		handle.register_ask(ask("a1"), true);
 		let _needed = next_server_msg(&mut ws).await;
@@ -727,6 +821,7 @@ mod tests {
 		let handle = start(config).await.unwrap();
 		let _rx = handle.take_reply_receiver();
 		let mut ws = connect(&handle, "secret").await;
+		next_server_hello(&mut ws).await;
 		wait_for_clients(&handle, 1).await;
 
 		let reply = Reply {
@@ -787,6 +882,7 @@ mod tests {
 		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
 		let mut inbound = handle.take_inbound_receiver().expect("inbound rx");
 		let mut ws = connect(&handle, "secret").await;
+		next_server_hello(&mut ws).await;
 		wait_for_clients(&handle, 1).await;
 		ws.send(Message::Text(
 			serde_json::to_string(&ClientMessage::UserMessage(crate::protocol::UserMessage {
@@ -821,6 +917,7 @@ mod tests {
 		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
 		let mut inbound = handle.take_inbound_receiver().expect("inbound rx");
 		let mut ws = connect(&handle, "secret").await;
+		next_server_hello(&mut ws).await;
 		wait_for_clients(&handle, 1).await;
 		ws.send(Message::Text(
 			serde_json::to_string(&ClientMessage::UserMessage(crate::protocol::UserMessage {

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1,6 +1,7 @@
 import { spawn as childProcessSpawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { logger } from "@gajae-code/utils";
 import { withFileLock } from "../config/file-lock";
 import type { Settings } from "../config/settings";
 import { getNotificationConfig, isGloballyConfigured, tokenFingerprint } from "./config";
@@ -75,6 +76,10 @@ export interface TelegramDaemonDeps {
 export const HEARTBEAT_INTERVAL_MS = 5_000;
 export const HEARTBEAT_TTL_MS = 20_000;
 export const DAEMON_VERSION = 1;
+/** Capability token advertised when the server supports app-level ping/pong. */
+export const CLIENT_PING_PONG_CAPABILITY = "client_ping_pong";
+/** Protocol version the daemon advertises in its ClientHello. */
+export const NOTIFICATION_PROTOCOL_VERSION = 2;
 
 const nodeFs: TelegramDaemonFs = fs.promises as unknown as TelegramDaemonFs;
 const RATE_LIMIT_FLUSH_INTERVAL_MS = 1_000;
@@ -471,6 +476,14 @@ interface SessionSocket {
 	token: string;
 	ws: WebSocket;
 	pending: Map<string, { sessionId: string; actionId: string }>;
+	/** True once the server advertised the `client_ping_pong` capability. */
+	capable: boolean;
+	/** Timestamp (via opts.now) of the last received pong; seeds the TTL window. */
+	lastPongAt: number;
+	/** Nonce of the most recent in-flight ping, if any. */
+	awaitingNonce: string | undefined;
+	/** Per-session liveness interval handle (only set for capable sessions). */
+	pingTimer: ReturnType<typeof setInterval> | undefined;
 }
 
 export class TelegramNotificationDaemon {
@@ -576,9 +589,37 @@ export class TelegramNotificationDaemon {
 	connectSession(sessionId: string, url: string, token: string): void {
 		const WS = this.opts.WebSocketImpl ?? WebSocket;
 		const ws = new WS(`${url}/?token=${encodeURIComponent(token)}`);
-		const session: SessionSocket = { sessionId, token, ws, pending: new Map() };
+		const session: SessionSocket = {
+			sessionId,
+			token,
+			ws,
+			pending: new Map(),
+			capable: false,
+			lastPongAt: 0,
+			awaitingNonce: undefined,
+			pingTimer: undefined,
+		};
 		this.sessions.set(sessionId, session);
+		// Bidirectional capability advertisement: announce client_ping_pong once the
+		// socket is open. Sent on "open" only — a real WHATWG WebSocket cannot send
+		// while CONNECTING — and liveness starts only after a capable ServerHello.
+		ws.addEventListener("open", () => {
+			if (session.ws.readyState === WebSocket.OPEN) {
+				try {
+					session.ws.send(
+						JSON.stringify({
+							type: "hello",
+							protocolVersion: NOTIFICATION_PROTOCOL_VERSION,
+							capabilities: [CLIENT_PING_PONG_CAPABILITY],
+						}),
+					);
+				} catch {}
+			}
+		});
 		ws.addEventListener("message", ev => {
+			// Identity guard: a delayed frame from a superseded socket must not act
+			// through the replacement session.
+			if (this.sessions.get(sessionId) !== session) return;
 			void this.handleSessionMessage(session, JSON.parse(String(ev.data))).catch(err => {
 				// Surface frame-handling failures (e.g. a rejected ask sendMessage) to
 				// the daemon log instead of an invisible unhandled rejection.
@@ -586,9 +627,59 @@ export class TelegramNotificationDaemon {
 			});
 		});
 		ws.addEventListener("close", () => {
-			this.sessions.delete(sessionId);
-			this.busy.delete(sessionId);
+			this.dropSession(session, "socket_closed");
 		});
+	}
+
+	/**
+	 * Start ack-based liveness for a session whose server advertised the
+	 * `client_ping_pong` capability. Each interval drops the session when no pong
+	 * has arrived within the TTL (the half-open case the socket never signals via
+	 * `close`), otherwise sends a fresh application-level ping. The timer is bound
+	 * to this exact session object.
+	 */
+	private startLiveness(session: SessionSocket): void {
+		if (session.pingTimer) return;
+		const setIntervalImpl = this.opts.setIntervalImpl ?? setInterval;
+		const now = () => (this.opts.now ?? Date.now)();
+		session.lastPongAt = now();
+		session.pingTimer = setIntervalImpl(() => {
+			if (this.sessions.get(session.sessionId) !== session) return;
+			const t = now();
+			if (t - session.lastPongAt >= HEARTBEAT_TTL_MS) {
+				this.dropSession(session, "liveness_timeout");
+				return;
+			}
+			if (session.ws.readyState === WebSocket.OPEN) {
+				const nonce = `${session.sessionId}:${t}:${Math.random().toString(36).slice(2)}`;
+				session.awaitingNonce = nonce;
+				try {
+					session.ws.send(JSON.stringify({ type: "ping", nonce }));
+				} catch {}
+			}
+		}, HEARTBEAT_INTERVAL_MS);
+	}
+
+	/**
+	 * Idempotent, identity-guarded session teardown. Clears the liveness timer,
+	 * removes the map entry only when it still points at this exact session object
+	 * (so a delayed old close cannot delete a replacement), and best-effort closes
+	 * the socket. `scanRoots()` then reconnects the session.
+	 */
+	private dropSession(session: SessionSocket, _reason: string): void {
+		const clearIntervalImpl = this.opts.clearIntervalImpl ?? clearInterval;
+		if (session.pingTimer) {
+			clearIntervalImpl(session.pingTimer);
+			session.pingTimer = undefined;
+		}
+		if (this.sessions.get(session.sessionId) === session) {
+			this.sessions.delete(session.sessionId);
+		}
+		if (session.ws.readyState !== WebSocket.CLOSED) {
+			try {
+				session.ws.close();
+			} catch {}
+		}
 	}
 
 	private static readonly THREADED_FRAMES = new Set([
@@ -782,6 +873,21 @@ export class TelegramNotificationDaemon {
 	}
 
 	async handleSessionMessage(session: SessionSocket, msg: any): Promise<void> {
+		if (msg?.type === "hello") {
+			const caps = Array.isArray(msg.capabilities) ? msg.capabilities : [];
+			if (caps.includes(CLIENT_PING_PONG_CAPABILITY)) {
+				session.capable = true;
+				this.startLiveness(session);
+			}
+			return;
+		}
+		if (msg?.type === "pong") {
+			if (typeof msg.nonce === "string" && msg.nonce === session.awaitingNonce) {
+				session.awaitingNonce = undefined;
+				session.lastPongAt = (this.opts.now ?? Date.now)();
+			}
+			return;
+		}
 		// Live typing indicator: track busy/idle per session and push an immediate
 		// chat action so "typing…" appears without waiting for the refresh tick.
 		if (msg?.type === "activity") {
@@ -1039,6 +1145,7 @@ export class TelegramNotificationDaemon {
 			await this.loadTopics();
 			await this.runScan();
 			let idleSince = (this.opts.now ?? Date.now)();
+			let pollBackoffMs = 0;
 			while (this.running) {
 				if (
 					!(await renewDaemonHeartbeat({
@@ -1055,7 +1162,18 @@ export class TelegramNotificationDaemon {
 					if ((this.opts.now ?? Date.now)() - idleSince >= (this.opts.idleTimeoutMs ?? 60_000)) break;
 				} else {
 					idleSince = (this.opts.now ?? Date.now)();
-					await this.pollOnce();
+					try {
+						await this.pollOnce();
+						pollBackoffMs = 0;
+					} catch (e) {
+						// A transient getUpdates/network failure must not kill the
+						// daemon. Back off (bounded, below the heartbeat TTL) and keep
+						// renewing ownership at the loop top.
+						pollBackoffMs = pollBackoffMs === 0 ? 250 : Math.min(pollBackoffMs * 2, 4_000);
+						logger.warn(`notifications: getUpdates failed, backing off ${pollBackoffMs}ms: ${String(e)}`);
+						await new Promise(resolve => (this.opts.setTimeoutImpl ?? setTimeout)(resolve, pollBackoffMs));
+						continue;
+					}
 				}
 				await new Promise(resolve => (this.opts.setTimeoutImpl ?? setTimeout)(resolve, 10));
 			}

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -581,6 +581,121 @@ describe("telegram daemon", () => {
 	});
 });
 
+describe("telegram daemon connection-drop resilience (repro-first)", () => {
+	// Phase 1 / AC-1: half-open daemon->session WebSocket. The socket stays
+	// readyState OPEN, accepts send(), and never dispatches 'close'. On current
+	// code there is no per-session liveness, so a stale half-open socket lives in
+	// the sessions map forever and scanRoots() (which skips when sessions.has(id))
+	// never reconnects. This test asserts the DESIRED post-fix recovery and is
+	// therefore RED on current code.
+	test("AC-1/AC-2: half-open session socket is detected and reconnected", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "sess-cwd");
+		await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
+		const roots = JSON.parse(fs.readFileSync(daemonPaths(agentDir).roots, "utf8")) as { roots: string[] };
+		const endpointDir = path.join(roots.roots[0]!, "notifications");
+		fs.mkdirSync(endpointDir, { recursive: true });
+		fs.writeFileSync(path.join(endpointDir, "S.json"), JSON.stringify({ url: "ws://s", token: "ts" }));
+
+		let now = 0;
+		const liveness: Array<() => void> = [];
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: new FakeBotApi(),
+			WebSocketImpl: FakeWs as any,
+			now: () => now,
+			setIntervalImpl: ((cb: () => void) => {
+				liveness.push(cb);
+				return 0;
+			}) as any,
+			clearIntervalImpl: (() => {}) as any,
+		});
+
+		await daemon.scanRoots();
+		expect(FakeWs.instances).toHaveLength(1);
+		expect(daemon.sessions.has("S")).toBe(true);
+
+		// The native server advertises the ping/pong capability so ack-based
+		// liveness can start; then the link goes half-open (no further frames,
+		// socket never closes, no pong will arrive).
+		FakeWs.instances[0]!.emit({ type: "hello", protocolVersion: 2, capabilities: ["client_ping_pong"] });
+
+		// Advance past the heartbeat TTL and fire any liveness probe. Post-fix this
+		// detects the missing pong, drops the stale session, and reconnects.
+		now += 25_000;
+		for (const cb of liveness) cb();
+		await Promise.resolve();
+		await daemon.scanRoots();
+
+		expect(FakeWs.instances).toHaveLength(2);
+		expect(daemon.sessions.get("S")?.ws).toBe(FakeWs.instances[1] as unknown as WebSocket);
+		expect(FakeWs.instances[1]!.readyState).toBe(FakeWs.OPEN);
+	});
+
+	// Phase 1 / AC-7: a getUpdates rejection during an internet outage must not
+	// kill the daemon. On current code run() awaits pollOnce() with no try/catch,
+	// so the rejection unwinds run() and releases ownership. This asserts the
+	// DESIRED survival (run resolves) and is RED on current code (run rejects).
+	test("AC-7: getUpdates rejection during outage does not terminate the daemon", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "fp",
+			chatId: "42",
+			pid: process.pid,
+			randomId: () => "owner",
+		});
+
+		let now = 0;
+		let getUpdatesCalls = 0;
+		const bot = {
+			calls: [] as Array<{ method: string; body: any }>,
+			async call(method: string, body: unknown): Promise<unknown> {
+				this.calls.push({ method, body });
+				if (method === "getUpdates") {
+					getUpdatesCalls++;
+					if (getUpdatesCalls === 1) {
+						// Drop the only session so the next loop iteration idle-exits
+						// once the daemon survives the rejection (post-fix path).
+						daemon.sessions.get("S")?.ws.close();
+						throw new Error("network down: getUpdates rejected");
+					}
+					return { ok: true, result: [] };
+				}
+				return { ok: true, result: true };
+			},
+		};
+
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			idleTimeoutMs: 10,
+			now: () => (now += 1000),
+			setTimeoutImpl: ((cb: () => void) => {
+				cb();
+				return 0;
+			}) as any,
+			setIntervalImpl: (() => 0) as any,
+			clearIntervalImpl: (() => {}) as any,
+		});
+		daemon.connectSession("S", "ws://s", "ts");
+
+		await expect(daemon.run()).resolves.toBeUndefined();
+		expect(getUpdatesCalls).toBeGreaterThanOrEqual(1);
+	});
+});
+
 test("daemon registers in-thread config commands and drops stale rpc/answer commands", async () => {
 	const s = settings(tempAgentDir());
 	const bot = new FakeBotApi();
@@ -807,4 +922,209 @@ test("inbound thread message gets a queued reaction, flipped to consumed on ack"
 	expect(consumed).toBeTruthy();
 	expect(consumed!.body.message_id).toBe(555);
 	expect(consumed!.body.reaction[0].emoji).toBe("✅");
+});
+
+describe("telegram daemon reconnect reconciliation", () => {
+	function endpointFor(agentDir: string, cwd: string, s: Settings, sessionId: string) {
+		return (async () => {
+			await registerNotificationRoot({ settings: s, cwd, sessionId });
+			const roots = JSON.parse(fs.readFileSync(daemonPaths(agentDir).roots, "utf8")) as { roots: string[] };
+			const dir = path.join(roots.roots[0]!, "notifications");
+			fs.mkdirSync(dir, { recursive: true });
+			fs.writeFileSync(path.join(dir, `${sessionId}.json`), JSON.stringify({ url: "ws://s", token: "ts" }));
+		})();
+	}
+
+	test("identity-guarded replacement survives delayed old close and old message", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		await endpointFor(agentDir, path.join(agentDir, "cwd"), s, "S");
+
+		let now = 0;
+		const liveness: Array<() => void> = [];
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			now: () => now,
+			setIntervalImpl: ((cb: () => void) => {
+				liveness.push(cb);
+				return 0;
+			}) as any,
+			clearIntervalImpl: (() => {}) as any,
+		});
+		await daemon.scanRoots();
+		FakeWs.instances[0]!.emit({ type: "hello", protocolVersion: 2, capabilities: ["client_ping_pong"] });
+		now += 25_000;
+		for (const cb of liveness) cb();
+		await daemon.scanRoots();
+		const replacement = daemon.sessions.get("S");
+		expect(FakeWs.instances).toHaveLength(2);
+		expect(replacement?.ws).toBe(FakeWs.instances[1] as unknown as WebSocket);
+
+		// Delayed old close from the superseded socket must not delete the replacement.
+		FakeWs.instances[0]!.dispatchEvent(new Event("close"));
+		expect(daemon.sessions.get("S")).toBe(replacement);
+
+		// Delayed old message from the superseded socket must not produce a send.
+		bot.calls = [];
+		FakeWs.instances[0]!.emit({ type: "action_needed", kind: "ask", id: "old", question: "Q", options: ["Y"] });
+		await Promise.resolve();
+		expect(bot.calls).toHaveLength(0);
+	});
+
+	test("legacy server without ping/pong capability does not start ack liveness", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		await endpointFor(agentDir, path.join(agentDir, "cwd"), s, "S");
+
+		let now = 0;
+		const liveness: Array<() => void> = [];
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: new FakeBotApi(),
+			WebSocketImpl: FakeWs as any,
+			now: () => now,
+			setIntervalImpl: ((cb: () => void) => {
+				liveness.push(cb);
+				return 0;
+			}) as any,
+			clearIntervalImpl: (() => {}) as any,
+		});
+		await daemon.scanRoots();
+		// Legacy server: advertises capabilities WITHOUT client_ping_pong.
+		FakeWs.instances[0]!.emit({ type: "hello", protocolVersion: 1, capabilities: ["threaded"] });
+		expect(liveness).toHaveLength(0);
+		now += 100_000;
+		for (const cb of liveness) cb();
+		await daemon.scanRoots();
+		// No ack-based force-drop: the single original socket remains; half-open ack
+		// recovery is simply unavailable for a non-capable server.
+		expect(FakeWs.instances).toHaveLength(1);
+		expect(daemon.sessions.has("S")).toBe(true);
+	});
+
+	test("AC-3/AC-5: after reconnect a replayed ask renders one re-ask and future frames flow", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		await endpointFor(agentDir, path.join(agentDir, "cwd"), s, "S");
+
+		let now = 0;
+		const liveness: Array<() => void> = [];
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			now: () => now,
+			setIntervalImpl: ((cb: () => void) => {
+				liveness.push(cb);
+				return 0;
+			}) as any,
+			clearIntervalImpl: (() => {}) as any,
+		});
+		await daemon.scanRoots();
+		FakeWs.instances[0]!.emit({ type: "hello", protocolVersion: 2, capabilities: ["client_ping_pong"] });
+		now += 25_000;
+		for (const cb of liveness) cb();
+		await daemon.scanRoots();
+		const replacement = daemon.sessions.get("S")!;
+		expect(replacement.ws).toBe(FakeWs.instances[1] as unknown as WebSocket);
+
+		// AC-3: the native server replays its single buffered ask to the fresh
+		// client; the daemon renders exactly one fresh re-ask in the topic.
+		bot.calls = [];
+		await daemon.handleSessionMessage(replacement, {
+			type: "action_needed",
+			kind: "ask",
+			id: "ask1",
+			question: "Resume?",
+			options: ["Yes", "No"],
+		});
+		const reAsks = bot.calls.filter(c => c.method === "sendMessage" && c.body.reply_markup?.inline_keyboard);
+		expect(reAsks).toHaveLength(1);
+
+		// AC-5: future streamed frames after reconnect are delivered to the topic.
+		bot.calls = [];
+		await daemon.handleSessionMessage(replacement, {
+			type: "turn_stream",
+			sessionId: "S",
+			phase: "finalized",
+			text: "post-reconnect output",
+		});
+		expect(bot.calls.some(c => c.method === "sendMessage" && String(c.body.text).includes("post-reconnect"))).toBe(
+			true,
+		);
+	});
+});
+
+describe("telegram daemon reconnect answer routing", () => {
+	test("AC-4: a button tap after reconnect routes a reply through the replacement socket", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "cwd");
+		await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
+		const roots = JSON.parse(fs.readFileSync(daemonPaths(agentDir).roots, "utf8")) as { roots: string[] };
+		const dir = path.join(roots.roots[0]!, "notifications");
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(path.join(dir, "S.json"), JSON.stringify({ url: "ws://s", token: "ts" }));
+
+		let now = 0;
+		const liveness: Array<() => void> = [];
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			now: () => now,
+			setIntervalImpl: ((cb: () => void) => {
+				liveness.push(cb);
+				return 0;
+			}) as any,
+			clearIntervalImpl: (() => {}) as any,
+		});
+		await daemon.scanRoots();
+		FakeWs.instances[0]!.emit({ type: "hello", protocolVersion: 2, capabilities: ["client_ping_pong"] });
+		now += 25_000;
+		for (const cb of liveness) cb();
+		await daemon.scanRoots();
+		const replacement = daemon.sessions.get("S")!;
+
+		// The native server replays the buffered ask to the reconnected client.
+		await daemon.handleSessionMessage(replacement, {
+			type: "action_needed",
+			kind: "ask",
+			id: "ask1",
+			question: "Resume?",
+			options: ["Yes", "No"],
+		});
+		const alias = bot.calls.find(c => c.method === "sendMessage" && c.body.reply_markup)!.body.reply_markup
+			.inline_keyboard[0][0].callback_data;
+
+		// A button tap on the fresh re-ask must route a reply over the new socket.
+		await daemon.handleTelegramUpdate({
+			update_id: 1,
+			callback_query: { id: "cb", data: alias, message: { chat: { id: 42 } } },
+		});
+		const sent = (replacement.ws as unknown as { sent: string[] }).sent;
+		const replyFrame = sent.map(x => JSON.parse(x)).find(m => m.type === "reply");
+		expect(replyFrame).toEqual({ type: "reply", id: "ask1", answer: 0, token: "ts" });
+	});
 });


### PR DESCRIPTION
## Problem
A laptop internet drop+restore left the **in-flight session unreachable** via Telegram (stale buttons + no streaming), while **new sessions worked**. Repro-first testing confirmed two independent daemon root causes:

1. **Half-open socket** — `connectSession` only reconnected on a WS `close` event; a half-open socket (sleep/network drop) never fires `close`, so the stale `sessions` entry permanently blocked `scanRoots()` reconnect.
2. **Daemon death** — `run()` awaited `pollOnce()` with no try/catch, so a `getUpdates` network rejection unwound the loop and released ownership; only a *new* session respawned the daemon.

## Fix
**Native `crates/gjc-notifications` (protocol.rs, server.rs)**
- Add `client_ping_pong` capability + `ClientMessage::Ping` / `ServerMessage::Pong` (nonce echo, client-directed).
- Emit `ServerHello` as the **first frame** on connect, **before** buffered-ask replay.

**Daemon `telegram-daemon.ts`**
- App-level ack liveness (probe every `HEARTBEAT_INTERVAL_MS`=5s, drop after `HEARTBEAT_TTL_MS`=20s no-pong), started **only** after a capable `ServerHello`; explicit legacy/no-capability fallback that does not falsely claim half-open recovery.
- Identity-guarded `dropSession` replacement: delete the map entry only when it still points at that exact session; message listener ignores superseded sockets; idempotent close (no close-event recursion).
- Bounded `getUpdates` backoff (250/500/1000/2000, cap 4000ms — below the heartbeat TTL), reset on success, ownership heartbeat preserved through the outage; no tight-loop.

The WHATWG/global `WebSocket` exposes no JS control ping/pong, so liveness is application-level and capability-gated. Native dead-client eviction is intentionally deferred behind documented escalation triggers.

## Tests
Repro-first RED tests, now green: half-open reconnect (AC-1/AC-2), `getUpdates`-rejection survival (AC-7), delayed old-close/old-message identity races, legacy-server path (AC-6), single-buffered-ask fresh re-ask (AC-3), button-tap-after-reconnect reply routing (AC-4), future-frame delivery (AC-5), new-session regression (AC-8).

- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts` — 23 pass
- `cargo test -p gjc-notifications` — 59 pass
- all `notifications-*.test.ts` — 95 pass; natives — 35 pass; e2e + compiled-smoke — 5 pass
- `check:types` clean; biome OK; native addon rebuilt

Produced via deep-interview → ralplan consensus (Architect CLEAR/APPROVE, Critic OKAY) → ultragoal execution (5/5 stories through the hardened quality gate).