### PR TITLE
Fix session entry undefined persistence

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1308,6 +1308,45 @@ function isImageBlock(value: unknown): value is { type: "image"; data: string; m
 	);
 }
 
+function stripUndefinedPlainObjectFields(value: unknown, path = "entry"): unknown {
+	if (value === undefined) return undefined;
+	if (value === null || typeof value !== "object") return value;
+	if (Array.isArray(value)) {
+		let changed = false;
+		const result: unknown[] = new Array(value.length);
+		for (let index = 0; index < value.length; index++) {
+			const item = value[index];
+			if (item === undefined) {
+				throw new Error(`Session entry contains undefined array item at ${path}[${index}]`);
+			}
+			const next = stripUndefinedPlainObjectFields(item, `${path}[${index}]`);
+			if (next !== item) changed = true;
+			result[index] = next;
+		}
+		return changed ? result : value;
+	}
+
+	const prototype = Object.getPrototypeOf(value);
+	if (prototype !== Object.prototype && prototype !== null) return value;
+
+	let changed = false;
+	const entries: Array<readonly [string, unknown]> = [];
+	for (const [key, item] of Object.entries(value)) {
+		if (item === undefined) {
+			changed = true;
+			continue;
+		}
+		const next = stripUndefinedPlainObjectFields(item, `${path}.${key}`);
+		if (next !== item) changed = true;
+		entries.push([key, next]);
+	}
+	return changed ? Object.fromEntries(entries) : value;
+}
+
+function normalizeSessionEntryForStorage(entry: SessionEntry): SessionEntry {
+	return stripUndefinedPlainObjectFields(entry) as SessionEntry;
+}
+
 const RESIDENT_EXTERNALIZE_STRING_EXCLUDED_KEYS = new Set([
 	"id",
 	"type",
@@ -3736,7 +3775,8 @@ export class SessionManager {
 	}
 
 	#appendEntry(entry: SessionEntry): void {
-		const residentEntry = prepareEntryForResidentSync(entry, this.#residentBlobStores()) as SessionEntry;
+		const normalizedEntry = normalizeSessionEntryForStorage(entry);
+		const residentEntry = prepareEntryForResidentSync(normalizedEntry, this.#residentBlobStores()) as SessionEntry;
 		this.#fileEntries.push(residentEntry);
 		this.#byId.set(residentEntry.id, residentEntry);
 		this.#leafId = residentEntry.id;

--- a/packages/coding-agent/test/session-manager/save-entry.test.ts
+++ b/packages/coding-agent/test/session-manager/save-entry.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "bun:test";
 import { type CustomEntry, SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 
+function hasUndefinedPlainObjectField(value: unknown): boolean {
+	if (value === undefined) return true;
+	if (value === null || typeof value !== "object") return false;
+	if (Array.isArray(value)) return value.some(item => hasUndefinedPlainObjectField(item));
+	const prototype = Object.getPrototypeOf(value);
+	if (prototype !== Object.prototype && prototype !== null) return false;
+	return Object.values(value).some(item => item === undefined || hasUndefinedPlainObjectField(item));
+}
+
 describe("SessionManager.saveCustomEntry", () => {
 	it("saves custom entries and includes them in tree traversal", () => {
 		const session = SessionManager.inMemory();
@@ -62,5 +71,39 @@ describe("SessionManager.saveCustomEntry", () => {
 			provider: "openai",
 			items: nativeHistory,
 		});
+	});
+
+	it("normalizes optional undefined fields before live session-entry persistence", () => {
+		const session = SessionManager.inMemory();
+
+		session.appendModeChange("goal", {
+			goal: {
+				id: "goal-1",
+				objective: "finish issue",
+				status: "complete",
+				tokensUsed: undefined,
+			},
+		});
+		session.appendCustomMessageEntry(
+			"ask.prompt",
+			"Choose an option",
+			false,
+			{
+				customInput: undefined,
+				selectedOptions: ["Done"],
+				nested: { clarificationQuestion: undefined, retained: true },
+			},
+			"agent",
+		);
+		session.appendCustomEntry("goal-completed", {
+			objective: "finish issue",
+			tokensUsed: undefined,
+			timeUsedSeconds: undefined,
+		});
+
+		const entries = session.getEntries();
+		expect(entries).toHaveLength(3);
+		expect(entries.some(entry => hasUndefinedPlainObjectField(entry))).toBe(false);
+		expect(JSON.stringify(entries)).not.toContain("undefined");
 	});
 });


### PR DESCRIPTION
## Summary
- Normalize session entries at the shared append choke point by omitting optional undefined plain-object fields before resident/persistence preparation.
- Keep validation strict for malformed undefined array items instead of silently converting them.
- Add a regression covering live-ish goal mode, ask/custom-message, and goal-completed session entries with undefined optional fields.

Fixes #1532

## Verification
- `bun test packages/coding-agent/test/session-manager/save-entry.test.ts`
- `bun --cwd=packages/coding-agent run check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*