### PR TITLE
fix(model-selector): keep cursor at end after prefilled search input

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -405,7 +405,7 @@ export class ModelSelectorComponent extends Container {
 		// Create search input
 		this.#searchInput = new Input();
 		if (initialSearchInput) {
-			this.#searchInput.setValue(initialSearchInput);
+			this.#setSearchInputValue(initialSearchInput);
 		}
 		this.#searchInput.onSubmit = () => {
 			const selectedItem = this.#getSelectedItem();
@@ -1012,6 +1012,11 @@ export class ModelSelectorComponent extends Container {
 		if (!this.#relocatePresetCursor(targetIdentity)) this.#clampPresetCursor();
 	}
 
+	#setSearchInputValue(value: string): void {
+		this.#searchInput.setValue(value);
+		this.#searchInput.handleInput("\x05"); // Move cursor to end after programmatic prefill.
+	}
+
 	#switchToModelMode(seed?: string): void {
 		this.#viewMode = "models";
 		this.#expandedPresetProviderId = undefined;
@@ -1021,7 +1026,7 @@ export class ModelSelectorComponent extends Container {
 		this.#presetLoginHint = undefined;
 		this.#activeTabIndex = 0;
 		this.#selectedIndex = 0;
-		this.#searchInput.setValue(seed ?? this.#searchInput.getValue());
+		this.#setSearchInputValue(seed ?? this.#searchInput.getValue());
 		this.#updateTabBar();
 		this.#filterModels(this.#searchInput.getValue());
 	}

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -205,6 +205,29 @@ describe("model selector profiles", () => {
 		expect(rendered).not.toContain("Codex Eco");
 		expect(rendered).not.toContain("profile-a");
 	});
+	test("preset search keeps first typed character before subsequent input", async () => {
+		installTestTheme();
+		const selector = createSelector(() => {});
+		await Bun.sleep(10);
+		installTestTheme();
+
+		selector.handleInput("c");
+		selector.handleInput("l");
+		selector.handleInput("a");
+
+		expect(selector.getSearchInput().getValue()).toBe("cla");
+	});
+
+	test("initial search input appends new typing at the end", async () => {
+		installTestTheme();
+		const selector = createSelector(() => {}, { initialSearchInput: "cla" });
+		await Bun.sleep(10);
+		installTestTheme();
+
+		selector.handleInput("u");
+
+		expect(selector.getSearchInput().getValue()).toBe("clau");
+	});
 
 	test("temporary-only mode hides Profiles", async () => {
 		installTestTheme();


### PR DESCRIPTION
Retarget of #1424 onto `dev` per maintainer guidance.

## Summary
- Model 선택창에서 preset landing 화면일 때 첫 글자를 입력해 검색 모드로 전환하면 그 첫 글자가 맨 뒤로 밀리는 버그를 수정합니다. (예: `cla` 입력 → `lac`)
- 원인: `Input.setValue()`는 값만 채우고 커서를 끝으로 옮기지 않아, 새 `Input`의 커서(0) 뒤로 이후 입력이 앞쪽에 삽입되었습니다.
- `#setSearchInputValue()` 헬퍼를 추가해 프로그램적 prefill 이후 항상 커서를 끝(Ctrl+E)으로 이동시킵니다. `initialSearchInput` 경로도 동일 처리.

## Changes
- `packages/coding-agent/src/modes/components/model-selector.ts`
- `packages/coding-agent/test/model-selector-profiles.test.ts`

## Test
- `bun test` model-selector-profiles / -redteam / -role-badge-thinking / tui input → 55 pass, 0 fail
- `bun --cwd=packages/coding-agent run check:types` → 통과
- `bunx biome check <changed files>` → OK