### PR TITLE
fix(ai): surface Anthropic hard 429 before stream watchdog

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -21,6 +21,7 @@ import {
 } from "@gajae-code/utils";
 import { hasOpus47ApiRestrictions, mapEffortToAnthropicAdaptiveEffort } from "../model-thinking";
 import { calculateCost } from "../models";
+import { isUsageLimitError } from "../rate-limit-utils";
 import { getEnvApiKey, OUTPUT_FALLBACK_BUFFER } from "../stream";
 import type {
 	Api,
@@ -62,6 +63,7 @@ import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse";
 import { parseGitHubCopilotApiKey } from "../utils/oauth/github-copilot";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { isCopilotTransientModelError } from "../utils/retry";
+import { getRetryAfterMsFromHeaders } from "../utils/retry-after";
 import { resolveRetryBudget } from "../utils/retry-budget";
 import {
 	COMBINATOR_KEYS,
@@ -724,6 +726,7 @@ export type AnthropicClientOptionsArgs = {
 	onSseEvent?: AnthropicOptions["onSseEvent"];
 	fetch?: FetchImpl;
 	requestMaxRetries?: number;
+	maxRetryDelayMs?: number;
 };
 
 export type AnthropicClientOptionsResult = {
@@ -875,6 +878,101 @@ function mergeHeaders(...headerSources: (Record<string, string> | undefined)[]):
 		}
 	}
 	return merged;
+}
+
+const ANTHROPIC_RETRY_DELAY_CAP_MS = 60_000;
+const ANTHROPIC_RATE_LIMIT_HEADER_PREFIX = "anthropic-ratelimit-";
+
+function getSafeAnthropicHeaderEvidence(headers: Headers): string[] {
+	const evidence: string[] = [];
+	for (const [name, value] of headers) {
+		const lowerName = name.toLowerCase();
+		if (
+			lowerName === "retry-after" ||
+			lowerName === "retry-after-ms" ||
+			lowerName.startsWith(ANTHROPIC_RATE_LIMIT_HEADER_PREFIX)
+		) {
+			evidence.push(`${lowerName}=${value}`);
+		}
+	}
+	return evidence.sort();
+}
+
+function getStringProperty(source: unknown, key: string): string | undefined {
+	if (!isRecord(source)) return undefined;
+	const value = source[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+function appendAnthropicRateLimitEvidence(bodyText: string, headers: Headers): string {
+	const evidence = getSafeAnthropicHeaderEvidence(headers);
+	if (evidence.length === 0) return bodyText;
+
+	const suffix = ` Anthropic rate-limit evidence: ${evidence.join(", ")}`;
+	try {
+		const parsed = JSON.parse(bodyText) as unknown;
+		if (isRecord(parsed)) {
+			const error = parsed.error;
+			if (isRecord(error) && typeof error.message === "string" && !error.message.includes(suffix)) {
+				return JSON.stringify({ ...parsed, error: { ...error, message: `${error.message}${suffix}` } });
+			}
+			if (typeof parsed.message === "string" && !parsed.message.includes(suffix)) {
+				return JSON.stringify({ ...parsed, message: `${parsed.message}${suffix}` });
+			}
+		}
+	} catch {}
+
+	return bodyText.includes(suffix) ? bodyText : `${bodyText}${suffix}`;
+}
+
+function isAnthropicUsageExhaustionResponse(
+	bodyText: string,
+	headers: Headers,
+	retryAfterMs: number | undefined,
+	retryDelayCapMs: number,
+): boolean {
+	const overageReason = headers.get("anthropic-ratelimit-unified-overage-disabled-reason")?.toLowerCase();
+	if (overageReason === "out_of_credits") return true;
+	if (retryAfterMs !== undefined && retryAfterMs > retryDelayCapMs) return true;
+
+	try {
+		const parsed = JSON.parse(bodyText) as unknown;
+		const error = isRecord(parsed) ? parsed.error : undefined;
+		const type = getStringProperty(error, "type") ?? getStringProperty(parsed, "type");
+		const message = getStringProperty(error, "message") ?? getStringProperty(parsed, "message") ?? bodyText;
+		return (
+			/rate_limit_error/i.test(type ?? "") &&
+			(/request would exceed your account.?s rate limit/i.test(message) || /out_of_credits/i.test(message))
+		);
+	} catch {
+		return /request would exceed your account.?s rate limit|out_of_credits/i.test(bodyText);
+	}
+}
+
+function wrapAnthropicFetchForBoundedRateLimits(baseFetch: FetchImpl, maxRetryDelayMs: number | undefined): FetchImpl {
+	const retryDelayCapMs = maxRetryDelayMs ?? ANTHROPIC_RETRY_DELAY_CAP_MS;
+	return Object.assign(
+		async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			const response = await baseFetch(input, init);
+			if (response.status !== 429 || retryDelayCapMs === 0) return response;
+
+			const headers = new Headers(response.headers);
+			const retryAfterMs = getRetryAfterMsFromHeaders(headers);
+			const bodyText = await response
+				.clone()
+				.text()
+				.catch(() => "");
+			if (!isAnthropicUsageExhaustionResponse(bodyText, headers, retryAfterMs, retryDelayCapMs)) return response;
+
+			headers.set("x-should-retry", "false");
+			return new Response(appendAnthropicRateLimitEvidence(bodyText, headers), {
+				status: response.status,
+				statusText: response.statusText,
+				headers,
+			});
+		},
+		baseFetch.preconnect ? { preconnect: baseFetch.preconnect } : {},
+	);
 }
 
 // The Anthropic SDK logs malformed SSE frames directly before rethrowing them.
@@ -1042,6 +1140,7 @@ export function isProviderRetryableError(error: unknown, provider?: string): boo
 	if (!(error instanceof Error)) return false;
 	if (provider === "github-copilot" && isCopilotTransientModelError(error)) return true;
 	const msg = error.message.toLowerCase();
+	if (isUsageLimitError(error.message)) return false;
 	if (
 		isUnexpectedSocketCloseMessage(msg) ||
 		/rate.?limit|too many requests|overloaded|service.?unavailable|internal_error|stream error.*received from peer|1302|timed?\s*out while waiting for the first event|timeout waiting for first/i.test(
@@ -1166,6 +1265,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 					onSseEvent: options?.onSseEvent,
 					fetch: options?.fetch,
 					requestMaxRetries: options?.requestMaxRetries,
+					maxRetryDelayMs: options?.maxRetryDelayMs,
 				});
 				client = created.client;
 				isOAuthToken = created.isOAuthToken;
@@ -1723,11 +1823,8 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 	const foundryCustomHeaders = resolveAnthropicCustomHeaders(model);
 	const tlsFetchOptions = buildClaudeCodeTlsFetchOptions(model, baseUrl);
 	const baseFetch = args.fetch ?? fetch;
-	const debugFetch = onSseEvent
-		? wrapFetchForSseDebug(baseFetch, event => onSseEvent(event, model))
-		: args.fetch
-			? baseFetch
-			: undefined;
+	const boundedFetch = wrapAnthropicFetchForBoundedRateLimits(baseFetch, args.maxRetryDelayMs);
+	const debugFetch = onSseEvent ? wrapFetchForSseDebug(boundedFetch, event => onSseEvent(event, model)) : boundedFetch;
 	if (model.provider === "github-copilot") {
 		const copilotApiKey = parseGitHubCopilotApiKey(apiKey).accessToken;
 		const betaFeatures = [...extraBetas];
@@ -1755,7 +1852,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 			dangerouslyAllowBrowser: true,
 			defaultHeaders,
 			logLevel: ANTHROPIC_SDK_LOG_LEVEL,
-			...(debugFetch ? { fetch: debugFetch } : {}),
+			fetch: debugFetch,
 			...(tlsFetchOptions ? { fetchOptions: tlsFetchOptions } : {}),
 		};
 	}
@@ -1789,7 +1886,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 			dangerouslyAllowBrowser: true,
 			defaultHeaders,
 			logLevel: ANTHROPIC_SDK_LOG_LEVEL,
-			...(debugFetch ? { fetch: debugFetch } : {}),
+			fetch: debugFetch,
 		};
 	}
 
@@ -1802,7 +1899,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		dangerouslyAllowBrowser: true,
 		defaultHeaders,
 		logLevel: ANTHROPIC_SDK_LOG_LEVEL,
-		...(debugFetch ? { fetch: debugFetch } : {}),
+		fetch: debugFetch,
 		...(tlsFetchOptions ? { fetchOptions: tlsFetchOptions } : {}),
 	};
 }

--- a/packages/ai/src/rate-limit-utils.ts
+++ b/packages/ai/src/rate-limit-utils.ts
@@ -37,6 +37,14 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 	}
 
 	if (
+		lower.includes("out_of_credits") ||
+		lower.includes("request would exceed your account's rate limit") ||
+		lower.includes("request would exceed your accounts rate limit")
+	) {
+		return "QUOTA_EXHAUSTED";
+	}
+
+	if (
 		lower.includes("per minute") ||
 		lower.includes("rate limit") ||
 		lower.includes("too many requests") ||
@@ -86,8 +94,13 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
-	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|model.?limit|model_limit_reached|message.?limit|message_limit_reached|limit for this model|quota.?exceeded|resource has been exhausted[^\n]*(?:quota|limit)/i;
+	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|model.?limit|model_limit_reached|message.?limit|message_limit_reached|limit for this model|quota.?exceeded|out_of_credits|request would exceed your account.?s rate limit|resource has been exhausted[^\n]*(?:quota|limit)/i;
+const LARGE_RETRY_AFTER_HINT_MS = 15 * 60 * 1000;
 
 export function isUsageLimitError(errorMessage: string): boolean {
-	return USAGE_LIMIT_PATTERN.test(errorMessage);
+	if (USAGE_LIMIT_PATTERN.test(errorMessage)) return true;
+	const retryAfterMatch = /retry-after-ms=(\d+)/i.exec(errorMessage);
+	if (!retryAfterMatch) return false;
+	const retryAfterMs = Number(retryAfterMatch[1]);
+	return Number.isFinite(retryAfterMs) && retryAfterMs >= LARGE_RETRY_AFTER_HINT_MS;
 }

--- a/packages/ai/test/anthropic-stream-timeout.test.ts
+++ b/packages/ai/test/anthropic-stream-timeout.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import type Anthropic from "@anthropic-ai/sdk";
 import { streamAnthropic } from "../src/providers/anthropic";
-import type { Context, Model } from "../src/types";
+import type { Context, FetchImpl, Model } from "../src/types";
 import { waitForDelayOrAbort } from "./helpers";
 
 const model: Model<"anthropic-messages"> = {
@@ -160,6 +160,50 @@ describe("anthropic first-event timeout retries", () => {
 		expect(result.stopReason).toBe("stop");
 		expect(result.content).toEqual([{ type: "text", text: "retry recovered" }]);
 		expect(result.responseId).toBe("msg_retry_success");
+	});
+
+	it("surfaces large retry-after Anthropic 429s instead of first-event timeouts", async () => {
+		let attempts = 0;
+		const fetchMock = (async () => {
+			attempts += 1;
+			return new Response(
+				JSON.stringify({
+					type: "error",
+					error: {
+						type: "rate_limit_error",
+						message: "This request would exceed your account's rate limit. Please try again later.",
+					},
+				}),
+				{
+					status: 429,
+					headers: {
+						"content-type": "application/json",
+						"retry-after": "62291",
+						"anthropic-ratelimit-unified-status": "rejected",
+						"anthropic-ratelimit-unified-7d-status": "rejected",
+						"anthropic-ratelimit-unified-overage-disabled-reason": "out_of_credits",
+					},
+				},
+			);
+		}) as FetchImpl;
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, context, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			streamFirstEventTimeoutMs: 1,
+			providerRetryWait,
+		}).result();
+
+		expect(attempts).toBe(1);
+		expect(providerRetryWait).not.toHaveBeenCalled();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(429);
+		expect(result.errorMessage).toContain("rate_limit_error");
+		expect(result.errorMessage).toContain("This request would exceed your account's rate limit");
+		expect(result.errorMessage).toContain("retry-after-ms=62291000");
+		expect(result.errorMessage).toContain("anthropic-ratelimit-unified-overage-disabled-reason=out_of_credits");
+		expect(result.errorMessage).not.toContain("timed out while waiting for the first event");
 	});
 
 	it("does not arm the Anthropic first-event watchdog before the stream connects", async () => {

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -50,6 +50,15 @@ describe("parseRateLimitReason", () => {
 		expect(parseRateLimitReason("429 model_limit_reached: limit for this model reached")).toBe("QUOTA_EXHAUSTED");
 		expect(parseRateLimitReason("You have reached the message limit for this model")).toBe("QUOTA_EXHAUSTED");
 	});
+
+	it("classifies Anthropic account exhaustion as QUOTA_EXHAUSTED", () => {
+		expect(parseRateLimitReason("This request would exceed your account's rate limit. Please try again later.")).toBe(
+			"QUOTA_EXHAUSTED",
+		);
+		expect(parseRateLimitReason("anthropic-ratelimit-unified-overage-disabled-reason=out_of_credits")).toBe(
+			"QUOTA_EXHAUSTED",
+		);
+	});
 });
 
 describe("calculateRateLimitBackoffMs", () => {
@@ -73,6 +82,15 @@ describe("isUsageLimitError", () => {
 			isUsageLimitError("Cloud Code Assist API error (429): Resource has been exhausted (e.g. check quota)."),
 		).toBe(true);
 		expect(isUsageLimitError("resource exhausted")).toBe(false);
+	});
+
+	it("detects Anthropic account exhaustion and large retry-after hints", () => {
+		expect(isUsageLimitError("This request would exceed your account's rate limit. Please try again later.")).toBe(
+			true,
+		);
+		expect(isUsageLimitError("anthropic-ratelimit-unified-overage-disabled-reason=out_of_credits")).toBe(true);
+		expect(isUsageLimitError("429 rate limit exceeded retry-after-ms=62291000")).toBe(true);
+		expect(isUsageLimitError("429 rate limit exceeded retry-after-ms=5000")).toBe(false);
 	});
 
 	it("does not classify generic rate limits as usage exhaustion", () => {


### PR DESCRIPTION
## Summary
- Bound Anthropic SDK retry behavior for hard 429 usage-exhaustion responses by marking those responses non-retryable before the SDK can sleep on a huge retry-after.
- Preserve normal retry behavior for short/transient provider failures and OAuth 401 refresh paths.
- Extend usage-limit classification for Anthropic out_of_credits / account-rate-limit exhaustion evidence.

Fixes #1368

## Verification
- bun test packages/ai/test/anthropic-stream-timeout.test.ts packages/ai/test/rate-limit-utils.test.ts packages/ai/test/anthropic-retry.test.ts packages/ai/test/anthropic-oauth.test.ts
- bun --cwd=packages/ai run check

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*