### PR TITLE
fix(state): return lock-owned stamped envelopes

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -847,11 +847,14 @@ async function writeJsonAtomic(
 			forced: options?.force ?? false,
 		},
 	});
-	// `writeResult.revision` is computed inside the writer lock, so it is the revision this
-	// write actually owns. Prefer it over a post-lock file re-read, which a concurrent writer
-	// could have advanced before the read — that race could otherwise let this payload be
-	// published with another writer's newer revision.
-	return { warning, stamped: (await readJsonFile(filePath)) ?? {}, revision: writeResult.revision };
+	// `writeResult.stamped` and `.revision` are computed inside the writer lock, so they are
+	// the envelope/revision this write actually owns. Never post-lock re-read here: a concurrent
+	// writer could advance the file before that read and make this payload publish another
+	// writer's newer revision into the derived active-state cache.
+	if (!writeResult.written || !isPlainObject(writeResult.stamped)) {
+		throw new Error(`state writer did not return a stamped workflow envelope for ${filePath}`);
+	}
+	return { warning, stamped: writeResult.stamped, revision: writeResult.revision };
 }
 
 function parseFieldsFlag(args: readonly string[]): StateProjectionField[] | undefined {

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -99,7 +99,7 @@ export interface GuardedStateWriterOptions extends StateWriterOptions {
 }
 
 export type GuardedWriteResult =
-	| { path: string; written: true; revision: number }
+	| { path: string; written: true; revision: number; stamped: unknown }
 	| { path: string; written: false; reason: "stale-skip"; revision: number };
 
 export interface StateWriterOptions {
@@ -511,7 +511,7 @@ async function writeGuardedResolvedJsonAtomic(
 				const next = stampStateRevision(withWorkflowReceipt(value, buildReceipt(options)), currentRevision + 1);
 				await atomicWrite(filePath, jsonText(next));
 				await maybeAudit(filePath, options);
-				return { path: filePath, written: true, revision: currentRevision + 1 };
+				return { path: filePath, written: true, revision: currentRevision + 1, stamped: next };
 			}
 
 			const incomingSourceRevision =
@@ -526,7 +526,7 @@ async function writeGuardedResolvedJsonAtomic(
 			);
 			await atomicWrite(filePath, jsonText(next));
 			await maybeAudit(filePath, options);
-			return { path: filePath, written: true, revision: currentRevision + 1 };
+			return { path: filePath, written: true, revision: currentRevision + 1, stamped: next };
 		},
 		options.lock,
 	);
@@ -574,7 +574,7 @@ export async function writeGuardedWorkflowEnvelopeAtomic(
 				}
 				await atomicWrite(filePath, jsonText(next));
 				await maybeAudit(filePath, options);
-				return { path: filePath, written: true, revision: currentRevision + 1 };
+				return { path: filePath, written: true, revision: currentRevision + 1, stamped: next };
 			}
 
 			const incomingSourceRevision =
@@ -599,7 +599,7 @@ export async function writeGuardedWorkflowEnvelopeAtomic(
 			}
 			await atomicWrite(filePath, jsonText(next));
 			await maybeAudit(filePath, options);
-			return { path: filePath, written: true, revision: currentRevision + 1 };
+			return { path: filePath, written: true, revision: currentRevision + 1, stamped: next };
 		},
 		options.lock,
 	);

--- a/packages/coding-agent/test/gjc-runtime/state-writer-cas.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-writer-cas.test.ts
@@ -3,7 +3,12 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { sessionStateDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
-import { updateJsonAtomic, withWorkflowStateLock } from "@gajae-code/coding-agent/gjc-runtime/state-writer";
+import {
+	updateJsonAtomic,
+	withWorkflowStateLock,
+	writeGuardedWorkflowEnvelopeAtomic,
+} from "@gajae-code/coding-agent/gjc-runtime/state-writer";
+import { WORKFLOW_STATE_VERSION } from "@gajae-code/coding-agent/skill-state/workflow-state-contract";
 
 const tempRoots: string[] = [];
 
@@ -100,5 +105,48 @@ describe("state-writer concurrency (issue #646)", () => {
 		// If the lock serializes correctly, only one critical section is ever in
 		// flight, so the observed peak concurrency stays at 1.
 		expect(maxActive).toBe(1);
+	});
+	it("returns the lock-owned stamped workflow envelope without rereading the file", async () => {
+		const root = await tempDir();
+		const target = path.relative(root, path.join(sessionStateDir(root, "test-session"), "stamped-probe.json"));
+		const filePath = path.join(root, target);
+		const envelope = (marker: string, updatedAt: string): Record<string, unknown> => ({
+			skill: "ralplan",
+			version: WORKFLOW_STATE_VERSION,
+			active: true,
+			current_phase: "planner",
+			updated_at: updatedAt,
+			marker,
+		});
+		const receipt = (marker: string) => ({
+			cwd: root,
+			skill: "ralplan" as const,
+			owner: "gjc-state-cli" as const,
+			command: `test ${marker}`,
+			sessionId: "test-session",
+			mutationId: `state-writer-cas:${marker}`,
+		});
+
+		const first = await writeGuardedWorkflowEnvelopeAtomic(target, envelope("first", "2026-01-01T00:00:00.000Z"), {
+			cwd: root,
+			policy: "source",
+			receipt: receipt("first"),
+		});
+		const second = await writeGuardedWorkflowEnvelopeAtomic(target, envelope("second", "2026-01-01T00:00:01.000Z"), {
+			cwd: root,
+			policy: "source",
+			receipt: receipt("second"),
+		});
+
+		if (!first.written) throw new Error("first write unexpectedly stale-skipped");
+		if (!second.written) throw new Error("second write unexpectedly stale-skipped");
+		const firstStamped = first.stamped as Record<string, unknown>;
+		expect(firstStamped.marker).toBe("first");
+		expect(firstStamped.state_revision).toBe(1);
+		expect((firstStamped.receipt as Record<string, unknown>).mutation_id).toBe("state-writer-cas:first");
+
+		const final = await readJson(filePath);
+		expect(final.marker).toBe("second");
+		expect(final.state_revision).toBe(2);
 	});
 });

--- a/packages/coding-agent/test/gjc-state-writer-policy.test.ts
+++ b/packages/coding-agent/test/gjc-state-writer-policy.test.ts
@@ -115,7 +115,12 @@ describe("GJC state writer revision policy", () => {
 			{ cwd: root, policy: "cache", sourceRevision: 3 },
 		);
 
-		expect(result).toEqual({ path: path.join(root, target), written: true, revision: 2 });
+		expect(result).toMatchObject({
+			path: path.join(root, target),
+			written: true,
+			revision: 2,
+			stamped: { value: "new", source_state_revision: 3, state_revision: 2 },
+		});
 		await expect(readJson(root, target)).resolves.toMatchObject({
 			value: "new",
 			source_state_revision: 3,


### PR DESCRIPTION
## Summary
- return the lock-owned stamped payload from guarded state writers
- stop `gjc state write` from post-lock re-reading mode-state before syncing active-state/HUD
- add regression coverage for preserving a writer's own stamped envelope after a later write advances the file

## Tests
- `bun test packages/coding-agent/test/gjc-runtime/state-writer-cas.test.ts`
- `bun test packages/coding-agent/test/gjc-runtime/state-runtime.test.ts`
- `bun test packages/coding-agent/test/gjc-state-writer-policy.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/gjc-runtime/state-writer.ts packages/coding-agent/src/gjc-runtime/state-runtime.ts packages/coding-agent/test/gjc-runtime/state-writer-cas.test.ts packages/coding-agent/test/gjc-state-writer-policy.test.ts`
- `bun --cwd=packages/coding-agent run check` (passes; existing unrelated Biome warnings remain in `test/gjc-runtime/ultragoal-runtime.test.ts`)