### PR TITLE
Fix psmux tmux session attach targets

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -6,6 +6,7 @@ import type { Args } from "../cli/args";
 import { tmuxRuntimeSessionPath } from "./session-layout";
 import { GJC_COORDINATOR_SESSION_ID_ENV, GJC_COORDINATOR_SESSION_STATE_FILE_ENV } from "./session-state-sidecar";
 import {
+	buildGjcTmuxExactSessionTarget,
 	buildGjcTmuxProfileCommands,
 	buildGjcTmuxSessionName,
 	buildGjcTmuxSessionSlug,
@@ -21,6 +22,7 @@ import {
 import { findGjcTmuxSessionByName, findGjcTmuxSessionByScope, type GjcTmuxSessionStatus } from "./tmux-sessions";
 
 export {
+	buildGjcTmuxExactSessionTarget,
 	buildGjcTmuxProfileCommands,
 	GJC_DEFAULT_TMUX_SESSION,
 	GJC_TMUX_COMMAND_ENV,
@@ -407,7 +409,11 @@ function readCurrentBranch(cwd: string): string | null {
 }
 
 function cleanupCreatedTmuxSession(plan: TmuxLaunchPlan, spawnSync: TmuxSpawnSync, options: TmuxSpawnOptions): void {
-	spawnSync(plan.tmuxCommand, ["kill-session", "-t", `=${plan.sessionName}`], options);
+	spawnSync(
+		plan.tmuxCommand,
+		["kill-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env: options.env })],
+		options,
+	);
 }
 function isTmuxAttachDisconnectError(result: TmuxSpawnResult): boolean {
 	if (result.signalCode === "SIGHUP") return true;
@@ -511,7 +517,11 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 	};
 
 	if (plan.attachSessionName) {
-		const attached = spawnSync(plan.tmuxCommand, ["attach-session", "-t", `=${plan.attachSessionName}`], options);
+		const attached = spawnSync(
+			plan.tmuxCommand,
+			["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.attachSessionName, { env })],
+			options,
+		);
 		if (attached.exitCode === 0) return true;
 	}
 
@@ -522,7 +532,7 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			buildGjcTmuxWindowTitle(plan.project ?? plan.cwd, plan.branch),
 			spawnSync,
 			options,
-			`=${plan.sessionName}`,
+			buildGjcTmuxExactSessionTarget(plan.sessionName, { env }),
 		);
 
 		const profile = applyGjcTmuxProfile({
@@ -547,7 +557,11 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		}
 	}
 	if (created.exitCode !== 0) return false;
-	const attached = spawnSync(plan.tmuxCommand, ["attach-session", "-t", `=${plan.sessionName}`], options);
+	const attached = spawnSync(
+		plan.tmuxCommand,
+		["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env })],
+		options,
+	);
 	if (attached.exitCode === 0) return true;
 	if (isTmuxAttachDisconnectError(attached)) {
 		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("attach disconnected", attached.stderr));

--- a/packages/coding-agent/src/gjc-runtime/tmux-common.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-common.ts
@@ -86,6 +86,22 @@ export function buildGjcTmuxExactOptionTarget(
 	return `=${sessionName}:`;
 }
 
+/**
+ * Build the exact-session target for tmux *session-scoped* commands such as
+ * `attach-session` and `kill-session`. Native tmux accepts `=NAME` for an
+ * exact session match, but Windows psmux 3.3.x rejects that target form for
+ * session commands even though the bare `NAME` resolves. Keep native tmux on
+ * exact targets and intentionally use the bare session name for psmux.
+ */
+export function buildGjcTmuxExactSessionTarget(
+	sessionName: string,
+	opts: { env?: NodeJS.ProcessEnv; platform?: NodeJS.Platform; binary?: ResolvedTmuxBinary } = {},
+): string {
+	const binary = opts.binary ?? resolveGjcTmuxBinary({ env: opts.env, platform: opts.platform });
+	if (binary.isPsmux) return sessionName;
+	return `=${sessionName}`;
+}
+
 export const GJC_TMUX_UNTAGGED_REASON = "gjc_tmux_session_untagged";
 
 export function buildGjcTmuxUntaggedSessionHint(tmuxCommand: string): string {

--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -1,6 +1,7 @@
 import { resolveGjcTmuxBinary } from "./psmux-detect";
 import {
 	buildGjcTmuxExactOptionTarget,
+	buildGjcTmuxExactSessionTarget,
 	buildGjcTmuxProfileCommands,
 	buildGjcTmuxSessionName,
 	buildGjcTmuxUntaggedSessionError,
@@ -60,7 +61,7 @@ function runTmux(args: string[], env: NodeJS.ProcessEnv = process.env): string {
 
 function tryKillSession(sessionName: string, env: NodeJS.ProcessEnv): void {
 	try {
-		runTmux(["kill-session", "-t", `=${sessionName}`], env);
+		runTmux(["kill-session", "-t", buildGjcTmuxExactSessionTarget(sessionName, { env })], env);
 	} catch {
 		// Best-effort cleanup only; preserve the original create/tag failure.
 	}
@@ -360,7 +361,7 @@ export function removeGjcTmuxSession(sessionName: string, env: NodeJS.ProcessEnv
 	if (readProfileForExactTarget(session.name, env) !== GJC_TMUX_PROFILE_VALUE) {
 		throw new Error(`gjc_tmux_session_not_managed:${sessionName}`);
 	}
-	runTmux(["kill-session", "-t", `=${session.name}`], env);
+	runTmux(["kill-session", "-t", buildGjcTmuxExactSessionTarget(session.name, { env })], env);
 	return session;
 }
 
@@ -404,18 +405,21 @@ export function forceCloseGjcTmuxSession(
 		}
 	}
 	// Intentionally NOT refusing live/attached panes — force-close is hard-kill.
-	runTmux(["kill-session", "-t", `=${session.name}`], env);
+	runTmux(["kill-session", "-t", buildGjcTmuxExactSessionTarget(session.name, { env })], env);
 	return session;
 }
 
 export function attachGjcTmuxSession(sessionName: string, env: NodeJS.ProcessEnv = process.env): never {
 	const session = statusGjcTmuxSession(sessionName, env);
 	const tmuxCommand = resolveGjcTmuxCommand(env);
-	const result = Bun.spawnSync([tmuxCommand, "attach-session", "-t", `=${session.name}`], {
-		stdin: "inherit",
-		stdout: "inherit",
-		stderr: "inherit",
-		env,
-	});
+	const result = Bun.spawnSync(
+		[tmuxCommand, "attach-session", "-t", buildGjcTmuxExactSessionTarget(session.name, { env })],
+		{
+			stdin: "inherit",
+			stdout: "inherit",
+			stderr: "inherit",
+			env,
+		},
+	);
 	process.exit(result.exitCode ?? 1);
 }

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -14,6 +14,7 @@ import {
 	launchDefaultTmuxIfNeeded,
 	type TmuxSpawnOptions,
 } from "@gajae-code/coding-agent/gjc-runtime/launch-tmux";
+import { __setBinaryResolverForTests } from "@gajae-code/coding-agent/gjc-runtime/psmux-detect";
 import { sessionRuntimeDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 
 function args(overrides: Partial<Args> = {}): Args {
@@ -340,6 +341,35 @@ describe("default GJC tmux launch", () => {
 		expect(handled).toBe(true);
 		expect(calls.some(call => call.args[0] === "new-session")).toBe(false);
 		expect(calls.at(-1)?.args).toEqual(["attach-session", "-t", "=gajae_code_feature"]);
+	});
+
+	it("uses bare session targets for psmux attach paths", () => {
+		__setBinaryResolverForTests(candidate => (candidate === "psmux" ? "/fake/psmux" : null));
+		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
+		try {
+			const handled = launchDefaultTmuxIfNeeded({
+				parsed: args({ messages: ["hello world"], tmux: true, resume: true }),
+				rawArgs: ["--tmux", "--resume", "hello world"],
+				cwd: "/repo",
+				env: { GJC_TMUX_COMMAND: "psmux", GJC_PSMUX_COMMAND: "psmux" },
+				argv: ["bun", "packages/coding-agent/src/cli.ts"],
+				execPath: "/bin/bun",
+				platform: "win32",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				worktreeBranch: "feature/demo",
+				existingBranchSessionName: "gajae_code_feature",
+				spawnSync: (command, spawnArgs, options) => {
+					calls.push({ command, args: spawnArgs, options });
+					return { exitCode: 0 };
+				},
+			});
+
+			expect(handled).toBe(true);
+			expect(calls.at(-1)?.args).toEqual(["attach-session", "-t", "gajae_code_feature"]);
+		} finally {
+			__setBinaryResolverForTests(null);
+		}
 	});
 
 	it("explicit resume attaches existing tagged session for matching worktree branch", () => {

--- a/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
@@ -3,7 +3,10 @@ import {
 	__setBinaryResolverForTests,
 	clearPsmuxDetectionCache,
 } from "@gajae-code/coding-agent/gjc-runtime/psmux-detect";
-import { buildGjcTmuxExactOptionTarget } from "@gajae-code/coding-agent/gjc-runtime/tmux-common";
+import {
+	buildGjcTmuxExactOptionTarget,
+	buildGjcTmuxExactSessionTarget,
+} from "@gajae-code/coding-agent/gjc-runtime/tmux-common";
 import {
 	createGjcTmuxSession,
 	listGjcTmuxSessions,
@@ -188,6 +191,23 @@ describe("GJC tmux session management", () => {
 		expect(showOptions).toEqual(["tmux", "show-options", "-qv", "-t", "=gajae_code_work:", "@gjc-profile"]);
 		// Session-scoped commands keep the bare exact target, which tmux resolves.
 		expect(calls.at(-1)).toEqual(["tmux", "kill-session", "-t", "=gajae_code_work"]);
+	});
+
+	it("builds psmux-aware targets for session-scoped commands", () => {
+		__setBinaryResolverForTests(candidate =>
+			candidate === "psmux" || candidate === "pmux" ? `/fake/${candidate}` : null,
+		);
+		try {
+			expect(buildGjcTmuxExactSessionTarget("work", { env: { GJC_TMUX_COMMAND: "tmux" } })).toBe("=work");
+			expect(
+				buildGjcTmuxExactSessionTarget("work", { env: { GJC_TMUX_COMMAND: "psmux", GJC_PSMUX_COMMAND: "psmux" } }),
+			).toBe("work");
+			expect(
+				buildGjcTmuxExactSessionTarget("work", { env: { GJC_TMUX_COMMAND: "pmux", GJC_PSMUX_COMMAND: "pmux" } }),
+			).toBe("work");
+		} finally {
+			__setBinaryResolverForTests(null);
+		}
 	});
 
 	it("drops the tmux `=NAME` exact-session prefix on psmux for option commands", () => {


### PR DESCRIPTION
## Summary
- add a psmux-aware session target builder for `attach-session` / `kill-session`
- keep native tmux on exact `=SESSION` targets, but use bare `SESSION` for psmux session-scoped commands
- route `gjc --tmux` attach/reuse/cleanup and managed-session attach/close paths through the shared helper
- add focused mocked psmux coverage for attach/session target behavior

Fixes #1275.

## Tests
- `bun test packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts`
- `bun --cwd=packages/coding-agent run check`

## Scope note
This fixes the psmux `gjc --tmux` workaround path where attach failed after session creation due to `=SESSION` targeting. It does not claim to fix the broader Codex App lower-panel terminal/TUI rendering mismatch described in the issue comment.

## Harness note
A GJC tmux session was attempted first, but the session disappeared before prompt injection; this PR was completed directly under the repo-specific gajae-code exception on a dev-targeted branch.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
