### PR TITLE
feat(coding-agent): add status line custom editor

### DIFF
--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -27,7 +27,9 @@ import { getTabBarTheme } from "../shared";
 import { DynamicBorder } from "./dynamic-border";
 import { handleInputOrEscape, PluginSettingsComponent } from "./plugin-settings";
 import { getSettingsForTab, type SettingDef } from "./settings-defs";
+import type { StatusLineSegmentOptions } from "./status-line";
 import { getPreset } from "./status-line/presets";
+import { ALL_SEGMENT_IDS } from "./status-line/segments";
 
 /**
  * A submenu component for selecting from a list of options.
@@ -161,6 +163,447 @@ class SelectSubmenu extends Container {
 		this.#selectList.handleInput(data);
 	}
 }
+const STATUS_LINE_CUSTOM_EDITOR_ID = "statusLine.customEditor";
+const PUBLIC_STATUS_SEGMENTS = ALL_SEGMENT_IDS.filter(id => id !== "pi");
+
+type StatusLineDraft = Required<
+	Pick<StatusLinePreviewSettings, "preset" | "leftSegments" | "rightSegments" | "separator" | "segmentOptions">
+>;
+
+const BOOL_VALUES = ["true", "false"];
+const PATH_LENGTH_OPTIONS: SelectItem[] = [16, 24, 32, 40, 50, 60, 80].map(value => ({
+	value: String(value),
+	label: String(value),
+}));
+const TIME_FORMAT_OPTIONS: SelectItem[] = [
+	{ value: "24h", label: "24h" },
+	{ value: "12h", label: "12h" },
+];
+
+function cloneSegmentOptions(options: StatusLineSegmentOptions | undefined): StatusLineSegmentOptions {
+	return mergeSegmentOptions(undefined, options);
+}
+
+function mergeSegmentOptions(
+	base: StatusLineSegmentOptions | undefined,
+	overrides: StatusLineSegmentOptions | undefined,
+): StatusLineSegmentOptions {
+	return {
+		model: base?.model || overrides?.model ? { ...(base?.model ?? {}), ...(overrides?.model ?? {}) } : undefined,
+		path: base?.path || overrides?.path ? { ...(base?.path ?? {}), ...(overrides?.path ?? {}) } : undefined,
+		git: base?.git || overrides?.git ? { ...(base?.git ?? {}), ...(overrides?.git ?? {}) } : undefined,
+		time: base?.time || overrides?.time ? { ...(base?.time ?? {}), ...(overrides?.time ?? {}) } : undefined,
+	};
+}
+
+function effectiveSegmentOptions(
+	preset: StatusLinePreset,
+	options: StatusLineSegmentOptions | undefined,
+): StatusLineSegmentOptions {
+	return mergeSegmentOptions(getPreset(preset).segmentOptions, options);
+}
+
+function effectiveCustomSegments(
+	preset: StatusLinePreset,
+	leftSegments: StatusLineSegmentId[],
+	rightSegments: StatusLineSegmentId[],
+): { leftSegments: StatusLineSegmentId[]; rightSegments: StatusLineSegmentId[] } {
+	if (preset === "custom" && (leftSegments.length > 0 || rightSegments.length > 0)) {
+		return { leftSegments: [...leftSegments], rightSegments: [...rightSegments] };
+	}
+	const presetDef = getPreset(preset);
+	return {
+		leftSegments: [...presetDef.leftSegments],
+		rightSegments: [...presetDef.rightSegments],
+	};
+}
+
+function statusSegmentLabel(id: StatusLineSegmentId): string {
+	return id.replace(/_/g, " ");
+}
+
+function segmentPlacement(
+	id: StatusLineSegmentId,
+	leftSegments: StatusLineSegmentId[],
+	rightSegments: StatusLineSegmentId[],
+): "hidden" | "left" | "right" {
+	if (leftSegments.includes(id)) return "left";
+	if (rightSegments.includes(id)) return "right";
+	return "hidden";
+}
+
+class StatusLineCustomEditor extends Container {
+	#list!: SettingsList;
+	#draft: StatusLineDraft;
+	#currentWidthPreviewText!: Text;
+	#narrowWidthPreviewText!: Text;
+	#previewHighlightSegment: StatusLineSegmentId | undefined;
+
+	constructor(
+		private readonly callbacks: SettingsCallbacks,
+		private readonly done: (value?: string) => void,
+	) {
+		super();
+		const preset = settings.get("statusLine.preset");
+		const seeded = effectiveCustomSegments(
+			preset,
+			settings.get("statusLine.leftSegments"),
+			settings.get("statusLine.rightSegments"),
+		);
+		this.#draft = {
+			preset: "custom",
+			leftSegments: seeded.leftSegments,
+			rightSegments: seeded.rightSegments,
+			separator: settings.get("statusLine.separator"),
+			segmentOptions: effectiveSegmentOptions(
+				preset,
+				settings.get("statusLine.segmentOptions") as StatusLineSegmentOptions,
+			),
+		};
+		this.#preview();
+		this.#build();
+	}
+
+	#build(): void {
+		this.clear();
+		this.addChild(new Text(theme.bold(theme.fg("accent", "Status Line Custom Editor")), 0, 0));
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(theme.fg("muted", "Current width preview:"), 0, 0));
+		this.#currentWidthPreviewText = new Text(this.#statusLinePreview(), 0, 0);
+		this.addChild(this.#currentWidthPreviewText);
+		this.addChild(new Text(theme.fg("muted", "Narrow width preview:"), 0, 0));
+		this.#narrowWidthPreviewText = new Text(this.#statusLinePreview(40), 0, 0);
+		this.addChild(this.#narrowWidthPreviewText);
+		this.addChild(new Spacer(1));
+		this.#list = new SettingsList(
+			this.#items(),
+			14,
+			getSettingsListTheme(),
+			(id, value) => this.#handleChange(id, value),
+			() => this.#cancel(),
+			item => this.#setSelectedItem(item),
+		);
+		this.addChild(this.#list);
+	}
+
+	#refresh(): void {
+		this.#refreshPreview();
+		this.#list.setItems(this.#items());
+	}
+
+	#refreshPreview(): void {
+		this.#currentWidthPreviewText.setText(this.#statusLinePreview());
+		this.#narrowWidthPreviewText.setText(this.#statusLinePreview(40));
+	}
+
+	#statusLinePreview(width?: number): string {
+		return this.callbacks.getStatusLinePreview?.(width) ?? theme.fg("dim", "(preview not available)");
+	}
+	#setSelectedItem(item: SettingItem | undefined): void {
+		this.#previewHighlightSegment = this.#highlightSegmentForItem(item);
+		this.#preview();
+		this.#refreshPreview();
+	}
+
+	#highlightSegmentForItem(item: SettingItem | undefined): StatusLineSegmentId | undefined {
+		if (!item) return undefined;
+		if (item.id.startsWith("segment.")) {
+			return item.id.slice("segment.".length) as StatusLineSegmentId;
+		}
+		if (item.id.startsWith("moveup.")) {
+			return item.id.slice("moveup.".length) as StatusLineSegmentId;
+		}
+		if (item.id.startsWith("movedown.")) {
+			return item.id.slice("movedown.".length) as StatusLineSegmentId;
+		}
+		if (item.id.startsWith("option.")) {
+			const [segment] = item.id.slice("option.".length).split(".");
+			return segment as StatusLineSegmentId;
+		}
+		return undefined;
+	}
+
+	#items(): SettingItem[] {
+		const items: SettingItem[] = [
+			{
+				id: "action.save",
+				label: "Save custom status line",
+				description: "Persist the previewed custom status line to user config.",
+				currentValue: "approve",
+				values: ["approve"],
+			},
+			{
+				id: "action.cancel",
+				label: "Cancel and restore",
+				description: "Close without persisting draft settings and restore the previous preview.",
+				currentValue: "restore",
+				values: ["restore"],
+			},
+			{
+				id: "separator",
+				label: "Separator",
+				description: "Separator style between status line segments.",
+				currentValue: this.#draft.separator,
+				submenu: (currentValue, done) =>
+					new SelectSubmenu(
+						"Status Line Separator",
+						"Style of separators between segments.",
+						[
+							{ value: "powerline", label: "Powerline" },
+							{ value: "powerline-thin", label: "Thin chevron" },
+							{ value: "slash", label: "Slash" },
+							{ value: "pipe", label: "Pipe" },
+							{ value: "block", label: "Block" },
+							{ value: "none", label: "None" },
+							{ value: "ascii", label: "ASCII" },
+						],
+						currentValue,
+						done,
+						() => done(),
+					),
+			},
+		];
+
+		for (const id of PUBLIC_STATUS_SEGMENTS) {
+			items.push({
+				id: `segment.${id}`,
+				label: `Segment: ${statusSegmentLabel(id)}`,
+				description: "Cycle placement: hidden → left → right. Use move actions below to reorder visible segments.",
+				currentValue: segmentPlacement(id, this.#draft.leftSegments, this.#draft.rightSegments),
+				values: ["hidden", "left", "right"],
+			});
+			if (segmentPlacement(id, this.#draft.leftSegments, this.#draft.rightSegments) !== "hidden") {
+				items.push(
+					{
+						id: `moveup.${id}`,
+						label: `Move left: ${statusSegmentLabel(id)}`,
+						currentValue: "←",
+						values: ["←"],
+					},
+					{
+						id: `movedown.${id}`,
+						label: `Move right: ${statusSegmentLabel(id)}`,
+						currentValue: "→",
+						values: ["→"],
+					},
+				);
+			}
+		}
+
+		items.push(
+			{
+				id: "option.model.showThinkingLevel",
+				label: "Model: show thinking level",
+				currentValue: String(this.#draft.segmentOptions.model?.showThinkingLevel !== false),
+				values: BOOL_VALUES,
+			},
+			{
+				id: "option.path.abbreviate",
+				label: "Path: abbreviate",
+				currentValue: String(this.#draft.segmentOptions.path?.abbreviate !== false),
+				values: BOOL_VALUES,
+			},
+			{
+				id: "option.path.maxLength",
+				label: "Path: max length",
+				currentValue: String(this.#draft.segmentOptions.path?.maxLength ?? 32),
+				submenu: (currentValue, done) =>
+					new SelectSubmenu(
+						"Path max length",
+						"Maximum displayed path length.",
+						PATH_LENGTH_OPTIONS,
+						currentValue,
+						done,
+						() => done(),
+					),
+			},
+			{
+				id: "option.path.stripWorkPrefix",
+				label: "Path: strip work prefix",
+				currentValue: String(this.#draft.segmentOptions.path?.stripWorkPrefix === true),
+				values: BOOL_VALUES,
+			},
+			{
+				id: "option.git.showBranch",
+				label: "Git: show branch",
+				currentValue: String(this.#draft.segmentOptions.git?.showBranch !== false),
+				values: BOOL_VALUES,
+			},
+			{
+				id: "option.git.showStaged",
+				label: "Git: show staged",
+				currentValue: String(this.#draft.segmentOptions.git?.showStaged !== false),
+				values: BOOL_VALUES,
+			},
+			{
+				id: "option.git.showUnstaged",
+				label: "Git: show unstaged",
+				currentValue: String(this.#draft.segmentOptions.git?.showUnstaged !== false),
+				values: BOOL_VALUES,
+			},
+			{
+				id: "option.git.showUntracked",
+				label: "Git: show untracked",
+				currentValue: String(this.#draft.segmentOptions.git?.showUntracked !== false),
+				values: BOOL_VALUES,
+			},
+			{
+				id: "option.time.format",
+				label: "Time: format",
+				currentValue: this.#draft.segmentOptions.time?.format ?? "24h",
+				submenu: (currentValue, done) =>
+					new SelectSubmenu(
+						"Time format",
+						"Clock format for the time segment.",
+						TIME_FORMAT_OPTIONS,
+						currentValue,
+						done,
+						() => done(),
+					),
+			},
+			{
+				id: "option.time.showSeconds",
+				label: "Time: show seconds",
+				currentValue: String(this.#draft.segmentOptions.time?.showSeconds === true),
+				values: BOOL_VALUES,
+			},
+		);
+
+		return items;
+	}
+
+	#handleChange(id: string, value: string): void {
+		if (id === "action.save") {
+			this.#save();
+			return;
+		}
+		if (id === "action.cancel") {
+			this.#cancel();
+			return;
+		}
+		if (id === "separator") {
+			this.#draft.separator = value as StatusLineSeparatorStyle;
+		} else if (id.startsWith("segment.")) {
+			this.#setSegmentPlacement(
+				id.slice("segment.".length) as StatusLineSegmentId,
+				value as "hidden" | "left" | "right",
+			);
+		} else if (id.startsWith("moveup.")) {
+			this.#moveSegment(id.slice("moveup.".length) as StatusLineSegmentId, -1);
+		} else if (id.startsWith("movedown.")) {
+			this.#moveSegment(id.slice("movedown.".length) as StatusLineSegmentId, 1);
+		} else if (id.startsWith("option.")) {
+			this.#setOption(id.slice("option.".length), value);
+		}
+		this.#preview();
+		this.#refresh();
+	}
+
+	#setSegmentPlacement(id: StatusLineSegmentId, placement: "hidden" | "left" | "right"): void {
+		this.#draft.leftSegments = this.#draft.leftSegments.filter(segment => segment !== id);
+		this.#draft.rightSegments = this.#draft.rightSegments.filter(segment => segment !== id);
+		if (placement === "left") this.#draft.leftSegments.push(id);
+		if (placement === "right") this.#draft.rightSegments.push(id);
+	}
+
+	#moveSegment(id: StatusLineSegmentId, delta: -1 | 1): void {
+		const group = this.#draft.leftSegments.includes(id) ? this.#draft.leftSegments : this.#draft.rightSegments;
+		const index = group.indexOf(id);
+		if (index < 0) return;
+		const nextIndex = Math.max(0, Math.min(group.length - 1, index + delta));
+		if (nextIndex === index) return;
+		const [segment] = group.splice(index, 1);
+		if (segment) group.splice(nextIndex, 0, segment);
+	}
+
+	#setOption(path: string, value: string): void {
+		const bool = value === "true";
+		switch (path) {
+			case "model.showThinkingLevel":
+				this.#draft.segmentOptions.model = { ...(this.#draft.segmentOptions.model ?? {}), showThinkingLevel: bool };
+				break;
+			case "path.abbreviate":
+				this.#draft.segmentOptions.path = { ...(this.#draft.segmentOptions.path ?? {}), abbreviate: bool };
+				break;
+			case "path.maxLength":
+				this.#draft.segmentOptions.path = { ...(this.#draft.segmentOptions.path ?? {}), maxLength: Number(value) };
+				break;
+			case "path.stripWorkPrefix":
+				this.#draft.segmentOptions.path = { ...(this.#draft.segmentOptions.path ?? {}), stripWorkPrefix: bool };
+				break;
+			case "git.showBranch":
+				this.#draft.segmentOptions.git = { ...(this.#draft.segmentOptions.git ?? {}), showBranch: bool };
+				break;
+			case "git.showStaged":
+				this.#draft.segmentOptions.git = { ...(this.#draft.segmentOptions.git ?? {}), showStaged: bool };
+				break;
+			case "git.showUnstaged":
+				this.#draft.segmentOptions.git = { ...(this.#draft.segmentOptions.git ?? {}), showUnstaged: bool };
+				break;
+			case "git.showUntracked":
+				this.#draft.segmentOptions.git = { ...(this.#draft.segmentOptions.git ?? {}), showUntracked: bool };
+				break;
+			case "time.format":
+				this.#draft.segmentOptions.time = {
+					...(this.#draft.segmentOptions.time ?? {}),
+					format: value as "12h" | "24h",
+				};
+				break;
+			case "time.showSeconds":
+				this.#draft.segmentOptions.time = { ...(this.#draft.segmentOptions.time ?? {}), showSeconds: bool };
+				break;
+		}
+	}
+
+	#preview(): void {
+		this.callbacks.onStatusLinePreview?.({
+			preset: "custom",
+			leftSegments: [...this.#draft.leftSegments],
+			rightSegments: [...this.#draft.rightSegments],
+			separator: this.#draft.separator,
+			segmentOptions: cloneSegmentOptions(this.#draft.segmentOptions),
+			previewHighlightSegment: this.#previewHighlightSegment,
+		});
+	}
+
+	#restorePreview(): void {
+		this.callbacks.onStatusLinePreview?.({
+			preset: settings.get("statusLine.preset"),
+			leftSegments: settings.get("statusLine.leftSegments"),
+			rightSegments: settings.get("statusLine.rightSegments"),
+			separator: settings.get("statusLine.separator"),
+			segmentOptions: cloneSegmentOptions(settings.get("statusLine.segmentOptions") as StatusLineSegmentOptions),
+			sessionAccent: settings.get("statusLine.sessionAccent"),
+		});
+	}
+
+	#save(): void {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", [...this.#draft.leftSegments]);
+		settings.set("statusLine.rightSegments", [...this.#draft.rightSegments]);
+		settings.set("statusLine.separator", this.#draft.separator);
+		settings.set(
+			"statusLine.segmentOptions",
+			cloneSegmentOptions(this.#draft.segmentOptions) as Record<string, unknown>,
+		);
+		this.callbacks.onChange("statusLine.preset", "custom");
+		this.callbacks.onChange("statusLine.leftSegments", [...this.#draft.leftSegments]);
+		this.callbacks.onChange("statusLine.rightSegments", [...this.#draft.rightSegments]);
+		this.callbacks.onChange("statusLine.separator", this.#draft.separator);
+		this.callbacks.onChange("statusLine.segmentOptions", cloneSegmentOptions(this.#draft.segmentOptions));
+		this.#preview();
+		this.done("saved");
+	}
+
+	#cancel(): void {
+		this.#restorePreview();
+		this.done();
+	}
+
+	handleInput(data: string): void {
+		this.#list.handleInput(data);
+	}
+}
 
 function getSettingsTabs(): Tab[] {
 	return [
@@ -194,6 +637,8 @@ export interface StatusLinePreviewSettings {
 	leftSegments?: StatusLineSegmentId[];
 	rightSegments?: StatusLineSegmentId[];
 	separator?: StatusLineSeparatorStyle;
+	segmentOptions?: StatusLineSegmentOptions;
+	previewHighlightSegment?: StatusLineSegmentId;
 	sessionAccent?: boolean;
 }
 
@@ -207,7 +652,7 @@ export interface SettingsCallbacks {
 	/** Called for status line preview while configuring */
 	onStatusLinePreview?: (settings: StatusLinePreviewSettings) => void;
 	/** Get current rendered status line for inline preview */
-	getStatusLinePreview?: () => string;
+	getStatusLinePreview?: (width?: number) => string;
 	/** Called when plugins change */
 	onPluginsChanged?: () => void;
 	/** Called when settings panel is closed */
@@ -372,7 +817,9 @@ export class SettingsSelectorComponent extends Container {
 		} else if (def.path === "theme.dark" || def.path === "theme.light") {
 			options = this.context.availableThemes.map(t => ({ value: t, label: t }));
 		}
-
+		if (def.path === "statusLine.preset") {
+			options = options.filter(option => option.value !== "custom");
+		}
 		// Preview handlers
 		let onPreview: ((value: string) => void | Promise<void>) | undefined;
 		let onPreviewCancel: (() => void) | undefined;
@@ -401,11 +848,23 @@ export class SettingsSelectorComponent extends Container {
 			onPreviewCancel = () => {
 				const currentPreset = settings.get("statusLine.preset");
 				const presetDef = getPreset(currentPreset);
+				const savedCustomSettings =
+					currentPreset === "custom"
+						? {
+								leftSegments: settings.get("statusLine.leftSegments"),
+								rightSegments: settings.get("statusLine.rightSegments"),
+								separator: settings.get("statusLine.separator"),
+								segmentOptions: cloneSegmentOptions(
+									settings.get("statusLine.segmentOptions") as StatusLineSegmentOptions,
+								),
+							}
+						: {};
 				this.callbacks.onStatusLinePreview?.({
 					preset: currentPreset,
 					leftSegments: presetDef.leftSegments,
 					rightSegments: presetDef.rightSegments,
 					separator: presetDef.separator,
+					...savedCustomSettings,
 				});
 				this.#updateStatusPreview();
 			};
@@ -509,7 +968,7 @@ export class SettingsSelectorComponent extends Container {
 		}
 
 		this.#currentList = new SettingsList(
-			this.#buildItemsForDefs(defs),
+			this.#buildItemsForTab(defs, tabId),
 			10,
 			getSettingsListTheme(),
 			(id, newValue) => {
@@ -553,10 +1012,31 @@ export class SettingsSelectorComponent extends Container {
 		return items;
 	}
 
+	#buildItemsForTab(defs: SettingDef[], tabId: SettingTab): SettingItem[] {
+		const items = this.#buildItemsForDefs(defs);
+		if (tabId === "appearance") {
+			const customEditorItem: SettingItem = {
+				id: STATUS_LINE_CUSTOM_EDITOR_ID,
+				label: "Status Line Custom Editor",
+				description:
+					"Edit custom status line segments, placement, separator, and typed segment options with live previews.",
+				currentValue: "open",
+				submenu: (_currentValue, done) => new StatusLineCustomEditor(this.callbacks, done),
+			};
+			const presetIndex = items.findIndex(item => item.id === "statusLine.preset");
+			if (presetIndex >= 0) {
+				items.splice(presetIndex + 1, 0, customEditorItem);
+			} else {
+				items.push(customEditorItem);
+			}
+		}
+		return items;
+	}
+
 	/** Re-evaluate condition gates against the current settings and refresh the active list. */
 	#refreshCurrentTabItems(defs: SettingDef[]): void {
 		if (this.#currentTabId === "plugins" || !this.#currentList) return;
-		this.#currentList.setItems(this.#buildItemsForDefs(defs));
+		this.#currentList.setItems(this.#buildItemsForTab(defs, this.#currentTabId));
 	}
 
 	/**
@@ -578,6 +1058,7 @@ export class SettingsSelectorComponent extends Container {
 			leftSegments: settings.get("statusLine.leftSegments"),
 			rightSegments: settings.get("statusLine.rightSegments"),
 			separator: settings.get("statusLine.separator"),
+			segmentOptions: cloneSegmentOptions(settings.get("statusLine.segmentOptions") as StatusLineSegmentOptions),
 			sessionAccent: settings.get("statusLine.sessionAccent"),
 		};
 		this.callbacks.onStatusLinePreview?.(statusLineSettings);

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -208,7 +208,7 @@ function effectiveCustomSegments(
 	leftSegments: StatusLineSegmentId[],
 	rightSegments: StatusLineSegmentId[],
 ): { leftSegments: StatusLineSegmentId[]; rightSegments: StatusLineSegmentId[] } {
-	if (preset === "custom" && (leftSegments.length > 0 || rightSegments.length > 0)) {
+	if (preset === "custom") {
 		return { leftSegments: [...leftSegments], rightSegments: [...rightSegments] };
 	}
 	const presetDef = getPreset(preset);
@@ -574,6 +574,7 @@ class StatusLineCustomEditor extends Container {
 			separator: settings.get("statusLine.separator"),
 			segmentOptions: cloneSegmentOptions(settings.get("statusLine.segmentOptions") as StatusLineSegmentOptions),
 			sessionAccent: settings.get("statusLine.sessionAccent"),
+			previewHighlightSegment: undefined,
 		});
 	}
 
@@ -591,6 +592,7 @@ class StatusLineCustomEditor extends Container {
 		this.callbacks.onChange("statusLine.rightSegments", [...this.#draft.rightSegments]);
 		this.callbacks.onChange("statusLine.separator", this.#draft.separator);
 		this.callbacks.onChange("statusLine.segmentOptions", cloneSegmentOptions(this.#draft.segmentOptions));
+		this.#previewHighlightSegment = undefined;
 		this.#preview();
 		this.done("saved");
 	}
@@ -842,6 +844,7 @@ export class SettingsSelectorComponent extends Container {
 					leftSegments: presetDef.leftSegments,
 					rightSegments: presetDef.rightSegments,
 					separator: presetDef.separator,
+					previewHighlightSegment: undefined,
 				});
 				this.#updateStatusPreview();
 			};
@@ -865,6 +868,7 @@ export class SettingsSelectorComponent extends Container {
 					rightSegments: presetDef.rightSegments,
 					separator: presetDef.separator,
 					...savedCustomSettings,
+					previewHighlightSegment: undefined,
 				});
 				this.#updateStatusPreview();
 			};
@@ -875,7 +879,7 @@ export class SettingsSelectorComponent extends Container {
 			};
 			onPreviewCancel = () => {
 				const separator = settings.get("statusLine.separator");
-				this.callbacks.onStatusLinePreview?.({ separator });
+				this.callbacks.onStatusLinePreview?.({ separator, previewHighlightSegment: undefined });
 				this.#updateStatusPreview();
 			};
 		}
@@ -1060,6 +1064,7 @@ export class SettingsSelectorComponent extends Container {
 			separator: settings.get("statusLine.separator"),
 			segmentOptions: cloneSegmentOptions(settings.get("statusLine.segmentOptions") as StatusLineSegmentOptions),
 			sessionAccent: settings.get("statusLine.sessionAccent"),
+			previewHighlightSegment: undefined,
 		};
 		this.callbacks.onStatusLinePreview?.(statusLineSettings);
 		this.#updateStatusPreview();

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -40,6 +40,7 @@ export interface StatusLineSettings {
 	rightSegments?: StatusLineSegmentId[];
 	separator?: StatusLineSeparatorStyle;
 	segmentOptions?: StatusLineSegmentOptions;
+	previewHighlightSegment?: StatusLineSegmentId;
 	showHookStatus?: boolean;
 	showSkillHud?: boolean;
 	sessionAccent?: boolean;
@@ -684,12 +685,15 @@ export class StatusLineComponent implements Component {
 		const sepAnsi = theme.getFgAnsi("statusLineSep");
 
 		// Collect visible segment contents
+		const highlightSegment = (segId: StatusLineSegmentId, content: string): string =>
+			effectiveSettings.previewHighlightSegment === segId ? `\x1b[7m${content}\x1b[27m` : content;
+
 		const leftParts: string[] = [];
 		const leftSegIds: StatusLineSegmentId[] = [];
 		for (const segId of effectiveSettings.leftSegments) {
 			const rendered = renderSegment(segId, ctx);
 			if (rendered.visible && rendered.content) {
-				leftParts.push(rendered.content);
+				leftParts.push(highlightSegment(segId, rendered.content));
 				leftSegIds.push(segId);
 			}
 		}
@@ -698,7 +702,7 @@ export class StatusLineComponent implements Component {
 		for (const segId of effectiveSettings.rightSegments) {
 			const rendered = renderSegment(segId, ctx);
 			if (rendered.visible && rendered.content) {
-				rightParts.push(rendered.content);
+				rightParts.push(highlightSegment(segId, rendered.content));
 			}
 		}
 
@@ -765,7 +769,7 @@ export class StatusLineComponent implements Component {
 							if (!adjusted.visible || !adjusted.content) break;
 							reRendered = adjusted;
 						}
-						left[pathIdx] = reRendered.content;
+						left[pathIdx] = highlightSegment("path", reRendered.content);
 						leftWidth = groupWidth(left, leftCapWidth, leftSepWidth);
 					}
 				}

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -222,7 +222,7 @@ export class StatusLineComponent implements Component {
 	}
 
 	updateSettings(settings: StatusLineSettings): void {
-		this.#settings = { ...this.#settings, ...settings };
+		this.#settings = { ...this.#settings, previewHighlightSegment: undefined, ...settings };
 	}
 
 	setAutoCompactEnabled(enabled: boolean): void {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -338,14 +338,16 @@ export class SelectorController {
 								separator: settings.get("statusLine.separator"),
 								showHookStatus: settings.get("statusLine.showHookStatus"),
 								sessionAccent: settings.get("statusLine.sessionAccent"),
+								segmentOptions: settings.get("statusLine.segmentOptions"),
 								...previewSettings,
 							});
 							this.ctx.updateEditorTopBorder();
 							this.ctx.ui.requestRender();
 						},
-						getStatusLinePreview: () => {
+						getStatusLinePreview: (width?: number) => {
 							// Return the rendered status line for inline preview
-							const availableWidth = this.ctx.editor.getTopBorderAvailableWidth(this.ctx.ui.terminal.columns);
+							const availableWidth =
+								width ?? this.ctx.editor.getTopBorderAvailableWidth(this.ctx.ui.terminal.columns);
 							return this.ctx.statusLine.getTopBorder(availableWidth).content;
 						},
 						onPluginsChanged: () => {
@@ -361,6 +363,7 @@ export class SelectorController {
 								separator: settings.get("statusLine.separator"),
 								showHookStatus: settings.get("statusLine.showHookStatus"),
 								sessionAccent: settings.get("statusLine.sessionAccent"),
+								segmentOptions: settings.get("statusLine.segmentOptions"),
 							});
 							this.ctx.updateEditorTopBorder();
 							this.ctx.ui.requestRender();
@@ -605,6 +608,9 @@ export class SelectorController {
 			case "statusLineShowHooks":
 			case "statusLine.showHookStatus":
 			case "statusLine.sessionAccent":
+			case "statusLine.leftSegments":
+			case "statusLine.rightSegments":
+			case "statusLine.segmentOptions":
 			case "statusLineSegments":
 			case "statusLineModelThinking":
 			case "statusLinePathAbbreviate":

--- a/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
@@ -124,6 +124,25 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 
 		expect(settings.get("statusLine.segmentOptions")).toEqual(minimalSegmentOptions as Record<string, unknown>);
 	});
+	it("preserves an intentionally empty saved custom layout", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", []);
+		settings.set("statusLine.rightSegments", []);
+		const { component, previews } = createSelector();
+
+		openCustomEditor(component);
+
+		expect(previews.at(-1)).toMatchObject({
+			preset: "custom",
+			leftSegments: [],
+			rightSegments: [],
+		});
+
+		component.handleInput("\n");
+
+		expect(settings.get("statusLine.leftSegments")).toEqual([]);
+		expect(settings.get("statusLine.rightSegments")).toEqual([]);
+	});
 
 	it("edits segment placement and typed options before saving", () => {
 		settings.set("statusLine.preset", "minimal");
@@ -162,6 +181,8 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 			leftSegments: [],
 			rightSegments: [],
 		});
+		expect(Object.hasOwn(previews.at(-1) ?? {}, "previewHighlightSegment")).toBe(true);
+		expect(previews.at(-1)?.previewHighlightSegment).toBeUndefined();
 		expect(settings.get("statusLine.preset")).toBe("minimal");
 	});
 	it("moves segments between sides, reorders within a side, and saves separator changes", () => {

--- a/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
@@ -1,0 +1,233 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { SettingPath } from "@gajae-code/coding-agent/config/settings";
+import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
+import {
+	SettingsSelectorComponent,
+	type StatusLinePreviewSettings,
+} from "@gajae-code/coding-agent/modes/components/settings-selector";
+import { getPreset } from "@gajae-code/coding-agent/modes/components/status-line/presets";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+
+interface ChangedSetting {
+	path: SettingPath;
+	value: unknown;
+}
+
+beforeAll(async () => {
+	await initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+});
+
+beforeEach(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	vi.restoreAllMocks();
+});
+
+function createSelector() {
+	const previews: StatusLinePreviewSettings[] = [];
+	const changedSettings: ChangedSetting[] = [];
+	const previewWidths: Array<number | undefined> = [];
+	const component = new SettingsSelectorComponent(
+		{
+			availableThinkingLevels: [],
+			thinkingLevel: undefined,
+			availableThemes: ["red-claw", "blue-crab"],
+			cwd: process.cwd(),
+		},
+		{
+			onChange: (path, value) => changedSettings.push({ path, value }),
+			onStatusLinePreview: preview => previews.push(preview),
+			getStatusLinePreview: width => {
+				previewWidths.push(width);
+				return `preview-${width ?? "current"}`;
+			},
+			onCancel: () => {},
+		},
+	);
+	return { component, previews, changedSettings, previewWidths };
+}
+function selectCustomEditor(component: SettingsSelectorComponent): void {
+	for (let i = 0; i < 5; i++) component.handleInput("\x1b[B");
+}
+
+function openCustomEditor(component: SettingsSelectorComponent): void {
+	selectCustomEditor(component);
+	component.handleInput("\n");
+}
+describe("SettingsSelectorComponent status line custom editor", () => {
+	it("exposes a dedicated Appearance editor", () => {
+		const { component } = createSelector();
+		selectCustomEditor(component);
+
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("Status Line Custom Editor");
+	});
+	it("keeps Custom out of the generic preset selector", () => {
+		const { component } = createSelector();
+
+		for (let i = 0; i < 4; i++) component.handleInput("\x1b[B");
+
+		component.handleInput("\n");
+
+		const presetMenu = Bun.stripANSI(component.render(120).join("\n"));
+		expect(presetMenu).toContain("Status Line Preset");
+		expect(presetMenu).not.toContain("Custom");
+	});
+	it("seeds custom layout from the active preset, previews segment options, and saves to settings", () => {
+		settings.set("statusLine.preset", "minimal");
+		settings.set("statusLine.leftSegments", []);
+		settings.set("statusLine.rightSegments", []);
+		settings.set("statusLine.segmentOptions", { path: { maxLength: 24 }, git: { showUntracked: false } });
+		const { component, previews, changedSettings, previewWidths } = createSelector();
+
+		openCustomEditor(component);
+
+		const opened = Bun.stripANSI(component.render(120).join("\n"));
+		expect(opened).toContain("Status Line Custom Editor");
+		expect(opened).toContain("Narrow width preview");
+		expect(previewWidths).toContain(40);
+		expect(previews.at(-1)).toMatchObject({
+			preset: "custom",
+			leftSegments: getPreset("minimal").leftSegments,
+			rightSegments: getPreset("minimal").rightSegments,
+			segmentOptions: { path: { maxLength: 24 }, git: { showUntracked: false } },
+		});
+
+		component.handleInput("\n"); // Save custom status line.
+
+		expect(settings.get("statusLine.preset")).toBe("custom");
+		expect(settings.get("statusLine.leftSegments")).toEqual(getPreset("minimal").leftSegments);
+		expect(settings.get("statusLine.rightSegments")).toEqual(getPreset("minimal").rightSegments);
+		expect(changedSettings.map(change => change.path)).toEqual(
+			expect.arrayContaining([
+				"statusLine.preset",
+				"statusLine.leftSegments",
+				"statusLine.rightSegments",
+				"statusLine.separator",
+				"statusLine.segmentOptions",
+			]),
+		);
+	});
+	it("clones preset segment option defaults when saving from a preset", () => {
+		settings.set("statusLine.preset", "minimal");
+		settings.set("statusLine.segmentOptions", {});
+		const minimalSegmentOptions = getPreset("minimal").segmentOptions ?? {};
+		const { component, previews } = createSelector();
+
+		openCustomEditor(component);
+
+		expect(previews.at(-1)?.segmentOptions).toEqual(minimalSegmentOptions);
+
+		component.handleInput("\n");
+
+		expect(settings.get("statusLine.segmentOptions")).toEqual(minimalSegmentOptions as Record<string, unknown>);
+	});
+
+	it("edits segment placement and typed options before saving", () => {
+		settings.set("statusLine.preset", "minimal");
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+
+		for (let i = 0; i < 3; i++) component.handleInput("\x1b[B");
+		component.handleInput("\n"); // Segment: gajae hidden -> left.
+
+		component.handleInput("\x1b[A"); // Move back to the separator row; selection was preserved after refresh.
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("Separator");
+
+		component.handleInput("\x1b[A");
+		component.handleInput("\x1b[A");
+		component.handleInput("\n"); // Save.
+
+		expect(settings.get("statusLine.leftSegments")).toEqual([...getPreset("minimal").leftSegments, "gajae"]);
+	});
+
+	it("edits option rows and restores preview on cancel", () => {
+		settings.set("statusLine.preset", "minimal");
+		const { component, previews } = createSelector();
+
+		openCustomEditor(component);
+
+		component.handleInput("\x1b[A"); // Wrap from Save to the final Time: show seconds option.
+		expect(previews.at(-1)?.previewHighlightSegment).toBe("time");
+		component.handleInput("\n");
+		expect(previews.at(-1)?.segmentOptions?.time?.showSeconds).toBe(true);
+
+		component.handleInput("\x1b"); // Escape from the editor.
+
+		expect(previews.at(-1)).toMatchObject({
+			preset: "minimal",
+			leftSegments: [],
+			rightSegments: [],
+		});
+		expect(settings.get("statusLine.preset")).toBe("minimal");
+	});
+	it("moves segments between sides, reorders within a side, and saves separator changes", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model", "path"]);
+		settings.set("statusLine.rightSegments", []);
+		settings.set("statusLine.separator", "slash");
+		const { component, previews } = createSelector();
+
+		openCustomEditor(component);
+
+		for (let i = 0; i < 9; i++) component.handleInput("\x1b[B");
+		component.handleInput("\n"); // Move left: path before model.
+		expect(previews.at(-1)?.leftSegments).toEqual(["path", "model"]);
+
+		for (let i = 0; i < 5; i++) component.handleInput("\x1b[A");
+		component.handleInput("\n"); // Segment: model left -> right.
+
+		for (let i = 0; i < 2; i++) component.handleInput("\x1b[A");
+		component.handleInput("\n"); // Open separator submenu.
+		component.handleInput("\x1b[B");
+		component.handleInput("\n"); // slash -> pipe.
+		expect(previews.at(-1)).toMatchObject({
+			leftSegments: ["path"],
+			rightSegments: ["model"],
+			separator: "pipe",
+		});
+
+		component.handleInput("\x1b[A");
+		component.handleInput("\x1b[A");
+		component.handleInput("\n"); // Save.
+
+		expect(settings.get("statusLine.leftSegments")).toEqual(["path"]);
+		expect(settings.get("statusLine.rightSegments")).toEqual(["model"]);
+		expect(settings.get("statusLine.separator")).toBe("pipe");
+	});
+	it("persists approved custom settings across settings reload", async () => {
+		const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-status-line-settings-"));
+		try {
+			resetSettingsForTest();
+			await Settings.init({ agentDir });
+			settings.set("statusLine.preset", "minimal");
+			settings.set("statusLine.leftSegments", []);
+			settings.set("statusLine.rightSegments", []);
+			settings.set("statusLine.segmentOptions", { time: { showSeconds: true } });
+
+			const { component } = createSelector();
+			openCustomEditor(component);
+			component.handleInput("\n");
+
+			await Bun.sleep(150);
+
+			resetSettingsForTest();
+			await Settings.init({ agentDir });
+
+			expect(settings.get("statusLine.preset")).toBe("custom");
+			expect(settings.get("statusLine.leftSegments")).toEqual(getPreset("minimal").leftSegments);
+			expect(settings.get("statusLine.rightSegments")).toEqual(getPreset("minimal").rightSegments);
+			expect(settings.get("statusLine.segmentOptions")).toEqual({
+				...getPreset("minimal").segmentOptions,
+				time: { showSeconds: true },
+			});
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(agentDir, { recursive: true, force: true });
+			await Settings.init({ inMemory: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -123,6 +123,24 @@ describe("status line session accent", () => {
 		expect(border).not.toContain(`${accentAnsi}${theme.boxRound.horizontal}`);
 	});
 });
+describe("status line preview highlight", () => {
+	it("clears transient highlight when later settings omit it", () => {
+		const component = new StatusLineComponent(createStatusLineSession("Highlight session"));
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["gajae"],
+			rightSegments: [],
+			separator: "powerline-thin",
+			previewHighlightSegment: "gajae",
+		});
+
+		expect(component.getTopBorder(80).content).toContain("\x1b[7m");
+
+		component.updateSettings({ separator: "pipe" });
+
+		expect(component.getTopBorder(80).content).not.toContain("\x1b[7m");
+	});
+});
 
 describe("status line version display", () => {
 	function buildComponent(widthVersion: string = "9.8.7") {

--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -32,6 +32,7 @@ export class SettingsList implements Component {
 	#maxVisible: number;
 	#onChange: (id: string, newValue: string) => void;
 	#onCancel: () => void;
+	#onSelectionChange?: (item: SettingItem | undefined) => void;
 
 	// Submenu state
 	#submenuComponent: Component | null = null;
@@ -43,12 +44,15 @@ export class SettingsList implements Component {
 		theme: SettingsListTheme,
 		onChange: (id: string, newValue: string) => void,
 		onCancel: () => void,
+		onSelectionChange?: (item: SettingItem | undefined) => void,
 	) {
 		this.#items = items;
 		this.#maxVisible = maxVisible;
 		this.#theme = theme;
 		this.#onChange = onChange;
 		this.#onCancel = onCancel;
+		this.#onSelectionChange = onSelectionChange;
+		this.#notifySelectionChange();
 	}
 
 	/** Update an item's currentValue */
@@ -73,10 +77,15 @@ export class SettingsList implements Component {
 		} else if (this.#selectedIndex >= this.#items.length) {
 			this.#selectedIndex = this.#items.length - 1;
 		}
+		this.#notifySelectionChange();
 	}
 
 	invalidate(): void {
 		this.#submenuComponent?.invalidate?.();
+	}
+
+	#notifySelectionChange(): void {
+		this.#onSelectionChange?.(this.#items[this.#selectedIndex]);
 	}
 
 	render(width: number): string[] {
@@ -167,8 +176,10 @@ export class SettingsList implements Component {
 		const kb = getKeybindings();
 		if (kb.matches(data, "tui.select.up")) {
 			this.#selectedIndex = this.#selectedIndex === 0 ? this.#items.length - 1 : this.#selectedIndex - 1;
+			this.#notifySelectionChange();
 		} else if (kb.matches(data, "tui.select.down")) {
 			this.#selectedIndex = this.#selectedIndex === this.#items.length - 1 ? 0 : this.#selectedIndex + 1;
+			this.#notifySelectionChange();
 		} else if (kb.matches(data, "tui.select.confirm") || data === " " || data === "\n") {
 			this.#activateItem();
 		} else if (kb.matches(data, "tui.select.cancel")) {
@@ -206,6 +217,7 @@ export class SettingsList implements Component {
 		if (this.#submenuItemIndex !== null) {
 			this.#selectedIndex = this.#submenuItemIndex;
 			this.#submenuItemIndex = null;
+			this.#notifySelectionChange();
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add a dedicated Status Line Custom Editor under Appearance directly beneath Status Line Preset
- keep Custom out of the generic preset picker and persist custom left/right segments, separator, and segment options
- add live current/narrow previews plus preview-side segment highlighting for the row being edited
- address #1252 review blockers by preserving intentionally empty custom layouts and clearing transient preview highlights on restore/cancel/update paths

## Verification
- bun test packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts packages/coding-agent/test/status-line-overflow.test.ts
- bun run check:ts

Addresses review blockers from #1252.