### PR TITLE
fix(tui): keep settings-list selection valid when empty

### DIFF
--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -75,16 +75,20 @@ export class SettingsList implements Component {
 	 */
 	setItems(items: SettingItem[]): void {
 		this.#items = items;
-		if (this.#items.length === 0) {
-			this.#selectedIndex = 0;
-		} else if (this.#selectedIndex >= this.#items.length) {
-			this.#selectedIndex = this.#items.length - 1;
-		}
+		this.#clampSelectedIndex();
 		this.#notifySelectionChange();
 	}
 
 	invalidate(): void {
 		this.#submenuComponent?.invalidate?.();
+	}
+
+	#clampSelectedIndex(): void {
+		if (this.#items.length === 0) {
+			this.#selectedIndex = 0;
+			return;
+		}
+		this.#selectedIndex = Math.max(0, Math.min(this.#selectedIndex, this.#items.length - 1));
 	}
 
 	#notifySelectionChange(): void {
@@ -186,6 +190,11 @@ export class SettingsList implements Component {
 
 		// Main list input handling
 		const kb = getKeybindings();
+		if (kb.matches(data, "tui.select.cancel")) {
+			this.#onCancel();
+			return;
+		}
+		if (this.#items.length === 0) return;
 		if (kb.matches(data, "tui.select.up")) {
 			this.#selectedIndex = this.#selectedIndex === 0 ? this.#items.length - 1 : this.#selectedIndex - 1;
 			this.#notifySelectionChange();
@@ -194,8 +203,6 @@ export class SettingsList implements Component {
 			this.#notifySelectionChange();
 		} else if (kb.matches(data, "tui.select.confirm") || data === " " || data === "\n") {
 			this.#activateItem();
-		} else if (kb.matches(data, "tui.select.cancel")) {
-			this.#onCancel();
 		}
 	}
 
@@ -228,6 +235,7 @@ export class SettingsList implements Component {
 		// Restore selection to the item that opened the submenu
 		if (this.#submenuItemIndex !== null) {
 			this.#selectedIndex = this.#submenuItemIndex;
+			this.#clampSelectedIndex();
 			this.#submenuItemIndex = null;
 			this.#notifySelectionChange();
 		}

--- a/packages/tui/test/settings-list.test.ts
+++ b/packages/tui/test/settings-list.test.ts
@@ -44,4 +44,55 @@ describe("SettingsList", () => {
 
 		expect(changes).toEqual([["mode", "on"]]);
 	});
+	it("keeps selection valid after navigation while empty then repopulating", () => {
+		const changes: Array<[string, string]> = [];
+		let cancelCount = 0;
+		const list = new SettingsList(
+			[],
+			5,
+			testTheme,
+			(id, value) => {
+				changes.push([id, value]);
+			},
+			() => {
+				cancelCount += 1;
+			},
+		);
+
+		list.handleInput("\x1b[A");
+		list.handleInput("\x1b[B");
+		list.handleInput("\n");
+		list.setItems([
+			{
+				id: "mode",
+				label: "Mode",
+				currentValue: "off",
+				values: ["off", "on"],
+			},
+		]);
+		list.handleInput("\n");
+
+		expect(changes).toEqual([["mode", "on"]]);
+		expect(cancelCount).toBe(0);
+	});
+
+	it("cancels from an empty list", () => {
+		let cancelCount = 0;
+		const list = new SettingsList(
+			[],
+			5,
+			testTheme,
+			() => {
+				throw new Error("change should not be called");
+			},
+			() => {
+				cancelCount += 1;
+			},
+		);
+
+		expect(list.render(80)).toEqual(["  No settings available"]);
+		list.handleInput("\x1b");
+
+		expect(cancelCount).toBe(1);
+	});
 });


### PR DESCRIPTION
## Summary
- ignore navigation/confirm input while `SettingsList` has no rows, while still allowing cancel
- clamp negative/overflow selection indexes when rows are replaced or a submenu closes
- add regression coverage for empty-list navigation followed by repopulation

## Why
If a settings list was temporarily empty, Up/Down could move `#selectedIndex` to `-1` or `1`. A later `setItems()` only clamped overflow, not negative indexes, so the repopulated list could render with no selected row and Enter/Space would no-op. Empty settings views should remain cancellable and recover to a valid first selection when data arrives.

## Tests
- `bun test packages/tui/test/settings-list.test.ts`
- `bunx biome check packages/tui/src/components/settings-list.ts packages/tui/test/settings-list.test.ts`
- `bun --cwd=packages/tui run check`