### PR TITLE
fix(coding-agent): send session_closed on process teardown via postmortem

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Notification endpoints now emit the graceful `session_closed` frame on process teardown (native terminal-window close/SIGHUP, SIGTERM, fatal errors) via a postmortem cleanup, so the managed Telegram daemon deletes the session's forum topic instead of orphaning it when the session dies without a clean `/quit`.
 - Native Windows terminals now default `app.message.queue` to `Alt+Q` instead of `Alt+Enter`, avoiding the Windows Terminal fullscreen shortcut conflict (#1422).
 - Coordinator MCP tmux prompt delivery now submits with tmux `Enter` instead of `C-m`, while preserving runtime prompt-ack/`turn_start` as the delivery success gate (#1409).
 - The session-close resume hint now prints the `gjc --resume <id>` command on its own line so it can be selected and copied without the surrounding prose.

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -26,7 +26,7 @@ import * as path from "node:path";
 import { promisify } from "node:util";
 import type { ImageContent, TextContent } from "@gajae-code/ai";
 import { NotificationServer } from "@gajae-code/natives";
-import { logger } from "@gajae-code/utils";
+import { logger, postmortem } from "@gajae-code/utils";
 import { Settings } from "../config/settings";
 import type { ExtensionCommandContext, ExtensionContext, ExtensionFactory } from "../extensibility/extensions";
 import { registerAskAnswerSource } from "../tools/ask-answer-registry";
@@ -348,6 +348,8 @@ interface SessionRuntime {
 	/** Assistant text already flushed before an ask this turn (turn-scoped dedupe
 	 * so turn_end does not re-emit the pre-ask lead-in). Reset each turn. */
 	preAskFlushedText?: string;
+	/** Cancels the postmortem cleanup that emits `session_closed` on process teardown. */
+	cancelPostmortemCleanup: () => void;
 }
 
 interface ResolvedSettings {
@@ -500,6 +502,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		if (!rt) return false;
 		runtimes.delete(id);
 		try {
+			rt.cancelPostmortemCleanup();
 			rt.disposeAnswerSource();
 			rt.disposeFileSink();
 		} catch {}
@@ -680,6 +683,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 				pendingInteractive,
 				disposeAnswerSource,
 				disposeFileSink,
+				cancelPostmortemCleanup: () => {},
 				redact,
 				verbosity,
 				sessionTag: tag,
@@ -687,6 +691,15 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 				pendingInbound: new Set<number>(),
 			};
 			runtimes.set(id, runtime);
+			// A native terminal close (SIGHUP), SIGTERM, Ctrl+C exit, or fatal error
+			// skips AgentSession.dispose(), so the `session_shutdown` extension event
+			// never fires and the daemon-side topic would be orphaned. postmortem
+			// awaits registered cleanups on those paths, so send the graceful
+			// `session_closed` frame from there too. stopSession() cancels this
+			// registration on every other teardown path, so it never double-fires.
+			runtime.cancelPostmortemCleanup = postmortem.register(`notifications-session-closed:${id}`, async () => {
+				await stopSession(id);
+			});
 			logger.info(`notifications: serving session ${id} at ${endpoint.url} (unattended=${unattended})`);
 
 			if (settingsAvailable && settings && isGloballyConfigured(cfg)) {
@@ -848,9 +861,15 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		// Re-bind the interactive ask answer source: the ask tool resolves the
 		// source by the current session id, which just changed.
 		try {
+			rt.cancelPostmortemCleanup();
 			rt.disposeAnswerSource();
 			rt.disposeFileSink();
 		} catch {}
+		// Follow the id change so a later process teardown closes the re-keyed
+		// session (the old closure captured the retired id).
+		rt.cancelPostmortemCleanup = postmortem.register(`notifications-session-closed:${newId}`, async () => {
+			await stopSession(newId);
+		});
 		rt.disposeAnswerSource = registerInteractiveAnswerSource(
 			newId,
 			rt.server,

--- a/packages/coding-agent/test/notifications-postmortem-close.test.ts
+++ b/packages/coding-agent/test/notifications-postmortem-close.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, expect, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { postmortem } from "@gajae-code/utils";
+import { createNotificationsExtension } from "../src/notifications/index";
+import { readEndpoint } from "../src/notifications/telegram-reference";
+
+/**
+ * Regression for "hard terminal close orphans the Telegram topic": a native
+ * terminal-window close (SIGHUP), SIGTERM, or fatal error never runs
+ * AgentSession.dispose(), so the `session_shutdown` extension event does not
+ * fire and no `session_closed` frame reaches connected clients — the daemon
+ * keeps the session's forum topic forever. The notifications extension must
+ * register a postmortem cleanup that emits `session_closed` on those teardown
+ * paths, and cancel it when the session stops through any other path.
+ */
+
+const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+async function waitFor(pred: () => boolean, ms = 4000, label = "condition"): Promise<void> {
+	const deadline = Date.now() + ms;
+	while (Date.now() < deadline) {
+		if (pred()) return;
+		await sleep(25);
+	}
+	throw new Error(`timed out waiting for ${label}`);
+}
+
+type Handler = (event: unknown, ctx: unknown) => unknown;
+type Frame = { type: string; sessionId?: string };
+type CleanupCallback = (reason: postmortem.Reason) => void | Promise<void>;
+
+const tempDirs: string[] = [];
+const openSockets: WebSocket[] = [];
+afterEach(() => {
+	for (const ws of openSockets.splice(0)) ws.close();
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+	vi.restoreAllMocks();
+});
+
+function createHarness(prefix: string) {
+	const handlers = new Map<string, Handler>();
+	const api = {
+		on: (event: string, handler: Handler) => {
+			handlers.set(event, handler);
+		},
+		registerCommand: () => {},
+		sendUserMessage: () => {},
+	} as never;
+	createNotificationsExtension(api);
+
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(cwd);
+
+	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	const sid = `${prefix}${suffix}`;
+	const ctx = {
+		cwd,
+		sessionManager: {
+			getSessionId: () => sid,
+			getSessionName: () => "Original",
+			getArtifactsDir: () => cwd,
+			getCwd: () => cwd,
+		},
+	} as never;
+
+	const endpoint = path.join(cwd, ".gjc", "state", "notifications", `${sid}.json`);
+	return { handlers, ctx, sid, endpoint };
+}
+
+async function connectFrames(endpoint: string): Promise<Frame[]> {
+	const { url, token } = readEndpoint(endpoint);
+	const frames: Frame[] = [];
+	const ws = new WebSocket(`${url}/?token=${encodeURIComponent(token)}`);
+	openSockets.push(ws);
+	ws.addEventListener("message", ev => frames.push(JSON.parse(String((ev as MessageEvent).data))));
+	await new Promise<void>((resolve, reject) => {
+		ws.addEventListener("open", () => resolve());
+		ws.addEventListener("error", () => reject(new Error("ws error")));
+	});
+	await sleep(250);
+	return frames;
+}
+
+async function withNotifications<T>(fn: () => Promise<T>): Promise<T> {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		return await fn();
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
+	}
+}
+
+test("postmortem teardown emits session_closed to connected clients", async () => {
+	await withNotifications(async () => {
+		const registered = new Map<string, CleanupCallback>();
+		vi.spyOn(postmortem, "register").mockImplementation((id: string, cb: CleanupCallback) => {
+			registered.set(id, cb);
+			return () => {
+				registered.delete(id);
+			};
+		});
+
+		const harness = createHarness("gjc-notif-pm-");
+		await harness.handlers.get("session_start")!({ type: "session_start" }, harness.ctx);
+		await waitFor(() => fs.existsSync(harness.endpoint), 4000, "endpoint file");
+		const frames = await connectFrames(harness.endpoint);
+
+		const cleanup = registered.get(`notifications-session-closed:${harness.sid}`);
+		expect(cleanup).toBeDefined();
+
+		// Simulate the postmortem signal path (SIGHUP/SIGTERM/fatal error).
+		await cleanup!(postmortem.Reason.SIGTERM);
+
+		await waitFor(
+			() => frames.some(f => f.type === "session_closed" && f.sessionId === harness.sid),
+			4000,
+			"session_closed frame",
+		);
+	});
+}, 20000);
+
+test("graceful session_shutdown cancels the postmortem registration", async () => {
+	await withNotifications(async () => {
+		const registered = new Map<string, CleanupCallback>();
+		vi.spyOn(postmortem, "register").mockImplementation((id: string, cb: CleanupCallback) => {
+			registered.set(id, cb);
+			return () => {
+				registered.delete(id);
+			};
+		});
+
+		const harness = createHarness("gjc-notif-pm-cancel-");
+		await harness.handlers.get("session_start")!({ type: "session_start" }, harness.ctx);
+		await waitFor(() => fs.existsSync(harness.endpoint), 4000, "endpoint file");
+		expect(registered.has(`notifications-session-closed:${harness.sid}`)).toBe(true);
+
+		// A clean /quit path emits session_shutdown; the postmortem registration
+		// must be cancelled so process teardown cannot double-fire.
+		await harness.handlers.get("session_shutdown")!({ type: "session_shutdown" }, harness.ctx);
+		expect(registered.has(`notifications-session-closed:${harness.sid}`)).toBe(false);
+	});
+}, 20000);


### PR DESCRIPTION
## What

Registers a `postmortem` cleanup per notification session runtime that runs the existing `stopSession()` (emit `session_closed`, brief drain, stop the loopback server) when the process is torn down by a signal or fatal error.

- `startSession()`: after the runtime is registered, `postmortem.register("notifications-session-closed:<id>", ...)` arms the teardown path.
- `stopSession()`: cancels the registration first, so every graceful stop path (`/quit` -> `session_shutdown`, `/notify off`, resume-switch) never double-fires.
- `session_switch` re-key (`/new`/fork): the registration follows the id change, since the old closure captured the retired session id.

## Why

The managed Telegram daemon deletes a session's forum topic only when it receives the graceful `session_closed` frame, and that frame was emitted only from `AgentSession.dispose()` (a clean `/quit`). A native terminal-window close (SIGHUP), SIGTERM, or an uncaught fatal error skips `dispose()`, so the topic was orphaned forever; the daemon's `scanRoots()` skips dead-pid endpoints but has no reaper.

`postmortem` (packages/utils) already installs SIGINT/SIGTERM/SIGHUP handlers that await registered cleanups before exit, so the session process has a perfectly good async window to say goodbye; nothing was using it for notifications. With this change the topic is cleaned up on every teardown path reachable from inside the process; only SIGKILL remains, which no in-process handler can cover.

## Testing

- New `test/notifications-postmortem-close.test.ts` (2 tests): a connected WS client receives `session_closed` when the registered postmortem cleanup fires (simulated SIGTERM path), and a graceful `session_shutdown` cancels the registration (no double-fire). Uses `vi.spyOn(postmortem, "register")` so global cleanup state is not poisoned.
- `bun test test/notifications-postmortem-close.test.ts` - 2 pass.
- `bun test test/notifications-session-switch.test.ts test/notifications-e2e.test.ts` - 10 pass (no regression on the switch/re-key and e2e paths).
- `bun run check` in `packages/coding-agent` (biome + tsgo): passes; remaining diagnostics are the pre-existing `ultragoal-runtime.test.ts` unused-variable warnings.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
