### PR TITLE
fix(coding-agent): slim notify daemon startup

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -79,6 +79,19 @@ async function installRuntimeGlobals(): Promise<void> {
 	delete process.env.MallocStackLoggingNoCompact;
 }
 
+function isNotifyDaemonInternalFastPath(argv: string[]): boolean {
+	return argv[0] === "notify" && argv[1] === "daemon-internal";
+}
+
+async function runNotifyDaemonInternalFastPath(argv: string[]): Promise<void> {
+	const { parseNotifyArgs, runNotifyCommand } = await import("./cli/notify-cli");
+	const cmd = parseNotifyArgs(argv);
+	if (cmd?.action !== "daemon-internal") {
+		throw new Error("invalid notify daemon-internal fast path");
+	}
+	await runNotifyCommand(cmd);
+}
+
 function hasRootFastFlag(argv: string[], flags: readonly string[]): boolean {
 	for (const arg of argv) {
 		if (isSubcommand(arg)) return false;
@@ -208,6 +221,10 @@ async function runSmokeTest(): Promise<void> {
 
 /** Run the CLI with the given argv (no `process.argv` prefix). */
 export async function runCli(argv: string[]): Promise<void> {
+	if (isNotifyDaemonInternalFastPath(argv)) {
+		await runNotifyDaemonInternalFastPath(argv);
+		return;
+	}
 	if (argv[0] === "--smoke-test") {
 		await runSmokeTest();
 		return;

--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -6,7 +6,7 @@
 import { createInterface } from "node:readline/promises";
 import { APP_NAME } from "@gajae-code/utils";
 import chalk from "chalk";
-import { Settings } from "../config/settings";
+import type { Settings } from "../config/settings";
 import { getNotificationConfig, maskToken } from "../notifications/config";
 
 export type NotifyAction = "setup" | "status" | "daemon-internal";
@@ -122,7 +122,9 @@ export async function runNotifyCommand(cmd: NotifyCommandArgs, deps: NotifyComma
 }
 
 async function getSettings(deps: NotifyCommandDeps): Promise<Settings> {
-	return deps.settings ?? (await Settings.init());
+	if (deps.settings) return deps.settings;
+	const { Settings } = await import("../config/settings");
+	return await Settings.init();
 }
 
 async function runSetup(deps: NotifyCommandDeps): Promise<void> {

--- a/packages/coding-agent/src/commands/notify.ts
+++ b/packages/coding-agent/src/commands/notify.ts
@@ -55,7 +55,7 @@ export default class Notify extends Command {
 			redact: Boolean(flags.redact),
 		};
 
-		await initTheme();
+		if (action !== "daemon-internal") await initTheme();
 		await runNotifyCommand(cmd);
 	}
 }

--- a/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
@@ -1,14 +1,16 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { Settings } from "../config/settings";
+import { YAML } from "bun";
+import type { Settings } from "../config/settings";
 import { getNotificationConfig, isGloballyConfigured } from "./config";
 import { daemonPaths, TelegramNotificationDaemon } from "./telegram-daemon";
 import { clearTelegramControlRequest, readTelegramControlRequest } from "./telegram-daemon-control";
 
 export interface RunDaemonInternalDeps {
-	SettingsImpl?: Pick<typeof Settings, "init">;
+	SettingsImpl?: { init: (options?: { agentDir?: string }) => Promise<Pick<Settings, "get" | "getAgentDir">> };
 	DaemonImpl?: typeof TelegramNotificationDaemon;
 	processPid?: number;
+	pidAlive?: (pid: number) => boolean;
 }
 
 function argValue(argv: string[], name: string): string | undefined {
@@ -16,9 +18,105 @@ function argValue(argv: string[], name: string): string | undefined {
 	return i >= 0 ? argv[i + 1] : undefined;
 }
 
+function getByPath(obj: unknown, pathSegments: string[]): unknown {
+	let current = obj;
+	for (const segment of pathSegments) {
+		if (!current || typeof current !== "object" || Array.isArray(current)) return undefined;
+		current = (current as Record<string, unknown>)[segment];
+	}
+	return current;
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+	return typeof value === "boolean" ? value : fallback;
+}
+
+function asIdleTimeoutMs(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 60_000;
+}
+
+export function createLightweightDaemonSettings(input: {
+	agentDir: string;
+	rawConfig?: unknown;
+}): Pick<Settings, "get" | "getAgentDir"> {
+	const rawConfig = input.rawConfig && typeof input.rawConfig === "object" ? input.rawConfig : {};
+	return {
+		get(pathName: string): unknown {
+			const value = getByPath(rawConfig, pathName.split("."));
+			switch (pathName) {
+				case "notifications.enabled":
+					return asBoolean(value, false);
+				case "notifications.telegram.botToken":
+				case "notifications.telegram.chatId":
+				case "notifications.discord.botToken":
+				case "notifications.discord.channelId":
+				case "notifications.slack.botToken":
+				case "notifications.slack.channelId":
+					return asString(value);
+				case "notifications.redact":
+					return asBoolean(value, false);
+				case "notifications.verbosity":
+					return value === "verbose" ? "verbose" : "lean";
+				case "notifications.daemon.idleTimeoutMs":
+					return asIdleTimeoutMs(value);
+				default:
+					return undefined;
+			}
+		},
+		getAgentDir(): string {
+			return input.agentDir;
+		},
+	} as Pick<Settings, "get" | "getAgentDir">;
+}
+
+export async function loadLightweightDaemonSettings(agentDir: string): Promise<Pick<Settings, "get" | "getAgentDir">> {
+	const configPath = path.join(agentDir, "config.yml");
+	let rawConfig: unknown = {};
+	try {
+		rawConfig = YAML.parse(await fs.promises.readFile(configPath, "utf8"));
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+	return createLightweightDaemonSettings({ agentDir, rawConfig });
+}
+
+async function resolveDaemonSettings(
+	agentDir: string,
+	deps: RunDaemonInternalDeps,
+): Promise<Pick<Settings, "get" | "getAgentDir">> {
+	if (deps.SettingsImpl) return await deps.SettingsImpl.init({ agentDir });
+	return await loadLightweightDaemonSettings(agentDir);
+}
+
+export function ownerPidFromOwnerId(ownerId: string): number | undefined {
+	const match = /^(\d+)(?:-|$)/.exec(ownerId);
+	if (!match) return undefined;
+	const pid = Number(match[1]);
+	return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
+}
+
+function defaultPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function ownerProcessIsAlive(ownerId: string, deps: RunDaemonInternalDeps): boolean {
+	const ownerPid = ownerPidFromOwnerId(ownerId);
+	if (ownerPid === undefined) return true;
+	return (deps.pidAlive ?? defaultPidAlive)(ownerPid);
+}
+
 export async function runDaemonSmoke(opts: { agentDir?: string } = {}): Promise<void> {
 	const agentDir = opts.agentDir ?? fs.mkdtempSync(path.join(process.cwd(), ".telegram-daemon-smoke-"));
-	const settings = Settings.isolated({});
+	const settings = createLightweightDaemonSettings({ agentDir, rawConfig: {} });
 	const paths = daemonPaths(agentDir);
 	await fs.promises.mkdir(paths.dir, { recursive: true, mode: 0o700 });
 	const tempLock = `${paths.lock}.smoke.${process.pid}`;
@@ -34,12 +132,17 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 	if (smoke) return runDaemonSmoke({ agentDir });
 	const ownerId = argValue(argv, "--owner-id");
 	if (!ownerId) throw new Error("missing --owner-id");
-	const settings = await (deps.SettingsImpl ?? Settings).init(agentDir ? { agentDir } : {});
-	const cfg = getNotificationConfig(settings);
+	if (!ownerProcessIsAlive(ownerId, deps)) {
+		process.stderr.write(`GJC notify daemon exiting: owner process from --owner-id ${ownerId} is not alive.\n`);
+		return;
+	}
+	const resolvedAgentDir = agentDir ?? process.env.GJC_CODING_AGENT_DIR ?? path.join(process.cwd(), ".gjc", "agent");
+	const settings = await resolveDaemonSettings(resolvedAgentDir, deps);
+	const cfg = getNotificationConfig(settings as Settings);
 	if (!isGloballyConfigured(cfg) || !cfg.botToken || !cfg.chatId) return;
 	const Daemon = deps.DaemonImpl ?? TelegramNotificationDaemon;
 	const daemon = new Daemon({
-		settings,
+		settings: settings as Settings,
 		ownerId,
 		botToken: cfg.botToken,
 		chatId: cfg.chatId,
@@ -47,15 +150,15 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 		pid: deps.processPid ?? process.pid,
 		control: {
 			shouldStop: async owner => {
-				const req = await readTelegramControlRequest(settings);
+				const req = await readTelegramControlRequest(settings as Settings);
 				return Boolean(req && (!req.ownerId || req.ownerId === owner));
 			},
 			clear: async owner => {
-				const req = await readTelegramControlRequest(settings);
+				const req = await readTelegramControlRequest(settings as Settings);
 				// Only clear a request that targets this daemon owner, so an exiting
 				// daemon never erases a newer request meant for a different owner.
 				if (req && (!req.ownerId || req.ownerId === owner)) {
-					await clearTelegramControlRequest(settings, req.requestId);
+					await clearTelegramControlRequest(settings as Settings, req.requestId);
 				}
 			},
 		},

--- a/packages/coding-agent/test/notify-setup.test.ts
+++ b/packages/coding-agent/test/notify-setup.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { parseNotifyArgs, runNotifyCommand } from "../src/cli/notify-cli";
 import { Settings } from "../src/config/settings";
 import { getNotificationConfig, maskToken } from "../src/notifications/config";
+import {
+	createLightweightDaemonSettings,
+	loadLightweightDaemonSettings,
+	ownerPidFromOwnerId,
+	runDaemonInternal,
+} from "../src/notifications/telegram-daemon-cli";
 
 type FakeCall = { method: string; body: Record<string, unknown> };
 
@@ -505,5 +514,82 @@ describe("notify setup threaded mode verification", () => {
 			),
 		).rejects.toThrow("Pairing rejected supergroup chat");
 		expect(getNotificationConfig(settings).enabled).toBe(false);
+	});
+});
+
+describe("notify daemon-internal lightweight startup", () => {
+	function tempAgentDir(): string {
+		return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notify-daemon-agent-"));
+	}
+
+	test("lightweight daemon settings read only notification keys from config.yml", async () => {
+		const agentDir = tempAgentDir();
+		fs.writeFileSync(
+			path.join(agentDir, "config.yml"),
+			`notifications:
+  enabled: true
+  telegram:
+    botToken: 1234:token
+    chatId: "999"
+  redact: true
+  verbosity: verbose
+  daemon:
+    idleTimeoutMs: 12345
+`,
+		);
+
+		const settings = await loadLightweightDaemonSettings(agentDir);
+		const cfg = getNotificationConfig(settings as Settings);
+		expect(settings.getAgentDir()).toBe(agentDir);
+		expect(cfg.enabled).toBe(true);
+		expect(cfg.botToken).toBe("1234:token");
+		expect(cfg.chatId).toBe("999");
+		expect(cfg.redact).toBe(true);
+		expect(cfg.verbosity).toBe("verbose");
+		expect(cfg.idleTimeoutMs).toBe(12345);
+	});
+
+	test("lightweight daemon settings fall back to safe notification defaults", () => {
+		const settings = createLightweightDaemonSettings({ agentDir: "/tmp/gjc-agent", rawConfig: {} });
+		const cfg = getNotificationConfig(settings as Settings);
+		expect(cfg.enabled).toBe(false);
+		expect(cfg.botToken).toBeUndefined();
+		expect(cfg.chatId).toBeUndefined();
+		expect(cfg.redact).toBe(false);
+		expect(cfg.verbosity).toBe("lean");
+		expect(cfg.idleTimeoutMs).toBe(60_000);
+	});
+
+	test("daemon-internal exits before loading settings when owner pid is stale", async () => {
+		let settingsLoaded = false;
+		let daemonConstructed = false;
+		const { stderr } = await captureOutput(() =>
+			runDaemonInternal(["--owner-id", "12345-dead", "--agent-dir", tempAgentDir()], {
+				pidAlive: () => false,
+				SettingsImpl: {
+					async init() {
+						settingsLoaded = true;
+						return createLightweightDaemonSettings({ agentDir: "/tmp/gjc-agent", rawConfig: {} });
+					},
+				},
+				DaemonImpl: class {
+					constructor() {
+						daemonConstructed = true;
+					}
+					requestStop(): void {}
+					async run(): Promise<void> {}
+				} as never,
+			}),
+		);
+		expect(stderr).toContain("owner process");
+		expect(settingsLoaded).toBe(false);
+		expect(daemonConstructed).toBe(false);
+	});
+
+	test("owner pid parser accepts pid-prefixed owner ids only", () => {
+		expect(ownerPidFromOwnerId("12345-kabc-random")).toBe(12345);
+		expect(ownerPidFromOwnerId("12345")).toBe(12345);
+		expect(ownerPidFromOwnerId("owner-12345")).toBeUndefined();
+		expect(ownerPidFromOwnerId("0-dead")).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary
- add a root `notify daemon-internal` fast path so detached notification daemons skip the generic command runner/runtime-global path
- avoid eager theme and full `Settings`/`AgentStorage` initialization for the hidden daemon entrypoint
- load only notification-related keys from `config.yml` for daemon startup and exit early when a pid-prefixed `--owner-id` is already stale

## Verification
- `bunx biome check --write packages/coding-agent/src/cli.ts packages/coding-agent/src/cli/notify-cli.ts packages/coding-agent/src/commands/notify.ts packages/coding-agent/src/notifications/telegram-daemon-cli.ts packages/coding-agent/test/notify-setup.test.ts`
- `bun test packages/coding-agent/test/notify-setup.test.ts`
- `bun test packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

## Notes
- Linux CI cannot directly reproduce the Windows PowerShell process table from #1242, so the lifecycle part is covered through injected `pidAlive` behavior and the existing compiled daemon smoke.
- This PR intentionally keeps the reporter's broader `cli/args.ts` and `commands/launch.ts` hot-path import cleanup as follow-up scope instead of bundling it into the notify-daemon fix.

Closes #1242
