### PR TITLE
fix(ai): preserve object-valued tool replay fields

### DIFF
--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -117,7 +117,7 @@ function sanitizeResponsesMessageContentForReplay(content: unknown): unknown {
 	return content.map(part => {
 		if (!part || typeof part !== "object") return part;
 		const sanitizedPart = { ...(part as Record<string, unknown>) };
-		if ("text" in sanitizedPart && typeof sanitizedPart.text !== "string") {
+		if ("text" in sanitizedPart) {
 			sanitizedPart.text = normalizeResponsesMessageTextForReplay(sanitizedPart.text);
 		}
 		return sanitizedPart;

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -91,12 +91,8 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(items: Array<Record
 		return sanitized ? [sanitized] : [];
 	});
 }
-function normalizeResponsesStringParamForReplay(value: unknown): string {
+function stringifyResponsesStringParamForReplay(value: unknown): string {
 	if (typeof value === "string") return value.toWellFormed();
-	if (value && typeof value === "object") {
-		const nestedText = (value as { text?: unknown }).text;
-		if (typeof nestedText === "string") return nestedText.toWellFormed();
-	}
 	try {
 		const encoded = JSON.stringify(value);
 		if (typeof encoded === "string") return encoded.toWellFormed();
@@ -106,6 +102,15 @@ function normalizeResponsesStringParamForReplay(value: unknown): string {
 	return String(value ?? "").toWellFormed();
 }
 
+function normalizeResponsesMessageTextForReplay(value: unknown): string {
+	if (typeof value === "string") return value.toWellFormed();
+	if (value && typeof value === "object") {
+		const nestedText = (value as { text?: unknown }).text;
+		if (typeof nestedText === "string") return nestedText.toWellFormed();
+	}
+	return stringifyResponsesStringParamForReplay(value);
+}
+
 function sanitizeResponsesMessageContentForReplay(content: unknown): unknown {
 	if (typeof content === "string") return content.toWellFormed();
 	if (!Array.isArray(content)) return content;
@@ -113,7 +118,7 @@ function sanitizeResponsesMessageContentForReplay(content: unknown): unknown {
 		if (!part || typeof part !== "object") return part;
 		const sanitizedPart = { ...(part as Record<string, unknown>) };
 		if ("text" in sanitizedPart && typeof sanitizedPart.text !== "string") {
-			sanitizedPart.text = normalizeResponsesStringParamForReplay(sanitizedPart.text);
+			sanitizedPart.text = normalizeResponsesMessageTextForReplay(sanitizedPart.text);
 		}
 		return sanitizedPart;
 	});
@@ -124,17 +129,17 @@ function sanitizeResponsesStringFieldsForReplay(item: Record<string, unknown>): 
 		item.content = sanitizeResponsesMessageContentForReplay(item.content);
 	}
 	if (item.type === "function_call" && "arguments" in item && typeof item.arguments !== "string") {
-		item.arguments = normalizeResponsesStringParamForReplay(item.arguments);
+		item.arguments = stringifyResponsesStringParamForReplay(item.arguments);
 	}
 	if (item.type === "custom_tool_call" && "input" in item && typeof item.input !== "string") {
-		item.input = normalizeResponsesStringParamForReplay(item.input);
+		item.input = stringifyResponsesStringParamForReplay(item.input);
 	}
 	if (
 		(item.type === "function_call_output" || item.type === "custom_tool_call_output") &&
 		"output" in item &&
 		typeof item.output !== "string"
 	) {
-		item.output = normalizeResponsesStringParamForReplay(item.output);
+		item.output = stringifyResponsesStringParamForReplay(item.output);
 	}
 }
 

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -506,6 +506,31 @@ describe("OpenAI responses history payload", () => {
 		]);
 	});
 
+	it("normalizes string-valued message text to well-formed replay input", async () => {
+		const model = getBundledModel("openai-codex", "gpt-5.2-codex") as Model<"openai-codex-responses">;
+		const illFormedText = "Bad surrogate \uD800";
+		const payload = (await captureCodexPayload(model, {
+			messages: [
+				{ role: "user", content: "generic history that should be replaced", timestamp: Date.now() },
+				makeAssistantMessage(
+					[
+						{
+							type: "message",
+							role: "user",
+							content: [{ type: "input_text", text: illFormedText }],
+						},
+					],
+					false,
+					"openai-codex",
+					"gpt-5.2-codex",
+				),
+				{ role: "user", content: "follow-up user", timestamp: Date.now() },
+			],
+		})) as { input?: Array<{ content?: Array<{ text?: string }> }> };
+
+		expect(payload.input?.[0]?.content?.[0]?.text).toBe(illFormedText.toWellFormed());
+	});
+
 	it("stringifies object-valued tool replay fields instead of collapsing nested text", async () => {
 		const model = getBundledModel("openai-codex", "gpt-5.2-codex") as Model<"openai-codex-responses">;
 		const functionCallId = "call_replay_object_args";

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -506,6 +506,58 @@ describe("OpenAI responses history payload", () => {
 		]);
 	});
 
+	it("stringifies object-valued tool replay fields instead of collapsing nested text", async () => {
+		const model = getBundledModel("openai-codex", "gpt-5.2-codex") as Model<"openai-codex-responses">;
+		const functionCallId = "call_replay_object_args";
+		const customCallId = "call_replay_custom_input";
+		const malformedHistoryItems: Record<string, unknown>[] = [
+			{
+				type: "function_call",
+				id: "fc_replay_object_args",
+				call_id: functionCallId,
+				name: "echo",
+				arguments: { text: "hello", limit: 3 },
+			},
+			{
+				type: "function_call_output",
+				call_id: functionCallId,
+				output: { text: "tool result", ok: true },
+			},
+			{
+				type: "custom_tool_call",
+				id: "ctc_replay_custom_input",
+				call_id: customCallId,
+				name: "apply_patch",
+				input: { text: "patch body", operation: "insert" },
+			},
+			{
+				type: "custom_tool_call_output",
+				call_id: customCallId,
+				output: { text: "custom result", ok: true },
+			},
+		];
+		const payload = (await captureCodexPayload(model, {
+			messages: [
+				{ role: "user", content: "generic history that should be replaced", timestamp: Date.now() },
+				makeAssistantMessage(malformedHistoryItems, false, "openai-codex", "gpt-5.2-codex"),
+				{ role: "user", content: "follow-up user", timestamp: Date.now() },
+			],
+		})) as { input?: Array<Record<string, unknown>> };
+
+		expect(payload.input?.find(item => item.type === "function_call")).toMatchObject({
+			arguments: '{"text":"hello","limit":3}',
+		});
+		expect(payload.input?.find(item => item.type === "function_call_output")).toMatchObject({
+			output: '{"text":"tool result","ok":true}',
+		});
+		expect(payload.input?.find(item => item.type === "custom_tool_call")).toMatchObject({
+			input: '{"text":"patch body","operation":"insert"}',
+		});
+		expect(payload.input?.find(item => item.type === "custom_tool_call_output")).toMatchObject({
+			output: '{"text":"custom result","ok":true}',
+		});
+	});
+
 	it("ignores incompatible native history snapshots across providers", async () => {
 		const model = getBundledModel("github-copilot", "gpt-5.4") as Model<"openai-responses">;
 		const payload = (await captureResponsesPayload(model, codexToCopilotContext)) as { input?: unknown[] };


### PR DESCRIPTION
## Summary
- follow-up to #1199 after review noted sanitizer overreach
- restrict nested `{ text }` recovery to message content text parts only
- stringify object-valued function/custom tool input and output fields so replay preserves full payloads
- add regression coverage for object-valued tool replay fields

## Verification
- `bun --cwd=packages/ai run check`
- `bun test packages/ai/test/openai-responses-history-payload.test.ts`