### PR TITLE
Fix forge viewport shell width expectation

### DIFF
--- a/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
+++ b/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
@@ -121,7 +121,7 @@ describe("redesigned interactive shell chrome", () => {
 		const wideTop = Bun.stripANSI(wideLines[0] ?? "");
 
 		expect(visibleWidth(narrowTop)).toBe(98);
-		expect(visibleWidth(wideTop)).toBe(132);
+		expect(visibleWidth(wideTop)).toBe(158);
 		expect(visibleWidth(wideTop)).toBeGreaterThan(visibleWidth(narrowTop));
 		expect(wideTop).toContain("GJC forge");
 		for (const line of wideLines) {


### PR DESCRIPTION
## Summary
- Update the redesigned shell chrome wide-terminal assertion for the new full-viewport forge welcome behavior from #1126.
- Fixes the current dev CI failure in run 28167484666 (`Affected path validation / test:@gajae-code/coding-agent`).

## Verification
- Inspected failed job log from run 28167484666: `redesigned interactive shell chrome > uses a wider forge splash box on wide terminals` expected stale width `132` after #1126 now renders the full 160-column viewport as width `158`.
- `git diff --check`
- Local test execution is blocked in this host worktree because the current local `gjc`/workspace install resolves `@gajae-code/tui` through a stale issue worktree symlink; PR CI is the validation gate for this one-line test expectation repair.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
