### PR TITLE
feat(agent): add Composer live capture harness

### DIFF
--- a/packages/agent/bench/capture-composer-v3-live.ts
+++ b/packages/agent/bench/capture-composer-v3-live.ts
@@ -1,0 +1,415 @@
+#!/usr/bin/env bun
+/**
+ * Plans or runs live Composer V3 matrix capture via isolated GJC print-mode sessions.
+ * Default: --dry-run prints the matrix without API calls.
+ */
+import { spawn } from "node:child_process";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { seedScenarioWorkdir } from "./composer-live-fixtures";
+import {
+	buildTraceRecord,
+	findLatestSessionFile,
+	readSessionJsonl,
+	sessionLinesToTraceEvents,
+	traceExpectationForScenario,
+} from "./composer-print-trace";
+import {
+	COMPOSER_SCENARIOS,
+	COMPOSER_SCENARIOS_VERSION,
+	DEFAULT_CODEX_BASELINE_MODEL,
+	DEFAULT_COMPOSER_CANDIDATE_MODEL,
+	SCENARIO_BY_ID,
+	TOTAL_SCENARIO_COUNT,
+	type ScenarioId,
+} from "./composer-scenarios";
+import { scanTextForPublishSecrets } from "./composer-evidence";
+import type { TraceRecord } from "./composer-stability-v3";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
+
+type Role = "candidate" | "baseline";
+
+type PlannedRow = {
+	scenarioId: ScenarioId;
+	role: Role;
+	model: string;
+	trial: number;
+	userPrompt: string;
+};
+
+type RunResult = {
+	role: Role;
+	model: string;
+	scenarioId: ScenarioId;
+	artifactSlug: string;
+	hasSessionFile: boolean;
+	exitCode: number;
+	stderrByteLength: number;
+	stderrSha256?: string;
+	finalTextByteLength: number;
+	finalTextSha256?: string;
+	toolCount: number;
+	toolErrorCount: number;
+};
+
+function parseArgs(argv: string[]): {
+	dryRun: boolean;
+	skipCredCheck: boolean;
+	k: number;
+	out?: string;
+	candidateModel: string;
+	baselineModel: string;
+	gjcBin: string;
+	scenarioFilter?: Set<ScenarioId>;
+	timeoutSec: number;
+} {
+	let dryRun = true;
+	let skipCredCheck = false;
+	let k = 1;
+	let out: string | undefined;
+	let candidateModel = DEFAULT_COMPOSER_CANDIDATE_MODEL;
+	let baselineModel = DEFAULT_CODEX_BASELINE_MODEL;
+	let gjcBin = process.env.GJC_BIN?.trim() || "gjc";
+	let scenarioFilter: Set<ScenarioId> | undefined;
+	let timeoutSec = 600;
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--run") dryRun = false;
+		if (arg === "--dry-run") dryRun = true;
+		if (arg === "--skip-cred-check") skipCredCheck = true;
+		if (arg === "-k" || arg === "--k") k = Number(argv[++i] ?? "1");
+		if (arg === "--out") out = argv[++i];
+		if (arg === "--model") candidateModel = argv[++i] ?? candidateModel;
+		if (arg === "--baseline-model") baselineModel = argv[++i] ?? baselineModel;
+		if (arg === "--gjc") gjcBin = argv[++i] ?? gjcBin;
+		if (arg === "--timeout") timeoutSec = Number(argv[++i] ?? "600");
+		if (arg === "--scenarios") {
+			const ids = (argv[++i] ?? "").split(",").map(s => s.trim()).filter(Boolean) as ScenarioId[];
+			scenarioFilter = new Set(ids);
+		}
+	}
+	return { dryRun, skipCredCheck, k, out, candidateModel, baselineModel, gjcBin, scenarioFilter, timeoutSec };
+}
+
+function hasGrokCreds(): boolean {
+	return Boolean(process.env.GROK_CLI_OAUTH_TOKEN?.trim());
+}
+
+function hasBaselineCreds(): boolean {
+	return Boolean(
+		process.env.OPENAI_CODEX_OAUTH_TOKEN?.trim() ||
+			process.env.CODEX_OAUTH_TOKEN?.trim() ||
+			process.env.OPENAI_OAUTH_TOKEN?.trim() ||
+			process.env.OPENAI_API_KEY?.trim(),
+	);
+}
+
+function buildMatrix(args: ReturnType<typeof parseArgs>): PlannedRow[] {
+	const scenarios = args.scenarioFilter
+		? COMPOSER_SCENARIOS.filter(s => args.scenarioFilter!.has(s.id))
+		: COMPOSER_SCENARIOS;
+	const planned: PlannedRow[] = [];
+	let trial = 0;
+	for (const scenario of scenarios) {
+		for (let t = 0; t < args.k; t++) {
+			planned.push({
+				scenarioId: scenario.id,
+				role: "candidate",
+				model: args.candidateModel,
+				trial: trial++,
+				userPrompt: scenario.userPrompt,
+			});
+			planned.push({
+				scenarioId: scenario.id,
+				role: "baseline",
+				model: args.baselineModel,
+				trial: trial++,
+				userPrompt: scenario.userPrompt,
+			});
+		}
+	}
+	return planned;
+}
+
+function slugModel(model: string): string {
+	return model.replace(/[/:]/g, "_");
+}
+
+const STDERR_CAPTURE_MAX = 64 * 1024;
+
+function sha256Text(text: string): string {
+	return crypto.createHash("sha256").update(text).digest("hex");
+}
+
+function assertPublishSafeArtifact(name: string, text: string): void {
+	const lint = scanTextForPublishSecrets(text);
+	if (!lint.ok) {
+		throw new Error(`${name} linter failed: ${lint.findings.join(", ")}`);
+	}
+}
+
+async function runGjcPrint(input: {
+	gjcBin: string;
+	cwd: string;
+	model: string;
+	prompt: string;
+	sessionDir: string;
+	timeoutSec: number;
+}): Promise<{ exitCode: number; stderr: string }> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(
+			input.gjcBin,
+			["-p", "--mode", "json", "--model", input.model, "--session-dir", input.sessionDir, input.prompt],
+			{
+				cwd: input.cwd,
+				env: process.env,
+				stdio: ["ignore", "pipe", "pipe"],
+			},
+		);
+		let stderr = "";
+		child.stdout?.on("data", () => {
+			// discard JSONL stream; session jsonl on disk is the source of truth
+		});
+		child.stderr?.on("data", (chunk: Buffer) => {
+			if (stderr.length < STDERR_CAPTURE_MAX) {
+				stderr += chunk.toString("utf8").slice(0, STDERR_CAPTURE_MAX - stderr.length);
+			}
+		});
+		const timer = setTimeout(() => {
+			child.kill("SIGTERM");
+		}, input.timeoutSec * 1000);
+		child.on("error", err => {
+			clearTimeout(timer);
+			reject(err);
+		});
+		child.on("close", code => {
+			clearTimeout(timer);
+			resolve({ exitCode: code ?? 1, stderr });
+		});
+	});
+}
+
+function countToolsFromSession(lines: Awaited<ReturnType<typeof readSessionJsonl>>): {
+	toolCount: number;
+	toolErrorCount: number;
+} {
+	let toolCount = 0;
+	let toolErrorCount = 0;
+	for (const line of lines) {
+		if (line.type !== "message") continue;
+		const message = line.message as Record<string, unknown> | undefined;
+		if (message?.role === "toolResult") {
+			toolCount++;
+			if (message.isError === true) toolErrorCount++;
+		}
+	}
+	return { toolCount, toolErrorCount };
+}
+
+async function extractFinalTextFromSession(sessionFile: string | undefined): Promise<string> {
+	if (!sessionFile) return "";
+	const lines = await readSessionJsonl(sessionFile);
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i]!;
+		if (line.type !== "message") continue;
+		const message = line.message as Record<string, unknown> | undefined;
+		if (message?.role !== "assistant") continue;
+		const content = message.content;
+		if (!Array.isArray(content)) continue;
+		for (const part of content) {
+			if (part && typeof part === "object" && (part as Record<string, unknown>).type === "text") {
+				const text = (part as Record<string, unknown>).text;
+				if (typeof text === "string" && text.trim()) return text.trim();
+			}
+		}
+	}
+	return "";
+}
+
+async function executeRow(
+	args: ReturnType<typeof parseArgs>,
+	row: PlannedRow,
+	outDir: string,
+	tracePath: string,
+	index: number,
+): Promise<{ run: RunResult; record: TraceRecord }> {
+	const scenario = SCENARIO_BY_ID.get(row.scenarioId);
+	if (!scenario) throw new Error(`unknown scenario ${row.scenarioId}`);
+	const workSlug = `${index}-${row.role}-${row.scenarioId}-${slugModel(row.model)}`;
+	const workdir = path.join(outDir, "work", workSlug);
+	const sessionDir = path.join(outDir, "sessions", workSlug);
+	await fs.mkdir(workdir, { recursive: true });
+	await fs.mkdir(sessionDir, { recursive: true });
+	await seedScenarioWorkdir(workdir, row.scenarioId);
+
+	const { exitCode, stderr } = await runGjcPrint({
+		gjcBin: args.gjcBin,
+		cwd: workdir,
+		model: row.model,
+		prompt: row.userPrompt,
+		sessionDir,
+		timeoutSec: args.timeoutSec,
+	});
+
+	const sessionFile = await findLatestSessionFile(sessionDir);
+	let events: ReturnType<typeof sessionLinesToTraceEvents> = [];
+	let toolCount = 0;
+	let toolErrorCount = 0;
+	if (sessionFile) {
+		const lines = await readSessionJsonl(sessionFile);
+		events = sessionLinesToTraceEvents(lines, exitCode);
+		const counts = countToolsFromSession(lines);
+		toolCount = counts.toolCount;
+		toolErrorCount = counts.toolErrorCount;
+	} else {
+		events = [{ type: "scenario_result", status: "failed", message: "missing session jsonl" }];
+	}
+
+	const record = buildTraceRecord({
+		scenarioId: row.scenarioId,
+		modelRole: row.role,
+		model: row.model,
+		trial: row.trial,
+		events,
+		tracePath: path.relative(outDir, tracePath),
+		expected: traceExpectationForScenario(row.scenarioId),
+	});
+
+	const finalText = await extractFinalTextFromSession(sessionFile);
+	const run: RunResult = {
+		role: row.role,
+		model: row.model,
+		scenarioId: row.scenarioId,
+		artifactSlug: workSlug,
+		hasSessionFile: sessionFile !== undefined,
+		exitCode,
+		stderrByteLength: Buffer.byteLength(stderr, "utf8"),
+		stderrSha256: stderr.length > 0 ? sha256Text(stderr) : undefined,
+		finalTextByteLength: Buffer.byteLength(finalText, "utf8"),
+		finalTextSha256: finalText.length > 0 ? sha256Text(finalText) : undefined,
+		toolCount,
+		toolErrorCount,
+	};
+	return { run, record };
+}
+
+
+async function main(): Promise<void> {
+	const args = parseArgs(process.argv.slice(2));
+	const planned = buildMatrix(args);
+	const runId = new Date().toISOString().replace(/[:.]/g, "-");
+	const outDir =
+		args.out ?? path.join(REPO_ROOT, ".gjc/ultragoal/artifacts", `composer-evidence-${runId}`);
+	const tracePath = path.join(outDir, "traces", "real-gjc-print-traces.json");
+
+	const payload = {
+		schemaVersion: 1,
+		composer_scenarios_version: COMPOSER_SCENARIOS_VERSION,
+		scenario_count: TOTAL_SCENARIO_COUNT,
+		planned_records: planned.length,
+		k: args.k,
+		capture_mode: "print",
+		candidate_model: args.candidateModel,
+		baseline_model: args.baselineModel,
+		dry_run: args.dryRun,
+		credentials: {
+			grok: hasGrokCreds(),
+			baseline: hasBaselineCreds(),
+		},
+		repoRootArtifact: path.basename(REPO_ROOT),
+		gjc_bin_basename: path.basename(args.gjcBin),
+		planned,
+	};
+
+	if (args.dryRun) {
+		process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+		return;
+	}
+
+	if (!args.skipCredCheck && (!hasGrokCreds() || !hasBaselineCreds())) {
+		process.stderr.write(
+			"capture-composer-v3-live: missing GROK_CLI_OAUTH_TOKEN and/or OpenAI/Codex credentials; use --dry-run or set env\n",
+		);
+		process.exit(2);
+	}
+
+	await fs.mkdir(path.dirname(tracePath), { recursive: true });
+	const results: RunResult[] = [];
+	const records: TraceRecord[] = [];
+
+	for (let i = 0; i < planned.length; i++) {
+		const row = planned[i]!;
+		process.stderr.write(`capture: ${row.scenarioId} ${row.role} trial=${row.trial}\n`);
+		const { run, record } = await executeRow(args, row, outDir, tracePath, i);
+		results.push(run);
+		records.push(record);
+	}
+
+	const traceArtifact = {
+		schemaVersion: 1,
+		runId,
+		generatedAt: new Date().toISOString(),
+		records,
+	};
+	const traceText = `${JSON.stringify(traceArtifact, null, 2)}\n`;
+	assertPublishSafeArtifact("trace artifact", traceText);
+
+	const summary = {
+		schemaVersion: 1,
+		runId,
+		traceArtifact: path.relative(outDir, tracePath),
+		results,
+	};
+	const summaryText = `${JSON.stringify(summary, null, 2)}\n`;
+	assertPublishSafeArtifact("summary artifact", summaryText);
+
+	const manifestText = `${JSON.stringify(
+		{
+			schemaVersion: 1,
+			runId,
+			traceArtifact: path.relative(outDir, tracePath),
+			summaryArtifact: "summary.json",
+			composer_scenarios_version: COMPOSER_SCENARIOS_VERSION,
+			planned_records: planned.length,
+			captured_records: records.length,
+			record_count: records.length,
+			capture_mode: "print",
+			k: args.k,
+			candidate_model: args.candidateModel,
+			baseline_model: args.baselineModel,
+			gjc_bin_basename: path.basename(args.gjcBin),
+			trace_sha256: sha256Text(traceText),
+		},
+		null,
+		2,
+	)}\n`;
+	assertPublishSafeArtifact("provenance manifest", manifestText);
+
+	await fs.writeFile(tracePath, traceText, "utf8");
+	const summaryPath = path.join(outDir, "summary.json");
+	await fs.writeFile(summaryPath, summaryText, "utf8");
+	const manifestPath = path.join(outDir, "provenance-manifest.json");
+	await fs.writeFile(manifestPath, manifestText, "utf8");
+
+	process.stdout.write(
+		`${JSON.stringify(
+			{
+				ok: true,
+				outputArtifact: path.basename(outDir),
+				traceArtifact: path.relative(outDir, tracePath),
+				summaryArtifact: "summary.json",
+				manifestArtifact: "provenance-manifest.json",
+				planned_records: planned.length,
+				captured_records: records.length,
+			},
+			null,
+			2,
+		)}\n`,
+	);
+}
+
+if (import.meta.main) {
+	await main();
+}

--- a/packages/agent/bench/capture-composer-v3-live.ts
+++ b/packages/agent/bench/capture-composer-v3-live.ts
@@ -54,7 +54,7 @@ type RunResult = {
 	toolErrorCount: number;
 };
 
-function parseArgs(argv: string[]): {
+type CaptureArgs = {
 	dryRun: boolean;
 	skipCredCheck: boolean;
 	k: number;
@@ -64,7 +64,12 @@ function parseArgs(argv: string[]): {
 	gjcBin: string;
 	scenarioFilter?: Set<ScenarioId>;
 	timeoutSec: number;
-} {
+};
+
+type SessionJsonLine = Record<string, unknown>;
+type TraceEvent = Record<string, unknown>;
+
+function parseArgs(argv: string[]): CaptureArgs {
 	let dryRun = true;
 	let skipCredCheck = false;
 	let k = 1;
@@ -106,7 +111,7 @@ function hasBaselineCreds(): boolean {
 	);
 }
 
-function buildMatrix(args: ReturnType<typeof parseArgs>): PlannedRow[] {
+function buildMatrix(args: CaptureArgs): PlannedRow[] {
 	const scenarios = args.scenarioFilter
 		? COMPOSER_SCENARIOS.filter(s => args.scenarioFilter!.has(s.id))
 		: COMPOSER_SCENARIOS;
@@ -158,40 +163,40 @@ async function runGjcPrint(input: {
 	sessionDir: string;
 	timeoutSec: number;
 }): Promise<{ exitCode: number; stderr: string }> {
-	return new Promise((resolve, reject) => {
-		const child = spawn(
-			input.gjcBin,
-			["-p", "--mode", "json", "--model", input.model, "--session-dir", input.sessionDir, input.prompt],
-			{
-				cwd: input.cwd,
-				env: process.env,
-				stdio: ["ignore", "pipe", "pipe"],
-			},
-		);
-		let stderr = "";
-		child.stdout?.on("data", () => {
-			// discard JSONL stream; session jsonl on disk is the source of truth
-		});
-		child.stderr?.on("data", (chunk: Buffer) => {
-			if (stderr.length < STDERR_CAPTURE_MAX) {
-				stderr += chunk.toString("utf8").slice(0, STDERR_CAPTURE_MAX - stderr.length);
-			}
-		});
-		const timer = setTimeout(() => {
-			child.kill("SIGTERM");
-		}, input.timeoutSec * 1000);
-		child.on("error", err => {
-			clearTimeout(timer);
-			reject(err);
-		});
-		child.on("close", code => {
-			clearTimeout(timer);
-			resolve({ exitCode: code ?? 1, stderr });
-		});
+	const { promise, resolve, reject } = Promise.withResolvers<{ exitCode: number; stderr: string }>();
+	const child = spawn(
+		input.gjcBin,
+		["-p", "--mode", "json", "--model", input.model, "--session-dir", input.sessionDir, input.prompt],
+		{
+			cwd: input.cwd,
+			env: process.env,
+			stdio: ["ignore", "pipe", "pipe"],
+		},
+	);
+	let stderr = "";
+	child.stdout?.on("data", () => {
+		// discard JSONL stream; session jsonl on disk is the source of truth
 	});
+	child.stderr?.on("data", (chunk: Buffer) => {
+		if (stderr.length < STDERR_CAPTURE_MAX) {
+			stderr += chunk.toString("utf8").slice(0, STDERR_CAPTURE_MAX - stderr.length);
+		}
+	});
+	const timer = setTimeout(() => {
+		child.kill("SIGTERM");
+	}, input.timeoutSec * 1000);
+	child.on("error", err => {
+		clearTimeout(timer);
+		reject(err);
+	});
+	child.on("close", code => {
+		clearTimeout(timer);
+		resolve({ exitCode: code ?? 1, stderr });
+	});
+	return promise;
 }
 
-function countToolsFromSession(lines: Awaited<ReturnType<typeof readSessionJsonl>>): {
+function countToolsFromSession(lines: SessionJsonLine[]): {
 	toolCount: number;
 	toolErrorCount: number;
 } {
@@ -229,7 +234,7 @@ async function extractFinalTextFromSession(sessionFile: string | undefined): Pro
 }
 
 async function executeRow(
-	args: ReturnType<typeof parseArgs>,
+	args: CaptureArgs,
 	row: PlannedRow,
 	outDir: string,
 	tracePath: string,
@@ -254,7 +259,7 @@ async function executeRow(
 	});
 
 	const sessionFile = await findLatestSessionFile(sessionDir);
-	let events: ReturnType<typeof sessionLinesToTraceEvents> = [];
+	let events: TraceEvent[] = [];
 	let toolCount = 0;
 	let toolErrorCount = 0;
 	if (sessionFile) {

--- a/packages/agent/bench/composer-live-fixtures.ts
+++ b/packages/agent/bench/composer-live-fixtures.ts
@@ -1,0 +1,98 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { ScenarioId } from "./composer-scenarios";
+
+/** Seed an isolated print-mode workdir for a V3 scenario (paths match frozen composer-scenarios prompts). */
+export async function seedScenarioWorkdir(workdir: string, scenarioId: ScenarioId): Promise<void> {
+	await fs.mkdir(workdir, { recursive: true });
+	const ws = path.join(workdir, "fixtures", "workspace");
+	const pkg = path.join(ws, "src", "pkg");
+	const transcripts = path.join(workdir, "fixtures", "transcripts");
+
+	await write(
+		path.join(workdir, "packages", "agent", "test", "fixtures", "composer-stability-v3", "traces", "parity.json"),
+		'{"events":[{"type":"tool_execution_end","toolName":"read","status":"success"}]}\n',
+	);
+	await write(
+		path.join(workdir, "docs", "composer-codex-parity.md"),
+		"# Composer/Codex parity\n\n## V3 trace gate\n\nSeeded live fixture for timeout-handling.\n",
+	);
+
+	switch (scenarioId) {
+		case "bash-discipline":
+			await write(path.join(ws, "src", "secret.ts"), "export const SECRET = 'LIVE_SECRET_7319';\n");
+			break;
+		case "read-edit-hashline":
+			await write(path.join(ws, "src", "foo.ts"), "export const greeting = 'hello-old';\n");
+			break;
+		case "three-turn-tools":
+			await write(path.join(ws, "src", "a.ts"), "export const TARGET_MARKER = 'pending';\n");
+			await write(path.join(ws, "src", "b.ts"), "// secondary\n");
+			break;
+		case "file-discovery-discipline":
+			await write(path.join(ws, "src", "one.ts"), "export const x = 1;\n");
+			await write(path.join(ws, "src", "two.ts"), "export const y = 2;\n");
+			break;
+		case "shell-write-discipline":
+			await write(path.join(ws, "src", "write-target.ts"), "export const VALUE = 0;\n");
+			break;
+		case "command-contamination":
+			await mkdir(transcripts, "command-contamination");
+			await write(path.join(transcripts, "command-contamination", "sample.json"), "{}\n");
+			break;
+		case "grok-sanitize-replay":
+			await mkdir(transcripts, "grok-sanitize-replay");
+			await write(path.join(transcripts, "grok-sanitize-replay", "sample.json"), "{}\n");
+			break;
+		case "multi-file-search-edit":
+			await write(path.join(pkg, "alpha.ts"), "export const pkg_marker_alpha = 'pkg-marker-alpha';\n");
+			await write(path.join(pkg, "beta.ts"), "export const other = 1;\n");
+			break;
+		case "multi-file-search-edit-bad-anchor":
+			await write(path.join(ws, "src", "target.ts"), "export const STATUS = 'pending';\n");
+			break;
+		case "bad-anchor-recovery":
+			await write(path.join(ws, "src", "recover.ts"), "export const STATUS = 'pending';\n");
+			break;
+		case "tool-json-malformed-recovery":
+			await mkdir(transcripts, "tool-json-malformed-recovery");
+			await write(path.join(transcripts, "tool-json-malformed-recovery", "sample.json"), "{}\n");
+			await write(path.join(ws, "src", "foo.ts"), "export const ok = true;\n");
+			break;
+		case "multi-turn-yield-discipline":
+			await write(path.join(ws, "src", "multi.ts"), "export const MULTI_TURN = 'base';\n");
+			break;
+		case "timeout-handling":
+			await mkdir(transcripts, "timeout");
+			await write(path.join(transcripts, "timeout", "sample.json"), "{}\n");
+			break;
+		case "hard-guard-feedback":
+			await write(path.join(ws, "src", "policy-secret.ts"), "export const POLICY_SECRET = 'guarded';\n");
+			break;
+		case "legitimate-bash-after-tools":
+			await write(path.join(ws, "src", "bash-ok.ts"), "export const BASH_OK = true;\n");
+			break;
+		case "wrong-target-disambiguation":
+			await write(path.join(ws, "src", "disambiguation", "target.ts"), "export const EXACT_TARGET = 'pending';\n");
+			await write(path.join(ws, "src", "disambiguation", "decoy.ts"), "export const EXACT_TARGET_DECOY = 'pending';\n");
+			break;
+		case "malformed-edit-recovery":
+			await write(path.join(ws, "src", "malformed-edit.ts"), "export const MALFORMED_EDIT_PENDING = true;\n");
+			break;
+		case "cost-safe-timeout":
+			await mkdir(transcripts, "cost-safe-timeout");
+			await write(path.join(transcripts, "cost-safe-timeout", "sample.json"), "{}\n");
+			break;
+		default:
+			break;
+	}
+}
+
+async function write(filePath: string, content: string): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, content, "utf8");
+}
+
+async function mkdir(dir: string, sub?: string): Promise<void> {
+	await fs.mkdir(sub ? path.join(dir, sub) : dir, { recursive: true });
+}

--- a/packages/agent/bench/composer-print-trace.ts
+++ b/packages/agent/bench/composer-print-trace.ts
@@ -1,0 +1,108 @@
+import * as fs from "node:fs/promises";
+import { traceExpectationForScenario, type ScenarioId, type TraceExpectation } from "./composer-scenarios";
+import type { TraceRecord } from "./composer-stability-v3";
+
+type JsonObject = Record<string, unknown>;
+
+export { traceExpectationForScenario, type TraceExpectation } from "./composer-scenarios";
+
+export async function readSessionJsonl(sessionFile: string): Promise<JsonObject[]> {
+	const raw = await fs.readFile(sessionFile, "utf8");
+	return raw
+		.split("\n")
+		.map(line => line.trim())
+		.filter(Boolean)
+		.map(line => JSON.parse(line) as JsonObject);
+}
+
+/** Convert persisted GJC session JSONL into classifier events (tool_call / tool_execution_end / scenario_result). */
+export function sessionLinesToTraceEvents(lines: JsonObject[], exitCode: number): JsonObject[] {
+	const events: JsonObject[] = [];
+	for (const line of lines) {
+		if (line.type !== "message") continue;
+		const message = line.message;
+		if (!message || typeof message !== "object") continue;
+		const role = (message as JsonObject).role;
+		if (role === "assistant") {
+			const content = (message as JsonObject).content;
+			if (!Array.isArray(content)) continue;
+			for (const part of content) {
+				if (!part || typeof part !== "object") continue;
+				const p = part as JsonObject;
+				if (p.type === "toolCall") {
+					events.push({
+						type: "tool_call",
+						toolName: p.name,
+						status: "called",
+						arguments: p.arguments,
+					});
+				}
+			}
+		}
+		if (role === "toolResult") {
+			const m = message as JsonObject;
+			const isError = m.isError === true;
+			events.push({
+				type: "tool_execution_end",
+				toolName: m.toolName,
+				status: isError ? "error" : "success",
+				arguments: extractToolArgsFromDetails(m.details),
+				message: flattenToolResultContent(m.content),
+			});
+		}
+	}
+	events.push({
+		type: "scenario_result",
+		status: exitCode === 0 ? "passed" : "failed",
+	});
+	return events;
+}
+
+function extractToolArgsFromDetails(details: unknown): unknown {
+	if (!details || typeof details !== "object") return undefined;
+	return (details as JsonObject).arguments;
+}
+
+function flattenToolResultContent(content: unknown): string | undefined {
+	if (!Array.isArray(content)) return undefined;
+	const parts: string[] = [];
+	for (const item of content) {
+		if (item && typeof item === "object" && (item as JsonObject).type === "text") {
+			const text = (item as JsonObject).text;
+			if (typeof text === "string") parts.push(text);
+		}
+	}
+	return parts.length > 0 ? parts.join("") : undefined;
+}
+
+export function buildTraceRecord(input: {
+	scenarioId: ScenarioId;
+	modelRole: "candidate" | "baseline";
+	model: string;
+	trial: number;
+	events: JsonObject[];
+	tracePath?: string;
+	expected?: TraceExpectation;
+}): TraceRecord {
+	return {
+		scenarioId: input.scenarioId,
+		modelRole: input.modelRole,
+		model: input.model,
+		trial: input.trial,
+		events: input.events,
+		expected: input.expected ?? traceExpectationForScenario(input.scenarioId),
+		tracePath: input.tracePath,
+	};
+}
+
+export async function findLatestSessionFile(sessionDir: string): Promise<string | undefined> {
+	let entries: string[];
+	try {
+		entries = await fs.readdir(sessionDir);
+	} catch {
+		return undefined;
+	}
+	const jsonl = entries.filter(name => name.endsWith(".jsonl")).sort();
+	if (jsonl.length === 0) return undefined;
+	return `${sessionDir}/${jsonl[jsonl.length - 1]}`;
+}

--- a/packages/agent/test/capture-composer-v3-live.test.ts
+++ b/packages/agent/test/capture-composer-v3-live.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { seedScenarioWorkdir } from "../bench/composer-live-fixtures";
+import {
+	buildTraceRecord,
+	sessionLinesToTraceEvents,
+	traceExpectationForScenario,
+} from "../bench/composer-print-trace";
+import { COMPOSER_SCENARIOS, type ScenarioId } from "../bench/composer-scenarios";
+import { classifyTraceRecord } from "../bench/composer-stability-v3";
+import "../bench/capture-composer-v3-live";
+
+const PROMPT_PATH_RE =
+	/\b(?:fixtures\/[A-Za-z0-9._{},*?/-]+|docs\/[A-Za-z0-9._{},*?/-]+|packages\/agent\/test\/fixtures\/[A-Za-z0-9._{},*?/-]+)/g;
+
+function extractPromptFixturePaths(prompt: string): string[] {
+	return Array.from(prompt.matchAll(PROMPT_PATH_RE), match => match[0].replace(/[,).]+$/, ""));
+}
+
+const MUTATION_TARGET_SCENARIOS = [
+	{ id: "read-edit-hashline", targetPath: "fixtures/workspace/src/foo.ts" },
+	{ id: "three-turn-tools", targetPath: "fixtures/workspace/src/a.ts" },
+	{ id: "shell-write-discipline", targetPath: "fixtures/workspace/src/write-target.ts" },
+	{ id: "multi-file-search-edit", targetPath: "fixtures/workspace/src/pkg/alpha.ts" },
+	{ id: "multi-file-search-edit-bad-anchor", targetPath: "fixtures/workspace/src/target.ts" },
+	{ id: "bad-anchor-recovery", targetPath: "fixtures/workspace/src/recover.ts" },
+	{ id: "multi-turn-yield-discipline", targetPath: "fixtures/workspace/src/multi.ts" },
+	{ id: "wrong-target-disambiguation", targetPath: "fixtures/workspace/src/disambiguation/target.ts" },
+	{ id: "malformed-edit-recovery", targetPath: "fixtures/workspace/src/malformed-edit.ts" },
+] as const satisfies readonly { id: ScenarioId; targetPath: string }[];
+const MUTATION_TARGET_SCENARIO_CASES = MUTATION_TARGET_SCENARIOS.map(({ id, targetPath }) => [id, targetPath] as const);
+
+function successfulMutationEvents(scenarioId: ScenarioId, targetPath: string): Record<string, unknown>[] {
+	const expected = traceExpectationForScenario(scenarioId);
+	const events: Record<string, unknown>[] = (expected.requiredTools ?? [])
+		.filter(toolName => toolName !== "edit" && toolName !== "write" && toolName !== "apply_patch")
+		.map(toolName => ({
+			type: "tool_execution_end",
+			toolName,
+			status: "success",
+			arguments:
+				toolName === "read" ? { path: targetPath } : { query: expected.expectedEditText ?? "mutation-target" },
+		}));
+	events.push({
+		type: "tool_execution_end",
+		toolName: "edit",
+		status: "success",
+		arguments: { path: targetPath, input: expected.expectedEditText ?? "mutation-target" },
+	});
+	events.push({ type: "scenario_result", status: "passed" });
+	return events;
+}
+
+async function promptPathExists(workdir: string, promptPath: string): Promise<boolean> {
+	if (promptPath.includes("*") || promptPath.includes("{")) {
+		const wildcardIndex = promptPath.search(/[*{]/);
+		const prefix = promptPath.slice(0, wildcardIndex);
+		const dir = prefix.endsWith("/") ? prefix.slice(0, -1) : path.dirname(prefix);
+		const entries = await fs.readdir(path.join(workdir, dir)).catch(() => []);
+		return entries.length > 0;
+	}
+	return fs.stat(path.join(workdir, promptPath)).then(
+		stat => stat.isFile() || stat.isDirectory(),
+		() => false,
+	);
+}
+
+describe("composer-live-fixtures", () => {
+	it("seeds bash-discipline workdir", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "composer-live-"));
+		await seedScenarioWorkdir(dir, "bash-discipline");
+		const text = await fs.readFile(path.join(dir, "fixtures", "workspace", "src", "secret.ts"), "utf8");
+		expect(text).toContain("LIVE_SECRET");
+	});
+
+	it("seeds composer-scenarios-v2 workdirs", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "composer-live-v2-"));
+		await seedScenarioWorkdir(dir, "wrong-target-disambiguation");
+		await seedScenarioWorkdir(dir, "cost-safe-timeout");
+		const target = await fs.readFile(
+			path.join(dir, "fixtures", "workspace", "src", "disambiguation", "target.ts"),
+			"utf8",
+		);
+		const timeoutFixture = await fs.readFile(
+			path.join(dir, "fixtures", "transcripts", "cost-safe-timeout", "sample.json"),
+			"utf8",
+		);
+		expect(target).toContain("EXACT_TARGET");
+		expect(timeoutFixture.trim()).toBe("{}");
+	});
+	it("seeds every literal fixture path referenced by scenario prompts", async () => {
+		const missing: string[] = [];
+		for (const scenario of COMPOSER_SCENARIOS) {
+			const dir = await fs.mkdtemp(path.join(os.tmpdir(), `composer-live-${scenario.id}-`));
+			await seedScenarioWorkdir(dir, scenario.id);
+			for (const promptPath of extractPromptFixturePaths(scenario.userPrompt)) {
+				if (!(await promptPathExists(dir, promptPath))) {
+					missing.push(`${scenario.id}: ${promptPath}`);
+				}
+			}
+		}
+
+		expect(missing).toEqual([]);
+	});
+});
+
+describe("capture-composer-v3-live dry-run", () => {
+	it("prints L3 planning metadata without running live sessions", async () => {
+		const proc = Bun.spawn(
+			[
+				process.execPath,
+				"packages/agent/bench/capture-composer-v3-live.ts",
+				"--dry-run",
+				"--k",
+				"3",
+				"--scenarios",
+				"bash-discipline",
+				"--model",
+				"grok-build/grok-composer-2.5-fast",
+				"--baseline-model",
+				"openai-codex/gpt-5.5:low",
+			],
+			{ cwd: path.resolve(import.meta.dir, "../../..") },
+		);
+		const stdout = await new Response(proc.stdout).text();
+		const stderr = await new Response(proc.stderr).text();
+		expect(await proc.exited).toBe(0);
+		expect(stderr).toBe("");
+		expect(stdout).not.toContain(path.resolve(import.meta.dir, "../../.."));
+
+		const payload = JSON.parse(stdout) as {
+			composer_scenarios_version: string;
+			capture_mode: string;
+			k: number;
+			planned_records: number;
+			candidate_model: string;
+			baseline_model: string;
+		};
+		expect(payload.composer_scenarios_version).toBe("v2");
+		expect(payload.capture_mode).toBe("print");
+		expect(payload.k).toBe(3);
+		expect(payload.planned_records).toBe(6);
+		expect(payload.candidate_model).toBe("grok-build/grok-composer-2.5-fast");
+		expect(payload.baseline_model).toBe("openai-codex/gpt-5.5:low");
+	});
+});
+
+describe("composer-print-trace", () => {
+	it("converts session toolResult to tool_execution_end", () => {
+		const lines = [
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", name: "read", arguments: { path: "src/secret.ts" } }],
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "read",
+					isError: false,
+					content: [{ type: "text", text: "ok\n" }],
+				},
+			},
+		];
+		const events = sessionLinesToTraceEvents(lines as never, 0);
+		expect(events.some(e => e.type === "tool_execution_end" && e.toolName === "read")).toBe(true);
+		expect(events.at(-1)).toEqual({ type: "scenario_result", status: "passed" });
+	});
+	it("uses prompted target paths for every mutation-obligation trace expectation", () => {
+		for (const { id, targetPath } of MUTATION_TARGET_SCENARIOS) {
+			const expected = traceExpectationForScenario(id);
+			expect(expected.targetPath).toBe(targetPath);
+			expect(expected).not.toEqual({ requireSuccess: true });
+		}
+	});
+
+	it.each(MUTATION_TARGET_SCENARIO_CASES)("classifies prompted target-path edit as pass for %s", (id, targetPath) => {
+		const record = buildTraceRecord({
+			scenarioId: id,
+			modelRole: "candidate",
+			model: "grok-build/grok-composer-2.5-fast",
+			trial: 0,
+			events: successfulMutationEvents(id, targetPath),
+			tracePath: "/tmp/trace.json",
+			expected: traceExpectationForScenario(id),
+		});
+		const classified = classifyTraceRecord(record);
+		expect(classified.status).toBe("passed");
+		expect(classified.failureClasses).toEqual([]);
+	});
+
+	it.each(MUTATION_TARGET_SCENARIO_CASES)("classifies terminal-only mutation trace as failure for %s", id => {
+		const record = buildTraceRecord({
+			scenarioId: id,
+			modelRole: "candidate",
+			model: "grok-build/grok-composer-2.5-fast",
+			trial: 0,
+			events: [{ type: "scenario_result", status: "passed" }],
+			tracePath: "/tmp/trace.json",
+			expected: traceExpectationForScenario(id),
+		});
+		const classified = classifyTraceRecord(record);
+		expect(classified.status).toBe("failed");
+		expect(classified.failureClasses).toContain("missing-tool-turn");
+	});
+
+	it.each(
+		MUTATION_TARGET_SCENARIO_CASES,
+	)("classifies missing target-path edit as failure for %s", (id, targetPath) => {
+		const record = buildTraceRecord({
+			scenarioId: id,
+			modelRole: "candidate",
+			model: "grok-build/grok-composer-2.5-fast",
+			trial: 0,
+			events: [
+				{ type: "tool_execution_end", toolName: "read", status: "success", arguments: { path: targetPath } },
+				{ type: "scenario_result", status: "passed" },
+			],
+			tracePath: "/tmp/trace.json",
+			expected: traceExpectationForScenario(id),
+		});
+		const classified = classifyTraceRecord(record);
+		expect(classified.status).toBe("failed");
+		expect(classified.failureClasses).toContain("missing-tool-turn");
+	});
+
+	it.each(MUTATION_TARGET_SCENARIO_CASES)("classifies wrong target-path edit as failure for %s", (id, targetPath) => {
+		const record = buildTraceRecord({
+			scenarioId: id,
+			modelRole: "candidate",
+			model: "grok-build/grok-composer-2.5-fast",
+			trial: 0,
+			events: [
+				...successfulMutationEvents(id, targetPath).filter(
+					event => event.type !== "scenario_result" && event.toolName !== "edit",
+				),
+				{
+					type: "tool_execution_end",
+					toolName: "edit",
+					status: "success",
+					arguments: { path: `${targetPath}.wrong` },
+				},
+				{ type: "scenario_result", status: "passed" },
+			],
+			tracePath: "/tmp/trace.json",
+			expected: traceExpectationForScenario(id),
+		});
+		const classified = classifyTraceRecord(record);
+		expect(classified.status).toBe("failed");
+		expect(classified.failureClasses).toEqual(["missing-tool-turn", "wrong-file-edit"]);
+	});
+
+	it.each(
+		MUTATION_TARGET_SCENARIO_CASES,
+	)("classifies wrong-content target edit as failure for %s", (id, targetPath) => {
+		const record = buildTraceRecord({
+			scenarioId: id,
+			modelRole: "candidate",
+			model: "grok-build/grok-composer-2.5-fast",
+			trial: 0,
+			events: [
+				...successfulMutationEvents(id, targetPath).filter(
+					event => event.type !== "scenario_result" && event.toolName !== "edit",
+				),
+				{
+					type: "tool_execution_end",
+					toolName: "edit",
+					status: "success",
+					arguments: { path: targetPath, input: "NO_OP_MUTATION" },
+				},
+				{ type: "scenario_result", status: "passed" },
+			],
+			tracePath: "/tmp/trace.json",
+			expected: traceExpectationForScenario(id),
+		});
+		const classified = classifyTraceRecord(record);
+		expect(classified.status).toBe("failed");
+		expect(classified.failureClasses).toEqual(["missing-tool-turn"]);
+	});
+
+	it.each(
+		MUTATION_TARGET_SCENARIO_CASES,
+	)("classifies target-only expectation wrong-content edit as failure for %s", (id, targetPath) => {
+		const record = buildTraceRecord({
+			scenarioId: id,
+			modelRole: "candidate",
+			model: "grok-build/grok-composer-2.5-fast",
+			trial: 0,
+			events: [
+				...successfulMutationEvents(id, targetPath).filter(
+					event => event.type !== "scenario_result" && event.toolName !== "edit",
+				),
+				{
+					type: "tool_execution_end",
+					toolName: "edit",
+					status: "success",
+					arguments: { path: targetPath, input: "NO_OP_MUTATION" },
+				},
+				{ type: "scenario_result", status: "passed" },
+			],
+			tracePath: "/tmp/trace.json",
+			expected: { targetPath, requireSuccess: true },
+		});
+		const classified = classifyTraceRecord(record);
+		expect(classified.status).toBe("failed");
+		expect(classified.failureClasses).toEqual(["missing-tool-turn"]);
+	});
+
+	it.each(MUTATION_TARGET_SCENARIO_CASES)("classifies failed target-path edit as failure for %s", (id, targetPath) => {
+		const record = buildTraceRecord({
+			scenarioId: id,
+			modelRole: "candidate",
+			model: "grok-build/grok-composer-2.5-fast",
+			trial: 0,
+			events: [
+				...successfulMutationEvents(id, targetPath).filter(
+					event => event.type !== "scenario_result" && event.toolName !== "edit",
+				),
+				{ type: "tool_execution_end", toolName: "edit", status: "error", arguments: { path: targetPath } },
+				{ type: "scenario_result", status: "passed" },
+			],
+			tracePath: "/tmp/trace.json",
+			expected: traceExpectationForScenario(id),
+		});
+		const classified = classifyTraceRecord(record);
+		expect(classified.status).toBe("failed");
+		expect(classified.failureClasses).toEqual(["missing-tool-turn"]);
+	});
+
+	it("classifies converted bash-discipline trace as pass", () => {
+		const record = buildTraceRecord({
+			scenarioId: "bash-discipline",
+			modelRole: "candidate",
+			model: "grok-build/grok-composer-2.5-fast",
+			trial: 0,
+			events: [
+				{ type: "tool_execution_end", toolName: "read", status: "success" },
+				{ type: "scenario_result", status: "passed" },
+			],
+			tracePath: "/tmp/trace.json",
+			expected: traceExpectationForScenario("bash-discipline"),
+		});
+		const classified = classifyTraceRecord(record);
+		expect(classified.status).toBe("passed");
+	});
+});


### PR DESCRIPTION
## Summary
- Adds the Composer print-mode live capture runner for K>=3 candidate/baseline scenario matrices.
- Adds reusable live fixtures and trace-print helpers so captured traces carry scenario ids, model roles, trials, expectations, and safe artifact slugs.
- Adds dry-run/regression tests proving manifests/reports avoid raw workdir/session/stderr/finalText publication and classify only real target edits as mutation success.

## Split strategy
Slice 3 of the Composer stability split. Depends on #1105 and #1106; merge those first. This keeps the live harness separate from prompt/persona wording and docs claim changes.

## Verification
- `npx --yes bun@1.3.14 test packages/agent/test/composer-stability-v3.test.ts packages/agent/test/composer-evidence.test.ts packages/agent/test/capture-composer-v3-live.test.ts` — 93 pass / 0 fail / 313 expects
- `npx --yes bun@1.3.14 run check:ts` — passed (existing Biome deprecation info only)
- `git diff --cached --check` before commit — passed