### PR TITLE
feat(coding-agent): add local provider diagnostics

### DIFF
--- a/packages/coding-agent/src/cli/local-provider-smoke.ts
+++ b/packages/coding-agent/src/cli/local-provider-smoke.ts
@@ -7,11 +7,35 @@ export interface LocalProviderSmokeCommandArgs {
 	modelsPath?: string;
 	timeoutMs?: number;
 	json?: boolean;
+	smoke?: boolean;
 }
 
 export interface LocalOpenAICompatConfig {
 	baseUrl: string;
 	apiKey?: string;
+}
+
+export type LocalProviderDiagnosticCheckName = "config" | "models" | "chat_stream";
+export type LocalProviderDiagnosticStatus = "ok" | "skipped" | "error";
+export type LocalProviderDiagnosticCategory =
+	| "auth"
+	| "timeout"
+	| "unreachable"
+	| "not_ready"
+	| "oom"
+	| "malformed_response"
+	| "http_error"
+	| "configuration"
+	| "empty_response";
+
+export interface LocalProviderDiagnosticCheck {
+	name: LocalProviderDiagnosticCheckName;
+	status: LocalProviderDiagnosticStatus;
+	message: string;
+	action?: string;
+	category?: LocalProviderDiagnosticCategory;
+	error?: string;
+	httpStatus?: number;
 }
 
 export interface LocalProviderSmokeResult {
@@ -20,6 +44,8 @@ export interface LocalProviderSmokeResult {
 	model?: string;
 	message: string;
 	error?: string;
+	category?: LocalProviderDiagnosticCategory;
+	action?: string;
 }
 
 export interface LocalProviderDiscoveryResult {
@@ -29,6 +55,26 @@ export interface LocalProviderDiscoveryResult {
 	models: string[];
 	message: string;
 	error?: string;
+	category?: LocalProviderDiagnosticCategory;
+	action?: string;
+}
+
+export interface LocalProviderStatusResult {
+	ok: boolean;
+	provider: "local";
+	baseUrl?: string;
+	model?: string;
+	models: string[];
+	checks: LocalProviderDiagnosticCheck[];
+	message: string;
+}
+
+interface ClassifiedFailure {
+	category: LocalProviderDiagnosticCategory;
+	message: string;
+	action: string;
+	error?: string;
+	httpStatus?: number;
 }
 
 const DEFAULT_TIMEOUT_MS = 3000;
@@ -90,13 +136,21 @@ async function readLocalConfig(
 	configFile.invalidate?.();
 	const loaded = configFile.tryLoad();
 	if (loaded.status === "error") {
-		return { ok: false, message: "Failed to load models config.", error: loaded.error.message };
+		return {
+			ok: false,
+			message: "Failed to load models config.",
+			error: loaded.error.message,
+			category: "configuration",
+			action: "Fix the models config file syntax, then retry the local-provider diagnostic.",
+		};
 	}
 	const localConfig = getLocalOpenAICompatConfig(loaded.value ?? undefined);
 	if (!localConfig) {
 		return {
 			ok: false,
 			message: `No local OpenAI-compatible endpoint configured. Add providers.local.openaiCompat.baseUrl to ${configFile.path()}.`,
+			category: "configuration",
+			action: "Configure providers.local.openaiCompat.baseUrl for the local server you already run.",
 		};
 	}
 	return localConfig;
@@ -112,13 +166,132 @@ function toErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
+async function responsePreview(response: Response): Promise<string> {
+	const text = await response.text().catch(() => "");
+	return text.slice(0, 500);
+}
+
+function bodyLooksLike(text: string | undefined, needles: readonly string[]): boolean {
+	const lower = (text ?? "").toLowerCase();
+	return needles.some(needle => lower.includes(needle));
+}
+
+function classifyHttpFailure(context: "models" | "chat_stream", status: number, body: string): ClassifiedFailure {
+	if (status === 401 || status === 403) {
+		return {
+			category: "auth",
+			httpStatus: status,
+			message: `${context === "models" ? "GET /v1/models" : "Streaming chat smoke"} authentication failed.`,
+			action:
+				"Check providers.local.openaiCompat.apiKey/apiKeyEnv, or remove auth if the local server does not require it.",
+			error: `HTTP ${status}${body ? `: ${body}` : ""}`,
+		};
+	}
+	if (bodyLooksLike(body, ["out of memory", "oom", "cuda out", "insufficient memory"])) {
+		return {
+			category: "oom",
+			httpStatus: status,
+			message: `${context === "models" ? "GET /v1/models" : "Streaming chat smoke"} reported an out-of-memory condition.`,
+			action: "Free GPU/CPU memory, lower the model/context size, or unload another model before retrying.",
+			error: `HTTP ${status}${body ? `: ${body}` : ""}`,
+		};
+	}
+	if (
+		status === 408 ||
+		status === 409 ||
+		status === 425 ||
+		status === 429 ||
+		status === 503 ||
+		status === 504 ||
+		bodyLooksLike(body, ["loading", "warming", "not ready", "initializing", "starting", "model is loading"])
+	) {
+		return {
+			category: "not_ready",
+			httpStatus: status,
+			message: `${context === "models" ? "GET /v1/models" : "Streaming chat smoke"} reached the server, but it is not ready.`,
+			action: "Wait for the local server/model load to finish, verify the selected model is loaded, then retry.",
+			error: `HTTP ${status}${body ? `: ${body}` : ""}`,
+		};
+	}
+	return {
+		category: "http_error",
+		httpStatus: status,
+		message: `${context === "models" ? "GET /v1/models" : "Streaming chat smoke"} returned HTTP ${status}.`,
+		action:
+			"Check the local server logs and confirm the configured base URL points at an OpenAI-compatible /v1 endpoint.",
+		error: `HTTP ${status}${body ? `: ${body}` : ""}`,
+	};
+}
+
+function classifyThrownFailure(
+	context: "models" | "chat_stream",
+	error: unknown,
+	timeoutMs: number,
+): ClassifiedFailure {
+	const message = toErrorMessage(error);
+	const name = error instanceof Error ? error.name : "";
+	if (name === "AbortError" || name === "TimeoutError" || message.toLowerCase().includes("abort")) {
+		return {
+			category: "timeout",
+			message: `${context === "models" ? "GET /v1/models" : "Streaming chat smoke"} timed out after ${timeoutMs}ms.`,
+			action:
+				"Confirm the local server is running and responsive; if it is loading a model, retry after it is ready or pass a slightly larger --timeout-ms.",
+			error: message,
+		};
+	}
+	if (
+		bodyLooksLike(message, [
+			"connection refused",
+			"econnrefused",
+			"couldn't connect",
+			"failed to connect",
+			"connection reset",
+			"enotfound",
+			"fetch failed",
+		])
+	) {
+		return {
+			category: "unreachable",
+			message: `${context === "models" ? "GET /v1/models" : "Streaming chat smoke"} could not reach the configured endpoint.`,
+			action:
+				"Start the local OpenAI-compatible server or update providers.local.openaiCompat.baseUrl to the listening host/port.",
+			error: message,
+		};
+	}
+	if (bodyLooksLike(message, ["out of memory", "oom", "cuda out", "insufficient memory"])) {
+		return {
+			category: "oom",
+			message: `${context === "models" ? "GET /v1/models" : "Streaming chat smoke"} reported an out-of-memory condition.`,
+			action: "Free GPU/CPU memory, lower the model/context size, or unload another model before retrying.",
+			error: message,
+		};
+	}
+	return {
+		category: "http_error",
+		message: `${context === "models" ? "GET /v1/models" : "Streaming chat smoke"} failed.`,
+		action: "Check the local server logs and retry the diagnostic after the endpoint is healthy.",
+		error: message,
+	};
+}
+
+function malformedFailure(error: unknown): ClassifiedFailure {
+	return {
+		category: "malformed_response",
+		message: "GET /v1/models returned a malformed OpenAI-compatible response.",
+		action:
+			"Confirm the endpoint serves OpenAI-compatible JSON shaped like { data: [{ id: string }] } at /v1/models.",
+		error: toErrorMessage(error),
+	};
+}
+
 async function fetchLocalModelIds(config: LocalOpenAICompatConfig, timeoutMs: number): Promise<string[]> {
 	const response = await fetch(`${config.baseUrl}/models`, {
 		headers: buildHeaders(config.apiKey),
 		signal: AbortSignal.timeout(timeoutMs),
 	});
 	if (!response.ok) {
-		throw new Error(`HTTP ${response.status} from ${config.baseUrl}/models`);
+		const body = await responsePreview(response);
+		throw new Error(classifyHttpFailure("models", response.status, body).error);
 	}
 	let payload: unknown;
 	try {
@@ -127,6 +300,47 @@ async function fetchLocalModelIds(config: LocalOpenAICompatConfig, timeoutMs: nu
 		throw new Error(`Failed to parse /models JSON: ${toErrorMessage(error)}`);
 	}
 	return extractModelIds(payload);
+}
+
+async function diagnoseLocalModels(
+	config: LocalOpenAICompatConfig,
+	timeoutMs: number,
+): Promise<{ models: string[]; check: LocalProviderDiagnosticCheck }> {
+	try {
+		const response = await fetch(`${config.baseUrl}/models`, {
+			headers: buildHeaders(config.apiKey),
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+		if (!response.ok) {
+			const body = await responsePreview(response);
+			const failure = classifyHttpFailure("models", response.status, body);
+			return { models: [], check: { name: "models", status: "error", ...failure } };
+		}
+		let payload: unknown;
+		try {
+			payload = await response.json();
+		} catch (error) {
+			const failure = malformedFailure(new Error(`Failed to parse /models JSON: ${toErrorMessage(error)}`));
+			return { models: [], check: { name: "models", status: "error", ...failure } };
+		}
+		try {
+			const models = extractModelIds(payload);
+			return {
+				models,
+				check: {
+					name: "models",
+					status: "ok",
+					message: `GET /v1/models succeeded and returned ${models.length} model${models.length === 1 ? "" : "s"}.`,
+				},
+			};
+		} catch (error) {
+			const failure = malformedFailure(error);
+			return { models: [], check: { name: "models", status: "error", ...failure } };
+		}
+	} catch (error) {
+		const failure = classifyThrownFailure("models", error, timeoutMs);
+		return { models: [], check: { name: "models", status: "error", ...failure } };
+	}
 }
 
 async function discoverFirstModel(config: LocalOpenAICompatConfig, timeoutMs: number): Promise<string> {
@@ -157,8 +371,52 @@ async function readStreamingBody(response: Response): Promise<number> {
 	return chunks;
 }
 
+async function diagnoseChatStream(
+	config: LocalOpenAICompatConfig,
+	model: string,
+	timeoutMs: number,
+): Promise<LocalProviderDiagnosticCheck> {
+	try {
+		const response = await fetch(`${config.baseUrl}/chat/completions`, {
+			method: "POST",
+			headers: buildHeaders(config.apiKey),
+			body: JSON.stringify({
+				model,
+				messages: [{ role: "user", content: DEFAULT_SMOKE_PROMPT }],
+				stream: true,
+				max_tokens: 16,
+			}),
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+		if (!response.ok) {
+			const body = await responsePreview(response);
+			const failure = classifyHttpFailure("chat_stream", response.status, body);
+			return { name: "chat_stream", status: "error", ...failure };
+		}
+		const chunks = await readStreamingBody(response);
+		if (chunks === 0) {
+			return {
+				name: "chat_stream",
+				status: "error",
+				category: "empty_response",
+				message: "Streaming chat smoke reached the server but returned no body chunks.",
+				action:
+					"Check whether the selected model supports streaming chat completions and inspect the local server logs.",
+			};
+		}
+		return {
+			name: "chat_stream",
+			status: "ok",
+			message: `Streaming chat smoke succeeded for ${model} (${chunks} chunk${chunks === 1 ? "" : "s"}).`,
+		};
+	} catch (error) {
+		const failure = classifyThrownFailure("chat_stream", error, timeoutMs);
+		return { name: "chat_stream", status: "error", ...failure };
+	}
+}
+
 export async function runLocalProviderDiscover(
-	cmd: Omit<LocalProviderSmokeCommandArgs, "model">,
+	cmd: Omit<LocalProviderSmokeCommandArgs, "model" | "smoke">,
 ): Promise<LocalProviderDiscoveryResult> {
 	const timeoutMs = cmd.timeoutMs && cmd.timeoutMs > 0 ? cmd.timeoutMs : DEFAULT_TIMEOUT_MS;
 	const configResult = await readLocalConfig(cmd.modelsPath);
@@ -169,28 +427,94 @@ export async function runLocalProviderDiscover(
 			models: [],
 			message: configResult.message,
 			error: configResult.error,
+			category: configResult.category,
+			action: configResult.action,
 		};
 	}
 
-	try {
-		const models = await fetchLocalModelIds(configResult, timeoutMs);
+	const diagnostics = await diagnoseLocalModels(configResult, timeoutMs);
+	if (diagnostics.check.status === "ok") {
 		return {
 			ok: true,
 			provider: "local",
 			baseUrl: configResult.baseUrl,
-			models,
-			message: `Discovered ${models.length} model${models.length === 1 ? "" : "s"}.`,
-		};
-	} catch (error) {
-		return {
-			ok: false,
-			provider: "local",
-			baseUrl: configResult.baseUrl,
-			models: [],
-			message: "Local provider model discovery failed.",
-			error: toErrorMessage(error),
+			models: diagnostics.models,
+			message: `Discovered ${diagnostics.models.length} model${diagnostics.models.length === 1 ? "" : "s"}.`,
 		};
 	}
+	return {
+		ok: false,
+		provider: "local",
+		baseUrl: configResult.baseUrl,
+		models: [],
+		message: "Local provider model discovery failed.",
+		error: diagnostics.check.error,
+		category: diagnostics.check.category,
+		action: diagnostics.check.action,
+	};
+}
+
+export async function runLocalProviderStatus(cmd: LocalProviderSmokeCommandArgs): Promise<LocalProviderStatusResult> {
+	const timeoutMs = cmd.timeoutMs && cmd.timeoutMs > 0 ? cmd.timeoutMs : DEFAULT_TIMEOUT_MS;
+	const checks: LocalProviderDiagnosticCheck[] = [];
+	const configResult = await readLocalConfig(cmd.modelsPath);
+	if ("ok" in configResult) {
+		checks.push({
+			name: "config",
+			status: "error",
+			message: configResult.message,
+			error: configResult.error,
+			category: configResult.category,
+			action: configResult.action,
+		});
+		return { ok: false, provider: "local", models: [], checks, message: "Local provider diagnostics failed." };
+	}
+
+	checks.push({
+		name: "config",
+		status: "ok",
+		message: "Found providers.local.openaiCompat without mutating config.",
+	});
+	const modelDiagnostics = await diagnoseLocalModels(configResult, timeoutMs);
+	checks.push(modelDiagnostics.check);
+	let model = cmd.model?.trim();
+	const shouldSmoke = Boolean(cmd.smoke || model);
+	if (!shouldSmoke) {
+		checks.push({
+			name: "chat_stream",
+			status: "skipped",
+			message: "Streaming chat smoke skipped; pass --smoke or --model to run it.",
+		});
+	} else if (modelDiagnostics.check.status !== "ok") {
+		checks.push({
+			name: "chat_stream",
+			status: "skipped",
+			message: "Streaming chat smoke skipped because GET /v1/models did not pass.",
+			action: "Fix the /v1/models diagnostic first, then retry with --smoke or --model.",
+		});
+	} else {
+		model = model || modelDiagnostics.models[0];
+		if (!model) {
+			checks.push({
+				name: "chat_stream",
+				status: "skipped",
+				message: "Streaming chat smoke skipped because no model id was available.",
+				action: "Pass --model with a loaded local model id.",
+			});
+		} else {
+			checks.push(await diagnoseChatStream(configResult, model, timeoutMs));
+		}
+	}
+	const ok = checks.every(check => check.status !== "error");
+	return {
+		ok,
+		provider: "local",
+		baseUrl: configResult.baseUrl,
+		model,
+		models: modelDiagnostics.models,
+		checks,
+		message: ok ? "Local provider diagnostics passed." : "Local provider diagnostics failed.",
+	};
 }
 
 export async function runLocalProviderSmoke(cmd: LocalProviderSmokeCommandArgs): Promise<LocalProviderSmokeResult> {
@@ -201,55 +525,40 @@ export async function runLocalProviderSmoke(cmd: LocalProviderSmokeCommandArgs):
 	let model = cmd.model;
 	try {
 		model = model?.trim() || (await discoverFirstModel(configResult, timeoutMs));
-		const response = await fetch(`${configResult.baseUrl}/chat/completions`, {
-			method: "POST",
-			headers: buildHeaders(configResult.apiKey),
-			body: JSON.stringify({
-				model,
-				messages: [{ role: "user", content: DEFAULT_SMOKE_PROMPT }],
-				stream: true,
-				max_tokens: 16,
-			}),
-			signal: AbortSignal.timeout(timeoutMs),
-		});
-		if (!response.ok) {
-			const text = await response.text().catch(() => "");
+		const check = await diagnoseChatStream(configResult, model, timeoutMs);
+		if (check.status === "ok") {
 			return {
-				ok: false,
+				ok: true,
 				baseUrl: configResult.baseUrl,
 				model,
-				message: "Local provider streaming smoke request failed.",
-				error: `HTTP ${response.status}${text ? `: ${text.slice(0, 500)}` : ""}`,
+				message: check.message,
 			};
 		}
-		const chunks = await readStreamingBody(response);
-		if (chunks === 0) {
-			return {
-				ok: false,
-				baseUrl: configResult.baseUrl,
-				model,
-				message: "Local provider returned an empty streaming response.",
-			};
-		}
-		return {
-			ok: true,
-			baseUrl: configResult.baseUrl,
-			model,
-			message: `Local provider streaming smoke succeeded (${chunks} chunk${chunks === 1 ? "" : "s"}).`,
-		};
-	} catch (error) {
 		return {
 			ok: false,
 			baseUrl: configResult.baseUrl,
 			model,
-			message: "Local provider streaming smoke request failed.",
-			error: toErrorMessage(error),
+			message: check.message,
+			error: check.error,
+			category: check.category,
+			action: check.action,
+		};
+	} catch (error) {
+		const failure = classifyThrownFailure("chat_stream", error, timeoutMs);
+		return {
+			ok: false,
+			baseUrl: configResult.baseUrl,
+			model,
+			message: failure.message,
+			error: failure.error,
+			category: failure.category,
+			action: failure.action,
 		};
 	}
 }
 
 export async function runLocalProviderDiscoverCommand(
-	cmd: Omit<LocalProviderSmokeCommandArgs, "model">,
+	cmd: Omit<LocalProviderSmokeCommandArgs, "model" | "smoke">,
 ): Promise<void> {
 	const result = await runLocalProviderDiscover(cmd);
 	if (cmd.json) {
@@ -264,6 +573,40 @@ export async function runLocalProviderDiscoverCommand(
 		process.stderr.write(`${chalk.red("error")} ${result.message}\n`);
 		process.stderr.write(`${chalk.dim(`provider=${result.provider} baseUrl=${result.baseUrl ?? "<unknown>"}`)}\n`);
 		if (result.error) process.stderr.write(`${chalk.dim(result.error)}\n`);
+		if (result.action) process.stderr.write(`${chalk.dim(`action: ${result.action}`)}\n`);
+	}
+	if (!result.ok) process.exitCode = 1;
+}
+
+function renderStatusCheck(check: LocalProviderDiagnosticCheck): string {
+	const label =
+		check.status === "ok"
+			? chalk.green("ok")
+			: check.status === "skipped"
+				? chalk.yellow("skip")
+				: chalk.red("error");
+	const suffix = check.category ? chalk.dim(` [${check.category}]`) : "";
+	return `${label} ${check.name}: ${check.message}${suffix}\n`;
+}
+
+export async function runLocalProviderStatusCommand(cmd: LocalProviderSmokeCommandArgs): Promise<void> {
+	const result = await runLocalProviderStatus(cmd);
+	if (cmd.json) {
+		process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+	} else {
+		const stream = result.ok ? process.stdout : process.stderr;
+		stream.write(`${result.ok ? chalk.green("ok") : chalk.red("error")} ${result.message}\n`);
+		stream.write(
+			`${chalk.dim(`provider=${result.provider} endpoint=${result.baseUrl ?? "<unknown>"}${result.model ? ` model=${result.model}` : ""}`)}\n`,
+		);
+		for (const check of result.checks) {
+			stream.write(renderStatusCheck(check));
+			if (check.error) stream.write(`${chalk.dim(`  ${check.error}`)}\n`);
+			if (check.action) stream.write(`${chalk.dim(`  action: ${check.action}`)}\n`);
+		}
+		if (result.models.length > 0) {
+			stream.write(`${chalk.dim(`models: ${result.models.join(", ")}`)}\n`);
+		}
 	}
 	if (!result.ok) process.exitCode = 1;
 }
@@ -283,6 +626,7 @@ export async function runLocalProviderSmokeCommand(cmd: LocalProviderSmokeComman
 			);
 		}
 		if (result.error) process.stderr.write(`${chalk.dim(result.error)}\n`);
+		if (result.action) process.stderr.write(`${chalk.dim(`action: ${result.action}`)}\n`);
 	}
 	if (!result.ok) process.exitCode = 1;
 }

--- a/packages/coding-agent/src/commands/local-provider.ts
+++ b/packages/coding-agent/src/commands/local-provider.ts
@@ -2,13 +2,17 @@
  * Test configured local OpenAI-compatible providers.
  */
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
-import { runLocalProviderDiscoverCommand, runLocalProviderSmokeCommand } from "../cli/local-provider-smoke";
+import {
+	runLocalProviderDiscoverCommand,
+	runLocalProviderSmokeCommand,
+	runLocalProviderStatusCommand,
+} from "../cli/local-provider-smoke";
 
-export const LOCAL_PROVIDER_ACTIONS = ["discover", "models", "smoke"] as const;
-export const LOCAL_PROVIDER_DEFAULT_ACTION = "smoke";
+export const LOCAL_PROVIDER_ACTIONS = ["status", "diagnose", "discover", "models", "smoke"] as const;
+export const LOCAL_PROVIDER_DEFAULT_ACTION = "status";
 
 export default class LocalProvider extends Command {
-	static description = "Discover or test configured local OpenAI-compatible providers";
+	static description = "Diagnose configured local OpenAI-compatible providers";
 
 	static args = {
 		action: Args.string({ description: "Action", required: false, options: LOCAL_PROVIDER_ACTIONS }),
@@ -18,12 +22,23 @@ export default class LocalProvider extends Command {
 		model: Flags.string({ description: "Model id to use for smoke (otherwise uses the first /models id)" }),
 		"models-path": Flags.string({ description: "Override models config path" }),
 		"timeout-ms": Flags.integer({ description: "Request timeout in milliseconds" }),
+		smoke: Flags.boolean({ description: "Run optional streaming chat smoke during status/diagnose" }),
 		json: Flags.boolean({ description: "Output JSON" }),
 	};
 
 	async run(): Promise<void> {
 		const { args, flags } = await this.parse(LocalProvider);
 		const action = args.action ?? LOCAL_PROVIDER_DEFAULT_ACTION;
+		if (action === "status" || action === "diagnose") {
+			await runLocalProviderStatusCommand({
+				model: flags.model,
+				modelsPath: flags["models-path"],
+				timeoutMs: flags["timeout-ms"],
+				smoke: flags.smoke,
+				json: flags.json,
+			});
+			return;
+		}
 		if (action === "discover" || action === "models") {
 			await runLocalProviderDiscoverCommand({
 				modelsPath: flags["models-path"],

--- a/packages/coding-agent/test/local-provider-smoke.test.ts
+++ b/packages/coding-agent/test/local-provider-smoke.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -6,8 +7,9 @@ import {
 	runLocalProviderDiscover,
 	runLocalProviderDiscoverCommand,
 	runLocalProviderSmoke,
+	runLocalProviderStatus,
 } from "@gajae-code/coding-agent/cli/local-provider-smoke";
-import { hookFetch, Snowflake } from "@gajae-code/utils";
+import { hookFetch } from "@gajae-code/utils/hook-fetch";
 import { LOCAL_PROVIDER_ACTIONS, LOCAL_PROVIDER_DEFAULT_ACTION } from "../src/commands/local-provider";
 
 describe("local provider streaming smoke", () => {
@@ -15,7 +17,7 @@ describe("local provider streaming smoke", () => {
 	let modelsPath: string;
 
 	beforeEach(() => {
-		tempDir = path.join(os.tmpdir(), `gjc-local-provider-smoke-${Snowflake.next()}`);
+		tempDir = path.join(os.tmpdir(), `gjc-local-provider-smoke-${crypto.randomUUID()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
 		modelsPath = path.join(tempDir, "models.json");
 	});
@@ -102,9 +104,130 @@ describe("local provider streaming smoke", () => {
 		expect(output).toContain("local-alpha");
 	});
 
-	test("keeps bare local-provider command defaulting to streaming smoke while exposing discovery actions", () => {
-		expect(LOCAL_PROVIDER_DEFAULT_ACTION).toBe("smoke");
-		expect(LOCAL_PROVIDER_ACTIONS).toEqual(["discover", "models", "smoke"]);
+	test("keeps bare local-provider command defaulting to status while exposing diagnostics actions", () => {
+		expect(LOCAL_PROVIDER_DEFAULT_ACTION).toBe("status");
+		expect(LOCAL_PROVIDER_ACTIONS).toEqual(["status", "diagnose", "discover", "models", "smoke"]);
+	});
+
+	test("reports status without streaming smoke and without mutating config", async () => {
+		const configText = JSON.stringify({
+			providers: {
+				local: { openaiCompat: { baseUrl: "http://127.0.0.1:1234/", apiKey: "local-key" } },
+			},
+		});
+		fs.writeFileSync(modelsPath, configText);
+		const requestedUrls: string[] = [];
+		using _hook = hookFetch((input, init) => {
+			const url = String(input);
+			requestedUrls.push(url);
+			expect(init?.method ?? "GET").toBe("GET");
+			return new Response(JSON.stringify({ data: [{ id: "local-alpha" }] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		const result = await runLocalProviderStatus({ modelsPath });
+
+		expect(result.ok).toBe(true);
+		expect(result.baseUrl).toBe("http://127.0.0.1:1234/v1");
+		expect(result.models).toEqual(["local-alpha"]);
+		expect(result.checks.map(check => [check.name, check.status])).toEqual([
+			["config", "ok"],
+			["models", "ok"],
+			["chat_stream", "skipped"],
+		]);
+		expect(requestedUrls).toEqual(["http://127.0.0.1:1234/v1/models"]);
+		expect(fs.readFileSync(modelsPath, "utf8")).toBe(configText);
+	});
+
+	test("runs optional status streaming smoke against the discovered model", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					local: { openaiCompat: { baseUrl: "http://127.0.0.1:1234", apiKey: "local-key" } },
+				},
+			}),
+		);
+		const requestedUrls: string[] = [];
+		using _hook = hookFetch((input, init) => {
+			const url = String(input);
+			requestedUrls.push(url);
+			if (url.endsWith("/models")) {
+				return new Response(JSON.stringify({ data: [{ id: "local-alpha" }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			expect(url).toBe("http://127.0.0.1:1234/v1/chat/completions");
+			const body = JSON.parse(String(init?.body)) as { model: string; stream: boolean };
+			expect(body.model).toBe("local-alpha");
+			expect(body.stream).toBe(true);
+			return new Response(
+				new ReadableStream({
+					start(controller) {
+						controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+						controller.close();
+					},
+				}),
+				{ status: 200 },
+			);
+		});
+
+		const result = await runLocalProviderStatus({ modelsPath, smoke: true });
+
+		expect(result.ok).toBe(true);
+		expect(result.model).toBe("local-alpha");
+		expect(result.checks.map(check => [check.name, check.status])).toEqual([
+			["config", "ok"],
+			["models", "ok"],
+			["chat_stream", "ok"],
+		]);
+		expect(requestedUrls).toEqual(["http://127.0.0.1:1234/v1/models", "http://127.0.0.1:1234/v1/chat/completions"]);
+	});
+
+	test("classifies status authentication failures from /v1/models", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					local: { openaiCompat: { baseUrl: "http://127.0.0.1:1234", apiKey: "bad-key" } },
+				},
+			}),
+		);
+		using _hook = hookFetch(() => new Response("unauthorized", { status: 401 }));
+
+		const result = await runLocalProviderStatus({ modelsPath, smoke: true });
+
+		expect(result.ok).toBe(false);
+		expect(result.checks.find(check => check.name === "models")?.category).toBe("auth");
+		expect(result.checks.find(check => check.name === "chat_stream")?.status).toBe("skipped");
+	});
+
+	test("classifies streaming smoke not-ready failures", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					local: { openaiCompat: { baseUrl: "http://127.0.0.1:1234", apiKey: "local-key" } },
+				},
+			}),
+		);
+		using _hook = hookFetch(input => {
+			const url = String(input);
+			if (url.endsWith("/models")) {
+				return new Response(JSON.stringify({ data: [{ id: "local-alpha" }] }), { status: 200 });
+			}
+			return new Response("model is loading", { status: 503 });
+		});
+
+		const result = await runLocalProviderStatus({ modelsPath, smoke: true });
+
+		expect(result.ok).toBe(false);
+		const streamCheck = result.checks.find(check => check.name === "chat_stream");
+		expect(streamCheck?.status).toBe("error");
+		expect(streamCheck?.category).toBe("not_ready");
 	});
 
 	test("reports local discovery network failures clearly", async () => {
@@ -180,7 +303,8 @@ describe("local provider streaming smoke", () => {
 		const result = await runLocalProviderSmoke({ modelsPath, model: "local-model", timeoutMs: 25 });
 
 		expect(result.ok).toBe(false);
-		expect(result.message).toContain("smoke request failed");
+		expect(result.category).toBe("unreachable");
+		expect(result.message).toContain("could not reach");
 		expect(result.error).toContain("connection refused");
 	});
 


### PR DESCRIPTION
## Summary
- add `local-provider status` / `diagnose` for configured local OpenAI-compatible endpoints
- report `/v1/models` reachability, model discovery, optional streaming chat smoke, and actionable failure categories
- keep diagnostics bounded, repeatable, and config read-only

Fixes #1248

## Validation
- `bun test packages/coding-agent/test/local-provider-smoke.test.ts` — 13 pass, 0 fail

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
