### PR TITLE
feat(coding-agent): track workflow intent routing

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -61,10 +61,15 @@ Use for read-only plan critique. It approves only when execution can proceed wit
 <routing>
 - Clear, low-risk implementation request → implement directly with focused verification.
 - Do not invoke `deep-interview`, `ralplan`, `ultragoal`, `team`, or role agents for simple clear implementation requests; direct tools and the default launch path are enough.
+- The runtime records a `workflow-intent-diff` CustomEntry for direct-path traceability; it does not participate in LLM context and is not a reason to slow down direct execution.
 - When a task is clear, bounded, and low-risk, the default action is to make the smallest correct change and verify it, not to interview, plan, open a durable ledger, or delegate.
 - Small verification needs do not make a task a planning workflow. Escalate only for real ambiguity, non-trivial architecture/sequence risk, durable multi-goal tracking, or useful coordinated workers.
+- Ambiguous requirements → use `deep-interview` before planning or execution.
+- Architecture/sequence risk → use `ralplan --deliberate` and stop at pending approval.
+- Durable tracking needed → use `ultragoal`; if no approved plan exists, run `ralplan` first.
+- Root-cause phase schema is active only for contradiction, regression, or high-risk transition work; otherwise keep ordinary verification and do not add root-cause ceremony.
 - Vague requirements → use `deep-interview` before planning or execution.
-- Clear requirements but non-trivial architecture/sequence risk → use `ralplan` and stop at pending approval.
+- Clear requirements but non-trivial architecture/sequence risk → use `ralplan --deliberate` and stop at pending approval.
 - Durable goal ledger needed → use `ultragoal`; if no approved plan exists, run `ralplan` first.
 - Approved work benefits from coordinated persistent workers → use `team`.
 - Large enough implementation work → delegate bounded slices to `executor` through the task/sub-agent tool when it improves quality or throughput.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -260,6 +260,7 @@ import { type EditMode, resolveEditMode } from "../utils/edit-mode";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import { extractFileMentions, generateFileMentionMessages } from "../utils/file-mentions";
 import { buildNamedToolChoice, buildNamedToolChoiceResult } from "../utils/tool-choice";
+import { buildWorkflowIntentDiff, WORKFLOW_INTENT_DIFF_CUSTOM_TYPE } from "../workflow/workflow-intent-diff";
 import type { AuthStorage } from "./auth-storage";
 import type { ClientBridge, ClientBridgePermissionOption, ClientBridgePermissionOutcome } from "./client-bridge";
 import {
@@ -4828,6 +4829,7 @@ export class AgentSession {
 
 		// Expand file-based prompt templates if requested
 		const expandedText = expandPromptTemplates ? expandPromptTemplate(text, [...this.#promptTemplates]) : text;
+		const workflowIntentDiff = options?.synthetic ? null : buildWorkflowIntentDiff(expandedText);
 
 		// If streaming, queue via steer() or followUp() based on option
 		if (this.isStreaming) {
@@ -4839,7 +4841,14 @@ export class AgentSession {
 			} else {
 				await this.#queueSteer(expandedText, options?.images);
 			}
+			if (workflowIntentDiff) {
+				this.sessionManager.appendCustomEntry(WORKFLOW_INTENT_DIFF_CUSTOM_TYPE, workflowIntentDiff);
+			}
 			return;
+		}
+
+		if (workflowIntentDiff) {
+			this.sessionManager.appendCustomEntry(WORKFLOW_INTENT_DIFF_CUSTOM_TYPE, workflowIntentDiff);
 		}
 
 		// Skip eager todo prelude when the user has already queued a directive

--- a/packages/coding-agent/src/workflow/workflow-intent-diff.ts
+++ b/packages/coding-agent/src/workflow/workflow-intent-diff.ts
@@ -1,0 +1,199 @@
+export const WORKFLOW_INTENT_DIFF_CUSTOM_TYPE = "workflow-intent-diff";
+
+export type WorkflowIntentRoute = "direct" | "deep-interview" | "ralplan" | "ultragoal" | "team";
+export type DirectTrackingMode = "custom-entry-only" | "not-direct";
+export type RootCausePhaseStatus = "active" | "inactive";
+
+export interface WorkflowIntentDiff {
+	readonly version: 1;
+	readonly route: WorkflowIntentRoute;
+	readonly reason: string;
+	readonly directTracking: DirectTrackingMode;
+	readonly recommendedSkill?: Exclude<WorkflowIntentRoute, "direct">;
+	readonly recommendedInvocation?: string;
+	readonly triggers: readonly string[];
+	readonly rootCausePhase: {
+		readonly status: RootCausePhaseStatus;
+		readonly triggers: readonly string[];
+	};
+	readonly promptPreview: string;
+}
+
+interface RouteMatch {
+	readonly route: WorkflowIntentRoute;
+	readonly reason: string;
+	readonly recommendedInvocation?: string;
+	readonly triggers: readonly string[];
+}
+
+const PROMPT_PREVIEW_LIMIT = 240;
+
+const DURABLE_TRACKING_PATTERNS = [
+	/\bultragoal\b/i,
+	/\bdurable (?:goal|tracking|ledger|plan)\b/i,
+	/\b(?:goal|tracking|plan) ledger\b/i,
+	/\bcheckpoint(?:ed|ing)? (?:goal|plan|workflow|release|work)\b/i,
+	/\bcheckpoint (?:this|the) (?:goal|plan|workflow|release|work)\b/i,
+] as const;
+
+const AMBIGUOUS_REQUIREMENT_PATTERNS = [
+	/\bambiguous (?:requirement|requirements|request|requests|scope)\b/i,
+	/\bdeep[- ]interview\b/i,
+	/\binterview me\b/i,
+	/\bdon't assume\b/i,
+	/\bnot sure\b/i,
+	/\bunclear\b/i,
+	/\bvague\b/i,
+] as const;
+
+const ARCHITECTURE_SEQUENCE_PATTERNS = [
+	/\barchitecture\b/i,
+	/\barchitectural\b/i,
+	/\bsequence\b/i,
+	/\bmigrate\b/i,
+	/\bmigration\b/i,
+	/\bauth(?:entication|orization)? (?:migration|sequence|rollout|release|refactor|rewrite|transition)\b/i,
+	/\bsecurity\b/i,
+	/\bcompliance\b/i,
+	/\bPII\b/i,
+	/\bproduction (?:release|rollout|deployment|migration|incident|data|change|cutover)\b/i,
+	/\bdeploy(?:ing)? to production\b/i,
+	/\bbreaking change\b/i,
+	/\bdata loss\b/i,
+	/\bdestructive\b/i,
+] as const;
+
+const TEAM_PATTERNS = [
+	/\buse (?:a )?team\b/i,
+	/\bcoordinated (?:persistent )?workers\b/i,
+	/\bpersistent workers\b/i,
+	/\bworker coordination\b/i,
+] as const;
+
+const ROOT_CAUSE_TRIGGERS = [
+	{ name: "contradiction", pattern: /\bcontradict(?:ion|s|ory)?\b/i },
+	{ name: "regression", pattern: /\bregression\b/i },
+	{
+		name: "high-risk transition",
+		pattern:
+			/\b(?:migrate|migration|auth(?:entication|orization)? (?:migration|sequence|rollout|release|refactor|rewrite|transition)|security|breaking change|data loss|destructive|production (?:release|rollout|deployment|migration|incident|data|change|cutover)|deploy(?:ing)? to production|compliance|PII)\b/i,
+	},
+] as const;
+
+function matchesAny(text: string, patterns: readonly RegExp[]): boolean {
+	return patterns.some(pattern => pattern.test(text));
+}
+
+function withGlobal(pattern: RegExp): RegExp {
+	const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
+	return new RegExp(pattern.source, flags);
+}
+
+function isNegatedAt(text: string, index: number): boolean {
+	const prefix = text.slice(Math.max(0, index - 48), index).toLowerCase();
+	const boundary = Math.max(
+		prefix.lastIndexOf("."),
+		prefix.lastIndexOf(","),
+		prefix.lastIndexOf(";"),
+		prefix.lastIndexOf(":"),
+		prefix.lastIndexOf("?"),
+		prefix.lastIndexOf("!"),
+		prefix.lastIndexOf("\n"),
+		prefix.lastIndexOf(" but "),
+		prefix.lastIndexOf(" however "),
+		prefix.lastIndexOf(" yet "),
+		prefix.lastIndexOf(" then "),
+	);
+	const localPrefix = boundary >= 0 ? prefix.slice(boundary + 1) : prefix;
+	return /(?:^|[\s([{])(?:no|not|without|excluding|exclude|absent|absence of|avoid)\b[^.,!?;:\n]{0,48}$/.test(
+		localPrefix,
+	);
+}
+
+function matchesAnyNonNegated(text: string, patterns: readonly RegExp[]): boolean {
+	return patterns.some(pattern => {
+		for (const match of text.matchAll(withGlobal(pattern))) {
+			if (!isNegatedAt(text, match.index ?? 0)) return true;
+		}
+		return false;
+	});
+}
+
+function collectRootCauseTriggers(text: string): readonly string[] {
+	return ROOT_CAUSE_TRIGGERS.filter(trigger => matchesAnyNonNegated(text, [trigger.pattern])).map(
+		trigger => trigger.name,
+	);
+}
+
+function buildPromptPreview(text: string): string {
+	const compact = text.replace(/\s+/g, " ").trim();
+	return compact.length > PROMPT_PREVIEW_LIMIT ? `${compact.slice(0, PROMPT_PREVIEW_LIMIT - 3)}...` : compact;
+}
+
+function classifyRoute(text: string): RouteMatch {
+	if (matchesAny(text, AMBIGUOUS_REQUIREMENT_PATTERNS)) {
+		return {
+			route: "deep-interview",
+			reason: "ambiguous requirements need clarification",
+			recommendedInvocation: "/skill:deep-interview",
+			triggers: ["ambiguous requirements"],
+		};
+	}
+
+	if (matchesAny(text, DURABLE_TRACKING_PATTERNS)) {
+		return {
+			route: "ultragoal",
+			reason: "durable tracking requested",
+			recommendedInvocation: "/skill:ultragoal",
+			triggers: ["durable tracking"],
+		};
+	}
+
+	if (matchesAnyNonNegated(text, ARCHITECTURE_SEQUENCE_PATTERNS)) {
+		return {
+			route: "ralplan",
+			reason: "architecture or sequence risk requires deliberate planning",
+			recommendedInvocation: "/skill:ralplan --deliberate",
+			triggers: ["architecture/sequence risk"],
+		};
+	}
+
+	if (matchesAny(text, TEAM_PATTERNS)) {
+		return {
+			route: "team",
+			reason: "coordinated persistent workers requested",
+			recommendedInvocation: "/skill:team",
+			triggers: ["coordinated workers"],
+		};
+	}
+
+	return {
+		route: "direct",
+		reason: "clear low-risk prompt stays on direct implementation path",
+		triggers: ["low-risk direct"],
+	};
+}
+
+export function buildWorkflowIntentDiff(text: string): WorkflowIntentDiff | null {
+	const promptPreview = buildPromptPreview(text);
+	if (!promptPreview) return null;
+
+	const route = classifyRoute(text);
+	const rootCauseTriggers = collectRootCauseTriggers(text);
+	const rootCauseActive = rootCauseTriggers.length > 0;
+	const direct = route.route === "direct";
+
+	return {
+		version: 1,
+		route: route.route,
+		reason: route.reason,
+		directTracking: direct ? "custom-entry-only" : "not-direct",
+		...(direct ? {} : { recommendedSkill: route.route, recommendedInvocation: route.recommendedInvocation }),
+		triggers: route.triggers,
+		rootCausePhase: {
+			status: rootCauseActive ? "active" : "inactive",
+			triggers: rootCauseTriggers,
+		},
+		promptPreview,
+	};
+}

--- a/packages/coding-agent/test/agent-session-workflow-intent-diff.test.ts
+++ b/packages/coding-agent/test/agent-session-workflow-intent-diff.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent, AgentBusyError } from "@gajae-code/agent-core";
+import { getBundledModel } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { type CustomEntry, SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+
+type WorkflowIntentDiffEntry = CustomEntry<{
+	readonly route: string;
+	readonly recommendedSkill?: string;
+	readonly recommendedInvocation?: string;
+	readonly directTracking: string;
+	readonly rootCausePhase: {
+		readonly status: string;
+		readonly triggers: readonly string[];
+	};
+}>;
+
+describe("AgentSession workflow intent-diff tracking", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@gjc-workflow-intent-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled Anthropic test model to exist");
+
+		const mock = createMockModel({
+			responses: Array.from({ length: 12 }, () => ({ content: ["ack"] })),
+		});
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: mock.stream,
+		});
+
+		sessionManager = SessionManager.inMemory(tempDir.path());
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+	});
+
+	afterEach(async () => {
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	function workflowIntentEntries(): WorkflowIntentDiffEntry[] {
+		return sessionManager
+			.getEntries()
+			.filter(
+				(entry): entry is WorkflowIntentDiffEntry =>
+					entry.type === "custom" && entry.customType === "workflow-intent-diff",
+			);
+	}
+
+	it("records a CustomEntry-only intent diff for clear low-risk direct prompts", async () => {
+		await session.prompt("fix packages/coding-agent/src/session/agent-session.ts null check");
+
+		const [entry] = workflowIntentEntries();
+		expect(entry?.data).toMatchObject({
+			route: "direct",
+			directTracking: "custom-entry-only",
+			rootCausePhase: { status: "inactive", triggers: [] },
+		});
+		expect(session.agent.state.messages).not.toEqual(
+			expect.arrayContaining([expect.objectContaining({ customType: "workflow-intent-diff" })]),
+		);
+	});
+
+	it("records ralplan deliberate plus root-cause activation for high-risk sequence prompts", async () => {
+		await session.prompt("plan the auth migration sequence and explain the regression risk before implementation");
+		await session.prompt("avoid regression but migrate auth");
+
+		const [combinedRisk, contrastiveRisk] = workflowIntentEntries();
+		expect(combinedRisk?.data).toMatchObject({
+			route: "ralplan",
+			recommendedSkill: "ralplan",
+			recommendedInvocation: "/skill:ralplan --deliberate",
+			directTracking: "not-direct",
+			rootCausePhase: { status: "active" },
+		});
+		expect(combinedRisk?.data?.rootCausePhase.triggers).toEqual(
+			expect.arrayContaining(["regression", "high-risk transition"]),
+		);
+		expect(contrastiveRisk?.data).toMatchObject({
+			route: "ralplan",
+			recommendedSkill: "ralplan",
+			recommendedInvocation: "/skill:ralplan --deliberate",
+			directTracking: "not-direct",
+			rootCausePhase: { status: "active" },
+		});
+		expect(contrastiveRisk?.data?.rootCausePhase.triggers).toEqual(["high-risk transition"]);
+	});
+
+	it("records ambiguous and durable prompts as explicit workflow escalations", async () => {
+		await session.prompt("I'm not sure what this product should be, don't assume the requirements");
+		await session.prompt("create a durable goal ledger for this multi-step release");
+		await session.prompt("create a durable goal ledger for this production release");
+
+		const [deepInterview, ultragoal, productionUltragoal] = workflowIntentEntries();
+		expect(deepInterview?.data).toMatchObject({
+			route: "deep-interview",
+			recommendedSkill: "deep-interview",
+			recommendedInvocation: "/skill:deep-interview",
+			directTracking: "not-direct",
+		});
+		expect(ultragoal?.data).toMatchObject({
+			route: "ultragoal",
+			recommendedSkill: "ultragoal",
+			recommendedInvocation: "/skill:ultragoal",
+			directTracking: "not-direct",
+		});
+		expect(productionUltragoal?.data).toMatchObject({
+			route: "ultragoal",
+			recommendedSkill: "ultragoal",
+			recommendedInvocation: "/skill:ultragoal",
+			directTracking: "not-direct",
+			rootCausePhase: { status: "active", triggers: ["high-risk transition"] },
+		});
+	});
+
+	it("lets ambiguous requirements take precedence over durable tracking words", async () => {
+		await session.prompt("I'm not sure what this product should be; create a durable goal ledger after that");
+		await session.prompt("ambiguous requirements; create a durable goal ledger after clarification");
+
+		const [naturalLanguage, policyPhrase] = workflowIntentEntries();
+		expect(naturalLanguage?.data).toMatchObject({
+			route: "deep-interview",
+			recommendedSkill: "deep-interview",
+			recommendedInvocation: "/skill:deep-interview",
+			directTracking: "not-direct",
+		});
+		expect(policyPhrase?.data).toMatchObject({
+			route: "deep-interview",
+			recommendedSkill: "deep-interview",
+			recommendedInvocation: "/skill:deep-interview",
+			directTracking: "not-direct",
+		});
+	});
+
+	it("records coordinated persistent worker requests as team escalations", async () => {
+		await session.prompt("use a team of coordinated persistent workers for this approved implementation");
+
+		const [entry] = workflowIntentEntries();
+		expect(entry?.data).toMatchObject({
+			route: "team",
+			recommendedSkill: "team",
+			recommendedInvocation: "/skill:team",
+			directTracking: "not-direct",
+		});
+	});
+
+	it("keeps ordinary product-domain workflow words on the direct path", async () => {
+		await session.prompt("fix the team settings page typo");
+		await session.prompt("fix the auth settings page typo");
+		await session.prompt("fix the production settings page typo");
+		await session.prompt("fix the ledger table typo");
+		await session.prompt("fix the checkpoint page typo");
+
+		for (const entry of workflowIntentEntries()) {
+			expect(entry.data).toMatchObject({
+				route: "direct",
+				directTracking: "custom-entry-only",
+				rootCausePhase: { status: "inactive", triggers: [] },
+			});
+		}
+	});
+
+	it("activates root-cause phase for contradiction without requiring workflow escalation", async () => {
+		await session.prompt("resolve the contradiction between the intended contract and the observed behavior");
+
+		const [entry] = workflowIntentEntries();
+		expect(entry?.data).toMatchObject({
+			route: "direct",
+			directTracking: "custom-entry-only",
+			rootCausePhase: { status: "active" },
+		});
+		expect(entry?.data?.rootCausePhase.triggers).toEqual(["contradiction"]);
+	});
+
+	it("does not activate root-cause phase for explicitly absent risks", async () => {
+		await session.prompt("plan the architecture sequence without migration or regression");
+
+		const [entry] = workflowIntentEntries();
+		expect(entry?.data).toMatchObject({
+			route: "ralplan",
+			rootCausePhase: { status: "inactive", triggers: [] },
+		});
+	});
+
+	it("keeps rejected busy prompts out of workflow intent tracking", async () => {
+		try {
+			session.agent.state.isStreaming = true;
+
+			await expect(session.prompt("fix the direct null check")).rejects.toBeInstanceOf(AgentBusyError);
+			expect(workflowIntentEntries()).toEqual([]);
+		} finally {
+			session.agent.state.isStreaming = false;
+		}
+	});
+
+	it("does not record workflow intent diffs for synthetic prompts", async () => {
+		await session.prompt("internal continuation", { synthetic: true });
+
+		expect(workflowIntentEntries()).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -318,8 +318,15 @@ Project executor override body.
 
 		expect(routing).toMatch(/Clear,\s+low-risk implementation request\s+→\s+implement directly/i);
 		expect(routing).toMatch(/simple clear implementation requests[\s\S]*direct tools[\s\S]*default launch path/i);
+		expect(routing).toMatch(/workflow-intent-diff[\s\S]*CustomEntry[\s\S]*does not participate in LLM context/i);
 		expect(routing).toMatch(/clear,\s+bounded,\s+and low-risk[\s\S]*smallest correct change[\s\S]*verify/i);
 		expect(routing).toMatch(/Small verification needs[\s\S]*do not make[\s\S]*planning workflow/i);
+		expect(routing).toMatch(/Architecture\/sequence risk[\s\S]*`ralplan --deliberate`/i);
+		expect(routing).toMatch(/Ambiguous requirements[\s\S]*`deep-interview`/i);
+		expect(routing).toMatch(/Durable tracking[\s\S]*`ultragoal`/i);
+		expect(routing).toMatch(
+			/root-cause phase schema[\s\S]*only[\s\S]*contradiction[\s\S]*regression[\s\S]*high-risk transition/i,
+		);
 		for (const escalationTrigger of [
 			"Vague requirements",
 			"non-trivial architecture/sequence risk",


### PR DESCRIPTION
## Summary

This PR adds runtime workflow-intent routing traceability for GJC prompts without slowing the low-risk direct path.

It continues PR #1420's decision-artifact work: #1420 made planning decisions durable and reviewable; this PR records the runtime intent-diff that decides whether a prompt should stay direct or escalate into an existing workflow lane.

## Problem

Before this change, the routing contract lived mostly in prompt text. That left three practical gaps:

- Clear direct work had no lightweight structured trace showing why it stayed direct.
- Escalation choices such as `deep-interview`, `ralplan --deliberate`, `ultragoal`, and `team` were not backed by runtime intent-diff data.
- Root-cause schema activation could not be tested as a conditional contract, so contradiction/regression/high-risk cases and ordinary direct cases were easy to blur.

## Solution

- Add `workflow-intent-diff` CustomEntry payloads from accepted user prompts only.
- Keep the entry out of LLM message context so direct work stays fast and does not trigger extra ceremony.
- Classify prompts into direct, `deep-interview`, `ralplan`, `ultragoal`, or `team` using conservative patterns.
- Activate `rootCausePhase` only for contradiction, regression, or high-risk transition evidence.
- Avoid false positives for product-domain words like team/auth/production/ledger/checkpoint.
- Avoid ledger pollution by writing the CustomEntry after busy/streaming rejection checks.

## QA & Evidence

- `bun test packages/coding-agent/test/agent-session-workflow-intent-diff.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts`
  - Observed: `33 pass`, `0 fail`, `253 expect() calls`
- `bunx biome check packages/coding-agent/src/workflow/workflow-intent-diff.ts packages/coding-agent/src/session/agent-session.ts packages/coding-agent/test/agent-session-workflow-intent-diff.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/src/prompts/system/system-prompt.md`
  - Observed: pass, no fixes applied
- `bun run --cwd packages/coding-agent check`
  - Observed: pass, no warnings on latest `origin/dev`

## PR Sequence

1. #1420 standardized `ralplan` decision artifacts.
2. This PR adds runtime workflow intent-diff tracking and routing guardrails.
3. A follow-up can use these CustomEntries for higher-level consensus/claims-ledger reporting if needed.
