### PR TITLE
fix(web-search): restrict codex provider to official OpenAI endpoints

### DIFF
--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -240,14 +240,41 @@ export function isLocalBaseUrl(baseUrl: string | undefined): boolean {
 	return false;
 }
 
+/**
+ * Whether `baseUrl` is an official OpenAI endpoint (or absent, i.e. the default
+ * hosted OpenAI). The dedicated `codex` provider authenticates against the
+ * ChatGPT backend with the user's *local* Codex OAuth, so it must only be
+ * selected when the active model is genuinely served by OpenAI/ChatGPT — never
+ * for a custom/proxy endpoint, which should reuse its own credentials through
+ * the `openai-compatible` adapter instead.
+ */
+function isOpenAIOfficialBaseUrl(baseUrl: string | undefined): boolean {
+	if (!baseUrl?.trim()) return true;
+	let host: string;
+	try {
+		host = new URL(baseUrl).hostname.toLowerCase();
+	} catch {
+		return false;
+	}
+	return (
+		host === "api.openai.com" ||
+		host === "chatgpt.com" ||
+		host.endsWith(".openai.com") ||
+		host.endsWith(".chatgpt.com")
+	);
+}
+
 export function inferNativeProviderFromModel(ctx: ActiveSearchModelContext | undefined): SearchProviderId | undefined {
 	if (!ctx || ctx.webSearch === "off") return undefined;
 	const modelId = (ctx.wireModelId ?? ctx.modelId).toLowerCase();
 	if (modelId.startsWith("claude-") && isAnthropicWire(ctx.api)) return "anthropic";
 	if (modelId.startsWith("gemini-") && isGoogleWire(ctx.api)) return "gemini";
 	if (looksXaiFamilyModelId(ctx) && isOpenAICompatWire(ctx.api)) return "xai";
-	if (looksOpenAIFamilyModelId(ctx) && isOpenAICompatWire(ctx.api)) {
-		if (ctx.webSearch === "on" || !isLocalBaseUrl(ctx.baseUrl)) return "codex";
+	// `codex` hits the ChatGPT backend with local Codex OAuth, so only infer it
+	// for genuine OpenAI endpoints. Custom/proxy OpenAI-compatible models fall
+	// through to `activeContextNativeId` → `openai-compatible` (their own creds).
+	if (looksOpenAIFamilyModelId(ctx) && isOpenAICompatWire(ctx.api) && isOpenAIOfficialBaseUrl(ctx.baseUrl)) {
+		return "codex";
 	}
 	return undefined;
 }
@@ -255,8 +282,9 @@ export function inferNativeProviderFromModel(ctx: ActiveSearchModelContext | und
 function canUseDirectProviderMapping(ctx: ActiveSearchModelContext, id: SearchProviderId): boolean {
 	if (ctx.webSearch === "off") return false;
 	if (id !== "codex") return true;
-	if (!isOpenAICompatWire(ctx.api)) return true;
-	return ctx.webSearch === "on" || !isLocalBaseUrl(ctx.baseUrl);
+	// Same constraint as inference: the ChatGPT-backed codex provider is valid
+	// only for official OpenAI endpoints, not custom/proxy base URLs.
+	return isOpenAIOfficialBaseUrl(ctx.baseUrl);
 }
 
 export async function canUseGenericCredentials(

--- a/packages/coding-agent/test/web/search/provider-resolution.test.ts
+++ b/packages/coding-agent/test/web/search/provider-resolution.test.ts
@@ -207,7 +207,7 @@ describe("native web-search provider resolution", () => {
 				{ provider: "proxy", modelId: "gpt-5", api: "openai-responses", baseUrl: "https://models.example" },
 				{ auth: ["openai-codex", "proxy"] },
 			),
-		).resolves.toEqual(["codex", "duckduckgo"]);
+		).resolves.toEqual(["openai-compatible", "duckduckgo"]);
 		await expect(
 			ids(
 				{ provider: "proxy", modelId: "gpt-5", api: "anthropic-messages", baseUrl: "https://models.example" },
@@ -261,5 +261,21 @@ describe("native web-search provider resolution", () => {
 				{ auth: [] },
 			),
 		).resolves.toEqual(["duckduckgo"]);
+	});
+
+	it("uses openai-compatible (not local-OAuth codex) for a codex/gpt model served through a proxy", async () => {
+		// Regression: a Codex-via-proxy setup must reuse the proxy's own creds, not
+		// the user's local Codex OAuth (which hits chatgpt.com and 429s on its own plan).
+		await expect(
+			ids(
+				{
+					provider: "layofflabs",
+					modelId: "gpt-5.3-codex-spark",
+					api: "openai-completions",
+					baseUrl: "https://api.layofflabs.com/v1",
+				},
+				{ auth: ["openai-codex", "layofflabs"] },
+			),
+		).resolves.toEqual(["openai-compatible", "duckduckgo"]);
 	});
 });

--- a/packages/coding-agent/test/web/search/web-search-citation-harvest.test.ts
+++ b/packages/coding-agent/test/web/search/web-search-citation-harvest.test.ts
@@ -23,7 +23,15 @@ const openaiCtx = (api: "openai-responses" | "openai-completions"): ActiveSearch
 });
 
 async function ocSearch(json: unknown, api: "openai-responses" | "openai-completions" = "openai-responses") {
-	using _hook = hookFetch(async () => Response.json(json));
+	using _hook = hookFetch(async input => {
+		// Chat-wire contexts exercise the real responses-first control flow: the
+		// mock proxy has no /responses (404), so the adapter falls back to
+		// /chat/completions and parses the supplied chat-shaped payload.
+		if (api === "openai-completions" && String(input).endsWith("/responses")) {
+			return new Response("not found", { status: 404 });
+		}
+		return Response.json(json);
+	});
 	return await new OpenAICompatibleSearchProvider().search({
 		query: "latest stable Bun version",
 		systemPrompt: "Search the web and cite sources.",

--- a/packages/coding-agent/test/web/search/web-search-redteam.test.ts
+++ b/packages/coding-agent/test/web/search/web-search-redteam.test.ts
@@ -118,9 +118,14 @@ describe("red-team native-provider inference", () => {
 		await expect(chainIds(ctx, { auth: ["codex", "openai-codex"] })).resolves.toEqual(["duckduckgo"]);
 	});
 
-	it("selects codex for hosted OpenAI-family models only when Codex credentials exist", async () => {
-		await expect(chainIds(hostedOpenAI, { auth: [] })).resolves.toEqual(["duckduckgo"]);
-		await expect(chainIds(hostedOpenAI, { auth: ["openai-codex"] })).resolves.toEqual(["codex", "duckduckgo"]);
+	it("selects codex only for official OpenAI base URLs, never for custom/proxy endpoints", async () => {
+		const officialOpenAI = { ...hostedOpenAI, provider: "openai", baseUrl: "https://api.openai.com/v1" };
+		// Official OpenAI endpoint + Codex OAuth → dedicated codex (ChatGPT backend).
+		await expect(chainIds(officialOpenAI, { auth: [] })).resolves.toEqual(["duckduckgo"]);
+		await expect(chainIds(officialOpenAI, { auth: ["openai-codex"] })).resolves.toEqual(["codex", "duckduckgo"]);
+		// A custom/proxy endpoint must NOT use the local-OAuth codex backend even
+		// when Codex OAuth exists; with no own creds here it falls to DuckDuckGo.
+		await expect(chainIds(hostedOpenAI, { auth: ["openai-codex"] })).resolves.toEqual(["duckduckgo"]);
 	});
 
 	it("never selects hosted codex for ambiguous OpenAI-family ids on local baseUrls", async () => {

--- a/packages/coding-agent/test/web/search/web-search-responses-first-redteam.test.ts
+++ b/packages/coding-agent/test/web/search/web-search-responses-first-redteam.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "bun:test";
+import { hookFetch } from "@gajae-code/utils";
+import type { AuthStorage } from "../../../src/session/auth-storage";
+import { OpenAICompatibleSearchProvider } from "../../../src/web/search/providers/openai-compatible";
+import type { ActiveSearchModelContext } from "../../../src/web/search/types";
+
+function auth(keys: Record<string, string> = { proxy: "sk-proxy" }): AuthStorage {
+	return {
+		getApiKey: (provider: string) => keys[provider],
+	} as unknown as AuthStorage;
+}
+
+const ctx: ActiveSearchModelContext = {
+	provider: "proxy",
+	modelId: "gpt-redteam",
+	api: "openai-completions",
+	baseUrl: "https://proxy.example/v1",
+	headers: { "X-Trace": "redteam", "X-Client": "gjc" },
+};
+
+function searchParams(activeModelContext: ActiveSearchModelContext = ctx) {
+	return {
+		query: "latest grounded result",
+		systemPrompt: "Search the web and cite sources.",
+		limit: 5,
+		authStorage: auth(),
+		activeModelContext,
+	};
+}
+
+function responseWithAnnotation(url = "https://responses.example/source") {
+	return {
+		id: "resp_ok",
+		output: [
+			{ type: "web_search_call", status: "completed", action: { type: "search" } },
+			{
+				type: "message",
+				content: [
+					{
+						type: "output_text",
+						text: "grounded answer",
+						annotations: [{ type: "url_citation", url, title: "Responses Source" }],
+					},
+				],
+			},
+		],
+	};
+}
+
+describe("OpenAI-compatible responses-first red-team", () => {
+	it("hits /responses first even for an openai-completions context", async () => {
+		const urls: string[] = [];
+		using _hook = hookFetch(async input => {
+			urls.push(String(input));
+			return Response.json(responseWithAnnotation());
+		});
+
+		const result = await new OpenAICompatibleSearchProvider().search(searchParams());
+
+		expect(urls).toEqual(["https://proxy.example/v1/responses"]);
+		expect(result.sources.map(s => s.url)).toEqual(["https://responses.example/source"]);
+	});
+
+	it("falls back after 404 from /responses, preserves order, and parses chat annotations", async () => {
+		const urls: string[] = [];
+		using _hook = hookFetch(async input => {
+			const url = String(input);
+			urls.push(url);
+			if (url.endsWith("/responses")) return new Response("missing", { status: 404 });
+			expect(url).toBe("https://proxy.example/v1/chat/completions");
+			return Response.json({
+				id: "chat_404_fallback",
+				choices: [
+					{
+						message: {
+							content: "chat fallback answer",
+							annotations: [{ type: "url_citation", url: "https://chat.example/404", title: "Chat 404" }],
+						},
+					},
+				],
+			});
+		});
+
+		const result = await new OpenAICompatibleSearchProvider().search(searchParams());
+
+		expect(urls).toEqual(["https://proxy.example/v1/responses", "https://proxy.example/v1/chat/completions"]);
+		expect(result.sources).toEqual([{ title: "Chat 404", url: "https://chat.example/404", snippet: undefined }]);
+	});
+
+	it("falls back after 405 from /responses", async () => {
+		const urls: string[] = [];
+		using _hook = hookFetch(async input => {
+			const url = String(input);
+			urls.push(url);
+			if (url.endsWith("/responses")) return new Response("method not allowed", { status: 405 });
+			return Response.json({
+				id: "chat_405_fallback",
+				choices: [
+					{
+						message: {
+							content: "chat fallback answer",
+							annotations: [{ type: "url_citation", url: "https://chat.example/405", title: "Chat 405" }],
+						},
+					},
+				],
+			});
+		});
+
+		const result = await new OpenAICompatibleSearchProvider().search(searchParams());
+
+		expect(urls).toEqual(["https://proxy.example/v1/responses", "https://proxy.example/v1/chat/completions"]);
+		expect(result.sources.map(s => s.url)).toEqual(["https://chat.example/405"]);
+	});
+
+	it("surfaces non-404/405 /responses errors without falling back", async () => {
+		const urls: string[] = [];
+		using _hook = hookFetch(async input => {
+			urls.push(String(input));
+			return new Response("upstream exploded", { status: 500 });
+		});
+
+		await expect(new OpenAICompatibleSearchProvider().search(searchParams())).rejects.toMatchObject({
+			provider: "openai-compatible",
+			status: 500,
+		});
+		expect(urls).toEqual(["https://proxy.example/v1/responses"]);
+	});
+
+	it("harvests inline-only response sources only when web_search_call proves search ran", async () => {
+		using _hook = hookFetch(async () =>
+			Response.json({
+				id: "resp_inline",
+				output: [
+					{ type: "web_search_call", status: "completed", action: { type: "search", query: "latest" } },
+					{
+						type: "message",
+						content: [
+							{
+								type: "output_text",
+								text: "The grounded result is documented at [release notes](https://inline.example/releases).",
+							},
+						],
+					},
+				],
+			}),
+		);
+
+		const result = await new OpenAICompatibleSearchProvider().search(searchParams());
+
+		expect(result.sources.map(s => s.url)).toEqual(["https://inline.example/releases"]);
+	});
+
+	it("fails closed with 424 when responses has no search signal but mentions a prose URL", async () => {
+		using _hook = hookFetch(async () =>
+			Response.json({
+				id: "resp_no_signal",
+				output_text: "This ordinary model answer mentions https://masked.example/ but search did not run.",
+				output: [
+					{
+						type: "message",
+						content: [
+							{
+								type: "output_text",
+								text: "Also see [masked](https://masked.example/docs).",
+							},
+						],
+					},
+				],
+			}),
+		);
+
+		await expect(new OpenAICompatibleSearchProvider().search(searchParams())).rejects.toMatchObject({
+			provider: "openai-compatible",
+			status: 424,
+		});
+	});
+
+	it("sends bearer credentials and context headers on both responses and chat fallback POSTs", async () => {
+		const seen: Array<{ url: string; method?: string; authorization?: string; trace?: string; client?: string }> = [];
+		using _hook = hookFetch(async (input, init) => {
+			const headers = init?.headers as Record<string, string>;
+			const url = String(input);
+			seen.push({
+				url,
+				method: init?.method,
+				authorization: headers.Authorization,
+				trace: headers["X-Trace"],
+				client: headers["X-Client"],
+			});
+			if (url.endsWith("/responses")) return new Response("missing", { status: 404 });
+			return Response.json({
+				id: "chat_headers",
+				choices: [
+					{
+						message: {
+							content: "chat fallback answer",
+							annotations: [{ type: "url_citation", url: "https://headers.example/", title: "Headers" }],
+						},
+					},
+				],
+			});
+		});
+
+		await new OpenAICompatibleSearchProvider().search(searchParams());
+
+		expect(seen).toEqual([
+			{
+				url: "https://proxy.example/v1/responses",
+				method: "POST",
+				authorization: "Bearer sk-proxy",
+				trace: "redteam",
+				client: "gjc",
+			},
+			{
+				url: "https://proxy.example/v1/chat/completions",
+				method: "POST",
+				authorization: "Bearer sk-proxy",
+				trace: "redteam",
+				client: "gjc",
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Problem

After the responses-first fix (#1064), a model served through a **custom/proxy** endpoint (e.g. a Codex/gpt model routed via a proxy) was still selected as the dedicated **`codex`** search provider. That provider authenticates against the **ChatGPT backend with the user's LOCAL Codex OAuth** — so web search hit the user's personal ChatGPT plan and failed:

```
Error: All web search providers failed: Codex API error (429):
{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"pro",...}}; duckduckgo: rate-limited (202)
```

i.e. it ignored the proxy entirely and burned the local plan, then fell to a rate-limited DuckDuckGo.

## Fix

The dedicated `codex` provider is only valid for **genuine OpenAI/ChatGPT endpoints**. Gate its selection on `isOpenAIOfficialBaseUrl(ctx.baseUrl)` (`api.openai.com` / `chatgpt.com` / `*.openai.com` / `*.chatgpt.com`, or no baseUrl = default hosted):

- `inferNativeProviderFromModel`: infer `codex` only for official OpenAI base URLs.
- `canUseDirectProviderMapping`: same constraint for the `openai|openai-codex|openai-responses → codex` direct mapping.

Custom/proxy OpenAI-compatible models now fall through to `activeContextNativeId` → **`openai-compatible`**, which reuses the model's **own** credentials + `/responses` (the responses-first path from #1064). Also resolves the architect WATCH from #1064 by making the chat-harvest test helper 404 `/responses` so those tests exercise the real `/chat/completions` fallback route.

## Verification (real LLM wiring)

`resolveProviderChain` for the exact failing scenario — a Codex/gpt model via the proxy **with local Codex OAuth present**:

```
ctx = { provider: layofflabs, modelId: gpt-5.3-codex-spark, api: openai-completions, baseUrl: https://api.layofflabs.com/v1 }
auth = { openai-codex OAuth + layofflabs key }
resolved chain: openai-compatible -> duckduckgo      (was: codex -> duckduckgo -> 429)
```

Live adapter call against the proxy with that codex-named model:

```
OK provider=openai-compatible sources=2 -> https://github.com/oven-sh/bun/releases/latest , https://bun.com/
```

## Tests
- New regression test: codex/gpt model via proxy with local Codex OAuth → `openai-compatible`, not `codex`.
- Updated codex selection contracts (codex only for official OpenAI base URLs).
- `bun test test/web/search/` → 144 pass / 0 fail; workspace `check:ts` green.
