### PR TITLE
Fix queued prompts during context compaction

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Queued prompt shortcuts now keep working during auto context-full compaction: Tab/Alt+Enter queue text immediately, and Alt+Up restores only the newest queued prompt for editing instead of merging the full queue.
 
 ## [0.7.10] - 2026-07-02
 ### Added

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -201,7 +201,7 @@ export class InputController {
 		this.ctx.editor.setActionKeys("app.message.queue", this.ctx.keybindings.getKeys("app.message.queue"));
 		this.ctx.editor.onQueue = () => void this.handleQueueSubmit();
 		this.ctx.editor.onTabDeclined = () => {
-			if (this.ctx.session.isStreaming) void this.handleQueueSubmit();
+			if (this.ctx.session.isStreaming || this.ctx.session.isCompacting) void this.handleQueueSubmit();
 		};
 
 		this.ctx.editor.clearCustomKeyHandlers();
@@ -492,7 +492,7 @@ export class InputController {
 	}
 
 	handleDequeue(): void {
-		const restored = this.restoreQueuedMessagesToEditor();
+		const restored = this.restoreLatestQueuedMessageToEditor();
 		if (restored === 0) {
 			this.ctx.showStatus("No queued messages to restore");
 		} else {
@@ -610,6 +610,10 @@ export class InputController {
 		// the queued entry is later re-parsed into a skill invocation is a
 		// separate concern owned by the compaction-resume path.
 		if (this.ctx.session.isCompacting) {
+			if (this.ctx.pendingImages.length > 0) {
+				this.ctx.showStatus("Compaction in progress. Retry after it completes to send images.");
+				return;
+			}
 			this.ctx.queueCompactionMessage(text, "followUp");
 			return;
 		}
@@ -643,10 +647,28 @@ export class InputController {
 		return this.handleFollowUp();
 	}
 
+	restoreLatestQueuedMessageToEditor(options?: { currentText?: string }): number {
+		const compactionQueued = this.ctx.compactionQueuedMessages.pop();
+		const queuedText = compactionQueued?.text ?? this.ctx.session.popLastQueuedMessage();
+		if (!queuedText) {
+			this.ctx.updatePendingMessagesDisplay();
+			return 0;
+		}
+
+		this.ctx.locallySubmittedUserSignatures.delete(`${queuedText}\u00000`);
+		const currentText = options?.currentText ?? this.ctx.editor.getText();
+		const combinedText = [queuedText, currentText].filter(t => t.trim()).join("\n\n");
+		this.ctx.editor.setText(combinedText);
+		this.ctx.updatePendingMessagesDisplay();
+		return 1;
+	}
+
 	restoreQueuedMessagesToEditor(options?: { abort?: boolean; currentText?: string }): number {
 		this.ctx.locallySubmittedUserSignatures.clear();
 		const { steering, followUp } = this.ctx.session.clearQueue();
-		const allQueued = [...steering, ...followUp];
+		const compactionQueued = this.ctx.compactionQueuedMessages.map(entry => entry.text);
+		this.ctx.compactionQueuedMessages = [];
+		const allQueued = [...steering, ...followUp, ...compactionQueued];
 		if (allQueued.length === 0) {
 			this.ctx.updatePendingMessagesDisplay();
 			if (options?.abort) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -901,8 +901,9 @@ function extractPermissionLocations(
  *  `tag` is set only by `enqueueCustomMessageDisplay` (used for skill-prompt
  *  custom messages queued during streaming) and is matched by the custom-role
  *  `message_start` dequeue branch; user-message pushes leave it undefined and
- *  rely on the existing text-equality match. */
-type QueuedDisplayEntry = { text: string; tag?: string };
+ *  rely on the existing text-equality match. `sequence` preserves cross-queue
+ *  insertion order for one-at-a-time dequeue/edit UX. */
+type QueuedDisplayEntry = { text: string; tag?: string; sequence: number };
 
 /** A custom message contributed at the before-agent-start point. */
 export type BeforeAgentStartInternalMessage = Pick<
@@ -956,6 +957,7 @@ export class AgentSession {
 	/** Tracks pending follow-up messages for UI display. Removed when delivered.
 	 *  See `#steeringMessages` for entry shape. */
 	#followUpMessages: QueuedDisplayEntry[] = [];
+	#queuedDisplaySequence = 0;
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	#pendingNextTurnMessages: CustomMessage[] = [];
 	#scheduledHiddenNextTurnGeneration: number | undefined = undefined;
@@ -1625,6 +1627,14 @@ export class AgentSession {
 		this.#planCompactAbortPending = false;
 	}
 
+	#createQueuedDisplayEntry(text: string, tag?: string): QueuedDisplayEntry {
+		const entry: QueuedDisplayEntry = { text, sequence: ++this.#queuedDisplaySequence };
+		if (tag !== undefined) {
+			entry.tag = tag;
+		}
+		return entry;
+	}
+
 	/** Register a compact display string for a custom message that the caller is
 	 *  about to dispatch via `promptCustomMessage` / `sendCustomMessage`.
 	 *  Returns a stable tag the caller MUST embed in
@@ -1638,7 +1648,7 @@ export class AgentSession {
 		const tag = `gjc-cmd-${Date.now()}-${++this.#customDisplayTagCounter}`;
 		const displayText = text.trim();
 		if (!displayText) return tag;
-		const entry: QueuedDisplayEntry = { text: displayText, tag };
+		const entry = this.#createQueuedDisplayEntry(displayText, tag);
 		if (mode === "steer") {
 			this.#steeringMessages.push(entry);
 		} else {
@@ -5285,7 +5295,7 @@ export class AgentSession {
 	 */
 	async #queueSteer(text: string, images?: ImageContent[]): Promise<void> {
 		const displayText = text || (images && images.length > 0 ? "[Image]" : "");
-		this.#steeringMessages.push({ text: displayText });
+		this.#steeringMessages.push(this.#createQueuedDisplayEntry(displayText));
 		const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
 		if (images && images.length > 0) {
 			content.push(...images);
@@ -5316,7 +5326,7 @@ export class AgentSession {
 	 */
 	async #queueFollowUp(text: string, images?: ImageContent[]): Promise<void> {
 		const displayText = text || (images && images.length > 0 ? "[Image]" : "");
-		this.#followUpMessages.push({ text: displayText });
+		this.#followUpMessages.push(this.#createQueuedDisplayEntry(displayText));
 		const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
 		if (images && images.length > 0) {
 			content.push(...images);
@@ -5686,24 +5696,27 @@ export class AgentSession {
 	}
 
 	/**
-	 * Pop the last queued message (steering first, then follow-up).
+	 * Pop the newest queued message across steering and follow-up queues.
 	 * Used by dequeue keybinding to restore messages to editor one at a time.
 	 * Returns the popped entry's `.text`; the tag (if any) dies with the
 	 * record — no orphan state can outlive the queue entry.
 	 */
 	popLastQueuedMessage(): string | undefined {
-		// Pop from steering first (LIFO)
-		if (this.#steeringMessages.length > 0) {
+		const steeringEntry = this.#steeringMessages.at(-1);
+		const followUpEntry = this.#followUpMessages.at(-1);
+
+		if (steeringEntry && (!followUpEntry || steeringEntry.sequence > followUpEntry.sequence)) {
 			const entry = this.#steeringMessages.pop();
 			this.agent.popLastSteer();
 			return entry?.text;
 		}
-		// Then from follow-up
-		if (this.#followUpMessages.length > 0) {
+
+		if (followUpEntry) {
 			const entry = this.#followUpMessages.pop();
 			this.agent.popLastFollowUp();
 			return entry?.text;
 		}
+
 		return undefined;
 	}
 

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import { InputController } from "../src/modes/controllers/input-controller";
-import type { InteractiveModeContext } from "../src/modes/types";
+import type { CompactionQueuedMessage, InteractiveModeContext } from "../src/modes/types";
 
 type FakeEditor = {
 	onEscape?: () => void;
@@ -51,6 +51,21 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 	const updatePendingMessagesDisplay = vi.fn();
 	const handleBashCommand = vi.fn(async () => {});
 	const showStatus = vi.fn();
+	const compactionQueuedMessages: CompactionQueuedMessage[] = [];
+	const sessionQueuedMessages: string[] = [];
+	const queueCompactionMessage = vi.fn((text: string, mode: "steer" | "followUp") => {
+		compactionQueuedMessages.push({ text, mode });
+		editor.addToHistory(text);
+		editor.setText("");
+		updatePendingMessagesDisplay();
+		showStatus("Queued message for after compaction");
+	});
+	const popLastQueuedMessage = vi.fn(() => sessionQueuedMessages.pop());
+	const clearQueue = vi.fn(() => {
+		const followUp = [...sessionQueuedMessages];
+		sessionQueuedMessages.length = 0;
+		return { steering: [], followUp };
+	});
 	const editor: FakeEditor = {
 		setText(text: string) {
 			editorText = text;
@@ -83,6 +98,9 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 			abortBash: vi.fn(),
 			extensionRunner: undefined,
 			prompt,
+			popLastQueuedMessage,
+			clearQueue,
+			getQueuedMessages: () => ({ steering: [], followUp: [...sessionQueuedMessages] }),
 		} as unknown as InteractiveModeContext["session"],
 		keybindings: {
 			getKeys(action: string) {
@@ -90,6 +108,8 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 			},
 		} as InteractiveModeContext["keybindings"],
 		pendingImages: [],
+		compactionQueuedMessages,
+		queueCompactionMessage,
 		settings: {
 			get(path: string) {
 				if (path === "images.autoResize") return false;
@@ -162,6 +182,13 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 			updatePendingMessagesDisplay,
 			handleBashCommand,
 			showStatus,
+			queueCompactionMessage,
+			popLastQueuedMessage,
+			clearQueue,
+		},
+		queues: {
+			compactionQueuedMessages,
+			sessionQueuedMessages,
 		},
 	};
 }
@@ -263,6 +290,70 @@ describe("InputController keybinding setup", () => {
 		expect(spies.prompt).toHaveBeenCalledWith("queue after declined tab completion", {
 			streamingBehavior: "followUp",
 		});
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+	it("queues compaction Tab after editor tab completion declines", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const session = ctx.session as unknown as { isCompacting: boolean };
+		session.isCompacting = true;
+		editor.setText("queue while compacting via tab");
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onTabDeclined?.(editor.getText());
+		await Bun.sleep(0);
+
+		expect(spies.queueCompactionMessage).toHaveBeenCalledWith("queue while compacting via tab", "followUp");
+		expect(spies.prompt).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("");
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("queues explicit message action during compaction", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const session = ctx.session as unknown as { isCompacting: boolean };
+		session.isCompacting = true;
+		editor.setText("queue while compacting via shortcut");
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		await editor.onQueue?.();
+		await Bun.sleep(0);
+
+		expect(spies.queueCompactionMessage).toHaveBeenCalledWith("queue while compacting via shortcut", "followUp");
+		expect(spies.prompt).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("");
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("restores only the newest compaction queued message for editing", async () => {
+		const { InputController, ctx, editor, spies, queues } = await createContext();
+		queues.compactionQueuedMessages.push(
+			{ text: "older compaction queue", mode: "followUp" },
+			{ text: "newest compaction queue", mode: "followUp" },
+		);
+		editor.setText("current draft");
+		const controller = new InputController(ctx);
+
+		controller.handleDequeue();
+
+		expect(editor.getText()).toBe("newest compaction queue\n\ncurrent draft");
+		expect(queues.compactionQueuedMessages.map(entry => entry.text)).toEqual(["older compaction queue"]);
+		expect(spies.popLastQueuedMessage).not.toHaveBeenCalled();
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("restores only the newest session queued message for editing", async () => {
+		const { InputController, ctx, editor, spies, queues } = await createContext();
+		queues.sessionQueuedMessages.push("older session queue", "newest session queue");
+		editor.setText("current draft");
+		const controller = new InputController(ctx);
+
+		controller.handleDequeue();
+
+		expect(editor.getText()).toBe("newest session queue\n\ncurrent draft");
+		expect(queues.sessionQueuedMessages).toEqual(["older session queue"]);
+		expect(spies.clearQueue).not.toHaveBeenCalled();
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 	});
 

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -47,6 +47,29 @@ function writeSkillFile(dir: string, skillName: string, body: string): string {
 	return skillPath;
 }
 
+function isBusyRmError(error: unknown): boolean {
+	return typeof error === "object" && error !== null && "code" in error && error.code === "EBUSY";
+}
+
+async function removeTempDirWithRetry(tempDir: TempDir): Promise<void> {
+	for (let attempt = 0; attempt < 10; attempt += 1) {
+		try {
+			await fs.promises.rm(tempDir.path(), { recursive: true, force: true });
+			return;
+		} catch (error) {
+			if (!isBusyRmError(error)) {
+				throw error;
+			}
+			if (attempt === 9) {
+				// Windows can keep the SQLite temp directory busy after close; do
+				// not fail queue-behavior assertions on best-effort cleanup.
+				return;
+			}
+			await Bun.sleep(100);
+		}
+	}
+}
+
 // ============================================================================
 // E1-E3: InputController tag generation with a stubbed session.
 // ============================================================================
@@ -393,7 +416,7 @@ describe("AgentSession custom-role tag dequeue (E4-E7)", () => {
 		if (fixture) {
 			await fixture.session.dispose();
 			fixture.authStorage.close();
-			fixture.tempDir.removeSync();
+			await removeTempDirWithRetry(fixture.tempDir);
 			fixture = undefined;
 		}
 		vi.restoreAllMocks();
@@ -481,6 +504,21 @@ describe("AgentSession custom-role tag dequeue (E4-E7)", () => {
 		await Promise.resolve();
 		expect(session.getQueuedMessages().steering).toEqual([]);
 	});
+	it("E7b: popLastQueuedMessage follows newest cross-queue insertion order", async () => {
+		fixture = await createRealSession();
+		const { session } = fixture;
+
+		await session.steer("first steer");
+		await session.followUp("latest follow-up");
+
+		expect(session.popLastQueuedMessage()).toBe("latest follow-up");
+		expect(session.getQueuedMessages().steering).toEqual(["first steer"]);
+		expect(session.getQueuedMessages().followUp).toEqual([]);
+
+		expect(session.popLastQueuedMessage()).toBe("first steer");
+		expect(session.getQueuedMessages().steering).toEqual([]);
+		expect(session.getQueuedMessages().followUp).toEqual([]);
+	});
 });
 
 // ============================================================================
@@ -541,7 +579,7 @@ describe("UiHelpers / InputController against the queued-display layer (E8-E9)",
 		if (fixture) {
 			await fixture.session.dispose();
 			fixture.authStorage.close();
-			fixture.tempDir.removeSync();
+			await removeTempDirWithRetry(fixture.tempDir);
 			fixture = undefined;
 		}
 		vi.restoreAllMocks();


### PR DESCRIPTION
## What

- Keep Tab/Alt+Enter queue shortcuts active while auto context-full compaction is running.
- Let Alt+Up restore queued compaction prompts immediately.
- Restore only the newest queued prompt for editing instead of merging every queued prompt into the composer.
- Preserve newest-first behavior across steer/follow-up queues and add focused regression coverage.

## Why

During context overflow maintenance, queued prompt controls could feel frozen: Tab did not queue while compaction was active, Alt+Up could not edit compaction-held prompts, and dequeue restored the whole queue instead of the most recent prompt.

## Testing

- [x] `bun test packages/coding-agent/test/input-controller-keybindings.test.ts --test-name-pattern "compaction|newest"`
- [x] `bun test packages/coding-agent/test/input-controller-skill-queue.test.ts`
- [x] `bun test packages/coding-agent/test/issue-825-repro.test.ts`
- [x] `bun --cwd=packages/coding-agent run check:types`
- [x] `bunx biome check packages/coding-agent/src/modes/controllers/input-controller.ts packages/coding-agent/src/session/agent-session.ts packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/input-controller-skill-queue.test.ts`
- [x] CHANGELOG updated

Note: On this Windows workstation I had to install dependencies and copy the published win32 native addon into the ignored workspace native package path because Rust/cargo is not installed locally.