### PR TITLE
Support inline skill invocation

### DIFF
--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -326,12 +326,28 @@ interface SkillTokenMatch {
 	skill: Skill;
 }
 
+function buildInlineSkillInvocationArgs(text: string, matches: readonly SkillTokenMatch[]): string {
+	const pieces: string[] = [];
+	let cursor = 0;
+	for (const match of matches) {
+		pieces.push(text.slice(cursor, match.index));
+		cursor = match.end;
+	}
+	pieces.push(text.slice(cursor));
+	return pieces
+		.join("")
+		.replace(/[ \t]{2,}/g, " ")
+		.replace(/[ \t]+\n/g, "\n")
+		.replace(/\n[ \t]+/g, "\n")
+		.trim();
+}
+
 export function parseSkillInvocations(
 	text: string,
 	skillsByCommandName: ReadonlyMap<string, Skill>,
 ): ParsedSkillInvocation[] {
 	const trimmedText = text.trim();
-	if (!trimmedText.startsWith("/")) return [];
+	if (!trimmedText) return [];
 	const canonicalSkillCommandPattern = /(^|\s)\/(skill:[^\s]+)/g;
 	const matches: SkillTokenMatch[] = [];
 	for (const match of trimmedText.matchAll(canonicalSkillCommandPattern)) {
@@ -348,7 +364,19 @@ export function parseSkillInvocations(
 			skill,
 		});
 	}
-	if (matches.length === 0 || matches[0]?.index !== 0) return [];
+	if (matches.length === 0) return [];
+	if (matches[0]?.index !== 0) {
+		// Preserve leading slash-command semantics: `/skill:unknown /skill:alpha`
+		// should remain plain text rather than silently skipping the unknown
+		// leading command and invoking the later known one.
+		if (trimmedText.startsWith("/")) return [];
+		const args = buildInlineSkillInvocationArgs(trimmedText, matches);
+		return matches.map(match => ({
+			commandName: match.commandName,
+			args,
+			skill: match.skill,
+		}));
+	}
 	return matches.map((match, index) => {
 		const next = matches[index + 1];
 		return {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -710,9 +710,6 @@ export class AcpAgent implements Agent {
 		text: string,
 		options: { directAliasMayCollide?: boolean } = {},
 	): Promise<boolean> {
-		if (!text.startsWith("/")) {
-			return false;
-		}
 		if (!record.session.skillsSettings?.enableSkillCommands) {
 			return false;
 		}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -755,9 +755,13 @@ export class AcpAgent implements Agent {
 			}
 			return true;
 		}
-		const spaceIndex = text.indexOf(" ");
-		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
+		const slashText = text.trimStart();
+		if (!slashText.startsWith("/")) {
+			return false;
+		}
+		const spaceIndex = slashText.indexOf(" ");
+		const commandName = spaceIndex === -1 ? slashText.slice(1) : slashText.slice(1, spaceIndex);
+		const args = spaceIndex === -1 ? "" : slashText.slice(spaceIndex + 1).trim();
 		if (
 			!isNamespacedSkillSlashCommandName(commandName) &&
 			options.directAliasMayCollide !== true &&

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -644,19 +644,18 @@ export class InputController {
 
 	/**
 	 * Dispatch skill slash invocation(s) (`/skill:<name>`) through custom messages
-	 * using the supplied `streamingBehavior`. Returns true if the text was a
-	 * recognised skill command chain and was dispatched. A failure to load a skill
-	 * file is surfaced via `showError` but still returns true — the editor was
-	 * already cleared on the success path, so falling through to plain-text
-	 * handling at that point would double-submit. Returns false when the text
-	 * isn't a `/skill:` prefix or the command name isn't a registered skill,
-	 * so the caller can fall through to plain-text handling (this branch
+	 * using the supplied `streamingBehavior`. Returns true if the text contains a
+	 * recognised canonical skill command or command chain and was dispatched. A
+	 * failure to load a skill file is surfaced via `showError` but still returns
+	 * true — the editor was already cleared on the success path, so falling
+	 * through to plain-text handling at that point would double-submit. Returns
+	 * false when the text has no registered canonical skill invocation, so the
+	 * caller can fall through to plain-text handling (this branch
 	 * leaves the editor state untouched). `streamingBehavior` is only consulted
 	 * while the agent is streaming; the idle path of `promptCustomMessage`
 	 * ignores it.
 	 */
 	async #invokeSkillCommand(text: string, streamingBehavior: "steer" | "followUp"): Promise<boolean> {
-		if (!text.startsWith("/")) return false;
 		const invocations = parseSkillInvocations(text, this.ctx.skillCommands ?? new Map());
 		if (invocations.length === 0) return false;
 		this.ctx.editor.addToHistory(text);

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -177,6 +177,9 @@ function getSlashTokenPrefix(textBeforeCursor: string): string | null {
 	return token;
 }
 
+function isLeadingSlashToken(textBeforeCursor: string, slashPrefix: string): boolean {
+	return textBeforeCursor.trimStart() === slashPrefix;
+}
 export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 	#baseProvider: CombinedAutocompleteProvider;
 	#actions: PromptActionDefinition[];
@@ -223,10 +226,14 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 
 		const slashPrefix = getSlashTokenPrefix(textBeforeCursor);
 		if (slashPrefix) {
-			const baseSuggestions = withoutSkillCommandSuggestions(
-				await this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol),
-			);
-			const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor);
+			const isLeading = isLeadingSlashToken(textBeforeCursor, slashPrefix);
+			const baseSuggestions = isLeading
+				? withoutSkillCommandSuggestions(await this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol))
+				: null;
+			const skillCommandSuggestions =
+				isLeading || slashPrefix.startsWith("/skill")
+					? this.#getSkillCommandSuggestions(textBeforeCursor, { includeEmpty: isLeading })
+					: null;
 			return sortSlashCommandSuggestions(
 				mergeAutocompleteSuggestions(baseSuggestions, skillCommandSuggestions),
 				this.#commands,
@@ -300,7 +307,7 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 		const baseSuggestions = withoutSkillCommandSuggestions(
 			this.#baseProvider.trySyncSlashCompletion?.(textBeforeCursor) ?? null,
 		);
-		const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor);
+		const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor, { includeEmpty: false });
 		return sortSlashCommandSuggestions(
 			mergeAutocompleteSuggestions(baseSuggestions, skillCommandSuggestions),
 			this.#commands,
@@ -311,11 +318,14 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 		return tryEmojiInlineReplace(textBeforeCursor);
 	}
 
-	#getSkillCommandSuggestions(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
+	#getSkillCommandSuggestions(
+		textBeforeCursor: string,
+		options: { includeEmpty: boolean },
+	): { items: AutocompleteItem[]; prefix: string } | null {
 		const prefix = getSlashTokenPrefix(textBeforeCursor);
 		if (!prefix) return null;
 		const query = prefix.slice(1).toLowerCase();
-		if (query.length === 0) return null;
+		if (query.length === 0 && !options.includeEmpty) return null;
 		const normalizedQuery = query.startsWith("skill-") ? `skill:${query.slice("skill-".length)}` : query;
 		const exactNonSkillCommand = this.#commands.some(
 			command => command.name === query && !command.name.startsWith("skill:"),

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1177,6 +1177,39 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("executes inline ACP skill commands through custom skill messages", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		const skillDir = path.join(harness.cwdA, ".skills", "sample");
+		const skillPath = path.join(skillDir, "SKILL.md");
+		await fs.promises.mkdir(skillDir, { recursive: true });
+		await fs.promises.writeFile(skillPath, "---\ndescription: Sample skill\n---\n# Sample\nDo work.\n");
+		session.skills = [
+			{
+				name: "sample",
+				description: "Sample skill",
+				filePath: skillPath,
+				baseDir: skillDir,
+				source: "test",
+			},
+		];
+
+		await harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-0000000000a1",
+			prompt: [{ type: "text", text: "please use /skill:sample for this" }],
+		} as PromptRequest);
+
+		expect(session.promptCalls).toEqual([]);
+		expect(session.customMessages).toHaveLength(1);
+		expect(session.customMessages[0]!.content).toContain("# Sample\nDo work.");
+		expect(session.customMessages[0]!.content).toContain("User: please use for this");
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("executes chained ACP skill commands in source order", async () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -290,6 +290,22 @@ describe("InputController #invokeSkillCommand (E1-E3)", () => {
 		expect(messageArg.details.__pendingDisplayTag).toBeUndefined();
 	});
 
+	it("dispatches inline canonical skill commands with surrounding prompt text as args", async () => {
+		const { ctx, editor, promptCustomMessage } = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: false,
+		});
+
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+		editor.setText("please use /skill:test-skill for this plan");
+		await editor.onSubmit?.("please use /skill:test-skill for this plan");
+
+		expect(promptCustomMessage).toHaveBeenCalledTimes(1);
+		expect(promptCustomMessage.mock.calls[0]?.[0].content).toContain("Do the thing.");
+		expect(promptCustomMessage.mock.calls[0]?.[0].content).toContain("User: please use for this plan");
+	});
+
 	it("dispatches chained canonical skill commands in order while idle", async () => {
 		const secondSkillPath = writeSkillFile(tempDir.path(), "second-skill", "Do the second thing.");
 		skillCommands.set("skill:second-skill", {

--- a/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
@@ -50,6 +50,22 @@ describe("prompt action skill autocomplete", () => {
 		expect(applied.lines[0]).toBe("/skill:deep-interview first /skill:deep-interview ");
 	});
 
+	it("does not offer skill completions from a bare slash token after prompt text", async () => {
+		const provider = createProvider();
+		const line = "please use /";
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+		expect(suggestions).toBeNull();
+	});
+
+	it("offers skill completions from an inline /skill token after prompt text", async () => {
+		const provider = createProvider();
+		const line = "please use /skill";
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+		expect(suggestions?.prefix).toBe("/skill");
+		expect(suggestions?.items.map(item => item.value)).toContain("skill:team");
+		expect(suggestions?.items.map(item => item.value)).not.toContain("model");
+	});
+
 	it("does not let direct-name normalization shadow an exact non-skill command", async () => {
 		const provider = createProvider();
 		const suggestions = await provider.getSuggestions(["/fast"], 0, 5);

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -63,8 +63,17 @@ describe("parseSkillInvocations", () => {
 		]);
 	});
 
-	it("requires the prompt to start with a recognized canonical skill command", () => {
-		expect(parseSkillInvocations("normal text /skill:alpha later", skillsByCommandName)).toEqual([]);
+	it("extracts canonical skill invocations from inline prompt text", () => {
+		expect(parseSkillInvocations("normal text /skill:alpha later", skillsByCommandName)).toEqual([
+			{ commandName: "skill:alpha", args: "normal text later", skill: alpha },
+		]);
+		expect(parseSkillInvocations("use /skill:alpha and /skill:beta for this", skillsByCommandName)).toEqual([
+			{ commandName: "skill:alpha", args: "use and for this", skill: alpha },
+			{ commandName: "skill:beta", args: "use and for this", skill: beta },
+		]);
+	});
+
+	it("does not treat aliases or unknown leading skill commands as invocations", () => {
 		expect(parseSkillInvocations("/alpha autocomplete alias is not invocation", skillsByCommandName)).toEqual([]);
 		expect(parseSkillInvocations("/skill:unknown /skill:alpha later", skillsByCommandName)).toEqual([]);
 	});

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1152,7 +1152,7 @@ export class Editor implements Component, Focusable {
 					// Check for stale autocomplete state due to debounce
 					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
 					const currentTextBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-					if (currentTextBeforeCursor !== this.#autocompletePrefix) {
+					if (!currentTextBeforeCursor.endsWith(this.#autocompletePrefix)) {
 						// Autocomplete is stale - cancel and fall through to normal submission
 						this.#cancelAutocomplete();
 					} else {
@@ -1290,8 +1290,8 @@ export class Editor implements Component, Focusable {
 				const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
 				const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
 				if (
-					textBeforeCursor.startsWith("/") &&
-					this.#isInSubmittedSlashCommandContext() &&
+					(this.#isInSubmittedSlashCommandContext() ||
+						this.#getSlashTokenBeforeCursor()?.startsWith("/skill") === true) &&
 					this.#autocompleteProvider?.trySyncSlashCompletion
 				) {
 					const syncResult = this.#autocompleteProvider.trySyncSlashCompletion(textBeforeCursor);
@@ -1728,7 +1728,8 @@ export class Editor implements Component, Focusable {
 
 		// Check if we should trigger or update autocomplete
 		if (!this.#autocompleteState) {
-			// Auto-trigger for "/" at the start of a line (slash commands)
+			// Auto-trigger for "/" at the start of a submitted command.
+			// Inline skill autocomplete starts after the token becomes "/skill...".
 			if (char === "/" && this.#isAtStartOfSubmittedMessage()) {
 				this.#tryTriggerAutocomplete();
 			}
@@ -1750,8 +1751,8 @@ export class Editor implements Component, Focusable {
 			else if (/[a-zA-Z0-9.\-_/]/.test(char)) {
 				const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 				const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-				// Check if we're in a slash command (with or without space for arguments)
-				if (this.#isInSubmittedSlashCommandContext()) {
+				// Check if we're in a slash command or inline slash token
+				if (this.#isInSubmittedSlashCommandContext() || this.#isInSlashTokenContext()) {
 					this.#tryTriggerAutocomplete();
 				}
 				// Check if we're in an @ file reference context
@@ -1946,8 +1947,8 @@ export class Editor implements Component, Focusable {
 			// If autocomplete was cancelled (no matches), re-trigger if we're in a completable context
 			const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 			const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-			// Slash command context
-			if (this.#isInSubmittedSlashCommandContext()) {
+			// Slash command or inline slash token context
+			if (this.#isInSubmittedSlashCommandContext() || this.#isInSlashTokenContext()) {
 				this.#tryTriggerAutocomplete();
 			}
 			// @ file reference context
@@ -2103,7 +2104,7 @@ export class Editor implements Component, Focusable {
 		} else {
 			const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 			const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-			if (this.#isInSubmittedSlashCommandContext()) {
+			if (this.#isInSubmittedSlashCommandContext() || this.#isInSlashTokenContext()) {
 				this.#tryTriggerAutocomplete();
 			} else if (textBeforeCursor.match(/(?:^|[\s])@[^\s]*$/)) {
 				this.#tryTriggerAutocomplete();
@@ -2417,8 +2418,8 @@ export class Editor implements Component, Focusable {
 		} else {
 			const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 			const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-			// Slash command context
-			if (this.#isInSubmittedSlashCommandContext()) {
+			// Slash command or inline slash token context
+			if (this.#isInSubmittedSlashCommandContext() || this.#isInSlashTokenContext()) {
 				this.#tryTriggerAutocomplete();
 			}
 			// @ file reference context
@@ -2645,6 +2646,17 @@ export class Editor implements Component, Focusable {
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
 		return this.#hasOnlyWhitespaceBeforeCursorLine() && beforeCursor.trimStart().startsWith("/");
+	}
+
+	#getSlashTokenBeforeCursor(): string | null {
+		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
+		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
+		const match = beforeCursor.match(/(?:^|\s)(\/[^\s]*)$/);
+		return match?.[1] ?? null;
+	}
+
+	#isInSlashTokenContext(): boolean {
+		return this.#getSlashTokenBeforeCursor()?.startsWith("/skill") === true;
 	}
 
 	#isSlashCommandNameAutocompleteSelection(): boolean {

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -102,8 +102,50 @@ class SyncSlashProvider implements AutocompleteProvider {
 	callCount = 0;
 }
 
+class InlineSkillProvider implements AutocompleteProvider {
+	async getSuggestions(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
+		this.suggestionCalls += 1;
+		const line = lines[cursorLine] || "";
+		const textBeforeCursor = line.slice(0, cursorCol);
+		const match = textBeforeCursor.match(/(?:^|\s)(\/[^\s]*)$/);
+		const prefix = match?.[1];
+		if (!prefix) return null;
+		if (prefix !== "/" && !"/skill:team".startsWith(prefix) && !"/skill-team".startsWith(prefix)) {
+			return null;
+		}
+		return {
+			prefix,
+			items: [{ value: "skill:team", label: "skill:team" }],
+		};
+	}
+
+	applyCompletion(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+		item: AutocompleteItem,
+		prefix: string,
+	): { lines: string[]; cursorLine: number; cursorCol: number; onApplied?: () => void } {
+		const line = lines[cursorLine] || "";
+		const beforePrefix = line.slice(0, cursorCol - prefix.length);
+		const afterCursor = line.slice(cursorCol);
+		const nextLines = [...lines];
+		nextLines[cursorLine] = `${beforePrefix}/${item.value} ${afterCursor}`;
+		return {
+			lines: nextLines,
+			cursorLine,
+			cursorCol: beforePrefix.length + item.value.length + 2,
+		};
+	}
+
+	suggestionCalls = 0;
+}
 describe("Editor Enter handler sync slash completion", () => {
-	it("does not trigger slash autocomplete after prior prompt text", async () => {
+	it("does not auto-trigger slash autocomplete from a bare slash after prior prompt text", async () => {
 		let suggestionCalls = 0;
 		const editor = new Editor(defaultEditorTheme);
 		editor.setAutocompleteProvider({
@@ -123,6 +165,34 @@ describe("Editor Enter handler sync slash completion", () => {
 
 		expect(suggestionCalls).toBe(0);
 		expect(editor.isShowingAutocomplete()).toBe(false);
+	});
+
+	it("auto-triggers inline slash skill autocomplete after prompt text", async () => {
+		const provider = new InlineSkillProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+
+		editor.handleInput("explain with /skill-te");
+		await Bun.sleep(0);
+
+		expect(provider.suggestionCalls).toBeGreaterThan(0);
+		expect(editor.isShowingAutocomplete()).toBe(true);
+	});
+
+	it("applies inline slash skill completion before submitting", async () => {
+		const provider = new InlineSkillProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.handleInput("explain with /skill-te");
+		await Bun.sleep(0);
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("explain with /skill:team");
 	});
 
 	it("completes slash command synchronously before async resolves and submits", () => {


### PR DESCRIPTION
## Summary
- parse canonical `/skill:<name>` invocations from inline prompt text, preserving leading slash-command fallback semantics
- allow interactive and ACP skill dispatch without requiring the prompt to start with `/`
- keep ACP direct-alias fallback slash-only after canonical inline skill parsing, so plain prompts do not run slash-command discovery before `record.session.prompt()`
- update prompt-action/TUI autocomplete so inline `/skill...` tokens offer skill completions and Enter can apply `/skill...` before submit
- keep bare inline `/` literal-friendly: it does not open skill autocomplete until the token becomes `/skill...`

## Tests
- `bun test packages/coding-agent/test/acp-agent.test.ts`
- `bun test packages/coding-agent/test/acp-agent.test.ts packages/coding-agent/test/skills.test.ts packages/coding-agent/test/input-controller-skill-queue.test.ts packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts packages/tui/test/editor-autocomplete-actions.test.ts`
- `bun check`

## Notes
- Multiple inline skills receive the same surrounding prompt args with recognized skill tokens stripped.