### PR TITLE
fix(notifications): forward getAskAnswerSource into production ToolSession (ask emits at invocation)

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1244,6 +1244,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			getPlanModeState: () => session?.getPlanModeState(),
 			getGoalModeState: () => session?.getGoalModeState(),
 			getWorkflowGateEmitter: () => session?.getWorkflowGateEmitter(),
+			getAskAnswerSource: () => session?.getAskAnswerSource(),
 			getGoalRuntime: () => session?.goalRuntime,
 			getClientBridge: () => session?.clientBridge,
 			getCompactContext: () => session.formatCompactContext(),

--- a/packages/coding-agent/test/sdk-ask-answer-source.test.ts
+++ b/packages/coding-agent/test/sdk-ask-answer-source.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentToolContext } from "@gajae-code/agent-core";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { createAgentSession } from "@gajae-code/coding-agent/sdk";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { registerAskAnswerSource } from "@gajae-code/coding-agent/tools/ask-answer-registry";
+
+/**
+ * Regression for the "ask buttons only appear after finalize" report: the
+ * production ToolSession built by createAgentSession must forward
+ * getAskAnswerSource, otherwise AskTool.execute never reaches the notifications
+ * awaitAnswer path and never broadcasts action_needed at invocation. A unit test
+ * that constructs AskTool directly does NOT cover this — the bug lived in the SDK
+ * toolSession literal, not in AskTool.
+ */
+describe("createAgentSession wires getAskAnswerSource into built-in AskTool", () => {
+	beforeAll(async () => {
+		await initTheme(false);
+	});
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("invokes the registered ask answer source before opening the local selector", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-ask-source-"));
+		tempDirs.push(tempDir);
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			hasUI: true,
+		});
+
+		try {
+			const order: string[] = [];
+			registerAskAnswerSource(session.sessionId, {
+				awaitAnswer: () => {
+					order.push("remote");
+					return new Promise<string | undefined>(() => {});
+				},
+			});
+
+			const askTool = session.getToolByName("ask");
+			expect(askTool).toBeDefined();
+
+			const context = {
+				hasUI: true,
+				ui: {
+					select: async () => {
+						order.push("local");
+						return "yes";
+					},
+					editor: async () => undefined,
+				},
+				abort: () => {},
+			} as unknown as AgentToolContext;
+
+			const result = await askTool!.execute(
+				"call-prod-ask",
+				{ questions: [{ id: "confirm", question: "Proceed?", options: [{ label: "yes" }, { label: "no" }] }] },
+				undefined,
+				undefined,
+				context,
+			);
+
+			// The remote source must be consulted (proving the SDK forwarded
+			// getAskAnswerSource), and at invocation — before the local selector.
+			expect(order[0]).toBe("remote");
+			expect(result.content[0]?.type).toBe("text");
+			if (result.content[0]?.type === "text") expect(result.content[0].text).toContain("yes");
+		} finally {
+			await session.dispose?.();
+		}
+	}, 20_000);
+});


### PR DESCRIPTION
Follow-up to #988 / #991. Those addressed daemon connection timing and crash/retry resilience, but the user reported the ask Telegram buttons **still only appeared after finalizing the ask locally**. An architect deep-dive found the real root cause.

## Root cause

The `toolSession` literal built by `createAgentSession` (`packages/coding-agent/src/sdk.ts`) forwarded `getWorkflowGateEmitter` but **not** `getAskAnswerSource`. `AskTool.execute` reads `this.session.getAskAnswerSource?.()`; because the production `ToolSession` lacked the accessor, the optional call resolved to `undefined` and the tool always took the local-only selector branch — it never called the notifications `awaitAnswer` → `server.registerAsk` broadcast. So interactive asks emitted no `action_needed` frame at invocation. (The earlier ask.ts remote-before-local reorder was correct but unreachable in production.)

Verified independently: the napi NotificationServer (multi-thread `tokio_rt`) delivers broadcasts to a separate-process daemon regardless of the agent's event loop (a separate-process client received `action_needed` 1ms after `registerAsk` even while the agent loop was busy-blocked 2.5s), so this was a wiring gap, not runtime starvation.

## Fix

One line: forward `getAskAnswerSource: () => session?.getAskAnswerSource()` next to `getWorkflowGateEmitter` in the `toolSession` literal.

## Test

Adds `packages/coding-agent/test/sdk-ask-answer-source.test.ts`: builds an `AskTool` via `createAgentSession` (production path, not `new AskTool(...)`), registers an ask answer source, and asserts `awaitAnswer` runs **before** the local selector. It fails without the wiring and passes with it.

## Verification

- Focused tests: `sdk-ask-answer-source`, `tools/ask`, `notifications-telegram-daemon` — all pass.
- Typecheck clean.
- Real local dev build: `bun run build` succeeded (native + compiled `dist/gjc`); binary smoke `gjc --version` → `gjc/0.6.5`.
