### PR TITLE
fix(tui): allow cancelling empty select lists

### DIFF
--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -117,8 +117,15 @@ export class SelectList implements Component {
 	}
 
 	handleInput(keyData: string): void {
-		if (this.#filteredItems.length === 0) return;
 		const kb = getKeybindings();
+		// Escape or Ctrl+C must work even when the current filter has no matches.
+		if (kb.matches(keyData, "tui.select.cancel")) {
+			if (this.onCancel) {
+				this.onCancel();
+			}
+			return;
+		}
+		if (this.#filteredItems.length === 0) return;
 		// Up arrow - wrap to bottom when at top
 		if (kb.matches(keyData, "tui.select.up")) {
 			this.#selectedIndex = this.#selectedIndex === 0 ? this.#filteredItems.length - 1 : this.#selectedIndex - 1;
@@ -144,12 +151,6 @@ export class SelectList implements Component {
 			const selectedItem = this.#filteredItems[this.#selectedIndex];
 			if (selectedItem && this.onSelect) {
 				this.onSelect(selectedItem);
-			}
-		}
-		// Escape or Ctrl+C
-		else if (kb.matches(keyData, "tui.select.cancel")) {
-			if (this.onCancel) {
-				this.onCancel();
 			}
 		}
 	}

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -168,4 +168,24 @@ describe("SelectList", () => {
 
 		expect(selectedValue).toBe("run");
 	});
+	it("cancels even when the active filter has no matches", () => {
+		const items = [{ value: "run", label: "run" }];
+		const list = new SelectList(items, 5, testTheme);
+		let cancelCount = 0;
+		let selectedValue: string | undefined;
+		list.onCancel = () => {
+			cancelCount += 1;
+		};
+		list.onSelect = item => {
+			selectedValue = item.value;
+		};
+
+		list.setFilter("missing");
+		expect(list.render(80)).toEqual(["  No matching commands"]);
+		list.handleInput("\x1b");
+		list.handleInput("\n");
+
+		expect(cancelCount).toBe(1);
+		expect(selectedValue).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## Summary
- keep `SelectList` cancel handling active even when the current filter has zero matches
- preserve no-op behavior for confirm/navigation while empty
- add regression coverage for Esc on an empty filtered list

## Why
When a filtered command/selector list rendered `No matching commands`, `handleInput()` returned before checking cancel keys. That left users stuck in the selector until they edited the filter back to a match. Escape/Ctrl+C should always close the selector, even from the empty state.

## Tests
- `bun test packages/tui/test/select-list.test.ts`
- `bunx biome check packages/tui/src/components/select-list.ts packages/tui/test/select-list.test.ts`
- `bun --cwd=packages/tui run check:types`
- `bun --cwd=packages/tui run check`