### PR TITLE
fix(ultragoal): eliminate goal-identity drift; single durable source

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -11,7 +11,7 @@ Use when the user asks for `ultragoal`, `create-goals`, `complete-goals`, durabl
 
 ## Purpose
 
-`ultragoal` turns a brief into repo-native artifacts and then drives a GJC goal safely through the unified `goal` tool. New plans default to a stable pointer-style aggregate GJC goal for the whole durable plan in `.gjc/_session-{sessionid}/ultragoal/goals.json`, including later accepted/appended stories under the original brief constraints, while GJC tracks G001/G002 story progress in the ledger. Ultragoal does not require any `/goal` slash-command between runs. For back-to-back ultragoal runs in one session/thread, call `goal({"op":"drop"})` only when `goal({"op":"get"})` still reports an active aggregate; then call `goal({"op":"create"})`. The goal tool stays armed across drop so the next create works in-session, and no slash-command cleanup exists or is required.
+`ultragoal` turns a brief into repo-native durable artifacts and then drives execution through the unified `goal` tool as a UX bridge only. `goals.json` is the canonical source of goal identity and state; `ledger.jsonl` is the canonical proof stream for checkpoints, receipts, blockers, steering, and reviews. The inline `goal` tool and goal-mode-request create-bridge exist only to keep the agent's interactive loop focused on the current aggregate or story objective. Completion is verified purely from durable `goals.json` plus fresh `ledger.jsonl` receipts, never from inline goal state. The agent, not the CLI or hooks, calls `goal({"op":"complete"})` or `goal({"op":"drop"})` after durable run completion or cleanup; CLI commands and hooks never mutate goal state.
 
 - `.gjc/_session-{sessionid}/ultragoal/brief.md`
 - `.gjc/_session-{sessionid}/ultragoal/goals.json`
@@ -36,7 +36,7 @@ gjc ultragoal complete-goals
 gjc ultragoal complete-goals --retry-failed
 gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --quality-gate-json <quality-gate-json-or-path>
 gjc ultragoal checkpoint --goal-id <id> --status failed --evidence "<blocker/evidence>"
-gjc ultragoal record-review-blockers --goal-id <id> --title "Resolve final review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --gjc-goal-json <active-goal-get-json-or-path>
+gjc ultragoal record-review-blockers --goal-id <id> --title "Resolve final review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>"
 ```
 
 Use these exact goal-tool calls for the inline goal state:
@@ -50,7 +50,7 @@ goal({"op":"resume"})
 ```
 `drop` clears the active goal without exiting goal mode; `resume` reactivates a paused goal.
 
-Complete checkpoints source the active GJC goal snapshot from the current session when `--gjc-goal-json` is omitted. Use an explicit `--gjc-goal-json` only as an override; supplied values are still strictly validated and must be active goal-mode snapshots, not `.gjc/ultragoal/goals.json` records.
+Durable completion is single-source: `goals.json` defines which goals exist and their required state, while `ledger.jsonl` provides the receipt proof used to verify completion. Inline goal state is UX-only and is reconciled by the agent after durable completion, not by CLI checkpoints or hooks.
 
 ## Create goals
 
@@ -98,13 +98,13 @@ Loop until `gjc ultragoal status` reports all goals complete:
 5. Complete the current GJC story only.
 6. Run a completion audit against the story objective and real artifacts/tests.
 7. Before any `--status complete` checkpoint, run the mandatory final cleanup/review gate below. In aggregate mode, do **not** call `goal({"op":"complete"})` for intermediate stories; checkpoint each story while the aggregate objective is still `active`. On the final story, create the final aggregate receipt first; only after that receipt exists may `goal({"op":"complete"})` run.
-8. Checkpoint the durable ledger. Complete checkpoints require `--quality-gate-json`; the runtime sources the active GJC goal snapshot from current session state when `--gjc-goal-json` is omitted, and rejects any explicitly supplied bad snapshot:
+8. Checkpoint the durable ledger. Complete checkpoints require `--quality-gate-json` only:
    `gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --quality-gate-json <quality-gate-json-or-path>`
    A successful complete checkpoint is story completion, not automatic run completion. Read the checkpoint output: when it prints `Next ultragoal goal: <id>`, continue that active story under the same aggregate GJC goal; when it prints `All ultragoal goals are complete`, the durable run is terminal. `gjc ultragoal complete-goals` remains the supported manual next-story command if continuation output was missed.
 9. If blocked or failed, checkpoint failure:
    `gjc ultragoal checkpoint --goal-id <id> --status failed --evidence "<blocker/evidence>"`
 10. For legacy per-story completed-goal blockers, preserve the non-terminal blocker with:
-   `gjc ultragoal checkpoint --goal-id <id> --status blocked --evidence "<completed legacy GJC goal blocks goal create in this thread>" --gjc-goal-json <goal-get-json-or-path>`
+   `gjc ultragoal checkpoint --goal-id <id> --status blocked --evidence "<completed legacy GJC goal blocks goal create in this thread>"`
 11. Resume failed goals with `gjc ultragoal complete-goals --retry-failed`.
 
 ## Blocker triage and pause discipline
@@ -179,7 +179,7 @@ For large subgoals with independent slices, the Ultragoal leader must spawn para
 
 Use ultragoal and team together for a durable Ultragoal story that benefits from one visible tmux worker session. Ultragoal remains leader-owned: `.gjc/_session-{sessionid}/ultragoal/goals.json` stores the story plan and `.gjc/_session-{sessionid}/ultragoal/ledger.jsonl` stores checkpoints. Team is the single-worker tmux execution engine and returns task/evidence status to the leader.
 
-The leader checkpoints Ultragoal from Team evidence; the runtime uses the active current-session GJC goal snapshot unless an explicit `--gjc-goal-json` override is supplied:
+The leader checkpoints Ultragoal from Team evidence; durable state remains leader-owned in `goals.json` and `ledger.jsonl`:
 
 ```sh
 gjc ultragoal checkpoint --goal-id <id> --status complete --evidence "<team evidence mentioning .gjc/_session-{sessionid}/ultragoal and <id>>" --quality-gate-json <quality-gate-json-or-path>
@@ -219,10 +219,10 @@ An ultragoal story cannot be checkpointed `complete` until the active agent has 
 8. Run a final code review pass and fold it into the strict quality gate. Clean means `architectReview.architectureStatus`, `architectReview.productStatus`, and `architectReview.codeStatus` are all `"CLEAR"`, `architectReview.recommendation` is `"APPROVE"`, executor QA statuses are `"passed"`, iteration is `"passed"` with `fullRerun: true`, every evidence field is non-empty, every required matrix row is present, and every blockers array is empty. `COMMENT`, `WATCH`, `REQUEST CHANGES`, `BLOCK`, missing evidence, missing or shallow matrix rows, plan/code mismatches, or non-empty blockers are non-clean.
 9. If any lane finds an issue, do **not** checkpoint `complete` and do **not** call `goal({"op":"complete"})`. Record durable blocker work instead:
    ```sh
-   gjc ultragoal record-review-blockers --goal-id <id> --title "Resolve verification blockers" --objective "<blocker-resolution objective>" --evidence "<architect/executor findings>" --gjc-goal-json <active-goal-get-json-or-path>
+   gjc ultragoal record-review-blockers --goal-id <id> --title "Resolve verification blockers" --objective "<blocker-resolution objective>" --evidence "<architect/executor findings>"
    ```
 10. Complete or steer through the blocker story, then rerun the full blocking verification loop. Repeat until all verifier lanes are clean.
-11. Only after the loop is clean, checkpoint the story as complete with a structured quality gate and current-session active goal snapshot. The checkpoint creates a receipt; `goals.json.status` alone is not proof. In aggregate mode, the final aggregate receipt must exist before `goal({"op":"complete"})` is allowed.
+11. Only after the loop is clean, checkpoint the story as complete with a structured quality gate. The checkpoint creates a receipt in `ledger.jsonl`; `goals.json.status` alone is not proof. In aggregate mode, the final aggregate receipt must exist before the agent calls `goal({"op":"complete"})` to reconcile the inline UX goal state.
 
 While an Ultragoal run is active, the `ask` tool is blocked for all agents. Record unresolved review decisions as durable blockers with `gjc ultragoal record-review-blockers` instead of prompting interactively.
 
@@ -392,6 +392,6 @@ The skill tool then dispatches `/skill:ralplan` or `/skill:deep-interview` same-
 - For back-to-back ultragoal runs in the same session/thread, when `goal({"op":"get"})` still reports an active aggregate, call `goal({"op":"drop"})` before `goal({"op":"create"})`; when no active goal exists or the prior aggregate is already complete or dropped, call `goal({"op":"create"})` directly. The goal tool remains callable across drop; no slash-command cleanup exists or is required.
 - Never call `goal({"op":"create"})` when `goal({"op":"get"})` reports a different active goal.
 - Never call `goal({"op":"complete"})` unless the aggregate run or legacy per-story goal is actually complete.
-- In aggregate mode, intermediate and final story checkpoints require a matching `active` GJC goal snapshot; omitted complete-checkpoint `--gjc-goal-json` reads that snapshot from current session state, and the final story checkpoint creates the final aggregate receipt before `goal({"op":"complete"})` may reconcile the inline goal state.
-- Completion checkpoints require read-only goal snapshot reconciliation: omit `--gjc-goal-json` to use current session state, or pass an explicit JSON/path override that remains strictly validated; shell commands and hooks must not mutate goal state.
+- In aggregate mode, intermediate and final story checkpoints update durable `goals.json` state and append receipt proof to `ledger.jsonl`; the final story checkpoint creates the final aggregate receipt before the agent may call `goal({"op":"complete"})`.
+- Completion checkpoints require `--quality-gate-json` only. Shell commands and hooks must not mutate goal state; the agent reconciles inline goal-tool state after durable completion.
 - Treat `ledger.jsonl` as the durable audit trail; checkpoint after every success or failure.

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
@@ -253,13 +253,6 @@ export function validateCompletionReceipt(input: {
 			goalId: input.goal.id,
 		};
 	}
-	if (hashStructuredValue(event.gjcGoalJson) !== receipt.gjcGoalSnapshotHash) {
-		return {
-			state: "active_stale_receipt",
-			message: `Ultragoal ${input.goal.id} receipt goal({"op":"get"}) snapshot hash does not match ledger.`,
-			goalId: input.goal.id,
-		};
-	}
 	if (input.goal.updatedAt !== receipt.verifiedAt) {
 		return {
 			state: "active_stale_receipt",
@@ -276,15 +269,28 @@ export function validateCompletionReceipt(input: {
 				goalId: input.goal.id,
 			};
 		}
-		const missingReceipts = requiredGoals(input.plan).filter(
-			goal => goal.id !== input.goal.id && !goal.completionVerification,
-		);
-		if (missingReceipts.length > 0) {
-			return {
-				state: "active_missing_receipt",
-				message: `Ultragoal final receipt is missing per-goal evidence for: ${missingReceipts.map(goal => goal.id).join(", ")}.`,
-				goalId: input.goal.id,
-			};
+		for (const priorGoal of requiredGoals(input.plan)) {
+			if (priorGoal.id === input.goal.id) continue;
+			if (!priorGoal.completionVerification) {
+				return {
+					state: "active_missing_receipt",
+					message: `Ultragoal final receipt is missing per-goal evidence for: ${priorGoal.id}.`,
+					goalId: input.goal.id,
+				};
+			}
+			const priorDiagnostic = validateCompletionReceipt({
+				plan: input.plan,
+				ledger: input.ledger,
+				goal: priorGoal,
+				receiptKind: "per-goal",
+			});
+			if (priorDiagnostic.state !== "active_verified_complete") {
+				return {
+					state: priorDiagnostic.state,
+					message: `Ultragoal final receipt requires a valid per-goal receipt for ${priorGoal.id}: ${priorDiagnostic.message}`,
+					goalId: input.goal.id,
+				};
+			}
 		}
 	}
 	return {
@@ -373,6 +379,120 @@ export async function readUltragoalVerificationState(input: {
 		};
 	}
 	return receiptDiagnostic;
+}
+
+export async function verifyUltragoalDurableCompletionState(input: {
+	cwd: string;
+	sessionId?: string | null;
+}): Promise<UltragoalGuardDiagnostic> {
+	let paths: UltragoalPaths;
+	let sessionId: string | null;
+	try {
+		({ paths, sessionId } = await ultragoalReadPaths(input.cwd, { sessionId: input.sessionId }));
+	} catch (error) {
+		return {
+			state: "unreadable_fail_closed",
+			message: `Unable to resolve durable Ultragoal state: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+	if (sessionId === null)
+		return { state: "inactive", message: "No active GJC session resolved; ultragoal is inactive." };
+	try {
+		await fs.stat(paths.dir);
+	} catch (error) {
+		if (isEnoent(error)) return { state: "inactive", message: "No durable .gjc/ultragoal state exists." };
+		return {
+			state: "unreadable_fail_closed",
+			message: `Durable .gjc/ultragoal state is present but unreadable: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+
+	let plan: UltragoalPlan | null;
+	let ledger: UltragoalLedgerEvent[];
+	try {
+		plan = await readUltragoalPlan(input.cwd, sessionId);
+		ledger = await readUltragoalLedger(input.cwd, sessionId);
+	} catch (error) {
+		return {
+			state: "unreadable_fail_closed",
+			message: `Unable to read durable Ultragoal state: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+	if (!plan) return { state: "inactive", message: "No Ultragoal plan exists." };
+
+	if (plan.goals.some(goal => goal.status === "review_blocked")) {
+		return {
+			state: "active_review_blocked_recorded",
+			message: "Ultragoal has recorded review blockers; complete blocker work and rerun verification.",
+		};
+	}
+
+	const runState = getUltragoalRunCompletionState(plan);
+	if (runState.incompleteGoals.some(goal => goal.status === "blocked" || goal.status === "failed")) {
+		return {
+			state: "active_dirty_quality_gate",
+			message: "Ultragoal has blocked or failed goals; record blockers or rerun verification.",
+		};
+	}
+
+	if (plan.gjcGoalMode === "per-story") {
+		const incomplete = requiredGoals(plan).filter(goal => goal.status !== "complete");
+		if (incomplete.length > 0) {
+			return {
+				state: "active_missing_receipt",
+				message: `Ultragoal per-story completion requires all required stories to be complete; incomplete: ${incomplete.map(goal => goal.id).join(", ")}.`,
+				goalId: incomplete[0]?.id,
+			};
+		}
+		for (const goal of requiredGoals(plan)) {
+			const diagnostic = validateCompletionReceipt({
+				plan,
+				ledger,
+				goal,
+				receiptKind: "per-goal",
+			});
+			if (diagnostic.state !== "active_verified_complete") return diagnostic;
+		}
+		return {
+			state: "active_verified_complete",
+			message: "Ultragoal per-story run is verified complete.",
+		};
+	}
+
+	const ask = await isUltragoalAskBlocked(input.cwd, { sessionId });
+	if (!ask.active) {
+		return {
+			state: "active_verified_complete",
+			message: ask.reason,
+			goalId: ask.goalIds?.at(0),
+		};
+	}
+	if (ask.source === "durable_state_unreadable") {
+		return {
+			state: "unreadable_fail_closed",
+			message: ask.reason,
+			goalId: ask.goalIds?.at(0),
+		};
+	}
+	if (ask.reason.includes("recorded review blockers")) {
+		return {
+			state: "active_review_blocked_recorded",
+			message: ask.reason,
+			goalId: ask.goalIds?.at(0),
+		};
+	}
+	if (ask.reason.includes("incomplete required goals")) {
+		return {
+			state: "active_missing_final_receipt",
+			message: ask.reason,
+			goalId: ask.goalIds?.at(0),
+		};
+	}
+	return {
+		state: "active_missing_final_receipt",
+		message: ask.reason,
+		goalId: ask.goalIds?.at(0),
+	};
 }
 
 export async function isUltragoalAskBlocked(
@@ -600,8 +720,8 @@ export async function assertCanCompleteCurrentGoal(input: {
 	sessionId?: string | null;
 }): Promise<void> {
 	if (!input.cwd) return;
-	const diagnostic = await readUltragoalVerificationState(input);
-	if (["inactive", "unrelated_goal", "active_verified_complete"].includes(diagnostic.state)) return;
+	const diagnostic = await verifyUltragoalDurableCompletionState(input);
+	if (["inactive", "active_verified_complete"].includes(diagnostic.state)) return;
 	const nudge = await consumeUltragoalNudge({
 		cwd: input.cwd,
 		surface: "premature_complete",
@@ -610,7 +730,7 @@ export async function assertCanCompleteCurrentGoal(input: {
 	});
 	if (nudge.nudged) throw new Error(nudge.message);
 	throw new Error(
-		`${diagnostic.message} Run strict \`gjc ultragoal checkpoint --status complete --quality-gate-json <file> --gjc-goal-json <file>\` first, or record review blockers and rerun verification.`,
+		`${diagnostic.message} Run \`gjc ultragoal checkpoint --status complete --quality-gate-json <file>\` first, or record review blockers and rerun verification.`,
 	);
 }
 

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -2,12 +2,10 @@ import * as crypto from "node:crypto";
 import * as os from "node:os";
 import * as path from "node:path";
 import { inflateSync } from "node:zlib";
-import { normalizeGoal } from "../goals/state";
-import { buildSessionContext, loadEntriesFromFile, type SessionEntry } from "../session/session-manager";
 import type { WorkflowHudSummary } from "../skill-state/active-state";
 import { buildUltragoalHudSummary as buildWorkflowUltragoalHudSummary } from "../skill-state/workflow-hud";
 import { renderCliWriteReceipt } from "./cli-write-receipt";
-import { DEFAULT_ULTRAGOAL_OBJECTIVE, GJC_SESSION_FILE_ENV } from "./goal-mode-request";
+import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
 import { gjcRoot, sessionUltragoalDir } from "./session-layout";
 import { resolveGjcSessionForRead, resolveGjcSessionForWrite, writeSessionActivityMarker } from "./session-resolution";
 import { renderUltragoalStatusMarkdown } from "./state-renderer";
@@ -68,7 +66,6 @@ export interface UltragoalCompletionVerification {
 	gjcGoalMode: UltragoalGjcGoalMode;
 	gjcObjective: string;
 	qualityGateHash: string;
-	gjcGoalSnapshotHash: string;
 	planGeneration: string;
 	basis: {
 		planHashBeforeCheckpoint: string;
@@ -174,10 +171,9 @@ const ACCEPTED_PROOF_STATUSES = new Set([COVERED_STATUS, "passed", "verified"]);
 const MIN_SUBSTANTIVE_EVIDENCE_WORDS = 5;
 const MIN_SUBSTANTIVE_EVIDENCE_CHARS = 32;
 
-const GJC_GOAL_SNAPSHOT_MAX_AGE_MILLISECONDS = 10 * 60 * 1000;
-const GJC_GOAL_SNAPSHOT_MAX_FUTURE_SKEW_MILLISECONDS = 60 * 1000;
-
 const SCHEDULABLE_STATUSES = new Set<UltragoalGoalStatus>(["pending", "active", "failed"]);
+const COMPLETE_CHECKPOINT_ALLOWED_PRE_STATUSES = new Set<UltragoalGoalStatus>(["active", "failed"]);
+
 const NATIVE_STEERING_KINDS = [
 	"add_subgoal",
 	"split_subgoal",
@@ -570,7 +566,6 @@ function buildCompletionReceipt(input: {
 	receiptKind: UltragoalReceiptKind;
 	beforeStatus: UltragoalGoalStatus;
 	qualityGateJson: JsonObject;
-	gjcGoalJson: JsonObject;
 	now: string;
 	checkpointLedgerEventId: string;
 }): UltragoalCompletionVerification {
@@ -593,7 +588,6 @@ function buildCompletionReceipt(input: {
 		gjcGoalMode: input.plan.gjcGoalMode,
 		gjcObjective: input.plan.gjcObjective,
 		qualityGateHash: hashStructuredValue(input.qualityGateJson),
-		gjcGoalSnapshotHash: hashStructuredValue(input.gjcGoalJson),
 		planGeneration: generation.planGeneration,
 		basis: generation.basis,
 		checkpointLedgerEventId: input.checkpointLedgerEventId,
@@ -2470,93 +2464,24 @@ async function readRequiredCompletionQualityGate(
 	return gate;
 }
 
-function snapshotUpdatedAtMilliseconds(value: unknown): number | null {
-	if (typeof value === "number" && Number.isFinite(value)) return value;
-	if (typeof value !== "string" || value.trim().length === 0) return null;
-	const trimmed = value.trim();
-	if (/^\d+$/.test(trimmed)) {
-		const parsed = Number.parseInt(trimmed, 10);
-		return Number.isFinite(parsed) ? parsed : null;
+function validateCompleteCheckpointTargetGoal(goal: UltragoalGoal): void {
+	if (COMPLETE_CHECKPOINT_ALLOWED_PRE_STATUSES.has(goal.status)) return;
+	if (goal.status === "pending") {
+		throw new Error(
+			`Cannot checkpoint ${goal.id} as complete while its durable goals.json status is pending; start the goal before completing it.`,
+		);
 	}
-	const parsed = Date.parse(trimmed);
-	return Number.isFinite(parsed) ? parsed : null;
-}
-
-function singleSessionLeafId(entries: readonly SessionEntry[]): string | undefined {
-	if (entries.length === 0) return undefined;
-	const parentIds = new Set(
-		entries.map(entry => entry.parentId).filter((parentId): parentId is string => typeof parentId === "string"),
+	if (goal.status === "complete") {
+		throw new Error(
+			`Cannot checkpoint ${goal.id} as complete with different evidence because its durable goals.json status is already complete.`,
+		);
+	}
+	if (goal.status === "superseded") {
+		throw new Error(`Cannot checkpoint ${goal.id} as complete because its durable goals.json status is superseded.`);
+	}
+	throw new Error(
+		`Cannot checkpoint ${goal.id} as complete while its durable goals.json status is ${goal.status}; only active or retryable failed goals can be completed.`,
 	);
-	const leafIds = entries.map(entry => entry.id).filter(id => !parentIds.has(id));
-	return leafIds.length === 1 ? leafIds[0] : undefined;
-}
-
-async function readCurrentSessionGjcGoalSnapshot(): Promise<unknown | undefined> {
-	const sessionFile = process.env[GJC_SESSION_FILE_ENV]?.trim();
-	if (!sessionFile) return undefined;
-	const fileEntries = await loadEntriesFromFile(sessionFile);
-	const entries = fileEntries.filter((entry): entry is SessionEntry => entry.type !== "session");
-	const leafId = singleSessionLeafId(entries);
-	if (!leafId) return undefined;
-	const context = buildSessionContext(entries, leafId);
-	if (context.mode !== "goal" && context.mode !== "goal_paused") return undefined;
-	const goal = normalizeGoal(context.modeData?.goal);
-	return goal ? { goal } : undefined;
-}
-async function readGjcGoalSnapshot(input: {
-	cwd: string;
-	value: string | undefined;
-	plan: UltragoalPlan;
-	goal?: UltragoalGoal;
-	required: boolean;
-	errorPrefix: string;
-	allowCompletedLegacyBlocker?: boolean;
-}): Promise<unknown> {
-	const snapshot = input.value?.trim()
-		? await readStructuredValue(input.cwd, input.value)
-		: await readCurrentSessionGjcGoalSnapshot();
-	if (snapshot === undefined) {
-		if (!input.required) return undefined;
-		throw new Error(
-			`${input.errorPrefix} require an active GJC goal-mode snapshot from the current session or --gjc-goal-json; this is the GJC goal-mode receipt, not the .gjc/ultragoal/goals.json goal record`,
-		);
-	}
-	const snapshotObject = qualityGateObject(snapshot);
-	const detailsObject = qualityGateObject(snapshotObject?.details);
-	const goalObject = qualityGateObject(snapshotObject?.goal) ?? qualityGateObject(detailsObject?.goal);
-	if (!goalObject)
-		throw new Error(
-			`${input.errorPrefix} require --gjc-goal-json with a goal object from goal({"op":"get"}); pass the active GJC goal-mode snapshot, not the .gjc/ultragoal/goals.json goal record`,
-		);
-	const updatedAt = snapshotUpdatedAtMilliseconds(goalObject.updatedAt);
-	if (!updatedAt)
-		throw new Error(
-			`${input.errorPrefix} require --gjc-goal-json goal.updatedAt as epoch milliseconds or an ISO timestamp from goal({"op":"get"}); pass the active GJC goal-mode snapshot, not the .gjc/ultragoal/goals.json goal record`,
-		);
-	const nowMilliseconds = Date.now();
-	if (updatedAt < nowMilliseconds - GJC_GOAL_SNAPSHOT_MAX_AGE_MILLISECONDS) {
-		throw new Error(`${input.errorPrefix} require a fresh --gjc-goal-json snapshot`);
-	}
-	if (updatedAt > nowMilliseconds + GJC_GOAL_SNAPSHOT_MAX_FUTURE_SKEW_MILLISECONDS) {
-		throw new Error(`${input.errorPrefix} require --gjc-goal-json goal.updatedAt that is not from the future`);
-	}
-	const objective = typeof goalObject.objective === "string" ? goalObject.objective : "";
-	const expectedObjectives = new Set([input.plan.gjcObjective, ...(input.plan.gjcObjectiveAliases ?? [])]);
-	if (input.plan.gjcGoalMode === "per-story" && input.goal?.objective) {
-		expectedObjectives.add(input.goal.objective);
-	}
-	if (input.allowCompletedLegacyBlocker && goalObject.status === "complete" && !expectedObjectives.has(objective)) {
-		return snapshot;
-	}
-	if (!expectedObjectives.has(objective)) {
-		throw new Error(
-			`${input.errorPrefix} require --gjc-goal-json objective to match the active GJC goal-mode objective from goal({"op":"get"}), not the .gjc/ultragoal/goals.json goal ${input.goal?.id ?? "record"}`,
-		);
-	}
-	if (goalObject.status !== "active") {
-		throw new Error(`${input.errorPrefix} require --gjc-goal-json goal.status to be active`);
-	}
-	return snapshot;
 }
 
 export async function checkpointUltragoalGoal(input: {
@@ -2564,7 +2489,6 @@ export async function checkpointUltragoalGoal(input: {
 	goalId: string;
 	status: UltragoalGoalStatus;
 	evidence: string;
-	gjcGoalJson?: string;
 	qualityGateJson?: string;
 }): Promise<UltragoalPlan> {
 	const plan = await readUltragoalPlan(input.cwd);
@@ -2593,6 +2517,7 @@ export async function checkpointUltragoalGoal(input: {
 		// instead of silently dropping it.
 		return plan;
 	}
+	if (input.status === "complete") validateCompleteCheckpointTargetGoal(goal);
 	const changeSet = input.status === "complete" ? await computeCheckpointChangeSet(input.cwd) : undefined;
 	const qualityGateJson =
 		input.status === "complete"
@@ -2615,25 +2540,6 @@ export async function checkpointUltragoalGoal(input: {
 		}
 	}
 	const receiptKind = input.status === "complete" ? chooseReceiptKind(plan, goal, input.status) : null;
-	const gjcGoalJson =
-		input.status === "complete"
-			? await readGjcGoalSnapshot({
-					cwd: input.cwd,
-					value: input.gjcGoalJson,
-					plan,
-					goal,
-					required: true,
-					errorPrefix: "complete checkpoints",
-				})
-			: await readGjcGoalSnapshot({
-					cwd: input.cwd,
-					value: input.gjcGoalJson,
-					plan,
-					goal,
-					required: false,
-					errorPrefix: `${input.status} checkpoints`,
-					allowCompletedLegacyBlocker: input.status === "blocked",
-				});
 	const pendingCheckpointEventId = crypto.randomUUID();
 	if (input.status === "complete" && receiptKind && qualityGateJson && !Array.isArray(qualityGateJson)) {
 		goal.completionVerification = buildCompletionReceipt({
@@ -2643,7 +2549,6 @@ export async function checkpointUltragoalGoal(input: {
 			receiptKind,
 			beforeStatus,
 			qualityGateJson: qualityGateJson as JsonObject,
-			gjcGoalJson: gjcGoalJson as JsonObject,
 			now,
 			checkpointLedgerEventId: pendingCheckpointEventId,
 		});
@@ -2662,7 +2567,6 @@ export async function checkpointUltragoalGoal(input: {
 		goalId: goal.id,
 		status: input.status,
 		evidence,
-		gjcGoalJson,
 		qualityGateJson,
 		completionVerification: goal.completionVerification,
 	});
@@ -2682,7 +2586,6 @@ export async function checkpointAndContinueUltragoalGoal(input: {
 	goalId: string;
 	status: UltragoalGoalStatus;
 	evidence: string;
-	gjcGoalJson?: string;
 	qualityGateJson?: string;
 	advanceNext?: boolean;
 	retryFailed?: boolean;
@@ -3091,19 +2994,14 @@ export async function recordUltragoalReviewBlockers(input: {
 	title: string;
 	objective: string;
 	evidence: string;
-	gjcGoalJson?: string;
 }): Promise<UltragoalPlan> {
 	const objective = input.objective.trim();
 	if (!objective) throw new Error("record-review-blockers --objective is required");
-	if (!input.gjcGoalJson?.trim()) {
-		throw new Error('record-review-blockers require --gjc-goal-json from a fresh active goal({"op":"get"}) snapshot');
-	}
 	const plan = await checkpointUltragoalGoal({
 		cwd: input.cwd,
 		goalId: input.goalId,
 		status: "review_blocked",
 		evidence: input.evidence,
-		gjcGoalJson: input.gjcGoalJson,
 	});
 	const persistedPlan = await readUltragoalPlan(input.cwd);
 	if (persistedPlan?.state_revision !== undefined) plan.state_revision = persistedPlan.state_revision;
@@ -3551,7 +3449,6 @@ const FLAGS_WITH_VALUES = new Set([
 	"--goal-id",
 	"--status",
 	"--evidence",
-	"--gjc-goal-json",
 	"--quality-gate-json",
 	"--executor-qa-json",
 	"--executor-qa",
@@ -3605,15 +3502,12 @@ function renderUltragoalHelp(args: readonly string[]): string | null {
 			"      --status=<value>             pending|active|complete|failed|blocked|review_blocked|superseded",
 			"      --evidence=<value>           Completion or checkpoint evidence text",
 			"      --quality-gate-json=<value>  JSON string or path for complete checkpoints",
-			"      --gjc-goal-json=<value>      Optional JSON/path override for current goal snapshot; omitted complete checkpoints read current session goal state",
 			"      --json                       Output a machine-readable receipt",
 			"",
 			"COMPLETE CHECKPOINT RECEIPTS",
 			"  --quality-gate-json must be an object with architectReview, executorQa, and iteration.",
 			"  executorQa.contractCoverage[] rows require an obligation field; description is not a substitute.",
-			"  Complete checkpoints use the current session's active GJC goal-mode snapshot when --gjc-goal-json is omitted.",
-			"  Explicit --gjc-goal-json values must contain an active GJC goal-mode snapshot, not the .gjc/ultragoal/goals.json goal record.",
-			"  goal.updatedAt may be epoch milliseconds or an ISO timestamp and must be fresh.",
+			"  Complete checkpoints validate the target durable goals.json record before writing a receipt.",
 			"",
 			"EXAMPLES",
 			'  $ gjc ultragoal checkpoint --goal-id G001 --status blocked --evidence "waiting on review"',
@@ -3949,7 +3843,6 @@ async function dispatchUltragoalCommand(args: string[], cwd: string): Promise<Ul
 					goalId,
 					status,
 					evidence,
-					gjcGoalJson: flagValue(args, "--gjc-goal-json"),
 					qualityGateJson: flagValue(args, "--quality-gate-json"),
 					advanceNext: status === "complete",
 				});
@@ -3981,7 +3874,6 @@ async function dispatchUltragoalCommand(args: string[], cwd: string): Promise<Ul
 					title: flagValue(args, "--title") ?? "Resolve final code-review blockers",
 					objective: flagValue(args, "--objective") ?? "",
 					evidence: flagValue(args, "--evidence") ?? "",
-					gjcGoalJson: flagValue(args, "--gjc-goal-json"),
 				});
 				const goal = plan.goals.at(-1);
 				return {

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
@@ -1481,14 +1481,6 @@
       },
       {
         "appliesToVerbs": [
-          "checkpoint",
-          "record-review-blockers"
-        ],
-        "name": "gjc-goal-json",
-        "type": "string"
-      },
-      {
-        "appliesToVerbs": [
           "checkpoint"
         ],
         "name": "quality-gate-json",

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
@@ -271,7 +271,6 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 				required: true,
 				appliesToVerbs: ["checkpoint", "record-review-blockers", "steer", "classify-blocker"],
 			},
-			{ name: "gjc-goal-json", type: "string", appliesToVerbs: ["checkpoint", "record-review-blockers"] },
 			{ name: "quality-gate-json", type: "string", appliesToVerbs: ["checkpoint"] },
 			{ name: "goal-id", type: "string", appliesToVerbs: ["steer"] },
 			{ name: "goal-id", type: "string", appliesToVerbs: ["classify-blocker"] },

--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -11,8 +11,7 @@ import {
 	writeGuardedJsonAtomic,
 	writeGuardedWorkflowEnvelopeAtomic,
 } from "../gjc-runtime/state-writer";
-import { isUltragoalBypassPrompt, readUltragoalVerificationState } from "../gjc-runtime/ultragoal-guard";
-import { getUltragoalRunCompletionState, readUltragoalPlan } from "../gjc-runtime/ultragoal-runtime";
+import { isUltragoalBypassPrompt, verifyUltragoalDurableCompletionState } from "../gjc-runtime/ultragoal-guard";
 import { buildSessionContext, loadEntriesFromFile, type SessionEntry } from "../session/session-manager";
 import {
 	readVisibleSkillActiveState as readCanonicalVisibleSkillActiveState,
@@ -565,6 +564,10 @@ function modeStateReleasesStop(state: ModeState | null, handoffRequired: boolean
 	return false;
 }
 
+function ultragoalDurableCompletionReleasesStop(state: string): boolean {
+	return state === "inactive" || state === "active_verified_complete";
+}
+
 /**
  * Cross-file coherence guard for a mode-state that claims it releases the Stop
  * block. `modeStateReleasesStop` trusts a single mode-state file; if any writer
@@ -577,18 +580,15 @@ function modeStateReleasesStop(state: ModeState | null, handoffRequired: boolean
  * cheap and read-only — ultragoal reads the durable plan; skills without an
  * independent durable source release as before.
  */
-async function detectStaleModeStateRelease(skill: GjcWorkflowSkill, cwd: string): Promise<string | null> {
-	if (skill === "ultragoal") {
-		const plan = await readUltragoalPlan(cwd);
-		if (!plan) return null;
-		const runState = getUltragoalRunCompletionState(plan);
-		if (runState.incompleteGoals.length > 0) {
-			return `the durable Ultragoal plan still has incomplete required goals (${runState.incompleteGoals
-				.map(goal => goal.id)
-				.join(", ")}); run \`gjc ultragoal complete-goals\` to continue`;
-		}
-	}
-	return null;
+async function detectStaleModeStateRelease(
+	skill: GjcWorkflowSkill,
+	cwd: string,
+	sessionId?: string | null,
+): Promise<string | null> {
+	if (skill !== "ultragoal") return null;
+	const diagnostic = await verifyUltragoalDurableCompletionState({ cwd, sessionId });
+	if (ultragoalDurableCompletionReleasesStop(diagnostic.state)) return null;
+	return `${diagnostic.message} Run \`gjc ultragoal complete-goals\` to continue, or checkpoint a finished story with \`gjc ultragoal checkpoint --status complete --quality-gate-json <file>\`, before stopping`;
 }
 
 /**
@@ -663,19 +663,6 @@ function stateMatchesContext(state: ModeState, sessionId?: string, threadId?: st
 	return true;
 }
 
-async function readCurrentGoalObjectiveFromSessionFile(sessionFile: string | undefined): Promise<string | null> {
-	const trimmed = sessionFile?.trim();
-	if (!trimmed) return null;
-	const entries = (await loadEntriesFromFile(trimmed)).filter(
-		(entry): entry is SessionEntry => entry.type !== "session",
-	);
-	const context = buildSessionContext(entries);
-	const goal = context.modeData?.goal;
-	if (typeof goal !== "object" || goal === null) return null;
-	const objective = (goal as { objective?: unknown }).objective;
-	return typeof objective === "string" && objective.trim().length > 0 ? objective.trim() : null;
-}
-
 async function readLatestAssistantTextFromSessionFile(sessionFile: string | undefined): Promise<string | null> {
 	const trimmed = sessionFile?.trim();
 	if (!trimmed) return null;
@@ -730,34 +717,18 @@ export async function buildActiveUltragoalPromptContext(input: UserPromptSubmitS
 	if (!stateMatchesContext(visibleModeState.state, resolvedSessionId, input.threadId)) return null;
 
 	const phase = String(visibleModeState.state.current_phase ?? "active");
-	const stateObjective =
-		typeof visibleModeState.state.objective === "string"
-			? visibleModeState.state.objective
-			: typeof visibleModeState.state.gjcObjective === "string"
-				? visibleModeState.state.gjcObjective
-				: "";
-	const sessionObjective = await readCurrentGoalObjectiveFromSessionFile(input.sessionFile);
 	const normalizedPrompt = input.prompt?.replace(/\\?"/g, '"');
 	const isBypassPrompt = Boolean(
 		(normalizedPrompt && isUltragoalBypassPrompt(normalizedPrompt)) ||
 			(input.prompt && /goal[\s\S]{0,80}complete/i.test(input.prompt)),
 	);
 	if (isBypassPrompt) {
-		const objectives = [sessionObjective, stateObjective].filter(
-			(value): value is string => typeof value === "string" && value.trim().length > 0,
-		);
-		if (objectives.length === 0) {
-			return "BLOCK_ULTRAGOAL_COMPLETION: Active Ultragoal completion is blocked until a current GJC goal objective can be verified. Use durable blocker work or run strict `gjc ultragoal checkpoint --status complete --quality-gate-json <file> --gjc-goal-json <file>` before completion.";
-		}
-		for (const objective of objectives) {
-			const diagnostic = await readUltragoalVerificationState({
-				cwd: input.cwd,
-				currentGoal: { objective },
-			});
-			if (diagnostic.state === "unrelated_goal") continue;
-			if (!["inactive", "active_verified_complete"].includes(diagnostic.state)) {
-				return `BLOCK_ULTRAGOAL_COMPLETION: ${diagnostic.message} Use durable blocker work or run strict \`gjc ultragoal checkpoint --status complete --quality-gate-json <file> --gjc-goal-json <file>\` before completion.`;
-			}
+		const diagnostic = await verifyUltragoalDurableCompletionState({
+			cwd: input.cwd,
+			sessionId: resolvedSessionId,
+		});
+		if (!ultragoalDurableCompletionReleasesStop(diagnostic.state)) {
+			return `BLOCK_ULTRAGOAL_COMPLETION: ${diagnostic.message} Use durable blocker work or run strict \`gjc ultragoal checkpoint --status complete --quality-gate-json <file>\` before completion.`;
 		}
 	}
 	return `Ultragoal is active (phase: ${phase}; state: ${visibleModeState.statePath}). If the user prompt is a steering request, use \`gjc ultragoal steer\` to add or steer subgoals. Normal prose should not mutate Ultragoal state.`;
@@ -818,7 +789,7 @@ export async function buildSkillStopOutput(input: StopHookInput): Promise<Record
 			// authoritative durable state. If a stale/incoherent mode-state would
 			// release while the plan/ledger still shows pending work, block instead
 			// of trusting the single file (see #659).
-			const staleRelease = await detectStaleModeStateRelease(entry.skill, input.cwd);
+			const staleRelease = await detectStaleModeStateRelease(entry.skill, input.cwd, resolvedSessionId);
 			if (staleRelease) {
 				const coherenceMessage = `GJC skill "${entry.skill}" mode-state reports it released the Stop block (${modeStatePath(input.cwd, entry.skill, resolvedSessionId)}), but ${staleRelease}. The mode-state is incoherent with authoritative durable state; finish or explicitly clear the pending work before stopping.`;
 				return {
@@ -847,29 +818,18 @@ export async function buildSkillStopOutput(input: StopHookInput): Promise<Record
 		const phase = String(modeState?.current_phase ?? entry.phase ?? skillState.phase ?? "active");
 		const statePath = modeStatePath(input.cwd, entry.skill, resolvedSessionId);
 		if (entry.skill === "ultragoal") {
-			const objective =
-				(await readCurrentGoalObjectiveFromSessionFile(input.sessionFile)) ??
-				(typeof modeState?.objective === "string"
-					? modeState.objective
-					: typeof modeState?.gjcObjective === "string"
-						? modeState.gjcObjective
-						: "");
-			if (objective) {
-				const diagnostic = await readUltragoalVerificationState({
-					cwd: input.cwd,
-					currentGoal: { objective },
-				});
-				if (diagnostic.state === "active_verified_complete") continue;
-				if (!["inactive", "unrelated_goal"].includes(diagnostic.state)) {
-					const ultragoalMessage = `GJC ultragoal verification is blocking stop: ${diagnostic.message} Run strict checkpoint verification or record review blockers before stopping.`;
-					return {
-						decision: "block",
-						reason: ultragoalMessage,
-						stopReason: `gjc_ultragoal_verification_${diagnostic.state}`,
-						systemMessage: ultragoalMessage,
-					};
-				}
-			}
+			const diagnostic = await verifyUltragoalDurableCompletionState({
+				cwd: input.cwd,
+				sessionId: resolvedSessionId,
+			});
+			if (ultragoalDurableCompletionReleasesStop(diagnostic.state)) continue;
+			const ultragoalMessage = `GJC ultragoal verification is blocking stop: ${diagnostic.message} Run \`gjc ultragoal checkpoint --status complete --quality-gate-json <file>\` or record review blockers before stopping.`;
+			return {
+				decision: "block",
+				reason: ultragoalMessage,
+				stopReason: `gjc_ultragoal_verification_${diagnostic.state}`,
+				systemMessage: ultragoalMessage,
+			};
 		}
 		const systemMessage = handoffRequired
 			? buildHandoffForceAskMessage(entry.skill, phase, statePath)

--- a/packages/coding-agent/test/gjc-runtime/computer-red-team-fixtures.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/computer-red-team-fixtures.test.ts
@@ -99,9 +99,8 @@ function syntheticPng(): Buffer {
 	return Buffer.concat([PNG_SIGNATURE, pngChunk("IHDR", ihdr), pngChunk("IDAT", deflateSync(raw)), pngChunk("IEND")]);
 }
 
-let activeObjective = "";
 async function seedPlan(root: string): Promise<void> {
-	const created = await createUltragoalPlan({
+	await createUltragoalPlan({
 		cwd: root,
 		brief: "@goal computer gate fixture",
 	});
@@ -111,20 +110,7 @@ async function seedPlan(root: string): Promise<void> {
 		path.relative(root, path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl")),
 	]);
 	await runGit(root, ["commit", "-m", "plan"]);
-	activeObjective = created.gjcObjective;
 	await startNextUltragoalGoal({ cwd: root });
-}
-
-function goalSnapshot(): string {
-	return JSON.stringify({
-		goal: {
-			threadId: "test-thread",
-			objective: activeObjective,
-			status: "active",
-			createdAt: Date.now(),
-			updatedAt: Date.now(),
-		},
-	});
 }
 
 function artifact(kind = "native screenshot"): Record<string, unknown> {
@@ -236,8 +222,6 @@ async function checkpoint(root: string, qa: Record<string, unknown>): Promise<st
 			"complete",
 			"--evidence",
 			"fixture complete",
-			"--gjc-goal-json",
-			goalSnapshot(),
 			"--quality-gate-json",
 			qualityGate(qa),
 		],

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-dogfood.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-dogfood.test.ts
@@ -219,20 +219,8 @@ function qualityGate(): Record<string, unknown> {
 	};
 }
 
-function goalSnapshot(objective: string): string {
-	return JSON.stringify({
-		goal: {
-			threadId: "dogfood-test-thread",
-			objective,
-			status: "active",
-			createdAt: Date.now(),
-			updatedAt: Date.now(),
-		},
-	});
-}
-
 async function checkpoint(root: string): Promise<{ status: number; stdout?: string; stderr?: string }> {
-	const created = await createUltragoalPlan({ cwd: root, brief: "Dogfood hardened live red-team gate" });
+	await createUltragoalPlan({ cwd: root, brief: "Dogfood hardened live red-team gate" });
 	await startNextUltragoalGoal({ cwd: root });
 	return runNativeUltragoalCommand(
 		[
@@ -243,8 +231,6 @@ async function checkpoint(root: string): Promise<{ status: number; stdout?: stri
 			"complete",
 			"--evidence",
 			"dogfood live web plus cli replay gate",
-			"--gjc-goal-json",
-			goalSnapshot(created.gjcObjective),
 			"--quality-gate-json",
 			JSON.stringify(qualityGate()),
 		],

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-durable-completion-release.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-durable-completion-release.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { sessionUltragoalDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
+import {
+	type UltragoalGuardState,
+	verifyUltragoalDurableCompletionState,
+} from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
+import {
+	addUltragoalSubgoal,
+	checkpointUltragoalGoal,
+	createUltragoalPlan,
+	readUltragoalPlan,
+	startNextUltragoalGoal,
+} from "@gajae-code/coding-agent/gjc-runtime/ultragoal-runtime";
+
+const TEST_SESSION_ID = "ultragoal-durable-completion-release-test-session";
+const tempRoots: string[] = [];
+
+let savedSessionId: string | undefined;
+let savedSessionFile: string | undefined;
+
+beforeEach(() => {
+	savedSessionId = process.env.GJC_SESSION_ID;
+	savedSessionFile = process.env.GJC_SESSION_FILE;
+	process.env.GJC_SESSION_ID = TEST_SESSION_ID;
+	delete process.env.GJC_SESSION_FILE;
+});
+
+afterEach(async () => {
+	if (savedSessionId === undefined) delete process.env.GJC_SESSION_ID;
+	else process.env.GJC_SESSION_ID = savedSessionId;
+	if (savedSessionFile === undefined) delete process.env.GJC_SESSION_FILE;
+	else process.env.GJC_SESSION_FILE = savedSessionFile;
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-ultragoal-durable-release-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+function isReleaseAllowed(state: UltragoalGuardState): boolean {
+	return state === "inactive" || state === "active_verified_complete";
+}
+
+function passingQualityGate(): string {
+	return JSON.stringify({
+		architectReview: {
+			architectureStatus: "CLEAR",
+			productStatus: "CLEAR",
+			codeStatus: "CLEAR",
+			recommendation: "APPROVE",
+			evidence: "architect reviewed the implementation and found no blockers",
+			commands: ["architect-review"],
+			blockers: [],
+		},
+		executorQa: {
+			status: "passed",
+			e2eStatus: "passed",
+			redTeamStatus: "passed",
+			evidence: "executor ran API package checks and adversarial coverage",
+			e2eCommands: ["bun test package-consumer"],
+			redTeamCommands: ["bun test adversarial"],
+			artifactRefs: [
+				{
+					id: "api-report",
+					kind: "api-package-test-report",
+					path: "artifacts/api-report.txt",
+					description: "API package consumer test report",
+				},
+				{
+					id: "adversarial-report",
+					kind: "algorithm-boundary-test-report",
+					path: "artifacts/adversarial-report.txt",
+					description: "Adversarial boundary test report",
+				},
+			],
+			contractCoverage: [
+				{
+					id: "contract-api",
+					contractRef: "approved-plan:goal",
+					obligation: "The completed goal satisfies the approved API/package contract",
+					status: "covered",
+					surfaceEvidenceRefs: ["surface-api"],
+					adversarialCaseRefs: ["case-boundary"],
+				},
+			],
+			surfaceEvidence: [
+				{
+					id: "surface-api",
+					surface: "api/package",
+					contractRef: "approved-plan:goal",
+					invocation: "Run the package consumer API test",
+					verdict: "passed",
+					artifactRefs: ["api-report"],
+				},
+			],
+			adversarialCases: [
+				{
+					id: "case-boundary",
+					contractRef: "approved-plan:goal",
+					scenario: "Exercise invalid and boundary inputs through the API",
+					expectedBehavior: "The API rejects invalid input and preserves invariants",
+					verdict: "passed",
+					artifactRefs: ["adversarial-report"],
+				},
+			],
+			blockers: [],
+		},
+		iteration: {
+			status: "passed",
+			evidence: "verification rerun found no remaining findings",
+			fullRerun: true,
+			rerunCommands: ["bun test package-consumer", "bun test adversarial"],
+			blockers: [],
+		},
+	});
+}
+
+async function passingLiveQualityGate(root: string): Promise<string> {
+	await fs.mkdir(path.join(root, "artifacts"), { recursive: true });
+	await fs.writeFile(path.join(root, "artifacts", "api-report.txt"), "API package consumer test passed\n");
+	await fs.writeFile(
+		path.join(root, "artifacts", "adversarial-report.txt"),
+		"Boundary and adversarial tests passed\n",
+	);
+	return passingQualityGate();
+}
+
+async function createTwoGoalPlan(root: string, mode: "aggregate" | "per-story" = "aggregate"): Promise<void> {
+	await createUltragoalPlan({ cwd: root, brief: "Ship the feature", gjcGoalMode: mode });
+	await addUltragoalSubgoal({
+		cwd: root,
+		title: "Second story",
+		objective: "Complete the second story.",
+		evidence: "The feature requires a second required story.",
+		rationale: "Exercise multi-goal completion release checks.",
+	});
+}
+
+async function completeGoal(root: string, goalId: string): Promise<void> {
+	await startNextUltragoalGoal({ cwd: root });
+	await checkpointUltragoalGoal({
+		cwd: root,
+		goalId,
+		status: "complete",
+		evidence: `${goalId} verified complete`,
+		qualityGateJson: await passingLiveQualityGate(root),
+	});
+}
+
+describe("ultragoal durable completion release state", () => {
+	it("treats missing durable plan as inactive and release-allowed", async () => {
+		const root = await tempDir();
+
+		const diagnostic = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+
+		expect(diagnostic.state).toBe("inactive");
+		expect(isReleaseAllowed(diagnostic.state)).toBe(true);
+	});
+
+	it("blocks aggregate mode while a required goal is incomplete", async () => {
+		const root = await tempDir();
+		await createTwoGoalPlan(root);
+		await completeGoal(root, "G001");
+
+		const diagnostic = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+
+		expect(diagnostic.state).toBe("active_missing_final_receipt");
+		expect(diagnostic.message).toContain("incomplete required goals");
+		expect(isReleaseAllowed(diagnostic.state)).toBe(false);
+	});
+
+	it("blocks aggregate mode when complete-looking goals have no fresh final aggregate receipt", async () => {
+		const root = await tempDir();
+		await createTwoGoalPlan(root);
+		await completeGoal(root, "G001");
+		await completeGoal(root, "G002");
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const plan = await readUltragoalPlan(root, TEST_SESSION_ID);
+		if (!plan) throw new Error("missing plan");
+		const finalGoal = plan.goals.find(goal => goal.id === "G002");
+		if (!finalGoal) throw new Error("missing final goal");
+		delete finalGoal.completionVerification;
+		await fs.writeFile(goalsPath, `${JSON.stringify(plan, null, 2)}\n`);
+
+		const diagnostic = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+
+		expect(diagnostic.state).toBe("active_missing_final_receipt");
+		expect(diagnostic.message).toContain("final aggregate receipt");
+		expect(isReleaseAllowed(diagnostic.state)).toBe(false);
+	});
+
+	it("allows aggregate mode when final aggregate and prior per-goal receipts are fresh", async () => {
+		const root = await tempDir();
+		await createTwoGoalPlan(root);
+		await completeGoal(root, "G001");
+		await completeGoal(root, "G002");
+
+		const diagnostic = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+
+		expect(diagnostic.state).toBe("active_verified_complete");
+		expect(isReleaseAllowed(diagnostic.state)).toBe(true);
+	});
+
+	it("blocks per-story mode when a required story lacks a valid per-goal receipt", async () => {
+		const root = await tempDir();
+		await createTwoGoalPlan(root, "per-story");
+		await completeGoal(root, "G001");
+
+		const diagnostic = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+
+		expect(diagnostic.state).toBe("active_missing_receipt");
+		expect(diagnostic.message).toContain("incomplete: G002");
+		expect(isReleaseAllowed(diagnostic.state)).toBe(false);
+	});
+
+	it("allows per-story mode when all required stories have fresh per-goal receipts", async () => {
+		const root = await tempDir();
+		await createTwoGoalPlan(root, "per-story");
+		await completeGoal(root, "G001");
+		await completeGoal(root, "G002");
+
+		const diagnostic = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+
+		expect(diagnostic.state).toBe("active_verified_complete");
+		expect(isReleaseAllowed(diagnostic.state)).toBe(true);
+	});
+
+	it("fails closed when durable state is corrupt", async () => {
+		const root = await tempDir();
+		await createTwoGoalPlan(root);
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		await fs.writeFile(goalsPath, "{ not valid json");
+
+		const diagnostic = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+
+		expect(diagnostic.state).toBe("unreadable_fail_closed");
+		expect(isReleaseAllowed(diagnostic.state)).toBe(false);
+	});
+
+	it("documents the complete release predicate matrix", () => {
+		const states: UltragoalGuardState[] = [
+			"inactive",
+			"unrelated_goal",
+			"active_verified_complete",
+			"active_missing_receipt",
+			"active_stale_receipt",
+			"active_missing_final_receipt",
+			"active_dirty_quality_gate",
+			"active_review_blocked_unrecorded",
+			"active_review_blocked_recorded",
+			"unreadable_fail_closed",
+		];
+
+		expect(states.filter(isReleaseAllowed)).toEqual(["inactive", "active_verified_complete"]);
+	});
+});

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-nudge-guard.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-nudge-guard.test.ts
@@ -144,9 +144,7 @@ describe("ultragoal nudge guard", () => {
 		).rejects.toThrow(/try-harder nudge/);
 		await expect(
 			assertCanCompleteCurrentGoal({ cwd, currentGoal: DEFAULT_OBJECTIVE_GOAL, sessionId: TEST_SESSION_ID }),
-		).rejects.toThrow(
-			/strict `gjc ultragoal checkpoint --status complete --quality-gate-json <file> --gjc-goal-json <file>`/,
-		);
+		).rejects.toThrow(/`gjc ultragoal checkpoint --status complete --quality-gate-json <file>`/);
 		const ledger = await readUltragoalLedger(cwd, TEST_SESSION_ID);
 		expect(ledger.filter(event => event.event === "nudge" && event.surface === "premature_complete").length).toBe(1);
 	});

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-review.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-review.test.ts
@@ -246,7 +246,7 @@ function passingQualityGate(): Record<string, unknown> {
 
 async function completeSingleGoal(root: string): Promise<void> {
 	await writeStructuralArtifacts(root);
-	const created = await createUltragoalPlan({ cwd: root, brief: "Ship review reconcile" });
+	await createUltragoalPlan({ cwd: root, brief: "Ship review reconcile" });
 	await startNextUltragoalGoal({ cwd: root });
 	const checkpoint = await runNativeUltragoalCommand(
 		[
@@ -257,10 +257,6 @@ async function completeSingleGoal(root: string): Promise<void> {
 			"complete",
 			"--evidence",
 			"final story verified with targeted regression coverage",
-			"--gjc-goal-json",
-			JSON.stringify({
-				goal: { threadId: "test", objective: created.gjcObjective, status: "active", updatedAt: Date.now() },
-			}),
 			"--quality-gate-json",
 			JSON.stringify(passingQualityGate()),
 		],
@@ -365,7 +361,7 @@ describe("ultragoal review command", () => {
 		const root = await tempDir();
 		const qa = invalidInlineOnlyExecutorQa();
 		const reviewOutput = await review(root, ["--executor-qa-json", await writeQa(root, qa)]);
-		const created = await createUltragoalPlan({ cwd: root, brief: "Ship review gate" });
+		await createUltragoalPlan({ cwd: root, brief: "Ship review gate" });
 		await startNextUltragoalGoal({ cwd: root });
 		const checkpoint = await runNativeUltragoalCommand(
 			[
@@ -376,10 +372,6 @@ describe("ultragoal review command", () => {
 				"complete",
 				"--evidence",
 				"review gate parity check",
-				"--gjc-goal-json",
-				JSON.stringify({
-					goal: { threadId: "test", objective: created.gjcObjective, status: "active", updatedAt: Date.now() },
-				}),
 				"--quality-gate-json",
 				JSON.stringify({
 					architectReview: {

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -10,10 +10,8 @@ import {
 	sessionUltragoalDir,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { reconcileWorkflowSkillState } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
-import {
-	assertCanCompleteCurrentGoal,
-	validateCompletionReceipt,
-} from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
+import { validateCompletionReceipt } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
+
 import {
 	addUltragoalSubgoal,
 	buildUltragoalHudSummary,
@@ -347,8 +345,6 @@ async function expectRejectedExecutorQa(root: string, executorQa: Record<string,
 			"complete",
 			"--evidence",
 			"focused CLI replay gate check",
-			"--gjc-goal-json",
-			goalSnapshot(created.gjcObjective),
 			"--quality-gate-json",
 			JSON.stringify({ ...JSON.parse(passingQualityGate()), executorQa }),
 		],
@@ -370,8 +366,6 @@ async function expectAcceptedExecutorQa(root: string, executorQa: Record<string,
 			"complete",
 			"--evidence",
 			"focused CLI replay gate check",
-			"--gjc-goal-json",
-			goalSnapshot(created.gjcObjective),
 			"--quality-gate-json",
 			JSON.stringify({ ...JSON.parse(passingQualityGate()), executorQa }),
 		],
@@ -402,92 +396,6 @@ function webExecutorQa(overrides: Record<string, unknown> = {}): Record<string, 
 async function passingLiveQualityGate(root: string): Promise<string> {
 	await writeStructuralArtifacts(root);
 	return passingQualityGate();
-}
-
-function goalSnapshot(objective: string, status = "active", updatedAt: number | string = Date.now()): string {
-	return JSON.stringify({
-		goal: {
-			threadId: "test-thread",
-			objective,
-			status,
-			createdAt: updatedAt,
-			updatedAt,
-		},
-	});
-}
-
-async function seedGoalModeSessionFile(root: string, objective: string, status = "active"): Promise<string> {
-	const sessionFile = path.join(root, "session.jsonl");
-	const now = Date.now();
-	await Bun.write(
-		sessionFile,
-		`${JSON.stringify({ version: 3, type: "session", id: TEST_SESSION_ID, createdAt: new Date(now).toISOString() })}\n${JSON.stringify(
-			{
-				type: "mode_change",
-				id: "goal-mode",
-				parentId: null,
-				timestamp: new Date(now).toISOString(),
-				mode: "goal",
-				data: {
-					goal: {
-						id: "goal-1",
-						objective,
-						status,
-						tokensUsed: 0,
-						timeUsedSeconds: 0,
-						createdAt: now,
-						updatedAt: now,
-					},
-				},
-			},
-		)}\n`,
-	);
-	process.env.GJC_SESSION_FILE = sessionFile;
-	return sessionFile;
-}
-
-async function seedAmbiguousGoalModeSessionFile(root: string, objective: string): Promise<string> {
-	const sessionFile = path.join(root, "ambiguous-session.jsonl");
-	const now = Date.now();
-	const staleMatchingGoal = {
-		id: "stale-goal",
-		objective,
-		status: "active",
-		tokensUsed: 0,
-		timeUsedSeconds: 0,
-		createdAt: now,
-		updatedAt: now,
-	};
-	const intendedBranchGoal = { ...staleMatchingGoal, id: "intended-goal", objective: "different active branch goal" };
-	const entries = [
-		{ version: 3, type: "session", id: TEST_SESSION_ID, timestamp: new Date(now).toISOString(), cwd: root },
-		{
-			type: "mode_change",
-			id: "root-goal",
-			parentId: null,
-			timestamp: new Date(now).toISOString(),
-			mode: "goal",
-			data: { goal: intendedBranchGoal },
-		},
-		{
-			type: "mode_change",
-			id: "intended-branch",
-			parentId: "root-goal",
-			timestamp: new Date(now).toISOString(),
-			mode: "none",
-		},
-		{
-			type: "mode_change",
-			id: "stale-matching-branch",
-			parentId: "root-goal",
-			timestamp: new Date(now).toISOString(),
-			mode: "goal",
-			data: { goal: staleMatchingGoal },
-		},
-	];
-	await Bun.write(sessionFile, `${entries.map(entry => JSON.stringify(entry)).join("\n")}\n`);
-	process.env.GJC_SESSION_FILE = sessionFile;
-	return sessionFile;
 }
 
 async function readJsonFile(filePath: string): Promise<Record<string, unknown>> {
@@ -603,8 +511,6 @@ async function expectRejectedCompleteGate(
 			"complete",
 			"--evidence",
 			"tests passed",
-			"--gjc-goal-json",
-			goalSnapshot(created.gjcObjective),
 			"--quality-gate-json",
 			qualityGateJson,
 		],
@@ -616,22 +522,6 @@ async function expectRejectedCompleteGate(
 		beforeLedger,
 	);
 	return result.stderr ?? "";
-}
-
-function goalToolSnapshot(objective: string, status = "active", updatedAt: number | string = Date.now()): string {
-	return JSON.stringify({
-		content: [{ type: "text", text: `Goal: ${objective}` }],
-		details: {
-			op: "get",
-			goal: {
-				threadId: "test-thread",
-				objective,
-				status,
-				createdAt: updatedAt,
-				updatedAt,
-			},
-		},
-	});
 }
 
 async function expectRejectedSteering(root: string, args: string[], kind: string): Promise<string> {
@@ -964,8 +854,6 @@ describe("native GJC ultragoal runtime", () => {
 				"complete",
 				"--evidence",
 				"tests passed",
-				"--gjc-goal-json",
-				goalSnapshot(created.gjcObjective),
 				"--quality-gate-json",
 				await passingLiveQualityGate(root),
 				"--json",
@@ -994,7 +882,7 @@ describe("native GJC ultragoal runtime", () => {
 		expect(result.status).toBe(0);
 		expect(result.stdout).toContain("gjc ultragoal checkpoint --goal-id");
 		expect(result.stdout).toContain("--quality-gate-json");
-		expect(result.stdout).toContain("current session goal state");
+		expect(result.stdout).toContain("COMPLETE CHECKPOINT RECEIPTS");
 		expect(result.stdout).toContain("obligation");
 	});
 
@@ -1375,8 +1263,6 @@ describe("native GJC ultragoal runtime", () => {
 				"Fix architect and executor QA findings.",
 				"--evidence",
 				"architect found product regression",
-				"--gjc-goal-json",
-				goalSnapshot(created.gjcObjective),
 				"--json",
 			],
 			root,
@@ -1403,7 +1289,6 @@ describe("native GJC ultragoal runtime", () => {
 			goalId: "G001",
 			status: "complete",
 			evidence: "tests passed",
-			gjcGoalJson: goalSnapshot(created.gjcObjective),
 			qualityGateJson: await passingLiveQualityGate(root),
 		});
 		const status = await getUltragoalStatus(root);
@@ -1473,7 +1358,7 @@ describe("native GJC ultragoal runtime", () => {
 		expect(await countCheckpoints()).toBe(2);
 	});
 
-	it("accepts full goal get tool result snapshots with millisecond timestamps", async () => {
+	it("completes from durable active goal state", async () => {
 		const root = await tempDir();
 		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
 		await startNextUltragoalGoal({ cwd: root });
@@ -1483,15 +1368,13 @@ describe("native GJC ultragoal runtime", () => {
 			goalId: "G001",
 			status: "complete",
 			evidence: "tests passed",
-			gjcGoalJson: goalToolSnapshot(created.gjcObjective),
 			qualityGateJson: await passingLiveQualityGate(root),
 		});
 
 		expect(plan.goals[0]?.status).toBe("complete");
-		expect(plan.goals[0]?.completionVerification?.gjcGoalSnapshotHash).toBeTruthy();
 	});
 
-	it("accepts ISO goal snapshot timestamps after normalizing freshness", async () => {
+	it("completes without goal snapshot freshness input", async () => {
 		const root = await tempDir();
 		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
 		await startNextUltragoalGoal({ cwd: root });
@@ -1501,15 +1384,13 @@ describe("native GJC ultragoal runtime", () => {
 			goalId: "G001",
 			status: "complete",
 			evidence: "tests passed",
-			gjcGoalJson: goalSnapshot(created.gjcObjective, "active", new Date().toISOString()),
 			qualityGateJson: await passingLiveQualityGate(root),
 		});
 
 		expect(plan.goals[0]?.status).toBe("complete");
-		expect(plan.goals[0]?.completionVerification?.gjcGoalSnapshotHash).toBeTruthy();
 	});
 
-	it("accepts per-story goal get snapshots for per-story plans", async () => {
+	it("accepts per-story durable active goals for per-story plans", async () => {
 		const root = await tempDir();
 		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix", gjcGoalMode: "per-story" });
 		await startNextUltragoalGoal({ cwd: root });
@@ -1521,7 +1402,6 @@ describe("native GJC ultragoal runtime", () => {
 			goalId: "G001",
 			status: "complete",
 			evidence: "tests passed",
-			gjcGoalJson: goalSnapshot(storyObjective),
 			qualityGateJson: await passingLiveQualityGate(root),
 		});
 
@@ -1549,8 +1429,6 @@ describe("native GJC ultragoal runtime", () => {
 				"complete",
 				"--evidence",
 				"tests passed",
-				"--gjc-goal-json",
-				goalSnapshot(created.gjcObjective),
 				"--quality-gate-json",
 				await passingLiveQualityGate(root),
 			],
@@ -1588,8 +1466,6 @@ describe("native GJC ultragoal runtime", () => {
 				"complete",
 				"--evidence",
 				"tests passed",
-				"--gjc-goal-json",
-				goalSnapshot(created.gjcObjective),
 				"--quality-gate-json",
 				await passingLiveQualityGate(root),
 				"--json",
@@ -1619,7 +1495,6 @@ describe("native GJC ultragoal runtime", () => {
 			goalId: "G001",
 			status: "complete",
 			evidence: "tests passed",
-			gjcGoalJson: goalSnapshot(created.gjcObjective),
 			qualityGateJson: await passingLiveQualityGate(root),
 		});
 		const goal = plan.goals[0];
@@ -1636,7 +1511,7 @@ describe("native GJC ultragoal runtime", () => {
 		expect(diagnostic.state).toBe("active_stale_receipt");
 	});
 
-	it("treats receipts as stale after goal get snapshot ledger mutation", async () => {
+	it("treats receipts as dirty after quality gate ledger mutation", async () => {
 		const root = await tempDir();
 		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
 		await startNextUltragoalGoal({ cwd: root });
@@ -1645,13 +1520,15 @@ describe("native GJC ultragoal runtime", () => {
 			goalId: "G001",
 			status: "complete",
 			evidence: "tests passed",
-			gjcGoalJson: goalSnapshot(created.gjcObjective),
 			qualityGateJson: await passingLiveQualityGate(root),
 		});
 		const ledger = await readUltragoalLedger(root);
 		const checkpointEvent = ledger.find(event => event.event === "goal_checkpointed");
 		if (!checkpointEvent) throw new Error("missing checkpoint event");
-		checkpointEvent.gjcGoalJson = { goal: { objective: created.gjcObjective, status: "active", updatedAt: 1 } };
+		checkpointEvent.qualityGateJson = {
+			...(checkpointEvent.qualityGateJson as Record<string, unknown>),
+			tampered: true,
+		};
 
 		const diagnostic = validateCompletionReceipt({
 			plan,
@@ -1660,8 +1537,53 @@ describe("native GJC ultragoal runtime", () => {
 			receiptKind: "final-aggregate",
 		});
 
-		expect(diagnostic.state).toBe("active_stale_receipt");
-		expect(diagnostic.message).toContain("snapshot hash");
+		expect(diagnostic.state).toBe("active_dirty_quality_gate");
+		expect(diagnostic.message).toContain("quality-gate hash");
+	});
+
+	it("rejects final-aggregate release when a prior per-goal receipt is tampered", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the multi-stage fix" });
+		await addUltragoalSubgoal({
+			cwd: root,
+			title: "Second stage",
+			objective: "Complete the second stage.",
+			evidence: "Need a prior required goal to tamper.",
+			rationale: "Regression coverage for prior per-goal receipt validation.",
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first stage verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		const plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G002",
+			status: "complete",
+			evidence: "second stage verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		const ledger = await readUltragoalLedger(root);
+		const priorEvent = ledger.find(event => event.event === "goal_checkpointed" && event.goalId === "G001");
+		if (!priorEvent) throw new Error("missing prior checkpoint event");
+		priorEvent.qualityGateJson = {
+			...(priorEvent.qualityGateJson as Record<string, unknown>),
+			tampered: true,
+		};
+
+		const diagnostic = validateCompletionReceipt({
+			plan,
+			ledger,
+			goal: plan.goals.find(goal => goal.id === "G002")!,
+			receiptKind: "final-aggregate",
+		});
+
+		expect(diagnostic.state).not.toBe("active_verified_complete");
+		expect(diagnostic.message).toContain("G001");
 	});
 
 	it("blocks complete checkpoints without full architect and executor verification", async () => {
@@ -1765,8 +1687,6 @@ describe("native GJC ultragoal runtime", () => {
 		missingEvidenceGate.architectReview!.evidence = "";
 		const dirtyBlockersGate = JSON.parse(passingQualityGate()) as Record<string, Record<string, unknown>>;
 		dirtyBlockersGate.executorQa!.blockers = ["regression remains"];
-		const snapshot = goalSnapshot(created.gjcObjective);
-
 		const missingEvidence = await runNativeUltragoalCommand(
 			[
 				"checkpoint",
@@ -1776,8 +1696,6 @@ describe("native GJC ultragoal runtime", () => {
 				"complete",
 				"--evidence",
 				"tests passed",
-				"--gjc-goal-json",
-				snapshot,
 				"--quality-gate-json",
 				JSON.stringify(missingEvidenceGate),
 			],
@@ -1792,8 +1710,6 @@ describe("native GJC ultragoal runtime", () => {
 				"complete",
 				"--evidence",
 				"tests passed",
-				"--gjc-goal-json",
-				snapshot,
 				"--quality-gate-json",
 				JSON.stringify(dirtyBlockersGate),
 			],
@@ -2141,7 +2057,6 @@ describe("native GJC ultragoal runtime", () => {
 			goalId: "G001",
 			status: "complete",
 			evidence: "tests passed",
-			gjcGoalJson: goalSnapshot(created.gjcObjective),
 			qualityGateJson: mixedProof,
 		});
 
@@ -2343,11 +2258,10 @@ describe("native GJC ultragoal runtime", () => {
 		).rejects.toThrow(/kill-switch-bypass/);
 	});
 
-	it("sources complete checkpoint goal snapshots from current session state when omitted", async () => {
+	it("sources complete checkpoint identity from durable ultragoal state", async () => {
 		const root = await tempDir();
-		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
 		await startNextUltragoalGoal({ cwd: root });
-		await seedGoalModeSessionFile(root, created.gjcObjective);
 
 		const result = await runNativeUltragoalCommand(
 			[
@@ -2365,152 +2279,12 @@ describe("native GJC ultragoal runtime", () => {
 			root,
 		);
 		const receipt = JSON.parse(result.stdout ?? "{}");
-		const plan = await readUltragoalPlan(root);
-		const ledger = await readUltragoalLedger(root);
-		const checkpoint = ledger.find(event => event.event === "goal_checkpointed");
 
 		expect(result.status).toBe(0);
 		expect(receipt.quality_gate_hash).toEqual(expect.any(String));
-		expect(plan?.goals[0]?.completionVerification?.gjcGoalSnapshotHash).toEqual(expect.any(String));
-		expect(checkpoint?.gjcGoalJson).toMatchObject({ goal: { objective: created.gjcObjective, status: "active" } });
 	});
 
-	it("requires supplied or current-session goal snapshots for complete checkpoints", async () => {
-		const root = await tempDir();
-		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
-		await startNextUltragoalGoal({ cwd: root });
-		const beforeGoals = await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text();
-
-		const result = await runNativeUltragoalCommand(
-			[
-				"checkpoint",
-				"--goal-id",
-				"G001",
-				"--status",
-				"complete",
-				"--evidence",
-				"tests passed",
-				"--quality-gate-json",
-				await passingLiveQualityGate(root),
-			],
-			root,
-		);
-
-		expect(result.status).toBe(1);
-		expect(result.stderr).toContain("complete checkpoints require an active GJC goal-mode snapshot");
-		expect(await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text()).toBe(
-			beforeGoals,
-		);
-	});
-
-	it("fails closed instead of using stale last-entry goal snapshots from ambiguous session branches", async () => {
-		const root = await tempDir();
-		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
-		await startNextUltragoalGoal({ cwd: root });
-		await seedAmbiguousGoalModeSessionFile(root, created.gjcObjective);
-		const beforeGoals = await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text();
-		const beforeLedger = await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl")).text();
-
-		const result = await runNativeUltragoalCommand(
-			[
-				"checkpoint",
-				"--goal-id",
-				"G001",
-				"--status",
-				"complete",
-				"--evidence",
-				"tests passed",
-				"--quality-gate-json",
-				await passingLiveQualityGate(root),
-			],
-			root,
-		);
-
-		expect(result.status).toBe(1);
-		expect(result.stderr).toContain("complete checkpoints require an active GJC goal-mode snapshot");
-		expect(await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text()).toBe(
-			beforeGoals,
-		);
-		expect(await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl")).text()).toBe(
-			beforeLedger,
-		);
-	});
-
-	it("fails closed when an active Ultragoal objective has no durable plan", async () => {
-		const root = await tempDir();
-		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
-		await fs.rm(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json"));
-
-		await expect(
-			assertCanCompleteCurrentGoal({
-				cwd: root,
-				currentGoal: { objective: created.gjcObjective, status: "active" },
-			}),
-		).rejects.toThrow("missing durable .gjc/ultragoal/goals.json");
-	});
-
-	it("fails closed for per-story Ultragoal objectives when the durable plan is missing", async () => {
-		const root = await tempDir();
-		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix", gjcGoalMode: "per-story" });
-		const storyObjective = created.goals[0]?.objective;
-		if (!storyObjective) throw new Error("missing story objective");
-		await fs.rm(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json"));
-
-		await expect(
-			assertCanCompleteCurrentGoal({
-				cwd: root,
-				currentGoal: { objective: storyObjective, status: "active" },
-			}),
-		).rejects.toThrow("missing durable .gjc/ultragoal/goals.json");
-	});
-
-	it("rejects unrelated or stale goal get snapshots before mutation", async () => {
-		const root = await tempDir();
-		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
-		await startNextUltragoalGoal({ cwd: root });
-		const beforeGoals = await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text();
-		const beforeLedger = await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl")).text();
-		const baseArgs = [
-			"checkpoint",
-			"--goal-id",
-			"G001",
-			"--status",
-			"complete",
-			"--evidence",
-			"tests passed",
-			"--quality-gate-json",
-			await passingLiveQualityGate(root),
-			"--gjc-goal-json",
-		];
-
-		const bogus = await runNativeUltragoalCommand([...baseArgs, JSON.stringify({ nope: true })], root);
-		const wrongObjective = await runNativeUltragoalCommand([...baseArgs, goalSnapshot("other goal")], root);
-		const staleStatus = await runNativeUltragoalCommand(
-			[...baseArgs, goalSnapshot(created.gjcObjective, "complete")],
-			root,
-		);
-		const staleSnapshot = await runNativeUltragoalCommand(
-			[...baseArgs, goalSnapshot(created.gjcObjective, "active", 1)],
-			root,
-		);
-
-		expect(bogus.status).toBe(1);
-		expect(bogus.stderr).toContain("goal object");
-		expect(wrongObjective.status).toBe(1);
-		expect(wrongObjective.stderr).toContain("objective");
-		expect(staleStatus.status).toBe(1);
-		expect(staleStatus.stderr).toContain("goal.status to be active");
-		expect(staleSnapshot.status).toBe(1);
-		expect(staleSnapshot.stderr).toContain("fresh");
-		expect(await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text()).toBe(
-			beforeGoals,
-		);
-		expect(await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl")).text()).toBe(
-			beforeLedger,
-		);
-	});
-
-	it("allows completed legacy goal snapshots for blocked checkpoints", async () => {
+	it("allows blocked checkpoints without completion quality gates", async () => {
 		const root = await tempDir();
 		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
 		await startNextUltragoalGoal({ cwd: root });
@@ -2524,8 +2298,6 @@ describe("native GJC ultragoal runtime", () => {
 				"blocked",
 				"--evidence",
 				"legacy completed GJC goal blocks goal create in this thread",
-				"--gjc-goal-json",
-				goalSnapshot("legacy completed unrelated goal", "complete"),
 			],
 			root,
 		);
@@ -2535,40 +2307,6 @@ describe("native GJC ultragoal runtime", () => {
 		expect(result.status).toBe(0);
 		expect(status.goals[0]?.status).toBe("blocked");
 		expect(ledgerRaw).toContain("legacy completed GJC goal blocks");
-	});
-
-	it("rejects unrelated review-blocker snapshots before mutation", async () => {
-		const root = await tempDir();
-		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
-		await startNextUltragoalGoal({ cwd: root });
-		const beforeGoals = await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text();
-		const beforeLedger = await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl")).text();
-
-		const result = await runNativeUltragoalCommand(
-			[
-				"record-review-blockers",
-				"--goal-id",
-				"G001",
-				"--title",
-				"Resolve verification blockers",
-				"--objective",
-				"Fix architect and executor QA findings.",
-				"--evidence",
-				"architect found product regression",
-				"--gjc-goal-json",
-				goalSnapshot("unrelated", "complete"),
-			],
-			root,
-		);
-
-		expect(result.status).toBe(1);
-		expect(result.stderr).toContain("objective");
-		expect(await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text()).toBe(
-			beforeGoals,
-		);
-		expect(await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl")).text()).toBe(
-			beforeLedger,
-		);
 	});
 
 	it("unblocks plans after verification blocker stories complete cleanly", async () => {
@@ -2587,8 +2325,6 @@ describe("native GJC ultragoal runtime", () => {
 				"Fix architect and executor QA findings.",
 				"--evidence",
 				"architect found product regression",
-				"--gjc-goal-json",
-				goalSnapshot(created.gjcObjective),
 			],
 			root,
 		);
@@ -2598,7 +2334,6 @@ describe("native GJC ultragoal runtime", () => {
 			goalId: "G002",
 			status: "complete",
 			evidence: "fixed regression and reran full verification",
-			gjcGoalJson: goalSnapshot(created.gjcObjective),
 			qualityGateJson: await passingLiveQualityGate(root),
 		});
 		const status = await getUltragoalStatus(root);
@@ -2610,33 +2345,6 @@ describe("native GJC ultragoal runtime", () => {
 		expect(completedBlocker.goals[1]?.completionVerification?.receiptKind).toBe("final-aggregate");
 	});
 
-	it("requires review blockers to include a fresh active goal get snapshot", async () => {
-		const root = await tempDir();
-		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
-		await startNextUltragoalGoal({ cwd: root });
-		const beforeGoals = await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text();
-
-		const result = await runNativeUltragoalCommand(
-			[
-				"record-review-blockers",
-				"--goal-id",
-				"G001",
-				"--title",
-				"Resolve verification blockers",
-				"--objective",
-				"Fix architect and executor QA findings.",
-				"--evidence",
-				"architect found product regression",
-			],
-			root,
-		);
-
-		expect(result.status).toBe(1);
-		expect(result.stderr).toContain("record-review-blockers require --gjc-goal-json");
-		expect(await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json")).text()).toBe(
-			beforeGoals,
-		);
-	});
 	it("blocks complete checkpoints without the strict architect/executor/iteration quality gate", async () => {
 		const root = await tempDir();
 		const created = await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
@@ -2648,7 +2356,6 @@ describe("native GJC ultragoal runtime", () => {
 				goalId: "G001",
 				status: "complete",
 				evidence: "tests passed",
-				gjcGoalJson: goalSnapshot(created.gjcObjective),
 			}),
 		).rejects.toThrow("require --quality-gate-json");
 
@@ -2658,7 +2365,6 @@ describe("native GJC ultragoal runtime", () => {
 				goalId: "G001",
 				status: "complete",
 				evidence: "tests passed",
-				gjcGoalJson: goalSnapshot(created.gjcObjective),
 				qualityGateJson: JSON.stringify({
 					verification: { status: "passed" },
 					codeReview: { recommendation: "APPROVE", architectStatus: "WATCH" },
@@ -2676,17 +2382,7 @@ describe("native GJC ultragoal runtime", () => {
 		await startNextUltragoalGoal({ cwd: root });
 
 		const result = await runNativeUltragoalCommand(
-			[
-				"checkpoint",
-				"--goal-id",
-				"G001",
-				"--status",
-				"complete",
-				"--evidence",
-				"tests passed",
-				"--gjc-goal-json",
-				goalSnapshot(created.gjcObjective),
-			],
+			["checkpoint", "--goal-id", "G001", "--status", "complete", "--evidence", "tests passed"],
 			root,
 		);
 		const status = await getUltragoalStatus(root);
@@ -2922,8 +2618,6 @@ describe("ultragoal @goal decomposition", () => {
 				"complete",
 				"--evidence",
 				"final story verified with targeted regression coverage",
-				"--gjc-goal-json",
-				goalSnapshot(created.gjcObjective),
 				"--quality-gate-json",
 				await passingLiveQualityGate(root),
 			],
@@ -2981,8 +2675,6 @@ describe("ultragoal @goal decomposition", () => {
 				"complete",
 				"--evidence",
 				"final story verified with targeted regression coverage",
-				"--gjc-goal-json",
-				goalSnapshot(created.gjcObjective),
 				"--quality-gate-json",
 				await passingLiveQualityGate(root),
 			],
@@ -3017,7 +2709,6 @@ describe("ultragoal @goal decomposition", () => {
 			goalId: "G001",
 			status: "complete",
 			evidence: "first story verified",
-			gjcGoalJson: goalSnapshot(created.gjcObjective),
 			qualityGateJson: await passingLiveQualityGate(root),
 		});
 
@@ -3165,8 +2856,6 @@ describe("ultragoal mode-state + HUD reconciliation (#342)", () => {
 					"complete",
 					"--evidence",
 					"tests passed",
-					"--gjc-goal-json",
-					goalSnapshot(created.gjcObjective),
 					"--quality-gate-json",
 					await passingLiveQualityGate(root),
 				],

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -198,18 +198,6 @@ describe("GJC native skill-state hooks", () => {
 		});
 	}
 
-	function goalSnapshot(objective: string, status = "active", updatedAt = Date.now()): string {
-		return JSON.stringify({
-			goal: {
-				threadId: "test-thread",
-				objective,
-				status,
-				createdAt: updatedAt,
-				updatedAt,
-			},
-		});
-	}
-
 	it("detects only the public GJC workflow skill surface", () => {
 		expect(detectSkillKeywords("$deep-interview then $team").map(match => match.skill)).toEqual([
 			"deep-interview",
@@ -1468,21 +1456,21 @@ disabledExtensions:
 				hookEventName: "UserPromptSubmit",
 				userPrompt: "$ultragoal plan this",
 				cwd: root,
-				sessionId: "session-ultra-block",
+				sessionId: "test-session",
 				threadId: "thread-ultra-block",
 			},
 			{ effectiveSkillConfig: testEffectiveSkillConfig },
 		);
-		const statePath = modeStatePath(root, "session-ultra-block", "ultragoal");
+		const statePath = modeStatePath(root, "test-session", "ultragoal");
 		const state = await Bun.file(statePath).json();
 		await Bun.write(statePath, JSON.stringify({ ...state, objective: plan.goals[0]?.objective }, null, 2));
 
-		const prompt = 'call goal({op:"complete"}) now for the active durable objective';
+		const prompt = 'call goal({"op":"complete"}) now for the active durable objective';
 		const result = await dispatchGjcNativeSkillHook({
 			hookEventName: "UserPromptSubmit",
 			userPrompt: prompt,
 			cwd: root,
-			sessionId: "session-ultra-block",
+			sessionId: "test-session",
 			threadId: "thread-ultra-block",
 		});
 
@@ -1490,7 +1478,7 @@ disabledExtensions:
 		expect(String(result.outputJson?.reason ?? "")).toContain("BLOCK_ULTRAGOAL_COMPLETION");
 	});
 
-	it("UserPromptSubmit recovers active Ultragoal objective from session transcript", async () => {
+	it("UserPromptSubmit blocks completion from durable state (no transcript recovery)", async () => {
 		const root = await cwd();
 		const plan = await createUltragoalPlan({ cwd: root, brief: "Ship verified ultragoal" });
 		const sessionFile = path.join(root, "session.jsonl");
@@ -1503,21 +1491,21 @@ disabledExtensions:
 				hookEventName: "UserPromptSubmit",
 				userPrompt: "$ultragoal plan this",
 				cwd: root,
-				sessionId: "session-ultra-transcript",
+				sessionId: "test-session",
 			},
 			{ effectiveSkillConfig: testEffectiveSkillConfig },
 		);
 
 		const result = await dispatchGjcNativeSkillHook({
 			hookEventName: "UserPromptSubmit",
-			userPrompt: 'please call goal({op:"complete"})',
+			userPrompt: 'please call goal({"op":"complete"})',
 			cwd: root,
-			sessionId: "session-ultra-transcript",
+			sessionId: "test-session",
 			sessionFile,
 		});
 
 		expect(result.outputJson).toMatchObject({ decision: "block" });
-		expect(String(result.outputJson?.reason ?? "")).toContain("fresh final aggregate receipt");
+		expect(String(result.outputJson?.reason ?? "")).toContain("BLOCK_ULTRAGOAL_COMPLETION");
 	});
 
 	it("Stop blocks verified Ultragoal stories while later required goals remain", async () => {
@@ -1536,7 +1524,6 @@ disabledExtensions:
 			goalId: "G001",
 			status: "complete",
 			evidence: "first stage verified",
-			gjcGoalJson: goalSnapshot(plan.gjcObjective),
 			qualityGateJson: ultragoalQualityGate(),
 		});
 		await dispatchGjcNativeSkillHook(
@@ -1561,8 +1548,10 @@ disabledExtensions:
 		});
 
 		expect(blocked.outputJson).toMatchObject({ decision: "block" });
-		expect(String(blocked.outputJson?.reason ?? "")).toContain("Ultragoal still has incomplete required goals: G002");
-		expect(String(blocked.outputJson?.reason ?? "")).toContain("complete-goals");
+		expect(String(blocked.outputJson?.reason ?? "")).toContain("Ultragoal has incomplete required goals: G002");
+		expect(String(blocked.outputJson?.reason ?? "")).toContain(
+			"gjc ultragoal checkpoint --status complete --quality-gate-json <file>",
+		);
 	});
 
 	it("Stop blocks when stale Ultragoal mode-state would release but the plan still has pending goals", async () => {
@@ -1574,7 +1563,7 @@ disabledExtensions:
 				hookEventName: "UserPromptSubmit",
 				userPrompt: "$ultragoal plan this",
 				cwd: root,
-				sessionId: "session-ultra-stale-release",
+				sessionId: "test-session",
 				threadId: "thread-ultra-stale-release",
 			},
 			{ effectiveSkillConfig: testEffectiveSkillConfig },
@@ -1586,14 +1575,14 @@ disabledExtensions:
 		// cross-file coherence guard must keep blocking while the plan has
 		// incomplete goals.
 		await Bun.write(
-			modeStatePath(root, "session-ultra-stale-release", "ultragoal"),
-			JSON.stringify({ active: false, current_phase: "complete", session_id: "session-ultra-stale-release" }),
+			modeStatePath(root, "test-session", "ultragoal"),
+			JSON.stringify({ active: false, current_phase: "complete", session_id: "test-session" }),
 		);
 
 		const blocked = await dispatchGjcNativeSkillHook({
 			hookEventName: "Stop",
 			cwd: root,
-			sessionId: "session-ultra-stale-release",
+			sessionId: "test-session",
 			threadId: "thread-ultra-stale-release",
 		});
 
@@ -1613,7 +1602,7 @@ disabledExtensions:
 				hookEventName: "UserPromptSubmit",
 				userPrompt: "$ultragoal plan this",
 				cwd: root,
-				sessionId: "session-ultra-releasing-phase",
+				sessionId: "test-session",
 				threadId: "thread-ultra-releasing-phase",
 			},
 			{ effectiveSkillConfig: testEffectiveSkillConfig },
@@ -1622,14 +1611,14 @@ disabledExtensions:
 		// active:true but a terminal phase still releases via STOP_RELEASING_PHASES;
 		// the coherence guard must override that release while goals remain.
 		await Bun.write(
-			modeStatePath(root, "session-ultra-releasing-phase", "ultragoal"),
-			JSON.stringify({ active: true, current_phase: "completed", session_id: "session-ultra-releasing-phase" }),
+			modeStatePath(root, "test-session", "ultragoal"),
+			JSON.stringify({ active: true, current_phase: "completed", session_id: "test-session" }),
 		);
 
 		const blocked = await dispatchGjcNativeSkillHook({
 			hookEventName: "Stop",
 			cwd: root,
-			sessionId: "session-ultra-releasing-phase",
+			sessionId: "test-session",
 			threadId: "thread-ultra-releasing-phase",
 		});
 
@@ -1685,7 +1674,6 @@ disabledExtensions:
 			goalId: "G001",
 			status: "complete",
 			evidence: "first stage verified",
-			gjcGoalJson: goalSnapshot(plan.gjcObjective),
 			qualityGateJson: ultragoalQualityGate(),
 		});
 		await dispatchGjcNativeSkillHook(
@@ -1711,8 +1699,10 @@ disabledExtensions:
 		});
 
 		expect(result.outputJson).toMatchObject({ decision: "block" });
-		expect(String(result.outputJson?.reason ?? "")).toContain("Ultragoal still has incomplete required goals: G002");
-		expect(String(result.outputJson?.reason ?? "")).toContain("complete-goals");
+		expect(String(result.outputJson?.reason ?? "")).toContain("Ultragoal has incomplete required goals: G002");
+		expect(String(result.outputJson?.reason ?? "")).toContain(
+			"gjc ultragoal checkpoint --status complete --quality-gate-json <file>",
+		);
 	});
 	it("UserPromptSubmit includes steer guidance when activating Ultragoal", async () => {
 		const root = await cwd();

--- a/packages/coding-agent/test/goals/goal-tool.test.ts
+++ b/packages/coding-agent/test/goals/goal-tool.test.ts
@@ -280,7 +280,7 @@ describe("GoalTool", () => {
 			);
 
 			await expect(tool.execute("call-complete", { op: "complete" })).rejects.toThrow(
-				"Ultragoal aggregate completion requires a fresh final aggregate receipt",
+				"gjc ultragoal checkpoint --status complete --quality-gate-json <file>",
 			);
 			expect(harness.getState()?.goal.status).toBe("active");
 		} finally {

--- a/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
+++ b/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
@@ -282,7 +282,6 @@ describe("ultragoal ask guard", () => {
 		plan.goals[0].completedAt = now;
 		const eventId = "event-final";
 		const qualityGateJson = {};
-		const gjcGoalJson = {};
 		const generation = computeUltragoalPlanGeneration({
 			plan,
 			ledger: [],
@@ -301,7 +300,6 @@ describe("ultragoal ask guard", () => {
 			gjcGoalMode: plan.gjcGoalMode,
 			gjcObjective: plan.gjcObjective,
 			qualityGateHash: hashStructuredValue(qualityGateJson),
-			gjcGoalSnapshotHash: hashStructuredValue(gjcGoalJson),
 			planGeneration: generation.planGeneration,
 			basis: generation.basis,
 			checkpointLedgerEventId: eventId,
@@ -309,7 +307,7 @@ describe("ultragoal ask guard", () => {
 		await fs.writeFile(paths.goalsPath, JSON.stringify(plan, null, 2));
 		await fs.writeFile(
 			paths.ledgerPath,
-			`${JSON.stringify({ eventId, event: "goal_checkpointed", goalId: plan.goals[0].id, status: "complete", completionVerification: plan.goals[0].completionVerification, qualityGateJson, gjcGoalJson })}\n`,
+			`${JSON.stringify({ eventId, event: "goal_checkpointed", goalId: plan.goals[0].id, status: "complete", completionVerification: plan.goals[0].completionVerification, qualityGateJson })}\n`,
 		);
 		const diagnostic = await isUltragoalAskBlocked(cwd);
 		expect(diagnostic.active).toBe(false);


### PR DESCRIPTION
## Problem
`gjc ultragoal checkpoint --status complete` repeatedly drifted between two goal-identity concepts:
- the inline `goal` tool's **goal-mode snapshot**, reconstructed out-of-process by **replaying the session JSONL transcript** (`readCurrentSessionGjcGoalSnapshot`), and
- the durable `.gjc/_session-*/ultragoal/goals.json` record (G001…).

There is **no `gjc goal` CLI** — the fragile piece was the transcript-replayed snapshot passed via `--gjc-goal-json`, which failed whenever the transcript was stale/branched or the env wasn't wired.

## Fix
Make the canonical session-scoped artifacts the **single source of truth** — `goals.json` for identity/state, `ledger.jsonl` for completion proof — and delete the goal-mode snapshot path entirely.

- **`ultragoal-runtime.ts`**: remove `readGjcGoalSnapshot`/`readCurrentSessionGjcGoalSnapshot`/transcript replay, `gjcGoalSnapshotHash`, all `gjcGoalJson` threading, and `--gjc-goal-json` from every verb/flag/help/dispatch/error string; `record-review-blockers` keys off `goals.json`; add `validateCompleteCheckpointTargetGoal` (only `active`/retryable-`failed` targets may complete).
- **`ultragoal-guard.ts`**: new objective-independent, **mode-aware, fail-closed** `verifyUltragoalDurableCompletionState` (aggregate = fresh final-aggregate receipt **+ validated prior per-goal receipts**; per-story = all per-goal receipts, no final-aggregate); `assertCanCompleteCurrentGoal` refactored onto it.
- **`skill-state.ts`**: all four completion-release paths (`buildActiveUltragoalPromptContext`, `buildSkillStopOutput`, `detectStaleModeStateRelease`, direct `goal({op:complete})`) route through the one helper; `readCurrentGoalObjectiveFromSessionFile` dependency severed.
- **`workflow-manifest.ts` / `workflow-manifest.generated.json`**: drop `gjc-goal-json`.
- **ultragoal `SKILL.md`**: rewritten to the single-source narrative; inline `goal` tool + create-bridge documented as UX-only with agent-driven termination.

## Testing
- New `ultragoal-durable-completion-release.test.ts` — 8-case fail-closed matrix.
- New regression: tampered **prior** per-goal receipt must block final-aggregate release.
- Existing ultragoal/guard/hook/goal-tool suites updated for the removed flag/field.
- `tsgo` typecheck clean · Biome clean · **275+ affected tests pass**.
- Consensus-reviewed (ralplan): architect **CLEAR/APPROVE** after fixing one HIGH blocker (aggregate release now validates prior per-goal receipt integrity, not presence); executor QA red-team all green.
- Live proof via the patched source CLI: complete checkpoint succeeds with **only** `--quality-gate-json` (no `--gjc-goal-json`).

## Notes
- No `goals.json` schema change; no `--gjc-goal-json` deprecation shim (all references removed).
- Base branch: `dev` (interpreted from "ev").

🤖 Generated with Claude Code