### PR TITLE
fix(tui): harden empty selection lists

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Empty select/settings lists now still honor cancel while preserving populated-list keybinding precedence, and settings lists keep selection indices clamped when items disappear or submenus close after list shrinkage.
+
 ## [0.7.11] - 2026-07-03
 
 ### Fixed

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -117,8 +117,15 @@ export class SelectList implements Component {
 	}
 
 	handleInput(keyData: string): void {
-		if (this.#filteredItems.length === 0) return;
 		const kb = getKeybindings();
+		if (this.#filteredItems.length === 0) {
+			if (kb.matches(keyData, "tui.select.cancel")) {
+				if (this.onCancel) {
+					this.onCancel();
+				}
+			}
+			return;
+		}
 		// Up arrow - wrap to bottom when at top
 		if (kb.matches(keyData, "tui.select.up")) {
 			this.#selectedIndex = this.#selectedIndex === 0 ? this.#filteredItems.length - 1 : this.#selectedIndex - 1;

--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -58,6 +58,14 @@ export class SettingsList implements Component {
 		this.#notifySelectionChange();
 	}
 
+	#clampSelectedIndex(): void {
+		if (this.#items.length === 0) {
+			this.#selectedIndex = 0;
+			return;
+		}
+		this.#selectedIndex = Math.max(0, Math.min(this.#selectedIndex, this.#items.length - 1));
+	}
+
 	/** Update an item's currentValue */
 	updateValue(id: string, newValue: string): void {
 		const item = this.#items.find(i => i.id === id);
@@ -75,11 +83,7 @@ export class SettingsList implements Component {
 	 */
 	setItems(items: SettingItem[]): void {
 		this.#items = items;
-		if (this.#items.length === 0) {
-			this.#selectedIndex = 0;
-		} else if (this.#selectedIndex >= this.#items.length) {
-			this.#selectedIndex = this.#items.length - 1;
-		}
+		this.#clampSelectedIndex();
 		this.#notifySelectionChange();
 	}
 
@@ -186,6 +190,13 @@ export class SettingsList implements Component {
 
 		// Main list input handling
 		const kb = getKeybindings();
+		if (this.#items.length === 0) {
+			if (kb.matches(data, "tui.select.cancel")) {
+				this.#onCancel();
+			}
+			return;
+		}
+
 		if (kb.matches(data, "tui.select.up")) {
 			this.#selectedIndex = this.#selectedIndex === 0 ? this.#items.length - 1 : this.#selectedIndex - 1;
 			this.#notifySelectionChange();
@@ -228,6 +239,7 @@ export class SettingsList implements Component {
 		// Restore selection to the item that opened the submenu
 		if (this.#submenuItemIndex !== null) {
 			this.#selectedIndex = this.#submenuItemIndex;
+			this.#clampSelectedIndex();
 			this.#submenuItemIndex = null;
 			this.#notifySelectionChange();
 		}

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -168,4 +168,38 @@ describe("SelectList", () => {
 
 		expect(selectedValue).toBe("run");
 	});
+	it("keeps populated confirm precedence when cancel also matches Enter", () => {
+		setKeybindings(
+			new KeybindingsManager(TUI_KEYBINDINGS, {
+				"tui.select.cancel": "enter",
+			}),
+		);
+		const list = new SelectList([{ value: "run", label: "run" }], 5, testTheme);
+		let selectedValue: string | undefined;
+		let cancelled = false;
+		list.onSelect = item => {
+			selectedValue = item.value;
+		};
+		list.onCancel = () => {
+			cancelled = true;
+		};
+
+		list.handleInput("\n");
+
+		expect(selectedValue).toBe("run");
+		expect(cancelled).toBe(false);
+	});
+	it("allows cancelling when no filtered items are visible", () => {
+		const list = new SelectList([{ value: "run", label: "run" }], 5, testTheme);
+		let cancelled = false;
+		list.onCancel = () => {
+			cancelled = true;
+		};
+
+		list.setFilter("missing");
+		list.handleInput("\x1b");
+
+		expect(list.render(80)).toContain("  No matching commands");
+		expect(cancelled).toBe(true);
+	});
 });

--- a/packages/tui/test/settings-list.test.ts
+++ b/packages/tui/test/settings-list.test.ts
@@ -44,4 +44,125 @@ describe("SettingsList", () => {
 
 		expect(changes).toEqual([["mode", "on"]]);
 	});
+	it("keeps populated confirm precedence when cancel also matches Enter", () => {
+		setKeybindings(
+			new KeybindingsManager(TUI_KEYBINDINGS, {
+				"tui.select.cancel": "enter",
+			}),
+		);
+		const changes: Array<[string, string]> = [];
+		let cancelled = false;
+		const list = new SettingsList(
+			[
+				{
+					id: "mode",
+					label: "Mode",
+					currentValue: "off",
+					values: ["off", "on"],
+				},
+			],
+			5,
+			testTheme,
+			(id, value) => {
+				changes.push([id, value]);
+			},
+			() => {
+				cancelled = true;
+			},
+		);
+
+		list.handleInput("\n");
+
+		expect(changes).toEqual([["mode", "on"]]);
+		expect(cancelled).toBe(false);
+	});
+	it("does not poison selection when navigation arrives while empty", () => {
+		const changes: Array<[string, string]> = [];
+		const selections: Array<string | undefined> = [];
+		const list = new SettingsList(
+			[],
+			5,
+			testTheme,
+			(id, value) => {
+				changes.push([id, value]);
+			},
+			() => {
+				throw new Error("cancel should not be called");
+			},
+			item => selections.push(item?.id),
+		);
+
+		list.handleInput("\x1b[A");
+		list.handleInput("\x1b[B");
+		list.handleInput("\n");
+		list.setItems([
+			{
+				id: "mode",
+				label: "Mode",
+				currentValue: "off",
+				values: ["off", "on"],
+			},
+		]);
+		list.handleInput("\n");
+
+		expect(Bun.stripANSI(list.render(80).join("\n"))).toContain("→ Mode");
+		expect(selections.at(-1)).toBe("mode");
+		expect(changes).toEqual([["mode", "on"]]);
+	});
+
+	it("still allows cancelling an empty list", () => {
+		let cancelled = false;
+		const list = new SettingsList(
+			[],
+			5,
+			testTheme,
+			() => {},
+			() => {
+				cancelled = true;
+			},
+		);
+
+		list.handleInput("\x1b");
+
+		expect(cancelled).toBe(true);
+	});
+
+	it("clamps selection when a submenu closes after the list shrinks", () => {
+		const list = new SettingsList(
+			[
+				{
+					id: "first",
+					label: "First",
+					currentValue: "open",
+				},
+				{
+					id: "second",
+					label: "Second",
+					currentValue: "open",
+					submenu: (_currentValue, done) => ({
+						render: () => ["submenu"],
+						handleInput: () => done(),
+						invalidate: () => {},
+					}),
+				},
+			],
+			5,
+			testTheme,
+			() => {},
+			() => {},
+		);
+
+		list.handleInput("\x1b[B");
+		list.handleInput("\n");
+		list.setItems([
+			{
+				id: "only",
+				label: "Only",
+				currentValue: "open",
+			},
+		]);
+		list.handleInput("\n");
+
+		expect(Bun.stripANSI(list.render(80).join("\n"))).toContain("→ Only");
+	});
 });


### PR DESCRIPTION
## Summary
- keep empty SelectList screens cancellable without changing populated-list keybinding precedence
- keep SettingsList selection indices clamped when the list is empty, when items are restored, and when a submenu closes after the backing list shrinks
- add regression coverage for empty-list cancel, index poisoning, submenu shrink, and overlapping cancel/confirm keybindings

## Verification
- bun test test/settings-list.test.ts test/select-list.test.ts
- bun run check
- bun run test (packages/tui, 569 pass)
- bun test packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts