### PR TITLE
fix(update): refresh stale on-disk default workflow skills after update

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `gjc update` now refreshes opted-in on-disk default workflow skill copies (written by `gjc setup defaults` under the agent dir) after a successful update, so they no longer stay stale relative to the embedded defaults; copies that were never installed are left absent.
+
 ## [0.7.10] - 2026-07-02
 ### Added
 

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -10,6 +10,7 @@ import { pipeline } from "node:stream/promises";
 import { $which, APP_NAME, isEnoent, VERSION } from "@gajae-code/utils";
 import { $ } from "bun";
 import chalk from "chalk";
+import { installDefaultGjcDefinitions } from "../defaults/gjc-defaults";
 import { theme } from "../modes/theme/theme";
 
 const RELEASE_REPO = "Yeachan-Heo/gajae-code";
@@ -627,6 +628,29 @@ export async function runUpdateCommand(opts: { force: boolean; check: boolean })
 	} catch (err) {
 		console.error(chalk.red(`Update failed: ${err}`));
 		process.exit(1);
+	}
+
+	await refreshInstalledDefaultSkills();
+}
+
+/**
+ * Refresh opted-in on-disk default workflow skill copies after a successful
+ * update. The four default skills ship embedded in the binary, so most users
+ * need nothing here. But users who ran `gjc setup defaults` have on-disk copies
+ * under the agent dir that shadow the embedded defaults; those would otherwise
+ * go stale after an update. Only rewrite files that already exist and differ —
+ * never materialize new copies for users who never opted in.
+ */
+async function refreshInstalledDefaultSkills(): Promise<void> {
+	try {
+		const result = await installDefaultGjcDefinitions({ refreshOnly: true });
+		if (result.written > 0) {
+			console.log(
+				chalk.dim(`Refreshed ${result.written} local default workflow skill file(s) at ${result.targetRoot}`),
+			);
+		}
+	} catch (err) {
+		console.error(chalk.yellow(`Warning: failed to refresh local default workflow skills: ${err}`));
 	}
 }
 

--- a/packages/coding-agent/src/defaults/gjc-defaults.ts
+++ b/packages/coding-agent/src/defaults/gjc-defaults.ts
@@ -44,6 +44,13 @@ export type DefaultGjcDefinition = DefaultGjcSkillDefinition | DefaultGjcSkillFr
 export interface InstallDefaultGjcDefinitionsOptions {
 	check?: boolean;
 	force?: boolean;
+	/**
+	 * Only rewrite default definition files that already exist on disk but whose
+	 * content differs from the embedded defaults. Files that are absent are left
+	 * absent (status "missing"). Used by `gjc update` to refresh opted-in copies
+	 * without materializing new on-disk copies for users who never installed them.
+	 */
+	refreshOnly?: boolean;
 	targetRoot?: string;
 }
 
@@ -160,6 +167,15 @@ export async function installDefaultGjcDefinitions(
 
 		if (options.check) {
 			status = existing === undefined ? "missing" : existing === definition.content ? "matching" : "different";
+		} else if (options.refreshOnly) {
+			if (existing === undefined) {
+				status = "missing";
+			} else if (existing === definition.content) {
+				status = "matching";
+			} else {
+				await Bun.write(destination, definition.content);
+				status = "written";
+			}
 		} else if (existing !== undefined && !options.force) {
 			status = "skipped";
 		} else {

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -451,6 +451,34 @@ Project executor override body.
 		).toBe(true);
 	});
 
+	it("refreshOnly rewrites stale local copies but never materializes missing ones", async () => {
+		const targetRoot = await makeTempRoot();
+		const deepInterviewSkillPath = path.join(targetRoot, "skills", "deep-interview", "SKILL.md");
+
+		// No files on disk yet: refreshOnly must not create any (opt-in preserved).
+		const untouched = await installDefaultGjcDefinitions({ targetRoot, refreshOnly: true });
+		expect(untouched.written).toBe(0);
+		expect(untouched.missing).toBe(8);
+		expect(await Bun.file(deepInterviewSkillPath).exists()).toBe(false);
+
+		// User opted in, then a local file went stale relative to the embedded default.
+		const installed = await installDefaultGjcDefinitions({ targetRoot });
+		const canonicalDeepInterview = await Bun.file(deepInterviewSkillPath).text();
+		expect(installed.written).toBe(8);
+		await Bun.write(deepInterviewSkillPath, "stale content");
+
+		const refreshed = await installDefaultGjcDefinitions({ targetRoot, refreshOnly: true });
+		expect(refreshed.written).toBe(1);
+		expect(refreshed.matching).toBe(7);
+		expect(refreshed.missing).toBe(0);
+		expect(await Bun.file(deepInterviewSkillPath).text()).toBe(canonicalDeepInterview);
+
+		// Second refresh is a no-op once everything matches.
+		const stable = await installDefaultGjcDefinitions({ targetRoot, refreshOnly: true });
+		expect(stable.written).toBe(0);
+		expect(stable.matching).toBe(8);
+	});
+
 	it("does not make installed fragments reachable as skill-relative internal URL assets", async () => {
 		await withTempHome(async () => {
 			const repoRoot = await makeTempRoot();


### PR DESCRIPTION
## Problem

The four default workflow skills (`deep-interview`, `ralplan`, `team`, `ultragoal`) are embedded into the binary at build time (`gjc-defaults.ts`, text imports) and normally served straight from the binary at session startup (`sdk.ts`). So for most users, `gjc update` refreshes the skill text automatically because it ships inside the reinstalled package.

However, `withEmbeddedDefaultGjcSkills` (`sdk.ts`) only falls back to an embedded default when **no on-disk skill of the same name was discovered**:

```
if (!byName.has(defaultSkill.name)) { byName.set(...) }
```

Users who ran `gjc setup defaults` have on-disk copies under the agent dir (`~/.gjc/skills/*/SKILL.md`). Those copies **shadow** the embedded defaults. `gjc update` previously only reinstalled the package/binary and never touched those files, so those users kept getting **stale skill text** until they manually ran `gjc setup defaults --force`.

## Fix

- Add a `refreshOnly` mode to `installDefaultGjcDefinitions` that rewrites only files that already exist on disk but differ from the embedded defaults. Absent files stay absent (status `missing`) — no new copies are materialized for users who never opted in.
- `runUpdateCommand` calls this refresh after a successful update, reporting how many local copies were refreshed. Failures are non-fatal (warning only).

## Tests

- New test in `default-gjc-definitions.test.ts` covering: refreshOnly never creates missing files, rewrites stale copies to canonical content, and is a no-op once everything matches.
- `bun test default-gjc-definitions.test.ts` passes; typecheck (`tsgo`) clean; biome clean on changed files.