### PR TITLE
test(coding-agent): repair dev CI shard

### DIFF
--- a/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { modeStatePath, sessionStateDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
@@ -32,6 +32,14 @@ function receiptFrom(stdout: string | undefined): Record<string, unknown> {
 	const parsed = JSON.parse(stdout ?? "{}") as Record<string, unknown>;
 	expect(parsed.state).toBeUndefined();
 	return parsed;
+}
+function captureStderrWrites(): { writes: string[]; restore: () => void } {
+	const writes: string[] = [];
+	const spy = spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+		writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+		return true;
+	});
+	return { writes, restore: () => spy.mockRestore() };
 }
 
 async function writeState(root: string, mode: string, state: Record<string, unknown>, extra: string[] = []) {
@@ -166,11 +174,16 @@ describe("gjc state write hardening", () => {
 	it("corrupt existing state fails open for read and status but write and clear require force", async () => {
 		const root = await tempDir();
 		await writeRawState(root, "ralplan", "{broken json");
-
-		const read = await runNativeStateCommand(["read", "--mode", "ralplan", "--json"], root);
-		expect(read.status).toBe(0);
-		const status = await runNativeStateCommand(["status", "--mode", "ralplan", "--json"], root);
-		expect(status.status).toBe(0);
+		const stderr = captureStderrWrites();
+		try {
+			const read = await runNativeStateCommand(["read", "--mode", "ralplan", "--json"], root);
+			expect(read.status).toBe(0);
+			const status = await runNativeStateCommand(["status", "--mode", "ralplan", "--json"], root);
+			expect(status.status).toBe(0);
+			expect(stderr.writes.join("")).toContain("ignoring corrupt state");
+		} finally {
+			stderr.restore();
+		}
 
 		const rejectedWrite = await writeState(root, "ralplan", { current_phase: "planner" });
 		expect(rejectedWrite.status).not.toBe(0);

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { deflateSync } from "node:zlib";
@@ -25,6 +25,7 @@ import {
 	resolveGitBase,
 	runNativeUltragoalCommand,
 	startNextUltragoalGoal,
+	type UltragoalCommandResult,
 	validateExecutorQaRedTeamEvidenceForReview,
 	waitForReplayProcessWithTimeout,
 } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-runtime";
@@ -51,6 +52,15 @@ afterEach(async () => {
 	else process.env.GJC_SESSION_ID = savedSessionId;
 	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
+
+function captureStderrWrites(): { writes: string[]; restore: () => void } {
+	const writes: string[] = [];
+	const spy = spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+		writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+		return true;
+	});
+	return { writes, restore: () => spy.mockRestore() };
+}
 
 function passingQualityGate(): string {
 	return JSON.stringify({
@@ -3147,11 +3157,18 @@ describe("ultragoal mode-state + HUD reconciliation (#342)", () => {
 			await fs.mkdir(p, { recursive: true });
 
 			const beforeGoals = await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text();
-			const result = await runNativeUltragoalCommand(["status", "--json"], root);
+			const stderr = captureStderrWrites();
+			let result: UltragoalCommandResult | undefined;
+			try {
+				result = await runNativeUltragoalCommand(["status", "--json"], root);
+				expect(stderr.writes.join("")).toContain("ultragoal state reconciliation failed");
+			} finally {
+				stderr.restore();
+			}
 
 			// The triggering command still succeeds with an intact receipt.
-			expect(result.status).toBe(0);
-			expect(() => JSON.parse(result.stdout ?? "")).not.toThrow();
+			expect(result?.status).toBe(0);
+			expect(() => JSON.parse(result?.stdout ?? "")).not.toThrow();
 
 			// The plan is untouched and the failure is recorded in the audit trail.
 			expect(await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text()).toBe(
@@ -3189,10 +3206,17 @@ describe("ultragoal mode-state + HUD reconciliation (#342)", () => {
 			await fs.mkdir(activePath, { recursive: true });
 
 			const beforeGoals = await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text();
-			const result = await runNativeUltragoalCommand(["status", "--json"], root);
+			const stderr = captureStderrWrites();
+			let result: UltragoalCommandResult | undefined;
+			try {
+				result = await runNativeUltragoalCommand(["status", "--json"], root);
+				expect(stderr.writes.join("")).toContain("ultragoal state reconciliation failed");
+			} finally {
+				stderr.restore();
+			}
 
 			// Command still succeeds; the HUD-sync failure is diagnosable via the audit trail.
-			expect(result.status).toBe(0);
+			expect(result?.status).toBe(0);
 			expect(await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text()).toBe(
 				beforeGoals,
 			);

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -234,7 +234,6 @@ describe("resolveProviderChain — active-model-gated resolution", () => {
 		expect(await chainIds(fakeAuth({ oauth: ["openai-codex"] }), "auto", "openai")).toEqual(["codex", "duckduckgo"]);
 		expect(await chainIds(fakeAuth({ oauth: ["openai-codex"] }), "auto", "openai-codex")).toEqual([
 			"codex",
-			"openai-compatible",
 			"duckduckgo",
 		]);
 		expect(await chainIds(fakeAuth({ oauth: ["google-gemini-cli"] }), "auto", "google-gemini-cli")).toEqual([


### PR DESCRIPTION
## Summary
- Contain expected corrupt-state and ultragoal reconcile diagnostics inside the tests that intentionally trigger them.
- Update the active-model web-search provider-chain expectation for openai-codex so it matches the current single Codex native provider path plus DuckDuckGo fallback.

## Evidence
- `bun test packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts --timeout 20000` — 174 pass, 0 fail.
- `bun test packages/coding-agent/test/tools/web-search-duckduckgo.test.ts --timeout 20000` — 22 pass, 1 skip, 0 fail.
- `bun test packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts packages/coding-agent/test/tools/web-search-duckduckgo.test.ts --timeout 20000` — 196 pass, 1 skip, 0 fail.
- `GITHUB_EVENT_BEFORE=13e545cd2e6d34f7ef7887fd5421a1dea7780484 AFFECTED_TASK_KEY='test:@gajae-code/coding-agent' bun scripts/ci-dev-affected.ts --task='test:@gajae-code/coding-agent'` — 6927 pass, 359 skip, 0 fail.
- `bun run check:ts` — passed; only existing Biome deprecated-config infos.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*