### PR TITLE
workflow: standardize ralplan decision artifacts

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
@@ -74,15 +74,15 @@ The consensus workflow:
    - The Architect agent/subagent must persist its review with `gjc ralplan --write --stage architect --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT --json`, then return the receipt/path plus compact verdict/status (`CLEAR`/`WATCH`/`BLOCK`, `APPROVE`/`COMMENT`/`REQUEST CHANGES`) instead of pasting the full review body.
 4. **Critic** evaluates against quality criteria — run only after step 3 completes. Critic must enforce principle-option consistency, fair alternatives, risk mitigation clarity, testable acceptance criteria, and concrete verification steps. In deliberate mode, Critic must reject missing/weak pre-mortem or expanded test plan.
    - The Critic agent/subagent must persist its evaluation with `gjc ralplan --write --stage critic --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT --json`, then return the receipt/path plus compact verdict/status (`OKAY`/`ITERATE`/`REJECT`) instead of pasting the full evaluation body.
-5. **Re-review loop** (max 5 iterations): Any non-`APPROVE` Critic verdict (`ITERATE` or `REJECT`) MUST run the same full closed loop:
+5. **Re-review loop** (max 5 iterations): Any non-`OKAY` Critic verdict (`ITERATE` or `REJECT`) MUST run the same full closed loop:
    a. Collect Architect + Critic feedback
    b. Revise the plan by resuming the SAME persisted Planner subagent with consolidated Architect + Critic feedback (see **Persisted Planner** below); fall back to a fresh Planner spawn only per the fallback routing table
    c. Return to Architect review
       - Persist each Planner revision with `gjc ralplan --write --stage revision --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT --json` before re-review, then pass the receipt/path forward instead of duplicating the full revision markdown in the parent conversation.
    d. Return to Critic evaluation
-   e. Repeat this loop until Critic returns `APPROVE` or 5 iterations are reached
-   f. If 5 iterations are reached without `APPROVE`, present the best version to the user
-6. **Post-ralplan interview** (intent reconciliation gate): After Critic returns `APPROVE` and before the plan is finalized, reconcile the consensus plan against the user's actual intent. The goal is to make sure ralplan did not silently bake in assumptions that conflict with what the user wants.
+   e. Repeat this loop until Critic returns `OKAY` or 5 iterations are reached
+   f. If 5 iterations are reached without `OKAY`, present the best version to the user
+6. **Post-ralplan interview** (intent reconciliation gate): After Critic returns `OKAY` and before the plan is finalized, reconcile the consensus plan against the user's actual intent. The goal is to make sure ralplan did not silently bake in assumptions that conflict with what the user wants.
    a. **Collect open items** from the run: every assumption the Planner/Architect/Critic resolved by assumption rather than by stated fact, every ambiguity flagged during review, and every decision the loop made without explicit user input. Source these from the persisted `planner`/`architect`/`critic`/`revision` stage artifacts, not from memory.
    b. **Cross-check prior context for conflicts**: glob `.gjc/_session-{sessionid}/specs/deep-interview-*.md` and other prior specs/plans/context relevant by topic. For each, list points where the consensus plan contradicts, weakens, or expands beyond a previously crystallized decision, constraint, or non-goal. Cite the conflicting artifact and line/section.
    c. **Reconcile with the user via the `ask` tool (always, regardless of `--interactive`)**: Never stop idle with plain-text prose after the consensus loop. Every reconciliation question MUST go through the `ask` tool with contextual options plus free-text.

--- a/packages/coding-agent/src/prompts/agents/architect.md
+++ b/packages/coding-agent/src/prompts/agents/architect.md
@@ -63,6 +63,9 @@ A narrow compatibility fallback can be acceptable only when it is scoped to a kn
 ## Summary
 2-3 sentences with result and main recommendation.
 
+## Claims
+Evidence-backed claims being reviewed or introduced.
+
 ## Analysis
 Evidence-backed findings.
 
@@ -81,7 +84,7 @@ Prioritized concrete actions.
 ## Code Review Recommendation
 `APPROVE` / `COMMENT` / `REQUEST CHANGES`
 
-## Trade-offs
+## Tradeoffs
 Table or bullets comparing viable options when relevant.
 
 Persist this full review as the durable artifact via the restricted bash CLI, passing the markdown through the `GJC_RALPLAN_ARTIFACT` env override (never a file path, never `/tmp`):

--- a/packages/coding-agent/src/prompts/agents/critic.md
+++ b/packages/coding-agent/src/prompts/agents/critic.md
@@ -42,11 +42,19 @@ Review plan clarity, completeness, verification, big-picture fit, referenced fil
 </success_criteria>
 
 <output_contract>
+## Verdict
 **[OKAY / ITERATE / REJECT]**
 
-**Justification**: concise evidence-backed explanation.
+## Claim Checks
+Concise evidence-backed explanation of verified claims.
 
-**Summary**:
+## Missing Evidence
+Definitely missing or unverified evidence, or `None`.
+
+## Approval Boundary
+What execution may proceed with, and what remains outside approval.
+
+## Summary
 - Clarity
 - Verifiability
 - Completeness
@@ -55,7 +63,8 @@ Review plan clarity, completeness, verification, big-picture fit, referenced fil
 - Alternatives Depth
 - Risk/Verification Rigor
 
-If not OKAY, list concrete required fixes.
+## Required Changes
+If not OKAY, list concrete required fixes; otherwise write `None`.
 
 Persist this full evaluation as the durable artifact via the restricted bash CLI, passing the markdown through the `GJC_RALPLAN_ARTIFACT` env override (never a file path, never `/tmp`):
 

--- a/packages/coding-agent/src/prompts/agents/planner.md
+++ b/packages/coding-agent/src/prompts/agents/planner.md
@@ -45,11 +45,16 @@ Leave execution with a right-sized, evidence-grounded plan: scope, steps, accept
 <output_contract>
 Build the full plan as a single markdown document containing:
 - Summary
+- Intent Diff
+- Decision Drivers
+- Options
 - In scope / out of scope
 - File-level changes
 - Sequencing and dependencies
 - Acceptance criteria
 - Verification
+- Escalation/Risk Gate
+- Verification Plan
 - Risks and mitigations
 
 Persist that markdown as the durable artifact via the restricted bash CLI, passing the plan through the `GJC_RALPLAN_ARTIFACT` env override (never a file path, never `/tmp`):

--- a/packages/coding-agent/test/ralplan-decision-artifacts.test.ts
+++ b/packages/coding-agent/test/ralplan-decision-artifacts.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import { getDefaultGjcDefinitions } from "@gajae-code/coding-agent/defaults/gjc-defaults";
+import { getBundledAgent } from "@gajae-code/coding-agent/task/agents";
+
+const rolePromptSectionContracts = [
+	{
+		name: "planner",
+		requiredSections: ["Intent Diff", "Decision Drivers", "Options", "Escalation/Risk Gate", "Verification Plan"],
+	},
+	{
+		name: "architect",
+		requiredSections: ["Claims", "Root Cause", "Tradeoffs", "Recommendations"],
+	},
+	{
+		name: "critic",
+		requiredSections: ["Verdict", "Claim Checks", "Missing Evidence", "Approval Boundary", "Required Changes"],
+	},
+] as const;
+
+const finalPlanContractPatterns = [
+	/\*\*## Intent Reconciliation\*\*/u,
+	/Final plan must include ADR \(Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups\)/u,
+	/workflowGate: \{ stage: "ralplan", kind: "approval" \}/u,
+	/mark the plan `pending approval`/u,
+] as const;
+
+const criticApprovalContractPatterns = [
+	/Any non-`OKAY` Critic verdict \(`ITERATE` or `REJECT`\)/u,
+	/until Critic returns `OKAY`/u,
+	/without `OKAY`/u,
+	/After Critic returns `OKAY`/u,
+] as const;
+
+const staleCriticApprovalPatterns = [
+	/non-`APPROVE` Critic verdict/u,
+	/Critic returns `APPROVE`/u,
+	/without `APPROVE`/u,
+] as const;
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function sectionMarkerPattern(section: string): RegExp {
+	return new RegExp(`(^|\\n)(?:#{1,6}\\s+|[-*]\\s+)${escapeRegExp(section)}(?:\\s|$)`, "u");
+}
+
+describe("ralplan decision artifacts", () => {
+	it("requires decision artifact sections in bundled role prompts and final handoff", () => {
+		for (const contract of rolePromptSectionContracts) {
+			const agent = getBundledAgent(contract.name);
+			if (!agent) throw new Error(`missing bundled ${contract.name} agent`);
+			for (const requiredSection of contract.requiredSections) {
+				expect(agent.systemPrompt).toMatch(sectionMarkerPattern(requiredSection));
+			}
+		}
+
+		const ralplan = getDefaultGjcDefinitions().find(
+			definition => definition.kind === "skill" && definition.name === "ralplan",
+		);
+		expect(ralplan).toBeDefined();
+		const content = ralplan?.content ?? "";
+
+		for (const pattern of finalPlanContractPatterns) {
+			expect(content).toMatch(pattern);
+		}
+
+		for (const pattern of criticApprovalContractPatterns) {
+			expect(content).toMatch(pattern);
+		}
+		for (const pattern of staleCriticApprovalPatterns) {
+			expect(content).not.toMatch(pattern);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Standardize the bundled `ralplan` role prompts around explicit decision artifacts: intent diff, decision drivers, options, escalation/risk gate, claim checks, missing evidence, and approval boundaries.
- Align the `ralplan` consensus loop with the Critic prompt by using `OKAY` as the single Critic pass token, instead of mixing `OKAY` and `APPROVE`.
- Add a focused regression test that locks the bundled planner/architect/critic prompt sections, the final handoff contract, and the Critic approval-token vocabulary.

## Problem
`ralplan` already asks agents to plan, review, and critique, but the durable artifacts did not consistently name the decision structure that follow-up work needs to inspect. That makes later improvements harder to verify because a direct implementation path, consensus-loop path, and critic approval path can all describe decisions differently.

While tightening that vocabulary, the PR also exposed a concrete contradiction: the Critic prompt returns `OKAY` / `ITERATE` / `REJECT`, but the workflow text still treated `APPROVE` as the Critic pass token in the re-review loop and post-ralplan gate. A literal role agent could return `OKAY` while the workflow continued as if consensus had not been reached.

## Fix
This PR gives the bundled role prompts a shared artifact shape:
- planner records `Intent Diff`, `Decision Drivers`, `Options`, `Escalation/Risk Gate`, and `Verification Plan`.
- architect records evidence-backed `Claims` alongside root cause, recommendation, and tradeoffs.
- critic records `Verdict`, `Claim Checks`, `Missing Evidence`, `Approval Boundary`, and `Required Changes`.

It also updates the `ralplan` skill so the Critic loop consistently treats `OKAY` as the pass verdict, and adds regression coverage that rejects stale Critic-loop `APPROVE` wording.

## PR chain
This is PR 1 in the P1 -> P5 workflow-improvement chain:
1. This PR: standardize `ralplan` decision artifacts and Critic approval vocabulary so later work has a stable section/token contract.
2. Next: add typed reference projection metadata for claim/intent evidence without changing the user-facing routing rules yet.
3. Then: record lightweight direct intent diffs for low-risk direct work through custom session entries.
4. Then: add root-cause phase schema only for contradiction, regression, and high-risk transition work.
5. Finally: add an advisory routing classifier matrix for direct work, deliberate planning, deep interview, and durable goal tracking.

## Verification
- `bun run build:native`
- `bun test packages/coding-agent/test/ralplan-decision-artifacts.test.ts`
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`
- `bunx biome check packages/coding-agent/test/ralplan-decision-artifacts.test.ts --no-errors-on-unmatched`
- `bun --cwd packages/coding-agent run check`
- `git diff --check`
- Manual CLI surface check: `bun packages/coding-agent/src/cli.ts ralplan --write --stage planner --stage_n 1 --session-id <qa-session> --run-id <qa-run> --artifact ... --json` in an isolated temp repo, then verified artifact/index creation and removed the temp repo.
