### PR TITLE
Do not expose robogjc replay tokens in dashboard HTML

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -135,6 +135,10 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3"
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        if: ${{ startsWith(matrix.key, 'python-') }}
+        with:
+          python-version: "3.11"
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
         if: ${{ matrix.rust }}
         with:

--- a/python/gjc-rpc/tests/test_client_workflow_gate.py
+++ b/python/gjc-rpc/tests/test_client_workflow_gate.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import sys
 import textwrap
 import threading
-import time
 import unittest
 
 from gjc_rpc import RpcClient, WorkflowGate

--- a/python/gjc-rpc/tests/test_host_uris.py
+++ b/python/gjc-rpc/tests/test_host_uris.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import sys
 import textwrap
-import threading
 import time
 import unittest
 
 from gjc_rpc import RpcClient, host_uri
-from gjc_rpc.host_uris import HostUri, normalize_read_result
+from gjc_rpc.host_uris import normalize_read_result
 
 
 URI_SERVER = textwrap.dedent(

--- a/python/robogjc/src/dashboard.py
+++ b/python/robogjc/src/dashboard.py
@@ -17,7 +17,8 @@ from typing import Any
 _TAIL_MAX_BYTES = 2 * 1024 * 1024
 
 # Sentinel literally embedded in the built `index.html`; replaced per-request
-# with a JSON config blob so the SPA can pick up the replay token.
+# with a JSON config blob so the SPA can learn whether privileged actions exist
+# without receiving the replay token itself.
 _CONFIG_SENTINEL = "__ROBGJC_CONFIG__"
 
 _STATIC_DIR = Path(__file__).resolve().parent / "static"
@@ -112,19 +113,12 @@ def reset_index_cache() -> None:
     _load_index_template.cache_clear()
 
 
-def render_index(replay_token: str | None) -> str:
-    """Render the dashboard HTML with the server's replay token baked in.
-
-    The token lands inside a `<script type="application/json">` block that the
-    page parses at startup and attaches to every privileged fetch. The user
-    never sees or types it; the only credential to manage is the env var on
-    the server itself.
-    """
+def render_index(replay_enabled: bool) -> str:
+    """Render the dashboard HTML with non-secret per-instance config."""
     config = {
-        "replayEnabled": bool(replay_token),
-        "replayToken": replay_token or "",
+        "replayEnabled": replay_enabled,
     }
-    # `</` would otherwise let an attacker-controlled token break out of the
+    # `</` would otherwise allow string values added later to break out of the
     # script element; escape it the standard way.
     payload = json.dumps(config, separators=(",", ":")).replace("</", "<\\/")
     return _load_index_template().replace(_CONFIG_SENTINEL, payload)

--- a/python/robogjc/src/manual_triage.py
+++ b/python/robogjc/src/manual_triage.py
@@ -53,9 +53,7 @@ def parse_issue_ref(ref: str) -> tuple[str, int]:
     cleaned = ref.strip()
     match = _ISSUE_REF.match(cleaned) or _ISSUE_URL.match(cleaned)
     if match is None:
-        raise InvalidIssueRef(
-            f"expected owner/repo#NN or https://github.com/owner/repo/issues/NN, got {ref!r}"
-        )
+        raise InvalidIssueRef(f"expected owner/repo#NN or https://github.com/owner/repo/issues/NN, got {ref!r}")
     return f"{match.group('owner')}/{match.group('repo')}", int(match.group("number"))
 
 

--- a/python/robogjc/src/server.py
+++ b/python/robogjc/src/server.py
@@ -703,8 +703,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     @app.get("/", response_class=HTMLResponse)
     async def index(request: Request) -> HTMLResponse:
         cfg: Settings = request.app.state.bag["settings"]
-        token = cfg.replay_token.get_secret_value() if cfg.replay_token else None
-        return HTMLResponse(render_index(token))
+        return HTMLResponse(render_index(cfg.replay_token is not None))
 
     @app.get("/api/status")
     async def api_status(request: Request) -> dict[str, Any]:

--- a/python/robogjc/tests/test_github_events.py
+++ b/python/robogjc/tests/test_github_events.py
@@ -425,7 +425,7 @@ def test_extract_mention_returns_none_without_mention() -> None:
 
 
 def test_extract_mention_is_case_insensitive() -> None:
-    assert extract_mention("yo @ROBGJC-BOT", "robogjc-bot") == "yo"
+    assert extract_mention("yo @ROBOGJC-BOT", "robogjc-bot") == "yo"
 
 
 def test_extract_mention_respects_hyphen_word_boundary() -> None:

--- a/python/robogjc/tests/test_server.py
+++ b/python/robogjc/tests/test_server.py
@@ -77,8 +77,8 @@ def test_index_serves_dashboard_html(settings: Settings) -> None:
     assert '"replayEnabled":' in resp.text
 
 
-def test_index_substitutes_replay_token(env, monkeypatch: pytest.MonkeyPatch) -> None:
-    """When a replay token is set, the config blob exposes it to the SPA."""
+def test_index_does_not_expose_replay_token(env, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When a replay token is set, the config blob only exposes non-secret state."""
     monkeypatch.setenv("ROBGJC_REPLAY_TOKEN", "secret-token-7")
     reset_settings_cache()
     cfg = Settings()  # type: ignore[call-arg]
@@ -89,7 +89,8 @@ def test_index_substitutes_replay_token(env, monkeypatch: pytest.MonkeyPatch) ->
             resp = client.get("/")
         assert resp.status_code == 200
         assert '"replayEnabled":true' in resp.text
-        assert '"replayToken":"secret-token-7"' in resp.text
+        assert "secret-token-7" not in resp.text
+        assert "replayToken" not in resp.text
     finally:
         close_database()
 

--- a/python/robogjc/tests/test_worker.py
+++ b/python/robogjc/tests/test_worker.py
@@ -663,6 +663,7 @@ async def test_run_rpc_skips_reminder_when_unclassified(tmp_path: Path, settings
 # Dirty-state watchdog
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_run_rpc_sends_dirty_state_reminder_when_worktree_has_unpushed_work(
     tmp_path: Path, settings: Settings, monkeypatch: pytest.MonkeyPatch

--- a/python/robogjc/web/src/api.ts
+++ b/python/robogjc/web/src/api.ts
@@ -1,4 +1,4 @@
-import { AUTH_HEADERS } from "./config";
+import { replayAuthHeaders } from "./config";
 import type {
   BrowseResponse,
   CancelResponse,
@@ -41,11 +41,11 @@ async function unwrap<T>(resp: Response): Promise<T> {
 }
 
 function authHeaders(): Record<string, string> {
-  return { ...AUTH_HEADERS };
+  return replayAuthHeaders();
 }
 
 function jsonHeaders(): Record<string, string> {
-  return { "Content-Type": "application/json", ...AUTH_HEADERS };
+  return { "Content-Type": "application/json", ...replayAuthHeaders() };
 }
 
 export const api = {

--- a/python/robogjc/web/src/config.ts
+++ b/python/robogjc/web/src/config.ts
@@ -5,34 +5,40 @@
 
 export interface AppConfig {
   replayEnabled: boolean;
-  replayToken: string;
 }
 
 function readConfig(): AppConfig {
   const node = document.getElementById("robogjc-config");
   const text = node?.textContent?.trim();
   if (!text || text === "__ROBGJC_CONFIG__") {
-    return { replayEnabled: false, replayToken: "" };
+    return { replayEnabled: false };
   }
   try {
     const parsed: unknown = JSON.parse(text);
     if (parsed === null || typeof parsed !== "object") {
-      return { replayEnabled: false, replayToken: "" };
+      return { replayEnabled: false };
     }
     const record = parsed as Record<string, unknown>;
     return {
       replayEnabled: Boolean(record.replayEnabled),
-      replayToken: typeof record.replayToken === "string" ? record.replayToken : "",
     };
   } catch {
-    return { replayEnabled: false, replayToken: "" };
+    return { replayEnabled: false };
   }
 }
 
 export const CONFIG: AppConfig = readConfig();
 
-export const AUTH_HEADERS: Readonly<Record<string, string>> = CONFIG.replayEnabled
-  ? Object.freeze({ "X-Robogjc-Replay-Token": CONFIG.replayToken })
-  : Object.freeze({});
+const REPLAY_TOKEN_STORAGE_KEY = "robogjc:replay-token";
+
+export function replayAuthHeaders(): Record<string, string> {
+  if (!CONFIG.replayEnabled) return {};
+  const cached = window.sessionStorage.getItem(REPLAY_TOKEN_STORAGE_KEY)?.trim();
+  if (cached) return { "X-Robogjc-Replay-Token": cached };
+  const token = window.prompt("ROBGJC replay token")?.trim();
+  if (!token) return {};
+  window.sessionStorage.setItem(REPLAY_TOKEN_STORAGE_KEY, token);
+  return { "X-Robogjc-Replay-Token": token };
+}
 
 export const POLL_INTERVAL_MS = 3000;

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -55,6 +55,22 @@ describe("planTasks command shape (issue #622)", () => {
 		expect(typecheck?.cwd).toBe(resolvePackageCwd("python/robogjc/web"));
 		expect(build?.cwd).toBe(resolvePackageCwd("python/robogjc/web"));
 	});
+
+	test("python tasks install dev dependencies before invoking pytest and ruff modules", () => {
+		const tasks = planForPaths(["python/robogjc/src/server.py"]);
+		const lint = tasks.find(task => task.key === "python-lint");
+		const runTest = tasks.find(task => task.key === "python-test");
+		expect(lint?.command).toEqual([
+			"bash",
+			"-lc",
+			"python3 -m pip install --user --upgrade 'pip>=24' 'setuptools>=69' wheel && python3 -m pip install --user -e python/gjc-rpc -e 'python/robogjc[dev]' && python3 -m ruff check python && python3 -m ruff format --check python/robogjc",
+		]);
+		expect(runTest?.command).toEqual([
+			"bash",
+			"-lc",
+			"python3 -m pip install --user --upgrade 'pip>=24' 'setuptools>=69' wheel && python3 -m pip install --user -e python/gjc-rpc -e 'python/robogjc[dev]' && python3 -m pytest -x --import-mode=importlib python/gjc-rpc/tests python/robogjc/tests",
+		]);
+	});
 });
 
 	describe("deep-interview selector narrowing", () => {

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -7,6 +7,8 @@ import * as fs from "node:fs/promises";
 const repoRoot = path.join(import.meta.dir, "..");
 const ZERO_SHA = /^0+$/;
 const PACKAGE_SCOPES = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] as const;
+const PYTHON_DEV_SETUP =
+	"python3 -m pip install --user --upgrade 'pip>=24' 'setuptools>=69' wheel && python3 -m pip install --user -e python/gjc-rpc -e 'python/robogjc[dev]'";
 // Keys for tasks that compile the @gajae-code/natives addon. They run once in
 // the dedicated dev-ci native-build job (not as matrix shards) and publish the
 // built `.node` files as an artifact the runtime-dependent shards download.
@@ -467,8 +469,8 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 	}
 
 	if (pythonChanged) {
-		add(tasks, "python-lint", "Python lint", ["bun", "run", "lint:py"]);
-		add(tasks, "python-test", "Python tests", ["bun", "run", "test:py"]);
+		add(tasks, "python-lint", "Python lint", pythonLintCommand());
+		add(tasks, "python-test", "Python tests", pythonTestCommand());
 	}
 	if (webChanged) {
 		add(tasks, "robogjc-web-typecheck", "robogjc web typecheck", packageScriptCommand("typecheck"), resolvePackageCwd("python/robogjc/web"));
@@ -536,8 +538,8 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 			continue;
 		}
 		if (isPythonPath(changedPath)) {
-			add(tasks, "python-lint", "Python lint", ["bun", "run", "lint:py"]);
-			add(tasks, "python-test", "Python tests", ["bun", "run", "test:py"]);
+			add(tasks, "python-lint", "Python lint", pythonLintCommand());
+			add(tasks, "python-test", "Python tests", pythonTestCommand());
 			continue;
 		}
 		if (isWebPath(changedPath)) {
@@ -679,6 +681,22 @@ function add(tasks: Map<string, Task>, key: string, description: string, command
 // (issue #622).
 export function packageScriptCommand(script: string): readonly string[] {
 	return ["bun", "run", script];
+}
+
+function pythonLintCommand(): readonly string[] {
+	return [
+		"bash",
+		"-lc",
+		`${PYTHON_DEV_SETUP} && python3 -m ruff check python && python3 -m ruff format --check python/robogjc`,
+	];
+}
+
+function pythonTestCommand(): readonly string[] {
+	return [
+		"bash",
+		"-lc",
+		`${PYTHON_DEV_SETUP} && python3 -m pytest -x --import-mode=importlib python/gjc-rpc/tests python/robogjc/tests`,
+	];
 }
 
 // Resolve a workspace-relative package directory to an absolute path used as


### PR DESCRIPTION
## Summary
- Stop embedding the replay token in the unauthenticated robogjc dashboard HTML.
- Expose only a replay-enabled flag and have the web client collect/store the token client-side when replay calls need it.
- Add a server regression test that asserts the token is absent from the index response.
- Restore affected-path CI Python shards on clean runners: install Python 3.11 for python shards, upgrade pip/setuptools, install local Python packages editably, avoid pytest `tests` package collisions, and keep Ruff format checking scoped to robogjc's configured policy.
- Include minimal Python lint/format baseline cleanup so this PR does not break the existing dev workflow when Python shards run.

## Security impact
This prevents any browser or intermediary with access to the dashboard HTML from passively recovering the replay token.

## Latest dev validation
- Rebased onto `origin/dev@0a265141b9875b0d65037e9c29f6793075a0d5c0` after #1114/#1115/#1116 merged upstream.
- Local aggregate branch `codex/security-fixes-aggregate-verify-v8` combines latest `dev` plus this remaining PR commit only.
- GitHub checks passed on commit `04ca2b08`, including `python-lint`, `python-test`, `robogjc-web-build`, `robogjc-web-typecheck`, `yaml-parse`, `ci-selftest`, `ci-dry-run`, and `gjc-state-gates`.

## Verification
- `PATH=/Users/mac/.bun/bin:$PATH bun run check:ts`
- `PATH=/Users/mac/.bun/bin:$PATH bun run ci:test:smoke`
- `PATH=/Users/mac/.bun/bin:$PATH bun --cwd=python/robogjc/web run typecheck && PATH=/Users/mac/.bun/bin:$PATH bun scripts/check-workflow-yaml.ts && git diff --check origin/dev..HEAD`
- `PATH=/Users/mac/.bun/bin:$PATH CI_DEV_PLAN_MODE=pr CI_DEV_CHANGED_PATHS="$(git diff --name-only origin/dev..HEAD)" bun scripts/ci-dev-affected.ts --matrix-json`
- `/tmp/gajae-code-ci-py-oldpip/bin/python -m ruff check python && /tmp/gajae-code-ci-py-oldpip/bin/python -m ruff format --check python/robogjc`
- `/tmp/gajae-code-ci-py-oldpip/bin/python -m pytest -q -x --import-mode=importlib python/gjc-rpc/tests python/robogjc/tests` (`506 passed, 9 skipped`)

## Local full-suite note
- Full local `bun run test:ts` was not used as the final completion gate because an earlier run exposed unrelated baseline failures that reproduced on the then-current `dev-base`. The final gate is targeted security coverage plus `check:ts`, GJC smoke, Python full suite, workflow planner checks, and GitHub CI on this PR.
