### PR TITLE
fix(ai): glm-zcode model auth via ZCode coding-plan gateway + ZCode JWT

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -75704,7 +75704,14 @@
 			"name": "GLM-5.2 (ZCode)",
 			"api": "anthropic-messages",
 			"provider": "glm-zcode",
-			"baseUrl": "https://api.z.ai/api/anthropic",
+			"baseUrl": "https://zcode.z.ai/api/v1/zcode-plan/anthropic",
+			"headers": {
+				"User-Agent": "ZCode/1.0.0",
+				"HTTP-Referer": "https://zcode.z.ai",
+				"X-Title": "Z Code@electron",
+				"X-ZCode-App-Version": "1.0.0",
+				"X-ZCode-Agent": "glm"
+			},
 			"reasoning": true,
 			"input": [
 				"text"

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -2282,7 +2282,7 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDe
 	anthropicMessagesDescriptor(
 		"glm-zcode-coding-plan",
 		"glm-zcode",
-		process.env.ZCODE_PLAN_ANTHROPIC_BASE_URL ?? "https://api.z.ai/api/anthropic",
+		process.env.ZCODE_PLAN_ANTHROPIC_BASE_URL ?? "https://zcode.z.ai/api/v1/zcode-plan/anthropic",
 	),
 	// --- Xiaomi ---
 	openAiCompletionsDescriptor("xiaomi", "xiaomi", "https://api.xiaomimimo.com/v1", {

--- a/packages/ai/src/utils/oauth/glm-zcode.ts
+++ b/packages/ai/src/utils/oauth/glm-zcode.ts
@@ -7,21 +7,27 @@
  * violate ZCode/Z.AI Terms of Service. Endpoints and the client id are
  * overridable via `ZCODE_OAUTH_*` environment variables.
  *
- * Triple-hop token exchange:
+ * Login flow:
  *   1. Authorize:  GET  {authorize}?redirect_uri=zcode://oauth/callback&response_type=code&client_id=...&state=...
  *                  (custom-protocol redirect → a CLI cannot catch it, so the user pastes the code/redirect URL)
- *   2. Broker:     POST {broker}        { provider: "zai", code, redirect_uri, state }
- *                       → { data: { token: <zcode JWT>, zai: { access_token: <upstream Z.AI token> } } }
- *   3. Business:   POST {zai z/login}   { token: <upstream Z.AI token> }
- *                       → { data: { access_token: <business token>, expires_in } }
+ *   2. Broker:     POST {broker}  { provider: "zai", code, redirect_uri, state }
+ *                       → { code: 0, data: { token: <ZCode JWT>, zai: { access_token: <upstream Z.AI token> }, expires_in } }
  *
- * Credential mapping:
- *   - `access`  = business token (sent to GLM /v1/messages as `Authorization: Bearer`)
- *   - `refresh` = the plain upstream Z.AI access token (re-run z/login to re-mint `access`)
- * The ZCode JWT is used only transiently for identity decode at login; it is never stored.
+ * Credential mapping (verified against the ZCode host bundle):
+ *   - `access`  = the **ZCode JWT** (`data.token`). This is the GLM coding-plan
+ *                 model credential: ZCode stores it under the `zcodejwttoken`
+ *                 key and sends it as `Authorization: Bearer` to the coding-plan
+ *                 gateway `${ZCODE_PLAN_ANTHROPIC_BASE_URL}` (default
+ *                 https://zcode.z.ai/api/v1/zcode-plan/anthropic), which
+ *                 validates the ZCode session and injects the upstream GLM key
+ *                 server-side. Model traffic does NOT go to api.z.ai directly.
+ *   - `refresh` = the upstream Z.AI OAuth access token (`data.zai.access_token`),
+ *                 kept for identity/userinfo only. ZCode's separate z/login
+ *                 "business token" is used by ZCode for billing/userinfo, NOT
+ *                 model calls, so it is intentionally never minted here.
  *
- * The business token reaches the Anthropic-messages request as a plain bearer
- * automatically (the GLM base URL is not api.anthropic.com). This provider must
+ * The ZCode JWT reaches the Anthropic-messages request as a plain bearer
+ * automatically (the gateway base is not api.anthropic.com). This provider must
  * NEVER force `isOAuth=true`, which would route GLM into the Claude-Code OAuth
  * header branch (claude-cli UA, `claude_` tool prefixes, Claude system prompt).
  */
@@ -36,8 +42,15 @@ export const GLM_ZCODE_OAUTH_AUTHORIZE_URL = "https://chat.z.ai/api/oauth/author
 export const GLM_ZCODE_OAUTH_CLIENT_ID = "client_P8X5CMWmlaRO9gyO-KSqtg";
 export const GLM_ZCODE_OAUTH_REDIRECT_URI = "zcode://oauth/callback";
 export const GLM_ZCODE_OAUTH_BROKER_TOKEN_URL = "https://zcode.z.ai/api/v1/oauth/token";
-export const GLM_ZCODE_ZAI_LOGIN_URL = "https://api.z.ai/api/auth/z/login";
 export const GLM_ZCODE_USERINFO_URL = "https://chat.z.ai/api/oauth/userinfo";
+
+/**
+ * Default coding-plan ("start plan") Anthropic gateway base. ZCode derives this
+ * as `${zcodeBackend}/api/v1/zcode-plan/anthropic`. Model requests go here
+ * (NOT api.z.ai), authenticated with the ZCode JWT. Override via
+ * `ZCODE_PLAN_ANTHROPIC_BASE_URL`. Exported for the model descriptor / catalog.
+ */
+export const GLM_ZCODE_PLAN_ANTHROPIC_BASE_URL = "https://zcode.z.ai/api/v1/zcode-plan/anthropic";
 
 type FetchImpl = typeof globalThis.fetch;
 
@@ -58,9 +71,6 @@ function resolveRedirectUri(): string {
 function resolveBrokerTokenUrl(): string {
 	return envOr("ZCODE_OAUTH_BROKER_TOKEN_URL", GLM_ZCODE_OAUTH_BROKER_TOKEN_URL);
 }
-function resolveZaiLoginUrl(): string {
-	return envOr("ZCODE_OAUTH_ZAI_LOGIN_URL", GLM_ZCODE_ZAI_LOGIN_URL);
-}
 function resolveUserinfoUrl(): string {
 	return envOr("ZCODE_OAUTH_USERINFO_URL", GLM_ZCODE_USERINFO_URL);
 }
@@ -73,7 +83,7 @@ export function isGlmZcodeOAuthConfigured(): boolean {
 	return resolveClientId().length > 0;
 }
 
-/** Mask token-like substrings so broker/upstream/business tokens never leak into errors or logs. */
+/** Mask token-like substrings so broker/upstream/JWT tokens never leak into errors or logs. */
 function redactSecrets(text: string): string {
 	return text
 		.replace(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, "[redacted-jwt]")
@@ -195,7 +205,13 @@ async function resolveIdentity(
 	return identityFromJwts(jwtCandidates);
 }
 
-function parseBrokerResponse(payload: unknown): { zcodeToken: string; upstreamZaiAccess: string } {
+interface BrokerResult {
+	zcodeToken: string;
+	upstreamZaiAccess: string;
+	expiresIn: number;
+}
+
+function parseBrokerResponse(payload: unknown): BrokerResult {
 	const data = isRecord(payload) && isRecord(payload.data) ? payload.data : undefined;
 	const zcodeToken = data && typeof data.token === "string" ? data.token : undefined;
 	const zai = data && isRecord(data.zai) ? data.zai : undefined;
@@ -203,43 +219,9 @@ function parseBrokerResponse(payload: unknown): { zcodeToken: string; upstreamZa
 	if (!zcodeToken || !upstreamZaiAccess) {
 		throw new Error("GLM ZCode broker response missing data.token or data.zai.access_token");
 	}
-	return { zcodeToken, upstreamZaiAccess };
-}
-
-interface BusinessToken {
-	access: string;
-	expiresIn: number;
-}
-
-async function resolveBusinessToken(
-	fetchImpl: FetchImpl,
-	upstreamZaiAccess: string,
-	signal: AbortSignal | undefined,
-): Promise<BusinessToken> {
-	const zaiLoginUrl = validateHttpsEndpoint(resolveZaiLoginUrl(), "z/login");
-	const payload = await postJson(fetchImpl, zaiLoginUrl, { token: upstreamZaiAccess }, "z/login", signal);
-	const data = isRecord(payload) && isRecord(payload.data) ? payload.data : undefined;
-	const access = data && typeof data.access_token === "string" ? data.access_token : undefined;
-	if (!access) {
-		throw new Error("GLM ZCode z/login response missing data.access_token");
-	}
 	const expiresIn =
 		data && typeof data.expires_in === "number" && Number.isFinite(data.expires_in) ? data.expires_in : 3600;
-	return { access, expiresIn };
-}
-
-function credentialsFromBusiness(
-	business: BusinessToken,
-	upstreamZaiAccess: string,
-	identity: Identity,
-): OAuthCredentials {
-	return {
-		refresh: upstreamZaiAccess,
-		access: business.access,
-		expires: Date.now() + business.expiresIn * 1000 - GLM_ZCODE_REFRESH_SKEW_MS,
-		email: identity.email,
-		accountId: identity.accountId,
-	};
+	return { zcodeToken, upstreamZaiAccess, expiresIn };
 }
 
 async function exchangeGlmZcodeCode(
@@ -258,15 +240,17 @@ async function exchangeGlmZcodeCode(
 		"broker",
 		signal,
 	);
-	const { zcodeToken, upstreamZaiAccess } = parseBrokerResponse(brokerPayload);
-	const business = await resolveBusinessToken(fetchImpl, upstreamZaiAccess, signal);
-	const identity = await resolveIdentity(
-		fetchImpl,
-		upstreamZaiAccess,
-		[zcodeToken, upstreamZaiAccess, business.access],
-		signal,
-	);
-	return credentialsFromBusiness(business, upstreamZaiAccess, identity);
+	const { zcodeToken, upstreamZaiAccess, expiresIn } = parseBrokerResponse(brokerPayload);
+	const identity = await resolveIdentity(fetchImpl, upstreamZaiAccess, [zcodeToken, upstreamZaiAccess], signal);
+	// access = ZCode JWT (the coding-plan model credential); refresh = upstream
+	// Z.AI token (identity only — there is no documented JWT refresh grant).
+	return {
+		access: zcodeToken,
+		refresh: upstreamZaiAccess,
+		expires: Date.now() + expiresIn * 1000 - GLM_ZCODE_REFRESH_SKEW_MS,
+		email: identity.email,
+		accountId: identity.accountId,
+	};
 }
 
 export interface GlmZcodeOAuthFlowOptions {
@@ -322,33 +306,16 @@ export interface GlmZcodeRefreshOptions {
 }
 
 /**
- * Re-mint the GLM business token. ZCode exposes no documented refresh endpoint,
- * so this re-runs z/login with the stored upstream Z.AI token. If that fails the
- * caller must re-login; expired credentials are never returned as valid.
+ * The ZCode session JWT is the model credential. ZCode mints it from a one-time
+ * authorization code via the broker and exposes no documented refresh grant, so
+ * there is no autonomous refresh: an expired credential requires re-login
+ * (`/login glm-zcode`). Never return an expired credential as valid.
  */
 export async function refreshGlmZcodeToken(
-	credentials: OAuthCredentials,
-	options: AbortSignal | GlmZcodeRefreshOptions = {},
+	_credentials: OAuthCredentials,
+	_options: AbortSignal | GlmZcodeRefreshOptions = {},
 ): Promise<OAuthCredentials> {
-	const { signal, fetch: fetchImpl } =
-		options instanceof AbortSignal ? { signal: options, fetch: undefined } : options;
-	const upstreamZaiAccess = credentials.refresh;
-	if (!upstreamZaiAccess) {
-		throw new Error(
-			"glm-zcode credentials require re-login; no stored upstream Z.AI token and no documented refresh endpoint",
-		);
-	}
-	const resolvedFetch = fetchImpl ?? globalThis.fetch;
-	let business: BusinessToken;
-	try {
-		business = await resolveBusinessToken(resolvedFetch, upstreamZaiAccess, signal);
-	} catch (error) {
-		throw new Error(
-			`glm-zcode credentials require re-login; re-minting via z/login failed (${redactSecrets(String(error))})`,
-		);
-	}
-	return credentialsFromBusiness(business, upstreamZaiAccess, {
-		email: credentials.email,
-		accountId: credentials.accountId,
-	});
+	throw new Error(
+		"glm-zcode session expired; re-login required (`/login glm-zcode`). The ZCode coding-plan token has no documented refresh endpoint.",
+	);
 }

--- a/packages/ai/test/oauth-glm-zcode.test.ts
+++ b/packages/ai/test/oauth-glm-zcode.test.ts
@@ -13,12 +13,11 @@ import {
 	GLM_ZCODE_OAUTH_BROKER_TOKEN_URL,
 	GLM_ZCODE_OAUTH_CLIENT_ID,
 	GLM_ZCODE_OAUTH_REDIRECT_URI,
-	GLM_ZCODE_ZAI_LOGIN_URL,
+	GLM_ZCODE_PLAN_ANTHROPIC_BASE_URL,
 	GlmZcodeOAuthFlow,
 	isGlmZcodeOAuthConfigured,
 	refreshGlmZcodeToken,
 } from "../src/utils/oauth/glm-zcode";
-import type { OAuthCredentials } from "../src/utils/oauth/types";
 import { withEnv } from "./helpers";
 
 const originalFetch = global.fetch;
@@ -29,9 +28,9 @@ const SUPPRESS_ENV = {
 	ZCODE_OAUTH_CLIENT_ID: undefined,
 } as const;
 
-const UPSTREAM_ZAI_TOKEN = "upstream-zai-access-token-value-1234567890";
+// The ZCode JWT (broker data.token) is the GLM coding-plan model credential.
 const ZCODE_JWT = jwt({ sub: "zcode-sub-id", email: "ZJwt@Example.com" });
-const BUSINESS_TOKEN = "business-token-value-abcdefghijklmnop-998877";
+const UPSTREAM_ZAI_TOKEN = "upstream-zai-access-token-value-1234567890";
 
 function jwt(payload: Record<string, unknown>): string {
 	const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
@@ -40,13 +39,11 @@ function jwt(payload: Record<string, unknown>): string {
 
 interface MockOptions {
 	expiresIn?: number;
-	businessToken?: string;
+	zcodeToken?: string;
 	userinfo?: { email?: string; id?: string } | null;
 	captureBroker?: (body: string) => void;
-	captureZLogin?: (body: string) => void;
-	zLoginStatus?: number;
-	zLoginErrorBody?: string;
 	brokerPayloadOverride?: unknown;
+	brokerStatus?: number;
 }
 
 function routingFetch(options: MockOptions = {}) {
@@ -54,24 +51,20 @@ function routingFetch(options: MockOptions = {}) {
 		const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
 		if (url === GLM_ZCODE_OAUTH_BROKER_TOKEN_URL) {
 			options.captureBroker?.(String(init?.body ?? ""));
+			if (options.brokerStatus && options.brokerStatus >= 400) {
+				return new Response("rejected", { status: options.brokerStatus });
+			}
 			return new Response(
 				JSON.stringify(
 					options.brokerPayloadOverride ?? {
-						data: { token: ZCODE_JWT, zai: { access_token: UPSTREAM_ZAI_TOKEN } },
+						code: 0,
+						data: {
+							token: options.zcodeToken ?? ZCODE_JWT,
+							zai: { access_token: UPSTREAM_ZAI_TOKEN },
+							expires_in: options.expiresIn ?? 3600,
+						},
 					},
 				),
-				{ status: 200, headers: { "Content-Type": "application/json" } },
-			);
-		}
-		if (url === GLM_ZCODE_ZAI_LOGIN_URL) {
-			options.captureZLogin?.(String(init?.body ?? ""));
-			if (options.zLoginStatus && options.zLoginStatus >= 400) {
-				return new Response(options.zLoginErrorBody ?? "rejected", { status: options.zLoginStatus });
-			}
-			return new Response(
-				JSON.stringify({
-					data: { access_token: options.businessToken ?? BUSINESS_TOKEN, expires_in: options.expiresIn ?? 3600 },
-				}),
 				{ status: 200, headers: { "Content-Type": "application/json" } },
 			);
 		}
@@ -125,6 +118,15 @@ describe("GLM ZCode OAuth login provider", () => {
 		expect(GLM_ZCODE_OAUTH_REDIRECT_URI).toBe("zcode://oauth/callback");
 	});
 
+	it("defaults the model base to the ZCode coding-plan gateway, not api.z.ai", () => {
+		expect(GLM_ZCODE_PLAN_ANTHROPIC_BASE_URL).toBe("https://zcode.z.ai/api/v1/zcode-plan/anthropic");
+		const model = getBundledModel("glm-zcode", "glm-5.2");
+		expect(model.baseUrl).toBe("https://zcode.z.ai/api/v1/zcode-plan/anthropic");
+		// ZCode source headers must accompany coding-plan requests.
+		expect(model.headers?.["X-ZCode-Agent"]).toBe("glm");
+		expect(model.headers?.["User-Agent"]).toMatch(/^ZCode\//);
+	});
+
 	it("builds the authorize URL with client id, custom redirect, response_type, and state", async () => {
 		const flow = new GlmZcodeOAuthFlow(
 			{ onAuth: () => {}, onPrompt: async () => "" },
@@ -140,17 +142,9 @@ describe("GLM ZCode OAuth login provider", () => {
 		expect(instructions ?? "").toMatch(/unofficial/i);
 	});
 
-	it("runs the broker exchange then z/login and maps tokens correctly", async () => {
+	it("exchanges the code via the broker and maps the ZCode JWT to access", async () => {
 		let brokerBody = "";
-		let zLoginBody = "";
-		const fetchMock = routingFetch({
-			captureBroker: body => {
-				brokerBody = body;
-			},
-			captureZLogin: body => {
-				zLoginBody = body;
-			},
-		});
+		const fetchMock = routingFetch({ captureBroker: body => (brokerBody = body) });
 		const flow = new GlmZcodeOAuthFlow(
 			{ onAuth: () => {}, onPrompt: async () => "" },
 			{ fetch: fetchMock as unknown as typeof fetch },
@@ -163,18 +157,16 @@ describe("GLM ZCode OAuth login provider", () => {
 			redirect_uri: GLM_ZCODE_OAUTH_REDIRECT_URI,
 			state: "state-123",
 		});
-		expect(JSON.parse(zLoginBody)).toEqual({ token: UPSTREAM_ZAI_TOKEN });
-
-		// access = business token; refresh = plain upstream Z.AI token (NOT JSON, NOT the ZCode JWT).
-		expect(credentials.access).toBe(BUSINESS_TOKEN);
+		// The model credential is the ZCode JWT (data.token), NOT a z/login business token.
+		expect(credentials.access).toBe(ZCODE_JWT);
 		expect(credentials.refresh).toBe(UPSTREAM_ZAI_TOKEN);
-		expect(() => JSON.parse(credentials.refresh)).toThrow();
-		expect(credentials.refresh).not.toBe(ZCODE_JWT);
 		expect(credentials.email).toBe("member@example.com");
 		expect(credentials.accountId).toBe("account-xyz");
 		expect(credentials.expires).toBeGreaterThan(Date.now());
-		// 2-minute refresh skew applied.
 		expect(credentials.expires).toBeLessThanOrEqual(Date.now() + 3600 * 1000 - 60_000);
+		// No direct call to api.z.ai/z-login is made during login.
+		const calledUrls = fetchMock.mock.calls.map(c => String(c[0]));
+		expect(calledUrls.some(u => u.includes("/api/auth/z/login"))).toBe(false);
 	});
 
 	it("accepts a pasted full zcode:// redirect URL as the code", async () => {
@@ -188,7 +180,7 @@ describe("GLM ZCode OAuth login provider", () => {
 			"state-123",
 			GLM_ZCODE_OAUTH_REDIRECT_URI,
 		);
-		expect(credentials.access).toBe(BUSINESS_TOKEN);
+		expect(credentials.access).toBe(ZCODE_JWT);
 		const brokerCall = fetchMock.mock.calls.find(c => String(c[0]) === GLM_ZCODE_OAUTH_BROKER_TOKEN_URL);
 		expect(JSON.parse(String((brokerCall?.[1] as RequestInit).body)).code).toBe("pasted-code");
 	});
@@ -204,59 +196,8 @@ describe("GLM ZCode OAuth login provider", () => {
 		expect(credentials.accountId).toBe("zcode-sub-id");
 	});
 
-	it("re-mints the business token on refresh via z/login using the stored upstream token", async () => {
-		let zLoginBody = "";
-		const fetchMock = routingFetch({
-			businessToken: "business-token-rotated-zzz-2222222222",
-			captureZLogin: body => {
-				zLoginBody = body;
-			},
-		});
-		const credentials: OAuthCredentials = {
-			access: "business-old",
-			refresh: UPSTREAM_ZAI_TOKEN,
-			expires: Date.now() - 60_000,
-			email: "member@example.com",
-			accountId: "account-xyz",
-		};
-		const refreshed = await refreshGlmZcodeToken(credentials, { fetch: fetchMock as unknown as typeof fetch });
-		expect(JSON.parse(zLoginBody)).toEqual({ token: UPSTREAM_ZAI_TOKEN });
-		expect(refreshed.access).toBe("business-token-rotated-zzz-2222222222");
-		expect(refreshed.refresh).toBe(UPSTREAM_ZAI_TOKEN);
-		expect(refreshed.email).toBe("member@example.com");
-		expect(refreshed.expires).toBeGreaterThan(Date.now());
-	});
-
-	it("dispatches refreshOAuthToken('glm-zcode') to the z/login re-mint path", async () => {
-		const fetchMock = routingFetch({ businessToken: "business-via-dispatch-7777777777777" });
-		global.fetch = fetchMock as unknown as typeof fetch;
-		const refreshed = await refreshOAuthToken("glm-zcode", {
-			access: "business-old",
-			refresh: UPSTREAM_ZAI_TOKEN,
-			expires: Date.now() - 60_000,
-		});
-		expect(refreshed.access).toBe("business-via-dispatch-7777777777777");
-		expect(refreshed.refresh).toBe(UPSTREAM_ZAI_TOKEN);
-	});
-
-	it("fails with a sanitized re-login error when refresh has no upstream token", async () => {
-		await expect(refreshGlmZcodeToken({ access: "business", refresh: "", expires: Date.now() - 1 })).rejects.toThrow(
-			/require re-login/i,
-		);
-	});
-
-	it("fails with a re-login error (no expired credential returned) when z/login rejects", async () => {
-		const fetchMock = routingFetch({ zLoginStatus: 401 });
-		await expect(
-			refreshGlmZcodeToken(
-				{ access: "business-old", refresh: UPSTREAM_ZAI_TOKEN, expires: Date.now() - 1 },
-				{ fetch: fetchMock as unknown as typeof fetch },
-			),
-		).rejects.toThrow(/require re-login/i);
-	});
-
-	it("rejects a malformed broker payload missing the upstream Z.AI token", async () => {
-		const fetchMock = routingFetch({ brokerPayloadOverride: { data: { token: ZCODE_JWT } } });
+	it("rejects a malformed broker payload missing the ZCode JWT", async () => {
+		const fetchMock = routingFetch({ brokerPayloadOverride: { code: 0, data: { zai: { access_token: "x" } } } });
 		const flow = new GlmZcodeOAuthFlow(
 			{ onAuth: () => {}, onPrompt: async () => "" },
 			{ fetch: fetchMock as unknown as typeof fetch },
@@ -266,26 +207,34 @@ describe("GLM ZCode OAuth login provider", () => {
 		);
 	});
 
-	it("redacts token-like strings echoed in an upstream error body", async () => {
-		const leakedToken = "leaked-secret-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-		const fetchMock = routingFetch({ zLoginStatus: 500, zLoginErrorBody: `upstream said: ${leakedToken}` });
+	it("redacts token-like strings echoed in a broker error body", async () => {
+		const leaked = "leaked-secret-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+		const fetchMock = vi.fn(async () => new Response(`upstream said: ${leaked}`, { status: 500 }));
+		const flow = new GlmZcodeOAuthFlow(
+			{ onAuth: () => {}, onPrompt: async () => "" },
+			{ fetch: fetchMock as unknown as typeof fetch },
+		);
 		let caught: unknown;
 		try {
-			await refreshGlmZcodeToken(
-				{ access: "business-old", refresh: UPSTREAM_ZAI_TOKEN, expires: Date.now() - 1 },
-				{ fetch: fetchMock as unknown as typeof fetch },
-			);
+			await flow.exchangeToken("auth-code", "state-123", GLM_ZCODE_OAUTH_REDIRECT_URI);
 		} catch (error) {
 			caught = error;
 		}
-		expect(caught).toBeInstanceOf(Error);
-		const message = String(caught);
-		expect(message).toMatch(/require re-login/i);
-		expect(message).not.toContain(leakedToken);
-		expect(message).toContain("[redacted]");
+		expect(String(caught)).not.toContain(leaked);
+		expect(String(caught)).toContain("[redacted]");
 	});
 
-	it("stores glm-zcode login as OAuth and getApiKey returns the business token", async () => {
+	it("refresh requires re-login (ZCode JWT has no documented refresh grant)", async () => {
+		await expect(
+			refreshGlmZcodeToken({ access: ZCODE_JWT, refresh: UPSTREAM_ZAI_TOKEN, expires: Date.now() - 1 }),
+		).rejects.toThrow(/re-login required/i);
+		// Same via the registry dispatcher.
+		await expect(
+			refreshOAuthToken("glm-zcode", { access: ZCODE_JWT, refresh: UPSTREAM_ZAI_TOKEN, expires: Date.now() - 1 }),
+		).rejects.toThrow(/re-login required/i);
+	});
+
+	it("stores glm-zcode login as OAuth and getApiKey returns the ZCode JWT", async () => {
 		if (!store || !authStorage) throw new Error("test setup failed");
 		const fetchMock = routingFetch();
 		global.fetch = fetchMock as unknown as typeof fetch;
@@ -303,11 +252,11 @@ describe("GLM ZCode OAuth login provider", () => {
 		expect(credentials).toHaveLength(1);
 		expect(credentials[0]?.credential).toMatchObject({
 			type: "oauth",
-			access: BUSINESS_TOKEN,
+			access: ZCODE_JWT,
 			refresh: UPSTREAM_ZAI_TOKEN,
 		});
 		await withEnv(SUPPRESS_ENV, async () => {
-			expect(await authStorage?.getApiKey("glm-zcode", "session-glm-zcode")).toBe(BUSINESS_TOKEN);
+			expect(await authStorage?.getApiKey("glm-zcode", "session-glm-zcode")).toBe(ZCODE_JWT);
 		});
 	});
 
@@ -327,7 +276,6 @@ describe("GLM ZCode OAuth login provider", () => {
 			onManualCodeInput: async () => `zcode://oauth/callback?code=login-code&state=${capturedState ?? ""}`,
 		});
 
-		// Legacy zai stays an API key under its own provider.
 		const zaiCreds = store.listAuthCredentials("zai");
 		expect(zaiCreds).toHaveLength(1);
 		expect(zaiCreds[0]?.credential).toMatchObject({ type: "api_key" });
@@ -337,7 +285,7 @@ describe("GLM ZCode OAuth login provider", () => {
 
 		await withEnv(SUPPRESS_ENV, async () => {
 			expect(await authStorage?.getApiKey("zai", "session-zai")).toBe("legacy-zai-key");
-			expect(await authStorage?.getApiKey("glm-zcode", "session-glm")).toBe(BUSINESS_TOKEN);
+			expect(await authStorage?.getApiKey("glm-zcode", "session-glm")).toBe(ZCODE_JWT);
 		});
 	});
 
@@ -346,20 +294,21 @@ describe("GLM ZCode OAuth login provider", () => {
 		expect(model).toBeDefined();
 		expect(model.provider).toBe("glm-zcode");
 		expect(model.api).toBe("anthropic-messages");
-		expect(model.baseUrl).toBe("https://api.z.ai/api/anthropic");
 	});
 
-	it("sends Authorization: Bearer (no x-api-key, no claude-cli UA, no isOAuth) for the GLM business token", () => {
-		// GLM base is not api.anthropic.com → the non-Anthropic-base branch emits a
-		// plain bearer. isOAuth must NOT be set; the business token is not a Claude
-		// OAuth token, so no Claude-Code header/tool-prefix behavior applies.
-		expect(isOAuthToken(BUSINESS_TOKEN)).toBe(false);
+	it("sends Authorization: Bearer (no x-api-key, no claude-cli UA, no isOAuth) for the ZCode JWT", () => {
+		// The gateway base is not api.anthropic.com → the non-Anthropic-base branch
+		// emits a plain bearer. isOAuth must NOT be set; the ZCode JWT is not a
+		// Claude OAuth token, so no Claude-Code header/tool-prefix behavior applies.
+		expect(isOAuthToken(ZCODE_JWT)).toBe(false);
 		const headers = buildAnthropicHeaders({
-			apiKey: BUSINESS_TOKEN,
-			baseUrl: "https://api.z.ai/api/anthropic",
+			apiKey: ZCODE_JWT,
+			baseUrl: GLM_ZCODE_PLAN_ANTHROPIC_BASE_URL,
+			modelHeaders: { "User-Agent": "ZCode/1.0.0", "X-ZCode-Agent": "glm" },
 		});
-		expect(headers.Authorization).toBe(`Bearer ${BUSINESS_TOKEN}`);
+		expect(headers.Authorization).toBe(`Bearer ${ZCODE_JWT}`);
 		expect(headers["X-Api-Key"]).toBeUndefined();
+		expect(headers["X-ZCode-Agent"]).toBe("glm");
 		expect((headers["User-Agent"] ?? "").toLowerCase().startsWith("claude-cli")).toBe(false);
 	});
 });


### PR DESCRIPTION
## Problem
After login, GLM requests failed with `401 / 1004 Invalid API Key`. Root cause: the first implementation (#995) used the wrong token against the wrong endpoint.

Decoding the stored credential proved the z/login **"business token" is a Z.ai web/portal session JWT** (`user_type`, `customer`, `api_key: null`) — not a model API key. `api.z.ai/api/anthropic` rejects it with `1004`.

## Correct flow (from the ZCode host bundle)
`host/index.js:38482-38498` (broker exchange) + `41885-41900` (start-plan provider) + `zcodePlanAnthropicBaseUrl`:
- **base** = `${ZCODE_PLAN_ANTHROPIC_BASE_URL}`, default `https://zcode.z.ai/api/v1/zcode-plan/anthropic` (ZCode's own gateway) — **not** `api.z.ai`.
- **credential** = the **ZCode JWT** (`data.token`, stored as `zcodejwttoken`), sent as `Authorization: Bearer`.
- **headers** = ZCode source headers (`X-ZCode-Agent: glm`, `User-Agent: ZCode/...`, `HTTP-Referer`, `X-Title`, `X-ZCode-App-Version`).

The gateway validates the ZCode session and injects the real upstream GLM key server-side.

## Changes
- `glm-zcode.ts`: `OAuthCredentials.access` = `data.token` (ZCode JWT); `refresh` = upstream Z.ai token (identity only). Removed the z/login business-token step from the model-credential path. `refreshGlmZcodeToken` now surfaces a clear "re-login required" (the JWT has no documented refresh grant).
- `models.json`: `glm-zcode/glm-5.2` base -> coding-plan gateway + ZCode source headers.
- `openai-compat.ts`: descriptor default base -> coding-plan gateway.
- Tests rewritten for the corrected mapping.

## Verification
- `bun test packages/ai/test/oauth-glm-zcode.test.ts` -> 14 pass / 0 fail
- `tsc -p packages/ai` clean; biome clean; `generate-json-schemas --check` clean.

> Note: a fresh `/login glm-zcode` is required after pulling, so the corrected flow stores the ZCode JWT (old credentials hold the wrong token). Still unofficial; reuses ZCode's private client/broker/gateway.
