### PR TITLE
feat: sync cmux workspace title

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- GJC now best-effort renames the containing cmux workspace to the current GJC session name when running inside a cmux terminal.
+
 ### Fixed
 
 - Deep Interview option-clarification prompts now stay out of the interview transcript and ambiguity recorder, so asking about displayed choices no longer persists as the round answer before the user selects an actual option.

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -24,6 +24,8 @@ For simple local side effects that do not need a full extension, set the user-le
 gjc config set completion.notifyCommand 'cmux notify --title "$GJC_NOTIFICATION_TITLE" --body "$GJC_NOTIFICATION_BODY"'
 ```
 
+When GJC is running inside a cmux terminal (`CMUX_WORKSPACE_ID` is set), GJC also best-effort renames that cmux workspace to the current GJC session name whenever the session title is set or restored.
+
 Windows Terminal may keep BEL (`[Console]::Write([char]7)`) silent depending on profile and system sound settings even when `notifications.terminalBell` is enabled. For an audible Windows completion beep, configure a user-level PowerShell command hook instead:
 
 ```powershell

--- a/packages/coding-agent/src/utils/cmux-workspace.ts
+++ b/packages/coding-agent/src/utils/cmux-workspace.ts
@@ -1,0 +1,106 @@
+import { logger } from "@gajae-code/utils";
+
+const CMUX_COMMAND = "cmux";
+const CMUX_WORKSPACE_ID_ENV = "CMUX_WORKSPACE_ID";
+const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
+const CMUX_WORKSPACE_RENAME_TIMEOUT_MS = 1500;
+
+export interface CmuxWorkspaceRenameCommand {
+	command: string;
+	args: string[];
+}
+
+export interface CmuxWorkspaceRenameProcess {
+	exited: Promise<number>;
+	kill(): void;
+	unref(): void;
+}
+
+export interface CmuxWorkspaceTitleSyncOptions {
+	env?: NodeJS.ProcessEnv;
+	isTty?: boolean;
+	which?: (command: string) => string | null;
+	spawn?: (
+		command: string[],
+		options: { env: NodeJS.ProcessEnv; stdin: "ignore"; stdout: "ignore"; stderr: "ignore" },
+	) => CmuxWorkspaceRenameProcess;
+}
+
+function defaultSpawn(
+	command: string[],
+	options: { env: NodeJS.ProcessEnv; stdin: "ignore"; stdout: "ignore"; stderr: "ignore" },
+): CmuxWorkspaceRenameProcess {
+	return Bun.spawn(command, options);
+}
+
+export function sanitizeCmuxWorkspaceTitle(title: string | undefined): string | undefined {
+	if (!title) return undefined;
+	const sanitized = title.replace(CONTROL_CHARS, " ").replace(/\s+/g, " ").trim();
+	return sanitized || undefined;
+}
+
+export function buildCmuxWorkspaceRenameCommand(
+	sessionName: string | undefined,
+	env: NodeJS.ProcessEnv = process.env,
+): CmuxWorkspaceRenameCommand | null {
+	const workspaceId = env[CMUX_WORKSPACE_ID_ENV]?.trim();
+	if (!workspaceId) return null;
+
+	const title = sanitizeCmuxWorkspaceTitle(sessionName);
+	if (!title) return null;
+
+	return {
+		command: CMUX_COMMAND,
+		args: ["workspace", "rename", workspaceId, "--title", title],
+	};
+}
+
+export function syncCmuxWorkspaceTitle(
+	sessionName: string | undefined,
+	options: CmuxWorkspaceTitleSyncOptions = {},
+): void {
+	const isTty = options.isTty ?? process.stdout.isTTY === true;
+	if (!isTty) return;
+
+	const env = options.env ?? process.env;
+	const plan = buildCmuxWorkspaceRenameCommand(sessionName, env);
+	if (!plan) return;
+
+	const which = options.which ?? Bun.which;
+	let resolvedCommand: string | null;
+	try {
+		resolvedCommand = which(plan.command);
+	} catch (error) {
+		logger.debug("cmux workspace rename command lookup failed", { error: String(error) });
+		return;
+	}
+	if (!resolvedCommand) return;
+
+	const spawn = options.spawn ?? defaultSpawn;
+	try {
+		const proc = spawn([resolvedCommand, ...plan.args], {
+			env,
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		proc.unref();
+		const timer = setTimeout(() => {
+			try {
+				proc.kill();
+			} catch {}
+		}, CMUX_WORKSPACE_RENAME_TIMEOUT_MS);
+		timer.unref?.();
+		void proc.exited
+			.then(exitCode => {
+				clearTimeout(timer);
+				if (exitCode !== 0) logger.debug("cmux workspace rename exited non-zero", { exitCode });
+			})
+			.catch(error => {
+				clearTimeout(timer);
+				logger.debug("cmux workspace rename failed", { error: String(error) });
+			});
+	} catch (error) {
+		logger.debug("cmux workspace rename failed to start", { error: String(error) });
+	}
+}

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -9,6 +9,7 @@ import type { ModelRegistry } from "../config/model-registry";
 import { resolveRoleSelection } from "../config/model-resolver";
 import type { Settings } from "../config/settings";
 import titleSystemPrompt from "../prompts/system/title-system.md" with { type: "text" };
+import { syncCmuxWorkspaceTitle } from "./cmux-workspace";
 
 const TITLE_SYSTEM_PROMPT = prompt.render(titleSystemPrompt);
 
@@ -218,6 +219,7 @@ export function setTerminalTitle(title: string): void {
 
 export function setSessionTerminalTitle(sessionName: string | undefined, cwd?: string): void {
 	setTerminalTitle(formatSessionTerminalTitle(sessionName, cwd));
+	syncCmuxWorkspaceTitle(sessionName);
 }
 
 /**

--- a/packages/coding-agent/test/cmux-workspace.test.ts
+++ b/packages/coding-agent/test/cmux-workspace.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "bun:test";
+import {
+	buildCmuxWorkspaceRenameCommand,
+	sanitizeCmuxWorkspaceTitle,
+	syncCmuxWorkspaceTitle,
+} from "../src/utils/cmux-workspace";
+
+function cmuxEnv(workspaceId = "workspace-123"): NodeJS.ProcessEnv {
+	return { CMUX_WORKSPACE_ID: workspaceId } as NodeJS.ProcessEnv;
+}
+
+describe("cmux workspace title sync", () => {
+	it("builds an explicit workspace rename command", () => {
+		expect(buildCmuxWorkspaceRenameCommand("Investigate Resolver", cmuxEnv())).toEqual({
+			command: "cmux",
+			args: ["workspace", "rename", "workspace-123", "--title", "Investigate Resolver"],
+		});
+	});
+
+	it("skips when the current terminal is not a cmux workspace", () => {
+		expect(buildCmuxWorkspaceRenameCommand("Investigate Resolver", {} as NodeJS.ProcessEnv)).toBeNull();
+	});
+
+	it("sanitizes control characters and whitespace", () => {
+		expect(sanitizeCmuxWorkspaceTitle("  Fix\u0001\u001b  cmux\n\tworkspace  ")).toBe("Fix cmux workspace");
+	});
+
+	it("does not spawn outside a tty", () => {
+		let spawned = false;
+		syncCmuxWorkspaceTitle("Investigate Resolver", {
+			env: cmuxEnv(),
+			isTty: false,
+			which: () => "/usr/local/bin/cmux",
+			spawn: () => {
+				spawned = true;
+				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
+			},
+		});
+
+		expect(spawned).toBe(false);
+	});
+
+	it("spawns a best-effort cmux rename inside a tty cmux workspace", () => {
+		const unref = vi.fn(() => {});
+		const kill = vi.fn(() => {});
+		const calls: string[][] = [];
+		const seenEnv: NodeJS.ProcessEnv[] = [];
+
+		syncCmuxWorkspaceTitle("Investigate Resolver", {
+			env: cmuxEnv(),
+			isTty: true,
+			which: command => (command === "cmux" ? "/usr/local/bin/cmux" : null),
+			spawn: (command, options) => {
+				calls.push(command);
+				seenEnv.push(options.env);
+				return { exited: Promise.resolve(0), kill, unref };
+			},
+		});
+
+		expect(calls).toEqual([
+			["/usr/local/bin/cmux", "workspace", "rename", "workspace-123", "--title", "Investigate Resolver"],
+		]);
+		expect(seenEnv[0]?.CMUX_WORKSPACE_ID).toBe("workspace-123");
+		expect(unref).toHaveBeenCalledTimes(1);
+		expect(kill).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- Rename the containing cmux workspace to the current GJC session name when `CMUX_WORKSPACE_ID` is present.
- Keep the integration best-effort, TTY-gated, sanitized, and timeout-bounded.
- Document the behavior and add focused unit coverage.

## QA
- `bun test packages/coding-agent/test/cmux-workspace.test.ts packages/coding-agent/test/title-generator.test.ts`
- `bun run check` in `packages/coding-agent` (passed; Biome reported pre-existing unused-variable warnings in `test/gjc-runtime/ultragoal-runtime.test.ts`)
- `git diff --check`
- Live cmux E2E via source import: renamed caller workspace to `QA cmux Rename E2E`, verified with `cmux workspace list`, then restored to `cmux Workspace Auto Rename`

## Notes
- Full `bun test` for `packages/coding-agent` was attempted and failed on unrelated local/pre-existing suites: resident blob auto-compaction errors, URL fetch blocked for example.com test hosts, and Korean-localized git remote errors in `tools/gh.test.ts`. The focused behavior and package check gates for this change pass.