### PR TITLE
Reject browser-origin no-auth auth-gateway requests

### DIFF
--- a/packages/ai/src/auth-gateway/http.ts
+++ b/packages/ai/src/auth-gateway/http.ts
@@ -47,7 +47,7 @@ export function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
 const TOKEN_ENCODER = new TextEncoder();
 
 export function isAuthorized(req: Request, tokens: ReadonlySet<string>): boolean {
-	if (tokens.size === 0) return true;
+	if (tokens.size === 0) return !isNoAuthBrowserOriginRequest(req, tokens);
 	const header = req.headers.get("authorization");
 	if (!header) return false;
 	const match = header.match(/^Bearer\s+(.+)$/i);
@@ -61,6 +61,10 @@ export function isAuthorized(req: Request, tokens: ReadonlySet<string>): boolean
 		if (timingSafeEqual(presented, expected)) ok = true;
 	}
 	return ok;
+}
+
+export function isNoAuthBrowserOriginRequest(req: Request, tokens: ReadonlySet<string>): boolean {
+	return tokens.size === 0 && req.headers.has("origin");
 }
 
 /**

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -27,7 +27,15 @@ import * as piNative from "../providers/pi-native-server";
 import { streamSimple } from "../stream";
 import type { Api, AssistantMessageEventStream, Context, Model, SimpleStreamOptions } from "../types";
 import { parseBind } from "../utils/parse-bind";
-import { captureRequestHeaders, corsHeaders, isAuthorized, json, resolvePeer, withCors } from "./http";
+import {
+	captureRequestHeaders,
+	corsHeaders,
+	isAuthorized,
+	isNoAuthBrowserOriginRequest,
+	json,
+	resolvePeer,
+	withCors,
+} from "./http";
 import type {
 	AuthGatewayServerHandle,
 	AuthGatewayServerOptions,
@@ -640,6 +648,15 @@ export function startAuthGateway(opts: AuthGatewayBootOptions): AuthGatewayServe
 			const url = new URL(req.url);
 			const pathname = url.pathname;
 			const peer = resolvePeer(req);
+			if (isNoAuthBrowserOriginRequest(req, tokens)) {
+				logger.info("auth-gateway no-auth browser-origin request rejected", {
+					method: req.method,
+					path: pathname,
+					peer,
+					origin: req.headers.get("origin"),
+				});
+				return json(403, { error: "browser origin requires bearer token" });
+			}
 			// CORS preflight is always answered without auth — browsers send
 			// preflights pre-authentication and a 401 here breaks the actual
 			// request before the bearer is ever attached.

--- a/packages/ai/test/auth-gateway-no-auth-origin.test.ts
+++ b/packages/ai/test/auth-gateway-no-auth-origin.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import { startAuthGateway } from "../src/auth-gateway/server";
+import type { AuthGatewayServerHandle } from "../src/auth-gateway/types";
+import type { AuthStorage } from "../src/auth-storage";
+import type { Api, Model } from "../src/types";
+
+const TEST_MODEL = {
+	id: "test-model",
+	provider: "test-provider",
+	api: "anthropic-messages",
+} as Model<Api>;
+
+async function withGateway(
+	bearerTokens: string[],
+	fn: (handle: AuthGatewayServerHandle) => Promise<void>,
+): Promise<void> {
+	const handle = startAuthGateway({
+		bind: "127.0.0.1:0",
+		bearerTokens,
+		version: "test",
+		storage: {} as AuthStorage,
+		resolveModel: () => TEST_MODEL,
+		listModels: () => [TEST_MODEL],
+	});
+	try {
+		await fn(handle);
+	} finally {
+		await handle.close();
+	}
+}
+
+describe("auth-gateway no-auth browser origin guard", () => {
+	it("preserves no-auth access for non-browser local clients", async () => {
+		await withGateway([], async gateway => {
+			const response = await fetch(`${gateway.url}/v1/models`);
+
+			expect(response.status).toBe(200);
+			const body = (await response.json()) as { data?: Array<{ id: string }> };
+			expect(body.data?.[0]?.id).toBe("test-model");
+		});
+	});
+
+	it("rejects no-auth browser-origin requests before route handling", async () => {
+		await withGateway([], async gateway => {
+			const response = await fetch(`${gateway.url}/v1/models`, {
+				headers: { Origin: "https://attacker.example" },
+			});
+
+			expect(response.status).toBe(403);
+			expect(response.headers.get("access-control-allow-origin")).toBeNull();
+			const body = (await response.json()) as { error?: string };
+			expect(body.error).toContain("bearer token");
+		});
+	});
+
+	it("rejects no-auth browser preflight without wildcard CORS", async () => {
+		await withGateway([], async gateway => {
+			const response = await fetch(`${gateway.url}/v1/models`, {
+				method: "OPTIONS",
+				headers: {
+					Origin: "https://attacker.example",
+					"Access-Control-Request-Method": "GET",
+				},
+			});
+
+			expect(response.status).toBe(403);
+			expect(response.headers.get("access-control-allow-origin")).toBeNull();
+		});
+	});
+
+	it("preserves tokenized browser clients", async () => {
+		await withGateway(["secret-token"], async gateway => {
+			const preflight = await fetch(`${gateway.url}/v1/models`, {
+				method: "OPTIONS",
+				headers: {
+					Origin: "https://client.example",
+					"Access-Control-Request-Method": "GET",
+				},
+			});
+			expect(preflight.status).toBe(204);
+			expect(preflight.headers.get("access-control-allow-origin")).toBe("*");
+
+			const response = await fetch(`${gateway.url}/v1/models`, {
+				headers: {
+					Origin: "https://client.example",
+					Authorization: "Bearer secret-token",
+				},
+			});
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("access-control-allow-origin")).toBe("*");
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Reject browser-origin requests when the auth gateway is running in no-auth mode.
- Reject no-auth browser preflights before route handling and avoid emitting wildcard CORS for that path.
- Preserve local non-browser no-auth clients and tokenized browser clients.

## Security impact
This prevents a no-auth local gateway from being driven by arbitrary browser origins while keeping intended local client behavior intact.

## Latest dev validation
- Rebased onto `origin/dev@ef2806d9a3711a78b6d0c0dd8de9c6020223b5b6` after #1114/#1116 merged upstream.
- GitHub checks on commit `4ad751b6` all passed, including `check:@gajae-code/ai`, `cli-smoke`, `native-build`, the targeted auth-gateway test, and `gjc-state-gates`.
- Local aggregate branch `codex/security-fixes-aggregate-verify-v7` combines latest `dev` plus the remaining open security fixes (#1113 and #1115).

## Verification
- `PATH=/Users/mac/.bun/bin:$PATH bun test packages/ai/test/auth-gateway-no-auth-origin.test.ts`
- `PATH=/Users/mac/.bun/bin:$PATH bun --cwd=packages/ai run check`
- `PATH=/Users/mac/.bun/bin:$PATH bun run check:ts`
- `PATH=/Users/mac/.bun/bin:$PATH bun run ci:test:smoke`
- `PATH=/Users/mac/.bun/bin:$PATH bun test scripts/ci-dev-affected.test.ts packages/coding-agent/test/web/insane/url-guard.test.ts packages/coding-agent/test/web/scrapers/public-url-guard.test.ts packages/coding-agent/test/tools/fetch-insane-fallback.test.ts packages/coding-agent/test/rpc-unattended-stdio.test.ts packages/coding-agent/test/bridge/bridge-live-unattended-regression.test.ts packages/coding-agent/test/bridge/bridge-conformance.test.ts packages/coding-agent/test/bridge/bridge-mode-handler.test.ts packages/coding-agent/test/bridge/agent-wire-scopes.test.ts packages/coding-agent/test/rpc-workflow-gate.test.ts packages/ai/test/auth-gateway-no-auth-origin.test.ts` (`94 passed`)
- `/tmp/gajae-code-ci-py-oldpip/bin/python -m ruff check python && /tmp/gajae-code-ci-py-oldpip/bin/python -m ruff format --check python/robogjc && /tmp/gajae-code-ci-py-oldpip/bin/python -m pytest -q -x --import-mode=importlib python/gjc-rpc/tests python/robogjc/tests` (`506 passed, 9 skipped`)

## Local full-suite note
- Full local `bun run test:ts` was not used as the final completion gate because an earlier run exposed unrelated baseline failures that reproduced on the then-current `dev-base`. The final gate is targeted security coverage plus `check:ts`, GJC smoke, Python full suite, workflow planner checks, and GitHub CI on this PR.
