### PR TITLE
fix(tmux): sanitize dot-prefixed cwd window titles

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -306,8 +306,15 @@ function truncateVisibleTail(value: string, maxWidth: number): string {
 	return `…${result}`;
 }
 
+function sanitizeTmuxWindowProjectName(project: string): string {
+	const trimmed = project.trim();
+	if (!trimmed || /^\.+$/.test(trimmed)) return "gjc";
+	if (trimmed.startsWith(".")) return `dot-${trimmed.replace(/^\.+/, "")}`;
+	return trimmed;
+}
+
 export function buildGjcTmuxWindowTitle(cwd: string, branch: string | null | undefined): string {
-	const project = path.basename(path.resolve(cwd)) || "gjc";
+	const project = sanitizeTmuxWindowProjectName(path.basename(path.resolve(cwd)) || "gjc");
 	const trimmedBranch = branch?.trim();
 	if (!trimmedBranch) return truncateVisible(project, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
 

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -87,6 +87,43 @@ describe("default GJC tmux launch", () => {
 		expect(title.endsWith("끝")).toBe(true);
 	});
 
+	it("sanitizes dot-prefixed cwd basenames for tmux window titles", () => {
+		expect(buildGjcTmuxWindowTitle("/tmp/.claude", null)).toBe("dot-claude");
+		expect(buildGjcTmuxWindowTitle("/tmp/.claude", "feature/demo")).toBe("dot-claude:feature/demo");
+		expect(buildGjcTmuxWindowTitle("/tmp/...", "feature/demo")).toBe("gjc:feature/demo");
+	});
+
+	it("passes sanitized dot-prefixed cwd basenames to tmux rename-window", () => {
+		const calls: Array<{ command: string; args: string[]; options: TmuxSpawnOptions }> = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/tmp/.claude",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			existingBranchSessionName: null,
+			currentBranch: null,
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
+		expect(calls.find(call => call.args[0] === "rename-window")?.args).toEqual([
+			"rename-window",
+			"-t",
+			expect.stringMatching(/^=gajae_code_/),
+			"--",
+			"dot-claude",
+		]);
+	});
+
 	it("separates dash-leading tmux window titles from tmux options", () => {
 		const calls: Array<{ command: string; args: string[]; options: TmuxSpawnOptions }> = [];
 		const handled = launchDefaultTmuxIfNeeded({


### PR DESCRIPTION
## Summary
- sanitize cwd-derived tmux window project names when the basename is dot-prefixed
- keep normal and dash-leading project labels stable while mapping hidden basenames like `.claude` to `dot-claude`
- add regression coverage for title construction and managed `rename-window` arguments

Fixes #1197

## Verification
- `bun install --frozen-lockfile`
- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts` (46 pass / 0 fail)
- `bun --cwd=packages/coding-agent run check:types`
