### PR TITLE
Fail closed on vanished gjc tmux owners

### DIFF
--- a/scripts/gjc-session/create.sh
+++ b/scripts/gjc-session/create.sh
@@ -12,6 +12,9 @@
 #   GJC_SESSION_ROUTER            router binary (default: clawhip, if present)
 #   GJC_SESSION_SKIP_ROUTER=1     skip router watch registration
 #   GJC_SESSION_STATE_DIR         durable metadata/log root (default: <worktree>/.gjc-session-state/<session>)
+#   GJC_SESSION_TMUX_BIN          tmux-compatible binary (default: tmux)
+#   GJC_SESSION_MONITOR_INTERVAL  seconds between vanished-session checks (default: 5)
+#   GJC_SESSION_MONITOR_DISABLE=1 disable external vanished-session monitor
 
 set -euo pipefail
 
@@ -22,7 +25,14 @@ MENTION="${4:-}"
 GJC_BIN="${GJC_BIN:-$(command -v gjc || true)}"
 GJC_FLAGS="${GJC_SESSION_FLAGS:-}"
 ROUTER_BIN="${GJC_SESSION_ROUTER:-$(command -v clawhip || true)}"
-TMUX_CMD=(tmux)
+TMUX_BIN="${GJC_SESSION_TMUX_BIN:-tmux}"
+TMUX_CMD=("$TMUX_BIN")
+TURN_EVIDENCE_PATTERN="${GJC_SESSION_TURN_EVIDENCE_PATTERN:-Working|Tool|Running|Executing|function call|tool call}"
+
+has_turn_evidence() {
+  [[ -s "$STATE_DIR/pane.log" ]] && grep -Eiq "$TURN_EVIDENCE_PATTERN" "$STATE_DIR/pane.log"
+}
+
 
 json_escape() {
   python3 -c 'import json,sys; print(json.dumps(sys.stdin.read())[1:-1])'
@@ -37,6 +47,7 @@ show_recovery_hint() {
   echo "durable pane log: $STATE_DIR/pane.log" >&2
   echo "durable events: $STATE_DIR/events.log" >&2
   echo "durable final status: $STATE_DIR/final.json" >&2
+  echo "durable vanished status: $STATE_DIR/vanished.json" >&2
   if [[ -s "$STATE_DIR/pane.log" ]]; then
     echo "--- durable pane log tail ---" >&2
     tail -40 "$STATE_DIR/pane.log" >&2
@@ -75,7 +86,8 @@ CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   printf '  "stateDir": "%s",\n' "$(printf '%s' "$STATE_DIR" | json_escape)"
   printf '  "paneLog": "%s",\n' "$(printf '%s' "$STATE_DIR/pane.log" | json_escape)"
   printf '  "eventsLog": "%s",\n' "$(printf '%s' "$STATE_DIR/events.log" | json_escape)"
-  printf '  "finalStatus": "%s"\n' "$(printf '%s' "$STATE_DIR/final.json" | json_escape)"
+  printf '  "finalStatus": "%s",\n' "$(printf '%s' "$STATE_DIR/final.json" | json_escape)"
+  printf '  "vanishedStatus": "%s"\n' "$(printf '%s' "$STATE_DIR/vanished.json" | json_escape)"
   printf '}\n'
 } >"$STATE_DIR/metadata.json"
 : >"$STATE_DIR/pane.log"
@@ -94,11 +106,21 @@ echo "[gjc-session] durable pane log=$GJC_SESSION_PANE_LOG"
 rc=$?
 finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 printf '[%s] gjc exited status=%s\n' "$finished_at" "$rc" >>"$GJC_SESSION_EVENTS_LOG"
-python3 - "$GJC_SESSION_FINAL_JSON" "$GJC_SESSION_NAME" "$rc" "$started_at" "$finished_at" "$GJC_SESSION_PANE_LOG" <<'PY'
+turn_evidence=false
+if [[ -s "$GJC_SESSION_PANE_LOG" ]] && grep -Eiq "$GJC_SESSION_TURN_EVIDENCE_PATTERN" "$GJC_SESSION_PANE_LOG"; then
+  turn_evidence=true
+fi
+owner_exit_reason="normal_exit"
+owner_exit_severity="normal"
+if [[ "$turn_evidence" != "true" ]]; then
+  owner_exit_reason="owner_exited_before_turn_evidence"
+  owner_exit_severity="failure"
+fi
+python3 - "$GJC_SESSION_FINAL_JSON" "$GJC_SESSION_NAME" "$rc" "$started_at" "$finished_at" "$GJC_SESSION_PANE_LOG" "$turn_evidence" "$owner_exit_reason" "$owner_exit_severity" <<'PY'
 import json
 import sys
 
-path, session, status, started_at, finished_at, pane_log = sys.argv[1:]
+path, session, status, started_at, finished_at, pane_log, turn_evidence, owner_exit_reason, owner_exit_severity = sys.argv[1:]
 with open(path, "w", encoding="utf-8") as handle:
     json.dump(
         {
@@ -107,6 +129,9 @@ with open(path, "w", encoding="utf-8") as handle:
             "startedAt": started_at,
             "finishedAt": finished_at,
             "paneLog": pane_log,
+            "turnEvidencePresent": turn_evidence == "true",
+            "ownerExitReason": owner_exit_reason,
+            "severity": owner_exit_severity,
         },
         handle,
         indent=2,
@@ -120,6 +145,81 @@ echo "[gjc-session] pane preserved for postmortem; press Ctrl-D to close"
 exec bash -l
 RUNNER
 chmod +x "$STATE_DIR/runner.sh"
+cat >"$STATE_DIR/monitor.sh" <<'MONITOR'
+#!/usr/bin/env bash
+set +e
+interval="${GJC_SESSION_MONITOR_INTERVAL:-5}"
+case "$interval" in
+  ''|*[!0-9]*) interval=5 ;;
+esac
+if [[ "$interval" -lt 1 ]]; then
+  interval=1
+fi
+printf '[%s] monitor started session=%s interval=%ss\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$GJC_SESSION_NAME" "$interval" >>"$GJC_SESSION_EVENTS_LOG"
+while true; do
+  sleep "$interval"
+  if "$GJC_SESSION_TMUX_BIN" has-session -t "$GJC_SESSION_NAME" >/dev/null 2>&1; then
+    continue
+  fi
+  detected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  final_present=false
+  [[ -s "$GJC_SESSION_FINAL_JSON" ]] && final_present=true
+  final_severity=""
+  if [[ "$final_present" == "true" ]]; then
+    final_severity="$(python3 - "$GJC_SESSION_FINAL_JSON" <<'PYFINAL'
+import json
+import sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        data = json.load(handle)
+    print(data.get("severity") or "normal")
+except Exception:
+    print("unreadable_final_status")
+PYFINAL
+)"
+  fi
+  severity="failure"
+  if [[ "$final_present" == "true" && "$final_severity" == "normal" ]]; then
+    severity="closed_after_final"
+  fi
+  printf '[%s] tmux session vanished final_present=%s severity=%s\n' "$detected_at" "$final_present" "$severity" >>"$GJC_SESSION_EVENTS_LOG"
+  python3 - "$GJC_SESSION_VANISHED_JSON" "$GJC_SESSION_NAME" "$detected_at" "$GJC_SESSION_WORKDIR" "$GJC_SESSION_BRANCH" "$GJC_SESSION_PANE_LOG" "$GJC_SESSION_EVENTS_LOG" "$GJC_SESSION_FINAL_JSON" "$final_present" "$severity" "$final_severity" <<'PYINNER'
+import json
+import sys
+
+(path, session, detected_at, workdir, branch, pane_log, events_log, final_json, final_present, severity, final_severity) = sys.argv[1:]
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(
+        {
+            "session": session,
+            "detectedAt": detected_at,
+            "workdir": workdir,
+            "branch": branch,
+            "paneLog": pane_log,
+            "eventsLog": events_log,
+            "finalStatus": final_json,
+            "finalPresent": final_present == "true",
+            "severity": severity,
+            "reason": "tmux_session_missing",
+            "finalSeverity": final_severity,
+        },
+        handle,
+        indent=2,
+    )
+    handle.write("\n")
+PYINNER
+  if [[ "$severity" == "failure" && -n "${GJC_SESSION_ROUTER_BIN:-}" && -n "${GJC_SESSION_CHANNEL:-}" ]]; then
+    "$GJC_SESSION_ROUTER_BIN" tmux stale \
+      --session "$GJC_SESSION_NAME" \
+      --pane "missing" \
+      --minutes 0 \
+      --last-line "GJC tmux session vanished before final status; see $GJC_SESSION_VANISHED_JSON" \
+      --channel "$GJC_SESSION_CHANNEL" >/dev/null 2>&1 || true
+  fi
+  exit 0
+done
+MONITOR
+chmod +x "$STATE_DIR/monitor.sh"
 
 if "${TMUX_CMD[@]}" has-session -t "$SESSION" 2>/dev/null; then
   echo "tmux session already exists: $SESSION" >&2
@@ -135,6 +235,8 @@ LAUNCH_CMD=(
   "GJC_SESSION_PANE_LOG=$STATE_DIR/pane.log"
   "GJC_SESSION_EVENTS_LOG=$STATE_DIR/events.log"
   "GJC_SESSION_FINAL_JSON=$STATE_DIR/final.json"
+  "GJC_SESSION_VANISHED_JSON=$STATE_DIR/vanished.json"
+  "GJC_SESSION_TURN_EVIDENCE_PATTERN=$TURN_EVIDENCE_PATTERN"
   "GJC_SESSION_GJC_BIN=$GJC_BIN"
   "GJC_SESSION_FLAGS=$GJC_FLAGS"
   bash "$STATE_DIR/runner.sh"
@@ -151,6 +253,29 @@ LAUNCH_SHELL="$(shell_join "${LAUNCH_CMD[@]}")"
 }
 "${TMUX_CMD[@]}" capture-pane -t "$SESSION":0.0 -p -S -200 >>"$STATE_DIR/pane.log" 2>/dev/null || true
 printf '[%s] tmux session launched and pipe attached\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$STATE_DIR/events.log"
+
+if [[ "${GJC_SESSION_MONITOR_DISABLE:-0}" != "1" ]]; then
+  MONITOR_CMD=(
+    env
+    "GJC_SESSION_NAME=$SESSION"
+    "GJC_SESSION_WORKDIR=$WORKDIR"
+    "GJC_SESSION_BRANCH=$BRANCH"
+    "GJC_SESSION_PANE_LOG=$STATE_DIR/pane.log"
+    "GJC_SESSION_EVENTS_LOG=$STATE_DIR/events.log"
+    "GJC_SESSION_FINAL_JSON=$STATE_DIR/final.json"
+    "GJC_SESSION_VANISHED_JSON=$STATE_DIR/vanished.json"
+    "GJC_SESSION_TMUX_BIN=$TMUX_BIN"
+    "GJC_SESSION_MONITOR_INTERVAL=${GJC_SESSION_MONITOR_INTERVAL:-5}"
+    "GJC_SESSION_ROUTER_BIN=$ROUTER_BIN"
+    "GJC_SESSION_CHANNEL=$CHANNEL"
+    "GJC_SESSION_TURN_EVIDENCE_PATTERN=$TURN_EVIDENCE_PATTERN"
+    bash "$STATE_DIR/monitor.sh"
+  )
+  nohup "${MONITOR_CMD[@]}" >>"$STATE_DIR/monitor.log" 2>&1 &
+  MONITOR_PID=$!
+  printf '%s\n' "$MONITOR_PID" >"$STATE_DIR/monitor.pid"
+  printf '[%s] monitor launched pid=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$MONITOR_PID" >>"$STATE_DIR/events.log"
+fi
 
 # Optional Clawhip-style router registration. Private channel ids/mentions stay caller-owned.
 if [[ "${GJC_SESSION_SKIP_ROUTER:-0}" != "1" && -n "$ROUTER_BIN" ]]; then
@@ -175,6 +300,11 @@ if ! "${TMUX_CMD[@]}" has-session -t "$SESSION" 2>/dev/null; then
   show_recovery_hint
   exit 1
 fi
+if [[ -s "$STATE_DIR/final.json" ]] && ! has_turn_evidence; then
+  echo "GJC owner exited before durable turn evidence: $SESSION" >&2
+  show_recovery_hint
+  exit 1
+fi
 if ! "${TMUX_CMD[@]}" list-panes -t "$SESSION" -F '#{pane_pid} #{pane_current_command}' >"$STATE_DIR/panes.txt" 2>/dev/null; then
   echo "GJC session has no readable panes after launch: $SESSION" >&2
   show_recovery_hint
@@ -188,5 +318,6 @@ echo "  state:   $STATE_DIR"
 echo "  log:     $STATE_DIR/pane.log"
 echo "  events:  $STATE_DIR/events.log"
 echo "  final:   $STATE_DIR/final.json"
+echo "  vanish:  $STATE_DIR/vanished.json"
 echo "  tail:    $(dirname "$0")/tail.sh $SESSION"
 echo "  prompt:  $(dirname "$0")/prompt.sh $SESSION @/path/to/prompt.md"

--- a/scripts/gjc-session/create.test.ts
+++ b/scripts/gjc-session/create.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const tempRoots: string[] = [];
+const tmuxSessions: string[] = [];
+
+async function makeExecutable(file: string, content: string): Promise<void> {
+	await fs.mkdir(path.dirname(file), { recursive: true });
+	await Bun.write(file, content);
+	await fs.chmod(file, 0o755);
+}
+
+async function makeGitWorktree(root: string): Promise<string> {
+	const worktree = path.join(root, "worktree");
+	await fs.mkdir(worktree, { recursive: true });
+	expect(Bun.spawnSync(["git", "init"], { cwd: worktree }).exitCode).toBe(0);
+	await Bun.write(path.join(worktree, "README.md"), "fixture\n");
+	expect(Bun.spawnSync(["git", "add", "README.md"], { cwd: worktree }).exitCode).toBe(0);
+	expect(
+		Bun.spawnSync(["git", "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "fixture"], {
+			cwd: worktree,
+		}).exitCode,
+	).toBe(0);
+	expect(Bun.spawnSync(["git", "checkout", "-b", "issue-1385-test"], { cwd: worktree }).exitCode).toBe(0);
+	return worktree;
+}
+
+async function waitForFile(file: string, timeoutMs = 7000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			const stat = await fs.stat(file);
+			if (stat.size > 0) return;
+		} catch {
+			// keep polling
+		}
+		await Bun.sleep(100);
+	}
+	throw new Error(`timed out waiting for ${file}`);
+}
+
+afterEach(async () => {
+	for (const session of tmuxSessions.splice(0)) {
+		Bun.spawnSync(["tmux", "kill-session", "-t", session], { stderr: "pipe", stdout: "pipe" });
+	}
+	await Promise.all(tempRoots.splice(0).map(root => fs.rm(root, { force: true, recursive: true })));
+});
+
+describe("gjc-session create", () => {
+	test("fails closed when the owner exits before durable turn evidence", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-owner-exit-"));
+		tempRoots.push(root);
+		const session = `gjc_issue_1385_exit_${process.pid}_${Date.now()}`;
+		tmuxSessions.push(session);
+		const worktree = await makeGitWorktree(root);
+		const stateDir = path.join(root, "state");
+		const fakeGjc = path.join(root, "bin", "gjc");
+		await makeExecutable(fakeGjc, "#!/usr/bin/env bash\necho 'booted without accepting work'\nexit 0\n");
+
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree], {
+			env: {
+				...process.env,
+				GJC_BIN: fakeGjc,
+				GJC_SESSION_MONITOR_DISABLE: "1",
+				GJC_SESSION_SKIP_ROUTER: "1",
+				GJC_SESSION_STATE_DIR: stateDir,
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr.toString()).toContain("GJC owner exited before durable turn evidence");
+		const finalStatus = (await Bun.file(path.join(stateDir, "final.json")).json()) as {
+			ownerExitReason: string;
+			severity: string;
+			turnEvidencePresent: boolean;
+		};
+		expect(finalStatus).toMatchObject({
+			ownerExitReason: "owner_exited_before_turn_evidence",
+			severity: "failure",
+			turnEvidencePresent: false,
+		});
+	});
+
+	test("external monitor records vanished tmux sessions and alerts the router", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-vanish-"));
+		tempRoots.push(root);
+		const session = `gjc_issue_1385_vanish_${process.pid}_${Date.now()}`;
+		tmuxSessions.push(session);
+		const worktree = await makeGitWorktree(root);
+		const stateDir = path.join(root, "state");
+		const fakeGjc = path.join(root, "bin", "gjc");
+		const routerLog = path.join(root, "router.log");
+		const fakeRouter = path.join(root, "bin", "clawhip");
+		await makeExecutable(fakeGjc, "#!/usr/bin/env bash\necho 'Gajae forge'\nsleep 60\n");
+		await makeExecutable(fakeRouter, `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> '${routerLog}'\nexit 0\n`);
+
+		const created = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree, "C-test"], {
+			env: {
+				...process.env,
+				GJC_BIN: fakeGjc,
+				GJC_SESSION_MONITOR_INTERVAL: "1",
+				GJC_SESSION_ROUTER: fakeRouter,
+				GJC_SESSION_SKIP_ROUTER: "1",
+				GJC_SESSION_STATE_DIR: stateDir,
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		expect(created.exitCode).toBe(0);
+
+		Bun.spawnSync(["tmux", "kill-session", "-t", session], { stderr: "pipe", stdout: "pipe" });
+		await waitForFile(path.join(stateDir, "vanished.json"));
+
+		const vanished = (await Bun.file(path.join(stateDir, "vanished.json")).json()) as {
+			finalPresent: boolean;
+			reason: string;
+			severity: string;
+		};
+		expect(vanished).toMatchObject({
+			finalPresent: false,
+			reason: "tmux_session_missing",
+			severity: "failure",
+		});
+		expect(await Bun.file(routerLog).text()).toContain("tmux stale --session");
+	});
+	test("prompt refuses success without durable turn evidence", async () => {
+		const session = `gjc_issue_1385_prompt_${process.pid}_${Date.now()}`;
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-prompt-"));
+		tempRoots.push(root);
+		const stateDir = path.join(root, "state");
+		await fs.mkdir(stateDir, { recursive: true });
+		await Bun.write(path.join(stateDir, "pane.log"), "");
+		tmuxSessions.push(session);
+		expect(
+			Bun.spawnSync([
+				"tmux",
+				"new-session",
+				"-d",
+				"-s",
+				session,
+				"printf 'Gajae forge\\n> Type your message\\n'; sleep 20",
+			]).exitCode,
+		).toBe(0);
+		await Bun.sleep(500);
+
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "do work"], {
+			env: {
+				...process.env,
+				GJC_SESSION_TURN_EVIDENCE_PATTERN: "__NO_TURN_EVIDENCE__",
+				GJC_SESSION_STATE_DIR: stateDir,
+				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr.toString()).toContain("prompt acceptance failed: no durable turn evidence appeared");
+	}, 20000);
+});

--- a/scripts/gjc-session/create.test.ts
+++ b/scripts/gjc-session/create.test.ts
@@ -161,4 +161,72 @@ describe("gjc-session create", () => {
 		expect(result.exitCode).toBe(1);
 		expect(result.stderr.toString()).toContain("prompt acceptance failed: no durable turn evidence appeared");
 	}, 20000);
+	test("prompt ignores stale pre-existing turn evidence", async () => {
+		const session = `gjc_issue_1385_prompt_stale_${process.pid}_${Date.now()}`;
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-prompt-stale-"));
+		tempRoots.push(root);
+		const stateDir = path.join(root, "state");
+		await fs.mkdir(stateDir, { recursive: true });
+		await Bun.write(path.join(stateDir, "pane.log"), "Tool output from previous turn\nWorking on previous prompt\n");
+		tmuxSessions.push(session);
+		expect(
+			Bun.spawnSync([
+				"tmux",
+				"new-session",
+				"-d",
+				"-s",
+				session,
+				"printf 'Gajae forge\\nWorking on previous prompt\\n> Type your message\\n'; sleep 20",
+			]).exitCode,
+		).toBe(0);
+		await Bun.sleep(500);
+
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "new prompt that sleeping process will not accept"], {
+			env: {
+				...process.env,
+				GJC_SESSION_STATE_DIR: stateDir,
+				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr.toString()).toContain("prompt acceptance failed: no durable turn evidence appeared");
+		expect(result.stdout.toString()).not.toContain("sent to");
+	}, 20000);
+
+	test("prompt accepts turn evidence produced after send", async () => {
+		const session = `gjc_issue_1385_prompt_fresh_${process.pid}_${Date.now()}`;
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-prompt-fresh-"));
+		tempRoots.push(root);
+		const stateDir = path.join(root, "state");
+		await fs.mkdir(stateDir, { recursive: true });
+		await Bun.write(path.join(stateDir, "pane.log"), "");
+		tmuxSessions.push(session);
+		expect(
+			Bun.spawnSync([
+				"tmux",
+				"new-session",
+				"-d",
+				"-s",
+				session,
+				"bash -lc \"printf 'Gajae forge\\n> Type your message\\n'; IFS= read -r line; printf '\\nWorking on accepted prompt\\n'; sleep 20\"",
+			]).exitCode,
+		).toBe(0);
+		await Bun.sleep(500);
+
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "do accepted work"], {
+			env: {
+				...process.env,
+				GJC_SESSION_STATE_DIR: stateDir,
+				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.toString()).toContain("sent to");
+	}, 20000);
 });

--- a/scripts/gjc-session/create.test.ts
+++ b/scripts/gjc-session/create.test.ts
@@ -196,6 +196,36 @@ describe("gjc-session create", () => {
 		expect(result.stdout.toString()).not.toContain("sent to");
 	}, 20000);
 
+	test("prompt ignores stale evidence when capture window shifts after send", async () => {
+		const session = `gjc_issue_1385_prompt_window_${process.pid}_${Date.now()}`;
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-prompt-window-"));
+		tempRoots.push(root);
+		const stateDir = path.join(root, "state");
+		await fs.mkdir(stateDir, { recursive: true });
+		await Bun.write(path.join(stateDir, "pane.log"), "");
+		tmuxSessions.push(session);
+		const script = `for i in $(seq 1 150); do if [ "$i" = 120 ]; then printf 'Working on previous prompt\n'; else printf 'filler %03d\n' "$i"; fi; done; printf '> Type your message\n'; sleep 20`;
+		expect(Bun.spawnSync(["tmux", "new-session", "-d", "-s", session, "bash", "-lc", script]).exitCode).toBe(0);
+		await Bun.sleep(500);
+
+		const result = Bun.spawnSync(
+			["bash", "scripts/gjc-session/prompt.sh", session, "new prompt sleeping process should not accept"],
+			{
+				env: {
+					...process.env,
+					GJC_SESSION_STATE_DIR: stateDir,
+					GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
+				},
+				stderr: "pipe",
+				stdout: "pipe",
+			},
+		);
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr.toString()).toContain("prompt acceptance failed: no durable turn evidence appeared");
+		expect(result.stdout.toString()).not.toContain("sent to");
+	}, 20000);
+
 	test("prompt accepts turn evidence produced after send", async () => {
 		const session = `gjc_issue_1385_prompt_fresh_${process.pid}_${Date.now()}`;
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-prompt-fresh-"));

--- a/scripts/gjc-session/prompt.sh
+++ b/scripts/gjc-session/prompt.sh
@@ -5,7 +5,37 @@
 set -euo pipefail
 SESSION="${1:?Usage: $0 <session-name> <text|@file>}"
 TEXT_ARG="${2:?Usage: $0 <session-name> <text|@file>}"
-TMUX_CMD=(tmux)
+TMUX_BIN="${GJC_SESSION_TMUX_BIN:-tmux}"
+TMUX_CMD=("$TMUX_BIN")
+TURN_EVIDENCE_PATTERN="${GJC_SESSION_TURN_EVIDENCE_PATTERN:-Working|Tool|Running|Executing|function call|tool call}"
+PROMPT_EVIDENCE_ATTEMPTS="${GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS:-10}"
+case "$PROMPT_EVIDENCE_ATTEMPTS" in
+  ''|*[!0-9]*) PROMPT_EVIDENCE_ATTEMPTS=10 ;;
+esac
+if [[ "$PROMPT_EVIDENCE_ATTEMPTS" -lt 1 ]]; then
+  PROMPT_EVIDENCE_ATTEMPTS=1
+fi
+
+find_durable_pane_logs() {
+  if [[ -n "${GJC_SESSION_STATE_DIR:-}" && -f "$GJC_SESSION_STATE_DIR/pane.log" ]]; then
+    printf '%s\n' "$GJC_SESSION_STATE_DIR/pane.log"
+  else
+    find "${GJC_SESSION_LOG_SEARCH_ROOT:-$HOME/Workspace}" \( -path "*/.gjc-session-state/$SESSION/pane.log" -o -path "*/$SESSION/pane.log" \) -type f 2>/dev/null | sort
+  fi
+}
+
+has_turn_evidence() {
+  local pane_text="$1"
+  if printf '%s\n' "$pane_text" | grep -Eiq "$TURN_EVIDENCE_PATTERN"; then
+    return 0
+  fi
+  local candidates=()
+  mapfile -t candidates < <(find_durable_pane_logs)
+  if [[ "${#candidates[@]}" -gt 0 ]] && grep -Eiq "$TURN_EVIDENCE_PATTERN" "${candidates[0]}"; then
+    return 0
+  fi
+  return 1
+}
 
 show_missing_session_diagnostics() {
   local log_path="$1"
@@ -35,11 +65,7 @@ fi
 
 PANE_TEXT="$(${TMUX_CMD[@]} capture-pane -t "$SESSION":0.0 -p -S -80 2>/dev/null || true)"
 if [[ -z "$PANE_TEXT" ]]; then
-  if [[ -n "${GJC_SESSION_STATE_DIR:-}" && -f "$GJC_SESSION_STATE_DIR/pane.log" ]]; then
-    candidates=("$GJC_SESSION_STATE_DIR/pane.log")
-  else
-    mapfile -t candidates < <(find "${GJC_SESSION_LOG_SEARCH_ROOT:-$HOME/Workspace}" \( -path "*/.gjc-session-state/$SESSION/pane.log" -o -path "*/$SESSION/pane.log" \) -type f 2>/dev/null | sort)
-  fi
+  mapfile -t candidates < <(find_durable_pane_logs)
   if [[ "${#candidates[@]}" -gt 0 ]]; then
     show_missing_session_diagnostics "${candidates[0]}"
   else
@@ -64,4 +90,25 @@ sleep 1
 sleep 1
 "${TMUX_CMD[@]}" send-keys -t "$SESSION" Enter
 
-echo "sent to $SESSION: ${TEXT:0:80}..."
+for _ in $(seq 1 "$PROMPT_EVIDENCE_ATTEMPTS"); do
+  sleep 1
+  PANE_TEXT="$(${TMUX_CMD[@]} capture-pane -t "$SESSION":0.0 -p -S -120 2>/dev/null || true)"
+  if [[ -z "$PANE_TEXT" ]]; then
+    mapfile -t candidates < <(find_durable_pane_logs)
+    if [[ "${#candidates[@]}" -gt 0 ]]; then
+      show_missing_session_diagnostics "${candidates[0]}"
+    else
+      echo "prompt acceptance failed: tmux session $SESSION vanished before durable turn evidence" >&2
+    fi
+    exit 1
+  fi
+  if has_turn_evidence "$PANE_TEXT"; then
+    echo "sent to $SESSION with durable turn evidence: ${TEXT:0:80}..."
+    exit 0
+  fi
+done
+
+echo "prompt acceptance failed: no durable turn evidence appeared in session $SESSION" >&2
+echo "--- pane tail ---" >&2
+printf '%s\n' "$PANE_TEXT" | tail -40 >&2
+exit 1

--- a/scripts/gjc-session/prompt.sh
+++ b/scripts/gjc-session/prompt.sh
@@ -25,12 +25,8 @@ find_durable_pane_logs() {
 }
 
 has_turn_evidence() {
-  local pane_text="$1"
-  local log_path="${2:-}"
-  local log_offset="${3:-0}"
-  if printf '%s\n' "$pane_text" | grep -Eiq "$TURN_EVIDENCE_PATTERN"; then
-    return 0
-  fi
+  local log_path="${1:-}"
+  local log_offset="${2:-0}"
   if [[ -n "$log_path" && -f "$log_path" ]]; then
     local log_size
     log_size="$(wc -c <"$log_path" | tr -d ' ')"
@@ -84,16 +80,19 @@ if ! printf '%s\n' "$PANE_TEXT" | grep -qE 'Gajae forge|Type your message|> Type
   exit 1
 fi
 
-# Establish freshness before sending. Prompt acceptance must come from pane/log
-# output produced after this boundary, not stale evidence from a previous turn.
-PANE_BASELINE_LINES="$(printf '%s\n' "$PANE_TEXT" | wc -l | tr -d ' ')"
-EVIDENCE_LOG=""
+# Establish freshness before sending. Prompt acceptance must come from output
+# captured after this boundary. Do not use a later capture-pane slice as the
+# freshness source: tmux's scrollback window can move and reclassify stale lines
+# as "new" after we paste a long prompt. A temporary pipe-pane log records only
+# bytes emitted after the boundary.
+EVIDENCE_LOG="$(mktemp "${TMPDIR:-/tmp}/gjc-session-prompt-evidence.XXXXXX")"
 EVIDENCE_LOG_OFFSET=0
-mapfile -t candidates < <(find_durable_pane_logs)
-if [[ "${#candidates[@]}" -gt 0 ]]; then
-  EVIDENCE_LOG="${candidates[0]}"
-  EVIDENCE_LOG_OFFSET="$(wc -c <"$EVIDENCE_LOG" | tr -d ' ')"
-fi
+cleanup_evidence_log() {
+  "${TMUX_CMD[@]}" pipe-pane -t "$SESSION":0.0 2>/dev/null || true
+  rm -f "$EVIDENCE_LOG"
+}
+trap cleanup_evidence_log EXIT
+"${TMUX_CMD[@]}" pipe-pane -t "$SESSION":0.0 "cat >> '$EVIDENCE_LOG'"
 
 "${TMUX_CMD[@]}" send-keys -t "$SESSION" -l "$TEXT"
 sleep 0.5
@@ -117,8 +116,7 @@ for _ in $(seq 1 "$PROMPT_EVIDENCE_ATTEMPTS"); do
     fi
     exit 1
   fi
-  NEW_PANE_TEXT="$(printf '%s\n' "$PANE_TEXT" | tail -n +$((PANE_BASELINE_LINES + 1)))"
-  if has_turn_evidence "$NEW_PANE_TEXT" "$EVIDENCE_LOG" "$EVIDENCE_LOG_OFFSET"; then
+  if has_turn_evidence "$EVIDENCE_LOG" "$EVIDENCE_LOG_OFFSET"; then
     echo "sent to $SESSION with durable turn evidence: ${TEXT:0:80}..."
     exit 0
   fi

--- a/scripts/gjc-session/prompt.sh
+++ b/scripts/gjc-session/prompt.sh
@@ -26,13 +26,17 @@ find_durable_pane_logs() {
 
 has_turn_evidence() {
   local pane_text="$1"
+  local log_path="${2:-}"
+  local log_offset="${3:-0}"
   if printf '%s\n' "$pane_text" | grep -Eiq "$TURN_EVIDENCE_PATTERN"; then
     return 0
   fi
-  local candidates=()
-  mapfile -t candidates < <(find_durable_pane_logs)
-  if [[ "${#candidates[@]}" -gt 0 ]] && grep -Eiq "$TURN_EVIDENCE_PATTERN" "${candidates[0]}"; then
-    return 0
+  if [[ -n "$log_path" && -f "$log_path" ]]; then
+    local log_size
+    log_size="$(wc -c <"$log_path" | tr -d ' ')"
+    if [[ "$log_size" -gt "$log_offset" ]] && tail -c +$((log_offset + 1)) "$log_path" | grep -Eiq "$TURN_EVIDENCE_PATTERN"; then
+      return 0
+    fi
   fi
   return 1
 }
@@ -80,6 +84,17 @@ if ! printf '%s\n' "$PANE_TEXT" | grep -qE 'Gajae forge|Type your message|> Type
   exit 1
 fi
 
+# Establish freshness before sending. Prompt acceptance must come from pane/log
+# output produced after this boundary, not stale evidence from a previous turn.
+PANE_BASELINE_LINES="$(printf '%s\n' "$PANE_TEXT" | wc -l | tr -d ' ')"
+EVIDENCE_LOG=""
+EVIDENCE_LOG_OFFSET=0
+mapfile -t candidates < <(find_durable_pane_logs)
+if [[ "${#candidates[@]}" -gt 0 ]]; then
+  EVIDENCE_LOG="${candidates[0]}"
+  EVIDENCE_LOG_OFFSET="$(wc -c <"$EVIDENCE_LOG" | tr -d ' ')"
+fi
+
 "${TMUX_CMD[@]}" send-keys -t "$SESSION" -l "$TEXT"
 sleep 0.5
 # Multiple Enters work around terminal focus/submission edge cases. Prompt visibility is not acceptance;
@@ -102,7 +117,8 @@ for _ in $(seq 1 "$PROMPT_EVIDENCE_ATTEMPTS"); do
     fi
     exit 1
   fi
-  if has_turn_evidence "$PANE_TEXT"; then
+  NEW_PANE_TEXT="$(printf '%s\n' "$PANE_TEXT" | tail -n +$((PANE_BASELINE_LINES + 1)))"
+  if has_turn_evidence "$NEW_PANE_TEXT" "$EVIDENCE_LOG" "$EVIDENCE_LOG_OFFSET"; then
     echo "sent to $SESSION with durable turn evidence: ${TEXT:0:80}..."
     exit 0
   fi


### PR DESCRIPTION
Fixes #1385.

## Summary
- Persist final owner-exit status with `turnEvidencePresent`, `ownerExitReason`, and severity outside the tmux pane.
- Add a detached vanished-session monitor that writes `vanished.json` and signals `clawhip tmux stale` when a tmux session disappears before normal final status.
- Make `prompt.sh` fail closed unless durable turn evidence appears after prompt submission.

## Verification
- `bash -n scripts/gjc-session/create.sh scripts/gjc-session/prompt.sh`
- `bun test scripts/gjc-session/create.test.ts`

Terminal state: PR_OPENED

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*