### PR TITLE
fix(ask): record unmatched remote answer as provide-my-own custom input

### DIFF
--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -430,8 +430,18 @@ async function askSingleQuestion(
 				// If input was dismissed (undefined), keep prior selectedOptions/customInput intact
 			}
 		} else {
-			selectedOptions = [stripRecommendedSuffix(choice)];
-			customInput = undefined;
+			const stripped = stripRecommendedSuffix(choice);
+			if (optionLabels.includes(stripped)) {
+				selectedOptions = [stripped];
+				customInput = undefined;
+			} else {
+				// A remote answer (e.g. a typed Telegram reply) that is not one of the
+				// listed options is the "provide my own" custom input — recorded the same
+				// as picking Other and typing it. The local selector can only ever return
+				// a listed entry, so this branch is reached only for free-text answers.
+				customInput = choice;
+				selectedOptions = [];
+			}
 		}
 		if (navigation?.allowForward) {
 			return { selectedOptions, customInput, timedOut, navigation: "forward" };

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -202,6 +202,50 @@ describe("AskTool cancellation", () => {
 		if (result.content[0]?.type === "text") expect(result.content[0].text).toContain("yes");
 	});
 
+	it("treats an unmatched remote answer as provide-my-own custom input", async () => {
+		const source = {
+			awaitAnswer: (_q: string, _opts: string[], _signal?: AbortSignal) => Promise.resolve("ship it tomorrow"),
+		};
+		const tool = new AskTool(createSession({ getAskAnswerSource: () => source } as Partial<ToolSession>));
+		const context = createContext({
+			// Local selector never resolves; the remote free-text answer wins.
+			select: () => new Promise<string | undefined>(() => {}),
+		});
+
+		const result = await tool.execute(
+			"call-remote-custom",
+			{ questions: [{ id: "confirm", question: "Proceed?", options: [{ label: "yes" }, { label: "no" }] }] },
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(result.details?.customInput).toBe("ship it tomorrow");
+		expect(result.details?.selectedOptions).toEqual([]);
+		if (result.content[0]?.type === "text") expect(result.content[0].text).toContain("custom input");
+	});
+
+	it("treats a remote answer that matches an option as a selection (not custom input)", async () => {
+		const source = {
+			awaitAnswer: (_q: string, _opts: string[], _signal?: AbortSignal) => Promise.resolve("no"),
+		};
+		const tool = new AskTool(createSession({ getAskAnswerSource: () => source } as Partial<ToolSession>));
+		const context = createContext({
+			select: () => new Promise<string | undefined>(() => {}),
+		});
+
+		const result = await tool.execute(
+			"call-remote-match",
+			{ questions: [{ id: "confirm", question: "Proceed?", options: [{ label: "yes" }, { label: "no" }] }] },
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(result.details?.selectedOptions).toEqual(["no"]);
+		expect(result.details?.customInput).toBeUndefined();
+	});
+
 	it("defaults to no timeout when ask.timeout is unset", async () => {
 		// Regression for the surprise-auto-select report: a fresh install must let the user
 		// deliberate indefinitely. The dialog timeout is opt-in via the `ask.timeout` setting.


### PR DESCRIPTION
Follow-up on the "I'll provide my own" (custom input) case for remote answering.

When an ask is answered remotely with **typed text that is not one of the listed options**, the single-select path (`packages/coding-agent/src/tools/ask.ts`) recorded it as a literal *selected option* rather than custom input. It is now treated as the **"provide my own" custom input** — the same outcome as picking *Other* and typing it locally. A remote answer that **matches** a listed option is still recorded as a selection.

This is safe because the local selector can only ever return a listed entry, so the new branch is reached only for free-text remote answers.

Note: tapping the *Other* button remotely still opens a local-only editor (not remotely fillable); the supported remote affordance for custom answers is to **type the answer**, which now lands as custom input.

## Tests
- `treats an unmatched remote answer as provide-my-own custom input`
- `treats a remote answer that matches an option as a selection (not custom input)`

ask suite green; typecheck + biome clean; real local dev build `bun run build` succeeded (binary `gjc/0.6.5`).
