### PR TITLE
feat(coding-agent): fallback from unavailable local providers

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -526,6 +526,15 @@ export interface SessionStats {
 type RetryFallbackChains = Record<string, string[]>;
 
 type RetryFallbackRevertPolicy = "never" | "cooldown-expiry";
+type RetryErrorClassification =
+	| "none"
+	| "overflow"
+	| "terminal"
+	| "usage_limit"
+	| "first_event_timeout"
+	| "transient"
+	| "local_unavailable"
+	| "unknown";
 
 interface RetryFallbackSelector {
 	raw: string;
@@ -561,6 +570,37 @@ function formatRetryFallbackSelector(model: Model, thinkingLevel: ThinkingLevel 
 
 function formatRetryFallbackBaseSelector(selector: RetryFallbackSelector): string {
 	return `${selector.provider}/${selector.id}`;
+}
+
+function isLocalModelEndpoint(model: Model | undefined): boolean {
+	if (!model) return false;
+	if (model.provider === "ollama" || model.provider === "lm-studio" || model.provider === "llama.cpp") {
+		return true;
+	}
+	try {
+		const hostname = new URL(model.baseUrl).hostname.toLowerCase();
+		if (
+			hostname === "localhost" ||
+			hostname === "0.0.0.0" ||
+			hostname === "::1" ||
+			hostname === "[::1]" ||
+			hostname.endsWith(".local")
+		) {
+			return true;
+		}
+		if (/^127\./.test(hostname) || /^10\./.test(hostname) || /^192\.168\./.test(hostname)) {
+			return true;
+		}
+		const private172 = /^172\.(\d{1,2})\./.exec(hostname);
+		if (private172) {
+			const secondOctet = Number(private172[1]);
+			return secondOctet >= 16 && secondOctet <= 31;
+		}
+	} catch {
+		// A malformed base URL is configuration, not availability. Keep it visible.
+		return false;
+	}
+	return false;
 }
 
 const IRC_REPLY_MAX_BYTES = 4096;
@@ -8221,6 +8261,12 @@ export class AgentSession {
 	 */
 	#isRetryableError(message: AssistantMessage): boolean {
 		const classification = this.#classifyErrorForRetry(message);
+		if (classification === "local_unavailable") {
+			return this.#hasRetryFallbackCandidate({
+				currentSelector: this.model ? formatRetryFallbackSelector(this.model, this.thinkingLevel) : undefined,
+				requireNonLocal: true,
+			});
+		}
 		return (
 			classification === "usage_limit" ||
 			classification === "transient" ||
@@ -8258,6 +8304,12 @@ export class AgentSession {
 		// message and the per-provider variants
 		// ("<Provider> stream timed out while waiting for the first event").
 		return /timed?\s*out while waiting for the first event|timeout waiting for first/i.test(errorMessage);
+	}
+
+	#isLocalProviderAvailabilityErrorMessage(errorMessage: string): boolean {
+		return /connection.?refused|econnrefused|timed?\s*out|timeout|fetch failed|network.?error|socket hang up|terminated|service.?unavailable|server.?error|internal.?error|503|model_not_found|model not found|no such model|unknown model|model .*not.*(found|available|loaded)|not ready|not.?ready|warming|loading|currently loading|try again|out of memory|\boom\b|memory guard|insufficient memory|not enough memory|failed to allocate|kv.?cache|malformed (stream|streaming|sse)|invalid (stream|streaming|sse)|stream envelope error|unexpected end of (json|input)|unterminated json|no error details in response/i.test(
+			errorMessage,
+		);
 	}
 
 	/**
@@ -8303,13 +8355,14 @@ export class AgentSession {
 	 * -> usage_limit (rotation) -> first_event_timeout (bounded retry) ->
 	 * transient (retry) -> unknown (retry).
 	 */
-	#classifyErrorForRetry(
-		message: AssistantMessage,
-	): "none" | "overflow" | "terminal" | "usage_limit" | "first_event_timeout" | "transient" | "unknown" {
+	#classifyErrorForRetry(message: AssistantMessage): RetryErrorClassification {
 		if (message.stopReason !== "error" || !message.errorMessage) return "none";
 		const contextWindow = this.model?.contextWindow ?? 0;
 		if (isContextOverflow(message, contextWindow)) return "overflow";
 		const err = message.errorMessage;
+		if (isLocalModelEndpoint(this.model) && this.#isLocalProviderAvailabilityErrorMessage(err)) {
+			return "local_unavailable";
+		}
 		// Stream-envelope errors are only transient in the pre-message_start
 		// variant; any other envelope failure is structural and must surface.
 		if (/anthropic stream envelope error:/i.test(err)) {
@@ -8444,6 +8497,20 @@ export class AgentSession {
 		return chain;
 	}
 
+	#hasRetryFallbackCandidate(options: { currentSelector: string | undefined; requireNonLocal?: boolean }): boolean {
+		if (!options.currentSelector) return false;
+		const role = this.#activeRetryFallback?.role ?? this.#resolveRetryFallbackRole(options.currentSelector);
+		if (!role) return false;
+		for (const selector of this.#findRetryFallbackCandidates(role, options.currentSelector)) {
+			if (this.#isRetryFallbackSelectorSuppressed(selector)) continue;
+			const candidate = this.#modelRegistry.find(selector.provider, selector.id);
+			if (!candidate) continue;
+			if (options.requireNonLocal && isLocalModelEndpoint(candidate)) continue;
+			return true;
+		}
+		return false;
+	}
+
 	#findRetryFallbackCandidates(role: string, currentSelector: string): RetryFallbackSelector[] {
 		const chain = this.#getRetryFallbackEffectiveChain(role);
 		if (chain.length <= 1) return [];
@@ -8497,7 +8564,7 @@ export class AgentSession {
 		});
 	}
 
-	async #tryRetryModelFallback(currentSelector: string): Promise<boolean> {
+	async #tryRetryModelFallback(currentSelector: string, options?: { requireNonLocal?: boolean }): Promise<boolean> {
 		const role = this.#activeRetryFallback?.role ?? this.#resolveRetryFallbackRole(currentSelector);
 		if (!role) return false;
 
@@ -8505,6 +8572,7 @@ export class AgentSession {
 			if (this.#isRetryFallbackSelectorSuppressed(selector)) continue;
 			const candidate = this.#modelRegistry.find(selector.provider, selector.id);
 			if (!candidate) continue;
+			if (options?.requireNonLocal && isLocalModelEndpoint(candidate)) continue;
 			const apiKey = await this.#modelRegistry.getApiKey(candidate, this.sessionId);
 			if (!apiKey) continue;
 			await this.#applyRetryFallbackCandidate(role, selector, currentSelector);
@@ -8615,6 +8683,7 @@ export class AgentSession {
 		if (!retrySettings.enabled) return false;
 		const retryClassification = this.#classifyErrorForRetry(message);
 		const unboundedClass = retryClassification === "transient" || retryClassification === "unknown";
+		const localUnavailable = retryClassification === "local_unavailable";
 
 		const generation = this.#promptGeneration;
 		this.#retryAttempt++;
@@ -8668,7 +8737,7 @@ export class AgentSession {
 		const currentSelector = this.model ? formatRetryFallbackSelector(this.model, this.thinkingLevel) : undefined;
 		if (!switchedCredential && currentSelector) {
 			this.#noteRetryFallbackCooldown(currentSelector, parsedRetryAfterMs, errorMessage);
-			switchedModel = await this.#tryRetryModelFallback(currentSelector);
+			switchedModel = await this.#tryRetryModelFallback(currentSelector, { requireNonLocal: localUnavailable });
 			if (switchedModel) {
 				delayMs = 0;
 			} else if (parsedRetryAfterMs && parsedRetryAfterMs > delayMs) {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -63,7 +63,11 @@ function createFallbackAgent(primaryModel: Model, requestedModels: string[]): Ag
 	});
 }
 
-function createCachedLocalModel(provider: "ollama" | "lm-studio", id: string, baseUrl: string): Model<"openai-responses"> {
+function createCachedLocalModel(
+	provider: "ollama" | "lm-studio",
+	id: string,
+	baseUrl: string,
+): Model<"openai-responses"> {
 	return {
 		id,
 		name: id,
@@ -262,10 +266,7 @@ describe("AgentSession retry fallback", () => {
 			"retry.baseDelayMs": 5,
 			"retry.maxRetries": 1,
 			"retry.fallbackChains": {
-				default: [
-					`${localFallback.provider}/${localFallback.id}`,
-					`${cloudFallback.provider}/${cloudFallback.id}`,
-				],
+				default: [`${localFallback.provider}/${localFallback.id}`, `${cloudFallback.provider}/${cloudFallback.id}`],
 			},
 		});
 		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
@@ -324,7 +325,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const mock = createMockModel({ handler: () => ({ throw: "fetch failed: connect ECONNREFUSED 127.0.0.1:11434" }) });
+		const mock = createMockModel({
+			handler: () => ({ throw: "fetch failed: connect ECONNREFUSED 127.0.0.1:11434" }),
+		});
 		const agent = new Agent({
 			getApiKey: provider => `${provider}-test-key`,
 			initialState: {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -63,6 +63,33 @@ function createFallbackAgent(primaryModel: Model, requestedModels: string[]): Ag
 	});
 }
 
+function createCachedLocalModel(provider: "ollama" | "lm-studio", id: string, baseUrl: string): Model<"openai-responses"> {
+	return {
+		id,
+		name: id,
+		api: "openai-responses",
+		provider,
+		baseUrl,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	};
+}
+
+function seedLocalProviderCache(
+	tempDir: TempDir,
+	authStorage: AuthStorage,
+	models: Model<"openai-responses">[],
+): ModelRegistry {
+	const cacheDbPath = path.join(tempDir.path(), "models.db");
+	for (const model of models) {
+		writeModelCache(model.provider, Date.now(), [model], true, "", cacheDbPath);
+	}
+	return new ModelRegistry(authStorage, path.join(tempDir.path(), "models.json"));
+}
+
 describe("AgentSession retry fallback", () => {
 	let tempDir: TempDir;
 	let authStorage: AuthStorage;
@@ -194,6 +221,157 @@ describe("AgentSession retry fallback", () => {
 				role: "default",
 			},
 		]);
+	});
+
+	it("explicitly falls back from an unavailable local provider to the first non-local configured fallback", async () => {
+		const primaryModel = createCachedLocalModel("ollama", "qwen-local", "http://127.0.0.1:11434/v1");
+		const localFallback = createCachedLocalModel("lm-studio", "backup-local", "http://localhost:1234/v1");
+		const cloudFallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!cloudFallback) {
+			throw new Error("Expected bundled OpenAI fallback model to exist");
+		}
+		modelRegistry = seedLocalProviderCache(tempDir, authStorage, [primaryModel, localFallback]);
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const fallbackSucceededEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_succeeded" }>> = [];
+		const mock = createMockModel();
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				if (requestedModel.provider === primaryModel.provider && requestedModel.id === primaryModel.id) {
+					mock.push({ throw: "connect ECONNREFUSED 127.0.0.1:11434" });
+				} else if (requestedModel.provider === cloudFallback.provider && requestedModel.id === cloudFallback.id) {
+					mock.push({ content: ["Recovered on explicit cloud fallback"] });
+				} else {
+					throw new Error(`Unexpected model requested: ${requestedModel.provider}/${requestedModel.id}`);
+				}
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 1,
+			"retry.fallbackChains": {
+				default: [
+					`${localFallback.provider}/${localFallback.id}`,
+					`${cloudFallback.provider}/${cloudFallback.id}`,
+				],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+			if (event.type === "retry_fallback_succeeded") {
+				fallbackSucceededEvents.push(event);
+			}
+		});
+
+		await session.prompt("Recover from unavailable local provider");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${cloudFallback.provider}/${cloudFallback.id}`,
+		]);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryStartEvents[0]).toMatchObject({ attempt: 1, maxAttempts: 1, delayMs: 0 });
+		expect(fallbackAppliedEvents).toEqual([
+			{
+				type: "retry_fallback_applied",
+				from: `${primaryModel.provider}/${primaryModel.id}`,
+				to: `${cloudFallback.provider}/${cloudFallback.id}`,
+				role: "default",
+			},
+		]);
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: true, attempt: 1 });
+		expect(fallbackSucceededEvents).toEqual([
+			{
+				type: "retry_fallback_succeeded",
+				model: `${cloudFallback.provider}/${cloudFallback.id}`,
+				role: "default",
+			},
+		]);
+		const lastAssistant = getLastAssistantMessage(session);
+		expect(lastAssistant.stopReason).toBe("stop");
+		expect(lastAssistant.content).toContainEqual({ type: "text", text: "Recovered on explicit cloud fallback" });
+	});
+
+	it("does not hammer a failing local provider when no non-local fallback is explicitly configured", async () => {
+		const primaryModel = createCachedLocalModel("ollama", "qwen-local", "http://127.0.0.1:11434/v1");
+		const localFallback = createCachedLocalModel("lm-studio", "backup-local", "http://localhost:1234/v1");
+		modelRegistry = seedLocalProviderCache(tempDir, authStorage, [primaryModel, localFallback]);
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const mock = createMockModel({ handler: () => ({ throw: "fetch failed: connect ECONNREFUSED 127.0.0.1:11434" }) });
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 3,
+			"retry.fallbackChains": {
+				default: [`${localFallback.provider}/${localFallback.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+		});
+
+		await session.prompt("Do not retry unavailable local provider without cloud fallback");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([`${primaryModel.provider}/${primaryModel.id}`]);
+		expect(retryStartEvents).toHaveLength(0);
+		expect(retryEndEvents).toHaveLength(0);
+		expect(fallbackAppliedEvents).toHaveLength(0);
+		const lastAssistant = getLastAssistantMessage(session);
+		expect(lastAssistant.stopReason).toBe("error");
+		expect(lastAssistant.errorMessage).toBe("fetch failed: connect ECONNREFUSED 127.0.0.1:11434");
 	});
 
 	it("uses Google retry hints in quota errors before quota backoff", async () => {


### PR DESCRIPTION
## Summary
- classify local provider availability failures separately in retry handling
- require explicit non-local fallback candidates before retrying unavailable local endpoints
- add regression tests for visible cloud fallback and no-hammering behavior when only local fallbacks are configured

Fixes #1250

## Validation
- `bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts` — 14 pass, 0 fail

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
