### PR TITLE
fix: prefix cmux workspace titles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `gjc update` now refreshes opted-in on-disk default workflow skill copies (written by `gjc setup defaults` under the agent dir) after a successful update, so they no longer stay stale relative to the embedded defaults; copies that were never installed are left absent.
+- cmux workspace auto-renames now include a `GJC: ` prefix so renamed workspaces remain identifiable as GJC sessions.
 
 ## [0.7.10] - 2026-07-02
 ### Added

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -24,7 +24,7 @@ For simple local side effects that do not need a full extension, set the user-le
 gjc config set completion.notifyCommand 'cmux notify --title "$GJC_NOTIFICATION_TITLE" --body "$GJC_NOTIFICATION_BODY"'
 ```
 
-When GJC is running inside a cmux terminal (`CMUX_WORKSPACE_ID` is set), GJC also best-effort renames that cmux workspace to the current GJC session name whenever the session title is set or restored.
+When GJC is running inside a cmux terminal (`CMUX_WORKSPACE_ID` is set), GJC also best-effort renames that cmux workspace to the current GJC session name with a `GJC: ` prefix whenever the session title is set or restored.
 
 Windows Terminal may keep BEL (`[Console]::Write([char]7)`) silent depending on profile and system sound settings even when `notifications.terminalBell` is enabled. For an audible Windows completion beep, configure a user-level PowerShell command hook instead:
 

--- a/packages/coding-agent/src/utils/cmux-workspace.ts
+++ b/packages/coding-agent/src/utils/cmux-workspace.ts
@@ -3,6 +3,7 @@ import { logger } from "@gajae-code/utils";
 const CMUX_COMMAND = "cmux";
 const CMUX_WORKSPACE_ID_ENV = "CMUX_WORKSPACE_ID";
 const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
+const CMUX_WORKSPACE_TITLE_PREFIX = "GJC: ";
 const CMUX_WORKSPACE_RENAME_TIMEOUT_MS = 1500;
 
 export interface CmuxWorkspaceRenameCommand {
@@ -39,6 +40,12 @@ export function sanitizeCmuxWorkspaceTitle(title: string | undefined): string | 
 	return sanitized || undefined;
 }
 
+export function formatCmuxWorkspaceTitle(title: string | undefined): string | undefined {
+	const sanitized = sanitizeCmuxWorkspaceTitle(title);
+	if (!sanitized) return undefined;
+	return sanitized.startsWith(CMUX_WORKSPACE_TITLE_PREFIX) ? sanitized : `${CMUX_WORKSPACE_TITLE_PREFIX}${sanitized}`;
+}
+
 export function buildCmuxWorkspaceRenameCommand(
 	sessionName: string | undefined,
 	env: NodeJS.ProcessEnv = process.env,
@@ -46,7 +53,7 @@ export function buildCmuxWorkspaceRenameCommand(
 	const workspaceId = env[CMUX_WORKSPACE_ID_ENV]?.trim();
 	if (!workspaceId) return null;
 
-	const title = sanitizeCmuxWorkspaceTitle(sessionName);
+	const title = formatCmuxWorkspaceTitle(sessionName);
 	if (!title) return null;
 
 	return {

--- a/packages/coding-agent/test/cmux-workspace.test.ts
+++ b/packages/coding-agent/test/cmux-workspace.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "bun:test";
 import {
 	buildCmuxWorkspaceRenameCommand,
+	formatCmuxWorkspaceTitle,
 	sanitizeCmuxWorkspaceTitle,
 	syncCmuxWorkspaceTitle,
 } from "../src/utils/cmux-workspace";
@@ -13,7 +14,7 @@ describe("cmux workspace title sync", () => {
 	it("builds an explicit workspace rename command", () => {
 		expect(buildCmuxWorkspaceRenameCommand("Investigate Resolver", cmuxEnv())).toEqual({
 			command: "cmux",
-			args: ["workspace", "rename", "workspace-123", "--title", "Investigate Resolver"],
+			args: ["workspace", "rename", "workspace-123", "--title", "GJC: Investigate Resolver"],
 		});
 	});
 
@@ -23,6 +24,11 @@ describe("cmux workspace title sync", () => {
 
 	it("sanitizes control characters and whitespace", () => {
 		expect(sanitizeCmuxWorkspaceTitle("  Fix\u0001\u001b  cmux\n\tworkspace  ")).toBe("Fix cmux workspace");
+	});
+
+	it("prefixes cmux workspace titles once", () => {
+		expect(formatCmuxWorkspaceTitle("Investigate Resolver")).toBe("GJC: Investigate Resolver");
+		expect(formatCmuxWorkspaceTitle("GJC: Investigate Resolver")).toBe("GJC: Investigate Resolver");
 	});
 
 	it("does not spawn outside a tty", () => {
@@ -58,7 +64,7 @@ describe("cmux workspace title sync", () => {
 		});
 
 		expect(calls).toEqual([
-			["/usr/local/bin/cmux", "workspace", "rename", "workspace-123", "--title", "Investigate Resolver"],
+			["/usr/local/bin/cmux", "workspace", "rename", "workspace-123", "--title", "GJC: Investigate Resolver"],
 		]);
 		expect(seenEnv[0]?.CMUX_WORKSPACE_ID).toBe("workspace-123");
 		expect(unref).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- Prefix cmux workspace auto-renames with `GJC: ` so renamed workspaces remain visibly associated with GJC.
- Avoid double-prefixing titles that already start with `GJC: `.
- Update docs/changelog and focused cmux workspace title coverage.

## QA
- `bun test packages/coding-agent/test/cmux-workspace.test.ts packages/coding-agent/test/title-generator.test.ts`
- `bun run check` in `packages/coding-agent` (completed; existing ultragoal unused-variable warnings still reported by Biome)
- `bunx biome check packages/coding-agent/src/utils/cmux-workspace.ts packages/coding-agent/src/utils/title-generator.ts packages/coding-agent/test/cmux-workspace.test.ts packages/coding-agent/README.md packages/coding-agent/CHANGELOG.md && git diff --check`
- Live cmux E2E via source import: renamed caller workspace to `GJC: Prefix QA`, verified with `cmux workspace list`, then restored to `GJC: cmux Workspace Auto Rename`.