### PR TITLE
fix(ai): keep generic long retry-after rate limits retryable

### DIFF
--- a/packages/ai/src/rate-limit-utils.ts
+++ b/packages/ai/src/rate-limit-utils.ts
@@ -95,12 +95,6 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
 	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|model.?limit|model_limit_reached|message.?limit|message_limit_reached|limit for this model|quota.?exceeded|out_of_credits|request would exceed your account.?s rate limit|resource has been exhausted[^\n]*(?:quota|limit)/i;
-const LARGE_RETRY_AFTER_HINT_MS = 15 * 60 * 1000;
-
 export function isUsageLimitError(errorMessage: string): boolean {
-	if (USAGE_LIMIT_PATTERN.test(errorMessage)) return true;
-	const retryAfterMatch = /retry-after-ms=(\d+)/i.exec(errorMessage);
-	if (!retryAfterMatch) return false;
-	const retryAfterMs = Number(retryAfterMatch[1]);
-	return Number.isFinite(retryAfterMs) && retryAfterMs >= LARGE_RETRY_AFTER_HINT_MS;
+	return USAGE_LIMIT_PATTERN.test(errorMessage);
 }

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -84,12 +84,12 @@ describe("isUsageLimitError", () => {
 		expect(isUsageLimitError("resource exhausted")).toBe(false);
 	});
 
-	it("detects Anthropic account exhaustion and large retry-after hints", () => {
+	it("detects Anthropic account exhaustion without treating generic retry-after as usage exhaustion", () => {
 		expect(isUsageLimitError("This request would exceed your account's rate limit. Please try again later.")).toBe(
 			true,
 		);
 		expect(isUsageLimitError("anthropic-ratelimit-unified-overage-disabled-reason=out_of_credits")).toBe(true);
-		expect(isUsageLimitError("429 rate limit exceeded retry-after-ms=62291000")).toBe(true);
+		expect(isUsageLimitError("429 rate limit exceeded retry-after-ms=62291000")).toBe(false);
 		expect(isUsageLimitError("429 rate limit exceeded retry-after-ms=5000")).toBe(false);
 	});
 


### PR DESCRIPTION
## Summary
- Keep generic long `retry-after-ms` rate limits out of the persistent usage-limit classifier.
- Preserve explicit usage/quota exhaustion detection for Anthropic account exhaustion, out-of-credits, model/message limits, and quota wording.
- This restores the coding-agent retry-cap contract broken after #1369: generic long retry-after rate limits remain retryable/unbounded instead of surfacing as first-event-timeout-masked failures.

## Verification
- `bun test packages/ai/test/rate-limit-utils.test.ts` ✅
- `bun test packages/ai/test/anthropic-stream-timeout.test.ts` blocked locally before test execution: missing `pi_natives` native addon in this worktree.
- `bun test packages/coding-agent/test/agent-session-retry-cap.test.ts` blocked locally before test execution: missing `pi_natives` native addon in this worktree.
- CI should validate the blocked native-dependent shards with the workflow native artifact setup.

## References
- Fixes post-merge Dev CI failure run 28518557392, job 84536536799.
- Follow-up to #1369.
- Related to #1368.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
