### PR TITLE
feat(ai): add Sakana Fugu provider

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -79757,5 +79757,71 @@
 				"maxLevel": "xhigh"
 			}
 		}
+	},
+	"fugu": {
+		"fugu": {
+			"id": "fugu",
+			"name": "Sakana Fugu",
+			"api": "openai-completions",
+			"provider": "fugu",
+			"baseUrl": "https://api.sakana.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 65536,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": false,
+				"supportsUsageInStreaming": true,
+				"maxTokensField": "max_tokens"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"fugu-ultra": {
+			"id": "fugu-ultra",
+			"name": "Sakana Fugu Ultra",
+			"api": "openai-completions",
+			"provider": "fugu",
+			"baseUrl": "https://api.sakana.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 65536,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": false,
+				"supportsUsageInStreaming": true,
+				"maxTokensField": "max_tokens"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		}
 	}
 }

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -16,6 +16,7 @@ import {
 	deepseekModelManagerOptions,
 	firepassModelManagerOptions,
 	fireworksModelManagerOptions,
+	fuguModelManagerOptions,
 	githubCopilotModelManagerOptions,
 	groqModelManagerOptions,
 	huggingfaceModelManagerOptions,
@@ -154,6 +155,12 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		catalog("Fireworks", ["FIREWORKS_API_KEY"]),
 	),
 	descriptor("firepass", "kimi-k2.6-turbo", config => firepassModelManagerOptions(config)),
+	catalogDescriptor(
+		"fugu",
+		"fugu",
+		config => fuguModelManagerOptions(config),
+		catalog("Sakana Fugu", ["FUGU_API_KEY"]),
+	),
 	descriptor("xai", "grok-4-fast-non-reasoning", config => xaiModelManagerOptions(config)),
 	catalogDescriptor(
 		"deepseek",

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -785,6 +785,15 @@ export function firepassModelManagerOptions(
 // 7. Mistral
 // ---------------------------------------------------------------------------
 
+export interface FuguModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export function fuguModelManagerOptions(config?: FuguModelManagerConfig): ModelManagerOptions<"openai-completions"> {
+	return createSimpleOpenAICompletionsOptions("fugu", config?.baseUrl ?? "https://api.sakana.ai/v1", config);
+}
+
 export interface MistralModelManagerConfig {
 	apiKey?: string;
 	baseUrl?: string;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -84,6 +84,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	xai: "XAI_API_KEY",
 	fireworks: "FIREWORKS_API_KEY",
 	firepass: "FIREPASS_API_KEY",
+	fugu: "FUGU_API_KEY",
 	openrouter: "OPENROUTER_API_KEY",
 	kilo: "KILO_API_KEY",
 	"vercel-ai-gateway": "AI_GATEWAY_API_KEY",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -112,6 +112,7 @@ export type KnownProvider =
 	| "github-copilot"
 	| "fireworks"
 	| "firepass"
+	| "fugu"
 	| "gitlab-duo"
 	| "cursor"
 	| "deepseek"

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -76,6 +76,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "fugu",
+		name: "Sakana Fugu (API key)",
+		available: true,
+	},
+	{
 		id: "github-copilot",
 		name: "GitHub Copilot",
 		available: true,

--- a/packages/ai/test/fugu-provider.test.ts
+++ b/packages/ai/test/fugu-provider.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { getBundledModel } from "../src/models";
+import { DEFAULT_MODEL_PER_PROVIDER, PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
+import { fuguModelManagerOptions } from "../src/provider-models/openai-compat";
+import { getEnvApiKey } from "../src/stream";
+import { getOAuthProviders } from "../src/utils/oauth";
+
+const originalFuguApiKey = Bun.env.FUGU_API_KEY;
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	if (originalFuguApiKey === undefined) {
+		delete Bun.env.FUGU_API_KEY;
+	} else {
+		Bun.env.FUGU_API_KEY = originalFuguApiKey;
+	}
+	global.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("Sakana Fugu provider support", () => {
+	test("resolves FUGU_API_KEY from environment", () => {
+		Bun.env.FUGU_API_KEY = "fugu-test-key";
+		expect(getEnvApiKey("fugu")).toBe("fugu-test-key");
+	});
+
+	test("registers built-in descriptor and default model", () => {
+		const descriptor = PROVIDER_DESCRIPTORS.find(item => item.providerId === "fugu");
+		expect(descriptor).toBeDefined();
+		expect(descriptor?.defaultModel).toBe("fugu");
+		expect(descriptor?.catalogDiscovery?.envVars).toContain("FUGU_API_KEY");
+		expect(DEFAULT_MODEL_PER_PROVIDER.fugu).toBe("fugu");
+	});
+
+	test("registers API-key auth selector without inventing OAuth endpoints", () => {
+		const provider = getOAuthProviders().find(item => item.id === "fugu");
+		expect(provider?.name).toBe("Sakana Fugu (API key)");
+	});
+
+	test("bundles Fugu and Fugu Ultra as OpenAI-compatible chat models", () => {
+		const fugu = getBundledModel("fugu", "fugu");
+		const ultra = getBundledModel("fugu", "fugu-ultra");
+		expect(fugu.provider).toBe("fugu");
+		expect(fugu.api).toBe("openai-completions");
+		expect(fugu.baseUrl).toBe("https://api.sakana.ai/v1");
+		expect(fugu.api).toBe("openai-completions");
+		expect((fugu.compat as { maxTokensField?: string } | undefined)?.maxTokensField).toBe("max_tokens");
+		expect(ultra.name).toBe("Sakana Fugu Ultra");
+		expect(ultra.reasoning).toBe(true);
+	});
+
+	test("discovers OpenAI-compatible models with configurable base URL", async () => {
+		global.fetch = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						data: [
+							{ id: "fugu", name: "Fugu", context_length: 200000, max_completion_tokens: 65536 },
+							{ id: "fugu-ultra", name: "Fugu Ultra", context_length: 200000, max_completion_tokens: 65536 },
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+		) as unknown as typeof fetch;
+
+		const options = fuguModelManagerOptions({ apiKey: "fugu-test-key", baseUrl: "https://fugu.example/v1" });
+		expect(options.providerId).toBe("fugu");
+		expect(options.fetchDynamicModels).toBeDefined();
+
+		const models = await options.fetchDynamicModels?.();
+		expect(global.fetch).toHaveBeenCalledWith(
+			"https://fugu.example/v1/models",
+			expect.objectContaining({ method: "GET" }),
+		);
+		expect(models?.map(model => model.id)).toEqual(["fugu", "fugu-ultra"]);
+		expect(models?.[0]?.baseUrl).toBe("https://fugu.example/v1");
+	});
+});


### PR DESCRIPTION
## Summary
- add `fugu` as an OpenAI-compatible provider with bundled `fugu` and `fugu-ultra` models
- wire `FUGU_API_KEY`, provider descriptor/catalog discovery, and auth selector support
- add focused tests for env auth, descriptor/default model registration, bundled models, and configurable OpenAI-compatible discovery

OAuth note: the public Fugu page currently states the API is OpenAI-compatible and lists Fugu/Fugu Ultra, but the fetched public content does not expose OAuth endpoint details. This PR intentionally does not invent OAuth endpoints or secrets; it provides the verified API-key/OpenAI-compatible path and leaves OAuth to be added when public provider docs are available.

Closes #1082

## Verification
- `bun test packages/ai/test/fugu-provider.test.ts`
- `(cd packages/ai && bun run check)`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*