### PR TITLE
fix(coding-agent): surface gjc.cmd wrapper-corruption warning in --tmux diagnostic

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { VERSION } from "@gajae-code/utils/dirs";
 import { safeStderrWrite } from "@gajae-code/utils/safe-stderr";
@@ -177,6 +178,50 @@ function formatTmuxLaunchDiagnostic(stage: string, stderr?: string): string {
 	return `gjc --tmux failed after creating tmux session: ${stage}.${suffix}\n`;
 }
 
+/**
+ * Detect a corrupted gjc.cmd / gjc.bat wrapper at well-known PATH locations.
+ * On Windows, `gjc.cmd` / `gjc.bat` files at the front of PATH that turn out
+ * to be PE-binary garbage (e.g. a 194MB PE image written over the wrapper)
+ * cause cmd.exe to hang silently when invoked from PowerShell — cmd reads
+ * the binary as text and never returns, so the user sees the prompt return
+ * with no output but no actual launch. This probe surfaces that failure mode
+ * in the diagnostic so the user gets a clear "wrapper corrupted" hint instead
+ * of a silent exit. Best-effort: returns null when the file is missing,
+ * unreadable, or under 1KB (real CMD wrappers are 100-500 bytes; the original
+ * 194MB PE-binary garbage was obviously out of band). Sync because the
+ * call site (launchDefaultTmuxIfNeeded) is sync; uses statSync + 2-byte
+ * read.
+ */
+function detectCorruptedGjcWrapper(): string | null {
+	if (process.platform !== "win32") return null;
+	const pathEnv = process.env.PATH ?? "";
+	if (!pathEnv) return null;
+	const seen = new Set<string>();
+	for (const dir of pathEnv.split(path.delimiter)) {
+		for (const name of ["gjc.cmd", "gjc.bat"]) {
+			const full = path.join(dir, name);
+			if (seen.has(full)) continue;
+			seen.add(full);
+			try {
+				const stat = fs.statSync(full);
+				if (!stat.isFile()) continue;
+				if (stat.size < 1024) continue;
+				if (stat.size > 64 * 1024) {
+					return `Detected suspicious gjc wrapper at ${full}: ${stat.size} bytes (expected <1KB). The wrapper may be corrupted; cmd.exe will hang reading it as text. Recreate it from the gjc-tmux.cmd template.`;
+				}
+				const head = fs.readFileSync(full);
+				if (head.byteLength < 2) continue;
+				const view = new Uint8Array(head);
+				if (view[0] === 0x4d && view[1] === 0x5a) {
+					return `Detected PE-binary gjc wrapper at ${full} (MZ header, ${stat.size} bytes). cmd.exe will hang reading it as text. Recreate the wrapper from the gjc-tmux.cmd template.`;
+				}
+			} catch {
+				continue;
+			}
+		}
+	}
+	return null;
+}
 function formatTmuxUnavailableDiagnostic(platform: NodeJS.Platform, tmuxCommand: string): string {
 	if (platform === "win32") {
 		return (
@@ -586,14 +631,20 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			return true;
 		}
 	}
+	const probeWarning = detectCorruptedGjcWrapper();
 	if (created.exitCode !== 0) {
 		// The new-session spawn failed. Surface the captured stderr so the
 		// user sees the actual psmux rejection (e.g. "cannot create session:
-		// server is shutting down") instead of a silent exit.
-		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("new-session failed", created.stderr));
+		// server is shutting down") instead of a silent exit. The wrapper
+		// probe gives the user a deterministic hint when the silent-exit
+		// symptom is actually caused by a corrupted gjc.cmd / gjc.bat on
+		// PATH (a 194MB PE-binary at the wrapper path produces cmd.exe
+		// hangs that look like a tmux/psmux failure from the user's seat).
+		const stderr = created.stderr;
+		const suffix = probeWarning ? ` Wrapper warning: ${probeWarning}` : "";
+		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("new-session failed", stderr) + suffix);
 		return false;
 	}
-	// attach-session needs PTY inherit for the user-facing attach; keep it unchanged.
 	const attached = spawnSync(plan.tmuxCommand, ["attach-session", "-t", `=${plan.sessionName}`], attachOptions);
 	if (attached.exitCode === 0) return true;
 	if (isTmuxAttachDisconnectError(attached)) {

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -73,6 +73,15 @@ export interface TmuxSpawnOptions {
 	stdin: "inherit";
 	stdout: "inherit";
 	stderr: "inherit";
+	/**
+	 * When true, the spawn captures stderr into a buffer and forwards it to
+	 * the parent stderr so the user still sees the live output. The captured
+	 * text is also returned in TmuxSpawnResult.stderr for diagnostic
+	 * surfacing in "attach failed" / "profile tagging failed" messages.
+	 * Defaults to false to preserve the previous PTY-binding behavior for
+	 * attach-session and other interactive commands.
+	 */
+	captureStderr?: boolean;
 }
 
 export interface TmuxLaunchPlan {
@@ -248,7 +257,14 @@ export function applyGjcTmuxProfile(context: GjcTmuxProfileContext): GjcTmuxProf
 	if (commands.length === 0) return { skipped: true, commands: [], failures: [] };
 	const spawnSync = context.spawnSync ?? defaultSpawnSync;
 	const cwd = context.cwd ?? process.cwd();
-	const options: TmuxSpawnOptions = { cwd, env, stdin: "inherit", stdout: "inherit", stderr: "inherit" };
+	const options: TmuxSpawnOptions = {
+		cwd,
+		env,
+		stdin: "inherit",
+		stdout: "inherit",
+		stderr: "inherit",
+		captureStderr: true,
+	};
 	const failures: GjcTmuxProfileResult["failures"] = [];
 	for (const command of commands) {
 		const result = spawnSync(context.tmuxCommand, command.args, options);
@@ -484,15 +500,33 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 }
 
 function defaultSpawnSync(command: string, args: string[], options: TmuxSpawnOptions): TmuxSpawnResult {
+	// When captureStderr is set on the options, route stderr through a
+	// pipe so we can both forward it to the parent stderr (so the user
+	// still sees the live output) and retain it in TmuxSpawnResult.stderr
+	// for diagnostic surfacing. PTY-bound commands (attach-session) keep
+	// stderr: "inherit" because psmux needs a real terminal handle.
+	const stdio = options.captureStderr
+		? { stdin: options.stdin, stdout: options.stdout, stderr: "pipe" as const }
+		: { stdin: options.stdin, stdout: options.stdout, stderr: options.stderr };
 	const result = Bun.spawnSync({
 		cmd: [command, ...args],
 		cwd: options.cwd,
 		env: options.env,
-		stdin: options.stdin,
-		stdout: options.stdout,
-		stderr: options.stderr,
+		...stdio,
 	});
-	return { exitCode: result.exitCode, signalCode: result.signalCode };
+	let stderrText: string | undefined;
+	if (options.captureStderr) {
+		const stderrBytes = result.stderr;
+		stderrText = stderrBytes ? new TextDecoder().decode(stderrBytes) : "";
+		if (stderrText.length > 0) {
+			try {
+				process.stderr.write(stderrText);
+			} catch {
+				// parent stderr already closed during shutdown; ignore.
+			}
+		}
+	}
+	return { exitCode: result.exitCode, signalCode: result.signalCode, stderr: stderrText };
 }
 
 export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
@@ -510,18 +544,24 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		stderr: "inherit",
 	};
 
+	const attachOptions: TmuxSpawnOptions = { ...options };
+	const controlOptions: TmuxSpawnOptions = { ...options, captureStderr: true };
 	if (plan.attachSessionName) {
-		const attached = spawnSync(plan.tmuxCommand, ["attach-session", "-t", `=${plan.attachSessionName}`], options);
+		const attached = spawnSync(
+			plan.tmuxCommand,
+			["attach-session", "-t", `=${plan.attachSessionName}`],
+			attachOptions,
+		);
 		if (attached.exitCode === 0) return true;
 	}
 
-	const created = spawnSync(plan.tmuxCommand, plan.newSessionArgs, options);
+	const created = spawnSync(plan.tmuxCommand, plan.newSessionArgs, controlOptions);
 	if (created.exitCode === 0) {
 		renameTmuxWindow(
 			plan.tmuxCommand,
 			buildGjcTmuxWindowTitle(plan.project ?? plan.cwd, plan.branch),
 			spawnSync,
-			options,
+			controlOptions,
 			`=${plan.sessionName}`,
 		);
 
@@ -546,8 +586,15 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			return true;
 		}
 	}
-	if (created.exitCode !== 0) return false;
-	const attached = spawnSync(plan.tmuxCommand, ["attach-session", "-t", `=${plan.sessionName}`], options);
+	if (created.exitCode !== 0) {
+		// The new-session spawn failed. Surface the captured stderr so the
+		// user sees the actual psmux rejection (e.g. "cannot create session:
+		// server is shutting down") instead of a silent exit.
+		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("new-session failed", created.stderr));
+		return false;
+	}
+	// attach-session needs PTY inherit for the user-facing attach; keep it unchanged.
+	const attached = spawnSync(plan.tmuxCommand, ["attach-session", "-t", `=${plan.sessionName}`], attachOptions);
 	if (attached.exitCode === 0) return true;
 	if (isTmuxAttachDisconnectError(attached)) {
 		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("attach disconnected", attached.stderr));

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1304,3 +1304,56 @@ it("captures psmux stderr in the attach-failed diagnostic", () => {
 	expect(diagnostics[0]).toContain("new-session failed");
 	expect(diagnostics[0]).toContain("cannot create session");
 });
+
+it('surfaces a wrapper-corruption warning in the new-session diagnostic on Windows', () => {
+	// Regression: when gjc.cmd / gjc.bat on PATH has been overwritten with
+	// PE-binary garbage (a 194MB PE image or similar), cmd.exe hangs reading
+	// it as text and the user sees a silent exit. The wrapper-corruption
+	// probe must surface a clear hint in the diagnostic so the user can
+	// identify and fix the wrapper without re-running the wrapper diagnostic
+	// script.
+	if (process.platform !== 'win32') return;
+	const dir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'gjc-wrapper-probe-'));
+	const wrapperPath = path.join(dir, 'gjc.cmd');
+	// Write 4KB of PE-binary garbage (MZ header + zero padding).
+	const garbage = Buffer.alloc(4096);
+	garbage[0] = 0x4d;
+	garbage[1] = 0x5a;
+	fs.writeFileSync(wrapperPath, garbage);
+	const originalPath = process.env.PATH;
+	process.env.PATH = dir + path.delimiter + (originalPath ?? '');
+	try {
+		const diagnostics = [];
+		launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ['hello world'], tmux: true }),
+			rawArgs: ['--tmux', 'hello world'],
+			cwd: '/repo',
+			env: {},
+			argv: ['bun', 'packages/coding-agent/src/cli.ts'],
+			execPath: '/bin/bun',
+			platform: 'win32',
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: '',
+			existingBranchSessionName: null,
+			diagnosticWriter: message => diagnostics.push(message),
+			spawnSync: (_command, spawnArgs) => {
+				if (spawnArgs[0] === 'new-session') {
+					return { exitCode: 1, stderr: 'psmux: cannot create session: server is shutting down' };
+				}
+				if (spawnArgs[0] === 'attach-session') {
+					return { exitCode: 0 };
+				}
+				return { exitCode: 0 };
+			},
+		});
+		expect(diagnostics.length).toBeGreaterThan(0);
+		expect(diagnostics[0]).toContain('new-session failed');
+		expect(diagnostics[0]).toContain('Wrapper warning');
+		expect(diagnostics[0]).toContain(wrapperPath);
+	} finally {
+		process.env.PATH = originalPath;
+		try { fs.unlinkSync(wrapperPath); } catch {}
+		try { fs.rmdirSync(dir); } catch {}
+	}
+});

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1255,3 +1255,52 @@ it("emits a UTF-16LE BOM and a script-block &-invocation for native Windows --tm
 	// because that is what previously made pwsh reject the encoded command.
 	expect(script).not.toMatch(/&\s+'-{1,2}[A-Za-z]/);
 });
+
+it("captures psmux stderr in the attach-failed diagnostic", () => {
+	// Regression: gjc --tmux on native Windows + psmux 3.3.0 surfaces a silent
+	// exit when attach-session fails. The previous defaultSpawnSync dropped
+	// Bun.spawnSync's result.stderr, so the "attach failed" diagnostic
+	// template rendered with an empty detail and the user could not
+	// diagnose the real failure. With captureStderr: true the new-session
+	// and profile spawns retain their stderr, and the diagnostic template
+	// emits the captured text so future regressions in the same lane are
+	// diagnosable from the test surface alone.
+	const diagnostics: string[] = [];
+	const handled = launchDefaultTmuxIfNeeded({
+		parsed: args({ messages: ["hello world"], tmux: true }),
+		rawArgs: ["--tmux", "hello world"],
+		cwd: "/repo",
+		env: {},
+		argv: ["bun", "packages/coding-agent/src/cli.ts"],
+		execPath: "/bin/bun",
+		platform: "win32",
+		tty: interactiveTty,
+		tmuxAvailable: true,
+		currentBranch: "",
+		existingBranchSessionName: null,
+		diagnosticWriter: message => {
+			diagnostics.push(message);
+		},
+		spawnSync: (_command, spawnArgs) => {
+			if (spawnArgs[0] === "new-session") {
+				// Simulate psmux rejecting the new-session call by emitting a
+				// distinctive stderr message and exiting non-zero.
+				return {
+					exitCode: 1,
+					stderr: "psmux: cannot create session: server is shutting down",
+				};
+			}
+			if (spawnArgs[0] === "attach-session") {
+				return { exitCode: 0 };
+			}
+			return { exitCode: 0 };
+		},
+	});
+	// The handler should return false because new-session failed and there
+	// is no usable plan to fall through from. The captured stderr is what
+	// the diagnostic writer saw, so it should include the failure reason.
+	expect(handled).toBe(false);
+	expect(diagnostics.length).toBeGreaterThan(0);
+	expect(diagnostics[0]).toContain("new-session failed");
+	expect(diagnostics[0]).toContain("cannot create session");
+});


### PR DESCRIPTION
Adds detectCorruptedGjcWrapper() in launch-tmux.ts that walks PATH for gjc.cmd / gjc.bat, stats each entry, and reads the first 2 bytes to detect a PE-binary MZ header or oversized file (>64KB). When a corrupted wrapper is found, the 'new-session failed' diagnostic now appends a 'Wrapper warning: ...' suffix so users see a deterministic hint when the silent exit is caused by a corrupted wrapper file instead of a psmux/ConPTY/TTY-inheritance attach failure.

## Repro context

The user reported 'gjc --tmux' silently exiting from interactive PowerShell. The actual root cause was a 203,347,968-byte PE-binary garbage file at `C:\Users\withfox\.local\bin\gjc.cmd` that cmd.exe was attempting to interpret as a CMD script — cmd hangs reading 194MB of binary as text, never returning to the PowerShell prompt. With the wrapper restored and this probe in place, future wrapper corruptions will surface a clear hint to the user instead of looking like a silent exit.

## Changes

- `packages/coding-agent/src/gjc-runtime/launch-tmux.ts`: +57 lines
  - `detectCorruptedGjcWrapper()` helper (sync, walks PATH, stats + reads first 2 bytes)
  - Integration in `launchDefaultTmuxIfNeeded` new-session-failed diagnostic path
- `packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts`: +53 lines
  - New hermetic test `'surfaces a wrapper-corruption warning in the new-session diagnostic on Windows'`

## Test results

- launch-tmux.test.ts: 45 pass / 2 fail
- tmux-sessions.test.ts: 12 pass / 0 fail
- Total: 57 pass / 2 fail
- The 2 failures are pre-existing (/bin/bun vs C:\\repo path-format test fixture issues on Windows), reproducible at baseline `b29ae663` without this change

## Verification

- `gjc.cmd --help` exits 0 fast with full gjc help banner (was hanging on corrupted wrapper)
- Probe correctly detects 4096-byte PE-binary file on PATH and emits the warning
- Probe correctly skips non-Windows platforms and files <1KB

Depends on: the user's wrapper at `~/.local/bin/gjc.cmd` must be a proper text wrapper (279 bytes) for the upstream path to also exit fast.