### PR TITLE
Fix web_search provider preference fallback

### DIFF
--- a/packages/coding-agent/src/cli/web-search-cli.ts
+++ b/packages/coding-agent/src/cli/web-search-cli.ts
@@ -9,6 +9,7 @@ import chalk from "chalk";
 import { Settings } from "../config/settings";
 import { initTheme, theme } from "../modes/theme/theme";
 import {
+	getConfiguredSearchProviderPreference,
 	isConfigurableSearchProviderId,
 	isSearchProviderPreference,
 	runSearchQuery,
@@ -170,8 +171,8 @@ export async function runSearchCommand(cmd: SearchCommandArgs): Promise<void> {
 
 	await initTheme();
 	const settings = await Settings.init();
-	const configuredProvider = settings.get("providers.webSearch");
-	if (typeof configuredProvider === "string" && isSearchProviderPreference(configuredProvider)) {
+	const configuredProvider = getConfiguredSearchProviderPreference(settings);
+	if (isSearchProviderPreference(configuredProvider)) {
 		setPreferredSearchProvider(configuredProvider);
 	}
 	const configuredFallback = settings.get("web_search.fallback");

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2210,6 +2210,11 @@ export const SETTINGS_SCHEMA = {
 		ui: { tab: "tools", label: "Web Search", description: "Enable the web_search tool for web searching" },
 	},
 
+	"web_search.provider": {
+		type: "enum",
+		values: ["auto", ...CONFIGURABLE_SEARCH_PROVIDER_IDS] as const,
+		default: "auto",
+	},
 	"web_search.fallback": {
 		type: "array",
 		default: EMPTY_STRING_ARRAY,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -127,10 +127,10 @@ import {
 	EditTool,
 	EvalTool,
 	FindTool,
+	getConfiguredSearchProviderPreference,
 	getSearchTools,
 	HIDDEN_TOOLS,
 	isConfigurableSearchProviderId,
-	isSearchProviderPreference,
 	type LspStartupServerInfo,
 	loadSshTool,
 	ReadTool,
@@ -932,10 +932,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	slashCommandsPromise.catch(() => {});
 
 	// Initialize provider preferences from settings
-	const webSearchProvider = settings.get("providers.webSearch");
-	if (typeof webSearchProvider === "string" && isSearchProviderPreference(webSearchProvider)) {
-		setPreferredSearchProvider(webSearchProvider);
-	}
+	const webSearchProvider = getConfiguredSearchProviderPreference(settings);
+	setPreferredSearchProvider(webSearchProvider);
 	const webSearchFallback = settings.get("web_search.fallback");
 	if (Array.isArray(webSearchFallback)) {
 		setSearchFallbackProviders(

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -68,6 +68,18 @@ function formatProviderError(error: unknown, provider: SearchProvider): string {
 	return `Unknown error from ${provider.label}`;
 }
 
+function formatProviderFailure(error: unknown, provider: SearchProvider): string {
+	if (error instanceof SearchProviderError) return error.message;
+	return `${provider.id}: ${formatProviderError(error, provider)}`;
+}
+
+function formatFallbackWarning(
+	failures: Array<{ provider: SearchProvider; error: unknown }>,
+	provider: SearchProvider,
+): string {
+	return `Web search provider fallback: ${failures.map(f => formatProviderFailure(f.error, f.provider)).join("; ")}; using ${provider.label}.`;
+}
+
 /** Truncate text for tool output */
 function truncateText(text: string, maxLen: number): string {
 	if (text.length <= maxLen) return text;
@@ -185,10 +197,11 @@ async function executeSearch(
 			});
 
 			const text = formatForLLM(response);
+			const warning = failures.length > 0 ? formatFallbackWarning(failures, provider) : undefined;
 
 			return {
-				content: [{ type: "text" as const, text }],
-				details: { response },
+				content: [{ type: "text" as const, text: warning ? `Warning: ${warning}\n\n${text}` : text }],
+				details: { response, ...(warning ? { warning } : {}) },
 			};
 		} catch (error) {
 			// Surface user-initiated cancellation immediately so the session sees
@@ -207,13 +220,7 @@ async function executeSearch(
 		: `Unknown error from ${lastProvider.label}`;
 	const message =
 		providers.length > 1
-			? `All web search providers failed: ${failures
-					.map(f =>
-						f.error instanceof SearchProviderError
-							? f.error.message
-							: `${f.provider.id}: ${formatProviderError(f.error, f.provider)}`,
-					)
-					.join("; ")}`
+			? `All web search providers failed: ${failures.map(f => formatProviderFailure(f.error, f.provider)).join("; ")}`
 			: baseMessage;
 
 	return {
@@ -321,7 +328,12 @@ export function getSearchTools(): CustomTool<any, any>[] {
 	return [webSearchCustomTool];
 }
 
-export { getSearchProvider, setPreferredSearchProvider, setSearchFallbackProviders } from "./provider";
+export {
+	getConfiguredSearchProviderPreference,
+	getSearchProvider,
+	setPreferredSearchProvider,
+	setSearchFallbackProviders,
+} from "./provider";
 export { setSearchHardTimeoutMs } from "./providers/utils";
 export type { SearchProviderId as SearchProvider, SearchResponse } from "./types";
 export { isConfigurableSearchProviderId, isSearchProviderPreference } from "./types";

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -149,6 +149,21 @@ export function setSearchFallbackProviders(ids: readonly string[]): void {
 	fallbackProvIds = ids.filter(isConfigurableSearchProviderId);
 }
 
+export interface SearchProviderPreferenceSource {
+	get(path: "providers.webSearch" | "web_search.provider"): SearchProviderId | "auto";
+	has(path: "providers.webSearch" | "web_search.provider"): boolean;
+}
+
+export function getConfiguredSearchProviderPreference(
+	settings: SearchProviderPreferenceSource,
+): SearchProviderId | "auto" {
+	const providerPreference = settings.get("providers.webSearch");
+	if (settings.has("providers.webSearch") || providerPreference !== "auto") return providerPreference;
+
+	const legacyProviderPreference = settings.get("web_search.provider");
+	return legacyProviderPreference;
+}
+
 export interface ResolveProviderChainOptions {
 	authStorage: AuthStorage;
 	sessionId?: string;

--- a/packages/coding-agent/src/web/search/render.ts
+++ b/packages/coding-agent/src/web/search/render.ts
@@ -66,6 +66,7 @@ function renderFallbackText(contentText: string, expanded: boolean, theme: Theme
 export interface SearchRenderDetails {
 	response: SearchResponse;
 	error?: string;
+	warning?: string;
 }
 
 /** Render web search result with tree-based layout */
@@ -130,6 +131,8 @@ export function renderSearchResult(
 
 	const metaLines: string[] = [];
 	metaLines.push(`${theme.fg("muted", "Provider:")} ${theme.fg("text", providerLabel)}`);
+	if (details.warning)
+		metaLines.push(`${theme.fg("muted", "Fallback:")} ${theme.fg("warning", truncateToWidth(details.warning, 110))}`);
 	if (response.authMode)
 		metaLines.push(
 			`${theme.fg("muted", "Auth:")} ${theme.fg("text", response.authMode === "oauth" ? "OAuth" : response.authMode === "api_key" ? "API key" : response.authMode)}`,

--- a/packages/coding-agent/test/tools/web-search-insane.test.ts
+++ b/packages/coding-agent/test/tools/web-search-insane.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { hookFetch } from "@gajae-code/utils";
 import type { AuthStorage } from "../../src/session/auth-storage";
-import { runSearchQuery } from "../../src/web/search";
+import { runSearchQuery, setPreferredSearchProvider } from "../../src/web/search";
 import { InsaneProvider, routeInsanePublicUrl, searchInsane } from "../../src/web/search/providers/insane";
 
 const REDDIT_FEED = `<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom">
@@ -11,6 +11,10 @@ const REDDIT_FEED = `<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/At
 function fakeAuth(): AuthStorage {
 	return { hasAuth: () => false, hasOAuth: () => false, getApiKey: () => undefined } as unknown as AuthStorage;
 }
+
+afterEach(() => {
+	setPreferredSearchProvider("auto");
+});
 
 describe("Insane public-route provider", () => {
 	it("is keyless and selectable", () => {
@@ -71,6 +75,26 @@ describe("Insane public-route provider", () => {
 		const result = await runSearchQuery({ query: "reddit test", provider: "insane" }, { authStorage: fakeAuth() });
 		expect(result.details.response.provider).toBe("insane");
 		expect(result.content[0]?.text).toContain("Reddit Post");
+	});
+
+	it("emits a diagnostic when configured Insane falls back to DuckDuckGo", async () => {
+		setPreferredSearchProvider("insane");
+		using _hook = hookFetch(input => {
+			const url = input.toString();
+			if (url.startsWith("https://html.duckduckgo.com")) {
+				return new Response(
+					`<a class="result__a" href="//duckduckgo.com/l/?uddg=${encodeURIComponent("https://example.com/plain")}">Plain</a><a class="result__snippet">plain snippet</a>`,
+					{ status: 200 },
+				);
+			}
+			return new Response("", { status: 404 });
+		});
+
+		const result = await runSearchQuery({ query: "plain web" }, { authStorage: fakeAuth() });
+		expect(result.details.response.provider).toBe("duckduckgo");
+		expect(result.details.warning).toContain("insane");
+		expect(result.details.warning).toContain("using DuckDuckGo");
+		expect(result.content[0]?.text).toContain("Warning: Web search provider fallback");
 	});
 
 	it("fails closed when only block pages are available", async () => {

--- a/packages/coding-agent/test/web/search/config-schema.test.ts
+++ b/packages/coding-agent/test/web/search/config-schema.test.ts
@@ -45,6 +45,15 @@ describe("web search config schema", () => {
 		expect(webSearch.ui?.options).toContainEqual(expect.objectContaining({ value: "tavily", label: "Tavily" }));
 	});
 
+	it("accepts web_search.provider as a compatibility alias", () => {
+		const webSearchProvider = SETTINGS_SCHEMA["web_search.provider"];
+		expect(webSearchProvider.type).toBe("enum");
+		expect(webSearchProvider.values).toContain("insane");
+		expect(webSearchProvider.values).toContain("duckduckgo");
+		expect(webSearchProvider.default).toBe("auto");
+		expect(Settings.isolated({ "web_search.provider": "insane" }).get("web_search.provider")).toBe("insane");
+	});
+
 	it("defines web.insaneFallback as a boolean defaulting to false", () => {
 		const setting = SETTINGS_SCHEMA["web.insaneFallback"];
 		expect(setting.type).toBe("boolean");

--- a/packages/coding-agent/test/web/search/web-search-cli.test.ts
+++ b/packages/coding-agent/test/web/search/web-search-cli.test.ts
@@ -120,4 +120,33 @@ describe("web search CLI settings", () => {
 		expect(fetchSpy).toHaveBeenCalled();
 		expect(Bun.stripANSI(output)).toContain("Provider: xAI");
 	});
+
+	it("honors legacy web_search.provider when providers.webSearch is unset", async () => {
+		await Settings.init({
+			agentDir: testAgentDir,
+			inMemory: true,
+			overrides: { "web_search.provider": "insane" },
+		});
+
+		vi.spyOn(globalThis, "fetch").mockImplementation((async input => {
+			const url = input.toString();
+			if (url === "https://www.reddit.com/r/test/.rss") {
+				return new Response(
+					`<?xml version="1.0"?><feed><entry><title>Alias Provider</title><link href="https://www.reddit.com/r/test/comments/1"/><content>via alias</content></entry></feed>`,
+					{ status: 200 },
+				);
+			}
+			return new Response("", { status: 404 });
+		}) as typeof fetch);
+		let output = "";
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			output += String(chunk);
+			return true;
+		});
+
+		await runSearchCommand({ query: "https://www.reddit.com/r/test", expanded: false });
+
+		expect(Bun.stripANSI(output)).toContain("Provider: Insane");
+		expect(Bun.stripANSI(output)).toContain("Alias Provider");
+	});
 });

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1723,6 +1723,30 @@
 					"description": "Enable the web_search tool for web searching",
 					"default": true
 				},
+				"provider": {
+					"type": "string",
+					"enum": [
+						"auto",
+						"duckduckgo",
+						"insane",
+						"exa",
+						"brave",
+						"jina",
+						"kimi",
+						"zai",
+						"anthropic",
+						"perplexity",
+						"gemini",
+						"codex",
+						"xai",
+						"tavily",
+						"parallel",
+						"kagi",
+						"synthetic",
+						"searxng"
+					],
+					"default": "auto"
+				},
 				"fallback": {
 					"type": "array",
 					"items": {


### PR DESCRIPTION
Closes #1347.

## Summary
- Honor the compatibility `web_search.provider` setting when `providers.webSearch` is unset, so `provider=insane` style config no longer silently defaults to DuckDuckGo.
- Preserve default DuckDuckGo behavior and keep `providers.webSearch` precedence when explicitly set.
- Surface fallback diagnostics in tool output/render details when a selected provider fails and execution falls through to another provider.

## Verification
- `bun test packages/coding-agent/test/tools/web-search-insane.test.ts packages/coding-agent/test/web/search/web-search-cli.test.ts packages/coding-agent/test/web/search/config-schema.test.ts packages/coding-agent/test/tools/web-search-duckduckgo.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun run check:schemas`
- `bun run check:tools` (passes with existing warnings in `packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts`)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*