### PR TITLE
fix(coding-agent): widen forge splash on wide terminals

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -74,8 +74,8 @@ export class WelcomeComponent implements Component {
 	}
 
 	render(termWidth: number): string[] {
-		// Box dimensions - responsive with max width and small-terminal support
-		const maxWidth = 100;
+		// Box dimensions - responsive with a wider cap for modern launch surfaces while preserving small-terminal support
+		const maxWidth = 132;
 		const boxWidth = Math.min(maxWidth, Math.max(0, termWidth - 2));
 		if (boxWidth < 4) {
 			return [];

--- a/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
+++ b/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
@@ -113,6 +113,22 @@ describe("redesigned interactive shell chrome", () => {
 		}
 	});
 
+	it("uses a wider forge splash box on wide terminals", () => {
+		const component = new WelcomeComponent("1.2.3", "gpt-5.5", "openai");
+		const narrowLines = component.render(100);
+		const wideLines = component.render(160);
+		const narrowTop = Bun.stripANSI(narrowLines[0] ?? "");
+		const wideTop = Bun.stripANSI(wideLines[0] ?? "");
+
+		expect(visibleWidth(narrowTop)).toBe(98);
+		expect(visibleWidth(wideTop)).toBe(132);
+		expect(visibleWidth(wideTop)).toBeGreaterThan(visibleWidth(narrowTop));
+		expect(wideTop).toContain("GJC forge");
+		for (const line of wideLines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(160);
+		}
+	});
+
 	it("renders an ASCII-safe welcome logo when requested", () => {
 		const component = new WelcomeComponent("1.2.3", "gpt-5.5", "openai", [], [], "ascii");
 		const lines = component.render(54);


### PR DESCRIPTION
## Summary
- widen the forge welcome splash cap from 100 to 132 columns so wide terminals have a more balanced launch surface
- preserve existing responsive behavior for smaller terminal widths
- add deterministic render-string coverage for wide vs narrower splash widths

Fixes #1109

## Verification
- `bun test packages/coding-agent/test/modes/components/redesigned-shell.test.ts` → 16 pass / 0 fail / 167 expects
- `bun run check:ts` → passed

## Notes
- Initial recipe/dev-link attempts hit local setup noise: the recipe invocation fanned into broader workspace tests before dependencies were ready, and `dev:link` reported missing local workspace/native modules. Resolved with `bun install` + `bun run build:native`, then reran the exact targeted test and package check successfully.
- Generated native build files were not included.
