### PR TITLE
docs: refresh Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://gajae-code.com"><img alt="Website" src="https://img.shields.io/badge/website-gajae--code.com-ff4d4f?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/gajae-code"><img alt="npm package" src="https://img.shields.io/npm/v/gajae-code?style=flat-square"></a>
   <a href="LICENSE"><img alt="MIT license" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="https://discord.gg/sj4exxQ9v"><img alt="Discord" src="https://img.shields.io/badge/Discord-join-5865F2?style=flat-square&logo=discord&logoColor=white"></a>
+  <a href="https://discord.gg/8vPXmxSt9"><img alt="Discord" src="https://img.shields.io/badge/Discord-join-5865F2?style=flat-square&logo=discord&logoColor=white"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Updated the root README Discord badge to the new canonical invite: https://discord.gg/8vPXmxSt9
- Confirmed scoped public surfaces (README, docs, packages, plugins, .github, python/robogjc) do not retain the stale Gajae-Code invite.
- Left vendored Brush README Discord invites unchanged as third-party upstream community links, outside the Gajae-Code public surface.

## Validation
- `git diff --check origin/dev...HEAD`
- focused search: no `sj4exxQ9v` or `discord.com/invite/` matches in scoped public surfaces
- focused search: canonical `discord.gg/8vPXmxSt9` appears in `README.md`
- read-only website check: `https://gajae-code.com` rendered text exposes no Discord invite
- read-only repo metadata check: `homepageUrl` empty and description `Gajae Code MVP`; no GitHub repo metadata Discord invite field/value found

## External metadata
No repo-file-backed GitHub metadata update was needed. If a future owner wants to set a repository homepage, the relevant field is repository `homepage`; safe command: `gh repo edit Yeachan-Heo/gajae-code --homepage <url>`.