### PR TITLE
Clarify Windows tmux fallback guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Troubleshooting:
 - **`gjc.exe` exists but `gjc` is "not recognized".** The launcher is installed
   but not on `PATH`. Confirm `%USERPROFILE%\.bun\bin` is listed in
   `echo $env:Path`, then restart the terminal.
+- **`gjc --tmux` starts without a tmux-backed session.** Native Windows needs a
+  tmux-compatible executable on `PATH`. For GJC-managed session/team guarantees,
+  use WSL with real tmux, or another provider that round-trips tmux user options
+  such as `@gjc-profile`. Native psmux can provide `tmux`/`pmux`/`psmux`
+  commands, but that path is not fully supported for GJC ownership tags and team
+  guarantees yet; see `docs/environment-variables.md#interactive---tmux-startup-and-scrollmouse-profile`.
 
 ## Quick start
 

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -166,6 +166,17 @@ function formatTmuxLaunchDiagnostic(stage: string, stderr?: string): string {
 	return `gjc --tmux failed after creating tmux session: ${stage}.${suffix}\n`;
 }
 
+function formatTmuxUnavailableDiagnostic(platform: NodeJS.Platform, tmuxCommand: string): string {
+	if (platform === "win32") {
+		return (
+			`gjc --tmux requested but no ${tmuxCommand} executable was found; starting without a tmux-backed session. ` +
+			"For managed GJC session/team flows on Windows, use WSL with real tmux, or another tmux provider that round-trips tmux user options. " +
+			"Native psmux can expose tmux-compatible commands, but it is not fully supported for GJC-managed ownership tags/team guarantees yet.\n"
+		);
+	}
+	return `gjc --tmux requested but no ${tmuxCommand} executable was found; starting without a tmux-backed session.\n`;
+}
+
 function shellQuote(value: string): string {
 	if (value.length === 0) return "''";
 	return `'${value.replace(/'/g, `'\\''`)}'`;
@@ -385,7 +396,10 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 		env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim() ||
 		tmuxRuntimeSessionPath(cwd, gjcSessionId, buildGjcTmuxSessionSlug(sessionName));
 	const tmuxAvailable = context.tmuxAvailable ?? Bun.which(tmuxCommand) !== null;
-	if (!tmuxAvailable) return undefined;
+	if (!tmuxAvailable) {
+		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxUnavailableDiagnostic(platform, tmuxCommand));
+		return undefined;
+	}
 	const existingSessionName = allowsExistingTmuxAttach(context.parsed, env)
 		? "existingBranchSessionName" in context
 			? (context.existingBranchSessionName ?? undefined)

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1060,7 +1060,8 @@ describe("default GJC tmux launch", () => {
 		expect(writeSpy).toHaveBeenCalledWith(process.stderr.fd, expect.stringContaining("attach failed"));
 	});
 
-	it("falls through to direct launch when tmux is unavailable", () => {
+	it("falls through to direct launch with a diagnostic when tmux is unavailable", () => {
+		const diagnostics: string[] = [];
 		const plan = buildDefaultTmuxLaunchPlan({
 			parsed: args({ tmux: true }),
 			rawArgs: [],
@@ -1071,9 +1072,35 @@ describe("default GJC tmux launch", () => {
 			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: false,
+			diagnosticWriter: message => diagnostics.push(message),
 		});
 
 		expect(plan).toBeUndefined();
+		expect(diagnostics).toEqual([
+			"gjc --tmux requested but no tmux executable was found; starting without a tmux-backed session.\n",
+		]);
+	});
+
+	it("explains the native Windows psmux support boundary when tmux is unavailable", () => {
+		const diagnostics: string[] = [];
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ tmux: true }),
+			rawArgs: [],
+			cwd: "C:\\repo",
+			env: {},
+			argv: ["C:\\Program Files\\GJC\\gjc.exe"],
+			execPath: "C:\\Program Files\\GJC\\gjc.exe",
+			platform: "win32",
+			tty: interactiveTty,
+			tmuxAvailable: false,
+			diagnosticWriter: message => diagnostics.push(message),
+		});
+
+		expect(plan).toBeUndefined();
+		expect(diagnostics[0]).toContain("no tmux executable was found");
+		expect(diagnostics[0]).toContain("WSL with real tmux");
+		expect(diagnostics[0]).toContain("psmux");
+		expect(diagnostics[0]).toContain("not fully supported");
 	});
 
 	it("applies session-scoped mouse scrolling when launching tmux on WSL/Linux", () => {


### PR DESCRIPTION
## Summary
- Print an explicit diagnostic when `gjc --tmux` is requested but no tmux-compatible executable is available.
- Add Windows-specific wording that avoids silently recommending unsupported psmux-managed flows while explaining the current support boundary.
- Document the native Windows `--tmux` fallback in the README troubleshooting section.

Closes #1130.

## Verification
- `bun --cwd=packages/natives run build`
- `cd packages/coding-agent && bun test test/gjc-runtime/launch-tmux.test.ts`
- `cd packages/coding-agent && bun run check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
