### PR TITLE
Fix vanished GJC session evidence

### DIFF
--- a/docs/gjc-session-clawhip-routing.md
+++ b/docs/gjc-session-clawhip-routing.md
@@ -54,7 +54,7 @@ This repository includes a portable implementation in `scripts/gjc-session/`. It
 
 The `scripts/gjc-session/` directory contains the public version of the operator helpers:
 
-- `create.sh` validates a dedicated git worktree, starts interactive `gjc` in tmux, preserves the pane after exit, prints and writes the session-specific durable state path, writes `metadata.json`, mirrors pane output to `pane.log`, records lifecycle events in `events.log`, writes normal-exit `final.json`, and optionally registers a Clawhip-style `tmux watch`.
+- `create.sh` validates a dedicated git worktree, starts interactive `gjc` in tmux, preserves the pane after exit, prints and writes the session-specific durable state path, writes `metadata.json`, mirrors pane output to `pane.log`, records lifecycle events in `events.log`, bridges the inner `gjc` process to a public-safe `runtime-state.json`, writes normal-exit `final.json`, and optionally registers a Clawhip-style `tmux watch`.
 - `prompt.sh` sends a text or `@file` prompt only after the pane looks like a ready GJC TUI; if the tmux session vanished, it refuses injection and prints the durable metadata/log/final/events recovery paths plus the last pane-log excerpt.
 - `tail.sh` captures bounded pane output for readiness and acceptance checks, with durable metadata, pane-log, event-log, and final-status fallback when tmux vanished.
 - `harness-tmux-owner-start.sh` starts the GJC harness control plane with the RuntimeOwner resident inside tmux for dogfood/debug cases that need visible owner liveness.
@@ -149,7 +149,7 @@ After prompt delivery, require one of these before reporting that the session is
 - a GitHub comment/review/PR URL,
 - a terminal verdict such as `MERGE_READY` or `REQUEST_CHANGES`.
 
-A prompt being visible in tmux scrollback is not acceptance by itself. If tmux disappears before terminal verdict, inspect the state path printed by `create.sh`: `metadata.json` identifies the worktree/session, `pane.log` contains the mirrored transcript, `events.log` records launch/exit milestones, and `final.json` is present when `gjc` exited normally. Use `tail.sh <session-name> [lines]` to surface these artifacts without a live tmux server.
+A prompt being visible in tmux scrollback is not acceptance by itself. If tmux disappears before terminal verdict, inspect the state path printed by `create.sh`: `metadata.json` identifies the worktree/session and links `runtime-state.json`; `runtime-state.json` contains public-safe GJC lifecycle state (`completed` / `errored`, timestamps, cwd/workdir, branch, session file, exit code/signal/error when available) without pane logs, prompts, transcripts, tokens, config, environment dumps, or raw tool output; `pane.log` contains the private mirrored transcript; `events.log` records launch/exit milestones; `final.json` is present when the wrapper observed `gjc` exit; and `vanished.json` is present when the external monitor observed the tmux session disappear. Use `tail.sh <session-name> [lines]` to surface these artifacts without a live tmux server.
 
 ## Anti-patterns
 

--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -1,12 +1,17 @@
+import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AssistantMessage } from "@gajae-code/ai";
-import { logger } from "@gajae-code/utils";
+import { logger, postmortem } from "@gajae-code/utils";
 
 export const GJC_COORDINATOR_SESSION_STATE_FILE_ENV = "GJC_COORDINATOR_SESSION_STATE_FILE";
 export const GJC_COORDINATOR_SESSION_ID_ENV = "GJC_COORDINATOR_SESSION_ID";
+export const GJC_COORDINATOR_SESSION_BRANCH_ENV = "GJC_COORDINATOR_SESSION_BRANCH";
 
 export type RuntimeState = "ready_for_input" | "running" | "needs_user_input" | "completed" | "errored";
+
+type FinalResponseSource = "agent_end" | "launch_error";
+const MAX_PUBLIC_ERROR_MESSAGE_LENGTH = 2000;
 
 interface RuntimeStateEvent {
 	type: string;
@@ -17,6 +22,7 @@ interface RuntimeStateContext {
 	sessionId: string;
 	cwd: string;
 	sessionFile?: string | null;
+	branch?: string | null;
 }
 
 interface RuntimeStateSidecarPayload {
@@ -26,6 +32,7 @@ interface RuntimeStateSidecarPayload {
 	ready_for_input?: unknown;
 	cwd?: unknown;
 	session_file?: unknown;
+	final_response?: { source?: unknown };
 }
 
 export type TerminalRuntimeStateStatus =
@@ -103,7 +110,7 @@ function assistantText(assistant: AssistantMessage | undefined): string | null {
 function finalResponseForEvent(event: RuntimeStateEvent): {
 	text: string | null;
 	format: "markdown";
-	source: "agent_end";
+	source: FinalResponseSource;
 	artifact_path: null;
 	truncated: false;
 } | null {
@@ -127,6 +134,118 @@ function stateForEvent(event: RuntimeStateEvent): RuntimeState | null {
 	return null;
 }
 
+function readPreviousPayload(stateFile: string): Record<string, unknown> {
+	try {
+		return JSON.parse(fsSync.readFileSync(stateFile, "utf8")) as Record<string, unknown>;
+	} catch {
+		return {};
+	}
+}
+
+function shouldPreserveTerminalPayload(previous: RuntimeStateSidecarPayload): boolean {
+	if (previous.state !== "completed" && previous.state !== "errored") return false;
+	const source = previous.final_response?.source;
+	return source === "agent_end" || source === "launch_error";
+}
+
+function branchForContext(context: RuntimeStateContext): string | null {
+	return context.branch ?? (process.env[GJC_COORDINATOR_SESSION_BRANCH_ENV]?.trim() || null);
+}
+
+function basePayload(input: {
+	context: RuntimeStateContext;
+	previous: Record<string, unknown>;
+	state: RuntimeState;
+	now: string;
+	source: string;
+	event: string;
+	reason: string | null;
+}): Record<string, unknown> {
+	return {
+		schema_version: 1,
+		session_id: process.env[GJC_COORDINATOR_SESSION_ID_ENV]?.trim() || input.context.sessionId,
+		state: input.state,
+		ready_for_input: input.state === "completed" || input.state === "ready_for_input",
+		updated_at: input.now,
+		current_turn_id: typeof input.previous.current_turn_id === "string" ? input.previous.current_turn_id : null,
+		last_turn_id: typeof input.previous.last_turn_id === "string" ? input.previous.last_turn_id : null,
+		live: input.state === "running",
+		reason: input.reason,
+		source: input.source,
+		event: input.event,
+		cwd: input.context.cwd,
+		workdir: input.context.cwd,
+		branch: branchForContext(input.context),
+		session_file: input.context.sessionFile ?? null,
+	};
+}
+function publicSafeErrorMessage(message: string): string {
+	const normalized = message.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, " ").trim();
+	if (normalized.length <= MAX_PUBLIC_ERROR_MESSAGE_LENGTH) return normalized;
+	return `${normalized.slice(0, MAX_PUBLIC_ERROR_MESSAGE_LENGTH)}…`;
+}
+
+function errorMessageForPostmortem(reason: postmortem.Reason): string {
+	return publicSafeErrorMessage(`GJC process cleanup ran for ${reason}`);
+}
+
+function numericProcessExitCode(defaultCode: number | null): number | null {
+	return typeof process.exitCode === "number" ? process.exitCode : defaultCode;
+}
+
+function postmortemExitDetails(reason: postmortem.Reason): {
+	state: RuntimeState;
+	reason: string;
+	exitKind: string;
+	exitCode: number | null;
+	signal: string | null;
+	error?: { code: string; message: string; recoverable: true };
+} {
+	if (reason === postmortem.Reason.EXIT || reason === postmortem.Reason.MANUAL) {
+		const exitCode = numericProcessExitCode(0) ?? 0;
+		const state: RuntimeState = exitCode === 0 ? "completed" : "errored";
+		return {
+			state,
+			reason: reason === postmortem.Reason.EXIT ? "process_exit" : "manual_cleanup",
+			exitKind: reason,
+			exitCode,
+			signal: null,
+			...(state === "errored"
+				? {
+						error: {
+							code: "process_exit",
+							message: publicSafeErrorMessage(`GJC process exited with code ${exitCode}`),
+							recoverable: true,
+						},
+					}
+				: {}),
+		};
+	}
+	const signalByReason: Partial<Record<postmortem.Reason, string>> = {
+		[postmortem.Reason.SIGINT]: "SIGINT",
+		[postmortem.Reason.SIGTERM]: "SIGTERM",
+		[postmortem.Reason.SIGHUP]: "SIGHUP",
+	};
+	return {
+		state: "errored",
+		reason,
+		exitKind: reason,
+		exitCode: numericProcessExitCode(null),
+		signal: signalByReason[reason] ?? null,
+		error: { code: reason, message: errorMessageForPostmortem(reason), recoverable: true },
+	};
+}
+
+function writeStateFileSync(stateFile: string, payload: Record<string, unknown>): void {
+	fsSync.mkdirSync(path.dirname(stateFile), { recursive: true });
+	fsSync.writeFileSync(stateFile, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+async function writeStateFile(stateFile: string, payload: Record<string, unknown>): Promise<void> {
+	await fs.mkdir(path.dirname(stateFile), { recursive: true });
+	await Bun.write(stateFile, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
 export async function persistCoordinatorRuntimeStateFromEvent(
 	event: RuntimeStateEvent,
 	context: RuntimeStateContext,
@@ -136,42 +255,66 @@ export async function persistCoordinatorRuntimeStateFromEvent(
 	const state = stateForEvent(event);
 	if (!state) return;
 	const now = new Date().toISOString();
-	let previous: Record<string, unknown> = {};
-	try {
-		previous = JSON.parse(await Bun.file(stateFile).text()) as Record<string, unknown>;
-	} catch {
-		previous = {};
-	}
+	const previous = readPreviousPayload(stateFile);
 	const finalResponse = finalResponseForEvent(event);
 	const payload = {
-		schema_version: 1,
-		session_id: process.env[GJC_COORDINATOR_SESSION_ID_ENV]?.trim() || context.sessionId,
-		state,
-		ready_for_input: state === "completed" || state === "ready_for_input",
-		updated_at: now,
-		current_turn_id: typeof previous.current_turn_id === "string" ? previous.current_turn_id : null,
-		last_turn_id: typeof previous.last_turn_id === "string" ? previous.last_turn_id : null,
-		live: typeof previous.live === "boolean" ? previous.live : null,
-		reason: null,
-		source: "agent_session_event",
-		event: event.type,
-		cwd: context.cwd,
-		session_file: context.sessionFile ?? null,
+		...basePayload({ context, previous, state, now, source: "agent_session_event", event: event.type, reason: null }),
+		...(state === "completed" || state === "errored" ? { ended_at: now } : {}),
 		...(finalResponse ? { final_response: finalResponse } : {}),
 		...(state === "errored"
 			? {
 					error: {
 						code: "agent_error",
-						message: lastAssistant(event.messages)?.errorMessage ?? "agent_error",
+						message: publicSafeErrorMessage(lastAssistant(event.messages)?.errorMessage ?? "agent_error"),
 						recoverable: true,
 					},
 				}
 			: {}),
 	};
 	try {
-		await fs.mkdir(path.dirname(stateFile), { recursive: true });
-		await Bun.write(stateFile, `${JSON.stringify(payload, null, 2)}\n`);
+		await writeStateFile(stateFile, payload);
 	} catch (error) {
 		logger.warn("Failed to persist coordinator runtime state", { error: String(error), stateFile });
 	}
+}
+
+export function persistCoordinatorRuntimeStateFromPostmortem(
+	reason: postmortem.Reason,
+	context: RuntimeStateContext,
+): void {
+	const stateFile = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim();
+	if (!stateFile) return;
+	const previous = readPreviousPayload(stateFile);
+	if (shouldPreserveTerminalPayload(previous as RuntimeStateSidecarPayload)) return;
+	const now = new Date().toISOString();
+	const details = postmortemExitDetails(reason);
+	const payload = {
+		...basePayload({
+			context,
+			previous,
+			state: details.state,
+			now,
+			source: "process_postmortem",
+			event: "process_exit",
+			reason: details.reason,
+		}),
+		ended_at: now,
+		detected_at: now,
+		exit_kind: details.exitKind,
+		exit_code: details.exitCode,
+		signal: details.signal,
+		...(details.error ? { error: details.error } : {}),
+	};
+	try {
+		writeStateFileSync(stateFile, payload);
+	} catch (error) {
+		logger.warn("Failed to persist coordinator runtime state during postmortem", { error: String(error), stateFile });
+	}
+}
+
+export function registerCoordinatorRuntimeStateFinalizer(context: RuntimeStateContext): () => void {
+	if (!process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim()) return () => {};
+	return postmortem.register("coordinator-runtime-state", reason => {
+		persistCoordinatorRuntimeStateFromPostmortem(reason, context);
+	});
 }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -192,7 +192,10 @@ import {
 	modeStatePath as sessionModeStatePath,
 	sessionStateDir,
 } from "../gjc-runtime/session-layout";
-import { persistCoordinatorRuntimeStateFromEvent } from "../gjc-runtime/session-state-sidecar";
+import {
+	persistCoordinatorRuntimeStateFromEvent,
+	registerCoordinatorRuntimeStateFinalizer,
+} from "../gjc-runtime/session-state-sidecar";
 import { writeArtifact } from "../gjc-runtime/state-writer";
 import { requestGjcWorkerIntegrationAttempt } from "../gjc-runtime/team-runtime";
 import { GoalRuntime } from "../goals/runtime";
@@ -1010,6 +1013,7 @@ export class AgentSession {
 	#evalKernelOwnerId: string;
 	/** Idempotent unregister handle for this session's resource-GC registration. */
 	#unregisterResourceGc?: () => void;
+	#unregisterRuntimeStateFinalizer?: () => void;
 	/**
 	 * AsyncJobManager owned by this session (top-level only). Subagents leave
 	 * this undefined and **MUST NOT** dispose the global instance on teardown.
@@ -1235,6 +1239,11 @@ export class AgentSession {
 				settings: this.settings,
 			});
 		}
+		this.#unregisterRuntimeStateFinalizer = registerCoordinatorRuntimeStateFinalizer({
+			sessionId: this.sessionId,
+			cwd: this.sessionManager.getCwd(),
+			sessionFile: this.sessionManager.getSessionFile(),
+		});
 		// Power assertions are taken per turn (see #beginInFlight); nothing acquired here.
 		this.#evalKernelOwnerId = config.evalKernelOwnerId ?? `agent-session:${Snowflake.next()}`;
 		this.#ownedAsyncJobManager = config.ownedAsyncJobManager;
@@ -3350,6 +3359,8 @@ export class AgentSession {
 		// No-op when this session opened no tabs. Failure is logged, not thrown.
 		this.#unregisterResourceGc?.();
 		this.#unregisterResourceGc = undefined;
+		this.#unregisterRuntimeStateFinalizer?.();
+		this.#unregisterRuntimeStateFinalizer = undefined;
 		await releaseTabsForOwner(this.sessionManager.getSessionId()).catch((error: unknown) =>
 			logger.warn("session dispose: releaseTabsForOwner failed", { error }),
 		);

--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -2,16 +2,20 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { postmortem } from "@gajae-code/utils";
 import {
+	GJC_COORDINATOR_SESSION_BRANCH_ENV,
 	GJC_COORDINATOR_SESSION_ID_ENV,
 	GJC_COORDINATOR_SESSION_STATE_FILE_ENV,
 	persistCoordinatorRuntimeStateFromEvent,
+	persistCoordinatorRuntimeStateFromPostmortem,
 	readTerminalRuntimeStateMarker,
 } from "../src/gjc-runtime/session-state-sidecar";
 
 const tempDirs: string[] = [];
 const ORIGINAL_STATE_FILE = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV];
 const ORIGINAL_SESSION_ID = process.env[GJC_COORDINATOR_SESSION_ID_ENV];
+const ORIGINAL_BRANCH = process.env[GJC_COORDINATOR_SESSION_BRANCH_ENV];
 
 async function tempRoot(): Promise<string> {
 	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-sidecar-"));
@@ -24,6 +28,8 @@ afterEach(async () => {
 	else process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = ORIGINAL_STATE_FILE;
 	if (ORIGINAL_SESSION_ID === undefined) delete process.env[GJC_COORDINATOR_SESSION_ID_ENV];
 	else process.env[GJC_COORDINATOR_SESSION_ID_ENV] = ORIGINAL_SESSION_ID;
+	if (ORIGINAL_BRANCH === undefined) delete process.env[GJC_COORDINATOR_SESSION_BRANCH_ENV];
+	else process.env[GJC_COORDINATOR_SESSION_BRANCH_ENV] = ORIGINAL_BRANCH;
 	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -111,5 +117,69 @@ describe("coordinator runtime state sidecar", () => {
 		await expect(
 			readTerminalRuntimeStateMarker({ stateFile, sessionId: "session-a", cwd: path.join(root, "other") }),
 		).resolves.toEqual({ terminal: false, reason: "cwd_mismatch" });
+	});
+
+	it("writes public-safe postmortem exit evidence without transcript payloads", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "postmortem-session";
+		process.env[GJC_COORDINATOR_SESSION_BRANCH_ENV] = "issue-1496";
+
+		persistCoordinatorRuntimeStateFromPostmortem(postmortem.Reason.SIGTERM, {
+			sessionId: "fallback",
+			cwd: root,
+			sessionFile: path.join(root, "session.jsonl"),
+		});
+
+		const payload = JSON.parse(await Bun.file(stateFile).text());
+		expect(payload).toMatchObject({
+			schema_version: 1,
+			session_id: "postmortem-session",
+			state: "errored",
+			ready_for_input: false,
+			source: "process_postmortem",
+			event: "process_exit",
+			reason: "sigterm",
+			exit_kind: "sigterm",
+			signal: "SIGTERM",
+			cwd: root,
+			workdir: root,
+			branch: "issue-1496",
+			session_file: path.join(root, "session.jsonl"),
+			error: { code: "sigterm", recoverable: true },
+		});
+		expect(payload).not.toHaveProperty("messages");
+		expect(payload).not.toHaveProperty("transcript");
+		expect(payload).not.toHaveProperty("paneLog");
+	});
+
+	it("does not overwrite richer terminal agent_end evidence during postmortem", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "preserved-session";
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "preserved-session",
+				state: "completed",
+				final_response: { source: "agent_end", text: "Already done" },
+			}),
+		);
+
+		persistCoordinatorRuntimeStateFromPostmortem(postmortem.Reason.SIGTERM, {
+			sessionId: "fallback",
+			cwd: root,
+			sessionFile: null,
+		});
+
+		const payload = JSON.parse(await Bun.file(stateFile).text());
+		expect(payload).toMatchObject({
+			state: "completed",
+			final_response: { source: "agent_end", text: "Already done" },
+		});
+		expect(payload.source).not.toBe("process_postmortem");
 	});
 });

--- a/scripts/gjc-session/create.sh
+++ b/scripts/gjc-session/create.sh
@@ -48,6 +48,7 @@ show_recovery_hint() {
   echo "durable events: $STATE_DIR/events.log" >&2
   echo "durable final status: $STATE_DIR/final.json" >&2
   echo "durable vanished status: $STATE_DIR/vanished.json" >&2
+  echo "durable runtime state: $RUNTIME_STATE_JSON" >&2
   if [[ -s "$STATE_DIR/pane.log" ]]; then
     echo "--- durable pane log tail ---" >&2
     tail -40 "$STATE_DIR/pane.log" >&2
@@ -74,6 +75,7 @@ if [[ -z "$BRANCH" || "$BRANCH" == "HEAD" ]]; then
 fi
 
 STATE_DIR="${GJC_SESSION_STATE_DIR:-$WORKDIR/.gjc-session-state/$SESSION}"
+RUNTIME_STATE_JSON="$STATE_DIR/runtime-state.json"
 mkdir -p "$STATE_DIR"
 CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 {
@@ -87,6 +89,7 @@ CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   printf '  "paneLog": "%s",\n' "$(printf '%s' "$STATE_DIR/pane.log" | json_escape)"
   printf '  "eventsLog": "%s",\n' "$(printf '%s' "$STATE_DIR/events.log" | json_escape)"
   printf '  "finalStatus": "%s",\n' "$(printf '%s' "$STATE_DIR/final.json" | json_escape)"
+  printf '  "runtimeState": "%s",\n' "$(printf '%s' "$RUNTIME_STATE_JSON" | json_escape)"
   printf '  "vanishedStatus": "%s"\n' "$(printf '%s' "$STATE_DIR/vanished.json" | json_escape)"
   printf '}\n'
 } >"$STATE_DIR/metadata.json"
@@ -102,6 +105,7 @@ printf '[%s] runner started session=%s branch=%s cwd=%s\n' "$started_at" "$GJC_S
 echo "[gjc-session] session=$GJC_SESSION_NAME branch=$GJC_SESSION_BRANCH cwd=$GJC_SESSION_WORKDIR"
 echo "[gjc-session] durable state=$GJC_SESSION_STATE_DIR"
 echo "[gjc-session] durable pane log=$GJC_SESSION_PANE_LOG"
+echo "[gjc-session] durable runtime state=$GJC_COORDINATOR_SESSION_STATE_FILE"
 "$GJC_SESSION_GJC_BIN" $GJC_SESSION_FLAGS
 rc=$?
 finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -116,11 +120,11 @@ if [[ "$turn_evidence" != "true" ]]; then
   owner_exit_reason="owner_exited_before_turn_evidence"
   owner_exit_severity="failure"
 fi
-python3 - "$GJC_SESSION_FINAL_JSON" "$GJC_SESSION_NAME" "$rc" "$started_at" "$finished_at" "$GJC_SESSION_PANE_LOG" "$turn_evidence" "$owner_exit_reason" "$owner_exit_severity" <<'PY'
+python3 - "$GJC_SESSION_FINAL_JSON" "$GJC_SESSION_NAME" "$rc" "$started_at" "$finished_at" "$GJC_SESSION_PANE_LOG" "$GJC_COORDINATOR_SESSION_STATE_FILE" "$turn_evidence" "$owner_exit_reason" "$owner_exit_severity" <<'PY'
 import json
 import sys
 
-path, session, status, started_at, finished_at, pane_log, turn_evidence, owner_exit_reason, owner_exit_severity = sys.argv[1:]
+path, session, status, started_at, finished_at, pane_log, runtime_state, turn_evidence, owner_exit_reason, owner_exit_severity = sys.argv[1:]
 with open(path, "w", encoding="utf-8") as handle:
     json.dump(
         {
@@ -129,6 +133,7 @@ with open(path, "w", encoding="utf-8") as handle:
             "startedAt": started_at,
             "finishedAt": finished_at,
             "paneLog": pane_log,
+            "runtimeState": runtime_state,
             "turnEvidencePresent": turn_evidence == "true",
             "ownerExitReason": owner_exit_reason,
             "severity": owner_exit_severity,
@@ -183,11 +188,11 @@ PYFINAL
     severity="closed_after_final"
   fi
   printf '[%s] tmux session vanished final_present=%s severity=%s\n' "$detected_at" "$final_present" "$severity" >>"$GJC_SESSION_EVENTS_LOG"
-  python3 - "$GJC_SESSION_VANISHED_JSON" "$GJC_SESSION_NAME" "$detected_at" "$GJC_SESSION_WORKDIR" "$GJC_SESSION_BRANCH" "$GJC_SESSION_PANE_LOG" "$GJC_SESSION_EVENTS_LOG" "$GJC_SESSION_FINAL_JSON" "$final_present" "$severity" "$final_severity" <<'PYINNER'
+  python3 - "$GJC_SESSION_VANISHED_JSON" "$GJC_SESSION_NAME" "$detected_at" "$GJC_SESSION_WORKDIR" "$GJC_SESSION_BRANCH" "$GJC_SESSION_PANE_LOG" "$GJC_SESSION_EVENTS_LOG" "$GJC_SESSION_FINAL_JSON" "$GJC_COORDINATOR_SESSION_STATE_FILE" "$final_present" "$severity" "$final_severity" <<'PYINNER'
 import json
 import sys
 
-(path, session, detected_at, workdir, branch, pane_log, events_log, final_json, final_present, severity, final_severity) = sys.argv[1:]
+(path, session, detected_at, workdir, branch, pane_log, events_log, final_json, runtime_state, final_present, severity, final_severity) = sys.argv[1:]
 with open(path, "w", encoding="utf-8") as handle:
     json.dump(
         {
@@ -198,6 +203,7 @@ with open(path, "w", encoding="utf-8") as handle:
             "paneLog": pane_log,
             "eventsLog": events_log,
             "finalStatus": final_json,
+            "runtimeState": runtime_state,
             "finalPresent": final_present == "true",
             "severity": severity,
             "reason": "tmux_session_missing",
@@ -236,6 +242,9 @@ LAUNCH_CMD=(
   "GJC_SESSION_EVENTS_LOG=$STATE_DIR/events.log"
   "GJC_SESSION_FINAL_JSON=$STATE_DIR/final.json"
   "GJC_SESSION_VANISHED_JSON=$STATE_DIR/vanished.json"
+  "GJC_COORDINATOR_SESSION_ID=$SESSION"
+  "GJC_COORDINATOR_SESSION_STATE_FILE=$RUNTIME_STATE_JSON"
+  "GJC_COORDINATOR_SESSION_BRANCH=$BRANCH"
   "GJC_SESSION_TURN_EVIDENCE_PATTERN=$TURN_EVIDENCE_PATTERN"
   "GJC_SESSION_GJC_BIN=$GJC_BIN"
   "GJC_SESSION_FLAGS=$GJC_FLAGS"
@@ -264,6 +273,7 @@ if [[ "${GJC_SESSION_MONITOR_DISABLE:-0}" != "1" ]]; then
     "GJC_SESSION_EVENTS_LOG=$STATE_DIR/events.log"
     "GJC_SESSION_FINAL_JSON=$STATE_DIR/final.json"
     "GJC_SESSION_VANISHED_JSON=$STATE_DIR/vanished.json"
+    "GJC_COORDINATOR_SESSION_STATE_FILE=$RUNTIME_STATE_JSON"
     "GJC_SESSION_TMUX_BIN=$TMUX_BIN"
     "GJC_SESSION_MONITOR_INTERVAL=${GJC_SESSION_MONITOR_INTERVAL:-5}"
     "GJC_SESSION_ROUTER_BIN=$ROUTER_BIN"
@@ -318,6 +328,7 @@ echo "  state:   $STATE_DIR"
 echo "  log:     $STATE_DIR/pane.log"
 echo "  events:  $STATE_DIR/events.log"
 echo "  final:   $STATE_DIR/final.json"
+echo "  runtime: $RUNTIME_STATE_JSON"
 echo "  vanish:  $STATE_DIR/vanished.json"
 echo "  tail:    $(dirname "$0")/tail.sh $SESSION"
 echo "  prompt:  $(dirname "$0")/prompt.sh $SESSION @/path/to/prompt.md"

--- a/scripts/gjc-session/create.test.ts
+++ b/scripts/gjc-session/create.test.ts
@@ -57,7 +57,23 @@ describe("gjc-session create", () => {
 		const worktree = await makeGitWorktree(root);
 		const stateDir = path.join(root, "state");
 		const fakeGjc = path.join(root, "bin", "gjc");
-		await makeExecutable(fakeGjc, "#!/usr/bin/env bash\necho 'booted without accepting work'\nexit 0\n");
+		await makeExecutable(
+			fakeGjc,
+			`#!/usr/bin/env bash
+python3 - <<'PY'
+import json
+import os
+with open(os.path.join(os.environ["GJC_SESSION_STATE_DIR"], "env.json"), "w", encoding="utf-8") as handle:
+    json.dump({
+        "sessionId": os.environ.get("GJC_COORDINATOR_SESSION_ID"),
+        "stateFile": os.environ.get("GJC_COORDINATOR_SESSION_STATE_FILE"),
+        "branch": os.environ.get("GJC_COORDINATOR_SESSION_BRANCH"),
+    }, handle)
+PY
+echo 'booted without accepting work'
+exit 0
+`,
+		);
 
 		const result = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree], {
 			env: {
@@ -73,15 +89,30 @@ describe("gjc-session create", () => {
 
 		expect(result.exitCode).toBe(1);
 		expect(result.stderr.toString()).toContain("GJC owner exited before durable turn evidence");
+		expect(result.stderr.toString()).toContain(`durable runtime state: ${path.join(stateDir, "runtime-state.json")}`);
+		const metadata = (await Bun.file(path.join(stateDir, "metadata.json")).json()) as { runtimeState: string };
+		expect(metadata.runtimeState).toBe(path.join(stateDir, "runtime-state.json"));
+		const envDump = (await Bun.file(path.join(stateDir, "env.json")).json()) as {
+			sessionId: string;
+			stateFile: string;
+			branch: string;
+		};
+		expect(envDump).toEqual({
+			sessionId: session,
+			stateFile: path.join(stateDir, "runtime-state.json"),
+			branch: "issue-1385-test",
+		});
 		const finalStatus = (await Bun.file(path.join(stateDir, "final.json")).json()) as {
 			ownerExitReason: string;
 			severity: string;
 			turnEvidencePresent: boolean;
+			runtimeState: string;
 		};
 		expect(finalStatus).toMatchObject({
 			ownerExitReason: "owner_exited_before_turn_evidence",
 			severity: "failure",
 			turnEvidencePresent: false,
+			runtimeState: path.join(stateDir, "runtime-state.json"),
 		});
 	});
 
@@ -119,12 +150,14 @@ describe("gjc-session create", () => {
 			finalPresent: boolean;
 			reason: string;
 			severity: string;
+			runtimeState: string;
 		};
 		expect(vanished).toMatchObject({
 			finalPresent: false,
 			reason: "tmux_session_missing",
 			severity: "failure",
 		});
+		expect(vanished.runtimeState).toBe(path.join(stateDir, "runtime-state.json"));
 		expect(await Bun.file(routerLog).text()).toContain("tmux stale --session");
 	});
 	test("prompt refuses success without durable turn evidence", async () => {


### PR DESCRIPTION
## Summary
- add public-safe runtime sidecar postmortem finalization for tmux-resident GJC sessions
- bridge scripts/gjc-session launches into runtime-state.json and cross-link final/vanished evidence
- document durable recovery artifacts and add focused regression coverage

Fixes #1496

## Verification
- bun test packages/coding-agent/test/session-state-sidecar.test.ts scripts/gjc-session/create.test.ts packages/coding-agent/test/gjc-runtime/tmux-gc.test.ts
- bun --cwd=packages/coding-agent run check
- git diff --check origin/dev...HEAD
- git diff --check