### PR TITLE
fix(ultragoal): scope ask guard to active session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - `gjc update` now verifies the installed runtime after package-manager failures and treats a nonzero Bun/npm exit as recoverable when the requested version and smoke test actually landed, avoiding false failures from Bun tarball extraction errors (#1280).
+- Scoped Ultragoal ask-guard checks for `deep-interview` and `ralplan` asks to the current session, so stale or ambiguous Ultragoal state from other sessions no longer suppresses the choice UI while same-session active Ultragoal blockers still apply.
 - Submitted user prompts now use the live terminal viewport width in wide Windows Terminal/PowerShell sessions, keeping Korean/CJK prompt wrapping responsive without changing narrow layouts (#1239).
 - Coordinator MCP now fails tmux-delivered turns that never receive a runtime prompt acknowledgement/`turn_start`, surfacing an explicit unacknowledged delivery reason instead of leaving Hermes/Oren waiting on a normal active/running state (#1237).
 - Telegram now advertises `/session_create`, `/session_recent`, `/session_close`, and `/session_resume` in the bot command menu so lifecycle control commands are discoverable from `/` autocomplete.

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
@@ -69,9 +69,12 @@ function isKnownUltragoalObjective(currentObjective: string): boolean {
 	);
 }
 
-async function ultragoalReadPaths(cwd: string): Promise<{ paths: UltragoalPaths; sessionId: string | null }> {
-	const envSessionId = process.env.GJC_SESSION_ID?.trim();
-	if (envSessionId) return { paths: getUltragoalPaths(cwd, envSessionId), sessionId: envSessionId };
+async function ultragoalReadPaths(
+	cwd: string,
+	options: { sessionId?: string | null } = {},
+): Promise<{ paths: UltragoalPaths; sessionId: string | null }> {
+	const explicitSessionId = options.sessionId?.trim() || process.env.GJC_SESSION_ID?.trim();
+	if (explicitSessionId) return { paths: getUltragoalPaths(cwd, explicitSessionId), sessionId: explicitSessionId };
 	try {
 		const session = await resolveGjcSessionForRead(cwd, { envSessionId: process.env.GJC_SESSION_ID });
 		return { paths: getUltragoalPaths(cwd, session.gjcSessionId), sessionId: session.gjcSessionId };
@@ -372,11 +375,14 @@ export async function readUltragoalVerificationState(input: {
 	return receiptDiagnostic;
 }
 
-export async function isUltragoalAskBlocked(cwd: string): Promise<UltragoalAskBlockDiagnostic> {
+export async function isUltragoalAskBlocked(
+	cwd: string,
+	options: { sessionId?: string | null } = {},
+): Promise<UltragoalAskBlockDiagnostic> {
 	let paths: UltragoalPaths;
 	let sessionId: string | null;
 	try {
-		({ paths, sessionId } = await ultragoalReadPaths(cwd));
+		({ paths, sessionId } = await ultragoalReadPaths(cwd, options));
 	} catch (error) {
 		return activeAskDiagnostic({
 			reason: `Unable to resolve durable Ultragoal state: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2007,7 +2007,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			.map(name => toolRegistry.get(name))
 			.filter((tool): tool is AgentTool => tool !== undefined)
 			// AgentSession tool wrapping is not installed until after Agent construction.
-			.map(tool => guardToolForUltragoalAsk(tool, () => sessionManager.getCwd()));
+			.map(tool =>
+				guardToolForUltragoalAsk(
+					tool,
+					() => sessionManager.getCwd(),
+					() => ({
+						activeSkillState: session?.getActiveSkillState(),
+						sessionId: sessionManager.getSessionId?.() ?? null,
+					}),
+				),
+			);
 
 		const openaiWebsocketSetting = settings.get("providers.openaiWebsockets") ?? "off";
 		const preferOpenAICodexWebsockets =

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3920,7 +3920,16 @@ export class AgentSession {
 
 	#prepareToolForExecution<T extends AgentTool>(tool: T): T {
 		return this.#wrapToolForDeepInterviewMutationGuard(
-			this.#wrapToolForAcpPermission(guardToolForUltragoalAsk(tool, () => this.sessionManager.getCwd())),
+			this.#wrapToolForAcpPermission(
+				guardToolForUltragoalAsk(
+					tool,
+					() => this.sessionManager.getCwd(),
+					() => ({
+						activeSkillState: this.getActiveSkillState(),
+						sessionId: this.sessionManager.getSessionId(),
+					}),
+				),
+			),
 		);
 	}
 

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -551,7 +551,10 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 		_onUpdate?: AgentToolUpdateCallback<AskToolDetails>,
 		context?: AgentToolContext,
 	): Promise<AgentToolResult<AskToolDetails>> {
-		await assertUltragoalAskAllowed(this.session.cwd);
+		await assertUltragoalAskAllowed(this.session.cwd, {
+			activeSkillState: this.session.getActiveSkillState?.(),
+			sessionId: this.session.getSessionId?.() ?? null,
+		});
 		const gateEmitter = this.session.getWorkflowGateEmitter?.();
 		const canUseWorkflowGate = gateEmitter?.isUnattended() === true;
 

--- a/packages/coding-agent/src/tools/ultragoal-ask-guard.ts
+++ b/packages/coding-agent/src/tools/ultragoal-ask-guard.ts
@@ -10,6 +10,29 @@ const ULTRAGOAL_ASK_GUARD = Symbol.for("gajae-code.ultragoalAskGuard");
 
 type GuardedTool = AgentTool & { [ULTRAGOAL_ASK_GUARD]?: true };
 
+export interface UltragoalAskGuardContext {
+	activeSkillState?: { skill?: string; session_id?: string } | null;
+	sessionId?: string | null;
+}
+
+const UPSTREAM_PLANNING_ASK_SKILLS = new Set(["deep-interview", "ralplan"]);
+
+function normalizedActiveSkill(context?: UltragoalAskGuardContext): string | undefined {
+	const skill = context?.activeSkillState?.skill?.trim();
+	return skill || undefined;
+}
+
+function sessionScopedAskGuardId(
+	context: UltragoalAskGuardContext,
+	activeSkill: string | undefined,
+): string | undefined {
+	if (activeSkill !== "ultragoal" && !UPSTREAM_PLANNING_ASK_SKILLS.has(activeSkill ?? "")) return undefined;
+	const activeSessionId = context.activeSkillState?.session_id?.trim();
+	if (activeSessionId) return activeSessionId;
+	const sessionId = context.sessionId?.trim();
+	return sessionId || undefined;
+}
+
 export function formatUltragoalAskBlockMessage(diagnostic: UltragoalAskBlockDiagnostic): string {
 	return [
 		diagnostic.message,
@@ -18,15 +41,26 @@ export function formatUltragoalAskBlockMessage(diagnostic: UltragoalAskBlockDiag
 	].join("\n");
 }
 
-export async function assertUltragoalAskAllowed(cwd: string): Promise<void> {
-	const diagnostic = await isUltragoalAskBlocked(cwd);
+export async function assertUltragoalAskAllowed(cwd: string, context: UltragoalAskGuardContext = {}): Promise<void> {
+	const activeSkill = normalizedActiveSkill(context);
+	// Deep-interview and ralplan are upstream planning workflows whose core gates
+	// are `ask` calls. Scope their Ultragoal check to the current session so stale
+	// or ambiguous Ultragoal durable state from another session cannot hijack those
+	// prompts; same-session active Ultragoal state still falls through to the
+	// blocker/nudge checks below.
+	const sessionId = sessionScopedAskGuardId(context, activeSkill);
+	const diagnostic = await isUltragoalAskBlocked(cwd, { sessionId });
 	if (!diagnostic.active) return;
-	const nudge = await consumeUltragoalAskNudge(cwd);
+	const nudge = await consumeUltragoalAskNudge(cwd, sessionId);
 	if (nudge.nudged) throw new ToolError(nudge.message);
 	throw new ToolError(formatUltragoalAskBlockMessage(diagnostic));
 }
 
-export function guardToolForUltragoalAsk<T extends AgentTool>(tool: T, getCwd: () => string): T {
+export function guardToolForUltragoalAsk<T extends AgentTool>(
+	tool: T,
+	getCwd: () => string,
+	getContext: () => UltragoalAskGuardContext = () => ({}),
+): T {
 	if (tool.name !== "ask") return tool;
 	const candidate = tool as GuardedTool;
 	if (candidate[ULTRAGOAL_ASK_GUARD]) return tool;
@@ -35,7 +69,7 @@ export function guardToolForUltragoalAsk<T extends AgentTool>(tool: T, getCwd: (
 			if (prop === ULTRAGOAL_ASK_GUARD) return true;
 			if (prop !== "execute") return Reflect.get(target, prop, receiver);
 			return async (...args: unknown[]): Promise<unknown> => {
-				await assertUltragoalAskAllowed(getCwd());
+				await assertUltragoalAskAllowed(getCwd(), getContext());
 				return Reflect.apply(target.execute, target, args);
 			};
 		},

--- a/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
+++ b/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
@@ -1,8 +1,13 @@
-import { afterEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AgentTool, AgentToolContext } from "@gajae-code/agent-core";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
+import {
+	activeSnapshotPath,
+	modeStatePath,
+	sessionActivityPath,
+} from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { isUltragoalAskBlocked } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
 import {
 	computeUltragoalPlanGeneration,
@@ -10,6 +15,7 @@ import {
 	getUltragoalPaths,
 	hashStructuredValue,
 } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-runtime";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { AskTool } from "@gajae-code/coding-agent/tools/ask";
 import { ToolError } from "@gajae-code/coding-agent/tools/tool-errors";
@@ -25,19 +31,24 @@ async function tempDir(): Promise<string> {
 	return dir;
 }
 
+beforeAll(async () => {
+	await initTheme(false);
+});
+
 afterEach(async () => {
 	if (ORIGINAL_GJC_SESSION_ID === undefined) delete process.env.GJC_SESSION_ID;
 	else process.env.GJC_SESSION_ID = ORIGINAL_GJC_SESSION_ID;
 	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
 
-function createSession(cwd: string): ToolSession {
+function createSession(cwd: string, overrides: Partial<ToolSession> = {}): ToolSession {
 	return {
 		cwd,
 		hasUI: true,
 		getSessionFile: () => null,
 		getSessionSpawns: () => "*",
 		settings: Settings.isolated(),
+		...overrides,
 	};
 }
 
@@ -50,6 +61,39 @@ function createContext(select: () => Promise<string | undefined>): AgentToolCont
 		},
 		abort: () => {},
 	} as unknown as AgentToolContext;
+}
+
+async function writeActivityMarker(cwd: string, sessionId: string, updatedAt: string): Promise<void> {
+	await Bun.write(
+		sessionActivityPath(cwd, sessionId),
+		`${JSON.stringify({ session_id: sessionId, updated_at: updatedAt, writer: "test" }, null, 2)}\n`,
+	);
+}
+
+async function writeActiveDeepInterviewState(cwd: string, sessionId: string): Promise<void> {
+	const now = new Date().toISOString();
+	const activeState = {
+		version: 1,
+		active: true,
+		skill: "deep-interview",
+		phase: "interviewing",
+		updated_at: now,
+		session_id: sessionId,
+		active_skills: [
+			{
+				skill: "deep-interview",
+				phase: "interviewing",
+				active: true,
+				updated_at: now,
+				session_id: sessionId,
+			},
+		],
+	};
+	await Bun.write(activeSnapshotPath(cwd, sessionId), `${JSON.stringify(activeState, null, 2)}\n`);
+	await Bun.write(
+		modeStatePath(cwd, sessionId, "deep-interview"),
+		`${JSON.stringify({ active: true, current_phase: "interviewing", session_id: sessionId }, null, 2)}\n`,
+	);
 }
 
 function stubAskTool(execute: () => Promise<void>): AgentTool {
@@ -153,6 +197,71 @@ describe("ultragoal ask guard", () => {
 			tool.execute(
 				"call",
 				{ questions: [{ id: "q", question: "Ask?", options: [{ label: "Yes" }] }] },
+				undefined,
+				undefined,
+				createContext(select),
+			),
+		).rejects.toThrow(/try-harder nudge/);
+		expect(select).not.toHaveBeenCalled();
+	});
+	it("allows active deep-interview ask when latest ultragoal sessions are ambiguous", async () => {
+		const cwd = await tempDir();
+		const deepSessionId = "deep-interview-active-session";
+		const ultragoalSessionA = "ultragoal-ambiguous-a";
+		const ultragoalSessionB = "ultragoal-ambiguous-b";
+		const tiedActivity = "2026-06-29T00:00:00.000Z";
+
+		process.env.GJC_SESSION_ID = ultragoalSessionA;
+		await createUltragoalPlan({ cwd, brief: "Implement the first stale story" });
+		process.env.GJC_SESSION_ID = ultragoalSessionB;
+		await createUltragoalPlan({ cwd, brief: "Implement the second stale story" });
+		delete process.env.GJC_SESSION_ID;
+
+		await writeActivityMarker(cwd, ultragoalSessionA, tiedActivity);
+		await writeActivityMarker(cwd, ultragoalSessionB, tiedActivity);
+		await writeActiveDeepInterviewState(cwd, deepSessionId);
+
+		const select = vi.fn(async () => "Continue");
+		const tool = new AskTool(
+			createSession(cwd, {
+				getSessionId: () => deepSessionId,
+				getActiveSkillState: () => ({ skill: "deep-interview", session_id: deepSessionId }),
+			}),
+		);
+
+		const result = await tool.execute(
+			"call",
+			{ questions: [{ id: "q", question: "Continue interview?", options: [{ label: "Continue" }] }] },
+			undefined,
+			undefined,
+			createContext(select),
+		);
+
+		expect(select).toHaveBeenCalledTimes(1);
+		expect(result.content[0]).toMatchObject({ type: "text" });
+	});
+
+	it("blocks active deep-interview ask when the same session has active ultragoal state", async () => {
+		const cwd = await tempDir();
+		const sessionId = "deep-interview-with-ultragoal-state";
+
+		process.env.GJC_SESSION_ID = sessionId;
+		await createUltragoalPlan({ cwd, brief: "Implement the same-session story" });
+		delete process.env.GJC_SESSION_ID;
+		await writeActiveDeepInterviewState(cwd, sessionId);
+
+		const select = vi.fn(async () => "Continue");
+		const tool = new AskTool(
+			createSession(cwd, {
+				getSessionId: () => sessionId,
+				getActiveSkillState: () => ({ skill: "deep-interview", session_id: sessionId }),
+			}),
+		);
+
+		await expect(
+			tool.execute(
+				"call",
+				{ questions: [{ id: "q", question: "Continue interview?", options: [{ label: "Continue" }] }] },
 				undefined,
 				undefined,
 				createContext(select),


### PR DESCRIPTION
## What

Scope the Ultragoal `ask` guard to the current GJC session when `ask` is invoked from upstream planning workflows (`deep-interview` / `ralplan`). This prevents stale or ambiguous Ultragoal durable state from other sessions from suppressing the interactive choice UI, while preserving the active Ultragoal blocker/nudge flow for same-session Ultragoal state.

Touched surfaces:

- `AskTool.execute` backstop now passes the active skill + current session id into the Ultragoal ask guard.
- `AgentSession` guarded-tool wrapping passes the same context for normal session tool execution.
- SDK initial tool wrapping passes the same context for the pre-Agent construction path.
- `isUltragoalAskBlocked` can consume an explicit session id so callers do not have to re-run latest-session auto-detect when they already know the current session.

## Why

The reported failure was not an ask-choice UI rendering bug. It was a cross-workflow guard bug:

1. We were in `deep-interview`, where `ask` is the required UI/gate path.
2. The global Ultragoal ask guard ran before the selector UI.
3. The guard tried to resolve Ultragoal durable state by latest-session auto-detect.
4. Multiple Ultragoal session activity markers made that auto-detect ambiguous.
5. The guard converted the ambiguity into `durable_state_unreadable` and blocked the `ask`, surfacing the misleading `gjc ultragoal record-review-blockers` message instead of rendering the choice UI.

That behavior is correct for a genuinely active Ultragoal run, but wrong for a planning workflow whose current session is not the ambiguous Ultragoal session. Foreign stale/ambiguous Ultragoal state should not hijack `deep-interview` or `ralplan` prompts.

## Fix

The fix is deliberately narrower than a blanket fail-open:

- For upstream planning workflows (`deep-interview`, `ralplan`), the guard checks only the current session's Ultragoal state.
- If other sessions have stale/ambiguous Ultragoal state, the planning `ask` proceeds normally.
- If the same session has active Ultragoal durable state, the guard still blocks and uses the existing nudge / `record-review-blockers` path.
- For active Ultragoal, the guard still scopes to the active Ultragoal session and preserves the existing behavior.
- For callers with no active skill context, the old auto-detect behavior remains available.

This keeps the safety property that Ultragoal runs cannot casually ask the user instead of recording blockers, without letting unrelated sessions break planning workflows.

## Regression coverage

Added two focused guard tests:

1. `allows active deep-interview ask when latest ultragoal sessions are ambiguous`
   - Sets up two tied Ultragoal session activity markers.
   - Runs an active `deep-interview` session with its own session id.
   - Verifies `AskTool.execute` reaches the selector instead of throwing the Ultragoal guard error.
   - This failed before the fix with `SessionResolutionError: ambiguous latest session among [...]` before the choice UI could render.

2. `blocks active deep-interview ask when the same session has active ultragoal state`
   - Proves the patch is not a broad bypass.
   - Same-session active Ultragoal durable state still blocks `ask` with the existing try-harder / blocker flow.

Existing active-Ultragoal ask-guard and nudge tests continue to pass.

## Testing

- `bun run --cwd packages/coding-agent check`
- `bun test packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts packages/coding-agent/test/tools/ask.test.ts packages/coding-agent/test/gjc-runtime/ultragoal-nudge-guard.test.ts`

Results observed locally:

- package check clean (`biome check .` + `tsgo -p tsconfig.json --noEmit`)
- focused suites: 73 pass / 0 fail / 278 expect calls

---

- [x] Red regression reproduced before the guard change
- [x] Same-session Ultragoal blocker behavior preserved
- [x] CHANGELOG updated
