### PR TITLE
fix(web-search): fail closed on Anthropic web_search error blocks

### DIFF
--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -193,7 +193,7 @@ function parseResponse(response: AnthropicApiResponse): SearchResponse {
 			if (block.input?.query) {
 				searchQueries.push(block.input.query);
 			}
-		} else if (block.type === "web_search_tool_result" && block.content) {
+		} else if (block.type === "web_search_tool_result" && Array.isArray(block.content)) {
 			// Search results
 			for (const result of block.content) {
 				if (result.type === "web_search_result") {
@@ -245,7 +245,15 @@ function parseResponse(response: AnthropicApiResponse): SearchResponse {
 function anthropicSearchPerformed(response: AnthropicApiResponse): boolean {
 	if (response.usage?.server_tool_use?.web_search_requests) return true;
 	for (const block of response.content ?? []) {
-		if (block.type === "web_search_tool_result") return true;
+		if (block.type === "web_search_tool_result") {
+			// `content` is an array of results on success but an error OBJECT
+			// (`web_search_tool_result_error`) on failure; only count a result
+			// array with at least one real result as proof of search.
+			if (Array.isArray(block.content) && block.content.some(result => result.type === "web_search_result")) {
+				return true;
+			}
+			continue;
+		}
 		if (
 			block.type === "server_tool_use" &&
 			block.name &&

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -164,6 +164,15 @@ export interface AnthropicCitation {
 	encrypted_index: string;
 }
 
+/**
+ * Error payload returned in `web_search_tool_result.content` when a server-side
+ * web search fails. Unlike the success case, this is an object, not an array.
+ */
+export interface AnthropicWebSearchToolResultError {
+	type: "web_search_tool_result_error";
+	error_code?: string;
+}
+
 export interface AnthropicContentBlock {
 	type: string;
 	/** Text content (for type="text") */
@@ -174,8 +183,8 @@ export interface AnthropicContentBlock {
 	name?: string;
 	/** Tool input (for type="server_tool_use") */
 	input?: { query: string };
-	/** Search results (for type="web_search_tool_result") */
-	content?: AnthropicSearchResult[];
+	/** Search results array on success, or an error object on failure (type="web_search_tool_result") */
+	content?: AnthropicSearchResult[] | AnthropicWebSearchToolResultError;
 }
 
 export interface AnthropicApiResponse {

--- a/packages/coding-agent/test/web/search/web-search-citation-harvest-redteam.test.ts
+++ b/packages/coding-agent/test/web/search/web-search-citation-harvest-redteam.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "bun:test";
+import { hookFetch } from "@gajae-code/utils";
+import type { AuthStorage } from "../../../src/session/auth-storage";
+import { AnthropicProvider } from "../../../src/web/search/providers/anthropic";
+import { OpenAICompatibleSearchProvider } from "../../../src/web/search/providers/openai-compatible";
+import { extractTextSources } from "../../../src/web/search/providers/text-citations";
+import type { ActiveSearchModelContext } from "../../../src/web/search/types";
+
+function keyAuth(keys: Record<string, string> = {}): AuthStorage {
+	return {
+		hasAuth: (p: string) => Boolean(keys[p]),
+		hasOAuth: () => false,
+		getOAuthAccess: () => undefined,
+		getApiKey: (p: string) => keys[p],
+		getSessionCredentialType: () => "api-key",
+	} as unknown as AuthStorage;
+}
+
+const openaiCtx = (api: "openai-responses" | "openai-completions"): ActiveSearchModelContext => ({
+	provider: "proxy",
+	modelId: "gpt-5.5",
+	api,
+	baseUrl: "https://proxy.example/v1",
+});
+
+async function openaiSearch(json: unknown, api: "openai-responses" | "openai-completions" = "openai-responses") {
+	using _hook = hookFetch(async () => Response.json(json));
+	return await new OpenAICompatibleSearchProvider().search({
+		query: "latest stable Bun version",
+		systemPrompt: "Search the web and cite sources.",
+		limit: 5,
+		authStorage: keyAuth({ proxy: "sk-proxy" }),
+		activeModelContext: openaiCtx(api),
+	} as any);
+}
+
+const anthropicCtx: ActiveSearchModelContext = {
+	provider: "proxy",
+	modelId: "claude-sonnet-4",
+	api: "anthropic-messages",
+	baseUrl: "https://proxy.example",
+};
+
+async function anthropicSearch(json: unknown) {
+	using _hook = hookFetch(async () => Response.json(json));
+	return await new AnthropicProvider().search({
+		query: "latest stable Bun version",
+		systemPrompt: "Search the web and cite sources.",
+		limit: 5,
+		authStorage: keyAuth({ proxy: "sk-proxy" }),
+		activeModelContext: anthropicCtx,
+	} as any);
+}
+
+describe("citation harvest red-team: OpenAI-compatible responses", () => {
+	it("preserves fail-closed guard for a non-search response with a stray prose URL", async () => {
+		await expect(
+			openaiSearch({ id: "resp_stray", output_text: "I remember seeing this at https://bun.com/releases." }),
+		).rejects.toMatchObject({ provider: "openai-compatible", status: 424 });
+	});
+
+	it("returns a searched response with empty sources when the answer has only non-http tokens", async () => {
+		const result = await openaiSearch({
+			id: "resp_non_http",
+			output: [
+				{ type: "web_search_call", status: "completed", action: { type: "search", query: "bun releases" } },
+				{ type: "message", content: [{ type: "output_text", text: "Latest release is listed at bun:releases." }] },
+			],
+		});
+
+		expect(result.answer).toContain("bun:releases");
+		expect(result.sources).toEqual([]);
+	});
+
+	it("treats tool_usage.web_search.num_requests === 0 as not searched", async () => {
+		await expect(
+			openaiSearch({
+				id: "resp_zero_requests",
+				tool_usage: { web_search: { num_requests: 0 } },
+				output: [
+					{ type: "message", content: [{ type: "output_text", text: "See https://bun.com/ for details." }] },
+				],
+			}),
+		).rejects.toMatchObject({ provider: "openai-compatible", status: 424 });
+	});
+});
+
+describe("citation harvest red-team: OpenAI-compatible chat completions", () => {
+	it("fails closed for a plain chat-completions answer with no links", async () => {
+		await expect(
+			openaiSearch(
+				{ id: "chat_plain", choices: [{ message: { content: "Bun is a JavaScript runtime." } }] },
+				"openai-completions",
+			),
+		).rejects.toMatchObject({ provider: "openai-compatible", status: 424 });
+	});
+
+	it("harvests a markdown link from a chat-completions answer", async () => {
+		const result = await openaiSearch(
+			{
+				id: "chat_markdown",
+				choices: [
+					{
+						message: { content: "Latest Bun releases are on [GitHub](https://github.com/oven-sh/bun/releases)." },
+					},
+				],
+			},
+			"openai-completions",
+		);
+
+		expect(result.sources.map(source => source.url)).toEqual(["https://github.com/oven-sh/bun/releases"]);
+	});
+});
+
+describe("citation harvest red-team: Anthropic", () => {
+	it("harvests a markdown link when server_tool_use web_search is present", async () => {
+		const result = await anthropicSearch({
+			id: "msg_markdown",
+			model: "claude-sonnet-4",
+			usage: { input_tokens: 1, output_tokens: 1 },
+			content: [
+				{ type: "server_tool_use", name: "web_search", input: { query: "bun releases" } },
+				{ type: "text", text: "Latest Bun releases are on [GitHub](https://github.com/oven-sh/bun/releases)." },
+			],
+		});
+
+		expect(result.sources.map(source => source.url)).toEqual(["https://github.com/oven-sh/bun/releases"]);
+	});
+
+	it("fails closed when no search signal exists even if prose contains a URL", async () => {
+		await expect(
+			anthropicSearch({
+				id: "msg_no_search_url",
+				model: "claude-sonnet-4",
+				usage: { input_tokens: 1, output_tokens: 1 },
+				content: [{ type: "text", text: "I remember the release notes are around https://bun.com/ somewhere." }],
+			}),
+		).rejects.toMatchObject({ provider: "anthropic", status: 424 });
+	});
+
+	it("fails closed for a web_search_tool_result_error block with no results or citations", async () => {
+		await expect(
+			anthropicSearch({
+				id: "msg_search_error",
+				model: "claude-sonnet-4",
+				usage: { input_tokens: 1, output_tokens: 1 },
+				content: [
+					{
+						type: "web_search_tool_result",
+						content: { type: "web_search_tool_result_error", error_code: "max_uses_exceeded" },
+					},
+					{ type: "text", text: "I could not retrieve current release sources." },
+				],
+			}),
+		).rejects.toMatchObject({ provider: "anthropic", status: 424 });
+	});
+});
+
+describe("citation harvest red-team: text source extraction", () => {
+	it("normalizes valid URLs and drops malformed or non-http URL-like garbage", () => {
+		expect(
+			extractTextSources(
+				"Bad: [ftp](ftp://example.com), [broken](https://), https://exa mple.com, javascript:alert(1), http://[::1. Good: [release](https://bun.com/releases).",
+			)
+				.map(source => source.url)
+				.sort(),
+		).toEqual(["https://bun.com/releases", "https://exa/"]);
+	});
+});


### PR DESCRIPTION
## Summary

QA/red-team follow-up to #1060 (citation harvest for native web search). The Anthropic search-performed detector counted **any** `web_search_tool_result` block as proof a search ran — including an **error-only** block whose `content` is the object `{type:"web_search_tool_result_error", error_code}` (per the Claude API, the failure payload is an object, **not** an array of results).

Two concrete defects:
1. A failed search (e.g. `max_uses_exceeded`) with no results and no citations would **resolve** instead of failing closed to DuckDuckGo.
2. `parseResponse`'s `for..of` over `content` would **throw** on the real object-shaped error payload (the type previously declared `content` as always an array).

## Fix
- `anthropicSearchPerformed`: only treat a `web_search_tool_result` block as searched when `Array.isArray(content)` **and** it contains at least one `web_search_result`. `server_tool_use`(web_search) and a non-zero `usage.server_tool_use.web_search_requests` remain independent search signals.
- `parseResponse`: guard the result iteration with `Array.isArray(content)`.
- Types: add `AnthropicWebSearchToolResultError` and widen `AnthropicContentBlock.content` to `AnthropicSearchResult[] | AnthropicWebSearchToolResultError`.
- Adds `web-search-citation-harvest-redteam.test.ts` covering the **real object-shaped** error payload (→ 424) plus the search-signal gating guards across Responses/Chat-Completions/Anthropic.

## Verification
- `bun test test/web/search/` → 135 pass / 0 fail; new red-team file 9 pass.
- Workspace `check:ts` (biome + tsgo) → green.
- Reviewed: architect 3-lane **CLEAR/CLEAR/CLEAR → APPROVE** (this was the sole blocker it identified, now resolved); executor QA/red-team found and validated the fix.

Not merging; opening for review.