### PR TITLE
fix(test): format composer render assertions

### DIFF
--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -81,10 +81,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 	}
 
 	it("shows busy steering and queueing hints only while work is active", () => {
-		let rendered = mode.editor
-			.render(96)
-			.map(stripRenderControls)
-			.join("\n");
+		let rendered = mode.editor.render(96).map(stripRenderControls).join("\n");
 		expect(rendered).toContain("Type your message...");
 		expect(rendered).not.toContain("Enter: Steering");
 		expect(rendered).not.toContain(expectedQueueShortcutHint());
@@ -92,10 +89,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = true;
 		mode.updateEditorChrome();
 
-		rendered = mode.editor
-			.render(96)
-			.map(stripRenderControls)
-			.join("\n");
+		rendered = mode.editor.render(96).map(stripRenderControls).join("\n");
 		expect(rendered).toContain("Type your message...");
 		expect(rendered).toContain("Enter: Steering");
 		expect(rendered).toContain(expectedQueueShortcutHint());
@@ -103,10 +97,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = false;
 		mode.updateEditorChrome();
 
-		rendered = mode.editor
-			.render(96)
-			.map(stripRenderControls)
-			.join("\n");
+		rendered = mode.editor.render(96).map(stripRenderControls).join("\n");
 		expect(rendered).toContain("Type your message...");
 		expect(rendered).not.toContain("Enter: Steering");
 		expect(rendered).not.toContain(expectedQueueShortcutHint());


### PR DESCRIPTION
Fixes the dev CI `check:@gajae-code/coding-agent` failure after #1152.

Evidence:
- `bunx biome check packages/coding-agent/test/interactive-mode-editor-component.test.ts packages/tui/src/components/editor.ts` → pass.
- The attempted focused test in this fresh worktree was blocked by missing local native addon artifacts (`pi_natives...node`), not by the formatter-only change; CI native-build provides those artifacts.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*