### PR TITLE
fix(notifications): only mirror assistant message_end as pre-ask turn text

### DIFF
--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -669,11 +669,14 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		const id = sessionId(ctx);
 		const rt = runtimes.get(id);
 		if (!rt || rt.redact) return;
-		// Capture the in-flight assistant text here (message_end is on the awaited
+		// Capture the in-flight ASSISTANT text here (message_end is on the awaited
 		// extension path and ordered before tool_execution_start) so the pre-ask
-		// flush can emit it before the ask prompt.
-		const turnText = summaryFromMessage(event.message, 3500);
-		if (turnText) rt.currentTurnText = turnText;
+		// flush can emit it before the ask prompt. Role-scoped: message_end also
+		// fires for the user prompt, which must never be mirrored back as turn output.
+		if ((event.message as { role?: unknown }).role === "assistant") {
+			const turnText = summaryFromMessage(event.message, 3500);
+			if (turnText) rt.currentTurnText = turnText;
+		}
 		for (const img of imageAttachmentsFromMessage(event.message)) {
 			try {
 				rt.server.pushFrame(

--- a/packages/coding-agent/test/notifications-turn-ordering.test.ts
+++ b/packages/coding-agent/test/notifications-turn-ordering.test.ts
@@ -8,8 +8,9 @@ import { readEndpoint } from "../src/notifications/telegram-reference";
 /**
  * Regression for the text-before-ask ordering bug: the assistant text that
  * precedes an ask must reach the remote BEFORE the ask's action_needed (it used
- * to arrive only at turn_end, after the ask resolved), and must not be emitted
- * twice once turn_end fires.
+ * to arrive only at turn_end, after the ask resolved), must not be emitted twice
+ * once turn_end fires, and must never mirror the user's own prompt back as turn
+ * output (message_end fires for user messages too).
  */
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
@@ -21,63 +22,72 @@ async function waitFor(pred: () => boolean, ms = 4000, label = "condition"): Pro
 	}
 }
 
-function fakeApi() {
-	const handlers = new Map<string, (event: unknown, ctx: unknown) => unknown>();
+type Handler = (event: unknown, ctx: unknown) => unknown;
+type Frame = { type: string; text?: string };
+
+const tempDirs: string[] = [];
+const openSockets: WebSocket[] = [];
+afterEach(() => {
+	for (const ws of openSockets.splice(0)) ws.close();
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+/** Boot the notifications extension against a real NotificationServer + WS client. */
+async function setup(): Promise<{ handlers: Map<string, Handler>; ctx: unknown; frames: Frame[] }> {
+	const handlers = new Map<string, Handler>();
 	const api = {
-		on: (event: string, handler: (event: unknown, ctx: unknown) => unknown) => {
+		on: (event: string, handler: Handler) => {
 			handlers.set(event, handler);
 		},
 		registerCommand: () => {},
 		sendUserMessage: () => {},
-	};
-	return { api: api as never, handlers };
-}
+	} as never;
+	createNotificationsExtension(api);
 
-const tempDirs: string[] = [];
-afterEach(() => {
-	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
-});
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-order-"));
+	tempDirs.push(cwd);
+	const sid = `order-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	const ctx = {
+		cwd,
+		sessionManager: {
+			getSessionId: () => sid,
+			getSessionName: () => "Ordering Test",
+			getArtifactsDir: () => cwd,
+			getCwd: () => cwd,
+		},
+	} as never;
+
+	await handlers.get("session_start")!({ type: "session_start" }, ctx);
+
+	const endpointFile = path.join(cwd, ".gjc", "state", "notifications", `${sid}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), 4000, "endpoint file");
+	const { url, token } = readEndpoint(endpointFile);
+
+	const frames: Frame[] = [];
+	const ws = new WebSocket(`${url}/?token=${encodeURIComponent(token)}`);
+	openSockets.push(ws);
+	ws.addEventListener("message", ev => frames.push(JSON.parse(String((ev as MessageEvent).data))));
+	await new Promise<void>((resolve, reject) => {
+		ws.addEventListener("open", () => resolve());
+		ws.addEventListener("error", () => reject(new Error("ws error")));
+	});
+	// Let the server-side connection subscribe before any (unbuffered) broadcast.
+	await sleep(250);
+	return { handlers, ctx, frames };
+}
 
 test("assistant text preceding an ask is flushed before the ask and not duplicated at turn_end", async () => {
 	const prevEnv = process.env.GJC_NOTIFICATIONS;
 	process.env.GJC_NOTIFICATIONS = "1";
 	try {
-		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-order-"));
-		tempDirs.push(cwd);
-		const sid = `order-${process.pid}-${Date.now()}`;
-		const { api, handlers } = fakeApi();
-		createNotificationsExtension(api);
-
-		const ctx = {
-			cwd,
-			sessionManager: {
-				getSessionId: () => sid,
-				getSessionName: () => "Ordering Test",
-				getArtifactsDir: () => cwd,
-				getCwd: () => cwd,
-			},
-		} as never;
-
-		await handlers.get("session_start")!({ type: "session_start" }, ctx);
-
-		const endpointFile = path.join(cwd, ".gjc", "state", "notifications", `${sid}.json`);
-		await waitFor(() => fs.existsSync(endpointFile), 4000, "endpoint file");
-		const { url, token } = readEndpoint(endpointFile);
-
-		const frames: Array<{ type: string; text?: string }> = [];
-		const ws = new WebSocket(`${url}/?token=${encodeURIComponent(token)}`);
-		ws.addEventListener("message", ev => frames.push(JSON.parse(String((ev as MessageEvent).data))));
-		await new Promise<void>((resolve, reject) => {
-			ws.addEventListener("open", () => resolve());
-			ws.addEventListener("error", () => reject(new Error("ws error")));
-		});
-		// Let the server-side connection subscribe before any (unbuffered) broadcast.
-		await sleep(250);
-
+		const { handlers, ctx, frames } = await setup();
 		const turnStreams = () => frames.filter(f => f.type === "turn_stream");
 
 		// The assistant message (lead-in text) completes, then the ask tool starts.
-		await handlers.get("message_end")!({ type: "message_end", message: { content: "Here are your options:" } }, ctx);
+		await handlers.get("message_end")!(
+			{ type: "message_end", message: { role: "assistant", content: "Here are your options:" } },
+			ctx,
+		);
 		await handlers.get("tool_execution_start")!(
 			{ type: "tool_execution_start", toolName: "ask", toolCallId: "t1", args: {} },
 			ctx,
@@ -89,20 +99,55 @@ test("assistant text preceding an ask is flushed before the ask and not duplicat
 
 		// turn_end for the same message must NOT duplicate the lead-in.
 		await handlers.get("turn_end")!(
-			{ type: "turn_end", turnIndex: 0, message: { content: "Here are your options:" } },
+			{ type: "turn_end", turnIndex: 0, message: { role: "assistant", content: "Here are your options:" } },
 			ctx,
 		);
 		await sleep(150);
 		expect(turnStreams().length).toBe(1);
 
 		// A later turn with different text streams once at turn_end.
-		await handlers.get("message_end")!({ type: "message_end", message: { content: "All done." } }, ctx);
-		await handlers.get("turn_end")!({ type: "turn_end", turnIndex: 1, message: { content: "All done." } }, ctx);
+		await handlers.get("message_end")!(
+			{ type: "message_end", message: { role: "assistant", content: "All done." } },
+			ctx,
+		);
+		await handlers.get("turn_end")!(
+			{ type: "turn_end", turnIndex: 1, message: { role: "assistant", content: "All done." } },
+			ctx,
+		);
 		await waitFor(() => turnStreams().length === 2, 3000, "second turn_stream");
 		expect(turnStreams()[1]!.text).toContain("All done.");
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
+	}
+}, 30000);
 
-		ws.close();
-		await handlers.get("session_shutdown")!({ type: "session_shutdown" }, ctx);
+test("a tool-only ask turn does not mirror the preceding user prompt as turn output", async () => {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		const { handlers, ctx, frames } = await setup();
+		const turnStreams = () => frames.filter(f => f.type === "turn_stream");
+
+		// The user's prompt fires message_end (role user) first.
+		await handlers.get("message_end")!(
+			{ type: "message_end", message: { role: "user", content: "please ask me something" } },
+			ctx,
+		);
+		// The assistant turn is tool-only: a message with NO text, just the ask tool_use.
+		await handlers.get("message_end")!(
+			{ type: "message_end", message: { role: "assistant", content: [{ type: "tool_use", name: "ask" }] } },
+			ctx,
+		);
+		await handlers.get("tool_execution_start")!(
+			{ type: "tool_execution_start", toolName: "ask", toolCallId: "t1", args: {} },
+			ctx,
+		);
+		await sleep(250);
+
+		// Nothing should have been streamed: the user's prompt must not be mirrored,
+		// and the assistant turn had no text of its own.
+		expect(turnStreams().length).toBe(0);
 	} finally {
 		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
 		else process.env.GJC_NOTIFICATIONS = prevEnv;


### PR DESCRIPTION
Follow-up to #1006. A late-arriving architect review found a post-merge blocker.

## Bug
The pre-ask flush captured the in-flight text on `message_end` without checking role, but `message_end` also fires for the **user's prompt** before assistant/tool execution. On a **tool-only ask turn** (the assistant message has no text of its own), the user's prompt was left in `currentTurnText` and flushed back as assistant turn output before the ask — mirroring the user's own text at them.

## Fix
`packages/coding-agent/src/notifications/index.ts`: capture `currentTurnText` only when `event.message.role === "assistant"`.

## Test
`notifications-turn-ordering.test.ts`: adds a tool-only-ask-after-user-prompt case asserting the user prompt is **not** streamed (assertion: zero turn_stream frames). Verified to FAIL without the role guard. The happy-path test (assistant lead-in flushed before the ask, deduped at turn_end) still passes.

## Verification
Focused suites green (turn-ordering, e2e, telegram-daemon); typecheck + biome clean; real local dev build `bun run build` succeeded (binary `gjc/0.7.0`).
