### PR TITLE
fix(ai): heal Anthropic tool-call XML leaked into visible text (incl. antml: streaming)

### DIFF
--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -6,7 +6,12 @@ type ResolvedToolStrictMode = NonNullable<OpenAICompat["toolStrictMode"]> | "mix
 export type ResolvedOpenAICompat = Required<
 	Omit<
 		OpenAICompat,
-		"openRouterRouting" | "vercelGatewayRouting" | "extraBody" | "toolStrictMode" | "toolChoiceSupport"
+		| "openRouterRouting"
+		| "vercelGatewayRouting"
+		| "extraBody"
+		| "toolStrictMode"
+		| "toolChoiceSupport"
+		| "healToolCallXml"
 	>
 > & {
 	openRouterRouting?: OpenAICompat["openRouterRouting"];
@@ -15,6 +20,8 @@ export type ResolvedOpenAICompat = Required<
 	toolStrictMode: ResolvedToolStrictMode;
 	/** Optional explicit capability override; resolved via deriveToolChoiceSupport. */
 	toolChoiceSupport?: OpenAICompat["toolChoiceSupport"];
+	/** Relay opt-in to heal leaked Anthropic tool-call XML; read directly from model.compat, not auto-detected. */
+	healToolCallXml?: OpenAICompat["healToolCallXml"];
 };
 
 function detectStrictModeSupport(provider: string, baseUrl: string): boolean {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -802,9 +802,19 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 								flushHealedToolCalls();
 							}
 						} else if (xmlHealer) {
-							const clean = xmlHealer.feed(normalizedDeltaText);
-							if (clean.length > 0) appendTextDelta(clean);
-							flushXmlHealedToolCalls();
+							const hasStructuredToolCalls =
+								Array.isArray(choice.delta.tool_calls) && choice.delta.tool_calls.length > 0;
+							if (hasStructuredToolCalls) {
+								// Same chunk leaks XML AND carries structured tool_calls.
+								// Strip the marker text but drop any synthesized calls so
+								// the structured payload stays the single source of truth.
+								const clean = xmlHealer.consumeWithoutCalls(normalizedDeltaText);
+								if (clean.length > 0) appendTextDelta(clean);
+							} else {
+								const clean = xmlHealer.feed(normalizedDeltaText);
+								if (clean.length > 0) appendTextDelta(clean);
+								flushXmlHealedToolCalls();
+							}
 						} else {
 							appendTextDelta(normalizedDeltaText);
 						}

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -37,6 +37,10 @@ import {
 } from "../types";
 import { normalizeSystemPrompts } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
+import {
+	AnthropicXmlToolCallHealer,
+	modelMayLeakAnthropicXmlToolCalls,
+} from "../utils/anthropic-xml-tool-call-healing";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { toFirepassWireModelId, toFireworksWireModelId } from "../utils/fireworks-model-id";
 import {
@@ -719,6 +723,23 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				for (const call of calls) emitHealedToolCall(call);
 			};
 
+			// Claude served through OpenAI-compatible relays may leak Anthropic
+			// tool-call XML (`<invoke name="…"><parameter …>`) into visible text
+			// rather than emitting structured `tool_calls`. Reconstruct it so
+			// UI-bound tools (e.g. the deep-interview question panel) still fire.
+			const xmlHealer = modelMayLeakAnthropicXmlToolCalls({
+				provider: model.provider,
+				modelId: model.id,
+				healToolCallXml: model.compat?.healToolCallXml,
+			})
+				? new AnthropicXmlToolCallHealer()
+				: undefined;
+			const flushXmlHealedToolCalls = (): void => {
+				if (!xmlHealer) return;
+				const calls = xmlHealer.drainCompleted();
+				for (const call of calls) emitHealedToolCall(call);
+			};
+
 			for await (const chunk of iterateWithIdleTimeout(openaiStream, {
 				watchdog: firstEventWatchdog,
 				idleTimeoutMs,
@@ -780,6 +801,10 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 								if (clean.length > 0) appendTextDelta(clean);
 								flushHealedToolCalls();
 							}
+						} else if (xmlHealer) {
+							const clean = xmlHealer.feed(normalizedDeltaText);
+							if (clean.length > 0) appendTextDelta(clean);
+							flushXmlHealedToolCalls();
 						} else {
 							appendTextDelta(normalizedDeltaText);
 						}
@@ -885,6 +910,18 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 					// `finish_reason: stop` for the surrounding turn. Promote
 					// only that natural-completion finish — leave `error`,
 					// `length`, `aborted`, etc. untouched.
+					output.stopReason = "toolUse";
+				}
+			}
+
+			if (xmlHealer) {
+				const trailing = xmlHealer.flushPending();
+				if (trailing.length > 0) appendTextDelta(trailing);
+				flushXmlHealedToolCalls();
+				if (healedToolCallEmitted && output.stopReason === "stop") {
+					// Relays that leak Claude tool-call XML typically still report
+					// `finish_reason: stop`. Promote only that natural-completion
+					// finish so the agent loop dispatches the reconstructed call.
 					output.stopReason = "toolUse";
 				}
 			}

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -448,11 +448,19 @@ export async function processResponsesStream<TApi extends Api>(
 		? new AnthropicXmlToolCallHealer()
 		: undefined;
 	const emitXmlHealedToolCall = (call: { id: string; name: string; arguments: string }): void => {
+		const args = parseStreamingJson(call.arguments);
+		// If the relay already surfaced this exact call as a structured
+		// function_call (same name + arguments), don't synthesize a duplicate.
+		const argsKey = JSON.stringify(args);
+		const duplicate = output.content.some(
+			b => b.type === "toolCall" && b.name === call.name && JSON.stringify(b.arguments) === argsKey,
+		);
+		if (duplicate) return;
 		const block: ToolCall = {
 			type: "toolCall",
 			id: call.id,
 			name: call.name,
-			arguments: parseStreamingJson(call.arguments),
+			arguments: args,
 		};
 		output.content.push(block);
 		const contentIndex = output.content.length - 1;

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -17,6 +17,7 @@ import {
 	type AssistantMessage,
 	type ImageContent,
 	type Model,
+	type OpenAICompat,
 	resolveServiceTier,
 	type ServiceTier,
 	type StopReason,
@@ -29,6 +30,10 @@ import {
 	type ToolResultMessage,
 } from "../types";
 import { normalizeResponsesToolCallId } from "../utils";
+import {
+	AnthropicXmlToolCallHealer,
+	modelMayLeakAnthropicXmlToolCalls,
+} from "../utils/anthropic-xml-tool-call-healing";
 import type { AssistantMessageEventStream } from "../utils/event-stream";
 import { parseStreamingJson } from "../utils/json-parse";
 import { joinTextWithImagePlaceholder, NON_VISION_IMAGE_PLACEHOLDER, partitionVisionContent } from "./vision-guard";
@@ -432,6 +437,30 @@ export async function processResponsesStream<TApi extends Api>(
 	};
 	let sawFirstToken = false;
 
+	// Claude served through OpenAI-compatible relays may leak Anthropic tool-call
+	// XML (`<invoke name="…"><parameter …>`) into `output_text` rather than
+	// emitting structured function calls. Heal it so UI-bound tools still fire.
+	const xmlHealer = modelMayLeakAnthropicXmlToolCalls({
+		provider: model.provider,
+		modelId: model.id,
+		healToolCallXml: (model.compat as OpenAICompat | undefined)?.healToolCallXml,
+	})
+		? new AnthropicXmlToolCallHealer()
+		: undefined;
+	const emitXmlHealedToolCall = (call: { id: string; name: string; arguments: string }): void => {
+		const block: ToolCall = {
+			type: "toolCall",
+			id: call.id,
+			name: call.name,
+			arguments: parseStreamingJson(call.arguments),
+		};
+		output.content.push(block);
+		const contentIndex = output.content.length - 1;
+		stream.push({ type: "toolcall_start", contentIndex, partial: output });
+		stream.push({ type: "toolcall_delta", contentIndex, delta: call.arguments, partial: output });
+		stream.push({ type: "toolcall_end", contentIndex, toolCall: block, partial: output });
+	};
+
 	for await (const event of openaiStream) {
 		if (event.type === "response.created") {
 			output.responseId = event.response.id;
@@ -542,14 +571,20 @@ export async function processResponsesStream<TApi extends Api>(
 			if (entry?.item.type === "message" && entry.block.type === "text") {
 				const lastPart = entry.item.content?.[entry.item.content.length - 1];
 				if (lastPart?.type === "output_text") {
-					entry.block.text += event.delta;
-					lastPart.text += event.delta;
-					stream.push({
-						type: "text_delta",
-						contentIndex: entry.blockContentIndex,
-						delta: event.delta,
-						partial: output,
-					});
+					const visible = xmlHealer ? xmlHealer.feed(event.delta) : event.delta;
+					if (visible.length > 0) {
+						entry.block.text += visible;
+						lastPart.text += visible;
+						stream.push({
+							type: "text_delta",
+							contentIndex: entry.blockContentIndex,
+							delta: visible,
+							partial: output,
+						});
+					}
+					if (xmlHealer) {
+						for (const call of xmlHealer.drainCompleted()) emitXmlHealedToolCall(call);
+					}
 				}
 			}
 		} else if (event.type === "response.refusal.delta") {
@@ -635,9 +670,27 @@ export async function processResponsesStream<TApi extends Api>(
 				dropEntry(item.id, event.output_index);
 			} else if (item.type === "message" && entry?.block.type === "text") {
 				const block = entry.block;
-				block.text = item.content
-					.map(part => (part.type === "output_text" ? (part.text ?? "") : (part.refusal ?? "")))
-					.join("");
+				if (xmlHealer) {
+					// The wire item carries the raw text including any leaked tool-call
+					// XML; overwriting from it would undo the streamed healing. Keep the
+					// healed accumulation, flush any held-back trailing prose, and emit
+					// tool calls completed right at the item boundary.
+					const trailing = xmlHealer.flushPending();
+					if (trailing.length > 0) {
+						block.text += trailing;
+						stream.push({
+							type: "text_delta",
+							contentIndex: entry.blockContentIndex,
+							delta: trailing,
+							partial: output,
+						});
+					}
+					for (const call of xmlHealer.drainCompleted()) emitXmlHealedToolCall(call);
+				} else {
+					block.text = item.content
+						.map(part => (part.type === "output_text" ? (part.text ?? "") : (part.refusal ?? "")))
+						.join("");
+				}
 				block.textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
 				stream.push({
 					type: "text_end",
@@ -709,6 +762,9 @@ export async function processResponsesStream<TApi extends Api>(
 							? `status_details: ${statusDetailsReason}`
 							: "Unknown error (no error details in response)";
 				throw new Error(message);
+			}
+			if (xmlHealer) {
+				for (const call of xmlHealer.drainCompleted()) emitXmlHealedToolCall(call);
 			}
 			if (output.content.some(block => block.type === "toolCall") && output.stopReason === "stop") {
 				output.stopReason = "toolUse";

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -822,6 +822,16 @@ export interface OpenAICompat extends ToolChoiceCompat {
 	supportsStrictMode?: boolean;
 	/** Whether tool schemas must be sent either all strict or all non-strict. Undefined keeps the existing per-tool mixed behavior. */
 	toolStrictMode?: "all_strict" | "none";
+	/**
+	 * Whether to recover Anthropic-style tool-call XML (`<function_calls>` /
+	 * `<invoke name="…"><parameter name="…">…`) that leaks into visible assistant
+	 * text and reconstruct it into structured tool calls. Set this for relays
+	 * (e.g. LiteLLM/OpenAI-compatible proxies fronting Claude) that forward the
+	 * raw model text instead of converting it into `tool_calls`, which otherwise
+	 * makes UI-bound tools silently fail to render. Default: auto-detected for
+	 * claude-family model ids; explicitly set to force on/off.
+	 */
+	healToolCallXml?: boolean;
 }
 
 /**

--- a/packages/ai/src/utils/anthropic-xml-tool-call-healing.ts
+++ b/packages/ai/src/utils/anthropic-xml-tool-call-healing.ts
@@ -1,0 +1,313 @@
+/**
+ * Streaming-safe filter for Anthropic-style tool-call XML that leaks into
+ * visible assistant text.
+ *
+ * Claude models are trained to request tools with an XML grammar:
+ *
+ *     <function_calls>
+ *       <invoke name="proxy_ask">
+ *         <parameter name="_i">why now</parameter>
+ *         <parameter name="questions">[{"id":"r3", ...}]</parameter>
+ *       </invoke>
+ *     </function_calls>
+ *
+ * When a Claude model is served through a relay that forwards the raw model
+ * text instead of converting it into structured `tool_calls` (common with
+ * LiteLLM / OpenAI-compatible proxies fronting Claude), this grammar lands in
+ * `delta.content` / `response.output_text.delta`. The agent loop then never
+ * sees a tool call, so UI-bound tools like `proxy_ask` (the deep-interview
+ * question panel) silently fail to render — the user just sees the raw XML.
+ *
+ * This module reconstructs the embedded calls and strips the markers from the
+ * visible text. It is stream-aware: any partial tag at the end of a chunk is
+ * held back until the next chunk arrives. It mirrors the design of the Kimi-K2
+ * {@link ToolCallHealer}, but the grammar carries attributes (`name="…"`) and
+ * nests, so the matcher is tag-oriented rather than fixed-token.
+ *
+ * The `antml:` namespace prefix (used by some harness encodings) and a missing
+ * outer `<function_calls>` wrapper are both tolerated: a bare `<invoke …>`
+ * opens an implicit section.
+ */
+
+import { generateHealedToolCallId, type HealedToolCall } from "./tool-call-healing";
+
+/** Longest partial tag we hold back waiting for more bytes before giving up. */
+const MAX_PARTIAL_HOLD = 1024;
+
+/** Literal tag stems we may be in the middle of receiving (no attrs / close yet). */
+const TAG_STEMS = [
+	"<function_calls",
+	"</function_calls",
+	"<function_calls",
+	"</function_calls",
+	"<invoke",
+	"</invoke",
+	"<invoke",
+	"</invoke",
+	"<parameter",
+	"</parameter",
+	"<parameter",
+	"</parameter",
+] as const;
+
+const RE_FUNCTION_CALLS_OPEN = /^<(?:antml:)?function_calls\s*>/;
+const RE_FUNCTION_CALLS_CLOSE = /^<\/(?:antml:)?function_calls\s*>/;
+const RE_INVOKE_OPEN = /^<(?:antml:)?invoke\s+name\s*=\s*"([^"]*)"\s*>/;
+const RE_INVOKE_CLOSE = /^<\/(?:antml:)?invoke\s*>/;
+const RE_PARAMETER_OPEN = /^<(?:antml:)?parameter\s+name\s*=\s*"([^"]*)"\s*>/;
+const RE_PARAMETER_CLOSE = /^<\/(?:antml:)?parameter\s*>/;
+const RE_PARAMETER_CLOSE_STEMS = ["</parameter", "</parameter"] as const;
+
+type TagMatch =
+	| { kind: "functionCallsOpen" | "functionCallsClose" | "invokeClose" | "parameterClose"; length: number }
+	| { kind: "invokeOpen" | "parameterOpen"; length: number; name: string };
+
+/**
+ * Coerce a raw `<parameter>` body into the JSON value the tool schema expects.
+ * Typed params (objects, arrays, numbers, booleans) are written as JSON; plain
+ * strings are written verbatim. Try a strict JSON parse first and fall back to
+ * the raw (trimmed) string — never repair, so a value that merely *looks*
+ * JSON-ish is not silently rewritten.
+ */
+function coerceParameterValue(raw: string): unknown {
+	const trimmed = raw.trim();
+	if (trimmed.length === 0) return "";
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		return raw;
+	}
+}
+
+/**
+ * State machine that consumes streamed text, emits visible text with all
+ * Anthropic tool-call XML stripped, and accumulates the embedded calls for the
+ * caller to drain after each {@link feed}.
+ *
+ * One instance per stream. Feed only the visible-text channel (assistant
+ * content); never the reasoning channel.
+ */
+export class AnthropicXmlToolCallHealer {
+	#buffer = "";
+	#offset = 0;
+	#inFunctionCalls = false;
+	#invokeName: string | null = null;
+	#params: Record<string, unknown> = {};
+	#paramName: string | null = null;
+	#paramValue = "";
+	readonly #completed: HealedToolCall[] = [];
+
+	/**
+	 * Feed a chunk of streamed text. Returns the portion safe to emit
+	 * downstream (with all tool-call XML stripped). Any partial tag suffix is
+	 * held back until the next chunk arrives or {@link flushPending} is called.
+	 */
+	feed(text: string): string {
+		if (text.length === 0) return "";
+		this.#compact();
+		this.#buffer += text;
+		return this.#consume();
+	}
+
+	/** Drain accumulated tool calls. The internal list is cleared. */
+	drainCompleted(): HealedToolCall[] {
+		if (this.#completed.length === 0) return [];
+		return this.#completed.splice(0, this.#completed.length);
+	}
+
+	/**
+	 * Flush any held-back fragment when the stream ends. If we are mid-invoke
+	 * the partial is dropped (emitting raw XML bytes would surface markers to
+	 * the user); otherwise the fragment is returned verbatim so a literal `<`
+	 * in prose is not lost.
+	 */
+	flushPending(): string {
+		const tail = this.#remaining();
+		this.#buffer = "";
+		this.#offset = 0;
+		if (this.#invokeName !== null || this.#inFunctionCalls) return "";
+		return tail;
+	}
+
+	/** True if a `<function_calls>` or `<invoke>` section is currently open. */
+	get inSection(): boolean {
+		return this.#inFunctionCalls || this.#invokeName !== null;
+	}
+
+	#remaining(): string {
+		return this.#offset === 0 ? this.#buffer : this.#buffer.slice(this.#offset);
+	}
+
+	#compact(): void {
+		if (this.#offset === 0) return;
+		this.#buffer = this.#buffer.slice(this.#offset);
+		this.#offset = 0;
+	}
+
+	#consume(): string {
+		let clean = "";
+
+		while (this.#offset < this.#buffer.length) {
+			// Inside a <parameter> body the only structural token is its close
+			// tag; everything else is literal value content.
+			if (this.#paramName !== null) {
+				if (this.#buffer[this.#offset] === "<") {
+					const close = this.#matchParameterClose();
+					if (close) {
+						this.#finalizeParameter();
+						this.#offset += close;
+						continue;
+					}
+					if (this.#couldBePartialParameterClose()) break;
+				}
+				this.#paramValue += this.#buffer[this.#offset];
+				this.#offset += 1;
+				continue;
+			}
+
+			if (this.#buffer[this.#offset] !== "<") {
+				const ch = this.#buffer[this.#offset]!;
+				this.#offset += 1;
+				// Swallow inter-element whitespace/content inside a section;
+				// pass everything through outside one.
+				if (!this.inSection) clean += ch;
+				continue;
+			}
+
+			const tag = this.#matchTag();
+			if (tag) {
+				clean += this.#applyTag(tag);
+				this.#offset += tag.length;
+				continue;
+			}
+
+			if (this.#couldBePartialTag()) break;
+
+			// A `<` that cannot start any known tag — emit literally.
+			this.#offset += 1;
+			if (!this.inSection) clean += "<";
+		}
+
+		return clean;
+	}
+
+	/** Apply a fully-matched tag, returning any text it should emit verbatim. */
+	#applyTag(tag: TagMatch): string {
+		switch (tag.kind) {
+			case "functionCallsOpen":
+				this.#inFunctionCalls = true;
+				return "";
+			case "functionCallsClose":
+				this.#inFunctionCalls = false;
+				return "";
+			case "invokeOpen":
+				this.#invokeName = tag.name;
+				this.#params = {};
+				return "";
+			case "invokeClose":
+				if (this.#invokeName !== null) this.#finalizeInvoke();
+				return "";
+			case "parameterOpen":
+				if (this.#invokeName !== null) {
+					this.#paramName = tag.name;
+					this.#paramValue = "";
+					return "";
+				}
+				// Stray `<parameter>` outside an invoke — pass through as text so
+				// docs explaining the grammar are not silently eaten.
+				return this.#buffer.slice(this.#offset, this.#offset + tag.length);
+			case "parameterClose":
+				return this.inSection ? "" : this.#buffer.slice(this.#offset, this.#offset + tag.length);
+		}
+	}
+
+	#matchTag(): TagMatch | null {
+		const rest = this.#buffer.slice(this.#offset);
+		let m = RE_INVOKE_OPEN.exec(rest);
+		if (m) return { kind: "invokeOpen", length: m[0].length, name: m[1] ?? "" };
+		m = RE_PARAMETER_OPEN.exec(rest);
+		if (m) return { kind: "parameterOpen", length: m[0].length, name: m[1] ?? "" };
+		m = RE_INVOKE_CLOSE.exec(rest);
+		if (m) return { kind: "invokeClose", length: m[0].length };
+		m = RE_PARAMETER_CLOSE.exec(rest);
+		if (m) return { kind: "parameterClose", length: m[0].length };
+		m = RE_FUNCTION_CALLS_OPEN.exec(rest);
+		if (m) return { kind: "functionCallsOpen", length: m[0].length };
+		m = RE_FUNCTION_CALLS_CLOSE.exec(rest);
+		if (m) return { kind: "functionCallsClose", length: m[0].length };
+		return null;
+	}
+
+	#matchParameterClose(): number | null {
+		const m = RE_PARAMETER_CLOSE.exec(this.#buffer.slice(this.#offset));
+		return m ? m[0].length : null;
+	}
+
+	/**
+	 * True if the unconsumed buffer is a strict prefix of some tag, or an open
+	 * tag still streaming its attributes (`<invoke name="foo` with no `>` yet).
+	 * Capped so a stray `<` in prose can't grow the holdback unboundedly.
+	 */
+	#couldBePartialTag(): boolean {
+		return this.#couldBePartial(TAG_STEMS);
+	}
+
+	#couldBePartialParameterClose(): boolean {
+		return this.#couldBePartial(RE_PARAMETER_CLOSE_STEMS);
+	}
+
+	#couldBePartial(stems: readonly string[]): boolean {
+		const remaining = this.#buffer.length - this.#offset;
+		if (remaining === 0 || remaining > MAX_PARTIAL_HOLD) return false;
+		const slice = this.#buffer.slice(this.#offset);
+		for (const stem of stems) {
+			// Case 1: we have less than the stem and it is a prefix of the stem.
+			if (slice.length < stem.length && stem.startsWith(slice)) return true;
+			// Case 2: we have the full stem but the tag has not closed (`>`) yet,
+			// so its attributes may still be streaming.
+			if (slice.startsWith(stem) && !slice.includes(">")) return true;
+		}
+		return false;
+	}
+
+	#finalizeParameter(): void {
+		if (this.#paramName === null) return;
+		this.#params[this.#paramName] = coerceParameterValue(this.#paramValue);
+		this.#paramName = null;
+		this.#paramValue = "";
+	}
+
+	#finalizeInvoke(): void {
+		const name = (this.#invokeName ?? "").trim();
+		// A `</invoke>` arriving mid-parameter still flushes the captured value.
+		if (this.#paramName !== null) this.#finalizeParameter();
+		this.#completed.push({
+			id: generateHealedToolCallId(),
+			name,
+			arguments: JSON.stringify(this.#params),
+		});
+		this.#invokeName = null;
+		this.#params = {};
+	}
+}
+
+/**
+ * Whether a provider/model may leak Anthropic tool-call XML into visible text.
+ *
+ * The leak is relay-specific, not model-id detectable (a proxy may surface a
+ * Claude model under an arbitrary id), so the primary switch is an explicit
+ * provider `compat.healToolCallXml` opt-in. Claude-family ids served through an
+ * OpenAI-compatible API (where structured tool calls would otherwise be
+ * expected) are also treated as candidates.
+ */
+export function modelMayLeakAnthropicXmlToolCalls(opts: {
+	provider: string;
+	modelId: string;
+	healToolCallXml?: boolean;
+}): boolean {
+	if (opts.healToolCallXml === true) return true;
+	if (opts.healToolCallXml === false) return false;
+	return /claude|anthropic/i.test(opts.modelId) || /anthropic/i.test(opts.provider);
+}
+
+export type { HealedToolCall };

--- a/packages/ai/src/utils/anthropic-xml-tool-call-healing.ts
+++ b/packages/ai/src/utils/anthropic-xml-tool-call-healing.ts
@@ -34,21 +34,26 @@ import { generateHealedToolCallId, type HealedToolCall } from "./tool-call-heali
 /** Longest partial tag we hold back waiting for more bytes before giving up. */
 const MAX_PARTIAL_HOLD = 1024;
 
-/** Literal tag stems we may be in the middle of receiving (no attrs / close yet). */
-const TAG_STEMS = [
-	"<function_calls",
-	"</function_calls",
-	"<function_calls",
-	"</function_calls",
-	"<invoke",
-	"</invoke",
-	"<invoke",
-	"</invoke",
-	"<parameter",
-	"</parameter",
-	"<parameter",
-	"</parameter",
-] as const;
+/**
+ * XML namespace prefix some harness encodings use. Built by concatenation so the
+ * `<`-followed-by-prefix adjacency is never written as a source literal (which
+ * upstream tooling has been observed to strip), and so the plain and namespaced
+ * stems are always generated as a matched pair.
+ */
+const NS = "ant" + "ml" + ":";
+const TAG_NAMES = ["function_calls", "invoke", "parameter"] as const;
+
+/**
+ * Literal tag stems we may be in the middle of receiving (no attrs / close yet).
+ * Includes both plain and `antml:`-namespaced open/close stems for every tag so
+ * streaming partial-tag holdback engages for either spelling.
+ */
+const TAG_STEMS: readonly string[] = TAG_NAMES.flatMap(name => [
+	`<${name}`,
+	`</${name}`,
+	`<${NS}${name}`,
+	`</${NS}${name}`,
+]);
 
 const RE_FUNCTION_CALLS_OPEN = /^<(?:antml:)?function_calls\s*>/;
 const RE_FUNCTION_CALLS_CLOSE = /^<\/(?:antml:)?function_calls\s*>/;
@@ -56,7 +61,7 @@ const RE_INVOKE_OPEN = /^<(?:antml:)?invoke\s+name\s*=\s*"([^"]*)"\s*>/;
 const RE_INVOKE_CLOSE = /^<\/(?:antml:)?invoke\s*>/;
 const RE_PARAMETER_OPEN = /^<(?:antml:)?parameter\s+name\s*=\s*"([^"]*)"\s*>/;
 const RE_PARAMETER_CLOSE = /^<\/(?:antml:)?parameter\s*>/;
-const RE_PARAMETER_CLOSE_STEMS = ["</parameter", "</parameter"] as const;
+const RE_PARAMETER_CLOSE_STEMS: readonly string[] = [`</parameter`, `</${NS}parameter`];
 
 type TagMatch =
 	| { kind: "functionCallsOpen" | "functionCallsClose" | "invokeClose" | "parameterClose"; length: number }
@@ -107,6 +112,19 @@ export class AnthropicXmlToolCallHealer {
 		this.#compact();
 		this.#buffer += text;
 		return this.#consume();
+	}
+
+	/**
+	 * Like {@link feed}, but discards any tool calls the chunk completes. Used
+	 * when the upstream provider also emits structured tool calls for the same
+	 * chunk: the healer still strips the leaked marker text from visible output,
+	 * but the structured payload stays the single source of truth (avoids
+	 * double-dispatching the same call).
+	 */
+	consumeWithoutCalls(text: string): string {
+		const clean = this.feed(text);
+		if (this.#completed.length > 0) this.#completed.length = 0;
+		return clean;
 	}
 
 	/** Drain accumulated tool calls. The internal list is cleared. */

--- a/packages/ai/src/utils/tool-call-healing.ts
+++ b/packages/ai/src/utils/tool-call-healing.ts
@@ -266,6 +266,6 @@ function normalizeFunctionName(rawId: string): string {
 	return colon >= 0 ? stripped.slice(0, colon) : stripped;
 }
 
-function generateHealedToolCallId(): string {
+export function generateHealedToolCallId(): string {
 	return `call_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`;
 }

--- a/packages/ai/test/anthropic-xml-tool-call-healing.test.ts
+++ b/packages/ai/test/anthropic-xml-tool-call-healing.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "bun:test";
+import {
+	AnthropicXmlToolCallHealer,
+	modelMayLeakAnthropicXmlToolCalls,
+} from "../src/utils/anthropic-xml-tool-call-healing";
+
+/** Feed an entire string in one chunk and return {text, calls}. */
+function healOnce(input: string) {
+	const healer = new AnthropicXmlToolCallHealer();
+	const text = healer.feed(input) + healer.flushPending();
+	return { text, calls: healer.drainCompleted() };
+}
+
+/** Feed char-by-char to exercise partial-tag holdback at every boundary. */
+function healByChar(input: string) {
+	const healer = new AnthropicXmlToolCallHealer();
+	let text = "";
+	const calls: ReturnType<AnthropicXmlToolCallHealer["drainCompleted"]> = [];
+	for (const ch of input) {
+		text += healer.feed(ch);
+		calls.push(...healer.drainCompleted());
+	}
+	text += healer.flushPending();
+	calls.push(...healer.drainCompleted());
+	return { text, calls };
+}
+
+describe("AnthropicXmlToolCallHealer", () => {
+	const FULL =
+		"<function_calls>\n" +
+		'<invoke name="proxy_ask">\n' +
+		'<parameter name="_i">why now</parameter>\n' +
+		'<parameter name="questions">[{"id":"r3","q":"how?"}]</parameter>\n' +
+		"</invoke>\n" +
+		"</function_calls>";
+
+	it("strips a complete block and reconstructs the tool call", () => {
+		const { text, calls } = healOnce(`I'll ask. ${FULL}`);
+		expect(text.trim()).toBe("I'll ask.");
+		expect(text).not.toContain("<invoke");
+		expect(text).not.toContain("<parameter");
+		expect(calls).toHaveLength(1);
+		expect(calls[0].name).toBe("proxy_ask");
+		expect(calls[0].id).toMatch(/^call_[0-9a-f]+$/);
+		expect(JSON.parse(calls[0].arguments)).toEqual({
+			_i: "why now",
+			questions: [{ id: "r3", q: "how?" }],
+		});
+	});
+
+	it("works without a <function_calls> wrapper (bare invoke)", () => {
+		const bare = '<invoke name="ask"><parameter name="x">1</parameter></invoke>';
+		const { text, calls } = healOnce(`before ${bare} after`);
+		expect(text).toBe("before  after");
+		expect(calls).toHaveLength(1);
+		expect(calls[0].name).toBe("ask");
+		expect(JSON.parse(calls[0].arguments)).toEqual({ x: 1 });
+	});
+
+	it("tolerates the antml: namespace prefix", () => {
+		const ns =
+			"<function_calls>" +
+			'<invoke name="ask">' +
+			'<parameter name="p">"v"</parameter>' +
+			"</invoke>" +
+			"</function_calls>";
+		const { text, calls } = healOnce(ns);
+		expect(text).toBe("");
+		expect(calls).toHaveLength(1);
+		expect(calls[0].name).toBe("ask");
+		expect(JSON.parse(calls[0].arguments)).toEqual({ p: "v" });
+	});
+
+	it("reconstructs a block split across every character boundary", () => {
+		const { text, calls } = healByChar(`ok ${FULL} done`);
+		expect(text.replace(/\s+/g, " ").trim()).toBe("ok done");
+		expect(text).not.toContain("<");
+		expect(calls).toHaveLength(1);
+		expect(JSON.parse(calls[0].arguments)).toEqual({
+			_i: "why now",
+			questions: [{ id: "r3", q: "how?" }],
+		});
+	});
+
+	it("preserves a parameter value that contains '<' and '>'", () => {
+		const block = '<invoke name="ask"><parameter name="expr">a < b && c > d</parameter></invoke>';
+		const { calls } = healOnce(block);
+		expect(calls).toHaveLength(1);
+		expect(JSON.parse(calls[0].arguments)).toEqual({ expr: "a < b && c > d" });
+	});
+
+	it("coerces typed parameter values; keeps plain strings verbatim", () => {
+		const block =
+			'<invoke name="t">' +
+			'<parameter name="n">42</parameter>' +
+			'<parameter name="b">true</parameter>' +
+			'<parameter name="s">hello world</parameter>' +
+			'<parameter name="o">{"k":1}</parameter>' +
+			"</invoke>";
+		const { calls } = healOnce(block);
+		expect(JSON.parse(calls[0].arguments)).toEqual({
+			n: 42,
+			b: true,
+			s: "hello world",
+			o: { k: 1 },
+		});
+	});
+
+	it("handles multiple invokes inside one function_calls section", () => {
+		const block =
+			"<function_calls>" +
+			'<invoke name="a"><parameter name="x">1</parameter></invoke>' +
+			'<invoke name="b"><parameter name="y">2</parameter></invoke>' +
+			"</function_calls>";
+		const { calls } = healOnce(block);
+		expect(calls.map(c => c.name)).toEqual(["a", "b"]);
+		expect(calls[0].id).not.toBe(calls[1].id);
+		expect(JSON.parse(calls[1].arguments)).toEqual({ y: 2 });
+	});
+
+	it("passes prose through unchanged when no markers are present", () => {
+		const { text, calls } = healOnce("Just normal text with a < b comparison.");
+		expect(text).toBe("Just normal text with a < b comparison.");
+		expect(calls).toHaveLength(0);
+	});
+
+	it("does not eat a stray '<' that cannot start a tag", () => {
+		const { text, calls } = healByChar("price < 5 and x<y");
+		expect(text).toBe("price < 5 and x<y");
+		expect(calls).toHaveLength(0);
+	});
+
+	it("drops an unterminated invoke at stream end (no raw XML leaks)", () => {
+		const { text, calls } = healOnce('thinking… <invoke name="ask"><parameter name="x">1');
+		expect(text.trim()).toBe("thinking…");
+		expect(text).not.toContain("<invoke");
+		expect(calls).toHaveLength(0);
+	});
+
+	it("emits an empty-args call for an invoke with no parameters", () => {
+		const { calls } = healOnce('<invoke name="ping"></invoke>');
+		expect(calls).toHaveLength(1);
+		expect(calls[0].arguments).toBe("{}");
+	});
+});
+
+describe("modelMayLeakAnthropicXmlToolCalls", () => {
+	it("honors the explicit compat opt-in/out first", () => {
+		expect(
+			modelMayLeakAnthropicXmlToolCalls({ provider: "litellm", modelId: "gpt-5.5", healToolCallXml: true }),
+		).toBe(true);
+		expect(
+			modelMayLeakAnthropicXmlToolCalls({
+				provider: "anthropic",
+				modelId: "claude-opus-4-8",
+				healToolCallXml: false,
+			}),
+		).toBe(false);
+	});
+
+	it("treats claude-family ids/providers as candidates by default", () => {
+		expect(modelMayLeakAnthropicXmlToolCalls({ provider: "litellm", modelId: "claude-opus-4-8" })).toBe(true);
+		expect(modelMayLeakAnthropicXmlToolCalls({ provider: "openrouter", modelId: "gpt-5.5" })).toBe(false);
+	});
+});

--- a/packages/ai/test/anthropic-xml-tool-call-healing.test.ts
+++ b/packages/ai/test/anthropic-xml-tool-call-healing.test.ts
@@ -57,18 +57,49 @@ describe("AnthropicXmlToolCallHealer", () => {
 		expect(JSON.parse(calls[0].arguments)).toEqual({ x: 1 });
 	});
 
-	it("tolerates the antml: namespace prefix", () => {
-		const ns =
-			"<function_calls>" +
-			'<invoke name="ask">' +
-			'<parameter name="p">"v"</parameter>' +
-			"</invoke>" +
-			"</function_calls>";
-		const { text, calls } = healOnce(ns);
+	// The namespace prefix is assembled by concatenation so the `<`-prefix
+	// adjacency is never written as a source literal (which upstream tooling can
+	// strip — the exact bug that made the earlier version of this test pass
+	// against plain, un-namespaced XML).
+	const NS = `ant${"ml:"}`;
+	const NS_BLOCK =
+		`<${NS}function_calls>` +
+		`<${NS}invoke name="ask">` +
+		`<${NS}parameter name="p">"v"</${NS}parameter>` +
+		`</${NS}invoke>` +
+		`</${NS}function_calls>`;
+
+	it("tolerates the antml: namespace prefix (single chunk)", () => {
+		expect(NS_BLOCK).toContain(`<${NS}invoke`); // guard: prefix really is present
+		const { text, calls } = healOnce(NS_BLOCK);
 		expect(text).toBe("");
 		expect(calls).toHaveLength(1);
 		expect(calls[0].name).toBe("ask");
 		expect(JSON.parse(calls[0].arguments)).toEqual({ p: "v" });
+	});
+
+	it("tolerates the antml: namespace prefix (char-by-char, no leak)", () => {
+		const { text, calls } = healByChar(`run: ${NS_BLOCK} ok`);
+		// The whole namespaced block must be stripped — not even a `<` may leak.
+		expect(text.replace(/\s+/g, " ").trim()).toBe("run: ok");
+		expect(text).not.toContain("<");
+		expect(calls).toHaveLength(1);
+		expect(calls[0].name).toBe("ask");
+		expect(JSON.parse(calls[0].arguments)).toEqual({ p: "v" });
+	});
+
+	it("heals a namespaced block split mid-tag across two chunks", () => {
+		const healer = new AnthropicXmlToolCallHealer();
+		// Split right after `<inv` to force partial-tag holdback on a
+		// namespaced open tag.
+		const cut = NS_BLOCK.indexOf("invoke") + 3;
+		let text = healer.feed(NS_BLOCK.slice(0, cut));
+		text += healer.feed(NS_BLOCK.slice(cut));
+		text += healer.flushPending();
+		const calls = healer.drainCompleted();
+		expect(text).toBe("");
+		expect(calls).toHaveLength(1);
+		expect(calls[0].name).toBe("ask");
 	});
 
 	it("reconstructs a block split across every character boundary", () => {

--- a/packages/ai/test/composer-discipline.test.ts
+++ b/packages/ai/test/composer-discipline.test.ts
@@ -39,6 +39,7 @@ const compat: Required<OpenAICompat> = {
 	extraBody: {},
 	supportsStrictMode: true,
 	toolStrictMode: "none",
+	healToolCallXml: false,
 };
 
 function createXaiModel(id: string): Model<"openai-completions"> {

--- a/packages/ai/test/issue-967-vision-guard.test.ts
+++ b/packages/ai/test/issue-967-vision-guard.test.ts
@@ -47,6 +47,7 @@ const compat: Required<OpenAICompat> = {
 	extraBody: {},
 	supportsStrictMode: true,
 	toolStrictMode: "none",
+	healToolCallXml: false,
 };
 
 function makeModel<TApi extends Api>(api: TApi, provider: Model["provider"]): Model<TApi> {

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -95,6 +95,7 @@ describe("openai-completions compatibility", () => {
 			extraBody: {},
 			supportsStrictMode: true,
 			toolStrictMode: "none",
+			healToolCallXml: false,
 		} satisfies Required<OpenAICompat>;
 		const assistantMessage: AssistantMessage = {
 			role: "assistant",

--- a/packages/ai/test/openai-completions-heal-toolcall-xml.test.ts
+++ b/packages/ai/test/openai-completions-heal-toolcall-xml.test.ts
@@ -10,12 +10,22 @@ afterEach(() => {
 	global.fetch = originalFetch;
 });
 
+interface ToolCallDelta {
+	index: number;
+	id?: string;
+	type?: "function";
+	function?: { name?: string; arguments?: string };
+}
 interface SseChunk {
 	id: string;
 	object: "chat.completion.chunk";
 	created: number;
 	model: string;
-	choices: Array<{ index: number; delta: { content?: string }; finish_reason?: "stop" | "length" | null }>;
+	choices: Array<{
+		index: number;
+		delta: { content?: string; tool_calls?: ToolCallDelta[] };
+		finish_reason?: "stop" | "length" | "tool_calls" | null;
+	}>;
 }
 
 function sseResponse(events: ReadonlyArray<SseChunk | "[DONE]">): Response {
@@ -97,5 +107,45 @@ describe("chat-completions: leaked Anthropic tool-call XML healing", () => {
 		const tools = result.content.filter((b): b is ToolCall => b.type === "toolCall");
 		expect(tools).toHaveLength(1);
 		expect(tools[0].arguments).toEqual({ _i: "why", questions: [{ id: "r3" }] });
+	});
+
+	it("does not double-dispatch when the same chunk also carries structured tool_calls", async () => {
+		// A relay leaks the XML AND emits the structured call in one delta. The
+		// healer must strip the marker text but not synthesize a second call.
+		const dupChunk: SseChunk = {
+			id: "chatcmpl-xml-test",
+			object: "chat.completion.chunk",
+			created: 0,
+			model: "claude-opus-4-8",
+			choices: [
+				{
+					index: 0,
+					delta: {
+						content: FULL,
+						tool_calls: [
+							{
+								index: 0,
+								id: "call_structured",
+								type: "function",
+								function: { name: "proxy_ask", arguments: '{"_i":"why"}' },
+							},
+						],
+					},
+					finish_reason: null,
+				},
+			],
+		};
+		global.fetch = mockFetch([dupChunk, chunk(undefined, "tool_calls"), "[DONE]"]);
+
+		const result = await streamOpenAICompletions(model(), context(), { apiKey: "test" }).result();
+		const tools = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(tools).toHaveLength(1);
+		expect(tools[0].id).toBe("call_structured");
+
+		const text = result.content
+			.filter(b => b.type === "text")
+			.map(b => (b as { text: string }).text)
+			.join("");
+		expect(text).not.toContain("<invoke");
 	});
 });

--- a/packages/ai/test/openai-completions-heal-toolcall-xml.test.ts
+++ b/packages/ai/test/openai-completions-heal-toolcall-xml.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { streamOpenAICompletions } from "@gajae-code/ai/providers/openai-completions";
+import type { Context, Model, ToolCall } from "@gajae-code/ai/types";
+
+// Coverage for the Anthropic tool-call-XML healer wired into the chat-completions
+// provider (e.g. a Claude model served via an OpenAI-compatible relay).
+
+const originalFetch = global.fetch;
+afterEach(() => {
+	global.fetch = originalFetch;
+});
+
+interface SseChunk {
+	id: string;
+	object: "chat.completion.chunk";
+	created: number;
+	model: string;
+	choices: Array<{ index: number; delta: { content?: string }; finish_reason?: "stop" | "length" | null }>;
+}
+
+function sseResponse(events: ReadonlyArray<SseChunk | "[DONE]">): Response {
+	const payload = `${events.map(e => `data: ${typeof e === "string" ? e : JSON.stringify(e)}`).join("\n\n")}\n\n`;
+	return new Response(payload, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+function mockFetch(events: ReadonlyArray<SseChunk | "[DONE]">): typeof fetch {
+	const fn = async (): Promise<Response> => sseResponse(events);
+	return Object.assign(fn, { preconnect: originalFetch.preconnect });
+}
+
+function chunk(content: string | undefined, finish: SseChunk["choices"][0]["finish_reason"] = null): SseChunk {
+	return {
+		id: "chatcmpl-xml-test",
+		object: "chat.completion.chunk",
+		created: 0,
+		model: "claude-opus-4-8",
+		choices: [{ index: 0, delta: content === undefined ? {} : { content }, finish_reason: finish }],
+	};
+}
+
+function model(): Model<"openai-completions"> {
+	return {
+		id: "claude-opus-4-8",
+		name: "Claude via relay",
+		api: "openai-completions",
+		provider: "litellm",
+		baseUrl: "http://127.0.0.1:4000/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 8192,
+		compat: { healToolCallXml: true },
+	};
+}
+
+function context(): Context {
+	return { messages: [{ role: "user", content: "ask me", timestamp: Date.now() }] };
+}
+
+const FULL =
+	'<invoke name="proxy_ask">' +
+	'<parameter name="_i">why</parameter>' +
+	'<parameter name="questions">[{"id":"r3"}]</parameter>' +
+	"</invoke>";
+
+describe("chat-completions: leaked Anthropic tool-call XML healing", () => {
+	it("strips XML and synthesizes the tool call, promoting stop -> toolUse", async () => {
+		global.fetch = mockFetch([chunk("Sure. "), chunk(FULL), chunk(undefined, "stop"), "[DONE]"]);
+
+		const result = await streamOpenAICompletions(model(), context(), { apiKey: "test" }).result();
+
+		const text = result.content
+			.filter(b => b.type === "text")
+			.map(b => (b as { text: string }).text)
+			.join("");
+		expect(text.trim()).toBe("Sure.");
+		expect(text).not.toContain("<invoke");
+
+		const tools = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(tools).toHaveLength(1);
+		expect(tools[0].name).toBe("proxy_ask");
+		expect(tools[0].arguments).toEqual({ _i: "why", questions: [{ id: "r3" }] });
+		expect(result.stopReason).toBe("toolUse");
+	});
+
+	it("reconstructs across a token split mid-tag", async () => {
+		const split = FULL.indexOf('name="questions"') + 5;
+		global.fetch = mockFetch([
+			chunk(FULL.slice(0, split)),
+			chunk(FULL.slice(split)),
+			chunk(undefined, "stop"),
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model(), context(), { apiKey: "test" }).result();
+		const tools = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(tools).toHaveLength(1);
+		expect(tools[0].arguments).toEqual({ _i: "why", questions: [{ id: "r3" }] });
+	});
+});

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -40,6 +40,7 @@ const compat: Required<OpenAICompat> = {
 	extraBody: {},
 	supportsStrictMode: true,
 	toolStrictMode: "none",
+	healToolCallXml: false,
 };
 
 function buildToolResult(toolCallId: string, timestamp: number): ToolResultMessage {

--- a/packages/ai/test/openai-responses-heal-toolcall-xml.test.ts
+++ b/packages/ai/test/openai-responses-heal-toolcall-xml.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import { processResponsesStream } from "@gajae-code/ai/providers/openai-responses-shared";
+import type { AssistantMessage, Model, ToolCall } from "@gajae-code/ai/types";
+import type { ResponseStreamEvent } from "openai/resources/responses/responses";
+
+// End-to-end coverage for the Anthropic tool-call-XML healer wired into the
+// Responses provider: a Claude model fronted by an OpenAI-compatible relay
+// leaks `<invoke name="…"><parameter …>` into `output_text` instead of emitting
+// a structured function call. The healer must strip it from visible text AND
+// reconstruct the structured call so UI-bound tools (proxy_ask) still fire.
+
+async function* makeStream(events: unknown[]): AsyncIterable<ResponseStreamEvent> {
+	for (const e of events) yield e as ResponseStreamEvent;
+}
+
+function makeModel(healToolCallXml = true): Model<"openai-responses"> {
+	return {
+		id: "claude-opus-4-8",
+		name: "Claude via relay",
+		api: "openai-responses",
+		provider: "litellm",
+		baseUrl: "http://127.0.0.1:4000/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 8192,
+		compat: { healToolCallXml },
+	};
+}
+
+function makeOutput(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		timestamp: Date.now(),
+		provider: "litellm",
+		model: "claude-opus-4-8",
+		api: "openai-responses",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+	};
+}
+
+function makeCapture() {
+	const emitted: Array<Record<string, unknown>> = [];
+	const stream = { push: (e: Record<string, unknown>) => emitted.push(e), end: () => {} } as never;
+	return { emitted, stream };
+}
+
+function textOf(output: AssistantMessage): string {
+	return output.content
+		.filter(b => b.type === "text")
+		.map(b => (b as { text: string }).text)
+		.join("");
+}
+
+function toolBlocks(output: AssistantMessage): ToolCall[] {
+	return output.content.filter(b => b.type === "toolCall") as ToolCall[];
+}
+
+/** Build a message stream whose output_text is delivered as the given delta chunks. */
+function messageStream(deltas: string[], fullText: string): unknown[] {
+	return [
+		{ type: "response.output_item.added", output_index: 0, item: { type: "message", id: "msg_1", content: [] } },
+		{
+			type: "response.content_part.added",
+			item_id: "msg_1",
+			output_index: 0,
+			part: { type: "output_text", text: "", annotations: [] },
+		},
+		...deltas.map(delta => ({ type: "response.output_text.delta", item_id: "msg_1", output_index: 0, delta })),
+		{
+			type: "response.output_item.done",
+			output_index: 0,
+			item: {
+				type: "message",
+				id: "msg_1",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text: fullText, annotations: [] }],
+			},
+		},
+		{ type: "response.completed", response: { id: "resp_1", status: "completed", usage: undefined } },
+	];
+}
+
+const FULL =
+	"Let me ask you. " +
+	"<function_calls>" +
+	'<invoke name="proxy_ask">' +
+	'<parameter name="_i">why now</parameter>' +
+	'<parameter name="questions">[{"id":"r3","question":"how?"}]</parameter>' +
+	"</invoke>" +
+	"</function_calls>";
+
+describe("Responses provider: leaked Anthropic tool-call XML healing", () => {
+	test("strips the XML and reconstructs the tool call (single delta)", async () => {
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(messageStream([FULL], FULL)), output, stream, makeModel());
+
+		expect(textOf(output).trim()).toBe("Let me ask you.");
+		expect(textOf(output)).not.toContain("<invoke");
+
+		const tools = toolBlocks(output);
+		expect(tools).toHaveLength(1);
+		expect(tools[0].name).toBe("proxy_ask");
+		expect(tools[0].arguments).toEqual({ _i: "why now", questions: [{ id: "r3", question: "how?" }] });
+
+		// A leaked-XML turn reports status "completed"; promote so the call dispatches.
+		expect(output.stopReason).toBe("toolUse");
+
+		const ends = emitted.filter(e => e.type === "toolcall_end");
+		expect(ends).toHaveLength(1);
+		// Streamed text never contained raw markers.
+		const textDeltas = emitted.filter(e => e.type === "text_delta").map(e => e.delta as string);
+		expect(textDeltas.join("")).not.toContain("<invoke");
+	});
+
+	test("reconstructs the call when the XML is split across many deltas", async () => {
+		// One char per delta — forces partial-tag holdback at every boundary.
+		const deltas = [...FULL];
+		const output = makeOutput();
+		const { stream } = makeCapture();
+		await processResponsesStream(makeStream(messageStream(deltas, FULL)), output, stream, makeModel());
+
+		expect(textOf(output).trim()).toBe("Let me ask you.");
+		expect(textOf(output)).not.toContain("<");
+		const tools = toolBlocks(output);
+		expect(tools).toHaveLength(1);
+		expect(tools[0].arguments).toEqual({ _i: "why now", questions: [{ id: "r3", question: "how?" }] });
+		expect(output.stopReason).toBe("toolUse");
+	});
+
+	test("leaves text untouched when healing is disabled for the model", async () => {
+		const output = makeOutput();
+		const { stream } = makeCapture();
+		await processResponsesStream(makeStream(messageStream([FULL], FULL)), output, stream, makeModel(false));
+
+		// Disabled → raw text passes through, no synthesized tool call.
+		expect(textOf(output)).toContain("<invoke");
+		expect(toolBlocks(output)).toHaveLength(0);
+	});
+
+	test("does not disturb a normal message with no tool-call XML", async () => {
+		const prose = "Here is a plain answer with a < b math and no tools.";
+		const output = makeOutput();
+		const { stream } = makeCapture();
+		await processResponsesStream(makeStream(messageStream([prose], prose)), output, stream, makeModel());
+
+		expect(textOf(output)).toBe(prose);
+		expect(toolBlocks(output)).toHaveLength(0);
+		expect(output.stopReason).toBe("stop");
+	});
+});


### PR DESCRIPTION
Follow-up to #1023 (closed for an `antml:` streaming blocker). The blocker is fixed; this PR carries the full change plus the fix.

## Problem

Claude models request tools with an XML grammar (`<function_calls>` / `<invoke name="…"><parameter name="…">…`). When a Claude model is served through an OpenAI-compatible relay (e.g. LiteLLM) that forwards the raw model text instead of structured `tool_calls`, the grammar lands in `delta.content` / `response.output_text.delta`. The agent loop never sees a tool call, so UI-bound tools — notably `proxy_ask` (the deep-interview panel) — silently fail to render: the user just sees raw XML.

## Fix

Streaming-safe `AnthropicXmlToolCallHealer` (mirrors the Kimi-K2 `ToolCallHealer`): strips the tool-call XML from visible text and reconstructs the embedded calls, with partial-tag holdback across chunk boundaries. Wired into both the chat-completions and Responses providers, gated by a `compat.healToolCallXml` opt-in (defaulting on for claude-family ids). The Responses path also suppresses the `output_item.done` raw-text overwrite so healed text isn't clobbered.

## Blocker fix from the #1023 review (`7fc9418d`)

The reviewer found `antml:`-namespaced tags leaked raw and synthesized zero calls when streamed **char-by-char**: the full tag regexes allowed an optional `antml:` prefix (so single-chunk healed), but the partial-tag holdback stems only listed the plain spellings, so `<inv…` never held back and leaked a char at a time. The old "tolerates the antml: namespace prefix" test was a false positive (its prefix had been stripped).

- Holdback stems (and parameter-close stems) are now generated programmatically for **both** plain and `antml:` spellings; the prefix is assembled by concatenation so the `<`+prefix adjacency is never a source literal.
- The false-positive test is replaced with real namespaced cases covering single-chunk, char-by-char (asserting not even a `<` leaks), and a mid-tag split.
- Duplicate dispatch: added `consumeWithoutCalls` (completions suppress synthesis when a chunk also carries structured `tool_calls`); the Responses provider skips a call that exactly duplicates an existing structured one.

## Tests / verification

- Exhaustive healer unit tests + provider integration tests through the real completions and Responses parsers.
- Full `packages/ai` suite: 1530 pass / 0 fail; typecheck + biome clean.
- Live `gjc -p` turn through a LiteLLM proxy (claude-family model, healer active) clean — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)