### PR TITLE
feat(notifications): gate Telegram session commands by bot mention

### DIFF
--- a/packages/coding-agent/src/notifications/lifecycle-commands.ts
+++ b/packages/coding-agent/src/notifications/lifecycle-commands.ts
@@ -15,6 +15,25 @@ import * as os from "node:os";
 import type { SessionCloseTarget, SessionCreateTarget, SessionLifecycleResponse, SessionResumeTarget } from "./index";
 
 export type LifecycleCommandVerb = "session_create" | "session_close" | "session_resume";
+function firstLifecycleCommandToken(text: string | undefined): string | undefined {
+	if (!text) return undefined;
+	const [rawCommand] = text.trim().split(/\s+/, 1);
+	return rawCommand;
+}
+
+function normalizeLifecycleCommandToken(
+	token: string,
+	ctx: { chatType?: string; botUsername?: string } = {},
+): string | undefined {
+	const at = token.indexOf("@");
+	const command = at === -1 ? token : token.slice(0, at);
+	if (!/^\/session_(create|close|resume|recent)\b/.test(command)) return undefined;
+	if (at === -1) return ctx.chatType === undefined || ctx.chatType === "private" ? command : undefined;
+
+	const botUsername = ctx.botUsername;
+	if (!botUsername || token.slice(at + 1).toLowerCase() !== botUsername.toLowerCase()) return undefined;
+	return command;
+}
 
 /** A parsed, validated lifecycle command (transport identity added by caller). */
 export type ParsedLifecycleCommand =
@@ -36,10 +55,22 @@ const USAGE = [
 	"/session_recent [create|resume]",
 ].join("\n");
 
-/** True when the text begins a /session_* command (cheap pre-gate). */
-export function isLifecycleCommandText(text: string | undefined): boolean {
-	if (!text) return false;
-	return /^\/session_(create|close|resume|recent)\b/.test(text.trim());
+/** True when the text begins with any /session_* token, regardless of addressability. */
+export function isLifecycleCommandLikeText(text: string | undefined): boolean {
+	const token = firstLifecycleCommandToken(text);
+	if (!token) return false;
+	const at = token.indexOf("@");
+	const command = at === -1 ? token : token.slice(0, at);
+	return /^\/session_(create|close|resume|recent)\b/.test(command);
+}
+
+/** True when the text begins an addressable /session_* command (cheap pre-gate). */
+export function isLifecycleCommandText(
+	text: string | undefined,
+	ctx: { chatType?: string; botUsername?: string } = {},
+): boolean {
+	const rawCommand = firstLifecycleCommandToken(text);
+	return normalizeLifecycleCommandToken(rawCommand ?? "", ctx) !== undefined;
 }
 
 /**
@@ -50,9 +81,14 @@ export function isLifecycleCommandText(text: string | undefined): boolean {
  * The caller MUST have already enforced paired-chat authorization; this function
  * performs grammar + target validation only.
  */
-export function parseLifecycleCommand(text: string | undefined): ParsedLifecycleCommand {
-	if (!isLifecycleCommandText(text)) return { kind: "none" };
+export function parseLifecycleCommand(
+	text: string | undefined,
+	ctx: { chatType?: string; botUsername?: string } = {},
+): ParsedLifecycleCommand {
 	const raw = (text ?? "").trim();
+	const [rawCommand, ...args] = raw.split(/\s+/);
+	const command = normalizeLifecycleCommandToken(rawCommand ?? "", ctx);
+	if (command === undefined) return { kind: "none" };
 
 	// MVP: reject any initial-prompt separator outright (no prompt handling yet).
 	if (/\s--(\s|$)/.test(raw)) {
@@ -62,8 +98,6 @@ export function parseLifecycleCommand(text: string | undefined): ParsedLifecycle
 			message: `Initial prompts (\`-- <prompt>\`) are not supported yet. Create the session, then send a normal message in its thread.\n\n${USAGE}`,
 		};
 	}
-
-	const [command, ...args] = raw.split(/\s+/);
 
 	if (command === "/session_recent") {
 		const which = args[0];

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -27,6 +27,7 @@ import type {
 } from "./index";
 import {
 	formatLifecycleOutcome,
+	isLifecycleCommandLikeText,
 	isLifecycleCommandText,
 	lifecycleUsage,
 	parseLifecycleCommand,
@@ -820,6 +821,8 @@ export class TelegramNotificationDaemon {
 	private readonly flatIdentitySent = new Set<string>();
 	/** Cached result of whether the paired chat is a private chat (flat-fallback gate). */
 	private pairedChatPrivate: boolean | undefined;
+	/** Bot username from getMe, cached once at owner startup for group/forum command targeting. */
+	private botUsername: string | undefined;
 	/** Sessions whose agent loop is currently busy (drives the typing indicator). */
 	private get busy(): Set<string> {
 		return this.dispatchState.busy;
@@ -1078,8 +1081,9 @@ export class TelegramNotificationDaemon {
 		text: string | undefined,
 		updateId: number | undefined,
 		threadId: number | undefined,
+		commandCtx: { chatType?: string; botUsername?: string },
 	): Promise<boolean> {
-		if (!isLifecycleCommandText(text)) return false;
+		if (!isLifecycleCommandText(text, commandCtx)) return false;
 		const reply = async (body: string): Promise<void> => {
 			for (const text of splitTelegramPlainText(body)) {
 				await this.botApi
@@ -1104,6 +1108,8 @@ export class TelegramNotificationDaemon {
 			}
 		};
 
+		const parsed = parseLifecycleCommand(text, commandCtx);
+		if (parsed.kind === "none") return false;
 		if (!this.lifecycleControlActive) {
 			await reply("Session lifecycle control is not available right now.");
 			return true;
@@ -1111,8 +1117,6 @@ export class TelegramNotificationDaemon {
 		if (updateId !== undefined && this.dispatchState.seenUpdateIds.has(updateId)) return true;
 		if (updateId !== undefined) this.dispatchState.seenUpdateIds.add(updateId);
 
-		const parsed = parseLifecycleCommand(text);
-		if (parsed.kind === "none") return false;
 		if (parsed.kind === "usage" || parsed.kind === "reject") {
 			await reply(parsed.message);
 			return true;
@@ -1143,6 +1147,17 @@ export class TelegramNotificationDaemon {
 		const response = await this.submitLifecycleFrame(frame);
 		await reply(this.formatLifecycleResponse(response));
 		return true;
+	}
+
+	private async refreshBotIdentity(): Promise<void> {
+		try {
+			const response = (await this.botApi.call("getMe", {})) as { result?: { username?: unknown } };
+			const username = response.result?.username;
+			this.botUsername =
+				typeof username === "string" && username.trim() ? username.trim().replace(/^@/, "") : undefined;
+		} catch {
+			this.botUsername = undefined;
+		}
 	}
 
 	/** Map a lifecycle response/error to a user-facing message (G010 surfacing). */
@@ -1924,12 +1939,18 @@ export class TelegramNotificationDaemon {
 		// session input.
 		{
 			const m = (update as { update_id?: number; message?: Record<string, unknown> }).message;
-			const chatId = (m?.chat as { id?: unknown } | undefined)?.id;
+			const chat = m?.chat as { id?: unknown; type?: unknown } | undefined;
+			const chatId = chat?.id;
+			const chatType = typeof chat?.type === "string" ? chat.type : undefined;
 			const cmdText = typeof m?.text === "string" ? m.text : undefined;
-			if (m !== undefined && String(chatId) === String(this.opts.chatId) && isLifecycleCommandText(cmdText)) {
-				const updateId = (update as { update_id?: number }).update_id;
-				const threadId = typeof m.message_thread_id === "number" ? (m.message_thread_id as number) : undefined;
-				if (await this.handleLifecycleCommand(cmdText, updateId, threadId)) return;
+			const commandCtx = { chatType, botUsername: this.botUsername };
+			if (m !== undefined && String(chatId) === String(this.opts.chatId)) {
+				if (isLifecycleCommandText(cmdText, commandCtx)) {
+					const updateId = (update as { update_id?: number }).update_id;
+					const threadId = typeof m.message_thread_id === "number" ? (m.message_thread_id as number) : undefined;
+					if (await this.handleLifecycleCommand(cmdText, updateId, threadId, commandCtx)) return;
+				}
+				if (chatType !== undefined && chatType !== "private" && isLifecycleCommandLikeText(cmdText)) return;
 			}
 		}
 		// Threaded injection: a free-text message in a known topic (not a button
@@ -2068,6 +2089,7 @@ export class TelegramNotificationDaemon {
 		this.startScanTimer();
 		this.startTypingTimer();
 		try {
+			await this.refreshBotIdentity();
 			await this.registerBotCommands();
 			await this.loadAliases();
 			await this.loadTopics();

--- a/packages/coding-agent/test/notifications-lifecycle-commands.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-commands.test.ts
@@ -64,6 +64,45 @@ describe("lifecycle command parser (G009)", () => {
 		expect(parseLifecycleCommand("/session_recent")).toEqual({ kind: "recent", which: "all" });
 		expect(parseLifecycleCommand("/session_recent create")).toEqual({ kind: "recent", which: "create" });
 	});
+	it("accepts only this bot's Telegram username suffix in non-private chats", () => {
+		const groupCtx = { chatType: "supergroup", botUsername: "GajaeCodeBot" };
+		expect(isLifecycleCommandText("/session_recent@GajaeCodeBot", groupCtx)).toBe(true);
+		expect(parseLifecycleCommand("/session_recent@GajaeCodeBot", groupCtx)).toEqual({
+			kind: "recent",
+			which: "all",
+		});
+		expect(parseLifecycleCommand("/session_create@GajaeCodeBot path /repo", groupCtx)).toEqual({
+			kind: "create",
+			target: { kind: "existing_path", path: "/repo" },
+		});
+		expect(parseLifecycleCommand("/session_create@GajaeCodeBot worktree /repo feat/x", groupCtx)).toEqual({
+			kind: "create",
+			target: { kind: "worktree", repo: "/repo", branch: "feat/x" },
+		});
+		expect(parseLifecycleCommand("/session_create@GajaeCodeBot dir /new/dir", groupCtx)).toEqual({
+			kind: "create",
+			target: { kind: "plain_dir", path: "/new/dir" },
+		});
+		expect(parseLifecycleCommand("/session_close@GajaeCodeBot sess-1", groupCtx)).toEqual({
+			kind: "close",
+			target: { sessionId: "sess-1" },
+		});
+		expect(parseLifecycleCommand("/session_resume@GajaeCodeBot abc", groupCtx)).toEqual({
+			kind: "resume",
+			target: { sessionIdOrPrefix: "abc" },
+		});
+		expect(
+			parseLifecycleCommand("/session_recent@GajaeCodeBot", { chatType: "group", botUsername: "gajaecodebot" }),
+		).toEqual({
+			kind: "recent",
+			which: "all",
+		});
+		expect(parseLifecycleCommand("/session_recent", groupCtx)).toEqual({ kind: "none" });
+		expect(parseLifecycleCommand("/session_recent@OtherBot", groupCtx)).toEqual({ kind: "none" });
+		expect(parseLifecycleCommand("/session_recent@GajaeCodeBot", { chatType: "supergroup" })).toEqual({
+			kind: "none",
+		});
+	});
 
 	it("rejects an initial prompt (MVP) with usage and no frame", () => {
 		const out = parseLifecycleCommand("/session_create path /repo -- do the thing");

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -72,6 +72,7 @@ class FakeBotApi {
 	updates: any[] = [];
 	activeGetUpdates = 0;
 	maxConcurrentGetUpdates = 0;
+	botUsername: string | undefined = undefined;
 	async call(method: string, body: unknown): Promise<unknown> {
 		this.calls.push({ method, body });
 		if (method === "getUpdates") {
@@ -83,6 +84,8 @@ class FakeBotApi {
 			this.updates = [];
 			return { ok: true, result };
 		}
+		if (method === "getMe")
+			return { ok: true, result: this.botUsername ? { id: 1, username: this.botUsername } : { id: 1 } };
 		if (method === "getFile") return { ok: true, result: { file_path: "docs/file_7.bin" } };
 		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: this.calls.length } };
 		if (method === "sendMessage") return { ok: true, result: { message_id: this.calls.length } };
@@ -863,6 +866,93 @@ test("daemon registers in-thread config and lifecycle commands and drops stale r
 	expect(cmds).not.toContain("answer");
 	expect(cmds).not.toContain("attach");
 	expect(cmds).not.toContain("detach");
+});
+test("forum lifecycle commands must target this bot username", async () => {
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(tempAgentDir()),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+	});
+	Object.assign(daemon, { lifecycleControlActive: true, botUsername: "GajaeCodeBot" });
+
+	await daemon.handleTelegramUpdate({
+		update_id: 101,
+		message: { chat: { id: -10042, type: "supergroup" }, text: "/session_recent", message_id: 1 },
+	});
+	await daemon.handleTelegramUpdate({
+		update_id: 102,
+		message: { chat: { id: -10042, type: "supergroup" }, text: "/session_recent@OtherBot", message_id: 2 },
+	});
+	expect(bot.calls.filter(c => c.method === "sendMessage")).toHaveLength(0);
+
+	await daemon.handleTelegramUpdate({
+		update_id: 103,
+		message: { chat: { id: -10042, type: "supergroup" }, text: "/session_recent@GajaeCodeBot", message_id: 3 },
+	});
+	const sends = bot.calls.filter(c => c.method === "sendMessage");
+	expect(sends).toHaveLength(1);
+	expect(String(sends[0]!.body.text)).toContain("No recent sessions.");
+});
+
+test("forum lifecycle commands fail closed when bot username is unavailable", async () => {
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(tempAgentDir()),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+	});
+	Object.assign(daemon, { lifecycleControlActive: true });
+
+	await daemon.handleTelegramUpdate({
+		update_id: 104,
+		message: { chat: { id: -10042, type: "supergroup" }, text: "/session_recent@GajaeCodeBot", message_id: 4 },
+	});
+
+	expect(bot.calls.filter(c => c.method === "sendMessage")).toHaveLength(0);
+});
+
+test("non-addressable forum lifecycle commands in known topics are dropped", async () => {
+	let updateId = 200;
+	const exercise = async (text: string, botUsername?: string): Promise<void> => {
+		FakeWs.instances = [];
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: settings(tempAgentDir()),
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "-10042",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+		});
+		Object.assign(daemon, { lifecycleControlActive: true, botUsername });
+		daemon.connectSession("S", "ws://s", "ts");
+		const session = daemon.sessions.get("S")!;
+		await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
+		const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
+		bot.calls = [];
+
+		await daemon.handleTelegramUpdate({
+			update_id: updateId++,
+			message: {
+				chat: { id: -10042, type: "supergroup" },
+				message_thread_id: threadId,
+				message_id: updateId,
+				text,
+			},
+		});
+
+		expect(FakeWs.instances[0]!.sent).toHaveLength(0);
+		expect(bot.calls.filter(c => c.method === "sendMessage")).toHaveLength(0);
+	};
+
+	await exercise("/session_recent", "GajaeCodeBot");
+	await exercise("/session_recent@OtherBot", "GajaeCodeBot");
+	await exercise("/session_recent@GajaeCodeBot");
 });
 
 test("ensureTelegramDaemonRunning spawns the daemon subcommand with owner-id and agent-dir", async () => {


### PR DESCRIPTION
## Summary
- Allow Telegram `/session_*` lifecycle commands in group, supergroup, and forum chats only when they are addressed to this bot with `@BotUsername`.
- Preserve private-chat behavior: suffix-less `/session_*` commands still work in DMs.
- Cache the bot username from `getMe` at daemon startup and fail closed for non-private command routing when the username is unavailable.
- Add parser and Telegram daemon coverage for matching suffixes, wrong-bot suffixes, suffix-less group messages, and username-unavailable fail-closed behavior.

## Scope
- Does not change per-user ACL behavior or paired-chat authorization.
- Does not change session create/resume/close orchestration semantics.
- Does not change topic creation, notification copy, or non-lifecycle message routing.

## Validation
- `bun test packages/coding-agent/test/notifications-lifecycle-commands.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun run check:ts`
- `rtk git diff --check`

Supersedes #1527.
