### PR TITLE
Add maintainer-owned contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Gajae-Code
+
+Thanks for contributing. This guide is intentionally short so pull requests land on the right branch with enough context to review.
+
+## Branch policy
+
+Open pull requests against `dev`.
+
+Do not target `main` unless a maintainer explicitly asks you to. `main` is reserved for maintainer-directed release flow, so PRs opened against `main` may be closed and asked to reopen against `dev`.
+
+## Local setup
+
+This repository uses Bun workspaces.
+
+```sh
+bun install
+bun run dev:doctor
+```
+
+To run Gajae-Code from the checkout:
+
+```sh
+bun run dev
+```
+
+## Focused tests
+
+Run the smallest command that covers your change before opening a PR. Common options are:
+
+```sh
+bun test path/to/file.test.ts
+bun run check:tools
+bun run check
+```
+
+Use focused tests first for code changes, then broader checks when the change affects shared behavior or release-critical paths.
+
+## PR checklist
+
+- Target branch is `dev`, not `main`.
+- The PR description explains what changed and why.
+- Relevant focused tests or checks are listed in the PR description.
+- User-facing changes include a changelog entry when appropriate.


### PR DESCRIPTION
## What

Adds a concise root `CONTRIBUTING.md` with maintainer-owned contribution guidance.

## Why

This replaces the closed broad external guide from #1310 with narrow public guidance owned by maintainers, and addresses recurring confusion about contributors opening PRs against `main` instead of `dev`.

## Testing

- `python3` content sanity check for required branch/setup/test guidance and private/internal wording exclusions
- `git diff --check origin/dev...HEAD`
- `bun run check:tools` was attempted, but local dependencies are not installed (`biome: command not found`)

## Notes

The guide is intentionally limited to branch policy, local setup, focused tests, and a short PR checklist.