### PR TITLE
fix(utils): $flag을 대소문자 무시로 만들어 소문자 boolean 값 인식

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Deduplicated `globPaths` results so a path is returned at most once even when overlapping glob patterns (e.g. `["**/*.ts", "src/*.ts"]`) both match the same file.
 
+### Fixed
+
+- Made `$flag` case-insensitive so documented boolean-like env values work regardless of case. Previously only `1` and uppercase `TRUE`/`YES`/`ON`/`Y` were truthy, so the common lowercase spellings (`true`/`yes`/`on`) documented for flags such as `AWS_BEDROCK_SKIP_AUTH`, `PI_HARDWARE_CURSOR`, and `PI_CODEX_DEBUG` silently read as `false`.
+
 ## [0.5.2] - 2026-06-15
 
 ### Fixed

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -272,7 +272,10 @@ export function isCompiledBinary(): boolean {
 
 const TRUTHY: Dict<boolean> = { "1": true, Y: true, TRUE: true, YES: true, ON: true };
 export function $flag(name: string, def: boolean = false): boolean {
-	const value = $env[name];
+	const value = $env[name]?.trim();
 	if (!value) return def;
-	return TRUTHY[value] === true;
+	// Boolean-like env values are documented as case-insensitive (`1`/`true`/`yes`/`on`),
+	// so normalize before the lookup — otherwise `FOO=true` (the common lowercase spelling)
+	// would silently read as false while only `FOO=TRUE`/`FOO=1` worked.
+	return TRUTHY[value.toUpperCase()] === true;
 }

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
-import { filterProcessEnv, parseEnvFile, parseShellEnvFile } from "../src/env";
+import { $flag, filterProcessEnv, parseEnvFile, parseShellEnvFile } from "../src/env";
 
 const tempDirs: string[] = [];
 
@@ -315,5 +315,31 @@ describe("filterProcessEnv", () => {
 			"ProgramFiles(x86)": "C:\\Program Files (x86)",
 			"CommonProgramFiles(x86)": "C:\\Program Files (x86)\\Common Files",
 		});
+	});
+});
+
+describe("$flag", () => {
+	const NAME = "__PI_UTILS_FLAG_PROBE";
+	afterEach(() => {
+		delete process.env[NAME];
+	});
+
+	it("treats documented boolean-like values as truthy regardless of case", () => {
+		for (const value of ["1", "true", "TRUE", "True", "yes", "YES", "on", "ON", "y", "Y", " true "]) {
+			process.env[NAME] = value;
+			expect($flag(NAME)).toBe(true);
+		}
+	});
+
+	it("treats non-boolean-like and falsy values as false", () => {
+		for (const value of ["0", "false", "FALSE", "off", "no", "n", "2", "enabled", ""]) {
+			process.env[NAME] = value;
+			expect($flag(NAME)).toBe(false);
+		}
+	});
+
+	it("returns the default when the variable is unset", () => {
+		expect($flag(NAME)).toBe(false);
+		expect($flag(NAME, true)).toBe(true);
 	});
 });


### PR DESCRIPTION
`$flag`이 대문자 boolean 값만 truthy로 인식하던 문제를 고칩니다. `TRUTHY` 맵이 `1`, `TRUE`, `YES`, `ON`, `Y`만 담고 env 값을 정규화 없이 조회해서, 흔한 소문자 `true`/`yes`/`on`/`y`는 전부 `false`로 읽혔습니다.

이건 코드베이스의 다른 boolean 리더들과 일관되지 않습니다. `ai/src/utils/foundry.ts`의 `isFoundryEnabled()`는 `value.trim().toLowerCase()` 후 `"1"/"true"/"yes"/"on"`을 체크하고, 커밋 fallback 플래그도 `.toLowerCase() === "true"`로 읽습니다 — 즉 대소문자 무시가 의도된 관례이고 `$flag`만 대문자 전용 outlier입니다. `docs/environment-variables.md`도 boolean-like 값을 소문자 `1`/`true`/`yes`/`on`으로 문서화합니다. 결과적으로 `$flag`으로 읽는 플래그(예: `AWS_BEDROCK_SKIP_AUTH`, `PI_CODEX_DEBUG`, `PI_HARDWARE_CURSOR`, `E2E` 등 15곳)는 `=true`로 켜도 조용히 꺼진 채 동작했습니다.

### 변경
- `$flag`이 `TRUTHY` 조회 전에 값을 `toUpperCase()`로 정규화 → 소문자 `true`/`yes`/`on`/`y`도 인식
- 값 앞뒤 공백을 `trim` (`$pickenv`와 동일), 빈 값/미설정은 기존대로 기본값 반환
- `packages/utils/CHANGELOG.md` (Unreleased → Fixed) 항목 추가

### 테스트
- `test/env.test.ts` — `$flag` describe 추가: 대소문자 무시 truthy(`1`/`true`/`TRUE`/`yes`/`on`/`y`/` true `), falsy(`0`/`false`/`off`/`no`/임의 문자열/빈값), 미설정 시 기본값
- 수정 전엔 소문자 `true`가 `false`로 읽혀 새 테스트가 실패, 수정 후 통과 확인
- `bun test packages/utils/test/env.test.ts` 14/14 pass, 변경 파일 biome 통과