### PR TITLE
Fix wrapped TUI input space rendering

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1505,10 +1505,34 @@ export class Editor implements Component, Focusable {
 					}
 
 					if (hasCursorInChunk) {
+						let displayChunkText = chunk.text;
+						let displayCursorPos = adjustedCursorPos;
+						if (displayCursorPos > displayChunkText.length) {
+							let hiddenWhitespaceWidth = displayCursorPos - displayChunkText.length;
+							const displayChunkWidth = visibleWidth(displayChunkText);
+							if (displayChunkWidth + hiddenWhitespaceWidth <= contentWidth) {
+								displayChunkText += padding(hiddenWhitespaceWidth);
+							} else {
+								layoutLines.push({
+									text: displayChunkText,
+									hasCursor: false,
+								});
+								hiddenWhitespaceWidth -= Math.max(0, contentWidth - displayChunkWidth);
+								while (hiddenWhitespaceWidth > contentWidth) {
+									layoutLines.push({
+										text: padding(contentWidth),
+										hasCursor: false,
+									});
+									hiddenWhitespaceWidth -= contentWidth;
+								}
+								displayChunkText = padding(hiddenWhitespaceWidth);
+								displayCursorPos = hiddenWhitespaceWidth;
+							}
+						}
 						layoutLines.push({
-							text: chunk.text,
+							text: displayChunkText,
 							hasCursor: true,
-							cursorPos: adjustedCursorPos,
+							cursorPos: displayCursorPos,
 						});
 					} else {
 						layoutLines.push({

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -419,6 +419,36 @@ describe("Editor component", () => {
 			expect(narrow).toBeGreaterThan(wide);
 		});
 
+		it("renders cursor movement immediately after a trailing space on wrapped input", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setBorderVisible(false);
+			editor.setPaddingX(0);
+			editor.focused = true;
+
+			for (const char of "aaaaaaaaaa") editor.handleInput(char);
+			const beforeSpace = editor.render(10).map(line => stripVTControlCharacters(line));
+
+			editor.handleInput(" ");
+			const afterSpace = editor.render(10);
+			const afterSpacePlain = afterSpace.map(line => stripVTControlCharacters(line));
+
+			expect(editor.getText()).toBe("aaaaaaaaaa ");
+			expect(beforeSpace).toHaveLength(1);
+			expect(afterSpace).toHaveLength(2);
+			expect(afterSpacePlain[0]).toBe("aaaaaaaaaa");
+			expect(afterSpace[1]).toContain("\x1b[5m|\x1b[0m");
+
+			editor.handleInput("bbb");
+			const beforeWrappedSpace = editor.render(10);
+
+			editor.handleInput(" ");
+			const afterWrappedSpace = editor.render(10);
+
+			expect(editor.getText()).toBe("aaaaaaaaaa bbb ");
+			expect(beforeWrappedSpace[1]).toContain("bbb\x1b_pi:c\u0007\x1b[5m|\x1b[0m");
+			expect(afterWrappedSpace[1]).toContain("bbb \x1b_pi:c\u0007\x1b[5m|\x1b[0m");
+		});
+
 		it("recomputes layout after synchronous autocomplete replacement", () => {
 			const editor = new Editor(defaultEditorTheme);
 			editor.setBorderVisible(false);


### PR DESCRIPTION
## Summary
- keep cursor layout aware of trimmed trailing whitespace in wrapped editor chunks
- render a new/advanced cursor position immediately when a space is typed at a wrapped boundary or on an already wrapped visual line
- add a focused regression covering trailing spaces on wrapped input lines

## Validation
- bun test packages/tui/test/editor.test.ts packages/tui/test/input-render-latency.test.ts packages/tui/test/input-render-redteam.test.ts packages/tui/test/render-regressions.test.ts packages/tui/test/render-goldens.test.ts
- bun --cwd=packages/tui run check

Fixes #1455

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*