### PR TITLE
Polish composer spacing and queued-message editing

### DIFF
--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -299,15 +299,14 @@ export class ExtensionUiController {
 	}
 
 	#rebuildHookWidgets(): void {
-		this.#renderHookWidgetContainer(this.ctx.hookWidgetContainerAbove, this.#hookWidgetsAbove, true, true);
-		this.#renderHookWidgetContainer(this.ctx.hookWidgetContainerBelow, this.#hookWidgetsBelow, false, false);
+		this.#renderHookWidgetContainer(this.ctx.hookWidgetContainerAbove, this.#hookWidgetsAbove, true);
+		this.#renderHookWidgetContainer(this.ctx.hookWidgetContainerBelow, this.#hookWidgetsBelow, false);
 		this.ctx.ui.requestRender();
 	}
 
 	#renderHookWidgetContainer(
 		container: Container,
 		widgets: Map<string, ExtensionUiComponent>,
-		spacerWhenEmpty: boolean,
 		leadingSpacer: boolean,
 	): void {
 		// Detach (not dispose): hook widgets are persistent instances owned by the
@@ -317,9 +316,6 @@ export class ExtensionUiController {
 		container.detachAll();
 
 		if (widgets.size === 0) {
-			if (spacerWhenEmpty) {
-				container.addChild(new Spacer(1));
-			}
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -443,7 +443,6 @@ export class InteractiveMode implements InteractiveModeContext {
 			logger.warn("History storage unavailable", { error: String(error) });
 		}
 		this.hookWidgetContainerAbove = new Container();
-		this.hookWidgetContainerAbove.addChild(new Spacer(1));
 		this.hookWidgetContainerBelow = new Container();
 		this.editorContainer = new Container();
 		this.editorContainer.addChild(this.editor);

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -77,7 +77,8 @@ describe("InteractiveMode.setEditorComponent", () => {
 	});
 
 	function expectedQueueShortcutHint(): string {
-		return "Alt+Enter: Message Queueing";
+		const shortcut = process.platform === "win32" ? "Alt+q" : "Alt+Enter";
+		return `${shortcut}: Message Queueing`;
 	}
 
 	it("shows busy steering and queueing hints only while work is active", () => {
@@ -103,17 +104,27 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(rendered).not.toContain(expectedQueueShortcutHint());
 	});
 
-	it("renders one visible blank row above the composer without hook widgets", async () => {
+	it("renders the composer directly below the status line without hook widgets", async () => {
 		vi.spyOn(mode.ui, "start").mockImplementation(() => {});
 
 		await mode.init();
 
-		const rendered = mode.ui.render(48).map(stripRenderControls);
-		const composerContentIndex = rendered.findIndex(line => line.includes("Type your message..."));
-		const composerIndex = composerContentIndex - 1;
+		const assertComposerFollowsStatusLine = () => {
+			const rendered = mode.ui.render(48).map(stripRenderControls);
+			const composerContentIndex = rendered.findIndex(line => line.includes("Type your message..."));
+			const composerIndex = composerContentIndex - 1;
+			const statusRows = mode.statusLine.render(48).map(stripRenderControls);
 
-		expect(composerIndex).toBeGreaterThan(0);
-		expect(rendered[composerIndex - 1]).toBe("");
+			expect(composerIndex).toBeGreaterThan(0);
+			expect(rendered.slice(composerIndex - statusRows.length, composerIndex)).toEqual(statusRows);
+		};
+
+		assertComposerFollowsStatusLine();
+
+		mode.setHookWidget("test", ["temporary widget"]);
+		mode.setHookWidget("test", undefined);
+
+		assertComposerFollowsStatusLine();
 	});
 
 	it("keeps closed rounded composer chrome for one-line, multiline, and narrow prompts", () => {


### PR DESCRIPTION
Hello,

This PR polishes the interactive composer behavior in a few related places.

Changes:
- Removed the default blank row between the status line and the composer when no hook widgets are rendered.
- Stopped re-inserting an empty spacer when the above-editor hook widget container is rebuilt with no widgets.
- Leaves `Tab` available for editor autocomplete while the agent is busy, so selecting a slash-command autocomplete item no longer queues the current composer text.
- Keeps explicit queued-message submission on the configured queue shortcut instead of `Tab`.
- Changes `Alt+Up` dequeue/edit behavior so the restored queued message replaces the current composer draft instead of being prepended above it.
- Updated regression tests for composer spacing, Tab handling, dequeue editing, and Windows queue-key expectations.

Verification:
- `bun test packages/coding-agent/test/input-controller-keybindings.test.ts -t "leaves .*Tab|restores only"`
- `bun test packages/coding-agent/test/custom-editor-keybindings.test.ts`
- `bun test packages/coding-agent/test/interactive-mode-editor-component.test.ts -t "composer directly below"`
- `bun --cwd=packages/coding-agent run check:types`

Note: a full local run of `packages/coding-agent/test/input-controller-keybindings.test.ts` on this Windows machine still hits an existing unrelated clipboard-image-path expectation; the focused tests covering this PR pass.

Thank you for reviewing.