### PR TITLE
Keep public project links resolvable

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
   - name: Model Configuration
-    url: https://github.com/can1357/gajae-code/blob/main/docs/models.md
+    url: https://github.com/Yeachan-Heo/gajae-code/blob/main/docs/models.md
     about: How to add custom providers and models via models.yml
-  - name: Extensions Guide
-    url: https://github.com/can1357/gajae-code/blob/main/docs/extensions.md
-    about: Build custom tools, commands, and integrations
+  - name: Plugin Bundles
+    url: https://github.com/Yeachan-Heo/gajae-code/blob/main/docs/gjc-plugins.md
+    about: Build and distribute GJC plugin bundles
   - name: Skills Documentation
-    url: https://github.com/can1357/gajae-code/blob/main/docs/skills.md
-    about: How to create and use skills
+    url: https://gajae-code.com/docs/skills.html
+    about: Create and use workflow skills

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -9,7 +9,7 @@ Only the latest release is supported with security updates.
 To report a security issue, either:
 
 - Email can1357 directly, or
-- Open a [private security advisory](https://github.com/can1357/gajae-code/security/advisories/new) on GitHub
+- Open a [private security advisory](https://github.com/Yeachan-Heo/gajae-code/security/advisories/new) on GitHub
 
 Include steps to reproduce and any relevant details. Do not open a public issue for security vulnerabilities.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ version = "0.7.11"
 edition = "2024"
 license = "MIT"
 authors = ["Yeachan-Heo"]
-homepage = "https://gaebal-gajae.dev/"
-repository = "https://github.com/can1357/gajae-code"
+homepage = "https://gajae-code.com/"
+repository = "https://github.com/Yeachan-Heo/gajae-code"
 
 [patch.crates-io]
 brush-core = { path = "crates/brush-core-vendored" }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -3,7 +3,7 @@
 	"name": "@gajae-code/agent-core",
 	"version": "0.7.11",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"contributors": [
 		"Mario Zechner"
@@ -11,11 +11,11 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/agent"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"keywords": [
 		"ai",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -3,7 +3,7 @@
 	"name": "@gajae-code/ai",
 	"version": "0.7.11",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"contributors": [
 		"Mario Zechner"
@@ -11,11 +11,11 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/ai"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"keywords": [
 		"ai",

--- a/packages/bridge-client/package.json
+++ b/packages/bridge-client/package.json
@@ -3,16 +3,16 @@
 	"name": "@gajae-code/bridge-client",
 	"version": "0.7.11",
 	"description": "TypeScript client SDK for the GJC backend bridge protocol",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/bridge-client"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"keywords": [
 		"gjc",

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -4,7 +4,7 @@ Core implementation package for the `gjc` coding agent in the `gajae-code` monor
 
 For installation, setup, provider configuration, model roles, slash commands, and full CLI reference, see:
 - [Monorepo README (local)](../../README.md)
-- [Monorepo README (GitHub)](https://github.com/can1357/gajae-code#readme)
+- [Monorepo README (GitHub)](https://github.com/Yeachan-Heo/gajae-code#readme)
 
 Package-specific references:
 - [CHANGELOG](./CHANGELOG.md)

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -3,7 +3,7 @@
 	"name": "@gajae-code/coding-agent",
 	"version": "0.7.11",
 	"description": "Gajae Code CLI with read, bash, edit, write tools and session management",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"contributors": [
 		"Mario Zechner"
@@ -11,11 +11,11 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/coding-agent"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"keywords": [
 		"coding-agent",

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/can1357/gajae-code/main/packages/coding-agent/src/config/mcp-schema.json",
+  "$id": "https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/packages/coding-agent/src/config/mcp-schema.json",
   "title": "GJC MCP configuration",
   "description": "Schema for mcp.json, .mcp.json, .gjc/mcp.json, and ~/.gjc/agent/mcp.json used by the GJC coding agent.",
   "type": "object",

--- a/packages/gajae-code/package.json
+++ b/packages/gajae-code/package.json
@@ -3,7 +3,7 @@
 	"name": "gajae-code",
 	"version": "0.7.11",
 	"description": "One-line npm install wrapper for the Gajae-Code gjc CLI",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"contributors": [
 		"Mario Zechner"
@@ -11,11 +11,11 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/gajae-code"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"keywords": [
 		"coding-agent",

--- a/packages/natives-darwin-arm64/package.json
+++ b/packages/natives-darwin-arm64/package.json
@@ -3,16 +3,16 @@
 	"version": "0.7.11",
 	"description": "Darwin arm64 native addon for @gajae-code/natives",
 	"type": "module",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/natives-darwin-arm64"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"os": [
 		"darwin"

--- a/packages/natives-darwin-x64/package.json
+++ b/packages/natives-darwin-x64/package.json
@@ -3,16 +3,16 @@
 	"version": "0.7.11",
 	"description": "Darwin x64 native addon for @gajae-code/natives",
 	"type": "module",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/natives-darwin-x64"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"os": [
 		"darwin"

--- a/packages/natives-linux-arm64/package.json
+++ b/packages/natives-linux-arm64/package.json
@@ -3,16 +3,16 @@
 	"version": "0.7.11",
 	"description": "Linux arm64 native addon for @gajae-code/natives",
 	"type": "module",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/natives-linux-arm64"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"os": [
 		"linux"

--- a/packages/natives-linux-x64/package.json
+++ b/packages/natives-linux-x64/package.json
@@ -3,16 +3,16 @@
 	"version": "0.7.11",
 	"description": "Linux x64 native addons for @gajae-code/natives",
 	"type": "module",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/natives-linux-x64"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"os": [
 		"linux"

--- a/packages/natives-win32-x64/package.json
+++ b/packages/natives-win32-x64/package.json
@@ -3,16 +3,16 @@
 	"version": "0.7.11",
 	"description": "Windows x64 native addon for @gajae-code/natives",
 	"type": "module",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/natives-win32-x64"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"os": [
 		"win32"

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -361,7 +361,7 @@ function buildHelpMessage(ctx) {
 		const expectedPaths = ctx.addonFilenames.map(filename => `  ${path.join(ctx.versionedDir, filename)}`).join("\n");
 		const downloadHints = ctx.addonFilenames
 			.map(filename => {
-				const downloadUrl = `https://github.com/can1357/gajae-code/releases/latest/download/${filename}`;
+				const downloadUrl = `https://github.com/Yeachan-Heo/gajae-code/releases/latest/download/${filename}`;
 				const targetPath = path.join(ctx.versionedDir, filename);
 				return `  curl -fsSL "${downloadUrl}" -o "${targetPath}"`;
 			})

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -3,16 +3,16 @@
 	"version": "0.7.11",
 	"description": "Native Rust bindings for grep, clipboard, image processing, syntax highlighting, PTY, and shell operations via N-API",
 	"type": "module",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/natives"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"keywords": [
 		"napi",

--- a/packages/orchestration-token-benchmark/package.json
+++ b/packages/orchestration-token-benchmark/package.json
@@ -8,7 +8,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/orchestration-token-benchmark"
 	},
 	"main": "./src/index.ts",
@@ -28,5 +28,5 @@
 	"engines": {
 		"bun": ">=1.3.14"
 	},
-	"homepage": "https://gaebal-gajae.dev"
+	"homepage": "https://gajae-code.com"
 }

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -3,16 +3,16 @@
 	"name": "@gajae-code/stats",
 	"version": "0.7.11",
 	"description": "Local observability dashboard for pi AI usage statistics",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/stats"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"keywords": [
 		"ai",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -3,7 +3,7 @@
 	"name": "@gajae-code/tui",
 	"version": "0.7.11",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"contributors": [
 		"Mario Zechner"
@@ -11,11 +11,11 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/tui"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"keywords": [
 		"tui",

--- a/packages/typescript-edit-benchmark/package.json
+++ b/packages/typescript-edit-benchmark/package.json
@@ -8,7 +8,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/typescript-edit-benchmark"
 	},
 	"main": "./src/index.ts",
@@ -47,5 +47,5 @@
 	"engines": {
 		"bun": ">=1.3.14"
 	},
-	"homepage": "https://gaebal-gajae.dev"
+	"homepage": "https://gajae-code.com"
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,16 +3,16 @@
 	"name": "@gajae-code/utils",
 	"version": "0.7.11",
 	"description": "Shared utilities for pi packages",
-	"homepage": "https://gaebal-gajae.dev",
+	"homepage": "https://gajae-code.com",
 	"author": "Yeachan-Heo",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gajae-ai/gajae-code.git",
+		"url": "git+https://github.com/Yeachan-Heo/gajae-code.git",
 		"directory": "packages/utils"
 	},
 	"bugs": {
-		"url": "https://github.com/gajae-ai/gajae-code/issues"
+		"url": "https://github.com/Yeachan-Heo/gajae-code/issues"
 	},
 	"keywords": [
 		"utilities",


### PR DESCRIPTION
## Summary
- Replaces retired project URLs across package metadata, Cargo metadata, security reporting, the MCP schema id, and native-loader recovery guidance.
- Opens this as a fresh dev-based replacement for #1450 after the requested-changes review found two issue-template links resolving to 404.
- Retargets the issue-template contact links to verified pages: docs/models.md, docs/gjc-plugins.md, and https://gajae-code.com/docs/skills.html.

## Verification
- curl returned 200 for all three issue-template contact links.
- jq empty over packages/*/package.json.
- jq empty packages/coding-agent/src/config/mcp-schema.json.
- cargo metadata --no-deps --format-version 1.
- git diff --cached --check.
- rg stale URL scan over changed public-link surfaces returned no matches.

## Not tested
- Full Bun workspace checks were not run because dependency install/lifecycle scripts were not approved.