### PR TITLE
perf(utils): precompile glob exclude patterns

### DIFF
--- a/packages/utils/src/glob.ts
+++ b/packages/utils/src/glob.ts
@@ -145,6 +145,8 @@ export async function globPaths(patterns: string | string[], options: GlobPathsO
 		effectiveExclude = [...effectiveExclude, ...gitignorePatterns];
 	}
 
+	const excludeGlobs = effectiveExclude.map(pattern => new Glob(pattern));
+
 	const base = cwd ?? getProjectDir();
 	const allResults: string[] = [];
 
@@ -171,17 +173,10 @@ export async function globPaths(patterns: string | string[], options: GlobPathsO
 
 			// Check exclusion patterns
 			const normalized = entry.replace(/\\/g, "/");
-			let excluded = false;
-			for (const excludePattern of effectiveExclude) {
-				const excludeGlob = new Glob(excludePattern);
-				if (excludeGlob.match(normalized)) {
-					excluded = true;
-					break;
-				}
+			if (excludeGlobs.some(excludeGlob => excludeGlob.match(normalized))) {
+				continue;
 			}
-			if (!excluded) {
-				allResults.push(normalized);
-			}
+			allResults.push(normalized);
 		}
 	}
 

--- a/packages/utils/test/glob.test.ts
+++ b/packages/utils/test/glob.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { globPaths } from "../src/glob";
+
+let tempDir: string | undefined;
+
+async function makeTempDir(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "gajae-glob-"));
+	return tempDir;
+}
+
+afterEach(async () => {
+	if (tempDir) {
+		await rm(tempDir, { recursive: true, force: true });
+		tempDir = undefined;
+	}
+});
+
+describe("globPaths", () => {
+	it("applies exclude patterns without dropping included files", async () => {
+		const cwd = await makeTempDir();
+		await mkdir(join(cwd, "src"), { recursive: true });
+		await mkdir(join(cwd, "dist"), { recursive: true });
+		await writeFile(join(cwd, "src", "keep.ts"), "export const keep = true;\n");
+		await writeFile(join(cwd, "dist", "skip.ts"), "export const skip = true;\n");
+
+		const results = await globPaths("**/*.ts", { cwd, exclude: ["dist/**"] });
+
+		expect(results.sort()).toEqual(["src/keep.ts"]);
+	});
+
+	it("keeps default node_modules excludes precompiled with custom excludes", async () => {
+		const cwd = await makeTempDir();
+		await mkdir(join(cwd, "node_modules", "pkg"), { recursive: true });
+		await mkdir(join(cwd, "src"), { recursive: true });
+		await writeFile(join(cwd, "node_modules", "pkg", "skip.ts"), "export {};\n");
+		await writeFile(join(cwd, "src", "skip.test.ts"), "export {};\n");
+		await writeFile(join(cwd, "src", "keep.ts"), "export {};\n");
+
+		const results = await globPaths("**/*.ts", { cwd, exclude: ["**/*.test.ts"] });
+
+		expect(results.sort()).toEqual(["src/keep.ts"]);
+	});
+});


### PR DESCRIPTION
## Summary
- precompile `globPaths()` exclude patterns once per call instead of constructing a `Glob` for every scanned entry and pattern
- keep existing default excludes (`.git`, `node_modules`) and custom excludes behavior
- add coverage for custom excludes and default node_modules filtering

## Verification
- `bun test test/glob.test.ts` in `packages/utils`
- `bun test test/*.test.ts` in `packages/utils` (101 pass)
- `bun run check` in `packages/utils`