### PR TITLE
fix(ai): sanitize Codex history replay text fields

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -44,6 +44,7 @@ import {
 	getOpenAIResponsesHistoryItems,
 	getOpenAIResponsesHistoryPayload,
 	normalizeSystemPrompts,
+	sanitizeOpenAIResponsesHistoryItemsForReplay,
 } from "../utils";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
@@ -2550,17 +2551,16 @@ function convertMessages(model: Model<"openai-codex-responses">, context: Contex
 	for (const msg of transformedMessages) {
 		if (msg.role === "user" || msg.role === "developer") {
 			const providerPayload = (msg as { providerPayload?: AssistantMessage["providerPayload"] }).providerPayload;
-			const historyItems = getOpenAIResponsesHistoryItems(providerPayload, model.provider) as
-				| Array<ResponseInput[number]>
-				| undefined;
+			const historyItems = getOpenAIResponsesHistoryItems(providerPayload, model.provider);
 			if (historyItems) {
-				for (const item of historyItems) {
+				const sanitizedHistoryItems = sanitizeOpenAIResponsesHistoryItemsForReplay(historyItems);
+				for (const item of sanitizedHistoryItems) {
 					const maybe = item as { type?: string; call_id?: string };
 					if (maybe.type === "custom_tool_call" && typeof maybe.call_id === "string") {
 						customCallIds.add(maybe.call_id);
 					}
 				}
-				messages.push(...historyItems);
+				messages.push(...sanitizedHistoryItems);
 				msgIndex += 1;
 				continue;
 			}
@@ -2579,18 +2579,19 @@ function convertMessages(model: Model<"openai-codex-responses">, context: Contex
 				model.provider,
 				assistantMsg.provider,
 			);
-			const historyItems = providerPayload?.items as Array<ResponseInput[number]> | undefined;
+			const historyItems = providerPayload?.items;
 			if (historyItems) {
-				for (const item of historyItems) {
+				const sanitizedHistoryItems = sanitizeOpenAIResponsesHistoryItemsForReplay(historyItems);
+				for (const item of sanitizedHistoryItems) {
 					const maybe = item as { type?: string; call_id?: string };
 					if (maybe.type === "custom_tool_call" && typeof maybe.call_id === "string") {
 						customCallIds.add(maybe.call_id);
 					}
 				}
 				if (providerPayload?.dt) {
-					messages.push(...historyItems);
+					messages.push(...sanitizedHistoryItems);
 				} else {
-					messages.splice(0, messages.length, ...historyItems);
+					messages.splice(0, messages.length, ...sanitizedHistoryItems);
 					// Keep customCallIds from the pre-splice state since historyItems may re-introduce them.
 				}
 				msgIndex += 1;

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -91,6 +91,52 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(items: Array<Record
 		return sanitized ? [sanitized] : [];
 	});
 }
+function normalizeResponsesStringParamForReplay(value: unknown): string {
+	if (typeof value === "string") return value.toWellFormed();
+	if (value && typeof value === "object") {
+		const nestedText = (value as { text?: unknown }).text;
+		if (typeof nestedText === "string") return nestedText.toWellFormed();
+	}
+	try {
+		const encoded = JSON.stringify(value);
+		if (typeof encoded === "string") return encoded.toWellFormed();
+	} catch {
+		// Fall through to String().
+	}
+	return String(value ?? "").toWellFormed();
+}
+
+function sanitizeResponsesMessageContentForReplay(content: unknown): unknown {
+	if (typeof content === "string") return content.toWellFormed();
+	if (!Array.isArray(content)) return content;
+	return content.map(part => {
+		if (!part || typeof part !== "object") return part;
+		const sanitizedPart = { ...(part as Record<string, unknown>) };
+		if ("text" in sanitizedPart && typeof sanitizedPart.text !== "string") {
+			sanitizedPart.text = normalizeResponsesStringParamForReplay(sanitizedPart.text);
+		}
+		return sanitizedPart;
+	});
+}
+
+function sanitizeResponsesStringFieldsForReplay(item: Record<string, unknown>): void {
+	if (item.type === "message") {
+		item.content = sanitizeResponsesMessageContentForReplay(item.content);
+	}
+	if (item.type === "function_call" && "arguments" in item && typeof item.arguments !== "string") {
+		item.arguments = normalizeResponsesStringParamForReplay(item.arguments);
+	}
+	if (item.type === "custom_tool_call" && "input" in item && typeof item.input !== "string") {
+		item.input = normalizeResponsesStringParamForReplay(item.input);
+	}
+	if (
+		(item.type === "function_call_output" || item.type === "custom_tool_call_output") &&
+		"output" in item &&
+		typeof item.output !== "string"
+	) {
+		item.output = normalizeResponsesStringParamForReplay(item.output);
+	}
+}
 
 function sanitizeOpenAIResponsesHistoryItemForReplay(
 	item: Record<string, unknown>,
@@ -105,6 +151,7 @@ function sanitizeOpenAIResponsesHistoryItemForReplay(
 	if (typeof item.call_id === "string") {
 		sanitizedItem.call_id = normalizeReplayedResponsesHistoryCallId(item.call_id, normalizedCallIds);
 	}
+	sanitizeResponsesStringFieldsForReplay(sanitizedItem);
 
 	return sanitizedItem as unknown as OpenAIResponsesReplayItem;
 }

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -471,6 +471,41 @@ describe("OpenAI responses history payload", () => {
 		]);
 	});
 
+	it("normalizes object-valued text fields before replaying openai-codex native history", async () => {
+		const model = getBundledModel("openai-codex", "gpt-5.2-codex") as Model<"openai-codex-responses">;
+		const malformedHistoryItems: Record<string, unknown>[] = [
+			{
+				type: "message",
+				role: "user",
+				id: "msg_user",
+				content: [{ type: "input_text", text: { type: "text", text: "Recovered user" } }],
+			},
+			{
+				type: "message",
+				role: "assistant",
+				id: "msg_assistant",
+				content: [{ type: "output_text", text: { type: "text", text: "Recovered assistant" } }],
+			},
+		];
+		const payload = (await captureCodexPayload(model, {
+			messages: [
+				{ role: "user", content: "generic history that should be replaced", timestamp: Date.now() },
+				makeAssistantMessage(malformedHistoryItems, false, "openai-codex", "gpt-5.2-codex"),
+				{ role: "user", content: "follow-up user", timestamp: Date.now() },
+			],
+		})) as { input?: unknown[] };
+
+		expect(payload.input).toEqual([
+			{ type: "message", role: "user", content: [{ type: "input_text", text: "Recovered user" }] },
+			{
+				type: "message",
+				role: "assistant",
+				content: [{ type: "output_text", text: "Recovered assistant" }],
+			},
+			{ role: "user", content: [{ type: "input_text", text: "follow-up user" }] },
+		]);
+	});
+
 	it("ignores incompatible native history snapshots across providers", async () => {
 		const model = getBundledModel("github-copilot", "gpt-5.4") as Model<"openai-responses">;
 		const payload = (await captureResponsesPayload(model, codexToCopilotContext)) as { input?: unknown[] };


### PR DESCRIPTION
## Summary
- sanitize replayed OpenAI Responses history string fields before reusing them as request input
- apply the existing history replay sanitizer to the openai-codex responses path
- add regression coverage for object-valued Codex history text fields

## Verification
- bun --cwd=packages/ai run check
- bun test packages/ai/test/openai-responses-history-payload.test.ts