### PR TITLE
feat: add local provider model discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 
 - Added a generic `providers.local.openaiCompat` models config path for OpenAI-compatible local endpoints plus `gjc local-provider smoke` for bounded streaming chat-completion checks (#1246).
+- Added `gjc local-provider discover` / `models` to list model IDs from a configured local OpenAI-compatible provider via `GET /v1/models`, with clear network and response-shape errors and no chat-completion request (#1247).
 
 ### Fixed
 

--- a/packages/coding-agent/src/cli/local-provider-smoke.ts
+++ b/packages/coding-agent/src/cli/local-provider-smoke.ts
@@ -22,6 +22,15 @@ export interface LocalProviderSmokeResult {
 	error?: string;
 }
 
+export interface LocalProviderDiscoveryResult {
+	ok: boolean;
+	provider: string;
+	baseUrl?: string;
+	models: string[];
+	message: string;
+	error?: string;
+}
+
 const DEFAULT_TIMEOUT_MS = 3000;
 const DEFAULT_SMOKE_PROMPT = "Reply with ok.";
 
@@ -56,6 +65,24 @@ export function getLocalOpenAICompatConfig(config: ModelsConfig | undefined): Lo
 	};
 }
 
+function extractModelIds(payload: unknown): string[] {
+	if (!isRecord(payload)) {
+		throw new Error("/models response was not a JSON object");
+	}
+	if (!Array.isArray(payload.data)) {
+		throw new Error("/models response did not include a data array");
+	}
+	const models = payload.data.flatMap(item => {
+		if (!isRecord(item) || typeof item.id !== "string") return [];
+		const id = item.id.trim();
+		return id ? [id] : [];
+	});
+	if (models.length === 0) {
+		throw new Error("/models returned no model ids");
+	}
+	return [...new Set(models)].sort((left, right) => left.localeCompare(right));
+}
+
 async function readLocalConfig(
 	modelsPath: string | undefined,
 ): Promise<LocalProviderSmokeResult | LocalOpenAICompatConfig> {
@@ -85,7 +112,7 @@ function toErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
-async function discoverFirstModel(config: LocalOpenAICompatConfig, timeoutMs: number): Promise<string> {
+async function fetchLocalModelIds(config: LocalOpenAICompatConfig, timeoutMs: number): Promise<string[]> {
 	const response = await fetch(`${config.baseUrl}/models`, {
 		headers: buildHeaders(config.apiKey),
 		signal: AbortSignal.timeout(timeoutMs),
@@ -93,17 +120,25 @@ async function discoverFirstModel(config: LocalOpenAICompatConfig, timeoutMs: nu
 	if (!response.ok) {
 		throw new Error(`HTTP ${response.status} from ${config.baseUrl}/models`);
 	}
-	const payload = (await response.json()) as unknown;
-	const data = isRecord(payload) ? payload.data : undefined;
-	if (!Array.isArray(data)) {
-		throw new Error("/models response did not include a data array");
+	let payload: unknown;
+	try {
+		payload = await response.json();
+	} catch (error) {
+		throw new Error(`Failed to parse /models JSON: ${toErrorMessage(error)}`);
 	}
-	for (const item of data) {
-		if (isRecord(item) && typeof item.id === "string" && item.id.trim()) {
-			return item.id;
+	return extractModelIds(payload);
+}
+
+async function discoverFirstModel(config: LocalOpenAICompatConfig, timeoutMs: number): Promise<string> {
+	try {
+		return (await fetchLocalModelIds(config, timeoutMs))[0]!;
+	} catch (error) {
+		const message = toErrorMessage(error);
+		if (message === "/models returned no model ids") {
+			throw new Error("/models returned no model ids; pass --model explicitly");
 		}
+		throw error;
 	}
-	throw new Error("/models returned no model ids; pass --model explicitly");
 }
 
 async function readStreamingBody(response: Response): Promise<number> {
@@ -120,6 +155,42 @@ async function readStreamingBody(response: Response): Promise<number> {
 		reader.releaseLock();
 	}
 	return chunks;
+}
+
+export async function runLocalProviderDiscover(
+	cmd: Omit<LocalProviderSmokeCommandArgs, "model">,
+): Promise<LocalProviderDiscoveryResult> {
+	const timeoutMs = cmd.timeoutMs && cmd.timeoutMs > 0 ? cmd.timeoutMs : DEFAULT_TIMEOUT_MS;
+	const configResult = await readLocalConfig(cmd.modelsPath);
+	if ("ok" in configResult) {
+		return {
+			ok: false,
+			provider: "local",
+			models: [],
+			message: configResult.message,
+			error: configResult.error,
+		};
+	}
+
+	try {
+		const models = await fetchLocalModelIds(configResult, timeoutMs);
+		return {
+			ok: true,
+			provider: "local",
+			baseUrl: configResult.baseUrl,
+			models,
+			message: `Discovered ${models.length} model${models.length === 1 ? "" : "s"}.`,
+		};
+	} catch (error) {
+		return {
+			ok: false,
+			provider: "local",
+			baseUrl: configResult.baseUrl,
+			models: [],
+			message: "Local provider model discovery failed.",
+			error: toErrorMessage(error),
+		};
+	}
 }
 
 export async function runLocalProviderSmoke(cmd: LocalProviderSmokeCommandArgs): Promise<LocalProviderSmokeResult> {
@@ -175,6 +246,26 @@ export async function runLocalProviderSmoke(cmd: LocalProviderSmokeCommandArgs):
 			error: toErrorMessage(error),
 		};
 	}
+}
+
+export async function runLocalProviderDiscoverCommand(
+	cmd: Omit<LocalProviderSmokeCommandArgs, "model">,
+): Promise<void> {
+	const result = await runLocalProviderDiscover(cmd);
+	if (cmd.json) {
+		process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+	} else if (result.ok) {
+		process.stdout.write(`${chalk.green("ok")} ${result.message}\n`);
+		process.stdout.write(`provider=${result.provider} baseUrl=${result.baseUrl}\n`);
+		for (const model of result.models) {
+			process.stdout.write(`${model}\n`);
+		}
+	} else {
+		process.stderr.write(`${chalk.red("error")} ${result.message}\n`);
+		process.stderr.write(`${chalk.dim(`provider=${result.provider} baseUrl=${result.baseUrl ?? "<unknown>"}`)}\n`);
+		if (result.error) process.stderr.write(`${chalk.dim(result.error)}\n`);
+	}
+	if (!result.ok) process.exitCode = 1;
 }
 
 export async function runLocalProviderSmokeCommand(cmd: LocalProviderSmokeCommandArgs): Promise<void> {

--- a/packages/coding-agent/src/commands/local-provider.ts
+++ b/packages/coding-agent/src/commands/local-provider.ts
@@ -2,19 +2,20 @@
  * Test configured local OpenAI-compatible providers.
  */
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
-import { runLocalProviderSmokeCommand } from "../cli/local-provider-smoke";
+import { runLocalProviderDiscoverCommand, runLocalProviderSmokeCommand } from "../cli/local-provider-smoke";
 
-const ACTIONS = ["smoke"] as const;
+export const LOCAL_PROVIDER_ACTIONS = ["discover", "models", "smoke"] as const;
+export const LOCAL_PROVIDER_DEFAULT_ACTION = "smoke";
 
 export default class LocalProvider extends Command {
-	static description = "Test configured local OpenAI-compatible providers";
+	static description = "Discover or test configured local OpenAI-compatible providers";
 
 	static args = {
-		action: Args.string({ description: "Action", required: false, options: ACTIONS }),
+		action: Args.string({ description: "Action", required: false, options: LOCAL_PROVIDER_ACTIONS }),
 	};
 
 	static flags = {
-		model: Flags.string({ description: "Model id to use (otherwise uses the first /models id)" }),
+		model: Flags.string({ description: "Model id to use for smoke (otherwise uses the first /models id)" }),
 		"models-path": Flags.string({ description: "Override models config path" }),
 		"timeout-ms": Flags.integer({ description: "Request timeout in milliseconds" }),
 		json: Flags.boolean({ description: "Output JSON" }),
@@ -22,17 +23,25 @@ export default class LocalProvider extends Command {
 
 	async run(): Promise<void> {
 		const { args, flags } = await this.parse(LocalProvider);
-		const action = args.action ?? "smoke";
-		if (action !== "smoke") {
-			process.stderr.write(`Unsupported local-provider action: ${action}\n`);
-			process.exitCode = 1;
+		const action = args.action ?? LOCAL_PROVIDER_DEFAULT_ACTION;
+		if (action === "discover" || action === "models") {
+			await runLocalProviderDiscoverCommand({
+				modelsPath: flags["models-path"],
+				timeoutMs: flags["timeout-ms"],
+				json: flags.json,
+			});
 			return;
 		}
-		await runLocalProviderSmokeCommand({
-			model: flags.model,
-			modelsPath: flags["models-path"],
-			timeoutMs: flags["timeout-ms"],
-			json: flags.json,
-		});
+		if (action === "smoke") {
+			await runLocalProviderSmokeCommand({
+				model: flags.model,
+				modelsPath: flags["models-path"],
+				timeoutMs: flags["timeout-ms"],
+				json: flags.json,
+			});
+			return;
+		}
+		process.stderr.write(`Unsupported local-provider action: ${action}\n`);
+		process.exitCode = 1;
 	}
 }

--- a/packages/coding-agent/test/local-provider-smoke.test.ts
+++ b/packages/coding-agent/test/local-provider-smoke.test.ts
@@ -2,8 +2,13 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { runLocalProviderSmoke } from "@gajae-code/coding-agent/cli/local-provider-smoke";
+import {
+	runLocalProviderDiscover,
+	runLocalProviderDiscoverCommand,
+	runLocalProviderSmoke,
+} from "@gajae-code/coding-agent/cli/local-provider-smoke";
 import { hookFetch, Snowflake } from "@gajae-code/utils";
+import { LOCAL_PROVIDER_ACTIONS, LOCAL_PROVIDER_DEFAULT_ACTION } from "../src/commands/local-provider";
 
 describe("local provider streaming smoke", () => {
 	let tempDir: string;
@@ -28,6 +33,135 @@ describe("local provider streaming smoke", () => {
 
 		expect(result.ok).toBe(false);
 		expect(result.message).toContain("No local OpenAI-compatible endpoint configured");
+	});
+
+	test("discovers configured local OpenAI-compatible models without a chat completion request", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					local: { openaiCompat: { baseUrl: "http://127.0.0.1:1234", apiKey: "local-key" } },
+				},
+			}),
+		);
+		const requestedUrls: string[] = [];
+		using _hook = hookFetch((input, init) => {
+			const url = String(input);
+			requestedUrls.push(url);
+			if (url !== "http://127.0.0.1:1234/v1/models") {
+				throw new Error(`Unexpected URL: ${url}`);
+			}
+			expect(init?.method ?? "GET").toBe("GET");
+			expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer local-key");
+			return new Response(JSON.stringify({ data: [{ id: "z-local" }, { id: "a-local" }, { id: "a-local" }] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		const result = await runLocalProviderDiscover({ modelsPath });
+
+		expect(result.ok).toBe(true);
+		expect(result.provider).toBe("local");
+		expect(result.baseUrl).toBe("http://127.0.0.1:1234/v1");
+		expect(result.models).toEqual(["a-local", "z-local"]);
+		expect(requestedUrls).toEqual(["http://127.0.0.1:1234/v1/models"]);
+	});
+
+	test("prints local discovery provider, base URL, and model ids", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					local: { openaiCompat: { baseUrl: "http://127.0.0.1:1234", apiKey: "local-key" } },
+				},
+			}),
+		);
+		using _hook = hookFetch(
+			() =>
+				new Response(JSON.stringify({ data: [{ id: "local-alpha" }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+		);
+		const captured: string[] = [];
+		const originalWrite = process.stdout.write.bind(process.stdout);
+		process.stdout.write = ((chunk: string | Uint8Array) => {
+			captured.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			return true;
+		}) as typeof process.stdout.write;
+		try {
+			await runLocalProviderDiscoverCommand({ modelsPath });
+		} finally {
+			process.stdout.write = originalWrite;
+		}
+
+		const output = captured.join("");
+		expect(output).toContain("provider=local");
+		expect(output).toContain("baseUrl=http://127.0.0.1:1234/v1");
+		expect(output).toContain("local-alpha");
+	});
+
+	test("keeps bare local-provider command defaulting to streaming smoke while exposing discovery actions", () => {
+		expect(LOCAL_PROVIDER_DEFAULT_ACTION).toBe("smoke");
+		expect(LOCAL_PROVIDER_ACTIONS).toEqual(["discover", "models", "smoke"]);
+	});
+
+	test("reports local discovery network failures clearly", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					local: { openaiCompat: { baseUrl: "http://127.0.0.1:65535/v1", apiKey: "local-key" } },
+				},
+			}),
+		);
+		using _hook = hookFetch(() => {
+			throw new Error("connection refused");
+		});
+
+		const result = await runLocalProviderDiscover({ modelsPath, timeoutMs: 25 });
+
+		expect(result.ok).toBe(false);
+		expect(result.message).toContain("model discovery failed");
+		expect(result.baseUrl).toBe("http://127.0.0.1:65535/v1");
+		expect(result.error).toContain("connection refused");
+	});
+
+	test("reports malformed local discovery JSON clearly", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					local: { openaiCompat: { baseUrl: "http://127.0.0.1:1234", apiKey: "local-key" } },
+				},
+			}),
+		);
+		using _hook = hookFetch(() => new Response("not json", { status: 200 }));
+
+		const result = await runLocalProviderDiscover({ modelsPath });
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("Failed to parse /models JSON");
+	});
+
+	test("reports malformed local discovery response shape clearly", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					local: { openaiCompat: { baseUrl: "http://127.0.0.1:1234", apiKey: "local-key" } },
+				},
+			}),
+		);
+		using _hook = hookFetch(
+			() => new Response(JSON.stringify({ models: [{ id: "not-openai-shape" }] }), { status: 200 }),
+		);
+
+		const result = await runLocalProviderDiscover({ modelsPath });
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("/models response did not include a data array");
 	});
 
 	test("does not throw when the configured local endpoint cannot be reached", async () => {


### PR DESCRIPTION
## Summary
- add `gjc local-provider discover` / `models` for configured local OpenAI-compatible providers
- keep bare `gjc local-provider` defaulting to the existing streaming smoke action
- sort/dedupe `/v1/models` ids and surface clear network / JSON / response-shape errors

## Verification
- `HOME=/tmp/gjc-test-home GJC_CODING_AGENT_DIR=/tmp/gjc-test-home/.gjc/agent bun test packages/coding-agent/test/local-provider-smoke.test.ts`
- `bunx biome check packages/coding-agent/src/cli/local-provider-smoke.ts packages/coding-agent/src/commands/local-provider.ts packages/coding-agent/test/local-provider-smoke.test.ts packages/coding-agent/CHANGELOG.md`

Closes #1247.