### PR TITLE
Fix coordinator MCP tmux prompt submission

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -1273,8 +1273,10 @@ async function sendTmuxPromptKeys(
 	prompt: string,
 	runner: CommandRunner = runCommand,
 ): Promise<boolean> {
-	const sent = await runner(["tmux", "send-keys", "-t", target, prompt, "C-m", "C-m"]);
-	return sent.exitCode === 0;
+	const typed = await runner(["tmux", "send-keys", "-t", target, "-l", prompt]);
+	if (typed.exitCode !== 0) return false;
+	const submitted = await runner(["tmux", "send-keys", "-t", target, "-l", "\x1b[13;5u"]);
+	return submitted.exitCode === 0;
 }
 
 function boundedLineCount(value: unknown): number {

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -362,6 +362,12 @@ export class CustomEditor extends Editor {
 			return;
 		}
 
+		// Main chat prompt uses Enter for multiline editing; Ctrl+Enter is the explicit submit chord.
+		if (!this.isAutocompleteOpen() && (data === "\r" || matchesKey(data, "enter") || matchesKey(data, "return"))) {
+			super.handleInput("\x1b[13;2u");
+			return;
+		}
+
 		// Check custom key handlers (extensions)
 		for (const [keyId, handler] of this.#customKeyHandlers) {
 			if (matchesKey(data, keyId)) {

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -195,7 +195,12 @@ describe("Coordinator MCP server protocol", () => {
 			status: "active",
 			delivery: { target: "visible-session:0.0", tmux_keys_sent: true, state: "tmux_keys_sent" },
 		});
-		expect(commands).toContainEqual(["tmux", "send-keys", "-t", "visible-session:0.0", "do work", "C-m", "C-m"]);
+		expect(commands).toEqual(
+			expect.arrayContaining([
+				["tmux", "send-keys", "-t", "visible-session:0.0", "-l", "do work"],
+				["tmux", "send-keys", "-t", "visible-session:0.0", "-l", "\x1b[13;5u"],
+			]),
+		);
 	});
 
 	it("fails tmux-delivered turns that never receive a runtime prompt ack", async () => {
@@ -301,6 +306,52 @@ describe("Coordinator MCP server protocol", () => {
 				error: { code: "runtime_prompt_ack_timeout" },
 			},
 		});
+	});
+
+	it("submits tmux-delivered prompts with the runtime submit chord instead of plain Enter", async () => {
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "state", "submit-chord-delivery");
+		const sendKeyCommands: string[][] = [];
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+			},
+			services: {
+				commandRunner: async command => {
+					if (command[1] === "has-session") return { exitCode: 0, stdout: "", stderr: "" };
+					if (command[1] === "display-message") return { exitCode: 0, stdout: "%24\n", stderr: "" };
+					if (command[1] === "send-keys") {
+						sendKeyCommands.push(command);
+						return { exitCode: 0, stdout: "", stderr: "" };
+					}
+					if (command[1] === "capture-pane") return { exitCode: 0, stdout: "idle\n", stderr: "" };
+					return { exitCode: 1, stdout: "", stderr: "unexpected command" };
+				},
+			},
+		});
+
+		await server.callTool("gjc_coordinator_register_session", {
+			session_id: "visible-session",
+			cwd: root,
+			tmux_session: "visible-session",
+			tmux_target: "visible-session:0.0",
+			visible: true,
+			allow_mutation: true,
+		});
+		await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "line one\nline two",
+			allow_mutation: true,
+		});
+
+		expect(sendKeyCommands).toEqual([
+			["tmux", "send-keys", "-t", "visible-session:0.0", "-l", "line one\nline two"],
+			["tmux", "send-keys", "-t", "visible-session:0.0", "-l", "\x1b[13;5u"],
+		]);
 	});
 
 	it("marks tmux-delivered turns acknowledged when runtime state accepts the current turn", async () => {
@@ -522,7 +573,8 @@ describe("Coordinator MCP server protocol", () => {
 		expect(response.ok).toBe(true);
 		expect(activeTurnExistedAtSend).toBe(true);
 		expect(commands.filter(command => command[1] === "send-keys")).toEqual([
-			["tmux", "send-keys", "-t", "gjc-coordinator-test:0.0", "hello", "C-m", "C-m"],
+			["tmux", "send-keys", "-t", "gjc-coordinator-test:0.0", "-l", "hello"],
+			["tmux", "send-keys", "-t", "gjc-coordinator-test:0.0", "-l", "\x1b[13;5u"],
 		]);
 	});
 

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -83,6 +83,19 @@ describe("CustomEditor queue keybinding", () => {
 		expect(editor.getText()).toBe("");
 	});
 
+	it("keeps plain Enter as a multiline newline chord", () => {
+		const editor = createEditor();
+		const onSubmit = vi.fn();
+		editor.onSubmit = onSubmit;
+
+		editor.handleInput("a");
+		editor.handleInput("\r");
+		editor.handleInput("b");
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("a\nb");
+	});
+
 	it("routes Ctrl+Enter through slash command completion before submit", () => {
 		const editor = createEditor();
 		const onSubmit = vi.fn();


### PR DESCRIPTION
## Summary
- deliver coordinator MCP prompts to tmux panes with literal `send-keys -l` to preserve prompt bytes
- submit delivered prompts with the runtime Ctrl+Enter CSI-u chord instead of plain Enter
- keep plain Enter as multiline input in `CustomEditor` and cover the regression

Closes #1325

## Verification
- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/coordinator-mcp-server.test.ts packages/coding-agent/test/custom-editor-keybindings.test.ts`

Generated with [Gajae Code](https://gaebal-gajae.dev)
