### PR TITLE
fix(coding-agent): keep managed --tmux window auto-sized on attach

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `gjc --tmux --resume` now reaches the session picker/resume target instead of auto-attaching a same-branch managed tmux session before the inner resume resolver runs.
 - `gjc --tmux` now preserves a newly created managed tmux session when `attach-session` exits after the parent SSH/PTY closes but the tmux server still reports the session live, so closing a Windows Terminal tab no longer kills the Mac host session before reattach.
 - Managed `gjc --tmux` launches now size the inner tmux window to the caller terminal minus inherited tmux status lines, preventing the bottom of the GJC input from being clipped when the user's tmux status bar is visible.
+- Managed `gjc --tmux` launches no longer pin the initial window to `manual` sizing on native tmux. The pre-attach reassert used `resize-window`, which flips the window's `window-size` option to `manual` and stops `attach-session` from resizing the window to the real terminal; when the attaching terminal was larger than the capture-time size, tmux left a smaller-than-client window and painted the uncovered area with `·` fill. The window now stays on `window-size latest` so it tracks the attaching client (psmux keeps the explicit `resize-window` reassert).
 
 ### Changed
 

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -600,25 +600,38 @@ function buildTmuxNewSessionSizeArgs(size: TmuxTerminalSize | undefined): string
 	return size ? ["-x", String(size.columns), "-y", String(size.rows)] : [];
 }
 
-function resizeCreatedTmuxWindowToCallerTerminalSize(
+// Ensure the freshly created window fits the terminal that ultimately attaches.
+// `new-session` already starts the window (and the inner TUI) at the caller's
+// captured `-x/-y` size; this step governs what happens on `attach-session`.
+//
+// On native tmux we must NOT reassert with `resize-window`: that command flips
+// the window's `window-size` option to `manual`, pinning it to the capture-time
+// dimensions and stopping `attach-session` from resizing the window to the real
+// client. When the attaching terminal is larger than the capture — e.g. a GUI
+// terminal that reports a smaller size before it finishes sizing — the pinned
+// window stays small and tmux paints the uncovered client area with `·` fill
+// (the "window smaller than client" symptom). Keeping `window-size` on `latest`
+// lets tmux size the window to the attaching client (status line included).
+//
+// psmux (Windows) does not share tmux's `window-size` semantics, so preserve the
+// historical explicit `resize-window` reassert there rather than sending an
+// option its server may reject and echo into the user's pane.
+function ensureCreatedTmuxWindowTracksCallerTerminal(
 	plan: TmuxLaunchPlan,
 	spawnSync: TmuxSpawnSync,
 	options: TmuxSpawnOptions,
 ): void {
 	if (!plan.initialSize) return;
-	spawnSync(
-		plan.tmuxCommand,
-		[
-			"resize-window",
-			"-t",
-			buildGjcTmuxExactOptionTarget(plan.sessionName, { env: options.env }),
-			"-x",
-			String(plan.initialSize.columns),
-			"-y",
-			String(plan.initialSize.rows),
-		],
-		options,
-	);
+	const target = buildGjcTmuxExactOptionTarget(plan.sessionName, { env: options.env });
+	if (plan.isPsmux) {
+		spawnSync(
+			plan.tmuxCommand,
+			["resize-window", "-t", target, "-x", String(plan.initialSize.columns), "-y", String(plan.initialSize.rows)],
+			options,
+		);
+		return;
+	}
+	spawnSync(plan.tmuxCommand, ["set-window-option", "-t", target, "window-size", "latest"], options);
 }
 
 export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaunchPlan | undefined {
@@ -901,7 +914,7 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 			}
 			// Recovery succeeded via retry — fall through to attach-session below.
 		}
-		resizeCreatedTmuxWindowToCallerTerminalSize(plan, spawnSync, controlOptions);
+		ensureCreatedTmuxWindowTracksCallerTerminal(plan, spawnSync, controlOptions);
 		applyGjcTmuxRootTerminalTitleProfile({
 			tmuxCommand: plan.tmuxCommand,
 			target: plan.sessionName,
@@ -959,7 +972,7 @@ export function launchDefaultTmuxIfNeeded(context: TmuxLaunchContext): boolean {
 					item.command.args.includes("@gjc-profile"),
 				);
 				if (!retryOwnershipFailure) {
-					resizeCreatedTmuxWindowToCallerTerminalSize(plan, spawnSync, controlOptions);
+					ensureCreatedTmuxWindowTracksCallerTerminal(plan, spawnSync, controlOptions);
 					applyGjcTmuxRootTerminalTitleProfile({
 						tmuxCommand: plan.tmuxCommand,
 						target: plan.sessionName,

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -454,7 +454,7 @@ describe("default GJC tmux launch", () => {
 		expect(plan).toBeUndefined();
 	});
 
-	it("reasserts caller dimensions before attaching a newly created managed tmux session", () => {
+	it("keeps a newly created managed tmux window in automatic sizing mode before attaching", () => {
 		const calls: Array<{ command: string; args: string[]; options: TmuxSpawnOptions }> = [];
 		const handled = launchDefaultTmuxIfNeeded({
 			parsed: args({ messages: ["hello world"], tmux: true }),
@@ -476,23 +476,75 @@ describe("default GJC tmux launch", () => {
 
 		expect(handled).toBe(true);
 		const newSession = calls.find(call => call.args[0] === "new-session");
-		const resizeIndex = calls.findIndex(call => call.args[0] === "resize-window");
+		const setWindowSizeIndex = calls.findIndex(
+			call => call.args[0] === "set-window-option" && call.args.includes("window-size"),
+		);
 		const attachIndex = calls.findIndex(call => call.args[0] === "attach-session");
 		expect(newSession?.args).toContain("-x");
 		expect(newSession?.args).toContain("178");
 		expect(newSession?.args).toContain("-y");
 		expect(newSession?.args).toContain("35");
-		expect(resizeIndex).toBeGreaterThan(0);
-		expect(resizeIndex).toBeLessThan(attachIndex);
-		expect(calls[resizeIndex]?.args).toEqual([
-			"resize-window",
+		// The initial size comes from new-session -x/-y. On native tmux the window
+		// must then stay in automatic sizing mode so attach-session fits it to the
+		// real client. A `resize-window` reassert would flip window-size to
+		// `manual`, pinning the window to the capture-time size and leaving a
+		// smaller-than-client window that tmux paints with `·` fill.
+		expect(calls.some(call => call.args[0] === "resize-window")).toBe(false);
+		expect(setWindowSizeIndex).toBeGreaterThan(0);
+		expect(setWindowSizeIndex).toBeLessThan(attachIndex);
+		expect(calls[setWindowSizeIndex]?.args).toEqual([
+			"set-window-option",
 			"-t",
 			expect.stringMatching(/^=gajae_code_.*:$/),
-			"-x",
-			"178",
-			"-y",
-			"35",
+			"window-size",
+			"latest",
 		]);
+	});
+
+	it("keeps the explicit resize-window reassert on the psmux (Windows) launch path", () => {
+		__setBinaryResolverForTests(candidate => (candidate === "psmux" ? "/fake/psmux" : null));
+		const calls: Array<{ command: string; args: string[]; options: TmuxSpawnOptions }> = [];
+		try {
+			const handled = launchDefaultTmuxIfNeeded({
+				parsed: args({ messages: ["hello world"], tmux: true }),
+				rawArgs: ["--tmux", "hello world"],
+				cwd: "/repo",
+				env: { GJC_TMUX_COMMAND: "psmux", GJC_PSMUX_COMMAND: "psmux" },
+				argv: ["bun", "packages/coding-agent/src/cli.ts"],
+				execPath: "/bin/bun",
+				platform: "win32",
+				tty: { stdin: true, stdout: true, columns: 178, rows: 35 },
+				tmuxAvailable: true,
+				currentBranch: "feature/demo",
+				existingBranchSessionName: null,
+				spawnSync: (command, spawnArgs, options) => {
+					calls.push({ command, args: spawnArgs, options });
+					return { exitCode: 0 };
+				},
+			});
+
+			expect(handled).toBe(true);
+			const resizeIndex = calls.findIndex(call => call.args[0] === "resize-window");
+			const attachIndex = calls.findIndex(call => call.args[0] === "attach-session");
+			// psmux does not share tmux's window-size semantics, so the launch path
+			// keeps the explicit resize-window reassert and never emits window-size.
+			expect(resizeIndex).toBeGreaterThan(0);
+			expect(resizeIndex).toBeLessThan(attachIndex);
+			expect(calls[resizeIndex]?.args).toEqual([
+				"resize-window",
+				"-t",
+				expect.stringMatching(/^gajae_code_/),
+				"-x",
+				"178",
+				"-y",
+				"35",
+			]);
+			expect(calls.some(call => call.args[0] === "set-window-option" && call.args.includes("window-size"))).toBe(
+				false,
+			);
+		} finally {
+			__setBinaryResolverForTests(null);
+		}
 	});
 
 	it("plans native Windows --tmux launches when tmux is available", () => {


### PR DESCRIPTION
## What

On native tmux, managed `gjc --tmux` no longer pins the initial window to `manual` sizing. The pre-attach reassert now uses `set-window-option window-size latest` instead of `resize-window`, so `attach-session` sizes the window to the real terminal. psmux (Windows) keeps its existing `resize-window` reassert.

## Why

`resize-window` flips the window's `window-size` option to `manual`, pinning the window to the capture-time `process.stdout` dimensions. When the attaching terminal is larger than the capture, tmux renders the window in the top-left and fills the rest of the client with `·` dots (the reported dotted bottom half of the GJC TUI). `new-session -x/-y` (plus `dev`'s status-line subtraction) still starts the inner TUI at the caller size; keeping `window-size` on `latest` lets `attach-session` finish the fit regardless of the capture-vs-attach mismatch.

## Testing

- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts` → 68 pass.
- `bun run check` (biome + tsgo types) → the changed files are clean. (Pre-existing unused-variable warnings in `ultragoal-runtime.test.ts` are unrelated to this change.)
- Verified against real tmux 3.6b: `resize-window` sets `window-size=manual` and pins a 100×20 window under a 200×50 client; `set-window-option window-size latest` lets it grow to 200×49 on attach.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated
