### PR TITLE
docs(readme): mascot-first visual in workflow section (#1355)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ deep-interview -> ralplan -> ultragoal
                          └─ optional team execution when parallel tmux workers help
 ```
 
+<p align="center">
+  <img src="assets/character.png" alt="Gajae-Code mascot guiding the deep-interview to ralplan to ultragoal workflow loop" width="240" />
+</p>
+
 It is intentionally not a hidden plugin for Codex CLI, Claude Code, OpenCode, or Claw Code. Start `gjc` beside those tools when you want structured planning, persistent evidence, tmux-backed workers, or an isolated worktree.
 
 ## Install


### PR DESCRIPTION
Resolves #1355 (partial, in-scope).

## Context
The issue suggests a mascot-forward visual treatment for the README, proposing images near the hero, the `What is Gajae-Code?` workflow loop, and the pipeline explanation. The proposal images were direction-only and not attached, so this change reinforces the mascot presence using the existing `assets/character.png` asset.

## Change
- Adds the mascot character image directly under the `deep-interview -> ralplan -> ultragoal` workflow diagram in the `What is Gajae-Code?` section (the Image 2 placement from the suggestion).

## Scope
Minimal README-only diff (+4 lines), reusing an existing asset. No new binaries added.

(Re-opens the change from closed PR #1357 with a correct base branch.)