### PR TITLE
test(web-search): repair codex gate CI expectations

### DIFF
--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -69,7 +69,7 @@ async function chainIds(
 							: activeModelProvider.includes("kimi")
 								? "anthropic-messages"
 								: "openai-responses",
-				baseUrl: "https://api.example.com",
+				baseUrl: activeModelProvider.startsWith("openai") ? "https://api.openai.com/v1" : "https://api.example.com",
 			}
 		: undefined;
 	const providers = await resolveProviderChain({ authStorage, preferredProvider, activeModelContext });

--- a/packages/coding-agent/test/web/search/web-search-codex-gate-redteam.test.ts
+++ b/packages/coding-agent/test/web/search/web-search-codex-gate-redteam.test.ts
@@ -28,7 +28,10 @@ async function chainIds(ctx?: ActiveSearchModelContext, providers: string[] = []
 	return chain.map(provider => provider.id);
 }
 
-function openAIContext(baseUrl: string | undefined, overrides: Partial<ActiveSearchModelContext> = {}): ActiveSearchModelContext {
+function openAIContext(
+	baseUrl: string | undefined,
+	overrides: Partial<ActiveSearchModelContext> = {},
+): ActiveSearchModelContext {
 	return {
 		provider: "openai",
 		modelId: "gpt-5",


### PR DESCRIPTION
## Summary
- format the codex official-endpoint red-team test so coding-agent check passes
- update the older DuckDuckGo provider-chain fixture to model OpenAI registry providers with an official OpenAI base URL, matching the new codex gate contract

## Verification
- bun --cwd=packages/natives run build
- bun --cwd=packages/coding-agent run check
- bun test packages/coding-agent/test/tools/web-search-duckduckgo.test.ts packages/coding-agent/test/web/search/web-search-codex-gate-redteam.test.ts

Fixes the current dev CI failure on run 28072660223.