### PR TITLE
fix(session): guard getTree against child cycles

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -4439,18 +4439,48 @@ export class SessionManager {
 			nodeMap.set(entry.id, { entry, children: [], label });
 		}
 
-		// Build tree
+		const addRoot = (node: SessionTreeNode): void => {
+			if (!roots.includes(node)) {
+				roots.push(node);
+			}
+		};
+		const removeRoot = (node: SessionTreeNode): void => {
+			const index = roots.indexOf(node);
+			if (index !== -1) {
+				roots.splice(index, 1);
+			}
+		};
+		const wouldCreateChildCycle = (parent: SessionTreeNode, child: SessionTreeNode): boolean => {
+			const stack: SessionTreeNode[] = [child];
+			const visited = new Set<SessionTreeNode>();
+			while (stack.length > 0) {
+				const current = stack.pop()!;
+				if (current === parent) {
+					return true;
+				}
+				if (visited.has(current)) {
+					continue;
+				}
+				visited.add(current);
+				stack.push(...current.children);
+			}
+			return false;
+		};
+
+		// Build tree. Corrupt session files can contain duplicate IDs or parentId
+		// cycles; reject only the edge that would make the returned tree cyclic.
 		for (const entry of entries) {
 			const node = nodeMap.get(entry.id)!;
 			if (entry.parentId === null || entry.parentId === entry.id) {
-				roots.push(node);
+				addRoot(node);
 			} else {
 				const parent = nodeMap.get(entry.parentId);
-				if (parent) {
+				if (parent && !wouldCreateChildCycle(parent, node)) {
 					parent.children.push(node);
+					removeRoot(node);
 				} else {
-					// Orphan - treat as root
-					roots.push(node);
+					// Orphan or cycle-closing edge - treat as root
+					addRoot(node);
 				}
 			}
 		}
@@ -4458,8 +4488,13 @@ export class SessionManager {
 		// Sort children by timestamp (oldest first, newest at bottom)
 		// Use iterative approach to avoid stack overflow on deep trees
 		const stack: SessionTreeNode[] = [...roots];
+		const sorted = new Set<SessionTreeNode>();
 		while (stack.length > 0) {
 			const node = stack.pop()!;
+			if (sorted.has(node)) {
+				continue;
+			}
+			sorted.add(node);
 			node.children.sort((a, b) => new Date(a.entry.timestamp).getTime() - new Date(b.entry.timestamp).getTime());
 			stack.push(...node.children);
 		}

--- a/packages/coding-agent/test/session-manager/tree-traversal.test.ts
+++ b/packages/coding-agent/test/session-manager/tree-traversal.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { type CustomEntry, SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import { assistantMsg, userMsg } from "../utilities";
 
@@ -268,6 +271,41 @@ describe("SessionManager append and tree traversal", () => {
 
 			const node3 = node2.children.find(c => c.entry.id === id3)!;
 			expect(node3.children).toHaveLength(1); // id4
+		});
+
+		it("terminates when duplicate ids create a child cycle reachable from roots", async () => {
+			const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gajae-gettree-cycle-"));
+			try {
+				const sessionFile = path.join(tempDir, "corrupt.jsonl");
+				const corruptSessionJsonl = `${[
+					'{"type":"session","id":"session","timestamp":"2026-06-27T10:50:00.000Z","cwd":"/tmp"}',
+					'{"type":"message","id":"a","parentId":null,"timestamp":"2026-06-27T10:50:01.000Z","message":{"role":"user","content":"root-a","timestamp":1}}',
+					'{"type":"message","id":"a","parentId":"b","timestamp":"2026-06-27T10:50:02.000Z","message":{"role":"user","content":"duplicate-a","timestamp":2}}',
+					JSON.stringify({
+						type: "message",
+						id: "b",
+						parentId: "a",
+						timestamp: "2026-06-27T10:50:03.000Z",
+						message: assistantMsg("child-b"),
+					}),
+				].join("\n")}\n`;
+				fs.writeFileSync(sessionFile, corruptSessionJsonl);
+
+				const session = await SessionManager.open(sessionFile);
+				const tree = session.getTree();
+
+				expect(tree.length).toBeGreaterThan(0);
+				const visited = new Set<object>();
+				const stack = [...tree];
+				while (stack.length > 0) {
+					const node = stack.pop()!;
+					expect(visited.has(node)).toBe(false);
+					visited.add(node);
+					stack.push(...node.children);
+				}
+			} finally {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary
- make `SessionManager.getTree()` reject cycle-closing child edges in corrupt duplicate-id / `parentId` graphs
- keep normal acyclic root/child traversal and timestamp sorting behavior intact
- add a regression test for the duplicate-id `a -> b -> a` child-cycle shape from #1194

Fixes #1194

## Verification
- `bun install --frozen-lockfile`
- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/session-manager/tree-traversal.test.ts` — 29 pass / 0 fail
- `bunx biome check packages/coding-agent/src/session/session-manager.ts packages/coding-agent/test/session-manager/tree-traversal.test.ts` — no errors; existing unrelated warnings in `session-manager.ts`
- `bun --cwd=packages/coding-agent run check:types`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
