### PR TITLE
Improve status line custom editor UX

### DIFF
--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -273,6 +273,7 @@ class StatusLineCustomEditor extends Container {
 			(id, value) => this.#handleChange(id, value),
 			() => this.#cancel(),
 			item => this.#setSelectedItem(item),
+			2,
 		);
 		this.addChild(this.#list);
 	}

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -235,8 +235,6 @@ function segmentPlacement(
 class StatusLineCustomEditor extends Container {
 	#list!: SettingsList;
 	#draft: StatusLineDraft;
-	#currentWidthPreviewText!: Text;
-	#narrowWidthPreviewText!: Text;
 	#previewHighlightSegment: StatusLineSegmentId | undefined;
 
 	constructor(
@@ -268,13 +266,6 @@ class StatusLineCustomEditor extends Container {
 		this.clear();
 		this.addChild(new Text(theme.bold(theme.fg("accent", "Status Line Custom Editor")), 0, 0));
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("muted", "Current width preview:"), 0, 0));
-		this.#currentWidthPreviewText = new Text(this.#statusLinePreview(), 0, 0);
-		this.addChild(this.#currentWidthPreviewText);
-		this.addChild(new Text(theme.fg("muted", "Narrow width preview:"), 0, 0));
-		this.#narrowWidthPreviewText = new Text(this.#statusLinePreview(40), 0, 0);
-		this.addChild(this.#narrowWidthPreviewText);
-		this.addChild(new Spacer(1));
 		this.#list = new SettingsList(
 			this.#items(),
 			14,
@@ -287,22 +278,11 @@ class StatusLineCustomEditor extends Container {
 	}
 
 	#refresh(): void {
-		this.#refreshPreview();
 		this.#list.setItems(this.#items());
-	}
-
-	#refreshPreview(): void {
-		this.#currentWidthPreviewText.setText(this.#statusLinePreview());
-		this.#narrowWidthPreviewText.setText(this.#statusLinePreview(40));
-	}
-
-	#statusLinePreview(width?: number): string {
-		return this.callbacks.getStatusLinePreview?.(width) ?? theme.fg("dim", "(preview not available)");
 	}
 	#setSelectedItem(item: SettingItem | undefined): void {
 		this.#previewHighlightSegment = this.#highlightSegmentForItem(item);
 		this.#preview();
-		this.#refreshPreview();
 	}
 
 	#highlightSegmentForItem(item: SettingItem | undefined): StatusLineSegmentId | undefined {

--- a/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
@@ -80,14 +80,14 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 		settings.set("statusLine.leftSegments", []);
 		settings.set("statusLine.rightSegments", []);
 		settings.set("statusLine.segmentOptions", { path: { maxLength: 24 }, git: { showUntracked: false } });
-		const { component, previews, changedSettings, previewWidths } = createSelector();
+		const { component, previews, changedSettings } = createSelector();
 
 		openCustomEditor(component);
 
 		const opened = Bun.stripANSI(component.render(120).join("\n"));
 		expect(opened).toContain("Status Line Custom Editor");
-		expect(opened).toContain("Narrow width preview");
-		expect(previewWidths).toContain(40);
+		expect(opened).not.toContain("Current width preview");
+		expect(opened).not.toContain("Narrow width preview");
 		expect(previews.at(-1)).toMatchObject({
 			preset: "custom",
 			leftSegments: getPreset("minimal").leftSegments,

--- a/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
@@ -110,6 +110,21 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 			]),
 		);
 	});
+	it("keeps the description area height stable while navigating custom rows", () => {
+		settings.set("statusLine.preset", "minimal");
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+
+		for (let i = 0; i < 5; i++) component.handleInput("\x1b[B"); // Segment: mode.
+		const segmentLines = component.render(120).length;
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("❯ Segment: mode");
+
+		component.handleInput("\x1b[B"); // Move left: mode.
+		const moveLines = component.render(120).length;
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("❯ Move left: mode");
+		expect(moveLines).toBe(segmentLines);
+	});
 	it("clones preset segment option defaults when saving from a preset", () => {
 		settings.set("statusLine.preset", "minimal");
 		settings.set("statusLine.segmentOptions", {});

--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -33,6 +33,7 @@ export class SettingsList implements Component {
 	#onChange: (id: string, newValue: string) => void;
 	#onCancel: () => void;
 	#onSelectionChange?: (item: SettingItem | undefined) => void;
+	#descriptionRows: number;
 
 	// Submenu state
 	#submenuComponent: Component | null = null;
@@ -45,6 +46,7 @@ export class SettingsList implements Component {
 		onChange: (id: string, newValue: string) => void,
 		onCancel: () => void,
 		onSelectionChange?: (item: SettingItem | undefined) => void,
+		descriptionRows = 0,
 	) {
 		this.#items = items;
 		this.#maxVisible = maxVisible;
@@ -52,6 +54,7 @@ export class SettingsList implements Component {
 		this.#onChange = onChange;
 		this.#onCancel = onCancel;
 		this.#onSelectionChange = onSelectionChange;
+		this.#descriptionRows = Math.max(0, descriptionRows);
 		this.#notifySelectionChange();
 	}
 
@@ -147,9 +150,18 @@ export class SettingsList implements Component {
 			lines.push(this.#theme.hint(truncateToWidth(scrollText, width - 2, Ellipsis.Omit)));
 		}
 
-		// Add description for selected item
+		// Add description for selected item. Some hosts reserve a fixed
+		// description area so keyboard navigation does not resize the TUI when
+		// moving between described and undescribed rows.
 		const selectedItem = this.#items[this.#selectedIndex];
-		if (selectedItem?.description) {
+		if (this.#descriptionRows > 0) {
+			lines.push("");
+			const wrappedDesc = selectedItem?.description ? wrapTextWithAnsi(selectedItem.description, width - 4) : [];
+			for (let i = 0; i < this.#descriptionRows; i++) {
+				const line = wrappedDesc[i] ?? "";
+				lines.push(line ? this.#theme.description(`  ${line}`) : "");
+			}
+		} else if (selectedItem?.description) {
 			lines.push("");
 			const wrappedDesc = wrapTextWithAnsi(selectedItem.description, width - 4);
 			for (const line of wrappedDesc) {


### PR DESCRIPTION
## Summary
- remove the duplicate Current width/Narrow width previews from the status line custom editor; the main settings preview already covers live previewing
- stabilize the custom editor description area so keyboard navigation does not change the TUI render height
- document the UX regression in tests: rows with descriptions previously made the TUI grow/shrink, causing visible jitter while navigating options

## Verification
- bun test packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
- bunx biome check packages/tui/src/components/settings-list.ts packages/coding-agent/src/modes/components/settings-selector.ts packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts