### PR TITLE
fix(tui): preserve composer placeholder with IME cursor

### DIFF
--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -4,6 +4,7 @@ import { stripVTControlCharacters } from "node:util";
 import { Agent } from "@gajae-code/agent-core";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { initTheme, theme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { CURSOR_MARKER } from "@gajae-code/tui";
 import { TempDir } from "@gajae-code/utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import { CustomEditor } from "../src/modes/components/custom-editor";
@@ -13,6 +14,9 @@ import { AuthStorage } from "../src/session/auth-storage";
 import { SessionManager } from "../src/session/session-manager";
 
 class TestModalEditor extends CustomEditor {}
+function stripRenderControls(line: string): string {
+	return stripVTControlCharacters(line.replaceAll(CURSOR_MARKER, ""));
+}
 
 describe("InteractiveMode.setEditorComponent", () => {
 	let tempDir: TempDir;
@@ -61,7 +65,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 	});
 
 	it("renders the default composer as a closed rounded input box", () => {
-		const lines = mode.editor.render(48).map(line => stripVTControlCharacters(line));
+		const lines = mode.editor.render(48).map(stripRenderControls);
 
 		expect(lines[0]).toStartWith("╭");
 		expect(lines[0]).toEndWith("╮");
@@ -79,7 +83,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 	it("shows busy steering and queueing hints only while work is active", () => {
 		let rendered = mode.editor
 			.render(96)
-			.map(line => stripVTControlCharacters(line))
+			.map(stripRenderControls)
 			.join("\n");
 		expect(rendered).toContain("Type your message...");
 		expect(rendered).not.toContain("Enter: Steering");
@@ -90,7 +94,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 
 		rendered = mode.editor
 			.render(96)
-			.map(line => stripVTControlCharacters(line))
+			.map(stripRenderControls)
 			.join("\n");
 		expect(rendered).toContain("Type your message...");
 		expect(rendered).toContain("Enter: Steering");
@@ -101,7 +105,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 
 		rendered = mode.editor
 			.render(96)
-			.map(line => stripVTControlCharacters(line))
+			.map(stripRenderControls)
 			.join("\n");
 		expect(rendered).toContain("Type your message...");
 		expect(rendered).not.toContain("Enter: Steering");
@@ -113,7 +117,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 
 		await mode.init();
 
-		const rendered = mode.ui.render(48).map(line => stripVTControlCharacters(line));
+		const rendered = mode.ui.render(48).map(stripRenderControls);
 		const composerContentIndex = rendered.findIndex(line => line.includes("Type your message..."));
 		const composerIndex = composerContentIndex - 1;
 
@@ -128,7 +132,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 			[28, "narrow terminal composer"],
 		] as const) {
 			mode.editor.setText(text);
-			const lines = mode.editor.render(width).map(line => stripVTControlCharacters(line));
+			const lines = mode.editor.render(width).map(stripRenderControls);
 
 			expect(lines[0]).toStartWith("╭");
 			expect(lines[0]).toEndWith("╮");
@@ -147,7 +151,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 		mode.updateEditorChrome();
 
 		expect(mode.editor.borderColor("x")).toBe(theme.fg("warning", "x"));
-		let lines = mode.editor.render(48).map(line => stripVTControlCharacters(line));
+		let lines = mode.editor.render(48).map(stripRenderControls);
 		expect(
 			lines.some(
 				line =>
@@ -162,13 +166,13 @@ describe("InteractiveMode.setEditorComponent", () => {
 		mode.updateEditorChrome();
 
 		expect(mode.editor.borderColor("x")).toBe(theme.getBashModeBorderColor()("x"));
-		lines = mode.editor.render(48).map(line => stripVTControlCharacters(line));
+		lines = mode.editor.render(48).map(stripRenderControls);
 		expect(lines.some(line => line.startsWith("│") && line.includes("shell") && line.includes("!!pwd"))).toBe(true);
 
 		mode.isBashMode = false;
 		mode.updateEditorChrome();
 
-		lines = mode.editor.render(48).map(line => stripVTControlCharacters(line));
+		lines = mode.editor.render(48).map(stripRenderControls);
 		expect(lines.some(line => line.startsWith("│") && line.includes(">") && line.includes("!!pwd"))).toBe(true);
 		expect(lines.join("\n")).not.toContain("shell");
 	});

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -833,7 +833,7 @@ export class Editor implements Component, Focusable {
 		// Compute inline hint text (dim ghost text after cursor)
 		const inlineHint = this.#getInlineHint();
 		const hintStyle = this.#theme.hintStyle ?? ((t: string) => `\x1b[2m${t}\x1b[0m`);
-		const showPlaceholder = this.#isEditorEmpty() && !inlineHint && !!this.#placeholder && !this.#useTerminalCursor;
+		const showPlaceholder = this.#isEditorEmpty() && !inlineHint && !!this.#placeholder;
 
 		for (let visibleIndex = 0; visibleIndex < visibleLayoutLines.length; visibleIndex++) {
 			const layoutLine = visibleLayoutLines[visibleIndex]!;
@@ -853,7 +853,9 @@ export class Editor implements Component, Focusable {
 			if (showPlaceholder) {
 				displayText = hintStyle(truncateToWidth(this.#placeholder ?? "", lineContentWidth));
 				displayWidth = Math.min(visibleWidth(this.#placeholder ?? ""), lineContentWidth);
-				hasCursor = false;
+				if (!this.#useTerminalCursor) {
+					hasCursor = false;
+				}
 			}
 
 			if (!borderVisible && displayWidth > lineContentWidth) {


### PR DESCRIPTION
## Summary
- Restore placeholder rendering when terminal cursor mode is active so the default coding-agent composer remains visible after PR #1150.
- Keep hardware cursor metadata (`CURSOR_MARKER`) for IME anchoring while treating it as non-visible render metadata in InteractiveMode assertions.

## Evidence
- `bun test packages/coding-agent/test/interactive-mode-editor-component.test.ts` => 6 pass, 0 fail, 48 expect calls.
- `CI_DEV_PLAN_MODE=push CI_DEV_CHANGED_PATHS='packages/coding-agent/test/interactive-mode-editor-component.test.ts,packages/tui/src/components/editor.ts' bun scripts/ci-dev-affected.ts --task='test:@gajae-code/coding-agent'` => 7551 tests, 359 skip, 0 fail, 37 snapshots, 38830 expect calls.\n- QA subagent: focused TUI terminal-cursor placeholder adversarial check passed; focused Korean IME/jamo cursor tests passed (7 pass, 0 fail, 17 expect calls).\n\nDev CI red is expected to recover because the failing InteractiveMode.setEditorComponent assertions now pass and the affected coding-agent test shard is green locally.\n\n—\n*[repo owner's gaebal-gajae (clawdbot) 🦞]*