### PR TITLE
fix(cli): register the plugin command so `gjc plugin …` resolves

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -22,7 +22,7 @@ process.title = APP_NAME;
 const rootHelpFlags = ["--help", "-h", "help"];
 const versionFlags = ["--version", "-v"];
 
-const commands: CommandEntry[] = [
+export const commands: CommandEntry[] = [
 	{ name: "codex-native-hook", load: () => import("./commands/codex-native-hook").then(m => m.default) },
 	{ name: "state", load: () => import("./commands/state").then(m => m.default) },
 	{ name: "setup", load: () => import("./commands/setup").then(m => m.default) },
@@ -48,6 +48,7 @@ const commands: CommandEntry[] = [
 	{ name: "migrate", load: () => import("./commands/migrate").then(m => m.default) },
 	{ name: "rlm", load: () => import("./commands/rlm").then(m => m.default) },
 	{ name: "update", load: () => import("./commands/update").then(m => m.default) },
+	{ name: "plugin", load: () => import("./commands/plugin").then(m => m.default) },
 	{ name: "launch", load: () => import("./commands/launch").then(m => m.default) },
 ];
 
@@ -220,4 +221,6 @@ export async function runCli(argv: string[]): Promise<void> {
 	return run({ bin: APP_NAME, version: VERSION, argv: runArgv, commands, help: showHelp });
 }
 
-await runCli(process.argv.slice(2));
+if (import.meta.main) {
+	await runCli(process.argv.slice(2));
+}

--- a/packages/coding-agent/test/cli-command-registry.test.ts
+++ b/packages/coding-agent/test/cli-command-registry.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { commands } from "../src/cli";
+
+describe("CLI command registry", () => {
+	it("registers the `plugin` command so `gjc plugin …` resolves instead of routing to launch", () => {
+		// Regression: `src/commands/plugin.ts` existed (and was unit-tested in
+		// isolation) but was never added to the `commands` registry in cli.ts.
+		// `isSubcommand()` therefore returned false for "plugin", so `gjc plugin
+		// install …` fell through to the default `launch` command and was treated
+		// as a chat message. The TUI plugin panel meanwhile advertised
+		// `gjc plugin install <package>`, an unreachable command.
+		const entry = commands.find(c => c.name === "plugin");
+		expect(entry).toBeDefined();
+	});
+
+	it("lazily resolves the registered `plugin` entry to the Plugin command class", async () => {
+		const entry = commands.find(c => c.name === "plugin");
+		const cmd = (await entry?.load()) as { description?: string } | undefined;
+		expect(cmd).toBeDefined();
+		expect(cmd?.description ?? "").toMatch(/plugin/i);
+	});
+});


### PR DESCRIPTION
## Summary

`gjc plugin …` is unreachable from the CLI. `packages/coding-agent/src/commands/plugin.ts` implements the full plugin command (`install`, `uninstall`, `list`, `link`, `doctor`, `features`, `config`, `enable`, `disable`, `marketplace`, `discover`, `upgrade`) and has unit coverage — but it was never added to the `commands` registry in `packages/coding-agent/src/cli.ts`.

`isSubcommand()` decides routing by checking that registry. Since `plugin` is absent, `gjc plugin install …` returns `false` there and falls through to the default `launch` command, i.e. the whole argv is treated as a chat message. Meanwhile the TUI plugin panel (`src/modes/components/plugin-settings.ts`) advertises `Install with: gjc plugin install <package>` — pointing users at a command that does not resolve.

## Reproduction (on the released 0.7.1 binary)

```
$ gjc plugin install --help     # prints the root/launch help, not plugin help
$ gjc plugin list               # starts an interactive session with "plugin list" as the prompt
```

The compiled binary contains the TUI hint string but not the `plugin` command class (no `Manage plugins (install, uninstall, list, etc.)` literal), confirming the command is never bundled because it is never registered.

## Fix

- Register `plugin` in the `commands` array in `cli.ts`.
- Export `commands` and guard the top-level `runCli()` call with `import.meta.main`, so the registry can be unit-tested without executing the CLI on import. `cli.ts` is the `bun build --compile` entry (see `scripts/build-binary.ts`), so `import.meta.main` remains `true` in the standalone binary and normal startup is unchanged.
- Add `test/cli-command-registry.test.ts` asserting `plugin` is registered and that its lazy `load()` resolves to the Plugin command class. The existing `test/plugin-command.test.ts` imports the command class directly, which is why the missing registration was not caught.

## Verification

```
$ bun src/cli.ts plugin --help
Manage plugins (install, uninstall, list, etc.)
USAGE
  $ gjc plugin [ACTION] [TARGETS] [FLAGS]
  ...

$ bun src/cli.ts --version
gjc/0.7.2
```

- `bun test test/cli-command-registry.test.ts` → 2 pass
- `bun test test/plugin-command.test.ts` → 1 pass (no regression)
- `biome lint` on changed files → clean
