### PR TITLE
fix(tui): avoid nested contribute-pr worker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - The main composer now uses `PageUp` / `PageDown` to page the visible transcript viewport instead of duplicating prompt-history navigation; `Up` / `Down` and `Ctrl+R` remain the prompt-history paths, and autocomplete lists keep their own page navigation.
 - Shared the duplicated two-column dashboard renderer used by agent and extension dashboards, keeping narrow-width truncation behavior in one tested component.
 - Avoided duplicate line splitting when formatting `ast_grep` matches, reducing allocation in large structural-search result rendering.
+- `/contribute-pr` in the interactive TUI now prepares the redacted manifest and worker prompt without spawning a second GJC process on the same terminal, avoiding competing TUI renderers that make the chat viewport jump around. Run the generated worker prompt from a separate terminal instead.
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1276,17 +1276,18 @@ export class CommandController {
 	async handleContributionPrepCommand(customInstructions?: string): Promise<void> {
 		this.ctx.editor.setText("");
 		try {
-			const result = await this.ctx.session.prepareContributionPrep({ customInstructions, spawnWorker: true });
+			const result = await this.ctx.session.prepareContributionPrep({ customInstructions, spawnWorker: false });
 			this.ctx.showStatus(
 				[
 					"Contribution prep artifacts written.",
 					`Manifest: ${result.manifestPath}`,
 					`Worker prompt: ${result.workerPromptPath}`,
+					"Open the worker prompt from a separate terminal to keep this TUI session stable.",
 				].join("\n"),
 			);
 			this.ctx.chatContainer.addChild(
 				new Text(
-					`${theme.fg("accent", `${theme.status.success} Contribution prep ready`)}\nManifest: ${result.manifestPath}`,
+					`${theme.fg("accent", `${theme.status.success} Contribution prep ready`)}\nWorker prompt: ${result.workerPromptPath}`,
 					1,
 					1,
 				),

--- a/packages/coding-agent/test/modes/controllers/handoff-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/handoff-command.test.ts
@@ -77,7 +77,7 @@ describe("/handoff command", () => {
 		expect(ctx.session.handoff).toHaveBeenCalledWith("focus on tests");
 	});
 
-	it("runs contribution-prep without rebuilding or switching the active chat", async () => {
+	it("prepares contribution-pr artifacts without spawning a competing TUI worker", async () => {
 		const statusContainer = createContainer();
 		const chatContainer = createContainer();
 		const requestRender = vi.fn();
@@ -89,7 +89,7 @@ describe("/handoff command", () => {
 					workerPromptPath: "/tmp/prep/worker-prompt.md",
 					artifactDir: "/tmp/prep",
 					changedFiles: [],
-					spawned: true,
+					spawned: false,
 				})),
 			},
 			statusContainer,
@@ -107,11 +107,12 @@ describe("/handoff command", () => {
 
 		expect(ctx.session.prepareContributionPrep).toHaveBeenCalledWith({
 			customInstructions: "focus on repro",
-			spawnWorker: true,
+			spawnWorker: false,
 		});
 		expect(ctx.rebuildChatFromMessages).not.toHaveBeenCalled();
 		expect(ctx.statusLine.invalidate).not.toHaveBeenCalled();
 		expect(ctx.showStatus).toHaveBeenCalledWith(expect.stringContaining("Manifest: /tmp/prep/manifest.json"));
+		expect(ctx.showStatus).toHaveBeenCalledWith(expect.stringContaining("separate terminal"));
 		expect(chatContainer.children).toHaveLength(1);
 		expect(requestRender).toHaveBeenCalled();
 	});


### PR DESCRIPTION
## Summary
- stop the interactive `/contribute-pr` command from spawning a second GJC process on the same terminal
- keep artifact/worker-prompt generation and surface the prompt path with guidance to open it from a separate terminal
- update the controller regression test so the TUI path passes `spawnWorker: false`

## Verification
- `bun test test/modes/controllers/handoff-command.test.ts test/contribution-prep.test.ts`
- `bun run check`