### PR TITLE
fix(render): guard renderer string helpers against undefined (deep-interview ask /background crash + class hardening)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 
+- Fixed a class of TUI renderer crashes (`TypeError: undefined is not an object (evaluating 'x.trim'/'x.split')`) where render helpers typed `(x: string)` ran a string op on an optional/possibly-undefined tool-detail field. The deep-interview/ralplan `ask` renderer crashed on a result with a missing `question`; caught during streaming but fatal on render/teardown paths such as `/background` detach. Hardened `normalizeText`, `getPreviewLines`, `shortenPath`, and the eval git_log status-event renderer (#1290).
+
 - `gjc update` now verifies the installed runtime after package-manager failures and treats a nonzero Bun/npm exit as recoverable when the requested version and smoke test actually landed, avoiding false failures from Bun tarball extraction errors (#1280).
 - Submitted user prompts now use the live terminal viewport width in wide Windows Terminal/PowerShell sessions, keeping Korean/CJK prompt wrapping responsive without changing narrow layouts (#1239).
 - Coordinator MCP now fails tmux-delivered turns that never receive a runtime prompt acknowledgement/`turn_start`, surfacing an explicit unacknowledged delivery reason instead of leaving Hermes/Oren waiting on a normal active/running state (#1237).

--- a/packages/coding-agent/src/deep-interview/render-middleware.ts
+++ b/packages/coding-agent/src/deep-interview/render-middleware.ts
@@ -49,6 +49,7 @@ interface ThresholdModel {
 type DeepInterviewModel = RoundQuestionModel | TopologyQuestionModel | ProgressModel | ThresholdModel;
 
 function normalizeText(text: string): string {
+	if (typeof text !== "string") return "";
 	return text.trim().replaceAll("\r\n", "\n");
 }
 

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -754,8 +754,8 @@ function formatStatusEventExpanded(event: EvalStatusEvent, theme: Theme): string
 		case "git_log":
 			if (data.entries) {
 				addItems(data.entries as unknown[], e => {
-					const entry = e as { sha: string; subject: string };
-					return `${entry.sha} ${truncateToWidth(entry.subject, 50)}`;
+					const entry = e as { sha?: string; subject?: string };
+					return `${String(entry.sha ?? "")} ${truncateToWidth(String(entry.subject ?? ""), 50)}`;
 				});
 			}
 			break;

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -86,6 +86,7 @@ export const EXPAND_HINT = "(Ctrl+O for more)";
  * Get first N lines of text as preview, with each line truncated.
  */
 export function getPreviewLines(text: string, maxLines: number, maxLineLen: number, ellipsis?: Ellipsis): string[] {
+	if (typeof text !== "string") return [];
 	const lines = text.split("\n").filter(l => l.trim());
 	return lines.slice(0, maxLines).map(l => truncateToWidth(l.trim(), maxLineLen, ellipsis));
 }
@@ -568,6 +569,7 @@ export function truncateDiffByHunk(
 // =============================================================================
 
 export function shortenPath(filePath: string, homeDir?: string): string {
+	if (typeof filePath !== "string") return "";
 	const home = homeDir ?? os.homedir();
 	if (home && filePath.startsWith(home)) {
 		return `~${filePath.slice(home.length)}`;

--- a/packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts
+++ b/packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts
@@ -1,8 +1,14 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import type { AssistantMessage } from "@gajae-code/ai";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
+import {
+	formatDeepInterviewSelectorPrompt,
+	isDeepInterviewAskQuestion,
+	renderDeepInterviewAskQuestion,
+} from "@gajae-code/coding-agent/deep-interview/render-middleware";
 import { AssistantMessageComponent } from "@gajae-code/coding-agent/modes/components/assistant-message";
-import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { initTheme, theme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { askToolRenderer } from "@gajae-code/coding-agent/tools/ask";
 
 function createAssistantMessage(text: string): AssistantMessage {
 	return {
@@ -106,5 +112,43 @@ describe("deep-interview assistant render middleware", () => {
 		expect(rendered).toContain("한국어 출력이 리터럴로 보여야 합니다");
 		expect(rendered).toContain("한국어 기준을 명확히 합니다");
 		expect(rendered).not.toContain("\\u");
+	});
+});
+
+describe("deep-interview render middleware null-safety", () => {
+	for (const value of [undefined, null] as const) {
+		it(`does not throw on ${String(value)} question input`, () => {
+			// @ts-expect-error exercising defensive guard against missing question text
+			expect(() => isDeepInterviewAskQuestion(value)).not.toThrow();
+			// @ts-expect-error exercising defensive guard against missing question text
+			expect(() => formatDeepInterviewSelectorPrompt(value)).not.toThrow();
+			// @ts-expect-error exercising defensive guard against missing question text
+			expect(() => renderDeepInterviewAskQuestion(value, theme)).not.toThrow();
+			// @ts-expect-error exercising defensive guard against missing question text
+			expect(isDeepInterviewAskQuestion(value)).toBe(false);
+			// @ts-expect-error exercising defensive guard against missing question text
+			expect(renderDeepInterviewAskQuestion(value, theme)).toBeNull();
+		});
+	}
+
+	it("renders an ask result with a missing question field without crashing", () => {
+		const result = {
+			content: [{ type: "text", text: "User answers:" }],
+			details: {
+				results: [
+					{
+						id: "q1",
+						// question intentionally omitted to mirror malformed/partial ask details
+						options: ["a", "b"],
+						multi: false,
+						selectedOptions: ["a"],
+					},
+				],
+			},
+		};
+		expect(() =>
+			// @ts-expect-error partial details deliberately omit the question field
+			askToolRenderer.renderResult(result, { expanded: false, isPartial: false }, theme).render(100),
+		).not.toThrow();
 	});
 });

--- a/packages/coding-agent/test/tools/render-utils.test.ts
+++ b/packages/coding-agent/test/tools/render-utils.test.ts
@@ -8,6 +8,8 @@ import {
 	formatDiagnostics,
 	formatParseErrors,
 	formatScreenshot,
+	getPreviewLines,
+	shortenPath,
 } from "@gajae-code/coding-agent/tools/render-utils";
 
 describe("parse error formatting", () => {
@@ -182,5 +184,25 @@ describe("formatCodeFrameLine", () => {
 		expect(formatCodeFrameLine("*", 448, "match", 3)).toBe("*448│match");
 		expect(formatCodeFrameLine("+", 11, "added", 3)).toBe(" +11│added");
 		expect(formatCodeFrameLine("+", 235, "added", 3)).toBe("+235│added");
+	});
+});
+
+describe("render helper null-safety", () => {
+	it("getPreviewLines returns [] for non-string input instead of throwing", () => {
+		// Mirrors the normalizeText-class bug: a (text: string) helper doing a
+		// first-action string op crashes when a renderer passes an optional field.
+		expect(() => getPreviewLines(undefined as unknown as string, 3, 80)).not.toThrow();
+		expect(getPreviewLines(undefined as unknown as string, 3, 80)).toEqual([]);
+		expect(getPreviewLines(null as unknown as string, 3, 80)).toEqual([]);
+		// Sanity: real input still works.
+		expect(getPreviewLines("a\nb\nc\nd", 2, 80)).toEqual(["a", "b"]);
+	});
+
+	it("shortenPath returns '' for non-string input instead of throwing", () => {
+		expect(() => shortenPath(undefined as unknown as string)).not.toThrow();
+		expect(shortenPath(undefined as unknown as string)).toBe("");
+		expect(shortenPath(null as unknown as string)).toBe("");
+		// Sanity: real input still works.
+		expect(shortenPath("/home/u/x", "/home/u")).toBe("~/x");
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - The render loop now isolates a component whose `render()` throws: the failure is logged once and replaced with a `[render error: <Name>]` fallback line instead of escaping the frame and tripping the process-level fail-fast `uncaughtException` exit. Previously any unguarded renderer fault (e.g. a tool renderer fed an undefined field) crashed the whole app on whatever triggered the next frame — a keystroke, resize, or command such as `/background` (#1291).
+- `truncateToWidth` now coerces its required napi `text` argument to a safe string, mirroring the existing nullish guards for `maxWidth`/`ellipsis`/`pad`. Renderers that passed an optional/possibly-undefined field no longer crash with a napi String conversion / `undefined is not an object` error (#1290).
 
 - Resolved terminal dimensions from the live TTY window size before stream defaults so wide Windows Terminal/PowerShell sessions render against the actual viewport width (#1239).
 

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -45,14 +45,18 @@ export function truncateToWidth(
 	// Guard nullish napi inputs: napi-rs 3 on the Windows prebuilt rejects
 	// `null` for `Option<u8>` (Ellipsis) / `Option<bool>` (pad) (issue #848),
 	// and `maxWidth` is a required `u32` that throws on `null`/`undefined`
-	// everywhere. Pass concrete defaults that mirror the Rust `unwrap_or`s.
+	// everywhere. The `text` arg is a required `String` that likewise throws on
+	// `null`/`undefined` on every platform, which crashed renderers that passed
+	// an optional/possibly-undefined field. Pass concrete defaults that mirror
+	// the Rust `unwrap_or`s.
+	const safeText = typeof text === "string" ? text : String(text ?? "");
 	const safeWidth = Number.isFinite(maxWidth) ? Math.max(0, Math.trunc(maxWidth)) : 0;
 	let resolvedEllipsis: Ellipsis | null | undefined | string = ellipsisKind;
 	if (typeof resolvedEllipsis === "string") {
 		resolvedEllipsis = resolvedEllipsis === "" ? Ellipsis.Omit : Ellipsis.Unicode;
 	}
 	return nativeTruncateToWidth(
-		text,
+		safeText,
 		safeWidth,
 		resolvedEllipsis ?? Ellipsis.Unicode,
 		pad ?? false,

--- a/packages/tui/test/issue-848-repro.test.ts
+++ b/packages/tui/test/issue-848-repro.test.ts
@@ -48,4 +48,20 @@ describe("issue #848: truncateToWidth wrapper rejects nullish napi inputs", () =
 		const result = truncateToWidth("hello world", undefined as unknown as number, Ellipsis.Omit, null);
 		expect(typeof result).toBe("string");
 	});
+
+	it("does not throw a napi conversion error when text is undefined", () => {
+		// Renderers passed an optional/possibly-undefined field straight into
+		// truncateToWidth (e.g. an ask/git_log detail whose field was omitted),
+		// which crashed with "undefined is not an object" / a napi String
+		// conversion error. The wrapper must coerce text to a safe string.
+		const result = truncateToWidth(undefined as unknown as string, 50, Ellipsis.Unicode, null);
+		expect(typeof result).toBe("string");
+		expect(result).toBe("");
+	});
+
+	it("does not throw a napi conversion error when text is null", () => {
+		const result = truncateToWidth(null as unknown as string, 50, Ellipsis.Unicode, null);
+		expect(typeof result).toBe("string");
+		expect(result).toBe("");
+	});
 });


### PR DESCRIPTION
## What

Fix a class of TUI renderer crashes where render helpers typed `(x: string)` perform a first-action `String.prototype` op, so a renderer that receives an optional/possibly-undefined detail field crashes with `TypeError: undefined is not an object (evaluating 'x.trim'/'x.split')`.

Commit 1 — the originally-reported crash:
- `deep-interview/render-middleware.ts` `normalizeText()` called `text.trim()` unconditionally. The `ask` tool renderer routes `AskToolDetails.question` / `QuestionResult.question` (both effectively optional — `question?: string`) through `renderDeepInterviewAskQuestion` → `parseTopologyQuestion`/`parseRoundQuestion` → `normalizeText`. A ralplan/deep-interview ask whose result carried a missing `question` crashed the renderer. Guard `normalizeText` for non-string input so the three entry points (`renderDeepInterviewAskQuestion`, `isDeepInterviewAskQuestion`, `formatDeepInterviewSelectorPrompt`) fail soft.

Commit 2 — class hardening after auditing every tool/middleware renderer (`renderCall`/`renderResult` + helpers) across `coding-agent` + `tui`:
- The class was **not** widespread — most call sites already guard with `typeof x === "string"` / `?? ""` / `if (!x)`. Hardened the keystone primitive plus the two remaining unguarded `(x: string)` helpers and the one confirmed reachable call site:
  - `tui` `truncateToWidth()`: coerce the required napi `text` arg to a safe string, mirroring the existing issue #848 nullish guards for `maxWidth`/`ellipsis`/`pad`. This is the most-used render primitive, so it neutralizes the class at the boundary.
  - `render-utils` `getPreviewLines()` / `shortenPath()`: guard non-string input (return `[]` / `""`) instead of throwing.
  - `eval.ts` git_log status-event renderer: `String()`-wrap `entry.sha`/`entry.subject`, which come from an `unknown[]` cast and can be undefined.

## Why

During normal streaming these crashes are caught by `modes/components/tool-execution.ts`'s try/catch (logged as `Tool renderer failed`), so they only flooded warnings. They turn **fatal** on render/teardown paths outside that try/catch — e.g. pressing `/background` (UI detach via `ui.stop()` + `SIGTSTP`) during a ralplan `ask`, which is how this was originally hit. Present on `main` (v0.7.7) and `dev`.

## Testing

- New regression tests, each verified to fail without its fix and pass with it:
  - `deep-interview-render-middleware.test.ts`: 3 entry points with undefined/null + end-to-end `askToolRenderer.renderResult` with a missing `question`.
  - `tui/test/issue-848-repro.test.ts`: `truncateToWidth` undefined/null `text` → `""`.
  - `render-utils.test.ts`: `getPreviewLines`/`shortenPath` non-string input.
- `bun test` on all touched + adjacent suites green (deep-interview render, render-utils, ask, eval, tui text-utils/truncate). tsc clean on changed files; biome clean.

---

- [x] Tested locally (targeted + adjacent suites)
- [x] CHANGELOG updated
