### PR TITLE
fix(coding-agent): honor GJC_NO_TITLE alias in managed tmux launch title guard

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The managed tmux launch root-terminal-title guard now honors the documented `GJC_NO_TITLE` alias in addition to `PI_NO_TITLE`; previously the documented flag did not suppress the tmux root terminal title.
+
 ### Added
 
 - The `/model` preset landing now shows the session's current preset, model, and per-role assignments in the header, marks the active preset with `(current)`, and Enter now expands/collapses provider groups (right/left arrows still work).

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -476,7 +476,7 @@ function applyGjcTmuxRootTerminalTitleProfile(context: {
 }
 
 function shouldSetGjcTmuxRootTerminalTitle(parsed: Args, env: NodeJS.ProcessEnv): boolean {
-	return !parsed.noTitle && !env.PI_NO_TITLE;
+	return !parsed.noTitle && !env.GJC_NO_TITLE && !env.PI_NO_TITLE;
 }
 
 function buildTmuxRenameWindowArgs(title: string, target?: string): string[] {

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -255,6 +255,34 @@ describe("default GJC tmux launch", () => {
 		expect(writeSpy).not.toHaveBeenCalled();
 	});
 
+	it("honors the documented GJC_NO_TITLE alias while launching managed tmux", () => {
+		const calls: Array<{ command: string; args: string[] }> = [];
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"], tmux: true }),
+			rawArgs: ["--tmux", "hello world"],
+			cwd: "/repo",
+			env: { GJC_NO_TITLE: "1" },
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			existingBranchSessionName: null,
+			currentBranch: "feature/demo",
+			spawnSync: (command, spawnArgs) => {
+				calls.push({ command, args: spawnArgs });
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls.some(call => call.args.includes("set-titles") || call.args.includes("set-titles-string"))).toBe(
+			false,
+		);
+		expect(writeSpy).not.toHaveBeenCalled();
+	});
+
 	it("passes prefixed tmux window titles after the tmux option separator", () => {
 		const calls: Array<{ command: string; args: string[]; options: TmuxSpawnOptions }> = [];
 		const handled = launchDefaultTmuxIfNeeded({


### PR DESCRIPTION
Follow-up to the Codex P2 finding on #1472 (fixed for interactive title generation in #1476): the managed tmux launch root-terminal-title guard had the same gap.

## Problem

`shouldSetGjcTmuxRootTerminalTitle` only checked `PI_NO_TITLE`, so the documented `GJC_NO_TITLE` flag (see `docs/environment-variables.md`) did not suppress the tmux root terminal title on managed `--tmux` launches.

## Change

- Guard now checks `env.GJC_NO_TITLE` in addition to `env.PI_NO_TITLE` (both on the injected env param, keeping the function testable).
- Added a `GJC_NO_TITLE` variant of the existing `PI_NO_TITLE` launch test.
- Changelog entry under `[Unreleased]` / Fixed.

Kept separate from #1476 since it touches a different surface (launch path vs interactive session titles).

## Verification

- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts` — 69 pass
- `bun run --cwd packages/coding-agent check` (biome + tsgo) — green