### PR TITLE
test(coding-agent): allow builtin browser in quarantine

### DIFF
--- a/packages/coding-agent/test/utility-extensibility-quarantine.test.ts
+++ b/packages/coding-agent/test/utility-extensibility-quarantine.test.ts
@@ -34,7 +34,6 @@ describe("GJC utility extensibility quarantine", () => {
 			"reload-plugins",
 			"plan",
 			"share",
-			"browser",
 			"todo",
 			"changelog",
 			"branch",


### PR DESCRIPTION
## Summary
- updates the utility extensibility quarantine test contract now that `/browser` is an intentional builtin selector command from #1350
- keeps the repair minimal to the stale quarantine allowlist only

## Verification
- `bun test packages/coding-agent/test/utility-extensibility-quarantine.test.ts packages/coding-agent/test/slash-command-builtin-registry.test.ts`
- `bunx biome check packages/coding-agent/test/utility-extensibility-quarantine.test.ts --no-errors-on-unmatched`
- `bun --cwd=packages/natives run build`
- `bun run check:tools` (completed with existing warnings)

Repairs post-merge Dev CI run 28509998029 / job 84507820803 after #1350.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
