### PR TITLE
Fix Telegram clarify choice rendering

### DIFF
--- a/packages/coding-agent/src/notifications/html-format.ts
+++ b/packages/coding-agent/src/notifications/html-format.ts
@@ -349,14 +349,52 @@ export function buttonLabel(label: string, index: number): string {
 	return `${index + 1}. ${stripped}`;
 }
 
+/** Numbered, escaped option list for the Telegram message body. */
+export function numberedOptionList(labels: string[]): string {
+	return labels.map((label, i) => `${i + 1}. ${escapeHtml(label.replace(/^\s*\d+[.)]\s+/, ""))}`).join("\n");
+}
+
+/** Compact numeric button label; full option text belongs in the message body. */
+export function choiceButtonLabel(index: number): string {
+	return String(index + 1);
+}
+
 export interface InlineButton {
 	text: string;
 	callback_data: string;
 }
 
+const COMPACT_BUTTONS_PER_ROW = 5;
+
 /** A prefixed button label is "long" when it is wide or contains a newline. */
 function isLongLabel(label: string): boolean {
 	return label.length > 18 || /[\r\n]/.test(label);
+}
+
+/**
+ * Lay out option callbacks as compact numeric buttons. Telegram mobile clients
+ * ellipsize long inline-keyboard labels and tall keyboards can be obscured by
+ * the composer, so the full choice text is rendered in the message body while
+ * the keyboard keeps only stable one-based tap targets.
+ */
+export function buildCompactChoiceGrid(
+	labels: string[],
+	callbackForIndex: (index: number) => string,
+): InlineButton[][] {
+	const rows: InlineButton[][] = [];
+	let run: InlineButton[] = [];
+	const flush = () => {
+		if (run.length) {
+			rows.push(run);
+			run = [];
+		}
+	};
+	labels.forEach((_label, i) => {
+		run.push({ text: choiceButtonLabel(i), callback_data: callbackForIndex(i) });
+		if (run.length === COMPACT_BUTTONS_PER_ROW) flush();
+	});
+	flush();
+	return rows;
 }
 
 /**

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -10,7 +10,7 @@ import type { DaemonRuntimeInfo } from "../daemon/control-types";
 import { resolveGjcRuntimeSpawnInfo } from "../daemon/runtime";
 import { getNotificationConfig, isGloballyConfigured, tokenFingerprint } from "./config";
 import { parseInThreadConfigCommand } from "./config-commands";
-import { buildButtonGrid, TELEGRAM_PARSE_MODE } from "./html-format";
+import { buildCompactChoiceGrid, TELEGRAM_PARSE_MODE } from "./html-format";
 import { NotificationOperatorRuntime, OperatorBackoffPolicy, OperatorEventRouter } from "./operator-runtime";
 import { RateLimitPool } from "./rate-limit-pool";
 import {
@@ -1434,9 +1434,9 @@ export class TelegramNotificationDaemon {
 				summary: msg.summary,
 			});
 			const options = Array.isArray(msg.options) ? msg.options : [];
-			// Daemon keyboards MUST use alias callback data (not reference encodeCallbackData).
-			// Labels show one-based numbers; the stored alias answer stays zero-based.
-			const inline_keyboard = buildButtonGrid(options, (i: number) =>
+			// Daemon keyboards use alias callback data with compact one-based tap targets;
+			// full option text is rendered in the message body by buildActionMessage.
+			const inline_keyboard = buildCompactChoiceGrid(options, (i: number) =>
 				this.aliasTable.put({ sessionId: session.sessionId, actionId: msg.id, answer: i }),
 			);
 			const result = (await this.botApi.call("sendMessage", {

--- a/packages/coding-agent/src/notifications/telegram-reference.ts
+++ b/packages/coding-agent/src/notifications/telegram-reference.ts
@@ -15,7 +15,14 @@
  */
 
 import * as fs from "node:fs";
-import { bold, buildButtonGrid, escapeHtml, TELEGRAM_PARSE_MODE, truncateTelegramHtml } from "./html-format";
+import {
+	bold,
+	buildCompactChoiceGrid,
+	escapeHtml,
+	numberedOptionList,
+	TELEGRAM_PARSE_MODE,
+	truncateTelegramHtml,
+} from "./html-format";
 import { renderThreadedFrame } from "./threaded-render";
 
 /** One inline-keyboard button. */
@@ -129,8 +136,9 @@ export function buildActionMessage(action: {
 	const text = `❓ ${bold(action.question ?? "Question")}`;
 	const options = action.options ?? [];
 	if (options.length === 0) return { text: truncateTelegramHtml(`${text}\n\n(reply with text)`) };
-	const inline_keyboard = buildButtonGrid(options, i => encodeCallbackData(action.id, i));
-	return { text: truncateTelegramHtml(text), inline_keyboard };
+	const body = `${text}\n\n${numberedOptionList(options)}`;
+	const inline_keyboard = buildCompactChoiceGrid(options, i => encodeCallbackData(action.id, i));
+	return { text: truncateTelegramHtml(body), inline_keyboard };
 }
 
 /** A protocol `reply` frame the client should send to the server. */

--- a/packages/coding-agent/test/notifications-html-format.test.ts
+++ b/packages/coding-agent/test/notifications-html-format.test.ts
@@ -3,10 +3,13 @@ import { Settings } from "../src/config/settings";
 import {
 	bold,
 	buildButtonGrid,
+	buildCompactChoiceGrid,
 	buttonLabel,
+	choiceButtonLabel,
 	code,
 	escapeHtml,
 	markdownToTelegramHtml,
+	numberedOptionList,
 	TELEGRAM_MESSAGE_LIMIT,
 	TELEGRAM_PARSE_MODE,
 	truncateTelegramHtml,
@@ -119,6 +122,41 @@ describe("button grid (AC6)", () => {
 		expect(buttonLabel("3 apples", 2)).toBe("3. 3 apples");
 	});
 
+	test("numberedOptionList renders full escaped choices in message body", () => {
+		expect(numberedOptionList(["1. Keep <alpha>", "Merge & continue"])).toBe(
+			"1. Keep &lt;alpha&gt;\n2. Merge &amp; continue",
+		);
+	});
+
+	test("compact choice grid uses numeric tap targets and preserves callback indexes", () => {
+		const grid = buildCompactChoiceGrid(
+			[
+				"A long Deep Interview clarify choice that would be clipped by Telegram mobile",
+				"Second",
+				"Third",
+				"Fourth",
+				"Fifth",
+				"Sixth",
+			],
+			i => `cb:${i}`,
+		);
+		expect(grid).toEqual([
+			[
+				{ text: "1", callback_data: "cb:0" },
+				{ text: "2", callback_data: "cb:1" },
+				{ text: "3", callback_data: "cb:2" },
+				{ text: "4", callback_data: "cb:3" },
+				{ text: "5", callback_data: "cb:4" },
+			],
+			[{ text: "6", callback_data: "cb:5" }],
+		]);
+	});
+
+	test("choiceButtonLabel is compact and one-based", () => {
+		expect(choiceButtonLabel(0)).toBe("1");
+		expect(choiceButtonLabel(9)).toBe("10");
+	});
+
 	test("short options pack into rows of three; callback index stays zero-based", () => {
 		const grid = buildButtonGrid(["Yes", "No", "Maybe", "Later"], i => `cb:${i}`);
 		expect(grid).toEqual([
@@ -142,11 +180,16 @@ describe("button grid (AC6)", () => {
 });
 
 describe("buildActionMessage (AC6)", () => {
-	test("ask bolds the escaped question, keeps emoji, and grids numbered options", () => {
-		const rendered = buildActionMessage({ kind: "ask", id: "a1", question: "Pick <one>", options: ["Yes", "No"] });
-		expect(rendered.text).toBe(`❓ ${bold("Pick <one>")}`);
-		expect(rendered.inline_keyboard?.[0]?.[0]?.text).toBe("1. Yes");
-		expect(rendered.inline_keyboard?.[0]?.[1]?.text).toBe("2. No");
+	test("ask puts full escaped options in the message body and compact numbers in the keyboard", () => {
+		const rendered = buildActionMessage({
+			kind: "ask",
+			id: "a1",
+			question: "Pick <one>",
+			options: ["1. Long <choice>", "No & wait"],
+		});
+		expect(rendered.text).toBe(`❓ ${bold("Pick <one>")}\n\n1. Long &lt;choice&gt;\n2. No &amp; wait`);
+		expect(rendered.inline_keyboard?.[0]?.[0]?.text).toBe("1");
+		expect(rendered.inline_keyboard?.[0]?.[1]?.text).toBe("2");
 	});
 
 	test("idle escapes the summary and keeps the emoji", () => {
@@ -274,7 +317,8 @@ describe("daemon send sites force parse_mode HTML (AC1)", () => {
 		const keyboard = send?.body.reply_markup?.inline_keyboard as Array<
 			Array<{ text: string; callback_data: string }>
 		>;
-		expect(keyboard[0]?.[0]?.text).toBe("1. Yes");
+		expect(keyboard[0]?.[0]?.text).toBe("1");
+		expect(send?.body.text).toContain("1. Yes\n2. No");
 		// The first button's alias must resolve to zero-based answer 0.
 		const alias = keyboard[0]?.[0]?.callback_data as string;
 		expect(daemon.aliasTable.get(alias)?.answer).toBe(0);

--- a/packages/coding-agent/test/notifications-telegram-reference.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-reference.test.ts
@@ -105,12 +105,13 @@ describe("telegram reference client helpers", () => {
 		});
 	});
 
-	test("buildActionMessage renders ask with an inline keyboard", () => {
+	test("buildActionMessage renders full options in body with compact inline keyboard", () => {
 		const m = buildActionMessage({ kind: "ask", id: "a1", question: "Proceed?", options: ["Yes", "No"] });
 		expect(m.text).toContain("Proceed?");
+		expect(m.text).toContain("1. Yes\n2. No");
 		expect(m.inline_keyboard).toHaveLength(1);
-		expect(m.inline_keyboard?.[0]?.[0]?.text).toBe("1. Yes");
-		expect(m.inline_keyboard?.[0]?.[1]?.text).toBe("2. No");
+		expect(m.inline_keyboard?.[0]?.[0]?.text).toBe("1");
+		expect(m.inline_keyboard?.[0]?.[1]?.text).toBe("2");
 		expect(decodeCallbackData(m.inline_keyboard![0]![0]!.callback_data)).toEqual({ id: "a1", index: 0 });
 	});
 


### PR DESCRIPTION
## Summary
- Fixes #1146.
- Renders full Telegram ask/clarify option text in the message body instead of relying on long inline-keyboard labels that Telegram mobile truncates.
- Uses compact numeric inline-keyboard tap targets while preserving one-based display ordering and zero-based callback/answer semantics.
- Applies the same rendering path to the reference client and daemon alias-backed Telegram delivery.

## Verification
- `bun test packages/coding-agent/test/notifications-html-format.test.ts packages/coding-agent/test/notifications-telegram-reference.test.ts` — 40 pass, 0 fail, 85 expect calls.
- LSP diagnostics OK for `html-format.ts`, `telegram-reference.ts`, and `telegram-daemon.ts`.
- `bunx biome check --write ...` on the five changed files.
- `bun run test:ts -- packages/coding-agent/test/notifications-html-format.test.ts packages/coding-agent/test/notifications-telegram-reference.test.ts` was attempted first, but the workspace runner broadcast the path filters to unrelated workspace tests and failed on unrelated missing/native workspace setup; reran the focused `bun test` command directly successfully.

## Notes
- This repo owns Telegram Bot API inline-keyboard rendering rather than the native Telegram composer UI. Composer overlap is mitigated by reducing keyboard height via compact numeric buttons and moving full readable option text into the scrollable message body.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*