### PR TITLE
Hide internal sessions from Telegram recent list

### DIFF
--- a/packages/coding-agent/src/notifications/recent-activity.ts
+++ b/packages/coding-agent/src/notifications/recent-activity.ts
@@ -25,6 +25,8 @@ export interface RecentSessionEntry {
 	mtimeMs: number;
 	/** True when a terminal breadcrumb points at this session file. */
 	currentTerminal?: boolean;
+	/** True when this history is an internal helper/sub-agent session. */
+	internal?: boolean;
 }
 
 export interface RecentActivityDeps {
@@ -34,17 +36,18 @@ export interface RecentActivityDeps {
 	breadcrumbPaths?: string[];
 	/** Max entries to return (default 20). */
 	limit?: number;
+	/** Include internal helper/sub-agent sessions (default true). */
+	includeInternal?: boolean;
 	/** Injection seam for tests. */
-	readFirstLine?: (file: string) => string | undefined;
+	readInitialLines?: (file: string, maxLines: number) => string[];
 }
 
-function defaultReadFirstLine(file: string): string | undefined {
+function defaultReadInitialLines(file: string, maxLines: number): string[] {
 	try {
-		const buf = fs.readFileSync(file, "utf8");
-		const nl = buf.indexOf("\n");
-		return nl === -1 ? buf : buf.slice(0, nl);
+		const lines = fs.readFileSync(file, "utf8").split("\n");
+		return lines.slice(0, maxLines);
 	} catch {
-		return undefined;
+		return [];
 	}
 }
 
@@ -63,6 +66,22 @@ function headerMeta(line: string | undefined): { id?: string; path?: string; bra
 	} catch {
 		return {};
 	}
+}
+
+/** Detect task-tool helper sessions from the durable early session_init metadata entry. */
+function isInternalSession(lines: readonly string[]): boolean {
+	for (const line of lines.slice(1)) {
+		if (!line.trim()) continue;
+		try {
+			const obj = JSON.parse(line) as unknown;
+			if (typeof obj === "object" && obj !== null && (obj as { type?: unknown }).type === "session_init") {
+				return true;
+			}
+		} catch {
+			// Ignore malformed JSONL entries; classification is best-effort.
+		}
+	}
+	return false;
 }
 
 /**
@@ -85,7 +104,8 @@ function sessionIdForFile(stem: string, headerId: string | undefined): string {
  */
 export function listRecentSessions(deps: RecentActivityDeps): RecentSessionEntry[] {
 	const limit = deps.limit ?? 20;
-	const readFirstLine = deps.readFirstLine ?? defaultReadFirstLine;
+	const includeInternal = deps.includeInternal ?? true;
+	const readInitialLines = deps.readInitialLines ?? defaultReadInitialLines;
 	const breadcrumbs = new Set((deps.breadcrumbPaths ?? []).map(p => path.resolve(p)));
 
 	let projectDirs: string[];
@@ -114,7 +134,10 @@ export function listRecentSessions(deps: RecentActivityDeps): RecentSessionEntry
 			} catch {
 				continue;
 			}
-			const meta = headerMeta(readFirstLine(file));
+			const initialLines = readInitialLines(file, 8);
+			const meta = headerMeta(initialLines[0]);
+			const internal = isInternalSession(initialLines);
+			if (internal && !includeInternal) continue;
 			entries.push({
 				sessionId: sessionIdForFile(name.slice(0, -".jsonl".length), meta.id),
 				path: meta.path,
@@ -123,6 +146,7 @@ export function listRecentSessions(deps: RecentActivityDeps): RecentSessionEntry
 				sessionStateFile: file,
 				mtimeMs,
 				currentTerminal: breadcrumbs.has(path.resolve(file)) || undefined,
+				internal: internal || undefined,
 			});
 		}
 	}

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1115,6 +1115,7 @@ export class TelegramNotificationDaemon {
 			const recent = listRecentSessions({
 				sessionsRoot: path.join(this.opts.settings.getAgentDir(), "sessions"),
 				limit: 10,
+				includeInternal: false,
 			});
 			const lines = recent.length
 				? recent.map(e => `• ${e.sessionId}${e.path ? ` (${e.path})` : ""}`).join("\n")

--- a/packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts
@@ -52,11 +52,19 @@ function msg(chatId: string, text: string, updateId: number): unknown {
 	return { update_id: updateId, message: { chat: { id: chatId }, text, message_id: updateId } };
 }
 
-function writeSession(agentDir: string, project: string, id: string, header: object, mtimeMs: number): void {
+function writeSession(
+	agentDir: string,
+	project: string,
+	id: string,
+	header: object,
+	mtimeMs: number,
+	entries: object[] = [],
+): void {
 	const dir = path.join(agentDir, "sessions", project);
 	fs.mkdirSync(dir, { recursive: true });
 	const file = path.join(dir, `${id}.jsonl`);
-	fs.writeFileSync(file, `${JSON.stringify(header)}\n`);
+	const suffix = entries.length > 0 ? `${entries.map(entry => JSON.stringify(entry)).join("\n")}\n` : "";
+	fs.writeFileSync(file, `${JSON.stringify(header)}\n${suffix}`);
 	fs.utimesSync(file, new Date(mtimeMs), new Date(mtimeMs));
 }
 
@@ -117,6 +125,26 @@ describe("lifecycle command routing (G009)", () => {
 		expect(sends.every(c => String(c.body?.text).length <= 4096)).toBe(true);
 		expect(String(sends[0]?.body?.text).startsWith("<pre>")).toBe(true);
 		expect(sends.map(c => String(c.body?.text)).join("")).toContain("/repo/&lt;tag&gt;&amp;branch");
+		fs.rmSync(agentDir, { recursive: true, force: true });
+	});
+	test("/session_recent hides internal helper sessions by default", async () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-lc-route-"));
+		const { calls, api } = spyBot();
+		const daemon = makeDaemon(agentDir, api);
+		(daemon as unknown as { lifecycleControlActive: boolean }).lifecycleControlActive = true;
+		writeSession(agentDir, "repo", "user-session", { cwd: "/repo/user" }, 1000);
+		writeSession(agentDir, "repo", "helper-session", { cwd: "/repo/helper" }, 2000, [{ type: "session_init" }]);
+
+		await daemon.handleTelegramUpdate(msg("42", "/session_recent", 5));
+
+		const text = calls
+			.filter(c => c.method === "sendMessage")
+			.map(c => String(c.body?.text))
+			.join("");
+		expect(text).toContain("user-session");
+		expect(text).toContain("/repo/user");
+		expect(text).not.toContain("helper-session");
+		expect(text).not.toContain("/repo/helper");
 		fs.rmSync(agentDir, { recursive: true, force: true });
 	});
 });

--- a/packages/coding-agent/test/notifications-recent-activity.test.ts
+++ b/packages/coding-agent/test/notifications-recent-activity.test.ts
@@ -15,11 +15,18 @@ afterAll(() => {
 	for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
 });
 
-function writeSession(root: string, project: string, id: string, header: object, mtimeMs: number): string {
+function writeSession(
+	root: string,
+	project: string,
+	id: string,
+	header: object,
+	mtimeMs: number,
+	entries: object[] = [{ type: "message" }],
+): string {
 	const dir = path.join(root, project);
 	fs.mkdirSync(dir, { recursive: true });
 	const file = path.join(dir, `${id}.jsonl`);
-	fs.writeFileSync(file, `${JSON.stringify(header)}\n{"type":"message"}\n`);
+	fs.writeFileSync(file, `${JSON.stringify(header)}\n${entries.map(entry => JSON.stringify(entry)).join("\n")}\n`);
 	fs.utimesSync(file, new Date(mtimeMs), new Date(mtimeMs));
 	return file;
 }
@@ -61,6 +68,32 @@ describe("recent-activity picker", () => {
 		const out = listRecentSessions({ sessionsRoot: root });
 		expect(out).toHaveLength(1);
 		expect(out[0]?.path).toBeUndefined();
+	});
+
+	it("marks internal helper sessions and can exclude them", () => {
+		const root = tempSessionsRoot();
+		writeSession(root, "r", "user", { cwd: "/r" }, 2000);
+		writeSession(root, "r", "helper", { cwd: "/r" }, 3000, [
+			{ type: "session_init", systemPrompt: "subagent", initialTask: "help" },
+		]);
+
+		const defaultOut = listRecentSessions({ sessionsRoot: root });
+		expect(defaultOut.map(e => e.sessionId)).toEqual(["helper", "user"]);
+		expect(defaultOut.find(e => e.sessionId === "helper")?.internal).toBe(true);
+		expect(defaultOut.find(e => e.sessionId === "user")?.internal).toBeUndefined();
+
+		const visibleOnly = listRecentSessions({ sessionsRoot: root, includeInternal: false });
+		expect(visibleOnly.map(e => e.sessionId)).toEqual(["user"]);
+	});
+
+	it("filters internal sessions before applying the limit", () => {
+		const root = tempSessionsRoot();
+		writeSession(root, "r", "older-visible", { cwd: "/r" }, 1000);
+		writeSession(root, "r", "newer-visible", { cwd: "/r" }, 2000);
+		writeSession(root, "r", "newest-helper", { cwd: "/r" }, 3000, [{ type: "session_init" }]);
+
+		const out = listRecentSessions({ sessionsRoot: root, limit: 2, includeInternal: false });
+		expect(out.map(e => e.sessionId)).toEqual(["newer-visible", "older-visible"]);
 	});
 	it("surfaces the authoritative header id (not the timestamped filename stem)", () => {
 		const root = tempSessionsRoot();


### PR DESCRIPTION
## Summary
- Mark recent session histories with early `session_init` entries as internal helper/sub-agent sessions.
- Keep `listRecentSessions` inclusive by default for operator/non-Telegram paths, while making Telegram `/session_recent` exclude internal sessions.
- Add regressions for default inclusion, explicit exclusion, filter-before-limit behavior, and Telegram output omission.

## Verification
- `bun test packages/coding-agent/test/notifications-recent-activity.test.ts packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts`
- `bunx biome check packages/coding-agent/src/notifications/recent-activity.ts packages/coding-agent/src/notifications/telegram-daemon.ts packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts packages/coding-agent/test/notifications-recent-activity.test.ts`
- Attempted `bun run check:ts`; blocked by pre-existing unrelated `packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts` unused-variable lint warnings.

Fixes #1364
—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*