### PR TITLE
fix(deep-interview): keep implementation wording in interview phase

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Deep Interview now treats English `implementation` and Korean `구현` wording as eventual-target language, not permission to edit code or launch implementation before post-interview approval (#1320).
 - Compiled binaries can now include the hidden Telegram daemon CLI entrypoint without hanging root startup, and release builds preserve that entry so `gjc notify daemon-internal --smoke` is available in standalone binaries (#1288).
 - Documented Windows Terminal BEL limitations for terminal bell notifications and added a PowerShell `completion.notifyCommand` beep workaround example (#1318).
 

--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -51,6 +51,10 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 - Keep prompt payloads budgeted: summarize or trim oversized initial context/history before composing question, scoring, spec, or handoff prompts
 - If the user's initial context is oversized, create a concise prompt-safe summary first and wait for that summary before ambiguity scoring, question generation, or downstream execution handoff
 - Do not proceed to execution until ambiguity ≤ the resolved threshold for this run and the user explicitly approves a scoped execution path
+- Treat user wording such as `implementation`, "implementation plan", Korean `구현`, or "구현 계획" as describing the eventual target, not permission to implement now.
+- While still in deep-interview, do not implement, edit/write code, launch implementation workers, or start task/skill/ultragoal implementation; continue interviewing for scope, risks, acceptance criteria, and unknowns.
+- When the user wants interview output for eventual implementation, say: "I can interview for an implementation plan, but I won't implement during deep-interview." Then continue clarifying scope, risks, acceptance criteria, and unknowns.
+- Implementation requires an explicit phase transition/approval after the interview: deep-interview must first produce its spec/handoff, the workflow phase must explicitly transition out of deep-interview, and execution approval must be captured by a downstream execution path.
 - Allow early exit with a clear warning if ambiguity is still high
 - Persist interview state for resume across session interruptions
 - A multi-persona lateral-review panel convenes at ambiguity-milestone transitions (and before synthesizing any agent-supplied answer) to expose blind spots from independent perspectives

--- a/packages/coding-agent/test/deep-interview-skill-contract.test.ts
+++ b/packages/coding-agent/test/deep-interview-skill-contract.test.ts
@@ -78,3 +78,22 @@ describe("deep-interview self-proofread output rule", () => {
 		expect(skill).toContain("was silently self-proofread once according to");
 	});
 });
+
+describe("deep-interview implementation wording boundary", () => {
+	it("treats English and Korean implementation wording as eventual target wording, not execution approval", () => {
+		expect(skill).toContain('`implementation`, "implementation plan", Korean `구현`, or "구현 계획"');
+		expect(skill).toContain("describing the eventual target, not permission to implement now");
+		expect(skill).toContain("do not implement, edit/write code, launch implementation workers");
+		expect(skill).toContain("start task/skill/ultragoal implementation");
+	});
+
+	it("states the deep-interview implementation boundary and required phase transition", () => {
+		expect(skill).toContain(
+			"I can interview for an implementation plan, but I won't implement during deep-interview.",
+		);
+		expect(skill).toContain("continue clarifying scope, risks, acceptance criteria, and unknowns");
+		expect(skill).toContain("Implementation requires an explicit phase transition/approval after the interview");
+		expect(skill).toContain("workflow phase must explicitly transition out of deep-interview");
+		expect(skill).toContain("execution approval must be captured by a downstream execution path");
+	});
+});


### PR DESCRIPTION
## Summary
- Clarifies that English `implementation` and Korean `구현` wording inside deep-interview describes the eventual target, not permission to implement.
- Explicitly keeps code edits, implementation workers, and task/skill/ultragoal implementation out of the deep-interview phase.
- Adds contract regression coverage for the phase-transition/approval boundary.

Closes #1320.

## Tests
- `bun test packages/coding-agent/test/deep-interview-skill-contract.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts`