### PR TITLE
fix(tui): anchor Korean/CJK IME preedit to the input caret

### DIFF
--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -554,6 +554,12 @@ export class HookSelectorComponent extends Container {
 		editor.setBorderVisible(false);
 		editor.setPromptGutter("> ");
 		editor.disableSubmit = true;
+		// Mark the inline editor focused only when mirroring the app's hardware-cursor
+		// mode, so it emits CURSOR_MARKER at the input caret for IME preedit anchoring
+		// without changing legacy non-hardware-cursor layout.
+		const useTerminalCursor = this.#tui?.getShowHardwareCursor() ?? false;
+		editor.focused = useTerminalCursor;
+		editor.setUseTerminalCursor(useTerminalCursor);
 		if (this.#autocompleteProvider) {
 			editor.setAutocompleteProvider(this.#autocompleteProvider);
 		}

--- a/packages/coding-agent/test/hook-selector-inline-input.test.ts
+++ b/packages/coding-agent/test/hook-selector-inline-input.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { HookSelectorComponent } from "@gajae-code/coding-agent/modes/components/hook-selector";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { CURSOR_MARKER, type TUI } from "@gajae-code/tui";
 import type { AutocompleteItem, AutocompleteProvider } from "@gajae-code/tui/autocomplete";
 
 beforeAll(async () => {
@@ -21,7 +22,7 @@ interface Callbacks {
 	submitted: string[];
 }
 
-function createSelector(opts?: { scrollTitleRows?: number; autocompleteProvider?: AutocompleteProvider }): {
+function createSelector(opts?: { scrollTitleRows?: number; autocompleteProvider?: AutocompleteProvider; tui?: TUI }): {
 	component: HookSelectorComponent;
 	calls: Callbacks;
 } {
@@ -38,6 +39,7 @@ function createSelector(opts?: { scrollTitleRows?: number; autocompleteProvider?
 			},
 			scrollTitleRows: opts?.scrollTitleRows,
 			autocompleteProvider: opts?.autocompleteProvider,
+			tui: opts?.tui,
 		},
 	);
 	return { component, calls };
@@ -109,6 +111,21 @@ describe("HookSelectorComponent inline custom input", () => {
 		const optionRow = after.indexOf("3. Other");
 		const promptRow = after.indexOf("> ");
 		expect(promptRow).toBeGreaterThan(optionRow);
+	});
+
+	it("marks the Other inline editor focused and mirrors hardware cursor mode", () => {
+		const component = createSelector({
+			tui: { getShowHardwareCursor: () => true } as TUI,
+		}).component;
+		moveToOther(component);
+		component.handleInput("\r");
+
+		const rendered = component.render(80).join("\n");
+		const markerIndex = rendered.indexOf(CURSOR_MARKER);
+		const promptIndex = Bun.stripANSI(rendered).indexOf("> ");
+
+		expect(markerIndex).toBeGreaterThanOrEqual(0);
+		expect(promptIndex).toBeGreaterThan(rendered.indexOf("3. Other"));
 	});
 
 	it("submits typed text via onSubmit instead of resolving an option", () => {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -851,11 +851,16 @@ export class Editor implements Component, Focusable {
 			const marker = emitCursorMarker ? CURSOR_MARKER : "";
 
 			if (showPlaceholder) {
-				displayText = hintStyle(truncateToWidth(this.#placeholder ?? "", lineContentWidth));
+				const hintText = hintStyle(truncateToWidth(this.#placeholder ?? "", lineContentWidth));
+				// Anchor the hardware cursor at the input start (terminal-cursor mode) even
+				// while the placeholder shows. Otherwise no cursor marker is emitted, the
+				// hardware cursor is left at its stale position from the previous frame,
+				// and a composing IME preedit renders there instead of at the prompt.
+				// The marker is zero-width and stripped before output, so the placeholder is unchanged.
+				const anchorCursor = emitCursorMarker && this.#useTerminalCursor && visibleIndex === 0;
+				displayText = anchorCursor ? marker + hintText : hintText;
 				displayWidth = Math.min(visibleWidth(this.#placeholder ?? ""), lineContentWidth);
-				if (!this.#useTerminalCursor) {
-					hasCursor = false;
-				}
+				hasCursor = false;
 			}
 
 			if (!borderVisible && displayWidth > lineContentWidth) {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -858,6 +858,22 @@ describe("Editor component", () => {
 			expect(visibleWidth(line!.slice(0, markerIndex))).toBe(2 + visibleWidth("한글"));
 		});
 
+		it("anchors terminal cursor at an empty placeholder", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setBorderVisible(false);
+			editor.setPromptGutter("> ");
+			editor.setPlaceholder("Describe the change");
+			editor.setUseTerminalCursor(true);
+			editor.focused = true;
+
+			const [line] = editor.render(40);
+			const markerIndex = line!.indexOf(CURSOR_MARKER);
+
+			expect(markerIndex).toBeGreaterThanOrEqual(0);
+			expect(visibleWidth(line!.slice(0, markerIndex))).toBe(2);
+			expect(Bun.stripANSI(line!.replaceAll(CURSOR_MARKER, ""))).toContain("Describe the change");
+		});
+
 		it("handles mixed ASCII and wide characters in wrapping", () => {
 			const editor = new Editor(defaultEditorTheme);
 			const width = 15;


### PR DESCRIPTION
## Problem

When typing Korean/CJK text through the macOS system IME, the **composing character (preedit)** does not appear at the input caret. It lands at a **stale, inconsistent position that changes with TUI state** — the far-right of the input box, column 0 below it, or the far-right of the animated HUD/spinner line several rows above the input. Committed text is placed correctly; only the in-progress preedit is misplaced. ASCII input is unaffected (it has no preedit phase).

Two cases:

- **A — empty composer:** typing the first Korean syllable into the empty main composer (placeholder showing) draws the preedit off-caret.
- **B — deep-interview "Other" input (most visible):** with the deep-interview HUD spinner animating, typing Korean into the Ask "Other (type your own)" field draws the composing character on the HUD/spinner line at the top while the committed text stays in the input box at the bottom.

## Root cause (confirmed by a cursor-position trace)

The OS IME draws the preedit at the **terminal hardware cursor position**. The TUI parks that cursor at the input caret by emitting a zero-width `CURSOR_MARKER` in the focused input's rendered line; `TUI#extractCursorPosition` locates it and `TUI#cursorControlSequence` moves the hardware cursor there.

A render trace (`extract.found` / `extract.none` / `cursor.move`) showed the failing frames produced **no `CURSOR_MARKER` anywhere in the output** (full-scan `fullRow: -1`), so the cursor was never repositioned and the preedit followed whatever the previous frame left on screen (often the animated spinner line). Two reasons for the missing marker:

- **A:** `Editor`'s placeholder branch set `hasCursor = false`, so a focused-but-empty editor showing its placeholder emitted no marker.
- **B:** the deep-interview inline "Other" editor in `HookSelectorComponent` was added to the tree and fed input manually, but `editor.focused` was never set, so `emitCursorMarker` was false and it emitted no marker at all.

## Fix

- `packages/tui/src/components/editor.ts` — in the placeholder branch, anchor the `CURSOR_MARKER` at the input start when focused in terminal-cursor mode. The marker is zero-width and stripped before output, so the visible placeholder is unchanged.
- `packages/coding-agent/src/modes/components/hook-selector.ts` — when entering inline "Other" input mode, set `editor.focused = true` and mirror the app's hardware-cursor mode (`setUseTerminalCursor(this.#tui?.getShowHardwareCursor() ?? false)`).

## Tests

- `packages/tui/test/editor.test.ts` — placeholder cursor anchoring (borderless exact column, bordered left-anchored, block-cursor mode emits no marker).
- `packages/coding-agent/test/hook-selector-inline-input.test.ts` — inline input emits `CURSOR_MARKER` after entering input mode; `renderText` helper updated to strip the marker so existing text assertions are unaffected.

Affected suites pass (editor, ime-jamo-cursor, hook-selector inline/overflow, ask): 207/207.

## Verification

Manually verified on macOS (darwin) + ghostty 1.3.2: the first Korean syllable in the empty composer (case A) and Korean input in the deep-interview "Other" field (case B) now compose at the prompt instead of jumping off-caret.

## Risks / out of scope

A separately reported symptom — jamo occasionally decomposing into individually committed compatibility jamo (`안` → `ㅇ`,`ㄴ`) — was not consistently reproducible and is likely downstream of the mispositioned preedit; out of scope here. If it recurs, isolate with `GJC_TUI_KEYBOARD_PROTOCOL=0`.
