### PR TITLE
Show Telegram verbose session identity

### DIFF
--- a/crates/gjc-notifications/src/protocol.rs
+++ b/crates/gjc-notifications/src/protocol.rs
@@ -251,7 +251,8 @@ pub struct IdentityHeader {
 pub struct ContextUpdate {
 	/// The session this update belongs to.
 	pub session_id:   String,
-	/// Compact current working directory label; never the full host path by default.
+	/// Compact current working directory label; never the full host path by
+	/// default.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub cwd:          Option<String>,
 	/// Last assistant message text.

--- a/crates/gjc-notifications/src/protocol.rs
+++ b/crates/gjc-notifications/src/protocol.rs
@@ -251,6 +251,9 @@ pub struct IdentityHeader {
 pub struct ContextUpdate {
 	/// The session this update belongs to.
 	pub session_id:   String,
+	/// Compact current working directory label; never the full host path by default.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub cwd:          Option<String>,
 	/// Last assistant message text.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub last_message: Option<String>,
@@ -671,11 +674,13 @@ mod tests {
 			token_usage:  Some("12k/200k".into()),
 			model:        Some("opus".into()),
 			diff:         None,
+			cwd:          Some("repo-worktree".into()),
 		});
 		let v = serde_json::to_value(&msg).unwrap();
 		assert_eq!(v["type"], "context_update");
 		assert_eq!(v["lastMessage"], "done");
 		assert_eq!(v["tokenUsage"], "12k/200k");
+		assert_eq!(v["cwd"], "repo-worktree");
 		assert!(v.get("task").is_none());
 		assert!(v.get("diff").is_none());
 	}

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -297,6 +297,15 @@ function buildIdentity(
 	return { repo, branch, machine: os.hostname(), title: sessionName };
 }
 
+/** Compact cwd label for remote session identity; never emits the full host path by default. */
+function compactCwd(cwd: string): string | undefined {
+	const home = os.homedir();
+	const resolved = path.resolve(cwd);
+	if (resolved === home) return "~";
+	const base = path.basename(resolved);
+	return base || path.parse(resolved).root || undefined;
+}
+
 const execFileAsync = promisify(execFile);
 
 /** Best-effort working-tree diff stat for the context update (no throw). */
@@ -973,7 +982,8 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 			const tokenUsage = usage && usage.tokens != null ? `${usage.tokens}/${usage.contextWindow}` : undefined;
 			const modelId = model?.id;
 			void readGitDiffStat(ctx.cwd).then(diff => {
-				if (!diff && !tokenUsage && !modelId) return;
+				const cwd = compactCwd(ctx.cwd);
+				if (!diff && !tokenUsage && !modelId && !cwd) return;
 				try {
 					rt.server.pushFrame(
 						JSON.stringify({
@@ -982,6 +992,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 							tokenUsage,
 							model: modelId,
 							diff,
+							cwd,
 						}),
 					);
 				} catch (e) {

--- a/packages/coding-agent/src/notifications/threaded-render.ts
+++ b/packages/coding-agent/src/notifications/threaded-render.ts
@@ -49,6 +49,7 @@ interface ThreadedFrame {
 	tokenUsage?: unknown;
 	model?: unknown;
 	diff?: unknown;
+	cwd?: unknown;
 	// turn_stream
 	phase?: unknown;
 	text?: unknown;
@@ -89,18 +90,25 @@ export function formatIdentityHeader(frame: {
 /** Format a streamed context update into a compact block (omitting empty fields). */
 export function formatContextUpdate(frame: ThreadedFrame): string | undefined {
 	const lines: string[] = [];
+	const session = str(frame.sessionId);
+	const cwd = str(frame.cwd);
 	const last = str(frame.lastMessage);
-	if (last) lines.push(escapeHtml(truncate(last, 600)));
 	const task = str(frame.task);
-	if (task) lines.push(`${italic("task:")} ${escapeHtml(task)}`);
 	const goal = str(frame.goal);
-	if (goal) lines.push(`${italic("goal:")} ${escapeHtml(goal)}`);
 	const usage = str(frame.tokenUsage);
 	const model = str(frame.model);
-	if (usage || model) lines.push(`ctx: ${code([usage, model].filter(Boolean).join(" · "))}`);
 	const diff = str(frame.diff);
+	if (!cwd && !last && !task && !goal && !usage && !model && !diff) return undefined;
+	const meta = [session ? `session: ${code(session)}` : undefined, cwd ? `cwd: ${code(cwd)}` : undefined].filter(
+		Boolean,
+	);
+	if (meta.length > 0) lines.push(meta.join(" · "));
+	if (last) lines.push(escapeHtml(truncate(last, 600)));
+	if (task) lines.push(`${italic("task:")} ${escapeHtml(task)}`);
+	if (goal) lines.push(`${italic("goal:")} ${escapeHtml(goal)}`);
+	if (usage || model) lines.push(`ctx: ${code([usage, model].filter(Boolean).join(" · "))}`);
 	if (diff) lines.push(`diff:\n${pre(truncate(diff, 1200))}`);
-	return lines.length ? lines.join("\n") : undefined;
+	return lines.join("\n");
 }
 
 /**

--- a/packages/coding-agent/test/notifications-threaded-render.test.ts
+++ b/packages/coding-agent/test/notifications-threaded-render.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { formatIdentityHeader, renderThreadedFrame } from "../src/notifications/threaded-render";
+import { formatContextUpdate, formatIdentityHeader, renderThreadedFrame } from "../src/notifications/threaded-render";
 
 describe("renderThreadedFrame", () => {
 	test("identity_header renders pinned bullets with identity flag", () => {
@@ -50,6 +50,11 @@ describe("renderThreadedFrame", () => {
 		expect(send?.lane).toBe("live");
 		expect(send?.coalesceKey).toBe("ctx:s");
 		expect(send?.text).toContain("ctx: <code>12k/200k · opus</code>");
+		expect(send?.text).toContain("session: <code>s</code>");
+
+		const withCwd = formatContextUpdate({ type: "context_update", sessionId: "session-full", cwd: "gajae-worktree" });
+		expect(withCwd).toContain("session: <code>session-full</code>");
+		expect(withCwd).toContain("cwd: <code>gajae-worktree</code>");
 	});
 
 	test("image_attachment renders a sendPhoto with caption", () => {

--- a/packages/coding-agent/test/notifications-turn-ordering.test.ts
+++ b/packages/coding-agent/test/notifications-turn-ordering.test.ts
@@ -23,7 +23,17 @@ async function waitFor(pred: () => boolean, ms = 4000, label = "condition"): Pro
 }
 
 type Handler = (event: unknown, ctx: unknown) => unknown;
-type Frame = { type: string; text?: string; verbosity?: "lean" | "verbose"; tokenUsage?: string; model?: string };
+type Frame = {
+	type: string;
+	text?: string;
+	verbosity?: "lean" | "verbose";
+	tokenUsage?: string;
+	model?: string;
+	cwd?: string;
+};
+
+type TestContextUsage = { tokens: number | null; contextWindow: number };
+type TestModel = { id?: string };
 
 const tempDirs: string[] = [];
 const openSockets: WebSocket[] = [];
@@ -33,7 +43,7 @@ afterEach(() => {
 });
 
 /** Boot the notifications extension against a real NotificationServer + WS client. */
-async function setup(): Promise<{
+async function setup(options: { contextUsage?: TestContextUsage | false; model?: TestModel | false } = {}): Promise<{
 	handlers: Map<string, Handler>;
 	ctx: unknown;
 	frames: Frame[];
@@ -62,8 +72,9 @@ async function setup(): Promise<{
 			getArtifactsDir: () => cwd,
 			getCwd: () => cwd,
 		},
-		getContextUsage: () => ({ tokens: 12, contextWindow: 100 }),
-		getModel: () => ({ id: "test-model" }),
+		getContextUsage: () =>
+			options.contextUsage === false ? undefined : (options.contextUsage ?? { tokens: 12, contextWindow: 100 }),
+		getModel: () => (options.model === false ? undefined : (options.model ?? { id: "test-model" })),
 	} as never;
 
 	await handlers.get("session_start")!({ type: "session_start" }, ctx);
@@ -180,7 +191,13 @@ test("inbound /verbose and /lean update runtime verbosity and confirmation polic
 
 		await handlers.get("agent_end")!({ type: "agent_end" }, ctx);
 		await waitFor(
-			() => contextUpdates().some(f => f.tokenUsage === "12/100" && f.model === "test-model"),
+			() =>
+				contextUpdates().some(
+					f =>
+						f.tokenUsage === "12/100" &&
+						f.model === "test-model" &&
+						f.cwd === path.basename((ctx as { cwd: string }).cwd),
+				),
 			3000,
 			"verbose context_update",
 		);
@@ -192,6 +209,35 @@ test("inbound /verbose and /lean update runtime verbosity and confirmation polic
 		await handlers.get("agent_end")!({ type: "agent_end" }, ctx);
 		await sleep(200);
 		expect(contextUpdates().length).toBe(beforeLeanIdle);
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
+	}
+}, 30000);
+
+test("verbose idle context includes compact cwd without usage metadata", async () => {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		const { handlers, ctx, frames, ws, token, sid } = await setup({ contextUsage: false, model: false });
+		const configUpdates = () => frames.filter(f => f.type === "config_update");
+		const contextUpdates = () => frames.filter(f => f.type === "context_update");
+
+		ws.send(JSON.stringify({ type: "config_command", sessionId: sid, token, verbosity: "verbose" }));
+		await waitFor(() => configUpdates().some(f => f.verbosity === "verbose"), 3000, "verbose config_update");
+
+		await handlers.get("agent_end")!({ type: "agent_end" }, ctx);
+		await waitFor(
+			() =>
+				contextUpdates().some(
+					f =>
+						f.cwd === path.basename((ctx as { cwd: string }).cwd) &&
+						f.tokenUsage === undefined &&
+						f.model === undefined,
+				),
+			3000,
+			"cwd-only verbose context_update",
+		);
 	} finally {
 		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
 		else process.env.GJC_NOTIFICATIONS = prevEnv;


### PR DESCRIPTION
## Summary
- add compact cwd metadata to verbose Telegram context updates without exposing full host paths
- render session id and cwd in threaded Telegram context updates
- cover cwd-only verbose updates and Rust wire serialization

## Verification
- bun test packages/coding-agent/test/notifications-threaded-render.test.ts packages/coding-agent/test/notifications-turn-ordering.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts
- cargo test -p gjc-notifications protocol
- bun run check:ts (passes; existing ultragoal-runtime unused-variable warnings remain)

Closes #1343

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*