### PR TITLE
Expose Telegram lifecycle commands in bot menu

### DIFF
--- a/docs/notifications-sdk.md
+++ b/docs/notifications-sdk.md
@@ -437,7 +437,8 @@ End-to-end manual check once `gjc notify setup` has paired your private chat:
    running (`gjc launch` in a repo, or `GJC_NOTIFICATIONS=1`). The owner starts
    the loopback control endpoint and accepts `/session_*` while running; with zero
    active sessions it still idle-exits after the inactivity timeout.
-2. **Create.** From your paired chat send `/session_create path <repo-dir>` (or
+2. **Create.** From your paired chat, pick `/session_create` from the Telegram
+   command menu or send `/session_create path <repo-dir>` (or
    `/session_create worktree <repo> <branch>`, or `/session_create dir <newdir>`).
    `<repo-dir>`, `<repo>`, and `<newdir>` may use `~`/`~/...` for your own home
    directory; named-user forms such as `~alice/repo` are rejected. The bot replies

--- a/docs/telegram-onboarding.md
+++ b/docs/telegram-onboarding.md
@@ -227,6 +227,13 @@ Reply paths:
   - `/lean`
   - `/verbosity <lean|verbose>`
   - `/redact <on|off>`
+- send paired-chat lifecycle commands from the Telegram command menu or by typing:
+  - `/session_create path <dir>`
+  - `/session_create worktree <repo> <branch>`
+  - `/session_create dir <newdir>`
+  - `/session_recent [create|resume]`
+  - `/session_close <sessionId>`
+  - `/session_resume <sessionId|prefix>`
 
 The removed legacy `/answer <session-tag> <answer>` flow is not the primary UX;
 Telegram topic routing identifies the target session when the configured chat

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Telegram now advertises `/session_create`, `/session_recent`, `/session_close`, and `/session_resume` in the bot command menu so lifecycle control commands are discoverable from `/` autocomplete.
 
 ## [0.7.7] - 2026-06-28
 ### Added

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -2005,6 +2005,10 @@ export class TelegramNotificationDaemon {
 					{ command: "verbose", description: "Mirror full tool output + reasoning in this thread" },
 					{ command: "lean", description: "Mirror assistant text + tool names only (default)" },
 					{ command: "redact", description: "Toggle redaction of streamed content: /redact <on|off>" },
+					{ command: "session_create", description: "Create a GJC session: path, worktree, or dir" },
+					{ command: "session_recent", description: "List recent GJC sessions" },
+					{ command: "session_close", description: "Close a GJC-managed session" },
+					{ command: "session_resume", description: "Resume or reattach a session" },
 				],
 			});
 		} catch {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -839,7 +839,7 @@ describe("telegram daemon connection-drop resilience (repro-first)", () => {
 	});
 });
 
-test("daemon registers in-thread config commands and drops stale rpc/answer commands", async () => {
+test("daemon registers in-thread config and lifecycle commands and drops stale rpc/answer commands", async () => {
 	const s = settings(tempAgentDir());
 	const bot = new FakeBotApi();
 	const daemon = new TelegramNotificationDaemon({
@@ -856,6 +856,10 @@ test("daemon registers in-thread config commands and drops stale rpc/answer comm
 	expect(cmds).toContain("verbose");
 	expect(cmds).toContain("lean");
 	expect(cmds).toContain("redact");
+	expect(cmds).toContain("session_create");
+	expect(cmds).toContain("session_recent");
+	expect(cmds).toContain("session_close");
+	expect(cmds).toContain("session_resume");
 	expect(cmds).not.toContain("answer");
 	expect(cmds).not.toContain("attach");
 	expect(cmds).not.toContain("detach");


### PR DESCRIPTION
## Summary
- Add `/session_create`, `/session_recent`, `/session_close`, and `/session_resume` to the Telegram bot command menu
- Cover lifecycle command menu registration in the daemon test
- Update Telegram lifecycle docs and changelog

## Verification
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bunx biome check packages/coding-agent/src/notifications/telegram-daemon.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts docs/telegram-onboarding.md docs/notifications-sdk.md packages/coding-agent/CHANGELOG.md`