### PR TITLE
fix(coding-agent): preserve worktree launch failures

### DIFF
--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -2,14 +2,53 @@
  * Root command for the coding agent CLI.
  */
 
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import { THINKING_EFFORTS } from "@gajae-code/ai";
 import { APP_NAME, setProjectDir } from "@gajae-code/utils";
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { parseArgs } from "../cli/args";
 import { launchDefaultTmuxIfNeeded } from "../gjc-runtime/launch-tmux";
 import { prepareLaunchWorktree } from "../gjc-runtime/launch-worktree";
+import {
+	GJC_COORDINATOR_SESSION_ID_ENV,
+	GJC_COORDINATOR_SESSION_STATE_FILE_ENV,
+} from "../gjc-runtime/session-state-sidecar";
 import { runRootCommand } from "../main";
 import { prepareAcpTerminalAuthArgs } from "../modes/acp/terminal-auth";
+
+async function persistCoordinatorLaunchFailure(error: unknown, cwd: string): Promise<void> {
+	const stateFile = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim();
+	if (!stateFile) return;
+	const message = error instanceof Error ? error.message : String(error);
+	const code = message.split(":", 1)[0] || "launch_failed";
+	const now = new Date().toISOString();
+	const payload = {
+		schema_version: 1,
+		session_id: process.env[GJC_COORDINATOR_SESSION_ID_ENV]?.trim() || null,
+		state: "errored",
+		ready_for_input: false,
+		updated_at: now,
+		current_turn_id: null,
+		last_turn_id: null,
+		live: false,
+		reason: code,
+		source: "agent_session_event",
+		event: "launch_error",
+		cwd,
+		session_file: null,
+		final_response: {
+			text: message,
+			format: "markdown",
+			source: "launch_error",
+			artifact_path: null,
+			truncated: false,
+		},
+		error: { code, message, recoverable: true },
+	};
+	await fs.mkdir(path.dirname(stateFile), { recursive: true });
+	await Bun.write(stateFile, `${JSON.stringify(payload, null, 2)}\n`);
+}
 
 export default class Index extends Command {
 	static description = "Red-claw AI coding assistant";
@@ -157,7 +196,13 @@ export default class Index extends Command {
 			return;
 		}
 
-		const launch = prepareLaunchWorktree(process.cwd(), args);
+		let launch: ReturnType<typeof prepareLaunchWorktree>;
+		try {
+			launch = prepareLaunchWorktree(process.cwd(), args);
+		} catch (error) {
+			await persistCoordinatorLaunchFailure(error, process.cwd());
+			throw error;
+		}
 		if (launch.worktree.enabled) {
 			process.chdir(launch.cwd);
 			setProjectDir(launch.cwd);

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -1708,7 +1708,10 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		if (
 			sessionState &&
 			ACTIVE_TURN_STATUSES.has(resolvedTurn.status) &&
-			sessionState.current_turn_id === resolvedTurn.turn_id &&
+			(sessionState.current_turn_id === resolvedTurn.turn_id ||
+				(sessionState.state === "errored" &&
+					sessionState.source === "agent_session_event" &&
+					sessionState.current_turn_id == null)) &&
 			(sessionState.state === "completed" || sessionState.state === "errored")
 		) {
 			resolvedTurn = await markTurnTerminalFromSessionState(namespaceDir, resolvedTurn, sessionState);

--- a/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
@@ -118,6 +118,20 @@ function findWorktreeByPath(entries: GitWorktreeEntry[], worktreePath: string): 
 	return entries.find(entry => path.resolve(entry.path) === resolved) ?? null;
 }
 
+function describeWorktreeEntry(entry: GitWorktreeEntry): string {
+	return entry.detached ? `detached HEAD ${entry.head}` : (entry.branchRef ?? `HEAD ${entry.head}`);
+}
+
+function formatWorktreeTargetMismatch(plan: GjcLaunchWorktreePlan, existing: GitWorktreeEntry): string {
+	const expected = plan.detached ? `detached HEAD ${plan.baseRef}` : `branch refs/heads/${plan.branchName ?? ""}`;
+	return [
+		`worktree_target_mismatch:${plan.worktreePath}`,
+		`GJC launch worktree target is already registered for ${describeWorktreeEntry(existing)}, but this launch expects ${expected}.`,
+		`Path: ${plan.worktreePath}`,
+		"Refusing to delete or reuse the conflicting worktree automatically. Safe remediation: inspect the path, commit/stash any work, then remove or prune the stale worktree with git worktree remove <path> when it is no longer needed, or choose a different --worktree name.",
+	].join("\n");
+}
+
 function hasBranchInUse(entries: GitWorktreeEntry[], branchName: string, worktreePath: string): boolean {
 	const expectedRef = `refs/heads/${branchName}`;
 	const resolvedPath = path.resolve(worktreePath);
@@ -228,7 +242,7 @@ export function ensureLaunchWorktree(
 		let dirty = isWorktreeDirty(plan.worktreePath);
 		if (plan.detached) {
 			if (!existingAtPath.detached) {
-				throw new Error(`worktree_target_mismatch:${plan.worktreePath}`);
+				throw new Error(formatWorktreeTargetMismatch(plan, existingAtPath));
 			}
 			if (existingAtPath.head !== plan.baseRef) {
 				if (dirty) throw new Error(`worktree_dirty:${plan.worktreePath}`);
@@ -236,7 +250,7 @@ export function ensureLaunchWorktree(
 				dirty = false;
 			}
 		} else if (existingAtPath.branchRef !== expectedBranchRef) {
-			throw new Error(`worktree_target_mismatch:${plan.worktreePath}`);
+			throw new Error(formatWorktreeTargetMismatch(plan, existingAtPath));
 		}
 		return {
 			...plan,

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -952,6 +952,81 @@ describe("Coordinator MCP server protocol", () => {
 		}
 	});
 
+	it("preserves launch errors from runtime state before tmux liveness masking", async () => {
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "state", "hermes-launch-error");
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+			},
+			services: {
+				startSession: async input => ({
+					sessionId: "gjc-demo",
+					tmuxSession: "gjc-demo",
+					tmuxTarget: "gjc-demo:0.0",
+					cwd: input.cwd,
+					createdAt: "2026-06-07T00:00:00.000Z",
+				}),
+				commandRunner: async command => {
+					if (command[1] === "has-session") return { exitCode: 0, stdout: "", stderr: "" };
+					if (command[1] === "send-keys") return { exitCode: 0, stdout: "", stderr: "" };
+					return { exitCode: 1, stdout: "", stderr: "unexpected command" };
+				},
+			},
+		});
+		await server.callTool("gjc_coordinator_start_session", { cwd: root, allow_mutation: true });
+		const turn = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "gjc-demo",
+			prompt: "work",
+			allow_mutation: true,
+		});
+		const turnId = turn.turn_id as string;
+		const sessionStatesDir = path.join(stateRoot, "local", "repo", "session-states");
+		await fs.mkdir(sessionStatesDir, { recursive: true });
+		await Bun.write(
+			path.join(sessionStatesDir, "gjc-demo.json"),
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "gjc-demo",
+				state: "errored",
+				ready_for_input: false,
+				current_turn_id: null,
+				last_turn_id: null,
+				updated_at: "2026-06-07T00:00:01.000Z",
+				source: "agent_session_event",
+				live: false,
+				reason: "worktree_target_mismatch",
+				final_response: {
+					text: "worktree_target_mismatch:/tmp/repo.gajae-code-worktrees/main",
+					format: "markdown",
+					source: "launch_error",
+					artifact_path: null,
+					truncated: false,
+				},
+				error: {
+					code: "worktree_target_mismatch",
+					message: "worktree_target_mismatch:/tmp/repo.gajae-code-worktrees/main",
+					recoverable: true,
+				},
+			}),
+		);
+
+		const read = await server.callTool("gjc_coordinator_read_turn", {
+			session_id: "gjc-demo",
+			turn_id: turnId,
+		});
+
+		expect((read.turn as { status: string }).status).toBe("failed");
+		expect((read.turn as { error: { code: string } }).error.code).toBe("worktree_target_mismatch");
+		expect((read.turn as { final_response: { text: string } }).final_response.text).toContain(
+			"worktree_target_mismatch",
+		);
+	});
+
 	it("terminalizes active turns from durable runtime session state", async () => {
 		const root = await tempRoot();
 		const stateRoot = path.join(root, ".gjc", "state", "hermes-runtime");

--- a/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
@@ -134,6 +134,17 @@ describe("default launch worktrees", () => {
 		).toBe(false);
 	});
 
+	it("reports actionable diagnostics when the deterministic detached target is a different branch", async () => {
+		const repo = await createRepo("gjc-launch-target-mismatch-");
+		const first = prepareLaunchWorktree(repo, ["--worktree"]);
+		expect(first.worktree.enabled && first.worktree.created).toBe(true);
+		run("git", ["checkout", "-b", "other-agent-work"], first.cwd);
+
+		expect(() => prepareLaunchWorktree(repo, ["--worktree"])).toThrow(
+			/worktree_target_mismatch:[\s\S]*already registered for refs\/heads\/other-agent-work[\s\S]*Refusing to delete or reuse the conflicting worktree automatically[\s\S]*git worktree remove/,
+		);
+	});
+
 	it("updates a clean reused detached launch worktree when source HEAD advances", async () => {
 		const repo = await createRepo("gjc-launch-advance-worktree-");
 		const first = prepareLaunchWorktree(repo, ["--worktree"]);


### PR DESCRIPTION
## Summary
- make `gjc --worktree` target mismatches actionable instead of a bare `worktree_target_mismatch:<path>` crash
- persist launch-time failures into the Coordinator runtime state sidecar so MCP reads preserve the original error before tmux liveness can mask it as `tmux_session_missing`
- add regression coverage for conflicting launch worktrees and Coordinator launch-error terminalization

Fixes #1264

## Validation
- `bun test packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts packages/coding-agent/test/coordinator-mcp-server.test.ts` — 37 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — pass

Note: initial GJC session launch for this issue reached the TUI but the model request failed with `401 Invalid API key`, so this fix used the repository's direct non-main gajae-code exception after recording the active issue session/worktree.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
