### PR TITLE
fix(notifications): free-text answers pending ask; keep ask choices unredacted on buttons

### DIFF
--- a/packages/coding-agent/src/notifications/config.ts
+++ b/packages/coding-agent/src/notifications/config.ts
@@ -84,10 +84,11 @@ export interface RedactableAction {
 
 /**
  * When redact is true, strip sensitive content for remote delivery:
- *  - ask: question -> `Session <tag> needs input: [Ask]`, options -> generic ["1","2",...] preserving COUNT/index, summary removed.
+ *  - ask: question -> `Session <tag> needs input: [Ask]`, summary removed. Option
+ *    labels are kept intact so the remote (e.g. Telegram inline-keyboard) buttons
+ *    remain answerable and readable — the choices are not the sensitive payload.
  *  - idle: summary removed, (no question/options).
  * When redact is false, return the action unchanged.
- * Index-based answers must still resolve: keep options.length identical.
  */
 export function buildRedactedAction(
 	action: RedactableAction,
@@ -95,12 +96,12 @@ export function buildRedactedAction(
 ): RedactableAction {
 	if (!opts.redact) return action;
 
-	const { summary: _summary, question: _question, options: _options, ...base } = action;
+	const { summary: _summary, question: _question, ...base } = action;
 	if (action.kind === "ask") {
 		return {
 			...base,
 			question: `Session ${opts.sessionTag} needs input: [Ask]`,
-			options: action.options?.map((_, index) => String(index + 1)),
+			options: action.options,
 		};
 	}
 

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1139,6 +1139,23 @@ export class TelegramNotificationDaemon {
 				const session = this.sessions.get(inbound.sessionId);
 				if (session?.ws.readyState === WebSocket.OPEN) {
 					const cfg = parseInThreadConfigCommand(inbound.text);
+					// A plain (non-config) message while an ask is pending for this session
+					// answers that ask as free-input — instead of starting a new user turn.
+					// Telegram asks always accept custom text (the SDK maps a string answer
+					// to the ask's custom-input slot), so route the latest pending ask here.
+					const pendingAsk = cfg ? undefined : [...session.pending.values()].at(-1);
+					if (pendingAsk) {
+						session.ws.send(
+							JSON.stringify({
+								type: "reply",
+								id: pendingAsk.actionId,
+								answer: inbound.text,
+								token: session.token,
+							}),
+						);
+						if (inbound.messageId !== undefined) await this.setReaction(inbound.messageId, QUEUED_REACTION);
+						return;
+					}
 					session.ws.send(
 						JSON.stringify(
 							cfg

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -133,7 +133,7 @@ describe("notifications config", () => {
 		expect(sessionTag("abc")).toBe("abc");
 	});
 
-	test("buildRedactedAction strips ask content but preserves option count with numeric labels", () => {
+	test("buildRedactedAction redacts ask question/summary but keeps real option labels", () => {
 		const action: RedactableAction = {
 			id: "a1",
 			kind: "ask",
@@ -148,7 +148,7 @@ describe("notifications config", () => {
 			kind: "ask",
 			sessionId: "session-abcdef",
 			question: "Session abcdef needs input: [Ask]",
-			options: ["1", "2", "3"],
+			options: ["Yes, deploy", "No, stop", "Custom"],
 		});
 	});
 

--- a/packages/coding-agent/test/notifications-e2e.test.ts
+++ b/packages/coding-agent/test/notifications-e2e.test.ts
@@ -176,7 +176,7 @@ test("interactive ask answered remotely via answer source (no RPC)", async () =>
 	srv.stop();
 }, 30000);
 
-test("redacted ask frame hides raw text and numeric answer still maps to local option", async () => {
+test("redacted ask frame hides question text but keeps answerable option labels", async () => {
 	const stateRoot = `/tmp/notif-e2e-redact-${process.pid}-${Date.now()}`;
 	const srv = new NotificationServer("redact", "tok", stateRoot, true);
 	const options = ["Ship secret alpha", "Abort secret beta"];
@@ -224,9 +224,10 @@ test("redacted ask frame hides raw text and numeric answer still maps to local o
 	);
 
 	await waitFor(() => actionFrame !== undefined, 4000, "redacted action frame");
+	// Question text is redacted...
 	expect(String(actionFrame?.question)).not.toContain("Alpha");
-	expect(JSON.stringify(actionFrame)).not.toContain("Ship secret alpha");
-	expect(actionFrame?.options).toEqual(["1", "2"]);
+	// ...but the choices are NOT redacted, so the remote buttons stay readable/answerable.
+	expect(actionFrame?.options).toEqual(options);
 	await waitFor(() => resolvedBroadcast, 3000, "redacted action resolved");
 	expect(resolvedLabel).toBe("Ship secret alpha");
 

--- a/packages/coding-agent/test/notifications-helpers.test.ts
+++ b/packages/coding-agent/test/notifications-helpers.test.ts
@@ -113,7 +113,7 @@ describe("notifications helpers", () => {
 		expect(out?.endsWith("\u2026")).toBe(true);
 	});
 
-	test("notificationActionPayload delegates redaction while preserving option count", () => {
+	test("notificationActionPayload redacts the ask question but keeps real option labels", () => {
 		const ask = notificationActionPayload(
 			{
 				id: "ask-1",
@@ -126,7 +126,7 @@ describe("notifications helpers", () => {
 		);
 
 		expect(ask.question).not.toContain("TOKEN");
-		expect(ask.options).toEqual(["1", "2"]);
+		expect(ask.options).toEqual(["Deploy prod", "Cancel"]);
 
 		const idle = notificationActionPayload(
 			{ id: "idle-1", kind: "idle", sessionId: "session-secret", summary: "sensitive summary" },

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -411,6 +411,78 @@ describe("telegram daemon", () => {
 		expect(JSON.parse(FakeWs.instances[0]!.sent[0]!)).toEqual({ type: "reply", id: "A", answer: "ok", token: "ts" });
 	});
 
+	test("plain text answers a pending ask as free-input instead of injecting a new turn", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+		});
+		daemon.connectSession("S", "ws://s", "ts");
+		// Emit an ask: creates the forum topic, registers the pending ask, sends the message.
+		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
+			type: "action_needed",
+			kind: "ask",
+			id: "ask1",
+			question: "Name it?",
+			options: ["a", "b"],
+		});
+		const askSend = bot.calls.find(c => c.method === "sendMessage");
+		const threadId = askSend!.body.message_thread_id;
+
+		// A plain free-text message in that topic answers the pending ask...
+		await daemon.handleTelegramUpdate({
+			update_id: 1,
+			message: { chat: { id: 42 }, message_thread_id: threadId, text: "my typed answer", message_id: 99 },
+		});
+
+		const sent = FakeWs.instances[0]!.sent.map(frame => JSON.parse(frame));
+		expect(sent).toContainEqual({ type: "reply", id: "ask1", answer: "my typed answer", token: "ts" });
+		// ...and must NOT be injected as a new user turn.
+		expect(sent.some(frame => frame.type === "user_message")).toBe(false);
+	});
+
+	test("plain text injects a user turn when no ask is pending", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+		});
+		daemon.connectSession("S", "ws://s", "ts");
+		// Create the topic + pending via an ask, then resolve it so nothing is pending.
+		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
+			type: "action_needed",
+			kind: "ask",
+			id: "ask1",
+			question: "Name it?",
+			options: ["a", "b"],
+		});
+		const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
+		await daemon.handleSessionMessage(daemon.sessions.get("S")!, { type: "action_resolved", id: "ask1" });
+
+		await daemon.handleTelegramUpdate({
+			update_id: 7,
+			message: { chat: { id: 42 }, message_thread_id: threadId, text: "start a new task", message_id: 100 },
+		});
+
+		const sent = FakeWs.instances[0]!.sent.map(frame => JSON.parse(frame));
+		expect(sent.some(frame => frame.type === "user_message" && frame.text === "start a new task")).toBe(true);
+		expect(sent.some(frame => frame.type === "reply")).toBe(false);
+	});
+
 	test("runDaemonSmoke exits without polling and emits no token", async () => {
 		const agentDir = tempAgentDir();
 		await runDaemonSmoke({ agentDir });


### PR DESCRIPTION
Two Telegram ask fixes.

## 1. Free-input asks are now answerable by typing
A plain text message in a session topic was always injected as a **new user turn**, even while an ask was pending — so a free-input ask (or any ask you wanted to answer with custom text) could not be answered by typing on Telegram. The daemon now routes a plain (non-config) message to the session's pending ask as the free-text answer; when **no** ask is pending it still injects a user turn (unchanged). In-thread config commands (`/verbose`, `/lean`, `/redact`) still take precedence.

`packages/coding-agent/src/notifications/telegram-daemon.ts`

## 2. Ask choices are no longer redacted on buttons
Under redaction the option labels were replaced with generic `["1","2",…]`, leaving the Telegram inline-keyboard buttons unreadable. Redaction now keeps the real option labels (only the **question text** and **summary** are stripped) so the buttons stay readable and answerable.

`packages/coding-agent/src/notifications/config.ts`

## Tests
- `plain text answers a pending ask as free-input instead of injecting a new turn`
- `plain text injects a user turn when no ask is pending`
- redaction tests updated (config/helpers/e2e) to assert real option labels are preserved while the question is redacted.

Focused notification suites green; typecheck + biome clean; real local dev build `bun run build` succeeded (binary `gjc/0.6.5`).
