### PR TITLE
fix(coding-agent): handle missing model registry in model slash

### DIFF
--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -268,7 +268,7 @@ async function resolveModelCommandSelection(
 	}
 
 	const providerRef = parseProviderQualifiedSelector(selector);
-	const discoverableProviders = runtime.session.modelRegistry.getDiscoverableProviders?.() ?? [];
+	const discoverableProviders = runtime.session.modelRegistry?.getDiscoverableProviders?.() ?? [];
 	if (providerRef && discoverableProviders.includes(providerRef.provider)) {
 		await runtime.session.modelRegistry.refreshProvider?.(providerRef.provider, "online");
 		availableModels = runtime.session.getAvailableModels?.() ?? [];


### PR DESCRIPTION
## Summary
- make `/model` selector resolution tolerate ACP/test runtimes that do not expose `session.modelRegistry`
- restores provider onboarding guidance for unknown selectors instead of throwing before usage text is rendered

Fixes the latest dev CI failure after #1261/#1262.

## Validation
- `bun test packages/coding-agent/test/model-onboarding-guidance.test.ts packages/coding-agent/test/agent-session-python-cleanup.test.ts` — 17 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — pass

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
