### PR TITLE
fix(tui): use PageUp/PageDown for transcript viewport

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -52,6 +52,8 @@ Older unqualified action names are migrated when `keybindings.json` is loaded, b
 
 On native Windows terminals, GJC defaults `app.message.queue` to `Alt+Q` because Windows Terminal and PowerShell commonly reserve `Alt+Enter` for fullscreen before GJC can receive it. Users who prefer another chord can remap `app.message.queue` in `~/.gjc/agent/keybindings.json`.
 
+In the main GJC composer, plain `PageUp` / `PageDown` page the visible transcript viewport instead of browsing prompt history; use `Up` / `Down` or `Ctrl+R` for prompt history. Autocomplete and selector surfaces still use `PageUp` / `PageDown` for list paging while they have focus.
+
 ## Auditing default-key collisions
 
 Some default chords are intentionally reused across different UI contexts, where the focused component disambiguates them at dispatch time. For example `Enter` maps to both input submit and selection confirm, and `Ctrl+C` maps to both input copy and selection cancel. These are not conflicts — only one context is active at a time.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Escape now reliably cancels active context maintenance, handoff generation, retry backoff, and workflow ask dialogs even when transient UI focus or typed drafts would previously consume the key.
+- The main composer now uses `PageUp` / `PageDown` to page the visible transcript viewport instead of duplicating prompt-history navigation; `Up` / `Down` and `Ctrl+R` remain the prompt-history paths, and autocomplete lists keep their own page navigation.
 
 ## [0.7.11] - 2026-07-03
 ### Fixed

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -103,6 +103,10 @@ export class CustomEditor extends Editor {
 	onQueue?: () => void;
 	/** Called when Caps Lock is pressed. */
 	onCapsLock?: () => void;
+	/** Called when PageUp/PageDown should scroll the transcript viewport instead of prompt history. */
+	onViewportPageScroll?: (direction: -1 | 1) => void;
+	/** Called before regular composer input should return the transcript viewport to the live bottom. */
+	onViewportFollowLive?: () => void;
 
 	/** Custom key handlers from extensions and non-built-in app actions. */
 	#customKeyHandlers = new Map<KeyId, () => boolean | undefined>();
@@ -242,6 +246,20 @@ export class CustomEditor extends Editor {
 				}
 				return;
 			}
+		}
+		if (!this.isShowingAutocomplete()) {
+			if (matchesKey(data, "pageUp") && this.onViewportPageScroll) {
+				this.onViewportPageScroll(-1);
+				return;
+			}
+			if (matchesKey(data, "pageDown") && this.onViewportPageScroll) {
+				this.onViewportPageScroll(1);
+				return;
+			}
+		}
+
+		if (!matchesKey(data, "pageUp") && !matchesKey(data, "pageDown")) {
+			this.onViewportFollowLive?.();
 		}
 		// Intercept configured image paste (async - fires and handles result)
 		if (this.#matchesAction(data, "app.clipboard.pasteImage") && this.onPasteImage) {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -316,6 +316,10 @@ export class InputController {
 		this.ctx.editor.onTabDeclined = () => {
 			if (this.ctx.session.isStreaming || this.ctx.session.isCompacting) void this.handleQueueSubmit();
 		};
+		this.ctx.editor.onViewportPageScroll = direction => this.ctx.ui.scrollViewportPages(direction);
+		this.ctx.editor.onViewportFollowLive = () => {
+			this.ctx.ui.followLiveViewport();
+		};
 
 		this.ctx.editor.clearCustomKeyHandlers();
 		// Wire up extension shortcuts

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -189,6 +189,60 @@ describe("CustomEditor queue keybinding", () => {
 		expect(onQueue).toHaveBeenCalledTimes(1);
 	});
 });
+describe("CustomEditor viewport paging", () => {
+	it("routes PageUp and PageDown to transcript scrolling instead of prompt history", () => {
+		const editor = createEditor();
+		const onViewportPageScroll = vi.fn((_direction: -1 | 1) => undefined);
+		editor.onViewportPageScroll = onViewportPageScroll;
+		editor.addToHistory("previous prompt");
+
+		editor.handleInput("\x1b[5~");
+		editor.handleInput("\x1b[6~");
+
+		expect(onViewportPageScroll).toHaveBeenNthCalledWith(1, -1);
+		expect(onViewportPageScroll).toHaveBeenNthCalledWith(2, 1);
+		expect(editor.getText()).toBe("");
+	});
+
+	it("keeps PageUp and PageDown available to autocomplete lists", async () => {
+		const editor = createEditor();
+		const onViewportPageScroll = vi.fn((_direction: -1 | 1) => undefined);
+		editor.onViewportPageScroll = onViewportPageScroll;
+		editor.setAutocompleteProvider({
+			async getSuggestions() {
+				return {
+					items: [
+						{ value: "alpha", label: "alpha" },
+						{ value: "beta", label: "beta" },
+					],
+					prefix: "/",
+				};
+			},
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return { lines, cursorLine, cursorCol };
+			},
+		} satisfies AutocompleteProvider);
+
+		editor.handleInput("/");
+		await Bun.sleep(0);
+		editor.handleInput("\x1b[5~");
+		editor.handleInput("\x1b[6~");
+
+		expect(editor.isShowingAutocomplete()).toBe(true);
+		expect(onViewportPageScroll).not.toHaveBeenCalled();
+	});
+
+	it("returns the transcript viewport to live output before regular input", () => {
+		const editor = createEditor();
+		const onViewportFollowLive = vi.fn();
+		editor.onViewportFollowLive = onViewportFollowLive;
+
+		editor.handleInput("a");
+
+		expect(onViewportFollowLive).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("a");
+	});
+});
 
 describe("CustomEditor pasteImage default sourced from KEYBINDINGS", () => {
 	it("intercepts the registry's platform-aware pasteImage default (single source of truth)", () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Added manual transcript viewport paging support so applications can repaint older terminal output with PageUp/PageDown without reusing editor history navigation.
+
 - Empty select/settings lists now still honor cancel while preserving populated-list keybinding precedence, and settings lists keep selection indices clamped when items disappear or submenus close after list shrinkage.
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -341,6 +341,8 @@ export class TUI extends Container {
 	#cursorRow = 0; // Logical cursor row (end of rendered content)
 	#hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
 	#viewportTopRow = 0; // Content row currently mapped to screen row 0
+	#manualViewportTop: number | undefined;
+	#lastCursorPosition: { row: number; col: number } | null = null;
 	#sixelProbePendingDa = false;
 	#sixelProbePendingGraphics = false;
 	#sixelProbeBuffer = "";
@@ -426,6 +428,47 @@ export class TUI extends Container {
 	setBottomPinnedComponent(component: Component | null): void {
 		this.#bottomPinnedComponent = component;
 		this.requestRender();
+	}
+	scrollViewportPages(direction: -1 | 1): boolean {
+		const height = this.terminal.rows;
+		const width = this.terminal.columns;
+		if (height <= 0 || width <= 0 || this.#previousLines.length === 0) return false;
+		const maxViewportTop = Math.max(0, this.#previousLines.length - height);
+		const currentViewportTop = Math.max(0, Math.min(maxViewportTop, this.#manualViewportTop ?? this.#viewportTopRow));
+		const pageStep = Math.max(1, height - 1);
+		const targetViewportTop = Math.max(0, Math.min(maxViewportTop, currentViewportTop + direction * pageStep));
+
+		if (targetViewportTop >= maxViewportTop) {
+			this.#manualViewportTop = undefined;
+		} else {
+			this.#manualViewportTop = targetViewportTop;
+		}
+
+		const cursorPos = this.#manualViewportTop === undefined ? this.#lastCursorPosition : null;
+		return this.#repaintViewportFromLines(
+			this.#previousLines,
+			width,
+			height,
+			targetViewportTop,
+			cursorPos,
+			"manual viewport scroll",
+		);
+	}
+
+	followLiveViewport(): boolean {
+		if (this.#manualViewportTop === undefined) return false;
+		const height = this.terminal.rows;
+		const width = this.terminal.columns;
+		const liveViewportTop = Math.max(0, this.#previousLines.length - height);
+		this.#manualViewportTop = undefined;
+		return this.#repaintViewportFromLines(
+			this.#previousLines,
+			width,
+			height,
+			liveViewportTop,
+			this.#lastCursorPosition,
+			"manual viewport follow live",
+		);
 	}
 
 	/**
@@ -1361,6 +1404,64 @@ export class TUI extends Container {
 		padded.splice(insertAt, 0, ...Array.from({ length: blankRows }, () => ""));
 		return padded;
 	}
+	#repaintViewportFromLines(
+		lines: string[],
+		width: number,
+		height: number,
+		viewportTop: number,
+		cursorPos: { row: number; col: number } | null,
+		reason: string,
+	): boolean {
+		if (height <= 0 || width <= 0) return false;
+		const maxViewportTop = Math.max(0, lines.length - height);
+		const nextViewportTop = Math.max(0, Math.min(maxViewportTop, viewportTop));
+		const currentScreenRow = Math.max(0, Math.min(height - 1, this.#hardwareCursorRow - this.#viewportTopRow));
+		let buffer = "\x1b[?2026h";
+		if (currentScreenRow > 0) {
+			buffer += `\x1b[${currentScreenRow}A`;
+		}
+		buffer += "\r";
+
+		for (let screenRow = 0; screenRow < height; screenRow++) {
+			if (screenRow > 0) buffer += "\r\n";
+			buffer += "\x1b[2K";
+			const lineIndex = nextViewportTop + screenRow;
+			if (lineIndex >= lines.length) continue;
+			const line = lines[lineIndex];
+			const isImage = TERMINAL.isImageLine(line);
+			if (!isImage && visibleWidth(line) > width) {
+				let truncatedLine = truncateToWidth(line, width, Ellipsis.Omit);
+				truncatedLine += truncatedLine.includes("\x1b]8;") ? LINE_TERMINATOR : SEGMENT_RESET;
+				buffer += truncatedLine;
+			} else {
+				buffer += line;
+			}
+		}
+
+		const finalPhysicalRow = nextViewportTop + Math.max(0, height - 1);
+		let cursorSeq = "\x1b[?25l";
+		let cursorToRow = finalPhysicalRow;
+		if (cursorPos && cursorPos.row >= nextViewportTop && cursorPos.row < nextViewportTop + height) {
+			const cursor = this.#cursorControlSequence(cursorPos, lines.length, finalPhysicalRow);
+			cursorSeq = cursor.seq;
+			cursorToRow = cursor.toRow;
+		}
+		this.#hardwareCursorRow = cursorToRow;
+		buffer += cursorSeq;
+		buffer += "\x1b[?2026l";
+		if (!this.#writeTerminal(buffer)) return false;
+
+		if ($flag("PI_DEBUG_REDRAW")) {
+			const logPath = getDebugLogPath();
+			const msg = `[${new Date().toISOString()}] viewportRepaint: ${reason} (lines=${lines.length}, height=${height}, viewportTop=${nextViewportTop})\n`;
+			fs.appendFileSync(logPath, msg);
+		}
+
+		this.#cursorRow = Math.max(0, lines.length - 1);
+		this.#maxLinesRendered = lines.length;
+		this.#viewportTopRow = nextViewportTop;
+		return true;
+	}
 
 	#doRender(): void {
 		if (this.#stopped || !this.terminalAvailable) return;
@@ -1391,6 +1492,7 @@ export class TUI extends Container {
 
 		// Extract cursor position (marker must be found before diff comparison)
 		const cursorPos = this.#extractCursorPosition(newLines, height);
+		this.#lastCursorPosition = cursorPos;
 
 		// Terminate every non-image line so #previousLines mirrors emitted bytes
 		// (closes SGR + OSC 8 hyperlink state). Must run after cursor extraction
@@ -1451,6 +1553,28 @@ export class TUI extends Container {
 			if (usedWindowNormalize) renderMetrics.recordLineCount("offscreenScan", diffStart);
 		}
 
+		if (this.#manualViewportTop !== undefined) {
+			const maxViewportTop = Math.max(0, newLines.length - height);
+			const nextViewportTop = Math.max(0, Math.min(maxViewportTop, this.#manualViewportTop));
+			const followingLive = nextViewportTop >= maxViewportTop;
+			this.#manualViewportTop = followingLive ? undefined : nextViewportTop;
+			const repaintCursorPos = followingLive ? cursorPos : null;
+			if (
+				this.#repaintViewportFromLines(
+					newLines,
+					width,
+					height,
+					nextViewportTop,
+					repaintCursorPos,
+					"manual viewport render",
+				)
+			) {
+				this.#previousLines = newLines;
+				this.#previousWidth = width;
+				this.#previousHeight = height;
+			}
+			return;
+		}
 		// Helper to clear scrollback and viewport and render all new lines
 		const fullRender = (clear: boolean, reason = "full render"): void => {
 			this.#fullRedrawCount += 1;

--- a/packages/tui/test/viewport-scroll.test.ts
+++ b/packages/tui/test/viewport-scroll.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import { type Component, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+class Lines implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	append(line: string): void {
+		this.#lines = [...this.#lines, line];
+	}
+
+	render(_width: number): string[] {
+		return this.#lines;
+	}
+
+	invalidate(): void {}
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await new Promise<void>(resolve => process.nextTick(resolve));
+	await Bun.sleep(1);
+	await term.flush();
+}
+
+function visible(term: VirtualTerminal): string[] {
+	return term.getViewport().map(line => line.trimEnd());
+}
+
+describe("TUI manual viewport paging", () => {
+	it("pages through the rendered transcript without editing content", async () => {
+		const term = new VirtualTerminal(30, 5);
+		const tui = new TUI(term);
+		const content = new Lines(Array.from({ length: 10 }, (_value, index) => `line-${index}`));
+		tui.addChild(content);
+
+		try {
+			tui.start();
+			await settle(term);
+			expect(visible(term)).toEqual(["line-5", "line-6", "line-7", "line-8", "line-9"]);
+
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			expect(visible(term)).toEqual(["line-1", "line-2", "line-3", "line-4", "line-5"]);
+
+			expect(tui.scrollViewportPages(1)).toBe(true);
+			await term.flush();
+			expect(visible(term)).toEqual(["line-5", "line-6", "line-7", "line-8", "line-9"]);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("keeps the manual viewport stable across new output until following live", async () => {
+		const term = new VirtualTerminal(30, 5);
+		const tui = new TUI(term);
+		const content = new Lines(Array.from({ length: 10 }, (_value, index) => `line-${index}`));
+		tui.addChild(content);
+
+		try {
+			tui.start();
+			await settle(term);
+
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			expect(visible(term)).toEqual(["line-1", "line-2", "line-3", "line-4", "line-5"]);
+
+			content.append("line-10");
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term)).toEqual(["line-1", "line-2", "line-3", "line-4", "line-5"]);
+
+			expect(tui.followLiveViewport()).toBe(true);
+			await term.flush();
+			expect(visible(term)).toEqual(["line-6", "line-7", "line-8", "line-9", "line-10"]);
+		} finally {
+			tui.stop();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- route PageUp/PageDown in the main GJC composer to transcript viewport paging instead of prompt-history navigation
- keep autocomplete and selector PageUp/PageDown behavior intact
- add TUI manual viewport repaint support that holds the viewed transcript page across new output until the composer follows live output again

## Verification
- bun test --preload C:/tmp/gjc-test-preload/mock-natives.ts packages/tui/test/viewport-scroll.test.ts
- bun test --preload C:/tmp/gjc-test-preload/mock-natives.ts packages/coding-agent/test/custom-editor-keybindings.test.ts --test-name-pattern "viewport paging"
- bun --cwd=packages/tui run check:types
- bun --cwd=packages/coding-agent run check:types
- bunx biome check docs/keybindings.md packages/coding-agent/CHANGELOG.md packages/coding-agent/src/modes/components/custom-editor.ts packages/coding-agent/src/modes/controllers/input-controller.ts packages/coding-agent/test/custom-editor-keybindings.test.ts packages/tui/CHANGELOG.md packages/tui/src/tui.ts packages/tui/test/viewport-scroll.test.ts