### PR TITLE
fix(tui): elide runaway thinking token loops

### DIFF
--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -7,6 +7,54 @@ import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { isSilentAbort } from "../../session/messages";
 import { resolveImageOptions } from "../../tools/render-utils";
 
+const THINKING_REPETITION_ELIDE_MIN_RUN = 24;
+const THINKING_REPETITION_VISIBLE_TOKENS = 3;
+const THINKING_REPETITION_TOKEN_PATTERN = /[\p{L}\p{N}_'-]{1,32}/gu;
+
+interface ThinkingRepetitionToken {
+	text: string;
+	normalized: string;
+	start: number;
+	end: number;
+}
+
+function elideRunawayThinkingRepetition(text: string): string {
+	const tokens: ThinkingRepetitionToken[] = [];
+	for (const match of text.matchAll(THINKING_REPETITION_TOKEN_PATTERN)) {
+		if (match.index === undefined) continue;
+		tokens.push({
+			text: match[0],
+			normalized: match[0].toLocaleLowerCase("en-US"),
+			start: match.index,
+			end: match.index + match[0].length,
+		});
+	}
+
+	let runStart = 0;
+	for (let i = 1; i <= tokens.length; i++) {
+		const current = tokens[i];
+		const previous = tokens[i - 1];
+		if (current && previous && current.normalized === previous.normalized) continue;
+
+		const runLength = i - runStart;
+		if (runLength >= THINKING_REPETITION_ELIDE_MIN_RUN) {
+			const first = tokens[runStart];
+			const last = tokens[i - 1];
+			if (!first || !last) return text;
+
+			const visibleCount = Math.min(THINKING_REPETITION_VISIBLE_TOKENS, runLength);
+			const visible = Array.from({ length: visibleCount }, () => first.text).join(" ");
+			const omitted = runLength - visibleCount;
+			const marker = `${visible} … [thinking loop elided: "${first.text}" repeated ${omitted} more times]`;
+			return `${text.slice(0, first.start)}${marker}${text.slice(last.end)}`.trim();
+		}
+
+		runStart = i;
+	}
+
+	return text;
+}
+
 /**
  * Component that renders a complete assistant message
  */
@@ -128,7 +176,7 @@ export class AssistantMessageComponent extends Container {
 	#renderThinkingBlock(content: { thinking: string }): Markdown {
 		const cached = this.#contentBlocksCache.get(content);
 		if (cached?.source === content.thinking) return cached.component as Markdown;
-		const trimmed = content.thinking.trim();
+		const trimmed = elideRunawayThinkingRepetition(content.thinking.trim());
 		const component = new Markdown(trimmed, 1, 0, getMarkdownTheme(), {
 			color: (text: string) => theme.fg("thinkingText", text),
 			italic: true,

--- a/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
@@ -37,6 +37,17 @@ function renderAssistantMessage(markdown: string): string {
 		.join("\n");
 }
 
+function renderAssistantThinking(thinking: string): string {
+	const component = new AssistantMessageComponent({
+		...createAssistantMessage(""),
+		content: [{ type: "thinking", thinking }],
+	});
+	return Bun.stripANSI(component.render(240).join("\n"))
+		.split("\n")
+		.map(line => line.trimEnd())
+		.join("\n");
+}
+
 beforeAll(async () => {
 	await initTheme(false);
 });
@@ -71,6 +82,24 @@ describe("AssistantMessageComponent mermaid markdown", () => {
 		expect(TERMINAL.imageProtocol).toBeNull();
 		expect(rendered).toContain("```mermaid");
 		expect(rendered).toContain("this is not mermaid");
+	});
+});
+
+describe("AssistantMessageComponent thinking rendering", () => {
+	it("elides pathological repeated-token thinking loops", () => {
+		const repeated = Array.from({ length: 40 }, () => "is").join(" ");
+		const rendered = renderAssistantThinking(`The plan is sound. ${repeated}`);
+
+		expect(rendered).toContain('The plan is sound. is is is … [thinking loop elided: "is" repeated 37 more times]');
+		expect(rendered.match(/\bis\b/g)?.length ?? 0).toBeLessThan(10);
+	});
+
+	it("keeps non-pathological repeated thinking visible", () => {
+		const repeated = Array.from({ length: 12 }, () => "is").join(" ");
+		const rendered = renderAssistantThinking(`Checking a small loop. ${repeated}`);
+
+		expect(rendered).toContain(`Checking a small loop. ${repeated}`);
+		expect(rendered).not.toContain("thinking loop elided");
 	});
 });
 


### PR DESCRIPTION
## Summary
- elide pathological repeated-token loops in visible thinking blocks
- preserve normal shorter repeated thinking text
- add renderer regression coverage

## Verification
- bun test packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
- bun --cwd=packages/coding-agent run check

Note: package check passed type checking and reported two pre-existing biome warnings in src/session/session-manager.ts unrelated to this PR.