### PR TITLE
test: include acp in CLI command surface

### DIFF
--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -20,6 +20,7 @@ describe("GJC public CLI command surface", () => {
 			"codex-native-hook",
 			"state",
 			"setup",
+			"acp",
 			"skills",
 			"session",
 			"harness",


### PR DESCRIPTION
## Summary

- Add the newly registered `acp` command to the CLI command-surface regression expectation.
- Keep runtime command registration unchanged; `acp` is already registered after `setup` in `packages/coding-agent/src/cli.ts`.
- Fixes dev CI failure from run 28474784279.

## Verification

- `bun test packages/coding-agent/test/cli-command-surface.test.ts` — 8 pass, 0 fail, 30 expect calls
- PR CI: Affected path validation + gjc-state-gates all green on run 28475585713

🤖 Generated with Gajae-Code

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*