### PR TITLE
fix(tui): harden MCP wizard and paste buffering

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -28,6 +28,10 @@
 - The main composer now uses `PageUp` / `PageDown` to page the visible transcript viewport instead of duplicating prompt-history navigation; `Up` / `Down` and `Ctrl+R` remain the prompt-history paths, and autocomplete lists keep their own page navigation.
 - Shared the duplicated two-column dashboard renderer used by agent and extension dashboards, keeping narrow-width truncation behavior in one tested component.
 - Avoided duplicate line splitting when formatting `ast_grep` matches, reducing allocation in large structural-search result rendering.
+- `/contribute-pr` in the interactive TUI now prepares the redacted manifest and worker prompt without spawning a second GJC process on the same terminal, avoiding competing TUI renderers that make the chat viewport jump around. Run the generated worker prompt from a separate terminal instead.
+- The interactive MCP add wizard now returns from no-auth scope selection to the URL/args step on Escape instead of jumping into the unrelated HTTP header-name prompt.
+
+### Fixed
 
 - Tab now queues prompt drafts immediately while the agent is streaming or compacting instead of opening/applying forced file autocomplete first.
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -241,6 +241,9 @@ export class CustomEditor extends Editor {
 		if (this.onPasteText) {
 			const paste = this.#pasteHandler.process(data);
 			if (paste.handled) {
+				if (paste.normalText) {
+					this.handleInput(paste.normalText);
+				}
 				if (paste.pasteContent !== undefined) {
 					this.#handleBracketedPaste(paste.pasteContent, paste.remaining);
 				}

--- a/packages/coding-agent/src/modes/components/runtime-mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/runtime-mcp-add-wizard.ts
@@ -817,8 +817,16 @@ export class MCPAddWizard extends Container {
 				}
 				break;
 			case "scope":
-				// Go back to last authentication step
-				if (this.#state.authMethod === "oauth") {
+				// Go back to the last configuration step. No-auth flows come straight
+				// from the transport connection step; manual/OAuth flows come from
+				// their respective auth detail steps.
+				if (this.#state.authMethod === "none") {
+					if (this.#state.transport === "stdio") {
+						this.#currentStep = "args";
+					} else {
+						this.#currentStep = "url";
+					}
+				} else if (this.#state.authMethod === "oauth") {
 					this.#currentStep = "oauth-scopes";
 				} else {
 					// manual - go back to env var name or header name

--- a/packages/coding-agent/test/runtime-mcp-add-wizard.test.ts
+++ b/packages/coding-agent/test/runtime-mcp-add-wizard.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { MCPAddWizard } from "../src/modes/components/runtime-mcp-add-wizard";
+
+function visibleText(component: { render(width: number): string[] }): string {
+	return Bun.stripANSI(component.render(160).join("\n"));
+}
+
+function typeText(component: { handleInput(input: string): void }, text: string): void {
+	for (const char of text) component.handleInput(char);
+}
+
+async function flushAsync(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("MCP add wizard", () => {
+	beforeEach(async () => {
+		vi.useFakeTimers();
+		await initTheme(false);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("returns from no-auth scope selection to the transport connection step", async () => {
+		const wizard = new MCPAddWizard(
+			() => undefined,
+			() => undefined,
+			undefined,
+			async () => undefined,
+			undefined,
+			"example-server",
+		);
+
+		wizard.handleInput("\x1b[B"); // http transport
+		wizard.handleInput("\n");
+		expect(visibleText(wizard)).toContain("Step 3: Server URL");
+
+		typeText(wizard, "https://example.test/mcp");
+		wizard.handleInput("\n");
+		await flushAsync();
+		vi.advanceTimersByTime(1_000);
+		await flushAsync();
+		expect(visibleText(wizard)).toContain("Step: Configuration Scope");
+
+		wizard.handleInput("\x1b");
+		const afterBack = visibleText(wizard);
+		expect(afterBack).toContain("Step 3: Server URL");
+		expect(afterBack).not.toContain("Step: HTTP Header Name");
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added manual transcript viewport paging support so applications can repaint older terminal output with PageUp/PageDown without reusing editor history navigation.
 
 - Empty select/settings lists now still honor cancel while preserving populated-list keybinding precedence, and settings lists keep selection indices clamped when items disappear or submenus close after list shrinkage.
+- Bracketed paste handling now buffers a start marker split across input chunks instead of leaking raw `\x1b[200~` fragments into editors/search fields.
 
 - Fixed Windows Hangul/CJK IME composition breaking the queue-message shortcut (Alt+Enter/Alt+Q): the app no longer enables the xterm `modifyOtherKeys` fallback on win32, where Windows Terminal/conhost do not support the Kitty keyboard protocol anyway. `modifyOtherKeys` made modified-key chords bypass the IME commit, so a syllable still being composed was dropped and the queue action fired on empty text unless the user typed a trailing space first. Legacy encodings still deliver Alt+Enter and the newline chords; opt back into the enhancement with `GJC_TUI_KEYBOARD_PROTOCOL`.
 

--- a/packages/tui/src/bracketed-paste.ts
+++ b/packages/tui/src/bracketed-paste.ts
@@ -1,7 +1,16 @@
 const PASTE_START = "\x1b[200~";
 const PASTE_END = "\x1b[201~";
 
-export type PasteResult = { handled: false } | { handled: true; pasteContent?: string; remaining: string };
+type HandledPasteResult = { handled: true; normalText?: string; pasteContent?: string; remaining: string };
+export type PasteResult = { handled: false } | HandledPasteResult;
+
+function trailingPasteStartPrefixLength(value: string): number {
+	const maxLength = Math.min(PASTE_START.length - 1, value.length);
+	for (let length = maxLength; length >= 2; length--) {
+		if (PASTE_START.startsWith(value.slice(-length))) return length;
+	}
+	return 0;
+}
 
 /**
  * Handles bracketed paste mode buffering for terminal input components.
@@ -13,6 +22,7 @@ export type PasteResult = { handled: false } | { handled: true; pasteContent?: s
 export class BracketedPasteHandler {
 	#buffer = "";
 	#active = false;
+	#pendingStart = "";
 
 	/**
 	 * Process incoming terminal data for bracketed paste sequences.
@@ -23,14 +33,41 @@ export class BracketedPasteHandler {
 	 *          paste has been assembled; omitted when still buffering.
 	 */
 	process(data: string): PasteResult {
-		if (data.includes(PASTE_START)) {
-			this.#active = true;
-			this.#buffer = "";
-			data = data.replace(PASTE_START, "");
+		if (this.#active) {
+			return this.#consumeActivePaste(data);
 		}
 
-		if (!this.#active) return { handled: false };
+		const hadPendingStart = this.#pendingStart.length > 0;
+		const input = `${this.#pendingStart}${data}`;
+		this.#pendingStart = "";
 
+		const startIndex = input.indexOf(PASTE_START);
+		if (startIndex !== -1) {
+			this.#active = true;
+			this.#buffer = "";
+			const normalText = input.slice(0, startIndex);
+			const paste = this.#consumeActivePaste(input.slice(startIndex + PASTE_START.length));
+			if (normalText.length > 0) {
+				return { ...paste, normalText };
+			}
+			return paste;
+		}
+
+		const pendingLength = trailingPasteStartPrefixLength(input);
+		if (pendingLength > 0) {
+			this.#pendingStart = input.slice(-pendingLength);
+			const normalText = input.slice(0, -pendingLength);
+			return normalText.length > 0 ? { handled: true, normalText, remaining: "" } : { handled: true, remaining: "" };
+		}
+
+		if (hadPendingStart) {
+			return { handled: true, normalText: input, remaining: "" };
+		}
+
+		return { handled: false };
+	}
+
+	#consumeActivePaste(data: string): HandledPasteResult {
 		this.#buffer += data;
 
 		const endIndex = this.#buffer.indexOf(PASTE_END);

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1057,6 +1057,9 @@ export class Editor implements Component, Focusable {
 		// Handle bracketed paste mode
 		const paste = this.#pasteHandler.process(data);
 		if (paste.handled) {
+			if (paste.normalText) {
+				this.handleInput(paste.normalText);
+			}
 			if (paste.pasteContent !== undefined) {
 				this.#handlePaste(paste.pasteContent);
 				if (paste.remaining.length > 0) {

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -66,6 +66,9 @@ export class Input implements Component, Focusable {
 		// Handle bracketed paste mode
 		const paste = this.#pasteHandler.process(data);
 		if (paste.handled) {
+			if (paste.normalText) {
+				this.handleInput(paste.normalText);
+			}
 			if (paste.pasteContent !== undefined) {
 				this.#handlePaste(paste.pasteContent);
 				if (paste.remaining.length > 0) {

--- a/packages/tui/test/bracketed-paste.test.ts
+++ b/packages/tui/test/bracketed-paste.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { BracketedPasteHandler } from "../src/bracketed-paste";
+
+describe("BracketedPasteHandler", () => {
+	it("assembles a paste when the start marker arrives in one chunk", () => {
+		const handler = new BracketedPasteHandler();
+
+		expect(handler.process("\x1b[200~hello\x1b[201~")).toEqual({
+			handled: true,
+			pasteContent: "hello",
+			remaining: "",
+		});
+	});
+	it("does not treat a standalone Escape key as a pending paste", () => {
+		const handler = new BracketedPasteHandler();
+
+		expect(handler.process("\x1b")).toEqual({ handled: false });
+	});
+
+	it("buffers a split start marker before collecting paste content", () => {
+		const handler = new BracketedPasteHandler();
+
+		expect(handler.process("\x1b[200")).toEqual({ handled: true, remaining: "" });
+		expect(handler.process("~hello\x1b[201~")).toEqual({
+			handled: true,
+			pasteContent: "hello",
+			remaining: "",
+		});
+	});
+
+	it("keeps normal text before a split start marker replayable", () => {
+		const handler = new BracketedPasteHandler();
+
+		expect(handler.process("prefix\x1b[200")).toEqual({
+			handled: true,
+			normalText: "prefix",
+			remaining: "",
+		});
+		expect(handler.process("~payload\x1b[201~suffix")).toEqual({
+			handled: true,
+			pasteContent: "payload",
+			remaining: "suffix",
+		});
+	});
+
+	it("keeps split end marker buffering intact", () => {
+		const handler = new BracketedPasteHandler();
+
+		expect(handler.process("\x1b[200~hello\x1b[201")).toEqual({ handled: true, remaining: "" });
+		expect(handler.process("~tail")).toEqual({
+			handled: true,
+			pasteContent: "hello",
+			remaining: "tail",
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- fix the MCP add wizard no-auth back path so Escape from scope returns to URL/args instead of the unrelated header-name prompt
- buffer split bracketed-paste start markers and replay normal text before the paste, preventing raw `\x1b[200~` fragments from entering editors/search fields
- cover both regressions with focused component/unit tests

## Verification
- `bun test test/runtime-mcp-add-wizard.test.ts test/custom-editor-keybindings.test.ts --test-name-pattern 'MCP add wizard|paste'`\n- `bun run check` in `packages/coding-agent`\n- `bun test test/bracketed-paste.test.ts test/input.test.ts test/editor.test.ts --test-name-pattern paste`\n- `bun run check` in `packages/tui`