### PR TITLE
fix(coding-agent): enforce hard 2000px image ceiling regardless of autoResize

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `gjc update` now refreshes opted-in on-disk default workflow skill copies (written by `gjc setup defaults` under the agent dir) after a successful update, so they no longer stay stale relative to the embedded defaults; copies that were never installed are left absent.
 - cmux workspace auto-renames now include a `GJC: ` prefix so renamed workspaces remain identifiable as GJC sessions.
+- Enforce a hard 2000px image-dimension ceiling on image ingestion even when `images.autoResize` is disabled. A single image whose longest edge exceeds 2000px makes Anthropic reject the entire request ("many-image requests" limit) with HTTP 400 on every retry, permanently bricking the session; `loadImageInput` now always clamps over-ceiling images (in-spec images pass through untouched).
 
 ## [0.7.10] - 2026-07-02
 ### Added

--- a/packages/coding-agent/src/utils/image-loading.ts
+++ b/packages/coding-agent/src/utils/image-loading.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import type { ImageContent } from "@gajae-code/ai";
 import { formatBytes, readImageMetadata, SUPPORTED_IMAGE_MIME_TYPES } from "@gajae-code/utils";
 import { resolveReadPath } from "../tools/path-utils";
-import { formatDimensionNote, resizeImage } from "./image-resize";
+import { clampImageToApiDimensionCeiling, formatDimensionNote, resizeImage } from "./image-resize";
 
 export const MAX_IMAGE_INPUT_BYTES = 20 * 1024 * 1024;
 export const SUPPORTED_INPUT_IMAGE_MIME_TYPES = SUPPORTED_IMAGE_MIME_TYPES;
@@ -83,6 +83,21 @@ export async function loadImageInput(options: LoadImageInputOptions): Promise<Lo
 			dimensionNote = formatDimensionNote(resized);
 		} catch {
 			// keep original image when resize fails
+		}
+	} else {
+		// Auto-resize is off, but the hard API dimension ceiling MUST still hold: a single
+		// image over 2000px on any edge permanently bricks multi-image requests (HTTP 400).
+		// Downscale only when the ceiling is exceeded; in-spec images pass through untouched.
+		try {
+			const clamped = await clampImageToApiDimensionCeiling({ type: "image", data: outputData, mimeType });
+			if (clamped.wasResized) {
+				outputData = clamped.data;
+				outputMimeType = clamped.mimeType;
+				outputBytes = clamped.buffer.byteLength;
+				dimensionNote = formatDimensionNote(clamped);
+			}
+		} catch {
+			// keep original image when clamp fails
 		}
 	}
 

--- a/packages/coding-agent/src/utils/image-resize.ts
+++ b/packages/coding-agent/src/utils/image-resize.ts
@@ -23,6 +23,13 @@ export interface ResizedImage {
 // binding constraint once images are downsized to 1568px (Anthropic's internal threshold).
 const DEFAULT_MAX_BYTES = 500 * 1024;
 
+// Anthropic rejects any image whose longest edge exceeds 2000px when a request carries
+// multiple images ("many-image requests"). One over-ceiling image makes the WHOLE request
+// fail with HTTP 400 on every retry, permanently bricking the session. This is a hard
+// API-compatibility ceiling — distinct from the aggressive `images.autoResize` downscale —
+// and MUST hold even when aggressive resizing is disabled.
+export const IMAGE_API_HARD_MAX_DIMENSION = 2000;
+
 const DEFAULT_OPTIONS: Required<Omit<ImageResizeOptions, "excludeWebP">> = {
 	// Anthropic's "internal recommended size" — Anthropic model internally caps images at
 	// 1568px on the longest edge before vision processing.
@@ -288,6 +295,27 @@ export async function resizeImage(img: ImageContent, options?: ImageResizeOption
 			},
 		};
 	}
+}
+
+/**
+ * Enforce the hard API-compatibility dimension ceiling (`IMAGE_API_HARD_MAX_DIMENSION`)
+ * WITHOUT the aggressive byte/quality compression `resizeImage` applies by default.
+ *
+ * Only downscales when an edge exceeds the ceiling; in-spec images pass through untouched
+ * (`wasResized === false`). Use this on image-ingestion paths even when `images.autoResize`
+ * is disabled, because a single over-ceiling image permanently bricks multi-image requests.
+ */
+export async function clampImageToApiDimensionCeiling(
+	img: ImageContent,
+	maxDimension: number = IMAGE_API_HARD_MAX_DIMENSION,
+): Promise<ResizedImage> {
+	// Effectively unbound `maxBytes` so in-spec images are not recompressed — we want a
+	// pure dimension clamp here, not the byte-target ladder.
+	return resizeImage(img, {
+		maxWidth: maxDimension,
+		maxHeight: maxDimension,
+		maxBytes: Number.MAX_SAFE_INTEGER,
+	});
 }
 
 /**

--- a/packages/coding-agent/test/image-input.test.ts
+++ b/packages/coding-agent/test/image-input.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { readImageMetadata } from "@gajae-code/utils";
+import { loadImageInput } from "../src/utils/image-loading";
 
 describe("readImageMetadata", () => {
 	let testDir: string;
@@ -55,5 +56,55 @@ describe("readImageMetadata", () => {
 
 		const metadata = await readImageMetadata(textPath);
 		expect(metadata).toBeNull();
+	});
+});
+
+// 1x1 red PNG seed — upscaled via Bun.Image to synthesize fixtures without binary blobs.
+const RED_1X1_PNG_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+
+async function writeRedPng(dir: string, name: string, width: number, height: number): Promise<string> {
+	const seed = Buffer.from(RED_1X1_PNG_BASE64, "base64");
+	const bytes = await new Bun.Image(seed).resize(width, height, { filter: "nearest" }).png().bytes();
+	const filePath = path.join(dir, name);
+	fs.writeFileSync(filePath, bytes);
+	return filePath;
+}
+
+describe("loadImageInput hard dimension ceiling", () => {
+	let testDir: string;
+
+	beforeEach(() => {
+		testDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-image-clamp-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(testDir, { recursive: true, force: true });
+	});
+
+	it("clamps an over-2000px image even when autoResize is disabled", async () => {
+		// 2560x1080 ultrawide screenshot — the case that permanently bricks sessions.
+		const imagePath = await writeRedPng(testDir, "ultrawide.png", 2560, 1080);
+
+		const result = await loadImageInput({ path: imagePath, cwd: testDir, autoResize: false });
+
+		expect(result).not.toBeNull();
+		const { width, height } = await new Bun.Image(Buffer.from(result!.data, "base64")).metadata();
+		expect(width).toBeLessThanOrEqual(2000);
+		expect(height).toBeLessThanOrEqual(2000);
+	});
+
+	it("passes through an in-spec image unchanged when autoResize is disabled", async () => {
+		const imagePath = await writeRedPng(testDir, "in-spec.png", 1800, 1600);
+		const originalData = fs.readFileSync(imagePath).toString("base64");
+
+		const result = await loadImageInput({ path: imagePath, cwd: testDir, autoResize: false });
+
+		expect(result).not.toBeNull();
+		expect(result!.mimeType).toBe("image/png");
+		expect(result!.data).toBe(originalData);
+		const { width, height } = await new Bun.Image(Buffer.from(result!.data, "base64")).metadata();
+		expect(width).toBe(1800);
+		expect(height).toBe(1600);
 	});
 });

--- a/packages/coding-agent/test/utils/image-resize.test.ts
+++ b/packages/coding-agent/test/utils/image-resize.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { resizeImage } from "../../src/utils/image-resize";
+import {
+	clampImageToApiDimensionCeiling,
+	IMAGE_API_HARD_MAX_DIMENSION,
+	resizeImage,
+} from "../../src/utils/image-resize";
 
 // 1x1 red PNG (69 bytes) — used as a Bun.Image seed to synthesize larger fixtures
 // without checking binary blobs into the repo.
@@ -145,5 +149,43 @@ describe("resizeImage env wiring", () => {
 		Bun.env.GJC_NO_WEBP = "0";
 		const zero = await resizeImage({ type: "image", data, mimeType: "image/webp" });
 		expect(zero.mimeType).toBe("image/webp");
+	});
+});
+
+describe("clampImageToApiDimensionCeiling", () => {
+	it("downscales images that exceed the 2000px many-image ceiling", async () => {
+		// 2560x1080 — an ultrawide desktop screenshot: the real-world brick case.
+		const data = await makeRedPng(2560, 1080);
+
+		const result = await clampImageToApiDimensionCeiling({ type: "image", data, mimeType: "image/png" });
+
+		expect(result.wasResized).toBe(true);
+		expect(result.width).toBeLessThanOrEqual(IMAGE_API_HARD_MAX_DIMENSION);
+		expect(result.height).toBeLessThanOrEqual(IMAGE_API_HARD_MAX_DIMENSION);
+		// Aspect ratio preserved (with rounding tolerance).
+		expect(Math.abs(result.width / result.height - 2560 / 1080)).toBeLessThan(0.01);
+	});
+
+	it("leaves in-spec images untouched (dimension-only, no byte-target recompression)", async () => {
+		// 1800x1600 — both edges <= 2000, so the ceiling must not touch it, even though it
+		// exceeds the aggressive 1568 autoResize cap. clamp is a pure dimension guard.
+		const data = await makeRedPng(1800, 1600);
+
+		const result = await clampImageToApiDimensionCeiling({ type: "image", data, mimeType: "image/png" });
+
+		expect(result.wasResized).toBe(false);
+		expect(result.width).toBe(1800);
+		expect(result.height).toBe(1600);
+		expect(result.mimeType).toBe("image/png");
+	});
+
+	it("treats exactly 2000px as in-spec (inclusive ceiling)", async () => {
+		const data = await makeRedPng(2000, 1200);
+
+		const result = await clampImageToApiDimensionCeiling({ type: "image", data, mimeType: "image/png" });
+
+		expect(result.wasResized).toBe(false);
+		expect(result.width).toBe(2000);
+		expect(result.height).toBe(1200);
 	});
 });


### PR DESCRIPTION
## What

Enforce a hard **2000px image-dimension ceiling** on the image-ingestion path (`loadImageInput`) that always runs — even when the `images.autoResize` setting is disabled.

- New `IMAGE_API_HARD_MAX_DIMENSION` (= 2000) + `clampImageToApiDimensionCeiling()` in `utils/image-resize.ts` — a dimension-only clamp with no aggressive byte/quality recompression (in-spec images pass through untouched, `wasResized === false`).
- `loadImageInput` applies the clamp in its `autoResize === false` branch.

## Why

Anthropic rejects the **entire** request with HTTP 400 when it carries multiple images and *any* image's longest edge exceeds 2000px ("many-image requests" cap). The offending image stays in session history, so every subsequent turn re-sends it and re-fails — the session is **permanently bricked with no UI recovery path**.

`images.autoResize` (default on) already downscales to 1568px, so the default path is safe. But when a user turns auto-resize off, `loadImageInput` embedded full-resolution images, so reading one oversized image (e.g. a 2560×1080 ultrawide screenshot) could brick the session. A quality/token preference must not be able to produce a request that hard-fails forever. The `computer` tool already bounds its inline images (448b8042); this generalizes the same guarantee to the shared ingestion path.

## Testing

- `test/utils/image-resize.test.ts` — new `clampImageToApiDimensionCeiling` cases (downscales >2000px, leaves in-spec untouched, inclusive 2000px boundary). **12/12 pass locally.**
- `test/image-input.test.ts` — new `loadImageInput` integration cases (clamps an over-2000px image with `autoResize: false`; passes an in-spec image through unchanged). Requires the `@gajae-code/natives` addon (transitive import) → runs in CI.
- `tsgo --noEmit` clean on the (byte-identical) source; biome clean.

> Resubmitted against `dev` per maintainer request on #1161. Scope kept to the hard image-dimension ceiling + tests.

---

- [x] Tested locally (clamp helper tests + typecheck)
- [x] CHANGELOG updated
- [ ] `bun check` — TS/typecheck pass locally; `check:rs` + native-dependent tests deferred to CI
