### PR TITLE
docs(git-daemon): add crate note

### DIFF
--- a/crates/git-daemon/README.md
+++ b/crates/git-daemon/README.md
@@ -1,0 +1,1 @@
+Autonomous per-repo git daemon for gajae-code repository operations.


### PR DESCRIPTION
## Summary
- Add a one-line README note for `crates/git-daemon` describing it as the autonomous per-repo git daemon.

Closes #1377

## Verification
- Not run; docs-only one-line README addition.

## Risk notes
- One file only, documentation-only.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
