### PR TITLE
feat(mcp): suggest gjc mcp import when no servers are configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ gjc mcp import all --dry-run
 
 `gjc mcp import <claude|codex|opencode|cursor|all>` copies MCP server definitions from another host's config into GJC's own config. This is a one-time migration, not live inheritance: once imported, GJC owns the runtime, auth, and lifecycle of those servers. Use `--dry-run` to preview, `--force` to overwrite collisions, and `--project` to write to `./.gjc/mcp.json`. Secret-indirection fields are never read, and output redacts secrets the same way `gjc mcp list` does.
 
+Imported servers connect automatically at session startup. To keep one configured without auto-connecting, run `gjc mcp autoload <name> off`, then use `/mcp connect <name>` to connect it on demand within a session.
+
 ## Configuration
 
 Provider retry budgets live in `~/.gjc/config.yml`:

--- a/README.md
+++ b/README.md
@@ -227,6 +227,15 @@ gjc setup defaults --check
 
 For standalone MCP support boundaries, see [`docs/standalone-mcp.md`](docs/standalone-mcp.md). For evaluating Aside as an opt-in search/context retrieval sidecar, see [`docs/aside-integration.md`](docs/aside-integration.md). For generic third-party bot setup and provider-independent smokes, see [`docs/bot-integration.md`](docs/bot-integration.md). For the readiness classification across RPC, ACP, and Bridge/HTTPS surfaces, see [`docs/external-control-readiness.md`](docs/external-control-readiness.md). For lower-level protocol details, see [`docs/hermes-mcp-bridge.md`](docs/hermes-mcp-bridge.md), [`docs/rpc.md`](docs/rpc.md), and [`docs/bridge.md`](docs/bridge.md).
 
+### Import MCP servers from another host
+
+```sh
+gjc mcp import claude
+gjc mcp import all --dry-run
+```
+
+`gjc mcp import <claude|codex|opencode|cursor|all>` copies MCP server definitions from another host's config into GJC's own config. This is a one-time migration, not live inheritance: once imported, GJC owns the runtime, auth, and lifecycle of those servers. Use `--dry-run` to preview, `--force` to overwrite collisions, and `--project` to write to `./.gjc/mcp.json`. Secret-indirection fields are never read, and output redacts secrets the same way `gjc mcp list` does.
+
 ## Configuration
 
 Provider retry budgets live in `~/.gjc/config.yml`:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `gjc mcp import <claude|codex|opencode|cursor|all>` copies MCP server definitions from another host's config into GJC's own config as a single collision-safe, dry-run-capable migration routed through the migrate planner (adding a cursor migrate adapter and an `only` filter to `runMigrate`). Importing never inherits live runtime and never reads secret-indirection fields, and a README subsection documents the workflow.
+
 ### Fixed
 
 - Goal completion now preserves the terminal `goal({op: "complete"})` state even when a `goal_updated` extension hook throws, preventing hook-side write errors from trapping a verified ultragoal run in the continuation loop.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `gjc mcp import <claude|codex|opencode|cursor|all>` copies MCP server definitions from another host's config into GJC's own config as a single collision-safe, dry-run-capable migration routed through the migrate planner (adding a cursor migrate adapter and an `only` filter to `runMigrate`). Importing never inherits live runtime and never reads secret-indirection fields, and a README subsection documents the workflow.
+- Adds MCP autoload and connect management surfaces: `gjc mcp autoload <name> on|off` toggles whether a configured server connects at session startup, `/mcp connect|disconnect|autoload` are handled in both the interactive TUI controller and the ACP slash-command handlers, and `gjc mcp list` now reports configured/connected/autoload state per server. This completes the on-demand connect workflow that the import command's help and README point to.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `gjc mcp import <claude|codex|opencode|cursor|all>` copies MCP server definitions from another host's config into GJC's own config as a single collision-safe, dry-run-capable migration routed through the migrate planner (adding a cursor migrate adapter and an `only` filter to `runMigrate`). Importing never inherits live runtime and never reads secret-indirection fields, and a README subsection documents the workflow.
 - Adds MCP autoload and connect management surfaces: `gjc mcp autoload <name> on|off` toggles whether a configured server connects at session startup, `/mcp connect|disconnect|autoload` are handled in both the interactive TUI controller and the ACP slash-command handlers, and `gjc mcp list` now reports configured/connected/autoload state per server. This completes the on-demand connect workflow that the import command's help and README point to.
+- When no MCP servers are configured, the empty-list output across the CLI (`gjc mcp list`), the ACP slash command, and the interactive controller now probes other hosts' configs and prints a one-line `gjc mcp import <source>` tip naming a host that has servers to copy. The probe never throws, never slows the command down, and leaves JSON output unchanged.
 
 ### Fixed
 

--- a/packages/coding-agent/src/cli/mcp-cli.ts
+++ b/packages/coding-agent/src/cli/mcp-cli.ts
@@ -7,11 +7,17 @@
  * once written, GJC owns runtime execution, auth, and lifecycle.
  */
 import { getMCPConfigPath, getProjectDir } from "@gajae-code/utils";
-import { getMCPServer, readMCPConfigFile, removeMCPServer, upsertMCPServer } from "../runtime-mcp/config-writer";
+import {
+	getMCPServer,
+	readMCPConfigFile,
+	removeMCPServer,
+	setServerAutoload,
+	upsertMCPServer,
+} from "../runtime-mcp/config-writer";
 import type { MCPConfigFile, MCPServerConfig } from "../runtime-mcp/types";
 import { runMigrateCommand } from "./migrate-cli";
 
-export type MCPAction = "add" | "list" | "remove" | "import";
+export type MCPAction = "add" | "list" | "remove" | "autoload" | "import";
 
 /** Friendly aliases for `gjc mcp import <source>`. */
 const IMPORT_SOURCE_ALIASES: Record<string, string> = {
@@ -185,11 +191,12 @@ function writeJson(value: unknown): void {
 
 function renderServerLine(entry: RedactedServerEntry): string {
 	const config = entry.config;
+	const autoload = config.autoload === false ? "\tautoload:off" : "";
 	if (config.type === "http" || config.type === "sse") {
-		return `${entry.name}\t${config.type}\t${config.url}`;
+		return `${entry.name}\t${config.type}\t${config.url}${autoload}`;
 	}
 	const args = config.args && config.args.length > 0 ? ` ${config.args.join(" ")}` : "";
-	return `${entry.name}\tstdio\t${config.command}${args}`;
+	return `${entry.name}\tstdio\t${config.command}${args}${autoload}`;
 }
 
 function renderDetails(entry: RedactedServerEntry): string {
@@ -289,8 +296,40 @@ async function runImport(args: MCPCommandArgs): Promise<void> {
 	});
 
 	if (!args.flags.json && !args.flags.dryRun) {
-		process.stdout.write("\nImport complete. Use `gjc mcp list` to review.\n");
+		process.stdout.write(
+			"\nImported servers connect at session startup. Use `gjc mcp autoload <name> off` to keep one configured without auto-connecting, and `gjc mcp list` to review.\n",
+		);
 	}
+}
+
+async function runAutoload(args: MCPCommandArgs, scoped: ScopedPath): Promise<void> {
+	if (!args.name) throw new MCPArgsError("`gjc mcp autoload` requires a server name.");
+	const value = args.commandArgs?.[0]?.toLowerCase();
+	if (value !== "on" && value !== "off") {
+		throw new MCPArgsError("`gjc mcp autoload <name> on|off` requires an on/off value.");
+	}
+	const existing = await getMCPServer(scoped.path, args.name);
+	if (!existing) {
+		throw new MCPArgsError(`MCP server "${args.name}" not found in ${scoped.scope} config.`);
+	}
+	const autoload = value === "on";
+	await setServerAutoload(scoped.path, args.name, autoload);
+	if (args.flags.json) {
+		writeJson({
+			action: "autoload",
+			status: "updated",
+			name: args.name,
+			scope: scoped.scope,
+			path: scoped.path,
+			autoload,
+		});
+		return;
+	}
+	process.stdout.write(
+		autoload
+			? `Autoload enabled for "${args.name}" in ${scoped.scope} config — it connects at session startup.\n`
+			: `Autoload disabled for "${args.name}" in ${scoped.scope} config — connect it on demand with /mcp connect ${args.name}.\n`,
+	);
 }
 
 export async function runMCPCommand(args: MCPCommandArgs): Promise<void> {
@@ -305,6 +344,9 @@ export async function runMCPCommand(args: MCPCommandArgs): Promise<void> {
 				return;
 			case "remove":
 				await runRemove(args, scoped);
+				return;
+			case "autoload":
+				await runAutoload(args, scoped);
 				return;
 			case "import":
 				await runImport(args);

--- a/packages/coding-agent/src/cli/mcp-cli.ts
+++ b/packages/coding-agent/src/cli/mcp-cli.ts
@@ -1,14 +1,27 @@
 /**
  * Direct MCP server registration CLI helpers.
  *
- * This surface only writes explicit user-provided server definitions to GJC's
- * own MCP config. It never imports or inherits live configs from other agents.
+ * This surface writes server definitions to GJC's own MCP config — either
+ * explicit user-provided ones (`add`) or copies imported from another host's
+ * config (`import`, a one-time migration). It never inherits live configs:
+ * once written, GJC owns runtime execution, auth, and lifecycle.
  */
 import { getMCPConfigPath, getProjectDir } from "@gajae-code/utils";
 import { getMCPServer, readMCPConfigFile, removeMCPServer, upsertMCPServer } from "../runtime-mcp/config-writer";
 import type { MCPConfigFile, MCPServerConfig } from "../runtime-mcp/types";
+import { runMigrateCommand } from "./migrate-cli";
 
-export type MCPAction = "add" | "list" | "remove";
+export type MCPAction = "add" | "list" | "remove" | "import";
+
+/** Friendly aliases for `gjc mcp import <source>`. */
+const IMPORT_SOURCE_ALIASES: Record<string, string> = {
+	claude: "claude-code",
+	"claude-code": "claude-code",
+	codex: "codex",
+	opencode: "opencode",
+	cursor: "cursor",
+	all: "all",
+};
 
 export interface MCPCommandArgs {
 	action: MCPAction;
@@ -18,6 +31,7 @@ export interface MCPCommandArgs {
 		project?: boolean;
 		force?: boolean;
 		json?: boolean;
+		dryRun?: boolean;
 		type?: "stdio" | "http" | "sse";
 		command?: string;
 		url?: string;
@@ -247,6 +261,38 @@ async function runRemove(args: MCPCommandArgs, scoped: ScopedPath): Promise<void
 	process.stdout.write(`${renderDetails(entry)}\n`);
 }
 
+async function runImport(args: MCPCommandArgs): Promise<void> {
+	const rawSource = args.name;
+	if (!rawSource) {
+		throw new MCPArgsError(
+			"`gjc mcp import` requires a source: claude-code (alias: claude), codex, opencode, cursor, or all.",
+		);
+	}
+	const resolved = IMPORT_SOURCE_ALIASES[rawSource.toLowerCase()];
+	if (!resolved) {
+		throw new MCPArgsError(
+			`Unknown import source "${rawSource}". Valid: claude-code (alias: claude), codex, opencode, cursor, all.`,
+		);
+	}
+
+	// Import is a one-time copy into GJC config via the migrate planner
+	// (collision-safe, dry-run capable, secrets never read). Runtime stays
+	// fully GJC-owned afterwards — no live dependency on the source host.
+	await runMigrateCommand({
+		from: [resolved],
+		project: args.flags.project ?? false,
+		force: args.flags.force ?? false,
+		dryRun: args.flags.dryRun ?? false,
+		json: args.flags.json ?? false,
+		only: "mcp",
+		cwd: args.cwd,
+	});
+
+	if (!args.flags.json && !args.flags.dryRun) {
+		process.stdout.write("\nImport complete. Use `gjc mcp list` to review.\n");
+	}
+}
+
 export async function runMCPCommand(args: MCPCommandArgs): Promise<void> {
 	const scoped = resolvePath(args);
 	try {
@@ -259,6 +305,9 @@ export async function runMCPCommand(args: MCPCommandArgs): Promise<void> {
 				return;
 			case "remove":
 				await runRemove(args, scoped);
+				return;
+			case "import":
+				await runImport(args);
 				return;
 		}
 	} catch (error) {

--- a/packages/coding-agent/src/cli/mcp-cli.ts
+++ b/packages/coding-agent/src/cli/mcp-cli.ts
@@ -7,6 +7,7 @@
  * once written, GJC owns runtime execution, auth, and lifecycle.
  */
 import { getMCPConfigPath, getProjectDir } from "@gajae-code/utils";
+import { detectImportableMcpSources, formatImportHintLine } from "../migrate/import-hint";
 import {
 	getMCPServer,
 	readMCPConfigFile,
@@ -48,6 +49,8 @@ export interface MCPCommandArgs {
 		timeout?: number;
 	};
 	cwd?: string;
+	/** Test seam: override home dir for the empty-list import hint. */
+	homeDir?: string;
 }
 
 export class MCPArgsError extends Error {}
@@ -237,6 +240,10 @@ async function runList(args: MCPCommandArgs, scoped: ScopedPath): Promise<void> 
 	}
 	if (entries.length === 0) {
 		process.stdout.write(`No MCP servers registered in ${scoped.scope} config: ${scoped.path}\n`);
+		const importable = await detectImportableMcpSources(args.homeDir);
+		for (const source of importable) {
+			process.stdout.write(`${formatImportHintLine(source)}\n`);
+		}
 		return;
 	}
 	process.stdout.write(`MCP servers in ${scoped.scope} config: ${scoped.path}\n`);

--- a/packages/coding-agent/src/cli/migrate-cli.ts
+++ b/packages/coding-agent/src/cli/migrate-cli.ts
@@ -23,6 +23,8 @@ export interface MigrateCommandArgs {
 	force: boolean;
 	dryRun: boolean;
 	json: boolean;
+	/** Restrict migration to one item type (e.g. `gjc mcp import` passes "mcp"). */
+	only?: "mcp" | "skill";
 	/** Test seam: override home dir for source discovery. */
 	homeDir?: string;
 	/** Test seam: override cwd for project-scope destinations. */
@@ -34,7 +36,9 @@ export class MigrateArgsError extends Error {}
 /** Expand `all`/repeated `--from`, validate, and return sources in canonical order. */
 export function resolveSources(from: string[]): MigrateSource[] {
 	if (from.length === 0) {
-		throw new MigrateArgsError("No source selected. Use --from <claude-code|codex|opencode|all> (repeatable).");
+		throw new MigrateArgsError(
+			"No source selected. Use --from <claude-code|codex|opencode|cursor|all> (repeatable).",
+		);
 	}
 	const selected = new Set<MigrateSource>();
 	for (const raw of from) {
@@ -64,10 +68,22 @@ export async function runMigrate(args: MigrateCommandArgs): Promise<MigrateRepor
 	const homeDir = args.homeDir ?? os.homedir();
 	const destinations = resolveDestinations(args.project, cwd);
 
-	const results: AdapterResult[] = [];
+	const collected: AdapterResult[] = [];
 	for (const source of sources) {
-		results.push(await getAdapter(source).collect({ homeDir }));
+		collected.push(await getAdapter(source).collect({ homeDir }));
 	}
+
+	// `only` narrows the migration to one item type: candidates and their
+	// per-type diagnostics for the other type are dropped before planning.
+	const results: AdapterResult[] =
+		args.only === undefined
+			? collected
+			: collected.map(result => ({
+					...result,
+					mcpCandidates: args.only === "mcp" ? result.mcpCandidates : [],
+					skillCandidates: args.only === "skill" ? result.skillCandidates : [],
+					diagnostics: result.diagnostics.filter(d => d.type === args.only || d.type === "source"),
+				}));
 
 	const { actions, warnings } = await planMigration({ results, destinations, force: args.force });
 	const finalActions = args.dryRun ? actions : await executeActions(actions);

--- a/packages/coding-agent/src/commands/mcp.ts
+++ b/packages/coding-agent/src/commands/mcp.ts
@@ -4,7 +4,7 @@
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { type MCPAction, type MCPCommandArgs, runMCPCommand } from "../cli/mcp-cli";
 
-const ACTIONS: MCPAction[] = ["add", "list", "remove", "import"];
+const ACTIONS: MCPAction[] = ["add", "list", "remove", "autoload", "import"];
 
 export default class MCP extends Command {
 	static description = "Register standalone MCP servers explicitly in GJC config";
@@ -15,6 +15,7 @@ export default class MCP extends Command {
 		"gjc mcp add docs --type http --url https://example.test/mcp --header Authorization=Bearer_TOKEN",
 		"gjc mcp import claude",
 		"gjc mcp import codex --dry-run",
+		"gjc mcp autoload context7 off",
 		"gjc mcp list --json",
 		"gjc mcp remove context7",
 	];
@@ -88,14 +89,15 @@ export default class MCP extends Command {
 		process.stdout.write(`Register standalone MCP servers explicitly in GJC config
 
 USAGE
-  $ gjc mcp [add|list|remove|import] [NAME] [COMMAND_OR_URL] [ARGS...] [FLAGS]
+  $ gjc mcp [add|list|remove|autoload|import] [NAME] [COMMAND_OR_URL] [ARGS...] [FLAGS]
 
 COMMANDS
-  add     Add an explicit user-provided MCP server definition
-  list    List registered servers with env/header/auth values redacted
-  remove  Remove a registered server and print the removed definition redacted
-  import  Copy MCP servers from another host into GJC config:
-          gjc mcp import <claude|codex|opencode|cursor|all> [--dry-run] [--force] [--project]
+  add       Add an explicit user-provided MCP server definition
+  list      List registered servers with env/header/auth values redacted
+  remove    Remove a registered server and print the removed definition redacted
+  autoload  Toggle connecting a server at session startup: gjc mcp autoload <name> on|off
+  import    Copy MCP servers from another host into GJC config:
+            gjc mcp import <claude|codex|opencode|cursor|all> [--dry-run] [--force] [--project]
 
 FLAGS
       --project          Use project scope (./.gjc/mcp.json) instead of user scope
@@ -115,6 +117,7 @@ EXAMPLES
   $ gjc mcp add docs --type http --url https://example.test/mcp --header Authorization=Bearer_TOKEN
   $ gjc mcp import claude
   $ gjc mcp import codex --dry-run
+  $ gjc mcp autoload context7 off
   $ gjc mcp list --json
   $ gjc mcp remove context7
 

--- a/packages/coding-agent/src/commands/mcp.ts
+++ b/packages/coding-agent/src/commands/mcp.ts
@@ -4,7 +4,7 @@
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { type MCPAction, type MCPCommandArgs, runMCPCommand } from "../cli/mcp-cli";
 
-const ACTIONS: MCPAction[] = ["add", "list", "remove"];
+const ACTIONS: MCPAction[] = ["add", "list", "remove", "import"];
 
 export default class MCP extends Command {
 	static description = "Register standalone MCP servers explicitly in GJC config";
@@ -13,6 +13,8 @@ export default class MCP extends Command {
 	static examples = [
 		"gjc mcp add context7 npx -y @upstash/context7-mcp",
 		"gjc mcp add docs --type http --url https://example.test/mcp --header Authorization=Bearer_TOKEN",
+		"gjc mcp import claude",
+		"gjc mcp import codex --dry-run",
 		"gjc mcp list --json",
 		"gjc mcp remove context7",
 	];
@@ -29,7 +31,8 @@ export default class MCP extends Command {
 
 	static flags = {
 		project: Flags.boolean({ description: "Write/read project scope (./.gjc/mcp.json) instead of user scope" }),
-		force: Flags.boolean({ description: "Overwrite an existing server during add", default: false }),
+		force: Flags.boolean({ description: "Overwrite an existing server during add/import", default: false }),
+		"dry-run": Flags.boolean({ description: "Preview an import without writing anything", default: false }),
 		json: Flags.boolean({
 			char: "j",
 			description: "Emit machine-readable JSON with sensitive values redacted",
@@ -67,6 +70,7 @@ export default class MCP extends Command {
 				project: flags.project,
 				force: flags.force,
 				json: flags.json,
+				dryRun: flags["dry-run"],
 				type: flags.type as MCPCommandArgs["flags"]["type"],
 				command: flags.command,
 				url: flags.url,
@@ -84,12 +88,14 @@ export default class MCP extends Command {
 		process.stdout.write(`Register standalone MCP servers explicitly in GJC config
 
 USAGE
-  $ gjc mcp [add|list|remove] [NAME] [COMMAND_OR_URL] [ARGS...] [FLAGS]
+  $ gjc mcp [add|list|remove|import] [NAME] [COMMAND_OR_URL] [ARGS...] [FLAGS]
 
 COMMANDS
   add     Add an explicit user-provided MCP server definition
   list    List registered servers with env/header/auth values redacted
   remove  Remove a registered server and print the removed definition redacted
+  import  Copy MCP servers from another host into GJC config:
+          gjc mcp import <claude|codex|opencode|cursor|all> [--dry-run] [--force] [--project]
 
 FLAGS
       --project          Use project scope (./.gjc/mcp.json) instead of user scope
@@ -107,11 +113,13 @@ FLAGS
 EXAMPLES
   $ gjc mcp add context7 npx -y @upstash/context7-mcp
   $ gjc mcp add docs --type http --url https://example.test/mcp --header Authorization=Bearer_TOKEN
+  $ gjc mcp import claude
+  $ gjc mcp import codex --dry-run
   $ gjc mcp list --json
   $ gjc mcp remove context7
 
 SECURITY
-  This command writes only the server definition supplied on this invocation. It does not import or inherit Claude Code, Codex, OpenCode, or other live MCP configs. Public output redacts env, header, auth, and OAuth credential values.
+  \`add\` writes only the server definition supplied on this invocation. \`import\` copies definitions from another host's config exactly once — GJC never inherits live MCP runtime from Claude Code, Codex, OpenCode, or Cursor, and secret-indirection fields are omitted rather than read. Public output redacts env, header, auth, and OAuth credential values.
 `);
 	}
 }

--- a/packages/coding-agent/src/commands/migrate.ts
+++ b/packages/coding-agent/src/commands/migrate.ts
@@ -5,7 +5,7 @@ import { Command, Flags } from "@gajae-code/utils/cli";
 import { type MigrateCommandArgs, runMigrateCommand } from "../cli/migrate-cli";
 
 export default class Migrate extends Command {
-	static description = "Import MCP servers and skills from Claude Code, Codex, or OpenCode";
+	static description = "Import MCP servers and skills from Claude Code, Codex, OpenCode, or Cursor";
 
 	static examples = [
 		"gjc migrate --from claude-code",
@@ -16,7 +16,7 @@ export default class Migrate extends Command {
 
 	static flags = {
 		from: Flags.string({
-			description: "Source agent to import from (repeatable): claude-code | codex | opencode | all",
+			description: "Source agent to import from (repeatable): claude-code | codex | opencode | cursor | all",
 			multiple: true,
 			required: true,
 		}),

--- a/packages/coding-agent/src/migrate/adapters/cursor.ts
+++ b/packages/coding-agent/src/migrate/adapters/cursor.ts
@@ -1,0 +1,41 @@
+/**
+ * Cursor adapter: reads `~/.cursor/mcp.json` (mcpServers).
+ *
+ * Cursor has no home-level skill/prompt store, so only MCP candidates are
+ * produced. Project `.cursor/mcp.json` is out of scope by the adapter contract
+ * (home-only, see adapters/index.ts).
+ */
+import * as path from "node:path";
+import type { AdapterResult, McpCandidate } from "../types";
+import { type Adapter, type AdapterOptions, parseSourceJson, readSourceText } from "./index";
+
+const SOURCE = "cursor" as const;
+
+export const cursorAdapter: Adapter = {
+	source: SOURCE,
+	async collect({ homeDir }: AdapterOptions): Promise<AdapterResult> {
+		const result: AdapterResult = { mcpCandidates: [], skillCandidates: [], diagnostics: [] };
+
+		const configPath = path.join(homeDir, ".cursor", "mcp.json");
+		const read = await readSourceText(configPath, SOURCE, "mcp");
+		if ("diagnostic" in read) {
+			result.diagnostics.push(read.diagnostic);
+			return result;
+		}
+
+		const parsed = parseSourceJson(read.text, configPath, SOURCE, "mcp");
+		if ("diagnostic" in parsed) {
+			result.diagnostics.push(parsed.diagnostic);
+			return result;
+		}
+
+		const servers = parsed.data.mcpServers;
+		if (servers && typeof servers === "object" && !Array.isArray(servers)) {
+			for (const [name, raw] of Object.entries(servers as Record<string, unknown>)) {
+				result.mcpCandidates.push({ source: SOURCE, name, raw } satisfies McpCandidate);
+			}
+		}
+
+		return result;
+	},
+};

--- a/packages/coding-agent/src/migrate/adapters/index.ts
+++ b/packages/coding-agent/src/migrate/adapters/index.ts
@@ -11,6 +11,7 @@ import { normalizeSkill } from "../skill-normalizer";
 import type { AdapterResult, MigrateSource, SkillCandidate, SourceDiagnostic } from "../types";
 import { claudeCodeAdapter } from "./claude-code";
 import { codexAdapter } from "./codex";
+import { cursorAdapter } from "./cursor";
 import { opencodeAdapter } from "./opencode";
 
 export interface AdapterOptions {
@@ -27,6 +28,7 @@ const ADAPTERS: Record<MigrateSource, Adapter> = {
 	"claude-code": claudeCodeAdapter,
 	codex: codexAdapter,
 	opencode: opencodeAdapter,
+	cursor: cursorAdapter,
 };
 
 export function getAdapter(source: MigrateSource): Adapter {

--- a/packages/coding-agent/src/migrate/import-hint.ts
+++ b/packages/coding-agent/src/migrate/import-hint.ts
@@ -1,0 +1,66 @@
+/**
+ * Contextual "import hint" for empty MCP-list output.
+ *
+ * GJC deliberately never scans foreign coding-agent configs at startup — import
+ * is always explicit opt-in (`gjc mcp import <source>`). This helper is the one
+ * sanctioned exception to that rule, and a narrow one: it runs ONLY when the
+ * user asks to list MCP servers and has none configured. In that specific
+ * empty-list moment we peek at other hosts' configs and, if any contain MCP
+ * servers, surface a one-line suggestion to import them. It is the deliberate
+ * alternative to a first-run onboarding prompt.
+ *
+ * Because it piggybacks on a common command, it must never throw, never slow
+ * the command down noticeably, and never surface an error: every source is
+ * probed independently and any failure just drops that source from the result.
+ */
+import * as os from "node:os";
+import { getAdapter } from "./adapters/index";
+import { MIGRATE_SOURCES, type MigrateSource } from "./types";
+
+/** A source host whose config contains importable MCP servers. */
+export interface ImportableMcpSource {
+	source: MigrateSource;
+	/** Alias to show in the suggested command (claude-code → "claude"). */
+	importArg: string;
+	/** Human-readable host name, e.g. "Claude Code". */
+	displayName: string;
+	count: number;
+}
+
+const SOURCE_META: Record<MigrateSource, { importArg: string; displayName: string }> = {
+	"claude-code": { importArg: "claude", displayName: "Claude Code" },
+	codex: { importArg: "codex", displayName: "Codex" },
+	opencode: { importArg: "opencode", displayName: "OpenCode" },
+	cursor: { importArg: "cursor", displayName: "Cursor" },
+};
+
+/**
+ * Probe every known source host for importable MCP servers.
+ *
+ * Returns only sources with at least one MCP server, in canonical source order.
+ * `homeDir` is a test seam; production callers omit it to use `os.homedir()`.
+ * Never throws — a source that errors is silently skipped.
+ */
+export async function detectImportableMcpSources(homeDir?: string): Promise<ImportableMcpSource[]> {
+	const resolvedHome = homeDir ?? os.homedir();
+	const found: ImportableMcpSource[] = [];
+	for (const source of MIGRATE_SOURCES) {
+		try {
+			const result = await getAdapter(source).collect({ homeDir: resolvedHome });
+			const count = result.mcpCandidates.length;
+			if (count > 0) {
+				const meta = SOURCE_META[source];
+				found.push({ source, importArg: meta.importArg, displayName: meta.displayName, count });
+			}
+		} catch {
+			// The hint must never throw or slow-fail; skip any source that errors.
+		}
+	}
+	return found;
+}
+
+/** One-line, host-agnostic suggestion for a single importable source. */
+export function formatImportHintLine(source: ImportableMcpSource): string {
+	const servers = source.count === 1 ? "1 MCP server" : `${source.count} MCP servers`;
+	return `Tip: found ${servers} in ${source.displayName} config — run \`gjc mcp import ${source.importArg}\` to copy them.`;
+}

--- a/packages/coding-agent/src/migrate/mcp-mapper.ts
+++ b/packages/coding-agent/src/migrate/mcp-mapper.ts
@@ -34,6 +34,7 @@ const SECRET_INDIRECTION_FIELDS: Record<MigrateSource, string[]> = {
 	"claude-code": [],
 	codex: ["env_vars", "env_http_headers", "bearer_token_env_var"],
 	opencode: [],
+	cursor: [],
 };
 
 /** Fields recognized for a source (handled or intentionally omitted). Anything else is omitted-with-warning. */
@@ -59,6 +60,8 @@ const RECOGNIZED_FIELDS: Record<MigrateSource, ReadonlySet<string>> = {
 		"disabled_tools",
 	]),
 	opencode: new Set(["type", "command", "args", "env", "url", "headers", "enabled", "timeout", "cwd"]),
+	// Cursor's ~/.cursor/mcp.json uses the standard mcpServers shape.
+	cursor: new Set(["type", "command", "args", "env", "url", "headers", "enabled", "timeout", "cwd"]),
 };
 
 /** Fields with no GJC equivalent: omitted-with-warning (named explicitly so the warning is precise). */
@@ -66,6 +69,7 @@ const OMITTED_FIELDS: Record<MigrateSource, string[]> = {
 	"claude-code": [],
 	codex: ["startup_timeout_sec", "enabled_tools", "disabled_tools"],
 	opencode: [],
+	cursor: [],
 };
 
 export function mapMcpEntry(source: MigrateSource, name: string, raw: unknown): McpMapOutcome {

--- a/packages/coding-agent/src/migrate/types.ts
+++ b/packages/coding-agent/src/migrate/types.ts
@@ -8,9 +8,9 @@
 import type { MCPServerConfig } from "../runtime-mcp/types";
 
 /** Supported migration sources. */
-export type MigrateSource = "claude-code" | "codex" | "opencode";
+export type MigrateSource = "claude-code" | "codex" | "opencode" | "cursor";
 
-export const MIGRATE_SOURCES: readonly MigrateSource[] = ["claude-code", "codex", "opencode"];
+export const MIGRATE_SOURCES: readonly MigrateSource[] = ["claude-code", "codex", "opencode", "cursor"];
 
 /** Canonical, deterministic ordering used when expanding `--from all` / repeated `--from`. */
 export const CANONICAL_SOURCE_ORDER: readonly MigrateSource[] = MIGRATE_SOURCES;

--- a/packages/coding-agent/src/modes/controllers/runtime-mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/runtime-mcp-command-controller.ts
@@ -14,6 +14,7 @@ import {
 	readDisabledServers,
 	readMCPConfigFile,
 	removeMCPServer,
+	setServerAutoload,
 	setServerDisabled,
 	updateMCPServer,
 } from "../../runtime-mcp/config-writer";
@@ -147,6 +148,15 @@ export class MCPCommandController {
 			case "reconnect":
 				await this.#handleReconnect(parts[2]);
 				break;
+			case "connect":
+				await this.#handleConnect(parts[2]);
+				break;
+			case "disconnect":
+				await this.#handleDisconnect(parts[2]);
+				break;
+			case "autoload":
+				await this.#handleAutoload(parts[2], parts[3]);
+				break;
 			case "reload":
 				await this.#handleReload();
 				break;
@@ -179,6 +189,9 @@ export class MCPCommandController {
 			"                        Search Smithery registry and deploy from picker",
 			"  /mcp smithery-login   Login to Smithery and cache API key",
 			"  /mcp smithery-logout  Remove cached Smithery API key",
+			"  /mcp connect <name>   Connect a configured server into this session",
+			"  /mcp disconnect <name> Disconnect a server from this session",
+			"  /mcp autoload <name> on|off   Toggle connecting a server at session startup",
 			"  /mcp reconnect <name> Reconnect to a specific MCP server",
 			"  /mcp reload           Force reload and rediscover MCP runtime tools",
 			"  /mcp resources        List available resources from connected servers",
@@ -911,6 +924,28 @@ export class MCPCommandController {
 	/**
 	 * Handle /mcp list - Show all configured servers
 	 */
+	/**
+	 * One /mcp list row: configured state, live connection state, autoload flag,
+	 * and — for reachable-but-disconnected servers — the action to connect.
+	 */
+	#formatServerListLine(name: string, config: MCPServerConfig): string {
+		const type = config.type ?? "stdio";
+		const state =
+			config.enabled === false ? "inactive" : (this.ctx.mcpManager?.getConnectionStatus(name) ?? "disconnected");
+		const status =
+			state === "inactive"
+				? theme.fg("warning", " ◌ inactive")
+				: state === "connected"
+					? theme.fg("success", " ● connected")
+					: state === "connecting"
+						? theme.fg("muted", " ◌ connecting")
+						: theme.fg("muted", " ○ not connected");
+		const autoload = config.autoload === false ? theme.fg("dim", " (autoload off)") : "";
+		const hint =
+			state === "disconnected" && config.enabled !== false ? theme.fg("dim", ` — /mcp connect ${name}`) : "";
+		return `  ${theme.fg("accent", name)}${status}${autoload} ${theme.fg("dim", `[${type}]`)}${hint}`;
+	}
+
 	async #handleList(): Promise<void> {
 		try {
 			const cwd = getProjectDir();
@@ -968,21 +1003,7 @@ export class MCPCommandController {
 			if (userServers.length > 0) {
 				lines.push(theme.fg("accent", "User level") + theme.fg("muted", ` (${userPathLabel}):`));
 				for (const name of userServers) {
-					const config = userConfig.mcpServers![name];
-					const type = config.type ?? "stdio";
-					const state =
-						config.enabled === false
-							? "inactive"
-							: (this.ctx.mcpManager?.getConnectionStatus(name) ?? "disconnected");
-					const status =
-						state === "inactive"
-							? theme.fg("warning", " ◌ inactive")
-							: state === "connected"
-								? theme.fg("success", " ● connected")
-								: state === "connecting"
-									? theme.fg("muted", " ◌ connecting")
-									: theme.fg("muted", " ○ not connected");
-					lines.push(`  ${theme.fg("accent", name)}${status} ${theme.fg("dim", `[${type}]`)}`);
+					lines.push(this.#formatServerListLine(name, userConfig.mcpServers![name]));
 				}
 				lines.push("");
 			}
@@ -991,21 +1012,7 @@ export class MCPCommandController {
 			if (projectServers.length > 0) {
 				lines.push(theme.fg("accent", "Project level") + theme.fg("muted", ` (${projectPathLabel}):`));
 				for (const name of projectServers) {
-					const config = projectConfig.mcpServers![name];
-					const type = config.type ?? "stdio";
-					const state =
-						config.enabled === false
-							? "inactive"
-							: (this.ctx.mcpManager?.getConnectionStatus(name) ?? "disconnected");
-					const status =
-						state === "inactive"
-							? theme.fg("warning", " ◌ inactive")
-							: state === "connected"
-								? theme.fg("success", " ● connected")
-								: state === "connecting"
-									? theme.fg("muted", " ◌ connecting")
-									: theme.fg("muted", " ○ not connected");
-					lines.push(`  ${theme.fg("accent", name)}${status} ${theme.fg("dim", `[${type}]`)}`);
+					lines.push(this.#formatServerListLine(name, projectConfig.mcpServers![name]));
 				}
 				lines.push("");
 			}
@@ -1444,6 +1451,139 @@ export class MCPCommandController {
 	}
 
 	/**
+	 * Handle /mcp connect <name> - Connect a configured server into this session.
+	 *
+	 * Complements autoload: servers stored with `autoload: false` stay
+	 * configured-but-disconnected at startup and are brought in here on demand.
+	 */
+	async #handleConnect(name: string | undefined): Promise<void> {
+		if (!name) {
+			this.ctx.showError("Server name required. Usage: /mcp connect <name>");
+			return;
+		}
+		if (!this.ctx.mcpManager) {
+			this.ctx.showError("MCP manager not available.");
+			return;
+		}
+		if (this.ctx.mcpManager.getConnectionStatus(name) === "connected") {
+			this.#showMessage(["", theme.fg("muted", `"${name}" is already connected.`), ""].join("\n"));
+			return;
+		}
+		const found = await this.#findConfiguredServer(name);
+		if (!found) {
+			this.ctx.showError(`Server "${name}" not found in user or project config. Run /mcp list to see servers.`);
+			return;
+		}
+		if (found.config.enabled === false) {
+			this.ctx.showError(`Server "${name}" is disabled. Run /mcp enable ${name} first.`);
+			return;
+		}
+
+		try {
+			await this.#syncManagerConnection(name, found.config);
+			const state = await this.#waitForServerConnectionWithAnimation(name);
+			if (state === "connected") {
+				const serverTools = this.ctx.mcpManager.getTools().filter(t => t.mcpServerName === name);
+				const lines = ["", theme.fg("success", `✓ Connected to "${name}"`), `  Tools: ${serverTools.length}`];
+				if (found.config.autoload === false) {
+					lines.push(
+						theme.fg("muted", `  This session only — run /mcp autoload ${name} on to connect at startup.`),
+					);
+				}
+				lines.push("");
+				this.#showMessage(lines.join("\n"));
+			}
+		} catch (error) {
+			this.ctx.showError(
+				`Failed to connect to "${name}": ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+
+	/**
+	 * Handle /mcp disconnect <name> - Disconnect a server from this session.
+	 *
+	 * Config is untouched: the server stays registered and reconnects on the
+	 * next startup unless its autoload flag is turned off.
+	 */
+	async #handleDisconnect(name: string | undefined): Promise<void> {
+		if (!name) {
+			this.ctx.showError("Server name required. Usage: /mcp disconnect <name>");
+			return;
+		}
+		if (!this.ctx.mcpManager) {
+			this.ctx.showError("MCP manager not available.");
+			return;
+		}
+		if (this.ctx.mcpManager.getConnectionStatus(name) === "disconnected") {
+			this.#showMessage(["", theme.fg("muted", `"${name}" is not connected.`), ""].join("\n"));
+			return;
+		}
+
+		try {
+			await this.ctx.mcpManager.disconnectServer(name);
+			await this.ctx.session.refreshMCPTools(this.ctx.mcpManager.getTools());
+			this.#showMessage(
+				[
+					"",
+					theme.fg("success", `✓ Disconnected "${name}"`),
+					theme.fg("muted", `  Still configured — reconnects next session unless /mcp autoload ${name} off.`),
+					"",
+				].join("\n"),
+			);
+		} catch (error) {
+			this.ctx.showError(
+				`Failed to disconnect "${name}": ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+
+	/**
+	 * Handle /mcp autoload <name> on|off - Persist whether a server connects at startup.
+	 */
+	async #handleAutoload(name: string | undefined, value: string | undefined): Promise<void> {
+		const normalized = value?.toLowerCase();
+		if (!name || (normalized !== "on" && normalized !== "off")) {
+			this.ctx.showError("Usage: /mcp autoload <name> on|off");
+			return;
+		}
+		const autoload = normalized === "on";
+
+		const found = await this.#findConfiguredServer(name);
+		if (!found) {
+			this.ctx.showError(`Server "${name}" not found in user or project config. Run /mcp list to see servers.`);
+			return;
+		}
+
+		try {
+			await setServerAutoload(found.filePath, name, autoload);
+			const lines = [
+				"",
+				theme.fg(
+					"success",
+					`✓ Autoload ${autoload ? "enabled" : "disabled"} for "${name}" (${found.scope} config)`,
+				),
+			];
+			if (autoload) {
+				lines.push(theme.fg("muted", "  The server will connect automatically at session startup."));
+				if (this.ctx.mcpManager && this.ctx.mcpManager.getConnectionStatus(name) !== "connected") {
+					lines.push(theme.fg("muted", `  Run /mcp connect ${name} to use it in this session.`));
+				}
+			} else {
+				lines.push(
+					theme.fg("muted", `  Still configured — use /mcp connect ${name} when you need it in a session.`),
+				);
+			}
+			lines.push("");
+			this.#showMessage(lines.join("\n"));
+		} catch (error) {
+			this.ctx.showError(
+				`Failed to update autoload for "${name}": ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+
+	/**
 	 * Reload MCP manager with new configs
 	 */
 	async #reloadMCP(): Promise<void> {
@@ -1454,8 +1594,13 @@ export class MCPCommandController {
 		// Disconnect all existing servers
 		await this.ctx.mcpManager.disconnectAll();
 
-		// Rediscover and connect
-		const result = await this.ctx.mcpManager.discoverAndConnect();
+		// Rediscover and connect, mirroring the session-startup policy: only
+		// autoload servers reconnect; autoload:false servers wait for /mcp connect.
+		const result = await this.ctx.mcpManager.discoverAndConnect({
+			autoloadOnly: true,
+			enableProjectConfig: this.ctx.settings.get("mcp.enableProjectConfig"),
+			filterBrowser: this.ctx.settings.get("browser.enabled") ?? false,
+		});
 		await this.ctx.session.refreshMCPTools(this.ctx.mcpManager.getTools());
 
 		// Show any connection errors

--- a/packages/coding-agent/src/modes/controllers/runtime-mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/runtime-mcp-command-controller.ts
@@ -7,6 +7,7 @@ import * as path from "node:path";
 import { Spacer, Text } from "@gajae-code/tui";
 import { getMCPConfigPath, getProjectDir } from "@gajae-code/utils";
 import type { SourceMeta } from "../../capability/types";
+import { detectImportableMcpSources } from "../../migrate/import-hint";
 import { analyzeAuthError, discoverOAuthEndpoints, MCPManager } from "../../runtime-mcp";
 import { connectToServer, disconnectServer, listTools } from "../../runtime-mcp/client";
 import {
@@ -985,15 +986,19 @@ export class MCPCommandController {
 				discoveredServers.length === 0 &&
 				disabledServerNames.size === 0
 			) {
-				this.#showMessage(
-					[
-						"",
-						theme.fg("muted", "No MCP servers configured."),
-						"",
-						`Use ${theme.fg("accent", "/mcp add")} to add a server.`,
-						"",
-					].join("\n"),
-				);
+				const importable = await detectImportableMcpSources();
+				const emptyLines = ["", theme.fg("muted", "No MCP servers configured."), ""];
+				for (const source of importable) {
+					const servers = source.count === 1 ? "1 MCP server" : `${source.count} MCP servers`;
+					emptyLines.push(
+						theme.fg(
+							"muted",
+							`Found ${servers} in ${source.displayName} config — run ${theme.fg("accent", `gjc mcp import ${source.importArg}`)} to copy them.`,
+						),
+					);
+				}
+				emptyLines.push(`Use ${theme.fg("accent", "/mcp add")} to add a server.`, "");
+				this.#showMessage(emptyLines.join("\n"));
 				return;
 			}
 

--- a/packages/coding-agent/src/slash-commands/helpers/mcp.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/mcp.ts
@@ -1,4 +1,5 @@
 import { getMCPConfigPath, logger } from "@gajae-code/utils";
+import { detectImportableMcpSources, formatImportHintLine } from "../../migrate/import-hint";
 import { connectToServer, disconnectServer, listPrompts, listResources, listTools } from "../../runtime-mcp/client";
 import {
 	addMCPServer,
@@ -378,7 +379,9 @@ async function handleListCommand(runtime: SlashCommandRuntime): Promise<SlashCom
 			if (!entries.some(entry => entry.name === name)) entries.push({ name, config, scope: "project" });
 		}
 		if (entries.length === 0) {
-			await runtime.output("No MCP servers configured.");
+			const importable = await detectImportableMcpSources();
+			const lines = ["No MCP servers configured.", ...importable.map(formatImportHintLine)];
+			await runtime.output(lines.join("\n"));
 			return commandConsumed();
 		}
 		await runtime.output(

--- a/packages/coding-agent/src/slash-commands/helpers/mcp.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/mcp.ts
@@ -5,6 +5,7 @@ import {
 	readDisabledServers,
 	readMCPConfigFile,
 	removeMCPServer,
+	setServerAutoload,
 	setServerDisabled,
 	updateMCPServer,
 } from "../../runtime-mcp/config-writer";
@@ -405,7 +406,8 @@ async function handleListCommand(runtime: SlashCommandRuntime): Promise<SlashCom
 					} else {
 						location = (config as { command: string }).command;
 					}
-					return `${name} | ${type} | ${enabled} | ${location ?? "(unknown)"} [${scope}]`;
+					const autoload = config.autoload === false ? " | autoload off" : "";
+					return `${name} | ${type} | ${enabled}${autoload} | ${location ?? "(unknown)"} [${scope}]`;
 				})
 				.join("\n"),
 		);
@@ -452,6 +454,39 @@ async function handleEnableDisableCommand(
 	}
 }
 
+async function handleAutoloadCommand(rest: string, runtime: SlashCommandRuntime): Promise<SlashCommandResult> {
+	const [name, rawValue] = rest.split(/\s+/);
+	const value = rawValue?.toLowerCase();
+	if (!name || (value !== "on" && value !== "off")) {
+		return usage("Usage: /mcp autoload <name> on|off", runtime);
+	}
+	try {
+		const userPath = getMCPConfigPath("user", runtime.cwd);
+		const projectPath = getMCPConfigPath("project", runtime.cwd);
+		const [userConfig, projectConfig] = await Promise.all([
+			readMCPConfigFile(userPath),
+			readMCPConfigFile(projectPath),
+		]);
+		const filePath = userConfig.mcpServers?.[name]
+			? userPath
+			: projectConfig.mcpServers?.[name]
+				? projectPath
+				: undefined;
+		if (!filePath) {
+			return usage(`Server "${name}" not found in user or project config.`, runtime);
+		}
+		await setServerAutoload(filePath, name, value === "on");
+		await runtime.output(
+			value === "on"
+				? `Autoload enabled for "${name}" — it connects automatically at session startup.`
+				: `Autoload disabled for "${name}" — it stays configured until connected explicitly.`,
+		);
+		return commandConsumed();
+	} catch (err) {
+		return usage(`Failed to update autoload for "${name}": ${errorMessage(err)}`, runtime);
+	}
+}
+
 async function handleRemoveCommand(rest: string, runtime: SlashCommandRuntime): Promise<SlashCommandResult> {
 	const parsed = parseNamedScopeArgs(rest, "Invalid --scope value. Use project or user.");
 	if (parsed.error) return usage(parsed.error, runtime);
@@ -471,6 +506,7 @@ const MCP_HELP_TEXT = [
 	"  /mcp list                                               List configured servers",
 	"  /mcp enable <name>                                      Enable a server",
 	"  /mcp disable <name>                                     Disable a server",
+	"  /mcp autoload <name> on|off                             Toggle connecting a server at session startup",
 	"  /mcp remove <name> [--scope project|user]               Remove a server",
 	"  /mcp reload                                             Reload MCP runtime",
 	"  /mcp resources                                          List resources from all servers",
@@ -482,7 +518,15 @@ const MCP_HELP_TEXT = [
 	"  /mcp help                                               Show this help",
 ].join("\n");
 
-const TUI_ONLY_MCP_VERBS = new Set(["reauth", "unauth", "smithery-login", "smithery-logout", "reconnect"]);
+const TUI_ONLY_MCP_VERBS = new Set([
+	"reauth",
+	"unauth",
+	"smithery-login",
+	"smithery-logout",
+	"reconnect",
+	"connect",
+	"disconnect",
+]);
 
 /** ACP/text-mode `/mcp` handler. Shared by both dispatchers via the spec. */
 export async function handleMcpAcp(
@@ -501,7 +545,11 @@ export async function handleMcpAcp(
 		);
 	}
 	if (TUI_ONLY_MCP_VERBS.has(verb)) {
-		return usage(`/mcp ${verb} requires OAuth or browser flows only available in the TUI client.`, runtime);
+		const reason =
+			verb === "connect" || verb === "disconnect" || verb === "reconnect"
+				? "requires the live MCP manager"
+				: "requires OAuth or browser flows";
+		return usage(`/mcp ${verb} ${reason} only available in the TUI client.`, runtime);
 	}
 	switch (verb) {
 		case "resources":
@@ -523,6 +571,8 @@ export async function handleMcpAcp(
 		case "enable":
 		case "disable":
 			return await handleEnableDisableCommand(verb, rest, runtime);
+		case "autoload":
+			return await handleAutoloadCommand(rest, runtime);
 		case "remove":
 		case "rm":
 			return await handleRemoveCommand(rest, runtime);

--- a/packages/coding-agent/test/mcp-cli.test.ts
+++ b/packages/coding-agent/test/mcp-cli.test.ts
@@ -181,6 +181,41 @@ describe("gjc mcp CLI helpers", () => {
 		expect(output).not.toContain("super-secret");
 	});
 
+	it("suggests importing when the config is empty and another host has MCP servers", async () => {
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const fakeHome = path.join(tmpDir, "home");
+		await fs.mkdir(fakeHome, { recursive: true });
+		await fs.writeFile(
+			path.join(fakeHome, ".claude.json"),
+			JSON.stringify({ mcpServers: { a: { command: "bin" }, b: { command: "bin2" } } }),
+		);
+
+		await runMCPCommand({ action: "list", flags: {}, cwd: projectDir, homeDir: fakeHome });
+
+		const output = stdoutText(stdout);
+		expect(output).toContain("No MCP servers registered");
+		expect(output).toContain("found 2 MCP servers in Claude Code config");
+		expect(output).toContain("gjc mcp import claude");
+	});
+
+	it("omits the import tip from --json list output", async () => {
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const fakeHome = path.join(tmpDir, "home");
+		await fs.mkdir(fakeHome, { recursive: true });
+		await fs.writeFile(
+			path.join(fakeHome, ".claude.json"),
+			JSON.stringify({ mcpServers: { a: { command: "bin" } } }),
+		);
+
+		await runMCPCommand({ action: "list", flags: { json: true }, cwd: projectDir, homeDir: fakeHome });
+
+		const output = stdoutText(stdout);
+		expect(output).not.toContain("import claude");
+		expect(output).not.toContain("Tip:");
+		// JSON shape stays a plain empty server list.
+		expect(output).toContain('"servers": []');
+	});
+
 	it("redacts auth and OAuth output through explicit safe fields", async () => {
 		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 		const configPath = getMCPConfigPath("user", projectDir);

--- a/packages/coding-agent/test/mcp-cli.test.ts
+++ b/packages/coding-agent/test/mcp-cli.test.ts
@@ -127,6 +127,41 @@ describe("gjc mcp CLI helpers", () => {
 		expect((await readMCPConfigFile(configPath)).mcpServers?.srv).toMatchObject({ command: "new-bin" });
 	});
 
+	it("toggles autoload on and off for an existing server", async () => {
+		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const configPath = getMCPConfigPath("user", projectDir);
+
+		await runMCPCommand({ action: "add", name: "srv", commandArgs: ["srv-bin"], flags: {}, cwd: projectDir });
+
+		await runMCPCommand({ action: "autoload", name: "srv", commandArgs: ["off"], flags: {}, cwd: projectDir });
+		expect((await readMCPConfigFile(configPath)).mcpServers?.srv).toMatchObject({
+			command: "srv-bin",
+			autoload: false,
+		});
+
+		// Turning autoload back on removes the redundant key (default is on).
+		await runMCPCommand({ action: "autoload", name: "srv", commandArgs: ["on"], flags: {}, cwd: projectDir });
+		const stored = (await readMCPConfigFile(configPath)).mcpServers?.srv;
+		expect(stored).toMatchObject({ command: "srv-bin" });
+		expect(stored && "autoload" in stored).toBe(false);
+	});
+
+	it("rejects autoload for unknown servers and invalid values", async () => {
+		const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+		await runMCPCommand({ action: "autoload", name: "missing", commandArgs: ["off"], flags: {}, cwd: projectDir });
+		expect(process.exitCode).toBe(2);
+		process.exitCode = 0;
+
+		await runMCPCommand({ action: "autoload", name: "missing", commandArgs: ["maybe"], flags: {}, cwd: projectDir });
+		expect(process.exitCode).toBe(2);
+		process.exitCode = 0;
+
+		const output = stderr.mock.calls.map((call: [unknown, ...unknown[]]) => String(call[0] ?? "")).join("");
+		expect(output).toContain('MCP server "missing" not found');
+		expect(output).toContain("on|off");
+	});
+
 	it("redacts malformed pair values from argument errors", async () => {
 		const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 

--- a/packages/coding-agent/test/migrate-adapters.test.ts
+++ b/packages/coding-agent/test/migrate-adapters.test.ts
@@ -67,6 +67,36 @@ describe("codex adapter", () => {
 	});
 });
 
+describe("cursor adapter", () => {
+	test("absent config yields skipped_absent_source diagnostics, no candidates", async () => {
+		const result = await getAdapter("cursor").collect({ homeDir: home });
+		expect(result.mcpCandidates).toHaveLength(0);
+		expect(result.skillCandidates).toHaveLength(0);
+		expect(result.diagnostics.every(d => d.status === "skipped_absent_source")).toBe(true);
+	});
+
+	test("reads mcpServers from ~/.cursor/mcp.json", async () => {
+		await writeFile(
+			".cursor/mcp.json",
+			JSON.stringify({
+				mcpServers: { srv: { command: "bin", args: ["--x"] }, docs: { url: "https://d.test/mcp" } },
+			}),
+		);
+		const result = await getAdapter("cursor").collect({ homeDir: home });
+		expect(result.mcpCandidates).toEqual([
+			{ source: "cursor", name: "srv", raw: { command: "bin", args: ["--x"] } },
+			{ source: "cursor", name: "docs", raw: { url: "https://d.test/mcp" } },
+		]);
+		expect(result.skillCandidates).toHaveLength(0);
+	});
+
+	test("malformed mcp config yields failed_invalid_source", async () => {
+		await writeFile(".cursor/mcp.json", "{ not json");
+		const result = await getAdapter("cursor").collect({ homeDir: home });
+		expect(result.diagnostics.some(d => d.status === "failed_invalid_source")).toBe(true);
+	});
+});
+
 describe("opencode adapter", () => {
 	test("reads mcp, skills, and command conversions", async () => {
 		await writeFile(

--- a/packages/coding-agent/test/migrate-cli.test.ts
+++ b/packages/coding-agent/test/migrate-cli.test.ts
@@ -37,7 +37,7 @@ afterEach(async () => {
 
 describe("resolveSources", () => {
 	test("expands all", () => {
-		expect(resolveSources(["all"])).toEqual(["claude-code", "codex", "opencode"]);
+		expect(resolveSources(["all"])).toEqual(["claude-code", "codex", "opencode", "cursor"]);
 	});
 	test("dedupes and returns canonical order regardless of input order", () => {
 		expect(resolveSources(["opencode", "claude-code", "opencode"])).toEqual(["claude-code", "opencode"]);
@@ -65,6 +65,22 @@ describe("runMigrate", () => {
 		expect(report.actions.length).toBeGreaterThan(0);
 		expect(await exists(path.join(cwd, ".gjc", "mcp.json"))).toBe(false);
 		expect(await exists(path.join(cwd, ".gjc", "skills"))).toBe(false);
+	});
+
+	test("only: 'mcp' plans MCP imports and drops skill candidates entirely", async () => {
+		const report = await runMigrate({
+			from: ["claude-code"],
+			project: true,
+			force: false,
+			dryRun: true,
+			json: true,
+			only: "mcp",
+			homeDir: home,
+			cwd,
+		});
+		expect(report.actions.some(a => a.type === "mcp" && a.status === "imported")).toBe(true);
+		expect(report.actions.some(a => a.type === "skill")).toBe(false);
+		expect(report.warnings.every(w => w.type !== "skill")).toBe(true);
 	});
 
 	test("--json report carries taxonomy counts by total/type/source", async () => {

--- a/packages/coding-agent/test/migrate-import-hint.test.ts
+++ b/packages/coding-agent/test/migrate-import-hint.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { detectImportableMcpSources, formatImportHintLine } from "../src/migrate/import-hint";
+
+let home: string;
+
+async function writeFile(rel: string, content: string): Promise<void> {
+	const full = path.join(home, rel);
+	await fs.mkdir(path.dirname(full), { recursive: true });
+	await fs.writeFile(full, content, "utf-8");
+}
+
+beforeEach(async () => {
+	home = await fs.mkdtemp(path.join(os.tmpdir(), "migrate-import-hint-"));
+});
+
+afterEach(async () => {
+	await fs.rm(home, { recursive: true, force: true });
+});
+
+describe("detectImportableMcpSources", () => {
+	test("empty home yields no importable sources", async () => {
+		const sources = await detectImportableMcpSources(home);
+		expect(sources).toEqual([]);
+	});
+
+	test("detects sources with MCP servers, in canonical order with counts and aliases", async () => {
+		await writeFile(
+			".claude.json",
+			JSON.stringify({ mcpServers: { a: { command: "bin" }, b: { url: "https://d.test/mcp" } } }),
+		);
+		await writeFile(".codex/config.toml", '[mcp_servers.codexsrv]\ncommand = "bin"\n');
+		await writeFile(".cursor/mcp.json", JSON.stringify({ mcpServers: { c: { command: "bin" } } }));
+
+		const sources = await detectImportableMcpSources(home);
+
+		// Canonical order is claude-code, codex, opencode, cursor.
+		expect(sources.map(s => s.source)).toEqual(["claude-code", "codex", "cursor"]);
+		expect(sources).toEqual([
+			{ source: "claude-code", importArg: "claude", displayName: "Claude Code", count: 2 },
+			{ source: "codex", importArg: "codex", displayName: "Codex", count: 1 },
+			{ source: "cursor", importArg: "cursor", displayName: "Cursor", count: 1 },
+		]);
+	});
+
+	test("omits sources with no MCP servers", async () => {
+		// Claude config present but empty; only cursor has a server.
+		await writeFile(".claude.json", JSON.stringify({ mcpServers: {} }));
+		await writeFile(".cursor/mcp.json", JSON.stringify({ mcpServers: { only: { command: "bin" } } }));
+
+		const sources = await detectImportableMcpSources(home);
+		expect(sources.map(s => s.source)).toEqual(["cursor"]);
+	});
+
+	test("skips malformed configs silently", async () => {
+		await writeFile(".claude.json", "{ not json");
+		await writeFile(".codex/config.toml", "this is = = not toml ][");
+		await writeFile(".cursor/mcp.json", JSON.stringify({ mcpServers: { c: { command: "bin" } } }));
+
+		// Malformed sources are simply dropped; the valid cursor config still shows.
+		const sources = await detectImportableMcpSources(home);
+		expect(sources.map(s => s.source)).toEqual(["cursor"]);
+	});
+});
+
+describe("formatImportHintLine", () => {
+	test("uses singular for one server and the import alias", () => {
+		const line = formatImportHintLine({
+			source: "claude-code",
+			importArg: "claude",
+			displayName: "Claude Code",
+			count: 1,
+		});
+		expect(line).toBe("Tip: found 1 MCP server in Claude Code config — run `gjc mcp import claude` to copy them.");
+	});
+
+	test("uses plural for multiple servers", () => {
+		const line = formatImportHintLine({ source: "cursor", importArg: "cursor", displayName: "Cursor", count: 3 });
+		expect(line).toBe("Tip: found 3 MCP servers in Cursor config — run `gjc mcp import cursor` to copy them.");
+	});
+});


### PR DESCRIPTION
## What

When no MCP servers are configured, GJC now suggests `gjc mcp import` with the host sources it can detect on the machine. Adds an import-hint detector (`detectImportableMcpSources` / `formatImportHintLine`) wired into the empty-list output of `gjc mcp list` and the `/mcp` controller, so a first-time user is pointed at the one-time import path instead of an empty list.

## Why

Part 6 of the MCP series. Built on Parts 4-5 (#1525, #1526); its diff versus dev shows their commits until they merge, and this PR's own change is the top commit. Depends on Part 4's cursor migrate adapter (the hint enumerates the same importable sources the import command accepts).

## Testing

- Pinned biome 2.5.1 `biome check` on the changed files: clean, no fixes.
- `bun run --cwd packages/coding-agent check` (biome + `tsgo` typecheck): clean, exit 0.
- Clean-env `bun test` (fresh `HOME` / `GJC_CODING_AGENT_DIR` tmp dir): `migrate-import-hint`, `mcp-cli`, `runtime-mcp/*` — **41 pass / 0 fail** across 6 files.
- Fork-CI probe on a `dev`-synced base (diff carries Parts 4-5 commits until they merge) — green including `check:@gajae-code/coding-agent`, `cli-smoke`, and the `mcp-cli` / `migrate-import-hint` test shards: https://github.com/mpfo0106/gajae-code/actions/runs/28698788084

Supersedes closed #1494 with a fresh branch.
