### PR TITLE
Enable inline slash command autocomplete

### DIFF
--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -272,6 +272,55 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		this.#basePath = basePath;
 	}
 
+	#getCommandName(cmd: SlashCommand | AutocompleteItem): string {
+		return "name" in cmd ? cmd.name : cmd.value;
+	}
+
+	#getSlashCommandNameSuggestions(prefix: string): AutocompleteItem[] {
+		const lowerPrefix = prefix.toLowerCase();
+
+		return this.#commands
+			.filter(cmd => {
+				const name = this.#getCommandName(cmd);
+				if (!name) return false;
+				if (fuzzyMatch(lowerPrefix, name.toLowerCase())) return true;
+				if (getSlashCommandMatchRank(lowerPrefix, name.toLowerCase()) < 4) return true;
+				const desc = cmd.description?.toLowerCase();
+				return desc ? fuzzyMatch(lowerPrefix, desc) : false;
+			})
+			.map((cmd, index) => {
+				const name = this.#getCommandName(cmd);
+				const lowerName = name?.toLowerCase() ?? "";
+				const lowerDesc = cmd.description?.toLowerCase() ?? "";
+				const nameScore = fuzzyMatch(lowerPrefix, lowerName) ? fuzzyScore(lowerPrefix, lowerName) : 0;
+				const descScore = fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
+				const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
+				const desc = cmd.description ?? "";
+				const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
+				const priority = "priority" in cmd && typeof cmd.priority === "number" ? cmd.priority : 0;
+				return {
+					value: name,
+					label: "name" in cmd ? cmd.name : cmd.label,
+					score: Math.max(nameScore, descScore),
+					priority,
+					matchRank: getSlashCommandMatchRank(lowerPrefix, lowerName),
+					index,
+					...(fullDesc && { description: fullDesc }),
+				} as AutocompleteItem & { score: number; priority: number; matchRank: number; index: number };
+			})
+			.sort((a, b) => a.matchRank - b.matchRank || b.priority - a.priority || b.score - a.score || a.index - b.index)
+			.map(({ score: _score, priority: _priority, matchRank: _matchRank, index: _index, ...rest }) => rest);
+	}
+
+	#extractSlashCommandPrefix(text: string): string | null {
+		const match = text.match(/(?:^|\s)(\/[^/\s]*)$/);
+		return match?.[1] ?? null;
+	}
+
+	#isKnownCommandItem(item: AutocompleteItem): boolean {
+		return this.#commands.some(cmd => this.#getCommandName(cmd) === item.value);
+	}
+
 	async getSuggestions(
 		lines: string[],
 		cursorLine: number,
@@ -301,52 +350,14 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			};
 		}
 
-		// Check for slash commands
+		// Check for slash commands at the submitted-message start
 		if (textBeforeCursor.startsWith("/")) {
 			const spaceIndex = textBeforeCursor.indexOf(" ");
 
 			if (spaceIndex === -1) {
 				// No space yet - complete command names
 				const prefix = textBeforeCursor.slice(1); // Remove the "/"
-				const lowerPrefix = prefix.toLowerCase();
-
-				// Filter commands using fuzzy matching (subsequence match)
-				const matches = this.#commands
-					.filter(cmd => {
-						const name = "name" in cmd ? cmd.name : cmd.value;
-						if (!name) return false;
-						// Match name, normalized slash-name aliases, or description.
-						if (fuzzyMatch(lowerPrefix, name.toLowerCase())) return true;
-						if (getSlashCommandMatchRank(lowerPrefix, name.toLowerCase()) < 4) return true;
-						const desc = cmd.description?.toLowerCase();
-						return desc ? fuzzyMatch(lowerPrefix, desc) : false;
-					})
-					.map((cmd, index) => {
-						const name = "name" in cmd ? cmd.name : cmd.value;
-						const lowerName = name?.toLowerCase() ?? "";
-						const lowerDesc = cmd.description?.toLowerCase() ?? "";
-						// Score name matches higher than description matches
-						const nameScore = fuzzyMatch(lowerPrefix, lowerName) ? fuzzyScore(lowerPrefix, lowerName) : 0;
-						const descScore = fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
-						const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
-						const desc = cmd.description ?? "";
-						const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
-						const priority = "priority" in cmd && typeof cmd.priority === "number" ? cmd.priority : 0;
-						return {
-							value: name,
-							label: "name" in cmd ? cmd.name : cmd.label,
-							score: Math.max(nameScore, descScore),
-							priority,
-							matchRank: getSlashCommandMatchRank(lowerPrefix, lowerName),
-							index,
-							...(fullDesc && { description: fullDesc }),
-						};
-					})
-					.sort(
-						(a, b) =>
-							a.matchRank - b.matchRank || b.priority - a.priority || b.score - a.score || a.index - b.index,
-					)
-					.map(({ score: _score, priority: _priority, matchRank: _matchRank, index: _index, ...rest }) => rest);
+				const matches = this.#getSlashCommandNameSuggestions(prefix);
 
 				if (matches.length === 0) return null;
 
@@ -354,29 +365,37 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					items: matches,
 					prefix: textBeforeCursor,
 				};
-			} else {
-				// Space found - complete command arguments
-				const commandName = textBeforeCursor.slice(1, spaceIndex); // Command without "/"
-				const argumentText = textBeforeCursor.slice(spaceIndex + 1); // Text after space
-
-				const command = this.#commands.find(cmd => {
-					const name = "name" in cmd ? cmd.name : cmd.value;
-					return name === commandName;
-				});
-				if (!command || !("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
-					return null; // No argument completion for this command
-				}
-
-				const argumentSuggestions = await command.getArgumentCompletions(argumentText);
-				if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
-					return null;
-				}
-
-				return {
-					items: argumentSuggestions,
-					prefix: argumentText,
-				};
 			}
+
+			// Space found - complete command arguments
+			const commandName = textBeforeCursor.slice(1, spaceIndex); // Command without "/"
+			const argumentText = textBeforeCursor.slice(spaceIndex + 1); // Text after space
+
+			const command = this.#commands.find(cmd => this.#getCommandName(cmd) === commandName);
+			if (!command || !("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
+				return null; // No argument completion for this command
+			}
+
+			const argumentSuggestions = await command.getArgumentCompletions(argumentText);
+			if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
+				return null;
+			}
+
+			return {
+				items: argumentSuggestions,
+				prefix: argumentText,
+			};
+		}
+
+		const slashPrefix = this.#extractSlashCommandPrefix(textBeforeCursor);
+		if (slashPrefix) {
+			const matches = this.#getSlashCommandNameSuggestions(slashPrefix.slice(1));
+			if (matches.length === 0) return null;
+
+			return {
+				items: matches,
+				prefix: slashPrefix,
+			};
 		}
 
 		// Check for file paths - triggered by Tab or if we detect a path pattern
@@ -418,9 +437,12 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const beforePrefix = currentLine.slice(0, cursorCol - prefix.length);
 		const afterCursor = currentLine.slice(cursorCol);
 
-		// Check if we're completing a slash command (prefix starts with "/" but NOT a file path)
-		// Slash commands are at the start of the line and don't contain path separators after the first /
-		const isSlashCommand = prefix.startsWith("/") && beforePrefix.trim() === "" && !prefix.slice(1).includes("/");
+		// Check if we're completing a slash command name. Start-of-line commands
+		// execute on submit; inline slash tokens are completed as ordinary text.
+		const isSlashCommand =
+			prefix.startsWith("/") &&
+			!prefix.slice(1).includes("/") &&
+			(beforePrefix.trim() === "" || (/\s$/.test(beforePrefix) && this.#isKnownCommandItem(item)));
 		if (isSlashCommand) {
 			// This is a command name completion
 			const newLine = `${beforePrefix}/${item.value} ${afterCursor}`;
@@ -855,40 +877,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		if (textBeforeCursor.length <= 1) return null; // Bare "/" alone, don't auto-complete
 		if (textBeforeCursor.includes(" ")) return null; // Only complete command name, not args
 
-		const prefix = textBeforeCursor.slice(1);
-		const lowerPrefix = prefix.toLowerCase();
-
-		const matches = this.#commands
-			.filter(cmd => {
-				const name = "name" in cmd ? cmd.name : cmd.value;
-				if (!name) return false;
-				if (fuzzyMatch(lowerPrefix, name.toLowerCase())) return true;
-				if (getSlashCommandMatchRank(lowerPrefix, name.toLowerCase()) < 4) return true;
-				const desc = cmd.description?.toLowerCase();
-				return desc ? fuzzyMatch(lowerPrefix, desc) : false;
-			})
-			.map((cmd, index) => {
-				const name = "name" in cmd ? cmd.name : cmd.value;
-				const lowerName = name?.toLowerCase() ?? "";
-				const lowerDesc = cmd.description?.toLowerCase() ?? "";
-				const nameScore = fuzzyMatch(lowerPrefix, lowerName) ? fuzzyScore(lowerPrefix, lowerName) : 0;
-				const descScore = fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
-				const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
-				const desc = cmd.description ?? "";
-				const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
-				const priority = "priority" in cmd && typeof cmd.priority === "number" ? cmd.priority : 0;
-				return {
-					value: name,
-					label: "name" in cmd ? cmd.name : cmd.label,
-					score: Math.max(nameScore, descScore),
-					priority,
-					matchRank: getSlashCommandMatchRank(lowerPrefix, lowerName),
-					index,
-					...(fullDesc && { description: fullDesc }),
-				} as AutocompleteItem & { score: number; priority: number; matchRank: number; index: number };
-			})
-			.sort((a, b) => a.matchRank - b.matchRank || b.priority - a.priority || b.score - a.score || a.index - b.index)
-			.map(({ score: _score, priority: _priority, matchRank: _matchRank, index: _index, ...rest }) => rest);
+		const matches = this.#getSlashCommandNameSuggestions(textBeforeCursor.slice(1));
 
 		if (matches.length === 0) return null;
 		return { items: matches, prefix: textBeforeCursor };

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1728,9 +1728,8 @@ export class Editor implements Component, Focusable {
 
 		// Check if we should trigger or update autocomplete
 		if (!this.#autocompleteState) {
-			// Auto-trigger for "/" at the start of a submitted command.
-			// Inline skill autocomplete starts after the token becomes "/skill...".
-			if (char === "/" && this.#isAtStartOfSubmittedMessage()) {
+			// Auto-trigger for slash command tokens.
+			if (char === "/" && (this.#isAtStartOfSubmittedMessage() || this.#isInSlashTokenContext())) {
 				this.#tryTriggerAutocomplete();
 			}
 			// Auto-trigger for "@" file reference (fuzzy search)
@@ -2656,7 +2655,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#isInSlashTokenContext(): boolean {
-		return this.#getSlashTokenBeforeCursor()?.startsWith("/skill") === true;
+		return this.#getSlashTokenBeforeCursor() !== null;
 	}
 
 	#isSlashCommandNameAutocompleteSelection(): boolean {
@@ -2740,7 +2739,10 @@ export class Editor implements Component, Focusable {
 		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
 
 		// Check if we're in a slash command context
-		if (this.#isInSubmittedSlashCommandContext() && !beforeCursor.trimStart().includes(" ")) {
+		if (
+			(this.#isInSubmittedSlashCommandContext() && !beforeCursor.trimStart().includes(" ")) ||
+			this.#isInSlashTokenContext()
+		) {
 			this.#handleSlashCommandCompletion();
 		} else {
 			this.#forceFileAutocomplete(true);

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -168,6 +168,33 @@ describe("CombinedAutocompleteProvider", () => {
 		});
 	});
 });
+
+describe("inline slash command suggestions", () => {
+	it("suggests command names for slash tokens after existing prompt text", async () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "model", description: "Switch AI model", value: "model" }],
+			"/tmp",
+		);
+		const line = "explain this /mo";
+		const result = await provider.getSuggestions([line], 0, line.length);
+
+		expect(result).not.toBeNull();
+		expect(result!.prefix).toBe("/mo");
+		expect(result!.items.map(item => item.value)).toEqual(["model"]);
+	});
+
+	it("applies inline slash command completion without replacing prior text", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "model", description: "Switch AI model", value: "model" }],
+			"/tmp",
+		);
+		const line = "explain this /mo";
+		const result = provider.applyCompletion([line], 0, line.length, { value: "model", label: "model" }, "/mo");
+
+		expect(result.lines[0]).toBe("explain this /model ");
+		expect(result.cursorCol).toBe("explain this /model ".length);
+	});
+});
 describe("trySyncSlashCompletion", () => {
 	it("returns null for bare '/' (no prefix to match)", () => {
 		const provider = new CombinedAutocompleteProvider([], "/tmp");

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import type { AutocompleteItem, AutocompleteProvider } from "@gajae-code/tui/autocomplete";
+import {
+	type AutocompleteItem,
+	type AutocompleteProvider,
+	CombinedAutocompleteProvider,
+} from "@gajae-code/tui/autocomplete";
 import { Editor } from "@gajae-code/tui/components/editor";
 import { defaultEditorTheme } from "./test-themes";
 
@@ -145,26 +149,16 @@ class InlineSkillProvider implements AutocompleteProvider {
 	suggestionCalls = 0;
 }
 describe("Editor Enter handler sync slash completion", () => {
-	it("does not auto-trigger slash autocomplete from a bare slash after prior prompt text", async () => {
-		let suggestionCalls = 0;
+	it("auto-triggers slash command autocomplete from a bare slash after prompt text", async () => {
 		const editor = new Editor(defaultEditorTheme);
-		editor.setAutocompleteProvider({
-			async getSuggestions(lines, cursorLine, cursorCol) {
-				suggestionCalls += 1;
-				const currentLine = lines[cursorLine] ?? "";
-				return { prefix: currentLine.slice(0, cursorCol), items: [{ value: "model", label: "/model" }] };
-			},
-			applyCompletion(lines, cursorLine, cursorCol) {
-				return { lines, cursorLine, cursorCol };
-			},
-		});
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider([{ name: "model", description: "Switch model", value: "model" }], "/tmp"),
+		);
 
-		editor.setText("explain this\n");
-		editor.handleInput("/");
+		editor.handleInput("explain this /");
 		await Bun.sleep(0);
 
-		expect(suggestionCalls).toBe(0);
-		expect(editor.isShowingAutocomplete()).toBe(false);
+		expect(editor.isShowingAutocomplete()).toBe(true);
 	});
 
 	it("auto-triggers inline slash skill autocomplete after prompt text", async () => {


### PR DESCRIPTION
Hello,

This PR improves composer slash command autocomplete so command suggestions also appear when the user types a slash command token after existing prompt text, not only at the beginning of the composer.

Changes:
- Allow `CombinedAutocompleteProvider` to suggest slash command names for inline slash tokens such as `explain this /mo`.
- Apply inline slash command completions without replacing the prompt text before the slash token.
- Keep start-of-message slash command behavior intact for executable slash commands and command argument completion.
- Add regression coverage for provider-level inline slash suggestions and editor auto-trigger behavior.

Verification:
- `bun test packages/tui/test/autocomplete.test.ts packages/tui/test/editor-autocomplete-actions.test.ts`
- `bun --cwd=packages/tui run check`
- `bun --cwd=packages/coding-agent run check:types`
- `bun packages/coding-agent/src/cli.ts contribute-pr --no-spawn --artifact-root /tmp/gajae-contribute-pr`
- Local installed `gjc/0.8.1` patch verified: `explain this /` opens slash autocomplete.

Thank you.