### PR TITLE
fix(tui): keep session picker selection valid

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - The Python `gjc_rpc` client no longer tears down its reader loop on real server frames it had not modeled: OAuth `open_url` extension-UI requests emitted during `login`, `workflow_gate` frames carrying structured `{value, label, description}` options (the `next_workflow_gate()` queue path re-parsed them with a legacy strings-only parser), and `max`/`inherit` thinking levels returned by `get_state`/model info. `install_headless_ui` now answers interactive UI requests with `extension_ui_response` frames instead of misrouting them as `workflow_gate_response` commands, and `get_pending_workflow_gates()` is exposed as a typed method. Previously dropped payloads (`notice`, `thinking_level_changed`, `goal_updated`, `irc_message`, `subagent_steer_message` events; `agent_end.stopReason`/`telemetry`/`coverage`; `auto_retry_start.unbounded`; `auto_compaction_end.continuationSkipReason`; gate `required`) now parse into typed models, and the env-gated real-binary lane covers the new surface.
+- The session picker now keeps its selection index valid after an empty search result is navigated and then cleared, so Enter still resumes the first restored session instead of leaving the list with no selected row.
 
 ## [0.7.11] - 2026-07-03
 

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -50,6 +50,14 @@ class SessionList implements Component {
 		};
 	}
 
+	#clampSelectedIndex(): void {
+		if (this.#filteredSessions.length === 0) {
+			this.#selectedIndex = 0;
+			return;
+		}
+		this.#selectedIndex = Math.max(0, Math.min(this.#selectedIndex, this.#filteredSessions.length - 1));
+	}
+
 	#filterSessions(query: string): void {
 		this.#filteredSessions = fuzzyFilter(this.allSessions, query, session => {
 			const parts = [
@@ -62,7 +70,7 @@ class SessionList implements Component {
 			];
 			return parts.filter(Boolean).join(" ");
 		});
-		this.#selectedIndex = Math.min(this.#selectedIndex, Math.max(0, this.#filteredSessions.length - 1));
+		this.#clampSelectedIndex();
 	}
 
 	removeSession(sessionPath: string): void {
@@ -71,10 +79,6 @@ class SessionList implements Component {
 		this.allSessions.splice(index, 1);
 		// Re-filter to update filteredSessions
 		this.#filterSessions(this.#searchInput.getValue());
-		// Adjust selectedIndex if we deleted the last item or beyond
-		if (this.#selectedIndex >= this.#filteredSessions.length) {
-			this.#selectedIndex = Math.max(0, this.#filteredSessions.length - 1);
-		}
 	}
 
 	invalidate(): void {
@@ -182,6 +186,12 @@ class SessionList implements Component {
 	}
 
 	handleInput(keyData: string): void {
+		const moveSelection = (delta: number): void => {
+			if (this.#filteredSessions.length === 0) return;
+			this.#selectedIndex += delta;
+			this.#clampSelectedIndex();
+		};
+
 		// Delete key - request delete confirmation from parent
 		if (matchesKey(keyData, "delete")) {
 			const selected = this.#filteredSessions[this.#selectedIndex];
@@ -193,22 +203,22 @@ class SessionList implements Component {
 
 		// Up arrow
 		if (matchesKey(keyData, "up")) {
-			this.#selectedIndex = Math.max(0, this.#selectedIndex - 1);
+			moveSelection(-1);
 			return;
 		}
 		// Down arrow
 		if (matchesKey(keyData, "down")) {
-			this.#selectedIndex = Math.min(this.#filteredSessions.length - 1, this.#selectedIndex + 1);
+			moveSelection(1);
 			return;
 		}
 		// Page up - jump up by maxVisible items
 		if (matchesKey(keyData, "pageUp")) {
-			this.#selectedIndex = Math.max(0, this.#selectedIndex - this.#maxVisible);
+			moveSelection(-this.#maxVisible);
 			return;
 		}
 		// Page down - jump down by maxVisible items
 		if (matchesKey(keyData, "pageDown")) {
-			this.#selectedIndex = Math.min(this.#filteredSessions.length - 1, this.#selectedIndex + this.#maxVisible);
+			moveSelection(this.#maxVisible);
 			return;
 		}
 		// Enter

--- a/packages/coding-agent/test/modes/controllers/session-selector-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/session-selector-delete.test.ts
@@ -26,10 +26,13 @@ function createSession(id: string, title: string): SessionInfo {
 	};
 }
 
-function createSelector(onDelete: (session: SessionInfo) => Promise<boolean>): SessionSelectorComponent {
+function createSelector(
+	onDelete: (session: SessionInfo) => Promise<boolean>,
+	onSelect: (sessionPath: string) => void = () => {},
+): SessionSelectorComponent {
 	return new SessionSelectorComponent(
 		[createSession("session-a", "Alpha"), createSession("session-b", "Beta")],
-		() => {},
+		onSelect,
 		() => {},
 		() => {},
 		onDelete,
@@ -37,7 +40,7 @@ function createSelector(onDelete: (session: SessionInfo) => Promise<boolean>): S
 }
 
 function renderText(selector: SessionSelectorComponent): string {
-	return selector.render(120).join("\n");
+	return Bun.stripANSI(selector.render(120).join("\n"));
 }
 
 describe("SessionSelectorComponent delete confirmation", () => {
@@ -89,5 +92,24 @@ describe("SessionSelectorComponent delete confirmation", () => {
 		expect(onDelete).toHaveBeenCalledTimes(1);
 		expect(rendered).not.toContain("Alpha");
 		expect(rendered).toContain("Beta");
+	});
+	it("keeps selection valid after navigating empty search results", () => {
+		const onSelect = vi.fn();
+		const selector = createSelector(async () => false, onSelect);
+
+		for (const char of "zzz") selector.handleInput(char);
+		expect(renderText(selector)).toContain("No sessions in current folder");
+
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[6~");
+		for (let i = 0; i < 3; i++) selector.handleInput("\x7f");
+
+		const rendered = renderText(selector);
+		expect(rendered).toContain("Alpha");
+		expect(rendered).toContain("❯ Alpha");
+
+		selector.handleInput("\n");
+
+		expect(onSelect).toHaveBeenCalledWith("/tmp/session-a.jsonl");
 	});
 });


### PR DESCRIPTION
## Summary
- clamp the session picker selection index whenever search results shrink to zero and later repopulate
- route arrow/page navigation through one bounded movement helper so empty result navigation cannot poison selection with -1
- add regression coverage for empty search navigation followed by clearing the filter and pressing Enter

## Verification
- bun test test/modes/controllers/session-selector-delete.test.ts
- bun run check

## Red-team repro
1. Open the session picker with at least one session.
2. Type a query with no matches.
3. Press Down/PageDown.
4. Backspace the query away.
5. Press Enter.

Before this fix, no row was selected and Enter did nothing. After this fix, the first restored session is selected and resumes.