### PR TITLE
Clarify busy composer shortcuts

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -122,9 +122,9 @@ const DEFAULT_COMPOSER_PLACEHOLDER = `Type your message... ${COMPOSER_NEWLINE_HI
 const WELCOME_RESERVED_CONTAINER_CHILD_LIMIT = 8;
 const FRIENDLY_KEY_PARTS: Record<string, string> = {
 	alt: "Alt",
-	cmd: "Command",
-	command: "Command",
-	ctrl: "Control",
+	cmd: "Cmd",
+	command: "Cmd",
+	ctrl: "Ctrl",
 	enter: "Enter",
 	meta: process.platform === "darwin" ? "Command" : "Meta",
 	option: "Option",
@@ -134,7 +134,7 @@ const FRIENDLY_KEY_PARTS: Record<string, string> = {
 function formatShortcutForPlaceholder(key: string): string {
 	return key
 		.split("+")
-		.map(part => FRIENDLY_KEY_PARTS[part.toLowerCase()] ?? part)
+		.map(part => FRIENDLY_KEY_PARTS[part.toLowerCase()] ?? (part.length === 1 ? part.toUpperCase() : part))
 		.join("+");
 }
 
@@ -935,10 +935,10 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	#getComposerPlaceholder(): string {
 		if (!this.#isPromptDeliveryBusy()) return DEFAULT_COMPOSER_PLACEHOLDER;
-		const enterAction = this.settings.get("busyPromptMode") === "steer" ? "Steering" : "Message Queueing";
+		const enterAction = this.settings.get("busyPromptMode") === "steer" ? "Steer" : "Queue";
 		const parts = [`Enter: ${enterAction}`];
 		const queueKey = this.#getMessageQueueShortcut();
-		if (queueKey) parts.push(`${formatShortcutForPlaceholder(queueKey)}: Message Queueing`);
+		if (queueKey) parts.push(`${formatShortcutForPlaceholder(queueKey)}: Queue`);
 		return `${DEFAULT_COMPOSER_PLACEHOLDER} · ${parts.join(" · ")}`;
 	}
 

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -87,8 +87,8 @@ describe("InteractiveMode.setEditorComponent", () => {
 	}
 
 	function expectedQueueShortcutHint(): string {
-		const shortcut = process.platform === "win32" ? "Alt+q" : "Alt+Enter";
-		return `${shortcut}: Message Queueing`;
+		const shortcut = process.platform === "win32" ? "Alt+Q" : "Alt+Enter";
+		return `${shortcut}: Queue`;
 	}
 
 	it("shows busy steering and queueing hints only while work is active", () => {
@@ -96,7 +96,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(rendered).toContain("Type your message...");
 		expect(rendered).toContain(expectedNewlineShortcutHint());
 		expect(rendered).toContain("Ctrl+C: Clear");
-		expect(rendered).not.toContain("Enter: Steering");
+		expect(rendered).not.toContain("Enter: Steer");
 		expect(rendered).not.toContain(expectedQueueShortcutHint());
 
 		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = true;
@@ -104,7 +104,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 
 		rendered = mode.editor.render(160).map(stripRenderControls).join("\n");
 		expect(rendered).toContain("Type your message...");
-		expect(rendered).toContain("Enter: Steering");
+		expect(rendered).toContain("Enter: Steer");
 		expect(rendered).toContain(expectedQueueShortcutHint());
 
 		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = false;
@@ -112,7 +112,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 
 		rendered = mode.editor.render(160).map(stripRenderControls).join("\n");
 		expect(rendered).toContain("Type your message...");
-		expect(rendered).not.toContain("Enter: Steering");
+		expect(rendered).not.toContain("Enter: Steer");
 		expect(rendered).not.toContain(expectedQueueShortcutHint());
 	});
 


### PR DESCRIPTION
Hello,

This is a small follow-up to make the busy composer placeholder clearer.

Changes:
- Show concise delivery hints while the agent is busy: `Enter: Steer` or `Enter: Queue` based on `busyPromptMode`.
- Show the explicit queue shortcut in the same placeholder, e.g. `Alt+Q: Queue` on Windows.
- Keep the existing newline and clear hints unchanged.
- Normalize placeholder shortcut labels to compact forms such as `Ctrl`/`Cmd` and uppercase single-letter keys.

Verification:
- `bun test packages/coding-agent/test/interactive-mode-editor-component.test.ts -t "busy steering"`
- `bun --cwd=packages/coding-agent run check`
- `bun packages/coding-agent/src/cli.ts contribute-pr --no-spawn --artifact-root /tmp/gajae-contribute-pr`

Thank you.