### PR TITLE
Fix tmux attach disconnect survival

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -352,6 +352,11 @@ function readCurrentBranch(cwd: string): string | null {
 function cleanupCreatedTmuxSession(plan: TmuxLaunchPlan, spawnSync: TmuxSpawnSync, options: TmuxSpawnOptions): void {
 	spawnSync(plan.tmuxCommand, ["kill-session", "-t", `=${plan.sessionName}`], options);
 }
+function isTmuxAttachDisconnectError(result: TmuxSpawnResult): boolean {
+	if (result.signalCode === "SIGHUP") return true;
+	const stderr = result.stderr?.toLowerCase() ?? "";
+	return stderr.includes("eio") || stderr.includes("input/output error");
+}
 
 export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaunchPlan | undefined {
 	const env = context.env ?? process.env;
@@ -478,6 +483,10 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 	if (created.exitCode !== 0) return false;
 	const attached = spawnSync(plan.tmuxCommand, ["attach-session", "-t", `=${plan.sessionName}`], options);
 	if (attached.exitCode === 0) return true;
+	if (isTmuxAttachDisconnectError(attached)) {
+		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("attach disconnected", attached.stderr));
+		return true;
+	}
 	cleanupCreatedTmuxSession(plan, spawnSync, options);
 	(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("attach failed", attached.stderr));
 	return true;

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn, vi } from "bun:test";
 import { Buffer } from "node:buffer";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Args } from "@gajae-code/coding-agent/cli/args";
 import {
@@ -842,12 +843,100 @@ describe("default GJC tmux launch", () => {
 		expect(diagnostics[0].length).toBeLessThan(320);
 	});
 
-	it("does not throw when the default tmux diagnostic write hits a closed stderr", () => {
-		const writes: string[] = [];
-		process.stderr.write = ((chunk: string | Uint8Array) => {
-			writes.push(String(chunk));
+	it("preserves a newly created managed session when attach reports SSH disconnect EIO", () => {
+		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
+		const diagnostics: string[] = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ tmux: true }),
+			rawArgs: [],
+			cwd: "/repo",
+			env: {},
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
+			diagnosticWriter: message => diagnostics.push(message),
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				if (spawnArgs[0] === "attach-session")
+					return { exitCode: 1, stderr: "write /dev/tty: input/output error (EIO)" };
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
+		expect(calls.some(call => call.args[0] === "attach-session")).toBe(true);
+		expect(calls.some(call => call.args[0] === "kill-session")).toBe(false);
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach disconnected.");
+	});
+
+	it("does not throw when reporting attach disconnect EIO to closed stderr", () => {
+		const writeSpy = spyOn(fs, "writeSync").mockImplementation(() => {
 			throw stderrError("EIO");
-		}) satisfies typeof process.stderr.write;
+		});
+
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ tmux: true }),
+			rawArgs: [],
+			cwd: "/repo",
+			env: {},
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
+			spawnSync: (_command, spawnArgs) => {
+				if (spawnArgs[0] === "attach-session") return { exitCode: 1, stderr: "attach failed: EIO" };
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(writeSpy).toHaveBeenCalledWith(process.stderr.fd, expect.stringContaining("attach disconnected"));
+	});
+
+	it("preserves a newly created managed session when attach receives SIGHUP", () => {
+		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
+		const diagnostics: string[] = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ tmux: true }),
+			rawArgs: [],
+			cwd: "/repo",
+			env: {},
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
+			diagnosticWriter: message => diagnostics.push(message),
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				if (spawnArgs[0] === "attach-session") return { exitCode: null, signalCode: "SIGHUP" };
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
+		expect(calls.some(call => call.args[0] === "attach-session")).toBe(true);
+		expect(calls.some(call => call.args[0] === "kill-session")).toBe(false);
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach disconnected.");
+	});
+
+	it("does not throw when the default tmux diagnostic write hits a closed stderr", () => {
+		const writeSpy = spyOn(fs, "writeSync").mockImplementation(() => {
+			throw stderrError("EIO");
+		});
 
 		const handled = launchDefaultTmuxIfNeeded({
 			parsed: args({ tmux: true }),
@@ -868,8 +957,7 @@ describe("default GJC tmux launch", () => {
 		});
 
 		expect(handled).toBe(true);
-		expect(writes).toHaveLength(1);
-		expect(writes[0]).toStartWith("gjc --tmux failed after creating tmux session: attach failed.");
+		expect(writeSpy).toHaveBeenCalledWith(process.stderr.fd, expect.stringContaining("attach failed"));
 	});
 
 	it("falls through to direct launch when tmux is unavailable", () => {

--- a/packages/utils/src/safe-stderr.ts
+++ b/packages/utils/src/safe-stderr.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs";
+
 const CLOSED_STDERR_ERROR_CODES = new Set(["EIO", "EPIPE", "EBADF"]);
 
 function isClosedStderrWriteError(error: unknown): boolean {
@@ -6,8 +8,9 @@ function isClosedStderrWriteError(error: unknown): boolean {
 }
 
 export function safeStderrWrite(message: string): void {
+	if (!process.stderr.writable) return;
 	try {
-		process.stderr.write(message);
+		fs.writeSync(process.stderr.fd, message);
 	} catch (error) {
 		if (isClosedStderrWriteError(error)) return;
 		throw error;

--- a/packages/utils/test/safe-stderr.test.ts
+++ b/packages/utils/test/safe-stderr.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import * as fs from "node:fs";
 import { safeStderrWrite } from "../src/safe-stderr";
 
 const originalStderrWrite = process.stderr.write.bind(process.stderr);
@@ -12,25 +13,48 @@ function stderrError(code: string): Error {
 describe("safeStderrWrite", () => {
 	afterEach(() => {
 		process.stderr.write = originalStderrWrite;
+		vi.restoreAllMocks();
 	});
 
-	it("swallows closed stderr write errors during shutdown diagnostics", () => {
-		const calls: string[] = [];
-		process.stderr.write = ((chunk: string | Uint8Array) => {
-			calls.push(String(chunk));
-			throw stderrError("EIO");
-		}) satisfies typeof process.stderr.write;
+	it("writes diagnostics through stderr fd", () => {
+		const writeSpy = spyOn(fs, "writeSync").mockImplementation((_fd, buffer) => {
+			return String(buffer).length;
+		});
 
 		safeStderrWrite("fatal diagnostic\n");
 
-		expect(calls).toEqual(["fatal diagnostic\n"]);
+		expect(writeSpy).toHaveBeenCalledWith(process.stderr.fd, "fatal diagnostic\n");
+	});
+
+	it("swallows closed stderr write errors during shutdown diagnostics", () => {
+		const writeSpy = spyOn(fs, "writeSync").mockImplementation(() => {
+			throw stderrError("EIO");
+		});
+
+		safeStderrWrite("fatal diagnostic\n");
+
+		expect(writeSpy).toHaveBeenCalledWith(process.stderr.fd, "fatal diagnostic\n");
 	});
 
 	it("rethrows unexpected stderr write errors", () => {
-		process.stderr.write = (() => {
+		spyOn(fs, "writeSync").mockImplementation(() => {
 			throw new RangeError("unexpected stderr failure");
-		}) satisfies typeof process.stderr.write;
+		});
 
 		expect(() => safeStderrWrite("fatal diagnostic\n")).toThrow(RangeError);
+	});
+
+	it("does not touch a non-writable stderr stream", () => {
+		const writeSpy = spyOn(fs, "writeSync");
+		const stderr = process.stderr as typeof process.stderr & { writable: boolean };
+		const originalWritable = stderr.writable;
+		Object.defineProperty(stderr, "writable", { configurable: true, value: false });
+		try {
+			safeStderrWrite("fatal diagnostic\n");
+		} finally {
+			Object.defineProperty(stderr, "writable", { configurable: true, value: originalWritable });
+		}
+
+		expect(writeSpy).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary
- Preserve newly-created managed `gjc --tmux` sessions when `tmux attach-session` exits from disconnect-like failures (`SIGHUP`, `EIO`, or input/output errors) instead of killing them as failed launches.
- Keep fail-safe cleanup for ordinary unexpected attach failures, so sessions created by a truly failed attach are still removed.
- Harden `safeStderrWrite` to write directly through the stderr file descriptor and swallow closed-stderr `EIO`/`EPIPE`/`EBADF`, preventing dead-PTY diagnostics from surfacing as uncaught async stream errors under Bun.

Closes #1045.

## Evidence
- `git fetch origin dev && git rebase --autostash origin/dev`
- `bun install` (to restore workspace dependencies)
- `bun --cwd=packages/natives run build` (to restore local native addon required by tests)
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/utils/test/safe-stderr.test.ts` -> 43 pass, 0 fail, 156 expect() calls
- `bun --cwd=packages/coding-agent run check && bun --cwd=packages/utils run check` -> passed; Biome reported only an existing deprecation info in `src/defaults/gjc/extensions/grok-cli-vendor/biome.json`
