### PR TITLE
feat(daemon): scalable gjc daemon control plane with safe reload

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -36,6 +36,7 @@ const commands: CommandEntry[] = [
 	{ name: "ralplan", load: () => import("./commands/ralplan").then(m => m.default) },
 	{ name: "config", load: () => import("./commands/config").then(m => m.default) },
 	{ name: "notify", load: () => import("./commands/notify").then(m => m.default) },
+	{ name: "daemon", load: () => import("./commands/daemon").then(m => m.default) },
 	{ name: "web-search", aliases: ["q"], load: () => import("./commands/web-search").then(m => m.default) },
 	{ name: "mcp-serve", load: () => import("./commands/mcp-serve").then(m => m.default) },
 	{

--- a/packages/coding-agent/src/cli/daemon-cli.ts
+++ b/packages/coding-agent/src/cli/daemon-cli.ts
@@ -1,0 +1,122 @@
+/**
+ * `gjc daemon` command handler.
+ *
+ * Generic over the static built-in daemon controller map: lists/inspects
+ * daemons and drives cooperative stop/reload. Telegram is the only kind today.
+ */
+
+import { Settings } from "../config/settings";
+import { selectDaemonControllers } from "../daemon/builtin";
+import type {
+	BuiltInDaemonController,
+	DaemonKind,
+	DaemonOperationOptions,
+	DaemonOperationResult,
+	DaemonStatus,
+} from "../daemon/control-types";
+
+export type DaemonCliAction = "list" | "status" | "stop" | "reload";
+
+export interface DaemonCommandArgs {
+	action: DaemonCliAction;
+	kinds: DaemonKind[];
+	all: boolean;
+	json: boolean;
+	force: boolean;
+	gracefulTimeoutMs?: number;
+	killTimeoutMs?: number;
+	spawnIfStopped?: boolean;
+}
+
+export interface DaemonCommandDeps {
+	settings?: Settings;
+	controllers?: BuiltInDaemonController[];
+}
+
+const KNOWN_ACTIONS: DaemonCliAction[] = ["list", "status", "stop", "reload"];
+const KNOWN_KINDS: DaemonKind[] = ["telegram"];
+
+export function parseDaemonArgs(argv: string[]): DaemonCommandArgs | undefined {
+	if (argv.length === 0 || argv[0] !== "daemon") return undefined;
+	const rest = argv.slice(1);
+	const action = (KNOWN_ACTIONS as string[]).includes(rest[0] ?? "") ? (rest[0] as DaemonCliAction) : "status";
+	const positional = (KNOWN_ACTIONS as string[]).includes(rest[0] ?? "") ? rest.slice(1) : rest;
+	const kinds: DaemonKind[] = [];
+	let all = false;
+	let json = false;
+	let force = false;
+	let gracefulTimeoutMs: number | undefined;
+	let killTimeoutMs: number | undefined;
+	let spawnIfStopped: boolean | undefined;
+	for (let i = 0; i < positional.length; i++) {
+		const arg = positional[i];
+		if (arg === "--all") all = true;
+		else if (arg === "--json") json = true;
+		else if (arg === "--force") force = true;
+		else if (arg === "--spawn-if-stopped") spawnIfStopped = true;
+		else if (arg === "--graceful-timeout-ms") gracefulTimeoutMs = Number.parseInt(positional[++i], 10);
+		else if (arg === "--kill-timeout-ms") killTimeoutMs = Number.parseInt(positional[++i], 10);
+		else if (!arg.startsWith("--") && (KNOWN_KINDS as string[]).includes(arg)) kinds.push(arg as DaemonKind);
+	}
+	return { action, kinds, all, json, force, gracefulTimeoutMs, killTimeoutMs, spawnIfStopped };
+}
+
+function formatStatus(status: DaemonStatus): string {
+	const parts = [
+		`${status.kind}: ${status.health}`,
+		status.configured ? undefined : "(not configured)",
+		status.pid !== undefined ? `pid=${status.pid}` : undefined,
+		status.ownerId ? `owner=${status.ownerId}` : undefined,
+		status.rootCount !== undefined ? `roots=${status.rootCount}` : undefined,
+		`mode=${status.runtime.mode}`,
+	].filter(Boolean);
+	let line = parts.join(" ");
+	if (status.runtime.warning) line += `\n  warning: ${status.runtime.warning}`;
+	return line;
+}
+
+function formatResult(result: DaemonOperationResult): string {
+	const head = `${result.kind} ${result.action}: ${result.ok ? "ok" : "failed"} — ${result.message}`;
+	const warnings = result.warnings.map(w => `\n  warning: ${w}`).join("");
+	return head + warnings;
+}
+
+export async function runDaemonCommand(cmd: DaemonCommandArgs, deps: DaemonCommandDeps = {}): Promise<void> {
+	const unknownKinds = cmd.kinds.filter(kind => !(KNOWN_KINDS as string[]).includes(kind));
+	if (unknownKinds.length > 0) {
+		process.stderr.write(
+			`Unknown daemon kind(s): ${unknownKinds.join(", ")}. Known kinds: ${KNOWN_KINDS.join(", ")}.\n`,
+		);
+		process.exitCode = 1;
+		return;
+	}
+	const settings = deps.settings ?? (await Settings.init());
+	const controllers = deps.controllers ?? selectDaemonControllers(settings, cmd.kinds, cmd.all);
+
+	if (cmd.action === "list" || cmd.action === "status") {
+		const statuses = await Promise.all(controllers.map(c => c.status()));
+		if (cmd.json) {
+			process.stdout.write(`${JSON.stringify(statuses, null, 2)}\n`);
+		} else {
+			process.stdout.write(`${statuses.map(formatStatus).join("\n")}\n`);
+		}
+		return;
+	}
+
+	const opts: DaemonOperationOptions = {
+		gracefulTimeoutMs: cmd.gracefulTimeoutMs,
+		killTimeoutMs: cmd.killTimeoutMs,
+		force: cmd.force,
+		spawnIfStopped: cmd.spawnIfStopped,
+	};
+	const results: DaemonOperationResult[] = [];
+	for (const controller of controllers) {
+		results.push(cmd.action === "reload" ? await controller.reload(opts) : await controller.stop(opts));
+	}
+	if (cmd.json) {
+		process.stdout.write(`${JSON.stringify(results, null, 2)}\n`);
+	} else {
+		process.stdout.write(`${results.map(formatResult).join("\n")}\n`);
+	}
+	if (results.some(r => !r.ok)) process.exitCode = 1;
+}

--- a/packages/coding-agent/src/commands/daemon.ts
+++ b/packages/coding-agent/src/commands/daemon.ts
@@ -1,0 +1,47 @@
+/**
+ * Manage GJC background daemons (status/list/stop/reload).
+ */
+import { Args, Command, Flags } from "@gajae-code/utils/cli";
+import { type DaemonCliAction, type DaemonCommandArgs, runDaemonCommand } from "../cli/daemon-cli";
+import type { DaemonKind } from "../daemon/control-types";
+import { initTheme } from "../modes/theme/theme";
+
+const ACTIONS: DaemonCliAction[] = ["list", "status", "stop", "reload"];
+
+export default class Daemon extends Command {
+	static description = "Manage GJC background daemons (status, list, stop, reload)";
+
+	static args = {
+		action: Args.string({ description: "Daemon action", required: false, options: ACTIONS }),
+		kind: Args.string({ description: "Daemon kind(s) to target", required: false, multiple: true }),
+	};
+
+	static flags = {
+		all: Flags.boolean({ description: "Target all registered daemon kinds" }),
+		json: Flags.boolean({ description: "Emit JSON output" }),
+		force: Flags.boolean({ description: "Allow hard-kill escalation when graceful stop times out" }),
+		"graceful-timeout-ms": Flags.integer({ description: "Cooperative stop timeout before escalation" }),
+		"kill-timeout-ms": Flags.integer({ description: "Wait for old pid death after SIGKILL" }),
+		"spawn-if-stopped": Flags.boolean({ description: "On reload, spawn even when no daemon is running" }),
+	};
+
+	async run(): Promise<void> {
+		const { args, flags } = await this.parse(Daemon);
+		const action = (args.action ?? "status") as DaemonCliAction;
+		const kinds = (Array.isArray(args.kind) ? args.kind : args.kind ? [args.kind] : []) as DaemonKind[];
+		const flagRec = flags as Record<string, unknown>;
+		const cmd: DaemonCommandArgs = {
+			action,
+			kinds,
+			all: Boolean(flags.all),
+			json: Boolean(flags.json),
+			force: Boolean(flags.force),
+			gracefulTimeoutMs: flagRec["graceful-timeout-ms"] as number | undefined,
+			killTimeoutMs: flagRec["kill-timeout-ms"] as number | undefined,
+			spawnIfStopped: flagRec["spawn-if-stopped"] as boolean | undefined,
+		};
+
+		await initTheme();
+		await runDaemonCommand(cmd);
+	}
+}

--- a/packages/coding-agent/src/daemon/builtin.ts
+++ b/packages/coding-agent/src/daemon/builtin.ts
@@ -1,0 +1,46 @@
+/**
+ * Static built-in daemon controller map.
+ *
+ * Intentionally a static map keyed by daemon kind rather than a mutable plugin
+ * registry: there is exactly one kind today (`telegram`). Promote to a richer
+ * registry only when a second daemon kind exists.
+ */
+
+import type { Settings } from "../config/settings";
+import { type TelegramDaemonControlDeps, TelegramDaemonController } from "../notifications/telegram-daemon-control";
+import type { BuiltInDaemonController, DaemonKind } from "./control-types";
+
+export const BUILT_IN_DAEMON_KINDS = ["telegram"] as const satisfies readonly DaemonKind[];
+
+export interface BuiltInDaemonControllerDeps {
+	telegram?: TelegramDaemonControlDeps;
+}
+
+export function createBuiltInDaemonControllers(
+	settings: Settings,
+	deps: BuiltInDaemonControllerDeps = {},
+): Record<DaemonKind, BuiltInDaemonController> {
+	return {
+		telegram: new TelegramDaemonController(settings, deps.telegram),
+	};
+}
+
+/**
+ * Resolve the controllers a command should act on. `--all` selects every
+ * built-in kind; otherwise the explicit `kinds` (defaulting to `telegram`).
+ */
+export function selectDaemonControllers(
+	settings: Settings,
+	kinds: DaemonKind[] | undefined,
+	all: boolean,
+	deps: BuiltInDaemonControllerDeps = {},
+): BuiltInDaemonController[] {
+	const map = createBuiltInDaemonControllers(settings, deps);
+	if (all) return Object.values(map);
+	const selected = kinds && kinds.length > 0 ? kinds : (["telegram"] as DaemonKind[]);
+	return selected.map(kind => {
+		const controller = map[kind];
+		if (!controller) throw new Error(`unknown daemon kind: ${kind}`);
+		return controller;
+	});
+}

--- a/packages/coding-agent/src/daemon/control-types.ts
+++ b/packages/coding-agent/src/daemon/control-types.ts
@@ -1,0 +1,65 @@
+/**
+ * Public types for the `gjc daemon` control plane.
+ *
+ * Deliberately compact: a small result/status surface plus a built-in
+ * controller contract. There is exactly one daemon kind today (`telegram`);
+ * a richer registry is intentionally deferred until a second kind exists.
+ */
+
+export type DaemonKind = "telegram";
+
+export type DaemonAction = "list" | "status" | "stop" | "reload";
+
+export type DaemonHealth = "not_configured" | "stopped" | "running" | "stale" | "stopping" | "error";
+
+export interface DaemonRuntimeInfo {
+	/** `source` when respawn goes through bun/node + the entry script; `compiled` for a single-file binary. */
+	mode: "source" | "compiled";
+	execPath: string;
+	/** True only in source/dev mode, where a respawn loads amended TypeScript directly. */
+	reloadPicksUpSourceEdits: boolean;
+	/** Present when the runtime mode constrains what reload can achieve (e.g. compiled binary). */
+	warning?: string;
+}
+
+export interface DaemonStatus {
+	kind: DaemonKind;
+	configured: boolean;
+	health: DaemonHealth;
+	pid?: number;
+	ownerId?: string;
+	startedAt?: number;
+	heartbeatAt?: number;
+	roots?: string[];
+	rootCount?: number;
+	runtime: DaemonRuntimeInfo;
+	detail?: string;
+}
+
+export interface DaemonOperationOptions {
+	/** How long to wait for cooperative release before escalating. */
+	gracefulTimeoutMs?: number;
+	/** How long to wait for the old pid to die after SIGKILL. */
+	killTimeoutMs?: number;
+	/** Allow hard-kill escalation / acting on a still-live owner. */
+	force?: boolean;
+	/** For reload: spawn a fresh owner even when none is currently running. */
+	spawnIfStopped?: boolean;
+}
+
+export interface DaemonOperationResult {
+	kind: DaemonKind;
+	action: Exclude<DaemonAction, "list">;
+	ok: boolean;
+	before?: DaemonStatus;
+	after?: DaemonStatus;
+	warnings: string[];
+	message: string;
+}
+
+export interface BuiltInDaemonController {
+	readonly kind: DaemonKind;
+	status(): Promise<DaemonStatus>;
+	stop(opts?: DaemonOperationOptions): Promise<DaemonOperationResult>;
+	reload(opts?: DaemonOperationOptions): Promise<DaemonOperationResult>;
+}

--- a/packages/coding-agent/src/daemon/runtime.ts
+++ b/packages/coding-agent/src/daemon/runtime.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared source-vs-compiled runtime detection for daemon spawning.
+ *
+ * Centralizes the logic previously embedded in `ensureTelegramDaemonRunning`
+ * so session autostart, reload, and status reporting agree on how a daemon
+ * process is launched and whether a reload can pick up amended source.
+ */
+
+import * as path from "node:path";
+
+export interface GjcRuntimeSpawnInfo {
+	execPath: string;
+	mode: "source" | "compiled";
+	/** Prefix prepended before the gjc subcommand args; `[Bun.main]` in source mode, otherwise `[]`. */
+	argsPrefix: string[];
+	/** True only when respawn loads edited TypeScript directly (source/dev mode). */
+	reloadPicksUpSourceEdits: boolean;
+	/** Set in compiled mode to explain that a rebuild is required before reload picks up source edits. */
+	warning?: string;
+}
+
+const COMPILED_RELOAD_WARNING =
+	"Compiled binary: reload respawns the same binary. Rebuild the binary first for amended source to take effect.";
+
+/**
+ * Resolve how to spawn a detached gjc subcommand for the current runtime.
+ *
+ * Source/dev mode (bun/node) prepends the entry script (`Bun.main`) so the
+ * respawn loads edited source. A compiled single-file binary self-spawns its
+ * own subcommand directly and cannot pick up workspace source edits.
+ */
+export function resolveGjcRuntimeSpawnInfo(execPath: string = process.execPath): GjcRuntimeSpawnInfo {
+	const base = path.basename(execPath).toLowerCase();
+	const fromSource = base === "bun" || base === "node" || base.startsWith("bun") || base.startsWith("node");
+	const mainScript = fromSource && typeof Bun !== "undefined" ? (Bun as unknown as { main?: string }).main : undefined;
+	if (fromSource) {
+		return {
+			execPath,
+			mode: "source",
+			argsPrefix: mainScript ? [mainScript] : [],
+			reloadPicksUpSourceEdits: true,
+		};
+	}
+	return {
+		execPath,
+		mode: "compiled",
+		argsPrefix: [],
+		reloadPicksUpSourceEdits: false,
+		warning: COMPILED_RELOAD_WARNING,
+	};
+}

--- a/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { Settings } from "../config/settings";
 import { getNotificationConfig, isGloballyConfigured } from "./config";
 import { daemonPaths, TelegramNotificationDaemon } from "./telegram-daemon";
+import { clearTelegramControlRequest, readTelegramControlRequest } from "./telegram-daemon-control";
 
 export interface RunDaemonInternalDeps {
 	SettingsImpl?: Pick<typeof Settings, "init">;
@@ -44,6 +45,30 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 		chatId: cfg.chatId,
 		idleTimeoutMs: cfg.idleTimeoutMs,
 		pid: deps.processPid ?? process.pid,
+		control: {
+			shouldStop: async owner => {
+				const req = await readTelegramControlRequest(settings);
+				return Boolean(req && (!req.ownerId || req.ownerId === owner));
+			},
+			clear: async owner => {
+				const req = await readTelegramControlRequest(settings);
+				// Only clear a request that targets this daemon owner, so an exiting
+				// daemon never erases a newer request meant for a different owner.
+				if (req && (!req.ownerId || req.ownerId === owner)) {
+					await clearTelegramControlRequest(settings, req.requestId);
+				}
+			},
+		},
 	});
-	await daemon.run();
+	// Signals are a process concern: install them at the daemon-internal boundary,
+	// not inside the embeddable daemon class. SIGTERM is the reload wakeup path.
+	const onSignal = (): void => daemon.requestStop("signal");
+	process.once("SIGTERM", onSignal);
+	process.once("SIGINT", onSignal);
+	try {
+		await daemon.run();
+	} finally {
+		process.off("SIGTERM", onSignal);
+		process.off("SIGINT", onSignal);
+	}
 }

--- a/packages/coding-agent/src/notifications/telegram-daemon-control.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-control.ts
@@ -1,0 +1,370 @@
+/**
+ * Telegram daemon controller + owner-scoped control-request helpers.
+ *
+ * Reload is a hybrid: an owner-scoped control-request file records auditable
+ * intent, SIGTERM is the wakeup that aborts the in-flight long poll, and a
+ * fresh daemon is spawned only after the old pid is dead / has exited. This
+ * keeps the single-poller invariant (no Telegram getUpdates 409 overlap) and
+ * never steals a still-live owner.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { Settings } from "../config/settings";
+import type {
+	BuiltInDaemonController,
+	DaemonHealth,
+	DaemonOperationOptions,
+	DaemonOperationResult,
+	DaemonRuntimeInfo,
+	DaemonStatus,
+} from "../daemon/control-types";
+import { resolveGjcRuntimeSpawnInfo } from "../daemon/runtime";
+import { getNotificationConfig, isGloballyConfigured, tokenFingerprint } from "./config";
+import {
+	daemonPaths,
+	isFreshLiveOwner,
+	readDaemonRoots,
+	readDaemonState,
+	spawnTelegramDaemonOwner,
+	type TelegramDaemonDeps,
+	type TelegramDaemonFs,
+} from "./telegram-daemon";
+
+const nodeFs: TelegramDaemonFs = fs.promises as unknown as TelegramDaemonFs;
+const DEFAULT_GRACEFUL_TIMEOUT_MS = 8_000;
+const DEFAULT_KILL_TIMEOUT_MS = 3_000;
+const DEFAULT_WAIT_STEP_MS = 25;
+
+export interface TelegramDaemonControlRequest {
+	version: 1;
+	requestId: string;
+	action: "reload" | "stop";
+	ownerId: string;
+	pid: number;
+	createdAt: number;
+}
+
+export function telegramControlRequestPath(agentDir: string): string {
+	return path.join(daemonPaths(agentDir).dir, "telegram-daemon.control.json");
+}
+
+export async function readTelegramControlRequest(
+	settings: Settings,
+	fsImpl: TelegramDaemonFs = nodeFs,
+): Promise<TelegramDaemonControlRequest | undefined> {
+	const file = telegramControlRequestPath(settings.getAgentDir());
+	try {
+		const parsed = JSON.parse(await fsImpl.readFile(file, "utf8")) as TelegramDaemonControlRequest;
+		return parsed?.version === 1 ? parsed : undefined;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		return undefined;
+	}
+}
+
+export async function writeTelegramControlRequest(
+	settings: Settings,
+	request: TelegramDaemonControlRequest,
+	fsImpl: TelegramDaemonFs = nodeFs,
+): Promise<void> {
+	const dir = daemonPaths(settings.getAgentDir()).dir;
+	await fsImpl.mkdir(dir, { recursive: true, mode: 0o700 });
+	const file = telegramControlRequestPath(settings.getAgentDir());
+	const tmp = `${file}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
+	await fsImpl.writeFile(tmp, `${JSON.stringify(request, null, 2)}\n`, { mode: 0o600 });
+	await fsImpl.chmod(tmp, 0o600).catch(() => undefined);
+	await fsImpl.rename(tmp, file);
+}
+
+export async function clearTelegramControlRequest(
+	settings: Settings,
+	requestId?: string,
+	fsImpl: TelegramDaemonFs = nodeFs,
+): Promise<void> {
+	const file = telegramControlRequestPath(settings.getAgentDir());
+	if (requestId) {
+		const current = await readTelegramControlRequest(settings, fsImpl);
+		if (current && current.requestId !== requestId) return;
+	}
+	await fsImpl.unlink(file).catch(() => undefined);
+}
+
+export interface TelegramDaemonControlDeps {
+	fs?: TelegramDaemonFs;
+	now?: () => number;
+	pidAlive?: (pid: number) => boolean;
+	sendSignal?: (pid: number, signal: NodeJS.Signals) => void;
+	spawn?: TelegramDaemonDeps["spawn"];
+	execPath?: string;
+	randomId?: () => string;
+	sleep?: (ms: number) => Promise<void>;
+	waitStepMs?: number;
+}
+
+function defaultPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function defaultSendSignal(pid: number, signal: NodeJS.Signals): void {
+	try {
+		process.kill(pid, signal);
+	} catch {
+		// Best-effort: the process may already be gone.
+	}
+}
+
+export class TelegramDaemonController implements BuiltInDaemonController {
+	readonly kind = "telegram" as const;
+	private readonly fsImpl: TelegramDaemonFs;
+	private readonly now: () => number;
+	private readonly pidAlive: (pid: number) => boolean;
+	private readonly sendSignal: (pid: number, signal: NodeJS.Signals) => void;
+	private readonly waitStepMs: number;
+
+	constructor(
+		private readonly settings: Settings,
+		private readonly deps: TelegramDaemonControlDeps = {},
+	) {
+		this.fsImpl = deps.fs ?? nodeFs;
+		this.now = deps.now ?? Date.now;
+		this.pidAlive = deps.pidAlive ?? defaultPidAlive;
+		this.sendSignal = deps.sendSignal ?? defaultSendSignal;
+		this.waitStepMs = deps.waitStepMs ?? DEFAULT_WAIT_STEP_MS;
+	}
+
+	private runtimeInfo(): DaemonRuntimeInfo {
+		const rt = resolveGjcRuntimeSpawnInfo(this.deps.execPath ?? process.execPath);
+		return {
+			mode: rt.mode,
+			execPath: rt.execPath,
+			reloadPicksUpSourceEdits: rt.reloadPicksUpSourceEdits,
+			warning: rt.warning,
+		};
+	}
+
+	async status(): Promise<DaemonStatus> {
+		const runtime = this.runtimeInfo();
+		const cfg = getNotificationConfig(this.settings);
+		const configured = isGloballyConfigured(cfg) && Boolean(cfg.botToken) && Boolean(cfg.chatId);
+		if (!configured) {
+			return { kind: this.kind, configured: false, health: "not_configured", runtime };
+		}
+		const state = await readDaemonState(this.settings, this.fsImpl);
+		const roots = await readDaemonRoots(this.settings, this.fsImpl);
+		const live =
+			state !== undefined &&
+			isFreshLiveOwner({
+				state,
+				now: this.now(),
+				tokenFingerprint: tokenFingerprint(cfg.botToken as string),
+				chatId: cfg.chatId as string,
+				pidAlive: this.pidAlive,
+			});
+		let health: DaemonHealth = "stopped";
+		if (live) health = "running";
+		else if (state && state.stoppedAt === undefined) health = "stale";
+		return {
+			kind: this.kind,
+			configured: true,
+			health,
+			pid: state?.pid,
+			ownerId: state?.ownerId,
+			startedAt: state?.startedAt,
+			heartbeatAt: state?.heartbeatAt,
+			roots,
+			rootCount: roots.length,
+			runtime,
+		};
+	}
+
+	private spawnDeps(): TelegramDaemonDeps {
+		return {
+			fs: this.deps.fs,
+			now: this.deps.now,
+			pidAlive: this.deps.pidAlive,
+			spawn: this.deps.spawn,
+			execPath: this.deps.execPath,
+			randomId: this.deps.randomId,
+		};
+	}
+
+	private sleep(ms: number): Promise<void> {
+		if (this.deps.sleep) return this.deps.sleep(ms);
+		return new Promise(resolve => setTimeout(resolve, ms));
+	}
+
+	/**
+	 * Wait until the captured pid is dead. Ownership-file movement is NOT treated
+	 * as quiescence here: only actual process death proves the old poller stopped,
+	 * which is what the no-409 invariant requires before spawning a fresh poller.
+	 */
+	private async waitForPidDeath(pid: number, timeoutMs: number): Promise<boolean> {
+		if (!this.pidAlive(pid)) return true;
+		const deadline = this.now() + timeoutMs;
+		while (this.now() < deadline) {
+			await this.sleep(this.waitStepMs);
+			if (!this.pidAlive(pid)) return true;
+		}
+		return !this.pidAlive(pid);
+	}
+
+	private result(
+		action: "stop" | "reload",
+		ok: boolean,
+		message: string,
+		before: DaemonStatus | undefined,
+		after: DaemonStatus | undefined,
+		warnings: string[],
+	): DaemonOperationResult {
+		return { kind: this.kind, action, ok, before, after, message, warnings };
+	}
+
+	async reload(opts: DaemonOperationOptions = {}): Promise<DaemonOperationResult> {
+		return this.stopOrReload("reload", opts);
+	}
+
+	async stop(opts: DaemonOperationOptions = {}): Promise<DaemonOperationResult> {
+		return this.stopOrReload("stop", opts);
+	}
+
+	private async stopOrReload(action: "stop" | "reload", opts: DaemonOperationOptions): Promise<DaemonOperationResult> {
+		const before = await this.status();
+		const warnings: string[] = [];
+		if (before.runtime.warning) warnings.push(before.runtime.warning);
+		if (!before.configured) {
+			return this.result(action, false, "telegram notifications are not configured", before, before, warnings);
+		}
+		const cfg = getNotificationConfig(this.settings);
+		const fp = tokenFingerprint(cfg.botToken as string);
+		const chatId = cfg.chatId as string;
+		const roots = before.roots ?? (await readDaemonRoots(this.settings, this.fsImpl));
+		const gracefulTimeoutMs = opts.gracefulTimeoutMs ?? DEFAULT_GRACEFUL_TIMEOUT_MS;
+		const killTimeoutMs = opts.killTimeoutMs ?? DEFAULT_KILL_TIMEOUT_MS;
+
+		// No running owner.
+		if (before.health !== "running") {
+			if (action === "stop") {
+				return this.result(action, true, "no running telegram daemon", before, before, warnings);
+			}
+			const spawnIfStopped = opts.spawnIfStopped ?? true;
+			if (!spawnIfStopped) {
+				return this.result(action, true, "no running telegram daemon to reload", before, before, warnings);
+			}
+			const spawned = await spawnTelegramDaemonOwner(
+				{ settings: this.settings, roots, tokenFingerprint: fp, chatId },
+				this.spawnDeps(),
+			);
+			const after = await this.status();
+			return this.result(
+				action,
+				spawned.result === "owner_spawned",
+				`spawned fresh telegram daemon (${spawned.result})`,
+				before,
+				after,
+				warnings,
+			);
+		}
+
+		// Running owner: capture identity, request cooperative stop, signal, wait.
+		const oldOwnerId = before.ownerId as string;
+		const oldPid = before.pid as number;
+		const requestId = this.deps.randomId?.() ?? `${this.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+		await writeTelegramControlRequest(
+			this.settings,
+			{ version: 1, requestId, action, ownerId: oldOwnerId, pid: oldPid, createdAt: this.now() },
+			this.fsImpl,
+		);
+		if (this.pidAlive(oldPid)) this.sendSignal(oldPid, "SIGTERM");
+
+		let dead = await this.waitForPidDeath(oldPid, gracefulTimeoutMs);
+		if (!dead) {
+			// Old pid still alive after the cooperative SIGTERM. Inspect current ownership.
+			const current = await readDaemonState(this.settings, this.fsImpl);
+			const changedToLiveOwner =
+				current !== undefined &&
+				current.ownerId !== oldOwnerId &&
+				isFreshLiveOwner({
+					state: current,
+					now: this.now(),
+					tokenFingerprint: fp,
+					chatId,
+					pidAlive: this.pidAlive,
+				});
+			if (changedToLiveOwner) {
+				// A different, fresh-live owner already supersedes the old one. Do not
+				// kill it or spawn another; attach to the running daemon.
+				await this.clearOwnRequest(requestId, oldOwnerId);
+				const after = await this.status();
+				warnings.push("ownership changed to a live owner; attached without spawning");
+				return this.result(
+					action,
+					true,
+					action === "reload"
+						? "a live owner already exists; attached instead of reloading"
+						: "another live owner already exists",
+					before,
+					after,
+					warnings,
+				);
+			}
+			// No live replacement. Escalate to SIGKILL only with --force and only when
+			// the captured owner/pid still matches, so we never kill a different owner.
+			const stillSameOwner = current !== undefined && current.ownerId === oldOwnerId && current.pid === oldPid;
+			if (opts.force && stillSameOwner && this.pidAlive(oldPid)) {
+				this.sendSignal(oldPid, "SIGKILL");
+				dead = await this.waitForPidDeath(oldPid, killTimeoutMs);
+			}
+			if (!dead) {
+				await this.clearOwnRequest(requestId, oldOwnerId);
+				const after = await this.status();
+				const message = opts.force
+					? "old daemon did not exit after SIGKILL; refusing to spawn to avoid a Telegram 409 conflict"
+					: "old daemon did not exit within the graceful timeout; rerun with --force to hard-kill";
+				return this.result(action, false, message, before, after, warnings);
+			}
+		}
+
+		// Old pid is dead: safe to clear our request and proceed.
+		await this.clearOwnRequest(requestId, oldOwnerId);
+
+		if (action === "stop") {
+			const after = await this.status();
+			return this.result(action, true, "stopped telegram daemon", before, after, warnings);
+		}
+
+		const spawned = await spawnTelegramDaemonOwner(
+			{ settings: this.settings, roots, tokenFingerprint: fp, chatId },
+			this.spawnDeps(),
+		);
+		const after = await this.status();
+		if (spawned.result === "attached") {
+			// A live owner already exists; attaching to it is a valid running end-state.
+			warnings.push("a live owner already exists; attached instead of spawning");
+		} else if (after.ownerId && after.ownerId === oldOwnerId) {
+			warnings.push("owner id unchanged after reload");
+		}
+		return this.result(
+			action,
+			spawned.result !== "disabled",
+			`reloaded telegram daemon (${spawned.result})`,
+			before,
+			after,
+			warnings,
+		);
+	}
+
+	/** Clear our own control request unless a newer owner-scoped request replaced it. */
+	private async clearOwnRequest(requestId: string, oldOwnerId: string): Promise<void> {
+		const current = await readTelegramControlRequest(this.settings, this.fsImpl);
+		if (!current) return;
+		if (current.requestId === requestId || current.ownerId === oldOwnerId) {
+			await clearTelegramControlRequest(this.settings, current.requestId, this.fsImpl);
+		}
+	}
+}

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -4,6 +4,8 @@ import * as path from "node:path";
 import { logger } from "@gajae-code/utils";
 import { withFileLock } from "../config/file-lock";
 import type { Settings } from "../config/settings";
+import type { DaemonRuntimeInfo } from "../daemon/control-types";
+import { resolveGjcRuntimeSpawnInfo } from "../daemon/runtime";
 import { getNotificationConfig, isGloballyConfigured, tokenFingerprint } from "./config";
 import { parseInThreadConfigCommand } from "./config-commands";
 import { buildButtonGrid, TELEGRAM_PARSE_MODE } from "./html-format";
@@ -19,7 +21,7 @@ import {
 } from "./telegram-reference";
 import { decideThreadedInbound } from "./threaded-inbound";
 import { renderThreadedFrame, type ThreadedSend } from "./threaded-render";
-import { TopicRegistry } from "./topic-registry";
+import { TopicRegistry, type TopicRegistryState } from "./topic-registry";
 
 export type EnsureDaemonResult = "owner_spawned" | "attached" | "disabled";
 
@@ -370,6 +372,20 @@ export async function releaseDaemonOwnership(input: {
 	await fsImpl.unlink(paths.lock).catch(() => undefined);
 }
 
+/** Read the persisted daemon ownership state (or undefined when absent). */
+export async function readDaemonState(
+	settings: Settings,
+	fs: TelegramDaemonFs = nodeFs,
+): Promise<DaemonState | undefined> {
+	return readJson<DaemonState>(fs, daemonPaths(settings.getAgentDir()).state);
+}
+
+/** Read the persisted notification roots list. */
+export async function readDaemonRoots(settings: Settings, fs: TelegramDaemonFs = nodeFs): Promise<string[]> {
+	const roots = await readJson<{ roots?: string[] }>(fs, daemonPaths(settings.getAgentDir()).roots);
+	return roots?.roots ?? [];
+}
+
 function defaultPidAlive(pid: number): boolean {
 	try {
 		process.kill(pid, 0);
@@ -377,6 +393,11 @@ function defaultPidAlive(pid: number): boolean {
 	} catch {
 		return false;
 	}
+}
+
+/** True for AbortError-shaped rejections raised when an in-flight fetch is aborted. */
+function isAbortError(err: unknown): boolean {
+	return err instanceof Error && (err.name === "AbortError" || /\baborted\b/i.test(err.message));
 }
 
 function defaultDaemonSpawn(
@@ -402,6 +423,89 @@ function defaultDaemonSpawn(
 	return { unref: () => child.unref() };
 }
 
+export interface TelegramSpawnOwnerInput {
+	settings: Settings;
+	roots?: string[];
+	tokenFingerprint: string;
+	chatId: string;
+}
+
+export interface TelegramSpawnOwnerResult {
+	result: EnsureDaemonResult;
+	ownerId?: string;
+	runtime: DaemonRuntimeInfo;
+	warnings: string[];
+}
+
+/**
+ * Build the detached spawn command/args for the daemon-internal entrypoint.
+ * Source mode prepends the entry script so the respawn loads edited source;
+ * a compiled binary self-spawns its own subcommand directly.
+ */
+export function buildTelegramDaemonSpawnArgs(input: { execPath?: string; ownerId: string; agentDir: string }): {
+	command: string;
+	args: string[];
+	runtime: DaemonRuntimeInfo;
+} {
+	const rt = resolveGjcRuntimeSpawnInfo(input.execPath ?? process.execPath);
+	const args = [
+		...rt.argsPrefix,
+		"notify",
+		"daemon-internal",
+		"--owner-id",
+		input.ownerId,
+		"--agent-dir",
+		input.agentDir,
+	];
+	const runtime: DaemonRuntimeInfo = {
+		mode: rt.mode,
+		execPath: rt.execPath,
+		reloadPicksUpSourceEdits: rt.reloadPicksUpSourceEdits,
+		warning: rt.warning,
+	};
+	return { command: rt.execPath, args, runtime };
+}
+
+/**
+ * Acquire ownership for the given Telegram identity and, if acquired, spawn a
+ * fresh detached daemon process. Does NOT register notification roots; callers
+ * that own a session (autostart) register roots separately, while reload reuses
+ * already-persisted roots.
+ */
+export async function spawnTelegramDaemonOwner(
+	input: TelegramSpawnOwnerInput,
+	deps: TelegramDaemonDeps = {},
+): Promise<TelegramSpawnOwnerResult> {
+	const agentDir = input.settings.getAgentDir();
+	const execPath = deps.execPath ?? process.execPath;
+	const ownership = await acquireDaemonOwnership({
+		settings: input.settings,
+		roots: input.roots,
+		tokenFingerprint: input.tokenFingerprint,
+		chatId: input.chatId,
+		fs: deps.fs,
+		now: deps.now,
+		pid: deps.pid,
+		pidAlive: deps.pidAlive,
+		randomId: deps.randomId,
+	});
+	// One source of truth for runtime detection + spawn args (no duplicate resolve).
+	const { command, args, runtime } = buildTelegramDaemonSpawnArgs({
+		execPath,
+		ownerId: ownership.ownerId ?? "",
+		agentDir,
+	});
+	if (!ownership.acquired) return { result: "attached", runtime, warnings: [] };
+	const spawnImpl = deps.spawn ?? defaultDaemonSpawn;
+	const child = spawnImpl(command, args, {
+		detached: true,
+		stdio: "ignore",
+		logPath: path.join(daemonPaths(agentDir).dir, "daemon.log"),
+	});
+	child?.unref?.();
+	return { result: "owner_spawned", ownerId: ownership.ownerId, runtime, warnings: [] };
+}
+
 export async function ensureTelegramDaemonRunning(
 	input: { settings: Settings; cwd: string; sessionId: string },
 	deps: TelegramDaemonDeps = {},
@@ -410,45 +514,27 @@ export async function ensureTelegramDaemonRunning(
 	if (!isGloballyConfigured(cfg) || !cfg.botToken || !cfg.chatId) return "disabled";
 	const root = await registerNotificationRoot({ ...input, fs: deps.fs });
 	const fp = tokenFingerprint(cfg.botToken);
-	const ownership = await acquireDaemonOwnership({
-		settings: input.settings,
-		roots: [root],
-		tokenFingerprint: fp,
-		chatId: cfg.chatId,
-		fs: deps.fs,
-		now: deps.now,
-		pid: deps.pid,
-		pidAlive: deps.pidAlive,
-		randomId: deps.randomId,
-	});
-	if (!ownership.acquired) return "attached";
-	const execPath = deps.execPath ?? process.execPath;
-	// Source mode (bun/node) needs the entry script prepended; a compiled single-file
-	// binary (basename gjc/etc.) self-spawns its own subcommand directly.
-	const base = path.basename(execPath).toLowerCase();
-	const fromSource = base === "bun" || base === "node" || base.startsWith("bun") || base.startsWith("node");
-	const mainScript = fromSource && typeof Bun !== "undefined" ? (Bun as unknown as { main?: string }).main : undefined;
-	const args = [
-		...(mainScript ? [mainScript] : []),
-		"notify",
-		"daemon-internal",
-		"--owner-id",
-		ownership.ownerId!,
-		"--agent-dir",
-		input.settings.getAgentDir(),
-	];
-	const spawnImpl = deps.spawn ?? defaultDaemonSpawn;
-	const child = spawnImpl(execPath, args, {
-		detached: true,
-		stdio: "ignore",
-		logPath: path.join(daemonPaths(input.settings.getAgentDir()).dir, "daemon.log"),
-	});
-	child?.unref?.();
-	return "owner_spawned";
+	const spawned = await spawnTelegramDaemonOwner(
+		{ settings: input.settings, roots: [root], tokenFingerprint: fp, chatId: cfg.chatId },
+		deps,
+	);
+	return spawned.result;
 }
 
 export interface BotApi {
-	call(method: string, body: unknown): Promise<unknown>;
+	call(method: string, body: unknown, opts?: { signal?: AbortSignal }): Promise<unknown>;
+}
+
+/**
+ * Cooperative control seam for the daemon run loop. Implemented by the
+ * daemon-internal CLI / controller against the owner-scoped control-request
+ * file so the daemon does not import the control module directly.
+ */
+export interface DaemonControlHooks {
+	/** Returns true when a stop/reload has been requested for this owner. */
+	shouldStop(ownerId: string): Promise<boolean>;
+	/** Clear a consumed control request (best-effort). */
+	clear?(ownerId: string): Promise<void>;
 }
 
 export interface TelegramDaemonOptions {
@@ -469,6 +555,7 @@ export interface TelegramDaemonOptions {
 	scanIntervalMs?: number;
 	pid?: number;
 	botApi?: BotApi;
+	control?: DaemonControlHooks;
 }
 
 interface SessionSocket {
@@ -505,12 +592,29 @@ export class TelegramNotificationDaemon {
 	private readonly busy = new Set<string>();
 	/** Inbound update id → originating Telegram message, for delivery reactions. */
 	private readonly inboundReactions = new Map<number, { messageId: number }>();
+	/** AbortController for the in-flight long poll; aborted by requestStop() to wake the loop. */
+	private activePoll: AbortController | undefined;
+	/** Set when a cooperative stop has been requested (signal or control request). */
+	private stopRequested = false;
+	/** Current bounded backoff after a Telegram getUpdates 409 conflict (0 when healthy). */
+	private pollConflictBackoffMs = 0;
+
+	/**
+	 * Cooperatively stop the daemon: set the stop flag and abort the in-flight
+	 * long poll so the run loop wakes immediately instead of waiting out the
+	 * ~25s getUpdates timeout. Safe to call from a signal handler.
+	 */
+	requestStop(_reason?: "reload" | "stop" | "signal"): void {
+		this.stopRequested = true;
+		this.running = false;
+		this.activePoll?.abort();
+	}
 
 	constructor(private readonly opts: TelegramDaemonOptions) {
 		this.fsImpl = opts.fs ?? nodeFs;
 		this.aliasTable = createAliasTable();
 		this.botApi = opts.botApi ?? {
-			call: async (method, body) => {
+			call: async (method, body, callOpts) => {
 				const apiBase = opts.apiBase ?? "https://api.telegram.org";
 				const url = `${apiBase}/bot${opts.botToken}/${method}`;
 				const fetchImpl = opts.fetchImpl ?? fetch;
@@ -534,7 +638,12 @@ export class TelegramNotificationDaemon {
 					if (b.caption) form.set("caption", b.caption);
 					if (b.parse_mode) form.set("parse_mode", String(b.parse_mode));
 					form.set("photo", new Blob([Buffer.from(b.photo, "base64")], { type: b.mime ?? "image/png" }), "image");
-					const res = await fetchWithRetry(fetchImpl, url, { method: "POST", body: form }, sleep);
+					const res = await fetchWithRetry(
+						fetchImpl,
+						url,
+						{ method: "POST", body: form, signal: callOpts?.signal },
+						sleep,
+					);
 					return res.json();
 				}
 				const res = await fetchWithRetry(
@@ -544,6 +653,7 @@ export class TelegramNotificationDaemon {
 						method: "POST",
 						headers: { "content-type": "application/json" },
 						body: JSON.stringify(body),
+						signal: callOpts?.signal,
 					},
 					sleep,
 				);
@@ -741,18 +851,10 @@ export class TelegramNotificationDaemon {
 
 	async loadTopics(): Promise<void> {
 		const paths = daemonPaths(this.opts.settings.getAgentDir());
-		const raw = await readJson<{ topics?: Record<string, unknown> }>(
-			this.fsImpl,
-			path.join(paths.dir, "telegram-topics.json"),
-		);
-		if (raw && typeof raw === "object") {
-			// Reconstruct via a fresh registry then copy in (TopicRegistry loads from state in ctor).
-			const restored = new TopicRegistry(raw as never);
-			for (const sid of Object.keys(raw.topics ?? {})) {
-				const rec = restored.get(sid);
-				if (rec) await this.topics.getOrCreateTopic(sid, async () => rec.topicId, this.opts.now);
-			}
-		}
+		const raw = await readJson<TopicRegistryState>(this.fsImpl, path.join(paths.dir, "telegram-topics.json"));
+		// Restore the full serialized registry (topicId + identitySent + name) so a
+		// fresh daemon after reload does not resend identity headers or lose renames.
+		if (raw && typeof raw === "object") this.topics.load(raw);
 	}
 
 	/** Drain the shared rate-limit pool and deliver each granted send to its topic. */
@@ -1085,22 +1187,43 @@ export class TelegramNotificationDaemon {
 		}
 	}
 
-	async pollOnce(): Promise<number> {
-		let body: { result?: Array<{ update_id: number } & Record<string, unknown>> };
+	async pollOnce(signal?: AbortSignal): Promise<number> {
+		let body: {
+			ok?: boolean;
+			error_code?: number;
+			description?: string;
+			result?: Array<{ update_id: number } & Record<string, unknown>>;
+		};
 		try {
-			body = (await this.botApi.call("getUpdates", {
-				offset: this.offset,
-				timeout: 25,
-				allowed_updates: ["message", "callback_query"],
-			})) as { result?: Array<{ update_id: number } & Record<string, unknown>> };
+			body = (await this.botApi.call(
+				"getUpdates",
+				{ offset: this.offset, timeout: 25, allowed_updates: ["message", "callback_query"] },
+				{ signal },
+			)) as typeof body;
 		} catch (err) {
+			// A cooperative stop aborts the in-flight long poll; treat as a clean wake.
+			if (isAbortError(err)) return 0;
 			// A transient Telegram API failure (e.g. ECONNRESET on the long-poll) must
 			// never crash the daemon — that silently stops all delivery, including ask
 			// notifications. Log, back off, and let the run loop retry.
 			console.error("notifications daemon: getUpdates failed:", err);
-			await new Promise(resolve => (this.opts.setTimeoutImpl ?? setTimeout)(resolve, POLL_BACKOFF_MS));
+			await this.sleep(POLL_BACKOFF_MS, signal);
 			return 0;
 		}
+		// Telegram allows only one active getUpdates poller per bot. A 409 means
+		// another poller is live; back off boundedly instead of hot-looping.
+		if (body && body.ok === false && (body.error_code === 409 || /409|conflict/i.test(body.description ?? ""))) {
+			this.pollConflictBackoffMs = Math.min(
+				this.pollConflictBackoffMs ? this.pollConflictBackoffMs * 2 : 500,
+				5_000,
+			);
+			console.error(
+				`notifications daemon: Telegram getUpdates 409 conflict (${body.description ?? "no description"}); backing off ${this.pollConflictBackoffMs}ms`,
+			);
+			await this.sleep(this.pollConflictBackoffMs, signal);
+			return 0;
+		}
+		this.pollConflictBackoffMs = 0;
 		for (const update of body.result ?? []) {
 			this.offset = update.update_id + 1;
 			try {
@@ -1110,6 +1233,22 @@ export class TelegramNotificationDaemon {
 			}
 		}
 		return body.result?.length ?? 0;
+	}
+
+	/** Abortable sleep honoring the injected timer; resolves early on abort. */
+	private sleep(ms: number, signal?: AbortSignal): Promise<void> {
+		return new Promise<void>(resolve => {
+			if (signal?.aborted) return resolve();
+			const timer = (this.opts.setTimeoutImpl ?? setTimeout)(() => resolve(), ms);
+			signal?.addEventListener(
+				"abort",
+				() => {
+					(this.opts.clearTimeoutImpl ?? clearTimeout)(timer);
+					resolve();
+				},
+				{ once: true },
+			);
+		});
 	}
 
 	/** Sync the bot's Telegram command menu to what the daemon actually handles. */
@@ -1147,6 +1286,7 @@ export class TelegramNotificationDaemon {
 			let idleSince = (this.opts.now ?? Date.now)();
 			let pollBackoffMs = 0;
 			while (this.running) {
+				if (await this.controlStopRequested()) break;
 				if (
 					!(await renewDaemonHeartbeat({
 						settings: this.opts.settings,
@@ -1158,12 +1298,14 @@ export class TelegramNotificationDaemon {
 				)
 					break;
 				await this.runScan();
+				if (await this.controlStopRequested()) break;
 				if (this.sessions.size === 0) {
 					if ((this.opts.now ?? Date.now)() - idleSince >= (this.opts.idleTimeoutMs ?? 60_000)) break;
 				} else {
 					idleSince = (this.opts.now ?? Date.now)();
+					this.activePoll = new AbortController();
 					try {
-						await this.pollOnce();
+						await this.pollOnce(this.activePoll.signal);
 						pollBackoffMs = 0;
 					} catch (e) {
 						// A transient getUpdates/network failure must not kill the
@@ -1173,20 +1315,39 @@ export class TelegramNotificationDaemon {
 						logger.warn(`notifications: getUpdates failed, backing off ${pollBackoffMs}ms: ${String(e)}`);
 						await new Promise(resolve => (this.opts.setTimeoutImpl ?? setTimeout)(resolve, pollBackoffMs));
 						continue;
+					} finally {
+						this.activePoll = undefined;
 					}
 				}
+				if (await this.controlStopRequested()) break;
 				await new Promise(resolve => (this.opts.setTimeoutImpl ?? setTimeout)(resolve, 10));
 			}
 		} finally {
 			this.stopFlushTimer();
 			this.stopScanTimer();
 			this.stopTypingTimer();
+			// Persist durable state before releasing ownership so a fresh daemon
+			// (e.g. after reload) reloads aliases/topics seamlessly.
+			await this.persistAliases().catch(() => undefined);
+			await this.persistTopics().catch(() => undefined);
+			await this.opts.control?.clear?.(this.opts.ownerId).catch(() => undefined);
 			await releaseDaemonOwnership({
 				settings: this.opts.settings,
 				ownerId: this.opts.ownerId,
 				fs: this.fsImpl,
 				now: this.opts.now,
 			});
+		}
+	}
+
+	/** True when a signal-driven stop or an owner-scoped control request asks the loop to exit. */
+	private async controlStopRequested(): Promise<boolean> {
+		if (this.stopRequested) return true;
+		if (!this.opts.control) return false;
+		try {
+			return await this.opts.control.shouldStop(this.opts.ownerId);
+		} catch {
+			return false;
 		}
 	}
 }

--- a/packages/coding-agent/src/notifications/topic-registry.ts
+++ b/packages/coding-agent/src/notifications/topic-registry.ts
@@ -52,6 +52,14 @@ export class TopicRegistry {
 		for (const [sessionId, record] of this.topics) this.byTopic.set(record.topicId, sessionId);
 	}
 
+	/** Merge a serialized state into this registry, preserving all persisted fields. */
+	load(state: TopicRegistryState): void {
+		for (const [sessionId, record] of Object.entries(state.topics ?? {})) {
+			this.topics.set(sessionId, record);
+			this.byTopic.set(record.topicId, sessionId);
+		}
+	}
+
 	/** Resolve the owning session for a topic id (for fail-closed inbound routing). */
 	sessionForTopic(topicId: string): string | undefined {
 		return this.byTopic.get(topicId);

--- a/packages/coding-agent/test/daemon-control.test.ts
+++ b/packages/coding-agent/test/daemon-control.test.ts
@@ -1,0 +1,499 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseDaemonArgs, runDaemonCommand } from "../src/cli/daemon-cli";
+import { Settings } from "../src/config/settings";
+import { createBuiltInDaemonControllers, selectDaemonControllers } from "../src/daemon/builtin";
+import type { BuiltInDaemonController, DaemonOperationResult, DaemonStatus } from "../src/daemon/control-types";
+import { resolveGjcRuntimeSpawnInfo } from "../src/daemon/runtime";
+import { tokenFingerprint } from "../src/notifications/config";
+import { daemonPaths } from "../src/notifications/telegram-daemon";
+import {
+	clearTelegramControlRequest,
+	readTelegramControlRequest,
+	TelegramDaemonController,
+	writeTelegramControlRequest,
+} from "../src/notifications/telegram-daemon-control";
+import { TopicRegistry } from "../src/notifications/topic-registry";
+
+const BOT_TOKEN = "123456:secret-token";
+
+function tempAgentDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-daemon-control-test-"));
+}
+
+function setPrivateAgentDir(s: Settings, agentDir: string): Settings {
+	return new Proxy(s, {
+		get(target, prop) {
+			if (prop === "getAgentDir") return () => agentDir;
+			const value = Reflect.get(target, prop, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	}) as Settings;
+}
+
+function settings(agentDir: string): Settings {
+	return setPrivateAgentDir(
+		Settings.isolated({
+			"notifications.enabled": true,
+			"notifications.telegram.botToken": BOT_TOKEN,
+			"notifications.telegram.chatId": "42",
+		}) as Settings,
+		agentDir,
+	);
+}
+
+function writeState(agentDir: string, state: Record<string, unknown>): void {
+	const paths = daemonPaths(agentDir);
+	fs.mkdirSync(paths.dir, { recursive: true });
+	fs.writeFileSync(paths.state, JSON.stringify(state));
+}
+
+function freshState(extra: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+	return {
+		pid: 999,
+		ownerId: "old",
+		tokenFingerprint: tokenFingerprint(BOT_TOKEN),
+		chatId: "42",
+		startedAt: Date.now(),
+		heartbeatAt: Date.now(),
+		roots: [],
+		version: 1,
+		...extra,
+	};
+}
+
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+	const orig = process.stdout.write.bind(process.stdout);
+	let out = "";
+	process.stdout.write = ((chunk: unknown): boolean => {
+		out += String(chunk);
+		return true;
+	}) as typeof process.stdout.write;
+	try {
+		await fn();
+	} finally {
+		process.stdout.write = orig;
+	}
+	return out;
+}
+
+describe("daemon runtime detection", () => {
+	test("source runtime picks up edits; compiled warns", () => {
+		const source = resolveGjcRuntimeSpawnInfo("/usr/local/bin/node");
+		expect(source.mode).toBe("source");
+		expect(source.reloadPicksUpSourceEdits).toBe(true);
+		expect(source.warning).toBeUndefined();
+
+		const compiled = resolveGjcRuntimeSpawnInfo("/opt/gjc/gjc");
+		expect(compiled.mode).toBe("compiled");
+		expect(compiled.reloadPicksUpSourceEdits).toBe(false);
+		expect(compiled.warning).toContain("Rebuild");
+		expect(compiled.argsPrefix).toEqual([]);
+	});
+});
+
+describe("static built-in controller map", () => {
+	test("createBuiltInDaemonControllers exposes telegram only", () => {
+		const s = settings(tempAgentDir());
+		const map = createBuiltInDaemonControllers(s);
+		expect(Object.keys(map)).toEqual(["telegram"]);
+		expect(map.telegram).toBeInstanceOf(TelegramDaemonController);
+	});
+
+	test("selectDaemonControllers resolves default, all, and rejects unknown kinds", () => {
+		const s = settings(tempAgentDir());
+		expect(selectDaemonControllers(s, undefined, false)).toHaveLength(1);
+		expect(selectDaemonControllers(s, ["telegram"], false)).toHaveLength(1);
+		expect(selectDaemonControllers(s, undefined, true)).toHaveLength(1);
+		// Unknown kinds are rejected by the static map.
+		expect(() => selectDaemonControllers(s, ["mystery" as never], false)).toThrow(/unknown daemon kind/);
+	});
+});
+
+describe("parseDaemonArgs", () => {
+	test("parses action, kind, and flags", () => {
+		const parsed = parseDaemonArgs([
+			"daemon",
+			"reload",
+			"telegram",
+			"--json",
+			"--force",
+			"--graceful-timeout-ms",
+			"1500",
+		]);
+		expect(parsed).toBeTruthy();
+		expect(parsed?.action).toBe("reload");
+		expect(parsed?.kinds).toEqual(["telegram"]);
+		expect(parsed?.json).toBe(true);
+		expect(parsed?.force).toBe(true);
+		expect(parsed?.gracefulTimeoutMs).toBe(1500);
+	});
+
+	test("defaults to status and ignores non-daemon argv", () => {
+		expect(parseDaemonArgs(["notify", "status"])).toBeUndefined();
+		expect(parseDaemonArgs(["daemon"])?.action).toBe("status");
+	});
+});
+
+describe("control request helpers", () => {
+	test("write/read/clear roundtrip is owner-scoped", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		await writeTelegramControlRequest(s, {
+			version: 1,
+			requestId: "r1",
+			action: "reload",
+			ownerId: "owner-a",
+			pid: 123,
+			createdAt: Date.now(),
+		});
+		const read = await readTelegramControlRequest(s);
+		expect(read?.requestId).toBe("r1");
+		expect(read?.ownerId).toBe("owner-a");
+
+		// Clearing with a mismatched requestId must not remove a newer request.
+		await clearTelegramControlRequest(s, "different-id");
+		expect(await readTelegramControlRequest(s)).toBeTruthy();
+
+		await clearTelegramControlRequest(s, "r1");
+		expect(await readTelegramControlRequest(s)).toBeUndefined();
+	});
+});
+
+describe("TelegramDaemonController.status", () => {
+	test("reports not_configured when token/chat missing", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(Settings.isolated({}) as Settings, agentDir);
+		const status = await new TelegramDaemonController(s).status();
+		expect(status.configured).toBe(false);
+		expect(status.health).toBe("not_configured");
+	});
+
+	test("reports running for a fresh live owner and stale for a dead one", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		writeState(agentDir, freshState());
+
+		const running = await new TelegramDaemonController(s, { pidAlive: () => true }).status();
+		expect(running.health).toBe("running");
+		expect(running.pid).toBe(999);
+		expect(running.ownerId).toBe("old");
+
+		const stale = await new TelegramDaemonController(s, { pidAlive: () => false }).status();
+		expect(stale.health).toBe("stale");
+	});
+});
+
+describe("TelegramDaemonController.reload", () => {
+	test("cooperatively stops the old owner and spawns a fresh one", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		writeState(agentDir, freshState());
+		fs.writeFileSync(daemonPaths(agentDir).lock, "");
+
+		const alive = new Set<number>([999, process.pid]);
+		const signals: Array<[number, string]> = [];
+		const spawns: Array<{ command: string; args: string[] }> = [];
+		const ctrl = new TelegramDaemonController(s, {
+			pidAlive: pid => alive.has(pid),
+			sendSignal: (pid, sig) => {
+				signals.push([pid, sig]);
+				if (sig === "SIGTERM") alive.delete(999);
+			},
+			spawn: (command, args) => {
+				spawns.push({ command, args });
+				return { unref() {} };
+			},
+			sleep: async () => undefined,
+		});
+
+		const result = await ctrl.reload();
+		expect(result.ok).toBe(true);
+		expect(signals).toContainEqual([999, "SIGTERM"]);
+		expect(spawns).toHaveLength(1);
+		const after = JSON.parse(fs.readFileSync(daemonPaths(agentDir).state, "utf8")) as { ownerId: string };
+		expect(after.ownerId).not.toBe("old");
+		// No leftover control request after a successful reload.
+		expect(await readTelegramControlRequest(s)).toBeUndefined();
+	});
+
+	test("escalates to SIGKILL when the old owner ignores SIGTERM", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		writeState(agentDir, freshState());
+		fs.writeFileSync(daemonPaths(agentDir).lock, "");
+
+		const alive = new Set<number>([999, process.pid]);
+		const signals: Array<[number, string]> = [];
+		const ctrl = new TelegramDaemonController(s, {
+			pidAlive: pid => alive.has(pid),
+			sendSignal: (pid, sig) => {
+				signals.push([pid, sig]);
+				if (sig === "SIGKILL") alive.delete(999);
+			},
+			spawn: () => ({ unref() {} }),
+			sleep: async () => undefined,
+			waitStepMs: 1,
+		});
+
+		const result = await ctrl.reload({ gracefulTimeoutMs: 5, killTimeoutMs: 50, force: true });
+		expect(result.ok).toBe(true);
+		expect(signals.some(([, sig]) => sig === "SIGTERM")).toBe(true);
+		expect(signals.some(([, sig]) => sig === "SIGKILL")).toBe(true);
+	});
+
+	test("does not escalate or kill when ownership changes mid-wait", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		writeState(agentDir, freshState());
+		fs.writeFileSync(daemonPaths(agentDir).lock, "");
+
+		const alive = new Set<number>([999, process.pid, 1000]);
+		const signals: Array<[number, string]> = [];
+		let mutated = false;
+		const ctrl = new TelegramDaemonController(s, {
+			pidAlive: pid => alive.has(pid),
+			// SIGTERM never kills 999 here; ownership changes underneath instead.
+			sendSignal: (pid, sig) => signals.push([pid, sig]),
+			spawn: () => ({ unref() {} }),
+			sleep: async () => {
+				if (!mutated) {
+					mutated = true;
+					writeState(agentDir, freshState({ ownerId: "newer", pid: 1000 }));
+				}
+			},
+			waitStepMs: 1,
+		});
+
+		const result = await ctrl.reload({ gracefulTimeoutMs: 50 });
+		expect(result.ok).toBe(true);
+		// We must never SIGKILL a different/newer owner.
+		expect(signals.some(([, sig]) => sig === "SIGKILL")).toBe(false);
+		expect(result.warnings.some(w => /live owner|ownership changed/i.test(w))).toBe(true);
+	});
+
+	test("without --force, an unresponsive old daemon is not killed or replaced", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		writeState(agentDir, freshState());
+		fs.writeFileSync(daemonPaths(agentDir).lock, "");
+		const alive = new Set<number>([999, process.pid]);
+		const signals: Array<[number, string]> = [];
+		let spawnCalls = 0;
+		const ctrl = new TelegramDaemonController(s, {
+			pidAlive: pid => alive.has(pid),
+			sendSignal: (pid, sig) => signals.push([pid, sig]),
+			spawn: () => {
+				spawnCalls++;
+				return { unref() {} };
+			},
+			sleep: async () => undefined,
+			waitStepMs: 1,
+		});
+		const result = await ctrl.reload({ gracefulTimeoutMs: 5 });
+		expect(result.ok).toBe(false);
+		expect(signals.some(([, sig]) => sig === "SIGKILL")).toBe(false);
+		expect(spawnCalls).toBe(0);
+		expect(result.message).toMatch(/--force/);
+	});
+
+	test("never spawns while the captured old pid is still alive (stale changed-owner)", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		writeState(agentDir, freshState());
+		fs.writeFileSync(daemonPaths(agentDir).lock, "");
+		// 999 stays alive; ownership flips to a DEAD different owner (pid 1000 not alive).
+		const alive = new Set<number>([999]);
+		let spawnCalls = 0;
+		let mutated = false;
+		const ctrl = new TelegramDaemonController(s, {
+			pidAlive: pid => alive.has(pid),
+			sendSignal: () => undefined,
+			spawn: () => {
+				spawnCalls++;
+				return { unref() {} };
+			},
+			sleep: async () => {
+				if (!mutated) {
+					mutated = true;
+					writeState(agentDir, freshState({ ownerId: "stale-newer", pid: 1000 }));
+				}
+			},
+			waitStepMs: 1,
+		});
+		const result = await ctrl.reload({ gracefulTimeoutMs: 20, force: true });
+		// Old pid 999 never died and the changed owner is not live -> must not spawn.
+		expect(spawnCalls).toBe(0);
+		expect(result.ok).toBe(false);
+	});
+
+	test("spawns the fresh owner only after the old pid is confirmed dead (no poll overlap)", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		writeState(agentDir, freshState());
+		fs.writeFileSync(daemonPaths(agentDir).lock, "");
+		const alive = new Set<number>([999, process.pid]);
+		let oldAliveAtSpawn: boolean | undefined;
+		const ctrl = new TelegramDaemonController(s, {
+			pidAlive: pid => alive.has(pid),
+			sendSignal: (_pid, sig) => {
+				if (sig === "SIGTERM") alive.delete(999);
+			},
+			spawn: () => {
+				oldAliveAtSpawn = alive.has(999);
+				return { unref() {} };
+			},
+			sleep: async () => undefined,
+		});
+		const result = await ctrl.reload();
+		expect(result.ok).toBe(true);
+		// The no-409 invariant: the old poller must be dead before a new one spawns.
+		expect(oldAliveAtSpawn).toBe(false);
+	});
+
+	test("rejects an unknown kind with a clean error and exit code 1", async () => {
+		const prevExit = process.exitCode;
+		const orig = process.stderr.write.bind(process.stderr);
+		let err = "";
+		process.stderr.write = ((chunk: unknown): boolean => {
+			err += String(chunk);
+			return true;
+		}) as typeof process.stderr.write;
+		try {
+			await runDaemonCommand(
+				{ action: "status", kinds: ["bogus" as never], all: false, json: true, force: false },
+				{ controllers: undefined },
+			);
+		} finally {
+			process.stderr.write = orig;
+		}
+		expect(err).toContain("Unknown daemon kind(s): bogus");
+		expect(process.exitCode).toBe(1);
+		// Reset so this expected non-zero exitCode does not leak into the test runner's exit status.
+		process.exitCode = typeof prevExit === "number" ? prevExit : 0;
+	});
+
+	test("reload with no running daemon spawns a fresh one (spawnIfStopped default)", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const spawns: Array<{ command: string; args: string[] }> = [];
+		const ctrl = new TelegramDaemonController(s, {
+			pidAlive: () => true,
+			spawn: (command, args) => {
+				spawns.push({ command, args });
+				return { unref() {} };
+			},
+		});
+		const result = await ctrl.reload();
+		expect(result.ok).toBe(true);
+		expect(spawns).toHaveLength(1);
+	});
+});
+
+describe("TelegramDaemonController.stop", () => {
+	test("stops a running owner without spawning a replacement", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		writeState(agentDir, freshState());
+		fs.writeFileSync(daemonPaths(agentDir).lock, "");
+
+		const alive = new Set<number>([999]);
+		let spawnCalls = 0;
+		const ctrl = new TelegramDaemonController(s, {
+			pidAlive: pid => alive.has(pid),
+			sendSignal: (pid, sig) => {
+				if (sig === "SIGTERM") alive.delete(pid);
+			},
+			spawn: () => {
+				spawnCalls++;
+				return { unref() {} };
+			},
+			sleep: async () => undefined,
+		});
+		const result = await ctrl.stop();
+		expect(result.ok).toBe(true);
+		expect(spawnCalls).toBe(0);
+	});
+});
+
+describe("runDaemonCommand", () => {
+	function fakeController(status: DaemonStatus, result: DaemonOperationResult): BuiltInDaemonController {
+		return {
+			kind: "telegram",
+			status: async () => status,
+			stop: async () => result,
+			reload: async () => result,
+		};
+	}
+
+	test("status --json prints the controller status array", async () => {
+		const status: DaemonStatus = {
+			kind: "telegram",
+			configured: true,
+			health: "running",
+			pid: 7,
+			ownerId: "o1",
+			rootCount: 2,
+			runtime: { mode: "source", execPath: "/usr/bin/node", reloadPicksUpSourceEdits: true },
+		};
+		const out = await captureStdout(() =>
+			runDaemonCommand(
+				{ action: "status", kinds: ["telegram"], all: false, json: true, force: false },
+				{ controllers: [fakeController(status, {} as DaemonOperationResult)] },
+			),
+		);
+		const parsed = JSON.parse(out) as DaemonStatus[];
+		expect(parsed[0].health).toBe("running");
+		expect(parsed[0].ownerId).toBe("o1");
+	});
+
+	test("reload prints a human result line", async () => {
+		const status: DaemonStatus = {
+			kind: "telegram",
+			configured: true,
+			health: "running",
+			runtime: { mode: "source", execPath: "/usr/bin/node", reloadPicksUpSourceEdits: true },
+		};
+		const result: DaemonOperationResult = {
+			kind: "telegram",
+			action: "reload",
+			ok: true,
+			warnings: [],
+			message: "reloaded telegram daemon (owner_spawned)",
+		};
+		const out = await captureStdout(() =>
+			runDaemonCommand(
+				{ action: "reload", kinds: ["telegram"], all: false, json: false, force: false },
+				{ controllers: [fakeController(status, result)] },
+			),
+		);
+		expect(out).toContain("telegram reload: ok");
+		expect(out).toContain("reloaded telegram daemon");
+	});
+});
+
+describe("cli registration", () => {
+	test("gjc daemon is registered in the explicit command registry", () => {
+		const cliSource = fs.readFileSync(path.join(import.meta.dir, "../src/cli.ts"), "utf8");
+		expect(cliSource).toContain('{ name: "daemon"');
+		expect(cliSource).toContain('import("./commands/daemon")');
+	});
+});
+
+describe("topic registry reload persistence", () => {
+	test("load() preserves identitySent and name so reload does not resend identity", () => {
+		const registry = new TopicRegistry();
+		registry.load({
+			topics: {
+				S1: { topicId: "100", identitySent: true, name: "repo/main - title", createdAt: 1 },
+			},
+		});
+		// identitySent must survive so a reloaded daemon does not re-emit the header.
+		expect(registry.needsIdentity("S1")).toBe(false);
+		expect(registry.get("S1")?.name).toBe("repo/main - title");
+		// topicId routing must also survive.
+		expect(registry.sessionForTopic("100")).toBe("S1");
+	});
+});

--- a/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
+++ b/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { daemonPaths } from "../src/notifications/telegram-daemon";
+import { buildTelegramDaemonSpawnArgs, daemonPaths } from "../src/notifications/telegram-daemon";
 
 const repoRoot = path.resolve(import.meta.dir, "../../..");
 
@@ -55,5 +55,21 @@ describe("compiled daemon smoke coverage", () => {
 	test("build script preserves the dynamic daemon entrypoint for compiled binaries", () => {
 		const buildScript = fs.readFileSync(path.join(repoRoot, "packages/coding-agent/scripts/build-binary.ts"), "utf8");
 		expect(buildScript).toContain("telegram-daemon-cli.ts");
+	});
+
+	test("compiled-mode spawn args self-spawn the binary without a script prefix and carry a reload warning", () => {
+		const { command, args, runtime } = buildTelegramDaemonSpawnArgs({
+			execPath: "/opt/gjc/gjc",
+			ownerId: "owner-1",
+			agentDir: "/tmp/agent",
+		});
+		expect(command).toBe("/opt/gjc/gjc");
+		// No bun/node entry-script prefix in compiled mode: the binary self-spawns its subcommand.
+		expect(args[0]).toBe("notify");
+		expect(args).toContain("daemon-internal");
+		expect(args).toEqual(expect.arrayContaining(["--owner-id", "owner-1", "--agent-dir", "/tmp/agent"]));
+		expect(runtime.mode).toBe("compiled");
+		expect(runtime.reloadPicksUpSourceEdits).toBe(false);
+		expect(runtime.warning).toContain("Rebuild");
 	});
 });

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -1128,3 +1128,228 @@ describe("telegram daemon reconnect answer routing", () => {
 		expect(replyFrame).toEqual({ type: "reply", id: "ask1", answer: 0, token: "ts" });
 	});
 });
+
+test("pollOnce resolves to 0 when the in-flight getUpdates is aborted", async () => {
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const bot = {
+		call: (_method: string, _body: unknown, opts?: { signal?: AbortSignal }) =>
+			new Promise((_resolve, reject) => {
+				opts?.signal?.addEventListener("abort", () =>
+					reject(Object.assign(new Error("The operation was aborted"), { name: "AbortError" })),
+				);
+			}),
+	};
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const ac = new AbortController();
+	const pending = daemon.pollOnce(ac.signal);
+	ac.abort();
+	expect(await pending).toBe(0);
+});
+
+test("pollOnce backs off on a Telegram 409 conflict instead of processing updates", async () => {
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	let slept = 0;
+	const bot = {
+		call: async () => ({
+			ok: false,
+			error_code: 409,
+			description: "Conflict: terminated by other getUpdates request",
+		}),
+	};
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		setTimeoutImpl: ((cb: () => void) => {
+			slept++;
+			cb();
+			return 0;
+		}) as any,
+	});
+	expect(await daemon.pollOnce()).toBe(0);
+	expect(slept).toBe(1);
+});
+
+test("requestStop aborts the active long poll and run() exits, releasing ownership", async () => {
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	await acquireDaemonOwnership({
+		settings: s,
+		tokenFingerprint: "e60b05c186ca",
+		chatId: "42",
+		pid: process.pid,
+		randomId: () => "owner",
+	});
+	const bot = {
+		call: (method: string, _body: unknown, opts?: { signal?: AbortSignal }) => {
+			if (method === "getUpdates") {
+				return new Promise((_resolve, reject) => {
+					opts?.signal?.addEventListener("abort", () =>
+						reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
+					);
+				});
+			}
+			return Promise.resolve({ ok: true, result: true });
+		},
+	};
+	class NoScan extends TelegramNotificationDaemon {
+		override async scanRoots(): Promise<void> {}
+	}
+	const daemon = new NoScan({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+		setTimeoutImpl: ((cb: () => void) => {
+			cb();
+			return 0;
+		}) as any,
+	});
+	daemon.connectSession("S", "ws://s", "t");
+	const runPromise = daemon.run();
+	await new Promise(resolve => setTimeout(resolve, 5));
+	daemon.requestStop("signal");
+	await runPromise;
+	expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(false);
+});
+
+test("run() loop exits when an owner-scoped control request asks it to stop", async () => {
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	await acquireDaemonOwnership({
+		settings: s,
+		tokenFingerprint: "e60b05c186ca",
+		chatId: "42",
+		pid: process.pid,
+		randomId: () => "owner",
+	});
+	let cleared = false;
+	class NoScan extends TelegramNotificationDaemon {
+		override async scanRoots(): Promise<void> {}
+	}
+	const daemon = new NoScan({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: new FakeBotApi(),
+		control: {
+			shouldStop: async owner => owner === "owner",
+			clear: async () => {
+				cleared = true;
+			},
+		},
+		setTimeoutImpl: ((cb: () => void) => {
+			cb();
+			return 0;
+		}) as any,
+	});
+	await daemon.run();
+	expect(cleared).toBe(true);
+	expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(false);
+});
+
+test("run() persists aliases before releasing ownership on exit", async () => {
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	await acquireDaemonOwnership({
+		settings: s,
+		tokenFingerprint: "e60b05c186ca",
+		chatId: "42",
+		pid: process.pid,
+		randomId: () => "owner",
+	});
+	let now = 0;
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: new FakeBotApi(),
+		idleTimeoutMs: 10,
+		now: () => (now += 11),
+		setTimeoutImpl: ((cb: () => void) => {
+			cb();
+			return 0;
+		}) as any,
+	});
+	daemon.aliasTable.put({ sessionId: "S", actionId: "ask", answer: 0 });
+	await daemon.run();
+	expect(fs.existsSync(daemonPaths(agentDir).aliases)).toBe(true);
+});
+
+test("a fresh daemon scanRoots reconnects an existing session endpoint", async () => {
+	FakeWs.instances = [];
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const cwd = path.join(agentDir, "repo");
+	await registerNotificationRoot({ settings: s, cwd, sessionId: "live-session" });
+	const endpointDir = path.join(cwd, ".gjc", "state", "notifications");
+	fs.mkdirSync(endpointDir, { recursive: true });
+	fs.writeFileSync(path.join(endpointDir, "live-session.json"), JSON.stringify({ url: "ws://live", token: "tok" }));
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: new FakeBotApi(),
+		WebSocketImpl: FakeWs as any,
+	});
+	await daemon.scanRoots();
+	expect(daemon.sessions.has("live-session")).toBe(true);
+	expect(FakeWs.instances.some(ws => ws.url.startsWith("ws://live"))).toBe(true);
+});
+
+test("runDaemonInternal wires SIGTERM to the daemon stop method", async () => {
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	let stopped = false;
+	let resolveRun: (() => void) | undefined;
+	class StubDaemon {
+		constructor(public opts: unknown) {}
+		requestStop(): void {
+			stopped = true;
+			resolveRun?.();
+		}
+		run(): Promise<void> {
+			return new Promise<void>(resolve => {
+				resolveRun = resolve;
+			});
+		}
+	}
+	const originalOnce = process.once.bind(process);
+	const originalOff = process.off.bind(process);
+	let sigtermHandler: (() => void) | undefined;
+	(process as any).once = (event: string, handler: () => void) => {
+		if (event === "SIGTERM") sigtermHandler = handler;
+		// Do not register real signal handlers in-process; just capture them.
+		return process;
+	};
+	(process as any).off = () => process;
+	try {
+		const runPromise = runDaemonInternal(["--agent-dir", agentDir, "--owner-id", "owner"], {
+			SettingsImpl: { init: async () => s },
+			DaemonImpl: StubDaemon as any,
+		});
+		await new Promise(resolve => setTimeout(resolve, 5));
+		expect(sigtermHandler).toBeTruthy();
+		sigtermHandler?.();
+		await runPromise;
+		expect(stopped).toBe(true);
+	} finally {
+		(process as any).once = originalOnce;
+		(process as any).off = originalOff;
+	}
+});


### PR DESCRIPTION
## Summary
Adds a generic `gjc daemon list|status|stop|reload` command backed by a static built-in controller map (Telegram is the only kind today). `reload` completely replaces the detached Telegram daemon so amended source takes effect, **without orphaning live sessions** — the per-session NotificationServer, endpoint-discovery files, and roots persist, and a fresh daemon's `scanRoots` reconnects automatically.

## Design (consensus-planned via ralplan, executed via ultragoal)
Reload is a hybrid cooperative design:
- An **owner-scoped control-request file** records auditable intent.
- **SIGTERM** (wired in `runDaemonInternal`, not the daemon class) aborts the in-flight 25s `getUpdates` long poll via an `AbortSignal`.
- A fresh poller spawns **only after the captured old pid is confirmed dead** — `SIGKILL` is gated behind `--force` with an ownerId/pid recheck. This preserves the single-poller invariant and avoids Telegram `getUpdates` 409 conflicts.
- Persisted aliases/topics survive reload (`TopicRegistry.load` restores `identitySent`/`name`); a shared spawn helper is reused by session autostart and reload so source/compiled detection lives in one place.

## Scope
- `daemon/control-types.ts`, `daemon/runtime.ts`, `daemon/builtin.ts` — compact types, source/compiled detection, static controller map.
- `notifications/telegram-daemon.ts` — shared spawn helper, abortable `pollOnce`, `requestStop`, 409 backoff, final alias/topic persist, registry-preserving `loadTopics`.
- `notifications/telegram-daemon-control.ts` — control-request helpers + reload/stop state machine.
- `notifications/telegram-daemon-cli.ts` — SIGTERM/SIGINT wiring + owner-scoped control hook.
- `cli/daemon-cli.ts`, `commands/daemon.ts`, `cli.ts` — command surface + explicit registry entry; clean unknown-kind error.

## Verification
- 62 tests pass across `daemon-control.test.ts` (new) and the extended `notifications-telegram-daemon.test.ts` / `notifications-compiled-daemon-smoke.test.ts`, including: no-spawn-while-old-pid-alive, stale changed-owner protection, `--force` SIGKILL, no-poll-overlap, scanRoots reattach, 409 backoff, requestStop abort, SIGTERM wiring, topic-registry restore.
- `bun run check` (biome + tsgo) clean.
- Live CLI verified: `status`/`list`/`reload` functional; unconfigured `reload` returns `ok:false` + exit 1.
- Architect review: architecture/product/code CLEAR, APPROVE.

Rebased onto `dev`.