### PR TITLE
fix(ai): sanitize replay image URL fields

### DIFF
--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -149,8 +149,10 @@ function sanitizeResponsesMessageContentForReplay(content: unknown): unknown {
 			if (sanitizedPart.type === "image_url") {
 				sanitizedPart.type = "input_image";
 			}
-			if (!("detail" in sanitizedPart) && normalizedImageUrl.detail) {
+			if (normalizedImageUrl.detail) {
 				sanitizedPart.detail = normalizedImageUrl.detail;
+			} else if ("detail" in sanitizedPart && !isResponsesImageDetail(sanitizedPart.detail)) {
+				delete sanitizedPart.detail;
 			}
 		}
 		return sanitizedPart;

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -111,6 +111,29 @@ function normalizeResponsesMessageTextForReplay(value: unknown): string {
 	return stringifyResponsesStringParamForReplay(value);
 }
 
+type ResponsesImageDetail = "auto" | "low" | "high";
+
+interface NormalizedResponsesImageUrl {
+	readonly imageUrl: string;
+	readonly detail?: ResponsesImageDetail;
+}
+
+function isResponsesImageDetail(value: unknown): value is ResponsesImageDetail {
+	return value === "auto" || value === "low" || value === "high";
+}
+
+function normalizeResponsesImageUrlForReplay(value: unknown): NormalizedResponsesImageUrl {
+	if (typeof value === "string") return { imageUrl: value.toWellFormed() };
+	if (value && typeof value === "object" && "url" in value && typeof value.url === "string") {
+		const detail = "detail" in value && isResponsesImageDetail(value.detail) ? value.detail : undefined;
+		return {
+			imageUrl: value.url.toWellFormed(),
+			...(detail ? { detail } : {}),
+		};
+	}
+	return { imageUrl: stringifyResponsesStringParamForReplay(value) };
+}
+
 function sanitizeResponsesMessageContentForReplay(content: unknown): unknown {
 	if (typeof content === "string") return content.toWellFormed();
 	if (!Array.isArray(content)) return content;
@@ -119,6 +142,16 @@ function sanitizeResponsesMessageContentForReplay(content: unknown): unknown {
 		const sanitizedPart = { ...(part as Record<string, unknown>) };
 		if ("text" in sanitizedPart) {
 			sanitizedPart.text = normalizeResponsesMessageTextForReplay(sanitizedPart.text);
+		}
+		if ("image_url" in sanitizedPart) {
+			const normalizedImageUrl = normalizeResponsesImageUrlForReplay(sanitizedPart.image_url);
+			sanitizedPart.image_url = normalizedImageUrl.imageUrl;
+			if (sanitizedPart.type === "image_url") {
+				sanitizedPart.type = "input_image";
+			}
+			if (!("detail" in sanitizedPart) && normalizedImageUrl.detail) {
+				sanitizedPart.detail = normalizedImageUrl.detail;
+			}
 		}
 		return sanitizedPart;
 	});

--- a/packages/ai/test/openai-responses-history-image-url.test.ts
+++ b/packages/ai/test/openai-responses-history-image-url.test.ts
@@ -74,7 +74,7 @@ describe("OpenAI responses history image replay", () => {
 				id: "msg_user_with_image",
 				content: [
 					{ type: "input_text", text: "Recovered user image" },
-					{ type: "image_url", image_url: { url: imageUrl, detail: "high" } },
+					{ type: "image_url", image_url: { url: imageUrl, detail: "high" }, detail: "huge" },
 				],
 			},
 		];

--- a/packages/ai/test/openai-responses-history-image-url.test.ts
+++ b/packages/ai/test/openai-responses-history-image-url.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import { getBundledModel } from "@gajae-code/ai/models";
+import { streamOpenAICodexResponses } from "@gajae-code/ai/providers/openai-codex-responses";
+import type { AssistantMessage, Context, Model } from "@gajae-code/ai/types";
+import { createOpenAIResponsesHistoryPayload } from "../src/utils";
+
+interface CapturedCodexPayload {
+	readonly input?: unknown[];
+}
+
+function createAbortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function createCodexToken(accountId: string): string {
+	const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+	).toString("base64url");
+	return `${header}.${payload}.signature`;
+}
+
+function isCapturedCodexPayload(value: unknown): value is CapturedCodexPayload {
+	return typeof value === "object" && value !== null;
+}
+
+function captureCodexPayload(model: Model<"openai-codex-responses">, context: Context): Promise<CapturedCodexPayload> {
+	const { promise, resolve, reject } = Promise.withResolvers<CapturedCodexPayload>();
+	streamOpenAICodexResponses(model, context, {
+		apiKey: createCodexToken("acc_test"),
+		signal: createAbortedSignal(),
+		onPayload: payload => {
+			if (isCapturedCodexPayload(payload)) {
+				resolve(payload);
+				return;
+			}
+			reject(new Error("Expected captured Codex payload to be an object"));
+		},
+	});
+	return promise;
+}
+
+function makeCodexAssistantMessage(items: Record<string, unknown>[]): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "ignored" }],
+		api: "openai-codex-responses",
+		provider: "openai-codex",
+		model: "gpt-5.2-codex",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		providerPayload: createOpenAIResponsesHistoryPayload("openai-codex", items, false),
+		timestamp: Date.now(),
+	};
+}
+
+describe("OpenAI responses history image replay", () => {
+	it("normalizes object-valued image_url fields before replaying openai-codex native history", async () => {
+		const model = getBundledModel<"openai-codex-responses">("openai-codex", "gpt-5.2-codex");
+		const imageUrl = "data:image/png;base64,AAA";
+		const malformedHistoryItems: Record<string, unknown>[] = [
+			{
+				type: "message",
+				role: "user",
+				id: "msg_user_with_image",
+				content: [
+					{ type: "input_text", text: "Recovered user image" },
+					{ type: "image_url", image_url: { url: imageUrl, detail: "high" } },
+				],
+			},
+		];
+
+		const payload = await captureCodexPayload(model, {
+			messages: [
+				{ role: "user", content: "generic history that should be replaced", timestamp: Date.now() },
+				makeCodexAssistantMessage(malformedHistoryItems),
+				{ role: "user", content: "follow-up user", timestamp: Date.now() },
+			],
+		});
+
+		expect(payload.input).toEqual([
+			{
+				type: "message",
+				role: "user",
+				content: [
+					{ type: "input_text", text: "Recovered user image" },
+					{ type: "input_image", image_url: imageUrl, detail: "high" },
+				],
+			},
+			{ role: "user", content: [{ type: "input_text", text: "follow-up user" }] },
+		]);
+	});
+});


### PR DESCRIPTION
## Summary
- normalize object-valued replay `image_url` parts into Responses `input_image` parts with string URLs
- preserve valid nested image `detail` values while replaying native history
- add a focused Codex native-history regression test

## Test plan
- `bun test packages/ai/test/openai-responses-history-image-url.test.ts packages/ai/test/openai-responses-history-payload.test.ts --timeout 30000`
- `bunx biome check packages/ai/src/utils.ts packages/ai/test/openai-responses-history-image-url.test.ts`
- `(cd packages/ai && bun run check)`