### PR TITLE
Fix Ctrl+Enter composer submission

### DIFF
--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -118,7 +118,7 @@ export const KEYBINDINGS = {
 	},
 	"app.message.followUp": {
 		defaultKeys: [],
-		description: "Send follow-up message (no default; Ctrl+Enter inserts a newline)",
+		description: "Send follow-up message (no default; Ctrl+Enter submits)",
 	},
 	"app.message.queue": {
 		defaultKeys: "alt+enter",

--- a/packages/coding-agent/src/modes/components/hook-editor.ts
+++ b/packages/coding-agent/src/modes/components/hook-editor.ts
@@ -96,14 +96,17 @@ export class HookEditorComponent extends Container {
 			return;
 		}
 
-		// Submit on plain Enter encodings. On Windows, raw LF is reserved for terminal
-		// newline mappings (Shift+Enter/Ctrl+J/Ctrl+Enter); plain Enter reports CR.
-		if (!isWindowsRawLfNewlineInput(keyData) && (matchesKey(keyData, "enter") || matchesKey(keyData, "return"))) {
+		// Submit on Enter and Ctrl+Enter encodings. On Windows, raw LF is reserved for
+		// terminal newline mappings (Shift+Enter/Ctrl+J); plain Enter reports CR.
+		if (
+			!isWindowsRawLfNewlineInput(keyData) &&
+			(matchesKey(keyData, "enter") || matchesKey(keyData, "return") || matchesKey(keyData, "ctrl+enter"))
+		) {
 			this.#onSubmitCallback(this.#editor.getText());
 			return;
 		}
 
-		// Let Editor handle modified newline-producing variants (Shift+Enter, Ctrl+Enter, Alt+Enter, etc.)
+		// Let Editor handle newline-producing variants (Shift+Enter, Ctrl+J, Alt+Enter, etc.)
 		this.#editor.handleInput(keyData);
 	}
 

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AutocompleteProvider } from "@gajae-code/tui";
 import { defaultEditorTheme } from "../../tui/test/test-themes";
 import { KEYBINDINGS } from "../src/config/keybindings";
 import { CustomEditor } from "../src/modes/components/custom-editor";
@@ -66,16 +67,55 @@ describe("CustomEditor queue keybinding", () => {
 		expect(editor.getText()).toBe("");
 	});
 
-	it("leaves Ctrl+Enter for newline by default", () => {
+	it("submits Ctrl+Enter instead of inserting a newline", () => {
 		const editor = createEditor();
 		const onQueue = vi.fn();
+		const onSubmit = vi.fn();
 		editor.onQueue = onQueue;
+		editor.onSubmit = onSubmit;
 
 		editor.handleInput("a");
 		editor.handleInput("\x1b[13;5u");
-		editor.handleInput("b");
 
 		expect(onQueue).not.toHaveBeenCalled();
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit).toHaveBeenCalledWith("a");
+		expect(editor.getText()).toBe("");
+	});
+
+	it("routes Ctrl+Enter through slash command completion before submit", () => {
+		const editor = createEditor();
+		const onSubmit = vi.fn();
+		editor.onSubmit = onSubmit;
+		editor.setAutocompleteProvider({
+			async getSuggestions() {
+				return null;
+			},
+			applyCompletion(_lines, cursorLine, _cursorCol, _item, _prefix) {
+				return { lines: ["/model"], cursorLine, cursorCol: "/model".length };
+			},
+			trySyncSlashCompletion(textBeforeCursor) {
+				return textBeforeCursor === "/mo" ? { items: [{ value: "/model", label: "/model" }], prefix: "/mo" } : null;
+			},
+		} satisfies AutocompleteProvider);
+
+		editor.handleInput("/mo");
+		editor.handleInput("\x1b[13;5u");
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit).toHaveBeenCalledWith("/model");
+	});
+
+	it("keeps Shift+Enter as the multiline newline chord", () => {
+		const editor = createEditor();
+		const onSubmit = vi.fn();
+		editor.onSubmit = onSubmit;
+
+		editor.handleInput("a");
+		editor.handleInput("\x1b[13;2u");
+		editor.handleInput("b");
+
+		expect(onSubmit).not.toHaveBeenCalled();
 		expect(editor.getText()).toBe("a\nb");
 	});
 

--- a/packages/coding-agent/test/hook-editor.test.ts
+++ b/packages/coding-agent/test/hook-editor.test.ts
@@ -245,7 +245,7 @@ describe("HookEditorComponent prompt-style mode", () => {
 		}
 	});
 
-	it("treats Ctrl+Enter as newline in prompt-style mode", () => {
+	it("submits on Ctrl+Enter in prompt-style mode", () => {
 		const onSubmit = vi.fn();
 		const onCancel = vi.fn();
 		const component = new HookEditorComponent(createTui(), "Prompt", undefined, onSubmit, onCancel, {
@@ -255,13 +255,9 @@ describe("HookEditorComponent prompt-style mode", () => {
 		component.handleInput("x");
 		component.handleInput("\x1b[13;5u");
 
-		expect(onSubmit).not.toHaveBeenCalled();
-
-		component.handleInput("y");
-		component.handleInput("\r");
-
 		expect(onSubmit).toHaveBeenCalledTimes(1);
-		expect(onSubmit).toHaveBeenCalledWith("x\ny");
+		expect(onSubmit).toHaveBeenCalledWith("x");
+		expect(onCancel).not.toHaveBeenCalled();
 	});
 
 	it("renders prompt-style editor with legacy ask chrome", () => {

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -40,7 +40,7 @@ describe("message keybinding defaults", () => {
 });
 
 describe("extension shortcut reservations", () => {
-	it("keeps Ctrl+Enter reserved for composer newline", () => {
+	it("keeps Ctrl+Enter reserved for composer submit", () => {
 		const shortcut = {
 			shortcut: "ctrl+enter" as const,
 			description: "conflicting shortcut",

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1249,15 +1249,10 @@ export class Editor implements Component, Focusable {
 				this.#addNewLine();
 			}
 		}
-		// New line
+		// New line. Shift+Enter is the dedicated multiline chord; Ctrl+Enter submits.
 		else if (
-			(data.charCodeAt(0) === 10 && data.length > 1) || // Ctrl+Enter with modifiers
-			matchesKey(data, "ctrl+enter") || // Ctrl+Enter (Kitty/modifyOtherKeys, including lock bits/keypad Enter)
-			matchesKey(data, "ctrl+shift+enter") || // Ctrl+Shift+Enter (Kitty/modifyOtherKeys combined modifier)
-			data === "\x1b\r" || // Option+Enter in some terminals (legacy)
 			data === "\x1b[13;2~" || // Shift+Enter in some terminals (legacy format)
 			kb.matches(data, "tui.input.newLine") || // Shift+Enter (Kitty protocol, handles lock bits)
-			(data.length > 1 && data.includes("\x1b") && data.includes("\r")) ||
 			(data === "\n" && data.length === 1) // Shift+Enter from terminal sendInput mapping
 		) {
 			if (this.#shouldSubmitOnBackslashEnter(data, kb)) {
@@ -1267,8 +1262,13 @@ export class Editor implements Component, Focusable {
 			}
 			this.#addNewLine();
 		}
-		// Plain Enter - submit (handles both legacy \r and Kitty protocol with lock bits)
-		else if (kb.matches(data, "tui.input.submit") || data === "\n") {
+		// Enter/Ctrl+Enter - submit (handles both legacy \r and Kitty protocol with lock bits)
+		else if (
+			matchesKey(data, "ctrl+enter") ||
+			matchesKey(data, "ctrl+shift+enter") ||
+			kb.matches(data, "tui.input.submit") ||
+			data === "\n"
+		) {
 			// If submit is disabled, do nothing
 			if (this.disableSubmit) {
 				return;

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -492,31 +492,49 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("a1");
 		});
 
-		it("inserts a newline for Ctrl+Enter variants with NumLock or keypad Enter metadata", () => {
+		it("submits Ctrl+Enter variants with NumLock or keypad Enter metadata", () => {
 			const variants = ["\x1b[13;133u", "\x1b[57414;5u", "\x1b[57414;133u"];
 
 			for (const variant of variants) {
 				const editor = new Editor(defaultEditorTheme);
+				let submitted = "";
+				editor.onSubmit = text => {
+					submitted = text;
+				};
 
 				editor.handleInput("a");
 				editor.handleInput(variant);
-				editor.handleInput("b");
 
-				expect(editor.getText()).toBe("a\nb");
+				expect(submitted).toBe("a");
+				expect(editor.getText()).toBe("");
 			}
 		});
 
-		it("inserts a newline for Ctrl+Shift+Enter terminal protocol variants", () => {
-			const variants = ["\x1b[13;6u", "\x1b[27;6;13~", "\x1b[13;6~", "\x1b[13;2~", "\x1b[13;2u"];
+		it("submits Ctrl+Shift+Enter terminal protocol variants while Shift+Enter inserts newline", () => {
+			const submitVariants = ["\x1b[13;6u", "\x1b[27;6;13~", "\x1b[13;6~"];
+			const newlineVariants = ["\x1b[13;2~", "\x1b[13;2u"];
 
-			for (const [index, variant] of variants.entries()) {
+			for (const variant of submitVariants) {
 				const editor = new Editor(defaultEditorTheme);
-				const prefix = index === 0 ? "alpha" : "beta";
+				let submitted = "";
+				editor.onSubmit = text => {
+					submitted = text;
+				};
 
-				editor.setText(prefix);
+				editor.setText("alpha");
 				editor.handleInput(variant);
 
-				expect(editor.getText()).toBe(`${prefix}\n`);
+				expect(submitted).toBe("alpha");
+				expect(editor.getText()).toBe("");
+			}
+
+			for (const variant of newlineVariants) {
+				const editor = new Editor(defaultEditorTheme);
+
+				editor.setText("beta");
+				editor.handleInput(variant);
+
+				expect(editor.getText()).toBe("beta\n");
 			}
 		});
 


### PR DESCRIPTION
## Summary
- make Ctrl+Enter submit the TUI composer instead of inserting a newline
- keep Shift+Enter as the dedicated multiline/newline chord
- preserve Alt+Enter explicit queue behavior and update focused regression coverage

## Verification
- `bun test packages/coding-agent/test/custom-editor-keybindings.test.ts packages/coding-agent/test/hook-editor.test.ts packages/coding-agent/test/keybindings-display.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/input-controller-skill-queue.test.ts`
- `bun --cwd=packages/coding-agent run check`

Fixes #1295

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*