### PR TITLE
feat(mcp): restore opt-in MCP runtime for user/project servers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- GJC restores an opt-in MCP runtime for user- and project-scoped servers, gated behind a new `enableMCP` session option that only the CLI turns on while embedders, ACP, and subagents stay off. Top-level sessions always own an `MCPManager` so `/mcp` reload/connect work even with zero connected servers, autoload-eligible servers connect at session startup, and `mcp.discoveryMode` is the sole switch for MCP discovery — kept deliberately independent of `tools.discoveryMode`, which now defaults to `"all"`. MCP discovery is source-aware per tool: `gjc-plugins` provider tools are always-on, while user-config server tools stay selectable behind `search_tool_bm25` until explicitly activated.
+
 ### Fixed
 
 - The Telegram notification daemon now tombstones a session endpoint generation after `session_closed`, preventing the scan loop from reconnecting to the still-live old endpoint and recreating an empty topic immediately after deleting the original topic.

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -194,6 +194,12 @@ export interface CustomTool<TParams extends TSchema = TSchema, TDetails = any> {
 	mcpServerName?: string;
 	/** Original MCP tool name for discovery/search metadata. */
 	mcpToolName?: string;
+	/** Source provider for source-aware MCP discovery gating. */
+	mcpSourceProvider?: string;
+	/** Source provider display name for source-aware MCP discovery gating. */
+	mcpSourceProviderName?: string;
+	/** Discovery eligibility for source-aware MCP gating. */
+	mcpDiscoveryScope?: "selectable" | "always-on";
 	/**
 	 * Execute the tool.
 	 * @param toolCallId - Unique ID for this tool call

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -413,6 +413,12 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	mcpServerName?: string;
 	/** Original MCP tool name for discovery/search metadata. */
 	mcpToolName?: string;
+	/** Source provider for source-aware MCP discovery gating. */
+	mcpSourceProvider?: string;
+	/** Source provider display name for source-aware MCP discovery gating. */
+	mcpSourceProviderName?: string;
+	/** Discovery eligibility for source-aware MCP gating. */
+	mcpDiscoveryScope?: "selectable" | "always-on";
 	/** Execute the tool. */
 	execute(
 		toolCallId: string,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -945,6 +945,11 @@ export async function runRootCommand(
 	sessionOptions.authStorage = authStorage;
 	sessionOptions.modelRegistry = modelRegistry;
 	sessionOptions.hasUI = isInteractive || mode === "rpc-ui";
+	// The CLI product surface owns the MCP runtime: autoload servers from
+	// user/project mcp.json connect at session startup. The ACP factory below
+	// forces this off (the ACP client owns MCP), and subagent sessions inherit
+	// the parent's manager instead of discovering their own.
+	sessionOptions.enableMCP = true;
 	sessionOptions.settings = settingsInstance;
 
 	// Research-mode (RLM) preset: augment session options before session creation.

--- a/packages/coding-agent/src/runtime-mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/runtime-mcp/tool-bridge.ts
@@ -217,6 +217,12 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly mcpToolName: string;
 	/** Server name */
 	readonly mcpServerName: string;
+	/** Source provider that registered this MCP tool, when known. */
+	readonly mcpSourceProvider: string | undefined;
+	/** Human-readable source provider name, when known. */
+	readonly mcpSourceProviderName: string | undefined;
+	/** Discovery eligibility for source-aware MCP gating. */
+	readonly mcpDiscoveryScope: "selectable" | "always-on";
 
 	/** Create MCPTool instances for all tools from an MCP server connection */
 	static fromTools(connection: MCPServerConnection, tools: MCPToolDefinition[], reconnect?: MCPReconnect): MCPTool[] {
@@ -234,6 +240,9 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		this.parameters = normalizeSchemaForMCP(tool.inputSchema) as TSchema;
 		this.mcpToolName = tool.name;
 		this.mcpServerName = connection.name;
+		this.mcpSourceProvider = connection._source?.provider;
+		this.mcpSourceProviderName = connection._source?.providerName;
+		this.mcpDiscoveryScope = this.mcpSourceProvider === "gjc-plugins" ? "always-on" : "selectable";
 	}
 
 	renderCall(args: unknown, _options: RenderResultOptions, theme: Theme) {
@@ -300,6 +309,12 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly mcpToolName: string;
 	/** Server name */
 	readonly mcpServerName: string;
+	/** Source provider that registered this MCP tool, when known. */
+	readonly mcpSourceProvider: string | undefined;
+	/** Human-readable source provider name, when known. */
+	readonly mcpSourceProviderName: string | undefined;
+	/** Discovery eligibility for source-aware MCP gating. */
+	readonly mcpDiscoveryScope: "selectable" | "always-on";
 	readonly #fallbackProvider: string | undefined;
 	readonly #fallbackProviderName: string | undefined;
 
@@ -329,6 +344,9 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		this.mcpServerName = serverName;
 		this.#fallbackProvider = source?.provider;
 		this.#fallbackProviderName = source?.providerName;
+		this.mcpSourceProvider = source?.provider;
+		this.mcpSourceProviderName = source?.providerName;
+		this.mcpDiscoveryScope = this.mcpSourceProvider === "gjc-plugins" ? "always-on" : "selectable";
 	}
 
 	renderCall(args: unknown, _options: RenderResultOptions, theme: Theme) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -93,7 +93,7 @@ import {
 } from "./notifications/config";
 import asyncResultTemplate from "./prompts/tools/async-result.md" with { type: "text" };
 import { AgentRegistry, MAIN_AGENT_ID } from "./registry/agent-registry";
-import { MCPManager } from "./runtime-mcp";
+import { discoverAndLoadMCPTools, MCPManager } from "./runtime-mcp";
 import {
 	collectEnvSecrets,
 	deobfuscateSessionContext,
@@ -117,7 +117,14 @@ import {
 } from "./system-prompt";
 import { AgentOutputManager } from "./task/output-manager";
 import { parseThinkingLevel, resolveThinkingLevelForModel, toReasoningEffort } from "./thinking";
-import { collectDiscoverableTools, type DiscoverableTool } from "./tool-discovery/tool-index";
+import {
+	collectDiscoverableMCPTools,
+	collectDiscoverableTools,
+	type DiscoverableTool,
+	formatDiscoverableMCPToolServerSummary,
+	selectDiscoverableMCPToolNamesByServer,
+	summarizeDiscoverableTools,
+} from "./tool-discovery/tool-index";
 import {
 	applyConfiguredSearchTimeout,
 	BashTool,
@@ -296,7 +303,13 @@ export interface CreateAgentSessionOptions {
 	/** File-based slash commands. Default: discovered from commands/ directories */
 	slashCommands?: FileSlashCommand[];
 
-	/** @deprecated MCP runtime discovery is quarantined and ignored. */
+	/**
+	 * Enable the MCP runtime for user/project mcp.json servers (default: false).
+	 * When on, configured servers with autoload !== false connect at session
+	 * startup; the rest stay configured for explicit `/mcp connect`. The CLI
+	 * surface enables this; embedders, ACP, and subagent sessions leave it off.
+	 * Plugin-bundle MCP is always on regardless of this flag.
+	 */
 	enableMCP?: boolean;
 	/** Existing MCP manager to reuse (skips discovery, propagates to toolSession). */
 	mcpManager?: MCPManager;
@@ -644,6 +657,9 @@ function customToolToDefinition(tool: CustomTool): ToolDefinition {
 		deferrable: tool.deferrable,
 		mcpServerName: tool.mcpServerName,
 		mcpToolName: tool.mcpToolName,
+		mcpSourceProvider: tool.mcpSourceProvider,
+		mcpSourceProviderName: tool.mcpSourceProviderName,
+		mcpDiscoveryScope: tool.mcpDiscoveryScope,
 		execute: (toolCallId, params, signal, onUpdate, ctx) =>
 			tool.execute(toolCallId, params, onUpdate, createCustomToolContext(ctx), signal),
 		onSession: tool.onSession ? (event, ctx) => tool.onSession?.(event, createCustomToolContext(ctx)) : undefined,
@@ -1357,14 +1373,17 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Create built-in tools (already wrapped with meta notice formatting)
 		const builtinTools = await logger.time("createAllTools", createTools, toolSession, options.toolNames);
 
-		// MCP runtime discovery is quarantined for the GJC surface. Keep an
-		// explicitly supplied manager only for legacy in-process callers that own
-		// lifecycle themselves; never discover project/user MCP configs here. The
-		// owned manager for always-on plugin-bundle MCP servers is created further
-		// below, after `customTools` is populated, so its tools can be surfaced as
-		// always-on tools per the plugin product contract.
+		// MCP runtime manager. An explicitly supplied manager wins (in-process
+		// callers that own lifecycle themselves). Otherwise the owned manager for
+		// user/project MCP servers and always-on plugin-bundle MCP servers is
+		// created further below, after `customTools` is populated, so its tools
+		// can be surfaced per the product contract.
 		let mcpManager: MCPManager | undefined = options.mcpManager;
 		let ownsMcpManager = false;
+		// True when the owned manager holds user/project config servers (enableMCP).
+		// Those need reactive tool refresh (reconnects, tools/list_changed); a
+		// plugin-only owned manager stays static per the always-on contract.
+		let ownsUserMcpRuntime = false;
 		const customTools: CustomTool[] = [];
 
 		// Add image tools when the active model or configured image providers can generate images.
@@ -1435,19 +1454,65 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			logger.warn("Failed to load always-on GJC plugin tools", { error });
 		}
 
-		// Always-on GJC plugin-bundle MCP servers. Top-level sessions own a manager
-		// and connect the validated servers; subagents inherit the parent's manager
-		// via options.mcpManager and never spawn their own (prevents duplicate
-		// processes and leaks). Per the plugin product contract, connected MCP tools
-		// are surfaced as always-on tools rather than gated behind MCP selection.
+		// MCP runtime servers. Top-level sessions own a single manager that holds
+		// both user/project config servers and always-on plugin-bundle servers;
+		// subagents inherit the parent's manager via options.mcpManager and never
+		// spawn their own (prevents duplicate processes and leaks).
 		if (!mcpManager && !options.parentTaskPrefix) {
+			let owned: MCPManager | undefined;
+
+			// User/project MCP servers from GJC's own mcp.json config, opt-in via
+			// enableMCP (the CLI surface turns it on; embedders, ACP, and subagents
+			// stay off). Only servers with autoload !== false connect at startup;
+			// the rest stay configured-but-disconnected until `/mcp connect`. The
+			// manager is kept even when nothing connects so runtime /mcp commands
+			// (reload/connect) always have a live manager to act on.
+			if (options.enableMCP ?? false) {
+				const mcpResult = await logger.time("discoverAndLoadMCPTools", discoverAndLoadMCPTools, cwd, {
+					onConnecting: serverNames => {
+						if (options.hasUI && serverNames.length > 0) {
+							process.stderr.write(`Connecting to MCP servers: ${serverNames.join(", ")}…\n`);
+						}
+					},
+					enableProjectConfig: settings.get("mcp.enableProjectConfig"),
+					// Always filter Exa - we have native integration
+					filterExa: true,
+					// Filter browser MCP servers when builtin browser tool is active
+					filterBrowser: settings.get("browser.enabled") ?? false,
+					autoloadOnly: true,
+					cacheStorage: settings.getStorage(),
+					authStorage,
+				});
+				owned = mcpResult.manager;
+				ownsUserMcpRuntime = true;
+				if (settings.get("mcp.notifications")) {
+					owned.setNotificationsEnabled(true);
+				}
+				// If we extracted Exa API keys from MCP configs and EXA_API_KEY isn't set, use the first one
+				if (mcpResult.exaApiKeys.length > 0 && !process.env.EXA_API_KEY) {
+					Bun.env.EXA_API_KEY = mcpResult.exaApiKeys[0];
+				}
+				for (const { path, error } of mcpResult.errors) {
+					logger.error("MCP tool load failed", { path, error });
+				}
+				if (mcpResult.tools.length > 0) {
+					customTools.push(...mcpResult.tools.map(loaded => loaded.tool));
+				}
+			}
+
+			// Always-on GJC plugin-bundle MCP servers (validated registry surfaces),
+			// connected into the same owned manager. Per the plugin product contract,
+			// connected MCP tools are surfaced as always-on tools rather than gated
+			// behind MCP selection. User-config servers connect first, so a plugin
+			// server whose name collides with an already-connected user server is
+			// skipped rather than double-spawned.
 			try {
 				const { configs, quarantine } = await buildPluginMcpConfigs({ cwd });
 				for (const q of quarantine) {
 					logger.warn("Quarantined GJC plugin MCP", { plugin: q.plugin, surface: q.surfaceId, code: q.code });
 				}
 				if (Object.keys(configs).length > 0) {
-					const owned = new MCPManager(cwd);
+					const target = owned ?? new MCPManager(cwd);
 					try {
 						const sources = Object.fromEntries(
 							Object.keys(configs).map(name => [
@@ -1455,25 +1520,32 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 								{ provider: "gjc-plugins", providerName: "GJC plugin bundle", level: "project" as const },
 							]),
 						);
-						const result = await owned.connectServers(configs, sources as never);
+						const result = await target.connectServers(configs, sources as never);
 						for (const [server, err] of result.errors) {
 							logger.warn("GJC plugin MCP connect failed", { path: `mcp:${server}`, error: err });
 						}
-						if (result.connectedServers.length > 0) {
-							mcpManager = owned;
-							ownsMcpManager = true;
+						if (result.tools.length > 0) {
 							customTools.push(...(result.tools as CustomTool[]));
+						}
+						if (result.connectedServers.length > 0 || owned) {
+							owned = target;
 						} else {
-							await owned.disconnectAll().catch(() => {});
+							await target.disconnectAll().catch(() => {});
 						}
 					} catch (error) {
-						// Avoid leaking partially-started server processes on failure.
-						await owned.disconnectAll().catch(() => {});
+						// Avoid leaking partially-started plugin server processes, but never
+						// tear down a manager that already holds user-config connections.
+						if (!owned) await target.disconnectAll().catch(() => {});
 						throw error;
 					}
 				}
 			} catch (error) {
 				logger.warn("Failed to wire GJC plugin MCP servers", { error });
+			}
+
+			if (owned) {
+				mcpManager = owned;
+				ownsMcpManager = true;
 			}
 		} else if (options.parentTaskPrefix) {
 			// Subagent: inherit the parent's always-on plugin MCP tools WITHOUT
@@ -1757,6 +1829,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			tools: Map<string, AgentTool>,
 		): Promise<BuildSystemPromptResult> => {
 			toolContextStore.setToolNames(toolNames);
+			const discoverableMCPTools = mcpDiscoveryEnabled ? collectDiscoverableMCPTools(tools.values()) : [];
 			const activeToolNames = new Set(toolNames);
 			const discoverableBuiltinTools: DiscoverableTool[] =
 				effectiveDiscoveryMode === "all"
@@ -1767,7 +1840,21 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 							{ source: "builtin" },
 						)
 					: [];
-			const discoverableToolsForDesc: DiscoverableTool[] = [...discoverableBuiltinTools];
+			const discoverableToolsForDesc: DiscoverableTool[] = [
+				...discoverableBuiltinTools,
+				...discoverableMCPTools.map(t => ({
+					name: t.name,
+					label: t.label,
+					summary: t.description,
+					source: "mcp" as const,
+					serverName: t.serverName,
+					mcpToolName: t.mcpToolName,
+					schemaKeys: t.schemaKeys,
+				})),
+			];
+			const discoverableToolSummary = summarizeDiscoverableTools(discoverableToolsForDesc);
+			const hasDiscoverableTools =
+				mcpDiscoveryEnabled && toolNames.includes("search_tool_bm25") && discoverableToolsForDesc.length > 0;
 			const promptTools = buildSystemPromptToolMetadata(tools, {
 				search_tool_bm25: { description: renderSearchToolBm25Description(discoverableToolsForDesc) },
 			});
@@ -1814,8 +1901,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				pluginAppendices: pluginSystemAppendices,
 				repeatToolDescriptions,
 				intentField,
-				mcpDiscoveryMode: false,
-				mcpDiscoveryServerSummaries: [],
+				mcpDiscoveryMode: hasDiscoverableTools,
+				mcpDiscoveryServerSummaries: discoverableToolSummary.servers.map(formatDiscoverableMCPToolServerSummary),
 				toolDiscoveryActive: effectiveDiscoveryMode === "all",
 				discoverableTools: discoverableBuiltinTools
 					.map(tool => ({ name: tool.name, summary: tool.summary }))
@@ -1847,11 +1934,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			: toolNamesFromRegistry;
 		const normalizedRequested = requestedToolNames.filter(name => toolRegistry.has(name));
 		const requestedToolNameSet = new Set(normalizedRequested);
-		// Effective discovery mode only covers built-in tools; MCP tool discovery
-		// is quarantined from the GJC public surface.
+		// Built-in tool discovery (tools.discoveryMode) and MCP tool discovery
+		// (mcp.discoveryMode) are independent switches: "all" hides non-essential
+		// BUILT-IN tools behind search_tool_bm25 and says nothing about MCP.
 		const toolsDiscoveryModeSetting = settings.get("tools.discoveryMode");
 		const effectiveDiscoveryMode: "off" | "all" = toolsDiscoveryModeSetting === "all" ? "all" : "off";
-		const mcpDiscoveryEnabled = false;
+		const mcpDiscoveryEnabled = settings.get("mcp.discoveryMode") ?? false;
 		const defaultInactiveToolNames = new Set(
 			registeredTools.filter(tool => tool.definition.defaultInactive).map(tool => tool.definition.name),
 		);
@@ -1859,9 +1947,21 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const initialRequestedActiveToolNames = options.toolNames
 			? requestedActiveToolNames
 			: requestedActiveToolNames.filter(name => !defaultInactiveToolNames.has(name));
-		const discoverableMCPToolNames = new Set<string>();
-		const explicitlyRequestedMCPToolNames: string[] = [];
-		const discoveryDefaultServerToolNames: string[] = [];
+		const discoverableMCPToolNames = new Set(
+			collectDiscoverableMCPTools(toolRegistry.values()).map(tool => tool.name),
+		);
+		const explicitlyRequestedMCPToolNames = options.toolNames
+			? requestedActiveToolNames.filter(name => discoverableMCPToolNames.has(name))
+			: [];
+		const discoveryDefaultServers = new Set(
+			(settings.get("mcp.discoveryDefaultServers") ?? []).map(serverName => serverName.trim()).filter(Boolean),
+		);
+		const discoveryDefaultServerToolNames = mcpDiscoveryEnabled
+			? selectDiscoverableMCPToolNamesByServer(
+					collectDiscoverableMCPTools(toolRegistry.values()),
+					discoveryDefaultServers,
+				)
+			: [];
 		let initialSelectedMCPToolNames: string[] = [];
 		let defaultSelectedMCPToolNames: string[] = [];
 		let initialToolNames = [...initialRequestedActiveToolNames];
@@ -2223,7 +2323,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			initialSelectedMCPToolNames,
 			defaultSelectedMCPToolNames,
 			persistInitialMCPToolSelection: !hasExistingSession,
-			defaultSelectedMCPServerNames: [],
+			defaultSelectedMCPServerNames: [...discoveryDefaultServers],
 			ttsrManager,
 			obfuscator,
 			agentId: resolvedAgentId,
@@ -2349,16 +2449,18 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Wire MCP manager callbacks to session for reactive tool updates.
 		// Skip when reusing a parent's manager — the parent owns the callbacks.
 		if (mcpManager && !options.mcpManager) {
-			// The owned plugin-bundle manager surfaces its tools as always-on custom
+			// A plugin-only owned manager surfaces its tools as always-on custom
 			// tools (registered above), so it must NOT drive refreshMCPTools — that
 			// path strips MCP bridge tools and re-gates them behind MCP selection,
-			// which would deactivate the always-on plugin tools. Reactive tool
-			// updates remain wired only for externally supplied managers.
+			// which would deactivate the always-on plugin tools. But when the owned
+			// manager also holds user/project config servers (enableMCP), reactive
+			// refresh is required: reconnects and tools/list_changed notifications
+			// must reach the session or its tool registry goes stale. refreshMCPTools
+			// receives the manager's full tool list, and its selection-preservation
+			// keeps previously active (plugin) tools active across the refresh.
 			// The owned manager is disconnected by AgentSession.dispose via
-			// ownedMcpManager; only externally supplied managers wire reactive
-			// refreshMCPTools (the owned always-on path must not, or it would
-			// deactivate the plugin tools).
-			if (!ownsMcpManager) {
+			// ownedMcpManager.
+			if (!ownsMcpManager || ownsUserMcpRuntime) {
 				mcpManager.setOnToolsChanged(tools => {
 					void session.refreshMCPTools(tools);
 				});

--- a/packages/coding-agent/src/tool-discovery/tool-index.ts
+++ b/packages/coding-agent/src/tool-discovery/tool-index.ts
@@ -115,6 +115,16 @@ export function isMCPBridgeTool(tool: { name: string; mcpServerName?: unknown; m
 	);
 }
 
+function isSelectableMCPBridgeTool(tool: {
+	name: string;
+	mcpServerName?: unknown;
+	mcpToolName?: unknown;
+	mcpSourceProvider?: unknown;
+	mcpDiscoveryScope?: unknown;
+}): boolean {
+	return isMCPBridgeTool(tool) && tool.mcpSourceProvider !== "gjc-plugins" && tool.mcpDiscoveryScope !== "always-on";
+}
+
 function getSchemaPropertyKeys(parameters: unknown): string[] {
 	if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) return [];
 	const properties = (parameters as { properties?: unknown }).properties;
@@ -315,9 +325,11 @@ export function getDiscoverableMCPTool(tool: AgentTool): DiscoverableMCPTool | n
 		description?: string;
 		mcpServerName?: string;
 		mcpToolName?: string;
+		mcpSourceProvider?: string;
+		mcpDiscoveryScope?: "selectable" | "always-on";
 		parameters?: unknown;
 	};
-	if (!isMCPBridgeTool(toolRecord)) return null;
+	if (!isSelectableMCPBridgeTool(toolRecord)) return null;
 	return {
 		name: tool.name,
 		label: typeof toolRecord.label === "string" ? toolRecord.label : tool.name,

--- a/packages/coding-agent/test/gjc-plugin-mcp-connect.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-mcp-connect.test.ts
@@ -33,7 +33,13 @@ describe("plugin MCP live connection", () => {
 
 		expect(result.errors.size).toBe(0);
 		// The bundled server advertises a "lookup" tool; MCP tools are namespaced.
-		expect(result.tools.some(t => t.name.includes("lookup"))).toBe(true);
+		const lookup = result.tools.find(t => t.name.includes("lookup"));
+		const lookupMetadata = lookup as
+			| { mcpSourceProvider?: string; mcpDiscoveryScope?: "selectable" | "always-on" }
+			| undefined;
+		expect(lookup).toBeDefined();
+		expect(lookupMetadata?.mcpSourceProvider).toBe("gjc-plugins");
+		expect(lookupMetadata?.mcpDiscoveryScope).toBe("always-on");
 	}, 30_000);
 
 	test("plugin stdio configs request no-env isolation and the child cannot read host secrets", async () => {

--- a/packages/coding-agent/test/gjc-plugin-mcp-session.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-mcp-session.test.ts
@@ -57,6 +57,45 @@ describe("always-on plugin-bundle MCP in a live session", () => {
 		expect(mcpManager?.getConnectedServers()).toEqual([]);
 	}, 30_000);
 
+	test("keeps plugin-bundle MCP tools always-on when MCP discovery is enabled", async () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-mcp-session-discovery-"));
+
+		tempDirs.push(cwd);
+		await installGjcPluginBundle(mcpBundle, { scope: "project", cwd });
+
+		const { session, mcpManager } = await createAgentSession({
+			cwd,
+			agentDir: cwd,
+			sessionManager: SessionManager.inMemory(cwd),
+			settings: Settings.isolated({ "mcp.discoveryMode": true }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			extensions: [],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			expect(mcpManager).toBeDefined();
+			expect(mcpManager?.getConnectedServers()).toContain("domain_docs");
+
+			const lookup = session.getAllToolNames().find(n => n.includes("lookup"));
+			expect(lookup).toBeDefined();
+			expect(session.getActiveToolNames()).toContain(lookup as string);
+			expect(session.getDiscoverableMCPTools().map(tool => tool.name)).not.toContain(lookup as string);
+			expect(session.getSelectedMCPToolNames()).not.toContain(lookup as string);
+			expect(session.systemPrompt.join("\n")).not.toContain("### MCP tool discovery");
+		} finally {
+			await session.dispose();
+		}
+
+		expect(mcpManager?.getConnectedServers()).toEqual([]);
+	}, 30_000);
+
 	test("does not connect any MCP server when no plugin bundle is installed", async () => {
 		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-mcp-session-empty-"));
 		tempDirs.push(cwd);

--- a/packages/coding-agent/test/mcp-quarantine-surface.test.ts
+++ b/packages/coding-agent/test/mcp-quarantine-surface.test.ts
@@ -20,13 +20,17 @@ describe("GJC MCP quarantine surface", () => {
 		expect(barrel).not.toContain("mcp-protocol");
 	});
 
-	it("does not discover or proxy MCP tools into agent or subagent sessions", async () => {
+	it("keeps MCP runtime discovery opt-in and quarantined from subagent sessions", async () => {
 		const sdk = await source("sdk.ts");
 		const taskExecutor = await source("task", "executor.ts");
 		const taskIndex = await source("task", "index.ts");
 
-		expect(sdk).not.toContain("discoverAndLoadMCPTools");
+		// User/project MCP discovery is allowed for top-level sessions but must
+		// stay gated behind the explicit enableMCP option (the CLI surface opts
+		// in; embedders, ACP, and subagents stay off by default).
+		expect(sdk).toContain("options.enableMCP ?? false");
 		expect(sdk).not.toContain("discoverMCPServers");
+		// Subagents inherit the parent's manager and never proxy or discover.
 		expect(taskExecutor).not.toContain("createMCPProxyTools");
 		expect(taskExecutor).not.toContain("runtime-mcp/client");
 		expect(taskIndex).not.toContain("MCPManager.instance()");

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -55,7 +55,7 @@ function createReasoningModel(): Model<"openai-responses"> {
 }
 
 const oldSessionMtime = new Date("2000-01-01T00:00:00.000Z");
-const SLOW_SDK_TEST_TIMEOUT_MS = 15_000;
+const SLOW_SDK_TEST_TIMEOUT_MS = 30_000;
 
 describe("createAgentSession MCP discovery prompt gating", () => {
 	let tempDir: string;
@@ -104,9 +104,13 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			toolNames: ["read"],
 		});
 
-		expect(mcpManager).toBeUndefined();
-		expect(session.getAllToolNames().filter(name => name.startsWith("mcp__"))).toEqual([]);
-		expect(session.getActiveToolNames().filter(name => name.startsWith("mcp__"))).toEqual([]);
+		try {
+			expect(mcpManager).toBeUndefined();
+			expect(session.getAllToolNames().filter(name => name.startsWith("mcp__"))).toEqual([]);
+			expect(session.getActiveToolNames().filter(name => name.startsWith("mcp__"))).toEqual([]);
+		} finally {
+			await session.dispose();
+		}
 	});
 
 	it("does not advertise MCP discovery when search_tool_bm25 is not active", async () => {
@@ -128,10 +132,14 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			customTools: [createMcpCustomTool("mcp__github_create_issue", "github", "create_issue")],
 		});
 
-		expect(session.systemPrompt.join("\n")).not.toContain("### MCP tool discovery");
-		expect(session.systemPrompt.join("\n")).not.toContain(
-			"call `search_tool_bm25` before concluding no such tool exists",
-		);
+		try {
+			expect(session.systemPrompt.join("\n")).not.toContain("### MCP tool discovery");
+			expect(session.systemPrompt.join("\n")).not.toContain(
+				"call `search_tool_bm25` before concluding no such tool exists",
+			);
+		} finally {
+			await session.dispose();
+		}
 	});
 
 	it(
@@ -157,12 +165,16 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 				enableLsp: false,
 			});
 
-			const prompt = session.systemPrompt.join("\n");
-			const searchTool = session.agent.state.tools.find(tool => tool.name === "search_tool_bm25");
-			expect(session.getActiveToolNames()).not.toContain("todo_write");
-			expect(prompt).toContain("SearchTools: `search_tool_bm25`");
-			expect(searchTool?.description).toContain("Search hidden tool metadata");
-			expect(searchTool?.description).toContain("total_tools");
+			try {
+				const prompt = session.systemPrompt.join("\n");
+				const searchTool = session.agent.state.tools.find(tool => tool.name === "search_tool_bm25");
+				expect(session.getActiveToolNames()).not.toContain("todo_write");
+				expect(prompt).toContain("SearchTools: `search_tool_bm25`");
+				expect(searchTool?.description).toContain("Search hidden tool metadata");
+				expect(searchTool?.description).toContain("total_tools");
+			} finally {
+				await session.dispose();
+			}
 		},
 		SLOW_SDK_TEST_TIMEOUT_MS,
 	);
@@ -189,19 +201,23 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			],
 		});
 
-		expect(session.getActiveToolNames()).toContain("mcp__github_create_issue");
-		expect(session.getSelectedMCPToolNames()).toEqual(["mcp__github_create_issue", "mcp__slack_post_message"]);
-		expect(session.systemPrompt.join("\n")).toContain("mcp__github_create_issue");
+		try {
+			expect(session.getActiveToolNames()).toContain("mcp__github_create_issue");
+			expect(session.getSelectedMCPToolNames()).toEqual(["mcp__github_create_issue"]);
+			expect(session.systemPrompt.join("\n")).toContain("mcp__github_create_issue");
 
-		await session.activateDiscoveredMCPTools(["mcp__slack_post_message"]);
+			await session.activateDiscoveredMCPTools(["mcp__slack_post_message"]);
 
-		expect(session.getActiveToolNames()).toEqual(
-			expect.arrayContaining(["read", "search_tool_bm25", "mcp__slack_post_message"]),
-		);
-		expect(session.getSelectedMCPToolNames()).toEqual(["mcp__slack_post_message"]);
+			expect(session.getActiveToolNames()).toEqual(
+				expect.arrayContaining(["read", "search_tool_bm25", "mcp__github_create_issue", "mcp__slack_post_message"]),
+			);
+			expect(session.getSelectedMCPToolNames()).toEqual(["mcp__github_create_issue", "mcp__slack_post_message"]);
+		} finally {
+			await session.dispose();
+		}
 	});
 
-	it("activates configured discovery default servers in discovery mode", async () => {
+	it("keeps configured discovery default servers visible in discovery mode", async () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
@@ -226,16 +242,17 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			],
 		});
 		try {
-			expect(session.getSelectedMCPToolNames()).toEqual(["mcp__github_create_issue", "mcp__slack_post_message"]);
+			expect(session.getSelectedMCPToolNames()).toEqual(["mcp__github_create_issue"]);
 			expect(session.getActiveToolNames()).toEqual(
-				expect.arrayContaining(["read", "search_tool_bm25", "mcp__github_create_issue", "mcp__slack_post_message"]),
+				expect.arrayContaining(["read", "search_tool_bm25", "mcp__github_create_issue"]),
 			);
+			expect(session.getActiveToolNames()).not.toContain("mcp__slack_post_message");
 		} finally {
 			await session.dispose();
 		}
 	});
 
-	it("keeps inline local mcp__-prefixed custom tools active alongside explicitly supplied MCP tools", async () => {
+	it("keeps inline local mcp__-prefixed custom tools active while gating MCP bridge tools behind discovery", async () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
@@ -258,9 +275,10 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		});
 		try {
 			expect(session.getActiveToolNames()).toEqual(
-				expect.arrayContaining(["read", "search_tool_bm25", "mcp__local_inline_tool", "mcp__github_create_issue"]),
+				expect.arrayContaining(["read", "search_tool_bm25", "mcp__local_inline_tool"]),
 			);
-			expect(session.getSelectedMCPToolNames()).toEqual(["mcp__local_inline_tool", "mcp__github_create_issue"]);
+			expect(session.getActiveToolNames()).not.toContain("mcp__github_create_issue");
+			expect(session.getSelectedMCPToolNames()).toEqual([]);
 			expect(session.getDiscoverableMCPTools().map(tool => tool.name)).toEqual(["mcp__github_create_issue"]);
 		} finally {
 			await session.dispose();
@@ -286,9 +304,13 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			customTools: [createMcpCustomTool("mcp__github_create_issue", "github", "create_issue")],
 		});
 
-		const searchTool = session.agent.state.tools.find(tool => tool.name === "search_tool_bm25");
-		expect(searchTool?.description).toContain("total_tools");
-		expect(searchTool?.description).toContain("- `server_name`");
+		try {
+			const searchTool = session.agent.state.tools.find(tool => tool.name === "search_tool_bm25");
+			expect(searchTool?.description).toContain("total_tools");
+			expect(searchTool?.description).toContain("- `server_name`");
+		} finally {
+			await session.dispose();
+		}
 	});
 
 	it(
@@ -314,15 +336,19 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 				enableLsp: false,
 			});
 
-			expect(await session.activateDiscoveredTools(["todo_write"])).toEqual(["todo_write"]);
-			expect(session.getSelectedDiscoveredToolNames()).toContain("todo_write");
+			try {
+				expect(await session.activateDiscoveredTools(["todo_write"])).toEqual(["todo_write"]);
+				expect(session.getSelectedDiscoveredToolNames()).toContain("todo_write");
 
-			await session.setActiveToolsByName(["read", "search_tool_bm25"]);
+				await session.setActiveToolsByName(["read", "search_tool_bm25"]);
 
-			expect(session.getActiveToolNames()).not.toContain("todo_write");
-			expect(session.getSelectedDiscoveredToolNames()).not.toContain("todo_write");
-			expect(await session.activateDiscoveredTools(["todo_write"])).toEqual(["todo_write"]);
-			expect(session.getActiveToolNames()).toContain("todo_write");
+				expect(session.getActiveToolNames()).not.toContain("todo_write");
+				expect(session.getSelectedDiscoveredToolNames()).not.toContain("todo_write");
+				expect(await session.activateDiscoveredTools(["todo_write"])).toEqual(["todo_write"]);
+				expect(session.getActiveToolNames()).toContain("todo_write");
+			} finally {
+				await session.dispose();
+			}
 		},
 		SLOW_SDK_TEST_TIMEOUT_MS,
 	);
@@ -394,17 +420,9 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			try {
 				expect(resumedSession.thinkingLevel).toBe(ThinkingLevel.Off);
 				expect(resumedSession.serviceTier).toBe("priority");
-				expect(resumedSession.getSelectedMCPToolNames()).toEqual([
-					"mcp__github_create_issue",
-					"mcp__slack_post_message",
-				]);
+				expect(resumedSession.getSelectedMCPToolNames()).toEqual(["mcp__slack_post_message"]);
 				expect(resumedSession.getActiveToolNames()).toEqual(
-					expect.arrayContaining([
-						"read",
-						"search_tool_bm25",
-						"mcp__github_create_issue",
-						"mcp__slack_post_message",
-					]),
+					expect.arrayContaining(["read", "search_tool_bm25", "mcp__slack_post_message"]),
 				);
 				expect(resumedSession.systemPrompt.join("\n")).toContain("mcp__slack_post_message");
 				expect(fs.readFileSync(sessionFile!, "utf8")).toBe(persistedBeforeResume);
@@ -458,9 +476,9 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		try {
 			expect(session.thinkingLevel).toBe(ThinkingLevel.High);
 			expect(session.serviceTier).toBe("priority");
-			expect(session.getSelectedMCPToolNames()).toEqual(["mcp__github_create_issue", "mcp__slack_post_message"]);
+			expect(session.getSelectedMCPToolNames()).toEqual(["mcp__github_create_issue"]);
 			expect(session.getActiveToolNames()).toEqual(
-				expect.arrayContaining(["read", "search_tool_bm25", "mcp__github_create_issue", "mcp__slack_post_message"]),
+				expect.arrayContaining(["read", "search_tool_bm25", "mcp__github_create_issue"]),
 			);
 			expect(session.sessionManager.buildSessionContext().hasPersistedMCPToolSelection).toBe(false);
 			expect(fs.readFileSync(sessionFile!, "utf8")).toBe(persistedBeforeResume);
@@ -471,7 +489,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 	}, 30_000);
 
 	it(
-		"rebuilds explicit MCP custom-tool selections when resuming with requested MCP tools",
+		"keeps a cleared MCP selection empty when resuming with explicitly requested MCP tools",
 		async () => {
 			const firstManager = SessionManager.create(tempDir, tempDir);
 			const { session: firstSession } = await createAgentSession({
@@ -523,18 +541,9 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 				],
 			});
 			try {
-				expect(resumedSession.getSelectedMCPToolNames()).toEqual([
-					"mcp__github_create_issue",
-					"mcp__slack_post_message",
-				]);
-				expect(resumedSession.getActiveToolNames()).toEqual(
-					expect.arrayContaining([
-						"read",
-						"search_tool_bm25",
-						"mcp__github_create_issue",
-						"mcp__slack_post_message",
-					]),
-				);
+				expect(resumedSession.getSelectedMCPToolNames()).toEqual([]);
+				expect(resumedSession.getActiveToolNames()).toEqual(expect.arrayContaining(["read", "search_tool_bm25"]));
+				expect(resumedSession.getActiveToolNames()).not.toContain("mcp__github_create_issue");
 			} finally {
 				await resumedSession.dispose();
 			}


### PR DESCRIPTION
## What

Restores an opt-in MCP runtime for user- and project-scoped servers:

- A new `enableMCP` session option consumes the MCP runtime. Only the CLI surface turns it on; embedders, ACP, and subagents stay off (`options.enableMCP ?? false`).
- Top-level sessions always own an `MCPManager`, even with zero connected servers, so `/mcp` reload/connect are no longer no-ops when nothing is connected yet.
- Autoload-eligible servers connect at session startup (`autoloadOnly`), wiring up the `autoload` config contract added in #1489.
- `mcp.discoveryMode` is the sole switch for MCP tool discovery, kept deliberately independent of `tools.discoveryMode` (which now defaults to `"all"` post-#1504) so MCP tools are never unexpectedly hidden.
- MCP discovery is source-aware per tool: `gjc-plugins` provider tools are always-on, while user-config server tools stay selectable behind `search_tool_bm25` until explicitly activated.

## Why

This completes the merged #1489/#1490 groundwork: the per-server `autoload` flag (#1489) currently has no caller, and removing live MCP inheritance from other hosts (#1490) left no replacement runtime. This change is the missing middle that turns those into a working user/project MCP runtime.

## Testing

Clean-env run (isolated `HOME`/`GJC_CODING_AGENT_DIR` to avoid local plugin leakage), from `packages/coding-agent`:

- `test/sdk-mcp-discovery.test.ts`: 11 pass, 0 fail (52 assertions) — the previously-failing shard, now fully green.
- Full MCP batch (`sdk-mcp-discovery`, `mcp-quarantine-surface`, `acp-mcp-isolation`, `agent-session-mcp-discovery`, `runtime-mcp/`): 61 pass, 0 fail across 8 files.
- `bun run --cwd packages/coding-agent check`: biome clean (1873 files) and tsgo `--noEmit` clean.
- Pre-verified on fork CI before opening this PR: https://github.com/mpfo0106/gajae-code/actions/runs/28695666835 (head `d137a052`) — the `test:packages/coding-agent/test/sdk-mcp-discovery.test.ts` shard and `check:@gajae-code/coding-agent` both pass, alongside `cli-smoke`, `native-build`, and the other MCP shards.

Clean re-attempt of closed #1491 with a fresh branch, rebased onto the post-#1504 discovery defaults and incorporating the source-aware gating fix contributed on that branch.
