### PR TITLE
Fix unscoped gjc wrapper execution

### DIFF
--- a/packages/gajae-code/bin/gjc.js
+++ b/packages/gajae-code/bin/gjc.js
@@ -1,2 +1,4 @@
 #!/usr/bin/env bun
-import "@gajae-code/coding-agent/cli";
+import { runCli } from "@gajae-code/coding-agent/cli";
+
+await runCli(process.argv.slice(2));

--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -34,6 +34,9 @@ describe("unscoped gajae-code package publication", () => {
 		);
 		expect(aliasManifest.bin).toEqual({ gjc: "bin/gjc.js" });
 		expect(aliasManifest.dependencies?.["@gajae-code/coding-agent"]).toBe("catalog:");
+		const wrapper = await Bun.file(path.join(repoRoot, "packages/gajae-code/bin/gjc.js")).text();
+		expect(wrapper).toContain('import { runCli } from "@gajae-code/coding-agent/cli";');
+		expect(wrapper).toContain("await runCli(process.argv.slice(2));");
 	});
 
 	test("release dependency normalization collapses repeated file prefixes", () => {


### PR DESCRIPTION
## Summary

This fixes the unscoped `gajae-code` package wrapper so the installed `gjc` command actually executes the CLI runner.

The published wrapper previously only imported `@gajae-code/coding-agent/cli`. Importing the module is not enough to start the CLI because the real CLI entrypoint only runs automatically when its own module is the main entrypoint:

```ts
if (import.meta.main) {
	await runCli(process.argv.slice(2));
}
```

When `packages/gajae-code/bin/gjc.js` imports that module, `import.meta.main` is false inside the imported CLI module. As a result, the wrapper can load successfully, exit with status 0, and still produce no output for commands such as `gjc`, `gjc --help`, and `gjc --version`.

## Changes

- Updated `packages/gajae-code/bin/gjc.js` to import the exported `runCli` function from `@gajae-code/coding-agent/cli`.
- Updated the wrapper to call `await runCli(process.argv.slice(2));` directly, preserving normal CLI argument forwarding.
- Added release publication test coverage so the unscoped wrapper is checked for the explicit `runCli` import and invocation.

## Why this is needed

The unscoped `gajae-code` package exists as the one-line install wrapper for the scoped CLI package. Its `bin/gjc.js` file is the public executable users receive when installing `gajae-code` globally.

Because the wrapper was only importing the CLI module, it depended on import side effects that the CLI intentionally does not provide. The scoped CLI module exports `runCli` and protects automatic execution behind `import.meta.main`, which is correct for direct execution but means wrapper packages must call the runner themselves.

This change makes the wrapper behavior explicit and avoids silent successful exits after global installs or upgrades.

## Verification

Ran the unscoped wrapper directly from the repository:

```sh
bun packages/gajae-code/bin/gjc.js --version
```

Output:

```text
gjc/0.7.3
```

Ran help through the wrapper:

```sh
bun packages/gajae-code/bin/gjc.js --help
```

Result: normal `gjc v0.7.3` help text was printed.

Ran the focused release publication test suite:

```sh
bun test scripts/release-publish-order.test.ts
```

Result:

```text
6 pass
0 fail
```

## Notes

Markdown files were intentionally excluded from the commit as requested.
