### PR TITLE
test(tui): fix raw LF submit typecheck

### DIFF
--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -545,22 +545,21 @@ describe("Editor component", () => {
 				for (const kittyActive of [false, true]) {
 					setKittyProtocolActive(kittyActive);
 					const editor = new Editor(defaultEditorTheme);
-					let submitted: string | null = null;
+					const submissions: string[] = [];
 					editor.onSubmit = text => {
-						submitted = text;
+						submissions.push(text);
 					};
 
 					editor.handleInput("a");
 					editor.handleInput("\n");
 
-					expect(submitted).toBe("a");
+					expect(submissions).toEqual(["a"]);
 					expect(editor.getText()).toBe("");
 				}
 			} finally {
 				setKittyProtocolActive(wasKittyActive);
 			}
 		});
-
 		it("inserts a newline for a Shift+Enter sequence", () => {
 			const editor = new Editor(defaultEditorTheme);
 			let submitted: string | null = null;


### PR DESCRIPTION
## Summary
- Fixes the dev CI `check:@gajae-code/tui` failure after #1336.
- Replaces the callback-mutated nullable scalar with a submissions array so tsgo can type-check the raw LF submit test.
- Keeps the assertion stricter: exactly one submission with `"a"`, editor buffer cleared.

## Verification
- `bun run --filter @gajae-code/tui check`
- `bun test packages/tui/test/editor.test.ts`

## Note
- I intentionally did not change coding-agent `HookEditorComponent` wrapper tests here; that wrapper still owns separate hook/prompt-style newline semantics on top of TUI Editor.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*