### PR TITLE
fix(ultragoal): fall open in ask guard when no GJC session resolves

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Preserve GJC-managed tmux sessions on attach/disconnect instead of tearing them down, and stop implicitly attaching on launch (#1063).
 - Corrected the auto-compaction output reserve so post-compaction responses keep adequate headroom (#1021).
 - Improved active-input shortcut hints and the busy-input queueing hint for clearer in-session guidance (#1022, #1024).
+- Fixed the Ultragoal ask guard blocking the `ask` tool when no GJC session can be resolved. `ultragoalReadPaths` falls back to the legacy/global `.gjc/ultragoal` directory when neither `GJC_SESSION_ID` nor an auto-detectable active session is present, but the follow-up `readUltragoalPlan`/`readUltragoalLedger` reads ignored that resolution and re-ran session detection, throwing `no active GJC session found` and surfacing `durable_state_unreadable` — which blocked `ask` for every agent even with no active Ultragoal run. `ultragoalReadPaths` now returns the resolved session id (or `null`); the ask guard treats a null session as inactive and falls open, and threads the resolved id into the plan/ledger reads so they no longer re-resolve. An inconsistent state (state dir present but `goals.json` missing/empty) still fails closed so the pause guard keeps blocking give-ups.
 
 ## [0.7.1] - 2026-06-23
 ### Fixed

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
@@ -65,15 +65,17 @@ function isKnownUltragoalObjective(currentObjective: string): boolean {
 	);
 }
 
-async function ultragoalReadPaths(cwd: string): Promise<UltragoalPaths> {
+async function ultragoalReadPaths(cwd: string): Promise<{ paths: UltragoalPaths; sessionId: string | null }> {
 	const envSessionId = process.env.GJC_SESSION_ID?.trim();
-	if (envSessionId) return getUltragoalPaths(cwd, envSessionId);
+	if (envSessionId) return { paths: getUltragoalPaths(cwd, envSessionId), sessionId: envSessionId };
 	try {
 		const session = await resolveGjcSessionForRead(cwd, { envSessionId: process.env.GJC_SESSION_ID });
-		return getUltragoalPaths(cwd, session.gjcSessionId);
+		return { paths: getUltragoalPaths(cwd, session.gjcSessionId), sessionId: session.gjcSessionId };
 	} catch (error) {
 		if (error instanceof SessionResolutionError && error.code === "no_session") {
-			return getUltragoalPaths(cwd, null);
+			// No session could be resolved (no env, no auto-detectable active session).
+			// Surface the null session id so callers can decide; ask-guard treats it as inactive.
+			return { paths: getUltragoalPaths(cwd, null), sessionId: null };
 		}
 		throw error;
 	}
@@ -82,7 +84,7 @@ async function ultragoalReadPaths(cwd: string): Promise<UltragoalPaths> {
 async function hasDurableUltragoalState(cwd: string): Promise<boolean> {
 	let paths: UltragoalPaths;
 	try {
-		paths = await ultragoalReadPaths(cwd);
+		({ paths } = await ultragoalReadPaths(cwd));
 	} catch (error) {
 		if (error instanceof SessionResolutionError) return true;
 		throw error;
@@ -368,12 +370,24 @@ export async function readUltragoalVerificationState(input: {
 
 export async function isUltragoalAskBlocked(cwd: string): Promise<UltragoalAskBlockDiagnostic> {
 	let paths: UltragoalPaths;
+	let sessionId: string | null;
 	try {
-		paths = await ultragoalReadPaths(cwd);
+		({ paths, sessionId } = await ultragoalReadPaths(cwd));
 	} catch (error) {
 		return activeAskDiagnostic({
 			reason: `Unable to resolve durable Ultragoal state: ${error instanceof Error ? error.message : String(error)}`,
 			source: "durable_state_unreadable",
+		});
+	}
+	// Ultragoal state is session-scoped. When no session can be resolved (no env,
+	// no auto-detectable active session) there is no active run to protect, so the
+	// ask guard must fall open rather than block on legacy/global durable state.
+	if (sessionId === null) {
+		return inactiveAskDiagnostic({
+			reason: "No active GJC session resolved; ultragoal is inactive.",
+			source: "absent",
+			goalsPath: paths.goalsPath,
+			ledgerPath: paths.ledgerPath,
 		});
 	}
 	try {
@@ -398,8 +412,8 @@ export async function isUltragoalAskBlocked(cwd: string): Promise<UltragoalAskBl
 	let plan: UltragoalPlan | null;
 	let ledger: UltragoalLedgerEvent[];
 	try {
-		plan = await readUltragoalPlan(cwd);
-		ledger = await readUltragoalLedger(cwd);
+		plan = await readUltragoalPlan(cwd, sessionId);
+		ledger = await readUltragoalLedger(cwd, sessionId);
 	} catch (error) {
 		return activeAskDiagnostic({
 			reason: `Unable to read durable Ultragoal state: ${error instanceof Error ? error.message : String(error)}`,
@@ -409,6 +423,9 @@ export async function isUltragoalAskBlocked(cwd: string): Promise<UltragoalAskBl
 		});
 	}
 	if (!plan) {
+		// goals.json absent or empty while the state dir exists is an inconsistent
+		// durable state, not a clean "no run". Fail closed so the pause guard (which
+		// relies on this `durable_state_unreadable` signal) keeps blocking give-ups.
 		return activeAskDiagnostic({
 			reason: "Durable .gjc/ultragoal state exists but goals.json is missing or empty.",
 			source: "durable_state_unreadable",

--- a/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
+++ b/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
@@ -206,4 +206,33 @@ describe("ultragoal ask guard", () => {
 		expect(diagnostic.active).toBe(false);
 		expect(diagnostic.source).toBe("durable_state");
 	});
+
+	it("allows ask when no GJC session resolves even if a stale global ultragoal plan exists", async () => {
+		const cwd = await tempDir();
+		const previousSessionId = process.env.GJC_SESSION_ID;
+		delete process.env.GJC_SESSION_ID;
+		try {
+			// Legacy/global .gjc/ultragoal with an incomplete plan, but no resolvable
+			// session (no env, no _session-* activity marker). Must not block ask.
+			const globalDir = path.join(cwd, ".gjc", "ultragoal");
+			await fs.mkdir(globalDir, { recursive: true });
+			await fs.writeFile(
+				path.join(globalDir, "goals.json"),
+				JSON.stringify({
+					version: 1,
+					brief: "Stale run",
+					gjcGoalMode: "aggregate",
+					goals: [{ id: "G001", title: "Leftover", objective: "Leftover", status: "pending" }],
+				}),
+			);
+
+			const diagnostic = await isUltragoalAskBlocked(cwd);
+
+			expect(diagnostic.active).toBe(false);
+			expect(diagnostic.source).toBe("absent");
+		} finally {
+			if (previousSessionId === undefined) delete process.env.GJC_SESSION_ID;
+			else process.env.GJC_SESSION_ID = previousSessionId;
+		}
+	});
 });


### PR DESCRIPTION
## Summary

The Ultragoal **ask guard** blocks the `ask` tool for *every* agent whenever it
cannot resolve a GJC session — even when no Ultragoal run is active. The guard is
supposed to block `ask` only *during* an active Ultragoal run (forcing
`gjc ultragoal record-review-blockers` instead of interactive prompts), so this is
a fail-closed-where-it-should-fail-open bug.

Observed at runtime:

```
Ultragoal ask guard blocked ask
  (source: durable_state_unreadable;
   reason: Unable to read durable Ultragoal state:
           no active GJC session found: pass --session-id or set GJC_SESSION_ID)
```

…in a session that had **no** active Ultragoal goal (`gjc ultragoal status` →
`status: missing`).

## Root cause

`#930` taught `isUltragoalAskBlocked` to tolerate a missing session env via
`ultragoalReadPaths`, which falls back to the legacy/global `.gjc/ultragoal`
directory on `no_session`:

```ts
if (error instanceof SessionResolutionError && error.code === "no_session") {
  return getUltragoalPaths(cwd, null); // -> global .gjc/ultragoal
}
```

But the follow-up reads were still session-less:

```ts
plan   = await readUltragoalPlan(cwd);    // re-resolves the session internally
ledger = await readUltragoalLedger(cwd);  // re-resolves the session internally
```

Both `readUltragoalPlan`/`readUltragoalLedger` re-run `resolveGjcSessionForRead`.
When no session can be resolved **and a legacy/global `.gjc/ultragoal` dir already
exists** (so the earlier `fs.stat(paths.dir)` passes), these reads throw
`no active GJC session found`, which the guard reports as
`durable_state_unreadable` and treats as `active: true` → **ask blocked**. A stale
global ultragoal dir left over from a prior run is enough to wedge `ask` in a
brand-new, session-less context.

## Fix

- `ultragoalReadPaths` now returns the resolved session id (or `null`).
- `isUltragoalAskBlocked` treats a `null` session as **inactive** and falls open
  (Ultragoal state is session-scoped; no session ⇒ no run to protect ⇒ allow ask),
  instead of consulting stale global state.
- The resolved session id is threaded into `readUltragoalPlan`/`readUltragoalLedger`
  so they no longer re-run session auto-detect (and can't differ from the path the
  guard already chose).

### Deliberately unchanged (still fail-closed)

- A genuinely inconsistent state — the session ultragoal **dir exists but
  `goals.json` is missing/empty** — keeps returning `durable_state_unreadable`.
  `isUltragoalPauseBlocked` relies on that signal to block give-up pauses, and the
  red-team suite asserts it (`ultragoal-pause-guard-redteam`). Removing `goals.json`
  mid-run is an anomaly, not a clean "no run".
- Unreadable durable state (permission / corrupt JSON / ambiguous-session ties)
  still fails closed.

## Testing

- Added a regression test: a stale global `.gjc/ultragoal/goals.json` with no
  resolvable session no longer blocks `ask` (`active: false`, `source: "absent"`).
  Fails before the change (`active: true`), passes after.
- `bun test` (ask-guard + ultragoal-runtime + both pause guards + ultragoal-review +
  coordinator-mcp-policy): **141 pass / 0 fail**.
- `tsgo -p tsconfig.json --noEmit`: clean.
- `biome check` on changed files: clean.
