### PR TITLE
fix(session): preserve Codex encrypted replay strings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept Codex `reasoning.encrypted_content` replay strings out of the resident large-text externalizer so resumed sessions preserve the provider's opaque encrypted reasoning payload instead of degrading it to a resident blob object.
+
 ## [0.7.4] - 2026-06-27
 
 ### Added

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1324,6 +1324,8 @@ const RESIDENT_EXTERNALIZE_STRING_EXCLUDED_KEYS = new Set([
 	"toolName",
 	"targetId",
 	"firstKeptEntryId",
+	"encrypted_content",
+	"reasoning_encrypted_content",
 ]);
 
 function shouldExternalizeResidentString(key: string | undefined): boolean {

--- a/packages/coding-agent/test/session-resident-cache.test.ts
+++ b/packages/coding-agent/test/session-resident-cache.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AssistantMessage, UserMessage } from "@gajae-code/ai";
+
 import { exportFromFile, exportSessionToHtml } from "@gajae-code/coding-agent/export/html";
 import {
 	BlobStore,
@@ -222,6 +223,33 @@ describe("resident text cache missing-blob and reference hygiene", () => {
 		sm.appendMessage(assistantMessage("invalidate warm resident view"));
 		expectMissingBlob(() => sm.getEntries());
 		await sm.close().catch(() => {});
+	});
+	it("keeps encrypted reasoning replay strings inline instead of resident-blob externalizing them", async () => {
+		for (const replayKey of ["encrypted_content", "reasoning_encrypted_content"] as const) {
+			const root = makeTempDir();
+			const sm = SessionManager.create(root, path.join(root, "sessions"));
+			const encryptedContent = `enc_${replayKey}_${"r".repeat(2048)}`;
+			sm.appendMessage({
+				...assistantMessage(`codex reasoning replay ${replayKey}`),
+				providerPayload: {
+					type: "openaiResponsesHistory",
+					provider: "openai-codex",
+					items: [{ type: "reasoning", [replayKey]: encryptedContent }],
+				},
+			});
+
+			expect(JSON.stringify(sm.getEntries())).toContain(encryptedContent);
+			await fs.promises.rm(residentCacheRoot(sm), { recursive: true, force: true });
+			Bun.gc(true);
+			sm.appendMessage(assistantMessage(`invalidate encrypted replay materialization ${replayKey}`));
+			expect(JSON.stringify(sm.getEntries())).toContain(encryptedContent);
+			await sm.ensureOnDisk();
+			await sm.flush();
+			const sessionFile = sm.getSessionFile();
+			if (!sessionFile) throw new Error("Expected session file");
+			expect(await Bun.file(sessionFile).text()).toContain(encryptedContent);
+			await sm.close();
+		}
 	});
 
 	it("standalone export close does not destroy the live manager resident cache", async () => {


### PR DESCRIPTION
## Summary
- follow-up to the Codex encrypted-content replay fix in #1208
- keep `reasoning.encrypted_content` / `reasoning_encrypted_content` out of the resident large-text externalizer so resumed sessions preserve Codex opaque encrypted reasoning strings
- add regression coverage that deletes the resident cache and verifies encrypted replay still materializes and persists as a string

## Verification
- `bun install --frozen-lockfile`
- `bun test packages/coding-agent/test/session-resident-cache.test.ts` → 7 pass / 0 fail
- `bun run --cwd packages/coding-agent check:types`
- `bun run --cwd packages/coding-agent lint`
- `git diff --check`

Note: `bun run --cwd packages/natives build` could not run because this host has no `cargo`/`rustc`; for local focused tests I copied the installed darwin-arm64 native addon into the ignored workspace native path.