### PR TITLE
fix(utils): avoid compact format boundary rollover

### DIFF
--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -33,9 +33,9 @@ export function formatDuration(ms: number): string {
 export function formatNumber(n: number): string {
 	if (n < 1_000) return n.toString();
 	if (n < 10_000) return `${trim1(n / 1_000)}K`;
-	if (n < 1_000_000) return `${Math.round(n / 1_000)}K`;
+	if (n < 1_000_000) return `${roundBelow(n / 1_000, 1_000)}K`;
 	if (n < 10_000_000) return `${trim1(n / 1_000_000)}M`;
-	if (n < 1_000_000_000) return `${Math.round(n / 1_000_000)}M`;
+	if (n < 1_000_000_000) return `${roundBelow(n / 1_000_000, 1_000)}M`;
 	if (n < 10_000_000_000) return `${trim1(n / 1_000_000_000)}B`;
 	return `${Math.round(n / 1_000_000_000)}B`;
 }
@@ -46,15 +46,26 @@ function trim1(n: number): string {
 	return s.endsWith(".0") ? s.slice(0, -2) : s;
 }
 
+/** Round to an integer without crossing the next compact suffix boundary. */
+function roundBelow(n: number, nextUnit: number): number {
+	return Math.min(Math.round(n), nextUnit - 1);
+}
+
 /**
  * Format a byte count to a human-readable string.
  * Examples: "512B", "1.5KB", "2.3MB", "1.2GB"
  */
 export function formatBytes(bytes: number): string {
 	if (bytes < 1024) return `${bytes}B`;
-	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
-	if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
-	return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}GB`;
+	if (bytes < 1024 * 1024) return `${formatByteUnit(bytes, 1024)}KB`;
+	if (bytes < 1024 * 1024 * 1024) return `${formatByteUnit(bytes, 1024 * 1024)}MB`;
+	return `${formatByteUnit(bytes, 1024 * 1024 * 1024)}GB`;
+}
+
+/** Format bytes to 1 decimal without rounding up into the next byte unit. */
+function formatByteUnit(bytes: number, unit: number): string {
+	const tenths = Math.min(Math.round((bytes / unit) * 10), 1024 * 10 - 1);
+	return (tenths / 10).toFixed(1);
 }
 
 /**

--- a/packages/utils/test/format.test.ts
+++ b/packages/utils/test/format.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { formatBytes, formatNumber } from "../src/format";
+
+describe("formatNumber", () => {
+	it("does not round K and M values into the next suffix", () => {
+		expect(formatNumber(999_499)).toBe("999K");
+		expect(formatNumber(999_999)).toBe("999K");
+		expect(formatNumber(1_000_000)).toBe("1M");
+		expect(formatNumber(999_999_999)).toBe("999M");
+		expect(formatNumber(1_000_000_000)).toBe("1B");
+	});
+});
+
+describe("formatBytes", () => {
+	it("does not round bytes into the next unit before the threshold", () => {
+		expect(formatBytes(1024 * 1024 - 1)).toBe("1023.9KB");
+		expect(formatBytes(1024 * 1024)).toBe("1.0MB");
+		expect(formatBytes(1024 * 1024 * 1024 - 1)).toBe("1023.9MB");
+		expect(formatBytes(1024 * 1024 * 1024)).toBe("1.0GB");
+	});
+});


### PR DESCRIPTION
## Summary
- prevent `formatNumber()` from displaying values below a suffix threshold as `1000K`/`1000M`
- prevent `formatBytes()` from rounding just-below-threshold values into `1024.0KB`/`1024.0MB`
- add boundary coverage for compact number and byte formatting

## Verification
- `bun test packages/utils/test/format.test.ts`
- `bun test packages/utils/test/*.test.ts` (101 pass)
- `bun run check` in `packages/utils`