### PR TITLE
fix(tui): preserve prefixes around bracketed paste

### DIFF
--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -241,6 +241,9 @@ export class CustomEditor extends Editor {
 		if (this.onPasteText) {
 			const paste = this.#pasteHandler.process(data);
 			if (paste.handled) {
+				if (paste.normalText !== undefined) {
+					super.handleInput(paste.normalText);
+				}
 				if (paste.pasteContent !== undefined) {
 					this.#handleBracketedPaste(paste.pasteContent, paste.remaining);
 				}

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -285,6 +285,19 @@ describe("CustomEditor bracketed paste interception", () => {
 		expect(editor.getText()).toBe("hello");
 	});
 
+	it("keeps prefix text when coding-agent consumes paste after a split start marker", async () => {
+		const editor = createEditor();
+		const onPasteText = vi.fn(() => true);
+		editor.onPasteText = onPasteText;
+
+		editor.handleInput("prefix\x1b[200~pay");
+		editor.handleInput("load\x1b[201~");
+		await Bun.sleep(0);
+
+		expect(onPasteText).toHaveBeenCalledWith("payload");
+		expect(editor.getText()).toBe("prefix");
+	});
+
 	it("keeps later input behind a pending async consumed paste", async () => {
 		const editor = createEditor();
 		const pasteDecision = Promise.withResolvers<boolean>();

--- a/packages/tui/src/bracketed-paste.ts
+++ b/packages/tui/src/bracketed-paste.ts
@@ -1,7 +1,20 @@
 const PASTE_START = "\x1b[200~";
 const PASTE_END = "\x1b[201~";
 
-export type PasteResult = { handled: false } | { handled: true; pasteContent?: string; remaining: string };
+export type PasteResult =
+	| { handled: false }
+	| { handled: true; normalText?: string; pasteContent?: string; remaining: string };
+
+function findPartialStartMarkerIndex(data: string): number {
+	const maxLength = Math.min(data.length, PASTE_START.length - 1);
+	for (let length = maxLength; length > 1; length--) {
+		const suffix = data.slice(data.length - length);
+		if (PASTE_START.startsWith(suffix)) {
+			return data.length - length;
+		}
+	}
+	return -1;
+}
 
 /**
  * Handles bracketed paste mode buffering for terminal input components.
@@ -13,6 +26,7 @@ export type PasteResult = { handled: false } | { handled: true; pasteContent?: s
 export class BracketedPasteHandler {
 	#buffer = "";
 	#active = false;
+	#pendingStart = "";
 
 	/**
 	 * Process incoming terminal data for bracketed paste sequences.
@@ -23,18 +37,43 @@ export class BracketedPasteHandler {
 	 *          paste has been assembled; omitted when still buffering.
 	 */
 	process(data: string): PasteResult {
-		if (data.includes(PASTE_START)) {
-			this.#active = true;
-			this.#buffer = "";
-			data = data.replace(PASTE_START, "");
+		const hadPendingStart = this.#pendingStart.length > 0;
+		if (hadPendingStart) {
+			data = this.#pendingStart + data;
+			this.#pendingStart = "";
 		}
 
-		if (!this.#active) return { handled: false };
+		if (!this.#active) {
+			const startIndex = data.indexOf(PASTE_START);
+			if (startIndex !== -1) {
+				const normalText = data.slice(0, startIndex);
+				this.#active = true;
+				this.#buffer = "";
+				return this.#processPasteData(data.slice(startIndex + PASTE_START.length), normalText);
+			}
 
+			const partialStartIndex = findPartialStartMarkerIndex(data);
+			if (partialStartIndex !== -1) {
+				const normalText = data.slice(0, partialStartIndex);
+				this.#pendingStart = data.slice(partialStartIndex);
+				return this.#handled(normalText);
+			}
+
+			if (hadPendingStart) {
+				return this.#handled(data);
+			}
+
+			return { handled: false };
+		}
+
+		return this.#processPasteData(data);
+	}
+
+	#processPasteData(data: string, normalText?: string): PasteResult {
 		this.#buffer += data;
 
 		const endIndex = this.#buffer.indexOf(PASTE_END);
-		if (endIndex === -1) return { handled: true, remaining: "" };
+		if (endIndex === -1) return this.#handled(normalText);
 
 		const pasteContent = this.#buffer.substring(0, endIndex);
 		const remaining = this.#buffer.substring(endIndex + PASTE_END.length);
@@ -42,6 +81,16 @@ export class BracketedPasteHandler {
 		this.#buffer = "";
 		this.#active = false;
 
-		return { handled: true, pasteContent, remaining };
+		return this.#handled(normalText, pasteContent, remaining);
+	}
+
+	#handled(normalText?: string, pasteContent?: string, remaining = ""): PasteResult {
+		const result: { handled: true; normalText?: string; pasteContent?: string; remaining: string } = {
+			handled: true,
+			remaining,
+		};
+		if (normalText !== undefined && normalText.length > 0) result.normalText = normalText;
+		if (pasteContent !== undefined) result.pasteContent = pasteContent;
+		return result;
 	}
 }

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1057,6 +1057,9 @@ export class Editor implements Component, Focusable {
 		// Handle bracketed paste mode
 		const paste = this.#pasteHandler.process(data);
 		if (paste.handled) {
+			if (paste.normalText !== undefined) {
+				this.#handleNormalInput(paste.normalText);
+			}
 			if (paste.pasteContent !== undefined) {
 				this.#handlePaste(paste.pasteContent);
 				if (paste.remaining.length > 0) {
@@ -1065,6 +1068,12 @@ export class Editor implements Component, Focusable {
 			}
 			return;
 		}
+
+		this.#handleNormalInput(data);
+	}
+
+	#handleNormalInput(data: string): void {
+		const kb = getKeybindings();
 
 		// Handle special key combinations first
 

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -66,6 +66,9 @@ export class Input implements Component, Focusable {
 		// Handle bracketed paste mode
 		const paste = this.#pasteHandler.process(data);
 		if (paste.handled) {
+			if (paste.normalText !== undefined) {
+				this.#handleNormalInput(paste.normalText);
+			}
 			if (paste.pasteContent !== undefined) {
 				this.#handlePaste(paste.pasteContent);
 				if (paste.remaining.length > 0) {
@@ -75,6 +78,10 @@ export class Input implements Component, Focusable {
 			return;
 		}
 
+		this.#handleNormalInput(data);
+	}
+
+	#handleNormalInput(data: string): void {
 		const kb = getKeybindings();
 
 		// Escape/Cancel

--- a/packages/tui/test/bracketed-paste.test.ts
+++ b/packages/tui/test/bracketed-paste.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { BracketedPasteHandler } from "@gajae-code/tui/bracketed-paste";
+
+describe("BracketedPasteHandler", () => {
+	it("keeps normal prefix outside paste when the start marker is split before tilde", () => {
+		const handler = new BracketedPasteHandler();
+
+		const first = handler.process("prefix\x1b[200");
+		const second = handler.process("~payload\x1b[201~");
+
+		expect(first).toEqual({ handled: true, normalText: "prefix", remaining: "" });
+		expect(second).toEqual({ handled: true, pasteContent: "payload", remaining: "" });
+	});
+
+	it("keeps normal prefix outside paste when a complete start marker shares the first chunk", () => {
+		const handler = new BracketedPasteHandler();
+
+		const first = handler.process("prefix\x1b[200~pay");
+		const second = handler.process("load\x1b[201~");
+
+		expect(first).toEqual({ handled: true, normalText: "prefix", remaining: "" });
+		expect(second).toEqual({ handled: true, pasteContent: "payload", remaining: "" });
+	});
+
+	it("replays false partial start markers as normal text", () => {
+		const handler = new BracketedPasteHandler();
+
+		const first = handler.process("prefix\x1b[20");
+		const second = handler.process("x");
+
+		expect(first).toEqual({ handled: true, normalText: "prefix", remaining: "" });
+		expect(second).toEqual({ handled: true, normalText: "\x1b[20x", remaining: "" });
+	});
+
+	it("does not hold a standalone escape key as a partial paste marker", () => {
+		const handler = new BracketedPasteHandler();
+
+		expect(handler.process("\x1b")).toEqual({ handled: false });
+	});
+});

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2050,6 +2050,26 @@ describe("Editor component", () => {
 			expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
 		});
 
+		it("keeps normal prefix outside paste when the bracketed start marker is split", () => {
+			const editor = new Editor(defaultEditorTheme);
+
+			editor.handleInput("prefix\x1b[200");
+			expect(editor.getText()).toBe("prefix");
+
+			editor.handleInput("~payload\x1b[201~");
+			expect(editor.getText()).toBe("prefixpayload");
+		});
+
+		it("keeps normal prefix outside paste when a complete start marker shares the first chunk", () => {
+			const editor = new Editor(defaultEditorTheme);
+
+			editor.handleInput("prefix\x1b[200~pay");
+			expect(editor.getText()).toBe("prefix");
+
+			editor.handleInput("load\x1b[201~");
+			expect(editor.getText()).toBe("prefixpayload");
+		});
+
 		it("removes a transient undo trigger even when there is no earlier edit to restore", () => {
 			const editor = new Editor(defaultEditorTheme);
 

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -182,6 +182,38 @@ describe("Input component", () => {
 		expect(input.getValue()).toBe(`a${" ".repeat(getIndentation())}bc`);
 	});
 
+	it("keeps normal prefix outside paste when the bracketed start marker is split", () => {
+		const input = setupAtEnd("");
+
+		input.handleInput("prefix\x1b[200");
+		expect(input.getValue()).toBe("prefix");
+
+		input.handleInput("~payload\x1b[201~");
+		expect(input.getValue()).toBe("prefixpayload");
+	});
+
+	it("keeps normal prefix outside paste when a complete start marker shares the first chunk", () => {
+		const input = setupAtEnd("");
+
+		input.handleInput("prefix\x1b[200~pay");
+		expect(input.getValue()).toBe("prefix");
+
+		input.handleInput("load\x1b[201~");
+		expect(input.getValue()).toBe("prefixpayload");
+	});
+
+	it("still treats standalone escape as cancel instead of paste buffering", () => {
+		const input = setupAtEnd("");
+		let didEscape = false;
+		input.onEscape = () => {
+			didEscape = true;
+		};
+
+		input.handleInput("\x1b");
+
+		expect(didEscape).toBe(true);
+	});
+
 	it("never renders a line wider than the terminal width (wide chars)", () => {
 		const input = new Input();
 		input.focused = true;


### PR DESCRIPTION
## Summary

Fresh follow-up to closed PR #1509. This keeps normal text before a bracketed paste start marker outside the paste payload, including the maintainer repros where the start marker is split across chunks or shares a chunk with prefix text.

Note: I first opened #1519 from the same fix branch, but that PR was closed and GitHub would not reopen it via API. This is the fresh replacement PR from a new fork branch.

## Root cause

`BracketedPasteHandler` only looked for a complete `\x1b[200~` in the current chunk. When normal text preceded the marker, the handler removed the marker and buffered the prefix as paste content. When the marker arrived as `\x1b[200` then `~...`, the first chunk was not retained as a pending paste start.

## Changes

- Teach `BracketedPasteHandler` to return `normalText` before paste starts, buffer partial start markers, and replay false partial starts as normal input.
- Route `normalText` through the normal input path in `Input`, `Editor`, and `CustomEditor` without duplicating paste state in consumers.
- Add focused parser and consumer tests for the two #1509 repro shapes.
- Guard standalone Escape so it still cancels normally instead of being held as a partial paste marker.

## Verification

- RED before fix: `work/evidence/bracketed-paste-pr/c001-red.txt`
- GREEN after fix: `PATH="$PWD/work/tools/node_modules/.bin:$PATH" bun test packages/tui/test/bracketed-paste.test.ts packages/tui/test/input.test.ts packages/tui/test/editor.test.ts packages/coding-agent/test/custom-editor-keybindings.test.ts --test-name-pattern "prefix|BracketedPasteHandler|bracketed paste|standalone escape"`
- Regression: `PATH="$PWD/work/tools/node_modules/.bin:$PATH" bun test packages/tui/test/bracketed-paste.test.ts packages/tui/test/input.test.ts packages/tui/test/editor.test.ts packages/coding-agent/test/custom-editor-keybindings.test.ts` => 174 pass
- Checks: `bun --cwd=packages/tui run check`; `bun --cwd=packages/coding-agent run check`
- Manual tmux QA: `work/evidence/bracketed-paste-pr/c003-tmux-transcript.txt` shows both split sequences produce `prefixpayload` with `pass:true`.

Environment note: this shell did not have `bun` on PATH, so I used Bun 1.3.14 installed under `work/tools` for verification and unpacked the published `@gajae-code/natives-darwin-arm64@0.7.11` test fixture locally because Rust was not installed for building natives.
