### PR TITLE
Fix git daemon doc workspace member

### DIFF
--- a/crates/git-daemon/README.md
+++ b/crates/git-daemon/README.md
@@ -1,3 +1,0 @@
-# git-daemon
-
-This crate is the autonomous per-repo git daemon that watches a repository and resolves referenced work items by opening reviewed pull requests.

--- a/docs/git-daemon.md
+++ b/docs/git-daemon.md
@@ -1,0 +1,3 @@
+# Git daemon
+
+The git daemon is the autonomous per-repo service that watches a repository and resolves referenced work items by opening reviewed pull requests.


### PR DESCRIPTION
## Summary
- move the git daemon note from `crates/git-daemon/README.md` to `docs/git-daemon.md`
- remove the non-crate `crates/git-daemon` directory so the `crates/*` Cargo workspace glob no longer tries to load it

Fixes #1361

## Validation
- `cargo metadata --format-version 1 --no-deps`
- `bun run check:rs`
- `bun run test:rs`
- `bun run build`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*