### PR TITLE
Fix goal completion hook crash

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Goal completion now preserves the terminal `goal({op: "complete"})` state even when a `goal_updated` extension hook throws, preventing hook-side write errors from trapping a verified ultragoal run in the continuation loop.
 - The Telegram notification daemon now tombstones a session endpoint generation after `session_closed`, preventing the scan loop from reconnecting to the still-live old endpoint and recreating an empty topic immediately after deleting the original topic.
 - `/contribute-pr` in the interactive TUI now prepares the redacted manifest and worker prompt without spawning a second GJC process on the same terminal, avoiding competing TUI renderers that make the chat viewport jump around. Run the generated worker prompt from a separate terminal instead.
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3227,11 +3227,15 @@ export class AgentSession {
 				maxAttempts: event.maxAttempts,
 			});
 		} else if (event.type === "goal_updated") {
-			await this.#extensionRunner.emit({
-				type: "goal_updated",
-				goal: event.goal,
-				state: event.state,
-			});
+			try {
+				await this.#extensionRunner.emit({
+					type: "goal_updated",
+					goal: event.goal,
+					state: event.state,
+				});
+			} catch (error) {
+				logger.warn("Goal updated extension hook failed", { error: String(error) });
+			}
 		}
 	}
 

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { Agent } from "@gajae-code/agent-core";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import type { ExtensionRunner } from "@gajae-code/coding-agent/extensibility/extensions";
 import { GoalTool } from "@gajae-code/coding-agent/goals/tools/goal-tool";
 import { InteractiveMode } from "@gajae-code/coding-agent/modes/interactive-mode";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
@@ -33,7 +34,7 @@ type GoalHarness = {
 	cleanup: () => Promise<void>;
 };
 
-async function createGoalHarness(): Promise<GoalHarness> {
+async function createGoalHarness(options: { extensionRunner?: ExtensionRunner } = {}): Promise<GoalHarness> {
 	resetSettingsForTest();
 	const tempDir = TempDir.createSync("@pi-goal-mode-");
 	await Settings.init({ inMemory: true, cwd: tempDir.path() });
@@ -67,6 +68,7 @@ async function createGoalHarness(): Promise<GoalHarness> {
 		modelRegistry,
 		toolRegistry,
 		rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"] }),
+		extensionRunner: options.extensionRunner,
 	});
 	const mode = new InteractiveMode(session, "test");
 	const toolSession = createToolSession(tempDir.path(), settings, {
@@ -360,6 +362,30 @@ describe("InteractiveMode goal mode integration", () => {
 		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "next turn" }));
 		await nextTurn;
 	});
+
+	it("completes goal state even when a goal_updated extension hook throws", async () => {
+		await harness.cleanup();
+		const extensionError = new TypeError(
+			'The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined',
+		);
+		const emit = vi.fn(async (event: { type: string }) => {
+			if (event.type === "goal_updated") throw extensionError;
+		});
+		harness = await createGoalHarness({
+			extensionRunner: { emit, getRegisteredCommands: () => [] } as unknown as ExtensionRunner,
+		});
+		await harness.mode.handleGoalModeCommand("Ship the release");
+
+		const tool = new GoalTool(harness.toolSession);
+		const result = await tool.execute("call-complete", { op: "complete" });
+
+		expect(result.details).toMatchObject({ op: "complete" });
+		expect(result.details?.goal?.status).toBe("complete");
+		expect(harness.session.getGoalModeState()?.goal.status).toBe("complete");
+		expect(harness.session.getGoalModeState()?.mode).toBe("exiting");
+		expect(emit).toHaveBeenCalledWith(expect.objectContaining({ type: "goal_updated" }));
+	});
+
 	it("does not loop AgentBusyError when a busy/orphaned session triggers goal continuation", async () => {
 		await harness.mode.handleGoalModeCommand("Ship the release");
 		expect(harness.mode.goalModeEnabled).toBe(true);


### PR DESCRIPTION
## Summary
- Keep `goal_updated` extension hook failures from aborting goal completion after durable state has been persisted.
- Add a regression that simulates the reported Node `data` argument TypeError during `goal({op:"complete"})`.
- Update the coding-agent changelog.

## Validation
- `bun test packages/coding-agent/test/goals/goal-mode-integration.test.ts packages/coding-agent/test/goals/goal-tool.test.ts packages/coding-agent/test/goals/goal-runtime.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`

Fixes #1511

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*