### PR TITLE
fix(coding-agent): dispose welcome intro timer

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -57,6 +57,11 @@ export class WelcomeComponent implements Component {
 			}
 			requestRender();
 		}, INTRO_TICK_MS);
+		this.#animTimer.unref?.();
+	}
+
+	dispose(): void {
+		this.#stopAnimation();
 	}
 
 	#stopAnimation(): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1958,6 +1958,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.loadingAnimation.stop();
 			this.loadingAnimation = undefined;
 		}
+		this.#welcomeComponent?.dispose();
+		this.#welcomeComponent = undefined;
 		this.#cleanupMicAnimation();
 		this.#cancelGoalContinuation();
 		if (this.#sttController) {

--- a/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
+++ b/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
@@ -131,7 +131,7 @@ describe("redesigned interactive shell chrome", () => {
 		const lines = component.render(54);
 		const rendered = Bun.stripANSI(lines.join("\n"));
 
-		expect(rendered).toContain("Gajae forge");
+		expect(rendered).toContain("GJC Forge");
 		expect(rendered).toContain("╭────────────────╮        ╭────────╮");
 		expect(rendered).toContain("╰────────────────╯        ╰────────╯");
 		expect(rendered).not.toContain("●");
@@ -147,10 +147,10 @@ describe("redesigned interactive shell chrome", () => {
 		const narrowTop = Bun.stripANSI(narrowLines[0] ?? "");
 		const wideTop = Bun.stripANSI(wideLines[0] ?? "");
 
-		expect(visibleWidth(narrowTop)).toBe(98);
-		expect(visibleWidth(wideTop)).toBe(158);
+		expect(visibleWidth(narrowTop)).toBe(100);
+		expect(visibleWidth(wideTop)).toBe(160);
 		expect(visibleWidth(wideTop)).toBeGreaterThan(visibleWidth(narrowTop));
-		expect(wideTop).toContain("GJC forge");
+		expect(wideTop).toContain("GJC Forge");
 		for (const line of wideLines) {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(160);
 		}

--- a/packages/coding-agent/test/modes/controllers/btw-escape-dismiss.test.ts
+++ b/packages/coding-agent/test/modes/controllers/btw-escape-dismiss.test.ts
@@ -22,7 +22,7 @@ interface Harness {
 function makeHarness(runEphemeralTurn: () => Promise<unknown>): Harness {
 	const editor = new CustomEditor(getEditorTheme());
 	const btwContainer = new Container();
-	const ui = { requestRender: vi.fn(), onDebug: undefined } as unknown as TUI;
+	const ui = { requestRender: vi.fn(), followLiveViewport: vi.fn(), onDebug: undefined } as unknown as TUI;
 	const session = {
 		model: { provider: "anthropic", id: "test" },
 		runEphemeralTurn,


### PR DESCRIPTION
## Summary
- unref/dispose the welcome intro animation timer so package test shards can exit cleanly
- dispose the welcome component from interactive mode teardown
- update startup splash expectations for the expanded viewport branding
- update the BTW escape-dismiss test TUI fixture for the live-viewport method now used by the flow

## Verification
- `timeout 20s bun test packages/coding-agent/test/welcome-viewport.test.ts`
- `timeout 20s bun test packages/coding-agent/test/modes/components/redesigned-shell.test.ts`
- `timeout 20s bun test packages/coding-agent/test/interactive-mode-editor-component.test.ts`
- `timeout 60s bun test packages/coding-agent/test/modes`
- `timeout 600s env CI_DEV_CHANGED_PATHS="packages/coding-agent/CHANGELOG.md,packages/coding-agent/src/modes/components/welcome.ts,packages/coding-agent/src/modes/interactive-mode.ts,packages/coding-agent/test/welcome-viewport.test.ts" bun scripts/ci-dev-affected.ts --task='test:@gajae-code/coding-agent'`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check origin/dev...HEAD`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*