### PR TITLE
Fix packaged native imports for smoke test

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed packaged source installs (`gajae-code` wrapper) failing `gjc --smoke-test` because native smoke/fallback imports used monorepo-relative paths instead of the `@gajae-code/natives` package export.
 
 ## [0.7.0] - 2026-06-22
 

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -176,9 +176,7 @@ async function runSmokeTest(): Promise<void> {
 	// the COMPILED single binary (dev runs only load the on-disk .node). Loading the
 	// natives module triggers loadNative()/embedded extraction; calling each new
 	// export confirms the symbols are present in the shipped binary.
-	const { h06FormatHashLines, h02ScoreSequenceFuzzy, h01FindBestFuzzyMatch } = await import(
-		"../../natives/native/index.js"
-	);
+	const { h06FormatHashLines, h02ScoreSequenceFuzzy, h01FindBestFuzzyMatch } = await import("@gajae-code/natives");
 	const hashed = h06FormatHashLines("a\nb", 1);
 	if (hashed.split("\n").length !== 2) {
 		throw new Error(`smoke-test: h06FormatHashLines returned unexpected output: ${JSON.stringify(hashed)}`);

--- a/packages/coding-agent/src/edit/modes/replace.ts
+++ b/packages/coding-agent/src/edit/modes/replace.ts
@@ -42,7 +42,7 @@ let scoreSequenceFuzzyNative:
 let findBestFuzzyMatchNative:
 	| ((content: string, target: string, threshold: number) => NativeBestFuzzyMatchResult)
 	| undefined;
-void import("../../../../natives/native/index.js")
+void import("@gajae-code/natives")
 	.then(mod => {
 		if (typeof mod.h02ScoreSequenceFuzzy === "function") {
 			scoreSequenceFuzzyNative = mod.h02ScoreSequenceFuzzy;

--- a/packages/coding-agent/src/hashline/hash.ts
+++ b/packages/coding-agent/src/hashline/hash.ts
@@ -9,7 +9,7 @@ import bigrams from "./bigrams.json" with { type: "json" };
 // module evaluation so this core module (and its re-exported helpers) stays
 // usable and falls back to the TS loop if the native addon is unavailable.
 let formatHashLinesNative: ((text: string, startLine?: number) => string) | undefined;
-void import("../../../natives/native/index.js")
+void import("@gajae-code/natives")
 	.then(mod => {
 		if (typeof mod.h06FormatHashLines === "function") {
 			formatHashLinesNative = mod.h06FormatHashLines;


### PR DESCRIPTION
## Summary
- import `@gajae-code/natives` via the package export instead of monorepo-relative native paths
- fix `gjc --smoke-test` for packaged `gajae-code` wrapper installs
- align hashline/edit native fallback imports with installed package layout

## Verification
- `bun packages/coding-agent/src/cli.ts --smoke-test`
- `bun run check` (packages/coding-agent)

Replaces #1008; that PR was closed for a formatting-only CI failure.