### PR TITLE
Add status line usage display mode

### DIFF
--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -179,6 +179,10 @@ const TIME_FORMAT_OPTIONS: SelectItem[] = [
 	{ value: "24h", label: "24h" },
 	{ value: "12h", label: "12h" },
 ];
+const USAGE_MODE_OPTIONS: SelectItem[] = [
+	{ value: "used", label: "Used" },
+	{ value: "remaining", label: "Remaining" },
+];
 
 function cloneSegmentOptions(options: StatusLineSegmentOptions | undefined): StatusLineSegmentOptions {
 	return mergeSegmentOptions(undefined, options);
@@ -193,6 +197,7 @@ function mergeSegmentOptions(
 		path: base?.path || overrides?.path ? { ...(base?.path ?? {}), ...(overrides?.path ?? {}) } : undefined,
 		git: base?.git || overrides?.git ? { ...(base?.git ?? {}), ...(overrides?.git ?? {}) } : undefined,
 		time: base?.time || overrides?.time ? { ...(base?.time ?? {}), ...(overrides?.time ?? {}) } : undefined,
+		usage: base?.usage || overrides?.usage ? { ...(base?.usage ?? {}), ...(overrides?.usage ?? {}) } : undefined,
 	};
 }
 
@@ -388,6 +393,22 @@ class StatusLineCustomEditor extends Container {
 					},
 				);
 			}
+			if (id === "usage") {
+				items.push({
+					id: "option.usage.mode",
+					label: "Usage: mode",
+					currentValue: this.#draft.segmentOptions.usage?.mode ?? "used",
+					submenu: (currentValue, done) =>
+						new SelectSubmenu(
+							"Usage mode",
+							"Show used quota or remaining quota in the usage segment.",
+							USAGE_MODE_OPTIONS,
+							currentValue,
+							done,
+							() => done(),
+						),
+				});
+			}
 		}
 
 		items.push(
@@ -551,6 +572,12 @@ class StatusLineCustomEditor extends Container {
 				break;
 			case "time.showSeconds":
 				this.#draft.segmentOptions.time = { ...(this.#draft.segmentOptions.time ?? {}), showSeconds: bool };
+				break;
+			case "usage.mode":
+				this.#draft.segmentOptions.usage = {
+					...(this.#draft.segmentOptions.usage ?? {}),
+					mode: value === "remaining" ? "remaining" : "used",
+				};
 				break;
 		}
 	}

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -32,6 +32,7 @@ export interface StatusLineSegmentOptions {
 	path?: { abbreviate?: boolean; maxLength?: number; stripWorkPrefix?: boolean };
 	git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };
 	time?: { format?: "12h" | "24h"; showSeconds?: boolean };
+	usage?: { mode?: "used" | "remaining" };
 }
 
 export interface StatusLineSettings {

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -480,7 +480,12 @@ const sessionNameSegment: StatusLineSegment = {
 	},
 };
 
-function pickUsageColor(percent: number): "muted" | "warning" | "error" {
+function pickUsageColor(percent: number, mode: "used" | "remaining"): "muted" | "warning" | "error" {
+	if (mode === "remaining") {
+		if (percent <= 20) return "error";
+		if (percent <= 50) return "warning";
+		return "muted";
+	}
 	if (percent >= 80) return "error";
 	if (percent >= 50) return "warning";
 	return "muted";
@@ -508,8 +513,11 @@ const usageSegment: StatusLineSegment = {
 		if (!u || u.windows.length === 0) {
 			return { content: "", visible: false };
 		}
+		const mode = ctx.options.usage?.mode === "remaining" ? "remaining" : "used";
 		const parts = u.windows.map(window => {
-			const pctText = theme.fg(pickUsageColor(window.percent), `${Math.round(window.percent)}%`);
+			const displayPercent =
+				mode === "remaining" ? Math.max(0, Math.min(100, 100 - window.percent)) : window.percent;
+			const pctText = theme.fg(pickUsageColor(displayPercent, mode), `${Math.round(displayPercent)}%`);
 			const reset =
 				window.resetValue !== undefined && window.resetUnit !== undefined
 					? theme.fg("muted", ` (${formatUsageReset(window.resetValue, window.resetUnit)})`)

--- a/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
@@ -144,6 +144,23 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 		expect(settings.get("statusLine.rightSegments")).toEqual([]);
 	});
 
+	it("places usage mode next to the usage segment", () => {
+		settings.set("statusLine.preset", "minimal");
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+
+		for (let i = 0; i < 80; i++) {
+			const rendered = Bun.stripANSI(component.render(120).join("\n"));
+			if (rendered.includes("❯ Segment: usage")) break;
+			component.handleInput("\x1b[B");
+		}
+
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("❯ Segment: usage");
+		component.handleInput("\x1b[B");
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("❯ Usage: mode");
+	});
+
 	it("edits segment placement and typed options before saving", () => {
 		settings.set("statusLine.preset", "minimal");
 		const { component } = createSelector();
@@ -169,7 +186,7 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 
 		openCustomEditor(component);
 
-		component.handleInput("\x1b[A"); // Wrap from Save to the final Time: show seconds option.
+		component.handleInput("\x1b[A"); // Wrap from Save to Time: show seconds.
 		expect(previews.at(-1)?.previewHighlightSegment).toBe("time");
 		component.handleInput("\n");
 		expect(previews.at(-1)?.segmentOptions?.time?.showSeconds).toBe(true);

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -87,6 +87,45 @@ describe("status line usage segment", () => {
 		component.dispose();
 	});
 
+	it("renders remaining quota when usage mode is remaining", async () => {
+		const now = Date.now();
+		const session = makeSession(async () => [
+			{
+				provider: "openai-codex",
+				fetchedAt: now,
+				limits: [
+					{
+						id: "openai-codex:primary",
+						scope: { provider: "openai-codex", windowId: "5h", tier: "pro" },
+						window: { id: "5h", resetsAt: now + 180 * 60_000 },
+						amount: { usedFraction: 0.24, unit: "percent" },
+					},
+					{
+						id: "openai-codex:secondary",
+						scope: { provider: "openai-codex", windowId: "7d", tier: "pro" },
+						window: { id: "7d", resetsAt: now + 49 * 3_600_000 },
+						amount: { usedFraction: 0.51, unit: "percent" },
+					},
+				],
+			},
+		]);
+		const component = new StatusLineComponent(session);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: [],
+			rightSegments: ["usage"],
+			segmentOptions: { usage: { mode: "remaining" } },
+			showSkillHud: false,
+		});
+
+		const text = await waitForUsageText(component);
+
+		expect(text).toContain("5h 76% (3h)");
+		expect(text).toContain("7d 49% (2d 1h)");
+		expect(text).not.toContain("24%");
+		component.dispose();
+	});
+
 	it("keeps rendering non-tiered Anthropic usage windows", async () => {
 		const now = Date.now();
 		const session = makeSession(async () => [


### PR DESCRIPTION
## Summary
- add a status line usage display mode for used vs remaining quota
- surface Usage: mode next to the usage segment in the custom status line editor
- cover remaining quota rendering and custom editor ordering in focused tests

## Verification
- bun test packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts packages/coding-agent/test/status-line-usage.test.ts
- bunx biome check packages/coding-agent/src/modes/components/settings-selector.ts packages/coding-agent/src/modes/components/status-line.ts packages/coding-agent/src/modes/components/status-line/segments.ts packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts packages/coding-agent/test/status-line-usage.test.ts