### PR TITLE
fix(utils): 겹치는 glob 패턴에서 globPaths 결과 경로 중복 제거

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Deduplicated `globPaths` results so a path is returned at most once even when overlapping glob patterns (e.g. `["**/*.ts", "src/*.ts"]`) both match the same file.
+
 ## [0.5.2] - 2026-06-15
 
 ### Fixed

--- a/packages/utils/src/glob.ts
+++ b/packages/utils/src/glob.ts
@@ -149,6 +149,9 @@ export async function globPaths(patterns: string | string[], options: GlobPathsO
 
 	const base = cwd ?? getProjectDir();
 	const allResults: string[] = [];
+	// Overlapping patterns (e.g. `["**/*.ts", "src/*.ts"]`) can both match the same
+	// file; dedupe so a path is returned at most once regardless of pattern overlap.
+	const seen = new Set<string>();
 
 	// Combine timeout and abort signals
 	const timeoutSignal = timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined;
@@ -176,6 +179,10 @@ export async function globPaths(patterns: string | string[], options: GlobPathsO
 			if (excludeGlobs.some(excludeGlob => excludeGlob.match(normalized))) {
 				continue;
 			}
+			if (seen.has(normalized)) {
+				continue;
+			}
+			seen.add(normalized);
 			allResults.push(normalized);
 		}
 	}

--- a/packages/utils/test/glob.test.ts
+++ b/packages/utils/test/glob.test.ts
@@ -43,4 +43,15 @@ describe("globPaths", () => {
 
 		expect(results.sort()).toEqual(["src/keep.ts"]);
 	});
+	it("returns each path once when patterns overlap", async () => {
+		const cwd = await makeTempDir();
+		await mkdir(join(cwd, "src"), { recursive: true });
+		await writeFile(join(cwd, "src", "a.ts"), "export {};\n");
+		await writeFile(join(cwd, "src", "b.ts"), "export {};\n");
+
+		const results = await globPaths(["**/*.ts", "src/*.ts"], { cwd });
+
+		expect(results.sort()).toEqual(["src/a.ts", "src/b.ts"]);
+		expect(results.length).toBe(new Set(results).size);
+	});
 });


### PR DESCRIPTION
`globPaths`가 겹치는 glob 패턴을 받으면 같은 파일 경로를 여러 번 반환하던 문제를 고칩니다. `globPaths(["**/*.ts", "src/*.ts"])`가 `["src/a.ts", "src/a.ts"]`처럼 중복을 내보냈습니다. 매칭된 경로를 `Set`으로 추적해 이미 본 경로는 건너뛰어 각 경로가 한 번만 반환되게 하고, 기존 정렬 순서와 exclude/gitignore 동작은 그대로 유지합니다.

경로 목록 API가 중복을 반환하는 건 계약 위반이고, 유일성을 가정하는 소비자에서 결과 개수를 부풀리거나 불필요한 작업을 유발합니다.

### 변경
- `globPaths` 스캔 루프에 `seen` Set 추가 → 이미 본 경로는 스킵
- 기존 정렬 순서와 exclude/gitignore 동작 보존
- `packages/utils/CHANGELOG.md` (Unreleased → Fixed) 항목 추가

### 테스트
- `test/glob.test.ts` — 겹치는 패턴에서 각 경로가 1회만 반환되는 회귀 추가 (수정 전엔 `src/a.ts` 중복으로 실패, 수정 후 통과 확인)
- `bun test packages/utils/test/glob.test.ts` 3/3 pass, 변경 파일 biome 통과