### PR TITLE
Fix coordinator MCP prompt acknowledgement timeout

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Coordinator MCP now fails tmux-delivered turns that never receive a runtime prompt acknowledgement/`turn_start`, surfacing an explicit unacknowledged delivery reason instead of leaving Hermes/Oren waiting on a normal active/running state (#1237).
 - Telegram now advertises `/session_create`, `/session_recent`, `/session_close`, and `/session_resume` in the bot command menu so lifecycle control commands are discoverable from `/` autocomplete.
 
 ## [0.7.7] - 2026-06-28

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -119,7 +119,7 @@ interface TurnRecord {
 		target: string | null;
 		tmux_keys_sent?: boolean;
 		prompt_acknowledged?: boolean;
-		state?: "queued" | "tmux_keys_sent" | "acknowledged" | "unavailable";
+		state?: "queued" | "tmux_keys_sent" | "acknowledged" | "unavailable" | "unacknowledged";
 		attempts: Array<{
 			delivered: boolean;
 			created_at: string;
@@ -214,6 +214,9 @@ interface CoordinatorEventInput {
 }
 
 const MISSING_FINAL_RESPONSE_ADVISORY = "completion_missing_final_response";
+const PROMPT_ACK_TIMEOUT_REASON = "runtime_prompt_ack_timeout";
+const DEFAULT_RUNTIME_PROMPT_ACK_TIMEOUT_MS = 10_000;
+const MAX_RUNTIME_PROMPT_ACK_TIMEOUT_MS = 5 * 60 * 1000;
 const ACTIVE_TURN_STATUSES = new Set<TurnStatus>(["delivering", "active", "waiting_for_answer", "completing"]);
 const TERMINAL_TURN_STATUSES = new Set<TurnStatus>(["completed", "failed", "cancelled", "superseded"]);
 const TURN_ID_PATTERN = /^turn-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -1049,6 +1052,135 @@ async function markTurnTerminalFromSessionState(
 	return resolved;
 }
 
+function runtimeStateAcknowledgesTurn(turn: TurnRecord, sessionState: CoordinatorSessionState | null): boolean {
+	return (
+		sessionState?.source === "agent_session_event" &&
+		sessionState.current_turn_id === turn.turn_id &&
+		(sessionState.state === "running" ||
+			sessionState.state === "needs_user_input" ||
+			sessionState.state === "completed" ||
+			sessionState.state === "errored")
+	);
+}
+
+async function markTurnAcknowledgedFromRuntimeState(
+	namespaceDir: string,
+	turn: TurnRecord,
+	sessionState: CoordinatorSessionState,
+): Promise<TurnRecord> {
+	if (turn.delivery.prompt_acknowledged === true && turn.delivery.state === "acknowledged") return turn;
+	const timestamp = new Date().toISOString();
+	const acknowledged: TurnRecord = {
+		...turn,
+		delivery: {
+			...turn.delivery,
+			delivered: true,
+			prompt_acknowledged: true,
+			state: "acknowledged",
+			attempts: [
+				...turn.delivery.attempts,
+				{
+					delivered: true,
+					created_at: sessionState.updated_at,
+					reason: "runtime_prompt_acknowledged",
+					channel: "runtime_ack",
+					tmux_keys_sent: turn.delivery.tmux_keys_sent,
+				},
+			],
+		},
+		updated_at: timestamp,
+	};
+	await writeTurnRecord(namespaceDir, acknowledged);
+	await writeActiveTurn(namespaceDir, acknowledged);
+	return acknowledged;
+}
+
+function turnAwaitingRuntimeAckExpired(turn: TurnRecord, nowMs: number, ackTimeoutMs: number): boolean {
+	if (!ACTIVE_TURN_STATUSES.has(turn.status)) return false;
+	if (turn.delivery.tmux_keys_sent !== true) return false;
+	if (turn.delivery.prompt_acknowledged === true) return false;
+	if (turn.delivery.state !== "tmux_keys_sent") return false;
+	const deliveredAt =
+		turn.delivery.attempts.findLast(attempt => attempt.channel === "tmux_keys")?.created_at ?? turn.updated_at;
+	const deliveredMs = Date.parse(deliveredAt);
+	return Number.isFinite(deliveredMs) && nowMs - deliveredMs >= ackTimeoutMs;
+}
+
+async function markTurnFailedForUnacknowledgedDelivery(
+	namespaceDir: string,
+	turn: TurnRecord,
+	ackTimeoutMs: number,
+): Promise<TurnRecord> {
+	const timestamp = new Date().toISOString();
+	const message = `Tmux key delivery succeeded, but the GJC runtime did not acknowledge the prompt or emit turn_start within ${ackTimeoutMs}ms. The turn never started; stop waiting and inspect/retry the coordinator session.`;
+	const failed: TurnRecord = {
+		...turn,
+		status: "failed",
+		delivery: {
+			...turn.delivery,
+			delivered: false,
+			queued: false,
+			prompt_acknowledged: false,
+			state: "unacknowledged",
+			attempts: [
+				...turn.delivery.attempts,
+				{
+					delivered: false,
+					created_at: timestamp,
+					reason: PROMPT_ACK_TIMEOUT_REASON,
+					channel: "runtime_ack",
+					tmux_keys_sent: true,
+				},
+			],
+		},
+		final_response: {
+			text: message,
+			format: "markdown",
+			source: "coordinator_delivery_ack_timeout",
+			artifact_path: null,
+			truncated: false,
+		},
+		error: { code: PROMPT_ACK_TIMEOUT_REASON, message, recoverable: true },
+		evidence: [
+			...turn.evidence,
+			{
+				type: PROMPT_ACK_TIMEOUT_REASON,
+				message,
+				tmux_keys_sent: true,
+				prompt_acknowledged: false,
+				created_at: timestamp,
+			},
+		],
+		liveness: { checked_at: timestamp, live: turn.liveness.live, reason: PROMPT_ACK_TIMEOUT_REASON },
+		updated_at: timestamp,
+		completed_at: timestamp,
+	};
+	await writeTurnRecord(namespaceDir, failed);
+	await clearActiveTurn(namespaceDir, failed);
+	await writeSessionState(namespaceDir, failed.session_id, "stale", {
+		lastTurnId: failed.turn_id,
+		live: failed.liveness.live,
+		reason: PROMPT_ACK_TIMEOUT_REASON,
+	});
+	return failed;
+}
+
+async function reconcileRuntimeAcknowledgement(
+	namespaceDir: string,
+	turn: TurnRecord,
+	sessionState: CoordinatorSessionState | null,
+	ackTimeoutMs: number,
+	options: { failOnTimeout: boolean } = { failOnTimeout: true },
+): Promise<TurnRecord> {
+	if (sessionState && runtimeStateAcknowledgesTurn(turn, sessionState)) {
+		return await markTurnAcknowledgedFromRuntimeState(namespaceDir, turn, sessionState);
+	}
+	if (options.failOnTimeout && turnAwaitingRuntimeAckExpired(turn, Date.now(), ackTimeoutMs)) {
+		return await markTurnFailedForUnacknowledgedDelivery(namespaceDir, turn, ackTimeoutMs);
+	}
+	return turn;
+}
+
 function shellQuote(value: string): string {
 	return `'${value.replaceAll("'", "'\\''")}'`;
 }
@@ -1097,6 +1229,7 @@ function asTerminalTurnStatus(status: unknown): TurnStatus | null {
 }
 
 export const COORDINATOR_AWAIT_TURN_TIMEOUT_MAX_MS = 30 * 60 * 1000;
+export const COORDINATOR_RUNTIME_PROMPT_ACK_TIMEOUT_MAX_MS = MAX_RUNTIME_PROMPT_ACK_TIMEOUT_MS;
 export const COORDINATOR_EVENT_WATCH_TIMEOUT_MAX_MS = 30_000;
 export const COORDINATOR_POLL_INTERVAL_MAX_MS = 10_000;
 
@@ -1107,6 +1240,13 @@ function parsePositiveIntegerMs(value: unknown, fallback: number): number {
 
 export function boundedAwaitTurnTimeoutMs(value: unknown): number {
 	return Math.min(parsePositiveIntegerMs(value, 1000), COORDINATOR_AWAIT_TURN_TIMEOUT_MAX_MS);
+}
+
+export function boundedRuntimePromptAckTimeoutMs(value: unknown): number {
+	return Math.min(
+		parsePositiveIntegerMs(value, DEFAULT_RUNTIME_PROMPT_ACK_TIMEOUT_MS),
+		COORDINATOR_RUNTIME_PROMPT_ACK_TIMEOUT_MAX_MS,
+	);
 }
 
 export function boundedEventWatchTimeoutMs(value: unknown): number {
@@ -1406,7 +1546,9 @@ export async function readCoordinatorArtifact(
 }
 
 export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions = {}) {
-	const config = buildCoordinatorMcpConfig(options.env ?? process.env);
+	const env = options.env ?? process.env;
+	const config = buildCoordinatorMcpConfig(env);
+	const promptAckTimeoutMs = boundedRuntimePromptAckTimeoutMs(env.GJC_COORDINATOR_MCP_PROMPT_ACK_TIMEOUT_MS);
 	const services = options.services ?? {};
 	const namespaceDir = coordinatorNamespacePath(config);
 	const commandRunner = services.commandRunner ?? runCommand;
@@ -1504,14 +1646,17 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		await writeTurnRecord(namespaceDir, activeTurn);
 		await writeActiveTurn(namespaceDir, activeTurn);
 		const sessionState = await readSessionState(namespaceDir, activeTurn.session_id);
-		const runtimeStateAlreadySettled =
-			sessionState?.current_turn_id === activeTurn.turn_id &&
-			(sessionState.state === "completed" || sessionState.state === "errored");
-		if (!runtimeStateAlreadySettled) {
-			await writeSessionState(namespaceDir, activeTurn.session_id, tmuxKeysSent ? "running" : "stale", {
+		const runtimeStateAlreadyAcknowledged =
+			sessionState !== null && runtimeStateAcknowledgesTurn(activeTurn, sessionState);
+		const resolvedTurn =
+			runtimeStateAlreadyAcknowledged && sessionState
+				? await markTurnAcknowledgedFromRuntimeState(namespaceDir, activeTurn, sessionState)
+				: activeTurn;
+		if (!runtimeStateAlreadyAcknowledged && !tmuxKeysSent) {
+			await writeSessionState(namespaceDir, activeTurn.session_id, "stale", {
 				currentTurnId: activeTurn.turn_id,
 				live,
-				reason: tmuxKeysSent ? null : "tmux_delivery_unavailable",
+				reason: "tmux_delivery_unavailable",
 			});
 		}
 		await appendCoordinatorEvent(namespaceDir, {
@@ -1524,7 +1669,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			payloadRef: path.relative(namespaceDir, turnFile(namespaceDir, activeTurn.turn_id)),
 			metadata: { target: typeof target === "string" ? target : null, live },
 		});
-		return activeTurn;
+		return resolvedTurn;
 	}
 
 	async function promoteNextQueuedTurn(sessionId: string): Promise<TurnRecord | null> {
@@ -1552,33 +1697,64 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		let resolvedTurn = turn;
 		let advisoryStatus: Record<string, unknown> = { live: false };
 		let sessionState = await readSessionState(namespaceDir, turn.session_id);
+		resolvedTurn = await reconcileRuntimeAcknowledgement(
+			namespaceDir,
+			resolvedTurn,
+			sessionState,
+			promptAckTimeoutMs,
+			{ failOnTimeout: false },
+		);
+		if (resolvedTurn !== turn) sessionState = await readSessionState(namespaceDir, resolvedTurn.session_id);
 		if (
 			sessionState &&
-			ACTIVE_TURN_STATUSES.has(turn.status) &&
-			sessionState.current_turn_id === turn.turn_id &&
+			ACTIVE_TURN_STATUSES.has(resolvedTurn.status) &&
+			sessionState.current_turn_id === resolvedTurn.turn_id &&
 			(sessionState.state === "completed" || sessionState.state === "errored")
 		) {
-			resolvedTurn = await markTurnTerminalFromSessionState(namespaceDir, turn, sessionState);
+			resolvedTurn = await markTurnTerminalFromSessionState(namespaceDir, resolvedTurn, sessionState);
 			sessionState = await readSessionState(namespaceDir, resolvedTurn.session_id);
 		} else if (
 			sessionState &&
-			ACTIVE_TURN_STATUSES.has(turn.status) &&
-			sessionState.current_turn_id === turn.turn_id &&
+			ACTIVE_TURN_STATUSES.has(resolvedTurn.status) &&
+			sessionState.current_turn_id === resolvedTurn.turn_id &&
 			sessionState.state === "stale" &&
 			sessionState.reason === "tmux_delivery_unavailable" &&
-			turn.delivery.state === "unavailable" &&
+			resolvedTurn.delivery.state === "unavailable" &&
 			session &&
 			hasTmuxIdentity(session)
 		) {
-			resolvedTurn = await markTurnFailedForUnavailableSession(namespaceDir, turn, "tmux_delivery_unavailable");
+			resolvedTurn = await markTurnFailedForUnavailableSession(
+				namespaceDir,
+				resolvedTurn,
+				"tmux_delivery_unavailable",
+			);
 			sessionState = await readSessionState(namespaceDir, resolvedTurn.session_id);
-		} else if (!session && ACTIVE_TURN_STATUSES.has(turn.status)) {
-			resolvedTurn = await markTurnFailedForUnavailableSession(namespaceDir, turn, "session_record_missing");
+		} else if (!session && ACTIVE_TURN_STATUSES.has(resolvedTurn.status)) {
+			resolvedTurn = await markTurnFailedForUnavailableSession(namespaceDir, resolvedTurn, "session_record_missing");
 			sessionState = await readSessionState(namespaceDir, resolvedTurn.session_id);
 		} else if (session) {
 			advisoryStatus = await inspectTmuxSession(session, boundedLineCount(lines), commandRunner);
-			if (ACTIVE_TURN_STATUSES.has(turn.status) && hasTmuxIdentity(session) && advisoryStatus.live === false) {
-				resolvedTurn = await markTurnFailedForUnavailableSession(namespaceDir, turn, "tmux_session_missing");
+			if (
+				ACTIVE_TURN_STATUSES.has(resolvedTurn.status) &&
+				hasTmuxIdentity(session) &&
+				advisoryStatus.live === false
+			) {
+				resolvedTurn = await markTurnFailedForUnavailableSession(
+					namespaceDir,
+					resolvedTurn,
+					"tmux_session_missing",
+				);
+				sessionState = await readSessionState(namespaceDir, resolvedTurn.session_id);
+			}
+		}
+		if (ACTIVE_TURN_STATUSES.has(resolvedTurn.status)) {
+			resolvedTurn = await reconcileRuntimeAcknowledgement(
+				namespaceDir,
+				resolvedTurn,
+				sessionState,
+				promptAckTimeoutMs,
+			);
+			if (!ACTIVE_TURN_STATUSES.has(resolvedTurn.status)) {
 				sessionState = await readSessionState(namespaceDir, resolvedTurn.session_id);
 			}
 		}
@@ -1596,6 +1772,46 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 					}
 				: {}),
 		};
+	}
+
+	async function reconcileActiveTurnAcknowledgements(): Promise<void> {
+		const turns = (await listJsonFiles(turnsDir(namespaceDir)))
+			.map(turn => asRecord(turn) as TurnRecord | null)
+			.filter((turn): turn is TurnRecord => turn !== null && ACTIVE_TURN_STATUSES.has(turn.status));
+		for (const turn of turns) {
+			let sessionState = await readSessionState(namespaceDir, turn.session_id);
+			const resolvedTurn = await reconcileRuntimeAcknowledgement(
+				namespaceDir,
+				turn,
+				sessionState,
+				promptAckTimeoutMs,
+				{ failOnTimeout: false },
+			);
+			if (!ACTIVE_TURN_STATUSES.has(resolvedTurn.status)) continue;
+			if (resolvedTurn !== turn) sessionState = await readSessionState(namespaceDir, resolvedTurn.session_id);
+			const session = asRecord(await readJsonFile(sessionFile(resolvedTurn.session_id)));
+			if (
+				sessionState &&
+				sessionState.current_turn_id === resolvedTurn.turn_id &&
+				sessionState.state === "stale" &&
+				sessionState.reason === "tmux_delivery_unavailable" &&
+				resolvedTurn.delivery.state === "unavailable" &&
+				session &&
+				hasTmuxIdentity(session)
+			) {
+				await markTurnFailedForUnavailableSession(namespaceDir, resolvedTurn, "tmux_delivery_unavailable");
+				continue;
+			}
+			if (!session) {
+				await markTurnFailedForUnavailableSession(namespaceDir, resolvedTurn, "session_record_missing");
+				continue;
+			}
+			if (hasTmuxIdentity(session) && (await hasTmuxSession(session, commandRunner)) === false) {
+				await markTurnFailedForUnavailableSession(namespaceDir, resolvedTurn, "tmux_session_missing");
+				continue;
+			}
+			await reconcileRuntimeAcknowledgement(namespaceDir, resolvedTurn, sessionState, promptAckTimeoutMs);
+		}
 	}
 
 	async function callTool(name: string, args: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
@@ -1638,6 +1854,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 				};
 			}
 			if (name === "gjc_coordinator_read_status") {
+				await reconcileActiveTurnAcknowledgements();
 				const sessionId = args.session_id;
 				if (sessionId) {
 					const session = asRecord(await readJsonFile(sessionFile(sessionId)));
@@ -1670,6 +1887,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			if (name === "gjc_coordinator_read_artifact")
 				return await readCoordinatorArtifact(config, { path: args.path });
 			if (name === "gjc_coordinator_read_coordination_status") {
+				await reconcileActiveTurnAcknowledgements();
 				const sessions = jsonRecords(await listSessions());
 				const sessionStates = jsonRecords(await listJsonFiles(path.join(namespaceDir, "session-states")));
 				const turns = jsonRecords(await listJsonFiles(turnsDir(namespaceDir)));
@@ -1703,6 +1921,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 				};
 			}
 			if (name === "gjc_coordinator_watch_events") {
+				await reconcileActiveTurnAcknowledgements();
 				const limit = boundedEventLimit(args.limit);
 				const timeoutMs = boundedEventWatchTimeoutMs(args.timeout_ms);
 				let events = await readCoordinatorEvents(namespaceDir);
@@ -1710,6 +1929,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 				let timedOut = false;
 				if (matched.length === 0 && timeoutMs > 0) {
 					await waitForCoordinatorEvents(namespaceDir, timeoutMs);
+					await reconcileActiveTurnAcknowledgements();
 					events = await readCoordinatorEvents(namespaceDir);
 					matched = filterCoordinatorEvents(events, args, limit);
 					timedOut = matched.length === 0;

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -7,6 +7,7 @@ import {
 	boundedAwaitTurnTimeoutMs,
 	boundedEventWatchTimeoutMs,
 	boundedPollIntervalMs,
+	boundedRuntimePromptAckTimeoutMs,
 	COORDINATOR_AWAIT_TURN_TIMEOUT_MAX_MS,
 	COORDINATOR_EVENT_WATCH_TIMEOUT_MAX_MS,
 	COORDINATOR_MCP_TOOL_NAMES,
@@ -33,6 +34,7 @@ describe("Coordinator MCP server protocol", () => {
 		expect(boundedEventWatchTimeoutMs(1_800_000)).toBe(COORDINATOR_EVENT_WATCH_TIMEOUT_MAX_MS);
 		expect(boundedPollIntervalMs(10_000)).toBe(10_000);
 		expect(boundedPollIntervalMs(60_000)).toBe(COORDINATOR_POLL_INTERVAL_MAX_MS);
+		expect(boundedRuntimePromptAckTimeoutMs(3_600_000)).toBe(300_000);
 	});
 
 	it("initializes with GJC coordinator server identity and lists GJC-named tools", async () => {
@@ -194,6 +196,250 @@ describe("Coordinator MCP server protocol", () => {
 			delivery: { target: "visible-session:0.0", tmux_keys_sent: true, state: "tmux_keys_sent" },
 		});
 		expect(commands).toContainEqual(["tmux", "send-keys", "-t", "visible-session:0.0", "do work", "C-m", "C-m"]);
+	});
+
+	it("fails tmux-delivered turns that never receive a runtime prompt ack", async () => {
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "state", "unacknowledged-delivery");
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+				GJC_COORDINATOR_MCP_PROMPT_ACK_TIMEOUT_MS: "1",
+			},
+			services: {
+				startSession: async input => ({
+					sessionId: "delegate-session",
+					tmuxSession: "delegate-session",
+					tmuxTarget: "delegate-session:0.0",
+					cwd: input.cwd,
+					createdAt: "2026-06-28T00:00:00.000Z",
+				}),
+				commandRunner: async command => {
+					if (command[1] === "has-session") return { exitCode: 0, stdout: "", stderr: "" };
+					if (command[1] === "display-message") return { exitCode: 0, stdout: "%24\n", stderr: "" };
+					if (command[1] === "send-keys") return { exitCode: 0, stdout: "", stderr: "" };
+					if (command[1] === "capture-pane") return { exitCode: 0, stdout: "idle\n", stderr: "" };
+					return { exitCode: 1, stdout: "", stderr: "unexpected command" };
+				},
+			},
+		});
+
+		await server.callTool("gjc_coordinator_register_session", {
+			session_id: "visible-session",
+			cwd: root,
+			tmux_session: "visible-session",
+			tmux_target: "visible-session:0.0",
+			visible: true,
+			allow_mutation: true,
+		});
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "do work",
+			allow_mutation: true,
+		});
+		expect(sent).toMatchObject({
+			ok: true,
+			status: "active",
+			session_state: { state: "running" },
+			delivery: { tmux_keys_sent: true, prompt_acknowledged: false, state: "tmux_keys_sent" },
+		});
+
+		await Bun.sleep(5);
+		const read = await server.callTool("gjc_coordinator_read_turn", {
+			session_id: "visible-session",
+			turn_id: sent.turn_id,
+		});
+		expect(read).toMatchObject({
+			ok: true,
+			turn: {
+				status: "failed",
+				delivery: { tmux_keys_sent: true, prompt_acknowledged: false, state: "unacknowledged" },
+				error: { code: "runtime_prompt_ack_timeout" },
+				final_response: { source: "coordinator_delivery_ack_timeout" },
+			},
+			session_state: { state: "stale", reason: "runtime_prompt_ack_timeout" },
+		});
+		expect(JSON.stringify(read)).toContain("turn never started");
+
+		const status = await server.callTool("gjc_coordinator_read_coordination_status");
+		expect(status.summary).toMatchObject({ active_sessions: 1, active_turns: 0, terminal_turns: 1 });
+		expect(status.turns).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					status: "failed",
+					error: expect.objectContaining({ code: "runtime_prompt_ack_timeout" }),
+				}),
+			]),
+		);
+		const events = await server.callTool("gjc_coordinator_watch_events", {
+			after_seq: 0,
+			event_types: ["turn.failed"],
+			timeout_ms: 1,
+		});
+		expect(events.events).toEqual(
+			expect.arrayContaining([expect.objectContaining({ kind: "turn.failed", turn_id: sent.turn_id })]),
+		);
+
+		const delegated = await server.callTool("gjc_delegate_execute", {
+			cwd: root,
+			task: "execute delegated work",
+			allow_mutation: true,
+			await_completion: true,
+			timeout_ms: 50,
+			poll_interval_ms: 1,
+		});
+		expect(delegated).toMatchObject({
+			ok: true,
+			workflow: "execute",
+			status: "failed",
+			turn: {
+				delivery: { tmux_keys_sent: true, prompt_acknowledged: false, state: "unacknowledged" },
+				error: { code: "runtime_prompt_ack_timeout" },
+			},
+		});
+	});
+
+	it("marks tmux-delivered turns acknowledged when runtime state accepts the current turn", async () => {
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "state", "acknowledged-delivery");
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+				GJC_COORDINATOR_MCP_PROMPT_ACK_TIMEOUT_MS: "60000",
+			},
+			services: {
+				commandRunner: async command => {
+					if (command[1] === "has-session") return { exitCode: 0, stdout: "", stderr: "" };
+					if (command[1] === "display-message") return { exitCode: 0, stdout: "%24\n", stderr: "" };
+					if (command[1] === "send-keys") return { exitCode: 0, stdout: "", stderr: "" };
+					if (command[1] === "capture-pane") return { exitCode: 0, stdout: "working\n", stderr: "" };
+					return { exitCode: 1, stdout: "", stderr: "unexpected command" };
+				},
+			},
+		});
+
+		await server.callTool("gjc_coordinator_register_session", {
+			session_id: "visible-session",
+			cwd: root,
+			tmux_session: "visible-session",
+			tmux_target: "visible-session:0.0",
+			visible: true,
+			allow_mutation: true,
+		});
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "do acknowledged work",
+			allow_mutation: true,
+		});
+		const turnId = sent.turn_id as string;
+		const sessionStatesDir = path.join(stateRoot, "local", "repo", "session-states");
+		await fs.mkdir(sessionStatesDir, { recursive: true });
+		await Bun.write(
+			path.join(sessionStatesDir, "visible-session.json"),
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "visible-session",
+				state: "running",
+				ready_for_input: false,
+				current_turn_id: turnId,
+				last_turn_id: null,
+				updated_at: "2026-06-28T00:00:01.000Z",
+				source: "agent_session_event",
+				live: true,
+				reason: "turn_start",
+			}),
+		);
+
+		const read = await server.callTool("gjc_coordinator_read_turn", {
+			session_id: "visible-session",
+			turn_id: turnId,
+		});
+
+		expect(read).toMatchObject({
+			ok: true,
+			turn: {
+				status: "active",
+				delivery: { tmux_keys_sent: true, prompt_acknowledged: true, state: "acknowledged" },
+				error: null,
+			},
+			session_state: { state: "running", current_turn_id: turnId, source: "agent_session_event" },
+		});
+		expect((read.turn as { delivery: { attempts: Array<{ reason: string | null }> } }).delivery.attempts).toEqual(
+			expect.arrayContaining([expect.objectContaining({ reason: "runtime_prompt_acknowledged" })]),
+		);
+	});
+
+	it("preserves session-missing failure precedence over runtime ack timeout", async () => {
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "state", "missing-session-precedence");
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+				GJC_COORDINATOR_MCP_PROMPT_ACK_TIMEOUT_MS: "1",
+			},
+			services: {
+				commandRunner: async command => {
+					if (command[1] === "has-session") return { exitCode: 0, stdout: "", stderr: "" };
+					if (command[1] === "display-message") return { exitCode: 0, stdout: "%24\n", stderr: "" };
+					if (command[1] === "send-keys") return { exitCode: 0, stdout: "", stderr: "" };
+					if (command[1] === "capture-pane") return { exitCode: 0, stdout: "idle\n", stderr: "" };
+					return { exitCode: 1, stdout: "", stderr: "unexpected command" };
+				},
+			},
+		});
+
+		await server.callTool("gjc_coordinator_register_session", {
+			session_id: "visible-session",
+			cwd: root,
+			tmux_session: "visible-session",
+			tmux_target: "visible-session:0.0",
+			visible: true,
+			allow_mutation: true,
+		});
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "do work before session disappears",
+			allow_mutation: true,
+		});
+		await fs.rm(path.join(stateRoot, "local", "repo", "sessions", "visible-session.json"), { force: true });
+
+		await Bun.sleep(5);
+		const status = await server.callTool("gjc_coordinator_read_coordination_status");
+		expect(status.turns).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					status: "failed",
+					error: expect.objectContaining({ code: "session_unavailable", message: "session_record_missing" }),
+				}),
+			]),
+		);
+
+		const read = await server.callTool("gjc_coordinator_read_turn", {
+			session_id: "visible-session",
+			turn_id: sent.turn_id,
+		});
+
+		expect(read).toMatchObject({
+			ok: true,
+			turn: {
+				status: "failed",
+				delivery: { tmux_keys_sent: true, state: "tmux_keys_sent" },
+				error: { code: "session_unavailable", message: "session_record_missing" },
+			},
+			session_state: { state: "stale", reason: "session_record_missing" },
+		});
 	});
 
 	it("starts sessions through the structured GJC service adapter, not arbitrary terminal relay", async () => {


### PR DESCRIPTION
## Summary
- Distinguish tmux key delivery from runtime prompt acceptance in coordinator MCP turns.
- Add a bounded `GJC_COORDINATOR_MCP_PROMPT_ACK_TIMEOUT_MS` timeout that fails unacknowledged tmux-delivered turns with explicit `runtime_prompt_ack_timeout` evidence/final response.
- Preserve runtime ack success and existing session/tmux unavailable precedence across read/status/watch surfaces.

Closes #1237.

## Verification
- `bun test packages/coding-agent/test/coordinator-mcp-server.test.ts` — 26 pass / 121 expects
- `cd packages/coding-agent && bun run check` — Biome + typecheck pass
- Independent review: code-reviewer APPROVE; architect CLEAR

## Residual risk
- None identified in scoped coordinator MCP server/test/changelog changes.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
