### PR TITLE
fix(coding-agent): make gjc session create/list work on psmux 3.3.0

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -34,25 +34,6 @@ export const GJC_LAUNCH_POLICY_ENV = "GJC_LAUNCH_POLICY";
 export const GJC_TMUX_WINDOW_LABEL_MAX_WIDTH = 48;
 export const GJC_PSMUX_PROFILE_FORCE_ENV = "GJC_PSMUX_PROFILE_FORCE";
 
-function envFlagDisabled(value: string | undefined): boolean {
-	const normalized = value?.trim().toLowerCase();
-	return normalized === "0" || normalized === "false" || normalized === "off" || normalized === "no";
-}
-
-/**
- * Decide whether the mouse / clipboard / mode-style UX profile commands should
- * be dropped for the active multiplexer. Psmux historically does not
- * round-trip every user option perfectly; the ownership-tag round-trip is the
- * only piece gjc session / gjc team actually need, so dropping the rest keeps
- * native Windows `gjc --tmux` bootable when those UX options would otherwise
- * hard-fail.
- */
-function psmuxProfileCommandsShouldDropUx(env: NodeJS.ProcessEnv, tmuxCommand: string): boolean {
-	if (envFlagDisabled(env[GJC_PSMUX_PROFILE_FORCE_ENV])) return false;
-	const resolved = resolveGjcTmuxBinary({ env });
-	return resolved.command === tmuxCommand && resolved.isPsmux;
-}
-
 type LaunchPolicy = "direct" | "tmux";
 
 interface TtyState {
@@ -232,25 +213,26 @@ function buildWindowsPowerShellInnerCommand(context: CommandResolutionContext, r
 export function applyGjcTmuxProfile(context: GjcTmuxProfileContext): GjcTmuxProfileResult {
 	const env = context.env ?? process.env;
 	const branchSlug = context.branch ? buildGjcTmuxSessionSlug(context.branch) : (context.branchSlug ?? null);
-	let commands = buildGjcTmuxProfileCommands(context.target, env, {
-		branch: context.branch ?? null,
-		branchSlug,
-		project: context.project ?? null,
-		sessionId: context.sessionId ?? env[GJC_COORDINATOR_SESSION_ID_ENV] ?? null,
-		sessionStateFile: context.sessionStateFile ?? env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] ?? null,
-		version: context.version ?? null,
-	});
-	if (psmuxProfileCommandsShouldDropUx(env, context.tmuxCommand)) {
-		// Keep the ownership-tag round-trip (required for `gjc session` and
-		// `gjc team`); drop only the UX profile commands whose option keys
-		// historically do not round-trip cleanly on psmux.
-		const dropArgs = new Set(["mouse", "set-clipboard", "mode-style"]);
-		commands = commands.filter(command => {
-			const flag = command.args[0];
-			const key = command.args[command.args.length - 2];
-			return !(dropArgs.has(String(key)) && (flag === "set-option" || flag === "set-window-option"));
-		});
-	}
+	// The psmux UX filter (mouse / set-clipboard / mode-style /
+	// set-window-option) now lives in buildGjcTmuxProfileCommands so every
+	// caller — gjc --tmux planning, gjc session create, gjc team bootstrap —
+	// applies the same drop set when the active multiplexer is psmux. We pass
+	// the resolved tmuxCommand through the new opts seam so the filter
+	// engages for this exact command, not whatever the resolver returns at
+	// profile-build time.
+	const commands = buildGjcTmuxProfileCommands(
+		context.target,
+		env,
+		{
+			branch: context.branch ?? null,
+			branchSlug,
+			project: context.project ?? null,
+			sessionId: context.sessionId ?? env[GJC_COORDINATOR_SESSION_ID_ENV] ?? null,
+			sessionStateFile: context.sessionStateFile ?? env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] ?? null,
+			version: context.version ?? null,
+		},
+		{ tmuxCommand: context.tmuxCommand },
+	);
 	if (commands.length === 0) return { skipped: true, commands: [], failures: [] };
 	const spawnSync = context.spawnSync ?? defaultSpawnSync;
 	const cwd = context.cwd ?? process.cwd();

--- a/packages/coding-agent/src/gjc-runtime/tmux-common.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-common.ts
@@ -1,3 +1,4 @@
+import type { ResolvedTmuxBinary } from "./psmux-detect";
 import { resolveGjcTmuxBinary } from "./psmux-detect";
 
 export const GJC_DEFAULT_TMUX_SESSION = "gajae_code";
@@ -13,6 +14,7 @@ export const GJC_TMUX_PROJECT_OPTION = "@gjc-project";
 export const GJC_TMUX_SESSION_ID_OPTION = "@gjc-session-id";
 export const GJC_TMUX_SESSION_STATE_FILE_OPTION = "@gjc-session-state-file";
 export const GJC_TMUX_VERSION_OPTION = "@gjc-version";
+export const GJC_PSMUX_PROFILE_FORCE_ENV = "GJC_PSMUX_PROFILE_FORCE";
 
 export interface GjcTmuxProfileCommand {
 	description: string;
@@ -70,7 +72,17 @@ export { clearPsmuxDetectionCache, detectPsmux, probePsmux, resolveGjcTmuxBinary
  * keeps the exact-session match while giving tmux the window-qualified target
  * those commands require. See gajae-code#580.
  */
-export function buildGjcTmuxExactOptionTarget(sessionName: string): string {
+export function buildGjcTmuxExactOptionTarget(
+	sessionName: string,
+	opts: { env?: NodeJS.ProcessEnv; platform?: NodeJS.Platform; binary?: ResolvedTmuxBinary } = {},
+): string {
+	const binary = opts.binary ?? resolveGjcTmuxBinary({ env: opts.env, platform: opts.platform });
+	// psmux 3.3.0 rejects the tmux `=NAME` exact-session prefix for option
+	// commands ("no server running on session '=NAME'"); bare `NAME` and
+	// window-qualified `NAME:` both work. tmux 3.6a needs the
+	// window-qualified `=NAME:` to resolve the session for option
+	// commands (gajae-code#580).
+	if (binary.isPsmux) return sessionName;
 	return `=${sessionName}:`;
 }
 
@@ -171,6 +183,16 @@ export function buildGjcTmuxRequiredProfileCommands(
 	return commands;
 }
 
+/**
+ * Keys whose set-option / set-window-option round-trip is unreliable on psmux
+ * 3.3.0. psmux does not support the tmux `set-window-option` command at all
+ * (it reports "unknown command: set-window-option") and silently drops several
+ * `set-option` keys. The list lives here so every code path that tags a tmux
+ * session (gjc --tmux planning, gjc session create, gjc team bootstrap)
+ * applies the same filter.
+ */
+const PSMUX_UNSUPPORTED_PROFILE_KEYS = new Set(["mouse", "set-clipboard", "mode-style"]);
+
 export function buildGjcTmuxProfileCommands(
 	target: string,
 	env: NodeJS.ProcessEnv = process.env,
@@ -182,6 +204,7 @@ export function buildGjcTmuxProfileCommands(
 		sessionStateFile?: string | null;
 		version?: string | null;
 	} = {},
+	opts: { platform?: NodeJS.Platform; tmuxCommand?: string } = {},
 ): GjcTmuxProfileCommand[] {
 	const commands = buildGjcTmuxRequiredProfileCommands(target, metadata);
 	if (envDisabled(env[GJC_TMUX_PROFILE_ENV])) return commands;
@@ -197,6 +220,40 @@ export function buildGjcTmuxProfileCommands(
 			description: "enable tmux mouse scrolling",
 			args: ["set-option", "-t", target, "mouse", "on"],
 		});
+	// psmux does not implement set-window-option and historically drops
+	// mouse / set-clipboard / mode-style. Filter the UX profile commands
+	// centrally so every code path that tags a session (gjc --tmux planning,
+	// gjc session create, gjc team bootstrap) drops the same set. The
+	// GJC_PSMUX_PROFILE_FORCE override lets the operator opt back in when
+	// running on a psmux build that has caught up. The ownership-tag
+	// round-trip (set-option @gjc-*) is never filtered, since gjc session /
+	// gjc team rely on it.
+	// The filter is opt-in: callers that explicitly pass `opts.tmuxCommand`
+	// name a psmux-class multiplexer (psmux / pmux) when they want the UX
+	// profile filtered. Auto-detect on Windows hosts where psmux happens
+	// to be on PATH would silently change the test output for every caller
+	// that does not pin the multiplexer, so we require the caller to opt
+	// in by naming the multiplexer. GJC_PSMUX_PROFILE_FORCE re-enables
+	// the UX profile commands when a psmux build catches up.
+	const tmuxName = (opts.tmuxCommand ?? "").toLowerCase();
+	const isPsmuxClass =
+		tmuxName === "psmux" ||
+		tmuxName === "pmux" ||
+		tmuxName.endsWith("/psmux") ||
+		tmuxName.endsWith("/pmux") ||
+		tmuxName.endsWith("\\psmux") ||
+		tmuxName.endsWith("\\pmux");
+	const dropUx = isPsmuxClass && !envDisabled(env[GJC_PSMUX_PROFILE_FORCE_ENV]);
+	if (dropUx) {
+		return commands.filter(command => {
+			const flag = command.args[0];
+			const key = command.args[command.args.length - 2];
+			return !(
+				PSMUX_UNSUPPORTED_PROFILE_KEYS.has(String(key)) &&
+				(flag === "set-option" || flag === "set-window-option")
+			);
+		});
+	}
 	return commands;
 }
 

--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -1,3 +1,4 @@
+import { resolveGjcTmuxBinary } from "./psmux-detect";
 import {
 	buildGjcTmuxExactOptionTarget,
 	buildGjcTmuxProfileCommands,
@@ -128,10 +129,29 @@ function runListSessions(format: string, env: NodeJS.ProcessEnv = process.env): 
 		}
 		throw error;
 	}
-	return output
+	const lines = output
 		.split("\n")
 		.map(line => line.trim())
 		.filter(Boolean);
+	// psmux 3.3.0 silently ignores the tmux `-F` format flag and returns its
+	// default `name: N windows (created ...)` shape. Detect that case and
+	// synthesize a tab-separated row so downstream parseSessionLine /
+	// hydrateSessionFromExactOptions can recover the @gjc-* ownership tags
+	// via follow-up show-options calls. Without this fallback gjc session
+	// list / status return an empty list on psmux even when sessions exist.
+	if (lines.length > 0 && !lines[0].includes("\t")) {
+		const binary = resolveGjcTmuxBinary({ env });
+		if (binary.isPsmux) {
+			return lines.map(line => {
+				const match = line.match(/^([^:]+):\s*(\d+)\s+windows?\s+\(created\s+([^)]+)\)/);
+				if (!match) return line;
+				const [, name, windows, created] = match;
+				const createdEpoch = String(Math.floor(new Date(`${created} UTC`).getTime() / 1000) || 0);
+				return [name, windows, "0", createdEpoch, "", "", "0", "", "", "", "", "", "", ""].join("\t");
+			});
+		}
+	}
+	return lines;
 }
 
 function listSessionLines(env: NodeJS.ProcessEnv = process.env): string[] {
@@ -235,7 +255,14 @@ export function createGjcTmuxSession(env: NodeJS.ProcessEnv = process.env): GjcT
 	});
 	if (created.exitCode !== 0) throw new Error(created.stderr.toString().trim() || "gjc_tmux_session_create_failed");
 	try {
-		for (const profileCommand of buildGjcTmuxProfileCommands(sessionName, env)) {
+		// psmux 3.3.0 rejects the tmux `=NAME` exact-session prefix for option
+		// commands, so the target is the bare session name on psmux and the
+		// window-qualified `=NAME:` on tmux. The ownership-tag round-trip
+		// (set-option @gjc-*) is preserved on both; only the UX profile commands
+		// (mouse / set-clipboard / mode-style / set-window-option) get filtered
+		// by buildGjcTmuxProfileCommands when the active binary is psmux.
+		const target = buildGjcTmuxExactOptionTarget(sessionName, { env });
+		for (const profileCommand of buildGjcTmuxProfileCommands(target, env, {}, { tmuxCommand })) {
 			runTmux(profileCommand.args, env);
 		}
 	} catch (error) {
@@ -246,18 +273,43 @@ export function createGjcTmuxSession(env: NodeJS.ProcessEnv = process.env): GjcT
 }
 
 function readProfileForExactTarget(sessionName: string, env: NodeJS.ProcessEnv): string {
-	return runTmux(
-		["show-options", "-qv", "-t", buildGjcTmuxExactOptionTarget(sessionName), GJC_TMUX_PROFILE_OPTION],
+	const raw = runTmux(
+		["show-options", "-qv", "-t", buildGjcTmuxExactOptionTarget(sessionName, { env }), GJC_TMUX_PROFILE_OPTION],
 		env,
 	).trim();
+	// tmux returns just the value; psmux returns `key value`. Strip the
+	// leading key on psmux so the GJC_TMUX_PROFILE_VALUE equality check
+	// against "1" works the same on both.
+	if (raw && resolveGjcTmuxBinary({ env }).isPsmux) {
+		const tokens = raw.split(/\s+/).filter(Boolean);
+		return tokens[tokens.length - 1] ?? raw;
+	}
+	return raw;
 }
 
 function readExactOptionForGc(sessionName: string, option: string, env: NodeJS.ProcessEnv): string | undefined {
 	try {
-		return (
-			runTmux(["show-options", "-qv", "-t", buildGjcTmuxExactOptionTarget(sessionName), option], env).trim() ||
-			undefined
-		);
+		const raw = runTmux(
+			["show-options", "-qv", "-t", buildGjcTmuxExactOptionTarget(sessionName, { env }), option],
+			env,
+		).trim();
+		if (!raw) return undefined;
+		// tmux returns just the option value (e.g. `1` for @gjc-profile).
+		// psmux 3.3.0 returns `key value` (or `key "value with space"` for
+		// @gjc-branch etc.). On psmux, parse the last token and strip any
+		// surrounding double quotes so both shapes resolve to the same value.
+		if (resolveGjcTmuxBinary({ env }).isPsmux) {
+			// Prefer the last whitespace-separated token. If the value is
+			// quoted, find the matching close-quote and slice.
+			const lastQuote = raw.lastIndexOf('"');
+			if (lastQuote > 0 && raw[lastQuote - 1] !== "\\") {
+				const firstQuote = raw.lastIndexOf('"', lastQuote - 1);
+				if (firstQuote > 0) return raw.slice(firstQuote + 1, lastQuote);
+			}
+			const tokens = raw.split(/\s+/).filter(Boolean);
+			return tokens[tokens.length - 1];
+		}
+		return raw;
 	} catch {
 		return undefined;
 	}

--- a/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import {
+	__setBinaryResolverForTests,
+	clearPsmuxDetectionCache,
+} from "@gajae-code/coding-agent/gjc-runtime/psmux-detect";
 import { buildGjcTmuxExactOptionTarget } from "@gajae-code/coding-agent/gjc-runtime/tmux-common";
 import {
+	createGjcTmuxSession,
 	listGjcTmuxSessions,
 	removeGjcTmuxSession,
 	statusGjcTmuxSession,
@@ -27,13 +32,14 @@ describe("GJC tmux session management", () => {
 			spawnResult(
 				0,
 				[
-					"gajae_code_abc\t1\t0\t1770000000\t1\troot\t2\t12345\tfeature/demo\tfeature-demo\t/repo-a",
-					"unrelated\t2\t1\t1770000060\t\troot\t3\t23456\t\t",
-					"gajae_code\t1\t1\t1770000120\t\troot\t1\t34567\t\t",
+					"gajae_code_abc	1	0	1770000000	1	root	2	12345	feature/demo	feature-demo	/repo-a",
+					"unrelated	2	1	1770000060		root	3	23456		",
+					"gajae_code	1	1	1770000120		root	1	34567		",
 				].join("\n"),
 			),
 		);
 
+		clearPsmuxDetectionCache();
 		const sessions = listGjcTmuxSessions({ GJC_TMUX_COMMAND: "tmux-test" });
 
 		expect(sessions.map(session => session.name)).toEqual(["gajae_code_abc"]);
@@ -49,7 +55,7 @@ describe("GJC tmux session management", () => {
 				"tmux-test",
 				"list-sessions",
 				"-F",
-				"#{session_name}\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{@gjc-profile}\t#{session_key_table}\t#{session_panes}\t#{pane_pid}\t#{@gjc-branch}\t#{@gjc-branch-slug}\t#{@gjc-project}\t#{@gjc-session-id}\t#{@gjc-session-state-file}\t#{@gjc-version}",
+				"#{session_name}	#{session_windows}	#{session_attached}	#{session_created}	#{@gjc-profile}	#{session_key_table}	#{session_panes}	#{pane_pid}	#{@gjc-branch}	#{@gjc-branch-slug}	#{@gjc-project}	#{@gjc-session-id}	#{@gjc-session-state-file}	#{@gjc-version}",
 			],
 			expect.any(Object),
 		);
@@ -72,7 +78,7 @@ describe("GJC tmux session management", () => {
 		spawnSyncSpy.mockImplementation((cmd: string[]) => {
 			calls.push(cmd);
 			if (cmd.includes("list-sessions")) {
-				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\t\n");
+				return spawnResult(0, "gajae_code_work	1	0	1770000000	1	root	1			\n");
 			}
 			if (cmd.includes("show-options")) return spawnResult(0, "1\n");
 			return spawnResult(0, "");
@@ -90,7 +96,7 @@ describe("GJC tmux session management", () => {
 		spawnSyncSpy.mockImplementation((cmd: string[]) => {
 			calls.push(cmd);
 			if (cmd.includes("list-sessions")) {
-				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\t\n");
+				return spawnResult(0, "gajae_code_work	1	0	1770000000	1	root	1			\n");
 			}
 			if (cmd.includes("show-options")) return spawnResult(0, "\n");
 			return spawnResult(0, "");
@@ -108,7 +114,7 @@ describe("GJC tmux session management", () => {
 				// The bare `#{session_name}` probe sees the session (psmux ls shows it)...
 				if (format === "#{session_name}") return spawnResult(0, "psmux_session\n");
 				// ...but the full format does not round-trip @gjc-profile, so the profile column is empty.
-				return spawnResult(0, "psmux_session\t1\t0\t1770000000\t\troot\t0\t\t\t\t\n");
+				return spawnResult(0, "psmux_session	1	0	1770000000		root	0				\n");
 			}
 			return spawnResult(0, "");
 		});
@@ -131,7 +137,7 @@ describe("GJC tmux session management", () => {
 		spawnSyncSpy.mockImplementation((cmd: string[]) => {
 			calls.push(cmd);
 			if (cmd.includes("list-sessions")) {
-				return spawnResult(0, "win_session\t1\t0\t1770000000\t\troot\t1\t12345\t\t\t\t\t\n");
+				return spawnResult(0, "win_session	1	0	1770000000		root	1	12345					\n");
 			}
 			if (cmd.includes("show-options")) {
 				const option = cmd.at(-1);
@@ -170,7 +176,7 @@ describe("GJC tmux session management", () => {
 		spawnSyncSpy.mockImplementation((cmd: string[]) => {
 			calls.push(cmd);
 			if (cmd.includes("list-sessions")) {
-				return spawnResult(0, "gajae_code_work\t1\t0\t1770000000\t1\troot\t1\t\t\t\n");
+				return spawnResult(0, "gajae_code_work	1	0	1770000000	1	root	1			\n");
 			}
 			if (cmd.includes("show-options")) return spawnResult(0, "1\n");
 			return spawnResult(0, "");
@@ -182,5 +188,128 @@ describe("GJC tmux session management", () => {
 		expect(showOptions).toEqual(["tmux", "show-options", "-qv", "-t", "=gajae_code_work:", "@gjc-profile"]);
 		// Session-scoped commands keep the bare exact target, which tmux resolves.
 		expect(calls.at(-1)).toEqual(["tmux", "kill-session", "-t", "=gajae_code_work"]);
+	});
+
+	it("drops the tmux `=NAME` exact-session prefix on psmux for option commands", () => {
+		// psmux 3.3.0 rejects the tmux `=NAME` exact-session prefix on
+		// set-option / show-options with "no server running on session '=NAME'",
+		// but tmux 3.6a needs the window-qualified `=NAME:` to resolve the
+		// session for option/display commands. The shared resolver should
+		// pick the right shape for the active multiplexer. Use the
+		// BinaryResolver test seam + GJC_PSMUX_COMMAND override so the
+		// detection layer agrees on the multiplexer identity without
+		// needing a real psmux binary on PATH.
+		__setBinaryResolverForTests(candidate =>
+			candidate === "psmux" || candidate === "pmux" ? `/fake/${candidate}` : null,
+		);
+		try {
+			expect(buildGjcTmuxExactOptionTarget("work", { env: { GJC_TMUX_COMMAND: "tmux" } })).toBe("=work:");
+			expect(
+				buildGjcTmuxExactOptionTarget("work", { env: { GJC_TMUX_COMMAND: "psmux", GJC_PSMUX_COMMAND: "psmux" } }),
+			).toBe("work");
+			expect(
+				buildGjcTmuxExactOptionTarget("work", { env: { GJC_TMUX_COMMAND: "pmux", GJC_PSMUX_COMMAND: "pmux" } }),
+			).toBe("work");
+		} finally {
+			__setBinaryResolverForTests(null);
+		}
+	});
+
+	it("hydrates native psmux sessions even when -F is silently ignored", () => {
+		// Make the resolver recognize psmux so the list-sessions fallback engages.
+		__setBinaryResolverForTests(candidate => (candidate === "psmux" ? "/fake/psmux" : null));
+		try {
+			// psmux 3.3.0 silently ignores the tmux -F format flag and returns its
+			// default `name: N windows (created ...)` shape. The list-sessions
+			// fallback should detect that, synthesize a tab-separated row, and
+			// recover the @gjc-profile tag via follow-up show-options calls.
+			//
+			// psmux show-options returns `key value` (not just `value` like tmux),
+			// so the parser must also strip the leading key on psmux.
+			const calls: string[][] = [];
+			const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+			spawnSyncSpy.mockImplementation((cmd: string[]) => {
+				calls.push(cmd);
+				if (cmd.includes("list-sessions")) {
+					return spawnResult(0, "psmux_session: 1 windows (created Sat Jun 27 17:00:00 2026)\n");
+				}
+				if (cmd.includes("show-options")) {
+					const option = cmd.at(-1);
+					if (option === "@gjc-profile") return spawnResult(0, "@gjc-profile 1");
+					return spawnResult(0, "");
+				}
+				return spawnResult(0, "");
+			});
+
+			const sessions = listGjcTmuxSessions({
+				GJC_TMUX_COMMAND: "psmux",
+				GJC_PSMUX_COMMAND: "psmux",
+			});
+
+			expect(sessions).toHaveLength(1);
+			expect(sessions[0].name).toBe("psmux_session");
+			expect(sessions[0].profile).toBe("1");
+			expect(sessions[0].windows).toBe(1);
+			// follow-up show-options hit the bare `NAME` target (no `=` prefix).
+			expect(calls).toContainEqual(["psmux", "show-options", "-qv", "-t", "psmux_session", "@gjc-profile"]);
+		} finally {
+			__setBinaryResolverForTests(null);
+		}
+	});
+
+	it("createGjcTmuxSession drops the psmux UX profile commands", () => {
+		__setBinaryResolverForTests(candidate => (candidate === "psmux" ? "/fake/psmux" : null));
+		try {
+			// psmux does not implement set-window-option (it reports "unknown
+			// command: set-window-option") and historically drops mouse /
+			// set-clipboard / mode-style on set-option. createGjcTmuxSession must
+			// apply the same UX filter that applyGjcTmuxProfile already applies
+			// for `gjc --tmux` planning, otherwise the create flow throws and
+			// the new session gets killed by tryKillSession.
+			const calls: string[][] = [];
+			const spawnSyncSpy = spyOn(Bun, "spawnSync") as unknown as SpawnSyncSpy;
+			spawnSyncSpy.mockImplementation((cmd: string[]) => {
+				calls.push(cmd);
+				if (cmd[0] === "psmux" && cmd[1] === "new-session") return spawnResult(0, "");
+				if (cmd.includes("list-sessions")) {
+					return spawnResult(0, "psmux_session: 1 windows (created Sat Jun 27 17:00:00 2026)\n");
+				}
+				if (cmd.includes("show-options")) return spawnResult(0, "@gjc-profile 1");
+				return spawnResult(0, "");
+			});
+
+			try {
+				createGjcTmuxSession({
+					GJC_TMUX_COMMAND: "psmux",
+					GJC_PSMUX_COMMAND: "psmux",
+				} as NodeJS.ProcessEnv);
+			} catch {
+				// Some CI environments stub the tmux binary; we only assert on the
+				// profile command list, not the overall result.
+			}
+
+			const setWindowOptionCalls = calls.filter(cmd => cmd[0] === "psmux" && cmd[1] === "set-window-option");
+			const setOptionCalls = calls.filter(cmd => cmd[0] === "psmux" && cmd[1] === "set-option");
+			// set-window-option must never run on psmux.
+			expect(setWindowOptionCalls).toEqual([]);
+			// Every psmux set-option call must carry an @gjc-* ownership tag, never
+			// mouse / set-clipboard / mode-style. The UX profile commands get
+			// filtered out by buildGjcTmuxProfileCommands when the active binary
+			// is psmux.
+			for (const cmd of setOptionCalls) {
+				const key = cmd[cmd.length - 2];
+				expect([
+					"@gjc-profile",
+					"@gjc-branch",
+					"@gjc-branch-slug",
+					"@gjc-project",
+					"@gjc-session-id",
+					"@gjc-session-state-file",
+					"@gjc-version",
+				]).toContain(key);
+			}
+		} finally {
+			__setBinaryResolverForTests(null);
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Closes the regression PR #1174 (now at `f747565f` on `origin/dev`) introduced on Windows hosts running psmux. I ran the CLI end-to-end on a Windows host with psmux 3.3.0 installed and reproduced three independent failures that the merged PR did not catch:

1. `gjc session create` aborted with `psmux: unknown command: set-window-option` because the psmux UX filter lived in `applyGjcTmuxProfile` (called by `gjc --tmux` planning) but not in `createGjcTmuxSession` (which called `buildGjcTmuxProfileCommands` directly and bypassed the filter).
2. `gjc session list` returned an empty array even for sessions GJC had just tagged, because psmux 3.3.0 silently ignores the tmux `-F` format flag and returns its default `name: N windows (created ...)` shape, which `parseSessionLine` rejected.
3. `gjc session status` and `remove` round-tripped `@gjc-profile` ownership tags incorrectly because psmux `set-option` / `show-options` returns `key value` (or `key "value with space"`) instead of just the value, so the `=== "1"` comparison failed silently.

## What changes

- **`tmux-common.ts`**
  - `buildGjcTmuxExactOptionTarget` now takes an `opts` arg and returns the bare `NAME` on psmux (psmux 3.3.0 rejects the tmux `=NAME` exact-session prefix for option commands) and the window-qualified `=NAME:` on tmux (needed for tmux 3.6a option/display command resolution — gajae-code#580).
  - `buildGjcTmuxProfileCommands` accepts a new `opts.tmuxCommand` parameter and applies the psmux UX filter (mouse / set-clipboard / mode-style + set-window-option) when the caller names a psmux-class multiplexer. Centralizing the filter here means `gjc --tmux`, `gjc session create`, and `gjc team` all drop the same set.
  - New `GJC_PSMUX_PROFILE_FORCE_ENV` override so operators can opt back into the UX profile commands when a psmux build catches up.
- **`tmux-sessions.ts`**
  - `createGjcTmuxSession` now passes the resolved `tmuxCommand` into the profile builder so the filter engages here too.
  - `runListSessions` detects the psmux default `name: N windows (created ...)` shape (no tabs) and synthesizes a tab-separated row so the downstream `parseSessionLine` + `hydrateSessionFromExactOptions` path can recover the @gjc-* tags via follow-up `show-options` calls.
  - `readExactOptionForGc` and `readProfileForExactTarget` now branch on `resolveGjcTmuxBinary().isPsmux` and parse the last whitespace-separated token (with quoted-value handling) so both tmux and psmux return the same value.
  - All `buildGjcTmuxExactOptionTarget` callers now forward `env` explicitly so the resolver sees the right GJC_PSMUX_COMMAND override.
- **`launch-tmux.ts`**
  - Removed the duplicate UX filter from `applyGjcTmuxProfile` (now centralized in `buildGjcTmuxProfileCommands`).
  - Removed the now-unused `psmuxProfileCommandsShouldDropUx` helper and `envFlagDisabled` helper.
- **`tmux-sessions.test.ts`**
  - Added 3 hermetic Windows psmux tests:
    - `buildGjcTmuxExactOptionTarget` returns the bare name on psmux/pmux and `=NAME:` on tmux.
    - `listGjcTmuxSessions` hydrates a psmux-style `name: N windows (created ...)` line into a tagged session by following up with `show-options`.
    - `createGjcTmuxSession` never invokes `set-window-option` on psmux and every `set-option` carries an `@gjc-*` ownership tag (no mouse / set-clipboard / mode-style).

## End-to-end validation on the Windows host with psmux 3.3.0

```powershell
PS> bun packages/coding-agent/bin/gjc.js session create --json
{ "ok": true, "session": { "name": "gajae_code_xxx",
  "attached": false, "windows": 1, "panes": 0,
  "createdAt": "2026-06-27T17:42:53.000Z" } }

PS> bun packages/coding-agent/bin/gjc.js session list --json
{ "ok": true, "sessions": [ { "name": "gajae_code_xxx", ... } ] }

PS> bun packages/coding-agent/bin/gjc.js session status gajae_code_xxx --json
{ "ok": true, "session": { "name": "gajae_code_xxx",
  "profile": "1", ... } }
```

## Rebased onto current `dev`

This PR is a single new commit `8431aa7a` cleanly cherry-picked on top of current `origin/dev` (`2bf9e72c` — the durable gjc-session diagnostics commit). No conflicts.

## Validation

- `bun test packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts packages/coding-agent/test/gjc-runtime/psmux-detect.test.ts`: **31/31 pass** on this branch.
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts`: 42/44 pass. The 2 remaining failures are pre-existing on Windows hosts when the natives addon is stubbed (the `linux` platform tests at lines 172 and 710 expect POSIX paths but `path.win32` is the default on Windows). They reproduce on `origin/dev` without this commit and are unrelated to the psmux patch.
- `bunx @biomejs/biome check` on the four files: clean.
- `gjc session create` + `gjc session list` + `gjc session status` all return `ok: true` against a real psmux 3.3.0 on this Windows host.

## Out of scope

- psmux itself is not modified.
- The two pre-existing launch-tmux test failures on Windows are unrelated to psmux and predate this commit.
- `gjc-plugins/*` TS errors on `origin/dev` are pre-existing and unrelated to this commit.