### PR TITLE
Fix gjc --tmux workspace titles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Submitted user prompts now use the live terminal viewport width in wide Windows Terminal/PowerShell sessions, keeping Korean/CJK prompt wrapping responsive without changing narrow layouts (#1239).
 - Coordinator MCP now fails tmux-delivered turns that never receive a runtime prompt acknowledgement/`turn_start`, surfacing an explicit unacknowledged delivery reason instead of leaving Hermes/Oren waiting on a normal active/running state (#1237).
 - Telegram now advertises `/session_create`, `/session_recent`, `/session_close`, and `/session_resume` in the bot command menu so lifecycle control commands are discoverable from `/` autocomplete.
+- `gjc --tmux` now prefixes the root terminal title (`GJC: tmp`) and managed tmux window names (`GJC-tmp`) with a GJC workspace label so terminal multiplexers and workspace switchers do not fall back to noisy launch paths.
 
 ## [0.7.7] - 2026-06-28
 ### Added

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -585,7 +585,6 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			);
 			return true;
 		}
-		if (rootTerminalTitle) setGjcTmuxRootTerminalTitle(rootTerminalTitle);
 	}
 	if (created.exitCode !== 0) return false;
 	const attached = spawnSync(
@@ -593,7 +592,10 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env })],
 		options,
 	);
-	if (attached.exitCode === 0) return true;
+	if (attached.exitCode === 0) {
+		if (rootTerminalTitle) setGjcTmuxRootTerminalTitle(rootTerminalTitle);
+		return true;
+	}
 	if (isTmuxAttachDisconnectError(attached)) {
 		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("attach disconnected", attached.stderr));
 		return true;

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -367,6 +367,10 @@ function setGjcTmuxRootTerminalTitle(title: string): void {
 	process.stdout.write(`\x1b]0;${sanitized}\x07`);
 }
 
+function shouldSetGjcTmuxRootTerminalTitle(parsed: Args, env: NodeJS.ProcessEnv): boolean {
+	return !parsed.noTitle && !env.PI_NO_TITLE;
+}
+
 function buildTmuxRenameWindowArgs(title: string, target?: string): string[] {
 	return target ? ["rename-window", "-t", target, "--", title] : ["rename-window", "--", title];
 }
@@ -535,7 +539,9 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 	};
 
 	const windowTitle = buildGjcTmuxWindowTitle(plan.project ?? plan.cwd, plan.branch);
-	setGjcTmuxRootTerminalTitle(buildGjcTmuxRootTerminalTitle(plan.project ?? plan.cwd, plan.branch));
+	const rootTerminalTitle = shouldSetGjcTmuxRootTerminalTitle(context.parsed, env)
+		? buildGjcTmuxRootTerminalTitle(plan.project ?? plan.cwd, plan.branch)
+		: undefined;
 
 	if (plan.attachSessionName) {
 		const attached = spawnSync(
@@ -543,7 +549,10 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.attachSessionName, { env })],
 			options,
 		);
-		if (attached.exitCode === 0) return true;
+		if (attached.exitCode === 0) {
+			if (rootTerminalTitle) setGjcTmuxRootTerminalTitle(rootTerminalTitle);
+			return true;
+		}
 	}
 
 	const created = spawnSync(plan.tmuxCommand, plan.newSessionArgs, options);
@@ -576,6 +585,7 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			);
 			return true;
 		}
+		if (rootTerminalTitle) setGjcTmuxRootTerminalTitle(rootTerminalTitle);
 	}
 	if (created.exitCode !== 0) return false;
 	const attached = spawnSync(

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -35,6 +35,7 @@ export const GJC_TMUX_LAUNCHED_ENV = "GJC_TMUX_LAUNCHED";
 export const GJC_LAUNCH_POLICY_ENV = "GJC_LAUNCH_POLICY";
 export const GJC_TMUX_WINDOW_LABEL_MAX_WIDTH = 48;
 export const GJC_PSMUX_PROFILE_FORCE_ENV = "GJC_PSMUX_PROFILE_FORCE";
+const TERMINAL_TITLE_CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
 
 type LaunchPolicy = "direct" | "tmux";
 
@@ -321,6 +322,8 @@ function truncateVisibleTail(value: string, maxWidth: number): string {
 }
 
 const GJC_TMUX_WINDOW_BRANCH_SEPARATOR = "-";
+const GJC_TMUX_WINDOW_TITLE_PREFIX = "GJC-";
+const GJC_TMUX_TERMINAL_TITLE_PREFIX = "GJC: ";
 
 function sanitizeTmuxWindowTitleSegment(value: string): string {
 	return value.replace(/:+/g, "-");
@@ -333,20 +336,35 @@ function sanitizeTmuxWindowProjectName(project: string): string {
 	return sanitizeTmuxWindowTitleSegment(trimmed);
 }
 
-export function buildGjcTmuxWindowTitle(cwd: string, branch: string | null | undefined): string {
+function buildGjcTmuxPrefixedTitle(prefix: string, cwd: string, branch: string | null | undefined): string {
 	const project = sanitizeTmuxWindowProjectName(path.basename(path.resolve(cwd)) || "gjc");
+	const projectTitle = `${prefix}${project}`;
 	const trimmedBranch = sanitizeTmuxWindowTitleSegment(branch?.trim() ?? "");
-	if (!trimmedBranch) return truncateVisible(project, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
+	if (!trimmedBranch) return truncateVisible(projectTitle, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
 
 	const separatorWidth = visibleWidth(GJC_TMUX_WINDOW_BRANCH_SEPARATOR);
-	const projectWidth = visibleWidth(project);
-	const fullTitle = `${project}${GJC_TMUX_WINDOW_BRANCH_SEPARATOR}${trimmedBranch}`;
+	const projectWidth = visibleWidth(projectTitle);
+	const fullTitle = `${projectTitle}${GJC_TMUX_WINDOW_BRANCH_SEPARATOR}${trimmedBranch}`;
 	if (visibleWidth(fullTitle) <= GJC_TMUX_WINDOW_LABEL_MAX_WIDTH) return fullTitle;
 
 	const remainingBranchWidth = GJC_TMUX_WINDOW_LABEL_MAX_WIDTH - projectWidth - separatorWidth;
-	if (remainingBranchWidth <= 0) return truncateVisible(project, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
+	if (remainingBranchWidth <= 0) return truncateVisible(projectTitle, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
 
-	return `${project}${GJC_TMUX_WINDOW_BRANCH_SEPARATOR}${truncateVisibleTail(trimmedBranch, remainingBranchWidth)}`;
+	return `${projectTitle}${GJC_TMUX_WINDOW_BRANCH_SEPARATOR}${truncateVisibleTail(trimmedBranch, remainingBranchWidth)}`;
+}
+
+export function buildGjcTmuxWindowTitle(cwd: string, branch: string | null | undefined): string {
+	return buildGjcTmuxPrefixedTitle(GJC_TMUX_WINDOW_TITLE_PREFIX, cwd, branch);
+}
+
+function buildGjcTmuxRootTerminalTitle(cwd: string, branch: string | null | undefined): string {
+	return buildGjcTmuxPrefixedTitle(GJC_TMUX_TERMINAL_TITLE_PREFIX, cwd, branch);
+}
+
+function setGjcTmuxRootTerminalTitle(title: string): void {
+	if (!process.stdout.isTTY) return;
+	const sanitized = title.replace(TERMINAL_TITLE_CONTROL_CHARS, "").trim() || "GJC";
+	process.stdout.write(`\x1b]0;${sanitized}\x07`);
 }
 
 function buildTmuxRenameWindowArgs(title: string, target?: string): string[] {
@@ -516,6 +534,9 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		stderr: "inherit",
 	};
 
+	const windowTitle = buildGjcTmuxWindowTitle(plan.project ?? plan.cwd, plan.branch);
+	setGjcTmuxRootTerminalTitle(buildGjcTmuxRootTerminalTitle(plan.project ?? plan.cwd, plan.branch));
+
 	if (plan.attachSessionName) {
 		const attached = spawnSync(
 			plan.tmuxCommand,
@@ -529,7 +550,7 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 	if (created.exitCode === 0) {
 		renameTmuxWindow(
 			plan.tmuxCommand,
-			buildGjcTmuxWindowTitle(plan.project ?? plan.cwd, plan.branch),
+			windowTitle,
 			spawnSync,
 			options,
 			buildGjcTmuxExactSessionTarget(plan.sessionName, { env }),

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -169,8 +169,8 @@ describe("default GJC tmux launch", () => {
 			const attachIndex = events.lastIndexOf("spawn:attach-session");
 
 			expect(newSessionIndex).toBeGreaterThanOrEqual(0);
-			expect(titleIndex).toBeGreaterThan(newSessionIndex);
-			expect(attachIndex).toBeGreaterThan(titleIndex);
+			expect(attachIndex).toBeGreaterThan(newSessionIndex);
+			expect(titleIndex).toBeGreaterThan(attachIndex);
 			expect(writeSpy).toHaveBeenCalledTimes(1);
 		} finally {
 			stdout.isTTY = previousIsTTY;
@@ -691,31 +691,41 @@ describe("default GJC tmux launch", () => {
 	it("cleans up a newly created managed session when attach fails", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
 		const diagnostics: string[] = [];
-		const handled = launchDefaultTmuxIfNeeded({
-			parsed: args({ tmux: true }),
-			rawArgs: [],
-			cwd: "/repo",
-			env: {},
-			argv: ["/usr/local/bin/gjc"],
-			execPath: "/bin/bun",
-			platform: "darwin",
-			tty: interactiveTty,
-			tmuxAvailable: true,
-			currentBranch: "",
-			existingBranchSessionName: null,
-			diagnosticWriter: message => diagnostics.push(message),
-			spawnSync: (command, spawnArgs, options) => {
-				calls.push({ command, args: spawnArgs, options });
-				if (spawnArgs[0] === "attach-session") return { exitCode: 1, stderr: "attach failed" };
-				return { exitCode: 0 };
-			},
-		});
+		const stdout = process.stdout as typeof process.stdout & { isTTY?: boolean };
+		const previousIsTTY = stdout.isTTY;
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+		stdout.isTTY = true;
 
-		expect(handled).toBe(true);
-		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
-		expect(calls.some(call => call.args[0] === "attach-session")).toBe(true);
-		expect(calls.some(call => call.args[0] === "kill-session")).toBe(true);
-		expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach failed.");
+		try {
+			const handled = launchDefaultTmuxIfNeeded({
+				parsed: args({ tmux: true }),
+				rawArgs: [],
+				cwd: "/repo",
+				env: {},
+				argv: ["/usr/local/bin/gjc"],
+				execPath: "/bin/bun",
+				platform: "darwin",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				currentBranch: "",
+				existingBranchSessionName: null,
+				diagnosticWriter: message => diagnostics.push(message),
+				spawnSync: (command, spawnArgs, options) => {
+					calls.push({ command, args: spawnArgs, options });
+					if (spawnArgs[0] === "attach-session") return { exitCode: 1, stderr: "attach failed" };
+					return { exitCode: 0 };
+				},
+			});
+
+			expect(handled).toBe(true);
+			expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
+			expect(calls.some(call => call.args[0] === "attach-session")).toBe(true);
+			expect(calls.some(call => call.args[0] === "kill-session")).toBe(true);
+			expect(writeSpy).not.toHaveBeenCalled();
+			expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach failed.");
+		} finally {
+			stdout.isTTY = previousIsTTY;
+		}
 	});
 
 	it("builds a session-scoped tmux profile without global tmux mutation", () => {

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -67,23 +67,23 @@ describe("default GJC tmux launch", () => {
 	});
 
 	it("builds sanitized project and branch tmux window titles", () => {
-		expect(buildGjcTmuxWindowTitle("/repo", "feature/demo")).toBe("repo-feature/demo");
-		expect(buildGjcTmuxWindowTitle("/repo", "main")).toBe("repo-main");
-		expect(buildGjcTmuxWindowTitle("/repo", null)).toBe("repo");
-		expect(buildGjcTmuxWindowTitle("/repo", "")).toBe("repo");
+		expect(buildGjcTmuxWindowTitle("/repo", "feature/demo")).toBe("GJC-repo-feature/demo");
+		expect(buildGjcTmuxWindowTitle("/repo", "main")).toBe("GJC-repo-main");
+		expect(buildGjcTmuxWindowTitle("/repo", null)).toBe("GJC-repo");
+		expect(buildGjcTmuxWindowTitle("/repo", "")).toBe("GJC-repo");
 	});
 
 	it("replaces colon-bearing tmux window title segments", () => {
-		expect(buildGjcTmuxWindowTitle("/repo:backend", "main")).toBe("repo-backend-main");
-		expect(buildGjcTmuxWindowTitle("/repo", "release:main")).toBe("repo-release-main");
-		expect(buildGjcTmuxWindowTitle("/repo", "feature:::demo")).toBe("repo-feature-demo");
+		expect(buildGjcTmuxWindowTitle("/repo:backend", "main")).toBe("GJC-repo-backend-main");
+		expect(buildGjcTmuxWindowTitle("/repo", "release:main")).toBe("GJC-repo-release-main");
+		expect(buildGjcTmuxWindowTitle("/repo", "feature:::demo")).toBe("GJC-repo-feature-demo");
 	});
 
 	it("truncates long tmux window titles to 48 visible columns while preserving the project and branch tail", () => {
 		const title = buildGjcTmuxWindowTitle("/repo", `feature/${"a".repeat(80)}tail`);
 
 		expect(Bun.stringWidth(title)).toBeLessThanOrEqual(48);
-		expect(title.startsWith("repo-…")).toBe(true);
+		expect(title.startsWith("GJC-repo-…")).toBe(true);
 		expect(title.endsWith("tail")).toBe(true);
 	});
 
@@ -91,16 +91,16 @@ describe("default GJC tmux launch", () => {
 		const title = buildGjcTmuxWindowTitle("/저장소", `feature/${"界".repeat(80)}끝`);
 
 		expect(Bun.stringWidth(title)).toBeLessThanOrEqual(48);
-		expect(title.startsWith("저장소-…")).toBe(true);
+		expect(title.startsWith("GJC-저장소-…")).toBe(true);
 		expect(title.endsWith("끝")).toBe(true);
 	});
 
 	it("sanitizes dot-prefixed cwd basenames for tmux window titles", () => {
-		expect(buildGjcTmuxWindowTitle("/tmp/.claude", null)).toBe("dot-claude");
-		expect(buildGjcTmuxWindowTitle("/tmp/.claude", "feature/demo")).toBe("dot-claude-feature/demo");
-		expect(buildGjcTmuxWindowTitle("/tmp/.claude", "repo:main")).toBe("dot-claude-repo-main");
-		expect(buildGjcTmuxWindowTitle("/tmp/...", null)).toBe("gjc");
-		expect(buildGjcTmuxWindowTitle("/tmp/...", "feature/demo")).toBe("gjc-feature/demo");
+		expect(buildGjcTmuxWindowTitle("/tmp/.claude", null)).toBe("GJC-dot-claude");
+		expect(buildGjcTmuxWindowTitle("/tmp/.claude", "feature/demo")).toBe("GJC-dot-claude-feature/demo");
+		expect(buildGjcTmuxWindowTitle("/tmp/.claude", "repo:main")).toBe("GJC-dot-claude-repo-main");
+		expect(buildGjcTmuxWindowTitle("/tmp/...", null)).toBe("GJC-gjc");
+		expect(buildGjcTmuxWindowTitle("/tmp/...", "feature/demo")).toBe("GJC-gjc-feature/demo");
 	});
 
 	it("passes sanitized dot-prefixed cwd basenames to tmux rename-window", () => {
@@ -130,11 +130,49 @@ describe("default GJC tmux launch", () => {
 			"-t",
 			expect.stringMatching(/^=gajae_code_/),
 			"--",
-			"dot-claude",
+			"GJC-dot-claude",
 		]);
 	});
 
-	it("separates dash-leading tmux window titles from tmux options", () => {
+	it("sets the root terminal title before starting managed tmux", () => {
+		const events: string[] = [];
+		const stdout = process.stdout as typeof process.stdout & { isTTY?: boolean };
+		const previousIsTTY = stdout.isTTY;
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+			events.push(String(chunk));
+			return true;
+		});
+		stdout.isTTY = true;
+
+		try {
+			const handled = launchDefaultTmuxIfNeeded({
+				parsed: args({ messages: ["hello world"], tmux: true }),
+				rawArgs: ["--tmux", "hello world"],
+				cwd: "/repo",
+				env: {},
+				argv: ["bun", "packages/coding-agent/src/cli.ts"],
+				execPath: "/bin/bun",
+				platform: "darwin",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				existingBranchSessionName: null,
+				currentBranch: "feature/demo",
+				spawnSync: (_command, spawnArgs) => {
+					events.push(spawnArgs[0] ?? "");
+					return { exitCode: 0 };
+				},
+			});
+
+			expect(handled).toBe(true);
+			expect(events[0]).toBe("\x1b]0;GJC: repo-feature/demo\x07");
+			expect(events[1]).toBe("new-session");
+			expect(writeSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			stdout.isTTY = previousIsTTY;
+		}
+	});
+
+	it("passes prefixed tmux window titles after the tmux option separator", () => {
 		const calls: Array<{ command: string; args: string[]; options: TmuxSpawnOptions }> = [];
 		const handled = launchDefaultTmuxIfNeeded({
 			parsed: args({ messages: ["hello world"] }),
@@ -155,7 +193,7 @@ describe("default GJC tmux launch", () => {
 		});
 
 		expect(handled).toBe(false);
-		expect(calls[0]?.args).toEqual(["rename-window", "--", "-repo-feature/demo"]);
+		expect(calls[0]?.args).toEqual(["rename-window", "--", "GJC--repo-feature/demo"]);
 	});
 
 	it("does not plan tmux for interactive root launch without --tmux", () => {
@@ -785,7 +823,7 @@ describe("default GJC tmux launch", () => {
 		expect(calls).toHaveLength(1);
 		expect(calls[0]).toMatchObject({
 			command: "tmux",
-			args: ["rename-window", "--", "repo-feature/demo"],
+			args: ["rename-window", "--", "GJC-repo-feature/demo"],
 		});
 	});
 
@@ -889,7 +927,13 @@ describe("default GJC tmux launch", () => {
 
 		expect(newSessionIndex).toBeGreaterThanOrEqual(0);
 		expect(renameIndex).toBeGreaterThan(newSessionIndex);
-		expect(calls[renameIndex]?.args).toEqual(["rename-window", "-t", `=${sessionName}`, "--", "repo-feature/demo"]);
+		expect(calls[renameIndex]?.args).toEqual([
+			"rename-window",
+			"-t",
+			`=${sessionName}`,
+			"--",
+			"GJC-repo-feature/demo",
+		]);
 	});
 	it("falls through to direct launch when session creation fails", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -134,12 +134,12 @@ describe("default GJC tmux launch", () => {
 		]);
 	});
 
-	it("sets the root terminal title before starting managed tmux", () => {
+	it("sets the root terminal title after creating managed tmux", () => {
 		const events: string[] = [];
 		const stdout = process.stdout as typeof process.stdout & { isTTY?: boolean };
 		const previousIsTTY = stdout.isTTY;
 		const writeSpy = spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
-			events.push(String(chunk));
+			events.push(`title:${String(chunk)}`);
 			return true;
 		});
 		stdout.isTTY = true;
@@ -158,15 +158,78 @@ describe("default GJC tmux launch", () => {
 				existingBranchSessionName: null,
 				currentBranch: "feature/demo",
 				spawnSync: (_command, spawnArgs) => {
-					events.push(spawnArgs[0] ?? "");
+					events.push(`spawn:${spawnArgs[0] ?? ""}`);
 					return { exitCode: 0 };
 				},
 			});
 
 			expect(handled).toBe(true);
-			expect(events[0]).toBe("\x1b]0;GJC: repo-feature/demo\x07");
-			expect(events[1]).toBe("new-session");
+			const newSessionIndex = events.indexOf("spawn:new-session");
+			const titleIndex = events.indexOf("title:\x1b]0;GJC: repo-feature/demo\x07");
+			const attachIndex = events.lastIndexOf("spawn:attach-session");
+
+			expect(newSessionIndex).toBeGreaterThanOrEqual(0);
+			expect(titleIndex).toBeGreaterThan(newSessionIndex);
+			expect(attachIndex).toBeGreaterThan(titleIndex);
 			expect(writeSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			stdout.isTTY = previousIsTTY;
+		}
+	});
+
+	it("honors title opt-out while launching managed tmux", () => {
+		const stdout = process.stdout as typeof process.stdout & { isTTY?: boolean };
+		const previousIsTTY = stdout.isTTY;
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+		stdout.isTTY = true;
+
+		try {
+			const handled = launchDefaultTmuxIfNeeded({
+				parsed: args({ messages: ["hello world"], tmux: true, noTitle: true }),
+				rawArgs: ["--tmux", "--no-title", "hello world"],
+				cwd: "/repo",
+				env: {},
+				argv: ["bun", "packages/coding-agent/src/cli.ts"],
+				execPath: "/bin/bun",
+				platform: "darwin",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				existingBranchSessionName: null,
+				currentBranch: "feature/demo",
+				spawnSync: () => ({ exitCode: 0 }),
+			});
+
+			expect(handled).toBe(true);
+			expect(writeSpy).not.toHaveBeenCalled();
+		} finally {
+			stdout.isTTY = previousIsTTY;
+		}
+	});
+
+	it("honors PI_NO_TITLE while launching managed tmux", () => {
+		const stdout = process.stdout as typeof process.stdout & { isTTY?: boolean };
+		const previousIsTTY = stdout.isTTY;
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+		stdout.isTTY = true;
+
+		try {
+			const handled = launchDefaultTmuxIfNeeded({
+				parsed: args({ messages: ["hello world"], tmux: true }),
+				rawArgs: ["--tmux", "hello world"],
+				cwd: "/repo",
+				env: { PI_NO_TITLE: "1" },
+				argv: ["bun", "packages/coding-agent/src/cli.ts"],
+				execPath: "/bin/bun",
+				platform: "darwin",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				existingBranchSessionName: null,
+				currentBranch: "feature/demo",
+				spawnSync: () => ({ exitCode: 0 }),
+			});
+
+			expect(handled).toBe(true);
+			expect(writeSpy).not.toHaveBeenCalled();
 		} finally {
 			stdout.isTTY = previousIsTTY;
 		}
@@ -937,27 +1000,36 @@ describe("default GJC tmux launch", () => {
 	});
 	it("falls through to direct launch when session creation fails", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
-		const handled = launchDefaultTmuxIfNeeded({
-			parsed: args({ tmux: true }),
-			rawArgs: [],
-			cwd: "/repo",
-			env: {},
-			argv: ["/usr/local/bin/gjc"],
-			execPath: "/bin/bun",
-			platform: "darwin",
-			tty: interactiveTty,
-			tmuxAvailable: true,
-			currentBranch: "",
-			existingBranchSessionName: null,
-			spawnSync: (command, spawnArgs, options) => {
-				calls.push({ command, args: spawnArgs, options });
-				return { exitCode: 1 };
-			},
-		});
+		const stdout = process.stdout as typeof process.stdout & { isTTY?: boolean };
+		const previousIsTTY = stdout.isTTY;
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+		stdout.isTTY = true;
+		try {
+			const handled = launchDefaultTmuxIfNeeded({
+				parsed: args({ tmux: true }),
+				rawArgs: [],
+				cwd: "/repo",
+				env: {},
+				argv: ["/usr/local/bin/gjc"],
+				execPath: "/bin/bun",
+				platform: "darwin",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				currentBranch: "",
+				existingBranchSessionName: null,
+				spawnSync: (command, spawnArgs, options) => {
+					calls.push({ command, args: spawnArgs, options });
+					return { exitCode: 1 };
+				},
+			});
 
-		expect(handled).toBe(false);
-		expect(calls).toHaveLength(1);
-		expect(calls[0].args[0]).toBe("new-session");
+			expect(handled).toBe(false);
+			expect(calls).toHaveLength(1);
+			expect(calls[0].args[0]).toBe("new-session");
+			expect(writeSpy).not.toHaveBeenCalled();
+		} finally {
+			stdout.isTTY = previousIsTTY;
+		}
 	});
 
 	it("handles and reports partial launch when required profile tagging fails", () => {


### PR DESCRIPTION
## Summary
- Set the root terminal title during successful `gjc --tmux` launch so workspace switchers can show `GJC: <project>` instead of noisy launch paths.
- Rename managed tmux windows with tmux-safe `GJC-<project>` labels because real tmux rejects `:` in window names.
- Gate the new root-title write behind `--no-title` / `PI_NO_TITLE` and avoid mutating the terminal title when tmux creation falls back to direct launch.

## Follow-up from #1292 review
- Moved the root terminal title write until after tmux acquisition/profile tagging succeeds on the create path.
- Added regressions for `--no-title`, `PI_NO_TITLE`, and failed `new-session` direct fallback.

## QA
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts`
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/test/modes/tmux-scroll.test.ts packages/coding-agent/test/title-generator.test.ts`
- `bun --cwd=packages/coding-agent run check`
- Real tmux smoke: renamed/displayed `GJC-tmp` and `GJC-repo-feature/demo` successfully

## Notes
- Full `bun --cwd=packages/coding-agent test` was run during #1292 QA and currently has unrelated pre-existing failures in resident blob/session retry/runtime MCP areas.