### PR TITLE
Improve custom model preset creation

### DIFF
--- a/packages/coding-agent/src/modes/components/custom-model-preset-wizard.ts
+++ b/packages/coding-agent/src/modes/components/custom-model-preset-wizard.ts
@@ -6,15 +6,6 @@ import { DynamicBorder } from "./dynamic-border";
 
 const PROFILE_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
 
-type WizardStep = "name" | "display-name" | "provider" | "model" | "confirm";
-
-interface WizardState {
-	name: string;
-	displayName: string;
-	provider: string;
-	model: string;
-}
-
 export interface CustomModelPresetWizardSubmit {
 	name: string;
 	profile: ModelProfileConfig;
@@ -23,25 +14,21 @@ export interface CustomModelPresetWizardSubmit {
 export class CustomModelPresetWizardComponent extends Container {
 	#contentContainer: Container;
 	#input: Input | null = null;
-	#step: WizardStep = "name";
-	#selectedIndex = 0;
 	#lastError: string | null = null;
-	#state: WizardState = {
-		name: "",
-		displayName: "",
-		provider: "",
-		model: "",
-	};
+	#name = "";
+	#snapshot: ModelProfileConfig;
 	#onSubmit: (input: CustomModelPresetWizardSubmit) => void;
 	#onCancel: () => void;
 	#onRender: () => void;
 
 	constructor(
+		snapshot: ModelProfileConfig,
 		onSubmit: (input: CustomModelPresetWizardSubmit) => void,
 		onCancel: () => void,
 		onRender: () => void = () => {},
 	) {
 		super();
+		this.#snapshot = snapshot;
 		this.#onSubmit = onSubmit;
 		this.#onCancel = onCancel;
 		this.#onRender = onRender;
@@ -51,7 +38,7 @@ export class CustomModelPresetWizardComponent extends Container {
 		this.addChild(new TruncatedText(theme.bold("Create custom model preset")));
 		this.addChild(
 			new TruncatedText(
-				theme.fg("muted", "  Save provider/model as a selectable profile. Secrets are not requested."),
+				theme.fg("muted", "  Save the current default and explicit role models as a selectable profile."),
 				0,
 				0,
 			),
@@ -72,222 +59,76 @@ export class CustomModelPresetWizardComponent extends Container {
 
 	handleInput(keyData: string): void {
 		if (matchesAppInterrupt(keyData)) {
-			if (this.#step === "name") {
-				this.#onCancel();
-				return;
-			}
-			this.#goBack();
+			this.#onCancel();
 			return;
 		}
 
 		if (this.#input) {
 			if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
-				this.#saveInputAndProceed();
+				this.#saveInputAndSubmit();
 				return;
 			}
 			this.#input.handleInput(keyData);
-			return;
-		}
-
-		if (matchesKey(keyData, "up")) {
-			this.#moveSelection(-1);
-			return;
-		}
-		if (matchesKey(keyData, "down")) {
-			this.#moveSelection(1);
-			return;
-		}
-		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
-			this.#selectCurrentOption();
 		}
 	}
 
 	#renderStep(): void {
 		this.#contentContainer.clear();
 		this.#input = null;
-		switch (this.#step) {
-			case "name":
-				this.#renderInputStep(
-					"Step 1: Preset id",
-					"Enter a unique preset id:",
-					this.#state.name,
-					"e.g. my-fast-coder",
-				);
-				break;
-			case "display-name":
-				this.#renderInputStep(
-					"Step 2: Display name",
-					"Enter a display name:",
-					this.#state.displayName,
-					"e.g. My Fast Coder",
-				);
-				break;
-			case "provider":
-				this.#renderInputStep(
-					"Step 3: Provider",
-					"Enter the provider id:",
-					this.#state.provider,
-					"e.g. openai-codex, anthropic, my-oai",
-				);
-				break;
-			case "model":
-				this.#renderInputStep(
-					"Step 4: Model",
-					"Enter the model id or provider/model selector:",
-					this.#state.model,
-					"e.g. gpt-5.5:medium or my-oai/gpt-example:low",
-				);
-				break;
-			case "confirm":
-				this.#renderConfirmStep();
-				break;
-		}
-	}
-
-	#renderInputStep(title: string, prompt: string, value: string, hint: string): void {
-		this.#contentContainer.addChild(new Text(theme.fg("accent", title)));
+		this.#contentContainer.addChild(new Text(theme.fg("accent", "Preset id")));
 		this.#contentContainer.addChild(new Spacer(1));
 		if (this.#lastError) {
 			this.#contentContainer.addChild(new Text(theme.fg("error", this.#lastError), 0, 0));
 			this.#contentContainer.addChild(new Spacer(1));
 		}
-		this.#contentContainer.addChild(new Text(prompt, 0, 0));
+		this.#contentContainer.addChild(new Text("Enter a unique preset id:", 0, 0));
 		this.#contentContainer.addChild(new Spacer(1));
 		this.#input = new Input();
-		this.#input.setValue(value);
+		this.#input.setValue(this.#name);
 		this.#contentContainer.addChild(this.#input);
 		this.#contentContainer.addChild(new Spacer(1));
-		this.#addHelp(hint);
-		this.#addHelp("[Enter to continue, Esc to go back]");
+		this.#addSnapshotPreview();
+		this.#addHelp("e.g. my-fast-coder");
+		this.#addHelp("[Enter to create, Esc to cancel]");
 	}
 
-	#renderConfirmStep(): void {
-		this.#contentContainer.addChild(new Text(theme.fg("accent", "Confirm custom preset")));
-		this.#contentContainer.addChild(new Spacer(1));
-		if (this.#lastError) {
-			this.#contentContainer.addChild(new Text(theme.fg("error", this.#lastError), 0, 0));
-			this.#contentContainer.addChild(new Spacer(1));
+	#addSnapshotPreview(): void {
+		this.#contentContainer.addChild(new Text(theme.fg("muted", "Snapshot:"), 0, 0));
+		for (const [role, selector] of Object.entries(this.#snapshot.model_mapping)) {
+			this.#contentContainer.addChild(new Text(`  ${role}: ${selector}`, 0, 0));
 		}
-		this.#contentContainer.addChild(new Text(`Preset id: ${this.#state.name}`, 0, 0));
-		this.#contentContainer.addChild(new Text(`Display name: ${this.#state.displayName}`, 0, 0));
-		this.#contentContainer.addChild(new Text(`Provider: ${this.#state.provider}`, 0, 0));
-		this.#contentContainer.addChild(new Text(`Default model: ${this.#selector()}`, 0, 0));
+		this.#contentContainer.addChild(new Text(`  providers: ${this.#snapshot.required_providers.join(", ")}`, 0, 0));
 		this.#contentContainer.addChild(new Spacer(1));
-		this.#addOption(0, "Create preset");
-		this.#addOption(1, "Go back");
-		this.#addHelp("[↑↓ to navigate, Enter to select, Esc to go back]");
-	}
-
-	#addOption(index: number, label: string): void {
-		const selected = index === this.#selectedIndex;
-		const prefix = selected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
-		this.#contentContainer.addChild(new Text(`${prefix}${selected ? theme.fg("accent", label) : label}`, 0, 0));
 	}
 
 	#addHelp(text: string): void {
 		this.#contentContainer.addChild(new Text(theme.fg("muted", text), 0, 0));
 	}
 
-	#saveInputAndProceed(): void {
+	#saveInputAndSubmit(): void {
 		const value = this.#input?.getValue().trim() ?? "";
 		if (!value) {
-			this.#lastError = this.#emptyFieldMessage();
+			this.#lastError = "Preset id is required.";
 			this.#renderStep();
 			this.#onRender();
 			return;
 		}
-		const validationError = this.#validateCurrentInput(value);
-		if (validationError) {
-			this.#lastError = validationError;
+		if (!PROFILE_NAME_PATTERN.test(value)) {
+			this.#lastError = "Preset id must use lowercase letters, numbers, dots, underscores, or hyphens.";
 			this.#renderStep();
 			this.#onRender();
 			return;
 		}
+		this.#name = value;
 		this.#lastError = null;
-		if (this.#step === "name") {
-			this.#state.name = value;
-			this.#step = "display-name";
-		} else if (this.#step === "display-name") {
-			this.#state.displayName = value;
-			this.#step = "provider";
-		} else if (this.#step === "provider") {
-			this.#state.provider = value;
-			this.#step = "model";
-		} else if (this.#step === "model") {
-			this.#state.model = value;
-			this.#step = "confirm";
-			this.#selectedIndex = 0;
-		}
-		this.#renderStep();
-		this.#onRender();
-	}
-
-	#emptyFieldMessage(): string {
-		switch (this.#step) {
-			case "name":
-				return "Preset id is required.";
-			case "display-name":
-				return "Display name is required.";
-			case "provider":
-				return "Provider is required.";
-			case "model":
-				return "Model is required.";
-			case "confirm":
-				return "Value is required.";
-		}
-	}
-
-	#validateCurrentInput(value: string): string | undefined {
-		if (this.#step === "name" && !PROFILE_NAME_PATTERN.test(value)) {
-			return "Preset id must use lowercase letters, numbers, dots, underscores, or hyphens.";
-		}
-		if (this.#step === "provider" && !PROFILE_NAME_PATTERN.test(value)) {
-			return "Provider id must use lowercase letters, numbers, dots, underscores, or hyphens.";
-		}
-		if (this.#step === "model" && value.includes(",")) {
-			return "Model must be one selector, not a comma-separated list.";
-		}
-		return undefined;
-	}
-
-	#selectCurrentOption(): void {
-		if (this.#step !== "confirm") return;
-		if (this.#selectedIndex === 0) {
-			this.#onSubmit(this.#buildInput());
-			return;
-		}
-		this.#goBack();
-	}
-
-	#buildInput(): CustomModelPresetWizardSubmit {
-		return {
-			name: this.#state.name,
+		this.#onSubmit({
+			name: value,
 			profile: {
-				required_providers: [this.#state.provider],
-				display_name: this.#state.displayName,
-				model_mapping: { default: this.#selector() },
+				...this.#snapshot,
+				display_name: value,
+				model_mapping: { ...this.#snapshot.model_mapping },
+				required_providers: [...this.#snapshot.required_providers],
 			},
-		};
-	}
-
-	#selector(): string {
-		return this.#state.model.includes("/") ? this.#state.model : `${this.#state.provider}/${this.#state.model}`;
-	}
-
-	#moveSelection(delta: number): void {
-		this.#selectedIndex = (this.#selectedIndex + delta + 2) % 2;
-		this.#renderStep();
-		this.#onRender();
-	}
-
-	#goBack(): void {
-		if (this.#step === "display-name") this.#step = "name";
-		else if (this.#step === "provider") this.#step = "display-name";
-		else if (this.#step === "model") this.#step = "provider";
-		else if (this.#step === "confirm") this.#step = "model";
-		this.#selectedIndex = 0;
-		this.#lastError = null;
-		this.#renderStep();
-		this.#onRender();
+		});
 	}
 }

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -28,6 +28,7 @@ import {
 	resolveModelRoleValue,
 	type ScopedModelSelection,
 } from "../../config/model-resolver";
+import type { ModelProfileConfig } from "../../config/models-config-schema";
 import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
 import { formatModelOnboardingInlineHint } from "../../setup/model-onboarding-guidance";
@@ -105,6 +106,7 @@ export type ModelSelectorSelection =
 	  }
 	| {
 			kind: "createProfile";
+			profile: ModelProfileConfig;
 	  };
 
 interface PendingThinkingChoice {
@@ -155,11 +157,16 @@ interface PresetCreateRow {
 	kind: "create";
 }
 
+interface PresetAlreadySavedRow {
+	kind: "alreadySaved";
+	profileName: string;
+}
+
 interface PresetBrowseRow {
 	kind: "browse";
 }
 
-type PresetLandingRow = PresetGroupRow | PresetProfileRow | PresetCreateRow | PresetBrowseRow;
+type PresetLandingRow = PresetGroupRow | PresetProfileRow | PresetCreateRow | PresetAlreadySavedRow | PresetBrowseRow;
 
 // Stable logical identity for a preset landing row, independent of its current
 // list position. Used to relocate the cursor after the expanded group changes so
@@ -174,6 +181,8 @@ function presetRowIdentity(row: PresetLandingRow): string {
 			return "browse";
 		case "create":
 			return "create";
+		case "alreadySaved":
+			return `alreadySaved:${row.profileName}`;
 	}
 }
 
@@ -192,6 +201,54 @@ function isPrintableCharacter(keyData: string): boolean {
 
 function profileRequiredProviders(profile: ModelProfileDefinition): string[] {
 	return [...new Set(profile.requiredProviders)].sort((a, b) => a.localeCompare(b));
+}
+
+function isInheritedRoleSelector(value: string | undefined): boolean {
+	const normalized = value?.trim();
+	return !normalized || normalized === "default" || normalized === "pi/default";
+}
+
+function getSelectorProvider(selector: string): string | undefined {
+	const slashIndex = selector.indexOf("/");
+	return slashIndex > 0 ? selector.slice(0, slashIndex) : undefined;
+}
+
+function deriveRequiredProviders(modelMapping: ModelProfileConfig["model_mapping"]): string[] {
+	const providers = new Set<string>();
+	for (const selector of Object.values(modelMapping)) {
+		const provider = getSelectorProvider(selector);
+		if (provider) providers.add(provider);
+	}
+	return [...providers].sort((a, b) => a.localeCompare(b));
+}
+
+function sameStringRecord(
+	left: Readonly<Record<string, string | undefined>>,
+	right: Readonly<Record<string, string | undefined>>,
+): boolean {
+	const leftEntries = Object.entries(left)
+		.filter((entry): entry is [string, string] => entry[1] !== undefined)
+		.sort(([a], [b]) => a.localeCompare(b));
+	const rightEntries = Object.entries(right)
+		.filter((entry): entry is [string, string] => entry[1] !== undefined)
+		.sort(([a], [b]) => a.localeCompare(b));
+	if (leftEntries.length !== rightEntries.length) return false;
+	for (let i = 0; i < leftEntries.length; i++) {
+		const leftEntry = leftEntries[i];
+		const rightEntry = rightEntries[i];
+		if (!leftEntry || !rightEntry || leftEntry[0] !== rightEntry[0] || leftEntry[1] !== rightEntry[1]) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function sameStringArray(left: readonly string[], right: readonly string[]): boolean {
+	if (left.length !== right.length) return false;
+	for (let i = 0; i < left.length; i++) {
+		if (left[i] !== right[i]) return false;
+	}
+	return true;
 }
 /**
  * Component that renders a canonical model selector with provider tabs.
@@ -733,6 +790,46 @@ export class ModelSelectorComponent extends Container {
 		return groupModelProfilesForPresetLanding(this.#modelRegistry.getModelProfiles?.() ?? new Map());
 	}
 
+	#buildCustomModelProfileSnapshot(): ModelProfileConfig {
+		const modelMapping: ModelProfileConfig["model_mapping"] = {};
+		if (this.#currentModel) {
+			modelMapping.default = formatModelSelectorValue(
+				`${this.#currentModel.provider}/${this.#currentModel.id}`,
+				this.#currentThinkingLevel,
+			);
+		} else {
+			const defaultRole = this.#settings.getModelRole("default");
+			if (!isInheritedRoleSelector(defaultRole)) modelMapping.default = defaultRole;
+		}
+
+		const visionRole = this.#settings.getModelRole("vision");
+		if (!isInheritedRoleSelector(visionRole)) modelMapping.vision = visionRole;
+
+		const agentOverrides = this.#settings.get("task.agentModelOverrides");
+		for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
+			if (role === "default" || role === "vision") continue;
+			const selector = agentOverrides[role];
+			if (!isInheritedRoleSelector(selector)) modelMapping[role] = selector;
+		}
+
+		return {
+			required_providers: deriveRequiredProviders(modelMapping),
+			model_mapping: modelMapping,
+		};
+	}
+
+	#findDuplicateGeneratedProfile(snapshot: ModelProfileConfig): ModelProfileDefinition | undefined {
+		for (const profile of this.#modelRegistry.getModelProfiles?.().values() ?? []) {
+			if (
+				sameStringRecord(profile.modelMapping, snapshot.model_mapping) &&
+				sameStringArray(profile.requiredProviders, snapshot.required_providers)
+			) {
+				return profile;
+			}
+		}
+		return undefined;
+	}
+
 	#getPresetRows(): PresetLandingRow[] {
 		const rows: PresetLandingRow[] = [];
 		for (const [groupId, profiles] of this.#getPresetGroups()) {
@@ -741,7 +838,9 @@ export class ModelSelectorComponent extends Container {
 				for (const profile of profiles) rows.push({ kind: "profile", groupId, profile });
 			}
 		}
-		rows.push({ kind: "create" });
+		const snapshot = this.#buildCustomModelProfileSnapshot();
+		const duplicateProfile = this.#findDuplicateGeneratedProfile(snapshot);
+		rows.push(duplicateProfile ? { kind: "alreadySaved", profileName: duplicateProfile.name } : { kind: "create" });
 		rows.push({ kind: "browse" });
 		return rows;
 	}
@@ -815,7 +914,8 @@ export class ModelSelectorComponent extends Container {
 
 	#expandSelectedPresetProvider(): void {
 		const selected = this.#getSelectedPresetRow();
-		if (!selected || selected.kind === "browse" || selected.kind === "create") return;
+		if (!selected || selected.kind === "browse" || selected.kind === "create" || selected.kind === "alreadySaved")
+			return;
 		if (this.#expandedPresetProviderId === selected.groupId) return;
 		const targetIdentity = presetRowIdentity(selected);
 		this.#expandedPresetProviderId = selected.groupId;
@@ -824,7 +924,8 @@ export class ModelSelectorComponent extends Container {
 
 	#collapseSelectedPresetProvider(): void {
 		const selected = this.#getSelectedPresetRow();
-		if (!selected || selected.kind === "browse" || selected.kind === "create") return;
+		if (!selected || selected.kind === "browse" || selected.kind === "create" || selected.kind === "alreadySaved")
+			return;
 		if (this.#expandedPresetProviderId !== selected.groupId) return;
 		const targetIdentity = selected.kind === "profile" ? `group:${selected.groupId}` : presetRowIdentity(selected);
 		this.#expandedPresetProviderId = undefined;
@@ -858,6 +959,12 @@ export class ModelSelectorComponent extends Container {
 			if (row.kind === "create") {
 				const label = "Create custom preset";
 				this.#listContainer.addChild(new Text(`${prefix}${selected ? theme.fg("accent", label) : label}`, 0, 0));
+				continue;
+			}
+			if (row.kind === "alreadySaved") {
+				const label = `Already saved as ${row.profileName}`;
+				const renderedLabel = selected ? theme.fg("accent", label) : theme.fg("dim", label);
+				this.#listContainer.addChild(new Text(`${prefix}${renderedLabel}`, 0, 0));
 				continue;
 			}
 			if (row.kind === "browse") {
@@ -1306,7 +1413,10 @@ export class ModelSelectorComponent extends Container {
 		const row = this.#getSelectedPresetRow();
 		if (!row) return;
 		if (row.kind === "create") {
-			this.#onSelectCallback({ kind: "createProfile" });
+			this.#onSelectCallback({ kind: "createProfile", profile: this.#buildCustomModelProfileSnapshot() });
+			return;
+		}
+		if (row.kind === "alreadySaved") {
 			return;
 		}
 		if (row.kind === "browse") {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -8,6 +8,7 @@ import { activateModelProfile, materializeActiveModelProfileAssignment } from ".
 import { recommendModelProfileForProvider } from "../../config/model-profiles";
 import { GJC_MODEL_ASSIGNMENT_TARGETS } from "../../config/model-registry";
 import { formatModelSelectorValue } from "../../config/model-resolver";
+import type { ModelProfileConfig } from "../../config/models-config-schema";
 import { settings } from "../../config/settings";
 import { DebugSelectorComponent } from "../../debug";
 import { disableProvider, enableProvider } from "../../discovery";
@@ -238,7 +239,7 @@ export class SelectorController {
 		this.ctx.ui.requestRender();
 	}
 
-	showCustomModelPresetWizard(): void {
+	showCustomModelPresetWizard(snapshot: ModelProfileConfig): void {
 		this.showSelector(done => {
 			let wizard: CustomModelPresetWizardComponent;
 			const submit = async (input: CustomModelPresetWizardSubmit): Promise<void> => {
@@ -255,6 +256,7 @@ export class SelectorController {
 				}
 			};
 			wizard = new CustomModelPresetWizardComponent(
+				snapshot,
 				input => {
 					void submit(input);
 				},
@@ -676,7 +678,7 @@ export class SelectorController {
 					try {
 						if (selection.kind === "createProfile") {
 							done();
-							this.showCustomModelPresetWizard();
+							this.showCustomModelPresetWizard(selection.profile);
 							return;
 						}
 						if (selection.kind === "profile") {

--- a/packages/coding-agent/test/custom-model-preset-creation.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-creation.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import type { ModelProfileDefinition } from "@gajae-code/coding-agent/config/model-profiles";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import type { ModelProfileConfig } from "@gajae-code/coding-agent/config/models-config-schema";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { CustomModelPresetWizardComponent } from "@gajae-code/coding-agent/modes/components/custom-model-preset-wizard";
 import {
@@ -16,6 +20,14 @@ import { YAML } from "bun";
 
 let tempDir: string;
 let authStorage: AuthStorage;
+
+const currentModel = (provider: string, id: string): Model =>
+	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
+
+const snapshot: ModelProfileConfig = {
+	required_providers: ["my-oai"],
+	model_mapping: { default: "my-oai/gpt-custom:low" },
+};
 
 beforeEach(async () => {
 	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-custom-preset-"));
@@ -37,27 +49,55 @@ function normalizeRenderedText(text: string): string {
 	return text.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
+function createRegistry(profiles: Iterable<[string, ModelProfileDefinition]> = []) {
+	const profileMap = new Map(profiles);
+	return {
+		refresh: async () => {},
+		getError: () => undefined,
+		getAvailable: () => [currentModel("my-oai", "gpt-custom"), currentModel("anthropic", "claude")],
+		getAll: () => [currentModel("my-oai", "gpt-custom"), currentModel("anthropic", "claude")],
+		getProviders: () => [],
+		getCanonicalModels: () => [],
+		getDiscoverableProviders: () => [],
+		findCanonicalModel: () => undefined,
+		resolveCanonicalModel: () => undefined,
+		getModelProfiles: () => new Map(profileMap),
+		getModelProfile: (name: string) => profileMap.get(name),
+		getApiKeyForProvider: async () => "key",
+	} as unknown as ModelRegistry;
+}
+
 describe("custom model preset creation", () => {
-	it("validates wizard input with human-readable errors and never asks for secrets", () => {
+	it("validates the one-name wizard and never asks for secrets", () => {
 		const submitted: unknown[] = [];
 		const wizard = new CustomModelPresetWizardComponent(
+			snapshot,
 			input => submitted.push(input),
 			() => {},
 			() => {},
 		);
 
 		typeText(wizard, "Bad Name");
-		let text = normalizeRenderedText(wizard.render(120).join("\n"));
+		const text = normalizeRenderedText(wizard.render(120).join("\n"));
 		expect(text).toContain("Preset id must use lowercase letters, numbers, dots, underscores, or hyphens.");
+		expect(text).not.toContain("Display name");
+		expect(text).not.toContain("Provider");
+		expect(text).not.toContain("Model");
 		expect(text).not.toContain("API key");
 		expect(text).not.toContain("secret");
+		expect(submitted).toEqual([]);
 
 		typeText(wizard, "my-fast");
-		typeText(wizard, "My Fast");
-		typeText(wizard, "bad provider");
-		text = normalizeRenderedText(wizard.render(120).join("\n"));
-		expect(text).toContain("Provider id must use lowercase letters, numbers, dots, underscores, or hyphens.");
-		expect(submitted).toEqual([]);
+		expect(submitted).toEqual([
+			{
+				name: "my-fast",
+				profile: {
+					display_name: "my-fast",
+					required_providers: ["my-oai"],
+					model_mapping: { default: "my-oai/gpt-custom:low" },
+				},
+			},
+		]);
 	});
 
 	it("persists a custom preset and includes it in later registry sessions", async () => {
@@ -65,12 +105,12 @@ describe("custom model preset creation", () => {
 		const registry = new ModelRegistry(authStorage, modelsPath);
 
 		const profile = await registry.saveCustomModelProfile("my-fast", {
-			display_name: "My Fast",
+			display_name: "my-fast",
 			required_providers: ["my-oai"],
 			model_mapping: { default: "my-oai/gpt-custom:low" },
 		});
 
-		expect(profile.displayName).toBe("My Fast");
+		expect(profile.displayName).toBe("my-fast");
 		expect(registry.getModelProfile("my-fast")?.modelMapping.default).toBe("my-oai/gpt-custom:low");
 		const parsed = YAML.parse(await Bun.file(modelsPath).text()) as {
 			profiles: Record<
@@ -78,13 +118,13 @@ describe("custom model preset creation", () => {
 				{ display_name?: string; required_providers: string[]; model_mapping: Record<string, string> }
 			>;
 		};
-		expect(parsed.profiles["my-fast"]?.display_name).toBe("My Fast");
+		expect(parsed.profiles["my-fast"]?.display_name).toBe("my-fast");
 		expect(parsed.profiles["my-fast"]?.required_providers).toEqual(["my-oai"]);
 		expect(parsed.profiles["my-fast"]?.model_mapping.default).toBe("my-oai/gpt-custom:low");
 
 		const laterRegistry = new ModelRegistry(authStorage, modelsPath);
 		expect(laterRegistry.getAvailableModelProfileNames()).toContain("my-fast");
-		expect(laterRegistry.getModelProfile("my-fast")?.displayName).toBe("My Fast");
+		expect(laterRegistry.getModelProfile("my-fast")?.displayName).toBe("my-fast");
 	});
 
 	it("rejects creating a preset when existing models config is invalid and preserves it", async () => {
@@ -107,7 +147,7 @@ describe("custom model preset creation", () => {
 
 		await expect(
 			registry.saveCustomModelProfile("my-fast", {
-				display_name: "My Fast",
+				display_name: "my-fast",
 				required_providers: ["my-oai"],
 				model_mapping: { default: "my-oai/gpt-custom:low" },
 			}),
@@ -184,57 +224,123 @@ describe("custom model preset creation", () => {
 		).rejects.toThrow("Expected provider/modelId with optional :effort suffix");
 	});
 
-	it("surfaces create custom preset as a separate preset action", async () => {
-		const registry = {
-			refresh: async () => {},
-			getError: () => undefined,
-			getAll: () => [],
-			getProviders: () => [],
-			getCanonicalModels: () => [],
-			getDiscoverableProviders: () => [],
-			findCanonicalModel: () => undefined,
-			resolveCanonicalModel: () => undefined,
-			getModelProfiles: () =>
-				new Map([
-					[
-						"my-fast",
-						{
-							name: "my-fast",
-							displayName: "My Fast",
-							requiredProviders: ["my-oai"],
-							modelMapping: { default: "my-oai/gpt-custom" },
-							source: "user" as const,
-						},
-					],
-				]),
-			getModelProfile: (name: string) => registry.getModelProfiles().get(name),
-			getApiKeyForProvider: async () => "key",
-		} as unknown as ModelRegistry;
+	it("surfaces create custom preset with the generated current model snapshot", async () => {
+		const settings = Settings.isolated({
+			modelRoles: { vision: "default" },
+			"task.agentModelOverrides": {
+				executor: "anthropic/claude:high",
+				architect: "pi/default",
+				planner: "",
+				critic: "my-oai/gpt-custom",
+			},
+		});
+		const otherProfile: ModelProfileDefinition = {
+			name: "other",
+			displayName: "Other",
+			requiredProviders: ["other-provider"],
+			modelMapping: { default: "other-provider/model" },
+			source: "user",
+		};
 		const selections: ModelSelectorSelection[] = [];
 		const selector = new ModelSelectorComponent(
 			{ requestRender: () => {} } as unknown as TUI,
-			undefined,
-			Settings.isolated({}),
-			registry,
+			currentModel("my-oai", "gpt-custom"),
+			settings,
+			createRegistry([[otherProfile.name, otherProfile]]),
 			[],
 			selection => {
 				selections.push(selection);
 			},
 			() => {},
+			{ currentThinkingLevel: ThinkingLevel.Low },
 		);
-		await new Promise(resolve => setTimeout(resolve, 0));
+		await Bun.sleep(0);
 
-		let text = normalizeRenderedText(selector.render(180).join("\n"));
-		expect(text).toContain("CUSTOM");
-		selector.handleInput("\x1b[C");
-		text = normalizeRenderedText(selector.render(180).join("\n"));
-		expect(text).toContain("My Fast");
+		const text = normalizeRenderedText(selector.render(180).join("\n"));
 		expect(text).toContain("Create custom preset");
 		expect(text).toContain("Browse all models");
 
 		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		expect(selections).toEqual([
+			{
+				kind: "createProfile",
+				profile: {
+					required_providers: ["anthropic", "my-oai"],
+					model_mapping: {
+						default: "my-oai/gpt-custom:low",
+						executor: "anthropic/claude:high",
+						critic: "my-oai/gpt-custom",
+					},
+				},
+			},
+		]);
+	});
+
+	it("keeps create custom preset visible when raw required provider order differs", async () => {
+		const orderMismatchProfile: ModelProfileDefinition = {
+			name: "order-mismatch",
+			displayName: "Order Mismatch",
+			requiredProviders: ["my-oai", "anthropic"],
+			modelMapping: {
+				default: "my-oai/gpt-custom:low",
+				executor: "anthropic/claude:high",
+			},
+			source: "user",
+		};
+		const selections: ModelSelectorSelection[] = [];
+		const selector = new ModelSelectorComponent(
+			{ requestRender: () => {} } as unknown as TUI,
+			currentModel("my-oai", "gpt-custom"),
+			Settings.isolated({ "task.agentModelOverrides": { executor: "anthropic/claude:high" } }),
+			createRegistry([[orderMismatchProfile.name, orderMismatchProfile]]),
+			[],
+			selection => {
+				selections.push(selection);
+			},
+			() => {},
+			{ currentThinkingLevel: ThinkingLevel.Low },
+		);
+		await Bun.sleep(0);
+
+		const text = normalizeRenderedText(selector.render(180).join("\n"));
+		expect(text).toContain("Create custom preset");
+		expect(text).not.toContain("Already saved as order-mismatch");
+
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
-		expect(selections).toEqual([{ kind: "createProfile" }]);
+		expect(selections[0]?.kind).toBe("createProfile");
+	});
+	it("replaces create custom preset with a disabled already-saved row for duplicate raw payloads", async () => {
+		const duplicateProfile: ModelProfileDefinition = {
+			name: "saved-current",
+			displayName: "Saved Current",
+			requiredProviders: ["my-oai"],
+			modelMapping: { default: "my-oai/gpt-custom:low" },
+			source: "user",
+		};
+		const selections: ModelSelectorSelection[] = [];
+		const selector = new ModelSelectorComponent(
+			{ requestRender: () => {} } as unknown as TUI,
+			currentModel("my-oai", "gpt-custom"),
+			Settings.isolated({}),
+			createRegistry([[duplicateProfile.name, duplicateProfile]]),
+			[],
+			selection => {
+				selections.push(selection);
+			},
+			() => {},
+			{ currentThinkingLevel: ThinkingLevel.Low },
+		);
+		await Bun.sleep(0);
+
+		const text = normalizeRenderedText(selector.render(180).join("\n"));
+		expect(text).toContain("Already saved as saved-current");
+		expect(text).not.toContain("Create custom preset");
+		expect(text).toContain("Browse all models");
+
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		expect(selections).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary
- simplify custom model preset creation to a one-name wizard backed by the current model snapshot
- generate one raw profile payload in the model selector and pass it through the controller to persistence
- replace duplicate creation with an inert `Already saved as <preset>` row when raw `model_mapping` and `required_providers` match
- add focused coverage for snapshot generation, duplicate suppression, raw provider-order mismatch, and validation/id-collision behavior

## Verification
- `bun test packages/coding-agent/test/custom-model-preset-creation.test.ts packages/coding-agent/test/model-selector-profiles.test.ts` — 18 pass, 0 fail
- `bun run check:ts` — exited 0; only unrelated pre-existing warnings in `packages/coding-agent/src/session/session-manager.ts`

## Notes
- PR branch is based on upstream `dev`.
- Unrelated local changes in `packages/natives/native/index.d.ts` and `packages/natives/native/index.js` were not included.