### PR TITLE
fix(ai): drop invalid Codex encrypted content

### DIFF
--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -23,6 +23,7 @@ export interface InputItem {
 	name?: string;
 	output?: unknown;
 	arguments?: unknown;
+	encrypted_content?: unknown;
 }
 
 export interface RequestBody {
@@ -97,11 +98,19 @@ function normalizeTextPartFields(content: unknown, path: string): unknown {
 function normalizeInputTextPartFields(input: InputItem[] | undefined): InputItem[] | undefined {
 	if (!Array.isArray(input)) return input;
 	return input.map((item, itemIndex) => {
-		if (item.type !== "message") return item;
-		return {
-			...item,
-			content: normalizeTextPartFields(item.content, `input[${itemIndex}].content`),
-		};
+		const normalizedItem = { ...item };
+		const itemRecord = normalizedItem as Record<string, unknown>;
+		if ("encrypted_content" in itemRecord) {
+			if (typeof itemRecord.encrypted_content === "string") {
+				itemRecord.encrypted_content = itemRecord.encrypted_content.toWellFormed();
+			} else {
+				delete itemRecord.encrypted_content;
+			}
+		}
+		if (normalizedItem.type === "message") {
+			normalizedItem.content = normalizeTextPartFields(normalizedItem.content, `input[${itemIndex}].content`);
+		}
+		return normalizedItem;
 	});
 }
 

--- a/packages/ai/test/openai-codex.test.ts
+++ b/packages/ai/test/openai-codex.test.ts
@@ -105,6 +105,28 @@ describe("openai-codex request transformer", () => {
 		);
 	});
 
+	it("drops non-string encrypted_content before provider send", async () => {
+		const body: RequestBody = {
+			model: "gpt-5.1-codex",
+			input: [
+				{
+					type: "reasoning",
+					encrypted_content: { opaque: "not-a-valid-encrypted-payload" },
+				},
+				{
+					type: "reasoning",
+					encrypted_content: "enc_valid",
+				},
+			],
+		};
+
+		const transformed = await transformRequestBody(body, createCodexModel(body.model), {});
+		const [dropped, preserved] = transformed.input as Array<Record<string, unknown>>;
+
+		expect(dropped?.encrypted_content).toBeUndefined();
+		expect(preserved?.encrypted_content).toBe("enc_valid");
+	});
+
 	it("fails locally for unserializable text parts", async () => {
 		const circular: Record<string, unknown> = { summary: "compacted continuation" };
 		circular.self = circular;


### PR DESCRIPTION
## Summary
- drop non-string top-level `encrypted_content` from outgoing Codex request input items before provider send
- preserve valid string `encrypted_content` values, including well-formed string normalization
- add regression coverage for object-valued replay `encrypted_content`

Fixes #1207.

## Verification
- `bun install --frozen-lockfile`
- `bun --cwd=packages/natives run build`
- `bun test packages/ai/test/openai-codex.test.ts` → 8 pass / 0 fail
- `bun --cwd=packages/ai run check:types`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
