### PR TITLE
Fix initial forge viewport layout

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- Expanded the initial GJC forge welcome box to the live terminal viewport width and pinned the status/composer area to the bottom when the startup layout is shorter than the screen (#1120).
+
 - Deep Interview Restate/option gates now recover through the ask selector path instead of waiting on plaintext `Options:` output.
 
 ## [0.7.2] - 2026-06-24

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -74,9 +74,8 @@ export class WelcomeComponent implements Component {
 	}
 
 	render(termWidth: number): string[] {
-		// Box dimensions - responsive with a wider cap for modern launch surfaces while preserving small-terminal support
-		const maxWidth = 132;
-		const boxWidth = Math.min(maxWidth, Math.max(0, termWidth - 2));
+		// Box dimensions track the live viewport so wide terminals feel intentionally full-screen.
+		const boxWidth = Math.max(0, termWidth - 2);
 		if (boxWidth < 4) {
 			return [];
 		}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -568,6 +568,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.addChild(this.hookWidgetContainerAbove);
 		this.ui.addChild(this.editorContainer);
 		this.ui.addChild(this.hookWidgetContainerBelow);
+		this.ui.setBottomPinnedComponent(this.statusLine);
 		this.ui.setFocus(this.editor);
 
 		this.#inputController.setupKeyHandlers();

--- a/packages/coding-agent/test/welcome-viewport.test.ts
+++ b/packages/coding-agent/test/welcome-viewport.test.ts
@@ -1,0 +1,30 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { visibleWidth } from "@gajae-code/tui";
+import { WelcomeComponent } from "../src/modes/components/welcome";
+import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
+
+beforeAll(async () => {
+	const theme = await getThemeByName("red-claw");
+	if (!theme) throw new Error("Failed to load red-claw theme");
+	setThemeInstance(theme);
+});
+
+describe("WelcomeComponent viewport sizing", () => {
+	it("uses the full terminal width on wide initial forge viewports", () => {
+		const welcome = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii");
+		const lines = welcome.render(200);
+
+		expect(lines.length).toBeGreaterThan(0);
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBe(198);
+		}
+	});
+
+	it("degrades gracefully on tiny terminal widths", () => {
+		const welcome = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii");
+
+		expect(welcome.render(5).every(line => visibleWidth(line) <= 3)).toBe(true);
+		expect(welcome.render(3)).toEqual([]);
+		expect(welcome.render(24).every(line => visibleWidth(line) <= 22)).toBe(true);
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added bottom-pinned TUI layout support so short initial screens can pad above composer/status components and keep the prompt anchored to the terminal viewport bottom (#1120).
+
 ## [0.6.0] - 2026-06-18
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -321,6 +321,7 @@ export class TUI extends Container {
 	#fullRedrawCount = 0;
 	#stopped = false;
 	#terminalUnavailable = false;
+	#bottomPinnedComponent: Component | null = null;
 
 	// Overlay stack for modal components rendered on top of base content
 	overlayStack: {
@@ -380,6 +381,11 @@ export class TUI extends Container {
 		if (isFocusable(component)) {
 			component.focused = true;
 		}
+	}
+
+	setBottomPinnedComponent(component: Component | null): void {
+		this.#bottomPinnedComponent = component;
+		this.requestRender();
 	}
 
 	/**
@@ -1269,6 +1275,31 @@ export class TUI extends Container {
 		return lines;
 	}
 
+	#padBeforeBottomPinnedComponent(lines: string[], height: number): string[] {
+		const component = this.#bottomPinnedComponent;
+		if (component === null || lines.length >= height) return lines;
+
+		let pinnedStart = -1;
+		for (let i = this.children.length - 1; i >= 0; i--) {
+			if (this.children[i] === component) {
+				pinnedStart = i;
+				break;
+			}
+		}
+		if (pinnedStart < 0) return lines;
+
+		let pinnedLineCount = 0;
+		for (let i = pinnedStart; i < this.children.length; i++) {
+			pinnedLineCount += this.children[i].render(this.terminal.columns).length;
+		}
+
+		const blankRows = height - lines.length;
+		const insertAt = Math.max(0, lines.length - pinnedLineCount);
+		const padded = [...lines];
+		padded.splice(insertAt, 0, ...Array.from({ length: blankRows }, () => ""));
+		return padded;
+	}
+
 	#doRender(): void {
 		if (this.#stopped || !this.terminalAvailable) return;
 		const width = this.terminal.columns;
@@ -1286,6 +1317,10 @@ export class TUI extends Container {
 		const renderTreeStart = renderMetrics.now();
 		let newLines = this.render(width);
 		if (renderMetrics.enabled) renderMetrics.recordHelper("renderTree", renderMetrics.now() - renderTreeStart);
+
+		if (this.#bottomPinnedComponent !== null && height > 0) {
+			newLines = this.#padBeforeBottomPinnedComponent(newLines, height);
+		}
 
 		// Composite overlays into the rendered lines (before differential compare)
 		if (this.overlayStack.length > 0) {

--- a/packages/tui/test/bottom-pinned-layout.test.ts
+++ b/packages/tui/test/bottom-pinned-layout.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { type Component, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+class LinesComponent implements Component {
+	constructor(private readonly lines: string[]) {}
+
+	invalidate(): void {}
+
+	render(_width: number): string[] {
+		return this.lines;
+	}
+}
+
+describe("TUI bottom-pinned layout", () => {
+	it("pads short content so the pinned component reaches the bottom row", async () => {
+		const term = new VirtualTerminal(40, 8);
+		const tui = new TUI(term);
+		const header = new LinesComponent(["forge"]);
+		const pinned = new LinesComponent(["status", "composer"]);
+
+		tui.addChild(header);
+		tui.addChild(pinned);
+		tui.setBottomPinnedComponent(pinned);
+
+		try {
+			tui.start();
+			await term.waitForRender();
+
+			const viewport = term.getViewport().map(line => line.trimEnd());
+			expect(viewport[0]).toBe("forge");
+			expect(viewport.slice(1, 6)).toEqual(["", "", "", "", ""]);
+			expect(viewport[6]).toBe("status");
+			expect(viewport[7]).toBe("composer");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("does not insert spacer rows when content already exceeds the viewport", async () => {
+		const term = new VirtualTerminal(40, 4);
+		const tui = new TUI(term);
+		const header = new LinesComponent(["line-0", "line-1", "line-2"]);
+		const pinned = new LinesComponent(["status", "composer"]);
+
+		tui.addChild(header);
+		tui.addChild(pinned);
+		tui.setBottomPinnedComponent(pinned);
+
+		try {
+			tui.start();
+			await term.waitForRender();
+
+			const viewport = term.getViewport().map(line => line.trimEnd());
+			expect(viewport).toEqual(["line-1", "line-2", "status", "composer"]);
+		} finally {
+			tui.stop();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Make the initial GJC forge welcome frame use the live terminal viewport width instead of the previous wide-screen cap.
- Add a generic TUI bottom-pinned component hook and use it to keep the status/composer area attached to the bottom when startup content is shorter than the terminal.
- Cover wide, tiny/medium, short-content, and overflow viewport behavior with focused tests.

Closes #1120.

## Verification
- `bun test packages/tui/test/bottom-pinned-layout.test.ts packages/coding-agent/test/welcome-viewport.test.ts`
- `bun run check:ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
