### PR TITLE
feat(coding-agent): add terminal bell notifications

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 
+- Terminal bell notifications can now be enabled for agent completion, approval, and ask/user-input prompts (#1277).
 - Added a generic `providers.local.openaiCompat` models config path for OpenAI-compatible local endpoints plus `gjc local-provider smoke` for bounded streaming chat-completion checks (#1246).
 - Added `gjc local-provider discover` / `models` to list model IDs from a configured local OpenAI-compatible provider via `GET /v1/models`, with clear network and response-shape errors and no chat-completion request (#1247).
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -274,6 +274,43 @@ export const SETTINGS_SCHEMA = {
 		validate: (value: number) => Number.isFinite(value) && value > 0,
 	},
 
+	"notifications.terminalBell": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "interaction",
+			label: "Terminal Bell",
+			description: "Emit a BEL character for local terminal notifications",
+		},
+	},
+	"notifications.bellOnComplete": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			label: "Bell on Completion",
+			description: "Ring the terminal bell when an agent turn completes",
+		},
+	},
+	"notifications.bellOnApproval": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			label: "Bell on Approval",
+			description: "Ring the terminal bell when a plan or approval prompt needs attention",
+		},
+	},
+	"notifications.bellOnAsk": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			label: "Bell on Ask",
+			description: "Ring the terminal bell when an ask/user-input prompt needs attention",
+		},
+	},
+
 	autoResume: {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -23,6 +23,7 @@ import { isSilentAbort, readPendingDisplayTag } from "../../session/messages";
 import type { ResolveToolDetails } from "../../tools/resolve";
 import { interruptHint } from "../shared";
 import { buildAbortDisplayMessage } from "../utils/abort-message";
+import { ringTerminalBell } from "../utils/terminal-bell";
 
 type AgentSessionEventKind = AgentSessionEvent["type"];
 
@@ -962,6 +963,7 @@ export class EventController {
 			lastAssistantMessage: summary,
 			stopReason: last?.stopReason,
 		};
+		ringTerminalBell("complete");
 		if (isBackgrounded) TERMINAL.sendNotification(title);
 		this.#runCompletionNotifyCommand(payload);
 	}

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -23,6 +23,7 @@ import { HookSelectorComponent } from "../../modes/components/hook-selector";
 import { getAvailableThemesWithPaths, getThemeByName, setTheme, type Theme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext } from "../../modes/types";
 import { setSessionTerminalTitle, setTerminalTitle } from "../../utils/title-generator";
+import { classifyHookSelectorBellEvent, ringTerminalBell } from "../utils/terminal-bell";
 
 const MAX_WIDGET_LINES = 10;
 const HOOK_SELECTOR_CHROME_ROWS = 7;
@@ -621,6 +622,8 @@ export class ExtensionUiController {
 			this.ctx.ui.terminal.rows - scrollOptionRows - listChromeRows - inlineInputRows - HOOK_SELECTOR_CHROME_ROWS;
 		const scrollTitleRows =
 			requestedTitleRows === undefined ? undefined : Math.max(1, Math.min(requestedTitleRows, availableTitleRows));
+
+		ringTerminalBell(classifyHookSelectorBellEvent(title));
 
 		this.ctx.hookSelector = new HookSelectorComponent(
 			title,

--- a/packages/coding-agent/src/modes/utils/terminal-bell.ts
+++ b/packages/coding-agent/src/modes/utils/terminal-bell.ts
@@ -1,0 +1,37 @@
+import { settings } from "../../config/settings";
+
+export type TerminalBellEvent = "complete" | "approval" | "ask";
+
+const BEL = "\x07";
+
+function enabledForEvent(event: TerminalBellEvent): boolean {
+	if (!settings.get("notifications.terminalBell")) return false;
+	switch (event) {
+		case "complete":
+			return settings.get("notifications.bellOnComplete");
+		case "approval":
+			return settings.get("notifications.bellOnApproval");
+		case "ask":
+			return settings.get("notifications.bellOnAsk");
+	}
+}
+
+export function ringTerminalBell(
+	event: TerminalBellEvent,
+	output: Pick<NodeJS.WriteStream, "write"> = process.stdout,
+): void {
+	if (!enabledForEvent(event)) return;
+	try {
+		output.write(BEL);
+	} catch {
+		// Best-effort local notification only.
+	}
+}
+
+export function classifyHookSelectorBellEvent(title: string): TerminalBellEvent {
+	const normalized = title.toLowerCase();
+	if (normalized.includes("approval") || normalized.includes("approve") || normalized.includes("plan ready")) {
+		return "approval";
+	}
+	return "ask";
+}

--- a/packages/coding-agent/test/modes/controllers/event-controller-abort-guard.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-abort-guard.test.ts
@@ -89,6 +89,28 @@ describe("EventController.sendCompletionNotification — abort guard", () => {
 		expect(spy).toHaveBeenCalledWith(expect.stringContaining("Complete"));
 	});
 
+	it("rings terminal bell on completion only when enabled", () => {
+		vi.spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});
+		const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		settings.override("completion.notify", "on");
+		settings.set("notifications.terminalBell", true);
+		settings.set("notifications.bellOnComplete", true);
+		const controller = new EventController(makeContext(makeAssistantMessage("stop")));
+		controller.sendCompletionNotification();
+		expect(writeSpy).toHaveBeenCalledWith("\x07");
+	});
+
+	it("does not ring terminal bell when completion bell is disabled", () => {
+		vi.spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});
+		const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		settings.override("completion.notify", "on");
+		settings.set("notifications.terminalBell", true);
+		settings.set("notifications.bellOnComplete", false);
+		const controller = new EventController(makeContext(makeAssistantMessage("stop")));
+		controller.sendCompletionNotification();
+		expect(writeSpy).not.toHaveBeenCalledWith("\x07");
+	});
+
 	it("fires notification when getLastAssistantMessage is absent (e.g. brand-new session)", () => {
 		// Defensive: optional-chain `?.()` returns undefined; treat as 'no abort flag', proceed.
 		const spy = vi.spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});

--- a/packages/coding-agent/test/terminal-bell.test.ts
+++ b/packages/coding-agent/test/terminal-bell.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
+import { classifyHookSelectorBellEvent, ringTerminalBell } from "@gajae-code/coding-agent/modes/utils/terminal-bell";
+
+beforeEach(async () => {
+	resetSettingsForTest();
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-terminal-bell-"));
+	await Settings.init({ inMemory: true, cwd: tempDir });
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	resetSettingsForTest();
+});
+
+describe("terminal bell notifications", () => {
+	it("is opt-in by default", () => {
+		const output = { write: vi.fn(() => true) };
+		ringTerminalBell("complete", output);
+		expect(output.write).not.toHaveBeenCalled();
+	});
+
+	it("rings for enabled ask and approval events", () => {
+		settings.set("notifications.terminalBell", true);
+		settings.set("notifications.bellOnAsk", true);
+		settings.set("notifications.bellOnApproval", true);
+		const output = { write: vi.fn(() => true) };
+
+		ringTerminalBell("ask", output);
+		ringTerminalBell("approval", output);
+
+		expect(output.write).toHaveBeenCalledTimes(2);
+		expect(output.write).toHaveBeenNthCalledWith(1, "\x07");
+		expect(output.write).toHaveBeenNthCalledWith(2, "\x07");
+	});
+
+	it("honors per-event toggles", () => {
+		settings.set("notifications.terminalBell", true);
+		settings.set("notifications.bellOnAsk", false);
+		const output = { write: vi.fn(() => true) };
+
+		ringTerminalBell("ask", output);
+
+		expect(output.write).not.toHaveBeenCalled();
+	});
+
+	it("classifies approval-like selector titles separately from generic ask prompts", () => {
+		expect(classifyHookSelectorBellEvent("Plan ready for approval")).toBe("approval");
+		expect(classifyHookSelectorBellEvent("Approve tool use?")).toBe("approval");
+		expect(classifyHookSelectorBellEvent("Choose an option")).toBe("ask");
+	});
+});

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -86,6 +86,26 @@
 						}
 					},
 					"additionalProperties": false
+				},
+				"terminalBell": {
+					"type": "boolean",
+					"description": "Emit a BEL character for local terminal notifications",
+					"default": false
+				},
+				"bellOnComplete": {
+					"type": "boolean",
+					"description": "Ring the terminal bell when an agent turn completes",
+					"default": true
+				},
+				"bellOnApproval": {
+					"type": "boolean",
+					"description": "Ring the terminal bell when a plan or approval prompt needs attention",
+					"default": true
+				},
+				"bellOnAsk": {
+					"type": "boolean",
+					"description": "Ring the terminal bell when an ask/user-input prompt needs attention",
+					"default": true
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## Summary
- add opt-in terminal BEL notifications under notifications.terminalBell
- support per-event toggles for completion, approval, and ask/user-input prompts
- reuse one helper across completion and hook selector prompt paths

Fixes #1277

## Verification
- bun test packages/coding-agent/test/terminal-bell.test.ts packages/coding-agent/test/modes/controllers/event-controller-abort-guard.test.ts scripts/generate-json-schemas.test.ts
- bun --cwd=packages/coding-agent run check