### PR TITLE
fix: stabilize telegram daemon attachment tests

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1130,6 +1130,7 @@ export class TelegramNotificationDaemon {
 				// exclusive 0600 create (`wx`) refuses to follow a pre-existing file/symlink.
 				const dest = path.join(dir, `${crypto.randomBytes(8).toString("hex")}-${safeBase}`);
 				await fs.promises.writeFile(dest, bytes, { flag: "wx", mode: 0o600 });
+				await fs.promises.chmod(dest, 0o600).catch(() => undefined);
 				fileNotes.push(`[user attached a file, saved to ${dest}${att.mime ? ` (${att.mime})` : ""}]`);
 			}
 		} catch (e) {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -1346,9 +1346,11 @@ test("inbound document is saved to a tmp file and its path injected into the tex
 	const dest = match![1]!;
 	const fileMode = fs.statSync(dest).mode & 0o777;
 	const dirMode = fs.statSync(path.dirname(dest)).mode & 0o777;
-	expect(fileMode).toBe(0o600);
-	expect(fileMode & 0o077).toBe(0);
-	expect(dirMode & 0o077).toBe(0);
+	if (process.platform !== "win32") {
+		expect(fileMode).toBe(0o600);
+		expect(fileMode & 0o077).toBe(0);
+		expect(dirMode & 0o077).toBe(0);
+	}
 	expect(dest.startsWith(os.tmpdir())).toBe(true);
 });
 
@@ -1749,14 +1751,19 @@ test("requestStop aborts the active long poll and run() exits, releasing ownersh
 		pid: process.pid,
 		randomId: () => "owner",
 	});
+	const pollStarted = Promise.withResolvers<void>();
 	const bot = {
 		call: (method: string, _body: unknown, opts?: { signal?: AbortSignal }) => {
 			if (method === "getUpdates") {
-				return new Promise((_resolve, reject) => {
-					opts?.signal?.addEventListener("abort", () =>
-						reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
-					);
-				});
+				pollStarted.resolve();
+				if (opts?.signal?.aborted) {
+					return Promise.reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+				}
+				const abort = Promise.withResolvers<never>();
+				opts?.signal?.addEventListener("abort", () =>
+					abort.reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
+				);
+				return abort.promise;
 			}
 			return Promise.resolve({ ok: true, result: true });
 		},
@@ -1778,7 +1785,7 @@ test("requestStop aborts the active long poll and run() exits, releasing ownersh
 	});
 	daemon.connectSession("S", "ws://s", "t");
 	const runPromise = daemon.run();
-	await new Promise(resolve => setTimeout(resolve, 5));
+	await pollStarted.promise;
 	daemon.requestStop("signal");
 	await runPromise;
 	expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(false);


### PR DESCRIPTION
## Summary
- Makes the Telegram daemon inbound document permission assertion portable on Windows, where POSIX mode bits are not enforced the same way.
- Keeps a defensive chmod after attachment writes for POSIX runtimes.
- Replaces the long-poll stop test's timer race with an explicit poll-start signal so the abort path is deterministic.

## Tests
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts -t "inbound document is saved"` — 1 pass, 0 fail.
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts -t "requestStop aborts"` — 1 pass, 0 fail.
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts` — 53 pass, 0 fail, 174 expect() calls.
- `bun run check:ts` — passed. Biome reported existing deprecated `recommended` config info only.

## Failure notes
- Before this fix, `inbound document is saved to a tmp file and its path injected into the text` failed on Windows because `fs.stat().mode & 0o777` reported `0o666` instead of the POSIX-only expected `0o600`.
- Before this fix, `requestStop aborts the active long poll and run() exits, releasing ownership` could time out because the test slept for 5ms and sometimes requested stop before the long poll's abort signal listener was installed.
