### PR TITLE
docs(git-daemon): add README describing the crate

### DIFF
--- a/crates/git-daemon/README.md
+++ b/crates/git-daemon/README.md
@@ -1,0 +1,3 @@
+# git-daemon
+
+The autonomous per-repository git daemon.


### PR DESCRIPTION
Resolves #1377.

Adds crates/git-daemon/README.md with a single sentence describing this crate as the autonomous per-repo git daemon. One file only, minimal in-scope change.