### PR TITLE
fix(agent): catch leaked invoke envelopes across providers

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Mitigate leaked Anthropic-style `<invoke name="…">` tool-call envelopes across providers, not only `openai-codex`, while keeping Codex `to=functions.*` harmony-header mitigation provider-scoped.
+
 ## [0.7.4] - 2026-06-27
 
 ### Added

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -25,6 +25,7 @@ import {
 	isHarmonyLeakMitigationTarget,
 	recoverHarmonyToolCall,
 	signalListLabel,
+	shouldMitigateHarmonyLeak,
 } from "./harmony-leak";
 import { type AgentRunCoverage, type AgentRunSummary, ToolCallBlockedError } from "./run-collector";
 import {
@@ -515,19 +516,11 @@ async function runLoopBody(
 					streamFn,
 					harmonyRetryAttempt,
 				);
-				// Post-stream harmony-leak detection. The mitigation scaffolding
-				// below (HarmonyLeakInterruption catch + retry/recover/audit,
-				// plus harmonyAbortController) existed but nothing invoked the
-				// detector, so leaks on openai-codex models were never caught.
-				// Detect on the completed message and route recoverable tool-arg
-				// leaks through recovery, everything else through abort-retry.
-				if (isHarmonyLeakMitigationTarget(config.model)) {
-					const detection = detectHarmonyLeakInAssistantMessage(message);
-					if (detection) {
-						const rec = recoverHarmonyToolCall(message, detection);
-						const removed = rec ? rec.removed : extractHarmonyRemoved(message, detection);
-						throw new HarmonyLeakInterruption(detection, removed, rec);
-					}
+				const detection = detectHarmonyLeakInAssistantMessage(message);
+				if (detection && shouldMitigateHarmonyLeak(config.model, detection)) {
+					const rec = recoverHarmonyToolCall(message, detection);
+					const removed = rec ? rec.removed : extractHarmonyRemoved(message, detection);
+					throw new HarmonyLeakInterruption(detection, removed, rec);
 				}
 				harmonyRetryAttempt = 0;
 				harmonyTruncateResumeCount = 0;

--- a/packages/agent/src/harmony-leak.ts
+++ b/packages/agent/src/harmony-leak.ts
@@ -127,6 +127,11 @@ export function isHarmonyLeakMitigationTarget(model: Model): boolean {
 	return model.provider === "openai-codex";
 }
 
+export function shouldMitigateHarmonyLeak(model: Model, detection: HarmonyDetection): boolean {
+	if (isHarmonyLeakMitigationTarget(model)) return true;
+	return detection.signals.some(signal => signal.classes.includes("I"));
+}
+
 export function signalListLabel(signals: readonly HarmonySignal[]): string {
 	const seen: string[] = [];
 	for (const signal of signals) {

--- a/packages/agent/test/agent-loop-harmony-leak.test.ts
+++ b/packages/agent/test/agent-loop-harmony-leak.test.ts
@@ -13,12 +13,14 @@ function identityConverter(messages: AgentMessage[]): Message[] {
 // model emitted the `ask` call as visible text instead of a native function
 // call (with the `court` glitch line in front), exactly as seen in the wild.
 const LEAKED = [
-	"court",
-	'<invoke name="proxy_ask">',
-	'<parameter name="_i">decision</parameter>',
-	'<parameter name="questions">[{"id":"x"}]</parameter>',
+	"call",
+	'<invoke name="web_search">',
+	"<parameter name=\"query\">portfolio copywriting examples</parameter>",
+	'<parameter name="_i">Researching copy</parameter>',
 	"</invoke>",
 ].join("\n");
+
+const HARMONY_HEADER_LEAK = "analysis to=functions.read code {\n  \"path\": \"src/x.ts\"\n}";
 
 function assistantContains(messages: AgentMessage[], needle: string): boolean {
 	return messages.some(m => m.role === "assistant" && JSON.stringify(m.content).includes(needle));
@@ -57,11 +59,11 @@ describe("agent-loop harmony-leak mitigation wiring (openai-codex)", () => {
 		expect(assistantContains(context.messages, "<invoke name=")).toBe(false);
 	});
 
-	it("does not engage for non-codex providers (gate is provider-scoped)", async () => {
+	it("detects a leaked <invoke> envelope for non-codex providers too", async () => {
 		const context: AgentContext = { systemPrompt: [], messages: [], tools: [] };
 		const mock = createMockModel({
 			provider: "anthropic",
-			responses: [{ content: [LEAKED] }],
+			responses: [{ content: [LEAKED] }, { content: ["ok"] }],
 		});
 		const audits: Array<{ action: string }> = [];
 		const config: AgentLoopConfig = {
@@ -76,9 +78,33 @@ describe("agent-loop harmony-leak mitigation wiring (openai-codex)", () => {
 		await Array.fromAsync(stream);
 		const messages = await stream.result();
 
-		// Gate off: no detection, no retry, and the leak passes through unmitigated.
+		expect(audits.some(a => a.action === "abort_retry")).toBe(true);
+		expect(mock.calls).toHaveLength(2);
+		expect(assistantContains(messages, "ok")).toBe(true);
+		expect(assistantContains(messages, "<invoke name=")).toBe(false);
+	});
+
+	it("keeps harmony-header mitigation scoped to codex providers", async () => {
+		const context: AgentContext = { systemPrompt: [], messages: [], tools: [] };
+		const mock = createMockModel({
+			provider: "anthropic",
+			responses: [{ content: [HARMONY_HEADER_LEAK] }],
+		});
+		const audits: Array<{ action: string }> = [];
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			onHarmonyLeak: e => {
+				audits.push(e);
+			},
+		};
+
+		const stream = agentLoop([createUserMessage("hi")], context, config, undefined, mock.stream);
+		await Array.fromAsync(stream);
+		const messages = await stream.result();
+
 		expect(audits).toHaveLength(0);
 		expect(mock.calls).toHaveLength(1);
-		expect(assistantContains(messages, "<invoke name=")).toBe(true);
+		expect(assistantContains(messages, "to=functions.read")).toBe(true);
 	});
 });

--- a/packages/agent/test/harmony-leak.test.ts
+++ b/packages/agent/test/harmony-leak.test.ts
@@ -8,6 +8,7 @@ import {
 	extractHarmonyRemoved,
 	isHarmonyLeakMitigationTarget,
 	recoverHarmonyToolCall,
+	shouldMitigateHarmonyLeak,
 	signalListLabel,
 } from "../src/harmony-leak";
 import corpus from "./fixtures/harmony-leak-corpus.json" with { type: "json" };
@@ -49,6 +50,30 @@ describe("isHarmonyLeakMitigationTarget", () => {
 
 	it("does not target Anthropic models", () => {
 		expect(isHarmonyLeakMitigationTarget(anthropicModel)).toBe(false);
+	});
+});
+
+describe("shouldMitigateHarmonyLeak", () => {
+	it("mitigates provider-neutral invoke envelope leaks for Anthropic models", () => {
+		const detection = detectHarmonyLeak(
+			[
+				"call",
+				'<invoke name="web_search">',
+				'<parameter name="query">portfolio copywriting examples</parameter>',
+				"</invoke>",
+			].join("\n"),
+			"assistant_text",
+		);
+
+		expect(detection).toBeDefined();
+		expect(shouldMitigateHarmonyLeak(anthropicModel, detection!)).toBe(true);
+	});
+
+	it("does not broaden codex harmony-header mitigation to Anthropic models", () => {
+		const detection = detectHarmonyLeak("analysis to=functions.read code {}", "assistant_text");
+
+		expect(detection).toBeDefined();
+		expect(shouldMitigateHarmonyLeak(anthropicModel, detection!)).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Summary
- extend post-stream leak mitigation so committed `<invoke name="…">` tool-call envelopes are retried across providers, including Anthropic-style sessions
- keep Codex `to=functions.*` harmony-header mitigation scoped to `openai-codex` to avoid broad false positives
- add regression coverage for the captured `call` + `web_search` envelope shape and the non-Codex header boundary

## Verification
- `bun test packages/agent/test/agent-loop-harmony-leak.test.ts packages/agent/test/harmony-leak.test.ts`
- `bun --cwd=packages/agent test`
- `bun --cwd=packages/agent run check:types`
- dry-run mock agent loop: Anthropic leaked `<invoke name="web_search">` produced `calls: 2`, `auditActions: ["abort_retry"]`, `leakedVisible: false`, `finalContainsOk: true`
- `git diff --check`

## Note
- `bun --cwd=packages/agent run check` currently fails before checking changed files because root `biome.json` uses an unknown `rules.preset` key for the installed Biome version. Type check and package tests pass.