### PR TITLE
Fix PowerShell tmux startup fast paths

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -64,7 +64,7 @@ async function showHelp(config: CliConfig): Promise<void> {
 }
 
 async function installRuntimeGlobals(): Promise<void> {
-	const [{ installH2Fetch }, { procmgr }] = await Promise.all([import("@gajae-code/ai"), import("@gajae-code/utils")]);
+	const { installH2Fetch } = await import("@gajae-code/ai/utils/h2-fetch");
 	// Activate HTTP/2 for all `fetch()` calls (provider streams, OAuth, model
 	// discovery, web tools). Bun's HTTP/2 client is gated on a startup flag we
 	// can't toggle from JS, so we patch globalThis.fetch to pass
@@ -75,7 +75,24 @@ async function installRuntimeGlobals(): Promise<void> {
 	// Strip macOS malloc-stack-logging env vars before any subprocess is spawned.
 	// Otherwise every child bun process (subagents, plugin installs, ptree spawns,
 	// etc.) prints a `MallocStackLogging: can't turn off …` warning to stderr.
-	procmgr.scrubProcessEnv();
+	delete process.env.MallocStackLogging;
+	delete process.env.MallocStackLoggingNoCompact;
+}
+
+function hasRootFastFlag(argv: string[], flags: readonly string[]): boolean {
+	for (const arg of argv) {
+		if (isSubcommand(arg)) return false;
+		if (flags.includes(arg)) return true;
+	}
+	return false;
+}
+
+function hasRootHelpFlag(argv: string[]): boolean {
+	return hasRootFastFlag(argv, rootHelpFlags);
+}
+
+function hasRootVersionFlag(argv: string[]): boolean {
+	return hasRootFastFlag(argv, versionFlags);
 }
 
 class RootHelpCommand extends Command {
@@ -195,7 +212,7 @@ export async function runCli(argv: string[]): Promise<void> {
 		await runSmokeTest();
 		return;
 	}
-	if (rootHelpFlags.includes(argv[0] ?? "")) {
+	if (hasRootHelpFlag(argv)) {
 		const { renderRootHelp } = await import("@gajae-code/utils/cli");
 		const { getExtraHelpText } = await import("./cli/fast-help");
 		renderRootHelp({ bin: APP_NAME, version: VERSION, commands: new Map([["launch", RootHelpCommand]]) });
@@ -205,7 +222,7 @@ export async function runCli(argv: string[]): Promise<void> {
 		}
 		return;
 	}
-	if (versionFlags.includes(argv[0] ?? "")) {
+	if (hasRootVersionFlag(argv)) {
 		process.stdout.write(`${APP_NAME}/${VERSION}\n`);
 		return;
 	}

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "node:buffer";
 import * as path from "node:path";
-import { safeStderrWrite } from "@gajae-code/utils";
 import { VERSION } from "@gajae-code/utils/dirs";
+import { safeStderrWrite } from "@gajae-code/utils/safe-stderr";
 import type { Args } from "../cli/args";
 import { tmuxRuntimeSessionPath } from "./session-layout";
 import { GJC_COORDINATOR_SESSION_ID_ENV, GJC_COORDINATOR_SESSION_STATE_FILE_ENV } from "./session-state-sidecar";
@@ -175,6 +175,14 @@ function formatTmuxUnavailableDiagnostic(platform: NodeJS.Platform, tmuxCommand:
 		);
 	}
 	return `gjc --tmux requested but no ${tmuxCommand} executable was found; starting without a tmux-backed session.\n`;
+}
+
+function formatNativeWindowsDirectDiagnostic(): string {
+	return (
+		"gjc --tmux requested on native Windows; starting without a tmux-backed session. " +
+		"For managed GJC session/team flows on Windows, use WSL with real tmux, or another tmux provider that round-trips tmux user options. " +
+		"Native psmux can expose tmux-compatible commands, but it is not fully supported for GJC-managed ownership tags/team guarantees yet.\n"
+	);
 }
 
 function shellQuote(value: string): string {
@@ -379,6 +387,10 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 	if (!context.parsed.tmux || policy === "direct") return undefined;
 	if (env.TMUX || env[GJC_TMUX_LAUNCHED_ENV] === "1") return undefined;
 	const platform = context.platform ?? process.platform;
+	if (platform === "win32") {
+		(context.diagnosticWriter ?? safeStderrWrite)(formatNativeWindowsDirectDiagnostic());
+		return undefined;
+	}
 	const tty = context.tty ?? { stdin: Boolean(process.stdin.isTTY), stdout: Boolean(process.stdout.isTTY) };
 	if (policy === "tmux" && !isInteractiveRootLaunch(context.parsed, tty)) return undefined;
 
@@ -465,7 +477,7 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 
 	if (plan.attachSessionName) {
 		const attached = spawnSync(plan.tmuxCommand, ["attach-session", "-t", `=${plan.attachSessionName}`], options);
-		return attached.exitCode === 0;
+		if (attached.exitCode === 0) return true;
 	}
 
 	const created = spawnSync(plan.tmuxCommand, plan.newSessionArgs, options);

--- a/packages/coding-agent/test/cli-help-load-order.test.ts
+++ b/packages/coding-agent/test/cli-help-load-order.test.ts
@@ -121,4 +121,82 @@ describe("CLI help load order", () => {
 		expect(combined).not.toContain("raw-http-request");
 		expect(combined).not.toContain("http-400-requests");
 	}, 15_000);
+
+	it("fast-paths root --tmux --help before runtime globals", async () => {
+		if (Bun.semver.order(Bun.version, "1.3.14") < 0) {
+			return;
+		}
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-tmux-help-fast-path-"));
+		cleanupRoot = root;
+		const home = path.join(root, "home");
+		const xdg = path.join(root, "xdg");
+		const agentDir = path.join(root, "agent");
+		await fs.mkdir(home, { recursive: true });
+		await fs.mkdir(xdg, { recursive: true });
+		await fs.mkdir(agentDir, { recursive: true });
+
+		const proc = Bun.spawn([process.execPath, cliEntry, "--tmux", "--help"], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: {
+				...process.env,
+				HOME: home,
+				XDG_CONFIG_HOME: xdg,
+				XDG_DATA_HOME: xdg,
+				PI_CODING_AGENT_DIR: agentDir,
+				PI_NO_TITLE: "1",
+				NO_COLOR: "1",
+			},
+		});
+
+		const [stdout, stderr, exitCode] = await Promise.all([
+			readStream(proc.stdout as ReadableStream<Uint8Array>),
+			readStream(proc.stderr as ReadableStream<Uint8Array>),
+			proc.exited,
+		]);
+
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain("USAGE");
+		expect(stderr).toBe("");
+	}, 15_000);
+
+	it("fast-paths root --tmux --version before runtime globals", async () => {
+		if (Bun.semver.order(Bun.version, "1.3.14") < 0) {
+			return;
+		}
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-tmux-version-fast-path-"));
+		cleanupRoot = root;
+		const home = path.join(root, "home");
+		const xdg = path.join(root, "xdg");
+		const agentDir = path.join(root, "agent");
+		await fs.mkdir(home, { recursive: true });
+		await fs.mkdir(xdg, { recursive: true });
+		await fs.mkdir(agentDir, { recursive: true });
+
+		const proc = Bun.spawn([process.execPath, cliEntry, "--tmux", "--version"], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: {
+				...process.env,
+				HOME: home,
+				XDG_CONFIG_HOME: xdg,
+				XDG_DATA_HOME: xdg,
+				PI_CODING_AGENT_DIR: agentDir,
+				PI_NO_TITLE: "1",
+				NO_COLOR: "1",
+			},
+		});
+
+		const [stdout, stderr, exitCode] = await Promise.all([
+			readStream(proc.stdout as ReadableStream<Uint8Array>),
+			readStream(proc.stderr as ReadableStream<Uint8Array>),
+			proc.exited,
+		]);
+
+		expect(exitCode).toBe(0);
+		expect(stdout).toMatch(/^gjc\/\d+\.\d+\.\d+\n$/);
+		expect(stderr).toBe("");
+	}, 15_000);
 });

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -36,11 +36,6 @@ function spawnResult(exitCode: number, stdout: string, stderr = ""): SpawnSyncRe
 		stderr: Buffer.from(stderr),
 	} as SpawnSyncResult;
 }
-function decodePowerShellEncodedCommand(command: string): string {
-	const match = command.match(/ -EncodedCommand (?<encoded>[A-Za-z0-9+/=]+)$/);
-	if (!match?.groups?.encoded) throw new Error(`missing encoded command: ${command}`);
-	return Buffer.from(match.groups.encoded, "base64").toString("utf16le");
-}
 
 let previousGjcSessionId: string | undefined;
 
@@ -181,7 +176,8 @@ describe("default GJC tmux launch", () => {
 		expect(plan.innerCommand).toContain("GJC_COORDINATOR_SESSION_STATE_FILE=");
 	});
 
-	it("plans native Windows --tmux launches when tmux is available", () => {
+	it("falls through to direct launch for native Windows --tmux", () => {
+		const diagnostics: string[] = [];
 		const plan = buildDefaultTmuxLaunchPlan({
 			parsed: args({ messages: ["hello world"], tmux: true }),
 			rawArgs: ["--tmux", "hello world"],
@@ -194,46 +190,15 @@ describe("default GJC tmux launch", () => {
 			tmuxAvailable: true,
 			currentBranch: "",
 			existingBranchSessionName: null,
+			diagnosticWriter: message => diagnostics.push(message),
 		});
 
-		expect(plan).toBeDefined();
-		if (!plan) throw new Error("expected tmux plan");
-
-		expect(plan.newSessionArgs.slice(0, 6)).toEqual(["new-session", "-d", "-s", plan.sessionName, "-c", "C:\\repo"]);
-		expect(plan.innerCommand).toStartWith(
-			"pwsh -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ",
-		);
-		expect(plan.innerCommand).not.toContain("exec env");
-		expect(decodePowerShellEncodedCommand(plan.innerCommand)).toContain("$env:GJC_TMUX_LAUNCHED = '1'");
+		expect(plan).toBeUndefined();
+		expect(diagnostics[0]).toContain("native Windows");
+		expect(diagnostics[0]).toContain("starting without a tmux-backed session");
+		expect(diagnostics[0]).toContain("WSL with real tmux");
 	});
 
-	it("builds a PowerShell-safe Windows tmux bootstrap command", () => {
-		const plan = buildDefaultTmuxLaunchPlan({
-			parsed: args({ messages: ["say it's ok"], tmux: true }),
-			rawArgs: ["--tmux", "say it's ok"],
-			cwd: "C:\\repo",
-			env: {},
-			argv: ["bun", "packages/coding-agent/src/cli.ts"],
-			execPath: "C:\\Program Files\\Bun\\bun.exe",
-			platform: "win32",
-			tty: interactiveTty,
-			tmuxAvailable: true,
-			currentBranch: "",
-			existingBranchSessionName: null,
-		});
-
-		expect(plan).toBeDefined();
-		if (!plan) throw new Error("expected tmux plan");
-
-		const script = decodePowerShellEncodedCommand(plan.innerCommand);
-		expect(script).toContain("$env:GJC_TMUX_LAUNCHED = '1'");
-		expect(script).toContain(`$env:GJC_COORDINATOR_SESSION_ID = '${plan.sessionId}'`);
-		expect(script).toContain(
-			"& 'C:\\Program Files\\Bun\\bun.exe' 'C:\\repo\\packages\\coding-agent\\src\\cli.ts' 'say it''s ok'",
-		);
-		expect(script).not.toContain("'--tmux'");
-		expect(script).toEndWith("if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 }");
-	});
 	it("uses a host command for compiled Bun virtual entrypoints", () => {
 		const plan = buildDefaultTmuxLaunchPlan({
 			parsed: args({ messages: ["hello world"], tmux: true }),
@@ -353,6 +318,35 @@ describe("default GJC tmux launch", () => {
 		expect(calls.at(-1)?.args).toEqual(["attach-session", "-t", "=gajae_code_feature"]);
 	});
 
+	it("falls through to a fresh session when existing tagged session attach fails", () => {
+		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"], tmux: true, resume: true }),
+			rawArgs: ["--tmux", "--resume", "hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			worktreeBranch: "feature/demo",
+			existingBranchSessionName: "gajae_code_feature",
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				if (spawnArgs[0] === "attach-session" && spawnArgs[2] === "=gajae_code_feature") return { exitCode: 1 };
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls[0]?.args).toEqual(["attach-session", "-t", "=gajae_code_feature"]);
+		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
+		expect(calls.some(call => call.args[0] === "attach-session" && call.args[2] !== "=gajae_code_feature")).toBe(
+			true,
+		);
+	});
+
 	it("does not reuse same-branch sessions from another project", () => {
 		const plan = buildDefaultTmuxLaunchPlan({
 			parsed: args({ messages: ["hello world"], tmux: true }),
@@ -396,7 +390,8 @@ describe("default GJC tmux launch", () => {
 		expect(plan?.newSessionArgs.slice(0, 6)).toEqual(["new-session", "-d", "-s", "custom-gjc", "-c", "/repo"]);
 	});
 
-	it("treats GJC_TMUX_COMMAND as an executable override instead of splitting psmux flags", () => {
+	it("falls through to direct launch for native Windows GJC_TMUX_COMMAND overrides", () => {
+		const diagnostics: string[] = [];
 		const plan = buildDefaultTmuxLaunchPlan({
 			parsed: args({ messages: ["hello world"], tmux: true }),
 			rawArgs: ["--tmux", "hello world"],
@@ -409,15 +404,12 @@ describe("default GJC tmux launch", () => {
 			tmuxAvailable: true,
 			currentBranch: "",
 			existingBranchSessionName: null,
+			diagnosticWriter: message => diagnostics.push(message),
 		});
 
-		expect(plan).toBeDefined();
-		if (!plan) throw new Error("expected tmux plan");
-
-		expect(plan.tmuxCommand).toBe("psmux -L repo");
-		expect(plan.newSessionArgs[0]).toBe("new-session");
-		expect(plan.newSessionArgs).not.toContain("-L");
-		expect(plan.newSessionArgs).not.toContain("repo");
+		expect(plan).toBeUndefined();
+		expect(diagnostics[0]).toContain("native Windows");
+		expect(diagnostics[0]).toContain("psmux");
 	});
 	it("does not auto-reuse scoped sessions from another GJC version", () => {
 		spyOn(Bun, "spawnSync").mockReturnValue(
@@ -883,7 +875,7 @@ describe("default GJC tmux launch", () => {
 			env: {},
 			argv: ["/usr/local/bin/gjc"],
 			execPath: "/bin/bun",
-			platform: "win32",
+			platform: "darwin",
 			tty: interactiveTty,
 			tmuxAvailable: true,
 			existingBranchSessionName: null,
@@ -1097,7 +1089,7 @@ describe("default GJC tmux launch", () => {
 		});
 
 		expect(plan).toBeUndefined();
-		expect(diagnostics[0]).toContain("no tmux executable was found");
+		expect(diagnostics[0]).toContain("native Windows");
 		expect(diagnostics[0]).toContain("WSL with real tmux");
 		expect(diagnostics[0]).toContain("psmux");
 		expect(diagnostics[0]).toContain("not fully supported");


### PR DESCRIPTION
Fixes #1141

## Summary
- fast-path root `--help`/`--version` even when `--tmux` is also present, before runtime globals are installed
- narrow startup imports for HTTP/2 fetch and safe stderr usage
- keep native Windows `--tmux` on the direct-launch fallback path with explicit diagnostics
- recover from failed existing-session tmux attach by creating and attaching a fresh managed session

## Verification
- `bun install`
- `bun --cwd=packages/natives run build` (needed locally because native addon was absent)
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts --timeout 40000`
- `bun test packages/coding-agent/test/cli-help-load-order.test.ts --timeout 40000`
- `bun run check:types` from `packages/coding-agent`
- `bunx biome check packages/coding-agent/src/cli.ts packages/coding-agent/src/gjc-runtime/launch-tmux.ts packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/test/cli-help-load-order.test.ts`