### PR TITLE
fix(coding-agent): retry transient psmux attach failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Retried transient native Windows psmux attach failures after managed `gjc --tmux` session creation before cleaning up the session, covering connection-refused startup races after the psmux server is killed (#1391).
 
 ### Fixed
 

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -38,6 +38,7 @@ export const GJC_LAUNCH_POLICY_ENV = "GJC_LAUNCH_POLICY";
 export const GJC_TMUX_WINDOW_LABEL_MAX_WIDTH = 48;
 export const GJC_PSMUX_PROFILE_FORCE_ENV = "GJC_PSMUX_PROFILE_FORCE";
 const TERMINAL_TITLE_CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
+const GJC_PSMUX_ATTACH_RECOVERY_DELAYS_MS = [100, 250] as const;
 
 type LaunchPolicy = "direct" | "tmux";
 
@@ -58,6 +59,7 @@ export interface TmuxLaunchContext {
 	platform?: NodeJS.Platform;
 	tty?: TtyState;
 	spawnSync?: TmuxSpawnSync;
+	sleepSync?: (milliseconds: number) => void;
 	tmuxAvailable?: boolean;
 	worktreeBranch?: string | null;
 	currentBranch?: string | null;
@@ -107,6 +109,7 @@ export interface TmuxLaunchPlan {
 	project?: string | null;
 	sessionId?: string | null;
 	sessionStateFile?: string | null;
+	isPsmux: boolean;
 }
 
 function explicitTmuxSessionName(env: NodeJS.ProcessEnv): string | undefined {
@@ -351,8 +354,8 @@ function resolveCurrentGjcCommand(context: CommandResolutionContext): string[] {
 function isWindowsPlatform(platform: NodeJS.Platform | undefined): boolean {
 	return platform === "win32";
 }
-function pathModuleForPlatform(platform: NodeJS.Platform | undefined): typeof path.win32 | typeof path {
-	return isWindowsPlatform(platform) ? path.win32 : path;
+function pathModuleForPlatform(platform: NodeJS.Platform | undefined): typeof path.win32 | typeof path.posix {
+	return isWindowsPlatform(platform) ? path.win32 : path.posix;
 }
 
 function buildInnerCommand(context: CommandResolutionContext, rawArgs: string[]): string {
@@ -500,7 +503,7 @@ function renameExistingTmuxWindowIfNeeded(context: TmuxLaunchContext): void {
 	const tty = context.tty ?? { stdin: Boolean(process.stdin.isTTY), stdout: Boolean(process.stdout.isTTY) };
 	if (!isInteractiveRootLaunch(context.parsed, tty)) return;
 
-	const tmuxCommand = resolveGjcTmuxCommand(env);
+	const tmuxCommand = resolveGjcTmuxCommand(env, context.platform ?? process.platform);
 	const tmuxAvailable = context.tmuxAvailable ?? Bun.which(tmuxCommand) !== null;
 	if (!tmuxAvailable) return;
 
@@ -662,6 +665,7 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 		project,
 		sessionId,
 		sessionStateFile,
+		isPsmux: resolvedBinary.isPsmux,
 		attachSessionName: existingSessionName,
 	};
 }
@@ -695,6 +699,13 @@ function defaultSpawnSync(command: string, args: string[], options: TmuxSpawnOpt
 	}
 	return { exitCode: result.exitCode, signalCode: result.signalCode, stderr: stderrText };
 }
+function defaultSleepSync(milliseconds: number): void {
+	Bun.sleepSync(milliseconds);
+}
+
+function shouldRecoverPsmuxAttach(plan: TmuxLaunchPlan, platform: NodeJS.Platform): boolean {
+	return platform === "win32" && plan.isPsmux;
+}
 
 export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 	renameExistingTmuxWindowIfNeeded(context);
@@ -702,7 +713,9 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 	const plan = buildDefaultTmuxLaunchPlan(context);
 	if (!plan) return false;
 	const env = context.env ?? process.env;
+	const platform = context.platform ?? process.platform;
 	const spawnSync = context.spawnSync ?? defaultSpawnSync;
+	const sleepSync = context.sleepSync ?? defaultSleepSync;
 	const options: TmuxSpawnOptions = {
 		cwd: plan.cwd,
 		env,
@@ -742,6 +755,24 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 	const rootTerminalTitle = shouldSetGjcTmuxRootTerminalTitle(context.parsed, env)
 		? buildGjcTmuxRootTerminalTitle(plan.project ?? plan.cwd, plan.branch)
 		: undefined;
+	const buildProfileInputs = (): GjcTmuxProfileContext => ({
+		tmuxCommand: plan.tmuxCommand,
+		target: plan.sessionName,
+		cwd: plan.cwd,
+		env,
+		spawnSync,
+		branch: plan.branch,
+		project: plan.project,
+		sessionId: plan.sessionId ?? null,
+		sessionStateFile: plan.sessionStateFile ?? null,
+		version: VERSION,
+	});
+	const probeHasSession = (): TmuxSpawnResult =>
+		spawnSync(
+			plan.tmuxCommand,
+			["has-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env })],
+			probeOptions,
+		);
 
 	if (plan.attachSessionName) {
 		applyGjcTmuxRootTerminalTitleProfile({
@@ -767,24 +798,6 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		// server first, and if the race fired, retry new-session before
 		// we hand the session to rename-window / applyGjcTmuxProfile so the
 		// profile-tagging path always sees a registered session.
-		const buildProfileInputs = (): GjcTmuxProfileContext => ({
-			tmuxCommand: plan.tmuxCommand,
-			target: plan.sessionName,
-			cwd: plan.cwd,
-			env,
-			spawnSync,
-			branch: plan.branch,
-			project: plan.project,
-			sessionId: plan.sessionId ?? null,
-			sessionStateFile: plan.sessionStateFile ?? null,
-			version: VERSION,
-		});
-		const probeHasSession = (): TmuxSpawnResult =>
-			spawnSync(
-				plan.tmuxCommand,
-				["has-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env })],
-				probeOptions,
-			);
 		const probeResult = probeHasSession();
 		if (probeResult.exitCode !== 0) {
 			const retry = spawnSync(plan.tmuxCommand, plan.newSessionArgs, newSessionOptions);
@@ -874,12 +887,53 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("new-session failed", stderr) + suffix);
 		return false;
 	}
+	const attachToManagedSession = (): TmuxSpawnResult =>
+		spawnSync(
+			plan.tmuxCommand,
+			["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env })],
+			attachOptions,
+		);
+	const recreateManagedSessionForAttach = (): boolean => {
+		const retry = spawnSync(plan.tmuxCommand, plan.newSessionArgs, newSessionOptions);
+		const retryProbe = probeHasSession();
+		if (retry.exitCode !== 0 || retryProbe.exitCode !== 0) return false;
+		renameTmuxWindow(
+			plan.tmuxCommand,
+			windowTitle,
+			spawnSync,
+			controlOptions,
+			buildGjcTmuxExactSessionTarget(plan.sessionName, { env }),
+		);
+		const retryProfile = applyGjcTmuxProfile(buildProfileInputs());
+		const retryOwnershipFailure = retryProfile.failures.find(item => item.command.args.includes("@gjc-profile"));
+		if (retryOwnershipFailure) return false;
+		applyGjcTmuxRootTerminalTitleProfile({
+			tmuxCommand: plan.tmuxCommand,
+			target: plan.sessionName,
+			title: rootTerminalTitle,
+			spawnSync,
+			options,
+		});
+		return true;
+	};
+	const recoverPsmuxAttach = (): TmuxSpawnResult | undefined => {
+		if (!shouldRecoverPsmuxAttach(plan, platform)) return undefined;
+		let retriedAttach: TmuxSpawnResult | undefined;
+		for (const delayMs of GJC_PSMUX_ATTACH_RECOVERY_DELAYS_MS) {
+			sleepSync(delayMs);
+			const probeResult = probeHasSession();
+			if (probeResult.exitCode !== 0 && !recreateManagedSessionForAttach()) continue;
+			retriedAttach = attachToManagedSession();
+			if (retriedAttach.exitCode === 0 || isTmuxAttachDisconnectError(retriedAttach)) return retriedAttach;
+		}
+		return retriedAttach;
+	};
 	// attach-session needs PTY inherit for the user-facing attach; keep it unchanged.
-	const attached = spawnSync(
-		plan.tmuxCommand,
-		["attach-session", "-t", buildGjcTmuxExactSessionTarget(plan.sessionName, { env })],
-		attachOptions,
-	);
+	let attached = attachToManagedSession();
+	if (attached.exitCode !== 0 && !isTmuxAttachDisconnectError(attached)) {
+		const recoveredAttach = recoverPsmuxAttach();
+		if (recoveredAttach) attached = recoveredAttach;
+	}
 	if (attached.exitCode === 0) return true;
 	if (isTmuxAttachDisconnectError(attached)) {
 		(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("attach disconnected", attached.stderr));

--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AssistantMessage } from "@gajae-code/ai";
-import { logger } from "@gajae-code/utils";
+import * as logger from "@gajae-code/utils/logger";
 
 export const GJC_COORDINATOR_SESSION_STATE_FILE_ENV = "GJC_COORDINATOR_SESSION_STATE_FILE";
 export const GJC_COORDINATOR_SESSION_ID_ENV = "GJC_COORDINATOR_SESSION_ID";

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -2,7 +2,6 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn, vi } from 
 import { Buffer } from "node:buffer";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { VERSION } from "@gajae-code/coding-agent";
 import type { Args } from "@gajae-code/coding-agent/cli/args";
 import {
 	applyGjcTmuxProfile,
@@ -16,6 +15,7 @@ import {
 } from "@gajae-code/coding-agent/gjc-runtime/launch-tmux";
 import { __setBinaryResolverForTests } from "@gajae-code/coding-agent/gjc-runtime/psmux-detect";
 import { sessionRuntimeDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
+import { VERSION } from "@gajae-code/utils/dirs";
 
 function args(overrides: Partial<Args> = {}): Args {
 	return {
@@ -1279,6 +1279,46 @@ describe("default GJC tmux launch", () => {
 		expect(diagnostics).toHaveLength(1);
 		expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach failed.");
 		expect(diagnostics[0].length).toBeLessThan(320);
+	});
+	it("retries native Windows psmux attach after transient connection refusal", () => {
+		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
+		const diagnostics: string[] = [];
+		const delays: number[] = [];
+		let attachCount = 0;
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "C:\\repo",
+			env: { GJC_TMUX_COMMAND: "psmux", GJC_PSMUX_COMMAND: "psmux" },
+			argv: ["C:\\Program Files\\GJC\\gjc.exe"],
+			execPath: "C:\\Program Files\\GJC\\gjc.exe",
+			platform: "win32",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
+			diagnosticWriter: message => diagnostics.push(message),
+			sleepSync: milliseconds => delays.push(milliseconds),
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				if (spawnArgs[0] === "attach-session") {
+					attachCount++;
+					if (attachCount === 1) {
+						return {
+							exitCode: 1,
+							stderr: "psmux: 대상 컴퓨터에서 연결을 거부했으므로 연결하지 못했습니다. (os error 10061)",
+						};
+					}
+				}
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(attachCount).toBe(2);
+		expect(delays).toEqual([100]);
+		expect(calls.some(call => call.args[0] === "kill-session")).toBe(false);
+		expect(diagnostics).toEqual([]);
 	});
 
 	it("preserves a newly created managed session when attach reports SSH disconnect EIO", () => {


### PR DESCRIPTION
## Summary

Fixes #1391.

Native Windows psmux can reject the first `attach-session` immediately after a managed `gjc --tmux` session is created, especially after the psmux server was killed and restarted. This adds a Windows+psmux-only recovery path before cleaning up the newly-created session.

## Changes

- Carry the resolved psmux/tmux verdict into the tmux launch plan.
- On native Windows psmux attach failure, briefly back off, probe `has-session`, and retry attach.
- If the session disappeared during the race, recreate it, reapply the GJC tmux profile/title metadata, and retry attach.
- Keep existing cleanup behavior for persistent failures.
- Avoid loading the broad utils index from `session-state-sidecar` so focused tmux tests do not unnecessarily trigger native addon loading.
- Add regression coverage for the Korean Windows `os error 10061` psmux connection-refused stderr.

## Verification

- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts` — 62 pass, 0 fail
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/gjc-runtime/launch-tmux.ts packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/CHANGELOG.md`