### PR TITLE
fix(compaction): default summary reasoning to Effort.Low and make it configurable

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Compaction summary calls (`generateSummary`, `generateShortSummary`, `generateTurnPrefixSummary`) now default to `Effort.Low` thinking instead of a hardcoded `Effort.High`, and accept a `reasoning?: Effort` override via `SummaryOptions`. Compaction summarization is a mechanical text-summarization task over a large serialized-conversation input; forcing maximum extended-thinking effort inflated latency, token cost, and the request's server-side failure surface (auto-compaction one-shots intermittently failing with `overloaded_error`/`Internal server error`) with no summary-quality benefit. Embedders can pass `reasoning: Effort.High` to restore the previous behavior. Handoff generation is unchanged.
+
 ## [0.6.2] - 2026-06-19
 
 ### Changed

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -677,6 +677,15 @@ export interface SummaryOptions {
 	providerSessionState?: Map<string, ProviderSessionState>;
 	/** Hint that websocket transport should be preferred when supported by the provider implementation. */
 	preferWebsockets?: boolean;
+	/**
+	 * Reasoning/thinking effort for the summarization call. Compaction summaries
+	 * are a mechanical text-summarization task over a large serialized-conversation
+	 * input, so they default to {@link Effort.Low} rather than the model's normal
+	 * turn effort: forcing high extended-thinking effort inflates latency/cost and
+	 * the request's failure surface with no summary-quality benefit. Embedders may
+	 * override (e.g. {@link Effort.High}) when they want richer summaries.
+	 */
+	reasoning?: Effort;
 }
 
 export async function generateSummary(
@@ -740,7 +749,7 @@ export async function generateSummary(
 			maxTokens,
 			signal,
 			apiKey,
-			reasoning: Effort.High,
+			reasoning: options?.reasoning ?? Effort.Low,
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
 			sessionId: options?.sessionId,
@@ -890,7 +899,7 @@ async function generateShortSummary(
 			maxTokens,
 			signal,
 			apiKey,
-			reasoning: Effort.High,
+			reasoning: options?.reasoning ?? Effort.Low,
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
 			sessionId: options?.sessionId,
@@ -1252,7 +1261,7 @@ async function generateTurnPrefixSummary(
 			maxTokens,
 			signal,
 			apiKey,
-			reasoning: Effort.High,
+			reasoning: options?.reasoning ?? Effort.Low,
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
 			sessionId: options?.sessionId,

--- a/packages/agent/test/compaction-transport.test.ts
+++ b/packages/agent/test/compaction-transport.test.ts
@@ -21,6 +21,7 @@ import {
 import type { AgentMessage } from "@gajae-code/agent-core/types";
 import type { AssistantMessage, Model, ProviderSessionState, SimpleStreamOptions, Usage } from "@gajae-code/ai";
 import * as ai from "@gajae-code/ai";
+import { Effort } from "@gajae-code/ai";
 
 const MODEL: Model = {
 	id: "mock-model",
@@ -269,5 +270,32 @@ describe("split-turn compaction sequencing (#736)", () => {
 		await compact(splitPreparation(), MODEL, "k", undefined, undefined, {});
 
 		expect(tracker.peak()).toBe(2);
+	});
+});
+
+describe("compaction summary reasoning effort", () => {
+	it("defaults summarization to Effort.Low", async () => {
+		const captured = spyCompleteSimple();
+		await generateSummary([makeUserMessage("Hi")], MODEL, 4096, "k");
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.reasoning).toBe(Effort.Low);
+	});
+
+	it("respects an explicit reasoning override", async () => {
+		const captured = spyCompleteSimple();
+		await generateSummary([makeUserMessage("Hi")], MODEL, 4096, "k", undefined, undefined, undefined, {
+			reasoning: Effort.High,
+		});
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.reasoning).toBe(Effort.High);
+	});
+
+	it("compact() defaults both history and short summaries to Effort.Low", async () => {
+		const captured = spyCompleteSimple();
+		await compact(makePreparation(), MODEL, "k");
+		expect(captured.length).toBeGreaterThanOrEqual(1);
+		for (const options of captured) {
+			expect(options.reasoning).toBe(Effort.Low);
+		}
 	});
 });


### PR DESCRIPTION
## Problem

Auto-compaction one-shot calls intermittently fail with `overloaded_error` / `Internal server error`, surfaced to users as repeated `Auto-compaction failed: Turn prefix summarization failed` warnings — even when interactive turns on the same model/account succeed and context usage is low.

Root cause is in the summary call shape, not server capacity. `generateSummary`, `generateShortSummary`, and `generateTurnPrefixSummary` hardcode `reasoning: Effort.High`. Compaction serializes the entire conversation prefix into a single large text input; forcing maximum extended-thinking effort on top of that makes every auto-compaction a heavyweight high-reasoning request. That inflates latency, token cost, and the server-side failure surface, with no summary-quality benefit (summarization is a mechanical text task). Interactive turns are incremental and lighter, so they pass while the compaction one-shot fails and retries.

## Change

- Add `reasoning?: Effort` to `SummaryOptions`.
- The three compaction summary calls now use `options?.reasoning ?? Effort.Low` instead of hardcoded `Effort.High`.
- Default lowered to `Effort.Low`; embedders can pass `Effort.High` to restore previous behavior.
- Handoff generation (`generateHandoff`) is intentionally unchanged.

## Tests

Added to `packages/agent/test/compaction-transport.test.ts`:
- `generateSummary` defaults to `Effort.Low`
- explicit `reasoning` override is respected
- `compact()` defaults both history and short summaries to `Effort.Low`

`bun test packages/agent/test/compaction-transport.test.ts` → 12 pass / 0 fail. Type-check clean.

## Follow-up (not in this PR)

A dedicated compaction model setting (e.g. `compaction.model`) would let users route compaction to a large-context model (Gemini 1M) instead of the active session model's same-provider fallbacks — useful for 1M-context sessions where smaller-context fallbacks cannot fit the serialized prefix. Left as a separate change since it spans `coding-agent` settings + candidate selection.
