### PR TITLE
feat(coding-agent): add Fable 5 built-in model profiles

### DIFF
--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -104,6 +104,13 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		critic: "anthropic/claude-opus-4-8:high",
 		architect: "anthropic/claude-opus-4-8:xhigh",
 	}),
+	profile("claude-fable", ["anthropic"], {
+		default: "anthropic/claude-fable-5:xhigh",
+		executor: "anthropic/claude-sonnet-5",
+		planner: "anthropic/claude-fable-5:low",
+		critic: "anthropic/claude-fable-5:high",
+		architect: "anthropic/claude-fable-5:xhigh",
+	}),
 	profile("glm-eco", ["zai"], {
 		default: "zai/glm-5.2:low",
 		executor: "zai/glm-5.2:minimal",
@@ -261,6 +268,13 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		critic: "opencode-go/mimo-v2.5-pro",
 		architect: "openai-codex/gpt-5.5:xhigh",
 	}),
+	profile("fable-opus-codex", ["anthropic", "openai-codex"], {
+		default: "anthropic/claude-fable-5:high",
+		executor: "openai-codex/gpt-5.5:high",
+		planner: "anthropic/claude-opus-4-8:medium",
+		critic: "anthropic/claude-opus-4-8:high",
+		architect: "openai-codex/gpt-5.5:xhigh",
+	}),
 ];
 
 export interface ModelProfilePresentation {
@@ -278,6 +292,7 @@ const PROFILE_PRESENTATION: Record<string, ModelProfilePresentation> = {
 	"codex-pro": { displayName: "Codex Pro", providerGroup: "CODEX" },
 	opencodego: { displayName: "OpenCodeGo", providerGroup: "OPENCODEGO" },
 	"claude-opus": { displayName: "Claude Opus", providerGroup: "CLAUDE" },
+	"claude-fable": { displayName: "Claude Fable", providerGroup: "CLAUDE" },
 	"glm-eco": { displayName: "GLM Eco", providerGroup: "GLM" },
 	"glm-medium": { displayName: "GLM Medium", providerGroup: "GLM" },
 	"glm-pro": { displayName: "GLM Pro", providerGroup: "GLM" },
@@ -299,6 +314,7 @@ const PROFILE_PRESENTATION: Record<string, ModelProfilePresentation> = {
 	"minimax-pro": { displayName: "MiniMax Pro", providerGroup: "MINIMAX" },
 	"opus-codex": { displayName: "Opus + Codex", providerGroup: "COMBOS" },
 	"codex-opencodego": { displayName: "Codex + OpenCodeGo", providerGroup: "COMBOS" },
+	"fable-opus-codex": { displayName: "Fable + Opus + Codex", providerGroup: "COMBOS" },
 };
 
 const PROFILE_GROUP_ORDER = [

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -74,6 +74,17 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 		},
 	},
 	{
+		name: "claude-fable",
+		requiredProviders: ["anthropic"],
+		mapping: {
+			default: "anthropic/claude-fable-5:xhigh",
+			executor: "anthropic/claude-sonnet-5",
+			planner: "anthropic/claude-fable-5:low",
+			critic: "anthropic/claude-fable-5:high",
+			architect: "anthropic/claude-fable-5:xhigh",
+		},
+	},
+	{
 		name: "glm-eco",
 		requiredProviders: ["zai"],
 		mapping: {
@@ -304,6 +315,17 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 			architect: "openai-codex/gpt-5.5:xhigh",
 		},
 	},
+	{
+		name: "fable-opus-codex",
+		requiredProviders: ["anthropic", "openai-codex"],
+		mapping: {
+			default: "anthropic/claude-fable-5:high",
+			executor: "openai-codex/gpt-5.5:high",
+			planner: "anthropic/claude-opus-4-8:medium",
+			critic: "anthropic/claude-opus-4-8:high",
+			architect: "openai-codex/gpt-5.5:xhigh",
+		},
+	},
 ];
 
 const oldNames = [
@@ -318,7 +340,6 @@ const oldNames = [
 	"minimax-cn-standard",
 	"kimi-standard",
 	"glm-standard",
-	"claude-fable",
 	"fable-codex",
 ];
 
@@ -330,7 +351,7 @@ function selectorExists(selector: string): boolean {
 }
 
 describe("built-in model profile catalog", () => {
-	test("contains exact 26-profile matrix cell-for-cell", () => {
+	test("contains exact 28-profile matrix cell-for-cell", () => {
 		expect(BUILTIN_MODEL_PROFILES.map(profile => profile.name)).toEqual(
 			expectedProfiles.map(profile => profile.name),
 		);

--- a/packages/coding-agent/test/model-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-profiles-redteam.test.ts
@@ -159,7 +159,7 @@ describe("model profile red-team schema and catalog cases", () => {
 		const merged = mergeModelProfiles(undefined);
 
 		expect(merged.size).toBe(BUILTIN_MODEL_PROFILES.length);
-		expect(merged.size).toBe(26);
+		expect(merged.size).toBe(28);
 		expect([...merged.values()]).toEqual([...BUILTIN_MODEL_PROFILES]);
 	});
 


### PR DESCRIPTION
## What

Add two first-class **Claude Fable 5** presets to the `/model` preset landing.

Follow-up to #1386 (which restored `anthropic/claude-fable-5` to the bundled
catalog). With the model bundled, users can now pick it as a proper preset
instead of only via a hand-written CUSTOM profile in `models.yml`.

## Changes

- **`claude-fable`** (CLAUDE group): Fable 5 main loop with Sonnet 5 executor,
  mirroring the existing `claude-opus` preset.
- **`fable-opus-codex`** (COMBOS group): a three-way combo —
  - `default`: `anthropic/claude-fable-5:high`
  - `executor`: `openai-codex/gpt-5.5:high`
  - `planner`: `anthropic/claude-opus-4-8:medium`
  - `critic`: `anthropic/claude-opus-4-8:high`
  - `architect`: `openai-codex/gpt-5.5:xhigh`

This restores the `claude-fable` profile name that was removed during the
June 2026 suspension (it was kept in the catalog test's `oldNames` guard).

## Tests

- `model-profiles-catalog.test.ts`: matrix updated 26 → 28 profiles; every
  selector still resolves in `models.json`; preset-landing group order
  unchanged (CLAUDE / COMBOS gain members, no new groups).
- `model-profiles-redteam.test.ts`: hardcoded builtin count 26 → 28.
- Full profile/selector suite passes locally (84/84 across 8 files).
- `biome check` clean.
