### PR TITLE
Fix gjc --tmux workspace titles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Submitted user prompts now use the live terminal viewport width in wide Windows Terminal/PowerShell sessions, keeping Korean/CJK prompt wrapping responsive without changing narrow layouts (#1239).
 - Coordinator MCP now fails tmux-delivered turns that never receive a runtime prompt acknowledgement/`turn_start`, surfacing an explicit unacknowledged delivery reason instead of leaving Hermes/Oren waiting on a normal active/running state (#1237).
 - Telegram now advertises `/session_create`, `/session_recent`, `/session_close`, and `/session_resume` in the bot command menu so lifecycle control commands are discoverable from `/` autocomplete.
+- `gjc --tmux` now prefixes the root terminal title (`GJC: tmp`) and managed tmux window names (`GJC-tmp`) with a GJC workspace label so terminal multiplexers and workspace switchers do not fall back to noisy launch paths.
 
 ## [0.7.7] - 2026-06-28
 ### Added

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -7,6 +7,7 @@ import type { Args } from "../cli/args";
 import { tmuxRuntimeSessionPath } from "./session-layout";
 import { GJC_COORDINATOR_SESSION_ID_ENV, GJC_COORDINATOR_SESSION_STATE_FILE_ENV } from "./session-state-sidecar";
 import {
+	buildGjcTmuxExactOptionTarget,
 	buildGjcTmuxExactSessionTarget,
 	buildGjcTmuxProfileCommands,
 	buildGjcTmuxSessionName,
@@ -36,6 +37,7 @@ export const GJC_TMUX_LAUNCHED_ENV = "GJC_TMUX_LAUNCHED";
 export const GJC_LAUNCH_POLICY_ENV = "GJC_LAUNCH_POLICY";
 export const GJC_TMUX_WINDOW_LABEL_MAX_WIDTH = 48;
 export const GJC_PSMUX_PROFILE_FORCE_ENV = "GJC_PSMUX_PROFILE_FORCE";
+const TERMINAL_TITLE_CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
 
 type LaunchPolicy = "direct" | "tmux";
 
@@ -386,6 +388,8 @@ function truncateVisibleTail(value: string, maxWidth: number): string {
 }
 
 const GJC_TMUX_WINDOW_BRANCH_SEPARATOR = "-";
+const GJC_TMUX_WINDOW_TITLE_PREFIX = "GJC-";
+const GJC_TMUX_TERMINAL_TITLE_PREFIX = "GJC: ";
 
 function sanitizeTmuxWindowTitleSegment(value: string): string {
 	return value.replace(/:+/g, "-");
@@ -398,20 +402,68 @@ function sanitizeTmuxWindowProjectName(project: string): string {
 	return sanitizeTmuxWindowTitleSegment(trimmed);
 }
 
-export function buildGjcTmuxWindowTitle(cwd: string, branch: string | null | undefined): string {
+function buildGjcTmuxPrefixedTitle(prefix: string, cwd: string, branch: string | null | undefined): string {
 	const project = sanitizeTmuxWindowProjectName(path.basename(path.resolve(cwd)) || "gjc");
+	const projectTitle = `${prefix}${project}`;
 	const trimmedBranch = sanitizeTmuxWindowTitleSegment(branch?.trim() ?? "");
-	if (!trimmedBranch) return truncateVisible(project, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
+	if (!trimmedBranch) return truncateVisible(projectTitle, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
 
 	const separatorWidth = visibleWidth(GJC_TMUX_WINDOW_BRANCH_SEPARATOR);
-	const projectWidth = visibleWidth(project);
-	const fullTitle = `${project}${GJC_TMUX_WINDOW_BRANCH_SEPARATOR}${trimmedBranch}`;
+	const projectWidth = visibleWidth(projectTitle);
+	const fullTitle = `${projectTitle}${GJC_TMUX_WINDOW_BRANCH_SEPARATOR}${trimmedBranch}`;
 	if (visibleWidth(fullTitle) <= GJC_TMUX_WINDOW_LABEL_MAX_WIDTH) return fullTitle;
 
 	const remainingBranchWidth = GJC_TMUX_WINDOW_LABEL_MAX_WIDTH - projectWidth - separatorWidth;
-	if (remainingBranchWidth <= 0) return truncateVisible(project, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
+	if (remainingBranchWidth <= 0) return truncateVisible(projectTitle, GJC_TMUX_WINDOW_LABEL_MAX_WIDTH);
 
-	return `${project}${GJC_TMUX_WINDOW_BRANCH_SEPARATOR}${truncateVisibleTail(trimmedBranch, remainingBranchWidth)}`;
+	return `${projectTitle}${GJC_TMUX_WINDOW_BRANCH_SEPARATOR}${truncateVisibleTail(trimmedBranch, remainingBranchWidth)}`;
+}
+
+export function buildGjcTmuxWindowTitle(cwd: string, branch: string | null | undefined): string {
+	return buildGjcTmuxPrefixedTitle(GJC_TMUX_WINDOW_TITLE_PREFIX, cwd, branch);
+}
+
+function buildGjcTmuxRootTerminalTitle(cwd: string, branch: string | null | undefined): string {
+	return buildGjcTmuxPrefixedTitle(GJC_TMUX_TERMINAL_TITLE_PREFIX, cwd, branch);
+}
+
+function sanitizeGjcTmuxRootTerminalTitle(title: string): string {
+	return title.replace(TERMINAL_TITLE_CONTROL_CHARS, "").trim() || "GJC";
+}
+
+function escapeTmuxFormatLiteral(value: string): string {
+	return value.replace(/#/g, "##");
+}
+
+function buildGjcTmuxRootTerminalTitleCommands(target: string, title: string): GjcTmuxProfileCommand[] {
+	const sanitized = escapeTmuxFormatLiteral(sanitizeGjcTmuxRootTerminalTitle(title));
+	return [
+		{ description: "enable tmux client terminal title", args: ["set-option", "-t", target, "set-titles", "on"] },
+		{
+			description: "set tmux client terminal title",
+			args: ["set-option", "-t", target, "set-titles-string", sanitized],
+		},
+	];
+}
+
+function applyGjcTmuxRootTerminalTitleProfile(context: {
+	tmuxCommand: string;
+	target: string;
+	title: string | undefined;
+	spawnSync: TmuxSpawnSync;
+	options: TmuxSpawnOptions;
+}): void {
+	if (!context.title) return;
+	for (const command of buildGjcTmuxRootTerminalTitleCommands(
+		buildGjcTmuxExactOptionTarget(context.target, { env: context.options.env }),
+		context.title,
+	)) {
+		context.spawnSync(context.tmuxCommand, command.args, context.options);
+	}
+}
+
+function shouldSetGjcTmuxRootTerminalTitle(parsed: Args, env: NodeJS.ProcessEnv): boolean {
+	return !parsed.noTitle && !env.PI_NO_TITLE;
 }
 
 function buildTmuxRenameWindowArgs(title: string, target?: string): string[] {
@@ -626,7 +678,19 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		captureStderr: true,
 	};
 
+	const windowTitle = buildGjcTmuxWindowTitle(plan.project ?? plan.cwd, plan.branch);
+	const rootTerminalTitle = shouldSetGjcTmuxRootTerminalTitle(context.parsed, env)
+		? buildGjcTmuxRootTerminalTitle(plan.project ?? plan.cwd, plan.branch)
+		: undefined;
+
 	if (plan.attachSessionName) {
+		applyGjcTmuxRootTerminalTitleProfile({
+			tmuxCommand: plan.tmuxCommand,
+			target: plan.attachSessionName,
+			title: rootTerminalTitle,
+			spawnSync,
+			options,
+		});
 		const attached = spawnSync(
 			plan.tmuxCommand,
 			["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.attachSessionName, { env })],
@@ -678,7 +742,7 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		}
 		renameTmuxWindow(
 			plan.tmuxCommand,
-			buildGjcTmuxWindowTitle(plan.project ?? plan.cwd, plan.branch),
+			windowTitle,
 			spawnSync,
 			controlOptions,
 			buildGjcTmuxExactSessionTarget(plan.sessionName, { env }),
@@ -727,6 +791,13 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			}
 			// Recovery succeeded via retry — fall through to attach-session below.
 		}
+		applyGjcTmuxRootTerminalTitleProfile({
+			tmuxCommand: plan.tmuxCommand,
+			target: plan.sessionName,
+			title: rootTerminalTitle,
+			spawnSync,
+			options,
+		});
 	}
 	const probeWarning = detectCorruptedGjcWrapper();
 	if (created.exitCode !== 0) {
@@ -742,7 +813,6 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("new-session failed", stderr) + suffix);
 		return false;
 	}
-	// attach-session needs PTY inherit for the user-facing attach; keep it unchanged.
 	// attach-session needs PTY inherit for the user-facing attach; keep it unchanged.
 	const attached = spawnSync(
 		plan.tmuxCommand,

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -67,23 +67,23 @@ describe("default GJC tmux launch", () => {
 	});
 
 	it("builds sanitized project and branch tmux window titles", () => {
-		expect(buildGjcTmuxWindowTitle("/repo", "feature/demo")).toBe("repo-feature/demo");
-		expect(buildGjcTmuxWindowTitle("/repo", "main")).toBe("repo-main");
-		expect(buildGjcTmuxWindowTitle("/repo", null)).toBe("repo");
-		expect(buildGjcTmuxWindowTitle("/repo", "")).toBe("repo");
+		expect(buildGjcTmuxWindowTitle("/repo", "feature/demo")).toBe("GJC-repo-feature/demo");
+		expect(buildGjcTmuxWindowTitle("/repo", "main")).toBe("GJC-repo-main");
+		expect(buildGjcTmuxWindowTitle("/repo", null)).toBe("GJC-repo");
+		expect(buildGjcTmuxWindowTitle("/repo", "")).toBe("GJC-repo");
 	});
 
 	it("replaces colon-bearing tmux window title segments", () => {
-		expect(buildGjcTmuxWindowTitle("/repo:backend", "main")).toBe("repo-backend-main");
-		expect(buildGjcTmuxWindowTitle("/repo", "release:main")).toBe("repo-release-main");
-		expect(buildGjcTmuxWindowTitle("/repo", "feature:::demo")).toBe("repo-feature-demo");
+		expect(buildGjcTmuxWindowTitle("/repo:backend", "main")).toBe("GJC-repo-backend-main");
+		expect(buildGjcTmuxWindowTitle("/repo", "release:main")).toBe("GJC-repo-release-main");
+		expect(buildGjcTmuxWindowTitle("/repo", "feature:::demo")).toBe("GJC-repo-feature-demo");
 	});
 
 	it("truncates long tmux window titles to 48 visible columns while preserving the project and branch tail", () => {
 		const title = buildGjcTmuxWindowTitle("/repo", `feature/${"a".repeat(80)}tail`);
 
 		expect(Bun.stringWidth(title)).toBeLessThanOrEqual(48);
-		expect(title.startsWith("repo-…")).toBe(true);
+		expect(title.startsWith("GJC-repo-…")).toBe(true);
 		expect(title.endsWith("tail")).toBe(true);
 	});
 
@@ -91,16 +91,16 @@ describe("default GJC tmux launch", () => {
 		const title = buildGjcTmuxWindowTitle("/저장소", `feature/${"界".repeat(80)}끝`);
 
 		expect(Bun.stringWidth(title)).toBeLessThanOrEqual(48);
-		expect(title.startsWith("저장소-…")).toBe(true);
+		expect(title.startsWith("GJC-저장소-…")).toBe(true);
 		expect(title.endsWith("끝")).toBe(true);
 	});
 
 	it("sanitizes dot-prefixed cwd basenames for tmux window titles", () => {
-		expect(buildGjcTmuxWindowTitle("/tmp/.claude", null)).toBe("dot-claude");
-		expect(buildGjcTmuxWindowTitle("/tmp/.claude", "feature/demo")).toBe("dot-claude-feature/demo");
-		expect(buildGjcTmuxWindowTitle("/tmp/.claude", "repo:main")).toBe("dot-claude-repo-main");
-		expect(buildGjcTmuxWindowTitle("/tmp/...", null)).toBe("gjc");
-		expect(buildGjcTmuxWindowTitle("/tmp/...", "feature/demo")).toBe("gjc-feature/demo");
+		expect(buildGjcTmuxWindowTitle("/tmp/.claude", null)).toBe("GJC-dot-claude");
+		expect(buildGjcTmuxWindowTitle("/tmp/.claude", "feature/demo")).toBe("GJC-dot-claude-feature/demo");
+		expect(buildGjcTmuxWindowTitle("/tmp/.claude", "repo:main")).toBe("GJC-dot-claude-repo-main");
+		expect(buildGjcTmuxWindowTitle("/tmp/...", null)).toBe("GJC-gjc");
+		expect(buildGjcTmuxWindowTitle("/tmp/...", "feature/demo")).toBe("GJC-gjc-feature/demo");
 	});
 
 	it("passes sanitized dot-prefixed cwd basenames to tmux rename-window", () => {
@@ -130,11 +130,132 @@ describe("default GJC tmux launch", () => {
 			"-t",
 			expect.stringMatching(/^=gajae_code_/),
 			"--",
-			"dot-claude",
+			"GJC-dot-claude",
 		]);
 	});
 
-	it("separates dash-leading tmux window titles from tmux options", () => {
+	it("configures the tmux client terminal title before managed attach", () => {
+		const calls: Array<{ command: string; args: string[] }> = [];
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			existingBranchSessionName: null,
+			currentBranch: "feature/demo",
+			spawnSync: (command, spawnArgs) => {
+				calls.push({ command, args: spawnArgs });
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		const newSessionIndex = calls.findIndex(call => call.args[0] === "new-session");
+		const titleIndex = calls.findIndex(call => call.args[3] === "set-titles-string");
+		const attachIndex = calls.findIndex(call => call.args[0] === "attach-session");
+
+		expect(newSessionIndex).toBeGreaterThanOrEqual(0);
+		expect(titleIndex).toBeGreaterThan(newSessionIndex);
+		expect(titleIndex).toBeLessThan(attachIndex);
+		expect(calls[titleIndex]?.args).toEqual([
+			"set-option",
+			"-t",
+			expect.stringMatching(/^=gajae_code_.*:$/),
+			"set-titles-string",
+			"GJC: repo-feature/demo",
+		]);
+		expect(calls.some(call => call.args[3] === "set-titles" && call.args[4] === "on")).toBe(true);
+		expect(writeSpy).not.toHaveBeenCalled();
+	});
+
+	it("escapes tmux format markers in client terminal titles", () => {
+		const calls: Array<{ command: string; args: string[] }> = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			existingBranchSessionName: null,
+			currentBranch: "feature/#S/demo",
+			spawnSync: (command, spawnArgs) => {
+				calls.push({ command, args: spawnArgs });
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls.find(call => call.args[3] === "set-titles-string")?.args.at(-1)).toBe("GJC: repo-feature/##S/demo");
+	});
+
+	it("honors title opt-out while launching managed tmux", () => {
+		const calls: Array<{ command: string; args: string[] }> = [];
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"], tmux: true, noTitle: true }),
+			rawArgs: ["--tmux", "--no-title", "hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			existingBranchSessionName: null,
+			currentBranch: "feature/demo",
+			spawnSync: (command, spawnArgs) => {
+				calls.push({ command, args: spawnArgs });
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls.some(call => call.args.includes("set-titles") || call.args.includes("set-titles-string"))).toBe(
+			false,
+		);
+		expect(writeSpy).not.toHaveBeenCalled();
+	});
+
+	it("honors PI_NO_TITLE while launching managed tmux", () => {
+		const calls: Array<{ command: string; args: string[] }> = [];
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo",
+			env: { PI_NO_TITLE: "1" },
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			existingBranchSessionName: null,
+			currentBranch: "feature/demo",
+			spawnSync: (command, spawnArgs) => {
+				calls.push({ command, args: spawnArgs });
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls.some(call => call.args.includes("set-titles") || call.args.includes("set-titles-string"))).toBe(
+			false,
+		);
+		expect(writeSpy).not.toHaveBeenCalled();
+	});
+
+	it("passes prefixed tmux window titles after the tmux option separator", () => {
 		const calls: Array<{ command: string; args: string[]; options: TmuxSpawnOptions }> = [];
 		const handled = launchDefaultTmuxIfNeeded({
 			parsed: args({ messages: ["hello world"] }),
@@ -155,7 +276,7 @@ describe("default GJC tmux launch", () => {
 		});
 
 		expect(handled).toBe(false);
-		expect(calls[0]?.args).toEqual(["rename-window", "--", "-repo-feature/demo"]);
+		expect(calls[0]?.args).toEqual(["rename-window", "--", "GJC--repo-feature/demo"]);
 	});
 
 	it("does not plan tmux for interactive root launch without --tmux", () => {
@@ -419,7 +540,11 @@ describe("default GJC tmux launch", () => {
 		});
 
 		expect(handled).toBe(true);
-		expect(calls[0]?.args).toEqual(["attach-session", "-t", "=gajae_code_feature"]);
+		expect(calls.find(call => call.args[0] === "attach-session")?.args).toEqual([
+			"attach-session",
+			"-t",
+			"=gajae_code_feature",
+		]);
 		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
 		expect(calls.some(call => call.args[0] === "attach-session" && call.args[2] !== "=gajae_code_feature")).toBe(
 			true,
@@ -590,31 +715,41 @@ describe("default GJC tmux launch", () => {
 	it("cleans up a newly created managed session when attach fails", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
 		const diagnostics: string[] = [];
-		const handled = launchDefaultTmuxIfNeeded({
-			parsed: args({ tmux: true }),
-			rawArgs: [],
-			cwd: "/repo",
-			env: {},
-			argv: ["/usr/local/bin/gjc"],
-			execPath: "/bin/bun",
-			platform: "darwin",
-			tty: interactiveTty,
-			tmuxAvailable: true,
-			currentBranch: "",
-			existingBranchSessionName: null,
-			diagnosticWriter: message => diagnostics.push(message),
-			spawnSync: (command, spawnArgs, options) => {
-				calls.push({ command, args: spawnArgs, options });
-				if (spawnArgs[0] === "attach-session") return { exitCode: 1, stderr: "attach failed" };
-				return { exitCode: 0 };
-			},
-		});
+		const stdout = process.stdout as typeof process.stdout & { isTTY?: boolean };
+		const previousIsTTY = stdout.isTTY;
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+		stdout.isTTY = true;
 
-		expect(handled).toBe(true);
-		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
-		expect(calls.some(call => call.args[0] === "attach-session")).toBe(true);
-		expect(calls.some(call => call.args[0] === "kill-session")).toBe(true);
-		expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach failed.");
+		try {
+			const handled = launchDefaultTmuxIfNeeded({
+				parsed: args({ tmux: true }),
+				rawArgs: [],
+				cwd: "/repo",
+				env: {},
+				argv: ["/usr/local/bin/gjc"],
+				execPath: "/bin/bun",
+				platform: "darwin",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				currentBranch: "",
+				existingBranchSessionName: null,
+				diagnosticWriter: message => diagnostics.push(message),
+				spawnSync: (command, spawnArgs, options) => {
+					calls.push({ command, args: spawnArgs, options });
+					if (spawnArgs[0] === "attach-session") return { exitCode: 1, stderr: "attach failed" };
+					return { exitCode: 0 };
+				},
+			});
+
+			expect(handled).toBe(true);
+			expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
+			expect(calls.some(call => call.args[0] === "attach-session")).toBe(true);
+			expect(calls.some(call => call.args[0] === "kill-session")).toBe(true);
+			expect(writeSpy).not.toHaveBeenCalled();
+			expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach failed.");
+		} finally {
+			stdout.isTTY = previousIsTTY;
+		}
 	});
 
 	it("builds a session-scoped tmux profile without global tmux mutation", () => {
@@ -785,7 +920,7 @@ describe("default GJC tmux launch", () => {
 		expect(calls).toHaveLength(1);
 		expect(calls[0]).toMatchObject({
 			command: "tmux",
-			args: ["rename-window", "--", "repo-feature/demo"],
+			args: ["rename-window", "--", "GJC-repo-feature/demo"],
 		});
 	});
 
@@ -889,31 +1024,46 @@ describe("default GJC tmux launch", () => {
 
 		expect(newSessionIndex).toBeGreaterThanOrEqual(0);
 		expect(renameIndex).toBeGreaterThan(newSessionIndex);
-		expect(calls[renameIndex]?.args).toEqual(["rename-window", "-t", `=${sessionName}`, "--", "repo-feature/demo"]);
+		expect(calls[renameIndex]?.args).toEqual([
+			"rename-window",
+			"-t",
+			`=${sessionName}`,
+			"--",
+			"GJC-repo-feature/demo",
+		]);
 	});
 	it("falls through to direct launch when session creation fails", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
-		const handled = launchDefaultTmuxIfNeeded({
-			parsed: args({ tmux: true }),
-			rawArgs: [],
-			cwd: "/repo",
-			env: {},
-			argv: ["/usr/local/bin/gjc"],
-			execPath: "/bin/bun",
-			platform: "darwin",
-			tty: interactiveTty,
-			tmuxAvailable: true,
-			currentBranch: "",
-			existingBranchSessionName: null,
-			spawnSync: (command, spawnArgs, options) => {
-				calls.push({ command, args: spawnArgs, options });
-				return { exitCode: 1 };
-			},
-		});
+		const stdout = process.stdout as typeof process.stdout & { isTTY?: boolean };
+		const previousIsTTY = stdout.isTTY;
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+		stdout.isTTY = true;
+		try {
+			const handled = launchDefaultTmuxIfNeeded({
+				parsed: args({ tmux: true }),
+				rawArgs: [],
+				cwd: "/repo",
+				env: {},
+				argv: ["/usr/local/bin/gjc"],
+				execPath: "/bin/bun",
+				platform: "darwin",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				currentBranch: "",
+				existingBranchSessionName: null,
+				spawnSync: (command, spawnArgs, options) => {
+					calls.push({ command, args: spawnArgs, options });
+					return { exitCode: 1 };
+				},
+			});
 
-		expect(handled).toBe(false);
-		expect(calls).toHaveLength(1);
-		expect(calls[0].args[0]).toBe("new-session");
+			expect(handled).toBe(false);
+			expect(calls).toHaveLength(1);
+			expect(calls[0].args[0]).toBe("new-session");
+			expect(writeSpy).not.toHaveBeenCalled();
+		} finally {
+			stdout.isTTY = previousIsTTY;
+		}
 	});
 
 	it("handles and reports partial launch when required profile tagging fails", () => {


### PR DESCRIPTION
## Summary
- Configure tmux client terminal titles with session-scoped `set-titles` / `set-titles-string` before attach so active `gjc --tmux` clients expose `GJC: <project>` during the blocking attach lifetime.
- Keep tmux window names tmux-safe as `GJC-<project>` because real tmux rejects `:` in window names.
- Preserve `--no-title` / `PI_NO_TITLE` by skipping the tmux title profile when title generation is disabled.

## Follow-up from prior reviews
- Replaces #1292, #1293, and #1304.
- Uses tmux-managed title options instead of root stdout OSC writes.
- Uses exact tmux option targets (`=session:` on real tmux, psmux-safe through the shared resolver).
- Escapes `#` in `set-titles-string` so literal branch/project labels cannot be interpreted as tmux format strings (`#S`, `#{...}`, etc.).
- Adds regression coverage for title opt-outs, attach failure, active-attach ordering, and tmux format escaping.
- Squashed/rebased onto current `dev` as one clean commit.

## QA
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts`
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/test/modes/tmux-scroll.test.ts packages/coding-agent/test/title-generator.test.ts`
- `bun --cwd=packages/coding-agent run check`
- Real tmux smoke: window rename + `set-titles-string` with escaped `##S`
- Independent architect review: CLEAR / APPROVE