### PR TITLE
fix(notifications): prevent duplicate Telegram topics for transient sessions

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -105,6 +105,7 @@ const TYPING_REFRESH_INTERVAL_MS = 4_000;
 // Native reactions used as a two-stage delivery double-check on inbound thread
 // messages: queued on receipt, consumed once a turn picks the message up.
 const QUEUED_REACTION = "👀";
+const PENDING_TOPIC_FRAME_LIMIT = 20;
 const CONSUMED_REACTION = "✅";
 
 /**
@@ -724,6 +725,11 @@ interface SessionSocket {
 	pingTimer: ReturnType<typeof setInterval> | undefined;
 }
 
+interface PendingThreadedFrame {
+	send: ThreadedSend;
+	msg: Record<string, unknown>;
+}
+
 export class TelegramNotificationDaemon {
 	readonly aliasTable: AliasTable;
 	readonly messageRoutes = new Map<string | number, CallbackRoute | Omit<CallbackRoute, "answer">>();
@@ -739,6 +745,10 @@ export class TelegramNotificationDaemon {
 	private readonly pool: RateLimitPool<{ send: ThreadedSend; topicId?: string }>;
 	private readonly poller: TelegramUpdatePoller;
 	private readonly dispatchState = new TelegramEventDispatchState();
+	/** Identity-bearing sessions by repo/branch surface, used to avoid transient duplicate topics. */
+	private readonly topicOwnerByIdentity = new Map<string, string>();
+	/** Non-identity frames held until identity creates the correct thread. */
+	private readonly pendingThreadedFrames = new Map<string, PendingThreadedFrame[]>();
 	/** True once the daemon has nudged the user to enable Threaded Mode. */
 	private threadedFallbackNoticeSent = false;
 	/** Sessions whose identity header was already sent flat (Threaded Mode off). */
@@ -989,6 +999,60 @@ export class TelegramNotificationDaemon {
 		if (base) return title ? `${base} - ${title}` : base;
 		if (title) return title;
 		return `GJC ${sessionId.slice(-6)}`;
+	}
+
+	private topicIdentityKey(msg: { repo?: unknown; branch?: unknown }): string | undefined {
+		const repo = typeof msg?.repo === "string" && msg.repo.trim() ? msg.repo.trim() : undefined;
+		if (!repo) return undefined;
+		const branch = typeof msg?.branch === "string" && msg.branch.trim() ? msg.branch.trim() : "";
+		return `${repo}\0${branch}`;
+	}
+
+	private topicIdentityBase(msg: { repo?: unknown; branch?: unknown }): string | undefined {
+		const repo = typeof msg?.repo === "string" && msg.repo.trim() ? msg.repo.trim() : undefined;
+		if (!repo) return undefined;
+		const branch = typeof msg?.branch === "string" && msg.branch.trim() ? msg.branch.trim() : undefined;
+		return branch ? `${repo}/${branch}` : repo;
+	}
+
+	private topicOwnerForIdentity(msg: { repo?: unknown; branch?: unknown }): string | undefined {
+		const identityKey = this.topicIdentityKey(msg);
+		const remembered = identityKey ? this.topicOwnerByIdentity.get(identityKey) : undefined;
+		if (remembered && this.topics.get(remembered)) return remembered;
+		const base = this.topicIdentityBase(msg);
+		if (!identityKey || !base) return undefined;
+		for (const sessionId of this.topics.sessionIds()) {
+			const name = this.topics.get(sessionId)?.name;
+			if (name === base || name?.startsWith(`${base} - `)) {
+				this.topicOwnerByIdentity.set(identityKey, sessionId);
+				return sessionId;
+			}
+		}
+		return undefined;
+	}
+
+	private async submitThreadedFrame(sessionId: string, send: ThreadedSend, topicId: string): Promise<void> {
+		this.pool.submit({
+			sessionId,
+			lane: send.lane,
+			coalesceKey: send.coalesceKey,
+			payload: { send, topicId },
+		});
+		await this.flushPool();
+	}
+
+	private rememberPendingThreadedFrame(sessionId: string, send: ThreadedSend, msg: Record<string, unknown>): void {
+		const frames = this.pendingThreadedFrames.get(sessionId) ?? [];
+		frames.push({ send, msg });
+		if (frames.length > PENDING_TOPIC_FRAME_LIMIT) frames.shift();
+		this.pendingThreadedFrames.set(sessionId, frames);
+	}
+
+	private async flushPendingThreadedFrames(sessionId: string, topicId: string): Promise<void> {
+		const frames = this.pendingThreadedFrames.get(sessionId);
+		if (!frames || frames.length === 0) return;
+		this.pendingThreadedFrames.delete(sessionId);
+		for (const frame of frames) await this.submitThreadedFrame(sessionId, frame.send, topicId);
 	}
 
 	/**
@@ -1304,12 +1368,28 @@ export class TelegramNotificationDaemon {
 		if (typeof msg?.type === "string" && TelegramNotificationDaemon.THREADED_FRAMES.has(msg.type)) {
 			const send = renderThreadedFrame(msg);
 			if (!send) return;
-			const topicId = await this.ensureTopic(session.sessionId, this.topicNameFor(session.sessionId, msg));
+			const existingTopic = this.topics.get(session.sessionId)?.topicId;
+			if (!send.identity && !existingTopic && !this.flatIdentitySent.has(session.sessionId)) {
+				this.rememberPendingThreadedFrame(session.sessionId, send, msg as Record<string, unknown>);
+				return;
+			}
+			if (send.identity) {
+				const ownerId = this.topicOwnerForIdentity(msg);
+				const ownerTopic = ownerId ? this.topics.get(ownerId) : undefined;
+				if (ownerId && ownerId !== session.sessionId && ownerTopic) {
+					await this.flushPendingThreadedFrames(session.sessionId, ownerTopic.topicId);
+					return;
+				}
+			}
+			const topicId =
+				existingTopic ?? (await this.ensureTopic(session.sessionId, this.topicNameFor(session.sessionId, msg)));
 			if (!topicId) {
 				await this.deliverFlatFallback(session.sessionId, send);
 				return;
 			}
 			if (send.identity) {
+				const identityKey = this.topicIdentityKey(msg);
+				if (identityKey) this.topicOwnerByIdentity.set(identityKey, session.sessionId);
 				// Rename the topic if the title changed (e.g. the session title was
 				// auto-generated after the topic was first created). This runs on
 				// every identity frame, but does NOT re-send the bulleted message.
@@ -1327,25 +1407,14 @@ export class TelegramNotificationDaemon {
 				}
 				// Send the full bulleted identity header EXACTLY ONCE per topic.
 				if (this.topics.needsIdentity(session.sessionId)) {
-					this.pool.submit({
-						sessionId: session.sessionId,
-						lane: send.lane,
-						coalesceKey: send.coalesceKey,
-						payload: { send, topicId },
-					});
-					await this.flushPool();
+					await this.submitThreadedFrame(session.sessionId, send, topicId);
 					this.topics.markIdentitySent(session.sessionId);
 				}
+				await this.flushPendingThreadedFrames(session.sessionId, topicId);
 				await this.persistTopics();
 				return;
 			}
-			this.pool.submit({
-				sessionId: session.sessionId,
-				lane: send.lane,
-				coalesceKey: send.coalesceKey,
-				payload: { send, topicId },
-			});
-			await this.flushPool();
+			await this.submitThreadedFrame(session.sessionId, send, topicId);
 			return;
 		}
 		if (msg.type === "action_needed" && msg.id) {

--- a/packages/coding-agent/src/notifications/topic-registry.ts
+++ b/packages/coding-agent/src/notifications/topic-registry.ts
@@ -65,6 +65,11 @@ export class TopicRegistry {
 		return this.byTopic.get(topicId);
 	}
 
+	/** All session ids with a persisted topic record. */
+	sessionIds(): string[] {
+		return [...this.topics.keys()];
+	}
+
 	/** The existing topic record for a session, if any. */
 	get(sessionId: string): TopicRecord | undefined {
 		return this.topics.get(sessionId);

--- a/packages/coding-agent/test/notifications-html-format.test.ts
+++ b/packages/coding-agent/test/notifications-html-format.test.ts
@@ -218,6 +218,12 @@ describe("daemon send sites force parse_mode HTML (AC1)", () => {
 		const bot = new CapturingBotApi();
 		const daemon = makeDaemon(bot, agentDir);
 		await daemon.handleSessionMessage(fakeSession() as any, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		await daemon.handleSessionMessage(fakeSession() as any, {
 			type: "turn_stream",
 			sessionId: "S",
 			phase: "finalized",
@@ -230,6 +236,12 @@ describe("daemon send sites force parse_mode HTML (AC1)", () => {
 	test("image_attachment sendPhoto sets parse_mode", async () => {
 		const bot = new CapturingBotApi();
 		const daemon = makeDaemon(bot, Bun.env.TMPDIR ?? "/tmp");
+		await daemon.handleSessionMessage(fakeSession() as any, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
 		await daemon.handleSessionMessage(fakeSession() as any, {
 			type: "image_attachment",
 			sessionId: "S",
@@ -245,13 +257,19 @@ describe("daemon send sites force parse_mode HTML (AC1)", () => {
 		const bot = new CapturingBotApi();
 		const daemon = makeDaemon(bot, Bun.env.TMPDIR ?? "/tmp");
 		await daemon.handleSessionMessage(fakeSession() as any, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		await daemon.handleSessionMessage(fakeSession() as any, {
 			type: "action_needed",
 			kind: "ask",
 			id: "act-1",
 			question: "Pick",
 			options: ["Yes", "No"],
 		});
-		const send = bot.calls.find(c => c.method === "sendMessage");
+		const send = bot.calls.find(c => c.method === "sendMessage" && c.body.reply_markup);
 		expect(send?.body.parse_mode).toBe(TELEGRAM_PARSE_MODE);
 		const keyboard = send?.body.reply_markup?.inline_keyboard as Array<
 			Array<{ text: string; callback_data: string }>

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -884,7 +884,7 @@ test("ensureTelegramDaemonRunning spawns the daemon subcommand with owner-id and
 	expect(ai).toBeGreaterThanOrEqual(0);
 	expect(captured!.args[ai + 1]).toBe(agentDir);
 });
-test("image_attachment frame uploads via sendPhoto into the session topic", async () => {
+test("image_attachment frame uploads via sendPhoto into an identified session topic", async () => {
 	const agentDir = tempAgentDir();
 	const bot = new FakeBotApi();
 	const daemon = new TelegramNotificationDaemon({
@@ -901,6 +901,12 @@ test("image_attachment frame uploads via sendPhoto into the session topic", asyn
 		pending: new Map(),
 	};
 	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+	});
+	await daemon.handleSessionMessage(session as any, {
 		type: "image_attachment",
 		sessionId: "S",
 		source: "computer",
@@ -910,9 +916,76 @@ test("image_attachment frame uploads via sendPhoto into the session topic", asyn
 	const createTopic = bot.calls.find(c => c.method === "createForumTopic");
 	const photo = bot.calls.find(c => c.method === "sendPhoto");
 	expect(createTopic).toBeTruthy();
+	expect(createTopic!.body.name).toBe("gajae-code/dev");
 	expect(photo).toBeTruthy();
 	expect(photo!.body.photo).toBe("AAAA");
 	expect(Number(photo!.body.message_thread_id)).toBeGreaterThan(0);
+});
+
+test("identity-less threaded frames wait for identity instead of creating fallback topics", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "image_attachment",
+		sessionId: "S",
+		source: "computer",
+		mime: "image/png",
+		data: "AAAA",
+	});
+	expect(bot.calls.find(c => c.method === "createForumTopic")).toBeUndefined();
+	expect(bot.calls.find(c => c.method === "sendPhoto")).toBeUndefined();
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+	});
+	const createTopic = bot.calls.find(c => c.method === "createForumTopic");
+	const photo = bot.calls.find(c => c.method === "sendPhoto");
+	expect(createTopic).toBeTruthy();
+	expect(createTopic!.body.name).toBe("gajae-code/dev");
+	expect(photo).toBeTruthy();
+	expect(photo!.body.message_thread_id).toBeGreaterThan(0);
+});
+
+test("transient identity for an existing repo branch does not create a duplicate topic", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const live = { sessionId: "LIVE", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	const transient = { sessionId: "DEAD", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+	await daemon.handleSessionMessage(live as any, {
+		type: "identity_header",
+		sessionId: "LIVE",
+		repo: "gajae-code",
+		branch: "dev",
+	});
+	await daemon.handleSessionMessage(transient as any, {
+		type: "identity_header",
+		sessionId: "DEAD",
+		repo: "gajae-code",
+		branch: "dev",
+	});
+
+	expect(bot.calls.filter(c => c.method === "createForumTopic")).toHaveLength(1);
+	expect(bot.calls.filter(c => c.method === "sendMessage")).toHaveLength(1);
 });
 
 test("threaded mode off: frames fall back to the flat paired chat with a one-time notice", async () => {
@@ -1021,6 +1094,10 @@ test("threaded mode off: image_attachment uploads flat without message_thread_id
 		chatId: "42",
 		botApi: bot,
 	});
+	await daemon.handleSessionMessage(
+		{ sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() } as any,
+		{ type: "identity_header", sessionId: "S", repo: "r", branch: "b" },
+	);
 	await daemon.handleSessionMessage(
 		{ sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() } as any,
 		{ type: "image_attachment", sessionId: "S", source: "computer", mime: "image/png", data: "AAAA" },


### PR DESCRIPTION
Fixes #1119.

## Summary
- Gate Telegram threaded topic creation so identity-less frames buffer instead of creating fallback `GJC <last6>` topics.
- Reuse the existing live repo/branch topic when a duplicate transient identity frame appears for the same surface.
- Preserve live session routing and flat fallback behavior with focused regression coverage.

## Verification
- `bun --cwd=packages/natives run build`
- `bun --cwd=packages/coding-agent run test test/notifications-telegram-daemon.test.ts test/notifications-html-format.test.ts test/notifications-topic-registry.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/notifications/telegram-daemon.ts packages/coding-agent/src/notifications/topic-registry.ts packages/coding-agent/test/notifications-html-format.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
