### PR TITLE
perf(tui): auto-enable viewport-windowed render for long transcripts

### DIFF
--- a/docs/tui-runtime-internals.md
+++ b/docs/tui-runtime-internals.md
@@ -117,13 +117,13 @@ Critical safety checks in `TUI`:
 
 These constraints are runtime guards plus component conventions; renderers should still return width-safe lines rather than rely on truncation.
 
-## Virtual viewport (opt-in, `PI_TUI_VIRTUAL_VIEWPORT`)
+## Virtual viewport (`PI_TUI_VIRTUAL_VIEWPORT`)
 
 By default `#doRender` normalizes/truncates and diffs the full rendered transcript every frame (`O(total lines)`), which becomes a per-frame cost on very long sessions / weak hardware.
 
-Setting `PI_TUI_VIRTUAL_VIEWPORT=1` enables an opt-in fast path: when the terminal width is unchanged and the off-screen raw prefix is unchanged from the previous frame (compared by raw value equality per line, which short-circuits to a fast reference check when components return stable string instances for unchanged lines), the previous frame's normalized prefix is reused and only the visible window (terminal rows + a small overscan) is re-normalized, with the differential diff starting at the window boundary. Output is byte-identical to the default path (reused entries are deterministic normalizations of identical raw lines), so it is a pure performance toggle.
+Viewport virtualization is a byte-identical fast path: when the terminal width is unchanged and the off-screen raw prefix is unchanged from the previous frame (compared by raw value equality per line, which short-circuits to a fast reference check when components return stable string instances for unchanged lines), the previous frame's normalized prefix is reused and only the visible window (terminal rows + a small overscan) is re-normalized, with the differential diff starting at the window boundary. Output is byte-identical to the full path (reused entries are deterministic normalizations of identical raw lines), so it is a pure performance optimization.
 
-The flag defaults to **off** because it changes a core render path; enable it to reduce per-frame normalize/diff cost on huge transcripts. Any width change, off-screen edit, forced render (`requestRender(true)`), or first frame transparently falls back to the full path. `PI_TUI_METRICS` exposes `lineCounts` gauges (`rendered`, `normalized`, `measured`, `diffed`, and `offscreenScan`) to observe the bound.
+It is **auto-enabled per frame** once the rendered transcript grows past a few screens (`>= max(rows * 4, 256)` lines) — exactly when a long session would otherwise start to feel slow — and stays on the full path for short transcripts (no behavior change). Set `PI_TUI_VIRTUAL_VIEWPORT=1` to force it on for every frame regardless of size; set `PI_TUI_VIRTUAL_VIEWPORT=0` (or `false`/`off`/`no`) to disable it entirely. Any width change, off-screen edit, forced render (`requestRender(true)`), or first frame transparently falls back to the full path. `PI_TUI_METRICS` exposes `lineCounts` gauges (`rendered`, `normalized`, `measured`, `diffed`, and `offscreenScan`) to observe the bound.
 
 ## Resize handling
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Viewport-windowed normalize/diff (`PI_TUI_VIRTUAL_VIEWPORT`) is now **auto-enabled per frame** once the rendered transcript grows past a few screens (`>= max(rows * 4, 256)` lines), instead of being opt-in only. This keeps per-frame render cost ~O(rows) on long/resumed sessions — where it previously grew O(total lines) and made long sessions feel sluggish — while staying byte-identical to the full path and leaving short transcripts untouched. `PI_TUI_VIRTUAL_VIEWPORT=1` still forces it on for every frame; `PI_TUI_VIRTUAL_VIEWPORT=0` (or `false`/`off`/`no`) disables it. The per-frame line normalization step is now non-mutating so the reused raw frame is never corrupted.
+
 ## [0.6.0] - 2026-06-18
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -149,6 +149,24 @@ function useLegacyMultiplexerFullRender(): boolean {
 }
 
 /**
+ * Viewport virtualization auto-enable thresholds. The windowed-normalize path
+ * (see {@link TUI.#doRender}) bounds the expensive per-frame normalize/diff work
+ * to roughly the visible window instead of the whole transcript. It is byte-identical
+ * to the full path, so we turn it on automatically once a transcript grows past a few
+ * screens — which is exactly when a long session starts to feel slow — while leaving
+ * short sessions on the original path (no behavior change, no extra bookkeeping).
+ */
+const VIRTUAL_VIEWPORT_AUTO_FACTOR = 4; // content taller than N screens auto-virtualizes
+const VIRTUAL_VIEWPORT_AUTO_MIN = 256; // ...but never below this many lines
+
+const FALSY_ENV = new Set(["0", "false", "off", "no", "n"]);
+/** Explicit opt-out: `PI_TUI_VIRTUAL_VIEWPORT=0` (or false/off/no) disables auto-virtualization too. */
+function isVirtualViewportDisabled(): boolean {
+	const raw = Bun.env.PI_TUI_VIRTUAL_VIEWPORT;
+	return raw !== undefined && FALSY_ENV.has(raw.trim().toLowerCase());
+}
+
+/**
  * Options for overlay positioning and sizing.
  * Values can be absolute numbers or percentage strings (e.g., "50%").
  */
@@ -278,10 +296,11 @@ export class TUI extends Container {
 	terminal: Terminal;
 	#previousLines: string[] = [];
 	/**
-	 * Raw (pre-normalization) lines from the previous frame, kept only when the
-	 * virtual-viewport flag is on. Used to detect whether the off-screen prefix is
-	 * unchanged (by raw value equality, with a fast reference short-circuit when components
-	 * return stable string instances) so its normalized form can be reused (bounded normalize).
+	 * Raw (pre-normalization) lines from the previous frame, kept whenever viewport
+	 * virtualization was active last frame (forced via env or auto-enabled for a long
+	 * transcript). Used to detect whether the off-screen prefix is unchanged (by raw
+	 * value equality, with a fast reference short-circuit when components return stable
+	 * string instances) so its normalized form can be reused (bounded normalize).
 	 */
 	#previousRaw: string[] = [];
 	#lineNormalizationCache = new Map<string, LineNormalizationCacheEntry>();
@@ -314,9 +333,13 @@ export class TUI extends Container {
 	#sixelProbeUnsubscribe?: () => void;
 	#showHardwareCursor = $flag("PI_HARDWARE_CURSOR");
 	#clearOnShrink = $flag("PI_CLEAR_ON_SHRINK"); // Clear empty rows when content shrinks (default: off)
-	// Opt-in: reuse the previous normalized off-screen prefix and only normalize/diff the
-	// visible window, bounding per-frame work on huge transcripts. Output stays byte-identical.
-	#virtualViewport = $flag("PI_TUI_VIRTUAL_VIEWPORT");
+	// Viewport virtualization: reuse the previous normalized off-screen prefix and only
+	// normalize/diff the visible window, bounding per-frame work on huge transcripts.
+	// Output stays byte-identical. Forced on with PI_TUI_VIRTUAL_VIEWPORT=1; otherwise
+	// auto-enabled per frame once the transcript grows past a few screens (see
+	// VIRTUAL_VIEWPORT_AUTO_*). Set PI_TUI_VIRTUAL_VIEWPORT=0 to disable entirely.
+	#virtualViewportForced = $flag("PI_TUI_VIRTUAL_VIEWPORT");
+	#virtualViewportDisabled = isVirtualViewportDisabled();
 	#maxLinesRendered = 0; // Line count from last render, used for viewport calculation
 	#fullRedrawCount = 0;
 	#stopped = false;
@@ -1261,12 +1284,18 @@ export class TUI extends Container {
 		return this.#lineFitsWidth(normalized, width) ? terminated : this.#truncateNormalizedLine(normalized, width);
 	}
 
+	/**
+	 * Normalize + width-fit every line for emission. Non-mutating: returns a fresh array
+	 * and never writes back into `lines`, so a cached raw frame (reused next frame by the
+	 * virtualization path) is never corrupted.
+	 */
 	#applyLineResetsAndTruncate(lines: string[], width: number): string[] {
+		const out = new Array<string>(lines.length);
 		for (let i = 0; i < lines.length; i++) {
-			lines[i] = this.#normalizeLineForEmit(lines[i], width);
+			out[i] = this.#normalizeLineForEmit(lines[i], width);
 		}
 		this.#trimLineCachesForRender(lines.length);
-		return lines;
+		return out;
 	}
 
 	#doRender(): void {
@@ -1303,19 +1332,25 @@ export class TUI extends Container {
 		const widthChanged = this.#previousWidth !== 0 && this.#previousWidth !== width;
 		const heightChanged = this.#previousHeight !== 0 && this.#previousHeight !== height;
 
-		// Normalize/truncate lines for emission. With the opt-in virtual-viewport flag
-		// (PI_TUI_VIRTUAL_VIEWPORT) we reuse the previous frame's normalized prefix when the
-		// off-screen raw prefix is unchanged (raw value equality per line; fast reference
-		// short-circuit for cached components), so only the visible window is
-		// re-normalized and the diff starts at the window. Output is byte-identical to the
-		// full path (reused entries are deterministic normalizations of identical raw lines).
+		// Normalize/truncate lines for emission. Viewport virtualization reuses the previous
+		// frame's normalized prefix when the off-screen raw prefix is unchanged (raw value
+		// equality per line; fast reference short-circuit for cached components), so only the
+		// visible window is re-normalized and the diff starts at the window. Output is
+		// byte-identical to the full path (reused entries are deterministic normalizations of
+		// identical raw lines). It is forced on with PI_TUI_VIRTUAL_VIEWPORT=1 and otherwise
+		// auto-enabled once the transcript grows past a few screens — bounding the expensive
+		// per-frame work exactly when a long session would otherwise get slow.
 		const VIEWPORT_NORMALIZE_OVERSCAN = 8;
 		const rawLines = newLines;
 		const total = rawLines.length;
+		const virtualViewport =
+			!this.#virtualViewportDisabled &&
+			(this.#virtualViewportForced ||
+				total >= Math.max(height * VIRTUAL_VIEWPORT_AUTO_FACTOR, VIRTUAL_VIEWPORT_AUTO_MIN));
 		let diffStart = 0;
 		let usedWindowNormalize = false;
 		if (
-			this.#virtualViewport &&
+			virtualViewport &&
 			!widthChanged &&
 			this.#previousRaw.length > 0 &&
 			this.#previousLines.length === this.#previousRaw.length
@@ -1342,11 +1377,11 @@ export class TUI extends Container {
 			}
 		}
 		if (!usedWindowNormalize) {
-			newLines = this.#applyLineResetsAndTruncate(this.#virtualViewport ? rawLines.slice() : rawLines, width);
+			newLines = this.#applyLineResetsAndTruncate(rawLines, width);
 		}
-		if (this.#virtualViewport) {
-			this.#previousRaw = rawLines;
-		}
+		// Retain the raw frame only while virtualization is active so a later re-enable never
+		// reuses a stale prefix; clearing it keeps the windowed-path guard honest.
+		this.#previousRaw = virtualViewport ? rawLines : [];
 		if (renderMetrics.enabled) {
 			renderMetrics.recordLineCount("rendered", total);
 			renderMetrics.recordLineCount("normalized", total - diffStart);

--- a/packages/tui/test/viewport-virtualization.test.ts
+++ b/packages/tui/test/viewport-virtualization.test.ts
@@ -173,4 +173,122 @@ describe("virtual viewport rendering (W1b / F1)", () => {
 			if (!wasEnabled) renderMetrics.disable();
 		}
 	});
+	it("auto-enables virtualization for a long transcript with no flag set", async () => {
+		delete Bun.env[FLAG];
+		const wasEnabled = renderMetrics.enabled;
+		renderMetrics.reset();
+		renderMetrics.enable();
+		const term = new VirtualTerminal(40, 40);
+		const tui = new TUI(term);
+		// 600 lines > max(height*4, 256) auto-enable threshold.
+		const big = Array.from({ length: 600 }, (_v, i) => `row-${i}`);
+		const content = new CachedLines(big);
+		tui.addChild(content);
+		try {
+			tui.start();
+			await settle(term);
+			content.setLine(599, "row-599-edited");
+			tui.requestRender();
+			await settle(term);
+			const lc = renderMetrics.snapshot().lineCounts;
+			// Bottom-line edit must re-normalize ~viewport, not the whole 600-line transcript,
+			// even though PI_TUI_VIRTUAL_VIEWPORT was never set.
+			expect(lc.normalized?.last).toBeLessThanOrEqual(60);
+			expect(lc.offscreenScan?.last).toBeGreaterThan(500);
+		} finally {
+			tui.stop();
+			renderMetrics.reset();
+			if (!wasEnabled) renderMetrics.disable();
+		}
+	});
+
+	it("does not auto-virtualize a short transcript (below threshold)", async () => {
+		delete Bun.env[FLAG];
+		const wasEnabled = renderMetrics.enabled;
+		renderMetrics.reset();
+		renderMetrics.enable();
+		const term = new VirtualTerminal(40, 40);
+		const tui = new TUI(term);
+		const small = Array.from({ length: 100 }, (_v, i) => `row-${i}`);
+		const content = new CachedLines(small);
+		tui.addChild(content);
+		try {
+			tui.start();
+			await settle(term);
+			content.setLine(99, "row-99-edited");
+			tui.requestRender();
+			await settle(term);
+			const lc = renderMetrics.snapshot().lineCounts;
+			// Short transcripts stay on the original full-normalize path: no windowed reuse.
+			expect(lc.offscreenScan?.last ?? 0).toBe(0);
+		} finally {
+			tui.stop();
+			renderMetrics.reset();
+			if (!wasEnabled) renderMetrics.disable();
+		}
+	});
+
+	it("PI_TUI_VIRTUAL_VIEWPORT=0 opts out of auto-virtualization", async () => {
+		Bun.env[FLAG] = "0";
+		const wasEnabled = renderMetrics.enabled;
+		renderMetrics.reset();
+		renderMetrics.enable();
+		const term = new VirtualTerminal(40, 40);
+		const tui = new TUI(term);
+		const big = Array.from({ length: 600 }, (_v, i) => `row-${i}`);
+		const content = new CachedLines(big);
+		tui.addChild(content);
+		try {
+			tui.start();
+			await settle(term);
+			content.setLine(599, "row-599-edited");
+			tui.requestRender();
+			await settle(term);
+			const lc = renderMetrics.snapshot().lineCounts;
+			// Disabled: every frame normalizes the full transcript, no windowed reuse.
+			expect(lc.offscreenScan?.last ?? 0).toBe(0);
+			expect(lc.normalized?.last).toBeGreaterThanOrEqual(600);
+		} finally {
+			tui.stop();
+			renderMetrics.reset();
+			if (!wasEnabled) renderMetrics.disable();
+		}
+	});
+
+	it("auto-virtualized output is byte-identical to the opt-out path", async () => {
+		const render = async (mode: "auto" | "off"): Promise<string[][]> => {
+			if (mode === "off") Bun.env[FLAG] = "0";
+			else delete Bun.env[FLAG];
+			const term = new VirtualTerminal(50, 20);
+			const tui = new TUI(term);
+			const rows = Array.from({ length: 400 }, (_v, i) => `line-${i}`);
+			const content = new CachedLines(rows);
+			tui.addChild(content);
+			const snaps: string[][] = [];
+			try {
+				tui.start();
+				await settle(term);
+				snaps.push(visible(term));
+				content.append("appended-A");
+				content.append("appended-B");
+				tui.requestRender();
+				await settle(term);
+				snaps.push(visible(term));
+				content.setLine(401, "appended-A-edited");
+				tui.requestRender();
+				await settle(term);
+				snaps.push(visible(term));
+				content.setLine(0, "line-0-edited-offscreen");
+				tui.requestRender();
+				await settle(term);
+				snaps.push(visible(term));
+			} finally {
+				tui.stop();
+			}
+			return snaps;
+		};
+		const auto = await render("auto");
+		const off = await render("off");
+		expect(auto).toEqual(off);
+	});
 });


### PR DESCRIPTION
## What

Auto-enables the byte-identical viewport-windowed normalize/diff path in `TUI.#doRender` once a rendered transcript grows past a few screens (`>= max(rows * 4, 256)` lines), instead of leaving it opt-in behind `PI_TUI_VIRTUAL_VIEWPORT`.

- `PI_TUI_VIRTUAL_VIEWPORT=1` → force on every frame (unchanged).
- unset → auto-enabled only for long transcripts (new default).
- `PI_TUI_VIRTUAL_VIEWPORT=0` / `false` / `off` / `no` → fully disabled (opt-out).
- `#applyLineResetsAndTruncate` is now non-mutating, so the raw frame reused next frame by the windowed path can never be corrupted by the full-normalize fallback.

## Why

Resuming/continuing a long session (`gjc --resume <id>`) got progressively slower: `#doRender` normalized + diffed the **entire** rendered transcript every frame (`O(total lines)`), so per-frame cost grew with session length — streaming, spinner ticks, and keystrokes all paid it. The viewport-windowed path that bounds this to ~`O(rows)` already existed and is proven byte-identical, but was opt-in, so users never benefited by default.

Auto-enabling it exactly when a session gets long fixes the slowdown without touching short-session behavior.

Measured per-frame stream render on a 100k-line transcript (VirtualTerminal, 120x40):

| mode | per-frame |
|---|---|
| `=0` (old default / full path) | ~11.3ms |
| unset (new default / auto) | ~3.6ms |
| `=1` (forced) | ~2.8ms |

## Testing

- `bun test packages/tui/test` — 548 pass / 0 fail.
- New cases in `viewport-virtualization.test.ts`: auto-enable on a long transcript with no flag set; no auto-virtualization below threshold; `PI_TUI_VIRTUAL_VIEWPORT=0` opt-out; and auto-vs-opt-out byte-identical output.
- `tsc --noEmit -p packages/tui/tsconfig.json` clean.
- Existing "byte-identical with flag on vs off" + 100k-line bound tests still pass.

---

- [x] `bun test packages/tui/test` passes
- [x] Tested locally (benchmark above)
- [x] CHANGELOG updated (packages/tui/CHANGELOG.md)