### PR TITLE
Materialize resident blobs in compaction replay context

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1515,6 +1515,40 @@ function cloneSessionEntry(entry: SessionEntry): SessionEntry {
 	return { ...entry, message: cloneAgentMessage(entry.message) } as SessionEntry;
 }
 
+function materializeProviderVisibleEntrySync(entry: SessionEntry, stores: ResidentBlobStores): SessionEntry {
+	if (entry.type === "compaction") {
+		const cache = new Map<string, string>();
+		const summary = materializeResidentValueSync(entry.summary, stores, "summary", cache);
+		const shortSummary = materializeResidentValueSync(entry.shortSummary, stores, "shortSummary", cache);
+		const remote = entry.preserveData?.openaiRemoteCompaction;
+		const remoteRecord = isRecord(remote) ? remote : undefined;
+		const replacementHistory = remoteRecord
+			? materializeResidentValueSync(remoteRecord.replacementHistory, stores, "replacementHistory", cache)
+			: undefined;
+		const preserveData =
+			remoteRecord && replacementHistory !== undefined && replacementHistory !== remoteRecord.replacementHistory
+				? {
+						...entry.preserveData,
+						openaiRemoteCompaction: {
+							...remoteRecord,
+							replacementHistory,
+						},
+					}
+				: entry.preserveData;
+		return {
+			...entry,
+			summary: typeof summary === "string" ? summary : entry.summary,
+			shortSummary: typeof shortSummary === "string" ? shortSummary : entry.shortSummary,
+			preserveData,
+		};
+	}
+	if (entry.type === "branch_summary") {
+		const summary = materializeResidentValueSync(entry.summary, stores, "summary", new Map<string, string>());
+		return typeof summary === "string" ? { ...entry, summary } : { ...entry };
+	}
+	return cloneSessionEntry(entry);
+}
+
 const COLD_SPILL_NOTICE = "[Compacted history content evicted to durable cold storage]";
 const COLD_SPILL_ARGUMENTS_SENTINEL_KEY = "__gjcColdSpillArguments";
 const COLD_SPILL_MIN_CHARS = 1024;
@@ -1533,19 +1567,6 @@ type ColdSpillResidentPromotion = {
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
-
-function isColdSpillRef(value: unknown): value is ColdSpillRef {
-	return (
-		isRecord(value) &&
-		value.kind === "cold_spill" &&
-		typeof value.ref === "string" &&
-		(value.encoding === "utf8" || value.encoding === "json") &&
-		typeof value.originalChars === "number" &&
-		typeof value.sha256 === "string" &&
-		typeof value.bytes === "number"
-	);
-}
-
 function isColdSpillArgumentsSentinel(value: unknown): value is Record<string, unknown> {
 	return isRecord(value) && value[COLD_SPILL_ARGUMENTS_SENTINEL_KEY] === true;
 }
@@ -4008,8 +4029,7 @@ export class SessionManager {
 		const firstKept = this.#byId.get(firstKeptEntryId);
 		const compaction = this.#byId.get(compactionEntryId);
 		if (!firstKept) throw new Error(`Entry ${firstKeptEntryId} not found`);
-		if (!compaction || compaction.type !== "compaction")
-			throw new Error(`Compaction entry ${compactionEntryId} not found`);
+		if (compaction?.type !== "compaction") throw new Error(`Compaction entry ${compactionEntryId} not found`);
 		const ids: string[] = [];
 		const visited = new Set<string>();
 		let current: SessionEntry | undefined = compaction;
@@ -4351,7 +4371,8 @@ export class SessionManager {
 		if (coldSpillPolicy === "covered" && (entry.type === "message" || entry.type === "custom_message")) {
 			return cloneSessionEntry(entry);
 		}
-		if (entry.type !== "message" && entry.type !== "custom_message") return cloneSessionEntry(entry);
+		if (entry.type !== "message" && entry.type !== "custom_message")
+			return materializeProviderVisibleEntrySync(entry, this.#residentBlobStores());
 		const materialized = materializeResidentEntrySync(entry, this.#residentBlobStores(), new Map());
 		const rehydrated = rehydrateColdSpillEntry(
 			materialized,

--- a/packages/coding-agent/test/session-compaction-eviction.test.ts
+++ b/packages/coding-agent/test/session-compaction-eviction.test.ts
@@ -526,6 +526,79 @@ describe("SessionManager compacted cold-spill eviction", () => {
 		expect(JSON.stringify(context.messages)).toContain("openaiResponsesHistory");
 	});
 
+	it("materializes resident compaction provider-visible fields for replay context", () => {
+		const { session, firstKeptEntryId } = buildLargeSession(4, false);
+		const summary = `resident replay summary ${"s".repeat(5_000)}`;
+		const encryptedContent = `resident encrypted ${"e".repeat(5_000)}`;
+		const nestedText = `resident nested text ${"t".repeat(5_000)}`;
+		const compactionEntryId = session.appendCompaction(
+			summary,
+			"short",
+			firstKeptEntryId,
+			123,
+			undefined,
+			undefined,
+			{
+				openaiRemoteCompaction: {
+					provider: "openai-codex",
+					replacementHistory: [
+						{ type: "reasoning", encrypted_content: encryptedContent },
+						{
+							type: "message",
+							role: "assistant",
+							content: [{ type: "output_text", text: nestedText }],
+						},
+					],
+				},
+			},
+		);
+		session.evictCompactedContent(firstKeptEntryId, compactionEntryId);
+
+		const canonical = session.getCanonicalEntryForTests(compactionEntryId);
+		expect(canonical?.type).toBe("compaction");
+		if (canonical?.type !== "compaction") throw new Error("Expected compaction entry");
+		expect(residentTextSentinel(canonical.summary).ref).toBeString();
+		const remote = canonical.preserveData?.openaiRemoteCompaction;
+		expect(remote).toBeObject();
+		const replacementHistory = (remote as { replacementHistory?: unknown }).replacementHistory;
+		expect(JSON.stringify(replacementHistory)).toContain("__gjcResidentBlob");
+
+		const context = session.buildSessionContext();
+		const compactionMessage = context.messages.find(message => message.role === "compactionSummary");
+		expect(compactionMessage).toBeDefined();
+		if (compactionMessage?.role !== "compactionSummary") {
+			throw new Error("Expected compaction summary message");
+		}
+		expect(compactionMessage.summary).toBe(summary);
+		expect(JSON.stringify(compactionMessage.providerPayload)).not.toContain("__gjcResidentBlob");
+		expect(compactionMessage.providerPayload?.type).toBe("openaiResponsesHistory");
+		const items = compactionMessage.providerPayload?.items;
+		expect(items).toBeArray();
+		expect(items?.[0]?.encrypted_content).toBe(encryptedContent);
+		const messageItem = items?.[1] as { content?: Array<{ text?: unknown }> } | undefined;
+		expect(messageItem?.content?.[0]?.text).toBe(nestedText);
+	});
+
+	it("materializes resident branch summary text for replay context", () => {
+		const session = SessionManager.inMemory("/cwd", new MemorySessionStorage());
+		const anchor = session.appendMessage({ role: "user", content: "anchor", timestamp: Date.now() });
+		const summary = `resident branch summary ${"b".repeat(5_000)}`;
+		const summaryId = session.branchWithSummary(anchor, summary);
+		const canonical = session.getCanonicalEntryForTests(summaryId);
+		expect(canonical?.type).toBe("branch_summary");
+		if (canonical?.type !== "branch_summary") throw new Error("Expected branch summary entry");
+		expect(residentTextSentinel(canonical.summary).ref).toBeString();
+
+		const context = session.buildSessionContext();
+		const branchMessage = context.messages.find(message => message.role === "branchSummary");
+		expect(branchMessage).toBeDefined();
+		if (branchMessage?.role !== "branchSummary") {
+			throw new Error("Expected branch summary message");
+		}
+		expect(branchMessage.summary).toBe(summary);
+		expect(JSON.stringify(context.messages)).not.toContain("__gjcResidentBlob");
+	});
+
 	it("preserves assistant metadata and tool call identity in hot evicted entries", () => {
 		const { session, firstKeptEntryId, oldAssistantEntryId } = buildLargeSession(4, false);
 		const compactionEntryId = session.appendCompaction("summary", "short", firstKeptEntryId, 123);


### PR DESCRIPTION
## Summary
- materialize resident blob sentinels for provider-visible compaction replay fields before building provider context
- cover compaction summary, OpenAI remote replacement history encrypted content, nested text replay, and branch summary replay materialization
- keep native generated files out of the PR after local native build setup

## Verification
- bun --cwd=packages/coding-agent test test/session-compaction-eviction.test.ts
- bun --cwd=packages/coding-agent run check

Fixes #1212
