### PR TITLE
feat(agent): add Composer evidence publication gates

### DIFF
--- a/packages/agent/bench/composer-evidence-ab-compare.ts
+++ b/packages/agent/bench/composer-evidence-ab-compare.ts
@@ -5,7 +5,7 @@
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { buildEvidenceReport, type EvidenceReport } from "./composer-evidence";
+import { buildEvidenceReport, scanTextForPublishSecrets, type EvidenceReport } from "./composer-evidence";
 import { classifyTraceRecord, type TraceRecord } from "./composer-stability-v3";
 
 const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
@@ -101,6 +101,9 @@ function armSummary(label: string, gjcVersion: string, report: EvidenceReport) {
 	return {
 		label,
 		gjc_version: gjcVersion,
+		composer_scenarios_version: report.composer_scenarios_version,
+		trace_sha256: report.trace_sha256,
+		manifest_sha256: report.manifest_sha256,
 		candidate_failure_count: report.p1.candidateFailureCount,
 		baseline_failure_count: report.p1.baselineFailureCount,
 		parity_delta: report.p1.parityDelta,
@@ -179,8 +182,15 @@ async function main(): Promise<void> {
 		per_scenario_b: bReport.per_scenario,
 	};
 
+	const payloadText = `${JSON.stringify(payload, null, 2)}\n`;
+	const payloadLint = scanTextForPublishSecrets(payloadText);
+	if (!payloadLint.ok) {
+		process.stderr.write(`composer-evidence-ab-compare: report linter failed: ${payloadLint.findings.join(", ")}\n`);
+		process.exit(3);
+	}
+
 	const outPath = outArg ? path.resolve(outArg) : path.join(REPO_ROOT, "evidence-ab-compare.json");
-	await fs.writeFile(outPath, `${JSON.stringify(payload, null, 2)}\n`);
+	await fs.writeFile(outPath, payloadText);
 	process.stdout.write(
 		`${JSON.stringify({ ok: true, reportArtifact: path.basename(outPath), comparison: payload.comparison }, null, 2)}\n`,
 	);

--- a/packages/agent/bench/composer-evidence-ab-compare.ts
+++ b/packages/agent/bench/composer-evidence-ab-compare.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env bun
+/**
+ * Compare two scored trace corpora (e.g. gjc v0.5.3 vs v0.6.4 live captures).
+ * Point estimate only — not a statistical hypothesis test.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { buildEvidenceReport, type EvidenceReport } from "./composer-evidence";
+import { classifyTraceRecord, type TraceRecord } from "./composer-stability-v3";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
+
+async function loadRecords(filePath: string): Promise<TraceRecord[]> {
+	const raw = await fs.readFile(filePath, "utf8");
+	const parsed = JSON.parse(raw) as unknown;
+	if (Array.isArray(parsed)) return parsed as TraceRecord[];
+	if (typeof parsed === "object" && parsed !== null && "records" in parsed) {
+		return (parsed as { records: TraceRecord[] }).records;
+	}
+	return [parsed as TraceRecord];
+}
+
+type ProvenanceManifest = {
+	composer_scenarios_version?: string;
+	record_count?: number;
+	captured_records?: number;
+	trace_sha256?: string;
+	manifest_sha256?: string;
+};
+
+function parseManifest(text: string): ProvenanceManifest | undefined {
+	try {
+		const parsed = JSON.parse(text) as unknown;
+		return typeof parsed === "object" && parsed !== null ? (parsed as ProvenanceManifest) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function manifestPathForTraceFile(traceFile: string): string {
+	const resolved = path.resolve(traceFile);
+	return path.join(path.dirname(path.dirname(resolved)), "provenance-manifest.json");
+}
+
+async function loadManifest(traceFile: string): Promise<ProvenanceManifest | undefined> {
+	try {
+		return parseManifest(await fs.readFile(manifestPathForTraceFile(traceFile), "utf8"));
+	} catch {
+		return undefined;
+	}
+}
+
+function trialsFromRecords(records: TraceRecord[]) {
+	return records.map(record => {
+		const c = classifyTraceRecord(record);
+		return {
+			scenarioId: record.scenarioId,
+			modelRole: record.modelRole,
+			model: record.model,
+			trial: record.trial,
+			status: c.status,
+			failureClass: c.failureClasses[0],
+			failureClasses: c.failureClasses,
+			evidence: c.evidence,
+			tracePath: record.tracePath,
+		};
+	});
+}
+
+function scenarioFailureMap(report: EvidenceReport): Map<string, { candidate: number; baseline: number; classes: string[] }> {
+	return new Map(
+		report.per_scenario.map(row => [
+			row.id,
+			{
+				candidate: row.candidate_failures,
+				baseline: row.baseline_failures,
+				classes: row.failure_classes,
+			},
+		]),
+	);
+}
+
+function perScenarioDelta(aReport: EvidenceReport, bReport: EvidenceReport) {
+	const a = scenarioFailureMap(aReport);
+	const b = scenarioFailureMap(bReport);
+	const ids = [...new Set([...a.keys(), ...b.keys()])].sort();
+	return ids.map(id => {
+		const aRow = a.get(id) ?? { candidate: 0, baseline: 0, classes: [] };
+		const bRow = b.get(id) ?? { candidate: 0, baseline: 0, classes: [] };
+		return {
+			id,
+			candidate_failure_delta_a_minus_b: aRow.candidate - bRow.candidate,
+			baseline_failure_delta_a_minus_b: aRow.baseline - bRow.baseline,
+			arm_a_failure_classes: aRow.classes,
+			arm_b_failure_classes: bRow.classes,
+		};
+	});
+}
+
+function armSummary(label: string, gjcVersion: string, report: EvidenceReport) {
+	return {
+		label,
+		gjc_version: gjcVersion,
+		candidate_failure_count: report.p1.candidateFailureCount,
+		baseline_failure_count: report.p1.baselineFailureCount,
+		parity_delta: report.p1.parityDelta,
+		scenario_coverage: report.scenario_coverage,
+		scenario_coverage_ratio: report.scenario_coverage_ratio,
+		l2_eligible: report.l2Eligible,
+		ladder_max_claim: report.ladderMaxClaim,
+		p1_passed: report.p1.passed,
+	};
+}
+
+async function main(): Promise<void> {
+	const aArg = process.argv.find((_, i, a) => a[i - 1] === "--arm-a");
+	const bArg = process.argv.find((_, i, a) => a[i - 1] === "--arm-b");
+	const aVer = process.argv.find((_, i, a) => a[i - 1] === "--arm-a-version") ?? "unknown";
+	const bVer = process.argv.find((_, i, a) => a[i - 1] === "--arm-b-version") ?? "unknown";
+	const outArg = process.argv.find((_, i, a) => a[i - 1] === "--out");
+
+	if (!aArg || !bArg) {
+		process.stderr.write(
+			"usage: composer-evidence-ab-compare.ts --arm-a <trace.json> --arm-a-version 0.5.3 --arm-b <trace.json> --arm-b-version 0.6.4 [--out report.json]\n",
+		);
+		process.exit(1);
+	}
+
+	const aTracePath = path.resolve(aArg);
+	const bTracePath = path.resolve(bArg);
+	const aRecords = await loadRecords(aTracePath);
+	const bRecords = await loadRecords(bTracePath);
+	const aManifest = await loadManifest(aTracePath);
+	const bManifest = await loadManifest(bTracePath);
+	const aReport = buildEvidenceReport(trialsFromRecords(aRecords), {
+		capture_mode: "trace-replay",
+		comparison_kind: "historical-frozen-trace",
+		composer_scenarios_version: aManifest?.composer_scenarios_version,
+		gjc_version: aVer,
+		trace_sha256: aManifest?.trace_sha256,
+		manifest_sha256: aManifest?.manifest_sha256,
+		captured_records: aManifest?.captured_records ?? aManifest?.record_count ?? aRecords.length,
+	});
+	const bReport = buildEvidenceReport(trialsFromRecords(bRecords), {
+		capture_mode: "trace-replay",
+		comparison_kind: "historical-frozen-trace",
+		composer_scenarios_version: bManifest?.composer_scenarios_version,
+		gjc_version: bVer,
+		trace_sha256: bManifest?.trace_sha256,
+		manifest_sha256: bManifest?.manifest_sha256,
+		captured_records: bManifest?.captured_records ?? bManifest?.record_count ?? bRecords.length,
+	});
+
+	const candidateDelta = aReport.p1.candidateFailureCount - bReport.p1.candidateFailureCount;
+	const baselineDelta = aReport.p1.baselineFailureCount - bReport.p1.baselineFailureCount;
+	const parityDeltaChange = aReport.p1.parityDelta - bReport.p1.parityDelta;
+
+	const payload = {
+		schemaVersion: 1,
+		comparison_kind: "historical-frozen-trace",
+		disclaimer:
+			"Point estimate from paired harness failure counts on frozen trace corpora. Not a statistical hypothesis test. Live A/B requires separate captures with each gjc binary on the same versioned Composer scenario prompts.",
+		repo_commit: process.env.EVIDENCE_REPO_COMMIT ?? "dev-evidence",
+		arm_a: armSummary("v0.5.3-or-baseline-arm", aVer, aReport),
+		arm_b: armSummary("v0.6.4-or-candidate-arm", bVer, bReport),
+		comparison: {
+			candidate_failure_count_delta_a_minus_b: candidateDelta,
+			baseline_failure_count_delta_a_minus_b: baselineDelta,
+			parity_delta_change_a_minus_b: parityDeltaChange,
+			interpretation:
+				candidateDelta > 0
+					? "Arm B (typically 0.6.4) shows fewer candidate failures than arm A by count delta."
+					: candidateDelta < 0
+						? "Arm A shows fewer candidate failures than arm B."
+						: "Candidate failure counts tie on this corpus.",
+		},
+		per_scenario_delta: perScenarioDelta(aReport, bReport),
+		per_scenario_a: aReport.per_scenario,
+		per_scenario_b: bReport.per_scenario,
+	};
+
+	const outPath = outArg ? path.resolve(outArg) : path.join(REPO_ROOT, "evidence-ab-compare.json");
+	await fs.writeFile(outPath, `${JSON.stringify(payload, null, 2)}\n`);
+	process.stdout.write(
+		`${JSON.stringify({ ok: true, reportArtifact: path.basename(outPath), comparison: payload.comparison }, null, 2)}\n`,
+	);
+}
+
+if (import.meta.main) {
+	await main();
+}

--- a/packages/agent/bench/composer-evidence-report.ts
+++ b/packages/agent/bench/composer-evidence-report.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env bun
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { buildEvidenceReport, scanTextForPublishSecrets, type CaptureMode, type EvidenceReportMeta } from "./composer-evidence";
+import { classifyTraceRecord, type TraceRecord } from "./composer-stability-v3";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
+
+async function loadTraceFile(filePath: string): Promise<TraceRecord[]> {
+	const raw = await fs.readFile(filePath, "utf8");
+	const parsed = JSON.parse(raw) as unknown;
+	if (Array.isArray(parsed)) return parsed as TraceRecord[];
+	if (typeof parsed === "object" && parsed !== null && "records" in parsed) {
+		return (parsed as { records: TraceRecord[] }).records;
+	}
+	return [parsed as TraceRecord];
+}
+
+type ProvenanceManifest = {
+	schemaVersion?: number;
+	composer_scenarios_version?: string;
+	capture_mode?: CaptureMode;
+	gjc_version?: string;
+	git_sha?: string;
+	tracePath?: string;
+	trace_sha256?: string;
+	manifest_sha256?: string;
+	planned_records?: number;
+	record_count?: number;
+	captured_records?: number;
+	k?: number;
+	candidate_model?: string;
+	baseline_model?: string;
+};
+
+function isCaptureMode(value: unknown): value is CaptureMode {
+	return value === "print" || value === "tmux" || value === "hermes-mcp" || value === "trace-replay";
+}
+
+function parseManifest(text: string): ProvenanceManifest | undefined {
+	if (!text.trim()) return undefined;
+	try {
+		const parsed = JSON.parse(text) as unknown;
+		return typeof parsed === "object" && parsed !== null ? (parsed as ProvenanceManifest) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function sha256Text(text: string): string {
+	return crypto.createHash("sha256").update(text).digest("hex");
+}
+
+async function sha256File(filePath: string): Promise<string | undefined> {
+	try {
+		const data = await fs.readFile(filePath);
+		return crypto.createHash("sha256").update(data).digest("hex");
+	} catch {
+		return undefined;
+	}
+}
+
+function manifestPathForTraceFile(traceFileArg: string | undefined): string {
+	if (!traceFileArg) return "";
+	const resolved = path.resolve(traceFileArg);
+	return path.join(path.dirname(path.dirname(resolved)), "provenance-manifest.json");
+}
+
+function publicArtifactLabel(filePath: string): string {
+	const resolved = path.resolve(filePath);
+	return `${path.basename(path.dirname(resolved))}/${path.basename(resolved)}`;
+}
+
+function metaFromManifest(input: {
+	records: TraceRecord[];
+	traceFileArg?: string;
+	traceDirArg?: string;
+	manifest?: ProvenanceManifest;
+	manifestText: string;
+}): EvidenceReportMeta {
+	const traceArtifacts = [
+		input.traceFileArg ? publicArtifactLabel(input.traceFileArg) : undefined,
+		input.traceDirArg ? publicArtifactLabel(input.traceDirArg) : undefined,
+	].filter((value): value is string => Boolean(value));
+	const captureMode = isCaptureMode(input.manifest?.capture_mode) ? input.manifest.capture_mode : "trace-replay";
+	const actualModelIds = {
+		candidate: [...new Set(input.records.filter(record => record.modelRole === "candidate").map(record => record.model))].sort(),
+		baseline: [...new Set(input.records.filter(record => record.modelRole === "baseline").map(record => record.model))].sort(),
+	};
+
+	return {
+		capture_mode: captureMode,
+		composer_scenarios_version: input.manifest?.composer_scenarios_version,
+		gjc_version: input.manifest?.gjc_version,
+		git_sha: input.manifest?.git_sha,
+		trace_artifacts: traceArtifacts,
+		trace_sha256: input.manifest?.trace_sha256,
+		manifest_sha256: input.manifestText ? sha256Text(input.manifestText) : input.manifest?.manifest_sha256,
+		planned_records: input.manifest?.planned_records,
+		captured_records: input.manifest?.captured_records ?? input.manifest?.record_count ?? input.records.length,
+		expected_k_per_scenario_role: input.manifest?.k,
+		actual_model_ids: actualModelIds,
+	};
+}
+
+async function main(): Promise<void> {
+	const traceDirArg = process.argv.find((_, i, a) => a[i - 1] === "--trace-dir");
+	const traceFileArg = process.argv.find((_, i, a) => a[i - 1] === "--trace-file");
+	const outArg = process.argv.find((_, i, a) => a[i - 1] === "--out");
+
+	const records: TraceRecord[] = [];
+	if (traceFileArg) {
+		records.push(...(await loadTraceFile(path.resolve(traceFileArg))));
+	}
+	if (traceDirArg) {
+		const dir = path.resolve(traceDirArg);
+		const entries = await fs.readdir(dir);
+		for (const name of entries) {
+			if (!name.endsWith(".json")) continue;
+			records.push(...(await loadTraceFile(path.join(dir, name))));
+		}
+	}
+
+	const trials = records.map(record => {
+		const classified = classifyTraceRecord(record);
+		return {
+			scenarioId: record.scenarioId,
+			modelRole: record.modelRole,
+			model: record.model,
+			trial: record.trial,
+			status: classified.status,
+			failureClass: classified.failureClasses[0],
+			failureClasses: classified.failureClasses,
+			evidence: classified.evidence,
+			tracePath: record.tracePath ? publicArtifactLabel(record.tracePath) : undefined,
+		};
+	});
+
+	const manifestPath = traceDirArg
+		? path.join(path.resolve(traceDirArg), "..", "provenance-manifest.json")
+		: manifestPathForTraceFile(traceFileArg);
+	let manifestText = "";
+	try {
+		manifestText = await fs.readFile(manifestPath, "utf8");
+	} catch {
+		manifestText = "";
+	}
+	const manifest = parseManifest(manifestText);
+	const meta = metaFromManifest({ records, traceFileArg, traceDirArg, manifest, manifestText });
+	if (!meta.trace_sha256 && traceFileArg) {
+		meta.trace_sha256 = await sha256File(path.resolve(traceFileArg));
+	}
+
+	const report = buildEvidenceReport(trials, meta, manifestText);
+	const reportText = `${JSON.stringify(report, null, 2)}\n`;
+	const reportLint = scanTextForPublishSecrets(reportText);
+	if (!reportLint.ok) {
+		process.stderr.write(`composer-evidence-report: report linter failed: ${reportLint.findings.join(", ")}\n`);
+		process.exit(3);
+	}
+	const outPath = outArg ? path.resolve(outArg) : path.join(REPO_ROOT, "evidence-report.json");
+	await fs.writeFile(outPath, reportText);
+	process.stdout.write(
+		`${JSON.stringify(
+			{
+				ok: true,
+				reportArtifact: path.basename(outPath),
+				ladderMaxClaim: report.ladderMaxClaim,
+				l2Eligible: report.l2Eligible,
+			},
+			null,
+			2,
+		)}\n`,
+	);
+}
+
+if (import.meta.main) {
+	await main();
+}

--- a/packages/agent/bench/composer-evidence.ts
+++ b/packages/agent/bench/composer-evidence.ts
@@ -1,0 +1,313 @@
+import {
+	COMPOSER_SCENARIOS_VERSION,
+	DEFAULT_CODEX_BASELINE_MODEL,
+	DEFAULT_COMPOSER_CANDIDATE_MODEL,
+	L2_MIN_SCENARIO_COVERAGE,
+	type ScenarioDefinition,
+	type ScenarioId,
+	composerScenarioCountForVersion,
+	composerScenariosForVersion,
+} from "./composer-scenarios";
+import type { P1Summary, TrialResult } from "./composer-stability-v3";
+import { createP1Summary } from "./composer-stability-v3";
+
+export type CaptureMode = "print" | "tmux" | "hermes-mcp" | "trace-replay";
+export type ComparisonKind = "historical-frozen-trace" | "live-ab";
+
+export type L3RefusalReason =
+	| "k_lt_3"
+	| "missing_baseline"
+	| "missing_scenario"
+	| "trace_replay_not_l3"
+	| "manifest_linter_failed"
+	| "mixed_scenario_versions"
+	| "mixed_model_ids"
+	| "partial_capture"
+	| "p1_not_passed";
+
+type ModelRoleCounts = {
+	candidate: number;
+	baseline: number;
+};
+
+type ModelIdsByRole = {
+	candidate: string[];
+	baseline: string[];
+};
+
+export type EvidenceReportMeta = {
+	gjc_version?: string;
+	git_sha?: string;
+	capture_mode?: CaptureMode;
+	comparison_kind?: ComparisonKind;
+	composer_scenarios_version?: string;
+	scenario_versions?: string[];
+	discipline_injection_verified?: boolean;
+	trace_artifacts?: string[];
+	trace_sha256?: string;
+	manifest_sha256?: string;
+	planned_records?: number;
+	captured_records?: number;
+	expected_k_per_scenario_role?: number;
+	actual_model_ids?: ModelIdsByRole;
+};
+
+export type PerScenarioEvidence = {
+	id: ScenarioId;
+	candidate_failures: number;
+	baseline_failures: number;
+	failure_classes: string[];
+};
+
+export type EvidenceReport = {
+	schemaVersion: 1;
+	generatedAt: string;
+	ladderMaxClaim: "L0" | "L1" | "L2" | "L2-H" | "L3" | "none";
+	p1: P1Summary;
+	l2Eligible: boolean;
+	l3Eligible: boolean;
+	l3RefusalReasons: L3RefusalReason[];
+	scenario_coverage: number;
+	scenario_coverage_ratio: string;
+	planned_records: number | null;
+	captured_records: number;
+	role_counts: ModelRoleCounts;
+	k_per_scenario_role: Record<ScenarioId, ModelRoleCounts>;
+	min_k_per_scenario_role: number;
+	model_ids: ModelIdsByRole;
+	composer_harness_failure_rate: number;
+	baseline_failure_rate: number;
+	parityDelta: number;
+	per_scenario: PerScenarioEvidence[];
+	composer_scenarios_version: string;
+	candidate_model: string;
+	baseline_model: string;
+	trace_sha256?: string;
+	manifest_sha256?: string;
+	meta: EvidenceReportMeta;
+	manifest_linter_ok: boolean;
+	manifest_linter_findings: string[];
+};
+
+const SECRET_PATTERNS: Array<{ id: string; pattern: RegExp }> = [
+	{ id: "authorization_header", pattern: /\bAuthorization\s*:\s*Bearer\s+/i },
+	{ id: "bearer_token", pattern: /\bBearer\s+[A-Za-z0-9._-]{20,}/ },
+	{ id: "openai_sk", pattern: /\bsk-[A-Za-z0-9]{20,}/ },
+	{ id: "grok_env_value", pattern: /GROK_CLI_OAUTH_TOKEN\s*=\s*\S+/ },
+	{
+		id: "oauth_env_value",
+		pattern: /\b(?:GROK_CLI_OAUTH_TOKEN|OPENAI(?:_CODEX)?_OAUTH_TOKEN|CODEX_OAUTH_TOKEN|OPENAI_API_KEY)["']?\s*[:=]\s*["']?[A-Za-z0-9._-]{12,}/i,
+	},
+	{ id: "home_path", pattern: /\/Users\/[^/\s"'`]+/ },
+	{ id: "linux_home_path", pattern: /\/home\/[^/\s"'`]+/ },
+	{ id: "windows_home_path", pattern: /[A-Za-z]:\\+Users\\+[^\\\s"'`]+/ },
+	{ id: "temp_path", pattern: /(?:\/private)?\/tmp\/[^\s"'`]+/ },
+	{ id: "tilde_home", pattern: /~\/\.[^\s'"]+/ },
+];
+
+export function scanTextForPublishSecrets(text: string): { ok: boolean; findings: string[] } {
+	const findings: string[] = [];
+	for (const { id, pattern } of SECRET_PATTERNS) {
+		if (pattern.test(text)) findings.push(id);
+	}
+	return { ok: findings.length === 0, findings };
+}
+
+export function countScenarioCoverage(
+	trialResults: TrialResult[],
+	scenarios: readonly ScenarioDefinition[] = composerScenariosForVersion(COMPOSER_SCENARIOS_VERSION),
+): number {
+	const scenarioIds = new Set(scenarios.map(scenario => scenario.id));
+	const candidateIds = new Set(
+		trialResults.filter(r => scenarioIds.has(r.scenarioId) && r.modelRole === "candidate").map(r => r.scenarioId),
+	);
+	const baselineIds = new Set(
+		trialResults.filter(r => scenarioIds.has(r.scenarioId) && r.modelRole === "baseline").map(r => r.scenarioId),
+	);
+	return Array.from(candidateIds).filter(id => baselineIds.has(id)).length;
+}
+
+export function buildPerScenarioEvidence(trialResults: TrialResult[]): PerScenarioEvidence[] {
+	const byScenario = new Map<ScenarioId, PerScenarioEvidence>();
+	for (const result of trialResults) {
+		const existing = byScenario.get(result.scenarioId) ?? {
+			id: result.scenarioId,
+			candidate_failures: 0,
+			baseline_failures: 0,
+			failure_classes: [],
+		};
+		if (result.modelRole === "candidate" && result.status === "failed") {
+			existing.candidate_failures += 1;
+			for (const fc of result.failureClasses ?? []) {
+				if (!existing.failure_classes.includes(fc)) existing.failure_classes.push(fc);
+			}
+		}
+		if (result.modelRole === "baseline" && result.status === "failed") {
+			existing.baseline_failures += 1;
+			for (const fc of result.failureClasses ?? []) {
+				if (!existing.failure_classes.includes(fc)) existing.failure_classes.push(fc);
+			}
+		}
+		byScenario.set(result.scenarioId, existing);
+	}
+	return Array.from(byScenario.values()).sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function uniqueSorted(values: string[]): string[] {
+	return Array.from(new Set(values.filter(value => value.trim().length > 0))).sort();
+}
+
+function buildRoleCounts(trialResults: TrialResult[]): ModelRoleCounts {
+	return {
+		candidate: trialResults.filter(result => result.modelRole === "candidate").length,
+		baseline: trialResults.filter(result => result.modelRole === "baseline").length,
+	};
+}
+
+function buildModelIds(trialResults: TrialResult[]): ModelIdsByRole {
+	return {
+		candidate: uniqueSorted(trialResults.filter(result => result.modelRole === "candidate").map(result => result.model)),
+		baseline: uniqueSorted(trialResults.filter(result => result.modelRole === "baseline").map(result => result.model)),
+	};
+}
+
+function modelLabel(models: string[], fallback: string): string {
+	if (models.length === 0) return fallback;
+	if (models.length === 1) return models[0]!;
+	return "mixed";
+}
+
+function buildKPerScenarioRole(
+	trialResults: TrialResult[],
+	scenarios: readonly ScenarioDefinition[],
+): Record<ScenarioId, ModelRoleCounts> {
+	const counts = Object.fromEntries(
+		scenarios.map(scenario => [scenario.id, { candidate: 0, baseline: 0 }]),
+	) as Record<ScenarioId, ModelRoleCounts>;
+	for (const result of trialResults) {
+		const existing = counts[result.scenarioId];
+		if (!existing) continue;
+		existing[result.modelRole] += 1;
+	}
+	return counts;
+}
+
+function minKPerScenarioRole(kPerScenarioRole: Record<ScenarioId, ModelRoleCounts>): number {
+	return Math.min(...Object.values(kPerScenarioRole).flatMap(counts => [counts.candidate, counts.baseline]));
+}
+
+function computeL3RefusalReasons(input: {
+	p1: P1Summary;
+	meta: EvidenceReportMeta;
+	linterOk: boolean;
+	plannedRecords: number | null;
+	capturedRecords: number;
+	kPerScenarioRole: Record<ScenarioId, ModelRoleCounts>;
+	minK: number;
+	modelIds: ModelIdsByRole;
+}): L3RefusalReason[] {
+	const reasons: L3RefusalReason[] = [];
+	const hasMissingScenario = Object.values(input.kPerScenarioRole).some(
+		counts => counts.candidate === 0 && counts.baseline === 0,
+	);
+	const hasMissingBaseline = Object.values(input.kPerScenarioRole).some(
+		counts => counts.candidate > 0 && counts.baseline === 0,
+	);
+	const scenarioVersions = uniqueSorted([
+		input.meta.composer_scenarios_version ?? COMPOSER_SCENARIOS_VERSION,
+		...(input.meta.scenario_versions ?? []),
+	]);
+
+	if (input.minK < 3) reasons.push("k_lt_3");
+	if (hasMissingBaseline) reasons.push("missing_baseline");
+	if (hasMissingScenario) reasons.push("missing_scenario");
+	if (input.meta.capture_mode === "trace-replay" || !input.meta.capture_mode) reasons.push("trace_replay_not_l3");
+	if (!input.linterOk) reasons.push("manifest_linter_failed");
+	if (scenarioVersions.length > 1) reasons.push("mixed_scenario_versions");
+	if (input.modelIds.candidate.length > 1 || input.modelIds.baseline.length > 1) reasons.push("mixed_model_ids");
+	if (
+		(input.plannedRecords !== null && input.plannedRecords !== input.capturedRecords) ||
+		(input.meta.capture_mode !== "trace-replay" && (!input.meta.trace_sha256 || !input.meta.manifest_sha256))
+	) {
+		reasons.push("partial_capture");
+	}
+	if (!input.p1.passed) reasons.push("p1_not_passed");
+
+	return reasons;
+}
+
+export function resolveLadderMaxClaim(
+	p1: P1Summary,
+	l2Eligible: boolean,
+	l3Eligible = false,
+): EvidenceReport["ladderMaxClaim"] {
+	if (!p1.applicable) return "L1";
+	if (l3Eligible) return "L3";
+	if (l2Eligible && p1.passed && p1.parityDelta <= 0) return "L2";
+	if (p1.passed) return "L1";
+	return "none";
+}
+
+export function buildEvidenceReport(
+	trialResults: TrialResult[],
+	meta: EvidenceReportMeta = {},
+	manifestText = "",
+): EvidenceReport {
+	const p1 = createP1Summary(trialResults);
+	const reportScenarioVersion = meta.composer_scenarios_version ?? COMPOSER_SCENARIOS_VERSION;
+	const reportScenarios = composerScenariosForVersion(reportScenarioVersion);
+	const reportScenarioCount = composerScenarioCountForVersion(reportScenarioVersion);
+	const coverage = countScenarioCoverage(trialResults, reportScenarios);
+	const l2Eligible = coverage >= L2_MIN_SCENARIO_COVERAGE && p1.applicable && p1.passed && p1.parityDelta <= 0;
+	const roleCounts = buildRoleCounts(trialResults);
+	const modelIds = meta.actual_model_ids ?? buildModelIds(trialResults);
+	const candidateCount = roleCounts.candidate;
+	const baselineCount = roleCounts.baseline;
+	const candidateFailures = p1.candidateFailureCount;
+	const baselineFailures = p1.baselineFailureCount;
+	const linter = scanTextForPublishSecrets(manifestText);
+	const plannedRecords = meta.planned_records ?? null;
+	const capturedRecords = meta.captured_records ?? trialResults.length;
+	const kPerScenarioRole = buildKPerScenarioRole(trialResults, reportScenarios);
+	const minK = minKPerScenarioRole(kPerScenarioRole);
+	const l3RefusalReasons = computeL3RefusalReasons({
+		p1,
+		meta,
+		linterOk: linter.ok,
+		plannedRecords,
+		capturedRecords,
+		kPerScenarioRole,
+		minK,
+		modelIds,
+	});
+
+	return {
+		schemaVersion: 1,
+		generatedAt: new Date().toISOString(),
+		ladderMaxClaim: resolveLadderMaxClaim(p1, l2Eligible, l3RefusalReasons.length === 0),
+		p1,
+		l2Eligible,
+		l3Eligible: l3RefusalReasons.length === 0,
+		l3RefusalReasons,
+		scenario_coverage: coverage,
+		scenario_coverage_ratio: `${coverage}/${reportScenarioCount}`,
+		planned_records: plannedRecords,
+		captured_records: capturedRecords,
+		role_counts: roleCounts,
+		k_per_scenario_role: kPerScenarioRole,
+		min_k_per_scenario_role: minK,
+		model_ids: modelIds,
+		composer_harness_failure_rate: candidateCount > 0 ? candidateFailures / candidateCount : 0,
+		baseline_failure_rate: baselineCount > 0 ? baselineFailures / baselineCount : 0,
+		parityDelta: p1.parityDelta,
+		per_scenario: buildPerScenarioEvidence(trialResults),
+		composer_scenarios_version: reportScenarioVersion,
+		candidate_model: modelLabel(modelIds.candidate, DEFAULT_COMPOSER_CANDIDATE_MODEL),
+		baseline_model: modelLabel(modelIds.baseline, DEFAULT_CODEX_BASELINE_MODEL),
+		trace_sha256: meta.trace_sha256,
+		manifest_sha256: meta.manifest_sha256,
+		meta,
+		manifest_linter_ok: linter.ok,
+		manifest_linter_findings: linter.findings,
+	};
+}

--- a/packages/agent/bench/composer-scenarios.ts
+++ b/packages/agent/bench/composer-scenarios.ts
@@ -1,0 +1,360 @@
+/**
+ * Single source of truth for Composer stability V3 scenarios (prompts + obligations).
+ * Live capture and the trace classifier must import from here — do not duplicate prompts.
+ */
+
+export type ScenarioId =
+	| "read-edit-hashline"
+	| "three-turn-tools"
+	| "bash-discipline"
+	| "file-discovery-discipline"
+	| "shell-write-discipline"
+	| "command-contamination"
+	| "grok-sanitize-replay"
+	| "multi-file-search-edit"
+	| "multi-file-search-edit-bad-anchor"
+	| "bad-anchor-recovery"
+	| "tool-json-malformed-recovery"
+	| "multi-turn-yield-discipline"
+	| "timeout-handling"
+	| "hard-guard-feedback"
+	| "legitimate-bash-after-tools"
+	| "wrong-target-disambiguation"
+	| "malformed-edit-recovery"
+	| "cost-safe-timeout";
+
+export type FailureClass =
+	| "shell-read"
+	| "shell-file-discovery"
+	| "shell-write"
+	| "contaminated-command"
+	| "bad-anchor-unrecovered"
+	| "malformed-tool-args-unrecovered"
+	| "sanitize-replay-regression"
+	| "wrong-file-edit"
+	| "missing-tool-turn"
+	| "timeout";
+
+export type ScenarioDefinition = {
+	id: ScenarioId;
+	description: string;
+	turns: string;
+	fixture: string;
+	obligation: string;
+	/** Frozen user prompt for live print-mode capture (composer-scenarios v1). */
+	userPrompt: string;
+	failureClass: FailureClass;
+	recovery: boolean;
+};
+
+/** P1 anti-fake-pass: minimum comparable scenario ids (candidate + baseline). */
+export const MIN_COMPARABLE_TRACE_SCENARIOS = 3;
+
+/** Public L2 claim: minimum scenarios with both roles represented in trace corpus. */
+export const L2_MIN_SCENARIO_COVERAGE = 10;
+
+export const COMPOSER_SCENARIOS_V1_COUNT = 13;
+export const TOTAL_SCENARIO_COUNT = 18;
+
+export const COMPOSER_SCENARIOS_VERSION = "v2";
+
+export const DEFAULT_COMPOSER_CANDIDATE_MODEL = "grok-build/grok-composer-2.5-fast";
+export const DEFAULT_CODEX_BASELINE_MODEL = "openai-codex/gpt-5.5:low";
+
+export const L3_MIN_TRIALS_PER_ARM = 3;
+
+export type TraceExpectation = {
+	targetPath?: string;
+	requiredTools?: string[];
+	expectedEditText?: string;
+	requireSuccess?: boolean;
+};
+
+export function traceExpectationForScenario(scenarioId: ScenarioId): TraceExpectation {
+	switch (scenarioId) {
+		case "bash-discipline":
+			return { requiredTools: ["read"], requireSuccess: true };
+		case "three-turn-tools":
+			return {
+				targetPath: "fixtures/workspace/src/a.ts",
+				expectedEditText: "TARGET_MARKER_DONE",
+				requiredTools: ["read", "search", "edit"],
+				requireSuccess: true,
+			};
+		case "shell-write-discipline":
+			return { targetPath: "fixtures/workspace/src/write-target.ts", expectedEditText: "42", requireSuccess: true };
+		case "multi-file-search-edit":
+			return {
+				targetPath: "fixtures/workspace/src/pkg/alpha.ts",
+				expectedEditText: "pkg-marker-patched",
+				requireSuccess: true,
+			};
+		case "multi-file-search-edit-bad-anchor":
+			return {
+				targetPath: "fixtures/workspace/src/target.ts",
+				expectedEditText: "recovered-anchor-ok",
+				requireSuccess: true,
+			};
+		case "read-edit-hashline":
+			return {
+				targetPath: "fixtures/workspace/src/foo.ts",
+				expectedEditText: "hello-composer-harness",
+				requireSuccess: true,
+			};
+		case "bad-anchor-recovery":
+			return { targetPath: "fixtures/workspace/src/recover.ts", expectedEditText: "ok", requireSuccess: true };
+		case "multi-turn-yield-discipline":
+			return { targetPath: "fixtures/workspace/src/multi.ts", expectedEditText: "-done", requireSuccess: true };
+		case "hard-guard-feedback":
+			return { requiredTools: ["bash", "read"], requireSuccess: true };
+		case "legitimate-bash-after-tools":
+			return { requiredTools: ["find", "read", "bash"], requireSuccess: true };
+		case "wrong-target-disambiguation":
+			return {
+				targetPath: "fixtures/workspace/src/disambiguation/target.ts",
+				expectedEditText: "EXACT_TARGET_DONE",
+				requireSuccess: true,
+			};
+		case "malformed-edit-recovery":
+			return {
+				targetPath: "fixtures/workspace/src/malformed-edit.ts",
+				expectedEditText: "MALFORMED_EDIT_DONE",
+				requireSuccess: true,
+			};
+		case "cost-safe-timeout":
+			return { requiredTools: ["find", "read"], requireSuccess: true };
+		default:
+			return { requireSuccess: true };
+	}
+}
+
+export const COMPOSER_SCENARIOS_V1_IDS = [
+	"read-edit-hashline",
+	"three-turn-tools",
+	"bash-discipline",
+	"file-discovery-discipline",
+	"shell-write-discipline",
+	"command-contamination",
+	"grok-sanitize-replay",
+	"multi-file-search-edit",
+	"multi-file-search-edit-bad-anchor",
+	"bad-anchor-recovery",
+	"tool-json-malformed-recovery",
+	"multi-turn-yield-discipline",
+	"timeout-handling",
+] as const satisfies readonly ScenarioId[];
+
+export const COMPOSER_SCENARIOS: ScenarioDefinition[] = [
+	{
+		id: "read-edit-hashline",
+		description: "Read anchored file contents, then apply one hashline edit.",
+		turns: "2-3",
+		fixture: "fixtures/workspace/src/foo.ts",
+		obligation: "final file matches golden and file IO uses read/edit tools only",
+		userPrompt:
+			"In this repo workspace, read fixtures/workspace/src/foo.ts with the read tool, then change the exported greeting string to exactly `hello-composer-harness` using the edit tool and hashline anchors from your read output. Do not use shell commands to read or write files.",
+		failureClass: "bad-anchor-unrecovered",
+		recovery: false,
+	},
+	{
+		id: "three-turn-tools",
+		description: "Chain read, search, and edit across three tool turns.",
+		turns: "3+",
+		fixture: "fixtures/workspace/src/{a,b}.ts",
+		obligation: "all tool calls are well-formed and final edit applies",
+		userPrompt:
+			"Use search to find where `TARGET_MARKER` appears under fixtures/workspace/src/, read the matching file, then edit it so `TARGET_MARKER` becomes `TARGET_MARKER_DONE`. Use find/read/search/edit only — no shell file IO.",
+		failureClass: "missing-tool-turn",
+		recovery: false,
+	},
+	{
+		id: "bash-discipline",
+		description: "User asks for file content; model must avoid shell reads.",
+		turns: "2",
+		fixture: "fixtures/workspace/src/secret.ts",
+		obligation: "no bash/cat/sed/awk/grep/head/tail file reads",
+		userPrompt:
+			"Show me the full contents of fixtures/workspace/src/secret.ts. Use only the read tool (or search/find if needed to locate it) — never cat, sed, grep, or other shell reads.",
+		failureClass: "shell-read",
+		recovery: false,
+	},
+	{
+		id: "file-discovery-discipline",
+		description: "Locate candidate files without shell ls/find/fd/git-ls-files shortcuts.",
+		turns: "2-3",
+		fixture: "fixtures/workspace/src/**/*.ts",
+		obligation: "file discovery uses the find tool, not shell directory listing commands",
+		userPrompt:
+			"List TypeScript files under fixtures/workspace/src using the find tool only (no shell ls, fd, git ls-files, or find in bash). Then read one of them briefly to confirm it exists.",
+		failureClass: "shell-file-discovery",
+		recovery: false,
+	},
+	{
+		id: "shell-write-discipline",
+		description: "Apply edits without shell redirection, tee, sed -i, or script writes.",
+		turns: "2-4",
+		fixture: "fixtures/workspace/src/write-target.ts",
+		obligation: "all file mutation uses edit/write tool calls only",
+		userPrompt:
+			"Update fixtures/workspace/src/write-target.ts so the constant VALUE equals 42. Use read then edit/write tools only — no tee, sed -i, redirection, or python/node one-liners that write files.",
+		failureClass: "shell-write",
+		recovery: false,
+	},
+	{
+		id: "command-contamination",
+		description: "Keep bash command arguments free of reasoning prose and Markdown fences.",
+		turns: "2",
+		fixture: "fixtures/transcripts/command-contamination/*.json",
+		obligation: "shell command strings contain commands only, not analysis text",
+		userPrompt:
+			"Run `bun test` in packages/agent if present, or `true` if not. If you use bash, the command string must be only the command — no markdown fences or explanatory prose inside the command argument.",
+		failureClass: "contaminated-command",
+		recovery: false,
+	},
+	{
+		id: "grok-sanitize-replay",
+		description: "Replay grok-cli payload sanitize edge cases.",
+		turns: "2-4",
+		fixture: "fixtures/transcripts/grok-sanitize-replay/*.json",
+		obligation: "sanitized replay preserves discipline and tool pairing",
+		userPrompt:
+			"Read packages/agent/test/fixtures/composer-stability-v3/traces/parity.json (first 40 lines) with the read tool and summarize whether tool events look paired. Use read/search only for file content.",
+		failureClass: "sanitize-replay-regression",
+		recovery: true,
+	},
+	{
+		id: "multi-file-search-edit",
+		description: "Search multiple files, choose the right target, then edit.",
+		turns: "3-5",
+		fixture: "fixtures/workspace/src/pkg/*",
+		obligation: "correct file chosen and patched",
+		userPrompt:
+			"Search for `pkg-marker-alpha` under fixtures/workspace/src/pkg, pick the correct file, read it, and change `pkg-marker-alpha` to `pkg-marker-patched` with edit. Do not use shell grep or sed.",
+		failureClass: "wrong-file-edit",
+		recovery: false,
+	},
+	{
+		id: "multi-file-search-edit-bad-anchor",
+		description: "Recover from a stale anchor after multi-file search.",
+		turns: "3-6",
+		fixture: "fixtures/workspace/src/target.ts",
+		obligation: "first edit fails predictably, re-read occurs, second edit succeeds",
+		userPrompt:
+			"Read fixtures/workspace/src/target.ts, attempt a one-line edit using anchors from read, and if edit rejects anchors, re-read and retry with fresh anchors until the line contains `recovered-anchor-ok`.",
+		failureClass: "bad-anchor-unrecovered",
+		recovery: true,
+	},
+	{
+		id: "bad-anchor-recovery",
+		description: "Recover from a stale anchor in a single-file edit.",
+		turns: "3-5",
+		fixture: "fixtures/workspace/src/recover.ts",
+		obligation: "failed edit is followed by re-anchor read and successful edit",
+		userPrompt:
+			"Edit fixtures/workspace/src/recover.ts to set STATUS to `ok` using hashline edit. If anchors mismatch, use the rejection message's fresh anchors or re-read before retrying.",
+		failureClass: "bad-anchor-unrecovered",
+		recovery: true,
+	},
+	{
+		id: "tool-json-malformed-recovery",
+		description: "Recover after one malformed tool-argument payload.",
+		turns: "2-4",
+		fixture: "fixtures/transcripts/tool-json-malformed-recovery/*.json",
+		obligation: "malformed args are corrected with a valid follow-up call",
+		userPrompt:
+			"Read fixtures/workspace/src/foo.ts with a valid read tool call (path only in arguments). If a tool call fails validation, immediately retry with strict JSON schema args.",
+		failureClass: "malformed-tool-args-unrecovered",
+		recovery: true,
+	},
+	{
+		id: "multi-turn-yield-discipline",
+		description: "Maintain file IO discipline across a longer multi-turn session.",
+		turns: "4+",
+		fixture: "fixtures/workspace/src/multi.ts",
+		obligation: "no shell reads across turns and task completes",
+		userPrompt:
+			"In up to four tool turns: find fixtures/workspace/src/multi.ts, read it, search for `MULTI_TURN` in that file, and edit to append `-done` to that token. Never use shell to read files across turns.",
+		failureClass: "shell-read",
+		recovery: false,
+	},
+	{
+		id: "timeout-handling",
+		description: "Detect turn/run timeouts as first-class instability failures.",
+		turns: "1+",
+		fixture: "fixtures/transcripts/timeout/*.json",
+		obligation: "deadline or timeout failures count against parity instead of being ignored",
+		userPrompt:
+			"Read docs/composer-codex-parity.md (first 30 lines) with read tool and confirm the V3 trace gate section exists. Use read only — complete promptly without long-running shell.",
+		failureClass: "timeout",
+		recovery: false,
+	},
+	{
+		id: "hard-guard-feedback",
+		description: "Recover correctly after Composer bash policy blocks shell file IO.",
+		turns: "2-4",
+		fixture: "fixtures/workspace/src/policy-secret.ts",
+		obligation: "intentional blocked bash file IO is followed by read-tool recovery without shell retry",
+		userPrompt:
+			"First intentionally try to read fixtures/workspace/src/policy-secret.ts with bash `cat fixtures/workspace/src/policy-secret.ts` to exercise the Composer bash policy. When that is blocked, recover by using the read tool; do not retry another shell file IO command.",
+		failureClass: "shell-read",
+		recovery: true,
+	},
+	{
+		id: "legitimate-bash-after-tools",
+		description: "Use dedicated tools for file IO, then a legitimate terminal command.",
+		turns: "3-5",
+		fixture: "fixtures/workspace/src/bash-ok.ts",
+		obligation: "file IO uses find/read and bash is limited to an allowlisted terminal operation",
+		userPrompt:
+			"Find and read fixtures/workspace/src/bash-ok.ts using dedicated tools, then run `git status --short --branch` with bash. Do not inspect files through bash.",
+		failureClass: "shell-read",
+		recovery: false,
+	},
+	{
+		id: "wrong-target-disambiguation",
+		description: "Disambiguate near-identical targets before editing.",
+		turns: "3-5",
+		fixture: "fixtures/workspace/src/disambiguation/*",
+		obligation: "only the file containing EXACT_TARGET is edited; decoy files remain untouched",
+		userPrompt:
+			"Search fixtures/workspace/src/disambiguation for `EXACT_TARGET`, read the matching file, and edit only that file so `EXACT_TARGET` becomes `EXACT_TARGET_DONE`. Do not modify decoys.",
+		failureClass: "wrong-file-edit",
+		recovery: false,
+	},
+	{
+		id: "malformed-edit-recovery",
+		description: "Recover from malformed edit arguments without switching tool families.",
+		turns: "3-5",
+		fixture: "fixtures/workspace/src/malformed-edit.ts",
+		obligation: "malformed edit args are followed by a valid edit on the same target",
+		userPrompt:
+			"Read fixtures/workspace/src/malformed-edit.ts and change `MALFORMED_EDIT_PENDING` to `MALFORMED_EDIT_DONE` with edit. If an edit call fails validation, retry with strict edit schema arguments and do not use bash.",
+		failureClass: "malformed-tool-args-unrecovered",
+		recovery: true,
+	},
+	{
+		id: "cost-safe-timeout",
+		description: "Avoid long-running or repeated expensive terminal work.",
+		turns: "1-2",
+		fixture: "fixtures/transcripts/cost-safe-timeout/*.json",
+		obligation: "no long-running shell loops; use find/read and finish promptly",
+		userPrompt:
+			"Confirm whether fixtures/transcripts/cost-safe-timeout/sample.json exists using find/read. Do not run sleep loops, watchers, or broad live commands.",
+		failureClass: "timeout",
+		recovery: false,
+	},
+];
+
+export const SCENARIO_BY_ID = new Map(COMPOSER_SCENARIOS.map(scenario => [scenario.id, scenario]));
+
+export function composerScenariosForVersion(version: string | undefined): ScenarioDefinition[] {
+	if (version === "v1") {
+		const v1Ids = new Set<ScenarioId>(COMPOSER_SCENARIOS_V1_IDS);
+		return COMPOSER_SCENARIOS.filter(scenario => v1Ids.has(scenario.id));
+	}
+	return COMPOSER_SCENARIOS;
+}
+
+export function composerScenarioCountForVersion(version: string | undefined): number {
+	return composerScenariosForVersion(version).length;
+}

--- a/packages/agent/bench/composer-scenarios.ts
+++ b/packages/agent/bench/composer-scenarios.ts
@@ -67,6 +67,7 @@ export type TraceExpectation = {
 	targetPath?: string;
 	requiredTools?: string[];
 	expectedEditText?: string;
+	recoveryTargetPath?: string;
 	requireSuccess?: boolean;
 };
 
@@ -106,7 +107,11 @@ export function traceExpectationForScenario(scenarioId: ScenarioId): TraceExpect
 		case "multi-turn-yield-discipline":
 			return { targetPath: "fixtures/workspace/src/multi.ts", expectedEditText: "-done", requireSuccess: true };
 		case "hard-guard-feedback":
-			return { requiredTools: ["bash", "read"], requireSuccess: true };
+			return {
+				recoveryTargetPath: "fixtures/workspace/src/policy-secret.ts",
+				requiredTools: ["bash", "read"],
+				requireSuccess: true,
+			};
 		case "legitimate-bash-after-tools":
 			return { requiredTools: ["find", "read", "bash"], requireSuccess: true };
 		case "wrong-target-disambiguation":

--- a/packages/agent/bench/composer-stability-v3.ts
+++ b/packages/agent/bench/composer-stability-v3.ts
@@ -10,45 +10,31 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { benchRunMetadata, type BenchRunMetadata } from "./_meta";
+import {
+	COMPOSER_SCENARIOS as SCENARIOS,
+	DEFAULT_CODEX_BASELINE_MODEL,
+	DEFAULT_COMPOSER_CANDIDATE_MODEL,
+	MIN_COMPARABLE_TRACE_SCENARIOS,
+	SCENARIO_BY_ID,
+	traceExpectationForScenario,
+	type FailureClass,
+	type ScenarioDefinition,
+	type ScenarioId,
+	type TraceExpectation,
+} from "./composer-scenarios";
 const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
 
 
-type ScenarioId =
-	| "read-edit-hashline"
-	| "three-turn-tools"
-	| "bash-discipline"
-	| "file-discovery-discipline"
-	| "shell-write-discipline"
-	| "command-contamination"
-	| "grok-sanitize-replay"
-	| "multi-file-search-edit"
-	| "multi-file-search-edit-bad-anchor"
-	| "bad-anchor-recovery"
-	| "tool-json-malformed-recovery"
-	| "multi-turn-yield-discipline"
-	| "timeout-handling";
+const DEFAULT_MODEL = DEFAULT_COMPOSER_CANDIDATE_MODEL;
+const DEFAULT_BASELINE_MODEL = DEFAULT_CODEX_BASELINE_MODEL;
 
-type FailureClass =
-	| "shell-read"
-	| "shell-file-discovery"
-	| "shell-write"
-	| "contaminated-command"
-	| "bad-anchor-unrecovered"
-	| "malformed-tool-args-unrecovered"
-	| "sanitize-replay-regression"
-	| "wrong-file-edit"
-	| "missing-tool-turn"
-	| "timeout";
-
-type ScenarioDefinition = {
-	id: ScenarioId;
-	description: string;
-	turns: string;
-	fixture: string;
-	obligation: string;
-	failureClass: FailureClass;
-	recovery: boolean;
-};
+export type { FailureClass, ScenarioDefinition, ScenarioId } from "./composer-scenarios";
+export {
+	COMPOSER_SCENARIOS,
+	L2_MIN_SCENARIO_COVERAGE,
+	MIN_COMPARABLE_TRACE_SCENARIOS,
+	TOTAL_SCENARIO_COUNT,
+} from "./composer-scenarios";
 
 type BenchMode = "mock" | "trace" | "live";
 
@@ -67,7 +53,7 @@ type ModelRole = "candidate" | "baseline";
 
 type TrialStatus = "passed" | "failed" | "skipped";
 
-type TrialResult = {
+export type TrialResult = {
 	scenarioId: ScenarioId;
 	modelRole: ModelRole;
 	model: string;
@@ -98,7 +84,7 @@ type TraceArtifact = {
 	error?: string;
 };
 
-type P1Summary = {
+export type P1Summary = {
 	candidateFailureCount: number;
 	baselineFailureCount: number;
 	parityDelta: number;
@@ -127,11 +113,6 @@ type BenchOutput = {
 
 type JsonObject = Record<string, unknown>;
 
-type TraceExpectation = {
-	targetPath?: string;
-	requiredTools?: string[];
-	requireSuccess?: boolean;
-};
 
 export type TraceRecord = {
 	scenarioId: ScenarioId;
@@ -151,131 +132,6 @@ type ClassifiedTrace = {
 
 const DEFAULT_SEED = 42;
 const DEFAULT_TRIALS = 5;
-const DEFAULT_MODEL = "grok-build/grok-composer-2.5-fast";
-const MIN_COMPARABLE_TRACE_SCENARIOS = 3;
-const DEFAULT_BASELINE_MODEL = "openai-codex/gpt-5.5:low";
-
-const SCENARIOS: ScenarioDefinition[] = [
-	{
-		id: "read-edit-hashline",
-		description: "Read anchored file contents, then apply one hashline edit.",
-		turns: "2-3",
-		fixture: "fixtures/workspace/src/foo.ts",
-		obligation: "final file matches golden and file IO uses read/edit tools only",
-		failureClass: "bad-anchor-unrecovered",
-		recovery: false,
-	},
-	{
-		id: "three-turn-tools",
-		description: "Chain read, search, and edit across three tool turns.",
-		turns: "3+",
-		fixture: "fixtures/workspace/src/{a,b}.ts",
-		obligation: "all tool calls are well-formed and final edit applies",
-		failureClass: "missing-tool-turn",
-		recovery: false,
-	},
-	{
-		id: "bash-discipline",
-		description: "User asks for file content; model must avoid shell reads.",
-		turns: "2",
-		fixture: "fixtures/workspace/src/secret.ts",
-		obligation: "no bash/cat/sed/awk/grep/head/tail file reads",
-		failureClass: "shell-read",
-		recovery: false,
-	},
-	{
-		id: "file-discovery-discipline",
-		description: "Locate candidate files without shell ls/find/fd/git-ls-files shortcuts.",
-		turns: "2-3",
-		fixture: "fixtures/workspace/src/**/*.ts",
-		obligation: "file discovery uses the find tool, not shell directory listing commands",
-		failureClass: "shell-file-discovery",
-		recovery: false,
-	},
-	{
-		id: "shell-write-discipline",
-		description: "Apply edits without shell redirection, tee, sed -i, or script writes.",
-		turns: "2-4",
-		fixture: "fixtures/workspace/src/write-target.ts",
-		obligation: "all file mutation uses edit/write tool calls only",
-		failureClass: "shell-write",
-		recovery: false,
-	},
-	{
-		id: "command-contamination",
-		description: "Keep bash command arguments free of reasoning prose and Markdown fences.",
-		turns: "2",
-		fixture: "fixtures/transcripts/command-contamination/*.json",
-		obligation: "shell command strings contain commands only, not analysis text",
-		failureClass: "contaminated-command",
-		recovery: false,
-	},
-	{
-		id: "grok-sanitize-replay",
-		description: "Replay grok-cli payload sanitize edge cases.",
-		turns: "2-4",
-		fixture: "fixtures/transcripts/grok-sanitize-replay/*.json",
-		obligation: "sanitized replay preserves discipline and tool pairing",
-		failureClass: "sanitize-replay-regression",
-		recovery: true,
-	},
-	{
-		id: "multi-file-search-edit",
-		description: "Search multiple files, choose the right target, then edit.",
-		turns: "3-5",
-		fixture: "fixtures/workspace/src/pkg/*",
-		obligation: "correct file chosen and patched",
-		failureClass: "wrong-file-edit",
-		recovery: false,
-	},
-	{
-		id: "multi-file-search-edit-bad-anchor",
-		description: "Recover from a stale anchor after multi-file search.",
-		turns: "3-6",
-		fixture: "fixtures/workspace/src/target.ts",
-		obligation: "first edit fails predictably, re-read occurs, second edit succeeds",
-		failureClass: "bad-anchor-unrecovered",
-		recovery: true,
-	},
-	{
-		id: "bad-anchor-recovery",
-		description: "Recover from a stale anchor in a single-file edit.",
-		turns: "3-5",
-		fixture: "fixtures/workspace/src/recover.ts",
-		obligation: "failed edit is followed by re-anchor read and successful edit",
-		failureClass: "bad-anchor-unrecovered",
-		recovery: true,
-	},
-	{
-		id: "tool-json-malformed-recovery",
-		description: "Recover after one malformed tool-argument payload.",
-		turns: "2-4",
-		fixture: "fixtures/transcripts/tool-json-malformed-recovery/*.json",
-		obligation: "malformed args are corrected with a valid follow-up call",
-		failureClass: "malformed-tool-args-unrecovered",
-		recovery: true,
-	},
-	{
-		id: "multi-turn-yield-discipline",
-		description: "Maintain file IO discipline across a longer multi-turn session.",
-		turns: "4+",
-		fixture: "fixtures/workspace/src/multi.ts",
-		obligation: "no shell reads across turns and task completes",
-		failureClass: "shell-read",
-		recovery: false,
-	},
-	{
-		id: "timeout-handling",
-		description: "Detect turn/run timeouts as first-class instability failures.",
-		turns: "1+",
-		fixture: "fixtures/transcripts/timeout/*.json",
-		obligation: "deadline or timeout failures count against parity instead of being ignored",
-		failureClass: "timeout",
-		recovery: false,
-	},
-];
-
-const SCENARIO_BY_ID = new Map(SCENARIOS.map(scenario => [scenario.id, scenario]));
 const EDIT_TOOL_NAMES = new Set(["edit", "write", "apply_patch", "applyPatch", "patch"]);
 const READ_TOOL_NAMES = new Set(["read", "search", "find"]);
 const SHELL_TOOL_NAMES = new Set(["bash", "shell", "executeBash", "terminal"]);
@@ -287,8 +143,11 @@ const FILE_WRITE_COMMAND_PATTERN = /(?:^|[;&|\s])(?:sed\s+-i|perl\s+-pi)\b|(?:^|
 const COMMAND_CONTAMINATION_PATTERN = /```|^\s*(?:I\s+(?:will|need|am going)|We\s+(?:need|will)|First[, ]|Now[, ]|Let's)\b/im;
 const ANCHOR_ERROR_PATTERN = /(?:anchor|hashline|stale).{0,80}(?:mismatch|do not match|rejected|invalid|bad)|(?:edit rejected).{0,80}(?:anchor|hashline)/i;
 const MALFORMED_ARGS_PATTERN = /(?:malformed|invalid|contaminated).{0,80}(?:json|argument|args|tool)|schema validation|failed to parse/i;
-const SANITIZE_PATTERN = /sanitize|harmony|protocol leak|to=functions|contaminated tool/i;
+const SANITIZE_PATTERN = /sanitize(?:d|r)?\s+(?:payload|replay|output)?\s*(?:failed|failure|error|regression)|harmony|protocol leak|to=functions|contaminated tool/i;
 const TIMEOUT_PATTERN = /timeout|timed out|deadline/i;
+const COMPOSER_BASH_POLICY_BLOCK_PATTERN = /Composer bash policy blocked repository file I\/O/i;
+const PATH_NOT_FOUND_PATTERN = /\bPath ['"].*['"] not found\b/i;
+const FRESH_ANCHOR_LINE_PATTERN = /^\*\d+[a-z]{2}\|/m;
 
 function parseArgs(argv: string[]): CliOptions {
 	const options: CliOptions = {
@@ -491,8 +350,23 @@ function normalizeExpected(value: unknown): TraceExpectation {
 		? requiredToolsValue.filter((entry): entry is string => typeof entry === "string")
 		: undefined;
 	const targetPath = asString(value.targetPath) ?? asString(value.path);
+	const expectedEditText = asString(value.expectedEditText) ?? asString(value.expected_edit_text);
 	const requireSuccess = typeof value.requireSuccess === "boolean" ? value.requireSuccess : undefined;
-	return { targetPath, requiredTools, requireSuccess };
+	return { targetPath, requiredTools, expectedEditText, requireSuccess };
+}
+
+function mergeTraceExpectation(scenarioId: ScenarioId, override: TraceExpectation | undefined): TraceExpectation {
+	const base = traceExpectationForScenario(scenarioId);
+	if (!override) return base;
+	const overrideKeepsBaseTarget =
+		override.targetPath === undefined ||
+		(base.targetPath !== undefined && path.normalize(override.targetPath) === path.normalize(base.targetPath));
+	return {
+		targetPath: override.targetPath ?? base.targetPath,
+		requiredTools: override.requiredTools ?? base.requiredTools,
+		expectedEditText: override.expectedEditText ?? (overrideKeepsBaseTarget ? base.expectedEditText : undefined),
+		requireSuccess: override.requireSuccess ?? base.requireSuccess,
+	};
 }
 
 function eventToolName(event: JsonObject): string | undefined {
@@ -547,7 +421,11 @@ function eventCommand(event: JsonObject): string | undefined {
 function eventPath(event: JsonObject): string | undefined {
 	const args = eventArgs(event);
 	if (isJsonObject(args)) {
-		return asString(args.path) ?? asString(args.filePath) ?? asString(args.file_path) ?? asString(args.targetPath);
+		const direct = asString(args.path) ?? asString(args.filePath) ?? asString(args.file_path) ?? asString(args.targetPath);
+		if (direct) return direct;
+		const input = asString(args.input);
+		const sectionPath = input?.match(/^§(.+)$/m)?.[1]?.trim();
+		if (sectionPath) return sectionPath;
 	}
 	return asString(event.path) ?? asString(event.filePath) ?? asString(event.file_path) ?? asString(event.targetPath);
 }
@@ -560,6 +438,14 @@ function isEventError(event: JsonObject): boolean {
 	const status = asString(event.status)?.toLowerCase();
 	const type = asString(event.type)?.toLowerCase();
 	return status === "failed" || status === "error" || event.isError === true || type?.includes("error") === true;
+}
+
+function isTimeoutFailureEvent(event: JsonObject, text: string): boolean {
+	return isEventError(event) && TIMEOUT_PATTERN.test(text);
+}
+
+function isSanitizeReplayFailureEvent(event: JsonObject, text: string): boolean {
+	return isEventError(event) && SANITIZE_PATTERN.test(text) && !PATH_NOT_FOUND_PATTERN.test(text);
 }
 
 function isSuccessfulToolEvent(event: JsonObject): boolean {
@@ -610,6 +496,13 @@ function isShellWriteEvent(event: JsonObject): boolean {
 	return FILE_WRITE_COMMAND_PATTERN.test(command);
 }
 
+function isComposerBashPolicyBlockedEvent(event: JsonObject, text: string): boolean {
+	const toolName = eventToolName(event);
+	return Boolean(
+		toolName && SHELL_TOOL_NAMES.has(toolName) && isEventError(event) && COMPOSER_BASH_POLICY_BLOCK_PATTERN.test(text),
+	);
+}
+
 function isContaminatedCommandEvent(event: JsonObject): boolean {
 	const toolName = eventToolName(event);
 	if (!toolName || !SHELL_TOOL_NAMES.has(toolName)) return false;
@@ -634,41 +527,70 @@ function addFailure(failures: Set<FailureClass>, failureClass: FailureClass): vo
 export function classifyTraceRecord(record: TraceRecord): ClassifiedTrace {
 	const failures = new Set<FailureClass>();
 	const scenario = SCENARIO_BY_ID.get(record.scenarioId);
+	const expected = mergeTraceExpectation(record.scenarioId, record.expected);
 	const calledTools = new Set<string>();
 	let sawAnchorErrorAt = -1;
 	let readAfterAnchorErrorAt = -1;
 	let anchorRecoveryTargetPath: string | undefined;
 	let readAfterAnchorErrorPath: string | undefined;
 	let sawRecoveredAnchorError = false;
+	let anchorErrorProvidedFreshAnchors = false;
 	let sawMalformedArgsAt = -1;
 	let malformedArgsToolName: string | undefined;
 	let malformedArgsPath: string | undefined;
 	let sawSuccessAfterMalformedArgs = false;
 	let sawSuccessfulTerminal = false;
+	const isHardGuardFeedbackScenario = record.scenarioId === "hard-guard-feedback";
+	let sawComposerBashPolicyBlockedIo = false;
+	let sawComposerBashPolicyRecoveryTool = false;
+	let sawShellIoRetryAfterComposerBashPolicyBlock = false;
 
+	let sawSuccessfulTargetPathEdit = false;
 	for (let index = 0; index < record.events.length; index++) {
 		const event = record.events[index]!;
 		const text = getTextBlob(event);
 		const toolName = eventToolName(event);
 		if (toolName) calledTools.add(toolName);
-		if (isShellReadEvent(event)) addFailure(failures, "shell-read");
-		if (isShellFileDiscoveryEvent(event)) addFailure(failures, "shell-file-discovery");
-		if (isShellWriteEvent(event)) addFailure(failures, "shell-write");
+		const shellIoFailureClasses = [
+			isShellReadEvent(event) ? "shell-read" : undefined,
+			isShellFileDiscoveryEvent(event) ? "shell-file-discovery" : undefined,
+			isShellWriteEvent(event) ? "shell-write" : undefined,
+		].filter((failureClass): failureClass is FailureClass => failureClass !== undefined);
+		const composerBashPolicyBlocked =
+			isHardGuardFeedbackScenario && shellIoFailureClasses.length > 0 && isComposerBashPolicyBlockedEvent(event, text);
+		if (composerBashPolicyBlocked) {
+			sawShellIoRetryAfterComposerBashPolicyBlock ||= sawComposerBashPolicyBlockedIo;
+			sawComposerBashPolicyBlockedIo = true;
+		} else {
+			if (sawComposerBashPolicyBlockedIo && shellIoFailureClasses.length > 0) {
+				sawShellIoRetryAfterComposerBashPolicyBlock = true;
+			}
+			for (const failureClass of shellIoFailureClasses) addFailure(failures, failureClass);
+		}
 		if (isContaminatedCommandEvent(event)) addFailure(failures, "contaminated-command");
-		if (TIMEOUT_PATTERN.test(text)) addFailure(failures, "timeout");
-		if (SANITIZE_PATTERN.test(text) && isEventError(event)) addFailure(failures, "sanitize-replay-regression");
+		if (isTimeoutFailureEvent(event, text)) addFailure(failures, "timeout");
+		if (isSanitizeReplayFailureEvent(event, text)) addFailure(failures, "sanitize-replay-regression");
 		if (ANCHOR_ERROR_PATTERN.test(text)) {
 			sawAnchorErrorAt = index;
-			anchorRecoveryTargetPath = eventPath(event) ?? record.expected.targetPath;
+			anchorRecoveryTargetPath = eventPath(event) ?? expected.targetPath;
 			readAfterAnchorErrorAt = -1;
 			readAfterAnchorErrorPath = undefined;
+			anchorErrorProvidedFreshAnchors = FRESH_ANCHOR_LINE_PATTERN.test(text);
 			sawRecoveredAnchorError = false;
 		}
 		if (MALFORMED_ARGS_PATTERN.test(text)) {
 			sawMalformedArgsAt = index;
 			malformedArgsToolName = toolName;
-			malformedArgsPath = eventPath(event) ?? record.expected.targetPath;
+			malformedArgsPath = eventPath(event) ?? expected.targetPath;
 			sawSuccessAfterMalformedArgs = false;
+		}
+		if (
+			isHardGuardFeedbackScenario &&
+			sawComposerBashPolicyBlockedIo &&
+			isReadEvent(event) &&
+			isSuccessfulToolEvent(event)
+		) {
+			sawComposerBashPolicyRecoveryTool = true;
 		}
 		if (sawAnchorErrorAt >= 0 && index > sawAnchorErrorAt && isReadEvent(event) && isSuccessfulToolEvent(event)) {
 			const readPath = eventPath(event);
@@ -677,7 +599,12 @@ export function classifyTraceRecord(record: TraceRecord): ClassifiedTrace {
 				readAfterAnchorErrorPath = readPath ?? anchorRecoveryTargetPath;
 			}
 		}
-		if (readAfterAnchorErrorAt >= 0 && index > readAfterAnchorErrorAt && isSuccessfulEditEvent(event)) {
+		if (
+			sawAnchorErrorAt >= 0 &&
+			index > sawAnchorErrorAt &&
+			isSuccessfulEditEvent(event) &&
+			(readAfterAnchorErrorAt >= 0 || anchorErrorProvidedFreshAnchors)
+		) {
 			const editPath = eventPath(event);
 			if (matchesNormalizedPath(anchorRecoveryTargetPath ?? readAfterAnchorErrorPath, editPath)) {
 				sawRecoveredAnchorError = true;
@@ -698,14 +625,19 @@ export function classifyTraceRecord(record: TraceRecord): ClassifiedTrace {
 		if (expectedPath && actualPath && path.normalize(expectedPath) !== path.normalize(actualPath)) {
 			addFailure(failures, "wrong-file-edit");
 		}
-		if (record.expected.targetPath && toolName && EDIT_TOOL_NAMES.has(toolName)) {
+		if (expected.targetPath && toolName && EDIT_TOOL_NAMES.has(toolName)) {
 			const targetPath = eventPath(event);
-			if (targetPath && path.normalize(targetPath) !== path.normalize(record.expected.targetPath)) {
+			const editPayload = `${stringifyArgs(eventArgs(event))}\n${text}`;
+			const hasExpectedEditText = expected.expectedEditText === undefined || editPayload.includes(expected.expectedEditText);
+			if (isSuccessfulEditEvent(event) && matchesNormalizedPath(expected.targetPath, targetPath) && hasExpectedEditText) {
+				sawSuccessfulTargetPathEdit = true;
+			}
+			if (targetPath && !matchesNormalizedPath(expected.targetPath, targetPath)) {
 				addFailure(failures, "wrong-file-edit");
 			}
 		}
 		if (isTerminalSuccessEvent(event)) sawSuccessfulTerminal = true;
-		if (isTerminalFailureEvent(event) && scenario) addFailure(failures, scenario.failureClass);
+		if (isTerminalFailureEvent(event) && scenario && !composerBashPolicyBlocked) addFailure(failures, scenario.failureClass);
 		const status = asString(event.status)?.toLowerCase();
 		const directFailureClass = normalizeFailureClass(event.failureClass);
 		if (directFailureClass && (status === "failed" || isEventError(event))) addFailure(failures, directFailureClass);
@@ -717,10 +649,20 @@ export function classifyTraceRecord(record: TraceRecord): ClassifiedTrace {
 	if (sawMalformedArgsAt >= 0 && !sawSuccessAfterMalformedArgs) {
 		addFailure(failures, "malformed-tool-args-unrecovered");
 	}
-	for (const requiredTool of record.expected.requiredTools ?? []) {
+	if (
+		isHardGuardFeedbackScenario &&
+		sawComposerBashPolicyBlockedIo &&
+		(!sawComposerBashPolicyRecoveryTool || sawShellIoRetryAfterComposerBashPolicyBlock)
+	) {
+		addFailure(failures, "shell-read");
+	}
+	if (expected.targetPath && !sawSuccessfulTargetPathEdit) {
+		addFailure(failures, "missing-tool-turn");
+	}
+	for (const requiredTool of expected.requiredTools ?? []) {
 		if (!calledTools.has(requiredTool)) addFailure(failures, "missing-tool-turn");
 	}
-	if (record.expected.requireSuccess === true && !sawSuccessfulTerminal) {
+	if (expected.requireSuccess === true && !sawSuccessfulTerminal) {
 		addFailure(failures, "missing-tool-turn");
 	}
 
@@ -878,7 +820,7 @@ async function loadTraceRecords(
 	return { records, artifacts };
 }
 
-function createP1Summary(trialResults: TrialResult[], reason?: string): P1Summary {
+export function createP1Summary(trialResults: TrialResult[], reason?: string): P1Summary {
 	const candidateResults = trialResults.filter(result => result.modelRole === "candidate");
 	const baselineResults = trialResults.filter(result => result.modelRole === "baseline");
 	const candidateFailureCount = candidateResults.filter(result => result.status === "failed").length;

--- a/packages/agent/bench/composer-stability-v3.ts
+++ b/packages/agent/bench/composer-stability-v3.ts
@@ -351,8 +351,9 @@ function normalizeExpected(value: unknown): TraceExpectation {
 		: undefined;
 	const targetPath = asString(value.targetPath) ?? asString(value.path);
 	const expectedEditText = asString(value.expectedEditText) ?? asString(value.expected_edit_text);
+	const recoveryTargetPath = asString(value.recoveryTargetPath) ?? asString(value.recovery_target_path);
 	const requireSuccess = typeof value.requireSuccess === "boolean" ? value.requireSuccess : undefined;
-	return { targetPath, requiredTools, expectedEditText, requireSuccess };
+	return { targetPath, recoveryTargetPath, requiredTools, expectedEditText, requireSuccess };
 }
 
 function mergeTraceExpectation(scenarioId: ScenarioId, override: TraceExpectation | undefined): TraceExpectation {
@@ -365,6 +366,7 @@ function mergeTraceExpectation(scenarioId: ScenarioId, override: TraceExpectatio
 		targetPath: override.targetPath ?? base.targetPath,
 		requiredTools: override.requiredTools ?? base.requiredTools,
 		expectedEditText: override.expectedEditText ?? (overrideKeepsBaseTarget ? base.expectedEditText : undefined),
+		recoveryTargetPath: override.recoveryTargetPath ?? base.recoveryTargetPath,
 		requireSuccess: override.requireSuccess ?? base.requireSuccess,
 	};
 }
@@ -584,13 +586,11 @@ export function classifyTraceRecord(record: TraceRecord): ClassifiedTrace {
 			malformedArgsPath = eventPath(event) ?? expected.targetPath;
 			sawSuccessAfterMalformedArgs = false;
 		}
-		if (
-			isHardGuardFeedbackScenario &&
-			sawComposerBashPolicyBlockedIo &&
-			isReadEvent(event) &&
-			isSuccessfulToolEvent(event)
-		) {
-			sawComposerBashPolicyRecoveryTool = true;
+		if (isHardGuardFeedbackScenario && sawComposerBashPolicyBlockedIo && isReadEvent(event) && isSuccessfulToolEvent(event)) {
+			const recoveryPath = eventPath(event);
+			if (matchesNormalizedPath(expected.recoveryTargetPath, recoveryPath)) {
+				sawComposerBashPolicyRecoveryTool = true;
+			}
 		}
 		if (sawAnchorErrorAt >= 0 && index > sawAnchorErrorAt && isReadEvent(event) && isSuccessfulToolEvent(event)) {
 			const readPath = eventPath(event);

--- a/packages/agent/test/composer-evidence.test.ts
+++ b/packages/agent/test/composer-evidence.test.ts
@@ -308,8 +308,8 @@ describe("composer-evidence report", () => {
 		const payload = JSON.parse(payloadText) as {
 			comparison_kind: string;
 			disclaimer: string;
-			arm_a: { scenario_coverage_ratio: string };
-			arm_b: { scenario_coverage_ratio: string };
+			arm_a: { composer_scenarios_version: string; scenario_coverage_ratio: string; trace_sha256?: string };
+			arm_b: { composer_scenarios_version: string; scenario_coverage_ratio: string; trace_sha256?: string };
 			comparison: { candidate_failure_count_delta_a_minus_b: number };
 		};
 		expect(payload.comparison.candidate_failure_count_delta_a_minus_b).toBe(0);
@@ -318,8 +318,85 @@ describe("composer-evidence report", () => {
 		expect(payload.disclaimer).toContain("same versioned Composer scenario prompts");
 		expect(payload.disclaimer).not.toContain("composer-scenarios-v1");
 		expect(payload.arm_a.scenario_coverage_ratio).toBe("1/13");
+		expect(payload.arm_a.composer_scenarios_version).toBe("v1");
+		expect(payload.arm_b.composer_scenarios_version).toBe("v1");
 		expect(payload.arm_b.scenario_coverage_ratio).toBe("1/13");
 		expect(payloadText).not.toContain("ab-arm-a");
 		expect(payloadText).not.toContain("ab-arm-b");
+	});
+	it("A/B compare rejects publish-secret values in public payload fields", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "composer-ab-compare-lint-"));
+		const traceDir = path.join(tempDir, "traces");
+		await fs.mkdir(traceDir, { recursive: true });
+		const armA = path.join(traceDir, "arm-a.json");
+		const armB = path.join(traceDir, "arm-b.json");
+		const outPath = path.join(tempDir, "ab-report.json");
+		const records: TraceRecord[] = [
+			{
+				scenarioId: "bash-discipline",
+				modelRole: "candidate",
+				model: "grok-build/grok-composer-2.5-fast",
+				trial: 0,
+				events: [],
+				expected: {},
+			},
+			{
+				scenarioId: "bash-discipline",
+				modelRole: "baseline",
+				model: "openai-codex/gpt-5.5:low",
+				trial: 0,
+				events: [],
+				expected: {},
+			},
+		];
+
+		await fs.writeFile(armA, JSON.stringify(records));
+		await fs.writeFile(armB, JSON.stringify(records));
+		await fs.writeFile(
+			path.join(tempDir, "provenance-manifest.json"),
+			JSON.stringify({
+				schemaVersion: 1,
+				composer_scenarios_version: "/home/alice/scenarios",
+				trace_sha256: "trace-hash",
+				manifest_sha256: "manifest-hash",
+				record_count: 2,
+			}),
+		);
+
+		const proc = Bun.spawn(
+			[
+				process.execPath,
+				"packages/agent/bench/composer-evidence-ab-compare.ts",
+				"--arm-a",
+				armA,
+				"--arm-a-version",
+				"Bearer abcdefghijklmnopqrstuvwxyz",
+				"--arm-b",
+				armB,
+				"--arm-b-version",
+				"0.6.4",
+				"--out",
+				outPath,
+			],
+			{
+				cwd: path.resolve(import.meta.dir, "../../.."),
+				env: { ...Bun.env, EVIDENCE_REPO_COMMIT: "/home/alice/worktree" },
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		const stderr = await new Response(proc.stderr).text();
+		const stdout = await new Response(proc.stdout).text();
+		expect(await proc.exited).toBe(3);
+		expect(stdout).toBe("");
+		expect(stderr).toContain("composer-evidence-ab-compare: report linter failed");
+		expect(stderr).toContain("linux_home_path");
+		expect(stderr).toContain("bearer_token");
+		expect(
+			await fs.stat(outPath).then(
+				() => true,
+				() => false,
+			),
+		).toBe(false);
 	});
 });

--- a/packages/agent/test/composer-evidence.test.ts
+++ b/packages/agent/test/composer-evidence.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildEvidenceReport, scanTextForPublishSecrets } from "../bench/composer-evidence";
+import {
+	COMPOSER_SCENARIOS,
+	COMPOSER_SCENARIOS_V1_COUNT,
+	COMPOSER_SCENARIOS_VERSION,
+	composerScenariosForVersion,
+	L2_MIN_SCENARIO_COVERAGE,
+	TOTAL_SCENARIO_COUNT,
+} from "../bench/composer-scenarios";
+import type { TraceRecord, TrialResult } from "../bench/composer-stability-v3";
+import "../bench/composer-evidence-ab-compare";
+import "../bench/composer-evidence-report";
+
+describe("composer-scenarios SoT", () => {
+	it("exports versioned scenarios with userPrompt", () => {
+		expect(COMPOSER_SCENARIOS).toHaveLength(TOTAL_SCENARIO_COUNT);
+		for (const s of COMPOSER_SCENARIOS) {
+			expect(s.userPrompt.length).toBeGreaterThan(20);
+		}
+	});
+
+	it("bumps v2 with hard-guard and recovery scenarios", () => {
+		expect(COMPOSER_SCENARIOS_VERSION).toBe("v2");
+		expect(COMPOSER_SCENARIOS.map(scenario => scenario.id)).toEqual(
+			expect.arrayContaining([
+				"hard-guard-feedback",
+				"legitimate-bash-after-tools",
+				"wrong-target-disambiguation",
+				"malformed-edit-recovery",
+				"cost-safe-timeout",
+			]),
+		);
+	});
+
+	it("keeps v1 historical reports on the v1 scenario denominator", () => {
+		const v1Scenarios = composerScenariosForVersion("v1");
+		const trials: TrialResult[] = [];
+		for (const scenario of [
+			...v1Scenarios,
+			composerScenariosForVersion("v2").find(candidate => candidate.id === "hard-guard-feedback")!,
+		]) {
+			trials.push({
+				scenarioId: scenario.id,
+				modelRole: "candidate",
+				model: "grok-build/grok-composer-2.5-fast",
+				trial: trials.length,
+				status: "passed",
+				evidence: "ok",
+			});
+			trials.push({
+				scenarioId: scenario.id,
+				modelRole: "baseline",
+				model: "openai-codex/gpt-5.5:low",
+				trial: trials.length,
+				status: "passed",
+				evidence: "ok",
+			});
+		}
+
+		const report = buildEvidenceReport(trials, {
+			capture_mode: "trace-replay",
+			comparison_kind: "historical-frozen-trace",
+			composer_scenarios_version: "v1",
+			planned_records: trials.length,
+			captured_records: trials.length,
+			trace_sha256: "trace-hash",
+			manifest_sha256: "manifest-hash",
+		});
+
+		expect(v1Scenarios).toHaveLength(COMPOSER_SCENARIOS_V1_COUNT);
+		expect(report.composer_scenarios_version).toBe("v1");
+		expect(report.scenario_coverage).toBe(COMPOSER_SCENARIOS_V1_COUNT);
+		expect(report.scenario_coverage_ratio).toBe(`${COMPOSER_SCENARIOS_V1_COUNT}/${COMPOSER_SCENARIOS_V1_COUNT}`);
+		expect(report.k_per_scenario_role["hard-guard-feedback"]).toBeUndefined();
+	});
+});
+
+describe("composer-evidence report", () => {
+	function passingMatrixTrials(k: number): TrialResult[] {
+		const trials: TrialResult[] = [];
+		let trial = 0;
+		for (const scenario of COMPOSER_SCENARIOS) {
+			for (let i = 0; i < k; i++) {
+				trials.push({
+					scenarioId: scenario.id,
+					modelRole: "candidate",
+					model: "grok-build/grok-composer-2.5-fast",
+					trial: trial++,
+					status: "passed",
+					evidence: "ok",
+				});
+				trials.push({
+					scenarioId: scenario.id,
+					modelRole: "baseline",
+					model: "openai-codex/gpt-5.5:low",
+					trial: trial++,
+					status: "passed",
+					evidence: "ok",
+				});
+			}
+		}
+		return trials;
+	}
+
+	it("l2Eligible false below L2_MIN coverage", () => {
+		const trials: TrialResult[] = [
+			{
+				scenarioId: "bash-discipline",
+				modelRole: "candidate",
+				model: "grok-build/grok-composer-2.5-fast",
+				trial: 0,
+				status: "passed",
+				evidence: "ok",
+			},
+			{
+				scenarioId: "bash-discipline",
+				modelRole: "baseline",
+				model: "openai-codex/gpt-5.5:low",
+				trial: 1,
+				status: "passed",
+				evidence: "ok",
+			},
+		];
+		const report = buildEvidenceReport(trials);
+		expect(report.scenario_coverage).toBe(1);
+		expect(L2_MIN_SCENARIO_COVERAGE).toBe(10);
+		expect(report.l2Eligible).toBe(false);
+		expect(report.ladderMaxClaim).not.toBe("L2");
+	});
+
+	it("reports L3 refusal reasons for K=1 trace replay", () => {
+		const trials: TrialResult[] = [
+			{
+				scenarioId: "bash-discipline",
+				modelRole: "candidate",
+				model: "grok-build/grok-composer-2.5-fast",
+				trial: 0,
+				status: "passed",
+				evidence: "ok",
+			},
+			{
+				scenarioId: "bash-discipline",
+				modelRole: "baseline",
+				model: "openai-codex/gpt-5.5:low",
+				trial: 1,
+				status: "passed",
+				evidence: "ok",
+			},
+		];
+		const report = buildEvidenceReport(trials, {
+			capture_mode: "trace-replay",
+			comparison_kind: "historical-frozen-trace",
+			planned_records: 2,
+			captured_records: 2,
+			trace_sha256: "trace-hash",
+			manifest_sha256: "manifest-hash",
+		});
+
+		expect(report.l3Eligible).toBe(false);
+		expect(report.l3RefusalReasons).toEqual(
+			expect.arrayContaining(["k_lt_3", "missing_scenario", "trace_replay_not_l3", "p1_not_passed"]),
+		);
+		expect(report.planned_records).toBe(2);
+		expect(report.captured_records).toBe(2);
+		expect(report.min_k_per_scenario_role).toBe(0);
+		expect(report.model_ids.candidate).toEqual(["grok-build/grok-composer-2.5-fast"]);
+		expect(report.candidate_model).toBe("grok-build/grok-composer-2.5-fast");
+	});
+
+	it("marks full K>=3 live print evidence L3 eligible", () => {
+		const trials = passingMatrixTrials(3);
+		const report = buildEvidenceReport(
+			trials,
+			{
+				capture_mode: "print",
+				planned_records: trials.length,
+				captured_records: trials.length,
+				expected_k_per_scenario_role: 3,
+				trace_sha256: "trace-hash",
+				manifest_sha256: "manifest-hash",
+			},
+			'{"schemaVersion":1,"trace_sha256":"trace-hash"}',
+		);
+
+		expect(report.l3Eligible).toBe(true);
+		expect(report.ladderMaxClaim).toBe("L3");
+		expect(report.l3RefusalReasons).toEqual([]);
+		expect(report.min_k_per_scenario_role).toBe(3);
+		expect(report.role_counts).toEqual({ candidate: 54, baseline: 54 });
+		expect(report.planned_records).toBe(108);
+		expect(report.captured_records).toBe(108);
+		expect(report.trace_sha256).toBe("trace-hash");
+		expect(report.manifest_sha256).toBe("manifest-hash");
+	});
+
+	it("refuses L3 for mixed model ids and partial captures", () => {
+		const trials = passingMatrixTrials(3);
+		trials[0] = { ...trials[0]!, model: "grok-build/grok-composer-2.5-slow" };
+		const report = buildEvidenceReport(trials, {
+			capture_mode: "print",
+			planned_records: trials.length + 1,
+			captured_records: trials.length,
+			expected_k_per_scenario_role: 3,
+			trace_sha256: "trace-hash",
+			manifest_sha256: "manifest-hash",
+		});
+
+		expect(report.l3Eligible).toBe(false);
+		expect(report.l3RefusalReasons).toEqual(expect.arrayContaining(["mixed_model_ids", "partial_capture"]));
+		expect(report.candidate_model).toBe("mixed");
+		expect(report.model_ids.candidate).toEqual([
+			"grok-build/grok-composer-2.5-fast",
+			"grok-build/grok-composer-2.5-slow",
+		]);
+	});
+
+	it("manifest linter rejects local paths and credential-shaped values", () => {
+		const mac = scanTextForPublishSecrets('{"path":"/Users/mac/secret"}');
+		const linux = scanTextForPublishSecrets('{"path":"/home/alice/project"}');
+		const windows = scanTextForPublishSecrets('{"path":"C:\\\\Users\\\\alice\\\\project"}');
+		const temp = scanTextForPublishSecrets('{"path":"/tmp/composer-artifact/summary.json"}');
+		const token = scanTextForPublishSecrets('{"auth":"Bearer abcdefghijklmnopqrstuvwxyz"}');
+		const oauthJson = scanTextForPublishSecrets('{"OPENAI_OAUTH_TOKEN":"oauth-token-value-12345"}');
+
+		expect(mac.findings).toContain("home_path");
+		expect(linux.findings).toContain("linux_home_path");
+		expect(windows.findings).toContain("windows_home_path");
+		expect(temp.findings).toContain("temp_path");
+		expect(token.findings).toContain("bearer_token");
+		expect(oauthJson.findings).toContain("oauth_env_value");
+		expect([mac, linux, windows, temp, token, oauthJson].every(result => !result.ok)).toBe(true);
+	});
+
+	it("A/B compare keeps arm labels out of capture_mode metadata", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "composer-ab-compare-"));
+		const traceDir = path.join(tempDir, "traces");
+		await fs.mkdir(traceDir, { recursive: true });
+		const armA = path.join(traceDir, "arm-a.json");
+		const armB = path.join(traceDir, "arm-b.json");
+		const outPath = path.join(tempDir, "ab-report.json");
+		const records = (candidateEvents: TraceRecord["events"]): TraceRecord[] => [
+			{
+				scenarioId: "bash-discipline",
+				modelRole: "candidate",
+				model: "grok-build/grok-composer-2.5-fast",
+				trial: 0,
+				events: candidateEvents,
+				expected: {},
+			},
+			{
+				scenarioId: "bash-discipline",
+				modelRole: "baseline",
+				model: "openai-codex/gpt-5.5:low",
+				trial: 0,
+				events: [],
+				expected: {},
+			},
+		];
+
+		await fs.writeFile(
+			armA,
+			JSON.stringify(
+				records([
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "success",
+						arguments: { command: "cat src/secret.ts" },
+					},
+				]),
+			),
+		);
+		await fs.writeFile(armB, JSON.stringify(records([])));
+		await fs.writeFile(
+			path.join(tempDir, "provenance-manifest.json"),
+			JSON.stringify({ schemaVersion: 1, composer_scenarios_version: "v1", record_count: 2 }),
+		);
+
+		const proc = Bun.spawn(
+			[
+				process.execPath,
+				"packages/agent/bench/composer-evidence-ab-compare.ts",
+				"--arm-a",
+				armA,
+				"--arm-a-version",
+				"0.5.3",
+				"--arm-b",
+				armB,
+				"--arm-b-version",
+				"0.6.4",
+				"--out",
+				outPath,
+			],
+			{ cwd: path.resolve(import.meta.dir, "../../..") },
+		);
+		const stderr = await new Response(proc.stderr).text();
+		const stdout = await new Response(proc.stdout).text();
+		expect(await proc.exited).toBe(0);
+		expect(stderr).toBe("");
+		expect(stdout).toContain('"reportArtifact": "ab-report.json"');
+		expect(stdout).not.toContain(tempDir);
+
+		const payloadText = await fs.readFile(outPath, "utf8");
+		const payload = JSON.parse(payloadText) as {
+			comparison_kind: string;
+			disclaimer: string;
+			arm_a: { scenario_coverage_ratio: string };
+			arm_b: { scenario_coverage_ratio: string };
+			comparison: { candidate_failure_count_delta_a_minus_b: number };
+		};
+		expect(payload.comparison.candidate_failure_count_delta_a_minus_b).toBe(0);
+		expect(payload.comparison_kind).toBe("historical-frozen-trace");
+		expect(payload.disclaimer).toContain("frozen trace corpora");
+		expect(payload.disclaimer).toContain("same versioned Composer scenario prompts");
+		expect(payload.disclaimer).not.toContain("composer-scenarios-v1");
+		expect(payload.arm_a.scenario_coverage_ratio).toBe("1/13");
+		expect(payload.arm_b.scenario_coverage_ratio).toBe("1/13");
+		expect(payloadText).not.toContain("ab-arm-a");
+		expect(payloadText).not.toContain("ab-arm-b");
+	});
+});

--- a/packages/agent/test/composer-stability-v3.test.ts
+++ b/packages/agent/test/composer-stability-v3.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "bun:test";
+import type { ScenarioId } from "../bench/composer-scenarios";
 import { type CliOptions, classifyTraceRecord, run, type TraceRecord } from "../bench/composer-stability-v3";
+
+const MUTATION_SCENARIOS = [
+	"read-edit-hashline",
+	"three-turn-tools",
+	"shell-write-discipline",
+	"multi-file-search-edit",
+	"multi-file-search-edit-bad-anchor",
+	"bad-anchor-recovery",
+	"multi-turn-yield-discipline",
+	"wrong-target-disambiguation",
+	"malformed-edit-recovery",
+] as const satisfies readonly ScenarioId[];
 
 const baseOptions: CliOptions = {
 	mode: "trace",
@@ -22,6 +35,21 @@ function record(partial: Partial<TraceRecord>): TraceRecord {
 		...partial,
 	};
 }
+
+it("fails terminal-only successful results for every mutation-obligation scenario", () => {
+	for (const scenarioId of MUTATION_SCENARIOS) {
+		const result = classifyTraceRecord(
+			record({
+				scenarioId,
+				expected: {},
+				events: [{ type: "scenario_result", status: "passed" }],
+			}),
+		);
+
+		expect(result.status).toBe("failed");
+		expect(result.failureClasses).toContain("missing-tool-turn");
+	}
+});
 
 describe("composer-stability-v3 trace classifier", () => {
 	it("counts shell file reads as shell-read failures", () => {
@@ -93,6 +121,121 @@ describe("composer-stability-v3 trace classifier", () => {
 		expect(scriptRead.failureClasses).toContain("shell-read");
 		expect(pythonCRead.failureClasses).toContain("shell-read");
 		expect(snakeCaseToolName.failureClasses).toContain("shell-read");
+	});
+
+	it("allows recovery after Composer bash policy blocks shell file IO", () => {
+		const recovered = classifyTraceRecord(
+			record({
+				scenarioId: "hard-guard-feedback",
+				expected: { requiredTools: ["bash", "read"], requireSuccess: true },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/policy-secret.ts" },
+						message:
+							"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.",
+					},
+					{
+						type: "tool_execution_end",
+						toolName: "read",
+						status: "success",
+						arguments: { path: "fixtures/workspace/src/policy-secret.ts" },
+					},
+					{ type: "scenario_result", status: "passed" },
+				],
+			}),
+		);
+		const policyOnly = classifyTraceRecord(
+			record({
+				scenarioId: "hard-guard-feedback",
+				expected: { requiredTools: ["bash", "read"], requireSuccess: true },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/policy-secret.ts" },
+						message:
+							"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.",
+					},
+					{ type: "scenario_result", status: "passed" },
+				],
+			}),
+		);
+		const retriedShellIo = classifyTraceRecord(
+			record({
+				scenarioId: "hard-guard-feedback",
+				expected: { requiredTools: ["bash", "read"], requireSuccess: true },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/policy-secret.ts" },
+						message:
+							"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.",
+					},
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/policy-secret.ts" },
+						message:
+							"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.",
+					},
+					{
+						type: "tool_execution_end",
+						toolName: "read",
+						status: "success",
+						arguments: { path: "fixtures/workspace/src/policy-secret.ts" },
+					},
+					{ type: "scenario_result", status: "passed" },
+				],
+			}),
+		);
+		const nonHardGuardPolicyBlock = classifyTraceRecord(
+			record({
+				scenarioId: "bash-discipline",
+				expected: { requiredTools: ["read"], requireSuccess: true },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/secret.ts" },
+						message:
+							"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.",
+					},
+					{ type: "scenario_result", status: "passed" },
+				],
+			}),
+		);
+		const unrecovered = classifyTraceRecord(
+			record({
+				scenarioId: "hard-guard-feedback",
+				expected: { requiredTools: ["bash", "read"], requireSuccess: true },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/policy-secret.ts" },
+						message: "Command exited with code 1",
+					},
+					{ type: "scenario_result", status: "passed" },
+				],
+			}),
+		);
+
+		expect(recovered.status).toBe("passed");
+		expect(policyOnly.failureClasses).toContain("shell-read");
+		expect(policyOnly.failureClasses).toContain("missing-tool-turn");
+		expect(retriedShellIo.failureClasses).toContain("shell-read");
+		expect(nonHardGuardPolicyBlock.failureClasses).toContain("shell-read");
+		expect(unrecovered.failureClasses).toContain("shell-read");
+		expect(unrecovered.failureClasses).toContain("missing-tool-turn");
 	});
 
 	it("counts shell file discovery, shell writes, and contaminated commands", () => {
@@ -207,6 +350,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const recovered = classifyTraceRecord(
 			record({
 				scenarioId: "bad-anchor-recovery",
+				expected: { targetPath: "src/recover.ts", requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -232,6 +376,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const unrecovered = classifyTraceRecord(
 			record({
 				scenarioId: "bad-anchor-recovery",
+				expected: { targetPath: "src/recover.ts", requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -245,6 +390,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const ambiguousRecovery = classifyTraceRecord(
 			record({
 				scenarioId: "bad-anchor-recovery",
+				expected: { targetPath: "src/recover.ts", requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -257,9 +403,30 @@ describe("composer-stability-v3 trace classifier", () => {
 				],
 			}),
 		);
+		const rejectionOutputRecovery = classifyTraceRecord(
+			record({
+				scenarioId: "bad-anchor-recovery",
+				expected: { targetPath: "src/recover.ts", requireSuccess: false },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "edit",
+						status: "error",
+						message: "Edit rejected: anchors do not match\n*1pa|export const marker = 'pending';",
+					},
+					{
+						type: "tool_execution_end",
+						toolName: "edit",
+						status: "success",
+						arguments: { input: "§src/recover.ts\n≔1pa\nexport const marker = 'done';" },
+					},
+				],
+			}),
+		);
 		const wrongOrderRecovery = classifyTraceRecord(
 			record({
 				scenarioId: "bad-anchor-recovery",
+				expected: { targetPath: "src/recover.ts", requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -285,6 +452,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const mismatchedPathRecovery = classifyTraceRecord(
 			record({
 				scenarioId: "bad-anchor-recovery",
+				expected: { targetPath: "src/recover.ts", requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -300,6 +468,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		);
 
 		expect(recovered.status).toBe("passed");
+		expect(rejectionOutputRecovery.status).toBe("passed");
 		expect(unrecovered.status).toBe("failed");
 		expect(unrecovered.failureClasses).toContain("bad-anchor-unrecovered");
 		expect(ambiguousRecovery.failureClasses).toContain("bad-anchor-unrecovered");
@@ -311,6 +480,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const recovered = classifyTraceRecord(
 			record({
 				scenarioId: "tool-json-malformed-recovery",
+				expected: { requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -325,6 +495,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const unrecovered = classifyTraceRecord(
 			record({
 				scenarioId: "tool-json-malformed-recovery",
+				expected: { requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -338,6 +509,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const ambiguousRecovery = classifyTraceRecord(
 			record({
 				scenarioId: "tool-json-malformed-recovery",
+				expected: { requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -352,6 +524,7 @@ describe("composer-stability-v3 trace classifier", () => {
 		const unrelatedSuccess = classifyTraceRecord(
 			record({
 				scenarioId: "tool-json-malformed-recovery",
+				expected: { requireSuccess: false },
 				events: [
 					{
 						type: "tool_execution_end",
@@ -424,6 +597,38 @@ describe("composer-stability-v3 trace classifier", () => {
 		expect(sanitize.failureClasses).toContain("sanitize-replay-regression");
 	});
 
+	it("does not classify scenario names or missing-path text as timeout/sanitize failures", () => {
+		const successfulTimeoutPath = classifyTraceRecord(
+			record({
+				scenarioId: "timeout-handling",
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "read",
+						status: "success",
+						message: "fixtures/transcripts/timeout/sample.json",
+					},
+				],
+			}),
+		);
+		const missingSanitizePath = classifyTraceRecord(
+			record({
+				scenarioId: "grok-sanitize-replay",
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "read",
+						status: "error",
+						message: "Path '/tmp/work/grok-sanitize-replay/parity.json' not found",
+					},
+				],
+			}),
+		);
+
+		expect(successfulTimeoutPath.failureClasses).not.toContain("timeout");
+		expect(missingSanitizePath.failureClasses).not.toContain("sanitize-replay-regression");
+	});
+
 	it("scores trace parity over candidate and baseline artifacts", async () => {
 		const output = await run({
 			...baseOptions,
@@ -432,8 +637,8 @@ describe("composer-stability-v3 trace classifier", () => {
 
 		expect(output.mode).toBe("trace");
 		expect(output.p1.applicable).toBe(true);
-		expect(output.p1.candidateFailureCount).toBe(14);
-		expect(output.p1.baselineFailureCount).toBe(1);
+		expect(output.p1.candidateFailureCount).toBe(16);
+		expect(output.p1.baselineFailureCount).toBe(3);
 		expect(output.p1.parityDelta).toBe(13);
 		expect(output.p1.passed).toBe(false);
 		expect(output.traceArtifacts?.map(artifact => artifact.records).reduce((sum, count) => sum + count, 0)).toBe(26);

--- a/packages/agent/test/composer-stability-v3.test.ts
+++ b/packages/agent/test/composer-stability-v3.test.ts
@@ -147,6 +147,29 @@ describe("composer-stability-v3 trace classifier", () => {
 				],
 			}),
 		);
+		const wrongTargetRecovery = classifyTraceRecord(
+			record({
+				scenarioId: "hard-guard-feedback",
+				expected: { requiredTools: ["bash", "read"], requireSuccess: true },
+				events: [
+					{
+						type: "tool_execution_end",
+						toolName: "bash",
+						status: "error",
+						arguments: { command: "cat fixtures/workspace/src/policy-secret.ts" },
+						message:
+							"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.",
+					},
+					{
+						type: "tool_execution_end",
+						toolName: "read",
+						status: "success",
+						arguments: { path: "fixtures/workspace/src/other.ts" },
+					},
+					{ type: "scenario_result", status: "passed" },
+				],
+			}),
+		);
 		const policyOnly = classifyTraceRecord(
 			record({
 				scenarioId: "hard-guard-feedback",
@@ -230,6 +253,8 @@ describe("composer-stability-v3 trace classifier", () => {
 		);
 
 		expect(recovered.status).toBe("passed");
+		expect(wrongTargetRecovery.status).toBe("failed");
+		expect(wrongTargetRecovery.failureClasses).toContain("shell-read");
 		expect(policyOnly.failureClasses).toContain("shell-read");
 		expect(policyOnly.failureClasses).toContain("missing-tool-turn");
 		expect(retriedShellIo.failureClasses).toContain("shell-read");


### PR DESCRIPTION
## Summary
- Adds the Composer evidence report builder with L2/L3 eligibility, K>=3 refusal reasons, model/scenario coverage, and P1 parity fields.
- Adds publication-safety scanning for token-shaped values and local user/temp paths before reports are treated as publishable.
- Adds report/A-B compare CLIs that emit artifact labels without raw absolute repo/workdir paths.

## Split strategy
Slice 2 of the Composer stability split. Depends on #1105 (scenario/classifier foundation); merge #1105 first, then this PR. This PR intentionally does not change Composer prompt/persona text and does not add the live capture runner.

## Verification
- `npx --yes bun@1.3.14 test packages/agent/test/composer-stability-v3.test.ts packages/agent/test/composer-evidence.test.ts` — 23 pass / 0 fail / 153 expects
- `npx --yes bun@1.3.14 run check:ts` — passed (existing Biome deprecation info only)
- `git diff --cached --check` before commit — passed