### PR TITLE
fix(coding-agent): print resume hint command on its own line

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Coordinator MCP tmux prompt delivery now submits with tmux `Enter` instead of `C-m`, while preserving runtime prompt-ack/`turn_start` as the delivery success gate (#1409).
+- The session-close resume hint now prints the `gjc --resume <id>` command on its own line so it can be selected and copied without the surrounding prose.
 - Coordinator MCP tmux prompt delivery now uses a paste buffer for prompt text before submitting with `Enter`, preserving multiline delegated `/skill:*` prompt separators that `send-keys -l` could flatten into an unstarted visible prompt (#1416).
 
 - `/retry` now resumes sessions left with an interrupted user/custom/tool-result tail after a crash or power loss, and recovers unresolved assistant tool-use tails instead of reporting "Nothing to retry".

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2038,7 +2038,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		const sessionId = this.sessionManager.getSessionId();
 		const sessionFile = this.sessionManager.getSessionFile();
 		if (sessionId && sessionFile) {
-			process.stderr.write(`\n${chalk.dim(`Resume this session with ${APP_NAME} --resume ${sessionId}`)}\n`);
+			process.stderr.write(
+				`\n${chalk.dim("Resume this session with:")}\n${chalk.dim(`${APP_NAME} --resume ${sessionId}`)}\n`,
+			);
 		}
 
 		await postmortem.quit(0);


### PR DESCRIPTION
## What

On session close, the resume hint now renders as two dim lines instead of one:

Before:
```
Resume this session with gjc --resume <id>
```

After:
```
Resume this session with:
gjc --resume <id>
```

## Why

The prose and the command shared one line, so selecting the command in a terminal (double/triple-click or drag-select) also grabs the "Resume this session with" prefix, making the hint hard to copy-paste. With the command on its own line it is selectable and runnable as-is (triple-click → paste → Enter).

## Testing

- `bun run check` in `packages/coding-agent` (biome + tsgo): passes; the only remaining diagnostics are pre-existing `ultragoal-runtime.test.ts` unused-variable warnings unrelated to this change.
- Verified the two-line output locally by patching the installed 0.7.10 package with the same change and closing a session.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
