### PR TITLE
fix(team): adopt user-created tmux sessions as team leaders

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 - Deep Interview Restate/option gates now recover through the ask selector path instead of waiting on plaintext `Options:` output.
 
+- `gjc team` now adopts any real tmux session as its leader — including one you started yourself outside `gjc --tmux` — by writing and reading back GJC's `@gjc-profile` ownership tag, instead of only accepting `gjc --tmux`-launched sessions. Providers that cannot round-trip tmux user options (e.g. psmux) are still rejected as unmanaged.
+
 ## [0.7.2] - 2026-06-24
 ### Added
 

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -5,7 +5,7 @@ import type { WorkflowHudSummary } from "../skill-state/active-state";
 import { buildTeamHudSummary as buildWorkflowTeamHudSummary } from "../skill-state/workflow-hud";
 import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
 import type { GcPidProbe, GcRecord } from "./gc-runtime";
-import { applyGjcTmuxProfile, GJC_TMUX_LAUNCHED_ENV } from "./launch-tmux";
+import { applyGjcTmuxProfile } from "./launch-tmux";
 import { modeStatePath, sessionIdFromDirName, sessionReportsDir, teamStateRoot } from "./session-layout";
 import { resolveGjcSessionForWrite, writeSessionActivityMarker } from "./session-resolution";
 import {
@@ -1812,7 +1812,7 @@ async function ensureWorkerWorktree(
 
 function buildTeamTmuxLeaderRequirementMessage(detail?: string): string {
 	const suffix = detail?.trim() ? `:${detail.trim()}` : "";
-	return `gjc_team_requires_tmux_leader: run \`gjc --tmux\` first, then run \`gjc team ...\` inside that tmux-backed leader session, or use \`gjc team --dry-run\` for state-only smoke tests${suffix}`;
+	return `gjc_team_requires_tmux_leader: start a tmux session first (run \`gjc --tmux\`, or launch tmux yourself), then run \`gjc team ...\` inside it, or use \`gjc team --dry-run\` for state-only smoke tests${suffix}`;
 }
 function readGjcTmuxProfileValue(tmuxCommand: string, sessionName: string): string {
 	const result = Bun.spawnSync(
@@ -1826,7 +1826,7 @@ function readGjcTmuxProfileValue(tmuxCommand: string, sessionName: string): stri
 	return result.stdout.toString().trim();
 }
 
-function retagGjcLaunchedTmuxSession(tmuxCommand: string, sessionName: string): boolean {
+function tagTmuxSessionAsGjcLeader(tmuxCommand: string, sessionName: string): boolean {
 	const result = Bun.spawnSync(
 		[
 			tmuxCommand,
@@ -1856,14 +1856,15 @@ function readCurrentTmuxLeaderContext(tmuxCommand: string, env: NodeJS.ProcessEn
 	if (!sessionName || !windowIndex || !leaderPaneId.startsWith("%"))
 		throw new Error(buildTeamTmuxLeaderRequirementMessage(`invalid_tmux_context:${result.stdout.toString().trim()}`));
 	if (readGjcTmuxProfileValue(tmuxCommand, sessionName) !== GJC_TMUX_PROFILE_VALUE) {
-		// Self-heal: a pane launched through `gjc --tmux` exports
-		// GJC_TMUX_LAUNCHED=1, but the session can lose (or never receive) the
-		// @gjc-profile user-option tag when startup attach fails mid-way or the
-		// registry write races. That stranded-but-genuinely-GJC leader pane
-		// previously hard-failed as unmanaged_tmux_session; re-tag it instead.
-		const launchedByGjc = env[GJC_TMUX_LAUNCHED_ENV] === "1";
-		const retagged = launchedByGjc && retagGjcLaunchedTmuxSession(tmuxCommand, sessionName);
-		if (!retagged || readGjcTmuxProfileValue(tmuxCommand, sessionName) !== GJC_TMUX_PROFILE_VALUE)
+		// Adopt any real tmux leader as a GJC team leader — including a session
+		// the user created outside `gjc --tmux` — by writing GJC's @gjc-profile
+		// ownership tag and reading it back. A provider that round-trips tmux
+		// user options (real tmux) keeps the tag and is adopted; one that does
+		// not (e.g. psmux on Windows) drops it, so the readback still fails and
+		// the leader is rejected as unmanaged. This also self-heals a genuine
+		// `gjc --tmux` pane that lost its @gjc-profile tag mid-startup.
+		const tagged = tagTmuxSessionAsGjcLeader(tmuxCommand, sessionName);
+		if (!tagged || readGjcTmuxProfileValue(tmuxCommand, sessionName) !== GJC_TMUX_PROFILE_VALUE)
 			throw new Error(
 				buildTeamTmuxLeaderRequirementMessage(
 					`unmanaged_tmux_session:${sessionName} — ${buildGjcTmuxUntaggedSessionHint(tmuxCommand)}`,

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -53,7 +53,7 @@ function runGit(cwd: string, args: string[]): string {
 
 async function createFakeTmuxBin(
 	root: string,
-	options: { failDisplay?: boolean; failSplit?: boolean; gjcProfile?: boolean } = {},
+	options: { failDisplay?: boolean; failSplit?: boolean; gjcProfile?: boolean; untaggableProfile?: boolean } = {},
 ): Promise<string> {
 	const binDir = path.join(root, ".test-bin");
 	await fs.mkdir(binDir, { recursive: true });
@@ -90,9 +90,13 @@ case "$1" in
     ;;
   set-option)
     profile_file=${JSON.stringify(path.join(root, "tmux-profile-tag"))}
-    for arg in "$@"; do
+    ${
+			options.untaggableProfile
+				? `: # psmux-like provider: accepts set-option but does not persist tmux user options`
+				: `for arg in "$@"; do
       if [ "$arg" = "@gjc-profile" ]; then echo "1" > "$profile_file"; fi
-    done
+    done`
+}
     exit 0
     ;;
   split-window)
@@ -656,7 +660,7 @@ describe("native gjc team runtime", () => {
 					GJC_TEAM_TMUX_COMMAND: fakeTmux,
 				},
 			}),
-		).rejects.toThrow(/gjc_team_requires_tmux_leader: run `gjc --tmux` first/);
+		).rejects.toThrow(/gjc_team_requires_tmux_leader: start a tmux session first/);
 
 		expect(await Bun.file(path.join(teamStateDir(cleanupRoot, "fail-team"), "phase.json")).exists()).toBe(false);
 		expect(
@@ -664,9 +668,9 @@ describe("native gjc team runtime", () => {
 		).toBe(false);
 	});
 
-	it("rejects unmanaged tmux sessions before state, worktree, split, or profile mutation", async () => {
+	it("rejects a tmux provider that cannot persist GJC's ownership tag (e.g. psmux)", async () => {
 		cleanupRoot = await createGitRepo();
-		const fakeTmux = await createFakeTmuxBin(cleanupRoot, { gjcProfile: false });
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot, { gjcProfile: false, untaggableProfile: true });
 
 		await expect(
 			startGjcTeam({
@@ -696,8 +700,10 @@ describe("native gjc team runtime", () => {
 		// tmux 3.6a refuses to resolve the bare `=NAME` form for show-options (#580).
 		expect(tmuxLog).toContain("show-options -qv -t =test-session: @gjc-profile");
 		expect(tmuxLog).not.toContain("show-options -qv -t =test-session @gjc-profile");
+		// Adoption probes the tag once, but a provider that drops user options
+		// never round-trips it, so the leader is rejected before any pane split.
+		expect(tmuxLog).toContain("set-option -t =test-session: @gjc-profile 1");
 		expect(tmuxLog).not.toContain("split-window");
-		expect(tmuxLog).not.toContain("set-option -t test-session:0");
 	});
 
 	it("self-heals a missing @gjc-profile tag when the leader pane was launched by gjc --tmux", async () => {
@@ -730,29 +736,33 @@ describe("native gjc team runtime", () => {
 		expect(tmuxLog).toContain("split-window");
 	});
 
-	it("keeps rejecting untagged sessions when GJC_TMUX_LAUNCHED is not set even with TMUX present", async () => {
+	it("adopts a user-created tmux leader by tagging it even without GJC_TMUX_LAUNCHED", async () => {
 		cleanupRoot = await createGitRepo();
 		const fakeTmux = await createFakeTmuxBin(cleanupRoot, { gjcProfile: false });
 
-		await expect(
-			startGjcTeam({
-				workerCount: 1,
-				agentType: "executor",
-				task: "Do not hijack foreign tmux",
-				teamName: "foreign-team",
-				cwd: cleanupRoot,
-				env: {
-					GJC_SESSION_ID: TEST_SESSION_ID,
-					PATH: process.env.PATH ?? "",
-					GJC_TEAM_WORKER_COMMAND: "true",
-					GJC_TEAM_TMUX_COMMAND: fakeTmux,
-					TMUX: "/tmp/tmux-501/default,1,0",
-				},
-			}),
-		).rejects.toThrow(/unmanaged_tmux_session:test-session/);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Adopt the user's own tmux",
+			teamName: "adopted-team",
+			cwd: cleanupRoot,
+			dryRun: false,
+			env: {
+				GJC_SESSION_ID: TEST_SESSION_ID,
+				PATH: process.env.PATH ?? "",
+				GJC_TEAM_WORKER_COMMAND: "true",
+				GJC_TEAM_TMUX_COMMAND: fakeTmux,
+				TMUX: "/tmp/tmux-501/default,1,0",
+			},
+		});
 
+		expect(snapshot.team_name).toBe("adopted-team");
+		expect(snapshot.tmux_target).toBe("test-session:0");
 		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
-		expect(tmuxLog).not.toContain("set-option");
+		// A real tmux session the user created (no GJC_TMUX_LAUNCHED) is adopted
+		// by writing and reading back GJC's ownership tag, then split into workers.
+		expect(tmuxLog).toContain("set-option -t =test-session: @gjc-profile 1");
+		expect(tmuxLog).toContain("split-window");
 	});
 
 	it("cleans partial worker worktrees without killing the leader session when pane startup fails", async () => {


### PR DESCRIPTION
## Problem

`gjc team` only worked inside a tmux session that `gjc --tmux` had launched.
`readCurrentTmuxLeaderContext` required the leader session to carry the
`@gjc-profile` ownership tag, and the missing-tag self-heal path was gated on
`GJC_TMUX_LAUNCHED=1` — an env var exported **only** by `gjc --tmux` panes.

So running `gjc team ...` inside a tmux session you started yourself (plain
`tmux`, real provider, `$TMUX` set) failed with:

```
gjc_team_requires_tmux_leader: ... unmanaged_tmux_session:<session>
```

even though there is nothing technically wrong with hosting worker panes in a
user-created real-tmux session.

## Change

Generalize leader adoption in `readCurrentTmuxLeaderContext`: when the
`@gjc-profile` tag is absent, **write it and read it back** instead of gating
on `GJC_TMUX_LAUNCHED`.

- Real tmux round-trips the user option → the tag sticks → the session is
  adopted as the team leader (works for both user-created and `gjc --tmux`
  sessions, subsuming the old self-heal path).
- A provider that does **not** persist tmux user options (e.g. psmux on
  Windows) drops the tag → the readback still fails → the leader is rejected
  as `unmanaged_tmux_session`, exactly as before.

`retagGjcLaunchedTmuxSession` → `tagTmuxSessionAsGjcLeader` (no behavior change
beyond the gate removal), the now-unused `GJC_TMUX_LAUNCHED_ENV` import is
dropped, and the leader-requirement message no longer implies `gjc --tmux` is
mandatory.

### Safety notes

- GC is unaffected: live sessions (panes present) are never collected, and
  orphan GC only targets `gajae_code`/`gajae_code_*`-named sessions, so a
  tagged user session (arbitrary name) is not at risk.
- The full scoped tmux profile (`mouse`, `set-clipboard`, etc.) is still
  applied during `startTmuxSession` as today.

## Testing

- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts` — 47 pass
- Adjacent cluster (`launch-tmux`, `tmux-sessions`, `tmux-gc`, `tmux-gc.redteam`) — 66 pass
- `bun --cwd=packages/coding-agent run check:types` — clean
- `biome check` on changed files — clean

Test changes:
- Flipped the untagged-session case to assert **adoption** (tag written +
  read back, then split into workers) with no `GJC_TMUX_LAUNCHED`.
- Added a psmux-style fixture option (`untaggableProfile`) that accepts
  `set-option` but does not persist user options, preserving the
  unmanaged-rejection guarantee.
- Updated the not-in-tmux message regex.
