### PR TITLE
fix(ai): reject truncated tool calls instead of executing partial args

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1084,6 +1084,17 @@ async function executeToolCalls(
 
 		await runInActiveSpan(toolSpan, async () => {
 			try {
+				if (toolCall.incompleteArguments) {
+					// The provider flagged this call's argument JSON as truncated
+					// (the model hit its output-token limit mid-call). Executing the
+					// best-effort partial parse would run the tool on wrong input, so
+					// reject with a retryable, actionable error instead.
+					throw new Error(
+						`Tool call "${toolCall.name}" was cut off before its arguments finished streaming ` +
+							`(the response hit its output token limit). The partial arguments cannot be executed. ` +
+							`Re-issue the call with complete arguments, splitting the work into smaller steps if needed.`,
+					);
+				}
 				if (!tool) throw new Error(`Tool ${toolCall.name} not found`);
 
 				let effectiveArgs: Record<string, unknown>;

--- a/packages/agent/test/agent-loop-truncated-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-truncated-toolcall.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test";
+import { agentLoop } from "@gajae-code/agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool } from "@gajae-code/agent-core/types";
+import type { Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import * as z from "zod/v4";
+import { createUserMessage } from "./helpers";
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+describe("agentLoop: truncated tool-call guard", () => {
+	it("rejects a tool call flagged incompleteArguments without executing it", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const toolSchema = z.object({ path: z.string(), content: z.string() });
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "write_file",
+			label: "Write",
+			description: "Write a file",
+			parameters: toolSchema,
+			async execute(_id, params) {
+				executed.push(params as Record<string, unknown>);
+				return { content: [{ type: "text", text: "wrote" }], details: {} };
+			},
+		};
+
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{
+					// Provider flagged the arguments as truncated (hit max output tokens).
+					content: [
+						{
+							type: "toolCall",
+							id: "tc-1",
+							name: "write_file",
+							arguments: { path: "a.ts" }, // best-effort partial parse (missing `content`)
+							incompleteArguments: true,
+						},
+					],
+					stopReason: "length",
+				},
+				{ content: ["recovered"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const toolResults: Array<{ isError?: boolean; text: string }> = [];
+		const stream = agentLoop([createUserMessage("write the file")], context, config, undefined, mock.stream);
+		for await (const event of stream) {
+			if (event.type === "tool_execution_end") {
+				const first = event.result.content?.[0];
+				toolResults.push({ isError: event.isError, text: first?.type === "text" ? first.text : "" });
+			}
+		}
+
+		// The tool must never have run on the truncated input.
+		expect(executed).toHaveLength(0);
+
+		// Exactly one (error) tool result, with an actionable truncation message.
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0].isError).toBe(true);
+		expect(toolResults[0].text).toContain("cut off");
+		expect(toolResults[0].text.toLowerCase()).toContain("re-issue");
+	});
+
+	it("executes normally when incompleteArguments is not set", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const toolSchema = z.object({ path: z.string() });
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "read_file",
+			label: "Read",
+			description: "Read a file",
+			parameters: toolSchema,
+			async execute(_id, params) {
+				executed.push(params as Record<string, unknown>);
+				return { content: [{ type: "text", text: "ok" }], details: {} };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tc-1", name: "read_file", arguments: { path: "a.ts" } }] },
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoop([createUserMessage("read it")], context, config, undefined, mock.stream);
+		for await (const _ of stream) {
+			// drain
+		}
+		expect(executed).toEqual([{ path: "a.ts" }]);
+	});
+});

--- a/packages/ai/src/providers/mock.ts
+++ b/packages/ai/src/providers/mock.ts
@@ -73,6 +73,8 @@ export type MockContent =
 			name: string;
 			/** Object form is preferred; strings are passed through verbatim. */
 			arguments: Record<string, unknown> | string;
+			/** Simulate a provider-flagged truncated call (cut off mid-arguments). */
+			incompleteArguments?: boolean;
 	  };
 
 /** One scripted response. */
@@ -416,6 +418,7 @@ function normalizeContent(input: MockContent, state: MockModel): TextContent | T
 			id: input.id ?? generateToolCallId(state),
 			name: input.name,
 			arguments: typeof input.arguments === "string" ? input.arguments : { ...input.arguments },
+			...(input.incompleteArguments ? { incompleteArguments: true } : {}),
 		} as ToolCall;
 	}
 	return input;

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -78,6 +78,7 @@ import {
 	convertResponsesInputContent,
 	encodeResponsesToolCallId,
 	encodeTextSignatureV1,
+	flagTruncatedToolCalls,
 	mapOpenAIResponsesStopReason,
 	populateResponsesUsageFromResponse,
 } from "./openai-responses-shared";
@@ -254,6 +255,8 @@ interface CodexStreamRuntime {
 	providerRetryAttempt: number;
 	sawTerminalEvent: boolean;
 	canSafelyReplayWebsocketOverSse: boolean;
+	/** Ids of tool calls that received their terminal `output_item.done`. */
+	finalizedToolCallIds: Set<string>;
 }
 
 interface CodexStreamProcessingContext {
@@ -910,6 +913,7 @@ function createCodexStreamRuntime(initial: {
 		providerRetryAttempt: 0,
 		sawTerminalEvent: false,
 		canSafelyReplayWebsocketOverSse: true,
+		finalizedToolCallIds: new Set<string>(),
 	};
 }
 
@@ -1267,9 +1271,11 @@ function handleOutputItemDone(
 	}
 
 	if (item.type === "function_call") {
+		const id = encodeResponsesToolCallId(item.call_id, item.id);
+		runtime.finalizedToolCallIds.add(id);
 		const toolCall: ToolCall = {
 			type: "toolCall",
-			id: encodeResponsesToolCallId(item.call_id, item.id),
+			id,
 			name: item.name,
 			arguments: parseStreamingJson(item.arguments || "{}"),
 		};
@@ -1279,13 +1285,15 @@ function handleOutputItemDone(
 	}
 
 	if (item.type === "custom_tool_call") {
+		const id = encodeResponsesToolCallId(item.call_id, item.id);
+		runtime.finalizedToolCallIds.add(id);
 		const rawInput =
 			runtime.currentBlock?.type === "toolCall" && runtime.currentBlock.partialJson
 				? runtime.currentBlock.partialJson
 				: (item.input ?? "");
 		const toolCall: ToolCall = {
 			type: "toolCall",
-			id: encodeResponsesToolCallId(item.call_id, item.id),
+			id,
 			name: item.name,
 			arguments: { input: rawInput },
 			customWireName: item.name,
@@ -1349,6 +1357,10 @@ function handleResponseCompleted(
 	calculateCost(model, output.usage);
 	applyCodexServiceTierPricing(model, output.usage, response?.service_tier, runtime.requestBodyForState.service_tier);
 	output.stopReason = mapOpenAIResponsesStopReason(response?.status as OpenAI.Responses.ResponseStatus | undefined);
+	// A response cut short for length may have stopped mid-tool-call. Flag any
+	// call that never received its `output_item.done` so the agent loop rejects
+	// the truncated arguments instead of executing a best-effort partial parse.
+	flagTruncatedToolCalls(output, output.stopReason, block => runtime.finalizedToolCallIds.has(block.id));
 	if (output.content.some(block => block.type === "toolCall") && output.stopReason === "stop") {
 		output.stopReason = "toolUse";
 	}

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -51,7 +51,7 @@ import {
 	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
-import { parseStreamingJson } from "../utils/json-parse";
+import { isCompleteJson, parseStreamingJson } from "../utils/json-parse";
 import { parseGitHubCopilotApiKey } from "../utils/oauth/github-copilot";
 import { getKimiCommonHeaders } from "../utils/oauth/kimi";
 import { notifyProviderResponse } from "../utils/provider-response";
@@ -886,6 +886,17 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 					// only that natural-completion finish — leave `error`,
 					// `length`, `aborted`, etc. untouched.
 					output.stopReason = "toolUse";
+				}
+			}
+
+			// A turn cut short for length may have stopped mid-tool-call. The open
+			// block's `partialArgs` would otherwise be repaired into a plausible-
+			// but-wrong object by `finishCurrentBlock`; flag it first so the agent
+			// loop rejects the truncated call instead of executing it.
+			if (output.stopReason === "length" && currentBlock?.type === "toolCall") {
+				const partial = (currentBlock as { partialArgs?: string }).partialArgs;
+				if (partial !== undefined && !isCompleteJson(partial)) {
+					currentBlock.incompleteArguments = true;
 				}
 			}
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -711,18 +711,12 @@ export async function processResponsesStream<TApi extends Api>(
 				throw new Error(message);
 			}
 			// A response cut short for length (`incomplete`) may have stopped
-			// mid-tool-call. `parseStreamingJson` would silently repair the partial
-			// arguments into a plausible-but-wrong object; flag those calls so the
-			// agent loop rejects them instead of executing truncated input.
-			if (output.stopReason === "length") {
-				for (const block of output.content) {
-					if (block.type !== "toolCall") continue;
-					const partial = (block as { partialJson?: string }).partialJson;
-					if (partial !== undefined && !isCompleteJson(partial)) {
-						block.incompleteArguments = true;
-					}
-				}
-			}
+			// mid-tool-call. Any tool-call item still tracked in `items` never
+			// received its terminal `output_item.done`, so it was cut off; flag it
+			// (along with any finalized-but-unparseable JSON call) so the agent loop
+			// rejects it instead of executing repaired/partial arguments.
+			const openBlocks = new Set<unknown>(Array.from(items.values(), entry => entry.block));
+			flagTruncatedToolCalls(output, output.stopReason, block => !openBlocks.has(block));
 			if (output.content.some(block => block.type === "toolCall") && output.stopReason === "stop") {
 				output.stopReason = "toolUse";
 			}
@@ -737,6 +731,41 @@ export async function processResponsesStream<TApi extends Api>(
 					? `incomplete: ${details.reason}`
 					: "Unknown error (no error details in response)";
 			throw new Error(message);
+		}
+	}
+}
+
+/**
+ * Mark tool-call blocks left incomplete by a length-truncated response so the
+ * agent loop rejects them instead of executing a best-effort partial parse.
+ *
+ * The universal signal is finalization: a call that never received its terminal
+ * `output_item.done` (passed in via `isFinalized`) was cut off mid-arguments.
+ * This covers both JSON function calls and raw-input custom tools without
+ * mis-flagging a *completed* custom tool whose raw input is not valid JSON. As a
+ * defensive secondary, a finalized JSON function call whose buffered arguments
+ * still don't parse (e.g. a misbehaving relay) is flagged too. No-op unless the
+ * turn stopped for length.
+ *
+ * Shared by both Responses providers (`openai-responses`, `openai-codex-responses`).
+ */
+export function flagTruncatedToolCalls(
+	output: AssistantMessage,
+	stopReason: StopReason,
+	isFinalized: (block: ToolCall) => boolean,
+): void {
+	if (stopReason !== "length") return;
+	for (const block of output.content) {
+		if (block.type !== "toolCall") continue;
+		if (!isFinalized(block)) {
+			block.incompleteArguments = true;
+			continue;
+		}
+		// Finalized: custom tools carry raw (non-JSON) input and are complete once
+		// finalized; only JSON function calls get the parse double-check.
+		if (!block.customWireName) {
+			const partial = (block as { partialJson?: string }).partialJson;
+			if (partial !== undefined && !isCompleteJson(partial)) block.incompleteArguments = true;
 		}
 	}
 }

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -30,7 +30,7 @@ import {
 } from "../types";
 import { normalizeResponsesToolCallId } from "../utils";
 import type { AssistantMessageEventStream } from "../utils/event-stream";
-import { parseStreamingJson } from "../utils/json-parse";
+import { isCompleteJson, parseStreamingJson } from "../utils/json-parse";
 import { joinTextWithImagePlaceholder, NON_VISION_IMAGE_PLACEHOLDER, partitionVisionContent } from "./vision-guard";
 
 export function encodeTextSignatureV1(id: string, phase?: TextSignatureV1["phase"]): string {
@@ -709,6 +709,19 @@ export async function processResponsesStream<TApi extends Api>(
 							? `status_details: ${statusDetailsReason}`
 							: "Unknown error (no error details in response)";
 				throw new Error(message);
+			}
+			// A response cut short for length (`incomplete`) may have stopped
+			// mid-tool-call. `parseStreamingJson` would silently repair the partial
+			// arguments into a plausible-but-wrong object; flag those calls so the
+			// agent loop rejects them instead of executing truncated input.
+			if (output.stopReason === "length") {
+				for (const block of output.content) {
+					if (block.type !== "toolCall") continue;
+					const partial = (block as { partialJson?: string }).partialJson;
+					if (partial !== undefined && !isCompleteJson(partial)) {
+						block.incompleteArguments = true;
+					}
+				}
 			}
 			if (output.content.some(block => block.type === "toolCall") && output.stopReason === "stop") {
 				output.stopReason = "toolUse";

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -490,6 +490,14 @@ export interface ToolCall {
 	 * JSON function tools.
 	 */
 	customWireName?: string;
+	/**
+	 * Set when the provider detected the argument JSON was truncated — the model
+	 * hit its output-token limit (or the response was otherwise cut short) before
+	 * emitting a complete arguments object. The `arguments` field then holds a
+	 * best-effort partial parse and must not be executed as-is; the agent loop
+	 * rejects the call with a retryable error instead.
+	 */
+	incompleteArguments?: boolean;
 }
 
 export interface Usage {

--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -146,3 +146,21 @@ export function parseStreamingJson<T = Record<string, unknown>>(partialJson: str
 		}
 	}
 }
+
+/**
+ * Whether a string is a complete, well-formed JSON document (strict parse, no
+ * repair). Used to distinguish a tool-call argument blob that finished cleanly
+ * from one that was cut off mid-stream (truncation). An empty / whitespace-only
+ * string is treated as complete: a tool invoked with no arguments legitimately
+ * streams an empty buffer and must not be flagged as truncated.
+ */
+export function isCompleteJson(text: string | undefined): boolean {
+	const trimmed = text?.trim();
+	if (!trimmed) return true;
+	try {
+		JSON.parse(trimmed);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/packages/ai/test/openai-codex-truncated-toolcall.test.ts
+++ b/packages/ai/test/openai-codex-truncated-toolcall.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { streamOpenAICodexResponses } from "@gajae-code/ai/providers/openai-codex-responses";
+import type { Context, Model, ToolCall } from "@gajae-code/ai/types";
+import { getAgentDir, setAgentDir, TempDir } from "@gajae-code/utils";
+
+// The Codex Responses provider has its own stream handlers; the truncated
+// tool-call guard must cover it too. A `function_call` that never receives its
+// `output_item.done` before a length-truncated completion must be flagged.
+
+const originalFetch = global.fetch;
+const originalAgentDir = getAgentDir();
+afterEach(() => {
+	global.fetch = originalFetch;
+	setAgentDir(originalAgentDir);
+});
+
+function token(): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acc_test" } }),
+		"utf8",
+	).toBase64();
+	return `aaa.${payload}.bbb`;
+}
+
+function model(): Model<"openai-codex-responses"> {
+	return {
+		id: "gpt-5.3-codex-spark",
+		name: "Codex",
+		api: "openai-codex-responses",
+		provider: "openai-codex",
+		baseUrl: "https://chatgpt.com/backend-api",
+		reasoning: true,
+		preferWebsockets: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 128000,
+	};
+}
+
+function context(): Context {
+	return { systemPrompt: ["You are helpful."], messages: [{ role: "user", content: "go", timestamp: Date.now() }] };
+}
+
+function sse(events: unknown[]): string {
+	return `${events.map(e => `data: ${JSON.stringify(e)}`).join("\n\n")}\n\n`;
+}
+
+function mockFetchOnce(body: string): void {
+	const fn = async (): Promise<Response> =>
+		new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+	global.fetch = Object.assign(fn, { preconnect: originalFetch.preconnect });
+}
+
+const USAGE = { input_tokens: 5, output_tokens: 3, total_tokens: 8, input_tokens_details: { cached_tokens: 0 } };
+
+describe("openai-codex: truncated tool-call detection", () => {
+	it("flags a function call cut off before output_item.done (status incomplete)", async () => {
+		setAgentDir(TempDir.createSync("@pi-codex-trunc-").path());
+		mockFetchOnce(
+			sse([
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "write_file", arguments: "" },
+				},
+				{
+					type: "response.function_call_arguments.delta",
+					item_id: "fc_1",
+					output_index: 0,
+					delta: '{"path":"a.ts","content":"partial',
+				},
+				{ type: "response.incomplete", response: { status: "incomplete", usage: USAGE } },
+			]),
+		);
+
+		const result = await streamOpenAICodexResponses(model(), context(), { apiKey: token() }).result();
+		expect(result.stopReason).toBe("length");
+		const tools = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(tools).toHaveLength(1);
+		expect(tools[0].name).toBe("write_file");
+		expect(tools[0].incompleteArguments).toBe(true);
+	});
+
+	it("does NOT flag a completed function call", async () => {
+		setAgentDir(TempDir.createSync("@pi-codex-trunc-").path());
+		mockFetchOnce(
+			sse([
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "read_file", arguments: "" },
+				},
+				{
+					type: "response.function_call_arguments.delta",
+					item_id: "fc_1",
+					output_index: 0,
+					delta: '{"path":"a.ts"}',
+				},
+				{
+					type: "response.function_call_arguments.done",
+					item_id: "fc_1",
+					output_index: 0,
+					arguments: '{"path":"a.ts"}',
+				},
+				{
+					type: "response.output_item.done",
+					output_index: 0,
+					item: {
+						type: "function_call",
+						id: "fc_1",
+						call_id: "call_1",
+						name: "read_file",
+						arguments: '{"path":"a.ts"}',
+					},
+				},
+				{ type: "response.completed", response: { status: "completed", usage: USAGE } },
+			]),
+		);
+
+		const result = await streamOpenAICodexResponses(model(), context(), { apiKey: token() }).result();
+		const tools = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(tools).toHaveLength(1);
+		expect(tools[0].incompleteArguments).toBeFalsy();
+	});
+
+	it("flags a custom tool whose raw input was cut off; not a completed one", async () => {
+		setAgentDir(TempDir.createSync("@pi-codex-trunc-").path());
+		// Truncated custom tool.
+		mockFetchOnce(
+			sse([
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "custom_tool_call", id: "ct_1", call_id: "call_1", name: "apply_patch", input: "" },
+				},
+				{
+					type: "response.custom_tool_call_input.delta",
+					item_id: "ct_1",
+					output_index: 0,
+					delta: "*** Begin Patch\n+const x =",
+				},
+				{ type: "response.incomplete", response: { status: "incomplete", usage: USAGE } },
+			]),
+		);
+		let result = await streamOpenAICodexResponses(model(), context(), { apiKey: token() }).result();
+		let tools = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(tools[0].customWireName).toBe("apply_patch");
+		expect(tools[0].incompleteArguments).toBe(true);
+
+		// Completed custom tool on a truncated turn — must NOT be flagged.
+		const fullPatch = "*** Begin Patch\n+const x = 1\n*** End Patch";
+		mockFetchOnce(
+			sse([
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "custom_tool_call", id: "ct_2", call_id: "call_2", name: "apply_patch", input: "" },
+				},
+				{ type: "response.custom_tool_call_input.delta", item_id: "ct_2", output_index: 0, delta: fullPatch },
+				{ type: "response.custom_tool_call_input.done", item_id: "ct_2", output_index: 0, input: fullPatch },
+				{
+					type: "response.output_item.done",
+					output_index: 0,
+					item: { type: "custom_tool_call", id: "ct_2", call_id: "call_2", name: "apply_patch", input: fullPatch },
+				},
+				{ type: "response.incomplete", response: { status: "incomplete", usage: USAGE } },
+			]),
+		);
+		result = await streamOpenAICodexResponses(model(), context(), { apiKey: token() }).result();
+		tools = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(tools[0].incompleteArguments).toBeFalsy();
+	});
+});

--- a/packages/ai/test/openai-completions-truncated-toolcall.test.ts
+++ b/packages/ai/test/openai-completions-truncated-toolcall.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { streamOpenAICompletions } from "@gajae-code/ai/providers/openai-completions";
+import type { Context, Model, ToolCall } from "@gajae-code/ai/types";
+
+// finish_reason "length" can land mid-tool-call. The provider must flag the open
+// call's truncated arguments so the agent loop rejects it rather than executing
+// a best-effort partial parse.
+
+const originalFetch = global.fetch;
+afterEach(() => {
+	global.fetch = originalFetch;
+});
+
+interface ToolCallDelta {
+	index: number;
+	id?: string;
+	type?: "function";
+	function?: { name?: string; arguments?: string };
+}
+interface SseChunk {
+	id: string;
+	object: "chat.completion.chunk";
+	created: number;
+	model: string;
+	choices: Array<{
+		index: number;
+		delta: { content?: string; tool_calls?: ToolCallDelta[] };
+		finish_reason?: "stop" | "length" | "tool_calls" | null;
+	}>;
+}
+
+function sseResponse(events: ReadonlyArray<SseChunk | "[DONE]">): Response {
+	const payload = `${events.map(e => `data: ${typeof e === "string" ? e : JSON.stringify(e)}`).join("\n\n")}\n\n`;
+	return new Response(payload, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+function mockFetch(events: ReadonlyArray<SseChunk | "[DONE]">): typeof fetch {
+	const fn = async (): Promise<Response> => sseResponse(events);
+	return Object.assign(fn, { preconnect: originalFetch.preconnect });
+}
+function chunk(
+	delta: SseChunk["choices"][0]["delta"],
+	finish: SseChunk["choices"][0]["finish_reason"] = null,
+): SseChunk {
+	return {
+		id: "chatcmpl-trunc",
+		object: "chat.completion.chunk",
+		created: 0,
+		model: "test-model",
+		choices: [{ index: 0, delta, finish_reason: finish }],
+	};
+}
+function model(): Model<"openai-completions"> {
+	return {
+		id: "test-model",
+		name: "Test",
+		api: "openai-completions",
+		provider: "test-provider",
+		baseUrl: "https://example.com/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	};
+}
+function context(): Context {
+	return { messages: [{ role: "user", content: "go", timestamp: Date.now() }] };
+}
+
+describe("chat-completions: truncated tool-call detection", () => {
+	it("flags a tool call whose arguments are cut off by finish_reason length", async () => {
+		global.fetch = mockFetch([
+			chunk({
+				tool_calls: [
+					{
+						index: 0,
+						id: "call_1",
+						type: "function",
+						function: { name: "write_file", arguments: '{"path":"a.ts","content":"hello' },
+					},
+				],
+			}),
+			chunk({}, "length"),
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model(), context(), { apiKey: "test" }).result();
+		const tools = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(tools).toHaveLength(1);
+		expect(tools[0].name).toBe("write_file");
+		expect(tools[0].incompleteArguments).toBe(true);
+		expect(result.stopReason).toBe("length");
+	});
+
+	it("does NOT flag a tool call whose arguments completed before length truncation", async () => {
+		global.fetch = mockFetch([
+			chunk({
+				tool_calls: [
+					{
+						index: 0,
+						id: "call_1",
+						type: "function",
+						function: { name: "read_file", arguments: '{"path":"a.ts"}' },
+					},
+				],
+			}),
+			// finish_reason length, but the args JSON is already complete.
+			chunk({}, "length"),
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model(), context(), { apiKey: "test" }).result();
+		const tools = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(tools).toHaveLength(1);
+		expect(tools[0].arguments).toEqual({ path: "a.ts" });
+		expect(tools[0].incompleteArguments).toBeFalsy();
+	});
+
+	it("does NOT flag a normally completed tool call", async () => {
+		global.fetch = mockFetch([
+			chunk({
+				tool_calls: [
+					{
+						index: 0,
+						id: "call_1",
+						type: "function",
+						function: { name: "read_file", arguments: '{"path":"a.ts"}' },
+					},
+				],
+			}),
+			chunk({}, "tool_calls"),
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model(), context(), { apiKey: "test" }).result();
+		const tools = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(tools[0].incompleteArguments).toBeFalsy();
+		expect(result.stopReason).toBe("toolUse");
+	});
+});

--- a/packages/ai/test/openai-responses-truncated-toolcall.test.ts
+++ b/packages/ai/test/openai-responses-truncated-toolcall.test.ts
@@ -153,6 +153,63 @@ describe("Responses provider: truncated tool-call detection", () => {
 		expect(output.stopReason).toBe("toolUse");
 		expect(toolBlocks(output)[0].incompleteArguments).toBeFalsy();
 	});
+
+	test("flags a custom tool whose raw input was cut off (status incomplete)", async () => {
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "custom_tool_call", id: "ct_1", call_id: "call_1", name: "apply_patch", input: "" },
+			},
+			// Raw, non-JSON input that ends mid-stream.
+			{
+				type: "response.custom_tool_call_input.delta",
+				item_id: "ct_1",
+				output_index: 0,
+				delta: "*** Begin Patch\n*** Update File: a.ts\n@@\n+const x =",
+			},
+			{ type: "response.completed", response: { id: "resp_1", status: "incomplete" } },
+		];
+		const output = makeOutput();
+		const { stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		expect(output.stopReason).toBe("length");
+		const tools = toolBlocks(output);
+		expect(tools).toHaveLength(1);
+		expect(tools[0].customWireName).toBe("apply_patch");
+		expect(tools[0].incompleteArguments).toBe(true);
+	});
+
+	test("does NOT flag a COMPLETED custom tool even when the turn truncates (no JSON false-positive)", async () => {
+		// Regression: the raw custom-tool input is not valid JSON, so a naive
+		// `isCompleteJson` check would wrongly flag a finished apply_patch call.
+		const fullPatch = "*** Begin Patch\n*** Update File: a.ts\n@@\n+const x = 1\n*** End Patch";
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "custom_tool_call", id: "ct_1", call_id: "call_1", name: "apply_patch", input: "" },
+			},
+			{ type: "response.custom_tool_call_input.delta", item_id: "ct_1", output_index: 0, delta: fullPatch },
+			{ type: "response.custom_tool_call_input.done", item_id: "ct_1", output_index: 0, input: fullPatch },
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: { type: "custom_tool_call", id: "ct_1", call_id: "call_1", name: "apply_patch", input: fullPatch },
+			},
+			// Turn truncated on trailing content AFTER the tool call finished.
+			{ type: "response.completed", response: { id: "resp_1", status: "incomplete" } },
+		];
+		const output = makeOutput();
+		const { stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		const tools = toolBlocks(output);
+		expect(tools).toHaveLength(1);
+		expect(tools[0].arguments).toEqual({ input: fullPatch });
+		expect(tools[0].incompleteArguments).toBeFalsy();
+	});
 });
 
 describe("isCompleteJson", () => {

--- a/packages/ai/test/openai-responses-truncated-toolcall.test.ts
+++ b/packages/ai/test/openai-responses-truncated-toolcall.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+import { processResponsesStream } from "@gajae-code/ai/providers/openai-responses-shared";
+import type { AssistantMessage, Model, ToolCall } from "@gajae-code/ai/types";
+import { isCompleteJson } from "@gajae-code/ai/utils/json-parse";
+import type { ResponseStreamEvent } from "openai/resources/responses/responses";
+
+// A response cut short for length (`incomplete`) can stop mid-tool-call. The
+// streaming JSON parser repairs the partial arguments into a plausible-but-wrong
+// object; the provider must flag such calls so the agent loop can reject them.
+
+async function* makeStream(events: unknown[]): AsyncIterable<ResponseStreamEvent> {
+	for (const e of events) yield e as ResponseStreamEvent;
+}
+
+function makeModel(): Model<"openai-responses"> {
+	return {
+		id: "test-model",
+		name: "Test",
+		api: "openai-responses",
+		provider: "test-provider",
+		baseUrl: "https://example.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	};
+}
+
+function makeOutput(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		timestamp: Date.now(),
+		provider: "test-provider",
+		model: "test-model",
+		api: "openai-responses",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+	};
+}
+
+function makeCapture() {
+	const emitted: Array<Record<string, unknown>> = [];
+	const stream = { push: (e: Record<string, unknown>) => emitted.push(e), end: () => {} } as never;
+	return { emitted, stream };
+}
+
+function toolBlocks(output: AssistantMessage): ToolCall[] {
+	return output.content.filter(b => b.type === "toolCall") as ToolCall[];
+}
+
+describe("Responses provider: truncated tool-call detection", () => {
+	test("flags a tool call whose arguments were cut off (status incomplete)", async () => {
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "write_file", arguments: "" },
+			},
+			// Partial, structurally-incomplete JSON — the stream ends before it closes.
+			{
+				type: "response.function_call_arguments.delta",
+				item_id: "fc_1",
+				output_index: 0,
+				delta: '{"path":"/etc/hosts","content":"line1\\nline2',
+			},
+			{
+				type: "response.completed",
+				response: { id: "resp_1", status: "incomplete", incomplete_details: { reason: "max_output_tokens" } },
+			},
+		];
+		const output = makeOutput();
+		const { stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		expect(output.stopReason).toBe("length");
+		const tools = toolBlocks(output);
+		expect(tools).toHaveLength(1);
+		expect(tools[0].name).toBe("write_file");
+		expect(tools[0].incompleteArguments).toBe(true);
+	});
+
+	test("does NOT flag a completed tool call even if the turn later truncates", async () => {
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "read_file", arguments: "" },
+			},
+			{ type: "response.function_call_arguments.delta", item_id: "fc_1", output_index: 0, delta: '{"path":"a.ts"}' },
+			{
+				type: "response.function_call_arguments.done",
+				item_id: "fc_1",
+				output_index: 0,
+				arguments: '{"path":"a.ts"}',
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: {
+					type: "function_call",
+					id: "fc_1",
+					call_id: "call_1",
+					name: "read_file",
+					arguments: '{"path":"a.ts"}',
+				},
+			},
+			{ type: "response.completed", response: { id: "resp_1", status: "incomplete" } },
+		];
+		const output = makeOutput();
+		const { stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		const tools = toolBlocks(output);
+		expect(tools).toHaveLength(1);
+		expect(tools[0].arguments).toEqual({ path: "a.ts" });
+		expect(tools[0].incompleteArguments).toBeFalsy();
+	});
+
+	test("does NOT flag tool calls on a normally completed turn", async () => {
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "read_file", arguments: "" },
+			},
+			{ type: "response.function_call_arguments.delta", item_id: "fc_1", output_index: 0, delta: '{"path":"a.ts"}' },
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: {
+					type: "function_call",
+					id: "fc_1",
+					call_id: "call_1",
+					name: "read_file",
+					arguments: '{"path":"a.ts"}',
+				},
+			},
+			{ type: "response.completed", response: { id: "resp_1", status: "completed" } },
+		];
+		const output = makeOutput();
+		const { stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		expect(output.stopReason).toBe("toolUse");
+		expect(toolBlocks(output)[0].incompleteArguments).toBeFalsy();
+	});
+});
+
+describe("isCompleteJson", () => {
+	test("treats empty / whitespace as complete (no-arg tools)", () => {
+		expect(isCompleteJson("")).toBe(true);
+		expect(isCompleteJson("   ")).toBe(true);
+		expect(isCompleteJson(undefined)).toBe(true);
+	});
+	test("accepts well-formed JSON", () => {
+		expect(isCompleteJson('{"a":1}')).toBe(true);
+		expect(isCompleteJson("[1,2,3]")).toBe(true);
+		expect(isCompleteJson('"str"')).toBe(true);
+	});
+	test("rejects truncated JSON", () => {
+		expect(isCompleteJson('{"a":1')).toBe(false);
+		expect(isCompleteJson('{"path":"/etc/hosts","content":"line1')).toBe(false);
+		expect(isCompleteJson("[1,2,")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Problem

When a response is cut short for length mid-tool-call —

- chat-completions: `finish_reason: "length"`
- Responses: `status: "incomplete"` (`incomplete_details.reason: "max_output_tokens"`)

— the accumulated argument JSON is incomplete. `parseStreamingJson` **silently
repairs** it (partial-json closes open structures) into a structurally-valid but
semantically-wrong object. The tool then executes on garbage:

- the deep-interview `proxy_ask` panel renders a half-formed question,
- a file write runs with truncated content,

…with **no signal** that truncation happened. There is no completeness check on
the payload before the call dispatches.

## Fix

Detect truncation at the provider boundary:

- Add `isCompleteJson()` (strict parse; empty/whitespace = complete, so no-arg
  tools aren't flagged).
- When the turn stopped for length **and** a tool call's raw argument buffer does
  not strictly parse, set the new `ToolCall.incompleteArguments` flag.
- The agent loop rejects flagged calls **before execution** with a retryable,
  actionable error — *"…was cut off before its arguments finished streaming … 
  Re-issue the call with complete arguments…"* — surfaced to the model as the
  tool result, instead of running the tool on the partial parse.

A tool call whose arguments completed *before* a later truncation is **not**
flagged. Wired into both the chat-completions and Responses providers.

## Tests

- `isCompleteJson` unit cases (empty / well-formed / truncated).
- Provider integration tests through the **real** parsers: truncated-mid-call,
  completed-then-truncated, and clean turns — for both completions and Responses.
- Agent-loop test: a flagged call is rejected (the tool's `execute` never runs)
  with the actionable message; an unflagged call still executes normally.
- Full `packages/ai` (1517) + `packages/agent` (314) suites pass.

## Verification

- `bun run check:types` clean (ai + agent); biome clean.
- Live `gjc -p` turn against a LiteLLM proxy completed normally — no regression
  on the live streaming path.

## Relationship to #1023

Complementary. #1023 recovers tool calls that leak into visible text (a *missing*
call); this PR rejects tool calls whose arguments arrived *incomplete* (a
*corrupt* call). Together they close the "payload completeness" gap behind the
intermittent deep-interview render failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)