### PR TITLE
fix(tui): anchor status-line context% to provider usage instead of chars/4 heuristic

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -605,11 +605,22 @@ export class StatusLineComponent implements Component {
 			tokensPerSecond: this.#getTokensPerSecond(),
 		};
 
-		// Context usage — aligned with /context command so both surfaces report the same value
+		// Context usage — anchor to provider usage (getContextUsage) so the
+		// status-line matches the footer / /context / actual billed tokens.
+		// getContextUsage() = calculatePromptTokens(lastUsage) (input+cacheRead+
+		// cacheWrite) + trailing unsent delta. Fall back to the chars/4 heuristic
+		// only when provider usage is unavailable (e.g. right after compaction,
+		// tokens === null).
+		const usage = this.session.getContextUsage();
 		const breakdown = this.getCachedContextBreakdown();
-		const contextTokens = breakdown.usedTokens;
-		const contextWindow = breakdown.contextWindow || state.model?.contextWindow || 0;
-		const contextPercent = contextWindow > 0 ? (contextTokens / contextWindow) * 100 : 0;
+		const contextWindow = usage?.contextWindow || breakdown.contextWindow || state.model?.contextWindow || 0;
+		const contextTokens = usage?.tokens != null ? usage.tokens : breakdown.usedTokens;
+		const contextPercent =
+			usage?.percent != null
+				? usage.percent
+				: contextWindow > 0
+					? (contextTokens / contextWindow) * 100
+					: 0;
 
 		return {
 			session: this.session,


### PR DESCRIPTION
# PR: fix(tui): anchor status-line context% to provider usage (not chars/4 heuristic)

**Title**
```
fix(tui): anchor status-line context% to provider usage instead of chars/4 heuristic
```

**Body**

## Problem
The TUI status-line context `%` under-reports actual context usage by ~5×.
Observed: status-line shows **5.2%** while the real prompt is
`input + cacheRead + cacheWrite = 258,310` tokens on a 1M-window model
(claude-opus-4-8) = **~26%**. The footer / `/context` already report the
correct value, so the two surfaces disagree.

## Root cause
Two independent code paths compute context usage:

- **Provider-anchored (correct):** `AgentSession.getContextUsage()` →
  `calculatePromptTokens(lastUsage)` (`input+cacheRead+cacheWrite`) + trailing
  unsent delta. Used by `footer.ts`.
- **Heuristic (wrong for display):** `StatusLineComponent.getCachedContextBreakdown()`
  → `estimateMessageTokensHeuristic` (chars/4). Used by `status-line.ts`
  `#buildSegmentContext` → `segments.ts`.

`compaction.ts` explicitly documents that provider usage is the authoritative
anchor and chars/4 is only for "unsent/trailing deltas and display surfaces",
yet the status-line uses the raw heuristic. The chars/4 estimate massively
undercounts dense/structured payloads (tool schemas, large tool results, the
system prompt), producing the 5× gap. The comment at `status-line.ts:608`
even claims it is "aligned with /context" — it is not.

## Fix
`#buildSegmentContext` now prefers `session.getContextUsage()` (provider-anchored,
the same value the footer and `/context` use) and falls back to the chars/4
heuristic only when provider usage is unavailable (e.g. right after compaction,
`tokens === null`).

File: `packages/coding-agent/src/modes/components/status-line.ts`

## Verification
- status-line %, footer, and `/context` now report the same provider-anchored value.
- Post-compaction (`getContextUsage()` returns `tokens/percent: null`) cleanly
  falls back to the heuristic — no NaN/`?` regression.
- `status-line.ts` transpiles clean (bun).

## Apply (maintainer)
```bash
git checkout -b fix/status-line-context-percent
git apply gjc-context-percent-fix.patch   # patch attached
# verify, then commit/push/open PR
```
