### PR TITLE
Fix Telegram daemon reload owner race

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Deep Interview option-clarification prompts now stay out of the interview transcript and ambiguity recorder, so asking about displayed choices no longer persists as the round answer before the user selects an actual option.
+- `gjc daemon reload telegram` now spawns the replacement daemon with a stable owner pid so the new daemon does not exit immediately after the short-lived reload CLI process ends.
 
 ## [0.7.9] - 2026-07-01
 ### Added

--- a/packages/coding-agent/src/notifications/telegram-daemon-control.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-control.ts
@@ -97,6 +97,14 @@ export interface TelegramDaemonControlDeps {
 	sendSignal?: (pid: number, signal: NodeJS.Signals) => void;
 	spawn?: TelegramDaemonDeps["spawn"];
 	execPath?: string;
+	/**
+	 * Stable process id encoded into freshly-spawned daemon owner ids.
+	 *
+	 * The daemon-internal entrypoint rejects numeric owner ids whose process is
+	 * already gone. `gjc daemon reload` is a short-lived CLI process, so using its
+	 * own pid can race the child startup and make the replacement exit immediately.
+	 */
+	ownerPid?: number;
 	randomId?: () => string;
 	sleep?: (ms: number) => Promise<void>;
 	waitStepMs?: number;
@@ -188,6 +196,7 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 			fs: this.deps.fs,
 			now: this.deps.now,
 			pidAlive: this.deps.pidAlive,
+			pid: this.deps.ownerPid ?? process.ppid,
 			spawn: this.deps.spawn,
 			execPath: this.deps.execPath,
 			randomId: this.deps.randomId,

--- a/packages/coding-agent/test/daemon-control.test.ts
+++ b/packages/coding-agent/test/daemon-control.test.ts
@@ -193,10 +193,11 @@ describe("TelegramDaemonController.reload", () => {
 		writeState(agentDir, freshState());
 		fs.writeFileSync(daemonPaths(agentDir).lock, "");
 
-		const alive = new Set<number>([999, process.pid]);
+		const alive = new Set<number>([999, 4242]);
 		const signals: Array<[number, string]> = [];
 		const spawns: Array<{ command: string; args: string[] }> = [];
 		const ctrl = new TelegramDaemonController(s, {
+			ownerPid: 4242,
 			pidAlive: pid => alive.has(pid),
 			sendSignal: (pid, sig) => {
 				signals.push([pid, sig]);
@@ -213,8 +214,13 @@ describe("TelegramDaemonController.reload", () => {
 		expect(result.ok).toBe(true);
 		expect(signals).toContainEqual([999, "SIGTERM"]);
 		expect(spawns).toHaveLength(1);
-		const after = JSON.parse(fs.readFileSync(daemonPaths(agentDir).state, "utf8")) as { ownerId: string };
+		const after = JSON.parse(fs.readFileSync(daemonPaths(agentDir).state, "utf8")) as {
+			ownerId: string;
+			pid: number;
+		};
 		expect(after.ownerId).not.toBe("old");
+		expect(after.ownerId.startsWith("4242-")).toBe(true);
+		expect(after.pid).toBe(4242);
 		// No leftover control request after a successful reload.
 		expect(await readTelegramControlRequest(s)).toBeUndefined();
 	});


### PR DESCRIPTION
## Summary
- Spawn replacement Telegram daemons from `gjc daemon reload telegram` with a stable owner pid instead of the short-lived reload CLI pid
- Add regression coverage that the fresh owner id/state pid use the stable owner pid
- Add changelog entry

## Verification
- `bun test packages/coding-agent/test/daemon-control.test.ts`
- `bunx biome check packages/coding-agent/src/notifications/telegram-daemon-control.ts packages/coding-agent/test/daemon-control.test.ts packages/coding-agent/CHANGELOG.md`

## Context
While refreshing Telegram bot commands after the lifecycle command menu change, `gjc daemon reload telegram --force` spawned a replacement daemon that exited immediately because `notify daemon-internal` rejected the reload CLI process pid after that short-lived process ended.