### PR TITLE
Require bridge controller ownership for workflow gates

### DIFF
--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -140,7 +140,7 @@ re-enable work has a stable baseline.
 
 When internally enabled for compatibility tests, event replay still uses `last_seq` and the bounded replay reset marker `replay_window_exceeded`; command and UI response retries still use `Idempotency-Key`. These mechanisms are dormant for default external bridge clients because the endpoint matrix rejects the endpoints before they reach replay, body parsing, idempotency, scope, or dispatch logic.
 
-Workflow-gate responses are part of the UI-response surface, not the dormant command surface: when internally enabled, an answerer responds to `workflow_gate` frame `wg_...` by posting `{ "gate_id": "wg_...", "answer": ... }` to `POST /v1/sessions/{session_id}/ui-responses/{gate_id}`. Gate answers are authorized by bearer auth plus the `control` scope on this (default-disabled) endpoint; `X-GJC-Bridge-Owner-Token` may be carried by SDK helpers and participates in idempotency/cache correlation, but — unlike UI/permission responses — gate resolution does not separately validate it as the current controller token. `Idempotency-Key` is optional and is also forwarded as `idempotency_key` when supplied by SDK helpers.
+Workflow-gate responses are part of the UI-response surface, not the dormant command surface: when internally enabled, an answerer responds to `workflow_gate` frame `wg_...` by posting `{ "gate_id": "wg_...", "answer": ... }` to `POST /v1/sessions/{session_id}/ui-responses/{gate_id}`. Gate answers are authorized by bearer auth, the `control` scope on this (default-disabled) endpoint, and the currently claimed controller owner token. `X-GJC-Bridge-Owner-Token` must match the claimed controller token; mismatches return `403 not_controller` and do not resolve the gate. `Idempotency-Key` is optional and is also forwarded as `idempotency_key` when supplied by SDK helpers.
 
 ### Scopes
 
@@ -202,7 +202,7 @@ endpoint matrix, the default handshake advertises no accepted scopes.
 | `get_login_providers` | `admin` |
 | `login` | `admin` |
 | `negotiate_unattended` | `control` |
-| `workflow_gate_response` | `prompt` |
+| `workflow_gate_response` | `control` |
 
 ### Dormant capabilities and frame types
 
@@ -242,7 +242,7 @@ unconfigured bridge those helpers should be expected to fail because the server
 endpoint matrix disables the corresponding session endpoints until they are
 explicitly enabled.
 
-`BridgeClient.respondGate(sessionId, gateId, ownerToken, answer, options)` posts to the fail-closed UI-response endpoint and returns the gate resolution envelope emitted by the bridge. It deliberately does not send `workflow_gate_response` through `/commands`. Gate answers are authorized by bearer auth plus the `control` scope on the (by-default-disabled) `ui-responses` endpoint; the owner token is carried for idempotency/controller correlation, but — unlike UI/permission responses — gate resolution itself is gated by `control` scope rather than a separately enforced controller-owner-token check.
+`BridgeClient.respondGate(sessionId, gateId, ownerToken, answer, options)` posts to the fail-closed UI-response endpoint and returns the gate resolution envelope emitted by the bridge. It deliberately does not send `workflow_gate_response` through `/commands`. Gate answers are authorized by bearer auth, the `control` scope on the (by-default-disabled) `ui-responses` endpoint, and the current controller owner token; unauthorized owner-token attempts return `403 not_controller` without resolving the gate.
 
 > Response typing: in this experimental version, `command()` and the typed
 > command helpers return `Promise<unknown>`. Callers narrow the response

--- a/packages/coding-agent/src/modes/bridge/bridge-mode.ts
+++ b/packages/coding-agent/src/modes/bridge/bridge-mode.ts
@@ -153,6 +153,14 @@ function jsonResponse(status: number, body: unknown): Response {
 	});
 }
 
+function isBridgeControllerOwner(options: BridgeFetchHandlerOptions, ownerToken: string): boolean {
+	if (!ownerToken) return false;
+	const ownerTokens = [options.permissionBroker?.ownerToken, options.uiBroker?.ownerToken].filter(
+		(token): token is string => typeof token === "string" && token.length > 0,
+	);
+	return ownerTokens.length > 0 && ownerTokens.every(token => token === ownerToken);
+}
+
 function parseBridgeScopes(value: string | undefined): readonly BridgeCommandScope[] {
 	if (!value?.trim()) return DEFAULT_BRIDGE_SCOPES;
 	const allowed = new Set(BRIDGE_COMMAND_SCOPES);
@@ -425,6 +433,9 @@ export function createBridgeFetchHandler(options: BridgeFetchHandlerOptions): (r
 				"answer" in payload &&
 				(correlationId === (payload as RpcWorkflowGateResponse).gate_id || correlationId.startsWith("wg_"))
 			) {
+				if (!isBridgeControllerOwner(options, ownerToken)) {
+					return jsonResponse(403, { status: "rejected", code: "not_controller" });
+				}
 				try {
 					const resolution = await options.unattendedControlPlane?.resolveGate({
 						gate_id: (payload as RpcWorkflowGateResponse).gate_id,

--- a/packages/coding-agent/src/modes/shared/agent-wire/scopes.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/scopes.ts
@@ -73,7 +73,7 @@ const RPC_COMMAND_SCOPE_REGISTRY: Record<RpcCommandType, BridgeCommandScope> = {
 	get_login_providers: "admin",
 	login: "admin",
 	negotiate_unattended: "control",
-	workflow_gate_response: "prompt",
+	workflow_gate_response: "control",
 };
 
 export const RPC_COMMAND_TYPES: readonly RpcCommandType[] = Object.keys(RPC_COMMAND_SCOPE_REGISTRY) as RpcCommandType[];

--- a/packages/coding-agent/test/bridge/agent-wire-scopes.test.ts
+++ b/packages/coding-agent/test/bridge/agent-wire-scopes.test.ts
@@ -81,6 +81,7 @@ describe("agent-wire RPC command scopes", () => {
 			"handoff",
 			"set_host_tools",
 			"set_host_uri_schemes",
+			"workflow_gate_response",
 		];
 		for (const type of sensitive) {
 			expect(isRpcCommandAllowed(type, floor)).toBe(false);
@@ -94,6 +95,7 @@ describe("agent-wire RPC command scopes", () => {
 		expect(scopeForRpcCommand("set_model")).toBe("model");
 		expect(scopeForRpcCommand("get_messages")).toBe("message:read");
 		expect(scopeForRpcCommand("set_todos")).toBe("control");
+		expect(scopeForRpcCommand("workflow_gate_response")).toBe("control");
 		expect(scopeForRpcCommand("set_host_tools")).toBe("host_tools");
 		expect(scopeForRpcCommand("set_host_uri_schemes")).toBe("host_uri");
 		expect(scopeForRpcCommand("handoff")).toBe("admin");

--- a/packages/coding-agent/test/bridge/bridge-live-unattended-regression.test.ts
+++ b/packages/coding-agent/test/bridge/bridge-live-unattended-regression.test.ts
@@ -5,6 +5,7 @@ import type {
 	BridgeHandshakeAccepted,
 	BridgeHandshakeRequest,
 } from "@gajae-code/coding-agent/modes/shared/agent-wire/handshake";
+import { UiRequestBroker } from "@gajae-code/coding-agent/modes/shared/agent-wire/ui-request-broker";
 import { UnattendedSessionControlPlane } from "@gajae-code/coding-agent/modes/shared/agent-wire/unattended-session";
 
 const declaration = {
@@ -23,11 +24,11 @@ function request(unattended = declaration): BridgeHandshakeRequest {
 	};
 }
 
-function authRequest(path: string, body: unknown) {
+function authRequest(path: string, body?: unknown, headers: Record<string, string> = {}) {
 	return new Request(`https://bridge.test${path}`, {
 		method: "POST",
-		headers: { Authorization: "Bearer secret", "Content-Type": "application/json" },
-		body: JSON.stringify(body),
+		headers: { Authorization: "Bearer secret", "Content-Type": "application/json", ...headers },
+		body: body === undefined ? undefined : JSON.stringify(body),
 	});
 }
 
@@ -54,26 +55,37 @@ describe("live bridge unattended workflow gate wiring", () => {
 			emitFrame: () => undefined,
 			providerSupportsTokenCostMetrics: true,
 		});
+		const permissionBroker = new UiRequestBroker<unknown, unknown>({ emitRequest: () => undefined });
 		const handle = createBridgeFetchHandler({
 			sessionId: "sess-b",
 			token: "secret",
-			endpointMatrix: { events: true, commands: true, uiResponses: true },
+			endpointMatrix: { events: true, commands: true, control: true, uiResponses: true },
 			commandScopes: ["prompt", "control"],
 			unattendedControlPlane: cp,
+			permissionBroker: permissionBroker as never,
 			idempotencyCache: new Map(),
 		});
 		const hs = await handle(authRequest("/v1/handshake", request()));
 		const accepted = (await hs.json()) as BridgeHandshakeAccepted;
 		expect(accepted.accepted_unattended).toEqual(declaration);
 		expect(accepted.unattended_active).toBe(true);
+		const ownerToken = "owner-bridge-test";
+		const claim = await handle(
+			authRequest("/v1/sessions/sess-b/control:claim", undefined, { "X-GJC-Bridge-Owner-Token": ownerToken }),
+		);
+		expect(claim.status).toBe(200);
 
 		const answerPromise = cp.emitGate(approvalGate({ summary: "bridge ship?" }));
 		const gateId = "wg_runb_ralplan_000001";
 		const response = await handle(
-			authRequest(`/v1/sessions/sess-b/ui-responses/${gateId}`, {
-				gate_id: gateId,
-				answer: { decision: "approve" },
-			}),
+			authRequest(
+				`/v1/sessions/sess-b/ui-responses/${gateId}`,
+				{
+					gate_id: gateId,
+					answer: { decision: "approve" },
+				},
+				{ "X-GJC-Bridge-Owner-Token": ownerToken },
+			),
 		);
 		expect(response.status).toBe(200);
 		expect(await response.json()).toMatchObject({ gate_id: gateId, status: "accepted" });

--- a/packages/coding-agent/test/bridge/bridge-mode-handler.test.ts
+++ b/packages/coding-agent/test/bridge/bridge-mode-handler.test.ts
@@ -1,12 +1,14 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import type { BridgePermissionRequestPayload } from "../../src/modes/bridge/bridge-client-bridge";
 import { createBridgeFetchHandler } from "../../src/modes/bridge/bridge-mode";
 import { BridgeEventStream } from "../../src/modes/bridge/event-stream";
 import { RpcHostToolBridge } from "../../src/modes/rpc/host-tools";
 import { RpcHostUriBridge } from "../../src/modes/rpc/host-uris";
+import type { RpcWorkflowGateResponse } from "../../src/modes/rpc/rpc-types";
 import { BRIDGE_PROTOCOL_VERSION } from "../../src/modes/shared/agent-wire/protocol";
 import { rpcSuccess } from "../../src/modes/shared/agent-wire/responses";
 import { UiRequestBroker } from "../../src/modes/shared/agent-wire/ui-request-broker";
+import type { UnattendedSessionControlPlane } from "../../src/modes/shared/agent-wire/unattended-session";
 import type { ClientBridgePermissionOutcome } from "../../src/session/client-bridge";
 
 type HandshakeJson = {
@@ -421,6 +423,102 @@ describe("bridge mode fetch handler", () => {
 		expect(disconnect.status).toBe(200);
 		expect(await pendingDisconnect).toEqual({ status: "cancelled", reason: "disconnect" });
 	});
+
+	it("requires claimed controller ownership before resolving workflow gate UI responses", async () => {
+		const permissionBroker = new UiRequestBroker<BridgePermissionRequestPayload, ClientBridgePermissionOutcome>({
+			emitRequest: () => {},
+		});
+		const gateResolution = {
+			gate_id: "gate-1",
+			status: "accepted" as const,
+			answer_hash: "answer-hash",
+			resolved_at: "2026-06-25T00:00:00.000Z",
+		};
+		const resolveGateCalls: RpcWorkflowGateResponse[] = [];
+		const resolveGate = mock(async (response: RpcWorkflowGateResponse) => {
+			resolveGateCalls.push(response);
+			return gateResolution;
+		});
+		const handle = createBridgeFetchHandler({
+			sessionId: "sess-1",
+			token: "secret",
+			permissionBroker,
+			commandScopes: ["prompt", "control"],
+			endpointMatrix: { control: true, uiResponses: true },
+			idempotencyCache: new Map(),
+			unattendedControlPlane: { resolveGate } as unknown as UnattendedSessionControlPlane,
+		});
+		const claim = await handle(
+			new Request("https://bridge.test/v1/sessions/sess-1/control:claim", {
+				method: "POST",
+				headers: { Authorization: "Bearer secret", "X-GJC-Bridge-Owner-Token": "owner-1" },
+			}),
+		);
+		expect(claim.status).toBe(200);
+
+		const body = JSON.stringify({ gate_id: "gate-1", answer: { decision: "approve" } });
+		const wrongOwner = await handle(
+			new Request("https://bridge.test/v1/sessions/sess-1/ui-responses/wg_gate-1", {
+				method: "POST",
+				headers: { Authorization: "Bearer secret", "X-GJC-Bridge-Owner-Token": "wrong" },
+				body,
+			}),
+		);
+		expect(wrongOwner.status).toBe(403);
+		expect(await wrongOwner.json()).toEqual({ status: "rejected", code: "not_controller" });
+		expect(resolveGate.mock.calls.length).toBe(0);
+
+		const response = await handle(
+			new Request("https://bridge.test/v1/sessions/sess-1/ui-responses/wg_gate-1", {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer secret",
+					"X-GJC-Bridge-Owner-Token": "owner-1",
+					"Idempotency-Key": "gate-idem-1",
+				},
+				body,
+			}),
+		);
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual(gateResolution);
+		expect(resolveGate.mock.calls.length).toBe(1);
+		expect(resolveGateCalls[0]).toEqual({
+			gate_id: "gate-1",
+			answer: { decision: "approve" },
+			idempotency_key: "gate-idem-1",
+		});
+
+		const retry = await handle(
+			new Request("https://bridge.test/v1/sessions/sess-1/ui-responses/wg_gate-1", {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer secret",
+					"X-GJC-Bridge-Owner-Token": "owner-1",
+					"Idempotency-Key": "gate-idem-1",
+				},
+				body,
+			}),
+		);
+		expect(retry.status).toBe(200);
+		expect(await retry.json()).toEqual(gateResolution);
+		expect(resolveGate.mock.calls.length).toBe(1);
+
+		const replayWrongOwner = await handle(
+			new Request("https://bridge.test/v1/sessions/sess-1/ui-responses/wg_gate-1", {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer secret",
+					"X-GJC-Bridge-Owner-Token": "attacker",
+					"Idempotency-Key": "gate-idem-1",
+				},
+				body,
+			}),
+		);
+		expect(replayWrongOwner.status).toBe(403);
+		expect(await replayWrongOwner.json()).toEqual({ status: "rejected", code: "not_controller" });
+		expect(resolveGate.mock.calls.length).toBe(1);
+	});
+
 	it("accepts host tool and URI callback results", async () => {
 		const toolRequests: Array<{ id: string }> = [];
 		const uriRequests: Array<{ id: string }> = [];

--- a/packages/coding-agent/test/rpc-unattended-stdio.test.ts
+++ b/packages/coding-agent/test/rpc-unattended-stdio.test.ts
@@ -100,7 +100,7 @@ const validDeclaration = {
 	actor: "openclaw/hermes",
 	budget: { max_tokens: 100000, max_tool_calls: 50, max_wall_time_ms: 600000, max_cost_usd: 10 },
 	scopes: ["prompt", "control", "bash"],
-	action_allowlist: ["command.prompt", "bash.readonly"],
+	action_allowlist: ["command.prompt", "command.control", "bash.readonly"],
 };
 
 describe("gjc --mode rpc unattended control plane (stdio transport)", () => {

--- a/packages/coding-agent/test/rpc-workflow-gate.test.ts
+++ b/packages/coding-agent/test/rpc-workflow-gate.test.ts
@@ -13,7 +13,7 @@ describe("RPC workflow_gate contract", () => {
 		expect(isRpcCommandType("negotiate_unattended")).toBe(true);
 		expect(isRpcCommandType("workflow_gate_response")).toBe(true);
 		expect(scopeForRpcCommand("negotiate_unattended")).toBe("control");
-		expect(scopeForRpcCommand("workflow_gate_response")).toBe("prompt");
+		expect(scopeForRpcCommand("workflow_gate_response")).toBe("control");
 	});
 
 	it("validates negotiate_unattended declarations (fail-closed shape)", () => {


### PR DESCRIPTION
## Summary
- Require the current claimed bridge controller owner token before resolving workflow gate UI responses.
- Move workflow_gate_response from prompt to control scope so prompt-only clients cannot answer lifecycle gates.
- Update bridge docs and live stdio/bridge regressions for the control-scope owner-token flow.

## Security impact
This prevents a bearer-authenticated but non-controller bridge client from answering workflow gates and mutating unattended workflow progress.

## Verification
- PATH=/Users/mac/.bun/bin:$PATH bun test packages/coding-agent/test/rpc-unattended-stdio.test.ts packages/coding-agent/test/bridge/bridge-live-unattended-regression.test.ts packages/coding-agent/test/bridge/bridge-conformance.test.ts packages/coding-agent/test/bridge/bridge-mode-handler.test.ts packages/coding-agent/test/bridge/agent-wire-scopes.test.ts packages/coding-agent/test/rpc-workflow-gate.test.ts
- PATH=/Users/mac/.bun/bin:$PATH bun --cwd=packages/coding-agent run check
- Aggregate with the other security fixes: PATH=/Users/mac/.bun/bin:$PATH bun run check:ts
- Aggregate gjc smoke: PATH=/Users/mac/.bun/bin:$PATH bun run ci:test:smoke
- Aggregate workflow/security tests: PATH=/Users/mac/.bun/bin:$PATH bun test packages/coding-agent/test/web/insane/url-guard.test.ts packages/coding-agent/test/web/scrapers/public-url-guard.test.ts packages/coding-agent/test/tools/fetch-insane-fallback.test.ts packages/coding-agent/test/rpc-unattended-stdio.test.ts packages/coding-agent/test/bridge/bridge-live-unattended-regression.test.ts packages/coding-agent/test/bridge/bridge-conformance.test.ts packages/coding-agent/test/bridge/bridge-mode-handler.test.ts packages/coding-agent/test/bridge/agent-wire-scopes.test.ts packages/coding-agent/test/rpc-workflow-gate.test.ts

## Local full-suite note
- PATH=/Users/mac/.bun/bin:$PATH GITHUB_ACTIONS="" bun run test:ts is not green locally, but the remaining failures reproduce on dev-base/origin dev: local llama.cpp 404 context-overflow, extension discovery, and migrate skill-file write tests. The directly affected bridge/rpc workflow checks pass.