### PR TITLE
Fix gjc-session vanish diagnostics

### DIFF
--- a/docs/gjc-session-clawhip-routing.md
+++ b/docs/gjc-session-clawhip-routing.md
@@ -54,9 +54,9 @@ This repository includes a portable implementation in `scripts/gjc-session/`. It
 
 The `scripts/gjc-session/` directory contains the public version of the operator helpers:
 
-- `create.sh` validates a dedicated git worktree, starts interactive `gjc` in tmux, preserves the pane after exit, and optionally registers a Clawhip-style `tmux watch`.
-- `prompt.sh` sends a text or `@file` prompt only after the pane looks like a ready GJC TUI, then sends multiple Enters to handle terminal submission edge cases.
-- `tail.sh` captures bounded pane output for readiness and acceptance checks.
+- `create.sh` validates a dedicated git worktree, starts interactive `gjc` in tmux, preserves the pane after exit, prints and writes the session-specific durable state path, writes `metadata.json`, mirrors pane output to `pane.log`, records lifecycle events in `events.log`, writes normal-exit `final.json`, and optionally registers a Clawhip-style `tmux watch`.
+- `prompt.sh` sends a text or `@file` prompt only after the pane looks like a ready GJC TUI; if the tmux session vanished, it refuses injection and prints the durable metadata/log/final/events recovery paths plus the last pane-log excerpt.
+- `tail.sh` captures bounded pane output for readiness and acceptance checks, with durable metadata, pane-log, event-log, and final-status fallback when tmux vanished.
 - `harness-tmux-owner-start.sh` starts the GJC harness control plane with the RuntimeOwner resident inside tmux for dogfood/debug cases that need visible owner liveness.
 
 Configuration is runtime-only:
@@ -66,6 +66,8 @@ export GJC_BIN=/path/to/gjc                         # optional; defaults to comm
 export GJC_SESSION_FLAGS="--model provider/model"   # optional interactive gjc flags
 export GJC_SESSION_ROUTER=clawhip                   # optional router binary
 export GJC_SESSION_SKIP_ROUTER=1                    # skip router registration
+export GJC_SESSION_STATE_DIR=/tmp/gjc-session-state # optional durable metadata/log root
+export GJC_SESSION_LOG_SEARCH_ROOT=$HOME/Workspace  # optional tail/prompt fallback search root
 export GJC_SESSION_STALE_MINUTES=60                 # router stale window
 export GJC_SESSION_KEYWORDS="/skill:ralplan,Question"
 ```
@@ -147,7 +149,7 @@ After prompt delivery, require one of these before reporting that the session is
 - a GitHub comment/review/PR URL,
 - a terminal verdict such as `MERGE_READY` or `REQUEST_CHANGES`.
 
-A prompt being visible in tmux scrollback is not acceptance by itself.
+A prompt being visible in tmux scrollback is not acceptance by itself. If tmux disappears before terminal verdict, inspect the state path printed by `create.sh`: `metadata.json` identifies the worktree/session, `pane.log` contains the mirrored transcript, `events.log` records launch/exit milestones, and `final.json` is present when `gjc` exited normally. Use `tail.sh <session-name> [lines]` to surface these artifacts without a live tmux server.
 
 ## Anti-patterns
 
@@ -155,5 +157,6 @@ A prompt being visible in tmux scrollback is not acceptance by itself.
 - Launching from the canonical repo checkout instead of a task worktree.
 - Running a long GJC/tmux session under a short shell timeout that can SIGKILL the owner process.
 - Treating tmux process existence as proof that the prompt was accepted.
+- Restarting a vanished session without first checking its durable metadata, pane log, event log, and final status.
 - Hard-coding private channel ids, bot mentions, or router tokens into public GJC docs.
 - Using this visible-session pattern when Coordinator MCP turn state is available and sufficient.

--- a/plugins/gajae-code/skills/gjc-session/SKILL.md
+++ b/plugins/gajae-code/skills/gjc-session/SKILL.md
@@ -11,9 +11,9 @@ Prefer Coordinator MCP for pure machine control. Prefer RPC/ACP when a host owns
 
 ## Public helpers
 
-- `scripts/gjc-session/create.sh` starts interactive `gjc` in a named tmux session, validates the worktree, preserves the pane after exit, and optionally registers a Clawhip-style router watch.
-- `scripts/gjc-session/prompt.sh` sends text or an `@file` prompt after the pane looks like a ready GJC TUI.
-- `scripts/gjc-session/tail.sh` captures bounded pane output for readiness and acceptance checks.
+- `scripts/gjc-session/create.sh` starts interactive `gjc` in a named tmux session, validates the worktree, preserves the pane after exit, prints and writes the session-specific durable state path, writes `metadata.json`, mirrors pane output to `pane.log`, records lifecycle events in `events.log`, writes normal-exit `final.json`, and optionally registers a Clawhip-style router watch.
+- `scripts/gjc-session/prompt.sh` sends text or an `@file` prompt after the pane looks like a ready GJC TUI; if the tmux session vanished, it refuses injection and prints the durable metadata/log/final/events recovery paths plus the last pane-log excerpt.
+- `scripts/gjc-session/tail.sh` captures bounded pane output for readiness and acceptance checks, with durable metadata, pane-log, event-log, and final-status fallback when tmux vanished.
 - `scripts/gjc-session/harness-tmux-owner-start.sh` starts the harness RuntimeOwner inside tmux for dogfood/debug cases that need visible owner liveness.
 - `docs/gjc-session-clawhip-routing.md` documents the full routed-session contract.
 
@@ -43,6 +43,8 @@ Prefer Coordinator MCP for pure machine control. Prefer RPC/ACP when a host owns
 
 6. Verify prompt acceptance from work evidence, not from pasted text alone. Acceptable evidence includes a tool call or file read, a plan/todo update, a diff or test command, a GitHub comment/review/PR URL, or a terminal verdict such as `MERGE_READY` or `REQUEST_CHANGES`.
 
+If tmux disappears before terminal verdict, inspect the state path printed by `create.sh`: `metadata.json` identifies the worktree/session, `pane.log` contains the mirrored transcript, `events.log` records launch/exit milestones, and `final.json` is present when `gjc` exited normally. Use `tail.sh <session-name> [lines]` to surface these artifacts without a live tmux server.
+
 ## Prompt expectations
 
 Include repository, worktree, branch, base branch, issue/PR id, scope, non-goals, verification, and whether to commit/push/open a PR. Keep channel and mention values outside the prompt unless the host policy explicitly requires them.
@@ -62,5 +64,6 @@ The helper requires the branch label to match the workspace checkout and prints 
 - Starting long-running visible repo work with `gjc -p` instead of an interactive tmux session.
 - Running the owner process under short shell timeouts or wrappers that can SIGKILL the session.
 - Treating tmux process existence or a visible pasted prompt as proof of acceptance.
+- Restarting a vanished session without first checking its durable metadata, pane log, event log, and final status.
 - Launching from a shared canonical checkout instead of a task worktree.
 - Hard-coding private channel ids, mentions, tokens, credentials, or internal-only paths.

--- a/scripts/generate-gjc-plugins.ts
+++ b/scripts/generate-gjc-plugins.ts
@@ -160,9 +160,9 @@ Prefer Coordinator MCP for pure machine control. Prefer RPC/ACP when a host owns
 
 ## Public helpers
 
-- \`scripts/gjc-session/create.sh\` starts interactive \`gjc\` in a named tmux session, validates the worktree, preserves the pane after exit, and optionally registers a Clawhip-style router watch.
-- \`scripts/gjc-session/prompt.sh\` sends text or an \`@file\` prompt after the pane looks like a ready GJC TUI.
-- \`scripts/gjc-session/tail.sh\` captures bounded pane output for readiness and acceptance checks.
+- \`scripts/gjc-session/create.sh\` starts interactive \`gjc\` in a named tmux session, validates the worktree, preserves the pane after exit, prints and writes the session-specific durable state path, writes \`metadata.json\`, mirrors pane output to \`pane.log\`, records lifecycle events in \`events.log\`, writes normal-exit \`final.json\`, and optionally registers a Clawhip-style router watch.
+- \`scripts/gjc-session/prompt.sh\` sends text or an \`@file\` prompt after the pane looks like a ready GJC TUI; if the tmux session vanished, it refuses injection and prints the durable metadata/log/final/events recovery paths plus the last pane-log excerpt.
+- \`scripts/gjc-session/tail.sh\` captures bounded pane output for readiness and acceptance checks, with durable metadata, pane-log, event-log, and final-status fallback when tmux vanished.
 - \`scripts/gjc-session/harness-tmux-owner-start.sh\` starts the harness RuntimeOwner inside tmux for dogfood/debug cases that need visible owner liveness.
 - \`docs/gjc-session-clawhip-routing.md\` documents the full routed-session contract.
 
@@ -192,6 +192,8 @@ Prefer Coordinator MCP for pure machine control. Prefer RPC/ACP when a host owns
 
 6. Verify prompt acceptance from work evidence, not from pasted text alone. Acceptable evidence includes a tool call or file read, a plan/todo update, a diff or test command, a GitHub comment/review/PR URL, or a terminal verdict such as \`MERGE_READY\` or \`REQUEST_CHANGES\`.
 
+If tmux disappears before terminal verdict, inspect the state path printed by \`create.sh\`: \`metadata.json\` identifies the worktree/session, \`pane.log\` contains the mirrored transcript, \`events.log\` records launch/exit milestones, and \`final.json\` is present when \`gjc\` exited normally. Use \`tail.sh <session-name> [lines]\` to surface these artifacts without a live tmux server.
+
 ## Prompt expectations
 
 Include repository, worktree, branch, base branch, issue/PR id, scope, non-goals, verification, and whether to commit/push/open a PR. Keep channel and mention values outside the prompt unless the host policy explicitly requires them.
@@ -211,6 +213,7 @@ The helper requires the branch label to match the workspace checkout and prints 
 - Starting long-running visible repo work with \`gjc -p\` instead of an interactive tmux session.
 - Running the owner process under short shell timeouts or wrappers that can SIGKILL the session.
 - Treating tmux process existence or a visible pasted prompt as proof of acceptance.
+- Restarting a vanished session without first checking its durable metadata, pane log, event log, and final status.
 - Launching from a shared canonical checkout instead of a task worktree.
 - Hard-coding private channel ids, mentions, tokens, credentials, or internal-only paths.
 `;

--- a/scripts/gjc-session/create.sh
+++ b/scripts/gjc-session/create.sh
@@ -11,6 +11,7 @@
 #   GJC_SESSION_KEYWORDS          comma-separated router watch keywords
 #   GJC_SESSION_ROUTER            router binary (default: clawhip, if present)
 #   GJC_SESSION_SKIP_ROUTER=1     skip router watch registration
+#   GJC_SESSION_STATE_DIR         durable metadata/log root (default: <worktree>/.gjc-session-state/<session>)
 
 set -euo pipefail
 
@@ -22,6 +23,25 @@ GJC_BIN="${GJC_BIN:-$(command -v gjc || true)}"
 GJC_FLAGS="${GJC_SESSION_FLAGS:-}"
 ROUTER_BIN="${GJC_SESSION_ROUTER:-$(command -v clawhip || true)}"
 TMUX_CMD=(tmux)
+
+json_escape() {
+  python3 -c 'import json,sys; print(json.dumps(sys.stdin.read())[1:-1])'
+}
+
+shell_join() {
+  printf '%q ' "$@"
+}
+
+show_recovery_hint() {
+  echo "durable metadata: $STATE_DIR/metadata.json" >&2
+  echo "durable pane log: $STATE_DIR/pane.log" >&2
+  echo "durable events: $STATE_DIR/events.log" >&2
+  echo "durable final status: $STATE_DIR/final.json" >&2
+  if [[ -s "$STATE_DIR/pane.log" ]]; then
+    echo "--- durable pane log tail ---" >&2
+    tail -40 "$STATE_DIR/pane.log" >&2
+  fi
+}
 
 if [[ -z "$GJC_BIN" ]]; then
   echo "gjc not found in PATH; set GJC_BIN" >&2
@@ -42,16 +62,95 @@ if [[ -z "$BRANCH" || "$BRANCH" == "HEAD" ]]; then
   exit 1
 fi
 
+STATE_DIR="${GJC_SESSION_STATE_DIR:-$WORKDIR/.gjc-session-state/$SESSION}"
+mkdir -p "$STATE_DIR"
+CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+{
+  printf '{\n'
+  printf '  "session": "%s",\n' "$(printf '%s' "$SESSION" | json_escape)"
+  printf '  "workdir": "%s",\n' "$(printf '%s' "$WORKDIR" | json_escape)"
+  printf '  "branch": "%s",\n' "$(printf '%s' "$BRANCH" | json_escape)"
+  printf '  "createdAt": "%s",\n' "$CREATED_AT"
+  printf '  "gjcBin": "%s",\n' "$(printf '%s' "$GJC_BIN" | json_escape)"
+  printf '  "stateDir": "%s",\n' "$(printf '%s' "$STATE_DIR" | json_escape)"
+  printf '  "paneLog": "%s",\n' "$(printf '%s' "$STATE_DIR/pane.log" | json_escape)"
+  printf '  "eventsLog": "%s",\n' "$(printf '%s' "$STATE_DIR/events.log" | json_escape)"
+  printf '  "finalStatus": "%s"\n' "$(printf '%s' "$STATE_DIR/final.json" | json_escape)"
+  printf '}\n'
+} >"$STATE_DIR/metadata.json"
+: >"$STATE_DIR/pane.log"
+: >"$STATE_DIR/events.log"
+printf '[%s] create requested session=%s workdir=%s branch=%s\n' "$CREATED_AT" "$SESSION" "$WORKDIR" "$BRANCH" >>"$STATE_DIR/events.log"
+cat >"$STATE_DIR/runner.sh" <<'RUNNER'
+#!/usr/bin/env bash
+set +e
+cd "$GJC_SESSION_WORKDIR" || exit 127
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf '[%s] runner started session=%s branch=%s cwd=%s\n' "$started_at" "$GJC_SESSION_NAME" "$GJC_SESSION_BRANCH" "$GJC_SESSION_WORKDIR" >>"$GJC_SESSION_EVENTS_LOG"
+echo "[gjc-session] session=$GJC_SESSION_NAME branch=$GJC_SESSION_BRANCH cwd=$GJC_SESSION_WORKDIR"
+echo "[gjc-session] durable state=$GJC_SESSION_STATE_DIR"
+echo "[gjc-session] durable pane log=$GJC_SESSION_PANE_LOG"
+"$GJC_SESSION_GJC_BIN" $GJC_SESSION_FLAGS
+rc=$?
+finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf '[%s] gjc exited status=%s\n' "$finished_at" "$rc" >>"$GJC_SESSION_EVENTS_LOG"
+python3 - "$GJC_SESSION_FINAL_JSON" "$GJC_SESSION_NAME" "$rc" "$started_at" "$finished_at" "$GJC_SESSION_PANE_LOG" <<'PY'
+import json
+import sys
+
+path, session, status, started_at, finished_at, pane_log = sys.argv[1:]
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(
+        {
+            "session": session,
+            "status": int(status),
+            "startedAt": started_at,
+            "finishedAt": finished_at,
+            "paneLog": pane_log,
+        },
+        handle,
+        indent=2,
+    )
+    handle.write("\n")
+PY
+echo
+echo "[gjc-session] GJC exited with status $rc"
+echo "[gjc-session] final status: $GJC_SESSION_FINAL_JSON"
+echo "[gjc-session] pane preserved for postmortem; press Ctrl-D to close"
+exec bash -l
+RUNNER
+chmod +x "$STATE_DIR/runner.sh"
+
 if "${TMUX_CMD[@]}" has-session -t "$SESSION" 2>/dev/null; then
   echo "tmux session already exists: $SESSION" >&2
   exit 1
 fi
 
-# Keep a shell after GJC exits so crashes/completions remain inspectable.
-"${TMUX_CMD[@]}" new-session -d -s "$SESSION" -c "$WORKDIR" -n gjc \
-  "bash -lc 'cd \"$WORKDIR\"; echo \"[gjc-session] session=$SESSION branch=$BRANCH cwd=$WORKDIR\"; \"$GJC_BIN\" $GJC_FLAGS; rc=\$?; echo; echo \"[gjc-session] GJC exited with status \$rc\"; echo \"[gjc-session] pane preserved for postmortem; press Ctrl-D to close\"; exec bash -l'"
+LAUNCH_CMD=(
+  env
+  "GJC_SESSION_NAME=$SESSION"
+  "GJC_SESSION_WORKDIR=$WORKDIR"
+  "GJC_SESSION_BRANCH=$BRANCH"
+  "GJC_SESSION_STATE_DIR=$STATE_DIR"
+  "GJC_SESSION_PANE_LOG=$STATE_DIR/pane.log"
+  "GJC_SESSION_EVENTS_LOG=$STATE_DIR/events.log"
+  "GJC_SESSION_FINAL_JSON=$STATE_DIR/final.json"
+  "GJC_SESSION_GJC_BIN=$GJC_BIN"
+  "GJC_SESSION_FLAGS=$GJC_FLAGS"
+  bash "$STATE_DIR/runner.sh"
+)
+LAUNCH_SHELL="$(shell_join "${LAUNCH_CMD[@]}")"
+# Keep a shell after GJC exits so crashes/completions remain inspectable. The runner
+# writes normal-exit finalization; pane.log/events.log remain useful if tmux vanishes.
+"${TMUX_CMD[@]}" new-session -d -s "$SESSION" -c "$WORKDIR" -n gjc "$LAUNCH_SHELL"
 
 "${TMUX_CMD[@]}" set-option -t "$SESSION" remain-on-exit on >/dev/null 2>&1 || true
+# Mirror pane output to a durable log so a tmux server/session vanish still leaves recoverable evidence.
+"${TMUX_CMD[@]}" pipe-pane -o -t "$SESSION":0.0 "cat >> '$STATE_DIR/pane.log'" >/dev/null 2>&1 || {
+  echo "warning: failed to attach durable pane log at $STATE_DIR/pane.log" >&2
+}
+"${TMUX_CMD[@]}" capture-pane -t "$SESSION":0.0 -p -S -200 >>"$STATE_DIR/pane.log" 2>/dev/null || true
+printf '[%s] tmux session launched and pipe attached\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$STATE_DIR/events.log"
 
 # Optional Clawhip-style router registration. Private channel ids/mentions stay caller-owned.
 if [[ "${GJC_SESSION_SKIP_ROUTER:-0}" != "1" && -n "$ROUTER_BIN" ]]; then
@@ -73,15 +172,21 @@ fi
 sleep 2
 if ! "${TMUX_CMD[@]}" has-session -t "$SESSION" 2>/dev/null; then
   echo "GJC session vanished immediately after launch: $SESSION" >&2
+  show_recovery_hint
   exit 1
 fi
-if ! "${TMUX_CMD[@]}" list-panes -t "$SESSION" -F '#{pane_pid} #{pane_current_command}' >/dev/null 2>&1; then
+if ! "${TMUX_CMD[@]}" list-panes -t "$SESSION" -F '#{pane_pid} #{pane_current_command}' >"$STATE_DIR/panes.txt" 2>/dev/null; then
   echo "GJC session has no readable panes after launch: $SESSION" >&2
+  show_recovery_hint
   exit 1
 fi
 
 echo "created GJC session: $SESSION"
 echo "  workdir: $WORKDIR"
 echo "  branch:  $BRANCH"
+echo "  state:   $STATE_DIR"
+echo "  log:     $STATE_DIR/pane.log"
+echo "  events:  $STATE_DIR/events.log"
+echo "  final:   $STATE_DIR/final.json"
 echo "  tail:    $(dirname "$0")/tail.sh $SESSION"
 echo "  prompt:  $(dirname "$0")/prompt.sh $SESSION @/path/to/prompt.md"

--- a/scripts/gjc-session/prompt.sh
+++ b/scripts/gjc-session/prompt.sh
@@ -7,6 +7,24 @@ SESSION="${1:?Usage: $0 <session-name> <text|@file>}"
 TEXT_ARG="${2:?Usage: $0 <session-name> <text|@file>}"
 TMUX_CMD=(tmux)
 
+show_missing_session_diagnostics() {
+  local log_path="$1"
+  local state_dir
+  state_dir="$(dirname "$log_path")"
+  if [[ -f "$state_dir/metadata.json" ]]; then
+    echo "durable metadata: $state_dir/metadata.json" >&2
+  fi
+  echo "refusing to paste prompt: tmux session $SESSION is not readable; durable pane log exists at $log_path" >&2
+  if [[ -f "$state_dir/final.json" ]]; then
+    echo "durable final status: $state_dir/final.json" >&2
+  fi
+  if [[ -f "$state_dir/events.log" ]]; then
+    echo "durable events: $state_dir/events.log" >&2
+  fi
+  echo "--- durable pane log tail ---" >&2
+  tail -40 "$log_path" >&2
+}
+
 if [[ "$TEXT_ARG" == @* ]]; then
   FILE="${TEXT_ARG#@}"
   [[ -f "$FILE" ]] || { echo "prompt file not found: $FILE" >&2; exit 1; }
@@ -15,7 +33,20 @@ else
   TEXT="$TEXT_ARG"
 fi
 
-PANE_TEXT="$("${TMUX_CMD[@]}" capture-pane -t "$SESSION":0.0 -p -S -80 2>/dev/null || true)"
+PANE_TEXT="$(${TMUX_CMD[@]} capture-pane -t "$SESSION":0.0 -p -S -80 2>/dev/null || true)"
+if [[ -z "$PANE_TEXT" ]]; then
+  if [[ -n "${GJC_SESSION_STATE_DIR:-}" && -f "$GJC_SESSION_STATE_DIR/pane.log" ]]; then
+    candidates=("$GJC_SESSION_STATE_DIR/pane.log")
+  else
+    mapfile -t candidates < <(find "${GJC_SESSION_LOG_SEARCH_ROOT:-$HOME/Workspace}" \( -path "*/.gjc-session-state/$SESSION/pane.log" -o -path "*/$SESSION/pane.log" \) -type f 2>/dev/null | sort)
+  fi
+  if [[ "${#candidates[@]}" -gt 0 ]]; then
+    show_missing_session_diagnostics "${candidates[0]}"
+  else
+    echo "refusing to paste prompt: tmux session $SESSION is not readable and no durable pane log was found" >&2
+  fi
+  exit 1
+fi
 if ! printf '%s\n' "$PANE_TEXT" | grep -qE 'Gajae forge|Type your message|> Type your message|Working'; then
   echo "refusing to paste prompt: GJC TUI is not ready in session $SESSION" >&2
   echo "--- pane tail ---" >&2

--- a/scripts/gjc-session/tail.sh
+++ b/scripts/gjc-session/tail.sh
@@ -7,4 +7,39 @@ SESSION="${1:?Usage: $0 <session-name> [lines]}"
 LINES="${2:-40}"
 TMUX_CMD=(tmux)
 
-"${TMUX_CMD[@]}" capture-pane -t "${SESSION}:0.0" -p -S -"$LINES" 2>/dev/null
+show_durable_state() {
+  local log_path="$1"
+  local state_dir
+  state_dir="$(dirname "$log_path")"
+  if [[ -f "$state_dir/metadata.json" ]]; then
+    echo "[gjc-session] durable metadata: $state_dir/metadata.json" >&2
+  fi
+  echo "[gjc-session] tmux session '$SESSION' is not readable; showing durable pane log: $log_path" >&2
+  if [[ -f "$state_dir/final.json" ]]; then
+    echo "[gjc-session] durable final status: $state_dir/final.json" >&2
+  fi
+  if [[ -f "$state_dir/events.log" ]]; then
+    echo "[gjc-session] durable events: $state_dir/events.log" >&2
+  fi
+  tail -n "$LINES" "$log_path"
+}
+
+if "${TMUX_CMD[@]}" capture-pane -t "${SESSION}:0.0" -p -S -"$LINES" 2>/dev/null; then
+  exit 0
+fi
+
+# tmux history is volatile. If the server/session vanished, fall back to the durable pane log
+# created by create.sh in the task worktree. Search common worktree roots without exposing
+# private routing values or requiring a live tmux server.
+if [[ -n "${GJC_SESSION_STATE_DIR:-}" && -f "$GJC_SESSION_STATE_DIR/pane.log" ]]; then
+  show_durable_state "$GJC_SESSION_STATE_DIR/pane.log"
+  exit 0
+fi
+mapfile -t candidates < <(find "${GJC_SESSION_LOG_SEARCH_ROOT:-$HOME/Workspace}" \( -path "*/.gjc-session-state/$SESSION/pane.log" -o -path "*/$SESSION/pane.log" \) -type f 2>/dev/null | sort)
+if [[ "${#candidates[@]}" -gt 0 ]]; then
+  show_durable_state "${candidates[0]}"
+  exit 0
+fi
+
+echo "gjc-session tail failed: tmux session '$SESSION' is not readable and no durable pane log was found" >&2
+exit 1


### PR DESCRIPTION
## Summary
- write session-specific gjc-session metadata, pane log, event log, and normal-exit final status paths from create.sh
- mirror tmux pane output to durable pane.log and print recovery paths when launch/readability fails
- make prompt.sh and tail.sh surface durable metadata/log/events/final paths plus pane-log excerpts when tmux vanished
- document the recovery flow in docs and regenerated plugin skill text

Fixes #1187

## Verification
- bash -n scripts/gjc-session/create.sh scripts/gjc-session/prompt.sh scripts/gjc-session/tail.sh
- bun scripts/generate-gjc-plugins.ts --check && bun scripts/verify-gjc-plugins.ts
- GJC_SESSION_STATE_DIR=/tmp/gjc-session-issue-1187-state scripts/gjc-session/tail.sh missing-session 3
- GJC_SESSION_STATE_DIR=/tmp/gjc-session-issue-1187-state scripts/gjc-session/prompt.sh missing-session 'hello' (expected refusal with durable recovery paths)
- GJC_BIN=/home/bellman/Workspace/gajae-code-issue-1187-gjc-session-vanish-diagnostics/.tmp/fake-gjc-session-gjc.sh GJC_SESSION_SKIP_ROUTER=1 GJC_SESSION_STATE_DIR=/tmp/<session> scripts/gjc-session/create.sh <session> /home/bellman/Workspace/gajae-code-issue-1187-gjc-session-vanish-diagnostics smoke test, followed by final.json/pane.log/events.log assertions and tail.sh