### PR TITLE
Add prompt action to scroll to previous user input

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ GJC accepts images in two ways:
 - **CLI startup**: prefix a local image path with `@`, for example `gjc @screenshot.png "What should I change?"`.
 - **Interactive TUI**: copy an image to the system clipboard and use the configured **Paste image from clipboard** key (Ctrl+V on Linux/macOS, Alt+V on Windows), or type `#paste-image` and choose the prompt action. When the clipboard is unavailable, paste or pass the image file path with `@path/to/image.png` instead.
 
+Type `#` in the interactive editor to open prompt actions. In a tmux-backed session, choose **Scroll to previous user input** (for example via `#prev`) to enter tmux copy-mode at the previous rendered user message.
+
 Inside a GJC session, use the public workflow surface:
 
 ```text

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Elided runaway thinking-token loops in the assistant message renderer so repeated thinking output no longer grows without bound (#1196).
 - Made `gjc session` create/list work on psmux-backed multiplexers (#1192).
 - Sanitized dot-prefixed cwd window titles so tmux window names render correctly (#1198).
+### Added
+
+- Added a `#` prompt action that enters tmux copy-mode and searches backward to the previous rendered `user` input marker, providing a tmux-local previous-input scroll jump without relying on terminal-specific modified key chords.
 
 ## [0.7.4] - 2026-06-27
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -9,6 +9,7 @@ import { buildSkillPromptMessage, parseSkillInvocations } from "../../extensibil
 import { expandEmoticons } from "../../modes/emoji-autocomplete";
 import { createPromptActionAutocompleteProvider } from "../../modes/prompt-action-autocomplete";
 import { theme } from "../../modes/theme/theme";
+import { scrollTmuxToPreviousUserInput as scrollTmuxPaneToPreviousUserInput } from "../../modes/tmux-scroll";
 import type { InteractiveModeContext } from "../../modes/types";
 import type { AgentSessionEvent } from "../../session/agent-session";
 import { SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../../session/messages";
@@ -858,6 +859,7 @@ export class InputController {
 			copyCurrentLine: () => this.handleCopyCurrentLine(),
 			copyPrompt: () => this.handleCopyPrompt(),
 			pasteImage: () => void this.handleImagePaste(),
+			scrollTmuxToPreviousUserInput: () => this.scrollTmuxToPreviousUserInput(),
 			undo: prefix => this.ctx.editor.undoPastTransientText(prefix),
 			moveCursorToMessageEnd: () => this.ctx.editor.moveToMessageEnd(),
 			moveCursorToMessageStart: () => this.ctx.editor.moveToMessageStart(),
@@ -950,6 +952,19 @@ export class InputController {
 
 	toggleToolOutputExpansion(): void {
 		this.setToolsExpanded(!this.ctx.toolOutputExpanded);
+	}
+
+	scrollTmuxToPreviousUserInput(): void {
+		const result = scrollTmuxPaneToPreviousUserInput();
+		if (result.ok) return;
+
+		if (result.reason === "not_inside_tmux") {
+			this.ctx.showWarning("Previous-input scroll works only inside tmux.");
+			return;
+		}
+
+		const detail = result.error ? `: ${result.error}` : ".";
+		this.ctx.showWarning(`Failed to scroll tmux to previous user input${detail}`);
 	}
 
 	setToolsExpanded(expanded: boolean): void {

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -29,6 +29,7 @@ interface PromptActionAutocompleteOptions {
 	copyCurrentLine: () => void;
 	copyPrompt: () => void;
 	pasteImage: () => void;
+	scrollTmuxToPreviousUserInput: () => void;
 	undo: (prefix: string) => void;
 	moveCursorToMessageEnd: () => void;
 	moveCursorToMessageStart: () => void;
@@ -377,6 +378,13 @@ export function createPromptActionAutocompleteProvider(
 			description: formatKeyHints(options.keybindings.getKeys("app.clipboard.pasteImage")),
 			keywords: ["paste", "image", "clipboard", "screenshot", "attach", "vision"],
 			execute: options.pasteImage,
+		},
+		{
+			id: "tmux-previous-user-input",
+			label: "Scroll to previous user input",
+			description: "tmux copy-mode",
+			keywords: ["scroll", "tmux", "previous", "user", "input", "prompt", "history"],
+			execute: options.scrollTmuxToPreviousUserInput,
 		},
 		{
 			id: "undo",

--- a/packages/coding-agent/src/modes/tmux-scroll.ts
+++ b/packages/coding-agent/src/modes/tmux-scroll.ts
@@ -1,0 +1,92 @@
+import { resolveGjcTmuxCommand } from "../gjc-runtime/tmux-common";
+
+// tmux copy-mode pads lines to the pane width, so require at least two spaces
+// after the standalone `user` label instead of using a brittle end-of-line anchor.
+export const TMUX_PREVIOUS_USER_INPUT_SEARCH_PATTERN = "^ *user  *";
+
+type TmuxScrollFailureReason =
+	| "not_inside_tmux"
+	| "tmux_command_failed"
+	| "copy_mode_failed"
+	| "history_bottom_failed"
+	| "search_failed";
+
+export type TmuxScrollToPreviousUserInputResult =
+	| { ok: true }
+	| { ok: false; reason: TmuxScrollFailureReason; error?: string };
+
+interface TmuxSpawnResult {
+	exitCode: number | null;
+	stderr?: { toString(): string };
+}
+
+type TmuxSpawnSync = (command: string, args: string[], env: NodeJS.ProcessEnv) => TmuxSpawnResult;
+
+function defaultSpawnSync(command: string, args: string[], env: NodeJS.ProcessEnv): TmuxSpawnResult {
+	return Bun.spawnSync([command, ...args], {
+		env,
+		stdout: "ignore",
+		stderr: "pipe",
+	});
+}
+
+function getErrorText(result: TmuxSpawnResult): string | undefined {
+	const text = result.stderr?.toString().trim();
+	return text ? text : undefined;
+}
+
+function runTmuxStep(
+	command: string,
+	args: string[],
+	env: NodeJS.ProcessEnv,
+	spawnSync: TmuxSpawnSync,
+	reason: TmuxScrollFailureReason,
+): TmuxScrollToPreviousUserInputResult {
+	try {
+		const result = spawnSync(command, args, env);
+		if (result.exitCode === 0) return { ok: true };
+		return { ok: false, reason, error: getErrorText(result) };
+	} catch (error) {
+		return { ok: false, reason, error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+export function scrollTmuxToPreviousUserInput(
+	env: NodeJS.ProcessEnv = process.env,
+	spawnSync: TmuxSpawnSync = defaultSpawnSync,
+): TmuxScrollToPreviousUserInputResult {
+	if (!env.TMUX) return { ok: false, reason: "not_inside_tmux" };
+
+	let tmuxCommand: string;
+	try {
+		tmuxCommand = resolveGjcTmuxCommand(env);
+	} catch (error) {
+		return {
+			ok: false,
+			reason: "tmux_command_failed",
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+
+	const targetPane = env.TMUX_PANE?.trim();
+	const targetArgs = targetPane ? ["-t", targetPane] : [];
+	const copyModeResult = runTmuxStep(tmuxCommand, ["copy-mode", ...targetArgs], env, spawnSync, "copy_mode_failed");
+	if (!copyModeResult.ok) return copyModeResult;
+
+	const historyBottomResult = runTmuxStep(
+		tmuxCommand,
+		["send-keys", ...targetArgs, "-X", "history-bottom"],
+		env,
+		spawnSync,
+		"history_bottom_failed",
+	);
+	if (!historyBottomResult.ok) return historyBottomResult;
+
+	return runTmuxStep(
+		tmuxCommand,
+		["send-keys", ...targetArgs, "-X", "search-backward", TMUX_PREVIOUS_USER_INPUT_SEARCH_PATTERN],
+		env,
+		spawnSync,
+		"search_failed",
+	);
+}

--- a/packages/coding-agent/test/modes/tmux-scroll.test.ts
+++ b/packages/coding-agent/test/modes/tmux-scroll.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { scrollTmuxToPreviousUserInput, TMUX_PREVIOUS_USER_INPUT_SEARCH_PATTERN } from "../../src/modes/tmux-scroll";
+
+describe("scrollTmuxToPreviousUserInput", () => {
+	it("reports unavailable outside tmux", () => {
+		const calls: string[][] = [];
+		const result = scrollTmuxToPreviousUserInput({}, (command, args) => {
+			calls.push([command, ...args]);
+			return { exitCode: 0 };
+		});
+
+		expect(result).toEqual({ ok: false, reason: "not_inside_tmux" });
+		expect(calls).toEqual([]);
+	});
+
+	it("enters copy mode and searches backward for the user-message label in the current pane", () => {
+		const calls: string[][] = [];
+		const env: NodeJS.ProcessEnv = {
+			GJC_TMUX_COMMAND: "tmux-test",
+			TMUX: "/tmp/tmux-501/default,123,0",
+			TMUX_PANE: "%7",
+		};
+		const result = scrollTmuxToPreviousUserInput(env, (command, args) => {
+			calls.push([command, ...args]);
+			return { exitCode: 0 };
+		});
+
+		expect(result).toEqual({ ok: true });
+		expect(calls).toEqual([
+			["tmux-test", "copy-mode", "-t", "%7"],
+			["tmux-test", "send-keys", "-t", "%7", "-X", "history-bottom"],
+			["tmux-test", "send-keys", "-t", "%7", "-X", "search-backward", TMUX_PREVIOUS_USER_INPUT_SEARCH_PATTERN],
+		]);
+	});
+
+	it("falls back to tmux's current pane when TMUX_PANE is absent", () => {
+		const calls: string[][] = [];
+		const env: NodeJS.ProcessEnv = {
+			GJC_TMUX_COMMAND: "tmux-test",
+			TMUX: "/tmp/tmux-501/default,123,0",
+		};
+		const result = scrollTmuxToPreviousUserInput(env, (command, args) => {
+			calls.push([command, ...args]);
+			return { exitCode: 0 };
+		});
+
+		expect(result).toEqual({ ok: true });
+		expect(calls).toEqual([
+			["tmux-test", "copy-mode"],
+			["tmux-test", "send-keys", "-X", "history-bottom"],
+			["tmux-test", "send-keys", "-X", "search-backward", TMUX_PREVIOUS_USER_INPUT_SEARCH_PATTERN],
+		]);
+	});
+
+	it("returns the tmux stderr from the failing step", () => {
+		const env: NodeJS.ProcessEnv = {
+			GJC_TMUX_COMMAND: "tmux-test",
+			TMUX: "/tmp/tmux-501/default,123,0",
+			TMUX_PANE: "%7",
+		};
+		const result = scrollTmuxToPreviousUserInput(env, () => ({
+			exitCode: 1,
+			stderr: { toString: () => "no current pane\n" },
+		}));
+
+		expect(result).toEqual({ ok: false, reason: "copy_mode_failed", error: "no current pane" });
+	});
+});

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -30,6 +30,7 @@ describe("prompt action autocomplete", () => {
 			copyCurrentLine: () => {},
 			copyPrompt: () => {},
 			pasteImage: () => {},
+			scrollTmuxToPreviousUserInput: () => {},
 			undo: () => {},
 			moveCursorToMessageEnd: () => {},
 			moveCursorToMessageStart: () => {},
@@ -44,6 +45,7 @@ describe("prompt action autocomplete", () => {
 			"Copy current line",
 			"Copy whole prompt",
 			"Paste image from clipboard",
+			"Scroll to previous user input",
 			"Undo",
 			"Move cursor to end of message",
 			"Move cursor to beginning of message",
@@ -72,6 +74,7 @@ describe("prompt action autocomplete", () => {
 			copyCurrentLine: () => {},
 			copyPrompt: () => {},
 			pasteImage: () => {},
+			scrollTmuxToPreviousUserInput: () => {},
 			undo: prefix => {
 				undoCalls += 1;
 				undoPrefix = prefix;
@@ -111,6 +114,7 @@ describe("prompt action autocomplete", () => {
 			pasteImage: () => {
 				pasteCalls += 1;
 			},
+			scrollTmuxToPreviousUserInput: () => {},
 			undo: () => {},
 			moveCursorToMessageEnd: () => {},
 			moveCursorToMessageStart: () => {},
@@ -133,6 +137,40 @@ describe("prompt action autocomplete", () => {
 		expect(pasteCalls).toBe(1);
 	});
 
+	it("runs tmux previous-user-input scroll from the prompt action menu", async () => {
+		let scrollCalls = 0;
+		const provider = createPromptActionAutocompleteProvider({
+			commands: [],
+			basePath: "/tmp",
+			keybindings: AppKeybindingsManager.inMemory(),
+			copyCurrentLine: () => {},
+			copyPrompt: () => {},
+			pasteImage: () => {},
+			scrollTmuxToPreviousUserInput: () => {
+				scrollCalls += 1;
+			},
+			undo: () => {},
+			moveCursorToMessageEnd: () => {},
+			moveCursorToMessageStart: () => {},
+			moveCursorToLineStart: () => {},
+			moveCursorToLineEnd: () => {},
+		});
+
+		const suggestions = await provider.getSuggestions(["please #prev"], 0, 12);
+		const item = suggestions?.items.find(entry => entry.label === "Scroll to previous user input");
+		expect(item).toBeDefined();
+		if (!item || !suggestions) {
+			throw new Error("expected tmux previous-user-input suggestion");
+		}
+
+		const result = provider.applyCompletion(["please #prev"], 0, 12, item, suggestions.prefix);
+		expect(result.lines).toEqual(["please "]);
+		expect(result.cursorLine).toBe(0);
+		expect(result.cursorCol).toBe(7);
+		result.onApplied?.();
+		expect(scrollCalls).toBe(1);
+	});
+
 	it("falls back to normal typing for literal hashtags with no matching action", async () => {
 		const provider = createPromptActionAutocompleteProvider({
 			commands: [],
@@ -141,6 +179,7 @@ describe("prompt action autocomplete", () => {
 			copyCurrentLine: () => {},
 			copyPrompt: () => {},
 			pasteImage: () => {},
+			scrollTmuxToPreviousUserInput: () => {},
 			undo: () => {},
 			moveCursorToMessageEnd: () => {},
 			moveCursorToMessageStart: () => {},
@@ -160,6 +199,7 @@ describe("prompt action autocomplete", () => {
 			copyCurrentLine: () => {},
 			copyPrompt: () => {},
 			pasteImage: () => {},
+			scrollTmuxToPreviousUserInput: () => {},
 			undo: () => {},
 			moveCursorToMessageEnd: () => {},
 			moveCursorToMessageStart: () => {},
@@ -180,6 +220,7 @@ describe("prompt action autocomplete", () => {
 			copyCurrentLine: () => {},
 			copyPrompt: () => {},
 			pasteImage: () => {},
+			scrollTmuxToPreviousUserInput: () => {},
 			undo: () => {},
 			moveCursorToMessageEnd: () => {},
 			moveCursorToMessageStart: () => {},

--- a/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
@@ -19,6 +19,7 @@ function createProvider() {
 		copyCurrentLine: () => {},
 		copyPrompt: () => {},
 		pasteImage: () => {},
+		scrollTmuxToPreviousUserInput: () => {},
 		undo: () => {},
 		moveCursorToMessageEnd: () => {},
 		moveCursorToMessageStart: () => {},


### PR DESCRIPTION
## Summary
- add a # prompt action that enters tmux copy-mode and searches back to the previous rendered user message
- surface tmux-only warnings through the TUI instead of relying on fragile modified key chords
- document the prompt action and cover helper/autocomplete behavior with tests

## Verification
- bun run check (packages/coding-agent)
- bun test packages/coding-agent/test/modes/tmux-scroll.test.ts packages/coding-agent/test/prompt-action-autocomplete.test.ts packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
- bun run check:tools
- tmux smoke: copy-mode history-bottom + search-backward '^ *user  *'
