### PR TITLE
revert(coding-agent): restore Enter=submit in main chat composer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Deep Interview now treats English `implementation` and Korean `구현` wording as eventual-target language, not permission to edit code or launch implementation before post-interview approval (#1320).
+- Restored default Enter = submit in the main chat composer. #1326 rerouted plain Enter in the prompt to insert a newline (making Ctrl+Enter the submit chord); this reverts that so Enter submits again and Shift+Enter inserts a newline.
 - Registered the optional `gjc acp` subcommand so Zed/custom ACP clients can launch the ACP stdio server through the documented command entrypoint, and documented the Zed `agent_servers` custom-agent shape (#1327).
 - Compiled binaries can now include the hidden Telegram daemon CLI entrypoint without hanging root startup, and release builds preserve that entry so `gjc notify daemon-internal --smoke` is available in standalone binaries (#1288).
 - Documented Windows Terminal BEL limitations for terminal bell notifications and added a PowerShell `completion.notifyCommand` beep workaround example (#1318).

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -362,12 +362,6 @@ export class CustomEditor extends Editor {
 			return;
 		}
 
-		// Main chat prompt uses Enter for multiline editing; Ctrl+Enter is the explicit submit chord.
-		if (!this.isAutocompleteOpen() && (data === "\r" || matchesKey(data, "enter") || matchesKey(data, "return"))) {
-			super.handleInput("\x1b[13;2u");
-			return;
-		}
-
 		// Check custom key handlers (extensions)
 		for (const [keyId, handler] of this.#customKeyHandlers) {
 			if (matchesKey(data, keyId)) {


### PR DESCRIPTION
## The actual cause

The main chat prompt is `CustomEditor`, which **overrode** `handleInput` to rewrite a plain Enter into a Shift+Enter (newline) and make Ctrl+Enter the submit chord — added in #1326 ("submit coordinator tmux prompts with ctrl-enter"):

```ts
// Main chat prompt uses Enter for multiline editing; Ctrl+Enter is the explicit submit chord.
if (!this.isAutocompleteOpen() && (data === "\r" || matchesKey(data, "enter") || matchesKey(data, "return"))) {
    super.handleInput("\x1b[13;2u");
    return;
}
```

This is why reverting the underlying `Editor` branches didn't help — the composer never let Enter reach them.

## Fix

Restore `custom-editor.ts` to its exact 0.7.8 form (removes the interception). Enter now submits; Shift+Enter inserts a newline.

Note: this reverts the main-prompt half of #1326. If coordinator tmux prompts still need a dedicated submit chord, that should be scoped to the coordinator prompt only, not the global chat composer.