### PR TITLE
Add completion notification command hook

### DIFF
--- a/docs/tui-runtime-internals.md
+++ b/docs/tui-runtime-internals.md
@@ -145,7 +145,7 @@ Effects:
 - `message_update`: updates streaming assistant content; creates/updates tool execution components as tool calls appear.
 - `tool_execution_update/end`: updates tool result components and completion state.
 - `message_end`: finalizes assistant stream, handles aborted/error annotations, marks pending tool args complete on normal stop.
-- `agent_end`: stops loaders, clears transient stream state, flushes deferred model switch, issues completion notification if backgrounded.
+- `agent_end`: stops loaders, clears transient stream state, flushes deferred model switch, issues terminal completion notification if backgrounded, and runs the user-level completion command hook when configured.
 
 Read-tool grouping is intentionally stateful (`#lastReadGroup`) to coalesce consecutive read tool calls into one visual block until a non-read break occurs.
 
@@ -195,7 +195,7 @@ Escape exits inactive mode by clearing editor text and restoring border color; w
 - Subscribes background event handler (primarily waits for `agent_end`).
 - Stops TUI and sends `SIGTSTP` (POSIX job control path).
 
-On `agent_end` in background with no queued work, controller sends completion notification and shuts down.
+On `agent_end` in background with no queued work, controller sends the terminal completion notification and shuts down. The configured `completion.notifyCommand` hook is not limited to background mode; it runs on completed agent turns so local tools such as cmux can receive foreground and background completion events.
 
 ## Cancellation paths
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a user-level `completion.notifyCommand` hook that runs a shell command with `GJC_NOTIFICATION_*` payload environment variables when an agent turn completes, enabling cmux/desktop/webhook completion alerts without project-config command execution.
+
 ## [0.7.1] - 2026-06-23
 ### Fixed
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -18,6 +18,14 @@ GJC already exposes public lifecycle events through the extension/hook event con
 - `turn_end` — a model/tool turn finished. The public payload is `{ type: "turn_end", turnIndex, message, toolResults }`.
 - `agent_end` — the agent loop for a submitted prompt reached a terminal boundary. The public payload is `{ type: "agent_end", messages }`.
 
+For simple local side effects that do not need a full extension, set the user-level `completion.notifyCommand`. GJC runs it on completed agent turns with `GJC_NOTIFICATION_*` environment variables (`GJC_NOTIFICATION_TITLE`, `GJC_NOTIFICATION_BODY`, `GJC_NOTIFICATION_JSON`, etc.); project settings cannot activate this command hook.
+
+```sh
+gjc config set completion.notifyCommand 'cmux notify --title "$GJC_NOTIFICATION_TITLE" --body "$GJC_NOTIFICATION_BODY"'
+```
+
+`cmux notify` returning successfully means GJC handed the completion event to cmux. cmux may still suppress the native desktop banner when the app/window is focused, the emitting workspace is active, or the notification panel is open. In those cases, check cmux's notification panel or unread workspace state instead of treating the missing banner as a GJC delivery failure.
+
 Recommended external mapping:
 
 | Notification | Public event | Status guidance |

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1131,6 +1131,16 @@ export const SETTINGS_SCHEMA = {
 		default: "on",
 		ui: { tab: "interaction", label: "Completion Notification", description: "Notify when the agent completes" },
 	},
+	"completion.notifyCommand": {
+		type: "string",
+		default: "",
+		ui: {
+			tab: "interaction",
+			label: "Completion Notification Command",
+			description:
+				"Optional user-level shell command to run when an agent turn completes; receives GJC_NOTIFICATION_* environment variables.",
+		},
+	},
 
 	"ask.timeout": {
 		type: "number",

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -297,6 +297,17 @@ export class Settings {
 		return getDefault(path);
 	}
 
+	/**
+	 * Get a setting value from the user/global config only.
+	 *
+	 * Use for machine-local command hooks and other settings that must not be
+	 * activated by project-scoped config files.
+	 */
+	getGlobal<P extends SettingPath>(path: P): SettingValue<P> | undefined {
+		const value = getByPath(this.#global, path.split("."));
+		return value === undefined ? undefined : (value as SettingValue<P>);
+	}
+
 	/** Check whether a setting is present in loaded settings/overrides rather than coming from schema defaults. */
 	has(path: SettingPath): boolean {
 		return getByPath(this.#merged, path.split(".")) !== undefined;

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -3,6 +3,7 @@ import { calculatePromptTokens } from "@gajae-code/agent-core/compaction/compact
 import type { AssistantMessage, ImageContent } from "@gajae-code/ai";
 import { parseRateLimitReason } from "@gajae-code/ai";
 import { type Component, Loader, TERMINAL, Text } from "@gajae-code/tui";
+import { logger } from "@gajae-code/utils";
 import { settings } from "../../config/settings";
 import { AssistantMessageComponent } from "../../modes/components/assistant-message";
 import {
@@ -15,6 +16,7 @@ import { ToolExecutionComponent } from "../../modes/components/tool-execution";
 import { TtsrNotificationComponent } from "../../modes/components/ttsr-notification";
 import { getSymbolTheme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext, TodoPhase } from "../../modes/types";
+import { summaryFromMessage } from "../../notifications/helpers";
 import type { PlanApprovalDetails } from "../../plan-mode/approved-plan";
 import type { AgentSessionEvent } from "../../session/agent-session";
 import { isSilentAbort, readPendingDisplayTag } from "../../session/messages";
@@ -25,6 +27,44 @@ import { buildAbortDisplayMessage } from "../utils/abort-message";
 type AgentSessionEventKind = AgentSessionEvent["type"];
 
 const IRC_MESSAGE_VISIBLE_TTL_MS = 10_000;
+const COMPLETION_NOTIFY_COMMAND_TIMEOUT_MS = 10_000;
+
+interface CompletionNotifyPayload {
+	type: "agent-turn-complete";
+	title: string;
+	body: string;
+	cwd: string;
+	sessionId?: string;
+	sessionName?: string;
+	lastAssistantMessage?: string;
+	stopReason?: string;
+}
+
+function completionNotifyShellCommand(command: string): string[] {
+	if (process.platform === "win32") {
+		return ["cmd.exe", "/d", "/s", "/c", command];
+	}
+	return ["/bin/sh", "-c", command];
+}
+
+function cleanNotificationEnvValue(value: string | undefined, max = 4000): string {
+	if (!value) return "";
+	return value.replaceAll("\0", "").slice(0, max);
+}
+
+function buildCompletionNotifyEnv(payload: CompletionNotifyPayload): Record<string, string> {
+	return {
+		GJC_NOTIFICATION_TYPE: payload.type,
+		GJC_NOTIFICATION_TITLE: cleanNotificationEnvValue(payload.title, 500),
+		GJC_NOTIFICATION_BODY: cleanNotificationEnvValue(payload.body),
+		GJC_NOTIFICATION_CWD: cleanNotificationEnvValue(payload.cwd, 2000),
+		GJC_NOTIFICATION_SESSION_ID: cleanNotificationEnvValue(payload.sessionId, 500),
+		GJC_NOTIFICATION_SESSION_NAME: cleanNotificationEnvValue(payload.sessionName, 500),
+		GJC_NOTIFICATION_LAST_ASSISTANT_MESSAGE: cleanNotificationEnvValue(payload.lastAssistantMessage),
+		GJC_NOTIFICATION_STOP_REASON: cleanNotificationEnvValue(payload.stopReason, 100),
+		GJC_NOTIFICATION_JSON: cleanNotificationEnvValue(JSON.stringify(payload), 8000),
+	};
+}
 
 function friendlyRetryReason(errorMessage: string | undefined): string {
 	if (!errorMessage) return "";
@@ -842,8 +882,46 @@ export class EventController {
 		return lastAssistant?.usage ? calculatePromptTokens(lastAssistant.usage) : 0;
 	}
 
+	#runCompletionNotifyCommand(payload: CompletionNotifyPayload): void {
+		const command = settings.getGlobal("completion.notifyCommand")?.trim();
+		if (!command) return;
+
+		try {
+			const proc = Bun.spawn(completionNotifyShellCommand(command), {
+				cwd: payload.cwd,
+				env: {
+					...process.env,
+					...buildCompletionNotifyEnv(payload),
+				},
+				stdin: "ignore",
+				stdout: "ignore",
+				stderr: "ignore",
+			});
+			proc.unref();
+			const timer = setTimeout(() => {
+				try {
+					proc.kill();
+				} catch {}
+			}, COMPLETION_NOTIFY_COMMAND_TIMEOUT_MS);
+			timer.unref?.();
+			void proc.exited
+				.then(exitCode => {
+					clearTimeout(timer);
+					if (exitCode !== 0) {
+						logger.warn("completion notify command exited non-zero", { exitCode });
+					}
+				})
+				.catch(error => {
+					clearTimeout(timer);
+					logger.warn("completion notify command failed", { error: String(error) });
+				});
+		} catch (error) {
+			logger.warn("completion notify command failed to start", { error: String(error) });
+		}
+	}
+
 	sendCompletionNotification(): void {
-		if (this.ctx.isBackgrounded === false) return;
+		const isBackgrounded = this.ctx.isBackgrounded !== false;
 		const notify = settings.get("completion.notify");
 		if (notify === "off") return;
 
@@ -854,9 +932,23 @@ export class EventController {
 		const last = this.ctx.session.getLastAssistantMessage?.();
 		if (last?.stopReason === "aborted" || last?.stopReason === "error") return;
 
-		const title = this.ctx.sessionManager.getSessionName();
-		const message = title ? `${title}: Complete` : "Complete";
-		TERMINAL.sendNotification(message);
+		const sessionName = this.ctx.sessionManager.getSessionName();
+		const title = sessionName ? `${sessionName}: Complete` : "Complete";
+		const summary = summaryFromMessage(last, 1000);
+		const body = summary ?? "Complete";
+		const sessionManager = this.ctx.sessionManager as { getCwd?: () => string; getSessionId?: () => string };
+		const payload: CompletionNotifyPayload = {
+			type: "agent-turn-complete",
+			title,
+			body,
+			cwd: sessionManager.getCwd?.() ?? settings.getCwd(),
+			sessionId: sessionManager.getSessionId?.(),
+			sessionName: sessionName || undefined,
+			lastAssistantMessage: summary,
+			stopReason: last?.stopReason,
+		};
+		if (isBackgrounded) TERMINAL.sendNotification(title);
+		this.#runCompletionNotifyCommand(payload);
 	}
 
 	async handleBackgroundEvent(event: AgentSessionEvent): Promise<void> {

--- a/packages/coding-agent/test/modes/controllers/event-controller-abort-guard.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-abort-guard.test.ts
@@ -53,6 +53,8 @@ function makeContext(lastMessage: AssistantMessage | undefined): InteractiveMode
 		isBackgrounded: true,
 		sessionManager: {
 			getSessionName: () => "test-session",
+			getCwd: () => process.cwd(),
+			getSessionId: () => "session-test",
 		},
 		session: {
 			getLastAssistantMessage: () => lastMessage,
@@ -95,7 +97,7 @@ describe("EventController.sendCompletionNotification — abort guard", () => {
 		expect(spy).toHaveBeenCalledTimes(1);
 	});
 
-	it("honors the existing isBackgrounded gate (no notification when foreground)", () => {
+	it("honors the existing isBackgrounded gate for terminal notifications", () => {
 		const spy = vi.spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});
 		settings.override("completion.notify", "on");
 		const ctx = makeContext(makeAssistantMessage("stop"));
@@ -111,5 +113,74 @@ describe("EventController.sendCompletionNotification — abort guard", () => {
 		const controller = new EventController(makeContext(makeAssistantMessage("stop")));
 		controller.sendCompletionNotification();
 		expect(spy).toHaveBeenCalledTimes(0);
+	});
+
+	it("runs the user-level completion notify command with payload environment", () => {
+		const terminalSpy = vi.spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});
+		const spawnSpy = vi.spyOn(Bun, "spawn").mockImplementation(
+			() =>
+				({
+					exited: Promise.resolve(0),
+					kill: () => {},
+					unref: () => {},
+				}) as unknown as ReturnType<typeof Bun.spawn>,
+		);
+		settings.override("completion.notify", "on");
+		settings.set("completion.notifyCommand", "notify-test");
+		const controller = new EventController(makeContext(makeAssistantMessage("stop")));
+		controller.sendCompletionNotification();
+
+		expect(terminalSpy).toHaveBeenCalledTimes(1);
+		expect(spawnSpy).toHaveBeenCalledTimes(1);
+		const [cmd, options] = spawnSpy.mock.calls[0] as unknown as [
+			string[],
+			{ cwd?: string; env?: Record<string, string> },
+		];
+		expect(cmd).toContain("notify-test");
+		expect(options.cwd).toBe(process.cwd());
+		expect(options.env?.GJC_NOTIFICATION_TYPE).toBe("agent-turn-complete");
+		expect(options.env?.GJC_NOTIFICATION_TITLE).toBe("test-session: Complete");
+		expect(options.env?.GJC_NOTIFICATION_BODY).toBe("hello");
+		expect(options.env?.GJC_NOTIFICATION_SESSION_ID).toBe("session-test");
+	});
+
+	it("runs the user-level completion notify command even when foreground", () => {
+		const terminalSpy = vi.spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});
+		const spawnSpy = vi.spyOn(Bun, "spawn").mockImplementation(
+			() =>
+				({
+					exited: Promise.resolve(0),
+					kill: () => {},
+					unref: () => {},
+				}) as unknown as ReturnType<typeof Bun.spawn>,
+		);
+		settings.override("completion.notify", "on");
+		settings.set("completion.notifyCommand", "notify-test");
+		const ctx = makeContext(makeAssistantMessage("stop"));
+		(ctx as unknown as { isBackgrounded: boolean }).isBackgrounded = false;
+		const controller = new EventController(ctx);
+		controller.sendCompletionNotification();
+
+		expect(terminalSpy).toHaveBeenCalledTimes(0);
+		expect(spawnSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not run completion notify commands from runtime or project overrides", () => {
+		const terminalSpy = vi.spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});
+		const spawnSpy = vi.spyOn(Bun, "spawn").mockImplementation(
+			() =>
+				({
+					exited: Promise.resolve(0),
+					kill: () => {},
+					unref: () => {},
+				}) as unknown as ReturnType<typeof Bun.spawn>,
+		);
+		settings.override("completion.notify", "on");
+		settings.override("completion.notifyCommand", "notify-test");
+		const controller = new EventController(makeContext(makeAssistantMessage("stop")));
+		controller.sendCompletionNotification();
+
+		expect(terminalSpy).toHaveBeenCalledTimes(1);
+		expect(spawnSpy).toHaveBeenCalledTimes(0);
 	});
 });

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -791,6 +791,11 @@
 					],
 					"description": "Notify when the agent completes",
 					"default": "on"
+				},
+				"notifyCommand": {
+					"type": "string",
+					"description": "Optional user-level shell command to run when an agent turn completes; receives GJC_NOTIFICATION_* environment variables.",
+					"default": ""
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## Summary
- add user-level `completion.notifyCommand` for completed agent turns
- pass completion payload through `GJC_NOTIFICATION_*` environment variables for local integrations like cmux
- keep terminal OSC/BEL completion notifications background-only while allowing the command hook in foreground and background
- block project/runtime overrides from activating the command hook

## Verification
- `bun test test/modes/controllers/event-controller-abort-guard.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- targeted `bunx biome check`
- `bun run ci:test:smoke`
