### PR TITLE
fix(deep-interview): reject blank gate free text

### DIFF
--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -435,6 +435,7 @@ export interface RpcJsonSchema {
 	items?: RpcJsonSchema;
 	minLength?: number;
 	maxLength?: number;
+	pattern?: string;
 	minItems?: number;
 	maxItems?: number;
 	uniqueItems?: boolean;

--- a/packages/coding-agent/src/modes/shared/agent-wire/deep-interview-gate.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/deep-interview-gate.ts
@@ -131,7 +131,12 @@ function questionAnswerSchema(question: AskGateQuestion, labels: string[]): RpcJ
 		properties: {
 			selected: selectedBase,
 			other: { type: "boolean", description: "set true to provide a free-text answer in `custom`" },
-			custom: { type: "string", minLength: 1, description: "free-text answer; required when `other` is true" },
+			custom: {
+				type: "string",
+				minLength: 1,
+				pattern: "\\S",
+				description: "free-text answer; required when `other` is true",
+			},
 			action: {
 				type: "string",
 				enum: ["answer", "clarify"],
@@ -140,6 +145,7 @@ function questionAnswerSchema(question: AskGateQuestion, labels: string[]): RpcJ
 			question: {
 				type: "string",
 				minLength: 1,
+				pattern: "\\S",
 				description: "clarification question; required when action is `clarify`",
 			},
 		},
@@ -156,7 +162,7 @@ function questionAnswerSchema(question: AskGateQuestion, labels: string[]): RpcJ
 				properties: {
 					selected: selectedWithOther,
 					other: { const: true },
-					custom: { type: "string", minLength: 1 },
+					custom: { type: "string", minLength: 1, pattern: "\\S" },
 					action: { const: "answer" },
 				},
 				required: ["selected", "other", "custom"],
@@ -166,7 +172,7 @@ function questionAnswerSchema(question: AskGateQuestion, labels: string[]): RpcJ
 				type: "object",
 				properties: {
 					action: { const: "clarify" },
-					question: { type: "string", minLength: 1 },
+					question: { type: "string", minLength: 1, pattern: "\\S" },
 				},
 				required: ["action", "question"],
 				additionalProperties: false,

--- a/packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-schema.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-schema.ts
@@ -25,6 +25,7 @@ const SUPPORTED_KEYWORDS = new Set<keyof RpcJsonSchema>([
 	"items",
 	"minLength",
 	"maxLength",
+	"pattern",
 	"minItems",
 	"maxItems",
 	"uniqueItems",
@@ -105,6 +106,17 @@ function walkSchema(schema: RpcJsonSchema, depth: number, path: string): void {
 	for (const meta of ["title", "description"] as const) {
 		if (schema[meta] !== undefined && typeof schema[meta] !== "string") {
 			throw new WorkflowGateSchemaError(`${meta} at ${path} must be a string`);
+		}
+	}
+	if (schema.pattern !== undefined) {
+		if (typeof schema.pattern !== "string") {
+			throw new WorkflowGateSchemaError(`pattern at ${path} must be a string`);
+		}
+		try {
+			new RegExp(schema.pattern);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new WorkflowGateSchemaError(`pattern at ${path} must be a valid regular expression: ${message}`);
 		}
 	}
 	for (const limit of ["minLength", "maxLength", "minItems", "maxItems"] as const) {
@@ -240,6 +252,14 @@ function validateValue(schema: RpcJsonSchema, value: unknown, path: string, erro
 				keyword: "maxLength",
 				message: `longer than ${schema.maxLength}`,
 				expected: schema.maxLength,
+			});
+		}
+		if (schema.pattern !== undefined && !new RegExp(schema.pattern).test(value)) {
+			errors.push({
+				path,
+				keyword: "pattern",
+				message: `does not match pattern ${schema.pattern}`,
+				expected: schema.pattern,
 			});
 		}
 	}

--- a/packages/coding-agent/test/deep-interview-workflow-gates.test.ts
+++ b/packages/coding-agent/test/deep-interview-workflow-gates.test.ts
@@ -36,6 +36,7 @@ describe("questionToGate", () => {
 		expect(gate.schema.properties?.selected?.items?.enum).toEqual(["JWT", "OAuth2", "Session cookies"]);
 		expect(gate.schema.properties?.other?.type).toBe("boolean");
 		expect(gate.schema.properties?.action?.enum).toEqual(["answer", "clarify"]);
+		expect(gate.schema.properties?.custom?.pattern).toBe("\\S");
 		expect(gate.context?.stage_state).toMatchObject({
 			question_id: "q1",
 			multi: false,
@@ -110,6 +111,18 @@ describe("end-to-end via the broker", () => {
 		});
 		expect(combined.status).toBe("rejected");
 		expect(combined.error?.errors.some(e => e.keyword === "anyOf")).toBe(true);
+		const blankOther = await broker.resolve({
+			gate_id: gate.gate_id,
+			answer: { selected: [], other: true, custom: " \t\n " },
+		});
+		expect(blankOther.status).toBe("rejected");
+		expect(blankOther.error?.errors.some(e => e.keyword === "pattern")).toBe(true);
+		const blankClarification = await broker.resolve({
+			gate_id: gate.gate_id,
+			answer: { action: "clarify", question: " \t\n " },
+		});
+		expect(blankClarification.status).toBe("rejected");
+		expect(blankClarification.error?.errors.some(e => e.keyword === "pattern")).toBe(true);
 		// A schema-valid answer is accepted and decodes to the human-path result.
 		const good = await broker.resolve({ gate_id: gate.gate_id, answer: { selected: ["JWT"] } });
 		expect(good.status).toBe("accepted");

--- a/packages/coding-agent/test/workflow-gate-schema.test.ts
+++ b/packages/coding-agent/test/workflow-gate-schema.test.ts
@@ -11,7 +11,7 @@ import {
 
 describe("workflow-gate-schema", () => {
 	it("rejects unsupported keywords at construction", () => {
-		const schema = { type: "string", pattern: "^x" } as unknown as RpcJsonSchema;
+		const schema = { type: "string", format: "email" } as unknown as RpcJsonSchema;
 		expect(() => assertSupportedGateSchema(schema)).toThrow(WorkflowGateSchemaError);
 	});
 
@@ -39,6 +39,8 @@ describe("workflow-gate-schema", () => {
 			{ type: "array", uniqueItems: "yes" }, // non-boolean
 			{ type: "number", minimum: Number.POSITIVE_INFINITY }, // non-finite
 			{ type: "string", title: 5 }, // non-string meta
+			{ type: "string", pattern: 5 }, // non-string pattern
+			{ type: "string", pattern: "[" }, // invalid pattern
 		];
 		for (const c of cases) {
 			expect(() => assertSupportedGateSchema(c as RpcJsonSchema)).toThrow(WorkflowGateSchemaError);
@@ -59,6 +61,12 @@ describe("workflow-gate-schema", () => {
 		expect(err?.code).toBe("invalid_workflow_gate_answer");
 		expect(err?.gate_id).toBe("g1");
 		expect(err?.errors[0]?.keyword).toBe("enum");
+	});
+
+	it("validates string patterns", () => {
+		const compiled = compileGateSchema({ type: "string", pattern: "\\S" });
+		expect(validateGateAnswer(compiled, "g-pattern", "has text")).toBeNull();
+		expect(validateGateAnswer(compiled, "g-pattern", "   ")?.errors[0]?.keyword).toBe("pattern");
 	});
 
 	it("validates object required + additionalProperties:false", () => {


### PR DESCRIPTION
## Summary
- Add `pattern` support to the constrained workflow-gate JSON Schema subset.
- Use `pattern: "\\S"` for Deep Interview gate free-text custom answers and clarification questions.
- Cover whitespace-only custom/clarification answers so they are rejected by the broker before a gate is consumed.

## Why
Whitespace-only Deep Interview gate answers could pass the advertised schema via `minLength: 1`, then fail later in `gateAnswerToResult()` after the workflow gate had already accepted the answer. This keeps invalid answers rejected at the gate boundary so the pending gate remains retryable.

## Testing
- `bun test packages/coding-agent/test/workflow-gate-schema.test.ts packages/coding-agent/test/deep-interview-workflow-gates.test.ts`
- `bun test packages/coding-agent/test/deep-interview-gate-redteam.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/modes/rpc/rpc-types.ts packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-schema.ts packages/coding-agent/src/modes/shared/agent-wire/deep-interview-gate.ts packages/coding-agent/test/workflow-gate-schema.test.ts packages/coding-agent/test/deep-interview-workflow-gates.test.ts --no-errors-on-unmatched`