### PR TITLE
feat(tools): safety-bounded memory GC for browser & computer-use tools

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2208,6 +2208,46 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"browser.gc.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "tools",
+			label: "Browser Tab GC",
+			description: "Automatically reclaim idle, unheld GJC-managed headless/spawned browser tabs.",
+		},
+	},
+	"browser.gc.idleMs": {
+		type: "number",
+		default: 300_000,
+		validate: (value: number) => Number.isFinite(value) && value >= 0,
+		ui: {
+			tab: "tools",
+			label: "Browser Tab GC Idle (ms)",
+			description: "Evict headless/spawned tabs idle longer than this many milliseconds.",
+		},
+	},
+	"browser.gc.rssLimitMb": {
+		type: "number",
+		default: 1536,
+		validate: (value: number) => Number.isFinite(value) && value > 0,
+		ui: {
+			tab: "tools",
+			label: "Browser Tab GC RSS Limit (MB)",
+			description: "Parent-process RSS (MB) above which idle tabs are opportunistically evicted LRU.",
+		},
+	},
+	"resourceGc.sweepIntervalMs": {
+		type: "number",
+		default: 30_000,
+		validate: (value: number) => Number.isFinite(value) && value > 0,
+		ui: {
+			tab: "tools",
+			label: "Resource GC Sweep Interval (ms)",
+			description: "How often the resource GC sweeps browser tabs and stale screenshot directories.",
+		},
+	},
+
 	"computer.enabled": {
 		type: "boolean",
 		default: false,
@@ -2265,6 +2305,35 @@ export const SETTINGS_SCHEMA = {
 			tab: "tools",
 			label: "Computer Audit Log",
 			description: "Persist audit records for enabled computer-use actions.",
+		},
+	},
+	"computer.screenshotGc.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "tools",
+			label: "Computer Screenshot GC",
+			description: "Delete stale computer-use screenshot fallback directories on disk.",
+		},
+	},
+	"computer.screenshotGc.staleMs": {
+		type: "number",
+		default: 43_200_000,
+		validate: (value: number) => Number.isFinite(value) && value >= 0,
+		ui: {
+			tab: "tools",
+			label: "Computer Screenshot GC Stale Age (ms)",
+			description: "Remove screenshot fallback directories whose mtime is older than this many milliseconds.",
+		},
+	},
+	"computer.screenshotGc.scanIntervalMs": {
+		type: "number",
+		default: 1_800_000,
+		validate: (value: number) => Number.isFinite(value) && value > 0,
+		ui: {
+			tab: "tools",
+			label: "Computer Screenshot GC Scan Interval (ms)",
+			description: "Minimum interval between os.tmpdir scans for stale screenshot directories.",
 		},
 	},
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -250,6 +250,7 @@ import { releaseTabsForOwner } from "../tools/browser/tab-supervisor";
 import type { CheckpointState } from "../tools/checkpoint";
 import { outputMeta, wrapToolWithMetaNotice } from "../tools/output-meta";
 import { normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";
+import { registerResourceGcSession } from "../tools/resource-gc";
 import { getLatestTodoPhasesFromEntries, type TodoItem, type TodoPhase } from "../tools/todo-write";
 import { ToolAbortError, ToolError } from "../tools/tool-errors";
 import { clampTimeout } from "../tools/tool-timeouts";
@@ -964,6 +965,8 @@ export class AgentSession {
 	// Python execution state
 	#evalAbortControllers = new Set<AbortController>();
 	#evalKernelOwnerId: string;
+	/** Idempotent unregister handle for this session's resource-GC registration. */
+	#unregisterResourceGc?: () => void;
 	/**
 	 * AsyncJobManager owned by this session (top-level only). Subagents leave
 	 * this undefined and **MUST NOT** dispose the global instance on teardown.
@@ -1180,6 +1183,15 @@ export class AgentSession {
 		this.sessionManager = config.sessionManager;
 		this.settings = config.settings;
 		this.taskDepth = config.taskDepth ?? 0;
+		// Register this session with the process-wide resource GC (idle/RSS browser-tab eviction
+		// + stale screenshot cleanup). Session-keyed so concurrent sessions share one timer safely.
+		const resourceGcSessionId = this.sessionManager.getSessionId();
+		if (resourceGcSessionId) {
+			this.#unregisterResourceGc = registerResourceGcSession({
+				sessionId: resourceGcSessionId,
+				settings: this.settings,
+			});
+		}
 		// Power assertions are taken per turn (see #beginInFlight); nothing acquired here.
 		this.#evalKernelOwnerId = config.evalKernelOwnerId ?? `agent-session:${Snowflake.next()}`;
 		this.#ownedAsyncJobManager = config.ownedAsyncJobManager;
@@ -3285,6 +3297,8 @@ export class AgentSession {
 		// browsers disconnect, headless close gracefully). Scoped by the session id the
 		// browser tool tagged tabs with, so other live sessions' tabs are untouched.
 		// No-op when this session opened no tabs. Failure is logged, not thrown.
+		this.#unregisterResourceGc?.();
+		this.#unregisterResourceGc = undefined;
 		await releaseTabsForOwner(this.sessionManager.getSessionId()).catch((error: unknown) =>
 			logger.warn("session dispose: releaseTabsForOwner failed", { error }),
 		);
@@ -3324,6 +3338,8 @@ export class AgentSession {
 	async disposeChildSubprocesses(timeoutMs = SIGNAL_TEARDOWN_TIMEOUT_MS): Promise<void> {
 		const sessionId = this.sessionManager.getSessionId();
 		const kernelOwnerId = this.#evalKernelOwnerId;
+		this.#unregisterResourceGc?.();
+		this.#unregisterResourceGc = undefined;
 		const work = Promise.allSettled([
 			// kill:true so a forced exit also reaps spawned-app Chrome we own (headless
 			// always closes; connected/attached browsers only disconnect — never killed).

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -57,6 +57,10 @@ export interface TabSession {
 	kindTag: BrowserKindTag;
 	/** Session that acquired this tab; used for session-scoped teardown (F13). */
 	ownerId?: string;
+	/** Unix-ms timestamp of the last acquire/run activity; drives GC idle + LRU ordering. */
+	lastUsedAt: number;
+	/** Set synchronously by the shared begin-release guard so concurrent release is a no-op. */
+	releasing?: boolean;
 }
 
 export interface AcquireTabOptions {
@@ -94,6 +98,76 @@ export function getTab(name: string): TabSession | undefined {
 	return tabs.get(name);
 }
 
+/**
+ * Shared synchronous begin-release guard. Returns true for the first caller (which then
+ * owns teardown) and false for any concurrent/repeat caller, so `releaseBrowser` and the
+ * `BrowserHandle.refCount` decrement happen exactly once even when the idle sweep, the RSS
+ * sweep, a manual close, and `forceKillTab` race on the same tab.
+ */
+function beginRelease(tab: TabSession): boolean {
+	if (tab.releasing) return false;
+	tab.releasing = true;
+	return true;
+}
+
+/** Read-only, GC-facing projection of a live tab. Never exposes the mutable `tabs` map. */
+export interface TabGcSnapshot {
+	name: string;
+	ownerId?: string;
+	state: TabSession["state"];
+	pendingCount: number;
+	kindTag: BrowserKindTag;
+	lastUsedAt: number;
+	browserRefCount: number;
+}
+
+export interface BrowserGcEligibilityPolicy {
+	now: () => number;
+	idleMs: number;
+}
+
+/** Snapshot every live tab for GC ordering/diagnostics. */
+export function listTabsForGc(): TabGcSnapshot[] {
+	return [...tabs.values()].map(tab => ({
+		name: tab.name,
+		ownerId: tab.ownerId,
+		state: tab.state,
+		pendingCount: tab.pending.size,
+		kindTag: tab.kindTag,
+		lastUsedAt: tab.lastUsedAt,
+		browserRefCount: tab.browser.refCount,
+	}));
+}
+
+/**
+ * Evict a tab only if it is still GC-eligible against the LIVE supervisor state. The full
+ * predicate is checked synchronously and `releaseTab` is invoked with no intervening await,
+ * so a tab that became busy after a GC snapshot cannot be closed (its run rejected). Returns
+ * true only when the tab was actually released.
+ */
+export async function releaseTabIfGcEligible(name: string, policy: BrowserGcEligibilityPolicy): Promise<boolean> {
+	const tab = tabs.get(name);
+	if (!tab) return false;
+	if (tab.releasing) return false;
+	if (tab.state !== "alive") return false;
+	if (tab.pending.size !== 0) return false;
+	if (tab.kindTag !== "headless" && tab.kindTag !== "spawned") return false;
+	if (policy.now() - tab.lastUsedAt <= policy.idleMs) return false;
+	// All predicates passed synchronously; releaseTab applies the shared begin-release guard
+	// on the same microtask, so no other code runs between the check and the state transition.
+	return await releaseTab(name, { kill: false });
+}
+
+/** Test-only: install a fabricated tab session. */
+export function setTabForTest(tab: TabSession): void {
+	tabs.set(tab.name, tab);
+}
+
+/** Test-only: clear the tab registry between cases. */
+export function clearTabsForTest(): void {
+	tabs.clear();
+}
+
 export async function acquireTab(
 	name: string,
 	browser: BrowserHandle,
@@ -105,6 +179,7 @@ export async function acquireTab(
 			if (opts.dialogs !== undefined && opts.dialogs !== existing.dialogPolicy) {
 				await releaseTab(name, { kill: false });
 			} else {
+				existing.lastUsedAt = Date.now();
 				if (opts.url) {
 					await runInTabWithSnapshot(
 						name,
@@ -166,6 +241,7 @@ export async function acquireTab(
 		dialogPolicy: opts.dialogs,
 		kindTag: browser.kind.kind,
 		ownerId: opts.ownerId,
+		lastUsedAt: Date.now(),
 	};
 	worker.onMessage(msg => handleTabMessage(tab, msg));
 	tabs.set(name, tab);
@@ -188,6 +264,7 @@ async function runInTabWithSnapshot(
 	const tab = tabs.get(name);
 	if (!tab || tab.state === "dead") throw new ToolError(`Tab ${JSON.stringify(name)} is not alive. Reopen it.`);
 	if (tab.pending.size > 0) throw new ToolError(`Tab ${JSON.stringify(name)} is busy`);
+	tab.lastUsedAt = Date.now();
 	const id = Snowflake.next();
 	const { promise, resolve, reject } = Promise.withResolvers<RunResultOk>();
 	const pending: PendingRun = {
@@ -224,6 +301,10 @@ export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Pr
 		logger.debug("releaseTab: unknown tab", { name });
 		return false;
 	}
+	if (!beginRelease(tab)) {
+		logger.debug("releaseTab: already releasing", { name });
+		return false;
+	}
 	const wasAlive = tab.state === "alive";
 	tab.state = "dead";
 	const closeError = new ToolError(`Tab ${JSON.stringify(name)} was closed`);
@@ -246,7 +327,9 @@ export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Pr
 	await tab.worker.terminate().catch(() => undefined);
 	if (forced && tab.kindTag === "headless") await closeOrphanTarget(tab);
 	await releaseBrowser(tab.browser, { kill: opts.kill ?? false });
-	tabs.delete(name);
+	// Only delete if the map still holds THIS tab: a same-name reacquire during our async
+	// teardown may have installed a fresh tab that we must not evict.
+	if (tabs.get(name) === tab) tabs.delete(name);
 	return true;
 }
 
@@ -392,6 +475,7 @@ function toErrorPayload(error: unknown): RunErrorPayload {
 async function forceKillTab(name: string, reason: string): Promise<void> {
 	const tab = tabs.get(name);
 	if (!tab) return;
+	if (!beginRelease(tab)) return;
 	tab.state = "dead";
 	const error = new ToolError(reason);
 	for (const pending of tab.pending.values()) pending.reject(error);
@@ -399,7 +483,7 @@ async function forceKillTab(name: string, reason: string): Promise<void> {
 	await tab.worker.terminate().catch(() => undefined);
 	if (tab.kindTag === "headless") await closeOrphanTarget(tab);
 	await releaseBrowser(tab.browser, { kill: false });
-	tabs.delete(name);
+	if (tabs.get(name) === tab) tabs.delete(name);
 }
 
 async function closeOrphanTarget(tab: TabSession): Promise<void> {

--- a/packages/coding-agent/src/tools/computer-gc.ts
+++ b/packages/coding-agent/src/tools/computer-gc.ts
@@ -1,0 +1,66 @@
+import type { Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { logger } from "@gajae-code/utils";
+
+/** Prefix of every computer-use screenshot fallback directory created under the OS temp dir. */
+export const SCREENSHOT_FALLBACK_DIR_PREFIX = "gjc-computer-screenshots-";
+
+let screenshotFallbackDirsCreated = false;
+
+/** Lazy-arm marker: called when the first screenshot fallback dir is created this process. */
+export function markScreenshotFallbackDirCreatedForGc(): void {
+	screenshotFallbackDirsCreated = true;
+}
+
+/** Whether any screenshot fallback dir has been created this process (GC lazy-arm gate). */
+export function hasCreatedScreenshotFallbackDir(): boolean {
+	return screenshotFallbackDirsCreated;
+}
+
+/** Test-only: reset the lazy-arm marker between cases. */
+export function resetScreenshotFallbackGcForTest(): void {
+	screenshotFallbackDirsCreated = false;
+}
+
+export interface ScreenshotGcOptions {
+	now: () => number;
+	staleMs: number;
+	/** Base dir to scan; defaults to os.tmpdir(). Injectable for tests. */
+	tmpDir?: string;
+}
+
+/**
+ * Disk-only GC for stale computer-use screenshot fallback directories. Scans the temp dir for
+ * `gjc-computer-screenshots-*` directories and removes those whose mtime is older than `staleMs`.
+ * Never throws on a per-directory failure; the whole sweep is best-effort.
+ */
+export async function cleanupStaleScreenshotFallbackDirs(
+	options: ScreenshotGcOptions,
+): Promise<{ scanned: number; removed: number }> {
+	const base = options.tmpDir ?? os.tmpdir();
+	const entries: Dirent[] = await fs.readdir(base, { withFileTypes: true }).catch(err => {
+		logger.debug("screenshot GC: failed to read temp dir", { base, error: (err as Error).message });
+		return [] as Dirent[];
+	});
+
+	const now = options.now();
+	let scanned = 0;
+	let removed = 0;
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		if (!entry.name.startsWith(SCREENSHOT_FALLBACK_DIR_PREFIX)) continue;
+		scanned++;
+		const dir = path.join(base, entry.name);
+		try {
+			const stat = await fs.stat(dir);
+			if (now - stat.mtimeMs <= options.staleMs) continue;
+			await fs.rm(dir, { recursive: true, force: true });
+			removed++;
+		} catch (err) {
+			logger.debug("screenshot GC: failed to remove stale dir", { dir, error: (err as Error).message });
+		}
+	}
+	return { scanned, removed };
+}

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -7,6 +7,7 @@ import { prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import computerDescription from "../prompts/tools/computer.md" with { type: "text" };
 import { resizeImage } from "../utils/image-resize";
+import { markScreenshotFallbackDirCreatedForGc } from "./computer-gc";
 import type { ToolSession } from "./index";
 import type { OutputMeta } from "./output-meta";
 import { ToolAbortError, ToolError, throwIfAborted } from "./tool-errors";
@@ -547,6 +548,7 @@ function getScreenshotFallbackDir(session: ToolSession): Promise<string> {
 async function createScreenshotFallbackDir(): Promise<string> {
 	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-computer-screenshots-"));
 	await fs.chmod(dir, 0o700);
+	markScreenshotFallbackDirCreatedForGc();
 	return dir;
 }
 

--- a/packages/coding-agent/src/tools/resource-gc.ts
+++ b/packages/coding-agent/src/tools/resource-gc.ts
@@ -1,0 +1,291 @@
+import { logger } from "@gajae-code/utils";
+import type { Settings } from "../config/settings";
+import { listTabsForGc, releaseTabIfGcEligible, type TabGcSnapshot } from "./browser/tab-supervisor";
+import { cleanupStaleScreenshotFallbackDirs, hasCreatedScreenshotFallbackDir } from "./computer-gc";
+
+/**
+ * Mandatory, session-aware resource garbage collector.
+ *
+ * A single process-wide, reference-counted, unref'd, non-overlapping interval sweeps:
+ *  - browser tabs (the heavyweight resource: one worker thread per tab + Chrome child
+ *    processes) via an idle sweep and an opportunistic RSS-pressure sweep, and
+ *  - stale computer-use screenshot fallback directories on disk (lazy-armed + throttled).
+ *
+ * Eviction targets ONLY alive, non-in-flight, GJC-managed headless/spawned tabs owned by a
+ * registered session; connected/real-Chrome/held/in-flight tabs and ownerless tabs are never
+ * touched. RSS is the GJC parent-process RSS only (`process.memoryUsage().rss`); pressure
+ * eviction is best-effort and never force-evicts.
+ */
+
+const DEFAULT_SWEEP_INTERVAL_MS = 30_000;
+const BYTES_PER_MB = 1024 * 1024;
+
+export interface BrowserGcPolicy {
+	enabled: boolean;
+	idleMs: number;
+	rssLimitBytes: number;
+}
+
+export interface ComputerGcPolicy {
+	enabled: boolean;
+	staleMs: number;
+	scanIntervalMs: number;
+}
+
+export function resolveBrowserGcPolicy(settings: Settings): BrowserGcPolicy {
+	return {
+		enabled: settings.get("browser.gc.enabled"),
+		idleMs: settings.get("browser.gc.idleMs"),
+		rssLimitBytes: settings.get("browser.gc.rssLimitMb") * BYTES_PER_MB,
+	};
+}
+
+export function resolveComputerGcPolicy(settings: Settings): ComputerGcPolicy {
+	return {
+		enabled: settings.get("computer.screenshotGc.enabled"),
+		staleMs: settings.get("computer.screenshotGc.staleMs"),
+		scanIntervalMs: settings.get("computer.screenshotGc.scanIntervalMs"),
+	};
+}
+
+export function resolveSweepIntervalMs(settings: Settings): number {
+	return settings.get("resourceGc.sweepIntervalMs");
+}
+
+/** Injectable seams so the controller is fully testable without real browsers/filesystem/RSS. */
+export interface ResourceGcDeps {
+	now: () => number;
+	rssBytes: () => number;
+	logWarn: (msg: string, meta?: Record<string, unknown>) => void;
+	listTabs: () => TabGcSnapshot[];
+	releaseTab: (name: string, policy: { now: () => number; idleMs: number }) => Promise<boolean>;
+	cleanupScreenshots: (opts: { now: () => number; staleMs: number }) => Promise<{ scanned: number; removed: number }>;
+	screenshotArmed: () => boolean;
+}
+
+const defaultDeps: ResourceGcDeps = {
+	now: () => Date.now(),
+	rssBytes: () => process.memoryUsage().rss,
+	logWarn: (msg, meta) => logger.warn(msg, meta),
+	listTabs: () => listTabsForGc(),
+	releaseTab: (name, policy) => releaseTabIfGcEligible(name, policy),
+	cleanupScreenshots: opts => cleanupStaleScreenshotFallbackDirs(opts),
+	screenshotArmed: () => hasCreatedScreenshotFallbackDir(),
+};
+
+// ── Controller state (process-global; tabs/browsers are module-global too) ──────────────────
+const activeSessions = new Map<string, Settings>();
+let timer: ReturnType<typeof setTimeout> | null = null;
+let stopped = false;
+// Bumped on every stop so an in-flight tick from a previous schedule cannot reschedule after a
+// stop+re-register and leak a duplicate timer.
+let timerGeneration = 0;
+let inProgress = false;
+let rssWarningActive = false;
+let lastScreenshotScanAt = 0;
+let deps: ResourceGcDeps = defaultDeps;
+
+export interface ResourceGcRegistration {
+	sessionId: string;
+	settings: Settings;
+}
+
+/**
+ * Register a session with the resource GC. Starts the single shared timer on the first
+ * registration. Returns an idempotent unregister function; the timer stops only when the last
+ * session unregisters.
+ */
+export function registerResourceGcSession(reg: ResourceGcRegistration): () => void {
+	activeSessions.set(reg.sessionId, reg.settings);
+	ensureTimerStarted();
+	let unregistered = false;
+	return () => {
+		if (unregistered) return;
+		unregistered = true;
+		activeSessions.delete(reg.sessionId);
+		if (activeSessions.size === 0) stopTimer();
+	};
+}
+
+function currentSweepIntervalMs(): number {
+	let min = Number.POSITIVE_INFINITY;
+	for (const settings of activeSessions.values()) min = Math.min(min, resolveSweepIntervalMs(settings));
+	return Number.isFinite(min) ? min : DEFAULT_SWEEP_INTERVAL_MS;
+}
+
+function ensureTimerStarted(): void {
+	if (timer) return;
+	stopped = false;
+	scheduleNextSweep();
+}
+
+// Recursive setTimeout (not setInterval) so the cadence is recomputed every cycle and later
+// session register/unregister changes to resourceGc.sweepIntervalMs are honored live.
+function scheduleNextSweep(): void {
+	if (stopped || activeSessions.size === 0) {
+		timer = null;
+		return;
+	}
+	const generation = timerGeneration;
+	timer = setTimeout(() => {
+		void tickAndReschedule(generation);
+	}, currentSweepIntervalMs());
+	timer.unref?.();
+}
+
+async function tickAndReschedule(generation: number): Promise<void> {
+	await runTick();
+	// A stop (and possible re-register) happened during the tick: a newer cycle owns the timer now.
+	if (generation !== timerGeneration) return;
+	scheduleNextSweep();
+}
+
+function stopTimer(): void {
+	stopped = true;
+	timerGeneration++;
+	if (timer) {
+		clearTimeout(timer);
+		timer = null;
+	}
+}
+
+async function runTick(): Promise<void> {
+	if (inProgress) return;
+	inProgress = true;
+	try {
+		await sweepOnce(deps);
+	} catch (err) {
+		logger.debug("resource GC sweep failed", { error: (err as Error).message });
+	} finally {
+		inProgress = false;
+	}
+}
+
+export async function sweepOnce(d: ResourceGcDeps = deps): Promise<void> {
+	if (activeSessions.size === 0) return;
+	await sweepBrowserTabs(d);
+	await sweepScreenshots(d);
+}
+
+function ownerBrowserPolicy(snapshot: TabGcSnapshot): BrowserGcPolicy | null {
+	if (!snapshot.ownerId) return null;
+	const settings = activeSessions.get(snapshot.ownerId);
+	if (!settings) return null;
+	return resolveBrowserGcPolicy(settings);
+}
+
+/** Coarse, ordering-only eligibility; the live recheck in releaseTabIfGcEligible is authoritative. */
+function isCoarselyEligible(snapshot: TabGcSnapshot): boolean {
+	return (
+		snapshot.state === "alive" &&
+		snapshot.pendingCount === 0 &&
+		(snapshot.kindTag === "headless" || snapshot.kindTag === "spawned")
+	);
+}
+
+/** Collect idle, non-in-flight, GJC-managed, owned-and-enabled tabs, sorted LRU (oldest first). */
+function collectIdleCandidates(d: ResourceGcDeps): Array<{ snapshot: TabGcSnapshot; policy: BrowserGcPolicy }> {
+	const candidates: Array<{ snapshot: TabGcSnapshot; policy: BrowserGcPolicy }> = [];
+	for (const snapshot of d.listTabs()) {
+		if (!isCoarselyEligible(snapshot)) continue;
+		const policy = ownerBrowserPolicy(snapshot);
+		if (!policy?.enabled) continue;
+		if (d.now() - snapshot.lastUsedAt <= policy.idleMs) continue;
+		candidates.push({ snapshot, policy });
+	}
+	candidates.sort((a, b) => a.snapshot.lastUsedAt - b.snapshot.lastUsedAt);
+	return candidates;
+}
+
+async function sweepBrowserTabs(d: ResourceGcDeps): Promise<void> {
+	// Reclamation honors IR-1 strictly: ONLY idle, non-in-flight, GJC-managed, owned tabs are ever
+	// evicted. RSS pressure never relaxes that boundary — it only drives the warning below.
+	for (const { snapshot, policy } of collectIdleCandidates(d)) {
+		await d.releaseTab(snapshot.name, { now: d.now, idleMs: policy.idleMs });
+	}
+	evaluateRssPressureWarning(d);
+}
+
+/** Owners whose own RSS limit is exceeded by the single shared parent-process RSS sample. */
+function pressuredOwnerIds(d: ResourceGcDeps): Set<string> {
+	const rss = d.rssBytes();
+	const owners = new Set<string>();
+	for (const [sessionId, settings] of activeSessions) {
+		const policy = resolveBrowserGcPolicy(settings);
+		if (policy.enabled && rss > policy.rssLimitBytes) owners.add(sessionId);
+	}
+	return owners;
+}
+
+/**
+ * RSS pressure is a best-effort warning signal only. Because eviction is always idle-gated
+ * (IR-1), when parent-process RSS stays over an enabled owner's limit and no idle, unheld tab
+ * remains to reclaim for a pressured owner, we warn exactly once per continuous episode and
+ * never force-evict. The warning episode resets when RSS recovers or a reclaimable tab appears.
+ */
+function evaluateRssPressureWarning(d: ResourceGcDeps): void {
+	const pressured = pressuredOwnerIds(d);
+	if (pressured.size === 0) {
+		rssWarningActive = false;
+		return;
+	}
+	const reclaimableRemains = collectIdleCandidates(d).some(
+		c => c.snapshot.ownerId !== undefined && pressured.has(c.snapshot.ownerId),
+	);
+	if (reclaimableRemains) {
+		rssWarningActive = false;
+		return;
+	}
+	if (!rssWarningActive) {
+		rssWarningActive = true;
+		d.logWarn("Browser GC: RSS over limit but no safe (idle, unheld) browser tabs are evictable", {
+			rssBytes: d.rssBytes(),
+		});
+	}
+}
+
+async function sweepScreenshots(d: ResourceGcDeps): Promise<void> {
+	if (!d.screenshotArmed()) return;
+
+	let staleMs: number | null = null;
+	let scanIntervalMs = Number.POSITIVE_INFINITY;
+	for (const settings of activeSessions.values()) {
+		const policy = resolveComputerGcPolicy(settings);
+		if (!policy.enabled) continue;
+		staleMs = staleMs === null ? policy.staleMs : Math.min(staleMs, policy.staleMs);
+		scanIntervalMs = Math.min(scanIntervalMs, policy.scanIntervalMs);
+	}
+	if (staleMs === null) return; // no session has screenshot GC enabled
+
+	const now = d.now();
+	if (now - lastScreenshotScanAt < scanIntervalMs) return;
+	lastScreenshotScanAt = now;
+	await d.cleanupScreenshots({ now: d.now, staleMs });
+}
+
+// ── Test-only seams ─────────────────────────────────────────────────────────────────────────
+export function __setResourceGcDepsForTest(overrides: Partial<ResourceGcDeps>): void {
+	deps = { ...defaultDeps, ...overrides };
+}
+
+export async function __runResourceGcTickForTest(): Promise<void> {
+	await runTick();
+}
+
+export function __getResourceGcStateForTest(): {
+	timerActive: boolean;
+	sessionCount: number;
+	rssWarningActive: boolean;
+	inProgress: boolean;
+} {
+	return { timerActive: timer !== null, sessionCount: activeSessions.size, rssWarningActive, inProgress };
+}
+
+export function __resetResourceGcForTest(): void {
+	stopTimer();
+	activeSessions.clear();
+	inProgress = false;
+	rssWarningActive = false;
+	lastScreenshotScanAt = 0;
+	deps = defaultDeps;
+}

--- a/packages/coding-agent/test/tools/browser-gc.test.ts
+++ b/packages/coding-agent/test/tools/browser-gc.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { Browser } from "puppeteer-core";
+import type { BrowserHandle, BrowserKindTag } from "../../src/tools/browser/registry";
+import {
+	clearTabsForTest,
+	getTab,
+	listTabsForGc,
+	releaseTab,
+	releaseTabIfGcEligible,
+	setTabForTest,
+	type TabSession,
+} from "../../src/tools/browser/tab-supervisor";
+
+const NOW = 1_000_000;
+const IDLE_MS = 1000;
+const policy = { now: () => NOW, idleMs: IDLE_MS };
+
+let counter = 0;
+
+function makeFakeBrowser(refCount: number): { handle: BrowserHandle; close: ReturnType<typeof vi.fn> } {
+	const close = vi.fn(async () => {});
+	const browser = {
+		connected: true,
+		close,
+		disconnect: vi.fn(() => {}),
+		process: () => null,
+		targets: () => [],
+	} as unknown as Browser;
+	const handle = {
+		key: `headless:test-${counter++}`,
+		kind: { kind: "headless", headless: true },
+		browser,
+		refCount,
+		stealth: { browserSession: null, override: null },
+	} as BrowserHandle;
+	return { handle, close };
+}
+
+function makeFakeWorker(): { worker: TabSession["worker"]; terminate: ReturnType<typeof vi.fn> } {
+	const handlers = new Set<(m: { type: string }) => void>();
+	const terminate = vi.fn(async () => {});
+	const worker = {
+		send: (msg: { type: string }) => {
+			if (msg.type === "close")
+				queueMicrotask(() => {
+					for (const handler of [...handlers]) handler({ type: "closed" });
+				});
+		},
+		onMessage: (handler: (m: { type: string }) => void) => {
+			handlers.add(handler);
+			return () => {
+				handlers.delete(handler);
+			};
+		},
+		onError: () => () => {},
+		terminate,
+		mode: "worker" as const,
+	} as unknown as TabSession["worker"];
+	return { worker, terminate };
+}
+
+interface InstallOpts {
+	name: string;
+	kindTag: BrowserKindTag;
+	lastUsedAt: number;
+	state?: "alive" | "dead";
+	pendingCount?: number;
+	refCount?: number;
+}
+
+function installTab(opts: InstallOpts): {
+	close: ReturnType<typeof vi.fn>;
+	terminate: ReturnType<typeof vi.fn>;
+	handle: BrowserHandle;
+} {
+	const { handle, close } = makeFakeBrowser(opts.refCount ?? 1);
+	const { worker, terminate } = makeFakeWorker();
+	const pending = new Map<string, unknown>();
+	for (let i = 0; i < (opts.pendingCount ?? 0); i++) {
+		pending.set(`p${i}`, { reject: () => {}, resolve: () => {}, toolCalls: new Map() });
+	}
+	const tab = {
+		name: opts.name,
+		browser: handle,
+		targetId: "target-1",
+		worker,
+		state: opts.state ?? "alive",
+		info: { targetId: "target-1" },
+		pending,
+		kindTag: opts.kindTag,
+		lastUsedAt: opts.lastUsedAt,
+	} as unknown as TabSession;
+	setTabForTest(tab);
+	return { close, terminate, handle };
+}
+
+describe("tab-supervisor GC primitives", () => {
+	beforeEach(() => {
+		clearTabsForTest();
+	});
+	afterEach(() => {
+		clearTabsForTest();
+		vi.restoreAllMocks();
+	});
+
+	it("evicts an idle headless tab: worker terminated, browser closed, tab removed", async () => {
+		const { close, terminate } = installTab({ name: "a", kindTag: "headless", lastUsedAt: NOW - 5000 });
+		const released = await releaseTabIfGcEligible("a", policy);
+		expect(released).toBe(true);
+		expect(terminate).toHaveBeenCalledTimes(1);
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(getTab("a")).toBeUndefined();
+	});
+
+	it("evicts an idle spawned tab", async () => {
+		const { close } = installTab({ name: "a", kindTag: "spawned", lastUsedAt: NOW - 5000 });
+		expect(await releaseTabIfGcEligible("a", policy)).toBe(true);
+		expect(close).toHaveBeenCalledTimes(1);
+	});
+
+	const protectedCases: Array<{ label: string; opts: InstallOpts }> = [
+		{ label: "connected", opts: { name: "a", kindTag: "connected", lastUsedAt: NOW - 5000 } },
+		{ label: "chrome-profile", opts: { name: "a", kindTag: "chrome-profile", lastUsedAt: NOW - 5000 } },
+		{ label: "in-flight", opts: { name: "a", kindTag: "headless", lastUsedAt: NOW - 5000, pendingCount: 1 } },
+		{ label: "recently used", opts: { name: "a", kindTag: "headless", lastUsedAt: NOW } },
+		{ label: "idle exactly at threshold", opts: { name: "a", kindTag: "headless", lastUsedAt: NOW - IDLE_MS } },
+		{ label: "dead", opts: { name: "a", kindTag: "headless", lastUsedAt: NOW - 5000, state: "dead" } },
+	];
+
+	for (const { label, opts } of protectedCases) {
+		it(`never evicts a ${label} tab`, async () => {
+			const { close } = installTab(opts);
+			expect(await releaseTabIfGcEligible("a", policy)).toBe(false);
+			expect(close).not.toHaveBeenCalled();
+			expect(getTab("a")).toBeDefined();
+		});
+	}
+
+	it("does not evict a tab that became busy after a GC snapshot", async () => {
+		installTab({ name: "a", kindTag: "headless", lastUsedAt: NOW - 5000 });
+		const snapshot = listTabsForGc();
+		expect(snapshot.find(s => s.name === "a")?.pendingCount).toBe(0); // eligible at snapshot time
+		// Tab becomes busy after the snapshot but before eviction.
+		getTab("a")?.pending.set("run", { reject: () => {}, resolve: () => {}, toolCalls: new Map() } as never);
+		expect(await releaseTabIfGcEligible("a", policy)).toBe(false);
+		expect(getTab("a")).toBeDefined();
+	});
+
+	it("decrements browser refCount exactly once under concurrent double release", async () => {
+		const { close, handle } = installTab({ name: "a", kindTag: "headless", lastUsedAt: NOW - 5000, refCount: 1 });
+		const [r1, r2] = await Promise.all([releaseTab("a"), releaseTab("a")]);
+		expect([r1, r2].filter(Boolean)).toHaveLength(1);
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(handle.refCount).toBe(0);
+		expect(getTab("a")).toBeUndefined();
+	});
+
+	it("listTabsForGc reflects live tab fields without exposing the map", () => {
+		installTab({ name: "a", kindTag: "headless", lastUsedAt: 4242, refCount: 2 });
+		const snap = listTabsForGc();
+		expect(snap).toHaveLength(1);
+		expect(snap[0]).toMatchObject({
+			name: "a",
+			state: "alive",
+			pendingCount: 0,
+			kindTag: "headless",
+			lastUsedAt: 4242,
+			browserRefCount: 2,
+		});
+	});
+});

--- a/packages/coding-agent/test/tools/computer-gc.test.ts
+++ b/packages/coding-agent/test/tools/computer-gc.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Snowflake } from "@gajae-code/utils";
+import {
+	cleanupStaleScreenshotFallbackDirs,
+	hasCreatedScreenshotFallbackDir,
+	markScreenshotFallbackDirCreatedForGc,
+	resetScreenshotFallbackGcForTest,
+	SCREENSHOT_FALLBACK_DIR_PREFIX,
+} from "../../src/tools/computer-gc";
+
+describe("computer screenshot GC", () => {
+	let base: string;
+	const NOW = 10_000_000_000; // fixed clock in ms
+	const STALE_MS = 1000;
+
+	beforeEach(async () => {
+		base = path.join(os.tmpdir(), "test-computer-gc", Snowflake.next());
+		await fs.mkdir(base, { recursive: true });
+		resetScreenshotFallbackGcForTest();
+	});
+
+	afterEach(async () => {
+		await fs.rm(base, { recursive: true, force: true });
+	});
+
+	const makeDir = async (name: string, ageMs: number): Promise<string> => {
+		const dir = path.join(base, name);
+		await fs.mkdir(dir, { recursive: true });
+		const mtimeSeconds = (NOW - ageMs) / 1000;
+		await fs.utimes(dir, mtimeSeconds, mtimeSeconds);
+		return dir;
+	};
+
+	const exists = async (dir: string): Promise<boolean> =>
+		await fs
+			.stat(dir)
+			.then(() => true)
+			.catch(() => false);
+
+	it("removes only stale matching directories, preserving recent and non-matching ones", async () => {
+		const oldMatching = await makeDir(`${SCREENSHOT_FALLBACK_DIR_PREFIX}old`, 5000);
+		const recentMatching = await makeDir(`${SCREENSHOT_FALLBACK_DIR_PREFIX}recent`, 100);
+		const oldNonMatching = await makeDir("some-other-tooldir-old", 5000);
+
+		const result = await cleanupStaleScreenshotFallbackDirs({ now: () => NOW, staleMs: STALE_MS, tmpDir: base });
+
+		expect(result.removed).toBe(1);
+		expect(await exists(oldMatching)).toBe(false);
+		expect(await exists(recentMatching)).toBe(true);
+		expect(await exists(oldNonMatching)).toBe(true);
+	});
+
+	it("does not throw and removes nothing when the base dir is missing", async () => {
+		const missing = path.join(base, "does-not-exist");
+		const result = await cleanupStaleScreenshotFallbackDirs({ now: () => NOW, staleMs: STALE_MS, tmpDir: missing });
+		expect(result).toEqual({ scanned: 0, removed: 0 });
+	});
+
+	it("tracks the lazy-arm marker", () => {
+		expect(hasCreatedScreenshotFallbackDir()).toBe(false);
+		markScreenshotFallbackDirCreatedForGc();
+		expect(hasCreatedScreenshotFallbackDir()).toBe(true);
+		resetScreenshotFallbackGcForTest();
+		expect(hasCreatedScreenshotFallbackDir()).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/tools/resource-gc-redteam.test.ts
+++ b/packages/coding-agent/test/tools/resource-gc-redteam.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { Browser } from "puppeteer-core";
+import { Settings } from "../../src/config/settings";
+import type { BrowserHandle, BrowserKindTag } from "../../src/tools/browser/registry";
+import {
+	clearTabsForTest,
+	getTab,
+	listTabsForGc,
+	releaseTabIfGcEligible,
+	setTabForTest,
+	type TabGcSnapshot,
+	type TabSession,
+} from "../../src/tools/browser/tab-supervisor";
+import {
+	__resetResourceGcForTest,
+	type ResourceGcDeps,
+	registerResourceGcSession,
+	sweepOnce,
+} from "../../src/tools/resource-gc";
+
+const MB = 1024 * 1024;
+const NOW = 7_000_000;
+const IDLE_MS = 1000;
+
+function snapshot(
+	name: string,
+	ownerId: string | undefined,
+	lastUsedAt: number,
+	over: Partial<TabGcSnapshot> = {},
+): TabGcSnapshot {
+	return {
+		name,
+		ownerId,
+		state: "alive",
+		pendingCount: 0,
+		kindTag: "headless",
+		lastUsedAt,
+		browserRefCount: 1,
+		...over,
+	};
+}
+
+function baseDeps(over: Partial<ResourceGcDeps> = {}): ResourceGcDeps {
+	return {
+		now: () => NOW,
+		rssBytes: () => 1,
+		logWarn: vi.fn(),
+		listTabs: () => [],
+		releaseTab: vi.fn(async () => true),
+		cleanupScreenshots: vi.fn(async () => ({ scanned: 0, removed: 0 })),
+		screenshotArmed: () => false,
+		...over,
+	};
+}
+
+let browserCounter = 0;
+
+function makeFakeBrowser(refCount: number): { handle: BrowserHandle; close: ReturnType<typeof vi.fn> } {
+	const close = vi.fn(async () => {});
+	const browser = {
+		connected: true,
+		close,
+		disconnect: vi.fn(() => {}),
+		process: () => null,
+		targets: () => [],
+	} as unknown as Browser;
+	const handle = {
+		key: `headless:redteam-${browserCounter++}`,
+		kind: { kind: "headless", headless: true },
+		browser,
+		refCount,
+		stealth: { browserSession: null, override: null },
+	} as BrowserHandle;
+	return { handle, close };
+}
+
+function makeFakeWorker(): { worker: TabSession["worker"]; terminate: ReturnType<typeof vi.fn> } {
+	const handlers = new Set<(m: { type: string }) => void>();
+	const terminate = vi.fn(async () => {});
+	const worker = {
+		send: (msg: { type: string }) => {
+			if (msg.type === "close") {
+				queueMicrotask(() => {
+					for (const handler of [...handlers]) handler({ type: "closed" });
+				});
+			}
+		},
+		onMessage: (handler: (m: { type: string }) => void) => {
+			handlers.add(handler);
+			return () => handlers.delete(handler);
+		},
+		onError: () => () => {},
+		terminate,
+		mode: "worker" as const,
+	} as unknown as TabSession["worker"];
+	return { worker, terminate };
+}
+
+interface InstallOpts {
+	name: string;
+	ownerId?: string;
+	kindTag?: BrowserKindTag;
+	lastUsedAt: number;
+	pendingCount?: number;
+	refCount?: number;
+}
+
+function installTab(opts: InstallOpts): { close: ReturnType<typeof vi.fn>; handle: BrowserHandle } {
+	const { handle, close } = makeFakeBrowser(opts.refCount ?? 1);
+	const { worker } = makeFakeWorker();
+	const pending = new Map<string, unknown>();
+	for (let i = 0; i < (opts.pendingCount ?? 0); i++) {
+		pending.set(`p${i}`, { reject: () => {}, resolve: () => {}, toolCalls: new Map() });
+	}
+	setTabForTest({
+		name: opts.name,
+		browser: handle,
+		targetId: "target-1",
+		worker,
+		state: "alive",
+		info: { targetId: "target-1" },
+		pending,
+		kindTag: opts.kindTag ?? "headless",
+		ownerId: opts.ownerId,
+		lastUsedAt: opts.lastUsedAt,
+	} as unknown as TabSession);
+	return { close, handle };
+}
+
+function registerSession(overrides: Record<string, unknown> = {}): void {
+	registerResourceGcSession({
+		sessionId: "s1",
+		settings: Settings.isolated({
+			"browser.gc.enabled": true,
+			"browser.gc.idleMs": IDLE_MS,
+			"browser.gc.rssLimitMb": 100,
+			"computer.screenshotGc.enabled": false,
+			...overrides,
+		}),
+	});
+}
+
+describe("resource GC red-team safety invariants", () => {
+	afterEach(() => {
+		clearTabsForTest();
+		__resetResourceGcForTest();
+		vi.restoreAllMocks();
+	});
+
+	it("never evicts ownerless tabs under RSS pressure and warns once", async () => {
+		registerSession({ "browser.gc.idleMs": 10_000_000 });
+		const release = vi.fn(async () => true);
+		const logWarn = vi.fn();
+
+		await sweepOnce(
+			baseDeps({
+				rssBytes: () => 200 * MB,
+				logWarn,
+				releaseTab: release,
+				listTabs: () => [snapshot("ownerless", undefined, NOW - 50_000)],
+			}),
+		);
+
+		expect(release).not.toHaveBeenCalled();
+		expect(logWarn).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not close a tab that flips in-flight between snapshot and eviction", async () => {
+		const { close } = installTab({ name: "a", ownerId: "s1", lastUsedAt: NOW - 50_000 });
+		const snap = listTabsForGc();
+		expect(snap.find(tab => tab.name === "a")?.pendingCount).toBe(0);
+		getTab("a")?.pending.set("late-run", { reject: () => {}, resolve: () => {}, toolCalls: new Map() } as never);
+
+		expect(await releaseTabIfGcEligible("a", { now: () => NOW, idleMs: IDLE_MS })).toBe(false);
+		expect(close).not.toHaveBeenCalled();
+		expect(getTab("a")?.state).toBe("alive");
+	});
+
+	it("does not double-release tabs eligible for both idle and RSS pressure", async () => {
+		registerSession();
+		const first = installTab({ name: "a", ownerId: "s1", lastUsedAt: NOW - 50_000 });
+		const second = installTab({ name: "b", ownerId: "s1", lastUsedAt: NOW - 40_000 });
+
+		await sweepOnce(
+			baseDeps({
+				rssBytes: () => 200 * MB,
+				listTabs: () => listTabsForGc(),
+				releaseTab: (name, policy) => releaseTabIfGcEligible(name, policy),
+			}),
+		);
+
+		expect(first.close).toHaveBeenCalledTimes(1);
+		expect(second.close).toHaveBeenCalledTimes(1);
+		expect(getTab("a")).toBeUndefined();
+		expect(getTab("b")).toBeUndefined();
+	});
+
+	it("RSS oscillation re-warns exactly once per over-limit episode", async () => {
+		registerSession({ "browser.gc.idleMs": 10_000_000 });
+		const logWarn = vi.fn();
+		let rss = 200 * MB;
+		const deps = baseDeps({
+			logWarn,
+			rssBytes: () => rss,
+			listTabs: () => [snapshot("ownerless", undefined, NOW - 50_000)],
+		});
+
+		await sweepOnce(deps);
+		await sweepOnce(deps);
+		expect(logWarn).toHaveBeenCalledTimes(1);
+
+		rss = 50 * MB;
+		await sweepOnce(deps);
+		rss = 200 * MB;
+		await sweepOnce(deps);
+		await sweepOnce(deps);
+		expect(logWarn).toHaveBeenCalledTimes(2);
+	});
+
+	it("disabled browser GC performs no eviction even when idle and over limit", async () => {
+		registerSession({ "browser.gc.enabled": false, "browser.gc.idleMs": IDLE_MS, "browser.gc.rssLimitMb": 100 });
+		const release = vi.fn(async () => true);
+		const logWarn = vi.fn();
+
+		await sweepOnce(
+			baseDeps({
+				rssBytes: () => 200 * MB,
+				logWarn,
+				releaseTab: release,
+				listTabs: () => [snapshot("disabled", "s1", NOW - IDLE_MS - 1)],
+			}),
+		);
+
+		expect(release).not.toHaveBeenCalled();
+		expect(logWarn).not.toHaveBeenCalled();
+	});
+
+	it("does not evict a tab idle exactly at the configured threshold", async () => {
+		registerSession({ "browser.gc.rssLimitMb": 1_000_000 });
+		const release = vi.fn(async () => true);
+
+		await sweepOnce(
+			baseDeps({
+				releaseTab: release,
+				listTabs: () => [snapshot("boundary", "s1", NOW - IDLE_MS)],
+			}),
+		);
+
+		expect(release).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/tools/resource-gc.test.ts
+++ b/packages/coding-agent/test/tools/resource-gc.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getProjectAgentDir, Snowflake } from "@gajae-code/utils";
+import { YAML } from "bun";
+import { resetSettingsForTest, Settings } from "../../src/config/settings";
+import type { TabGcSnapshot } from "../../src/tools/browser/tab-supervisor";
+import {
+	__getResourceGcStateForTest,
+	__resetResourceGcForTest,
+	__runResourceGcTickForTest,
+	__setResourceGcDepsForTest,
+	type ResourceGcDeps,
+	registerResourceGcSession,
+	resolveBrowserGcPolicy,
+	resolveComputerGcPolicy,
+	resolveSweepIntervalMs,
+	sweepOnce,
+} from "../../src/tools/resource-gc";
+
+const MB = 1024 * 1024;
+const NOW = 5_000_000;
+
+function snapshot(name: string, ownerId: string, lastUsedAt: number, over: Partial<TabGcSnapshot> = {}): TabGcSnapshot {
+	return {
+		name,
+		ownerId,
+		state: "alive",
+		pendingCount: 0,
+		kindTag: "headless",
+		lastUsedAt,
+		browserRefCount: 1,
+		...over,
+	};
+}
+
+function baseDeps(over: Partial<ResourceGcDeps> = {}): ResourceGcDeps {
+	return {
+		now: () => NOW,
+		rssBytes: () => 1,
+		logWarn: vi.fn(),
+		listTabs: () => [],
+		releaseTab: vi.fn(async () => true),
+		cleanupScreenshots: vi.fn(async () => ({ scanned: 0, removed: 0 })),
+		screenshotArmed: () => false,
+		...over,
+	};
+}
+
+describe("resource GC controller", () => {
+	afterEach(() => {
+		__resetResourceGcForTest();
+		vi.restoreAllMocks();
+	});
+
+	it("idle sweep evicts idle tabs oldest-first and spares recent ones", async () => {
+		const settings = Settings.isolated({
+			"browser.gc.enabled": true,
+			"browser.gc.idleMs": 1000,
+			"browser.gc.rssLimitMb": 1_000_000,
+			"computer.screenshotGc.enabled": false,
+		});
+		registerResourceGcSession({ sessionId: "s1", settings });
+
+		const releaseTab = vi.fn(async (_name: string) => true);
+		await sweepOnce(
+			baseDeps({
+				releaseTab,
+				listTabs: () => [
+					snapshot("recent", "s1", NOW - 100),
+					snapshot("old", "s1", NOW - 5000),
+					snapshot("mid", "s1", NOW - 3000),
+				],
+			}),
+		);
+
+		expect(releaseTab.mock.calls.map(c => c[0])).toEqual(["old", "mid"]);
+	});
+
+	it("skips tabs owned by no registered session", async () => {
+		const settings = Settings.isolated({ "browser.gc.idleMs": 1000, "browser.gc.rssLimitMb": 1_000_000 });
+		registerResourceGcSession({ sessionId: "s1", settings });
+		const releaseTab = vi.fn(async (_name: string) => true);
+		await sweepOnce(
+			baseDeps({
+				releaseTab,
+				listTabs: () => [snapshot("orphan", "ghost-session", NOW - 5000), snapshot("mine", "s1", NOW - 5000)],
+			}),
+		);
+		expect(releaseTab.mock.calls.map(c => c[0])).toEqual(["mine"]);
+	});
+
+	it("never evicts non-idle tabs under RSS pressure (IR-1) and warns once instead", async () => {
+		const settings = Settings.isolated({
+			"browser.gc.enabled": true,
+			"browser.gc.idleMs": 10_000_000, // huge: nothing is idle-eligible
+			"browser.gc.rssLimitMb": 100,
+			"computer.screenshotGc.enabled": false,
+		});
+		registerResourceGcSession({ sessionId: "s1", settings });
+
+		const releaseTab = vi.fn(async (_name: string) => true);
+		const logWarn = vi.fn();
+		await sweepOnce(
+			baseDeps({
+				releaseTab,
+				logWarn,
+				rssBytes: () => 200 * MB,
+				listTabs: () => [snapshot("recent", "s1", NOW - 100)],
+			}),
+		);
+
+		expect(releaseTab).not.toHaveBeenCalled();
+		expect(logWarn).toHaveBeenCalledTimes(1);
+	});
+
+	it("evicts idle tabs LRU under pressure, then warns once if still over limit", async () => {
+		const settings = Settings.isolated({
+			"browser.gc.enabled": true,
+			"browser.gc.idleMs": 1000,
+			"browser.gc.rssLimitMb": 100,
+			"computer.screenshotGc.enabled": false,
+		});
+		registerResourceGcSession({ sessionId: "s1", settings });
+
+		const removed = new Set<string>();
+		const releaseTab = vi.fn(async (name: string) => {
+			removed.add(name);
+			return true;
+		});
+		const logWarn = vi.fn();
+		const tabs = [snapshot("c", "s1", NOW - 2000), snapshot("a", "s1", NOW - 5000), snapshot("b", "s1", NOW - 3000)];
+		await sweepOnce(
+			baseDeps({
+				releaseTab,
+				logWarn,
+				rssBytes: () => 200 * MB, // stays over limit even after reclamation
+				listTabs: () => tabs.filter(t => !removed.has(t.name)),
+			}),
+		);
+
+		expect(releaseTab.mock.calls.map(c => c[0])).toEqual(["a", "b", "c"]);
+		expect(logWarn).toHaveBeenCalledTimes(1);
+	});
+
+	it("warns exactly once per continuous no-evictable RSS-pressure episode", async () => {
+		const settings = Settings.isolated({
+			"browser.gc.enabled": true,
+			"browser.gc.idleMs": 10_000_000,
+			"browser.gc.rssLimitMb": 100,
+			"computer.screenshotGc.enabled": false,
+		});
+		registerResourceGcSession({ sessionId: "s1", settings });
+
+		const logWarn = vi.fn();
+		let rss = 200 * MB;
+		const deps = baseDeps({ logWarn, rssBytes: () => rss, listTabs: () => [] });
+
+		await sweepOnce(deps);
+		await sweepOnce(deps);
+		expect(logWarn).toHaveBeenCalledTimes(1);
+
+		rss = 50 * MB; // recovery resets the episode
+		await sweepOnce(deps);
+		rss = 200 * MB;
+		await sweepOnce(deps);
+		expect(logWarn).toHaveBeenCalledTimes(2);
+	});
+
+	it("reference-counts the shared timer across sessions", () => {
+		const settings = Settings.isolated({});
+		const unregister1 = registerResourceGcSession({ sessionId: "s1", settings });
+		expect(__getResourceGcStateForTest()).toMatchObject({ timerActive: true, sessionCount: 1 });
+
+		const unregister2 = registerResourceGcSession({ sessionId: "s2", settings });
+		expect(__getResourceGcStateForTest()).toMatchObject({ timerActive: true, sessionCount: 2 });
+
+		unregister1();
+		expect(__getResourceGcStateForTest()).toMatchObject({ timerActive: true, sessionCount: 1 });
+
+		unregister2();
+		expect(__getResourceGcStateForTest()).toMatchObject({ timerActive: false, sessionCount: 0 });
+
+		expect(() => unregister1()).not.toThrow(); // idempotent
+		expect(__getResourceGcStateForTest().sessionCount).toBe(0);
+	});
+
+	it("does not run overlapping ticks", async () => {
+		const settings = Settings.isolated({
+			"browser.gc.enabled": true,
+			"browser.gc.idleMs": 1000,
+			"browser.gc.rssLimitMb": 1_000_000,
+			"computer.screenshotGc.enabled": false,
+		});
+		registerResourceGcSession({ sessionId: "s1", settings });
+
+		let resolveRelease: (() => void) | undefined;
+		const releaseTab = vi.fn(
+			() =>
+				new Promise<boolean>(resolve => {
+					resolveRelease = () => resolve(true);
+				}),
+		);
+		__setResourceGcDepsForTest({
+			releaseTab,
+			listTabs: () => [snapshot("a", "s1", NOW - 5000)],
+		});
+
+		const first = __runResourceGcTickForTest(); // enters sweep, blocks on releaseTab
+		await Promise.resolve();
+		await __runResourceGcTickForTest(); // guard: returns immediately
+		expect(releaseTab).toHaveBeenCalledTimes(1);
+
+		resolveRelease?.();
+		await first;
+	});
+
+	it("lazy-arms and throttles stale screenshot cleanup", async () => {
+		const settings = Settings.isolated({
+			"browser.gc.enabled": false,
+			"computer.screenshotGc.enabled": true,
+			"computer.screenshotGc.staleMs": 43_200_000,
+			"computer.screenshotGc.scanIntervalMs": 1000,
+		});
+		registerResourceGcSession({ sessionId: "s1", settings });
+
+		let armed = false;
+		let clock = NOW;
+		const cleanupScreenshots = vi.fn(async () => ({ scanned: 0, removed: 0 }));
+		const deps = baseDeps({ cleanupScreenshots, screenshotArmed: () => armed, now: () => clock });
+
+		await sweepOnce(deps);
+		expect(cleanupScreenshots).not.toHaveBeenCalled(); // not armed yet
+
+		armed = true;
+		await sweepOnce(deps);
+		expect(cleanupScreenshots).toHaveBeenCalledTimes(1);
+
+		await sweepOnce(deps); // within scan interval → throttled
+		expect(cleanupScreenshots).toHaveBeenCalledTimes(1);
+
+		clock += 2000; // past scan interval
+		await sweepOnce(deps);
+		expect(cleanupScreenshots).toHaveBeenCalledTimes(2);
+	});
+
+	it("resolves documented defaults from settings", () => {
+		const settings = Settings.isolated({});
+		expect(resolveBrowserGcPolicy(settings)).toEqual({ enabled: true, idleMs: 300_000, rssLimitBytes: 1536 * MB });
+		expect(resolveComputerGcPolicy(settings)).toEqual({
+			enabled: true,
+			staleMs: 43_200_000,
+			scanIntervalMs: 1_800_000,
+		});
+		expect(resolveSweepIntervalMs(settings)).toBe(30_000);
+	});
+});
+
+describe("resource GC settings precedence", () => {
+	let testDir: string;
+	let agentDir: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		resetSettingsForTest();
+		testDir = path.join(os.tmpdir(), "test-resource-gc-settings", Snowflake.next());
+		agentDir = path.join(testDir, "agent");
+		projectDir = path.join(testDir, "project");
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.mkdirSync(getProjectAgentDir(projectDir), { recursive: true });
+		fs.mkdirSync(path.join(projectDir, ".gjc"), { recursive: true });
+	});
+
+	afterEach(() => {
+		resetSettingsForTest();
+		fs.rmSync(testDir, { recursive: true, force: true });
+	});
+
+	it("lets project .gjc/settings.json override the user config.yml", async () => {
+		fs.writeFileSync(path.join(agentDir, "config.yml"), YAML.stringify({ browser: { gc: { idleMs: 111_111 } } }));
+		fs.writeFileSync(
+			path.join(projectDir, ".gjc", "settings.json"),
+			JSON.stringify({ browser: { gc: { idleMs: 222_222 } } }),
+		);
+
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		expect(settings.get("browser.gc.idleMs")).toBe(222_222);
+	});
+});

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1754,6 +1754,38 @@
 				"screenshotDir": {
 					"type": "string",
 					"description": "Directory to save screenshots. If unset, screenshots go to a temp file. Supports ~. Examples: ~/Downloads, ~/Desktop, /sdcard/Download (Android)"
+				},
+				"gc": {
+					"type": "object",
+					"properties": {
+						"enabled": {
+							"type": "boolean",
+							"description": "Automatically reclaim idle, unheld GJC-managed headless/spawned browser tabs.",
+							"default": true
+						},
+						"idleMs": {
+							"type": "number",
+							"description": "Evict headless/spawned tabs idle longer than this many milliseconds.",
+							"default": 300000
+						},
+						"rssLimitMb": {
+							"type": "number",
+							"description": "Parent-process RSS (MB) above which idle tabs are opportunistically evicted LRU.",
+							"default": 1536
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"resourceGc": {
+			"type": "object",
+			"properties": {
+				"sweepIntervalMs": {
+					"type": "number",
+					"description": "How often the resource GC sweeps browser tabs and stale screenshot directories.",
+					"default": 30000
 				}
 			},
 			"additionalProperties": false
@@ -1793,6 +1825,27 @@
 							"type": "boolean",
 							"description": "Persist audit records for enabled computer-use actions.",
 							"default": true
+						}
+					},
+					"additionalProperties": false
+				},
+				"screenshotGc": {
+					"type": "object",
+					"properties": {
+						"enabled": {
+							"type": "boolean",
+							"description": "Delete stale computer-use screenshot fallback directories on disk.",
+							"default": true
+						},
+						"staleMs": {
+							"type": "number",
+							"description": "Remove screenshot fallback directories whose mtime is older than this many milliseconds.",
+							"default": 43200000
+						},
+						"scanIntervalMs": {
+							"type": "number",
+							"description": "Minimum interval between os.tmpdir scans for stale screenshot directories.",
+							"default": 1800000
 						}
 					},
 					"additionalProperties": false


### PR DESCRIPTION
## Summary

Browser tabs are the heavyweight resource in the agent runtime — **one worker thread + Chrome child processes per tab** — and were only reclaimed on explicit `close`/session teardown. Long sessions that open many tabs accumulated substantial memory. This adds a session-aware, safety-bounded **resource garbage collector** for the browser and computer-use tools.

Pipeline: deep-interview spec (ambiguity 4.85%) → ralplan consensus plan → ultragoal execution (6 stories, all gated).

## What changed

**Browser tabs (primary target)**
- `tools/browser/tab-supervisor.ts`: `TabSession.lastUsedAt`; `TabGcSnapshot` + `listTabsForGc()`; `releaseTabIfGcEligible()` with a **synchronous live recheck** (no intervening await). A shared **begin-release guard** makes concurrent/double release a no-op (`BrowserHandle.refCount` decremented exactly once), and `tabs.delete` is **identity-guarded** so a same-name reacquire during an in-flight release isn't deleted.
- `tools/resource-gc.ts` (new): mandatory **session-keyed, reference-counted** controller on a single `unref`'d recursive `setTimeout` (generation-guarded against duplicate timers, non-overlapping). Idle sweep evicts **only** idle + non-in-flight + GJC-managed headless/spawned + registered-owner tabs; never connected (`cdp_url`), real Chrome profiles, held, in-flight, or ownerless tabs. RSS (parent-process, best-effort) is a **warning-only** signal that never force-evicts non-idle tabs.

**Computer-use (disk-only)**
- `tools/computer-gc.ts` (new): cleanup of stale `gjc-computer-screenshots-*` dirs in `os.tmpdir()` (lazy-armed + throttled). The computer tool holds no growing RAM; this is purely disk hygiene.

**Wiring & config**
- `session/agent-session.ts`: register on construct; idempotent unregister in `dispose()` and `disposeChildSubprocesses()`.
- `config/settings-schema.ts` (+ regenerated `schemas/config.schema.json`): `browser.gc.*`, `resourceGc.sweepIntervalMs`, `computer.screenshotGc.*`. Defaults **ON**: idle 5min, RSS 1536MB, sweep 30s, stale screenshots 12h. All override-able in `.gjc/settings.json` (project overrides user).

## Design note (Intent Reconciliation)

The spec's "unheld (refCount==0)" has no per-tab implementation — `refCount` is per `BrowserHandle` (= tab count). "Unheld" is therefore defined as **idle + non-in-flight + headless/spawned + registered-owner**. RSS eviction honors this boundary strictly (never evicts non-idle tabs); under unrelievable pressure it warns once per episode instead.

## Tests

- `test/tools/browser-gc.test.ts` — eligibility matrix, busy-after-snapshot, double-release refCount-once, `listTabsForGc`.
- `test/tools/resource-gc.test.ts` — idle LRU, RSS warning-only, defaults + project-over-user precedence, timer ref-counting, no-overlap, lazy/throttled screenshot cadence.
- `test/tools/resource-gc-redteam.test.ts` — adversarial: ownerless-under-pressure, busy-after-snapshot, concurrent idle+RSS double-release, RSS oscillation warn-once, disabled session, idle boundary.
- `test/tools/computer-gc.test.ts` — stale-dir cleanup (old-matching removed; recent/non-matching kept).

**Verification:** 34 GC tests + 6 adversarial cases pass; 31 computer-use safety regression tests pass; `biome` clean; typecheck clean on changed files; `check:schemas` clean. Architect review: architecture/product/code all CLEAR → APPROVE.

## Notes for reviewers

- Open confirmations carried from planning: the IR-1 "unheld" mapping above, owner-scoped eviction (ownerless tabs skipped), and the settings namespace (`browser.gc.*` / `computer.screenshotGc.*` / `resourceGc.sweepIntervalMs`).
- RSS is **parent-process** RSS (`process.memoryUsage().rss`); Chrome child memory isn't reflected, so pressure handling is best-effort by design.
