### PR TITLE
Fix startup model profile refresh for discovered models

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -223,6 +223,9 @@ export async function applyStartupModelProfiles(args: {
 	const explicitModel = args.parsedArgs.model ? (args.startupModel ?? args.session.model) : undefined;
 
 	const defaultProfile = args.settings.get("modelProfile.default");
+	if (defaultProfile || args.parsedArgs.mpreset) {
+		await args.modelRegistry.refresh("online-if-uncached");
+	}
 	if (defaultProfile) {
 		await applyProfile(defaultProfile, false);
 	}

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -11,14 +11,21 @@ import type { AgentSession } from "../src/session/agent-session";
 const model = (provider: string, id: string): Model =>
 	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
 
-function fakeRegistry(profiles: ModelProfileDefinition[]) {
+function fakeRegistry(
+	profiles: ModelProfileDefinition[],
+	options?: { afterRefreshModels?: Model[]; initialModels?: Model[] },
+) {
 	const profileMap = new Map(profiles.map(profile => [profile.name, profile]));
+	let models = options?.initialModels ?? [model("profile-provider", "default"), model("cli-provider", "explicit")];
 	return {
 		getModelProfile: (name: string) => profileMap.get(name),
 		getModelProfiles: () => new Map(profileMap),
 		getAvailableModelProfileNames: () => [...profileMap.keys()].sort(),
 		getApiKeyForProvider: async () => "key",
-		getAll: () => [model("profile-provider", "default"), model("cli-provider", "explicit")],
+		getAll: () => models,
+		refresh: async () => {
+			models = options?.afterRefreshModels ?? models;
+		},
 	};
 }
 
@@ -112,6 +119,32 @@ test("deferred explicit CLI --model is reapplied after --mpreset activation", as
 	).toEqual(["profile-provider/default:high", "cli-provider/explicit:undefined"]);
 	expect(session.setModelTemporaryCalls.at(-1)?.model).toBe(explicitModel);
 	expect(session.model).toBe(explicitModel);
+});
+
+test("default profile refreshes live-discovered models before activation", async () => {
+	const session = fakeSession();
+	const settings = Settings.isolated({ "modelProfile.default": "antigravity-flash" });
+	const liveModel = model("google-antigravity", "gemini-3.5-flash-low");
+
+	await applyStartupModelProfiles({
+		session,
+		settings,
+		modelRegistry: fakeRegistry(
+			[
+				{
+					name: "antigravity-flash",
+					requiredProviders: ["google-antigravity"],
+					modelMapping: { default: "google-antigravity/gemini-3.5-flash-low" },
+					source: "user",
+				},
+			],
+			{ initialModels: [], afterRefreshModels: [liveModel] },
+		) as never,
+		parsedArgs: {},
+	});
+
+	expect(session.setModelTemporaryCalls).toHaveLength(1);
+	expect(session.model).toBe(liveModel);
 });
 
 test("ACP session factory applies default profile and --mpreset before returning session", async () => {


### PR DESCRIPTION
## 요약

안녕하세요. 이전 PR(#1446)이 `main` 대상이라 닫혀서, 같은 수정 내용을 `dev` 기준 브랜치로 다시 올립니다.

시작 시 모델 프로필을 적용하기 전에 모델 레지스트리를 한 번 갱신하도록 수정했습니다.

`modelProfile.default` 또는 `--mpreset`으로 프로필을 적용하는 경우, live discovery로만 들어오는 모델이 아직 `modelRegistry.getAll()`에 없으면 프로필 해석이 실패할 수 있었습니다. 특히 비대화형 실행이나 Telegram/daemon 세션처럼 모델 선택 TUI를 띄우지 않으려는 환경에서, `gjc --list-models`에는 보이는 모델을 `models.yml` 프로필에 넣어도 시작 시 `default selector did not resolve`로 실패할 수 있었습니다.

이번 변경은 startup profile activation 직전에 `online-if-uncached` refresh를 수행해서, live-discovered 모델도 프로필 해석 대상에 포함되도록 합니다.

## 변경 내용

- `modelProfile.default` 또는 `--mpreset`이 있을 때 startup profile 적용 전에 `modelRegistry.refresh("online-if-uncached")`를 호출했습니다.
- refresh 이후에만 나타나는 모델을 기본 프로필이 정상 적용하는 회귀 테스트를 추가했습니다.

## 중복 확인

PR 작성 전에 아래 키워드로 open/closed issue 및 PR을 확인했지만, 같은 내용으로 보이는 항목은 찾지 못했습니다.

- `gemini-3.5-flash model profile`
- `default selector did not resolve`
- `startup model profile refresh`
- `discovered models profile`

## 검증

아래 명령으로 확인했습니다.

- `bun install --frozen-lockfile`
- `bun run build:native`
- `bun test packages/coding-agent/test/cli-args-mpreset.test.ts`
- `bunx biome check packages/coding-agent/src/main.ts packages/coding-agent/test/cli-args-mpreset.test.ts`
- `bun run check:node20-baseline`
- `bun --cwd=packages/coding-agent run check:types`

감사합니다.
