### PR TITLE
fix(notifications): close local ask selector on remote answer; stop double-numbering Telegram buttons

### DIFF
--- a/packages/coding-agent/src/notifications/html-format.ts
+++ b/packages/coding-agent/src/notifications/html-format.ts
@@ -224,8 +224,15 @@ export function finalizeTelegramHtml(message?: string): string | undefined {
 	return truncateTelegramHtml(message);
 }
 
-/** One-based, plain-text button label (Telegram does not parse HTML in labels). */
+/**
+ * One-based, plain-text button label (Telegram does not parse HTML in labels).
+ *
+ * Idempotent: labels that already carry a leading `N.`/`N)` index (e.g.
+ * deep-interview options pre-numbered by the ask tool) are left as-is so the
+ * Telegram button does not show duplicated numbering like `1. 1. …`.
+ */
 export function buttonLabel(label: string, index: number): string {
+	if (/^\s*\d+[.)]\s+/.test(label)) return label;
 	return `${index + 1}. ${label}`;
 }
 

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -557,15 +557,36 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 				// notifications SDK) so asks can be answered without RPC mode. When the
 				// local UI wins, abort the remote source so it stops waiting and marks the
 				// action resolved-locally. First valid answer wins.
-				const controller = new AbortController();
-				// Register the remote ask FIRST so the `action_needed` frame (the Telegram
-				// inline-keyboard message) is broadcast at invocation — before the local
-				// selector opens — instead of only after the ask is finalized locally.
-				const remote = source.awaitAnswer(prompt, options, controller.signal);
-				const local = extensionUi.select(prompt, options, dialogOptions).then(answer => {
-					controller.abort();
+				// Race the local UI against a remote answer (e.g. a Telegram reply via the
+				// notifications SDK) so asks can be answered without RPC mode. First valid
+				// answer wins; the loser is aborted so neither side is left hanging:
+				//   - local wins  -> abort the remote source (marks the action resolved-locally)
+				//   - remote wins -> abort the local selector so the TUI dialog actually closes
+				const remoteController = new AbortController();
+				const localController = new AbortController();
+				// Propagate an external cancel (the tool's signal) to the local selector too.
+				const toolSignal = dialogOptions?.signal;
+				if (toolSignal) {
+					if (toolSignal.aborted) localController.abort();
+					else toolSignal.addEventListener("abort", () => localController.abort(), { once: true });
+				}
+				const remote = source.awaitAnswer(prompt, options, remoteController.signal).then(answer => {
+					// undefined is not a valid remote answer (registration failed, or the local
+					// UI already won and aborted us): never settle the race, let the local
+					// selector decide instead of cancelling the ask.
+					if (answer === undefined) return new Promise<string | undefined>(() => {});
+					localController.abort();
 					return answer;
 				});
+				const local = extensionUi
+					.select(prompt, options, { ...dialogOptions, signal: localController.signal })
+					.then(answer => {
+						remoteController.abort();
+						return answer;
+					});
+				// The losing selector may reject when aborted after the race already settled;
+				// swallow that so it is not an unhandled rejection (the race result is unaffected).
+				void local.catch(() => undefined);
 				return Promise.race([local, remote]);
 			},
 			editor: (title, prefill, dialogOptions, editorOptions) => {

--- a/packages/coding-agent/test/notifications-html-format.test.ts
+++ b/packages/coding-agent/test/notifications-html-format.test.ts
@@ -92,6 +92,16 @@ describe("button grid (AC6)", () => {
 		expect(buttonLabel("No", 1)).toBe("2. No");
 	});
 
+	test("buttonLabel does not double-number labels that already carry an index", () => {
+		// Deep-interview options arrive pre-numbered (e.g. "1. Foo"); the Telegram
+		// button must not prepend another index and render "1. 1. Foo".
+		expect(buttonLabel("1. Foo", 0)).toBe("1. Foo");
+		expect(buttonLabel("2) Bar", 1)).toBe("2) Bar");
+		expect(buttonLabel("  3.  Spaced", 2)).toBe("  3.  Spaced");
+		// A leading bare number without a dot/paren is real option text, still numbered.
+		expect(buttonLabel("3 apples", 2)).toBe("3. 3 apples");
+	});
+
 	test("short options pack into rows of three; callback index stays zero-based", () => {
 		const grid = buildButtonGrid(["Yes", "No", "Maybe", "Later"], i => `cb:${i}`);
 		expect(grid).toEqual([

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -171,6 +171,37 @@ describe("AskTool cancellation", () => {
 		if (result.content[0]?.type === "text") expect(result.content[0].text).toContain("yes");
 	});
 
+	it("closes (aborts) the local selector when a remote answer wins the race", async () => {
+		const source = {
+			awaitAnswer: (_q: string, _opts: string[], _signal?: AbortSignal) => Promise.resolve("yes"),
+		};
+		const tool = new AskTool(createSession({ getAskAnswerSource: () => source } as Partial<ToolSession>));
+		let localAborted = false;
+		const context = createContext({
+			// The local selector only ends when its signal is aborted — proving the
+			// remote win actually tears the TUI dialog down instead of leaving it open.
+			select: (_prompt, _options, dialogOptions) =>
+				new Promise<string | undefined>(resolve => {
+					dialogOptions?.signal?.addEventListener("abort", () => {
+						localAborted = true;
+						resolve(undefined);
+					});
+				}),
+		});
+
+		const result = await tool.execute(
+			"call-remote-closes-local",
+			{ questions: [{ id: "confirm", question: "Proceed?", options: [{ label: "yes" }, { label: "no" }] }] },
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(localAborted).toBe(true);
+		expect(result.content[0]?.type).toBe("text");
+		if (result.content[0]?.type === "text") expect(result.content[0].text).toContain("yes");
+	});
+
 	it("defaults to no timeout when ask.timeout is unset", async () => {
 		// Regression for the surprise-auto-select report: a fresh install must let the user
 		// deliberate indefinitely. The dialog timeout is opt-in via the `ask.timeout` setting.


### PR DESCRIPTION
Two interactive-ask defects surfaced when answering via Telegram (follow-up to #988/#991/#992).

## 1. Local selector not closed on remote answer
The ask `ui.select` wrapper (`packages/coding-agent/src/tools/ask.ts`) aborted the remote source when the **local** UI won, but never aborted the **local** selector when the **remote** answer won — so after tapping an option in Telegram, the local TUI dialog stayed open.

Fix: a dedicated local `AbortController` closes the selector when the remote answer wins; the tool's own signal is forwarded to it; and a non-answer (`undefined`, e.g. failed registration or local-won abort) no longer settles the race or tears down the local UI.

## 2. Duplicated option numbering ("1. 1. …")
`buttonLabel` (`packages/coding-agent/src/notifications/html-format.ts`) always prepended a one-based index, but deep-interview options are already numbered by the ask tool — producing double numbering on Telegram buttons.

Fix: `buttonLabel` is now idempotent — labels already carrying a leading `N.`/`N)` index are left as-is.

## Tests
- `closes (aborts) the local selector when a remote answer wins the race` — fails without the abort wiring.
- `buttonLabel does not double-number labels that already carry an index` — fails without the idempotency guard.

All focused suites green (ask, html-format, sdk-ask-answer-source, notifications-telegram-daemon/reference); typecheck + biome clean.
