### PR TITLE
feat(web-search): configurable hard timeout, default 300s

### DIFF
--- a/packages/coding-agent/src/cli/web-search-cli.ts
+++ b/packages/coding-agent/src/cli/web-search-cli.ts
@@ -15,6 +15,7 @@ import {
 	type SearchQueryParams,
 } from "../web/search/index";
 import { SEARCH_PROVIDER_ORDER, setPreferredSearchProvider, setSearchFallbackProviders } from "../web/search/provider";
+import { setSearchHardTimeoutMs } from "../web/search/providers/utils";
 import { renderSearchResult } from "../web/search/render";
 import type { SearchProviderId } from "../web/search/types";
 
@@ -178,6 +179,10 @@ export async function runSearchCommand(cmd: SearchCommandArgs): Promise<void> {
 		setSearchFallbackProviders(
 			configuredFallback.filter(value => typeof value === "string" && isConfigurableSearchProviderId(value)),
 		);
+	}
+	const configuredTimeout = settings.get("web_search.timeout");
+	if (typeof configuredTimeout === "number" && Number.isFinite(configuredTimeout) && configuredTimeout > 0) {
+		setSearchHardTimeoutMs(configuredTimeout * 1000);
 	}
 
 	const params: SearchQueryParams = {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2178,6 +2178,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"web_search.timeout": {
+		type: "number",
+		default: 300,
+		validate: (value: number) => Number.isFinite(value) && value > 0,
+		ui: {
+			tab: "tools",
+			label: "Web Search Timeout",
+			description: "Hard timeout in seconds for a single web search request (default 300)",
+		},
+	},
+
 	"browser.enabled": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -51,6 +51,7 @@ import {
 	setPreferredImageProvider,
 	setPreferredSearchProvider,
 	setSearchFallbackProviders,
+	setSearchHardTimeoutMs,
 } from "../../tools";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { AgentDashboard } from "../components/agent-dashboard";
@@ -639,6 +640,11 @@ export class SelectorController {
 					setSearchFallbackProviders(
 						value.filter(item => typeof item === "string" && isConfigurableSearchProviderId(item)),
 					);
+				}
+				break;
+			case "web_search.timeout":
+				if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+					setSearchHardTimeoutMs(value * 1000);
 				}
 				break;
 			case "providers.image":

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -140,6 +140,7 @@ import {
 	setPreferredImageProvider,
 	setPreferredSearchProvider,
 	setSearchFallbackProviders,
+	setSearchHardTimeoutMs,
 	type Tool,
 	type ToolSession,
 	WebSearchTool,
@@ -940,6 +941,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		setSearchFallbackProviders(
 			webSearchFallback.filter(value => typeof value === "string" && isConfigurableSearchProviderId(value)),
 		);
+	}
+	const webSearchTimeout = settings.get("web_search.timeout");
+	if (typeof webSearchTimeout === "number" && Number.isFinite(webSearchTimeout) && webSearchTimeout > 0) {
+		setSearchHardTimeoutMs(webSearchTimeout * 1000);
 	}
 
 	const imageProvider = settings.get("providers.image");

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -322,5 +322,6 @@ export function getSearchTools(): CustomTool<any, any>[] {
 }
 
 export { getSearchProvider, setPreferredSearchProvider, setSearchFallbackProviders } from "./provider";
+export { setSearchHardTimeoutMs } from "./providers/utils";
 export type { SearchProviderId as SearchProvider, SearchResponse } from "./types";
 export { isConfigurableSearchProviderId, isSearchProviderPreference } from "./types";

--- a/packages/coding-agent/src/web/search/providers/utils.ts
+++ b/packages/coding-agent/src/web/search/providers/utils.ts
@@ -44,16 +44,33 @@ export function findCredential(
 }
 
 /**
- * Default hard ceiling for a single web-search round-trip. 60s tolerates
+ * Default hard ceiling for a single web-search round-trip. 300s tolerates
  * legitimate slow LLM-mediated responses (anthropic web_search_20250305,
  * perplexity, gemini, OpenAI code backend) while still guaranteeing the session unfreezes
- * within a minute if Bun's `AbortSignal` fails to propagate on Windows.
+ * if Bun's `AbortSignal` fails to propagate on Windows.
  *
  * Pure search APIs (brave, exa, jina, tavily, searxng, synthetic, zai)
  * settle far faster in practice; reusing the same ceiling keeps the wiring
  * uniform without compromising correctness.
  */
-export const SEARCH_HARD_TIMEOUT_MS = 60_000;
+export const SEARCH_HARD_TIMEOUT_MS = 300_000;
+
+/**
+ * Runtime-configurable hard timeout, seeded from the `web_search.timeout`
+ * setting via {@link setSearchHardTimeoutMs}. Falls back to
+ * {@link SEARCH_HARD_TIMEOUT_MS} when unset or invalid.
+ */
+let configuredHardTimeoutMs = SEARCH_HARD_TIMEOUT_MS;
+
+/**
+ * Override the hard timeout applied to every web-search round-trip.
+ *
+ * @param ms - Hard timeout in milliseconds. Non-finite or non-positive
+ *   values reset the timeout to {@link SEARCH_HARD_TIMEOUT_MS}.
+ */
+export function setSearchHardTimeoutMs(ms: number | undefined): void {
+	configuredHardTimeoutMs = typeof ms === "number" && Number.isFinite(ms) && ms > 0 ? ms : SEARCH_HARD_TIMEOUT_MS;
+}
 
 /**
  * Compose a caller-supplied {@link AbortSignal} with a hard timeout so an
@@ -66,9 +83,9 @@ export const SEARCH_HARD_TIMEOUT_MS = 60_000;
  * because the user's Esc is never delivered to the native layer.
  *
  * @param signal - Caller cancellation signal, if any.
- * @param ms - Hard timeout in milliseconds. Defaults to {@link SEARCH_HARD_TIMEOUT_MS}.
+ * @param ms - Hard timeout in milliseconds. Defaults to the configured value.
  */
-export function withHardTimeout(signal: AbortSignal | undefined, ms: number = SEARCH_HARD_TIMEOUT_MS): AbortSignal {
+export function withHardTimeout(signal: AbortSignal | undefined, ms: number = configuredHardTimeoutMs): AbortSignal {
 	const timeout = AbortSignal.timeout(ms);
 	return signal ? AbortSignal.any([signal, timeout]) : timeout;
 }

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1734,6 +1734,11 @@
 					},
 					"description": "Ordered fallback web search providers after the active model native provider",
 					"default": []
+				},
+				"timeout": {
+					"type": "number",
+					"description": "Hard timeout in seconds for a single web search request (default 300)",
+					"default": 300
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## Summary
The web-search hard timeout was hardcoded to 60s, which caused repeated timeouts on slower OpenAI-compatible (Responses-API) search endpoints. This makes the timeout configurable and raises the default to 300s.

## Changes
- `web/search/providers/utils.ts` — bump `SEARCH_HARD_TIMEOUT_MS` 60s → 300s; add module-global `configuredHardTimeoutMs` + `setSearchHardTimeoutMs(ms)`; `withHardTimeout()` defaults to the configured value (governs openai-compat and all shared-helper providers).
- `config/settings-schema.ts` — add `web_search.timeout` (number, seconds, default 300, must be > 0) under the tools tab.
- `sdk.ts`, `modes/controllers/selector-controller.ts`, `cli/web-search-cli.ts` — read the setting and apply `setSearchHardTimeoutMs(value * 1000)` at startup and on live setting changes.
- `schemas/config.schema.json` — regenerated.

## Notes
- This raises the global ceiling for every search provider, not just openai-compat. Trade-off: a stalled request can now hang up to the configured duration before the safety abort fires.

## Verification
- `bun run check:ts` passes (biome, node20 baseline, schemas, plugins, gjc-ui, all workspace typechecks).