### PR TITLE
fix(tui): restore default Enter=submit / Shift+Enter=newline

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored default Enter = submit / Shift+Enter = newline. A bare LF (`\n`) is now treated as a plain Enter (submit) when the Kitty keyboard protocol is inactive, and only inserts a newline when the protocol is active (the Ghostty/terminal `shift+enter → \n` sendInput mapping). This reverts the regression from #959, which made a bare LF always insert a newline and swallowed Enter submissions on terminals that emit `\n` for Enter.
+
 ## [0.7.8] - 2026-06-30
 
 ### Fixed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2,7 +2,7 @@ import { getProjectDir, logger } from "@gajae-code/utils";
 import type { AutocompleteProvider, CombinedAutocompleteProvider } from "../autocomplete";
 import { BracketedPasteHandler } from "../bracketed-paste";
 import { getKeybindings, type KeybindingsManager } from "../keybindings";
-import { extractPrintableText, matchesKey } from "../keys";
+import { extractPrintableText, isKittyProtocolActive, matchesKey } from "../keys";
 import { KillRing } from "../kill-ring";
 import type { SymbolTheme } from "../symbols";
 import { type Component, CURSOR_MARKER, type Focusable } from "../tui";
@@ -1253,7 +1253,9 @@ export class Editor implements Component, Focusable {
 		else if (
 			data === "\x1b[13;2~" || // Shift+Enter in some terminals (legacy format)
 			kb.matches(data, "tui.input.newLine") || // Shift+Enter (Kitty protocol, handles lock bits)
-			(data === "\n" && data.length === 1) // Shift+Enter from terminal sendInput mapping
+			// Bare LF is Shift+Enter only under a Kitty/Ghostty custom LF mapping (protocol active).
+			// With the protocol off, a bare LF is a plain Enter and must submit, not insert a newline.
+			(data === "\n" && data.length === 1 && isKittyProtocolActive())
 		) {
 			if (this.#shouldSubmitOnBackslashEnter(data, kb)) {
 				this.#handleBackspace();

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -6,6 +6,7 @@ import { Editor } from "@gajae-code/tui/components/editor";
 import { visibleWidth } from "@gajae-code/tui/utils";
 import { setDefaultTabWidth } from "@gajae-code/utils";
 import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keybindings";
+import { isKittyProtocolActive, setKittyProtocolActive } from "../src/keys";
 import { defaultEditorTheme } from "./test-themes";
 
 describe("Editor component", () => {
@@ -538,9 +539,29 @@ describe("Editor component", () => {
 			}
 		});
 
-		it("inserts a newline for raw LF on Windows terminal sendInput mappings", () => {
-			const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
-			Object.defineProperty(process, "platform", { value: "win32" });
+		it("submits raw LF as Enter when the Kitty protocol is inactive", () => {
+			const wasKittyActive = isKittyProtocolActive();
+			setKittyProtocolActive(false);
+			try {
+				const editor = new Editor(defaultEditorTheme);
+				let submitted = "";
+				editor.onSubmit = text => {
+					submitted = text;
+				};
+
+				editor.handleInput("a");
+				editor.handleInput("\n");
+
+				expect(submitted).toBe("a");
+				expect(editor.getText()).toBe("");
+			} finally {
+				setKittyProtocolActive(wasKittyActive);
+			}
+		});
+
+		it("inserts a newline for raw LF when the Kitty protocol is active (Ghostty Shift+Enter mapping)", () => {
+			const wasKittyActive = isKittyProtocolActive();
+			setKittyProtocolActive(true);
 			try {
 				const editor = new Editor(defaultEditorTheme);
 				let submitted = "";
@@ -555,7 +576,7 @@ describe("Editor component", () => {
 				expect(submitted).toBe("");
 				expect(editor.getText()).toBe("a\nb");
 			} finally {
-				if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+				setKittyProtocolActive(wasKittyActive);
 			}
 		});
 
@@ -650,7 +671,7 @@ describe("Editor component", () => {
 			editor.handleInput("ä");
 			editor.handleInput("ö");
 			editor.handleInput("ü");
-			editor.handleInput("\n"); // new line
+			editor.handleInput("\x1b[13;2~"); // Shift+Enter → new line
 			editor.handleInput("Ä");
 			editor.handleInput("Ö");
 			editor.handleInput("Ü");


### PR DESCRIPTION
## Problem

Default **Enter** stopped submitting the prompt and instead inserted a newline for users whose terminal emits a bare LF (`\n`) for a plain Enter. Shift+Enter is supposed to be the newline chord.

## Root cause

`Editor.handleInput` treated a bare LF (`\n`) as Shift+Enter (newline) **unconditionally**:

```ts
(data === "\n" && data.length === 1) // Shift+Enter from terminal sendInput mapping
```

This regressed in #959 ("Fix Windows LF newline handling", commit `0d60b0c5`), which removed the previous `process.platform !== "win32"` guard so a bare LF *always* inserts a newline. Terminals that send `\n` for a plain Enter then had their submissions swallowed into newlines.

## Fix

Gate bare-LF-as-newline on the **Kitty keyboard protocol** being active:

- Protocol **off** → a bare LF is a plain Enter and falls through to the submit branch (default Enter = submit).
- Protocol **on** → a bare LF is the Ghostty/terminal `shift+enter → \n` sendInput mapping and inserts a newline.

Under the Kitty protocol a plain Enter is reported as a CSI-u sequence (never a bare LF), so this is a reliable, cross-platform disambiguator — better than the old platform-specific guard.

## Tests

- Replaced the Windows-platform LF tests with protocol-gated ones: bare LF submits when the protocol is inactive, inserts a newline when active.
- Updated the umlaut line-break test to use the protocol-independent Shift+Enter sequence (`\x1b[13;2~`).
- `bun test packages/tui/test/editor.test.ts` and `keys.test.ts` pass.