### PR TITLE
Keep long-session context recovery from stranding agent loops

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reserved headroom when trimming OpenAI remote compaction input so `/responses/compact` requests stay below the model context window instead of filling the entire window.
+
 ## [0.6.2] - 2026-06-19
 
 ### Changed

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -237,6 +237,12 @@ export function trimOpenAiCompactInput(
 	return trimmed;
 }
 
+export function resolveOpenAiCompactInputBudget(contextWindow: number, maxOutputTokens = 0): number {
+	if (contextWindow <= 0) return 0;
+	const reservedTokens = Math.max(Math.floor(contextWindow * 0.15), maxOutputTokens, 1);
+	return Math.max(1, contextWindow - reservedTokens);
+}
+
 function collectKnownOpenAiCallIds(items: Array<Record<string, unknown>>): Set<string> {
 	const knownCallIds = new Set<string>();
 	for (const item of items) {
@@ -473,7 +479,11 @@ export async function requestOpenAiRemoteCompaction(
 	const endpoint = resolveOpenAiCompactEndpoint(model, options?.authCredentialType);
 	const request: OpenAiRemoteCompactionRequest = {
 		model: model.id,
-		input: trimOpenAiCompactInput(compactInput, model.contextWindow, instructions),
+		input: trimOpenAiCompactInput(
+			compactInput,
+			resolveOpenAiCompactInputBudget(model.contextWindow, model.maxTokens),
+			instructions,
+		),
 		instructions,
 	};
 	const headers: Record<string, string> = {

--- a/packages/agent/test/compaction-estimate-cache.test.ts
+++ b/packages/agent/test/compaction-estimate-cache.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { estimateEntriesTokens, estimateEntryTokens, findCutPoint } from "@gajae-code/agent-core/compaction/compaction";
 import type { SessionEntry, SessionMessageEntry } from "@gajae-code/agent-core/compaction/entries";
-import { estimateOpenAiCompactInputTokens, trimOpenAiCompactInput } from "@gajae-code/agent-core/compaction/openai";
+import {
+	estimateOpenAiCompactInputTokens,
+	resolveOpenAiCompactInputBudget,
+	trimOpenAiCompactInput,
+} from "@gajae-code/agent-core/compaction/openai";
 import { type PruneConfig, pruneToolOutputs } from "@gajae-code/agent-core/compaction/pruning";
 import type { AssistantMessage, Message, ToolResultMessage } from "@gajae-code/ai/types";
 
@@ -344,6 +348,35 @@ describe("digest pruning notices", () => {
 });
 
 describe("OpenAI trim sizing", () => {
+	test("resolveOpenAiCompactInputBudget reserves output and clamps tiny positive windows", () => {
+		expect(resolveOpenAiCompactInputBudget(100, 0)).toBe(85);
+		expect(resolveOpenAiCompactInputBudget(100, 20)).toBe(80);
+		expect(resolveOpenAiCompactInputBudget(2, 0)).toBe(1);
+		expect(resolveOpenAiCompactInputBudget(1, 0)).toBe(1);
+		expect(resolveOpenAiCompactInputBudget(10, 20)).toBe(1);
+		expect(resolveOpenAiCompactInputBudget(0, 0)).toBe(0);
+		expect(resolveOpenAiCompactInputBudget(-5, 0)).toBe(0);
+	});
+
+	test("trimOpenAiCompactInput removes suffix items when resolved budget is below full context window", () => {
+		const instructions = "compact";
+		const contextWindow = 100;
+		const budget = resolveOpenAiCompactInputBudget(contextWindow, 20);
+		const items: Array<Record<string, unknown>> = [
+			{ type: "message", role: "user", content: [{ type: "input_text", text: "keep user message" }] },
+			{
+				type: "message",
+				role: "developer",
+				content: [{ type: "input_text", text: "remove developer message ".repeat(8) }],
+			},
+		];
+
+		expect(estimateOpenAiCompactInputTokens(items, instructions)).toBeLessThanOrEqual(contextWindow);
+		expect(estimateOpenAiCompactInputTokens(items, instructions)).toBeGreaterThan(budget);
+		expect(trimOpenAiCompactInput(items, contextWindow, instructions)).toEqual(items);
+		expect(trimOpenAiCompactInput(items, budget, instructions)).toEqual([items[0]]);
+	});
+
 	test("trimOpenAiCompactInput matches full recount across removable scenarios", () => {
 		const instructions = "compact these items";
 		const scenarios: Array<{ name: string; items: Array<Record<string, unknown>>; budget: number }> = [

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -118,6 +118,34 @@ describe("buildOpenAiNativeHistory custom tool calls", () => {
 });
 
 describe("remote compaction input trimming", () => {
+	test("trims removable items against reserved input budget when input fits full context window", async () => {
+		let requestInput: Array<Record<string, unknown>> | undefined;
+		using _hook = hookFetch(async (_input, init) => {
+			const body = JSON.parse(String(init?.body)) as { input: Array<Record<string, unknown>> };
+			requestInput = body.input;
+			return Response.json({
+				output: [{ type: "compaction_summary", summary: "compact" }],
+			});
+		});
+
+		await requestOpenAiRemoteCompaction(
+			makeOpenAiModel({ contextWindow: 100, maxTokens: 20 }),
+			"test-key",
+			[
+				{ type: "message", role: "user", content: [{ type: "input_text", text: "keep user message" }] },
+				{
+					type: "message",
+					role: "developer",
+					content: [{ type: "input_text", text: "remove developer message ".repeat(8) }],
+				},
+			],
+			"compact",
+		);
+
+		expect(requestInput?.some(item => item.type === "message" && item.role === "developer")).toBe(false);
+		expect(requestInput?.some(item => item.type === "message" && item.role === "user")).toBe(true);
+	});
+
 	test("trims custom tool outputs with their matching custom calls", async () => {
 		let requestInput: Array<Record<string, unknown>> | undefined;
 		using _hook = hookFetch(async (_input, init) => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Hardened context-overflow recovery so automatic maintenance clears the TUI loader, surfaces overflow completion/skip status, retries resumable tails safely, and falls back to the synthetic auto-continue prompt for non-resumable tails when enabled.
+
 ## [0.7.1] - 2026-06-23
 ### Fixed
 

--- a/packages/coding-agent/src/extensibility/shared-events.ts
+++ b/packages/coding-agent/src/extensibility/shared-events.ts
@@ -217,6 +217,7 @@ export interface AutoCompactionEndEvent {
 	errorMessage?: string;
 	/** True when compaction was skipped for a benign reason (no model, no candidates, nothing to compact). */
 	skipped?: boolean;
+	continuationSkipReason?: "auto_continue_disabled_non_resumable_tail";
 }
 
 /** Fired when auto-retry starts */

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -673,12 +673,18 @@ export class EventController {
 			this.ctx.statusContainer.clear();
 		}
 		const isHandoffAction = event.action === "handoff";
+		const continuationDisabled = event.continuationSkipReason === "auto_continue_disabled_non_resumable_tail";
 		if (event.aborted) {
 			this.ctx.showStatus(isHandoffAction ? "Auto-handoff cancelled" : "Auto context-full maintenance cancelled");
 		} else if (event.result) {
 			this.ctx.rebuildChatFromMessages();
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorTopBorder();
+			if (continuationDisabled && !isHandoffAction) {
+				this.ctx.showStatus("Context overflow recovery skipped: auto_continue_disabled_non_resumable_tail");
+			} else if (event.willRetry && !isHandoffAction) {
+				this.ctx.showStatus("Context overflow maintenance completed");
+			}
 		} else if (event.errorMessage) {
 			this.ctx.showWarning(event.errorMessage);
 		} else if (isHandoffAction) {
@@ -691,6 +697,11 @@ export class EventController {
 		} else if (event.skipped) {
 			// Benign skip: no model selected, no candidate models available, or nothing
 			// to compact yet. Not a failure — suppress the warning.
+			if (continuationDisabled) {
+				this.ctx.showStatus("Context overflow recovery skipped: auto_continue_disabled_non_resumable_tail");
+			} else if (event.willRetry && !isHandoffAction) {
+				this.ctx.showStatus("Context overflow maintenance skipped");
+			}
 		} else {
 			this.ctx.showWarning("Auto context-full maintenance failed; continuing without maintenance");
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -286,6 +286,8 @@ import { ToolChoiceQueue } from "./tool-choice-queue";
 import { YieldQueue } from "./yield-queue";
 
 /** Session-specific events that extend the core AgentEvent */
+export type AutoCompactionContinuationSkipReason = "auto_continue_disabled_non_resumable_tail";
+
 export type AgentSessionEvent =
 	| AgentEvent
 	| { type: "auto_compaction_start"; reason: "threshold" | "overflow" | "idle"; action: "context-full" | "handoff" }
@@ -298,6 +300,7 @@ export type AgentSessionEvent =
 			errorMessage?: string;
 			/** True when compaction was skipped for a benign reason (no model, no candidates, nothing to compact). */
 			skipped?: boolean;
+			continuationSkipReason?: AutoCompactionContinuationSkipReason;
 	  }
 	| {
 			type: "auto_retry_start";
@@ -1869,7 +1872,6 @@ export class AgentSession {
 										this.#resolveTtsrResume();
 										return;
 									}
-									this.#ttsrAbortPending = false;
 									this.#perToolTtsrInjections.clear();
 									const ttsrSettings = this.#ttsrManager?.getSettings();
 									if (ttsrSettings?.contextMode === "discard" && targetAssistantIndex !== -1) {
@@ -1898,11 +1900,22 @@ export class AgentSession {
 										);
 										this.#markTtsrInjected(details.rules);
 									}
-									try {
-										await this.agent.continue();
-									} catch {
-										this.#resolveTtsrResume();
-									}
+									await this.#scheduleAgentContinue({
+										delayMs: 0,
+										generation,
+										shouldContinue: () => {
+											this.#ttsrAbortPending = false;
+											return true;
+										},
+										onSkip: () => {
+											this.#ttsrAbortPending = false;
+											this.#resolveTtsrResume();
+										},
+										onError: () => {
+											this.#ttsrAbortPending = false;
+											this.#resolveTtsrResume();
+										},
+									});
 								},
 								{ delayMs: 50 },
 							);
@@ -2214,7 +2227,7 @@ export class AgentSession {
 	#schedulePostPromptTask(
 		task: (signal: AbortSignal) => Promise<void>,
 		options?: { delayMs?: number; generation?: number; onSkip?: () => void },
-	): void {
+	): Promise<void> {
 		const delayMs = options?.delayMs ?? 0;
 		const signal = this.#postPromptTasksAbortController.signal;
 		const scheduled = (async () => {
@@ -2236,18 +2249,20 @@ export class AgentSession {
 			await task(signal);
 		})();
 		this.#trackPostPromptTask(scheduled);
+		return scheduled;
 	}
 
 	#scheduleAgentContinue(options?: {
 		delayMs?: number;
 		generation?: number;
+		skipCompactionCheck?: boolean;
 		shouldContinue?: () => boolean;
 		onSkip?: (reason: "generation_changed" | "aborted_signal" | "queue_drained") => void;
 		onError?: (error: unknown) => void;
-	}): void {
+	}): Promise<void> {
 		const scheduledGeneration = options?.generation;
 		const signal = this.#postPromptTasksAbortController.signal;
-		this.#schedulePostPromptTask(
+		return this.#schedulePostPromptTask(
 			async () => {
 				if (signal.aborted) {
 					options?.onSkip?.("aborted_signal");
@@ -2263,6 +2278,9 @@ export class AgentSession {
 				}
 				try {
 					await this.#maybeRestoreRetryFallbackPrimary();
+					if (!options?.skipCompactionCheck) {
+						await this.#checkEstimatedContextBeforePrompt();
+					}
 					await this.agent.continue();
 				} catch (error) {
 					logger.warn("agent.continue failed after scheduling", {
@@ -2305,6 +2323,34 @@ export class AgentSession {
 		if (lastMsg?.role === "assistant" && isContextOverflow(lastMsg as AssistantMessage, contextWindow)) {
 			this.agent.replaceMessages(messages.slice(0, -1));
 		}
+	}
+
+	#detectOverflowRetryContinuationSkip(): AutoCompactionContinuationSkipReason | undefined {
+		this.#stripOverflowFailedTurnForRetry();
+		if (this.#isResumableAgentTail()) return undefined;
+		const compactionSettings = this.settings.getGroup("compaction");
+		return compactionSettings.autoContinue === false ? "auto_continue_disabled_non_resumable_tail" : undefined;
+	}
+
+	#scheduleOverflowRetryContinuation(generation: number): void {
+		this.#stripOverflowFailedTurnForRetry();
+		if (this.#isResumableAgentTail()) {
+			this.#scheduleAgentContinue({
+				delayMs: 100,
+				generation,
+				onSkip: reason => this.#logCompactionContinuationSkipped("overflow_retry", reason),
+				onError: error => this.#logCompactionContinuationError("overflow_retry", error),
+			});
+			return;
+		}
+
+		const compactionSettings = this.settings.getGroup("compaction");
+		if (compactionSettings.autoContinue !== false) {
+			this.#scheduleAutoContinuePrompt(generation);
+			return;
+		}
+
+		this.#logCompactionContinuationSkipped("overflow_retry", "auto_continue_disabled_non_resumable_tail");
 	}
 
 	#scheduleAutoContinuePrompt(generation: number): void {
@@ -3052,6 +3098,7 @@ export class AgentSession {
 				willRetry: event.willRetry,
 				errorMessage: event.errorMessage,
 				skipped: event.skipped,
+				continuationSkipReason: event.continuationSkipReason,
 			});
 		} else if (event.type === "auto_retry_start") {
 			await this.#extensionRunner.emit({
@@ -6722,6 +6769,8 @@ export class AgentSession {
 			const compactionSettings = this.settings.getGroup("compaction");
 			if (compactionSettings.enabled && compactionSettings.strategy !== "off") {
 				await this.#runAutoCompaction("overflow", true);
+			} else {
+				this.#scheduleOverflowRetryContinuation(generation);
 			}
 			return;
 		}
@@ -7730,32 +7779,18 @@ export class AgentSession {
 
 			const preparation = prepareCompaction(pathEntries, compactionSettings);
 			if (!preparation) {
+				const continuationSkipReason = willRetry ? this.#detectOverflowRetryContinuationSkip() : undefined;
 				await this.#emitSessionEvent({
 					type: "auto_compaction_end",
 					action,
 					result: undefined,
 					aborted: false,
-					willRetry: false,
+					willRetry: willRetry && !continuationSkipReason,
 					skipped: true,
+					continuationSkipReason,
 				});
 				if (willRetry) {
-					this.#stripOverflowFailedTurnForRetry();
-					if (this.#isResumableAgentTail()) {
-						this.#scheduleAgentContinue({
-							delayMs: 100,
-							generation,
-							onSkip: skipReason => this.#logCompactionContinuationSkipped("overflow_retry", skipReason),
-							onError: error => this.#logCompactionContinuationError("overflow_retry", error),
-						});
-					} else {
-						const tail = this.agent.state.messages.at(-1) as AssistantMessage | undefined;
-						logger.warn("Auto-compaction continuation skipped", {
-							source: "overflow_retry",
-							reason: "not_resumable_tail",
-							role: tail?.role,
-							stopReason: tail?.stopReason,
-						});
-					}
+					this.#scheduleOverflowRetryContinuation(generation);
 				} else if (continueAfterMaintenance && reason !== "idle" && this.agent.hasQueuedMessages()) {
 					this.#scheduleAgentContinue({
 						delayMs: 100,
@@ -7966,26 +8001,18 @@ export class AgentSession {
 				details,
 				preserveData,
 			};
-			await this.#emitSessionEvent({ type: "auto_compaction_end", action, result, aborted: false, willRetry });
+			const continuationSkipReason = willRetry ? this.#detectOverflowRetryContinuationSkip() : undefined;
+			await this.#emitSessionEvent({
+				type: "auto_compaction_end",
+				action,
+				result,
+				aborted: false,
+				willRetry: willRetry && !continuationSkipReason,
+				continuationSkipReason,
+			});
 
 			if (willRetry) {
-				this.#stripOverflowFailedTurnForRetry();
-				if (!this.#isResumableAgentTail()) {
-					const tail = this.agent.state.messages.at(-1) as AssistantMessage | undefined;
-					logger.warn("Auto-compaction continuation skipped", {
-						source: "overflow_retry",
-						reason: "not_resumable_tail",
-						role: tail?.role,
-						stopReason: tail?.stopReason,
-					});
-				} else {
-					this.#scheduleAgentContinue({
-						delayMs: 100,
-						generation,
-						onSkip: reason => this.#logCompactionContinuationSkipped("overflow_retry", reason),
-						onError: error => this.#logCompactionContinuationError("overflow_retry", error),
-					});
-				}
+				this.#scheduleOverflowRetryContinuation(generation);
 			} else if (continueAfterMaintenance && reason !== "idle" && this.agent.hasQueuedMessages()) {
 				// Auto-compaction can complete while follow-up/steering/custom messages are waiting.
 				// Kick the loop so queued messages are actually delivered.

--- a/packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts
@@ -8,10 +8,10 @@ import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { loadExtensions } from "@gajae-code/coding-agent/extensibility/extensions/loader";
 import { ExtensionRunner } from "@gajae-code/coding-agent/extensibility/extensions/runner";
-import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AgentSession, type AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
-import { getProjectAgentDir, logger, TempDir } from "@gajae-code/utils";
+import { getProjectAgentDir, logger, TempDir, withTimeout } from "@gajae-code/utils";
 
 const runtimeSignalStoreKey = "__gjcAutoContinueSignals";
 type RuntimeSignalGlobal = typeof globalThis & { [runtimeSignalStoreKey]?: string[] };
@@ -149,19 +149,25 @@ describe("AgentSession auto-compaction continuation", () => {
 		expect(promptSpy.mock.invocationCallOrder[0]).toBeGreaterThan(0);
 	});
 
-	it("overflow with non-resumable tail logs not_resumable_tail and does not continue", async () => {
+	it("overflow with non-resumable tail starts one synthetic auto-continue prompt", async () => {
 		const warnSpy = vi.spyOn(logger, "warn");
 		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
-		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue();
+		const { promise: promptCalled, resolve: onPromptCalled } = Promise.withResolvers<void>();
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockImplementation(async () => {
+			onPromptCalled();
+		});
 		const overflow = assistantMessage({
 			stopReason: "error",
 			errorMessage: "prompt is too long: 1000001 tokens > 1000000 maximum",
 		});
 		await driveCompaction(overflow);
-		await advancePostPrompt(200);
+		await withTimeout(promptCalled, 1000, "Overflow auto-continue prompt timed out");
 		await session.waitForIdle();
 		expect(continueSpy).not.toHaveBeenCalled();
-		expect(promptSpy).not.toHaveBeenCalled();
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		expect(promptSpy.mock.calls[0]?.[0]).toEqual(
+			expect.arrayContaining([expect.objectContaining({ role: "developer", attribution: "agent" })]),
+		);
 		expect(
 			warnSpy.mock.calls.some(call => String(call[0]).includes("Cannot continue from message role: assistant")),
 		).toBe(false);
@@ -170,7 +176,63 @@ describe("AgentSession auto-compaction continuation", () => {
 				call =>
 					call[0] === "Auto-compaction continuation skipped" &&
 					JSON.stringify(call[1]).includes('"source":"overflow_retry"') &&
-					JSON.stringify(call[1]).includes('"reason":"not_resumable_tail"'),
+					JSON.stringify(call[1]).includes('"reason":"auto_continue_disabled_non_resumable_tail"'),
+			),
+		).toBe(false);
+	});
+
+	it("overflow with compaction disabled skips compaction and starts one synthetic auto-continue prompt", async () => {
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+		await createSession({ "compaction.enabled": false });
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+		const { promise: promptCalled, resolve: onPromptCalled } = Promise.withResolvers<void>();
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockImplementation(async () => {
+			onPromptCalled();
+		});
+		const overflow = assistantMessage({
+			stopReason: "error",
+			errorMessage: "prompt is too long: 1000001 tokens > 1000000 maximum",
+		});
+		await driveCompaction(overflow);
+		await withTimeout(promptCalled, 1000, "Disabled-compaction overflow prompt timed out");
+		await session.waitForIdle();
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		expect(getRuntimeSignals().some(signal => signal.startsWith("compaction:start:"))).toBe(false);
+	});
+
+	it("overflow with autoContinue false and non-resumable tail logs disabled skip reason", async () => {
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+		await createSession({ "compaction.autoContinue": false });
+		const warnSpy = vi.spyOn(logger, "warn");
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue();
+		const endEvents: Extract<AgentSessionEvent, { type: "auto_compaction_end" }>[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_end") endEvents.push(event);
+		});
+		const overflow = assistantMessage({
+			stopReason: "error",
+			errorMessage: "prompt is too long: 1000001 tokens > 1000000 maximum",
+		});
+		await driveCompaction(overflow);
+		await session.waitForIdle();
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(endEvents.at(-1)).toMatchObject({
+			continuationSkipReason: "auto_continue_disabled_non_resumable_tail",
+			willRetry: false,
+		});
+		expect(
+			warnSpy.mock.calls.some(
+				call =>
+					call[0] === "Auto-compaction continuation skipped" &&
+					JSON.stringify(call[1]).includes('"source":"overflow_retry"') &&
+					JSON.stringify(call[1]).includes('"reason":"auto_continue_disabled_non_resumable_tail"'),
 			),
 		).toBe(true);
 	});

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -229,6 +229,66 @@ describe("AgentSession auto-compaction queue resume", () => {
 		expect(runtimeSignals.some(signal => signal.startsWith("compaction:end:"))).toBe(true);
 	});
 
+	it("runs pre-continue compaction before resuming queued messages", async () => {
+		vi.useRealTimers();
+		session.settings.set("compaction.thresholdTokens", 1000);
+		session.settings.set("compaction.keepRecentTokens", 1);
+		session.agent.followUp({
+			role: "custom",
+			customType: "test",
+			content: [{ type: "text", text: "Queued custom" }],
+			display: false,
+			timestamp: Date.now(),
+		});
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+		const { promise: firstCompactionDone, resolve: onFirstCompactionDone } = Promise.withResolvers<void>();
+		const { promise: secondCompactionDone, resolve: onSecondCompactionDone } = Promise.withResolvers<void>();
+		let compactionEndCount = 0;
+		session.subscribe(event => {
+			if (event.type !== "auto_compaction_end") return;
+			compactionEndCount++;
+			if (compactionEndCount === 1) onFirstCompactionDone();
+			if (compactionEndCount === 2) onSecondCompactionDone();
+		});
+		const assistantMsg: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 190000,
+				output: 1000,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 191000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await withTimeout(firstCompactionDone, 1000, "Initial queued compaction timed out");
+		const largeToolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "queued-large-read",
+			toolName: "read",
+			content: [{ type: "text", text: "x".repeat(10_000) }],
+			isError: false,
+			timestamp: Date.now(),
+		};
+		sessionManager.appendMessage(largeToolResult);
+		session.agent.appendMessage(largeToolResult);
+		await withTimeout(secondCompactionDone, 1000, "Pre-continue compaction timed out");
+		await session.waitForIdle();
+
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(getRuntimeSignals().filter(signal => signal === "compaction:start:threshold")).toHaveLength(2);
+	});
+
 	it("compacts before a new prompt when tool results push context over threshold", async () => {
 		vi.useRealTimers();
 		session.settings.set("compaction.thresholdTokens", 1000);
@@ -450,7 +510,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 		await Promise.resolve();
 
 		expect(getRuntimeSignals()).toContain("todo:1/3");
-		expect(continueSpy).toHaveBeenCalledTimes(1);
 		await session.waitForIdle();
+		expect(continueSpy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, type Mock, vi } from "bun:test";
+import { EventController } from "@gajae-code/coding-agent/modes/controllers/event-controller";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import type { AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
+
+type AutoCompactionEndEvent = Extract<AgentSessionEvent, { type: "auto_compaction_end" }>;
+
+type AutoCompactionFixture = {
+	controller: EventController;
+	ctx: InteractiveModeContext;
+	order: string[];
+	showStatus: Mock<(message: string) => void>;
+	showWarning: Mock<(message: string) => void>;
+	flushCompactionQueue: Mock<(options: { willRetry: boolean }) => Promise<void>>;
+	loaderStop: Mock<() => void>;
+	statusContainerClear: Mock<() => void>;
+	rebuildChatFromMessages: Mock<() => void>;
+};
+
+function createFixture(): AutoCompactionFixture {
+	const order: string[] = [];
+	const loaderStop = vi.fn(() => {
+		order.push("loader.stop");
+	});
+	const statusContainerClear = vi.fn(() => {
+		order.push("statusContainer.clear");
+	});
+	const showStatus = vi.fn(() => {
+		order.push("showStatus");
+	});
+	const showWarning = vi.fn(() => {
+		order.push("showWarning");
+	});
+	const flushCompactionQueue = vi.fn(async () => {
+		order.push("flushCompactionQueue");
+	});
+	const rebuildChatFromMessages = vi.fn(() => {
+		order.push("rebuildChatFromMessages");
+	});
+
+	const ctx = {
+		isInitialized: true,
+		init: vi.fn(async () => {}),
+		autoCompactionEscapeHandler: () => order.push("originalEscape"),
+		autoCompactionLoader: { stop: loaderStop },
+		editor: { onEscape: () => order.push("temporaryEscape") },
+		statusContainer: { clear: statusContainerClear },
+		statusLine: {
+			invalidate: vi.fn(() => {
+				order.push("statusLine.invalidate");
+			}),
+		},
+		updateEditorTopBorder: vi.fn(() => {
+			order.push("updateEditorTopBorder");
+		}),
+		ui: {
+			requestRender: vi.fn(() => {
+				order.push("ui.requestRender");
+			}),
+		},
+		showStatus,
+		showWarning,
+		rebuildChatFromMessages,
+		flushCompactionQueue,
+		reloadTodos: vi.fn(async () => {
+			order.push("reloadTodos");
+		}),
+	} as unknown as InteractiveModeContext;
+
+	return {
+		controller: new EventController(ctx),
+		ctx,
+		order,
+		showStatus,
+		showWarning,
+		flushCompactionQueue,
+		loaderStop,
+		statusContainerClear,
+		rebuildChatFromMessages,
+	};
+}
+
+function compactionResult(): NonNullable<AutoCompactionEndEvent["result"]> {
+	return {
+		summary: "summary",
+		firstKeptEntryId: "entry-1",
+		tokensBefore: 100,
+	};
+}
+
+async function runEndEvent(event: AutoCompactionEndEvent): Promise<AutoCompactionFixture> {
+	const fixture = createFixture();
+	await fixture.controller.handleEvent(event);
+	return fixture;
+}
+
+describe("EventController auto-compaction overflow status", () => {
+	it("clears the loader before showing overflow completion status", async () => {
+		const fixture = await runEndEvent({
+			type: "auto_compaction_end",
+			action: "context-full",
+			result: compactionResult(),
+			aborted: false,
+			willRetry: true,
+		});
+
+		expect(fixture.loaderStop).toHaveBeenCalledTimes(1);
+		expect(fixture.statusContainerClear).toHaveBeenCalledTimes(1);
+		expect(fixture.ctx.autoCompactionLoader).toBeUndefined();
+		expect(fixture.showStatus).toHaveBeenCalledWith("Context overflow maintenance completed");
+		expect(fixture.showWarning).not.toHaveBeenCalled();
+		expect(fixture.order.indexOf("loader.stop")).toBeLessThan(fixture.order.indexOf("showStatus"));
+		expect(fixture.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: true });
+	});
+
+	it("clears the loader before showing overflow skipped status", async () => {
+		const fixture = await runEndEvent({
+			type: "auto_compaction_end",
+			action: "context-full",
+			result: undefined,
+			aborted: false,
+			willRetry: true,
+			skipped: true,
+		});
+
+		expect(fixture.loaderStop).toHaveBeenCalledTimes(1);
+		expect(fixture.ctx.autoCompactionLoader).toBeUndefined();
+		expect(fixture.showStatus).toHaveBeenCalledWith("Context overflow maintenance skipped");
+		expect(fixture.showWarning).not.toHaveBeenCalled();
+		expect(fixture.order.indexOf("statusContainer.clear")).toBeLessThan(fixture.order.indexOf("showStatus"));
+		expect(fixture.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: true });
+	});
+
+	it("clears the loader before showing disabled non-resumable overflow recovery status", async () => {
+		const fixture = await runEndEvent({
+			type: "auto_compaction_end",
+			action: "context-full",
+			result: compactionResult(),
+			aborted: false,
+			willRetry: false,
+			continuationSkipReason: "auto_continue_disabled_non_resumable_tail",
+		});
+
+		expect(fixture.loaderStop).toHaveBeenCalledTimes(1);
+		expect(fixture.ctx.autoCompactionLoader).toBeUndefined();
+		expect(fixture.rebuildChatFromMessages).toHaveBeenCalledTimes(1);
+		expect(fixture.showStatus).toHaveBeenCalledWith(
+			"Context overflow recovery skipped: auto_continue_disabled_non_resumable_tail",
+		);
+		expect(fixture.showWarning).not.toHaveBeenCalled();
+		expect(fixture.order.indexOf("loader.stop")).toBeLessThan(fixture.order.indexOf("showStatus"));
+		expect(fixture.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false });
+	});
+});


### PR DESCRIPTION
## What

- Harden long-session overflow recovery so post-compaction continuations do not strand the session on non-resumable assistant tails.
- Run scheduled/direct `agent.continue()` paths through pre-continue context maintenance, with explicit skip flags for immediately-post-maintenance paths.
- Reserve input budget for OpenAI remote compaction requests instead of trimming all the way up to the model context window.
- Surface overflow maintenance completion/skip states in the TUI, including disabled non-resumable recovery.
- Add focused regression coverage and changelog entries for the touched packages.

## Why

Long sessions could enter context-full maintenance and still fail with `context_length_exceeded` or leave the UI looking stuck when the rebuilt tail could not be resumed with `Agent.continue()`. This keeps the low-level assistant-tail invariant intact while giving the session layer a deterministic fallback and clearer user-visible recovery state.

## Testing

- `bun test packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts`
- `bun test packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts`
- `bun test packages/coding-agent/test/agent-session-concurrent.test.ts -t TTSR`
- `bun test packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts`
- `bun test packages/coding-agent/test/compaction.test.ts`
- `bun test packages/agent/test/compaction-estimate-cache.test.ts packages/agent/test/remote-compaction.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun --cwd=packages/agent run check:types`
- `bun --cwd=packages/coding-agent src/cli.ts --version`
- `git diff --check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
