### PR TITLE
fix(session): guard parentId tree walks against cycles to stop resume OOM

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -640,8 +640,11 @@ export function buildSessionContext(
 
 	// Walk from leaf to root, then reverse once to avoid repeated front insertions on long branches.
 	const path: SessionEntry[] = [];
+	const visited = new Set<string>();
 	let current: SessionEntry | undefined = leaf;
 	while (current) {
+		if (visited.has(current.id)) break;
+		visited.add(current.id);
 		path.push(current);
 		current = current.parentId ? byId.get(current.parentId) : undefined;
 	}
@@ -3988,8 +3991,11 @@ export class SessionManager {
 	 * Returns undefined if no model change has been recorded.
 	 */
 	getLastModelChangeRole(): string | undefined {
+		const visited = new Set<string>();
 		let current = this.getLeafEntry();
 		while (current) {
+			if (visited.has(current.id)) break;
+			visited.add(current.id);
 			if (current.type === "model_change") {
 				return current.role ?? "default";
 			}
@@ -4005,8 +4011,11 @@ export class SessionManager {
 		if (!compaction || compaction.type !== "compaction")
 			throw new Error(`Compaction entry ${compactionEntryId} not found`);
 		const ids: string[] = [];
+		const visited = new Set<string>();
 		let current: SessionEntry | undefined = compaction;
 		while (current) {
+			if (visited.has(current.id)) break;
+			visited.add(current.id);
 			ids.push(current.id);
 			current = current.parentId ? this.#byId.get(current.parentId) : undefined;
 		}
@@ -4155,8 +4164,11 @@ export class SessionManager {
 	getBranchForFidelity(fromId?: string): SessionEntry[] {
 		const cache = new Map<string, string>();
 		const path: SessionEntry[] = [];
+		const visited = new Set<string>();
 		let current = (fromId ?? this.#leafId) ? this.#byId.get(fromId ?? this.#leafId ?? "") : undefined;
 		while (current) {
+			if (visited.has(current.id)) break;
+			visited.add(current.id);
 			path.push(
 				rehydrateColdSpillEntry(
 					materializeResidentEntrySync(current, this.#residentBlobStores(), cache),
@@ -4172,8 +4184,11 @@ export class SessionManager {
 
 	#getCanonicalBranchClones(fromId?: string): SessionEntry[] {
 		const path: SessionEntry[] = [];
+		const visited = new Set<string>();
 		let current = (fromId ?? this.#leafId) ? this.#byId.get(fromId ?? this.#leafId ?? "") : undefined;
 		while (current) {
+			if (visited.has(current.id)) break;
+			visited.add(current.id);
 			path.push(cloneSessionEntry(current));
 			current = current.parentId ? this.#byId.get(current.parentId) : undefined;
 		}
@@ -4267,9 +4282,12 @@ export class SessionManager {
 		this.#getBranchMaterializerCallCount++;
 		const cache = new Map<string, string>();
 		const path: SessionEntry[] = [];
+		const visited = new Set<string>();
 		const startId = fromId ?? this.#leafId;
 		let current = startId ? this.#byId.get(startId) : undefined;
 		while (current) {
+			if (visited.has(current.id)) break;
+			visited.add(current.id);
 			path.push(materializeResidentEntrySync(current, this.#residentBlobStores(), cache));
 			current = current.parentId ? this.#byId.get(current.parentId) : undefined;
 		}
@@ -4303,8 +4321,11 @@ export class SessionManager {
 	#getActivePathEntriesForProviderContext(fromId?: string | null): SessionEntry[] {
 		if (fromId === null || (fromId === undefined && this.#leafId === null)) return [];
 		const ids: string[] = [];
+		const visited = new Set<string>();
 		let current = this.#byId.get(fromId ?? this.#leafId ?? "");
 		while (current) {
+			if (visited.has(current.id)) break;
+			visited.add(current.id);
 			ids.push(current.id);
 			current = current.parentId ? this.#byId.get(current.parentId) : undefined;
 		}

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -341,5 +341,24 @@ describe("buildSessionContext", () => {
 			// Should only get the orphan since parent chain is broken
 			expect(ctx.messages).toHaveLength(1);
 		});
+
+		it("terminates instead of OOMing when the parentId chain forms a cycle", () => {
+			// Regression: an old/corrupt session whose entries form a parentId
+			// cycle (e.g. duplicate ids overwriting each other in the byId index)
+			// previously made the leaf->root walk push entries forever until OOM.
+			const entries: SessionEntry[] = [
+				msg("a", "b", "user", "first"),
+				msg("b", "a", "assistant", "second"), // a <-> b cycle
+			];
+			const ctx = buildSessionContext(entries, "b");
+			// Each entry is visited at most once, so the walk halts.
+			expect(ctx.messages.length).toBeLessThanOrEqual(2);
+		});
+
+		it("terminates when an entry is its own parent (self-cycle)", () => {
+			const entries: SessionEntry[] = [msg("1", null, "user", "root"), msg("2", "2", "assistant", "self-parent")];
+			const ctx = buildSessionContext(entries, "2");
+			expect(ctx.messages).toHaveLength(1);
+		});
 	});
 });


### PR DESCRIPTION
## Problem

Resuming an old gjc session could turn into a **memory bomb (OOM) with CPU pegged at 100%**.

## Root cause

`packages/coding-agent/src/session/session-manager.ts` walks the entry tree from the current leaf up to the root by following `parentId` pointers, in seven places, with no cycle guard:

```ts
while (current) {
  path.push(current);
  current = current.parentId ? byId.get(current.parentId) : undefined;
}
```

If the entry graph contains a `parentId` **cycle**, the loop never reaches a `null` parent:
- it **spins forever** → CPU 100%, and
- it **keeps pushing onto an array** → unbounded RAM → OOM.

Both reported symptoms (memory + CPU) are the signature of a single unbounded synchronous loop.

How an *old* session ends up with a cycle:
1. **Duplicate entry ids.** `#buildIndex` does `byId.set(entry.id, entry)`, so a later entry with a duplicate id overwrites an earlier one. Once two entries share an id, the leaf→root walk can route back through the map and close a loop (e.g. `X→Y→X`). The legacy 8-hex `generateId` can collide on very long histories.
2. A **hand-edited / partially-written / corrupted** session file with a `parentId` pointing at a descendant.

## What introduced this

This is **not a recent regression** — it is an original design omission. The `id`/`parentId` tree structure and these unguarded walks have existed since the baseline import commit `19f8c1f4` ("Establish the OMP baseline for gajae-code migration"), which also added `migrateV1ToV2`. Later commits reshaped the loops but carried the omission forward:
- `4a234d4e` (perf: memory/performance optimization suite) reworked `buildSessionContext` into the leaf→root + `reverse()` form.
- `5283f4e6` (perf(session): resident text cache, #548) reshaped `getBranch`.

Neither added a cycle guard, so the latent OOM/CPU hang remained.

## Fix

Add a `visited = new Set<string>()` guard that `break`s on a revisited entry id to all seven walks:
`buildSessionContext`, `getLastModelChangeRole`, `evictCompactedContent`, `getBranchForFidelity`, `#getCanonicalBranchClones`, `getBranch`, `#getActivePathEntriesForProviderContext`.

Behavior is unchanged for well-formed acyclic sessions (a valid chain never revisits an id); `reverse()`/ordering and `getLastModelChangeRole`'s most-recent-first early return are preserved.

## Tests

Added cycle (`a↔b`) and self-cycle regression tests in `test/session-manager/build-context.test.ts` (they would previously hang/OOM).

- `bun test test/session-manager/build-context.test.ts` → 19 pass / 0 fail
- `bun test test/session-manager/ test/compaction.test.ts test/issue-849-repro.test.ts test/session-compaction-eviction.test.ts` → 181 pass / 0 fail
- LSP diagnostics clean; biome formatted

## Possible follow-up (not in this PR)

Repair duplicate ids at `#buildIndex` time so corrupt sessions don't silently drop entries. The cycle guard alone fully prevents the memory bomb and CPU hang.