### PR TITLE
fix(cli): list commands in root help

### DIFF
--- a/packages/coding-agent/src/cli/fast-help.ts
+++ b/packages/coding-agent/src/cli/fast-help.ts
@@ -1,7 +1,35 @@
 import { APP_NAME, CONFIG_DIR_NAME } from "@gajae-code/utils/dirs";
 
 export function getExtraHelpText(): string {
-	return `Environment Variables:
+	return `Commands:
+  ${APP_NAME} [prompt]             - Start an interactive coding session (default launch command)
+  ${APP_NAME} launch               - Start an explicit launch/session workflow
+  ${APP_NAME} setup                - Install GJC defaults or optional dependencies
+  ${APP_NAME} session              - List, inspect, create, remove, or attach sessions
+  ${APP_NAME} state                - Inspect or manage persisted GJC state
+  ${APP_NAME} harness              - Run harness control-plane commands
+  ${APP_NAME} coordinator          - Manage coordinator/runtime coordination helpers
+  ${APP_NAME} team                 - Run tmux-backed coordinated execution
+  ${APP_NAME} ultragoal            - Run durable goal execution workflow
+  ${APP_NAME} ralplan              - Run consensus planning workflow
+  ${APP_NAME} deep-interview       - Run requirements interview workflow
+  ${APP_NAME} skills               - List/read embedded workflow skills
+  ${APP_NAME} config               - List, get, and set configuration values
+  ${APP_NAME} notify               - Send or test notifications
+  ${APP_NAME} daemon               - Manage background daemon helpers
+  ${APP_NAME} mcp                  - Manage MCP server registrations
+  ${APP_NAME} mcp-serve            - Serve the MCP integration endpoint
+  ${APP_NAME} contribute-pr        - Prepare contribution/PR workflow artifacts
+  ${APP_NAME} migrate              - Run migration helpers
+  ${APP_NAME} rlm                  - Run RLM helpers
+  ${APP_NAME} update               - Update GJC installation artifacts
+  ${APP_NAME} plugin               - Install, remove, and list plugins
+  ${APP_NAME} web-search           - Search the web from the CLI (alias: q)
+  ${APP_NAME} codex-native-hook    - Run Codex native hook integration
+  ${APP_NAME} gc                   - Run garbage-collection/cleanup helpers
+  ${APP_NAME} <command> --help     - Show command-specific help
+
+Environment Variables:
   # Core Providers
   ANTHROPIC_API_KEY          - Anthropic Claude models
   ANTHROPIC_OAUTH_TOKEN      - Anthropic OAuth (takes precedence over API key)

--- a/packages/coding-agent/test/cli-help-load-order.test.ts
+++ b/packages/coding-agent/test/cli-help-load-order.test.ts
@@ -122,6 +122,64 @@ describe("CLI help load order", () => {
 		expect(combined).not.toContain("http-400-requests");
 	}, 15_000);
 
+	it("lists representative commands in root --help", async () => {
+		if (Bun.semver.order(Bun.version, "1.3.14") < 0) {
+			return;
+		}
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-help-commands-"));
+		cleanupRoot = root;
+		const home = path.join(root, "home");
+		const xdg = path.join(root, "xdg");
+		const agentDir = path.join(root, "agent");
+		await fs.mkdir(home, { recursive: true });
+		await fs.mkdir(xdg, { recursive: true });
+		await fs.mkdir(agentDir, { recursive: true });
+
+		const proc = Bun.spawn([process.execPath, cliEntry, "--help"], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: {
+				...process.env,
+				HOME: home,
+				XDG_CONFIG_HOME: xdg,
+				XDG_DATA_HOME: xdg,
+				GJC_CODING_AGENT_DIR: agentDir,
+				PI_CODING_AGENT_DIR: agentDir,
+				PI_NO_TITLE: "1",
+				NO_COLOR: "1",
+			},
+		});
+
+		const [stdout, stderr, exitCode] = await Promise.all([
+			readStream(proc.stdout as ReadableStream<Uint8Array>),
+			readStream(proc.stderr as ReadableStream<Uint8Array>),
+			proc.exited,
+		]);
+		const combined = `${stdout}\n${stderr}`;
+
+		expect(exitCode, combined).toBe(0);
+		expect(stdout).toContain("Commands:");
+		expect(stdout).toContain("gjc setup");
+		expect(stdout).toContain("gjc session");
+		expect(stdout).toContain("gjc state");
+		expect(stdout).toContain("gjc harness");
+		expect(stdout).toContain("gjc config");
+		expect(stdout).toContain("gjc ralplan");
+		expect(stdout).toContain("gjc ultragoal");
+		expect(stdout).toContain("gjc team");
+		expect(stdout).toContain("gjc mcp");
+		expect(stdout).toContain("gjc mcp-serve");
+		expect(stdout).toContain("gjc contribute-pr");
+		expect(stdout).toContain("gjc web-search");
+		expect(stdout).toContain("gjc codex-native-hook");
+		expect(stdout).toContain("gjc gc");
+		expect(stdout).toContain("gjc <command> --help");
+		expect(stdout).toContain("Available Tools");
+		expect(stdout).toContain("Useful Commands");
+		expect(stderr).toBe("");
+	}, 15_000);
+
 	it("fast-paths root --tmux --help before runtime globals", async () => {
 		if (Bun.semver.order(Bun.version, "1.3.14") < 0) {
 			return;


### PR DESCRIPTION
## Summary
- add a concise `Commands:` section to the root `gjc --help` fast-help output
- include representative workflow/session/config/plugin commands and command-specific help hint
- add regression coverage so root help must list representative commands while preserving existing sections

Fixes #1201

## Verification
- `bun install --frozen-lockfile`
- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/cli-help-load-order.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun packages/coding-agent/src/cli.ts --help`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*