### PR TITLE
fix(notifications): strip embedded option index in Telegram button labels

### DIFF
--- a/packages/coding-agent/src/notifications/html-format.ts
+++ b/packages/coding-agent/src/notifications/html-format.ts
@@ -227,13 +227,14 @@ export function finalizeTelegramHtml(message?: string): string | undefined {
 /**
  * One-based, plain-text button label (Telegram does not parse HTML in labels).
  *
- * Idempotent: labels that already carry a leading `N.`/`N)` index (e.g.
- * deep-interview options pre-numbered by the ask tool) are left as-is so the
- * Telegram button does not show duplicated numbering like `1. 1. …`.
+ * Strips any leading `N.`/`N)` index already embedded in the label (e.g.
+ * deep-interview options pre-numbered by the ask tool) and applies the canonical
+ * one-based button index instead. This avoids duplicated numbering like
+ * `1. 1. …` and keeps the displayed number aligned with the button's real index.
  */
 export function buttonLabel(label: string, index: number): string {
-	if (/^\s*\d+[.)]\s+/.test(label)) return label;
-	return `${index + 1}. ${label}`;
+	const stripped = label.replace(/^\s*\d+[.)]\s+/, "");
+	return `${index + 1}. ${stripped}`;
 }
 
 export interface InlineButton {

--- a/packages/coding-agent/test/notifications-html-format.test.ts
+++ b/packages/coding-agent/test/notifications-html-format.test.ts
@@ -92,13 +92,16 @@ describe("button grid (AC6)", () => {
 		expect(buttonLabel("No", 1)).toBe("2. No");
 	});
 
-	test("buttonLabel does not double-number labels that already carry an index", () => {
+	test("buttonLabel strips an existing leading index and applies the canonical button number", () => {
 		// Deep-interview options arrive pre-numbered (e.g. "1. Foo"); the Telegram
-		// button must not prepend another index and render "1. 1. Foo".
+		// button must strip that and render a single, canonical one-based index
+		// instead of duplicated numbering like "1. 1. Foo".
 		expect(buttonLabel("1. Foo", 0)).toBe("1. Foo");
-		expect(buttonLabel("2) Bar", 1)).toBe("2) Bar");
-		expect(buttonLabel("  3.  Spaced", 2)).toBe("  3.  Spaced");
-		// A leading bare number without a dot/paren is real option text, still numbered.
+		expect(buttonLabel("2) Bar", 1)).toBe("2. Bar");
+		expect(buttonLabel("  3.  Spaced", 2)).toBe("3. Spaced");
+		// A stale/mismatched embedded index is replaced by the real button index.
+		expect(buttonLabel("5. Foo", 0)).toBe("1. Foo");
+		// A leading bare number without a dot/paren is real option text, kept as-is.
 		expect(buttonLabel("3 apples", 2)).toBe("3. 3 apples");
 	});
 


### PR DESCRIPTION
Follow-up to #994. Per review, the Telegram button label should **strip** an embedded option index rather than keep it.

`buttonLabel` (`packages/coding-agent/src/notifications/html-format.ts`) now removes any leading `N.`/`N)` index already present in the label (e.g. deep-interview options pre-numbered by the ask tool) and applies the canonical one-based button index. This:
- removes duplicated numbering (`1. 1. …`), and
- keeps the displayed number aligned with the button's real index even when the embedded number is stale/mismatched (`"5. Foo"` at index 0 → `"1. Foo"`).

Bare numeric option text without a `.`/`)` (e.g. `"3 apples"`) is treated as real content and kept.

Test updated to assert stripping + canonical re-numbering. html-format / telegram-daemon / telegram-reference suites green; biome clean.
