### PR TITLE
fix(task): don't log subagent abort as "Subagent prompt failed" error

### DIFF
--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1535,6 +1535,11 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					);
 					await awaitAbortable(session.waitForIdle());
 				} catch (err) {
+					// An abort (parent cancel, session shutdown, timeout) rejects
+					// awaitAbortable with ToolAbortError — a cancellation, not a prompt
+					// failure. Mirror the outer catch's `!abortSignal.aborted` guard so
+					// expected cancellations aren't logged at error level.
+					if (abortSignal.aborted || err instanceof ToolAbortError) break;
 					logger.error("Subagent prompt failed", {
 						error: err instanceof Error ? err.message : String(err),
 					});


### PR DESCRIPTION
## Problem

In the subagent yield-retry loop (`runSubprocess`, `packages/coding-agent/src/task/executor.ts`), when a subagent is **aborted** — parent cancel (subagent tool), session/process shutdown, or timeout — `awaitAbortable(...)` rejects with `ToolAbortError` (message `"Operation aborted"`). The inner `catch` logs this at **error** level as `Subagent prompt failed`, mislabeling a normal cancellation as a failure.

Observed 5 times in one day across 5 distinct processes, every occurrence identical:

```json
{"level":"error","message":"Subagent prompt failed","error":"Operation aborted"}
```

`"Operation aborted"` is `ToolAbortError`'s default message — so every observed case is a cancellation, never a real prompt failure.

The **outer** catch already handles this correctly (`if (!abortSignal.aborted) { ... }`); only the inner yield-retry catch is inconsistent.

## Fix

On abort / `ToolAbortError`, break the loop quietly (mirroring the outer catch) instead of logging an error. `ToolAbortError` is already imported and `abortSignal` is in scope.

## Impact / risk

Log-hygiene, not data loss. The loop already exits on the next `!abortSignal.aborted` check, so behavior is unchanged apart from removing the spurious error log. Genuine (non-abort) prompt errors still log at `error`. Downstream abort handling (the outer `finally`) is untouched.

## Verification

Reproduced the loop in isolation:
- **before** → logs `[error] Subagent prompt failed / Operation aborted`
- **after** → no log, loop breaks (same iteration count); non-abort errors still log.

Verified via isolated reproduction + static analysis of the surrounding code. **Not** run against the full upstream test suite — CI will cover that.

> Surfaced by dogfooding gjc's own `~/.gjc/logs` (all 5 hits were `error: "Operation aborted"`).
