### PR TITLE
fix(tui): prevent tmux scrollback replay storm on terminal resize

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -432,7 +432,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.#syncEditorMaxHeight();
 			this.updateEditorChrome();
 			this.editor.invalidate();
-			this.ui.requestRender(true, "resize");
+			this.ui.requestResizeRender();
 		};
 		process.stdout.on("resize", this.#resizeHandler);
 		try {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -526,7 +526,7 @@ export class TUI extends Container {
 			data => this.#handleInput(data),
 			() => {
 				this.invalidate();
-				this.requestRender(!(isMultiplexerSession() && !useLegacyMultiplexerFullRender()), "resize");
+				this.requestResizeRender();
 			},
 		);
 		this.#hideCursor();
@@ -768,6 +768,22 @@ export class TUI extends Container {
 		this.#lineTruncationCache.clear();
 		this.#previousWidth = 0;
 		this.#previousHeight = 0;
+	}
+
+	/**
+	 * Multiplexer-aware resize render request.
+	 *
+	 * A forced full redraw (`requestRender(true)`) resets `#previousWidth`/`#previousHeight`
+	 * to -1, which makes `#doRender` treat the frame as a width change and fall into the
+	 * `fullRender` path. In terminal multiplexers that path skips the scrollback-clearing
+	 * `3J` escape (users navigate scrollback history), so replaying every transcript line
+	 * piles it back on top of scrollback — the "top of screen scrolls down to the prompt at
+	 * high speed" resize storm. Here we keep force off in multiplexers so `#doRender`'s
+	 * height-change branch takes the viewport-only `multiplexerViewportRepaint` path instead.
+	 * Set `PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER=1` to restore the legacy forced redraw.
+	 */
+	requestResizeRender(): void {
+		this.requestRender(!(isMultiplexerSession() && !useLegacyMultiplexerFullRender()), "resize");
 	}
 
 	requestRender(force = false, source = "unknown"): void {

--- a/packages/tui/test/resize-replay-storm.test.ts
+++ b/packages/tui/test/resize-replay-storm.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Text } from "../src/components/text";
+import { TUI } from "../src/tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// Regression test for the tmux resize replay storm.
+//
+// Symptom: in a terminal multiplexer (tmux/screen/zellij), resizing the
+// terminal — especially changing only the height — caused the whole transcript
+// to replay from the top of the screen down to the prompt at high speed. The
+// effect was invisible outside multiplexers because fullRender clears
+// scrollback there.
+//
+// Root cause: InteractiveMode's resize handler unconditionally called
+// requestRender(true, "resize"). force=true resets #previousWidth/#previousHeight
+// to -1, so #doRender always sees widthChanged===true and routes through
+// fullRender. In multiplexers fullRender skips the scrollback-clearing 3J
+// escape (users navigate scrollback), so replaying every line piles it back on
+// top of scrollback — the visible storm. The fix (requestResizeRender) keeps
+// force off in multiplexers so #doRender's height-change branch takes the
+// viewport-only multiplexerViewportRepaint path.
+//
+// Set PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER=1 to opt back into the old behavior.
+
+const COLS = 100;
+
+async function buildTranscript(tui: TUI, term: VirtualTerminal, count: number): Promise<void> {
+	for (let i = 0; i < count; i++) {
+		tui.addChild(new Text(`L${i}:${"x".repeat(20)}`, 1, 0));
+	}
+	tui.requestRender(false, "setup");
+	await term.waitForRender();
+}
+
+function distinctReplayedLineMarkers(out: string): number {
+	return new Set(out.match(/L\d+:/g) ?? []).size;
+}
+
+describe("tmux resize replay storm regression", () => {
+	let origTmux: string | undefined;
+
+	beforeEach(() => {
+		origTmux = process.env.TMUX;
+		// Any truthy value trips isMultiplexerSession() in tui.ts.
+		process.env.TMUX = "/tmp/fake-tmux,4242,0";
+	});
+
+	afterEach(() => {
+		if (origTmux === undefined) delete process.env.TMUX;
+		else process.env.TMUX = origTmux;
+	});
+
+	it("requestResizeRender repaints only the viewport on a height-only change", async () => {
+		const term = new VirtualTerminal(COLS, 30);
+		const tui = new TUI(term);
+		tui.start();
+		await term.waitForRender();
+
+		await buildTranscript(tui, term, 60);
+		term.clearWriteLog();
+
+		// Height-only shrink. VirtualTerminal.resize() invokes the TUI resize
+		// callback, which now calls requestResizeRender().
+		term.resize(COLS, 20);
+		await term.waitForRender();
+
+		const out = term.getWriteLog().join("");
+		// multiplexerViewportRepaint emits at most `height` (20) distinct lines;
+		// fullRender would replay all 60.
+		expect(distinctReplayedLineMarkers(out)).toBeLessThanOrEqual(22);
+
+		tui.stop();
+	});
+
+	it("requestRender(true, resize) still replays the whole transcript (pins why requestResizeRender exists)", async () => {
+		const term = new VirtualTerminal(COLS, 30);
+		const tui = new TUI(term);
+		tui.start();
+		await term.waitForRender();
+
+		await buildTranscript(tui, term, 60);
+		term.clearWriteLog();
+
+		term.resize(COLS, 20);
+		// The old buggy call: force=true forces widthChanged, routing through
+		// fullRender → full transcript replay into multiplexer scrollback.
+		tui.requestRender(true, "resize");
+		await term.waitForRender();
+
+		const out = term.getWriteLog().join("");
+		expect(distinctReplayedLineMarkers(out)).toBeGreaterThanOrEqual(55);
+
+		tui.stop();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes a scrollback replay storm where resizing the terminal inside **tmux** (or any terminal multiplexer: screen/zellij) replayed the entire transcript from the top of the screen down to the prompt at high speed.

## Problem

When GJC runs inside a terminal multiplexer, resizing the terminal window — especially changing only the height — causes the whole transcript to visibly replay from the top of the screen down to the current prompt at high speed. The effect is **invisible outside multiplexers** because the same code path clears scrollback there.

### Reproduction

The storm reproduces whenever tmux is the active session. Confirmed cases:

1. **Local tmux + remote attach** — Start tmux locally → launch `gjc` → from another machine, SSH in and attach to the tmux session → resize the terminal.
2. **Remote tmux** — SSH into a remote server → start tmux → launch `gjc` → resize the terminal.

The common factor is **tmux**; SSH itself is not required, and the order (tmux / gjc / SSH) does not matter. Without a multiplexer, resizing works cleanly (no replay).

## Root Cause

`InteractiveMode`'s resize handler unconditionally called `requestRender(true, "resize")`:

```ts
this.#resizeHandler = () => {
    this.#syncEditorMaxHeight();
    this.updateEditorChrome();
    this.editor.invalidate();
    this.ui.requestRender(true, "resize"); // <-- always force
};
```

The `force=true` argument has a destructive side effect inside `requestRender()` (`packages/tui/src/tui.ts`):

```ts
if (force) {
    ...
    this.#previousWidth = -1;  // -1 triggers widthChanged, forcing a full clear
    this.#previousHeight = -1; // -1 triggers heightChanged, forcing a full clear
    ...
}
```

Resetting `#previousWidth` to `-1` makes `#doRender` compute `widthChanged = (-1 !== 0 && -1 !== width) === true` **regardless of whether the width actually changed**. This forces the frame into the `fullRender` path:

```ts
// Width changes always need a full re-render because wrapping changes.
if (widthChanged) {
    fullRender(true, "terminal width changed");
    return;
}
```

`fullRender` re-emits **every** transcript line. In multiplexers it deliberately skips the scrollback-clearing `\x1b[3J` escape (users navigate scrollback history), so replaying every line piles it back on top of scrollback — the visible storm:

```ts
// Skip clearing scrollback (3J) in multiplexers — users actively navigate scrollback history
if (clear) buffer += isMultiplexerSession() ? "\x1b[2J\x1b[H" : "\x1b[2J\x1b[H\x1b[3J";
```

Outside multiplexers, the same `fullRender` emits `\x1b[3J` and clears scrollback, so the redraw is visually clean — which is why the bug only manifested under tmux.

Notably, `ProcessTerminal.start()` already had the **correct** multiplexer-aware logic for its own resize callback:

```ts
this.requestRender(!(isMultiplexerSession() && !useLegacyMultiplexerFullRender()), "resize");
```

But because `requestRender` is tick-debounced (one render per `process.nextTick`), `InteractiveMode`'s later `requestRender(true, ...)` superseded it and forced the full redraw anyway.

## Fix

1. Extract the multiplexer-aware force decision into a new `TUI.requestResizeRender()` method:
   ```ts
   requestResizeRender(): void {
       this.requestRender(!(isMultiplexerSession() && !useLegacyMultiplexerFullRender()), "resize");
   }
   ```
2. Both resize handlers now call it:
   - `ProcessTerminal.start()` resize callback (replaces the inline expression — DRY)
   - `InteractiveMode.#resizeHandler` (the actual bug fix)

In a multiplexer, `requestResizeRender()` now passes `force=false`, so `#doRender` does not reset `#previousWidth` and correctly detects the real change:
- **Height-only change** → `heightChanged` branch → `multiplexerViewportRepaint` (repaints only the `height` visible lines, scrollback untouched). ✅
- **Width change** → `widthChanged` branch → `fullRender` (unavoidable; wrapping semantics change). This still happens, but only when the width actually changes.
- **No change** → differential patch.

`PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER=1` restores the legacy forced-full-redraw behavior.

## Verification

- `tsgo` typecheck passes for both `packages/tui` and `packages/coding-agent`.
- `biome check` clean on all three changed files.
- New regression test `packages/tui/test/resize-replay-storm.test.ts` asserts the two paths diverge in a simulated `TMUX` session:
  - `requestResizeRender()` repaints **≤ 22** distinct lines (viewport-only).
  - `requestRender(true, "resize")` replays **≥ 55** distinct lines (full transcript).
- Full `packages/tui` test suite: **561 pass, 0 fail** (including the 2 new tests).

## Manual test plan

- [ ] `tmux` → `gjc` → have a multi-turn conversation → resize the tmux pane (height-only and width) → no replay storm, scrollback intact.
- [ ] Non-tmux terminal → resize → clean full redraw (no regression).
- [ ] `PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER=1` in tmux → legacy full-redraw behavior restored.

## Notes

The same `force=true`-induced `widthChanged` pattern exists at a few other one-time / intentional call sites (`start()`, sixel probe, external-editor resume, shutdown) that are low-risk because they fire once per lifecycle event. A separate audit of frequent-action force renders (e.g. autocomplete cancel) and the unguarded `clearOnShrink` full-paint path can be filed as follow-up.
