### PR TITLE
Fix POSIX team worker tmux startup

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -1931,16 +1931,14 @@ export function buildWorkerCommand(
 	const workspace = worker.worktree_path
 		? `Worker worktree: ${worker.worktree_path}.`
 		: `Worker cwd: ${config.leader.cwd}.`;
-	// The worker prompt body is dispatched into the pane through
-	// `tmux send-keys`, which treats embedded LF characters as Enter
-	// keypresses. A multi-line prompt therefore lands in the pane as
-	// multiple prompt bodies followed by premature Enter presses, which on
-	// Windows + psmux/ConPTY causes the worker CLI to bail out before the
-	// startup ACK fires. Normalize the body to a single line by replacing
-	// any LF/CRLF with a space, and strip a defensive U+FEFF in case a
-	// caller managed to inject a UTF-8 BOM into the task text. Empty /
-	// whitespace-only bodies fall back to a one-line placeholder so the
-	// worker never sits idle at an empty prompt.
+	// The worker prompt body must stay single-line because fallback startup on
+	// Windows/psmux dispatches the command through `tmux send-keys`, where
+	// embedded LF characters are treated as Enter keypresses. POSIX tmux starts
+	// workers by passing the command directly to `split-window`, but keeping the
+	// body normalized there too makes fake-tmux logs and shell argv handling
+	// deterministic. Strip a defensive U+FEFF in case a caller managed to inject
+	// a UTF-8 BOM into the task text. Empty / whitespace-only bodies fall back to
+	// a one-line placeholder so the worker never sits idle at an empty prompt.
 	const normalizePrompt = (raw: string): string =>
 		raw
 			.replace(/[\uFEFF\u200B]/g, "")
@@ -1995,6 +1993,11 @@ export function buildWorkerCommand(
 	}
 	return `${joined} ${config.worker_command} ${quote(prompt)}`;
 }
+
+function shouldDispatchWorkerWithSendKeys(tmuxCommand: string, platform: NodeJS.Platform = process.platform): boolean {
+	return platform === "win32" || path.basename(tmuxCommand).toLowerCase() === "psmux";
+}
+
 interface GjcTeamInitialLane {
 	label: string;
 	title: string;
@@ -2098,22 +2101,24 @@ async function startTmuxSession(
 			const splitDirection: string = worker.index === 1 ? "-h" : "-v";
 			const splitTarget: string =
 				worker.index === 1 ? config.leader.pane_id : (rightStackRootPaneId ?? config.leader.pane_id);
-			const split: Bun.SyncSubprocess<"pipe", "pipe"> = Bun.spawnSync(
-				[
-					config.tmux_command,
-					"split-window",
-					splitDirection,
-					"-t",
-					splitTarget,
-					"-d",
-					"-P",
-					"-F",
-					"#{pane_id}",
-					"-c",
-					worker.worktree_path ?? config.leader.cwd,
-				],
-				{ stdout: "pipe", stderr: "pipe" },
-			);
+			const workerCommand = buildWorkerCommand(config, worker);
+			const workerCwd = worker.worktree_path ?? config.leader.cwd;
+			const useSendKeysFallback = shouldDispatchWorkerWithSendKeys(config.tmux_command);
+			const splitArgs = [
+				config.tmux_command,
+				"split-window",
+				splitDirection,
+				"-t",
+				splitTarget,
+				"-d",
+				"-P",
+				"-F",
+				"#{pane_id}",
+				"-c",
+				workerCwd,
+				...(useSendKeysFallback ? [] : [workerCommand]),
+			];
+			const split: Bun.SyncSubprocess<"pipe", "pipe"> = Bun.spawnSync(splitArgs, { stdout: "pipe", stderr: "pipe" });
 			if (split.exitCode !== 0)
 				throw new Error(split.stderr.toString().trim() || `tmux_split_failed:${config.tmux_target}:${worker.id}`);
 			const paneId: string = split.stdout.toString().trim().split(/\r?\n/)[0]?.trim() ?? "";
@@ -2121,31 +2126,31 @@ async function startTmuxSession(
 			rollbackPaneIds.push(paneId);
 			if (worker.index === 1) rightStackRootPaneId = paneId;
 			workers.push({ ...worker, pane_id: paneId });
-			// On psmux/ConPTY (Windows pwsh default-shell) panes, tmux writes the
-			// split-window command argv to the new pane's stdin but pwsh's
-			// readline never receives an Enter, so the worker never starts.
-			// Create the pane without a command, then dispatch the worker
-			// command through send-keys + Enter so it actually executes.
-			// Two-step dispatch because tmux's `-l` (literal mode) flag is
-			// global per send-keys invocation, not per arg: passing `-l
-			// <body> Enter` would treat "Enter" as literal text too. Sending
-			// the body in literal mode first and the Enter keypress second
-			// keeps the body verbatim while still submitting the prompt as a
-			// keystroke.
-			const body = buildWorkerCommand(config, worker);
-			Bun.spawnSync([config.tmux_command, "send-keys", "-l", "-t", paneId, body], {
-				stdout: "ignore",
-				stderr: "ignore",
-			});
-			const sendKeys = Bun.spawnSync([config.tmux_command, "send-keys", "-t", paneId, "Enter"], {
-				stdout: "ignore",
-				stderr: "ignore",
-			});
-			// void-cast the exit code so the linter does not flag an unused
-			// expression; the value is intentionally discarded here because
-			// the actual spawn outcome is recovered by the leader through
-			// the worker startup-ack watcher, not via the spawn exit code.
-			void sendKeys.exitCode;
+			if (useSendKeysFallback) {
+				// On psmux/ConPTY (Windows pwsh default-shell) panes, tmux writes the
+				// split-window command argv to the new pane's stdin but pwsh's readline
+				// never receives an Enter, so the worker never starts. Create the pane
+				// without a command, then dispatch the worker command through send-keys +
+				// Enter so it actually executes.
+				// Two-step dispatch because tmux's `-l` (literal mode) flag is global per
+				// send-keys invocation, not per arg: passing `-l <body> Enter` would treat
+				// "Enter" as literal text too. Sending the body in literal mode first and
+				// the Enter keypress second keeps the body verbatim while still submitting
+				// the prompt as a keystroke.
+				Bun.spawnSync([config.tmux_command, "send-keys", "-l", "-t", paneId, workerCommand], {
+					stdout: "ignore",
+					stderr: "ignore",
+				});
+				const sendKeys = Bun.spawnSync([config.tmux_command, "send-keys", "-t", paneId, "Enter"], {
+					stdout: "ignore",
+					stderr: "ignore",
+				});
+				// void-cast the exit code so the linter does not flag an unused expression;
+				// the value is intentionally discarded here because the actual spawn outcome
+				// is recovered by the leader through the worker startup-ack watcher, not via
+				// the spawn exit code.
+				void sendKeys.exitCode;
+			}
 		}
 		Bun.spawnSync([config.tmux_command, "select-layout", "-t", config.tmux_target, "main-vertical"], {
 			stdout: "ignore",

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -55,11 +55,18 @@ function runGit(cwd: string, args: string[]): string {
 
 async function createFakeTmuxBin(
 	root: string,
-	options: { failDisplay?: boolean; failSplit?: boolean; gjcProfile?: boolean; untaggableProfile?: boolean } = {},
+	options: {
+		failDisplay?: boolean;
+		failSplit?: boolean;
+		gjcProfile?: boolean;
+		untaggableProfile?: boolean;
+		commandName?: string;
+	} = {},
 ): Promise<string> {
 	const binDir = path.join(root, ".test-bin");
 	await fs.mkdir(binDir, { recursive: true });
 	const logPath = path.join(root, "tmux.log");
+	const commandName = options.commandName ?? "tmux";
 	const script = `#!/usr/bin/env bash
 echo "$@" >> ${JSON.stringify(logPath)}
 case "$1" in
@@ -118,9 +125,9 @@ case "$1" in
     ;;
 esac
 `;
-	await Bun.write(path.join(binDir, "tmux"), script);
-	await fs.chmod(path.join(binDir, "tmux"), 0o755);
-	return path.join(binDir, "tmux");
+	await Bun.write(path.join(binDir, commandName), script);
+	await fs.chmod(path.join(binDir, commandName), 0o755);
+	return path.join(binDir, commandName);
 }
 
 async function createGitRepo(): Promise<string> {
@@ -515,7 +522,7 @@ describe("native gjc team runtime", () => {
 		expect(separatedShort.task).toBe("ship it");
 	});
 
-	it("creates worker worktrees by default for the tmux launch path", async () => {
+	it("starts native team runtime workers in sibling panes", async () => {
 		cleanupRoot = await createGitRepo();
 		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
 		const snapshot = await startGjcTeam({
@@ -558,6 +565,9 @@ describe("native gjc team runtime", () => {
 		expect(tmuxLog).toContain("worker-startup-ack");
 		expect(tmuxLog).toContain("protocol_version");
 		expect(tmuxLog).toContain("claim-task/transition-task-status");
+		expect(tmuxLog).toContain("GJC_TEAM_WORKER='worktree-team/worker-1'");
+		expect(tmuxLog).toContain("true 'You are worker-1 in gjc team worktree-team.");
+		expect(tmuxLog).not.toContain("send-keys -l");
 		expect(tmuxLog).toContain("select-layout -t test-session:0 main-vertical");
 		expect(tmuxLog).toContain("set-option -t test-session:0 mouse on");
 		expect(tmuxLog).toContain("set-option -t test-session:0 set-clipboard on");
@@ -589,6 +599,7 @@ describe("native gjc team runtime", () => {
 		expect(config.tmux_target).toBe("test-session:0");
 		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
 		expect(tmuxLog).toContain("display-message -p #S:#I #{pane_id}");
+		expect(tmuxLog).not.toContain("send-keys -l");
 	});
 
 	it("starts multiple runtime workers before tmux state mutation", async () => {
@@ -614,7 +625,39 @@ describe("native gjc team runtime", () => {
 		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
 		expect(tmuxLog).toContain("split-window -h -t %1");
 		expect(tmuxLog).toContain("split-window -v -t %2");
+		expect(tmuxLog).toContain("GJC_TEAM_WORKER='multi-team/worker-1'");
+		expect(tmuxLog).toContain("GJC_TEAM_WORKER='multi-team/worker-2'");
+		expect(tmuxLog).not.toContain("send-keys -l");
 		expect(tmuxLog).not.toContain("new-session");
+	});
+
+	it("keeps psmux worker startup on empty-pane send-keys fallback", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakePsmux = await createFakeTmuxBin(cleanupRoot, { commandName: "psmux" });
+
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Start psmux worker",
+			teamName: "psmux-team",
+			cwd: cleanupRoot,
+			env: {
+				GJC_SESSION_ID: TEST_SESSION_ID,
+				PATH: process.env.PATH ?? "",
+				GJC_TEAM_WORKER_COMMAND: "true",
+				GJC_TEAM_TMUX_COMMAND: fakePsmux,
+			},
+		});
+
+		expect(snapshot.workers).toHaveLength(1);
+		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
+		const splitLines = tmuxLog.split(/\r?\n/).filter(line => line.startsWith("split-window"));
+		expect(splitLines).toHaveLength(1);
+		expect(splitLines[0]).toContain("split-window -h -t %1 -d -P -F #{pane_id} -c ");
+		expect(splitLines[0]).not.toContain("worker-startup-ack");
+		expect(tmuxLog).toContain("send-keys -l -t %2");
+		expect(tmuxLog).toContain("worker-startup-ack");
+		expect(tmuxLog).toContain("send-keys -t %2 Enter");
 	});
 	it("distributes explicit markdown lane sections into worker-owned initial tasks", async () => {
 		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));


### PR DESCRIPTION
## Summary
- launch POSIX tmux team workers by passing the worker command directly to `tmux split-window -c <cwd> <command>`
- keep Windows/psmux on the empty-pane plus `send-keys` fallback path
- add fake-tmux regression coverage for POSIX split argv, no POSIX startup send-keys, and psmux fallback send-keys

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts --test-name-pattern 'starts native team runtime workers in sibling panes|starts multiple runtime workers|buildWorkerCommand prompt normalization'` — 4 pass, 52 filtered out, 0 fail, 45 expect calls\n- `git diff --check`\n- `bun --cwd=packages/coding-agent run check`\n\n—\n*[repo owner's gaebal-gajae (clawdbot) 🦞]*