### PR TITLE
test(ai): cover object-valued replay image detail

### DIFF
--- a/packages/ai/test/openai-responses-history-image-url.test.ts
+++ b/packages/ai/test/openai-responses-history-image-url.test.ts
@@ -74,7 +74,7 @@ describe("OpenAI responses history image replay", () => {
 				id: "msg_user_with_image",
 				content: [
 					{ type: "input_text", text: "Recovered user image" },
-					{ type: "image_url", image_url: { url: imageUrl, detail: "high" }, detail: "huge" },
+					{ type: "image_url", image_url: { url: imageUrl, detail: "high" }, detail: { leak: true } },
 				],
 			},
 		];


### PR DESCRIPTION
Follow-up to #1214 after it was merged.

This is a test-only tightening for the exact reviewer reproducer shape:

```ts
{ type: "image_url", image_url: { url, detail: "high" }, detail: { leak: true } }
```

The merged sanitizer already prefers the valid nested `image_url.detail` and replaces/deletes invalid top-level `detail`; this updates the focused regression input so it covers an object-valued top-level detail leak directly.

Verified locally:
- `bun test packages/ai/test/openai-responses-history-image-url.test.ts packages/ai/test/openai-responses-history-payload.test.ts --timeout 30000`
- `bunx biome check packages/ai/src/utils.ts packages/ai/test/openai-responses-history-image-url.test.ts`