### PR TITLE
fix(notifications): document Windows Terminal bell workaround

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Compiled binaries can now include the hidden Telegram daemon CLI entrypoint without hanging root startup, and release builds preserve that entry so `gjc notify daemon-internal --smoke` is available in standalone binaries (#1288).
+- Documented Windows Terminal BEL limitations for terminal bell notifications and added a PowerShell `completion.notifyCommand` beep workaround example (#1318).
 
 ## [0.7.8] - 2026-06-30
 ### Added

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -24,6 +24,12 @@ For simple local side effects that do not need a full extension, set the user-le
 gjc config set completion.notifyCommand 'cmux notify --title "$GJC_NOTIFICATION_TITLE" --body "$GJC_NOTIFICATION_BODY"'
 ```
 
+Windows Terminal may keep BEL (`[Console]::Write([char]7)`) silent depending on profile and system sound settings even when `notifications.terminalBell` is enabled. For an audible Windows completion beep, configure a user-level PowerShell command hook instead:
+
+```powershell
+gjc config set completion.notifyCommand 'powershell.exe -NoProfile -Command "[Console]::Beep(880, 300)"'
+```
+
 `cmux notify` returning successfully means GJC handed the completion event to cmux. cmux may still suppress the native desktop banner when the app/window is focused, the emitting workspace is active, or the notification panel is open. In those cases, check cmux's notification panel or unread workspace state instead of treating the missing banner as a GJC delivery failure.
 
 Recommended external mapping:

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -280,7 +280,8 @@ export const SETTINGS_SCHEMA = {
 		ui: {
 			tab: "interaction",
 			label: "Terminal Bell",
-			description: "Emit a BEL character for local terminal notifications",
+			description:
+				"Emit a BEL character for local terminal notifications. Windows Terminal may keep BEL silent depending on profile/system sound settings; use completion.notifyCommand for a PowerShell Console.Beep workaround.",
 		},
 	},
 	"notifications.bellOnComplete": {
@@ -1179,7 +1180,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "interaction",
 			label: "Completion Notification Command",
 			description:
-				"Optional user-level shell command to run when an agent turn completes; receives GJC_NOTIFICATION_* environment variables.",
+				"Optional user-level shell command to run when an agent turn completes; receives GJC_NOTIFICATION_* environment variables. On Windows, this can call PowerShell [Console]::Beep when terminal BEL is silent.",
 		},
 	},
 

--- a/packages/coding-agent/test/terminal-bell.test.ts
+++ b/packages/coding-agent/test/terminal-bell.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
+import { SETTINGS_SCHEMA } from "@gajae-code/coding-agent/config/settings-schema";
 import { classifyHookSelectorBellEvent, ringTerminalBell } from "@gajae-code/coding-agent/modes/utils/terminal-bell";
 
 beforeEach(async () => {
@@ -45,6 +46,15 @@ describe("terminal bell notifications", () => {
 		ringTerminalBell("ask", output);
 
 		expect(output.write).not.toHaveBeenCalled();
+	});
+
+	it("documents Windows Terminal BEL limitations in config help", () => {
+		const terminalBell = SETTINGS_SCHEMA["notifications.terminalBell"];
+		const notifyCommand = SETTINGS_SCHEMA["completion.notifyCommand"];
+
+		expect(terminalBell.ui?.description).toContain("Windows Terminal");
+		expect(terminalBell.ui?.description).toContain("completion.notifyCommand");
+		expect(notifyCommand.ui?.description).toContain("PowerShell [Console]::Beep");
 	});
 
 	it("classifies approval-like selector titles separately from generic ask prompts", () => {

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -89,7 +89,7 @@
 				},
 				"terminalBell": {
 					"type": "boolean",
-					"description": "Emit a BEL character for local terminal notifications",
+					"description": "Emit a BEL character for local terminal notifications. Windows Terminal may keep BEL silent depending on profile/system sound settings; use completion.notifyCommand for a PowerShell Console.Beep workaround.",
 					"default": false
 				},
 				"bellOnComplete": {
@@ -838,7 +838,7 @@
 				},
 				"notifyCommand": {
 					"type": "string",
-					"description": "Optional user-level shell command to run when an agent turn completes; receives GJC_NOTIFICATION_* environment variables.",
+					"description": "Optional user-level shell command to run when an agent turn completes; receives GJC_NOTIFICATION_* environment variables. On Windows, this can call PowerShell [Console]::Beep when terminal BEL is silent.",
 					"default": ""
 				}
 			},


### PR DESCRIPTION
## Summary
- Documents that Windows Terminal may keep BEL silent even when `notifications.terminalBell` is enabled.
- Adds a Windows PowerShell `completion.notifyCommand` example using `[Console]::Beep(880, 300)`.
- Updates config/schema help text and focused terminal-bell test coverage.

Closes #1318.

## Tests
- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/terminal-bell.test.ts packages/coding-agent/test/web/search/config-schema.test.ts`