### PR TITLE
docs(git-daemon): add README note describing the crate

### DIFF
--- a/crates/git-daemon/README.md
+++ b/crates/git-daemon/README.md
@@ -1,0 +1,3 @@
+# git-daemon
+
+The autonomous per-repo git daemon.


### PR DESCRIPTION
Resolves #1377

Minimal in-scope change: adds `crates/git-daemon/README.md` with a single sentence describing this crate as the autonomous per-repo git daemon. One file only.

Do not merge manually; the daemon runs the merge gate.