### PR TITLE
feat(ai): add JetBrains Junie (JetBrains AI) provider

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1601,6 +1601,14 @@ export class AuthStorage {
 				});
 				break;
 			}
+			case "jetbrains-junie": {
+				const { loginJetBrainsJunie } = await import("./utils/oauth/jetbrains-junie");
+				credentials = await loginJetBrainsJunie({
+					...ctrl,
+					onManualCodeInput: ctrl.onManualCodeInput ?? manualCodeInput,
+				});
+				break;
+			}
 			case "fireworks": {
 				const { loginFireworks } = await import("./utils/oauth/fireworks");
 				const apiKey = await loginFireworks(ctrl);

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -101,6 +101,7 @@ Commands:
 Providers:
   anthropic         Anthropic
   github-copilot    GitHub Copilot
+  jetbrains-junie   JetBrains AI (Junie; Claude via JetBrains Account)
   google-gemini-cli Google Gemini CLI
   google-antigravity Antigravity (Gemini 3, Anthropic, GPT-OSS)
   openai-codex      OpenAI code provider (ChatGPT Plus/Pro)

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -11408,6 +11408,77 @@
 			}
 		}
 	},
+	"jetbrains-junie": {
+		"claude-sonnet-4-6": {
+			"id": "claude-sonnet-4-6",
+			"name": "Junie · Claude Sonnet 4.6",
+			"api": "anthropic-messages",
+			"provider": "jetbrains-junie",
+			"baseUrl": "https://ingrazzio-cloud-prod.labs.jb.gg",
+			"headers": {
+				"Grazie-Agent": "{\"name\":\"junie:cli\",\"version\":\"888.219\"}",
+				"X-LLM-Model": "anthropic",
+				"X-Keep-Path": "true",
+				"X-Accept-EAP-License": "false"
+			},
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"claude-opus-4-6": {
+			"id": "claude-opus-4-6",
+			"name": "Junie · Claude Opus 4.6",
+			"api": "anthropic-messages",
+			"provider": "jetbrains-junie",
+			"baseUrl": "https://ingrazzio-cloud-prod.labs.jb.gg",
+			"headers": {
+				"Grazie-Agent": "{\"name\":\"junie:cli\",\"version\":\"888.219\"}",
+				"X-LLM-Model": "anthropic",
+				"X-Keep-Path": "true",
+				"X-Accept-EAP-License": "false"
+			},
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
+			}
+		}
+	},
 	"kilo": {
 		"~anthropic/claude-haiku-latest": {
 			"id": "~anthropic/claude-haiku-latest",

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -43,7 +43,12 @@ import {
 	xiaomiModelManagerOptions,
 	zenmuxModelManagerOptions,
 } from "./openai-compat";
-import { cursorModelManagerOptions, glmZcodeModelManagerOptions, zaiModelManagerOptions } from "./special";
+import {
+	cursorModelManagerOptions,
+	glmZcodeModelManagerOptions,
+	jetbrainsJunieModelManagerOptions,
+	zaiModelManagerOptions,
+} from "./special";
 
 /** Catalog discovery configuration for providers that support endpoint-based model listing. */
 export interface CatalogDiscoveryConfig {
@@ -305,6 +310,7 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		config => glmZcodeModelManagerOptions(config),
 		catalog("GLM ZCode (unofficial)", ["GLM_ZCODE_API_KEY"], { oauthProvider: "glm-zcode" }),
 	),
+	descriptor("jetbrains-junie", "claude-sonnet-4-6", config => jetbrainsJunieModelManagerOptions(config)),
 	descriptor("github-copilot", "gpt-4o", config => githubCopilotModelManagerOptions(config)),
 	descriptor("google", "gemini-2.5-pro", config => googleModelManagerOptions(config)),
 	catalogDescriptor(

--- a/packages/ai/src/provider-models/special.ts
+++ b/packages/ai/src/provider-models/special.ts
@@ -77,3 +77,15 @@ export function glmZcodeModelManagerOptions(
 ): ModelManagerOptions<"anthropic-messages"> {
 	return { providerId: "glm-zcode" };
 }
+
+// ---------------------------------------------------------------------------
+// JetBrains Junie (JetBrains AI Service)
+// ---------------------------------------------------------------------------
+
+export interface JetBrainsJunieModelManagerConfig {}
+
+export function jetbrainsJunieModelManagerOptions(
+	_config: JetBrainsJunieModelManagerConfig = {},
+): ModelManagerOptions<"anthropic-messages"> {
+	return { providerId: "jetbrains-junie" };
+}

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -89,6 +89,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	"vercel-ai-gateway": "AI_GATEWAY_API_KEY",
 	zai: "ZAI_API_KEY",
 	"glm-zcode": "GLM_ZCODE_API_KEY",
+	"jetbrains-junie": "JETBRAINS_JUNIE_API_KEY",
 	mistral: "MISTRAL_API_KEY",
 	minimax: "MINIMAX_API_KEY",
 	"minimax-code": "MINIMAX_CODE_API_KEY",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -123,6 +123,7 @@ export type KnownProvider =
 	| "vercel-ai-gateway"
 	| "zai"
 	| "glm-zcode"
+	| "jetbrains-junie"
 	| "mistral"
 	| "minimax"
 	| "opencode-go"

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -81,6 +81,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "jetbrains-junie",
+		name: "JetBrains AI (Junie)",
+		available: true,
+	},
+	{
 		id: "google-gemini-cli",
 		name: "Google Cloud Code Assist (Gemini CLI)",
 		available: true,
@@ -343,6 +348,11 @@ export async function refreshOAuthToken(
 		case "glm-zcode": {
 			const { refreshGlmZcodeToken } = await import("./glm-zcode");
 			newCredentials = await refreshGlmZcodeToken(credentials);
+			break;
+		}
+		case "jetbrains-junie": {
+			const { refreshJetBrainsJunieToken } = await import("./jetbrains-junie");
+			newCredentials = await refreshJetBrainsJunieToken(credentials);
 			break;
 		}
 		case "kilo":

--- a/packages/ai/src/utils/oauth/jetbrains-junie.ts
+++ b/packages/ai/src/utils/oauth/jetbrains-junie.ts
@@ -1,0 +1,215 @@
+/**
+ * JetBrains Junie / JetBrains AI OAuth flow.
+ *
+ * Logs in with a JetBrains Account using the same browser-based PKCE flow the
+ * official Junie CLI uses: the authorization request is opened against
+ * `junie.jetbrains.com/cli-auth`, which drives the JetBrains Hub login and
+ * redirects the authorization code back to a local loopback callback server.
+ * The resulting access token authenticates requests against the JetBrains AI
+ * Service (`ingrazzio-cloud-prod.labs.jb.gg`), which exposes a native Anthropic
+ * Messages endpoint.
+ *
+ * Endpoints and parameters mirror the public Junie CLI client (`junie-cli`).
+ */
+import { OAuthCallbackFlow, type OAuthCallbackFlowOptions, parseCallbackInput } from "./callback-server";
+import { generatePKCE } from "./pkce";
+import type { OAuthController, OAuthCredentials } from "./types";
+
+type FetchImpl = typeof globalThis.fetch;
+
+const CLIENT_ID = "junie-cli";
+const SCOPES = "offline_access openid jb-authn-service";
+const LOGIN_INITIAL_URL = "https://junie.jetbrains.com/cli-auth";
+const TOKEN_ENDPOINT = "https://oauth.account.jetbrains.com/oauth2/token";
+
+/** Loopback callback ports allow-listed for the `junie-cli` OAuth client. */
+const CALLBACK_PORT_START = 62345;
+const CALLBACK_PORT_END = 62364;
+const CALLBACK_HOST = "localhost";
+
+const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
+
+interface PKCE {
+	verifier: string;
+	challenge: string;
+}
+
+interface JetBrainsTokenResponse {
+	access_token?: unknown;
+	refresh_token?: unknown;
+	expires_in?: unknown;
+	token_type?: unknown;
+}
+
+function toExpiry(expiresIn: unknown): number {
+	const seconds = typeof expiresIn === "number" && Number.isFinite(expiresIn) && expiresIn > 0 ? expiresIn : 3600;
+	return Date.now() + seconds * 1000;
+}
+
+/** Probe a single loopback port; returns true when it can be bound right now. */
+function canBindPort(port: number): boolean {
+	try {
+		const server = Bun.serve({
+			hostname: CALLBACK_HOST,
+			port,
+			reusePort: false,
+			fetch: () => new Response(null, { status: 404 }),
+		});
+		server.stop(true);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Find the first free port in the JetBrains loopback callback range. */
+function findFreeCallbackPort(): number {
+	for (let port = CALLBACK_PORT_START; port <= CALLBACK_PORT_END; port++) {
+		if (canBindPort(port)) {
+			return port;
+		}
+	}
+	throw new Error(
+		`JetBrains Junie OAuth: no free callback port available in range ${CALLBACK_PORT_START}-${CALLBACK_PORT_END}`,
+	);
+}
+
+async function exchangeCodeForToken(
+	fetchImpl: FetchImpl,
+	code: string,
+	verifier: string,
+	redirectUri: string,
+	signal: AbortSignal | undefined,
+): Promise<OAuthCredentials> {
+	// Manual paste may include the whole redirect URL; recover the bare code.
+	const resolvedCode = parseCallbackInput(code).code ?? code;
+	const body = new URLSearchParams({
+		grant_type: "authorization_code",
+		code: resolvedCode,
+		code_verifier: verifier,
+		client_id: CLIENT_ID,
+		redirect_uri: redirectUri,
+	});
+	const response = await fetchImpl(TOKEN_ENDPOINT, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+		body,
+		signal: signal ?? AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+	});
+	if (!response.ok) {
+		throw new Error(`JetBrains Junie token exchange failed: ${response.status} ${await response.text()}`);
+	}
+	const data = (await response.json()) as JetBrainsTokenResponse;
+	if (typeof data.access_token !== "string" || data.access_token.length === 0) {
+		throw new Error("JetBrains Junie token exchange response missing access_token");
+	}
+	return {
+		access: data.access_token,
+		refresh: typeof data.refresh_token === "string" ? data.refresh_token : "",
+		expires: toExpiry(data.expires_in),
+	};
+}
+
+export interface JetBrainsJunieOAuthFlowOptions {
+	fetch?: FetchImpl;
+}
+
+export class JetBrainsJunieOAuthFlow extends OAuthCallbackFlow {
+	#fetch: FetchImpl;
+	#pkce: PKCE;
+
+	constructor(ctrl: OAuthController, pkce: PKCE, port: number, options: JetBrainsJunieOAuthFlowOptions = {}) {
+		super(ctrl, {
+			preferredPort: port,
+			// JetBrains redirects to the loopback root (`http://localhost:PORT`),
+			// so the callback request lands on the "/" path.
+			callbackPath: "/",
+			callbackHostname: CALLBACK_HOST,
+			callbackBindHostname: CALLBACK_HOST,
+			// Advertise the exact redirect_uri the Junie CLI uses (no trailing path).
+			redirectUri: `http://${CALLBACK_HOST}:${port}`,
+		} satisfies OAuthCallbackFlowOptions);
+		this.#pkce = pkce;
+		this.#fetch = options.fetch ?? ctrl.fetch ?? globalThis.fetch;
+	}
+
+	async generateAuthUrl(state: string, redirectUri: string): Promise<{ url: string; instructions?: string }> {
+		// Build the query manually to match the official Junie CLI byte-for-byte
+		// (encodeURIComponent encodes spaces as %20 inside the scope value).
+		const url =
+			`${LOGIN_INITIAL_URL}?client_id=${CLIENT_ID}` +
+			`&scope=${encodeURIComponent(SCOPES)}` +
+			`&state=${state}` +
+			`&code_challenge=${this.#pkce.challenge}` +
+			`&redirect_uri=${encodeURIComponent(redirectUri)}`;
+		return {
+			url,
+			instructions:
+				"Sign in with your JetBrains Account in the browser. If the CLI cannot capture the redirect automatically, paste the final redirect URL or authorization code when prompted.",
+		};
+	}
+
+	async exchangeToken(code: string, _state: string, redirectUri: string): Promise<OAuthCredentials> {
+		return exchangeCodeForToken(this.#fetch, code, this.#pkce.verifier, redirectUri, this.ctrl.signal);
+	}
+}
+
+/**
+ * Login with JetBrains Junie (JetBrains Account OAuth, PKCE browser flow).
+ */
+export async function loginJetBrainsJunie(
+	ctrl: OAuthController,
+	options?: JetBrainsJunieOAuthFlowOptions,
+): Promise<OAuthCredentials> {
+	const pkce = await generatePKCE();
+	const port = findFreeCallbackPort();
+	return new JetBrainsJunieOAuthFlow(ctrl, pkce, port, options).login();
+}
+
+export interface JetBrainsJunieRefreshOptions {
+	signal?: AbortSignal;
+	fetch?: FetchImpl;
+}
+
+/**
+ * Refresh a JetBrains Junie access token using the stored refresh token.
+ */
+export async function refreshJetBrainsJunieToken(
+	credentials: OAuthCredentials,
+	options: AbortSignal | JetBrainsJunieRefreshOptions = {},
+): Promise<OAuthCredentials> {
+	const { signal, fetch: fetchImpl } =
+		options instanceof AbortSignal ? { signal: options, fetch: undefined } : options;
+	if (!credentials.refresh) {
+		throw new Error(
+			"JetBrains Junie credentials require re-login (`/login jetbrains-junie`); no refresh token stored",
+		);
+	}
+	const fetchImplResolved = fetchImpl ?? globalThis.fetch;
+	const body = new URLSearchParams({
+		grant_type: "refresh_token",
+		refresh_token: credentials.refresh,
+		client_id: CLIENT_ID,
+	});
+	const response = await fetchImplResolved(TOKEN_ENDPOINT, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+		body,
+		signal: signal ?? AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+	});
+	if (!response.ok) {
+		throw new Error(`JetBrains Junie token refresh failed: ${response.status} ${await response.text()}`);
+	}
+	const data = (await response.json()) as JetBrainsTokenResponse;
+	if (typeof data.access_token !== "string" || data.access_token.length === 0) {
+		throw new Error("JetBrains Junie token refresh response missing access_token");
+	}
+	return {
+		access: data.access_token,
+		refresh:
+			typeof data.refresh_token === "string" && data.refresh_token.length > 0
+				? data.refresh_token
+				: credentials.refresh,
+		expires: toExpiry(data.expires_in),
+	};
+}

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -22,6 +22,7 @@ export type OAuthProvider =
 	| "google-antigravity"
 	| "gitlab-duo"
 	| "huggingface"
+	| "jetbrains-junie"
 	| "kimi-code"
 	| "kilo"
 	| "kagi"

--- a/packages/ai/test/oauth-jetbrains-junie.test.ts
+++ b/packages/ai/test/oauth-jetbrains-junie.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test";
+import { loginJetBrainsJunie, refreshJetBrainsJunieToken } from "../src/utils/oauth/jetbrains-junie";
+import type { OAuthController } from "../src/utils/oauth/types";
+
+const TOKEN_ENDPOINT = "https://oauth.account.jetbrains.com/oauth2/token";
+
+interface CapturedRequest {
+	url: string;
+	body: URLSearchParams;
+}
+
+function makeFetch(captured: CapturedRequest[], response: Record<string, unknown>): typeof globalThis.fetch {
+	return (async (input: string | URL | Request, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input.toString();
+		const raw = init?.body;
+		const body = new URLSearchParams(typeof raw === "string" ? raw : raw ? String(raw) : "");
+		captured.push({ url, body });
+		return new Response(JSON.stringify(response), { status: 200, headers: { "Content-Type": "application/json" } });
+	}) as unknown as typeof globalThis.fetch;
+}
+
+describe("JetBrains Junie OAuth", () => {
+	it("logs in via the PKCE browser flow and exchanges the authorization code", async () => {
+		const captured: CapturedRequest[] = [];
+		let authUrl = "";
+		const ctrl: OAuthController = {
+			fetch: makeFetch(captured, {
+				access_token: "junie-access-token",
+				refresh_token: "junie-refresh-token",
+				expires_in: 3600,
+				token_type: "Bearer",
+			}),
+			onAuth: info => {
+				authUrl = info.url;
+			},
+			// Simulate the user pasting the redirect URL so we do not depend on a
+			// real browser round-trip hitting the loopback callback server.
+			onManualCodeInput: async () => "http://localhost/?code=test-auth-code",
+		};
+
+		const creds = await loginJetBrainsJunie(ctrl);
+
+		// Authorization URL targets the Junie CLI auth entrypoint with PKCE params.
+		expect(authUrl.startsWith("https://junie.jetbrains.com/cli-auth?")).toBe(true);
+		const authQuery = new URL(authUrl).searchParams;
+		expect(authQuery.get("client_id")).toBe("junie-cli");
+		expect(authQuery.get("scope")).toBe("offline_access openid jb-authn-service");
+		expect(authQuery.get("code_challenge")).toBeTruthy();
+		const redirectUri = authQuery.get("redirect_uri") ?? "";
+		expect(redirectUri).toMatch(/^http:\/\/localhost:623(4[5-9]|5\d|6[0-4])$/);
+
+		// Token exchange posts the authorization_code grant with the PKCE verifier.
+		expect(captured).toHaveLength(1);
+		expect(captured[0].url).toBe(TOKEN_ENDPOINT);
+		expect(captured[0].body.get("grant_type")).toBe("authorization_code");
+		expect(captured[0].body.get("code")).toBe("test-auth-code");
+		expect(captured[0].body.get("client_id")).toBe("junie-cli");
+		expect(captured[0].body.get("code_verifier")).toBeTruthy();
+		expect(captured[0].body.get("redirect_uri")).toBe(redirectUri);
+
+		expect(creds.access).toBe("junie-access-token");
+		expect(creds.refresh).toBe("junie-refresh-token");
+		expect(creds.expires).toBeGreaterThan(Date.now());
+	});
+
+	it("refreshes the access token with the refresh_token grant", async () => {
+		const captured: CapturedRequest[] = [];
+		const fetchImpl = makeFetch(captured, {
+			access_token: "refreshed-access-token",
+			expires_in: 7200,
+			token_type: "Bearer",
+		});
+
+		const creds = await refreshJetBrainsJunieToken(
+			{ access: "old-access", refresh: "stored-refresh-token", expires: Date.now() - 1000 },
+			{ fetch: fetchImpl },
+		);
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0].url).toBe(TOKEN_ENDPOINT);
+		expect(captured[0].body.get("grant_type")).toBe("refresh_token");
+		expect(captured[0].body.get("refresh_token")).toBe("stored-refresh-token");
+		expect(captured[0].body.get("client_id")).toBe("junie-cli");
+
+		expect(creds.access).toBe("refreshed-access-token");
+		// Refresh token is preserved when the response omits a new one.
+		expect(creds.refresh).toBe("stored-refresh-token");
+		expect(creds.expires).toBeGreaterThan(Date.now());
+	});
+
+	it("rejects refresh when no refresh token is stored", async () => {
+		await expect(refreshJetBrainsJunieToken({ access: "x", refresh: "", expires: 0 })).rejects.toThrow(
+			/require re-login/,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a **JetBrains Junie (JetBrains AI)** provider, structurally analogous to the existing `github-copilot` / `zai` / `glm-zcode` providers. Users log in with their JetBrains Account via the Junie CLI PKCE browser flow and get Claude models served through the JetBrains AI Service native **Anthropic Messages** endpoint (`ingrazzio-cloud-prod.labs.jb.gg`).

## Why it works like Copilot

JetBrains AI's backend exposes a native Anthropic `/v1/messages` surface authenticated with a plain `Authorization: Bearer` token — identical wiring to `zai`/`glm-zcode` (anthropic-messages API + custom base URL). The anthropic provider already emits `Bearer` (not `x-api-key`) for non-Anthropic base URLs, and model `headers` pass through, so the Grazie passthrough headers ride along untouched.

## What's included

- **OAuth PKCE login + refresh** (`utils/oauth/jetbrains-junie.ts`) using the public `junie-cli` client, loopback callback (ports 62345–62364), with a manual-paste fallback.
- Provider registration: builtin OAuth list, `refreshOAuthToken` switch, `auth-storage` login dispatch.
- Model manager options + descriptor (default `claude-sonnet-4-6`).
- Bundled models `claude-sonnet-4-6` / `claude-opus-4-6` with Grazie passthrough headers (`Grazie-Agent`, `X-LLM-Model: anthropic`, `X-Keep-Path`, `X-Accept-EAP-License`).
- `JETBRAINS_JUNIE_API_KEY` env fallback for headless/CI.
- Unit tests for login + refresh.

## Scope

- **Included:** Claude Sonnet/Opus 4.6 via the native Anthropic passthrough (most reliable path).
- **Deliberately excluded:** GPT (OpenAI passthrough enforces an upstream payload field-whitelist that would need separate sanitization) and Gemini (proprietary Grazie translation protocol, not OpenAI-compatible).

## Verification

- Typecheck (`@gajae-code/ai` + `coding-agent`), biome, `check:schemas`, `check:plugins` pass.
- New unit tests + existing OAuth/registry suites pass.
- **Live end-to-end request confirmed:** OAuth token resolved & auto-refreshed, `claude-sonnet-4-6` streamed a real response from `ingrazzio-cloud-prod.labs.jb.gg`, usage tokens reported correctly.

## Note

The Grazie impersonation header version (`junie:cli` 888.219) is reverse-engineered and may need bumping if JetBrains changes it. Use is subject to the JetBrains AI Service Terms of Service.
