### PR TITLE
feat(notifications): auto-verify Telegram Threaded Mode on notify setup + flat fallback

### DIFF
--- a/docs/notifications-sdk.md
+++ b/docs/notifications-sdk.md
@@ -217,8 +217,9 @@ Run the setup command once:
 gjc notify setup
 ```
 
-The wizard validates the bot token with Telegram, waits for a private DM to the
-bot, and writes canonical global Settings under `config.yml` in the GJC agent
+The wizard validates the bot token with Telegram, verifies private-chat Threaded
+Mode capability via `getMe.has_topics_enabled`, waits for a private DM to the bot,
+and writes canonical global Settings under `config.yml` in the GJC agent
 directory. It enables:
 
 - `notifications.enabled`
@@ -246,11 +247,21 @@ The trust model is intentionally strict:
   action ids, pending status, or configuration hints;
 - daemon state stores a token fingerprint, not the raw bot token.
 
-### Routing in shared chats
+### Routing in private-chat topics
 
-A single paired chat can receive actions from multiple sessions. The daemon tags
-messages by session, stores compact callback aliases for inline buttons, and
-routes replies back to the exact session/action.
+The paired private chat receives actions from multiple sessions through
+per-session Telegram topics (Threaded Mode). The daemon tags messages by session,
+stores compact callback aliases for inline buttons, and routes replies back to the
+exact session/action. A forum-enabled supergroup is no longer required: once the
+bot owner enables Threaded Mode in @BotFather, the daemon creates one topic per
+session in the paired private chat. GJC cannot enable Threaded Mode through the Bot
+API; setup only verifies the capability and guides the manual BotFather toggle.
+Even after setup verifies `has_topics_enabled`, the first runtime
+`createForumTopic` for the paired chat can still be refused by Telegram. When that
+happens the daemon does not drop the send: it routes the notification to the normal
+(flat) paired chat and posts a one-time `turn on threaded mode from botfather
+miniapp to receive gjc notification!` nudge. Pairing is private-only, so flat
+delivery stays within the user's own private DM.
 
 Supported reply paths:
 

--- a/docs/telegram-onboarding.md
+++ b/docs/telegram-onboarding.md
@@ -47,39 +47,60 @@ The wizard does this:
 
 1. prompts for `Telegram BotFather token:`;
 2. validates the token with Telegram `getMe`;
-3. asks you to message the bot from a private Telegram chat;
-4. polls Telegram `getUpdates` until it sees a private chat message;
-5. writes the paired chat id and enables notifications.
+3. verifies private-chat Threaded Mode capability via `getMe.has_topics_enabled`
+   and, when it is off in an interactive run, prints @BotFather instructions and
+   re-checks until you enable it or skip;
+4. asks you to message the bot from a private Telegram chat;
+5. polls Telegram `getUpdates` until it sees a private chat message;
+6. writes the paired chat id and enables notifications.
 
 The setup pairing flow is private-chat only. If setup sees a `group`,
 `supergroup`, or `channel`, it rejects that chat and keeps waiting for a private
 DM. This is intentional for safe local discovery: group chats must not receive
 session names, action ids, or pending status by accident.
 
-Current limitation: the managed daemon's per-session remote delivery path uses
-Telegram forum topics (`createForumTopic` + `message_thread_id`). Private chats
-do not support forum topics, so the private-chat id discovered by setup is
-sufficient for configuration discovery/status but is not enough for end-to-end
-threaded delivery. Until setup grows a forum-chat onboarding path, operators who
-want Telegram delivery must configure `notifications.telegram.chatId` to a
-trusted forum-enabled supergroup that the bot can manage. If topic creation
-fails, the daemon drops remote sends fail-closed rather than flattening session
-traffic into a shared chat.
+Telegram private-chat topics: the managed daemon's per-session delivery uses
+Telegram forum topics (`createForumTopic` + `message_thread_id`). Telegram now
+supports forum topics in **private chats** when the bot owner enables **Threaded
+Mode** for the bot in @BotFather. GJC cannot enable Threaded Mode through the Bot
+API; setup only detects the capability (`getMe.has_topics_enabled`) and guides the
+manual BotFather toggle. A forum-enabled supergroup is no longer required.
+
+Note: enabling topics in private chats may require an additional Telegram Stars
+purchase fee, per Telegram's Terms of Service for Bot Developers.
+
+Setup verification is capability verification, not a delivery guarantee: even when
+setup reports `threaded=verified`, the first runtime `createForumTopic` for the
+paired chat can still fail if Telegram refuses it. When per-session topics are
+unavailable, the daemon does **not** drop notifications — it routes them to the
+normal (flat) paired chat and posts a one-time nudge: `turn on threaded mode from
+botfather miniapp to receive gjc notification!`. Because pairing is private-only,
+flat delivery lands in your own private DM with the bot.
+
+The final setup line reports a `threaded=` status:
+
+- `threaded=verified`: the bot has Threaded Mode capability (`has_topics_enabled`
+  was true during setup);
+- `threaded=unverified`: Threaded Mode was off and you skipped, or setup ran
+  non-interactively; setup is saved, but enable Threaded Mode in @BotFather before
+  expecting per-session delivery;
+- `threaded=unknown`: the Telegram response did not include `has_topics_enabled`,
+  so capability could not be verified.
 
 After setup succeeds, it prints a masked token and the paired chat id:
 
 ```text
-Notifications enabled. botToken=1234…(len N) chatId=123456789
+Notifications enabled. botToken=1234…(len N) chatId=123456789 threaded=verified
 ```
 
 The raw token is never printed by GJC status/setup output after it is stored.
 
 ## 3. Non-interactive setup
 
-For scripts or CI-style local provisioning, pass the bot token and known chat id
-explicitly. For end-to-end daemon delivery, use a trusted forum-enabled
-supergroup chat id; for private setup/status discovery only, a private chat id is
-accepted:
+For scripts or CI-style local provisioning, pass the bot token and known private
+chat id explicitly. Non-interactive runs cannot prompt for the BotFather toggle,
+so if Threaded Mode is off (or the capability is unknown) setup is still saved
+with a warning and a `threaded=unverified`/`threaded=unknown` status:
 
 ```sh
 gjc notify setup --token <botToken> --chat-id <chatId>
@@ -155,13 +176,15 @@ starting a second poller. This avoids Telegram `409 Conflict` failures.
 
 ## 7. Use the Telegram chat
 
-The current managed daemon uses Telegram forum-topic delivery for per-session
-routing. Pairing still discovers a private chat id for the local setup path, but
-threaded per-session delivery requires `notifications.telegram.chatId` to point
-at a trusted forum-enabled supergroup where the bot can call
-`createForumTopic`/`editForumTopic` and send messages with `message_thread_id`.
-If Telegram refuses topic creation, the daemon drops remote sends fail-closed
-instead of falling back to a flat shared chat.
+The managed daemon uses Telegram forum-topic delivery for per-session routing in
+the paired private chat. This requires the bot to have Threaded Mode enabled in
+@BotFather (verified during setup via `getMe.has_topics_enabled`); a forum-enabled
+supergroup is no longer required. The daemon calls
+`createForumTopic`/`editForumTopic` and sends messages with `message_thread_id`
+against the paired `notifications.telegram.chatId`. If Telegram refuses topic
+creation — even when setup reported `threaded=verified` — the daemon routes
+notifications to the normal (flat) paired chat and posts a one-time nudge to enable
+Threaded Mode, rather than dropping them.
 
 The managed daemon can render:
 
@@ -226,10 +249,15 @@ by the current setup flow.
 
 ### Setup succeeds but no Telegram session messages arrive
 
-Check whether `notifications.telegram.chatId` points at a forum-enabled
-supergroup where the bot can manage topics. The setup-discovered private chat id
-is not sufficient for current per-session threaded delivery because private chats
-do not support `createForumTopic`/`message_thread_id`.
+Check the `threaded=` status from the last `gjc notify setup` run. If it is
+`threaded=unverified` or `threaded=unknown`, enable Threaded Mode for the bot in
+@BotFather, then re-run `gjc notify setup` (or
+`gjc notify setup --token <botToken> --chat-id <chatId>`) to re-check the
+capability. Also confirm there is no Telegram `409 Conflict` poller conflict.
+Per-session delivery uses private-chat topics; GJC cannot enable Threaded Mode
+through the Bot API. When `createForumTopic` is refused for the paired chat, the
+daemon falls back to flat delivery in the paired chat and posts a one-time
+`turn on threaded mode from botfather miniapp to receive gjc notification!` nudge.
 
 ### Telegram 409 conflict
 

--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -29,6 +29,8 @@ export interface NotifyCommandDeps {
 	pollIntervalMs?: number;
 	setupChatId?: string;
 	setupRedact?: boolean;
+	setupInteractive?: boolean;
+	threadedModePrompt?: (message: string) => Promise<string>;
 }
 
 interface TelegramApiResponse<T> {
@@ -46,6 +48,18 @@ interface TelegramUpdate {
 		};
 	};
 }
+
+interface TelegramUser {
+	id: number;
+	is_bot?: boolean;
+	first_name?: string;
+	username?: string;
+	has_topics_enabled?: boolean;
+	allows_users_to_create_topics?: boolean;
+}
+
+type ThreadedModeState = "enabled" | "disabled" | "unknown";
+type ThreadedModeFinalLabel = "verified" | "unverified" | "unknown";
 
 const DEFAULT_API_BASE = "https://api.telegram.org";
 const DEFAULT_POLL_TIMEOUT_MS = 60_000;
@@ -120,7 +134,11 @@ async function runSetup(deps: NotifyCommandDeps): Promise<void> {
 		throw new Error("Telegram bot token is required.");
 	}
 
-	await callTelegram(fetchImpl, apiBase, token, "getMe", {});
+	const user = await getMe(fetchImpl, apiBase, token);
+	const threadedState = await verifyThreadedMode(fetchImpl, apiBase, token, user, {
+		interactive: resolveSetupInteractive(deps),
+		prompt: deps.threadedModePrompt ?? promptForThreadedMode,
+	});
 	process.stdout.write(
 		"Token validated. Message your bot now from the private Telegram chat to pair notifications.\n",
 	);
@@ -145,7 +163,9 @@ async function runSetup(deps: NotifyCommandDeps): Promise<void> {
 	if (deps.setupRedact) settings.set("notifications.redact", true);
 	await settings.flush();
 
-	process.stdout.write(`Notifications enabled. botToken=${maskToken(token)} chatId=${chatId}\n`);
+	process.stdout.write(
+		`Notifications enabled. botToken=${maskToken(token)} chatId=${chatId} threaded=${threadedLabel(threadedState)}\n`,
+	);
 }
 
 async function promptForToken(): Promise<string> {
@@ -157,6 +177,123 @@ async function promptForToken(): Promise<string> {
 		return (await rl.question("Telegram BotFather token: ")).trim();
 	} finally {
 		rl.close();
+	}
+}
+
+const THREADED_ENABLED_SUCCESS =
+	"Telegram Threaded Mode capability verified for this bot. GJC will request a private-chat topic per session; if Telegram ever refuses topic creation, notifications fall back to this flat chat with a one-time nudge.\n";
+
+const THREADED_MISSING_WARNING =
+	"Warning: Telegram getMe did not include has_topics_enabled, so GJC cannot verify private-chat Threaded Mode capability for this bot. Setup will continue; update Telegram/Bot API support or re-run setup if per-session topics fail.\n";
+
+const THREADED_NONINTERACTIVE_WARNING =
+	"Warning: Telegram Threaded Mode capability is OFF for this bot. Setup will be saved because this run is non-interactive, but per-session Telegram delivery may fail closed until the bot owner enables Threaded Mode in @BotFather. GJC cannot enable it through the Bot API.\n";
+
+const THREADED_DISABLED_GUIDANCE =
+	"Telegram Threaded Mode is OFF for this bot. GJC needs Telegram private-chat topics so each session can use its own thread.\n" +
+	"GJC cannot enable this through the Bot API. Open @BotFather, select this bot, enable Threaded Mode / forum topics for private chats, then return here.\n" +
+	"Telegram may require an additional Stars purchase fee for private-chat topics.\n";
+
+const THREADED_DISABLED_PROMPT =
+	"Press Enter after enabling Threaded Mode, or type skip to finish setup with a warning: ";
+
+const THREADED_STILL_OFF = "Telegram still reports Threaded Mode OFF for this bot.\n";
+
+const THREADED_RETRY_PROMPT = "Press Enter to check again, or type skip to finish setup with a warning: ";
+
+const THREADED_SKIP_WARNING =
+	"Warning: continuing without verified Telegram Threaded Mode capability. Setup will be saved, but per-session Telegram delivery may fail closed until Threaded Mode is enabled in BotFather.\n";
+
+const THREADED_INVALID_INPUT = "Type Enter to retry or skip to continue with a warning.\n";
+
+const THREADED_RETRY_INPUTS = new Set(["", "y", "yes", "r", "retry"]);
+const THREADED_SKIP_INPUTS = new Set(["s", "skip", "n", "no"]);
+
+function isTelegramUser(value: unknown): value is TelegramUser {
+	return Boolean(value) && typeof value === "object" && typeof (value as { id?: unknown }).id === "number";
+}
+
+async function getMe(fetchImpl: typeof fetch, apiBase: string, token: string): Promise<TelegramUser> {
+	const user = await callTelegram<unknown>(fetchImpl, apiBase, token, "getMe", {});
+	if (!isTelegramUser(user)) {
+		throw new Error("Telegram getMe returned invalid Telegram response: missing valid User result.");
+	}
+	return user;
+}
+
+function threadedModeState(user: TelegramUser): ThreadedModeState {
+	if (user.has_topics_enabled === true) return "enabled";
+	if (user.has_topics_enabled === false) return "disabled";
+	return "unknown";
+}
+
+function threadedLabel(state: ThreadedModeState): ThreadedModeFinalLabel {
+	if (state === "enabled") return "verified";
+	if (state === "disabled") return "unverified";
+	return "unknown";
+}
+
+function resolveSetupInteractive(deps: NotifyCommandDeps): boolean {
+	if (deps.setupInteractive !== undefined) return deps.setupInteractive;
+	return Boolean(process.stdin.isTTY) && !deps.setupChatId?.trim();
+}
+
+async function promptForThreadedMode(message: string): Promise<string> {
+	if (!process.stdin.isTTY) return "skip";
+	const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: true });
+	try {
+		return (await rl.question(message)).trim();
+	} finally {
+		rl.close();
+	}
+}
+
+async function verifyThreadedMode(
+	fetchImpl: typeof fetch,
+	apiBase: string,
+	token: string,
+	initialUser: TelegramUser,
+	opts: { interactive: boolean; prompt: (message: string) => Promise<string> },
+): Promise<ThreadedModeState> {
+	const classify = (user: TelegramUser): ThreadedModeState | undefined => {
+		const state = threadedModeState(user);
+		if (state === "enabled") {
+			process.stdout.write(THREADED_ENABLED_SUCCESS);
+			return "enabled";
+		}
+		if (state === "unknown") {
+			process.stdout.write(THREADED_MISSING_WARNING);
+			return "unknown";
+		}
+		return undefined;
+	};
+
+	const initial = classify(initialUser);
+	if (initial) return initial;
+
+	if (!opts.interactive) {
+		process.stdout.write(THREADED_NONINTERACTIVE_WARNING);
+		return "disabled";
+	}
+
+	process.stdout.write(THREADED_DISABLED_GUIDANCE);
+	let firstPrompt = true;
+	for (;;) {
+		const answer = (await opts.prompt(firstPrompt ? THREADED_DISABLED_PROMPT : THREADED_RETRY_PROMPT))
+			.trim()
+			.toLowerCase();
+		firstPrompt = false;
+		if (THREADED_SKIP_INPUTS.has(answer)) {
+			process.stdout.write(THREADED_SKIP_WARNING);
+			return "disabled";
+		}
+		if (!THREADED_RETRY_INPUTS.has(answer)) {
+			process.stdout.write(THREADED_INVALID_INPUT);
+			continue;
+		}
+		const resolved = classify(await getMe(fetchImpl, apiBase, token));
+		if (resolved) return resolved;
+		process.stdout.write(THREADED_STILL_OFF);
 	}
 }
 
@@ -263,12 +400,18 @@ ${chalk.bold("Usage:")}
   ${APP_NAME} notify status
 
 ${chalk.bold("Subcommands:")}
-  setup     Pair a Telegram bot token with a private chat
+  setup     Pair a Telegram bot token with a private chat and verify Threaded Mode capability
   status    Show notification configuration without secrets
 
 ${chalk.bold("Examples:")}
   ${APP_NAME} notify setup
   ${APP_NAME} notify setup --token <botToken> --chat-id <chatId> [--redact]
   ${APP_NAME} notify status
+
+${chalk.bold("Threaded Mode:")}
+  GJC uses Telegram private-chat topics for per-session threads. Setup verifies the bot
+  capability via getMe.has_topics_enabled. If it is off, enable Threaded Mode in @BotFather;
+  bots cannot toggle it through the Bot API. If Telegram refuses topic creation at runtime,
+  GJC delivers flat to the paired private chat and nudges you to enable Threaded Mode.
 `);
 }

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -582,8 +582,14 @@ export class TelegramNotificationDaemon {
 	private readonly fsImpl: TelegramDaemonFs;
 	private readonly botApi: BotApi;
 	private readonly topics = new TopicRegistry();
-	private readonly pool: RateLimitPool<{ send: ThreadedSend; topicId: string }>;
+	private readonly pool: RateLimitPool<{ send: ThreadedSend; topicId?: string }>;
 	private readonly seenUpdateIds = new Set<number>();
+	/** True once the daemon has nudged the user to enable Threaded Mode. */
+	private threadedFallbackNoticeSent = false;
+	/** Sessions whose identity header was already sent flat (Threaded Mode off). */
+	private readonly flatIdentitySent = new Set<string>();
+	/** Cached result of whether the paired chat is a private chat (flat-fallback gate). */
+	private pairedChatPrivate: boolean | undefined;
 	private flushTimer: ReturnType<typeof setInterval> | undefined;
 	private scanTimer: ReturnType<typeof setInterval> | undefined;
 	private scanning = false;
@@ -660,7 +666,7 @@ export class TelegramNotificationDaemon {
 				return res.json();
 			},
 		};
-		this.pool = new RateLimitPool<{ send: ThreadedSend; topicId: string }>({ now: opts.now });
+		this.pool = new RateLimitPool<{ send: ThreadedSend; topicId?: string }>({ now: opts.now });
 	}
 
 	async loadAliases(): Promise<void> {
@@ -815,8 +821,9 @@ export class TelegramNotificationDaemon {
 
 	/**
 	 * Resolve (creating once via `createForumTopic`) the forum topic for a
-	 * session. Threaded mode is required: on capability failure this returns
-	 * `undefined` and the caller drops the send (no flat fallback).
+	 * session. On capability failure (e.g. Threaded Mode off) this returns
+	 * `undefined`; callers then flat-deliver to a private paired chat (with a
+	 * one-time nudge) or drop fail-closed for a non-private chat.
 	 */
 	private async ensureTopic(sessionId: string, name: string): Promise<string | undefined> {
 		const existing = this.topics.get(sessionId);
@@ -861,13 +868,14 @@ export class TelegramNotificationDaemon {
 	private async flushPool(): Promise<void> {
 		for (const item of this.pool.drain()) {
 			const { send, topicId } = item.payload;
-			const thread = Number(topicId);
+			// Threaded topic when available; otherwise deliver flat to the paired chat.
+			const threadField = topicId ? { message_thread_id: Number(topicId) } : {};
 			try {
 				if (send.method === "sendPhoto" && send.photoBase64) {
 					// Real photo upload (the default botApi multiparts base64 -> file).
 					await this.botApi.call("sendPhoto", {
 						chat_id: this.opts.chatId,
-						message_thread_id: thread,
+						...threadField,
 						photo: send.photoBase64,
 						mime: send.mime,
 						caption: send.text,
@@ -876,7 +884,7 @@ export class TelegramNotificationDaemon {
 				} else if (send.text) {
 					await this.botApi.call("sendMessage", {
 						chat_id: this.opts.chatId,
-						message_thread_id: thread,
+						...threadField,
 						text: send.text,
 						parse_mode: TELEGRAM_PARSE_MODE,
 					});
@@ -884,6 +892,57 @@ export class TelegramNotificationDaemon {
 			} catch {
 				// Best-effort: a failed send must never stop the daemon.
 			}
+		}
+	}
+
+	/**
+	 * Threaded Mode is unavailable (the bot owner has not enabled forum topics in
+	 * @BotFather, so `createForumTopic` fails). Deliver the rendered frame flat to
+	 * the paired chat instead of dropping it, and nudge the user once. Flat delivery
+	 * is gated on the paired chat being a private chat: for a group/supergroup/channel
+	 * (e.g. a legacy or hand-edited `chatId`) we keep dropping fail-closed so session
+	 * content never lands in a shared chat. Identity headers are sent at most once per
+	 * session in flat mode.
+	 */
+	private async deliverFlatFallback(sessionId: string, send: ThreadedSend): Promise<void> {
+		if (!(await this.pairedChatIsPrivate())) return;
+		await this.notifyThreadedFallback();
+		if (send.identity && this.flatIdentitySent.has(sessionId)) return;
+		this.pool.submit({ sessionId, lane: send.lane, coalesceKey: send.coalesceKey, payload: { send } });
+		await this.flushPool();
+		if (send.identity) this.flatIdentitySent.add(sessionId);
+	}
+
+	/**
+	 * Resolve once (cached) whether the paired `chatId` is a private chat. Flat
+	 * fallback is only safe in a private DM; any non-private chat or an unresolvable
+	 * `getChat` is treated as not-private so delivery fails closed.
+	 */
+	private async pairedChatIsPrivate(): Promise<boolean> {
+		if (this.pairedChatPrivate !== undefined) return this.pairedChatPrivate;
+		try {
+			const res = (await this.botApi.call("getChat", { chat_id: this.opts.chatId })) as {
+				result?: { type?: string };
+			};
+			this.pairedChatPrivate = res.result?.type === "private";
+		} catch {
+			this.pairedChatPrivate = false;
+		}
+		return this.pairedChatPrivate;
+	}
+
+	/** Tell the user once (per daemon run) how to enable Threaded Mode. */
+	private async notifyThreadedFallback(): Promise<void> {
+		if (this.threadedFallbackNoticeSent) return;
+		this.threadedFallbackNoticeSent = true;
+		try {
+			await this.botApi.call("sendMessage", {
+				chat_id: this.opts.chatId,
+				text: "turn on threaded mode from botfather miniapp to receive gjc notification!",
+				parse_mode: TELEGRAM_PARSE_MODE,
+			});
+		} catch {
+			// Best-effort nudge; never block delivery.
 		}
 	}
 
@@ -1015,7 +1074,10 @@ export class TelegramNotificationDaemon {
 			const send = renderThreadedFrame(msg);
 			if (!send) return;
 			const topicId = await this.ensureTopic(session.sessionId, this.topicNameFor(session.sessionId, msg));
-			if (!topicId) return;
+			if (!topicId) {
+				await this.deliverFlatFallback(session.sessionId, send);
+				return;
+			}
 			if (send.identity) {
 				// Rename the topic if the title changed (e.g. the session title was
 				// auto-generated after the topic was first created). This runs on
@@ -1058,7 +1120,12 @@ export class TelegramNotificationDaemon {
 		if (msg.type === "action_needed" && msg.id) {
 			if (msg.kind === "ask") session.pending.set(msg.id, { sessionId: session.sessionId, actionId: msg.id });
 			const topicId = await this.ensureTopic(session.sessionId, this.topicNameFor(session.sessionId, msg));
-			if (!topicId) return;
+			if (!topicId) {
+				// Fail closed for non-private chats; only nudge + flat-deliver in a private DM.
+				if (!(await this.pairedChatIsPrivate())) return;
+				await this.notifyThreadedFallback();
+			}
+			const threadField = topicId ? { message_thread_id: Number(topicId) } : {};
 			const rendered = buildActionMessage({
 				kind: msg.kind ?? "ask",
 				id: msg.id,
@@ -1074,7 +1141,7 @@ export class TelegramNotificationDaemon {
 			);
 			const result = (await this.botApi.call("sendMessage", {
 				chat_id: this.opts.chatId,
-				message_thread_id: Number(topicId),
+				...threadField,
 				text: rendered.text,
 				parse_mode: TELEGRAM_PARSE_MODE,
 				...(inline_keyboard.length ? { reply_markup: { inline_keyboard } } : {}),

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -845,6 +845,198 @@ test("image_attachment frame uploads via sendPhoto into the session topic", asyn
 	expect(Number(photo!.body.message_thread_id)).toBeGreaterThan(0);
 });
 
+test("threaded mode off: frames fall back to the flat paired chat with a one-time notice", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	// Threaded Mode is off: createForumTopic yields no message_thread_id, so
+	// ensureTopic fails and the daemon must route flat instead of dropping.
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "createForumTopic") return { ok: true, result: {} };
+		if (method === "getChat") return { ok: true, result: { type: "private" } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	await daemon.handleSessionMessage(session as any, {
+		type: "context_update",
+		sessionId: "S",
+		lastMessage: "hello world",
+	});
+	await daemon.handleSessionMessage(session as any, {
+		type: "action_needed",
+		sessionId: "S",
+		id: "ask1",
+		kind: "ask",
+		question: "Proceed?",
+		options: ["Yes", "No"],
+	});
+
+	const sends = bot.calls.filter(c => c.method === "sendMessage");
+	// Everything is delivered flat (no message_thread_id) since topics are unavailable.
+	expect(sends.length).toBeGreaterThan(0);
+	expect(sends.every(c => c.body.message_thread_id === undefined)).toBe(true);
+	// The nudge is sent exactly once with the requested copy.
+	const notices = sends.filter(c =>
+		String(c.body.text).includes("turn on threaded mode from botfather miniapp to receive gjc notification!"),
+	);
+	expect(notices).toHaveLength(1);
+	// The ask still carries its inline keyboard in flat mode.
+	const ask = sends.find(c => String(c.body.text).includes("Proceed?"));
+	expect(ask).toBeTruthy();
+	expect(ask!.body.reply_markup?.inline_keyboard?.length).toBeGreaterThan(0);
+});
+
+test("threaded mode off: multiple sessions share a single fallback notice", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "createForumTopic") return { ok: true, result: {} };
+		if (method === "getChat") return { ok: true, result: { type: "private" } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	for (const sessionId of ["A", "B", "C"]) {
+		await daemon.handleSessionMessage(
+			{ sessionId, token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() } as any,
+			{ type: "identity_header", sessionId, repo: "r", branch: sessionId },
+		);
+	}
+	const sends = bot.calls.filter(c => c.method === "sendMessage");
+	expect(sends.every(c => c.body.message_thread_id === undefined)).toBe(true);
+	expect(
+		sends.filter(c =>
+			String(c.body.text).includes("turn on threaded mode from botfather miniapp to receive gjc notification!"),
+		),
+	).toHaveLength(1);
+});
+
+test("threaded mode off: image_attachment uploads flat without message_thread_id", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "createForumTopic") return { ok: true, result: {} };
+		if (method === "getChat") return { ok: true, result: { type: "private" } };
+		if (method === "sendPhoto") return { ok: true, result: { message_id: bot.calls.length } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	await daemon.handleSessionMessage(
+		{ sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() } as any,
+		{ type: "image_attachment", sessionId: "S", source: "computer", mime: "image/png", data: "AAAA" },
+	);
+	const photo = bot.calls.find(c => c.method === "sendPhoto");
+	expect(photo).toBeTruthy();
+	expect(photo!.body.photo).toBe("AAAA");
+	expect(photo!.body.message_thread_id).toBeUndefined();
+	const notice = bot.calls.filter(
+		c =>
+			c.method === "sendMessage" &&
+			String(c.body.text).includes("turn on threaded mode from botfather miniapp to receive gjc notification!"),
+	);
+	expect(notice).toHaveLength(1);
+});
+
+test("threaded off + non-private chat: fails closed (no flat send, no notice)", async () => {
+	for (const chatType of ["supergroup", "group", "channel"]) {
+		const agentDir = tempAgentDir();
+		const bot = new FakeBotApi();
+		// Topics off AND the paired chat is not a private DM: must drop fail-closed
+		// so session content never lands in a shared chat.
+		bot.call = (async (method: string, body: any) => {
+			bot.calls.push({ method, body });
+			if (method === "createForumTopic") return { ok: true, result: {} };
+			if (method === "getChat") return { ok: true, result: { type: chatType } };
+			if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+			return { ok: true, result: true };
+		}) as any;
+		const daemon = new TelegramNotificationDaemon({
+			settings: settings(agentDir),
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+		});
+		const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+		await daemon.handleSessionMessage(session as any, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		await daemon.handleSessionMessage(session as any, {
+			type: "context_update",
+			sessionId: "S",
+			lastMessage: "secret",
+		});
+		await daemon.handleSessionMessage(session as any, {
+			type: "action_needed",
+			sessionId: "S",
+			id: "ask1",
+			kind: "ask",
+			question: "Proceed?",
+			options: ["Yes"],
+		});
+
+		const sends = bot.calls.filter(c => c.method === "sendMessage");
+		expect(sends).toHaveLength(0);
+	}
+});
+
+test("threaded off + unresolvable getChat: fails closed", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "createForumTopic") return { ok: true, result: {} };
+		if (method === "getChat") throw new Error("getChat failed");
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+	await daemon.handleSessionMessage(session as any, { type: "context_update", sessionId: "S", lastMessage: "secret" });
+	expect(bot.calls.filter(c => c.method === "sendMessage")).toHaveLength(0);
+});
+
 test("identity_header without a title names the topic repo/branch", async () => {
 	const agentDir = tempAgentDir();
 	const bot = new FakeBotApi();

--- a/packages/coding-agent/test/notify-setup.test.ts
+++ b/packages/coding-agent/test/notify-setup.test.ts
@@ -209,3 +209,301 @@ test("non-interactive setup with --token and --chat-id writes config without pol
 	expect(cfg.botToken).toBe("123:abc");
 	expect(getUpdatesCalls).toBe(0);
 });
+
+function privateUpdates(chatId = 555111): unknown[] {
+	return [
+		{ ok: true, result: [] },
+		{ ok: true, result: [{ update_id: 7, message: { chat: { id: chatId, type: "private" } } }] },
+	];
+}
+
+function makePrompt(answers: string[]): { prompt: (message: string) => Promise<string>; asked: string[] } {
+	const asked: string[] = [];
+	const queue = [...answers];
+	const prompt = async (message: string): Promise<string> => {
+		asked.push(message);
+		return queue.length > 0 ? (queue.shift() as string) : "skip";
+	};
+	return { prompt, asked };
+}
+
+const userOn = { id: 1, username: "bot", has_topics_enabled: true };
+const userOff = { id: 1, username: "bot", has_topics_enabled: false };
+const userMissing = { id: 1, username: "bot" };
+
+describe("notify setup threaded mode verification", () => {
+	test("threaded ON interactive verifies capability and pairs", async () => {
+		const settings = Settings.isolated();
+		const { fetchImpl, calls } = makeFetch({
+			getMe: [{ ok: true, result: userOn }],
+			getUpdates: privateUpdates(),
+		});
+		const { stdout } = await captureOutput(() =>
+			runNotifyCommand(
+				{ action: "setup", rawArgs: [] },
+				{ fetchImpl, settings, setupToken: token, setupInteractive: true, pollTimeoutMs: 50, pollIntervalMs: 0 },
+			),
+		);
+		expect(stdout).toContain("Threaded Mode capability verified");
+		expect(stdout).toContain("threaded=verified");
+		expect(stdout).toContain(maskToken(token));
+		expect(stdout).not.toContain(token);
+		expect(getNotificationConfig(settings).chatId).toBe("555111");
+		expect(calls.filter(c => c.method === "getMe")).toHaveLength(1);
+	});
+
+	test("threaded ON non-interactive verifies without polling", async () => {
+		const settings = Settings.isolated();
+		const { fetchImpl, calls } = makeFetch({ getMe: [{ ok: true, result: userOn }] });
+		const cmd = parseNotifyArgs(["notify", "setup", "--token", "123:abc", "--chat-id", "999", "--redact"]);
+		const { stdout } = await captureOutput(() =>
+			runNotifyCommand(cmd!, { fetchImpl, settings, setupInteractive: false }),
+		);
+		expect(stdout).toContain("threaded=verified");
+		expect(calls.filter(c => c.method === "getUpdates")).toHaveLength(0);
+		expect(getNotificationConfig(settings).enabled).toBe(true);
+		expect(getNotificationConfig(settings).chatId).toBe("999");
+		expect(stdout).not.toContain("123:abc");
+	});
+
+	test("missing field interactive warns unknown and proceeds", async () => {
+		const settings = Settings.isolated();
+		const { fetchImpl } = makeFetch({
+			getMe: [{ ok: true, result: userMissing }],
+			getUpdates: privateUpdates(),
+		});
+		const { stdout } = await captureOutput(() =>
+			runNotifyCommand(
+				{ action: "setup", rawArgs: [] },
+				{ fetchImpl, settings, setupToken: token, setupInteractive: true, pollTimeoutMs: 50, pollIntervalMs: 0 },
+			),
+		);
+		expect(stdout).toContain("has_topics_enabled");
+		expect(stdout).toContain("threaded=unknown");
+		expect(getNotificationConfig(settings).enabled).toBe(true);
+		expect(stdout).not.toContain(token);
+	});
+
+	test("missing field non-interactive warns unknown without polling", async () => {
+		const settings = Settings.isolated();
+		const { fetchImpl, calls } = makeFetch({ getMe: [{ ok: true, result: userMissing }] });
+		const { stdout } = await captureOutput(() =>
+			runNotifyCommand(
+				{ action: "setup", rawArgs: [] },
+				{ fetchImpl, settings, setupToken: token, setupChatId: "888", setupInteractive: false },
+			),
+		);
+		expect(stdout).toContain("has_topics_enabled");
+		expect(stdout).toContain("threaded=unknown");
+		expect(calls.filter(c => c.method === "getUpdates")).toHaveLength(0);
+		expect(getNotificationConfig(settings).chatId).toBe("888");
+	});
+
+	test("non-boolean has_topics_enabled is unknown, not verified", async () => {
+		const settings = Settings.isolated();
+		const { fetchImpl } = makeFetch({
+			getMe: [{ ok: true, result: { id: 1, username: "bot", has_topics_enabled: "true" } }],
+			getUpdates: privateUpdates(),
+		});
+		const { stdout, stderr } = await captureOutput(() =>
+			runNotifyCommand(
+				{ action: "setup", rawArgs: [] },
+				{ fetchImpl, settings, setupToken: token, setupInteractive: true, pollTimeoutMs: 50, pollIntervalMs: 0 },
+			),
+		);
+		expect(stdout).toContain("threaded=unknown");
+		expect(stdout).not.toContain("threaded=verified");
+		expect(getNotificationConfig(settings).enabled).toBe(true);
+		expect(`${stdout}\n${stderr}`).not.toContain(token);
+	});
+
+	test("getMe missing id rejects even when has_topics_enabled is present", async () => {
+		const settings = Settings.isolated();
+		const { fetchImpl } = makeFetch({ getMe: [{ ok: true, result: { username: "bot", has_topics_enabled: true } }] });
+		const { stdout, stderr } = await captureOutput(async () => {
+			await expect(
+				runNotifyCommand(
+					{ action: "setup", rawArgs: [] },
+					{ fetchImpl, settings, setupToken: token, setupChatId: "555", setupInteractive: false },
+				),
+			).rejects.toThrow("invalid Telegram response");
+		});
+		expect(getNotificationConfig(settings).enabled).toBe(false);
+		expect(getNotificationConfig(settings).botToken).toBeUndefined();
+		expect(getNotificationConfig(settings).chatId).toBeUndefined();
+		expect(`${stdout}\n${stderr}`).not.toContain(token);
+	});
+
+	test("malformed getMe result rejects without writing settings", async () => {
+		for (const result of [null, {}, { username: "bot" }]) {
+			const settings = Settings.isolated();
+			const { fetchImpl } = makeFetch({ getMe: [{ ok: true, result }] });
+			await expect(
+				captureOutput(() =>
+					runNotifyCommand(
+						{ action: "setup", rawArgs: [] },
+						{ fetchImpl, settings, setupToken: token, setupInteractive: false },
+					),
+				),
+			).rejects.toThrow("invalid Telegram response");
+			expect(getNotificationConfig(settings).enabled).toBe(false);
+			expect(getNotificationConfig(settings).botToken).toBeUndefined();
+			expect(getNotificationConfig(settings).chatId).toBeUndefined();
+		}
+	});
+
+	test("threaded OFF interactive retry then enabled verifies", async () => {
+		const settings = Settings.isolated();
+		const { fetchImpl, calls } = makeFetch({
+			getMe: [
+				{ ok: true, result: userOff },
+				{ ok: true, result: userOn },
+			],
+			getUpdates: privateUpdates(),
+		});
+		const { prompt } = makePrompt([""]);
+		const { stdout } = await captureOutput(() =>
+			runNotifyCommand(
+				{ action: "setup", rawArgs: [] },
+				{
+					fetchImpl,
+					settings,
+					setupToken: token,
+					setupInteractive: true,
+					threadedModePrompt: prompt,
+					pollTimeoutMs: 50,
+					pollIntervalMs: 0,
+				},
+			),
+		);
+		expect(stdout).toContain("Threaded Mode is OFF");
+		expect(stdout).toContain("@BotFather");
+		expect(stdout).toContain("threaded=verified");
+		expect(calls.filter(c => c.method === "getMe")).toHaveLength(2);
+	});
+
+	test("threaded OFF interactive skip completes with unverified warning", async () => {
+		const settings = Settings.isolated();
+		const { fetchImpl, calls } = makeFetch({
+			getMe: [{ ok: true, result: userOff }],
+			getUpdates: privateUpdates(),
+		});
+		const { prompt } = makePrompt(["skip"]);
+		const { stdout } = await captureOutput(() =>
+			runNotifyCommand(
+				{ action: "setup", rawArgs: [] },
+				{
+					fetchImpl,
+					settings,
+					setupToken: token,
+					setupInteractive: true,
+					threadedModePrompt: prompt,
+					pollTimeoutMs: 50,
+					pollIntervalMs: 0,
+				},
+			),
+		);
+		expect(stdout).toContain("continuing without verified");
+		expect(stdout).toContain("threaded=unverified");
+		expect(getNotificationConfig(settings).enabled).toBe(true);
+		expect(getNotificationConfig(settings).chatId).toBe("555111");
+		expect(calls.filter(c => c.method === "getMe")).toHaveLength(1);
+		expect(stdout).not.toContain(token);
+	});
+
+	test("threaded OFF non-interactive warns and completes unverified", async () => {
+		const settings = Settings.isolated();
+		const { fetchImpl, calls } = makeFetch({ getMe: [{ ok: true, result: userOff }] });
+		const { stdout } = await captureOutput(() =>
+			runNotifyCommand(
+				{ action: "setup", rawArgs: [] },
+				{ fetchImpl, settings, setupToken: token, setupChatId: "777", setupInteractive: false },
+			),
+		);
+		expect(stdout).toContain("non-interactive");
+		expect(stdout).toContain("threaded=unverified");
+		expect(calls.filter(c => c.method === "getUpdates")).toHaveLength(0);
+		expect(getNotificationConfig(settings).chatId).toBe("777");
+		expect(stdout).not.toContain(token);
+	});
+
+	test("threaded OFF interactive invalid input then skip does not re-check", async () => {
+		const settings = Settings.isolated();
+		const { fetchImpl, calls } = makeFetch({
+			getMe: [{ ok: true, result: userOff }],
+			getUpdates: privateUpdates(),
+		});
+		const { prompt, asked } = makePrompt(["wat", "skip"]);
+		const { stdout } = await captureOutput(() =>
+			runNotifyCommand(
+				{ action: "setup", rawArgs: [] },
+				{
+					fetchImpl,
+					settings,
+					setupToken: token,
+					setupInteractive: true,
+					threadedModePrompt: prompt,
+					pollTimeoutMs: 50,
+					pollIntervalMs: 0,
+				},
+			),
+		);
+		expect(stdout).toContain("Type Enter to retry or skip");
+		expect(stdout).toContain("threaded=unverified");
+		expect(asked).toHaveLength(2);
+		expect(calls.filter(c => c.method === "getMe")).toHaveLength(1);
+		expect(getNotificationConfig(settings).enabled).toBe(true);
+	});
+
+	test("threaded OFF interactive invalid inputs then retry re-checks once and verifies", async () => {
+		const settings = Settings.isolated();
+		const { fetchImpl, calls } = makeFetch({
+			getMe: [
+				{ ok: true, result: userOff },
+				{ ok: true, result: userOn },
+			],
+			getUpdates: privateUpdates(),
+		});
+		const { prompt, asked } = makePrompt(["wat", "still bad", ""]);
+		const { stdout, stderr } = await captureOutput(() =>
+			runNotifyCommand(
+				{ action: "setup", rawArgs: [] },
+				{
+					fetchImpl,
+					settings,
+					setupToken: token,
+					setupInteractive: true,
+					threadedModePrompt: prompt,
+					pollTimeoutMs: 50,
+					pollIntervalMs: 0,
+				},
+			),
+		);
+		expect(stdout.match(/Type Enter to retry or skip/g)).toHaveLength(2);
+		expect(stdout).toContain("threaded=verified");
+		expect(asked).toHaveLength(3);
+		expect(calls.filter(c => c.method === "getMe")).toHaveLength(2);
+		expect(getNotificationConfig(settings).enabled).toBe(true);
+		expect(`${stdout}\n${stderr}`).not.toContain(token);
+	});
+
+	test("group rejection still holds with threaded enabled bot", async () => {
+		const settings = Settings.isolated();
+		const { fetchImpl } = makeFetch({
+			getMe: [{ ok: true, result: userOn }],
+			getUpdates: [
+				{ ok: true, result: [] },
+				{ ok: true, result: [{ update_id: 1, message: { chat: { id: -100, type: "supergroup" } } }] },
+			],
+		});
+		await expect(
+			captureOutput(() =>
+				runNotifyCommand(
+					{ action: "setup", rawArgs: [] },
+					{ fetchImpl, settings, setupToken: token, setupInteractive: true, pollTimeoutMs: 5, pollIntervalMs: 0 },
+				),
+			),
+		).rejects.toThrow("Pairing rejected supergroup chat");
+		expect(getNotificationConfig(settings).enabled).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Telegram now supports forum **topics in private chats** when the bot owner enables **Threaded Mode** via @BotFather (Bot API 9.3 `getMe.has_topics_enabled`, 9.4 `createForumTopic` in private chats). This wires GJC's per-session threaded notification surface to the paired **private chat** — removing the previous requirement to point `notifications.telegram.chatId` at a forum-enabled supergroup.

### `gjc notify setup` — verify Threaded Mode capability
- Reads `getMe.has_topics_enabled` and classifies `enabled` / `disabled` / `unknown`.
- Interactive run prints @BotFather guidance and re-checks (retry/skip) when off; non-interactive warns and completes.
- Final line reports `threaded=verified|unverified|unknown`.
- Malformed `getMe` result is rejected without writing settings.
- Bots cannot enable Threaded Mode via the Bot API — setup detects-and-guides only (ToS: private-chat topics may carry a Telegram Stars fee).

### Daemon — flat fallback instead of dropping
- When a per-session forum topic can't be created (Threaded Mode off), the daemon routes notifications to the **flat paired chat** and posts a one-time nudge: `turn on threaded mode from botfather miniapp to receive gjc notification!`.
- **Safety:** flat fallback is gated on a verified **private** chat (`getChat`). Supergroup/group/channel and unresolvable `getChat` still **fail closed** so session content never leaks into a shared chat.

### Non-goals / invariants
- No `settings-schema`/`config` changes; `isGloballyConfigured` unchanged (enabled + token + chatId).
- Private-only pairing and group/supergroup/channel rejection preserved; bot token always masked.

## Files
- `packages/coding-agent/src/cli/notify-cli.ts`
- `packages/coding-agent/src/notifications/telegram-daemon.ts`
- `packages/coding-agent/test/notify-setup.test.ts`
- `packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `docs/telegram-onboarding.md`, `docs/notifications-sdk.md`

## Verification
- `bun test test/notify-setup.test.ts test/notifications-telegram-daemon.test.ts` → 65 pass / 0 fail (incl. adversarial: malformed/non-boolean getMe, group rejection, OFF retry/skip/invalid, flat fallback, and non-private/unresolvable-getChat fail-closed).
- `bun run check:ts` green across all workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
