### PR TITLE
feat(notifications): Telegram photo/file attachments (inbound + outbound)

### DIFF
--- a/crates/gjc-notifications/src/protocol.rs
+++ b/crates/gjc-notifications/src/protocol.rs
@@ -166,6 +166,8 @@ pub enum ServerMessage {
 	TurnStream(TurnStream),
 	/// An agent-produced image artifact.
 	ImageAttachment(ImageAttachment),
+	/// An agent-produced file artifact delivered as a chat document.
+	FileAttachment(FileAttachment),
 	/// A pushed configuration update (verbosity/redact).
 	ConfigUpdate(ConfigUpdate),
 	/// Server capability/version advertisement for negotiation.
@@ -295,6 +297,24 @@ pub struct ImageAttachment {
 	pub caption:    Option<String>,
 }
 
+/// An agent-produced file artifact to deliver as a chat document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileAttachment {
+	/// The session this file belongs to.
+	pub session_id: String,
+	/// Suggested file name (with extension when known).
+	pub name:       String,
+	/// MIME type, e.g. "application/pdf".
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub mime:       Option<String>,
+	/// Base64-encoded file bytes.
+	pub data:       String,
+	/// Optional caption.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub caption:    Option<String>,
+}
+
 /// A pushed configuration update reflecting current verbosity/redaction.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -345,6 +365,17 @@ pub struct Pong {
 	pub nonce: String,
 }
 
+/// An inline image attachment carried by an inbound user message.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InboundImage {
+	/// Base64-encoded image bytes.
+	pub data: String,
+	/// MIME type when known (e.g. "image/jpeg").
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub mime: Option<String>,
+}
+
 /// An inbound free-text user message injecting/steering a session turn.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -361,6 +392,9 @@ pub struct UserMessage {
 	/// Originating thread/topic id, for fail-closed routing.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub thread_id:  Option<String>,
+	/// Inline image attachments to forward as image content blocks.
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub images:     Vec<InboundImage>,
 }
 
 /// An in-thread configuration command (verbosity/redact toggles).

--- a/crates/gjc-notifications/src/server.rs
+++ b/crates/gjc-notifications/src/server.rs
@@ -891,6 +891,7 @@ mod tests {
 				token:      "secret".into(),
 				update_id:  Some(7),
 				thread_id:  Some("topic-1".into()),
+				images:     vec![],
 			}))
 			.unwrap()
 			.into(),
@@ -926,6 +927,7 @@ mod tests {
 				token:      "WRONG".into(),
 				update_id:  None,
 				thread_id:  None,
+				images:     vec![],
 			}))
 			.unwrap()
 			.into(),

--- a/crates/pi-natives/src/notifications.rs
+++ b/crates/pi-natives/src/notifications.rs
@@ -65,6 +65,17 @@ pub struct InboundEvent {
 	pub verbosity:  Option<String>,
 	/// Requested redaction state (`config_command` only).
 	pub redact:     Option<bool>,
+	/// Inline image attachments forwarded with the message (`user_message` only).
+	pub images:     Option<Vec<InboundImageEvent>>,
+}
+
+/// One inline image attachment forwarded with an inbound user message.
+#[napi(object)]
+pub struct InboundImageEvent {
+	/// Base64-encoded image bytes.
+	pub data: String,
+	/// MIME type when known (e.g. "image/jpeg").
+	pub mime: Option<String>,
 }
 
 /// In-process notification server handle exposed to TypeScript.
@@ -170,6 +181,16 @@ impl NotificationServer {
 							text:       Some(u.text),
 							update_id:  u.update_id,
 							thread_id:  u.thread_id,
+							images:     if u.images.is_empty() {
+								None
+							} else {
+								Some(
+									u.images
+										.into_iter()
+										.map(|i| InboundImageEvent { data: i.data, mime: i.mime })
+										.collect(),
+								)
+							},
 							verbosity:  None,
 							redact:     None,
 						},
@@ -184,6 +205,7 @@ impl NotificationServer {
 								Verbosity::Verbose => "verbose".to_owned(),
 							}),
 							redact:     c.redact,
+							images:     None,
 						},
 						_ => continue,
 					};

--- a/crates/pi-natives/src/notifications.rs
+++ b/crates/pi-natives/src/notifications.rs
@@ -65,7 +65,8 @@ pub struct InboundEvent {
 	pub verbosity:  Option<String>,
 	/// Requested redaction state (`config_command` only).
 	pub redact:     Option<bool>,
-	/// Inline image attachments forwarded with the message (`user_message` only).
+	/// Inline image attachments forwarded with the message (`user_message`
+	/// only).
 	pub images:     Option<Vec<InboundImageEvent>>,
 }
 

--- a/packages/coding-agent/src/notifications/attachment-registry.ts
+++ b/packages/coding-agent/src/notifications/attachment-registry.ts
@@ -1,0 +1,23 @@
+/**
+ * Process-wide registry mapping a session id to a sink that delivers a local
+ * file to the session's connected Telegram chat as a document. Registered by
+ * the notifications extension; consumed by the telegram_send tool.
+ */
+
+/** Delivers a local file to the session's Telegram chat. */
+export type TelegramFileSink = (file: { path: string; caption?: string }) => Promise<{ ok: boolean; error?: string }>;
+
+const sinks = new Map<string, TelegramFileSink>();
+
+/** Register `sink` for `sessionId`. Returns a disposer that clears it. */
+export function registerTelegramFileSink(sessionId: string, sink: TelegramFileSink): () => void {
+	sinks.set(sessionId, sink);
+	return () => {
+		if (sinks.get(sessionId) === sink) sinks.delete(sessionId);
+	};
+}
+
+/** The Telegram file sink for `sessionId`, if one is registered. */
+export function getTelegramFileSink(sessionId: string): TelegramFileSink | undefined {
+	return sinks.get(sessionId);
+}

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -24,11 +24,13 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { promisify } from "node:util";
+import type { ImageContent, TextContent } from "@gajae-code/ai";
 import { NotificationServer } from "@gajae-code/natives";
 import { logger } from "@gajae-code/utils";
 import { Settings } from "../config/settings";
 import type { ExtensionCommandContext, ExtensionContext, ExtensionFactory } from "../extensibility/extensions";
 import { registerAskAnswerSource } from "../tools/ask-answer-registry";
+import { registerTelegramFileSink } from "./attachment-registry";
 import {
 	getNotificationConfig,
 	isGloballyConfigured,
@@ -136,6 +138,8 @@ interface SessionRuntime {
 	pendingInteractive: Map<string, PendingInteractiveAsk>;
 	/** Deregisters this session's ask answer source. */
 	disposeAnswerSource: () => void;
+	/** Deregisters this session's Telegram file sink. */
+	disposeFileSink: () => void;
 	redact: boolean;
 	sessionTag: string;
 	/** Whether the agent loop is currently running (drives the typing indicator). */
@@ -299,6 +303,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		runtimes.delete(id);
 		try {
 			rt.disposeAnswerSource();
+			rt.disposeFileSink();
 		} catch {}
 		// Resolve any still-pending interactive asks so the ask tool is not left hanging.
 		for (const pending of rt.pendingInteractive.values()) pending.resolve(undefined);
@@ -378,14 +383,27 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		// thread (forwarded by the daemon over the WS, fail-closed at the daemon).
 		server.onInbound((err, inbound) => {
 			if (err || !inbound) return;
-			if (inbound.kind === "user_message" && inbound.text) {
+			if (inbound.kind === "user_message") {
 				// Inject as a user turn (steers/continues the agent; the resulting
 				// turn streams back via the turn_end handler even when not idle).
 				// Record the update id so it can be acked as "consumed" on the next
 				// turn_start, and steer (vs start a fresh turn) when already busy.
+				const text = inbound.text ?? "";
+				const images = inbound.images ?? [];
+				if (!text && images.length === 0) return;
 				if (runtime && typeof inbound.updateId === "number") runtime.pendingInbound.add(inbound.updateId);
+				const content: string | (TextContent | ImageContent)[] =
+					images.length > 0
+						? [
+								...(text ? [{ type: "text", text } as TextContent] : []),
+								...images.map(
+									img =>
+										({ type: "image", data: img.data, mimeType: img.mime ?? "image/jpeg" }) as ImageContent,
+								),
+							]
+						: text;
 				try {
-					api.sendUserMessage(inbound.text, runtime?.busy ? { deliverAs: "steer" } : undefined);
+					api.sendUserMessage(content, runtime?.busy ? { deliverAs: "steer" } : undefined);
 				} catch (e) {
 					logger.warn(`notifications: sendUserMessage failed: ${String(e)}`);
 				}
@@ -401,12 +419,30 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 
 			// Interactive answer source: the ask tool races the local UI against this.
 			const disposeAnswerSource = registerInteractiveAnswerSource(id, server, pendingInteractive, redact, tag);
+			const disposeFileSink = registerTelegramFileSink(id, async file => {
+				try {
+					const data = await fs.promises.readFile(file.path);
+					server.pushFrame(
+						JSON.stringify({
+							type: "file_attachment",
+							sessionId: id,
+							name: path.basename(file.path),
+							data: data.toString("base64"),
+							caption: file.caption,
+						}),
+					);
+					return { ok: true };
+				} catch (e) {
+					return { ok: false, error: e instanceof Error ? e.message : String(e) };
+				}
+			});
 
 			runtime = {
 				server,
 				idleSeq: 0,
 				pendingInteractive,
 				disposeAnswerSource,
+				disposeFileSink,
 				redact,
 				sessionTag: tag,
 				busy: false,
@@ -574,6 +610,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		// source by the current session id, which just changed.
 		try {
 			rt.disposeAnswerSource();
+			rt.disposeFileSink();
 		} catch {}
 		rt.disposeAnswerSource = registerInteractiveAnswerSource(
 			newId,
@@ -582,6 +619,23 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 			rt.redact,
 			rt.sessionTag,
 		);
+		rt.disposeFileSink = registerTelegramFileSink(newId, async file => {
+			try {
+				const data = await fs.promises.readFile(file.path);
+				rt.server.pushFrame(
+					JSON.stringify({
+						type: "file_attachment",
+						sessionId: newId,
+						name: path.basename(file.path),
+						data: data.toString("base64"),
+						caption: file.caption,
+					}),
+				);
+				return { ok: true };
+			} catch (e) {
+				return { ok: false, error: e instanceof Error ? e.message : String(e) };
+			}
+		});
 		// Rename the existing topic now when the new session already has a name; a
 		// fresh unnamed session is renamed on its next agent_end re-assert, which
 		// avoids a transient rename to bare "repo/branch".

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1,4 +1,5 @@
 import { spawn as childProcessSpawn } from "node:child_process";
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -911,12 +912,43 @@ export class TelegramNotificationDaemon {
 	}
 
 	/**
+	 * Per-session private temp directories (mode 0700) holding inbound non-image
+	 * attachments. Keyed by session id and reused across transient reconnects;
+	 * removed when the daemon stops (see {@link cleanupAllAttachmentDirs}).
+	 */
+	private readonly attachmentDirs = new Map<string, string>();
+
+	/** Lazily create a private, unguessable 0700 temp dir for `sessionId`. */
+	private async ensureAttachmentDir(sessionId: string): Promise<string> {
+		const existing = this.attachmentDirs.get(sessionId);
+		if (existing) return existing;
+		// mkdtemp creates a directory with an unguessable suffix and 0700 perms;
+		// chmod defensively in case of an unusual platform/umask.
+		const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "gjc-telegram-"));
+		await fs.promises.chmod(dir, 0o700).catch(() => undefined);
+		this.attachmentDirs.set(sessionId, dir);
+		return dir;
+	}
+
+	/** Remove all per-session attachment directories. Called on daemon shutdown. */
+	private async cleanupAllAttachmentDirs(): Promise<void> {
+		const dirs = [...this.attachmentDirs.values()];
+		this.attachmentDirs.clear();
+		await Promise.all(dirs.map(dir => fs.promises.rm(dir, { recursive: true, force: true }).catch(() => undefined)));
+	}
+
+	/**
 	 * Resolve an inbound attachment to inline image bytes (forwarded as images) or
-	 * a saved /tmp file path note (non-images). Returns base64 images to inline and
-	 * human-readable file notes to append to the injected text.
+	 * a securely-saved file path note (non-images). Non-image bytes are written
+	 * into a private per-session temp dir (0700) under an unguessable name via an
+	 * exclusive 0600 create (`wx`), so the files are not world-readable and the
+	 * write never follows a pre-existing symlink. The directory is removed when the
+	 * daemon stops. Returns base64 images to inline plus human-readable file notes
+	 * to append to the injected text.
 	 */
 	private async resolveInboundAttachment(
 		att: InboundAttachment,
+		sessionId: string,
 	): Promise<{ images: { data: string; mime?: string }[]; fileNotes: string[] }> {
 		const images: { data: string; mime?: string }[] = [];
 		const fileNotes: string[] = [];
@@ -939,12 +971,16 @@ export class TelegramNotificationDaemon {
 			if (isImage) {
 				images.push({ data: bytes.toString("base64"), mime: att.mime ?? "image/jpeg" });
 			} else {
-				const base =
+				const safeBase =
 					(att.fileName?.trim() || path.basename(filePath) || `${att.kind}-${att.fileId}`)
 						.replace(/[^\w.-]+/g, "_")
+						.replace(/^\.+/, "_")
 						.slice(-128) || "file";
-				const dest = path.join(os.tmpdir(), `gjc-telegram-${Date.now()}-${base}`);
-				await fs.promises.writeFile(dest, bytes);
+				const dir = await this.ensureAttachmentDir(sessionId);
+				// Unguessable, non-colliding name inside the private 0700 dir; the
+				// exclusive 0600 create (`wx`) refuses to follow a pre-existing file/symlink.
+				const dest = path.join(dir, `${crypto.randomBytes(8).toString("hex")}-${safeBase}`);
+				await fs.promises.writeFile(dest, bytes, { flag: "wx", mode: 0o600 });
 				fileNotes.push(`[user attached a file, saved to ${dest}${att.mime ? ` (${att.mime})` : ""}]`);
 			}
 		} catch (e) {
@@ -1306,7 +1342,7 @@ export class TelegramNotificationDaemon {
 				const session = this.sessions.get(inbound.sessionId);
 				if (session?.ws.readyState === WebSocket.OPEN) {
 					const attachmentResult = inbound.attachment
-						? await this.resolveInboundAttachment(inbound.attachment)
+						? await this.resolveInboundAttachment(inbound.attachment, inbound.sessionId)
 						: undefined;
 					const images = attachmentResult?.images ?? [];
 					const fileNotes = attachmentResult?.fileNotes ?? [];
@@ -1518,6 +1554,7 @@ export class TelegramNotificationDaemon {
 			this.stopFlushTimer();
 			this.stopScanTimer();
 			this.stopTypingTimer();
+			await this.cleanupAllAttachmentDirs();
 			// Persist durable state before releasing ownership so a fresh daemon
 			// (e.g. after reload) reloads aliases/topics seamlessly.
 			await this.persistAliases().catch(() => undefined);

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1,5 +1,6 @@
 import { spawn as childProcessSpawn } from "node:child_process";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { logger } from "@gajae-code/utils";
 import { withFileLock } from "../config/file-lock";
@@ -19,7 +20,7 @@ import {
 	readEndpoint,
 	routeInboundUpdate,
 } from "./telegram-reference";
-import { decideThreadedInbound } from "./threaded-inbound";
+import { decideThreadedInbound, type InboundAttachment } from "./threaded-inbound";
 import { renderThreadedFrame, type ThreadedSend } from "./threaded-render";
 import { TopicRegistry, type TopicRegistryState } from "./topic-registry";
 
@@ -652,6 +653,35 @@ export class TelegramNotificationDaemon {
 					);
 					return res.json();
 				}
+				const docBody = body as { document?: unknown } | null;
+				if (method === "sendDocument" && docBody && typeof docBody.document === "string") {
+					const b = body as {
+						chat_id: unknown;
+						message_thread_id?: unknown;
+						document: string;
+						mime?: string;
+						fileName?: string;
+						caption?: string;
+						parse_mode?: string;
+					};
+					const form = new FormData();
+					form.set("chat_id", String(b.chat_id));
+					if (b.message_thread_id !== undefined) form.set("message_thread_id", String(b.message_thread_id));
+					if (b.caption) form.set("caption", b.caption);
+					if (b.parse_mode) form.set("parse_mode", String(b.parse_mode));
+					form.set(
+						"document",
+						new Blob([Buffer.from(b.document, "base64")], { type: b.mime ?? "application/octet-stream" }),
+						b.fileName ?? "file",
+					);
+					const res = await fetchWithRetry(
+						fetchImpl,
+						url,
+						{ method: "POST", body: form, signal: callOpts?.signal },
+						sleep,
+					);
+					return res.json();
+				}
 				const res = await fetchWithRetry(
 					fetchImpl,
 					url,
@@ -803,6 +833,7 @@ export class TelegramNotificationDaemon {
 		"context_update",
 		"turn_stream",
 		"image_attachment",
+		"file_attachment",
 		"config_update",
 	]);
 
@@ -864,6 +895,65 @@ export class TelegramNotificationDaemon {
 		if (raw && typeof raw === "object") this.topics.load(raw);
 	}
 
+	/** Download a Telegram file by its file_path (from getFile) into memory. */
+	private async downloadTelegramFile(filePath: string): Promise<Buffer | undefined> {
+		const apiBase = this.opts.apiBase ?? "https://api.telegram.org";
+		const fetchImpl = this.opts.fetchImpl ?? fetch;
+		const url = `${apiBase}/file/bot${this.opts.botToken}/${filePath}`;
+		try {
+			const res = await fetchImpl(url);
+			if (!res.ok) return undefined;
+			return Buffer.from(await res.arrayBuffer());
+		} catch (e) {
+			logger.warn(`notifications: file download failed: ${String(e)}`);
+			return undefined;
+		}
+	}
+
+	/**
+	 * Resolve an inbound attachment to inline image bytes (forwarded as images) or
+	 * a saved /tmp file path note (non-images). Returns base64 images to inline and
+	 * human-readable file notes to append to the injected text.
+	 */
+	private async resolveInboundAttachment(
+		att: InboundAttachment,
+	): Promise<{ images: { data: string; mime?: string }[]; fileNotes: string[] }> {
+		const images: { data: string; mime?: string }[] = [];
+		const fileNotes: string[] = [];
+		const label = att.fileName ?? att.kind;
+		try {
+			const got = (await this.botApi.call("getFile", { file_id: att.fileId })) as {
+				result?: { file_path?: unknown };
+			};
+			const filePath = typeof got?.result?.file_path === "string" ? got.result.file_path : undefined;
+			if (!filePath) {
+				fileNotes.push(`[attachment unavailable: ${label}]`);
+				return { images, fileNotes };
+			}
+			const bytes = await this.downloadTelegramFile(filePath);
+			if (!bytes) {
+				fileNotes.push(`[attachment download failed: ${label}]`);
+				return { images, fileNotes };
+			}
+			const isImage = att.kind === "photo" || (typeof att.mime === "string" && att.mime.startsWith("image/"));
+			if (isImage) {
+				images.push({ data: bytes.toString("base64"), mime: att.mime ?? "image/jpeg" });
+			} else {
+				const base =
+					(att.fileName?.trim() || path.basename(filePath) || `${att.kind}-${att.fileId}`)
+						.replace(/[^\w.-]+/g, "_")
+						.slice(-128) || "file";
+				const dest = path.join(os.tmpdir(), `gjc-telegram-${Date.now()}-${base}`);
+				await fs.promises.writeFile(dest, bytes);
+				fileNotes.push(`[user attached a file, saved to ${dest}${att.mime ? ` (${att.mime})` : ""}]`);
+			}
+		} catch (e) {
+			logger.warn(`notifications: inbound attachment failed: ${String(e)}`);
+			fileNotes.push(`[attachment error: ${label}]`);
+		}
+		return { images, fileNotes };
+	}
+
 	/** Drain the shared rate-limit pool and deliver each granted send to its topic. */
 	private async flushPool(): Promise<void> {
 		for (const item of this.pool.drain()) {
@@ -878,6 +968,16 @@ export class TelegramNotificationDaemon {
 						...threadField,
 						photo: send.photoBase64,
 						mime: send.mime,
+						caption: send.text,
+						parse_mode: TELEGRAM_PARSE_MODE,
+					});
+				} else if (send.method === "sendDocument" && send.documentBase64) {
+					await this.botApi.call("sendDocument", {
+						chat_id: this.opts.chatId,
+						...threadField,
+						document: send.documentBase64,
+						mime: send.mime,
+						fileName: send.fileName,
 						caption: send.text,
 						parse_mode: TELEGRAM_PARSE_MODE,
 					});
@@ -1205,12 +1305,19 @@ export class TelegramNotificationDaemon {
 				this.seenUpdateIds.add(inbound.updateId);
 				const session = this.sessions.get(inbound.sessionId);
 				if (session?.ws.readyState === WebSocket.OPEN) {
-					const cfg = parseInThreadConfigCommand(inbound.text);
+					const attachmentResult = inbound.attachment
+						? await this.resolveInboundAttachment(inbound.attachment)
+						: undefined;
+					const images = attachmentResult?.images ?? [];
+					const fileNotes = attachmentResult?.fileNotes ?? [];
+					const hasMedia = images.length > 0 || fileNotes.length > 0;
+					const injectedText = [inbound.text, ...fileNotes].filter(Boolean).join("\n");
+					const cfg = hasMedia ? undefined : parseInThreadConfigCommand(inbound.text);
 					// A plain (non-config) message while an ask is pending for this session
 					// answers that ask as free-input — instead of starting a new user turn.
 					// Telegram asks always accept custom text (the SDK maps a string answer
 					// to the ask's custom-input slot), so route the latest pending ask here.
-					const pendingAsk = cfg ? undefined : [...session.pending.values()].at(-1);
+					const pendingAsk = cfg || hasMedia ? undefined : [...session.pending.values()].at(-1);
 					if (pendingAsk) {
 						session.ws.send(
 							JSON.stringify({
@@ -1230,10 +1337,11 @@ export class TelegramNotificationDaemon {
 								: {
 										type: "user_message",
 										sessionId: inbound.sessionId,
-										text: inbound.text,
+										text: injectedText,
 										token: session.token,
 										updateId: inbound.updateId,
 										threadId: inbound.threadId,
+										images,
 									},
 						),
 					);

--- a/packages/coding-agent/src/notifications/threaded-inbound.ts
+++ b/packages/coding-agent/src/notifications/threaded-inbound.ts
@@ -21,9 +21,28 @@ export interface InboundUpdate {
 	message?: {
 		message_id?: unknown;
 		text?: unknown;
+		caption?: unknown;
+		photo?: unknown;
+		document?: unknown;
+		video?: unknown;
+		audio?: unknown;
+		voice?: unknown;
+		animation?: unknown;
 		chat?: { id?: unknown };
 		message_thread_id?: unknown;
 	};
+}
+
+/** A downloadable media attachment referenced by an inbound message. */
+export interface InboundAttachment {
+	/** Telegram file_id to resolve via getFile. */
+	fileId: string;
+	/** Source media kind; "photo" is always an image. */
+	kind: "photo" | "document" | "video" | "audio" | "voice" | "animation";
+	/** MIME type when Telegram provides one. */
+	mime?: string;
+	/** Original file name when provided. */
+	fileName?: string;
 }
 
 /** Context for {@link decideThreadedInbound}. All lookups are injected. */
@@ -38,13 +57,44 @@ export interface ThreadedInboundCtx {
 
 /** Outcome of routing an inbound update. */
 export type ThreadedInboundDecision =
-	| { kind: "inject"; sessionId: string; text: string; updateId: number; threadId: string; messageId?: number }
+	| {
+			kind: "inject";
+			sessionId: string;
+			text: string;
+			updateId: number;
+			threadId: string;
+			messageId?: number;
+			attachment?: InboundAttachment;
+	  }
 	| { kind: "duplicate"; updateId: number }
 	| { kind: "ignore"; reason: string };
 
 function asString(value: unknown): string | undefined {
 	if (typeof value === "string") return value;
 	if (typeof value === "number") return String(value);
+	return undefined;
+}
+
+function extractAttachment(message: NonNullable<InboundUpdate["message"]>): InboundAttachment | undefined {
+	if (Array.isArray(message.photo) && message.photo.length > 0) {
+		const photo = message.photo[message.photo.length - 1];
+		if (photo && typeof photo === "object" && "file_id" in photo && typeof photo.file_id === "string") {
+			return { fileId: photo.file_id, kind: "photo", mime: "image/jpeg" };
+		}
+	}
+
+	for (const kind of ["document", "video", "audio", "voice", "animation"] as const) {
+		const file = message[kind];
+		if (file && typeof file === "object" && "file_id" in file && typeof file.file_id === "string") {
+			return {
+				fileId: file.file_id,
+				kind,
+				mime: "mime_type" in file && typeof file.mime_type === "string" ? file.mime_type : undefined,
+				fileName: "file_name" in file && typeof file.file_name === "string" ? file.file_name : undefined,
+			};
+		}
+	}
+
 	return undefined;
 }
 
@@ -72,9 +122,15 @@ export function decideThreadedInbound(update: InboundUpdate, ctx: ThreadedInboun
 	const updateId = update.update_id;
 	if (ctx.isDuplicate(updateId)) return { kind: "duplicate", updateId };
 
-	const text = typeof message.text === "string" ? message.text.trim() : "";
-	if (!text) return { kind: "ignore", reason: "empty_text" };
+	const text =
+		typeof message.text === "string"
+			? message.text.trim()
+			: typeof message.caption === "string"
+				? message.caption.trim()
+				: "";
+	const attachment = extractAttachment(message);
+	if (!text && attachment === undefined) return { kind: "ignore", reason: "empty_text" };
 
 	const messageId = typeof message.message_id === "number" ? message.message_id : undefined;
-	return { kind: "inject", sessionId, text, updateId, threadId, messageId };
+	return { kind: "inject", sessionId, text, updateId, threadId, messageId, attachment };
 }

--- a/packages/coding-agent/src/notifications/threaded-render.ts
+++ b/packages/coding-agent/src/notifications/threaded-render.ts
@@ -15,15 +15,19 @@ import type { RateLimitLane } from "./rate-limit-pool";
 
 /** A Telegram send derived from a threaded frame (topic id is applied by the daemon). */
 export interface ThreadedSend {
-	method: "sendMessage" | "sendPhoto";
+	method: "sendMessage" | "sendPhoto" | "sendDocument";
 	/** Rate-limit lane for prioritisation/fairness. */
 	lane: RateLimitLane;
 	/** Message text (sendMessage) or photo caption (sendPhoto). */
 	text?: string;
 	/** Base64 image bytes for sendPhoto. */
 	photoBase64?: string;
+	/** Base64 file bytes for sendDocument. */
+	documentBase64?: string;
 	/** Image MIME type for sendPhoto. */
 	mime?: string;
+	/** Suggested document filename. */
+	fileName?: string;
 	/** Coalesce key for live edits (same key collapses to the latest). */
 	coalesceKey?: string;
 	/** True for the one-time identity header (the daemon pins it once). */
@@ -49,11 +53,12 @@ interface ThreadedFrame {
 	phase?: unknown;
 	text?: unknown;
 	messageRef?: unknown;
-	// image_attachment
+	// image_attachment / file_attachment
 	source?: unknown;
 	data?: unknown;
 	mime?: unknown;
 	caption?: unknown;
+	name?: unknown;
 	// config_update
 	verbosity?: unknown;
 	redact?: unknown;
@@ -138,6 +143,19 @@ export function renderThreadedFrame(frame: ThreadedFrame): ThreadedSend | undefi
 				lane: "finalized",
 				photoBase64: data,
 				mime: str(frame.mime),
+				text: finalizeTelegramHtml(caption === undefined ? undefined : escapeHtml(caption)),
+			};
+		}
+		case "file_attachment": {
+			const data = str(frame.data);
+			if (!data) return undefined;
+			const caption = str(frame.caption);
+			return {
+				method: "sendDocument",
+				lane: "finalized",
+				documentBase64: data,
+				mime: str(frame.mime),
+				fileName: str(frame.name),
 				text: finalizeTelegramHtml(caption === undefined ? undefined : escapeHtml(caption)),
 			};
 		}

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -58,6 +58,7 @@ import { SearchToolBm25Tool } from "./search-tool-bm25";
 import { SkillTool } from "./skill";
 import { loadSshTool } from "./ssh";
 import { SubagentTool } from "./subagent";
+import { TelegramSendTool } from "./telegram-send";
 import { type TodoPhase, TodoWriteTool } from "./todo-write";
 import { WriteTool } from "./write";
 import { YieldTool } from "./yield";
@@ -96,6 +97,7 @@ export * from "./search-tool-bm25";
 export * from "./skill";
 export * from "./ssh";
 export * from "./subagent";
+export * from "./telegram-send";
 export * from "./todo-write";
 export * from "./vim";
 export * from "./write";
@@ -402,6 +404,7 @@ export const BUILTIN_TOOLS: Record<string, ToolFactory> = {
 	todo_write: s => new TodoWriteTool(s),
 	web_search: s => new WebSearchTool(s),
 	search_tool_bm25: SearchToolBm25Tool.createIf,
+	telegram_send: TelegramSendTool.createIf,
 	write: s => new WriteTool(s),
 	skill: SkillTool.createIf,
 	goal: s => new GoalTool(s),

--- a/packages/coding-agent/src/tools/telegram-send.ts
+++ b/packages/coding-agent/src/tools/telegram-send.ts
@@ -1,0 +1,85 @@
+import * as path from "node:path";
+import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
+import { z } from "zod/v4";
+import { getTelegramFileSink } from "../notifications/attachment-registry";
+import { getNotificationConfig, isGloballyConfigured } from "../notifications/config";
+import type { ToolSession } from "./index";
+
+const telegramSendSchema = z.object({
+	path: z.string().describe("local file path (absolute or relative to cwd) to send to Telegram"),
+	caption: z.string().optional().describe("optional caption"),
+});
+
+type TelegramSendParams = z.infer<typeof telegramSendSchema>;
+
+interface TelegramSendDetails {
+	path: string;
+	caption?: string;
+	ok: boolean;
+	error?: string;
+}
+
+export class TelegramSendTool implements AgentTool<typeof telegramSendSchema, TelegramSendDetails> {
+	readonly name = "telegram_send";
+	readonly label = "TelegramSend";
+	readonly summary = "Send a local file to Telegram";
+	readonly loadMode = "discoverable";
+	readonly description =
+		"Send a local file to the connected Telegram chat as a document. Provide an absolute or cwd-relative path and an optional caption.";
+	readonly parameters = telegramSendSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	static createIf(session: ToolSession): TelegramSendTool | null {
+		return isGloballyConfigured(getNotificationConfig(session.settings)) ? new TelegramSendTool(session) : null;
+	}
+
+	async execute(
+		_toolCallId: string,
+		params: TelegramSendParams,
+		_signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<TelegramSendDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<TelegramSendDetails>> {
+		const sessionId = this.session.getSessionId?.();
+		if (!sessionId) {
+			return {
+				content: [{ type: "text", text: "telegram_send: no active session id" }],
+				details: { path: params.path, caption: params.caption, ok: false, error: "no active session id" },
+				isError: true,
+			};
+		}
+
+		const abs = path.isAbsolute(params.path) ? params.path : path.resolve(this.session.cwd, params.path);
+		const sink = getTelegramFileSink(sessionId);
+		if (!sink) {
+			return {
+				content: [
+					{ type: "text", text: "telegram_send: Telegram notifications are not connected for this session" },
+				],
+				details: {
+					path: abs,
+					caption: params.caption,
+					ok: false,
+					error: "Telegram notifications are not connected",
+				},
+				isError: true,
+			};
+		}
+
+		const result = await sink({ path: abs, caption: params.caption });
+		if (result.ok) {
+			return {
+				content: [{ type: "text", text: `Sent ${path.basename(abs)} to Telegram.` }],
+				details: { path: abs, caption: params.caption, ok: true },
+			};
+		}
+
+		return {
+			content: [{ type: "text", text: `telegram_send failed: ${result.error}` }],
+			details: { path: abs, caption: params.caption, ok: false, error: result.error },
+			isError: true,
+		};
+	}
+}

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -1271,6 +1271,16 @@ test("inbound document is saved to a tmp file and its path injected into the tex
 	expect(match).toBeTruthy();
 	expect(fs.existsSync(match![1]!)).toBe(true);
 	expect(fs.readFileSync(match![1]!)).toEqual(Buffer.from([9, 9, 9]));
+	// Security: the saved file must be private (0600, no group/other access) inside
+	// a private 0700 per-session directory under the system temp root — not a
+	// predictable, world-readable /tmp path.
+	const dest = match![1]!;
+	const fileMode = fs.statSync(dest).mode & 0o777;
+	const dirMode = fs.statSync(path.dirname(dest)).mode & 0o777;
+	expect(fileMode).toBe(0o600);
+	expect(fileMode & 0o077).toBe(0);
+	expect(dirMode & 0o077).toBe(0);
+	expect(dest.startsWith(os.tmpdir())).toBe(true);
 });
 
 test("outbound file_attachment frame triggers a sendDocument upload to the topic", async () => {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -80,6 +80,7 @@ class FakeBotApi {
 			this.updates = [];
 			return { ok: true, result };
 		}
+		if (method === "getFile") return { ok: true, result: { file_path: "docs/file_7.bin" } };
 		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: this.calls.length } };
 		if (method === "sendMessage") return { ok: true, result: { message_id: this.calls.length } };
 		return { ok: true, result: true };
@@ -1186,6 +1187,125 @@ test("inbound thread message gets a queued reaction, flipped to consumed on ack"
 	expect(consumed).toBeTruthy();
 	expect(consumed!.body.message_id).toBe(555);
 	expect(consumed!.body.reaction[0].emoji).toBe("✅");
+});
+
+test("inbound photo is downloaded and forwarded as an image in the user_message", async () => {
+	FakeWs.instances = [];
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const fetchImpl = (async () => ({
+		ok: true,
+		arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
+	})) as unknown as typeof fetch;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		fetchImpl,
+		WebSocketImpl: FakeWs as any,
+	});
+	daemon.connectSession("S", "ws://s", "ts");
+	const session = daemon.sessions.get("S")!;
+	await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
+	const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
+
+	await daemon.handleTelegramUpdate({
+		update_id: 11,
+		message: {
+			chat: { id: 42 },
+			message_thread_id: threadId,
+			message_id: 100,
+			photo: [{ file_id: "small" }, { file_id: "large" }],
+		},
+	});
+
+	const frame = JSON.parse(FakeWs.instances[0]!.sent[0]!);
+	expect(frame.type).toBe("user_message");
+	expect(frame.images).toHaveLength(1);
+	expect(frame.images[0].mime).toBe("image/jpeg");
+	expect(Buffer.from(frame.images[0].data, "base64")).toEqual(Buffer.from([1, 2, 3, 4]));
+	// The largest photo size is the one resolved/downloaded.
+	expect(bot.calls.some(c => c.method === "getFile" && c.body.file_id === "large")).toBe(true);
+});
+
+test("inbound document is saved to a tmp file and its path injected into the text", async () => {
+	FakeWs.instances = [];
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const fetchImpl = (async () => ({
+		ok: true,
+		arrayBuffer: async () => new Uint8Array([9, 9, 9]).buffer,
+	})) as unknown as typeof fetch;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		fetchImpl,
+		WebSocketImpl: FakeWs as any,
+	});
+	daemon.connectSession("S", "ws://s", "ts");
+	const session = daemon.sessions.get("S")!;
+	await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
+	const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
+
+	await daemon.handleTelegramUpdate({
+		update_id: 12,
+		message: {
+			chat: { id: 42 },
+			message_thread_id: threadId,
+			message_id: 101,
+			caption: "look",
+			document: { file_id: "doc-1", mime_type: "application/pdf", file_name: "report.pdf" },
+		},
+	});
+
+	const frame = JSON.parse(FakeWs.instances[0]!.sent[0]!);
+	expect(frame.type).toBe("user_message");
+	expect(frame.images).toHaveLength(0);
+	expect(frame.text).toContain("look");
+	const match = String(frame.text).match(/saved to (\S+report\.pdf)/);
+	expect(match).toBeTruthy();
+	expect(fs.existsSync(match![1]!)).toBe(true);
+	expect(fs.readFileSync(match![1]!)).toEqual(Buffer.from([9, 9, 9]));
+});
+
+test("outbound file_attachment frame triggers a sendDocument upload to the topic", async () => {
+	FakeWs.instances = [];
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+	});
+	daemon.connectSession("S", "ws://s", "ts");
+	const session = daemon.sessions.get("S")!;
+	await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
+	bot.calls = [];
+
+	const data = Buffer.from([5, 6, 7]).toString("base64");
+	await daemon.handleSessionMessage(session, {
+		type: "file_attachment",
+		sessionId: "S",
+		name: "out.pdf",
+		mime: "application/pdf",
+		data,
+		caption: "here",
+	});
+
+	const doc = bot.calls.find(c => c.method === "sendDocument");
+	expect(doc).toBeTruthy();
+	expect(doc!.body.document).toBe(data);
+	expect(doc!.body.fileName).toBe("out.pdf");
+	expect(doc!.body.mime).toBe("application/pdf");
+	expect(Number(doc!.body.message_thread_id)).toBeGreaterThan(0);
 });
 
 describe("telegram daemon reconnect reconciliation", () => {

--- a/packages/coding-agent/test/notifications-threaded-inbound.test.ts
+++ b/packages/coding-agent/test/notifications-threaded-inbound.test.ts
@@ -77,4 +77,52 @@ describe("decideThreadedInbound (fail-closed injection)", () => {
 		);
 		expect(decision).toEqual({ kind: "inject", sessionId: "sess-x", text: "go", updateId: 8, threadId: "1" });
 	});
+
+	test("injects a photo-only message with an image attachment and empty text", () => {
+		const decision = decideThreadedInbound(
+			{
+				update_id: 9,
+				message: {
+					chat: { id: 42 },
+					message_thread_id: "topic-1",
+					photo: [
+						{ file_id: "small", width: 90, height: 90 },
+						{ file_id: "large", width: 1280, height: 1280 },
+					],
+				},
+			},
+			ctx(),
+		);
+		expect(decision).toEqual({
+			kind: "inject",
+			sessionId: "sess-1",
+			text: "",
+			updateId: 9,
+			threadId: "topic-1",
+			attachment: { fileId: "large", kind: "photo", mime: "image/jpeg" },
+		});
+	});
+
+	test("injects a document using its caption as text plus a document attachment", () => {
+		const decision = decideThreadedInbound(
+			{
+				update_id: 10,
+				message: {
+					chat: { id: 42 },
+					message_thread_id: "topic-1",
+					caption: "  see attached  ",
+					document: { file_id: "doc-1", mime_type: "application/pdf", file_name: "report.pdf" },
+				},
+			},
+			ctx(),
+		);
+		expect(decision).toEqual({
+			kind: "inject",
+			sessionId: "sess-1",
+			text: "see attached",
+			updateId: 10,
+			threadId: "topic-1",
+			attachment: { fileId: "doc-1", kind: "document", mime: "application/pdf", fileName: "report.pdf" },
+		});
+	});
 });

--- a/packages/coding-agent/test/notifications-threaded-render.test.ts
+++ b/packages/coding-agent/test/notifications-threaded-render.test.ts
@@ -74,6 +74,29 @@ describe("renderThreadedFrame", () => {
 		expect(renderThreadedFrame({ type: "image_attachment", sessionId: "s", mime: "image/png" })).toBeUndefined();
 	});
 
+	test("file_attachment renders a sendDocument with filename, mime, and caption", () => {
+		const send = renderThreadedFrame({
+			type: "file_attachment",
+			sessionId: "s",
+			name: "report.pdf",
+			mime: "application/pdf",
+			data: "QkFTRTY0",
+			caption: "the report",
+		});
+		expect(send).toMatchObject({
+			method: "sendDocument",
+			lane: "finalized",
+			documentBase64: "QkFTRTY0",
+			fileName: "report.pdf",
+			mime: "application/pdf",
+			text: "the report",
+		});
+	});
+
+	test("file_attachment without data renders nothing", () => {
+		expect(renderThreadedFrame({ type: "file_attachment", sessionId: "s", name: "x.bin" })).toBeUndefined();
+	});
+
 	test("config_update renders a low-priority status line", () => {
 		const send = renderThreadedFrame({ type: "config_update", sessionId: "s", verbosity: "verbose", redact: false });
 		expect(send?.lane).toBe("idle");

--- a/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
+++ b/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
@@ -15,6 +15,7 @@ import {
 	JobTool,
 	RecipeTool,
 	SshTool,
+	TelegramSendTool,
 } from "../../src/tools/index";
 
 const allToolsSettings = Settings.isolated({
@@ -97,6 +98,7 @@ async function getToolMetadata(): Promise<Map<string, { loadMode?: string; summa
 		new JobTool(toolSession),
 		new RecipeTool(toolSession, []),
 		new IrcTool(toolSession),
+		new TelegramSendTool(toolSession),
 	]) {
 		metadata.set(tool.name, { loadMode: tool.loadMode, summary: tool.summary });
 	}

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -929,6 +929,16 @@ export interface InboundEvent {
   verbosity?: string
   /** Requested redaction state (`config_command` only). */
   redact?: boolean
+  /** Inline image attachments forwarded with the message (`user_message` only). */
+  images?: Array<InboundImageEvent>
+}
+
+/** One inline image attachment forwarded with an inbound user message. */
+export interface InboundImageEvent {
+  /** Base64-encoded image bytes. */
+  data: string
+  /** MIME type when known (e.g. "image/jpeg"). */
+  mime?: string
 }
 
 /**


### PR DESCRIPTION
Fresh dev-targeted PR replacing #1050, with the requested security hardening included.

## What
Adds attachment support to the Telegram notifications integration in **both directions**.

### Inbound (Telegram user → agent)
- `decideThreadedInbound` accepts `photo`/`document`/`video`/`audio`/`voice`/`animation` messages and captions, returning an `InboundAttachment` descriptor.
- The daemon resolves each attachment via `getFile` + file download:
  - **Images** → forwarded inline to the model as `ImageContent`.
  - **Other files** → saved securely on disk and the path is injected into the user-turn text.
- `onInbound` forwards inbound images to the agent via `sendUserMessage`.

### Outbound (agent → Telegram)
- New **`telegram_send`** tool sends a local file to the session's Telegram chat as a document (gated to appear only when Telegram is globally configured).
- A process-wide registry bridges the tool to the per-session notification server, which pushes a `file_attachment` frame; the daemon renders it to a `sendDocument` multipart upload.

### Wire protocol (Rust + native)
- `UserMessage.images` and `ServerMessage::FileAttachment` added; images mapped through the napi `InboundEvent` (regenerated `native/index.d.ts`).

## Security review fixes (the blocker on #1050)
Inbound non-image attachment storage is now hardened:
- **Private per-session directory** created with `fs.mkdtemp` (mode **0700**, chmod-enforced), reused across transient reconnects.
- **Exclusive create**: files written with `flag: "wx"` + **mode 0600** (no group/other access; refuses to follow a pre-existing file/symlink).
- **Unguessable name**: `crypto.randomBytes(8)` prefix instead of a predictable `Date.now()` name.
- **Path-traversal hardening**: the Telegram-provided name is stripped of path separators and leading dots before use.
- **Cleanup/lifetime**: per-session directories are removed when the daemon stops (`cleanupAllAttachmentDirs` in the run-loop `finally`).
- **Regression test** asserts the saved file is `0600` with no group/other bits, inside a private directory (no group/other bits) under the system temp root.

## Testing
- `check:ts` (biome + all workspace typechecks) green; Rust unchanged from the maintainer's rustfmt commit on this branch.
- Full notifications + tool suites: **216 pass**; attachment-specific suites green.
- Real native-server WebSocket round-trip of both new frames.
- Live Telegram HTTP smoke: `sendPhoto`/`sendDocument` accepted; `getFile` + download byte-exact.

## Notes
- Built `.node` binary is gitignored; regenerated `native/index.d.ts` is included.
- Includes the maintainer's rustfmt commit (`e0a4e47b`) already on this branch.