### PR TITLE
fix(deep-interview): accept long inline --spec, not just file paths

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -100,7 +100,7 @@ async function resolveSpecContent(rawSpec: string, cwd: string): Promise<string>
 		if (stat.isFile()) return await fs.readFile(candidate, "utf-8");
 	} catch (error) {
 		const err = error as NodeJS.ErrnoException;
-		if (err.code !== "ENOENT" && err.code !== "ENOTDIR") {
+		if (err.code !== "ENOENT" && err.code !== "ENOTDIR" && err.code !== "ENAMETOOLONG") {
 			throw new DeepInterviewCommandError(2, `failed to read --spec ${candidate}: ${err.message}`);
 		}
 	}

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
@@ -152,6 +152,23 @@ describe("native gjc deep-interview runtime", () => {
 		await expect(fs.access(sessionPlansDir(root, TEST_SESSION_ID))).rejects.toThrow();
 	});
 
+	it("accepts a long inline --spec that exceeds the OS path-length limit", async () => {
+		const root = await tempDir();
+		// A spec far longer than PATH_MAX so path.resolve(...) + fs.stat throws ENAMETOOLONG
+		// instead of ENOENT; the runtime must fall through to treating --spec as inline content.
+		const inlineSpec = `# Final Spec\n\n${"acceptance criterion line ".repeat(2000)}`;
+		expect(inlineSpec.length).toBeGreaterThan(4096);
+
+		const result = await runNativeDeepInterviewCommand(
+			["--write", "--stage", "final", "--slug", "long-inline", "--spec", inlineSpec, "--json"],
+			root,
+		);
+		expect(result.status).toBe(0);
+		const payload = JSON.parse(result.stdout ?? "{}");
+		expect(payload.path).toBe(path.join(sessionSpecsDir(root, TEST_SESSION_ID), "deep-interview-long-inline.md"));
+		expect(await fs.readFile(payload.path, "utf-8")).toBe(`${inlineSpec}\n`);
+	});
+
 	it("uses --deliberate to persist the final spec and hand off to ralplan", async () => {
 		const root = await tempDir();
 		const result = await runNativeDeepInterviewCommand(


### PR DESCRIPTION
## Summary
`gjc deep-interview --spec` is documented as "Final spec markdown **or** a path to the final spec markdown", but a long inline spec failed with `ENAMETOOLONG: ... failed to read --spec` (exit 2).

`resolveSpecContent` probed `--spec` as a path via `fs.stat` and only swallowed `ENOENT`/`ENOTDIR`. A long inline value made `fs.stat` throw `ENAMETOOLONG`, which propagated as a hard error instead of falling back to inline content.

## Change
- Swallow `ENAMETOOLONG` alongside `ENOENT`/`ENOTDIR` in the stat/read catch — an over-long candidate can never be a real file, so it falls through to treating `--spec` as inline content.
- Regression test: a >4KB inline `--spec` persists with exit 0 and exact content.

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts` → 19 pass / 0 fail.
- Live source CLI: 52KB inline spec → exit 0, persisted; real file-path branch unchanged; ENOENT fall-through unchanged; empty `--spec` still rejected (exit 2).