### PR TITLE
fix(tui): place prefilled input cursor at end

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1014,7 +1014,6 @@ export class ModelSelectorComponent extends Container {
 
 	#setSearchInputValue(value: string): void {
 		this.#searchInput.setValue(value);
-		this.#searchInput.handleInput("\x05"); // Move cursor to end after programmatic prefill.
 	}
 
 	#switchToModelMode(seed?: string): void {

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -60,8 +60,6 @@ class TextInputSubmenu extends Container {
 		this.#input = new Input();
 		if (currentValue) {
 			this.#input.setValue(currentValue);
-			// Move cursor to end of pre-filled value (ctrl+e = cursorLineEnd).
-			this.#input.handleInput("\x05");
 		}
 		this.#input.onSubmit = value => {
 			this.onSubmit(value); // empty string clears the setting

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -58,7 +58,8 @@ export class Input implements Component, Focusable {
 	setValue(value: string): void {
 		const normalized = value.normalize("NFC");
 		this.#value = normalized;
-		this.#cursor = Math.min(this.#cursor, normalized.length);
+		this.#cursor = normalized.length;
+		this.#lastAction = null;
 	}
 
 	handleInput(data: string): void {

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -23,6 +23,22 @@ describe("Input component", () => {
 		return input;
 	}
 
+	it("places cursor at the end after setValue prefill", () => {
+		const input = new Input();
+		input.setValue("cla");
+		input.handleInput("u");
+		expect(input.getValue()).toBe("clau");
+	});
+
+	it("resets pending type coalescing after setValue", () => {
+		const input = new Input();
+		input.handleInput("a");
+		input.setValue("bc");
+		input.handleInput("d");
+		input.handleInput("\x1f"); // Ctrl+/ undo
+		expect(input.getValue()).toBe("bc");
+	});
+
 	it("moves by CJK and punctuation blocks (backward)", () => {
 		const text = "天气不错，去散步吧！";
 


### PR DESCRIPTION
## Summary
- make `Input.setValue()` place the cursor at the end of the prefilled value
- reset pending type coalescing after programmatic prefills so undo restores the prefill instead of an older buffer
- remove local Ctrl+E cursor workarounds from model/settings selectors now that the shared input component owns the behavior

## Why
PR #1426 fixed the model selector symptom locally, but the same root TUI issue remained in other prefilled inputs such as custom provider/plugin/runtime MCP/settings forms: typing after a prefilled value inserted at the beginning unless each caller remembered to synthesize Ctrl+E.

## Tests
- `bun --cwd=packages/natives run build` (needed once locally so TUI tests can load the native addon)
- `bun test packages/tui/test/input.test.ts`
- `bun test packages/coding-agent/test/model-selector-profiles.test.ts packages/coding-agent/test/model-selector-profiles-redteam.test.ts packages/coding-agent/test/model-selector-role-badge-thinking.test.ts packages/coding-agent/test/modes/components/settings-selector-memory-refresh.test.ts packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts packages/coding-agent/test/modes/components/settings-selector-theme-confirm.test.ts`
- `bunx biome check packages/tui/src/components/input.ts packages/tui/test/input.test.ts packages/coding-agent/src/modes/components/model-selector.ts packages/coding-agent/src/modes/components/settings-selector.ts`
- `bun --cwd=packages/tui run check:types`
- `bun --cwd=packages/coding-agent run check:types`