### PR TITLE
fix(coding-agent): prioritize Tab queueing while busy

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Escape now reliably cancels active context maintenance, handoff generation, retry backoff, and workflow ask dialogs even when transient UI focus or typed drafts would previously consume the key.
 
+### Fixed
+
+- Tab now queues prompt drafts immediately while the agent is streaming or compacting instead of opening/applying forced file autocomplete first.
+
 ## [0.7.11] - 2026-07-03
 ### Fixed
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -313,6 +313,11 @@ export class InputController {
 		this.ctx.editor.onDequeue = () => this.handleDequeue();
 		this.ctx.editor.setActionKeys("app.message.queue", this.ctx.keybindings.getKeys("app.message.queue"));
 		this.ctx.editor.onQueue = () => void this.handleQueueSubmit();
+		this.ctx.editor.onTab = () => {
+			if (!this.ctx.session.isStreaming && !this.ctx.session.isCompacting) return false;
+			void this.handleQueueSubmit();
+			return true;
+		};
 		this.ctx.editor.onTabDeclined = () => {
 			if (this.ctx.session.isStreaming || this.ctx.session.isCompacting) void this.handleQueueSubmit();
 		};

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -27,6 +27,7 @@ type FakeEditor = {
 	onChange?: (text: string) => void;
 	onSubmit?: (text: string) => void | Promise<void>;
 	onTabDeclined?: (text: string) => void;
+	onTab?: (text: string) => boolean | undefined;
 	setText(text: string): void;
 	getText(): string;
 	insertText(text: string): void;
@@ -276,7 +277,40 @@ describe("InputController keybinding setup", () => {
 		});
 	});
 
-	it("queues streaming Tab only after editor tab completion declines", async () => {
+	it("queues streaming Tab before editor file completion can open", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const session = ctx.session as unknown as { isStreaming: boolean };
+		session.isStreaming = true;
+		editor.setText("queue before file completion");
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		expect(editor.onTab?.(editor.getText())).toBe(true);
+		await Bun.sleep(0);
+
+		expect(spies.prompt).toHaveBeenCalledWith("queue before file completion", {
+			streamingBehavior: "followUp",
+		});
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+	it("queues compaction Tab before editor file completion can open", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const session = ctx.session as unknown as { isCompacting: boolean };
+		session.isCompacting = true;
+		editor.setText("queue while compacting via tab");
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		expect(editor.onTab?.(editor.getText())).toBe(true);
+		await Bun.sleep(0);
+
+		expect(spies.queueCompactionMessage).toHaveBeenCalledWith("queue while compacting via tab", "followUp");
+		expect(spies.prompt).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("");
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps declined Tab completion as a fallback queue path while streaming", async () => {
 		const { InputController, ctx, editor, spies } = await createContext();
 		const session = ctx.session as unknown as { isStreaming: boolean };
 		session.isStreaming = true;
@@ -290,23 +324,6 @@ describe("InputController keybinding setup", () => {
 		expect(spies.prompt).toHaveBeenCalledWith("queue after declined tab completion", {
 			streamingBehavior: "followUp",
 		});
-		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
-	});
-	it("queues compaction Tab after editor tab completion declines", async () => {
-		const { InputController, ctx, editor, spies } = await createContext();
-		const session = ctx.session as unknown as { isCompacting: boolean };
-		session.isCompacting = true;
-		editor.setText("queue while compacting via tab");
-		const controller = new InputController(ctx);
-
-		controller.setupKeyHandlers();
-		editor.onTabDeclined?.(editor.getText());
-		await Bun.sleep(0);
-
-		expect(spies.queueCompactionMessage).toHaveBeenCalledWith("queue while compacting via tab", "followUp");
-		expect(spies.prompt).not.toHaveBeenCalled();
-		expect(editor.getText()).toBe("");
-		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 	});
 
 	it("queues explicit message action during compaction", async () => {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -450,6 +450,11 @@ export class Editor implements Component, Focusable {
 	onChange?: (text: string) => void;
 	onAutocompleteCancel?: () => void;
 	onTabDeclined?: (text: string) => void;
+	/**
+	 * Called before Tab opens/applies autocomplete. Return true to consume Tab
+	 * for app-level behavior (for example, queueing a draft while a turn runs).
+	 */
+	onTab?: (text: string) => boolean | undefined;
 	disableSubmit: boolean = false;
 
 	// Custom top border (for status line integration)
@@ -1073,6 +1078,10 @@ export class Editor implements Component, Focusable {
 		// Undo
 		if (kb.matches(data, "tui.editor.undo")) {
 			this.#applyUndo();
+			return;
+		}
+
+		if (kb.matches(data, "tui.input.tab") && this.onTab?.(this.getText())) {
 			return;
 		}
 

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import { CURSOR_MARKER } from "@gajae-code/tui";
-import { CombinedAutocompleteProvider } from "@gajae-code/tui/autocomplete";
+import { type AutocompleteProvider, CombinedAutocompleteProvider } from "@gajae-code/tui/autocomplete";
 import { Editor } from "@gajae-code/tui/components/editor";
 import { visibleWidth } from "@gajae-code/tui/utils";
 import { setDefaultTabWidth } from "@gajae-code/utils";
@@ -351,6 +351,40 @@ describe("Editor component", () => {
 
 			expect(editor.getText()).toBe("/model claude-opus");
 			expect(editor.isShowingAutocomplete()).toBe(false);
+		});
+
+		it("lets app-level Tab handlers consume before force file autocomplete", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			let forceFileSuggestionCalls = 0;
+			const provider = {
+				async getSuggestions() {
+					return null;
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+				async getForceFileSuggestions() {
+					forceFileSuggestionCalls += 1;
+					return { prefix: "", items: [{ label: "src/", value: "src/" }] };
+				},
+			} satisfies AutocompleteProvider & {
+				getForceFileSuggestions(): Promise<{ prefix: string; items: Array<{ label: string; value: string }> }>;
+			};
+			editor.setAutocompleteProvider(provider);
+			editor.setText("draft");
+			const tabTexts: string[] = [];
+			editor.onTab = text => {
+				tabTexts.push(text);
+				return true;
+			};
+
+			editor.handleInput("\t");
+			await Bun.sleep(0);
+
+			expect(tabTexts).toEqual(["draft"]);
+			expect(forceFileSuggestionCalls).toBe(0);
+			expect(editor.isShowingAutocomplete()).toBe(false);
+			expect(editor.getText()).toBe("draft");
 		});
 
 		it("does not show argument completions when command has no argument completer", async () => {


### PR DESCRIPTION
## Summary
- add an editor-level Tab preflight hook so apps can consume Tab before forced file autocomplete opens or applies a selection
- use that hook in GJC to queue prompt drafts immediately while the agent is streaming or context compaction is running
- keep the existing declined-tab fallback path for cases where the editor has no completion to apply
- add regression coverage for the editor preflight and GJC streaming/compaction Tab queue behavior

## Verification
- bun test --preload C:/tmp/gjc-test-preload/mock-natives.ts packages/tui/test/editor.test.ts --test-name-pattern "lets app-level Tab"
- bun test --preload C:/tmp/gjc-test-preload/mock-natives.ts packages/coding-agent/test/input-controller-keybindings.test.ts --test-name-pattern "Tab"
- bun --cwd=packages/tui run check:types
- bun --cwd=packages/coding-agent run check:types
- bunx biome check packages/tui/src/components/editor.ts packages/tui/test/editor.test.ts packages/coding-agent/src/modes/controllers/input-controller.ts packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/CHANGELOG.md

Note: local Windows verification used a native preload stub because this workspace is missing the pi_natives win32 addon and cargo is unavailable to rebuild it.