### PR TITLE
feat(ai): opt-in glm-zcode OAuth provider for ZCode→Z.ai/GLM

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1593,6 +1593,14 @@ export class AuthStorage {
 				});
 				break;
 			}
+			case "glm-zcode": {
+				const { loginGlmZcode } = await import("./utils/oauth/glm-zcode");
+				credentials = await loginGlmZcode({
+					...ctrl,
+					onManualCodeInput: ctrl.onManualCodeInput ?? manualCodeInput,
+				});
+				break;
+			}
 			case "fireworks": {
 				const { loginFireworks } = await import("./utils/oauth/fireworks");
 				const apiKey = await loginFireworks(ctrl);

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -109,6 +109,7 @@ Providers:
   kagi              Kagi
   tavily            Tavily
   zai               Z.AI (GLM Coding Plan)
+  glm-zcode         GLM ZCode OAuth (unofficial, opt-in; at your own risk)
   deepseek          DeepSeek
   xai               xAI
   nanogpt           NanoGPT

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -75698,6 +75698,32 @@
 			}
 		}
 	},
+	"glm-zcode": {
+		"glm-5.2": {
+			"id": "glm-5.2",
+			"name": "GLM-5.2 (ZCode)",
+			"api": "anthropic-messages",
+			"provider": "glm-zcode",
+			"baseUrl": "https://api.z.ai/api/anthropic",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		}
+	},
 	"zenmux": {
 		"anthropic/claude-3.5-haiku": {
 			"id": "anthropic/claude-3.5-haiku",

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -43,7 +43,7 @@ import {
 	xiaomiModelManagerOptions,
 	zenmuxModelManagerOptions,
 } from "./openai-compat";
-import { cursorModelManagerOptions, zaiModelManagerOptions } from "./special";
+import { cursorModelManagerOptions, glmZcodeModelManagerOptions, zaiModelManagerOptions } from "./special";
 
 /** Catalog discovery configuration for providers that support endpoint-based model listing. */
 export interface CatalogDiscoveryConfig {
@@ -299,6 +299,12 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		catalog("ZenMux", ["ZENMUX_API_KEY"]),
 	),
 	catalogDescriptor("zai", "glm-5.2", config => zaiModelManagerOptions(config), catalog("zAI", ["ZAI_API_KEY"])),
+	catalogDescriptor(
+		"glm-zcode",
+		"glm-5.2",
+		config => glmZcodeModelManagerOptions(config),
+		catalog("GLM ZCode (unofficial)", ["GLM_ZCODE_API_KEY"], { oauthProvider: "glm-zcode" }),
+	),
 	descriptor("github-copilot", "gpt-4o", config => githubCopilotModelManagerOptions(config)),
 	descriptor("google", "gemini-2.5-pro", config => googleModelManagerOptions(config)),
 	catalogDescriptor(

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -2278,6 +2278,12 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CORE: readonly ModelsDevProviderDescriptor
 const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDescriptor[] = [
 	// --- zAI ---
 	anthropicMessagesDescriptor("zai-coding-plan", "zai", "https://api.z.ai/api/anthropic"),
+	// --- GLM ZCode (unofficial Z.AI OAuth) ---
+	anthropicMessagesDescriptor(
+		"glm-zcode-coding-plan",
+		"glm-zcode",
+		process.env.ZCODE_PLAN_ANTHROPIC_BASE_URL ?? "https://api.z.ai/api/anthropic",
+	),
 	// --- Xiaomi ---
 	openAiCompletionsDescriptor("xiaomi", "xiaomi", "https://api.xiaomimimo.com/v1", {
 		defaultContextWindow: 262144,

--- a/packages/ai/src/provider-models/special.ts
+++ b/packages/ai/src/provider-models/special.ts
@@ -65,3 +65,15 @@ export interface ZaiModelManagerConfig {}
 export function zaiModelManagerOptions(_config: ZaiModelManagerConfig = {}): ModelManagerOptions<"anthropic-messages"> {
 	return { providerId: "zai" };
 }
+
+// ---------------------------------------------------------------------------
+// GLM ZCode (unofficial Z.AI OAuth)
+// ---------------------------------------------------------------------------
+
+export interface GlmZcodeModelManagerConfig {}
+
+export function glmZcodeModelManagerOptions(
+	_config: GlmZcodeModelManagerConfig = {},
+): ModelManagerOptions<"anthropic-messages"> {
+	return { providerId: "glm-zcode" };
+}

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2169,7 +2169,7 @@ function buildParams(
  * See: https://github.com/can1357/gajae-code/issues/814
  */
 function isZaiAnthropicEndpoint(model: Model<"anthropic-messages">): boolean {
-	if (model.provider === "zai") return true;
+	if (model.provider === "zai" || model.provider === "glm-zcode") return true;
 	const baseUrl = model.baseUrl;
 	if (!baseUrl) return false;
 	try {
@@ -2187,7 +2187,7 @@ function isZaiAnthropicEndpoint(model: Model<"anthropic-messages">): boolean {
  */
 function isNonSigningAnthropicEndpoint(model: Model<"anthropic-messages">): boolean {
 	// Known non-signing providers
-	if (model.provider === "zai" || model.provider === "deepseek") return true;
+	if (model.provider === "zai" || model.provider === "glm-zcode" || model.provider === "deepseek") return true;
 	const baseUrl = model.baseUrl;
 	if (!baseUrl) return false;
 	try {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -88,6 +88,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	kilo: "KILO_API_KEY",
 	"vercel-ai-gateway": "AI_GATEWAY_API_KEY",
 	zai: "ZAI_API_KEY",
+	"glm-zcode": "GLM_ZCODE_API_KEY",
 	mistral: "MISTRAL_API_KEY",
 	minimax: "MINIMAX_API_KEY",
 	"minimax-code": "MINIMAX_CODE_API_KEY",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -122,6 +122,7 @@ export type KnownProvider =
 	| "kilo"
 	| "vercel-ai-gateway"
 	| "zai"
+	| "glm-zcode"
 	| "mistral"
 	| "minimax"
 	| "opencode-go"

--- a/packages/ai/src/utils/oauth/glm-zcode.ts
+++ b/packages/ai/src/utils/oauth/glm-zcode.ts
@@ -1,0 +1,354 @@
+/**
+ * GLM ZCode OAuth flow (UNOFFICIAL, opt-in).
+ *
+ * Replicates the reverse-engineered ZCode desktop-app login to Z.AI/GLM. This
+ * is NOT an official Z.AI OAuth client: it reuses ZCode's authorize page,
+ * broker, and a custom-protocol redirect. It may break at any time and may
+ * violate ZCode/Z.AI Terms of Service. Endpoints and the client id are
+ * overridable via `ZCODE_OAUTH_*` environment variables.
+ *
+ * Triple-hop token exchange:
+ *   1. Authorize:  GET  {authorize}?redirect_uri=zcode://oauth/callback&response_type=code&client_id=...&state=...
+ *                  (custom-protocol redirect → a CLI cannot catch it, so the user pastes the code/redirect URL)
+ *   2. Broker:     POST {broker}        { provider: "zai", code, redirect_uri, state }
+ *                       → { data: { token: <zcode JWT>, zai: { access_token: <upstream Z.AI token> } } }
+ *   3. Business:   POST {zai z/login}   { token: <upstream Z.AI token> }
+ *                       → { data: { access_token: <business token>, expires_in } }
+ *
+ * Credential mapping:
+ *   - `access`  = business token (sent to GLM /v1/messages as `Authorization: Bearer`)
+ *   - `refresh` = the plain upstream Z.AI access token (re-run z/login to re-mint `access`)
+ * The ZCode JWT is used only transiently for identity decode at login; it is never stored.
+ *
+ * The business token reaches the Anthropic-messages request as a plain bearer
+ * automatically (the GLM base URL is not api.anthropic.com). This provider must
+ * NEVER force `isOAuth=true`, which would route GLM into the Claude-Code OAuth
+ * header branch (claude-cli UA, `claude_` tool prefixes, Claude system prompt).
+ */
+import { OAuthCallbackFlow, type OAuthCallbackFlowOptions, parseCallbackInput } from "./callback-server";
+import type { OAuthController, OAuthCredentials } from "./types";
+
+const TOKEN_REQUEST_TIMEOUT_MS = 30_000;
+export const GLM_ZCODE_REFRESH_SKEW_MS = 2 * 60 * 1000;
+
+/** Default endpoints / client id. Override via the matching `ZCODE_OAUTH_*` env vars. */
+export const GLM_ZCODE_OAUTH_AUTHORIZE_URL = "https://chat.z.ai/api/oauth/authorize";
+export const GLM_ZCODE_OAUTH_CLIENT_ID = "client_P8X5CMWmlaRO9gyO-KSqtg";
+export const GLM_ZCODE_OAUTH_REDIRECT_URI = "zcode://oauth/callback";
+export const GLM_ZCODE_OAUTH_BROKER_TOKEN_URL = "https://zcode.z.ai/api/v1/oauth/token";
+export const GLM_ZCODE_ZAI_LOGIN_URL = "https://api.z.ai/api/auth/z/login";
+export const GLM_ZCODE_USERINFO_URL = "https://chat.z.ai/api/oauth/userinfo";
+
+type FetchImpl = typeof globalThis.fetch;
+
+function envOr(name: string, fallback: string): string {
+	const value = process.env[name];
+	return value && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+function resolveAuthorizeUrl(): string {
+	return envOr("ZCODE_OAUTH_AUTHORIZE_URL", GLM_ZCODE_OAUTH_AUTHORIZE_URL);
+}
+function resolveClientId(): string {
+	return envOr("ZCODE_OAUTH_CLIENT_ID", GLM_ZCODE_OAUTH_CLIENT_ID);
+}
+function resolveRedirectUri(): string {
+	return envOr("ZCODE_OAUTH_REDIRECT_URI", GLM_ZCODE_OAUTH_REDIRECT_URI);
+}
+function resolveBrokerTokenUrl(): string {
+	return envOr("ZCODE_OAUTH_BROKER_TOKEN_URL", GLM_ZCODE_OAUTH_BROKER_TOKEN_URL);
+}
+function resolveZaiLoginUrl(): string {
+	return envOr("ZCODE_OAUTH_ZAI_LOGIN_URL", GLM_ZCODE_ZAI_LOGIN_URL);
+}
+function resolveUserinfoUrl(): string {
+	return envOr("ZCODE_OAUTH_USERINFO_URL", GLM_ZCODE_USERINFO_URL);
+}
+
+/**
+ * The provider is configured whenever a client id is available. The real ZCode
+ * client id ships as the default, so this is true unless explicitly cleared.
+ */
+export function isGlmZcodeOAuthConfigured(): boolean {
+	return resolveClientId().length > 0;
+}
+
+/** Mask token-like substrings so broker/upstream/business tokens never leak into errors or logs. */
+function redactSecrets(text: string): string {
+	return text
+		.replace(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, "[redacted-jwt]")
+		.replace(/[A-Za-z0-9_-]{40,}/g, "[redacted]");
+}
+
+function validateHttpsEndpoint(rawUrl: string, label: string): string {
+	let parsed: URL;
+	try {
+		parsed = new URL(rawUrl);
+	} catch {
+		throw new Error(`GLM ZCode ${label} endpoint is not a valid URL`);
+	}
+	if (parsed.protocol !== "https:") {
+		throw new Error(`GLM ZCode ${label} endpoint must use https`);
+	}
+	return parsed.toString();
+}
+
+function requestSignal(signal: AbortSignal | undefined): AbortSignal {
+	const timeoutSignal = AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS);
+	return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+async function postJson(
+	fetchImpl: FetchImpl,
+	url: string,
+	body: Record<string, unknown>,
+	label: string,
+	signal: AbortSignal | undefined,
+): Promise<unknown> {
+	const response = await fetchImpl(url, {
+		method: "POST",
+		headers: { Accept: "application/json", "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+		signal: requestSignal(signal),
+	});
+	if (!response.ok) {
+		throw new Error(`GLM ZCode ${label} request failed: ${response.status} ${redactSecrets(await response.text())}`);
+	}
+	return response.json();
+}
+
+interface JwtPayload {
+	sub?: unknown;
+	email?: unknown;
+	account_id?: unknown;
+	uid?: unknown;
+	[key: string]: unknown;
+}
+
+function decodeJwtPayload(token: string): JwtPayload | undefined {
+	const parts = token.split(".");
+	const payload = parts[1];
+	if (parts.length !== 3 || !payload) return undefined;
+	try {
+		return JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as JwtPayload;
+	} catch {
+		return undefined;
+	}
+}
+
+interface Identity {
+	email?: string;
+	accountId?: string;
+}
+
+function identityFromJwts(tokens: readonly string[]): Identity {
+	for (const token of tokens) {
+		const payload = decodeJwtPayload(token);
+		if (!payload) continue;
+		const accountId =
+			(typeof payload.sub === "string" && payload.sub) ||
+			(typeof payload.account_id === "string" && payload.account_id) ||
+			(typeof payload.uid === "string" && payload.uid) ||
+			undefined;
+		const email =
+			typeof payload.email === "string" && payload.email.length > 0 ? payload.email.toLowerCase() : undefined;
+		if (accountId || email) {
+			return { accountId: accountId || undefined, email };
+		}
+	}
+	return {};
+}
+
+async function resolveIdentity(
+	fetchImpl: FetchImpl,
+	upstreamZaiAccess: string,
+	jwtCandidates: readonly string[],
+	signal: AbortSignal | undefined,
+): Promise<Identity> {
+	// Best-effort userinfo; never fail login if identity lookup fails.
+	try {
+		const userinfoUrl = validateHttpsEndpoint(resolveUserinfoUrl(), "userinfo");
+		const response = await fetchImpl(userinfoUrl, {
+			headers: { Accept: "application/json", Authorization: `Bearer ${upstreamZaiAccess}` },
+			signal: requestSignal(signal),
+		});
+		if (response.ok) {
+			const payload = (await response.json()) as unknown;
+			const data = isRecord(payload) && isRecord(payload.data) ? payload.data : isRecord(payload) ? payload : {};
+			const email = typeof data.email === "string" && data.email.length > 0 ? data.email.toLowerCase() : undefined;
+			const accountId =
+				(typeof data.id === "string" && data.id) ||
+				(typeof data.account_id === "string" && data.account_id) ||
+				(typeof data.sub === "string" && data.sub) ||
+				undefined;
+			if (email || accountId) {
+				return { email, accountId: accountId || undefined };
+			}
+		}
+	} catch {
+		// fall through to JWT decode
+	}
+	return identityFromJwts(jwtCandidates);
+}
+
+function parseBrokerResponse(payload: unknown): { zcodeToken: string; upstreamZaiAccess: string } {
+	const data = isRecord(payload) && isRecord(payload.data) ? payload.data : undefined;
+	const zcodeToken = data && typeof data.token === "string" ? data.token : undefined;
+	const zai = data && isRecord(data.zai) ? data.zai : undefined;
+	const upstreamZaiAccess = zai && typeof zai.access_token === "string" ? zai.access_token : undefined;
+	if (!zcodeToken || !upstreamZaiAccess) {
+		throw new Error("GLM ZCode broker response missing data.token or data.zai.access_token");
+	}
+	return { zcodeToken, upstreamZaiAccess };
+}
+
+interface BusinessToken {
+	access: string;
+	expiresIn: number;
+}
+
+async function resolveBusinessToken(
+	fetchImpl: FetchImpl,
+	upstreamZaiAccess: string,
+	signal: AbortSignal | undefined,
+): Promise<BusinessToken> {
+	const zaiLoginUrl = validateHttpsEndpoint(resolveZaiLoginUrl(), "z/login");
+	const payload = await postJson(fetchImpl, zaiLoginUrl, { token: upstreamZaiAccess }, "z/login", signal);
+	const data = isRecord(payload) && isRecord(payload.data) ? payload.data : undefined;
+	const access = data && typeof data.access_token === "string" ? data.access_token : undefined;
+	if (!access) {
+		throw new Error("GLM ZCode z/login response missing data.access_token");
+	}
+	const expiresIn =
+		data && typeof data.expires_in === "number" && Number.isFinite(data.expires_in) ? data.expires_in : 3600;
+	return { access, expiresIn };
+}
+
+function credentialsFromBusiness(
+	business: BusinessToken,
+	upstreamZaiAccess: string,
+	identity: Identity,
+): OAuthCredentials {
+	return {
+		refresh: upstreamZaiAccess,
+		access: business.access,
+		expires: Date.now() + business.expiresIn * 1000 - GLM_ZCODE_REFRESH_SKEW_MS,
+		email: identity.email,
+		accountId: identity.accountId,
+	};
+}
+
+async function exchangeGlmZcodeCode(
+	fetchImpl: FetchImpl,
+	input: { code: string; state: string; redirectUri: string },
+	signal: AbortSignal | undefined,
+): Promise<OAuthCredentials> {
+	// Defensive: a pasted value may still be a full redirect URL or `code#state`.
+	const parsed = parseCallbackInput(input.code);
+	const code = parsed.code ?? input.code;
+	const brokerUrl = validateHttpsEndpoint(resolveBrokerTokenUrl(), "broker");
+	const brokerPayload = await postJson(
+		fetchImpl,
+		brokerUrl,
+		{ provider: "zai", code, redirect_uri: input.redirectUri, state: input.state },
+		"broker",
+		signal,
+	);
+	const { zcodeToken, upstreamZaiAccess } = parseBrokerResponse(brokerPayload);
+	const business = await resolveBusinessToken(fetchImpl, upstreamZaiAccess, signal);
+	const identity = await resolveIdentity(
+		fetchImpl,
+		upstreamZaiAccess,
+		[zcodeToken, upstreamZaiAccess, business.access],
+		signal,
+	);
+	return credentialsFromBusiness(business, upstreamZaiAccess, identity);
+}
+
+export interface GlmZcodeOAuthFlowOptions {
+	fetch?: FetchImpl;
+}
+
+export class GlmZcodeOAuthFlow extends OAuthCallbackFlow {
+	#fetch: FetchImpl;
+
+	constructor(ctrl: OAuthController, options: GlmZcodeOAuthFlowOptions = {}) {
+		super(ctrl, {
+			// Port 0 → a free random local port. The custom-protocol redirect
+			// never reaches it; login completes via manual code/redirect paste.
+			preferredPort: 0,
+			callbackPath: "/callback",
+			callbackHostname: "127.0.0.1",
+			callbackBindHostname: "127.0.0.1",
+			redirectUri: resolveRedirectUri(),
+		} satisfies OAuthCallbackFlowOptions);
+		this.#fetch = options.fetch ?? ctrl.fetch ?? globalThis.fetch;
+	}
+
+	async generateAuthUrl(state: string, redirectUri: string): Promise<{ url: string; instructions?: string }> {
+		const authorizeUrl = validateHttpsEndpoint(resolveAuthorizeUrl(), "authorize");
+		const params = new URLSearchParams({
+			redirect_uri: redirectUri,
+			response_type: "code",
+			client_id: resolveClientId(),
+			state,
+		});
+		return {
+			url: `${authorizeUrl}?${params.toString()}`,
+			instructions:
+				"Complete Z.AI login in your browser. This is an UNOFFICIAL ZCode-based login — use at your own risk; it may stop working or violate ZCode/Z.AI Terms of Service. Because this CLI cannot receive the zcode:// redirect, paste the final redirect URL or authorization code when prompted.",
+		};
+	}
+
+	async exchangeToken(code: string, state: string, redirectUri: string): Promise<OAuthCredentials> {
+		return exchangeGlmZcodeCode(this.#fetch, { code, state, redirectUri }, this.ctrl.signal);
+	}
+}
+
+export async function loginGlmZcode(
+	ctrl: OAuthController,
+	options?: GlmZcodeOAuthFlowOptions,
+): Promise<OAuthCredentials> {
+	return new GlmZcodeOAuthFlow(ctrl, options).login();
+}
+
+export interface GlmZcodeRefreshOptions {
+	signal?: AbortSignal;
+	fetch?: FetchImpl;
+}
+
+/**
+ * Re-mint the GLM business token. ZCode exposes no documented refresh endpoint,
+ * so this re-runs z/login with the stored upstream Z.AI token. If that fails the
+ * caller must re-login; expired credentials are never returned as valid.
+ */
+export async function refreshGlmZcodeToken(
+	credentials: OAuthCredentials,
+	options: AbortSignal | GlmZcodeRefreshOptions = {},
+): Promise<OAuthCredentials> {
+	const { signal, fetch: fetchImpl } =
+		options instanceof AbortSignal ? { signal: options, fetch: undefined } : options;
+	const upstreamZaiAccess = credentials.refresh;
+	if (!upstreamZaiAccess) {
+		throw new Error(
+			"glm-zcode credentials require re-login; no stored upstream Z.AI token and no documented refresh endpoint",
+		);
+	}
+	const resolvedFetch = fetchImpl ?? globalThis.fetch;
+	let business: BusinessToken;
+	try {
+		business = await resolveBusinessToken(resolvedFetch, upstreamZaiAccess, signal);
+	} catch (error) {
+		throw new Error(
+			`glm-zcode credentials require re-login; re-minting via z/login failed (${redactSecrets(String(error))})`,
+		);
+	}
+	return credentialsFromBusiness(business, upstreamZaiAccess, {
+		email: credentials.email,
+		accountId: credentials.accountId,
+	});
+}

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -171,6 +171,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "glm-zcode",
+		name: "GLM ZCode OAuth (unofficial, opt-in)",
+		available: true,
+	},
+	{
 		id: "minimax-code",
 		name: "MiniMax Coding Plan (International)",
 		available: true,
@@ -333,6 +338,11 @@ export async function refreshOAuthToken(
 		case "xai": {
 			const { refreshXaiToken } = await import("./xai");
 			newCredentials = await refreshXaiToken(credentials.refresh);
+			break;
+		}
+		case "glm-zcode": {
+			const { refreshGlmZcodeToken } = await import("./glm-zcode");
+			newCredentials = await refreshGlmZcodeToken(credentials);
 			break;
 		}
 		case "kilo":

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -49,6 +49,7 @@ export type OAuthProvider =
 	| "vercel-ai-gateway"
 	| "vllm"
 	| "xai"
+	| "glm-zcode"
 	| "xiaomi"
 	| "xiaomi-token-plan-sgp"
 	| "xiaomi-token-plan-ams"

--- a/packages/ai/test/oauth-glm-zcode.test.ts
+++ b/packages/ai/test/oauth-glm-zcode.test.ts
@@ -1,0 +1,365 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { AuthStorage, SqliteAuthCredentialStore } from "../src/auth-storage";
+import { getBundledModel } from "../src/models";
+import { buildAnthropicHeaders } from "../src/providers/anthropic";
+import { isOAuthToken } from "../src/utils/anthropic-auth";
+import { getOAuthProviders, refreshOAuthToken } from "../src/utils/oauth";
+import {
+	GLM_ZCODE_OAUTH_AUTHORIZE_URL,
+	GLM_ZCODE_OAUTH_BROKER_TOKEN_URL,
+	GLM_ZCODE_OAUTH_CLIENT_ID,
+	GLM_ZCODE_OAUTH_REDIRECT_URI,
+	GLM_ZCODE_ZAI_LOGIN_URL,
+	GlmZcodeOAuthFlow,
+	isGlmZcodeOAuthConfigured,
+	refreshGlmZcodeToken,
+} from "../src/utils/oauth/glm-zcode";
+import type { OAuthCredentials } from "../src/utils/oauth/types";
+import { withEnv } from "./helpers";
+
+const originalFetch = global.fetch;
+const USERINFO_URL = "https://chat.z.ai/api/oauth/userinfo";
+const SUPPRESS_ENV = {
+	GLM_ZCODE_API_KEY: undefined,
+	ZAI_API_KEY: undefined,
+	ZCODE_OAUTH_CLIENT_ID: undefined,
+} as const;
+
+const UPSTREAM_ZAI_TOKEN = "upstream-zai-access-token-value-1234567890";
+const ZCODE_JWT = jwt({ sub: "zcode-sub-id", email: "ZJwt@Example.com" });
+const BUSINESS_TOKEN = "business-token-value-abcdefghijklmnop-998877";
+
+function jwt(payload: Record<string, unknown>): string {
+	const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+	return `${encode({ alg: "none", typ: "JWT" })}.${encode(payload)}.`;
+}
+
+interface MockOptions {
+	expiresIn?: number;
+	businessToken?: string;
+	userinfo?: { email?: string; id?: string } | null;
+	captureBroker?: (body: string) => void;
+	captureZLogin?: (body: string) => void;
+	zLoginStatus?: number;
+	zLoginErrorBody?: string;
+	brokerPayloadOverride?: unknown;
+}
+
+function routingFetch(options: MockOptions = {}) {
+	return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+		if (url === GLM_ZCODE_OAUTH_BROKER_TOKEN_URL) {
+			options.captureBroker?.(String(init?.body ?? ""));
+			return new Response(
+				JSON.stringify(
+					options.brokerPayloadOverride ?? {
+						data: { token: ZCODE_JWT, zai: { access_token: UPSTREAM_ZAI_TOKEN } },
+					},
+				),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		}
+		if (url === GLM_ZCODE_ZAI_LOGIN_URL) {
+			options.captureZLogin?.(String(init?.body ?? ""));
+			if (options.zLoginStatus && options.zLoginStatus >= 400) {
+				return new Response(options.zLoginErrorBody ?? "rejected", { status: options.zLoginStatus });
+			}
+			return new Response(
+				JSON.stringify({
+					data: { access_token: options.businessToken ?? BUSINESS_TOKEN, expires_in: options.expiresIn ?? 3600 },
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		}
+		if (url === USERINFO_URL) {
+			if (options.userinfo === null) return new Response("no", { status: 404 });
+			const data = options.userinfo ?? { email: "Member@Example.com", id: "account-xyz" };
+			return new Response(JSON.stringify({ data }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		}
+		throw new Error(`Unexpected fetch: ${url}`);
+	});
+}
+
+describe("GLM ZCode OAuth login provider", () => {
+	let tempDir = "";
+	let store: SqliteAuthCredentialStore | undefined;
+	let authStorage: AuthStorage | undefined;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-glm-zcode-oauth-"));
+		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		authStorage = new AuthStorage(store);
+	});
+
+	afterEach(async () => {
+		global.fetch = originalFetch;
+		vi.restoreAllMocks();
+		store?.close();
+		store = undefined;
+		authStorage = undefined;
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	it("registers glm-zcode as an available, opt-in-labeled login provider", () => {
+		const provider = getOAuthProviders().find(p => p.id === "glm-zcode");
+		expect(provider).toEqual({
+			id: "glm-zcode",
+			name: "GLM ZCode OAuth (unofficial, opt-in)",
+			available: true,
+		});
+		expect(isGlmZcodeOAuthConfigured()).toBe(true);
+	});
+
+	it("uses the exact ZCode client id and custom-protocol redirect by default", () => {
+		expect(GLM_ZCODE_OAUTH_CLIENT_ID).toBe("client_P8X5CMWmlaRO9gyO-KSqtg");
+		expect(GLM_ZCODE_OAUTH_REDIRECT_URI).toBe("zcode://oauth/callback");
+	});
+
+	it("builds the authorize URL with client id, custom redirect, response_type, and state", async () => {
+		const flow = new GlmZcodeOAuthFlow(
+			{ onAuth: () => {}, onPrompt: async () => "" },
+			{ fetch: routingFetch() as unknown as typeof fetch },
+		);
+		const { url, instructions } = await flow.generateAuthUrl("state-123", GLM_ZCODE_OAUTH_REDIRECT_URI);
+		const authUrl = new URL(url);
+		expect(authUrl.origin + authUrl.pathname).toBe(GLM_ZCODE_OAUTH_AUTHORIZE_URL);
+		expect(authUrl.searchParams.get("client_id")).toBe(GLM_ZCODE_OAUTH_CLIENT_ID);
+		expect(authUrl.searchParams.get("redirect_uri")).toBe(GLM_ZCODE_OAUTH_REDIRECT_URI);
+		expect(authUrl.searchParams.get("response_type")).toBe("code");
+		expect(authUrl.searchParams.get("state")).toBe("state-123");
+		expect(instructions ?? "").toMatch(/unofficial/i);
+	});
+
+	it("runs the broker exchange then z/login and maps tokens correctly", async () => {
+		let brokerBody = "";
+		let zLoginBody = "";
+		const fetchMock = routingFetch({
+			captureBroker: body => {
+				brokerBody = body;
+			},
+			captureZLogin: body => {
+				zLoginBody = body;
+			},
+		});
+		const flow = new GlmZcodeOAuthFlow(
+			{ onAuth: () => {}, onPrompt: async () => "" },
+			{ fetch: fetchMock as unknown as typeof fetch },
+		);
+		const credentials = await flow.exchangeToken("auth-code", "state-123", GLM_ZCODE_OAUTH_REDIRECT_URI);
+
+		expect(JSON.parse(brokerBody)).toEqual({
+			provider: "zai",
+			code: "auth-code",
+			redirect_uri: GLM_ZCODE_OAUTH_REDIRECT_URI,
+			state: "state-123",
+		});
+		expect(JSON.parse(zLoginBody)).toEqual({ token: UPSTREAM_ZAI_TOKEN });
+
+		// access = business token; refresh = plain upstream Z.AI token (NOT JSON, NOT the ZCode JWT).
+		expect(credentials.access).toBe(BUSINESS_TOKEN);
+		expect(credentials.refresh).toBe(UPSTREAM_ZAI_TOKEN);
+		expect(() => JSON.parse(credentials.refresh)).toThrow();
+		expect(credentials.refresh).not.toBe(ZCODE_JWT);
+		expect(credentials.email).toBe("member@example.com");
+		expect(credentials.accountId).toBe("account-xyz");
+		expect(credentials.expires).toBeGreaterThan(Date.now());
+		// 2-minute refresh skew applied.
+		expect(credentials.expires).toBeLessThanOrEqual(Date.now() + 3600 * 1000 - 60_000);
+	});
+
+	it("accepts a pasted full zcode:// redirect URL as the code", async () => {
+		const fetchMock = routingFetch();
+		const flow = new GlmZcodeOAuthFlow(
+			{ onAuth: () => {}, onPrompt: async () => "" },
+			{ fetch: fetchMock as unknown as typeof fetch },
+		);
+		const credentials = await flow.exchangeToken(
+			"zcode://oauth/callback?code=pasted-code&state=state-123",
+			"state-123",
+			GLM_ZCODE_OAUTH_REDIRECT_URI,
+		);
+		expect(credentials.access).toBe(BUSINESS_TOKEN);
+		const brokerCall = fetchMock.mock.calls.find(c => String(c[0]) === GLM_ZCODE_OAUTH_BROKER_TOKEN_URL);
+		expect(JSON.parse(String((brokerCall?.[1] as RequestInit).body)).code).toBe("pasted-code");
+	});
+
+	it("falls back to JWT identity decode when userinfo fails", async () => {
+		const fetchMock = routingFetch({ userinfo: null });
+		const flow = new GlmZcodeOAuthFlow(
+			{ onAuth: () => {}, onPrompt: async () => "" },
+			{ fetch: fetchMock as unknown as typeof fetch },
+		);
+		const credentials = await flow.exchangeToken("auth-code", "state-123", GLM_ZCODE_OAUTH_REDIRECT_URI);
+		expect(credentials.email).toBe("zjwt@example.com");
+		expect(credentials.accountId).toBe("zcode-sub-id");
+	});
+
+	it("re-mints the business token on refresh via z/login using the stored upstream token", async () => {
+		let zLoginBody = "";
+		const fetchMock = routingFetch({
+			businessToken: "business-token-rotated-zzz-2222222222",
+			captureZLogin: body => {
+				zLoginBody = body;
+			},
+		});
+		const credentials: OAuthCredentials = {
+			access: "business-old",
+			refresh: UPSTREAM_ZAI_TOKEN,
+			expires: Date.now() - 60_000,
+			email: "member@example.com",
+			accountId: "account-xyz",
+		};
+		const refreshed = await refreshGlmZcodeToken(credentials, { fetch: fetchMock as unknown as typeof fetch });
+		expect(JSON.parse(zLoginBody)).toEqual({ token: UPSTREAM_ZAI_TOKEN });
+		expect(refreshed.access).toBe("business-token-rotated-zzz-2222222222");
+		expect(refreshed.refresh).toBe(UPSTREAM_ZAI_TOKEN);
+		expect(refreshed.email).toBe("member@example.com");
+		expect(refreshed.expires).toBeGreaterThan(Date.now());
+	});
+
+	it("dispatches refreshOAuthToken('glm-zcode') to the z/login re-mint path", async () => {
+		const fetchMock = routingFetch({ businessToken: "business-via-dispatch-7777777777777" });
+		global.fetch = fetchMock as unknown as typeof fetch;
+		const refreshed = await refreshOAuthToken("glm-zcode", {
+			access: "business-old",
+			refresh: UPSTREAM_ZAI_TOKEN,
+			expires: Date.now() - 60_000,
+		});
+		expect(refreshed.access).toBe("business-via-dispatch-7777777777777");
+		expect(refreshed.refresh).toBe(UPSTREAM_ZAI_TOKEN);
+	});
+
+	it("fails with a sanitized re-login error when refresh has no upstream token", async () => {
+		await expect(refreshGlmZcodeToken({ access: "business", refresh: "", expires: Date.now() - 1 })).rejects.toThrow(
+			/require re-login/i,
+		);
+	});
+
+	it("fails with a re-login error (no expired credential returned) when z/login rejects", async () => {
+		const fetchMock = routingFetch({ zLoginStatus: 401 });
+		await expect(
+			refreshGlmZcodeToken(
+				{ access: "business-old", refresh: UPSTREAM_ZAI_TOKEN, expires: Date.now() - 1 },
+				{ fetch: fetchMock as unknown as typeof fetch },
+			),
+		).rejects.toThrow(/require re-login/i);
+	});
+
+	it("rejects a malformed broker payload missing the upstream Z.AI token", async () => {
+		const fetchMock = routingFetch({ brokerPayloadOverride: { data: { token: ZCODE_JWT } } });
+		const flow = new GlmZcodeOAuthFlow(
+			{ onAuth: () => {}, onPrompt: async () => "" },
+			{ fetch: fetchMock as unknown as typeof fetch },
+		);
+		await expect(flow.exchangeToken("auth-code", "state-123", GLM_ZCODE_OAUTH_REDIRECT_URI)).rejects.toThrow(
+			/broker response missing/i,
+		);
+	});
+
+	it("redacts token-like strings echoed in an upstream error body", async () => {
+		const leakedToken = "leaked-secret-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+		const fetchMock = routingFetch({ zLoginStatus: 500, zLoginErrorBody: `upstream said: ${leakedToken}` });
+		let caught: unknown;
+		try {
+			await refreshGlmZcodeToken(
+				{ access: "business-old", refresh: UPSTREAM_ZAI_TOKEN, expires: Date.now() - 1 },
+				{ fetch: fetchMock as unknown as typeof fetch },
+			);
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(Error);
+		const message = String(caught);
+		expect(message).toMatch(/require re-login/i);
+		expect(message).not.toContain(leakedToken);
+		expect(message).toContain("[redacted]");
+	});
+
+	it("stores glm-zcode login as OAuth and getApiKey returns the business token", async () => {
+		if (!store || !authStorage) throw new Error("test setup failed");
+		const fetchMock = routingFetch();
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		let capturedState: string | undefined;
+		await authStorage.login("glm-zcode", {
+			onAuth: info => {
+				capturedState = new URL(info.url).searchParams.get("state") ?? undefined;
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: async () => `zcode://oauth/callback?code=login-code&state=${capturedState ?? ""}`,
+		});
+
+		const credentials = store.listAuthCredentials("glm-zcode");
+		expect(credentials).toHaveLength(1);
+		expect(credentials[0]?.credential).toMatchObject({
+			type: "oauth",
+			access: BUSINESS_TOKEN,
+			refresh: UPSTREAM_ZAI_TOKEN,
+		});
+		await withEnv(SUPPRESS_ENV, async () => {
+			expect(await authStorage?.getApiKey("glm-zcode", "session-glm-zcode")).toBe(BUSINESS_TOKEN);
+		});
+	});
+
+	it("coexists with the legacy zai API-key provider without cross-contamination", async () => {
+		if (!store || !authStorage) throw new Error("test setup failed");
+		const fetchMock = routingFetch();
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		await authStorage.set("zai", { type: "api_key", key: "legacy-zai-key" });
+
+		let capturedState: string | undefined;
+		await authStorage.login("glm-zcode", {
+			onAuth: info => {
+				capturedState = new URL(info.url).searchParams.get("state") ?? undefined;
+			},
+			onPrompt: async () => "",
+			onManualCodeInput: async () => `zcode://oauth/callback?code=login-code&state=${capturedState ?? ""}`,
+		});
+
+		// Legacy zai stays an API key under its own provider.
+		const zaiCreds = store.listAuthCredentials("zai");
+		expect(zaiCreds).toHaveLength(1);
+		expect(zaiCreds[0]?.credential).toMatchObject({ type: "api_key" });
+		const glmCreds = store.listAuthCredentials("glm-zcode");
+		expect(glmCreds).toHaveLength(1);
+		expect(glmCreds[0]?.credential).toMatchObject({ type: "oauth" });
+
+		await withEnv(SUPPRESS_ENV, async () => {
+			expect(await authStorage?.getApiKey("zai", "session-zai")).toBe("legacy-zai-key");
+			expect(await authStorage?.getApiKey("glm-zcode", "session-glm")).toBe(BUSINESS_TOKEN);
+		});
+	});
+
+	it("exposes a statically bundled glm-zcode/glm-5.2 model selectable without live credentials", () => {
+		const model = getBundledModel("glm-zcode", "glm-5.2");
+		expect(model).toBeDefined();
+		expect(model.provider).toBe("glm-zcode");
+		expect(model.api).toBe("anthropic-messages");
+		expect(model.baseUrl).toBe("https://api.z.ai/api/anthropic");
+	});
+
+	it("sends Authorization: Bearer (no x-api-key, no claude-cli UA, no isOAuth) for the GLM business token", () => {
+		// GLM base is not api.anthropic.com → the non-Anthropic-base branch emits a
+		// plain bearer. isOAuth must NOT be set; the business token is not a Claude
+		// OAuth token, so no Claude-Code header/tool-prefix behavior applies.
+		expect(isOAuthToken(BUSINESS_TOKEN)).toBe(false);
+		const headers = buildAnthropicHeaders({
+			apiKey: BUSINESS_TOKEN,
+			baseUrl: "https://api.z.ai/api/anthropic",
+		});
+		expect(headers.Authorization).toBe(`Bearer ${BUSINESS_TOKEN}`);
+		expect(headers["X-Api-Key"]).toBeUndefined();
+		expect((headers["User-Agent"] ?? "").toLowerCase().startsWith("claude-cli")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
Adds a new **opt-in `glm-zcode`** OAuth login provider plus a distinct `glm-zcode` model Provider that replicates ZCode's reverse-engineered triple-hop OAuth flow to Z.ai/GLM. The legacy `zai` API-key provider is left **completely unchanged**.

Planned via ralplan consensus (Planner → Architect → Critic), executed via ultragoal with a full quality gate.

## Flow
`authorize (chat.z.ai)` → `ZCode broker (zcode.z.ai/api/v1/oauth/token)` → `business token (api.z.ai/api/auth/z/login)`. A CLI cannot receive the `zcode://` custom-protocol redirect, so login uses manual code/redirect-URL paste.

## Key design points
- **Credential mapping:** `access` = GLM business token; `refresh` = plain upstream Z.ai access token (re-run z/login to refresh). No JSON/JWT stored in `refresh` (broker-sentinel safe). ZCode JWT used only transiently for identity decode.
- **No `isOAuth=true`:** GLM's non-`api.anthropic.com` base already yields `Authorization: Bearer`. Forcing `isOAuth` would wrongly trigger the Claude-Code header / `claude_` tool-prefix / system-prompt branch — explicitly avoided and covered by a header test.
- **Exact client id** `client_P8X5CMWmlaRO9gyO-KSqtg` as default, with `ZCODE_OAUTH_*` env overrides.
- Static bundled `glm-zcode/glm-5.2` entry so the model is selectable without live credentials.

## Files
- New `packages/ai/src/utils/oauth/glm-zcode.ts` (mirrors `xai.ts`, no PKCE)
- New `packages/ai/test/oauth-glm-zcode.test.ts` (16 tests incl. failure modes)
- Wiring: OAuth/model `Provider` unions, registry + refresh dispatch, auth-storage login case, env map, `special.ts`/`descriptors.ts`/`openai-compat.ts`, `models.json`, `anthropic.ts` z.ai compat predicates, CLI help

## Verification
- `bun test packages/ai/test/oauth-glm-zcode.test.ts` → 16 pass / 0 fail
- Full `@gajae-code/ai` suite → 1504 pass / 0 fail
- `bun run check:ts` → clean (biome + all-workspace tsgo + models.json schema)
- Architect 3-lane review: CLEAR / APPROVE, 0 findings; ai-slop-cleaner: 0 blocking

## Caveat
Reuses ZCode's private OAuth client + broker — **unofficial**, may break or conflict with ZCode/Z.ai Terms of Service. Provider/login text and docs carry at-your-own-risk wording; endpoints/client id are env-overridable.