### PR TITLE
Add local OpenAI-compatible provider smoke

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added a generic `providers.local.openaiCompat` models config path for OpenAI-compatible local endpoints plus `gjc local-provider smoke` for bounded streaming chat-completion checks (#1246).
+
 ### Fixed
 
 - Coordinator MCP now fails tmux-delivered turns that never receive a runtime prompt acknowledgement/`turn_start`, surfacing an explicit unacknowledged delivery reason instead of leaving Hermes/Oren waiting on a normal active/running state (#1237).

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -38,6 +38,7 @@ export const commands: CommandEntry[] = [
 	{ name: "notify", load: () => import("./commands/notify").then(m => m.default) },
 	{ name: "daemon", load: () => import("./commands/daemon").then(m => m.default) },
 	{ name: "web-search", aliases: ["q"], load: () => import("./commands/web-search").then(m => m.default) },
+	{ name: "local-provider", load: () => import("./commands/local-provider").then(m => m.default) },
 	{ name: "mcp-serve", load: () => import("./commands/mcp-serve").then(m => m.default) },
 	{ name: "mcp", load: () => import("./commands/mcp").then(m => m.default) },
 	{

--- a/packages/coding-agent/src/cli/local-provider-smoke.ts
+++ b/packages/coding-agent/src/cli/local-provider-smoke.ts
@@ -1,0 +1,197 @@
+import chalk from "chalk";
+import { ModelsConfigFile } from "../config/model-registry";
+import type { ModelsConfig } from "../config/models-config-schema";
+
+export interface LocalProviderSmokeCommandArgs {
+	model?: string;
+	modelsPath?: string;
+	timeoutMs?: number;
+	json?: boolean;
+}
+
+export interface LocalOpenAICompatConfig {
+	baseUrl: string;
+	apiKey?: string;
+}
+
+export interface LocalProviderSmokeResult {
+	ok: boolean;
+	baseUrl?: string;
+	model?: string;
+	message: string;
+	error?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 3000;
+const DEFAULT_SMOKE_PROMPT = "Reply with ok.";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function resolveApiKey(apiKey: string | undefined, apiKeyEnv: string | undefined): string | undefined {
+	if (apiKeyEnv) return Bun.env[apiKeyEnv];
+	if (!apiKey) return undefined;
+	return Bun.env[apiKey] ?? apiKey;
+}
+
+function normalizeOpenAICompatBaseUrl(baseUrl: string): string {
+	try {
+		const parsed = new URL(baseUrl);
+		const trimmedPath = parsed.pathname.replace(/\/+$/g, "");
+		parsed.pathname = trimmedPath.endsWith("/v1") ? trimmedPath || "/v1" : `${trimmedPath}/v1`;
+		return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+	} catch {
+		const trimmed = baseUrl.replace(/\/+$/g, "");
+		return trimmed.endsWith("/v1") ? trimmed : `${trimmed}/v1`;
+	}
+}
+
+export function getLocalOpenAICompatConfig(config: ModelsConfig | undefined): LocalOpenAICompatConfig | undefined {
+	const openaiCompat = config?.providers?.local?.openaiCompat;
+	if (!openaiCompat?.baseUrl) return undefined;
+	return {
+		baseUrl: normalizeOpenAICompatBaseUrl(openaiCompat.baseUrl),
+		apiKey: resolveApiKey(openaiCompat.apiKey, openaiCompat.apiKeyEnv),
+	};
+}
+
+async function readLocalConfig(
+	modelsPath: string | undefined,
+): Promise<LocalProviderSmokeResult | LocalOpenAICompatConfig> {
+	const configFile = modelsPath ? ModelsConfigFile.relocate(modelsPath) : ModelsConfigFile;
+	configFile.invalidate?.();
+	const loaded = configFile.tryLoad();
+	if (loaded.status === "error") {
+		return { ok: false, message: "Failed to load models config.", error: loaded.error.message };
+	}
+	const localConfig = getLocalOpenAICompatConfig(loaded.value ?? undefined);
+	if (!localConfig) {
+		return {
+			ok: false,
+			message: `No local OpenAI-compatible endpoint configured. Add providers.local.openaiCompat.baseUrl to ${configFile.path()}.`,
+		};
+	}
+	return localConfig;
+}
+
+function buildHeaders(apiKey: string | undefined): Record<string, string> {
+	const headers: Record<string, string> = { "Content-Type": "application/json" };
+	if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+	return headers;
+}
+
+function toErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+async function discoverFirstModel(config: LocalOpenAICompatConfig, timeoutMs: number): Promise<string> {
+	const response = await fetch(`${config.baseUrl}/models`, {
+		headers: buildHeaders(config.apiKey),
+		signal: AbortSignal.timeout(timeoutMs),
+	});
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status} from ${config.baseUrl}/models`);
+	}
+	const payload = (await response.json()) as unknown;
+	const data = isRecord(payload) ? payload.data : undefined;
+	if (!Array.isArray(data)) {
+		throw new Error("/models response did not include a data array");
+	}
+	for (const item of data) {
+		if (isRecord(item) && typeof item.id === "string" && item.id.trim()) {
+			return item.id;
+		}
+	}
+	throw new Error("/models returned no model ids; pass --model explicitly");
+}
+
+async function readStreamingBody(response: Response): Promise<number> {
+	if (!response.body) return 0;
+	const reader = response.body.getReader();
+	let chunks = 0;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (value.byteLength > 0) chunks += 1;
+		}
+	} finally {
+		reader.releaseLock();
+	}
+	return chunks;
+}
+
+export async function runLocalProviderSmoke(cmd: LocalProviderSmokeCommandArgs): Promise<LocalProviderSmokeResult> {
+	const timeoutMs = cmd.timeoutMs && cmd.timeoutMs > 0 ? cmd.timeoutMs : DEFAULT_TIMEOUT_MS;
+	const configResult = await readLocalConfig(cmd.modelsPath);
+	if ("ok" in configResult) return configResult;
+
+	let model = cmd.model;
+	try {
+		model = model?.trim() || (await discoverFirstModel(configResult, timeoutMs));
+		const response = await fetch(`${configResult.baseUrl}/chat/completions`, {
+			method: "POST",
+			headers: buildHeaders(configResult.apiKey),
+			body: JSON.stringify({
+				model,
+				messages: [{ role: "user", content: DEFAULT_SMOKE_PROMPT }],
+				stream: true,
+				max_tokens: 16,
+			}),
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+		if (!response.ok) {
+			const text = await response.text().catch(() => "");
+			return {
+				ok: false,
+				baseUrl: configResult.baseUrl,
+				model,
+				message: "Local provider streaming smoke request failed.",
+				error: `HTTP ${response.status}${text ? `: ${text.slice(0, 500)}` : ""}`,
+			};
+		}
+		const chunks = await readStreamingBody(response);
+		if (chunks === 0) {
+			return {
+				ok: false,
+				baseUrl: configResult.baseUrl,
+				model,
+				message: "Local provider returned an empty streaming response.",
+			};
+		}
+		return {
+			ok: true,
+			baseUrl: configResult.baseUrl,
+			model,
+			message: `Local provider streaming smoke succeeded (${chunks} chunk${chunks === 1 ? "" : "s"}).`,
+		};
+	} catch (error) {
+		return {
+			ok: false,
+			baseUrl: configResult.baseUrl,
+			model,
+			message: "Local provider streaming smoke request failed.",
+			error: toErrorMessage(error),
+		};
+	}
+}
+
+export async function runLocalProviderSmokeCommand(cmd: LocalProviderSmokeCommandArgs): Promise<void> {
+	const result = await runLocalProviderSmoke(cmd);
+	if (cmd.json) {
+		process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+	} else if (result.ok) {
+		process.stdout.write(`${chalk.green("ok")} ${result.message}\n`);
+		process.stdout.write(`${chalk.dim(`endpoint=${result.baseUrl} model=${result.model}`)}\n`);
+	} else {
+		process.stderr.write(`${chalk.red("error")} ${result.message}\n`);
+		if (result.baseUrl || result.model) {
+			process.stderr.write(
+				`${chalk.dim(`endpoint=${result.baseUrl ?? "<unknown>"} model=${result.model ?? "<unset>"}`)}\n`,
+			);
+		}
+		if (result.error) process.stderr.write(`${chalk.dim(result.error)}\n`);
+	}
+	if (!result.ok) process.exitCode = 1;
+}

--- a/packages/coding-agent/src/commands/local-provider.ts
+++ b/packages/coding-agent/src/commands/local-provider.ts
@@ -1,0 +1,38 @@
+/**
+ * Test configured local OpenAI-compatible providers.
+ */
+import { Args, Command, Flags } from "@gajae-code/utils/cli";
+import { runLocalProviderSmokeCommand } from "../cli/local-provider-smoke";
+
+const ACTIONS = ["smoke"] as const;
+
+export default class LocalProvider extends Command {
+	static description = "Test configured local OpenAI-compatible providers";
+
+	static args = {
+		action: Args.string({ description: "Action", required: false, options: ACTIONS }),
+	};
+
+	static flags = {
+		model: Flags.string({ description: "Model id to use (otherwise uses the first /models id)" }),
+		"models-path": Flags.string({ description: "Override models config path" }),
+		"timeout-ms": Flags.integer({ description: "Request timeout in milliseconds" }),
+		json: Flags.boolean({ description: "Output JSON" }),
+	};
+
+	async run(): Promise<void> {
+		const { args, flags } = await this.parse(LocalProvider);
+		const action = args.action ?? "smoke";
+		if (action !== "smoke") {
+			process.stderr.write(`Unsupported local-provider action: ${action}\n`);
+			process.exitCode = 1;
+			return;
+		}
+		await runLocalProviderSmokeCommand({
+			model: flags.model,
+			modelsPath: flags["models-path"],
+			timeoutMs: flags["timeout-ms"],
+			json: flags.json,
+		});
+	}
+}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -243,6 +243,7 @@ interface ProviderValidationConfig {
 	requestTransform?: ModelRequestTransform;
 	disableStrictTools?: boolean;
 	cacheRetention?: CacheRetention;
+	openaiCompat?: { baseUrl: string; apiKey?: string; apiKeyEnv?: string };
 	modelOverrides?: Record<string, unknown>;
 	models: ProviderValidationModel[];
 }
@@ -271,11 +272,12 @@ function validateProviderConfiguration(
 				!config.disableStrictTools &&
 				!config.requestTransform &&
 				!config.cacheRetention &&
+				!config.openaiCompat &&
 				!hasModelOverrides &&
 				!config.discovery
 			) {
 				throw new Error(
-					`Provider ${providerName}: must specify "baseUrl", "headers", "apiKey", "compat", "requestTransform", "cacheRetention", "disableStrictTools", "modelOverrides", "discovery", or "models"`,
+					`Provider ${providerName}: must specify "baseUrl", "headers", "apiKey", "compat", "requestTransform", "cacheRetention", "disableStrictTools", "modelOverrides", "discovery", "openaiCompat", or "models"`,
 				);
 			}
 		}
@@ -389,6 +391,7 @@ export const ModelsConfigFile = new ConfigFile<ModelsConfig>("models", ModelsCon
 					requestTransform: providerConfig.requestTransform,
 					disableStrictTools: providerConfig.disableStrictTools,
 					cacheRetention: providerConfig.cacheRetention,
+					openaiCompat: providerConfig.openaiCompat,
 					modelOverrides: providerConfig.modelOverrides,
 					models: (providerConfig.models ?? []) as ProviderValidationModel[],
 				},
@@ -434,6 +437,18 @@ function getProviderBaseUrlEnvKeys(provider: string): string[] {
 
 function resolveProviderBaseUrlFromEnv(provider: string): string | undefined {
 	return $pickenv(...getProviderBaseUrlEnvKeys(provider));
+}
+
+function normalizeLocalOpenAICompatBaseUrl(baseUrl: string): string {
+	try {
+		const parsed = new URL(baseUrl);
+		const trimmedPath = parsed.pathname.replace(/\/+$/g, "");
+		parsed.pathname = trimmedPath.endsWith("/v1") ? trimmedPath || "/v1" : `${trimmedPath}/v1`;
+		return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+	} catch {
+		const trimmed = baseUrl.replace(/\/+$/g, "");
+		return trimmed.endsWith("/v1") ? trimmed : `${trimmed}/v1`;
+	}
 }
 
 /**
@@ -1409,6 +1424,45 @@ export class ModelRegistry {
 		for (const [providerName, providerConfig] of providerEntries) {
 			if (providerConfig.webSearch) this.#providerWebSearchModes.set(providerName, providerConfig.webSearch);
 			const providerApiKeyConfig = providerConfig.apiKey ?? resolveApiKeyEnvConfig(providerConfig.apiKeyEnv);
+			const localOpenAICompat = providerConfig.openaiCompat;
+			const localOpenAICompatApiKeyConfig = localOpenAICompat
+				? (localOpenAICompat.apiKey ?? resolveApiKeyEnvConfig(localOpenAICompat.apiKeyEnv))
+				: undefined;
+			if (localOpenAICompat) {
+				const localOpenAICompatBaseUrl = normalizeLocalOpenAICompatBaseUrl(localOpenAICompat.baseUrl);
+				const localCompatResolvedKey = localOpenAICompat.apiKeyEnv
+					? resolveApiKeyEnvConfig(localOpenAICompat.apiKeyEnv)
+					: localOpenAICompat.apiKey
+						? resolveApiKeyConfig(localOpenAICompat.apiKey)
+						: undefined;
+				overrides.set(providerName, {
+					baseUrl: localOpenAICompatBaseUrl,
+					apiKey: localOpenAICompatApiKeyConfig,
+					compat: {
+						supportsStore: false,
+						supportsDeveloperRole: false,
+						supportsReasoningEffort: false,
+					},
+				});
+				discoverableProviders.push({
+					provider: providerName,
+					api: "openai-completions",
+					baseUrl: localOpenAICompatBaseUrl,
+					compat: {
+						supportsStore: false,
+						supportsDeveloperRole: false,
+						supportsReasoningEffort: false,
+					},
+					discovery: { type: "openai-models-list" },
+					optional: false,
+				});
+				if (localCompatResolvedKey) {
+					this.#customProviderApiKeys.set(providerName, localCompatResolvedKey);
+					this.authStorage.setConfigApiKey(providerName, localCompatResolvedKey);
+				} else {
+					keylessProviders.add(providerName);
+				}
+			}
 			// Always set overrides when baseUrl/headers/apiKey/authHeader/compat/disableStrictTools/transport are present
 			if (
 				providerConfig.baseUrl ||

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -193,6 +193,14 @@ export const ProviderDiscoverySchema = z.object({
 	type: z.enum(["ollama", "llama.cpp", "lm-studio", "openai-models-list"]),
 });
 
+const LocalOpenAICompatSchema = z
+	.object({
+		baseUrl: z.string().min(1),
+		apiKey: z.string().min(1).optional(),
+		apiKeyEnv: z.string().min(1).optional(),
+	})
+	.strict();
+
 export const ProviderAuthSchema = z.enum(["apiKey", "none", "oauth"]);
 
 export type ProviderAuthMode = z.infer<typeof ProviderAuthSchema>;
@@ -237,6 +245,7 @@ const ProviderConfigSchema = z
 		 */
 		transport: z.literal("pi-native").optional(),
 		cacheRetention: CacheRetentionSchema.optional(),
+		openaiCompat: LocalOpenAICompatSchema.optional(),
 	})
 	.strict();
 

--- a/packages/coding-agent/test/local-provider-smoke.test.ts
+++ b/packages/coding-agent/test/local-provider-smoke.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runLocalProviderSmoke } from "@gajae-code/coding-agent/cli/local-provider-smoke";
+import { hookFetch, Snowflake } from "@gajae-code/utils";
+
+describe("local provider streaming smoke", () => {
+	let tempDir: string;
+	let modelsPath: string;
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `gjc-local-provider-smoke-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsPath = path.join(tempDir, "models.json");
+	});
+
+	afterEach(() => {
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("reports a clear configuration failure when local openaiCompat is not configured", async () => {
+		fs.writeFileSync(modelsPath, JSON.stringify({ providers: {} }));
+
+		const result = await runLocalProviderSmoke({ modelsPath, model: "local-model" });
+
+		expect(result.ok).toBe(false);
+		expect(result.message).toContain("No local OpenAI-compatible endpoint configured");
+	});
+
+	test("does not throw when the configured local endpoint cannot be reached", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					local: { openaiCompat: { baseUrl: "http://127.0.0.1:65535/v1", apiKey: "local-key" } },
+				},
+			}),
+		);
+		using _hook = hookFetch(() => {
+			throw new Error("connection refused");
+		});
+
+		const result = await runLocalProviderSmoke({ modelsPath, model: "local-model", timeoutMs: 25 });
+
+		expect(result.ok).toBe(false);
+		expect(result.message).toContain("smoke request failed");
+		expect(result.error).toContain("connection refused");
+	});
+
+	test("sends a streaming chat completion request to the configured endpoint", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					local: { openaiCompat: { baseUrl: "http://127.0.0.1:1234", apiKey: "local-key" } },
+				},
+			}),
+		);
+		using _hook = hookFetch((input, init) => {
+			const url = String(input);
+			if (url !== "http://127.0.0.1:1234/v1/chat/completions") {
+				throw new Error(`Unexpected URL: ${url}`);
+			}
+			expect(init?.method).toBe("POST");
+			expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer local-key");
+			const body = JSON.parse(String(init?.body)) as { model: string; stream: boolean };
+			expect(body.model).toBe("local-model");
+			expect(body.stream).toBe(true);
+			return new Response(
+				new ReadableStream({
+					start(controller) {
+						controller.enqueue(new TextEncoder().encode('data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'));
+						controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+						controller.close();
+					},
+				}),
+				{ status: 200 },
+			);
+		});
+
+		const result = await runLocalProviderSmoke({ modelsPath, model: "local-model" });
+
+		expect(result.ok).toBe(true);
+		expect(result.baseUrl).toBe("http://127.0.0.1:1234/v1");
+		expect(result.model).toBe("local-model");
+	});
+});

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -3046,4 +3046,43 @@ describe("ModelRegistry", () => {
 		expect(model?.wireModelId).toBe("proxy-gpt-4o-mini");
 		expect(model?.requestTransform).toEqual({ extraBody: { routed: true } });
 	});
+	describe("generic local OpenAI-compatible provider config", () => {
+		test("does not add a generic local provider by default", () => {
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+			expect(getModelsForProvider(registry, "local")).toHaveLength(0);
+			expect(registry.getProviderBaseUrl("local")).toBeUndefined();
+		});
+
+		test("parses providers.local.openaiCompat and discovers OpenAI-compatible models", async () => {
+			writeRawModelsJson({
+				local: {
+					openaiCompat: {
+						baseUrl: "http://127.0.0.1:1234",
+						apiKey: "LOCAL_TEST_KEY",
+					},
+				},
+			});
+			using _hook = hookFetch((input, init) => {
+				const url = String(input);
+				if (url !== "http://127.0.0.1:1234/v1/models") {
+					throw new Error(`Unexpected URL: ${url}`);
+				}
+				expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer LOCAL_TEST_KEY");
+				return new Response(JSON.stringify({ data: [{ id: "local-model" }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			await registry.refresh();
+			const model = registry.find("local", "local-model");
+
+			expect(model?.api).toBe("openai-completions");
+			expect(model?.baseUrl).toBe("http://127.0.0.1:1234/v1");
+			expect(getOpenAICompat(model)?.supportsStore).toBe(false);
+			expect(await registry.getApiKeyForProvider("local")).toBe("LOCAL_TEST_KEY");
+		});
+	});
 });

--- a/schemas/models.schema.json
+++ b/schemas/models.schema.json
@@ -1079,6 +1079,27 @@
 							"short",
 							"long"
 						]
+					},
+					"openaiCompat": {
+						"type": "object",
+						"properties": {
+							"baseUrl": {
+								"type": "string",
+								"minLength": 1
+							},
+							"apiKey": {
+								"type": "string",
+								"minLength": 1
+							},
+							"apiKeyEnv": {
+								"type": "string",
+								"minLength": 1
+							}
+						},
+						"required": [
+							"baseUrl"
+						],
+						"additionalProperties": false
 					}
 				},
 				"additionalProperties": false


### PR DESCRIPTION
## Summary
- add `providers.local.openaiCompat` models config support for generic OpenAI-compatible local endpoints
- wire local config through existing OpenAI-compatible model discovery without changing cloud defaults
- add `gjc local-provider smoke` for bounded streaming chat-completion checks with safe failure reporting

## Verification
- `bun run check:schemas`
- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/local-provider-smoke.test.ts packages/coding-agent/test/model-registry.test.ts`
- `bun packages/coding-agent/src/cli.ts local-provider smoke --models-path <empty providers config> --model local-model` (clean error, exit 1)

Closes #1246