### PR TITLE
fix(team): launch win32 workers via PowerShell call operator

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -1896,10 +1896,23 @@ function readCurrentTmuxLeaderContext(tmuxCommand: string, env: NodeJS.ProcessEn
 	}
 	return { sessionName, windowIndex, leaderPaneId, target: `${sessionName}:${windowIndex}` };
 }
-export function resolveGjcWorkerCommand(cwd = process.cwd(), env: NodeJS.ProcessEnv = process.env): string {
+export function resolveGjcWorkerCommand(
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env,
+	platform: NodeJS.Platform = process.platform,
+): string {
 	const explicit = env.GJC_TEAM_WORKER_COMMAND?.trim();
 	if (explicit) return explicit;
 	const entrypoint = process.argv[1];
+	if (platform === "win32") {
+		if (entrypoint && /\.(?:ts|js|mjs)$/.test(entrypoint)) {
+			return `${powershellQuote(process.execPath)} ${powershellQuote(path.resolve(cwd, entrypoint))}`;
+		}
+		if (entrypoint && path.basename(entrypoint).toLowerCase().startsWith("gjc")) {
+			return powershellQuote(path.resolve(cwd, entrypoint));
+		}
+		return "gjc";
+	}
 	if (entrypoint?.endsWith(".ts"))
 		return `${shellQuote(process.execPath)} ${shellQuote(path.resolve(cwd, entrypoint))}`;
 	if (entrypoint && path.basename(entrypoint).startsWith("gjc")) return shellQuote(path.resolve(cwd, entrypoint));
@@ -1936,7 +1949,12 @@ export function buildWorkerCommand(
 		envAssignment("GJC_TEAM_DISPLAY_NAME", config.display_name),
 		...(worker.worktree_path ? [envAssignment("GJC_TEAM_WORKTREE_PATH", worker.worktree_path)] : []),
 	];
-	const joined = platform === "win32" ? envLines.join(" ") : envLines.join(" ");
+	const joined = envLines.join(" ");
+	if (platform === "win32") {
+		const workerCommand = config.worker_command.trim();
+		const invocation = workerCommand.startsWith("&") ? workerCommand : `& ${workerCommand}`;
+		return `${joined} ${invocation} ${quote(prompt)}`;
+	}
 	return `${joined} ${config.worker_command} ${quote(prompt)}`;
 }
 interface GjcTeamInitialLane {

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -4,10 +4,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { sessionReportsDir, teamStateRoot } from "../../src/gjc-runtime/session-layout";
 import {
+	buildWorkerCommand,
 	claimGjcTeamTask,
 	classifyGjcTeamCheckpointFiles,
 	executeGjcTeamApiOperation,
 	type GjcTeamConfig,
+	type GjcTeamWorker,
 	listGjcTeams,
 	monitorGjcTeam,
 	monitorGjcTeamSnapshot,
@@ -373,6 +375,60 @@ describe("native gjc team runtime", () => {
 		expect(manifest.worker_command).toBe("bun ./packages/coding-agent/src/cli.ts");
 		expect(telemetry).toContain("bun ./packages/coding-agent/src/cli.ts");
 		expect(resolveGjcWorkerCommand(cleanupRoot, { GJC_TEAM_WORKER_COMMAND: "gjc-dev" })).toBe("gjc-dev");
+	});
+
+	it("builds executable PowerShell worker launches on Windows", () => {
+		const previousArgv1 = process.argv[1];
+		process.argv[1] = "C:\\Users\\USER\\.bun\\install\\global\\node_modules\\@gajae-code\\coding-agent\\bin\\gjc.js";
+		try {
+			const workerCommand = resolveGjcWorkerCommand("C:\\work", {}, "win32");
+			expect(workerCommand).toBe(
+				`${"'"}${process.execPath.replace(/'/g, "''")}${"'"} 'C:\\Users\\USER\\.bun\\install\\global\\node_modules\\@gajae-code\\coding-agent\\bin\\gjc.js'`,
+			);
+
+			const worker: GjcTeamWorker = {
+				id: "worker-1",
+				name: "worker-1",
+				index: 1,
+				agent_type: "executor",
+				role: "executor",
+				status: "starting",
+				last_heartbeat: "2026-06-28T00:00:00.000Z",
+				assigned_tasks: [],
+				worktree_path: "C:\\work\\worker-1",
+			};
+			const config = {
+				team_name: "psmux-team",
+				display_name: "psmux-team",
+				requested_name: "psmux-team",
+				task: "Verify Windows worker command quoting",
+				agent_type: "executor",
+				worker_count: 1,
+				max_workers: 1,
+				state_root: "C:\\work\\.gjc\\state\\team\\psmux-team",
+				worker_command: workerCommand,
+				worker_cli_plan: ["gjc"],
+				tmux_command: "psmux",
+				tmux_session: "gjc",
+				tmux_session_name: "gjc",
+				tmux_target: "gjc:0",
+				workspace_mode: "worktree",
+				dry_run: true,
+				leader: { session_id: TEST_SESSION_ID, pane_id: "%1", cwd: "C:\\work" },
+				leader_cwd: "C:\\work",
+				team_state_root: "C:\\work\\.gjc\\state\\team",
+				workers: [worker],
+				created_at: "2026-06-28T00:00:00.000Z",
+				updated_at: "2026-06-28T00:00:00.000Z",
+			} satisfies GjcTeamConfig;
+
+			const command = buildWorkerCommand(config, worker, "win32");
+			expect(command).toContain(`; & ${workerCommand} '`);
+			expect(command).not.toContain(`; ${workerCommand} '`);
+			expect(command).toContain("$env:GJC_TEAM_WORKER = 'psmux-team/worker-1';");
+		} finally {
+			process.argv[1] = previousArgv1;
+		}
 	});
 
 	it("keeps worker CLI selection limited to GJC teammate sessions", async () => {


### PR DESCRIPTION
## Summary

Fixes `gjc team` worker startup on native Windows when psmux/tmux runs split panes through PowerShell.

The current worker command can be emitted as:

```powershell
$env:GJC_TEAM_WORKER = '…'; 'C:\...\bin\gjc.js' 'You are worker-1 ...'
```

PowerShell parses a leading quoted path as a string expression, not an invocation, so the following prompt token triggers `UnexpectedToken` and the pane exits before sending `worker-startup-ack`.

This patch:

- resolves script entrypoints on win32 as `<process.execPath> <entrypoint>` so `bin/gjc.js` is launched through bun instead of the Windows `.js` file association;
- wraps win32 worker commands with PowerShell's call operator `&` in `buildWorkerCommand()`;
- adds a regression test that constructs the Windows worker command and asserts the emitted pane command uses `; & <workerCommand> '<prompt>'`.

Fixes #1268.

## Verification

Ran on Windows 11:

```text
bun install --frozen-lockfile
bun --cwd=packages/natives run build
bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts --test-name-pattern "PowerShell worker launches|active worker command"
# 2 pass, 48 filtered out, 0 fail

bun --cwd=packages/coding-agent run check:types
# pass

bunx biome check --write packages/coding-agent/src/gjc-runtime/team-runtime.ts packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
# OK
```

Manual reproduction before/after:

```powershell
# broken shape exits 1 with ParserError / UnexpectedToken
'...\bin\gjc.js' 'You are worker-1'

# fixed shape exits 0
& 'C:\Users\USER\.bun\bin\bun.exe' '...\bin\gjc.js' '--version'
# gjc/0.7.7
```
