### PR TITLE
fix(deep-interview): exit early for simple tasks

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -21,13 +21,14 @@ Deep Interview implements Ouroboros-inspired Socratic questioning with mathemati
 - User wants to avoid "that's not what I meant" outcomes from autonomous execution
 - Task is complex enough that jumping to code would waste cycles on scope discovery
 - User wants mathematically-validated clarity before committing to execution
+- User explicitly requests deep-interview even after being told the request is already clear, bounded, and low-risk
 </Use_When>
 
 <Do_Not_Use_When>
 - User has a detailed, specific request with file paths, function names, or acceptance criteria -- execute directly
 - User wants to explore options or brainstorm -- use `ralplan` skill instead
-- User wants a quick fix or single change -- delegate to executor or execution
-- User says "just do it" or "skip the questions" without an explicit execution path -- respect their intent by ending interview and writing a `pending approval` spec, not by mutating files or delegating execution
+- User wants a quick fix or single change -- use direct execution, not deep-interview or role-agent delegation
+- User says "just do it" or "skip the questions" without an explicit execution path -- respect their intent by exiting deep-interview, not by writing a `pending approval` spec
 - User already has a PRD or plan file and explicitly asks to execute it -- use the requested execution skill with that plan
 </Do_Not_Use_When>
 
@@ -102,6 +103,27 @@ Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThreshold
    - Include `threshold_source` in the first `gjc state write` payload and preserve it on later state updates; do not edit `.gjc/_session-{sessionid}/state` files directly unless an explicit force override is active.
    - Include both threshold and source in the final spec metadata.
 - Read any `language` object from active deep-interview state and carry `language.instruction` forward mechanically. If absent, default to English unless `{{ARGUMENTS}}` makes another user/session language obvious or the user explicitly requests another language. Do not add language-specific special cases.
+
+## Phase 0.5: Suitability Gate
+
+Run this gate after the Phase 0 threshold marker and before Phase 1, brownfield exploration, `gjc state write`, Round 0, ambiguity scoring, or spec writing.
+
+If `{{ARGUMENTS}}` is already clear, bounded, low-risk, and asks for a quick fix, single change, known file/symbol edit, explicit command, or direct answer:
+
+1. **Stop deep-interview immediately**:
+   - First inspect current-session state with `gjc state read --mode deep-interview --json` (include `--session-id <current-session-id>` when available).
+   - Clear through `gjc state clear --force --mode deep-interview --json` only when the state is a newly seeded empty interview: no recorded `rounds`, no `spec_path`, no `handoff_from`, no final/pending spec, and no user-confirmed topology.
+   - If state already contains rounds, a spec path, handoff metadata, pending approval, or confirmed topology, do not clear it. Preserve the active interview and ask the user whether to continue, cancel, or explicitly clear the workflow.
+   - Do not initialize deep-interview state.
+   - Do not run Round 0.
+   - Do not write a pending-approval spec.
+   - Do not hand off to `ralplan`, `ultragoal`, `team`, or a role agent.
+2. **Return the request to direct implementation**:
+   - Say briefly that deep-interview is unnecessary because the request is already clear and small.
+   - State the direct implementation path the normal coding agent should take.
+   - If the user explicitly insists on deep-interview anyway, continue to Phase 1.
+
+This gate exists to prevent deep-interview from making easy problems harder. A small verification need does not make a request interview-worthy.
 
 ## Phase 1: Initialize
 

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -60,6 +60,9 @@ Use for read-only plan critique. It approves only when execution can proceed wit
 
 <routing>
 - Clear, low-risk implementation request → implement directly with focused verification.
+- Do not invoke `deep-interview`, `ralplan`, `ultragoal`, `team`, or role agents for simple clear implementation requests; direct tools and the default launch path are enough.
+- When a task is clear, bounded, and low-risk, the default action is to make the smallest correct change and verify it, not to interview, plan, open a durable ledger, or delegate.
+- Small verification needs do not make a task a planning workflow. Escalate only for real ambiguity, non-trivial architecture/sequence risk, durable multi-goal tracking, or useful coordinated workers.
 - Vague requirements → use `deep-interview` before planning or execution.
 - Clear requirements but non-trivial architecture/sequence risk → use `ralplan` and stop at pending approval.
 - Durable goal ledger needed → use `ultragoal`; if no approved plan exists, run `ralplan` first.
@@ -233,9 +236,10 @@ For image understanding, call `{{toolRefs.read}}` on the image path; the image i
 </before-editing>
 
 <decomposition>
-- Use todo tracking for tasks with three or more distinct steps.
+- Use todo tracking for tasks with three or more distinct steps; skip it for one-step or obvious two-step fixes where the next action is already clear.
 - Mark completed tasks immediately and continue to the next task without yielding.
 - Delegate rather than silently shrinking scope. Prefer `executor` for bounded implementation slices, `planner` for sequencing, `architect` for architecture/code-review lanes, and `critic` for plan critique.
+- Do not delegate for single-line typos, obvious syntax errors, single-file known-location fixes, or direct answers.
 </decomposition>
 
 <verification>

--- a/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
+++ b/packages/coding-agent/test/deep-interview-mutation-guard.test.ts
@@ -8,6 +8,7 @@ import {
 	modeStatePath,
 	sessionStateDir,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
+import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
 import {
 	assertDeepInterviewMutationRawPathsAllowed,
 	DEEP_INTERVIEW_MUTATION_BLOCK_MESSAGE,
@@ -86,6 +87,11 @@ function tool(name: string, extra: Record<string, unknown> = {}): AgentTool {
 		execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
 		...extra,
 	} as AgentTool;
+}
+
+function parseStateCommandJson(stdout: string | undefined): Record<string, unknown> {
+	if (!stdout) throw new Error("missing state command stdout");
+	return JSON.parse(stdout) as Record<string, unknown>;
 }
 
 afterEach(async () => {
@@ -322,6 +328,40 @@ describe("deep-interview mutation guard", () => {
 			args: { path: "src/product.ts", content: "x" },
 		});
 		expect(decision.blocked).toBe(false);
+	});
+
+	it("allows direct work after the deep-interview suitability gate clears seeded state", async () => {
+		const cwd = await makeTempRoot();
+		const sessionId = "session-a";
+		await writeActiveDeepInterview(cwd, sessionId);
+
+		const beforeClear = await getDeepInterviewMutationDecision({
+			cwd,
+			sessionId,
+			tool: tool("write"),
+			args: { path: "src/product.ts", content: "x" },
+		});
+		expect(beforeClear.blocked).toBe(true);
+
+		const clear = await runNativeStateCommand(
+			["clear", "--mode", "deep-interview", "--session-id", sessionId, "--force", "--json"],
+			cwd,
+		);
+		expect(clear.status).toBe(0);
+		expect(parseStateCommandJson(clear.stdout)).toMatchObject({
+			ok: true,
+			skill: "deep-interview",
+			active: false,
+			current_phase: "complete",
+		});
+
+		const afterClear = await getDeepInterviewMutationDecision({
+			cwd,
+			sessionId,
+			tool: tool("write"),
+			args: { path: "src/product.ts", content: "x" },
+		});
+		expect(afterClear.blocked).toBe(false);
 	});
 
 	it("allows writes and logs when deep-interview mode state is invalid", async () => {

--- a/packages/coding-agent/test/deep-interview-skill-contract.test.ts
+++ b/packages/coding-agent/test/deep-interview-skill-contract.test.ts
@@ -7,6 +7,13 @@ const skillPath = join(dirname(fileURLToPath(import.meta.url)), "../src/defaults
 
 const skill = readFileSync(skillPath, "utf8");
 
+function extractSection(content: string, sectionName: string): string {
+	const sectionMatch = content.match(new RegExp(`<${sectionName}>\\n([\\s\\S]*?)\\n</${sectionName}>`));
+	const sectionContent = sectionMatch?.[1];
+	if (sectionContent === undefined) throw new Error(`missing <${sectionName}> section`);
+	return sectionContent;
+}
+
 describe("deep-interview skill conflict-aware scoring contract", () => {
 	it("documents the ambiguity-raising triggers and established facts", () => {
 		expect(skill).toContain("A direct contradiction");
@@ -43,6 +50,37 @@ describe("deep-interview skill conflict-aware scoring contract", () => {
 		expect(skill).toMatch(/Convergence Pacing deferral/i);
 		expect(skill).toMatch(/min-round floor, score-drop cap, (confidence )?dampening/i);
 		expect(skill).toMatch(/Bidirectional scoring is the pacing mechanism/i);
+	});
+});
+
+describe("deep-interview simple-request escape hatch", () => {
+	it("stops before interview state, Round 0, or spec writing when the request is already clear and small", () => {
+		const doNotUseWhen = extractSection(skill, "Do_Not_Use_When");
+		const steps = extractSection(skill, "Steps");
+		const suitabilityGateIndex = steps.indexOf("## Phase 0.5: Suitability Gate");
+		const initializeIndex = steps.indexOf("## Phase 1: Initialize");
+		const roundZeroIndex = steps.indexOf("## Round 0: Topology Enumeration Gate");
+		const executionBridgeIndex = steps.indexOf("## Phase 5: Execution Bridge");
+
+		expect(doNotUseWhen).toMatch(/detailed,\s+specific request[\s\S]*execute directly/i);
+		expect(doNotUseWhen).toMatch(/quick fix or single change[\s\S]*direct execution/i);
+		expect(suitabilityGateIndex).toBeGreaterThanOrEqual(0);
+		expect(suitabilityGateIndex).toBeLessThan(initializeIndex);
+		expect(suitabilityGateIndex).toBeLessThan(roundZeroIndex);
+		expect(suitabilityGateIndex).toBeLessThan(executionBridgeIndex);
+
+		const suitabilityGate = steps.slice(suitabilityGateIndex, initializeIndex);
+		expect(suitabilityGate).toMatch(/clear,\s+bounded,\s+low-risk/i);
+		expect(suitabilityGate).toContain("gjc state read --mode deep-interview --json");
+		expect(suitabilityGate).toContain("gjc state clear --force --mode deep-interview");
+		expect(suitabilityGate).toMatch(/newly seeded empty interview/i);
+		expect(suitabilityGate).toMatch(/no recorded `rounds`[\s\S]*no `spec_path`[\s\S]*no `handoff_from`/i);
+		expect(suitabilityGate).toMatch(/If state already contains rounds[\s\S]*do not clear it/i);
+		expect(suitabilityGate).toMatch(/Preserve the active interview/i);
+		expect(suitabilityGate).toMatch(/do not initialize deep-interview state/i);
+		expect(suitabilityGate).toMatch(/do not run Round 0/i);
+		expect(suitabilityGate).toMatch(/do not write a pending-approval spec/i);
+		expect(suitabilityGate).toMatch(/direct implementation/i);
 	});
 });
 

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -23,6 +23,13 @@ const tempRoots: string[] = [];
 const roleAgentNames = ["architect", "critic", "executor", "planner"] as const;
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
 
+function extractPromptSection(content: string, sectionName: string): string {
+	const sectionMatch = content.match(new RegExp(`<${sectionName}>\\n([\\s\\S]*?)\\n</${sectionName}>`));
+	const sectionContent = sectionMatch?.[1];
+	if (sectionContent === undefined) throw new Error(`missing <${sectionName}> section`);
+	return sectionContent;
+}
+
 async function makeTempRoot(): Promise<string> {
 	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-default-definitions-"));
 	tempRoots.push(tempRoot);
@@ -300,6 +307,34 @@ Project executor override body.
 		expect(ultragoal).toContain("the subagent has actually failed");
 		expect(ultragoal).toContain("gone off-track");
 		expect(ultragoal).toContain("become unrecoverably wrong");
+	});
+
+	it("routes simple clear implementation requests directly without contradictory workflow escalation", async () => {
+		const systemPrompt = await Bun.file(
+			path.join(repoRoot, "packages", "coding-agent", "src", "prompts", "system", "system-prompt.md"),
+		).text();
+		const routing = extractPromptSection(systemPrompt, "routing");
+		const decomposition = extractPromptSection(systemPrompt, "decomposition");
+
+		expect(routing).toMatch(/Clear,\s+low-risk implementation request\s+→\s+implement directly/i);
+		expect(routing).toMatch(/simple clear implementation requests[\s\S]*direct tools[\s\S]*default launch path/i);
+		expect(routing).toMatch(/clear,\s+bounded,\s+and low-risk[\s\S]*smallest correct change[\s\S]*verify/i);
+		expect(routing).toMatch(/Small verification needs[\s\S]*do not make[\s\S]*planning workflow/i);
+		for (const escalationTrigger of [
+			"Vague requirements",
+			"non-trivial architecture/sequence risk",
+			"Durable goal ledger",
+			"coordinated persistent workers",
+		]) {
+			expect(routing).toContain(escalationTrigger);
+		}
+
+		expect(decomposition).toMatch(/skip it for one-step or obvious two-step fixes/i);
+		expect(decomposition).toMatch(/Do not delegate[\s\S]*single-line typos[\s\S]*known-location fixes/i);
+		const simpleRequestRule = routing.split("\n").find(line => line.includes("simple clear implementation requests"));
+		expect(simpleRequestRule).toBeDefined();
+		expect(simpleRequestRule).not.toMatch(/use `deep-interview`|use `ralplan`|use `ultragoal`|use `team`|delegate/i);
+		expect(simpleRequestRule).toMatch(/Do not invoke/i);
 	});
 
 	it("documents leader-owned Ultragoal checkpoints for Team bridge workers", async () => {


### PR DESCRIPTION
## Summary

- Tighten GJC system-prompt routing so simple, clear, low-risk implementation requests stay on the direct/default launch path.
- Fix the deeper issue in `deep-interview`: if the skill is invoked for an already clear, bounded, low-risk quick fix/single change/direct answer, it now exits before state init, Round 0, ambiguity scoring, or spec writing.
- Prevent over-release: the escape hatch first reads `deep-interview` state and clears only a newly seeded empty interview with no rounds, spec path, handoff metadata, pending/final spec, or confirmed topology.
- Clear eligible seeded `deep-interview` workflow state through the sanctioned `gjc state clear --force --mode deep-interview --json` path before returning to direct implementation, so mutation/Stop guards do not keep blocking direct work.
- Add prompt-contract and runtime mutation-guard coverage for the simple-request escape hatch.

Reference borrowed from `code-yeongyu/oh-my-openagent` at `a9523bc6073a17b2be2578939716852bca91b81c`:
- trivial/explicit tasks route direct: https://github.com/code-yeongyu/oh-my-openagent/blob/a9523bc6073a17b2be2578939716852bca91b81c/src/agents/sisyphus.ts#L53-L63
- stop searching after enough/direct answer: https://github.com/code-yeongyu/oh-my-openagent/blob/a9523bc6073a17b2be2578939716852bca91b81c/src/agents/sisyphus.ts#L148-L156
- minimal bugfix rule: https://github.com/code-yeongyu/oh-my-openagent/blob/a9523bc6073a17b2be2578939716852bca91b81c/src/agents/sisyphus.ts#L222-L228

## Verification

- RED: `bun test packages/coding-agent/test/default-gjc-definitions.test.ts -t "keeps simple clear implementation requests on the direct path"` failed before the global prompt change because the direct/simple guard was absent.
- RED: `bun test packages/coding-agent/test/deep-interview-skill-contract.test.ts -t "deep-interview simple-request escape hatch"` failed before the deep-interview patch because quick fixes did not route to direct execution and no suitability gate existed.
- GREEN: `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`
- GREEN: `bun test packages/coding-agent/test/deep-interview-skill-contract.test.ts packages/coding-agent/test/deep-interview-mutation-guard.test.ts`
- GREEN: `bun test packages/coding-agent/test/deep-interview-mutation-guard.test.ts -t "allows direct work after the deep-interview suitability gate clears seeded state"`
- GREEN: `bun --cwd=packages/coding-agent run check`
- GREEN: `bun scripts/check-visible-definitions.ts`
- GREEN: `bun scripts/rebrand-inventory.ts --strict`
- GREEN: `git diff --check`
- Manual surface QA: `bun packages/coding-agent/src/cli.ts --help | sed -n '/Commands:/,/Environment Variables:/p'` shows `gjc [prompt]` remains the default launch command and workflow commands remain separate.
- Gate review: unconditional approval after adding runtime-facing deep-interview state-clear coverage and updated evidence.

Known unrelated gate failure:
- `bun scripts/verify-g002-gates.ts` still fails on existing `MCP quarantine/no default discoverable MCP`, specifically `README.md: MCP`. This PR does not touch README or MCP surfaces.

Known unrelated checker finding:
- The no-excuse checker reports pre-existing non-null assertions in `packages/coding-agent/test/default-gjc-definitions.test.ts` outside this patch.
