### PR TITLE
fix(agent): harden Composer trace mutation classifier

### DIFF
--- a/packages/agent/bench/composer-scenarios.ts
+++ b/packages/agent/bench/composer-scenarios.ts
@@ -1,0 +1,360 @@
+/**
+ * Single source of truth for Composer stability V3 scenarios (prompts + obligations).
+ * Live capture and the trace classifier must import from here — do not duplicate prompts.
+ */
+
+export type ScenarioId =
+	| "read-edit-hashline"
+	| "three-turn-tools"
+	| "bash-discipline"
+	| "file-discovery-discipline"
+	| "shell-write-discipline"
+	| "command-contamination"
+	| "grok-sanitize-replay"
+	| "multi-file-search-edit"
+	| "multi-file-search-edit-bad-anchor"
+	| "bad-anchor-recovery"
+	| "tool-json-malformed-recovery"
+	| "multi-turn-yield-discipline"
+	| "timeout-handling"
+	| "hard-guard-feedback"
+	| "legitimate-bash-after-tools"
+	| "wrong-target-disambiguation"
+	| "malformed-edit-recovery"
+	| "cost-safe-timeout";
+
+export type FailureClass =
+	| "shell-read"
+	| "shell-file-discovery"
+	| "shell-write"
+	| "contaminated-command"
+	| "bad-anchor-unrecovered"
+	| "malformed-tool-args-unrecovered"
+	| "sanitize-replay-regression"
+	| "wrong-file-edit"
+	| "missing-tool-turn"
+	| "timeout";
+
+export type ScenarioDefinition = {
+	id: ScenarioId;
+	description: string;
+	turns: string;
+	fixture: string;
+	obligation: string;
+	/** Frozen user prompt for live print-mode capture (composer-scenarios v1). */
+	userPrompt: string;
+	failureClass: FailureClass;
+	recovery: boolean;
+};
+
+/** P1 anti-fake-pass: minimum comparable scenario ids (candidate + baseline). */
+export const MIN_COMPARABLE_TRACE_SCENARIOS = 3;
+
+/** Public L2 claim: minimum scenarios with both roles represented in trace corpus. */
+export const L2_MIN_SCENARIO_COVERAGE = 10;
+
+export const COMPOSER_SCENARIOS_V1_COUNT = 13;
+export const TOTAL_SCENARIO_COUNT = 18;
+
+export const COMPOSER_SCENARIOS_VERSION = "v2";
+
+export const DEFAULT_COMPOSER_CANDIDATE_MODEL = "grok-build/grok-composer-2.5-fast";
+export const DEFAULT_CODEX_BASELINE_MODEL = "openai-codex/gpt-5.5:low";
+
+export const L3_MIN_TRIALS_PER_ARM = 3;
+
+export type TraceExpectation = {
+	targetPath?: string;
+	requiredTools?: string[];
+	expectedEditText?: string;
+	requireSuccess?: boolean;
+};
+
+export function traceExpectationForScenario(scenarioId: ScenarioId): TraceExpectation {
+	switch (scenarioId) {
+		case "bash-discipline":
+			return { requiredTools: ["read"], requireSuccess: true };
+		case "three-turn-tools":
+			return {
+				targetPath: "fixtures/workspace/src/a.ts",
+				expectedEditText: "TARGET_MARKER_DONE",
+				requiredTools: ["read", "search", "edit"],
+				requireSuccess: true,
+			};
+		case "shell-write-discipline":
+			return { targetPath: "fixtures/workspace/src/write-target.ts", expectedEditText: "42", requireSuccess: true };
+		case "multi-file-search-edit":
+			return {
+				targetPath: "fixtures/workspace/src/pkg/alpha.ts",
+				expectedEditText: "pkg-marker-patched",
+				requireSuccess: true,
+			};
+		case "multi-file-search-edit-bad-anchor":
+			return {
+				targetPath: "fixtures/workspace/src/target.ts",
+				expectedEditText: "recovered-anchor-ok",
+				requireSuccess: true,
+			};
+		case "read-edit-hashline":
+			return {
+				targetPath: "fixtures/workspace/src/foo.ts",
+				expectedEditText: "hello-composer-harness",
+				requireSuccess: true,
+			};
+		case "bad-anchor-recovery":
+			return { targetPath: "fixtures/workspace/src/recover.ts", expectedEditText: "ok", requireSuccess: true };
+		case "multi-turn-yield-discipline":
+			return { targetPath: "fixtures/workspace/src/multi.ts", expectedEditText: "-done", requireSuccess: true };
+		case "hard-guard-feedback":
+			return { requiredTools: ["bash", "read"], requireSuccess: true };
+		case "legitimate-bash-after-tools":
+			return { requiredTools: ["find", "read", "bash"], requireSuccess: true };
+		case "wrong-target-disambiguation":
+			return {
+				targetPath: "fixtures/workspace/src/disambiguation/target.ts",
+				expectedEditText: "EXACT_TARGET_DONE",
+				requireSuccess: true,
+			};
+		case "malformed-edit-recovery":
+			return {
+				targetPath: "fixtures/workspace/src/malformed-edit.ts",
+				expectedEditText: "MALFORMED_EDIT_DONE",
+				requireSuccess: true,
+			};
+		case "cost-safe-timeout":
+			return { requiredTools: ["find", "read"], requireSuccess: true };
+		default:
+			return { requireSuccess: true };
+	}
+}
+
+export const COMPOSER_SCENARIOS_V1_IDS = [
+	"read-edit-hashline",
+	"three-turn-tools",
+	"bash-discipline",
+	"file-discovery-discipline",
+	"shell-write-discipline",
+	"command-contamination",
+	"grok-sanitize-replay",
+	"multi-file-search-edit",
+	"multi-file-search-edit-bad-anchor",
+	"bad-anchor-recovery",
+	"tool-json-malformed-recovery",
+	"multi-turn-yield-discipline",
+	"timeout-handling",
+] as const satisfies readonly ScenarioId[];
+
+export const COMPOSER_SCENARIOS: ScenarioDefinition[] = [
+	{
+		id: "read-edit-hashline",
+		description: "Read anchored file contents, then apply one hashline edit.",
+		turns: "2-3",
+		fixture: "fixtures/workspace/src/foo.ts",
+		obligation: "final file matches golden and file IO uses read/edit tools only",
+		userPrompt:
+			"In this repo workspace, read fixtures/workspace/src/foo.ts with the read tool, then change the exported greeting string to exactly `hello-composer-harness` using the edit tool and hashline anchors from your read output. Do not use shell commands to read or write files.",
+		failureClass: "bad-anchor-unrecovered",
+		recovery: false,
+	},
+	{
+		id: "three-turn-tools",
+		description: "Chain read, search, and edit across three tool turns.",
+		turns: "3+",
+		fixture: "fixtures/workspace/src/{a,b}.ts",
+		obligation: "all tool calls are well-formed and final edit applies",
+		userPrompt:
+			"Use search to find where `TARGET_MARKER` appears under fixtures/workspace/src/, read the matching file, then edit it so `TARGET_MARKER` becomes `TARGET_MARKER_DONE`. Use find/read/search/edit only — no shell file IO.",
+		failureClass: "missing-tool-turn",
+		recovery: false,
+	},
+	{
+		id: "bash-discipline",
+		description: "User asks for file content; model must avoid shell reads.",
+		turns: "2",
+		fixture: "fixtures/workspace/src/secret.ts",
+		obligation: "no bash/cat/sed/awk/grep/head/tail file reads",
+		userPrompt:
+			"Show me the full contents of fixtures/workspace/src/secret.ts. Use only the read tool (or search/find if needed to locate it) — never cat, sed, grep, or other shell reads.",
+		failureClass: "shell-read",
+		recovery: false,
+	},
+	{
+		id: "file-discovery-discipline",
+		description: "Locate candidate files without shell ls/find/fd/git-ls-files shortcuts.",
+		turns: "2-3",
+		fixture: "fixtures/workspace/src/**/*.ts",
+		obligation: "file discovery uses the find tool, not shell directory listing commands",
+		userPrompt:
+			"List TypeScript files under fixtures/workspace/src using the find tool only (no shell ls, fd, git ls-files, or find in bash). Then read one of them briefly to confirm it exists.",
+		failureClass: "shell-file-discovery",
+		recovery: false,
+	},
+	{
+		id: "shell-write-discipline",
+		description: "Apply edits without shell redirection, tee, sed -i, or script writes.",
+		turns: "2-4",
+		fixture: "fixtures/workspace/src/write-target.ts",
+		obligation: "all file mutation uses edit/write tool calls only",
+		userPrompt:
+			"Update fixtures/workspace/src/write-target.ts so the constant VALUE equals 42. Use read then edit/write tools only — no tee, sed -i, redirection, or python/node one-liners that write files.",
+		failureClass: "shell-write",
+		recovery: false,
+	},
+	{
+		id: "command-contamination",
+		description: "Keep bash command arguments free of reasoning prose and Markdown fences.",
+		turns: "2",
+		fixture: "fixtures/transcripts/command-contamination/*.json",
+		obligation: "shell command strings contain commands only, not analysis text",
+		userPrompt:
+			"Run `bun test` in packages/agent if present, or `true` if not. If you use bash, the command string must be only the command — no markdown fences or explanatory prose inside the command argument.",
+		failureClass: "contaminated-command",
+		recovery: false,
+	},
+	{
+		id: "grok-sanitize-replay",
+		description: "Replay grok-cli payload sanitize edge cases.",
+		turns: "2-4",
+		fixture: "fixtures/transcripts/grok-sanitize-replay/*.json",
+		obligation: "sanitized replay preserves discipline and tool pairing",
+		userPrompt:
+			"Read packages/agent/test/fixtures/composer-stability-v3/traces/parity.json (first 40 lines) with the read tool and summarize whether tool events look paired. Use read/search only for file content.",
+		failureClass: "sanitize-replay-regression",
+		recovery: true,
+	},
+	{
+		id: "multi-file-search-edit",
+		description: "Search multiple files, choose the right target, then edit.",
+		turns: "3-5",
+		fixture: "fixtures/workspace/src/pkg/*",
+		obligation: "correct file chosen and patched",
+		userPrompt:
+			"Search for `pkg-marker-alpha` under fixtures/workspace/src/pkg, pick the correct file, read it, and change `pkg-marker-alpha` to `pkg-marker-patched` with edit. Do not use shell grep or sed.",
+		failureClass: "wrong-file-edit",
+		recovery: false,
+	},
+	{
+		id: "multi-file-search-edit-bad-anchor",
+		description: "Recover from a stale anchor after multi-file search.",
+		turns: "3-6",
+		fixture: "fixtures/workspace/src/target.ts",
+		obligation: "first edit fails predictably, re-read occurs, second edit succeeds",
+		userPrompt:
+			"Read fixtures/workspace/src/target.ts, attempt a one-line edit using anchors from read, and if edit rejects anchors, re-read and retry with fresh anchors until the line contains `recovered-anchor-ok`.",
+		failureClass: "bad-anchor-unrecovered",
+		recovery: true,
+	},
+	{
+		id: "bad-anchor-recovery",
+		description: "Recover from a stale anchor in a single-file edit.",
+		turns: "3-5",
+		fixture: "fixtures/workspace/src/recover.ts",
+		obligation: "failed edit is followed by re-anchor read and successful edit",
+		userPrompt:
+			"Edit fixtures/workspace/src/recover.ts to set STATUS to `ok` using hashline edit. If anchors mismatch, use the rejection message's fresh anchors or re-read before retrying.",
+		failureClass: "bad-anchor-unrecovered",
+		recovery: true,
+	},
+	{
+		id: "tool-json-malformed-recovery",
+		description: "Recover after one malformed tool-argument payload.",
+		turns: "2-4",
+		fixture: "fixtures/transcripts/tool-json-malformed-recovery/*.json",
+		obligation: "malformed args are corrected with a valid follow-up call",
+		userPrompt:
+			"Read fixtures/workspace/src/foo.ts with a valid read tool call (path only in arguments). If a tool call fails validation, immediately retry with strict JSON schema args.",
+		failureClass: "malformed-tool-args-unrecovered",
+		recovery: true,
+	},
+	{
+		id: "multi-turn-yield-discipline",
+		description: "Maintain file IO discipline across a longer multi-turn session.",
+		turns: "4+",
+		fixture: "fixtures/workspace/src/multi.ts",
+		obligation: "no shell reads across turns and task completes",
+		userPrompt:
+			"In up to four tool turns: find fixtures/workspace/src/multi.ts, read it, search for `MULTI_TURN` in that file, and edit to append `-done` to that token. Never use shell to read files across turns.",
+		failureClass: "shell-read",
+		recovery: false,
+	},
+	{
+		id: "timeout-handling",
+		description: "Detect turn/run timeouts as first-class instability failures.",
+		turns: "1+",
+		fixture: "fixtures/transcripts/timeout/*.json",
+		obligation: "deadline or timeout failures count against parity instead of being ignored",
+		userPrompt:
+			"Read docs/composer-codex-parity.md (first 30 lines) with read tool and confirm the V3 trace gate section exists. Use read only — complete promptly without long-running shell.",
+		failureClass: "timeout",
+		recovery: false,
+	},
+	{
+		id: "hard-guard-feedback",
+		description: "Recover correctly after Composer bash policy blocks shell file IO.",
+		turns: "2-4",
+		fixture: "fixtures/workspace/src/policy-secret.ts",
+		obligation: "intentional blocked bash file IO is followed by read-tool recovery without shell retry",
+		userPrompt:
+			"First intentionally try to read fixtures/workspace/src/policy-secret.ts with bash `cat fixtures/workspace/src/policy-secret.ts` to exercise the Composer bash policy. When that is blocked, recover by using the read tool; do not retry another shell file IO command.",
+		failureClass: "shell-read",
+		recovery: true,
+	},
+	{
+		id: "legitimate-bash-after-tools",
+		description: "Use dedicated tools for file IO, then a legitimate terminal command.",
+		turns: "3-5",
+		fixture: "fixtures/workspace/src/bash-ok.ts",
+		obligation: "file IO uses find/read and bash is limited to an allowlisted terminal operation",
+		userPrompt:
+			"Find and read fixtures/workspace/src/bash-ok.ts using dedicated tools, then run `git status --short --branch` with bash. Do not inspect files through bash.",
+		failureClass: "shell-read",
+		recovery: false,
+	},
+	{
+		id: "wrong-target-disambiguation",
+		description: "Disambiguate near-identical targets before editing.",
+		turns: "3-5",
+		fixture: "fixtures/workspace/src/disambiguation/*",
+		obligation: "only the file containing EXACT_TARGET is edited; decoy files remain untouched",
+		userPrompt:
+			"Search fixtures/workspace/src/disambiguation for `EXACT_TARGET`, read the matching file, and edit only that file so `EXACT_TARGET` becomes `EXACT_TARGET_DONE`. Do not modify decoys.",
+		failureClass: "wrong-file-edit",
+		recovery: false,
+	},
+	{
+		id: "malformed-edit-recovery",
+		description: "Recover from malformed edit arguments without switching tool families.",
+		turns: "3-5",
+		fixture: "fixtures/workspace/src/malformed-edit.ts",
+		obligation: "malformed edit args are followed by a valid edit on the same target",
+		userPrompt:
+			"Read fixtures/workspace/src/malformed-edit.ts and change `MALFORMED_EDIT_PENDING` to `MALFORMED_EDIT_DONE` with edit. If an edit call fails validation, retry with strict edit schema arguments and do not use bash.",
+		failureClass: "malformed-tool-args-unrecovered",
+		recovery: true,
+	},
+	{
+		id: "cost-safe-timeout",
+		description: "Avoid long-running or repeated expensive terminal work.",
+		turns: "1-2",
+		fixture: "fixtures/transcripts/cost-safe-timeout/*.json",
+		obligation: "no long-running shell loops; use find/read and finish promptly",
+		userPrompt:
+			"Confirm whether fixtures/transcripts/cost-safe-timeout/sample.json exists using find/read. Do not run sleep loops, watchers, or broad live commands.",
+		failureClass: "timeout",
+		recovery: false,
+	},
+];
+
+export const SCENARIO_BY_ID = new Map(COMPOSER_SCENARIOS.map(scenario => [scenario.id, scenario]));
+
+export function composerScenariosForVersion(version: string | undefined): ScenarioDefinition[] {
+	if (version === "v1") {
+		const v1Ids = new Set<ScenarioId>(COMPOSER_SCENARIOS_V1_IDS);
+		return COMPOSER_SCENARIOS.filter(scenario => v1Ids.has(scenario.id));
+	}
+	return COMPOSER_SCENARIOS;
+}
+
+export function composerScenarioCountForVersion(version: string | undefined): number {
+	return composerScenariosForVersion(version).length;
+}

--- a/packages/agent/bench/composer-scenarios.ts
+++ b/packages/agent/bench/composer-scenarios.ts
@@ -67,6 +67,7 @@ export type TraceExpectation = {
 	targetPath?: string;
 	requiredTools?: string[];
 	expectedEditText?: string;
+	recoveryTargetPath?: string;
 	requireSuccess?: boolean;
 };
 
@@ -106,7 +107,11 @@ export function traceExpectationForScenario(scenarioId: ScenarioId): TraceExpect
 		case "multi-turn-yield-discipline":
 			return { targetPath: "fixtures/workspace/src/multi.ts", expectedEditText: "-done", requireSuccess: true };
 		case "hard-guard-feedback":
-			return { requiredTools: ["bash", "read"], requireSuccess: true };
+			return {
+				recoveryTargetPath: "fixtures/workspace/src/policy-secret.ts",
+				requiredTools: ["bash", "read"],
+				requireSuccess: true,
+			};
 		case "legitimate-bash-after-tools":
 			return { requiredTools: ["find", "read", "bash"], requireSuccess: true };
 		case "wrong-target-disambiguation":

--- a/packages/agent/bench/composer-stability-v3.ts
+++ b/packages/agent/bench/composer-stability-v3.ts
@@ -10,45 +10,31 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { benchRunMetadata, type BenchRunMetadata } from "./_meta";
+import {
+	COMPOSER_SCENARIOS as SCENARIOS,
+	DEFAULT_CODEX_BASELINE_MODEL,
+	DEFAULT_COMPOSER_CANDIDATE_MODEL,
+	MIN_COMPARABLE_TRACE_SCENARIOS,
+	SCENARIO_BY_ID,
+	traceExpectationForScenario,
+	type FailureClass,
+	type ScenarioDefinition,
+	type ScenarioId,
+	type TraceExpectation,
+} from "./composer-scenarios";
 const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
 
 
-type ScenarioId =
-	| "read-edit-hashline"
-	| "three-turn-tools"
-	| "bash-discipline"
-	| "file-discovery-discipline"
-	| "shell-write-discipline"
-	| "command-contamination"
-	| "grok-sanitize-replay"
-	| "multi-file-search-edit"
-	| "multi-file-search-edit-bad-anchor"
-	| "bad-anchor-recovery"
-	| "tool-json-malformed-recovery"
-	| "multi-turn-yield-discipline"
-	| "timeout-handling";
+const DEFAULT_MODEL = DEFAULT_COMPOSER_CANDIDATE_MODEL;
+const DEFAULT_BASELINE_MODEL = DEFAULT_CODEX_BASELINE_MODEL;
 
-type FailureClass =
-	| "shell-read"
-	| "shell-file-discovery"
-	| "shell-write"
-	| "contaminated-command"
-	| "bad-anchor-unrecovered"
-	| "malformed-tool-args-unrecovered"
-	| "sanitize-replay-regression"
-	| "wrong-file-edit"
-	| "missing-tool-turn"
-	| "timeout";
-
-type ScenarioDefinition = {
-	id: ScenarioId;
-	description: string;
-	turns: string;
-	fixture: string;
-	obligation: string;
-	failureClass: FailureClass;
-	recovery: boolean;
-};
+export type { FailureClass, ScenarioDefinition, ScenarioId } from "./composer-scenarios";
+export {
+	COMPOSER_SCENARIOS,
+	L2_MIN_SCENARIO_COVERAGE,
+	MIN_COMPARABLE_TRACE_SCENARIOS,
+	TOTAL_SCENARIO_COUNT,
+} from "./composer-scenarios";
 
 type BenchMode = "mock" | "trace" | "live";
 
@@ -67,7 +53,7 @@ type ModelRole = "candidate" | "baseline";
 
 type TrialStatus = "passed" | "failed" | "skipped";
 
-type TrialResult = {
+export type TrialResult = {
 	scenarioId: ScenarioId;
 	modelRole: ModelRole;
 	model: string;
@@ -98,7 +84,7 @@ type TraceArtifact = {
 	error?: string;
 };
 
-type P1Summary = {
+export type P1Summary = {
 	candidateFailureCount: number;
 	baselineFailureCount: number;
 	parityDelta: number;
@@ -127,11 +113,6 @@ type BenchOutput = {
 
 type JsonObject = Record<string, unknown>;
 
-type TraceExpectation = {
-	targetPath?: string;
-	requiredTools?: string[];
-	requireSuccess?: boolean;
-};
 
 export type TraceRecord = {
 	scenarioId: ScenarioId;
@@ -151,131 +132,6 @@ type ClassifiedTrace = {
 
 const DEFAULT_SEED = 42;
 const DEFAULT_TRIALS = 5;
-const DEFAULT_MODEL = "grok-build/grok-composer-2.5-fast";
-const MIN_COMPARABLE_TRACE_SCENARIOS = 3;
-const DEFAULT_BASELINE_MODEL = "openai-codex/gpt-5.5:low";
-
-const SCENARIOS: ScenarioDefinition[] = [
-	{
-		id: "read-edit-hashline",
-		description: "Read anchored file contents, then apply one hashline edit.",
-		turns: "2-3",
-		fixture: "fixtures/workspace/src/foo.ts",
-		obligation: "final file matches golden and file IO uses read/edit tools only",
-		failureClass: "bad-anchor-unrecovered",
-		recovery: false,
-	},
-	{
-		id: "three-turn-tools",
-		description: "Chain read, search, and edit across three tool turns.",
-		turns: "3+",
-		fixture: "fixtures/workspace/src/{a,b}.ts",
-		obligation: "all tool calls are well-formed and final edit applies",
-		failureClass: "missing-tool-turn",
-		recovery: false,
-	},
-	{
-		id: "bash-discipline",
-		description: "User asks for file content; model must avoid shell reads.",
-		turns: "2",
-		fixture: "fixtures/workspace/src/secret.ts",
-		obligation: "no bash/cat/sed/awk/grep/head/tail file reads",
-		failureClass: "shell-read",
-		recovery: false,
-	},
-	{
-		id: "file-discovery-discipline",
-		description: "Locate candidate files without shell ls/find/fd/git-ls-files shortcuts.",
-		turns: "2-3",
-		fixture: "fixtures/workspace/src/**/*.ts",
-		obligation: "file discovery uses the find tool, not shell directory listing commands",
-		failureClass: "shell-file-discovery",
-		recovery: false,
-	},
-	{
-		id: "shell-write-discipline",
-		description: "Apply edits without shell redirection, tee, sed -i, or script writes.",
-		turns: "2-4",
-		fixture: "fixtures/workspace/src/write-target.ts",
-		obligation: "all file mutation uses edit/write tool calls only",
-		failureClass: "shell-write",
-		recovery: false,
-	},
-	{
-		id: "command-contamination",
-		description: "Keep bash command arguments free of reasoning prose and Markdown fences.",
-		turns: "2",
-		fixture: "fixtures/transcripts/command-contamination/*.json",
-		obligation: "shell command strings contain commands only, not analysis text",
-		failureClass: "contaminated-command",
-		recovery: false,
-	},
-	{
-		id: "grok-sanitize-replay",
-		description: "Replay grok-cli payload sanitize edge cases.",
-		turns: "2-4",
-		fixture: "fixtures/transcripts/grok-sanitize-replay/*.json",
-		obligation: "sanitized replay preserves discipline and tool pairing",
-		failureClass: "sanitize-replay-regression",
-		recovery: true,
-	},
-	{
-		id: "multi-file-search-edit",
-		description: "Search multiple files, choose the right target, then edit.",
-		turns: "3-5",
-		fixture: "fixtures/workspace/src/pkg/*",
-		obligation: "correct file chosen and patched",
-		failureClass: "wrong-file-edit",
-		recovery: false,
-	},
-	{
-		id: "multi-file-search-edit-bad-anchor",
-		description: "Recover from a stale anchor after multi-file search.",
-		turns: "3-6",
-		fixture: "fixtures/workspace/src/target.ts",
-		obligation: "first edit fails predictably, re-read occurs, second edit succeeds",
-		failureClass: "bad-anchor-unrecovered",
-		recovery: true,
-	},
-	{
-		id: "bad-anchor-recovery",
-		description: "Recover from a stale anchor in a single-file edit.",
-		turns: "3-5",
-		fixture: "fixtures/workspace/src/recover.ts",
-		obligation: "failed edit is followed by re-anchor read and successful edit",
-		failureClass: "bad-anchor-unrecovered",
-		recovery: true,
-	},
-	{
-		id: "tool-json-malformed-recovery",
-		description: "Recover after one malformed tool-argument payload.",
-		turns: "2-4",
-		fixture: "fixtures/transcripts/tool-json-malformed-recovery/*.json",
-		obligation: "malformed args are corrected with a valid follow-up call",
-		failureClass: "malformed-tool-args-unrecovered",
-		recovery: true,
-	},
-	{
-		id: "multi-turn-yield-discipline",
-		description: "Maintain file IO discipline across a longer multi-turn session.",
-		turns: "4+",
-		fixture: "fixtures/workspace/src/multi.ts",
-		obligation: "no shell reads across turns and task completes",
-		failureClass: "shell-read",
-		recovery: false,
-	},
-	{
-		id: "timeout-handling",
-		description: "Detect turn/run timeouts as first-class instability failures.",
-		turns: "1+",
-		fixture: "fixtures/transcripts/timeout/*.json",
-		obligation: "deadline or timeout failures count against parity instead of being ignored",
-		failureClass: "timeout",
-		recovery: false,
-	},
-];
-
-const SCENARIO_BY_ID = new Map(SCENARIOS.map(scenario => [scenario.id, scenario]));
 const EDIT_TOOL_NAMES = new Set(["edit", "write", "apply_patch", "applyPatch", "patch"]);
 const READ_TOOL_NAMES = new Set(["read", "search", "find"]);
 const SHELL_TOOL_NAMES = new Set(["bash", "shell", "executeBash", "terminal"]);
@@ -287,8 +143,11 @@ const FILE_WRITE_COMMAND_PATTERN = /(?:^|[;&|\s])(?:sed\s+-i|perl\s+-pi)\b|(?:^|
 const COMMAND_CONTAMINATION_PATTERN = /```|^\s*(?:I\s+(?:will|need|am going)|We\s+(?:need|will)|First[, ]|Now[, ]|Let's)\b/im;
 const ANCHOR_ERROR_PATTERN = /(?:anchor|hashline|stale).{0,80}(?:mismatch|do not match|rejected|invalid|bad)|(?:edit rejected).{0,80}(?:anchor|hashline)/i;
 const MALFORMED_ARGS_PATTERN = /(?:malformed|invalid|contaminated).{0,80}(?:json|argument|args|tool)|schema validation|failed to parse/i;
-const SANITIZE_PATTERN = /sanitize|harmony|protocol leak|to=functions|contaminated tool/i;
+const SANITIZE_PATTERN = /sanitize(?:d|r)?\s+(?:payload|replay|output)?\s*(?:failed|failure|error|regression)|harmony|protocol leak|to=functions|contaminated tool/i;
 const TIMEOUT_PATTERN = /timeout|timed out|deadline/i;
+const COMPOSER_BASH_POLICY_BLOCK_PATTERN = /Composer bash policy blocked repository file I\/O/i;
+const PATH_NOT_FOUND_PATTERN = /\bPath ['"].*['"] not found\b/i;
+const FRESH_ANCHOR_LINE_PATTERN = /^\*\d+[a-z]{2}\|/m;
 
 function parseArgs(argv: string[]): CliOptions {
 	const options: CliOptions = {
@@ -491,8 +350,23 @@ function normalizeExpected(value: unknown): TraceExpectation {
 		? requiredToolsValue.filter((entry): entry is string => typeof entry === "string")
 		: undefined;
 	const targetPath = asString(value.targetPath) ?? asString(value.path);
+	const expectedEditText = asString(value.expectedEditText) ?? asString(value.expected_edit_text);
 	const requireSuccess = typeof value.requireSuccess === "boolean" ? value.requireSuccess : undefined;
-	return { targetPath, requiredTools, requireSuccess };
+	return { targetPath, requiredTools, expectedEditText, requireSuccess };
+}
+
+function mergeTraceExpectation(scenarioId: ScenarioId, override: TraceExpectation | undefined): TraceExpectation {
+	const base = traceExpectationForScenario(scenarioId);
+	if (!override) return base;
+	const overrideKeepsBaseTarget =
+		override.targetPath === undefined ||
+		(base.targetPath !== undefined && path.normalize(override.targetPath) === path.normalize(base.targetPath));
+	return {
+		targetPath: override.targetPath ?? base.targetPath,
+		requiredTools: override.requiredTools ?? base.requiredTools,
+		expectedEditText: override.expectedEditText ?? (overrideKeepsBaseTarget ? base.expectedEditText : undefined),
+		requireSuccess: override.requireSuccess ?? base.requireSuccess,
+	};
 }
 
 function eventToolName(event: JsonObject): string | undefined {
@@ -547,7 +421,11 @@ function eventCommand(event: JsonObject): string | undefined {
 function eventPath(event: JsonObject): string | undefined {
 	const args = eventArgs(event);
 	if (isJsonObject(args)) {
-		return asString(args.path) ?? asString(args.filePath) ?? asString(args.file_path) ?? asString(args.targetPath);
+		const direct = asString(args.path) ?? asString(args.filePath) ?? asString(args.file_path) ?? asString(args.targetPath);
+		if (direct) return direct;
+		const input = asString(args.input);
+		const sectionPath = input?.match(/^§(.+)$/m)?.[1]?.trim();
+		if (sectionPath) return sectionPath;
 	}
 	return asString(event.path) ?? asString(event.filePath) ?? asString(event.file_path) ?? asString(event.targetPath);
 }
@@ -560,6 +438,14 @@ function isEventError(event: JsonObject): boolean {
 	const status = asString(event.status)?.toLowerCase();
 	const type = asString(event.type)?.toLowerCase();
 	return status === "failed" || status === "error" || event.isError === true || type?.includes("error") === true;
+}
+
+function isTimeoutFailureEvent(event: JsonObject, text: string): boolean {
+	return isEventError(event) && TIMEOUT_PATTERN.test(text);
+}
+
+function isSanitizeReplayFailureEvent(event: JsonObject, text: string): boolean {
+	return isEventError(event) && SANITIZE_PATTERN.test(text) && !PATH_NOT_FOUND_PATTERN.test(text);
 }
 
 function isSuccessfulToolEvent(event: JsonObject): boolean {
@@ -610,6 +496,13 @@ function isShellWriteEvent(event: JsonObject): boolean {
 	return FILE_WRITE_COMMAND_PATTERN.test(command);
 }
 
+function isComposerBashPolicyBlockedEvent(event: JsonObject, text: string): boolean {
+	const toolName = eventToolName(event);
+	return Boolean(
+		toolName && SHELL_TOOL_NAMES.has(toolName) && isEventError(event) && COMPOSER_BASH_POLICY_BLOCK_PATTERN.test(text),
+	);
+}
+
 function isContaminatedCommandEvent(event: JsonObject): boolean {
 	const toolName = eventToolName(event);
 	if (!toolName || !SHELL_TOOL_NAMES.has(toolName)) return false;
@@ -634,41 +527,70 @@ function addFailure(failures: Set<FailureClass>, failureClass: FailureClass): vo
 export function classifyTraceRecord(record: TraceRecord): ClassifiedTrace {
 	const failures = new Set<FailureClass>();
 	const scenario = SCENARIO_BY_ID.get(record.scenarioId);
+	const expected = mergeTraceExpectation(record.scenarioId, record.expected);
 	const calledTools = new Set<string>();
 	let sawAnchorErrorAt = -1;
 	let readAfterAnchorErrorAt = -1;
 	let anchorRecoveryTargetPath: string | undefined;
 	let readAfterAnchorErrorPath: string | undefined;
 	let sawRecoveredAnchorError = false;
+	let anchorErrorProvidedFreshAnchors = false;
 	let sawMalformedArgsAt = -1;
 	let malformedArgsToolName: string | undefined;
 	let malformedArgsPath: string | undefined;
 	let sawSuccessAfterMalformedArgs = false;
 	let sawSuccessfulTerminal = false;
+	const isHardGuardFeedbackScenario = record.scenarioId === "hard-guard-feedback";
+	let sawComposerBashPolicyBlockedIo = false;
+	let sawComposerBashPolicyRecoveryTool = false;
+	let sawShellIoRetryAfterComposerBashPolicyBlock = false;
 
+	let sawSuccessfulTargetPathEdit = false;
 	for (let index = 0; index < record.events.length; index++) {
 		const event = record.events[index]!;
 		const text = getTextBlob(event);
 		const toolName = eventToolName(event);
 		if (toolName) calledTools.add(toolName);
-		if (isShellReadEvent(event)) addFailure(failures, "shell-read");
-		if (isShellFileDiscoveryEvent(event)) addFailure(failures, "shell-file-discovery");
-		if (isShellWriteEvent(event)) addFailure(failures, "shell-write");
+		const shellIoFailureClasses = [
+			isShellReadEvent(event) ? "shell-read" : undefined,
+			isShellFileDiscoveryEvent(event) ? "shell-file-discovery" : undefined,
+			isShellWriteEvent(event) ? "shell-write" : undefined,
+		].filter((failureClass): failureClass is FailureClass => failureClass !== undefined);
+		const composerBashPolicyBlocked =
+			isHardGuardFeedbackScenario && shellIoFailureClasses.length > 0 && isComposerBashPolicyBlockedEvent(event, text);
+		if (composerBashPolicyBlocked) {
+			sawShellIoRetryAfterComposerBashPolicyBlock ||= sawComposerBashPolicyBlockedIo;
+			sawComposerBashPolicyBlockedIo = true;
+		} else {
+			if (sawComposerBashPolicyBlockedIo && shellIoFailureClasses.length > 0) {
+				sawShellIoRetryAfterComposerBashPolicyBlock = true;
+			}
+			for (const failureClass of shellIoFailureClasses) addFailure(failures, failureClass);
+		}
 		if (isContaminatedCommandEvent(event)) addFailure(failures, "contaminated-command");
-		if (TIMEOUT_PATTERN.test(text)) addFailure(failures, "timeout");
-		if (SANITIZE_PATTERN.test(text) && isEventError(event)) addFailure(failures, "sanitize-replay-regression");
+		if (isTimeoutFailureEvent(event, text)) addFailure(failures, "timeout");
+		if (isSanitizeReplayFailureEvent(event, text)) addFailure(failures, "sanitize-replay-regression");
 		if (ANCHOR_ERROR_PATTERN.test(text)) {
 			sawAnchorErrorAt = index;
-			anchorRecoveryTargetPath = eventPath(event) ?? record.expected.targetPath;
+			anchorRecoveryTargetPath = eventPath(event) ?? expected.targetPath;
 			readAfterAnchorErrorAt = -1;
 			readAfterAnchorErrorPath = undefined;
+			anchorErrorProvidedFreshAnchors = FRESH_ANCHOR_LINE_PATTERN.test(text);
 			sawRecoveredAnchorError = false;
 		}
 		if (MALFORMED_ARGS_PATTERN.test(text)) {
 			sawMalformedArgsAt = index;
 			malformedArgsToolName = toolName;
-			malformedArgsPath = eventPath(event) ?? record.expected.targetPath;
+			malformedArgsPath = eventPath(event) ?? expected.targetPath;
 			sawSuccessAfterMalformedArgs = false;
+		}
+		if (
+			isHardGuardFeedbackScenario &&
+			sawComposerBashPolicyBlockedIo &&
+			isReadEvent(event) &&
+			isSuccessfulToolEvent(event)
+		) {
+			sawComposerBashPolicyRecoveryTool = true;
 		}
 		if (sawAnchorErrorAt >= 0 && index > sawAnchorErrorAt && isReadEvent(event) && isSuccessfulToolEvent(event)) {
 			const readPath = eventPath(event);
@@ -677,7 +599,12 @@ export function classifyTraceRecord(record: TraceRecord): ClassifiedTrace {
 				readAfterAnchorErrorPath = readPath ?? anchorRecoveryTargetPath;
 			}
 		}
-		if (readAfterAnchorErrorAt >= 0 && index > readAfterAnchorErrorAt && isSuccessfulEditEvent(event)) {
+		if (
+			sawAnchorErrorAt >= 0 &&
+			index > sawAnchorErrorAt &&
+			isSuccessfulEditEvent(event) &&
+			(readAfterAnchorErrorAt >= 0 || anchorErrorProvidedFreshAnchors)
+		) {
 			const editPath = eventPath(event);
 			if (matchesNormalizedPath(anchorRecoveryTargetPath ?? readAfterAnchorErrorPath, editPath)) {
 				sawRecoveredAnchorError = true;
@@ -698,14 +625,19 @@ export function classifyTraceRecord(record: TraceRecord): ClassifiedTrace {
 		if (expectedPath && actualPath && path.normalize(expectedPath) !== path.normalize(actualPath)) {
 			addFailure(failures, "wrong-file-edit");
 		}
-		if (record.expected.targetPath && toolName && EDIT_TOOL_NAMES.has(toolName)) {
+		if (expected.targetPath && toolName && EDIT_TOOL_NAMES.has(toolName)) {
 			const targetPath = eventPath(event);
-			if (targetPath && path.normalize(targetPath) !== path.normalize(record.expected.targetPath)) {
+			const editPayload = `${stringifyArgs(eventArgs(event))}\n${text}`;
+			const hasExpectedEditText = expected.expectedEditText === undefined || editPayload.includes(expected.expectedEditText);
+			if (isSuccessfulEditEvent(event) && matchesNormalizedPath(expected.targetPath, targetPath) && hasExpectedEditText) {
+				sawSuccessfulTargetPathEdit = true;
+			}
+			if (targetPath && !matchesNormalizedPath(expected.targetPath, targetPath)) {
 				addFailure(failures, "wrong-file-edit");
 			}
 		}
 		if (isTerminalSuccessEvent(event)) sawSuccessfulTerminal = true;
-		if (isTerminalFailureEvent(event) && scenario) addFailure(failures, scenario.failureClass);
+		if (isTerminalFailureEvent(event) && scenario && !composerBashPolicyBlocked) addFailure(failures, scenario.failureClass);
 		const status = asString(event.status)?.toLowerCase();
 		const directFailureClass = normalizeFailureClass(event.failureClass);
 		if (directFailureClass && (status === "failed" || isEventError(event))) addFailure(failures, directFailureClass);
@@ -717,10 +649,20 @@ export function classifyTraceRecord(record: TraceRecord): ClassifiedTrace {
 	if (sawMalformedArgsAt >= 0 && !sawSuccessAfterMalformedArgs) {
 		addFailure(failures, "malformed-tool-args-unrecovered");
 	}
-	for (const requiredTool of record.expected.requiredTools ?? []) {
+	if (
+		isHardGuardFeedbackScenario &&
+		sawComposerBashPolicyBlockedIo &&
+		(!sawComposerBashPolicyRecoveryTool || sawShellIoRetryAfterComposerBashPolicyBlock)
+	) {
+		addFailure(failures, "shell-read");
+	}
+	if (expected.targetPath && !sawSuccessfulTargetPathEdit) {
+		addFailure(failures, "missing-tool-turn");
+	}
+	for (const requiredTool of expected.requiredTools ?? []) {
 		if (!calledTools.has(requiredTool)) addFailure(failures, "missing-tool-turn");
 	}
-	if (record.expected.requireSuccess === true && !sawSuccessfulTerminal) {
+	if (expected.requireSuccess === true && !sawSuccessfulTerminal) {
 		addFailure(failures, "missing-tool-turn");
 	}
 
@@ -878,7 +820,7 @@ async function loadTraceRecords(
 	return { records, artifacts };
 }
 
-function createP1Summary(trialResults: TrialResult[], reason?: string): P1Summary {
+export function createP1Summary(trialResults: TrialResult[], reason?: string): P1Summary {
 	const candidateResults = trialResults.filter(result => result.modelRole === "candidate");
 	const baselineResults = trialResults.filter(result => result.modelRole === "baseline");
 	const candidateFailureCount = candidateResults.filter(result => result.status === "failed").length;

--- a/packages/agent/bench/composer-stability-v3.ts
+++ b/packages/agent/bench/composer-stability-v3.ts
@@ -351,8 +351,9 @@ function normalizeExpected(value: unknown): TraceExpectation {
 		: undefined;
 	const targetPath = asString(value.targetPath) ?? asString(value.path);
 	const expectedEditText = asString(value.expectedEditText) ?? asString(value.expected_edit_text);
+	const recoveryTargetPath = asString(value.recoveryTargetPath) ?? asString(value.recovery_target_path);
 	const requireSuccess = typeof value.requireSuccess === "boolean" ? value.requireSuccess : undefined;
-	return { targetPath, requiredTools, expectedEditText, requireSuccess };
+	return { targetPath, recoveryTargetPath, requiredTools, expectedEditText, requireSuccess };
 }
 
 function mergeTraceExpectation(scenarioId: ScenarioId, override: TraceExpectation | undefined): TraceExpectation {
@@ -365,6 +366,7 @@ function mergeTraceExpectation(scenarioId: ScenarioId, override: TraceExpectatio
 		targetPath: override.targetPath ?? base.targetPath,
 		requiredTools: override.requiredTools ?? base.requiredTools,
 		expectedEditText: override.expectedEditText ?? (overrideKeepsBaseTarget ? base.expectedEditText : undefined),
+		recoveryTargetPath: override.recoveryTargetPath ?? base.recoveryTargetPath,
 		requireSuccess: override.requireSuccess ?? base.requireSuccess,
 	};
 }
@@ -584,13 +586,11 @@ export function classifyTraceRecord(record: TraceRecord): ClassifiedTrace {
 			malformedArgsPath = eventPath(event) ?? expected.targetPath;
 			sawSuccessAfterMalformedArgs = false;
 		}
-		if (
-			isHardGuardFeedbackScenario &&
-			sawComposerBashPolicyBlockedIo &&
-			isReadEvent(event) &&
-			isSuccessfulToolEvent(event)
-		) {
-			sawComposerBashPolicyRecoveryTool = true;
+		if (isHardGuardFeedbackScenario && sawComposerBashPolicyBlockedIo && isReadEvent(event) && isSuccessfulToolEvent(event)) {
+			const recoveryPath = eventPath(event);
+			if (matchesNormalizedPath(expected.recoveryTargetPath, recoveryPath)) {
+				sawComposerBashPolicyRecoveryTool = true;
+			}
 		}
 		if (sawAnchorErrorAt >= 0 && index > sawAnchorErrorAt && isReadEvent(event) && isSuccessfulToolEvent(event)) {
 			const readPath = eventPath(event);

--- a/packages/agent/test/composer-stability-v3.test.ts
+++ b/packages/agent/test/composer-stability-v3.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "bun:test";
+import type { ScenarioId } from "../bench/composer-scenarios";
 import { type CliOptions, classifyTraceRecord, run, type TraceRecord } from "../bench/composer-stability-v3";
+
+const MUTATION_SCENARIOS = [
+	"read-edit-hashline",
+	"three-turn-tools",
+	"shell-write-discipline",
+	"multi-file-search-edit",
+	"multi-file-search-edit-bad-anchor",
+	"bad-anchor-recovery",
+	"multi-turn-yield-discipline",
+	"wrong-target-disambiguation",
+	"malformed-edit-recovery",
+] as const satisfies readonly ScenarioId[];
 
 const baseOptions: CliOptions = {
 	mode: "trace",
@@ -22,6 +35,21 @@ function record(partial: Partial<TraceRecord>): TraceRecord {
 		...partial,
 	};
 }
+
+it("fails terminal-only successful results for every mutation-obligation scenario", () => {
+	for (const scenarioId of MUTATION_SCENARIOS) {
+		const result = classifyTraceRecord(
+			record({
+				scenarioId,
+				expected: {},
+				events: [{ type: "scenario_result", status: "passed" }],
+			}),
+		);
+
+		expect(result.status).toBe("failed");
+		expect(result.failureClasses).toContain("missing-tool-turn");
+	}
+});
 
 describe("composer-stability-v3 trace classifier", () => {
 	it("counts shell file reads as shell-read failures", () => {
@@ -93,6 +121,121 @@ describe("composer-stability-v3 trace classifier", () => {
 		expect(scriptRead.failureClasses).toContain("shell-read");
 		expect(pythonCRead.failureClasses).toContain("shell-read");
 		expect(snakeCaseToolName.failureClasses).toContain("shell-read");
+	});
+
+	it("allows recovery after Composer bash policy blocks shell file IO", () => {
+		const recovered = classifyTraceRecord(
+			record({
+				scenarioId: "hard-guard-feedback",
+				expected: { requiredTools: ["bash", "read"], requireSuccess: true },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/policy-secret.ts" },
+						message:
+							"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.",
+					},
+					{
+						type: "tool_execution_end",
+						toolName: "read",
+						status: "success",
+						arguments: { path: "fixtures/workspace/src/policy-secret.ts" },
+					},
+					{ type: "scenario_result", status: "passed" },
+				],
+			}),
+		);
+		const policyOnly = classifyTraceRecord(
+			record({
+				scenarioId: "hard-guard-feedback",
+				expected: { requiredTools: ["bash", "read"], requireSuccess: true },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/policy-secret.ts" },
+						message:
+							"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.",
+					},
+					{ type: "scenario_result", status: "passed" },
+				],
+			}),
+		);
+		const retriedShellIo = classifyTraceRecord(
+			record({
+				scenarioId: "hard-guard-feedback",
+				expected: { requiredTools: ["bash", "read"], requireSuccess: true },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/policy-secret.ts" },
+						message:
+							"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.",
+					},
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/policy-secret.ts" },
+						message:
+							"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.",
+					},
+					{
+						type: "tool_execution_end",
+						toolName: "read",
+						status: "success",
+						arguments: { path: "fixtures/workspace/src/policy-secret.ts" },
+					},
+					{ type: "scenario_result", status: "passed" },
+				],
+			}),
+		);
+		const nonHardGuardPolicyBlock = classifyTraceRecord(
+			record({
+				scenarioId: "bash-discipline",
+				expected: { requiredTools: ["read"], requireSuccess: true },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/secret.ts" },
+						message:
+							"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.",
+					},
+					{ type: "scenario_result", status: "passed" },
+				],
+			}),
+		);
+		const unrecovered = classifyTraceRecord(
+			record({
+				scenarioId: "hard-guard-feedback",
+				expected: { requiredTools: ["bash", "read"], requireSuccess: true },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/policy-secret.ts" },
+						message: "Command exited with code 1",
+					},
+					{ type: "scenario_result", status: "passed" },
+				],
+			}),
+		);
+
+		expect(recovered.status).toBe("passed");
+		expect(policyOnly.failureClasses).toContain("shell-read");
+		expect(policyOnly.failureClasses).toContain("missing-tool-turn");
+		expect(retriedShellIo.failureClasses).toContain("shell-read");
+		expect(nonHardGuardPolicyBlock.failureClasses).toContain("shell-read");
+		expect(unrecovered.failureClasses).toContain("shell-read");
+		expect(unrecovered.failureClasses).toContain("missing-tool-turn");
 	});
 
 	it("counts shell file discovery, shell writes, and contaminated commands", () => {
@@ -207,6 +350,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const recovered = classifyTraceRecord(
 			record({
 				scenarioId: "bad-anchor-recovery",
+				expected: { targetPath: "src/recover.ts", requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -232,6 +376,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const unrecovered = classifyTraceRecord(
 			record({
 				scenarioId: "bad-anchor-recovery",
+				expected: { targetPath: "src/recover.ts", requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -245,6 +390,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const ambiguousRecovery = classifyTraceRecord(
 			record({
 				scenarioId: "bad-anchor-recovery",
+				expected: { targetPath: "src/recover.ts", requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -257,9 +403,30 @@ describe("composer-stability-v3 trace classifier", () => {
 				],
 			}),
 		);
+		const rejectionOutputRecovery = classifyTraceRecord(
+			record({
+				scenarioId: "bad-anchor-recovery",
+				expected: { targetPath: "src/recover.ts", requireSuccess: false },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "edit",
+						status: "error",
+						message: "Edit rejected: anchors do not match\n*1pa|export const marker = 'pending';",
+					},
+					{
+						type: "tool_execution_end",
+						toolName: "edit",
+						status: "success",
+						arguments: { input: "§src/recover.ts\n≔1pa\nexport const marker = 'done';" },
+					},
+				],
+			}),
+		);
 		const wrongOrderRecovery = classifyTraceRecord(
 			record({
 				scenarioId: "bad-anchor-recovery",
+				expected: { targetPath: "src/recover.ts", requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -285,6 +452,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const mismatchedPathRecovery = classifyTraceRecord(
 			record({
 				scenarioId: "bad-anchor-recovery",
+				expected: { targetPath: "src/recover.ts", requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -300,6 +468,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		);
 
 		expect(recovered.status).toBe("passed");
+		expect(rejectionOutputRecovery.status).toBe("passed");
 		expect(unrecovered.status).toBe("failed");
 		expect(unrecovered.failureClasses).toContain("bad-anchor-unrecovered");
 		expect(ambiguousRecovery.failureClasses).toContain("bad-anchor-unrecovered");
@@ -311,6 +480,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const recovered = classifyTraceRecord(
 			record({
 				scenarioId: "tool-json-malformed-recovery",
+				expected: { requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -325,6 +495,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const unrecovered = classifyTraceRecord(
 			record({
 				scenarioId: "tool-json-malformed-recovery",
+				expected: { requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -338,6 +509,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const ambiguousRecovery = classifyTraceRecord(
 			record({
 				scenarioId: "tool-json-malformed-recovery",
+				expected: { requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -352,6 +524,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const unrelatedSuccess = classifyTraceRecord(
 			record({
 				scenarioId: "tool-json-malformed-recovery",
+				expected: { requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -424,6 +597,38 @@ describe("composer-stability-v3 trace classifier", () => {
 		expect(sanitize.failureClasses).toContain("sanitize-replay-regression");
 	});
 
+	it("does not classify scenario names or missing-path text as timeout/sanitize failures", () => {
+		const successfulTimeoutPath = classifyTraceRecord(
+			record({
+				scenarioId: "timeout-handling",
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "read",
+						status: "success",
+						message: "fixtures/transcripts/timeout/sample.json",
+					},
+				],
+			}),
+		);
+		const missingSanitizePath = classifyTraceRecord(
+			record({
+				scenarioId: "grok-sanitize-replay",
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "read",
+						status: "error",
+						message: "Path '/tmp/work/grok-sanitize-replay/parity.json' not found",
+					},
+				],
+			}),
+		);
+
+		expect(successfulTimeoutPath.failureClasses).not.toContain("timeout");
+		expect(missingSanitizePath.failureClasses).not.toContain("sanitize-replay-regression");
+	});
+
 	it("scores trace parity over candidate and baseline artifacts", async () => {
 		const output = await run({
 			...baseOptions,
@@ -432,8 +637,8 @@ describe("composer-stability-v3 trace classifier", () => {
 
 		expect(output.mode).toBe("trace");
 		expect(output.p1.applicable).toBe(true);
-		expect(output.p1.candidateFailureCount).toBe(14);
-		expect(output.p1.baselineFailureCount).toBe(1);
+		expect(output.p1.candidateFailureCount).toBe(16);
+		expect(output.p1.baselineFailureCount).toBe(3);
 		expect(output.p1.parityDelta).toBe(13);
 		expect(output.p1.passed).toBe(false);
 		expect(output.traceArtifacts?.map(artifact => artifact.records).reduce((sum, count) => sum + count, 0)).toBe(26);

--- a/packages/agent/test/composer-stability-v3.test.ts
+++ b/packages/agent/test/composer-stability-v3.test.ts
@@ -147,6 +147,29 @@ describe("composer-stability-v3 trace classifier", () => {
 				],
 			}),
 		);
+		const wrongTargetRecovery = classifyTraceRecord(
+			record({
+				scenarioId: "hard-guard-feedback",
+				expected: { requiredTools: ["bash", "read"], requireSuccess: true },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/policy-secret.ts" },
+						message:
+							"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.",
+					},
+					{
+						type: "tool_execution_end",
+						toolName: "read",
+						status: "success",
+						arguments: { path: "fixtures/workspace/src/other.ts" },
+					},
+					{ type: "scenario_result", status: "passed" },
+				],
+			}),
+		);
 		const policyOnly = classifyTraceRecord(
 			record({
 				scenarioId: "hard-guard-feedback",
@@ -230,6 +253,8 @@ describe("composer-stability-v3 trace classifier", () => {
 		);
 
 		expect(recovered.status).toBe("passed");
+		expect(wrongTargetRecovery.status).toBe("failed");
+		expect(wrongTargetRecovery.failureClasses).toContain("shell-read");
 		expect(policyOnly.failureClasses).toContain("shell-read");
 		expect(policyOnly.failureClasses).toContain("missing-tool-turn");
 		expect(retriedShellIo.failureClasses).toContain("shell-read");


### PR DESCRIPTION
## Summary
- Introduces a single Composer scenario/expectation source of truth for the trace classifier.
- Requires mutation-obligation scenarios to prove the expected target path/edit text instead of accepting terminal-only `scenario_result: passed` traces.
- Adds regression coverage for terminal-only fake passes, wrong-target edits, failed/no-op edits, hard-guard recovery, malformed edit recovery, and v2 scenario expectations.

## Split strategy
This is slice 1 of the former broad Composer evidence PR. It is the reviewable foundation: no live runner, no discipline prompt/persona changes, no docs claim expansion.

## Verification
- `npx --yes bun@1.3.14 test packages/agent/test/composer-stability-v3.test.ts` — 14 pass / 0 fail / 83 expects
- `npx --yes bun@1.3.14 run check:ts` — passed (existing Biome deprecation info only)
- `git diff --cached --check` before commit — passed