### PR TITLE
fix(utils): silence benign postmortem exit reentry

### DIFF
--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -7,7 +7,7 @@
  */
 import inspector from "node:inspector";
 import { isMainThread } from "node:worker_threads";
-import { logger } from ".";
+import * as logger from "./logger";
 import { safeStderrWrite } from "./safe-stderr";
 
 // Cleanup reasons, in order of priority/meaning.
@@ -39,6 +39,9 @@ function runCleanup(reason: Reason): Promise<void> {
 			cleanupStage = "running";
 			break;
 		case "running":
+			if (reason === Reason.EXIT) {
+				return Promise.resolve();
+			}
 			logger.error("Cleanup invoked recursively", { stack: new Error().stack });
 			return Promise.resolve();
 		case "complete":

--- a/packages/utils/test/postmortem-fixture.ts
+++ b/packages/utils/test/postmortem-fixture.ts
@@ -1,0 +1,71 @@
+import * as logger from "../src/logger";
+import * as postmortem from "../src/postmortem";
+
+logger.setTransports({ console: true, file: false });
+
+type ExitListener = (code?: number) => unknown;
+
+function getPostmortemExitListener(): ExitListener {
+	const listener = process.rawListeners("exit").at(-1);
+	if (!listener) {
+		throw new Error("postmortem exit listener was not registered");
+	}
+	return listener as ExitListener;
+}
+
+function writeResult(result: Record<string, unknown>): void {
+	process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+async function runExitReentryWhileRunning(): Promise<void> {
+	let count = 0;
+	const exitListener = getPostmortemExitListener();
+	postmortem.register("fixture-exit-reentry", async () => {
+		count++;
+		await Promise.resolve(exitListener(0));
+	});
+
+	await postmortem.cleanup();
+	await Bun.sleep(20);
+	writeResult({ count });
+}
+
+async function runNonExitRecursiveCleanup(): Promise<void> {
+	let count = 0;
+	postmortem.register("fixture-non-exit-recursion", () => {
+		count++;
+		void postmortem.cleanup();
+	});
+
+	await postmortem.cleanup();
+	await Bun.sleep(20);
+	writeResult({ count });
+}
+
+async function runCompletedCleanupExitNoop(): Promise<void> {
+	let count = 0;
+	const exitListener = getPostmortemExitListener();
+	postmortem.register("fixture-complete-exit", () => {
+		count++;
+	});
+
+	await postmortem.cleanup();
+	await Promise.resolve(exitListener(0));
+	await Bun.sleep(20);
+	writeResult({ count });
+}
+
+const scenario = process.argv[2];
+switch (scenario) {
+	case "exit-reentry-while-running":
+		await runExitReentryWhileRunning();
+		break;
+	case "non-exit-recursive-cleanup":
+		await runNonExitRecursiveCleanup();
+		break;
+	case "completed-cleanup-exit-noop":
+		await runCompletedCleanupExitNoop();
+		break;
+	default:
+		throw new Error(`unknown postmortem fixture scenario: ${scenario ?? "(missing)"}`);
+}

--- a/packages/utils/test/postmortem.test.ts
+++ b/packages/utils/test/postmortem.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+
+interface ScenarioResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+}
+
+const fixturePath = path.join(import.meta.dir, "postmortem-fixture.ts");
+
+async function runScenario(scenario: string): Promise<ScenarioResult> {
+	const proc = Bun.spawn([process.execPath, fixturePath, scenario], {
+		cwd: path.join(import.meta.dir, ".."),
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	return { stdout, stderr, exitCode };
+}
+
+function parseResult(stdout: string): { count: number } {
+	const line = stdout.trim().split("\n").at(-1);
+	if (!line) {
+		throw new Error("postmortem fixture produced no JSON result");
+	}
+	return JSON.parse(line) as { count: number };
+}
+
+function combinedOutput(result: ScenarioResult): string {
+	return `${result.stdout}\n${result.stderr}`;
+}
+
+function hasRecursiveCleanupError(stderr: string): boolean {
+	return stderr.includes('"level":"error"') && stderr.includes('"message":"Cleanup invoked recursively"');
+}
+
+describe("postmortem cleanup re-entry", () => {
+	it("does not log an error when the exit handler re-enters while cleanup is running", async () => {
+		const result = await runScenario("exit-reentry-while-running");
+
+		expect(result.exitCode).toBe(0);
+		expect(parseResult(result.stdout).count).toBe(1);
+		expect(hasRecursiveCleanupError(combinedOutput(result))).toBe(false);
+	});
+
+	it("keeps the recursive cleanup error for non-exit re-entry", async () => {
+		const result = await runScenario("non-exit-recursive-cleanup");
+
+		expect(result.exitCode).toBe(0);
+		expect(parseResult(result.stdout).count).toBe(1);
+		expect(hasRecursiveCleanupError(combinedOutput(result))).toBe(true);
+		expect(combinedOutput(result)).toContain('"stack"');
+	});
+
+	it("keeps completed cleanup a no-op when the exit handler fires", async () => {
+		const result = await runScenario("completed-cleanup-exit-noop");
+
+		expect(result.exitCode).toBe(0);
+		expect(parseResult(result.stdout).count).toBe(1);
+		expect(hasRecursiveCleanupError(combinedOutput(result))).toBe(false);
+	});
+});


### PR DESCRIPTION
Fixes #1462

## Summary
- Treat `Reason.EXIT` re-entry during in-flight postmortem cleanup as a benign no-op.
- Preserve error-level `Cleanup invoked recursively` diagnostics for genuine non-exit recursion.
- Add focused subprocess-isolated postmortem regression tests for exit re-entry, non-exit recursion, and completed cleanup exit no-op.

## Verification
- `bun --cwd=packages/utils test test/postmortem.test.ts` (3 pass, 0 fail, 10 expect calls)
- `bun --cwd=packages/utils test` (106 pass, 0 fail, 198 expect calls)
- `bun --cwd=packages/utils run check`
- `git diff --check`