### PR TITLE
fix(coding-agent): preserve session-only profile overrides

### DIFF
--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -301,10 +301,17 @@ export async function applyPreparedModelProfileActivation(
 			});
 			modelChanged = true;
 		}
-		prepared.settings.override("modelRoles", prepared.modelRoles);
-		modelRolesChanged = true;
-		prepared.settings.override("task.agentModelOverrides", prepared.agentModelOverrides);
-		overridesChanged = true;
+		if (Object.keys(prepared.modelRoles).length > 0) {
+			prepared.settings.override("modelRoles", { ...previousModelRoles, ...prepared.modelRoles });
+			modelRolesChanged = true;
+		}
+		if (Object.keys(prepared.agentModelOverrides).length > 0) {
+			prepared.settings.override("task.agentModelOverrides", {
+				...previousAgentModelOverrides,
+				...prepared.agentModelOverrides,
+			});
+			overridesChanged = true;
+		}
 		if (options.persistDefault) {
 			prepared.settings.set("modelRoles", {});
 			prepared.settings.set("task.agentModelOverrides", {});

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -181,6 +181,7 @@ describe("model profile activation", () => {
 			vision: "provider-a/architect",
 		});
 		expect(settings.get("task.agentModelOverrides")).toEqual({
+			critic: "provider-a/old",
 			executor: "provider-b/executor",
 			architect: "provider-a/architect",
 		});
@@ -211,6 +212,7 @@ describe("model profile activation", () => {
 			vision: "provider-a/architect",
 		});
 		expect(settings.get("task.agentModelOverrides")).toEqual({
+			critic: "provider-a/old-critic",
 			executor: "provider-c/executor:medium",
 			architect: "provider-a/architect",
 		});


### PR DESCRIPTION
## Summary
- keep existing runtime model role overrides when activating a session-only profile with no profile modelRoles
- overlay profile agent overrides onto existing runtime overrides instead of dropping unrelated roles
- update profile activation coverage for the overlay semantics

## Verification
- bun test packages/coding-agent/test/model-profile-activation-redteam.test.ts packages/coding-agent/test/model-profile-activation.test.ts

Fixes the post-#1174 dev CI red in `test:@gajae-code/coding-agent`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*