### PR TITLE
fix(agent): wire harmony-leak detection + cover leaked <invoke> dialect

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -17,9 +17,12 @@ import {
 import { sanitizeText } from "@gajae-code/utils";
 import {
 	createHarmonyAuditEvent,
+	detectHarmonyLeakInAssistantMessage,
+	extractHarmonyRemoved,
 	type HarmonyDetection,
 	type HarmonyRecoveredToolCall,
 	isHarmonyLeakMitigationTarget,
+	recoverHarmonyToolCall,
 	signalListLabel,
 } from "./harmony-leak";
 import { type AgentRunCoverage, type AgentRunSummary, ToolCallBlockedError } from "./run-collector";
@@ -502,6 +505,20 @@ async function runLoopBody(
 					streamFn,
 					harmonyRetryAttempt,
 				);
+				// Post-stream harmony-leak detection. The mitigation scaffolding
+				// below (HarmonyLeakInterruption catch + retry/recover/audit,
+				// plus harmonyAbortController) existed but nothing invoked the
+				// detector, so leaks on openai-codex models were never caught.
+				// Detect on the completed message and route recoverable tool-arg
+				// leaks through recovery, everything else through abort-retry.
+				if (isHarmonyLeakMitigationTarget(config.model)) {
+					const detection = detectHarmonyLeakInAssistantMessage(message);
+					if (detection) {
+						const rec = recoverHarmonyToolCall(message, detection);
+						const removed = rec ? rec.removed : extractHarmonyRemoved(message, detection);
+						throw new HarmonyLeakInterruption(detection, removed, rec);
+					}
+				}
 				harmonyRetryAttempt = 0;
 				harmonyTruncateResumeCount = 0;
 			} catch (err) {
@@ -516,6 +533,15 @@ async function runLoopBody(
 					harmonyTruncateResumeCount++;
 					recovered = err.recovered;
 					message = recovered.message;
+					// Replace the contaminated assistant message committed during
+					// streaming with the recovered (truncated) one so the retry
+					// sees clean history.
+					{
+						const idx = currentContext.messages.length - 1;
+						if (idx >= 0 && currentContext.messages[idx]?.role === "assistant") {
+							currentContext.messages[idx] = recovered.message;
+						}
+					}
 					await emitHarmonyAudit(config, err, "truncate_resume", harmonyRetryAttempt);
 				} else {
 					if (harmonyRetryAttempt >= 2) {
@@ -526,6 +552,15 @@ async function runLoopBody(
 					}
 					await emitHarmonyAudit(config, err, "abort_retry", harmonyRetryAttempt);
 					harmonyRetryAttempt++;
+					// Drop the contaminated assistant message committed during
+					// streaming so the retry does not replay the model's own leak
+					// back to it as history.
+					{
+						const idx = currentContext.messages.length - 1;
+						if (idx >= 0 && currentContext.messages[idx]?.role === "assistant") {
+							currentContext.messages.splice(idx, 1);
+						}
+					}
 					continue;
 				}
 			}

--- a/packages/agent/src/harmony-leak.ts
+++ b/packages/agent/src/harmony-leak.ts
@@ -14,6 +14,19 @@ import type { AssistantMessage, Model, ToolCall } from "@gajae-code/ai";
 const MARKER_RE = /\bto=functions\.[A-Za-z_]\w*/g;
 const HARMONY_RE = /<\|(start|end|channel|message|call|return)\|>/g;
 
+// Leaked tool-call envelope (`I`): a structurally-committed Anthropic-style
+// invoke block (an opening tag carrying a name attribute). openai-codex models
+// use native function calling, so such an envelope appearing as visible
+// assistant text / thinking is always a leaked tool call — a different dialect
+// of the §1 phenomenon where the tool-call intent collapses into the content
+// channel (frequently prefixed by a glitch token such as a bare `court` line).
+// High precision: requires the opening tag AND a committed body (a parameter
+// tag or a closing invoke tag) within a short window, so prose that merely
+// mentions the tag does not trip. Like `H`, it trips on its own (outside code
+// fences). Source spelled with `\s` so this module does not self-trip.
+const INVOKE_OPEN_RE = /<invoke\s+name="[^"]+"\s*>/g;
+const INVOKE_BODY_RE = /<parameter\s+name="|<\/invoke>/;
+
 // Channel-word adjacency (`C`): channel/role name appearing immediately before the marker.
 const CHANNEL_WORD_RE = /\b(?:analysis|commentary|assistant|user|system|developer|tool)\s+to=functions\./;
 
@@ -66,7 +79,7 @@ const RECOVERY_REGISTRY: Record<string, RecoveryConfig> = {
 
 const SIGNAL_ORDER = ["M", "C", "G", "S", "B", "R", "T"] as const;
 
-export type HarmonySignalClass = "H" | (typeof SIGNAL_ORDER)[number];
+export type HarmonySignalClass = "H" | "I" | (typeof SIGNAL_ORDER)[number];
 
 export type HarmonySurface = "assistant_text" | "assistant_thinking" | "tool_arg";
 
@@ -152,6 +165,17 @@ export function detectHarmonyLeak(
 		const start = match.index ?? 0;
 		if (isInsideFence(fences, start)) continue;
 		signals.push(makeSignal(["H"], start, start + match[0].length, match[0]));
+	}
+
+	for (const match of text.matchAll(INVOKE_OPEN_RE)) {
+		const start = match.index ?? 0;
+		if (isInsideFence(fences, start)) continue;
+		// Require a committed body nearby so a bare mention of the tag in prose
+		// does not trip; a real leaked envelope continues into parameters or a
+		// close tag.
+		const forward = text.slice(start, Math.min(text.length, start + 400));
+		if (!INVOKE_BODY_RE.test(forward)) continue;
+		signals.push(makeSignal(["I"], start, start + match[0].length, match[0]));
 	}
 
 	for (const match of text.matchAll(MARKER_RE)) {
@@ -306,7 +330,7 @@ export function createHarmonyAuditEvent(params: {
 // ─── internals ──────────────────────────────────────────────────────────────
 
 function makeSignal(classes: HarmonySignalClass[], start: number, end: number, text: string): HarmonySignal {
-	if (classes[0] === "H") return { classes: ["H"], start, end, text };
+	if (classes[0] === "H" || classes[0] === "I") return { classes: [classes[0]], start, end, text };
 	const sorted: HarmonySignalClass[] = [];
 	for (const cls of SIGNAL_ORDER) {
 		if (classes.includes(cls)) sorted.push(cls);
@@ -402,7 +426,7 @@ function sha8(text: string): string {
 
 const PREVIEW_KEEP_RE = new RegExp(`[${SCRIPT_CLASS}\\s】【”“…」「、。]`, "u");
 const PREVIEW_TOKEN_RE =
-	/^(?:to=functions\.[A-Za-z_]\w*|analysis|commentary|assistant|user|system|developer|tool|changedFiles|RTLU|Jsii(?:_commentary)?|\x4aapgolly)/;
+	/^(?:to=functions\.[A-Za-z_]\w*|<\/?invoke\b[^>]*>|<parameter\b[^>]*>|analysis|commentary|assistant|user|system|developer|tool|changedFiles|RTLU|Jsii(?:_commentary)?|\x4aapgolly)/;
 
 /**
  * Privacy-safe preview for the audit log: keeps marker/channel/glitch tokens,

--- a/packages/agent/test/agent-loop-harmony-leak.test.ts
+++ b/packages/agent/test/agent-loop-harmony-leak.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import { agentLoop } from "@gajae-code/agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage } from "@gajae-code/agent-core/types";
+import type { Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { createUserMessage } from "./helpers";
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+// A leaked tool-call envelope on the assistant text surface: the openai-codex
+// model emitted the `ask` call as visible text instead of a native function
+// call (with the `court` glitch line in front), exactly as seen in the wild.
+const LEAKED = [
+	"court",
+	'<invoke name="proxy_ask">',
+	'<parameter name="_i">decision</parameter>',
+	'<parameter name="questions">[{"id":"x"}]</parameter>',
+	"</invoke>",
+].join("\n");
+
+function assistantContains(messages: AgentMessage[], needle: string): boolean {
+	return messages.some(m => m.role === "assistant" && JSON.stringify(m.content).includes(needle));
+}
+
+describe("agent-loop harmony-leak mitigation wiring (openai-codex)", () => {
+	it("detects a leaked <invoke> envelope, drops it from history, and retries to a clean turn", async () => {
+		const context: AgentContext = { systemPrompt: [], messages: [], tools: [] };
+		const mock = createMockModel({
+			provider: "openai-codex",
+			responses: [{ content: [LEAKED] }, { content: ["ok"] }],
+		});
+		const audits: Array<{ action: string }> = [];
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			onHarmonyLeak: e => {
+				audits.push(e);
+			},
+		};
+
+		const stream = agentLoop([createUserMessage("hi")], context, config, undefined, mock.stream);
+		await Array.fromAsync(stream);
+		const messages = await stream.result();
+
+		// Detector fired and routed to abort-retry (a text-surface leak is not a
+		// recoverable tool-arg leak).
+		expect(audits.some(a => a.action === "abort_retry")).toBe(true);
+		// Two model calls: the leaked turn + the clean retry.
+		expect(mock.calls).toHaveLength(2);
+		// The retry produced a clean turn; the leak is not replayed in the output.
+		expect(assistantContains(messages, "ok")).toBe(true);
+		expect(assistantContains(messages, "<invoke name=")).toBe(false);
+		// The contaminated assistant message was dropped from the working context,
+		// so the model does not see its own leak as history on the retry.
+		expect(assistantContains(context.messages, "<invoke name=")).toBe(false);
+	});
+
+	it("does not engage for non-codex providers (gate is provider-scoped)", async () => {
+		const context: AgentContext = { systemPrompt: [], messages: [], tools: [] };
+		const mock = createMockModel({
+			provider: "anthropic",
+			responses: [{ content: [LEAKED] }],
+		});
+		const audits: Array<{ action: string }> = [];
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			onHarmonyLeak: e => {
+				audits.push(e);
+			},
+		};
+
+		const stream = agentLoop([createUserMessage("hi")], context, config, undefined, mock.stream);
+		await Array.fromAsync(stream);
+		const messages = await stream.result();
+
+		// Gate off: no detection, no retry, and the leak passes through unmitigated.
+		expect(audits).toHaveLength(0);
+		expect(mock.calls).toHaveLength(1);
+		expect(assistantContains(messages, "<invoke name=")).toBe(true);
+	});
+});

--- a/packages/agent/test/harmony-leak.test.ts
+++ b/packages/agent/test/harmony-leak.test.ts
@@ -255,3 +255,61 @@ describe("createHarmonyAuditEvent", () => {
 		expect(event.signal).toBe(signalListLabel(detection.signals));
 	});
 });
+
+describe("detectHarmonyLeak — leaked <invoke> envelope dialect (I)", () => {
+	const leakedAsk = [
+		"court",
+		'<invoke name="proxy_ask">',
+		'<parameter name="_i">Round 11 self-ref exclusion detail</parameter>',
+		'<parameter name="questions">[{"id":"r11"}]</parameter>',
+		"</invoke>",
+	].join("\n");
+
+	it("trips on a leaked tool-call envelope in assistant text (no co-signal needed)", () => {
+		const detection = detectHarmonyLeak(leakedAsk, "assistant_text");
+		expect(detection).toBeDefined();
+		expect(signalListLabel(detection!.signals)).toContain("I");
+	});
+
+	it("trips with zero non-Latin content (the leak is not a Korean/script issue)", () => {
+		const asciiLeak = '<invoke name="proxy_read">\n<parameter name="path">src/x.ts</parameter>\n</invoke>';
+		const detection = detectHarmonyLeak(asciiLeak, "assistant_text");
+		expect(detection).toBeDefined();
+		expect(signalListLabel(detection!.signals)).toContain("I");
+	});
+
+	it("trips on the thinking surface too", () => {
+		expect(detectHarmonyLeak(leakedAsk, "assistant_thinking")).toBeDefined();
+	});
+
+	it("detects via detectHarmonyLeakInAssistantMessage; text-surface leak is not recoverable", () => {
+		const message = createAssistantMessage([{ type: "text", text: `ok\n\n${leakedAsk}` }], "stop");
+		const detection = detectHarmonyLeakInAssistantMessage(message);
+		expect(detection).toBeDefined();
+		expect(detection!.surface).toBe("assistant_text");
+		expect(recoverHarmonyToolCall(message, detection!)).toBeUndefined();
+	});
+
+	it("does NOT trip on an invoke example inside a fenced code block", () => {
+		const fenced = [
+			"Here is the wire format:",
+			"```xml",
+			'<invoke name="ask">',
+			'<parameter name="x">1</parameter>',
+			"</invoke>",
+			"```",
+		].join("\n");
+		expect(detectHarmonyLeak(fenced, "assistant_text")).toBeUndefined();
+	});
+
+	it("does NOT trip on prose that mentions the opening tag without a committed body", () => {
+		const prose =
+			'The model sometimes prints a bare <invoke name="ask"> and then ordinary prose continues right here with no parameter or closing tag whatsoever.';
+		expect(detectHarmonyLeak(prose, "assistant_text")).toBeUndefined();
+	});
+
+	it("does not treat normal Korean prose (even containing the word court) as a leak", () => {
+		const korean = "법원 판결문을 읽고 다음 단계를 정합니다. court 같은 단어가 나와도 문제 없어야 한다.";
+		expect(detectHarmonyLeak(korean, "assistant_text")).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What

Make the GPT-5 harmony-leak mitigation actually run for `openai-codex` models, and teach it the leak dialect those models emit in practice.

Two changes:

1. **Wire the mitigation (it was dead scaffolding).** The detector
   (`packages/agent/src/harmony-leak.ts`), the `HarmonyLeakInterruption` catch +
   retry/recover/audit loop, the `onHarmonyLeak` hook, and `harmonyAbortController`
   all existed, but **nothing ever invoked the detector**. `streamAssistantResponse`
   returned the final message without calling it, so on every `openai-codex` turn no
   leak was detected, recovered, or audited (the `agent-loop.ts` catch was
   unreachable). Now, after the streamed assistant message is assembled, we run
   `detectHarmonyLeakInAssistantMessage` when `isHarmonyLeakMitigationTarget(model)`;
   recoverable `tool_arg` leaks go through `recoverHarmonyToolCall`, everything else
   throws `HarmonyLeakInterruption` into the existing abort-retry/audit loop. The
   contaminated assistant message committed during streaming is removed (abort-retry)
   or replaced (truncate-resume) from the working context so the model does not replay
   its own leak as history.

2. **Cover the leaked-envelope dialect.** `openai-codex` models use native function
   calling, yet `gpt-5.5` intermittently emits the tool call as **visible assistant
   text** — an Anthropic-style `<invoke name="…">` envelope, frequently prefixed by a
   bare `court` glitch line — instead of a native `function_call`. The existing signals
   (`to=functions.` / `<|…|>`) miss this entirely. Adds an `I` signal that trips (like
   `H`) on a structurally-committed invoke envelope (opening tag + a parameter/close
   tag within a short window) outside code fences. It keys on envelope **structure**,
   not the literal word `court` (a common token), to avoid false positives.

## Why

Observed on `openai-codex/gpt-5.5` (ChatGPT Codex backend) during a `deep-interview`
run: the assistant repeatedly printed

```
court
<invoke name="proxy_ask">
<parameter name="_i">…</parameter>
<parameter name="questions">[ … ]</parameter>
</invoke>
```

verbatim instead of executing the tool. The tool never fired and the turn was wasted
(under `deep-interview` this surfaces as repeated "tool calling error", 2–4 retries per
question). Root cause was two-fold and both are fixed here:

- The mitigation was never wired in, so no leak of any dialect was caught. Verifiable on
  the base: `git grep -n "detectHarmonyLeak\|new HarmonyLeakInterruption\|harmonyAbortController.abort"`
  returns only tests/definitions — no production caller; `packages/ai` and
  `packages/coding-agent` don't reference `harmony-leak` at all.
- Even once wired, the detector's signals (`to=functions.`, `<|…|>`, channel words,
  glitch tokens) all return `false` on this `<invoke>`/`court` dialect.

This is the same class documented in `docs/ERRATA-GPT5-HARMONY.md` (a tool-call envelope
collapsing into the content channel), just a different surface (`assistant_text`) and
spelling (antml `<invoke>` rather than the `to=functions.` shadow).

Not a Korean/input-encoding issue: in the captured session 50+ Hangul-containing tool
calls succeeded as native `function_call`s, while leaks also occurred on zero-Hangul
payloads (`proxy_read`, `proxy_subagent`, `proxy_bash`) across many tools — so the new
signal keys on envelope structure, not script.

## Design notes / open questions for review

- **Detection point.** This uses **post-stream** detection (on the completed message),
  which is the lowest-risk way to engage the existing machinery. It fixes execution
  (the leaked call no longer runs / a retry produces the real call) and history
  (the leak is dropped before retry), but the junk text is briefly streamed before the
  retry. The already-wired `harmonyAbortController` suggests an intended **mid-stream**
  abort variant that would also suppress the on-screen flash; happy to follow up.
- **Escalation policy.** Text-surface leaks (no tool dispatched) currently share the
  `abort_retry` path that hard-fails after 2 retries. For a purely cosmetic leak that
  may be too harsh — open to a softer policy if preferred.

## Testing

- `bun --cwd=packages/agent test` → **326 pass, 0 fail** (incl. new tests).
- New unit tests (`harmony-leak.test.ts`): invoke-dialect positives (incl. zero-non-Latin
  payload, thinking surface) and negatives (fenced examples, prose mention without a
  body, Korean prose containing the word `court`).
- New loop test (`agent-loop-harmony-leak.test.ts`): a leaked envelope is detected,
  dropped from history, and retried to a clean turn; the gate stays off for non-codex
  providers (leak passes through).
- `bun --cwd=packages/agent run check:types` clean; `biome check` clean on changed files.

---

- [ ] `bun check` passes — verified `packages/agent` (typecheck + biome + tests); full-repo `bun check` (incl. Rust lanes) not run locally
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
