### PR TITLE
Expand welcome splash dynamic content

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -395,30 +395,28 @@ async function getChangelogForDisplay(parsed: Args): Promise<string | undefined>
 		return undefined;
 	}
 
-	const lastVersion = settings.get("lastChangelogVersion");
-	if (lastVersion === VERSION) {
-		// Steady state: user already saw the current version's changelog. Skip the file read + parse.
+	const entries = getDisplayChangelogEntries();
+	if (entries.length === 0) {
 		return undefined;
 	}
 
-	const entries = getDisplayChangelogEntries();
-
+	const lastVersion = settings.get("lastChangelogVersion");
 	if (!lastVersion) {
-		if (entries.length > 0) {
-			settings.set("lastChangelogVersion", VERSION);
-			await flushChangelogVersion();
-			return getInstalledVersionChangelogEntry(entries, VERSION)?.content;
-		}
-	} else {
+		settings.set("lastChangelogVersion", VERSION);
+		await flushChangelogVersion();
+		return getInstalledVersionChangelogEntry(entries, VERSION)?.content;
+	}
+
+	if (lastVersion !== VERSION) {
 		const newEntries = getNewEntries(entries, lastVersion);
+		settings.set("lastChangelogVersion", VERSION);
+		await flushChangelogVersion();
 		if (newEntries.length > 0) {
-			settings.set("lastChangelogVersion", VERSION);
-			await flushChangelogVersion();
 			return newEntries.map(e => e.content).join("\n\n");
 		}
 	}
 
-	return undefined;
+	return getInstalledVersionChangelogEntry(entries, VERSION)?.content;
 }
 
 async function flushChangelogVersion(): Promise<void> {

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -21,6 +21,10 @@ export interface WelcomeComponentOptions {
 	collapseChangelog?: boolean;
 }
 
+const WELCOME_FIXED_RIGHT_ROWS_EXCLUDING_DYNAMIC_SECTIONS = 13;
+const DEFAULT_WHATS_NEW_ROWS = 3;
+const MAX_WHATS_NEW_ROWS = 12;
+
 /**
  * GJC-native launch surface with compact command affordances, project
  * signals, and a claw/talon mark without copying another agent shell.
@@ -142,9 +146,6 @@ export class WelcomeComponent implements Component {
 
 		const rightColumnWidth = showRightColumn ? rightCol : leftCol;
 		const separator = buildSeparator(rightColumnWidth);
-		const changelogBudget = Math.max(1, Math.min(6, Math.floor((targetContentRows ?? 18) * 0.3)));
-
-		const changelogLines = this.#whatsNewLines(rightColumnWidth, changelogBudget);
 		const lspLines: string[] = [];
 		if (this.lspServers.length === 0) {
 			lspLines.push(` ${theme.fg("dim", "No LSP servers")}`);
@@ -161,6 +162,8 @@ export class WelcomeComponent implements Component {
 			}
 		}
 
+		const changelogRowLimit = this.#whatsNewRowLimit(targetContentRows, lspLines.length);
+		const changelogLines = this.#whatsNewLines(rightColumnWidth, changelogRowLimit);
 		const sessionLimit = this.#sessionTrailLimit(targetContentRows, changelogLines.length, lspLines.length);
 		const sessionLines = this.#sessionTrailLines(rightColumnWidth, sessionLimit);
 
@@ -301,17 +304,30 @@ export class WelcomeComponent implements Component {
 		return [...Array.from({ length: topPad }, () => ""), ...clipped, ...Array.from({ length: bottomPad }, () => "")];
 	}
 
+	#whatsNewRowLimit(targetContentRows: number | undefined, lspLineCount: number): number {
+		if (targetContentRows === undefined) return 5;
+
+		const sessionBaselineRows = this.recentSessions.length === 0 ? 1 : Math.min(3, this.recentSessions.length);
+		const dynamicRows = Math.max(
+			1,
+			targetContentRows - WELCOME_FIXED_RIGHT_ROWS_EXCLUDING_DYNAMIC_SECTIONS - lspLineCount,
+		);
+		const rowsAfterBaselineSessions = Math.max(1, dynamicRows - sessionBaselineRows);
+		const spareRows = Math.max(0, rowsAfterBaselineSessions - DEFAULT_WHATS_NEW_ROWS);
+		return Math.max(
+			1,
+			Math.min(MAX_WHATS_NEW_ROWS, rowsAfterBaselineSessions, DEFAULT_WHATS_NEW_ROWS + Math.floor(spareRows / 2)),
+		);
+	}
+
 	#sessionTrailLimit(targetContentRows: number | undefined, changelogLineCount: number, lspLineCount: number): number {
 		if (this.recentSessions.length === 0) return 0;
 
 		const defaultLimit = Math.min(3, this.recentSessions.length);
 		if (targetContentRows === undefined) return defaultLimit;
 
-		// Right-column rows that are always present when the session trail is shown:
-		// top/bottom padding, section headers, separators, and the four flow-key hints.
-		const fixedRightRowsExcludingDynamicSections = 13;
 		const rowsWithDefaultTrail =
-			fixedRightRowsExcludingDynamicSections + changelogLineCount + lspLineCount + defaultLimit;
+			WELCOME_FIXED_RIGHT_ROWS_EXCLUDING_DYNAMIC_SECTIONS + changelogLineCount + lspLineCount + defaultLimit;
 		const extraRows = Math.max(0, targetContentRows - rowsWithDefaultTrail);
 		return Math.min(this.recentSessions.length, defaultLimit + extraRows);
 	}
@@ -335,7 +351,8 @@ export class WelcomeComponent implements Component {
 		return lines;
 	}
 
-	#whatsNewLines(width: number, maxItems: number): string[] {
+	#whatsNewLines(width: number, maxRows: number): string[] {
+		const rowLimit = Math.max(1, Math.floor(maxRows));
 		const changelog = this.options.changelogMarkdown?.trim();
 		if (!changelog) {
 			return [` ${theme.fg("dim", "Ready for your next prompt")}`];
@@ -346,25 +363,25 @@ export class WelcomeComponent implements Component {
 			return [
 				` ${theme.fg("muted", `Updated to v${version}`)}`,
 				` ${theme.fg("dim", `Use ${theme.bold("/changelog")} for details`)}`,
-			];
+			].slice(0, rowLimit);
 		}
 
-		const itemLimit = Math.max(1, Math.floor(maxItems));
 		const items = this.#changelogItems(changelog);
 		if (items.length === 0) {
 			return [
 				` ${theme.fg("muted", `Updated to v${version}`)}`,
 				` ${theme.fg("dim", `Use ${theme.bold("/changelog")} for details`)}`,
-			];
+			].slice(0, rowLimit);
 		}
 
 		const prefix = ` ${theme.md.bullet} `;
 		const textWidth = Math.max(1, width - visibleWidth(prefix));
-		const visibleItems = items.slice(0, itemLimit).map(item => {
+		const visibleItemCount = items.length > rowLimit ? Math.max(1, rowLimit - 1) : rowLimit;
+		const visibleItems = items.slice(0, visibleItemCount).map(item => {
 			const text = visibleWidth(item) > textWidth ? truncateToWidth(item, textWidth) : item;
 			return `${theme.fg("dim", prefix)}${theme.fg("muted", text)}`;
 		});
-		if (items.length > visibleItems.length) {
+		if (items.length > visibleItems.length && visibleItems.length < rowLimit) {
 			visibleItems.push(` ${theme.fg("dim", `… ${theme.bold("/changelog")} for full notes`)}`);
 		}
 		return visibleItems;

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -101,7 +101,6 @@ export class WelcomeComponent implements Component {
 		}
 		const targetContentRows = targetRows === undefined ? undefined : Math.max(0, targetRows - 2);
 		const dualContentWidth = boxWidth - 3; // 3 = │ + │ + │
-		const preferredLeftCol = 40;
 		const minLeftCol = 20; // logo mark plus GJC identity labels
 		const minRightCol = 24;
 		const modelPill = this.#pill(theme.icon.model || "model", this.modelName, "statusLineModel");
@@ -116,10 +115,12 @@ export class WelcomeComponent implements Component {
 			visibleWidth(modelPill),
 			visibleWidth(providerPill),
 		);
-		const desiredLeftCol = Math.min(preferredLeftCol, Math.max(minLeftCol, Math.floor(dualContentWidth * 0.38)));
+		const evenLeftCol = Math.floor(dualContentWidth / 2);
+		const maxLeftColWithRightMinimum = Math.max(1, dualContentWidth - minRightCol);
+		const desiredLeftCol = Math.max(leftMinContentWidth, evenLeftCol);
 		const dualLeftCol =
 			dualContentWidth >= minRightCol + 1
-				? Math.min(desiredLeftCol, dualContentWidth - minRightCol)
+				? Math.min(desiredLeftCol, maxLeftColWithRightMinimum)
 				: Math.max(1, dualContentWidth - 1);
 		const dualRightCol = Math.max(1, dualContentWidth - dualLeftCol);
 		const showRightColumn = dualLeftCol >= leftMinContentWidth && dualRightCol >= minRightCol;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -117,7 +117,8 @@ import type { CompactionQueuedMessage, InteractiveModeContext, SubmittedUserInpu
 import { UiHelpers } from "./utils/ui-helpers";
 
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
-const DEFAULT_COMPOSER_PLACEHOLDER = "Type your message...";
+const COMPOSER_NEWLINE_HINT = process.platform === "win32" ? "Alt+Enter/Ctrl+J" : "Shift+Enter/Ctrl+J";
+const DEFAULT_COMPOSER_PLACEHOLDER = `Type your message... ${COMPOSER_NEWLINE_HINT}: New line · Ctrl+C: Clear`;
 const FRIENDLY_KEY_PARTS: Record<string, string> = {
 	alt: "Alt",
 	cmd: "Command",
@@ -943,7 +944,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		const parts = [`Enter: ${enterAction}`];
 		const queueKey = this.#getMessageQueueShortcut();
 		if (queueKey) parts.push(`${formatShortcutForPlaceholder(queueKey)}: Message Queueing`);
-		return `${DEFAULT_COMPOSER_PLACEHOLDER} ${parts.join(" · ")}`;
+		return `${DEFAULT_COMPOSER_PLACEHOLDER} · ${parts.join(" · ")}`;
 	}
 
 	updateEditorChrome(): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -119,6 +119,7 @@ import { UiHelpers } from "./utils/ui-helpers";
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
 const COMPOSER_NEWLINE_HINT = process.platform === "win32" ? "Alt+Enter/Ctrl+J" : "Shift+Enter/Ctrl+J";
 const DEFAULT_COMPOSER_PLACEHOLDER = `Type your message... ${COMPOSER_NEWLINE_HINT}: New line · Ctrl+C: Clear`;
+const WELCOME_RESERVED_CONTAINER_CHILD_LIMIT = 8;
 const FRIENDLY_KEY_PARTS: Record<string, string> = {
 	alt: "Alt",
 	cmd: "Command",
@@ -531,13 +532,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		if (!startupQuiet) {
-			const getWelcomeReservedBottomRows = (width: number): number =>
-				[
-					this.statusLine,
-					this.hookWidgetContainerAbove,
-					this.editorContainer,
-					this.hookWidgetContainerBelow,
-				].reduce((rows, component) => rows + component.render(width).length, 0);
+			const getWelcomeReservedBottomRows = (width: number): number => this.#getWelcomeReservedRows(width);
 
 			// Add welcome header
 			this.#welcomeComponent = new WelcomeComponent(
@@ -945,6 +940,32 @@ export class InteractiveMode implements InteractiveModeContext {
 		const queueKey = this.#getMessageQueueShortcut();
 		if (queueKey) parts.push(`${formatShortcutForPlaceholder(queueKey)}: Message Queueing`);
 		return `${DEFAULT_COMPOSER_PLACEHOLDER} · ${parts.join(" · ")}`;
+	}
+
+	#getWelcomeReservedRows(width: number): number {
+		const transientRows = [
+			this.chatContainer,
+			this.pendingMessagesContainer,
+			this.statusContainer,
+			this.todoContainer,
+			this.btwContainer,
+		].reduce((rows, container) => rows + this.#renderShortContainerRowsForWelcomeReservation(width, container), 0);
+
+		const pinnedRows = [
+			this.statusLine,
+			this.hookWidgetContainerAbove,
+			this.editorContainer,
+			this.hookWidgetContainerBelow,
+		].reduce((rows, component) => rows + component.render(width).length, 0);
+
+		return transientRows + pinnedRows;
+	}
+
+	#renderShortContainerRowsForWelcomeReservation(width: number, container: Container): number {
+		if (container.children.length === 0 || container.children.length > WELCOME_RESERVED_CONTAINER_CHILD_LIMIT) {
+			return 0;
+		}
+		return container.render(width).length;
 	}
 
 	updateEditorChrome(): void {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2254,10 +2254,12 @@ class NdjsonFileWriter {
 	}
 }
 
+const DEFAULT_WELCOME_RECENT_SESSION_LIMIT = 20;
+
 /** Get recent sessions for display in welcome screen */
 export async function getRecentSessions(
 	sessionDir: string,
-	limit = 3,
+	limit = DEFAULT_WELCOME_RECENT_SESSION_LIMIT,
 	storage: SessionStorage = new FileSessionStorage(),
 ): Promise<RecentSessionInfo[]> {
 	const sessions = await getSortedSessions(sessionDir, storage);

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -4,7 +4,7 @@ import { stripVTControlCharacters } from "node:util";
 import { Agent } from "@gajae-code/agent-core";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { initTheme, theme } from "@gajae-code/coding-agent/modes/theme/theme";
-import { CURSOR_MARKER } from "@gajae-code/tui";
+import { CURSOR_MARKER, Spacer, Text } from "@gajae-code/tui";
 import { TempDir } from "@gajae-code/utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import { CustomEditor } from "../src/modes/components/custom-editor";
@@ -16,6 +16,11 @@ import { SessionManager } from "../src/session/session-manager";
 class TestModalEditor extends CustomEditor {}
 function stripRenderControls(line: string): string {
 	return stripVTControlCharacters(line.replaceAll(CURSOR_MARKER, ""));
+}
+
+function forceTerminalSize(mode: InteractiveMode, columns: number, rows: number): void {
+	Object.defineProperty(mode.ui.terminal, "columns", { configurable: true, get: () => columns });
+	Object.defineProperty(mode.ui.terminal, "rows", { configurable: true, get: () => rows });
 }
 
 describe("InteractiveMode.setEditorComponent", () => {
@@ -132,6 +137,28 @@ describe("InteractiveMode.setEditorComponent", () => {
 		mode.setHookWidget("test", undefined);
 
 		assertComposerFollowsStatusLine();
+	});
+
+	it("keeps the welcome splash viewport-bound when /new shows a notification", async () => {
+		const width = 100;
+		const rows = 28;
+		vi.spyOn(mode.ui, "start").mockImplementation(() => {});
+		forceTerminalSize(mode, width, rows);
+
+		await mode.init();
+
+		mode.chatContainer.clear();
+		mode.chatContainer.addChild(new Spacer(1));
+		mode.chatContainer.addChild(
+			new Text(`${theme.fg("accent", `${theme.status.success} New session started`)}`, 1, 1),
+		);
+
+		const rendered = mode.ui.render(width).map(stripRenderControls);
+		const renderedText = rendered.join("\n");
+
+		expect(rendered.length).toBeLessThanOrEqual(rows);
+		expect(renderedText).toContain("GJC Forge");
+		expect(renderedText).toContain("New session started");
 	});
 
 	it("keeps closed rounded composer chrome for one-line, multiline, and narrow prompts", () => {

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -76,21 +76,28 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(lines.join("\n")).not.toContain("›");
 	});
 
+	function expectedNewlineShortcutHint(): string {
+		const shortcut = process.platform === "win32" ? "Alt+Enter/Ctrl+J" : "Shift+Enter/Ctrl+J";
+		return `${shortcut}: New line`;
+	}
+
 	function expectedQueueShortcutHint(): string {
 		const shortcut = process.platform === "win32" ? "Alt+q" : "Alt+Enter";
 		return `${shortcut}: Message Queueing`;
 	}
 
 	it("shows busy steering and queueing hints only while work is active", () => {
-		let rendered = mode.editor.render(96).map(stripRenderControls).join("\n");
+		let rendered = mode.editor.render(160).map(stripRenderControls).join("\n");
 		expect(rendered).toContain("Type your message...");
+		expect(rendered).toContain(expectedNewlineShortcutHint());
+		expect(rendered).toContain("Ctrl+C: Clear");
 		expect(rendered).not.toContain("Enter: Steering");
 		expect(rendered).not.toContain(expectedQueueShortcutHint());
 
 		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = true;
 		mode.updateEditorChrome();
 
-		rendered = mode.editor.render(96).map(stripRenderControls).join("\n");
+		rendered = mode.editor.render(160).map(stripRenderControls).join("\n");
 		expect(rendered).toContain("Type your message...");
 		expect(rendered).toContain("Enter: Steering");
 		expect(rendered).toContain(expectedQueueShortcutHint());
@@ -98,7 +105,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = false;
 		mode.updateEditorChrome();
 
-		rendered = mode.editor.render(96).map(stripRenderControls).join("\n");
+		rendered = mode.editor.render(160).map(stripRenderControls).join("\n");
 		expect(rendered).toContain("Type your message...");
 		expect(rendered).not.toContain("Enter: Steering");
 		expect(rendered).not.toContain(expectedQueueShortcutHint());

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import {
 	type FileEntry,
 	findMostRecentSession,
+	getRecentSessions,
 	loadEntriesFromFile,
 	resolveResumableSession,
 	type SessionHeader,
@@ -89,6 +90,40 @@ describe("findMostRecentSession", () => {
 		fs.writeFileSync(valid, '{"type":"session","id":"abc","timestamp":"2025-01-01T00:00:00Z","cwd":"/tmp"}\n');
 
 		expect(await findMostRecentSession(tempDir)).toBe(valid);
+	});
+});
+
+describe("getRecentSessions", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `session-test-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("returns enough default entries for the viewport-expanded welcome trail", async () => {
+		for (let index = 0; index < 5; index++) {
+			const file = path.join(tempDir, `session-${index}.jsonl`);
+			fs.writeFileSync(
+				file,
+				`${JSON.stringify({
+					type: "session",
+					id: `session-${index}`,
+					timestamp: `2025-01-01T00:00:0${index}Z`,
+					cwd: "/tmp",
+					title: `Recent Session ${index}`,
+				})}\n`,
+			);
+		}
+
+		const sessions = await getRecentSessions(tempDir);
+
+		expect(sessions).toHaveLength(5);
+		expect(sessions.map(session => session.name)).toContain("Recent Session 4");
 	});
 });
 

--- a/packages/coding-agent/test/welcome-viewport.test.ts
+++ b/packages/coding-agent/test/welcome-viewport.test.ts
@@ -65,6 +65,33 @@ describe("WelcomeComponent viewport sizing", () => {
 		}
 	});
 
+	it("expands What's New highlights when the viewport has spare rows", () => {
+		const changelogMarkdown = [
+			"## [1.2.3]",
+			"",
+			"### Added",
+			"",
+			...Array.from({ length: 8 }, (_, index) => `- Dynamic changelog item ${index + 1}`),
+		].join("\n");
+		const compact = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii", {
+			getViewportRows: () => 24,
+			getReservedBottomRows: () => 4,
+			changelogMarkdown,
+		});
+		const roomy = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii", {
+			getViewportRows: () => 40,
+			getReservedBottomRows: () => 4,
+			changelogMarkdown,
+		});
+
+		const compactText = compact.render(100).join("\n");
+		const roomyText = roomy.render(100).join("\n");
+
+		expect(compactText).toContain("Dynamic changelog item 1");
+		expect(compactText).not.toContain("Dynamic changelog item 4");
+		expect(roomyText).toContain("Dynamic changelog item 8");
+	});
+
 	it("does not steal rows when the pinned composer already fills the viewport", () => {
 		const hidden = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii", {
 			getViewportRows: () => 5,

--- a/packages/coding-agent/test/welcome-viewport.test.ts
+++ b/packages/coding-agent/test/welcome-viewport.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
 import { visibleWidth } from "@gajae-code/tui";
 import { WelcomeComponent } from "../src/modes/components/welcome";
 import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
@@ -9,6 +10,24 @@ beforeAll(async () => {
 	setThemeInstance(theme);
 });
 
+function stripRenderControls(line: string): string {
+	return stripVTControlCharacters(line);
+}
+
+function renderedColumnWidths(lines: string[]): { left: number; right: number } {
+	for (const line of lines.map(stripRenderControls)) {
+		const separators = Array.from(line.matchAll(/│/g), match => match.index ?? -1);
+		if (separators.length >= 3) {
+			const [leftEdge, divider, rightEdge] = separators;
+			return {
+				left: visibleWidth(line.slice(leftEdge + 1, divider)),
+				right: visibleWidth(line.slice(divider + 1, rightEdge)),
+			};
+		}
+	}
+	throw new Error("Expected two-column welcome layout");
+}
+
 describe("WelcomeComponent viewport sizing", () => {
 	it("uses the full terminal width on wide initial forge viewports", () => {
 		const welcome = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii");
@@ -18,6 +37,13 @@ describe("WelcomeComponent viewport sizing", () => {
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBe(200);
 		}
+	});
+
+	it("splits the forge and details columns evenly on wide viewports", () => {
+		const welcome = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii");
+		const columns = renderedColumnWidths(welcome.render(140));
+
+		expect(Math.abs(columns.left - columns.right)).toBeLessThanOrEqual(1);
 	});
 
 	it("degrades gracefully on tiny terminal widths", () => {


### PR DESCRIPTION
Hello,

This follow-up keeps the startup splash content dynamic instead of fixed to the old short lists, and polishes the composer guidance for new users.

Changes:
- Increase the welcome recent-session source limit from 3 to 20 so the viewport-expanded Session trail receives enough entries.
- Make What's New use a viewport-aware row budget, expanding when the splash has spare vertical space while still preserving room for Session trail.
- Keep What's New populated with the current embedded changelog in steady-state launches instead of falling back to “Ready for your next prompt” after the version has already been seen.
- Balance the welcome splash columns so the forge/logo panel and details panel split wide terminals approximately 50/50 while preserving narrow-terminal fallback behavior.
- Keep the welcome splash viewport-bound after `/new` by reserving rows for short below-splash notices/status containers, so the splash shrinks to the current terminal viewport instead of adding scrollback overflow.
- Add composer placeholder hints for inserting a message newline and clearing the current draft (`Alt+Enter`/`Ctrl+J` on Windows, `Shift+Enter`/`Ctrl+J` elsewhere, plus `Ctrl+C` clear).
- While the agent is busy, show concise composer delivery hints for `Enter: Steer` or `Enter: Queue` plus the explicit queue shortcut such as `Alt+Q: Queue` on Windows.
- Add regression coverage for the recent-session source limit, dynamic What's New expansion, balanced splash columns, `/new` viewport sizing, and composer placeholder hints.

Verification:
- `bun test packages/coding-agent/test/welcome-viewport.test.ts`
- `bun test packages/coding-agent/test/interactive-mode-editor-component.test.ts -t "viewport-bound"`
- `bun test packages/coding-agent/test/interactive-mode-editor-component.test.ts -t "busy steering"`
- `bun test packages/coding-agent/test/changelog.test.ts`
- `bun test packages/coding-agent/test/session-manager/file-operations.test.ts -t "getRecentSessions"`
- `bun --cwd=packages/coding-agent run check`
- `bun packages/coding-agent/src/cli.ts contribute-pr --no-spawn --artifact-root /tmp/gajae-contribute-pr`
- Local render check confirmed a 140-column splash splits as 68/69 columns.
- Local installed `gjc/0.8.1` patch verified in place; restart running GJC sessions to pick up the patched files.

Thank you.