### PR TITLE
fix(coding-agent): make gjc --tmux and gjc team spawn reliably on Windows + psmux

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -217,9 +217,7 @@ function detectCorruptedGjcWrapper(): string | null {
 				if (view[0] === 0x4d && view[1] === 0x5a) {
 					return `Detected PE-binary gjc wrapper at ${full} (MZ header, ${stat.size} bytes). cmd.exe will hang reading it as text. Recreate the wrapper from the gjc-tmux.cmd template.`;
 				}
-			} catch {
-				continue;
-			}
+			} catch {}
 		}
 	}
 	return null;

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -592,9 +592,23 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		stdout: "inherit",
 		stderr: "inherit",
 	};
-
 	const attachOptions: TmuxSpawnOptions = { ...options };
 	const controlOptions: TmuxSpawnOptions = { ...options, captureStderr: true };
+	// new-session needs pipe stdio (not inherit) because the user terminal must
+	// remain untouched until attach-session takes over. Inheriting psmux's
+	// stdout/stderr for new-session can corrupt the terminal state or race with
+	// attach-session on Windows, where psmux 3.3.0/3.3.6's server can die if it
+	// sees the controlling TTY in an inconsistent state mid-spawn. Capturing
+	// both streams also gives the diagnostic writer the full error detail when
+	// new-session itself fails.
+	const newSessionOptions: TmuxSpawnOptions = {
+		...options,
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+		captureStderr: true,
+	};
+
 	if (plan.attachSessionName) {
 		const attached = spawnSync(
 			plan.tmuxCommand,
@@ -602,8 +616,7 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		);
 		if (attached.exitCode === 0) return true;
 	}
-
-	const created = spawnSync(plan.tmuxCommand, plan.newSessionArgs, controlOptions);
+	const created = spawnSync(plan.tmuxCommand, plan.newSessionArgs, newSessionOptions);
 	if (created.exitCode === 0) {
 		renameTmuxWindow(
 			plan.tmuxCommand,
@@ -647,7 +660,34 @@ if (created.exitCode !== 0) {
 		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("new-session failed", stderr) + suffix);
 		return false;
 	}
-// attach-session needs PTY inherit for the user-facing attach; keep it unchanged.
+// Verify the psmux server is still alive and the session is registered
+// before we attach. On Windows, psmux 3.3.0/3.3.6 can race: new-session
+// returns exit 0 but the psmux server dies before it finishes registering
+// the session on its control socket. The follow-up attach-session then
+// fails with "no server running". Re-run new-session once if has-session
+// reports the session is missing, and capture the probe's stderr so the
+// diagnostic message names the actual psmux rejection.
+	const probeOptions: TmuxSpawnOptions = {
+		...options,
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+		captureStderr: true,
+	};
+	const hasSession = spawnSync(plan.tmuxCommand, ["has-session", "-t", `=${plan.sessionName}`], probeOptions);
+	if (hasSession.exitCode !== 0) {
+		const retry = spawnSync(plan.tmuxCommand, plan.newSessionArgs, newSessionOptions);
+		if (retry.exitCode !== 0) {
+			(context.diagnosticWriter ?? safeStderrWrite)(
+				formatTmuxLaunchDiagnostic(
+					"new-session retry failed after missing session",
+					retry.stderr ?? hasSession.stderr,
+				),
+			);
+			return true;
+		}
+	}
+	// attach-session needs PTY inherit for the user-facing attach; keep it unchanged.
 	const attached = spawnSync(
 		plan.tmuxCommand,
 		["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env })],

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -618,7 +618,8 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 	if (plan.attachSessionName) {
 		const attached = spawnSync(
 			plan.tmuxCommand,
-["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.attachSessionName, { env })], attachOptions,
+			["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.attachSessionName, { env })],
+			attachOptions,
 		);
 		if (attached.exitCode === 0) return true;
 	}
@@ -628,7 +629,8 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			plan.tmuxCommand,
 			buildGjcTmuxWindowTitle(plan.project ?? plan.cwd, plan.branch),
 			spawnSync,
-controlOptions, buildGjcTmuxExactSessionTarget(plan.sessionName, { env }),
+			controlOptions,
+			buildGjcTmuxExactSessionTarget(plan.sessionName, { env }),
 		);
 
 		const profile = applyGjcTmuxProfile({
@@ -652,8 +654,8 @@ controlOptions, buildGjcTmuxExactSessionTarget(plan.sessionName, { env }),
 			return true;
 		}
 	}
-const probeWarning = detectCorruptedGjcWrapper();
-if (created.exitCode !== 0) {
+	const probeWarning = detectCorruptedGjcWrapper();
+	if (created.exitCode !== 0) {
 		// The new-session spawn failed. Surface the captured stderr so the
 		// user sees the actual psmux rejection (e.g. "cannot create session:
 		// server is shutting down") instead of a silent exit. The wrapper
@@ -666,13 +668,13 @@ if (created.exitCode !== 0) {
 		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("new-session failed", stderr) + suffix);
 		return false;
 	}
-// Verify the psmux server is still alive and the session is registered
-// before we attach. On Windows, psmux 3.3.0/3.3.6 can race: new-session
-// returns exit 0 but the psmux server dies before it finishes registering
-// the session on its control socket. The follow-up attach-session then
-// fails with "no server running". Re-run new-session once if has-session
-// reports the session is missing, and capture the probe's stderr so the
-// diagnostic message names the actual psmux rejection.
+	// Verify the psmux server is still alive and the session is registered
+	// before we attach. On Windows, psmux 3.3.0/3.3.6 can race: new-session
+	// returns exit 0 but the psmux server dies before it finishes registering
+	// the session on its control socket. The follow-up attach-session then
+	// fails with "no server running". Re-run new-session once if has-session
+	// reports the session is missing, and capture the probe's stderr so the
+	// diagnostic message names the actual psmux rejection.
 	const probeOptions: TmuxSpawnOptions = {
 		...options,
 		stdin: "pipe",

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -75,6 +75,15 @@ export interface TmuxSpawnOptions {
 	stdin: "inherit";
 	stdout: "inherit";
 	stderr: "inherit";
+	/**
+	 * When true, the spawn captures stderr into a buffer and forwards it to
+	 * the parent stderr so the user still sees the live output. The captured
+	 * text is also returned in TmuxSpawnResult.stderr for diagnostic
+	 * surfacing in "attach failed" / "profile tagging failed" messages.
+	 * Defaults to false to preserve the previous PTY-binding behavior for
+	 * attach-session and other interactive commands.
+	 */
+	captureStderr?: boolean;
 }
 
 export interface TmuxLaunchPlan {
@@ -250,7 +259,14 @@ export function applyGjcTmuxProfile(context: GjcTmuxProfileContext): GjcTmuxProf
 	if (commands.length === 0) return { skipped: true, commands: [], failures: [] };
 	const spawnSync = context.spawnSync ?? defaultSpawnSync;
 	const cwd = context.cwd ?? process.cwd();
-	const options: TmuxSpawnOptions = { cwd, env, stdin: "inherit", stdout: "inherit", stderr: "inherit" };
+	const options: TmuxSpawnOptions = {
+		cwd,
+		env,
+		stdin: "inherit",
+		stdout: "inherit",
+		stderr: "inherit",
+		captureStderr: true,
+	};
 	const failures: GjcTmuxProfileResult["failures"] = [];
 	for (const command of commands) {
 		const result = spawnSync(context.tmuxCommand, command.args, options);
@@ -490,15 +506,33 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 }
 
 function defaultSpawnSync(command: string, args: string[], options: TmuxSpawnOptions): TmuxSpawnResult {
+	// When captureStderr is set on the options, route stderr through a
+	// pipe so we can both forward it to the parent stderr (so the user
+	// still sees the live output) and retain it in TmuxSpawnResult.stderr
+	// for diagnostic surfacing. PTY-bound commands (attach-session) keep
+	// stderr: "inherit" because psmux needs a real terminal handle.
+	const stdio = options.captureStderr
+		? { stdin: options.stdin, stdout: options.stdout, stderr: "pipe" as const }
+		: { stdin: options.stdin, stdout: options.stdout, stderr: options.stderr };
 	const result = Bun.spawnSync({
 		cmd: [command, ...args],
 		cwd: options.cwd,
 		env: options.env,
-		stdin: options.stdin,
-		stdout: options.stdout,
-		stderr: options.stderr,
+		...stdio,
 	});
-	return { exitCode: result.exitCode, signalCode: result.signalCode };
+	let stderrText: string | undefined;
+	if (options.captureStderr) {
+		const stderrBytes = result.stderr;
+		stderrText = stderrBytes ? new TextDecoder().decode(stderrBytes) : "";
+		if (stderrText.length > 0) {
+			try {
+				process.stderr.write(stderrText);
+			} catch {
+				// parent stderr already closed during shutdown; ignore.
+			}
+		}
+	}
+	return { exitCode: result.exitCode, signalCode: result.signalCode, stderr: stderrText };
 }
 
 export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
@@ -516,23 +550,23 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		stderr: "inherit",
 	};
 
+	const attachOptions: TmuxSpawnOptions = { ...options };
+	const controlOptions: TmuxSpawnOptions = { ...options, captureStderr: true };
 	if (plan.attachSessionName) {
 		const attached = spawnSync(
 			plan.tmuxCommand,
-			["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.attachSessionName, { env })],
-			options,
+["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.attachSessionName, { env })], attachOptions,
 		);
 		if (attached.exitCode === 0) return true;
 	}
 
-	const created = spawnSync(plan.tmuxCommand, plan.newSessionArgs, options);
+	const created = spawnSync(plan.tmuxCommand, plan.newSessionArgs, controlOptions);
 	if (created.exitCode === 0) {
 		renameTmuxWindow(
 			plan.tmuxCommand,
 			buildGjcTmuxWindowTitle(plan.project ?? plan.cwd, plan.branch),
 			spawnSync,
-			options,
-			buildGjcTmuxExactSessionTarget(plan.sessionName, { env }),
+controlOptions, buildGjcTmuxExactSessionTarget(plan.sessionName, { env }),
 		);
 
 		const profile = applyGjcTmuxProfile({
@@ -556,11 +590,18 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			return true;
 		}
 	}
-	if (created.exitCode !== 0) return false;
+if (created.exitCode !== 0) {
+		// The new-session spawn failed. Surface the captured stderr so the
+		// user sees the actual psmux rejection (e.g. "cannot create session:
+		// server is shutting down") instead of a silent exit.
+		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("new-session failed", created.stderr));
+		return false;
+	}
+	// attach-session needs PTY inherit for the user-facing attach; keep it unchanged.
 	const attached = spawnSync(
 		plan.tmuxCommand,
 		["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env })],
-		options,
+		attachOptions,
 	);
 	if (attached.exitCode === 0) return true;
 	if (isTmuxAttachDisconnectError(attached)) {

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -255,15 +255,20 @@ function buildWindowsPowerShellInnerCommand(context: CommandResolutionContext, r
 	const envLines = Object.entries({ [GJC_TMUX_LAUNCHED_ENV]: "1", ...(context.extraEnv ?? {}) }).map(
 		([key, value]) => `$env:${key} = ${powershellQuote(value)}`,
 	);
-	// The inner `&` invocation must wrap the resolved gjc command in a
-	// script-block so the trailing PowerShell exec-policy flags from the
-	// outer invocation are not forwarded into the bun / node / .bat
-	// binary the gjc command resolves to. Without the wrapping, the flags
-	// reach the runtime binary and cause an immediate failure that closes
-	// the psmux pane before the gjc --tmux attach can land.
+	// Resolve the inner command and arguments. PowerShell's `&` call operator
+	// accepts a single command followed by its arguments directly (no script
+	// block needed). Wrapping the call in `& { ... }` would be invalid because
+	// adjacent single-quoted tokens inside a script block body are a parser
+	// error: `& { 'a' 'b' }` fails with "Unexpected token 'b'" because PowerShell
+	// only concatenates adjacent *double-quoted* strings, and even then only in
+	// expression position. Emitting the arguments as a comma-separated array
+	// (`& 'cmd' @('a','b')`) is also rejected because arrays are not valid as
+	// the second-and-later positional arguments to `&` in command position. The
+	// correct form is `& 'cmd' 'arg1' 'arg2'` — exactly what the joined
+	// resolvedCommand + innerArgs produces below.
 	const resolvedCommand = command.map(powershellQuote).join(" ");
 	const innerArgs = stripRootTmuxFlag(rawArgs).map(powershellQuote).join(" ");
-	const invocation = `& { ${resolvedCommand} ${innerArgs} }`;
+	const invocation = `& ${resolvedCommand} ${innerArgs}`;
 	const exitLine = "if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 }";
 	const script = [...envLines, invocation, exitLine].join("\n");
 	// PowerShell -EncodedCommand requires a UTF-16LE BOM (0xFF 0xFE) at the

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { VERSION } from "@gajae-code/utils/dirs";
 import { safeStderrWrite } from "@gajae-code/utils/safe-stderr";
@@ -179,6 +180,50 @@ function formatTmuxLaunchDiagnostic(stage: string, stderr?: string): string {
 	return `gjc --tmux failed after creating tmux session: ${stage}.${suffix}\n`;
 }
 
+/**
+ * Detect a corrupted gjc.cmd / gjc.bat wrapper at well-known PATH locations.
+ * On Windows, `gjc.cmd` / `gjc.bat` files at the front of PATH that turn out
+ * to be PE-binary garbage (e.g. a 194MB PE image written over the wrapper)
+ * cause cmd.exe to hang silently when invoked from PowerShell — cmd reads
+ * the binary as text and never returns, so the user sees the prompt return
+ * with no output but no actual launch. This probe surfaces that failure mode
+ * in the diagnostic so the user gets a clear "wrapper corrupted" hint instead
+ * of a silent exit. Best-effort: returns null when the file is missing,
+ * unreadable, or under 1KB (real CMD wrappers are 100-500 bytes; the original
+ * 194MB PE-binary garbage was obviously out of band). Sync because the
+ * call site (launchDefaultTmuxIfNeeded) is sync; uses statSync + 2-byte
+ * read.
+ */
+function detectCorruptedGjcWrapper(): string | null {
+	if (process.platform !== "win32") return null;
+	const pathEnv = process.env.PATH ?? "";
+	if (!pathEnv) return null;
+	const seen = new Set<string>();
+	for (const dir of pathEnv.split(path.delimiter)) {
+		for (const name of ["gjc.cmd", "gjc.bat"]) {
+			const full = path.join(dir, name);
+			if (seen.has(full)) continue;
+			seen.add(full);
+			try {
+				const stat = fs.statSync(full);
+				if (!stat.isFile()) continue;
+				if (stat.size < 1024) continue;
+				if (stat.size > 64 * 1024) {
+					return `Detected suspicious gjc wrapper at ${full}: ${stat.size} bytes (expected <1KB). The wrapper may be corrupted; cmd.exe will hang reading it as text. Recreate it from the gjc-tmux.cmd template.`;
+				}
+				const head = fs.readFileSync(full);
+				if (head.byteLength < 2) continue;
+				const view = new Uint8Array(head);
+				if (view[0] === 0x4d && view[1] === 0x5a) {
+					return `Detected PE-binary gjc wrapper at ${full} (MZ header, ${stat.size} bytes). cmd.exe will hang reading it as text. Recreate the wrapper from the gjc-tmux.cmd template.`;
+				}
+			} catch {
+				continue;
+			}
+		}
+	}
+	return null;
+}
 function formatTmuxUnavailableDiagnostic(platform: NodeJS.Platform, tmuxCommand: string): string {
 	if (platform === "win32") {
 		return (
@@ -590,14 +635,21 @@ controlOptions, buildGjcTmuxExactSessionTarget(plan.sessionName, { env }),
 			return true;
 		}
 	}
+const probeWarning = detectCorruptedGjcWrapper();
 if (created.exitCode !== 0) {
 		// The new-session spawn failed. Surface the captured stderr so the
 		// user sees the actual psmux rejection (e.g. "cannot create session:
-		// server is shutting down") instead of a silent exit.
-		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("new-session failed", created.stderr));
+		// server is shutting down") instead of a silent exit. The wrapper
+		// probe gives the user a deterministic hint when the silent-exit
+		// symptom is actually caused by a corrupted gjc.cmd / gjc.bat on
+		// PATH (a 194MB PE-binary at the wrapper path produces cmd.exe
+		// hangs that look like a tmux/psmux failure from the user's seat).
+		const stderr = created.stderr;
+		const suffix = probeWarning ? ` Wrapper warning: ${probeWarning}` : "";
+		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("new-session failed", stderr) + suffix);
 		return false;
 	}
-	// attach-session needs PTY inherit for the user-facing attach; keep it unchanged.
+// attach-session needs PTY inherit for the user-facing attach; keep it unchanged.
 	const attached = spawnSync(
 		plan.tmuxCommand,
 		["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env })],

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -271,13 +271,14 @@ function buildWindowsPowerShellInnerCommand(context: CommandResolutionContext, r
 	const invocation = `& ${resolvedCommand} ${innerArgs}`;
 	const exitLine = "if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 }";
 	const script = [...envLines, invocation, exitLine].join("\n");
-	// PowerShell -EncodedCommand requires a UTF-16LE BOM (0xFF 0xFE) at the
-	// start of the decoded buffer; without it pwsh may misinterpret the
-	// leading bytes and reject the script with a parse error, which would
-	// kill the psmux pane before the gjc --tmux attach could land.
-	const bom = Buffer.from([0xff, 0xfe]);
+	// Encode the script as UTF-16LE base64 for pwsh -EncodedCommand. Do NOT
+	// prepend a UTF-16LE BOM (0xFF 0xFE): the BOM survives the decode and is
+	// inserted as a literal U+FEFF character in front of the first script
+	// token, which pwsh then reports as a "term not recognized" parse error
+	// (e.g. "﻿$env:GJC_TMUX_LAUNCHED"). pwsh expects the decoded buffer to
+	// start with the first character of the script, not with a BOM.
 	const body = Buffer.from(script, "utf16le");
-	const encodedCommand = Buffer.concat([bom, body]).toString("base64");
+	const encodedCommand = body.toString("base64");
 	return `pwsh -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodedCommand}`;
 }
 

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -1931,7 +1931,22 @@ export function buildWorkerCommand(
 	const workspace = worker.worktree_path
 		? `Worker worktree: ${worker.worktree_path}.`
 		: `Worker cwd: ${config.leader.cwd}.`;
-	const prompt = [
+	// The worker prompt body is dispatched into the pane through
+	// `tmux send-keys`, which treats embedded LF characters as Enter
+	// keypresses. A multi-line prompt therefore lands in the pane as
+	// multiple prompt bodies followed by premature Enter presses, which on
+	// Windows + psmux/ConPTY causes the worker CLI to bail out before the
+	// startup ACK fires. Normalize the body to a single line by replacing
+	// any LF/CRLF with a space, and strip a defensive U+FEFF in case a
+	// caller managed to inject a UTF-8 BOM into the task text. Empty /
+	// whitespace-only bodies fall back to a one-line placeholder so the
+	// worker never sits idle at an empty prompt.
+	const normalizePrompt = (raw: string): string =>
+		raw
+			.replace(/[\uFEFF\u200B]/g, "")
+			.replace(/\r?\n+/g, " ")
+			.trim();
+	const rawPrompt = [
 		`You are ${worker.id} in gjc team ${config.team_name}.`,
 		`Team state root: ${config.state_root}.`,
 		workspace,
@@ -1940,6 +1955,7 @@ export function buildWorkerCommand(
 		`Before claiming work, send startup ACK: gjc team api worker-startup-ack --input '{"team_name":"${config.team_name}","worker_id":"${worker.id}","protocol_version":"1"}' --json.`,
 		`Use gjc team api update-worker-status to report task-local activity, then claim-task/transition-task-status with this worker id; keep heartbeat current during long work, record completion_evidence (summary plus a passed command or verified inspection/artifact item) before completed, and do not mutate leader-owned goal state.`,
 	].join("\n");
+	const prompt = normalizePrompt(rawPrompt) || `Worker ${worker.id} ready.`;
 	const envLines = [
 		envAssignment("GJC_TEAM_WORKER", `${config.team_name}/${worker.id}`),
 		envAssignment("GJC_TEAM_INTERNAL_WORKER", `${config.team_name}/${worker.id}`),
@@ -2070,7 +2086,6 @@ async function startTmuxSession(
 					"#{pane_id}",
 					"-c",
 					worker.worktree_path ?? config.leader.cwd,
-					buildWorkerCommand(config, worker),
 				],
 				{ stdout: "pipe", stderr: "pipe" },
 			);
@@ -2081,6 +2096,25 @@ async function startTmuxSession(
 			rollbackPaneIds.push(paneId);
 			if (worker.index === 1) rightStackRootPaneId = paneId;
 			workers.push({ ...worker, pane_id: paneId });
+			// On psmux/ConPTY (Windows pwsh default-shell) panes, tmux writes the
+			// split-window command argv to the new pane's stdin but pwsh's
+			// readline never receives an Enter, so the worker never starts.
+			// Create the pane without a command, then dispatch the worker
+			// command through send-keys + Enter so it actually executes.
+			// `-l` makes tmux send every key literally (no key-name resolution),
+			// so the worker command body cannot accidentally expand any embedded
+			// control characters as Enter/C-c/etc. The trailing `Enter` is a
+			// separate argv entry and tmux still resolves that as the actual
+			// submit keystroke.
+			const sendKeys = Bun.spawnSync(
+				[config.tmux_command, "send-keys", "-l", "-t", paneId, buildWorkerCommand(config, worker), "Enter"],
+				{ stdout: "ignore", stderr: "ignore" },
+			);
+			// void-cast the exit code so the linter does not flag an unused
+			// expression; the value is intentionally discarded here because
+			// the actual spawn outcome is recovered by the leader through
+			// the worker startup-ack watcher, not via the spawn exit code.
+			void sendKeys.exitCode;
 		}
 		Bun.spawnSync([config.tmux_command, "select-layout", "-t", config.tmux_target, "main-vertical"], {
 			stdout: "ignore",

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -1967,7 +1967,7 @@ export function buildWorkerCommand(
 		...(worker.worktree_path ? [envAssignment("GJC_TEAM_WORKTREE_PATH", worker.worktree_path)] : []),
 	];
 	const joined = platform === "win32" ? envLines.join(" ") : envLines.join(" ");
-// On Windows we wrap the worker command invocation in `& { & 'cmd' 'arg1' ... }`
+	// On Windows we wrap the worker command invocation in `& { & 'cmd' 'arg1' ... }`
 	// so pwsh keeps the whole multi-statement body in command position. Two
 	// failure modes this avoids:
 	//   1. Bare `bun 'cli.ts' 'prompt'` after `$env:X = 'y'; ...` would be
@@ -1980,6 +1980,15 @@ export function buildWorkerCommand(
 	// the invocation. POSIX shells do not need this — they already treat
 	// `cmd 'arg'` as a normal command invocation after `;`-separated
 	// variable assignments.
+	//
+	// ASSUMPTION: this branch only fires when the worker pane is a PowerShell
+	// shell. psmux launches pwsh by default on Windows, so the unset /
+	// unset-and-replace cases are correct. If a user has explicitly set
+	// `set -g default-shell "C:/Program Files/Git/bin/bash.exe"` (or any
+	// other non-pwsh shell), this branch will send PowerShell syntax to a
+	// bash pane and the worker will fail with a parse error. Detecting the
+	// pane's shell at runtime and switching the quoting + invocation style
+	// accordingly is a follow-up; for now the pwsh default is assumed.
 	if (platform === "win32") {
 		const invocation = `& ${config.worker_command} ${quote(prompt)}`;
 		return `& { ${joined} ${invocation} }`;

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -1967,8 +1967,24 @@ export function buildWorkerCommand(
 		...(worker.worktree_path ? [envAssignment("GJC_TEAM_WORKTREE_PATH", worker.worktree_path)] : []),
 	];
 	const joined = platform === "win32" ? envLines.join(" ") : envLines.join(" ");
-	const invocation = platform === "win32" ? `& ${config.worker_command}` : config.worker_command;
-	return `${joined} ${invocation} ${quote(prompt)}`;
+// On Windows we wrap the worker command invocation in `& { & 'cmd' 'arg1' ... }`
+	// so pwsh keeps the whole multi-statement body in command position. Two
+	// failure modes this avoids:
+	//   1. Bare `bun 'cli.ts' 'prompt'` after `$env:X = 'y'; ...` would be
+	//      parsed in expression position and PowerShell would reject the
+	//      second quoted token with "Unexpected token '<cli.ts>'".
+	//   2. `& { 'cmd' 'arg1' 'arg2' }` (single & inside a block with adjacent
+	//      single-quoted tokens) is itself invalid because pwsh does not
+	//      concatenate adjacent single-quoted strings inside a script block.
+	// The nested `&` inside the block forces command-position parsing for
+	// the invocation. POSIX shells do not need this — they already treat
+	// `cmd 'arg'` as a normal command invocation after `;`-separated
+	// variable assignments.
+	if (platform === "win32") {
+		const invocation = `& ${config.worker_command} ${quote(prompt)}`;
+		return `& { ${joined} ${invocation} }`;
+	}
+	return `${joined} ${config.worker_command} ${quote(prompt)}`;
 }
 interface GjcTeamInitialLane {
 	label: string;
@@ -2101,15 +2117,21 @@ async function startTmuxSession(
 			// readline never receives an Enter, so the worker never starts.
 			// Create the pane without a command, then dispatch the worker
 			// command through send-keys + Enter so it actually executes.
-			// `-l` makes tmux send every key literally (no key-name resolution),
-			// so the worker command body cannot accidentally expand any embedded
-			// control characters as Enter/C-c/etc. The trailing `Enter` is a
-			// separate argv entry and tmux still resolves that as the actual
-			// submit keystroke.
-			const sendKeys = Bun.spawnSync(
-				[config.tmux_command, "send-keys", "-l", "-t", paneId, buildWorkerCommand(config, worker), "Enter"],
-				{ stdout: "ignore", stderr: "ignore" },
-			);
+			// Two-step dispatch because tmux's `-l` (literal mode) flag is
+			// global per send-keys invocation, not per arg: passing `-l
+			// <body> Enter` would treat "Enter" as literal text too. Sending
+			// the body in literal mode first and the Enter keypress second
+			// keeps the body verbatim while still submitting the prompt as a
+			// keystroke.
+			const body = buildWorkerCommand(config, worker);
+			Bun.spawnSync([config.tmux_command, "send-keys", "-l", "-t", paneId, body], {
+				stdout: "ignore",
+				stderr: "ignore",
+			});
+			const sendKeys = Bun.spawnSync([config.tmux_command, "send-keys", "-t", paneId, "Enter"], {
+				stdout: "ignore",
+				stderr: "ignore",
+			});
 			// void-cast the exit code so the linter does not flag an unused
 			// expression; the value is intentionally discarded here because
 			// the actual spawn outcome is recovered by the leader through

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1276,18 +1276,15 @@ it("emits a UTF-16LE BOM and a script-block &-invocation for native Windows --tm
 	expect(decoded[0]).toBe(0xff);
 	expect(decoded[1]).toBe(0xfe);
 	const script = decoded.subarray(2).toString("utf16le");
-	// The inner invocation must be wrapped in a script block so the trailing
-	// PowerShell exec-policy flags from the outer invocation are not
-	// forwarded into the resolved gjc binary itself.
-	expect(script).toContain("& {");
-	expect(script).toContain("}");
-	// No bare `& '<flag>'` invocation should leak into the inner script,
-	// because that is what previously made pwsh reject the encoded command.
-	expect(script).not.toMatch(/&\s+'-{1,2}[A-Za-z]/);
+	// The inner invocation must use the PowerShell `&` call operator directly
+	// (no `& { ... }` script-block wrapper) because adjacent single-quoted
+	// tokens inside a script-block body are a parser error. The correct shape
+	// is `& 'cmd' 'arg1' 'arg2'`, which is exactly what buildWindowsPowerShell
+	// InnerCommand produces below.
+	expect(script).toMatch(/&\s+'/);
 });
 
 it("captures psmux stderr in the attach-failed diagnostic", () => {
-	// Regression: gjc --tmux on native Windows + psmux 3.3.0 surfaces a silent
 	// exit when attach-session fails. The previous defaultSpawnSync dropped
 	// Bun.spawnSync's result.stderr, so the "attach failed" diagnostic
 	// template rendered with an empty detail and the user could not

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1242,16 +1242,16 @@ describe("default GJC tmux launch", () => {
 	});
 });
 
-it("emits a UTF-16LE BOM and a script-block &-invocation for native Windows --tmux plans", () => {
+it("emits a BOM-less UTF-16LE encoded command and a direct `&` invocation for native Windows --tmux plans", () => {
 	// Regression: gjc --tmux on native Windows + psmux previously failed with
-	// "attach failed: no server running" because the inner PowerShell-encoded
-	// command lacked a UTF-16LE BOM (pwsh rejected it with a parse error) and
-	// the trailing `-NoLogo -NoProfile -ExecutionPolicy Bypass` flags were
-	// being forwarded into the resolved gjc binary instead of being absorbed
-	// by PowerShell. Both root causes are fixed by:
-	//   1. Prepending a UTF-16LE BOM (0xFF 0xFE) to the encoded buffer.
-	//   2. Wrapping the `& <command> <args>` invocation in a script block
-	//      `& { ... }` so the trailing flags do not reach the runtime binary.
+	// the literal text "﻿$env:GJC_TMUX_LAUNCHED : The term '﻿$env:...' is not
+	// recognized" appearing in the psmux pane, because the encoded command
+	// was prefixed with a UTF-16LE BOM (0xFF 0xFE). pwsh does not strip the
+	// BOM on -EncodedCommand input; it decodes the BOM to U+FEFF and emits
+	// that character as part of the first token, which then fails to match
+	// any cmdlet. Fix: emit the buffer WITHOUT a BOM, and use a direct
+	// `& 'cmd' 'arg1' 'arg2'` invocation (no script-block wrapper, which
+	// is itself a parser error for adjacent single-quoted tokens).
 	const plan = buildDefaultTmuxLaunchPlan({
 		parsed: args({ messages: [], tmux: true }),
 		rawArgs: ["--tmux"],
@@ -1271,11 +1271,15 @@ it("emits a UTF-16LE BOM and a script-block &-invocation for native Windows --tm
 	expect(encodedMatch).not.toBeNull();
 	if (!encodedMatch) throw new Error("expected -EncodedCommand in inner command");
 	const decoded = Buffer.from(encodedMatch[1], "base64");
-	// The first two bytes of the decoded buffer must be the UTF-16LE BOM
-	// (0xFF 0xFE) so PowerShell -EncodedCommand parses the script correctly.
-	expect(decoded[0]).toBe(0xff);
-	expect(decoded[1]).toBe(0xfe);
-	const script = decoded.subarray(2).toString("utf16le");
+	// The decoded buffer must NOT start with the UTF-16LE BOM. pwsh does not
+	// strip the BOM on -EncodedCommand input, so prepending one would cause
+	// the first script token to be prefixed with U+FEFF, breaking the parse.
+	expect(decoded[0]).not.toBe(0xff);
+	expect(decoded[1]).not.toBe(0xfe);
+	const script = decoded.toString("utf16le");
+	// The first character of the decoded script must be the first character
+	// of the actual PowerShell command (`$` from `$env:GJC_TMUX_LAUNCHED`).
+	expect(script[0]).toBe("$");
 	// The inner invocation must use the PowerShell `&` call operator directly
 	// (no `& { ... }` script-block wrapper) because adjacent single-quoted
 	// tokens inside a script-block body are a parser error. The correct shape

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1335,55 +1335,59 @@ it("captures psmux stderr in the attach-failed diagnostic", () => {
 	expect(diagnostics[0]).toContain("cannot create session");
 });
 
-it('surfaces a wrapper-corruption warning in the new-session diagnostic on Windows', () => {
+it("surfaces a wrapper-corruption warning in the new-session diagnostic on Windows", () => {
 	// Regression: when gjc.cmd / gjc.bat on PATH has been overwritten with
 	// PE-binary garbage (a 194MB PE image or similar), cmd.exe hangs reading
 	// it as text and the user sees a silent exit. The wrapper-corruption
 	// probe must surface a clear hint in the diagnostic so the user can
 	// identify and fix the wrapper without re-running the wrapper diagnostic
 	// script.
-	if (process.platform !== 'win32') return;
-	const dir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'gjc-wrapper-probe-'));
-	const wrapperPath = path.join(dir, 'gjc.cmd');
+	if (process.platform !== "win32") return;
+	const dir = fs.mkdtempSync(path.join(require("os").tmpdir(), "gjc-wrapper-probe-"));
+	const wrapperPath = path.join(dir, "gjc.cmd");
 	// Write 4KB of PE-binary garbage (MZ header + zero padding).
 	const garbage = Buffer.alloc(4096);
 	garbage[0] = 0x4d;
 	garbage[1] = 0x5a;
 	fs.writeFileSync(wrapperPath, garbage);
 	const originalPath = process.env.PATH;
-	process.env.PATH = dir + path.delimiter + (originalPath ?? '');
+	process.env.PATH = dir + path.delimiter + (originalPath ?? "");
 	try {
 		const diagnostics = [];
 		launchDefaultTmuxIfNeeded({
-			parsed: args({ messages: ['hello world'], tmux: true }),
-			rawArgs: ['--tmux', 'hello world'],
-			cwd: '/repo',
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo",
 			env: {},
-			argv: ['bun', 'packages/coding-agent/src/cli.ts'],
-			execPath: '/bin/bun',
-			platform: 'win32',
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "win32",
 			tty: interactiveTty,
 			tmuxAvailable: true,
-			currentBranch: '',
+			currentBranch: "",
 			existingBranchSessionName: null,
 			diagnosticWriter: message => diagnostics.push(message),
 			spawnSync: (_command, spawnArgs) => {
-				if (spawnArgs[0] === 'new-session') {
-					return { exitCode: 1, stderr: 'psmux: cannot create session: server is shutting down' };
+				if (spawnArgs[0] === "new-session") {
+					return { exitCode: 1, stderr: "psmux: cannot create session: server is shutting down" };
 				}
-				if (spawnArgs[0] === 'attach-session') {
+				if (spawnArgs[0] === "attach-session") {
 					return { exitCode: 0 };
 				}
 				return { exitCode: 0 };
 			},
 		});
 		expect(diagnostics.length).toBeGreaterThan(0);
-		expect(diagnostics[0]).toContain('new-session failed');
-		expect(diagnostics[0]).toContain('Wrapper warning');
+		expect(diagnostics[0]).toContain("new-session failed");
+		expect(diagnostics[0]).toContain("Wrapper warning");
 		expect(diagnostics[0]).toContain(wrapperPath);
 	} finally {
 		process.env.PATH = originalPath;
-		try { fs.unlinkSync(wrapperPath); } catch {}
-		try { fs.rmdirSync(dir); } catch {}
+		try {
+			fs.unlinkSync(wrapperPath);
+		} catch {}
+		try {
+			fs.rmdirSync(dir);
+		} catch {}
 	}
 });

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1285,3 +1285,52 @@ it("emits a UTF-16LE BOM and a script-block &-invocation for native Windows --tm
 	// because that is what previously made pwsh reject the encoded command.
 	expect(script).not.toMatch(/&\s+'-{1,2}[A-Za-z]/);
 });
+
+it("captures psmux stderr in the attach-failed diagnostic", () => {
+	// Regression: gjc --tmux on native Windows + psmux 3.3.0 surfaces a silent
+	// exit when attach-session fails. The previous defaultSpawnSync dropped
+	// Bun.spawnSync's result.stderr, so the "attach failed" diagnostic
+	// template rendered with an empty detail and the user could not
+	// diagnose the real failure. With captureStderr: true the new-session
+	// and profile spawns retain their stderr, and the diagnostic template
+	// emits the captured text so future regressions in the same lane are
+	// diagnosable from the test surface alone.
+	const diagnostics: string[] = [];
+	const handled = launchDefaultTmuxIfNeeded({
+		parsed: args({ messages: ["hello world"], tmux: true }),
+		rawArgs: ["--tmux", "hello world"],
+		cwd: "/repo",
+		env: {},
+		argv: ["bun", "packages/coding-agent/src/cli.ts"],
+		execPath: "/bin/bun",
+		platform: "win32",
+		tty: interactiveTty,
+		tmuxAvailable: true,
+		currentBranch: "",
+		existingBranchSessionName: null,
+		diagnosticWriter: message => {
+			diagnostics.push(message);
+		},
+		spawnSync: (_command, spawnArgs) => {
+			if (spawnArgs[0] === "new-session") {
+				// Simulate psmux rejecting the new-session call by emitting a
+				// distinctive stderr message and exiting non-zero.
+				return {
+					exitCode: 1,
+					stderr: "psmux: cannot create session: server is shutting down",
+				};
+			}
+			if (spawnArgs[0] === "attach-session") {
+				return { exitCode: 0 };
+			}
+			return { exitCode: 0 };
+		},
+	});
+	// The handler should return false because new-session failed and there
+	// is no usable plan to fall through from. The captured stderr is what
+	// the diagnostic writer saw, so it should include the failure reason.
+	expect(handled).toBe(false);
+	expect(diagnostics.length).toBeGreaterThan(0);
+	expect(diagnostics[0]).toContain("new-session failed");
+	expect(diagnostics[0]).toContain("cannot create session");
+});

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1391,3 +1391,53 @@ it("surfaces a wrapper-corruption warning in the new-session diagnostic on Windo
 		} catch {}
 	}
 });
+
+it("retries new-session when the psmux server has not yet registered the session (Windows race)", () => {
+	// Regression: on Windows + psmux 3.3.0/3.3.6, the new-session spawn can
+	// return exit 0 before the psmux server has finished registering the
+	// session on its control socket. The follow-up attach-session then fails
+	// with "psmux: can't find session '=NAME' (no server running)" because
+	// the psmux server is alive but the session is briefly invisible. The
+	// has-session probe + new-session retry in launchDefaultTmuxIfNeeded
+	// closes the race. This test simulates the failure shape without
+	// requiring a live psmux server.
+	const calls = [];
+	let newSessionCount = 0;
+	let capturedSessionName = "";
+	const result = launchDefaultTmuxIfNeeded({
+		parsed: args({ messages: ["hello world"], tmux: true }),
+		rawArgs: ["--tmux", "hello world"],
+		cwd: "/repo",
+		env: {},
+		argv: ["bun", "packages/coding-agent/src/cli.ts"],
+		execPath: "/bin/bun",
+		platform: "win32",
+		tty: interactiveTty,
+		tmuxAvailable: true,
+		currentBranch: "",
+		existingBranchSessionName: null,
+		diagnosticWriter: () => {},
+		spawnSync: (_command, spawnArgs) => {
+			calls.push({ command: spawnArgs[0], args: spawnArgs });
+			if (spawnArgs[0] === "new-session") {
+				capturedSessionName = spawnArgs[3] ?? capturedSessionName;
+				newSessionCount++;
+				return { exitCode: 0, stderr: "" };
+			}
+			if (spawnArgs[0] === "has-session") {
+				if (newSessionCount === 1) {
+					return {
+						exitCode: 1,
+						stderr: `psmux: can't find session '=${capturedSessionName}' (no server running)`,
+					};
+				}
+				return { exitCode: 0 };
+			}
+			return { exitCode: 0 };
+		},
+	});
+	expect(result).toBe(true);
+	const newSessionCalls = calls.filter(call => call.command === "new-session");
+	expect(newSessionCalls.length).toBe(2);
+	expect(calls.some(call => call.command === "has-session" && call.args[2] === `=${capturedSessionName}`)).toBe(true);
+});

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1334,3 +1334,56 @@ it("captures psmux stderr in the attach-failed diagnostic", () => {
 	expect(diagnostics[0]).toContain("new-session failed");
 	expect(diagnostics[0]).toContain("cannot create session");
 });
+
+it('surfaces a wrapper-corruption warning in the new-session diagnostic on Windows', () => {
+	// Regression: when gjc.cmd / gjc.bat on PATH has been overwritten with
+	// PE-binary garbage (a 194MB PE image or similar), cmd.exe hangs reading
+	// it as text and the user sees a silent exit. The wrapper-corruption
+	// probe must surface a clear hint in the diagnostic so the user can
+	// identify and fix the wrapper without re-running the wrapper diagnostic
+	// script.
+	if (process.platform !== 'win32') return;
+	const dir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'gjc-wrapper-probe-'));
+	const wrapperPath = path.join(dir, 'gjc.cmd');
+	// Write 4KB of PE-binary garbage (MZ header + zero padding).
+	const garbage = Buffer.alloc(4096);
+	garbage[0] = 0x4d;
+	garbage[1] = 0x5a;
+	fs.writeFileSync(wrapperPath, garbage);
+	const originalPath = process.env.PATH;
+	process.env.PATH = dir + path.delimiter + (originalPath ?? '');
+	try {
+		const diagnostics = [];
+		launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ['hello world'], tmux: true }),
+			rawArgs: ['--tmux', 'hello world'],
+			cwd: '/repo',
+			env: {},
+			argv: ['bun', 'packages/coding-agent/src/cli.ts'],
+			execPath: '/bin/bun',
+			platform: 'win32',
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: '',
+			existingBranchSessionName: null,
+			diagnosticWriter: message => diagnostics.push(message),
+			spawnSync: (_command, spawnArgs) => {
+				if (spawnArgs[0] === 'new-session') {
+					return { exitCode: 1, stderr: 'psmux: cannot create session: server is shutting down' };
+				}
+				if (spawnArgs[0] === 'attach-session') {
+					return { exitCode: 0 };
+				}
+				return { exitCode: 0 };
+			},
+		});
+		expect(diagnostics.length).toBeGreaterThan(0);
+		expect(diagnostics[0]).toContain('new-session failed');
+		expect(diagnostics[0]).toContain('Wrapper warning');
+		expect(diagnostics[0]).toContain(wrapperPath);
+	} finally {
+		process.env.PATH = originalPath;
+		try { fs.unlinkSync(wrapperPath); } catch {}
+		try { fs.rmdirSync(dir); } catch {}
+	}
+});

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -2703,7 +2703,21 @@ describe("resolveGjcWorkerCommand bun prefix for script entrypoints", () => {
 	it("prepends the bun runtime when argv[1] ends in .js", async () => {
 		process.argv = ["C:\\Users\\withfox\\.bun\\bin\\bun.exe", "C:\\repo\\packages\\coding-agent\\bin\\gjc.js"];
 		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
-		const out = resolveGjcWorkerCommand("C:\\repo");
+		// pass win32 explicitly: the bun-prefix invariant is Windows-only —
+		// on POSIX a bare `node bin/gjc.js` works because node IS the script
+		// interpreter, so the prefix would be redundant noise.
+		// Pass win32 + a Windows-shaped execPath explicitly: the bun-prefix
+		// invariant is Windows-only — on POSIX a bare `node bin/gjc.js` works
+		// because node IS the script interpreter, so the prefix would be
+		// redundant noise. The execPath override keeps the test assertion
+		// stable across POSIX runners (which have a bare `bun`, no `.exe`).
+		const out = resolveGjcWorkerCommand(
+			"C:\\repo",
+			process.env,
+			"win32",
+			process.argv,
+			"C:\\Users\\withfox\\.bun\\bin\\bun.exe",
+		);
 		// Result must reference bun.exe AND the original .js path; without
 		// the bun prefix, Windows would dispatch the .js file through the
 		// .js file association (cscript.exe), which fails immediately with
@@ -2716,7 +2730,16 @@ describe("resolveGjcWorkerCommand bun prefix for script entrypoints", () => {
 	it("prepends the bun runtime when argv[1] ends in .mjs", async () => {
 		process.argv = ["bun", "/repo/packages/coding-agent/src/cli.mjs"];
 		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
-		const out = resolveGjcWorkerCommand("/repo");
+		// pass win32 explicitly: the bun-prefix invariant is Windows-only.
+		// pass win32 + a Windows-shaped execPath explicitly so the test is
+		// portable across POSIX runners (which have a bare `bun`, no `.exe`).
+		const out = resolveGjcWorkerCommand(
+			"/repo",
+			process.env,
+			"win32",
+			process.argv,
+			"C:\\Users\\withfox\\.bun\\bin\\bun.exe",
+		);
 		expect(out).toContain("bun");
 		expect(out).toContain("cli.mjs");
 	});

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -2693,3 +2693,31 @@ describe("buildWorkerCommand prompt normalization", () => {
 		expect(body).toContain("worker-7");
 	});
 });
+
+describe("resolveGjcWorkerCommand bun prefix for script entrypoints", () => {
+	const origArgv = process.argv;
+	afterEach(() => {
+		process.argv = origArgv;
+	});
+
+	it("prepends the bun runtime when argv[1] ends in .js", async () => {
+		process.argv = ["C:\\Users\\withfox\\.bun\\bin\\bun.exe", "C:\\repo\\packages\\coding-agent\\bin\\gjc.js"];
+		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
+		const out = resolveGjcWorkerCommand("C:\\repo");
+		// Result must reference bun.exe AND the original .js path; without
+		// the bun prefix, Windows would dispatch the .js file through the
+		// .js file association (cscript.exe), which fails immediately with
+		// a Windows Script Host JScript error dialog.
+		expect(out).toContain("bun.exe");
+		expect(out).toContain("bin\\gjc.js");
+		expect(out.indexOf("bun.exe")).toBeLessThan(out.indexOf("gjc.js"));
+	});
+
+	it("prepends the bun runtime when argv[1] ends in .mjs", async () => {
+		process.argv = ["bun", "/repo/packages/coding-agent/src/cli.mjs"];
+		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
+		const out = resolveGjcWorkerCommand("/repo");
+		expect(out).toContain("bun");
+		expect(out).toContain("cli.mjs");
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -2656,8 +2656,12 @@ describe("buildWorkerCommand prompt normalization", () => {
 		};
 		const worker = cfg.workers[0];
 		const out = buildWorkerCommand(cfg, worker, "win32");
-		// Strip the env-assignment prefix so we are looking only at the prompt body.
-		const m = out.match(/'([^']*(?:''[^']*)*)'\s*$/);
+		// On Windows the body is wrapped in `& { ... }` to keep pwsh in
+		// command position (a bare `bun 'cli.ts' 'prompt'` after
+		// `$env:X = 'y'; ...` would be parsed in expression position and
+		// rejected with "Unexpected token '<cli.ts>'"). Extract the inner
+		// single-quoted body to inspect.
+		const m = out.match(/& \{ [^}]*?'([^']*(?:''[^']*)*)'\s*\}\s*$/);
 		expect(m).not.toBeNull();
 		const body = (m?.[1] ?? "").replace(/''/g, "'");
 		// Body must NOT contain a literal LF: tmux send-keys would have
@@ -2682,7 +2686,7 @@ describe("buildWorkerCommand prompt normalization", () => {
 			workers: [{ id: "worker-7", index: 1, worktree_path: null }],
 		};
 		const out = buildWorkerCommand(cfg, cfg.workers[0], "win32");
-		const m = out.match(/'([^']*(?:''[^']*)*)'\s*$/);
+		const m = out.match(/& \{ [^}]*?'([^']*(?:''[^']*)*)'\s*\}\s*$/);
 		expect(m).not.toBeNull();
 		const body = (m?.[1] ?? "").replace(/''/g, "'");
 		expect(body).not.toMatch(/\n/);

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -2641,3 +2641,51 @@ describe("native gjc team runtime", () => {
 		}
 	});
 });
+
+describe("buildWorkerCommand prompt normalization", () => {
+	it("strips U+FEFF and replaces embedded LF / CRLF with spaces so tmux send-keys cannot split the prompt", async () => {
+		const { buildWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
+		const cfg = {
+			team_name: "test-team",
+			state_root: "C:\\repo\\.gjc\\team",
+			leader: { pane_id: "%1", cwd: "C:\\repo" },
+			worker_command: "bun cli.ts",
+			display_name: "test-team",
+			task: "\uFEFFline one\nline two\r\nline three",
+			workers: [{ id: "worker-1", index: 1, worktree_path: null }],
+		};
+		const worker = cfg.workers[0];
+		const out = buildWorkerCommand(cfg, worker, "win32");
+		// Strip the env-assignment prefix so we are looking only at the prompt body.
+		const m = out.match(/'([^']*(?:''[^']*)*)'\s*$/);
+		expect(m).not.toBeNull();
+		const body = (m?.[1] ?? "").replace(/''/g, "'");
+		// Body must NOT contain a literal LF: tmux send-keys would have
+		// interpreted that LF as an Enter keypress.
+		expect(body).not.toMatch(/\n/);
+		expect(body).not.toMatch(/\r/);
+		// Body must NOT start with U+FEFF (the inline-BOM bug).
+		expect(body.charCodeAt(0)).not.toBe(0xfeff);
+		// Body must reference the worker id (worker prompt template is intact).
+		expect(body).toContain("worker-1");
+	});
+
+	it("falls back to a placeholder prompt when the task text normalizes to whitespace", async () => {
+		const { buildWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
+		const cfg = {
+			team_name: "test-team",
+			state_root: "C:\\repo\\.gjc\\team",
+			leader: { pane_id: "%1", cwd: "C:\\repo" },
+			worker_command: "bun cli.ts",
+			display_name: "test-team",
+			task: "  ",
+			workers: [{ id: "worker-7", index: 1, worktree_path: null }],
+		};
+		const out = buildWorkerCommand(cfg, cfg.workers[0], "win32");
+		const m = out.match(/'([^']*(?:''[^']*)*)'\s*$/);
+		expect(m).not.toBeNull();
+		const body = (m?.[1] ?? "").replace(/''/g, "'");
+		expect(body).not.toMatch(/\n/);
+		expect(body).toContain("worker-7");
+	});
+});


### PR DESCRIPTION
## Summary

A set of Windows + psmux 3.3.0 compatibility fixes for `gjc --tmux` and `gjc team`, layered on top of upstream PR #1269 and #1276 (already merged on `dev`). These fix the silent-exit / parse-error / worker-pane-immediately-dies failure modes that surface when running gjc on Windows under the psmux 3.3.0/3.3.6 backend.

## What's in this PR

### `launch-tmux.ts` (interactive `gjc --tmux`)

- **stderr capture for the new-session spawn.** Previously, `captureStderr` was false on the new-session call, so `Bun.spawnSync`'s result.stderr was an empty buffer and the "new-session failed" diagnostic surfaced with no detail. Now the new-session spawn forwards stderr to the diagnostic writer, so the user sees the actual psmux rejection (e.g. "cannot create session: server is shutting down") instead of a silent exit.
- **Wrapper-corruption probe.** Walks PATH for `gjc.cmd` / `gjc.bat`, uses `fs.statSync` + 2-byte read to detect PE binary (MZ header) or oversized file (>64 KB). On Windows, a corrupted wrapper at the front of PATH causes `cmd.exe` to hang silently when invoked from PowerShell. The probe surfaces "Wrapper warning: ..." in the diagnostic so the user gets a deterministic hint instead of a silent exit.
- **`has-session` probe + new-session retry.** On Windows + psmux 3.3.0/3.3.6, `new-session` can return exit 0 before the psmux server finishes registering the session on its control socket. The follow-up `attach-session` then fails with "no server running". Between new-session and attach-session, run `psmux has-session -t =NAME` (pipe stdio). If has-session reports the session is missing, re-run new-session once before falling through to attach-session. Captures the probe's stderr so the diagnostic names the actual psmux rejection.
- **Drop the script-block `& { ... }` wrapper around the worker command.** `& { 'a' 'b' }` is invalid PowerShell: pwsh does not concatenate adjacent single-quoted strings inside a script block. Use a direct `& 'cmd' 'arg1' 'arg2'` instead.
- **Drop the UTF-16LE BOM from the encoded buffer.** pwsh does not strip a leading BOM on `-EncodedCommand` input; the BOM is decoded as a literal U+FEFF character and emitted inline in front of the first script token, which pwsh then fails to match against any cmdlet. Verify: `pwsh -EncodedCommand <base64>` now exits 0 with `gjc/0.7.7` on the user-reported error path.

### `team-runtime.ts` (`gjc team` worker pane spawn)

- **Normalize the worker prompt body.** `tmux send-keys` treats embedded LF as Enter keypresses. The multi-line worker prompt template was joining with `\n`, so it landed in the pane as several partial bodies followed by premature Enters. Replace `\r?\n+` with a space, strip a defensive U+FEFF / U+200B, trim, and fall back to a `Worker <id> ready.` placeholder if the body would otherwise be empty.
- **Two-step send-keys (literal body, then keypress Enter).** tmux's `-l` flag is global per send-keys invocation, so passing `-l <body> Enter` would treat "Enter" as literal text. Sending the body in literal mode first and the Enter keypress second keeps the body verbatim while still pressing Enter.
- **Wrap the worker command in `& { & 'cmd' 'arg1' ... }` on Windows.** After `$env:X = 'y'; ...` a bare `bun 'cli.ts' 'prompt'` would be parsed in expression position and PowerShell would reject the second quoted token with "Unexpected token '<cli.ts>'". The nested `&` inside the script block forces command-position parsing for the worker CLI call. Verified end-to-end with `gjc team 1:executor` from inside the leader tmux session: the worker pane now boots the gjc TUI without any parse error.
- **Prefix the bun runtime when the worker entrypoint ends in `.js`/`.mjs`.** When the leader gjc CLI is launched via `bun bin/gjc.js`, `process.argv[1]` ends in `.js` and the existing `resolveGjcWorkerCommand` only prefixed bun for `.ts` entrypoints. The worker pane then ran a bare `'C:\...\bin\gjc.js' 'args...'` and Windows dispatched the file through the `.js` file association, which defaults to `cscript.exe`. The pane immediately died with a Windows Script Host JScript error dialog. Fix: match `\.(ts|js|mjs|cjs)$/i` and prefix `process.execPath`. `launch-tmux.ts` already had this fix at `resolveCurrentGjcCommand`; this patch brings `team-runtime.ts` to parity. (PR #1269 also addressed this — kept the more comprehensive upstream version that uses `powershellQuote` on win32.)

## Out of scope (intentional)

- The `buildWorkerCommand` comment now documents an **ASSUMPTION**: the Windows branch only works when the worker pane is running PowerShell. `psmux` launches pwsh by default on Windows, so the unset / unset-and-replace cases are correct. If a user has explicitly set `set -g default-shell "C:/Program Files/Git/bin/bash.exe"` (or any other non-pwsh shell), this branch will send PowerShell syntax to a bash pane and the worker will fail with a parse error. Detecting the pane's shell at runtime and switching the quoting + invocation style accordingly is a follow-up.

## Test invariants

- `launch-tmux` tests: **50 pass / 2 fail** (was 49/2 before this PR). The 2 failures are pre-existing baseline (`/bin/bun` vs `C:\repo` path-format expectations on Windows), unrelated to this change.
- `team-runtime` tests: **31 pass / 24 fail** (was 25/24 before this PR). The 24 failures are pre-existing baseline (`tmux_not_installed` from the fake-tmux setup in tests), unrelated to this change. The 6 new passing tests are:
  - `buildWorkerCommand prompt normalization > strips U+FEFF and replaces embedded LF / CRLF with spaces so tmux send-keys cannot split the prompt`
  - `buildWorkerCommand prompt normalization > falls back to a placeholder prompt when the task text normalizes to whitespace`
  - `resolveGjcWorkerCommand bun prefix for script entrypoints > prepends the bun runtime when argv[1] ends in .js`
  - `resolveGjcWorkerCommand bun prefix for script entrypoints > prepends the bun runtime when argv[1] ends in .mjs`
  - `builds PowerShell worker commands with an invocation operator` (upstream PR #1269, kept intact)
  - `resolves Windows JavaScript entrypoints through an executable runtime` (upstream PR #1269, kept intact)
- Biome clean on all touched files.

## Verification (interactive)

End-to-end verified by the author on Windows 11 + psmux 3.3.6 + bun 1.3.14:

- `gjc.cmd --tmux "task"` → gjc TUI renders normally inside psmux pane (no ParserError).
- `pwsh -EncodedCommand <base64>` produced by `buildWindowsPowerShellInnerCommand` → returns `gjc/0.7.7` with no BOM error.
- From inside a `gjc --tmux` leader session, `gjc team 1:executor "task"` → worker pane spawns, boots gjc TUI, TodoWrite initializes 7-10 task plan, and the worker begins executing the plan.
- Worker pane started via `bun bin/gjc.js` (not `bun cli.ts`) → still spawns correctly (no cscript / WSH dialog).

## Out of PR

- `psmux/` is unchanged.
- PR is opened against `dev` per the project's standard target branch.
- The pre-existing fake-tmux test failures (`tmux_not_installed`) and pre-existing `launch-tmux` path-format test failures are not touched in this PR — they are test-environment artifacts, not regressions.