### PR TITLE
fix(tui): keep tree picker selection valid

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Escape now reliably cancels active context maintenance, handoff generation, retry backoff, and workflow ask dialogs even when transient UI focus or typed drafts would previously consume the key.
+- The session tree picker now keeps its selection index valid when it starts on an empty filter mode, receives navigation input, and then switches back to a populated filter.
 - The main composer now uses `PageUp` / `PageDown` to page the visible transcript viewport instead of duplicating prompt-history navigation; `Up` / `Down` and `Ctrl+R` remain the prompt-history paths, and autocomplete lists keep their own page navigation.
 - Shared the duplicated two-column dashboard renderer used by agent and extension dashboards, keeping narrow-width truncation behavior in one tested component.
 - Avoided duplicate line splitting when formatting `ast_grep` matches, reducing allocation in large structural-search result rendering.

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -135,6 +135,14 @@ class TreeList implements Component {
 		return this.#filteredNodes.length - 1;
 	}
 
+	#clampSelectedIndex(): void {
+		if (this.#filteredNodes.length === 0) {
+			this.#selectedIndex = 0;
+			return;
+		}
+		this.#selectedIndex = Math.max(0, Math.min(this.#selectedIndex, this.#filteredNodes.length - 1));
+	}
+
 	#flattenTree(roots: SessionTreeNode[]): FlatNode[] {
 		const result: FlatNode[] = [];
 		this.#toolCallMap.clear();
@@ -333,12 +341,11 @@ class TreeList implements Component {
 			return true;
 		});
 
-		// Try to preserve cursor on the same node, or find nearest visible ancestor
+		// Try to preserve cursor on the same node, or keep the index in range.
 		if (this.#lastSelectedId) {
 			this.#selectedIndex = this.#findNearestVisibleIndex(this.#lastSelectedId);
-		} else if (this.#selectedIndex >= this.#filteredNodes.length) {
-			// Clamp index if out of bounds
-			this.#selectedIndex = Math.max(0, this.#filteredNodes.length - 1);
+		} else {
+			this.#clampSelectedIndex();
 		}
 
 		// Update lastSelectedId to the actual selection (may have changed due to parent walk)
@@ -710,16 +717,29 @@ class TreeList implements Component {
 	}
 
 	handleInput(keyData: string): void {
+		const moveSelection = (delta: number, wrap: boolean): void => {
+			if (this.#filteredNodes.length === 0) return;
+			if (wrap) {
+				const next = this.#selectedIndex + delta;
+				this.#selectedIndex =
+					next < 0 ? this.#filteredNodes.length - 1 : next >= this.#filteredNodes.length ? 0 : next;
+			} else {
+				this.#selectedIndex += delta;
+				this.#clampSelectedIndex();
+			}
+			this.#lastSelectedId = this.#filteredNodes[this.#selectedIndex]?.node.entry.id ?? this.#lastSelectedId;
+		};
+
 		if (matchesKey(keyData, "up")) {
-			this.#selectedIndex = this.#selectedIndex === 0 ? this.#filteredNodes.length - 1 : this.#selectedIndex - 1;
+			moveSelection(-1, true);
 		} else if (matchesKey(keyData, "down")) {
-			this.#selectedIndex = this.#selectedIndex === this.#filteredNodes.length - 1 ? 0 : this.#selectedIndex + 1;
+			moveSelection(1, true);
 		} else if (matchesKey(keyData, "left")) {
 			// Page up
-			this.#selectedIndex = Math.max(0, this.#selectedIndex - this.maxVisibleLines);
+			moveSelection(-this.maxVisibleLines, false);
 		} else if (matchesKey(keyData, "right")) {
 			// Page down
-			this.#selectedIndex = Math.min(this.#filteredNodes.length - 1, this.#selectedIndex + this.maxVisibleLines);
+			moveSelection(this.maxVisibleLines, false);
 		} else if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
 			const selected = this.#filteredNodes[this.#selectedIndex];
 			if (selected && this.onSelect) {

--- a/packages/coding-agent/test/modes/controllers/tree-selector-empty-filter.test.ts
+++ b/packages/coding-agent/test/modes/controllers/tree-selector-empty-filter.test.ts
@@ -1,0 +1,54 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { TreeSelectorComponent } from "../../../src/modes/components/tree-selector";
+import { initTheme } from "../../../src/modes/theme/theme";
+import type { SessionTreeNode } from "../../../src/session/session-manager";
+
+beforeAll(() => {
+	initTheme();
+});
+
+function createNode(id: string, content: string): SessionTreeNode {
+	return {
+		entry: {
+			type: "message",
+			id,
+			parentId: null,
+			timestamp: "2024-01-01T00:00:00Z",
+			message: { role: "user", content } as never,
+		},
+		children: [],
+	};
+}
+
+function renderText(selector: TreeSelectorComponent): string {
+	return Bun.stripANSI(selector.render(100).join("\n"));
+}
+
+describe("TreeSelectorComponent empty-filter navigation", () => {
+	it("keeps selection valid when an empty initial filter is navigated then cleared", () => {
+		const onSelect = vi.fn();
+		const selector = new TreeSelectorComponent(
+			[createNode("entry-a", "Alpha"), createNode("entry-b", "Beta")],
+			"entry-a",
+			40,
+			onSelect,
+			() => {},
+			undefined,
+			"labeled-only",
+		);
+
+		expect(renderText(selector)).toContain("No entries found");
+
+		selector.handleInput("\x1b[A");
+		selector.handleInput("\x1b[5~");
+		selector.handleInput("\x1bd");
+
+		const rendered = renderText(selector);
+		expect(rendered).toContain("› ▸ user: Alpha");
+		expect(rendered).toContain("(1/2)");
+
+		selector.handleInput("\n");
+
+		expect(onSelect).toHaveBeenCalledWith("entry-a");
+	});
+});


### PR DESCRIPTION
## Summary
- keep the session tree picker selection index clamped when it starts on an empty filter mode
- ignore tree navigation while no entries are visible instead of allowing negative/out-of-range selection state
- preserve the selected entry id after successful tree navigation so later filter changes keep the cursor anchored

## Red-team repro
1. Open the session tree with an empty initial filter, e.g. labeled-only with no labels.
2. Press Up/PageUp while no entries are visible.
3. Switch back to a populated filter, e.g. Alt+D.
4. Press Enter.

Before this fix the list rendered `(0/2)` with no selected row and Enter did nothing. After this fix the first restored row is selected and Enter works.

## Copy/paste audit
The tmux prompt copy/paste delivery issue is already fixed on dev: coordinator MCP now uses tmux paste-buffer, dismisses focused autocomplete with Escape, and submits with tmux Enter. The changelog has that under 0.7.11/unreleased and coordinator MCP tests cover the paste-buffer command sequence.

## Verification
- bun test test/modes/controllers/tree-selector-empty-filter.test.ts
- bun test test/modes/controllers/tree-selector-empty-filter.test.ts test/tui-tree-list-collapsed-lines.test.ts
- bun run check
- manual repro probe using labeled-only empty tree filter -> Alt+D -> Enter