### PR TITLE
Fix tmux window-name sanitization

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -306,27 +306,33 @@ function truncateVisibleTail(value: string, maxWidth: number): string {
 	return `…${result}`;
 }
 
+const GJC_TMUX_WINDOW_BRANCH_SEPARATOR = "-";
+
+function sanitizeTmuxWindowTitleSegment(value: string): string {
+	return value.replace(/:+/g, "-");
+}
+
 function sanitizeTmuxWindowProjectName(project: string): string {
 	const trimmed = project.trim();
 	if (!trimmed || /^\.+$/.test(trimmed)) return "gjc";
-	if (trimmed.startsWith(".")) return `dot-${trimmed.replace(/^\.+/, "")}`;
-	return trimmed;
+	if (trimmed.startsWith(".")) return sanitizeTmuxWindowTitleSegment(`dot-${trimmed.replace(/^\.+/, "")}`);
+	return sanitizeTmuxWindowTitleSegment(trimmed);
 }
 
 export function buildGjcTmuxWindowTitle(cwd: string, branch: string | null | undefined): string {
 	const project = sanitizeTmuxWindowProjectName(path.basename(path.resolve(cwd)) || "gjc");
-	const trimmedBranch = branch?.trim();
+	const trimmedBranch = sanitizeTmuxWindowTitleSegment(branch?.trim() ?? "");
 	if (!trimmedBranch) return truncateVisible(project, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
 
-	const separatorWidth = visibleWidth(":");
+	const separatorWidth = visibleWidth(GJC_TMUX_WINDOW_BRANCH_SEPARATOR);
 	const projectWidth = visibleWidth(project);
-	const fullTitle = `${project}:${trimmedBranch}`;
+	const fullTitle = `${project}${GJC_TMUX_WINDOW_BRANCH_SEPARATOR}${trimmedBranch}`;
 	if (visibleWidth(fullTitle) <= GJC_TMUX_WINDOW_LABEL_MAX_WIDTH) return fullTitle;
 
 	const remainingBranchWidth = GJC_TMUX_WINDOW_LABEL_MAX_WIDTH - projectWidth - separatorWidth;
 	if (remainingBranchWidth <= 0) return truncateVisible(project, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
 
-	return `${project}:${truncateVisibleTail(trimmedBranch, remainingBranchWidth)}`;
+	return `${project}${GJC_TMUX_WINDOW_BRANCH_SEPARATOR}${truncateVisibleTail(trimmedBranch, remainingBranchWidth)}`;
 }
 
 function buildTmuxRenameWindowArgs(title: string, target?: string): string[] {
@@ -350,8 +356,8 @@ function renameExistingTmuxWindowIfNeeded(context: TmuxLaunchContext): void {
 
 	// Note: Windows is intentionally allowed here. Psmux supports
 	// `rename-window` and we want the leader window to inherit the
-	// project:branch title even on native Windows, where gjc --tmux runs
-	// through PowerShell to a psmux backend.
+	// sanitized project-branch title even on native Windows, where
+	// gjc --tmux runs through PowerShell to a psmux backend.
 
 	const tty = context.tty ?? { stdin: Boolean(process.stdin.isTTY), stdout: Boolean(process.stdout.isTTY) };
 	if (!isInteractiveRootLaunch(context.parsed, tty)) return;

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -65,17 +65,24 @@ describe("default GJC tmux launch", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("builds project and branch tmux window titles", () => {
-		expect(buildGjcTmuxWindowTitle("/repo", "feature/demo")).toBe("repo:feature/demo");
+	it("builds sanitized project and branch tmux window titles", () => {
+		expect(buildGjcTmuxWindowTitle("/repo", "feature/demo")).toBe("repo-feature/demo");
+		expect(buildGjcTmuxWindowTitle("/repo", "main")).toBe("repo-main");
 		expect(buildGjcTmuxWindowTitle("/repo", null)).toBe("repo");
 		expect(buildGjcTmuxWindowTitle("/repo", "")).toBe("repo");
+	});
+
+	it("replaces colon-bearing tmux window title segments", () => {
+		expect(buildGjcTmuxWindowTitle("/repo:backend", "main")).toBe("repo-backend-main");
+		expect(buildGjcTmuxWindowTitle("/repo", "release:main")).toBe("repo-release-main");
+		expect(buildGjcTmuxWindowTitle("/repo", "feature:::demo")).toBe("repo-feature-demo");
 	});
 
 	it("truncates long tmux window titles to 48 visible columns while preserving the project and branch tail", () => {
 		const title = buildGjcTmuxWindowTitle("/repo", `feature/${"a".repeat(80)}tail`);
 
 		expect(Bun.stringWidth(title)).toBeLessThanOrEqual(48);
-		expect(title.startsWith("repo:…")).toBe(true);
+		expect(title.startsWith("repo-…")).toBe(true);
 		expect(title.endsWith("tail")).toBe(true);
 	});
 
@@ -83,14 +90,16 @@ describe("default GJC tmux launch", () => {
 		const title = buildGjcTmuxWindowTitle("/저장소", `feature/${"界".repeat(80)}끝`);
 
 		expect(Bun.stringWidth(title)).toBeLessThanOrEqual(48);
-		expect(title.startsWith("저장소:…")).toBe(true);
+		expect(title.startsWith("저장소-…")).toBe(true);
 		expect(title.endsWith("끝")).toBe(true);
 	});
 
 	it("sanitizes dot-prefixed cwd basenames for tmux window titles", () => {
 		expect(buildGjcTmuxWindowTitle("/tmp/.claude", null)).toBe("dot-claude");
-		expect(buildGjcTmuxWindowTitle("/tmp/.claude", "feature/demo")).toBe("dot-claude:feature/demo");
-		expect(buildGjcTmuxWindowTitle("/tmp/...", "feature/demo")).toBe("gjc:feature/demo");
+		expect(buildGjcTmuxWindowTitle("/tmp/.claude", "feature/demo")).toBe("dot-claude-feature/demo");
+		expect(buildGjcTmuxWindowTitle("/tmp/.claude", "repo:main")).toBe("dot-claude-repo-main");
+		expect(buildGjcTmuxWindowTitle("/tmp/...", null)).toBe("gjc");
+		expect(buildGjcTmuxWindowTitle("/tmp/...", "feature/demo")).toBe("gjc-feature/demo");
 	});
 
 	it("passes sanitized dot-prefixed cwd basenames to tmux rename-window", () => {
@@ -145,7 +154,7 @@ describe("default GJC tmux launch", () => {
 		});
 
 		expect(handled).toBe(false);
-		expect(calls[0]?.args).toEqual(["rename-window", "--", "-repo:feature/demo"]);
+		expect(calls[0]?.args).toEqual(["rename-window", "--", "-repo-feature/demo"]);
 	});
 
 	it("does not plan tmux for interactive root launch without --tmux", () => {
@@ -746,7 +755,7 @@ describe("default GJC tmux launch", () => {
 		expect(calls).toHaveLength(1);
 		expect(calls[0]).toMatchObject({
 			command: "tmux",
-			args: ["rename-window", "--", "repo:feature/demo"],
+			args: ["rename-window", "--", "repo-feature/demo"],
 		});
 	});
 
@@ -850,7 +859,7 @@ describe("default GJC tmux launch", () => {
 
 		expect(newSessionIndex).toBeGreaterThanOrEqual(0);
 		expect(renameIndex).toBeGreaterThan(newSessionIndex);
-		expect(calls[renameIndex]?.args).toEqual(["rename-window", "-t", `=${sessionName}`, "--", "repo:feature/demo"]);
+		expect(calls[renameIndex]?.args).toEqual(["rename-window", "-t", `=${sessionName}`, "--", "repo-feature/demo"]);
 	});
 	it("falls through to direct launch when session creation fails", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];


### PR DESCRIPTION
## Summary
- replace colon-bearing tmux window title segments with dashes
- switch generated project/branch window separator away from colon
- preserve dot-prefixed cwd basename sanitization and add regressions for repo:main

## Verification
- bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
- bun --cwd=packages/coding-agent run check (passes; existing Biome warnings remain in src/session/session-manager.ts:1537 and :4011)

Fixes #1210