### PR TITLE
Add dev coverage for unscoped gjc wrapper execution

### DIFF
--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -34,6 +34,9 @@ describe("unscoped gajae-code package publication", () => {
 		);
 		expect(aliasManifest.bin).toEqual({ gjc: "bin/gjc.js" });
 		expect(aliasManifest.dependencies?.["@gajae-code/coding-agent"]).toBe("catalog:");
+		const wrapper = await Bun.file(path.join(repoRoot, "packages/gajae-code/bin/gjc.js")).text();
+		expect(wrapper).toContain('import { runCli } from "@gajae-code/coding-agent/cli";');
+		expect(wrapper).toContain("await runCli(process.argv.slice(2));");
 	});
 
 	test("release dependency normalization collapses repeated file prefixes", () => {


### PR DESCRIPTION
## Summary

This opens the same unscoped `gjc` wrapper fix line against the `dev` branch.

The `dev` branch already contains the corrected wrapper behavior in `packages/gajae-code/bin/gjc.js`, where the wrapper imports the exported `runCli` function and calls it directly with `process.argv.slice(2)`. This PR adds the matching release publication regression coverage on `dev` so the branch explicitly verifies that the unscoped wrapper keeps executing the CLI runner instead of only importing the CLI module.

## Background

The unscoped `gajae-code` package provides the public `gjc` executable for one-line installs. A wrapper that only imports `@gajae-code/coding-agent/cli` can silently load and exit without running the CLI because the actual CLI module only auto-executes when its own file is the main module:

```ts
if (import.meta.main) {
	await runCli(process.argv.slice(2));
}
```

When that module is imported by a package wrapper, `import.meta.main` is false inside the imported module. The wrapper therefore must call `runCli(...)` explicitly.

## Changes

- Added release publication test coverage to `scripts/release-publish-order.test.ts`.
- The test now checks that `packages/gajae-code/bin/gjc.js` imports `runCli` from `@gajae-code/coding-agent/cli`.
- The test also checks that the wrapper calls `await runCli(process.argv.slice(2));` so command-line arguments continue to be forwarded correctly.

## Verification

Ran the unscoped wrapper directly from the `dev`-based branch:

```sh
bun packages/gajae-code/bin/gjc.js --version
```

Output:

```text
gjc/0.7.3
```

Ran the focused release publication test suite:

```sh
bun test scripts/release-publish-order.test.ts
```

Result:

```text
6 pass
0 fail
```

## Notes

This PR intentionally excludes local markdown-only notes and does not include unrelated working-tree changes.
