### PR TITLE
Fix daemon CLI surface regression test

### DIFF
--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -30,6 +30,7 @@ describe("GJC public CLI command surface", () => {
 			"ralplan",
 			"config",
 			"notify",
+			"daemon",
 			"web-search",
 			"mcp-serve",
 			"contribute-pr",


### PR DESCRIPTION
## Summary
- Treat `gjc daemon` as intended public CLI surface because it has a registered command module and daemon control-plane implementation.
- Update the CLI command surface regression expectation to include `daemon` between `notify` and `web-search`.

## Verification
- `bun test packages/coding-agent/test/cli-command-surface.test.ts`
- `bun --cwd=packages/coding-agent run check` (Biome reported existing deprecated `recommended` config info; typecheck passed)