### PR TITLE
fix(tui): repaint multiplexer viewport on resize

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -486,7 +486,7 @@ export class TUI extends Container {
 			data => this.#handleInput(data),
 			() => {
 				this.invalidate();
-				this.requestRender(true, "resize");
+				this.requestRender(!(isMultiplexerSession() && !useLegacyMultiplexerFullRender()), "resize");
 			},
 		);
 		this.#hideCursor();

--- a/packages/tui/test/fixtures/render-goldens/termux-height-diff/meta.json
+++ b/packages/tui/test/fixtures/render-goldens/termux-height-diff/meta.json
@@ -25,7 +25,7 @@
     },
     "writelog": {
       "file": "writelog.bin",
-      "sha256": "4de73af54d8fb802c255f6441080b53d759ce9a275bea89928af9f45e7ce1d11"
+      "sha256": "ac0aa0d6e66a061c657429238ea71886eaf1101db717e6bba5b92e76500c544e"
     }
   }
 }

--- a/packages/tui/test/fixtures/render-goldens/termux-height-diff/writelog.bin
+++ b/packages/tui/test/fixtures/render-goldens/termux-height-diff/writelog.bin
@@ -5,7 +5,14 @@ termux-line-03[0m
 termux-line-04[0m
 termux-line-05[0m
 termux-line-06[0m
-termux-line-07[0m[?25l[?2026l[?25l[?2026h[2J[H[3Jtermux-line-00[0m
+termux-line-07[0m[?25l[?2026l[?2026h[2J[H[3Jtermux-line-00[0m
+termux-line-01[0m
+termux-line-02[0m
+termux-line-03[0m
+termux-line-04[0m
+termux-line-05[0m
+termux-line-06[0m
+termux-line-07[0m[?25l[?2026l[?2026h[2J[H[3Jtermux-line-00[0m
 termux-keyboard-height[0m
 termux-line-02[0m
 termux-line-03[0m[?25l[?2026l


### PR DESCRIPTION
## Summary
- keep resize renders differential in non-legacy multiplexer sessions so the viewport-repaint path can repair newly visible rows
- preserve legacy full-render behavior outside tmux/screen and behind `GJC_TUI_LEGACY_MULTIPLEXER_FULL_RENDER=1`
- update the Termux height-diff golden writelog for the narrower multiplexer repaint sequence

## Verification
- `bun test packages/tui/test/render-goldens.test.ts packages/tui/test/render-regressions.test.ts --timeout 30000`
- `bunx biome check packages/tui/src/tui.ts packages/tui/test/fixtures/render-goldens/termux-height-diff/meta.json`
- `bun --cwd=packages/tui run test`
