### PR TITLE
Fix Codex usage in status line

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -181,11 +181,8 @@ export class StatusLineComponent implements Component {
 	#lastTokensPerSecond: number | null = null;
 	#lastTokensPerSecondTimestamp: number | null = null;
 
-	// Anthropic usage caching (5-min TTL, OAuth/sub only)
-	#cachedUsage: {
-		fiveHour?: { percent: number; resetMinutes?: number };
-		sevenDay?: { percent: number; resetHours?: number };
-	} | null = null;
+	// Provider usage caching (5-min TTL, OAuth/sub only)
+	#cachedUsage: SegmentContext["usage"] = null;
 	#usageFetchedAt = 0;
 	#usageInFlight = false;
 	// Context breakdown — incremental cache. Replaces the previous 2-second
@@ -462,9 +459,9 @@ export class StatusLineComponent implements Component {
 	}
 
 	/**
-	 * Background-refresh the Anthropic OAuth quota report. Guarded by a 5-min
-	 * TTL on both success (cache lifetime) and error (backoff). Exposed
-	 * (non-private) so unit tests can verify the backoff invariant.
+	 * Background-refresh the OAuth quota report. Guarded by a 5-min TTL on both
+	 * success (cache lifetime) and error (backoff). Exposed (non-private) so
+	 * unit tests can verify the backoff invariant.
 	 */
 	refreshUsageInBackground(): void {
 		const now = Date.now();
@@ -478,6 +475,9 @@ export class StatusLineComponent implements Component {
 			.then(reports => {
 				this.#cachedUsage = this.#normalizeUsageReports(reports);
 				this.#usageFetchedAt = Date.now();
+				if (this.#onBranchChange) {
+					this.#onBranchChange();
+				}
 			})
 			.catch(() => {
 				// Backoff on error: stamp the fetch time so the 5-min TTL guard
@@ -491,47 +491,77 @@ export class StatusLineComponent implements Component {
 			});
 	}
 
-	#normalizeUsageReports(reports: unknown): {
-		fiveHour?: { percent: number; resetMinutes?: number };
-		sevenDay?: { percent: number; resetHours?: number };
-	} | null {
+	#normalizeUsageReports(reports: unknown): SegmentContext["usage"] {
 		if (!Array.isArray(reports)) return null;
-		let fiveHour: { percent: number; resetMinutes?: number } | undefined;
-		let sevenDay: { percent: number; resetHours?: number } | undefined;
+		const windows: NonNullable<SegmentContext["usage"]>["windows"] = [];
+		const seen = new Set<string>();
 		const now = Date.now();
+
+		const codexWindowLabel = (windowId: string | undefined, fallback: string): string => {
+			if (windowId && /^\d+[hd]$/.test(windowId)) return windowId;
+			return fallback;
+		};
+		const codexResetUnit = (label: string): "m" | "h" => (label.endsWith("d") ? "h" : "m");
+
+		const pushWindow = (
+			key: string,
+			label: string,
+			fraction: number,
+			resetsAt: number | undefined,
+			resetUnit: "m" | "h",
+		) => {
+			if (seen.has(key)) return;
+			seen.add(key);
+			windows.push({
+				label,
+				percent: fraction * 100,
+				resetValue:
+					typeof resetsAt === "number"
+						? Math.max(0, Math.round((resetsAt - now) / (resetUnit === "m" ? 60_000 : 3_600_000)))
+						: undefined,
+				resetUnit,
+			});
+		};
+
 		for (const report of reports) {
 			if (!report || typeof report !== "object") continue;
+			const provider = (report as { provider?: unknown }).provider;
+			const providerId = typeof provider === "string" ? provider : undefined;
 			const limits = (report as { limits?: unknown }).limits;
 			if (!Array.isArray(limits)) continue;
 			for (const limit of limits) {
 				if (!limit || typeof limit !== "object") continue;
 				const l = limit as {
-					scope?: { windowId?: string; tier?: string };
-					window?: { resetsAt?: number };
+					id?: unknown;
+					scope?: { windowId?: string; tier?: string; modelId?: string };
+					window?: { id?: string; resetsAt?: number };
 					amount?: { usedFraction?: number };
 				};
 				const fraction = l.amount?.usedFraction;
 				if (typeof fraction !== "number") continue;
-				const windowId = l.scope?.windowId;
+				const id = typeof l.id === "string" ? l.id : "";
+				const windowId = l.scope?.windowId ?? l.window?.id;
 				const tier = l.scope?.tier;
+				const modelId = l.scope?.modelId;
 				const resetsAt = l.window?.resetsAt;
-				if (windowId === "5h" && !tier && !fiveHour) {
-					fiveHour = {
-						percent: fraction * 100,
-						resetMinutes:
-							typeof resetsAt === "number" ? Math.max(0, Math.round((resetsAt - now) / 60_000)) : undefined,
-					};
-				} else if (windowId === "7d" && !tier && !sevenDay) {
-					sevenDay = {
-						percent: fraction * 100,
-						resetHours:
-							typeof resetsAt === "number" ? Math.max(0, Math.round((resetsAt - now) / 3_600_000)) : undefined,
-					};
+
+				if (providerId === "openai-codex") {
+					if (id === "openai-codex:primary" || (!id && !!windowId && windowId !== "7d" && !modelId)) {
+						const label = codexWindowLabel(windowId, "primary");
+						pushWindow("codex:primary", label, fraction, resetsAt, codexResetUnit(label));
+					} else if (id === "openai-codex:secondary" || (!id && windowId === "7d" && !modelId)) {
+						const label = codexWindowLabel(windowId, "secondary");
+						pushWindow("codex:secondary", label, fraction, resetsAt, codexResetUnit(label));
+					}
+				} else if (windowId === "5h" && !tier) {
+					pushWindow(`${providerId ?? "provider"}:5h`, "5h", fraction, resetsAt, "m");
+				} else if (windowId === "7d" && !tier) {
+					pushWindow(`${providerId ?? "provider"}:7d`, "7d", fraction, resetsAt, "h");
 				}
 			}
 		}
-		if (!fiveHour && !sevenDay) return null;
-		return { fiveHour, sevenDay };
+
+		return windows.length > 0 ? { windows } : null;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -505,28 +505,17 @@ const usageSegment: StatusLineSegment = {
 	id: "usage",
 	render(ctx) {
 		const u = ctx.usage;
-		if (!u || (!u.fiveHour && !u.sevenDay)) {
+		if (!u || u.windows.length === 0) {
 			return { content: "", visible: false };
 		}
-		const parts: string[] = [];
-		if (u.fiveHour) {
-			const pct = u.fiveHour.percent;
-			const pctText = theme.fg(pickUsageColor(pct), `${Math.round(pct)}%`);
+		const parts = u.windows.map(window => {
+			const pctText = theme.fg(pickUsageColor(window.percent), `${Math.round(window.percent)}%`);
 			const reset =
-				u.fiveHour.resetMinutes !== undefined
-					? theme.fg("muted", ` (${formatUsageReset(u.fiveHour.resetMinutes, "m")})`)
+				window.resetValue !== undefined && window.resetUnit !== undefined
+					? theme.fg("muted", ` (${formatUsageReset(window.resetValue, window.resetUnit)})`)
 					: "";
-			parts.push(`5h ${pctText}${reset}`);
-		}
-		if (u.sevenDay) {
-			const pct = u.sevenDay.percent;
-			const pctText = theme.fg(pickUsageColor(pct), `${Math.round(pct)}%`);
-			const reset =
-				u.sevenDay.resetHours !== undefined
-					? theme.fg("muted", ` (${formatUsageReset(u.sevenDay.resetHours, "h")})`)
-					: "";
-			parts.push(`7d ${pctText}${reset}`);
-		}
+			return `${window.label} ${pctText}${reset}`;
+		});
 		const content = withIcon(theme.icon.time, parts.join(theme.sep.dot));
 		return { content, visible: true };
 	},

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -51,8 +51,12 @@ export interface SegmentContext {
 		pr: { number: number; url: string } | null;
 	};
 	usage: {
-		fiveHour?: { percent: number; resetMinutes?: number };
-		sevenDay?: { percent: number; resetHours?: number };
+		windows: Array<{
+			label: string;
+			percent: number;
+			resetValue?: number;
+			resetUnit?: "m" | "h";
+		}>;
 	} | null;
 }
 

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
+import { StatusLineComponent } from "../src/modes/components/status-line";
+import { initTheme } from "../src/modes/theme/theme";
+import type { AgentSession } from "../src/session/agent-session";
+
+function stripAnsi(text: string): string {
+	return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function makeSession(fetchUsageReports: () => Promise<unknown>): AgentSession {
+	const usageStats = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, premiumRequests: 0, cost: 0 };
+	return {
+		state: { messages: [], model: { id: "openai-codex/gpt-5", contextWindow: 200_000 } },
+		messages: [],
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		model: { id: "openai-codex/gpt-5", contextWindow: 200_000 },
+		isStreaming: false,
+		fetchUsageReports,
+		sessionManager: {
+			getUsageStatistics: () => usageStats,
+			getSessionName: () => undefined,
+		},
+		getAsyncJobSnapshot: () => ({ running: [] }),
+	} as unknown as AgentSession;
+}
+
+async function waitForUsageText(component: StatusLineComponent): Promise<string> {
+	let text = "";
+	for (let i = 0; i < 20; i++) {
+		text = stripAnsi(component.getTopBorder(120).content);
+		if (text.includes("1h") || text.includes("5h")) return text;
+		await Bun.sleep(10);
+	}
+	return text;
+}
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+});
+
+describe("status line usage segment", () => {
+	it("renders OpenAI Codex primary and secondary usage windows despite plan tiers", async () => {
+		const now = Date.now();
+		const session = makeSession(async () => [
+			{
+				provider: "openai-codex",
+				fetchedAt: now,
+				limits: [
+					{
+						id: "openai-codex:primary",
+						scope: { provider: "openai-codex", windowId: "5h", tier: "pro" },
+						window: { id: "5h", resetsAt: now + 180 * 60_000 },
+						amount: { usedFraction: 0.24, unit: "percent" },
+					},
+					{
+						id: "openai-codex:secondary",
+						scope: { provider: "openai-codex", windowId: "7d", tier: "pro" },
+						window: { id: "7d", resetsAt: now + 49 * 3_600_000 },
+						amount: { usedFraction: 0.51, unit: "percent" },
+					},
+					{
+						id: "openai-codex:spark:primary",
+						scope: { provider: "openai-codex", windowId: "1h", tier: "spark", modelId: "codex-spark" },
+						window: { id: "1h", resetsAt: now + 10 * 60_000 },
+						amount: { usedFraction: 0.99, unit: "percent" },
+					},
+				],
+			},
+		]);
+		const component = new StatusLineComponent(session);
+		component.updateSettings({ preset: "custom", leftSegments: [], rightSegments: ["usage"], showSkillHud: false });
+
+		const text = await waitForUsageText(component);
+
+		expect(text).toContain("5h 24% (3h)");
+		expect(text).toContain("7d 51% (2d 1h)");
+		expect(text).not.toContain("99%");
+		component.dispose();
+	});
+
+	it("keeps rendering non-tiered Anthropic usage windows", async () => {
+		const now = Date.now();
+		const session = makeSession(async () => [
+			{
+				provider: "anthropic",
+				fetchedAt: now,
+				limits: [
+					{
+						id: "anthropic:5h",
+						scope: { provider: "anthropic", windowId: "5h" },
+						window: { id: "5h", resetsAt: now + 90 * 60_000 },
+						amount: { usedFraction: 0.4, unit: "percent" },
+					},
+					{
+						id: "anthropic:7d:opus",
+						scope: { provider: "anthropic", windowId: "7d", tier: "opus" },
+						window: { id: "7d", resetsAt: now + 12 * 3_600_000 },
+						amount: { usedFraction: 0.9, unit: "percent" },
+					},
+				],
+			},
+		]);
+		const component = new StatusLineComponent(session);
+		component.updateSettings({ preset: "custom", leftSegments: [], rightSegments: ["usage"], showSkillHud: false });
+
+		const text = await waitForUsageText(component);
+
+		expect(text).toContain("5h 40% (1h 30m)");
+		expect(text).not.toContain("90%");
+		component.dispose();
+	});
+});


### PR DESCRIPTION
## Summary
- recognize OpenAI Codex primary/secondary usage windows in the status line
- preserve actual Codex window labels such as 5h/7d and ignore additional model feature limits
- refresh the status line after usage fetch completes

## Verification
- bun test packages/coding-agent/test/status-line-usage.test.ts
- bun run check:ts