### PR TITLE
fix(coding-agent): route package bin through CLI wrapper

### DIFF
--- a/packages/coding-agent/bin/gjc.js
+++ b/packages/coding-agent/bin/gjc.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env bun
+import { runCli } from "@gajae-code/coding-agent/cli";
+
+await runCli(process.argv.slice(2));

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -28,7 +28,7 @@
 	"main": "./src/index.ts",
 	"types": "./src/index.ts",
 	"bin": {
-		"gjc": "src/cli.ts"
+		"gjc": "bin/gjc.js"
 	},
 	"scripts": {
 		"build": "bun scripts/build-binary.ts",
@@ -82,6 +82,7 @@
 	},
 	"files": [
 		"src",
+		"bin",
 		"scripts",
 		"examples",
 		"README.md",

--- a/packages/coding-agent/test/cli-help-load-order.test.ts
+++ b/packages/coding-agent/test/cli-help-load-order.test.ts
@@ -242,5 +242,4 @@ ${stderr}`;
 		expect(stdout).toContain("USAGE");
 		expect(combined).not.toContain("Bun is a fast JavaScript runtime");
 	}, 15_000);
-
 });

--- a/packages/coding-agent/test/cli-help-load-order.test.ts
+++ b/packages/coding-agent/test/cli-help-load-order.test.ts
@@ -199,4 +199,48 @@ describe("CLI help load order", () => {
 		expect(stdout).toMatch(/^gjc\/\d+\.\d+\.\d+\n$/);
 		expect(stderr).toBe("");
 	}, 15_000);
+	it("package bin wrapper executes CLI help when imported by a Bun global shim", async () => {
+		if (Bun.semver.order(Bun.version, "1.3.14") < 0) {
+			return;
+		}
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-bin-wrapper-help-"));
+		cleanupRoot = root;
+		const home = path.join(root, "home");
+		const xdg = path.join(root, "xdg");
+		const agentDir = path.join(root, "agent");
+		await fs.mkdir(home, { recursive: true });
+		await fs.mkdir(xdg, { recursive: true });
+		await fs.mkdir(agentDir, { recursive: true });
+
+		const wrapperPath = path.join(repoRoot, "packages", "coding-agent", "bin", "gjc.js");
+		const proc = Bun.spawn([process.execPath, wrapperPath, "--help"], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: {
+				...process.env,
+				HOME: home,
+				XDG_CONFIG_HOME: xdg,
+				XDG_DATA_HOME: xdg,
+				GJC_CODING_AGENT_DIR: agentDir,
+				PI_CODING_AGENT_DIR: agentDir,
+				PI_NO_TITLE: "1",
+				NO_COLOR: "1",
+			},
+		});
+
+		const [stdout, stderr, exitCode] = await Promise.all([
+			readStream(proc.stdout as ReadableStream<Uint8Array>),
+			readStream(proc.stderr as ReadableStream<Uint8Array>),
+			proc.exited,
+		]);
+		const combined = `${stdout}
+${stderr}`;
+
+		expect(exitCode, combined).toBe(0);
+		expect(stdout).toContain("gjc v");
+		expect(stdout).toContain("USAGE");
+		expect(combined).not.toContain("Bun is a fast JavaScript runtime");
+	}, 15_000);
+
 });


### PR DESCRIPTION
## Summary
- point the `@gajae-code/coding-agent` package bin at a dedicated Bun wrapper instead of the side-effect-free `src/cli.ts` export
- have the wrapper call `runCli(process.argv.slice(2))` so Bun global shims execute root help/version normally
- add regression coverage for wrapper `--help` output avoiding Bun runtime help

## Verification
- `bun test packages/coding-agent/test/cli-help-load-order.test.ts packages/coding-agent/test/cli-command-surface.test.ts`
- `bun packages/coding-agent/bin/gjc.js --help`
- `cd packages/coding-agent && bun pm pack --dry-run` includes `bin/gjc.js`

Fixes #1179
