### PR TITLE
ci(release): re-support Intel Mac build with macos-15-intel runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,7 @@ jobs:
             include:
                - { os: ubuntu-22.04, platform: linux, arch: arm64, target: aarch64-unknown-linux-gnu }
                - { os: macos-14, platform: darwin, arch: arm64 }
+               - { os: macos-15-intel, platform: darwin, arch: x64 }
                - { os: windows-latest, platform: win32, arch: x64, variant: baseline }
       runs-on: ${{ matrix.os }}
       steps:
@@ -386,6 +387,13 @@ jobs:
                     arch: arm64,
                     target_id: darwin-arm64,
                     binary_path: packages/coding-agent/binaries/gjc-darwin-arm64,
+                 }
+               - {
+                    os: macos-15-intel,
+                    platform: darwin,
+                    arch: x64,
+                    target_id: darwin-x64,
+                    binary_path: packages/coding-agent/binaries/gjc-darwin-x64,
                  }
                - {
                     os: windows-latest,

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ Prebuilt standalone release binaries are published only for:
 
 - **Linux** — x64 and arm64
 - **Windows** — x64
-- **macOS** — Apple Silicon (arm64)
+- **macOS** — Apple Silicon (arm64) and Intel (x64)
 
-Other platforms (notably Intel macOS / `darwin-x64`) are not built in release CI; use the npm/Bun package path or build from source.
+The npm/Bun package path and build-from-source also remain available on every platform.
 
 ### macOS Intel install
 
-Standalone release binaries currently target Apple Silicon macOS (`gjc-darwin-arm64`), Linux, and Windows. Intel macOS (`darwin-x64`) is no longer built in release CI because GitHub's Intel macOS runner pool is deprecated and can remain queued for hours. On Intel Macs, install through the npm/Bun package path or build from source:
+Standalone release binaries are published for both Apple Silicon (`gjc-darwin-arm64`) and Intel (`gjc-darwin-x64`) macOS. You can also install through the npm/Bun package path or build from source:
 
 ```sh
 bun install -g gajae-code

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -139,6 +139,7 @@
 - Added an opt-in `gjc rlm` research mode (v1, interactive): a Jupyter-notebook-style research session over the existing agent loop, backed by the shared persistent Python kernel. It loads a distinct research system prompt, restricts the toolset to a hard-gated allowlist (`python` + `read` + `web_search`, asserted after tool-registry assembly — no `bash`/edit/arbitrary mutation), optionally loads a project-root `DATA.md` (overridable via `--data <path>`), aggregates every executed cell live into `.gjc/rlm/<session>/notebook.ipynb` (single-queue atomic temp-rename writes with post-write validation), and synthesizes `.gjc/rlm/<session>/report.md` on session exit. Autonomous goal-arg runs, `--resume`, managed per-workspace venv provisioning, and the optional `>=N` completion gate are deferred follow-ups.
 - Added an experimental opt-in `computer` desktop-control tool surface for local macOS screenshot/input coordination, backed by native `ComputerController`/`computerScreenshot` bindings and gated through settings/tool registration so it can continue stabilizing on `dev` outside the 0.5.4 patch release.
 - Dropped deprecated GitHub Actions Intel macOS (`macos-13` / `darwin-x64`) release-binary coverage after the runner pool repeatedly blocked v0.6.0 publish; Intel macOS users should install through npm/Bun or build from source.
+- Re-enabled GitHub Actions Intel macOS (`darwin-x64`) release-binary coverage using the `macos-15-intel` runner, so standalone `gjc-darwin-x64` binaries ship again alongside Apple Silicon.
 
 ## [0.5.4] - 2026-06-17
 


### PR DESCRIPTION
Re-enables the Intel macOS (`darwin-x64`) release lane using the `macos-15-intel` runner in both the `native_release` and `release_binary` matrices, so `gjc-darwin-x64` standalone binaries ship again. Docs and CHANGELOG updated to reflect Intel macOS support.