### PR TITLE
Polish composer behavior and session trail

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -144,24 +144,7 @@ export class WelcomeComponent implements Component {
 		const separator = buildSeparator(rightColumnWidth);
 		const changelogBudget = Math.max(1, Math.min(6, Math.floor((targetContentRows ?? 18) * 0.3)));
 
-		const sessionLines: string[] = [];
-		if (this.recentSessions.length === 0) {
-			sessionLines.push(` ${theme.fg("dim", "No saved trails")}`);
-		} else {
-			const bulletPrefix = ` ${theme.md.bullet} `;
-			const prefixWidth = visibleWidth(bulletPrefix);
-			for (const session of this.recentSessions.slice(0, 3)) {
-				const timeSuffixRaw = ` (${session.timeAgo})`;
-				const timeWidth = visibleWidth(timeSuffixRaw);
-				const nameBudget = Math.max(1, rightColumnWidth - prefixWidth - timeWidth);
-				const nameVis = visibleWidth(session.name);
-				const name = nameVis > nameBudget ? truncateToWidth(session.name, nameBudget) : session.name;
-				sessionLines.push(
-					`${theme.fg("dim", bulletPrefix)}${theme.fg("muted", name)}${theme.fg("dim", timeSuffixRaw)}`,
-				);
-			}
-		}
-
+		const changelogLines = this.#whatsNewLines(rightColumnWidth, changelogBudget);
 		const lspLines: string[] = [];
 		if (this.lspServers.length === 0) {
 			lspLines.push(` ${theme.fg("dim", "No LSP servers")}`);
@@ -178,10 +161,13 @@ export class WelcomeComponent implements Component {
 			}
 		}
 
+		const sessionLimit = this.#sessionTrailLimit(targetContentRows, changelogLines.length, lspLines.length);
+		const sessionLines = this.#sessionTrailLines(rightColumnWidth, sessionLimit);
+
 		const rightLines = [
 			"",
 			` ${theme.bold(theme.fg("accent", "What's New"))}`,
-			...this.#whatsNewLines(rightColumnWidth, changelogBudget),
+			...changelogLines,
 			separator,
 			` ${theme.bold(theme.fg("accent", "Flow keys"))}`,
 			` ${theme.fg("dim", "/")}${theme.fg("muted", " commands")} ${theme.fg("dim", "·")} ${theme.fg(
@@ -313,6 +299,40 @@ export class WelcomeComponent implements Component {
 		const topPad = align === "center" ? Math.floor(missingRows / 2) : 0;
 		const bottomPad = missingRows - topPad;
 		return [...Array.from({ length: topPad }, () => ""), ...clipped, ...Array.from({ length: bottomPad }, () => "")];
+	}
+
+	#sessionTrailLimit(targetContentRows: number | undefined, changelogLineCount: number, lspLineCount: number): number {
+		if (this.recentSessions.length === 0) return 0;
+
+		const defaultLimit = Math.min(3, this.recentSessions.length);
+		if (targetContentRows === undefined) return defaultLimit;
+
+		// Right-column rows that are always present when the session trail is shown:
+		// top/bottom padding, section headers, separators, and the four flow-key hints.
+		const fixedRightRowsExcludingDynamicSections = 13;
+		const rowsWithDefaultTrail =
+			fixedRightRowsExcludingDynamicSections + changelogLineCount + lspLineCount + defaultLimit;
+		const extraRows = Math.max(0, targetContentRows - rowsWithDefaultTrail);
+		return Math.min(this.recentSessions.length, defaultLimit + extraRows);
+	}
+
+	#sessionTrailLines(rightColumnWidth: number, limit: number): string[] {
+		if (this.recentSessions.length === 0) {
+			return [` ${theme.fg("dim", "No saved trails")}`];
+		}
+
+		const bulletPrefix = ` ${theme.md.bullet} `;
+		const prefixWidth = visibleWidth(bulletPrefix);
+		const lines: string[] = [];
+		for (const session of this.recentSessions.slice(0, limit)) {
+			const timeSuffixRaw = ` (${session.timeAgo})`;
+			const timeWidth = visibleWidth(timeSuffixRaw);
+			const nameBudget = Math.max(1, rightColumnWidth - prefixWidth - timeWidth);
+			const nameVis = visibleWidth(session.name);
+			const name = nameVis > nameBudget ? truncateToWidth(session.name, nameBudget) : session.name;
+			lines.push(`${theme.fg("dim", bulletPrefix)}${theme.fg("muted", name)}${theme.fg("dim", timeSuffixRaw)}`);
+		}
+		return lines;
 	}
 
 	#whatsNewLines(width: number, maxItems: number): string[] {

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -299,15 +299,14 @@ export class ExtensionUiController {
 	}
 
 	#rebuildHookWidgets(): void {
-		this.#renderHookWidgetContainer(this.ctx.hookWidgetContainerAbove, this.#hookWidgetsAbove, true, true);
-		this.#renderHookWidgetContainer(this.ctx.hookWidgetContainerBelow, this.#hookWidgetsBelow, false, false);
+		this.#renderHookWidgetContainer(this.ctx.hookWidgetContainerAbove, this.#hookWidgetsAbove, true);
+		this.#renderHookWidgetContainer(this.ctx.hookWidgetContainerBelow, this.#hookWidgetsBelow, false);
 		this.ctx.ui.requestRender();
 	}
 
 	#renderHookWidgetContainer(
 		container: Container,
 		widgets: Map<string, ExtensionUiComponent>,
-		spacerWhenEmpty: boolean,
 		leadingSpacer: boolean,
 	): void {
 		// Detach (not dispose): hook widgets are persistent instances owned by the
@@ -317,9 +316,6 @@ export class ExtensionUiController {
 		container.detachAll();
 
 		if (widgets.size === 0) {
-			if (spacerWhenEmpty) {
-				container.addChild(new Spacer(1));
-			}
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -313,14 +313,7 @@ export class InputController {
 		this.ctx.editor.onDequeue = () => this.handleDequeue();
 		this.ctx.editor.setActionKeys("app.message.queue", this.ctx.keybindings.getKeys("app.message.queue"));
 		this.ctx.editor.onQueue = () => void this.handleQueueSubmit();
-		this.ctx.editor.onTab = () => {
-			if (!this.ctx.session.isStreaming && !this.ctx.session.isCompacting) return false;
-			void this.handleQueueSubmit();
-			return true;
-		};
-		this.ctx.editor.onTabDeclined = () => {
-			if (this.ctx.session.isStreaming || this.ctx.session.isCompacting) void this.handleQueueSubmit();
-		};
+
 		this.ctx.editor.onViewportPageScroll = direction => this.ctx.ui.scrollViewportPages(direction);
 		this.ctx.editor.onViewportFollowLive = () => {
 			this.ctx.ui.followLiveViewport();
@@ -766,7 +759,7 @@ export class InputController {
 		return this.handleFollowUp();
 	}
 
-	restoreLatestQueuedMessageToEditor(options?: { currentText?: string }): number {
+	restoreLatestQueuedMessageToEditor(): number {
 		const compactionQueued = this.ctx.compactionQueuedMessages.pop();
 		const queuedText = compactionQueued?.text ?? this.ctx.session.popLastQueuedMessage();
 		if (!queuedText) {
@@ -775,9 +768,7 @@ export class InputController {
 		}
 
 		this.ctx.locallySubmittedUserSignatures.delete(`${queuedText}\u00000`);
-		const currentText = options?.currentText ?? this.ctx.editor.getText();
-		const combinedText = [queuedText, currentText].filter(t => t.trim()).join("\n\n");
-		this.ctx.editor.setText(combinedText);
+		this.ctx.editor.setText(queuedText);
 		this.ctx.updatePendingMessagesDisplay();
 		return 1;
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -443,7 +443,6 @@ export class InteractiveMode implements InteractiveModeContext {
 			logger.warn("History storage unavailable", { error: String(error) });
 		}
 		this.hookWidgetContainerAbove = new Container();
-		this.hookWidgetContainerAbove.addChild(new Spacer(1));
 		this.hookWidgetContainerBelow = new Container();
 		this.editorContainer = new Container();
 		this.editorContainer.addChild(this.editor);

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -1,11 +1,22 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { AutocompleteProvider } from "@gajae-code/tui";
 import { defaultEditorTheme } from "../../tui/test/test-themes";
-import { KEYBINDINGS } from "../src/config/keybindings";
+import { defaultMessageQueueKeysForPlatform, KEYBINDINGS } from "../src/config/keybindings";
 import { CustomEditor } from "../src/modes/components/custom-editor";
 
 function ctrl(key: string): string {
 	return String.fromCharCode(key.toLowerCase().charCodeAt(0) & 31);
+}
+
+function inputForKey(key: string): string {
+	switch (key) {
+		case "alt+q":
+			return "\x1bq";
+		case "alt+enter":
+			return "\x1b\r";
+		default:
+			throw new Error(`Unsupported test key: ${key}`);
+	}
 }
 
 function createEditor() {
@@ -95,7 +106,7 @@ describe("CustomEditor queue keybinding", () => {
 		const onQueue = vi.fn();
 		editor.onQueue = onQueue;
 
-		editor.handleInput("\x1b\r");
+		editor.handleInput(inputForKey(defaultMessageQueueKeysForPlatform()));
 
 		expect(onQueue).toHaveBeenCalledTimes(1);
 		expect(editor.getText()).toBe("");
@@ -105,6 +116,7 @@ describe("CustomEditor queue keybinding", () => {
 		const editor = createEditor();
 		const onQueue = vi.fn();
 		editor.onQueue = onQueue;
+		editor.setActionKeys("app.message.queue", ["alt+enter"]);
 
 		editor.handleInput("\x1b\n");
 

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -277,53 +277,38 @@ describe("InputController keybinding setup", () => {
 		});
 	});
 
-	it("queues streaming Tab before editor file completion can open", async () => {
+	it("leaves streaming Tab available for editor autocomplete", async () => {
 		const { InputController, ctx, editor, spies } = await createContext();
 		const session = ctx.session as unknown as { isStreaming: boolean };
 		session.isStreaming = true;
-		editor.setText("queue before file completion");
+		editor.setText("/mo");
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
-		expect(editor.onTab?.(editor.getText())).toBe(true);
 		await Bun.sleep(0);
 
-		expect(spies.prompt).toHaveBeenCalledWith("queue before file completion", {
-			streamingBehavior: "followUp",
-		});
-		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+		expect(editor.onTab).toBeUndefined();
+		expect(editor.onTabDeclined).toBeUndefined();
+		expect(spies.prompt).not.toHaveBeenCalled();
+		expect(spies.updatePendingMessagesDisplay).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("/mo");
 	});
-	it("queues compaction Tab before editor file completion can open", async () => {
+
+	it("leaves compaction Tab available for editor autocomplete", async () => {
 		const { InputController, ctx, editor, spies } = await createContext();
 		const session = ctx.session as unknown as { isCompacting: boolean };
 		session.isCompacting = true;
-		editor.setText("queue while compacting via tab");
+		editor.setText("/skill:team");
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
-		expect(editor.onTab?.(editor.getText())).toBe(true);
 		await Bun.sleep(0);
 
-		expect(spies.queueCompactionMessage).toHaveBeenCalledWith("queue while compacting via tab", "followUp");
+		expect(editor.onTab).toBeUndefined();
+		expect(editor.onTabDeclined).toBeUndefined();
+		expect(spies.queueCompactionMessage).not.toHaveBeenCalled();
 		expect(spies.prompt).not.toHaveBeenCalled();
-		expect(editor.getText()).toBe("");
-		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
-	});
-
-	it("keeps declined Tab completion as a fallback queue path while streaming", async () => {
-		const { InputController, ctx, editor, spies } = await createContext();
-		const session = ctx.session as unknown as { isStreaming: boolean };
-		session.isStreaming = true;
-		editor.setText("queue after declined tab completion");
-		const controller = new InputController(ctx);
-
-		controller.setupKeyHandlers();
-		editor.onTabDeclined?.(editor.getText());
-		await Bun.sleep(0);
-
-		expect(spies.prompt).toHaveBeenCalledWith("queue after declined tab completion", {
-			streamingBehavior: "followUp",
-		});
+		expect(editor.getText()).toBe("/skill:team");
 	});
 
 	it("queues explicit message action during compaction", async () => {
@@ -354,7 +339,7 @@ describe("InputController keybinding setup", () => {
 
 		controller.handleDequeue();
 
-		expect(editor.getText()).toBe("newest compaction queue\n\ncurrent draft");
+		expect(editor.getText()).toBe("newest compaction queue");
 		expect(queues.compactionQueuedMessages.map(entry => entry.text)).toEqual(["older compaction queue"]);
 		expect(spies.popLastQueuedMessage).not.toHaveBeenCalled();
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
@@ -368,7 +353,7 @@ describe("InputController keybinding setup", () => {
 
 		controller.handleDequeue();
 
-		expect(editor.getText()).toBe("newest session queue\n\ncurrent draft");
+		expect(editor.getText()).toBe("newest session queue");
 		expect(queues.sessionQueuedMessages).toEqual(["older session queue"]);
 		expect(spies.clearQueue).not.toHaveBeenCalled();
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -77,7 +77,8 @@ describe("InteractiveMode.setEditorComponent", () => {
 	});
 
 	function expectedQueueShortcutHint(): string {
-		return "Alt+Enter: Message Queueing";
+		const shortcut = process.platform === "win32" ? "Alt+q" : "Alt+Enter";
+		return `${shortcut}: Message Queueing`;
 	}
 
 	it("shows busy steering and queueing hints only while work is active", () => {
@@ -103,17 +104,27 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(rendered).not.toContain(expectedQueueShortcutHint());
 	});
 
-	it("renders one visible blank row above the composer without hook widgets", async () => {
+	it("renders the composer directly below the status line without hook widgets", async () => {
 		vi.spyOn(mode.ui, "start").mockImplementation(() => {});
 
 		await mode.init();
 
-		const rendered = mode.ui.render(48).map(stripRenderControls);
-		const composerContentIndex = rendered.findIndex(line => line.includes("Type your message..."));
-		const composerIndex = composerContentIndex - 1;
+		const assertComposerFollowsStatusLine = () => {
+			const rendered = mode.ui.render(48).map(stripRenderControls);
+			const composerContentIndex = rendered.findIndex(line => line.includes("Type your message..."));
+			const composerIndex = composerContentIndex - 1;
+			const statusRows = mode.statusLine.render(48).map(stripRenderControls);
 
-		expect(composerIndex).toBeGreaterThan(0);
-		expect(rendered[composerIndex - 1]).toBe("");
+			expect(composerIndex).toBeGreaterThan(0);
+			expect(rendered.slice(composerIndex - statusRows.length, composerIndex)).toEqual(statusRows);
+		};
+
+		assertComposerFollowsStatusLine();
+
+		mode.setHookWidget("test", ["temporary widget"]);
+		mode.setHookWidget("test", undefined);
+
+		assertComposerFollowsStatusLine();
 	});
 
 	it("keeps closed rounded composer chrome for one-line, multiline, and narrow prompts", () => {

--- a/packages/coding-agent/test/welcome-viewport.test.ts
+++ b/packages/coding-agent/test/welcome-viewport.test.ts
@@ -80,4 +80,26 @@ describe("WelcomeComponent viewport sizing", () => {
 		expect(lines).toHaveLength(1);
 		expect(visibleWidth(lines[0] ?? "")).toBeLessThanOrEqual(80);
 	});
+
+	it("expands the session trail when the viewport has spare rows", () => {
+		const recentSessions = Array.from({ length: 8 }, (_, index) => ({
+			name: `trail-session-${index + 1}`,
+			timeAgo: `${index + 1}m ago`,
+		}));
+		const compact = new WelcomeComponent("1.2.3", "test-model", "test-provider", recentSessions, [], "ascii", {
+			getViewportRows: () => 24,
+			getReservedBottomRows: () => 4,
+		});
+		const roomy = new WelcomeComponent("1.2.3", "test-model", "test-provider", recentSessions, [], "ascii", {
+			getViewportRows: () => 40,
+			getReservedBottomRows: () => 4,
+		});
+
+		const compactText = compact.render(100).join("\n");
+		const roomyText = roomy.render(100).join("\n");
+
+		expect(compactText).toContain("trail-session-3");
+		expect(compactText).not.toContain("trail-session-4");
+		expect(roomyText).toContain("trail-session-8");
+	});
 });


### PR DESCRIPTION
Hello,

This PR resubmits the earlier composer polish work against `dev` as requested, and includes one additional startup-screen improvement.

Changes:
- Removed the default blank row between the status line and the composer when no hook widgets are rendered.
- Stopped re-inserting an empty spacer when the above-editor hook widget container is rebuilt with no widgets.
- Leaves `Tab` available for editor autocomplete while the agent is busy, so selecting a slash-command autocomplete item no longer queues the current composer text.
- Keeps explicit queued-message submission on the configured queue shortcut instead of `Tab`.
- Changes `Alt+Up` dequeue/edit behavior so the restored queued message replaces the current composer draft instead of being prepended above it.
- Expands the startup splash `Session trail` dynamically when the viewport has spare rows instead of always capping visible sessions at three.
- Updated regression tests for composer spacing, Tab handling, dequeue editing, Windows queue-key expectations, and dynamic session-trail rendering.

Verification:
- `gjc contribute-pr --no-spawn --artifact-root /tmp/gajae-contribute-pr`
- `bun test packages/coding-agent/test/welcome-viewport.test.ts`
- `bun test packages/coding-agent/test/custom-editor-keybindings.test.ts`
- `bun test packages/coding-agent/test/input-controller-keybindings.test.ts -t "leaves .*Tab|restores only"`
- `bun test packages/coding-agent/test/interactive-mode-editor-component.test.ts -t "composer directly below"`
- `bun --cwd=packages/coding-agent run check:types`

Note: this supersedes the closed `main`-target PR #1523.

Thank you for reviewing.