### PR TITLE
Chunk long Telegram messages and render /session_recent as code

### DIFF
--- a/packages/coding-agent/src/notifications/html-format.ts
+++ b/packages/coding-agent/src/notifications/html-format.ts
@@ -330,6 +330,55 @@ export function truncateTelegramHtml(message: string, max = TELEGRAM_MESSAGE_LIM
 	return out + closersFor(stack) + effectiveMarker;
 }
 
+/**
+ * Split a finished Telegram HTML message into ordered chunks that each fit
+ * within `max` chars, without splitting a tag or entity. Any allowed tags left
+ * open at a chunk boundary are closed at the end of that chunk and reopened at
+ * the start of the next, so every chunk is independently valid HTML. Returns a
+ * single-element array when the message already fits.
+ */
+export function chunkTelegramHtml(message: string, max = TELEGRAM_MESSAGE_LIMIT): string[] {
+	if (message.length <= max) return [message];
+
+	const tokens = tokenize(message);
+	const openersFor = (s: string[]): string => s.map(t => `<${t}>`).join("");
+	const closersFor = (s: string[]): string =>
+		s
+			.map(t => `</${t}>`)
+			.reverse()
+			.join("");
+
+	const chunks: string[] = [];
+	const stack: string[] = [];
+	let chunkStart: string[] = [];
+	let out = "";
+
+	for (const token of tokens) {
+		const nextStack = [...stack];
+		if (token.open) nextStack.push(token.open);
+		else if (token.close) {
+			const idx = nextStack.lastIndexOf(token.close);
+			if (idx !== -1) nextStack.splice(idx, 1);
+		}
+		const projected = openersFor(chunkStart).length + out.length + token.value.length + closersFor(nextStack).length;
+		// Flush the current chunk before it would overflow, but never emit an
+		// empty chunk (a single oversized token is kept whole).
+		if (projected > max && out.length > 0) {
+			chunks.push(openersFor(chunkStart) + out + closersFor(stack));
+			chunkStart = [...stack];
+			out = "";
+		}
+		out += token.value;
+		if (token.open) stack.push(token.open);
+		else if (token.close) {
+			const idx = stack.lastIndexOf(token.close);
+			if (idx !== -1) stack.splice(idx, 1);
+		}
+	}
+	if (out.length > 0) chunks.push(openersFor(chunkStart) + out + closersFor(stack));
+	return chunks;
+}
+
 /** Finalize an optional message: undefined passthrough, else safe-truncate. */
 export function finalizeTelegramHtml(message?: string): string | undefined {
 	if (message === undefined) return undefined;

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -11,7 +11,7 @@ import { resolveGjcRuntimeSpawnInfo } from "../daemon/runtime";
 import { getNotificationConfig, isGloballyConfigured, tokenFingerprint } from "./config";
 import { parseInThreadConfigCommand } from "./config-commands";
 import { daemonPaths } from "./daemon-paths";
-import { buildCompactChoiceGrid, TELEGRAM_PARSE_MODE } from "./html-format";
+import { buildCompactChoiceGrid, chunkTelegramHtml, code, TELEGRAM_PARSE_MODE } from "./html-format";
 import type {
 	SessionCloseTarget,
 	SessionCreateTarget,
@@ -1053,14 +1053,18 @@ export class TelegramNotificationDaemon {
 		threadId: number | undefined,
 	): Promise<boolean> {
 		if (!isLifecycleCommandText(text)) return false;
-		const reply = (body: string) =>
-			this.botApi
-				.call("sendMessage", {
-					chat_id: this.opts.chatId,
-					...(threadId !== undefined ? { message_thread_id: threadId } : {}),
-					text: body,
-				})
-				.catch(() => undefined);
+		const reply = async (body: string, parseMode?: string) => {
+			for (const chunk of chunkTelegramHtml(body)) {
+				await this.botApi
+					.call("sendMessage", {
+						chat_id: this.opts.chatId,
+						...(threadId !== undefined ? { message_thread_id: threadId } : {}),
+						text: chunk,
+						...(parseMode ? { parse_mode: parseMode } : {}),
+					})
+					.catch(() => undefined);
+			}
+		};
 
 		if (!this.lifecycleControlActive) {
 			await reply("Session lifecycle control is not available right now.");
@@ -1083,7 +1087,7 @@ export class TelegramNotificationDaemon {
 			const lines = recent.length
 				? recent.map(e => `\u2022 ${e.sessionId}${e.path ? ` (${e.path})` : ""}`).join("\n")
 				: "No recent sessions.";
-			await reply(lines);
+			await reply(code(lines), TELEGRAM_PARSE_MODE);
 			return true;
 		}
 
@@ -1612,12 +1616,14 @@ export class TelegramNotificationDaemon {
 						parse_mode: TELEGRAM_PARSE_MODE,
 					});
 				} else if (send.text) {
-					await this.botApi.call("sendMessage", {
-						chat_id: this.opts.chatId,
-						...threadField,
-						text: send.text,
-						parse_mode: TELEGRAM_PARSE_MODE,
-					});
+					for (const chunk of chunkTelegramHtml(send.text)) {
+						await this.botApi.call("sendMessage", {
+							chat_id: this.opts.chatId,
+							...threadField,
+							text: chunk,
+							parse_mode: TELEGRAM_PARSE_MODE,
+						});
+					}
 				}
 			} catch {
 				// Best-effort: a failed send must never stop the daemon.

--- a/packages/coding-agent/test/notifications-html-format.test.ts
+++ b/packages/coding-agent/test/notifications-html-format.test.ts
@@ -6,6 +6,7 @@ import {
 	buildCompactChoiceGrid,
 	buttonLabel,
 	choiceButtonLabel,
+	chunkTelegramHtml,
 	code,
 	escapeHtml,
 	markdownToTelegramHtml,
@@ -100,6 +101,45 @@ describe("truncateTelegramHtml (AC7)", () => {
 		expect(out.length).toBeLessThanOrEqual(18);
 		expect(out).not.toMatch(/&amp$/);
 		expect(out).not.toMatch(/&$/);
+	});
+});
+
+describe("chunkTelegramHtml", () => {
+	test("short messages return a single chunk unchanged", () => {
+		expect(chunkTelegramHtml("hello")).toEqual(["hello"]);
+	});
+
+	test("long plain text splits into ordered chunks each within the limit", () => {
+		const chunks = chunkTelegramHtml("a".repeat(10_000));
+		expect(chunks.length).toBeGreaterThan(1);
+		for (const chunk of chunks) {
+			expect(chunk.length).toBeLessThanOrEqual(TELEGRAM_MESSAGE_LIMIT);
+		}
+		expect(chunks.join("")).toBe("a".repeat(10_000));
+	});
+
+	test("closes and reopens an open tag across a boundary", () => {
+		const msg = `<code>${"x".repeat(30)}</code>`;
+		const chunks = chunkTelegramHtml(msg, 20);
+		expect(chunks.length).toBeGreaterThan(1);
+		for (const chunk of chunks) {
+			expect(chunk.length).toBeLessThanOrEqual(20);
+			expect(chunk.startsWith("<code>")).toBe(true);
+			expect(chunk.endsWith("</code>")).toBe(true);
+		}
+		// Concatenating the payloads (minus the injected close/reopen) reproduces the content.
+		const payload = chunks.map(c => c.replace(/^<code>/, "").replace(/<\/code>$/, "")).join("");
+		expect(payload).toBe("x".repeat(30));
+	});
+
+	test("never splits an entity across chunks", () => {
+		const msg = `${"a".repeat(15)}&amp;${"b".repeat(15)}`;
+		const chunks = chunkTelegramHtml(msg, 18);
+		for (const chunk of chunks) {
+			expect(chunk).not.toMatch(/&amp$/);
+			expect(chunk).not.toMatch(/&$/);
+		}
+		expect(chunks.join("")).toBe(msg);
 	});
 });
 


### PR DESCRIPTION
Closes #1351.

## What
- Add `chunkTelegramHtml(message, max)` to `html-format.ts`: splits a finished Telegram HTML message into ordered chunks that each fit within the 4096-char limit, never splitting a tag or entity. Allowed tags left open at a boundary are closed at the end of a chunk and reopened at the start of the next, so every chunk is independently valid HTML.
- Outbound session-frame deliveries (`flushPool`) and paired-chat lifecycle replies now send in chunks instead of a single over-limit message that Telegram would reject/clip.
- `/session_recent` output is now wrapped in `<code>` (content escaped) and sent with HTML parse mode, so the mostly-log content renders as preformatted text. Chunking reopens the `<code>` tag across boundaries, combining escaping + chunking safely.

## Testing
- New `chunkTelegramHtml` unit tests (single-chunk passthrough, plain-text splitting within limit, close/reopen of an open tag across boundaries, entity never split).
- `bun test test/notifications-html-format.test.ts` and the redteam / lifecycle-command / telegram-daemon suites pass.
- `biome check` clean on changed files.