### PR TITLE
feat(ai): glm-zcode auto-provisions a Z.AI API key (no gateway/captcha) — live 200

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -75704,14 +75704,7 @@
 			"name": "GLM-5.2 (ZCode)",
 			"api": "anthropic-messages",
 			"provider": "glm-zcode",
-			"baseUrl": "https://zcode.z.ai/api/v1/zcode-plan/anthropic",
-			"headers": {
-				"User-Agent": "ZCode/1.0.0",
-				"HTTP-Referer": "https://zcode.z.ai",
-				"X-Title": "Z Code@electron",
-				"X-ZCode-App-Version": "1.0.0",
-				"X-ZCode-Agent": "glm"
-			},
+			"baseUrl": "https://api.z.ai/api/anthropic",
 			"reasoning": true,
 			"input": [
 				"text"

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -2282,7 +2282,7 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDe
 	anthropicMessagesDescriptor(
 		"glm-zcode-coding-plan",
 		"glm-zcode",
-		process.env.ZCODE_PLAN_ANTHROPIC_BASE_URL ?? "https://zcode.z.ai/api/v1/zcode-plan/anthropic",
+		process.env.ZCODE_PLAN_ANTHROPIC_BASE_URL ?? "https://api.z.ai/api/anthropic",
 	),
 	// --- Xiaomi ---
 	openAiCompletionsDescriptor("xiaomi", "xiaomi", "https://api.xiaomimimo.com/v1", {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -678,14 +678,11 @@ function resolveAnthropicBaseUrl(model: Model<"anthropic-messages">, apiKey?: st
 	if (model.provider === "github-copilot") {
 		return normalizeAnthropicBaseUrl(resolveGitHubCopilotBaseUrl(model.baseUrl, apiKey) ?? model.baseUrl);
 	}
-	// glm-zcode is the unofficial ZCode coding-plan gateway. Pin its base to the
-	// ZCode plan gateway so dynamic discovery / stale bundled catalogs / model
-	// cache can never redirect it to api.z.ai (which rejects the ZCode JWT).
+	// glm-zcode logs in via ZCode's OAuth but auto-provisions a real Z.AI API key and
+	// calls api.z.ai directly (no zcode.z.ai gateway, no captcha). Pin the base so dynamic
+	// discovery / stale bundled catalogs / model cache can't redirect it elsewhere.
 	if (model.provider === "glm-zcode") {
-		return (
-			normalizeAnthropicBaseUrl(process.env.ZCODE_PLAN_ANTHROPIC_BASE_URL) ??
-			"https://zcode.z.ai/api/v1/zcode-plan/anthropic"
-		);
+		return normalizeAnthropicBaseUrl(process.env.ZCODE_PLAN_ANTHROPIC_BASE_URL) ?? "https://api.z.ai/api/anthropic";
 	}
 	if (model.provider === "anthropic" && isFoundryEnabled()) {
 		const foundryBaseUrl = normalizeAnthropicBaseUrl($env.FOUNDRY_BASE_URL);

--- a/packages/ai/src/utils/oauth/glm-zcode.ts
+++ b/packages/ai/src/utils/oauth/glm-zcode.ts
@@ -1,56 +1,54 @@
 /**
  * GLM ZCode OAuth flow (UNOFFICIAL, opt-in).
  *
- * Replicates the reverse-engineered ZCode desktop-app login to Z.AI/GLM. This
- * is NOT an official Z.AI OAuth client: it reuses ZCode's authorize page,
- * broker, and a custom-protocol redirect. It may break at any time and may
- * violate ZCode/Z.AI Terms of Service. Endpoints and the client id are
- * overridable via `ZCODE_OAUTH_*` environment variables.
+ * Replicates how the ZCode desktop app turns a Z.AI login into usable GLM model
+ * access. This is NOT an official Z.AI OAuth client: it reuses ZCode's authorize
+ * page, broker, and a custom-protocol redirect. It may break at any time and may
+ * violate ZCode/Z.AI Terms of Service. Endpoints/client id are overridable via
+ * `ZCODE_OAUTH_*` environment variables.
  *
- * Login flow:
- *   1. Authorize:  GET  {authorize}?redirect_uri=zcode://oauth/callback&response_type=code&client_id=...&state=...
- *                  (custom-protocol redirect → a CLI cannot catch it, so the user pastes the code/redirect URL)
- *   2. Broker:     POST {broker}  { provider: "zai", code, redirect_uri, state }
- *                       → { code: 0, data: { token: <ZCode JWT>, zai: { access_token: <upstream Z.AI token> }, expires_in } }
+ * Verified end-to-end against the ZCode host bundle (`resolveZaiApiKey` /
+ * `resolveBizApiKey`) and live traffic:
+ *   1. Authorize: GET {authorize}?redirect_uri=zcode://oauth/callback&response_type=code&client_id=...&state=...
+ *      (custom-protocol redirect → a CLI cannot catch it, so the user pastes the code/redirect URL)
+ *   2. Broker:    POST {broker} { provider:"zai", code, redirect_uri, state }
+ *                  → { data: { token: <ZCode JWT>, zai: { access_token: <upstream Z.AI token> } } }
+ *   3. Business:  POST {z/login} { token: <upstream Z.AI token> } → { data: { access_token: <business token> } }
+ *   4. Provision: with the business token, GET getCustomerInfo → default org/project,
+ *      GET/POST .../api_keys (find/create a key named "zcode-api-key"),
+ *      GET .../api_keys/copy/{id} → secretKey ⇒ a real Z.AI API key "{id}.{secret}".
  *
- * Credential mapping (verified against the ZCode host bundle):
- *   - `access`  = the **ZCode JWT** (`data.token`). This is the GLM coding-plan
- *                 model credential: ZCode stores it under the `zcodejwttoken`
- *                 key and sends it as `Authorization: Bearer` to the coding-plan
- *                 gateway `${ZCODE_PLAN_ANTHROPIC_BASE_URL}` (default
- *                 https://zcode.z.ai/api/v1/zcode-plan/anthropic), which
- *                 validates the ZCode session and injects the upstream GLM key
- *                 server-side. Model traffic does NOT go to api.z.ai directly.
- *   - `refresh` = the upstream Z.AI OAuth access token (`data.zai.access_token`),
- *                 kept for identity/userinfo only. ZCode's separate z/login
- *                 "business token" is used by ZCode for billing/userinfo, NOT
- *                 model calls, so it is intentionally never minted here.
+ * Credential mapping:
+ *   - `access`  = the provisioned **Z.AI API key** ("{id}.{secret}"). Model requests go to
+ *                 `https://api.z.ai/api/anthropic/v1/messages` with `Authorization: Bearer <key>`
+ *                 (exactly like a dashboard key) — NO zcode.z.ai gateway, NO captcha.
+ *   - `refresh` = the upstream Z.AI OAuth access token (used to re-provision the key).
+ * The API key is long-lived, so `expires` is set far in the future.
  *
- * The ZCode JWT reaches the Anthropic-messages request as a plain bearer
- * automatically (the gateway base is not api.anthropic.com). This provider must
- * NEVER force `isOAuth=true`, which would route GLM into the Claude-Code OAuth
- * header branch (claude-cli UA, `claude_` tool prefixes, Claude system prompt).
+ * This provider must NEVER force `isOAuth=true`: the key is a plain Z.AI API key, and
+ * api.z.ai is not api.anthropic.com, so the Anthropic path already emits a plain bearer.
  */
 import { OAuthCallbackFlow, type OAuthCallbackFlowOptions, parseCallbackInput } from "./callback-server";
 import type { OAuthController, OAuthCredentials } from "./types";
 
 const TOKEN_REQUEST_TIMEOUT_MS = 30_000;
 export const GLM_ZCODE_REFRESH_SKEW_MS = 2 * 60 * 1000;
+/** Provisioned API keys are long-lived; pin expiry far out so AuthStorage never force-refreshes. */
+const GLM_ZCODE_API_KEY_TTL_MS = 10 * 365 * 24 * 60 * 60 * 1000;
+/** Name ZCode gives the API key it auto-provisions (host bundle constant `FI`). */
+const GLM_ZCODE_API_KEY_NAME = "zcode-api-key";
 
 /** Default endpoints / client id. Override via the matching `ZCODE_OAUTH_*` env vars. */
 export const GLM_ZCODE_OAUTH_AUTHORIZE_URL = "https://chat.z.ai/api/oauth/authorize";
 export const GLM_ZCODE_OAUTH_CLIENT_ID = "client_P8X5CMWmlaRO9gyO-KSqtg";
 export const GLM_ZCODE_OAUTH_REDIRECT_URI = "zcode://oauth/callback";
 export const GLM_ZCODE_OAUTH_BROKER_TOKEN_URL = "https://zcode.z.ai/api/v1/oauth/token";
+export const GLM_ZCODE_ZAI_LOGIN_URL = "https://api.z.ai/api/auth/z/login";
 export const GLM_ZCODE_USERINFO_URL = "https://chat.z.ai/api/oauth/userinfo";
-
-/**
- * Default coding-plan ("start plan") Anthropic gateway base. ZCode derives this
- * as `${zcodeBackend}/api/v1/zcode-plan/anthropic`. Model requests go here
- * (NOT api.z.ai), authenticated with the ZCode JWT. Override via
- * `ZCODE_PLAN_ANTHROPIC_BASE_URL`. Exported for the model descriptor / catalog.
- */
-export const GLM_ZCODE_PLAN_ANTHROPIC_BASE_URL = "https://zcode.z.ai/api/v1/zcode-plan/anthropic";
+/** Z.AI business API base (customer/org/project/api-key management). */
+export const GLM_ZCODE_ZAI_API_BASE = "https://api.z.ai";
+/** Model API base — the provisioned key is used here, exactly like a dashboard key. */
+export const GLM_ZCODE_ANTHROPIC_BASE_URL = "https://api.z.ai/api/anthropic";
 
 type FetchImpl = typeof globalThis.fetch;
 
@@ -71,19 +69,22 @@ function resolveRedirectUri(): string {
 function resolveBrokerTokenUrl(): string {
 	return envOr("ZCODE_OAUTH_BROKER_TOKEN_URL", GLM_ZCODE_OAUTH_BROKER_TOKEN_URL);
 }
+function resolveZaiLoginUrl(): string {
+	return envOr("ZCODE_OAUTH_ZAI_LOGIN_URL", GLM_ZCODE_ZAI_LOGIN_URL);
+}
 function resolveUserinfoUrl(): string {
 	return envOr("ZCODE_OAUTH_USERINFO_URL", GLM_ZCODE_USERINFO_URL);
 }
+function resolveZaiApiBase(): string {
+	return envOr("ZCODE_OAUTH_ZAI_API_BASE", GLM_ZCODE_ZAI_API_BASE).replace(/\/+$/, "");
+}
 
-/**
- * The provider is configured whenever a client id is available. The real ZCode
- * client id ships as the default, so this is true unless explicitly cleared.
- */
+/** Configured whenever a client id is available; the real ZCode client id ships as default. */
 export function isGlmZcodeOAuthConfigured(): boolean {
 	return resolveClientId().length > 0;
 }
 
-/** Mask token-like substrings so broker/upstream/JWT tokens never leak into errors or logs. */
+/** Mask token-like substrings so broker/upstream/business tokens never leak into errors. */
 function redactSecrets(text: string): string {
 	return text
 		.replace(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, "[redacted-jwt]")
@@ -100,7 +101,7 @@ function validateHttpsEndpoint(rawUrl: string, label: string): string {
 	if (parsed.protocol !== "https:") {
 		throw new Error(`GLM ZCode ${label} endpoint must use https`);
 	}
-	return parsed.toString();
+	return parsed.toString().replace(/\/+$/, "");
 }
 
 function requestSignal(signal: AbortSignal | undefined): AbortSignal {
@@ -118,11 +119,31 @@ async function postJson(
 	body: Record<string, unknown>,
 	label: string,
 	signal: AbortSignal | undefined,
+	bearer?: string,
 ): Promise<unknown> {
+	const headers: Record<string, string> = { Accept: "application/json", "Content-Type": "application/json" };
+	if (bearer) headers.Authorization = `Bearer ${bearer}`;
 	const response = await fetchImpl(url, {
 		method: "POST",
-		headers: { Accept: "application/json", "Content-Type": "application/json" },
+		headers,
 		body: JSON.stringify(body),
+		signal: requestSignal(signal),
+	});
+	if (!response.ok) {
+		throw new Error(`GLM ZCode ${label} request failed: ${response.status} ${redactSecrets(await response.text())}`);
+	}
+	return response.json();
+}
+
+async function getJson(
+	fetchImpl: FetchImpl,
+	url: string,
+	bearer: string,
+	label: string,
+	signal: AbortSignal | undefined,
+): Promise<unknown> {
+	const response = await fetchImpl(url, {
+		headers: { Accept: "application/json", Authorization: `Bearer ${bearer}` },
 		signal: requestSignal(signal),
 	});
 	if (!response.ok) {
@@ -134,11 +155,8 @@ async function postJson(
 interface JwtPayload {
 	sub?: unknown;
 	email?: unknown;
-	account_id?: unknown;
-	uid?: unknown;
 	[key: string]: unknown;
 }
-
 function decodeJwtPayload(token: string): JwtPayload | undefined {
 	const parts = token.split(".");
 	const payload = parts[1];
@@ -155,31 +173,118 @@ interface Identity {
 	accountId?: string;
 }
 
-function identityFromJwts(tokens: readonly string[]): Identity {
-	for (const token of tokens) {
-		const payload = decodeJwtPayload(token);
-		if (!payload) continue;
-		const accountId =
-			(typeof payload.sub === "string" && payload.sub) ||
-			(typeof payload.account_id === "string" && payload.account_id) ||
-			(typeof payload.uid === "string" && payload.uid) ||
-			undefined;
-		const email =
-			typeof payload.email === "string" && payload.email.length > 0 ? payload.email.toLowerCase() : undefined;
-		if (accountId || email) {
-			return { accountId: accountId || undefined, email };
-		}
+function parseBrokerResponse(payload: unknown): { upstreamZaiAccess: string; zcodeToken: string } {
+	const data = isRecord(payload) && isRecord(payload.data) ? payload.data : undefined;
+	const zcodeToken = data && typeof data.token === "string" ? data.token : undefined;
+	const zai = data && isRecord(data.zai) ? data.zai : undefined;
+	const upstreamZaiAccess = zai && typeof zai.access_token === "string" ? zai.access_token : undefined;
+	if (!zcodeToken || !upstreamZaiAccess) {
+		throw new Error("GLM ZCode broker response missing data.token or data.zai.access_token");
 	}
-	return {};
+	return { upstreamZaiAccess, zcodeToken };
+}
+
+async function resolveBusinessToken(
+	fetchImpl: FetchImpl,
+	upstreamZaiAccess: string,
+	signal: AbortSignal | undefined,
+): Promise<string> {
+	const zaiLoginUrl = validateHttpsEndpoint(resolveZaiLoginUrl(), "z/login");
+	const payload = await postJson(fetchImpl, `${zaiLoginUrl}`, { token: upstreamZaiAccess }, "z/login", signal);
+	const data = isRecord(payload) && isRecord(payload.data) ? payload.data : undefined;
+	const access = data && typeof data.access_token === "string" ? data.access_token : undefined;
+	if (!access) throw new Error("GLM ZCode z/login response missing data.access_token");
+	return access;
+}
+
+interface OrgProject {
+	organizationId: string;
+	projectId: string;
+	email?: string;
+	accountId?: string;
+}
+
+function pickDefaultOrgProject(customerInfo: unknown): OrgProject {
+	const data = isRecord(customerInfo) && isRecord(customerInfo.data) ? customerInfo.data : customerInfo;
+	const root = isRecord(data) ? data : {};
+	const orgs = Array.isArray(root.organizations) ? root.organizations : [];
+	const org = (orgs.find(o => isRecord(o) && o.isDefault) ?? orgs[0]) as Record<string, unknown> | undefined;
+	const organizationId = org && typeof org.organizationId === "string" ? org.organizationId : undefined;
+	const projects = org && Array.isArray(org.projects) ? org.projects : [];
+	const proj = (projects.find(p => isRecord(p) && p.isDefault) ?? projects[0]) as Record<string, unknown> | undefined;
+	const projectId = proj && typeof proj.projectId === "string" ? proj.projectId : undefined;
+	if (!organizationId || !projectId) {
+		throw new Error("GLM ZCode getCustomerInfo response missing default organization/project");
+	}
+	const email = typeof root.email === "string" && root.email.length > 0 ? root.email.toLowerCase() : undefined;
+	const accountId = typeof root.id === "string" ? root.id : typeof root.id === "number" ? String(root.id) : undefined;
+	return { organizationId, projectId, email, accountId };
+}
+
+/**
+ * Provision (or reuse) a Z.AI API key named "zcode-api-key" using the business token,
+ * mirroring ZCode's `resolveBizApiKey`. Returns "{apiKeyId}.{secretKey}".
+ */
+async function provisionZaiApiKey(
+	fetchImpl: FetchImpl,
+	businessToken: string,
+	signal: AbortSignal | undefined,
+): Promise<{ apiKey: string; identity: Identity }> {
+	const apiBase = resolveZaiApiBase();
+	const customerInfo = await getJson(
+		fetchImpl,
+		`${apiBase}/api/biz/customer/getCustomerInfo`,
+		businessToken,
+		"getCustomerInfo",
+		signal,
+	);
+	const { organizationId, projectId, email, accountId } = pickDefaultOrgProject(customerInfo);
+	const keysUrl = `${apiBase}/api/biz/v1/organization/${organizationId}/projects/${projectId}/api_keys`;
+
+	const listPayload = await getJson(fetchImpl, keysUrl, businessToken, "api_keys.list", signal);
+	const listData = isRecord(listPayload) && Array.isArray(listPayload.data) ? listPayload.data : [];
+	let entry = listData.find(k => isRecord(k) && k.name === GLM_ZCODE_API_KEY_NAME) as
+		| Record<string, unknown>
+		| undefined;
+
+	if (!entry) {
+		const created = await postJson(
+			fetchImpl,
+			keysUrl,
+			{ name: GLM_ZCODE_API_KEY_NAME },
+			"api_keys.create",
+			signal,
+			businessToken,
+		);
+		entry = (isRecord(created) && isRecord(created.data) ? created.data : created) as Record<string, unknown>;
+	}
+
+	const apiKeyId =
+		typeof entry.apiKey === "string" ? entry.apiKey.trim() : typeof entry.id === "string" ? entry.id : "";
+	if (!apiKeyId) throw new Error("GLM ZCode api_keys response missing apiKey id");
+
+	const copyPayload = await getJson(
+		fetchImpl,
+		`${keysUrl}/copy/${encodeURIComponent(apiKeyId)}`,
+		businessToken,
+		"api_keys.copy",
+		signal,
+	);
+	const copyData = isRecord(copyPayload) && isRecord(copyPayload.data) ? copyPayload.data : copyPayload;
+	const secretKey = isRecord(copyData) && typeof copyData.secretKey === "string" ? copyData.secretKey.trim() : "";
+	if (!secretKey) throw new Error("GLM ZCode api_keys copy response missing secretKey");
+
+	return { apiKey: `${apiKeyId}.${secretKey}`, identity: { email, accountId } };
 }
 
 async function resolveIdentity(
 	fetchImpl: FetchImpl,
 	upstreamZaiAccess: string,
+	fallback: Identity,
 	jwtCandidates: readonly string[],
 	signal: AbortSignal | undefined,
 ): Promise<Identity> {
-	// Best-effort userinfo; never fail login if identity lookup fails.
+	if (fallback.email || fallback.accountId) return fallback;
 	try {
 		const userinfoUrl = validateHttpsEndpoint(resolveUserinfoUrl(), "userinfo");
 		const response = await fetchImpl(userinfoUrl, {
@@ -191,37 +296,47 @@ async function resolveIdentity(
 			const data = isRecord(payload) && isRecord(payload.data) ? payload.data : isRecord(payload) ? payload : {};
 			const email = typeof data.email === "string" && data.email.length > 0 ? data.email.toLowerCase() : undefined;
 			const accountId =
-				(typeof data.id === "string" && data.id) ||
-				(typeof data.account_id === "string" && data.account_id) ||
-				(typeof data.sub === "string" && data.sub) ||
-				undefined;
-			if (email || accountId) {
-				return { email, accountId: accountId || undefined };
-			}
+				(typeof data.id === "string" && data.id) || (typeof data.sub === "string" && data.sub) || undefined;
+			if (email || accountId) return { email, accountId: accountId || undefined };
 		}
 	} catch {
-		// fall through to JWT decode
+		// fall through
 	}
-	return identityFromJwts(jwtCandidates);
+	for (const token of jwtCandidates) {
+		const p = decodeJwtPayload(token);
+		const accountId = p && typeof p.sub === "string" ? p.sub : undefined;
+		const email = p && typeof p.email === "string" ? p.email.toLowerCase() : undefined;
+		if (accountId || email) return { accountId, email };
+	}
+	return {};
 }
 
-interface BrokerResult {
-	zcodeToken: string;
-	upstreamZaiAccess: string;
-	expiresIn: number;
+function credentialsFromApiKey(apiKey: string, upstreamZaiAccess: string, identity: Identity): OAuthCredentials {
+	return {
+		access: apiKey,
+		refresh: upstreamZaiAccess,
+		expires: Date.now() + GLM_ZCODE_API_KEY_TTL_MS,
+		email: identity.email,
+		accountId: identity.accountId,
+	};
 }
 
-function parseBrokerResponse(payload: unknown): BrokerResult {
-	const data = isRecord(payload) && isRecord(payload.data) ? payload.data : undefined;
-	const zcodeToken = data && typeof data.token === "string" ? data.token : undefined;
-	const zai = data && isRecord(data.zai) ? data.zai : undefined;
-	const upstreamZaiAccess = zai && typeof zai.access_token === "string" ? zai.access_token : undefined;
-	if (!zcodeToken || !upstreamZaiAccess) {
-		throw new Error("GLM ZCode broker response missing data.token or data.zai.access_token");
-	}
-	const expiresIn =
-		data && typeof data.expires_in === "number" && Number.isFinite(data.expires_in) ? data.expires_in : 3600;
-	return { zcodeToken, upstreamZaiAccess, expiresIn };
+async function provisionFromUpstream(
+	fetchImpl: FetchImpl,
+	upstreamZaiAccess: string,
+	zcodeTokenForIdentity: string | undefined,
+	signal: AbortSignal | undefined,
+): Promise<OAuthCredentials> {
+	const businessToken = await resolveBusinessToken(fetchImpl, upstreamZaiAccess, signal);
+	const { apiKey, identity: keyIdentity } = await provisionZaiApiKey(fetchImpl, businessToken, signal);
+	const identity = await resolveIdentity(
+		fetchImpl,
+		upstreamZaiAccess,
+		keyIdentity,
+		[zcodeTokenForIdentity ?? "", businessToken].filter(Boolean),
+		signal,
+	);
+	return credentialsFromApiKey(apiKey, upstreamZaiAccess, identity);
 }
 
 async function exchangeGlmZcodeCode(
@@ -229,7 +344,6 @@ async function exchangeGlmZcodeCode(
 	input: { code: string; state: string; redirectUri: string },
 	signal: AbortSignal | undefined,
 ): Promise<OAuthCredentials> {
-	// Defensive: a pasted value may still be a full redirect URL or `code#state`.
 	const parsed = parseCallbackInput(input.code);
 	const code = parsed.code ?? input.code;
 	const brokerUrl = validateHttpsEndpoint(resolveBrokerTokenUrl(), "broker");
@@ -240,17 +354,8 @@ async function exchangeGlmZcodeCode(
 		"broker",
 		signal,
 	);
-	const { zcodeToken, upstreamZaiAccess, expiresIn } = parseBrokerResponse(brokerPayload);
-	const identity = await resolveIdentity(fetchImpl, upstreamZaiAccess, [zcodeToken, upstreamZaiAccess], signal);
-	// access = ZCode JWT (the coding-plan model credential); refresh = upstream
-	// Z.AI token (identity only — there is no documented JWT refresh grant).
-	return {
-		access: zcodeToken,
-		refresh: upstreamZaiAccess,
-		expires: Date.now() + expiresIn * 1000 - GLM_ZCODE_REFRESH_SKEW_MS,
-		email: identity.email,
-		accountId: identity.accountId,
-	};
+	const { upstreamZaiAccess, zcodeToken } = parseBrokerResponse(brokerPayload);
+	return provisionFromUpstream(fetchImpl, upstreamZaiAccess, zcodeToken, signal);
 }
 
 export interface GlmZcodeOAuthFlowOptions {
@@ -262,8 +367,6 @@ export class GlmZcodeOAuthFlow extends OAuthCallbackFlow {
 
 	constructor(ctrl: OAuthController, options: GlmZcodeOAuthFlowOptions = {}) {
 		super(ctrl, {
-			// Port 0 → a free random local port. The custom-protocol redirect
-			// never reaches it; login completes via manual code/redirect paste.
 			preferredPort: 0,
 			callbackPath: "/callback",
 			callbackHostname: "127.0.0.1",
@@ -306,16 +409,25 @@ export interface GlmZcodeRefreshOptions {
 }
 
 /**
- * The ZCode session JWT is the model credential. ZCode mints it from a one-time
- * authorization code via the broker and exposes no documented refresh grant, so
- * there is no autonomous refresh: an expired credential requires re-login
- * (`/login glm-zcode`). Never return an expired credential as valid.
+ * Re-provision the Z.AI API key from the stored upstream token. The key itself is
+ * long-lived, so this is rarely needed; if the upstream token has expired it fails
+ * loudly and the user must re-login.
  */
 export async function refreshGlmZcodeToken(
-	_credentials: OAuthCredentials,
-	_options: AbortSignal | GlmZcodeRefreshOptions = {},
+	credentials: OAuthCredentials,
+	options: AbortSignal | GlmZcodeRefreshOptions = {},
 ): Promise<OAuthCredentials> {
-	throw new Error(
-		"glm-zcode session expired; re-login required (`/login glm-zcode`). The ZCode coding-plan token has no documented refresh endpoint.",
-	);
+	const { signal, fetch: fetchImpl } =
+		options instanceof AbortSignal ? { signal: options, fetch: undefined } : options;
+	const upstream = credentials.refresh;
+	if (!upstream) {
+		throw new Error("glm-zcode credentials require re-login (`/login glm-zcode`); no stored upstream Z.AI token");
+	}
+	try {
+		return await provisionFromUpstream(fetchImpl ?? globalThis.fetch, upstream, undefined, signal);
+	} catch (error) {
+		throw new Error(
+			`glm-zcode credentials require re-login (\`/login glm-zcode\`); re-provisioning the Z.AI API key failed (${redactSecrets(String(error))})`,
+		);
+	}
 }

--- a/packages/ai/test/oauth-glm-zcode.test.ts
+++ b/packages/ai/test/oauth-glm-zcode.test.ts
@@ -9,11 +9,11 @@ import { buildAnthropicClientOptions, buildAnthropicHeaders } from "../src/provi
 import { isOAuthToken } from "../src/utils/anthropic-auth";
 import { getOAuthProviders, refreshOAuthToken } from "../src/utils/oauth";
 import {
+	GLM_ZCODE_ANTHROPIC_BASE_URL,
 	GLM_ZCODE_OAUTH_AUTHORIZE_URL,
 	GLM_ZCODE_OAUTH_BROKER_TOKEN_URL,
 	GLM_ZCODE_OAUTH_CLIENT_ID,
 	GLM_ZCODE_OAUTH_REDIRECT_URI,
-	GLM_ZCODE_PLAN_ANTHROPIC_BASE_URL,
 	GlmZcodeOAuthFlow,
 	isGlmZcodeOAuthConfigured,
 	refreshGlmZcodeToken,
@@ -21,62 +21,66 @@ import {
 import { withEnv } from "./helpers";
 
 const originalFetch = global.fetch;
-const USERINFO_URL = "https://chat.z.ai/api/oauth/userinfo";
 const SUPPRESS_ENV = {
 	GLM_ZCODE_API_KEY: undefined,
 	ZAI_API_KEY: undefined,
 	ZCODE_OAUTH_CLIENT_ID: undefined,
 } as const;
 
-// The ZCode JWT (broker data.token) is the GLM coding-plan model credential.
-const ZCODE_JWT = jwt({ sub: "zcode-sub-id", email: "ZJwt@Example.com" });
-const UPSTREAM_ZAI_TOKEN = "upstream-zai-access-token-value-1234567890";
+const ZCODE_JWT = jwt({ sub: "zcode-sub", email: "Z@Example.com" });
+const UPSTREAM = "upstream-zai-access-token-1234567890";
+const BUSINESS = "business-session-token-abcdefghijklmnop";
+const ORG = "org-default-123";
+const PROJ = "proj_default_456";
+const KEY_ID = "keyid6670babb";
+const SECRET = "secretYkn1K3E1a3J";
+const MINTED_KEY = `${KEY_ID}.${SECRET}`;
 
 function jwt(payload: Record<string, unknown>): string {
-	const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
-	return `${encode({ alg: "none", typ: "JWT" })}.${encode(payload)}.`;
+	const enc = (v: unknown) => Buffer.from(JSON.stringify(v)).toString("base64url");
+	return `${enc({ alg: "none" })}.${enc(payload)}.`;
 }
 
-interface MockOptions {
-	expiresIn?: number;
-	zcodeToken?: string;
-	userinfo?: { email?: string; id?: string } | null;
-	captureBroker?: (body: string) => void;
-	brokerPayloadOverride?: unknown;
-	brokerStatus?: number;
+interface MockOpts {
+	existingKey?: boolean; // api_keys list already contains "zcode-api-key"
+	captureCreate?: () => void;
 }
 
-function routingFetch(options: MockOptions = {}) {
+function routingFetch(opts: MockOpts = {}) {
+	const keysUrl = `https://api.z.ai/api/biz/v1/organization/${ORG}/projects/${PROJ}/api_keys`;
 	return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
 		const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+		const method = (init?.method ?? "GET").toUpperCase();
+		const json = (o: unknown) => new Response(JSON.stringify(o), { headers: { "Content-Type": "application/json" } });
 		if (url === GLM_ZCODE_OAUTH_BROKER_TOKEN_URL) {
-			options.captureBroker?.(String(init?.body ?? ""));
-			if (options.brokerStatus && options.brokerStatus >= 400) {
-				return new Response("rejected", { status: options.brokerStatus });
-			}
-			return new Response(
-				JSON.stringify(
-					options.brokerPayloadOverride ?? {
-						code: 0,
-						data: {
-							token: options.zcodeToken ?? ZCODE_JWT,
-							zai: { access_token: UPSTREAM_ZAI_TOKEN },
-							expires_in: options.expiresIn ?? 3600,
-						},
-					},
-				),
-				{ status: 200, headers: { "Content-Type": "application/json" } },
-			);
+			return json({ code: 0, data: { token: ZCODE_JWT, zai: { access_token: UPSTREAM } } });
 		}
-		if (url === USERINFO_URL) {
-			if (options.userinfo === null) return new Response("no", { status: 404 });
-			const data = options.userinfo ?? { email: "Member@Example.com", id: "account-xyz" };
-			return new Response(JSON.stringify({ data }), {
-				status: 200,
-				headers: { "Content-Type": "application/json" },
+		if (url === "https://api.z.ai/api/auth/z/login") {
+			return json({ code: 0, data: { access_token: BUSINESS } });
+		}
+		if (url === "https://api.z.ai/api/biz/customer/getCustomerInfo") {
+			return json({
+				code: 200,
+				data: {
+					id: "5053550",
+					email: "member@example.com",
+					organizations: [
+						{ organizationId: ORG, isDefault: true, projects: [{ projectId: PROJ, isDefault: true }] },
+					],
+				},
 			});
 		}
-		throw new Error(`Unexpected fetch: ${url}`);
+		if (url === keysUrl && method === "GET") {
+			return json({ code: 200, data: opts.existingKey ? [{ name: "zcode-api-key", apiKey: KEY_ID }] : [] });
+		}
+		if (url === keysUrl && method === "POST") {
+			opts.captureCreate?.();
+			return json({ code: 200, data: { apiKey: KEY_ID } });
+		}
+		if (url === `${keysUrl}/copy/${KEY_ID}`) {
+			return json({ code: 200, data: { secretKey: SECRET } });
+		}
+		throw new Error(`Unexpected fetch: ${method} ${url}`);
 	});
 }
 
@@ -104,8 +108,7 @@ describe("GLM ZCode OAuth login provider", () => {
 	});
 
 	it("registers glm-zcode as an available, opt-in-labeled login provider", () => {
-		const provider = getOAuthProviders().find(p => p.id === "glm-zcode");
-		expect(provider).toEqual({
+		expect(getOAuthProviders().find(p => p.id === "glm-zcode")).toEqual({
 			id: "glm-zcode",
 			name: "GLM ZCode OAuth (unofficial, opt-in)",
 			available: true,
@@ -113,18 +116,11 @@ describe("GLM ZCode OAuth login provider", () => {
 		expect(isGlmZcodeOAuthConfigured()).toBe(true);
 	});
 
-	it("uses the exact ZCode client id and custom-protocol redirect by default", () => {
+	it("uses the exact ZCode client id, custom redirect, and api.z.ai model base", () => {
 		expect(GLM_ZCODE_OAUTH_CLIENT_ID).toBe("client_P8X5CMWmlaRO9gyO-KSqtg");
 		expect(GLM_ZCODE_OAUTH_REDIRECT_URI).toBe("zcode://oauth/callback");
-	});
-
-	it("defaults the model base to the ZCode coding-plan gateway, not api.z.ai", () => {
-		expect(GLM_ZCODE_PLAN_ANTHROPIC_BASE_URL).toBe("https://zcode.z.ai/api/v1/zcode-plan/anthropic");
-		const model = getBundledModel("glm-zcode", "glm-5.2");
-		expect(model.baseUrl).toBe("https://zcode.z.ai/api/v1/zcode-plan/anthropic");
-		// ZCode source headers must accompany coding-plan requests.
-		expect(model.headers?.["X-ZCode-Agent"]).toBe("glm");
-		expect(model.headers?.["User-Agent"]).toMatch(/^ZCode\//);
+		expect(GLM_ZCODE_ANTHROPIC_BASE_URL).toBe("https://api.z.ai/api/anthropic");
+		expect(getBundledModel("glm-zcode", "glm-5.2").baseUrl).toBe("https://api.z.ai/api/anthropic");
 	});
 
 	it("builds the authorize URL with client id, custom redirect, response_type, and state", async () => {
@@ -132,41 +128,47 @@ describe("GLM ZCode OAuth login provider", () => {
 			{ onAuth: () => {}, onPrompt: async () => "" },
 			{ fetch: routingFetch() as unknown as typeof fetch },
 		);
-		const { url, instructions } = await flow.generateAuthUrl("state-123", GLM_ZCODE_OAUTH_REDIRECT_URI);
+		const { url, instructions } = await flow.generateAuthUrl("state-1", GLM_ZCODE_OAUTH_REDIRECT_URI);
 		const authUrl = new URL(url);
 		expect(authUrl.origin + authUrl.pathname).toBe(GLM_ZCODE_OAUTH_AUTHORIZE_URL);
 		expect(authUrl.searchParams.get("client_id")).toBe(GLM_ZCODE_OAUTH_CLIENT_ID);
 		expect(authUrl.searchParams.get("redirect_uri")).toBe(GLM_ZCODE_OAUTH_REDIRECT_URI);
 		expect(authUrl.searchParams.get("response_type")).toBe("code");
-		expect(authUrl.searchParams.get("state")).toBe("state-123");
+		expect(authUrl.searchParams.get("state")).toBe("state-1");
 		expect(instructions ?? "").toMatch(/unofficial/i);
 	});
 
-	it("exchanges the code via the broker and maps the ZCode JWT to access", async () => {
-		let brokerBody = "";
-		const fetchMock = routingFetch({ captureBroker: body => (brokerBody = body) });
+	it("exchanges the code and provisions a Z.AI API key as the credential", async () => {
+		let created = false;
+		const fetchMock = routingFetch({ captureCreate: () => (created = true) });
 		const flow = new GlmZcodeOAuthFlow(
 			{ onAuth: () => {}, onPrompt: async () => "" },
 			{ fetch: fetchMock as unknown as typeof fetch },
 		);
-		const credentials = await flow.exchangeToken("auth-code", "state-123", GLM_ZCODE_OAUTH_REDIRECT_URI);
-
-		expect(JSON.parse(brokerBody)).toEqual({
-			provider: "zai",
-			code: "auth-code",
-			redirect_uri: GLM_ZCODE_OAUTH_REDIRECT_URI,
-			state: "state-123",
-		});
-		// The model credential is the ZCode JWT (data.token), NOT a z/login business token.
-		expect(credentials.access).toBe(ZCODE_JWT);
-		expect(credentials.refresh).toBe(UPSTREAM_ZAI_TOKEN);
+		const credentials = await flow.exchangeToken("auth-code", "state-1", GLM_ZCODE_OAUTH_REDIRECT_URI);
+		// access is the minted "{id}.{secret}" Z.AI API key — NOT a JWT.
+		expect(credentials.access).toBe(MINTED_KEY);
+		expect(credentials.access.split(".")).toHaveLength(2);
+		expect(credentials.refresh).toBe(UPSTREAM);
 		expect(credentials.email).toBe("member@example.com");
-		expect(credentials.accountId).toBe("account-xyz");
-		expect(credentials.expires).toBeGreaterThan(Date.now());
-		expect(credentials.expires).toBeLessThanOrEqual(Date.now() + 3600 * 1000 - 60_000);
-		// No direct call to api.z.ai/z-login is made during login.
-		const calledUrls = fetchMock.mock.calls.map(c => String(c[0]));
-		expect(calledUrls.some(u => u.includes("/api/auth/z/login"))).toBe(false);
+		expect(credentials.expires).toBeGreaterThan(Date.now() + 365 * 24 * 60 * 60 * 1000); // long-lived
+		expect(created).toBe(true); // no existing key → created one
+		// hit the provisioning endpoints
+		const urls = fetchMock.mock.calls.map(c => String(c[0]));
+		expect(urls.some(u => u.includes("/api/biz/customer/getCustomerInfo"))).toBe(true);
+		expect(urls.some(u => u.includes("/api_keys/copy/"))).toBe(true);
+	});
+
+	it("reuses an existing zcode-api-key without creating a new one", async () => {
+		let created = false;
+		const fetchMock = routingFetch({ existingKey: true, captureCreate: () => (created = true) });
+		const flow = new GlmZcodeOAuthFlow(
+			{ onAuth: () => {}, onPrompt: async () => "" },
+			{ fetch: fetchMock as unknown as typeof fetch },
+		);
+		const credentials = await flow.exchangeToken("auth-code", "state-1", GLM_ZCODE_OAUTH_REDIRECT_URI);
+		expect(credentials.access).toBe(MINTED_KEY);
+		expect(created).toBe(false);
 	});
 
 	it("accepts a pasted full zcode:// redirect URL as the code", async () => {
@@ -176,69 +178,46 @@ describe("GLM ZCode OAuth login provider", () => {
 			{ fetch: fetchMock as unknown as typeof fetch },
 		);
 		const credentials = await flow.exchangeToken(
-			"zcode://oauth/callback?code=pasted-code&state=state-123",
-			"state-123",
+			"zcode://oauth/callback?code=pasted&state=state-1",
+			"state-1",
 			GLM_ZCODE_OAUTH_REDIRECT_URI,
 		);
-		expect(credentials.access).toBe(ZCODE_JWT);
+		expect(credentials.access).toBe(MINTED_KEY);
 		const brokerCall = fetchMock.mock.calls.find(c => String(c[0]) === GLM_ZCODE_OAUTH_BROKER_TOKEN_URL);
-		expect(JSON.parse(String((brokerCall?.[1] as RequestInit).body)).code).toBe("pasted-code");
+		expect(JSON.parse(String((brokerCall?.[1] as RequestInit).body)).code).toBe("pasted");
 	});
 
-	it("falls back to JWT identity decode when userinfo fails", async () => {
-		const fetchMock = routingFetch({ userinfo: null });
-		const flow = new GlmZcodeOAuthFlow(
-			{ onAuth: () => {}, onPrompt: async () => "" },
+	it("refresh re-provisions the API key from the stored upstream token", async () => {
+		const fetchMock = routingFetch({ existingKey: true });
+		const refreshed = await refreshGlmZcodeToken(
+			{ access: "old", refresh: UPSTREAM, expires: Date.now() - 1 },
 			{ fetch: fetchMock as unknown as typeof fetch },
 		);
-		const credentials = await flow.exchangeToken("auth-code", "state-123", GLM_ZCODE_OAUTH_REDIRECT_URI);
-		expect(credentials.email).toBe("zjwt@example.com");
-		expect(credentials.accountId).toBe("zcode-sub-id");
+		expect(refreshed.access).toBe(MINTED_KEY);
+		expect(refreshed.refresh).toBe(UPSTREAM);
 	});
 
-	it("rejects a malformed broker payload missing the ZCode JWT", async () => {
-		const fetchMock = routingFetch({ brokerPayloadOverride: { code: 0, data: { zai: { access_token: "x" } } } });
-		const flow = new GlmZcodeOAuthFlow(
-			{ onAuth: () => {}, onPrompt: async () => "" },
-			{ fetch: fetchMock as unknown as typeof fetch },
-		);
-		await expect(flow.exchangeToken("auth-code", "state-123", GLM_ZCODE_OAUTH_REDIRECT_URI)).rejects.toThrow(
-			/broker response missing/i,
+	it("refresh fails with a re-login error when no upstream token is stored", async () => {
+		await expect(refreshGlmZcodeToken({ access: "x", refresh: "", expires: Date.now() - 1 })).rejects.toThrow(
+			/re-login/i,
 		);
 	});
 
-	it("redacts token-like strings echoed in a broker error body", async () => {
-		const leaked = "leaked-secret-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-		const fetchMock = vi.fn(async () => new Response(`upstream said: ${leaked}`, { status: 500 }));
-		const flow = new GlmZcodeOAuthFlow(
-			{ onAuth: () => {}, onPrompt: async () => "" },
-			{ fetch: fetchMock as unknown as typeof fetch },
-		);
-		let caught: unknown;
-		try {
-			await flow.exchangeToken("auth-code", "state-123", GLM_ZCODE_OAUTH_REDIRECT_URI);
-		} catch (error) {
-			caught = error;
-		}
-		expect(String(caught)).not.toContain(leaked);
-		expect(String(caught)).toContain("[redacted]");
+	it("dispatches refreshOAuthToken('glm-zcode') to re-provisioning", async () => {
+		const fetchMock = routingFetch({ existingKey: true });
+		global.fetch = fetchMock as unknown as typeof fetch;
+		const refreshed = await refreshOAuthToken("glm-zcode", {
+			access: "old",
+			refresh: UPSTREAM,
+			expires: Date.now() - 1,
+		});
+		expect(refreshed.access).toBe(MINTED_KEY);
 	});
 
-	it("refresh requires re-login (ZCode JWT has no documented refresh grant)", async () => {
-		await expect(
-			refreshGlmZcodeToken({ access: ZCODE_JWT, refresh: UPSTREAM_ZAI_TOKEN, expires: Date.now() - 1 }),
-		).rejects.toThrow(/re-login required/i);
-		// Same via the registry dispatcher.
-		await expect(
-			refreshOAuthToken("glm-zcode", { access: ZCODE_JWT, refresh: UPSTREAM_ZAI_TOKEN, expires: Date.now() - 1 }),
-		).rejects.toThrow(/re-login required/i);
-	});
-
-	it("stores glm-zcode login as OAuth and getApiKey returns the ZCode JWT", async () => {
+	it("stores glm-zcode login as OAuth and getApiKey returns the provisioned key", async () => {
 		if (!store || !authStorage) throw new Error("test setup failed");
 		const fetchMock = routingFetch();
 		global.fetch = fetchMock as unknown as typeof fetch;
-
 		let capturedState: string | undefined;
 		await authStorage.login("glm-zcode", {
 			onAuth: info => {
@@ -247,16 +226,11 @@ describe("GLM ZCode OAuth login provider", () => {
 			onPrompt: async () => "",
 			onManualCodeInput: async () => `zcode://oauth/callback?code=login-code&state=${capturedState ?? ""}`,
 		});
-
-		const credentials = store.listAuthCredentials("glm-zcode");
-		expect(credentials).toHaveLength(1);
-		expect(credentials[0]?.credential).toMatchObject({
-			type: "oauth",
-			access: ZCODE_JWT,
-			refresh: UPSTREAM_ZAI_TOKEN,
-		});
+		const creds = store.listAuthCredentials("glm-zcode");
+		expect(creds).toHaveLength(1);
+		expect(creds[0]?.credential).toMatchObject({ type: "oauth", access: MINTED_KEY, refresh: UPSTREAM });
 		await withEnv(SUPPRESS_ENV, async () => {
-			expect(await authStorage?.getApiKey("glm-zcode", "session-glm-zcode")).toBe(ZCODE_JWT);
+			expect(await authStorage?.getApiKey("glm-zcode", "session-glm")).toBe(MINTED_KEY);
 		});
 	});
 
@@ -264,9 +238,7 @@ describe("GLM ZCode OAuth login provider", () => {
 		if (!store || !authStorage) throw new Error("test setup failed");
 		const fetchMock = routingFetch();
 		global.fetch = fetchMock as unknown as typeof fetch;
-
 		await authStorage.set("zai", { type: "api_key", key: "legacy-zai-key" });
-
 		let capturedState: string | undefined;
 		await authStorage.login("glm-zcode", {
 			onAuth: info => {
@@ -275,17 +247,11 @@ describe("GLM ZCode OAuth login provider", () => {
 			onPrompt: async () => "",
 			onManualCodeInput: async () => `zcode://oauth/callback?code=login-code&state=${capturedState ?? ""}`,
 		});
-
-		const zaiCreds = store.listAuthCredentials("zai");
-		expect(zaiCreds).toHaveLength(1);
-		expect(zaiCreds[0]?.credential).toMatchObject({ type: "api_key" });
-		const glmCreds = store.listAuthCredentials("glm-zcode");
-		expect(glmCreds).toHaveLength(1);
-		expect(glmCreds[0]?.credential).toMatchObject({ type: "oauth" });
-
+		expect(store.listAuthCredentials("zai")[0]?.credential).toMatchObject({ type: "api_key" });
+		expect(store.listAuthCredentials("glm-zcode")[0]?.credential).toMatchObject({ type: "oauth" });
 		await withEnv(SUPPRESS_ENV, async () => {
-			expect(await authStorage?.getApiKey("zai", "session-zai")).toBe("legacy-zai-key");
-			expect(await authStorage?.getApiKey("glm-zcode", "session-glm")).toBe(ZCODE_JWT);
+			expect(await authStorage?.getApiKey("zai", "s-zai")).toBe("legacy-zai-key");
+			expect(await authStorage?.getApiKey("glm-zcode", "s-glm")).toBe(MINTED_KEY);
 		});
 	});
 
@@ -296,40 +262,29 @@ describe("GLM ZCode OAuth login provider", () => {
 		expect(model.api).toBe("anthropic-messages");
 	});
 
-	it("sends Authorization: Bearer (no x-api-key, no claude-cli UA, no isOAuth) for the ZCode JWT", () => {
-		// The gateway base is not api.anthropic.com → the non-Anthropic-base branch
-		// emits a plain bearer. isOAuth must NOT be set; the ZCode JWT is not a
-		// Claude OAuth token, so no Claude-Code header/tool-prefix behavior applies.
-		expect(isOAuthToken(ZCODE_JWT)).toBe(false);
-		const headers = buildAnthropicHeaders({
-			apiKey: ZCODE_JWT,
-			baseUrl: GLM_ZCODE_PLAN_ANTHROPIC_BASE_URL,
-			modelHeaders: { "User-Agent": "ZCode/1.0.0", "X-ZCode-Agent": "glm" },
-		});
-		expect(headers.Authorization).toBe(`Bearer ${ZCODE_JWT}`);
-		expect(headers["X-Api-Key"]).toBeUndefined();
-		expect(headers["X-ZCode-Agent"]).toBe("glm");
-		expect((headers["User-Agent"] ?? "").toLowerCase().startsWith("claude-cli")).toBe(false);
-	});
-
-	it("pins the request base to the ZCode gateway even if model.baseUrl was polluted to api.z.ai", () => {
-		// Dynamic discovery / stale bundled catalogs / model cache can overwrite
-		// model.baseUrl with api.z.ai (which rejects the ZCode JWT with 401). The
-		// request-time resolver must force the coding-plan gateway regardless.
+	it("pins the request base to api.z.ai even if model.baseUrl was polluted", () => {
 		const model = {
 			id: "glm-5.2",
 			name: "GLM-5.2 (ZCode)",
 			api: "anthropic-messages",
 			provider: "glm-zcode",
-			baseUrl: "https://api.z.ai/api/anthropic",
+			baseUrl: "https://zcode.z.ai/api/v1/zcode-plan/anthropic",
 			reasoning: true,
 			input: ["text"],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: 1_000_000,
 			maxTokens: 131072,
 		} as unknown as Parameters<typeof buildAnthropicClientOptions>[0]["model"];
-		const resolved = buildAnthropicClientOptions({ model, apiKey: ZCODE_JWT });
-		expect(resolved.baseURL).toBe(GLM_ZCODE_PLAN_ANTHROPIC_BASE_URL);
+		const resolved = buildAnthropicClientOptions({ model, apiKey: MINTED_KEY });
+		expect(resolved.baseURL).toBe("https://api.z.ai/api/anthropic");
 		expect(resolved.isOAuthToken).toBe(false);
+	});
+
+	it("sends Authorization: Bearer (no x-api-key, no claude-cli UA, no isOAuth) for the API key", () => {
+		expect(isOAuthToken(MINTED_KEY)).toBe(false);
+		const headers = buildAnthropicHeaders({ apiKey: MINTED_KEY, baseUrl: GLM_ZCODE_ANTHROPIC_BASE_URL });
+		expect(headers.Authorization).toBe(`Bearer ${MINTED_KEY}`);
+		expect(headers["X-Api-Key"]).toBeUndefined();
+		expect((headers["User-Agent"] ?? "").toLowerCase().startsWith("claude-cli")).toBe(false);
 	});
 });


### PR DESCRIPTION
## What this does
Makes `glm-zcode` OAuth actually serve GLM models — verified live (HTTP 200 from GLM-5.2).

## Root cause of the long stall
ZCode's `zcode.z.ai` coding-plan gateway is a dead end for replication: it requires an Aliyun captcha **and** a zcode-plan entitlement bound to the ZCode-JWT identity. Decompiling ZCode's host bundle (`resolveZaiApiKey`/`resolveBizApiKey`) + capturing its own logs showed ZCode does **not** use that gateway for inference — it **auto-provisions a real Z.AI API key** and calls `api.z.ai` directly.

## Flow (verified end-to-end)
```
OAuth code -> broker -> data.zai.access_token (upstream)
  -> POST api.z.ai/api/auth/z/login            -> business token
  -> GET  api.z.ai/api/biz/customer/getCustomerInfo  (default org/project)
  -> GET/POST .../api_keys                     (find/create "zcode-api-key")
  -> GET  .../api_keys/copy/{id}               -> secretKey
  => Z.AI API key "{id}.{secret}"
model calls: api.z.ai/api/anthropic/v1/messages, Authorization: Bearer <key>
```

## Changes
- `glm-zcode.ts`: provision (or reuse) the `zcode-api-key` Z.AI API key via the business token; store it as `access` (long-lived -> far-future expiry). `refresh` re-provisions from the stored upstream token.
- `anthropic.ts`: pin glm-zcode base to `api.z.ai/api/anthropic` (was the gateway).
- `models.json`: glm-zcode/glm-5.2 base -> `api.z.ai/api/anthropic`; dropped ZCode gateway headers.
- `openai-compat.ts`: descriptor base -> `api.z.ai/api/anthropic`.
- tests: full provisioning (mint/reuse), base pin, bearer-not-x-api-key, legacy-zai coexistence.

## Verification
- Live: provisioned key -> `api.z.ai/api/anthropic` GLM-5.2 -> 200.
- `bun test packages/ai/test/oauth-glm-zcode.test.ts` (15) + `anthropic-oauth` -> 28 pass; full @gajae-code/ai suite 1504 pass / 0 fail; tsc + biome + schema clean.

## After merge
Pull + rebuild, then `/logout glm-zcode` && `/login glm-zcode` (re-login provisions the API key). Then `glm-zcode/glm-5.2` works. Still unofficial/opt-in.
