### PR TITLE
fix(coding-agent): scroll structured deep-interview asks

### DIFF
--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -675,8 +675,9 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 			}
 			try {
 				const deepInterviewPrompt = formatDeepInterviewSelectorPrompt(q.question);
+				const isDeepInterviewQuestion = deepInterviewPrompt !== null || q.deepInterview !== undefined;
 				const displayQuestion = deepInterviewPrompt ?? q.question;
-				const shouldNumberOptions = isDeepInterviewAskQuestion(q.question);
+				const shouldNumberOptions = isDeepInterviewQuestion || isDeepInterviewAskQuestion(q.question);
 				const optionLabels = shouldNumberOptions ? numberOptionLabels(rawOptionLabels) : rawOptionLabels;
 				const initialSelection =
 					shouldNumberOptions && options?.previous
@@ -700,7 +701,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 					signal,
 					initialSelection,
 					navigation: options?.navigation,
-					scrollTitleRows: deepInterviewPrompt === null ? undefined : DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS,
+					scrollTitleRows: isDeepInterviewQuestion ? DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS : undefined,
 					otherOptionLabel: shouldNumberOptions
 						? formatNumberedOptionLabel(OTHER_OPTION, optionLabels.length)
 						: undefined,

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it, spyOn, vi } from "bun:test";
 import type { AgentToolContext } from "@gajae-code/agent-core";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
+import type { AppendOrMergeResult } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-recorder";
 import * as deepInterviewRecorder from "@gajae-code/coding-agent/gjc-runtime/deep-interview-recorder";
 import { getThemeByName, initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
@@ -1437,6 +1438,51 @@ describe("AskTool deep-interview rendering middleware", () => {
 						id: "round-4",
 						question: rawQuestion,
 						options: [{ label: "Visible options" }, { label: "Scrollable prompt" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		const dialogOptions = select.mock.calls[0]?.[2];
+		expect(dialogOptions?.scrollTitleRows).toBe(Number.MAX_SAFE_INTEGER);
+		expect(dialogOptions?.helpText).toContain("wheel/PgUp/PgDn scroll question");
+	});
+
+	it("opts structured deep-interview questions into local prompt scrolling", async () => {
+		spyOn(deepInterviewRecorder, "appendOrMergeDeepInterviewRound").mockResolvedValue({
+			action: "created",
+			record: {} as AppendOrMergeResult["record"],
+		});
+		spyOn(deepInterviewRecorder, "syncDeepInterviewRecorderHud").mockResolvedValue(undefined);
+		const tool = new AskTool(createSession({ getSessionId: () => "session-structured-scroll" }));
+		const rawQuestion = [
+			"The user-facing context is long enough that answer options can be pushed off screen.",
+			"",
+			"Which answer should prove the question area remains scrollable?",
+		].join("\n");
+		const select = vi.fn(
+			async (_prompt: string, options: string[], _dialogOptions?: { scrollTitleRows?: number; helpText?: string }) =>
+				options[0],
+		);
+		const context = createContext({ select });
+
+		await tool.execute(
+			"call-structured-deep-interview-scroll",
+			{
+				questions: [
+					{
+						id: "round-6",
+						question: rawQuestion,
+						options: [{ label: "Keep question scrolling" }, { label: "Regular selection" }],
+						deepInterview: {
+							round: 6,
+							component: "Selector UI",
+							dimension: "Readability",
+							ambiguity: 0.41,
+						},
 					},
 				],
 			},


### PR DESCRIPTION
## Summary
- Treat ask questions with structured `deepInterview` metadata as deep-interview prompts even when the visible text does not match the legacy header format.
- Enable local prompt scrolling and numbered options for those structured deep-interview asks.
- Add regression coverage for metadata-only deep-interview prompt scrolling.

## Verification
- `bun test packages/coding-agent/test/tools/ask.test.ts packages/coding-agent/test/hook-selector-overflow.test.ts packages/coding-agent/test/hook-selector-inline-input.test.ts`
- `bun run check` in `packages/coding-agent`