### PR TITLE
fix(coding-agent): guard dequeue against a missing compaction queue

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- The dequeue shortcut (restore newest queued message to the editor) no longer crashes the input handler when the compaction queue is missing from the mode context — the same undefined-queue condition #1404 guarded on the escape/abort restore path.
 - Native Windows terminals now default `app.message.queue` to `Alt+Q` instead of `Alt+Enter`, avoiding the Windows Terminal fullscreen shortcut conflict (#1422).
 - Coordinator MCP tmux prompt delivery now submits with tmux `Enter` instead of `C-m`, while preserving runtime prompt-ack/`turn_start` as the delivery success gate (#1409).
 - The session-close resume hint now prints the `gjc --resume <id>` command on its own line so it can be selected and copied without the surrounding prose.

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -648,7 +648,7 @@ export class InputController {
 	}
 
 	restoreLatestQueuedMessageToEditor(options?: { currentText?: string }): number {
-		const compactionQueued = this.ctx.compactionQueuedMessages.pop();
+		const compactionQueued = (this.ctx.compactionQueuedMessages ?? []).pop();
 		const queuedText = compactionQueued?.text ?? this.ctx.session.popLastQueuedMessage();
 		if (!queuedText) {
 			this.ctx.updatePendingMessagesDisplay();

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -357,6 +357,22 @@ describe("InputController keybinding setup", () => {
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 	});
 
+	it("dequeues from the session queue when the compaction queue is missing", async () => {
+		// Same undefined-ctx condition #1404 guarded in restoreQueuedMessagesToEditor:
+		// the dequeue path must not crash on a missing compaction queue either.
+		const { InputController, ctx, editor, spies, queues } = await createContext();
+		(ctx as unknown as { compactionQueuedMessages?: unknown }).compactionQueuedMessages = undefined;
+		queues.sessionQueuedMessages.push("queued during stream");
+		editor.setText("current draft");
+		const controller = new InputController(ctx);
+
+		controller.handleDequeue();
+
+		expect(editor.getText()).toBe("queued during stream\n\ncurrent draft");
+		expect(queues.sessionQueuedMessages).toEqual([]);
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
 	it("steers streaming Enter submissions by default", async () => {
 		const { InputController, ctx, editor, spies } = await createContext();
 		const session = ctx.session as unknown as { isStreaming: boolean };


### PR DESCRIPTION
## What

One-line guard + regression test: the dequeue shortcut's `restoreLatestQueuedMessageToEditor` (added in #1403) calls `this.ctx.compactionQueuedMessages.pop()` unguarded. #1404 ("Fix escape abort with missing compaction queue") established that `ctx.compactionQueuedMessages` can be `undefined` at runtime and guarded the sibling escape/abort path (`restoreQueuedMessagesToEditor`, `?? []`) — but left the dequeue path one method above it unguarded.

**Failure scenario:** in the same undefined-queue context #1404 fixed, pressing the dequeue keybinding throws `TypeError: Cannot read properties of undefined (reading 'pop')` and crashes the input handler.

## Fix

Same `?? []` guard as #1404. Also adds the regression test that #1404 shipped without: with `compactionQueuedMessages` set to `undefined`, dequeue falls through to the session queue instead of crashing (using the existing `input-controller-keybindings.test.ts` harness).

## Tests

- `bun test packages/coding-agent/test/input-controller-keybindings.test.ts` — 22 pass (1 new).
- Changelog entry added under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
