### PR TITLE
fix(coding-agent): route simple tasks directly

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -60,6 +60,9 @@ Use for read-only plan critique. It approves only when execution can proceed wit
 
 <routing>
 - Clear, low-risk implementation request → implement directly with focused verification.
+- Do not invoke `deep-interview`, `ralplan`, `ultragoal`, `team`, or role agents for simple clear implementation requests; direct tools and the default launch path are enough.
+- When a task is clear, bounded, and low-risk, the default action is to make the smallest correct change and verify it, not to interview, plan, open a durable ledger, or delegate.
+- Small verification needs do not make a task a planning workflow. Escalate only for real ambiguity, non-trivial architecture/sequence risk, durable multi-goal tracking, or useful coordinated workers.
 - Vague requirements → use `deep-interview` before planning or execution.
 - Clear requirements but non-trivial architecture/sequence risk → use `ralplan` and stop at pending approval.
 - Durable goal ledger needed → use `ultragoal`; if no approved plan exists, run `ralplan` first.
@@ -233,9 +236,10 @@ For image understanding, call `{{toolRefs.read}}` on the image path; the image i
 </before-editing>
 
 <decomposition>
-- Use todo tracking for tasks with three or more distinct steps.
+- Use todo tracking for tasks with three or more distinct steps; skip it for one-step or obvious two-step fixes where the next action is already clear.
 - Mark completed tasks immediately and continue to the next task without yielding.
 - Delegate rather than silently shrinking scope. Prefer `executor` for bounded implementation slices, `planner` for sequencing, `architect` for architecture/code-review lanes, and `critic` for plan critique.
+- Do not delegate for single-line typos, obvious syntax errors, single-file known-location fixes, or direct answers.
 </decomposition>
 
 <verification>

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -23,6 +23,13 @@ const tempRoots: string[] = [];
 const roleAgentNames = ["architect", "critic", "executor", "planner"] as const;
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
 
+function extractPromptSection(content: string, sectionName: string): string {
+	const sectionMatch = content.match(new RegExp(`<${sectionName}>\\n([\\s\\S]*?)\\n</${sectionName}>`));
+	const sectionContent = sectionMatch?.[1];
+	if (sectionContent === undefined) throw new Error(`missing <${sectionName}> section`);
+	return sectionContent;
+}
+
 async function makeTempRoot(): Promise<string> {
 	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-default-definitions-"));
 	tempRoots.push(tempRoot);
@@ -300,6 +307,34 @@ Project executor override body.
 		expect(ultragoal).toContain("the subagent has actually failed");
 		expect(ultragoal).toContain("gone off-track");
 		expect(ultragoal).toContain("become unrecoverably wrong");
+	});
+
+	it("routes simple clear implementation requests directly without contradictory workflow escalation", async () => {
+		const systemPrompt = await Bun.file(
+			path.join(repoRoot, "packages", "coding-agent", "src", "prompts", "system", "system-prompt.md"),
+		).text();
+		const routing = extractPromptSection(systemPrompt, "routing");
+		const decomposition = extractPromptSection(systemPrompt, "decomposition");
+
+		expect(routing).toMatch(/Clear,\s+low-risk implementation request\s+→\s+implement directly/i);
+		expect(routing).toMatch(/simple clear implementation requests[\s\S]*direct tools[\s\S]*default launch path/i);
+		expect(routing).toMatch(/clear,\s+bounded,\s+and low-risk[\s\S]*smallest correct change[\s\S]*verify/i);
+		expect(routing).toMatch(/Small verification needs[\s\S]*do not make[\s\S]*planning workflow/i);
+		for (const escalationTrigger of [
+			"Vague requirements",
+			"non-trivial architecture/sequence risk",
+			"Durable goal ledger",
+			"coordinated persistent workers",
+		]) {
+			expect(routing).toContain(escalationTrigger);
+		}
+
+		expect(decomposition).toMatch(/skip it for one-step or obvious two-step fixes/i);
+		expect(decomposition).toMatch(/Do not delegate[\s\S]*single-line typos[\s\S]*known-location fixes/i);
+		const simpleRequestRule = routing.split("\n").find(line => line.includes("simple clear implementation requests"));
+		expect(simpleRequestRule).toBeDefined();
+		expect(simpleRequestRule).not.toMatch(/use `deep-interview`|use `ralplan`|use `ultragoal`|use `team`|delegate/i);
+		expect(simpleRequestRule).toMatch(/Do not invoke/i);
 	});
 
 	it("documents leader-owned Ultragoal checkpoints for Team bridge workers", async () => {


### PR DESCRIPTION
## Summary

- Tighten GJC system-prompt routing so simple, clear, low-risk implementation requests stay on the direct/default launch path.
- Fix the deeper issue in `deep-interview`: if the skill is invoked for an already clear, bounded, low-risk quick fix/single change/direct answer, it now exits before state init, Round 0, ambiguity scoring, or spec writing.
- Clear already-seeded `deep-interview` workflow state through the sanctioned `gjc state clear --force --mode deep-interview --json` path before returning to direct implementation, so mutation/Stop guards do not keep blocking direct work.
- Add prompt-contract and runtime mutation-guard coverage for the simple-request escape hatch.

Reference borrowed from `code-yeongyu/oh-my-openagent` at `a9523bc6073a17b2be2578939716852bca91b81c`:
- trivial/explicit tasks route direct: https://github.com/code-yeongyu/oh-my-openagent/blob/a9523bc6073a17b2be2578939716852bca91b81c/src/agents/sisyphus.ts#L53-L63
- stop searching after enough/direct answer: https://github.com/code-yeongyu/oh-my-openagent/blob/a9523bc6073a17b2be2578939716852bca91b81c/src/agents/sisyphus.ts#L148-L156
- minimal bugfix rule: https://github.com/code-yeongyu/oh-my-openagent/blob/a9523bc6073a17b2be2578939716852bca91b81c/src/agents/sisyphus.ts#L222-L228

## Verification

- RED: `bun test packages/coding-agent/test/default-gjc-definitions.test.ts -t "keeps simple clear implementation requests on the direct path"` failed before the global prompt change because the direct/simple guard was absent.
- RED: `bun test packages/coding-agent/test/deep-interview-skill-contract.test.ts -t "deep-interview simple-request escape hatch"` failed before the deep-interview patch because quick fixes did not route to direct execution and no suitability gate existed.
- GREEN: `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`
- GREEN: `bun test packages/coding-agent/test/deep-interview-skill-contract.test.ts packages/coding-agent/test/deep-interview-mutation-guard.test.ts`
- GREEN: `bun test packages/coding-agent/test/deep-interview-mutation-guard.test.ts -t "allows direct work after the deep-interview suitability gate clears seeded state"`
- GREEN: `bun --cwd=packages/coding-agent run check`
- GREEN: `bun scripts/check-visible-definitions.ts`
- GREEN: `bun scripts/rebrand-inventory.ts --strict`
- GREEN: `git diff --check`
- Manual surface QA: `bun packages/coding-agent/src/cli.ts --help | sed -n '/Commands:/,/Environment Variables:/p'` shows `gjc [prompt]` remains the default launch command and workflow commands remain separate.
- Gate review: unconditional approval after adding runtime-facing deep-interview state-clear coverage and updated evidence.

Known unrelated gate failure:
- `bun scripts/verify-g002-gates.ts` still fails on existing `MCP quarantine/no default discoverable MCP`, specifically `README.md: MCP`. This PR does not touch README or MCP surfaces.

Known unrelated checker finding:
- The no-excuse checker reports pre-existing non-null assertions in `packages/coding-agent/test/default-gjc-definitions.test.ts` outside this patch.
