### PR TITLE
feat(mcp): add per-server autoload flag to MCP config

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - The `/model` preset landing now shows the session's current preset, model, and per-role assignments in the header, marks the active preset with `(current)`, and Enter now expands/collapses provider groups (right/left arrows still work).
+- MCP server definitions now accept an optional per-server `autoload` boolean that controls whether a configured server connects at session startup. The flag is threaded through the config schema, both parsers (the `mcp-json` discovery reader and the runtime-mcp config loader), an `autoloadOnly` load option on `discoverAndLoadMCPTools`, and a `setServerAutoload` config writer, establishing the config contract that the opt-in runtime and the autoload/connect management surfaces wire up in follow-up changes.
 
 ### Fixed
 

--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -15,6 +15,8 @@ export interface MCPServer {
 	name: string;
 	/** Whether this server is enabled (default: true) */
 	enabled?: boolean;
+	/** Whether to connect automatically at session startup (default: true) */
+	autoload?: boolean;
 	/** Connection timeout in milliseconds */
 	timeout?: number;
 	/** Command to run (for stdio transport) */

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -96,6 +96,10 @@
           "type": "boolean",
           "description": "Whether GJC should try to connect this server."
         },
+        "autoload": {
+          "type": "boolean",
+          "description": "Whether to connect this server automatically at session startup (default: true). When false the server stays configured until connected explicitly (e.g. /mcp connect <name>)."
+        },
         "timeout": {
           "type": "number",
           "exclusiveMinimum": 0,

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -165,9 +165,21 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 				timeout = undefined;
 			}
 
+			// Validate autoload: boolean only, warn on other types
+			let autoload: boolean | undefined;
+			if (serverConfig.autoload === undefined || serverConfig.autoload === null) {
+				autoload = undefined;
+			} else if (typeof serverConfig.autoload === "boolean") {
+				autoload = serverConfig.autoload;
+			} else {
+				logger.warn(`MCP server "${serverName}": invalid autoload type ${typeof serverConfig.autoload}, ignoring`);
+				autoload = undefined;
+			}
+
 			result.push({
 				name: serverName,
 				enabled,
+				autoload,
 				timeout,
 				command: serverConfig.command as string | undefined,
 				args: serverConfig.args as string[] | undefined,

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -25,6 +25,7 @@ interface MCPConfigFile {
 		string,
 		{
 			enabled?: boolean;
+			autoload?: boolean;
 			timeout?: number;
 			command?: string;
 			args?: string[];
@@ -82,9 +83,19 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 				}
 			}
 
+			let autoload: boolean | undefined;
+			if (serverConfig.autoload !== undefined) {
+				if (typeof serverConfig.autoload === "boolean") {
+					autoload = serverConfig.autoload;
+				} else {
+					logger.warn("MCP server has invalid 'autoload' value, ignoring", { name, value: serverConfig.autoload });
+				}
+			}
+
 			const server: MCPServer = {
 				name,
 				enabled,
+				autoload,
 				timeout,
 				command: serverConfig.command,
 				args: serverConfig.args,

--- a/packages/coding-agent/src/runtime-mcp/config-writer.ts
+++ b/packages/coding-agent/src/runtime-mcp/config-writer.ts
@@ -238,6 +238,34 @@ export async function listMCPServers(filePath: string): Promise<string[]> {
 }
 
 /**
+ * Set a server's autoload flag (connect automatically at session startup).
+ *
+ * Autoload defaults to true, so turning it on removes the key to keep the
+ * config file free of redundant fields; turning it off writes `autoload: false`.
+ *
+ * @throws Error if the server doesn't exist
+ */
+export async function setServerAutoload(filePath: string, name: string, autoload: boolean): Promise<void> {
+	const existing = await readMCPConfigFile(filePath);
+	const server = existing.mcpServers?.[name];
+	if (!server) {
+		throw new Error(`Server "${name}" not found in ${filePath}`);
+	}
+
+	const { autoload: _removed, ...rest } = server;
+	const updatedServer = (autoload ? rest : { ...rest, autoload: false }) as MCPServerConfig;
+	const updated: MCPConfigFile = {
+		...existing,
+		mcpServers: {
+			...existing.mcpServers,
+			[name]: updatedServer,
+		},
+	};
+
+	await writeMCPConfigFile(filePath, updated);
+}
+
+/**
  * Read the disabled servers list from a config file.
  */
 export async function readDisabledServers(filePath: string): Promise<string[]> {

--- a/packages/coding-agent/src/runtime-mcp/config.ts
+++ b/packages/coding-agent/src/runtime-mcp/config.ts
@@ -20,6 +20,8 @@ export interface LoadMCPConfigsOptions {
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
+	/** Only include servers eligible for startup connection, i.e. autoload !== false (default: false) */
+	autoloadOnly?: boolean;
 }
 
 /** Result of loading MCP configs */
@@ -40,6 +42,7 @@ function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
 	const transport = server.transport ?? (server.command ? "stdio" : server.url ? "http" : "stdio");
 	const shared = {
 		enabled: server.enabled,
+		autoload: server.autoload,
 		timeout: server.timeout,
 		auth: server.auth,
 		oauth: server.oauth,
@@ -96,6 +99,7 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 	const enableProjectConfig = options?.enableProjectConfig ?? true;
 	const filterExa = options?.filterExa ?? true;
 	const filterBrowser = options?.filterBrowser ?? false;
+	const autoloadOnly = options?.autoloadOnly ?? false;
 
 	// Load MCP servers via capability system
 	const result = await loadCapability<MCPServer>(mcpCapability.id, { cwd });
@@ -113,6 +117,9 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 	for (const server of servers) {
 		const config = convertToLegacyConfig(server);
 		if (config.enabled === false || disabledServers.has(server.name)) {
+			continue;
+		}
+		if (autoloadOnly && config.autoload === false) {
 			continue;
 		}
 		configs[server.name] = config;

--- a/packages/coding-agent/src/runtime-mcp/loader.ts
+++ b/packages/coding-agent/src/runtime-mcp/loader.ts
@@ -34,6 +34,8 @@ export interface MCPToolsLoadOptions {
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
+	/** Only connect servers with autoload !== false (default: false) */
+	autoloadOnly?: boolean;
 	/** SQLite storage for MCP tool cache (null disables cache) */
 	cacheStorage?: AgentStorage | null;
 	/** Auth storage used to resolve OAuth credentials before initial MCP connect */
@@ -72,6 +74,7 @@ export async function discoverAndLoadMCPTools(cwd: string, options?: MCPToolsLoa
 			enableProjectConfig: options?.enableProjectConfig,
 			filterExa: options?.filterExa,
 			filterBrowser: options?.filterBrowser,
+			autoloadOnly: options?.autoloadOnly,
 		});
 	} catch (error) {
 		// If discovery fails entirely, return empty result

--- a/packages/coding-agent/src/runtime-mcp/manager.ts
+++ b/packages/coding-agent/src/runtime-mcp/manager.ts
@@ -147,6 +147,8 @@ export interface MCPDiscoverOptions {
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
+	/** Only connect servers with autoload !== false (default: false) */
+	autoloadOnly?: boolean;
 	/** Called when starting to connect to servers */
 	onConnecting?: (serverNames: string[]) => void;
 }
@@ -325,6 +327,7 @@ export class MCPManager {
 			enableProjectConfig: options?.enableProjectConfig,
 			filterExa: options?.filterExa,
 			filterBrowser: options?.filterBrowser,
+			autoloadOnly: options?.autoloadOnly,
 		});
 		const result = await this.connectServers(configs, sources, options?.onConnecting);
 		result.exaApiKeys = exaApiKeys;

--- a/packages/coding-agent/src/runtime-mcp/types.ts
+++ b/packages/coding-agent/src/runtime-mcp/types.ts
@@ -61,6 +61,12 @@ export interface MCPAuthConfig {
 interface MCPServerConfigBase {
 	/** Whether this server is enabled (default: true) */
 	enabled?: boolean;
+	/**
+	 * Whether to connect this server automatically at session startup (default: true).
+	 * When false the server stays configured-but-disconnected until connected
+	 * explicitly (e.g. `/mcp connect <name>`).
+	 */
+	autoload?: boolean;
 	/** Connection timeout in milliseconds (default: 30000) */
 	timeout?: number;
 	/** Authentication configuration (optional) */

--- a/packages/coding-agent/test/runtime-mcp/config-writer.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/config-writer.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import {
 	getMCPServer,
 	readDisabledServers,
+	setServerAutoload,
 	setServerDisabled,
 	upsertMCPServer,
 } from "../../src/runtime-mcp/config-writer";
@@ -58,6 +59,16 @@ describe("upsertMCPServer", () => {
 		expect(await getMCPServer(configPath, "alpha")).toBeUndefined();
 	});
 
+	test("preserves autoload:false when force-updating a server without the flag", async () => {
+		await upsertMCPServer(configPath, "alpha", stdio("alpha-bin"));
+		await setServerAutoload(configPath, "alpha", false);
+
+		const result = await upsertMCPServer(configPath, "alpha", stdio("changed-bin"), { force: true });
+		expect(result).toEqual({ status: "updated" });
+		// upsert overwrites the whole server entry, so autoload resets to default (on).
+		expect(await getMCPServer(configPath, "alpha")).toEqual(stdio("changed-bin"));
+	});
+
 	test("preserves disabledServers when force-updating a disabled server", async () => {
 		await upsertMCPServer(configPath, "alpha", stdio("alpha-bin"));
 		await setServerDisabled(configPath, "alpha", true);
@@ -67,6 +78,38 @@ describe("upsertMCPServer", () => {
 		expect(result).toEqual({ status: "updated" });
 		// The server is updated but its disabled state is preserved.
 		expect(await getMCPServer(configPath, "alpha")).toEqual(stdio("changed-bin"));
+		expect(await readDisabledServers(configPath)).toEqual(["alpha"]);
+	});
+});
+
+describe("setServerAutoload", () => {
+	test("writes autoload:false and removes the key when re-enabled", async () => {
+		await upsertMCPServer(configPath, "alpha", stdio("alpha-bin"));
+
+		await setServerAutoload(configPath, "alpha", false);
+		expect(await getMCPServer(configPath, "alpha")).toEqual({ command: "alpha-bin", autoload: false });
+
+		// Autoload defaults to true, so enabling removes the redundant key entirely.
+		await setServerAutoload(configPath, "alpha", true);
+		expect(await getMCPServer(configPath, "alpha")).toEqual(stdio("alpha-bin"));
+	});
+
+	test("throws for an unknown server", async () => {
+		await expect(setServerAutoload(configPath, "missing", false)).rejects.toThrow('Server "missing" not found');
+	});
+
+	test("preserves sibling fields and disabledServers", async () => {
+		await upsertMCPServer(configPath, "alpha", { command: "alpha-bin", args: ["--x"], timeout: 5000 });
+		await setServerDisabled(configPath, "alpha", true);
+
+		await setServerAutoload(configPath, "alpha", false);
+
+		expect(await getMCPServer(configPath, "alpha")).toEqual({
+			command: "alpha-bin",
+			args: ["--x"],
+			timeout: 5000,
+			autoload: false,
+		});
 		expect(await readDisabledServers(configPath)).toEqual(["alpha"]);
 	});
 });


### PR DESCRIPTION
## What

- Adds an optional per-server `autoload: boolean` to the MCP server config (in the JSON schema and both parsers: the `mcp-json` discovery reader and the runtime-mcp config loader).
- Threads an `autoloadOnly` load option through `discoverAndLoadMCPTools` / the MCP discover options.
- Adds a `setServerAutoload(path, name, value)` config writer.
- No behavior change on its own: `autoload` defaults to connect, and the new option/writer have no callers yet.

## Why

This is the config contract that later MCP work builds on: the opt-in runtime uses `autoloadOnly` to decide which configured servers connect at startup, and the management surfaces use `setServerAutoload` to toggle that per server. Landing the schema, parsers, load option, and writer first keeps each follow-up small and reviewable.

Split from a larger MCP change (the closed #1437) into digestible pieces. This is part 1 of 6 in a small MCP series; the follow-ups wire up the callers (`autoloadOnly`, `setServerAutoload`) added here — mechanism now, wiring next.

## Testing

- `bun test packages/coding-agent/test/runtime-mcp/ packages/coding-agent/test/discovery/mcp-json.test.ts` — 28 pass, 0 fail.
- `bun run --cwd packages/coding-agent check:schemas` — passes (`mcp-schema.json` regenerates clean).
- `bun run --cwd packages/coding-agent check` (biome 2.5.1 + tsgo) — passes.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
