### PR TITLE
fix(ai): restore bundled claude-fable-5 after redeployment

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -63,7 +63,9 @@ function createAzureOpenAICatalogModels(): Model<"azure-openai-responses">[] {
 }
 
 const packageRoot = path.join(import.meta.dir, "..");
-const RETIRED_BUNDLED_MODEL_KEYS = new Set<string>(["anthropic/claude-fable-5"]);
+// Claude Fable 5 was temporarily retired during its June 2026 suspension; it
+// was redeployed on 2026-07-01, so no models are currently retired.
+const RETIRED_BUNDLED_MODEL_KEYS = new Set<string>();
 
 function isRetiredBundledModel(model: Pick<Model, "provider" | "id">): boolean {
 	return RETIRED_BUNDLED_MODEL_KEYS.has(`${model.provider}/${model.id}`);

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -3459,6 +3459,31 @@
 				"maxLevel": "max"
 			}
 		},
+		"claude-fable-5": {
+			"id": "claude-fable-5",
+			"name": "Anthropic Fable 5",
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"baseUrl": "https://api.anthropic.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"claude-sonnet-4-0": {
 			"id": "claude-sonnet-4-0",
 			"name": "Anthropic Sonnet 4 (latest)",


### PR DESCRIPTION
## What

Restore `anthropic/claude-fable-5` to the bundled model catalog.

## Why

Claude Fable 5 was removed from the bundled Anthropic catalog while it was
suspended in June 2026 — it is listed in `RETIRED_BUNDLED_MODEL_KEYS` in
`packages/ai/scripts/generate-models.ts`, which filters it out of
`packages/ai/src/models.json`.

Anthropic **redeployed Fable 5 on 2026-07-01** and it is generally available
again on `api.anthropic.com` (`claude-fable-5`, $10/$50 per MTok, 1M context).
Ref: https://www.anthropic.com/research/claude-fable-5-mythos-5 and
https://platform.claude.com/docs/en/about-claude/models/overview

While retired, the model only surfaces through live `/v1/models` discovery on
accounts that have access, and without correct static pricing/metadata. Every
other current Anthropic flagship (`claude-opus-4-8`, `claude-sonnet-5`) is in
the bundled catalog, so Fable's absence is now stale.

## Changes

- `generate-models.ts`: clear `RETIRED_BUNDLED_MODEL_KEYS` so the generator no
  longer filters Fable out.
- `models.json`: re-add `anthropic/claude-fable-5` with official metadata —
  1M context, 128k max output, `$10` in / `$50` out per MTok
  (cacheRead `$1` / cacheWrite `$12.5`), adaptive thinking. Shape matches the
  sibling `claude-opus-4-8` entry.

This keeps current runtime behavior identical to today's dynamic-discovery
result while making the model first-class in the static bundle; the parser in
`model-thinking.ts` is intentionally untouched.

## Verification

- `getBundledModel("anthropic", "claude-fable-5")` resolves with the expected
  context/output/cost.
- `bun test packages/ai/test/model-thinking.test.ts` → 19/19 pass (no thinking
  regression).
- `biome check packages/ai/scripts/generate-models.ts` clean.
- `models.json` parses and validates structurally against sibling entries.
- End-to-end sanity: `gjc -p --model anthropic/claude-fable-5 "Reply OK"`
  returns successfully against `api.anthropic.com`.
