### PR TITLE
Fix /retry resume after crash

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- `/retry` now resumes sessions left with an interrupted user/custom/tool-result tail after a crash or power loss, and recovers unresolved assistant tool-use tails instead of reporting "Nothing to retry".
 
 ## [0.7.10] - 2026-07-02
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8932,22 +8932,52 @@ export class AgentSession {
 	setAutoRetryEnabled(enabled: boolean): void {
 		this.settings.set("retry.enabled", enabled);
 	}
+	#isInterruptedRetryTail(message: AgentMessage | undefined): boolean {
+		if (!message) return false;
+		return (
+			message.role === "user" ||
+			message.role === "developer" ||
+			message.role === "toolResult" ||
+			message.role === "fileMention" ||
+			message.role === "custom" ||
+			message.role === "hookMessage"
+		);
+	}
+
+	#isUnresolvedToolUseAssistant(message: AssistantMessage): boolean {
+		return message.stopReason === "toolUse" && message.content.some(content => content.type === "toolCall");
+	}
+
 	/**
-	 * Manually retry the last failed assistant turn.
-	 * Removes the error message from agent state and re-attempts with a fresh retry budget.
-	 * @returns true if retry was initiated, false if no failed turn to retry or agent is busy
+	 * Manually retry the last failed assistant turn, or resume an interrupted tail
+	 * left by a non-graceful process exit after the user/custom/tool-result message
+	 * was persisted but before the agent emitted a terminal assistant response.
+	 * Removes failed/aborted/unresolved tool-use assistant tails before
+	 * re-attempting with a fresh retry budget.
+	 * @returns true if retry/resume was initiated, false if no retryable tail exists or agent is busy
 	 */
 	async retry(): Promise<boolean> {
 		if (this.isStreaming || this.isCompacting || this.isRetrying) return false;
 
 		const messages = this.agent.state.messages;
 		const lastMsg = messages[messages.length - 1];
-		if (lastMsg?.role !== "assistant") return false;
+		if (!lastMsg) return false;
+
+		if (lastMsg.role !== "assistant") {
+			if (!this.#isInterruptedRetryTail(lastMsg)) return false;
+			this.#retryAttempt = 0;
+			this.#scheduleAgentContinue({ delayMs: 1 });
+			return true;
+		}
 
 		const assistantMsg = lastMsg as AssistantMessage;
-		if (assistantMsg.stopReason !== "error" && assistantMsg.stopReason !== "aborted") return false;
+		const shouldDropAssistant =
+			assistantMsg.stopReason === "error" ||
+			assistantMsg.stopReason === "aborted" ||
+			this.#isUnresolvedToolUseAssistant(assistantMsg);
+		if (!shouldDropAssistant) return false;
 
-		// Remove the failed/aborted assistant message (same as auto-retry does before re-attempting)
+		// Remove the failed/aborted/incomplete assistant message before re-attempting.
 		this.agent.replaceMessages(messages.slice(0, -1));
 
 		// Reset retry budget for a fresh attempt

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1045,7 +1045,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "retry",
-		description: "Retry the last failed agent turn",
+		description: "Retry or resume the last interrupted agent turn",
 		handleTui: async (_command, runtime) => {
 			const didRetry = await runtime.ctx.session.retry();
 			if (!didRetry) {

--- a/packages/coding-agent/test/agent-session-manual-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-manual-retry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { Agent } from "@gajae-code/agent-core";
+import { Agent, type AgentMessage } from "@gajae-code/agent-core";
 import { type AssistantMessage, getBundledModel } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
@@ -16,6 +17,46 @@ function lastAgentMessage(session: AgentSession): AssistantMessage {
 		throw new Error("Expected trailing assistant message");
 	}
 	return message as AssistantMessage;
+}
+
+function getTestModel() {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) {
+		throw new Error("Expected bundled Anthropic test model to exist");
+	}
+	return model;
+}
+
+function emptyUsage(): AssistantMessage["usage"] {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function isBusyRmError(error: unknown): boolean {
+	return typeof error === "object" && error !== null && "code" in error && error.code === "EBUSY";
+}
+
+async function removeTempDirWithRetry(tempDir: TempDir): Promise<void> {
+	for (let attempt = 0; attempt < 10; attempt += 1) {
+		try {
+			await fs.rm(tempDir.path(), { recursive: true, force: true });
+			return;
+		} catch (error) {
+			if (!isBusyRmError(error)) {
+				throw error;
+			}
+			if (attempt === 9) {
+				return;
+			}
+			await Bun.sleep(100);
+		}
+	}
 }
 
 describe("AgentSession manual retry", () => {
@@ -35,7 +76,7 @@ describe("AgentSession manual retry", () => {
 			session = undefined;
 		}
 		authStorage.close();
-		tempDir.removeSync();
+		await removeTempDirWithRetry(tempDir);
 	});
 
 	it("removes the failed assistant turn and continues with a fresh attempt", async () => {
@@ -78,6 +119,93 @@ describe("AgentSession manual retry", () => {
 		expect(mock.calls.length).toBe(2);
 		expect(lastAgentMessage(session).stopReason).toBe("stop");
 		expect(lastAgentMessage(session).content).toContainEqual({ type: "text", text: "recovered after manual retry" });
+	});
+
+	it("continues from a persisted user tail left by a process crash", async () => {
+		const model = getTestModel();
+		const mock = createMockModel({
+			responses: [{ content: ["resumed after crash"], stopReason: "stop" }],
+		});
+		const messages: AgentMessage[] = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "continue this after restart" }],
+				timestamp: Date.now(),
+			},
+		];
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages,
+			},
+			streamFn: mock.stream,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false, "retry.enabled": false }),
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+		session.subscribe(() => {});
+
+		await expect(session.retry()).resolves.toBe(true);
+		await session.waitForIdle();
+
+		expect(mock.calls.length).toBe(1);
+		expect(lastAgentMessage(session).content).toContainEqual({ type: "text", text: "resumed after crash" });
+	});
+
+	it("drops an unresolved tool-use assistant tail before crash retry", async () => {
+		const model = getTestModel();
+		const mock = createMockModel({
+			responses: [{ content: ["reran after tool crash"], stopReason: "stop" }],
+		});
+		const messages: AgentMessage[] = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "use a tool" }],
+				timestamp: Date.now(),
+			},
+			{
+				role: "assistant",
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "README.md" } }],
+				usage: emptyUsage(),
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+			},
+		];
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages,
+			},
+			streamFn: mock.stream,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false, "retry.enabled": false }),
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+		session.subscribe(() => {});
+
+		await expect(session.retry()).resolves.toBe(true);
+		await session.waitForIdle();
+
+		expect(mock.calls.length).toBe(1);
+		expect(
+			session.agent.state.messages.some(message => message.role === "assistant" && message.stopReason === "toolUse"),
+		).toBe(false);
+		expect(lastAgentMessage(session).content).toContainEqual({ type: "text", text: "reran after tool crash" });
 	});
 
 	it("returns false when the trailing assistant turn succeeded", async () => {


### PR DESCRIPTION
## What

- Teach `/retry` to resume interrupted persisted tails after a crash or power loss instead of only accepting assistant `error` / `aborted` tails.
- Recover sessions that ended with a persisted user/custom/tool-result/file-mention message before a terminal assistant response was written.
- Recover unresolved assistant `toolUse` tails by dropping the incomplete assistant tool-call message and rerunning from the prior context.
- Update the slash command description and changelog.

## Why

If the computer or process dies after the user prompt is persisted but before the assistant response reaches `message_end`, the reopened session ends in a non-assistant tail. The old `retry()` rejected that state, so `/retry` displayed "Nothing to retry" even though the turn was actually resumable.

## Testing

- [x] `bun test packages/coding-agent/test/agent-session-manual-retry.test.ts`
- [x] `bun test packages/coding-agent/test/slash-commands/retry.test.ts`
- [x] `bun --cwd=packages/coding-agent run check:types`
- [x] `bunx biome check packages/coding-agent/src/session/agent-session.ts packages/coding-agent/src/slash-commands/builtin-registry.ts packages/coding-agent/test/agent-session-manual-retry.test.ts packages/coding-agent/test/slash-commands/retry.test.ts`
- [x] CHANGELOG updated

Note: On this Windows workstation, the published win32 native addon was copied into the ignored workspace native package path because Rust/cargo is not installed locally.