### PR TITLE
fix(notifications): apply Telegram verbosity commands

### DIFF
--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -141,6 +141,7 @@ interface SessionRuntime {
 	/** Deregisters this session's Telegram file sink. */
 	disposeFileSink: () => void;
 	redact: boolean;
+	verbosity: "lean" | "verbose";
 	sessionTag: string;
 	/** Whether the agent loop is currently running (drives the typing indicator). */
 	busy: boolean;
@@ -248,7 +249,7 @@ function registerInteractiveAnswerSource(
 	id: string,
 	server: NotificationServer,
 	pendingInteractive: Map<string, PendingInteractiveAsk>,
-	redact: boolean,
+	getRedact: () => boolean,
 	tag: string,
 ): () => void {
 	return registerAskAnswerSource(id, {
@@ -260,7 +261,7 @@ function registerInteractiveAnswerSource(
 					JSON.stringify(
 						notificationActionPayload(
 							{ id: askId, kind: "ask", sessionId: id, question, options },
-							{ redact, sessionTag: tag },
+							{ redact: getRedact(), sessionTag: tag },
 						),
 					),
 					true,
@@ -336,6 +337,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		const pendingInteractive = new Map<string, PendingInteractiveAsk>();
 		const tag = sessionTag(id);
 		const redact = cfg.redact;
+		const verbosity = cfg.verbosity;
 		let runtime: SessionRuntime | undefined;
 
 		// The SDK can always answer now (interactive via the answer source, or the
@@ -410,7 +412,31 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 				return;
 			}
 			if (inbound.kind === "config_command") {
-				if (runtime && typeof inbound.redact === "boolean") runtime.redact = inbound.redact;
+				if (!runtime) return;
+				const update: {
+					type: "config_update";
+					sessionId: string;
+					verbosity?: "lean" | "verbose";
+					redact?: boolean;
+				} = {
+					type: "config_update",
+					sessionId: id,
+				};
+				if (inbound.verbosity === "lean" || inbound.verbosity === "verbose") {
+					runtime.verbosity = inbound.verbosity;
+					update.verbosity = inbound.verbosity;
+				}
+				if (typeof inbound.redact === "boolean") {
+					runtime.redact = inbound.redact;
+					update.redact = inbound.redact;
+				}
+				if (update.verbosity !== undefined || update.redact !== undefined) {
+					try {
+						runtime.server.pushFrame(JSON.stringify(update));
+					} catch (e) {
+						logger.warn(`notifications: config_update failed: ${String(e)}`);
+					}
+				}
 			}
 		});
 
@@ -418,7 +444,13 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 			const endpoint = await server.start();
 
 			// Interactive answer source: the ask tool races the local UI against this.
-			const disposeAnswerSource = registerInteractiveAnswerSource(id, server, pendingInteractive, redact, tag);
+			const disposeAnswerSource = registerInteractiveAnswerSource(
+				id,
+				server,
+				pendingInteractive,
+				() => runtime?.redact ?? redact,
+				tag,
+			);
 			const disposeFileSink = registerTelegramFileSink(id, async file => {
 				try {
 					const data = await fs.promises.readFile(file.path);
@@ -444,6 +476,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 				disposeAnswerSource,
 				disposeFileSink,
 				redact,
+				verbosity,
 				sessionTag: tag,
 				busy: false,
 				pendingInbound: new Set<number>(),
@@ -567,8 +600,9 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 			const running = runtimes.has(id);
 			const locallyDisabled = disabledSessions.has(id);
 			const enabled = isEnabledForSession(id, resolved.cfg);
+			const runtime = runtimes.get(id);
 			ctx.ui.notify(
-				`Notifications ${running ? "running" : enabled ? "enabled" : "disabled"} for this session; redaction ${resolved.cfg.redact ? "on" : "off"}${locallyDisabled ? "; locally off" : ""}.`,
+				`Notifications ${running ? "running" : enabled ? "enabled" : "disabled"} for this session; redaction ${(runtime?.redact ?? resolved.cfg.redact) ? "on" : "off"}; verbosity ${runtime?.verbosity ?? resolved.cfg.verbosity}${locallyDisabled ? "; locally off" : ""}.`,
 				"info",
 			);
 		},
@@ -616,7 +650,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 			newId,
 			rt.server,
 			rt.pendingInteractive,
-			rt.redact,
+			() => rt.redact,
 			rt.sessionTag,
 		);
 		rt.disposeFileSink = registerTelegramFileSink(newId, async file => {
@@ -735,7 +769,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		// On idle, stream a context update with metadata (token/model usage +
 		// working-tree diff) unless redaction is on. The agent's last message is
 		// NOT repeated here — it is already streamed once via `turn_stream`.
-		if (!rt.redact) {
+		if (!rt.redact && rt.verbosity === "verbose") {
 			const usage = (
 				ctx as { getContextUsage?: () => { tokens: number | null; contextWindow: number } | undefined }
 			).getContextUsage?.();

--- a/packages/coding-agent/test/notifications-turn-ordering.test.ts
+++ b/packages/coding-agent/test/notifications-turn-ordering.test.ts
@@ -23,7 +23,7 @@ async function waitFor(pred: () => boolean, ms = 4000, label = "condition"): Pro
 }
 
 type Handler = (event: unknown, ctx: unknown) => unknown;
-type Frame = { type: string; text?: string };
+type Frame = { type: string; text?: string; verbosity?: "lean" | "verbose"; tokenUsage?: string; model?: string };
 
 const tempDirs: string[] = [];
 const openSockets: WebSocket[] = [];
@@ -33,7 +33,14 @@ afterEach(() => {
 });
 
 /** Boot the notifications extension against a real NotificationServer + WS client. */
-async function setup(): Promise<{ handlers: Map<string, Handler>; ctx: unknown; frames: Frame[] }> {
+async function setup(): Promise<{
+	handlers: Map<string, Handler>;
+	ctx: unknown;
+	frames: Frame[];
+	ws: WebSocket;
+	token: string;
+	sid: string;
+}> {
 	const handlers = new Map<string, Handler>();
 	const api = {
 		on: (event: string, handler: Handler) => {
@@ -55,6 +62,8 @@ async function setup(): Promise<{ handlers: Map<string, Handler>; ctx: unknown; 
 			getArtifactsDir: () => cwd,
 			getCwd: () => cwd,
 		},
+		getContextUsage: () => ({ tokens: 12, contextWindow: 100 }),
+		getModel: () => ({ id: "test-model" }),
 	} as never;
 
 	await handlers.get("session_start")!({ type: "session_start" }, ctx);
@@ -73,7 +82,7 @@ async function setup(): Promise<{ handlers: Map<string, Handler>; ctx: unknown; 
 	});
 	// Let the server-side connection subscribe before any (unbuffered) broadcast.
 	await sleep(250);
-	return { handlers, ctx, frames };
+	return { handlers, ctx, frames, ws, token, sid };
 }
 
 test("assistant text preceding an ask is flushed before the ask and not duplicated at turn_end", async () => {
@@ -148,6 +157,41 @@ test("a tool-only ask turn does not mirror the preceding user prompt as turn out
 		// Nothing should have been streamed: the user's prompt must not be mirrored,
 		// and the assistant turn had no text of its own.
 		expect(turnStreams().length).toBe(0);
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
+	}
+}, 30000);
+
+test("inbound /verbose and /lean update runtime verbosity and confirmation policy", async () => {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		const { handlers, ctx, frames, ws, token, sid } = await setup();
+		const configUpdates = () => frames.filter(f => f.type === "config_update");
+		const contextUpdates = () => frames.filter(f => f.type === "context_update");
+
+		await handlers.get("agent_end")!({ type: "agent_end" }, ctx);
+		await sleep(200);
+		expect(contextUpdates().length).toBe(0);
+
+		ws.send(JSON.stringify({ type: "config_command", sessionId: sid, token, verbosity: "verbose" }));
+		await waitFor(() => configUpdates().some(f => f.verbosity === "verbose"), 3000, "verbose config_update");
+
+		await handlers.get("agent_end")!({ type: "agent_end" }, ctx);
+		await waitFor(
+			() => contextUpdates().some(f => f.tokenUsage === "12/100" && f.model === "test-model"),
+			3000,
+			"verbose context_update",
+		);
+
+		ws.send(JSON.stringify({ type: "config_command", sessionId: sid, token, verbosity: "lean" }));
+		await waitFor(() => configUpdates().some(f => f.verbosity === "lean"), 3000, "lean config_update");
+
+		const beforeLeanIdle = contextUpdates().length;
+		await handlers.get("agent_end")!({ type: "agent_end" }, ctx);
+		await sleep(200);
+		expect(contextUpdates().length).toBe(beforeLeanIdle);
 	} finally {
 		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
 		else process.env.GJC_NOTIFICATIONS = prevEnv;


### PR DESCRIPTION
## Summary
- track per-session notification verbosity runtime state initialized from config
- apply inbound Telegram verbosity config commands to the active runtime and emit existing `config_update` confirmations
- gate idle context updates on `verbose` mode and include runtime verbosity in `/notify status`
- add focused notification turn-ordering coverage for `/verbose` and `/lean`

## Verification
- `bun test packages/coding-agent/test/notifications-turn-ordering.test.ts --timeout 40000`
- `bunx biome check packages/coding-agent/src/notifications/index.ts packages/coding-agent/test/notifications-turn-ordering.test.ts`

Fixes #1136.
