### PR TITLE
fix(tui): make bare LF always submit (default Enter submits)

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Restored default Enter = submit / Shift+Enter = newline. A bare LF (`\n`) is now treated as a plain Enter (submit) when the Kitty keyboard protocol is inactive, and only inserts a newline when the protocol is active (the Ghostty/terminal `shift+enter → \n` sendInput mapping). This reverts the regression from #959, which made a bare LF always insert a newline and swallowed Enter submissions on terminals that emit `\n` for Enter.
+- Restored default Enter = submit / Shift+Enter = newline in the composer. A bare LF (`\n`) now always submits, because terminals emit a bare LF for a plain Enter and that byte is indistinguishable from a `shift+enter → \n` text mapping — Enter-submits is the default. Newlines still come from the dedicated Shift+Enter sequences. This reverts the regression from #959, which made a bare LF always insert a newline and swallowed Enter submissions.
 
 ## [0.7.8] - 2026-06-30
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2,7 +2,7 @@ import { getProjectDir, logger } from "@gajae-code/utils";
 import type { AutocompleteProvider, CombinedAutocompleteProvider } from "../autocomplete";
 import { BracketedPasteHandler } from "../bracketed-paste";
 import { getKeybindings, type KeybindingsManager } from "../keybindings";
-import { extractPrintableText, isKittyProtocolActive, matchesKey } from "../keys";
+import { extractPrintableText, matchesKey } from "../keys";
 import { KillRing } from "../kill-ring";
 import type { SymbolTheme } from "../symbols";
 import { type Component, CURSOR_MARKER, type Focusable } from "../tui";
@@ -1250,12 +1250,13 @@ export class Editor implements Component, Focusable {
 			}
 		}
 		// New line. Shift+Enter is the dedicated multiline chord; Ctrl+Enter submits.
+		// A bare LF (\n) is intentionally NOT treated as a newline here: terminals emit a
+		// bare LF for a plain Enter too, and that byte cannot be distinguished from a
+		// Shift+Enter→\n text mapping. Enter-submits is the default, so bare LF falls through
+		// to the submit branch below. Real Shift+Enter arrives as its own CSI sequence.
 		else if (
 			data === "\x1b[13;2~" || // Shift+Enter in some terminals (legacy format)
-			kb.matches(data, "tui.input.newLine") || // Shift+Enter (Kitty protocol, handles lock bits)
-			// Bare LF is Shift+Enter only under a Kitty/Ghostty custom LF mapping (protocol active).
-			// With the protocol off, a bare LF is a plain Enter and must submit, not insert a newline.
-			(data === "\n" && data.length === 1 && isKittyProtocolActive())
+			kb.matches(data, "tui.input.newLine") // Shift+Enter (Kitty protocol, handles lock bits)
 		) {
 			if (this.#shouldSubmitOnBackslashEnter(data, kb)) {
 				this.#handleBackspace();

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -539,45 +539,41 @@ describe("Editor component", () => {
 			}
 		});
 
-		it("submits raw LF as Enter when the Kitty protocol is inactive", () => {
+		it("submits raw LF as Enter regardless of Kitty protocol state", () => {
 			const wasKittyActive = isKittyProtocolActive();
-			setKittyProtocolActive(false);
 			try {
-				const editor = new Editor(defaultEditorTheme);
-				let submitted = "";
-				editor.onSubmit = text => {
-					submitted = text;
-				};
+				for (const kittyActive of [false, true]) {
+					setKittyProtocolActive(kittyActive);
+					const editor = new Editor(defaultEditorTheme);
+					let submitted: string | null = null;
+					editor.onSubmit = text => {
+						submitted = text;
+					};
 
-				editor.handleInput("a");
-				editor.handleInput("\n");
+					editor.handleInput("a");
+					editor.handleInput("\n");
 
-				expect(submitted).toBe("a");
-				expect(editor.getText()).toBe("");
+					expect(submitted).toBe("a");
+					expect(editor.getText()).toBe("");
+				}
 			} finally {
 				setKittyProtocolActive(wasKittyActive);
 			}
 		});
 
-		it("inserts a newline for raw LF when the Kitty protocol is active (Ghostty Shift+Enter mapping)", () => {
-			const wasKittyActive = isKittyProtocolActive();
-			setKittyProtocolActive(true);
-			try {
-				const editor = new Editor(defaultEditorTheme);
-				let submitted = "";
-				editor.onSubmit = text => {
-					submitted = text;
-				};
+		it("inserts a newline for a Shift+Enter sequence", () => {
+			const editor = new Editor(defaultEditorTheme);
+			let submitted: string | null = null;
+			editor.onSubmit = text => {
+				submitted = text;
+			};
 
-				editor.handleInput("a");
-				editor.handleInput("\n");
-				editor.handleInput("b");
+			editor.handleInput("a");
+			editor.handleInput("\x1b[13;2~"); // Shift+Enter (legacy)
+			editor.handleInput("b");
 
-				expect(submitted).toBe("");
-				expect(editor.getText()).toBe("a\nb");
-			} finally {
-				setKittyProtocolActive(wasKittyActive);
-			}
+			expect(submitted).toBeNull();
+			expect(editor.getText()).toBe("a\nb");
 		});
 
 		it("still submits plain CR Enter on Windows", () => {


### PR DESCRIPTION
Follow-up to #1335.

## Problem

Enter still inserted a newline instead of submitting on terminals that negotiate the Kitty keyboard protocol **and** emit a bare LF (`\n`) for a plain Enter. #1335 gated bare-LF-as-newline on the Kitty protocol being active, but that byte is emitted for a plain Enter under Kitty too (depending on the enhancement flags), so Enter was still routed to the newline branch.

## Fix

A bare LF (`\n`) cannot be distinguished from a `shift+enter → \n` text mapping, and Enter-submits is the default intent. So a bare LF now **always submits**. Newlines come exclusively from the dedicated Shift+Enter sequences (`\x1b[13;2~`, `\x1b[13;2u`, Kitty-protocol `shift+enter`), plus Alt+Enter / Ctrl+Enter.

Caveat: an explicit terminal config that makes Shift+Enter send a bare `\n` (e.g. Ghostty `shift+enter=text:\n`) will now submit rather than newline. Default terminal configs send a distinct Shift+Enter escape sequence and are unaffected.

## Tests

- `submits raw LF as Enter regardless of Kitty protocol state`
- `inserts a newline for a Shift+Enter sequence`
- Full `editor.test.ts` (125) and `keys.test.ts` pass.