### PR TITLE
fix(coding-agent): make Escape cancel workflow tasks reliably

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Added a `statusLine.maxRows` setting (Appearance → Status Line Rows). When it is greater than 1, status line segments that overflow a narrow terminal now wrap onto additional rows instead of being dropped; the default of 1 keeps the existing single-line, drop-on-overflow behavior. The Appearance preview reflects the wrapped layout.
 
+### Fixed
+
+- Escape now reliably cancels active context maintenance, handoff generation, retry backoff, and workflow ask dialogs even when transient UI focus or typed drafts would previously consume the key.
+
 ## [0.7.11] - 2026-07-03
 ### Fixed
 

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -138,6 +138,7 @@ export class EventController {
 			this.ctx.editor.onEscape = this.ctx.retryEscapeHandler;
 			this.ctx.retryEscapeHandler = undefined;
 		}
+		this.ctx.retryEscapePrimed = false;
 		if (this.ctx.retryLoader) {
 			this.ctx.retryLoader.stop();
 			this.ctx.retryLoader = undefined;
@@ -241,6 +242,7 @@ export class EventController {
 			this.ctx.retryLoader = undefined;
 			this.ctx.statusContainer.clear();
 		}
+		this.ctx.retryEscapePrimed = false;
 		this.#cancelIdleCompaction();
 		this.ctx.updateEditorBorderColor();
 		this.ctx.ensureLoadingAnimation();
@@ -768,6 +770,7 @@ export class EventController {
 		if (!this.ctx.retryEscapeHandler) {
 			this.ctx.retryEscapeHandler = this.ctx.editor.onEscape;
 		}
+		this.ctx.retryEscapePrimed = false;
 		let escPressed = false;
 		this.ctx.editor.onEscape = () => {
 			if (!escPressed) {
@@ -818,6 +821,7 @@ export class EventController {
 			this.ctx.retryLoader = undefined;
 			this.ctx.statusContainer.clear();
 		}
+		this.ctx.retryEscapePrimed = false;
 		if (!event.success) {
 			this.ctx.showError(`Retry failed after ${event.attempt} attempts: ${event.finalError || "Unknown error"}`);
 		}

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
-import type { AutocompleteProvider, SlashCommand } from "@gajae-code/tui";
+import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@gajae-code/tui";
 import { $env, sanitizeText } from "@gajae-code/utils";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { resolveSubskillActivationForSkillInvocation } from "../../extensibility/gjc-plugins";
@@ -42,6 +42,127 @@ export class InputController {
 	 *  so abort cleanup going idle cannot turn the second Esc into an idle action. */
 	#steerConsumePending = false;
 
+	#globalInterruptUnsubscribe: (() => void) | undefined;
+
+	#matchesInterruptKey(data: string): boolean {
+		return this.ctx.keybindings.getKeys("app.interrupt").some(key => matchesKey(data, key));
+	}
+
+	#hasHookDialog(): boolean {
+		return Boolean(this.ctx.hookSelector || this.ctx.hookInput || this.ctx.hookEditor);
+	}
+
+	#isRetryBackoffActive(): boolean {
+		return Boolean(
+			this.ctx.retryLoader ||
+				this.ctx.retryEscapeHandler ||
+				(this.ctx.session.isRetrying && !this.ctx.session.isStreaming),
+		);
+	}
+
+	#handleCancellableWorkEscape(options: {
+		loading?: boolean;
+		processes?: boolean;
+		modes?: boolean;
+		maintenance?: boolean;
+		retry?: boolean;
+		streaming?: boolean;
+	}): boolean {
+		if (options.loading && this.ctx.loadingAnimation) {
+			if (this.ctx.cancelPendingSubmission()) {
+				return true;
+			}
+			this.restoreQueuedMessagesToEditor({ abort: true });
+			return true;
+		}
+		if (options.processes && this.ctx.session.isBashRunning) {
+			this.ctx.session.abortBash();
+			return true;
+		}
+		if (options.modes && this.ctx.isBashMode) {
+			this.ctx.editor.setText("");
+			this.ctx.isBashMode = false;
+			this.ctx.isBashNoContext = false;
+			this.ctx.updateEditorBorderColor();
+			return true;
+		}
+		if (options.processes && this.ctx.session.isEvalRunning) {
+			this.ctx.session.abortEval();
+			return true;
+		}
+		if (options.modes && this.ctx.isPythonMode) {
+			this.ctx.editor.setText("");
+			this.ctx.isPythonMode = false;
+			this.ctx.updateEditorBorderColor();
+			return true;
+		}
+		if (
+			options.maintenance &&
+			(this.ctx.session.isCompacting || this.ctx.autoCompactionLoader || this.ctx.autoCompactionEscapeHandler)
+		) {
+			this.ctx.session.abortCompaction();
+			return true;
+		}
+		if (options.maintenance && this.ctx.session.isGeneratingHandoff) {
+			this.ctx.session.abortHandoff();
+			return true;
+		}
+		if (options.retry) {
+			if (this.#isRetryBackoffActive()) {
+				if (this.ctx.retryEscapePrimed) {
+					this.ctx.session.abortRetry();
+				} else {
+					this.ctx.retryEscapePrimed = true;
+					this.ctx.session.retryNow();
+				}
+				return true;
+			}
+			this.ctx.retryEscapePrimed = false;
+		}
+		if (options.streaming && this.ctx.session.isStreaming) {
+			if (this.ctx.session.hasQueuedSteering && !this.#steerConsumePending) {
+				// First Esc with a queued steer: silently consume it and
+				// auto-continue via steer-on-interrupt instead of stalling on
+				// "Operation aborted".
+				this.#steerConsumePending = true;
+				void this.#abortInteractive({ silent: true });
+			} else {
+				void this.#abortInteractive();
+			}
+			return true;
+		}
+		return false;
+	}
+
+	#installGlobalInterruptListener(): void {
+		if (typeof this.ctx.ui.addInputListener !== "function") {
+			return;
+		}
+		this.#globalInterruptUnsubscribe?.();
+		this.#globalInterruptUnsubscribe = this.ctx.ui.addInputListener(data => {
+			if (!this.#matchesInterruptKey(data)) {
+				return undefined;
+			}
+			if (this.ctx.hasActiveBtw() && this.ctx.handleBtwEscape()) {
+				return { consume: true };
+			}
+			const hookDialogActive = this.#hasHookDialog();
+			if (
+				this.#handleCancellableWorkEscape({
+					loading: hookDialogActive,
+					processes: hookDialogActive,
+					modes: false,
+					maintenance: true,
+					retry: true,
+					streaming: hookDialogActive,
+				})
+			) {
+				return { consume: true };
+			}
+			return undefined;
+		});
+	}
+
 	#abortInteractive(options?: { silent?: boolean }): Promise<void> {
 		return this.ctx.session.abort({
 			timeoutMs: INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS,
@@ -60,6 +181,7 @@ export class InputController {
 					this.ctx.session.isStreaming ||
 					this.ctx.session.isCompacting ||
 					this.ctx.session.isGeneratingHandoff ||
+					this.ctx.session.isRetrying ||
 					this.ctx.session.isBashRunning ||
 					this.ctx.session.isEvalRunning ||
 					this.ctx.autoCompactionLoader ||
@@ -67,6 +189,8 @@ export class InputController {
 					this.ctx.autoCompactionEscapeHandler ||
 					this.ctx.retryEscapeHandler,
 			);
+		this.#installGlobalInterruptListener();
+
 		// An open btw panel must stay dismissable with Esc even while another
 		// controller (auto-compaction, auto-retry, manual compaction, etc.) has
 		// temporarily replaced editor.onEscape. This priority hook is never
@@ -87,6 +211,9 @@ export class InputController {
 				}
 				this.#steerConsumePending = false;
 			}
+			if (this.#handleCancellableWorkEscape({ maintenance: true, retry: true })) {
+				return;
+			}
 			// Normal input state with user-typed text: Esc must not interrupt a
 			// running task (streaming turn, bash/eval). A double Esc within the
 			// 500ms window clears the composer instead. Bash/Python input modes
@@ -101,35 +228,19 @@ export class InputController {
 				}
 				return;
 			}
-			if (this.ctx.loadingAnimation) {
-				if (this.ctx.cancelPendingSubmission()) {
-					return;
-				}
-				this.restoreQueuedMessagesToEditor({ abort: true });
-			} else if (this.ctx.session.isBashRunning) {
-				this.ctx.session.abortBash();
-			} else if (this.ctx.isBashMode) {
-				this.ctx.editor.setText("");
-				this.ctx.isBashMode = false;
-				this.ctx.isBashNoContext = false;
-				this.ctx.updateEditorBorderColor();
-			} else if (this.ctx.session.isEvalRunning) {
-				this.ctx.session.abortEval();
-			} else if (this.ctx.isPythonMode) {
-				this.ctx.editor.setText("");
-				this.ctx.isPythonMode = false;
-				this.ctx.updateEditorBorderColor();
-			} else if (this.ctx.session.isStreaming) {
-				if (this.ctx.session.hasQueuedSteering && !this.#steerConsumePending) {
-					// First Esc with a queued steer: silently consume it and
-					// auto-continue via steer-on-interrupt instead of stalling on
-					// "Operation aborted".
-					this.#steerConsumePending = true;
-					void this.#abortInteractive({ silent: true });
-				} else {
-					void this.#abortInteractive();
-				}
-			} else if (!this.ctx.editor.getText().trim()) {
+			if (
+				this.#handleCancellableWorkEscape({
+					loading: true,
+					processes: true,
+					modes: true,
+					maintenance: true,
+					retry: true,
+					streaming: true,
+				})
+			) {
+				return;
+			}
+			if (!this.ctx.editor.getText().trim()) {
 				// Double-interrupt with empty editor triggers /tree, /branch, or nothing based on setting
 				const action = settings.get("doubleEscapeAction");
 				if (action !== "none") {
@@ -727,6 +838,7 @@ export class InputController {
 			this.ctx.editor.onEscape = this.ctx.retryEscapeHandler;
 			this.ctx.retryEscapeHandler = undefined;
 		}
+		this.ctx.retryEscapePrimed = false;
 		this.ctx.statusContainer.clear();
 		this.ctx.statusLine.dispose();
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -321,6 +321,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 	autoCompactionEscapeHandler?: () => void;
 	retryEscapeHandler?: () => void;
+	retryEscapePrimed = false;
 	retryCountdownTimer?: NodeJS.Timeout;
 	unsubscribe?: () => void;
 	onInputCallback?: (input: SubmittedUserInput) => void;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -110,6 +110,7 @@ export interface InteractiveModeContext {
 	retryLoader: Loader | undefined;
 	autoCompactionEscapeHandler?: () => void;
 	retryEscapeHandler?: () => void;
+	retryEscapePrimed: boolean;
 	retryCountdownTimer?: NodeJS.Timeout;
 	unsubscribe?: () => void;
 	onInputCallback?: (input: SubmittedUserInput) => void;

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -41,6 +41,9 @@ type FakeEditor = {
 	clearCustomKeyHandlers(): void;
 };
 
+type FakeInputListenerResult = { consume?: boolean; data?: string } | undefined;
+type FakeInputListener = (data: string) => FakeInputListenerResult;
+
 function createSubmission(input: {
 	text: string;
 	images?: InteractiveModeContext["pendingImages"];
@@ -56,6 +59,7 @@ function createSubmission(input: {
 function createContext(): {
 	ctx: InteractiveModeContext;
 	editor: FakeEditor;
+	inputListeners: FakeInputListener[];
 	spies: {
 		abort: ReturnType<typeof vi.fn>;
 		abortBash: ReturnType<typeof vi.fn>;
@@ -72,12 +76,20 @@ function createContext(): {
 		requestRender: ReturnType<typeof vi.fn>;
 		startPendingSubmission: ReturnType<typeof vi.fn>;
 		clearEditor: ReturnType<typeof vi.fn>;
+		abortCompaction: ReturnType<typeof vi.fn>;
+		abortHandoff: ReturnType<typeof vi.fn>;
+		abortRetry: ReturnType<typeof vi.fn>;
+		retryNow: ReturnType<typeof vi.fn>;
 	};
 } {
 	let editorText = "";
 	const abort = vi.fn(() => Promise.resolve());
 	const abortBash = vi.fn();
 	const abortEval = vi.fn();
+	const abortCompaction = vi.fn();
+	const abortHandoff = vi.fn();
+	const abortRetry = vi.fn();
+	const retryNow = vi.fn();
 	const addMessageToChat = vi.fn();
 	const cancelPendingSubmission = vi.fn(() => false);
 	const clearQueue = vi.fn(() => ({ steering: [], followUp: [] }));
@@ -87,6 +99,14 @@ function createContext(): {
 	const handleBtwCommand = vi.fn(async () => {});
 	const handleBtwEscape = vi.fn(() => true);
 	const hasActiveBtw = vi.fn(() => false);
+	const inputListeners: FakeInputListener[] = [];
+	const addInputListener = vi.fn((listener: FakeInputListener) => {
+		inputListeners.push(listener);
+		return () => {
+			const index = inputListeners.indexOf(listener);
+			if (index >= 0) inputListeners.splice(index, 1);
+		};
+	});
 	const startPendingSubmission = vi.fn((input: { text: string; images?: InteractiveModeContext["pendingImages"] }) => {
 		ensureLoadingAnimation();
 		return createSubmission(input);
@@ -116,16 +136,18 @@ function createContext(): {
 	ctx = {
 		settings: { get: () => undefined } as unknown as InteractiveModeContext["settings"],
 		editor: editor as unknown as InteractiveModeContext["editor"],
-		ui: { requestRender } as unknown as InteractiveModeContext["ui"],
+		ui: { requestRender, addInputListener } as unknown as InteractiveModeContext["ui"],
 		loadingAnimation: undefined,
 		autoCompactionLoader: undefined,
 		retryLoader: undefined,
 		autoCompactionEscapeHandler: undefined,
 		retryEscapeHandler: undefined,
+		retryEscapePrimed: false,
 		session: {
 			isStreaming: false,
 			isCompacting: false,
 			isGeneratingHandoff: false,
+			isRetrying: false,
 			isBashRunning: false,
 			isEvalRunning: false,
 			queuedMessageCount: 0,
@@ -135,6 +157,10 @@ function createContext(): {
 			abort,
 			abortBash,
 			abortEval,
+			abortCompaction,
+			abortHandoff,
+			abortRetry,
+			retryNow,
 			clearQueue,
 			prompt,
 		} as unknown as InteractiveModeContext["session"],
@@ -142,7 +168,7 @@ function createContext(): {
 			getSessionName: () => "existing session",
 		} as unknown as InteractiveModeContext["sessionManager"],
 		keybindings: {
-			getKeys: () => [],
+			getKeys: (action: string) => (action === "app.interrupt" ? ["escape"] : []),
 		} as unknown as InteractiveModeContext["keybindings"],
 		pendingImages: [],
 		lastEscapeTime: 0,
@@ -177,10 +203,15 @@ function createContext(): {
 	return {
 		ctx,
 		editor,
+		inputListeners,
 		spies: {
 			abort,
 			abortBash,
 			abortEval,
+			abortCompaction,
+			abortHandoff,
+			abortRetry,
+			retryNow,
 			addMessageToChat,
 			cancelPendingSubmission,
 			clearQueue,
@@ -330,6 +361,95 @@ describe("InputController escape behavior", () => {
 		expect(spies.cancelPendingSubmission).not.toHaveBeenCalled();
 		expect(spies.clearQueue).not.toHaveBeenCalled();
 		expect(spies.abort).toHaveBeenCalledTimes(1);
+	});
+
+	it("cancels compaction even when the composer contains a draft", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isCompacting: boolean }).isCompacting = true;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.setText("draft while compacting");
+		editor.onEscape?.();
+
+		expect(spies.abortCompaction).toHaveBeenCalledTimes(1);
+		expect(spies.abortHandoff).not.toHaveBeenCalled();
+		expect(spies.abort).not.toHaveBeenCalled();
+		expect(spies.clearEditor).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("draft while compacting");
+	});
+
+	it("cancels manual handoff even when the composer contains a draft", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isGeneratingHandoff: boolean }).isGeneratingHandoff = true;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.setText("draft while handing off");
+		editor.onEscape?.();
+
+		expect(spies.abortHandoff).toHaveBeenCalledTimes(1);
+		expect(spies.abortCompaction).not.toHaveBeenCalled();
+		expect(spies.abort).not.toHaveBeenCalled();
+		expect(spies.clearEditor).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("draft while handing off");
+	});
+
+	it("cancels auto-handoff through the compaction controller", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isCompacting: boolean; isGeneratingHandoff: boolean }).isCompacting = true;
+		(ctx.session as { isGeneratingHandoff: boolean }).isGeneratingHandoff = true;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.abortCompaction).toHaveBeenCalledTimes(1);
+		expect(spies.abortHandoff).not.toHaveBeenCalled();
+	});
+
+	it("keeps retry backoff escape handling wired from the central handler", () => {
+		const { ctx, editor, spies } = createContext();
+		ctx.retryLoader = {} as InteractiveModeContext["retryLoader"];
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.setText("draft during retry");
+		editor.onEscape?.();
+		editor.onEscape?.();
+
+		expect(spies.retryNow).toHaveBeenCalledTimes(1);
+		expect(spies.abortRetry).toHaveBeenCalledTimes(1);
+		expect(spies.clearEditor).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("draft during retry");
+	});
+
+	it("globally aborts a workflow stream while a hook dialog has focus", () => {
+		const { ctx, inputListeners, spies } = createContext();
+		(ctx.session as { isStreaming: boolean }).isStreaming = true;
+		ctx.hookSelector = {} as InteractiveModeContext["hookSelector"];
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		const result = inputListeners[0]?.("\x1b");
+
+		expect(result).toEqual({ consume: true });
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(spies.abort).toHaveBeenCalledWith(expect.objectContaining({ cause: "user_interrupt" }));
+	});
+
+	it("does not globally steal draft-clearing Esc from a normal stream", () => {
+		const { ctx, editor, inputListeners, spies } = createContext();
+		(ctx.session as { isStreaming: boolean }).isStreaming = true;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.setText("draft message");
+		const result = inputListeners[0]?.("\x1b");
+
+		expect(result).toBeUndefined();
+		expect(spies.abort).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("draft message");
 	});
 
 	it("silently consumes a queued steer on the first Esc instead of a loud abort", () => {


### PR DESCRIPTION
## Summary
- route Escape cancellation through a central handler for compaction, handoff, retry backoff, running tools, and streaming turns
- add a global interrupt listener so workflow ask dialogs and other transient UI focus cannot swallow Escape while work is active
- keep draft-clearing behavior for normal streams, while letting context maintenance/retry cancellation win over typed drafts
- add regression coverage for compaction, handoff, retry backoff, hook-dialog workflow streams, and normal draft behavior

## Verification
- bun test --preload C:/tmp/gjc-test-preload/mock-natives.ts packages/coding-agent/test/input-controller-escape.test.ts — 29 pass
- bun --cwd=packages/coding-agent run check:types — pass
- bunx biome check packages/coding-agent/src/modes/controllers/input-controller.ts packages/coding-agent/src/modes/types.ts packages/coding-agent/src/modes/interactive-mode.ts packages/coding-agent/src/modes/controllers/event-controller.ts packages/coding-agent/test/input-controller-escape.test.ts packages/coding-agent/CHANGELOG.md — OK

Note: the un-preloaded focused test is blocked in this local Windows workspace because the pi_natives win32-x64 addon is absent and cargo is not installed to rebuild it.