### PR TITLE
feat(web-search): recover inline citations for native search across all wires

### DIFF
--- a/docs/tools/web_search.md
+++ b/docs/tools/web_search.md
@@ -139,6 +139,7 @@ Streaming: none. `WebSearchTool.execute()` does not forward its `_signal` argume
     - `max_tokens` and `temperature` pass through.
     - `limit` and `num_search_results` are collapsed together before dispatch: `num_results = params.numSearchResults ?? params.limit`.
     - Output may include `answer`, `sources`, `citations`, `searchQueries`, `usage.searchRequests`, `model`, `requestId`.
+    - When a search ran (`web_search_tool_result` / `server_tool_use` / `usage.server_tool_use.web_search_requests`) but only inline citations were emitted, sources are recovered from the answer text via `providers/text-citations.ts`. If no search ran and nothing is grounded, it fails closed (`424`) so the chain falls through to DuckDuckGo.
   - **Gemini** — `packages/coding-agent/src/web/search/providers/gemini.ts`
     - Availability: OAuth credentials in `agent.db` for `google-gemini-cli` or `google-antigravity`.
     - Querying: SSE `streamGenerateContent` call with Google Search grounding enabled. Antigravity auth tries two fallback endpoints and retries `401/403/400 invalid auth` once after token refresh; `429/5xx` retry with exponential backoff and server-provided retry delay, capped by a `5 * 60 * 1000` ms rate-limit budget.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Hardened context-overflow recovery so automatic maintenance clears the TUI loader, surfaces overflow completion/skip status, retries resumable tails safely, and falls back to the synthetic auto-continue prompt for non-resumable tails when enabled.
+- `web_search` native providers no longer discard genuinely grounded answers that omit structured `url_citation` annotations: when a search demonstrably ran — Responses `web_search_call` / `tool_usage.web_search`, a Chat Completions search request, or Anthropic `web_search_tool_result` / `server_tool_use` / `server_tool_use.web_search_requests` — sources are recovered from inline markdown links and bare URLs. Inline recovery is gated on that real-search signal so a stray prose URL in a non-search answer is never promoted to a citation, and Anthropic now fails closed to DuckDuckGo when Claude answers from stable knowledge without searching. Inline-citation helpers are shared via `providers/text-citations.ts`.
 
 ## [0.7.1] - 2026-06-23
 ### Fixed

--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -25,6 +25,7 @@ import type {
 import { SearchProviderError } from "../../../web/search/types";
 import type { SearchParams } from "./base";
 import { SearchProvider } from "./base";
+import { extractTextSources } from "./text-citations";
 import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
 const DEFAULT_MODEL = "claude-haiku-4-5";
@@ -237,6 +238,26 @@ function parseResponse(response: AnthropicApiResponse): SearchResponse {
 }
 
 /**
+ * Whether the response carries proof that a web search actually ran: a
+ * `web_search_tool_result` block, a `web_search` server tool call, or a
+ * non-zero `server_tool_use.web_search_requests` usage counter.
+ */
+function anthropicSearchPerformed(response: AnthropicApiResponse): boolean {
+	if (response.usage?.server_tool_use?.web_search_requests) return true;
+	for (const block of response.content ?? []) {
+		if (block.type === "web_search_tool_result") return true;
+		if (
+			block.type === "server_tool_use" &&
+			block.name &&
+			stripClaudeToolPrefix(block.name) === WEB_SEARCH_TOOL_NAME
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
  * Executes a web search using Anthropic's Anthropic model with built-in web search tool.
  * @param params - Search parameters including query and optional settings
  * @returns Search response with synthesized answer, sources, and citations
@@ -301,6 +322,21 @@ export async function searchAnthropic(
 	);
 
 	const result = parseResponse(response);
+	const searched = anthropicSearchPerformed(response);
+
+	// When a search ran but the model wrote its citations inline instead of as
+	// structured `web_search_result_location` blocks, recover sources from the
+	// answer text so a genuinely grounded result is not discarded.
+	if (result.sources.length === 0 && searched && result.answer) {
+		const inline = extractTextSources(result.answer);
+		if (inline.length > 0) result.sources = inline;
+	}
+
+	// Fail closed so the chain falls through to DuckDuckGo when Claude answered
+	// from stable knowledge without running a web search.
+	if (result.sources.length === 0 && !(result.citations && result.citations.length > 0) && !searched) {
+		throw new SearchProviderError("anthropic", "Anthropic web search returned no grounded sources", 424);
+	}
 
 	const numResults = "authStorage" in params ? (params.numSearchResults ?? params.limit) : params.num_results;
 	if (numResults && result.sources.length > numResults) {

--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -15,6 +15,7 @@ import type { SearchResponse, SearchSource } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
 import type { SearchParams } from "./base";
 import { SearchProvider } from "./base";
+import { addSource, extractTextSources } from "./text-citations";
 import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
 const CODEX_BASE_URL = "https://chatgpt.com/backend-api";
@@ -116,125 +117,6 @@ interface CodexResponse {
 
 function isImagePlaceholderAnswer(text: string): boolean {
 	return text.trim().toLowerCase() === "(see attached image)";
-}
-
-function addSource(sources: SearchSource[], source: SearchSource): void {
-	if (!sources.some(existing => existing.url === source.url)) {
-		sources.push(source);
-	}
-}
-
-function countCharacter(text: string, target: string): number {
-	let count = 0;
-	for (const char of text) {
-		if (char === target) {
-			count += 1;
-		}
-	}
-	return count;
-}
-
-/**
- * Strips prose punctuation and unmatched closing delimiters from extracted URLs.
- * OpenAI code backend often returns links in markdown or sentence text without structured annotations.
- */
-function normalizeExtractedUrl(candidate: string): string | null {
-	let url = candidate.trim();
-
-	while (url.length > 0) {
-		const lastCharacter = url.at(-1);
-		if (!lastCharacter) break;
-		if (/[.,!?;:'"]/u.test(lastCharacter)) {
-			url = url.slice(0, -1);
-			continue;
-		}
-		if (lastCharacter === ")" && countCharacter(url, ")") > countCharacter(url, "(")) {
-			url = url.slice(0, -1);
-			continue;
-		}
-		if (lastCharacter === "]" && countCharacter(url, "]") > countCharacter(url, "[")) {
-			url = url.slice(0, -1);
-			continue;
-		}
-		if (lastCharacter === "}" && countCharacter(url, "}") > countCharacter(url, "{")) {
-			url = url.slice(0, -1);
-			continue;
-		}
-		break;
-	}
-
-	if (!/^https?:\/\//.test(url)) {
-		return null;
-	}
-
-	try {
-		return new URL(url).toString();
-	} catch {
-		return null;
-	}
-}
-
-function findMarkdownLinkUrlEnd(text: string, openParenIndex: number): number | null {
-	let depth = 0;
-
-	for (let index = openParenIndex; index < text.length; index += 1) {
-		const character = text[index];
-		if (!character || character === "\n") {
-			return null;
-		}
-		if (character === "(") {
-			depth += 1;
-			continue;
-		}
-		if (character !== ")") {
-			continue;
-		}
-		depth -= 1;
-		if (depth === 0) {
-			return index;
-		}
-		if (depth < 0) {
-			return null;
-		}
-	}
-
-	return null;
-}
-
-/**
- * Extracts citation sources from markdown links and bare URLs in the answer text.
- * Used as a fallback when the OpenAI code backend response omits `url_citation` annotations.
- */
-function extractTextSources(text: string): SearchSource[] {
-	const sources: SearchSource[] = [];
-
-	for (let index = 0; index < text.length; index += 1) {
-		if (text[index] !== "[") {
-			continue;
-		}
-		const titleEnd = text.indexOf("]", index + 1);
-		if (titleEnd === -1 || text[titleEnd + 1] !== "(") {
-			continue;
-		}
-		const urlEnd = findMarkdownLinkUrlEnd(text, titleEnd + 1);
-		if (urlEnd === null) {
-			continue;
-		}
-		const title = text.slice(index + 1, titleEnd).trim();
-		const url = normalizeExtractedUrl(text.slice(titleEnd + 2, urlEnd));
-		if (url) {
-			addSource(sources, { title: title || url, url });
-		}
-		index = urlEnd;
-	}
-
-	for (const match of text.matchAll(/https?:\/\/\S+/g)) {
-		const url = normalizeExtractedUrl(match[0] ?? "");
-		if (!url) continue;
-		addSource(sources, { title: url, url });
-	}
-
-	return sources;
 }
 
 /**

--- a/packages/coding-agent/src/web/search/providers/openai-compatible.ts
+++ b/packages/coding-agent/src/web/search/providers/openai-compatible.ts
@@ -2,7 +2,21 @@ import type { SearchCitation, SearchResponse, SearchSource } from "../types";
 import { SearchProviderError } from "../types";
 import type { SearchParams } from "./base";
 import { SearchProvider } from "./base";
+import { extractTextSources } from "./text-citations";
 import { classifyProviderHttpError, withHardTimeout } from "./utils";
+
+/**
+ * Whether the response carries independent proof that a web search ran. Used to
+ * gate inline-citation recovery so a stray prose URL in a non-search answer is
+ * never promoted to a citation.
+ */
+function webSearchPerformed(json: any): boolean {
+	if (Array.isArray(json?.output) && json.output.some((item: any) => item?.type === "web_search_call")) {
+		return true;
+	}
+	const numRequests = json?.tool_usage?.web_search?.num_requests;
+	return typeof numRequests === "number" && numRequests > 0;
+}
 
 function endpoint(baseUrl: string, api: string): string {
 	const base = baseUrl.replace(/\/+$/, "");
@@ -135,14 +149,26 @@ export class OpenAICompatibleSearchProvider extends SearchProvider {
 		}
 		const json = text ? JSON.parse(text) : {};
 		const citations = parseCitations(json);
-		if (citations.length === 0) {
+		const answer = textFromResponse(json);
+		const limit = params.limit ?? params.numSearchResults ?? 10;
+		let sources = toSources(citations, limit);
+		const searched = webSearchPerformed(json);
+		// When a search demonstrably ran (Responses `web_search_call` / `tool_usage`)
+		// or this is a Chat Completions search request, recover inline-cited sources
+		// from the answer text if the model omitted structured `url_citation`
+		// annotations. Gating on a real search signal preserves the guard against
+		// promoting a stray prose URL in a non-search answer to a citation.
+		if (sources.length === 0 && answer && (searched || ctx.api === "openai-completions")) {
+			sources = extractTextSources(answer).slice(0, limit);
+		}
+		if (sources.length === 0 && !searched) {
 			throw new SearchProviderError(this.id, "OpenAI-compatible web search returned no citations", 424);
 		}
 		return {
 			provider: this.id,
-			answer: textFromResponse(json),
-			sources: toSources(citations, params.limit ?? params.numSearchResults ?? 10),
-			citations,
+			answer,
+			sources,
+			citations: citations.length > 0 ? citations : undefined,
 			model,
 			requestId: json.id,
 			authMode: "api-key",

--- a/packages/coding-agent/src/web/search/providers/text-citations.ts
+++ b/packages/coding-agent/src/web/search/providers/text-citations.ts
@@ -1,0 +1,111 @@
+/**
+ * Inline citation extraction shared by native web-search providers.
+ *
+ * Web-search-capable models sometimes return a genuinely grounded answer whose
+ * sources are written inline (markdown links or bare URLs) instead of as
+ * structured citation annotations. When a provider has independent proof that a
+ * web search actually ran, these helpers recover sources from the answer text so
+ * the result is not discarded.
+ */
+import type { SearchSource } from "../types";
+
+/** Append a source, de-duplicating by URL. */
+export function addSource(sources: SearchSource[], source: SearchSource): void {
+	if (!sources.some(existing => existing.url === source.url)) {
+		sources.push(source);
+	}
+}
+
+function countCharacter(text: string, target: string): number {
+	let count = 0;
+	for (const char of text) {
+		if (char === target) count += 1;
+	}
+	return count;
+}
+
+/**
+ * Strips prose punctuation and unmatched closing delimiters from extracted URLs.
+ * Models often return links embedded in markdown or sentence text.
+ */
+export function normalizeExtractedUrl(candidate: string): string | null {
+	let url = candidate.trim();
+
+	while (url.length > 0) {
+		const lastCharacter = url.at(-1);
+		if (!lastCharacter) break;
+		if (/[.,!?;:'"]/u.test(lastCharacter)) {
+			url = url.slice(0, -1);
+			continue;
+		}
+		if (lastCharacter === ")" && countCharacter(url, ")") > countCharacter(url, "(")) {
+			url = url.slice(0, -1);
+			continue;
+		}
+		if (lastCharacter === "]" && countCharacter(url, "]") > countCharacter(url, "[")) {
+			url = url.slice(0, -1);
+			continue;
+		}
+		if (lastCharacter === "}" && countCharacter(url, "}") > countCharacter(url, "{")) {
+			url = url.slice(0, -1);
+			continue;
+		}
+		break;
+	}
+
+	if (!/^https?:\/\//.test(url)) return null;
+
+	try {
+		return new URL(url).toString();
+	} catch {
+		return null;
+	}
+}
+
+function findMarkdownLinkUrlEnd(text: string, openParenIndex: number): number | null {
+	let depth = 0;
+
+	for (let index = openParenIndex; index < text.length; index += 1) {
+		const character = text[index];
+		if (!character || character === "\n") return null;
+		if (character === "(") {
+			depth += 1;
+			continue;
+		}
+		if (character !== ")") continue;
+		depth -= 1;
+		if (depth === 0) return index;
+		if (depth < 0) return null;
+	}
+
+	return null;
+}
+
+/**
+ * Extracts citation sources from markdown links and bare URLs in answer text.
+ * Used only as a fallback when a provider confirms a search ran but omits
+ * structured citation annotations.
+ */
+export function extractTextSources(text: string): SearchSource[] {
+	const sources: SearchSource[] = [];
+
+	for (let index = 0; index < text.length; index += 1) {
+		if (text[index] !== "[") continue;
+		const titleEnd = text.indexOf("]", index + 1);
+		if (titleEnd === -1 || text[titleEnd + 1] !== "(") continue;
+		const urlEnd = findMarkdownLinkUrlEnd(text, titleEnd + 1);
+		if (urlEnd === null) continue;
+		const title = text.slice(index + 1, titleEnd).trim();
+		const url = normalizeExtractedUrl(text.slice(titleEnd + 2, urlEnd));
+		if (url) addSource(sources, { title: title || url, url });
+		index = urlEnd;
+	}
+
+	for (const match of text.matchAll(/https?:\/\/\S+/g)) {
+		const url = normalizeExtractedUrl(match[0] ?? "");
+		if (!url) continue;
+		addSource(sources, { title: url, url });
+	}
+
+	return sources;
+}

--- a/packages/coding-agent/test/web/search/abort-and-timeout.test.ts
+++ b/packages/coding-agent/test/web/search/abort-and-timeout.test.ts
@@ -74,7 +74,9 @@ describe("Anthropic provider hard-timeout wiring", () => {
 			});
 		});
 
-		await searchAnthropic({ query: "ping", system_prompt: "" }, fakeStorage);
+		// The non-search "ok" response now fails closed (424) after fetch; the
+		// captured signal is set during fetch, so swallow the throw here.
+		await searchAnthropic({ query: "ping", system_prompt: "" }, fakeStorage).catch(() => {});
 
 		// Without the hard-timeout wrapper, init.signal would be undefined when
 		// the caller didn't supply one — leaving fetch with no cancellation at
@@ -96,7 +98,7 @@ describe("Anthropic provider hard-timeout wiring", () => {
 			});
 		});
 
-		await searchAnthropic({ query: "ping", system_prompt: "", signal: ac.signal }, fakeStorage);
+		await searchAnthropic({ query: "ping", system_prompt: "", signal: ac.signal }, fakeStorage).catch(() => {});
 
 		// The signal handed to fetch must be a *composed* one, not the raw
 		// caller signal: that's what guarantees the hard timeout fires even

--- a/packages/coding-agent/test/web/search/web-search-citation-harvest.test.ts
+++ b/packages/coding-agent/test/web/search/web-search-citation-harvest.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "bun:test";
+import { hookFetch } from "@gajae-code/utils";
+import type { AuthStorage } from "../../../src/session/auth-storage";
+import { AnthropicProvider } from "../../../src/web/search/providers/anthropic";
+import { OpenAICompatibleSearchProvider } from "../../../src/web/search/providers/openai-compatible";
+import type { ActiveSearchModelContext } from "../../../src/web/search/types";
+
+function keyAuth(keys: Record<string, string> = {}): AuthStorage {
+	return {
+		hasAuth: (p: string) => Boolean(keys[p]),
+		hasOAuth: () => false,
+		getOAuthAccess: () => undefined,
+		getApiKey: (p: string) => keys[p],
+		getSessionCredentialType: () => "api-key",
+	} as unknown as AuthStorage;
+}
+
+const openaiCtx = (api: "openai-responses" | "openai-completions"): ActiveSearchModelContext => ({
+	provider: "proxy",
+	modelId: "gpt-5.5",
+	api,
+	baseUrl: "https://proxy.example/v1",
+});
+
+async function ocSearch(json: unknown, api: "openai-responses" | "openai-completions" = "openai-responses") {
+	using _hook = hookFetch(async () => Response.json(json));
+	return await new OpenAICompatibleSearchProvider().search({
+		query: "latest stable Bun version",
+		systemPrompt: "Search the web and cite sources.",
+		limit: 5,
+		authStorage: keyAuth({ proxy: "sk-proxy" }),
+		activeModelContext: openaiCtx(api),
+	} as any);
+}
+
+describe("OpenAI-compatible inline citation harvest (responses)", () => {
+	it("harvests inline sources when a web_search_call ran but annotations are absent", async () => {
+		const r = await ocSearch({
+			id: "resp_1",
+			output: [
+				{ type: "web_search_call", status: "completed", action: { type: "search", query: "bun" } },
+				{
+					type: "message",
+					content: [
+						{
+							type: "output_text",
+							text: "Latest stable Bun is v1.3.14. ([github.com](https://github.com/oven-sh/bun/releases))",
+						},
+					],
+				},
+			],
+		});
+		expect(r.provider).toBe("openai-compatible");
+		expect(r.sources.map(s => s.url)).toEqual(["https://github.com/oven-sh/bun/releases"]);
+	});
+
+	it("treats tool_usage.web_search.num_requests as proof of search", async () => {
+		const r = await ocSearch({
+			id: "resp_2",
+			tool_usage: { web_search: { num_requests: 2 } },
+			output: [{ type: "message", content: [{ type: "output_text", text: "See https://bun.com/ for details." }] }],
+		});
+		expect(r.sources.map(s => s.url)).toEqual(["https://bun.com/"]);
+	});
+
+	it("returns the grounded answer with empty sources when a search ran but no URLs are present", async () => {
+		const r = await ocSearch({
+			id: "resp_3",
+			output: [
+				{ type: "web_search_call", status: "completed", action: { type: "search" } },
+				{ type: "message", content: [{ type: "output_text", text: "Bun v1.3.14 is the latest stable release." }] },
+			],
+		});
+		expect(r.sources).toEqual([]);
+		expect(r.answer).toContain("1.3.14");
+	});
+
+	it("still fails closed (424) for a non-search answer that merely mentions a URL", async () => {
+		await expect(
+			ocSearch({ id: "resp_4", output_text: "I think it's around https://bun.com somewhere." }),
+		).rejects.toMatchObject({ provider: "openai-compatible", status: 424 });
+	});
+});
+
+describe("OpenAI-compatible inline citation harvest (chat completions)", () => {
+	it("harvests inline sources from a chat-completions search answer without annotations", async () => {
+		const r = await ocSearch(
+			{
+				id: "chat_1",
+				choices: [
+					{
+						message: {
+							content: "Latest stable Bun is v1.3.14. ([releases](https://github.com/oven-sh/bun/releases))",
+						},
+					},
+				],
+			},
+			"openai-completions",
+		);
+		expect(r.sources.map(s => s.url)).toEqual(["https://github.com/oven-sh/bun/releases"]);
+	});
+
+	it("fails closed (424) for a chat-completions answer with no citations", async () => {
+		await expect(
+			ocSearch(
+				{ id: "chat_2", choices: [{ message: { content: "Bun is a JavaScript runtime." } }] },
+				"openai-completions",
+			),
+		).rejects.toMatchObject({ provider: "openai-compatible", status: 424 });
+	});
+
+	it("uses structured url_citation annotations when present", async () => {
+		const r = await ocSearch(
+			{
+				id: "chat_3",
+				choices: [
+					{
+						message: {
+							content: "Bun v1.3.14.",
+							annotations: [{ type: "url_citation", url_citation: { url: "https://bun.com/", title: "Bun" } }],
+						},
+					},
+				],
+			},
+			"openai-completions",
+		);
+		expect(r.sources.map(s => s.url)).toEqual(["https://bun.com/"]);
+	});
+});
+
+describe("Anthropic inline citation harvest + fail-closed", () => {
+	const ctx: ActiveSearchModelContext = {
+		provider: "proxy",
+		modelId: "claude-sonnet-4",
+		api: "anthropic-messages",
+		baseUrl: "https://proxy.example",
+	};
+	const run = async (json: unknown) => {
+		using _hook = hookFetch(async () => Response.json(json));
+		return await new AnthropicProvider().search({
+			query: "latest stable Bun version",
+			systemPrompt: "Search the web and cite sources.",
+			limit: 5,
+			authStorage: keyAuth({ proxy: "sk-proxy" }),
+			activeModelContext: ctx,
+		} as any);
+	};
+
+	it("harvests inline sources when a search ran but only inline links were emitted", async () => {
+		const r = await run({
+			id: "msg_1",
+			model: "claude-sonnet-4",
+			usage: { input_tokens: 1, output_tokens: 1, server_tool_use: { web_search_requests: 1 } },
+			content: [
+				{ type: "server_tool_use", name: "web_search", input: { query: "bun" } },
+				{
+					type: "text",
+					text: "Latest stable Bun is v1.3.14. See [releases](https://github.com/oven-sh/bun/releases).",
+				},
+			],
+		});
+		expect(r.provider).toBe("anthropic");
+		expect(r.sources.map(s => s.url)).toEqual(["https://github.com/oven-sh/bun/releases"]);
+	});
+
+	it("keeps structured web_search_result sources when present", async () => {
+		const r = await run({
+			id: "msg_2",
+			model: "claude-sonnet-4",
+			usage: { input_tokens: 1, output_tokens: 1, server_tool_use: { web_search_requests: 1 } },
+			content: [
+				{
+					type: "web_search_tool_result",
+					content: [{ type: "web_search_result", title: "Bun", url: "https://bun.com/" }],
+				},
+				{ type: "text", text: "Bun v1.3.14." },
+			],
+		});
+		expect(r.sources.map(s => s.url)).toEqual(["https://bun.com/"]);
+	});
+
+	it("fails closed (424) when Claude answered without running a web search", async () => {
+		await expect(
+			run({
+				id: "msg_3",
+				model: "claude-sonnet-4",
+				usage: { input_tokens: 1, output_tokens: 1 },
+				content: [{ type: "text", text: "Bun is a fast JavaScript runtime (mentions https://bun.com)." }],
+			}),
+		).rejects.toMatchObject({ provider: "anthropic", status: 424 });
+	});
+});


### PR DESCRIPTION
## Summary

Native web-search providers were discarding genuinely **grounded** answers whenever the model returned its sources inline instead of as structured `url_citation` annotations — throwing `424` and falling back to DuckDuckGo even though a real web search ran. This was reproduced live against a proxy (`gpt-5.5` over an OpenAI-compatible endpoint): `tool_usage.web_search.num_requests` and `web_search_call` items proved the search happened, but the adapter rejected it. After this change the same proxy returns native results **3/3 runs**.

## Behavior

When a search **demonstrably ran**, sources are recovered from inline markdown links and bare URLs. Recovery is gated on a real-search signal so a stray prose URL in a *non-search* answer is never promoted to a citation.

Search-performed signals per wire (researched against official docs):
- **Responses** (`/v1/responses`): `output[].type === "web_search_call"` or `tool_usage.web_search.num_requests > 0`.
- **Chat Completions** (`/v1/chat/completions`): search models always search — recover inline when structured annotations are absent.
- **Anthropic Messages**: `web_search_tool_result` block / `server_tool_use`(web_search) / `usage.server_tool_use.web_search_requests`.

Anthropic now also **fails closed (`424`)** when Claude answers from stable knowledge without searching, so the chain falls through to DuckDuckGo consistently with the OpenAI-compatible and Gemini paths.

## Changes

- New shared `providers/text-citations.ts` (markdown-link + bare-URL extraction), extracted from `codex.ts` and reused by `codex`, `openai-compatible`, and `anthropic`.
- `openai-compatible.ts`: `webSearchPerformed()` signal + inline harvest for responses & chat completions; `424` only when no search ran and no sources.
- `anthropic.ts`: `anthropicSearchPerformed()` signal + inline harvest + fail-closed `424`.
- Tests: new `web-search-citation-harvest.test.ts` covering inline harvest, the empty-sources-but-searched case, and the non-search `424` guard for all three formats; adjusted two anthropic signal-wiring tests for the new fail-closed path.

## Verification

- `bun test test/web/search/` → 135 pass / 0 fail.
- Workspace `check:ts` (biome + tsgo, all packages) → green.
- Live: `OpenAICompatibleSearchProvider` against the proxy now returns native `openai-compatible` sources 3/3 runs (previously frequent `424` → DuckDuckGo).

Not merging; opening for review.