### PR TITLE
Retry transient Windows psmux attach refusal

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -37,6 +37,7 @@ export const GJC_TMUX_LAUNCHED_ENV = "GJC_TMUX_LAUNCHED";
 export const GJC_LAUNCH_POLICY_ENV = "GJC_LAUNCH_POLICY";
 export const GJC_TMUX_WINDOW_LABEL_MAX_WIDTH = 48;
 export const GJC_PSMUX_PROFILE_FORCE_ENV = "GJC_PSMUX_PROFILE_FORCE";
+const WINDOWS_PSMUX_ATTACH_RETRY_DELAY_MS = 100;
 const TERMINAL_TITLE_CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
 
 type LaunchPolicy = "direct" | "tmux";
@@ -107,6 +108,8 @@ export interface TmuxLaunchPlan {
 	project?: string | null;
 	sessionId?: string | null;
 	sessionStateFile?: string | null;
+	isPsmux: boolean;
+	platform: NodeJS.Platform;
 }
 
 function explicitTmuxSessionName(env: NodeJS.ProcessEnv): string | undefined {
@@ -544,6 +547,13 @@ function isTmuxAttachDisconnectError(result: TmuxSpawnResult): boolean {
 	const stderr = result.stderr?.toLowerCase() ?? "";
 	return stderr.includes("eio") || stderr.includes("input/output error");
 }
+function isWindowsPsmuxAttachConnectionRefused(plan: TmuxLaunchPlan, result: TmuxSpawnResult): boolean {
+	if (plan.platform !== "win32" || !plan.isPsmux) return false;
+	return result.stderr?.toLowerCase().includes("os error 10061") === true;
+}
+function waitForWindowsPsmuxAttachRetry(): void {
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, WINDOWS_PSMUX_ATTACH_RETRY_DELAY_MS);
+}
 function normalizeTmuxTerminalDimension(value: number | undefined): number | undefined {
 	if (value === undefined || !Number.isSafeInteger(value) || value <= 0) return undefined;
 	return value;
@@ -644,6 +654,8 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 	const initialSize = resolveCallerTmuxTerminalSize(tty);
 	return {
 		tmuxCommand,
+		isPsmux: resolvedBinary.isPsmux,
+		platform,
 		sessionName,
 		cwd,
 		innerCommand,
@@ -742,6 +754,30 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 	const rootTerminalTitle = shouldSetGjcTmuxRootTerminalTitle(context.parsed, env)
 		? buildGjcTmuxRootTerminalTitle(plan.project ?? plan.cwd, plan.branch)
 		: undefined;
+	const buildProfileInputs = (): GjcTmuxProfileContext => ({
+		tmuxCommand: plan.tmuxCommand,
+		target: plan.sessionName,
+		cwd: plan.cwd,
+		env,
+		spawnSync,
+		branch: plan.branch,
+		project: plan.project,
+		sessionId: plan.sessionId ?? null,
+		sessionStateFile: plan.sessionStateFile ?? null,
+		version: VERSION,
+	});
+	const probeHasSession = (): TmuxSpawnResult =>
+		spawnSync(
+			plan.tmuxCommand,
+			["has-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env })],
+			probeOptions,
+		);
+	const attachCreatedSession = (): TmuxSpawnResult =>
+		spawnSync(
+			plan.tmuxCommand,
+			["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env })],
+			attachOptions,
+		);
 
 	if (plan.attachSessionName) {
 		applyGjcTmuxRootTerminalTitleProfile({
@@ -767,24 +803,6 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		// server first, and if the race fired, retry new-session before
 		// we hand the session to rename-window / applyGjcTmuxProfile so the
 		// profile-tagging path always sees a registered session.
-		const buildProfileInputs = (): GjcTmuxProfileContext => ({
-			tmuxCommand: plan.tmuxCommand,
-			target: plan.sessionName,
-			cwd: plan.cwd,
-			env,
-			spawnSync,
-			branch: plan.branch,
-			project: plan.project,
-			sessionId: plan.sessionId ?? null,
-			sessionStateFile: plan.sessionStateFile ?? null,
-			version: VERSION,
-		});
-		const probeHasSession = (): TmuxSpawnResult =>
-			spawnSync(
-				plan.tmuxCommand,
-				["has-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env })],
-				probeOptions,
-			);
 		const probeResult = probeHasSession();
 		if (probeResult.exitCode !== 0) {
 			const retry = spawnSync(plan.tmuxCommand, plan.newSessionArgs, newSessionOptions);
@@ -875,15 +893,59 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		return false;
 	}
 	// attach-session needs PTY inherit for the user-facing attach; keep it unchanged.
-	const attached = spawnSync(
-		plan.tmuxCommand,
-		["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env })],
-		attachOptions,
-	);
+	const attached = attachCreatedSession();
 	if (attached.exitCode === 0) return true;
 	if (isTmuxAttachDisconnectError(attached)) {
 		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("attach disconnected", attached.stderr));
 		return true;
+	}
+	if (isWindowsPsmuxAttachConnectionRefused(plan, attached)) {
+		waitForWindowsPsmuxAttachRetry();
+		const probeAfterAttach = probeHasSession();
+		if (probeAfterAttach.exitCode === 0) {
+			const retryAttached = attachCreatedSession();
+			if (retryAttached.exitCode === 0) return true;
+			if (isTmuxAttachDisconnectError(retryAttached)) {
+				(context.diagnosticWriter ?? safeStderrWrite)(
+					formatTmuxLaunchDiagnostic("attach disconnected", retryAttached.stderr),
+				);
+				return true;
+			}
+		} else {
+			const retry = spawnSync(plan.tmuxCommand, plan.newSessionArgs, newSessionOptions);
+			const retryProbe = probeHasSession();
+			if (retry.exitCode === 0 && retryProbe.exitCode === 0) {
+				renameTmuxWindow(
+					plan.tmuxCommand,
+					windowTitle,
+					spawnSync,
+					controlOptions,
+					buildGjcTmuxExactSessionTarget(plan.sessionName, { env }),
+				);
+				const retryProfile = applyGjcTmuxProfile(buildProfileInputs());
+				const retryOwnershipFailure = retryProfile.failures.find(item =>
+					item.command.args.includes("@gjc-profile"),
+				);
+				if (!retryOwnershipFailure) {
+					resizeCreatedTmuxWindowToCallerTerminalSize(plan, spawnSync, controlOptions);
+					applyGjcTmuxRootTerminalTitleProfile({
+						tmuxCommand: plan.tmuxCommand,
+						target: plan.sessionName,
+						title: rootTerminalTitle,
+						spawnSync,
+						options,
+					});
+					const retryAttached = attachCreatedSession();
+					if (retryAttached.exitCode === 0) return true;
+					if (isTmuxAttachDisconnectError(retryAttached)) {
+						(context.diagnosticWriter ?? safeStderrWrite)(
+							formatTmuxLaunchDiagnostic("attach disconnected", retryAttached.stderr),
+						);
+						return true;
+					}
+				}
+			}
+		}
 	}
 	cleanupCreatedTmuxSession(plan, spawnSync, options);
 	(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("attach failed", attached.stderr));

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1771,3 +1771,115 @@ it("retries new-session when the psmux server has not yet registered the session
 	expect(newSessionCalls.length).toBe(2);
 	expect(calls.filter(call => call.command === "has-session").length).toBeGreaterThanOrEqual(2);
 });
+
+it("retries Windows psmux attach once after transient os error 10061", () => {
+	const calls: Array<{ command: string; args: string[] }> = [];
+	let attachAttempts = 0;
+	const result = launchDefaultTmuxIfNeeded({
+		parsed: args({ messages: ["hello world"], tmux: true }),
+		rawArgs: ["--tmux", "hello world"],
+		cwd: "/repo",
+		env: { GJC_TMUX_COMMAND: "psmux", GJC_PSMUX_COMMAND: "psmux" },
+		argv: ["bun", "packages/coding-agent/src/cli.ts"],
+		execPath: "/bin/bun",
+		platform: "win32",
+		tty: interactiveTty,
+		tmuxAvailable: true,
+		currentBranch: "",
+		existingBranchSessionName: null,
+		diagnosticWriter: () => {},
+		spawnSync: (_command, spawnArgs) => {
+			calls.push({ command: spawnArgs[0], args: spawnArgs });
+			if (spawnArgs[0] === "attach-session") {
+				attachAttempts++;
+				if (attachAttempts === 1) {
+					return {
+						exitCode: 1,
+						stderr: "psmux: 대상 컴퓨터에서 연결을 거부했으므로 연결하지 못했습니다. (os error 10061)",
+					};
+				}
+			}
+			return { exitCode: 0 };
+		},
+	});
+
+	expect(result).toBe(true);
+	expect(calls.filter(call => call.command === "attach-session")).toHaveLength(2);
+	expect(calls.some(call => call.command === "has-session")).toBe(true);
+	expect(calls.some(call => call.command === "kill-session")).toBe(false);
+});
+
+it("recreates a Windows psmux session that disappears after transient attach os error 10061", () => {
+	const calls: Array<{ command: string; args: string[] }> = [];
+	let attachAttempts = 0;
+	let newSessionCount = 0;
+	const result = launchDefaultTmuxIfNeeded({
+		parsed: args({ messages: ["hello world"], tmux: true }),
+		rawArgs: ["--tmux", "hello world"],
+		cwd: "/repo",
+		env: { GJC_TMUX_COMMAND: "psmux", GJC_PSMUX_COMMAND: "psmux" },
+		argv: ["bun", "packages/coding-agent/src/cli.ts"],
+		execPath: "/bin/bun",
+		platform: "win32",
+		tty: interactiveTty,
+		tmuxAvailable: true,
+		currentBranch: "",
+		existingBranchSessionName: null,
+		diagnosticWriter: () => {},
+		spawnSync: (_command, spawnArgs) => {
+			calls.push({ command: spawnArgs[0], args: spawnArgs });
+			if (spawnArgs[0] === "new-session") {
+				newSessionCount++;
+				return { exitCode: 0 };
+			}
+			if (spawnArgs[0] === "has-session" && attachAttempts > 0 && newSessionCount === 1) {
+				return { exitCode: 1, stderr: "psmux: can't find session (no server running)" };
+			}
+			if (spawnArgs[0] === "attach-session") {
+				attachAttempts++;
+				if (attachAttempts === 1) {
+					return {
+						exitCode: 1,
+						stderr: "psmux: 대상 컴퓨터에서 연결을 거부했으므로 연결하지 못했습니다. (os error 10061)",
+					};
+				}
+			}
+			return { exitCode: 0 };
+		},
+	});
+
+	expect(result).toBe(true);
+	expect(calls.filter(call => call.command === "new-session")).toHaveLength(2);
+	expect(calls.filter(call => call.command === "attach-session")).toHaveLength(2);
+	expect(calls.some(call => call.args.includes("@gjc-profile"))).toBe(true);
+	expect(calls.some(call => call.command === "kill-session")).toBe(false);
+});
+
+it("does not retry Windows psmux attach failures without os error 10061", () => {
+	const calls: Array<{ command: string; args: string[] }> = [];
+	const diagnostics: string[] = [];
+	const result = launchDefaultTmuxIfNeeded({
+		parsed: args({ messages: ["hello world"], tmux: true }),
+		rawArgs: ["--tmux", "hello world"],
+		cwd: "/repo",
+		env: { GJC_TMUX_COMMAND: "psmux", GJC_PSMUX_COMMAND: "psmux" },
+		argv: ["bun", "packages/coding-agent/src/cli.ts"],
+		execPath: "/bin/bun",
+		platform: "win32",
+		tty: interactiveTty,
+		tmuxAvailable: true,
+		currentBranch: "",
+		existingBranchSessionName: null,
+		diagnosticWriter: message => diagnostics.push(message),
+		spawnSync: (_command, spawnArgs) => {
+			calls.push({ command: spawnArgs[0], args: spawnArgs });
+			if (spawnArgs[0] === "attach-session") return { exitCode: 1, stderr: "psmux: attach failed" };
+			return { exitCode: 0 };
+		},
+	});
+
+	expect(result).toBe(true);
+	expect(calls.filter(call => call.command === "attach-session")).toHaveLength(1);
+	expect(calls.some(call => call.command === "kill-session")).toBe(true);
+	expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach failed.");
+});


### PR DESCRIPTION
## Summary
- carry psmux/platform launch-plan metadata into tmux attach handling
- retry native Windows psmux attach once when stderr reports os error 10061
- re-probe/recreate disappeared sessions before retrying attach and reapplying metadata

## Verification
- bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
- bun --cwd=packages/coding-agent run check:types
- bunx biome check packages/coding-agent/src/gjc-runtime/launch-tmux.ts packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts