### PR TITLE
Block private-network URL fetches before loading

### DIFF
--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -17,7 +17,7 @@ import { CachedOutputBlock } from "../tui/output-block";
 import { formatDimensionNote, resizeImage } from "../utils/image-resize";
 import { ensureTool } from "../utils/tools-manager";
 import { INSANE_NOTES, tryInsaneFetch } from "../web/insane/bridge";
-import { validatePublicHttpUrlForInsane } from "../web/insane/url-guard";
+import { validatePublicHttpUrl, validatePublicHttpUrlForInsane } from "../web/insane/url-guard";
 import { extractWithParallel, findParallelApiKey, getParallelExtractContent } from "../web/parallel";
 import { specialHandlers } from "../web/scrapers";
 import type { RenderResult } from "../web/scrapers/types";
@@ -789,6 +789,21 @@ async function renderUrl(
 
 	// Step 0: Normalize URL (ensure scheme for special handlers)
 	url = normalizeUrl(url);
+	const publicUrl = await validatePublicHttpUrl(url);
+	if (!publicUrl.ok) {
+		notes.push(`Blocked URL fetch: target URL is not public HTTP(S): ${publicUrl.reason}`);
+		return {
+			url,
+			finalUrl: url,
+			contentType: "unknown",
+			method: "failed",
+			content: "",
+			fetchedAt,
+			truncated: false,
+			notes,
+		};
+	}
+	url = publicUrl.url.toString();
 
 	// Step 1: Try special handlers for known sites (unless raw mode)
 	if (!raw) {
@@ -802,7 +817,8 @@ async function renderUrl(
 		throw new ToolAbortError();
 	}
 	if (!response.ok) {
-		const failureNote = response.status ? `Failed to fetch URL (HTTP ${response.status})` : "Failed to fetch URL";
+		const failureNote =
+			response.error ?? (response.status ? `Failed to fetch URL (HTTP ${response.status})` : "Failed to fetch URL");
 		notes.push(failureNote);
 		const insane = await tryInsaneFallback({
 			url,

--- a/packages/coding-agent/src/web/insane/url-guard.ts
+++ b/packages/coding-agent/src/web/insane/url-guard.ts
@@ -1,16 +1,13 @@
 /**
- * Public HTTP(S) URL guard for the insane-search read fallback.
+ * Public HTTP(S) URL guard for user-supplied web fetch targets.
  *
- * The vendored insane-search engine performs its own network requests (curl_cffi,
- * a real browser) entirely outside the TypeScript fetch path, so the normal
- * `loadPage()` flow cannot protect against SSRF. This guard MUST run before any
- * dependency probe or engine subprocess is spawned. It is fail-closed: anything
- * it cannot prove is a public, non-credentialed http/https target is rejected.
+ * Network-capable URL readers MUST run this guard before the first request and
+ * before following any redirect target. It is fail-closed: anything it cannot
+ * prove is a public, non-credentialed http/https target is rejected.
  *
- * It does NOT follow or re-validate redirects — the engine may follow redirects
- * internally that this guard never sees. That residual risk is documented in the
- * plan and mitigated by validating the input target and keeping the feature
- * opt-in (default off).
+ * The vendored insane-search engine performs its own redirects outside the
+ * TypeScript fetch path, so its fallback remains opt-in and is guarded before
+ * any dependency probe or engine subprocess is spawned.
  */
 import * as dns from "node:dns/promises";
 import * as net from "node:net";
@@ -105,11 +102,11 @@ export function isPrivateOrSpecialAddress(address: string): boolean {
 }
 
 /**
- * Validate that `rawUrl` is a public http/https target safe to hand to the
- * insane-search engine. Resolves DNS names and rejects any that map to a
- * private/special address. Never throws; returns a discriminated result.
+ * Validate that `rawUrl` is a public http/https target. Resolves DNS names and
+ * rejects any that map to a private/special address. Never throws; returns a
+ * discriminated result.
  */
-export async function validatePublicHttpUrlForInsane(
+export async function validatePublicHttpUrl(
 	rawUrl: string,
 	options: { resolver?: AddressResolver } = {},
 ): Promise<PublicUrlResult> {
@@ -152,4 +149,11 @@ export async function validatePublicHttpUrlForInsane(
 		return { ok: false, reason: "host resolves to a private or reserved address" };
 	}
 	return { ok: true, url, addresses };
+}
+
+export async function validatePublicHttpUrlForInsane(
+	rawUrl: string,
+	options: { resolver?: AddressResolver } = {},
+): Promise<PublicUrlResult> {
+	return validatePublicHttpUrl(rawUrl, options);
 }

--- a/packages/coding-agent/src/web/scrapers/types.ts
+++ b/packages/coding-agent/src/web/scrapers/types.ts
@@ -6,6 +6,8 @@ import type TurndownService from "turndown";
 
 import type { AgentStorage } from "../../session/agent-storage";
 import { ToolAbortError } from "../../tools/tool-errors";
+import type { AddressResolver } from "../insane/url-guard";
+import { validatePublicHttpUrl } from "../insane/url-guard";
 
 export { formatNumber } from "@gajae-code/utils";
 
@@ -35,6 +37,7 @@ const USER_AGENTS = [
 	"Mozilla/5.0 (compatible; TextBot/1.0)",
 	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
 ];
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 function isBotBlocked(status: number, content: string): boolean {
 	if (status === 403 || status === 503) {
@@ -70,6 +73,9 @@ export interface LoadPageOptions {
 	body?: string;
 	maxBytes?: number;
 	signal?: AbortSignal;
+	publicUrlGuard?: boolean;
+	resolver?: AddressResolver;
+	maxRedirects?: number;
 }
 
 export interface LoadPageResult {
@@ -78,87 +84,179 @@ export interface LoadPageResult {
 	finalUrl: string;
 	ok: boolean;
 	status?: number;
+	error?: string;
+}
+
+async function guardPublicFetchUrl(
+	rawUrl: string,
+	resolver: AddressResolver | undefined,
+	context: string,
+): Promise<{ ok: true; url: string } | { ok: false; error: string; finalUrl: string }> {
+	const guard = await validatePublicHttpUrl(rawUrl, { resolver });
+	if (guard.ok) return { ok: true, url: guard.url.toString() };
+	return {
+		ok: false,
+		error: `${context}: target URL is not public HTTP(S): ${guard.reason}`,
+		finalUrl: rawUrl,
+	};
+}
+
+function shouldRewriteRedirectMethod(status: number, method: string): boolean {
+	const normalized = method.toUpperCase();
+	return status === 303 || ((status === 301 || status === 302) && normalized === "POST");
 }
 
 /**
  * Fetch a page with timeout and size limit
  */
 export async function loadPage(url: string, options: LoadPageOptions = {}): Promise<LoadPageResult> {
-	const { timeout = 20, headers = {}, maxBytes = MAX_BYTES, signal, method = "GET", body } = options;
+	const {
+		timeout = 20,
+		headers = {},
+		maxBytes = MAX_BYTES,
+		signal,
+		method = "GET",
+		body,
+		publicUrlGuard = true,
+		resolver,
+		maxRedirects = 10,
+	} = options;
 
-	for (let attempt = 0; attempt < USER_AGENTS.length; attempt++) {
+	let initialUrl = url;
+	if (publicUrlGuard) {
+		const guarded = await guardPublicFetchUrl(url, resolver, "Blocked URL fetch");
+		if (!guarded.ok) {
+			return {
+				content: "",
+				contentType: "",
+				finalUrl: guarded.finalUrl,
+				ok: false,
+				error: guarded.error,
+			};
+		}
+		initialUrl = guarded.url;
+	}
+
+	attempts: for (let attempt = 0; attempt < USER_AGENTS.length; attempt++) {
 		if (signal?.aborted) {
 			throw new ToolAbortError();
 		}
 
 		const userAgent = USER_AGENTS[attempt];
 		const requestSignal = ptree.combineSignals(signal, timeout * 1000);
+		let currentUrl = initialUrl;
+		let currentMethod = method;
+		let currentBody = body;
 
 		try {
-			const requestInit: RequestInit = {
-				signal: requestSignal,
-				method,
-				headers: {
-					"User-Agent": userAgent,
-					Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-					"Accept-Language": "en-US,en;q=0.5",
-					"Accept-Encoding": "identity", // Cloudflare Markdown-for-Agents returns corrupted bytes when compression is negotiated
-					...headers,
-				},
-				redirect: "follow",
-			};
+			for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount++) {
+				const requestInit: RequestInit = {
+					signal: requestSignal,
+					method: currentMethod,
+					headers: {
+						"User-Agent": userAgent,
+						Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+						"Accept-Language": "en-US,en;q=0.5",
+						"Accept-Encoding": "identity", // Cloudflare Markdown-for-Agents returns corrupted bytes when compression is negotiated
+						...headers,
+					},
+					redirect: "manual",
+				};
 
-			if (body !== undefined) {
-				requestInit.body = body;
-			}
-
-			const response = await fetch(url, requestInit);
-
-			const contentType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() ?? "";
-			const finalUrl = response.url;
-
-			const reader = response.body?.getReader();
-			if (!reader) {
-				return { content: "", contentType, finalUrl, ok: false, status: response.status };
-			}
-
-			const chunks: Uint8Array[] = [];
-			let totalSize = 0;
-
-			while (true) {
-				const { done, value } = await reader.read();
-				if (done) break;
-
-				chunks.push(value);
-				totalSize += value.length;
-
-				if (totalSize > maxBytes) {
-					reader.cancel();
-					break;
+				if (currentBody !== undefined) {
+					requestInit.body = currentBody;
 				}
-			}
 
-			const content = Buffer.concat(chunks).toString("utf-8");
-			if (isBotBlocked(response.status, content) && attempt < USER_AGENTS.length - 1) {
-				continue;
-			}
+				const response = await fetch(currentUrl, requestInit);
+				if (REDIRECT_STATUSES.has(response.status)) {
+					const location = response.headers.get("location");
+					if (!location) {
+						return {
+							content: "",
+							contentType: "",
+							finalUrl: currentUrl,
+							ok: false,
+							status: response.status,
+							error: "Redirect response missing Location header",
+						};
+					}
+					const redirectUrl = new URL(location, currentUrl).toString();
+					if (publicUrlGuard) {
+						const guarded = await guardPublicFetchUrl(redirectUrl, resolver, "Blocked URL redirect");
+						if (!guarded.ok) {
+							return {
+								content: "",
+								contentType: "",
+								finalUrl: guarded.finalUrl,
+								ok: false,
+								status: response.status,
+								error: guarded.error,
+							};
+						}
+						currentUrl = guarded.url;
+					} else {
+						currentUrl = redirectUrl;
+					}
+					if (shouldRewriteRedirectMethod(response.status, currentMethod)) {
+						currentMethod = "GET";
+						currentBody = undefined;
+					}
+					continue;
+				}
 
-			if (!response.ok) {
-				return { content, contentType, finalUrl, ok: false, status: response.status };
-			}
+				const contentType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() ?? "";
+				const finalUrl = response.url || currentUrl;
 
-			return { content, contentType, finalUrl, ok: true, status: response.status };
+				const reader = response.body?.getReader();
+				if (!reader) {
+					return { content: "", contentType, finalUrl, ok: false, status: response.status };
+				}
+
+				const chunks: Uint8Array[] = [];
+				let totalSize = 0;
+
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+
+					chunks.push(value);
+					totalSize += value.length;
+
+					if (totalSize > maxBytes) {
+						reader.cancel();
+						break;
+					}
+				}
+
+				const content = Buffer.concat(chunks).toString("utf-8");
+				if (isBotBlocked(response.status, content) && attempt < USER_AGENTS.length - 1) {
+					continue attempts;
+				}
+
+				if (!response.ok) {
+					return { content, contentType, finalUrl, ok: false, status: response.status };
+				}
+
+				return { content, contentType, finalUrl, ok: true, status: response.status };
+			}
+			return {
+				content: "",
+				contentType: "",
+				finalUrl: currentUrl,
+				ok: false,
+				error: `Too many redirects (${maxRedirects})`,
+			};
 		} catch {
 			if (signal?.aborted) {
 				throw new ToolAbortError();
 			}
 			if (attempt === USER_AGENTS.length - 1) {
-				return { content: "", contentType: "", finalUrl: url, ok: false };
+				return { content: "", contentType: "", finalUrl: currentUrl, ok: false };
 			}
 		}
 	}
 
-	return { content: "", contentType: "", finalUrl: url, ok: false };
+	return { content: "", contentType: "", finalUrl: initialUrl, ok: false };
 }
 
 /** Module-level Turndown instance — built lazily on first use. */

--- a/packages/coding-agent/src/web/scrapers/utils.ts
+++ b/packages/coding-agent/src/web/scrapers/utils.ts
@@ -4,6 +4,8 @@ export { isRecord };
 
 import { ToolAbortError } from "../../tools/tool-errors";
 import { convertBufferWithMarkit } from "../../utils/markit";
+import type { AddressResolver } from "../insane/url-guard";
+import { validatePublicHttpUrl } from "../insane/url-guard";
 import { MAX_BYTES } from "./types";
 
 export function asRecord(value: unknown): Record<string, unknown> | null {
@@ -27,6 +29,14 @@ export interface BinaryFetchSuccess {
 }
 
 export type BinaryFetchResult = BinaryFetchSuccess | { ok: false; error?: string };
+
+export interface FetchBinaryOptions {
+	publicUrlGuard?: boolean;
+	resolver?: AddressResolver;
+	maxRedirects?: number;
+}
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 async function readResponseWithLimit(response: Response, maxBytes: number, signal?: AbortSignal): Promise<Uint8Array> {
 	const reader = response.body?.getReader();
@@ -60,34 +70,75 @@ async function readResponseWithLimit(response: Response, maxBytes: number, signa
 	return new Uint8Array(Buffer.concat(chunks, totalBytes));
 }
 
+async function guardPublicBinaryUrl(
+	rawUrl: string,
+	resolver: AddressResolver | undefined,
+	context: string,
+): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
+	const guard = await validatePublicHttpUrl(rawUrl, { resolver });
+	if (guard.ok) return { ok: true, url: guard.url.toString() };
+	return { ok: false, error: `${context}: target URL is not public HTTP(S): ${guard.reason}` };
+}
+
 /**
  * Fetch binary content from a URL
  */
-export async function fetchBinary(url: string, timeout: number = 20, signal?: AbortSignal): Promise<BinaryFetchResult> {
+export async function fetchBinary(
+	url: string,
+	timeout: number = 20,
+	signal?: AbortSignal,
+	options: FetchBinaryOptions = {},
+): Promise<BinaryFetchResult> {
 	const requestSignal = ptree.combineSignals(signal, timeout * 1000);
+	const { publicUrlGuard = true, resolver, maxRedirects = 10 } = options;
 	try {
-		const response = await fetch(url, {
-			signal: requestSignal,
-			headers: {
-				"User-Agent": "Mozilla/5.0 (compatible; TextBot/1.0)",
-			},
-			redirect: "follow",
-		});
-
-		if (!response.ok) {
-			return { ok: false, error: `HTTP ${response.status}` };
+		let currentUrl = url;
+		if (publicUrlGuard) {
+			const guarded = await guardPublicBinaryUrl(url, resolver, "Blocked binary fetch");
+			if (!guarded.ok) return { ok: false, error: guarded.error };
+			currentUrl = guarded.url;
 		}
 
-		const contentDisposition = response.headers.get("content-disposition") || undefined;
-		const contentLength = response.headers.get("content-length");
-		if (contentLength) {
-			const size = Number.parseInt(contentLength, 10);
-			if (Number.isFinite(size) && size > MAX_BYTES) {
-				return { ok: false, error: `content-length ${size} exceeds ${MAX_BYTES}` };
+		for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount++) {
+			const response = await fetch(currentUrl, {
+				signal: requestSignal,
+				headers: {
+					"User-Agent": "Mozilla/5.0 (compatible; TextBot/1.0)",
+				},
+				redirect: "manual",
+			});
+
+			if (REDIRECT_STATUSES.has(response.status)) {
+				const location = response.headers.get("location");
+				if (!location) return { ok: false, error: "Redirect response missing Location header" };
+				const redirectUrl = new URL(location, currentUrl).toString();
+				if (publicUrlGuard) {
+					const guarded = await guardPublicBinaryUrl(redirectUrl, resolver, "Blocked binary redirect");
+					if (!guarded.ok) return { ok: false, error: guarded.error };
+					currentUrl = guarded.url;
+				} else {
+					currentUrl = redirectUrl;
+				}
+				continue;
 			}
+
+			if (!response.ok) {
+				return { ok: false, error: `HTTP ${response.status}` };
+			}
+
+			const contentDisposition = response.headers.get("content-disposition") || undefined;
+			const contentLength = response.headers.get("content-length");
+			if (contentLength) {
+				const size = Number.parseInt(contentLength, 10);
+				if (Number.isFinite(size) && size > MAX_BYTES) {
+					return { ok: false, error: `content-length ${size} exceeds ${MAX_BYTES}` };
+				}
+			}
+			const buffer = await readResponseWithLimit(response, MAX_BYTES, requestSignal);
+			return { ok: true, buffer, contentDisposition };
 		}
-		const buffer = await readResponseWithLimit(response, MAX_BYTES, requestSignal);
-		return { ok: true, buffer, contentDisposition };
+
+		return { ok: false, error: `Too many redirects (${maxRedirects})` };
 	} catch (err) {
 		if (signal?.aborted) throw new ToolAbortError();
 		if (requestSignal?.aborted) return { ok: false, error: "aborted" };

--- a/packages/coding-agent/test/tools/fetch-insane-fallback.test.ts
+++ b/packages/coding-agent/test/tools/fetch-insane-fallback.test.ts
@@ -145,14 +145,34 @@ describe("renderUrl hard-fail hook (integration via ReadTool)", () => {
 		} as unknown as ToolSession;
 	};
 
-	const mock403 = () =>
-		vi.spyOn(scrapers, "loadPage").mockResolvedValue({
+	const mockPublicReadGuard = () =>
+		vi.spyOn(urlGuard, "validatePublicHttpUrl").mockResolvedValue({
+			ok: true,
+			url: new URL("https://blocked.example/x"),
+			addresses: ["93.184.216.34"],
+		});
+
+	const mock403 = () => {
+		mockPublicReadGuard();
+		return vi.spyOn(scrapers, "loadPage").mockResolvedValue({
 			ok: false,
 			status: 403,
 			contentType: "text/html",
 			finalUrl: "https://blocked.example/x",
 			content: "",
 		});
+	};
+
+	it("blocks private URL reads before loadPage or insane fallback", async () => {
+		const loadPageSpy = vi.spyOn(scrapers, "loadPage");
+		const bridgeSpy = vi.spyOn(bridge, "tryInsaneFetch");
+		const tool = new ReadTool(createSession({ "web.insaneFallback": true }));
+		const result = await tool.execute("r-private", { path: "http://127.0.0.1:8123/admin" });
+		expect(result.details?.method).toBe("failed");
+		expect((result.details?.notes ?? []).some(note => note.startsWith("Blocked URL fetch:"))).toBe(true);
+		expect(loadPageSpy).not.toHaveBeenCalled();
+		expect(bridgeSpy).not.toHaveBeenCalled();
+	});
 
 	it("does not invoke the bridge when the setting is off", async () => {
 		mock403();

--- a/packages/coding-agent/test/web/insane/url-guard.test.ts
+++ b/packages/coding-agent/test/web/insane/url-guard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	type AddressResolver,
 	isPrivateOrSpecialAddress,
+	validatePublicHttpUrl,
 	validatePublicHttpUrlForInsane,
 } from "../../../src/web/insane/url-guard";
 
@@ -17,6 +18,13 @@ function staticResolver(map: Record<string, string[]>): AddressResolver {
 }
 
 describe("validatePublicHttpUrlForInsane", () => {
+	it("delegates to the shared public HTTP(S) URL guard", async () => {
+		const options = { resolver: staticResolver({ "example.com": ["93.184.216.34"] }) };
+		const shared = await validatePublicHttpUrl("https://example.com/path", options);
+		const insane = await validatePublicHttpUrlForInsane("https://example.com/path", options);
+		expect(insane).toEqual(shared);
+	});
+
 	it("accepts a normal https URL that resolves to a public IP", async () => {
 		const result = await validatePublicHttpUrlForInsane("https://example.com/path", {
 			resolver: staticResolver({ "example.com": ["93.184.216.34"] }),

--- a/packages/coding-agent/test/web/scrapers/public-url-guard.test.ts
+++ b/packages/coding-agent/test/web/scrapers/public-url-guard.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AddressResolver } from "../../../src/web/insane/url-guard";
+import { loadPage } from "../../../src/web/scrapers/types";
+import { fetchBinary } from "../../../src/web/scrapers/utils";
+
+function staticResolver(map: Record<string, string[]>): AddressResolver {
+	return async hostname => map[hostname] ?? [];
+}
+
+function throwingResolver(): AddressResolver {
+	return async () => {
+		throw new Error("resolver must not be called");
+	};
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("loadPage public URL guard", () => {
+	it("blocks private IP literals before opening a request", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+		const result = await loadPage("http://127.0.0.1/admin", { resolver: throwingResolver() });
+
+		expect(result.ok).toBe(false);
+		expect(result.error ?? "").toContain("not public HTTP(S)");
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("blocks redirects to private targets before following them", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async input => {
+			expect(String(input)).toBe("https://public.example/start");
+			return new Response(null, {
+				status: 302,
+				headers: { location: "http://127.0.0.1/admin" },
+			});
+		}) as typeof fetch);
+
+		const result = await loadPage("https://public.example/start", {
+			resolver: staticResolver({ "public.example": ["93.184.216.34"] }),
+		});
+
+		expect(result.ok).toBe(false);
+		expect(result.error ?? "").toContain("not public HTTP(S)");
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(fetchSpy.mock.calls[0]?.[1]?.redirect).toBe("manual");
+	});
+
+	it("follows public redirects after re-validating the target", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async input => {
+			const requested = String(input);
+			if (requested === "https://public.example/start") {
+				return new Response(null, { status: 302, headers: { location: "/next" } });
+			}
+			expect(requested).toBe("https://public.example/next");
+			return new Response("hello world", {
+				status: 200,
+				headers: { "content-type": "text/plain" },
+			});
+		}) as typeof fetch);
+
+		const result = await loadPage("https://public.example/start", {
+			resolver: staticResolver({ "public.example": ["93.184.216.34"] }),
+		});
+
+		expect(result.ok).toBe(true);
+		expect(result.finalUrl).toBe("https://public.example/next");
+		expect(result.content).toBe("hello world");
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("fetchBinary public URL guard", () => {
+	it("blocks private IP literals before opening a binary request", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+		const result = await fetchBinary("http://127.0.0.1/secret.pdf", 20, undefined, {
+			resolver: throwingResolver(),
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error ?? "").toContain("not public HTTP(S)");
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("blocks binary redirects to private targets before following them", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async input => {
+			expect(String(input)).toBe("https://public.example/file.pdf");
+			return new Response(null, {
+				status: 302,
+				headers: { location: "http://127.0.0.1/private.pdf" },
+			});
+		}) as typeof fetch);
+
+		const result = await fetchBinary("https://public.example/file.pdf", 20, undefined, {
+			resolver: staticResolver({ "public.example": ["93.184.216.34"] }),
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error ?? "").toContain("not public HTTP(S)");
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(fetchSpy.mock.calls[0]?.[1]?.redirect).toBe("manual");
+	});
+});


### PR DESCRIPTION
## Summary
- Add a shared public HTTP(S) URL guard for coding-agent URL reads.
- Reject local/private/special IPs, local hostnames, URL credentials, and DNS answers that resolve privately before opening requests.
- Revalidate redirect targets for both page and binary fetch paths and keep the insane fallback behind the same guard.

## Security impact
This blocks private-network SSRF through URL fetch/read surfaces before the code opens a connection or follows a redirect.

## Verification
- PATH=/Users/mac/.bun/bin:$PATH bun test packages/coding-agent/test/web/insane/url-guard.test.ts packages/coding-agent/test/web/scrapers/public-url-guard.test.ts packages/coding-agent/test/tools/fetch-insane-fallback.test.ts
- PATH=/Users/mac/.bun/bin:$PATH bun --cwd=packages/coding-agent run check
- Aggregate with the other security fixes: PATH=/Users/mac/.bun/bin:$PATH bun run check:ts
- Aggregate gjc smoke: PATH=/Users/mac/.bun/bin:$PATH bun run ci:test:smoke
- Aggregate workflow/security tests: PATH=/Users/mac/.bun/bin:$PATH bun test packages/coding-agent/test/web/insane/url-guard.test.ts packages/coding-agent/test/web/scrapers/public-url-guard.test.ts packages/coding-agent/test/tools/fetch-insane-fallback.test.ts packages/coding-agent/test/rpc-unattended-stdio.test.ts packages/coding-agent/test/bridge/bridge-live-unattended-regression.test.ts packages/coding-agent/test/bridge/bridge-conformance.test.ts packages/coding-agent/test/bridge/bridge-mode-handler.test.ts packages/coding-agent/test/bridge/agent-wire-scopes.test.ts packages/coding-agent/test/rpc-workflow-gate.test.ts

## Local full-suite note
- PATH=/Users/mac/.bun/bin:$PATH GITHUB_ACTIONS="" bun run test:ts is not green locally, but the remaining failures reproduce on dev-base/origin dev: local llama.cpp 404 context-overflow, extension discovery, and migrate skill-file write tests. The directly affected fetch and gjc workflow checks pass.