### PR TITLE
Fix managed tmux launch sizing

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -44,6 +44,8 @@ type LaunchPolicy = "direct" | "tmux";
 interface TtyState {
 	stdin: boolean;
 	stdout: boolean;
+	columns?: number;
+	rows?: number;
 }
 
 export interface TmuxLaunchContext {
@@ -68,6 +70,10 @@ export interface TmuxSpawnResult {
 	exitCode: number | null;
 	signalCode?: string | null;
 	stderr?: string;
+}
+export interface TmuxTerminalSize {
+	columns: number;
+	rows: number;
 }
 
 export type TmuxSpawnSync = (command: string, args: string[], options: TmuxSpawnOptions) => TmuxSpawnResult;
@@ -95,6 +101,7 @@ export interface TmuxLaunchPlan {
 	cwd: string;
 	innerCommand: string;
 	newSessionArgs: string[];
+	initialSize?: TmuxTerminalSize;
 	branch?: string | null;
 	attachSessionName?: string;
 	project?: string | null;
@@ -537,6 +544,43 @@ function isTmuxAttachDisconnectError(result: TmuxSpawnResult): boolean {
 	const stderr = result.stderr?.toLowerCase() ?? "";
 	return stderr.includes("eio") || stderr.includes("input/output error");
 }
+function normalizeTmuxTerminalDimension(value: number | undefined): number | undefined {
+	if (value === undefined || !Number.isSafeInteger(value) || value <= 0) return undefined;
+	return value;
+}
+
+function resolveCallerTmuxTerminalSize(tty: TtyState): TmuxTerminalSize | undefined {
+	if (!tty.stdout) return undefined;
+	const columns = normalizeTmuxTerminalDimension(tty.columns);
+	const rows = normalizeTmuxTerminalDimension(tty.rows);
+	if (columns === undefined || rows === undefined) return undefined;
+	return { columns, rows };
+}
+
+function buildTmuxNewSessionSizeArgs(size: TmuxTerminalSize | undefined): string[] {
+	return size ? ["-x", String(size.columns), "-y", String(size.rows)] : [];
+}
+
+function resizeCreatedTmuxWindowToCallerTerminalSize(
+	plan: TmuxLaunchPlan,
+	spawnSync: TmuxSpawnSync,
+	options: TmuxSpawnOptions,
+): void {
+	if (!plan.initialSize) return;
+	spawnSync(
+		plan.tmuxCommand,
+		[
+			"resize-window",
+			"-t",
+			buildGjcTmuxExactOptionTarget(plan.sessionName, { env: options.env }),
+			"-x",
+			String(plan.initialSize.columns),
+			"-y",
+			String(plan.initialSize.rows),
+		],
+		options,
+	);
+}
 
 export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaunchPlan | undefined {
 	const env = context.env ?? process.env;
@@ -544,7 +588,12 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 	if (!context.parsed.tmux || policy === "direct") return undefined;
 	if (env.TMUX || env[GJC_TMUX_LAUNCHED_ENV] === "1") return undefined;
 	const platform = context.platform ?? process.platform;
-	const tty = context.tty ?? { stdin: Boolean(process.stdin.isTTY), stdout: Boolean(process.stdout.isTTY) };
+	const tty = context.tty ?? {
+		stdin: Boolean(process.stdin.isTTY),
+		stdout: Boolean(process.stdout.isTTY),
+		columns: process.stdout.columns,
+		rows: process.stdout.rows,
+	};
 	if (policy === "tmux" && !isInteractiveRootLaunch(context.parsed, tty)) return undefined;
 
 	const cwd = context.cwd ?? process.cwd();
@@ -592,12 +641,23 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 		},
 		context.rawArgs,
 	);
+	const initialSize = resolveCallerTmuxTerminalSize(tty);
 	return {
 		tmuxCommand,
 		sessionName,
 		cwd,
 		innerCommand,
-		newSessionArgs: ["new-session", "-d", "-s", sessionName, "-c", cwd, innerCommand],
+		newSessionArgs: [
+			"new-session",
+			"-d",
+			...buildTmuxNewSessionSizeArgs(initialSize),
+			"-s",
+			sessionName,
+			"-c",
+			cwd,
+			innerCommand,
+		],
+		initialSize,
 		branch,
 		project,
 		sessionId,
@@ -791,6 +851,7 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			}
 			// Recovery succeeded via retry — fall through to attach-session below.
 		}
+		resizeCreatedTmuxWindowToCallerTerminalSize(plan, spawnSync, controlOptions);
 		applyGjcTmuxRootTerminalTitleProfile({
 			tmuxCommand: plan.tmuxCommand,
 			target: plan.sessionName,

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -348,6 +348,120 @@ describe("default GJC tmux launch", () => {
 		expect(plan.innerCommand).toContain("GJC_COORDINATOR_SESSION_STATE_FILE=");
 	});
 
+	it("sizes detached tmux new-session to the caller terminal when dimensions are known", () => {
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: { stdin: true, stdout: true, columns: 178, rows: 35 },
+			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
+		});
+
+		expect(plan).toBeDefined();
+		if (!plan) throw new Error("expected tmux plan");
+		expect(plan.initialSize).toEqual({ columns: 178, rows: 35 });
+		expect(plan.newSessionArgs.slice(0, 10)).toEqual([
+			"new-session",
+			"-d",
+			"-x",
+			"178",
+			"-y",
+			"35",
+			"-s",
+			plan.sessionName,
+			"-c",
+			"/repo",
+		]);
+	});
+
+	it("omits detached tmux sizing when caller dimensions are unknown", () => {
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
+		});
+
+		expect(plan).toBeDefined();
+		if (!plan) throw new Error("expected tmux plan");
+		expect(plan.initialSize).toBeUndefined();
+		expect(plan.newSessionArgs).not.toContain("-x");
+		expect(plan.newSessionArgs).not.toContain("-y");
+		expect(plan.newSessionArgs.slice(0, 6)).toEqual(["new-session", "-d", "-s", plan.sessionName, "-c", "/repo"]);
+	});
+
+	it("does not plan managed tmux from a non-tty root launch", () => {
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: { stdin: true, stdout: false, columns: 178, rows: 35 },
+			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
+		});
+
+		expect(plan).toBeUndefined();
+	});
+
+	it("reasserts caller dimensions before attaching a newly created managed tmux session", () => {
+		const calls: Array<{ command: string; args: string[]; options: TmuxSpawnOptions }> = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: { stdin: true, stdout: true, columns: 178, rows: 35 },
+			tmuxAvailable: true,
+			currentBranch: "feature/demo",
+			existingBranchSessionName: null,
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		const newSession = calls.find(call => call.args[0] === "new-session");
+		const resizeIndex = calls.findIndex(call => call.args[0] === "resize-window");
+		const attachIndex = calls.findIndex(call => call.args[0] === "attach-session");
+		expect(newSession?.args).toContain("-x");
+		expect(newSession?.args).toContain("178");
+		expect(newSession?.args).toContain("-y");
+		expect(newSession?.args).toContain("35");
+		expect(resizeIndex).toBeGreaterThan(0);
+		expect(resizeIndex).toBeLessThan(attachIndex);
+		expect(calls[resizeIndex]?.args).toEqual([
+			"resize-window",
+			"-t",
+			expect.stringMatching(/^=gajae_code_.*:$/),
+			"-x",
+			"178",
+			"-y",
+			"35",
+		]);
+	});
+
 	it("plans native Windows --tmux launches when tmux is available", () => {
 		// The historical direct-launch fallback only fires when no tmux binary
 		// resolves on PATH. When psmux / tmux is available,


### PR DESCRIPTION
## Summary
- Size managed detached `gjc --tmux` sessions with the caller terminal dimensions when they are known, so the first TUI frame is painted at the attached client size instead of tmux's default 80x24.
- Reassert the same dimensions with `tmux resize-window` before attach as a defensive fallback.
- Preserve the existing no-size behavior for unknown/non-TTY launches.
- Add focused launch-tmux regression coverage for sized and unsized managed launches.

Closes #1375

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts` — 61 pass, 0 fail

## Risk notes
- Narrow managed `--tmux` launch change only; direct launches and already-inside-tmux launches are unchanged.
- Uses tmux argv flags (`-x`, `-y`, `resize-window`) with normalized positive integer terminal dimensions, no shell interpolation.
- macOS/Kaku/tmux 3.7a blank-TUI symptom is not locally reproducible on this Linux host, so verification is focused unit coverage plus CI.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
