### PR TITLE
feat(coding-agent): show current session state and Enter-expand on the /model preset landing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- The `/model` preset landing now shows the session's current preset, model, and per-role assignments in the header, marks the active preset with `(current)`, and Enter now expands/collapses provider groups (right/left arrows still work).
+
 ### Fixed
 
 - The Python `gjc_rpc` client no longer tears down its reader loop on real server frames it had not modeled: OAuth `open_url` extension-UI requests emitted during `login`, `workflow_gate` frames carrying structured `{value, label, description}` options (the `next_workflow_gate()` queue path re-parsed them with a legacy strings-only parser), and `max`/`inherit` thinking levels returned by `get_state`/model info. `install_headless_ui` now answers interactive UI requests with `extension_ui_response` frames instead of misrouting them as `workflow_gate_response` commands, and `get_pending_workflow_gates()` is exposed as a typed method. Previously dropped payloads (`notice`, `thinking_level_changed`, `goal_updated`, `irc_message`, `subagent_steer_message` events; `agent_end.stopReason`/`telemetry`/`coverage`; `auto_retry_start.unbounded`; `auto_compaction_end.continuationSkipReason`; gate `required`) now parse into typed models, and the env-gated real-binary lane covers the new surface.

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1030,11 +1030,51 @@ export class ModelSelectorComponent extends Container {
 		this.#filterModels(this.#searchInput.getValue());
 	}
 
+	/**
+	 * "What is this session running right now" summary for the preset landing
+	 * header: active preset (when one is applied), the effective current model
+	 * and thinking level, and one line per assigned role (default, executor,
+	 * planner, critic, architect).
+	 */
+	#formatCurrentSessionLines(): string[] {
+		const lines: string[] = [];
+		const parts: string[] = [];
+		if (this.#activeModelProfile) {
+			const profile = this.#getProfileByName(this.#activeModelProfile);
+			const displayName = profile ? getModelProfilePresentation(profile).displayName : this.#activeModelProfile;
+			parts.push(`preset ${theme.fg("accent", displayName)}`);
+		}
+		if (this.#currentModel) {
+			parts.push(this.#formatAssignedModelLabel(this.#currentModel, this.#currentThinkingLevel));
+		}
+		if (parts.length > 0) lines.push(theme.fg("muted", `Current: ${parts.join(" · ")}`));
+		for (const role of PROFILE_ROLE_PREVIEW_ORDER) {
+			const assigned = this.#roles[role];
+			if (!assigned) continue;
+			const label = GJC_MODEL_ASSIGNMENT_TARGETS[role].tag ?? role.toUpperCase();
+			lines.push(
+				theme.fg("dim", `  ${label}: ${this.#formatAssignedModelLabel(assigned.model, assigned.thinkingLevel)}`),
+			);
+		}
+		return lines;
+	}
+
+	#formatAssignedModelLabel(model: Model, thinkingLevel: ThinkingLevel | undefined): string {
+		let label = `${model.provider}/${model.id}`;
+		if (thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit) {
+			label += ` (${getThinkingLevelMetadata(thinkingLevel).label})`;
+		}
+		return label;
+	}
+
 	#renderPresetLanding(): void {
 		this.#headerContainer.clear();
 		this.#tabBar = null;
 		this.#listContainer.clear();
 		this.#headerContainer.addChild(new Text(theme.fg("accent", "Model presets"), 0, 0));
+		for (const line of this.#formatCurrentSessionLines()) {
+			this.#headerContainer.addChild(new Text(line, 0, 0));
+		}
 		const rows = this.#getPresetRows();
 		for (let i = 0; i < rows.length; i++) {
 			const row = rows[i];
@@ -1065,17 +1105,23 @@ export class ModelSelectorComponent extends Container {
 			if (row.kind === "group") {
 				const authenticated = this.#isPresetGroupUsable(row.profiles);
 				const mark = this.#providerAuthPending ? "…" : authenticated ? "✓" : "✗";
+				const containsActive =
+					this.#activeModelProfile !== undefined &&
+					row.profiles.some(profile => profile.name === this.#activeModelProfile);
 				const label = `${mark} ${row.groupId}`;
 				const renderedLabel = selected ? theme.fg("accent", label) : authenticated ? label : theme.fg("dim", label);
-				this.#listContainer.addChild(new Text(`${prefix}${renderedLabel}`, 0, 0));
+				const activeSuffix = containsActive ? theme.fg("muted", " (current)") : "";
+				this.#listContainer.addChild(new Text(`${prefix}${renderedLabel}${activeSuffix}`, 0, 0));
 				continue;
 			}
 			const presentation = getModelProfilePresentation(row.profile);
 			const authenticated = this.#isPresetAuthenticated(row.profile);
 			const mark = this.#providerAuthPending ? "…" : authenticated ? "✓" : "✗";
+			const isActive = row.profile.name === this.#activeModelProfile;
 			const label = `  ${mark} ${presentation.displayName}`;
 			const renderedLabel = selected ? theme.fg("accent", label) : authenticated ? label : theme.fg("dim", label);
-			this.#listContainer.addChild(new Text(`${prefix}${renderedLabel}`, 0, 0));
+			const activeSuffix = isActive ? theme.fg("muted", " (current)") : "";
+			this.#listContainer.addChild(new Text(`${prefix}${renderedLabel}${activeSuffix}`, 0, 0));
 		}
 		if (this.#presetLoginHint) {
 			this.#listContainer.addChild(new Spacer(1));
@@ -1538,7 +1584,17 @@ export class ModelSelectorComponent extends Container {
 				const missing = this.#getMissingProviders(row.profiles);
 				this.#presetLoginHint = `Run ${missing.map(provider => `/login ${provider}`).join(", ")}`;
 				this.#renderPresetLanding();
+				return;
 			}
+			// Enter toggles a usable group's expansion so drilling into presets
+			// works without reaching for the arrow keys (right/left still work).
+			if (this.#expandedPresetProviderId === row.groupId) {
+				this.#collapseSelectedPresetProvider();
+			} else {
+				this.#expandSelectedPresetProvider();
+			}
+			this.#presetLoginHint = undefined;
+			this.#renderPresetLanding();
 			return;
 		}
 		const missing = this.#getMissingProviders(row.profile);

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -205,6 +205,45 @@ describe("model selector profiles", () => {
 		expect(rendered).not.toContain("Codex Eco");
 		expect(rendered).not.toContain("profile-a");
 	});
+
+	test("landing header shows the session's current preset, model, and role assignments", async () => {
+		installTestTheme();
+		const selector = createSelector(() => {}, {
+			currentModel: defaultModel,
+			currentThinkingLevel: ThinkingLevel.High,
+			activeModelProfile: "profile-a",
+			settings: Settings.isolated({
+				"task.agentModelOverrides": { executor: "provider-a/alternate" },
+			}),
+		});
+		await Bun.sleep(10);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("Current: preset Profile Alpha · provider-a/default (high)");
+		expect(rendered).toContain("DEFAULT: provider-a/default (high)");
+		expect(rendered).toContain("EXECUTOR: provider-a/alternate");
+		expect(rendered).toContain("(current)");
+	});
+
+	test("enter toggles a usable provider group's expansion", async () => {
+		installTestTheme();
+		const selector = createSelector(() => {});
+		await Bun.sleep(10);
+		installTestTheme();
+
+		let rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("CODEX");
+		expect(rendered).not.toContain("Codex Eco");
+
+		selector.handleInput("\r");
+		rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("Codex Eco");
+
+		selector.handleInput("\r");
+		rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).not.toContain("Codex Eco");
+	});
 	test("preset search keeps first typed character before subsequent input", async () => {
 		installTestTheme();
 		const selector = createSelector(() => {});


### PR DESCRIPTION
## What

Two UX improvements to the `/model` preset-first landing:

1. **Current-session visibility.** The header now shows what this session is running right now:

   ```
   Model presets
   Current: preset legend-cc · anthropic/claude-fable-5 (high)
     DEFAULT: anthropic/claude-fable-5 (high)
     EXECUTOR: openai-codex/gpt-5.5 (medium)
     ...
   ```

   One dim line per assigned role (default, executor, planner, critic, architect), plus a `(current)` marker on the active preset row and its provider group.

2. **Enter toggles provider groups.** Enter on a usable group now expands/collapses it. Previously Enter on a group was a silent no-op and only the right arrow expanded, so the natural "Enter to drill in" instinct dead-ended. Right/left arrows keep working; the `/login` hint for fully unauthenticated groups is unchanged.

## Why

Opening `/model` to *check* the active model/preset is at least as common as switching, but the landing rendered zero current-state information - the component already received `currentModel`, `currentThinkingLevel`, and `activeModelProfile` and only used them for row badges in the browse view. And requiring the right arrow for the primary drill-in action contradicts how every other list in the TUI confirms with Enter.

## Testing

- Two new tests in `test/model-selector-profiles.test.ts`: landing header shows current preset/model/role assignments; Enter toggles a usable group's expansion.
- `bun test` across all 5 model-selector suites: 73 pass, 0 fail.
- `bun run check` in `packages/coding-agent` (biome + tsgo): passes; only pre-existing `ultragoal-runtime.test.ts` warnings remain.
- Verified live by backporting the same change onto an installed 0.7.10 and opening `/model`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
