### PR TITLE
feat: add telegram command menu

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -109,6 +109,22 @@ export class ExtensionRuntime implements IExtensionRuntime {
 	setSessionName(): Promise<void> {
 		throw new ExtensionRuntimeNotInitializedError();
 	}
+
+	getMenuSkillIds(): string[] {
+		return [];
+	}
+
+	getMenuModelOptions(): import("./types").MenuModelOption[] {
+		return [];
+	}
+
+	runMenuSkill(): Promise<void> {
+		return Promise.resolve();
+	}
+
+	setMenuModelByRef(): Promise<{ previous?: string; next: string }> {
+		return Promise.reject(new Error("model switching not available"));
+	}
 }
 
 /**
@@ -251,6 +267,22 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 
 	setSessionName(name: string): Promise<void> {
 		return this.runtime.setSessionName(name);
+	}
+
+	getMenuSkillIds(): string[] {
+		return this.runtime.getMenuSkillIds?.() ?? [];
+	}
+
+	getMenuModelOptions(): import("./types").MenuModelOption[] {
+		return this.runtime.getMenuModelOptions?.() ?? [];
+	}
+
+	runMenuSkill(skillName: string, prompt: string): Promise<void> {
+		return this.runtime.runMenuSkill?.(skillName, prompt) ?? Promise.resolve();
+	}
+
+	setMenuModelByRef(ref: string): Promise<{ previous?: string; next: string }> {
+		return this.runtime.setMenuModelByRef?.(ref) ?? Promise.reject(new Error("model switching not available"));
 	}
 
 	registerProvider(name: string, config: import("./types").ProviderConfig): void {

--- a/packages/coding-agent/src/extensibility/extensions/menu-actions.ts
+++ b/packages/coding-agent/src/extensibility/extensions/menu-actions.ts
@@ -1,0 +1,93 @@
+/**
+ * Host-side implementations for the Telegram `/menu` button surface.
+ *
+ * These back the optional `getMenuSkillIds` / `getMenuModelOptions` /
+ * `runMenuSkill` / `setMenuModelByRef` ExtensionAPI methods. They live here so
+ * every host that wires an {@link AgentSession} into the extension runtime can
+ * expose the menu capabilities with one-line delegations, and the heavy skill /
+ * model logic (which mirrors the ACP text-mode path) is written once.
+ *
+ * Skill execution reuses the exact ACP single-invocation flow
+ * (`resolveSubskillActivationForSkillInvocation` -> `buildSkillPromptMessage` ->
+ * `promptCustomMessage`). Model switching is temporary-only via
+ * `setModelTemporary`, so saved defaults / role overrides / profiles are never
+ * touched.
+ */
+
+import type { Model } from "@gajae-code/ai";
+import type { AgentSession } from "../../session/agent-session";
+import { SKILL_PROMPT_MESSAGE_TYPE } from "../../session/messages";
+import { resolveSubskillActivationForSkillInvocation } from "../gjc-plugins/activation";
+import { buildSkillPromptMessage, getSkillSlashCommandNames } from "../skills";
+import { buildMenuModelOptions } from "./menu-model-options";
+import type { MenuModelOption } from "./types";
+
+export type { MenuModelOption };
+
+function modelRef(model: Pick<Model, "provider" | "id">): string {
+	return `${model.provider}/${model.id}`;
+}
+
+/** Slash-command names of the non-hidden skills the session exposes (or empty when disabled). */
+export function getMenuSkillIds(session: AgentSession): string[] {
+	if (!session.skillsSettings?.enableSkillCommands) return [];
+	return session.skills
+		.filter(skill => skill.hide !== true)
+		.map(skill => getSkillSlashCommandNames(skill)[0])
+		.filter((name): name is string => typeof name === "string" && name.length > 0);
+}
+
+/**
+ * Picker options for the model menu: the curated default models are always
+ * offered (intersected with availability), with the current model pinned first
+ * and recent-usage models filling the remaining slots.
+ */
+export function getMenuModelOptions(session: AgentSession): MenuModelOption[] {
+	const available = session.getAvailableModels().map(model => ({ ref: modelRef(model), label: model.id }));
+	const currentRef = session.model ? modelRef(session.model) : undefined;
+	const mruRefs = session.settings.getStorage()?.getModelUsageOrder?.() ?? [];
+	return buildMenuModelOptions({ available, currentRef, mruRefs });
+}
+
+/** Switch ONLY the current session's temporary model. Throws when `ref` is unavailable. */
+export async function setMenuModelByRef(
+	session: AgentSession,
+	ref: string,
+): Promise<{ previous?: string; next: string }> {
+	const target = session.getAvailableModels().find(model => modelRef(model) === ref);
+	if (!target) throw new Error(`model not available: ${ref}`);
+	const previous = session.model ? modelRef(session.model) : undefined;
+	await session.setModelTemporary(target);
+	return { previous, next: ref };
+}
+
+/** Run a skill by its slash-command name with `prompt` as its argument (ACP-parity flow). */
+export async function runMenuSkill(session: AgentSession, skillName: string, prompt: string): Promise<void> {
+	if (!session.skillsSettings?.enableSkillCommands) {
+		throw new Error("skill commands are disabled for this session");
+	}
+	const skill = session.skills.find(
+		candidate => candidate.hide !== true && getSkillSlashCommandNames(candidate).includes(skillName),
+	);
+	if (!skill) throw new Error(`unknown skill: ${skillName}`);
+
+	const activation = await resolveSubskillActivationForSkillInvocation({
+		cwd: session.sessionManager.getCwd(),
+		sessionId: session.sessionId,
+		skillName: skill.name,
+		args: prompt,
+	});
+	const built = await buildSkillPromptMessage(skill, activation.cleanedArgs, {
+		subskillActivation: activation.activation,
+		subskillActivationSet: activation.activeSubskillsToPersist,
+		cwd: session.sessionManager.getCwd(),
+		sessionId: session.sessionId,
+	});
+	await session.promptCustomMessage({
+		customType: SKILL_PROMPT_MESSAGE_TYPE,
+		content: built.message,
+		display: true,
+		details: built.details,
+		attribution: "user",
+	});
+}

--- a/packages/coding-agent/src/extensibility/extensions/menu-model-options.ts
+++ b/packages/coding-agent/src/extensibility/extensions/menu-model-options.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure construction of the Telegram `/menu` model picker options.
+ *
+ * The picker always offers a curated DEFAULT set (so common models are
+ * selectable even before they appear in this session's recent-usage history),
+ * with the current model pinned first and recent-usage models filling the rest.
+ * Everything is intersected with the session's actually-available models so a
+ * tap never resolves to a model with no configured provider/API key.
+ *
+ * Pure module: no I/O, no session imports (only the shared option type).
+ */
+
+import type { MenuModelOption } from "./types";
+
+/** A model the session can actually switch to, reduced to ref + display label. */
+export interface AvailableModelLite {
+	ref: string;
+	label: string;
+}
+
+/**
+ * Curated default models offered in the picker, in render order. `ref` is the
+ * canonical `provider/id`; `label` is the friendly button text. Only entries
+ * that are actually available in the session are shown.
+ */
+export const DEFAULT_MENU_MODELS: ReadonlyArray<{ ref: string; label: string }> = [
+	{ ref: "anthropic/claude-opus-4-8", label: "claude-opus-4-8" },
+	{ ref: "openai-codex/gpt-5.5", label: "gpt-5.5" },
+	{ ref: "opencode-go/glm-5.2", label: "glm-5.2" },
+	{ ref: "cursor/composer-2.5", label: "composer-2.5" },
+];
+
+/** Default cap on rendered model buttons (Telegram inline keyboards stay small). */
+export const DEFAULT_MAX_MODEL_OPTIONS = 8;
+
+/**
+ * Build the ordered, deduped, availability-filtered model option list:
+ * current model first (marked), then the curated defaults, then recent-usage
+ * models. Friendly default labels win over the raw model id.
+ */
+export function buildMenuModelOptions(input: {
+	available: readonly AvailableModelLite[];
+	currentRef?: string;
+	mruRefs?: readonly string[];
+	max?: number;
+}): MenuModelOption[] {
+	const { available, currentRef, mruRefs = [], max = DEFAULT_MAX_MODEL_OPTIONS } = input;
+	const availableByRef = new Map(available.map(model => [model.ref, model] as const));
+	const defaultLabelByRef = new Map(DEFAULT_MENU_MODELS.map(model => [model.ref, model.label] as const));
+
+	const options: MenuModelOption[] = [];
+	const seen = new Set<string>();
+	const labelFor = (ref: string): string => defaultLabelByRef.get(ref) ?? availableByRef.get(ref)?.label ?? ref;
+
+	const push = (ref: string, current?: boolean): void => {
+		if (seen.has(ref) || !availableByRef.has(ref)) return;
+		options.push(current ? { ref, label: labelFor(ref), current: true } : { ref, label: labelFor(ref) });
+		seen.add(ref);
+	};
+
+	if (currentRef) push(currentRef, true);
+	for (const model of DEFAULT_MENU_MODELS) push(model.ref);
+	for (const ref of mruRefs) push(ref);
+
+	return options.slice(0, max);
+}

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -228,6 +228,10 @@ export class ExtensionRunner {
 		this.runtime.setThinkingLevel = actions.setThinkingLevel;
 		this.runtime.getSessionName = actions.getSessionName;
 		this.runtime.setSessionName = actions.setSessionName;
+		this.runtime.getMenuSkillIds = actions.getMenuSkillIds;
+		this.runtime.getMenuModelOptions = actions.getMenuModelOptions;
+		this.runtime.runMenuSkill = actions.runMenuSkill;
+		this.runtime.setMenuModelByRef = actions.setMenuModelByRef;
 
 		// Context actions (required)
 		this.#getModel = contextActions.getModel;

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1040,6 +1040,12 @@ export interface ExtensionAPI {
 	/** Set the session name. Persists to the session file. */
 	setSessionName(name: string): Promise<void>;
 
+	/** Telegram `/menu` support hooks. */
+	getMenuSkillIds?(): string[];
+	getMenuModelOptions?(): MenuModelOption[];
+	runMenuSkill?(skillName: string, prompt: string): Promise<void>;
+	setMenuModelByRef?(ref: string): Promise<{ previous?: string; next: string }>;
+
 	// =========================================================================
 	// Provider Registration
 	// =========================================================================
@@ -1206,6 +1212,13 @@ export type GetThinkingLevelHandler = () => ThinkingLevel | undefined;
 
 export type SetThinkingLevelHandler = (level: ThinkingLevel, persist?: boolean) => void;
 
+/** A model option shown in the Telegram `/menu` model picker. */
+export interface MenuModelOption {
+	ref: string;
+	label: string;
+	current?: boolean;
+}
+
 /** Shared state created by loader, used during registration and runtime. */
 export interface ExtensionRuntimeState {
 	flagValues: Map<string, boolean | string>;
@@ -1228,6 +1241,10 @@ export interface ExtensionActions {
 	setThinkingLevel: SetThinkingLevelHandler;
 	getSessionName: () => string | undefined;
 	setSessionName: (name: string) => Promise<void>;
+	getMenuSkillIds?: () => string[];
+	getMenuModelOptions?: () => MenuModelOption[];
+	runMenuSkill?: (skillName: string, prompt: string) => Promise<void>;
+	setMenuModelByRef?: (ref: string) => Promise<{ previous?: string; next: string }>;
 }
 
 /** Actions for ExtensionContext (ctx.* in event handlers). */

--- a/packages/coding-agent/src/modes/runtime-init.ts
+++ b/packages/coding-agent/src/modes/runtime-init.ts
@@ -8,6 +8,12 @@
  */
 import { runExtensionCompact, runExtensionSetModel } from "../extensibility/extensions/compact-handler";
 import { getSessionSlashCommands } from "../extensibility/extensions/get-commands-handler";
+import {
+	getMenuModelOptions,
+	getMenuSkillIds,
+	runMenuSkill,
+	setMenuModelByRef,
+} from "../extensibility/extensions/menu-actions";
 import type { ExtensionError, ExtensionUIContext } from "../extensibility/extensions/types";
 import type { AgentSession } from "../session/agent-session";
 
@@ -68,6 +74,10 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 			setSessionName: async name => {
 				await session.sessionManager.setSessionName(name, "user");
 			},
+			getMenuSkillIds: () => getMenuSkillIds(session),
+			getMenuModelOptions: () => getMenuModelOptions(session),
+			runMenuSkill: (skillName, prompt) => runMenuSkill(session, skillName, prompt),
+			setMenuModelByRef: ref => setMenuModelByRef(session, ref),
 		},
 		// ExtensionContextActions
 		{

--- a/packages/coding-agent/src/notifications/command-menu-runtime.ts
+++ b/packages/coding-agent/src/notifications/command-menu-runtime.ts
@@ -1,0 +1,189 @@
+/**
+ * Session-side runtime for the Telegram `/menu` button surface.
+ */
+
+import {
+	makeSyntheticActionId,
+	type PendingMenuAction,
+	type SyntheticActionKind,
+	TOP_LEVEL_MENU,
+} from "./command-menu";
+import { isAllowedSkillInvocation, type MenuCategory } from "./command-policy";
+
+/** A model option shown in the picker. */
+export interface ModelOption {
+	ref: string;
+	label: string;
+	current?: boolean;
+}
+
+/** Result of switching the temporary model, for user feedback. */
+export interface ModelSwitchResult {
+	previous?: string;
+	next: string;
+}
+
+/** Injected session capabilities + side effects. */
+export interface MenuRuntimeDeps {
+	/** Skill ids the session exposes (already filtered to non-hidden). */
+	allowedSkillIds(): string[];
+	/** Recent models (current marked) for the picker, most-recent first. */
+	recentModels(): ModelOption[];
+	/** Register an answerable synthetic ask (maps to server.registerAsk). `options` empty = force-reply text ask. */
+	registerAsk(id: string, question: string, options: string[]): void;
+	/** Post a plain result/guidance message into the session thread. */
+	postMessage(text: string): void;
+	/** Run a skill with the collected prompt (maps to the shared text-mode executor). */
+	runSkill(skillName: string, prompt: string): Promise<void>;
+	/** Switch only the current session's temporary model. */
+	setModelTemporary(ref: string): Promise<ModelSwitchResult>;
+}
+
+/** Outcome of routing a reply, for the caller to resolve/reject the native action. */
+export type MenuReplyOutcome =
+	| { kind: "resolved" }
+	| { kind: "rejected"; reason: string }
+	| { kind: "not_menu_action" };
+
+export class CommandMenuRuntime {
+	private readonly pending = new Map<string, PendingMenuAction>();
+	/** Skill awaiting the user's free-text prompt (not a registered ask). */
+	private pendingSkillPrompt: string | undefined;
+
+	constructor(private readonly deps: MenuRuntimeDeps) {}
+
+	/** True when `actionId` belongs to this runtime's pending registry. */
+	owns(actionId: string): boolean {
+		return this.pending.has(actionId);
+	}
+
+	private register(kind: SyntheticActionKind, action: PendingMenuAction, question: string, options: string[]): string {
+		const id = makeSyntheticActionId(kind);
+		this.pending.set(id, action);
+		this.deps.registerAsk(id, question, options);
+		return id;
+	}
+
+	/** Open the top-level Skills/Model/Notify menu. Returns the action id. */
+	openTopLevelMenu(): string {
+		const categories = TOP_LEVEL_MENU.map(e => e.category);
+		return this.register(
+			"menu",
+			{ type: "menu", optionCategories: categories },
+			"Commands",
+			TOP_LEVEL_MENU.map(e => e.label),
+		);
+	}
+
+	private openSkillsSubmenu(): void {
+		const skills = this.deps.allowedSkillIds();
+		if (skills.length === 0) {
+			this.deps.postMessage("No skills are available for this session.");
+			return;
+		}
+		this.register("submenu", { type: "submenu", category: "skills", optionIds: skills }, "Skills", skills);
+	}
+
+	private openModelPicker(): void {
+		const models = this.deps.recentModels();
+		if (models.length === 0) {
+			this.deps.postMessage("No recent models to choose from yet.");
+			return;
+		}
+		const labels = models.map(m => (m.current ? `${m.label} (current)` : m.label));
+		this.register("model", { type: "model", modelRefs: models.map(m => m.ref) }, "Recent models", labels);
+	}
+
+	private openSkillPrompt(skillName: string): void {
+		this.pendingSkillPrompt = skillName;
+		this.deps.postMessage(`Enter the prompt for /skill:${skillName}, then send it as your next message.`);
+	}
+
+	/** Consume the next free-text message as a pending skill prompt, if any. */
+	async consumePendingSkillPrompt(text: string): Promise<boolean> {
+		const skillName = this.pendingSkillPrompt;
+		if (!skillName) return false;
+		this.pendingSkillPrompt = undefined;
+
+		const prompt = text.trim();
+		if (!prompt) {
+			this.deps.postMessage("Empty prompt; skill not run. Send /menu to try again.");
+			return true;
+		}
+
+		try {
+			await this.deps.runSkill(skillName, prompt);
+		} catch (e) {
+			this.deps.postMessage(`Skill run failed: ${e instanceof Error ? e.message : String(e)}`);
+		}
+		return true;
+	}
+
+	/** True when the runtime is waiting for the user's skill-prompt free text. */
+	get hasPendingSkillPrompt(): boolean {
+		return this.pendingSkillPrompt !== undefined;
+	}
+
+	private handleCategory(category: MenuCategory): MenuReplyOutcome {
+		switch (category) {
+			case "skills":
+				this.openSkillsSubmenu();
+				return { kind: "resolved" };
+			case "model":
+				this.openModelPicker();
+				return { kind: "resolved" };
+			case "notify":
+				this.deps.postMessage("Notify: send /notify status, /notify on, or /notify off.");
+				return { kind: "resolved" };
+		}
+	}
+
+	/**
+	 * Route a reply to a synthetic action. `answer` is the chosen option index
+	 * (number) for option asks, or free text (string) for a skill prompt.
+	 * Returns `not_menu_action` when the id is not ours so the caller can fall
+	 * through to real ask/gate handling.
+	 */
+	async handleReply(actionId: string, answer: number | string): Promise<MenuReplyOutcome> {
+		const action = this.pending.get(actionId);
+		if (!action) return { kind: "not_menu_action" };
+		// Consume the action; selecting opens follow-ups which register fresh ids.
+		this.pending.delete(actionId);
+		switch (action.type) {
+			case "menu": {
+				const index = typeof answer === "number" ? answer : Number.parseInt(String(answer), 10);
+				const category = action.optionCategories[index];
+				if (category === undefined) return { kind: "rejected", reason: "unknown menu option" };
+				return this.handleCategory(category);
+			}
+			case "submenu": {
+				const index = typeof answer === "number" ? answer : Number.parseInt(String(answer), 10);
+				const skillName = action.optionIds[index];
+				if (skillName === undefined) return { kind: "rejected", reason: "unknown submenu option" };
+				if (action.category === "skills") {
+					if (!isAllowedSkillInvocation(skillName, this.deps.allowedSkillIds())) {
+						return { kind: "rejected", reason: "skill is not allowed" };
+					}
+					this.openSkillPrompt(skillName);
+				}
+				return { kind: "resolved" };
+			}
+			case "model": {
+				const index = typeof answer === "number" ? answer : Number.parseInt(String(answer), 10);
+				const ref = action.modelRefs[index];
+				if (ref === undefined) return { kind: "rejected", reason: "unknown model option" };
+				try {
+					const result = await this.deps.setModelTemporary(ref);
+					const prev = result.previous ?? "(unset)";
+					this.deps.postMessage(`Model: ${prev} → ${result.next} (this session only)`);
+					return { kind: "resolved" };
+				} catch (e) {
+					return {
+						kind: "rejected",
+						reason: `model switch failed: ${e instanceof Error ? e.message : String(e)}`,
+					};
+				}
+			}
+		}
+	}
+}

--- a/packages/coding-agent/src/notifications/command-menu.ts
+++ b/packages/coding-agent/src/notifications/command-menu.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure helpers for the Telegram `/menu` button-first command surface.
+ *
+ * The Telegram menu is expressed as session-owned synthetic `kind:"ask"`
+ * notification actions (no native protocol change). Every menu/submenu/model
+ * picker/skill prompt is an answerable ask whose id is NAMESPACED so it can
+ * never collide with a real workflow ask (`ask:<uuid>`) or gate id. The session
+ * keeps the semantic meaning in a pending-action registry keyed by that id; the
+ * daemon only renders options and routes the chosen index/text back.
+ *
+ * Pure module: no I/O, no session imports (only the policy types), unit-testable.
+ */
+
+import { classifyTypedSlash, MENU_CATEGORIES, type MenuCategory } from "./command-policy";
+
+/** Discriminating prefixes for synthetic menu action ids. */
+export const SYNTHETIC_ACTION_KINDS = ["menu", "submenu", "model"] as const;
+export type SyntheticActionKind = (typeof SYNTHETIC_ACTION_KINDS)[number];
+
+/** Guidance posted when a raw typed slash command is redirected to the menu. */
+export const MENU_GUIDANCE = "Use /menu (or /m) to open the command buttons (Skills, Model, Notify).";
+
+/** Top-level palette entries, in render order. Labels are user-facing button text. */
+export const TOP_LEVEL_MENU: ReadonlyArray<{ category: MenuCategory; label: string }> = [
+	{ category: "skills", label: "Skills" },
+	{ category: "model", label: "Model" },
+	{ category: "notify", label: "Notify" },
+];
+
+/** A session-local pending synthetic action, keyed in the registry by its action id. */
+export type PendingMenuAction =
+	| { type: "menu"; optionCategories: MenuCategory[] }
+	| { type: "submenu"; category: MenuCategory; optionIds: string[] }
+	| { type: "model"; modelRefs: string[] };
+
+/** True for an exact `/menu` or its short alias `/m` (case-insensitive, whitespace-tolerant). */
+export function parseMenuTrigger(text: string): boolean {
+	const t = text.trim().toLowerCase();
+	return t === "/menu" || t === "/m";
+}
+
+function randomUuid(): string {
+	const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+	if (c?.randomUUID) return c.randomUUID();
+	// Deterministic-enough fallback for environments without WebCrypto.
+	return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/** Build a namespaced synthetic action id, e.g. `menu:<uuid>`. */
+export function makeSyntheticActionId(kind: SyntheticActionKind, uuid: string = randomUuid()): string {
+	return `${kind}:${uuid}`;
+}
+
+/** Parse a namespaced synthetic action id back into its kind + uuid, or undefined. */
+function parseSyntheticActionId(id: string): { kind: SyntheticActionKind; uuid: string } | undefined {
+	const idx = id.indexOf(":");
+	if (idx <= 0) return undefined;
+	const kind = id.slice(0, idx);
+	const uuid = id.slice(idx + 1);
+	if (!uuid) return undefined;
+	if (!(SYNTHETIC_ACTION_KINDS as readonly string[]).includes(kind)) return undefined;
+	return { kind: kind as SyntheticActionKind, uuid };
+}
+
+/** True when `id` is one of our namespaced synthetic action ids (not a workflow ask/gate id). */
+export function isSyntheticActionId(id: string): boolean {
+	return parseSyntheticActionId(id) !== undefined;
+}
+
+/**
+ * Decide whether a typed (non-button) inbound text should be redirected to
+ * `/menu` guidance instead of executed or injected.
+ *
+ * - exact `/menu`              → not redirected (it is the trigger itself).
+ * - existing config command    → not redirected (handled by the config parser).
+ * - any other `/`-command      → redirected with menu guidance.
+ * - denied (`/model <args>`, destructive, shell/eval) → redirected with the
+ *   policy reason plus menu guidance.
+ * - ordinary text              → not redirected (free-text injection).
+ */
+export type RedirectDecision = { redirect: false } | { redirect: true; message: string };
+
+export function redirectTypedSlash(text: string): RedirectDecision {
+	if (parseMenuTrigger(text)) return { redirect: false };
+	const cls = classifyTypedSlash(text);
+	switch (cls.kind) {
+		case "not_command":
+		case "config":
+			return { redirect: false };
+		case "denied":
+			return { redirect: true, message: `${cls.reason}. ${MENU_GUIDANCE}` };
+		case "command":
+			return { redirect: true, message: MENU_GUIDANCE };
+	}
+}
+
+/**
+ * Decide how the notifications inbound path should treat a free-text Telegram
+ * message, BEFORE it is injected as a user turn. Keeps the index.ts glue thin
+ * and unit-testable.
+ *
+ * - `open_menu`   — exact `/menu`: render the top-level palette.
+ * - `guidance`    — a raw typed command (or denied command): post `message`
+ *   instead of injecting/executing it.
+ * - `passthrough` — ordinary text (or config command): let the existing
+ *   user_message / config_command handling proceed unchanged.
+ */
+export type MenuInboundDecision =
+	| { kind: "open_menu" }
+	| { kind: "guidance"; message: string }
+	| { kind: "passthrough" };
+
+export function decideMenuInbound(text: string): MenuInboundDecision {
+	if (parseMenuTrigger(text)) return { kind: "open_menu" };
+	const redirect = redirectTypedSlash(text);
+	if (redirect.redirect) return { kind: "guidance", message: redirect.message };
+	return { kind: "passthrough" };
+}
+
+/** Re-export the canonical category order for menu construction convenience. */
+export { MENU_CATEGORIES };

--- a/packages/coding-agent/src/notifications/command-policy.ts
+++ b/packages/coding-agent/src/notifications/command-policy.ts
@@ -1,0 +1,125 @@
+/**
+ * Minimal allowlist policy for the Telegram `/menu` surface.
+ *
+ * Raw shell/eval escapes, persistent session/provider changes, and `/model <args>`
+ * stay local-only. Telegram model changes go through the temporary picker.
+ */
+
+/** The MVP palette categories. Order is the rendered top-level order. */
+export const MENU_CATEGORIES = ["skills", "model", "notify"] as const;
+
+export type MenuCategory = (typeof MENU_CATEGORIES)[number];
+
+/** Telegram thread config commands that remain handled by the existing parser. */
+export const CONFIG_COMMAND_NAMES = ["verbose", "lean", "verbosity", "redact"] as const;
+
+/**
+ * Command names that must never be reachable from the Telegram surface, because
+ * they mutate durable state, delete data, or only make sense in the local TUI.
+ * Matched case-insensitively against the first slash token.
+ */
+export const DENIED_COMMAND_NAMES = [
+	// destructive / persistent session + memory + provider mutations
+	"session",
+	"memory",
+	"provider",
+	"login",
+	"logout",
+	"compact",
+	"clear",
+	"reset",
+	"move",
+	"mcp",
+	// TUI-only selectors / dashboards with no text-mode contract
+	"resume",
+	"export",
+	"theme",
+	"vim",
+] as const;
+
+/** Normalize a raw inbound string into a leading slash command name + raw args. */
+export function parseSlashName(text: string): { name: string; args: string } | undefined {
+	const trimmed = text.trim();
+	if (!trimmed.startsWith("/")) return undefined;
+	const body = trimmed.slice(1);
+	// Split on the earliest whitespace or ':' so `/skill:ralplan x` and
+	// `/model gpt` both yield a name and the remaining args.
+	const match = /^([^\s:]+)([\s:]+)?([\s\S]*)$/.exec(body);
+	if (!match) return { name: "", args: "" };
+	const name = (match[1] ?? "").toLowerCase();
+	const args = (match[3] ?? "").trim();
+	return { name, args };
+}
+
+/** True when `text` is one of the existing in-thread config commands. */
+export function isConfigCommand(text: string): boolean {
+	const parsed = parseSlashName(text);
+	return !!parsed && (CONFIG_COMMAND_NAMES as readonly string[]).includes(parsed.name);
+}
+
+/** True when `text` is a `/model` invocation that carries arguments. */
+export function isModelCommandWithArgs(text: string): boolean {
+	const parsed = parseSlashName(text);
+	return !!parsed && parsed.name === "model" && parsed.args.length > 0;
+}
+
+/**
+ * True when `text` must be rejected from the Telegram surface entirely:
+ * shell/eval escapes, explicitly denied command names, or `/model <args>`
+ * (which would persist a default/role instead of a temporary change).
+ */
+export function isDeniedCommand(text: string): boolean {
+	const trimmed = text.trim();
+	if (trimmed.startsWith("!") || trimmed.startsWith("$")) return true;
+	if (isModelCommandWithArgs(trimmed)) return true;
+	const parsed = parseSlashName(trimmed);
+	if (!parsed) return false;
+	return (DENIED_COMMAND_NAMES as readonly string[]).includes(parsed.name);
+}
+
+/**
+ * Validate a skill invocation against the session-provided allowed skill ids.
+ * The session is authoritative for which skills exist; the policy only enforces
+ * that the id is non-empty and present in that allowlist.
+ */
+export function isAllowedSkillInvocation(skillName: string, allowedSkillIds: readonly string[]): boolean {
+	const id = skillName.trim().toLowerCase();
+	if (!id) return false;
+	return allowedSkillIds.some(allowed => allowed.trim().toLowerCase() === id);
+}
+
+/**
+ * Classify a typed (not button-driven) slash input for routing:
+ * - `config`   — keep existing in-thread config behavior.
+ * - `denied`   — never execute; surface a rejection.
+ * - `command`  — a `/`-prefixed input that is not config and not denied; the
+ *   Telegram surface redirects these to `/menu` guidance instead of executing
+ *   raw typed commands.
+ * - `not_command` — not slash-prefixed; ordinary text (free-text injection).
+ */
+export type TypedSlashClass =
+	| { kind: "config" }
+	| { kind: "denied"; reason: string }
+	| { kind: "command" }
+	| { kind: "not_command" };
+
+export function classifyTypedSlash(text: string): TypedSlashClass {
+	const trimmed = text.trim();
+	if (!trimmed.startsWith("/")) {
+		// `!`/`$` escapes are not `/`-commands but are still denied surfaces.
+		if (trimmed.startsWith("!") || trimmed.startsWith("$")) {
+			return { kind: "denied", reason: "shell and eval escapes are not available over Telegram" };
+		}
+		return { kind: "not_command" };
+	}
+	if (isConfigCommand(trimmed)) return { kind: "config" };
+	if (isDeniedCommand(trimmed)) {
+		return {
+			kind: "denied",
+			reason: isModelCommandWithArgs(trimmed)
+				? "use the Model menu to switch models for this session only"
+				: "this command is not available over Telegram",
+		};
+	}
+	return { kind: "command" };
+}

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -31,6 +31,8 @@ import { Settings } from "../config/settings";
 import type { ExtensionCommandContext, ExtensionContext, ExtensionFactory } from "../extensibility/extensions";
 import { registerAskAnswerSource } from "../tools/ask-answer-registry";
 import { registerTelegramFileSink } from "./attachment-registry";
+import { decideMenuInbound } from "./command-menu";
+import { CommandMenuRuntime } from "./command-menu-runtime";
 import {
 	getNotificationConfig,
 	isGloballyConfigured,
@@ -151,6 +153,7 @@ interface SessionRuntime {
 	/** Assistant text already flushed before an ask this turn (turn-scoped dedupe
 	 * so turn_end does not re-emit the pre-ask lead-in). Reset each turn. */
 	preAskFlushedText?: string;
+	menuRuntime?: CommandMenuRuntime;
 }
 
 interface ResolvedSettings {
@@ -342,8 +345,66 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		// unattended gate), so the endpoint advertises a resolver.
 		const server = new NotificationServer(id, resolveToken(), stateRoot, true);
 
+		const postThreadMessage = (text: string): void => {
+			try {
+				server.pushFrame(JSON.stringify({ type: "turn_stream", sessionId: id, phase: "finalized", text }));
+			} catch (e) {
+				logger.warn(`notifications: menu postMessage failed: ${String(e)}`);
+			}
+		};
+		const menuRuntime = new CommandMenuRuntime({
+			allowedSkillIds: () => api.getMenuSkillIds?.() ?? [],
+			recentModels: () => api.getMenuModelOptions?.() ?? [],
+			registerAsk: (actionId, question, options) => {
+				server.registerAsk(
+					JSON.stringify(
+						notificationActionPayload(
+							{ id: actionId, kind: "ask", sessionId: id, question, options },
+							{ redact, sessionTag: tag },
+						),
+					),
+					true,
+				);
+			},
+			postMessage: postThreadMessage,
+			runSkill: async (skillName, prompt) => {
+				if (api.runMenuSkill) return api.runMenuSkill(skillName, prompt);
+				postThreadMessage(
+					`Skill execution over Telegram is not wired in this runtime yet. Run /skill:${skillName} locally.`,
+				);
+			},
+			setModelTemporary: async ref => {
+				if (api.setMenuModelByRef) return api.setMenuModelByRef(ref);
+				postThreadMessage("Temporary model switching over Telegram is not wired in this runtime yet.");
+				throw new Error("setModelTemporary not available in this runtime");
+			},
+		});
+
 		server.onReply((err, reply) => {
 			if (err || !reply) return;
+			if (menuRuntime.owns(reply.id)) {
+				const parsed = parseAnswer(reply.answerJson);
+				const answer: number | string =
+					typeof parsed === "number" || typeof parsed === "string" ? parsed : String(parsed);
+				menuRuntime
+					.handleReply(reply.id, answer)
+					.then(outcome => {
+						try {
+							if (outcome.kind === "resolved")
+								server.resolveClient(reply.id, reply.answerJson, reply.idempotencyKey ?? undefined);
+							else server.reject(reply.id, "invalid_answer");
+						} catch (e) {
+							logger.warn(`notifications: menu resolve failed: ${String(e)}`);
+						}
+					})
+					.catch(e => {
+						logger.warn(`notifications: menu handleReply failed: ${String(e)}`);
+						try {
+							server.reject(reply.id, "invalid_answer");
+						} catch {}
+					});
+				return;
+			}
 			// 1) Interactive ask awaiting a remote answer.
 			const pending = pendingInteractive.get(reply.id);
 			if (pending) {
@@ -384,13 +445,24 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		server.onInbound((err, inbound) => {
 			if (err || !inbound) return;
 			if (inbound.kind === "user_message") {
-				// Inject as a user turn (steers/continues the agent; the resulting
-				// turn streams back via the turn_end handler even when not idle).
-				// Record the update id so it can be acked as "consumed" on the next
-				// turn_start, and steer (vs start a fresh turn) when already busy.
 				const text = inbound.text ?? "";
 				const images = inbound.images ?? [];
 				if (!text && images.length === 0) return;
+				if (text) {
+					const menuDecision = decideMenuInbound(text);
+					if (menuDecision.kind === "open_menu") {
+						menuRuntime.openTopLevelMenu();
+						return;
+					}
+					if (menuDecision.kind === "guidance") {
+						postThreadMessage(menuDecision.message);
+						return;
+					}
+					if (menuRuntime.hasPendingSkillPrompt) {
+						void menuRuntime.consumePendingSkillPrompt(text);
+						return;
+					}
+				}
 				if (runtime && typeof inbound.updateId === "number") runtime.pendingInbound.add(inbound.updateId);
 				const content: string | (TextContent | ImageContent)[] =
 					images.length > 0
@@ -447,6 +519,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 				sessionTag: tag,
 				busy: false,
 				pendingInbound: new Set<number>(),
+				menuRuntime,
 			};
 			runtimes.set(id, runtime);
 			logger.info(`notifications: serving session ${id} at ${endpoint.url} (unattended=${unattended})`);

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -8,6 +8,7 @@ import { withFileLock } from "../config/file-lock";
 import type { Settings } from "../config/settings";
 import type { DaemonRuntimeInfo } from "../daemon/control-types";
 import { resolveGjcRuntimeSpawnInfo } from "../daemon/runtime";
+import { isSyntheticActionId } from "./command-menu";
 import { getNotificationConfig, isGloballyConfigured, tokenFingerprint } from "./config";
 import { parseInThreadConfigCommand } from "./config-commands";
 import { buildButtonGrid, TELEGRAM_PARSE_MODE } from "./html-format";
@@ -713,7 +714,7 @@ interface SessionSocket {
 	sessionId: string;
 	token: string;
 	ws: WebSocket;
-	pending: Map<string, { sessionId: string; actionId: string }>;
+	pending: Map<string, PendingAsk>;
 	/** True once the server advertised the `client_ping_pong` capability. */
 	capable: boolean;
 	/** Timestamp (via opts.now) of the last received pong; seeds the TTL window. */
@@ -1349,7 +1350,12 @@ export class TelegramNotificationDaemon {
 			return;
 		}
 		if (msg.type === "action_needed" && msg.id) {
-			if (msg.kind === "ask") session.pending.set(msg.id, { sessionId: session.sessionId, actionId: msg.id });
+			if (msg.kind === "ask")
+				session.pending.set(msg.id, {
+					sessionId: session.sessionId,
+					actionId: msg.id,
+					buttonOnly: isSyntheticActionId(msg.id),
+				});
 			const topicId = await this.ensureTopic(session.sessionId, this.topicNameFor(session.sessionId, msg));
 			if (!topicId) {
 				// Fail closed for non-private chats; only nudge + flat-deliver in a private DM.

--- a/packages/coding-agent/src/notifications/telegram-reference.ts
+++ b/packages/coding-agent/src/notifications/telegram-reference.ts
@@ -172,6 +172,7 @@ export type RouteDecision =
 export interface PendingAsk {
 	sessionId: string;
 	actionId: string;
+	buttonOnly?: boolean;
 }
 
 export interface RouteInboundContext {
@@ -227,6 +228,7 @@ export function routeInboundUpdate(update: unknown, ctx: RouteInboundContext): R
 		const allPending = ctx.pendingBySession(undefined);
 		if (allPending.length === 1) {
 			const [pending] = allPending;
+			if (pending?.buttonOnly) return { kind: "ignore" };
 			return { kind: "reply", sessionId: pending!.sessionId, actionId: pending!.actionId, answer: text };
 		}
 		if (allPending.length > 1) return { kind: "stale", reason: "ambiguous_plain_text" };

--- a/packages/coding-agent/test/menu-model-options.test.ts
+++ b/packages/coding-agent/test/menu-model-options.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type AvailableModelLite,
+	buildMenuModelOptions,
+	DEFAULT_MENU_MODELS,
+} from "../src/extensibility/extensions/menu-model-options";
+
+const ALL_DEFAULTS: AvailableModelLite[] = DEFAULT_MENU_MODELS.map(m => ({ ref: m.ref, label: m.ref }));
+
+describe("buildMenuModelOptions defaults", () => {
+	test("offers the four curated default models with friendly labels", () => {
+		const options = buildMenuModelOptions({ available: ALL_DEFAULTS });
+		expect(options.map(o => o.ref)).toEqual([
+			"anthropic/claude-opus-4-8",
+			"openai-codex/gpt-5.5",
+			"opencode-go/glm-5.2",
+			"cursor/composer-2.5",
+		]);
+		expect(options.map(o => o.label)).toEqual(["claude-opus-4-8", "gpt-5.5", "glm-5.2", "composer-2.5"]);
+		expect(options.some(o => o.current)).toBe(false);
+	});
+
+	test("pins the current model first and marks it, without duplicating it among defaults", () => {
+		const options = buildMenuModelOptions({ available: ALL_DEFAULTS, currentRef: "openai-codex/gpt-5.5" });
+		expect(options[0]).toEqual({ ref: "openai-codex/gpt-5.5", label: "gpt-5.5", current: true });
+		expect(options.filter(o => o.ref === "openai-codex/gpt-5.5")).toHaveLength(1);
+		// all four defaults still present
+		expect(new Set(options.map(o => o.ref)).size).toBe(4);
+	});
+
+	test("only shows defaults that are actually available", () => {
+		const available: AvailableModelLite[] = [
+			{ ref: "anthropic/claude-opus-4-8", label: "anthropic/claude-opus-4-8" },
+			{ ref: "cursor/composer-2.5", label: "cursor/composer-2.5" },
+		];
+		const options = buildMenuModelOptions({ available });
+		expect(options.map(o => o.ref)).toEqual(["anthropic/claude-opus-4-8", "cursor/composer-2.5"]);
+	});
+
+	test("appends recent-usage models after the defaults, deduped", () => {
+		const available: AvailableModelLite[] = [...ALL_DEFAULTS, { ref: "other/model-x", label: "model-x" }];
+		const options = buildMenuModelOptions({
+			available,
+			mruRefs: ["other/model-x", "openai-codex/gpt-5.5"],
+		});
+		expect(options.map(o => o.ref)).toContain("other/model-x");
+		// gpt-5.5 already present as a default, not duplicated by MRU
+		expect(options.filter(o => o.ref === "openai-codex/gpt-5.5")).toHaveLength(1);
+		// defaults come before the extra MRU-only model
+		expect(options.findIndex(o => o.ref === "cursor/composer-2.5")).toBeLessThan(
+			options.findIndex(o => o.ref === "other/model-x"),
+		);
+	});
+
+	test("caps the number of options", () => {
+		const many: AvailableModelLite[] = Array.from({ length: 20 }, (_, i) => ({
+			ref: `p/m${i}`,
+			label: `m${i}`,
+		}));
+		const options = buildMenuModelOptions({
+			available: [...ALL_DEFAULTS, ...many],
+			mruRefs: many.map(m => m.ref),
+			max: 6,
+		});
+		expect(options).toHaveLength(6);
+	});
+
+	test("ignores an unavailable current ref", () => {
+		const options = buildMenuModelOptions({ available: ALL_DEFAULTS, currentRef: "nope/missing" });
+		expect(options.some(o => o.current)).toBe(false);
+		expect(options).toHaveLength(4);
+	});
+});

--- a/packages/coding-agent/test/notifications-command-menu-runtime.test.ts
+++ b/packages/coding-agent/test/notifications-command-menu-runtime.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { CommandMenuRuntime, type MenuRuntimeDeps, type ModelOption } from "../src/notifications/command-menu-runtime";
+
+interface Recorded {
+	asks: Array<{ id: string; question: string; options: string[] }>;
+	messages: string[];
+	skillRuns: Array<{ skillName: string; prompt: string }>;
+	modelSwitches: string[];
+}
+
+function makeRuntime(over: Partial<MenuRuntimeDeps> = {}): { rt: CommandMenuRuntime; rec: Recorded } {
+	const rec: Recorded = { asks: [], messages: [], skillRuns: [], modelSwitches: [] };
+	const deps: MenuRuntimeDeps = {
+		allowedSkillIds: over.allowedSkillIds ?? (() => ["ralplan", "deep-interview"]),
+		recentModels:
+			over.recentModels ??
+			((): ModelOption[] => [
+				{ ref: "anthropic/opus", label: "opus", current: true },
+				{ ref: "openai/gpt-5", label: "gpt-5" },
+			]),
+		registerAsk: over.registerAsk ?? ((id, question, options) => rec.asks.push({ id, question, options })),
+		postMessage: over.postMessage ?? (text => rec.messages.push(text)),
+		runSkill:
+			over.runSkill ??
+			(async (skillName, prompt) => {
+				rec.skillRuns.push({ skillName, prompt });
+			}),
+		setModelTemporary:
+			over.setModelTemporary ??
+			(async ref => {
+				rec.modelSwitches.push(ref);
+				return { previous: "anthropic/opus", next: ref };
+			}),
+	};
+	return { rt: new CommandMenuRuntime(deps), rec };
+}
+
+describe("CommandMenuRuntime top-level menu", () => {
+	test("opens a 3-option menu and owns its id", () => {
+		const { rt, rec } = makeRuntime();
+		const id = rt.openTopLevelMenu();
+		expect(rt.owns(id)).toBe(true);
+		expect(rec.asks).toHaveLength(1);
+		expect(rec.asks[0]?.options).toEqual(["Skills", "Model", "Notify"]);
+		expect(id.startsWith("menu:")).toBe(true);
+	});
+
+	test("unknown ids are not menu actions (fall through to real asks)", async () => {
+		const { rt } = makeRuntime();
+		expect(await rt.handleReply("ask:real-gate", 0)).toEqual({ kind: "not_menu_action" });
+	});
+});
+
+describe("CommandMenuRuntime skills flow", () => {
+	test("Skills → submenu → pending skill prompt (no ask registered)", async () => {
+		const { rt, rec } = makeRuntime();
+		const menuId = rt.openTopLevelMenu();
+		// index 0 = Skills
+		expect(await rt.handleReply(menuId, 0)).toEqual({ kind: "resolved" });
+		const submenu = rec.asks[1];
+		expect(submenu?.options).toEqual(["ralplan", "deep-interview"]);
+		// pick ralplan (index 0)
+		expect(await rt.handleReply(submenu!.id, 0)).toEqual({ kind: "resolved" });
+		// No options-less ask is registered; a prompt message is posted instead.
+		expect(rt.hasPendingSkillPrompt).toBe(true);
+		expect(rec.messages.some(m => m.includes("/skill:ralplan"))).toBe(true);
+		expect(rec.asks).toHaveLength(2); // menu + submenu only
+		expect(await rt.consumePendingSkillPrompt("make a plan")).toBe(true);
+		expect(rec.skillRuns).toEqual([{ skillName: "ralplan", prompt: "make a plan" }]);
+		expect(rt.hasPendingSkillPrompt).toBe(false);
+	});
+
+	test("consumePendingSkillPrompt returns false when nothing pending", async () => {
+		const { rt } = makeRuntime();
+		expect(await rt.consumePendingSkillPrompt("unused")).toBe(false);
+		expect(rt.hasPendingSkillPrompt).toBe(false);
+	});
+	test("empty skill prompt is consumed without running", async () => {
+		const { rt, rec } = makeRuntime();
+		const menuId = rt.openTopLevelMenu();
+		await rt.handleReply(menuId, 0);
+		await rt.handleReply(rec.asks[1]!.id, 0);
+		expect(await rt.consumePendingSkillPrompt("   ")).toBe(true);
+		expect(rec.skillRuns).toEqual([]);
+		expect(rec.messages.some(m => m.includes("Empty prompt"))).toBe(true);
+	});
+
+	test("no skills available posts a message instead of a submenu", async () => {
+		const { rt, rec } = makeRuntime({ allowedSkillIds: () => [] });
+		const menuId = rt.openTopLevelMenu();
+		await rt.handleReply(menuId, 0);
+		expect(rec.messages.some(m => m.includes("No skills"))).toBe(true);
+	});
+});
+
+describe("CommandMenuRuntime model flow (temporary only)", () => {
+	test("Model → picker → setModelTemporary + previous→new feedback", async () => {
+		const { rt, rec } = makeRuntime();
+		const menuId = rt.openTopLevelMenu();
+		// index 1 = Model
+		expect(await rt.handleReply(menuId, 1)).toEqual({ kind: "resolved" });
+		const picker = rec.asks[1];
+		expect(picker?.options).toEqual(["opus (current)", "gpt-5"]);
+		// pick gpt-5 (index 1)
+		expect(await rt.handleReply(picker!.id, 1)).toEqual({ kind: "resolved" });
+		expect(rec.modelSwitches).toEqual(["openai/gpt-5"]);
+		expect(
+			rec.messages.some(m => m.includes("anthropic/opus → openai/gpt-5") && m.includes("this session only")),
+		).toBe(true);
+	});
+
+	test("no recent models posts a message", async () => {
+		const { rt, rec } = makeRuntime({ recentModels: () => [] });
+		const menuId = rt.openTopLevelMenu();
+		await rt.handleReply(menuId, 1);
+		expect(rec.messages.some(m => m.includes("No recent models"))).toBe(true);
+	});
+});
+
+describe("CommandMenuRuntime notify", () => {
+	test("Notify posts guidance", async () => {
+		const { rt, rec } = makeRuntime();
+		const menuId = rt.openTopLevelMenu();
+		await rt.handleReply(menuId, 2); // Notify
+		expect(rec.messages.some(m => m.includes("/notify status"))).toBe(true);
+	});
+
+	test("Help is no longer a menu option (index out of range is rejected)", async () => {
+		const { rt } = makeRuntime();
+		const menuId = rt.openTopLevelMenu();
+		expect(await rt.handleReply(menuId, 3)).toEqual({ kind: "rejected", reason: "unknown menu option" });
+	});
+
+	test("out-of-range menu option is rejected", async () => {
+		const { rt } = makeRuntime();
+		const menuId = rt.openTopLevelMenu();
+		expect(await rt.handleReply(menuId, 9)).toEqual({ kind: "rejected", reason: "unknown menu option" });
+	});
+});

--- a/packages/coding-agent/test/notifications-command-menu.test.ts
+++ b/packages/coding-agent/test/notifications-command-menu.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import {
+	decideMenuInbound,
+	isSyntheticActionId,
+	MENU_GUIDANCE,
+	makeSyntheticActionId,
+	parseMenuTrigger,
+	redirectTypedSlash,
+	TOP_LEVEL_MENU,
+} from "../src/notifications/command-menu";
+
+describe("command-menu parseMenuTrigger", () => {
+	test("matches /menu and the short alias /m only", () => {
+		expect(parseMenuTrigger("/menu")).toBe(true);
+		expect(parseMenuTrigger("  /MENU  ")).toBe(true);
+		expect(parseMenuTrigger("/m")).toBe(true);
+		expect(parseMenuTrigger("  /M  ")).toBe(true);
+		expect(parseMenuTrigger("/menu skills")).toBe(false);
+		expect(parseMenuTrigger("/menuish")).toBe(false);
+		expect(parseMenuTrigger("/model")).toBe(false);
+		expect(parseMenuTrigger("menu")).toBe(false);
+	});
+});
+
+describe("command-menu top-level palette", () => {
+	test("renders the MVP categories in order (no Help)", () => {
+		expect(TOP_LEVEL_MENU.map(e => e.category)).toEqual(["skills", "model", "notify"]);
+		expect(TOP_LEVEL_MENU.map(e => e.label)).toEqual(["Skills", "Model", "Notify"]);
+	});
+});
+
+describe("command-menu synthetic action ids", () => {
+	test("namespaced ids round-trip and are disjoint from workflow ask ids", () => {
+		for (const kind of ["menu", "submenu", "model"] as const) {
+			const id = makeSyntheticActionId(kind, "abc-123");
+			expect(id).toBe(`${kind}:abc-123`);
+			expect(isSyntheticActionId(id)).toBe(true);
+			expect(isSyntheticActionId(id)).toBe(true);
+		}
+	});
+
+	test("generated ids are unique and synthetic", () => {
+		const a = makeSyntheticActionId("menu");
+		const b = makeSyntheticActionId("menu");
+		expect(a).not.toBe(b);
+		expect(isSyntheticActionId(a)).toBe(true);
+	});
+
+	test("rejects non-synthetic ids (workflow ask/gate ids)", () => {
+		expect(isSyntheticActionId("ask:xyz")).toBe(false);
+		expect(isSyntheticActionId("gate-123")).toBe(false);
+		expect(isSyntheticActionId("menu:")).toBe(false);
+		expect(isSyntheticActionId(":abc")).toBe(false);
+		expect(isSyntheticActionId("plain")).toBe(false);
+	});
+});
+
+describe("command-menu redirectTypedSlash", () => {
+	test("does not redirect the /menu trigger, config commands, or free text", () => {
+		expect(redirectTypedSlash("/menu")).toEqual({ redirect: false });
+		expect(redirectTypedSlash("/verbose")).toEqual({ redirect: false });
+		expect(redirectTypedSlash("keep going")).toEqual({ redirect: false });
+	});
+
+	test("redirects raw typed commands to the menu guidance", () => {
+		const r = redirectTypedSlash("/skill:ralplan go");
+		expect(r.redirect).toBe(true);
+		if (r.redirect) expect(r.message).toBe(MENU_GUIDANCE);
+	});
+
+	test("redirects denied commands with the policy reason plus guidance", () => {
+		const r = redirectTypedSlash("/model gpt-5");
+		expect(r.redirect).toBe(true);
+		if (r.redirect) {
+			expect(r.message).toContain("Model menu");
+			expect(r.message).toContain(MENU_GUIDANCE);
+		}
+	});
+});
+
+describe("command-menu decideMenuInbound", () => {
+	test("/menu opens the menu", () => {
+		expect(decideMenuInbound("/menu")).toEqual({ kind: "open_menu" });
+	});
+
+	test("raw typed command yields guidance, not passthrough", () => {
+		const d = decideMenuInbound("/skill:ralplan go");
+		expect(d.kind).toBe("guidance");
+		if (d.kind === "guidance") expect(d.message).toBe(MENU_GUIDANCE);
+	});
+
+	test("denied command yields guidance with reason", () => {
+		const d = decideMenuInbound("/model gpt-5");
+		expect(d.kind).toBe("guidance");
+		if (d.kind === "guidance") expect(d.message).toContain("Model menu");
+	});
+
+	test("ordinary text and config commands pass through", () => {
+		expect(decideMenuInbound("keep going")).toEqual({ kind: "passthrough" });
+		expect(decideMenuInbound("/verbose")).toEqual({ kind: "passthrough" });
+	});
+});

--- a/packages/coding-agent/test/notifications-command-policy.test.ts
+++ b/packages/coding-agent/test/notifications-command-policy.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import {
+	classifyTypedSlash,
+	isAllowedSkillInvocation,
+	isConfigCommand,
+	isDeniedCommand,
+	isModelCommandWithArgs,
+	parseSlashName,
+} from "../src/notifications/command-policy";
+
+describe("command-policy parseSlashName", () => {
+	test("parses name and args, colon and space separators", () => {
+		expect(parseSlashName("/skill:ralplan refactor auth")).toEqual({ name: "skill", args: "ralplan refactor auth" });
+		expect(parseSlashName("/model gpt-5")).toEqual({ name: "model", args: "gpt-5" });
+		expect(parseSlashName("/menu")).toEqual({ name: "menu", args: "" });
+		expect(parseSlashName("plain text")).toBeUndefined();
+	});
+});
+
+describe("command-policy config detection", () => {
+	test("recognizes existing in-thread config commands", () => {
+		for (const c of ["/verbose", "/lean", "/verbosity verbose", "/redact on"]) expect(isConfigCommand(c)).toBe(true);
+		expect(isConfigCommand("/menu")).toBe(false);
+		expect(isConfigCommand("/skill:ralplan")).toBe(false);
+	});
+});
+
+describe("command-policy denial", () => {
+	test("/model with args is denied; bare /model is not", () => {
+		expect(isModelCommandWithArgs("/model gpt-5")).toBe(true);
+		expect(isModelCommandWithArgs("/model")).toBe(false);
+		expect(isDeniedCommand("/model gpt-5")).toBe(true);
+		expect(isDeniedCommand("/model")).toBe(false);
+	});
+
+	test("destructive/persistent/TUI-only commands and shell/eval are denied", () => {
+		for (const c of [
+			"/session delete",
+			"/memory clear",
+			"/provider add x",
+			"/compact",
+			"/clear",
+			"/vim",
+			"!ls",
+			"$1+1",
+		]) {
+			expect(isDeniedCommand(c)).toBe(true);
+		}
+	});
+
+	test("allowed surfaces are not denied", () => {
+		for (const c of ["/skill:ralplan", "/notify status", "/help", "/menu", "/model"]) {
+			expect(isDeniedCommand(c)).toBe(false);
+		}
+	});
+});
+
+describe("command-policy skill invocation", () => {
+	test("validates against session-provided allowlist, case-insensitive", () => {
+		const allowed = ["ralplan", "deep-interview", "ultragoal", "team"];
+		expect(isAllowedSkillInvocation("ralplan", allowed)).toBe(true);
+		expect(isAllowedSkillInvocation("RALPLAN", allowed)).toBe(true);
+		expect(isAllowedSkillInvocation("nope", allowed)).toBe(false);
+		expect(isAllowedSkillInvocation("", allowed)).toBe(false);
+	});
+});
+
+describe("command-policy classifyTypedSlash", () => {
+	test("classifies config, denied, command, and not_command", () => {
+		expect(classifyTypedSlash("/verbose")).toEqual({ kind: "config" });
+		expect(classifyTypedSlash("keep going").kind).toBe("not_command");
+		expect(classifyTypedSlash("!rm -rf").kind).toBe("denied");
+		expect(classifyTypedSlash("/model gpt-5").kind).toBe("denied");
+		expect(classifyTypedSlash("/session delete").kind).toBe("denied");
+		expect(classifyTypedSlash("/skill:ralplan go")).toEqual({ kind: "command" });
+		expect(classifyTypedSlash("/menu")).toEqual({ kind: "command" });
+	});
+});

--- a/packages/coding-agent/test/notifications-telegram-reference.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-reference.test.ts
@@ -105,6 +105,16 @@ describe("telegram reference client helpers", () => {
 		});
 	});
 
+	test("routeInboundUpdate ignores plain text for button-only synthetic asks", () => {
+		const ctx = {
+			aliasTable: createAliasTable(),
+			messageRoutes: new Map(),
+			pendingBySession: () => [{ sessionId: "only", actionId: "submenu:abc", buttonOnly: true }],
+			pairedChatId: "42",
+		};
+		expect(routeInboundUpdate({ message: { chat: { id: 42 }, text: "typed" } }, ctx)).toEqual({ kind: "ignore" });
+	});
+
 	test("buildActionMessage renders ask with an inline keyboard", () => {
 		const m = buildActionMessage({ kind: "ask", id: "a1", question: "Proceed?", options: ["Yes", "No"] });
 		expect(m.text).toContain("Proceed?");


### PR DESCRIPTION
## Summary
- Adds a Telegram `/menu` / `/m` command-menu surface for session notifications.
- Shows three top-level buttons in the Telegram session thread: `Skills`, `Model`, and `Notify`.
- Keeps raw risky slash commands out of Telegram; users pick safe actions from buttons instead.

## What appears where
- Where: in the existing Telegram notification thread for the active GJC session.
- Trigger: send `/menu` or `/m` as a normal Telegram message in that thread.
- Result: the bot posts an answerable `Commands` prompt with inline buttons:
  - `Skills`
  - `Model`
  - `Notify`

## What each button does
- `Skills`
  - Opens a second `Skills` button list using the session's available `/skill:<name>` entries.
  - Tapping a skill asks for the next free-text prompt.
  - The next Telegram message is run as `/skill:<selected-skill> <prompt>` through the same session-side skill execution path used by text mode.
- `Model`
  - Opens a `Recent models` picker using the current session's recent/available model list.
  - Tapping a model switches only the current session's temporary model.
  - It does not persist a default model or role setting.
- `Notify`
  - Posts guidance for the existing notification controls: `/notify status`, `/notify on`, `/notify off`.

## Short example
1. User sends `/menu` in the Telegram session thread.
2. Bot shows `Commands` with buttons: `Skills`, `Model`, `Notify`.
3. User taps `Model`.
4. Bot shows recent model buttons, for example `gpt-5 (current)` and `claude-sonnet-4`.
5. User taps `claude-sonnet-4`.
6. Bot replies `Model: gpt-5 → claude-sonnet-4 (this session only)`.

Skill example:
1. User sends `/menu`.
2. User taps `Skills`.
3. User taps `ralplan`.
4. Bot says: `Enter the prompt for /skill:ralplan, then send it as your next message.`
5. User sends `Plan a safer Telegram menu rollout`.
6. The session runs `/skill:ralplan Plan a safer Telegram menu rollout`.

## Safety / routing behavior
- Ordinary Telegram text remains a normal user message.
- Existing in-thread config commands still work: `/verbose`, `/lean`, `/verbosity`, `/redact`.
- Raw slash commands that are not config commands are redirected to `/menu` guidance instead of being executed from Telegram.
- Shell/eval escapes and persistent/destructive commands are denied from Telegram.
- Synthetic menu asks are button-only (`menu:`, `submenu:`, `model:` action ids), so free text while a menu is open is not accidentally consumed as a button click.

## Scope
- Implementation and tests only.
- Based on `upstream/dev`.
- No release/version bumps, lockfiles, package manifests, changelogs, native generated output, or plugin generated output included.

## Tests
- `bun test packages/coding-agent/test/menu-model-options.test.ts packages/coding-agent/test/notifications-command-menu-runtime.test.ts packages/coding-agent/test/notifications-command-menu.test.ts packages/coding-agent/test/notifications-command-policy.test.ts packages/coding-agent/test/notifications-telegram-reference.test.ts` — 48 pass, 0 fail, 150 expect() calls.
- `bun run check:ts` — passed. Biome reported existing deprecated `recommended` config info only.

## Note
- This PR is intentionally context-heavy because the feature is user-visible in Telegram. I included the button map and short click examples instead of a screenshot so reviewers can understand the exact Telegram flow without running a bot locally.
