### PR TITLE
Fix auto context maintenance output reserve

### DIFF
--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -204,14 +204,14 @@ export function computeContextBreakdown(
 	if (contextWindow > 0) {
 		const compactionSettings = session.settings.getGroup("compaction") as CompactionSettings;
 		if (compactionSettings.enabled && compactionSettings.strategy !== "off") {
-			const threshold = resolveThresholdTokens(contextWindow, compactionSettings, model?.maxTokens ?? 0);
+			const threshold = resolveThresholdTokens(contextWindow, compactionSettings);
 			autoCompactBufferTokens = Math.max(0, contextWindow - threshold);
 		} else {
 			autoCompactBufferTokens = 0;
 		}
 		// Even when fully disabled, fall back to a sensible reserve floor for display.
 		if (autoCompactBufferTokens === 0 && compactionSettings.enabled) {
-			autoCompactBufferTokens = effectiveReserveTokens(contextWindow, compactionSettings, model?.maxTokens ?? 0);
+			autoCompactBufferTokens = effectiveReserveTokens(contextWindow, compactionSettings);
 		}
 	}
 	autoCompactBufferTokens = Math.min(autoCompactBufferTokens, Math.max(0, contextWindow - usedTokens));

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6732,17 +6732,19 @@ export class AgentSession {
 		// Skip if this was an error (non-overflow errors don't have usage data)
 		if (assistantMessage.stopReason === "error") return;
 		let contextTokens = calculateContextTokens(assistantMessage.usage);
-		const maxOutputTokens = this.model?.maxTokens ?? 0;
+		// Model maxTokens is a capability ceiling, not a per-turn reservation.
+		// Auto maintenance should track actual context fullness.
+		const autoCompactionOutputReserveTokens = 0;
 		// Cache-epoch invariant: pruning rewrites already-sent toolResult history,
 		// which breaks the provider prompt-cache prefix mid-epoch. Only prune at a
 		// sanctioned maintenance boundary, i.e. when the un-pruned context already
 		// crosses the compaction threshold. Pruning may then avert full compaction.
-		if (!shouldCompact(contextTokens, contextWindow, compactionSettings, maxOutputTokens)) return;
+		if (!shouldCompact(contextTokens, contextWindow, compactionSettings, autoCompactionOutputReserveTokens)) return;
 		const pruneResult = await this.#pruneToolOutputs();
 		if (pruneResult) {
 			contextTokens = Math.max(0, contextTokens - pruneResult.tokensSaved);
 		}
-		if (shouldCompact(contextTokens, contextWindow, compactionSettings, maxOutputTokens)) {
+		if (shouldCompact(contextTokens, contextWindow, compactionSettings, autoCompactionOutputReserveTokens)) {
 			// Try promotion first — if a larger model is available, switch instead of compacting
 			const promoted = await this.#tryContextPromotion(assistantMessage);
 			if (!promoted) {
@@ -6820,14 +6822,16 @@ export class AgentSession {
 		if (!compactionSettings.enabled || compactionSettings.strategy === "off") return;
 
 		let contextTokens = this.#estimateContextTokensForCompaction(pendingMessages).tokens;
-		const maxOutputTokens = model.maxTokens ?? 0;
-		if (!shouldCompact(contextTokens, contextWindow, compactionSettings, maxOutputTokens)) return;
+		// Model maxTokens is a capability ceiling, not a per-turn reservation.
+		// Auto maintenance should track actual context fullness.
+		const autoCompactionOutputReserveTokens = 0;
+		if (!shouldCompact(contextTokens, contextWindow, compactionSettings, autoCompactionOutputReserveTokens)) return;
 
 		const pruneResult = await this.#pruneToolOutputs();
 		if (pruneResult) {
 			contextTokens = Math.max(0, contextTokens - pruneResult.tokensSaved);
 		}
-		if (shouldCompact(contextTokens, contextWindow, compactionSettings, maxOutputTokens)) {
+		if (shouldCompact(contextTokens, contextWindow, compactionSettings, autoCompactionOutputReserveTokens)) {
 			await this.#runAutoCompaction("threshold", false, false, {
 				continueAfterMaintenance: false,
 				deferHandoffMaintenance: false,

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -99,11 +99,12 @@ describe("AgentSession auto-compaction queue resume", () => {
 		if (!model) {
 			throw new Error("Expected built-in anthropic model to exist");
 		}
+		const sessionModel = { ...model, contextWindow: 200_000, maxTokens: 128_000 };
 		streamCallCount = 0;
 
 		const agent = new Agent({
 			initialState: {
-				model,
+				model: sessionModel,
 				systemPrompt: ["Test"],
 				tools: [],
 				messages: [],
@@ -227,6 +228,34 @@ describe("AgentSession auto-compaction queue resume", () => {
 		const runtimeSignals = getRuntimeSignals();
 		expect(runtimeSignals).toContain("compaction:start:threshold");
 		expect(runtimeSignals.some(signal => signal.startsWith("compaction:end:"))).toBe(true);
+	});
+	it("does not reserve model output capability for threshold maintenance", async () => {
+		const assistantMsg: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 110_000,
+				output: 1_000,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 111_000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(getRuntimeSignals()).not.toContain("compaction:start:threshold");
+		expect(sessionManager.getBranch().some(entry => entry.type === "compaction")).toBe(false);
 	});
 
 	it("compacts before a new prompt when tool results push context over threshold", async () => {


### PR DESCRIPTION
## Summary
- stop using a model's maximum output capability as an automatic context-maintenance reservation
- align the `/context` buffer display with the same auto-maintenance threshold
- add a regression test covering a large max-output-capability model below the normal compaction threshold

## Evidence
Official provider docs treat output caps as generation limits, not the context window itself:
- OpenAI: `max_output_tokens` caps the number of tokens the model will generate: https://help.openai.com/en/articles/5072518-controlling-the-length-of-openai-model-responses#set-a-maximum-output-length
- Anthropic Messages API: `max_tokens` is the maximum number of tokens to generate before stopping: https://docs.anthropic.com/en/api/messages
- Anthropic model docs list `Context window` and `Max output` as separate model capabilities: https://docs.claude.com/en/docs/about-claude/models/overview

Observed impact: while using GPT-5.5 with a 272K context window, the session can show only about 54.6% context usage and still enter `Auto context-full maintenance… (esc to cancel)` because the previous calculation reserved the model's large max-output capability as if it were already consumed context.

Before this change, auto context-full maintenance treated the model-level max output capability as if every turn reserved that entire amount. For large-output-capability models, that moved the maintenance threshold far below the displayed context fullness. The automatic maintenance path now uses actual context fullness plus configured compaction reserves instead.

## Verification
- `bun run check:types` in `packages/coding-agent`
- `bunx biome check packages/coding-agent/src/session/agent-session.ts packages/coding-agent/src/modes/utils/context-usage.ts packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts --no-errors-on-unmatched`

Focused runtime test attempted but blocked by the local missing native addon:
- `bun --cwd packages/coding-agent test test/agent-session-auto-compaction-queue.test.ts`
- failure: `Failed to load pi_natives native addon for darwin-arm64`; local native build was not available in this checkout.