### PR TITLE
feat(ai): send ZCode client source headers on glm-zcode requests (exact match)

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1,5 +1,6 @@
 import * as nodeCrypto from "node:crypto";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import { scheduler } from "node:timers/promises";
 import * as tls from "node:tls";
 import Anthropic, { type ClientOptions as AnthropicSdkClientOptions } from "@anthropic-ai/sdk";
@@ -93,6 +94,13 @@ export type AnthropicHeaderOptions = {
 	stream?: boolean;
 	modelHeaders?: Record<string, string>;
 	isCloudflareAiGateway?: boolean;
+	/**
+	 * Attach ZCode client "source" headers (User-Agent: ZCode/<ver>, X-Title,
+	 * X-ZCode-Agent: glm, X-Platform, etc.) so api.z.ai recognizes the caller as
+	 * the ZCode client, exactly like ZCode's `buildZCodeSourceHeaders` does for
+	 * GLM providers. glm-zcode only.
+	 */
+	zcodeSourceHeaders?: boolean;
 };
 
 export function normalizeAnthropicBaseUrl(baseUrl?: string): string | undefined {
@@ -161,6 +169,67 @@ const sharedHeaders = {
 	"X-App": "cli",
 };
 
+// ZCode bakes its app version and runtime env at build time. Mirror the values
+// from the analyzed ZCode 3.1.2 desktop bundle (`resolveRuntimeZCodeEnv` returns
+// "production" for non-test builds). Both are overridable for forward-compat.
+const ZCODE_APP_VERSION = process.env.ZCODE_APP_VERSION?.trim() || "3.1.2";
+const ZCODE_RELEASE_CHANNEL = process.env.ZCODE_RELEASE_CHANNEL?.trim() || "production";
+
+// Mirrors ZCode's `normalizePrintableHeaderValue`: only printable ASCII passes.
+function normalizePrintableHeaderValue(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	if (trimmed && /^[\x20-\x7e]+$/.test(trimmed)) return trimmed;
+	return undefined;
+}
+
+// Mirrors ZCode's `normalizeOsCategory`.
+function normalizeOsCategory(platform: NodeJS.Platform): string {
+	switch (platform) {
+		case "darwin":
+			return "macos";
+		case "win32":
+			return "windows";
+		default:
+			return "linux";
+	}
+}
+
+/**
+ * Replicates ZCode's `buildZCodeSourceHeaders()` + GLM `X-ZCode-Agent` tag
+ * (host bundle `Bl` / `buildConnectivitySourceHeaders` for GLM providers), so
+ * api.z.ai sees gjc's glm-zcode requests as the ZCode client. Dynamic values
+ * (platform/arch, locale, timezone, OS version) are resolved at runtime exactly
+ * as ZCode does; printable-ASCII-only and conditionally omitted when empty.
+ */
+export function buildZCodeSourceHeaders(): Record<string, string> {
+	const platform = process.platform;
+	const arch = process.arch;
+	const appVersion = normalizePrintableHeaderValue(ZCODE_APP_VERSION);
+	const releaseChannel = normalizePrintableHeaderValue(ZCODE_RELEASE_CHANNEL);
+	let locale: string | undefined;
+	let timezone: string | undefined;
+	try {
+		const resolved = Intl.DateTimeFormat().resolvedOptions();
+		locale = normalizePrintableHeaderValue(resolved.locale);
+		timezone = normalizePrintableHeaderValue(resolved.timeZone);
+	} catch {}
+	const osVersion = normalizePrintableHeaderValue(os.version());
+	const headers: Record<string, string> = {
+		"User-Agent": `ZCode/${appVersion ?? "unknown"}`,
+		"HTTP-Referer": "https://zcode.z.ai",
+		"X-Title": "Z Code@electron",
+		"X-Platform": `${platform}-${arch}`,
+		"X-Client-Language": locale ?? "unknown",
+		"X-Client-Timezone": timezone ?? "unknown",
+		"X-Os-Category": normalizeOsCategory(platform),
+		"X-ZCode-Agent": "glm",
+	};
+	if (appVersion) headers["X-ZCode-App-Version"] = appVersion;
+	if (releaseChannel) headers["X-Release-Channel"] = releaseChannel;
+	if (osVersion) headers["X-Os-Version"] = osVersion;
+	return headers;
+}
+
 export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<string, string> {
 	const oauthToken = options.isOAuth ?? isAnthropicOAuthToken(options.apiKey);
 	const extraBetas = options.extraBetas ?? [];
@@ -197,6 +266,9 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 		};
 	} else if (!isAnthropicApiBaseUrl(options.baseUrl)) {
 		const incomingUserAgent = getHeaderCaseInsensitive(options.modelHeaders, "User-Agent");
+		// ZCode merges its source headers LAST for GLM providers (`withZCodeSourceHeaders`
+		// → `{ ...base, ...extra, ...source }`), so they win over any incoming User-Agent.
+		const zcodeSourceHeaders = options.zcodeSourceHeaders ? buildZCodeSourceHeaders() : undefined;
 		return {
 			...modelHeaders,
 			Accept: acceptHeader,
@@ -204,6 +276,7 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 			...sharedHeaders,
 			"Anthropic-Beta": betaHeader,
 			...(incomingUserAgent ? { "User-Agent": incomingUserAgent } : {}),
+			...(zcodeSourceHeaders ?? {}),
 		};
 	} else {
 		return {
@@ -1703,6 +1776,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		stream,
 		modelHeaders: mergeHeaders(model.headers, foundryCustomHeaders, headers, dynamicHeaders),
 		isCloudflareAiGateway: model.provider === "cloudflare-ai-gateway",
+		zcodeSourceHeaders: model.provider === "glm-zcode",
 	});
 
 	if (model.provider === "cloudflare-ai-gateway") {

--- a/packages/ai/test/oauth-glm-zcode.test.ts
+++ b/packages/ai/test/oauth-glm-zcode.test.ts
@@ -5,7 +5,11 @@ import * as path from "node:path";
 
 import { AuthStorage, SqliteAuthCredentialStore } from "../src/auth-storage";
 import { getBundledModel } from "../src/models";
-import { buildAnthropicClientOptions, buildAnthropicHeaders } from "../src/providers/anthropic";
+import {
+	buildAnthropicClientOptions,
+	buildAnthropicHeaders,
+	buildZCodeSourceHeaders,
+} from "../src/providers/anthropic";
 import { isOAuthToken } from "../src/utils/anthropic-auth";
 import { getOAuthProviders, refreshOAuthToken } from "../src/utils/oauth";
 import {
@@ -286,5 +290,49 @@ describe("GLM ZCode OAuth login provider", () => {
 		expect(headers.Authorization).toBe(`Bearer ${MINTED_KEY}`);
 		expect(headers["X-Api-Key"]).toBeUndefined();
 		expect((headers["User-Agent"] ?? "").toLowerCase().startsWith("claude-cli")).toBe(false);
+	});
+
+	it("attaches ZCode client source headers so api.z.ai recognizes the ZCode client", () => {
+		const headers = buildAnthropicHeaders({
+			apiKey: MINTED_KEY,
+			baseUrl: GLM_ZCODE_ANTHROPIC_BASE_URL,
+			zcodeSourceHeaders: true,
+		});
+		expect(headers["User-Agent"]).toBe("ZCode/3.1.2");
+		expect(headers["X-Title"]).toBe("Z Code@electron");
+		expect(headers["HTTP-Referer"]).toBe("https://zcode.z.ai");
+		expect(headers["X-ZCode-Agent"]).toBe("glm");
+		expect(headers["X-ZCode-App-Version"]).toBe("3.1.2");
+		expect(headers["X-Release-Channel"]).toBe("production");
+		expect(headers["X-Platform"]).toBe(`${process.platform}-${process.arch}`);
+		expect(headers["X-Os-Category"]).toMatch(/^(macos|windows|linux)$/);
+		expect(headers["X-Client-Language"]).toBeDefined();
+		expect(headers["X-Client-Timezone"]).toBeDefined();
+		// still a bearer API-key request, never x-api-key or claude-cli
+		expect(headers.Authorization).toBe(`Bearer ${MINTED_KEY}`);
+		expect(headers["X-Api-Key"]).toBeUndefined();
+	});
+
+	it("emits printable-only ZCode source headers from buildZCodeSourceHeaders()", () => {
+		const headers = buildZCodeSourceHeaders();
+		for (const value of Object.values(headers)) {
+			expect(value).toMatch(/^[\x20-\x7e]+$/);
+		}
+		expect(headers["X-ZCode-Agent"]).toBe("glm");
+	});
+
+	it("includes the ZCode source headers in glm-zcode client default headers", () => {
+		const model = getBundledModel("glm-zcode", "glm-5.2") as Parameters<
+			typeof buildAnthropicClientOptions
+		>[0]["model"];
+		const resolved = buildAnthropicClientOptions({ model, apiKey: MINTED_KEY });
+		expect(resolved.defaultHeaders?.["User-Agent"]).toBe("ZCode/3.1.2");
+		expect(resolved.defaultHeaders?.["X-ZCode-Agent"]).toBe("glm");
+	});
+
+	it("does NOT attach ZCode source headers when the flag is off (e.g. legacy zai)", () => {
+		const headers = buildAnthropicHeaders({ apiKey: MINTED_KEY, baseUrl: "https://api.z.ai/api/anthropic" });
+		expect(headers["X-ZCode-Agent"]).toBeUndefined();
+		expect(headers["User-Agent"] ?? "").not.toBe("ZCode/3.1.2");
 	});
 });


### PR DESCRIPTION
## What
Send ZCode's client "source" headers on every `glm-zcode` request so `api.z.ai` recognizes gjc as the ZCode client — matching ZCode 3.1.2 exactly.

## Why
Follow-up to #1016. Decompiling ZCode's host bundle (`buildZCodeSourceHeaders`/`Bl`, `withZCodeSourceHeaders`/`rb`, `buildConnectivitySourceHeaders`/`A3`) shows GLM requests carry a fixed source-header set + `X-ZCode-Agent: glm`. We now replicate it byte-for-byte as a hedge against any server-side client gating.

## Headers sent (glm-zcode only)
```
User-Agent: ZCode/3.1.2        HTTP-Referer: https://zcode.z.ai
X-Title: Z Code@electron       X-ZCode-Agent: glm
X-ZCode-App-Version: 3.1.2     X-Release-Channel: production
X-Platform: <platform>-<arch>  X-Os-Category: macos|windows|linux
X-Os-Version: <os.version()>   X-Client-Language / X-Client-Timezone (Intl)
```
- Version from ZCode `package.json` (3.1.2); channel from `resolveRuntimeZCodeEnv` -> "production".
- Dynamic fields resolved at runtime exactly as ZCode (printable-ASCII normalized, omitted when empty).
- Overridable via `ZCODE_APP_VERSION` / `ZCODE_RELEASE_CHANNEL`.

## Implementation
- `anthropic.ts`: `buildZCodeSourceHeaders()`; new `AnthropicHeaderOptions.zcodeSourceHeaders` flag; merged LAST in the non-anthropic API-key branch (matches ZCode's GLM `{ ...base, ...extra, ...source }` so the ZCode UA wins).
- `buildAnthropicClientOptions` sets the flag only for `provider === "glm-zcode"`; legacy `zai` untouched.

## Tests
Exact header set, printable-only, client default-header wiring, flag-off for non-glm-zcode. Full @gajae-code/ai suite **1508 pass / 0 fail**; tsc + biome clean.
