### PR TITLE
Fix Escape abort after compaction queue change

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -664,7 +664,7 @@ export class InputController {
 	restoreQueuedMessagesToEditor(options?: { abort?: boolean; currentText?: string }): number {
 		this.ctx.locallySubmittedUserSignatures.clear();
 		const { steering, followUp } = this.ctx.session.clearQueue();
-		const compactionQueued = this.ctx.compactionQueuedMessages.map(entry => entry.text);
+		const compactionQueued = (this.ctx.compactionQueuedMessages ?? []).map(entry => entry.text);
 		this.ctx.compactionQueuedMessages = [];
 		const allQueued = [...steering, ...followUp, ...compactionQueued];
 		if (allQueued.length === 0) {


### PR DESCRIPTION
Fixes the post-merge CI failure from PR #1403 by keeping Escape abort restoration tolerant of contexts without a compaction-local queue while preserving compaction-queued "/skill:*" custom-message delivery.

Focused tests run:
- `bun test packages/coding-agent/test/input-controller-escape.test.ts`
- `bun test packages/coding-agent/test/input-controller-skill-queue.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*