### PR TITLE
fix(coordinator-mcp): don't crash on broken stdio pipe (EPIPE)

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -2255,21 +2255,43 @@ export async function handleCoordinatorMcpRequest(
 
 export async function runCoordinatorMcpStdio(options: CoordinatorMcpServerOptions = {}): Promise<void> {
 	const server = createCoordinatorMcpServer(options);
+	// A broken stdio pipe — e.g. the parent MCP client/gateway shutting down or
+	// restarting — must not crash the server. Treat EPIPE (and a destroyed stream)
+	// as a clean shutdown signal instead of letting it surface as an uncaught
+	// exception that takes the whole process down.
+	const isBrokenPipe = (err: unknown): boolean => {
+		const code = (err as NodeJS.ErrnoException | undefined)?.code;
+		return code === "EPIPE" || code === "ERR_STREAM_DESTROYED";
+	};
+	// Defense in depth for runtimes that surface the write failure as an async
+	// 'error' event rather than a synchronous throw.
+	process.stdout.on("error", err => {
+		if (!isBrokenPipe(err)) throw err;
+	});
 	let buffer = "";
-	for await (const chunk of process.stdin) {
-		buffer += chunk.toString();
-		let newline = buffer.indexOf("\n");
-		while (newline >= 0) {
-			const line = buffer.slice(0, newline).trim();
-			buffer = buffer.slice(newline + 1);
-			if (line.length > 0) {
-				const request = JSON.parse(line) as JsonRpcRequest;
-				if (request.id !== undefined && request.id !== null) {
-					const response = await server.handleJsonRpc(request);
-					process.stdout.write(`${JSON.stringify(response)}\n`);
+	try {
+		for await (const chunk of process.stdin) {
+			buffer += chunk.toString();
+			let newline = buffer.indexOf("\n");
+			while (newline >= 0) {
+				const line = buffer.slice(0, newline).trim();
+				buffer = buffer.slice(newline + 1);
+				if (line.length > 0) {
+					const request = JSON.parse(line) as JsonRpcRequest;
+					if (request.id !== undefined && request.id !== null) {
+						const response = await server.handleJsonRpc(request);
+						try {
+							process.stdout.write(`${JSON.stringify(response)}\n`);
+						} catch (err) {
+							if (isBrokenPipe(err)) return;
+							throw err;
+						}
+					}
 				}
+				newline = buffer.indexOf("\n");
 			}
-			newline = buffer.indexOf("\n");
 		}
+	} catch (err) {
+		if (!isBrokenPipe(err)) throw err;
 	}
 }


### PR DESCRIPTION
## Problem

`runCoordinatorMcpStdio` writes JSON-RPC responses with `process.stdout.write(...)` without guarding against a closed pipe. When the parent MCP client (e.g. a gateway/host) shuts down or **restarts**, the write fails with `EPIPE`. The error is thrown synchronously (and on some runtimes surfaces as an async stream `'error'` event), and since nothing catches it, it became an **uncaught exception that crashed the entire coordinator MCP server process**:

```
Uncaught exception  EPIPE: broken pipe, write  (fd 5)
  at runCoordinatorMcpStdio (packages/coding-agent/src/coordinator-mcp/server.ts)
  at run (packages/coding-agent/src/commands/mcp-serve.ts)
```

Observed in the wild: an MCP host (Hermes) was restarted, it closed the `gjc mcp-serve coordinator` stdio pipe, and the coordinator process died with the trace above. After that the MCP server stayed down until manually restarted.

## Fix

Treat a broken pipe (`EPIPE` / `ERR_STREAM_DESTROYED`) as a clean shutdown signal rather than a fatal error:

- Wrap the `process.stdout.write` in a `try/catch`; on a broken pipe, return (the consumer is gone, there's nothing left to serve).
- Wrap the `for await` stdin read loop so a broken-pipe read also exits cleanly.
- Attach a `process.stdout.on("error", ...)` handler as defense in depth for runtimes that report the failure asynchronously.
- **Non-pipe errors still propagate unchanged**, so genuine bugs aren't swallowed.

This only changes shutdown behavior on a closed pipe; normal request/response handling is untouched.

## Verification

- `biome check` passes on the changed file.
- Behavior: closing the parent pipe now ends the loop quietly instead of throwing an uncaught `EPIPE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TikqDwu6KSybzrPLQ3HEaG