### PR TITLE
fix(coding-agent): tolerate unreadable git head in status chrome

### DIFF
--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -8,6 +8,7 @@ import { shortenPath } from "../../tools/render-utils";
 import * as git from "../../utils/git";
 import { sanitizeStatusText } from "../shared";
 import { getContextUsageLevel, getContextUsageThemeColor } from "./status-line/context-thresholds";
+import { resolveCurrentBranch } from "./status-line/git-utils";
 
 /**
  * Footer component that shows pwd, token stats, and context usage
@@ -103,9 +104,7 @@ export class FooterComponent implements Component {
 			return this.#cachedBranch;
 		}
 
-		const headState = git.head.resolveSync(getProjectDir());
-		this.#cachedBranch =
-			headState === null ? null : headState.kind === "ref" ? (headState.branchName ?? headState.ref) : "detached";
+		this.#cachedBranch = resolveCurrentBranch(getProjectDir()).branch;
 		return this.#cachedBranch;
 	}
 

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -20,6 +20,7 @@ import {
 	createPrCacheContext,
 	isSamePrCacheContext,
 	type PrCacheContext,
+	resolveCurrentBranch,
 } from "./status-line/git-utils";
 import { getPreset } from "./status-line/presets";
 import { renderSegment, type SegmentContext } from "./status-line/segments";
@@ -303,19 +304,13 @@ export class StatusLineComponent implements Component {
 		this.#cachedPrContext = undefined;
 	}
 	#getCurrentBranch(): string | null {
-		const head = git.head.resolveSync(getProjectDir());
-		const gitHeadPath = head?.headPath ?? null;
-		if (this.#cachedBranch !== undefined && this.#cachedBranchRepoId === gitHeadPath) {
+		const current = resolveCurrentBranch(getProjectDir());
+		if (this.#cachedBranch !== undefined && this.#cachedBranchRepoId === current.repoId) {
 			return this.#cachedBranch;
 		}
 
-		this.#cachedBranchRepoId = gitHeadPath;
-		if (!head) {
-			this.#cachedBranch = null;
-			return null;
-		}
-
-		this.#cachedBranch = head.kind === "ref" ? (head.branchName ?? head.ref) : "detached";
+		this.#cachedBranchRepoId = current.repoId;
+		this.#cachedBranch = current.branch;
 
 		return this.#cachedBranch ?? null;
 	}

--- a/packages/coding-agent/src/modes/components/status-line/git-utils.ts
+++ b/packages/coding-agent/src/modes/components/status-line/git-utils.ts
@@ -1,3 +1,6 @@
+import type { GitHeadState } from "../../../utils/git";
+import * as git from "../../../utils/git";
+
 /**
  * Extract "owner/repo" from a GitHub remote URL.
  * Handles HTTPS, SSH (scp-style), and git:// protocols.
@@ -39,4 +42,26 @@ export function canReuseCachedPr(
 	currentContext: PrCacheContext | null,
 ): boolean {
 	return cachedPr !== undefined && currentContext !== null && isSamePrCacheContext(cachedContext, currentContext);
+}
+
+export interface CurrentBranchState {
+	readonly branch: string | null;
+	readonly repoId: string | null;
+}
+
+export function resolveCurrentBranch(
+	cwd: string,
+	resolveHead: (cwd: string) => GitHeadState | null = git.head.resolveSync,
+): CurrentBranchState {
+	try {
+		const head = resolveHead(cwd);
+		if (!head) return { branch: null, repoId: null };
+		return {
+			branch: head.kind === "ref" ? (head.branchName ?? head.ref) : "detached",
+			repoId: head.headPath,
+		};
+	} catch (error) {
+		if (error instanceof Error) return { branch: null, repoId: null };
+		throw error;
+	}
 }

--- a/packages/coding-agent/test/status-line-git-utils.test.ts
+++ b/packages/coding-agent/test/status-line-git-utils.test.ts
@@ -5,6 +5,7 @@ import {
 	isSamePrCacheContext,
 	parseDefaultBranch,
 	parseGitHubRepo,
+	resolveCurrentBranch,
 } from "@gajae-code/coding-agent/modes/components/status-line/git-utils";
 
 describe("parseGitHubRepo", () => {
@@ -124,5 +125,17 @@ describe("canReuseCachedPr", () => {
 				null,
 			),
 		).toBe(false);
+	});
+});
+
+describe("resolveCurrentBranch", () => {
+	test("returns null branch metadata when HEAD cannot be read", () => {
+		const permissionError = Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+
+		const state = resolveCurrentBranch("/repo", () => {
+			throw permissionError;
+		});
+
+		expect(state).toEqual({ branch: null, repoId: null });
 	});
 });


### PR DESCRIPTION
## Summary
- add a safe current-branch resolver for status-line git metadata
- route the status line and legacy footer through the safe resolver
- cover HEAD read failures so EPERM no longer crashes TUI rendering

## Verification
- bun test packages/coding-agent/test/status-line-git-utils.test.ts packages/coding-agent/test/status-line-overflow.test.ts packages/coding-agent/test/modes/components/redesigned-shell.test.ts
- bun --cwd=packages/coding-agent run check