### PR TITLE
Fix hotkeys markdown test after command discoverability update

### DIFF
--- a/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
+++ b/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
@@ -13,6 +13,7 @@ describe("buildHotkeysMarkdown", () => {
 			"app.clear": "Ctrl+C",
 			"app.exit": "Ctrl+D",
 			"app.suspend": "Ctrl+Z",
+			"app.session.new": "Ctrl+N",
 			"app.thinking.cycle": "Shift+Tab",
 			"app.model.cycleForward": "Ctrl+P",
 			"app.model.cycleBackward": "Shift+Ctrl+P",
@@ -41,7 +42,8 @@ describe("buildHotkeysMarkdown", () => {
 		expect(markdown).toContain("| `Ctrl+Shift+L` | Select model (temporary) |");
 		expect(markdown).toContain("| `Ctrl+L` | Select default model |");
 		expect(markdown).toContain("| `Alt+M` | Toggle plan mode |");
-		expect(markdown).toContain("| `#` | Open prompt actions |");
+		expect(markdown).toContain("| `Ctrl+N` | Start a fresh session |");
+		expect(markdown).toContain("| `#` | Prompt actions (command-palette style actions) |");
 		for (const line of lines) {
 			if (line.length === 0) continue;
 			expect(line.startsWith(" ")).toBe(false);


### PR DESCRIPTION
## What

- Update the hotkeys markdown test fixture for the new `app.session.new` row added by #1396.
- Update the `#` prompt-action label expectation to the new command-palette wording.

## Why

Post-merge dev CI failed in `Affected path validation / test:@gajae-code/coding-agent` because the full coding-agent test suite includes `buildHotkeysMarkdown`, and that test still asserted the pre-#1396 hotkeys output.

## Testing

- `bun install --frozen-lockfile`
- `bun test packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
