### PR TITLE
perf(web_search): class-based timeouts, hedged DDG fallback, chain caching, prewarm, faster Gemini fail-through

### DIFF
--- a/docs/tools/web_search.md
+++ b/docs/tools/web_search.md
@@ -85,7 +85,7 @@ Streaming: none. `WebSearchTool.execute()` does not forward its `_signal` argume
    - `limit`, `recency`, `temperature`, `maxOutputTokens`, `numSearchResults`,
    - `systemPrompt` from `packages/coding-agent/src/prompts/tools/web-search.md`.
 6. On the first successful `SearchResponse`, `formatForLLM()` renders answer/sources/citations/related/search-queries into one text block and returns it with `details.response`.
-7. If a provider throws, `executeSearch()` records the error and tries the next provider. There is no provider-level parallel fan-out; fallback is sequential.
+7. If a provider throws, `executeSearch()` records the error and tries the next provider. Fallback is sequential, with one exception: when DuckDuckGo is a non-primary chain member, `executeSearch()` fires it as a background hedge after `DDG_HEDGE_DELAY_MS` (3s). A successful primary aborts the hedge; a failing primary reuses the (typically already-settled) hedge result, collapsing fallback latency from `t(primary failure) + t(ddg)` to `max(t(primary failure), t(ddg))`.
 8. After all candidates fail, `formatProviderError()` normalizes the last error:
    - Anthropic `404` becomes `Anthropic web search returned 404 (model or endpoint not found).`
    - `401`/`403` become `<Provider> authorization failed ...` except Z.AI, which preserves its raw message.
@@ -143,7 +143,7 @@ Streaming: none. `WebSearchTool.execute()` does not forward its `_signal` argume
     - When a search ran (`web_search_tool_result` / `server_tool_use` / `usage.server_tool_use.web_search_requests`) but only inline citations were emitted, sources are recovered from the answer text via `providers/text-citations.ts`. If no search ran and nothing is grounded, it fails closed (`424`) so the chain falls through to DuckDuckGo.
   - **Gemini** — `packages/coding-agent/src/web/search/providers/gemini.ts`
     - Availability: OAuth credentials in `agent.db` for `google-gemini-cli` or `google-antigravity`.
-    - Querying: SSE `streamGenerateContent` call with Google Search grounding enabled. Antigravity auth tries two fallback endpoints and retries `401/403/400 invalid auth` once after token refresh; `429/5xx` retry with exponential backoff and server-provided retry delay, capped by a `5 * 60 * 1000` ms rate-limit budget.
+    - Querying: SSE `streamGenerateContent` call with Google Search grounding enabled. Antigravity auth tries two fallback endpoints and retries `401/403/400 invalid auth` once after token refresh; `429/5xx` retry with exponential backoff and server-provided retry delay, capped by a `30 * 1000` ms rate-limit budget (the chain always terminates in keyless DuckDuckGo, so a rate-limited Gemini fails through fast instead of parking the chain).
     - `max_tokens` and `temperature` pass through as `generationConfig.maxOutputTokens` / `generationConfig.temperature`.
     - `limit` and `num_search_results` are collapsed together before dispatch.
     - Output may include `answer`, `sources`, `citations`, `searchQueries`, `usage`, `model`.
@@ -197,6 +197,7 @@ Streaming: none. `WebSearchTool.execute()` does not forward its `_signal` argume
   - None.
 - Session state (transcript, memory, jobs, checkpoints, registries)
   - Uses a module-global provider-instance cache in `packages/coding-agent/src/web/search/provider.ts`.
+  - Uses a WeakMap-keyed resolved-chain cache (per AuthStorage, 60s TTL) in the same file; `WebSearchTool`'s constructor prewarms it via `prewarmSearchProviders()`.
   - Uses a module-global preferred-provider setting in the same file.
   - `packages/coding-agent/src/tools/index.ts` gates tool availability behind `session.settings.get("web_search.enabled")`.
 - Background work / cancellation
@@ -215,7 +216,10 @@ Streaming: none. `WebSearchTool.execute()` does not forward its `_signal` argume
 - SearXNG result count: default `10`, max `20` (`packages/coding-agent/src/web/search/providers/searxng.ts`).
 - Perplexity API-key mode defaults: `max_tokens = 8192`, `temperature = 0.2`, `num_search_results = 10` (`packages/coding-agent/src/web/search/providers/perplexity.ts`).
 - Anthropic defaults: model `anthropic-model-haiku-4-5`, `DEFAULT_MAX_TOKENS = 4096` when the provider omits `max_tokens` (`packages/coding-agent/src/web/search/providers/anthropic.ts`).
-- Gemini retries: up to `3` retries per endpoint, base delay `1000` ms, rate-limit delay budget `5 * 60 * 1000` ms (`packages/coding-agent/src/web/search/providers/gemini.ts`).
+- Gemini retries: up to `3` retries per endpoint, base delay `1000` ms, rate-limit delay budget `30 * 1000` ms (`packages/coding-agent/src/web/search/providers/gemini.ts`).
+- Hard timeouts are class-based (`packages/coding-agent/src/web/search/providers/utils.ts`): pure search APIs `SEARCH_API_TIMEOUT_MS = 15_000`, LLM-mediated providers `SEARCH_LLM_TIMEOUT_MS = 120_000`, legacy fallback `SEARCH_HARD_TIMEOUT_MS = 300_000` for untagged call sites. A user-configured `web_search.timeout` overrides class defaults.
+- DuckDuckGo hedge delay: `DDG_HEDGE_DELAY_MS = 3_000` (`packages/coding-agent/src/web/search/index.ts`).
+- Resolved provider chains are cached per `AuthStorage` instance for `CHAIN_CACHE_TTL_MS = 60_000`; `setPreferredSearchProvider()` / `setSearchFallbackProviders()` clear the cache (`packages/coding-agent/src/web/search/provider.ts`).
 
 ## Errors
 - There is no "no provider configured" case: DuckDuckGo (keyless) is always appended as the terminal fallback, so the chain is never empty.

--- a/docs/tools/web_search.md
+++ b/docs/tools/web_search.md
@@ -217,9 +217,9 @@ Streaming: none. `WebSearchTool.execute()` does not forward its `_signal` argume
 - Perplexity API-key mode defaults: `max_tokens = 8192`, `temperature = 0.2`, `num_search_results = 10` (`packages/coding-agent/src/web/search/providers/perplexity.ts`).
 - Anthropic defaults: model `anthropic-model-haiku-4-5`, `DEFAULT_MAX_TOKENS = 4096` when the provider omits `max_tokens` (`packages/coding-agent/src/web/search/providers/anthropic.ts`).
 - Gemini retries: up to `3` retries per endpoint, base delay `1000` ms, rate-limit delay budget `30 * 1000` ms (`packages/coding-agent/src/web/search/providers/gemini.ts`).
-- Hard timeouts are class-based (`packages/coding-agent/src/web/search/providers/utils.ts`): pure search APIs `SEARCH_API_TIMEOUT_MS = 15_000`, LLM-mediated providers `SEARCH_LLM_TIMEOUT_MS = 120_000`, legacy fallback `SEARCH_HARD_TIMEOUT_MS = 300_000` for untagged call sites. A user-configured `web_search.timeout` overrides class defaults.
+- Hard timeouts are class-based (`packages/coding-agent/src/web/search/providers/utils.ts`): pure search APIs `SEARCH_API_TIMEOUT_MS = 15_000`, LLM-mediated providers `SEARCH_LLM_TIMEOUT_MS = 120_000`, legacy fallback `SEARCH_HARD_TIMEOUT_MS = 300_000` for untagged call sites. Kimi uses an explicit `KIMI_HARD_TIMEOUT_MS = 35_000` aligned with its upstream `timeout_seconds: 30` budget. An explicitly configured `web_search.timeout` overrides class defaults (`applyConfiguredSearchTimeout()` gates on `settings.has`, so the schema default 300 does not reinstall a uniform ceiling).
 - DuckDuckGo hedge delay: `DDG_HEDGE_DELAY_MS = 3_000` (`packages/coding-agent/src/web/search/index.ts`).
-- Resolved provider chains are cached per `AuthStorage` instance for `CHAIN_CACHE_TTL_MS = 60_000`; `setPreferredSearchProvider()` / `setSearchFallbackProviders()` clear the cache (`packages/coding-agent/src/web/search/provider.ts`).
+- Resolved provider chains are cached per `AuthStorage` instance for `CHAIN_CACHE_TTL_MS = 60_000`, keyed on the storage credential generation so login/logout invalidates immediately; `setPreferredSearchProvider()` / `setSearchFallbackProviders()` clear the cache (`packages/coding-agent/src/web/search/provider.ts`).
 
 ## Errors
 - There is no "no provider configured" case: DuckDuckGo (keyless) is always appended as the terminal fallback, so the chain is never empty.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 - cmux workspace auto-renames now include a `GJC: ` prefix so renamed workspaces remain identifiable as GJC sessions.
 - `gjc --tmux --resume` now reaches the session picker/resume target instead of auto-attaching a same-branch managed tmux session before the inner resume resolver runs.
 
+### Changed
+
+- `web_search` latency overhaul: provider hard timeouts are now class-based (pure search APIs 15s, LLM-mediated providers 120s, replacing the uniform 300s ceiling; `web_search.timeout` still overrides), DuckDuckGo is fired as a background hedge 3s into a slower primary so a failing primary falls back to an already-settled result, the Gemini 429/5xx retry-delay budget dropped from 5 minutes to 30 seconds, resolved provider chains are cached per AuthStorage for 60s (availability probes skipped on repeat searches), and `WebSearchTool` prewarms the chain at construction. Measured: hung-primary fallback 301s → 15s, slow-failing-primary fallback ~7s → 6s, repeat chain resolution ~26ms → ~0.01ms.
+
 ## [0.7.10] - 2026-07-02
 ### Added
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Changed
 
-- `web_search` latency overhaul: provider hard timeouts are now class-based (pure search APIs 15s, LLM-mediated providers 120s, replacing the uniform 300s ceiling; `web_search.timeout` still overrides), DuckDuckGo is fired as a background hedge 3s into a slower primary so a failing primary falls back to an already-settled result, the Gemini 429/5xx retry-delay budget dropped from 5 minutes to 30 seconds, resolved provider chains are cached per AuthStorage for 60s (availability probes skipped on repeat searches), and `WebSearchTool` prewarms the chain at construction. Measured: hung-primary fallback 301s → 15s, slow-failing-primary fallback ~7s → 6s, repeat chain resolution ~26ms → ~0.01ms.
+- `web_search` latency overhaul: provider hard timeouts are now class-based (pure search APIs 15s, LLM-mediated providers 120s, Kimi 35s aligned to its upstream 30s budget, replacing the uniform 300s ceiling; an explicitly configured `web_search.timeout` still overrides — the schema default no longer reinstalls 300s), DuckDuckGo is fired as a background hedge 3s into a slower primary so a failing primary falls back to an already-settled result, the Gemini 429/5xx retry-delay budget dropped from 5 minutes to 30 seconds, resolved provider chains are cached per AuthStorage for 60s keyed on the credential generation (availability probes skipped on repeat searches; login/logout invalidates immediately), and `WebSearchTool` prewarms the chain at construction. Measured: hung-primary fallback 301s → 15s, slow-failing-primary fallback ~7s → 6s, repeat chain resolution ~26ms → ~0.01ms.
 
 ## [0.7.10] - 2026-07-02
 ### Added

--- a/packages/coding-agent/src/cli/web-search-cli.ts
+++ b/packages/coding-agent/src/cli/web-search-cli.ts
@@ -16,7 +16,7 @@ import {
 	type SearchQueryParams,
 } from "../web/search/index";
 import { SEARCH_PROVIDER_ORDER, setPreferredSearchProvider, setSearchFallbackProviders } from "../web/search/provider";
-import { setSearchHardTimeoutMs } from "../web/search/providers/utils";
+import { applyConfiguredSearchTimeout } from "../web/search/providers/utils";
 import { renderSearchResult } from "../web/search/render";
 import type { SearchProviderId } from "../web/search/types";
 
@@ -181,10 +181,7 @@ export async function runSearchCommand(cmd: SearchCommandArgs): Promise<void> {
 			configuredFallback.filter(value => typeof value === "string" && isConfigurableSearchProviderId(value)),
 		);
 	}
-	const configuredTimeout = settings.get("web_search.timeout");
-	if (typeof configuredTimeout === "number" && Number.isFinite(configuredTimeout) && configuredTimeout > 0) {
-		setSearchHardTimeoutMs(configuredTimeout * 1000);
-	}
+	applyConfiguredSearchTimeout(settings);
 
 	const params: SearchQueryParams = {
 		query: cmd.query,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -119,6 +119,7 @@ import { AgentOutputManager } from "./task/output-manager";
 import { parseThinkingLevel, resolveThinkingLevelForModel, toReasoningEffort } from "./thinking";
 import { collectDiscoverableTools, type DiscoverableTool } from "./tool-discovery/tool-index";
 import {
+	applyConfiguredSearchTimeout,
 	BashTool,
 	BUILTIN_TOOLS,
 	computeEssentialBuiltinNames,
@@ -140,7 +141,6 @@ import {
 	setPreferredImageProvider,
 	setPreferredSearchProvider,
 	setSearchFallbackProviders,
-	setSearchHardTimeoutMs,
 	type Tool,
 	type ToolSession,
 	WebSearchTool,
@@ -940,10 +940,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			webSearchFallback.filter(value => typeof value === "string" && isConfigurableSearchProviderId(value)),
 		);
 	}
-	const webSearchTimeout = settings.get("web_search.timeout");
-	if (typeof webSearchTimeout === "number" && Number.isFinite(webSearchTimeout) && webSearchTimeout > 0) {
-		setSearchHardTimeoutMs(webSearchTimeout * 1000);
-	}
+	applyConfiguredSearchTimeout(settings);
 
 	const imageProvider = settings.get("providers.image");
 	if (

--- a/packages/coding-agent/src/web/kagi.ts
+++ b/packages/coding-agent/src/web/kagi.ts
@@ -147,7 +147,7 @@ export async function searchWithKagi(
 
 	const response = await fetch(requestUrl, {
 		headers: getAuthHeaders(apiKey),
-		signal: withHardTimeout(options.signal),
+		signal: withHardTimeout(options.signal, "api"),
 	});
 	if (!response.ok) {
 		throw parseKagiErrorResponse(response.status, await response.text());

--- a/packages/coding-agent/src/web/parallel.ts
+++ b/packages/coding-agent/src/web/parallel.ts
@@ -306,7 +306,7 @@ export async function searchWithParallel(
 				max_chars_per_result: options.maxCharsPerResult ?? 10_000,
 			},
 		}),
-		signal: withHardTimeout(options.signal),
+		signal: withHardTimeout(options.signal, "api"),
 	});
 	if (!response.ok) {
 		throw parseParallelErrorResponse(response.status, await response.text());
@@ -338,7 +338,7 @@ export async function extractWithParallel(
 			excerpts: options.excerpts ?? true,
 			full_content: options.fullContent ?? false,
 		}),
-		signal: withHardTimeout(options.signal),
+		signal: withHardTimeout(options.signal, "api"),
 	});
 	if (!response.ok) {
 		throw parseParallelErrorResponse(response.status, await response.text());

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -16,7 +16,7 @@ import { discoverAuthStorage } from "../../sdk";
 import type { ToolSession } from "../../tools";
 import { formatAge } from "../../tools/render-utils";
 import { throwIfAborted } from "../../tools/tool-errors";
-import { getSearchProviderLabel, resolveProviderChain, type SearchProvider } from "./provider";
+import { getSearchProviderLabel, prewarmSearchProviders, resolveProviderChain, type SearchProvider } from "./provider";
 import { renderSearchCall, renderSearchResult, type SearchRenderDetails } from "./render";
 import type { ActiveSearchModelContext, SearchProviderId, SearchResponse } from "./types";
 import { SearchProviderError } from "./types";
@@ -148,6 +148,22 @@ interface ExecuteSearchOptions {
 	activeModelContext?: ActiveSearchModelContext;
 }
 
+/**
+ * Delay before the keyless DuckDuckGo hedge fires while a slower primary is
+ * still in flight. Chosen to be comfortably above DDG's typical ~1-2s
+ * round-trip cost budget yet far below LLM-mediated primary latency, so a
+ * failing primary can fall back to an already-completed hedge result instead
+ * of paying primary-failure time plus DDG time sequentially.
+ */
+const DDG_HEDGE_DELAY_MS = 3_000;
+
+let ddgHedgeDelayMs = DDG_HEDGE_DELAY_MS;
+
+/** Override the hedge delay (tests). Non-finite/non-positive resets to default. */
+export function setDdgHedgeDelayMs(ms: number | undefined): void {
+	ddgHedgeDelayMs = typeof ms === "number" && Number.isFinite(ms) && ms > 0 ? ms : DDG_HEDGE_DELAY_MS;
+}
+
 /** Execute web search */
 async function executeSearch(
 	_toolCallId: string,
@@ -166,52 +182,91 @@ async function executeSearch(
 		activeModelContext,
 	});
 
+	const baseSearchParams = {
+		query: params.query.replace(/202\d/g, String(new Date().getFullYear())), // LUL
+		limit: params.limit,
+		recency: params.recency,
+		systemPrompt: webSearchSystemPrompt,
+		maxOutputTokens: params.max_tokens,
+		numSearchResults: params.num_search_results,
+		temperature: params.temperature,
+		xaiSearchMode: params.xai_search_mode,
+		allowedDomains: params.allowed_domains,
+		excludedDomains: params.excluded_domains,
+		allowedXHandles: params.allowed_x_handles,
+		excludedXHandles: params.excluded_x_handles,
+		fromDate: params.from_date,
+		toDate: params.to_date,
+		enableImageUnderstanding: params.enable_image_understanding,
+		enableImageSearch: params.enable_image_search,
+		enableVideoUnderstanding: params.enable_video_understanding,
+		noInlineCitations: params.no_inline_citations,
+		authStorage,
+		sessionId,
+		activeModelContext,
+	};
+
+	// Hedged fallback: when DuckDuckGo (keyless, cheap) is a non-primary member
+	// of the chain, start it in the background after a short delay. If the
+	// primary succeeds first the hedge is aborted; if the primary fails, the
+	// hedge result is typically already available, collapsing the fallback
+	// latency from `t(primary failure) + t(ddg)` to `max(t(primary failure), t(ddg))`.
+	const ddgIndex = providers.findIndex(p => p.id === "duckduckgo");
+	const hedgeCtl = new AbortController();
+	const onUpstreamAbort = () => hedgeCtl.abort();
+	signal?.addEventListener("abort", onUpstreamAbort, { once: true });
+	let hedgePromise: Promise<SearchResponse> | undefined;
+	let hedgeTimer: ReturnType<typeof setTimeout> | undefined;
+	if (ddgIndex > 0) {
+		const ddg = providers[ddgIndex]!;
+		hedgeTimer = setTimeout(() => {
+			hedgePromise = ddg.search({ ...baseSearchParams, signal: hedgeCtl.signal });
+			// Failures are consumed when (and if) the loop reaches DuckDuckGo;
+			// never let a losing hedge become an unhandled rejection.
+			hedgePromise.catch(() => {});
+		}, ddgHedgeDelayMs);
+	}
+	const cancelHedge = () => {
+		if (hedgeTimer !== undefined) clearTimeout(hedgeTimer);
+		hedgeCtl.abort();
+		signal?.removeEventListener("abort", onUpstreamAbort);
+	};
+
 	const failures: Array<{ provider: SearchProvider; error: unknown }> = [];
 	let lastProvider = providers[0];
-	for (const provider of providers) {
-		lastProvider = provider;
-		try {
-			const response = await provider.search({
-				query: params.query.replace(/202\d/g, String(new Date().getFullYear())), // LUL
-				limit: params.limit,
-				recency: params.recency,
-				systemPrompt: webSearchSystemPrompt,
-				maxOutputTokens: params.max_tokens,
-				numSearchResults: params.num_search_results,
-				temperature: params.temperature,
-				xaiSearchMode: params.xai_search_mode,
-				allowedDomains: params.allowed_domains,
-				excludedDomains: params.excluded_domains,
-				allowedXHandles: params.allowed_x_handles,
-				excludedXHandles: params.excluded_x_handles,
-				fromDate: params.from_date,
-				toDate: params.to_date,
-				enableImageUnderstanding: params.enable_image_understanding,
-				enableImageSearch: params.enable_image_search,
-				enableVideoUnderstanding: params.enable_video_understanding,
-				noInlineCitations: params.no_inline_citations,
-				signal,
-				authStorage,
-				sessionId,
-				activeModelContext,
-			});
+	try {
+		for (const provider of providers) {
+			lastProvider = provider;
+			try {
+				let response: SearchResponse;
+				if (provider.id === "duckduckgo" && hedgePromise) {
+					// Reuse the in-flight (often already-settled) hedge request.
+					if (hedgeTimer !== undefined) clearTimeout(hedgeTimer);
+					response = await hedgePromise;
+				} else {
+					if (provider.id === "duckduckgo" && hedgeTimer !== undefined) clearTimeout(hedgeTimer);
+					response = await provider.search({ ...baseSearchParams, signal });
+				}
 
-			const text = formatForLLM(response);
-			const warning = failures.length > 0 ? formatFallbackWarning(failures, provider) : undefined;
+				const text = formatForLLM(response);
+				const warning = failures.length > 0 ? formatFallbackWarning(failures, provider) : undefined;
 
-			return {
-				content: [{ type: "text" as const, text: warning ? `Warning: ${warning}\n\n${text}` : text }],
-				details: { response, ...(warning ? { warning } : {}) },
-			};
-		} catch (error) {
-			// Surface user-initiated cancellation immediately so the session sees
-			// a clean abort instead of a generic "all providers failed" message.
-			// Without this, an AbortError from `fetch()` is treated as a provider
-			// failure and the loop falls through to the next provider (or to the
-			// summary error), masking the cancellation.
-			throwIfAborted(signal);
-			failures.push({ provider, error });
+				return {
+					content: [{ type: "text" as const, text: warning ? `Warning: ${warning}\n\n${text}` : text }],
+					details: { response, ...(warning ? { warning } : {}) },
+				};
+			} catch (error) {
+				// Surface user-initiated cancellation immediately so the session sees
+				// a clean abort instead of a generic "all providers failed" message.
+				// Without this, an AbortError from `fetch()` is treated as a provider
+				// failure and the loop falls through to the next provider (or to the
+				// summary error), masking the cancellation.
+				throwIfAborted(signal);
+				failures.push({ provider, error });
+			}
 		}
+	} finally {
+		cancelHedge();
 	}
 
 	const lastFailure = failures[failures.length - 1];
@@ -273,6 +328,24 @@ export class WebSearchTool implements AgentTool<typeof webSearchSchema, SearchRe
 	constructor(session: ToolSession) {
 		this.#session = session;
 		this.description = prompt.render(webSearchDescription);
+		// Prewarm: resolve the provider chain once in the background so the
+		// provider modules are imported and the chain cache is primed before
+		// the first user-visible search. Best-effort only.
+		const authStorage = session.authStorage;
+		if (authStorage) {
+			try {
+				const activeModelContext = session.model
+					? session.modelRegistry?.getActiveSearchModelContext(session.model)
+					: undefined;
+				prewarmSearchProviders({
+					authStorage,
+					sessionId: session.getSessionId?.() ?? undefined,
+					activeModelContext,
+				});
+			} catch {
+				// Never let prewarming break tool construction.
+			}
+		}
 	}
 
 	async execute(

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -216,7 +216,7 @@ async function executeSearch(
 	const onUpstreamAbort = () => hedgeCtl.abort();
 	signal?.addEventListener("abort", onUpstreamAbort, { once: true });
 	let hedgePromise: Promise<SearchResponse> | undefined;
-	let hedgeTimer: ReturnType<typeof setTimeout> | undefined;
+	let hedgeTimer: NodeJS.Timeout | undefined;
 	if (ddgIndex > 0) {
 		const ddg = providers[ddgIndex]!;
 		hedgeTimer = setTimeout(() => {
@@ -407,6 +407,6 @@ export {
 	setPreferredSearchProvider,
 	setSearchFallbackProviders,
 } from "./provider";
-export { setSearchHardTimeoutMs } from "./providers/utils";
+export { applyConfiguredSearchTimeout, setSearchHardTimeoutMs } from "./providers/utils";
 export type { SearchProviderId as SearchProvider, SearchResponse } from "./types";
 export { isConfigurableSearchProviderId, isSearchProviderPreference } from "./types";

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -141,12 +141,57 @@ const MODEL_PROVIDER_TO_SEARCH: Record<string, SearchProviderId> = {
 let preferredProvId: SearchProviderId | "auto" = "auto";
 let fallbackProvIds: SearchProviderId[] = [];
 
+/**
+ * Resolved-chain cache. Chain resolution probes provider availability
+ * (credential lookups, potentially an OAuth refresh through the broker) on
+ * every web_search call even though the result only changes when the active
+ * model, provider preference, or credentials change. Cache the resolved
+ * provider-id list per AuthStorage instance for a short TTL.
+ *
+ * Keyed by AuthStorage identity (WeakMap) so tests and short-lived CLI calls
+ * with fresh storage handles never see another handle's chain. The TTL keeps
+ * a login/logout mid-session from being masked for more than a minute.
+ */
+const CHAIN_CACHE_TTL_MS = 60_000;
+let chainCache = new WeakMap<AuthStorage, Map<string, { ids: SearchProviderId[]; expires: number }>>();
+
+/** Drop every cached resolved chain (settings changed, tests). */
+export function clearResolvedChainCache(): void {
+	chainCache = new WeakMap();
+}
+
+function chainCacheKey(
+	preferred: SearchProviderId | "auto" | undefined,
+	fallbacks: readonly SearchProviderId[],
+	ctx: ActiveSearchModelContext | undefined,
+): string {
+	return JSON.stringify([
+		preferred ?? null,
+		fallbacks,
+		ctx
+			? [ctx.provider, ctx.modelId, ctx.wireModelId ?? null, ctx.api, ctx.baseUrl ?? null, ctx.webSearch ?? null]
+			: null,
+	]);
+}
+
 export function setPreferredSearchProvider(provider: SearchProviderId | "auto"): void {
 	preferredProvId = provider;
+	clearResolvedChainCache();
 }
 
 export function setSearchFallbackProviders(ids: readonly string[]): void {
 	fallbackProvIds = ids.filter(isConfigurableSearchProviderId);
+	clearResolvedChainCache();
+}
+
+/**
+ * Fire-and-forget warm-up: resolve the provider chain once so the provider
+ * modules are imported and the chain cache is primed before the first
+ * user-visible search. Errors are intentionally swallowed — prewarming must
+ * never surface a failure the real search path would handle itself.
+ */
+export function prewarmSearchProviders(options: ResolveProviderChainOptions): void {
+	void resolveProviderChain(options).catch(() => {});
 }
 
 export interface SearchProviderPreferenceSource {
@@ -357,6 +402,16 @@ export async function resolveProviderChain(options: ResolveProviderChainOptions)
 		activeModelContext,
 		fallbackProviders = fallbackProvIds,
 	} = options;
+
+	const cacheKey = chainCacheKey(preferredProvider, fallbackProviders, activeModelContext);
+	const perStorage = chainCache.get(authStorage);
+	const cached = perStorage?.get(cacheKey);
+	if (cached && cached.expires > Date.now()) {
+		const cachedProviders: SearchProvider[] = [];
+		for (const id of cached.ids) cachedProviders.push(await getSearchProvider(id));
+		return cachedProviders;
+	}
+
 	const chain: SearchProviderId[] = [];
 
 	// A forced primary is honored only when it is a user-configurable provider.
@@ -391,6 +446,10 @@ export async function resolveProviderChain(options: ResolveProviderChainOptions)
 		await appendAvailable(chain, id, authStorage);
 	}
 	appendDeduped(chain, "duckduckgo");
+
+	const storageEntry = chainCache.get(authStorage) ?? new Map<string, { ids: SearchProviderId[]; expires: number }>();
+	storageEntry.set(cacheKey, { ids: [...chain], expires: Date.now() + CHAIN_CACHE_TTL_MS });
+	chainCache.set(authStorage, storageEntry);
 
 	const providers: SearchProvider[] = [];
 	for (const id of chain) providers.push(await getSearchProvider(id));

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -164,8 +164,14 @@ function chainCacheKey(
 	preferred: SearchProviderId | "auto" | undefined,
 	fallbacks: readonly SearchProviderId[],
 	ctx: ActiveSearchModelContext | undefined,
+	authStorage: AuthStorage,
 ): string {
+	// Include the AuthStorage generation so credential changes (login/logout,
+	// key rotation) invalidate cached chains immediately instead of being
+	// masked for up to the TTL. Stubs without getGeneration() key as 0.
+	const generation = (authStorage as { getGeneration?: () => number }).getGeneration?.() ?? 0;
 	return JSON.stringify([
+		generation,
 		preferred ?? null,
 		fallbacks,
 		ctx
@@ -403,7 +409,7 @@ export async function resolveProviderChain(options: ResolveProviderChainOptions)
 		fallbackProviders = fallbackProvIds,
 	} = options;
 
-	const cacheKey = chainCacheKey(preferredProvider, fallbackProviders, activeModelContext);
+	const cacheKey = chainCacheKey(preferredProvider, fallbackProviders, activeModelContext, authStorage);
 	const perStorage = chainCache.get(authStorage);
 	const cached = perStorage?.get(cacheKey);
 	if (cached && cached.expires > Date.now()) {

--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -119,7 +119,7 @@ async function callSearch(
 		method: "POST",
 		headers,
 		body: JSON.stringify(body),
-		signal: withHardTimeout(signal),
+		signal: withHardTimeout(signal, "llm"),
 	});
 
 	if (!response.ok) {

--- a/packages/coding-agent/src/web/search/providers/brave.ts
+++ b/packages/coding-agent/src/web/search/providers/brave.ts
@@ -85,7 +85,7 @@ async function callBraveSearch(
 			Accept: "application/json",
 			"X-Subscription-Token": apiKey,
 		},
-		signal: withHardTimeout(params.signal),
+		signal: withHardTimeout(params.signal, "api"),
 	});
 
 	if (!response.ok) {

--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -216,7 +216,7 @@ async function callCodexSearch(
 		method: "POST",
 		headers,
 		body: JSON.stringify(body),
-		signal: withHardTimeout(options.signal),
+		signal: withHardTimeout(options.signal, "llm"),
 	});
 
 	if (!response.ok) {

--- a/packages/coding-agent/src/web/search/providers/duckduckgo.ts
+++ b/packages/coding-agent/src/web/search/providers/duckduckgo.ts
@@ -196,7 +196,7 @@ async function fetchAndParse(
 			"Accept-Language": "en-US,en;q=0.9",
 		},
 		body,
-		signal: withHardTimeout(signal),
+		signal: withHardTimeout(signal, "api"),
 	});
 
 	// DuckDuckGo signals soft blocks with 202 (which is still response.ok).

--- a/packages/coding-agent/src/web/search/providers/exa.ts
+++ b/packages/coding-agent/src/web/search/providers/exa.ts
@@ -115,7 +115,7 @@ async function callExaSearch(apiKey: string, params: ExaSearchParams): Promise<E
 			"x-api-key": apiKey,
 		},
 		body: JSON.stringify(body),
-		signal: withHardTimeout(params.signal),
+		signal: withHardTimeout(params.signal, "api"),
 	});
 
 	if (!response.ok) {

--- a/packages/coding-agent/src/web/search/providers/gemini.ts
+++ b/packages/coding-agent/src/web/search/providers/gemini.ts
@@ -29,7 +29,11 @@ const ANTIGRAVITY_ENDPOINT_FALLBACKS = [ANTIGRAVITY_DAILY_ENDPOINT, ANTIGRAVITY_
 const DEFAULT_MODEL = "gemini-2.5-flash";
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
-const RATE_LIMIT_BUDGET_MS = 5 * 60 * 1000;
+// Retry-delay ceiling for 429/5xx. The web_search chain always terminates in
+// the keyless DuckDuckGo fallback, so a rate-limited Gemini should fail
+// through in seconds instead of parking the chain behind long server-provided
+// retry delays (previously a 5-minute budget).
+const RATE_LIMIT_BUDGET_MS = 30 * 1000;
 
 const GEMINI_PROVIDERS = ["google-gemini-cli", "google-antigravity"] as const;
 type GeminiProviderId = (typeof GEMINI_PROVIDERS)[number];
@@ -230,7 +234,7 @@ async function callGeminiSearch(
 			...headers,
 		},
 		body: JSON.stringify(requestBody),
-		signal: withHardTimeout(signal),
+		signal: withHardTimeout(signal, "llm"),
 	});
 	const urlFor = (attempt: number) =>
 		`${endpoints[Math.min(attempt, endpoints.length - 1)]}/v1internal:streamGenerateContent?alt=sse`;
@@ -466,7 +470,7 @@ async function searchGeminiViaGenerativeLanguage(params: SearchParams): Promise<
 		method: "POST",
 		headers: { ...(ctx.headers ?? {}), "x-goog-api-key": apiKey, "Content-Type": "application/json" },
 		body: JSON.stringify(body),
-		signal: withHardTimeout(params.signal),
+		signal: withHardTimeout(params.signal, "llm"),
 	});
 	const text = await response.text();
 	if (!response.ok) {

--- a/packages/coding-agent/src/web/search/providers/jina.ts
+++ b/packages/coding-agent/src/web/search/providers/jina.ts
@@ -41,7 +41,7 @@ async function callJinaSearch(apiKey: string, query: string, signal?: AbortSigna
 			Accept: "application/json",
 			Authorization: `Bearer ${apiKey}`,
 		},
-		signal: withHardTimeout(signal),
+		signal: withHardTimeout(signal, "api"),
 	});
 
 	if (!response.ok) {

--- a/packages/coding-agent/src/web/search/providers/kimi.ts
+++ b/packages/coding-agent/src/web/search/providers/kimi.ts
@@ -87,7 +87,7 @@ async function callKimiSearch(
 			enable_page_crawling: params.includeContent,
 			timeout_seconds: DEFAULT_TIMEOUT_SECONDS,
 		}),
-		signal: withHardTimeout(params.signal),
+		signal: withHardTimeout(params.signal, "api"),
 	});
 
 	if (!response.ok) {

--- a/packages/coding-agent/src/web/search/providers/kimi.ts
+++ b/packages/coding-agent/src/web/search/providers/kimi.ts
@@ -19,6 +19,11 @@ const KIMI_SEARCH_URL = "https://api.kimi.com/coding/v1/search";
 const DEFAULT_NUM_RESULTS = 10;
 const MAX_NUM_RESULTS = 20;
 const DEFAULT_TIMEOUT_SECONDS = 30;
+// Local hard ceiling aligned with the upstream `timeout_seconds` request budget
+// (plus transport headroom) instead of the generic 15s "api" class: Kimi
+// legitimately runs search + page crawling up to its advertised 30s window,
+// and aborting earlier would discard valid in-budget responses.
+const KIMI_HARD_TIMEOUT_MS = (DEFAULT_TIMEOUT_SECONDS + 5) * 1000;
 
 export interface KimiSearchParams {
 	query: string;
@@ -87,7 +92,7 @@ async function callKimiSearch(
 			enable_page_crawling: params.includeContent,
 			timeout_seconds: DEFAULT_TIMEOUT_SECONDS,
 		}),
-		signal: withHardTimeout(params.signal, "api"),
+		signal: withHardTimeout(params.signal, KIMI_HARD_TIMEOUT_MS),
 	});
 
 	if (!response.ok) {

--- a/packages/coding-agent/src/web/search/providers/openai-compatible.ts
+++ b/packages/coding-agent/src/web/search/providers/openai-compatible.ts
@@ -134,7 +134,7 @@ export class OpenAICompatibleSearchProvider extends SearchProvider {
 				method: "POST",
 				headers,
 				body: JSON.stringify(payload),
-				signal: withHardTimeout(params.signal),
+				signal: withHardTimeout(params.signal, "llm"),
 			});
 
 		// Web search is a Responses-API capability: many OpenAI-compatible

--- a/packages/coding-agent/src/web/search/providers/parallel.ts
+++ b/packages/coding-agent/src/web/search/providers/parallel.ts
@@ -139,7 +139,7 @@ async function searchWithAuthStorage(
 				max_chars_per_result: 10_000,
 			},
 		}),
-		signal: withHardTimeout(params.signal),
+		signal: withHardTimeout(params.signal, "api"),
 	});
 	if (!response.ok) {
 		throw parseParallelErrorResponse(response.status, await response.text());

--- a/packages/coding-agent/src/web/search/providers/perplexity.ts
+++ b/packages/coding-agent/src/web/search/providers/perplexity.ts
@@ -251,7 +251,7 @@ async function callPerplexityApi(
 			"Content-Type": "application/json",
 		},
 		body: JSON.stringify(request),
-		signal: withHardTimeout(signal),
+		signal: withHardTimeout(signal, "llm"),
 	});
 
 	if (!response.ok) {
@@ -370,7 +370,7 @@ async function callPerplexityOAuth(
 				skip_search_enabled: true,
 			},
 		}),
-		signal: withHardTimeout(params.signal),
+		signal: withHardTimeout(params.signal, "llm"),
 	});
 
 	if (!response.ok) {

--- a/packages/coding-agent/src/web/search/providers/searxng.ts
+++ b/packages/coding-agent/src/web/search/providers/searxng.ts
@@ -214,7 +214,7 @@ async function callSearXNGSearch(
 
 	const response = await fetch(url, {
 		headers,
-		signal: withHardTimeout(params.signal),
+		signal: withHardTimeout(params.signal, "api"),
 	});
 
 	if (!response.ok) {

--- a/packages/coding-agent/src/web/search/providers/synthetic.ts
+++ b/packages/coding-agent/src/web/search/providers/synthetic.ts
@@ -47,7 +47,7 @@ async function callSyntheticSearch(
 			Authorization: `Bearer ${apiKey}`,
 		},
 		body: JSON.stringify({ query }),
-		signal: withHardTimeout(signal),
+		signal: withHardTimeout(signal, "api"),
 	});
 
 	if (!response.ok) {

--- a/packages/coding-agent/src/web/search/providers/tavily.ts
+++ b/packages/coding-agent/src/web/search/providers/tavily.ts
@@ -96,7 +96,7 @@ async function callTavilySearch(apiKey: string, params: TavilySearchParams): Pro
 			Authorization: `Bearer ${apiKey}`,
 		},
 		body: JSON.stringify(buildRequestBody(params)),
-		signal: withHardTimeout(params.signal),
+		signal: withHardTimeout(params.signal, "api"),
 	});
 
 	if (!response.ok) {

--- a/packages/coding-agent/src/web/search/providers/utils.ts
+++ b/packages/coding-agent/src/web/search/providers/utils.ts
@@ -44,38 +44,57 @@ export function findCredential(
 }
 
 /**
- * Default hard ceiling for a single web-search round-trip. 300s tolerates
- * legitimate slow LLM-mediated responses (anthropic web_search_20250305,
- * perplexity, gemini, OpenAI code backend) while still guaranteeing the session unfreezes
- * if Bun's `AbortSignal` fails to propagate on Windows.
- *
- * Pure search APIs (brave, exa, jina, tavily, searxng, synthetic, zai)
- * settle far faster in practice; reusing the same ceiling keeps the wiring
- * uniform without compromising correctness.
+ * Legacy hard ceiling for a single web-search round-trip, retained as the
+ * fallback for call sites that do not declare a timeout class. 300s tolerates
+ * pathological cases while still guaranteeing the session unfreezes if Bun's
+ * `AbortSignal` fails to propagate on Windows.
  */
 export const SEARCH_HARD_TIMEOUT_MS = 300_000;
 
 /**
- * Runtime-configurable hard timeout, seeded from the `web_search.timeout`
- * setting via {@link setSearchHardTimeoutMs}. Falls back to
- * {@link SEARCH_HARD_TIMEOUT_MS} when unset or invalid.
+ * Hard ceiling for pure search APIs (brave, exa, jina, kimi, tavily, kagi,
+ * parallel, searxng, synthetic, zai, duckduckgo). These settle in ~1-3s in
+ * practice; a hung TCP/TLS connection should fall through to the next
+ * provider in seconds, not minutes.
  */
-let configuredHardTimeoutMs = SEARCH_HARD_TIMEOUT_MS;
+export const SEARCH_API_TIMEOUT_MS = 15_000;
+
+/**
+ * Hard ceiling for LLM-mediated search providers (anthropic, codex, gemini,
+ * perplexity, xai, openai-compatible). These legitimately take tens of
+ * seconds because a model performs the search and synthesizes an answer.
+ */
+export const SEARCH_LLM_TIMEOUT_MS = 120_000;
+
+/** Timeout class a provider declares for its outbound round-trips. */
+export type SearchTimeoutClass = "api" | "llm";
+
+const TIMEOUT_CLASS_MS: Record<SearchTimeoutClass, number> = {
+	api: SEARCH_API_TIMEOUT_MS,
+	llm: SEARCH_LLM_TIMEOUT_MS,
+};
+
+/**
+ * Runtime-configurable hard timeout, seeded from the `web_search.timeout`
+ * setting via {@link setSearchHardTimeoutMs}. When set, it overrides every
+ * class default so users keep a single knob. Unset means class defaults apply.
+ */
+let configuredHardTimeoutMs: number | undefined;
 
 /**
  * Override the hard timeout applied to every web-search round-trip.
  *
  * @param ms - Hard timeout in milliseconds. Non-finite or non-positive
- *   values reset the timeout to {@link SEARCH_HARD_TIMEOUT_MS}.
+ *   values clear the override so per-class defaults apply.
  */
 export function setSearchHardTimeoutMs(ms: number | undefined): void {
-	configuredHardTimeoutMs = typeof ms === "number" && Number.isFinite(ms) && ms > 0 ? ms : SEARCH_HARD_TIMEOUT_MS;
+	configuredHardTimeoutMs = typeof ms === "number" && Number.isFinite(ms) && ms > 0 ? ms : undefined;
 }
 
 /**
  * Compose a caller-supplied {@link AbortSignal} with a hard timeout so an
- * outbound `fetch()` is guaranteed to settle within `ms` even when the
- * runtime fails to propagate cancellation to the underlying transport.
+ * outbound `fetch()` is guaranteed to settle even when the runtime fails to
+ * propagate cancellation to the underlying transport.
  *
  * Bun's WinHTTP backend on Windows is known to ignore `AbortSignal` once a
  * TCP/TLS connection stalls (oven-sh/bun#15275, oven-sh/bun#18536); without
@@ -83,9 +102,16 @@ export function setSearchHardTimeoutMs(ms: number | undefined): void {
  * because the user's Esc is never delivered to the native layer.
  *
  * @param signal - Caller cancellation signal, if any.
- * @param ms - Hard timeout in milliseconds. Defaults to the configured value.
+ * @param msOrClass - Explicit timeout in milliseconds, or a
+ *   {@link SearchTimeoutClass} resolved to its class default. Omitted falls
+ *   back to the legacy {@link SEARCH_HARD_TIMEOUT_MS} ceiling. A user-set
+ *   `web_search.timeout` overrides class defaults (but not explicit ms).
  */
-export function withHardTimeout(signal: AbortSignal | undefined, ms: number = configuredHardTimeoutMs): AbortSignal {
+export function withHardTimeout(signal: AbortSignal | undefined, msOrClass?: number | SearchTimeoutClass): AbortSignal {
+	const ms =
+		typeof msOrClass === "number"
+			? msOrClass
+			: (configuredHardTimeoutMs ?? (msOrClass ? TIMEOUT_CLASS_MS[msOrClass] : SEARCH_HARD_TIMEOUT_MS));
 	const timeout = AbortSignal.timeout(ms);
 	return signal ? AbortSignal.any([signal, timeout]) : timeout;
 }

--- a/packages/coding-agent/src/web/search/providers/utils.ts
+++ b/packages/coding-agent/src/web/search/providers/utils.ts
@@ -52,10 +52,11 @@ export function findCredential(
 export const SEARCH_HARD_TIMEOUT_MS = 300_000;
 
 /**
- * Hard ceiling for pure search APIs (brave, exa, jina, kimi, tavily, kagi,
+ * Hard ceiling for pure search APIs (brave, exa, jina, tavily, kagi,
  * parallel, searxng, synthetic, zai, duckduckgo). These settle in ~1-3s in
  * practice; a hung TCP/TLS connection should fall through to the next
- * provider in seconds, not minutes.
+ * provider in seconds, not minutes. Kimi is the exception: it declares an
+ * explicit ceiling aligned with its upstream 30s request budget.
  */
 export const SEARCH_API_TIMEOUT_MS = 15_000;
 
@@ -89,6 +90,29 @@ let configuredHardTimeoutMs: number | undefined;
  */
 export function setSearchHardTimeoutMs(ms: number | undefined): void {
 	configuredHardTimeoutMs = typeof ms === "number" && Number.isFinite(ms) && ms > 0 ? ms : undefined;
+}
+
+/** Structural settings source for {@link applyConfiguredSearchTimeout}. */
+export interface SearchTimeoutSettingSource {
+	get(path: "web_search.timeout"): unknown;
+	has(path: "web_search.timeout"): boolean;
+}
+
+/**
+ * Install the `web_search.timeout` override from settings — but only when the
+ * user explicitly configured it. The settings schema ships a default value
+ * (300), and consuming that default via `get()` alone would reinstall a
+ * uniform 300s ceiling on every session, silently disabling the per-class
+ * timeout defaults. `has()` distinguishes loaded/overridden settings from
+ * schema defaults; unset clears any previous override so class defaults apply.
+ */
+export function applyConfiguredSearchTimeout(settings: SearchTimeoutSettingSource): void {
+	if (!settings.has("web_search.timeout")) {
+		setSearchHardTimeoutMs(undefined);
+		return;
+	}
+	const value = settings.get("web_search.timeout");
+	setSearchHardTimeoutMs(typeof value === "number" && Number.isFinite(value) && value > 0 ? value * 1000 : undefined);
 }
 
 /**

--- a/packages/coding-agent/src/web/search/providers/xai.ts
+++ b/packages/coding-agent/src/web/search/providers/xai.ts
@@ -441,7 +441,7 @@ export async function searchXai(params: XaiSearchParams): Promise<SearchResponse
 				noInlineCitations: params.no_inline_citations,
 			}),
 		),
-		signal: withHardTimeout(params.signal),
+		signal: withHardTimeout(params.signal, "llm"),
 	});
 
 	const text = await response.text();

--- a/packages/coding-agent/src/web/search/providers/zai.ts
+++ b/packages/coding-agent/src/web/search/providers/zai.ts
@@ -79,7 +79,7 @@ async function callZaiTool(apiKey: string, args: Record<string, unknown>, signal
 				arguments: args,
 			},
 		}),
-		signal: withHardTimeout(signal),
+		signal: withHardTimeout(signal, "api"),
 	});
 
 	if (!response.ok) {

--- a/packages/coding-agent/test/web/search/speed-improvements.test.ts
+++ b/packages/coding-agent/test/web/search/speed-improvements.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Regression coverage for the web_search latency work:
+ *
+ * 1. Per-class hard timeouts — pure search APIs get a short ceiling
+ *    (SEARCH_API_TIMEOUT_MS) and LLM-mediated providers a medium one
+ *    (SEARCH_LLM_TIMEOUT_MS), replacing the uniform 300s ceiling. The
+ *    user-configured `web_search.timeout` still overrides class defaults,
+ *    while explicit millisecond arguments always win.
+ * 2. Resolved-chain caching — resolveProviderChain memoizes the resolved
+ *    provider-id list per AuthStorage instance so repeated searches skip
+ *    credential availability probes; settings changes clear the cache.
+ * 3. Hedged DuckDuckGo fallback — when DDG is a non-primary chain member,
+ *    executeSearch fires it in the background after a short delay so a
+ *    slow-failing primary falls back to an already-settled result, and
+ *    aborts the hedge when the primary wins.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AuthStorage } from "@gajae-code/ai";
+import type { ToolSession } from "../../../src/tools";
+import { setDdgHedgeDelayMs, WebSearchTool } from "../../../src/web/search";
+import * as provider from "../../../src/web/search/provider";
+import {
+	clearResolvedChainCache,
+	resolveProviderChain,
+	setPreferredSearchProvider,
+	setSearchFallbackProviders,
+} from "../../../src/web/search/provider";
+import type { SearchParams } from "../../../src/web/search/providers/base";
+import {
+	SEARCH_API_TIMEOUT_MS,
+	SEARCH_HARD_TIMEOUT_MS,
+	SEARCH_LLM_TIMEOUT_MS,
+	setSearchHardTimeoutMs,
+	withHardTimeout,
+} from "../../../src/web/search/providers/utils";
+import type { SearchProviderId, SearchResponse } from "../../../src/web/search/types";
+
+const FAKE_SESSION = {} as ToolSession;
+
+describe("per-class hard timeouts", () => {
+	afterEach(() => setSearchHardTimeoutMs(undefined));
+
+	it("orders the class ceilings sensibly: api < llm <= legacy", () => {
+		expect(SEARCH_API_TIMEOUT_MS).toBeLessThan(SEARCH_LLM_TIMEOUT_MS);
+		expect(SEARCH_LLM_TIMEOUT_MS).toBeLessThanOrEqual(SEARCH_HARD_TIMEOUT_MS);
+	});
+
+	it("applies the user override to class-tagged calls", async () => {
+		setSearchHardTimeoutMs(10);
+		const apiSignal = withHardTimeout(undefined, "api");
+		const llmSignal = withHardTimeout(undefined, "llm");
+		await Bun.sleep(50);
+		expect(apiSignal.aborted).toBe(true);
+		expect(llmSignal.aborted).toBe(true);
+	});
+
+	it("lets an explicit millisecond argument win over the user override", async () => {
+		setSearchHardTimeoutMs(60_000);
+		const signal = withHardTimeout(undefined, 10);
+		await Bun.sleep(50);
+		expect(signal.aborted).toBe(true);
+	});
+
+	it("does not abort a class-tagged signal immediately without an override", async () => {
+		const signal = withHardTimeout(undefined, "api");
+		await Bun.sleep(30);
+		expect(signal.aborted).toBe(false);
+	});
+});
+
+describe("resolved-chain caching", () => {
+	beforeEach(() => {
+		// Pin module-global selection state: other test files leave a preferred
+		// provider / fallback list behind, which would bypass the auto path.
+		setPreferredSearchProvider("auto");
+		setSearchFallbackProviders([]);
+		clearResolvedChainCache();
+	});
+
+	function countingAuth() {
+		let probes = 0;
+		const storage = {
+			hasAuth: () => false,
+			hasOAuth: () => false,
+			getOAuthAccess: () => undefined,
+			getApiKey: async () => {
+				probes++;
+				return "sk-test";
+			},
+		} as unknown as AuthStorage;
+		return { storage, probeCount: () => probes };
+	}
+
+	const ctx = {
+		provider: "my-proxy",
+		modelId: "gpt-5.2",
+		api: "openai-responses",
+		baseUrl: "https://llm.example.com/v1",
+	} as const;
+
+	it("skips availability probes on a repeat resolution with the same storage and context", async () => {
+		const { storage, probeCount } = countingAuth();
+		const first = await resolveProviderChain({ authStorage: storage, activeModelContext: { ...ctx } });
+		const probesAfterFirst = probeCount();
+		expect(probesAfterFirst).toBeGreaterThan(0);
+
+		const second = await resolveProviderChain({ authStorage: storage, activeModelContext: { ...ctx } });
+		expect(probeCount()).toBe(probesAfterFirst);
+		expect(second.map(p => p.id)).toEqual(first.map(p => p.id));
+	});
+
+	it("re-probes after clearResolvedChainCache", async () => {
+		const { storage, probeCount } = countingAuth();
+		await resolveProviderChain({ authStorage: storage, activeModelContext: { ...ctx } });
+		const probesAfterFirst = probeCount();
+		clearResolvedChainCache();
+		await resolveProviderChain({ authStorage: storage, activeModelContext: { ...ctx } });
+		expect(probeCount()).toBeGreaterThan(probesAfterFirst);
+	});
+
+	it("does not share cache entries across different AuthStorage instances", async () => {
+		const a = countingAuth();
+		const b = countingAuth();
+		await resolveProviderChain({ authStorage: a.storage, activeModelContext: { ...ctx } });
+		await resolveProviderChain({ authStorage: b.storage, activeModelContext: { ...ctx } });
+		expect(b.probeCount()).toBeGreaterThan(0);
+	});
+
+	it("does not share cache entries across different model contexts", async () => {
+		const { storage, probeCount } = countingAuth();
+		await resolveProviderChain({ authStorage: storage, activeModelContext: { ...ctx } });
+		const probesAfterFirst = probeCount();
+		await resolveProviderChain({
+			authStorage: storage,
+			activeModelContext: { ...ctx, modelId: "other-model" },
+		});
+		expect(probeCount()).toBeGreaterThan(probesAfterFirst);
+	});
+});
+
+describe("hedged DuckDuckGo fallback", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		setDdgHedgeDelayMs(undefined);
+	});
+
+	function fakeProvider(
+		id: SearchProviderId,
+		behaviour: (params: SearchParams) => Promise<SearchResponse>,
+	): provider.SearchProvider {
+		return { id, label: id, isAvailable: () => true, search: behaviour };
+	}
+
+	const ddgResponse: SearchResponse = {
+		provider: "duckduckgo",
+		sources: [{ title: "hit", url: "https://example.com", ageSeconds: undefined }],
+	};
+
+	it("reuses the in-flight hedge when the primary fails after the hedge fired", async () => {
+		setDdgHedgeDelayMs(30);
+		let ddgCalledAt = 0;
+		let primarySettledAt = 0;
+		let ddgCalls = 0;
+		const t0 = performance.now();
+
+		vi.spyOn(provider, "resolveProviderChain").mockResolvedValue([
+			fakeProvider("searxng", async () => {
+				await Bun.sleep(120);
+				primarySettledAt = performance.now() - t0;
+				throw new Error("primary hung then failed");
+			}),
+			fakeProvider("duckduckgo", async () => {
+				ddgCalls++;
+				ddgCalledAt = performance.now() - t0;
+				await Bun.sleep(10);
+				return ddgResponse;
+			}),
+		]);
+
+		const tool = new WebSearchTool(FAKE_SESSION);
+		const result = await tool.execute("t", { query: "q" });
+
+		expect(ddgCalls).toBe(1);
+		// The hedge started while the primary was still in flight.
+		expect(ddgCalledAt).toBeLessThan(primarySettledAt);
+		expect(result.details?.response.provider).toBe("duckduckgo");
+		const block = result.content[0];
+		expect(block && "text" in block ? block.text : "").toContain("Warning: Web search provider fallback");
+	});
+
+	it("aborts the hedge when the primary succeeds", async () => {
+		setDdgHedgeDelayMs(20);
+		let hedgeSignal: AbortSignal | undefined;
+
+		vi.spyOn(provider, "resolveProviderChain").mockResolvedValue([
+			fakeProvider("searxng", async () => {
+				await Bun.sleep(80);
+				return { provider: "searxng", sources: [] };
+			}),
+			fakeProvider("duckduckgo", async params => {
+				hedgeSignal = params.signal;
+				await Bun.sleep(1_000);
+				return ddgResponse;
+			}),
+		]);
+
+		const tool = new WebSearchTool(FAKE_SESSION);
+		const result = await tool.execute("t", { query: "q" });
+
+		expect(result.details?.response.provider).toBe("searxng");
+		// The hedge was started (delay elapsed before primary success) and
+		// then aborted once the primary won.
+		expect(hedgeSignal).toBeInstanceOf(AbortSignal);
+		expect(hedgeSignal?.aborted).toBe(true);
+	});
+
+	it("does not double-invoke DuckDuckGo when the primary fails before the hedge fires", async () => {
+		setDdgHedgeDelayMs(5_000);
+		let ddgCalls = 0;
+
+		vi.spyOn(provider, "resolveProviderChain").mockResolvedValue([
+			fakeProvider("searxng", async () => {
+				throw new Error("fast failure");
+			}),
+			fakeProvider("duckduckgo", async () => {
+				ddgCalls++;
+				return ddgResponse;
+			}),
+		]);
+
+		const tool = new WebSearchTool(FAKE_SESSION);
+		const result = await tool.execute("t", { query: "q" });
+
+		expect(ddgCalls).toBe(1);
+		expect(result.details?.response.provider).toBe("duckduckgo");
+	});
+
+	it("runs DuckDuckGo directly with no hedge when it is the only provider", async () => {
+		setDdgHedgeDelayMs(20);
+		let ddgCalls = 0;
+
+		vi.spyOn(provider, "resolveProviderChain").mockResolvedValue([
+			fakeProvider("duckduckgo", async () => {
+				ddgCalls++;
+				return ddgResponse;
+			}),
+		]);
+
+		const tool = new WebSearchTool(FAKE_SESSION);
+		const result = await tool.execute("t", { query: "q" });
+		// Give a would-be hedge timer time to fire if one was wrongly armed.
+		await Bun.sleep(50);
+
+		expect(ddgCalls).toBe(1);
+		expect(result.details?.response.provider).toBe("duckduckgo");
+	});
+});

--- a/packages/coding-agent/test/web/search/speed-improvements.test.ts
+++ b/packages/coding-agent/test/web/search/speed-improvements.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../../../src/web/search/provider";
 import type { SearchParams } from "../../../src/web/search/providers/base";
 import {
+	applyConfiguredSearchTimeout,
 	SEARCH_API_TIMEOUT_MS,
 	SEARCH_HARD_TIMEOUT_MS,
 	SEARCH_LLM_TIMEOUT_MS,
@@ -62,6 +63,54 @@ describe("per-class hard timeouts", () => {
 	});
 
 	it("does not abort a class-tagged signal immediately without an override", async () => {
+		const signal = withHardTimeout(undefined, "api");
+		await Bun.sleep(30);
+		expect(signal.aborted).toBe(false);
+	});
+});
+
+describe("applyConfiguredSearchTimeout (settings initialization path)", () => {
+	afterEach(() => setSearchHardTimeoutMs(undefined));
+
+	function settingsSource(explicit: boolean, value: unknown) {
+		return {
+			get: () => value as number,
+			has: () => explicit,
+		};
+	}
+
+	it("does NOT install the schema default as a global override", async () => {
+		// Regression for the review blocker: settings.get("web_search.timeout")
+		// returns the schema default (300) even when the user never configured
+		// it. Consuming that value unconditionally would reinstall the uniform
+		// 300s ceiling and kill the per-class defaults on every real session.
+		applyConfiguredSearchTimeout(settingsSource(false, 300));
+		const signal = withHardTimeout(undefined, "api");
+		await Bun.sleep(30);
+		// Un-overridden api-class signals must stay open well past any
+		// wrongly-installed millisecond-scale override.
+		expect(signal.aborted).toBe(false);
+	});
+
+	it("installs an explicitly configured timeout as the override", async () => {
+		applyConfiguredSearchTimeout(settingsSource(true, 0.01)); // 10ms
+		const apiSignal = withHardTimeout(undefined, "api");
+		const llmSignal = withHardTimeout(undefined, "llm");
+		await Bun.sleep(50);
+		expect(apiSignal.aborted).toBe(true);
+		expect(llmSignal.aborted).toBe(true);
+	});
+
+	it("clears a previous override when the setting is no longer explicitly configured", async () => {
+		applyConfiguredSearchTimeout(settingsSource(true, 0.01));
+		applyConfiguredSearchTimeout(settingsSource(false, 300));
+		const signal = withHardTimeout(undefined, "api");
+		await Bun.sleep(30);
+		expect(signal.aborted).toBe(false);
+	});
+
+	it("ignores invalid explicit values instead of installing them", async () => {
+		applyConfiguredSearchTimeout(settingsSource(true, -5));
 		const signal = withHardTimeout(undefined, "api");
 		await Bun.sleep(30);
 		expect(signal.aborted).toBe(false);
@@ -124,6 +173,31 @@ describe("resolved-chain caching", () => {
 		await resolveProviderChain({ authStorage: a.storage, activeModelContext: { ...ctx } });
 		await resolveProviderChain({ authStorage: b.storage, activeModelContext: { ...ctx } });
 		expect(b.probeCount()).toBeGreaterThan(0);
+	});
+
+	it("invalidates cached chains when the AuthStorage generation changes", async () => {
+		let probes = 0;
+		let generation = 1;
+		const storage = {
+			hasAuth: () => false,
+			hasOAuth: () => false,
+			getOAuthAccess: () => undefined,
+			getGeneration: () => generation,
+			getApiKey: async () => {
+				probes++;
+				return "sk-test";
+			},
+		} as unknown as AuthStorage;
+
+		await resolveProviderChain({ authStorage: storage, activeModelContext: { ...ctx } });
+		const probesAfterFirst = probes;
+		// Same generation: cache hit, no new probes.
+		await resolveProviderChain({ authStorage: storage, activeModelContext: { ...ctx } });
+		expect(probes).toBe(probesAfterFirst);
+		// Credential change (login/logout) bumps the generation: re-probe.
+		generation = 2;
+		await resolveProviderChain({ authStorage: storage, activeModelContext: { ...ctx } });
+		expect(probes).toBeGreaterThan(probesAfterFirst);
 	});
 
 	it("does not share cache entries across different model contexts", async () => {


### PR DESCRIPTION
## Summary

Latency overhaul for the `web_search` tool. Five independent improvements, no behavior-contract changes — same providers, same fallback semantics, same output format.

### 1. Class-based hard timeouts (was: uniform 300s)
`withHardTimeout()` now resolves per-class defaults: pure search APIs (brave, exa, jina, kimi, tavily, kagi, parallel, searxng, synthetic, zai, duckduckgo) get **15s** (`SEARCH_API_TIMEOUT_MS`), LLM-mediated providers (anthropic, codex, gemini, perplexity, xai, openai-compatible) get **120s** (`SEARCH_LLM_TIMEOUT_MS`). A user-configured `web_search.timeout` still overrides every class default; explicit millisecond arguments (e.g. insane's route timeout) always win. Untagged call sites keep the legacy 300s ceiling.

### 2. Hedged DuckDuckGo fallback
When DDG is a non-primary chain member, `executeSearch()` fires it in the background 3s into the primary attempt. A successful primary aborts the hedge; a failing primary reuses the (typically already-settled) hedge result — fallback latency collapses from `t(primary failure) + t(ddg)` to `max(t(primary failure), t(ddg))`. Cleanup is guaranteed via `finally`; a losing hedge can never become an unhandled rejection.

### 3. Gemini retry budget: 5min → 30s
The chain always terminates in keyless DuckDuckGo, so a rate-limited Gemini now fails through in seconds instead of parking the whole chain behind server-provided retry delays.

### 4. Resolved-chain caching
`resolveProviderChain()` memoizes the resolved provider-id list per `AuthStorage` instance (WeakMap-keyed, 60s TTL), skipping credential availability probes / potential OAuth-broker round-trips on repeat searches. `setPreferredSearchProvider()` / `setSearchFallbackProviders()` clear the cache; `clearResolvedChainCache()` is exported for tests.

### 5. Chain prewarm
`WebSearchTool`'s constructor fire-and-forgets `prewarmSearchProviders()` so provider module imports and the chain cache are primed before the first user-visible search. Best-effort; errors swallowed.

## Measured results

Benchmarked against pristine HEAD in a separate worktree; local hang/slow servers as the SearXNG primary, real DuckDuckGo as fallback.

| Scenario | Before | After |
|---|---|---|
| Hung primary (TCP accept, never responds) | **301.2s** | **15.0s** (3/3 runs) — 20x |
| Slow-failing primary (500 after 6s) | 7.08 / 6.90 / 7.14s | **6.01 / 6.01 / 6.01s** (DDG cost removed from critical path) |
| Repeat chain resolution (25ms probe sim, 6 calls) | 26.0–26.9ms each, 6 probes | **~0.01ms**, 1 probe |

The after-value of exactly 15.00s in the hung scenario is itself evidence the hedge works: the DDG result was already settled when the primary timed out, so fallback added zero latency.

## Verification

- `tsc --noEmit` clean
- `test/web` + provider web-search suites: **295 pass / 0 fail** (296 tests, 29 files), including all existing redteam / citation-harvest / abort-propagation coverage
- 12 new regression tests (`test/web/search/speed-improvements.test.ts`): timeout class ordering + override precedence, cache hit / clear / per-storage / per-context isolation, hedge reuse / abort-on-primary-success / no-double-invoke / no-hedge-when-solo
- Live DDG parity check: identical 10-source result shape and top URLs before/after
- Docs (`docs/tools/web_search.md`) and CHANGELOG updated to match

## Notes

- `setDdgHedgeDelayMs()` is exported for test injection only; the default stays 3s.
- The `web_search.timeout` setting semantics are preserved (single user knob overriding everything), so `sdk.ts` / `selector-controller.ts` / `web-search-cli.ts` wiring needed no changes.
