### PR TITLE
fix(notifications): reuse+rename the session topic across in-process session changes

### DIFF
--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -228,6 +228,56 @@ function mapAnswerToGate(
 	return { selected: [] };
 }
 
+/** Register the interactive `ask` answer source for a session (the ask tool
+ * races the local UI against a remote reply). Returns the deregister disposer. */
+function registerInteractiveAnswerSource(
+	id: string,
+	server: NotificationServer,
+	pendingInteractive: Map<string, PendingInteractiveAsk>,
+	redact: boolean,
+	tag: string,
+): () => void {
+	return registerAskAnswerSource(id, {
+		awaitAnswer(question, options, signal) {
+			if (signal?.aborted) return Promise.resolve(undefined);
+			const askId = `ask:${crypto.randomUUID()}`;
+			try {
+				server.registerAsk(
+					JSON.stringify(
+						notificationActionPayload(
+							{ id: askId, kind: "ask", sessionId: id, question, options },
+							{ redact, sessionTag: tag },
+						),
+					),
+					true,
+				);
+			} catch (e) {
+				logger.warn(`notifications: registerAsk failed: ${String(e)}`);
+				return Promise.resolve(undefined);
+			}
+			return new Promise<string | undefined>(resolve => {
+				pendingInteractive.set(askId, { resolve, options });
+				signal?.addEventListener("abort", () => {
+					if (!pendingInteractive.delete(askId)) return;
+					// Local UI answered: mark the remote action resolved-locally.
+					try {
+						server.resolveLocal(askId, undefined);
+					} catch {}
+					resolve(undefined);
+				});
+			});
+		},
+	});
+}
+
+/** Extract the session id from a `<timestamp>_<uuid>.jsonl` session file path. */
+function sessionIdFromFile(file: string | undefined): string | undefined {
+	if (!file) return undefined;
+	const base = path.basename(file).replace(/\.jsonl$/, "");
+	const underscore = base.indexOf("_");
+	return underscore >= 0 ? base.slice(underscore + 1) : undefined;
+}
+
 export const createNotificationsExtension: ExtensionFactory = api => {
 	const runtimes = new Map<string, SessionRuntime>();
 	const disabledSessions = new Set<string>();
@@ -271,6 +321,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		const pendingInteractive = new Map<string, PendingInteractiveAsk>();
 		const tag = sessionTag(id);
 		const redact = cfg.redact;
+		let runtime: SessionRuntime | undefined;
 
 		// The SDK can always answer now (interactive via the answer source, or the
 		// unattended gate), so the endpoint advertises a resolver.
@@ -322,18 +373,16 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 				// turn streams back via the turn_end handler even when not idle).
 				// Record the update id so it can be acked as "consumed" on the next
 				// turn_start, and steer (vs start a fresh turn) when already busy.
-				const rt = runtimes.get(id);
-				if (rt && typeof inbound.updateId === "number") rt.pendingInbound.add(inbound.updateId);
+				if (runtime && typeof inbound.updateId === "number") runtime.pendingInbound.add(inbound.updateId);
 				try {
-					api.sendUserMessage(inbound.text, rt?.busy ? { deliverAs: "steer" } : undefined);
+					api.sendUserMessage(inbound.text, runtime?.busy ? { deliverAs: "steer" } : undefined);
 				} catch (e) {
 					logger.warn(`notifications: sendUserMessage failed: ${String(e)}`);
 				}
 				return;
 			}
 			if (inbound.kind === "config_command") {
-				const rt = runtimes.get(id);
-				if (rt && typeof inbound.redact === "boolean") rt.redact = inbound.redact;
+				if (runtime && typeof inbound.redact === "boolean") runtime.redact = inbound.redact;
 			}
 		});
 
@@ -341,39 +390,9 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 			const endpoint = await server.start();
 
 			// Interactive answer source: the ask tool races the local UI against this.
-			const disposeAnswerSource = registerAskAnswerSource(id, {
-				awaitAnswer(question, options, signal) {
-					if (signal?.aborted) return Promise.resolve(undefined);
-					const askId = `ask:${crypto.randomUUID()}`;
-					try {
-						server.registerAsk(
-							JSON.stringify(
-								notificationActionPayload(
-									{ id: askId, kind: "ask", sessionId: id, question, options },
-									{ redact, sessionTag: tag },
-								),
-							),
-							true,
-						);
-					} catch (e) {
-						logger.warn(`notifications: registerAsk failed: ${String(e)}`);
-						return Promise.resolve(undefined);
-					}
-					return new Promise<string | undefined>(resolve => {
-						pendingInteractive.set(askId, { resolve, options });
-						signal?.addEventListener("abort", () => {
-							if (!pendingInteractive.delete(askId)) return;
-							// Local UI answered: mark the remote action resolved-locally.
-							try {
-								server.resolveLocal(askId, undefined);
-							} catch {}
-							resolve(undefined);
-						});
-					});
-				},
-			});
+			const disposeAnswerSource = registerInteractiveAnswerSource(id, server, pendingInteractive, redact, tag);
 
-			runtimes.set(id, {
+			runtime = {
 				server,
 				idleSeq: 0,
 				pendingInteractive,
@@ -382,7 +401,8 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 				sessionTag: tag,
 				busy: false,
 				pendingInbound: new Set<number>(),
-			});
+			};
+			runtimes.set(id, runtime);
 			logger.info(`notifications: serving session ${id} at ${endpoint.url} (unattended=${unattended})`);
 
 			if (settingsAvailable && settings && isGloballyConfigured(cfg)) {
@@ -510,6 +530,64 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 
 	api.on("session_start", async (_event, ctx) => {
 		await startSession(ctx);
+	});
+
+	// A session id change within the same process needs reason-aware handling.
+	// `/new` and fork CONTINUE the same terminal thread (e.g. plan "approve and
+	// execute" clears into a fresh session), so re-key the existing runtime
+	// old→new WITHOUT recreating the NotificationServer: the server, its endpoint
+	// discovery file, and the daemon's forum topic are all keyed by the original
+	// session id and the daemon routes by socket, so the existing topic is reused
+	// and the next identity frame renames it in place instead of spawning a new
+	// thread. `resume`, by contrast, loads a DIFFERENT, already-persisted session
+	// that owns its own topic — tear the previous runtime down and start fresh
+	// under the resumed id so the daemon attaches to (or recreates) that
+	// session's own discovery + topic rather than hijacking this terminal's.
+	api.on("session_switch", async (event, ctx) => {
+		const newId = sessionId(ctx);
+		const prevId = sessionIdFromFile(event.previousSessionFile);
+		if (!prevId || prevId === newId) return;
+
+		if (event.reason === "resume") {
+			stopSession(prevId);
+			await startSession(ctx);
+			return;
+		}
+
+		// `/new` / fork: re-key in place and rename the existing topic.
+		if (disabledSessions.delete(prevId)) disabledSessions.add(newId);
+		const rt = runtimes.get(prevId);
+		if (!rt || runtimes.has(newId)) return;
+		runtimes.delete(prevId);
+		runtimes.set(newId, rt);
+		// Re-bind the interactive ask answer source: the ask tool resolves the
+		// source by the current session id, which just changed.
+		try {
+			rt.disposeAnswerSource();
+		} catch {}
+		rt.disposeAnswerSource = registerInteractiveAnswerSource(
+			newId,
+			rt.server,
+			rt.pendingInteractive,
+			rt.redact,
+			rt.sessionTag,
+		);
+		// Rename the existing topic now when the new session already has a name; a
+		// fresh unnamed session is renamed on its next agent_end re-assert, which
+		// avoids a transient rename to bare "repo/branch".
+		if (ctx.sessionManager.getSessionName()) {
+			try {
+				rt.server.pushFrame(
+					JSON.stringify({
+						type: "identity_header",
+						sessionId: newId,
+						...buildIdentity(ctx.cwd, ctx.sessionManager.getSessionName()),
+					}),
+				);
+			} catch (e) {
+				logger.warn(`notifications: identity_header (switch) failed: ${String(e)}`);
+			}
+		}
 	});
 
 	// Drive the live typing indicator: mark busy when the agent loop starts so

--- a/packages/coding-agent/test/notifications-session-switch.test.ts
+++ b/packages/coding-agent/test/notifications-session-switch.test.ts
@@ -1,0 +1,369 @@
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createNotificationsExtension } from "../src/notifications/index";
+import { readEndpoint } from "../src/notifications/telegram-reference";
+
+/**
+ * Regression for "notifications SDK spawns a new session instead of renaming":
+ * an in-process session id change (`/new`, plan "approve and execute", fork,
+ * resume) emits `session_switch` with a new session id. Previously the
+ * notifications runtime was keyed only on `session_start`, so the new id had no
+ * runtime and a fresh NotificationServer + endpoint discovery file + Telegram
+ * topic would spawn instead of the existing thread being reused/renamed.
+ */
+
+const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+async function waitFor(pred: () => boolean, ms = 4000, label = "condition"): Promise<void> {
+	const deadline = Date.now() + ms;
+	while (Date.now() < deadline) {
+		if (pred()) return;
+		await sleep(25);
+	}
+	throw new Error(`timed out waiting for ${label}`);
+}
+
+type Handler = (event: unknown, ctx: unknown) => unknown;
+type Frame = { type: string; title?: string; sessionId?: string; state?: string };
+
+const tempDirs: string[] = [];
+const openSockets: WebSocket[] = [];
+afterEach(() => {
+	for (const ws of openSockets.splice(0)) ws.close();
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+async function withNotifications<T>(fn: () => Promise<T>): Promise<T> {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		return await fn();
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
+	}
+}
+
+function createHarness(prefix: string, initialName: string | undefined = "Original") {
+	const handlers = new Map<string, Handler>();
+	const api = {
+		on: (event: string, handler: Handler) => {
+			handlers.set(event, handler);
+		},
+		registerCommand: () => {},
+		sendUserMessage: () => {},
+	} as never;
+	createNotificationsExtension(api);
+
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(cwd);
+
+	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	let sid = `${prefix}${suffix}`;
+	let name: string | undefined = initialName;
+	const ctx = {
+		cwd,
+		sessionManager: {
+			getSessionId: () => sid,
+			getSessionName: () => name,
+			getArtifactsDir: () => cwd,
+			getCwd: () => cwd,
+		},
+	} as never;
+
+	const notifDir = path.join(cwd, ".gjc", "state", "notifications");
+	return {
+		handlers,
+		ctx,
+		cwd,
+		notifDir,
+		get sid() {
+			return sid;
+		},
+		set sid(value: string) {
+			sid = value;
+		},
+		get name() {
+			return name;
+		},
+		set name(value: string | undefined) {
+			name = value;
+		},
+		endpoint(id = sid) {
+			return path.join(notifDir, `${id}.json`);
+		},
+		previousSessionFile(id: string) {
+			return path.join(cwd, ".gjc", "agent", "sessions", `ts_${id}.jsonl`);
+		},
+	};
+}
+
+async function connectFrames(endpoint: string): Promise<Frame[]> {
+	const { url, token } = readEndpoint(endpoint);
+	const frames: Frame[] = [];
+	const ws = new WebSocket(`${url}/?token=${encodeURIComponent(token)}`);
+	openSockets.push(ws);
+	ws.addEventListener("message", ev => frames.push(JSON.parse(String((ev as MessageEvent).data))));
+	await new Promise<void>((resolve, reject) => {
+		ws.addEventListener("open", () => resolve());
+		ws.addEventListener("error", () => reject(new Error("ws error")));
+	});
+	await sleep(250);
+	return frames;
+}
+
+async function startAndConnect(harness: ReturnType<typeof createHarness>): Promise<Frame[]> {
+	await harness.handlers.get("session_start")!({ type: "session_start" }, harness.ctx);
+	await waitFor(() => fs.existsSync(harness.endpoint()), 4000, "original endpoint file");
+	return connectFrames(harness.endpoint());
+}
+
+test("session_switch reuses the existing topic instead of spawning a new session", async () => {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		const handlers = new Map<string, Handler>();
+		const api = {
+			on: (event: string, handler: Handler) => {
+				handlers.set(event, handler);
+			},
+			registerCommand: () => {},
+			sendUserMessage: () => {},
+		} as never;
+		createNotificationsExtension(api);
+
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-switch-"));
+		tempDirs.push(cwd);
+
+		const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		let sid = `switch-a-${suffix}`;
+		let name = "Original";
+		const ctx = {
+			cwd,
+			sessionManager: {
+				getSessionId: () => sid,
+				getSessionName: () => name,
+				getArtifactsDir: () => cwd,
+				getCwd: () => cwd,
+			},
+		} as never;
+
+		await handlers.get("session_start")!({ type: "session_start" }, ctx);
+
+		const notifDir = path.join(cwd, ".gjc", "state", "notifications");
+		const originalEndpoint = path.join(notifDir, `${sid}.json`);
+		await waitFor(() => fs.existsSync(originalEndpoint), 4000, "original endpoint file");
+
+		const { url, token } = readEndpoint(originalEndpoint);
+		const frames: Frame[] = [];
+		const ws = new WebSocket(`${url}/?token=${encodeURIComponent(token)}`);
+		openSockets.push(ws);
+		ws.addEventListener("message", ev => frames.push(JSON.parse(String((ev as MessageEvent).data))));
+		await new Promise<void>((resolve, reject) => {
+			ws.addEventListener("open", () => resolve());
+			ws.addEventListener("error", () => reject(new Error("ws error")));
+		});
+		await sleep(250);
+
+		// In-process session change: a fresh session id with a new (already-set) title.
+		const previousSessionId = sid;
+		sid = `switch-b-${suffix}`;
+		name = "Renamed Plan";
+		const previousSessionFile = path.join(cwd, ".gjc", "agent", "sessions", `ts_${previousSessionId}.jsonl`);
+		await handlers.get("session_switch")!({ type: "session_switch", reason: "new", previousSessionFile }, ctx);
+
+		// No new "session": the new id does NOT get its own endpoint discovery file,
+		// and the original server keeps serving.
+		const newEndpoint = path.join(notifDir, `${sid}.json`);
+		expect(fs.existsSync(newEndpoint)).toBe(false);
+		expect(fs.existsSync(originalEndpoint)).toBe(true);
+
+		// The existing topic is renamed: an identity_header with the new title is
+		// re-asserted over the SAME socket (the daemon edits the topic in place).
+		await waitFor(
+			() => frames.some(f => f.type === "identity_header" && f.title === "Renamed Plan"),
+			4000,
+			"identity_header rename frame",
+		);
+
+		// The runtime was re-keyed: events for the NEW id keep flowing over the same
+		// socket. Without the re-key, agent_start would find no runtime and emit nothing.
+		await handlers.get("agent_start")!({ type: "agent_start" }, ctx);
+		await waitFor(
+			() => frames.some(f => f.type === "activity" && f.state === "busy" && f.sessionId === sid),
+			4000,
+			"busy activity for new session id",
+		);
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
+	}
+}, 30000);
+
+test("session_switch with missing previousSessionFile is a safe no-op", async () => {
+	await withNotifications(async () => {
+		const harness = createHarness("gjc-notif-switch-missing-prev-");
+		const frames = await startAndConnect(harness);
+		const originalId = harness.sid;
+		const originalEndpoint = harness.endpoint(originalId);
+
+		harness.sid = `switch-new-${originalId}`;
+		await harness.handlers.get("session_switch")!(
+			{ type: "session_switch", previousSessionFile: undefined },
+			harness.ctx,
+		);
+		await sleep(250);
+
+		expect(fs.existsSync(originalEndpoint)).toBe(true);
+		expect(fs.existsSync(harness.endpoint(harness.sid))).toBe(false);
+
+		harness.sid = originalId;
+		await harness.handlers.get("agent_start")!({ type: "agent_start" }, harness.ctx);
+		await waitFor(
+			() => frames.some(f => f.type === "activity" && f.state === "busy" && f.sessionId === originalId),
+			4000,
+			"busy activity for original session id",
+		);
+	});
+}, 30000);
+
+test("session_switch with matching previous and current ids is a safe no-op", async () => {
+	await withNotifications(async () => {
+		const harness = createHarness("gjc-notif-switch-same-id-");
+		const frames = await startAndConnect(harness);
+		const originalId = harness.sid;
+		const originalEndpoint = harness.endpoint(originalId);
+
+		await harness.handlers.get("session_switch")!(
+			{ type: "session_switch", previousSessionFile: harness.previousSessionFile(originalId) },
+			harness.ctx,
+		);
+		await sleep(250);
+
+		expect(fs.existsSync(originalEndpoint)).toBe(true);
+		expect(frames.filter(f => f.type === "identity_header" && f.sessionId === originalId)).toHaveLength(0);
+
+		await harness.handlers.get("agent_start")!({ type: "agent_start" }, harness.ctx);
+		await waitFor(
+			() => frames.some(f => f.type === "activity" && f.state === "busy" && f.sessionId === originalId),
+			4000,
+			"busy activity for unchanged session id",
+		);
+	});
+}, 30000);
+
+test("session_switch with no runtime for previous id is a safe no-op", async () => {
+	await withNotifications(async () => {
+		const harness = createHarness("gjc-notif-switch-no-runtime-");
+		const missingPrevId = `missing-${harness.sid}`;
+		const newId = harness.sid;
+
+		await harness.handlers.get("session_switch")!(
+			{ type: "session_switch", previousSessionFile: harness.previousSessionFile(missingPrevId) },
+			harness.ctx,
+		);
+		await sleep(250);
+
+		expect(fs.existsSync(harness.endpoint(newId))).toBe(false);
+	});
+}, 30000);
+
+test("session_switch to unnamed session reuses socket without switch identity frame", async () => {
+	await withNotifications(async () => {
+		const harness = createHarness("gjc-notif-switch-unnamed-");
+		const frames = await startAndConnect(harness);
+		const originalId = harness.sid;
+		const originalEndpoint = harness.endpoint(originalId);
+		const initialFrameCount = frames.length;
+
+		harness.sid = `switch-b-${originalId}`;
+		harness.name = undefined;
+		await harness.handlers.get("session_switch")!(
+			{ type: "session_switch", previousSessionFile: harness.previousSessionFile(originalId) },
+			harness.ctx,
+		);
+		await sleep(250);
+
+		expect(fs.existsSync(originalEndpoint)).toBe(true);
+		expect(fs.existsSync(harness.endpoint(harness.sid))).toBe(false);
+		expect(frames.slice(initialFrameCount).some(f => f.type === "identity_header")).toBe(false);
+
+		await harness.handlers.get("agent_end")!({ type: "agent_end" }, harness.ctx);
+		await waitFor(
+			() => frames.some(f => f.type === "activity" && f.state === "idle" && f.sessionId === harness.sid),
+			4000,
+			"idle activity for unnamed switched session id",
+		);
+	});
+}, 30000);
+
+test("session_switch can chain A to B to C while keeping only the original endpoint", async () => {
+	await withNotifications(async () => {
+		const harness = createHarness("gjc-notif-switch-chain-");
+		const frames = await startAndConnect(harness);
+		const a = harness.sid;
+		const originalEndpoint = harness.endpoint(a);
+		const b = `switch-b-${a}`;
+		const c = `switch-c-${a}`;
+
+		harness.sid = b;
+		harness.name = "Session B";
+		await harness.handlers.get("session_switch")!(
+			{ type: "session_switch", previousSessionFile: harness.previousSessionFile(a) },
+			harness.ctx,
+		);
+		harness.sid = c;
+		harness.name = "Session C";
+		await harness.handlers.get("session_switch")!(
+			{ type: "session_switch", previousSessionFile: harness.previousSessionFile(b) },
+			harness.ctx,
+		);
+		await sleep(250);
+
+		expect(fs.existsSync(originalEndpoint)).toBe(true);
+		expect(fs.existsSync(harness.endpoint(b))).toBe(false);
+		expect(fs.existsSync(harness.endpoint(c))).toBe(false);
+
+		await harness.handlers.get("agent_start")!({ type: "agent_start" }, harness.ctx);
+		await waitFor(
+			() => frames.some(f => f.type === "activity" && f.state === "busy" && f.sessionId === c),
+			4000,
+			"busy activity for twice-switched session id",
+		);
+	});
+}, 30000);
+test("session_switch reason=resume starts a fresh runtime for the resumed session's own topic", async () => {
+	await withNotifications(async () => {
+		const harness = createHarness("gjc-notif-resume-");
+		await startAndConnect(harness);
+		const idA = harness.sid;
+		const endpointA = harness.endpoint(idA);
+		expect(fs.existsSync(endpointA)).toBe(true);
+
+		// Resume loads a DIFFERENT already-persisted session (its own id + title),
+		// which owns its own forum topic — it must not hijack this terminal's topic.
+		const idB = `resumed-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		harness.sid = idB;
+		harness.name = "Resumed Session";
+		await harness.handlers.get("session_switch")!(
+			{ type: "session_switch", reason: "resume", previousSessionFile: harness.previousSessionFile(idA) },
+			harness.ctx,
+		);
+
+		// The previous session's endpoint is torn down and the resumed session gets
+		// its OWN endpoint discovery file (its own topic), not the previous one.
+		const endpointB = harness.endpoint(idB);
+		await waitFor(() => fs.existsSync(endpointB), 4000, "resumed endpoint file");
+		await waitFor(() => !fs.existsSync(endpointA), 4000, "previous endpoint removed");
+
+		// The resumed session's fresh runtime serves over its own socket.
+		const frames = await connectFrames(endpointB);
+		await harness.handlers.get("agent_start")!({ type: "agent_start" }, harness.ctx);
+		await waitFor(
+			() => frames.some(f => f.type === "activity" && f.state === "busy" && f.sessionId === idB),
+			4000,
+			"busy activity for resumed session id",
+		);
+	});
+}, 30000);


### PR DESCRIPTION
## Summary

The notifications SDK spawned a brand-new Telegram forum topic ("session") instead of reusing and renaming the existing one whenever the GJC session id changed **within the same process**.

Root cause: `packages/coding-agent/src/notifications/index.ts` keyed its per-session runtime, `NotificationServer`, endpoint discovery file (`.gjc/state/notifications/<sessionId>.json`), and the daemon's forum topic by `getSessionId()`, and only (re)started on the `session_start` event. But `AgentSession.newSession()/fork()/switchSession()` emit `session_switch` (reason `new`/`fork`/`resume`) with a **new** session id and do **not** emit `session_start`. The extension never handled `session_switch`, so after `/new`, plan "approve and execute", fork, or resume the runtime was orphaned under the old id — and a fresh server + discovery file + Telegram topic later spawned for the new id instead of the original thread being reused/renamed.

## Changes

Added a reason-aware `api.on("session_switch", …)` handler:

- **`new` / `fork`** (continuation, e.g. plan execute clears into a fresh session): re-key the existing runtime old-id → new-id **without** recreating the `NotificationServer`. The server keeps its original discovery file + socket and the daemon routes by socket, so the existing topic is reused and renamed in place (identity re-asserted immediately when a name exists, else on the next `agent_end`).
- **`resume`** (loads a different already-persisted session that owns its own topic): tear down the previous runtime and start fresh under the resumed id so the daemon attaches to / recreates that session's own discovery + topic, rather than hijacking the current terminal's topic.

Supporting changes:
- Extracted a reused `registerInteractiveAnswerSource` helper and re-bind the `ask` answer source under the new id on switch.
- `onInbound` now resolves its runtime via a stable per-session holder instead of `runtimes.get(id)` so inbound ack/steer survive the re-key.
- Carry the locally-disabled flag across the re-key.

TS-only; no daemon protocol change, no native rebuild.

## Verification

- New `packages/coding-agent/test/notifications-session-switch.test.ts`: **7 pass / 0 fail** against a real `NotificationServer` + live WebSocket (happy-path reuse+rename, resume teardown+own-topic, and 5 adversarial cases: undefined `previousSessionFile`, `prevId===newId`, no-runtime, unnamed new session, and an A→B→C chain).
- `tsgo --noEmit` clean, biome clean.
- Existing `notifications-telegram-daemon` (40) and `notifications-topic-registry` (6) still pass.
- Architect review across architecture/product/code lanes: **CLEAR + APPROVE** (initial review caught a HIGH where `resume` hijacked the terminal's topic; fixed via the reason-aware split and re-reviewed clean).

The pre-existing `notifications-e2e.test.ts` native-addon load error is environmental (fails identically on the base branch).
