### PR TITLE
Fix startup model profile refresh without duplicate discovery

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -191,6 +191,10 @@ function applyExtensionFlagValues(session: AgentSession, rawArgs: string[]): Map
 
 type AcpSessionFactory = (cwd: string) => Promise<AgentSession>;
 
+function hasStartupModelProfile(settings: Settings, parsedArgs: Pick<Args, "mpreset">): boolean {
+	return Boolean(settings.get("modelProfile.default") || parsedArgs.mpreset);
+}
+
 export interface AcpSessionFactoryOptions {
 	baseOptions: CreateAgentSessionOptions;
 	settings: Settings;
@@ -963,13 +967,20 @@ export async function runRootCommand(
 		}
 	}
 
+	const startupModelProfileRefreshNeeded = hasStartupModelProfile(settingsInstance, parsedArgs);
+	if (startupModelProfileRefreshNeeded) {
+		await modelRegistry.refresh("online-if-uncached");
+	}
+
 	const createAgentSessionImpl = deps.createAgentSession ?? createAgentSession;
 	const createSession = async (options: CreateAgentSessionOptions): Promise<CreateAgentSessionResult> => {
 		const result = await logger.time("createAgentSession", createAgentSessionImpl, options);
 		// Kick off background model discovery only after createAgentSession finishes its parallel
 		// discovery arms; running these concurrently contends for the event loop and stretches
 		// every parallel arm by ~30ms.
-		modelRegistry.refreshInBackground();
+		if (!startupModelProfileRefreshNeeded) {
+			modelRegistry.refreshInBackground();
+		}
 		return result;
 	};
 

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -1,24 +1,35 @@
 import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
+import { TempDir } from "@gajae-code/utils";
 import { parseArgs } from "../src/cli/args";
 import type { ModelProfileDefinition } from "../src/config/model-profiles";
+import { ModelRegistry } from "../src/config/model-registry";
 import { Settings } from "../src/config/settings";
-import { applyStartupModelProfiles, createAcpSessionFactory } from "../src/main";
+import { applyStartupModelProfiles, createAcpSessionFactory, runRootCommand } from "../src/main";
 import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "../src/sdk";
 import type { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
 
 const model = (provider: string, id: string): Model =>
 	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
 
-function fakeRegistry(profiles: ModelProfileDefinition[]) {
+function fakeRegistry(
+	profiles: ModelProfileDefinition[],
+	options?: { afterRefreshModels?: Model[]; initialModels?: Model[] },
+) {
 	const profileMap = new Map(profiles.map(profile => [profile.name, profile]));
+	let models = options?.initialModels ?? [model("profile-provider", "default"), model("cli-provider", "explicit")];
 	return {
 		getModelProfile: (name: string) => profileMap.get(name),
 		getModelProfiles: () => new Map(profileMap),
 		getAvailableModelProfileNames: () => [...profileMap.keys()].sort(),
 		getApiKeyForProvider: async () => "key",
-		getAll: () => [model("profile-provider", "default"), model("cli-provider", "explicit")],
+		getAll: () => models,
+		refresh: async () => {
+			models = options?.afterRefreshModels ?? models;
+		},
 	};
 }
 
@@ -112,6 +123,100 @@ test("deferred explicit CLI --model is reapplied after --mpreset activation", as
 	).toEqual(["profile-provider/default:high", "cli-provider/explicit:undefined"]);
 	expect(session.setModelTemporaryCalls.at(-1)?.model).toBe(explicitModel);
 	expect(session.model).toBe(explicitModel);
+});
+
+test("default profile applies live-discovered models after startup refresh", async () => {
+	const session = fakeSession();
+	const settings = Settings.isolated({ "modelProfile.default": "antigravity-flash" });
+	const liveModel = model("google-antigravity", "gemini-3.5-flash-low");
+
+	await applyStartupModelProfiles({
+		session,
+		settings,
+		modelRegistry: fakeRegistry(
+			[
+				{
+					name: "antigravity-flash",
+					requiredProviders: ["google-antigravity"],
+					modelMapping: { default: "google-antigravity/gemini-3.5-flash-low" },
+					source: "user",
+				},
+			],
+			{ initialModels: [liveModel] },
+		) as never,
+		parsedArgs: {},
+	});
+
+	expect(session.setModelTemporaryCalls).toHaveLength(1);
+	expect(session.model).toBe(liveModel);
+});
+
+test("runRootCommand foreground-refreshes startup profiles without background refresh", async () => {
+	const session = fakeSession();
+	const settings = Settings.isolated({ "modelProfile.default": "antigravity-flash" });
+	const liveModel = model("google-antigravity", "gemini-3.5-flash-low");
+	const profile: ModelProfileDefinition = {
+		name: "antigravity-flash",
+		requiredProviders: ["google-antigravity"],
+		modelMapping: { default: "google-antigravity/gemini-3.5-flash-low" },
+		source: "user",
+	};
+	const refreshStrategies: string[] = [];
+	let backgroundRefreshCount = 0;
+	const originalRefresh = ModelRegistry.prototype.refresh;
+	const originalRefreshInBackground = ModelRegistry.prototype.refreshInBackground;
+	const originalGetModelProfile = ModelRegistry.prototype.getModelProfile;
+	const originalGetModelProfiles = ModelRegistry.prototype.getModelProfiles;
+	const originalGetAvailableModelProfileNames = ModelRegistry.prototype.getAvailableModelProfileNames;
+	const originalGetAll = ModelRegistry.prototype.getAll;
+	const originalGetApiKeyForProvider = ModelRegistry.prototype.getApiKeyForProvider;
+	using tempDir = TempDir.createSync("@gjc-mpreset-refresh-");
+	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+
+	ModelRegistry.prototype.refresh = async (strategy = "online-if-uncached") => {
+		refreshStrategies.push(strategy);
+	};
+	ModelRegistry.prototype.refreshInBackground = () => {
+		backgroundRefreshCount += 1;
+	};
+	ModelRegistry.prototype.getModelProfile = (name: string) => (name === profile.name ? profile : undefined);
+	ModelRegistry.prototype.getModelProfiles = () => new Map([[profile.name, profile]]);
+	ModelRegistry.prototype.getAvailableModelProfileNames = () => [profile.name];
+	ModelRegistry.prototype.getAll = () => [liveModel];
+	ModelRegistry.prototype.getApiKeyForProvider = async () => "key";
+
+	try {
+		await runRootCommand(parseArgs(["--mode", "acp", "--no-tools", "--no-lsp", "--no-skills", "--no-rules"]), [], {
+			discoverAuthStorage: async () => authStorage,
+			createAgentSession: async (): Promise<CreateAgentSessionResult> =>
+				({
+					session,
+					setToolUIContext: () => {},
+					extensionsResult: {},
+					eventBus: {},
+				}) as unknown as CreateAgentSessionResult,
+			settings,
+			runAcpMode: async createAcpSession => {
+				const nextSession = await createAcpSession(process.cwd());
+				expect(nextSession).toBe(session);
+			},
+			suppressProcessExit: true,
+		});
+	} finally {
+		authStorage.close();
+		ModelRegistry.prototype.refresh = originalRefresh;
+		ModelRegistry.prototype.refreshInBackground = originalRefreshInBackground;
+		ModelRegistry.prototype.getModelProfile = originalGetModelProfile;
+		ModelRegistry.prototype.getModelProfiles = originalGetModelProfiles;
+		ModelRegistry.prototype.getAvailableModelProfileNames = originalGetAvailableModelProfileNames;
+		ModelRegistry.prototype.getAll = originalGetAll;
+		ModelRegistry.prototype.getApiKeyForProvider = originalGetApiKeyForProvider;
+	}
+
+	expect(refreshStrategies).toEqual(["online-if-uncached"]);
+	expect(backgroundRefreshCount).toBe(0);
+	expect(session.setModelTemporaryCalls).toHaveLength(1);
+	expect(session.model).toBe(liveModel);
 });
 
 test("ACP session factory applies default profile and --mpreset before returning session", async () => {


### PR DESCRIPTION
## 요약
안녕하세요. #1451 리뷰에서 지적해주신 startup foreground refresh/background refresh 중복 문제를 반영해 `dev` 기준 새 브랜치로 다시 올립니다.

이번 버전은 `applyStartupModelProfiles()` 안에서 refresh하지 않고, `runRootCommand()`가 startup profile 필요 여부(`modelProfile.default` 또는 `--mpreset`)를 먼저 판단해 세션 생성 전에 `modelRegistry.refresh("online-if-uncached")`를 한 번 수행합니다. 이 경우 기존 `createSession()` 직후 `refreshInBackground()`는 건너뛰도록 해서 같은 startup 경로에서 discovery refresh가 중복 실행되지 않게 했습니다.

## 변경 내용
- startup profile이 필요한 경우 세션 생성 전에 foreground refresh 1회 수행
- 같은 경로에서는 post-create background refresh suppress
- `applyStartupModelProfiles()`는 refresh 없이 profile 적용만 담당
- `runRootCommand()`/ACP create-session 경로를 직접 타는 회귀 테스트 추가
- 테스트에서 foreground refresh 1회, background refresh 0회를 명시적으로 검증

## 중복 확인
PR 작성 전에 아래 키워드로 open PR을 확인했지만, 같은 내용으로 보이는 항목은 찾지 못했습니다.

- `startup model profile refresh`
- `default selector did not resolve`

## 검증
- `git diff --check origin/dev...HEAD`
- `bun test packages/coding-agent/test/cli-args-mpreset.test.ts`
- `bunx biome check packages/coding-agent/src/main.ts packages/coding-agent/test/cli-args-mpreset.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun run check:node20-baseline`

감사합니다.