### PR TITLE
fix(agent): detect proxy-level context overflow from empty responses

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -7,6 +7,7 @@ import {
 	type AssistantMessageEvent,
 	type Context,
 	EventStream,
+	isContextOverflow,
 	isZodSchema,
 	streamSimple,
 	type ToolResultMessage,
@@ -51,6 +52,15 @@ import type {
 
 /** Sentinel returned by the abort race in `streamAssistantResponse`. */
 const ABORTED: unique symbol = Symbol("agent-loop-aborted");
+/**
+ * Detect empty "successful" responses that indicate a proxy-level context
+ * overflow (e.g. LiteLLM returning `content: []`, `stopReason: "stop"`, and a
+ * fabricated near-zero usage). We delegate to {@link isContextOverflow} which
+ * has the threshold constant, so the detection logic stays in one place.
+ */
+function isEmptyResponseOverflow(message: AssistantMessage): boolean {
+	return isContextOverflow(message);
+}
 
 class HarmonyLeakInterruption extends Error {
 	constructor(
@@ -531,6 +541,19 @@ async function runLoopBody(
 			}
 			newMessages.push(message);
 			let steeringMessagesFromExecution: AgentMessage[] | undefined;
+
+			// Detect empty "successful" responses (stopReason "stop" + empty content).
+			// Some proxies (e.g. LiteLLM) return this when the upstream model's context
+			// window is exceeded, fabricating a near-zero usage instead of surfacing an
+			// error. Without this guard the agent loop treats the empty response as a
+			// natural turn completion and stops, leaving the user with a frozen session.
+			// Promote it to an error so the overflow/compaction recovery path can fire.
+			if (message.stopReason === "stop" && message.content.length === 0 && isEmptyResponseOverflow(message)) {
+				message.stopReason = "error";
+				message.errorMessage = message.errorMessage
+					? `${message.errorMessage} | Provider returned an empty response with anomalously low token usage (possible context overflow via proxy)`
+					: "Provider returned an empty response with anomalously low token usage (possible context overflow via proxy)";
+			}
 
 			if (message.stopReason === "error" || message.stopReason === "aborted") {
 				// Create placeholder tool results for any tool calls in the aborted message

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1058,3 +1058,69 @@ describe("agentLoopContinue with AgentMessage", () => {
 		expect(messages[2]).toMatchObject({ role: "user", content: "follow-up" });
 	});
 });
+
+describe("agentLoop - empty response overflow detection", () => {
+	it("promotes empty stop response with low usage to error stopReason", async () => {
+		const context: AgentContext = {
+			systemPrompt: ["You are helpful."],
+			messages: [],
+			tools: [],
+		};
+
+		// Simulate a proxy (e.g. LiteLLM) returning an empty "successful" response
+		// with fabricated near-zero usage when the upstream model context window
+		// is exceeded.
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [],
+					stopReason: "stop",
+					usage: { input: 1, output: 1 },
+				},
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, mock.stream);
+		for await (const _ of stream) {
+			// drain
+		}
+
+		const messages = await stream.result();
+		const assistantMessage = messages.find(m => m.role === "assistant") as AssistantMessage | undefined;
+		expect(assistantMessage).toBeDefined();
+		expect(assistantMessage!.stopReason).toBe("error");
+		expect(assistantMessage!.errorMessage).toContain("empty response");
+	});
+
+	it("does not promote empty stop response with realistic usage to error", async () => {
+		const context: AgentContext = {
+			systemPrompt: ["You are helpful."],
+			messages: [],
+			tools: [],
+		};
+
+		// An empty response with realistic usage should NOT be treated as overflow.
+		// (Some models legitimately return empty content with real token counts.)
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [],
+					stopReason: "stop",
+					usage: { input: 5000, output: 100 },
+				},
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, mock.stream);
+		for await (const _ of stream) {
+			// drain
+		}
+
+		const messages = await stream.result();
+		const assistantMessage = messages.find(m => m.role === "assistant") as AssistantMessage | undefined;
+		expect(assistantMessage).toBeDefined();
+		expect(assistantMessage!.stopReason).toBe("stop");
+	});
+});

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -53,13 +53,25 @@ const OVERFLOW_PATTERNS = [
 	/model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
 ];
 /**
+ * Threshold below which a "successful" (stopReason "stop") response with empty
+ * content is considered anomalous. Some proxies (notably LiteLLM) return an
+ * empty `choices[0].message.content` with a near-zero `usage` (e.g. input: 1,
+ * output: 1) when the upstream model context window is exceeded, instead of
+ * surfacing a proper error. The total token count for such a response is well
+ * below any realistic turn, so we treat it as a proxy-level overflow signal.
+ */
+const EMPTY_RESPONSE_USAGE_THRESHOLD = 5;
+/**
  * Check if an assistant message represents a context overflow error.
  *
- * This handles two cases:
+ * This handles three cases:
  * 1. Error-based overflow: Most providers return stopReason "error" with a
  *    specific error message pattern.
  * 2. Silent overflow: Some providers accept overflow requests and return
  *    successfully. For these, we check if usage.input exceeds the context window.
+ * 3. Proxy-level overflow: Some proxies (e.g. LiteLLM) return a "successful"
+ *    response with empty content and a fabricated near-zero usage when the
+ *    upstream model's context window is exceeded.
  *
  * ## Reliability by Provider
  *
@@ -83,6 +95,13 @@ const OVERFLOW_PATTERNS = [
  * - z.ai: Sometimes accepts overflow silently (detectable via usage.input > contextWindow),
  *   sometimes returns rate limit errors. Pass contextWindow param to detect silent overflow.
  * - Ollama: Silently truncates input without error. Cannot be detected via this function.
+ * - LiteLLM proxy: Returns a "successful" response with empty content and a
+ *   fabricated near-zero usage (e.g. input: 1, output: 1) when the upstream
+ *   model's context window is exceeded. Detected via Case 3 (empty content +
+ *   anomalously low usage). Note: the LiteLLM proxy's context limit may differ
+ *   from the underlying model's advertised contextWindow (e.g. configured via
+ *   `model_info.max_tokens` in LiteLLM's config.yaml), so Case 2 (which compares
+ *   usage.input against contextWindow) may not catch it.
  *   The response will have usage.input < expected, but we don't know the expected value.
  *
  * ## Custom Providers
@@ -124,6 +143,21 @@ export function isContextOverflow(message: AssistantMessage, contextWindow?: num
 		if (inputTokens > contextWindow) {
 			return true;
 		}
+	}
+
+	// Case 3: Empty response with anomalously low usage (proxy-level overflow)
+	// Some proxies (e.g. LiteLLM) return a "successful" response (stopReason "stop")
+	// with empty content and a near-zero token count when the upstream model's
+	// context window is exceeded. This is distinct from silent overflow (Case 2),
+	// where the provider reports the real input token count. Here the proxy
+	// fabricates a bogus usage (input: 1, output: 1) that is far below any
+	// realistic turn, so we detect it heuristically.
+	if (
+		message.stopReason === "stop" &&
+		message.content.length === 0 &&
+		message.usage.input + message.usage.output <= EMPTY_RESPONSE_USAGE_THRESHOLD
+	) {
+		return true;
 	}
 
 	return false;

--- a/packages/ai/test/overflow-utils.test.ts
+++ b/packages/ai/test/overflow-utils.test.ts
@@ -86,3 +86,56 @@ describe("isContextOverflow - 400/413 no-body (Cerebras, Mistral, proxy wrappers
 		expect(isContextOverflow(createErrorMessage("429 status code (no body)"))).toBe(false);
 	});
 });
+
+describe("isContextOverflow - empty response with low usage (proxy-level overflow)", () => {
+	function createEmptyStopMessage(input = 1, output = 1): AssistantMessage {
+		return {
+			role: "assistant",
+			content: [],
+			api: "openai-completions",
+			provider: "spac-litellm",
+			model: "zai-org/GLM-5.2",
+			usage: {
+				input,
+				output,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: input + output,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+	}
+
+	it("detects empty content with fabricated near-zero usage (LiteLLM proxy)", () => {
+		const message = createEmptyStopMessage(1, 1);
+		expect(isContextOverflow(message)).toBe(true);
+	});
+
+	it("detects empty content at threshold boundary (total = 5)", () => {
+		const message = createEmptyStopMessage(3, 2);
+		expect(isContextOverflow(message)).toBe(true);
+	});
+
+	it("does not classify empty content with realistic usage as overflow", () => {
+		const message = createEmptyStopMessage(5000, 100);
+		expect(isContextOverflow(message)).toBe(false);
+	});
+
+	it("does not classify non-empty content with low usage as overflow", () => {
+		const message: AssistantMessage = {
+			...createEmptyStopMessage(1, 1),
+			content: [{ type: "text", text: "ok" }],
+		};
+		expect(isContextOverflow(message)).toBe(false);
+	});
+
+	it("does not classify empty content with non-stop stopReason as overflow", () => {
+		const message: AssistantMessage = {
+			...createEmptyStopMessage(1, 1),
+			stopReason: "length",
+		};
+		expect(isContextOverflow(message)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Problem

When using a proxy such as LiteLLM with a model whose context window is smaller than the configured `contextWindow` (e.g. GLM-5.2 advertised at 1M tokens but LiteLLM proxy enforces 200K), sessions freeze once the context approaches the proxy limit. The user can type new messages but nothing happens — only starting a new session unblocks.

## Root Cause

Three-stage failure:

1. **LiteLLM proxy returns an empty "successful" response** — `content: []`, `stopReason: "stop"`, and a fabricated near-zero `usage` (e.g. `input: 1, output: 1`) when the upstream model context window is exceeded.

2. **`agent-loop.ts` treats this as normal completion** — `stopReason: "stop"` + empty content + no tool calls → the loop exits and the turn ends. No error is raised.

3. **`isContextOverflow` cannot detect it** — Case 1 requires `stopReason: "error"`, and Case 2 (silent overflow) compares `usage.input` against `contextWindow`, but the proxy reports `input: 1` which is far below any window.

### Evidence from a frozen session

```
# Normal turn just before the freeze:
stop=toolUse, input=181825, output=344, total=182169

# Then three consecutive empty responses:
stop=stop, input=1, output=1, total=2, content_len=0
stop=stop, input=1, output=1, total=2, content_len=0
stop=stop, input=1, output=1, total=2, content_len=0
```

## Fix

### `packages/ai/src/utils/overflow.ts`

Add **Case 3** to `isContextOverflow`: a "successful" response (`stopReason: "stop"`) with empty content and total usage (input + output) at or below `EMPTY_RESPONSE_USAGE_THRESHOLD` (5 tokens). This is well below any realistic turn and indicates the proxy did not actually process the request.

### `packages/agent/src/agent-loop.ts`

After `streamAssistantResponse` returns, if the empty-response-overflow pattern is detected, promote `stopReason` to `"error"` with a descriptive `errorMessage`. This causes the existing `#checkCompaction` → `isContextOverflow` path in `agent-session.ts` to trigger auto-compaction, recovering the session instead of freezing.

## Testing

- 5 new tests in `overflow-utils.test.ts` (Case 3 positive/negative cases)
- 2 new tests in `agent-loop.test.ts` (empty response promoted to error; realistic usage not promoted)
- All existing tests pass (17 overflow + 23 agent-loop)

```
bun test packages/ai/test/overflow-utils.test.ts   → 17 pass
bun test packages/agent/test/agent-loop.test.ts     → 23 pass
```