### PR TITLE
Fix TUI stdout EIO crash after tmux detach

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept the terminal stdout error handler armed briefly after TUI shutdown so late `EIO`/closed-PTY errors from SSH or Windows Terminal detach do not crash tmux-backed GJC panes.
+
 ## [0.7.9] - 2026-07-01
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -167,6 +167,7 @@ export function resolveTerminalRows(
 function isWindowsSubsystemForLinux(): boolean {
 	return process.platform === "linux" && (!!$env.WSL_DISTRO_NAME || !!$env.WSL_INTEROP);
 }
+const STDOUT_ERROR_HANDLER_GRACE_MS = 250;
 
 /**
  * Real terminal using process.stdin/stdout
@@ -185,6 +186,7 @@ export class ProcessTerminal implements Terminal {
 	#detachLogPath = $env.PI_TUI_TERMINAL_DETACH_LOG || "";
 	#windowsVTInputRestore?: () => void;
 	#stdoutErrorHandler?: (err: Error) => void;
+	#stdoutErrorHandlerCleanupTimer?: Timer;
 	#appearanceCallbacks: Array<(appearance: TerminalAppearance) => void> = [];
 	#appearance: TerminalAppearance | undefined;
 	#osc11Pending = false;
@@ -233,10 +235,16 @@ export class ProcessTerminal implements Terminal {
 
 		// Set up resize handler immediately
 		process.stdout.on("resize", this.#resizeHandler);
-		this.#stdoutErrorHandler = (err: Error) => {
-			this.#markUnavailable(err, "stdout-error");
-		};
-		process.stdout.on("error", this.#stdoutErrorHandler);
+		if (this.#stdoutErrorHandlerCleanupTimer) {
+			clearTimeout(this.#stdoutErrorHandlerCleanupTimer);
+			this.#stdoutErrorHandlerCleanupTimer = undefined;
+		}
+		if (!this.#stdoutErrorHandler) {
+			this.#stdoutErrorHandler = (err: Error) => {
+				this.#markUnavailable(err, "stdout-error");
+			};
+			process.stdout.on("error", this.#stdoutErrorHandler);
+		}
 
 		// Refresh terminal dimensions - they may be stale after suspend/resume
 		// (SIGWINCH is lost while process is stopped). Unix only.
@@ -692,10 +700,7 @@ export class ProcessTerminal implements Terminal {
 			process.stdout.removeListener("resize", this.#resizeHandler);
 			this.#resizeHandler = undefined;
 		}
-		if (this.#stdoutErrorHandler) {
-			process.stdout.removeListener("error", this.#stdoutErrorHandler);
-			this.#stdoutErrorHandler = undefined;
-		}
+		this.#scheduleStdoutErrorHandlerCleanup();
 
 		// Pause stdin to prevent any buffered input (e.g., Ctrl+D) from being
 		// re-interpreted after raw mode is disabled. This fixes a race condition
@@ -706,6 +711,23 @@ export class ProcessTerminal implements Terminal {
 		if (process.stdin.setRawMode) {
 			process.stdin.setRawMode(this.#wasRaw);
 		}
+	}
+
+	#scheduleStdoutErrorHandlerCleanup(): void {
+		if (!this.#stdoutErrorHandler) return;
+		if (this.#stdoutErrorHandlerCleanupTimer) clearTimeout(this.#stdoutErrorHandlerCleanupTimer);
+		// Terminal restore writes above can fail asynchronously after stop() returns
+		// when an SSH/Windows Terminal PTY disappears. Keep the stdout error listener
+		// armed briefly so late EIO/EPIPE events mark the terminal unavailable instead
+		// of surfacing as uncaught exceptions that kill the tmux pane.
+		this.#stdoutErrorHandlerCleanupTimer = setTimeout(() => {
+			if (this.#stdoutErrorHandler) {
+				process.stdout.removeListener("error", this.#stdoutErrorHandler);
+				this.#stdoutErrorHandler = undefined;
+			}
+			this.#stdoutErrorHandlerCleanupTimer = undefined;
+		}, STDOUT_ERROR_HANDLER_GRACE_MS);
+		this.#stdoutErrorHandlerCleanupTimer.unref?.();
 	}
 
 	write(data: string): void {

--- a/packages/tui/test/terminal-detach.test.ts
+++ b/packages/tui/test/terminal-detach.test.ts
@@ -183,6 +183,37 @@ describe("terminal detach handling", () => {
 			pauseSpy.mockRestore();
 		}
 	});
+	it("keeps stdout error listener armed briefly after stop restore writes", async () => {
+		const terminal = new ProcessTerminal();
+		const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const resumeSpy = vi.spyOn(process.stdin, "resume").mockImplementation(() => process.stdin);
+		const pauseSpy = vi.spyOn(process.stdin, "pause").mockImplementation(() => process.stdin);
+		await Bun.sleep(300);
+		const beforeListeners = process.stdout.listenerCount("error");
+
+		try {
+			withStdoutProperty("isTTY", true, () => {
+				terminal.start(
+					() => {},
+					() => {},
+				);
+				expect(process.stdout.listenerCount("error")).toBe(beforeListeners + 1);
+				terminal.stop();
+				expect(process.stdout.listenerCount("error")).toBe(beforeListeners + 1);
+				expect(() => {
+					process.stdout.emit("error", Object.assign(new Error("pty vanished after stop"), { code: "EIO" }));
+				}).not.toThrow();
+				expect(terminal.available).toBe(false);
+			});
+			await Bun.sleep(300);
+			expect(process.stdout.listenerCount("error")).toBe(beforeListeners);
+		} finally {
+			terminal.stop();
+			writeSpy.mockRestore();
+			resumeSpy.mockRestore();
+			pauseSpy.mockRestore();
+		}
+	});
 
 	it("marks ProcessTerminal unavailable when stdout is already closed", () => {
 		const terminal = new ProcessTerminal();


### PR DESCRIPTION
## What

- Keep the TUI stdout `error` listener armed briefly after `ProcessTerminal.stop()` restores terminal modes.
- Cancel/reuse the delayed listener cleanup on restart so repeated starts do not duplicate listeners.
- Add regression coverage for late `EIO` after stop, matching SSH/Windows Terminal closed-PTY detach behavior.
- Add an Unreleased TUI changelog entry.

## Why

`gjc --tmux` already preserves the outer tmux session when `attach-session` exits from disconnect-like failures, but the inner GJC pane can still die if terminal restoration writes race with a disappearing PTY. Bun can surface those write failures asynchronously as stdout `error` events after `stop()` has removed the listener, producing an uncaught `EIO` from `emergencyTerminalRestore` and leaving tmux with no live pane to reattach.

Keeping the listener alive for a short unref'd grace window lets the terminal mark itself unavailable instead of crashing the process.

Related context: #1045, #1051, and #1048 fixed the outer launcher/safe-stderr side of the same failure family.

## Testing

- `bun install`
- `bun --cwd=packages/natives run build`
- `bun test packages/tui/test/terminal-detach.test.ts` → 6 pass, 0 fail, 26 expect() calls
- `bun --cwd=packages/tui run check` → passed

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
