### PR TITLE
docs(notice): credit fivetaku/insane-search (vendored engine behind insane fallback)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -5,3 +5,4 @@ Gajae-Code builds on lessons from a small family of agent harnesses and keeps at
 - [`oh-my-pi`](https://github.com/can1357/oh-my-pi) — the upstream red-claw lineage and implementation DNA.
 - [`oh-my-codex`](https://github.com/Yeachan-Heo/oh-my-codex) — Codex-focused orchestration experiments.
 - [`oh-my-claudecode`](https://github.com/Yeachan-Heo/oh-my-claudecode) — Claude Code workflow exploration.
+- [`insane-search`](https://github.com/fivetaku/insane-search) — the vendored Phase 0→3 fetch engine behind the `insane` fallback.


### PR DESCRIPTION
The `insane` read-fallback + search provider added in **v0.7.2** vendor the Phase 0→3 fetch engine from [`fivetaku/insane-search`](https://github.com/fivetaku/insane-search) (MIT), pinned at `49306346`. The vendor `MANIFEST.json` and bundled `LICENSE` already record this 🙏 — but the top-level `NOTICE.md` (the canonical attribution list) doesn't yet. This adds one line.

**Receipts (the three the maintainer asked for)**
- **Original repo:** [fivetaku/insane-search](https://github.com/fivetaku/insane-search) — engine history predates the 2026-06-23 vendor
- **Vendor PR:** [#1032](https://github.com/Yeachan-Heo/gajae-code/pull/1032) (`packages/coding-agent/vendor/insane-search/` @ `49306346`), companion provider [#1020](https://github.com/Yeachan-Heo/gajae-code/pull/1020)
- **Credit location:** `NOTICE.md` (this PR) + v0.7.2 release notes

Attribution only — no code or behavior change. I'm [@fivetaku](https://github.com/fivetaku), the upstream author. 🦞
