### PR TITLE
fix(ai): sanitize tool call argument strings

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -28,7 +28,7 @@ import type {
 	ToolChoice,
 	ToolResultMessage,
 } from "../types";
-import { normalizeToolCallId, resolveCacheRetention } from "../utils";
+import { normalizeToolCallId, resolveCacheRetention, sanitizeJsonStrings } from "../utils";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { appendRawHttpRequestDumpFor400, type RawHttpRequestDump, withHttpStatus } from "../utils/http-inspector";
 import { parseStreamingJson } from "../utils/json-parse";
@@ -701,7 +701,7 @@ function convertMessages(
 								toolUse: {
 									toolUseId: normalizeToolCallId(c.id),
 									name: c.name,
-									input: c.arguments,
+									input: sanitizeJsonStrings(c.arguments),
 								},
 							});
 							break;

--- a/packages/ai/src/providers/anthropic-messages-server.ts
+++ b/packages/ai/src/providers/anthropic-messages-server.ts
@@ -13,6 +13,7 @@ import type {
 	ToolResultMessage,
 	UserMessage,
 } from "../types";
+import { sanitizeJsonStrings } from "../utils";
 import {
 	type AnthropicAssistantContentBlock,
 	type AnthropicMessage,
@@ -433,7 +434,7 @@ function encodeContentBlocks(message: AssistantMessage): Record<string, unknown>
 				blocks.push({ type: "redacted_thinking", data: c.data });
 				break;
 			case "toolCall":
-				blocks.push({ type: "tool_use", id: c.id, name: c.name, input: c.arguments ?? {} });
+				blocks.push({ type: "tool_use", id: c.id, name: c.name, input: sanitizeJsonStrings(c.arguments ?? {}) });
 				break;
 		}
 	}

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -53,6 +53,7 @@ import {
 	normalizeSystemPrompts,
 	normalizeToolCallId,
 	resolveCacheRetention,
+	sanitizeJsonStrings,
 } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream } from "../utils/event-stream";
@@ -2491,7 +2492,7 @@ export function convertAnthropicMessages(
 						type: "tool_use",
 						id: block.id,
 						name: isOAuthToken ? applyClaudeToolPrefix(block.name) : block.name,
-						input: block.arguments ?? {},
+						input: sanitizeJsonStrings(block.arguments ?? {}),
 					});
 				}
 			}

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -18,7 +18,7 @@ import type {
 	Tool,
 	ToolCall,
 } from "../types";
-import { normalizeSystemPrompts } from "../utils";
+import { normalizeSystemPrompts, sanitizeJsonStrings } from "../utils";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { finalizeErrorMessage, type RawHttpRequestDump, withHttpStatus } from "../utils/http-inspector";
 import { normalizeSchemaForCCA, normalizeSchemaForGoogle, toolWireSchema } from "../utils/schema";
@@ -237,7 +237,7 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 					const part: Part = {
 						functionCall: {
 							name: block.name,
-							args: block.arguments ?? {},
+							args: sanitizeJsonStrings(block.arguments ?? {}) as Record<string, unknown>,
 							...(requiresToolCallId(model.id) ? { id: block.id } : {}),
 						},
 					};
@@ -467,7 +467,7 @@ export function pushToolCallEvents(
 	stream.push({
 		type: "toolcall_delta",
 		contentIndex,
-		delta: JSON.stringify(toolCall.arguments),
+		delta: JSON.stringify(sanitizeJsonStrings(toolCall.arguments)),
 		partial: output,
 	});
 	stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output });

--- a/packages/ai/src/providers/openai-chat-server.ts
+++ b/packages/ai/src/providers/openai-chat-server.ts
@@ -19,6 +19,7 @@ import type {
 	ToolResultMessage,
 	TSchema,
 } from "../types";
+import { sanitizeJsonStrings } from "../utils";
 import {
 	type OpenAIChatContentPart,
 	type OpenAIChatMessage,
@@ -453,9 +454,9 @@ function isOnlyRaw(args: Record<string, unknown>): boolean {
 
 function stringifyArgs(args: Record<string, unknown>): string {
 	// `__raw` is our fallback marker for un-parseable inbound args; preserve it verbatim on the way out.
-	if (typeof args.__raw === "string" && isOnlyRaw(args)) return args.__raw;
+	if (typeof args.__raw === "string" && isOnlyRaw(args)) return args.__raw.toWellFormed();
 	try {
-		return JSON.stringify(args);
+		return JSON.stringify(sanitizeJsonStrings(args));
 	} catch {
 		return "{}";
 	}

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -1,6 +1,7 @@
 import type { Effort } from "../../model-thinking";
 import { requireSupportedEffort } from "../../model-thinking";
 import type { Api, Model } from "../../types";
+import { sanitizeJsonStrings } from "../../utils";
 
 export interface ReasoningConfig {
 	effort: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
@@ -109,6 +110,10 @@ function normalizeInputTextPartFields(input: InputItem[] | undefined): InputItem
 		}
 		if (normalizedItem.type === "message") {
 			normalizedItem.content = normalizeTextPartFields(normalizedItem.content, `input[${itemIndex}].content`);
+		} else if (normalizedItem.type === "function_call" && "arguments" in itemRecord) {
+			itemRecord.arguments = sanitizeJsonStrings(itemRecord.arguments);
+		} else if (normalizedItem.type === "custom_tool_call" && typeof itemRecord.input === "string") {
+			itemRecord.input = itemRecord.input.toWellFormed();
 		}
 		return normalizedItem;
 	});

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -35,7 +35,7 @@ import {
 	type ToolChoice,
 	type ToolResultMessage,
 } from "../types";
-import { normalizeSystemPrompts } from "../utils";
+import { normalizeSystemPrompts, sanitizeJsonStrings } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { toFirepassWireModelId, toFireworksWireModelId } from "../utils/fireworks-model-id";
@@ -166,7 +166,7 @@ function normalizeStreamingContentText(content: unknown): string {
 function serializeToolArguments(value: unknown): string {
 	if (value && typeof value === "object" && !Array.isArray(value)) {
 		try {
-			return JSON.stringify(value);
+			return JSON.stringify(sanitizeJsonStrings(value));
 		} catch {
 			return "{}";
 		}
@@ -178,7 +178,7 @@ function serializeToolArguments(value: unknown): string {
 		try {
 			const parsed = JSON.parse(trimmed);
 			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-				return JSON.stringify(parsed);
+				return JSON.stringify(sanitizeJsonStrings(parsed));
 			}
 		} catch {}
 		return "{}";

--- a/packages/ai/src/providers/openai-responses-server.ts
+++ b/packages/ai/src/providers/openai-responses-server.ts
@@ -22,6 +22,7 @@ import type {
 	Tool,
 	ToolCall,
 } from "../types";
+import { sanitizeJsonStrings } from "../utils";
 import {
 	type OpenAIResponsesFunctionCallItem,
 	type OpenAIResponsesFunctionCallOutputItem,
@@ -627,7 +628,7 @@ function buildOutputItems(message: AssistantMessage): OutputItem[] {
 					id: part.thoughtSignature ?? makeFuncCallId(),
 					call_id: part.id,
 					name: part.name,
-					arguments: JSON.stringify(part.arguments ?? {}),
+					arguments: JSON.stringify(sanitizeJsonStrings(part.arguments ?? {})),
 					status: "completed",
 				});
 			}
@@ -1085,7 +1086,8 @@ export function encodeStream(
 							} else {
 								// Standard JSON tool: arguments object on the gjc side, the
 								// wire wants the JSON string the model emitted (= streamed deltas).
-								const argsJson = cur.argsText || JSON.stringify(tc.arguments ?? {});
+								const argsJson =
+									cur.argsText.toWellFormed() || JSON.stringify(sanitizeJsonStrings(tc.arguments ?? {}));
 								cur.argsText = argsJson;
 								emit("response.function_call_arguments.done", {
 									item_id: cur.itemId,

--- a/packages/ai/src/providers/openai-responses-server.ts
+++ b/packages/ai/src/providers/openai-responses-server.ts
@@ -613,7 +613,8 @@ function buildOutputItems(message: AssistantMessage): OutputItem[] {
 		} else if (part.type === "toolCall") {
 			flushMessage();
 			if (part.customWireName) {
-				const rawInput = typeof part.arguments?.input === "string" ? (part.arguments.input as string) : "";
+				const rawInput =
+					typeof part.arguments?.input === "string" ? (part.arguments.input as string).toWellFormed() : "";
 				out.push({
 					type: "custom_tool_call",
 					id: part.thoughtSignature ?? makeCustomCallId(),

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -28,7 +28,7 @@ import {
 	type ToolCall,
 	type ToolResultMessage,
 } from "../types";
-import { normalizeResponsesToolCallId } from "../utils";
+import { normalizeResponsesToolCallId, sanitizeJsonStrings } from "../utils";
 import type { AssistantMessageEventStream } from "../utils/event-stream";
 import { isCompleteJson, parseStreamingJson } from "../utils/json-parse";
 import { joinTextWithImagePlaceholder, NON_VISION_IMAGE_PLACEHOLDER, partitionVisionContent } from "./vision-guard";
@@ -275,7 +275,7 @@ export function convertResponsesAssistantMessage<TApi extends Api>(
 		}
 		knownCallIds.add(normalized.callId);
 		if (block.customWireName) {
-			const rawInput = typeof block.arguments?.input === "string" ? block.arguments.input : "";
+			const rawInput = typeof block.arguments?.input === "string" ? block.arguments.input.toWellFormed() : "";
 			customCallIds?.add(normalized.callId);
 			outputItems.push({
 				type: "custom_tool_call",
@@ -291,7 +291,7 @@ export function convertResponsesAssistantMessage<TApi extends Api>(
 			id: itemId,
 			call_id: normalized.callId,
 			name: block.name,
-			arguments: JSON.stringify(block.arguments),
+			arguments: JSON.stringify(sanitizeJsonStrings(block.arguments ?? {})),
 		});
 	}
 

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -11,6 +11,34 @@ export function normalizeSystemPrompts(systemPrompt: readonly string[] | string 
 	return prompts.map(prompt => prompt.toWellFormed()).filter(prompt => prompt.length > 0);
 }
 
+export function sanitizeJsonStrings(value: unknown): unknown {
+	return sanitizeJsonStringsInner(value, new WeakMap<object, unknown>());
+}
+
+function sanitizeJsonStringsInner(value: unknown, seen: WeakMap<object, unknown>): unknown {
+	if (typeof value === "string") return value.toWellFormed();
+	if (!value || typeof value !== "object") return value;
+
+	const cached = seen.get(value);
+	if (cached !== undefined) return cached;
+
+	if (Array.isArray(value)) {
+		const sanitized: unknown[] = [];
+		seen.set(value, sanitized);
+		for (const item of value) {
+			sanitized.push(sanitizeJsonStringsInner(item, seen));
+		}
+		return sanitized;
+	}
+
+	const sanitized: Record<string, unknown> = {};
+	seen.set(value, sanitized);
+	for (const [key, nestedValue] of Object.entries(value)) {
+		sanitized[key.toWellFormed()] = sanitizeJsonStringsInner(nestedValue, seen);
+	}
+	return sanitized;
+}
+
 export function toNumber(value: unknown): number | undefined {
 	if (typeof value === "number" && Number.isFinite(value)) return value;
 	if (typeof value === "string" && value.trim()) {

--- a/packages/ai/test/unicode-surrogate.test.ts
+++ b/packages/ai/test/unicode-surrogate.test.ts
@@ -368,6 +368,26 @@ describe("toolCall argument surrogate sanitization", () => {
 		}
 	});
 
+	it("deep-sanitizes OpenAI Responses custom tool input before response serialization", () => {
+		const llm = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
+		const knownCallIds = new Set<string>();
+		const message = assistantWithSurrogateToolCall(llm);
+		const toolCall = message.content[0];
+		if (toolCall.type !== "toolCall") throw new Error("expected tool call");
+		toolCall.customWireName = "custom_probe";
+		toolCall.arguments = { input: `raw ${loneSurrogate}` };
+
+		const items = convertResponsesAssistantMessage(message, llm, 0, knownCallIds);
+
+		expectNoSerializedLoneSurrogate(items);
+		const customToolCall = items.find(item => item.type === "custom_tool_call");
+		expect(customToolCall?.type).toBe("custom_tool_call");
+		if (customToolCall?.type === "custom_tool_call") {
+			expect(customToolCall.input).toContain("�");
+			expect(customToolCall.input).not.toContain("\\ud92c");
+		}
+	});
+
 	it("deep-sanitizes Google functionCall args before request serialization", () => {
 		const llm = getBundledModel("google", "gemini-2.5-flash") as Model<"google-generative-ai">;
 		const contents = convertGoogleMessages(llm, { messages: [assistantWithSurrogateToolCall(llm)] });

--- a/packages/ai/test/unicode-surrogate.test.ts
+++ b/packages/ai/test/unicode-surrogate.test.ts
@@ -1,12 +1,56 @@
 import { describe, expect, it } from "bun:test";
 import { getBundledModel } from "@gajae-code/ai/models";
+import { convertAnthropicMessages } from "@gajae-code/ai/providers/anthropic";
+import { convertMessages as convertGoogleMessages } from "@gajae-code/ai/providers/google-shared";
+import {
+	convertMessages as convertOpenAICompletionsMessages,
+	detectCompat,
+} from "@gajae-code/ai/providers/openai-completions";
+import { convertResponsesAssistantMessage } from "@gajae-code/ai/providers/openai-responses-shared";
 import { complete } from "@gajae-code/ai/stream";
-import type { Api, Context, Model, OptionsForApi, ToolResultMessage } from "@gajae-code/ai/types";
+import type { Api, AssistantMessage, Context, Model, OptionsForApi, ToolResultMessage } from "@gajae-code/ai/types";
 import * as z from "zod/v4";
 import { e2eApiKey, resolveApiKey } from "./oauth";
 
 // Empty schema for test tools - must be proper OBJECT type for Cloud Code Assist
 const emptySchema = z.object({});
+const loneSurrogate = String.fromCharCode(0xd92c);
+
+function assistantWithSurrogateToolCall(model: Model<Api>): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			{
+				type: "toolCall",
+				id: "test_1",
+				name: "test_tool",
+				arguments: {
+					command: `echo broken ${loneSurrogate}`,
+					nested: { text: `inner ${loneSurrogate}` },
+					list: [`array ${loneSurrogate}`],
+					[`key_${loneSurrogate}`]: "key should also be well-formed",
+				},
+			},
+		],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	};
+}
+
+function expectNoSerializedLoneSurrogate(value: unknown) {
+	expect(JSON.stringify(value)).not.toContain("\\ud92c");
+}
 
 // Resolve OAuth tokens at module level (async, runs before tests)
 const oauthTokens = await Promise.all([
@@ -275,6 +319,65 @@ async function testUnpairedHighSurrogate<TApi extends Api>(llm: Model<TApi>, opt
 	expect(response.errorMessage).toBeFalsy();
 	expect(response.content.length).toBeGreaterThan(0);
 }
+
+describe("toolCall argument surrogate sanitization", () => {
+	it("deep-sanitizes Anthropic tool_use input before request serialization", () => {
+		const llm = getBundledModel("anthropic", "claude-haiku-4-5-20251001") as Model<"anthropic-messages">;
+		const params = convertAnthropicMessages([assistantWithSurrogateToolCall(llm)], llm, false);
+
+		expectNoSerializedLoneSurrogate(params);
+		const content = params[0]?.content;
+		expect(Array.isArray(content)).toBe(true);
+		if (!Array.isArray(content)) return;
+		const toolUse = content[0];
+		expect(toolUse?.type).toBe("tool_use");
+		if (toolUse?.type === "tool_use") {
+			const input = toolUse.input as Record<string, unknown>;
+			expect(input.command).toContain("�");
+			expect(input).toHaveProperty("key_�");
+		}
+	});
+
+	it("deep-sanitizes OpenAI-compatible tool call arguments before JSON stringification", () => {
+		const llm = getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">;
+		const compat = detectCompat(llm);
+		const messages = convertOpenAICompletionsMessages(
+			llm,
+			{ messages: [assistantWithSurrogateToolCall(llm)] },
+			compat,
+		);
+
+		expectNoSerializedLoneSurrogate(messages);
+		const assistantMessage = messages[0] as { tool_calls?: Array<{ function: { arguments: string } }> } | undefined;
+		const toolCalls = assistantMessage?.tool_calls;
+		expect(toolCalls?.[0]?.function.arguments).toContain("�");
+		expect(toolCalls?.[0]?.function.arguments).not.toContain("\\ud92c");
+	});
+
+	it("deep-sanitizes OpenAI Responses function_call arguments before request serialization", () => {
+		const llm = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
+		const knownCallIds = new Set<string>();
+		const items = convertResponsesAssistantMessage(assistantWithSurrogateToolCall(llm), llm, 0, knownCallIds);
+
+		expectNoSerializedLoneSurrogate(items);
+		const functionCall = items.find(item => item.type === "function_call");
+		expect(functionCall?.type).toBe("function_call");
+		if (functionCall?.type === "function_call") {
+			expect(functionCall.arguments).toContain("�");
+			expect(functionCall.arguments).not.toContain("\\ud92c");
+		}
+	});
+
+	it("deep-sanitizes Google functionCall args before request serialization", () => {
+		const llm = getBundledModel("google", "gemini-2.5-flash") as Model<"google-generative-ai">;
+		const contents = convertGoogleMessages(llm, { messages: [assistantWithSurrogateToolCall(llm)] });
+
+		expectNoSerializedLoneSurrogate(contents);
+		const functionCall = contents[0]?.parts?.[0]?.functionCall;
+		expect(functionCall?.args).toHaveProperty("key_�");
+		expect(JSON.stringify(functionCall?.args)).toContain("�");
+	});
+});
 
 describe("AI Providers Unicode Surrogate Pair Tests", () => {
 	describe.skipIf(!e2eApiKey("GEMINI_API_KEY"))("Google Provider Unicode Handling", () => {


### PR DESCRIPTION
Fixes #1498.

## Summary
- Added shared deep string sanitization for JSON-like provider payloads.
- Applied it to tool-call argument serialization/replay paths for Anthropic, Bedrock, Google, OpenAI-compatible chat/completions, OpenAI Responses, auth-gateway response encoders, and OpenAI Codex request replay.
- Added regression coverage for nested lone surrogate strings and object keys in `toolCall.arguments`.

## Verification
- `bun test packages/ai/test/unicode-surrogate.test.ts`
- `bun --cwd=packages/ai run check`
- `git diff --check origin/dev...HEAD`
