### PR TITLE
fix(cmux): guard workspace auto-rename against clobbering user titles

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -444,6 +444,7 @@ Extra conditional behavior:
 | `GJC_SLOW_MODEL`              | Ephemeral model-role override for `slow` (CLI `--slow` takes precedence)                           |
 | `GJC_PLAN_MODEL`              | Ephemeral model-role override for `plan` (CLI `--plan` takes precedence)                           |
 | `GJC_NO_TITLE`                | If set (any non-empty value), disables auto session title generation on first user message         |
+| `GJC_NO_CMUX_RENAME`         | If set (any non-empty value), disables renaming the containing cmux workspace to the current session name |
 | `NULL_PROMPT`                | If `true`, system prompt builder returns empty string                                              |
 | `GJC_BLOCKED_AGENT`           | Blocks a specific subagent type in task tool                                                       |
 | `GJC_SUBPROCESS_CMD`          | Overrides subagent spawn command (`gjc` / `gjc.cmd` resolution bypass)                             |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Skill prompt cards now size their collapsed arguments preview to the current terminal width instead of wrapping at a fixed narrow column.
 - `gjc update` now refreshes opted-in on-disk default workflow skill copies (written by `gjc setup defaults` under the agent dir) after a successful update, so they no longer stay stale relative to the embedded defaults; copies that were never installed are left absent.
 - cmux workspace auto-renames now include a `GJC: ` prefix so renamed workspaces remain identifiable as GJC sessions.
+- The cmux workspace auto-rename is now ownership-guarded: GJC reads the current workspace title via `cmux workspace list` and only renames a workspace that still has its default title, so it no longer overwrites a user-pinned workspace name or thrash a shared workspace title across multiple sessions running under the same `CMUX_WORKSPACE_ID`. Opt out with `GJC_NO_CMUX_RENAME`.
 - `gjc --tmux --resume` now reaches the session picker/resume target instead of auto-attaching a same-branch managed tmux session before the inner resume resolver runs.
 
 ### Changed

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -24,7 +24,7 @@ For simple local side effects that do not need a full extension, set the user-le
 gjc config set completion.notifyCommand 'cmux notify --title "$GJC_NOTIFICATION_TITLE" --body "$GJC_NOTIFICATION_BODY"'
 ```
 
-When GJC is running inside a cmux terminal (`CMUX_WORKSPACE_ID` is set), GJC also best-effort renames that cmux workspace to the current GJC session name with a `GJC: ` prefix whenever the session title is set or restored.
+When GJC runs inside a cmux terminal (`CMUX_WORKSPACE_ID` is set), GJC best-effort renames that cmux workspace to the current GJC session name (with a `GJC: ` prefix) — but only when the workspace still has its default title, so a name you pinned (or one set by a peer session sharing the workspace) is never overwritten. Opt out with `GJC_NO_CMUX_RENAME=1`.
 
 Windows Terminal may keep BEL (`[Console]::Write([char]7)`) silent depending on profile and system sound settings even when `notifications.terminalBell` is enabled. For an audible Windows completion beep, configure a user-level PowerShell command hook instead:
 

--- a/packages/coding-agent/src/utils/cmux-workspace.ts
+++ b/packages/coding-agent/src/utils/cmux-workspace.ts
@@ -2,13 +2,23 @@ import { logger } from "@gajae-code/utils";
 
 const CMUX_COMMAND = "cmux";
 const CMUX_WORKSPACE_ID_ENV = "CMUX_WORKSPACE_ID";
+const CMUX_NO_RENAME_ENV = "GJC_NO_CMUX_RENAME";
 const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
 const CMUX_WORKSPACE_TITLE_PREFIX = "GJC: ";
 const CMUX_WORKSPACE_RENAME_TIMEOUT_MS = 1500;
+const CMUX_WORKSPACE_LIST_TIMEOUT_MS = 1500;
 
 export interface CmuxWorkspaceRenameCommand {
 	command: string;
 	args: string[];
+}
+
+/** Current ownership state of a cmux workspace, read back from `cmux workspace list`. */
+export interface CmuxWorkspaceOwnership {
+	/** cmux marks a workspace `has_custom_title` once an explicit title is set (by the user or by GJC). */
+	hasCustomTitle: boolean;
+	/** The workspace's current display title. */
+	title: string;
 }
 
 export interface CmuxWorkspaceRenameProcess {
@@ -25,6 +35,12 @@ export interface CmuxWorkspaceTitleSyncOptions {
 		command: string[],
 		options: { env: NodeJS.ProcessEnv; stdin: "ignore"; stdout: "ignore"; stderr: "ignore" },
 	) => CmuxWorkspaceRenameProcess;
+	/** Reads the current ownership state of `workspaceId`. Injectable for tests. */
+	readOwnership?: (
+		cmuxCommand: string,
+		workspaceId: string,
+		env: NodeJS.ProcessEnv,
+	) => Promise<CmuxWorkspaceOwnership | null>;
 }
 
 function defaultSpawn(
@@ -32,6 +48,12 @@ function defaultSpawn(
 	options: { env: NodeJS.ProcessEnv; stdin: "ignore"; stdout: "ignore"; stderr: "ignore" },
 ): CmuxWorkspaceRenameProcess {
 	return Bun.spawn(command, options);
+}
+
+function isEnvSet(value: string | undefined): boolean {
+	if (!value) return false;
+	const normalized = value.trim().toLowerCase();
+	return normalized !== "" && normalized !== "0" && normalized !== "false";
 }
 
 export function sanitizeCmuxWorkspaceTitle(title: string | undefined): string | undefined {
@@ -62,26 +84,124 @@ export function buildCmuxWorkspaceRenameCommand(
 	};
 }
 
-export function syncCmuxWorkspaceTitle(
+/** Parse `cmux workspace list --json --id-format both` output and return the
+ * ownership state of the workspace matching `workspaceId` (by UUID `id` or `ref`). */
+export function parseCmuxWorkspaceOwnership(jsonText: string, workspaceId: string): CmuxWorkspaceOwnership | null {
+	const target = workspaceId.trim().toLowerCase();
+	if (!target) return null;
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(jsonText);
+	} catch {
+		return null;
+	}
+
+	const workspaces = (parsed as { workspaces?: unknown }).workspaces;
+	if (!Array.isArray(workspaces)) return null;
+
+	for (const entry of workspaces) {
+		if (!entry || typeof entry !== "object") continue;
+		const record = entry as Record<string, unknown>;
+		const id = typeof record.id === "string" ? record.id.toLowerCase() : "";
+		const ref = typeof record.ref === "string" ? record.ref.toLowerCase() : "";
+		if (id !== target && ref !== target) continue;
+		return {
+			hasCustomTitle: record.has_custom_title === true,
+			title: typeof record.title === "string" ? record.title : "",
+		};
+	}
+	return null;
+}
+
+/** Only rename when GJC owns the name:
+ * - unknown ownership (read failed) → skip (fail safe, never clobber)
+ * - already the desired title → skip (no-op)
+ * - workspace still on its default title → rename
+ * - any custom title (user- or peer-set) → skip
+ * This makes GJC name a fresh workspace once and then leave it alone, so it
+ * never overwrites a user-pinned name and multiple sessions sharing one
+ * CMUX_WORKSPACE_ID do not thrash the workspace title. */
+export function shouldRenameCmuxWorkspace(ownership: CmuxWorkspaceOwnership | null, desiredTitle: string): boolean {
+	if (!ownership) return false;
+	if ((sanitizeCmuxWorkspaceTitle(ownership.title) ?? "") === desiredTitle) return false;
+	return !ownership.hasCustomTitle;
+}
+
+async function defaultReadOwnership(
+	cmuxCommand: string,
+	workspaceId: string,
+	env: NodeJS.ProcessEnv,
+): Promise<CmuxWorkspaceOwnership | null> {
+	try {
+		const proc = Bun.spawn([cmuxCommand, "workspace", "list", "--json", "--id-format", "both"], {
+			env: { ...env, CMUX_QUIET: "1" },
+			stdin: "ignore",
+			stdout: "pipe",
+			stderr: "ignore",
+		});
+		const timer = setTimeout(() => {
+			try {
+				proc.kill();
+			} catch {}
+		}, CMUX_WORKSPACE_LIST_TIMEOUT_MS);
+		timer.unref?.();
+		const text = await new Response(proc.stdout).text();
+		await proc.exited;
+		clearTimeout(timer);
+		return parseCmuxWorkspaceOwnership(text, workspaceId);
+	} catch (error) {
+		logger.debug("cmux workspace list failed", { error: String(error) });
+		return null;
+	}
+}
+
+/**
+ * Best-effort sync of the containing cmux workspace title to the current GJC
+ * session name. Ownership-guarded: GJC reads the current workspace title and
+ * only renames a workspace that still has its default title, so it never
+ * overwrites a name the user pinned or a name a peer session (sharing the same
+ * CMUX_WORKSPACE_ID) set. Opt out with GJC_NO_CMUX_RENAME.
+ */
+export async function syncCmuxWorkspaceTitle(
 	sessionName: string | undefined,
 	options: CmuxWorkspaceTitleSyncOptions = {},
-): void {
+): Promise<void> {
+	const env = options.env ?? process.env;
+	if (isEnvSet(env[CMUX_NO_RENAME_ENV])) return;
+
 	const isTty = options.isTty ?? process.stdout.isTTY === true;
 	if (!isTty) return;
 
-	const env = options.env ?? process.env;
-	const plan = buildCmuxWorkspaceRenameCommand(sessionName, env);
-	if (!plan) return;
+	const workspaceId = env[CMUX_WORKSPACE_ID_ENV]?.trim();
+	if (!workspaceId) return;
+
+	const desired = formatCmuxWorkspaceTitle(sessionName);
+	if (!desired) return;
 
 	const which = options.which ?? Bun.which;
 	let resolvedCommand: string | null;
 	try {
-		resolvedCommand = which(plan.command);
+		resolvedCommand = which(CMUX_COMMAND);
 	} catch (error) {
 		logger.debug("cmux workspace rename command lookup failed", { error: String(error) });
 		return;
 	}
 	if (!resolvedCommand) return;
+
+	let ownership: CmuxWorkspaceOwnership | null;
+	try {
+		const readOwnership = options.readOwnership ?? defaultReadOwnership;
+		ownership = await readOwnership(resolvedCommand, workspaceId, env);
+	} catch (error) {
+		logger.debug("cmux workspace ownership read failed", { error: String(error) });
+		return;
+	}
+
+	if (!shouldRenameCmuxWorkspace(ownership, desired)) return;
+
+	const plan = buildCmuxWorkspaceRenameCommand(sessionName, env);
+	if (!plan) return;
 
 	const spawn = options.spawn ?? defaultSpawn;
 	try {

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -219,7 +219,7 @@ export function setTerminalTitle(title: string): void {
 
 export function setSessionTerminalTitle(sessionName: string | undefined, cwd?: string): void {
 	setTerminalTitle(formatSessionTerminalTitle(sessionName, cwd));
-	syncCmuxWorkspaceTitle(sessionName);
+	void syncCmuxWorkspaceTitle(sessionName);
 }
 
 /**

--- a/packages/coding-agent/test/cmux-workspace.test.ts
+++ b/packages/coding-agent/test/cmux-workspace.test.ts
@@ -1,17 +1,28 @@
 import { describe, expect, it, vi } from "bun:test";
 import {
 	buildCmuxWorkspaceRenameCommand,
+	type CmuxWorkspaceOwnership,
 	formatCmuxWorkspaceTitle,
+	parseCmuxWorkspaceOwnership,
 	sanitizeCmuxWorkspaceTitle,
+	shouldRenameCmuxWorkspace,
 	syncCmuxWorkspaceTitle,
 } from "../src/utils/cmux-workspace";
 
-function cmuxEnv(workspaceId = "workspace-123"): NodeJS.ProcessEnv {
-	return { CMUX_WORKSPACE_ID: workspaceId } as NodeJS.ProcessEnv;
+function cmuxEnv(workspaceId = "workspace-123", extra: Record<string, string> = {}): NodeJS.ProcessEnv {
+	return { CMUX_WORKSPACE_ID: workspaceId, ...extra } as NodeJS.ProcessEnv;
 }
 
+const LIST_JSON = JSON.stringify({
+	workspaces: [
+		{ id: "AAAA-1111", ref: "workspace:1", title: "Other", has_custom_title: true },
+		{ id: "DF98857C", ref: "workspace:8", title: "GJC: gajae-code", has_custom_title: true },
+		{ id: "CCCC-9999", ref: "workspace:9", title: "~/dev/x", has_custom_title: false },
+	],
+});
+
 describe("cmux workspace title sync", () => {
-	it("builds an explicit workspace rename command", () => {
+	it("builds an explicit workspace rename command with the GJC prefix", () => {
 		expect(buildCmuxWorkspaceRenameCommand("Investigate Resolver", cmuxEnv())).toEqual({
 			command: "cmux",
 			args: ["workspace", "rename", "workspace-123", "--title", "GJC: Investigate Resolver"],
@@ -31,43 +42,162 @@ describe("cmux workspace title sync", () => {
 		expect(formatCmuxWorkspaceTitle("GJC: Investigate Resolver")).toBe("GJC: Investigate Resolver");
 	});
 
-	it("does not spawn outside a tty", () => {
+	describe("parseCmuxWorkspaceOwnership", () => {
+		it("matches by UUID id case-insensitively", () => {
+			expect(parseCmuxWorkspaceOwnership(LIST_JSON, "df98857c")).toEqual({
+				hasCustomTitle: true,
+				title: "GJC: gajae-code",
+			});
+		});
+
+		it("matches by workspace ref", () => {
+			expect(parseCmuxWorkspaceOwnership(LIST_JSON, "workspace:9")).toEqual({
+				hasCustomTitle: false,
+				title: "~/dev/x",
+			});
+		});
+
+		it("returns null when the workspace is not present", () => {
+			expect(parseCmuxWorkspaceOwnership(LIST_JSON, "missing")).toBeNull();
+		});
+
+		it("returns null on unparseable output", () => {
+			expect(parseCmuxWorkspaceOwnership("not json", "df98857c")).toBeNull();
+		});
+	});
+
+	describe("shouldRenameCmuxWorkspace", () => {
+		const owned = (over: Partial<CmuxWorkspaceOwnership>): CmuxWorkspaceOwnership => ({
+			hasCustomTitle: true,
+			title: "current",
+			...over,
+		});
+
+		it("skips when ownership is unknown (read failed)", () => {
+			expect(shouldRenameCmuxWorkspace(null, "GJC: Desired")).toBe(false);
+		});
+
+		it("skips when the title already matches", () => {
+			expect(shouldRenameCmuxWorkspace(owned({ title: "GJC: Desired" }), "GJC: Desired")).toBe(false);
+		});
+
+		it("renames when the workspace still has the default title", () => {
+			expect(shouldRenameCmuxWorkspace(owned({ hasCustomTitle: false }), "GJC: Desired")).toBe(true);
+		});
+
+		it("skips a user- or peer-owned custom title", () => {
+			expect(shouldRenameCmuxWorkspace(owned({ title: "My Pinned Name" }), "GJC: Desired")).toBe(false);
+			expect(shouldRenameCmuxWorkspace(owned({ title: "GJC: Session A" }), "GJC: Session B")).toBe(false);
+		});
+	});
+
+	it("does not spawn outside a tty", async () => {
 		let spawned = false;
-		syncCmuxWorkspaceTitle("Investigate Resolver", {
+		await syncCmuxWorkspaceTitle("Investigate Resolver", {
 			env: cmuxEnv(),
 			isTty: false,
 			which: () => "/usr/local/bin/cmux",
+			readOwnership: async () => ({ hasCustomTitle: false, title: "default" }),
 			spawn: () => {
 				spawned = true;
 				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
 			},
 		});
-
 		expect(spawned).toBe(false);
 	});
 
-	it("spawns a best-effort cmux rename inside a tty cmux workspace", () => {
+	it("does not spawn when GJC_NO_CMUX_RENAME is set", async () => {
+		let spawned = false;
+		await syncCmuxWorkspaceTitle("Investigate Resolver", {
+			env: cmuxEnv("ws-optout", { GJC_NO_CMUX_RENAME: "1" }),
+			isTty: true,
+			which: () => "/usr/local/bin/cmux",
+			readOwnership: async () => ({ hasCustomTitle: false, title: "default" }),
+			spawn: () => {
+				spawned = true;
+				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
+			},
+		});
+		expect(spawned).toBe(false);
+	});
+
+	it("renames a default-titled workspace inside a tty cmux workspace", async () => {
 		const unref = vi.fn(() => {});
 		const kill = vi.fn(() => {});
 		const calls: string[][] = [];
-		const seenEnv: NodeJS.ProcessEnv[] = [];
 
-		syncCmuxWorkspaceTitle("Investigate Resolver", {
-			env: cmuxEnv(),
+		await syncCmuxWorkspaceTitle("Investigate Resolver", {
+			env: cmuxEnv("ws-default"),
 			isTty: true,
 			which: command => (command === "cmux" ? "/usr/local/bin/cmux" : null),
-			spawn: (command, options) => {
+			readOwnership: async () => ({ hasCustomTitle: false, title: "~/dev/x" }),
+			spawn: command => {
 				calls.push(command);
-				seenEnv.push(options.env);
 				return { exited: Promise.resolve(0), kill, unref };
 			},
 		});
 
 		expect(calls).toEqual([
-			["/usr/local/bin/cmux", "workspace", "rename", "workspace-123", "--title", "GJC: Investigate Resolver"],
+			["/usr/local/bin/cmux", "workspace", "rename", "ws-default", "--title", "GJC: Investigate Resolver"],
 		]);
-		expect(seenEnv[0]?.CMUX_WORKSPACE_ID).toBe("workspace-123");
 		expect(unref).toHaveBeenCalledTimes(1);
 		expect(kill).not.toHaveBeenCalled();
+	});
+
+	it("does not clobber a user-pinned workspace title", async () => {
+		let spawned = false;
+		await syncCmuxWorkspaceTitle("Investigate Resolver", {
+			env: cmuxEnv("ws-userpinned"),
+			isTty: true,
+			which: () => "/usr/local/bin/cmux",
+			readOwnership: async () => ({ hasCustomTitle: true, title: "My Pinned Name" }),
+			spawn: () => {
+				spawned = true;
+				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
+			},
+		});
+		expect(spawned).toBe(false);
+	});
+
+	it("skips renaming when ownership cannot be read", async () => {
+		let spawned = false;
+		await syncCmuxWorkspaceTitle("Investigate Resolver", {
+			env: cmuxEnv("ws-unreadable"),
+			isTty: true,
+			which: () => "/usr/local/bin/cmux",
+			readOwnership: async () => null,
+			spawn: () => {
+				spawned = true;
+				return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
+			},
+		});
+		expect(spawned).toBe(false);
+	});
+
+	it("does not thrash a workspace shared by multiple sessions", async () => {
+		// Two sessions share one CMUX_WORKSPACE_ID. Session A names the still-default
+		// workspace; session B then sees a custom title and must not overwrite it.
+		const calls: string[][] = [];
+		const spawn = (command: string[]) => {
+			calls.push(command);
+			return { exited: Promise.resolve(0), kill: () => {}, unref: () => {} };
+		};
+		await syncCmuxWorkspaceTitle("Session A task", {
+			env: cmuxEnv("ws-shared"),
+			isTty: true,
+			which: () => "/usr/local/bin/cmux",
+			readOwnership: async () => ({ hasCustomTitle: false, title: "~/dev/x" }),
+			spawn,
+		});
+		await syncCmuxWorkspaceTitle("Session B task", {
+			env: cmuxEnv("ws-shared"),
+			isTty: true,
+			which: () => "/usr/local/bin/cmux",
+			readOwnership: async () => ({ hasCustomTitle: true, title: "GJC: Session A task" }),
+			spawn,
+		});
+		expect(calls).toEqual([
+			["/usr/local/bin/cmux", "workspace", "rename", "ws-shared", "--title", "GJC: Session A task"],
+		]);
 	});
 });


### PR DESCRIPTION
## What

Make the cmux workspace auto-rename **ownership-guarded** instead of unconditional. Before renaming, GJC reads the current workspace title via `cmux workspace list --json` and only renames a workspace that still has its **default** title; a custom title (set by the user, or by a peer session sharing the workspace) is never overwritten. The `GJC: ` prefix behavior is preserved. Adds a `GJC_NO_CMUX_RENAME` opt-out.

## Why

`syncCmuxWorkspaceTitle` renamed the workspace on every session-title event (init, first-message auto title, rename, session switch) with no read-back and no opt-out. cmux shares **one `CMUX_WORKSPACE_ID` across all surfaces (terminals) in a workspace**, so:

- Multiple GJC sessions in one workspace overwrote the **same** workspace name → it thrashed to "whichever session last opened / got a message".
- A workspace name the user pinned was destroyed and kept reverting on the next event.

The rename uses the authoritative `cmux workspace rename` CLI (indistinguishable from a manual rename), so cmux can't protect the pinned name — the guard has to live in GJC. cmux already exposes `has_custom_title`, which is exactly the ownership signal needed.

### Reproduction (shipped 0.7.10)

With the shipped code, two sessions sharing one `CMUX_WORKSPACE_ID` both issue a rename — there is no code path that reads or preserves an existing title:

```
syncCmuxWorkspaceTitle("Session A task", { env: { CMUX_WORKSPACE_ID: "ws-shared" }, isTty: true, ... })
syncCmuxWorkspaceTitle("Session B task", { env: { CMUX_WORKSPACE_ID: "ws-shared" }, isTty: true, ... })
// both spawn: cmux workspace rename ws-shared --title "GJC: Session A task"
//             cmux workspace rename ws-shared --title "GJC: Session B task"
```

### Policy (`shouldRenameCmuxWorkspace`)

- read failed / unknown → skip (fail-safe, never clobber)
- current title already equals desired → skip (no-op)
- `has_custom_title === false` (still default) → rename
- any other custom title (user- or peer-set) → skip

GJC names a fresh workspace once and then leaves it alone: user-pinned names survive, and multiple sessions sharing one `CMUX_WORKSPACE_ID` no longer thrash the title. Trade-off: GJC does not keep re-pushing the latest session title after the first naming. Opt out entirely with `GJC_NO_CMUX_RENAME`.

## Affected files

- `packages/coding-agent/src/utils/cmux-workspace.ts` — ownership read + policy + opt-out (`syncCmuxWorkspaceTitle` is now async)
- `packages/coding-agent/src/utils/title-generator.ts` — `void`-call the now-async sync
- `packages/coding-agent/test/cmux-workspace.test.ts` — parser / policy / opt-out / ownership + no-thrash regression (18 cases)
- `packages/coding-agent/CHANGELOG.md`, `packages/coding-agent/README.md`, `docs/environment-variables.md`

## Testing

- `bun test packages/coding-agent/test/cmux-workspace.test.ts` → 18 pass (incl. reproduction-as-regression: a second session sharing the workspace id does not rename)
- `bun run check:ts` → `tsgo` typecheck passes for all packages (only pre-existing, unrelated `noUnusedVariables` warnings in `ultragoal-runtime.test.ts`)
- cmux CLI surface verified live (v0.64.17): `cmux workspace list --json --id-format both` exposes `id`/`has_custom_title`/`title`; `CMUX_WORKSPACE_ID` matches the `id` field

---

- [x] `bun check` passes
- [x] Tested locally (focused test 18/18)
- [x] CHANGELOG updated
