### PR TITLE
Fix ultragoal computer red-team false positive for tools index

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Goal completion now preserves the terminal `goal({op: "complete"})` state even when a `goal_updated` extension hook throws, preventing hook-side write errors from trapping a verified ultragoal run in the continuation loop.
+- Ultragoal completion no longer requires the computer-use red-team suite for non-computer changes that only touch the shared `tools/index.ts` registration file.
 
 ## [0.8.1] - 2026-07-04
 

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -1074,6 +1074,7 @@ interface UltragoalChangeSet extends JsonObject {
 	mergeBase?: string;
 	paths: UltragoalChangeSetPath[];
 	rawDiffStat?: string;
+	rawDiff?: string;
 	trusted: true;
 }
 
@@ -1086,9 +1087,14 @@ const MANDATORY_COMPUTER_CASE_IDS = [
 	"runaway-loop-halt",
 	"blast-radius",
 ] as const;
+const TOOLS_INDEX_PATH = "packages/coding-agent/src/tools/index.ts";
 
 function normalizeRepoPath(value: string): string {
 	return value.replaceAll("\\\\", "/").replace(/^\.\//, "");
+}
+
+function isToolsIndexPath(value: string): boolean {
+	return normalizeRepoPath(value) === TOOLS_INDEX_PATH;
 }
 
 function categorizeComputerChangePath(value: string): UltragoalChangeCategory {
@@ -1130,6 +1136,32 @@ function isComputerControlSurfaceCategory(category: UltragoalChangeCategory): bo
 	return category === "code" || category === "tool" || category === "settings-registry";
 }
 
+function isComputerSpecificToolsIndexDiff(diff: string | undefined, targetPath: string): boolean {
+	if (!diff || !isToolsIndexPath(targetPath)) return false;
+	let inTargetFile = false;
+	for (const line of diff.split("\n")) {
+		if (line.startsWith("diff --git ")) {
+			const match = /^diff --git a\/(.+?) b\/(.+)$/.exec(line);
+			inTargetFile = !!match && (isToolsIndexPath(match[1]!) || isToolsIndexPath(match[2]!));
+			continue;
+		}
+		if (!inTargetFile || line.startsWith("+++") || line.startsWith("---")) continue;
+		if (!line.startsWith("+") && !line.startsWith("-")) continue;
+		const changedLine = line.slice(1);
+		if (
+			/\bComputerTool\b/.test(changedLine) ||
+			/\bisComputerCallable\b/.test(changedLine) ||
+			/\bisComputerLoadablePlatform\b/.test(changedLine) ||
+			/["']computer["']/.test(changedLine) ||
+			/["']\.\/computer["']/.test(changedLine) ||
+			/\bcomputer\s*:/.test(changedLine)
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
 function isComputerControlSurfaceChangePath(row: UltragoalChangeSetPath): boolean {
 	const category = row.category ?? categorizeComputerChangePath(row.path);
 	const oldCategory = row.oldPath ? categorizeComputerChangePath(row.oldPath) : category;
@@ -1138,7 +1170,13 @@ function isComputerControlSurfaceChangePath(row: UltragoalChangeSetPath): boolea
 
 function trustedChangeSetRequiresComputerSuite(changeSet: UltragoalChangeSet | undefined): boolean {
 	if (!changeSet?.trusted) return false;
-	return changeSet.paths.some(isComputerControlSurfaceChangePath);
+	return changeSet.paths.some(row => {
+		if (isComputerControlSurfaceChangePath(row)) return true;
+		return (
+			isComputerSpecificToolsIndexDiff(changeSet.rawDiff, row.path) ||
+			(row.oldPath ? isComputerSpecificToolsIndexDiff(changeSet.rawDiff, row.oldPath) : false)
+		);
+	});
 }
 
 function requiresComputerRedTeamSuite(executorQa: JsonObject, changeSet: UltragoalChangeSet | undefined): boolean {
@@ -3183,15 +3221,17 @@ function mergeChangeSetPaths(groups: UltragoalChangeSetPath[][]): UltragoalChang
 async function computeCheckpointChangeSet(cwd: string): Promise<UltragoalChangeSet | undefined> {
 	const inGit = await spawnText(["git", "rev-parse", "--is-inside-work-tree"], { cwd, timeoutMs: 3000 });
 	if (!inGit.ok || inGit.stdout.trim() !== "true") return undefined;
-	if (!(await Bun.file(path.join(cwd, ".git")).exists())) return undefined;
 	const baseRef = await resolveGitBase(cwd);
 	const base = baseRef;
 	const mergeBase = await spawnText(["git", "merge-base", "HEAD", baseRef], { cwd, timeoutMs: 3000 });
-	const [committed, unstaged, staged, stat] = await Promise.all([
+	const [committed, unstaged, staged, stat, committedDiff, unstagedDiff, stagedDiff] = await Promise.all([
 		spawnText(["git", "diff", "--name-status", `${base}...HEAD`], { cwd, timeoutMs: 5000 }),
 		spawnText(["git", "diff", "--name-status"], { cwd, timeoutMs: 5000 }),
 		spawnText(["git", "diff", "--cached", "--name-status"], { cwd, timeoutMs: 5000 }),
 		spawnText(["git", "diff", "--stat", `${base}...HEAD`], { cwd, timeoutMs: 5000 }),
+		spawnText(["git", "diff", `${base}...HEAD`], { cwd, timeoutMs: 5000 }),
+		spawnText(["git", "diff"], { cwd, timeoutMs: 5000 }),
+		spawnText(["git", "diff", "--cached"], { cwd, timeoutMs: 5000 }),
 	]);
 	if (!committed.ok && !unstaged.ok && !staged.ok) return undefined;
 	return {
@@ -3205,6 +3245,7 @@ async function computeCheckpointChangeSet(cwd: string): Promise<UltragoalChangeS
 			parseGitNameStatus(staged.stdout),
 		]),
 		rawDiffStat: stat.stdout,
+		rawDiff: [committedDiff.stdout, unstagedDiff.stdout, stagedDiff.stdout].filter(Boolean).join("\n"),
 		trusted: true,
 	};
 }
@@ -3235,6 +3276,7 @@ function changeSetFromReviewSource(source: JsonObject): UltragoalChangeSet | und
 			source: "review-pr",
 			paths: parseUnifiedDiffPaths(source.diff),
 			rawDiffStat: source.diff,
+			rawDiff: source.diff,
 			trusted: true,
 		};
 	const local = qualityGateObject(source.local);
@@ -3244,6 +3286,7 @@ function changeSetFromReviewSource(source: JsonObject): UltragoalChangeSet | und
 			source: "review-worktree",
 			paths: parseGitNameStatus(String(source.nameStatus ?? source.status ?? "")),
 			rawDiffStat: String(source.diffStat ?? ""),
+			rawDiff: String(source.diff ?? ""),
 			trusted: true,
 		};
 	if (kind === "branch" || kind === "pr-fallback")
@@ -3253,6 +3296,7 @@ function changeSetFromReviewSource(source: JsonObject): UltragoalChangeSet | und
 			headRef: "HEAD",
 			paths: parseGitNameStatus(String(source.nameStatus ?? "")),
 			rawDiffStat: String(source.diffStat ?? ""),
+			rawDiff: String(source.diff ?? ""),
 			trusted: true,
 		};
 	return undefined;
@@ -3260,25 +3304,36 @@ function changeSetFromReviewSource(source: JsonObject): UltragoalChangeSet | und
 
 async function localDiffSource(cwd: string, sourceKind: string, branch?: string): Promise<JsonObject> {
 	if (sourceKind === "worktree") {
-		const [status, diff, unstaged, staged] = await Promise.all([
+		const [status, diffStat, unstaged, staged, unstagedDiff, stagedDiff] = await Promise.all([
 			spawnText(["git", "status", "--short"], { cwd, timeoutMs: 5000 }),
 			spawnText(["git", "diff", "--stat"], { cwd, timeoutMs: 5000 }),
 			spawnText(["git", "diff", "--name-status"], { cwd, timeoutMs: 5000 }),
 			spawnText(["git", "diff", "--cached", "--name-status"], { cwd, timeoutMs: 5000 }),
+			spawnText(["git", "diff"], { cwd, timeoutMs: 5000 }),
+			spawnText(["git", "diff", "--cached"], { cwd, timeoutMs: 5000 }),
 		]);
 		return {
 			kind: "worktree",
 			status: status.stdout,
-			diffStat: diff.stdout,
+			diffStat: diffStat.stdout,
+			diff: [unstagedDiff.stdout, stagedDiff.stdout].filter(Boolean).join("\n"),
 			nameStatus: `${unstaged.stdout}\n${staged.stdout}`,
 		};
 	}
 	const base = await resolveGitBase(cwd, branch);
-	const [diff, nameStatus] = await Promise.all([
+	const [diffStat, nameStatus, diff] = await Promise.all([
 		spawnText(["git", "diff", "--stat", `${base}...HEAD`], { cwd, timeoutMs: 5000 }),
 		spawnText(["git", "diff", "--name-status", `${base}...HEAD`], { cwd, timeoutMs: 5000 }),
+		spawnText(["git", "diff", `${base}...HEAD`], { cwd, timeoutMs: 5000 }),
 	]);
-	return { kind: sourceKind, base, branch, diffStat: diff.stdout, nameStatus: nameStatus.stdout };
+	return {
+		kind: sourceKind,
+		base,
+		branch,
+		diffStat: diffStat.stdout,
+		diff: diff.stdout,
+		nameStatus: nameStatus.stdout,
+	};
 }
 
 async function resolveReviewSource(

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -1101,7 +1101,6 @@ function categorizeComputerChangePath(value: string): UltragoalChangeCategory {
 	)
 		return "tool";
 	if (
-		normalized === "packages/coding-agent/src/tools/index.ts" ||
 		normalized === "packages/coding-agent/src/tools/renderers.ts" ||
 		normalized === "packages/coding-agent/src/config/settings-schema.ts"
 	)
@@ -1119,15 +1118,15 @@ function categorizeComputerChangePath(value: string): UltragoalChangeCategory {
 function isComputerControlSurfaceCategory(category: UltragoalChangeCategory): boolean {
 	// The computer-use red-team suite is conditional, not universal (see the
 	// ultragoal SKILL): require it only when the change actually touches
-	// computer-control source — the computer tool (`tool`), its settings/registry
-	// wiring (`settings-registry`), or computer Rust (`code`). A bare regeneration
-	// of the SHARED native binding (`generated-binding`: packages/natives/native/
-	// index.{d.ts,js}) is NOT by itself a computer-use change: that file is
-	// generated from Rust, so any real computer-use behavior change must also
-	// touch one of the categories above and will still trigger the suite. Treating
-	// the regenerated aggregate binding as a computer surface forced the suite on
-	// unrelated features (e.g. notifications), which the SKILL explicitly warns
-	// against, so it is excluded here.
+	// computer-control source — the computer tool (`tool`), its behavior-bearing
+	// settings/renderer wiring (`settings-registry`), or computer Rust (`code`).
+	// A bare regeneration of the SHARED native binding (`generated-binding`:
+	// packages/natives/native/index.{d.ts,js}) is NOT by itself a computer-use
+	// change: that file is generated from Rust, so any real computer-use behavior
+	// change must also touch one of the categories above and will still trigger
+	// the suite. Treating aggregate binding or registration files as a computer
+	// surface forced the suite on unrelated changes, which the SKILL explicitly
+	// warns against, so they are excluded here.
 	return category === "code" || category === "tool" || category === "settings-registry";
 }
 

--- a/packages/coding-agent/test/gjc-runtime/computer-red-team-fixtures.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/computer-red-team-fixtures.test.ts
@@ -230,9 +230,13 @@ async function checkpoint(root: string, qa: Record<string, unknown>): Promise<st
 	return (result.stderr ?? "") + (result.stdout ?? "");
 }
 
-async function seedComputerChange(root: string, file = "crates/pi-natives/src/computer/executor.rs"): Promise<void> {
+async function seedComputerChange(
+	root: string,
+	file = "crates/pi-natives/src/computer/executor.rs",
+	content = "// computer change\n",
+): Promise<void> {
 	await fs.mkdir(path.dirname(path.join(root, file)), { recursive: true });
-	await fs.writeFile(path.join(root, file), "// computer change\n");
+	await fs.writeFile(path.join(root, file), content);
 	await runGit(root, ["add", file]);
 }
 
@@ -335,6 +339,35 @@ describe("computer red-team fixture matrix", () => {
 		);
 		const qa = executorQa({ computerTouching: false, cases, surface: "native" });
 		expect(await checkpoint(root, qa)).toContain("Checkpointed G001 as complete");
+	});
+
+	it("triggers from computer-specific tools index registration diff", async () => {
+		const root = await tempDir();
+		await initRepo(root);
+		await seedPlan(root);
+		await writeQaArtifacts(root);
+		await seedComputerChange(
+			root,
+			"packages/coding-agent/src/tools/index.ts",
+			`import { ComputerTool, isComputerCallable, isComputerLoadablePlatform } from "./computer";
+
+export const BUILTIN_TOOLS = {
+	...(isComputerLoadablePlatform() ? { computer: ComputerTool.createIf } : {}),
+};
+
+export function isToolAllowed(name: string): boolean {
+	if (name === "computer") return isComputerCallable({});
+	return true;
+}
+`,
+		);
+		const cases = (executorQa().adversarialCases as Record<string, unknown>[]).filter(
+			row => row.id !== "blast-radius",
+		);
+		const message = await checkpoint(root, executorQa({ computerTouching: false, cases })).catch(error =>
+			String(error),
+		);
+		expect(message).toContain("COMPUTER_REDTEAM_CASE_MISSING");
 	});
 
 	it("allows non-operational docs-only computer tiering", async () => {

--- a/packages/coding-agent/test/gjc-runtime/computer-red-team-fixtures.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/computer-red-team-fixtures.test.ts
@@ -324,6 +324,19 @@ describe("computer red-team fixture matrix", () => {
 		expect(await checkpoint(root, qa)).toContain("Checkpointed G001 as complete");
 	});
 
+	it("does not trigger from non-computer edit to tools index registration", async () => {
+		const root = await tempDir();
+		await initRepo(root);
+		await seedPlan(root);
+		await writeQaArtifacts(root);
+		await seedComputerChange(root, "packages/coding-agent/src/tools/index.ts");
+		const cases = (executorQa().adversarialCases as Record<string, unknown>[]).filter(
+			row => row.id !== "blast-radius",
+		);
+		const qa = executorQa({ computerTouching: false, cases, surface: "native" });
+		expect(await checkpoint(root, qa)).toContain("Checkpointed G001 as complete");
+	});
+
 	it("allows non-operational docs-only computer tiering", async () => {
 		const root = await tempDir();
 		await initRepo(root);


### PR DESCRIPTION
## Summary
- Stop classifying shared `packages/coding-agent/src/tools/index.ts` registration-only diffs as computer-control surface changes.
- Add a regression fixture proving a non-computer edit to `tools/index.ts` can complete without mandatory computer-use adversarial cases.
- Record the fix in the coding-agent changelog.

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/computer-red-team-fixtures.test.ts`
- `bun --cwd=packages/coding-agent run check`

Closes #1507.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*