### PR TITLE
fix(bash): make Ctrl+B-twice fold foreground bash without auto-background

### DIFF
--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -833,9 +833,22 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			});
 		}
 
+		// Route through the client terminal when the client advertises the terminal capability.
+		// Skip when pty=true (PTY needs the local terminal UI).
+		const clientBridge =
+			this.session.bashRestrictionProfile === "read-only" ? undefined : this.session.getClientBridge?.();
+		const clientTerminalActive = Boolean(clientBridge?.capabilities.terminal && clientBridge.createTerminal && !pty);
+
 		const autoBgManager = AsyncJobManager.instance();
-		if (this.#autoBackgroundEnabled && !pty && autoBgManager) {
-			const autoBackgroundWaitMs = this.#resolveAutoBackgroundWaitMs(timeoutMs);
+		// Run non-PTY bash through the managed job path so Ctrl+B-twice fold-on-demand works
+		// even when auto-background is disabled. When a client terminal will handle the
+		// command, keep the existing bridge path unless auto-background is enabled.
+		if (!pty && autoBgManager && (this.#autoBackgroundEnabled || !clientTerminalActive)) {
+			// With auto-background off, wait past the command's own timeout so the job only
+			// leaves the foreground on an explicit Ctrl+B fold, never on an auto-background timer.
+			const autoBackgroundWaitMs = this.#autoBackgroundEnabled
+				? this.#resolveAutoBackgroundWaitMs(timeoutMs)
+				: timeoutMs + 1_000;
 			const startBackgrounded = autoBackgroundWaitMs === 0;
 			const job = this.#startManagedBashJob({
 				command,
@@ -891,10 +904,6 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			});
 		}
 
-		// Route through the client terminal when the client advertises the terminal capability.
-		// Skip when pty=true (PTY needs the local terminal UI).
-		const clientBridge =
-			this.session.bashRestrictionProfile === "read-only" ? undefined : this.session.getClientBridge?.();
 		if (clientBridge?.capabilities.terminal && clientBridge.createTerminal && !pty) {
 			const handle = await clientBridge.createTerminal({
 				command,

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -1258,6 +1258,66 @@ function b() {
 			await asyncJobManager.dispose();
 		});
 
+		it("should fold a managed foreground command even when auto-background is disabled", async () => {
+			const deliveries: Array<{ jobId: string; text: string }> = [];
+			const asyncJobManager = new AsyncJobManager({
+				onJobComplete: async (jobId, text) => {
+					deliveries.push({ jobId, text });
+				},
+			});
+			AsyncJobManager.setInstance(asyncJobManager);
+			let backgroundRequestHandler: (() => void) | undefined;
+			const foregroundBashTool = wrapToolWithMetaNotice(
+				new BashTool(
+					createTestToolSession(
+						testDir,
+						Settings.isolated({
+							"bash.autoBackground.enabled": false,
+						}),
+						{
+							getSessionId: () => "test-session",
+							registerForegroundBashBackgroundRequestHandler: handler => {
+								backgroundRequestHandler = handler;
+								return () => {
+									if (backgroundRequestHandler === handler) backgroundRequestHandler = undefined;
+								};
+							},
+						},
+					),
+				),
+			);
+
+			const resultPromise = foregroundBashTool.execute(
+				"test-call-9-fold-foreground-noauto",
+				{
+					command: "printf 'start\\n'; sleep 0.05; printf 'after-fold\\n'; sleep 0.2; printf 'done\\n'",
+				},
+				undefined,
+			);
+
+			for (let i = 0; i < 50 && !backgroundRequestHandler; i++) {
+				await Bun.sleep(10);
+			}
+			expect(backgroundRequestHandler).toBeDefined();
+			backgroundRequestHandler?.();
+
+			const result = await resultPromise;
+			expect(result.details?.async?.state).toBe("running");
+			expect(getTextOutput(result)).toContain("Background job");
+
+			const jobId = result.details?.async?.jobId;
+			if (!jobId) {
+				throw new Error("expected a folded background job id");
+			}
+			const runningJob = asyncJobManager.getJob(jobId);
+			await runningJob?.promise;
+			await asyncJobManager.drainDeliveries({ timeoutMs: 1 });
+			expect(deliveries).toHaveLength(1);
+			expect(deliveries[0]?.jobId).toBe(jobId);
+			expect(deliveries[0]?.text).toContain("done");
+			await asyncJobManager.dispose();
+		});
+
 		it("should background instead of timing out when auto-background wait exceeds the effective timeout", async () => {
 			const deliveries: Array<{ jobId: string; text: string }> = [];
 			const asyncJobManager = new AsyncJobManager({


### PR DESCRIPTION
## Problem
Pressing **Ctrl+B twice** on a running foreground bash did nothing (no status hint, no reaction) with default settings.

## Root cause
The foreground-bash fold handler is registered at `packages/coding-agent/src/tools/bash.ts` **inside** the block gated by `if (this.#autoBackgroundEnabled && !pty && autoBgManager)`. `bash.autoBackground.enabled` defaults to `false`, so `registerForegroundBashBackgroundRequestHandler` was never called, `hasForegroundBashBackgroundRequestHandler()` stayed `false`, and the first Ctrl+B press hit the early `return false` in the input controller.

## Fix
- Route non-PTY managed bash through the managed-job path whenever an `AsyncJobManager` exists, so the fold handler is always registered (decoupled from the auto-background setting).
- When auto-background is disabled, wait past the command's own timeout so the job only leaves the foreground on an explicit Ctrl+B fold — never on an auto-background timer.
- Preserve the client-terminal bridge path for remote clients where local Ctrl+B does not apply.
- Add a regression test covering the fold path with auto-background disabled.

## Verification
- `bun test packages/coding-agent/test/tools.test.ts` → 91 pass / 0 fail
- Adjacent suites (bash-executor, bash-resource-lifecycle, async-job-manager, agent-session-bash-detach) → 57 pass / 0 fail
- `bunx tsc --noEmit -p packages/coding-agent/tsconfig.json` → clean
- `bunx biome check` on changed files → clean