### PR TITLE
Fix model profile default badge precedence

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -221,6 +221,8 @@ export class ModelSelectorComponent extends Container {
 	#scopedModels: ReadonlyArray<ScopedModelItem>;
 	#temporaryOnly: boolean;
 	#currentModel?: Model;
+	#currentThinkingLevel?: ThinkingLevel;
+	#activeModelProfile?: string;
 	#isFastForProvider: (provider?: string) => boolean = () => false;
 	#isFastForSubagentProvider: (provider?: string) => boolean = () => false;
 	#pendingActionItem?: ModelItem | CanonicalModelItem;
@@ -258,6 +260,8 @@ export class ModelSelectorComponent extends Container {
 			sessionId?: string;
 			isFastForProvider?: (provider?: string) => boolean;
 			isFastForSubagentProvider?: (provider?: string) => boolean;
+			currentThinkingLevel?: ThinkingLevel;
+			activeModelProfile?: string;
 		},
 	) {
 		super();
@@ -271,6 +275,8 @@ export class ModelSelectorComponent extends Container {
 		this.#temporaryOnly = options?.temporaryOnly ?? false;
 		this.#authSessionId = options?.sessionId;
 		this.#currentModel = _currentModel;
+		this.#currentThinkingLevel = options?.currentThinkingLevel;
+		this.#activeModelProfile = options?.activeModelProfile;
 		this.#isFastForProvider = options?.isFastForProvider ?? (() => false);
 		this.#isFastForSubagentProvider = options?.isFastForSubagentProvider ?? (() => false);
 		const initialSearchInput = options?.initialSearchInput;
@@ -366,6 +372,12 @@ export class ModelSelectorComponent extends Container {
 							: ThinkingLevel.Inherit,
 				};
 			}
+		}
+		if (this.#activeModelProfile && this.#currentModel) {
+			this.#roles.default = {
+				model: this.#currentModel,
+				thinkingLevel: this.#currentThinkingLevel ?? ThinkingLevel.Inherit,
+			};
 		}
 	}
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -745,6 +745,9 @@ export class SelectorController {
 				{
 					...options,
 					sessionId: this.ctx.session.sessionId,
+					currentThinkingLevel: this.ctx.session.thinkingLevel,
+					activeModelProfile:
+						this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
 					isFastForProvider: provider => this.ctx.session.isFastForProvider(provider),
 					isFastForSubagentProvider: provider => this.ctx.session.isFastForSubagentProvider(provider),
 				},

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -66,13 +66,20 @@ function createRegistry(options: { missingCredentials?: boolean } = {}) {
 
 function createSelector(
 	onSelect: (selection: ModelSelectorSelection) => void,
-	options: { temporaryOnly?: boolean } = {},
+	options: {
+		temporaryOnly?: boolean;
+		initialSearchInput?: string;
+		settings?: Settings;
+		currentModel?: Model;
+		currentThinkingLevel?: ThinkingLevel;
+		activeModelProfile?: string;
+	} = {},
 ) {
 	const ui = { requestRender: vi.fn() } as unknown as TUI;
 	return new ModelSelectorComponent(
 		ui,
-		undefined,
-		Settings.isolated(),
+		options.currentModel,
+		options.settings ?? Settings.isolated(),
 		createRegistry() as never,
 		[],
 		onSelect,
@@ -207,6 +214,41 @@ describe("model selector profiles", () => {
 		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(rendered).not.toContain("Profiles");
 		expect(rendered).not.toContain("profile-a");
+	});
+
+	test("active profile makes DEFAULT badge follow runtime model instead of stored default", async () => {
+		installTestTheme();
+		const settings = Settings.isolated({ modelRoles: { default: "provider-a/alternate" } });
+		const selector = createSelector(() => {}, {
+			settings,
+			currentModel: defaultModel,
+			currentThinkingLevel: ThinkingLevel.High,
+			activeModelProfile: "profile-a",
+			initialSearchInput: "provider-a",
+		});
+		await Bun.sleep(10);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("provider-a/default DEFAULT (high)");
+		expect(rendered).not.toContain("provider-a/alternate DEFAULT");
+	});
+
+	test("without active profile DEFAULT badge follows persisted default model", async () => {
+		installTestTheme();
+		const settings = Settings.isolated({ modelRoles: { default: "provider-a/alternate" } });
+		const selector = createSelector(() => {}, {
+			settings,
+			currentModel: defaultModel,
+			currentThinkingLevel: ThinkingLevel.High,
+			initialSearchInput: "provider-a",
+		});
+		await Bun.sleep(10);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("provider-a/alternate DEFAULT (inherit)");
+		expect(rendered).not.toContain("provider-a/default DEFAULT");
 	});
 
 	test("Apply for this session activates profile through setModelTemporary", async () => {


### PR DESCRIPTION
## Summary
- Keep model profile/preset runtime precedence as the maintainer-owned contract for issue #1112.
- Make the model selector DEFAULT badge follow the current profile-controlled runtime model while a profile is active.
- Preserve persisted modelRoles.default badge behavior when no profile is active.

Fixes #1112

## Verification
- `bun test packages/coding-agent/test/model-selector-profiles.test.ts packages/coding-agent/test/model-profile-activation.test.ts packages/coding-agent/test/agent-session-profile-resume-default.test.ts`
- `bun run check:ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*