### PR TITLE
feat(coding-agent): unify composer chrome with rounded border and subtle status rail

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Refined the interactive composer chrome so the input box, status rail, and welcome banner share one visual language: the composer now uses a rounded border (matching the rounded welcome banner) instead of a sharp rectangle, and the status rail uses the subtle elevated `userMessageBg` surface tone instead of the heavy `statusLineBg` block, so it reads as a quiet layered zone rather than a solid bar. Both resolve through existing semantic theme slots, so every bundled theme tracks automatically.
+
 ## [0.7.2] - 2026-06-24
 ### Added
 

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -675,7 +675,11 @@ export class StatusLineComponent implements Component {
 		const effectiveSettings = this.#resolveSettings();
 		const separatorDef = getSeparator(effectiveSettings.separator ?? "powerline-thin", theme);
 
-		const bgAnsi = theme.getBgAnsi("statusLineBg");
+		// Use the subtle surface tone (the same elevated background as user-message
+		// bubbles) instead of the heavy `statusLineBg` block, so the rail layers
+		// just above the base background as a quiet zone rather than a solid bar.
+		// Resolving through a semantic slot keeps it correct across every theme.
+		const bgAnsi = theme.getBgAnsi("userMessageBg");
 		const fgAnsi = theme.getFgAnsi("text");
 		const sepAnsi = theme.getFgAnsi("statusLineSep");
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -155,7 +155,7 @@ function getShellInputPrefix(isNoContext: boolean): string {
 
 function configureDefaultComposerChrome(editor: CustomEditor): void {
 	editor.setBorderVisible(true);
-	editor.setBorderStyle("sharp");
+	editor.setBorderStyle("round");
 	editor.setClosedBorderBox(true);
 	editor.setPromptGutter(undefined);
 	editor.setInputPrefix(getDefaultInputPrefix());


### PR DESCRIPTION
## What

Unify the interactive composer chrome so the input box, status rail, and welcome banner share one visual language:

- **Composer input box** now uses a **rounded** border (`setBorderStyle("round")`) instead of a sharp rectangle, matching the rounded welcome banner.
- **Status rail** uses the subtle elevated `userMessageBg` surface tone instead of the heavy `statusLineBg` block, so it reads as a quiet layered zone rather than a solid bar.

Both changes resolve through existing **semantic theme slots**, so every bundled theme (`red-claw`, `blue-crab`, `claude-code`, `codex`, `opencode`) tracks automatically — no hardcoded colors.

## Why

The composer mixed visual vocabularies: a sharp-cornered input box under a rounded welcome banner, plus a heavy solid-color status block that visually crowded the rounded box and felt cramped.

This follows common TUI design guidance:
- **Visual consistency** — one border style across banner + composer.
- **Depth through background lightness, not heavy fills** — layer the status rail just above the base background (the same surface tone used for user-message bubbles) instead of a solid bar.
- **Avoid over-decorated chrome** — the content is the interface.

## Testing

- `biome check` on both changed files — clean.
- `bun run check:types` (tsgo) on `packages/coding-agent` — passes.
- Verified `userMessageBg` is defined in all five bundled theme JSONs, so `getBgAnsi("userMessageBg")` never throws.
- Manually verified in the running TUI: rounded composer border + subtle status rail render correctly.

## Screenshots

> Before / After (drag-and-drop screenshots here):

**Before:**
<img width="1242" height="857" alt="image" src="https://github.com/user-attachments/assets/fec22892-d699-403e-b534-afe5c982d8d1" />


**After:**
<img width="1274" height="797" alt="image" src="https://github.com/user-attachments/assets/8a5f4c34-ff7d-4717-b01f-689c59a2fa20" />

---

- [x] `bun check` passes (biome + types on changed package; clean)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
