### PR TITLE
fix(coding-agent): preserve tmux resume picker

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -235,7 +235,7 @@ providers:
 
 ### Interactive `--tmux` startup and scroll/mouse profile
 
-`gjc --tmux` launches the interactive TUI inside a fresh GJC-managed tmux session. Plain `gjc --tmux` does not auto-attach a scoped managed session from the same project/branch; use an explicit resume path such as `gjc --tmux --continue`, `gjc --tmux --resume`, or `gjc session attach <session>` when you intend to continue existing tmux context. Older-version sessions are not auto-attached after upgrades. When GJC creates a session it applies a profile that is **scoped to the GJC session only** (it never runs `set -g` / global tmux options), including:
+`gjc --tmux` launches the interactive TUI inside a fresh GJC-managed tmux session. Plain `gjc --tmux` does not auto-attach a scoped managed session from the same project/branch; use `gjc --tmux --continue` or `gjc session attach <session>` when you intend to continue existing tmux context. `gjc --tmux --resume` still reaches the inner GJC session resolver, so value-less resume shows the session picker and `--resume <id>` honors that target instead of reusing a branch tmux session. Older-version sessions are not auto-attached after upgrades. When GJC creates a session it applies a profile that is **scoped to the GJC session only** (it never runs `set -g` / global tmux options), including:
 
 - `mouse on` — enables mouse-wheel scrolling into tmux copy-mode (history/scrollback).
 - `set-clipboard on` and a readable copy-mode `mode-style`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - `gjc update` now refreshes opted-in on-disk default workflow skill copies (written by `gjc setup defaults` under the agent dir) after a successful update, so they no longer stay stale relative to the embedded defaults; copies that were never installed are left absent.
 - cmux workspace auto-renames now include a `GJC: ` prefix so renamed workspaces remain identifiable as GJC sessions.
+- `gjc --tmux --resume` now reaches the session picker/resume target instead of auto-attaching a same-branch managed tmux session before the inner resume resolver runs.
 
 ## [0.7.10] - 2026-07-02
 ### Added

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -120,7 +120,9 @@ function hasCurrentGjcVersion(session: GjcTmuxSessionStatus | undefined): boolea
 }
 
 function allowsExistingTmuxAttach(parsed: Args, env: NodeJS.ProcessEnv): boolean {
-	return Boolean(parsed.continue || parsed.resume || explicitTmuxSessionName(env));
+	// `--resume` belongs to the inner GJC session resolver. Let it reach main.ts so
+	// value-less resume can show the session picker and valued resume can honor the target.
+	return Boolean(parsed.continue || explicitTmuxSessionName(env));
 }
 
 function findExistingSessionForLaunch(context: {

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -583,8 +583,8 @@ describe("default GJC tmux launch", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
 		try {
 			const handled = launchDefaultTmuxIfNeeded({
-				parsed: args({ messages: ["hello world"], tmux: true, resume: true }),
-				rawArgs: ["--tmux", "--resume", "hello world"],
+				parsed: args({ messages: ["hello world"], tmux: true, continue: true }),
+				rawArgs: ["--tmux", "--continue", "hello world"],
 				cwd: "/repo",
 				env: { GJC_TMUX_COMMAND: "psmux", GJC_PSMUX_COMMAND: "psmux" },
 				argv: ["bun", "packages/coding-agent/src/cli.ts"],
@@ -607,11 +607,11 @@ describe("default GJC tmux launch", () => {
 		}
 	});
 
-	it("explicit resume attaches existing tagged session for matching worktree branch", () => {
+	it("value-less resume launches inner picker instead of attaching an existing tagged session", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
 		const handled = launchDefaultTmuxIfNeeded({
-			parsed: args({ messages: ["hello world"], tmux: true, resume: true }),
-			rawArgs: ["--tmux", "--resume", "hello world"],
+			parsed: args({ tmux: true, resume: true }),
+			rawArgs: ["--tmux", "--resume"],
 			cwd: "/repo",
 			env: {},
 			argv: ["bun", "packages/coding-agent/src/cli.ts"],
@@ -628,15 +628,38 @@ describe("default GJC tmux launch", () => {
 		});
 
 		expect(handled).toBe(true);
-		expect(calls.some(call => call.args[0] === "new-session")).toBe(false);
-		expect(calls.at(-1)?.args).toEqual(["attach-session", "-t", "=gajae_code_feature"]);
+		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
+		expect(calls.some(call => call.args[0] === "attach-session" && call.args[2] === "=gajae_code_feature")).toBe(
+			false,
+		);
+		expect(calls.find(call => call.args[0] === "new-session")?.args.at(-1)).toContain("--resume");
+	});
+
+	it("targeted resume launches inner session resolver instead of branch tmux attach", () => {
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ tmux: true, resume: "abc123" }),
+			rawArgs: ["--tmux", "--resume", "abc123"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			worktreeBranch: "feature/demo",
+			existingBranchSessionName: "gajae_code_feature",
+		});
+
+		expect(plan?.attachSessionName).toBeUndefined();
+		expect(plan?.innerCommand).toContain("--resume");
+		expect(plan?.innerCommand).toContain("abc123");
 	});
 
 	it("falls through to a fresh session when existing tagged session attach fails", () => {
 		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
 		const handled = launchDefaultTmuxIfNeeded({
-			parsed: args({ messages: ["hello world"], tmux: true, resume: true }),
-			rawArgs: ["--tmux", "--resume", "hello world"],
+			parsed: args({ messages: ["hello world"], tmux: true, continue: true }),
+			rawArgs: ["--tmux", "--continue", "hello world"],
 			cwd: "/repo",
 			env: {},
 			argv: ["bun", "packages/coding-agent/src/cli.ts"],


### PR DESCRIPTION
## Summary
- stop the outer `gjc --tmux` launcher from treating `--resume` as permission to attach an existing same-branch tmux session
- keep `--continue` and explicit tmux session overrides on the existing attach path
- add regression coverage for value-less `--tmux --resume` picker routing and `--resume <id>` target routing
- update tmux startup docs and changelog

## Verification
- `git diff --check`
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts`
- `bun --cwd=packages/coding-agent run check`

## Notes
- Broader related run `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts packages/coding-agent/test/gjc-runtime/tmux-gc.test.ts` exposed an existing `tmux-gc.test.ts` environment/mock mismatch (`worktree_list_failed` vs `branch_no_worktree_without_terminal_marker`); the changed launch/resume tests pass.