### PR TITLE
feat(status-line): 좁은 터미널에서 세그먼트 잘림 대신 여러 줄로 표시

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - The `/model` preset landing now shows the session's current preset, model, and per-role assignments in the header, marks the active preset with `(current)`, and Enter now expands/collapses provider groups (right/left arrows still work).
 
+- Added a `statusLine.maxRows` setting (Appearance → Status Line Rows). When it is greater than 1, status line segments that overflow a narrow terminal now wrap onto additional rows instead of being dropped; the default of 1 keeps the existing single-line, drop-on-overflow behavior. The Appearance preview reflects the wrapped layout.
+
+## [0.7.11] - 2026-07-03
 ### Fixed
 
 - The Python `gjc_rpc` client no longer tears down its reader loop on real server frames it had not modeled: OAuth `open_url` extension-UI requests emitted during `login`, `workflow_gate` frames carrying structured `{value, label, description}` options (the `next_workflow_gate()` queue path re-parsed them with a legacy strings-only parser), and `max`/`inherit` thinking levels returned by `get_state`/model info. `install_headless_ui` now answers interactive UI requests with `extension_ui_response` frames instead of misrouting them as `workflow_gate_response` commands, and `get_pending_workflow_gates()` is exposed as a typed method. Previously dropped payloads (`notice`, `thinking_level_changed`, `goal_updated`, `irc_message`, `subagent_steer_message` events; `agent_end.stopReason`/`telemetry`/`coverage`; `auto_retry_start.unbounded`; `auto_compaction_end.continuationSkipReason`; gate `required`) now parse into typed models, and the env-gated real-binary lane covers the new surface.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -507,6 +507,21 @@ export const SETTINGS_SCHEMA = {
 			description: "Use the session name color for the editor border and status line gap",
 		},
 	},
+	"statusLine.maxRows": {
+		type: "number",
+		default: 1,
+		ui: {
+			tab: "appearance",
+			label: "Status Line Rows",
+			description:
+				"Maximum rows for the status line. When greater than 1, overflowing segments wrap onto additional rows instead of being dropped.",
+			options: [
+				{ value: "1", label: "1 row", description: "Single line; overflow is truncated (default)" },
+				{ value: "2", label: "2 rows", description: "Wrap overflow onto a second row" },
+				{ value: "3", label: "3 rows", description: "Wrap overflow across up to three rows" },
+			],
+		},
+	},
 	"tools.artifactSpillThreshold": {
 		type: "number",
 		default: 50,
@@ -3280,6 +3295,7 @@ export interface ExaSettings {
 export interface StatusLineSettings {
 	preset: StatusLinePreset;
 	separator: StatusLineSeparatorStyle;
+	maxRows: number;
 	showHookStatus: boolean;
 	showSkillHud: boolean;
 	leftSegments: StatusLineSegmentId[];

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -670,6 +670,7 @@ export interface StatusLinePreviewSettings {
 	segmentOptions?: StatusLineSegmentOptions;
 	previewHighlightSegment?: StatusLineSegmentId;
 	sessionAccent?: boolean;
+	maxRows?: number;
 }
 
 export interface SettingsCallbacks {
@@ -906,6 +907,18 @@ export class SettingsSelectorComponent extends Container {
 			onPreviewCancel = () => {
 				const separator = settings.get("statusLine.separator");
 				this.callbacks.onStatusLinePreview?.({ separator, previewHighlightSegment: undefined });
+				this.#updateStatusPreview();
+			};
+		} else if (def.path === "statusLine.maxRows") {
+			onPreview = value => {
+				this.callbacks.onStatusLinePreview?.({ maxRows: Number(value) });
+				this.#updateStatusPreview();
+			};
+			onPreviewCancel = () => {
+				this.callbacks.onStatusLinePreview?.({
+					maxRows: settings.get("statusLine.maxRows"),
+					previewHighlightSegment: undefined,
+				});
 				this.#updateStatusPreview();
 			};
 		}

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -26,6 +26,7 @@ import { getPreset } from "./status-line/presets";
 import { renderSegment, type SegmentContext } from "./status-line/segments";
 import { getSeparator } from "./status-line/separators";
 import { calculateTokensPerSecond } from "./status-line/token-rate";
+import type { SeparatorDef } from "./status-line/types";
 
 export interface StatusLineSegmentOptions {
 	model?: { showThinkingLevel?: boolean };
@@ -45,10 +46,28 @@ export interface StatusLineSettings {
 	showHookStatus?: boolean;
 	showSkillHud?: boolean;
 	sessionAccent?: boolean;
+	maxRows?: number;
 }
 
 export interface StatusLineComponentOptions {
 	version?: string;
+}
+
+interface CollectedStatusSegments {
+	ctx: SegmentContext;
+	separatorDef: SeparatorDef;
+	bgAnsi: string;
+	fgAnsi: string;
+	sepAnsi: string;
+	left: string[];
+	leftSegIds: StatusLineSegmentId[];
+	right: string[];
+	previewHighlightSegment: StatusLineSegmentId | undefined;
+	sessionAccent: boolean | undefined;
+	leftSepWidth: number;
+	rightSepWidth: number;
+	leftCapWidth: number;
+	rightCapWidth: number;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -215,6 +234,7 @@ export class StatusLineComponent implements Component {
 			showSkillHud: settings.get("statusLine.showSkillHud"),
 			segmentOptions: settings.getGroup("statusLine").segmentOptions,
 			sessionAccent: settings.get("statusLine.sessionAccent"),
+			maxRows: settings.get("statusLine.maxRows"),
 		};
 		this.#version = options.version?.trim() || undefined;
 	}
@@ -702,7 +722,70 @@ export class StatusLineComponent implements Component {
 		};
 	}
 
-	#buildStatusLine(width: number): string {
+	#groupWidth(parts: string[], capWidth: number, sepWidth: number): number {
+		if (parts.length === 0) return 0;
+		const partsWidth = parts.reduce((sum, part) => sum + visibleWidth(part), 0);
+		const sepTotal = Math.max(0, parts.length - 1) * (sepWidth + 2);
+		return partsWidth + sepTotal + 2 + capWidth;
+	}
+
+	#renderStatusGroup(
+		parts: string[],
+		direction: "left" | "right",
+		separatorDef: SeparatorDef,
+		bgAnsi: string,
+		fgAnsi: string,
+		sepAnsi: string,
+	): string {
+		if (parts.length === 0) return "";
+		const sep = direction === "left" ? separatorDef.left : separatorDef.right;
+		const cap = separatorDef.endCaps
+			? direction === "left"
+				? separatorDef.endCaps.right
+				: separatorDef.endCaps.left
+			: "";
+		const capPrefix = separatorDef.endCaps?.useBgAsFg ? bgAnsi.replace("\x1b[48;", "\x1b[38;") : bgAnsi + sepAnsi;
+		const capText = cap ? `${capPrefix}${cap}\x1b[0m` : "";
+
+		let content = bgAnsi + fgAnsi;
+		content += ` ${parts.join(` ${sepAnsi}${sep}${fgAnsi} `)} `;
+		content += "\x1b[0m";
+
+		if (capText) {
+			return direction === "right" ? capText + content : content + capText;
+		}
+		return content;
+	}
+
+	#shrinkPathToWidth(content: string, ctx: SegmentContext, shrinkBy: number): string | null {
+		const currentPathVW = visibleWidth(content);
+		const minPathVW = 8; // icon + ellipsis + a few chars
+		const shrinkable = currentPathVW - minPathVW;
+		if (shrinkable <= 0 || shrinkBy <= 0) return null;
+		const targetShrink = Math.min(shrinkable, shrinkBy);
+		const currentMaxLen = ctx.options.path?.maxLength ?? 40;
+		let newMaxLen = Math.max(4, Math.min(currentMaxLen, currentPathVW) - targetShrink);
+		const pathCtx = (maxLen: number): SegmentContext => ({
+			...ctx,
+			options: { ...ctx.options, path: { ...ctx.options.path, maxLength: maxLen } },
+		});
+		let reRendered = renderSegment("path", pathCtx(newMaxLen));
+		if (!reRendered.visible || !reRendered.content) return null;
+		// maxLength governs path text, not icon prefix; iterate to compensate.
+		for (let i = 0; i < 8; i++) {
+			const saved = currentPathVW - visibleWidth(reRendered.content);
+			if (saved >= targetShrink) break;
+			const nextMaxLen = Math.max(4, newMaxLen - (targetShrink - saved));
+			if (nextMaxLen >= newMaxLen) break; // no progress or hit floor
+			newMaxLen = nextMaxLen;
+			const adjusted = renderSegment("path", pathCtx(newMaxLen));
+			if (!adjusted.visible || !adjusted.content) break;
+			reRendered = adjusted;
+		}
+		return reRendered.content;
+	}
+
+	#collectStatusSegments(width: number): CollectedStatusSegments {
 		const ctx = this.#buildSegmentContext(width);
 		const effectiveSettings = this.#resolveSettings();
 		const separatorDef = getSeparator(effectiveSettings.separator ?? "powerline-thin", theme);
@@ -715,25 +798,25 @@ export class StatusLineComponent implements Component {
 		const fgAnsi = theme.getFgAnsi("text");
 		const sepAnsi = theme.getFgAnsi("statusLineSep");
 
-		// Collect visible segment contents
+		const previewHighlightSegment = effectiveSettings.previewHighlightSegment;
 		const highlightSegment = (segId: StatusLineSegmentId, content: string): string =>
-			effectiveSettings.previewHighlightSegment === segId ? `\x1b[7m${content}\x1b[27m` : content;
+			previewHighlightSegment === segId ? `\x1b[7m${content}\x1b[27m` : content;
 
-		const leftParts: string[] = [];
+		const left: string[] = [];
 		const leftSegIds: StatusLineSegmentId[] = [];
 		for (const segId of effectiveSettings.leftSegments) {
 			const rendered = renderSegment(segId, ctx);
 			if (rendered.visible && rendered.content) {
-				leftParts.push(highlightSegment(segId, rendered.content));
+				left.push(highlightSegment(segId, rendered.content));
 				leftSegIds.push(segId);
 			}
 		}
 
-		const rightParts: string[] = [];
+		const right: string[] = [];
 		for (const segId of effectiveSettings.rightSegments) {
 			const rendered = renderSegment(segId, ctx);
 			if (rendered.visible && rendered.content) {
-				rightParts.push(highlightSegment(segId, rendered.content));
+				right.push(highlightSegment(segId, rendered.content));
 			}
 		}
 
@@ -742,114 +825,150 @@ export class StatusLineComponent implements Component {
 		if (runningBackgroundJobs > 0) {
 			const icon = theme.icon.agents ? `${theme.icon.agents} ` : "";
 			const label = `${formatCount("job", runningBackgroundJobs)} running`;
-			rightParts.push(theme.fg("statusLineSubagents", `${icon}${label}`));
+			right.push(theme.fg("statusLineSubagents", `${icon}${label}`));
 		}
 		if (this.#version) {
-			rightParts.push(theme.fg("dim", `v${this.#version}`));
+			right.push(theme.fg("dim", `v${this.#version}`));
 		}
-		const topFillWidth = Math.max(0, width);
-		const left = [...leftParts];
-		const right = [...rightParts];
 
-		const leftSepWidth = visibleWidth(separatorDef.left);
-		const rightSepWidth = visibleWidth(separatorDef.right);
-		const leftCapWidth = separatorDef.endCaps ? visibleWidth(separatorDef.endCaps.right) : 0;
-		const rightCapWidth = separatorDef.endCaps ? visibleWidth(separatorDef.endCaps.left) : 0;
-
-		const groupWidth = (parts: string[], capWidth: number, sepWidth: number): number => {
-			if (parts.length === 0) return 0;
-			const partsWidth = parts.reduce((sum, part) => sum + visibleWidth(part), 0);
-			const sepTotal = Math.max(0, parts.length - 1) * (sepWidth + 2);
-			return partsWidth + sepTotal + 2 + capWidth;
+		return {
+			ctx,
+			separatorDef,
+			bgAnsi,
+			fgAnsi,
+			sepAnsi,
+			left,
+			leftSegIds,
+			right,
+			previewHighlightSegment,
+			sessionAccent: effectiveSettings.sessionAccent,
+			leftSepWidth: visibleWidth(separatorDef.left),
+			rightSepWidth: visibleWidth(separatorDef.right),
+			leftCapWidth: separatorDef.endCaps ? visibleWidth(separatorDef.endCaps.right) : 0,
+			rightCapWidth: separatorDef.endCaps ? visibleWidth(separatorDef.endCaps.left) : 0,
 		};
+	}
 
-		let leftWidth = groupWidth(left, leftCapWidth, leftSepWidth);
-		let rightWidth = groupWidth(right, rightCapWidth, rightSepWidth);
+	#resolveMaxRows(): number {
+		const raw = this.#settings.maxRows ?? 1;
+		if (!Number.isFinite(raw)) return 1;
+		return Math.max(1, Math.min(3, Math.trunc(raw)));
+	}
+
+	#buildStatusLine(width: number, precollected?: CollectedStatusSegments): string {
+		const seg = precollected ?? this.#collectStatusSegments(width);
+		const { ctx, separatorDef, bgAnsi, fgAnsi, sepAnsi, previewHighlightSegment } = seg;
+		const { leftSepWidth, rightSepWidth, leftCapWidth, rightCapWidth } = seg;
+		const left = [...seg.left];
+		const leftIds = [...seg.leftSegIds];
+		const right = [...seg.right];
+		const topFillWidth = Math.max(0, width);
+
+		let leftWidth = this.#groupWidth(left, leftCapWidth, leftSepWidth);
+		let rightWidth = this.#groupWidth(right, rightCapWidth, rightSepWidth);
 		const totalWidth = () => leftWidth + rightWidth + (left.length > 0 && right.length > 0 ? 1 : 0);
 
 		if (topFillWidth > 0) {
 			while (totalWidth() > topFillWidth && right.length > 0) {
 				right.pop();
-				rightWidth = groupWidth(right, rightCapWidth, rightSepWidth);
+				rightWidth = this.#groupWidth(right, rightCapWidth, rightSepWidth);
 			}
 			// Shrink path before dropping left segments — path is the only elastic segment
-			const pathIdx = leftSegIds.indexOf("path");
+			const pathIdx = leftIds.indexOf("path");
 			if (pathIdx >= 0 && totalWidth() > topFillWidth) {
 				const overflow = totalWidth() - topFillWidth;
-				const currentPathVW = visibleWidth(left[pathIdx]);
-				const minPathVW = 8; // icon + ellipsis + a few chars
-				const shrinkable = currentPathVW - minPathVW;
-				if (shrinkable > 0) {
-					const shrinkBy = Math.min(shrinkable, overflow);
-					const currentMaxLen = ctx.options.path?.maxLength ?? 40;
-					let newMaxLen = Math.max(4, Math.min(currentMaxLen, currentPathVW) - shrinkBy);
-					const pathCtx = (maxLen: number): SegmentContext => ({
-						...ctx,
-						options: { ...ctx.options, path: { ...ctx.options.path, maxLength: maxLen } },
-					});
-					let reRendered = renderSegment("path", pathCtx(newMaxLen));
-					if (reRendered.visible && reRendered.content) {
-						// maxLength governs path text, not icon prefix; iterate to compensate
-						for (let i = 0; i < 8; i++) {
-							const saved = currentPathVW - visibleWidth(reRendered.content);
-							if (saved >= shrinkBy) break;
-							const nextMaxLen = Math.max(4, newMaxLen - (shrinkBy - saved));
-							if (nextMaxLen >= newMaxLen) break; // no progress or hit floor
-							newMaxLen = nextMaxLen;
-							const adjusted = renderSegment("path", pathCtx(newMaxLen));
-							if (!adjusted.visible || !adjusted.content) break;
-							reRendered = adjusted;
-						}
-						left[pathIdx] = highlightSegment("path", reRendered.content);
-						leftWidth = groupWidth(left, leftCapWidth, leftSepWidth);
-					}
+				const shrunk = this.#shrinkPathToWidth(left[pathIdx], ctx, overflow);
+				if (shrunk !== null) {
+					left[pathIdx] = previewHighlightSegment === "path" ? `\x1b[7m${shrunk}\x1b[27m` : shrunk;
+					leftWidth = this.#groupWidth(left, leftCapWidth, leftSepWidth);
 				}
 			}
 			while (totalWidth() > topFillWidth && left.length > 0) {
 				left.pop();
-				leftSegIds.pop();
-				leftWidth = groupWidth(left, leftCapWidth, leftSepWidth);
+				leftIds.pop();
+				leftWidth = this.#groupWidth(left, leftCapWidth, leftSepWidth);
 			}
 		}
 
-		const renderGroup = (parts: string[], direction: "left" | "right"): string => {
-			if (parts.length === 0) return "";
-			const sep = direction === "left" ? separatorDef.left : separatorDef.right;
-			const cap = separatorDef.endCaps
-				? direction === "left"
-					? separatorDef.endCaps.right
-					: separatorDef.endCaps.left
-				: "";
-			const capPrefix = separatorDef.endCaps?.useBgAsFg ? bgAnsi.replace("\x1b[48;", "\x1b[38;") : bgAnsi + sepAnsi;
-			const capText = cap ? `${capPrefix}${cap}\x1b[0m` : "";
-
-			let content = bgAnsi + fgAnsi;
-			content += ` ${parts.join(` ${sepAnsi}${sep}${fgAnsi} `)} `;
-			content += "\x1b[0m";
-
-			if (capText) {
-				return direction === "right" ? capText + content : content + capText;
-			}
-			return content;
-		};
-
-		const leftGroup = renderGroup(left, "left");
-		const rightGroup = renderGroup(right, "right");
+		const leftGroup = this.#renderStatusGroup(left, "left", separatorDef, bgAnsi, fgAnsi, sepAnsi);
+		const rightGroup = this.#renderStatusGroup(right, "right", separatorDef, bgAnsi, fgAnsi, sepAnsi);
 		if (!leftGroup && !rightGroup) return "";
 
 		if (topFillWidth === 0 || left.length === 0 || right.length === 0) {
 			return leftGroup + (leftGroup && rightGroup ? " " : "") + rightGroup;
 		}
 
-		leftWidth = groupWidth(left, leftCapWidth, leftSepWidth);
-		rightWidth = groupWidth(right, rightCapWidth, rightSepWidth);
+		leftWidth = this.#groupWidth(left, leftCapWidth, leftSepWidth);
+		rightWidth = this.#groupWidth(right, rightCapWidth, rightSepWidth);
 		const gapWidth = Math.max(1, topFillWidth - leftWidth - rightWidth);
-		const sessionName =
-			effectiveSettings.sessionAccent !== false ? this.session.sessionManager?.getSessionName() : undefined;
+		const sessionName = seg.sessionAccent !== false ? this.session.sessionManager?.getSessionName() : undefined;
 		const accentHex = sessionName ? getSessionAccentHex(sessionName) : undefined;
 		const gapColor = getSessionAccentAnsi(accentHex) ?? theme.getFgAnsi("border");
 		const gapFill = `${gapColor}${theme.boxRound.horizontal.repeat(gapWidth)}\x1b[39m`;
 		return leftGroup + gapFill + rightGroup;
+	}
+
+	/**
+	 * Multi-row status line. When `maxRows > 1` and the single-line layout would
+	 * overflow, segments wrap onto additional left-justified rows instead of
+	 * being dropped. Falls back to the polished justified single row whenever
+	 * everything fits on one line.
+	 */
+	#buildStatusRows(width: number, maxRows: number): string[] {
+		const seg = this.#collectStatusSegments(width);
+		if (seg.left.length === 0 && seg.right.length === 0) return [];
+
+		const topFillWidth = Math.max(1, width);
+		const leftWidth = this.#groupWidth(seg.left, seg.leftCapWidth, seg.leftSepWidth);
+		const rightWidth = this.#groupWidth(seg.right, seg.rightCapWidth, seg.rightSepWidth);
+		const gap = seg.left.length > 0 && seg.right.length > 0 ? 1 : 0;
+		const fitsSingleRow = leftWidth + rightWidth + gap <= topFillWidth;
+
+		if (maxRows <= 1 || fitsSingleRow) {
+			const single = this.#buildStatusLine(width, seg);
+			return single ? [single] : [];
+		}
+
+		// Ordered sequence: left segments first (in order), then right segments.
+		const items: { content: string; isPath: boolean }[] = [
+			...seg.left.map((content, i) => ({ content, isPath: seg.leftSegIds[i] === "path" })),
+			...seg.right.map(content => ({ content, isPath: false })),
+		];
+
+		// Pre-shrink an over-wide path so it never blows out a row on its own.
+		for (const item of items) {
+			if (!item.isPath) continue;
+			const alone = this.#groupWidth([item.content], seg.leftCapWidth, seg.leftSepWidth);
+			if (alone > topFillWidth) {
+				const shrunk = this.#shrinkPathToWidth(item.content, seg.ctx, alone - topFillWidth);
+				if (shrunk !== null) item.content = shrunk;
+			}
+		}
+
+		// Greedy pack into up to `maxRows` left-justified rows.
+		const rows: string[][] = [];
+		let current: string[] = [];
+		for (const item of items) {
+			if (current.length === 0) {
+				current.push(item.content);
+				continue;
+			}
+			const tentative = [...current, item.content];
+			if (this.#groupWidth(tentative, seg.leftCapWidth, seg.leftSepWidth) <= topFillWidth) {
+				current = tentative;
+			} else {
+				rows.push(current);
+				current = [item.content];
+				if (rows.length >= maxRows) break;
+			}
+		}
+		if (rows.length < maxRows && current.length > 0) {
+			rows.push(current);
+		}
+
+		return rows.map(row =>
+			this.#renderStatusGroup(row, "left", seg.separatorDef, seg.bgAnsi, seg.fgAnsi, seg.sepAnsi),
+		);
 	}
 
 	getTopBorder(width: number): { content: string; width: number } {
@@ -860,6 +979,16 @@ export class StatusLineComponent implements Component {
 		};
 	}
 
+	/**
+	 * Multi-row-aware content for the settings preview: the wrapped rows joined
+	 * with newlines so a single `Text` renders them stacked. Honors the current
+	 * `maxRows`; identical to the single status line when `maxRows` is 1 or when
+	 * everything fits on one row.
+	 */
+	getPreviewContent(width: number): string {
+		return this.#buildStatusRows(width, this.#resolveMaxRows()).join("\n");
+	}
+
 	render(width: number): string[] {
 		const lines: string[] = [];
 		this.#refreshSkillHudInBackground();
@@ -868,9 +997,9 @@ export class StatusLineComponent implements Component {
 			lines.push(skillHud);
 		}
 
-		const statusLine = this.#buildStatusLine(width);
-		if (statusLine) {
-			lines.push(truncateToWidth(statusLine, width));
+		const statusRows = this.#buildStatusRows(width, this.#resolveMaxRows());
+		for (const statusRow of statusRows) {
+			if (statusRow) lines.push(truncateToWidth(statusRow, width));
 		}
 
 		const showHooks = this.#settings.showHookStatus ?? true;

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -448,6 +448,7 @@ export class SelectorController {
 								separator: settings.get("statusLine.separator"),
 								showHookStatus: settings.get("statusLine.showHookStatus"),
 								sessionAccent: settings.get("statusLine.sessionAccent"),
+								maxRows: settings.get("statusLine.maxRows"),
 								segmentOptions: settings.get("statusLine.segmentOptions"),
 								...previewSettings,
 							});
@@ -458,7 +459,7 @@ export class SelectorController {
 							// Return the rendered status line for inline preview
 							const availableWidth =
 								width ?? this.ctx.editor.getTopBorderAvailableWidth(this.ctx.ui.terminal.columns);
-							return this.ctx.statusLine.getTopBorder(availableWidth).content;
+							return this.ctx.statusLine.getPreviewContent(availableWidth);
 						},
 						onPluginsChanged: () => {
 							this.ctx.ui.requestRender();
@@ -718,6 +719,7 @@ export class SelectorController {
 			case "statusLineShowHooks":
 			case "statusLine.showHookStatus":
 			case "statusLine.sessionAccent":
+			case "statusLine.maxRows":
 			case "statusLine.leftSegments":
 			case "statusLine.rightSegments":
 			case "statusLine.segmentOptions":
@@ -739,6 +741,7 @@ export class SelectorController {
 					separator: settings.get("statusLine.separator"),
 					showHookStatus: settings.get("statusLine.showHookStatus"),
 					sessionAccent: settings.get("statusLine.sessionAccent"),
+					maxRows: settings.get("statusLine.maxRows"),
 					segmentOptions: settings.get("statusLine.segmentOptions"),
 				};
 				this.ctx.statusLine.updateSettings(statusLineSettings);

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -368,3 +368,67 @@ describe("overflow: path shrinks before git is dropped", () => {
 		}
 	});
 });
+
+describe("status line multi-row wrapping (statusLine.maxRows)", () => {
+	const LONG_NAME = "WrapSess1";
+
+	function buildComponent(maxRows: number): StatusLineComponent {
+		const component = new StatusLineComponent(createStatusLineSession(LONG_NAME));
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["gajae", "session"],
+			rightSegments: ["session_name", "time"],
+			separator: "pipe",
+			showSkillHud: false,
+			sessionAccent: false,
+			maxRows,
+		});
+		return component;
+	}
+
+	const strip = (s: string): string => Bun.stripANSI(s);
+
+	it("keeps the polished single row when everything fits", () => {
+		const lines = buildComponent(2).render(200);
+		expect(lines).toHaveLength(1);
+	});
+
+	it("wraps overflow onto extra rows instead of dropping segments", () => {
+		const single = buildComponent(1).render(24);
+		expect(single).toHaveLength(1);
+
+		const wrapped = buildComponent(2).render(24);
+		expect(wrapped.length).toBeGreaterThan(1);
+		// Every emitted row stays within the terminal width.
+		for (const row of wrapped) {
+			expect(visibleWidth(row)).toBeLessThanOrEqual(24);
+		}
+		// Wrapping preserves content that the single-row layout would have dropped.
+		const singleLen = strip(single[0]).length;
+		const wrappedLen = wrapped.reduce((sum, row) => sum + strip(row).length, 0);
+		expect(wrappedLen).toBeGreaterThan(singleLen);
+		// The session name survives across the wrapped rows.
+		expect(wrapped.some(row => strip(row).includes(LONG_NAME))).toBe(true);
+	});
+
+	it("caps wrapping at maxRows", () => {
+		const wrapped = buildComponent(2).render(8);
+		expect(wrapped.length).toBeLessThanOrEqual(2);
+	});
+
+	it("allows up to three rows when maxRows is 3", () => {
+		const two = buildComponent(2).render(8);
+		const three = buildComponent(3).render(8);
+		expect(three.length).toBeLessThanOrEqual(3);
+		// A tighter cap keeps strictly fewer-or-equal rows than a looser cap.
+		expect(three.length).toBeGreaterThanOrEqual(two.length);
+	});
+
+	it("getPreviewContent stacks wrapped rows with newlines", () => {
+		const component = buildComponent(2);
+		const preview = component.getPreviewContent(24);
+		expect(preview.split("\n").length).toBeGreaterThan(1);
+		// maxRows=1 preview stays a single line.
+		expect(buildComponent(1).getPreviewContent(24).split("\n")).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
좁은 터미널에서 상태줄이 넘치면 오른쪽 세그먼트가 그냥 잘려서 안 보이는데, 이걸 잘라내는 대신 다음 줄로 넘겨서 보여주는 옵션을 넣었습니다.

## 배경

tmux 창 좁게 쓰거나 화면 분할하면 비용/컨텍스트 같은 오른쪽 정보가 조용히 사라져서 좀 답답했습니다. 자주 보는 값들이라 좁을 때만이라도 아래로 접어서 보여주면 좋겠다 싶었어요.

## 변경 내용

`statusLine.maxRows` 설정을 추가했습니다 (Appearance > Status Line Rows, 1~3).

- 기본값 1은 지금과 동일합니다. 한 줄이고, 넘치면 잘립니다.
- 2나 3으로 올리면 넘치는 세그먼트를 버리지 않고 아랫줄로 넘깁니다.

폭 24 정도 좁은 창이면 이런 식으로 나옵니다:

```
🦞 │ 🆔 new
WrapSess1 │ ⏱ 15:07
```

원래대로면 두 번째 줄 내용은 잘려나갔을 겁니다.

구현은 기존 `buildStatusLine`을 헬퍼 몇 개로 쪼개서(`groupWidth`, `renderStatusGroup`, `shrinkPathToWidth`, `collectStatusSegments`) 단일행 경로랑 새로 만든 `buildStatusRows`가 같이 쓰게 했습니다. 단일행 쪽 로직(오른쪽 pop → path 축소 → 왼쪽 pop)은 안 건드려서 `maxRows=1`이면 완전히 기존 그대로입니다. 한 줄에 다 들어가면 예전처럼 좌우 정렬 + 세션 액센트 갭을 쓰고, 실제로 넘칠 때만 좌측정렬로 아래에 쌓습니다. `maxRows`를 넘어가는 건 잘라냅니다.

Appearance 프리뷰도 줄바꿈된 모습으로 나오게 했고, 행 수 고르는 동안 separator/preset처럼 바로 갱신됩니다.

## 테스트

- `bun test packages/coding-agent/test/status-line-overflow.test.ts` 18 pass (기존 단일행 테스트 그대로 + 줄바꿈/캡/프리뷰 케이스 추가)
- status-line 스위트 전체 47 pass 0 fail
- `check:types`, `biome check` 통과
- 설치본에 얹어서 /settings에서 직접 확인했습니다

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
