### PR TITLE
fix(tui): isolate per-component render failures so one throw can't crash the app

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- The render loop now isolates a component whose `render()` throws: the failure is logged once and replaced with a `[render error: <Name>]` fallback line instead of escaping the frame and tripping the process-level fail-fast `uncaughtException` exit. Previously any unguarded renderer fault (e.g. a tool renderer fed an undefined field) crashed the whole app on whatever triggered the next frame — a keystroke, resize, or command such as `/background` (#1291).
+
 - Resolved terminal dimensions from the live TTY window size before stream defaults so wide Windows Terminal/PowerShell sessions render against the actual viewport width (#1239).
 
 ## [0.7.4] - 2026-06-27

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -4,7 +4,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { performance } from "node:perf_hooks";
-import { $flag, getDebugLogPath } from "@gajae-code/utils";
+import { $flag, getDebugLogPath, logger } from "@gajae-code/utils";
 import { getKeybindings } from "./keybindings";
 import { isKeyRelease } from "./keys";
 import { renderMetrics } from "./metrics";
@@ -257,12 +257,46 @@ export class Container implements Component {
 		width = Math.max(1, width);
 		const lines: string[] = [];
 		for (const child of this.children) {
-			const childLines = child.render(width);
+			const childLines = safeRenderComponent(child, width, "container-child");
 			for (let i = 0; i < childLines.length; i++) {
 				lines.push(childLines[i]);
 			}
 		}
 		return lines;
+	}
+}
+
+const MAX_REPORTED_RENDER_ERRORS = 200;
+const reportedRenderErrors = new Set<string>();
+
+/**
+ * Render a component's lines without letting a thrown error escape the frame.
+ *
+ * The TUI render loop ({@link TUI.#doRender}) runs inside a `nextTick`/`setTimeout`
+ * with no try/catch, and the process installs a fail-fast `uncaughtException`
+ * handler that exits. So a single component whose `render()` throws (e.g. a tool
+ * renderer fed an optional/undefined field) used to take down the whole app —
+ * fatal on whatever happened to trigger the frame (a keystroke, resize, or a
+ * command such as `/background`). Isolate the failure: log it once, emit a
+ * visible fallback line, and keep rendering the rest of the tree.
+ */
+function safeRenderComponent(component: Component, width: number, where: string): string[] {
+	try {
+		return component.render(width);
+	} catch (err) {
+		const name = component?.constructor?.name ?? "Component";
+		const key = `${where}:${name}:${err instanceof Error ? err.message : String(err)}`;
+		if (!reportedRenderErrors.has(key)) {
+			if (reportedRenderErrors.size >= MAX_REPORTED_RENDER_ERRORS) reportedRenderErrors.clear();
+			reportedRenderErrors.add(key);
+			logger.error("Component render failed; emitting fallback line", {
+				where,
+				component: name,
+				error: err instanceof Error ? err.message : String(err),
+				stack: err instanceof Error ? err.stack : undefined,
+			});
+		}
+		return [`[render error: ${name}]`];
 	}
 }
 
@@ -1071,7 +1105,7 @@ export class TUI extends Container {
 			const { width, maxHeight } = this.#resolveOverlayLayout(options, 0, termWidth, termHeight);
 
 			// Render component at calculated width
-			let overlayLines = component.render(width);
+			let overlayLines = safeRenderComponent(component, width, "overlay");
 
 			// Apply maxHeight if specified
 			if (maxHeight !== undefined && overlayLines.length > maxHeight) {
@@ -1302,7 +1336,7 @@ export class TUI extends Container {
 
 		let pinnedLineCount = 0;
 		for (let i = pinnedStart; i < this.children.length; i++) {
-			pinnedLineCount += this.children[i].render(this.terminal.columns).length;
+			pinnedLineCount += safeRenderComponent(this.children[i], this.terminal.columns, "pinned").length;
 		}
 
 		const blankRows = height - lines.length;

--- a/packages/tui/test/render-loop-resilience.test.ts
+++ b/packages/tui/test/render-loop-resilience.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { type Component, Container } from "@gajae-code/tui";
+
+/** Component whose render() always throws, mirroring a tool renderer fed an undefined field. */
+class ThrowingComponent implements Component {
+	invalidate(): void {}
+	render(_width: number): string[] {
+		// The exact shape of the original crash: a string op on undefined.
+		const value = undefined as unknown as string;
+		return [value.trim()];
+	}
+}
+
+/** Minimal fixed-line component. */
+class FixedLines implements Component {
+	constructor(private readonly lines: string[]) {}
+	invalidate(): void {}
+	render(_width: number): string[] {
+		return this.lines;
+	}
+}
+
+describe("render loop resilience: a throwing child must not crash the frame", () => {
+	it("isolates a throwing child and keeps rendering the rest of the tree", () => {
+		const container = new Container();
+		container.addChild(new FixedLines(["before"]));
+		container.addChild(new ThrowingComponent());
+		container.addChild(new FixedLines(["after"]));
+
+		let out: string[] = [];
+		expect(() => {
+			out = container.render(80);
+		}).not.toThrow();
+
+		// Siblings still rendered.
+		expect(out).toContain("before");
+		expect(out).toContain("after");
+		// The throwing child contributed a visible fallback line instead of taking down the frame.
+		expect(out.some(l => l.includes("render error"))).toBe(true);
+	});
+
+	it("survives a throwing child nested inside a child container", () => {
+		const inner = new Container();
+		inner.addChild(new ThrowingComponent());
+		inner.addChild(new FixedLines(["inner-tail"]));
+
+		const outer = new Container();
+		outer.addChild(new FixedLines(["outer-head"]));
+		outer.addChild(inner);
+
+		let out: string[] = [];
+		expect(() => {
+			out = outer.render(80);
+		}).not.toThrow();
+
+		expect(out).toContain("outer-head");
+		expect(out).toContain("inner-tail");
+		expect(out.some(l => l.includes("render error"))).toBe(true);
+	});
+});


### PR DESCRIPTION
## What

Make the TUI render loop resilient: a single component whose `render()` throws is now isolated (logged once + a visible `[render error: <Name>]` fallback line) instead of crashing the whole process. Wraps the three render entry points in a new `safeRenderComponent` helper:

- `Container.render` child loop (the main component tree)
- overlay composite render (`#compositeOverlays`)
- bottom-pinned component measurement (`#padBeforeBottomPinnedComponent`)

## Why

Two architectural facts combine into "any renderer bug = full app crash, from any trigger":

1. **`TUI.#doRender` is unprotected.** It runs every component's `render(width)` (via `Container.render`, which calls `child.render(width)` with no try/catch) inside a `process.nextTick`/`setTimeout` callback.
2. **Uncaught = exit.** `@gajae-code/utils` `postmortem` installs a fail-fast `uncaughtException` handler that runs cleanup and `process.exit(1)` (intentional fail-fast, wired via `main.ts` / `interactive-mode.ts`).

So a throw in any component's `render()` escapes the frame callback → no local catch → postmortem → `process.exit(1)`. The frame is driven by every keystroke, resize, scroll, and command, so the crash surfaces on whatever triggers the next frame — **it is not specific to any one command**. The reported repro was pressing `/background` (UI detach) during a ralplan `ask`, but the same underlying renderer fault would go fatal via resize/scroll/`/compact`/navigation just as easily.

Note `tool-execution` only wraps the **construction** of `renderCall`/`renderResult` in try/catch (the "Tool renderer failed" warning path). The returned component's later `render(width)`, and any render path outside that component (overlays, live selectors, assistant-message), were unprotected — so even with that warning path, a render-time throw was still fatal.

This is defense-in-depth for the **whole class**. The specific data-layer guards that fix the deep-interview/ask + shared-helper crashes ship separately in #1290; this PR ensures that *any* future unguarded renderer fault degrades to a fallback line rather than killing the session.

## Testing

- New `packages/tui/test/render-loop-resilience.test.ts`: a throwing child (top-level and nested in a child container) no longer crashes `Container.render`; siblings still render and a `[render error: ...]` fallback line is emitted. Verified to fail without the guard (exact `TypeError: undefined is not an object (evaluating '...trim')`) and pass with it.
- Full `packages/tui/test` suite: 552 pass. The only 2 failures (`keys.test.ts` legacy Alt+LF) are pre-existing on `dev` and unrelated (verified by reproducing them on a clean `dev` checkout). tsc clean on changed files; biome clean.

---

- [x] Tested locally (targeted + full tui suite; pre-existing unrelated failures noted)
- [x] CHANGELOG updated
