### PR TITLE
fix(notifications): exempt asks from redaction; make Other custom-input editor remote-answerable

### DIFF
--- a/packages/coding-agent/src/notifications/config.ts
+++ b/packages/coding-agent/src/notifications/config.ts
@@ -84,11 +84,14 @@ export interface RedactableAction {
 
 /**
  * When redact is true, strip sensitive content for remote delivery:
- *  - ask: question -> `Session <tag> needs input: [Ask]`, summary removed. Option
- *    labels are kept intact so the remote (e.g. Telegram inline-keyboard) buttons
- *    remain answerable and readable — the choices are not the sensitive payload.
+ *  - ask: NOT redacted. An ask is an interactive prompt the human must read and
+ *    answer on the remote surface; redacting its question/options would make it
+ *    unanswerable, defeating remote answering. Asks are returned unchanged.
  *  - idle: summary removed, (no question/options).
  * When redact is false, return the action unchanged.
+ *
+ * Redaction still applies to streamed content frames (turn_stream, context_update,
+ * image_attachment) which are suppressed at their emit sites, not here.
  */
 export function buildRedactedAction(
 	action: RedactableAction,
@@ -96,14 +99,9 @@ export function buildRedactedAction(
 ): RedactableAction {
 	if (!opts.redact) return action;
 
-	const { summary: _summary, question: _question, ...base } = action;
-	if (action.kind === "ask") {
-		return {
-			...base,
-			question: `Session ${opts.sessionTag} needs input: [Ask]`,
-			options: action.options,
-		};
-	}
+	// Asks stay fully readable/answerable even under redaction.
+	if (action.kind === "ask") return action;
 
+	const { summary: _summary, question: _question, ...base } = action;
 	return base;
 }

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -601,7 +601,31 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 			},
 			editor: (title, prefill, dialogOptions, editorOptions) => {
 				if (!extensionUi) throw new ToolAbortError("Ask tool requires interactive mode");
-				return extensionUi.editor(title, prefill, dialogOptions, editorOptions);
+				const source = this.session.getAskAnswerSource?.();
+				if (!source) return extensionUi.editor(title, prefill, dialogOptions, editorOptions);
+				// Race the local editor against a remote free-text answer so "Other / type
+				// your own" custom input can be provided remotely (e.g. a typed Telegram
+				// reply) instead of blocking on the local-only editor. Mirrors `select`.
+				const remoteController = new AbortController();
+				const localController = new AbortController();
+				const toolSignal = dialogOptions?.signal;
+				if (toolSignal) {
+					if (toolSignal.aborted) localController.abort();
+					else toolSignal.addEventListener("abort", () => localController.abort(), { once: true });
+				}
+				const remote = source.awaitAnswer(title, [], remoteController.signal).then(answer => {
+					if (answer === undefined) return new Promise<string | undefined>(() => {});
+					localController.abort();
+					return answer;
+				});
+				const local = extensionUi
+					.editor(title, prefill, { ...(dialogOptions ?? {}), signal: localController.signal }, editorOptions)
+					.then(answer => {
+						remoteController.abort();
+						return answer;
+					});
+				void local.catch(() => undefined);
+				return Promise.race([local, remote]);
 			},
 		};
 

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -133,7 +133,7 @@ describe("notifications config", () => {
 		expect(sessionTag("abc")).toBe("abc");
 	});
 
-	test("buildRedactedAction redacts ask question/summary but keeps real option labels", () => {
+	test("buildRedactedAction does NOT redact asks (they must stay answerable remotely)", () => {
 		const action: RedactableAction = {
 			id: "a1",
 			kind: "ask",
@@ -143,13 +143,8 @@ describe("notifications config", () => {
 			summary: "Sensitive summary",
 		};
 
-		expect(buildRedactedAction(action, { redact: true, sessionTag: "abcdef" })).toEqual({
-			id: "a1",
-			kind: "ask",
-			sessionId: "session-abcdef",
-			question: "Session abcdef needs input: [Ask]",
-			options: ["Yes, deploy", "No, stop", "Custom"],
-		});
+		// Asks are exempt from redaction: question and options are preserved.
+		expect(buildRedactedAction(action, { redact: true, sessionTag: "abcdef" })).toEqual(action);
 	});
 
 	test("buildRedactedAction returns unchanged action when redact is false", () => {

--- a/packages/coding-agent/test/notifications-e2e.test.ts
+++ b/packages/coding-agent/test/notifications-e2e.test.ts
@@ -176,7 +176,7 @@ test("interactive ask answered remotely via answer source (no RPC)", async () =>
 	srv.stop();
 }, 30000);
 
-test("redacted ask frame hides question text but keeps answerable option labels", async () => {
+test("ask frames are exempt from redaction so they stay readable and answerable", async () => {
 	const stateRoot = `/tmp/notif-e2e-redact-${process.pid}-${Date.now()}`;
 	const srv = new NotificationServer("redact", "tok", stateRoot, true);
 	const options = ["Ship secret alpha", "Abort secret beta"];
@@ -223,10 +223,10 @@ test("redacted ask frame hides question text but keeps answerable option labels"
 		true,
 	);
 
-	await waitFor(() => actionFrame !== undefined, 4000, "redacted action frame");
-	// Question text is redacted...
-	expect(String(actionFrame?.question)).not.toContain("Alpha");
-	// ...but the choices are NOT redacted, so the remote buttons stay readable/answerable.
+	await waitFor(() => actionFrame !== undefined, 4000, "ask action frame");
+	// Asks are exempt from redaction even with redact:true — both the question and
+	// the options reach the remote intact so the prompt is readable and answerable.
+	expect(String(actionFrame?.question)).toBe("Deploy secret project Alpha?");
 	expect(actionFrame?.options).toEqual(options);
 	await waitFor(() => resolvedBroadcast, 3000, "redacted action resolved");
 	expect(resolvedLabel).toBe("Ship secret alpha");

--- a/packages/coding-agent/test/notifications-helpers.test.ts
+++ b/packages/coding-agent/test/notifications-helpers.test.ts
@@ -113,7 +113,7 @@ describe("notifications helpers", () => {
 		expect(out?.endsWith("\u2026")).toBe(true);
 	});
 
-	test("notificationActionPayload redacts the ask question but keeps real option labels", () => {
+	test("notificationActionPayload does not redact asks (question and options preserved)", () => {
 		const ask = notificationActionPayload(
 			{
 				id: "ask-1",
@@ -125,7 +125,8 @@ describe("notifications helpers", () => {
 			{ redact: true, sessionTag: "secret" },
 		);
 
-		expect(ask.question).not.toContain("TOKEN");
+		// Asks must stay readable/answerable on the remote surface even under redaction.
+		expect(ask.question).toBe("Deploy prod with secret TOKEN?");
 		expect(ask.options).toEqual(["Deploy prod", "Cancel"]);
 
 		const idle = notificationActionPayload(

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -858,6 +858,36 @@ describe("AskTool custom input", () => {
 		expect(result.content[0].text).toContain("User selected: alpha");
 		expect(editor).toHaveBeenCalledTimes(1);
 	});
+
+	it("fills the Other/custom-input editor from a remote free-text answer", async () => {
+		let calls = 0;
+		const source = {
+			// 1st call = the select step (local picks Other); 2nd call = the editor step,
+			// which a remote (e.g. Telegram) reply fills instead of blocking locally.
+			awaitAnswer: (_q: string, _opts: string[], _signal?: AbortSignal) => {
+				calls++;
+				return calls === 1 ? new Promise<string | undefined>(() => {}) : Promise.resolve("remote typed answer");
+			},
+		};
+		const tool = new AskTool(createSession({ getAskAnswerSource: () => source } as Partial<ToolSession>));
+		const context = createContext({
+			// Local selector picks the last entry — the "Other / type your own" option.
+			select: (_prompt, options) => Promise.resolve(options[options.length - 1]),
+			// Local editor never resolves; only the remote answer can complete it.
+			editor: () => new Promise<string | undefined>(() => {}),
+		});
+
+		const result = await tool.execute(
+			"call-remote-editor",
+			{ questions: [{ id: "confirm", question: "Proceed?", options: [{ label: "yes" }, { label: "no" }] }] },
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(result.details?.customInput).toBe("remote typed answer");
+		if (result.content[0]?.type === "text") expect(result.content[0].text).toContain("remote typed answer");
+	});
 });
 
 describe("AskTool option rendering", () => {


### PR DESCRIPTION
Two follow-ups so asks are fully usable on Telegram (continuing #996/#998/#999).

## 1. Asks are no longer redacted
Redacting an ask's question text left the Telegram prompt unreadable (`Session … needs input: [Ask]`), so you couldn't tell what you were answering. `buildRedactedAction` (`config.ts`) now returns **ask** actions unchanged — both question and options reach the remote intact. Idle summaries and streamed turn/diff content remain redacted (handled at their emit sites). An ask is an interactive prompt the human must read to answer, so it is exempt from redaction by design.

## 2. "Other / type your own" is remote-answerable
Picking *Other* opens `ui.editor` for custom text. That editor was **not** raced against the remote answer source (only `select` was), so a remote (Telegram) user tapping Other — or being routed into custom input — hit a local-only editor that could never be filled, and the ask **blocked**. `editor` is now wrapped exactly like `select`: it races the local editor against a remote free-text answer, so a typed Telegram reply completes the custom-input step. (Typing a custom answer directly also still works via the unmatched-answer→customInput path from #999.)

## Tests
- redaction leaves asks intact: `buildRedactedAction does NOT redact asks`, helpers + e2e (`ask frames are exempt from redaction…`).
- `fills the Other/custom-input editor from a remote free-text answer` (fails/blocks without the editor wrapper).

ask + notification suites green; typecheck + biome clean; real local dev build `bun run build` succeeded (binary `gjc/0.6.5`).
