### PR TITLE
Fix queued prompts during compaction

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - `/retry` now resumes sessions left with an interrupted user/custom/tool-result tail after a crash or power loss, and recovers unresolved assistant tool-use tails instead of reporting "Nothing to retry".
+- Queued prompt shortcuts now keep working during auto context-full compaction: Tab/Alt+Enter queue text immediately, and Alt+Up restores only the newest queued prompt for editing instead of merging the full queue.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - `/retry` now resumes sessions left with an interrupted user/custom/tool-result tail after a crash or power loss, and recovers unresolved assistant tool-use tails instead of reporting "Nothing to retry".
 - Queued prompt shortcuts now keep working during auto context-full compaction: Tab/Alt+Enter queue text immediately, and Alt+Up restores only the newest queued prompt for editing instead of merging the full queue.
+- Queued prompt shortcuts now keep working during auto context-full compaction: Tab/Alt+Enter queue text immediately, `/skill:*` entries replay through the skill invocation path after compaction, and Alt+Up restores only the newest queued prompt for editing instead of merging the full queue.
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -603,12 +603,10 @@ export class InputController {
 		const text = this.ctx.editor.getText().trim();
 		if (!text) return;
 
-		// Compaction first: while compacting, free text gets queued via
-		// `queueCompactionMessage`, and `/skill:*` rides the same queue so a
-		// skill typed during compaction is not lost or short-circuited through
-		// `promptCustomMessage`. The skill text is queued verbatim; whether
-		// the queued entry is later re-parsed into a skill invocation is a
-		// separate concern owned by the compaction-resume path.
+		// Compaction first: while compacting, queue free text and `/skill:*`
+		// commands in the compaction-local queue. `flushCompactionQueue`
+		// replays skill entries through the custom-message skill path after
+		// compaction finishes so they are not degraded into plain prompts.
 		if (this.ctx.session.isCompacting) {
 			if (this.ctx.pendingImages.length > 0) {
 				this.ctx.showStatus("Compaction in progress. Retry after it completes to send images.");

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -201,7 +201,7 @@ export class InputController {
 		this.ctx.editor.setActionKeys("app.message.queue", this.ctx.keybindings.getKeys("app.message.queue"));
 		this.ctx.editor.onQueue = () => void this.handleQueueSubmit();
 		this.ctx.editor.onTabDeclined = () => {
-			if (this.ctx.session.isStreaming) void this.handleQueueSubmit();
+			if (this.ctx.session.isStreaming || this.ctx.session.isCompacting) void this.handleQueueSubmit();
 		};
 
 		this.ctx.editor.clearCustomKeyHandlers();
@@ -492,7 +492,7 @@ export class InputController {
 	}
 
 	handleDequeue(): void {
-		const restored = this.restoreQueuedMessagesToEditor();
+		const restored = this.restoreLatestQueuedMessageToEditor();
 		if (restored === 0) {
 			this.ctx.showStatus("No queued messages to restore");
 		} else {
@@ -610,6 +610,10 @@ export class InputController {
 		// the queued entry is later re-parsed into a skill invocation is a
 		// separate concern owned by the compaction-resume path.
 		if (this.ctx.session.isCompacting) {
+			if (this.ctx.pendingImages.length > 0) {
+				this.ctx.showStatus("Compaction in progress. Retry after it completes to send images.");
+				return;
+			}
 			this.ctx.queueCompactionMessage(text, "followUp");
 			return;
 		}
@@ -643,10 +647,28 @@ export class InputController {
 		return this.handleFollowUp();
 	}
 
+	restoreLatestQueuedMessageToEditor(options?: { currentText?: string }): number {
+		const compactionQueued = this.ctx.compactionQueuedMessages.pop();
+		const queuedText = compactionQueued?.text ?? this.ctx.session.popLastQueuedMessage();
+		if (!queuedText) {
+			this.ctx.updatePendingMessagesDisplay();
+			return 0;
+		}
+
+		this.ctx.locallySubmittedUserSignatures.delete(`${queuedText}\u00000`);
+		const currentText = options?.currentText ?? this.ctx.editor.getText();
+		const combinedText = [queuedText, currentText].filter(t => t.trim()).join("\n\n");
+		this.ctx.editor.setText(combinedText);
+		this.ctx.updatePendingMessagesDisplay();
+		return 1;
+	}
+
 	restoreQueuedMessagesToEditor(options?: { abort?: boolean; currentText?: string }): number {
 		this.ctx.locallySubmittedUserSignatures.clear();
 		const { steering, followUp } = this.ctx.session.clearQueue();
-		const allQueued = [...steering, ...followUp];
+		const compactionQueued = this.ctx.compactionQueuedMessages.map(entry => entry.text);
+		this.ctx.compactionQueuedMessages = [];
+		const allQueued = [...steering, ...followUp, ...compactionQueued];
 		if (allQueued.length === 0) {
 			this.ctx.updatePendingMessagesDisplay();
 			if (options?.abort) {

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -2,6 +2,8 @@ import type { AgentMessage } from "@gajae-code/agent-core";
 import type { AssistantMessage, ImageContent, Message } from "@gajae-code/ai";
 import { type Component, Spacer, Text, TruncatedText } from "@gajae-code/tui";
 import { settings } from "../../config/settings";
+import { resolveSubskillActivationForSkillInvocation } from "../../extensibility/gjc-plugins";
+import { buildSkillPromptMessage, parseSkillInvocations } from "../../extensibility/skills";
 import { AssistantMessageComponent } from "../../modes/components/assistant-message";
 import { BashExecutionComponent } from "../../modes/components/bash-execution";
 import { BranchSummaryMessageComponent } from "../../modes/components/branch-summary-message";
@@ -610,9 +612,80 @@ export class UiHelpers {
 		this.ctx.updatePendingMessagesDisplay();
 		this.ctx.showStatus("Queued message for after compaction");
 	}
+	#hasSkillInvocations(text: string): boolean {
+		return parseSkillInvocations(text, this.ctx.skillCommands ?? new Map()).length > 0;
+	}
 
+	#isCompactionCommandMessage(text: string): boolean {
+		return this.#hasSkillInvocations(text) || this.isKnownSlashCommand(text);
+	}
+
+	async #deliverQueuedSkillMessage(message: CompactionQueuedMessage): Promise<boolean> {
+		const invocations = parseSkillInvocations(message.text, this.ctx.skillCommands ?? new Map());
+		if (invocations.length === 0) {
+			return false;
+		}
+
+		for (let index = 0; index < invocations.length; index += 1) {
+			const invocation = invocations[index];
+			if (!invocation) continue;
+
+			const activationResult = await resolveSubskillActivationForSkillInvocation({
+				cwd: this.ctx.sessionManager.getCwd(),
+				sessionId: this.ctx.session.sessionId,
+				skillName: invocation.skill.name,
+				args: invocation.args,
+			});
+			const built = await buildSkillPromptMessage(invocation.skill, activationResult.cleanedArgs, {
+				subskillActivation: activationResult.activation,
+				subskillActivationSet: activationResult.activeSubskillsToPersist,
+				cwd: this.ctx.sessionManager.getCwd(),
+				sessionId: this.ctx.session.sessionId,
+			});
+			const details: SkillPromptDetails = built.details;
+			const displayText = `/${invocation.commandName}${activationResult.cleanedArgs ? ` ${activationResult.cleanedArgs}` : ""}`;
+
+			if (this.ctx.session.isStreaming) {
+				const tag = this.ctx.session.enqueueCustomMessageDisplay(displayText, message.mode);
+				details.__pendingDisplayTag = tag;
+			}
+
+			const isLast = index === invocations.length - 1;
+			if (!this.ctx.session.isStreaming && !isLast) {
+				await this.ctx.session.sendCustomMessage({
+					customType: SKILL_PROMPT_MESSAGE_TYPE,
+					content: built.message,
+					display: true,
+					details,
+					attribution: "user",
+				});
+				continue;
+			}
+
+			await this.ctx.session.promptCustomMessage(
+				{
+					customType: SKILL_PROMPT_MESSAGE_TYPE,
+					content: built.message,
+					display: true,
+					details,
+					attribution: "user",
+				},
+				{ streamingBehavior: message.mode },
+			);
+		}
+
+		if (this.ctx.session.isStreaming) {
+			this.ctx.updatePendingMessagesDisplay();
+			this.ctx.ui.requestRender();
+		}
+
+		return true;
+	}
 	async #deliverQueuedMessage(message: CompactionQueuedMessage): Promise<void> {
-		if (this.ctx.isKnownSlashCommand(message.text)) {
+		if (await this.#deliverQueuedSkillMessage(message)) {
+			return;
+		}
+		if (this.isKnownSlashCommand(message.text)) {
 			await this.ctx.session.prompt(message.text);
 			return;
 		}
@@ -671,14 +744,14 @@ export class UiHelpers {
 
 			let firstPromptIndex = -1;
 			for (let i = 0; i < queuedMessages.length; i++) {
-				if (!this.ctx.isKnownSlashCommand(queuedMessages[i].text)) {
+				if (!this.#isCompactionCommandMessage(queuedMessages[i].text)) {
 					firstPromptIndex = i;
 					break;
 				}
 			}
 			if (firstPromptIndex === -1) {
 				for (const message of queuedMessages) {
-					await this.ctx.session.prompt(message.text);
+					await this.#deliverQueuedMessage(message);
 				}
 				return;
 			}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -901,8 +901,9 @@ function extractPermissionLocations(
  *  `tag` is set only by `enqueueCustomMessageDisplay` (used for skill-prompt
  *  custom messages queued during streaming) and is matched by the custom-role
  *  `message_start` dequeue branch; user-message pushes leave it undefined and
- *  rely on the existing text-equality match. */
-type QueuedDisplayEntry = { text: string; tag?: string };
+ *  rely on the existing text-equality match. `sequence` preserves cross-queue
+ *  insertion order for one-at-a-time dequeue/edit UX. */
+type QueuedDisplayEntry = { text: string; tag?: string; sequence: number };
 
 /** A custom message contributed at the before-agent-start point. */
 export type BeforeAgentStartInternalMessage = Pick<
@@ -956,6 +957,7 @@ export class AgentSession {
 	/** Tracks pending follow-up messages for UI display. Removed when delivered.
 	 *  See `#steeringMessages` for entry shape. */
 	#followUpMessages: QueuedDisplayEntry[] = [];
+	#queuedDisplaySequence = 0;
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	#pendingNextTurnMessages: CustomMessage[] = [];
 	#scheduledHiddenNextTurnGeneration: number | undefined = undefined;
@@ -1625,6 +1627,14 @@ export class AgentSession {
 		this.#planCompactAbortPending = false;
 	}
 
+	#createQueuedDisplayEntry(text: string, tag?: string): QueuedDisplayEntry {
+		const entry: QueuedDisplayEntry = { text, sequence: ++this.#queuedDisplaySequence };
+		if (tag !== undefined) {
+			entry.tag = tag;
+		}
+		return entry;
+	}
+
 	/** Register a compact display string for a custom message that the caller is
 	 *  about to dispatch via `promptCustomMessage` / `sendCustomMessage`.
 	 *  Returns a stable tag the caller MUST embed in
@@ -1638,7 +1648,7 @@ export class AgentSession {
 		const tag = `gjc-cmd-${Date.now()}-${++this.#customDisplayTagCounter}`;
 		const displayText = text.trim();
 		if (!displayText) return tag;
-		const entry: QueuedDisplayEntry = { text: displayText, tag };
+		const entry = this.#createQueuedDisplayEntry(displayText, tag);
 		if (mode === "steer") {
 			this.#steeringMessages.push(entry);
 		} else {
@@ -5285,7 +5295,7 @@ export class AgentSession {
 	 */
 	async #queueSteer(text: string, images?: ImageContent[]): Promise<void> {
 		const displayText = text || (images && images.length > 0 ? "[Image]" : "");
-		this.#steeringMessages.push({ text: displayText });
+		this.#steeringMessages.push(this.#createQueuedDisplayEntry(displayText));
 		const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
 		if (images && images.length > 0) {
 			content.push(...images);
@@ -5316,7 +5326,7 @@ export class AgentSession {
 	 */
 	async #queueFollowUp(text: string, images?: ImageContent[]): Promise<void> {
 		const displayText = text || (images && images.length > 0 ? "[Image]" : "");
-		this.#followUpMessages.push({ text: displayText });
+		this.#followUpMessages.push(this.#createQueuedDisplayEntry(displayText));
 		const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
 		if (images && images.length > 0) {
 			content.push(...images);
@@ -5686,24 +5696,27 @@ export class AgentSession {
 	}
 
 	/**
-	 * Pop the last queued message (steering first, then follow-up).
+	 * Pop the newest queued message across steering and follow-up queues.
 	 * Used by dequeue keybinding to restore messages to editor one at a time.
 	 * Returns the popped entry's `.text`; the tag (if any) dies with the
 	 * record — no orphan state can outlive the queue entry.
 	 */
 	popLastQueuedMessage(): string | undefined {
-		// Pop from steering first (LIFO)
-		if (this.#steeringMessages.length > 0) {
+		const steeringEntry = this.#steeringMessages.at(-1);
+		const followUpEntry = this.#followUpMessages.at(-1);
+
+		if (steeringEntry && (!followUpEntry || steeringEntry.sequence > followUpEntry.sequence)) {
 			const entry = this.#steeringMessages.pop();
 			this.agent.popLastSteer();
 			return entry?.text;
 		}
-		// Then from follow-up
-		if (this.#followUpMessages.length > 0) {
+
+		if (followUpEntry) {
 			const entry = this.#followUpMessages.pop();
 			this.agent.popLastFollowUp();
 			return entry?.text;
 		}
+
 		return undefined;
 	}
 

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import { InputController } from "../src/modes/controllers/input-controller";
-import type { InteractiveModeContext } from "../src/modes/types";
+import type { CompactionQueuedMessage, InteractiveModeContext } from "../src/modes/types";
 
 type FakeEditor = {
 	onEscape?: () => void;
@@ -51,6 +51,21 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 	const updatePendingMessagesDisplay = vi.fn();
 	const handleBashCommand = vi.fn(async () => {});
 	const showStatus = vi.fn();
+	const compactionQueuedMessages: CompactionQueuedMessage[] = [];
+	const sessionQueuedMessages: string[] = [];
+	const queueCompactionMessage = vi.fn((text: string, mode: "steer" | "followUp") => {
+		compactionQueuedMessages.push({ text, mode });
+		editor.addToHistory(text);
+		editor.setText("");
+		updatePendingMessagesDisplay();
+		showStatus("Queued message for after compaction");
+	});
+	const popLastQueuedMessage = vi.fn(() => sessionQueuedMessages.pop());
+	const clearQueue = vi.fn(() => {
+		const followUp = [...sessionQueuedMessages];
+		sessionQueuedMessages.length = 0;
+		return { steering: [], followUp };
+	});
 	const editor: FakeEditor = {
 		setText(text: string) {
 			editorText = text;
@@ -83,6 +98,9 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 			abortBash: vi.fn(),
 			extensionRunner: undefined,
 			prompt,
+			popLastQueuedMessage,
+			clearQueue,
+			getQueuedMessages: () => ({ steering: [], followUp: [...sessionQueuedMessages] }),
 		} as unknown as InteractiveModeContext["session"],
 		keybindings: {
 			getKeys(action: string) {
@@ -90,6 +108,8 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 			},
 		} as InteractiveModeContext["keybindings"],
 		pendingImages: [],
+		compactionQueuedMessages,
+		queueCompactionMessage,
 		settings: {
 			get(path: string) {
 				if (path === "images.autoResize") return false;
@@ -162,6 +182,13 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 			updatePendingMessagesDisplay,
 			handleBashCommand,
 			showStatus,
+			queueCompactionMessage,
+			popLastQueuedMessage,
+			clearQueue,
+		},
+		queues: {
+			compactionQueuedMessages,
+			sessionQueuedMessages,
 		},
 	};
 }
@@ -263,6 +290,70 @@ describe("InputController keybinding setup", () => {
 		expect(spies.prompt).toHaveBeenCalledWith("queue after declined tab completion", {
 			streamingBehavior: "followUp",
 		});
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+	it("queues compaction Tab after editor tab completion declines", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const session = ctx.session as unknown as { isCompacting: boolean };
+		session.isCompacting = true;
+		editor.setText("queue while compacting via tab");
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onTabDeclined?.(editor.getText());
+		await Bun.sleep(0);
+
+		expect(spies.queueCompactionMessage).toHaveBeenCalledWith("queue while compacting via tab", "followUp");
+		expect(spies.prompt).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("");
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("queues explicit message action during compaction", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const session = ctx.session as unknown as { isCompacting: boolean };
+		session.isCompacting = true;
+		editor.setText("queue while compacting via shortcut");
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		await editor.onQueue?.();
+		await Bun.sleep(0);
+
+		expect(spies.queueCompactionMessage).toHaveBeenCalledWith("queue while compacting via shortcut", "followUp");
+		expect(spies.prompt).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("");
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("restores only the newest compaction queued message for editing", async () => {
+		const { InputController, ctx, editor, spies, queues } = await createContext();
+		queues.compactionQueuedMessages.push(
+			{ text: "older compaction queue", mode: "followUp" },
+			{ text: "newest compaction queue", mode: "followUp" },
+		);
+		editor.setText("current draft");
+		const controller = new InputController(ctx);
+
+		controller.handleDequeue();
+
+		expect(editor.getText()).toBe("newest compaction queue\n\ncurrent draft");
+		expect(queues.compactionQueuedMessages.map(entry => entry.text)).toEqual(["older compaction queue"]);
+		expect(spies.popLastQueuedMessage).not.toHaveBeenCalled();
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("restores only the newest session queued message for editing", async () => {
+		const { InputController, ctx, editor, spies, queues } = await createContext();
+		queues.sessionQueuedMessages.push("older session queue", "newest session queue");
+		editor.setText("current draft");
+		const controller = new InputController(ctx);
+
+		controller.handleDequeue();
+
+		expect(editor.getText()).toBe("newest session queue\n\ncurrent draft");
+		expect(queues.sessionQueuedMessages).toEqual(["older session queue"]);
+		expect(spies.clearQueue).not.toHaveBeenCalled();
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 	});
 

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -245,6 +245,30 @@ describe("InputController #invokeSkillCommand (E1-E3)", () => {
 		expect(ctx.showError).not.toHaveBeenCalled();
 	});
 
+	it("E3c: compaction queue flush replays /skill entries through the skill custom-message path", async () => {
+		const { ctx, prompt, promptCustomMessage } = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: false,
+		});
+		ctx.compactionQueuedMessages.push({ text: "/skill:test-skill from compaction", mode: "followUp" });
+
+		const uiHelpers = new UiHelpers(ctx);
+		await uiHelpers.flushCompactionQueue();
+
+		expect(prompt).not.toHaveBeenCalled();
+		expect(promptCustomMessage).toHaveBeenCalledTimes(1);
+		const firstCall = promptCustomMessage.mock.calls[0];
+		expect(firstCall).toBeDefined();
+		if (!firstCall) {
+			throw new Error("expected promptCustomMessage to be called");
+		}
+		const messageArg = firstCall[0];
+		expect(messageArg.content).toContain("Do the thing.");
+		expect(messageArg.content).toContain("User: from compaction");
+		expect(firstCall[1]).toEqual({ streamingBehavior: "followUp" });
+		expect(ctx.compactionQueuedMessages).toEqual([]);
+	});
+
 	it("E3: not streaming -> enqueueCustomMessageDisplay NOT called and tag absent", async () => {
 		const { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage } = createStubInputControllerContext({
 			skillCommands,

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -47,6 +47,29 @@ function writeSkillFile(dir: string, skillName: string, body: string): string {
 	return skillPath;
 }
 
+function isBusyRmError(error: unknown): boolean {
+	return typeof error === "object" && error !== null && "code" in error && error.code === "EBUSY";
+}
+
+async function removeTempDirWithRetry(tempDir: TempDir): Promise<void> {
+	for (let attempt = 0; attempt < 10; attempt += 1) {
+		try {
+			await fs.promises.rm(tempDir.path(), { recursive: true, force: true });
+			return;
+		} catch (error) {
+			if (!isBusyRmError(error)) {
+				throw error;
+			}
+			if (attempt === 9) {
+				// Windows can keep the SQLite temp directory busy after close; do
+				// not fail queue-behavior assertions on best-effort cleanup.
+				return;
+			}
+			await Bun.sleep(100);
+		}
+	}
+}
+
 // ============================================================================
 // E1-E3: InputController tag generation with a stubbed session.
 // ============================================================================
@@ -393,7 +416,7 @@ describe("AgentSession custom-role tag dequeue (E4-E7)", () => {
 		if (fixture) {
 			await fixture.session.dispose();
 			fixture.authStorage.close();
-			fixture.tempDir.removeSync();
+			await removeTempDirWithRetry(fixture.tempDir);
 			fixture = undefined;
 		}
 		vi.restoreAllMocks();
@@ -481,6 +504,21 @@ describe("AgentSession custom-role tag dequeue (E4-E7)", () => {
 		await Promise.resolve();
 		expect(session.getQueuedMessages().steering).toEqual([]);
 	});
+	it("E7b: popLastQueuedMessage follows newest cross-queue insertion order", async () => {
+		fixture = await createRealSession();
+		const { session } = fixture;
+
+		await session.steer("first steer");
+		await session.followUp("latest follow-up");
+
+		expect(session.popLastQueuedMessage()).toBe("latest follow-up");
+		expect(session.getQueuedMessages().steering).toEqual(["first steer"]);
+		expect(session.getQueuedMessages().followUp).toEqual([]);
+
+		expect(session.popLastQueuedMessage()).toBe("first steer");
+		expect(session.getQueuedMessages().steering).toEqual([]);
+		expect(session.getQueuedMessages().followUp).toEqual([]);
+	});
 });
 
 // ============================================================================
@@ -541,7 +579,7 @@ describe("UiHelpers / InputController against the queued-display layer (E8-E9)",
 		if (fixture) {
 			await fixture.session.dispose();
 			fixture.authStorage.close();
-			fixture.tempDir.removeSync();
+			await removeTempDirWithRetry(fixture.tempDir);
 			fixture = undefined;
 		}
 		vi.restoreAllMocks();


### PR DESCRIPTION
## What
- Allow Tab/Alt+Enter follow-up queuing while context compaction is running by storing compaction-local queued messages.
- Make Alt+Up restore queued messages immediately during compaction.
- Restore only the newest queued prompt first, even when multiple prompts are queued.
- Preserve `/skill:*` semantics for compaction-queued input by replaying skill entries through the custom-message skill invocation path instead of plain text.

## Why
- Replaces #1400, which was closed after review found that queued `/skill:*` commands were replayed as plain text.
- This version adds the missing skill replay path and a regression test.

## Testing
- bun test packages/coding-agent/test/input-controller-skill-queue.test.ts
- bun test packages/coding-agent/test/input-controller-keybindings.test.ts -t "compaction|newest"
- bun --cwd=packages/coding-agent run check:types
- bunx biome check packages/coding-agent/src/modes/utils/ui-helpers.ts packages/coding-agent/src/modes/controllers/input-controller.ts packages/coding-agent/test/input-controller-skill-queue.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts
- git diff --check