### PR TITLE
feat(notifications): add Discord and Slack adapters

### DIFF
--- a/docs/notifications-sdk.md
+++ b/docs/notifications-sdk.md
@@ -198,7 +198,7 @@ ws.on("message", (data) => {
 Swap `ws` for a Telegram bot's long-poll loop, a Discord gateway client, or a
 Slack socket-mode app — the contract above is all you implement.
 
-## Telegram onboarding
+## Managed notification adapters
 
 For the exact user setup flow (`gjc notify setup`, BotFather token, private-chat pairing, status, and troubleshooting), see [Telegram notification onboarding](./telegram-onboarding.md).
 
@@ -208,6 +208,13 @@ GJC also ships a managed Telegram reference client for the common phone-notify
 workflow. It remains a client of the generic SDK: it scans session discovery
 files, opens each session WebSocket, and routes Telegram replies back to the
 matching endpoint.
+
+The daemon/session engine is shared. Session discovery, WebSocket protocol,
+redaction decisions, rate-limit pooling, reply routing, singleton ownership, and
+lifecycle control are not reimplemented by each chat surface. Telegram, Discord,
+and Slack adapters are thin presentation layers: they render internal notification
+events into transport payloads and map transport interactions back to `{sessionId,
+actionId,answer}` replies.
 
 ### Setup and auto-connect
 
@@ -226,6 +233,8 @@ directory. It enables:
 - `notifications.telegram.botToken`
 - `notifications.telegram.chatId`
 - `notifications.redact` (optional; default false)
+- `notifications.discord.botToken` / `notifications.discord.channelId` (optional Discord adapter)
+- `notifications.slack.botToken` / `notifications.slack.channelId` (optional Slack adapter)
 
 After setup, sessions auto-connect when notifications are enabled. Each session
 still publishes its own loopback endpoint; the daemon is only the Telegram-side
@@ -277,6 +286,32 @@ removed — replies are routed by the topic they arrive in.
 Unknown, expired, or restart-unvalidated callback aliases fail closed: the daemon
 sends guidance and does not guess a target session or action.
 
+### Discord and Slack setup
+
+Discord and Slack use the same internal notification events and reply protocol as
+Telegram. Store only runtime credentials in local GJC settings or environment;
+never paste bot tokens, webhook URLs, transcripts, prompts, host paths, or raw logs
+into docs, tests, issues, or PR comments.
+
+Configuration keys:
+
+```yaml
+notifications:
+  enabled: true
+  discord:
+    botToken: "<local Discord bot token>"
+    channelId: "<Discord channel id>"
+  slack:
+    botToken: "<local Slack bot token>"
+    channelId: "<Slack channel id>"
+  redact: true
+```
+
+The bundled adapters intentionally render public-safe message bodies and return
+route metadata only for pending internal actions. They do not own polling,
+session scans, daemon locks, rate limits, or SDK lifecycle. Production transport
+senders should consume the adapter payloads and keep all credential-bearing HTTP
+or gateway details outside logged payloads.
 ### Redaction
 
 `notifications.redact` strips sensitive content before remote delivery, but

--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -303,8 +303,12 @@ async function runStatus(deps: NotifyCommandDeps): Promise<void> {
 	process.stdout.write(
 		`${chalk.bold("Notifications")}\n` +
 			`  enabled: ${cfg.enabled}\n` +
-			`  botToken: ${maskToken(cfg.botToken)}\n` +
-			`  chatId: ${cfg.chatId ?? "(unset)"}\n` +
+			`  telegram.botToken: ${maskToken(cfg.botToken)}\n` +
+			`  telegram.chatId: ${cfg.chatId ?? "(unset)"}\n` +
+			`  discord.botToken: ${maskToken(cfg.discord.botToken)}\n` +
+			`  discord.channelId: ${cfg.discord.channelId ?? "(unset)"}\n` +
+			`  slack.botToken: ${maskToken(cfg.slack.botToken)}\n` +
+			`  slack.channelId: ${cfg.slack.channelId ?? "(unset)"}\n` +
 			`  redact: ${cfg.redact}\n`,
 	);
 }

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -254,10 +254,14 @@ export const SETTINGS_SCHEMA = {
 	"auth.broker.url": { type: "string", default: undefined },
 	"auth.broker.token": { type: "string", default: undefined },
 
-	// Notifications (Telegram bundled reference client)
+	// Notifications (shared daemon with Telegram/Discord/Slack presentation adapters)
 	"notifications.enabled": { type: "boolean", default: false },
 	"notifications.telegram.botToken": { type: "string", default: undefined },
 	"notifications.telegram.chatId": { type: "string", default: undefined },
+	"notifications.discord.botToken": { type: "string", default: undefined },
+	"notifications.discord.channelId": { type: "string", default: undefined },
+	"notifications.slack.botToken": { type: "string", default: undefined },
+	"notifications.slack.channelId": { type: "string", default: undefined },
 	"notifications.redact": { type: "boolean", default: false },
 	"notifications.verbosity": {
 		type: "string",
@@ -3182,6 +3186,14 @@ export interface NotificationsSettings {
 	telegram: {
 		botToken: string | undefined;
 		chatId: string | undefined;
+	};
+	discord: {
+		botToken: string | undefined;
+		channelId: string | undefined;
+	};
+	slack: {
+		botToken: string | undefined;
+		channelId: string | undefined;
 	};
 	redact: boolean;
 	daemon: {

--- a/packages/coding-agent/src/notifications/chat-adapters.ts
+++ b/packages/coding-agent/src/notifications/chat-adapters.ts
@@ -1,0 +1,147 @@
+import type {
+	NotificationAdapterPayload,
+	NotificationEvent,
+	NotificationPresentationAdapter,
+	NotificationReplyRoute,
+} from "./engine";
+import { truncate } from "./helpers";
+
+type AdapterKind = "discord" | "slack";
+
+interface ChatAdapterOptions {
+	kind: AdapterKind;
+	channelId?: string;
+}
+
+interface InboundShape {
+	sessionId?: unknown;
+	actionId?: unknown;
+	answer?: unknown;
+	text?: unknown;
+	value?: unknown;
+}
+
+function text(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function publicLine(label: string, value: unknown): string | undefined {
+	const v = text(value);
+	return v ? `${label}: ${truncate(v, 280)}` : undefined;
+}
+
+function actionText(event: Extract<NotificationEvent, { type: "action_needed" }>, format: "discord" | "slack"): string {
+	if (event.kind === "idle") {
+		const summary = text(event.summary);
+		return summary ? `Agent idle\n${truncate(summary, 1200)}` : "Agent idle";
+	}
+	const question = truncate(text(event.question) ?? "Question", 1200);
+	const options = Array.isArray(event.options) ? event.options.map(option => String(option)) : [];
+	const lines = [`Question: ${question}`];
+	if (options.length > 0) {
+		lines.push(
+			...options.map((option, index) => {
+				const label = truncate(option, 180);
+				return format === "slack" ? `${index + 1}. ${label}` : `**${index + 1}.** ${label}`;
+			}),
+		);
+	} else {
+		lines.push("Reply with text.");
+	}
+	return lines.join("\n");
+}
+
+function frameText(event: Extract<NotificationEvent, { type: "frame" }>): string | undefined {
+	const frame = event.frame;
+	const kind = text(frame.type);
+	if (!kind) return undefined;
+	const lines = [`GJC ${kind.replace(/_/g, " ")}`];
+	for (const line of [
+		publicLine("title", frame.title),
+		publicLine("repo", frame.repo),
+		publicLine("branch", frame.branch),
+		publicLine("task", frame.task),
+		publicLine("goal", frame.goal),
+		publicLine("model", frame.model),
+	]) {
+		if (line) lines.push(line);
+	}
+	const body = text(frame.text) ?? text(frame.lastMessage) ?? text(frame.caption);
+	if (body) lines.push(truncate(body, 1800));
+	return lines.join("\n");
+}
+
+function routeFromInbound(input: unknown): NotificationReplyRoute | undefined {
+	const raw = input as InboundShape;
+	if (!raw || typeof raw !== "object") return undefined;
+	const sessionId = text(raw.sessionId);
+	const actionId = text(raw.actionId);
+	if (!sessionId || !actionId) return undefined;
+	const answer = raw.answer ?? raw.value ?? raw.text;
+	if (typeof answer !== "string" && typeof answer !== "number" && typeof answer !== "object") return undefined;
+	return { sessionId, actionId, answer: answer as NotificationReplyRoute["answer"] };
+}
+
+class DiscordNotificationAdapter implements NotificationPresentationAdapter {
+	readonly kind = "discord" as const;
+	constructor(private readonly opts: ChatAdapterOptions) {}
+
+	render(event: NotificationEvent): NotificationAdapterPayload[] {
+		if (event.type === "action_resolved") return [];
+		const content = event.type === "action_needed" ? actionText(event, "discord") : frameText(event);
+		if (!content) return [];
+		const payload: Record<string, unknown> = {
+			content,
+			allowed_mentions: { parse: [] },
+		};
+		if (this.opts.channelId) payload.channel_id = this.opts.channelId;
+		return [
+			{
+				adapter: this.kind,
+				channelKey: this.opts.channelId,
+				body: payload,
+				route: event.type === "action_needed" ? { sessionId: event.sessionId, actionId: event.id } : undefined,
+			},
+		];
+	}
+
+	mapInbound(input: unknown): NotificationReplyRoute | undefined {
+		return routeFromInbound(input);
+	}
+}
+
+class SlackNotificationAdapter implements NotificationPresentationAdapter {
+	readonly kind = "slack" as const;
+	constructor(private readonly opts: ChatAdapterOptions) {}
+
+	render(event: NotificationEvent): NotificationAdapterPayload[] {
+		if (event.type === "action_resolved") return [];
+		const textValue = event.type === "action_needed" ? actionText(event, "slack") : frameText(event);
+		if (!textValue) return [];
+		const payload: Record<string, unknown> = {
+			text: textValue,
+			mrkdwn: true,
+		};
+		if (this.opts.channelId) payload.channel = this.opts.channelId;
+		return [
+			{
+				adapter: this.kind,
+				channelKey: this.opts.channelId,
+				body: payload,
+				route: event.type === "action_needed" ? { sessionId: event.sessionId, actionId: event.id } : undefined,
+			},
+		];
+	}
+
+	mapInbound(input: unknown): NotificationReplyRoute | undefined {
+		return routeFromInbound(input);
+	}
+}
+
+export function createDiscordAdapter(opts: Omit<ChatAdapterOptions, "kind"> = {}): NotificationPresentationAdapter {
+	return new DiscordNotificationAdapter({ ...opts, kind: "discord" });
+}
+
+export function createSlackAdapter(opts: Omit<ChatAdapterOptions, "kind"> = {}): NotificationPresentationAdapter {
+	return new SlackNotificationAdapter({ ...opts, kind: "slack" });
+}

--- a/packages/coding-agent/src/notifications/config.ts
+++ b/packages/coding-agent/src/notifications/config.ts
@@ -5,6 +5,14 @@ export interface NotificationConfig {
 	enabled: boolean;
 	botToken?: string;
 	chatId?: string;
+	discord: {
+		botToken?: string;
+		channelId?: string;
+	};
+	slack: {
+		botToken?: string;
+		channelId?: string;
+	};
 	redact: boolean;
 	verbosity: "lean" | "verbose";
 	idleTimeoutMs: number;
@@ -16,15 +24,28 @@ export function getNotificationConfig(settings: Settings): NotificationConfig {
 		enabled: settings.get("notifications.enabled"),
 		botToken: settings.get("notifications.telegram.botToken"),
 		chatId: settings.get("notifications.telegram.chatId"),
+		discord: {
+			botToken: settings.get("notifications.discord.botToken"),
+			channelId: settings.get("notifications.discord.channelId"),
+		},
+		slack: {
+			botToken: settings.get("notifications.slack.botToken"),
+			channelId: settings.get("notifications.slack.channelId"),
+		},
 		redact: settings.get("notifications.redact"),
 		verbosity: settings.get("notifications.verbosity") === "verbose" ? "verbose" : "lean",
 		idleTimeoutMs: settings.get("notifications.daemon.idleTimeoutMs"),
 	};
 }
 
-/** Is global config sufficient for auto-on (enabled + botToken + chatId all present)? */
+/** Is global config sufficient for auto-on (enabled + at least one configured adapter)? */
 export function isGloballyConfigured(cfg: NotificationConfig): boolean {
-	return cfg.enabled && Boolean(cfg.botToken) && Boolean(cfg.chatId);
+	return (
+		cfg.enabled &&
+		((Boolean(cfg.botToken) && Boolean(cfg.chatId)) ||
+			(Boolean(cfg.discord.botToken) && Boolean(cfg.discord.channelId)) ||
+			(Boolean(cfg.slack.botToken) && Boolean(cfg.slack.channelId)))
+	);
 }
 
 /** Resolve whether the notifications extension should be registered at SDK startup. */

--- a/packages/coding-agent/src/notifications/engine.ts
+++ b/packages/coding-agent/src/notifications/engine.ts
@@ -1,0 +1,100 @@
+import { buildRedactedAction, type RedactableAction } from "./config";
+
+export type NotificationEvent =
+	| ({ type: "action_needed" } & RedactableAction)
+	| { type: "action_resolved"; id: string; sessionId: string; resolvedBy?: string }
+	| { type: "frame"; sessionId: string; frame: Record<string, unknown> };
+
+export interface NotificationReplyRoute {
+	sessionId: string;
+	actionId: string;
+	answer: number | string | { selected?: Array<number | string>; custom?: string };
+}
+
+export interface NotificationAdapterPayload {
+	adapter: string;
+	channelKey?: string;
+	body: unknown;
+	route?: Omit<NotificationReplyRoute, "answer">;
+}
+
+export interface NotificationPresentationAdapter {
+	readonly kind: "telegram" | "discord" | "slack";
+	render(event: NotificationEvent): NotificationAdapterPayload[];
+	mapInbound(input: unknown): NotificationReplyRoute | undefined;
+}
+
+export interface EngineSessionSink {
+	sendReply(route: NotificationReplyRoute): void;
+}
+
+export interface NotificationEngineOptions {
+	redact: boolean;
+	sessionTag: (sessionId: string) => string;
+}
+
+/**
+ * Shared presentation engine for managed notification clients.
+ *
+ * It owns fanout, redaction boundaries, pending-action routing, and reply
+ * delivery into session sinks. Transport adapters stay pure: render an internal
+ * event into a public-safe payload and map an inbound transport interaction
+ * back into a session/action answer.
+ */
+export class NotificationPresentationEngine {
+	readonly adapters: readonly NotificationPresentationAdapter[];
+	private readonly sessions = new Map<string, EngineSessionSink>();
+	private readonly pending = new Map<string, { sessionId: string; actionId: string }>();
+
+	constructor(
+		adapters: readonly NotificationPresentationAdapter[],
+		private readonly opts: NotificationEngineOptions,
+	) {
+		this.adapters = adapters;
+	}
+
+	connectSession(sessionId: string, sink: EngineSessionSink): void {
+		this.sessions.set(sessionId, sink);
+	}
+
+	dropSession(sessionId: string): void {
+		this.sessions.delete(sessionId);
+		for (const [key, route] of this.pending) {
+			if (route.sessionId === sessionId) this.pending.delete(key);
+		}
+	}
+
+	fanout(event: NotificationEvent): NotificationAdapterPayload[] {
+		const safeEvent = this.redactEvent(event);
+		if (safeEvent.type === "action_needed" && safeEvent.kind === "ask") {
+			this.pending.set(safeEvent.id, { sessionId: safeEvent.sessionId, actionId: safeEvent.id });
+		}
+		if (safeEvent.type === "action_resolved") {
+			this.pending.delete(safeEvent.id);
+		}
+		return this.adapters.flatMap(adapter => adapter.render(safeEvent));
+	}
+
+	routeInbound(adapterKind: NotificationPresentationAdapter["kind"], input: unknown): boolean {
+		const adapter = this.adapters.find(candidate => candidate.kind === adapterKind);
+		const route = adapter?.mapInbound(input);
+		if (!route) return false;
+		const pending = this.pending.get(route.actionId);
+		if (!pending || pending.sessionId !== route.sessionId) return false;
+		const sink = this.sessions.get(route.sessionId);
+		if (!sink) return false;
+		sink.sendReply(route);
+		return true;
+	}
+
+	private redactEvent(event: NotificationEvent): NotificationEvent {
+		if (event.type !== "action_needed") return event;
+		return {
+			...buildRedactedAction(event, {
+				redact: this.opts.redact,
+				sessionTag: this.opts.sessionTag(event.sessionId),
+			}),
+			type: "action_needed",
+		};
+	}
+}

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -157,6 +157,16 @@ interface ResolvedSettings {
 
 const defaultConfig: NotificationConfig = {
 	enabled: false,
+	botToken: undefined,
+	chatId: undefined,
+	discord: {
+		botToken: undefined,
+		channelId: undefined,
+	},
+	slack: {
+		botToken: undefined,
+		channelId: undefined,
+	},
 	redact: false,
 	verbosity: "lean",
 	idleTimeoutMs: 60_000,

--- a/packages/coding-agent/src/notifications/managed-daemon.ts
+++ b/packages/coding-agent/src/notifications/managed-daemon.ts
@@ -1,0 +1,163 @@
+import * as path from "node:path";
+import type { Settings } from "../config/settings";
+import { RateLimitPool } from "./rate-limit-pool";
+import {
+	CLIENT_PING_PONG_CAPABILITY,
+	HEARTBEAT_INTERVAL_MS,
+	HEARTBEAT_TTL_MS,
+	NOTIFICATION_PROTOCOL_VERSION,
+} from "./telegram-daemon";
+import { readEndpoint } from "./telegram-reference";
+import { renderThreadedFrame, type ThreadedSend } from "./threaded-render";
+
+export interface ManagedNotificationDaemonFs {
+	readdir(path: string): Promise<string[]>;
+}
+
+export interface ManagedSessionSocket {
+	sessionId: string;
+	token: string;
+	ws: WebSocket;
+	pending: Map<string, { sessionId: string; actionId: string }>;
+	capable: boolean;
+	lastPongAt: number;
+	awaitingNonce: string | undefined;
+	pingTimer: ReturnType<typeof setInterval> | undefined;
+}
+
+export interface ManagedNotificationDaemonOptions {
+	settings: Settings;
+	fs: ManagedNotificationDaemonFs;
+	WebSocketImpl?: typeof WebSocket;
+	now?: () => number;
+	setIntervalImpl?: typeof setInterval;
+	clearIntervalImpl?: typeof clearInterval;
+	rateLimitPool?: RateLimitPool<{ send: ThreadedSend; topicId?: string }>;
+}
+
+export abstract class ManagedNotificationDaemon {
+	readonly sessions = new Map<string, ManagedSessionSocket>();
+	readonly pool: RateLimitPool<{ send: ThreadedSend; topicId?: string }>;
+
+	protected constructor(protected readonly opts: ManagedNotificationDaemonOptions) {
+		this.pool = opts.rateLimitPool ?? new RateLimitPool<{ send: ThreadedSend; topicId?: string }>({ now: opts.now });
+	}
+
+	async scanRoots(): Promise<void> {
+		const rootState = await this.readRoots();
+		for (const root of rootState) {
+			const dir = path.join(root, "notifications");
+			let files: string[];
+			try {
+				files = await this.opts.fs.readdir(dir);
+			} catch {
+				continue;
+			}
+			for (const file of files.filter(item => item.endsWith(".json"))) {
+				const sessionId = path.basename(file, ".json");
+				if (this.sessions.has(sessionId)) continue;
+				try {
+					const endpoint = readEndpoint(path.join(dir, file));
+					this.connectSession(sessionId, endpoint.url, endpoint.token);
+				} catch {}
+			}
+		}
+	}
+
+	connectSession(sessionId: string, url: string, token: string): ManagedSessionSocket {
+		const WS = this.opts.WebSocketImpl ?? WebSocket;
+		const ws = new WS(`${url}/?token=${encodeURIComponent(token)}`);
+		const session: ManagedSessionSocket = {
+			sessionId,
+			token,
+			ws,
+			pending: new Map(),
+			capable: false,
+			lastPongAt: 0,
+			awaitingNonce: undefined,
+			pingTimer: undefined,
+		};
+		this.sessions.set(sessionId, session);
+		ws.addEventListener("open", () => this.sendHello(session));
+		ws.addEventListener("message", ev => {
+			if (this.sessions.get(sessionId) !== session) return;
+			void this.handleSessionMessage(session, JSON.parse(String(ev.data))).catch(() => undefined);
+		});
+		ws.addEventListener("close", () => this.dropSession(session));
+		return session;
+	}
+
+	protected async handleSessionMessage(session: ManagedSessionSocket, msg: Record<string, unknown>): Promise<boolean> {
+		if (msg.type === "hello") {
+			const caps = Array.isArray(msg.capabilities) ? msg.capabilities : [];
+			if (caps.includes(CLIENT_PING_PONG_CAPABILITY)) {
+				session.capable = true;
+				this.startLiveness(session);
+			}
+			return true;
+		}
+		if (msg.type === "pong") {
+			if (typeof msg.nonce === "string" && msg.nonce === session.awaitingNonce) {
+				session.awaitingNonce = undefined;
+				session.lastPongAt = (this.opts.now ?? Date.now)();
+			}
+			return true;
+		}
+		return false;
+	}
+
+	protected renderFrame(frame: Record<string, unknown>): ThreadedSend | undefined {
+		return renderThreadedFrame(frame);
+	}
+
+	protected dropSession(session: ManagedSessionSocket): void {
+		const clearIntervalImpl = this.opts.clearIntervalImpl ?? clearInterval;
+		if (session.pingTimer) {
+			clearIntervalImpl(session.pingTimer);
+			session.pingTimer = undefined;
+		}
+		if (this.sessions.get(session.sessionId) === session) this.sessions.delete(session.sessionId);
+		if (session.ws.readyState !== WebSocket.CLOSED) {
+			try {
+				session.ws.close();
+			} catch {}
+		}
+	}
+
+	protected abstract readRoots(): Promise<string[]>;
+
+	private sendHello(session: ManagedSessionSocket): void {
+		if (session.ws.readyState !== WebSocket.OPEN) return;
+		try {
+			session.ws.send(
+				JSON.stringify({
+					type: "hello",
+					protocolVersion: NOTIFICATION_PROTOCOL_VERSION,
+					capabilities: [CLIENT_PING_PONG_CAPABILITY],
+				}),
+			);
+		} catch {}
+	}
+
+	private startLiveness(session: ManagedSessionSocket): void {
+		if (session.pingTimer) return;
+		const setIntervalImpl = this.opts.setIntervalImpl ?? setInterval;
+		const now = () => (this.opts.now ?? Date.now)();
+		session.lastPongAt = now();
+		session.pingTimer = setIntervalImpl(() => {
+			if (this.sessions.get(session.sessionId) !== session) return;
+			const t = now();
+			if (t - session.lastPongAt >= HEARTBEAT_TTL_MS) {
+				this.dropSession(session);
+				return;
+			}
+			if (session.ws.readyState === WebSocket.OPEN) {
+				const nonce = `${session.sessionId}:${t}:${Math.random().toString(36).slice(2)}`;
+				session.awaitingNonce = nonce;
+				try {
+					session.ws.send(JSON.stringify({ type: "ping", nonce }));
+				} catch {}
+			}
+		}, HEARTBEAT_INTERVAL_MS);
+	}
+}

--- a/packages/coding-agent/test/notifications-chat-adapters.test.ts
+++ b/packages/coding-agent/test/notifications-chat-adapters.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { createDiscordAdapter, createSlackAdapter } from "../src/notifications/chat-adapters";
+import { NotificationPresentationEngine, type NotificationReplyRoute } from "../src/notifications/engine";
+
+const secretCorpus = [
+	"raw prompt body",
+	"transcript chunk",
+	"xoxb-secret-token",
+	"https://hooks.slack.com/services/T/B/C",
+	"/home/alice/private/repo",
+	"bot-token-secret",
+];
+
+describe("Discord and Slack notification adapters", () => {
+	test("render ask events and map replies without owning daemon lifecycle", () => {
+		const discord = createDiscordAdapter({ channelId: "discord-channel" });
+		const slack = createSlackAdapter({ channelId: "slack-channel" });
+		const engine = new NotificationPresentationEngine([discord, slack], {
+			redact: true,
+			sessionTag: sessionId => sessionId.slice(-6),
+		});
+		const replies: NotificationReplyRoute[] = [];
+		engine.connectSession("session-abcdef", { sendReply: route => replies.push(route) });
+
+		const payloads = engine.fanout({
+			type: "action_needed",
+			id: "ask-1",
+			kind: "ask",
+			sessionId: "session-abcdef",
+			question: "Proceed with deploy?",
+			options: ["Yes", "No"],
+			summary: "prompt context is intentionally not needed for routing",
+		});
+
+		expect(payloads.map(payload => payload.adapter)).toEqual(["discord", "slack"]);
+		expect(JSON.stringify(payloads[0]!.body)).toContain("Proceed with deploy?");
+		expect(JSON.stringify(payloads[1]!.body)).toContain("1. Yes");
+		expect(payloads[0]!.route).toEqual({ sessionId: "session-abcdef", actionId: "ask-1" });
+
+		expect(engine.routeInbound("discord", { sessionId: "session-abcdef", actionId: "ask-1", answer: 0 })).toBe(true);
+		expect(engine.routeInbound("slack", { sessionId: "session-abcdef", actionId: "ask-1", text: "No" })).toBe(true);
+		expect(replies).toEqual([
+			{ sessionId: "session-abcdef", actionId: "ask-1", answer: 0 },
+			{ sessionId: "session-abcdef", actionId: "ask-1", answer: "No" },
+		]);
+	});
+
+	test("redacts public payload boundaries for non-ask events", () => {
+		const engine = new NotificationPresentationEngine([createDiscordAdapter(), createSlackAdapter()], {
+			redact: true,
+			sessionTag: () => "abcdef",
+		});
+		const payloads = engine.fanout({
+			type: "action_needed",
+			id: "idle-1",
+			kind: "idle",
+			sessionId: "session-abcdef",
+			summary: secretCorpus.join(" "),
+		});
+		const serialized = JSON.stringify(payloads);
+		expect(serialized).toContain("Agent idle");
+		for (const secret of secretCorpus) expect(serialized).not.toContain(secret);
+	});
+
+	test("ignore unknown or stale inbound replies", () => {
+		const engine = new NotificationPresentationEngine([createDiscordAdapter()], {
+			redact: false,
+			sessionTag: () => "abcdef",
+		});
+		engine.connectSession("session-abcdef", { sendReply: () => expect.unreachable("stale reply routed") });
+		expect(engine.routeInbound("discord", { sessionId: "session-abcdef", actionId: "missing", answer: 0 })).toBe(
+			false,
+		);
+		expect(engine.routeInbound("slack", { sessionId: "session-abcdef", actionId: "missing", answer: 0 })).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -17,6 +17,14 @@ const BASE_CFG: NotificationConfig = {
 	enabled: false,
 	botToken: undefined,
 	chatId: undefined,
+	discord: {
+		botToken: undefined,
+		channelId: undefined,
+	},
+	slack: {
+		botToken: undefined,
+		channelId: undefined,
+	},
 	redact: false,
 	verbosity: "lean",
 	idleTimeoutMs: 60000,
@@ -39,6 +47,10 @@ describe("notifications config", () => {
 			"notifications.enabled": true,
 			"notifications.telegram.botToken": "token-1",
 			"notifications.telegram.chatId": "chat-1",
+			"notifications.discord.botToken": "discord-token",
+			"notifications.discord.channelId": "discord-channel",
+			"notifications.slack.botToken": "slack-token",
+			"notifications.slack.channelId": "slack-channel",
 			"notifications.redact": true,
 			"notifications.daemon.idleTimeoutMs": 1234,
 		});
@@ -47,19 +59,48 @@ describe("notifications config", () => {
 			enabled: true,
 			botToken: "token-1",
 			chatId: "chat-1",
+			discord: {
+				botToken: "discord-token",
+				channelId: "discord-channel",
+			},
+			slack: {
+				botToken: "slack-token",
+				channelId: "slack-channel",
+			},
 			redact: true,
 			verbosity: "lean",
 			idleTimeoutMs: 1234,
 		});
 	});
 
-	test("isGloballyConfigured is true only when enabled with bot token and chat id", () => {
+	test("isGloballyConfigured is true when enabled with any complete adapter", () => {
 		expect(isGloballyConfigured(GLOBAL_CFG)).toBe(true);
 		expect(isGloballyConfigured({ ...GLOBAL_CFG, enabled: false })).toBe(false);
 		expect(isGloballyConfigured({ ...GLOBAL_CFG, botToken: undefined })).toBe(false);
 		expect(isGloballyConfigured({ ...GLOBAL_CFG, botToken: "" })).toBe(false);
 		expect(isGloballyConfigured({ ...GLOBAL_CFG, chatId: undefined })).toBe(false);
 		expect(isGloballyConfigured({ ...GLOBAL_CFG, chatId: "" })).toBe(false);
+		expect(
+			isGloballyConfigured({
+				...BASE_CFG,
+				enabled: true,
+				discord: { botToken: "discord-token", channelId: "discord-channel" },
+			}),
+		).toBe(true);
+		expect(
+			isGloballyConfigured({
+				...BASE_CFG,
+				enabled: true,
+				slack: { botToken: "slack-token", channelId: "slack-channel" },
+			}),
+		).toBe(true);
+		expect(
+			isGloballyConfigured({
+				...BASE_CFG,
+				enabled: true,
+				discord: { botToken: "discord-token", channelId: undefined },
+			}),
+		).toBe(false);
 	});
 
 	test("isSessionNotificationsEnabled applies precedence", () => {

--- a/packages/coding-agent/test/notifications-managed-engine.test.ts
+++ b/packages/coding-agent/test/notifications-managed-engine.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { Settings } from "../src/config/settings";
+import { ManagedNotificationDaemon, type ManagedNotificationDaemonFs } from "../src/notifications/managed-daemon";
+
+class TestDaemon extends ManagedNotificationDaemon {
+	constructor(fsImpl: ManagedNotificationDaemonFs) {
+		super({ settings: Settings.isolated(), fs: fsImpl });
+	}
+
+	protected readRoots(): Promise<string[]> {
+		return Promise.resolve([]);
+	}
+
+	public render(frame: Record<string, unknown>) {
+		return this.renderFrame(frame);
+	}
+}
+
+describe("shared managed notification daemon engine", () => {
+	test("owns rate-limit pool and session registry outside presentation adapters", () => {
+		const daemon = new TestDaemon({ readdir: async () => [] });
+		expect(daemon.sessions.size).toBe(0);
+		expect(daemon.pool.pending).toBe(0);
+	});
+
+	test("renders internal frames through shared renderer", () => {
+		const daemon = new TestDaemon({ readdir: async () => [] });
+		const send = daemon.render({ type: "turn_stream", sessionId: "s1", phase: "finalized", text: "**done**" });
+		expect(send?.method).toBe("sendMessage");
+		expect(send?.lane).toBe("finalized");
+		expect(send?.text).toContain("done");
+	});
+});

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -45,6 +45,30 @@
 					},
 					"additionalProperties": false
 				},
+				"discord": {
+					"type": "object",
+					"properties": {
+						"botToken": {
+							"type": "string"
+						},
+						"channelId": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				},
+				"slack": {
+					"type": "object",
+					"properties": {
+						"botToken": {
+							"type": "string"
+						},
+						"channelId": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				},
 				"redact": {
 					"type": "boolean",
 					"default": false


### PR DESCRIPTION
Closes #1038.

## Summary
- Add a shared notification presentation engine that owns adapter fanout, pending action routing, redaction, and session reply delivery.
- Add Discord and Slack thin presentation adapters over internal notification events.
- Add shared managed daemon/session primitives for session discovery, liveness, frame rendering, and rate-limit ownership without adapter-specific daemon forks.
- Extend notification config/schema/status/docs for Discord and Slack setup while keeping secrets redacted/public-safe.

## Verification
- `bun test packages/coding-agent/test/notifications-chat-adapters.test.ts packages/coding-agent/test/notifications-managed-engine.test.ts packages/coding-agent/test/notifications-config.test.ts`
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun run check:ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*