### PR TITLE
fix(ask): keep wheel for transcript and add question scroll affordance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Deep Interview (and any scrollable `ask`/hook selector) no longer enables SGR mouse reporting, which was hijacking the mouse wheel and disabling the terminal's native scrollback while a question was on screen. The wheel now scrolls the terminal as usual; long questions still scroll inside the dialog via PgUp/PgDn.
+- Scrollable Deep Interview question boxes now show explicit `▲ more` / `▼ more` affordances when hidden question text exists, and selector mode also supports Ctrl+u/Ctrl+d as question-scroll aliases for PgUp/PgDn.
+
 ## [0.7.3] - 2026-06-25
 
 ### Added

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -28,22 +28,6 @@ import { getEditorCommand, openInEditor } from "../../utils/external-editor";
 import { CountdownTimer } from "./countdown-timer";
 import { DynamicBorder } from "./dynamic-border";
 
-const SGR_MOUSE_PRESS_PATTERN = /^\x1b\[<(\d+);\d+;\d+M$/;
-const MOUSE_WHEEL_TITLE_SCROLL_ROWS = 3;
-
-function getMouseWheelTitleScrollRows(keyData: string): number {
-	const match = SGR_MOUSE_PRESS_PATTERN.exec(keyData);
-	if (!match) return 0;
-
-	const button = Number.parseInt(match[1] ?? "", 10);
-	if (!Number.isFinite(button) || (button & 64) === 0) return 0;
-
-	const wheelDirection = button & 3;
-	if (wheelDirection === 0) return -MOUSE_WHEEL_TITLE_SCROLL_ROWS;
-	if (wheelDirection === 1) return MOUSE_WHEEL_TITLE_SCROLL_ROWS;
-	return 0;
-}
-
 export interface HookSelectorOptions {
 	tui?: TUI;
 	timeout?: number;
@@ -132,26 +116,58 @@ class ScrollableTitle extends Container {
 
 	render(width: number): string[] {
 		const lines = this.#markdown.render(width);
-		const maxScrollOffset = Math.max(0, lines.length - this.#maxRows);
-		this.#lastMaxScrollOffset = maxScrollOffset;
-		this.#scrollOffset = Math.max(0, Math.min(this.#scrollOffset, maxScrollOffset));
+		if (lines.length <= this.#maxRows) {
+			this.#lastMaxScrollOffset = 0;
+			this.#scrollOffset = 0;
+			return lines;
+		}
 
-		const visibleLines = lines.slice(this.#scrollOffset, this.#scrollOffset + this.#maxRows);
-		if (maxScrollOffset === 0 || visibleLines.length === 0) {
+		if (this.#maxRows < 3) {
+			const maxScrollOffset = Math.max(0, lines.length - this.#maxRows);
+			this.#lastMaxScrollOffset = maxScrollOffset;
+			this.#scrollOffset = Math.max(0, Math.min(this.#scrollOffset, maxScrollOffset));
+
+			const visibleLines = lines.slice(this.#scrollOffset, this.#scrollOffset + this.#maxRows);
+			const indicator =
+				this.#scrollOffset === 0
+					? theme.fg("dim", " PgDn↓")
+					: this.#scrollOffset >= maxScrollOffset
+						? theme.fg("dim", " PgUp↑")
+						: theme.fg("dim", " PgUp/PgDn↕");
+			const lastIndex = visibleLines.length - 1;
+			const availableWidth = Math.max(1, width - visibleWidth(indicator));
+			const fittedLine = truncateToWidth(visibleLines[lastIndex] ?? "", availableWidth);
+			visibleLines[lastIndex] = `${fittedLine}${indicator}`;
 			return visibleLines;
 		}
 
-		const indicator =
-			this.#scrollOffset === 0
-				? theme.fg("dim", " PgDn↓")
-				: this.#scrollOffset >= maxScrollOffset
-					? theme.fg("dim", " PgUp↑")
-					: theme.fg("dim", " PgUp/PgDn↕");
-		const lastIndex = visibleLines.length - 1;
-		const availableWidth = Math.max(1, width - visibleWidth(indicator));
-		const fittedLine = truncateToWidth(visibleLines[lastIndex] ?? "", availableWidth);
-		visibleLines[lastIndex] = `${fittedLine}${indicator}`;
-		return visibleLines;
+		let showTopIndicator = this.#scrollOffset > 0;
+		let showBottomIndicator = true;
+		let contentRows = 1;
+		let maxScrollOffset = 0;
+
+		for (let i = 0; i < 4; i++) {
+			contentRows = Math.max(1, this.#maxRows - (showTopIndicator ? 1 : 0) - (showBottomIndicator ? 1 : 0));
+			maxScrollOffset = Math.max(0, lines.length - contentRows);
+			this.#scrollOffset = Math.max(0, Math.min(this.#scrollOffset, maxScrollOffset));
+
+			const nextShowTopIndicator = this.#scrollOffset > 0;
+			const nextShowBottomIndicator = this.#scrollOffset + contentRows < lines.length;
+			if (nextShowTopIndicator === showTopIndicator && nextShowBottomIndicator === showBottomIndicator) {
+				break;
+			}
+			showTopIndicator = nextShowTopIndicator;
+			showBottomIndicator = nextShowBottomIndicator;
+		}
+
+		this.#lastMaxScrollOffset = maxScrollOffset;
+
+		const visibleLines = lines.slice(this.#scrollOffset, this.#scrollOffset + contentRows);
+		const result: string[] = [];
+		if (showTopIndicator) result.push(theme.fg("dim", truncateToWidth("▲ more", width)));
+		result.push(...visibleLines);
+		if (showBottomIndicator) result.push(theme.fg("dim", truncateToWidth("▼ more", width)));
+		return result.slice(0, this.#maxRows);
 	}
 }
 
@@ -454,18 +470,19 @@ export class HookSelectorComponent extends Container {
 		// Reset countdown on any interaction
 		this.#countdown?.reset();
 
-		if (this.#scrollTitleRows !== undefined) {
-			const wheelRows = getMouseWheelTitleScrollRows(keyData);
-			if (wheelRows !== 0) {
-				this.#scrollableTitle?.scrollBy(wheelRows);
-				return;
-			}
-		}
 		if (this.#scrollTitleRows !== undefined && matchesKey(keyData, "pageUp")) {
 			this.#scrollableTitle?.scrollBy(-this.#scrollTitleRows);
 			return;
 		}
 		if (this.#scrollTitleRows !== undefined && matchesKey(keyData, "pageDown")) {
+			this.#scrollableTitle?.scrollBy(this.#scrollTitleRows);
+			return;
+		}
+		if (!this.#inlineEditor && this.#scrollTitleRows !== undefined && matchesKey(keyData, "ctrl+u")) {
+			this.#scrollableTitle?.scrollBy(-this.#scrollTitleRows);
+			return;
+		}
+		if (!this.#inlineEditor && this.#scrollTitleRows !== undefined && matchesKey(keyData, "ctrl+d")) {
 			this.#scrollableTitle?.scrollBy(this.#scrollTitleRows);
 			return;
 		}
@@ -543,10 +560,11 @@ export class HookSelectorComponent extends Container {
 		this.#inlineEditor = editor;
 		this.#inputArea.addChild(new Spacer(1));
 		this.#inputArea.addChild(editor);
-		const scrollHint = this.#scrollTitleRows === undefined ? "" : "  wheel/PgUp/PgDn scroll question";
-		this.#helpTextComponent.setText(
-			theme.fg("dim", `enter submit  esc back to options  ctrl+g external editor${scrollHint}`),
-		);
+		const helpText =
+			this.#scrollTitleRows === undefined
+				? "enter submit  esc back to options  ctrl+g external editor"
+				: "enter submit  esc back to options  PgUp/PgDn: question · Wheel: transcript";
+		this.#helpTextComponent.setText(theme.fg("dim", helpText));
 		this.invalidate();
 	}
 

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -25,8 +25,6 @@ import type { InteractiveModeContext } from "../../modes/types";
 import { setSessionTerminalTitle, setTerminalTitle } from "../../utils/title-generator";
 
 const MAX_WIDGET_LINES = 10;
-const HOOK_SELECTOR_MOUSE_REPORTING_ENABLE = "\x1b[?1006h\x1b[?1000h";
-const HOOK_SELECTOR_MOUSE_REPORTING_DISABLE = "\x1b[?1000l\x1b[?1006l";
 const HOOK_SELECTOR_CHROME_ROWS = 7;
 const HOOK_SELECTOR_OUTLINE_ROWS = 2;
 const HOOK_SELECTOR_INLINE_INPUT_ROWS = 2;
@@ -35,7 +33,6 @@ export class ExtensionUiController {
 	#extensionTerminalInputUnsubscribers = new Set<() => void>();
 	#hookWidgetsAbove = new Map<string, ExtensionUiComponent>();
 	#hookWidgetsBelow = new Map<string, ExtensionUiComponent>();
-	#hookSelectorMouseReportingEnabled = false;
 	#activeHookCustomComponent?: Component & { dispose?(): void };
 	#activeHookCustomOverlay?: OverlayHandle;
 
@@ -624,9 +621,6 @@ export class ExtensionUiController {
 			this.ctx.ui.terminal.rows - scrollOptionRows - listChromeRows - inlineInputRows - HOOK_SELECTOR_CHROME_ROWS;
 		const scrollTitleRows =
 			requestedTitleRows === undefined ? undefined : Math.max(1, Math.min(requestedTitleRows, availableTitleRows));
-		if (scrollTitleRows !== undefined) {
-			this.#enableHookSelectorMouseReporting();
-		}
 
 		this.ctx.hookSelector = new HookSelectorComponent(
 			title,
@@ -691,31 +685,10 @@ export class ExtensionUiController {
 		return promise;
 	}
 
-	#enableHookSelectorMouseReporting(): void {
-		if (this.#hookSelectorMouseReportingEnabled) return;
-		this.#hookSelectorMouseReportingEnabled = true;
-		this.#writeTerminalControl(HOOK_SELECTOR_MOUSE_REPORTING_ENABLE);
-	}
-
-	#disableHookSelectorMouseReporting(): void {
-		if (!this.#hookSelectorMouseReportingEnabled) return;
-		this.#hookSelectorMouseReportingEnabled = false;
-		this.#writeTerminalControl(HOOK_SELECTOR_MOUSE_REPORTING_DISABLE);
-	}
-
-	#writeTerminalControl(sequence: string): void {
-		try {
-			this.ctx.ui.terminal.write(sequence);
-		} catch {
-			// Terminal teardown can race selector cleanup; normal shutdown restores modes.
-		}
-	}
-
 	/**
 	 * Hide the hook selector.
 	 */
 	hideHookSelector(): void {
-		this.#disableHookSelectorMouseReporting();
 		this.ctx.hookSelector?.dispose();
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(this.ctx.editor);

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -260,7 +260,11 @@ async function askSingleQuestion(
 			? "up/down navigate  enter select  ←/→ question  esc cancel"
 			: "up/down navigate  enter select  esc cancel";
 		const helpText =
-			scrollTitleRows === undefined ? baseHelpText : `${baseHelpText}  wheel/PgUp/PgDn scroll question`;
+			scrollTitleRows === undefined
+				? baseHelpText
+				: navigation
+					? "↑/↓ select  enter  ←/→ question  esc  PgUp/PgDn/Ctrl+u/d: question · Wheel: transcript"
+					: "↑/↓ select  enter  esc  PgUp/PgDn/Ctrl+u/d: question · Wheel: transcript";
 		const dialogOptions = {
 			initialIndex,
 			timeout,

--- a/packages/coding-agent/test/hook-editor.test.ts
+++ b/packages/coding-agent/test/hook-editor.test.ts
@@ -415,14 +415,17 @@ describe("ExtensionUiController hook editor abort", () => {
 		const rendered = Bun.stripANSI(ctx.hookSelector!.render(80).join("\n"));
 		const lines = rendered.split("\n");
 		expect(lines).toHaveLength(30);
-		expect(rendered).toContain("Prompt row 18");
-		expect(rendered).not.toContain("Prompt row 19");
+		expect(rendered).toContain("Prompt row 17");
+		expect(rendered).not.toContain("Prompt row 18");
+		expect(rendered).toContain("▼ more");
 		expect(rendered).toContain("Alpha");
 		expect(rendered).toContain("Gamma");
-		expect(ui.terminal.write).toHaveBeenCalledWith("\x1b[?1006h\x1b[?1000h");
+		// Scrollable selectors must NOT enable SGR mouse reporting: doing so would hijack the
+		// terminal's native wheel/scrollbar scrollback. The question scrolls via PgUp/PgDn only.
+		expect(ui.terminal.write).not.toHaveBeenCalledWith("\x1b[?1006h\x1b[?1000h");
 
 		ctx.hookSelector!.handleInput("\n");
 		expect(await promise).toBe("Alpha");
-		expect(ui.terminal.write).toHaveBeenCalledWith("\x1b[?1000l\x1b[?1006l");
+		expect(ui.terminal.write).not.toHaveBeenCalledWith("\x1b[?1000l\x1b[?1006l");
 	});
 });

--- a/packages/coding-agent/test/hook-selector-overflow.test.ts
+++ b/packages/coding-agent/test/hook-selector-overflow.test.ts
@@ -343,7 +343,7 @@ describe("HookSelectorComponent", () => {
 				wrapFocused: true,
 				scrollTitleRows: 3,
 				maxVisible: 2,
-				helpText: "up/down navigate  enter select  esc cancel  wheel/PgUp/PgDn scroll question",
+				helpText: "↑/↓ select  enter  esc  PgUp/PgDn/Ctrl+u/d: question · Wheel: transcript",
 			},
 		);
 
@@ -353,8 +353,9 @@ describe("HookSelectorComponent", () => {
 		expect(titleRows.length).toBeLessThanOrEqual(3);
 		expect(rendered).toContain("answer-a");
 		expect(rendered).toContain("answer-b");
-		expect(rendered).toContain("wheel/PgUp/PgDn scroll question");
-		expect(rendered).toContain("PgDn");
+		expect(rendered).toContain("PgUp/PgDn/Ctrl+u/d: question");
+		expect(rendered).toContain("Wheel: transcript");
+		expect(rendered).toContain("▼ more");
 	});
 
 	it("uses selector-local PageUp/PageDown for title scrolling without moving option focus", () => {
@@ -388,9 +389,8 @@ describe("HookSelectorComponent", () => {
 		const afterPageUp = Bun.stripANSI(component.render(56).join("\n"));
 		expect(afterPageUp).toContain("Question segment 1");
 	});
-
-	it("uses mouse wheel events for title scrolling without moving option focus", () => {
-		const title = Array.from({ length: 8 }, (_, index) => `Wheel segment ${index + 1}`).join("\n\n");
+	it("uses selector-local Ctrl+u/Ctrl+d aliases for title scrolling without moving option focus", () => {
+		const title = Array.from({ length: 8 }, (_, index) => `Ctrl segment ${index + 1}`).join("\n\n");
 		let selected: string | undefined;
 		const component = new HookSelectorComponent(
 			title,
@@ -403,21 +403,20 @@ describe("HookSelectorComponent", () => {
 		);
 
 		const initial = Bun.stripANSI(component.render(56).join("\n"));
-		expect(initial).toContain("Wheel segment 1");
-		expect(initial).not.toContain("Wheel segment 8");
-		expect(initial).toContain("first-choice");
+		expect(initial).toContain("Ctrl segment 1");
+		expect(initial).not.toContain("Ctrl segment 8");
 
-		for (let i = 0; i < 8; i++) component.handleInput("\x1b[<65;10;5M");
-		const afterWheelDown = Bun.stripANSI(component.render(56).join("\n"));
-		expect(afterWheelDown).not.toContain("Wheel segment 1");
-		expect(afterWheelDown).toContain("Wheel segment 8");
-		expect(afterWheelDown).toContain("first-choice");
+		for (let i = 0; i < 8; i++) component.handleInput("\x04");
+		const afterCtrlD = Bun.stripANSI(component.render(56).join("\n"));
+		expect(afterCtrlD).not.toContain("Ctrl segment 1");
+		expect(afterCtrlD).toContain("Ctrl segment 8");
+		expect(afterCtrlD).toContain("first-choice");
 
 		component.handleInput("\n");
 		expect(selected).toBe("first-choice");
 
-		for (let i = 0; i < 8; i++) component.handleInput("\x1b[<64;10;5M");
-		const afterWheelUp = Bun.stripANSI(component.render(56).join("\n"));
-		expect(afterWheelUp).toContain("Wheel segment 1");
+		for (let i = 0; i < 8; i++) component.handleInput("\x15");
+		const afterCtrlU = Bun.stripANSI(component.render(56).join("\n"));
+		expect(afterCtrlU).toContain("Ctrl segment 1");
 	});
 });

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1448,7 +1448,8 @@ describe("AskTool deep-interview rendering middleware", () => {
 
 		const dialogOptions = select.mock.calls[0]?.[2];
 		expect(dialogOptions?.scrollTitleRows).toBe(Number.MAX_SAFE_INTEGER);
-		expect(dialogOptions?.helpText).toContain("wheel/PgUp/PgDn scroll question");
+		expect(dialogOptions?.helpText).toContain("PgUp/PgDn/Ctrl+u/d: question");
+		expect(dialogOptions?.helpText).toContain("Wheel: transcript");
 	});
 
 	it("opts structured deep-interview questions into local prompt scrolling", async () => {
@@ -1493,7 +1494,8 @@ describe("AskTool deep-interview rendering middleware", () => {
 
 		const dialogOptions = select.mock.calls[0]?.[2];
 		expect(dialogOptions?.scrollTitleRows).toBe(Number.MAX_SAFE_INTEGER);
-		expect(dialogOptions?.helpText).toContain("wheel/PgUp/PgDn scroll question");
+		expect(dialogOptions?.helpText).toContain("PgUp/PgDn/Ctrl+u/d: question");
+		expect(dialogOptions?.helpText).toContain("Wheel: transcript");
 	});
 
 	it("Restate gate displays numbered selector labels while returning the raw selected label", async () => {


### PR DESCRIPTION
## Problem

Entering Deep Interview broke mouse-wheel scrolling: the wheel no longer scrolled the terminal transcript, and you had to drag the terminal's scrollbar instead.

## Mental model

The default, consistent terminal mental model is:

- **Wheel / terminal scrollbar = transcript scrollback**
- **PgUp/PgDn = current Deep Interview question box scroll**

Users expect the mouse wheel to scroll terminal history. When Deep Interview hijacks the wheel, it feels like the terminal is broken.

## Root cause

Deep Interview asks set `scrollTitleRows`, which made `ExtensionUiController` enable SGR mouse reporting (`\x1b[?1006h\x1b[?1000h`) for the lifetime of the dialog. With mouse reporting on, the terminal forwards wheel events to the app instead of scrolling its own scrollback. The app only used those events to nudge the in-dialog question box 3 rows at a time.

## Fix

Implement the selected direction from #1160: **Option A + stronger affordance + auxiliary keybindings**.

- Remove `HOOK_SELECTOR_MOUSE_REPORTING` enable/disable plumbing from `ExtensionUiController`.
- Remove the SGR wheel parser and wheel branch from `HookSelectorComponent`.
- Preserve the #259 layout fix: long questions are still clamped into a scrollable box and options stay visible.
- Keep PgUp/PgDn question-box scrolling.
- Add selector-mode Ctrl+u/Ctrl+d aliases for question scrolling (Mac-friendly fallback for PgUp/PgDn).
- Add explicit `▲ more` / `▼ more` affordances inside overflowing question boxes.
- Update scrollable selector footer copy to spell out the model: question-scroll keys vs transcript wheel.

The terminal's defensive mouse-mode reset on teardown (`terminal.ts`) is left in place.

## Tests

- Scrollable selectors assert mouse reporting is **not** written (`hook-editor.test.ts`).
- Long question boxes now assert explicit `▼ more` affordance (`hook-editor.test.ts`, `hook-selector-overflow.test.ts`).
- PgUp/PgDn title-scroll coverage remains.
- Ctrl+u/Ctrl+d selector-local title-scroll coverage added.
- Help-text wording expectations updated (`ask.test.ts`, `hook-selector-overflow.test.ts`).

## Verification

- `bun test packages/coding-agent/test/hook-selector-overflow.test.ts packages/coding-agent/test/hook-editor.test.ts packages/coding-agent/test/hook-selector-inline-input.test.ts packages/coding-agent/test/tools/ask.test.ts` -> 92 pass.
- `biome check` clean on all changed files.
- `bun --cwd=packages/coding-agent run check:types` -> exit 0.

Supersedes #1158, which GitHub would not reopen after it was closed while the trade-off was being discussed.