### PR TITLE
fix(ai): restore GPT-5.5 context window

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -197,7 +197,7 @@ export function applyGeneratedModelPolicies(models: ApiModel<Api>[]): void {
  * model with a larger context window on the same provider:
  * - `OpenAI code backend-spark` variants promote to `gpt-5.5`.
  *
- * `gpt-5.5` itself is a 400K-context model and is not demoted to `gpt-5.4`
+ * `gpt-5.5` itself is a 1M-context model and is not demoted to `gpt-5.4`
  * (which has a smaller window), so it has no promotion target.
  */
 export function linkOpenAIPromotionTargets(models: ApiModel<Api>[]): void {
@@ -453,15 +453,8 @@ function inferGeneratedApplyPatchToolType(
 }
 
 function applyGpt55ContextWindow(model: ApiModel<Api>, parsedModel: OpenAIModel): boolean {
-	// OpenAI Codex reports GPT-5.5 with a 272K prompt budget. Keep the generated
-	// bundle aligned with the backend limit so compaction fires before the prompt
-	// crosses the usable Codex window instead of trusting stale 400K snapshots.
-	if (model.provider === "openai-codex" && parsedModel.variant === "base" && semverEqual(parsedModel.version, "5.5")) {
-		model.contextWindow = 272000;
-		return true;
-	}
 	if (parsedModel.variant === "base" && semverEqual(parsedModel.version, "5.5")) {
-		model.contextWindow = 400000;
+		model.contextWindow = 1_000_000;
 		return true;
 	}
 	return false;

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -56310,7 +56310,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 272000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"priority": 9,

--- a/packages/ai/test/issue-489-repro.test.ts
+++ b/packages/ai/test/issue-489-repro.test.ts
@@ -154,7 +154,7 @@ describe("opencode-go qwen3.7-max keeps anthropic-messages transport (issue #489
 		expect(glm?.baseUrl).toBe("https://opencode.ai/zen/go/v1");
 		expect(glm?.cost.input).toBe(9);
 	});
-	test("gpt-5.5 context cap is clamped without clobbering static overrides", async () => {
+	test("gpt-5.5 context cap is normalized without clobbering static overrides", async () => {
 		const staticModels: Model<Api>[] = [
 			{
 				id: "gpt-5.5",
@@ -245,7 +245,7 @@ describe("opencode-go qwen3.7-max keeps anthropic-messages transport (issue #489
 		const preview = models.find(m => m.id === "gpt-5.5-preview");
 		const unknownSuffix = models.find(m => m.id === "gpt-5.5-experimental");
 		const other = models.find(m => m.id === "gpt-5.4");
-		expect(gpt55?.contextWindow).toBe(400_000);
+		expect(gpt55?.contextWindow).toBe(1_000_000);
 		expect(gpt55?.api).toBe("openai-responses");
 		expect(gpt55?.baseUrl).toBe("https://api.openai.com/v1");
 		expect(pro?.contextWindow).toBe(1_100_000);

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -281,11 +281,11 @@ describe("generated model policies", () => {
 		linkOpenAIPromotionTargets(models);
 
 		expect(models[0]?.contextPromotionTarget).toBe("openai-codex/gpt-5.5");
-		// gpt-5.5 is a 400K model and must not demote to the smaller gpt-5.4.
+		// gpt-5.5 is a 1M model and must not demote to the smaller gpt-5.4.
 		expect(models[1]?.contextPromotionTarget).toBeUndefined();
 	});
 
-	it("keeps Codex gpt-5.5 at the 272K prompt budget so compaction fires before the backend cap", () => {
+	it("keeps Codex gpt-5.5 at the 1M context window even if discovery is stale", () => {
 		const models: Model<Api>[] = [
 			{
 				...createModel({
@@ -293,7 +293,7 @@ describe("generated model policies", () => {
 					api: "openai-codex-responses",
 					provider: "openai-codex",
 				}),
-				// OpenAI code discovery can fall back to the stale 272K default.
+				// OpenAI code discovery/cache can carry stale 272K metadata.
 				contextWindow: 272000,
 				maxTokens: 128000,
 			},
@@ -301,7 +301,7 @@ describe("generated model policies", () => {
 
 		applyGeneratedModelPolicies(models);
 
-		expect(models[0]?.contextWindow).toBe(272000);
+		expect(models[0]?.contextWindow).toBe(1_000_000);
 	});
 
 	it("sets freeform apply_patch metadata for first-party GPT-5 Responses models", () => {

--- a/packages/ai/test/openai-codex-default.test.ts
+++ b/packages/ai/test/openai-codex-default.test.ts
@@ -16,8 +16,8 @@ describe("OpenAI Codex defaults", () => {
 			maxLevel: Effort.XHigh,
 			defaultLevel: Effort.XHigh,
 		});
-		// Codex discovery reports GPT-5.5 at 272K; bundled metadata must not
-		// drift back to a stale 400K snapshot or compaction fires too late.
-		expect(model.contextWindow).toBe(272000);
+		// GPT-5.5/Codex 5.5 is a 1M-context model; keep the bundled metadata aligned
+		// with the active runtime policy so status/compaction surfaces do not show 272K.
+		expect(model.contextWindow).toBe(1_000_000);
 	});
 });


### PR DESCRIPTION
## Summary
- Rebase the GPT-5.5 context-window fix onto dev as a narrow provider-metadata patch.
- Treat GPT-5.5/Codex 5.5 as 1M context in runtime policy and bundled openai-codex metadata.
- Update targeted regression coverage, including the issue-489 transport/static-override guard.

## Verification
- bun test packages/ai/test/model-thinking.test.ts packages/ai/test/openai-codex-default.test.ts packages/ai/test/issue-489-repro.test.ts
- bun --cwd=packages/ai run check:types