### PR TITLE
Reflow prompt draft on terminal resize

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -431,6 +431,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#resizeHandler = () => {
 			this.#syncEditorMaxHeight();
 			this.updateEditorChrome();
+			this.editor.invalidate();
+			this.ui.requestRender(true, "resize");
 		};
 		process.stdout.on("resize", this.#resizeHandler);
 		try {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -484,7 +484,10 @@ export class TUI extends Container {
 		this.#terminalUnavailable = false;
 		this.terminal.start(
 			data => this.#handleInput(data),
-			() => this.requestRender(),
+			() => {
+				this.invalidate();
+				this.requestRender(true, "resize");
+			},
 		);
 		this.#hideCursor();
 		this.#querySixelSupport();

--- a/packages/tui/test/input-render-redteam.test.ts
+++ b/packages/tui/test/input-render-redteam.test.ts
@@ -91,6 +91,29 @@ describe("keyboard input priority scheduler red-team", () => {
 		}
 	}, 30000);
 
+	it("reflows the current prompt draft after a terminal width resize", async () => {
+		const h = setup(44, 12, 0);
+		try {
+			await h.term.waitForRender();
+			const draft = "alpha beta gamma delta epsilon zeta eta theta iota kappa";
+			h.editor.setText(draft);
+			h.tui.requestRender(true, "test.narrow-draft");
+			await h.term.waitForRender();
+			const narrow = h.term.getViewport().join("\n");
+			expect(narrow).toContain("alpha beta gamma delta epsilon zeta");
+			expect(narrow).toContain("eta theta iota kappa");
+
+			h.term.resize(92, 12);
+			await h.term.waitForRender();
+			const wide = h.term.getViewport().join("\n");
+			expect(h.editor.getText()).toBe(draft);
+			expect(wide).toContain(draft);
+			expect(wide).not.toContain("+- eta theta iota kappa");
+		} finally {
+			h.tui.stop();
+		}
+	}, 30000);
+
 	it("forced render immediately after input preserves the keystroke and leaves no stale viewport", async () => {
 		const h = setup();
 		try {


### PR DESCRIPTION
## Summary
- Force resize-triggered invalidation/full redraws through the TUI resize path.
- Explicitly invalidate and redraw the active composer from `InteractiveMode`'s resize hook so Windows Terminal prompt drafts reflow without waiting for another input event.
- Add a regression test that types a long draft, resizes from narrow to wide, and verifies the prompt reflows to the new width.

Closes #1129.

## Verification
- `bun --cwd=packages/natives run build`
- `bun test packages/tui/test/input-render-redteam.test.ts`
- `bun --cwd=packages/tui run check`
- `bun --cwd=packages/coding-agent run check:types`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
