### PR TITLE
fix(ai): normalize Codex text parts

### DIFF
--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -62,6 +62,49 @@ function getReasoningConfig(model: Model<Api>, options: CodexRequestOptions): Re
 	return config;
 }
 
+function describeTextPartValue(value: unknown): string {
+	if (value === null) return "null";
+	if (Array.isArray(value)) return "array";
+	return typeof value;
+}
+
+function normalizeTextPartValue(value: unknown, path: string): string {
+	if (typeof value === "string") return value.toWellFormed();
+	try {
+		const encoded = JSON.stringify(value);
+		if (typeof encoded === "string") return encoded.toWellFormed();
+	} catch {
+		// Fall through to the actionable local error below.
+	}
+	throw new Error(
+		`Invalid Codex request text part at ${path}: expected a string or JSON-serializable value, received ${describeTextPartValue(value)}. Normalize compacted continuation content before sending to Codex.`,
+	);
+}
+
+function normalizeTextPartFields(content: unknown, path: string): unknown {
+	if (typeof content === "string") return content.toWellFormed();
+	if (!Array.isArray(content)) return content;
+	return content.map((part, index) => {
+		if (!part || typeof part !== "object") return part;
+		const normalizedPart = { ...(part as Record<string, unknown>) };
+		if ("text" in normalizedPart) {
+			normalizedPart.text = normalizeTextPartValue(normalizedPart.text, `${path}[${index}].text`);
+		}
+		return normalizedPart;
+	});
+}
+
+function normalizeInputTextPartFields(input: InputItem[] | undefined): InputItem[] | undefined {
+	if (!Array.isArray(input)) return input;
+	return input.map((item, itemIndex) => {
+		if (item.type !== "message") return item;
+		return {
+			...item,
+			content: normalizeTextPartFields(item.content, `input[${itemIndex}].content`),
+		};
+	});
+}
+
 function filterInput(input: InputItem[] | undefined): InputItem[] | undefined {
 	if (!Array.isArray(input)) return input;
 
@@ -121,6 +164,7 @@ export async function transformRequestBody(
 				return item;
 			});
 		}
+		body.input = normalizeInputTextPartFields(body.input);
 	}
 
 	if (prompt?.developerMessages && prompt.developerMessages.length > 0 && Array.isArray(body.input)) {

--- a/packages/ai/test/openai-codex.test.ts
+++ b/packages/ai/test/openai-codex.test.ts
@@ -69,6 +69,60 @@ describe("openai-codex request transformer", () => {
 		const orphaned = input.find(item => item.type === "message" && item.role === "assistant");
 		expect(orphaned?.content).toMatch(/Previous tool result/);
 	});
+
+	it("normalizes object-valued text parts before provider send", async () => {
+		const body: RequestBody = {
+			model: "gpt-5.1-codex",
+			input: [
+				{
+					type: "message",
+					role: "user",
+					content: [
+						{
+							type: "input_text",
+							text: {
+								summary: "compacted continuation",
+								facts: ["context overflow maintenance resumed"],
+							},
+						},
+					],
+				},
+			],
+		};
+
+		const transformed = await transformRequestBody(body, createCodexModel(body.model), {});
+		const message = transformed.input?.[0];
+		const content = message?.content;
+
+		expect(Array.isArray(content)).toBe(true);
+		const [part] = content as Array<{ text: unknown }>;
+		expect(typeof part.text).toBe("string");
+		expect(part.text).toBe(
+			JSON.stringify({
+				summary: "compacted continuation",
+				facts: ["context overflow maintenance resumed"],
+			}),
+		);
+	});
+
+	it("fails locally for unserializable text parts", async () => {
+		const circular: Record<string, unknown> = { summary: "compacted continuation" };
+		circular.self = circular;
+		const body: RequestBody = {
+			model: "gpt-5.1-codex",
+			input: [
+				{
+					type: "message",
+					role: "user",
+					content: [{ type: "input_text", text: circular }],
+				},
+			],
+		};
+
+		await expect(transformRequestBody(body, createCodexModel(body.model), {})).rejects.toThrow(
+			/Invalid Codex request text part at input\[0\]\.content\[0\]\.text/,
+		);
+	});
 });
 
 describe("openai-codex reasoning effort validation", () => {


### PR DESCRIPTION
## Summary
- normalize Codex message content parts so any `content[].text` value is a string before provider send
- JSON-stringify structured compacted continuation text and fail locally with a clear path for unserializable values
- add regression coverage for object-valued and circular text parts

Fixes #1203.

## Verification
- `bun install --frozen-lockfile`
- `bun --cwd=packages/natives run build`
- `bun test packages/ai/test/openai-codex.test.ts` → 7 pass / 0 fail
- `bun --cwd=packages/ai run check:types`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
