### PR TITLE
fix(read): match engine auth_required verdict token

### DIFF
--- a/packages/coding-agent/src/web/insane/bridge.ts
+++ b/packages/coding-agent/src/web/insane/bridge.ts
@@ -294,7 +294,9 @@ function mapEngineOutput(raw: EngineRawOutput, timeoutMs: number): InsaneBridgeR
 	}
 
 	const verdict = parsed.verdict?.trim();
-	if (verdict && /^authentication required$/i.test(verdict)) {
+	// The engine emits the Verdict enum value `auth_required` (401/407); also tolerate
+	// the human-readable phrase defensively. Either is a terminal public-content boundary.
+	if (verdict && /^(?:auth_required|authentication required)$/i.test(verdict)) {
 		notes.push(INSANE_NOTES.authRequired);
 		return { ok: false, reason: "auth-required", verdict, notes };
 	}

--- a/packages/coding-agent/test/web/insane/bridge.test.ts
+++ b/packages/coding-agent/test/web/insane/bridge.test.ts
@@ -106,16 +106,25 @@ describe("tryInsaneFetch JSON mapping", () => {
 		}
 	});
 
-	it("maps authentication required to failure without bypass", async () => {
+	it("maps the engine auth_required verdict token to failure without bypass", async () => {
 		const r = await tryInsaneFetch("https://example.com", {
 			prober: deps(),
-			runner: async () => rawOutput({ stdout: JSON.stringify({ ok: false, verdict: "authentication required" }) }),
+			runner: async () => rawOutput({ stdout: JSON.stringify({ ok: false, verdict: "auth_required" }) }),
 		});
 		expect(r.ok).toBe(false);
 		if (!r.ok) {
 			expect(r.reason).toBe("auth-required");
 			expect(r.notes).toContain(INSANE_NOTES.authRequired);
 		}
+	});
+
+	it("also tolerates the human-readable authentication-required phrase", async () => {
+		const r = await tryInsaneFetch("https://example.com", {
+			prober: deps(),
+			runner: async () => rawOutput({ stdout: JSON.stringify({ ok: false, verdict: "authentication required" }) }),
+		});
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.reason).toBe("auth-required");
 	});
 
 	it("maps invalid JSON to a controlled failure", async () => {


### PR DESCRIPTION
Follow-up to the insane-search integration (#1032).

While demonstrating the engine live, two `--json` contract bugs surfaced:

1. **`--json` omitted the page body** — already fixed on `dev` by patching the vendored engine to emit bounded content (`to_dict(include_content=True, content_limit=…)` + `--json-content-limit`). ✅ verified live: `--json` now returns `content`.
2. **Auth verdict token mismatch** (this PR) — the engine emits the `Verdict` enum value `auth_required` for 401/407, but the bridge only matched the human phrase `"authentication required"`, so auth/paywall pages were never mapped to the no-bypass `auth-required` note (they fell through to the generic verdict path). This matches `auth_required` (the real token) and keeps the phrase as a defensive fallback.

Verified: `bun test test/web/insane test/tools/fetch-insane-fallback.test.ts test/web/search/config-schema.test.ts` → 39 pass; insane/fetch files type-clean. Live: engine `auth_required` verdict → `insane fallback stopped: authentication required` note, no bypass.