### PR TITLE
Fix skill prompt card width wrapping

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,11 +4,8 @@
 ### Fixed
 
 - `/retry` now resumes sessions left with an interrupted user/custom/tool-result tail after a crash or power loss, and recovers unresolved assistant tool-use tails instead of reporting "Nothing to retry".
-- Queued prompt shortcuts now keep working during auto context-full compaction: Tab/Alt+Enter queue text immediately, and Alt+Up restores only the newest queued prompt for editing instead of merging the full queue.
 - Queued prompt shortcuts now keep working during auto context-full compaction: Tab/Alt+Enter queue text immediately, `/skill:*` entries replay through the skill invocation path after compaction, and Alt+Up restores only the newest queued prompt for editing instead of merging the full queue.
-
-### Fixed
-
+- Skill prompt cards now size their collapsed arguments preview to the current terminal width instead of wrapping at a fixed narrow column.
 - `gjc update` now refreshes opted-in on-disk default workflow skill copies (written by `gjc setup defaults` under the agent dir) after a successful update, so they no longer stay stale relative to the embedded defaults; copies that were never installed are left absent.
 - cmux workspace auto-renames now include a `GJC: ` prefix so renamed workspaces remain identifiable as GJC sessions.
 - `gjc --tmux --resume` now reaches the session picker/resume target instead of auto-attaching a same-branch managed tmux session before the inner resume resolver runs.

--- a/packages/coding-agent/src/modes/components/skill-message.ts
+++ b/packages/coding-agent/src/modes/components/skill-message.ts
@@ -13,18 +13,20 @@ import {
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import type { CustomMessage, SkillPromptDetails } from "../../session/messages";
 
-const COLLAPSED_ARGS_PREVIEW_WIDTH = 96;
+const DEFAULT_COLLAPSED_ARGS_PREVIEW_WIDTH = 96;
 const COLLAPSED_ARGS_PREVIEW_LINES = 6;
+const SKILL_BOX_HORIZONTAL_PADDING = 1;
 export class SkillMessageComponent extends Container {
 	#box: Box;
 	#contentComponent?: Component;
 	#expanded = false;
+	#argsPreviewWidth = DEFAULT_COLLAPSED_ARGS_PREVIEW_WIDTH;
 
 	constructor(private readonly message: CustomMessage<SkillPromptDetails>) {
 		super();
 		this.addChild(new Spacer(1));
 
-		this.#box = new Box(1, 1, t => theme.bg("customMessageBg", t));
+		this.#box = new Box(SKILL_BOX_HORIZONTAL_PADDING, 1, t => theme.bg("customMessageBg", t));
 		this.#rebuild();
 	}
 
@@ -38,6 +40,15 @@ export class SkillMessageComponent extends Container {
 	override invalidate(): void {
 		super.invalidate();
 		this.#rebuild();
+	}
+
+	override render(width: number): string[] {
+		const contentWidth = Math.max(1, width - SKILL_BOX_HORIZONTAL_PADDING * 2);
+		if (this.#argsPreviewWidth !== contentWidth) {
+			this.#argsPreviewWidth = contentWidth;
+			this.#rebuild();
+		}
+		return super.render(width);
 	}
 
 	#rebuild(): void {
@@ -57,7 +68,7 @@ export class SkillMessageComponent extends Container {
 		// Collapsed view keeps args readable without exposing the full prompt body.
 		// Each visual line is bounded, but multi-line arguments remain multi-line so
 		// the invocation context is not mistaken for a one-line truncated payload.
-		const argsPreview = args ? this.#formatArgsPreview(args) : [];
+		const argsPreview = args ? this.#formatArgsPreview(args, this.#argsPreviewWidth) : [];
 		const header = `${theme.fg("customMessageLabel", theme.bold("[skill]"))} ${theme.fg("customMessageText", name)}`;
 		this.#box.addChild(new Text(header, 0, 0));
 		if (argsPreview.length > 0) {
@@ -111,19 +122,19 @@ export class SkillMessageComponent extends Container {
 		this.#box.addChild(this.#contentComponent);
 	}
 
-	#formatArgsPreview(args: string): string[] {
+	#formatArgsPreview(args: string, width: number): string[] {
 		const preview: string[] = [];
 		let omitted = false;
 		const sourceLines = replaceTabs(args).split(/\r?\n/);
 		for (let index = 0; index < sourceLines.length; index += 1) {
 			const sourceLine = sourceLines[index]?.trimEnd() ?? "";
-			const wrapped = wrapTextWithAnsi(sourceLine.length > 0 ? sourceLine : " ", COLLAPSED_ARGS_PREVIEW_WIDTH);
+			const wrapped = wrapTextWithAnsi(sourceLine.length > 0 ? sourceLine : " ", width);
 			for (const line of wrapped.length > 0 ? wrapped : [""]) {
 				if (preview.length >= COLLAPSED_ARGS_PREVIEW_LINES) {
 					omitted = true;
 					break;
 				}
-				preview.push(truncateToWidth(line, COLLAPSED_ARGS_PREVIEW_WIDTH));
+				preview.push(truncateToWidth(line, width));
 			}
 			if (omitted) break;
 		}
@@ -132,10 +143,7 @@ export class SkillMessageComponent extends Container {
 			omitted ||= replaceTabs(args).trimEnd().length > visibleSource.trimEnd().length;
 		}
 		if (omitted && preview.length > 0) {
-			preview[preview.length - 1] = truncateToWidth(
-				`${preview[preview.length - 1]} …`,
-				COLLAPSED_ARGS_PREVIEW_WIDTH,
-			);
+			preview[preview.length - 1] = truncateToWidth(`${preview[preview.length - 1]} …`, width);
 		}
 		return preview;
 	}

--- a/packages/coding-agent/test/modes/components/skill-message-render.test.ts
+++ b/packages/coding-agent/test/modes/components/skill-message-render.test.ts
@@ -25,11 +25,11 @@ function makeMessage(details: SkillPromptDetails, content: string): CustomMessag
 	};
 }
 
-function render(message: CustomMessage<SkillPromptDetails>, expanded: boolean): string {
+function render(message: CustomMessage<SkillPromptDetails>, expanded: boolean, width = 120): string {
 	const component = new SkillMessageComponent(message);
 	component.setExpanded(expanded);
 	return component
-		.render(120)
+		.render(width)
 		.map(line => Bun.stripANSI(line))
 		.join("\n");
 }
@@ -75,6 +75,23 @@ describe("SkillMessageComponent rendering", () => {
 		expect(out).toContain("to re-architect our problem banks");
 		expect(out).toContain("make sure gaebal-gajae skill-invocation modal");
 		expect(out).toContain("even though we need few lines to use.");
+	});
+
+	it("collapsed args preview reflows when the terminal grows instead of keeping a fixed narrow cap", () => {
+		const longArgs = "A".repeat(120);
+		const component = new SkillMessageComponent(makeMessage({ ...DETAILS, args: longArgs }, "BODY"));
+
+		const narrowOut = component
+			.render(80)
+			.map(line => Bun.stripANSI(line))
+			.join("\n");
+		expect(narrowOut).not.toContain(longArgs);
+
+		const wideOut = component
+			.render(160)
+			.map(line => Bun.stripANSI(line))
+			.join("\n");
+		expect(wideOut).toContain(longArgs);
 	});
 
 	it("bounds over-long args without leaking the full payload", () => {


### PR DESCRIPTION
## What
- Make collapsed skill prompt cards compute their args preview width from the current render width instead of a fixed 96-column cap.
- Rebuild the collapsed args preview when the terminal/component width changes, so wide terminals use the available card width.
- Clean up duplicate Unreleased changelog entries while adding this fix.

## Testing
- bun test packages/coding-agent/test/modes/components/skill-message-render.test.ts
- bun --cwd=packages/coding-agent run check:types
- bunx biome check packages/coding-agent/src/modes/components/skill-message.ts packages/coding-agent/test/modes/components/skill-message-render.test.ts
- git diff --check

## UI notes
- Scope is the existing SkillMessageComponent, not a broad product-screen redesign.
- Regression coverage renders the same component at narrow and wide widths to verify it reflows instead of keeping the old narrow cap.