### PR TITLE
fix(ai): disable thinking for OpenCode Go forced tools

### DIFF
--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -2545,6 +2545,10 @@ function applyOpenCodeGoOfficialMetadata<TApi extends Api>(model: Model<TApi>): 
 		cost: { ...metadata.cost },
 		contextWindow: metadata.contextWindow,
 		maxTokens: metadata.maxTokens,
+		compat: {
+			...(model.compat ?? {}),
+			disableReasoningOnForcedToolChoice: true,
+		},
 	};
 }
 

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -2545,10 +2545,6 @@ function applyOpenCodeGoOfficialMetadata<TApi extends Api>(model: Model<TApi>): 
 		cost: { ...metadata.cost },
 		contextWindow: metadata.contextWindow,
 		maxTokens: metadata.maxTokens,
-		compat: {
-			...(model.compat ?? {}),
-			disableReasoningOnForcedToolChoice: true,
-		},
 	};
 }
 

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -103,6 +103,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		provider === "opencode-go" ||
 		baseUrl.includes("opencode.ai");
 	const isOpenCodeProvider = provider === "opencode-go" || provider === "opencode-zen";
+	const isOpenCodeGoReasoning = provider === "opencode-go" && Boolean(model.reasoning);
 
 	const useMaxTokens =
 		provider === "mistral" ||
@@ -194,7 +195,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		supportsReasoningEffort: !isGrok && !isZai,
 		reasoningEffortMap,
 		supportsUsageInStreaming: !isCerebras,
-		disableReasoningOnForcedToolChoice: isKimiModel || isAnthropicModel,
+		disableReasoningOnForcedToolChoice: isKimiModel || isAnthropicModel || isOpenCodeGoReasoning,
 		disableReasoningOnToolChoice: isDeepseekFamily && Boolean(model.reasoning) && !isOpenRouter,
 		supportsToolChoice: !isDirectDeepseekReasoning,
 		supportsForcedToolChoice: true,

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -2,8 +2,9 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { getBundledModel } from "../src/models";
 import { convertMessages, detectCompat, streamOpenAICompletions } from "../src/providers/openai-completions";
 import { resolveOpenAICompat } from "../src/providers/openai-completions-compat";
-import type { AssistantMessage, Context, Model, OpenAICompat } from "../src/types";
+import type { AssistantMessage, Context, Model, OpenAICompat, Tool } from "../src/types";
 
+import * as z from "zod/v4";
 const originalFetch = global.fetch;
 
 afterEach(() => {
@@ -506,6 +507,55 @@ describe("kimi model detection via detectCompat", () => {
 		expect(compat.requiresReasoningContentForToolCalls).toBe(false);
 		// Kimi-specific quirks still apply even on opencode hosts.
 		expect(compat.requiresAssistantContentForToolCalls).toBe(true);
+	});
+
+	async function captureOpenCodeGoPayload(options: Parameters<typeof streamOpenAICompletions>[2]): Promise<Record<string, unknown>> {
+		const tool: Tool = {
+			name: "search",
+			description: "Search test data",
+			parameters: z.object({ query: z.string() }),
+		};
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(
+			getBundledModel("opencode-go", "kimi-k2.5") as Model<"openai-completions">,
+			{ ...baseContext(), tools: [tool] },
+			{
+				...options,
+				apiKey: "test-key",
+				signal: createAbortedSignal(),
+				onPayload: payload => resolve(payload),
+			},
+		);
+		return (await promise) as Record<string, unknown>;
+	}
+	it("disables reasoning for forced tool_choice on official OpenCode Go models", () => {
+		const model = getBundledModel("opencode-go", "kimi-k2.5");
+		expect(model.provider).toBe("opencode-go");
+		expect(model.reasoning).toBe(true);
+
+		const compat = detectCompat(model as Model<"openai-completions">);
+
+		expect(compat.disableReasoningOnForcedToolChoice).toBe(true);
+	});
+
+	it("drops reasoning, not forced tool_choice, for OpenCode Go forced tool_choice payloads", async () => {
+		const payload = await captureOpenCodeGoPayload({
+			reasoning: "high",
+			toolChoice: { type: "function", function: { name: "search" } },
+		});
+
+		expect(payload.tools).toBeDefined();
+		expect(payload.tool_choice).toEqual({ type: "function", function: { name: "search" } });
+		expect(payload.reasoning_effort).toBeUndefined();
+		expect(payload.reasoning).toBeUndefined();
+	});
+
+	it("preserves reasoning for OpenCode Go auto tool_choice payloads", async () => {
+		const payload = await captureOpenCodeGoPayload({ reasoning: "high", toolChoice: "auto" });
+
+		expect(payload.tools).toBeDefined();
+		expect(payload.tool_choice).toBe("auto");
+		expect(payload.reasoning_effort).toBe("high");
 	});
 
 	it("does not inject reasoning_content placeholder for kimi on opencode-go", () => {

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import * as z from "zod/v4";
 import { getBundledModel } from "../src/models";
 import { convertMessages, detectCompat, streamOpenAICompletions } from "../src/providers/openai-completions";
 import { resolveOpenAICompat } from "../src/providers/openai-completions-compat";
 import type { AssistantMessage, Context, Model, OpenAICompat, Tool } from "../src/types";
 
-import * as z from "zod/v4";
 const originalFetch = global.fetch;
 
 afterEach(() => {
@@ -509,7 +509,9 @@ describe("kimi model detection via detectCompat", () => {
 		expect(compat.requiresAssistantContentForToolCalls).toBe(true);
 	});
 
-	async function captureOpenCodeGoPayload(options: Parameters<typeof streamOpenAICompletions>[2]): Promise<Record<string, unknown>> {
+	async function captureOpenCodeGoPayload(
+		options: Parameters<typeof streamOpenAICompletions>[2],
+	): Promise<Record<string, unknown>> {
 		const tool: Tool = {
 			name: "search",
 			description: "Search test data",


### PR DESCRIPTION
Fixes #1182.

## Summary
- route OpenCode Go reasoning-capable OpenAI-compatible models through the existing `disableReasoningOnForcedToolChoice` compat knob
- keep forced/specified `tool_choice` for tool-forcing turns, but omit reasoning fields on those payloads
- add regression coverage proving forced tool choice drops reasoning while auto tool choice preserves reasoning

## Verification
- `bun test packages/ai/test/openai-completions-compat.test.ts packages/ai/test/issue-945-repro.test.ts`
- `bunx biome check packages/ai/src/providers/openai-completions-compat.ts packages/ai/src/provider-models/openai-compat.ts packages/ai/test/openai-completions-compat.test.ts`
- `bun run check:ts` (passes; existing warnings only in `packages/coding-agent/src/session/session-manager.ts`)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*