### PR TITLE
fix(tui): stop breaking Windows Hangul/CJK IME on the queue shortcut

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Empty select/settings lists now still honor cancel while preserving populated-list keybinding precedence, and settings lists keep selection indices clamped when items disappear or submenus close after list shrinkage.
 
+### Fixed
+
+- Fixed Windows Hangul/CJK IME composition breaking the queue-message shortcut (Alt+Enter/Alt+Q): the app no longer enables the xterm `modifyOtherKeys` fallback on win32, where Windows Terminal/conhost do not support the Kitty keyboard protocol anyway. `modifyOtherKeys` made modified-key chords bypass the IME commit, so a syllable still being composed was dropped and the queue action fired on empty text unless the user typed a trailing space first. Legacy encodings still deliver Alt+Enter and the newline chords; opt back into the enhancement with `GJC_TUI_KEYBOARD_PROTOCOL`.
+
 ## [0.7.11] - 2026-07-03
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -586,6 +586,20 @@ export class ProcessTerminal implements Terminal {
 			return;
 		}
 		this.#safeWrite("\x1b[?u");
+		// Windows Terminal and conhost do not implement the Kitty keyboard
+		// protocol, so the query above never activates it there. They do honor the
+		// modifyOtherKeys fallback below — but that mode breaks Windows CJK/Hangul
+		// IME composition: Alt+Enter (and other chords) bypass the IME commit, so
+		// the syllable still being composed is never delivered to the app and the
+		// action fires on empty text (e.g. queue-message no-ops unless the user
+		// types a trailing space to force a commit first). Skip the fallback on
+		// win32; legacy encodings still deliver Alt+Enter (ESC CR) and the newline
+		// chords, and IME composition works again. Opt back in with
+		// GJC_TUI_KEYBOARD_PROTOCOL=0 disabling all enhancement, or force-enable
+		// elsewhere if a Kitty-capable Windows terminal appears.
+		if (process.platform === "win32") {
+			return;
+		}
 		this.#modifyOtherKeysTimeout = setTimeout(() => {
 			this.#modifyOtherKeysTimeout = undefined;
 			if (this.#kittyProtocolActive || this.#modifyOtherKeysActive) {

--- a/packages/tui/test/keyboard-protocol-optout.test.ts
+++ b/packages/tui/test/keyboard-protocol-optout.test.ts
@@ -5,6 +5,11 @@ const stdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isT
 const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 const stdinSetRawModeDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "setRawMode");
 const originalKeyboardProtocolEnv = Bun.env.GJC_TUI_KEYBOARD_PROTOCOL;
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setPlatform(platform: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
 
 // Kitty keyboard protocol query and the xterm modifyOtherKeys level-2 fallback.
 const KITTY_QUERY = "\x1b[?u";
@@ -40,6 +45,7 @@ describe("ProcessTerminal keyboard-protocol opt-out (GJC_TUI_KEYBOARD_PROTOCOL)"
 		restoreProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
 		restoreProperty(process.stdin, "setRawMode", stdinSetRawModeDescriptor);
 		restoreEnv("GJC_TUI_KEYBOARD_PROTOCOL", originalKeyboardProtocolEnv);
+		restoreProperty(process, "platform", platformDescriptor);
 	});
 
 	function setupTerminal() {
@@ -63,8 +69,9 @@ describe("ProcessTerminal keyboard-protocol opt-out (GJC_TUI_KEYBOARD_PROTOCOL)"
 		return { terminal, writes, received };
 	}
 
-	it("enables the keyboard protocol by default (query + modifyOtherKeys fallback)", () => {
+	it("enables the keyboard protocol by default on non-win32 (query + modifyOtherKeys fallback)", () => {
 		vi.useFakeTimers();
+		setPlatform("linux");
 		delete Bun.env.GJC_TUI_KEYBOARD_PROTOCOL;
 		expect(keyboardEnhancementEnabled()).toBe(true);
 
@@ -87,6 +94,24 @@ describe("ProcessTerminal keyboard-protocol opt-out (GJC_TUI_KEYBOARD_PROTOCOL)"
 		const { terminal, writes } = setupTerminal();
 
 		expect(writes).not.toContain(KITTY_QUERY);
+
+		vi.advanceTimersByTime(150);
+		expect(writes).not.toContain(MODIFY_OTHER_KEYS);
+
+		terminal.stop();
+	});
+
+	it("skips only the modifyOtherKeys fallback on win32 to preserve IME composition", () => {
+		vi.useFakeTimers();
+		setPlatform("win32");
+		delete Bun.env.GJC_TUI_KEYBOARD_PROTOCOL;
+		expect(keyboardEnhancementEnabled()).toBe(true);
+
+		const { terminal, writes } = setupTerminal();
+
+		// The Kitty query is still emitted (harmless where unsupported), but the
+		// modifyOtherKeys fallback that breaks Windows Hangul/CJK IME is skipped.
+		expect(writes).toContain(KITTY_QUERY);
 
 		vi.advanceTimersByTime(150);
 		expect(writes).not.toContain(MODIFY_OTHER_KEYS);


### PR DESCRIPTION
## Problem

On Windows, the queue-message shortcut (`app.message.queue` — Alt+Enter, or Alt+Q when remapped) silently does nothing **unless the user types a trailing space first**. Reported by a Korean user: pressing Alt+Enter while a Hangul syllable is still being composed drops the message.

## Root cause

Windows Terminal / conhost do not implement the Kitty keyboard protocol, so `#queryAndEnableKittyProtocol()` falls back to the xterm `modifyOtherKeys` level-2 mode after 150ms. That mode makes modified-key chords bypass the IME commit, so the syllable currently in composition is never delivered to the app. `handleFollowUp()` then reads an empty `getText()` and returns early (`if (!text) return`), so nothing is queued. Typing a space commits the composition first, which is why the trailing-space workaround "fixes" it.

The editor/key layer itself is fine — verified that `onQueue` fires for every Alt+Enter encoding regardless of buffer content; the gap is purely the uncommitted IME preedit not reaching the app.

## Fix

Skip the `modifyOtherKeys` fallback on `win32`. It provides no benefit there (Kitty is unsupported anyway) and only breaks Hangul/CJK IME. Legacy encodings still deliver Alt+Enter (`ESC CR`) and the newline chords, and IME composition works again. This mirrors the existing IME-protection precedent already in the same function. The `GJC_TUI_KEYBOARD_PROTOCOL` escape hatch is unchanged.

## Tradeoff

On Windows, some `modifyOtherKeys`-based chord disambiguation (e.g. Ctrl+Enter vs Enter) now relies on legacy encodings. Flagging for reviewer judgment.

## Tests

- `packages/tui/test/keyboard-protocol-optout.test.ts`: added a win32 case asserting the Kitty query is still emitted but `modifyOtherKeys` is skipped; pinned the default-behavior test to a non-win32 platform. All green.