### PR TITLE
Fix compiled Telegram daemon entrypoint startup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Compiled binaries can now include the hidden Telegram daemon CLI entrypoint without hanging root startup, and release builds preserve that entry so `gjc notify daemon-internal --smoke` is available in standalone binaries (#1288).
 
 ## [0.7.8] - 2026-06-30
 ### Added

--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -4,7 +4,7 @@
  * Handles `gjc notify` setup/status and the hidden daemon entrypoint.
  */
 import { createInterface } from "node:readline/promises";
-import { APP_NAME } from "@gajae-code/utils";
+import { APP_NAME } from "@gajae-code/utils/dirs";
 import chalk from "chalk";
 import type { Settings } from "../config/settings";
 import { getNotificationConfig, maskToken } from "../notifications/config";

--- a/packages/coding-agent/src/notifications/daemon-paths.ts
+++ b/packages/coding-agent/src/notifications/daemon-paths.ts
@@ -1,0 +1,22 @@
+import * as path from "node:path";
+
+export interface DaemonPaths {
+	dir: string;
+	lock: string;
+	state: string;
+	roots: string;
+	steal: string;
+	aliases: string;
+}
+
+export function daemonPaths(agentDir: string): DaemonPaths {
+	const dir = path.join(agentDir, "notifications");
+	return {
+		dir,
+		lock: path.join(dir, "telegram-daemon.lock"),
+		state: path.join(dir, "telegram-daemon.state.json"),
+		roots: path.join(dir, "telegram-daemon.roots.json"),
+		steal: path.join(dir, "telegram-daemon.steal"),
+		aliases: path.join(dir, "telegram-callback-aliases.json"),
+	};
+}

--- a/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
@@ -3,12 +3,19 @@ import * as path from "node:path";
 import { YAML } from "bun";
 import type { Settings } from "../config/settings";
 import { getNotificationConfig, isGloballyConfigured } from "./config";
-import { daemonPaths, TelegramNotificationDaemon } from "./telegram-daemon";
-import { clearTelegramControlRequest, readTelegramControlRequest } from "./telegram-daemon-control";
+import { daemonPaths } from "./daemon-paths";
+import type { TelegramDaemonOptions } from "./telegram-daemon";
+
+type TelegramDaemonRunner = {
+	run(): Promise<void>;
+	requestStop(reason?: "reload" | "signal" | "stop"): void;
+};
+
+type TelegramDaemonConstructor = new (opts: TelegramDaemonOptions) => TelegramDaemonRunner;
 
 export interface RunDaemonInternalDeps {
 	SettingsImpl?: { init: (options?: { agentDir?: string }) => Promise<Pick<Settings, "get" | "getAgentDir">> };
-	DaemonImpl?: typeof TelegramNotificationDaemon;
+	DaemonImpl?: TelegramDaemonConstructor;
 	processPid?: number;
 	pidAlive?: (pid: number) => boolean;
 }
@@ -140,7 +147,9 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 	const settings = await resolveDaemonSettings(resolvedAgentDir, deps);
 	const cfg = getNotificationConfig(settings as Settings);
 	if (!isGloballyConfigured(cfg) || !cfg.botToken || !cfg.chatId) return;
-	const Daemon = deps.DaemonImpl ?? TelegramNotificationDaemon;
+	const { clearTelegramControlRequest, readTelegramControlRequest } = await import("./telegram-daemon-control");
+	const Daemon: TelegramDaemonConstructor =
+		deps.DaemonImpl ?? (await import("./telegram-daemon")).TelegramNotificationDaemon;
 	const daemon = new Daemon({
 		settings: settings as Settings,
 		ownerId,

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -10,6 +10,7 @@ import type { DaemonRuntimeInfo } from "../daemon/control-types";
 import { resolveGjcRuntimeSpawnInfo } from "../daemon/runtime";
 import { getNotificationConfig, isGloballyConfigured, tokenFingerprint } from "./config";
 import { parseInThreadConfigCommand } from "./config-commands";
+import { daemonPaths } from "./daemon-paths";
 import { buildCompactChoiceGrid, TELEGRAM_PARSE_MODE } from "./html-format";
 import type {
 	SessionCloseTarget,
@@ -62,16 +63,6 @@ export interface DaemonState {
 	version: 1;
 	stoppedAt?: number;
 }
-
-export interface DaemonPaths {
-	dir: string;
-	lock: string;
-	state: string;
-	roots: string;
-	steal: string;
-	aliases: string;
-}
-
 export interface TelegramDaemonFs {
 	mkdir(path: string, opts?: fs.MakeDirectoryOptions): Promise<void>;
 	readFile(path: string, encoding: BufferEncoding): Promise<string>;
@@ -184,17 +175,7 @@ async function fetchWithRetry(
 	throw lastErr;
 }
 
-export function daemonPaths(agentDir: string): DaemonPaths {
-	const dir = path.join(agentDir, "notifications");
-	return {
-		dir,
-		lock: path.join(dir, "telegram-daemon.lock"),
-		state: path.join(dir, "telegram-daemon.state.json"),
-		roots: path.join(dir, "telegram-daemon.roots.json"),
-		steal: path.join(dir, "telegram-daemon.steal"),
-		aliases: path.join(dir, "telegram-callback-aliases.json"),
-	};
-}
+export { type DaemonPaths, daemonPaths } from "./daemon-paths";
 
 /**
  * Attach session-lifecycle control (create/close/resume) to the running daemon.

--- a/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
+++ b/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
@@ -11,6 +11,70 @@ describe("compiled daemon smoke coverage", () => {
 		return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 	}
 
+	async function runWithTimeout(
+		command: string[],
+		opts: { cwd: string },
+		timeoutMs: number,
+	): Promise<{
+		exitCode: number | null;
+		stdout: string;
+		stderr: string;
+		timedOut: boolean;
+	}> {
+		const proc = Bun.spawn(command, {
+			...opts,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		let timedOut = false;
+		const timeout = new Promise<null>(resolve => {
+			const timer = setTimeout(() => {
+				timedOut = true;
+				proc.kill();
+				resolve(null);
+			}, timeoutMs);
+			proc.exited.finally(() => clearTimeout(timer));
+		});
+		const [exitCode, stdout, stderr] = await Promise.all([
+			Promise.race([proc.exited, timeout]),
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+		return { exitCode, stdout, stderr, timedOut };
+	}
+
+	async function buildCompiledDaemonSmokeBinary(outPath: string): Promise<void> {
+		const proc = Bun.spawn(
+			[
+				"bun",
+				"build",
+				"--compile",
+				"--no-compile-autoload-bunfig",
+				"--no-compile-autoload-dotenv",
+				"--no-compile-autoload-tsconfig",
+				"--no-compile-autoload-package-json",
+				"--keep-names",
+				"--define",
+				'process.env.PI_COMPILED="true"',
+				"--root",
+				".",
+				"--external",
+				"mupdf",
+				"./packages/coding-agent/src/cli.ts",
+				"./packages/coding-agent/src/notifications/telegram-daemon-cli.ts",
+				"--outfile",
+				outPath,
+			],
+			{ cwd: repoRoot, stdout: "pipe", stderr: "pipe" },
+		);
+		const [exitCode, stdout, stderr] = await Promise.all([
+			proc.exited,
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+		expect(`${exitCode}\n${stdout}\n${stderr}`).toStartWith("0\n");
+	}
+
 	test("hidden daemon CLI smoke creates and removes its temp lock without leaking tokens", async () => {
 		const agentDir = tempDir("gjc-compiled-daemon-agent-");
 		const cwd = tempDir("gjc-compiled-daemon-cwd-");
@@ -52,9 +116,35 @@ describe("compiled daemon smoke coverage", () => {
 		expect(fs.readdirSync(paths.dir).filter(name => name.includes(".smoke."))).toEqual([]);
 	});
 
-	test("build script preserves the dynamic daemon entrypoint for compiled binaries", () => {
-		const buildScript = fs.readFileSync(path.join(repoRoot, "packages/coding-agent/scripts/build-binary.ts"), "utf8");
-		expect(buildScript).toContain("telegram-daemon-cli.ts");
+	test("compiled binary with daemon CLI entrypoint starts root version and daemon smoke", async () => {
+		const temp = tempDir("gjc-compiled-daemon-binary-");
+		const binaryPath = path.join(temp, "gjc-repro");
+		try {
+			await buildCompiledDaemonSmokeBinary(binaryPath);
+			const version = await runWithTimeout([binaryPath, "--version"], { cwd: temp }, 10_000);
+			expect(version.timedOut).toBe(false);
+			expect(`${version.exitCode}\n${version.stdout}\n${version.stderr}`).toStartWith("0\ngjc/");
+
+			const smoke = await runWithTimeout(
+				[binaryPath, "notify", "daemon-internal", "--smoke"],
+				{ cwd: temp },
+				10_000,
+			);
+			expect(smoke.timedOut).toBe(false);
+			expect(`${smoke.exitCode}\n${smoke.stdout}\n${smoke.stderr}`).toStartWith("0\n");
+		} finally {
+			fs.rmSync(temp, { recursive: true, force: true });
+		}
+	});
+
+	test("build scripts preserve the dynamic daemon entrypoint for compiled binaries", () => {
+		const devBuildScript = fs.readFileSync(
+			path.join(repoRoot, "packages/coding-agent/scripts/build-binary.ts"),
+			"utf8",
+		);
+		const releaseBuildScript = fs.readFileSync(path.join(repoRoot, "scripts/ci-release-build-binaries.ts"), "utf8");
+		expect(devBuildScript).toContain("telegram-daemon-cli.ts");
+		expect(releaseBuildScript).toContain("telegram-daemon-cli.ts");
 	});
 
 	test("compiled-mode spawn args self-spawn the binary without a script prefix and carry a reload warning", () => {

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -20,6 +20,11 @@ const entrypoint = "./packages/coding-agent/src/cli.ts";
 // Listing the module here makes the absolute target path exist in the compiled
 // bunfs.
 const nativeTokenizerEntrypoint = "./packages/natives/native/index.js";
+// Hidden notify daemon CLI. It is loaded dynamically from notify-cli, so Bun
+// standalone only emits it into $bunfs when the file is also listed as an
+// explicit compile entrypoint. The CLI module must stay lightweight at top
+// level; keep heavy daemon runtime imports behind the actual daemon path.
+const telegramDaemonEntrypoint = "./packages/coding-agent/src/notifications/telegram-daemon-cli.ts";
 // Worker entrypoints. Bun's `--compile` static analyzer discovers the
 // literal in `new Worker("…", …)` at each spawn site, but only actually
 // emits the worker into the bunfs root when it is also listed here as an
@@ -136,7 +141,7 @@ async function buildBinary(target: BinaryTarget): Promise<void> {
 	console.log(`Building ${target.outfile}...`);
 	await embedNative(target);
 	if (isDryRun) {
-		const compileEntrypoints = [...workerEntrypoints, nativeTokenizerEntrypoint].join(" ");
+		const compileEntrypoints = [...workerEntrypoints, nativeTokenizerEntrypoint, telegramDaemonEntrypoint].join(" ");
 		console.log(`DRY RUN bun build --compile --no-compile-autoload-bunfig --no-compile-autoload-dotenv --no-compile-autoload-tsconfig --no-compile-autoload-package-json --keep-names --define process.env.PI_COMPILED="true" --root . --external mupdf --target=${target.target} ${entrypoint} ${compileEntrypoints} --outfile ${target.outfile}`);
 		return;
 	}
@@ -165,6 +170,7 @@ async function buildBinary(target: BinaryTarget): Promise<void> {
 			entrypoint,
 			...workerEntrypoints,
 			nativeTokenizerEntrypoint,
+			telegramDaemonEntrypoint,
 			"--outfile",
 			target.outfile,
 		],


### PR DESCRIPTION
## Summary
- keep `telegram-daemon-cli.ts` lightweight at top level by moving daemon paths to a small module and lazy-loading the full daemon/control runtime only for the real daemon path
- include the hidden Telegram daemon CLI in the release compile entrypoints, matching the dev build
- add compiled-binary regression coverage for `--version` and `notify daemon-internal --smoke`

## Verification
- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts packages/coding-agent/test/notify-setup.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun scripts/ci-release-build-binaries.ts --dry-run --targets linux-x64`
- `bun --cwd=packages/coding-agent run build && packages/coding-agent/dist/gjc --version && packages/coding-agent/dist/gjc notify daemon-internal --smoke`

Fixes #1288

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*