### PR TITLE
fix(web-search): prefer Responses API for openai-compatible native search

### DIFF
--- a/packages/coding-agent/src/web/search/providers/openai-compatible.ts
+++ b/packages/coding-agent/src/web/search/providers/openai-compatible.ts
@@ -108,35 +108,44 @@ export class OpenAICompatibleSearchProvider extends SearchProvider {
 		});
 		if (!apiKey) throw new SearchProviderError(this.id, `No credentials for ${ctx.provider}`, 401);
 		const model = ctx.wireModelId ?? ctx.modelId;
+		const baseUrl = ctx.baseUrl ?? "";
 		const headers = { ...(ctx.headers ?? {}), Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" };
-		const body =
-			ctx.api === "openai-completions"
-				? {
-						model,
-						messages: [
-							{ role: "system", content: params.systemPrompt },
-							{ role: "user", content: params.query },
-						],
-						web_search_options: {},
-						temperature: params.temperature,
-						max_tokens: params.maxOutputTokens,
-					}
-				: {
-						model,
-						input: [
-							{ role: "system", content: params.systemPrompt },
-							{ role: "user", content: params.query },
-						],
-						tools: [{ type: "web_search" }],
-						temperature: params.temperature,
-						max_output_tokens: params.maxOutputTokens,
-					};
-		const response = await fetch(endpoint(ctx.baseUrl ?? "", ctx.api), {
-			method: "POST",
-			headers,
-			body: JSON.stringify(body),
-			signal: withHardTimeout(params.signal),
-		});
+		const messages = [
+			{ role: "system", content: params.systemPrompt },
+			{ role: "user", content: params.query },
+		];
+		const responsesBody = {
+			model,
+			input: messages,
+			tools: [{ type: "web_search" }],
+			temperature: params.temperature,
+			max_output_tokens: params.maxOutputTokens,
+		};
+		const chatBody = {
+			model,
+			messages,
+			web_search_options: {},
+			temperature: params.temperature,
+			max_tokens: params.maxOutputTokens,
+		};
+
+		const post = (api: "openai-responses" | "openai-completions", payload: unknown) =>
+			fetch(endpoint(baseUrl, api), {
+				method: "POST",
+				headers,
+				body: JSON.stringify(payload),
+				signal: withHardTimeout(params.signal),
+			});
+
+		// Web search is a Responses-API capability: many OpenAI-compatible
+		// endpoints (incl. proxies fronting chat-only models) only ground search
+		// through `/responses`, while `/chat/completions` answers from the model's
+		// stale knowledge. Prefer `/responses` regardless of the model's chat wire,
+		// and fall back to `/chat/completions` only when `/responses` is absent.
+		let response = await post("openai-responses", responsesBody);
+		if (response.status === 404 || response.status === 405) {
+			response = await post("openai-completions", chatBody);
+		}
 		const text = await response.text();
 		if (!response.ok) {
 			const classified = classifyProviderHttpError(this.id, response.status, text);
@@ -153,12 +162,11 @@ export class OpenAICompatibleSearchProvider extends SearchProvider {
 		const limit = params.limit ?? params.numSearchResults ?? 10;
 		let sources = toSources(citations, limit);
 		const searched = webSearchPerformed(json);
-		// When a search demonstrably ran (Responses `web_search_call` / `tool_usage`)
-		// or this is a Chat Completions search request, recover inline-cited sources
-		// from the answer text if the model omitted structured `url_citation`
-		// annotations. Gating on a real search signal preserves the guard against
-		// promoting a stray prose URL in a non-search answer to a citation.
-		if (sources.length === 0 && answer && (searched || ctx.api === "openai-completions")) {
+		// Recover inline-cited sources only when a search demonstrably ran
+		// (Responses `web_search_call` / `tool_usage.web_search`). This refuses to
+		// promote a model's guessed prose URLs from a non-search answer — exactly
+		// what a chat endpoint that ignores `web_search_options` returns.
+		if (sources.length === 0 && searched && answer) {
 			sources = extractTextSources(answer).slice(0, limit);
 		}
 		if (sources.length === 0 && !searched) {

--- a/packages/coding-agent/test/web/search/openai-compatible-provider.test.ts
+++ b/packages/coding-agent/test/web/search/openai-compatible-provider.test.ts
@@ -40,9 +40,13 @@ describe("OpenAI-compatible web search provider", () => {
 		expect(body.model).toBe("gpt-5-mini");
 	});
 
-	it("sends Chat Completions requests with web_search_options", async () => {
+	it("falls back to Chat Completions with web_search_options when /responses is absent", async () => {
 		let body: any;
-		using _hook = hookFetch(async (_input, init) => {
+		const urls: string[] = [];
+		using _hook = hookFetch(async (input, init) => {
+			const url = String(input);
+			urls.push(url);
+			if (url.endsWith("/responses")) return new Response("not found", { status: 404 });
 			body = JSON.parse(String(init?.body));
 			return Response.json({
 				choices: [
@@ -55,9 +59,44 @@ describe("OpenAI-compatible web search provider", () => {
 				],
 			});
 		});
-		await new OpenAICompatibleSearchProvider().search(params({ ...baseCtx, api: "openai-completions" }));
+		const result = await new OpenAICompatibleSearchProvider().search(
+			params({ ...baseCtx, api: "openai-completions" }),
+		);
+		// Tried /responses first, then fell back to /chat/completions.
+		expect(urls.some(u => u.endsWith("/responses"))).toBe(true);
+		expect(urls.some(u => u.endsWith("/chat/completions"))).toBe(true);
 		expect(body.web_search_options).toEqual({});
 		expect(body.messages[1].content).toBe("news");
+		expect(result.sources).toEqual([{ title: "B", url: "https://b.example", snippet: undefined }]);
+	});
+
+	it("prefers /responses for search even when the model's chat wire is openai-completions", async () => {
+		const urls: string[] = [];
+		using _hook = hookFetch(async input => {
+			urls.push(String(input));
+			return Response.json({
+				id: "r-pref",
+				output: [
+					{ type: "web_search_call", status: "completed", action: { type: "search" } },
+					{
+						type: "message",
+						content: [
+							{
+								type: "output_text",
+								text: "grounded",
+								annotations: [{ type: "url_citation", url: "https://r.example", title: "R" }],
+							},
+						],
+					},
+				],
+			});
+		});
+		const result = await new OpenAICompatibleSearchProvider().search(
+			params({ ...baseCtx, api: "openai-completions" }),
+		);
+		expect(urls).toHaveLength(1);
+		expect(urls[0]?.endsWith("/responses")).toBe(true);
+		expect(result.sources).toEqual([{ title: "R", url: "https://r.example", snippet: undefined }]);
 	});
 
 	it("parses citations into sources", async () => {

--- a/packages/coding-agent/test/web/search/web-search-citation-harvest-redteam.test.ts
+++ b/packages/coding-agent/test/web/search/web-search-citation-harvest-redteam.test.ts
@@ -95,20 +95,22 @@ describe("citation harvest red-team: OpenAI-compatible chat completions", () => 
 		).rejects.toMatchObject({ provider: "openai-compatible", status: 424 });
 	});
 
-	it("harvests a markdown link from a chat-completions answer", async () => {
-		const result = await openaiSearch(
-			{
-				id: "chat_markdown",
-				choices: [
-					{
-						message: { content: "Latest Bun releases are on [GitHub](https://github.com/oven-sh/bun/releases)." },
-					},
-				],
-			},
-			"openai-completions",
-		);
-
-		expect(result.sources.map(source => source.url)).toEqual(["https://github.com/oven-sh/bun/releases"]);
+	it("does not harvest a markdown link from a chat answer with no search signal (anti-masking)", async () => {
+		await expect(
+			openaiSearch(
+				{
+					id: "chat_markdown",
+					choices: [
+						{
+							message: {
+								content: "Latest Bun releases are on [GitHub](https://github.com/oven-sh/bun/releases).",
+							},
+						},
+					],
+				},
+				"openai-completions",
+			),
+		).rejects.toMatchObject({ provider: "openai-compatible", status: 424 });
 	});
 });
 

--- a/packages/coding-agent/test/web/search/web-search-citation-harvest.test.ts
+++ b/packages/coding-agent/test/web/search/web-search-citation-harvest.test.ts
@@ -83,21 +83,24 @@ describe("OpenAI-compatible inline citation harvest (responses)", () => {
 });
 
 describe("OpenAI-compatible inline citation harvest (chat completions)", () => {
-	it("harvests inline sources from a chat-completions search answer without annotations", async () => {
-		const r = await ocSearch(
-			{
-				id: "chat_1",
-				choices: [
-					{
-						message: {
-							content: "Latest stable Bun is v1.3.14. ([releases](https://github.com/oven-sh/bun/releases))",
+	it("fails closed for inline links in a chat answer with no search signal (anti-masking)", async () => {
+		// A chat endpoint that ignored web search returns prose URLs with no
+		// web_search_call / tool_usage; those guessed URLs must NOT be harvested.
+		await expect(
+			ocSearch(
+				{
+					id: "chat_1",
+					choices: [
+						{
+							message: {
+								content: "Latest stable Bun is v1.3.14. ([releases](https://github.com/oven-sh/bun/releases))",
+							},
 						},
-					},
-				],
-			},
-			"openai-completions",
-		);
-		expect(r.sources.map(s => s.url)).toEqual(["https://github.com/oven-sh/bun/releases"]);
+					],
+				},
+				"openai-completions",
+			),
+		).rejects.toMatchObject({ provider: "openai-compatible", status: 424 });
 	});
 
 	it("fails closed (424) for a chat-completions answer with no citations", async () => {


### PR DESCRIPTION
## Problem

After #1060/#1061, Anthropic native search works, but **gpt-5.5 still effectively used DuckDuckGo**. Root cause: the active gpt-5.5 model (via the layofflabs proxy) is configured `api: openai-completions`. Web search is fundamentally a **Responses-API** capability — the proxy's `/chat/completions` answers from stale knowledge (it literally replied *"I don't have live web-browsing access in this chat"*, no annotations, no `tool_usage`), while its `/responses` endpoint **does** perform real web search.

The old adapter dispatched search by the model's chat wire, so an `openai-completions` model either:
- 424'd → fell back to DuckDuckGo, or
- worse, had the model's **guessed prose URLs** harvested as fake "sources".

## Fix

- `OpenAICompatibleSearchProvider.search` now POSTs **`/responses`** (with the `web_search` tool) **first, regardless of the model's chat `api`**, and falls back to `/chat/completions` (`web_search_options`) only on **404/405** (endpoint absent).
- Inline-citation recovery is gated **strictly on a real search signal** (`web_search_call` / `tool_usage.web_search`). The previous chat-wire inline allowance — which promoted guessed prose URLs — is removed (anti-masking).

## Verification (real LLM wiring)

Ran the adapter with the **exact** `getActiveSearchModelContext` shape for gpt-5.5 (`provider: layofflabs, api: openai-completions, baseUrl: https://api.layofflabs.com/v1`) against the live proxy:

```
run 1: provider=openai-compatible sources=2 -> github.com/oven-sh/bun/releases/latest , bun.sh/guides/util
run 2: provider=openai-compatible sources=2 -> github.com/oven-sh/bun/releases , github.com/oven-sh/bun
run 3: provider=openai-compatible sources=2 -> github.com/oven-sh/bun/releases?utm_source=openai , bun.com/?utm_source=openai
3/3 runs returned native results (was: 424->DuckDuckGo or guessed prose URLs)
```

`utm_source=openai` confirms genuine search-engine-sourced results via the Responses `web_search` tool.

## Tests
- `test/web/search/openai-compatible-provider.test.ts`: responses-first preference even on `openai-completions` wire; `/responses` 404 → `/chat/completions` fallback with `web_search_options`.
- Harvest + red-team tests updated: chat answers with inline links but **no search signal** now fail closed (anti-masking) instead of harvesting guesses.
- `bun test test/web/search/` → 136 pass / 0 fail; workspace `check:ts` green.
