### PR TITLE
fix(notifications): resume Telegram sessions from saved cwd

### DIFF
--- a/packages/coding-agent/src/notifications/lifecycle-control-runtime.ts
+++ b/packages/coding-agent/src/notifications/lifecycle-control-runtime.ts
@@ -238,6 +238,7 @@ export function daemonResumeSession(env: NodeJS.ProcessEnv = process.env, opts: 
 		// restart, so an unknown or ambiguous prefix fails closed instead of
 		// blindly spawning `gjc --resume <prefix>` against a non-authoritative id.
 		let resumeId = target.sessionIdOrPrefix;
+		let resumeCwd = target.path;
 		if (opts.sessionsRoot) {
 			const saved = listRecentSessions({ sessionsRoot: opts.sessionsRoot, limit: 1000 });
 			const prefixed = saved.filter(
@@ -249,11 +250,19 @@ export function daemonResumeSession(env: NodeJS.ProcessEnv = process.env, opts: 
 			if (resolved.length > 1) {
 				return { ambiguous: resolved.map(s => ({ sessionId: s.sessionId, path: s.path })) };
 			}
-			resumeId = resolved[0]!.sessionId;
+			const selected = resolved[0]!;
+			resumeId = selected.sessionId;
+			resumeCwd = selected.path;
+		}
+		const resolvedResumeCwd = resumeCwd ? path.resolve(resumeCwd) : undefined;
+		const resumeCwdStat = resolvedResumeCwd ? fs.statSync(resolvedResumeCwd, { throwIfNoEntry: false }) : undefined;
+		if (!resumeCwdStat?.isDirectory()) {
+			throw new Error(`gjc_lifecycle_resume_cwd_unavailable: ${resolvedResumeCwd ?? "(missing)"}`);
 		}
 		const tmux = resolveGjcTmuxCommand(env);
 		const name = tmuxSessionNameFor(resumeId);
-		const command = `exec env GJC_TMUX_LAUNCHED=1 GJC_NOTIFICATIONS=1 gjc --resume ${shellQuote(resumeId)}`;
+		const cwdPrefix = resolvedResumeCwd ? `cd ${shellQuote(resolvedResumeCwd)} && ` : "";
+		const command = `${cwdPrefix}exec env GJC_TMUX_LAUNCHED=1 GJC_NOTIFICATIONS=1 gjc --resume ${shellQuote(resumeId)}`;
 		const r = Bun.spawnSync([tmux, "new-session", "-d", "-s", name, "sh", "-c", command], {
 			stdout: "pipe",
 			stderr: "pipe",
@@ -261,7 +270,7 @@ export function daemonResumeSession(env: NodeJS.ProcessEnv = process.env, opts: 
 		});
 		if (r.exitCode !== 0) throw new Error(r.stderr.toString().trim() || "gjc_lifecycle_resume_failed");
 		const tgt = buildGjcTmuxExactOptionTarget(name);
-		for (const cmd of buildGjcTmuxProfileCommands(tgt, env, { sessionId: resumeId })) {
+		for (const cmd of buildGjcTmuxProfileCommands(tgt, env, { sessionId: resumeId, project: resolvedResumeCwd })) {
 			Bun.spawnSync([tmux, ...cmd.args], { stdout: "pipe", stderr: "pipe", env });
 		}
 		return {

--- a/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
@@ -243,4 +243,43 @@ describe("lifecycle control runtime", () => {
 
 		fs.rmSync(root, { recursive: true, force: true });
 	});
+
+	it("daemonResumeSession cold-restarts saved sessions from their recorded cwd", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-resume-cwd-"));
+		const proj = path.join(root, "saved-project");
+		const sessionsDir = path.join(root, "encoded-project");
+		const callsFile = path.join(root, "tmux-calls.log");
+		const tmux = path.join(root, "fake-tmux.sh");
+		fs.mkdirSync(proj, { recursive: true });
+		fs.mkdirSync(sessionsDir, { recursive: true });
+		fs.writeFileSync(path.join(sessionsDir, "abc123.jsonl"), `${JSON.stringify({ id: "abc123", cwd: proj })}\n`);
+		fs.writeFileSync(
+			tmux,
+			[
+				"#!/usr/bin/env bash",
+				'printf \'%s\\n\' "$*" >> "$TMUX_CALLS"',
+				'if [ "$1" = "list-sessions" ]; then',
+				"  echo 'no server running' >&2",
+				"  exit 1",
+				"fi",
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+		fs.chmodSync(tmux, 0o755);
+
+		const resume = daemonResumeSession(
+			{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_CALLS: callsFile },
+			{ sessionsRoot: root },
+		);
+		const result = await resume({ sessionIdOrPrefix: "abc123" });
+
+		expect("mode" in result && result.mode).toBe("cold_restarted");
+		const calls = fs.readFileSync(callsFile, "utf8");
+		expect(calls).toContain("new-session -d -s gjc_lc_abc123 sh -c");
+		expect(calls).toContain(`cd '${proj}' && exec env GJC_TMUX_LAUNCHED=1 GJC_NOTIFICATIONS=1 gjc --resume 'abc123'`);
+		expect(calls).toContain(`@gjc-project ${proj}`);
+
+		fs.rmSync(root, { recursive: true, force: true });
+	});
 });


### PR DESCRIPTION
## Summary

Fix Telegram `/session_resume <id|prefix>` cold restarts so they run from the saved session cwd instead of the daemon owner cwd.

## Why

The Telegram daemon is shared by Telegram identity, not by session. Previously a cold resume ran `gjc --resume <id>` from the daemon cwd. If the saved session belonged to another repo, `main.ts` could show the interactive cross-project prompt:

```text
Session found in different project: ... Fork into current directory? [y/N]
```

Telegram cannot answer that prompt, so the resume flow stalled instead of reopening the intended session.

## Details

The daemon now resolves the saved session cwd from history, starts `gjc --resume` from that cwd, fails closed if the cwd is unavailable, and records the saved project path on the recreated tmux session.

## Tests

- `bun test packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts`
- `bun x biome check packages/coding-agent/src/notifications/lifecycle-control-runtime.ts packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts`
- `rtk git diff --check`
- Manual: linked local checkout, reloaded Telegram daemon from source, verified `/session_resume <id>` no longer blocks on the cross-project fork prompt