### PR TITLE
test(coding-agent): fix idle compaction controller mock

### DIFF
--- a/packages/coding-agent/test/modes/controllers/event-controller-idle-compaction.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-idle-compaction.test.ts
@@ -59,6 +59,7 @@ describe("EventController idle compaction teardown", () => {
 			statusContainer: { clear: vi.fn() },
 			statusLine: { invalidate: vi.fn() },
 			updateEditorTopBorder: vi.fn(),
+			updateEditorBorderColor: vi.fn(),
 			editor: { getText: () => "" },
 			sessionManager: { getSessionName: () => undefined },
 			session: {


### PR DESCRIPTION
## Summary
- add the missing updateEditorBorderColor test double to the idle compaction EventController unit test
- restores the post-#1022 dev affected coding-agent test path without changing runtime behavior

## Verification
- bun test packages/coding-agent/test/modes/controllers/event-controller-idle-compaction.test.ts

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*