### PR TITLE
fix(coding-agent): preserve tmux sessions after PTY close

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - cmux workspace auto-renames now include a `GJC: ` prefix so renamed workspaces remain identifiable as GJC sessions.
 - The cmux workspace auto-rename is now ownership-guarded: GJC reads the current workspace title via `cmux workspace list` and only renames a workspace that still has its default title, so it no longer overwrites a user-pinned workspace name or thrash a shared workspace title across multiple sessions running under the same `CMUX_WORKSPACE_ID`. Opt out with `GJC_NO_CMUX_RENAME`.
 - `gjc --tmux --resume` now reaches the session picker/resume target instead of auto-attaching a same-branch managed tmux session before the inner resume resolver runs.
+- `gjc --tmux` now preserves a newly created managed tmux session when `attach-session` exits after the parent SSH/PTY closes but the tmux server still reports the session live, so closing a Windows Terminal tab no longer kills the Mac host session before reattach.
 
 ### Changed
 

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -949,6 +949,21 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			}
 		}
 	}
+	// Closing an SSH/Windows Terminal tab can make `tmux attach-session`
+	// exit with code 1 and no captured stderr while the tmux server correctly
+	// keeps the just-created session alive. Preserve that live session so the
+	// user can reattach instead of treating the parent client teardown as a
+	// launch failure.
+	const attachFailureStderr = attached.stderr?.trim() ?? "";
+	if (attachFailureStderr.length === 0) {
+		const probeAfterAttachFailure = probeHasSession();
+		if (probeAfterAttachFailure.exitCode === 0) {
+			(context.diagnosticWriter ?? safeStderrWrite)(
+				formatTmuxLaunchDiagnostic("attach disconnected", attached.stderr),
+			);
+			return true;
+		}
+	}
 	cleanupCreatedTmuxSession(plan, spawnSync, options);
 	(context.diagnosticWriter ?? safeStderrWrite)(formatTmuxLaunchDiagnostic("attach failed", attached.stderr));
 	return true;

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -1394,6 +1394,38 @@ describe("default GJC tmux launch", () => {
 		expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach disconnected.");
 	});
 
+	it("preserves a live newly created managed session when attach exits after PTY close", () => {
+		const calls: { command: string; args: string[]; options: TmuxSpawnOptions }[] = [];
+		const diagnostics: string[] = [];
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ tmux: true }),
+			rawArgs: [],
+			cwd: "/repo",
+			env: {},
+			argv: ["/usr/local/bin/gjc"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			currentBranch: "",
+			existingBranchSessionName: null,
+			diagnosticWriter: message => diagnostics.push(message),
+			spawnSync: (command, spawnArgs, options) => {
+				calls.push({ command, args: spawnArgs, options });
+				if (spawnArgs[0] === "attach-session") return { exitCode: 1 };
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls.some(call => call.args[0] === "new-session")).toBe(true);
+		expect(calls.some(call => call.args[0] === "attach-session")).toBe(true);
+		expect(calls.filter(call => call.args[0] === "has-session").length).toBeGreaterThanOrEqual(2);
+		expect(calls.some(call => call.args[0] === "kill-session")).toBe(false);
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0]).toStartWith("gjc --tmux failed after creating tmux session: attach disconnected.");
+	});
+
 	it("does not throw when the default tmux diagnostic write hits a closed stderr", () => {
 		const writeSpy = spyOn(fs, "writeSync").mockImplementation(() => {
 			throw stderrError("EIO");


### PR DESCRIPTION
## What

- Preserve a newly created managed `gjc --tmux` session when `tmux attach-session` exits nonzero with no stderr but `tmux has-session` still reports the session alive.
- Keep the existing cleanup path for real attach failures where the session is not live.
- Add regression coverage for the silent PTY-close attach exit and update the coding-agent changelog.

## Why

When an SSH client / Windows Terminal tab closes, the controlling PTY can disappear under `tmux attach-session`. Native tmux may return exit code `1` with no stderr while the tmux server correctly keeps the just-created session alive. The previous launcher treated that unclassified attach exit as a launch failure and ran `kill-session`, which defeated the main purpose of `gjc --tmux`: leaving the Mac host session available for later reattach.

The existing disconnect handling already preserves sessions for explicit `EIO`/`SIGHUP` attach results; this closes the adjacent silent-exit case by probing tmux liveness before cleanup.

## Testing

- Local PTY reproduction: closing the attach PTY made `tmux attach-session` return `1` while `tmux has-session` still returned true for the same session.
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts` → 66 pass, 0 fail, 248 expect() calls
- `bun --cwd=packages/coding-agent run check` → passed; emits existing unrelated `noUnusedVariables` warnings in `test/gjc-runtime/ultragoal-runtime.test.ts`
- `bun run check:ts` → passed; same existing warnings
- `bun run check` → TS side passed, but full check exits nonzero in `check:rs` due pre-existing rustfmt diffs under vendored `crates/brush-*-vendored` files; this PR does not touch Rust

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)