### PR TITLE
fix(coding-agent): reserve tmux status rows for managed launches

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - The cmux workspace auto-rename is now ownership-guarded: GJC reads the current workspace title via `cmux workspace list` and only renames a workspace that still has its default title, so it no longer overwrites a user-pinned workspace name or thrash a shared workspace title across multiple sessions running under the same `CMUX_WORKSPACE_ID`. Opt out with `GJC_NO_CMUX_RENAME`.
 - `gjc --tmux --resume` now reaches the session picker/resume target instead of auto-attaching a same-branch managed tmux session before the inner resume resolver runs.
 - `gjc --tmux` now preserves a newly created managed tmux session when `attach-session` exits after the parent SSH/PTY closes but the tmux server still reports the session live, so closing a Windows Terminal tab no longer kills the Mac host session before reattach.
+- Managed `gjc --tmux` launches now size the inner tmux window to the caller terminal minus inherited tmux status lines, preventing the bottom of the GJC input from being clipped when the user's tmux status bar is visible.
 
 ### Changed
 

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -60,6 +60,7 @@ export interface TmuxLaunchContext {
 	tty?: TtyState;
 	spawnSync?: TmuxSpawnSync;
 	tmuxAvailable?: boolean;
+	tmuxStatusLines?: number;
 	worktreeBranch?: string | null;
 	currentBranch?: string | null;
 	existingBranchSessionName?: string | null;
@@ -561,12 +562,38 @@ function normalizeTmuxTerminalDimension(value: number | undefined): number | und
 	return value;
 }
 
-function resolveCallerTmuxTerminalSize(tty: TtyState): TmuxTerminalSize | undefined {
+function normalizeTmuxStatusLineCount(value: number | undefined): number {
+	if (value === undefined || !Number.isSafeInteger(value) || value <= 0) return 0;
+	return value;
+}
+
+function parseTmuxStatusLineCount(value: string): number {
+	const normalized = value.trim().toLowerCase();
+	if (normalized.length === 0 || normalized === "off" || normalized === "0") return 0;
+	if (normalized === "on") return 1;
+	const parsed = Number.parseInt(normalized, 10);
+	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function readTmuxStatusLineCount(tmuxCommand: string, cwd: string, env: NodeJS.ProcessEnv): number {
+	const result = Bun.spawnSync([tmuxCommand, "show-options", "-gqv", "status"], {
+		cwd,
+		env,
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (result.exitCode !== 0) return 0;
+	return parseTmuxStatusLineCount(new TextDecoder().decode(result.stdout));
+}
+
+function resolveCallerTmuxTerminalSize(tty: TtyState, tmuxStatusLines = 0): TmuxTerminalSize | undefined {
 	if (!tty.stdout) return undefined;
 	const columns = normalizeTmuxTerminalDimension(tty.columns);
 	const rows = normalizeTmuxTerminalDimension(tty.rows);
 	if (columns === undefined || rows === undefined) return undefined;
-	return { columns, rows };
+	const adjustedRows = Math.max(1, rows - normalizeTmuxStatusLineCount(tmuxStatusLines));
+	return { columns, rows: adjustedRows };
 }
 
 function buildTmuxNewSessionSizeArgs(size: TmuxTerminalSize | undefined): string[] {
@@ -653,7 +680,10 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 		},
 		context.rawArgs,
 	);
-	const initialSize = resolveCallerTmuxTerminalSize(tty);
+	const tmuxStatusLines =
+		context.tmuxStatusLines ??
+		(context.tmuxAvailable === undefined ? readTmuxStatusLineCount(tmuxCommand, cwd, env) : 0);
+	const initialSize = resolveCallerTmuxTerminalSize(tty, tmuxStatusLines);
 	return {
 		tmuxCommand,
 		isPsmux: resolvedBinary.isPsmux,

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -380,6 +380,39 @@ describe("default GJC tmux launch", () => {
 		]);
 	});
 
+	it("reserves caller terminal rows for tmux status lines", () => {
+		const plan = buildDefaultTmuxLaunchPlan({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: { stdin: true, stdout: true, columns: 178, rows: 35 },
+			tmuxAvailable: true,
+			tmuxStatusLines: 1,
+			currentBranch: "",
+			existingBranchSessionName: null,
+		});
+
+		expect(plan).toBeDefined();
+		if (!plan) throw new Error("expected tmux plan");
+		expect(plan.initialSize).toEqual({ columns: 178, rows: 34 });
+		expect(plan.newSessionArgs.slice(0, 10)).toEqual([
+			"new-session",
+			"-d",
+			"-x",
+			"178",
+			"-y",
+			"34",
+			"-s",
+			plan.sessionName,
+			"-c",
+			"/repo",
+		]);
+	});
+
 	it("omits detached tmux sizing when caller dimensions are unknown", () => {
 		const plan = buildDefaultTmuxLaunchPlan({
 			parsed: args({ messages: ["hello world"], tmux: true }),


### PR DESCRIPTION
## What

- Size managed `gjc --tmux` windows to the caller terminal height minus inherited tmux status lines.
- Read tmux's global `status` option for normal launches, while keeping tests deterministic through an explicit sizing seam.
- Add regression coverage that `new-session -y` uses the adjusted pane height when a status line is present.
- Update the coding-agent changelog.

## Why

`gjc --tmux` creates the inner tmux session detached and passes the caller terminal dimensions via `new-session -x/-y`, then reasserts those dimensions with `resize-window` before attach. When the new tmux session has a visible status bar (especially `status-position top` custom configs), `-y <caller rows>` describes the pane/window height, while the status line is additional chrome. On attach, the pane plus status line can exceed the actual client height by one row, making the bottom of the GJC composer/input appear clipped.

The fix treats tmux status lines as chrome and reserves those rows up front. If `status` is `off`, sizing is unchanged. If the option cannot be read, sizing falls back to the previous behavior.

## Reproduction evidence

A live tmux probe with `status on` + `status-position top` and a 24-row PTY showed the managed pane started with `stty size` reporting `24 80` while the status bar was also visible. That means the pane was sized to the full client height before accounting for tmux status chrome, matching the observed one-row clipping.

## Testing

- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts` → 66 pass, 0 fail, 244 expect() calls
- `bun --cwd=packages/coding-agent run check` → passed; emits existing unrelated `noUnusedVariables` warnings in `test/gjc-runtime/ultragoal-runtime.test.ts`
- `bun run check:ts` → passed; same existing warnings
- `bun run check` → TS side passed, but full check exits nonzero in `check:rs` due pre-existing rustfmt diffs under vendored `crates/brush-*-vendored` files; this PR does not touch Rust

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)