### PR TITLE
fix(ai): pin glm-zcode request base to the ZCode coding-plan gateway

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -678,6 +678,15 @@ function resolveAnthropicBaseUrl(model: Model<"anthropic-messages">, apiKey?: st
 	if (model.provider === "github-copilot") {
 		return normalizeAnthropicBaseUrl(resolveGitHubCopilotBaseUrl(model.baseUrl, apiKey) ?? model.baseUrl);
 	}
+	// glm-zcode is the unofficial ZCode coding-plan gateway. Pin its base to the
+	// ZCode plan gateway so dynamic discovery / stale bundled catalogs / model
+	// cache can never redirect it to api.z.ai (which rejects the ZCode JWT).
+	if (model.provider === "glm-zcode") {
+		return (
+			normalizeAnthropicBaseUrl(process.env.ZCODE_PLAN_ANTHROPIC_BASE_URL) ??
+			"https://zcode.z.ai/api/v1/zcode-plan/anthropic"
+		);
+	}
 	if (model.provider === "anthropic" && isFoundryEnabled()) {
 		const foundryBaseUrl = normalizeAnthropicBaseUrl($env.FOUNDRY_BASE_URL);
 		if (foundryBaseUrl) {

--- a/packages/ai/test/oauth-glm-zcode.test.ts
+++ b/packages/ai/test/oauth-glm-zcode.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 
 import { AuthStorage, SqliteAuthCredentialStore } from "../src/auth-storage";
 import { getBundledModel } from "../src/models";
-import { buildAnthropicHeaders } from "../src/providers/anthropic";
+import { buildAnthropicClientOptions, buildAnthropicHeaders } from "../src/providers/anthropic";
 import { isOAuthToken } from "../src/utils/anthropic-auth";
 import { getOAuthProviders, refreshOAuthToken } from "../src/utils/oauth";
 import {
@@ -310,5 +310,26 @@ describe("GLM ZCode OAuth login provider", () => {
 		expect(headers["X-Api-Key"]).toBeUndefined();
 		expect(headers["X-ZCode-Agent"]).toBe("glm");
 		expect((headers["User-Agent"] ?? "").toLowerCase().startsWith("claude-cli")).toBe(false);
+	});
+
+	it("pins the request base to the ZCode gateway even if model.baseUrl was polluted to api.z.ai", () => {
+		// Dynamic discovery / stale bundled catalogs / model cache can overwrite
+		// model.baseUrl with api.z.ai (which rejects the ZCode JWT with 401). The
+		// request-time resolver must force the coding-plan gateway regardless.
+		const model = {
+			id: "glm-5.2",
+			name: "GLM-5.2 (ZCode)",
+			api: "anthropic-messages",
+			provider: "glm-zcode",
+			baseUrl: "https://api.z.ai/api/anthropic",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1_000_000,
+			maxTokens: 131072,
+		} as unknown as Parameters<typeof buildAnthropicClientOptions>[0]["model"];
+		const resolved = buildAnthropicClientOptions({ model, apiKey: ZCODE_JWT });
+		expect(resolved.baseURL).toBe(GLM_ZCODE_PLAN_ANTHROPIC_BASE_URL);
+		expect(resolved.isOAuthToken).toBe(false);
 	});
 });


### PR DESCRIPTION
## Problem
On `dev`, glm-zcode model requests still hit `api.z.ai` (→ `401 token expired or incorrect`) instead of the ZCode coding-plan gateway, even though the bundled `models.json` base is the gateway.

Root cause: the runtime model-manager lets dynamic discovery / stale catalogs / the model cache overwrite `model.baseUrl` with `api.z.ai` (model-manager.ts:325 takes the discovered baseUrl when the api matches), and `resolveAnthropicBaseUrl` trusted `model.baseUrl`. The ZCode JWT is only valid at the gateway; api.z.ai rejects it.

## Fix
Pin the request base for provider `glm-zcode` to `ZCODE_PLAN_ANTHROPIC_BASE_URL ?? https://zcode.z.ai/api/v1/zcode-plan/anthropic` in `resolveAnthropicBaseUrl`, ignoring any polluted `model.baseUrl`. Adds a regression test (buildAnthropicClientOptions resolves the gateway base even when model.baseUrl is api.z.ai).

## Verification
- `bun test packages/ai/test/oauth-glm-zcode.test.ts packages/ai/test/anthropic-oauth.test.ts` → 29 pass / 0 fail
- tsc + biome clean.

After pulling + rebuild, glm-zcode requests go to the gateway. Note: an active GLM coding-plan subscription is still required (no plan → gateway `3012`), and an Aliyun captcha may challenge first-time/untrusted requests (`3007`); captcha auto-solve is a follow-up if needed.
