### PR TITLE
Fix Coordinator MCP tmux prompt submit key

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Fixed
 
+- Coordinator MCP tmux prompt delivery now submits with tmux `Enter` instead of `C-m`, while preserving runtime prompt-ack/`turn_start` as the delivery success gate (#1409).
+
 - `/retry` now resumes sessions left with an interrupted user/custom/tool-result tail after a crash or power loss, and recovers unresolved assistant tool-use tails instead of reporting "Nothing to retry".
 - Queued prompt shortcuts now keep working during auto context-full compaction: Tab/Alt+Enter queue text immediately, `/skill:*` entries replay through the skill invocation path after compaction, and Alt+Up restores only the newest queued prompt for editing instead of merging the full queue.
 - Skill prompt cards now size their collapsed arguments preview to the current terminal width instead of wrapping at a fixed narrow column.

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -1275,7 +1275,7 @@ async function sendTmuxPromptKeys(
 ): Promise<boolean> {
 	const typed = await runner(["tmux", "send-keys", "-t", target, "-l", prompt]);
 	if (typed.exitCode !== 0) return false;
-	const submitted = await runner(["tmux", "send-keys", "-t", target, "C-m"]);
+	const submitted = await runner(["tmux", "send-keys", "-t", target, "Enter"]);
 	return submitted.exitCode === 0;
 }
 

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -22,6 +22,9 @@ async function tempRoot(): Promise<string> {
 	tempDirs.push(dir);
 	return dir;
 }
+function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", `'\\''`)}'`;
+}
 
 afterEach(async () => {
 	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
@@ -134,7 +137,61 @@ describe("Coordinator MCP server protocol", () => {
 		).toEqual({ ok: false, reason: "invalid_tmux_session" });
 	});
 
-	it("registers a visible tmux session and submits prompts with Enter-compatible tmux C-m", async () => {
+	it("uses tmux Enter as the primary submit token", async () => {
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "state", "primary-enter-token");
+		const sendKeyCommands: string[][] = [];
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+			},
+			services: {
+				commandRunner: async command => {
+					if (command[1] === "has-session") return { exitCode: 0, stdout: "", stderr: "" };
+					if (command[1] === "display-message") return { exitCode: 0, stdout: "%24\n", stderr: "" };
+					if (command[1] === "send-keys") {
+						sendKeyCommands.push(command);
+						return { exitCode: 0, stdout: "", stderr: "" };
+					}
+					return { exitCode: 1, stdout: "", stderr: "unexpected command" };
+				},
+			},
+		});
+
+		await server.callTool("gjc_coordinator_register_session", {
+			session_id: "visible-session",
+			cwd: root,
+			tmux_session: "visible-session",
+			tmux_target: "visible-session:0.0",
+			visible: true,
+			allow_mutation: true,
+		});
+		await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "primary submit token",
+			allow_mutation: true,
+		});
+
+		expect(sendKeyCommands).toEqual([
+			["tmux", "send-keys", "-t", "visible-session:0.0", "-l", "primary submit token"],
+			["tmux", "send-keys", "-t", "visible-session:0.0", "Enter"],
+		]);
+		expect(sendKeyCommands).not.toContainEqual(["tmux", "send-keys", "-t", "visible-session:0.0", "C-m"]);
+		expect(sendKeyCommands).not.toContainEqual([
+			"tmux",
+			"send-keys",
+			"-t",
+			"visible-session:0.0",
+			"-l",
+			"\x1b[13;5u",
+		]);
+	});
+
+	it("registers a visible tmux session and submits prompts with tmux Enter", async () => {
 		const root = await tempRoot();
 		const stateRoot = path.join(root, ".gjc", "state", "visible-register");
 		const commands: string[][] = [];
@@ -198,13 +255,13 @@ describe("Coordinator MCP server protocol", () => {
 		expect(commands).toEqual(
 			expect.arrayContaining([
 				["tmux", "send-keys", "-t", "visible-session:0.0", "-l", "do work"],
-				["tmux", "send-keys", "-t", "visible-session:0.0", "C-m"],
+				["tmux", "send-keys", "-t", "visible-session:0.0", "Enter"],
 			]),
 		);
 		expect(commands).not.toContainEqual(["tmux", "send-keys", "-t", "visible-session:0.0", "-l", "\x1b[13;5u"]);
 		expect(commands.slice(-2)).toEqual([
 			["tmux", "send-keys", "-t", "visible-session:0.0", "-l", "do work"],
-			["tmux", "send-keys", "-t", "visible-session:0.0", "C-m"],
+			["tmux", "send-keys", "-t", "visible-session:0.0", "Enter"],
 		]);
 	});
 
@@ -313,7 +370,7 @@ describe("Coordinator MCP server protocol", () => {
 		});
 	});
 
-	it("submits tmux-delivered prompts with Enter-compatible tmux C-m after literal typing", async () => {
+	it("submits tmux-delivered prompts with tmux Enter after literal typing", async () => {
 		const root = await tempRoot();
 		const stateRoot = path.join(root, ".gjc", "state", "submit-chord-delivery");
 		const sendKeyCommands: string[][] = [];
@@ -355,7 +412,7 @@ describe("Coordinator MCP server protocol", () => {
 
 		expect(sendKeyCommands).toEqual([
 			["tmux", "send-keys", "-t", "visible-session:0.0", "-l", "line one\nline two"],
-			["tmux", "send-keys", "-t", "visible-session:0.0", "C-m"],
+			["tmux", "send-keys", "-t", "visible-session:0.0", "Enter"],
 		]);
 		expect(sendKeyCommands).not.toContainEqual([
 			"tmux",
@@ -587,8 +644,147 @@ describe("Coordinator MCP server protocol", () => {
 		expect(activeTurnExistedAtSend).toBe(true);
 		expect(commands.filter(command => command[1] === "send-keys")).toEqual([
 			["tmux", "send-keys", "-t", "gjc-coordinator-test:0.0", "-l", "hello"],
-			["tmux", "send-keys", "-t", "gjc-coordinator-test:0.0", "C-m"],
+			["tmux", "send-keys", "-t", "gjc-coordinator-test:0.0", "Enter"],
 		]);
+	});
+
+	it("acks a prompt delivered through a real tmux pane with Enter", async () => {
+		if (!Bun.which("tmux")) return;
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "state", "real-tmux-enter-ack");
+		const runtimeScript = path.join(root, "fake-runtime.mjs");
+		const runtimeLog = path.join(root, "fake-runtime.log");
+		const runtimeOutput = path.join(root, "fake-runtime-output.log");
+		await Bun.write(
+			runtimeScript,
+			`
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+const logFile = ${JSON.stringify(runtimeLog)};
+const log = async message => await fs.appendFile(logFile, message + "\\n").catch(() => {});
+process.on("uncaughtException", error => {
+  fs.appendFile(logFile, "uncaught:" + (error && error.stack ? error.stack : String(error)) + "\\n").finally(() => process.exit(99));
+});
+await log("started");
+
+const stateFile = process.env.GJC_COORDINATOR_SESSION_STATE_FILE;
+const sessionId = process.env.GJC_COORDINATOR_SESSION_ID;
+if (!stateFile || !sessionId) process.exit(2);
+await fs.mkdir(path.dirname(stateFile), { recursive: true });
+await fs.writeFile(stateFile, JSON.stringify({
+  schema_version: 1,
+  session_id: sessionId,
+  state: "ready_for_input",
+  ready_for_input: true,
+  current_turn_id: null,
+  last_turn_id: null,
+  updated_at: new Date().toISOString(),
+  source: "fake_runtime",
+  live: true,
+  reason: null
+}));
+await log("ready");
+
+process.stdin.setEncoding("utf8");
+process.stdin.resume();
+const input = await new Promise(resolve => {
+  let buffered = "";
+  process.stdin.on("data", chunk => {
+    buffered += String(chunk);
+    if (buffered.includes("\\n") || buffered.includes("\\r")) resolve(buffered);
+  });
+});
+await log("input:" + JSON.stringify(input));
+const activeTurnPath = path.join(path.dirname(path.dirname(stateFile)), "active-turns", sessionId + ".json");
+let activeTurn = null;
+for (let attempt = 0; attempt < 100; attempt++) {
+  try {
+    activeTurn = JSON.parse(await fs.readFile(activeTurnPath, "utf8"));
+    break;
+  } catch {
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+}
+if (!activeTurn) process.exit(3);
+await log("activeTurn:" + Boolean(activeTurn));
+await fs.writeFile(stateFile, JSON.stringify({
+  schema_version: 1,
+  session_id: sessionId,
+  state: "running",
+  ready_for_input: false,
+  current_turn_id: activeTurn.turn_id,
+  last_turn_id: null,
+  updated_at: new Date().toISOString(),
+  source: "agent_session_event",
+  live: true,
+  reason: input.trim().length > 0 ? "turn_start" : "empty_line"
+}));
+await log("ack");
+setInterval(() => {}, 1000);
+`,
+		);
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
+				GJC_COORDINATOR_MCP_SESSION_COMMAND: `${shellQuote(process.execPath)} ${shellQuote(runtimeScript)} > ${shellQuote(runtimeOutput)} 2>&1`,
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+				GJC_COORDINATOR_MCP_PROMPT_ACK_TIMEOUT_MS: "2000",
+			},
+		});
+		let tmuxSession: string | null = null;
+		try {
+			const started = await server.callTool("gjc_coordinator_start_session", {
+				cwd: root,
+				prompt: "real tmux enter ack smoke",
+				allow_mutation: true,
+			});
+			expect(started.ok).toBe(true);
+			tmuxSession = (started.session as { tmux_session?: string }).tmux_session ?? null;
+			const turnId = started.turn_id as string;
+			let read = await server.callTool("gjc_coordinator_read_turn", {
+				session_id: started.session_id ?? (started.session as { session_id: string }).session_id,
+				turn_id: turnId,
+			});
+			for (
+				let attempt = 0;
+				attempt < 50 &&
+				(read.turn as { delivery: { prompt_acknowledged: boolean } }).delivery.prompt_acknowledged !== true;
+				attempt++
+			) {
+				await Bun.sleep(20);
+				read = await server.callTool("gjc_coordinator_read_turn", {
+					session_id: (started.session as { session_id: string }).session_id,
+					turn_id: turnId,
+				});
+			}
+
+			if ((read.turn as { delivery: { prompt_acknowledged: boolean } }).delivery.prompt_acknowledged !== true) {
+				throw new Error(
+					(await Bun.file(runtimeLog)
+						.text()
+						.catch(() => "missing fake runtime log")) +
+						"\noutput:\n" +
+						(await Bun.file(runtimeOutput)
+							.text()
+							.catch(() => "missing fake runtime output")),
+				);
+			}
+			expect(read).toMatchObject({
+				ok: true,
+				turn: {
+					status: "active",
+					delivery: { tmux_keys_sent: true, prompt_acknowledged: true, state: "acknowledged" },
+					error: null,
+				},
+				session_state: { state: "running", current_turn_id: turnId, reason: "turn_start" },
+			});
+		} finally {
+			if (tmuxSession) Bun.spawnSync(["tmux", "kill-session", "-t", tmuxSession]);
+		}
 	});
 
 	it("exposes a canonical polling coordination snapshot", async () => {


### PR DESCRIPTION
## Summary
- switch Coordinator MCP tmux prompt submission from `C-m` to `Enter`
- keep delivery success gated on runtime prompt ack / `turn_start`, not `tmux_keys_sent`
- update regression coverage so `Enter` is the primary submit token and `C-m`/CSI-u are not accepted as primary submit paths
- add bounded real-tmux coverage with a fake runtime sidecar that acknowledges the delivered turn after `Enter`

Fixes #1409

## Verification
- `bun test packages/coding-agent/test/coordinator-mcp-server.test.ts --test-name-pattern 'real tmux pane'`
- `bun test packages/coding-agent/test/coordinator-mcp-server.test.ts`

## Integration coverage
Added a non-model-dependent real tmux test that launches a tmux-backed fake runtime through the Coordinator MCP session command, sends a prompt via the real tmux path, and asserts runtime prompt ack/`turn_start`. This covers the submit-key/control-plane path without broad flaky model dependency.