### PR TITLE
Add busy input shortcut hints

### DIFF
--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -201,6 +201,7 @@ export class EventController {
 			this.ctx.statusContainer.clear();
 		}
 		this.#cancelIdleCompaction();
+		this.ctx.updateEditorBorderColor();
 		this.ctx.ensureLoadingAnimation();
 		this.ctx.ui.requestRender();
 	}
@@ -633,6 +634,7 @@ export class EventController {
 		this.#readToolCallArgs.clear();
 		this.#readToolCallAssistantComponents.clear();
 		this.#lastAssistantComponent = undefined;
+		this.ctx.updateEditorBorderColor();
 		this.ctx.ui.requestRender();
 		this.#scheduleIdleCompaction();
 		this.sendCompletionNotification();
@@ -642,6 +644,7 @@ export class EventController {
 		event: Extract<AgentSessionEvent, { type: "auto_compaction_start" }>,
 	): Promise<void> {
 		this.#cancelIdleCompaction();
+		this.ctx.updateEditorBorderColor();
 		this.ctx.autoCompactionEscapeHandler = this.ctx.editor.onEscape;
 		this.ctx.editor.onEscape = () => {
 			this.ctx.session.abortCompaction();
@@ -672,6 +675,7 @@ export class EventController {
 			this.ctx.autoCompactionLoader = undefined;
 			this.ctx.statusContainer.clear();
 		}
+		this.ctx.updateEditorBorderColor();
 		const isHandoffAction = event.action === "handoff";
 		if (event.aborted) {
 			this.ctx.showStatus(isHandoffAction ? "Auto-handoff cancelled" : "Auto context-full maintenance cancelled");

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -84,6 +84,7 @@ import type { EvalExecutionComponent } from "./components/eval-execution";
 import type { HookEditorComponent } from "./components/hook-editor";
 import type { HookInputComponent } from "./components/hook-input";
 import type { HookSelectorComponent } from "./components/hook-selector";
+import { appKey } from "./components/keybinding-hints";
 import { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import {
@@ -117,6 +118,7 @@ import type { CompactionQueuedMessage, InteractiveModeContext, SubmittedUserInpu
 import { UiHelpers } from "./utils/ui-helpers";
 
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
+const DEFAULT_COMPOSER_PLACEHOLDER = "Type your message...";
 
 const HINT_SHIMMER_PALETTE: ShimmerPalette = {
 	low: "dim",
@@ -141,7 +143,7 @@ function configureDefaultComposerChrome(editor: CustomEditor): void {
 	editor.setClosedBorderBox(true);
 	editor.setPromptGutter(undefined);
 	editor.setInputPrefix(getDefaultInputPrefix());
-	editor.setPlaceholder("Type your message...");
+	editor.setPlaceholder(DEFAULT_COMPOSER_PLACEHOLDER);
 	editor.setPaddingX(1);
 	editor.setTopBorder(undefined);
 }
@@ -903,6 +905,20 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.editor.setMaxHeight(this.#computeEditorMaxHeight());
 	}
 
+	#isPromptDeliveryBusy(): boolean {
+		return this.session.isStreaming || this.session.isCompacting;
+	}
+
+	#getComposerPlaceholder(): string {
+		if (!this.#isPromptDeliveryBusy()) return DEFAULT_COMPOSER_PLACEHOLDER;
+		const queueKey =
+			appKey(this.keybindings, "app.message.queue") || appKey(this.keybindings, "app.message.followUp");
+		const enterAction = this.settings.get("busyPromptMode") === "steer" ? "Steer" : "Queue";
+		const parts = [`Enter ${enterAction.toLowerCase()}`];
+		if (queueKey) parts.push(`${queueKey} queue`);
+		return `${DEFAULT_COMPOSER_PLACEHOLDER} ${parts.join(" · ")}`;
+	}
+
 	updateEditorChrome(): void {
 		if (this.isBashMode) {
 			this.editor.borderColor = this.isBashNoContext
@@ -926,6 +942,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (!this.isBashMode) {
 			this.editor.setInputPrefix(getDefaultInputPrefix());
 		}
+		this.editor.setPlaceholder(this.#getComposerPlaceholder());
 		this.#setComposerTopBorder();
 		this.ui.requestRender();
 	}

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -72,6 +72,38 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(lines.join("\n")).not.toContain("›");
 	});
 
+	it("shows busy steering and queueing hints only while work is active", () => {
+		let rendered = mode.editor
+			.render(96)
+			.map(line => stripVTControlCharacters(line))
+			.join("\n");
+		expect(rendered).toContain("Type your message...");
+		expect(rendered).not.toContain("Enter steer");
+		expect(rendered).not.toContain("alt+enter queue");
+
+		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = true;
+		mode.updateEditorChrome();
+
+		rendered = mode.editor
+			.render(96)
+			.map(line => stripVTControlCharacters(line))
+			.join("\n");
+		expect(rendered).toContain("Type your message...");
+		expect(rendered).toContain("Enter steer");
+		expect(rendered).toContain("alt+enter queue");
+
+		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = false;
+		mode.updateEditorChrome();
+
+		rendered = mode.editor
+			.render(96)
+			.map(line => stripVTControlCharacters(line))
+			.join("\n");
+		expect(rendered).toContain("Type your message...");
+		expect(rendered).not.toContain("Enter steer");
+		expect(rendered).not.toContain("alt+enter queue");
+	});
+
 	it("renders one visible blank row between status line and composer without hook widgets", async () => {
 		vi.spyOn(mode.ui, "start").mockImplementation(() => {});
 


### PR DESCRIPTION
## Summary
- Keep the composer placeholder unchanged while idle
- Add Enter steering/queueing plus ctrl+enter/alt+enter queueing hints while work is active
- Refresh composer chrome when agent or auto-compaction activity starts and ends

## Verification
- bun --cwd packages/coding-agent run check:types
- bunx biome check packages/coding-agent/src/modes/interactive-mode.ts packages/coding-agent/test/interactive-mode-editor-component.test.ts --no-errors-on-unmatched