### PR TITLE
fix(edit): preserve UTF-8 BOM in replace mode

### DIFF
--- a/packages/coding-agent/src/edit/read-file.ts
+++ b/packages/coding-agent/src/edit/read-file.ts
@@ -14,6 +14,13 @@ import { isNotebookPath, readEditableNotebookText, serializeEditedNotebookText }
  */
 export const MAX_EDIT_FILE_BYTES = 8 * 1024 * 1024;
 
+const UTF8_BOM = [0xef, 0xbb, 0xbf] as const;
+
+async function fileHasUtf8Bom(file: Bun.BunFile): Promise<boolean> {
+	const bytes = await file.slice(0, UTF8_BOM.length).bytes();
+	return UTF8_BOM.every((byte, index) => bytes[index] === byte);
+}
+
 export async function readEditFileText(absolutePath: string, path: string): Promise<string> {
 	try {
 		const file = Bun.file(absolutePath);
@@ -28,7 +35,8 @@ export async function readEditFileText(absolutePath: string, path: string): Prom
 		// Guard BEFORE the notebook fast-path: a >8 MiB .ipynb would otherwise load + JSON-parse
 		// + convert the whole file via readEditableNotebookText, bypassing the F19 freeze guard.
 		if (isNotebookPath(absolutePath)) return await readEditableNotebookText(absolutePath, path);
-		return await file.text();
+		const text = await file.text();
+		return (await fileHasUtf8Bom(file)) && !text.startsWith("\uFEFF") ? `\uFEFF${text}` : text;
 	} catch (error) {
 		if (isEnoent(error)) {
 			throw new Error(`File not found: ${path}`);

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -1996,8 +1996,7 @@ describe("edit tool CRLF handling", () => {
 		).rejects.toThrow(/Found 2 occurrences/);
 	});
 
-	// TODO: CRLF preservation broken by LSP formatting - fix later
-	it.skip("should preserve UTF-8 BOM after edit", async () => {
+	it("should preserve UTF-8 BOM and CRLF line endings after edit", async () => {
 		const testFile = path.join(testDir, "bom-test.txt");
 		fs.writeFileSync(testFile, "\uFEFFfirst\r\nsecond\r\nthird\r\n");
 
@@ -2006,7 +2005,8 @@ describe("edit tool CRLF handling", () => {
 			edits: [{ old_text: "second\n", new_text: "REPLACED\n" }],
 		});
 
-		const content = await Bun.file(testFile).text();
+		const content = fs.readFileSync(testFile, "utf8");
 		expect(content).toBe("\uFEFFfirst\r\nREPLACED\r\nthird\r\n");
+		expect([...fs.readFileSync(testFile).slice(0, 3)]).toEqual([0xef, 0xbb, 0xbf]);
 	});
 });


### PR DESCRIPTION
## Summary
- Preserve a leading UTF-8 BOM when edit replace mode reads files through Bun's text API.
- Restore the skipped BOM + CRLF edit regression test and assert the raw BOM bytes remain on disk.
- Keep existing CRLF/LF normalization behavior unchanged.

## Why
`Bun.file().text()` strips a UTF-8 BOM from the decoded string. Replace-mode edits used that decoded text as the source of truth, so BOM-prefixed files could be rewritten without the BOM even while preserving CRLF line endings. The edit reader now defensively checks the raw leading bytes and reattaches the BOM before normalization.

## Testing
- `bun test packages/coding-agent/test/tools.test.ts -t "edit tool CRLF handling"`
- `bunx biome check packages/coding-agent/src/edit/read-file.ts packages/coding-agent/test/tools.test.ts --no-errors-on-unmatched`
- `bun --cwd=packages/coding-agent run check:types`