### PR TITLE
fix(coding-agent): tolerate Windows update backup cleanup failures

### DIFF
--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -27,6 +27,7 @@ export interface InstalledVersionVerification {
 	path?: string;
 	smokeTestFailed?: boolean;
 	smokeTestOutput?: string;
+	cleanupWarning?: string;
 }
 
 /** Paths and verifier used while replacing a downloaded binary update. */
@@ -367,6 +368,19 @@ async function unlinkIfExists(filePath: string): Promise<void> {
 	}
 }
 
+function formatBackupCleanupWarning(backupPath: string, err: unknown): string {
+	return `Installed update, but could not remove backup file ${backupPath}: ${err}. You can delete it manually after closing shells or antivirus processes that may still hold it.`;
+}
+
+async function cleanupVerifiedBackup(backupPath: string): Promise<string | undefined> {
+	try {
+		await unlinkIfExists(backupPath);
+		return undefined;
+	} catch (err) {
+		return formatBackupCleanupWarning(backupPath, err);
+	}
+}
+
 /**
  * Atomically replace the installed binary and roll back if version verification fails.
  */
@@ -386,8 +400,8 @@ export async function replaceBinaryForUpdate(options: BinaryReplacementOptions):
 		}
 
 		backupReady = false;
-		await unlinkIfExists(options.backupPath);
-		return verification;
+		const cleanupWarning = await cleanupVerifiedBackup(options.backupPath);
+		return cleanupWarning ? { ...verification, cleanupWarning } : verification;
 	} catch (err) {
 		if (backupReady) {
 			await unlinkIfExists(options.targetPath);
@@ -430,7 +444,7 @@ async function updateViaBinaryAt(targetPath: string, expectedVersion: string): P
 	await pipeline(response.body, fileStream);
 
 	console.log(chalk.dim("Installing update..."));
-	await replaceBinaryForUpdate({
+	const verification = await replaceBinaryForUpdate({
 		targetPath,
 		tempPath,
 		backupPath,
@@ -438,6 +452,7 @@ async function updateViaBinaryAt(targetPath: string, expectedVersion: string): P
 		verifyInstalledVersion: verifyInstalledRuntime,
 	});
 	printVerifiedVersion(expectedVersion);
+	if (verification.cleanupWarning) console.warn(chalk.yellow(verification.cleanupWarning));
 	printRestartGuidance();
 }
 

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fsNode from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -148,6 +149,43 @@ describe("update-cli binary replacement", () => {
 		expect(await Bun.file(targetPath).text()).toBe("old binary");
 		expect(await Bun.file(tempPath).exists()).toBe(false);
 		expect(await Bun.file(backupPath).exists()).toBe(false);
+	});
+
+	it("keeps a verified replacement when backup cleanup hits EPERM", async () => {
+		const dir = await makeTempDir();
+		const targetPath = path.join(dir, "gjc.cmd");
+		const tempPath = `${targetPath}.new`;
+		const backupPath = `${targetPath}.bak`;
+		await Bun.write(targetPath, "old binary");
+		await Bun.write(tempPath, "new binary");
+		const originalUnlink = fsNode.promises.unlink;
+		const unlinkSpy = vi.spyOn(fsNode.promises, "unlink").mockImplementation(async filePath => {
+			if (String(filePath) === backupPath && fsNode.existsSync(backupPath)) {
+				const err = new Error("EPERM: operation not permitted, unlink");
+				(err as NodeJS.ErrnoException).code = "EPERM";
+				throw err;
+			}
+			return await originalUnlink(filePath);
+		});
+
+		try {
+			const result = await replaceBinaryForUpdate({
+				targetPath,
+				tempPath,
+				backupPath,
+				expectedVersion: "15.1.8",
+				verifyInstalledVersion: async () => ({ ok: true, actual: "15.1.8", path: targetPath }),
+			});
+
+			expect(result.ok).toBe(true);
+			expect(result.cleanupWarning).toContain("Installed update, but could not remove backup file");
+			expect(result.cleanupWarning).toContain(backupPath);
+			expect(await Bun.file(targetPath).text()).toBe("new binary");
+			expect(await Bun.file(tempPath).exists()).toBe(false);
+			expect(await Bun.file(backupPath).text()).toBe("old binary");
+		} finally {
+			unlinkSpy.mockRestore();
+		}
 	});
 
 	it("keeps the replacement only after it reports the expected version", async () => {


### PR DESCRIPTION
## Summary
- keep verified binary updates successful when final `.bak` cleanup fails after replacement
- surface an actionable warning that the backup file can be removed manually after closing processes that may hold it
- preserve rollback behavior for real replacement/verification failures

Fixes #1266

## Validation
- `bun test packages/coding-agent/test/update-cli.test.ts` — 14 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — pass

Note: the GJC session for this issue launched but the model request failed with `401 Invalid API key`, so this used the repository's direct non-main gajae-code exception after recording the active issue session/worktree.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
