### PR TITLE
Make skill tool default-registered instead of discoverable

### DIFF
--- a/packages/coding-agent/src/tools/skill.ts
+++ b/packages/coding-agent/src/tools/skill.ts
@@ -50,7 +50,7 @@ export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails
 	readonly name = "skill";
 	readonly label = "Skill";
 	readonly summary = "Chain into another available skill in the current turn";
-	readonly loadMode = "discoverable";
+	readonly loadMode = "essential";
 	readonly description: string;
 	readonly parameters = skillSchema;
 	readonly strict = true;


### PR DESCRIPTION
## Summary
- The `skill` tool was `loadMode = "discoverable"`, so the model had to run `search_tool_bm25` to activate it before chaining into another workflow skill.
- Since skill-chaining is core to GJC's workflow surface, this changes it to `"essential"` (`skill.ts:53`), matching how `goal-tool.ts` self-declares essential.
- The sdk retention logic (`sdk.ts:1912`) keeps any tool with `loadMode === "essential"` resident, so `skill` is now registered by default instead of hidden behind tool discovery.

## Testing
- `bun run check:types` passes.