### PR TITLE
fix(tui): use live terminal width for prompt rendering

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Submitted user prompts now use the live terminal viewport width in wide Windows Terminal/PowerShell sessions, keeping Korean/CJK prompt wrapping responsive without changing narrow layouts (#1239).
 - Coordinator MCP now fails tmux-delivered turns that never receive a runtime prompt acknowledgement/`turn_start`, surfacing an explicit unacknowledged delivery reason instead of leaving Hermes/Oren waiting on a normal active/running state (#1237).
 - Telegram now advertises `/session_create`, `/session_recent`, `/session_close`, and `/session_resume` in the bot command menu so lifecycle control commands are discoverable from `/` autocomplete.
 

--- a/packages/coding-agent/src/modes/components/agent-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/agent-dashboard.ts
@@ -25,6 +25,7 @@ import {
 	matchesKey,
 	padding,
 	replaceTabs,
+	resolveTerminalColumns,
 	Spacer,
 	Text,
 	truncateToWidth,
@@ -870,7 +871,7 @@ export class AgentDashboard extends Container {
 	}
 
 	#uiWidth(): number {
-		return Math.max(40, process.stdout.columns ?? 100);
+		return Math.max(40, resolveTerminalColumns());
 	}
 
 	/** Rebuild layout and request a TUI render pass (for use after async state changes). */

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -15,7 +15,7 @@
  *   - Enter on main session -> close overlay (jump back)
  */
 import type { ToolResultMessage } from "@gajae-code/ai";
-import { Container, Markdown, type MarkdownTheme, matchesKey } from "@gajae-code/tui";
+import { Container, Markdown, type MarkdownTheme, matchesKey, resolveTerminalColumns } from "@gajae-code/tui";
 import { formatDuration, formatNumber, logger } from "@gajae-code/utils";
 import type { KeyId } from "../../config/keybindings";
 import { isSilentAbort } from "../../session/messages";
@@ -39,7 +39,7 @@ const INDENT = "    ";
 
 /** Compute the max content width for the current terminal, accounting for indent and chrome. */
 function contentWidth(indent = INDENT): number {
-	return Math.max(TRUNCATE_LENGTHS.SHORT, (process.stdout.columns || 80) - indent.length - 2);
+	return Math.max(TRUNCATE_LENGTHS.SHORT, resolveTerminalColumns() - indent.length - 2);
 }
 
 /** Sanitize a line for TUI display: replace tabs, then truncate to viewport width. */
@@ -390,7 +390,7 @@ export class SessionObserverOverlayComponent extends Container {
 
 	/** Render markdown text into indented lines using the theme's markdown renderer */
 	#renderMarkdownToLines(text: string, indent: string = INDENT): string[] {
-		const width = Math.max(40, (process.stdout.columns || 80) - indent.length - 4);
+		const width = Math.max(40, resolveTerminalColumns() - indent.length - 4);
 		const md = new Markdown(text, 0, 0, this.#mdTheme);
 		const rendered = md.render(width);
 		return rendered.map(line => `${indent}${line.trimEnd()}`);

--- a/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
+++ b/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
@@ -99,6 +99,33 @@ describe("redesigned interactive shell chrome", () => {
 		expect(assistant).not.toContain("▌");
 	});
 
+	it("sizes submitted Korean user prompts to the current viewport width", () => {
+		const prompt = "안녕하세요 ".repeat(30);
+		const narrowLines = new UserMessageComponent(prompt).render(80);
+		const wideLines = new UserMessageComponent(prompt).render(160);
+		const contentWidths = (lines: string[]) =>
+			lines
+				.map(line =>
+					Bun.stripANSI(line)
+						.replace(/\x1b\]133;[ABC]\x07/g, "")
+						.trimEnd(),
+				)
+				.filter(line => line.includes("안녕하세요"))
+				.map(line => visibleWidth(line));
+
+		const narrowContentWidths = contentWidths(narrowLines);
+		const wideContentWidths = contentWidths(wideLines);
+
+		expect(wideContentWidths.length).toBeLessThan(narrowContentWidths.length);
+		expect(Math.max(...wideContentWidths)).toBeGreaterThan(120);
+		for (const line of narrowLines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(80);
+		}
+		for (const line of wideLines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(160);
+		}
+	});
+
 	it("keeps the GJC forge launch surface responsive", () => {
 		const component = new WelcomeComponent("1.2.3", "gpt-5.5", "openai");
 		const lines = component.render(54);

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Resolved terminal dimensions from the live TTY window size before stream defaults so wide Windows Terminal/PowerShell sessions render against the actual viewport width (#1239).
+
 ## [0.7.4] - 2026-06-27
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -124,6 +124,46 @@ export interface Terminal {
 	get appearance(): TerminalAppearance | undefined;
 }
 
+interface TerminalSizeStream {
+	columns?: number;
+	rows?: number;
+	getWindowSize?: () => [number, number] | number[];
+}
+
+function positiveDimension(value: unknown): number | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+	const dimension = Math.trunc(value);
+	return dimension > 0 ? dimension : undefined;
+}
+
+export function resolveTerminalColumns(
+	stream: TerminalSizeStream = process.stdout,
+	envColumns: string | undefined = Bun.env.COLUMNS,
+): number {
+	try {
+		const windowSize = stream.getWindowSize?.();
+		const liveColumns = positiveDimension(windowSize?.[0]);
+		if (liveColumns !== undefined) return liveColumns;
+	} catch {
+		// Fall back below when the stream cannot report a live TTY size.
+	}
+	return positiveDimension(stream.columns) ?? positiveDimension(Number(envColumns)) ?? 80;
+}
+
+export function resolveTerminalRows(
+	stream: TerminalSizeStream = process.stdout,
+	envRows: string | undefined = Bun.env.LINES,
+): number {
+	try {
+		const windowSize = stream.getWindowSize?.();
+		const liveRows = positiveDimension(windowSize?.[1]);
+		if (liveRows !== undefined) return liveRows;
+	} catch {
+		// Fall back below when the stream cannot report a live TTY size.
+	}
+	return positiveDimension(stream.rows) ?? positiveDimension(Number(envRows)) ?? 24;
+}
+
 function isWindowsSubsystemForLinux(): boolean {
 	return process.platform === "linux" && (!!$env.WSL_DISTRO_NAME || !!$env.WSL_INTEROP);
 }
@@ -740,11 +780,11 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	get columns(): number {
-		return process.stdout.columns || Number(Bun.env.COLUMNS) || 80;
+		return resolveTerminalColumns();
 	}
 
 	get rows(): number {
-		return process.stdout.rows || Number(Bun.env.LINES) || 24;
+		return resolveTerminalRows();
 	}
 
 	moveBy(lines: number): void {

--- a/packages/tui/test/terminal-size.test.ts
+++ b/packages/tui/test/terminal-size.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { resolveTerminalColumns, resolveTerminalRows } from "../src/terminal";
+
+describe("terminal size resolution", () => {
+	it("prefers the live TTY window size over stale stream defaults", () => {
+		const stream = {
+			columns: 80,
+			rows: 24,
+			getWindowSize: () => [180, 52],
+		};
+
+		expect(resolveTerminalColumns(stream, undefined)).toBe(180);
+		expect(resolveTerminalRows(stream, undefined)).toBe(52);
+	});
+
+	it("falls back to stream and environment dimensions when live size is unavailable", () => {
+		expect(resolveTerminalColumns({ columns: 132 }, "200")).toBe(132);
+		expect(resolveTerminalRows({ rows: 40 }, "60")).toBe(40);
+		expect(resolveTerminalColumns({}, "200")).toBe(200);
+		expect(resolveTerminalRows({}, "60")).toBe(60);
+		expect(resolveTerminalColumns({}, "")).toBe(80);
+		expect(resolveTerminalRows({}, "")).toBe(24);
+	});
+});


### PR DESCRIPTION
## Summary
- resolve terminal width/height from the live TTY window size before stale stream/env defaults
- route coding-agent transcript/dashboard width helpers through the shared resolver
- add focused tests for wide Korean prompt wrapping and terminal-size fallback behavior

Fixes #1239

## Validation
- `bun test packages/tui/test/terminal-size.test.ts packages/coding-agent/test/modes/components/redesigned-shell.test.ts` — 19 pass, 0 fail
- `bun --cwd=packages/tui run check` — pass
- `bun --cwd=packages/coding-agent run check` — pass
- `bun --cwd=packages/coding-agent run build` — pass

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
