### PR TITLE
fix(notifications): delete Telegram topics on session shutdown

### DIFF
--- a/crates/gjc-notifications/src/protocol.rs
+++ b/crates/gjc-notifications/src/protocol.rs
@@ -179,6 +179,9 @@ pub enum ServerMessage {
 	/// Replayable readiness signal: the session is up and surfaced. Buffered
 	/// and replayed to late clients so WS-open alone never implies readiness.
 	SessionReady(SessionReady),
+	/// Session endpoint teardown signal for clients that maintain per-session
+	/// surfaces.
+	SessionClosed(SessionClosed),
 	/// Application-level liveness response to a client ping.
 	Pong(Pong),
 	/// Forward-compat: an unrecognized frame type. Tolerated, never emitted.
@@ -330,6 +333,14 @@ pub struct ConfigUpdate {
 	/// Whether redaction is enabled.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub redact:     Option<bool>,
+}
+
+/// Session endpoint teardown signal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionClosed {
+	/// The session whose notification endpoint is shutting down.
+	pub session_id: String,
 }
 
 /// Server capability/version advertisement.
@@ -640,6 +651,14 @@ mod tests {
 		assert_eq!(v["branch"], "feat/notification-surface");
 		assert_eq!(v["machine"], "mac-studio");
 		assert_eq!(v["title"], "Rebuild notifications");
+	}
+
+	#[test]
+	fn session_closed_serializes_camelcase() {
+		let msg = ServerMessage::SessionClosed(SessionClosed { session_id: "sess-1".into() });
+		let v = serde_json::to_value(&msg).unwrap();
+		assert_eq!(v["type"], "session_closed");
+		assert_eq!(v["sessionId"], "sess-1");
 	}
 
 	#[test]

--- a/crates/pi-natives/src/notifications.rs
+++ b/crates/pi-natives/src/notifications.rs
@@ -246,7 +246,8 @@ impl NotificationServer {
 
 	/// Broadcast an ephemeral threaded-session frame. `frame_json` is a JSON
 	/// `ServerMessage` (e.g. `identity_header`, `context_update`, `turn_stream`,
-	/// `image_attachment`, `config_update`, `hello`). Not buffered for replay.
+	/// `image_attachment`, `session_closed`, `config_update`, `hello`). Not
+	/// buffered for replay.
 	///
 	/// # Errors
 	/// Fails if not started or `frame_json` is not a valid `ServerMessage`.

--- a/docs/notifications-sdk.md
+++ b/docs/notifications-sdk.md
@@ -130,9 +130,10 @@ per-session repo/branch/machine header), `context_update` (last message, task,
 goal, token usage, model, diff), `turn_stream` (live/finalized turn output),
 `image_attachment` (agent-produced images), `activity` (busy/idle, drives the
 typing indicator), `inbound_ack` (delivery state of an injected user message),
-`config_update` (current verbosity/redact), `hello` (server capability/version),
-and `pong`. A minimal client only needs `action_needed`, `action_resolved`, and
-`reply_rejected`.
+`session_closed` (endpoint teardown; threaded clients may delete/archive the
+remote conversation), `config_update` (current verbosity/redact), `hello`
+(server capability/version), and `pong`. A minimal client only needs
+`action_needed`, `action_resolved`, and `reply_rejected`.
 
 ### Client → server
 
@@ -239,6 +240,12 @@ directory. It enables:
 After setup, sessions auto-connect when notifications are enabled. Each session
 still publishes its own loopback endpoint; the daemon is only the Telegram-side
 multiplexer.
+
+For Telegram forum topics, the daemon deletes the per-session topic when the local
+notification endpoint shuts down, so it disappears from the topic list. A resumed
+session creates a fresh topic before sending again. The bot must be allowed to
+delete messages in that chat; without that permission, deletion is best-effort and
+delivery continues.
 
 ### Singleton poller and trust model
 

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -12,7 +12,7 @@
  * - `ask` (unattended/RPC): observes emitted workflow gates and resolves the real
  *   gate on a remote reply via `ctx.workflowGate`.
  * - `turn_end` -> `action_needed` (kind `idle`, deduped per turn).
- * - `session_shutdown` -> stop the server + deregister the answer source.
+ * - `session_shutdown` -> `session_closed` frame, stop server, deregister answer source.
  *
  * Enable with Settings notifications config, `GJC_NOTIFICATIONS=1` (a token is
  * generated), or `GJC_NOTIFICATIONS_TOKEN`.
@@ -484,8 +484,9 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 	const runtimes = new Map<string, SessionRuntime>();
 	const disabledSessions = new Set<string>();
 	const sessionId = (ctx: ExtensionContext): string => ctx.sessionManager.getSessionId();
+	const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
 
-	function stopSession(id: string): boolean {
+	async function stopSession(id: string): Promise<boolean> {
 		const rt = runtimes.get(id);
 		if (!rt) return false;
 		runtimes.delete(id);
@@ -496,6 +497,14 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		// Resolve any still-pending interactive asks so the ask tool is not left hanging.
 		for (const pending of rt.pendingInteractive.values()) pending.resolve(undefined);
 		rt.pendingInteractive.clear();
+		let closeFrameSent = false;
+		try {
+			rt.server.pushFrame(JSON.stringify({ type: "session_closed", sessionId: id }));
+			closeFrameSent = true;
+		} catch (e) {
+			logger.warn(`notifications: session_closed failed: ${String(e)}`);
+		}
+		if (closeFrameSent) await sleep(100);
 		try {
 			rt.server.stop();
 		} catch (e) {
@@ -739,7 +748,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 
 			if (command === "off") {
 				disabledSessions.add(id);
-				const stopped = stopSession(id);
+				const stopped = await stopSession(id);
 				ctx.ui.notify(
 					stopped
 						? "Notifications disabled for this session."
@@ -1057,7 +1066,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		}
 	});
 
-	api.on("session_shutdown", (_event, ctx) => {
-		stopSession(sessionId(ctx));
+	api.on("session_shutdown", async (_event, ctx) => {
+		await stopSession(sessionId(ctx));
 	});
 };

--- a/packages/coding-agent/src/notifications/rate-limit-pool.ts
+++ b/packages/coding-agent/src/notifications/rate-limit-pool.ts
@@ -136,6 +136,25 @@ export class RateLimitPool<T = unknown> {
 		return granted;
 	}
 
+	/** Remove queued items matching `predicate` without consuming tokens. Returns removed items in lane/FIFO order. */
+	removeWhere(predicate: (item: RateLimitItem<T>) => boolean): RateLimitItem<T>[] {
+		const removed: RateLimitItem<T>[] = [];
+		for (const lane of LANE_PRIORITY) {
+			const queue = this.lanes.get(lane)!;
+			let write = 0;
+			for (let read = 0; read < queue.length; read++) {
+				const queued = queue[read]!;
+				if (predicate(queued.item)) {
+					removed.push(queued.item);
+				} else {
+					queue[write++] = queued;
+				}
+			}
+			queue.length = write;
+		}
+		return removed;
+	}
+
 	private refill(nowMs: number): void {
 		if (nowMs <= this.lastRefill) return;
 		const elapsedSec = (nowMs - this.lastRefill) / 1000;

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1199,6 +1199,14 @@ export class TelegramNotificationDaemon {
 						await this.setReaction(target.messageId, CONSUMED_REACTION);
 					}
 				},
+			})
+			.add({
+				name: "session_closed",
+				matches: msg => msg.type === "session_closed",
+				handle: async session => {
+					this.busy.delete(session.sessionId);
+					await this.deleteTopic(session.sessionId);
+				},
 			});
 	}
 
@@ -1450,6 +1458,31 @@ export class TelegramNotificationDaemon {
 			return rec.topicId;
 		} catch {
 			return undefined;
+		}
+	}
+
+	/** Best-effort delete of a session topic once its local notification endpoint shuts down. */
+	private async deleteTopic(sessionId: string): Promise<void> {
+		const record = this.topics.get(sessionId);
+		if (!record) return;
+		try {
+			// Drop queued sends for this session before deleting the topic; otherwise
+			// rate-limited frames can flush later into a deleted topic or across resume.
+			this.pool.removeWhere(item => item.sessionId === sessionId);
+			await this.flushPool();
+			const res = (await this.botApi.call("deleteForumTopic", {
+				chat_id: this.opts.chatId,
+				message_thread_id: Number(record.topicId),
+			})) as { ok?: boolean };
+			if (res?.ok === false) return;
+			this.topics.delete(sessionId);
+			this.topicOwnerByIdentity.forEach((ownerSessionId, identityKey) => {
+				if (ownerSessionId === sessionId) this.topicOwnerByIdentity.delete(identityKey);
+			});
+			this.pendingThreadedFrames.delete(sessionId);
+			await this.persistTopics();
+		} catch {
+			// Best-effort: missing Telegram topic permissions must not stop teardown.
 		}
 	}
 

--- a/packages/coding-agent/src/notifications/topic-registry.ts
+++ b/packages/coding-agent/src/notifications/topic-registry.ts
@@ -1,11 +1,11 @@
 /**
  * Per-session forum-topic registry for the threaded session surface.
  *
- * Each GJC session owns exactly one Telegram forum topic in the paired private
- * DM. The topic is created once (via `createForumTopic`) and REUSED on resume,
- * keyed by session id, so a resumed session streams back into its existing
- * thread/history. The registry also tracks whether the one-time identity header
- * has already been pinned, so it is sent exactly once per topic even across
+ * Each GJC session owns one active Telegram forum topic in the paired private
+ * DM. The topic is created via `createForumTopic`, reused while the session
+ * remains active, and removed from the registry when the daemon deletes it on
+ * shutdown. The registry also tracks whether the one-time identity header has
+ * already been pinned, so it is sent exactly once per active topic, even across
  * reconnects.
  *
  * State is a plain serialisable map persisted beside the daemon state files;
@@ -76,9 +76,8 @@ export class TopicRegistry {
 	}
 
 	/**
-	 * Return the existing topic for `sessionId`, or create one via `create`
-	 * (called only on first use). Reuse-on-resume: an existing record is
-	 * returned without invoking `create`.
+	 * Return the existing active topic for `sessionId`, or create one via
+	 * `create` (called only on first use).
 	 */
 	async getOrCreateTopic(
 		sessionId: string,
@@ -129,6 +128,15 @@ export class TopicRegistry {
 		const record = this.topics.get(sessionId);
 		if (!record || record.name === name) return false;
 		record.name = name;
+		return true;
+	}
+
+	/** Remove a session topic record after Telegram deletes the topic. */
+	delete(sessionId: string): boolean {
+		const record = this.topics.get(sessionId);
+		if (!record) return false;
+		this.topics.delete(sessionId);
+		this.byTopic.delete(record.topicId);
 		return true;
 	}
 

--- a/packages/coding-agent/test/notifications-rate-limit-pool.test.ts
+++ b/packages/coding-agent/test/notifications-rate-limit-pool.test.ts
@@ -71,4 +71,17 @@ describe("RateLimitPool", () => {
 		pool.submit(item("s1", "live", "c", "other"));
 		expect(pool.pending).toBe(3);
 	});
+
+	test("removes matching queued items without consuming tokens", () => {
+		const pool = new RateLimitPool<string>({ capacity: 1, refillPerSec: 0, now: () => 0 });
+		pool.submit(item("s1", "finalized", "s1-final"));
+		pool.submit(item("s1", "live", "s1-live"));
+		pool.submit(item("s2", "live", "s2-live"));
+
+		expect(pool.drain(0).map(i => i.payload)).toEqual(["s1-final"]);
+		const removed = pool.removeWhere(i => i.sessionId === "s1");
+		expect(removed.map(i => i.payload)).toEqual(["s1-live"]);
+		expect(pool.pending).toBe(1);
+		expect(pool.drain(60_000).map(i => i.payload)).toEqual([]);
+	});
 });

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -1293,6 +1293,63 @@ test("activity busy frame sends a typing chat action into the session topic", as
 	expect(bot.calls.some(c => c.method === "sendChatAction")).toBe(false);
 });
 
+test("session_closed deletes the topic and resume creates a fresh visible topic", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	let now = 0;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		now: () => now,
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
+	for (let i = 0; i < 25; i++) {
+		await daemon.handleSessionMessage(session as any, {
+			type: "turn_stream",
+			sessionId: "S",
+			phase: "finalized",
+			text: `queued-before-delete-${i}`,
+		});
+	}
+	bot.calls = [];
+
+	await daemon.handleSessionMessage(session as any, { type: "session_closed", sessionId: "S" });
+	const deleted = bot.calls.find(c => c.method === "deleteForumTopic");
+	expect(deleted).toBeTruthy();
+	expect(deleted!.body.message_thread_id).toBe(threadId);
+
+	now = 10_000;
+	bot.calls = [];
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+		title: "resumed",
+	});
+	const create = bot.calls.find(c => c.method === "createForumTopic");
+	const send = bot.calls.find(c => c.method === "sendMessage");
+	expect(create).toBeTruthy();
+	expect(create!.body.name).toBe("r/b - resumed");
+	expect(send).toBeTruthy();
+	expect(send!.body.message_thread_id).toBeTruthy();
+	expect(bot.calls.some(c => c.method === "reopenForumTopic")).toBe(false);
+	expect(bot.calls.some(c => c.method === "sendMessage" && String(c.body.text).includes("queued-before-delete"))).toBe(
+		false,
+	);
+});
+
 test("inbound thread message gets a queued reaction, flipped to consumed on ack", async () => {
 	FakeWs.instances = [];
 	const agentDir = tempAgentDir();

--- a/packages/coding-agent/test/notifications-topic-registry.test.ts
+++ b/packages/coding-agent/test/notifications-topic-registry.test.ts
@@ -78,4 +78,23 @@ describe("TopicRegistry", () => {
 		expect(results.map(r => r.topicId)).toEqual(["topic-1", "topic-1", "topic-1"]);
 		expect(reg.sessionForTopic("topic-1")).toBe("s1");
 	});
+
+	test("deletes topic records so later use creates a fresh topic", async () => {
+		const reg = new TopicRegistry();
+		await reg.getOrCreateTopic("s1", async () => "t1");
+
+		expect(reg.delete("s1")).toBe(true);
+		expect(reg.delete("s1")).toBe(false);
+		expect(reg.get("s1")).toBeUndefined();
+		expect(reg.sessionForTopic("t1")).toBeUndefined();
+
+		let created = false;
+		const rec = await reg.getOrCreateTopic("s1", async () => {
+			created = true;
+			return "t2";
+		});
+		expect(created).toBe(true);
+		expect(rec.topicId).toBe("t2");
+		expect(reg.sessionForTopic("t2")).toBe("s1");
+	});
 });

--- a/packages/coding-agent/test/notifications-turn-ordering.test.ts
+++ b/packages/coding-agent/test/notifications-turn-ordering.test.ts
@@ -197,3 +197,19 @@ test("inbound /verbose and /lean update runtime verbosity and confirmation polic
 		else process.env.GJC_NOTIFICATIONS = prevEnv;
 	}
 }, 30000);
+
+test("session shutdown emits session_closed before stopping the endpoint", async () => {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		const { handlers, ctx, frames } = await setup();
+		await handlers.get("agent_start")!({ type: "agent_start" }, ctx);
+		await waitFor(() => frames.some(f => f.type === "activity"), 3000, "activity frame");
+		frames.length = 0;
+		await handlers.get("session_shutdown")!({ type: "session_shutdown" }, ctx);
+		await waitFor(() => frames.some(f => f.type === "session_closed"), 3000, "session_closed frame");
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
+	}
+}, 30000);

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -146,7 +146,8 @@ export declare class NotificationServer {
   /**
    * Broadcast an ephemeral threaded-session frame. `frame_json` is a JSON
    * `ServerMessage` (e.g. `identity_header`, `context_update`, `turn_stream`,
-   * `image_attachment`, `config_update`, `hello`). Not buffered for replay.
+   * `image_attachment`, `session_closed`, `config_update`, `hello`). Not
+   * buffered for replay.
    *
    * # Errors
    * Fails if not started or `frame_json` is not a valid `ServerMessage`.


### PR DESCRIPTION
## Summary
- Emits a `session_closed` notification frame before each local notification endpoint stops.
- Deletes per-session Telegram forum topics on shutdown so they disappear from the topic list; resumed sessions create a fresh topic before sending again.
- Removes deleted topics from the registry and drops queued rate-limited sends for the closing session before deleting, preventing old frames from flushing into a deleted topic or across resume.

## Changes from closed PR #1165
- Replaces `closeForumTopic`/`reopenForumTopic` with `deleteForumTopic`.
- Adds `RateLimitPool.removeWhere(...)` and uses it to deterministically drop queued sends for the closing session before deletion.
- Adds a constrained rate-limit regression test proving queued pre-delete frames do not flush after delete/resume.

## Verification
- `bun test packages/coding-agent/test/notifications-rate-limit-pool.test.ts packages/coding-agent/test/notifications-topic-registry.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts packages/coding-agent/test/notifications-turn-ordering.test.ts`
- `cargo test -p gjc-notifications`

## Notes
- `bun --cwd=packages/coding-agent run check` still fails on the current base due to `ws` type declarations in an unrelated smoke script (`scripts/g011-daemon-path-smoke.ts`).
