### PR TITLE
feat(coding-agent): refresh session titles as the conversation topic drifts

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -443,7 +443,7 @@ Extra conditional behavior:
 | `GJC_SMOL_MODEL`              | Ephemeral model-role override for `smol` (CLI `--smol` takes precedence)                           |
 | `GJC_SLOW_MODEL`              | Ephemeral model-role override for `slow` (CLI `--slow` takes precedence)                           |
 | `GJC_PLAN_MODEL`              | Ephemeral model-role override for `plan` (CLI `--plan` takes precedence)                           |
-| `GJC_NO_TITLE`                | If set (any non-empty value), disables auto session title generation on first user message         |
+| `GJC_NO_TITLE`                | If set (any non-empty value), disables auto session title generation and periodic title refresh    |
 | `GJC_NO_CMUX_RENAME`         | If set (any non-empty value), disables renaming the containing cmux workspace to the current session name |
 | `NULL_PROMPT`                | If `true`, system prompt builder returns empty string                                              |
 | `GJC_BLOCKED_AGENT`           | Blocks a specific subagent type in task tool                                                       |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - The `/model` preset landing now shows the session's current preset, model, and per-role assignments in the header, marks the active preset with `(current)`, and Enter now expands/collapses provider groups (right/left arrows still work).
 
+### Changed
+
+- Session titles now refresh automatically as the conversation topic drifts: after every 8 user messages, an auto-generated title is regenerated from the trailing user messages (weighting the newest highest). User-set names (`/rename`) are never overwritten, and legacy titles without a recorded source are treated as user-owned. Interactive mode also now generates an initial title for resumed sessions that never got one, and retries on the same bounded interval after silent generation failures (previously the title was attempted exactly once, on the first message of a brand-new session). The opt-out now honors the documented `GJC_NO_TITLE` alias in addition to `PI_NO_TITLE` (previously only `PI_NO_TITLE` was checked).
+
+## [0.7.11] - 2026-07-03
 ### Fixed
 
 - The Python `gjc_rpc` client no longer tears down its reader loop on real server frames it had not modeled: OAuth `open_url` extension-UI requests emitted during `login`, `workflow_gate` frames carrying structured `{value, label, description}` options (the `next_workflow_gate()` queue path re-parsed them with a legacy strings-only parser), and `max`/`inherit` thinking levels returned by `get_state`/model info. `install_headless_ui` now answers interactive UI requests with `extension_ui_response` frames instead of misrouting them as `workflow_gate_response` commands, and `get_pending_workflow_gates()` is exposed as a typed method. Previously dropped payloads (`notice`, `thinking_level_changed`, `goal_updated`, `irc_message`, `subagent_steer_message` events; `agent_end.stopReason`/`telemetry`/`coverage`; `auto_retry_start.unbounded`; `auto_compaction_end.continuationSkipReason`; gate `required`) now parse into typed models, and the env-gated real-binary lane covers the new surface.

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
 import type { AutocompleteProvider, SlashCommand } from "@gajae-code/tui";
-import { $env, sanitizeText } from "@gajae-code/utils";
+import { $pickenv, sanitizeText } from "@gajae-code/utils";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { resolveSubskillActivationForSkillInvocation } from "../../extensibility/gjc-plugins";
 import { buildSkillPromptMessage, parseSkillInvocations } from "../../extensibility/skills";
@@ -18,7 +18,14 @@ import { copyToClipboard, readImageFromClipboard } from "../../utils/clipboard";
 import { getEditorCommand, openInEditor } from "../../utils/external-editor";
 import { ensureSupportedImageInput, ImageInputTooLargeError, loadImageInput } from "../../utils/image-loading";
 import { resizeImage } from "../../utils/image-resize";
-import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
+import {
+	buildTitleGenerationInput,
+	evaluateTitleGeneration,
+	generateSessionTitle,
+	reconcileTitleAttemptBaseline,
+	setSessionTerminalTitle,
+	type TitleAttemptBaseline,
+} from "../../utils/title-generator";
 
 interface Expandable {
 	setExpanded(expanded: boolean): void;
@@ -36,6 +43,11 @@ export class InputController {
 	constructor(private ctx: InteractiveModeContext) {}
 
 	#lastBackgroundFoldKeyTime = 0;
+
+	/** Session id + user-message count at the last title-generation attempt (or
+	 *  at this run's first submission for that session). Drives the bounded
+	 *  retry/refresh cadence for auto-generated session titles. */
+	#titleAttemptBaseline: TitleAttemptBaseline | undefined;
 
 	/** Set after a first Esc silently consumes a queued steer. Kept until the
 	 *  queued steer is either cancelled by a second Esc or drained by continuation,
@@ -421,12 +433,41 @@ export class InputController {
 			// First, move any pending bash components to chat
 			this.ctx.flushPendingBashComponents();
 
-			// Generate session title on first message
-			const hasUserMessages = this.ctx.session.messages.some((m: AgentMessage) => m.role === "user");
-			if (!hasUserMessages && !this.ctx.sessionManager.getSessionName() && !$env.PI_NO_TITLE) {
+			// Generate or refresh the session title. Fires on the first user
+			// message of a run (including resumed sessions that never got a
+			// title), retries on a bounded interval after silent failures, and
+			// refreshes drifted auto-generated titles as the topic moves.
+			// User-set names (/rename) always take precedence and are never
+			// overwritten.
+			const priorUserMessages = this.ctx.session.messages.filter(
+				(m: AgentMessage): m is Extract<AgentMessage, { role: "user" }> => m.role === "user",
+			);
+			this.#titleAttemptBaseline = reconcileTitleAttemptBaseline(
+				this.#titleAttemptBaseline,
+				this.ctx.session.sessionId,
+				priorUserMessages.length,
+			);
+			const titleGeneration = evaluateTitleGeneration({
+				disabled: Boolean($pickenv("GJC_NO_TITLE", "PI_NO_TITLE")),
+				sessionName: this.ctx.sessionManager.getSessionName(),
+				titleSource: this.ctx.sessionManager.titleSource,
+				userMessagesSinceLastAttempt: priorUserMessages.length - this.#titleAttemptBaseline.userMessages,
+			});
+			if (titleGeneration) {
+				this.#titleAttemptBaseline = {
+					sessionId: this.ctx.session.sessionId,
+					userMessages: priorUserMessages.length,
+				};
 				const registry = this.ctx.session.modelRegistry;
+				const titleInput =
+					titleGeneration === "refresh"
+						? buildTitleGenerationInput(
+								priorUserMessages.map(m => m.content),
+								text,
+							)
+						: text;
 				generateSessionTitle(
-					text,
+					titleInput,
 					registry,
 					this.ctx.settings,
 					this.ctx.session.sessionId,

--- a/packages/coding-agent/src/prompts/system/title-system.md
+++ b/packages/coding-agent/src/prompts/system/title-system.md
@@ -1,2 +1,2 @@
-Generate a 3-6 word title for a coding session from the user's first message. Capture the main task or topic.
+Generate a 3-6 word title for a coding session from the user's recent message(s). Capture the main task or topic, weighting the most recent message highest.
 Output ONLY the title. No quotes or trailing punctuation.

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -3,7 +3,14 @@
  */
 import * as path from "node:path";
 
-import { type Api, type AssistantMessage, completeSimple, type Model, type Tool } from "@gajae-code/ai";
+import {
+	type Api,
+	type AssistantMessage,
+	completeSimple,
+	type Model,
+	type Tool,
+	type UserMessage,
+} from "@gajae-code/ai";
 import { logger, prompt } from "@gajae-code/utils";
 import type { ModelRegistry } from "../config/model-registry";
 import { resolveRoleSelection } from "../config/model-resolver";
@@ -27,6 +34,88 @@ const SET_TITLE_TOOL_NAME = "set_title";
 // Beyond the cap we treat the response as a non-title hallucination and reject it.
 const MAX_TITLE_CHARS = 80;
 const MAX_TITLE_WORDS = 12;
+
+/** User messages between automatic title refreshes (and retries after a silent failure). */
+export const TITLE_GENERATION_USER_MESSAGE_INTERVAL = 8;
+/** Trailing user messages (including the one being submitted) fed to the title model. */
+const TITLE_INPUT_CONTEXT_MESSAGES = 3;
+
+export type TitleGenerationKind = "initial" | "refresh";
+
+/**
+ * Decide whether a user message submission should trigger title generation.
+ *
+ * - `initial`: the session has no name yet. Fires on the first submission of a
+ *   run (covers brand-new sessions and resumed sessions that never got a title)
+ *   and retries on a bounded interval after silent generation failures.
+ * - `refresh`: the session has an auto-generated name and enough user messages
+ *   have accumulated since the last attempt that the topic may have drifted.
+ * - User-set names take permanent precedence (mirrors SessionManager.setSessionName).
+ *   A name without a recorded source (legacy sessions) is treated as user-owned.
+ */
+export function evaluateTitleGeneration(options: {
+	disabled: boolean;
+	sessionName: string | undefined;
+	titleSource: "auto" | "user" | undefined;
+	/** User messages submitted since the last attempt (or since this run's first submission). */
+	userMessagesSinceLastAttempt: number;
+}): TitleGenerationKind | undefined {
+	if (options.disabled) return undefined;
+	if (options.titleSource === "user") return undefined;
+	const since = options.userMessagesSinceLastAttempt;
+	if (!options.sessionName) {
+		return since === 0 || since >= TITLE_GENERATION_USER_MESSAGE_INTERVAL ? "initial" : undefined;
+	}
+	if (options.titleSource !== "auto") return undefined;
+	return since >= TITLE_GENERATION_USER_MESSAGE_INTERVAL ? "refresh" : undefined;
+}
+
+export interface TitleAttemptBaseline {
+	sessionId: string;
+	userMessages: number;
+}
+
+/**
+ * Reconcile the per-run title-attempt baseline against the current session
+ * state before evaluating title generation:
+ * - a different session (switch) or no baseline starts fresh at the current count;
+ * - history rewrites (compaction, pruning, checkpoint rewind) can shrink the
+ *   message list below the recorded baseline, which would make the cadence
+ *   unreachable — clamp down so title generation can still fire.
+ */
+export function reconcileTitleAttemptBaseline(
+	baseline: TitleAttemptBaseline | undefined,
+	sessionId: string,
+	userMessageCount: number,
+): TitleAttemptBaseline {
+	if (!baseline || baseline.sessionId !== sessionId) {
+		return { sessionId, userMessages: userMessageCount };
+	}
+	return { sessionId, userMessages: Math.min(baseline.userMessages, userMessageCount) };
+}
+
+function userContentText(content: UserMessage["content"]): string {
+	if (typeof content === "string") return content;
+	return content
+		.filter((block): block is Extract<(typeof content)[number], { type: "text" }> => block.type === "text")
+		.map(block => block.text)
+		.join("\n");
+}
+
+/**
+ * Build the title-model input from the trailing user messages plus the message
+ * being submitted, so refreshed titles reflect the current topic rather than
+ * the session's first message.
+ */
+export function buildTitleGenerationInput(priorUserContents: UserMessage["content"][], currentText: string): string {
+	const texts = priorUserContents
+		.slice(-(TITLE_INPUT_CONTEXT_MESSAGES - 1))
+		.map(userContentText)
+		.concat(currentText)
+		.map(text => text.trim())
+		.filter(text => text.length > 0);
+	return texts.join("\n\n");
+}
 
 const setTitleTool: Tool = {
 	name: SET_TITLE_TOOL_NAME,

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as ai from "@gajae-code/ai";
 import { type Api, getBundledModel, type Model } from "@gajae-code/ai";
-import { formatSessionTerminalTitle, generateSessionTitle } from "../src/utils/title-generator";
+import {
+	buildTitleGenerationInput,
+	evaluateTitleGeneration,
+	formatSessionTerminalTitle,
+	generateSessionTitle,
+	reconcileTitleAttemptBaseline,
+	TITLE_GENERATION_USER_MESSAGE_INTERVAL,
+} from "../src/utils/title-generator";
 
 function getModelOrThrow(id: string): Model<Api> {
 	const model = getBundledModel("anthropic", id);
@@ -123,5 +130,126 @@ describe("formatSessionTerminalTitle", () => {
 
 	it("falls back to GJC when the sanitized session name is empty", () => {
 		expect(formatSessionTerminalTitle("\u0001\u001b")).toBe("GJC");
+	});
+});
+
+describe("evaluateTitleGeneration", () => {
+	const interval = TITLE_GENERATION_USER_MESSAGE_INTERVAL;
+
+	it("fires initial generation on the first submission of an unnamed session (new or resumed)", () => {
+		expect(
+			evaluateTitleGeneration({
+				disabled: false,
+				sessionName: undefined,
+				titleSource: undefined,
+				userMessagesSinceLastAttempt: 0,
+			}),
+		).toBe("initial");
+	});
+
+	it("retries initial generation only after the interval elapses", () => {
+		const base = {
+			disabled: false,
+			sessionName: undefined,
+			titleSource: undefined,
+		};
+		expect(evaluateTitleGeneration({ ...base, userMessagesSinceLastAttempt: 1 })).toBeUndefined();
+		expect(evaluateTitleGeneration({ ...base, userMessagesSinceLastAttempt: interval - 1 })).toBeUndefined();
+		expect(evaluateTitleGeneration({ ...base, userMessagesSinceLastAttempt: interval })).toBe("initial");
+	});
+
+	it("refreshes an auto-generated title once the interval elapses", () => {
+		const base = {
+			disabled: false,
+			sessionName: "Fix resolver bug",
+			titleSource: "auto" as const,
+		};
+		expect(evaluateTitleGeneration({ ...base, userMessagesSinceLastAttempt: 0 })).toBeUndefined();
+		expect(evaluateTitleGeneration({ ...base, userMessagesSinceLastAttempt: interval - 1 })).toBeUndefined();
+		expect(evaluateTitleGeneration({ ...base, userMessagesSinceLastAttempt: interval })).toBe("refresh");
+	});
+
+	it("never overwrites a user-set name", () => {
+		expect(
+			evaluateTitleGeneration({
+				disabled: false,
+				sessionName: "my name",
+				titleSource: "user",
+				userMessagesSinceLastAttempt: interval * 10,
+			}),
+		).toBeUndefined();
+	});
+
+	it("treats a named session without a recorded source as user-owned", () => {
+		expect(
+			evaluateTitleGeneration({
+				disabled: false,
+				sessionName: "legacy name",
+				titleSource: undefined,
+				userMessagesSinceLastAttempt: interval * 10,
+			}),
+		).toBeUndefined();
+	});
+
+	it("does nothing when title generation is disabled", () => {
+		expect(
+			evaluateTitleGeneration({
+				disabled: true,
+				sessionName: undefined,
+				titleSource: undefined,
+				userMessagesSinceLastAttempt: 0,
+			}),
+		).toBeUndefined();
+	});
+});
+
+describe("buildTitleGenerationInput", () => {
+	it("joins the trailing user messages with the current text", () => {
+		expect(buildTitleGenerationInput(["first", "second", "third"], "current")).toBe("second\n\nthird\n\ncurrent");
+	});
+
+	it("extracts text blocks from structured user content", () => {
+		expect(
+			buildTitleGenerationInput(
+				[
+					[
+						{ type: "text", text: "look at this" },
+						{ type: "image", data: "abc", mimeType: "image/png" },
+					],
+				],
+				"current",
+			),
+		).toBe("look at this\n\ncurrent");
+	});
+
+	it("skips empty messages", () => {
+		expect(buildTitleGenerationInput(["", "   "], "current")).toBe("current");
+	});
+
+	it("returns just the current text when there is no prior context", () => {
+		expect(buildTitleGenerationInput([], "current")).toBe("current");
+	});
+});
+
+describe("reconcileTitleAttemptBaseline", () => {
+	it("starts fresh at the current count when there is no baseline", () => {
+		expect(reconcileTitleAttemptBaseline(undefined, "s1", 5)).toEqual({ sessionId: "s1", userMessages: 5 });
+	});
+
+	it("resets when the session changes (session switch)", () => {
+		const baseline = { sessionId: "s1", userMessages: 2 };
+		expect(reconcileTitleAttemptBaseline(baseline, "s2", 20)).toEqual({ sessionId: "s2", userMessages: 20 });
+	});
+
+	it("keeps the baseline while the message count grows", () => {
+		const baseline = { sessionId: "s1", userMessages: 3 };
+		expect(reconcileTitleAttemptBaseline(baseline, "s1", 9)).toEqual({ sessionId: "s1", userMessages: 3 });
+	});
+
+	it("clamps down after a history rewrite shrinks the message list", () => {
+		// Compaction/pruning/checkpoint rewind can drop user messages below the
+		// recorded baseline; without clamping the cadence would never fire again.
+		const baseline = { sessionId: "s1", userMessages: 12 };
+		expect(reconcileTitleAttemptBaseline(baseline, "s1", 4)).toEqual({ sessionId: "s1", userMessages: 4 });
 	});
 });


### PR DESCRIPTION
Resubmission of #1472 against `dev` per repo contribution policy (previous PR targeted `main` and was closed). Also addresses the Codex P2 review from #1472.

## Problem

Title generation is a one-shot: attempted exactly once on the first user message of a brand-new session, never retried on silent failure (no title model / missing API key / model error are all swallowed by `.catch(() => {})`), and never run at all for sessions resumed without a title (`hasUserMessages` is already true, so the guard skips forever). Long sessions keep a stale title as the topic drifts.

## Change (interactive mode)

- **Drift refresh**: auto-generated titles are regenerated every 8 user messages (`TITLE_GENERATION_USER_MESSAGE_INTERVAL`) from the trailing user messages (newest weighted highest) instead of only the first message.
- **Resumed-session fix**: an unnamed resumed session now gets an initial title on its next submission.
- **Bounded retry**: silent generation failures retry on the same 8-message interval instead of giving up permanently.
- **Baseline reconciliation**: the attempt baseline tracks `{sessionId, userMessages}` and is reconciled each submission — reset on session switch, clamped down after history rewrites (`agent.replaceMessages` via compaction, pruning, checkpoint rewind) which shrink the in-memory message list and would otherwise make the cadence unreachable.
- **Codex P2 (from #1472)**: the opt-out guard now honors the documented `GJC_NO_TITLE` alias via `$pickenv("GJC_NO_TITLE", "PI_NO_TITLE")`, matching the per-call-site alias convention used elsewhere. Previously only `PI_NO_TITLE` was checked, so the documented flag silently did nothing for interactive title generation.

## Invariants preserved

- User-set names (`/rename`) keep permanent precedence (`titleSource === "user"` is never overwritten).
- A name without a recorded `titleSource` (legacy sessions) is treated as user-owned and never refreshed.
- Terminal/cmux title sync reuses the existing applied-title path.

## Implementation notes

- Decision logic is a pure function `evaluateTitleGeneration()`; model input built by `buildTitleGenerationInput()` (filters image blocks); baseline handled by `reconcileTitleAttemptBaseline()` — all unit-tested.
- `title-system.md` prompt generalized from "first message" to "recent message(s), weighting the most recent highest".
- Changelog entry under `[Unreleased]`; `GJC_NO_TITLE` doc row updated.

## Verification

- `bun test` title-generator (30), input-controller keybindings/skill-queue, title-source-persistence — all pass on the rebased branch
- `bun run --cwd packages/coding-agent check` (biome + tsgo) — green