### PR TITLE
feat(team): friendlier failure when gjc team has no tmux leader

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 - `gjc team` now adopts any real tmux session as its leader — including one you started yourself outside `gjc --tmux` — by writing and reading back GJC's `@gjc-profile` ownership tag, instead of only accepting `gjc --tmux`-launched sessions. Providers that cannot round-trip tmux user options (e.g. psmux) are still rejected as unmanaged.
 
+- `gjc team` now fails with actionable guidance when there is no tmux leader to host workers: running it with no tmux installed reports `tmux_not_installed`, and running it outside any tmux session reports `not_inside_tmux` (with a hint to start one via `gjc --tmux` or your own `tmux`, or use `--dry-run`), instead of surfacing raw tmux stderr.
+
 ## [0.7.2] - 2026-06-24
 ### Added
 

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -1845,12 +1845,25 @@ function tagTmuxSessionAsGjcLeader(tmuxCommand: string, sessionName: string): bo
 }
 
 function readCurrentTmuxLeaderContext(tmuxCommand: string, env: NodeJS.ProcessEnv): GjcTmuxLeaderContext {
+	if (Bun.which(tmuxCommand) === null)
+		throw new Error(buildTeamTmuxLeaderRequirementMessage(`tmux_not_installed:${tmuxCommand}`));
 	const paneTarget = env.TMUX_PANE?.trim();
 	const args = paneTarget
 		? ["display-message", "-p", "-t", paneTarget, "#S:#I #{pane_id}"]
 		: ["display-message", "-p", "#S:#I #{pane_id}"];
 	const result = Bun.spawnSync([tmuxCommand, ...args], { stdout: "pipe", stderr: "pipe" });
-	if (result.exitCode !== 0) throw new Error(buildTeamTmuxLeaderRequirementMessage(result.stderr.toString()));
+	if (result.exitCode !== 0) {
+		// Distinguish "you are not inside any tmux session" from a genuine tmux
+		// query failure so the caller gets actionable guidance instead of raw
+		// tmux stderr. `gjc team` needs a tmux leader; outside tmux there is none.
+		const insideTmux = Boolean(env.TMUX?.trim() || env.TMUX_PANE?.trim());
+		const stderr = result.stderr.toString().trim();
+		throw new Error(
+			buildTeamTmuxLeaderRequirementMessage(
+				insideTmux ? `tmux_query_failed${stderr ? `:${stderr}` : ""}` : "not_inside_tmux",
+			),
+		);
+	}
 	const [sessionAndWindow = "", leaderPaneId = ""] = result.stdout.toString().trim().split(/\s+/);
 	const [sessionName = "", windowIndex = ""] = sessionAndWindow.split(":");
 	if (!sessionName || !windowIndex || !leaderPaneId.startsWith("%"))

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -668,6 +668,53 @@ describe("native gjc team runtime", () => {
 		).toBe(false);
 	});
 
+	it("fails with friendly guidance when tmux is not installed", async () => {
+		cleanupRoot = await createGitRepo();
+
+		await expect(
+			startGjcTeam({
+				workerCount: 1,
+				agentType: "executor",
+				task: "No tmux here",
+				teamName: "no-tmux-team",
+				cwd: cleanupRoot,
+				env: {
+					GJC_SESSION_ID: TEST_SESSION_ID,
+					PATH: process.env.PATH ?? "",
+					GJC_TEAM_WORKER_COMMAND: "true",
+					GJC_TEAM_TMUX_COMMAND: "gjc-nonexistent-tmux-binary-xyz",
+				},
+			}),
+		).rejects.toThrow(/gjc_team_requires_tmux_leader:.*tmux_not_installed/);
+
+		expect(await Bun.file(path.join(teamStateDir(cleanupRoot, "no-tmux-team"), "phase.json")).exists()).toBe(false);
+	});
+
+	it("fails with not_inside_tmux guidance when run outside any tmux session", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot, { failDisplay: true });
+
+		await expect(
+			startGjcTeam({
+				workerCount: 1,
+				agentType: "executor",
+				task: "Outside tmux",
+				teamName: "outside-tmux-team",
+				cwd: cleanupRoot,
+				env: {
+					GJC_SESSION_ID: TEST_SESSION_ID,
+					PATH: process.env.PATH ?? "",
+					GJC_TEAM_WORKER_COMMAND: "true",
+					GJC_TEAM_TMUX_COMMAND: fakeTmux,
+				},
+			}),
+		).rejects.toThrow(/gjc_team_requires_tmux_leader:.*not_inside_tmux/);
+
+		expect(await Bun.file(path.join(teamStateDir(cleanupRoot, "outside-tmux-team"), "phase.json")).exists()).toBe(
+			false,
+		);
+	});
+
 	it("rejects a tmux provider that cannot persist GJC's ownership tag (e.g. psmux)", async () => {
 		cleanupRoot = await createGitRepo();
 		const fakeTmux = await createFakeTmuxBin(cleanupRoot, { gjcProfile: false, untaggableProfile: true });


### PR DESCRIPTION
## Why

`gjc team` needs a tmux leader to host worker panes. When you run it **without
a tmux leader** (no tmux installed, or simply not inside any tmux session),
`readCurrentTmuxLeaderContext` surfaced the raw `tmux display-message` stderr
(e.g. a trailing `:no current tmux`). That is opaque and doesn't tell the user
what to do next.

This is the "fail with friendly guidance" follow-up to #1140. #1140 made
`gjc team` work **inside** a tmux session you created yourself; this PR
improves the message you get when there is **no** tmux leader at all.

## Change

Two early, actionable failure paths in `readCurrentTmuxLeaderContext`:

- **tmux not installed** (`Bun.which(tmuxCommand) === null`) →
  `tmux_not_installed:<cmd>`.
- **not inside any tmux session** (`display-message` fails and neither
  `$TMUX` nor `$TMUX_PANE` is set) → `not_inside_tmux`. A genuine in-tmux
  query failure keeps the tmux stderr under `tmux_query_failed`.

All paths still route through the existing `gjc_team_requires_tmux_leader`
message, which already points at `gjc --tmux`, launching tmux yourself, or
`gjc team --dry-run`.

## Out of scope (intentional)

Auto-launching a tmux leader from `gjc team` (e.g. `--auto-tmux` /
default auto-promotion) is **not** included. The current design deliberately
does not present `gjc team` as runnable outside tmux (`team/SKILL.md`), so
auto-launch is a policy/UX change that deserves its own design pass.

## Testing

- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts` — 49 pass
- `bun --cwd=packages/coding-agent run check:types` — clean
- `biome check` on changed files — clean

New tests cover the `tmux_not_installed` and `not_inside_tmux` details.

## Relationship to #1140

Independent of #1140 (touches different regions of the same function — the
top-of-function guards and the `display-message` failure branch, not the
adoption block or the message body). They can merge in either order; any
overlap is a trivial CHANGELOG/test-file resolution.
