### PR TITLE
Handle missing resident blobs in session reads

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1461,9 +1461,25 @@ function materializeResidentEntrySync<T extends FileEntry | SessionEntry>(
 function materializeResidentEntriesSync<T extends FileEntry | SessionEntry>(
 	entries: T[],
 	stores: ResidentBlobStores,
+	missingPolicy: ResidentBlobMissingPolicy = "throw",
 ): T[] {
 	const cache = new Map<string, string>();
-	return entries.map(entry => materializeResidentEntrySync(entry, stores, cache));
+	return entries.map(entry => materializeResidentEntrySync(entry, stores, cache, missingPolicy));
+}
+
+function materializeResidentEntryForReadSync<T extends FileEntry | SessionEntry>(
+	entry: T,
+	stores: ResidentBlobStores,
+	cache: Map<string, string>,
+): T {
+	return materializeResidentEntrySync(entry, stores, cache, "placeholder");
+}
+
+function materializeResidentEntriesForReadSync<T extends FileEntry | SessionEntry>(
+	entries: T[],
+	stores: ResidentBlobStores,
+): T[] {
+	return materializeResidentEntriesSync(entries, stores, "placeholder");
 }
 
 function materializeResidentEntryForPersistenceSync<T extends FileEntry | SessionEntry>(
@@ -1520,12 +1536,24 @@ function cloneSessionEntry(entry: SessionEntry): SessionEntry {
 function materializeProviderVisibleEntrySync(entry: SessionEntry, stores: ResidentBlobStores): SessionEntry {
 	if (entry.type === "compaction") {
 		const cache = new Map<string, string>();
-		const summary = materializeResidentValueSync(entry.summary, stores, "summary", cache);
-		const shortSummary = materializeResidentValueSync(entry.shortSummary, stores, "shortSummary", cache);
+		const summary = materializeResidentValueSync(entry.summary, stores, "summary", cache, "placeholder");
+		const shortSummary = materializeResidentValueSync(
+			entry.shortSummary,
+			stores,
+			"shortSummary",
+			cache,
+			"placeholder",
+		);
 		const remote = entry.preserveData?.openaiRemoteCompaction;
 		const remoteRecord = isRecord(remote) ? remote : undefined;
 		const replacementHistory = remoteRecord
-			? materializeResidentValueSync(remoteRecord.replacementHistory, stores, "replacementHistory", cache)
+			? materializeResidentValueSync(
+					remoteRecord.replacementHistory,
+					stores,
+					"replacementHistory",
+					cache,
+					"placeholder",
+				)
 			: undefined;
 		const preserveData =
 			remoteRecord && replacementHistory !== undefined && replacementHistory !== remoteRecord.replacementHistory
@@ -1545,7 +1573,13 @@ function materializeProviderVisibleEntrySync(entry: SessionEntry, stores: Reside
 		};
 	}
 	if (entry.type === "branch_summary") {
-		const summary = materializeResidentValueSync(entry.summary, stores, "summary", new Map<string, string>());
+		const summary = materializeResidentValueSync(
+			entry.summary,
+			stores,
+			"summary",
+			new Map<string, string>(),
+			"placeholder",
+		);
 		return typeof summary === "string" ? { ...entry, summary } : { ...entry };
 	}
 	return cloneSessionEntry(entry);
@@ -2751,7 +2785,10 @@ export class SessionManager {
 	}
 
 	captureState(): SessionManagerStateSnapshot {
-		const materializedFileEntries = materializeResidentEntriesSync(this.#fileEntries, this.#residentBlobStores());
+		const materializedFileEntries = materializeResidentEntriesForReadSync(
+			this.#fileEntries,
+			this.#residentBlobStores(),
+		);
 		return {
 			sessionId: this.#sessionId,
 			sessionName: this.#sessionName,
@@ -2875,7 +2912,7 @@ export class SessionManager {
 
 		const oldSessionFile = this.#sessionFile;
 		const oldSessionId = this.#sessionId;
-		const materializedEntries = materializeResidentEntriesSync(this.#fileEntries, this.#residentBlobStores());
+		const materializedEntries = materializeResidentEntriesForReadSync(this.#fileEntries, this.#residentBlobStores());
 
 		// Close the current writer
 		await this.#closePersistWriter();
@@ -2947,7 +2984,10 @@ export class SessionManager {
 			hadSessionFile = this.storage.existsSync(oldSessionFile);
 			let movedSessionFile = false;
 			let movedArtifactDir = false;
-			const materializedEntries = materializeResidentEntriesSync(this.#fileEntries, this.#residentBlobStores());
+			const materializedEntries = materializeResidentEntriesForReadSync(
+				this.#fileEntries,
+				this.#residentBlobStores(),
+			);
 			const restoreResidentStateAfterFailure = (): void => {
 				this.#fileEntries = materializedEntries;
 				this.#resetResidentTextBlobStore();
@@ -4006,7 +4046,7 @@ export class SessionManager {
 	getLeafEntry(): SessionEntry | undefined {
 		if (!this.#leafId) return undefined;
 		const entry = this.#byId.get(this.#leafId);
-		return entry ? materializeResidentEntrySync(entry, this.#residentBlobStores(), new Map()) : undefined;
+		return entry ? materializeResidentEntryForReadSync(entry, this.#residentBlobStores(), new Map()) : undefined;
 	}
 
 	/**
@@ -4176,7 +4216,7 @@ export class SessionManager {
 		const entry = this.#byId.get(id);
 		return entry
 			? rehydrateColdSpillEntry(
-					materializeResidentEntrySync(entry, this.#residentBlobStores(), new Map()),
+					materializeResidentEntryForReadSync(entry, this.#residentBlobStores(), new Map()),
 					this.#blobStore,
 					this.#residentBlobStoresForColdRehydrate(),
 				)
@@ -4193,7 +4233,7 @@ export class SessionManager {
 			visited.add(current.id);
 			path.push(
 				rehydrateColdSpillEntry(
-					materializeResidentEntrySync(current, this.#residentBlobStores(), cache),
+					materializeResidentEntryForReadSync(current, this.#residentBlobStores(), cache),
 					this.#blobStore,
 					this.#residentBlobStoresForColdRehydrate(),
 				),
@@ -4233,7 +4273,7 @@ export class SessionManager {
 			.filter((entry): entry is SessionEntry => entry.type !== "session")
 			.map(entry =>
 				rehydrateColdSpillEntry(
-					materializeResidentEntrySync(entry, this.#residentBlobStores(), cache),
+					materializeResidentEntryForReadSync(entry, this.#residentBlobStores(), cache),
 					this.#blobStore,
 					this.#residentBlobStoresForColdRehydrate(),
 				),
@@ -4244,7 +4284,7 @@ export class SessionManager {
 		this.#publicMaterializerCallCount++;
 		this.#getEntryMaterializerCallCount++;
 		const entry = this.#byId.get(id);
-		return entry ? materializeResidentEntrySync(entry, this.#residentBlobStores(), new Map()) : undefined;
+		return entry ? materializeResidentEntryForReadSync(entry, this.#residentBlobStores(), new Map()) : undefined;
 	}
 
 	/**
@@ -4255,7 +4295,7 @@ export class SessionManager {
 		const children: SessionEntry[] = [];
 		for (const entry of this.#byId.values()) {
 			if (entry.parentId === parentId) {
-				children.push(materializeResidentEntrySync(entry, this.#residentBlobStores(), cache));
+				children.push(materializeResidentEntryForReadSync(entry, this.#residentBlobStores(), cache));
 			}
 		}
 		return children;
@@ -4310,7 +4350,7 @@ export class SessionManager {
 		while (current) {
 			if (visited.has(current.id)) break;
 			visited.add(current.id);
-			path.push(materializeResidentEntrySync(current, this.#residentBlobStores(), cache));
+			path.push(materializeResidentEntryForReadSync(current, this.#residentBlobStores(), cache));
 			current = current.parentId ? this.#byId.get(current.parentId) : undefined;
 		}
 		path.reverse();
@@ -4375,7 +4415,7 @@ export class SessionManager {
 		}
 		if (entry.type !== "message" && entry.type !== "custom_message")
 			return materializeProviderVisibleEntrySync(entry, this.#residentBlobStores());
-		const materialized = materializeResidentEntrySync(entry, this.#residentBlobStores(), new Map());
+		const materialized = materializeResidentEntryForReadSync(entry, this.#residentBlobStores(), new Map());
 		const rehydrated = rehydrateColdSpillEntry(
 			materialized,
 			this.#blobStore,
@@ -4434,7 +4474,7 @@ export class SessionManager {
 		const resolvedTextBlobCache = new Map<string, string>();
 		const materializedEntries = this.#fileEntries
 			.filter((e): e is SessionEntry => e.type !== "session")
-			.map(entry => materializeResidentEntrySync(entry, this.#residentBlobStores(), resolvedTextBlobCache));
+			.map(entry => materializeResidentEntryForReadSync(entry, this.#residentBlobStores(), resolvedTextBlobCache));
 		this.#materializedEntriesCache = materializedEntries;
 		this.#materializedEntriesRevision = this.#entryRevision;
 		return materializedEntries;
@@ -4591,7 +4631,7 @@ export class SessionManager {
 
 		// Filter out LabelEntry from path - we'll recreate them from the resolved map
 		const pathWithoutLabels = branchPath.filter(e => e.type !== "label");
-		const materializedPathWithoutLabels = materializeResidentEntriesSync(
+		const materializedPathWithoutLabels = materializeResidentEntriesForReadSync(
 			pathWithoutLabels,
 			this.#residentBlobStores(),
 		);

--- a/packages/coding-agent/test/session-resident-cache.test.ts
+++ b/packages/coding-agent/test/session-resident-cache.test.ts
@@ -5,12 +5,7 @@ import * as path from "node:path";
 import type { AssistantMessage, UserMessage } from "@gajae-code/ai";
 
 import { exportFromFile, exportSessionToHtml } from "@gajae-code/coding-agent/export/html";
-import {
-	BlobStore,
-	EphemeralBlobStore,
-	externalizeImageDataSync,
-	ResidentBlobMissingError,
-} from "@gajae-code/coding-agent/session/blob-store";
+import { BlobStore, EphemeralBlobStore, externalizeImageDataSync } from "@gajae-code/coding-agent/session/blob-store";
 import { SessionManager, type SessionMessageEntry } from "@gajae-code/coding-agent/session/session-manager";
 import { logger } from "@gajae-code/utils";
 
@@ -86,30 +81,22 @@ async function createPersistedLargeTextSession(
 	return { sm, sessionFile, artifactsDir, cacheDir, entryId };
 }
 
-function expectMissingBlob(fn: () => unknown): void {
-	try {
-		fn();
-		throw new Error("Expected ResidentBlobMissingError");
-	} catch (err) {
-		expectResidentBlobMissing(err);
-	}
+function expectResidentPlaceholder(value: unknown): void {
+	const serialized = JSON.stringify(value);
+	expect(serialized).toContain("Session resident text blob missing");
+	expect(serialized).toContain("original content unavailable");
+	expect(serialized).not.toContain("blob:sha256:");
+	expect(serialized).not.toContain("__gjcResidentBlob");
 }
 
-async function expectMissingBlobAsync(fn: () => Promise<unknown>): Promise<void> {
-	try {
-		await fn();
-		throw new Error("Expected ResidentBlobMissingError");
-	} catch (err) {
-		expectResidentBlobMissing(err);
-	}
-}
-
-function expectResidentBlobMissing(err: unknown): void {
-	expect(err).toBeInstanceOf(ResidentBlobMissingError);
-	const missing = err as ResidentBlobMissingError;
-	expect(missing.hash).toMatch(/^[a-f0-9]{64}$/);
-	expect(missing.kind).toBe("text");
-	expect(missing.message).not.toContain("blob:sha256:");
+async function expectFileContainsResidentPlaceholder(filePath: string): Promise<void> {
+	const bytes = await Bun.file(filePath).text();
+	const match = bytes.match(/<script id="session-data" type="application\/json">([^<]*)<\/script>/);
+	const decoded = match ? Buffer.from(match[1]!, "base64").toString("utf8") : bytes;
+	expect(decoded).toContain("Session resident text blob missing");
+	expect(decoded).toContain("original content unavailable");
+	expect(decoded).not.toContain("blob:sha256:");
+	expect(decoded).not.toContain("__gjcResidentBlob");
 }
 
 async function fileDoesNotContainBlobRef(filePath: string): Promise<void> {
@@ -119,7 +106,7 @@ async function fileDoesNotContainBlobRef(filePath: string): Promise<void> {
 }
 
 describe("resident text cache missing-blob and reference hygiene", () => {
-	it("throws typed ResidentBlobMissingError from public materialization APIs when the resident text blob is missing", async () => {
+	it("uses a public-safe placeholder from read/context APIs when a resident text blob is missing", async () => {
 		const sentinel = `missing resident text ${"x".repeat(2048)}`;
 		const { sm, sessionFile, cacheDir, entryId } = await createPersistedLargeTextSession(sentinel);
 		await sm.close();
@@ -136,10 +123,11 @@ describe("resident text cache missing-blob and reference hygiene", () => {
 			return BlobStore.prototype.getSync.call(this, hash);
 		});
 
-		expectMissingBlob(() => reopened.getEntries());
-		expectMissingBlob(() => reopened.getEntry(entryId));
-		expectMissingBlob(() => reopened.getBranch());
-		expectMissingBlob(() => reopened.buildSessionContext());
+		expectResidentPlaceholder(reopened.getEntries());
+		expectResidentPlaceholder(reopened.getEntry(entryId));
+		expectResidentPlaceholder(reopened.getBranch());
+		await expect(Promise.resolve().then(() => reopened.buildSessionContext())).resolves.toEqual(expect.any(Object));
+		expectResidentPlaceholder(reopened.buildSessionContext());
 		await reopened.close();
 	});
 
@@ -166,34 +154,41 @@ describe("resident text cache missing-blob and reference hygiene", () => {
 		await fileDoesNotContainBlobRef(sessionFile);
 	});
 
-	it("surfaces typed missing resident text errors from exports and persists a placeholder on rewrite after disk cache deletion", async () => {
+	it("exports and rewrites a public-safe placeholder after disk cache deletion", async () => {
 		const sentinel = `corrupt resident text ${"z".repeat(2048)}`;
 		const { sm, sessionFile } = await createPersistedLargeTextSession(sentinel);
 		const liveCacheDir = activeResidentCacheDir(sm);
 		await fs.promises.rm(liveCacheDir, { recursive: true, force: true });
+		vi.spyOn(EphemeralBlobStore.prototype, "getSync").mockImplementation(function (
+			this: EphemeralBlobStore,
+			hash: string,
+		) {
+			return BlobStore.prototype.getSync.call(this, hash);
+		});
 
-		await expectMissingBlobAsync(() =>
-			exportSessionToHtml(sm, undefined, { outputPath: path.join(makeTempDir(), "live-corrupt.html") }),
-		);
+		const liveHtml = path.join(makeTempDir(), "live-corrupt.html");
+		await exportSessionToHtml(sm, undefined, { outputPath: liveHtml });
+		await expectFileContainsResidentPlaceholder(liveHtml);
 		await sm.close();
 
 		const standalone = await SessionManager.open(sessionFile);
 		const standaloneCacheDir = activeResidentCacheDir(standalone);
 		await fs.promises.rm(standaloneCacheDir, { recursive: true, force: true });
-		await expectMissingBlobAsync(() =>
-			exportSessionToHtml(standalone, undefined, {
-				outputPath: path.join(makeTempDir(), "standalone-corrupt.html"),
-			}),
-		);
-		await standalone.close();
-		await expectMissingBlobAsync(async () => {
-			const exportManager = await SessionManager.open(sessionFile);
-			const exportCacheDir = activeResidentCacheDir(exportManager);
-			await fs.promises.rm(exportCacheDir, { recursive: true, force: true });
-			await exportSessionToHtml(exportManager, undefined, {
-				outputPath: path.join(makeTempDir(), "from-file-corrupt.html"),
-			});
+		const standaloneHtml = path.join(makeTempDir(), "standalone-corrupt.html");
+		await exportSessionToHtml(standalone, undefined, {
+			outputPath: standaloneHtml,
 		});
+		await expectFileContainsResidentPlaceholder(standaloneHtml);
+		await standalone.close();
+		const fromFileHtml = path.join(makeTempDir(), "from-file-corrupt.html");
+		const exportManager = await SessionManager.open(sessionFile);
+		const exportCacheDir = activeResidentCacheDir(exportManager);
+		await fs.promises.rm(exportCacheDir, { recursive: true, force: true });
+		await exportSessionToHtml(exportManager, undefined, {
+			outputPath: fromFileHtml,
+		});
+		await exportManager.close();
+		await expectFileContainsResidentPlaceholder(fromFileHtml);
 
 		const rewrite = await SessionManager.open(sessionFile);
 		const rewriteCacheDir = activeResidentCacheDir(rewrite);
@@ -208,9 +203,9 @@ describe("resident text cache missing-blob and reference hygiene", () => {
 	});
 
 	it("keeps warm materialized resident text readable until entry revision invalidation after cache deletion", async () => {
-		// Plan contract: "typed corruption for active materialization" — data that predates
-		// corruption remains readable from the warm in-memory view, equivalent to a
-		// caller-held array, but the next rematerialization must surface ResidentBlobMissingError.
+		// Data that predates corruption remains readable from the warm in-memory view,
+		// equivalent to a caller-held array. The next rematerialization degrades to a
+		// public-safe placeholder instead of throwing an unhandled rejection.
 		const sentinel = `warm sabotage resident text ${"w".repeat(2048)}`;
 		const { sm } = await createPersistedLargeTextSession(sentinel);
 		const warmEntries = sm.getEntries();
@@ -221,7 +216,7 @@ describe("resident text cache missing-blob and reference hygiene", () => {
 		expect(JSON.stringify(sm.getEntries())).toContain(sentinel);
 
 		sm.appendMessage(assistantMessage("invalidate warm resident view"));
-		expectMissingBlob(() => sm.getEntries());
+		expectResidentPlaceholder(sm.getEntries());
 		await sm.close().catch(() => {});
 	});
 	it("keeps encrypted reasoning replay strings inline instead of resident-blob externalizing them", async () => {


### PR DESCRIPTION
## Summary
- Materialize public session read/context/export paths with the existing explicit resident-blob missing placeholder instead of throwing when an ephemeral resident blob has been evicted.
- Keep low-level resident blob resolvers fail-closed so blob refs are never returned as content.
- Update resident-cache regressions to prove reads, context builds, exports, and rewrites do not leak resident blob refs or crash on missing resident text blobs.

## Verification
- `bun test packages/coding-agent/test/resident-materialization.test.ts packages/coding-agent/test/session-resident-cache.test.ts packages/coding-agent/test/session-manager/resident-retention.test.ts packages/coding-agent/test/session-manager/build-context.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check origin/dev...HEAD`

Closes #1470

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*