### PR TITLE
fix(ai): clamp Codex GPT-5.5 context cap

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -459,7 +459,8 @@ function applyGpt55ContextWindow(model: ApiModel<Api>, parsedModel: OpenAIModel)
 		// budget. GJC's `contextWindow` is the usable prompt/input cap, not the
 		// marketing total window; using 1M here delays compaction and makes the UI
 		// promise space that `/responses/compact`/agent turns cannot actually use.
-		model.contextWindow = model.provider === "openai-codex" || model.api === "openai-codex-responses" ? 272_000 : 1_000_000;
+		model.contextWindow =
+			model.provider === "openai-codex" || model.api === "openai-codex-responses" ? 272_000 : 1_000_000;
 		return true;
 	}
 	return false;

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -454,7 +454,12 @@ function inferGeneratedApplyPatchToolType(
 
 function applyGpt55ContextWindow(model: ApiModel<Api>, parsedModel: OpenAIModel): boolean {
 	if (parsedModel.variant === "base" && semverEqual(parsedModel.version, "5.5")) {
-		model.contextWindow = 1_000_000;
+		// The first-party OpenAI GPT-5.5 model advertises a 1M total window, but
+		// the OpenAI code backend request path still enforces the smaller prompt
+		// budget. GJC's `contextWindow` is the usable prompt/input cap, not the
+		// marketing total window; using 1M here delays compaction and makes the UI
+		// promise space that `/responses/compact`/agent turns cannot actually use.
+		model.contextWindow = model.provider === "openai-codex" || model.api === "openai-codex-responses" ? 272_000 : 1_000_000;
 		return true;
 	}
 	return false;

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -1,4 +1,4 @@
-import { enrichModelThinking } from "./model-thinking";
+import { applyGeneratedModelPolicies, enrichModelThinking } from "./model-thinking";
 import MODELS from "./models.json" with { type: "json" };
 import type { Api, KnownProvider, Model, Usage } from "./types";
 import { isClaudeForcedToolChoiceIncapableModelId } from "./utils/tool-choice-capability";
@@ -47,7 +47,9 @@ function applyBundledCompatDefaults(model: Model<Api>): Model<Api> {
 			compat: { ...(normalized.compat ?? {}), toolChoiceSupport: "auto" } as Model<Api>["compat"],
 		};
 	}
-	return normalized;
+	const policyModels = [normalized];
+	applyGeneratedModelPolicies(policyModels);
+	return policyModels[0] ?? normalized;
 }
 
 export type GeneratedProvider = keyof typeof MODELS;

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -285,7 +285,7 @@ describe("generated model policies", () => {
 		expect(models[1]?.contextPromotionTarget).toBeUndefined();
 	});
 
-	it("keeps Codex gpt-5.5 at the 1M context window even if discovery is stale", () => {
+	it("keeps Codex gpt-5.5 at the effective 272K request cap even if discovery advertises 1M", () => {
 		const models: Model<Api>[] = [
 			{
 				...createModel({
@@ -293,15 +293,16 @@ describe("generated model policies", () => {
 					api: "openai-codex-responses",
 					provider: "openai-codex",
 				}),
-				// OpenAI code discovery/cache can carry stale 272K metadata.
-				contextWindow: 272000,
+				// OpenAI code discovery/cache can advertise the total 1M window, but
+				// the usable request prompt cap remains lower on this transport.
+				contextWindow: 1_000_000,
 				maxTokens: 128000,
 			},
 		];
 
 		applyGeneratedModelPolicies(models);
 
-		expect(models[0]?.contextWindow).toBe(1_000_000);
+		expect(models[0]?.contextWindow).toBe(272_000);
 	});
 
 	it("sets freeform apply_patch metadata for first-party GPT-5 Responses models", () => {

--- a/packages/ai/test/openai-codex-default.test.ts
+++ b/packages/ai/test/openai-codex-default.test.ts
@@ -16,8 +16,9 @@ describe("OpenAI Codex defaults", () => {
 			maxLevel: Effort.XHigh,
 			defaultLevel: Effort.XHigh,
 		});
-		// GPT-5.5/Codex 5.5 is a 1M-context model; keep the bundled metadata aligned
-		// with the active runtime policy so status/compaction surfaces do not show 272K.
-		expect(model.contextWindow).toBe(1_000_000);
+		// Codex GPT-5.5 may advertise a 1M total window, but the code backend's
+		// effective prompt/request cap is lower. Status and compaction must use the
+		// safe request cap instead of promising a window that overflows upstream.
+		expect(model.contextWindow).toBe(272_000);
 	});
 });


### PR DESCRIPTION
## Summary

- clamp Codex/OpenAI-code GPT-5.5 `contextWindow` to the effective 272K prompt/request cap instead of the advertised 1M total window
- apply generated model policies to bundled model loading so stale `models.json` metadata cannot bypass runtime cap corrections
- update regression coverage for discovery and bundled defaults

Fixes #1230.

## Verification

- `bun install`
- `bun --cwd=packages/natives run build`
- `bun test packages/ai/test/model-thinking.test.ts packages/ai/test/openai-codex-default.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
