### PR TITLE
perf(coding-agent): dedupe dashboard rendering

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Escape now reliably cancels active context maintenance, handoff generation, retry backoff, and workflow ask dialogs even when transient UI focus or typed drafts would previously consume the key.
 - The main composer now uses `PageUp` / `PageDown` to page the visible transcript viewport instead of duplicating prompt-history navigation; `Up` / `Down` and `Ctrl+R` remain the prompt-history paths, and autocomplete lists keep their own page navigation.
+- Shared the duplicated two-column dashboard renderer used by agent and extension dashboards, keeping narrow-width truncation behavior in one tested component.
+- Avoided duplicate line splitting when formatting `ast_grep` matches, reducing allocation in large structural-search result rendering.
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/components/agent-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/agent-dashboard.ts
@@ -23,13 +23,11 @@ import {
 	extractPrintableText,
 	Input,
 	matchesKey,
-	padding,
 	replaceTabs,
 	resolveTerminalColumns,
 	Spacer,
 	Text,
 	truncateToWidth,
-	visibleWidth,
 	wrapTextWithAnsi,
 } from "@gajae-code/tui";
 import { isEnoent, prompt } from "@gajae-code/utils";
@@ -52,6 +50,7 @@ import { shortenPath } from "../../tools/render-utils";
 import { theme } from "../theme/theme";
 import { matchesAppInterrupt } from "../utils/keybinding-matchers";
 import { DynamicBorder } from "./dynamic-border";
+import { TwoColumnBody } from "./two-column-body";
 
 type SourceTabId = "all" | AgentSource;
 type AgentScope = "project" | "user";
@@ -294,38 +293,6 @@ class AgentInspectorPane implements Component {
 	}
 
 	invalidate(): void {}
-}
-
-class TwoColumnBody implements Component {
-	constructor(
-		private readonly leftPane: AgentListPane,
-		private readonly rightPane: AgentInspectorPane,
-		private readonly maxHeight: number,
-	) {}
-
-	render(width: number): string[] {
-		const leftWidth = Math.floor(width * 0.5);
-		const rightWidth = width - leftWidth - 3;
-		const leftLines = this.leftPane.render(leftWidth);
-		const rightLines = this.rightPane.render(rightWidth);
-		const lineCount = Math.min(this.maxHeight, Math.max(leftLines.length, rightLines.length));
-		const out: string[] = [];
-		const separator = theme.fg("dim", ` ${theme.boxSharp.vertical} `);
-
-		for (let i = 0; i < lineCount; i++) {
-			const left = truncateToWidth(leftLines[i] ?? "", leftWidth);
-			const leftPadded = left + padding(Math.max(0, leftWidth - visibleWidth(left)));
-			const right = truncateToWidth(rightLines[i] ?? "", rightWidth);
-			out.push(leftPadded + separator + right);
-		}
-
-		return out;
-	}
-
-	invalidate(): void {
-		this.leftPane.invalidate?.();
-		this.rightPane.invalidate?.();
-	}
 }
 
 export class AgentDashboard extends Container {

--- a/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
@@ -11,20 +11,12 @@
  * - Space: Toggle selected item (or master switch)
  * - Esc: Close dashboard (clears search first if active)
  */
-import {
-	type Component,
-	Container,
-	matchesKey,
-	padding,
-	Spacer,
-	Text,
-	truncateToWidth,
-	visibleWidth,
-} from "@gajae-code/tui";
+import { Container, matchesKey, Spacer, Text } from "@gajae-code/tui";
 import { Settings } from "../../../config/settings";
 import { DynamicBorder } from "../../../modes/components/dynamic-border";
 import { theme } from "../../../modes/theme/theme";
 import { matchesAppInterrupt } from "../../../modes/utils/keybinding-matchers";
+import { TwoColumnBody } from "../two-column-body";
 import { ExtensionList } from "./extension-list";
 import { InspectorPanel } from "./inspector-panel";
 import {
@@ -308,43 +300,5 @@ export class ExtensionDashboard extends Container {
 			this.#state.searchQuery = query;
 			this.#state.searchFiltered = applyFilter(this.#state.tabFiltered, query);
 		}
-	}
-}
-
-/**
- * Two-column body component for side-by-side rendering.
- */
-class TwoColumnBody implements Component {
-	constructor(
-		private readonly leftPane: ExtensionList,
-		private readonly rightPane: InspectorPanel,
-		private readonly maxHeight: number,
-	) {}
-
-	render(width: number): string[] {
-		const leftWidth = Math.floor(width * 0.5);
-		const rightWidth = Math.max(0, width - leftWidth - 3);
-
-		const leftLines = this.leftPane.render(leftWidth);
-		const rightLines = this.rightPane.render(rightWidth);
-
-		// Limit to maxHeight lines
-		const numLines = Math.min(this.maxHeight, Math.max(leftLines.length, rightLines.length));
-		const combined: string[] = [];
-		const separator = theme.fg("dim", ` ${theme.boxSharp.vertical} `);
-
-		for (let i = 0; i < numLines; i++) {
-			const left = truncateToWidth(leftLines[i] ?? "", leftWidth);
-			const leftPadded = left + padding(Math.max(0, leftWidth - visibleWidth(left)));
-			const right = truncateToWidth(rightLines[i] ?? "", rightWidth);
-			combined.push(leftPadded + separator + right);
-		}
-
-		return combined;
-	}
-
-	invalidate(): void {
-		this.leftPane.invalidate?.();
-		this.rightPane.invalidate?.();
 	}
 }

--- a/packages/coding-agent/src/modes/components/two-column-body.ts
+++ b/packages/coding-agent/src/modes/components/two-column-body.ts
@@ -1,0 +1,36 @@
+import { type Component, padding, truncateToWidth, visibleWidth } from "@gajae-code/tui";
+import { theme } from "../theme/theme";
+
+export class TwoColumnBody implements Component {
+	constructor(
+		private readonly leftPane: Component,
+		private readonly rightPane: Component,
+		private readonly maxHeight: number,
+	) {}
+
+	render(width: number): string[] {
+		const leftWidth = Math.floor(width * 0.5);
+		const separatorText = theme.fg("dim", ` ${theme.boxSharp.vertical} `);
+		const separatorWidth = width - leftWidth > 3 ? visibleWidth(separatorText) : 0;
+		const separator = separatorWidth > 0 ? separatorText : "";
+		const rightWidth = Math.max(0, width - leftWidth - separatorWidth);
+		const leftLines = this.leftPane.render(leftWidth);
+		const rightLines = this.rightPane.render(rightWidth);
+		const lineCount = Math.min(this.maxHeight, Math.max(leftLines.length, rightLines.length));
+		const out: string[] = [];
+
+		for (let i = 0; i < lineCount; i++) {
+			const left = truncateToWidth(leftLines[i] ?? "", leftWidth);
+			const leftPadded = left + padding(Math.max(0, leftWidth - visibleWidth(left)));
+			const right = truncateToWidth(rightLines[i] ?? "", rightWidth);
+			out.push(leftPadded + separator + right);
+		}
+
+		return out;
+	}
+
+	invalidate(): void {
+		this.leftPane.invalidate?.();
+		this.rightPane.invalidate?.();
+	}
+}

--- a/packages/coding-agent/src/tools/ast-grep.ts
+++ b/packages/coding-agent/src/tools/ast-grep.ts
@@ -223,13 +223,16 @@ export class AstGrepTool implements AgentTool<typeof astGrepSchema, AstGrepToolD
 				const modelOut: string[] = [];
 				const displayOut: string[] = [];
 				const fileMatches = matchesByFile.get(relativePath) ?? [];
-				const lineNumberWidth = fileMatches.reduce((width, match) => {
-					const lineCount = match.text.split("\n").length;
-					const endLine = match.startLine + lineCount - 1;
-					return Math.max(width, String(match.startLine).length, String(endLine).length);
-				}, 0);
-				for (const match of fileMatches) {
-					const matchLines = match.text.split("\n");
+				const preparedMatches = fileMatches.map(match => {
+					const lines = match.text.split("\n");
+					const endLine = match.startLine + lines.length - 1;
+					return { match, lines, endLine };
+				});
+				const lineNumberWidth = preparedMatches.reduce(
+					(width, entry) => Math.max(width, String(entry.match.startLine).length, String(entry.endLine).length),
+					0,
+				);
+				for (const { match, lines: matchLines } of preparedMatches) {
 					for (let index = 0; index < matchLines.length; index++) {
 						const lineNumber = match.startLine + index;
 						const isMatch = index === 0;

--- a/packages/coding-agent/test/two-column-body.test.ts
+++ b/packages/coding-agent/test/two-column-body.test.ts
@@ -1,0 +1,47 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { type Component, visibleWidth } from "@gajae-code/tui";
+import { TwoColumnBody } from "../src/modes/components/two-column-body";
+import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
+
+class StaticPane implements Component {
+	constructor(private readonly lines: string[]) {}
+
+	render(_width: number): string[] {
+		return this.lines;
+	}
+
+	invalidate = vi.fn();
+}
+
+beforeAll(async () => {
+	const theme = await getThemeByName("red-claw");
+	if (!theme) throw new Error("Failed to load red-claw theme");
+	setThemeInstance(theme);
+});
+
+describe("TwoColumnBody", () => {
+	it("keeps combined rows within the requested width", () => {
+		const body = new TwoColumnBody(
+			new StaticPane(["left column content that must truncate"]),
+			new StaticPane(["right column content that must truncate"]),
+			3,
+		);
+
+		for (const width of [2, 3, 20, 80]) {
+			const lines = body.render(width);
+			expect(lines.length).toBe(1);
+			expect(visibleWidth(lines[0] ?? "")).toBeLessThanOrEqual(width);
+		}
+	});
+
+	it("invalidates both panes", () => {
+		const left = new StaticPane(["left"]);
+		const right = new StaticPane(["right"]);
+		const body = new TwoColumnBody(left, right, 3);
+
+		body.invalidate();
+
+		expect(left.invalidate).toHaveBeenCalledTimes(1);
+		expect(right.invalidate).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary
- share the duplicated two-column dashboard renderer between the agent and extension dashboards
- add focused coverage for width clamping and pane invalidation in the shared renderer
- avoid duplicate `match.text.split("\n")` work when formatting `ast_grep` result frames

## Audit notes
Read-only audits checked TUI/coding-agent performance and duplicate user-facing behavior. I implemented the narrow high-confidence cleanup from those findings that was safe to verify in this environment.

## Verification
- bun test --preload C:/tmp/gjc-test-preload/mock-natives.ts packages/coding-agent/test/two-column-body.test.ts packages/coding-agent/test/extension-dashboard-state.test.ts
- bun --cwd=packages/coding-agent run check:types
- bunx biome check packages/coding-agent/src/modes/components/two-column-body.ts packages/coding-agent/src/modes/components/agent-dashboard.ts packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts packages/coding-agent/src/tools/ast-grep.ts packages/coding-agent/test/two-column-body.test.ts packages/coding-agent/CHANGELOG.md
- git diff --check origin/dev...HEAD

## Note
`bun test packages/coding-agent/test/tools/ast-grep.test.ts` could not run on this Windows workspace because the `pi_natives` win32 addon is not present locally; the ast-grep change is a contained allocation-only renderer refactor and is covered by type/lint checks here.