### PR TITLE
Fix Telegram message chunking

### DIFF
--- a/packages/coding-agent/src/notifications/html-format.ts
+++ b/packages/coding-agent/src/notifications/html-format.ts
@@ -248,6 +248,8 @@ interface Token {
 	value: string;
 	/** Tag name if this token opens a tag, else undefined. */
 	open?: string;
+	/** Exact opening tag text, including attributes, for safe chunk reopening. */
+	openTag?: string;
 	/** Tag name if this token closes a tag, else undefined. */
 	close?: string;
 }
@@ -266,8 +268,10 @@ function tokenize(html: string): Token[] {
 				const openMatch = /^<([a-z-]+)(?:\s[^>]*)?>$/i.exec(raw);
 				const token: Token = { value: raw };
 				if (close && ALLOWED_TAGS.has(close[1]!.toLowerCase())) token.close = close[1]!.toLowerCase();
-				else if (openMatch && ALLOWED_TAGS.has(openMatch[1]!.toLowerCase()))
+				else if (openMatch && ALLOWED_TAGS.has(openMatch[1]!.toLowerCase())) {
 					token.open = openMatch[1]!.toLowerCase();
+					token.openTag = raw;
+				}
 				tokens.push(token);
 				i = end + 1;
 				continue;
@@ -328,6 +332,53 @@ export function truncateTelegramHtml(message: string, max = TELEGRAM_MESSAGE_LIM
 	}
 
 	return out + closersFor(stack) + effectiveMarker;
+}
+
+interface OpenTag {
+	name: string;
+	tag: string;
+}
+
+/** Split a finished Telegram HTML message into ordered chunks without splitting tags or entities. */
+export function splitTelegramHtml(message: string, max = TELEGRAM_MESSAGE_LIMIT): string[] {
+	if (message.length <= max) return [message];
+	const chunks: string[] = [];
+	const tokens = tokenize(message);
+	const stack: OpenTag[] = [];
+	let out = "";
+	let chunkHasBody = false;
+
+	const closersFor = (s: OpenTag[]): string =>
+		s
+			.map(t => `</${t.name}>`)
+			.reverse()
+			.join("");
+	const openersFor = (s: OpenTag[]): string => s.map(t => t.tag).join("");
+	const flush = (): void => {
+		if (!chunkHasBody) return;
+		chunks.push(out + closersFor(stack));
+		out = openersFor(stack);
+		chunkHasBody = false;
+	};
+
+	for (const token of tokens) {
+		const nextStack = [...stack];
+		if (token.open) nextStack.push({ name: token.open, tag: token.openTag ?? token.value });
+		else if (token.close) {
+			const idx = nextStack.findLastIndex(t => t.name === token.close);
+			if (idx !== -1) nextStack.splice(idx, 1);
+		}
+		if (chunkHasBody && out.length + token.value.length + closersFor(nextStack).length > max) flush();
+		out += token.value;
+		chunkHasBody = true;
+		if (token.open) stack.push({ name: token.open, tag: token.openTag ?? token.value });
+		else if (token.close) {
+			const idx = stack.findLastIndex(t => t.name === token.close);
+			if (idx !== -1) stack.splice(idx, 1);
+		}
+	}
+	if (chunkHasBody) chunks.push(out + closersFor(stack));
+	return chunks;
 }
 
 /** Finalize an optional message: undefined passthrough, else safe-truncate. */

--- a/packages/coding-agent/src/notifications/html-format.ts
+++ b/packages/coding-agent/src/notifications/html-format.ts
@@ -354,6 +354,7 @@ export function splitTelegramHtml(message: string, max = TELEGRAM_MESSAGE_LIMIT)
 			.reverse()
 			.join("");
 	const openersFor = (s: OpenTag[]): string => s.map(t => t.tag).join("");
+	const minimumChunkLengthFor = (s: OpenTag[]): number => openersFor(s).length + closersFor(s).length + 1;
 	const flush = (): void => {
 		if (!chunkHasBody) return;
 		chunks.push(out + closersFor(stack));
@@ -361,21 +362,43 @@ export function splitTelegramHtml(message: string, max = TELEGRAM_MESSAGE_LIMIT)
 		chunkHasBody = false;
 	};
 
+	const updateStackForClose = (name: string): boolean => {
+		const idx = stack.findLastIndex(t => t.name === name);
+		if (idx === -1) return false;
+		stack.splice(idx, 1);
+		return true;
+	};
+
 	for (const token of tokens) {
-		const nextStack = [...stack];
-		if (token.open) nextStack.push({ name: token.open, tag: token.openTag ?? token.value });
-		else if (token.close) {
-			const idx = nextStack.findLastIndex(t => t.name === token.close);
-			if (idx !== -1) nextStack.splice(idx, 1);
+		if (token.open) {
+			const nextStack = [...stack, { name: token.open, tag: token.openTag ?? token.value }];
+			if (minimumChunkLengthFor(nextStack) > max) continue;
+			if (chunkHasBody && out.length + token.value.length + closersFor(nextStack).length > max) flush();
+			if (out.length + token.value.length + closersFor(nextStack).length > max) continue;
+			out += token.value;
+			chunkHasBody = true;
+			stack.push({ name: token.open, tag: token.openTag ?? token.value });
+			continue;
 		}
-		if (chunkHasBody && out.length + token.value.length + closersFor(nextStack).length > max) flush();
+
+		if (token.close) {
+			const idx = stack.findLastIndex(t => t.name === token.close);
+			if (idx === -1) continue;
+			const nextStack = stack.toSpliced(idx, 1);
+			if (chunkHasBody && out.length + token.value.length + closersFor(nextStack).length > max) flush();
+			if (out.length + token.value.length + closersFor(nextStack).length > max) {
+				updateStackForClose(token.close);
+				continue;
+			}
+			out += token.value;
+			chunkHasBody = true;
+			updateStackForClose(token.close);
+			continue;
+		}
+
+		if (chunkHasBody && out.length + token.value.length + closersFor(stack).length > max) flush();
 		out += token.value;
 		chunkHasBody = true;
-		if (token.open) stack.push({ name: token.open, tag: token.openTag ?? token.value });
-		else if (token.close) {
-			const idx = stack.findLastIndex(t => t.name === token.close);
-			if (idx !== -1) stack.splice(idx, 1);
-		}
 	}
 	if (chunkHasBody) chunks.push(out + closersFor(stack));
 	return chunks;

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -11,7 +11,13 @@ import { resolveGjcRuntimeSpawnInfo } from "../daemon/runtime";
 import { getNotificationConfig, isGloballyConfigured, tokenFingerprint } from "./config";
 import { parseInThreadConfigCommand } from "./config-commands";
 import { daemonPaths } from "./daemon-paths";
-import { buildCompactChoiceGrid, TELEGRAM_PARSE_MODE } from "./html-format";
+import {
+	buildCompactChoiceGrid,
+	pre,
+	splitTelegramHtml,
+	TELEGRAM_MESSAGE_LIMIT,
+	TELEGRAM_PARSE_MODE,
+} from "./html-format";
 import type {
 	SessionCloseTarget,
 	SessionCreateTarget,
@@ -121,6 +127,21 @@ const TYPING_REFRESH_INTERVAL_MS = 4_000;
 const QUEUED_REACTION = "👀";
 const PENDING_TOPIC_FRAME_LIMIT = 20;
 const CONSUMED_REACTION = "✅";
+
+function splitTelegramPlainText(text: string, max = TELEGRAM_MESSAGE_LIMIT): string[] {
+	if (text.length <= max) return [text];
+	const chunks: string[] = [];
+	let out = "";
+	for (const ch of text) {
+		if (out.length + ch.length > max) {
+			chunks.push(out);
+			out = "";
+		}
+		out += ch;
+	}
+	if (out) chunks.push(out);
+	return chunks;
+}
 
 /**
  * Whether `err` is a transient network failure worth retrying. Telegram API
@@ -1053,14 +1074,29 @@ export class TelegramNotificationDaemon {
 		threadId: number | undefined,
 	): Promise<boolean> {
 		if (!isLifecycleCommandText(text)) return false;
-		const reply = (body: string) =>
-			this.botApi
-				.call("sendMessage", {
-					chat_id: this.opts.chatId,
-					...(threadId !== undefined ? { message_thread_id: threadId } : {}),
-					text: body,
-				})
-				.catch(() => undefined);
+		const reply = async (body: string): Promise<void> => {
+			for (const text of splitTelegramPlainText(body)) {
+				await this.botApi
+					.call("sendMessage", {
+						chat_id: this.opts.chatId,
+						...(threadId !== undefined ? { message_thread_id: threadId } : {}),
+						text,
+					})
+					.catch(() => undefined);
+			}
+		};
+		const replyHtml = async (body: string): Promise<void> => {
+			for (const text of splitTelegramHtml(body)) {
+				await this.botApi
+					.call("sendMessage", {
+						chat_id: this.opts.chatId,
+						...(threadId !== undefined ? { message_thread_id: threadId } : {}),
+						text,
+						parse_mode: TELEGRAM_PARSE_MODE,
+					})
+					.catch(() => undefined);
+			}
+		};
 
 		if (!this.lifecycleControlActive) {
 			await reply("Session lifecycle control is not available right now.");
@@ -1081,9 +1117,9 @@ export class TelegramNotificationDaemon {
 				limit: 10,
 			});
 			const lines = recent.length
-				? recent.map(e => `\u2022 ${e.sessionId}${e.path ? ` (${e.path})` : ""}`).join("\n")
+				? recent.map(e => `• ${e.sessionId}${e.path ? ` (${e.path})` : ""}`).join("\n")
 				: "No recent sessions.";
-			await reply(lines);
+			await replyHtml(pre(lines));
 			return true;
 		}
 
@@ -1612,12 +1648,14 @@ export class TelegramNotificationDaemon {
 						parse_mode: TELEGRAM_PARSE_MODE,
 					});
 				} else if (send.text) {
-					await this.botApi.call("sendMessage", {
-						chat_id: this.opts.chatId,
-						...threadField,
-						text: send.text,
-						parse_mode: TELEGRAM_PARSE_MODE,
-					});
+					for (const text of splitTelegramHtml(send.text)) {
+						await this.botApi.call("sendMessage", {
+							chat_id: this.opts.chatId,
+							...threadField,
+							text,
+							parse_mode: TELEGRAM_PARSE_MODE,
+						});
+					}
 				}
 			} catch {
 				// Best-effort: a failed send must never stop the daemon.
@@ -1820,13 +1858,17 @@ export class TelegramNotificationDaemon {
 			const inline_keyboard = buildCompactChoiceGrid(options, (i: number) =>
 				this.aliasTable.put({ sessionId: session.sessionId, actionId: msg.id, answer: i }),
 			);
-			const result = (await this.botApi.call("sendMessage", {
-				chat_id: this.opts.chatId,
-				...threadField,
-				text: rendered.text,
-				parse_mode: TELEGRAM_PARSE_MODE,
-				...(inline_keyboard.length ? { reply_markup: { inline_keyboard } } : {}),
-			})) as { result?: { message_id?: number } };
+			const chunks = splitTelegramHtml(rendered.text);
+			let result: { result?: { message_id?: number } } = {};
+			for (let i = 0; i < chunks.length; i++) {
+				result = (await this.botApi.call("sendMessage", {
+					chat_id: this.opts.chatId,
+					...threadField,
+					text: chunks[i]!,
+					parse_mode: TELEGRAM_PARSE_MODE,
+					...(i === chunks.length - 1 && inline_keyboard.length ? { reply_markup: { inline_keyboard } } : {}),
+				})) as { result?: { message_id?: number } };
+			}
 			const messageId = result.result?.message_id;
 			if (messageId !== undefined)
 				this.messageRoutes.set(String(messageId), { sessionId: session.sessionId, actionId: msg.id });

--- a/packages/coding-agent/src/notifications/telegram-reference.ts
+++ b/packages/coding-agent/src/notifications/telegram-reference.ts
@@ -37,6 +37,8 @@ export interface RenderedMessage {
 	inline_keyboard?: InlineButton[][];
 }
 
+type TelegramSend = (method: string, body: unknown) => Promise<Response>;
+
 /** Encode `actionId` + option `index` into Telegram callback_data (<=64 bytes). */
 export function encodeCallbackData(actionId: string, index: number): string {
 	return `r:${index}:${actionId}`.slice(0, 64);
@@ -139,6 +141,24 @@ export function buildActionMessage(action: {
 	const body = `${text}\n\n${numberedOptionList(options)}`;
 	const inline_keyboard = buildCompactChoiceGrid(options, i => encodeCallbackData(action.id, i));
 	return { text: body, inline_keyboard };
+}
+
+/** Send Telegram HTML text chunks sequentially so long messages preserve order. */
+export async function sendTelegramHtmlChunks(
+	send: TelegramSend,
+	chatId: string,
+	text: string,
+	inlineKeyboard?: InlineButton[][],
+): Promise<void> {
+	const chunks = splitTelegramHtml(text);
+	for (let i = 0; i < chunks.length; i++) {
+		await send("sendMessage", {
+			chat_id: chatId,
+			text: chunks[i]!,
+			parse_mode: TELEGRAM_PARSE_MODE,
+			...(i === chunks.length - 1 && inlineKeyboard ? { reply_markup: { inline_keyboard: inlineKeyboard } } : {}),
+		});
+	}
 }
 
 /** A protocol `reply` frame the client should send to the server. */
@@ -285,15 +305,15 @@ export async function runTelegramReferenceClient(opts: TelegramReferenceOptions)
 	const ws = new WebSocket(`${url}/?token=${encodeURIComponent(token)}`);
 	let latestPendingAskId: string | undefined;
 
-	const send = (method: string, body: unknown): Promise<Response> =>
+	const send: TelegramSend = (method, body) =>
 		fetchImpl(`${api}/${method}`, {
 			method: "POST",
 			headers: { "content-type": "application/json" },
 			body: JSON.stringify(body),
 		});
 
-	ws.addEventListener("message", (ev: MessageEvent) => {
-		const msg = JSON.parse(String(ev.data)) as {
+	const handleServerMessage = async (data: string): Promise<void> => {
+		const msg = JSON.parse(data) as {
 			type: string;
 			kind?: "ask" | "idle";
 			id?: string;
@@ -311,17 +331,7 @@ export async function runTelegramReferenceClient(opts: TelegramReferenceOptions)
 				options: msg.options,
 				summary: msg.summary,
 			});
-			const chunks = splitTelegramHtml(rendered.text);
-			chunks.forEach((text, i) => {
-				void send("sendMessage", {
-					chat_id: opts.chatId,
-					text,
-					parse_mode: TELEGRAM_PARSE_MODE,
-					...(i === chunks.length - 1 && rendered.inline_keyboard
-						? { reply_markup: { inline_keyboard: rendered.inline_keyboard } }
-						: {}),
-				});
-			});
+			await sendTelegramHtmlChunks(send, opts.chatId, rendered.text, rendered.inline_keyboard);
 		} else if (msg.type === "action_resolved" && msg.id === latestPendingAskId) {
 			latestPendingAskId = undefined;
 		} else {
@@ -330,11 +340,16 @@ export async function runTelegramReferenceClient(opts: TelegramReferenceOptions)
 			// session's forum topic; this reference shows the minimal handling.
 			const threaded = renderThreadedFrame(msg as never);
 			if (threaded?.text) {
-				for (const text of splitTelegramHtml(threaded.text)) {
-					void send("sendMessage", { chat_id: opts.chatId, text, parse_mode: TELEGRAM_PARSE_MODE });
-				}
+				await sendTelegramHtmlChunks(send, opts.chatId, threaded.text);
 			}
 		}
+	};
+
+	let messageQueue = Promise.resolve();
+	ws.addEventListener("message", ev => {
+		const data = String(ev.data);
+		messageQueue = messageQueue.catch(() => undefined).then(() => handleServerMessage(data));
+		void messageQueue.catch(() => undefined);
 	});
 
 	// Telegram long-poll loop.

--- a/packages/coding-agent/src/notifications/telegram-reference.ts
+++ b/packages/coding-agent/src/notifications/telegram-reference.ts
@@ -20,8 +20,8 @@ import {
 	buildCompactChoiceGrid,
 	escapeHtml,
 	numberedOptionList,
+	splitTelegramHtml,
 	TELEGRAM_PARSE_MODE,
-	truncateTelegramHtml,
 } from "./html-format";
 import { renderThreadedFrame } from "./threaded-render";
 
@@ -131,14 +131,14 @@ export function buildActionMessage(action: {
 }): RenderedMessage {
 	if (action.kind === "idle") {
 		const text = action.summary ? `🟢 Agent idle\n${escapeHtml(action.summary)}` : "🟢 Agent idle";
-		return { text: truncateTelegramHtml(text) };
+		return { text };
 	}
 	const text = `❓ ${bold(action.question ?? "Question")}`;
 	const options = action.options ?? [];
-	if (options.length === 0) return { text: truncateTelegramHtml(`${text}\n\n(reply with text)`) };
+	if (options.length === 0) return { text: `${text}\n\n(reply with text)` };
 	const body = `${text}\n\n${numberedOptionList(options)}`;
 	const inline_keyboard = buildCompactChoiceGrid(options, i => encodeCallbackData(action.id, i));
-	return { text: truncateTelegramHtml(body), inline_keyboard };
+	return { text: body, inline_keyboard };
 }
 
 /** A protocol `reply` frame the client should send to the server. */
@@ -311,11 +311,16 @@ export async function runTelegramReferenceClient(opts: TelegramReferenceOptions)
 				options: msg.options,
 				summary: msg.summary,
 			});
-			void send("sendMessage", {
-				chat_id: opts.chatId,
-				text: rendered.text,
-				parse_mode: TELEGRAM_PARSE_MODE,
-				...(rendered.inline_keyboard ? { reply_markup: { inline_keyboard: rendered.inline_keyboard } } : {}),
+			const chunks = splitTelegramHtml(rendered.text);
+			chunks.forEach((text, i) => {
+				void send("sendMessage", {
+					chat_id: opts.chatId,
+					text,
+					parse_mode: TELEGRAM_PARSE_MODE,
+					...(i === chunks.length - 1 && rendered.inline_keyboard
+						? { reply_markup: { inline_keyboard: rendered.inline_keyboard } }
+						: {}),
+				});
 			});
 		} else if (msg.type === "action_resolved" && msg.id === latestPendingAskId) {
 			latestPendingAskId = undefined;
@@ -325,7 +330,9 @@ export async function runTelegramReferenceClient(opts: TelegramReferenceOptions)
 			// session's forum topic; this reference shows the minimal handling.
 			const threaded = renderThreadedFrame(msg as never);
 			if (threaded?.text) {
-				void send("sendMessage", { chat_id: opts.chatId, text: threaded.text, parse_mode: TELEGRAM_PARSE_MODE });
+				for (const text of splitTelegramHtml(threaded.text)) {
+					void send("sendMessage", { chat_id: opts.chatId, text, parse_mode: TELEGRAM_PARSE_MODE });
+				}
 			}
 		}
 	});

--- a/packages/coding-agent/src/notifications/threaded-render.ts
+++ b/packages/coding-agent/src/notifications/threaded-render.ts
@@ -133,7 +133,7 @@ export function renderThreadedFrame(frame: ThreadedFrame): ThreadedSend | undefi
 		case "turn_stream": {
 			const raw = str(frame.text);
 			if (!raw) return undefined;
-			const text = finalizeTelegramHtml(markdownToTelegramHtml(raw));
+			const text = markdownToTelegramHtml(raw);
 			const finalized = frame.phase === "finalized";
 			return {
 				method: "sendMessage",

--- a/packages/coding-agent/test/notifications-html-format.test.ts
+++ b/packages/coding-agent/test/notifications-html-format.test.ts
@@ -130,6 +130,17 @@ describe("splitTelegramHtml", () => {
 		expect(chunks.every(chunk => !chunk.startsWith("<a>") && !chunk.includes("<a>"))).toBe(true);
 		expect(chunks.filter(chunk => chunk.startsWith("<a ")).length).toBeGreaterThan(1);
 	});
+
+	test("degrades oversized anchor tags instead of emitting over-limit chunks", () => {
+		const url = `https://example.com/${"x".repeat(TELEGRAM_MESSAGE_LIMIT + 100)}`;
+		const chunks = splitTelegramHtml(`<a href="${url}">label</a>`);
+
+		expect(chunks.length).toBeGreaterThan(0);
+		expect(chunks.every(chunk => chunk.length <= TELEGRAM_MESSAGE_LIMIT)).toBe(true);
+		expect(chunks.join("")).toBe("label");
+		expect(chunks.join("")).not.toContain("<a");
+		expect(chunks.join("")).not.toContain("</a>");
+	});
 });
 
 describe("button grid (AC6)", () => {

--- a/packages/coding-agent/test/notifications-html-format.test.ts
+++ b/packages/coding-agent/test/notifications-html-format.test.ts
@@ -10,6 +10,7 @@ import {
 	escapeHtml,
 	markdownToTelegramHtml,
 	numberedOptionList,
+	splitTelegramHtml,
 	TELEGRAM_MESSAGE_LIMIT,
 	TELEGRAM_PARSE_MODE,
 	truncateTelegramHtml,
@@ -100,6 +101,34 @@ describe("truncateTelegramHtml (AC7)", () => {
 		expect(out.length).toBeLessThanOrEqual(18);
 		expect(out).not.toMatch(/&amp$/);
 		expect(out).not.toMatch(/&$/);
+	});
+});
+
+describe("splitTelegramHtml", () => {
+	test("chunks long plain text below Telegram limit without dropping content", () => {
+		const raw = "a".repeat(TELEGRAM_MESSAGE_LIMIT + 25);
+		const chunks = splitTelegramHtml(raw);
+		expect(chunks).toHaveLength(2);
+		expect(chunks.every(chunk => chunk.length <= TELEGRAM_MESSAGE_LIMIT)).toBe(true);
+		expect(chunks.join("")).toBe(raw);
+	});
+
+	test("does not split HTML tags or entities and reopens preformatted blocks", () => {
+		const body = `<pre>${"x".repeat(40)}&amp;${"y".repeat(40)}</pre>`;
+		const chunks = splitTelegramHtml(body, 35);
+		expect(chunks.length).toBeGreaterThan(1);
+		expect(chunks.every(chunk => chunk.length <= 35)).toBe(true);
+		expect(chunks.every(chunk => !chunk.includes("&amp") || chunk.includes("&amp;"))).toBe(true);
+		expect(chunks.every(chunk => chunk.startsWith("<pre>") && chunk.endsWith("</pre>"))).toBe(true);
+	});
+
+	test("preserves opening tag attributes when reopening chunks", () => {
+		const body = `<a href="https://example.com/${"x".repeat(20)}">${"label".repeat(20)}</a>`;
+		const chunks = splitTelegramHtml(body, 70);
+		expect(chunks.length).toBeGreaterThan(1);
+		expect(chunks.every(chunk => chunk.length <= 70)).toBe(true);
+		expect(chunks.every(chunk => !chunk.startsWith("<a>") && !chunk.includes("<a>"))).toBe(true);
+		expect(chunks.filter(chunk => chunk.startsWith("<a ")).length).toBeGreaterThan(1);
 	});
 });
 
@@ -274,6 +303,30 @@ describe("daemon send sites force parse_mode HTML (AC1)", () => {
 		});
 		const send = bot.calls.find(c => c.method === "sendMessage");
 		expect(send?.body.parse_mode).toBe(TELEGRAM_PARSE_MODE);
+	});
+
+	test("long turn_stream sendMessage is split in order", async () => {
+		const bot = new CapturingBotApi();
+		const daemon = makeDaemon(bot, Bun.env.TMPDIR ?? "/tmp");
+		await daemon.handleSessionMessage(fakeSession() as any, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		const raw = "a".repeat(TELEGRAM_MESSAGE_LIMIT + 25);
+		await daemon.handleSessionMessage(fakeSession() as any, {
+			type: "turn_stream",
+			sessionId: "S",
+			phase: "finalized",
+			text: raw,
+		});
+		const texts = bot.calls
+			.filter(c => c.method === "sendMessage" && c.body.text?.startsWith("a"))
+			.map(c => String(c.body.text));
+		expect(texts).toHaveLength(2);
+		expect(texts.every(text => text.length <= TELEGRAM_MESSAGE_LIMIT)).toBe(true);
+		expect(texts.join("")).toBe(raw);
 	});
 
 	test("image_attachment sendPhoto sets parse_mode", async () => {

--- a/packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { Settings } from "../src/config/settings";
+import { TELEGRAM_PARSE_MODE } from "../src/notifications/html-format";
 import { TelegramNotificationDaemon } from "../src/notifications/telegram-daemon";
 
 function settings(agentDir: string): Settings {
@@ -51,6 +52,14 @@ function msg(chatId: string, text: string, updateId: number): unknown {
 	return { update_id: updateId, message: { chat: { id: chatId }, text, message_id: updateId } };
 }
 
+function writeSession(agentDir: string, project: string, id: string, header: object, mtimeMs: number): void {
+	const dir = path.join(agentDir, "sessions", project);
+	fs.mkdirSync(dir, { recursive: true });
+	const file = path.join(dir, `${id}.jsonl`);
+	fs.writeFileSync(file, `${JSON.stringify(header)}\n`);
+	fs.utimesSync(file, new Date(mtimeMs), new Date(mtimeMs));
+}
+
 describe("lifecycle command routing (G009)", () => {
 	test("a paired-chat /session_* command is detected and answered (no injection fallthrough)", async () => {
 		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-lc-route-"));
@@ -83,6 +92,31 @@ describe("lifecycle command routing (G009)", () => {
 		await daemon.handleTelegramUpdate(msg("42", "hello there", 3));
 		// Not a /session_* command -> no lifecycle not-available reply.
 		expect(calls.filter(c => c.method === "sendMessage").length).toBe(0);
+		fs.rmSync(agentDir, { recursive: true, force: true });
+	});
+	test("/session_recent is sent as escaped preformatted HTML chunks", async () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-lc-route-"));
+		const { calls, api } = spyBot();
+		const daemon = makeDaemon(agentDir, api);
+		(daemon as unknown as { lifecycleControlActive: boolean }).lifecycleControlActive = true;
+		for (let i = 0; i < 20; i++) {
+			writeSession(
+				agentDir,
+				"repo",
+				`s-${String(i).padStart(3, "0")}`,
+				{ cwd: `/repo/<tag>&branch/${"x".repeat(500)}` },
+				1000 + i,
+			);
+		}
+
+		await daemon.handleTelegramUpdate(msg("42", "/session_recent", 4));
+
+		const sends = calls.filter(c => c.method === "sendMessage");
+		expect(sends.length).toBeGreaterThan(1);
+		expect(sends.every(c => c.body?.parse_mode === TELEGRAM_PARSE_MODE)).toBe(true);
+		expect(sends.every(c => String(c.body?.text).length <= 4096)).toBe(true);
+		expect(String(sends[0]?.body?.text).startsWith("<pre>")).toBe(true);
+		expect(sends.map(c => String(c.body?.text)).join("")).toContain("/repo/&lt;tag&gt;&amp;branch");
 		fs.rmSync(agentDir, { recursive: true, force: true });
 	});
 });

--- a/packages/coding-agent/test/notifications-telegram-reference.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-reference.test.ts
@@ -5,6 +5,7 @@ import {
 	decodeCallbackData,
 	encodeCallbackData,
 	routeInboundUpdate,
+	sendTelegramHtmlChunks,
 	telegramUpdateToReply,
 } from "../src/notifications/telegram-reference";
 
@@ -123,6 +124,29 @@ describe("telegram reference client helpers", () => {
 		const idle = buildActionMessage({ kind: "idle", id: "i1", summary: "done" });
 		expect(idle.inline_keyboard).toBeUndefined();
 		expect(idle.text).toContain("done");
+	});
+
+	test("sendTelegramHtmlChunks awaits chunks sequentially and attaches keyboard to final chunk", async () => {
+		const calls: Array<{ method: string; body: Record<string, unknown> }> = [];
+		const releases: Array<() => void> = [];
+		const send = async (method: string, body: unknown): Promise<Response> => {
+			calls.push({ method, body: body as Record<string, unknown> });
+			await new Promise<void>(resolve => releases.push(resolve));
+			return new Response(JSON.stringify({ ok: true }));
+		};
+		const keyboard = [[{ text: "1", callback_data: "r:0:a1" }]];
+		const sending = sendTelegramHtmlChunks(send, "42", "a".repeat(4100), keyboard);
+
+		await Bun.sleep(0);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.body.reply_markup).toBeUndefined();
+		releases.shift()?.();
+		await Bun.sleep(0);
+		expect(calls).toHaveLength(2);
+		expect(calls[1]?.body.reply_markup).toEqual({ inline_keyboard: keyboard });
+		releases.shift()?.();
+		await sending;
+		expect(calls.map(call => call.method)).toEqual(["sendMessage", "sendMessage"]);
 	});
 
 	test("telegramUpdateToReply maps a button tap to an option index", () => {


### PR DESCRIPTION
Closes #1351

## Summary
- Split long Telegram HTML messages into ordered chunks without breaking tags or entities.
- Preserve action keyboards on the final chunk and chunk threaded/reference Telegram sends before the 4096-character limit.
- Render `/session_recent` as escaped preformatted HTML and chunk it safely.

## Tests run
- `bun test packages/coding-agent/test/notifications-html-format.test.ts packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts`
- `bunx biome check packages/coding-agent/src/notifications/html-format.ts packages/coding-agent/src/notifications/telegram-daemon.ts packages/coding-agent/src/notifications/telegram-reference.ts packages/coding-agent/src/notifications/threaded-render.ts packages/coding-agent/test/notifications-html-format.test.ts packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts`
- `bun run check:types` (from `packages/coding-agent`)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*