### PR TITLE
feat(tui): crab mascot welcome banner mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `mascot` option to `startup.welcomeBannerMode` that replaces the claw logo on the welcome screen with the Gajae crab mascot, reusing the existing red-claw gradient and intro animation and falling back to an ASCII-safe crab when the symbol preset is `ascii`.
+
 ## [0.7.3] - 2026-06-25
 
 ### Added

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -106,4 +106,4 @@ The startup logo defaults to rounded Unicode box drawing. Windows Terminal can r
 }
 ```
 
-For terminals or fonts with broken rounded corners, set `startup.welcomeBannerMode` in `~/.gjc/agent/config.yml` to one of `unicode`, `square`, or `ascii`. `square` keeps a Unicode-looking logo using square corners (`┌ ┐ └ ┘`) while `ascii` uses only `+`, `-`, and `|`.
+For terminals or fonts with broken rounded corners, set `startup.welcomeBannerMode` in `~/.gjc/agent/config.yml` to one of `unicode`, `square`, or `ascii`. `square` keeps a Unicode-looking logo using square corners (`┌ ┐ └ ┘`) while `ascii` uses only `+`, `-`, and `|`. Set it to `mascot` to swap the claw logo for the Gajae crab mascot on the welcome screen; the crab follows your symbol preset, falling back to an ASCII-safe crab when the preset is `ascii`.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1087,7 +1087,7 @@ export const SETTINGS_SCHEMA = {
 
 	"startup.welcomeBannerMode": {
 		type: "enum",
-		values: ["auto", "unicode", "square", "ascii"] as const,
+		values: ["auto", "unicode", "square", "ascii", "mascot"] as const,
 		default: "auto",
 		ui: {
 			tab: "interaction",
@@ -1098,6 +1098,7 @@ export const SETTINGS_SCHEMA = {
 				{ value: "unicode", label: "Unicode", description: "Force the rounded Unicode logo" },
 				{ value: "square", label: "Square Unicode", description: "Force the square-corner Unicode fallback" },
 				{ value: "ascii", label: "ASCII", description: "Force the ASCII-safe logo" },
+				{ value: "mascot", label: "Crab Mascot", description: "Show the Gajae crab mascot instead of the logo" },
 			],
 		},
 	},

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -13,7 +13,7 @@ export interface LspServerInfo {
 	fileTypes: string[];
 }
 
-export type WelcomeLogoMode = "unicode" | "square" | "ascii";
+export type WelcomeLogoMode = "unicode" | "square" | "ascii" | "mascot";
 
 /**
  * GJC-native launch surface with compact command affordances, project
@@ -261,9 +261,9 @@ export class WelcomeComponent implements Component {
 
 	/** Pick the logo frame for the current intro phase, or the resting frame. */
 	#currentLogoFrame(logoLines: readonly string[]): readonly string[] {
-		if (this.#animStart == null) return REST_FRAMES[this.logoMode];
+		if (this.#animStart == null) return this.#restFrame();
 		const elapsed = performance.now() - this.#animStart;
-		if (elapsed >= INTRO_MS) return REST_FRAMES[this.logoMode];
+		if (elapsed >= INTRO_MS) return this.#restFrame();
 		// Ease-out cubic so the spin decelerates into the resting state.
 		const progress = elapsed / INTRO_MS;
 		const eased = 1 - (1 - progress) ** 3;
@@ -278,7 +278,18 @@ export class WelcomeComponent implements Component {
 		return gradientLogo(logoLines, phase, { strength: shineStrength, pos: shinePos });
 	}
 
+	/** Resting (settled) gradient frame for the active logo mode. */
+	#restFrame(): readonly string[] {
+		if (this.logoMode === "mascot") {
+			return theme.getSymbolPreset() === "ascii" ? ASCII_CRAB_REST : RED_CRAB_REST;
+		}
+		return REST_FRAMES[this.logoMode];
+	}
+
 	#logoLines(): readonly string[] {
+		if (this.logoMode === "mascot") {
+			return theme.getSymbolPreset() === "ascii" ? ASCII_CRAB_MASCOT : RED_CRAB_MASCOT;
+		}
 		if (this.logoMode === "ascii") return ASCII_CLAW_LOGO;
 		if (this.logoMode === "square") return SQUARE_CLAW_LOGO;
 		return RED_CLAW_LOGO;
@@ -313,6 +324,26 @@ const ASCII_CLAW_LOGO = [
 	"       +------+    +---+  +--+      ",
 	"+------+      +--+     +--+  +-----+",
 	"+----------------+        +--------+",
+];
+
+// biome-ignore format: preserve crab mascot layout
+const RED_CRAB_MASCOT = [
+	"   __         __   ",
+	"  /  \\  ___  /  \\  ",
+	"  \\   \\(o o)/   /  ",
+	"   \\___\\ ‿ /___/   ",
+	"   /   /   \\   \\   ",
+	"  /___/     \\___\\  ",
+];
+
+// biome-ignore format: preserve crab mascot layout
+const ASCII_CRAB_MASCOT = [
+	"   __         __   ",
+	"  /  \\  ___  /  \\  ",
+	"  \\   \\(o o)/   /  ",
+	"   \\___\\ _ /___/   ",
+	"   /   /   \\   \\   ",
+	"  /___/     \\___\\  ",
 ];
 
 /** Multi-stop palette for the red-claw diagonal gradient. */
@@ -413,9 +444,13 @@ const INTRO_SWEEPS = 2.5;
 /** Number of times the shine highlight crosses the diagonal across the intro. */
 const INTRO_SHINE_TRAVERSALS = 3;
 
-/** Resting gradient frames, cached for re-renders outside of the intro. */
-const REST_FRAMES: Record<WelcomeLogoMode, readonly string[]> = {
+/** Resting gradient frames for the claw logos, cached for re-renders outside of the intro. */
+const REST_FRAMES: Record<"unicode" | "square" | "ascii", readonly string[]> = {
 	unicode: gradientLogo(RED_CLAW_LOGO, 0),
 	square: gradientLogo(SQUARE_CLAW_LOGO, 0),
 	ascii: gradientLogo(ASCII_CLAW_LOGO, 0),
 };
+
+/** Resting crab-mascot frames, selected by the active symbol preset at render time. */
+const RED_CRAB_REST = gradientLogo(RED_CRAB_MASCOT, 0);
+const ASCII_CRAB_REST = gradientLogo(ASCII_CRAB_MASCOT, 0);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -240,7 +240,7 @@ function parseGoalSubcommand(args: string): { sub: GoalSubcommand | undefined; r
 	return { sub: undefined, rest: trimmed };
 }
 
-export type WelcomeBannerSettingMode = "auto" | "unicode" | "square" | "ascii";
+export type WelcomeBannerSettingMode = "auto" | "unicode" | "square" | "ascii" | "mascot";
 
 export function resolveWelcomeLogoMode(
 	mode: WelcomeBannerSettingMode,
@@ -252,6 +252,7 @@ export function resolveWelcomeLogoMode(
 	if (mode === "unicode") return "unicode";
 	if (mode === "square") return "square";
 	if (mode === "ascii") return "ascii";
+	if (mode === "mascot") return "mascot";
 	return "unicode";
 }
 

--- a/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
+++ b/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
@@ -156,6 +156,23 @@ describe("redesigned interactive shell chrome", () => {
 		}
 	});
 
+	it("renders the Gajae crab mascot welcome banner when requested", () => {
+		const component = new WelcomeComponent("1.2.3", "gpt-5.5", "openai", [], [], "mascot");
+		const lines = component.render(54);
+		const rendered = Bun.stripANSI(lines.join("\n"));
+
+		// Face + legs are identical across the unicode/ascii crab variants.
+		expect(rendered).toContain("(o o)");
+		expect(rendered).toContain("/___/");
+		expect(rendered).toContain("__         __");
+		// The crab replaces the claw logo, not augments it.
+		expect(rendered).not.toContain("╭────────────────╮");
+		expect(rendered).not.toContain("+----------------+");
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(54);
+		}
+	});
+
 	it("resolves welcome banner auto and manual override modes", () => {
 		expect(resolveWelcomeLogoMode("auto", { WT_SESSION: "session-id" }, "win32")).toBe("unicode");
 		expect(resolveWelcomeLogoMode("auto", { WT_SESSION: "session-id" }, "linux")).toBe("unicode");
@@ -163,6 +180,8 @@ describe("redesigned interactive shell chrome", () => {
 		expect(resolveWelcomeLogoMode("unicode", { WT_SESSION: "session-id" }, "win32")).toBe("unicode");
 		expect(resolveWelcomeLogoMode("square", { WT_SESSION: "session-id" }, "win32")).toBe("square");
 		expect(resolveWelcomeLogoMode("ascii", {}, "linux")).toBe("ascii");
+		expect(resolveWelcomeLogoMode("mascot", {}, "linux")).toBe("mascot");
+		expect(resolveWelcomeLogoMode("mascot", { WT_SESSION: "session-id" }, "win32")).toBe("mascot");
 	});
 
 	it("renders the live composer as a borderless opencode-style prompt", () => {

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -775,7 +775,8 @@
 						"auto",
 						"unicode",
 						"square",
-						"ascii"
+						"ascii",
+						"mascot"
 					],
 					"description": "Logo style for the startup welcome screen",
 					"default": "auto"


### PR DESCRIPTION
## What

Adds a `mascot` option to `startup.welcomeBannerMode` that swaps the claw logo on the welcome screen for the **Gajae crab mascot** — a first-screen mascot in the spirit of Claude Code's launch surface. It reuses the existing red-claw diagonal gradient and intro sweep animation, so the crab gets the same animated shimmer the claw logo already has.

## Why

The welcome screen already animates a claw mark. A friendly crab mascot makes the first screen feel more like the project's crustacean identity (`red-claw` / `blue-crab`) without copying another agent's shell. It's fully opt-in, so the default launch surface is unchanged.

## Preview

Unicode (`startup.welcomeBannerMode: mascot`):

```
╭─── gjc v0.7.3 · GJC forge ─────────────────────────────────────────╮
│                       │ Flow keys                                  │
│      Gajae forge      │ / commands · # actions                     │
│  shape · act · prove  │ ! shell · $ python                         │
│                       │ ? keymap · ctrl+l model                    │
│     __         __     │ shift+tab reasoning                        │
│    /  \  ___  /  \    │ ────────────────────────────────────────── │
│    \   \(o o)/   /    │ Project pulse                              │
│     \___\ ‿ /___/     │ ✔ tsserver ts tsx                          │
│     /   /   \   \     │ ────────────────────────────────────────── │
│    /___/     \___\    │ Session trail                              │
│                       │ ▸ refactor-auth (2h)                       │
│   [ ⬢ claude-opus ]   │                                            │
│   [ 📦 anthropic ]    │                                            │
╰───────────────────────┴────────────────────────────────────────────╯
```

ASCII fallback (auto-selected when the symbol preset is `ascii`):

```
|   __         __   |
|  /  \  ___  /  \  |
|  \   \(o o)/   /  |
|   \___\ _ /___/   |
|   /   /   \   \   |
|  /___/     \___\  |
```

## Changes

- `welcome.ts`: new `WelcomeLogoMode` value `"mascot"`, `RED_CRAB_MASCOT` / `ASCII_CRAB_MASCOT` art, and preset-aware `#restFrame()` / `#logoLines()`. `REST_FRAMES` is narrowed to the claw modes; the crab rest frames are precomputed separately and selected by `theme.getSymbolPreset()` at render time.
- `interactive-mode.ts`: `WelcomeBannerSettingMode` + `resolveWelcomeLogoMode` support for `mascot`.
- `settings-schema.ts`: `"mascot"` enum value and a `Crab Mascot` settings option; regenerated `schemas/config.schema.json`.
- Tests: render test (`(o o)` / `/___/` face+legs, claw logos absent, width-bounded) and `resolveWelcomeLogoMode("mascot") === "mascot"` in `redesigned-shell.test.ts`.
- Docs: README banner note + CHANGELOG entry.

## Verification

- `bun test` welcome/redesigned-shell/settings/json-schema suites — pass
- `bun run check:schemas` — clean
- `bun run check:types` (coding-agent) — clean
- `biome check` on changed files — clean

Default behavior is unchanged: `auto` still resolves to the rounded Unicode claw logo.
