### PR TITLE
fix(session): materialize resident blobs before branch export

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -4512,7 +4512,10 @@ export class SessionManager {
 
 		// Filter out LabelEntry from path - we'll recreate them from the resolved map
 		const pathWithoutLabels = branchPath.filter(e => e.type !== "label");
-
+		const materializedPathWithoutLabels = materializeResidentEntriesSync(
+			pathWithoutLabels,
+			this.#residentBlobStores(),
+		);
 		const newSessionId = createSessionId();
 		const timestamp = new Date().toISOString();
 		const fileTimestamp = timestamp.replace(/[:.]/g, "-");
@@ -4539,7 +4542,7 @@ export class SessionManager {
 		if (this.persist) {
 			const lines: string[] = [];
 			lines.push(JSON.stringify(header));
-			for (const entry of pathWithoutLabels) {
+			for (const entry of materializedPathWithoutLabels) {
 				lines.push(JSON.stringify(prepareEntryForPersistenceSync(entry, this.#blobStore)));
 			}
 			// Write fresh label entries at the end
@@ -4566,7 +4569,7 @@ export class SessionManager {
 			this.#resetResidentTextBlobStore();
 			this.#fileEntries = [
 				header,
-				...pathWithoutLabels.map(
+				...materializedPathWithoutLabels.map(
 					entry => prepareEntryForResidentSync(entry, this.#residentBlobStores()) as SessionEntry,
 				),
 				...labelEntries,
@@ -4596,7 +4599,7 @@ export class SessionManager {
 		this.#resetResidentTextBlobStore();
 		this.#fileEntries = [
 			header,
-			...pathWithoutLabels.map(
+			...materializedPathWithoutLabels.map(
 				entry => prepareEntryForResidentSync(entry, this.#residentBlobStores()) as SessionEntry,
 			),
 			...labelEntries,


### PR DESCRIPTION
## Summary
- materialize resident cold-spill refs before writing branch/export session JSONL
- re-run resident bounding on the materialized path so new sessions keep bounded resident payloads without persisting ephemeral resident blob refs

## Verification
- bun test packages/coding-agent/test/session-manager/resident-retention.test.ts packages/coding-agent/test/session-cold-spill-blob-store.test.ts (22 pass / 0 fail)
- @gajae-code/coding-agent check completed with exit 0 inside `bun run check` output; the wrapper command itself was invoked with an invalid `--filter` placement and exited 2 after package checks completed

## Notes
- GJC tmux session dropped after producing the patch, so this PR was finalized through the delegated gajae-code exception path for the active dev CI regression.
