### PR TITLE
Fix model selection after preset activation

### DIFF
--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -7,8 +7,13 @@ import {
 	formatAvailableProfileNames,
 	resolveProfileBindings,
 } from "./model-profiles";
-import { type GjcModelAssignmentTargetId, isAuthenticated, type ModelRegistry } from "./model-registry";
-import { resolveModelRoleValue } from "./model-resolver";
+import {
+	GJC_MODEL_ASSIGNMENT_TARGETS,
+	type GjcModelAssignmentTargetId,
+	isAuthenticated,
+	type ModelRegistry,
+} from "./model-registry";
+import { formatModelSelectorValue, resolveModelRoleValue } from "./model-resolver";
 import type { Settings } from "./settings";
 
 const LEGACY_MODEL_PROFILE_ALIASES: ReadonlyMap<string, string> = new Map([["codex-standard", "codex-medium"]]);
@@ -59,6 +64,48 @@ export interface PreparedModelProfileActivation {
 	 * resume default without promoting a transient model to it.
 	 */
 	previousSessionDefaultModel: string | undefined;
+}
+export interface MaterializeModelProfileAssignmentOptions {
+	session: Pick<
+		ModelProfileActivationSession,
+		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile"
+	>;
+	settings: Pick<Settings, "clearOverride" | "get" | "override" | "set">;
+	role: GjcModelAssignmentTargetId;
+	selector: string;
+}
+
+export function materializeActiveModelProfileAssignment(options: MaterializeModelProfileAssignmentOptions): boolean {
+	const activeProfile = options.session.getActiveModelProfile?.() ?? options.settings.get("modelProfile.default");
+	if (!activeProfile) return false;
+
+	const nextModelRoles = { ...options.settings.get("modelRoles") };
+	const nextAgentModelOverrides = { ...options.settings.get("task.agentModelOverrides") };
+	const target = GJC_MODEL_ASSIGNMENT_TARGETS[options.role];
+
+	if (options.role === "default") {
+		nextModelRoles.default = options.selector;
+	} else if (!nextModelRoles.default && options.session.model) {
+		nextModelRoles.default = formatModelSelectorValue(
+			`${options.session.model.provider}/${options.session.model.id}`,
+			options.session.thinkingLevel,
+		);
+	}
+
+	if (target.settingsPath === "modelRoles") {
+		nextModelRoles[options.role] = options.selector;
+	} else {
+		nextAgentModelOverrides[options.role] = options.selector;
+	}
+
+	options.settings.set("modelRoles", nextModelRoles);
+	options.settings.set("task.agentModelOverrides", nextAgentModelOverrides);
+	options.settings.set("modelProfile.default", undefined);
+	options.settings.clearOverride("modelProfile.default");
+	options.settings.override("modelRoles", nextModelRoles);
+	options.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
+	options.session.setActiveModelProfile?.(undefined);
+	return true;
 }
 
 export function formatModelProfileCredentialError(profileName: string, providers: readonly string[]): string {
@@ -254,21 +301,13 @@ export async function applyPreparedModelProfileActivation(
 			});
 			modelChanged = true;
 		}
-		if (Object.keys(prepared.modelRoles).length > 0) {
-			prepared.settings.override("modelRoles", {
-				...prepared.settings.get("modelRoles"),
-				...prepared.modelRoles,
-			});
-			modelRolesChanged = true;
-		}
-		if (Object.keys(prepared.agentModelOverrides).length > 0) {
-			prepared.settings.override("task.agentModelOverrides", {
-				...prepared.settings.get("task.agentModelOverrides"),
-				...prepared.agentModelOverrides,
-			});
-			overridesChanged = true;
-		}
+		prepared.settings.override("modelRoles", prepared.modelRoles);
+		modelRolesChanged = true;
+		prepared.settings.override("task.agentModelOverrides", prepared.agentModelOverrides);
+		overridesChanged = true;
 		if (options.persistDefault) {
+			prepared.settings.set("modelRoles", {});
+			prepared.settings.set("task.agentModelOverrides", {});
 			prepared.settings.set("modelProfile.default", prepared.profileName);
 			defaultChanged = true;
 			await prepared.settings.flush();
@@ -277,6 +316,8 @@ export async function applyPreparedModelProfileActivation(
 	} catch (error) {
 		if (defaultChanged) {
 			prepared.settings.set("modelProfile.default", previousPersistedDefault);
+			prepared.settings.set("modelRoles", previousModelRoles);
+			prepared.settings.set("task.agentModelOverrides", previousAgentModelOverrides);
 		}
 		if (modelRolesChanged) {
 			prepared.settings.override("modelRoles", previousModelRoles);

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -381,6 +381,17 @@ export class ModelSelectorComponent extends Container {
 		}
 	}
 
+	refreshRoleAssignments(
+		options: { currentModel?: Model; currentThinkingLevel?: ThinkingLevel; activeModelProfile?: string } = {},
+	): void {
+		if ("currentModel" in options) this.#currentModel = options.currentModel;
+		if ("currentThinkingLevel" in options) this.#currentThinkingLevel = options.currentThinkingLevel;
+		if ("activeModelProfile" in options) this.#activeModelProfile = options.activeModelProfile;
+		this.#roles = {};
+		this.#loadRoleModels();
+		this.#applyTabFilter();
+	}
+
 	#sortModels(models: ModelItem[]): void {
 		// Sort: default-tagged model first, then MRU, then alphabetical
 		const mruOrder = this.#settings.getStorage()?.getModelUsageOrder() ?? [];

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -4,8 +4,10 @@ import type { OAuthProvider } from "@gajae-code/ai/utils/oauth/types";
 import type { Component, OverlayHandle } from "@gajae-code/tui";
 import { Input, Loader, Spacer, Text } from "@gajae-code/tui";
 import { getAgentDbPath, getProjectDir } from "@gajae-code/utils";
-import { activateModelProfile } from "../../config/model-profile-activation";
+import { activateModelProfile, materializeActiveModelProfileAssignment } from "../../config/model-profile-activation";
 import { recommendModelProfileForProvider } from "../../config/model-profiles";
+import { GJC_MODEL_ASSIGNMENT_TARGETS } from "../../config/model-registry";
+import { formatModelSelectorValue } from "../../config/model-resolver";
 import { settings } from "../../config/settings";
 import { DebugSelectorComponent } from "../../debug";
 import { disableProvider, enableProvider } from "../../discovery";
@@ -663,7 +665,8 @@ export class SelectorController {
 
 	showModelSelector(options?: { temporaryOnly?: boolean }): void {
 		this.showSelector(done => {
-			const selector = new ModelSelectorComponent(
+			let modelSelector: ModelSelectorComponent;
+			modelSelector = new ModelSelectorComponent(
 				this.ctx.ui,
 				this.ctx.session.model,
 				this.ctx.settings,
@@ -697,38 +700,73 @@ export class SelectorController {
 							this.ctx.ui.requestRender();
 							return;
 						}
-						const { model, role, thinkingLevel, selector } = selection;
+						const { model, role, thinkingLevel, selector: selectedSelector } = selection;
 						if (role === null) {
 							// Temporary: update agent state but don't persist to settings
 							await this.ctx.session.setModelTemporary(model, thinkingLevel);
 							this.ctx.statusLine.invalidate();
 							this.ctx.updateEditorBorderColor();
-							this.ctx.showStatus(`Temporary model: ${selector ?? model.id}`);
+							this.ctx.showStatus(`Temporary model: ${selectedSelector ?? model.id}`);
 							done();
 							this.ctx.ui.requestRender();
 						} else if (role === "default") {
 							// Default: update agent state and persist as the active default model.
 							await this.ctx.session.setModel(model, role, {
-								selector,
+								selector: selectedSelector,
 								thinkingLevel,
+							});
+							const value = formatModelSelectorValue(
+								selectedSelector ?? `${model.provider}/${model.id}`,
+								thinkingLevel,
+							);
+							materializeActiveModelProfileAssignment({
+								session: this.ctx.session,
+								settings: this.ctx.settings,
+								role,
+								selector: value,
 							});
 							if (thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit) {
 								this.ctx.session.setThinkingLevel(thinkingLevel);
 							}
+							modelSelector.refreshRoleAssignments({
+								currentModel: this.ctx.session.model,
+								currentThinkingLevel: this.ctx.session.thinkingLevel,
+								activeModelProfile:
+									this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
+							});
 							this.ctx.statusLine.invalidate();
 							this.ctx.updateEditorBorderColor();
-							this.ctx.showStatus(`Default model: ${selector ?? model.id}`);
+							this.ctx.showStatus(`Default model: ${selectedSelector ?? model.id}`);
 							done();
 							this.ctx.ui.requestRender();
 						} else {
-							// Role-agent assignments configure Task dispatch and must not switch the active chat model.
 							const apiKey = await this.ctx.session.modelRegistry.getApiKey(model, this.ctx.session.sessionId);
 							if (!apiKey) {
 								throw new Error(`No API key for ${model.provider}/${model.id}`);
 							}
-							const overrides = this.ctx.settings.get("task.agentModelOverrides");
-							const value = selector ?? `${model.provider}/${model.id}`;
-							this.ctx.settings.set("task.agentModelOverrides", { ...overrides, [role]: value });
+							const value =
+								selectedSelector ?? formatModelSelectorValue(`${model.provider}/${model.id}`, thinkingLevel);
+							const materializedProfile = materializeActiveModelProfileAssignment({
+								session: this.ctx.session,
+								settings: this.ctx.settings,
+								role,
+								selector: value,
+							});
+							if (!materializedProfile) {
+								const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+								if (target.settingsPath === "modelRoles") {
+									this.ctx.settings.setModelRole(role, value);
+								} else {
+									const overrides = this.ctx.settings.get("task.agentModelOverrides");
+									this.ctx.settings.set("task.agentModelOverrides", { ...overrides, [role]: value });
+								}
+							}
+							modelSelector.refreshRoleAssignments({
+								currentModel: this.ctx.session.model,
+								currentThinkingLevel: this.ctx.session.thinkingLevel,
+								activeModelProfile:
+									this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
+							});
 							this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
 							this.ctx.showStatus(`${role} agent model: ${value}`);
 							done();
@@ -752,7 +790,7 @@ export class SelectorController {
 					isFastForSubagentProvider: provider => this.ctx.session.isFastForSubagentProvider(provider),
 				},
 			);
-			return { component: selector, focus: selector };
+			return { component: modelSelector, focus: modelSelector };
 		});
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -131,7 +131,7 @@ import {
 import { type AsyncJob, type AsyncJobDeliveryState, AsyncJobManager } from "../async";
 import { reset as resetCapabilities } from "../capability";
 import type { Rule } from "../capability/rule";
-import { MODEL_ROLE_IDS, type ModelRegistry } from "../config/model-registry";
+import { GJC_MODEL_ASSIGNMENT_TARGETS, MODEL_ROLE_IDS, type ModelRegistry } from "../config/model-registry";
 import {
 	extractExplicitThinkingSelector,
 	formatModelSelectorValue,
@@ -7507,11 +7507,14 @@ export class AgentSession {
 		availableModels: Model[],
 		currentModel: Model | undefined,
 	): ResolvedModelRoleValue {
+		const target = GJC_MODEL_ASSIGNMENT_TARGETS[role as keyof typeof GJC_MODEL_ASSIGNMENT_TARGETS];
 		const roleModelStr =
-			role === "default"
-				? (this.settings.getModelRole("default") ??
-					(currentModel ? `${currentModel.provider}/${currentModel.id}` : undefined))
-				: this.settings.getModelRole(role);
+			target?.settingsPath === "task.agentModelOverrides"
+				? this.settings.get("task.agentModelOverrides")[role]
+				: role === "default"
+					? (this.settings.getModelRole("default") ??
+						(currentModel ? `${currentModel.provider}/${currentModel.id}` : undefined))
+					: this.settings.getModelRole(role);
 
 		if (!roleModelStr) {
 			return { model: undefined, thinkingLevel: undefined, explicitThinkingLevel: false, warning: undefined };

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -6,6 +6,7 @@ import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import { Spacer, Text } from "@gajae-code/tui";
 import { setProjectDir } from "@gajae-code/utils";
 import { jobElapsedMs } from "../async";
+import { materializeActiveModelProfileAssignment } from "../config/model-profile-activation";
 import {
 	GJC_MODEL_ASSIGNMENT_TARGET_IDS,
 	GJC_MODEL_ASSIGNMENT_TARGETS,
@@ -298,6 +299,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 							selector: selection.selector,
 							thinkingLevel: selection.thinkingLevel,
 						});
+						materializeActiveModelProfileAssignment({
+							session: runtime.session,
+							settings: runtime.settings,
+							role: parsedArgs.targetId,
+							selector: persistedSelector,
+						});
 						if (selection.thinkingLevel) {
 							runtime.session.setThinkingLevel(selection.thinkingLevel);
 						}
@@ -316,10 +323,23 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 							selection.thinkingLevel ??
 							extractExplicitThinkingSelector(overrides[parsedArgs.targetId], runtime.settings);
 						const roleSelector = formatModelSelectorValue(selection.selector, thinkingLevel);
-						runtime.settings.set("task.agentModelOverrides", {
-							...overrides,
-							[parsedArgs.targetId]: roleSelector,
+						const materializedProfile = materializeActiveModelProfileAssignment({
+							session: runtime.session,
+							settings: runtime.settings,
+							role: parsedArgs.targetId,
+							selector: roleSelector,
 						});
+						if (!materializedProfile) {
+							const target = GJC_MODEL_ASSIGNMENT_TARGETS[parsedArgs.targetId];
+							if (target.settingsPath === "modelRoles") {
+								runtime.settings.setModelRole(parsedArgs.targetId, roleSelector);
+							} else {
+								runtime.settings.set("task.agentModelOverrides", {
+									...overrides,
+									[parsedArgs.targetId]: roleSelector,
+								});
+							}
+						}
 						runtime.settings.getStorage()?.recordModelUsage(`${selection.model.provider}/${selection.model.id}`);
 						await runtime.output(`${parsedArgs.targetId} agent model set to ${roleSelector}.`);
 					}

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -196,6 +196,28 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(session.agent.state.thinkingLevel).toBe(Effort.High);
 	});
 
+	it("resolves subagent model assignments from task.agentModelOverrides", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const executorModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+
+		await createSession({
+			initialModelId: defaultModel.id,
+			initialThinkingLevel: Effort.Low,
+			modelRoles: {
+				default: `${defaultModel.provider}/${defaultModel.id}:low`,
+			},
+		});
+		sessionSettings.set("task.agentModelOverrides", {
+			executor: `${executorModel.provider}/${executorModel.id}:high`,
+		});
+
+		const resolved = session.resolveRoleModelWithThinking("executor");
+
+		expect(resolved.model?.id).toBe(executorModel.id);
+		expect(resolved.thinkingLevel).toBe(Effort.High);
+		expect(resolved.explicitThinkingLevel).toBe(true);
+	});
+
 	it("clamps unsupported selections from model metadata", async () => {
 		const model = getAnthropicModelOrThrow("claude-sonnet-4-6");
 		const agent = new Agent({

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -5,6 +5,7 @@ import {
 	activateModelProfile,
 	applyPreparedModelProfileActivation,
 	formatModelProfileCredentialError,
+	materializeActiveModelProfileAssignment,
 	prepareModelProfileActivation,
 } from "../src/config/model-profile-activation";
 import type { ModelProfileDefinition } from "../src/config/model-profiles";
@@ -162,7 +163,7 @@ describe("model profile activation", () => {
 		expect(prepared.agentModelOverrides.critic).toBe("openai-codex/gpt-5.5:medium");
 	});
 
-	test("session-only changes active model and applies runtime overrides without persisted sets", async () => {
+	test("session-only changes active model and replaces runtime overrides without persisted sets", async () => {
 		const session = fakeSession();
 		const settings = Settings.isolated({ "task.agentModelOverrides": { critic: "provider-a/old" } });
 		const setCalls: string[] = [];
@@ -180,7 +181,6 @@ describe("model profile activation", () => {
 			vision: "provider-a/architect",
 		});
 		expect(settings.get("task.agentModelOverrides")).toEqual({
-			critic: "provider-a/old",
 			executor: "provider-b/executor",
 			architect: "provider-a/architect",
 		});
@@ -189,7 +189,58 @@ describe("model profile activation", () => {
 		expect(session.getActiveModelProfile()).toBe("profile-a");
 	});
 
-	test("--default persists only modelProfile.default and flushes", async () => {
+	test("materializing a profile role override persists the full effective assignment set and clears the profile", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({
+			"modelProfile.default": "codex-medium",
+			"task.agentModelOverrides": { critic: "provider-a/old-critic" },
+		});
+
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+
+		const materialized = materializeActiveModelProfileAssignment({
+			session,
+			settings,
+			role: "executor",
+			selector: "provider-c/executor:medium",
+		});
+
+		expect(materialized).toBe(true);
+		expect(settings.get("modelRoles")).toEqual({
+			default: "provider-a/default:high",
+			vision: "provider-a/architect",
+		});
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-c/executor:medium",
+			architect: "provider-a/architect",
+		});
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(session.getActiveModelProfile()).toBeUndefined();
+	});
+
+	test("materializing a default override stores the selected default and clears the profile", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({ "modelProfile.default": "profile-a" });
+
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+
+		const materialized = materializeActiveModelProfileAssignment({
+			session,
+			settings,
+			role: "default",
+			selector: "provider-c/default:low",
+		});
+
+		expect(materialized).toBe(true);
+		expect(settings.get("modelRoles")).toMatchObject({
+			default: "provider-c/default:low",
+			vision: "provider-a/architect",
+		});
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(session.getActiveModelProfile()).toBeUndefined();
+	});
+
+	test("--default persists profile default, clears persisted assignments, and flushes", async () => {
 		const session = fakeSession();
 		const settings = Settings.isolated();
 		const setCalls: string[] = [];
@@ -208,7 +259,7 @@ describe("model profile activation", () => {
 			{ persistDefault: true },
 		);
 
-		expect(setCalls).toEqual(["modelProfile.default"]);
+		expect(setCalls).toEqual(["modelRoles", "task.agentModelOverrides", "modelProfile.default"]);
 		expect(settings.get("modelProfile.default")).toBe("profile-a");
 		expect(flushCount).toBe(1);
 		expect(session.getActiveModelProfile()).toBe("profile-a");


### PR DESCRIPTION
## Summary
- Materialize effective preset role assignments before saving custom model selections.
- Clear the active default preset after a role/default model override so persisted custom selections are not overwritten on restart.
- Refresh selector role assignment labels after materialization.

## Tests
- bun test test/model-profile-activation.test.ts test/agent-session-role-thinking.test.ts