### PR TITLE
fix(notifications): emit assistant lead-in text before the ask prompt

### DIFF
--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -142,6 +142,11 @@ interface SessionRuntime {
 	busy: boolean;
 	/** Inbound Telegram update ids injected but not yet consumed by a turn. */
 	pendingInbound: Set<number>;
+	/** Latest assistant text of the in-flight turn (from message_update). */
+	currentTurnText?: string;
+	/** Assistant text already flushed before an ask this turn (turn-scoped dedupe
+	 * so turn_end does not re-emit the pre-ask lead-in). Reset each turn. */
+	preAskFlushedText?: string;
 }
 
 interface ResolvedSettings {
@@ -620,18 +625,42 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 	// Redaction suppresses streamed content (only the one-time identity header
 	// survives redaction). The daemon coalesces/throttles these via its shared
 	// rate-limit pool before sending to Telegram.
-	api.on("turn_end", (event, ctx) => {
-		const id = sessionId(ctx);
-		const rt = runtimes.get(id);
-		if (!rt) return;
-		if (rt.redact) return;
-		const text = summaryFromMessage(event.message, 3500);
-		if (!text) return;
+	// Push the in-flight turn's assistant text as a finalized turn_stream, deduped
+	// against what was already flushed for this turn (the pre-ask lead-in).
+	const flushTurnText = (rt: SessionRuntime, id: string, text: string | undefined): void => {
+		if (!text || text === rt.preAskFlushedText) return;
+		rt.preAskFlushedText = text;
 		try {
 			rt.server.pushFrame(JSON.stringify({ type: "turn_stream", sessionId: id, phase: "finalized", text }));
 		} catch (e) {
 			logger.warn(`notifications: pushFrame (turn) failed: ${String(e)}`);
 		}
+	};
+
+	// Emit the assistant text that precedes an ask BEFORE the ask's action_needed
+	// is broadcast, so the remote (e.g. Telegram) shows the lead-in first instead
+	// of only after the ask resolves at turn_end. The text is captured on
+	// message_end (which, like tool_execution_start, is on the awaited extension
+	// path and ordered before it — unlike message_update, which is queued async),
+	// then flushed here before the ask tool's execute calls registerAsk.
+	api.on("tool_execution_start", (event, ctx) => {
+		if (event.toolName !== "ask") return;
+		const id = sessionId(ctx);
+		const rt = runtimes.get(id);
+		if (!rt || rt.redact) return;
+		flushTurnText(rt, id, rt.currentTurnText);
+	});
+
+	api.on("turn_end", (event, ctx) => {
+		const id = sessionId(ctx);
+		const rt = runtimes.get(id);
+		if (!rt) return;
+		const text = rt.redact ? undefined : summaryFromMessage(event.message, 3500);
+		if (text) flushTurnText(rt, id, text);
+		// Reset per-turn streaming state so the next turn starts fresh and a later
+		// turn with identical text is not falsely deduped.
+		rt.currentTurnText = undefined;
+		rt.preAskFlushedText = undefined;
 	});
 
 	// Stream agent-produced images (computer/browser/tool screenshots) as
@@ -640,6 +669,11 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		const id = sessionId(ctx);
 		const rt = runtimes.get(id);
 		if (!rt || rt.redact) return;
+		// Capture the in-flight assistant text here (message_end is on the awaited
+		// extension path and ordered before tool_execution_start) so the pre-ask
+		// flush can emit it before the ask prompt.
+		const turnText = summaryFromMessage(event.message, 3500);
+		if (turnText) rt.currentTurnText = turnText;
 		for (const img of imageAttachmentsFromMessage(event.message)) {
 			try {
 				rt.server.pushFrame(

--- a/packages/coding-agent/test/notifications-turn-ordering.test.ts
+++ b/packages/coding-agent/test/notifications-turn-ordering.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createNotificationsExtension } from "../src/notifications/index";
+import { readEndpoint } from "../src/notifications/telegram-reference";
+
+/**
+ * Regression for the text-before-ask ordering bug: the assistant text that
+ * precedes an ask must reach the remote BEFORE the ask's action_needed (it used
+ * to arrive only at turn_end, after the ask resolved), and must not be emitted
+ * twice once turn_end fires.
+ */
+
+const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+async function waitFor(pred: () => boolean, ms = 4000, label = "condition"): Promise<void> {
+	const start = Date.now();
+	while (!pred()) {
+		if (Date.now() - start > ms) throw new Error(`timeout waiting for ${label}`);
+		await sleep(10);
+	}
+}
+
+function fakeApi() {
+	const handlers = new Map<string, (event: unknown, ctx: unknown) => unknown>();
+	const api = {
+		on: (event: string, handler: (event: unknown, ctx: unknown) => unknown) => {
+			handlers.set(event, handler);
+		},
+		registerCommand: () => {},
+		sendUserMessage: () => {},
+	};
+	return { api: api as never, handlers };
+}
+
+const tempDirs: string[] = [];
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("assistant text preceding an ask is flushed before the ask and not duplicated at turn_end", async () => {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-order-"));
+		tempDirs.push(cwd);
+		const sid = `order-${process.pid}-${Date.now()}`;
+		const { api, handlers } = fakeApi();
+		createNotificationsExtension(api);
+
+		const ctx = {
+			cwd,
+			sessionManager: {
+				getSessionId: () => sid,
+				getSessionName: () => "Ordering Test",
+				getArtifactsDir: () => cwd,
+				getCwd: () => cwd,
+			},
+		} as never;
+
+		await handlers.get("session_start")!({ type: "session_start" }, ctx);
+
+		const endpointFile = path.join(cwd, ".gjc", "state", "notifications", `${sid}.json`);
+		await waitFor(() => fs.existsSync(endpointFile), 4000, "endpoint file");
+		const { url, token } = readEndpoint(endpointFile);
+
+		const frames: Array<{ type: string; text?: string }> = [];
+		const ws = new WebSocket(`${url}/?token=${encodeURIComponent(token)}`);
+		ws.addEventListener("message", ev => frames.push(JSON.parse(String((ev as MessageEvent).data))));
+		await new Promise<void>((resolve, reject) => {
+			ws.addEventListener("open", () => resolve());
+			ws.addEventListener("error", () => reject(new Error("ws error")));
+		});
+		// Let the server-side connection subscribe before any (unbuffered) broadcast.
+		await sleep(250);
+
+		const turnStreams = () => frames.filter(f => f.type === "turn_stream");
+
+		// The assistant message (lead-in text) completes, then the ask tool starts.
+		await handlers.get("message_end")!({ type: "message_end", message: { content: "Here are your options:" } }, ctx);
+		await handlers.get("tool_execution_start")!(
+			{ type: "tool_execution_start", toolName: "ask", toolCallId: "t1", args: {} },
+			ctx,
+		);
+
+		// The lead-in must be flushed now (before the ask), not at turn_end.
+		await waitFor(() => turnStreams().length === 1, 3000, "pre-ask turn_stream");
+		expect(turnStreams()[0]!.text).toContain("Here are your options:");
+
+		// turn_end for the same message must NOT duplicate the lead-in.
+		await handlers.get("turn_end")!(
+			{ type: "turn_end", turnIndex: 0, message: { content: "Here are your options:" } },
+			ctx,
+		);
+		await sleep(150);
+		expect(turnStreams().length).toBe(1);
+
+		// A later turn with different text streams once at turn_end.
+		await handlers.get("message_end")!({ type: "message_end", message: { content: "All done." } }, ctx);
+		await handlers.get("turn_end")!({ type: "turn_end", turnIndex: 1, message: { content: "All done." } }, ctx);
+		await waitFor(() => turnStreams().length === 2, 3000, "second turn_stream");
+		expect(turnStreams()[1]!.text).toContain("All done.");
+
+		ws.close();
+		await handlers.get("session_shutdown")!({ type: "session_shutdown" }, ctx);
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
+	}
+}, 30000);


### PR DESCRIPTION
The assistant text that precedes an `ask` only reached the remote at `turn_end` — after the ask resolved — so on Telegram the ask prompt/buttons appeared *before* the text that introduced them.

## Fix
`packages/coding-agent/src/notifications/index.ts`:
- Capture the in-flight assistant text on **`message_end`** (the awaited extension-event path, ordered before `tool_execution_start` for the same assistant message — unlike `message_update`, which `agent-session.ts:1662-1664` dispatches via a deferred queue and is therefore not reliably available at tool start).
- On the **ask** tool's `tool_execution_start`, flush that text as a `turn_stream` **before** the ask's `action_needed` is broadcast (`tool_execution_start` is emitted+awaited before `execute` → before `registerAsk`).
- `turn_end` dedupes against the pre-ask flush (`preAskFlushedText`) and resets per-turn state so a later turn with identical text is not falsely suppressed.
- Redaction still suppresses streamed text.

## Test
`packages/coding-agent/test/notifications-turn-ordering.test.ts` drives the extension handlers against a **real `NotificationServer`** over a WS client and asserts the lead-in text is flushed at `tool_execution_start` (before the ask) and **not** duplicated at `turn_end`, and that a later turn streams once. Verified to FAIL (timeout) when the pre-ask flush is removed.

## Verification
- Focused suites green (turn-ordering, notifications-e2e, telegram-daemon).
- Architect review: product/code CLEAR; the initial architecture WATCH (reliance on the queued `message_update`) was resolved by switching capture to the awaited `message_end` path.
- typecheck + biome clean; real local dev build `bun run build` succeeded (binary `gjc/0.7.0`).
