### PR TITLE
fix(ssh): parse quoted remove host names

### DIFF
--- a/packages/coding-agent/src/slash-commands/helpers/parse.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/parse.ts
@@ -1,3 +1,4 @@
+import { parseCommandArgs } from "../../utils/command-args";
 import type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime } from "../types";
 
 export interface ParsedSubcommand {
@@ -65,7 +66,7 @@ export function errorMessage(error: unknown): string {
  * "name required" diagnostics with their own messaging.
  */
 export function parseNamedScopeArgs(rest: string, invalidScopeMessage: string): NamedScopeArgs {
-	const tokens = rest.split(/\s+/).filter(Boolean);
+	const tokens = parseCommandArgs(rest);
 	let name: string | undefined;
 	let scope: ConfigScope = "project";
 	let i = 0;

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -836,6 +836,22 @@ describe("wave 5 — adapters and polish", () => {
 		}
 	});
 
+	it("/ssh remove parses quoted host names", async () => {
+		const spy = spyOn(sshConfig, "removeSSHHost").mockResolvedValue(undefined);
+		try {
+			const { output, runtime } = createRuntime();
+			const result = await executeAcpBuiltinSlashCommand('/ssh remove "work vm" --scope user', runtime);
+			expect(result).toEqual({ consumed: true });
+			expect(output[0]).toContain('Removed SSH host "work vm" from user config.');
+			expect(spy).toHaveBeenCalledTimes(1);
+			const [configPath, name] = spy.mock.calls[0]!;
+			expect(typeof configPath).toBe("string");
+			expect(name).toBe("work vm");
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
 	// /model with unknown id
 	it("/model gpt-fake-9000: returns unknown-model message", async () => {
 		const { output, runtime } = createRuntime();


### PR DESCRIPTION
## What

- Make remove-style named/scope slash parsing use `parseCommandArgs` instead of whitespace splitting.
- Add an ACP regression test for removing a quoted SSH host alias.

## Why

`/ssh add` already accepts quoted host aliases via `parseCommandArgs`, so a user can add an alias with spaces:

```text
/ssh add "work vm" --host example.com --scope user
```

But `/ssh remove` went through `parseNamedScopeArgs`, which split on whitespace. The same quoted alias failed before reaching `removeSSHHost`.

Reproduction before this fix:

```bash
bun -e '
import { executeAcpBuiltinSlashCommand } from "./packages/coding-agent/src/slash-commands/acp-builtins.ts";
const output=[];
const runtime={cwd: process.cwd(), output: async (s)=>output.push(s), session:{ refreshSshTool: async()=>{} }, notifyTitleChanged: async()=>{}};
const result=await executeAcpBuiltinSlashCommand("/ssh remove \\"work vm\\" --scope user", runtime);
console.log(JSON.stringify({result, output}, null, 2));
'
```

Before output:

```json
{
  "result": {
    "consumed": true
  },
  "output": [
    "Unknown option: vm\""
  ]
}
```

## Testing

- [x] `bun --cwd=packages/natives run build`
- [x] `bun test packages/coding-agent/test/acp-builtins.test.ts --test-name-pattern 'ssh remove parses quoted host names'`
- [x] `bun test packages/coding-agent/test/acp-builtins.test.ts`
- [x] `bun --cwd=packages/coding-agent run check`

---

- [x] `bun check` passes (`bun --cwd=packages/coding-agent run check`; Biome printed one pre-existing deprecation info for `src/defaults/gjc/extensions/grok-cli-vendor/biome.json`)
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
