### PR TITLE
Fix Windows prompt newline shortcut discoverability

### DIFF
--- a/packages/coding-agent/src/modes/components/hook-editor.ts
+++ b/packages/coding-agent/src/modes/components/hook-editor.ts
@@ -66,7 +66,7 @@ export class HookEditorComponent extends Container {
 
 		// Hint
 		const hint = this.#promptStyle
-			? "enter submit  esc cancel  ctrl+g external editor"
+			? "enter submit  shift+enter/ctrl+j newline  esc cancel  ctrl+g external editor"
 			: "ctrl+enter submit  esc cancel  ctrl+g external editor";
 		this.addChild(new Text(theme.fg("dim", hint), 1, 0));
 

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -23,7 +23,7 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		"|-----|--------|",
 		"| `Enter` | Send / queue while busy |",
 		`| \`${appKey(bindings, "app.message.queue")}\` | Queue message for next turn |`,
-		"| `Shift+Enter` | New line |",
+		"| `Shift+Enter` / `Ctrl+J` | New line |",
 		"| `Ctrl+W` / `Option+Backspace` | Delete word backwards |",
 		"| `Ctrl+U` | Delete to start of line |",
 		"| `Ctrl+K` | Delete to end of line |",

--- a/packages/coding-agent/test/hook-editor.test.ts
+++ b/packages/coding-agent/test/hook-editor.test.ts
@@ -222,23 +222,27 @@ describe("HookEditorComponent prompt-style mode", () => {
 	});
 
 	it("inserts newline on Shift+Enter instead of submitting", () => {
-		const onSubmit = vi.fn();
-		const onCancel = vi.fn();
-		const component = new HookEditorComponent(createTui(), "Prompt", undefined, onSubmit, onCancel, {
-			promptStyle: true,
-		});
+		const variants = ["\x1b[13;2~", "\x1b[13;2u"];
 
-		component.handleInput("a");
-		component.handleInput("\x1b[13;2~");
+		for (const variant of variants) {
+			const onSubmit = vi.fn();
+			const onCancel = vi.fn();
+			const component = new HookEditorComponent(createTui(), "Prompt", undefined, onSubmit, onCancel, {
+				promptStyle: true,
+			});
 
-		expect(onSubmit).not.toHaveBeenCalled();
-		expect(onCancel).not.toHaveBeenCalled();
+			component.handleInput("a");
+			component.handleInput(variant);
 
-		component.handleInput("b");
-		component.handleInput("\r");
+			expect(onSubmit).not.toHaveBeenCalled();
+			expect(onCancel).not.toHaveBeenCalled();
 
-		expect(onSubmit).toHaveBeenCalledTimes(1);
-		expect(onSubmit).toHaveBeenCalledWith("a\nb");
+			component.handleInput("b");
+			component.handleInput("\r");
+
+			expect(onSubmit).toHaveBeenCalledTimes(1);
+			expect(onSubmit).toHaveBeenCalledWith("a\nb");
+		}
 	});
 
 	it("treats Ctrl+Enter as newline in prompt-style mode", () => {
@@ -271,8 +275,7 @@ describe("HookEditorComponent prompt-style mode", () => {
 		expect(lines[0]).toMatch(/^─+$/);
 		expect(lines.at(-1)).toMatch(/^─+$/);
 		expect(lines[4]?.startsWith("> ")).toBe(true);
-		expect(rendered).toContain(" enter submit  esc cancel");
-		expect(rendered).not.toContain("shift+enter newline");
+		expect(rendered).toContain(" enter submit  shift+enter/ctrl+j newline");
 		expect(rendered).toContain("ctrl+g external editor");
 	});
 

--- a/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
+++ b/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
@@ -37,7 +37,7 @@ describe("buildHotkeysMarkdown", () => {
 		expect(markdown).toContain("| `Ctrl+Shift+P` | Copy whole prompt |");
 		expect(markdown).toContain("| `Enter` | Send / queue while busy |");
 		expect(markdown).toContain("| `Alt+Enter` | Queue message for next turn |");
-		expect(markdown).toContain("| `Shift+Enter` | New line |");
+		expect(markdown).toContain("| `Shift+Enter` / `Ctrl+J` | New line |");
 		expect(markdown).toContain("| `Ctrl+Shift+L` | Select model (temporary) |");
 		expect(markdown).toContain("| `Ctrl+L` | Select default model |");
 		expect(markdown).toContain("| `Alt+M` | Toggle plan mode |");

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -507,7 +507,7 @@ describe("Editor component", () => {
 		});
 
 		it("inserts a newline for Ctrl+Shift+Enter terminal protocol variants", () => {
-			const variants = ["\x1b[13;6u", "\x1b[27;6;13~", "\x1b[13;6~", "\x1b[13;2~"];
+			const variants = ["\x1b[13;6u", "\x1b[27;6;13~", "\x1b[13;6~", "\x1b[13;2~", "\x1b[13;2u"];
 
 			for (const [index, variant] of variants.entries()) {
 				const editor = new Editor(defaultEditorTheme);

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -63,6 +63,7 @@ describe("matchesKey", () => {
 		expect(matchesKey("\x1b[27;6;13~", "ctrl+shift+enter")).toBe(true);
 		expect(matchesKey("\x1b[13;6~", "ctrl+shift+enter")).toBe(true);
 		expect(matchesKey("\x1b[13;2~", "shift+enter")).toBe(true);
+		expect(matchesKey("\x1b[13;2u", "shift+enter")).toBe(true);
 		setKittyProtocolActive(false);
 	});
 
@@ -116,6 +117,7 @@ describe("parseKey", () => {
 		expect(parseKey("\x1b[27;6;13~")).toBe("shift+ctrl+enter");
 		expect(parseKey("\x1b[13;6~")).toBe("shift+ctrl+enter");
 		expect(parseKey("\x1b[13;2~")).toBe("shift+enter");
+		expect(parseKey("\x1b[13;2u")).toBe("shift+enter");
 		setKittyProtocolActive(false);
 	});
 


### PR DESCRIPTION
## Summary
- document Ctrl+J as a newline fallback in the `/hotkeys` panel and prompt-style editor hint
- add regression coverage for Windows Terminal CSI-u Shift+Enter (`CSI 13;2u`) in key parsing, editor newline handling, and prompt-style hook editor submission behavior

Fixes #1131

## Verification
- `bunx biome format --write packages/coding-agent/src/modes/components/hook-editor.ts packages/coding-agent/src/modes/utils/hotkeys-markdown.ts packages/coding-agent/test/hook-editor.test.ts packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts packages/tui/test/editor.test.ts packages/tui/test/keys.test.ts`
- `bunx biome check packages/coding-agent/src/modes/components/hook-editor.ts packages/coding-agent/src/modes/utils/hotkeys-markdown.ts packages/coding-agent/test/hook-editor.test.ts packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts packages/tui/test/editor.test.ts packages/tui/test/keys.test.ts`
- `bun test packages/tui/test/keys.test.ts packages/tui/test/editor.test.ts packages/coding-agent/test/hook-editor.test.ts packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts --timeout 30000`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*