### PR TITLE
revert(tui): restore 0.7.8 composer Enter/Shift+Enter handling

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Restored default Enter = submit / Shift+Enter = newline in the composer. A bare LF (`\n`) now always submits, because terminals emit a bare LF for a plain Enter and that byte is indistinguishable from a `shift+enter → \n` text mapping — Enter-submits is the default. Newlines still come from the dedicated Shift+Enter sequences. This reverts the regression from #959, which made a bare LF always insert a newline and swallowed Enter submissions.
+- Reverted the composer Enter/Shift+Enter handling to the 0.7.8 behavior. A recent restructure (#1298 and follow-ups) changed how plain Enter, Ctrl+Enter, and bare-LF Enter were routed and regressed prompt submission for some terminals; the submit/newline branches are now restored to their 0.7.8 form so Enter submits and Shift+Enter inserts a newline.
 
 ## [0.7.8] - 2026-06-30
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1249,14 +1249,16 @@ export class Editor implements Component, Focusable {
 				this.#addNewLine();
 			}
 		}
-		// New line. Shift+Enter is the dedicated multiline chord; Ctrl+Enter submits.
-		// A bare LF (\n) is intentionally NOT treated as a newline here: terminals emit a
-		// bare LF for a plain Enter too, and that byte cannot be distinguished from a
-		// Shift+Enter→\n text mapping. Enter-submits is the default, so bare LF falls through
-		// to the submit branch below. Real Shift+Enter arrives as its own CSI sequence.
+		// New line
 		else if (
+			(data.charCodeAt(0) === 10 && data.length > 1) || // Ctrl+Enter with modifiers
+			matchesKey(data, "ctrl+enter") || // Ctrl+Enter (Kitty/modifyOtherKeys, including lock bits/keypad Enter)
+			matchesKey(data, "ctrl+shift+enter") || // Ctrl+Shift+Enter (Kitty/modifyOtherKeys combined modifier)
+			data === "\x1b\r" || // Option+Enter in some terminals (legacy)
 			data === "\x1b[13;2~" || // Shift+Enter in some terminals (legacy format)
-			kb.matches(data, "tui.input.newLine") // Shift+Enter (Kitty protocol, handles lock bits)
+			kb.matches(data, "tui.input.newLine") || // Shift+Enter (Kitty protocol, handles lock bits)
+			(data.length > 1 && data.includes("\x1b") && data.includes("\r")) ||
+			(data === "\n" && data.length === 1) // Shift+Enter from terminal sendInput mapping
 		) {
 			if (this.#shouldSubmitOnBackslashEnter(data, kb)) {
 				this.#handleBackspace();
@@ -1265,13 +1267,8 @@ export class Editor implements Component, Focusable {
 			}
 			this.#addNewLine();
 		}
-		// Enter/Ctrl+Enter - submit (handles both legacy \r and Kitty protocol with lock bits)
-		else if (
-			matchesKey(data, "ctrl+enter") ||
-			matchesKey(data, "ctrl+shift+enter") ||
-			kb.matches(data, "tui.input.submit") ||
-			data === "\n"
-		) {
+		// Plain Enter - submit (handles both legacy \r and Kitty protocol with lock bits)
+		else if (kb.matches(data, "tui.input.submit") || data === "\n") {
 			// If submit is disabled, do nothing
 			if (this.disableSubmit) {
 				return;

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -6,7 +6,6 @@ import { Editor } from "@gajae-code/tui/components/editor";
 import { visibleWidth } from "@gajae-code/tui/utils";
 import { setDefaultTabWidth } from "@gajae-code/utils";
 import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keybindings";
-import { isKittyProtocolActive, setKittyProtocolActive } from "../src/keys";
 import { defaultEditorTheme } from "./test-themes";
 
 describe("Editor component", () => {
@@ -493,10 +492,38 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("a1");
 		});
 
-		it("submits Ctrl+Enter variants with NumLock or keypad Enter metadata", () => {
+		it("inserts a newline for Ctrl+Enter variants with NumLock or keypad Enter metadata", () => {
 			const variants = ["\x1b[13;133u", "\x1b[57414;5u", "\x1b[57414;133u"];
 
 			for (const variant of variants) {
+				const editor = new Editor(defaultEditorTheme);
+
+				editor.handleInput("a");
+				editor.handleInput(variant);
+				editor.handleInput("b");
+
+				expect(editor.getText()).toBe("a\nb");
+			}
+		});
+
+		it("inserts a newline for Ctrl+Shift+Enter terminal protocol variants", () => {
+			const variants = ["\x1b[13;6u", "\x1b[27;6;13~", "\x1b[13;6~", "\x1b[13;2~", "\x1b[13;2u"];
+
+			for (const [index, variant] of variants.entries()) {
+				const editor = new Editor(defaultEditorTheme);
+				const prefix = index === 0 ? "alpha" : "beta";
+
+				editor.setText(prefix);
+				editor.handleInput(variant);
+
+				expect(editor.getText()).toBe(`${prefix}\n`);
+			}
+		});
+
+		it("inserts a newline for raw LF on Windows terminal sendInput mappings", () => {
+			const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+			Object.defineProperty(process, "platform", { value: "win32" });
+			try {
 				const editor = new Editor(defaultEditorTheme);
 				let submitted = "";
 				editor.onSubmit = text => {
@@ -504,76 +531,14 @@ describe("Editor component", () => {
 				};
 
 				editor.handleInput("a");
-				editor.handleInput(variant);
+				editor.handleInput("\n");
+				editor.handleInput("b");
 
-				expect(submitted).toBe("a");
-				expect(editor.getText()).toBe("");
-			}
-		});
-
-		it("submits Ctrl+Shift+Enter terminal protocol variants while Shift+Enter inserts newline", () => {
-			const submitVariants = ["\x1b[13;6u", "\x1b[27;6;13~", "\x1b[13;6~"];
-			const newlineVariants = ["\x1b[13;2~", "\x1b[13;2u"];
-
-			for (const variant of submitVariants) {
-				const editor = new Editor(defaultEditorTheme);
-				let submitted = "";
-				editor.onSubmit = text => {
-					submitted = text;
-				};
-
-				editor.setText("alpha");
-				editor.handleInput(variant);
-
-				expect(submitted).toBe("alpha");
-				expect(editor.getText()).toBe("");
-			}
-
-			for (const variant of newlineVariants) {
-				const editor = new Editor(defaultEditorTheme);
-
-				editor.setText("beta");
-				editor.handleInput(variant);
-
-				expect(editor.getText()).toBe("beta\n");
-			}
-		});
-
-		it("submits raw LF as Enter regardless of Kitty protocol state", () => {
-			const wasKittyActive = isKittyProtocolActive();
-			try {
-				for (const kittyActive of [false, true]) {
-					setKittyProtocolActive(kittyActive);
-					const editor = new Editor(defaultEditorTheme);
-					let submitted: string | null = null;
-					editor.onSubmit = text => {
-						submitted = text;
-					};
-
-					editor.handleInput("a");
-					editor.handleInput("\n");
-
-					expect(submitted).toBe("a");
-					expect(editor.getText()).toBe("");
-				}
+				expect(submitted).toBe("");
+				expect(editor.getText()).toBe("a\nb");
 			} finally {
-				setKittyProtocolActive(wasKittyActive);
+				if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
 			}
-		});
-
-		it("inserts a newline for a Shift+Enter sequence", () => {
-			const editor = new Editor(defaultEditorTheme);
-			let submitted: string | null = null;
-			editor.onSubmit = text => {
-				submitted = text;
-			};
-
-			editor.handleInput("a");
-			editor.handleInput("\x1b[13;2~"); // Shift+Enter (legacy)
-			editor.handleInput("b");
-
-			expect(submitted).toBeNull();
-			expect(editor.getText()).toBe("a\nb");
 		});
 
 		it("still submits plain CR Enter on Windows", () => {
@@ -667,7 +632,7 @@ describe("Editor component", () => {
 			editor.handleInput("ä");
 			editor.handleInput("ö");
 			editor.handleInput("ü");
-			editor.handleInput("\x1b[13;2~"); // Shift+Enter → new line
+			editor.handleInput("\n"); // new line
 			editor.handleInput("Ä");
 			editor.handleInput("Ö");
 			editor.handleInput("Ü");


### PR DESCRIPTION
Enter-to-submit regressed in the composer for some terminals after #1298 restructured the Enter handling (and my follow-ups #1335/#1336 didn't address the real cause). 0.7.8 works correctly, so this restores the editor submit/newline branches to their **exact 0.7.8 form**:

- **Enter** → submit
- **Shift+Enter** → newline

`packages/tui/test/editor.test.ts` is reverted to 0.7.8 to match; full editor suite (124) passes.