### PR TITLE
docs(git-daemon): add crate README note (#1359)

### DIFF
--- a/crates/git-daemon/README.md
+++ b/crates/git-daemon/README.md
@@ -1,0 +1,3 @@
+# git-daemon
+
+This crate is the autonomous per-repo git daemon that watches a repository and resolves referenced work items by opening reviewed pull requests.


### PR DESCRIPTION
Resolves #1359.

Creates crates/git-daemon/README.md with a single clarifying sentence describing that the crate is the autonomous per-repo git daemon. Diff is limited to that one new file.