### PR TITLE
fix(coding-agent): bound first-run changelog display

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- First-time `gjc` startup now shows only the installed/current version changelog entry instead of dumping the full historical changelog before the actionable UI; full history remains available through `/changelog --full`.
+
 - `gjc --tmux` on native Windows no longer silently falls through to a tmux-less launch: when psmux is installed the plan now boots gjc through a PowerShell-encoded inner command, when no tmux-class binary resolves on PATH the diagnostic points at the psmux install URL and `GJC_TMUX_COMMAND` override, and explicit `GJC_TMUX_COMMAND` overrides are honored on every platform.
 - The `gjc team` worker-command string is now formatted for the host shell: on Windows + psmux each env assignment uses the `$env:VAR = 'value';` PowerShell form (with PowerShell-safe single-quote escaping) instead of the POSIX `VAR='value'` form, so worker panes spawned via psmux ConPTY panes inherit the right `GJC_TEAM_*` environment.
 - `createGjcTmuxSession` now chooses the new-session bootstrap command for the host shell: PowerShell `$env:GJC_TMUX_LAUNCHED = '1'; gjc` on Windows, `exec env GJC_TMUX_LAUNCHED=1 gjc` on POSIX, so psmux-managed sessions tag the spawned gjc the same way tmux-managed ones do.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -52,7 +52,7 @@ import { formatModelOnboardingGuidance } from "./setup/model-onboarding-guidance
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { resolvePromptInput } from "./system-prompt";
 import type { LspStartupServerInfo } from "./tools";
-import { getDisplayChangelogEntries, getNewEntries } from "./utils/changelog";
+import { getDisplayChangelogEntries, getInstalledVersionChangelogEntry, getNewEntries } from "./utils/changelog";
 import type { EventBus } from "./utils/event-bus";
 
 async function checkForNewVersion(currentVersion: string): Promise<string | undefined> {
@@ -407,7 +407,7 @@ async function getChangelogForDisplay(parsed: Args): Promise<string | undefined>
 		if (entries.length > 0) {
 			settings.set("lastChangelogVersion", VERSION);
 			await flushChangelogVersion();
-			return entries.map(e => e.content).join("\n\n");
+			return getInstalledVersionChangelogEntry(entries, VERSION)?.content;
 		}
 	} else {
 		const newEntries = getNewEntries(entries, lastVersion);

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -92,6 +92,14 @@ export function getDisplayChangelogEntries(): ChangelogEntry[] {
 	return parseChangelogContent(CHANGELOG_TEXT);
 }
 
+export function getInstalledVersionChangelogEntry(
+	entries: readonly ChangelogEntry[],
+	installedVersion: string,
+): ChangelogEntry | undefined {
+	const [major = 0, minor = 0, patch = 0] = installedVersion.split(".").map(Number);
+	return entries.find(entry => entry.major === major && entry.minor === minor && entry.patch === patch) ?? entries[0];
+}
+
 /**
  * Compare versions. Returns: -1 if v1 < v2, 0 if v1 === v2, 1 if v1 > v2
  */

--- a/packages/coding-agent/test/changelog.test.ts
+++ b/packages/coding-agent/test/changelog.test.ts
@@ -3,7 +3,11 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { VERSION } from "@gajae-code/utils";
-import { getDisplayChangelogEntries, parseChangelogContent } from "../src/utils/changelog";
+import {
+	getDisplayChangelogEntries,
+	getInstalledVersionChangelogEntry,
+	parseChangelogContent,
+} from "../src/utils/changelog";
 
 const tempDirs: string[] = [];
 
@@ -100,5 +104,22 @@ describe("getDisplayChangelogEntries", () => {
 			if (originalPiPackageDir === undefined) delete process.env.PI_PACKAGE_DIR;
 			else process.env.PI_PACKAGE_DIR = originalPiPackageDir;
 		}
+	});
+});
+
+describe("first-run changelog display", () => {
+	it("uses only the current embedded changelog entry on first launch", () => {
+		const entries = getDisplayChangelogEntries();
+		expect(entries.length).toBeGreaterThanOrEqual(2);
+
+		const firstRunEntry = getInstalledVersionChangelogEntry(entries, VERSION);
+		const olderVersion = entries.find(entry => `${entry.major}.${entry.minor}.${entry.patch}` !== VERSION);
+		expect(firstRunEntry).toBeDefined();
+		expect(olderVersion).toBeDefined();
+
+		expect(firstRunEntry!.content).toContain(`## [${VERSION}]`);
+		expect(firstRunEntry!.content).not.toContain(
+			`## [${olderVersion!.major}.${olderVersion!.minor}.${olderVersion!.patch}]`,
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- Limit first-time startup changelog display to the installed/current version entry instead of all historical entries.
- Keep subsequent update behavior intact via newer-than-last-version entries.
- Add a targeted regression test for first-run changelog selection.

Fixes #1181

## Verification
- `bun test packages/coding-agent/test/changelog.test.ts`
- `bun run check:types` (in `packages/coding-agent`)
- `bunx biome check packages/coding-agent/src/main.ts packages/coding-agent/src/utils/changelog.ts packages/coding-agent/test/changelog.test.ts packages/coding-agent/CHANGELOG.md`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*