### PR TITLE
fix(coding-agent): launch team workers safely on Windows

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -1896,13 +1896,27 @@ function readCurrentTmuxLeaderContext(tmuxCommand: string, env: NodeJS.ProcessEn
 	}
 	return { sessionName, windowIndex, leaderPaneId, target: `${sessionName}:${windowIndex}` };
 }
-export function resolveGjcWorkerCommand(cwd = process.cwd(), env: NodeJS.ProcessEnv = process.env): string {
+export function resolveGjcWorkerCommand(
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+	platform: NodeJS.Platform = process.platform,
+	argv: string[] = process.argv,
+	execPath = process.execPath,
+): string {
 	const explicit = env.GJC_TEAM_WORKER_COMMAND?.trim();
 	if (explicit) return explicit;
-	const entrypoint = process.argv[1];
-	if (entrypoint?.endsWith(".ts"))
-		return `${shellQuote(process.execPath)} ${shellQuote(path.resolve(cwd, entrypoint))}`;
-	if (entrypoint && path.basename(entrypoint).startsWith("gjc")) return shellQuote(path.resolve(cwd, entrypoint));
+	const entrypoint = argv[1];
+	if (!entrypoint) return "gjc";
+	const pathModule = platform === "win32" ? path.win32 : path;
+	const resolvedEntrypoint = pathModule.isAbsolute(entrypoint) ? entrypoint : pathModule.resolve(cwd, entrypoint);
+	if (platform === "win32") {
+		if (entrypoint.endsWith(".ts") || entrypoint.endsWith(".js") || entrypoint.endsWith(".mjs"))
+			return `${powershellQuote(execPath)} ${powershellQuote(resolvedEntrypoint)}`;
+		if (pathModule.basename(entrypoint).startsWith("gjc")) return powershellQuote(resolvedEntrypoint);
+		return "gjc";
+	}
+	if (entrypoint.endsWith(".ts")) return `${shellQuote(execPath)} ${shellQuote(resolvedEntrypoint)}`;
+	if (path.basename(entrypoint).startsWith("gjc")) return shellQuote(path.resolve(cwd, entrypoint));
 	return "gjc";
 }
 /** @internal Exported for unit tests. */
@@ -1937,7 +1951,8 @@ export function buildWorkerCommand(
 		...(worker.worktree_path ? [envAssignment("GJC_TEAM_WORKTREE_PATH", worker.worktree_path)] : []),
 	];
 	const joined = platform === "win32" ? envLines.join(" ") : envLines.join(" ");
-	return `${joined} ${config.worker_command} ${quote(prompt)}`;
+	const invocation = platform === "win32" ? `& ${config.worker_command}` : config.worker_command;
+	return `${joined} ${invocation} ${quote(prompt)}`;
 }
 interface GjcTeamInitialLane {
 	label: string;

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -4,10 +4,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { sessionReportsDir, teamStateRoot } from "../../src/gjc-runtime/session-layout";
 import {
+	buildWorkerCommand,
 	claimGjcTeamTask,
 	classifyGjcTeamCheckpointFiles,
 	executeGjcTeamApiOperation,
 	type GjcTeamConfig,
+	type GjcTeamWorker,
 	listGjcTeams,
 	monitorGjcTeam,
 	monitorGjcTeamSnapshot,
@@ -373,6 +375,64 @@ describe("native gjc team runtime", () => {
 		expect(manifest.worker_command).toBe("bun ./packages/coding-agent/src/cli.ts");
 		expect(telemetry).toContain("bun ./packages/coding-agent/src/cli.ts");
 		expect(resolveGjcWorkerCommand(cleanupRoot, { GJC_TEAM_WORKER_COMMAND: "gjc-dev" })).toBe("gjc-dev");
+	});
+
+	it("builds PowerShell worker commands with an invocation operator", () => {
+		const config = {
+			team_name: "win-team",
+			display_name: "win-team",
+			requested_name: "win-team",
+			task: "Do Windows work",
+			agent_type: "executor",
+			worker_count: 1,
+			max_workers: 1,
+			state_root: "C:\\state",
+			worker_command: "'C:\\Program Files\\gjc\\gjc.exe'",
+			worker_cli_plan: ["gjc"],
+			tmux_command: "psmux",
+			tmux_session: "win-session",
+			tmux_session_name: "win-session",
+			tmux_target: "win-session:0",
+			workspace_mode: "direct",
+			dry_run: false,
+			leader: { session_id: "leader", pane_id: "%1", cwd: "C:\\repo" },
+			leader_cwd: "C:\\repo",
+			team_state_root: "C:\\state",
+			workers: [],
+			created_at: "2026-01-01T00:00:00.000Z",
+			updated_at: "2026-01-01T00:00:00.000Z",
+		} satisfies GjcTeamConfig;
+		const worker = {
+			id: "worker-1",
+			name: "worker-1",
+			index: 1,
+			agent_type: "executor",
+			role: "executor",
+			status: "starting",
+			last_heartbeat: "2026-01-01T00:00:00.000Z",
+			assigned_tasks: [],
+		} satisfies GjcTeamWorker;
+
+		const command = buildWorkerCommand(config, worker, "win32");
+
+		expect(command).toContain("; & 'C:\\Program Files\\gjc\\gjc.exe'");
+		expect(command).not.toContain("; 'C:\\Program Files\\gjc\\gjc.exe' ");
+		expect(command).toContain("'You are worker-1 in gjc team win-team.");
+	});
+
+	it("resolves Windows JavaScript entrypoints through an executable runtime", async () => {
+		const command = resolveGjcWorkerCommand(
+			"C:\\repo",
+			{},
+			"win32",
+			["node", "C:\\repo\\node_modules\\@gajae-code\\coding-agent\\bin\\gjc.js"],
+			"C:\\Users\\you\\.bun\\bin\\bun.exe",
+		);
+
+		expect(command).toBe(
+			"'C:\\Users\\you\\.bun\\bin\\bun.exe' 'C:\\repo\\node_modules\\@gajae-code\\coding-agent\\bin\\gjc.js'",
+		);
+		expect(command).not.toBe("'C:\\repo\\node_modules\\@gajae-code\\coding-agent\\bin\\gjc.js'");
 	});
 
 	it("keeps worker CLI selection limited to GJC teammate sessions", async () => {


### PR DESCRIPTION
## Summary
- make `gjc team` Windows worker commands invoke the resolved worker command through PowerShell `&`
- resolve Windows `.js`/`.ts`/`.mjs` worker entrypoints through the executable runtime instead of emitting a bare quoted script path
- keep POSIX worker command behavior unchanged and add regression coverage for the PowerShell/psmux command shape

Fixes #1268

## Validation
- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts --grep "PowerShell worker|JavaScript entrypoints|active worker command"` — 3 pass, 0 fail
- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts` — 51 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — pass

Note: the GJC session for this issue launched but the model request failed with `401 Invalid API key`, so this used the repository's direct non-main gajae-code exception after recording the active issue session/worktree.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
