### PR TITLE
Add default status line usage preset

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -454,7 +454,7 @@ export const SETTINGS_SCHEMA = {
 	// Status line
 	"statusLine.preset": {
 		type: "enum",
-		values: ["default", "minimal", "compact", "full", "nerd", "ascii", "custom"] as const,
+		values: ["default", "default-usage", "minimal", "compact", "full", "nerd", "ascii", "custom"] as const,
 		default: "default",
 		ui: {
 			tab: "appearance",
@@ -462,6 +462,11 @@ export const SETTINGS_SCHEMA = {
 			description: "Pre-built status line configurations",
 			options: [
 				{ value: "default", label: "Default", description: "Model, path, git, context, tokens, cost" },
+				{
+					value: "default-usage",
+					label: "Default + Usage",
+					description: "Default layout with provider usage quota",
+				},
 				{ value: "minimal", label: "Minimal", description: "Path and git only" },
 				{ value: "compact", label: "Compact", description: "Model, git, cost, context" },
 				{ value: "full", label: "Full", description: "All segments including time" },

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -164,6 +164,7 @@ class SelectSubmenu extends Container {
 	}
 }
 const STATUS_LINE_CUSTOM_EDITOR_ID = "statusLine.customEditor";
+const STATUS_LINE_USAGE_MODE_ID = "statusLine.usageMode";
 const PUBLIC_STATUS_SEGMENTS = ALL_SEGMENT_IDS.filter(id => id !== "pi");
 
 type StatusLineDraft = Required<
@@ -183,6 +184,8 @@ const USAGE_MODE_OPTIONS: SelectItem[] = [
 	{ value: "used", label: "Used" },
 	{ value: "remaining", label: "Remaining" },
 ];
+const USAGE_MODE_VALUES = ["used", "remaining"] as const;
+type UsageMode = (typeof USAGE_MODE_VALUES)[number];
 
 function cloneSegmentOptions(options: StatusLineSegmentOptions | undefined): StatusLineSegmentOptions {
 	return mergeSegmentOptions(undefined, options);
@@ -221,6 +224,25 @@ function effectiveCustomSegments(
 		leftSegments: [...presetDef.leftSegments],
 		rightSegments: [...presetDef.rightSegments],
 	};
+}
+
+function getSavedUsageMode(): UsageMode {
+	const segmentOptions = settings.get("statusLine.segmentOptions") as StatusLineSegmentOptions;
+	return segmentOptions.usage?.mode === "remaining" ? "remaining" : "used";
+}
+
+function setSavedUsageMode(mode: string): StatusLineSegmentOptions {
+	const normalizedMode: UsageMode = mode === "remaining" ? "remaining" : "used";
+	const segmentOptions = settings.get("statusLine.segmentOptions") as StatusLineSegmentOptions;
+	const nextOptions: StatusLineSegmentOptions = {
+		...segmentOptions,
+		usage: {
+			...(segmentOptions.usage ?? {}),
+			mode: normalizedMode,
+		},
+	};
+	settings.set("statusLine.segmentOptions", nextOptions as Record<string, unknown>);
+	return nextOptions;
 }
 
 function statusSegmentLabel(id: StatusLineSegmentId): string {
@@ -863,9 +885,7 @@ export class SettingsSelectorComponent extends Container {
 			};
 		} else if (def.path === "statusLine.preset") {
 			onPreview = value => {
-				const presetDef = getPreset(
-					value as "default" | "minimal" | "compact" | "full" | "nerd" | "ascii" | "custom",
-				);
+				const presetDef = getPreset(value as StatusLinePreset);
 				this.callbacks.onStatusLinePreview?.({
 					preset: value as StatusLinePreset,
 					leftSegments: presetDef.leftSegments,
@@ -1003,6 +1023,16 @@ export class SettingsSelectorComponent extends Container {
 			10,
 			getSettingsListTheme(),
 			(id, newValue) => {
+				if (id === STATUS_LINE_USAGE_MODE_ID) {
+					const segmentOptions = setSavedUsageMode(newValue);
+					this.callbacks.onChange("statusLine.segmentOptions", segmentOptions);
+					if (tabId === "appearance") {
+						this.#triggerStatusLinePreview();
+					}
+					this.#refreshCurrentTabItems(defs);
+					return;
+				}
+
 				const def = defs.find(d => d.path === id);
 				if (!def) return;
 
@@ -1059,6 +1089,20 @@ export class SettingsSelectorComponent extends Container {
 				items.splice(presetIndex + 1, 0, customEditorItem);
 			} else {
 				items.push(customEditorItem);
+			}
+			{
+				const usageModeItem: SettingItem = {
+					id: STATUS_LINE_USAGE_MODE_ID,
+					label: "Status Line Usage Mode",
+					description: "Show provider quota in the status line as used or remaining.",
+					currentValue: getSavedUsageMode(),
+					values: [...USAGE_MODE_VALUES],
+				};
+				if (presetIndex >= 0) {
+					items.splice(presetIndex + 2, 0, usageModeItem);
+				} else {
+					items.push(usageModeItem);
+				}
 			}
 		}
 		return items;

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -12,6 +12,17 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 		},
 	},
 
+	"default-usage": {
+		leftSegments: ["model", "mode", "git", "pr", "path"],
+		rightSegments: ["session_name", "jobs", "token_rate", "usage", "context_pct", "cost"],
+		separator: "slash",
+		segmentOptions: {
+			model: { showThinkingLevel: true },
+			path: { abbreviate: true, maxLength: 32, stripWorkPrefix: true },
+			git: { showBranch: true, showStaged: true, showUnstaged: true, showUntracked: true },
+		},
+	},
+
 	minimal: {
 		leftSegments: ["path", "git"],
 		rightSegments: ["session_name", "jobs", "mode", "context_pct"],

--- a/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
+++ b/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
@@ -299,6 +299,19 @@ describe("redesigned interactive shell chrome", () => {
 		expect(STATUS_LINE_PRESETS.default.segmentOptions?.path?.maxLength).toBe(32);
 	});
 
+	it("adds a default plus usage status preset without changing default", () => {
+		expect(STATUS_LINE_PRESETS["default-usage"].leftSegments).toEqual(STATUS_LINE_PRESETS.default.leftSegments);
+		expect(STATUS_LINE_PRESETS["default-usage"].rightSegments).toEqual([
+			"session_name",
+			"jobs",
+			"token_rate",
+			"usage",
+			"context_pct",
+			"cost",
+		]);
+		expect(STATUS_LINE_PRESETS["default-usage"].segmentOptions).toEqual(STATUS_LINE_PRESETS.default.segmentOptions);
+	});
+
 	it("keeps forge launch rendering on the bounded-work path", () => {
 		const component = new WelcomeComponent("1.2.3", "gpt-5.5", "openai", [
 			{ name: "very-long-session-name".repeat(10), timeAgo: "2h" },

--- a/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
@@ -75,6 +75,41 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 		expect(presetMenu).toContain("Status Line Preset");
 		expect(presetMenu).not.toContain("Custom");
 	});
+	it("shows usage mode on the appearance tab and persists it", () => {
+		settings.set("statusLine.preset", "default");
+		settings.set("statusLine.segmentOptions", {});
+		const { component, changedSettings, previews } = createSelector();
+
+		for (let i = 0; i < 40; i++) {
+			const rendered = Bun.stripANSI(component.render(120).join("\n"));
+			if (rendered.includes("❯ Status Line Usage Mode")) break;
+			component.handleInput("\x1b[B");
+		}
+
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("❯ Status Line Usage Mode");
+		component.handleInput("\n");
+
+		expect(settings.get("statusLine.segmentOptions")).toMatchObject({ usage: { mode: "remaining" } });
+		expect(changedSettings.at(-1)).toMatchObject({
+			path: "statusLine.segmentOptions",
+			value: { usage: { mode: "remaining" } },
+		});
+		expect(previews.at(-1)?.segmentOptions).toMatchObject({ usage: { mode: "remaining" } });
+	});
+	it("shows usage mode even when usage is hidden", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model"]);
+		settings.set("statusLine.rightSegments", ["context_pct"]);
+		const { component } = createSelector();
+
+		for (let i = 0; i < 40; i++) {
+			const rendered = Bun.stripANSI(component.render(120).join("\n"));
+			if (rendered.includes("❯ Status Line Usage Mode")) break;
+			component.handleInput("\x1b[B");
+		}
+
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("❯ Status Line Usage Mode");
+	});
 	it("seeds custom layout from the active preset, previews segment options, and saves to settings", () => {
 		settings.set("statusLine.preset", "minimal");
 		settings.set("statusLine.leftSegments", []);

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -17,7 +17,9 @@ function makeSession(fetchUsageReports: () => Promise<unknown>): AgentSession {
 		agent: { state: { tools: [] } },
 		skills: [],
 		model: { id: "openai-codex/gpt-5", contextWindow: 200_000 },
+		modelRegistry: { isUsingOAuth: () => false },
 		isStreaming: false,
+		isFastModeActive: () => false,
 		fetchUsageReports,
 		sessionManager: {
 			getUsageStatistics: () => usageStats,
@@ -123,6 +125,69 @@ describe("status line usage segment", () => {
 		expect(text).toContain("5h 76% (3h)");
 		expect(text).toContain("7d 49% (2d 1h)");
 		expect(text).not.toContain("24%");
+		component.dispose();
+	});
+
+	it("renders remaining quota in the default usage preset", async () => {
+		const now = Date.now();
+		const session = makeSession(async () => [
+			{
+				provider: "openai-codex",
+				fetchedAt: now,
+				limits: [
+					{
+						id: "openai-codex:primary",
+						scope: { provider: "openai-codex", windowId: "5h", tier: "pro" },
+						window: { id: "5h", resetsAt: now + 180 * 60_000 },
+						amount: { usedFraction: 0.24, unit: "percent" },
+					},
+				],
+			},
+		]);
+		const component = new StatusLineComponent(session);
+		component.updateSettings({
+			preset: "default-usage",
+			segmentOptions: { usage: { mode: "remaining" } },
+			showSkillHud: false,
+		});
+
+		const text = await waitForUsageText(component);
+
+		expect(text).toContain("5h 76% (3h)");
+		component.dispose();
+	});
+
+	it("does not render usage mode when the usage segment is hidden", async () => {
+		const now = Date.now();
+		const session = makeSession(async () => [
+			{
+				provider: "openai-codex",
+				fetchedAt: now,
+				limits: [
+					{
+						id: "openai-codex:primary",
+						scope: { provider: "openai-codex", windowId: "5h", tier: "pro" },
+						window: { id: "5h", resetsAt: now + 180 * 60_000 },
+						amount: { usedFraction: 0.24, unit: "percent" },
+					},
+				],
+			},
+		]);
+		const component = new StatusLineComponent(session);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: [],
+			rightSegments: ["context_pct"],
+			segmentOptions: { usage: { mode: "remaining" } },
+			showSkillHud: false,
+		});
+
+		component.getTopBorder(120);
+		await Bun.sleep(10);
+		const text = stripAnsi(component.getTopBorder(120).content);
+
+		expect(text).not.toContain("5h");
+		expect(text).not.toContain("76%");
 		component.dispose();
 	});
 

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -269,6 +269,7 @@
 					"type": "string",
 					"enum": [
 						"default",
+						"default-usage",
 						"minimal",
 						"compact",
 						"full",


### PR DESCRIPTION
## Summary
- add a `Default + Usage` status line preset that keeps the default layout and adds the `usage` segment
- expose `Status Line Usage Mode` in Appearance settings so users can choose used vs remaining quota display
- keep the setting harmless when `usage` is not visible; it only affects rendering when the usage segment is present
- regenerate the config schema and add focused coverage for preset shape, settings persistence, and usage rendering behavior

## Verification
- `bun test packages/coding-agent/test/status-line-usage.test.ts packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts packages/coding-agent/test/modes/components/redesigned-shell.test.ts packages/coding-agent/test/jobs-segment.test.ts packages/coding-agent/test/gjc-ui-redesign.test.ts`
- `bun run check:schemas`
- `bunx biome check packages/coding-agent/src/config/settings-schema.ts packages/coding-agent/src/modes/components/settings-selector.ts packages/coding-agent/src/modes/components/status-line/presets.ts packages/coding-agent/test/modes/components/redesigned-shell.test.ts packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts packages/coding-agent/test/status-line-usage.test.ts schemas/config.schema.json`