### PR TITLE
feat(mcp): add gjc mcp import to copy MCP servers from other hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,15 @@ gjc setup defaults --check
 
 For standalone MCP support boundaries, see [`docs/standalone-mcp.md`](docs/standalone-mcp.md). For evaluating Aside as an opt-in search/context retrieval sidecar, see [`docs/aside-integration.md`](docs/aside-integration.md). For generic third-party bot setup and provider-independent smokes, see [`docs/bot-integration.md`](docs/bot-integration.md). For the readiness classification across RPC, ACP, and Bridge/HTTPS surfaces, see [`docs/external-control-readiness.md`](docs/external-control-readiness.md). For lower-level protocol details, see [`docs/hermes-mcp-bridge.md`](docs/hermes-mcp-bridge.md), [`docs/rpc.md`](docs/rpc.md), and [`docs/bridge.md`](docs/bridge.md).
 
+### Import MCP servers from another host
+
+```sh
+gjc mcp import claude
+gjc mcp import all --dry-run
+```
+
+`gjc mcp import <claude|codex|opencode|cursor|all>` copies MCP server definitions from another host's config into GJC's own config. This is a one-time migration, not live inheritance: once imported, GJC owns the runtime, auth, and lifecycle of those servers. Use `--dry-run` to preview, `--force` to overwrite collisions, and `--project` to write to `./.gjc/mcp.json`. Secret-indirection fields are never read, and output redacts secrets the same way `gjc mcp list` does.
+
 ## Configuration
 
 Provider retry budgets live in `~/.gjc/config.yml`:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `gjc mcp import <claude|codex|opencode|cursor|all>` copies MCP server definitions from another host's config into GJC's own config as a single collision-safe, dry-run-capable migration routed through the migrate planner (adding a cursor migrate adapter and an `only` filter to `runMigrate`). Importing never inherits live runtime and never reads secret-indirection fields, and a README subsection documents the workflow.
+
 ### Fixed
 
 - Goal completion now preserves the terminal `goal({op: "complete"})` state even when a `goal_updated` extension hook throws, preventing hook-side write errors from trapping a verified ultragoal run in the continuation loop.

--- a/packages/coding-agent/src/cli/mcp-cli.ts
+++ b/packages/coding-agent/src/cli/mcp-cli.ts
@@ -1,14 +1,27 @@
 /**
  * Direct MCP server registration CLI helpers.
  *
- * This surface only writes explicit user-provided server definitions to GJC's
- * own MCP config. It never imports or inherits live configs from other agents.
+ * This surface writes server definitions to GJC's own MCP config — either
+ * explicit user-provided ones (`add`) or copies imported from another host's
+ * config (`import`, a one-time migration). It never inherits live configs:
+ * once written, GJC owns runtime execution, auth, and lifecycle.
  */
 import { getMCPConfigPath, getProjectDir } from "@gajae-code/utils";
 import { getMCPServer, readMCPConfigFile, removeMCPServer, upsertMCPServer } from "../runtime-mcp/config-writer";
 import type { MCPConfigFile, MCPServerConfig } from "../runtime-mcp/types";
+import { runMigrateCommand } from "./migrate-cli";
 
-export type MCPAction = "add" | "list" | "remove";
+export type MCPAction = "add" | "list" | "remove" | "import";
+
+/** Friendly aliases for `gjc mcp import <source>`. */
+const IMPORT_SOURCE_ALIASES: Record<string, string> = {
+	claude: "claude-code",
+	"claude-code": "claude-code",
+	codex: "codex",
+	opencode: "opencode",
+	cursor: "cursor",
+	all: "all",
+};
 
 export interface MCPCommandArgs {
 	action: MCPAction;
@@ -18,6 +31,7 @@ export interface MCPCommandArgs {
 		project?: boolean;
 		force?: boolean;
 		json?: boolean;
+		dryRun?: boolean;
 		type?: "stdio" | "http" | "sse";
 		command?: string;
 		url?: string;
@@ -247,6 +261,38 @@ async function runRemove(args: MCPCommandArgs, scoped: ScopedPath): Promise<void
 	process.stdout.write(`${renderDetails(entry)}\n`);
 }
 
+async function runImport(args: MCPCommandArgs): Promise<void> {
+	const rawSource = args.name;
+	if (!rawSource) {
+		throw new MCPArgsError(
+			"`gjc mcp import` requires a source: claude-code (alias: claude), codex, opencode, cursor, or all.",
+		);
+	}
+	const resolved = IMPORT_SOURCE_ALIASES[rawSource.toLowerCase()];
+	if (!resolved) {
+		throw new MCPArgsError(
+			`Unknown import source "${rawSource}". Valid: claude-code (alias: claude), codex, opencode, cursor, all.`,
+		);
+	}
+
+	// Import is a one-time copy into GJC config via the migrate planner
+	// (collision-safe, dry-run capable, secrets never read). Runtime stays
+	// fully GJC-owned afterwards — no live dependency on the source host.
+	await runMigrateCommand({
+		from: [resolved],
+		project: args.flags.project ?? false,
+		force: args.flags.force ?? false,
+		dryRun: args.flags.dryRun ?? false,
+		json: args.flags.json ?? false,
+		only: "mcp",
+		cwd: args.cwd,
+	});
+
+	if (!args.flags.json && !args.flags.dryRun) {
+		process.stdout.write("\nImport complete. Use `gjc mcp list` to review.\n");
+	}
+}
+
 export async function runMCPCommand(args: MCPCommandArgs): Promise<void> {
 	const scoped = resolvePath(args);
 	try {
@@ -259,6 +305,9 @@ export async function runMCPCommand(args: MCPCommandArgs): Promise<void> {
 				return;
 			case "remove":
 				await runRemove(args, scoped);
+				return;
+			case "import":
+				await runImport(args);
 				return;
 		}
 	} catch (error) {

--- a/packages/coding-agent/src/cli/migrate-cli.ts
+++ b/packages/coding-agent/src/cli/migrate-cli.ts
@@ -23,6 +23,8 @@ export interface MigrateCommandArgs {
 	force: boolean;
 	dryRun: boolean;
 	json: boolean;
+	/** Restrict migration to one item type (e.g. `gjc mcp import` passes "mcp"). */
+	only?: "mcp" | "skill";
 	/** Test seam: override home dir for source discovery. */
 	homeDir?: string;
 	/** Test seam: override cwd for project-scope destinations. */
@@ -34,7 +36,9 @@ export class MigrateArgsError extends Error {}
 /** Expand `all`/repeated `--from`, validate, and return sources in canonical order. */
 export function resolveSources(from: string[]): MigrateSource[] {
 	if (from.length === 0) {
-		throw new MigrateArgsError("No source selected. Use --from <claude-code|codex|opencode|all> (repeatable).");
+		throw new MigrateArgsError(
+			"No source selected. Use --from <claude-code|codex|opencode|cursor|all> (repeatable).",
+		);
 	}
 	const selected = new Set<MigrateSource>();
 	for (const raw of from) {
@@ -64,10 +68,22 @@ export async function runMigrate(args: MigrateCommandArgs): Promise<MigrateRepor
 	const homeDir = args.homeDir ?? os.homedir();
 	const destinations = resolveDestinations(args.project, cwd);
 
-	const results: AdapterResult[] = [];
+	const collected: AdapterResult[] = [];
 	for (const source of sources) {
-		results.push(await getAdapter(source).collect({ homeDir }));
+		collected.push(await getAdapter(source).collect({ homeDir }));
 	}
+
+	// `only` narrows the migration to one item type: candidates and their
+	// per-type diagnostics for the other type are dropped before planning.
+	const results: AdapterResult[] =
+		args.only === undefined
+			? collected
+			: collected.map(result => ({
+					...result,
+					mcpCandidates: args.only === "mcp" ? result.mcpCandidates : [],
+					skillCandidates: args.only === "skill" ? result.skillCandidates : [],
+					diagnostics: result.diagnostics.filter(d => d.type === args.only || d.type === "source"),
+				}));
 
 	const { actions, warnings } = await planMigration({ results, destinations, force: args.force });
 	const finalActions = args.dryRun ? actions : await executeActions(actions);

--- a/packages/coding-agent/src/commands/mcp.ts
+++ b/packages/coding-agent/src/commands/mcp.ts
@@ -4,7 +4,7 @@
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { type MCPAction, type MCPCommandArgs, runMCPCommand } from "../cli/mcp-cli";
 
-const ACTIONS: MCPAction[] = ["add", "list", "remove"];
+const ACTIONS: MCPAction[] = ["add", "list", "remove", "import"];
 
 export default class MCP extends Command {
 	static description = "Register standalone MCP servers explicitly in GJC config";
@@ -13,6 +13,8 @@ export default class MCP extends Command {
 	static examples = [
 		"gjc mcp add context7 npx -y @upstash/context7-mcp",
 		"gjc mcp add docs --type http --url https://example.test/mcp --header Authorization=Bearer_TOKEN",
+		"gjc mcp import claude",
+		"gjc mcp import codex --dry-run",
 		"gjc mcp list --json",
 		"gjc mcp remove context7",
 	];
@@ -29,7 +31,8 @@ export default class MCP extends Command {
 
 	static flags = {
 		project: Flags.boolean({ description: "Write/read project scope (./.gjc/mcp.json) instead of user scope" }),
-		force: Flags.boolean({ description: "Overwrite an existing server during add", default: false }),
+		force: Flags.boolean({ description: "Overwrite an existing server during add/import", default: false }),
+		"dry-run": Flags.boolean({ description: "Preview an import without writing anything", default: false }),
 		json: Flags.boolean({
 			char: "j",
 			description: "Emit machine-readable JSON with sensitive values redacted",
@@ -67,6 +70,7 @@ export default class MCP extends Command {
 				project: flags.project,
 				force: flags.force,
 				json: flags.json,
+				dryRun: flags["dry-run"],
 				type: flags.type as MCPCommandArgs["flags"]["type"],
 				command: flags.command,
 				url: flags.url,
@@ -84,12 +88,14 @@ export default class MCP extends Command {
 		process.stdout.write(`Register standalone MCP servers explicitly in GJC config
 
 USAGE
-  $ gjc mcp [add|list|remove] [NAME] [COMMAND_OR_URL] [ARGS...] [FLAGS]
+  $ gjc mcp [add|list|remove|import] [NAME] [COMMAND_OR_URL] [ARGS...] [FLAGS]
 
 COMMANDS
   add     Add an explicit user-provided MCP server definition
   list    List registered servers with env/header/auth values redacted
   remove  Remove a registered server and print the removed definition redacted
+  import  Copy MCP servers from another host into GJC config:
+          gjc mcp import <claude|codex|opencode|cursor|all> [--dry-run] [--force] [--project]
 
 FLAGS
       --project          Use project scope (./.gjc/mcp.json) instead of user scope
@@ -107,11 +113,13 @@ FLAGS
 EXAMPLES
   $ gjc mcp add context7 npx -y @upstash/context7-mcp
   $ gjc mcp add docs --type http --url https://example.test/mcp --header Authorization=Bearer_TOKEN
+  $ gjc mcp import claude
+  $ gjc mcp import codex --dry-run
   $ gjc mcp list --json
   $ gjc mcp remove context7
 
 SECURITY
-  This command writes only the server definition supplied on this invocation. It does not import or inherit Claude Code, Codex, OpenCode, or other live MCP configs. Public output redacts env, header, auth, and OAuth credential values.
+  \`add\` writes only the server definition supplied on this invocation. \`import\` copies definitions from another host's config exactly once — GJC never inherits live MCP runtime from Claude Code, Codex, OpenCode, or Cursor, and secret-indirection fields are omitted rather than read. Public output redacts env, header, auth, and OAuth credential values.
 `);
 	}
 }

--- a/packages/coding-agent/src/commands/migrate.ts
+++ b/packages/coding-agent/src/commands/migrate.ts
@@ -5,7 +5,7 @@ import { Command, Flags } from "@gajae-code/utils/cli";
 import { type MigrateCommandArgs, runMigrateCommand } from "../cli/migrate-cli";
 
 export default class Migrate extends Command {
-	static description = "Import MCP servers and skills from Claude Code, Codex, or OpenCode";
+	static description = "Import MCP servers and skills from Claude Code, Codex, OpenCode, or Cursor";
 
 	static examples = [
 		"gjc migrate --from claude-code",
@@ -16,7 +16,7 @@ export default class Migrate extends Command {
 
 	static flags = {
 		from: Flags.string({
-			description: "Source agent to import from (repeatable): claude-code | codex | opencode | all",
+			description: "Source agent to import from (repeatable): claude-code | codex | opencode | cursor | all",
 			multiple: true,
 			required: true,
 		}),

--- a/packages/coding-agent/src/migrate/adapters/cursor.ts
+++ b/packages/coding-agent/src/migrate/adapters/cursor.ts
@@ -1,0 +1,41 @@
+/**
+ * Cursor adapter: reads `~/.cursor/mcp.json` (mcpServers).
+ *
+ * Cursor has no home-level skill/prompt store, so only MCP candidates are
+ * produced. Project `.cursor/mcp.json` is out of scope by the adapter contract
+ * (home-only, see adapters/index.ts).
+ */
+import * as path from "node:path";
+import type { AdapterResult, McpCandidate } from "../types";
+import { type Adapter, type AdapterOptions, parseSourceJson, readSourceText } from "./index";
+
+const SOURCE = "cursor" as const;
+
+export const cursorAdapter: Adapter = {
+	source: SOURCE,
+	async collect({ homeDir }: AdapterOptions): Promise<AdapterResult> {
+		const result: AdapterResult = { mcpCandidates: [], skillCandidates: [], diagnostics: [] };
+
+		const configPath = path.join(homeDir, ".cursor", "mcp.json");
+		const read = await readSourceText(configPath, SOURCE, "mcp");
+		if ("diagnostic" in read) {
+			result.diagnostics.push(read.diagnostic);
+			return result;
+		}
+
+		const parsed = parseSourceJson(read.text, configPath, SOURCE, "mcp");
+		if ("diagnostic" in parsed) {
+			result.diagnostics.push(parsed.diagnostic);
+			return result;
+		}
+
+		const servers = parsed.data.mcpServers;
+		if (servers && typeof servers === "object" && !Array.isArray(servers)) {
+			for (const [name, raw] of Object.entries(servers as Record<string, unknown>)) {
+				result.mcpCandidates.push({ source: SOURCE, name, raw } satisfies McpCandidate);
+			}
+		}
+
+		return result;
+	},
+};

--- a/packages/coding-agent/src/migrate/adapters/index.ts
+++ b/packages/coding-agent/src/migrate/adapters/index.ts
@@ -11,6 +11,7 @@ import { normalizeSkill } from "../skill-normalizer";
 import type { AdapterResult, MigrateSource, SkillCandidate, SourceDiagnostic } from "../types";
 import { claudeCodeAdapter } from "./claude-code";
 import { codexAdapter } from "./codex";
+import { cursorAdapter } from "./cursor";
 import { opencodeAdapter } from "./opencode";
 
 export interface AdapterOptions {
@@ -27,6 +28,7 @@ const ADAPTERS: Record<MigrateSource, Adapter> = {
 	"claude-code": claudeCodeAdapter,
 	codex: codexAdapter,
 	opencode: opencodeAdapter,
+	cursor: cursorAdapter,
 };
 
 export function getAdapter(source: MigrateSource): Adapter {

--- a/packages/coding-agent/src/migrate/mcp-mapper.ts
+++ b/packages/coding-agent/src/migrate/mcp-mapper.ts
@@ -34,6 +34,7 @@ const SECRET_INDIRECTION_FIELDS: Record<MigrateSource, string[]> = {
 	"claude-code": [],
 	codex: ["env_vars", "env_http_headers", "bearer_token_env_var"],
 	opencode: [],
+	cursor: [],
 };
 
 /** Fields recognized for a source (handled or intentionally omitted). Anything else is omitted-with-warning. */
@@ -59,6 +60,8 @@ const RECOGNIZED_FIELDS: Record<MigrateSource, ReadonlySet<string>> = {
 		"disabled_tools",
 	]),
 	opencode: new Set(["type", "command", "args", "env", "url", "headers", "enabled", "timeout", "cwd"]),
+	// Cursor's ~/.cursor/mcp.json uses the standard mcpServers shape.
+	cursor: new Set(["type", "command", "args", "env", "url", "headers", "enabled", "timeout", "cwd"]),
 };
 
 /** Fields with no GJC equivalent: omitted-with-warning (named explicitly so the warning is precise). */
@@ -66,6 +69,7 @@ const OMITTED_FIELDS: Record<MigrateSource, string[]> = {
 	"claude-code": [],
 	codex: ["startup_timeout_sec", "enabled_tools", "disabled_tools"],
 	opencode: [],
+	cursor: [],
 };
 
 export function mapMcpEntry(source: MigrateSource, name: string, raw: unknown): McpMapOutcome {

--- a/packages/coding-agent/src/migrate/types.ts
+++ b/packages/coding-agent/src/migrate/types.ts
@@ -8,9 +8,9 @@
 import type { MCPServerConfig } from "../runtime-mcp/types";
 
 /** Supported migration sources. */
-export type MigrateSource = "claude-code" | "codex" | "opencode";
+export type MigrateSource = "claude-code" | "codex" | "opencode" | "cursor";
 
-export const MIGRATE_SOURCES: readonly MigrateSource[] = ["claude-code", "codex", "opencode"];
+export const MIGRATE_SOURCES: readonly MigrateSource[] = ["claude-code", "codex", "opencode", "cursor"];
 
 /** Canonical, deterministic ordering used when expanding `--from all` / repeated `--from`. */
 export const CANONICAL_SOURCE_ORDER: readonly MigrateSource[] = MIGRATE_SOURCES;

--- a/packages/coding-agent/test/migrate-adapters.test.ts
+++ b/packages/coding-agent/test/migrate-adapters.test.ts
@@ -67,6 +67,36 @@ describe("codex adapter", () => {
 	});
 });
 
+describe("cursor adapter", () => {
+	test("absent config yields skipped_absent_source diagnostics, no candidates", async () => {
+		const result = await getAdapter("cursor").collect({ homeDir: home });
+		expect(result.mcpCandidates).toHaveLength(0);
+		expect(result.skillCandidates).toHaveLength(0);
+		expect(result.diagnostics.every(d => d.status === "skipped_absent_source")).toBe(true);
+	});
+
+	test("reads mcpServers from ~/.cursor/mcp.json", async () => {
+		await writeFile(
+			".cursor/mcp.json",
+			JSON.stringify({
+				mcpServers: { srv: { command: "bin", args: ["--x"] }, docs: { url: "https://d.test/mcp" } },
+			}),
+		);
+		const result = await getAdapter("cursor").collect({ homeDir: home });
+		expect(result.mcpCandidates).toEqual([
+			{ source: "cursor", name: "srv", raw: { command: "bin", args: ["--x"] } },
+			{ source: "cursor", name: "docs", raw: { url: "https://d.test/mcp" } },
+		]);
+		expect(result.skillCandidates).toHaveLength(0);
+	});
+
+	test("malformed mcp config yields failed_invalid_source", async () => {
+		await writeFile(".cursor/mcp.json", "{ not json");
+		const result = await getAdapter("cursor").collect({ homeDir: home });
+		expect(result.diagnostics.some(d => d.status === "failed_invalid_source")).toBe(true);
+	});
+});
+
 describe("opencode adapter", () => {
 	test("reads mcp, skills, and command conversions", async () => {
 		await writeFile(

--- a/packages/coding-agent/test/migrate-cli.test.ts
+++ b/packages/coding-agent/test/migrate-cli.test.ts
@@ -37,7 +37,7 @@ afterEach(async () => {
 
 describe("resolveSources", () => {
 	test("expands all", () => {
-		expect(resolveSources(["all"])).toEqual(["claude-code", "codex", "opencode"]);
+		expect(resolveSources(["all"])).toEqual(["claude-code", "codex", "opencode", "cursor"]);
 	});
 	test("dedupes and returns canonical order regardless of input order", () => {
 		expect(resolveSources(["opencode", "claude-code", "opencode"])).toEqual(["claude-code", "opencode"]);
@@ -65,6 +65,22 @@ describe("runMigrate", () => {
 		expect(report.actions.length).toBeGreaterThan(0);
 		expect(await exists(path.join(cwd, ".gjc", "mcp.json"))).toBe(false);
 		expect(await exists(path.join(cwd, ".gjc", "skills"))).toBe(false);
+	});
+
+	test("only: 'mcp' plans MCP imports and drops skill candidates entirely", async () => {
+		const report = await runMigrate({
+			from: ["claude-code"],
+			project: true,
+			force: false,
+			dryRun: true,
+			json: true,
+			only: "mcp",
+			homeDir: home,
+			cwd,
+		});
+		expect(report.actions.some(a => a.type === "mcp" && a.status === "imported")).toBe(true);
+		expect(report.actions.some(a => a.type === "skill")).toBe(false);
+		expect(report.warnings.every(w => w.type !== "skill")).toBe(true);
 	});
 
 	test("--json report carries taxonomy counts by total/type/source", async () => {


### PR DESCRIPTION
## What

`gjc mcp import <claude|codex|opencode|cursor|all>` copies MCP server definitions from another host's config into GJC's own config. It routes through the existing migrate planner as an MCP-only, collision-safe migration: `--dry-run` previews without writing, `--force` overwrites collisions, and `--project` targets `./.gjc/mcp.json`. This adds a Cursor migrate adapter and an `only` filter to `runMigrate` so the import path reuses the planner without touching skills/settings, and documents the workflow in a README subsection. Import is a one-time copy — GJC owns runtime, auth, and lifecycle afterwards — and secret-indirection fields are omitted rather than read (output redacts secrets the same way `gjc mcp list` does).

## Why

Part 4 of the MCP series; #1489/#1490 are merged, and this PR is file- and compile-independent of the pending #1522 — it lands the one-time import path (`gjc mcp import <claude|codex|opencode|cursor|all>`, dry-run capable, collision-safe, secrets never read) on its own. Once #1522 lands, imported servers also connect at session startup.

## Testing

- Pinned biome 2.5.1 `biome check` on the changed files: clean, no fixes.
- `bun run --cwd packages/coding-agent check` (biome across 1874 files + `tsgo` typecheck): clean.
- Clean-env `bun test` (fresh `HOME` / `GJC_CODING_AGENT_DIR` tmp dir): `migrate-adapters`, `migrate-cli`, `migrate-action-planner`, `migrate-schema-matrix`, `mcp-cli`, `migrate-import` — **67 pass / 0 fail** across 6 files.
- Fork-CI probe on a `dev`-synced base — all 14 checks green, including `check:@gajae-code/coding-agent`, `cli-smoke`, `native-build`, and the `mcp-cli` / `migrate-adapters` / `migrate-cli` test shards: https://github.com/mpfo0106/gajae-code/actions/runs/28698649523

Supersedes closed #1492 with a fresh dev-based branch.
