### PR TITLE
fix(notifications): deliver ask buttons at invocation; harden daemon against transient errors

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -84,6 +84,64 @@ const RATE_LIMIT_FLUSH_INTERVAL_MS = 1_000;
 // buffered ask is delivered up to 25s late — or never, if the user answers the
 // local ask first (which clears the buffered ask).
 const SESSION_SCAN_INTERVAL_MS = 1_000;
+// Transient Telegram API delivery is retried this many times before giving up.
+const BOT_API_RETRY_ATTEMPTS = 3;
+// Backoff after a failed getUpdates long-poll so a persistent outage does not
+// busy-loop the daemon.
+const POLL_BACKOFF_MS = 1_000;
+
+/**
+ * Whether `err` is a transient network failure worth retrying. Telegram API
+ * calls over HTTP/2 occasionally surface mid-stream `ECONNRESET` (and similar)
+ * that the global h2 fallback does not catch; treating these as fatal drops ask
+ * notifications and (in the polling loop) crashes the daemon.
+ */
+function isTransientNetworkError(err: unknown): boolean {
+	const code = (err as { code?: unknown } | null)?.code;
+	if (typeof code === "string") {
+		const transient = new Set([
+			"ECONNRESET",
+			"ECONNREFUSED",
+			"ETIMEDOUT",
+			"EPIPE",
+			"ENOTFOUND",
+			"EAI_AGAIN",
+			"UND_ERR_SOCKET",
+			"ConnectionClosed",
+			"ConnectionReset",
+			"ConnectionRefused",
+			"ConnectionTimeout",
+			"FailedToOpenSocket",
+		]);
+		if (transient.has(code)) return true;
+	}
+	const message = (err as { message?: unknown } | null)?.message;
+	return (
+		typeof message === "string" &&
+		/socket connection was closed|econnreset|fetch failed|network|timed out|terminated/i.test(message)
+	);
+}
+
+/** `fetch` with bounded retries on transient network failures. */
+async function fetchWithRetry(
+	fetchImpl: typeof fetch,
+	url: string,
+	init: RequestInit,
+	sleep: (ms: number) => Promise<void>,
+	attempts: number = BOT_API_RETRY_ATTEMPTS,
+): Promise<Response> {
+	let lastErr: unknown;
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		try {
+			return await fetchImpl(url, init);
+		} catch (err) {
+			lastErr = err;
+			if (!isTransientNetworkError(err) || attempt === attempts - 1) throw err;
+			await sleep(200 * 2 ** attempt);
+		}
+	}
+	throw lastErr;
+}
 
 export function daemonPaths(agentDir: string): DaemonPaths {
 	const dir = path.join(agentDir, "notifications");
@@ -431,6 +489,8 @@ export class TelegramNotificationDaemon {
 				const apiBase = opts.apiBase ?? "https://api.telegram.org";
 				const url = `${apiBase}/bot${opts.botToken}/${method}`;
 				const fetchImpl = opts.fetchImpl ?? fetch;
+				const setTimeoutImpl = opts.setTimeoutImpl ?? setTimeout;
+				const sleep = (ms: number) => new Promise<void>(resolve => setTimeoutImpl(resolve, ms));
 				// sendPhoto with base64 bytes must be a multipart upload (Telegram does
 				// not accept base64 in JSON). Other methods stay JSON.
 				const photoBody = body as { photo?: unknown; mime?: unknown } | null;
@@ -449,14 +509,19 @@ export class TelegramNotificationDaemon {
 					if (b.caption) form.set("caption", b.caption);
 					if (b.parse_mode) form.set("parse_mode", String(b.parse_mode));
 					form.set("photo", new Blob([Buffer.from(b.photo, "base64")], { type: b.mime ?? "image/png" }), "image");
-					const res = await fetchImpl(url, { method: "POST", body: form });
+					const res = await fetchWithRetry(fetchImpl, url, { method: "POST", body: form }, sleep);
 					return res.json();
 				}
-				const res = await fetchImpl(url, {
-					method: "POST",
-					headers: { "content-type": "application/json" },
-					body: JSON.stringify(body),
-				});
+				const res = await fetchWithRetry(
+					fetchImpl,
+					url,
+					{
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify(body),
+					},
+					sleep,
+				);
 				return res.json();
 			},
 		};
@@ -830,14 +895,28 @@ export class TelegramNotificationDaemon {
 	}
 
 	async pollOnce(): Promise<number> {
-		const body = (await this.botApi.call("getUpdates", {
-			offset: this.offset,
-			timeout: 25,
-			allowed_updates: ["message", "callback_query"],
-		})) as { result?: Array<{ update_id: number } & Record<string, unknown>> };
+		let body: { result?: Array<{ update_id: number } & Record<string, unknown>> };
+		try {
+			body = (await this.botApi.call("getUpdates", {
+				offset: this.offset,
+				timeout: 25,
+				allowed_updates: ["message", "callback_query"],
+			})) as { result?: Array<{ update_id: number } & Record<string, unknown>> };
+		} catch (err) {
+			// A transient Telegram API failure (e.g. ECONNRESET on the long-poll) must
+			// never crash the daemon — that silently stops all delivery, including ask
+			// notifications. Log, back off, and let the run loop retry.
+			console.error("notifications daemon: getUpdates failed:", err);
+			await new Promise(resolve => (this.opts.setTimeoutImpl ?? setTimeout)(resolve, POLL_BACKOFF_MS));
+			return 0;
+		}
 		for (const update of body.result ?? []) {
 			this.offset = update.update_id + 1;
-			await this.handleTelegramUpdate(update);
+			try {
+				await this.handleTelegramUpdate(update);
+			} catch (err) {
+				console.error("notifications daemon: handleTelegramUpdate failed:", err);
+			}
 		}
 		return body.result?.length ?? 0;
 	}

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -558,11 +558,15 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 				// local UI wins, abort the remote source so it stops waiting and marks the
 				// action resolved-locally. First valid answer wins.
 				const controller = new AbortController();
+				// Register the remote ask FIRST so the `action_needed` frame (the Telegram
+				// inline-keyboard message) is broadcast at invocation — before the local
+				// selector opens — instead of only after the ask is finalized locally.
+				const remote = source.awaitAnswer(prompt, options, controller.signal);
 				const local = extensionUi.select(prompt, options, dialogOptions).then(answer => {
 					controller.abort();
 					return answer;
 				});
-				return Promise.race([local, source.awaitAnswer(prompt, options, controller.signal)]);
+				return Promise.race([local, remote]);
 			},
 			editor: (title, prefill, dialogOptions, editorOptions) => {
 				if (!extensionUi) throw new ToolAbortError("Ask tool requires interactive mode");

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -515,6 +515,70 @@ describe("telegram daemon", () => {
 		releasePoll();
 		await runPromise;
 	});
+
+	test("pollOnce survives a transient getUpdates failure instead of crashing", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		let calls = 0;
+		const bot = {
+			async call(method: string): Promise<unknown> {
+				if (method === "getUpdates") {
+					calls++;
+					const err = new Error("The socket connection was closed unexpectedly.") as Error & { code?: string };
+					err.code = "ECONNRESET";
+					throw err;
+				}
+				return { ok: true, result: [] };
+			},
+		};
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			setTimeoutImpl: ((cb: () => void) => {
+				cb();
+				return 0;
+			}) as any,
+		});
+		// Must resolve (not reject): the run loop relies on this never throwing.
+		await expect(daemon.pollOnce()).resolves.toBe(0);
+		expect(calls).toBe(1);
+	});
+
+	test("default botApi retries transient network failures before delivering", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		let attempts = 0;
+		const fetchImpl = (async () => {
+			attempts++;
+			if (attempts < 3) {
+				const err = new Error("socket reset") as Error & { code?: string };
+				err.code = "ECONNRESET";
+				throw err;
+			}
+			return new Response(JSON.stringify({ ok: true, result: { message_id: 7 } }), {
+				headers: { "content-type": "application/json" },
+			});
+		}) as unknown as typeof fetch;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			fetchImpl,
+			setTimeoutImpl: ((cb: () => void) => {
+				cb();
+				return 0;
+			}) as any,
+		});
+		const res = (await (daemon as any).botApi.call("sendMessage", { chat_id: 42, text: "hi" })) as {
+			result?: { message_id?: number };
+		};
+		expect(attempts).toBe(3);
+		expect(res.result?.message_id).toBe(7);
+	});
 });
 
 test("daemon registers in-thread config commands and drops stale rpc/answer commands", async () => {

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -115,6 +115,62 @@ describe("AskTool cancellation", () => {
 		expect(abort).toHaveBeenCalledTimes(1);
 	});
 
+	it("registers the remote ask before opening the local selector (Telegram buttons at invocation)", async () => {
+		const order: string[] = [];
+		// Remote source never resolves on its own; we only assert it was invoked
+		// (i.e. action_needed was broadcast) BEFORE the local selector opened.
+		const source = {
+			awaitAnswer: (_q: string, _opts: string[], _signal?: AbortSignal) => {
+				order.push("remote");
+				return new Promise<string | undefined>(() => {});
+			},
+		};
+		const tool = new AskTool(createSession({ getAskAnswerSource: () => source } as Partial<ToolSession>));
+		const context = createContext({
+			select: async () => {
+				order.push("local");
+				return "yes";
+			},
+		});
+
+		const result = await tool.execute(
+			"call-remote-emit",
+			{ questions: [{ id: "confirm", question: "Proceed?", options: [{ label: "yes" }, { label: "no" }] }] },
+			undefined,
+			undefined,
+			context,
+		);
+
+		// The remote ask must be registered first so the notification is emitted at
+		// invocation, not only after the ask is finalized locally.
+		expect(order[0]).toBe("remote");
+		expect(order).toContain("local");
+		expect(result.content[0]?.type).toBe("text");
+		if (result.content[0]?.type === "text") expect(result.content[0].text).toContain("yes");
+	});
+
+	it("resolves the ask from a remote (Telegram) answer that wins the race", async () => {
+		const source = {
+			awaitAnswer: (_q: string, _opts: string[], _signal?: AbortSignal) => Promise.resolve("yes"),
+		};
+		const tool = new AskTool(createSession({ getAskAnswerSource: () => source } as Partial<ToolSession>));
+		const context = createContext({
+			// Local selector never resolves: only the remote answer can finish the ask.
+			select: () => new Promise<string | undefined>(() => {}),
+		});
+
+		const result = await tool.execute(
+			"call-remote-answer",
+			{ questions: [{ id: "confirm", question: "Proceed?", options: [{ label: "yes" }, { label: "no" }] }] },
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(result.content[0]?.type).toBe("text");
+		if (result.content[0]?.type === "text") expect(result.content[0].text).toContain("yes");
+	});
+
 	it("defaults to no timeout when ask.timeout is unset", async () => {
 		// Regression for the surprise-auto-select report: a fresh install must let the user
 		// deliberate indefinitely. The dialog timeout is opt-in via the `ask.timeout` setting.


### PR DESCRIPTION
Follow-up to #988. The ask tool's Telegram inline-keyboard message still only appeared **after** the ask was finalized locally, so remote answering was impossible. The local daemon log (`~/.gjc/agent/notifications/daemon.log`) revealed the real causes:

1. **Daemon crash.** `getUpdates` hit a transient `ECONNRESET` that was **uncaught in `pollOnce`**, crashing the whole daemon process — after which nothing is delivered. The ask `sendMessage` also failed with `ECONNRESET` and was dropped. (`ECONNRESET` is not in the global h2-fetch fallback set, so it surfaced as a hard error.)
2. **Emission ordering.** The ask wrapper opened the local selector before registering the remote ask, so the `action_needed` broadcast was not guaranteed at invocation.

## Fixes

- **Retry transient Telegram API failures** (`ECONNRESET` and friends) in the daemon's `botApi.call` with bounded backoff, so ask delivery survives a reset.
- **Never crash the daemon**: `getUpdates` failures and per-update handling errors are caught, logged, and backed off; the run loop retries.
- **Emit at invocation**: register the remote ask *before* opening the local selector so the Telegram buttons appear while the ask is pending, not on finalize.

## Tests

- `pollOnce survives a transient getUpdates failure instead of crashing`
- `default botApi retries transient network failures before delivering`
- `registers the remote ask before opening the local selector` (fails without the reorder)
- `resolves the ask from a remote (Telegram) answer that wins the race`

All notification + ask tests pass; typecheck and format clean.
