### PR TITLE
Add custom preset rename and delete

### DIFF
--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -5,6 +5,7 @@ import { formatClampedModelSelector } from "../thinking";
 import {
 	aggregateModelProfileRequiredProviders,
 	formatAvailableProfileNames,
+	formatModelProfileDisplayLabel,
 	resolveProfileBindings,
 } from "./model-profiles";
 import {
@@ -183,7 +184,7 @@ export async function prepareModelProfileActivation(
 		const available = formatAvailableProfileNames(profiles);
 		throw new Error(`Unknown model profile "${options.profileName}". Available profiles: ${available}`);
 	}
-	const profileLabel = profile.displayName ?? options.profileName;
+	const profileLabel = formatModelProfileDisplayLabel(profile);
 
 	const allProviders = aggregateModelProfileRequiredProviders(profile.requiredProviders, profile);
 	const alternativeGroups = profile.alternativeProviderGroups ?? [];

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -46,7 +46,7 @@ export interface PrepareModelProfileActivationOptions {
 export interface PreparedModelProfileActivation {
 	profileName: string;
 	session: ModelProfileActivationSession & { setModelTemporary: AgentSession["setModelTemporary"] };
-	settings: Pick<Settings, "get" | "override" | "set" | "flush">;
+	settings: Pick<Settings, "clearOverride" | "get" | "getGlobal" | "override" | "set" | "flush">;
 	previousModel: Model<Api> | undefined;
 	previousThinkingLevel: ThinkingLevel | undefined;
 	previousAgentModelOverrides: Record<string, string>;
@@ -108,8 +108,8 @@ export function materializeActiveModelProfileAssignment(options: MaterializeMode
 	return true;
 }
 
-export function formatModelProfileCredentialError(profileName: string, providers: readonly string[]): string {
-	return `Model profile "${profileName}" requires credentials for: ${providers.join(", ")}. Run /login and configure the missing provider(s), then retry.`;
+export function formatModelProfileCredentialError(profileLabel: string, providers: readonly string[]): string {
+	return `Model profile "${profileLabel}" requires credentials for: ${providers.join(", ")}. Run /login and configure the missing provider(s), then retry.`;
 }
 
 function resolveModelProfileName(profileName: string, profiles: ReadonlyMap<string, unknown>): string {
@@ -183,6 +183,7 @@ export async function prepareModelProfileActivation(
 		const available = formatAvailableProfileNames(profiles);
 		throw new Error(`Unknown model profile "${options.profileName}". Available profiles: ${available}`);
 	}
+	const profileLabel = profile.displayName ?? options.profileName;
 
 	const allProviders = aggregateModelProfileRequiredProviders(profile.requiredProviders, profile);
 	const alternativeGroups = profile.alternativeProviderGroups ?? [];
@@ -202,19 +203,19 @@ export async function prepareModelProfileActivation(
 	// Check strict (non-alternative) providers — all must be authenticated.
 	const strictMissing = missingProviders.filter(p => !alternativeSet.has(p));
 	if (strictMissing.length > 0) {
-		throw new Error(formatModelProfileCredentialError(options.profileName, strictMissing));
+		throw new Error(formatModelProfileCredentialError(profileLabel, strictMissing));
 	}
 
 	// Check alternative groups — at least one provider per group must be authenticated.
 	for (const group of alternativeGroups) {
 		const groupAuthenticated = group.some(p => authenticatedProviders.includes(p));
 		if (!groupAuthenticated) {
-			throw new Error(formatModelProfileCredentialError(options.profileName, [...group]));
+			throw new Error(formatModelProfileCredentialError(profileLabel, [...group]));
 		}
 	}
 
 	if (authenticatedProviders.length === 0) {
-		throw new Error(formatModelProfileCredentialError(options.profileName, missingProviders));
+		throw new Error(formatModelProfileCredentialError(profileLabel, missingProviders));
 	}
 
 	const availableModels = options.modelRegistry.getAll();
@@ -229,9 +230,7 @@ export async function prepareModelProfileActivation(
 			})
 		: undefined;
 	if (bindings.defaultSelector && !resolvedDefault?.model) {
-		throw new Error(
-			`Model profile "${options.profileName}" default selector did not resolve: ${bindings.defaultSelector}`,
-		);
+		throw new Error(`Model profile "${profileLabel}" default selector did not resolve: ${bindings.defaultSelector}`);
 	}
 
 	const modelRoles: Record<string, string> = {};
@@ -241,7 +240,7 @@ export async function prepareModelProfileActivation(
 			modelRegistry: options.modelRegistry,
 		});
 		if (!resolved.model) {
-			throw new Error(`Model profile "${options.profileName}" ${role} selector did not resolve: ${selector}`);
+			throw new Error(`Model profile "${profileLabel}" ${role} selector did not resolve: ${selector}`);
 		}
 		modelRoles[role] = formatClampedModelSelector(selector, resolved.model);
 	}
@@ -256,7 +255,7 @@ export async function prepareModelProfileActivation(
 			modelRegistry: options.modelRegistry,
 		});
 		if (!resolved.model) {
-			throw new Error(`Model profile "${options.profileName}" ${role} selector did not resolve: ${selector}`);
+			throw new Error(`Model profile "${profileLabel}" ${role} selector did not resolve: ${selector}`);
 		}
 		agentModelOverrides[role] = formatClampedModelSelector(selector, resolved.model);
 	}
@@ -355,6 +354,87 @@ export async function applyPreparedModelProfileActivation(
 		}
 		throw error;
 	}
+}
+
+export interface MaterializeModelProfileForDeletionResult {
+	modelRoles: Record<string, string>;
+	agentModelOverrides: Record<string, string>;
+	previousModelRoles: Record<string, string>;
+	previousAgentModelOverrides: Record<string, string>;
+	previousDefaultProfile: string | undefined;
+	previousPersistedDefaultProfile: string | undefined;
+	previousActiveModelProfile: string | undefined;
+}
+
+export async function materializeModelProfileForDeletion(
+	options: PrepareModelProfileActivationOptions & {
+		settings: Pick<Settings, "clearOverride" | "flush" | "get" | "getGlobal" | "override" | "set">;
+	},
+): Promise<MaterializeModelProfileForDeletionResult> {
+	const prepared = await prepareModelProfileActivation(options);
+	const previousDefaultProfile = prepared.settings.get("modelProfile.default");
+	const previousPersistedDefaultProfile = prepared.settings.getGlobal("modelProfile.default");
+	const nextModelRoles = {
+		...prepared.previousModelRoles,
+		...(prepared.defaultModel
+			? {
+					default: formatModelSelectorValue(
+						`${prepared.defaultModel.provider}/${prepared.defaultModel.id}`,
+						prepared.defaultThinkingLevel,
+					),
+				}
+			: {}),
+		...prepared.modelRoles,
+	};
+	const nextAgentModelOverrides = {
+		...prepared.previousAgentModelOverrides,
+		...prepared.agentModelOverrides,
+	};
+
+	try {
+		prepared.settings.set("modelRoles", nextModelRoles);
+		prepared.settings.set("task.agentModelOverrides", nextAgentModelOverrides);
+		prepared.settings.set("modelProfile.default", undefined);
+		prepared.settings.clearOverride("modelProfile.default");
+		prepared.settings.override("modelRoles", nextModelRoles);
+		prepared.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
+		prepared.session.setActiveModelProfile?.(undefined);
+		await prepared.settings.flush();
+	} catch (error) {
+		prepared.settings.set("modelRoles", prepared.previousModelRoles);
+		prepared.settings.set("task.agentModelOverrides", prepared.previousAgentModelOverrides);
+		prepared.settings.set("modelProfile.default", previousPersistedDefaultProfile);
+		prepared.settings.override("modelRoles", prepared.previousModelRoles);
+		prepared.settings.override("task.agentModelOverrides", prepared.previousAgentModelOverrides);
+		prepared.settings.override("modelProfile.default", previousDefaultProfile);
+		prepared.session.setActiveModelProfile?.(prepared.previousActiveModelProfile);
+		throw error;
+	}
+
+	return {
+		modelRoles: nextModelRoles,
+		agentModelOverrides: nextAgentModelOverrides,
+		previousModelRoles: prepared.previousModelRoles,
+		previousAgentModelOverrides: prepared.previousAgentModelOverrides,
+		previousDefaultProfile,
+		previousPersistedDefaultProfile,
+		previousActiveModelProfile: prepared.previousActiveModelProfile,
+	};
+}
+
+export async function restoreMaterializedModelProfileForDeletion(options: {
+	settings: Pick<Settings, "flush" | "override" | "set">;
+	session: Pick<ModelProfileActivationSession, "setActiveModelProfile">;
+	snapshot: MaterializeModelProfileForDeletionResult;
+}): Promise<void> {
+	options.settings.set("modelRoles", options.snapshot.previousModelRoles);
+	options.settings.set("task.agentModelOverrides", options.snapshot.previousAgentModelOverrides);
+	options.settings.set("modelProfile.default", options.snapshot.previousPersistedDefaultProfile);
+	options.settings.override("modelRoles", options.snapshot.previousModelRoles);
+	options.settings.override("task.agentModelOverrides", options.snapshot.previousAgentModelOverrides);
+	options.settings.override("modelProfile.default", options.snapshot.previousDefaultProfile);
+	options.session.setActiveModelProfile?.(options.snapshot.previousActiveModelProfile);
+	await options.settings.flush();
 }
 
 export async function activateModelProfile(

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -1,3 +1,4 @@
+import { sanitizeText } from "@gajae-code/utils";
 import type { GjcModelAssignmentTargetId } from "./model-registry";
 import type { ModelsConfig } from "./models-config-schema";
 
@@ -267,6 +268,10 @@ export interface ModelProfilePresentation {
 	providerGroup: string;
 }
 
+function sanitizeModelProfileLabel(value: string): string {
+	return sanitizeText(value).replace(/\s+/g, " ").trim();
+}
+
 const PROFILE_PRESENTATION: Record<string, ModelProfilePresentation> = {
 	"codex-eco": { displayName: "Codex Eco", providerGroup: "CODEX" },
 	"codex-medium": { displayName: "Codex Medium", providerGroup: "CODEX" },
@@ -332,7 +337,15 @@ export function getModelProfilePresentation(
 	const displayName = typeof profile === "string" ? undefined : profile.displayName;
 	const presentation = PROFILE_PRESENTATION[name];
 	if (presentation) return presentation;
-	return { displayName: displayName ?? name, providerGroup: "CUSTOM" };
+	return { displayName: formatModelProfileDisplayLabel({ name, displayName }), providerGroup: "CUSTOM" };
+}
+
+export function formatModelProfileDisplayLabel(profile: Pick<ModelProfileDefinition, "name" | "displayName">): string {
+	return (
+		sanitizeModelProfileLabel(profile.displayName ?? profile.name) ||
+		sanitizeModelProfileLabel(profile.name) ||
+		"Unnamed profile"
+	);
 }
 
 export function groupModelProfilesForPresetLanding(

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -83,7 +83,8 @@ export const MODEL_ROLES: Record<ModelRole, ModelRoleInfo> = {
 };
 
 export const MODEL_ROLE_IDS: ModelRole[] = ["default"];
-
+export const MODEL_PROFILE_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+export const MODEL_PROFILE_NAME_PATTERN_DESCRIPTION = "lowercase letters, numbers, dots, underscores, or hyphens";
 export type GjcModelAssignmentTargetId = "default" | "executor" | "architect" | "planner" | "critic";
 
 export interface GjcModelAssignmentTargetInfo extends ModelRoleInfo {
@@ -1590,10 +1591,7 @@ export class ModelRegistry {
 			const where = first?.path.length ? `/${first.path.map(String).join("/")}` : "root";
 			throw new Error(`Generated models config is invalid at ${where}: ${first?.message ?? "unknown schema error"}`);
 		}
-		await fs.mkdir(path.dirname(this.#modelsConfigFile.path()), { recursive: true });
-		await Bun.write(this.#modelsConfigFile.path(), Bun.YAML.stringify(checkedConfig.data, null, 2));
-		this.#modelsConfigFile.invalidate();
-		this.#reloadStaticModels();
+		await this.#writeCheckedModelsConfig(checkedConfig.data);
 		const modelMapping = { ...definition.model_mapping };
 		const profile: ModelProfileDefinition = {
 			name: normalizedName,
@@ -1603,6 +1601,84 @@ export class ModelRegistry {
 			source: "user",
 		};
 		return profile;
+	}
+
+	async renameCustomModelProfile(name: string, displayName: string): Promise<ModelProfileDefinition> {
+		const normalizedName = name.trim();
+		const nextDisplayName = displayName.trim();
+		if (!normalizedName) throw new Error("Profile name is required.");
+		if (!nextDisplayName) throw new Error("Profile display name is required.");
+		const { current, profile } = this.#loadCustomProfileForMutation(normalizedName, "rename");
+		const nextProfiles = {
+			...(current.profiles ?? {}),
+			[normalizedName]: {
+				...profile,
+				display_name: nextDisplayName,
+			},
+		};
+		const checkedConfig = ModelsConfigSchema.safeParse({ ...current, profiles: nextProfiles });
+		if (!checkedConfig.success) {
+			const first = checkedConfig.error.issues[0];
+			const where = first?.path.length ? `/${first.path.map(String).join("/")}` : "root";
+			throw new Error(`Generated models config is invalid at ${where}: ${first?.message ?? "unknown schema error"}`);
+		}
+		await this.#writeCheckedModelsConfig(checkedConfig.data);
+		const modelMapping = { ...profile.model_mapping };
+		return {
+			name: normalizedName,
+			displayName: nextDisplayName,
+			requiredProviders: aggregateModelProfileRequiredProviders(profile.required_providers, { modelMapping }),
+			modelMapping,
+			source: "user",
+		};
+	}
+
+	async deleteCustomModelProfile(name: string): Promise<ModelProfileConfig> {
+		const normalizedName = name.trim();
+		if (!normalizedName) throw new Error("Profile name is required.");
+		const { current, profile } = this.#loadCustomProfileForMutation(normalizedName, "delete");
+		const nextProfiles = { ...(current.profiles ?? {}) };
+		delete nextProfiles[normalizedName];
+		const checkedConfig = ModelsConfigSchema.safeParse({
+			...current,
+			profiles: Object.keys(nextProfiles).length > 0 ? nextProfiles : undefined,
+		});
+		if (!checkedConfig.success) {
+			const first = checkedConfig.error.issues[0];
+			const where = first?.path.length ? `/${first.path.map(String).join("/")}` : "root";
+			throw new Error(`Generated models config is invalid at ${where}: ${first?.message ?? "unknown schema error"}`);
+		}
+		await this.#writeCheckedModelsConfig(checkedConfig.data);
+		return profile;
+	}
+
+	#loadCustomProfileForMutation(
+		normalizedName: string,
+		action: "rename" | "delete",
+	): { current: ModelsConfig; profile: ModelProfileConfig } {
+		const loaded = this.#modelsConfigFile.tryLoad();
+		if (loaded.status === "error") {
+			throw new Error(
+				`Cannot ${action} custom model profile because ${this.#modelsConfigFile.path()} is invalid. Fix the existing config before modifying presets.`,
+			);
+		}
+		const current = loaded.value ?? this.#modelsConfigFile.createDefault();
+		const profile = current.profiles?.[normalizedName];
+		if (!profile) {
+			const existing = this.#modelProfiles.get(normalizedName);
+			if (existing && existing.source !== "user") {
+				throw new Error(`Cannot ${action} bundled model profile: ${normalizedName}.`);
+			}
+			throw new Error(`Custom model profile does not exist: ${normalizedName}.`);
+		}
+		return { current, profile };
+	}
+
+	async #writeCheckedModelsConfig(config: ModelsConfig): Promise<void> {
+		await fs.mkdir(path.dirname(this.#modelsConfigFile.path()), { recursive: true });
+		await Bun.write(this.#modelsConfigFile.path(), Bun.YAML.stringify(config, null, 2));
+		this.#modelsConfigFile.invalidate();
+		this.#reloadStaticModels();
 	}
 	applyConfiguredModelBindings(targetSettings: Settings): void {
 		this.#modelBindingsTargetSettings = targetSettings;

--- a/packages/coding-agent/src/modes/components/custom-model-preset-wizard.ts
+++ b/packages/coding-agent/src/modes/components/custom-model-preset-wizard.ts
@@ -1,11 +1,9 @@
 import { Container, Input, matchesKey, Spacer, Text, TruncatedText } from "@gajae-code/tui";
+import { MODEL_PROFILE_NAME_PATTERN } from "../../config/model-registry";
 import type { ModelProfileConfig } from "../../config/models-config-schema";
 import { theme } from "../theme/theme";
 import { matchesAppInterrupt } from "../utils/keybinding-matchers";
 import { DynamicBorder } from "./dynamic-border";
-
-const PROFILE_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
-
 export interface CustomModelPresetWizardSubmit {
 	name: string;
 	profile: ModelProfileConfig;
@@ -113,7 +111,7 @@ export class CustomModelPresetWizardComponent extends Container {
 			this.#onRender();
 			return;
 		}
-		if (!PROFILE_NAME_PATTERN.test(value)) {
+		if (!MODEL_PROFILE_NAME_PATTERN.test(value)) {
 			this.#lastError = "Preset id must use lowercase letters, numbers, dots, underscores, or hyphens.";
 			this.#renderStep();
 			this.#onRender();

--- a/packages/coding-agent/src/modes/components/hook-input.ts
+++ b/packages/coding-agent/src/modes/components/hook-input.ts
@@ -8,6 +8,7 @@ import { CountdownTimer } from "./countdown-timer";
 import { DynamicBorder } from "./dynamic-border";
 
 export interface HookInputOptions {
+	initialValue?: string;
 	tui?: TUI;
 	timeout?: number;
 	onTimeout?: () => void;
@@ -23,7 +24,7 @@ export class HookInputComponent extends Container {
 
 	constructor(
 		title: string,
-		initialValue: string | undefined,
+		_placeholder: string | undefined,
 		onSubmit: (value: string) => void,
 		onCancel: () => void,
 		opts?: HookInputOptions,
@@ -54,8 +55,8 @@ export class HookInputComponent extends Container {
 		}
 
 		this.#input = new Input();
-		if (initialValue) {
-			this.#input.setValue(initialValue);
+		if (opts?.initialValue) {
+			this.#input.setValue(opts.initialValue);
 		}
 		this.addChild(this.#input);
 		this.addChild(new Spacer(1));

--- a/packages/coding-agent/src/modes/components/hook-input.ts
+++ b/packages/coding-agent/src/modes/components/hook-input.ts
@@ -23,7 +23,7 @@ export class HookInputComponent extends Container {
 
 	constructor(
 		title: string,
-		_placeholder: string | undefined,
+		initialValue: string | undefined,
 		onSubmit: (value: string) => void,
 		onCancel: () => void,
 		opts?: HookInputOptions,
@@ -54,6 +54,9 @@ export class HookInputComponent extends Container {
 		}
 
 		this.#input = new Input();
+		if (initialValue) {
+			this.#input.setValue(initialValue);
+		}
 		this.addChild(this.#input);
 		this.addChild(new Spacer(1));
 		this.addChild(new Text(theme.fg("dim", "enter submit  esc cancel"), 1, 0));

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -107,6 +107,14 @@ export type ModelSelectorSelection =
 	| {
 			kind: "createProfile";
 			profile: ModelProfileConfig;
+	  }
+	| {
+			kind: "renameProfile";
+			profileName: string;
+	  }
+	| {
+			kind: "deleteProfile";
+			profileName: string;
 	  };
 
 interface PendingThinkingChoice {
@@ -164,7 +172,7 @@ interface PresetCreateUnavailableRow {
 
 interface PresetAlreadySavedRow {
 	kind: "alreadySaved";
-	profileName: string;
+	profile: ModelProfileDefinition;
 }
 
 interface PresetBrowseRow {
@@ -195,7 +203,7 @@ function presetRowIdentity(row: PresetLandingRow): string {
 		case "createUnavailable":
 			return "createUnavailable";
 		case "alreadySaved":
-			return `alreadySaved:${row.profileName}`;
+			return `alreadySaved:${row.profile.name}`;
 	}
 }
 
@@ -207,6 +215,7 @@ const PROFILE_ROLE_PREVIEW_ORDER: GjcModelAssignmentTargetId[] = [
 	"architect",
 ];
 const PRESET_SCOPE_LABELS = ["Apply for this session", "Set as default"];
+const CUSTOM_PRESET_SCOPE_LABELS = ["Apply for this session", "Set as default", "Rename", "Delete"];
 
 function isPrintableCharacter(keyData: string): boolean {
 	return keyData.length === 1 && keyData >= " " && keyData !== "\x7f";
@@ -272,6 +281,10 @@ function sameStringArray(left: readonly string[], right: readonly string[]): boo
 
 function hasPersistableProfileSnapshot(snapshot: ModelProfileConfig): boolean {
 	return Object.keys(snapshot.model_mapping).length > 0 && snapshot.required_providers.length > 0;
+}
+
+function isCustomUserProfile(profile: ModelProfileDefinition): boolean {
+	return profile.source === "user";
 }
 /**
  * Component that renders a canonical model selector with provider tabs.
@@ -885,9 +898,7 @@ export class ModelSelectorComponent extends Container {
 		const snapshot = this.#buildCustomModelProfileSnapshot();
 		if (hasPersistableProfileSnapshot(snapshot)) {
 			const duplicateProfile = this.#findDuplicateGeneratedProfile(snapshot);
-			rows.push(
-				duplicateProfile ? { kind: "alreadySaved", profileName: duplicateProfile.name } : { kind: "create" },
-			);
+			rows.push(duplicateProfile ? { kind: "alreadySaved", profile: duplicateProfile } : { kind: "create" });
 		} else {
 			rows.push({ kind: "createUnavailable", label: "Select a model before creating a custom preset" });
 		}
@@ -961,7 +972,14 @@ export class ModelSelectorComponent extends Container {
 		this.#presetCursor = relocated;
 		return true;
 	}
-
+	#relocatePresetCursorForProfile(profileName: string): boolean {
+		for (const [groupId, profiles] of this.#getPresetGroups()) {
+			if (!profiles.some(profile => profile.name === profileName)) continue;
+			this.#expandedPresetProviderId = groupId;
+			return this.#relocatePresetCursor(`profile:${groupId}:${profileName}`);
+		}
+		return false;
+	}
 	#expandSelectedPresetProvider(): void {
 		const selected = this.#getSelectedPresetRow();
 		if (
@@ -1029,7 +1047,8 @@ export class ModelSelectorComponent extends Container {
 				continue;
 			}
 			if (row.kind === "alreadySaved") {
-				const label = `Already saved as ${row.profileName}`;
+				const presentation = getModelProfilePresentation(row.profile);
+				const label = `Already saved as ${presentation.displayName}`;
 				const renderedLabel = selected ? theme.fg("accent", label) : theme.fg("dim", label);
 				this.#listContainer.addChild(new Text(`${prefix}${renderedLabel}`, 0, 0));
 				continue;
@@ -1082,8 +1101,9 @@ export class ModelSelectorComponent extends Container {
 		}
 		this.#listContainer.addChild(new Spacer(1));
 		if (this.#presetScopeMenuOpen) {
-			for (let i = 0; i < PRESET_SCOPE_LABELS.length; i++) {
-				const label = PRESET_SCOPE_LABELS[i] ?? "";
+			const actionLabels = this.#getPresetScopeLabels(profile);
+			for (let i = 0; i < actionLabels.length; i++) {
+				const label = actionLabels[i] ?? "";
 				const prefix = i === this.#presetScopeIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
 				this.#listContainer.addChild(
 					new Text(`${prefix}${i === this.#presetScopeIndex ? theme.fg("accent", label) : label}`, 0, 0),
@@ -1394,8 +1414,8 @@ export class ModelSelectorComponent extends Container {
 			const rows = this.#getPresetRows();
 			if (rows.length === 0) return;
 			if (this.#presetScopeMenuOpen) {
-				this.#presetScopeIndex =
-					this.#presetScopeIndex === 0 ? PRESET_SCOPE_LABELS.length - 1 : this.#presetScopeIndex - 1;
+				const actionCount = this.#getPreviewPresetScopeLabels().length;
+				this.#presetScopeIndex = this.#presetScopeIndex === 0 ? actionCount - 1 : this.#presetScopeIndex - 1;
 			} else {
 				this.#presetCursor = this.#presetCursor === 0 ? rows.length - 1 : this.#presetCursor - 1;
 				this.#previewProfileName = undefined;
@@ -1409,7 +1429,7 @@ export class ModelSelectorComponent extends Container {
 			const rows = this.#getPresetRows();
 			if (rows.length === 0) return;
 			if (this.#presetScopeMenuOpen) {
-				this.#presetScopeIndex = (this.#presetScopeIndex + 1) % PRESET_SCOPE_LABELS.length;
+				this.#presetScopeIndex = (this.#presetScopeIndex + 1) % this.#getPreviewPresetScopeLabels().length;
 			} else {
 				this.#presetCursor = (this.#presetCursor + 1) % rows.length;
 				this.#previewProfileName = undefined;
@@ -1464,6 +1484,22 @@ export class ModelSelectorComponent extends Container {
 
 	#handlePresetEnter(): void {
 		if (this.#presetScopeMenuOpen && this.#previewProfileName) {
+			const profile = this.#getProfileByName(this.#previewProfileName);
+			if (!profile) return;
+			if (this.#presetScopeIndex === 2 && isCustomUserProfile(profile)) {
+				this.#onSelectCallback({ kind: "renameProfile", profileName: this.#previewProfileName });
+				return;
+			}
+			if (this.#presetScopeIndex === 3 && isCustomUserProfile(profile)) {
+				this.#onSelectCallback({ kind: "deleteProfile", profileName: this.#previewProfileName });
+				return;
+			}
+			const missing = this.#getMissingProviders(profile);
+			if (missing.length > 0) {
+				this.#presetLoginHint = `Run ${missing.map(provider => `/login ${provider}`).join(", ")}`;
+				this.#renderPresetLanding();
+				return;
+			}
 			this.#onSelectCallback({
 				kind: "profile",
 				profileName: this.#previewProfileName,
@@ -1502,7 +1538,7 @@ export class ModelSelectorComponent extends Container {
 			return;
 		}
 		const missing = this.#getMissingProviders(row.profile);
-		if (missing.length > 0) {
+		if (missing.length > 0 && !isCustomUserProfile(row.profile)) {
 			this.#presetLoginHint = `Run ${missing.map(provider => `/login ${provider}`).join(", ")}`;
 			this.#renderPresetLanding();
 			return;
@@ -1510,6 +1546,31 @@ export class ModelSelectorComponent extends Container {
 		this.#previewProfileName = row.profile.name;
 		this.#presetLoginHint = undefined;
 		this.#renderPresetLanding();
+	}
+
+	#getPresetScopeLabels(profile: ModelProfileDefinition): string[] {
+		return isCustomUserProfile(profile) ? CUSTOM_PRESET_SCOPE_LABELS : PRESET_SCOPE_LABELS;
+	}
+
+	#getPreviewPresetScopeLabels(): string[] {
+		const profile = this.#getProfileByName(this.#previewProfileName);
+		return profile ? this.#getPresetScopeLabels(profile) : PRESET_SCOPE_LABELS;
+	}
+
+	refreshPresetProfiles(profileName?: string): void {
+		if (profileName) {
+			this.#previewProfileName = profileName;
+			this.#presetLoginHint = undefined;
+			if (!this.#relocatePresetCursorForProfile(profileName)) this.#clampPresetCursor();
+		} else {
+			this.#previewProfileName = undefined;
+			this.#presetScopeMenuOpen = false;
+			this.#presetScopeIndex = 0;
+			this.#presetLoginHint = undefined;
+			this.#clampPresetCursor();
+		}
+		this.#renderPresetLanding();
+		this.#tui.requestRender();
 	}
 
 	#beginActionMenuOrSelect(item: ModelItem | CanonicalModelItem): void {
@@ -1630,6 +1691,16 @@ export class ModelSelectorComponent extends Container {
 	}
 	async __testSelectProfile(profileName: string, setDefault: boolean): Promise<void> {
 		await this.#onSelectCallback({ kind: "profile", profileName, setDefault });
+	}
+	async __testSelectPresetAction(profileName: string, action: "rename" | "delete"): Promise<void> {
+		await this.#onSelectCallback({
+			kind: action === "rename" ? "renameProfile" : "deleteProfile",
+			profileName,
+		});
+	}
+	__testSelectedPresetRowIdentity(): string | undefined {
+		const row = this.#getSelectedPresetRow();
+		return row ? presetRowIdentity(row) : undefined;
 	}
 }
 

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -715,6 +715,7 @@ export class ExtensionUiController {
 		title: string,
 		placeholder?: string,
 		dialogOptions?: ExtensionUIDialogOptions,
+		inputOptions?: { readonly initialValue?: string },
 	): Promise<string | undefined> {
 		const { promise, finish, attachAbort } = this.#createHookDialogState(
 			() => this.hideHookInput(),
@@ -732,6 +733,7 @@ export class ExtensionUiController {
 				finish(undefined);
 			},
 			{
+				initialValue: inputOptions?.initialValue,
 				timeout: dialogOptions?.timeout,
 				onTimeout: dialogOptions?.onTimeout,
 				tui: this.ctx.ui,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -6,11 +6,12 @@ import { Input, Loader, Spacer, Text } from "@gajae-code/tui";
 import { getAgentDbPath, getProjectDir } from "@gajae-code/utils";
 import {
 	activateModelProfile,
+	type MaterializeModelProfileForDeletionResult,
 	materializeActiveModelProfileAssignment,
 	materializeModelProfileForDeletion,
 	restoreMaterializedModelProfileForDeletion,
 } from "../../config/model-profile-activation";
-import { recommendModelProfileForProvider } from "../../config/model-profiles";
+import { formatModelProfileDisplayLabel, recommendModelProfileForProvider } from "../../config/model-profiles";
 import { GJC_MODEL_ASSIGNMENT_TARGETS } from "../../config/model-registry";
 import { formatModelSelectorValue } from "../../config/model-resolver";
 import type { ModelProfileConfig } from "../../config/models-config-schema";
@@ -44,7 +45,11 @@ import {
 	CREDENTIAL_AUTO_IMPORT_ROTATION_WARNING,
 	runExternalCredentialAutoImport,
 } from "../../setup/credential-auto-import";
-import { filterAutoImportOAuthCredentials, formatDiscoverySummary } from "../../setup/credential-import";
+import {
+	filterAutoImportOAuthCredentials,
+	formatDiscoverySummary,
+	type ImportableCredential,
+} from "../../setup/credential-import";
 import {
 	MODEL_ONBOARDING_API_PROVIDER_COMMAND,
 	MODEL_ONBOARDING_PROVIDER_PRESET_COMMAND,
@@ -253,7 +258,7 @@ export class SelectorController {
 					const profile = await this.ctx.session.modelRegistry.saveCustomModelProfile(input.name, input.profile);
 					await this.ctx.session.modelRegistry.refresh("offline");
 					await this.ctx.notifyConfigChanged?.();
-					this.ctx.showStatus(`Custom model preset created: ${profile.displayName ?? profile.name}`);
+					this.ctx.showStatus(`Custom model preset created: ${formatModelProfileDisplayLabel(profile)}`);
 					done();
 					this.ctx.ui.requestRender();
 				} catch (err) {
@@ -278,8 +283,10 @@ export class SelectorController {
 
 	async #renameCustomModelPreset(profileName: string, modelSelector: ModelSelectorComponent): Promise<void> {
 		const profile = this.ctx.session.modelRegistry.getModelProfile(profileName);
-		const currentName = profile?.displayName ?? profileName;
-		const input = await this.ctx.showHookInput(`Rename custom model preset: ${currentName}`, currentName);
+		const currentName = profile ? formatModelProfileDisplayLabel(profile) : profileName;
+		const input = await this.ctx.showHookInput(`Rename custom model preset: ${currentName}`, undefined, undefined, {
+			initialValue: currentName,
+		});
 		if (input === undefined) {
 			this.ctx.showStatus("Preset rename cancelled.");
 			this.ctx.ui.requestRender();
@@ -290,7 +297,7 @@ export class SelectorController {
 			await this.ctx.session.modelRegistry.refresh("offline");
 			await this.ctx.notifyConfigChanged?.();
 			modelSelector.refreshPresetProfiles(renamed.name);
-			this.ctx.showStatus(`Custom model preset renamed: ${renamed.displayName ?? renamed.name}`);
+			this.ctx.showStatus(`Custom model preset renamed: ${formatModelProfileDisplayLabel(renamed)}`);
 			this.ctx.ui.requestRender();
 		} catch (err) {
 			this.ctx.showError(`Preset rename failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -299,7 +306,7 @@ export class SelectorController {
 
 	async #deleteCustomModelPreset(profileName: string, modelSelector: ModelSelectorComponent): Promise<void> {
 		const profile = this.ctx.session.modelRegistry.getModelProfile(profileName);
-		const profileLabel = profile?.displayName ?? profileName;
+		const profileLabel = profile ? formatModelProfileDisplayLabel(profile) : profileName;
 		const confirmed = await this.ctx.showHookConfirm(
 			`Delete custom model preset: ${profileLabel}`,
 			"This removes the preset entry after preserving current role model settings when this preset is active/default.",
@@ -312,7 +319,7 @@ export class SelectorController {
 
 		const activeProfile = this.ctx.session.getActiveModelProfile?.();
 		const defaultProfile = this.ctx.settings.get("modelProfile.default");
-		let snapshot: Awaited<ReturnType<typeof materializeModelProfileForDeletion>> | undefined;
+		let snapshot: MaterializeModelProfileForDeletionResult | undefined;
 		let deletedProfile: ModelProfileConfig | undefined;
 		const refreshSelectorState = (refreshedProfileName?: string): void => {
 			modelSelector.refreshRoleAssignments({
@@ -805,9 +812,11 @@ export class SelectorController {
 							return;
 						}
 						if (selection.kind === "profile") {
-							const profileLabel =
-								this.ctx.session.modelRegistry.getModelProfile(selection.profileName)?.displayName ??
-								selection.profileName;
+							const profileLabel = formatModelProfileDisplayLabel(
+								this.ctx.session.modelRegistry.getModelProfile(selection.profileName) ?? {
+									name: selection.profileName,
+								},
+							);
 							await activateModelProfile(
 								{
 									session: this.ctx.session,
@@ -1452,7 +1461,7 @@ export class SelectorController {
 			}
 		}
 
-		let externalCredentialCandidates: ReturnType<typeof filterAutoImportOAuthCredentials> = [];
+		let externalCredentialCandidates: ImportableCredential[] = [];
 		if (
 			mode === "login" &&
 			providerId === undefined &&

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -4,7 +4,12 @@ import type { OAuthProvider } from "@gajae-code/ai/utils/oauth/types";
 import type { Component, OverlayHandle } from "@gajae-code/tui";
 import { Input, Loader, Spacer, Text } from "@gajae-code/tui";
 import { getAgentDbPath, getProjectDir } from "@gajae-code/utils";
-import { activateModelProfile, materializeActiveModelProfileAssignment } from "../../config/model-profile-activation";
+import {
+	activateModelProfile,
+	materializeActiveModelProfileAssignment,
+	materializeModelProfileForDeletion,
+	restoreMaterializedModelProfileForDeletion,
+} from "../../config/model-profile-activation";
 import { recommendModelProfileForProvider } from "../../config/model-profiles";
 import { GJC_MODEL_ASSIGNMENT_TARGETS } from "../../config/model-registry";
 import { formatModelSelectorValue } from "../../config/model-resolver";
@@ -269,6 +274,104 @@ export class SelectorController {
 			);
 			return { component: wizard, focus: wizard };
 		});
+	}
+
+	async #renameCustomModelPreset(profileName: string, modelSelector: ModelSelectorComponent): Promise<void> {
+		const profile = this.ctx.session.modelRegistry.getModelProfile(profileName);
+		const currentName = profile?.displayName ?? profileName;
+		const input = await this.ctx.showHookInput(`Rename custom model preset: ${currentName}`, currentName);
+		if (input === undefined) {
+			this.ctx.showStatus("Preset rename cancelled.");
+			this.ctx.ui.requestRender();
+			return;
+		}
+		try {
+			const renamed = await this.ctx.session.modelRegistry.renameCustomModelProfile(profileName, input);
+			await this.ctx.session.modelRegistry.refresh("offline");
+			await this.ctx.notifyConfigChanged?.();
+			modelSelector.refreshPresetProfiles(renamed.name);
+			this.ctx.showStatus(`Custom model preset renamed: ${renamed.displayName ?? renamed.name}`);
+			this.ctx.ui.requestRender();
+		} catch (err) {
+			this.ctx.showError(`Preset rename failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	async #deleteCustomModelPreset(profileName: string, modelSelector: ModelSelectorComponent): Promise<void> {
+		const profile = this.ctx.session.modelRegistry.getModelProfile(profileName);
+		const profileLabel = profile?.displayName ?? profileName;
+		const confirmed = await this.ctx.showHookConfirm(
+			`Delete custom model preset: ${profileLabel}`,
+			"This removes the preset entry after preserving current role model settings when this preset is active/default.",
+		);
+		if (!confirmed) {
+			this.ctx.showStatus("Preset delete cancelled.");
+			this.ctx.ui.requestRender();
+			return;
+		}
+
+		const activeProfile = this.ctx.session.getActiveModelProfile?.();
+		const defaultProfile = this.ctx.settings.get("modelProfile.default");
+		let snapshot: Awaited<ReturnType<typeof materializeModelProfileForDeletion>> | undefined;
+		let deletedProfile: ModelProfileConfig | undefined;
+		const refreshSelectorState = (refreshedProfileName?: string): void => {
+			modelSelector.refreshRoleAssignments({
+				currentModel: this.ctx.session.model,
+				currentThinkingLevel: this.ctx.session.thinkingLevel,
+				activeModelProfile:
+					this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
+			});
+			modelSelector.refreshPresetProfiles(refreshedProfileName);
+		};
+		try {
+			if (activeProfile === profileName || defaultProfile === profileName) {
+				snapshot = await materializeModelProfileForDeletion({
+					session: this.ctx.session,
+					modelRegistry: this.ctx.session.modelRegistry,
+					settings: this.ctx.settings,
+					profileName,
+				});
+			}
+			deletedProfile = await this.ctx.session.modelRegistry.deleteCustomModelProfile(profileName);
+			await this.ctx.session.modelRegistry.refresh("offline");
+			await this.ctx.notifyConfigChanged?.();
+			refreshSelectorState();
+			this.ctx.showStatus(`Custom model preset deleted: ${profileLabel}`);
+			this.ctx.ui.requestRender();
+		} catch (err) {
+			let presetRestoreError: unknown;
+			if (deletedProfile) {
+				try {
+					await this.ctx.session.modelRegistry.saveCustomModelProfile(profileName, deletedProfile);
+					await this.ctx.session.modelRegistry.refresh("offline");
+				} catch (restoreErr) {
+					presetRestoreError = restoreErr;
+				}
+			}
+			if (snapshot) {
+				try {
+					await restoreMaterializedModelProfileForDeletion({
+						settings: this.ctx.settings,
+						session: this.ctx.session,
+						snapshot,
+					});
+				} catch (restoreErr) {
+					refreshSelectorState(deletedProfile ? profileName : undefined);
+					this.ctx.showError(
+						`Preset delete failed and settings rollback failed: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`,
+					);
+					return;
+				}
+			}
+			if (deletedProfile) refreshSelectorState(profileName);
+			if (presetRestoreError) {
+				this.ctx.showError(
+					`Preset delete failed and preset restore failed: ${presetRestoreError instanceof Error ? presetRestoreError.message : String(presetRestoreError)}`,
+				);
+				return;
+			}
+			this.ctx.showError(`Preset delete failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
 	}
 
 	showCustomProviderWizard(): void {
@@ -693,7 +796,18 @@ export class SelectorController {
 							this.showCustomModelPresetWizard(selection.profile);
 							return;
 						}
+						if (selection.kind === "renameProfile") {
+							await this.#renameCustomModelPreset(selection.profileName, modelSelector);
+							return;
+						}
+						if (selection.kind === "deleteProfile") {
+							await this.#deleteCustomModelPreset(selection.profileName, modelSelector);
+							return;
+						}
 						if (selection.kind === "profile") {
+							const profileLabel =
+								this.ctx.session.modelRegistry.getModelProfile(selection.profileName)?.displayName ??
+								selection.profileName;
 							await activateModelProfile(
 								{
 									session: this.ctx.session,
@@ -707,8 +821,8 @@ export class SelectorController {
 							this.ctx.updateEditorBorderColor();
 							this.ctx.showStatus(
 								selection.setDefault
-									? `Default model profile: ${selection.profileName}`
-									: `Model profile: ${selection.profileName}`,
+									? `Default model profile: ${profileLabel}`
+									: `Model profile: ${profileLabel}`,
 							);
 							done();
 							this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2684,8 +2684,13 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#extensionUiController.hideHookSelector();
 	}
 
-	showHookInput(title: string, placeholder?: string): Promise<string | undefined> {
-		return this.#extensionUiController.showHookInput(title, placeholder);
+	showHookInput(
+		title: string,
+		placeholder?: string,
+		dialogOptions?: ExtensionUIDialogOptions,
+		inputOptions?: { readonly initialValue?: string },
+	): Promise<string | undefined> {
+		return this.#extensionUiController.showHookInput(title, placeholder, dialogOptions, inputOptions);
 	}
 
 	hideHookInput(): void {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -290,7 +290,12 @@ export interface InteractiveModeContext {
 		dialogOptions?: ExtensionUIDialogOptions,
 	): Promise<string | undefined>;
 	hideHookSelector(): void;
-	showHookInput(title: string, placeholder?: string): Promise<string | undefined>;
+	showHookInput(
+		title: string,
+		placeholder?: string,
+		dialogOptions?: ExtensionUIDialogOptions,
+		inputOptions?: { readonly initialValue?: string },
+	): Promise<string | undefined>;
 	hideHookInput(): void;
 	showHookEditor(
 		title: string,

--- a/packages/coding-agent/test/custom-model-preset-creation.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-creation.test.ts
@@ -685,12 +685,13 @@ describe("custom model preset creation", () => {
 		expect(activeProfiles.at(-1)).toBe("custom-default");
 	});
 	it("restores a deleted custom preset when post-delete notification fails", async () => {
+		const unsafeDisplayName = "Custom\x1b[31m Default\x1b[0m\nRestored";
 		const profiles = new Map<string, ModelProfileDefinition>([
 			[
 				"custom-default",
 				{
 					name: "custom-default",
-					displayName: "Custom Default",
+					displayName: unsafeDisplayName,
 					requiredProviders: ["my-oai"],
 					modelMapping: { default: "my-oai/gpt-custom:low" },
 					source: "user",
@@ -785,9 +786,9 @@ describe("custom model preset creation", () => {
 		await Bun.sleep(0);
 		await selector?.__testSelectPresetAction("custom-default", "delete");
 
-		expect(confirmTitle).toBe("Delete custom model preset: Custom Default");
-		expect(restoredProfile?.display_name).toBe("Custom Default");
-		expect(profiles.get("custom-default")?.displayName).toBe("Custom Default");
+		expect(confirmTitle).toBe("Delete custom model preset: Custom Default Restored");
+		expect(restoredProfile?.display_name).toBe(unsafeDisplayName);
+		expect(profiles.get("custom-default")?.displayName).toBe(unsafeDisplayName);
 		expect(settings.get("modelProfile.default")).toBe("custom-default");
 		expect(settings.get("modelRoles")).toEqual({ default: "old/default" });
 		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });

--- a/packages/coding-agent/test/custom-model-preset-creation.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-creation.test.ts
@@ -1,9 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
+import {
+	materializeModelProfileForDeletion,
+	restoreMaterializedModelProfileForDeletion,
+} from "@gajae-code/coding-agent/config/model-profile-activation";
 import type { ModelProfileDefinition } from "@gajae-code/coding-agent/config/model-profiles";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import type { ModelProfileConfig } from "@gajae-code/coding-agent/config/models-config-schema";
@@ -13,6 +17,7 @@ import {
 	ModelSelectorComponent,
 	type ModelSelectorSelection,
 } from "@gajae-code/coding-agent/modes/components/model-selector";
+import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import type { TUI } from "@gajae-code/tui";
@@ -60,6 +65,7 @@ function normalizeRenderedText(text: string): string {
 interface TestRegistryOptions {
 	readonly models?: readonly Model[];
 	readonly resolveCanonicalModel?: (canonicalId: string) => Model | undefined;
+	readonly apiKeyForProvider?: (providerId: string) => string | undefined;
 }
 
 function createRegistry(profiles: Iterable<[string, ModelProfileDefinition]> = [], options: TestRegistryOptions = {}) {
@@ -77,7 +83,7 @@ function createRegistry(profiles: Iterable<[string, ModelProfileDefinition]> = [
 		resolveCanonicalModel: options.resolveCanonicalModel ?? (() => undefined),
 		getModelProfiles: () => new Map(profileMap),
 		getModelProfile: (name: string) => profileMap.get(name),
-		getApiKeyForProvider: async () => "key",
+		getApiKeyForProvider: async (providerId: string) => options.apiKeyForProvider?.(providerId) ?? "key",
 	} as unknown as ModelRegistry;
 }
 
@@ -139,6 +145,78 @@ describe("custom model preset creation", () => {
 		const laterRegistry = new ModelRegistry(authStorage, modelsPath);
 		expect(laterRegistry.getAvailableModelProfileNames()).toContain("my-fast");
 		expect(laterRegistry.getModelProfile("my-fast")?.displayName).toBe("my-fast");
+	});
+
+	it("renames a custom preset display name without changing profile identity", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("my-fast", {
+			display_name: "my-fast",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/gpt-custom:low" },
+		});
+
+		const renamed = await registry.renameCustomModelProfile("my-fast", "renamed-fast");
+
+		expect(renamed.name).toBe("my-fast");
+		expect(renamed.displayName).toBe("renamed-fast");
+		expect(registry.getModelProfile("my-fast")?.displayName).toBe("renamed-fast");
+		const parsed = YAML.parse(await Bun.file(modelsPath).text()) as {
+			profiles: Record<string, { display_name?: string; model_mapping: Record<string, string> }>;
+		};
+		expect(parsed.profiles["my-fast"]?.display_name).toBe("renamed-fast");
+		expect(parsed.profiles["renamed-fast"]).toBeUndefined();
+		expect(parsed.profiles["my-fast"]?.model_mapping.default).toBe("my-oai/gpt-custom:low");
+	});
+
+	it("deletes only the selected custom preset", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("first", {
+			display_name: "first",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/gpt-custom" },
+		});
+		await registry.saveCustomModelProfile("second", {
+			display_name: "second",
+			required_providers: ["anthropic"],
+			model_mapping: { default: "anthropic/claude" },
+		});
+
+		const deleted = await registry.deleteCustomModelProfile("first");
+
+		expect(deleted).toEqual({
+			display_name: "first",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/gpt-custom" },
+		});
+
+		expect(registry.getModelProfile("first")).toBeUndefined();
+		expect(registry.getModelProfile("second")?.displayName).toBe("second");
+		const parsed = YAML.parse(await Bun.file(modelsPath).text()) as {
+			profiles: Record<string, { display_name?: string }>;
+		};
+		expect(parsed.profiles.first).toBeUndefined();
+		expect(parsed.profiles.second?.display_name).toBe("second");
+	});
+
+	it("rejects empty rename input and built-in delete without mutating config", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("my-fast", {
+			display_name: "my-fast",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/gpt-custom" },
+		});
+		const before = await Bun.file(modelsPath).text();
+
+		await expect(registry.renameCustomModelProfile("my-fast", "   ")).rejects.toThrow(
+			"Profile display name is required.",
+		);
+		await expect(registry.deleteCustomModelProfile("codex-medium")).rejects.toThrow(
+			"Cannot delete bundled model profile",
+		);
+		expect(await Bun.file(modelsPath).text()).toBe(before);
 	});
 
 	it("rejects creating a preset when existing models config is invalid and preserves it", async () => {
@@ -419,12 +497,300 @@ describe("custom model preset creation", () => {
 		await Bun.sleep(0);
 
 		const text = normalizeRenderedText(selector.render(180).join("\n"));
-		expect(text).toContain("Already saved as saved-current");
+		expect(text).toContain("Already saved as Saved Current");
 		expect(text).not.toContain("Create custom preset");
 		expect(text).toContain("Browse all models");
 
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 		expect(selections).toEqual([]);
+	});
+	it("emits custom preset rename and delete actions from preset rows", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "custom-row",
+			displayName: "Custom Row",
+			requiredProviders: ["my-oai"],
+			modelMapping: { default: "my-oai/gpt-custom" },
+			source: "user",
+		};
+		const selections: ModelSelectorSelection[] = [];
+		const selector = new ModelSelectorComponent(
+			{ requestRender: () => {} } as unknown as TUI,
+			currentModel("my-oai", "gpt-custom"),
+			Settings.isolated({}),
+			createRegistry([[customProfile.name, customProfile]]),
+			[],
+			selection => {
+				selections.push(selection);
+			},
+			() => {},
+		);
+		await Bun.sleep(0);
+
+		await selector.__testSelectPresetAction("custom-row", "rename");
+		await selector.__testSelectPresetAction("custom-row", "delete");
+
+		expect(selections).toEqual([
+			{ kind: "renameProfile", profileName: "custom-row" },
+			{ kind: "deleteProfile", profileName: "custom-row" },
+		]);
+	});
+
+	it("keeps rename and delete reachable for unauthenticated custom preset rows", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "needs-login",
+			displayName: "Needs Login",
+			requiredProviders: ["locked-provider"],
+			modelMapping: { default: "locked-provider/model" },
+			source: "user",
+		};
+		const selector = new ModelSelectorComponent(
+			{ requestRender: () => {} } as unknown as TUI,
+			currentModel("my-oai", "gpt-custom"),
+			Settings.isolated({}),
+			createRegistry([[customProfile.name, customProfile]], { apiKeyForProvider: () => undefined }),
+			[],
+			() => {},
+			() => {},
+		);
+		await Bun.sleep(0);
+
+		selector.handleInput("\x1b[C");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+		const text = normalizeRenderedText(selector.render(180).join("\n"));
+
+		expect(text).toContain("Rename");
+		expect(text).toContain("Delete");
+		expect(text).not.toContain("Run /login locked-provider");
+		expect(selector.__testSelectedPresetRowIdentity()).toBe("profile:CUSTOM:needs-login");
+		selector.refreshPresetProfiles();
+		const refreshedText = normalizeRenderedText(selector.render(180).join("\n"));
+		expect(refreshedText).not.toContain("Rename");
+		expect(refreshedText).not.toContain("Delete");
+	});
+
+	it("keeps the cursor on a refreshed custom preset row by actual group identity", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "custom-row",
+			displayName: "Custom Row",
+			requiredProviders: ["my-oai"],
+			modelMapping: { default: "my-oai/gpt-custom" },
+			source: "user",
+		};
+		const selector = new ModelSelectorComponent(
+			{ requestRender: () => {} } as unknown as TUI,
+			currentModel("my-oai", "gpt-custom"),
+			Settings.isolated({}),
+			createRegistry([[customProfile.name, customProfile]]),
+			[],
+			() => {},
+			() => {},
+		);
+		await Bun.sleep(0);
+
+		selector.refreshPresetProfiles("custom-row");
+
+		expect(selector.__testSelectedPresetRowIdentity()).toBe("profile:CUSTOM:custom-row");
+	});
+
+	it("materializes and restores a default custom preset deletion snapshot", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "custom-default",
+			displayName: "Custom Default",
+			requiredProviders: ["my-oai"],
+			modelMapping: {
+				default: "my-oai/gpt-custom:low",
+				executor: "my-oai/gpt-custom",
+			},
+			source: "user",
+		};
+		const settings = Settings.isolated({
+			"modelProfile.default": "custom-default",
+			modelRoles: { default: "old/default" },
+			"task.agentModelOverrides": { critic: "old/critic" },
+		});
+		const activeProfiles: (string | undefined)[] = ["other-session"];
+		const session = {
+			model: currentModel("other", "active"),
+			thinkingLevel: undefined,
+			sessionId: "session",
+			setActiveModelProfile: (profileName: string | undefined) => {
+				activeProfiles.push(profileName);
+			},
+			getActiveModelProfile: () => activeProfiles.at(-1),
+		};
+
+		const snapshot = await materializeModelProfileForDeletion({
+			session,
+			settings,
+			modelRegistry: createRegistry([[customProfile.name, customProfile]]),
+			profileName: "custom-default",
+		});
+
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(settings.get("modelRoles").default).toBe("my-oai/gpt-custom:low");
+		expect(settings.get("task.agentModelOverrides").executor).toBe("my-oai/gpt-custom");
+		expect(activeProfiles.at(-1)).toBeUndefined();
+
+		await restoreMaterializedModelProfileForDeletion({ settings, session, snapshot });
+
+		expect(settings.get("modelProfile.default")).toBe("custom-default");
+		expect(settings.get("modelRoles")).toEqual({ default: "old/default" });
+		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });
+		expect(activeProfiles.at(-1)).toBe("other-session");
+	});
+	it("rolls back deletion materialization when settings flush fails", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "custom-default",
+			displayName: "Custom Default",
+			requiredProviders: ["my-oai"],
+			modelMapping: { default: "my-oai/gpt-custom:low" },
+			source: "user",
+		};
+		const settings = Settings.isolated({
+			"modelProfile.default": "custom-default",
+			modelRoles: { default: "old/default" },
+			"task.agentModelOverrides": { critic: "old/critic" },
+		});
+		const activeProfiles: (string | undefined)[] = ["custom-default"];
+		const session = {
+			model: currentModel("other", "active"),
+			thinkingLevel: undefined,
+			sessionId: "session",
+			setActiveModelProfile: (profileName: string | undefined) => {
+				activeProfiles.push(profileName);
+			},
+			getActiveModelProfile: () => activeProfiles.at(-1),
+		};
+		const flushSpy = spyOn(settings, "flush").mockRejectedValueOnce(new Error("flush failed"));
+
+		try {
+			await expect(
+				materializeModelProfileForDeletion({
+					session,
+					settings,
+					modelRegistry: createRegistry([[customProfile.name, customProfile]]),
+					profileName: "custom-default",
+				}),
+			).rejects.toThrow("flush failed");
+		} finally {
+			flushSpy.mockRestore();
+		}
+
+		expect(settings.get("modelProfile.default")).toBe("custom-default");
+		expect(settings.get("modelRoles")).toEqual({ default: "old/default" });
+		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });
+		expect(activeProfiles.at(-1)).toBe("custom-default");
+	});
+	it("restores a deleted custom preset when post-delete notification fails", async () => {
+		const profiles = new Map<string, ModelProfileDefinition>([
+			[
+				"custom-default",
+				{
+					name: "custom-default",
+					displayName: "Custom Default",
+					requiredProviders: ["my-oai"],
+					modelMapping: { default: "my-oai/gpt-custom:low" },
+					source: "user",
+				},
+			],
+		]);
+		const settings = Settings.isolated({
+			"modelProfile.default": "custom-default",
+			modelRoles: { default: "old/default" },
+			"task.agentModelOverrides": { critic: "old/critic" },
+		});
+		const activeProfiles: (string | undefined)[] = ["custom-default"];
+		let restoredProfile:
+			| {
+					display_name?: string;
+					required_providers: string[];
+					model_mapping: Record<string, string>;
+			  }
+			| undefined;
+		const registry = {
+			...createRegistry(profiles),
+			getModelProfiles: () => new Map(profiles),
+			getModelProfile: (name: string) => profiles.get(name),
+			getAvailableModelProfileNames: () => [...profiles.keys()],
+			deleteCustomModelProfile: async (name: string) => {
+				const profile = profiles.get(name);
+				if (!profile) throw new Error("missing profile");
+				const config = {
+					display_name: profile.displayName,
+					required_providers: [...profile.requiredProviders],
+					model_mapping: { ...profile.modelMapping },
+				};
+				profiles.delete(name);
+				return config;
+			},
+			saveCustomModelProfile: async (
+				name: string,
+				config: { display_name?: string; required_providers: string[]; model_mapping: Record<string, string> },
+			) => {
+				restoredProfile = config;
+				profiles.set(name, {
+					name,
+					displayName: config.display_name,
+					requiredProviders: [...config.required_providers],
+					modelMapping: { ...config.model_mapping },
+					source: "user",
+				});
+				return profiles.get(name);
+			},
+			refresh: async () => {},
+		};
+		let selector: ModelSelectorComponent | undefined;
+		let confirmTitle: string | undefined;
+		const ctx = {
+			ui: { setFocus: () => {}, requestRender: () => {} },
+			editorContainer: {
+				clear: () => {},
+				addChild: (child: unknown) => {
+					if (child instanceof ModelSelectorComponent) selector = child;
+				},
+			},
+			editor: {},
+			settings,
+			session: {
+				model: currentModel("my-oai", "gpt-custom"),
+				thinkingLevel: ThinkingLevel.Low,
+				sessionId: "session",
+				scopedModels: [],
+				modelRegistry: registry,
+				setActiveModelProfile: (profileName: string | undefined) => activeProfiles.push(profileName),
+				getActiveModelProfile: () => activeProfiles.at(-1),
+				isFastForProvider: () => false,
+				isFastForSubagentProvider: () => false,
+				isFastModeActive: () => false,
+			},
+			statusLine: { invalidate: () => {} },
+			updateEditorBorderColor: () => {},
+			showStatus: () => {},
+			showError: (message: string) => {
+				expect(message).toBe("Preset delete failed: notify failed");
+			},
+			showHookConfirm: async (title: string) => {
+				confirmTitle = title;
+				return true;
+			},
+			notifyConfigChanged: async () => {
+				throw new Error("notify failed");
+			},
+		};
+
+		new SelectorController(ctx as never).showModelSelector();
+		await Bun.sleep(0);
+		await selector?.__testSelectPresetAction("custom-default", "delete");
+
+		expect(confirmTitle).toBe("Delete custom model preset: Custom Default");
+		expect(restoredProfile?.display_name).toBe("Custom Default");
+		expect(profiles.get("custom-default")?.displayName).toBe("Custom Default");
+		expect(settings.get("modelProfile.default")).toBe("custom-default");
+		expect(settings.get("modelRoles")).toEqual({ default: "old/default" });
+		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });
+		expect(activeProfiles.at(-1)).toBe("custom-default");
 	});
 });

--- a/packages/coding-agent/test/hook-input-timeout.test.ts
+++ b/packages/coding-agent/test/hook-input-timeout.test.ts
@@ -69,6 +69,16 @@ describe("HookInputComponent timeout", () => {
 		expect(onSubmit).toHaveBeenCalledWith("hi");
 		expect(onCancel).not.toHaveBeenCalled();
 		expect(onTimeout).not.toHaveBeenCalled();
+		component.dispose();
+	});
+
+	it("prefills the submitted value when an initial value is provided", () => {
+		const onSubmit = vi.fn();
+		const component = new HookInputComponent("Prompt", "Existing preset", onSubmit, vi.fn());
+
+		component.handleInput("\n");
+
+		expect(onSubmit).toHaveBeenCalledWith("Existing preset");
 
 		component.dispose();
 	});

--- a/packages/coding-agent/test/hook-input-timeout.test.ts
+++ b/packages/coding-agent/test/hook-input-timeout.test.ts
@@ -72,9 +72,22 @@ describe("HookInputComponent timeout", () => {
 		component.dispose();
 	});
 
-	it("prefills the submitted value when an initial value is provided", () => {
+	it("keeps placeholder text out of the submitted value", () => {
 		const onSubmit = vi.fn();
 		const component = new HookInputComponent("Prompt", "Existing preset", onSubmit, vi.fn());
+
+		component.handleInput("\n");
+
+		expect(onSubmit).toHaveBeenCalledWith("");
+
+		component.dispose();
+	});
+
+	it("prefills the submitted value when an explicit initial value is provided", () => {
+		const onSubmit = vi.fn();
+		const component = new HookInputComponent("Prompt", undefined, onSubmit, vi.fn(), {
+			initialValue: "Existing preset",
+		});
 
 		component.handleInput("\n");
 

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -34,6 +34,7 @@ const flatModel = model("provider-b", "zzz-flat-model");
 
 const userProfile: ModelProfileDefinition = {
 	name: "profile-a",
+	displayName: "Profile Alpha",
 	requiredProviders: ["provider-a"],
 	modelMapping: { default: "provider-a/default:high", executor: "provider-a/alternate" },
 	source: "user",
@@ -166,7 +167,7 @@ describe("model selector profile red-team", () => {
 		selector.handleInput("\x1b[C");
 		const rendered = normalizeRenderedText(selector.render(240).join("\n"));
 
-		expect(rendered.match(/profile-a/g) ?? []).toHaveLength(1);
+		expect(rendered.match(/Profile Alpha/g) ?? []).toHaveLength(1);
 	});
 
 	test("profile actions wire Apply for this session to persistDefault false and Set as default to true", async () => {
@@ -204,14 +205,14 @@ describe("model selector profile red-team", () => {
 
 		expect(sessionOnly.setCalls).not.toContainEqual({ path: "modelProfile.default", value: "profile-a" });
 		expect(sessionOnly.settings.get("modelProfile.default")).toBe("old-profile");
-		expect(sessionOnly.ctx.showStatus).toHaveBeenCalledWith("Model profile: profile-a");
+		expect(sessionOnly.ctx.showStatus).toHaveBeenCalledWith("Model profile: Profile Alpha");
 
 		const persistent = createControllerContext();
 		await selectProfileThroughController(new SelectorController(persistent.ctx as never), true);
 
 		expect(persistent.setCalls).toContainEqual({ path: "modelProfile.default", value: "profile-a" });
 		expect(persistent.flush).toHaveBeenCalledTimes(1);
-		expect(persistent.ctx.showStatus).toHaveBeenCalledWith("Default model profile: profile-a");
+		expect(persistent.ctx.showStatus).toHaveBeenCalledWith("Default model profile: Profile Alpha");
 	});
 
 	test("activation credential error shows error and preserves active model, thinking, overrides, and default", async () => {
@@ -219,7 +220,7 @@ describe("model selector profile red-team", () => {
 		await selectProfileThroughController(new SelectorController(ctx as never), false);
 
 		expect(ctx.showError).toHaveBeenCalledWith(
-			'Model profile "profile-a" requires credentials for: provider-a. Run /login and configure the missing provider(s), then retry.',
+			'Model profile "Profile Alpha" requires credentials for: provider-a. Run /login and configure the missing provider(s), then retry.',
 		);
 		expect(session.setModelTemporaryCalls).toEqual([]);
 		expect(session.model).toBe(alternateModel);
@@ -234,6 +235,7 @@ describe("model selector profile red-team", () => {
 		const weirdProfile: ModelProfileDefinition = {
 			...userProfile,
 			name: "Team/Profile: β 🚀 [default] {x}|$",
+			displayName: "Team/Profile: β 🚀 [default] {x}|$",
 		};
 		const selector = createSelector(() => {}, { profiles: [weirdProfile] });
 		await renderSelector(selector);
@@ -257,4 +259,74 @@ describe("model selector profile red-team", () => {
 		expect(rendered).toContain("provider-a/default");
 		expect(rendered).toContain("provider-b/zzz-flat-model");
 	});
+});
+
+test("delete action restores the profile when post-delete notification fails", async () => {
+	const profiles = new Map<string, ModelProfileDefinition>([[userProfile.name, { ...userProfile }]]);
+	const deletedConfigs: Record<string, { required_providers: string[]; model_mapping: Record<string, string> }> = {};
+	const registry = {
+		...createRegistry({ profiles: [...profiles.values()] }),
+		getModelProfiles: () => new Map(profiles),
+		getModelProfile: (name: string) => profiles.get(name),
+		getAvailableModelProfileNames: () => [...profiles.keys()],
+		deleteCustomModelProfile: vi.fn(async (name: string) => {
+			const profile = profiles.get(name);
+			if (!profile) throw new Error("missing profile");
+			const config = {
+				required_providers: [...profile.requiredProviders],
+				model_mapping: { ...profile.modelMapping },
+			};
+			deletedConfigs[name] = config;
+			profiles.delete(name);
+			return config;
+		}),
+		saveCustomModelProfile: vi.fn(
+			async (name: string, config: { required_providers: string[]; model_mapping: Record<string, string> }) => {
+				profiles.set(name, {
+					name,
+					requiredProviders: [...config.required_providers],
+					modelMapping: { ...config.model_mapping },
+					source: "user",
+				});
+				return profiles.get(name);
+			},
+		),
+		refresh: vi.fn(async () => {}),
+	};
+	const settings = Settings.isolated({ "modelProfile.default": "unrelated" });
+	const ctx = {
+		ui: { setFocus: vi.fn(), requestRender: vi.fn() },
+		editorContainer: { clear: vi.fn(), addChild: vi.fn() },
+		editor: {},
+		settings,
+		session: {
+			model: alternateModel,
+			thinkingLevel: ThinkingLevel.Low,
+			sessionId: "session-1",
+			scopedModels: [],
+			modelRegistry: registry,
+			getActiveModelProfile: () => undefined,
+			isFastForProvider: () => false,
+			isFastForSubagentProvider: () => false,
+			isFastModeActive: () => false,
+		},
+		statusLine: { invalidate: vi.fn() },
+		updateEditorBorderColor: vi.fn(),
+		showStatus: vi.fn(),
+		showError: vi.fn(),
+		showHookConfirm: vi.fn(async () => true),
+		notifyConfigChanged: vi.fn(async () => {
+			throw new Error("notify failed");
+		}),
+	};
+	const controller = new SelectorController(ctx as never);
+
+	controller.showModelSelector();
+	const selector = ctx.editorContainer.addChild.mock.calls[0]?.[0] as ModelSelectorComponent;
+	await selector.__testSelectPresetAction("profile-a", "delete");
+
+	expect(registry.deleteCustomModelProfile).toHaveBeenCalledWith("profile-a");
+	expect(registry.saveCustomModelProfile).toHaveBeenCalledWith("profile-a", deletedConfigs["profile-a"]);
+	expect(profiles.has("profile-a")).toBe(true);
+	expect(ctx.showError).toHaveBeenCalledWith("Preset delete failed: notify failed");
 });

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -247,6 +247,22 @@ describe("model selector profile red-team", () => {
 		expect(rendered).toContain("Browse all models");
 	});
 
+	test("custom profile display names strip terminal control characters before rendering", async () => {
+		const unsafeProfile: ModelProfileDefinition = {
+			...userProfile,
+			name: "unsafe-profile",
+			displayName: "Unsafe\x1b[31mRed\x1b[0m\nNext\tName",
+		};
+		const selector = createSelector(() => {}, { profiles: [unsafeProfile] });
+		await renderSelector(selector);
+		selector.handleInput("\x1b[C");
+		const rendered = selector.render(240).join("\n");
+		const plain = Bun.stripANSI(rendered);
+
+		expect(plain).toContain("UnsafeRed Next Name");
+		expect(plain).not.toContain("UnsafeRed\nNext");
+	});
+
 	test("Browse all models switches to flat model rows", async () => {
 		const selector = createSelector(() => {});
 		await renderSelector(selector);

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -32,6 +32,7 @@ const defaultModel = model("provider-a", "default");
 const alternateModel = model("provider-a", "alternate");
 const profile: ModelProfileDefinition = {
 	name: "profile-a",
+	displayName: "Profile Alpha",
 	requiredProviders: ["provider-a"],
 	modelMapping: { default: "provider-a/default:high", executor: "provider-a/alternate" },
 	source: "user",
@@ -261,7 +262,7 @@ describe("model selector profiles", () => {
 		expect(session.thinkingLevel).toBe(ThinkingLevel.High);
 		expect(settings.get("task.agentModelOverrides")).toMatchObject({ executor: "provider-a/alternate" });
 		expect(settings.get("modelProfile.default")).toBe("old-profile");
-		expect(ctx.showStatus).toHaveBeenCalledWith("Model profile: profile-a");
+		expect(ctx.showStatus).toHaveBeenCalledWith("Model profile: Profile Alpha");
 	});
 
 	test("Set as default persists and flushes modelProfile.default", async () => {
@@ -269,10 +270,10 @@ describe("model selector profiles", () => {
 		const controller = new SelectorController(ctx as never);
 		await selectFirstProfile(controller, true);
 
-		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: profile-a");
+		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: Profile Alpha");
 		expect(setCalls).toContainEqual({ path: "modelProfile.default", value: "profile-a" });
 		expect(flush).toHaveBeenCalledTimes(1);
-		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: profile-a");
+		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: Profile Alpha");
 	});
 
 	test("credential failure shows error and leaves model and overrides unchanged", async () => {
@@ -281,7 +282,7 @@ describe("model selector profiles", () => {
 		await selectFirstProfile(controller);
 
 		expect(ctx.showError).toHaveBeenCalledWith(
-			'Model profile "profile-a" requires credentials for: provider-a. Run /login and configure the missing provider(s), then retry.',
+			'Model profile "Profile Alpha" requires credentials for: provider-a. Run /login and configure the missing provider(s), then retry.',
 		);
 		expect(session.setModelTemporaryCalls).toEqual([]);
 		expect(session.model).toBe(alternateModel);


### PR DESCRIPTION
## Summary
- Add custom preset rename/delete follow-up from #1322
- Replace product-code ReturnType helpers with explicit concrete types
- Keep hook input placeholder behavior stable while using an internal initialValue option for rename prefill
- Sanitize custom preset display labels before rendering status/menu/confirmation text

## Verification
- /home/ubuntu/.bun/bin/bun test packages/coding-agent/test/hook-input-timeout.test.ts packages/coding-agent/test/model-selector-profiles-redteam.test.ts packages/coding-agent/test/custom-model-preset-creation.test.ts
- /home/ubuntu/.bun/bin/bunx biome check packages/coding-agent/src/config/model-profile-activation.ts packages/coding-agent/src/config/model-profiles.ts packages/coding-agent/src/modes/components/hook-input.ts packages/coding-agent/src/modes/controllers/extension-ui-controller.ts packages/coding-agent/src/modes/controllers/selector-controller.ts packages/coding-agent/src/modes/interactive-mode.ts packages/coding-agent/src/modes/types.ts packages/coding-agent/test/custom-model-preset-creation.test.ts packages/coding-agent/test/hook-input-timeout.test.ts packages/coding-agent/test/model-selector-profiles-redteam.test.ts
- PATH=/home/ubuntu/.bun/bin:$PATH /home/ubuntu/.bun/bin/bun --cwd=packages/coding-agent run check