### PR TITLE
fix(ai): map DeepSeek prompt cache usage

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Mapped DeepSeek-style `prompt_cache_hit_tokens` and `prompt_cache_miss_tokens` usage fields into OpenAI-compatible prompt-cache accounting (#1329).
+
 ## [0.7.5] - 2026-06-27
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1355,9 +1355,12 @@ export function parseChunkUsage(
 ): AssistantMessage["usage"] {
 	const promptTokenDetails = getOptionalObjectProperty(rawUsage, "prompt_tokens_details");
 	const completionTokenDetails = getOptionalObjectProperty(rawUsage, "completion_tokens_details");
+	const deepSeekCacheHitTokens = getOptionalNumberProperty(rawUsage, "prompt_cache_hit_tokens");
+	const deepSeekCacheMissTokens = getOptionalNumberProperty(rawUsage, "prompt_cache_miss_tokens");
 	const cachedTokens =
 		getOptionalNumberProperty(rawUsage, "cached_tokens") ??
 		(promptTokenDetails ? getOptionalNumberProperty(promptTokenDetails, "cached_tokens") : undefined) ??
+		deepSeekCacheHitTokens ??
 		0;
 	// OpenRouter exposes cache writes via `prompt_tokens_details.cache_write_tokens`
 	// and INCLUDES them in `prompt_tokens`. Without subtracting, cache-write tokens
@@ -1369,7 +1372,7 @@ export function parseChunkUsage(
 	const reasoningTokens =
 		(completionTokenDetails ? getOptionalNumberProperty(completionTokenDetails, "reasoning_tokens") : undefined) ?? 0;
 	const promptTokens = getOptionalNumberProperty(rawUsage, "prompt_tokens") ?? 0;
-	const input = Math.max(0, promptTokens - cachedTokens - cacheWriteTokens);
+	const input = Math.max(0, deepSeekCacheMissTokens ?? promptTokens - cachedTokens - cacheWriteTokens);
 	// Per OpenAI's CompletionUsage spec, `reasoning_tokens` is a subset of
 	// `completion_tokens` (which is the total billed output). Adding them would
 	// double-count.

--- a/packages/ai/test/usage-attribution.test.ts
+++ b/packages/ai/test/usage-attribution.test.ts
@@ -93,6 +93,40 @@ describe("openai-completions parseChunkUsage", () => {
 		expect(usage.cacheWrite).toBe(0);
 		expect(usage.totalTokens).toBe(6_250);
 	});
+
+	it("maps DeepSeek prompt cache hit and miss fields", () => {
+		const usage = parseChunkUsage(
+			{
+				prompt_tokens: 6_000,
+				completion_tokens: 250,
+				prompt_cache_hit_tokens: 5_800,
+				prompt_cache_miss_tokens: 200,
+			},
+			OPENAI_MODEL,
+			undefined,
+		);
+
+		expect(usage.input).toBe(200);
+		expect(usage.cacheRead).toBe(5_800);
+		expect(usage.cacheWrite).toBe(0);
+		expect(usage.totalTokens).toBe(6_250);
+	});
+
+	it("does not infer cache usage when routed providers omit cache metadata", () => {
+		const usage = parseChunkUsage(
+			{
+				prompt_tokens: 6_000,
+				completion_tokens: 250,
+			},
+			OPENAI_MODEL,
+			undefined,
+		);
+
+		expect(usage.input).toBe(6_000);
+		expect(usage.cacheRead).toBe(0);
+		expect(usage.cacheWrite).toBe(0);
+		expect(usage.totalTokens).toBe(6_250);
+	});
 });
 
 describe("anthropic applyAnthropicUsageExtras", () => {


### PR DESCRIPTION
## Summary
- Map DeepSeek `prompt_cache_hit_tokens` to `usage.cacheRead` and `prompt_cache_miss_tokens` to non-cached input tokens.
- Preserve existing OpenAI/OpenRouter `cached_tokens` and `cache_write_tokens` behavior.
- Add regression coverage for DeepSeek-style fields and the missing-cache-metadata fallback.

Closes #1329.

## Verification
- `bun test packages/ai/test/usage-attribution.test.ts`
- `bun --cwd=packages/ai run check:types`
- `bun --cwd=packages/ai biome check src/providers/openai-completions.ts test/usage-attribution.test.ts CHANGELOG.md`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*