### PR TITLE
fix(coding-agent): avoid reopening closed Telegram topics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Escape now reliably cancels active context maintenance, handoff generation, retry backoff, and workflow ask dialogs even when transient UI focus or typed drafts would previously consume the key.
 - The session tree picker now keeps its selection index valid when it starts on an empty filter mode, receives navigation input, and then switches back to a populated filter.
+- The Telegram notification daemon now tombstones a session endpoint generation after `session_closed`, preventing the scan loop from reconnecting to the still-live old endpoint and recreating an empty topic immediately after deleting the original topic.
 - The main composer now uses `PageUp` / `PageDown` to page the visible transcript viewport instead of duplicating prompt-history navigation; `Up` / `Down` and `Ctrl+R` remain the prompt-history paths, and autocomplete lists keep their own page navigation.
 - Shared the duplicated two-column dashboard renderer used by agent and extension dashboards, keeping narrow-width truncation behavior in one tested component.
 - Avoided duplicate line splitting when formatting `ast_grep` matches, reducing allocation in large structural-search result rendering.

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -142,6 +142,9 @@ function splitTelegramPlainText(text: string, max = TELEGRAM_MESSAGE_LIMIT): str
 	if (out) chunks.push(out);
 	return chunks;
 }
+function endpointGenerationKey(url: string, token: string): string {
+	return `${url}\0${token}`;
+}
 
 /**
  * Whether `err` is a transient network failure worth retrying. Telegram API
@@ -772,6 +775,7 @@ export interface TelegramDaemonOptions {
 interface SessionSocket {
 	sessionId: string;
 	token: string;
+	endpointKey: string;
 	ws: WebSocket;
 	pending: Map<string, { sessionId: string; actionId: string }>;
 	/** True once the server advertised the `client_ping_pong` capability. */
@@ -808,6 +812,8 @@ export class TelegramNotificationDaemon {
 	private readonly topicOwnerByIdentity = new Map<string, string>();
 	/** Non-identity frames held until identity creates the correct thread. */
 	private readonly pendingThreadedFrames = new Map<string, PendingThreadedFrame[]>();
+	/** Endpoint generation tombstones for sessions that already sent session_closed. */
+	private readonly closedEndpointKeys = new Map<string, string>();
 	/** True once the daemon has nudged the user to enable Threaded Mode. */
 	private threadedFallbackNoticeSent = false;
 	/** Sessions whose identity header was already sent flat (Threaded Mode off). */
@@ -1223,7 +1229,9 @@ export class TelegramNotificationDaemon {
 				matches: msg => msg.type === "session_closed",
 				handle: async session => {
 					this.busy.delete(session.sessionId);
+					this.closedEndpointKeys.set(session.sessionId, session.endpointKey);
 					await this.deleteTopic(session.sessionId);
+					this.dropSession(session, "session_closed");
 				},
 			});
 	}
@@ -1260,6 +1268,9 @@ export class TelegramNotificationDaemon {
 					// would chase a dead, token-bearing record forever.
 					const pidAlive = this.opts.pidAlive ?? defaultPidAlive;
 					if (endpoint.stale || (endpoint.pid !== undefined && !pidAlive(endpoint.pid))) continue;
+					const endpointKey = endpointGenerationKey(endpoint.url, endpoint.token);
+					if (this.closedEndpointKeys.get(sessionId) === endpointKey) continue;
+					this.closedEndpointKeys.delete(sessionId);
 					this.connectSession(sessionId, endpoint.url, endpoint.token);
 				} catch {}
 			}
@@ -1269,9 +1280,12 @@ export class TelegramNotificationDaemon {
 	connectSession(sessionId: string, url: string, token: string): void {
 		const WS = this.opts.WebSocketImpl ?? WebSocket;
 		const ws = new WS(`${url}/?token=${encodeURIComponent(token)}`);
+		const endpointKey = endpointGenerationKey(url, token);
+		this.closedEndpointKeys.delete(sessionId);
 		const session: SessionSocket = {
 			sessionId,
 			token,
+			endpointKey,
 			ws,
 			pending: new Map(),
 			capable: false,

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -1354,6 +1354,69 @@ test("session_closed deletes the topic and resume creates a fresh visible topic"
 	);
 });
 
+test("session_closed tombstones its endpoint generation so scans do not recreate an empty topic", async () => {
+	FakeWs.instances = [];
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const cwd = path.join(agentDir, "repo");
+	await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
+	const endpointDir = path.join(cwd, ".gjc", "state", "notifications");
+	fs.mkdirSync(endpointDir, { recursive: true });
+	fs.writeFileSync(path.join(endpointDir, "S.json"), JSON.stringify({ url: "ws://live", token: "ts", pid: 4242 }));
+
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+		pidAlive: (pid: number) => pid === 4242,
+	});
+
+	const waitForCreate = async () => {
+		for (let i = 0; i < 20; i++) {
+			const create = bot.calls.find(c => c.method === "createForumTopic");
+			if (create) return create;
+			await new Promise(resolve => setTimeout(resolve, 1));
+		}
+		throw new Error("createForumTopic was not called");
+	};
+
+	const waitForTopicRecord = async () => {
+		const topicsFile = path.join(daemonPaths(agentDir).dir, "telegram-topics.json");
+		for (let i = 0; i < 20; i++) {
+			if (fs.existsSync(topicsFile) && fs.readFileSync(topicsFile, "utf8").includes('"S"')) return;
+			await new Promise(resolve => setTimeout(resolve, 1));
+		}
+		throw new Error("topic registry was not persisted");
+	};
+
+	await daemon.scanRoots();
+	expect(FakeWs.instances).toHaveLength(1);
+	FakeWs.instances[0]!.dispatchEvent(new Event("open"));
+	await waitForCreate();
+	await waitForTopicRecord();
+
+	bot.calls = [];
+	await daemon.handleSessionMessage(daemon.sessions.get("S")!, { type: "session_closed", sessionId: "S" });
+	expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(true);
+	expect(daemon.sessions.has("S")).toBe(false);
+
+	bot.calls = [];
+	await daemon.scanRoots();
+	expect(FakeWs.instances).toHaveLength(1);
+	expect(bot.calls.some(c => c.method === "createForumTopic")).toBe(false);
+
+	fs.writeFileSync(path.join(endpointDir, "S.json"), JSON.stringify({ url: "ws://resumed", token: "ts2", pid: 4242 }));
+	await daemon.scanRoots();
+	expect(FakeWs.instances).toHaveLength(2);
+	FakeWs.instances[1]!.dispatchEvent(new Event("open"));
+	const resumedCreate = await waitForCreate();
+	expect(resumedCreate.body.name).toBe("GJC S");
+});
+
 test("inbound thread message gets a queued reaction, flipped to consumed on ack", async () => {
 	FakeWs.instances = [];
 	const agentDir = tempAgentDir();


### PR DESCRIPTION
## What

- Tombstone the exact Telegram notification endpoint generation after a session emits `session_closed`.
- Skip reconnecting to that same still-live endpoint during daemon root scans, so the daemon does not recreate an empty forum topic after deleting the original one.
- Clear the tombstone when a different endpoint generation appears, preserving legitimate resume/restart behavior.
- Add regression coverage and an Unreleased changelog note.

## Why

A session can close gracefully and ask the managed Telegram daemon to delete its forum topic while the old endpoint file/process is briefly still visible. The scan loop previously saw no active session, reconnected to the old endpoint, and created a fresh empty topic immediately after deletion.

## Testing

- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check CHANGELOG.md src/notifications/telegram-daemon.ts test/notifications-telegram-daemon.test.ts`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)