### PR TITLE
feat(coding-agent): hard guard Composer bash file IO

### DIFF
--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -25,6 +25,7 @@ import { type BashInteractiveResult, runInteractiveBashPty } from "./bash-intera
 import { checkBashInterception } from "./bash-interceptor";
 import { canUseInteractiveBashPty } from "./bash-pty-selection";
 import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-skill-urls";
+import { checkComposerBashPolicy } from "./composer-bash-policy";
 import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
 import { formatToolWorkingDirectory, replaceTabs } from "./render-utils";
@@ -568,6 +569,14 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					throw new ToolError(interception.message ?? "Command blocked");
 				}
 			}
+		}
+
+		const composerPolicy = checkComposerBashPolicy({
+			modelId: this.session.getActiveModelString?.() ?? this.session.getModelString?.() ?? this.session.model?.id,
+			commands: rawCommand === command ? [command] : [rawCommand, command],
+		});
+		if (!composerPolicy.allowed) {
+			throw new ToolError(composerPolicy.message);
 		}
 
 		const internalUrlOptions: InternalUrlExpansionOptions = {

--- a/packages/coding-agent/src/tools/composer-bash-policy.ts
+++ b/packages/coding-agent/src/tools/composer-bash-policy.ts
@@ -1,0 +1,96 @@
+import { isComposerHarnessModel } from "@gajae-code/ai/providers/composer-discipline";
+
+export const COMPOSER_BASH_POLICY_ERROR =
+	"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.";
+
+type ComposerBashPolicyResult =
+	| { allowed: true }
+	| {
+			allowed: false;
+			reason: string;
+			message: string;
+	  };
+
+const BLOCK_PATTERNS: Array<{ id: string; pattern: RegExp }> = [
+	{ id: "pipe", pattern: /\|/ },
+	{ id: "process-substitution", pattern: /<[>(]/ },
+	{ id: "heredoc", pattern: /<<[-~]?/ },
+	{ id: "command-substitution", pattern: /\$\(|`/ },
+	{ id: "redirection", pattern: /(^|[^<>])(?:>>?|<)(?!=)/ },
+	{ id: "tee", pattern: /(?:^|[;&|\s])tee(?:\s|$)/ },
+	{
+		id: "shell-file-read-discovery",
+		pattern: /(?:^|[;&|()\s])(?:\S*\/)?(?:cat|head|tail|less|more|grep|rg|find|fd|tree|ls)\b/,
+	},
+	{
+		id: "shell-file-mutation",
+		pattern: /(?:^|[;&|()\s])(?:\S*\/)?(?:cp|mv|rm|touch|mkdir|chmod|chown|ln)\b/,
+	},
+	{ id: "sed-print", pattern: /(?:^|[;&|()\s])sed\s+(?:-[^\s]*n\b|.*\bp\b)/ },
+	{ id: "awk-print", pattern: /(?:^|[;&|()\s])awk\b/ },
+	{ id: "git-ls-files", pattern: /(?:^|[;&|()\s])git(?:\s+-C\s+\S+)?\s+ls-files\b/ },
+	{ id: "git-grep", pattern: /(?:^|[;&|()\s])git(?:\s+-C\s+\S+)?\s+grep\b/ },
+	{ id: "git-show-path", pattern: /(?:^|[;&|()\s])git(?:\s+-C\s+\S+)?\s+show\s+\S+:\S+/ },
+	{ id: "git-diff", pattern: /(?:^|[;&|()\s])git(?:\s+-C\s+\S+)?\s+diff(?:\s|$)/ },
+	{ id: "git-cat-file", pattern: /(?:^|[;&|()\s])git(?:\s+-C\s+\S+)?\s+cat-file\b/ },
+	{
+		id: "git-show-discovery",
+		pattern: /(?:^|[;&|()\s])git(?:\s+-C\s+\S+)?\s+show\b.*(?:--name-only|--name-status|--stat)/,
+	},
+	{
+		id: "git-log-path-discovery",
+		pattern: /(?:^|[;&|()\s])git(?:\s+-C\s+\S+)?\s+log\b.*(?:--name-only|--name-status|--stat)/,
+	},
+	{ id: "sed-in-place", pattern: /(?:^|[;&|()\s])sed\s+-[^\s]*i\b/ },
+	{ id: "perl-in-place", pattern: /(?:^|[;&|()\s])perl\s+-[^\s]*p[^\s]*i\b/ },
+	{
+		id: "script-file-io",
+		pattern:
+			/(?:^|[;&|()\s])(?:python3?|node|bun)\s+(?:-\s*<<|-c\b|-e\b|--eval\b).*?(?:read_text|read_bytes|write_text|iterdir|listdir|glob\.glob|readFile|readFileSync|writeFile|writeFileSync|readdir|readdirSync|stat|statSync|cpSync|rmSync|mkdirSync|createReadStream|createWriteStream|Bun\.file|Bun\.write|fs\.readFile|fs\.writeFile|fs\.readdir|fs\.stat|fs\.cp|fs\.rm|fs\.mkdir|open\s*\()/s,
+	},
+	{
+		id: "contaminated-command",
+		pattern: /```|^\s*(?:I\s+(?:will|need|am going)|We\s+(?:need|will)|First[, ]|Now[, ]|Let's)\b/im,
+	},
+];
+
+const ALLOWED_TERMINAL_PATTERNS: RegExp[] = [
+	/^bun\s+test(?:\s+[\w./:@=-]+)*$/,
+	/^bun\s+run\s+(?:check(?::[\w-]+)?|test(?::[\w-]+)?|build(?::[\w-]+)?)(?:\s+[\w./:@=-]+)*$/,
+	/^bun\s+--version$/,
+	/^mise\s+x\s+bun@\d+\.\d+\.\d+\s+--\s+bun\s+test(?:\s+[\w./:@=-]+)*$/,
+	/^mise\s+x\s+bun@\d+\.\d+\.\d+\s+--\s+bun\s+run\s+(?:check(?::[\w-]+)?|test(?::[\w-]+)?|build(?::[\w-]+)?)(?:\s+[\w./:@=-]+)*$/,
+	/^cargo\s+(?:test|check|build)(?:\s+[\w./:@=-]+)*$/,
+	/^git\s+status(?:\s+--short)?(?:\s+--branch)?$/,
+	/^git\s+rev-parse\s+HEAD$/,
+	/^npm\s+--version$/,
+	/^pnpm\s+--version$/,
+	/^yarn\s+--version$/,
+];
+
+function isAllowedComposerTerminalCommand(command: string): boolean {
+	const normalized = command.trim().replace(/\s+/g, " ");
+	return ALLOWED_TERMINAL_PATTERNS.some(pattern => pattern.test(normalized));
+}
+
+export function isComposerBashPolicyModel(modelId: string | undefined): boolean {
+	return Boolean(modelId && isComposerHarnessModel(modelId));
+}
+
+export function checkComposerBashPolicy(input: {
+	modelId?: string;
+	commands: readonly string[];
+}): ComposerBashPolicyResult {
+	if (!isComposerBashPolicyModel(input.modelId)) return { allowed: true };
+	for (const command of input.commands) {
+		for (const block of BLOCK_PATTERNS) {
+			if (block.pattern.test(command)) {
+				return { allowed: false, reason: block.id, message: COMPOSER_BASH_POLICY_ERROR };
+			}
+		}
+		if (!isAllowedComposerTerminalCommand(command)) {
+			return { allowed: false, reason: "not-allowlisted", message: COMPOSER_BASH_POLICY_ERROR };
+		}
+	}
+	return { allowed: true };
+}

--- a/packages/coding-agent/test/tools/composer-bash-policy.test.ts
+++ b/packages/coding-agent/test/tools/composer-bash-policy.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "bun:test";
+import {
+	COMPOSER_BASH_POLICY_ERROR,
+	checkComposerBashPolicy,
+	isComposerBashPolicyModel,
+} from "../../src/tools/composer-bash-policy";
+
+const COMPOSER_MODEL = "grok-build/grok-composer-2.5-fast";
+const NON_COMPOSER_MODEL = "openai-codex/gpt-5.5";
+
+describe("composer bash policy", () => {
+	it("matches only composer harness models", () => {
+		expect(isComposerBashPolicyModel("xai/grok-composer-2.5-fast")).toBe(true);
+		expect(isComposerBashPolicyModel("cursor/composer2.5-fast")).toBe(true);
+		expect(isComposerBashPolicyModel("gpt-5.5")).toBe(false);
+		expect(isComposerBashPolicyModel("decomposer-2.5")).toBe(false);
+	});
+
+	it.each([
+		"cat src/secret.ts",
+		"/bin/cat src/secret.ts",
+		"'cat' src/file.ts",
+		'"cat" src/file.ts',
+		"c\\at src/file.ts",
+		"head -n 20 src/file.ts",
+		"sed -n '1,20p' src/file.ts",
+		"awk '{print}' src/file.ts",
+		"grep -R needle src",
+		"rg needle src",
+		"find src -name '*.ts'",
+		"fd target src",
+		"tree src",
+		"ls src",
+		"git ls-files '*.ts'",
+		"git cat-file -p HEAD:src/file.ts",
+		"git show --name-only HEAD",
+		"git show --stat HEAD",
+		"git grep needle",
+		"git --no-pager grep needle",
+		"git -c core.pager=cat show HEAD:src/file.ts",
+		"git --git-dir=.git ls-files",
+		"git show HEAD:src/file.ts",
+		"git diff",
+		"git log --name-only -1",
+		"cp src/a.ts src/b.ts",
+		"mv src/a.ts src/b.ts",
+		"rm src/a.ts",
+		"touch src/new.ts",
+		"mkdir src/newdir",
+		"chmod 644 src/a.ts",
+		"chown user src/a.ts",
+		"python -c \"open('src/file.ts').read()\"",
+		"python -c \"from pathlib import Path; Path('src/file.ts').read_bytes()\"",
+		"python -c \"import os; print(os.listdir('src'))\"",
+		"python -c \"from pathlib import Path; print(list(Path('src').iterdir()))\"",
+		"python -c \"import os; print(list(os.scandir('src')))\"",
+		"python -c \"from pathlib import Path; Path('src/file.ts').unlink()\"",
+		"python -c \"import shutil; shutil.copyfile('a','b')\"",
+		"node --input-type=module -e \"import fs from 'node:fs'; fs.readdirSync('src')\"",
+		"node -e \"require('fs').readdirSync('src')\"",
+		"node -e \"require('fs').statSync('src/file.ts')\"",
+		"node -e \"require('fs').rmSync('src/file.ts')\"",
+		"node -e \"require('fs').writeFileSync('x','y')\"",
+		"bun -e \"await Bun.file('x').text()\"",
+		"printf x > src/file.ts",
+		"printf x | tee src/file.ts",
+		"cat <(printf x)",
+		"python - <<'PY'\nfrom pathlib import Path\nPath('x').read_text()\nPY",
+		"I will now run bun test packages/coding-agent/test/tools/composer-bash-policy.test.ts",
+	])("blocks repository file I/O for composer model: %s", command => {
+		const result = checkComposerBashPolicy({ modelId: COMPOSER_MODEL, commands: [command] });
+		expect(result.allowed).toBe(false);
+		if (!result.allowed) expect(result.message).toBe(COMPOSER_BASH_POLICY_ERROR);
+	});
+
+	it.each([
+		"bun test packages/coding-agent/test/tools/composer-bash-policy.test.ts",
+		"bun run check:types",
+		"cargo test -p pi-natives",
+		"git status --short --branch",
+		"git rev-parse HEAD",
+		"npm --version",
+		"pnpm --version",
+		"yarn --version",
+		"mise x bun@1.3.14 -- bun test packages/coding-agent/test/tools/composer-bash-policy.test.ts",
+	])("allows terminal operations for composer model: %s", command => {
+		expect(checkComposerBashPolicy({ modelId: COMPOSER_MODEL, commands: [command] })).toEqual({ allowed: true });
+	});
+
+	it("checks both raw and cwd-normalized commands", () => {
+		const result = checkComposerBashPolicy({
+			modelId: COMPOSER_MODEL,
+			commands: ["cd repo && cat src/secret.ts", "cat src/secret.ts"],
+		});
+		expect(result.allowed).toBe(false);
+	});
+
+	it("preserves non-composer behavior", () => {
+		expect(checkComposerBashPolicy({ modelId: NON_COMPOSER_MODEL, commands: ["cat src/secret.ts"] })).toEqual({
+			allowed: true,
+		});
+		expect(checkComposerBashPolicy({ commands: ["cat src/secret.ts"] })).toEqual({ allowed: true });
+	});
+});


### PR DESCRIPTION
## Summary
- add a Composer-mode bash policy that blocks repository file reads/writes through shell commands
- wire the policy into the bash tool path
- add focused coverage for blocked and allowed Composer bash commands

## Verification
- Based on latest upstream/dev: 5f0fe76a4ea1b14485d097aaf4650e85a9987088
- Conflict check: `git merge-tree --write-tree upstream/dev pr/composer-bash-hard-guard-latest-dev` passed
- Secret scan: changed-file token/key/private-key scan passed
- Whitespace check: `git diff --check upstream/dev...HEAD` passed
- Tests: `npx --yes bun@1.3.14 test packages/coding-agent/test/tools/composer-bash-policy.test.ts` -> 62 pass / 0 fail
- CI check: `npx --yes bun@1.3.14 run check:ts` -> passed
