### PR TITLE
fix: 문서화된 GJC_ 접두사 토글 env 변수가 실제로 동작하도록 수정

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Documented `GJC_`-prefixed toggle env vars now take effect. Several debug/behavior flags were only read under their legacy `PI_` names while `docs/environment-variables.md` documents the `GJC_` spelling, so setting e.g. `GJC_HARDWARE_CURSOR`, `GJC_CLEAR_ON_SHRINK`, `GJC_DEBUG_REDRAW`, `GJC_TUI_DEBUG`, `GJC_DISABLE_LSPMUX`, `GJC_ALLOW_SIXEL_PASSTHROUGH`, `GJC_PYTHON_SKIP_CHECK`, or `GJC_PYTHON_IPC_TRACE` did nothing. These now honor the documented `GJC_` name with the `PI_` spelling still accepted as a legacy alias.
 - Goal completion now preserves the terminal `goal({op: "complete"})` state even when a `goal_updated` extension hook throws, preventing hook-side write errors from trapping a verified ultragoal run in the continuation loop.
 - The Telegram notification daemon now tombstones a session endpoint generation after `session_closed`, preventing the scan loop from reconnecting to the still-live old endpoint and recreating an empty topic immediately after deleting the original topic.
 - `/contribute-pr` in the interactive TUI now prepares the redacted manifest and worker prompt without spawning a second GJC process on the same terminal, avoiding competing TUI renderers that make the chat viewport jump around. Run the generated worker prompt from a separate terminal instead.

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -11,7 +11,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { $flag, isBunTestRuntime, logger, Snowflake } from "@gajae-code/utils";
+import { $flagAny, isBunTestRuntime, logger, Snowflake } from "@gajae-code/utils";
 import type { Subprocess } from "bun";
 import { $ } from "bun";
 import { Settings } from "../../config/settings";
@@ -23,7 +23,7 @@ import { ensurePythonRuntime, filterEnv, type PythonRuntimeOptions } from "./run
 export type { KernelDisplayOutput, PythonStatusEvent } from "./display";
 export { renderKernelDisplay } from "./display";
 
-const TRACE_IPC = $flag("PI_PYTHON_IPC_TRACE");
+const TRACE_IPC = $flagAny("GJC_PYTHON_IPC_TRACE", "PI_PYTHON_IPC_TRACE");
 
 // Cache the runner script on disk so the subprocess loads it normally. Cached
 // per script hash so installs don't race across versions.
@@ -125,7 +125,7 @@ export async function checkPythonKernelAvailability(
 	cwd: string,
 	runtimeOptions?: PythonRuntimeOptions,
 ): Promise<PythonKernelAvailability> {
-	if (isBunTestRuntime() || $flag("PI_PYTHON_SKIP_CHECK")) {
+	if (isBunTestRuntime() || $flagAny("GJC_PYTHON_SKIP_CHECK", "PI_PYTHON_SKIP_CHECK")) {
 		return { ok: true };
 	}
 	try {

--- a/packages/coding-agent/src/lsp/lspmux.ts
+++ b/packages/coding-agent/src/lsp/lspmux.ts
@@ -1,6 +1,6 @@
 import * as os from "node:os";
 import * as path from "node:path";
-import { $flag, $which, logger } from "@gajae-code/utils";
+import { $flagAny, $which, logger } from "@gajae-code/utils";
 import { TOML } from "bun";
 import { spawnOwnedProcess } from "../runtime/process-lifecycle";
 
@@ -151,7 +151,7 @@ function drainStream(stream: ReadableStream<Uint8Array> | null | undefined): voi
  * Detect lspmux availability and state.
  * Results are cached for STATE_CACHE_TTL_MS.
  *
- * Set PI_DISABLE_LSPMUX=1 to disable.
+ * Set GJC_DISABLE_LSPMUX=1 to disable (PI_DISABLE_LSPMUX legacy alias honored).
  */
 export async function detectLspmux(): Promise<LspmuxState> {
 	const now = Date.now();
@@ -159,7 +159,7 @@ export async function detectLspmux(): Promise<LspmuxState> {
 		return cachedState;
 	}
 
-	if ($flag("PI_DISABLE_LSPMUX")) {
+	if ($flagAny("GJC_DISABLE_LSPMUX", "PI_DISABLE_LSPMUX")) {
 		cachedState = { available: false, running: false, binaryPath: null, config: null };
 		cacheTimestamp = now;
 		return cachedState;

--- a/packages/coding-agent/src/utils/sixel.ts
+++ b/packages/coding-agent/src/utils/sixel.ts
@@ -1,4 +1,4 @@
-import { $env, $flag } from "@gajae-code/utils";
+import { $env, $flagAny } from "@gajae-code/utils";
 
 const SIXEL_START_REGEX = /\x1bP(?:[0-9;]*)q/u;
 const SIXEL_END_SEQUENCE = "\x1b\\";
@@ -11,11 +11,11 @@ const SIXEL_PLACEHOLDER_PREFIX = "__GJC_SIXEL_SEQUENCE_";
  *
  * Both gates must be enabled to preserve SIXEL control sequences:
  * - PI_FORCE_IMAGE_PROTOCOL=sixel
- * - PI_ALLOW_SIXEL_PASSTHROUGH=1
+ * - GJC_ALLOW_SIXEL_PASSTHROUGH=1 (PI_ legacy alias still honored)
  */
 export function isSixelPassthroughEnabled(): boolean {
 	const forcedProtocol = $env.PI_FORCE_IMAGE_PROTOCOL?.trim().toLowerCase();
-	return forcedProtocol === "sixel" && $flag("PI_ALLOW_SIXEL_PASSTHROUGH");
+	return forcedProtocol === "sixel" && $flagAny("GJC_ALLOW_SIXEL_PASSTHROUGH", "PI_ALLOW_SIXEL_PASSTHROUGH");
 }
 /** Returns true when the text contains a SIXEL start sequence. */
 export function containsSixelSequence(text: string): boolean {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -4,7 +4,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { performance } from "node:perf_hooks";
-import { $flag, getDebugLogPath, logger } from "@gajae-code/utils";
+import { $flag, $flagAny, getDebugLogPath, logger } from "@gajae-code/utils";
 import { getKeybindings } from "./keybindings";
 import { isKeyRelease } from "./keys";
 import { renderMetrics } from "./metrics";
@@ -348,12 +348,12 @@ export class TUI extends Container {
 	#sixelProbeBuffer = "";
 	#sixelProbeTimeout?: NodeJS.Timeout;
 	#sixelProbeUnsubscribe?: () => void;
-	#showHardwareCursor = $flag("PI_HARDWARE_CURSOR");
+	#showHardwareCursor = $flagAny("GJC_HARDWARE_CURSOR", "PI_HARDWARE_CURSOR");
 	// macOS: steady-block cursor anchors CJK IME overlays; disable with GJC_TUI_IME_CURSOR=0.
 	readonly #useImeBlockCursor = $flag("GJC_TUI_IME_CURSOR", process.platform === "darwin");
 	// showHardwareCursor=false but cursor is shown for IME anchoring (macOS).
 	#imeCursorActive = false;
-	#clearOnShrink = $flag("PI_CLEAR_ON_SHRINK"); // Clear empty rows when content shrinks (default: off)
+	#clearOnShrink = $flagAny("GJC_CLEAR_ON_SHRINK", "PI_CLEAR_ON_SHRINK"); // Clear empty rows when content shrinks (default: off)
 	// Opt-in: reuse the previous normalized off-screen prefix and only normalize/diff the
 	// visible window, bounding per-frame work on huge transcripts. Output stays byte-identical.
 	#virtualViewport = $flag("PI_TUI_VIRTUAL_VIEWPORT");
@@ -1451,7 +1451,7 @@ export class TUI extends Container {
 		buffer += "\x1b[?2026l";
 		if (!this.#writeTerminal(buffer)) return false;
 
-		if ($flag("PI_DEBUG_REDRAW")) {
+		if ($flagAny("GJC_DEBUG_REDRAW", "PI_DEBUG_REDRAW")) {
 			const logPath = getDebugLogPath();
 			const msg = `[${new Date().toISOString()}] viewportRepaint: ${reason} (lines=${lines.length}, height=${height}, viewportTop=${nextViewportTop})\n`;
 			fs.appendFileSync(logPath, msg);
@@ -1710,7 +1710,7 @@ export class TUI extends Container {
 
 		// Content shrunk below the previous render and no overlays - re-render to clear empty rows
 		// (overlays need the padding, so only do this when no overlays are active)
-		// Configurable via setClearOnShrink() or PI_CLEAR_ON_SHRINK=0 env var
+		// Configurable via setClearOnShrink() or GJC_CLEAR_ON_SHRINK=0 env var (PI_ legacy alias honored)
 		if (this.#clearOnShrink && newLines.length < this.#previousLines.length && this.overlayStack.length === 0) {
 			logRedraw(`clearOnShrink (prev=${this.#previousLines.length}, new=${newLines.length})`);
 			fullRender(true, "clearOnShrink");
@@ -1899,7 +1899,7 @@ export class TUI extends Container {
 		buffer += seq;
 		buffer += "\x1b[?2026l"; // End synchronized output
 
-		if ($flag("PI_TUI_DEBUG")) {
+		if ($flagAny("GJC_TUI_DEBUG", "PI_TUI_DEBUG")) {
 			const debugDir = "/tmp/tui";
 			fs.mkdirSync(debugDir, { recursive: true });
 			const debugPath = path.join(debugDir, `render-${Date.now()}-${Math.random().toString(36).slice(2)}.log`);

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `$flagAny(...names)` to resolve a boolean flag from the first matching env var, so a canonical name plus legacy aliases (e.g. `$flagAny("GJC_X", "PI_X")`) both keep working.
+
 ### Fixed
 
 - Deduplicated `globPaths` results so a path is returned at most once even when overlapping glob patterns (e.g. `["**/*.ts", "src/*.ts"]`) both match the same file.

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -279,3 +279,14 @@ export function $flag(name: string, def: boolean = false): boolean {
 	// would silently read as false while only `FOO=TRUE`/`FOO=1` worked.
 	return TRUTHY[value.toUpperCase()] === true;
 }
+
+/**
+ * True when any of the given env vars resolves to a truthy flag.
+ *
+ * Use for a canonical name plus legacy aliases so a renamed flag keeps working
+ * under both spellings, e.g. `$flagAny("GJC_HARDWARE_CURSOR", "PI_HARDWARE_CURSOR")`
+ * (mirrors the `GJC_* ?? PI_*` precedence used for directory env vars in `dirs.ts`).
+ */
+export function $flagAny(...names: string[]): boolean {
+	return names.some(name => $flag(name));
+}

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
-import { $flag, filterProcessEnv, parseEnvFile, parseShellEnvFile } from "../src/env";
+import { $flag, $flagAny, filterProcessEnv, parseEnvFile, parseShellEnvFile } from "../src/env";
 
 const tempDirs: string[] = [];
 
@@ -341,5 +341,31 @@ describe("$flag", () => {
 	it("returns the default when the variable is unset", () => {
 		expect($flag(NAME)).toBe(false);
 		expect($flag(NAME, true)).toBe(true);
+	});
+});
+
+describe("$flagAny", () => {
+	const CANON = "__PI_UTILS_FLAGANY_CANON";
+	const LEGACY = "__PI_UTILS_FLAGANY_LEGACY";
+	afterEach(() => {
+		delete process.env[CANON];
+		delete process.env[LEGACY];
+	});
+
+	it("is true when the canonical name is set", () => {
+		process.env[CANON] = "1";
+		expect($flagAny(CANON, LEGACY)).toBe(true);
+	});
+
+	it("falls back to a legacy alias when the canonical name is unset", () => {
+		process.env[LEGACY] = "1";
+		expect($flagAny(CANON, LEGACY)).toBe(true);
+	});
+
+	it("is false when no alias is set or all are falsy", () => {
+		expect($flagAny(CANON, LEGACY)).toBe(false);
+		process.env[CANON] = "0";
+		process.env[LEGACY] = "";
+		expect($flagAny(CANON, LEGACY)).toBe(false);
 	});
 });


### PR DESCRIPTION
리브랜딩(PI_ → GJC_) 이후, `docs/environment-variables.md`는 여러 토글 env 변수를 `GJC_` 접두사로 안내하는데 실제 코드는 레거시 `PI_` 이름으로만 읽고 있었습니다. 그래서 문서대로 `GJC_HARDWARE_CURSOR=1`, `GJC_DISABLE_LSPMUX=1` 등을 설정해도 **아무 효과가 없었습니다**(오직 `PI_...`만 동작).

이건 `dirs.ts`(`process.env.GJC_CONFIG_DIR ?? process.env.PI_CONFIG_DIR`)와 이슈 #12 fix(`$pickenv("GJC_RPC_EMIT_TITLE", "PI_RPC_EMIT_TITLE")`)에서 확립된 "GJC_ 우선 + PI_ 레거시 폴백" 관례를 `$flag` 기반 토글들이 따르지 못한 케이스입니다.

### 변경
- `packages/utils/src/env.ts`에 `$flagAny(...names): boolean` 추가 — 여러 이름 중 첫 truthy 플래그를 해석(canonical + 레거시 alias)
- `$flag("PI_X")`로만 읽던 문서화된 토글 8개 사이트를 `$flagAny("GJC_X", "PI_X")`로 교체:
  - tui: `HARDWARE_CURSOR`, `CLEAR_ON_SHRINK`, `DEBUG_REDRAW`, `TUI_DEBUG`
  - coding-agent: `DISABLE_LSPMUX`(lspmux), `ALLOW_SIXEL_PASSTHROUGH`(sixel), `PYTHON_SKIP_CHECK`/`PYTHON_IPC_TRACE`(py kernel)
- 관련 docstring도 `GJC_` 우선 표기로 갱신, `PI_`는 레거시 alias로 계속 인정
- CHANGELOG: utils(`$flagAny` 추가), coding-agent(문서화된 GJC_ 플래그 동작 수정)

### 범위 밖(후속)
- `FORCE_IMAGE_PROTOCOL`(sixel.ts / terminal-capabilities.ts)처럼 `$env`에서 직접 읽는 **문자열** 변수의 `PI_`→`GJC_` 폴백은 메커니즘이 달라 이 PR에서 제외했습니다. 별도 후속으로 다룰 수 있습니다.
- `PI_PY`/`PI_JS`는 presence 기반 로직이라 제외.

### 테스트
- `test/env.test.ts` — `$flagAny` describe 추가: canonical 설정 시 true, canonical 미설정 시 레거시 alias 폴백, 둘 다 미설정/falsy면 false
- `bun test packages/utils/test/env.test.ts` 14/14 pass
- 변경 6개 소스 파일 biome 통과(미사용 import 없음)

### 방향 근거
이 방향(코드가 `GJC_`를 인식하도록 수정, `PI_`는 alias 유지)은 승인된 리브랜딩 계획과 일치합니다 — `docs/REBRANDING_PLAN_260525.md`는 "legacy env aliases를 legacy/Pi 언급을 이유로 제거하지 말 것"(non-goal)과 "호환 alias를 internal alias / opt-in으로 보존"을 명시합니다. 즉 `GJC_`가 문서/노출 canonical 이름이고 `PI_`는 레거시 alias로 계속 동작해야 하므로, 문서를 `PI_`로 되돌리는 대신 코드가 `GJC_`를 인식하게 하는 것이 의도에 맞습니다.