### PR TITLE
fix(ci): exclude git-daemon docs directory from Cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["crates/*"]
-exclude = ["crates/brush-core-vendored", "crates/brush-builtins-vendored"]
+exclude = ["crates/brush-core-vendored", "crates/brush-builtins-vendored", "crates/git-daemon"]
 resolver = "3"
 
 [workspace.package]


### PR DESCRIPTION
## Summary
- Exclude `crates/git-daemon` from the Cargo workspace while it is a docs-only placeholder directory.
- Fix post-merge Dev CI failure from #1378, where `members = ["crates/*"]` made Cargo expect `crates/git-daemon/Cargo.toml`.

Fixes #1377 follow-up CI failure from #1378.

## Verification
- `CI=1 CI_DEV_CHANGED_PATHS=$'Cargo.toml\ncrates/git-daemon/README.md' CI_DEV_PLAN_MODE=push bun scripts/ci-dev-affected.ts --task=rust-check`
- `CI=1 CI_DEV_CHANGED_PATHS=$'Cargo.toml\ncrates/git-daemon/README.md' CI_DEV_PLAN_MODE=push bun scripts/ci-dev-affected.ts --task=rust-test`

## Risk notes
- Minimal root Cargo workspace metadata change only.
- Keeps the README-only git-daemon placeholder out of Rust workspace membership until it has a real `Cargo.toml`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
