### PR TITLE
Track raw tmux vanish after prompt acceptance

### DIFF
--- a/scripts/gjc-session/create.sh
+++ b/scripts/gjc-session/create.sh
@@ -90,7 +90,8 @@ CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   printf '  "eventsLog": "%s",\n' "$(printf '%s' "$STATE_DIR/events.log" | json_escape)"
   printf '  "finalStatus": "%s",\n' "$(printf '%s' "$STATE_DIR/final.json" | json_escape)"
   printf '  "runtimeState": "%s",\n' "$(printf '%s' "$RUNTIME_STATE_JSON" | json_escape)"
-  printf '  "vanishedStatus": "%s"\n' "$(printf '%s' "$STATE_DIR/vanished.json" | json_escape)"
+  printf '  "vanishedStatus": "%s",\n' "$(printf '%s' "$STATE_DIR/vanished.json" | json_escape)"
+  printf '  "promptAcceptedStatus": "%s"\n' "$(printf '%s' "$STATE_DIR/prompt-accepted.json" | json_escape)"
   printf '}\n'
 } >"$STATE_DIR/metadata.json"
 : >"$STATE_DIR/pane.log"
@@ -183,16 +184,22 @@ except Exception:
 PYFINAL
 )"
   fi
+  prompt_accepted=false
+  [[ -s "${GJC_SESSION_PROMPT_ACCEPTED_JSON:-}" ]] && prompt_accepted=true
+  vanish_reason="tmux_session_missing"
+  if [[ "$prompt_accepted" == "true" && "$final_present" != "true" ]]; then
+    vanish_reason="tmux_session_missing_after_prompt_acceptance"
+  fi
   severity="failure"
   if [[ "$final_present" == "true" && "$final_severity" == "normal" ]]; then
     severity="closed_after_final"
   fi
-  printf '[%s] tmux session vanished final_present=%s severity=%s\n' "$detected_at" "$final_present" "$severity" >>"$GJC_SESSION_EVENTS_LOG"
-  python3 - "$GJC_SESSION_VANISHED_JSON" "$GJC_SESSION_NAME" "$detected_at" "$GJC_SESSION_WORKDIR" "$GJC_SESSION_BRANCH" "$GJC_SESSION_PANE_LOG" "$GJC_SESSION_EVENTS_LOG" "$GJC_SESSION_FINAL_JSON" "$GJC_COORDINATOR_SESSION_STATE_FILE" "$final_present" "$severity" "$final_severity" <<'PYINNER'
+  printf '[%s] tmux session vanished final_present=%s prompt_accepted=%s severity=%s reason=%s\n' "$detected_at" "$final_present" "$prompt_accepted" "$severity" "$vanish_reason" >>"$GJC_SESSION_EVENTS_LOG"
+  python3 - "$GJC_SESSION_VANISHED_JSON" "$GJC_SESSION_NAME" "$detected_at" "$GJC_SESSION_WORKDIR" "$GJC_SESSION_BRANCH" "$GJC_SESSION_PANE_LOG" "$GJC_SESSION_EVENTS_LOG" "$GJC_SESSION_FINAL_JSON" "$GJC_COORDINATOR_SESSION_STATE_FILE" "$final_present" "$severity" "$final_severity" "$prompt_accepted" "$vanish_reason" "${GJC_SESSION_PROMPT_ACCEPTED_JSON:-}" <<'PYINNER'
 import json
 import sys
 
-(path, session, detected_at, workdir, branch, pane_log, events_log, final_json, runtime_state, final_present, severity, final_severity) = sys.argv[1:]
+(path, session, detected_at, workdir, branch, pane_log, events_log, final_json, runtime_state, final_present, severity, final_severity, prompt_accepted, reason, prompt_accepted_json) = sys.argv[1:]
 with open(path, "w", encoding="utf-8") as handle:
     json.dump(
         {
@@ -206,8 +213,10 @@ with open(path, "w", encoding="utf-8") as handle:
             "runtimeState": runtime_state,
             "finalPresent": final_present == "true",
             "severity": severity,
-            "reason": "tmux_session_missing",
+            "reason": reason,
             "finalSeverity": final_severity,
+            "promptAccepted": prompt_accepted == "true",
+            "promptAcceptedStatus": prompt_accepted_json or None,
         },
         handle,
         indent=2,
@@ -273,6 +282,7 @@ if [[ "${GJC_SESSION_MONITOR_DISABLE:-0}" != "1" ]]; then
     "GJC_SESSION_EVENTS_LOG=$STATE_DIR/events.log"
     "GJC_SESSION_FINAL_JSON=$STATE_DIR/final.json"
     "GJC_SESSION_VANISHED_JSON=$STATE_DIR/vanished.json"
+    "GJC_SESSION_PROMPT_ACCEPTED_JSON=$STATE_DIR/prompt-accepted.json"
     "GJC_COORDINATOR_SESSION_STATE_FILE=$RUNTIME_STATE_JSON"
     "GJC_SESSION_TMUX_BIN=$TMUX_BIN"
     "GJC_SESSION_MONITOR_INTERVAL=${GJC_SESSION_MONITOR_INTERVAL:-5}"

--- a/scripts/gjc-session/create.test.ts
+++ b/scripts/gjc-session/create.test.ts
@@ -41,6 +41,11 @@ async function waitForFile(file: string, timeoutMs = 7000): Promise<void> {
 	throw new Error(`timed out waiting for ${file}`);
 }
 
+function startPaneLog(session: string, stateDir: string): void {
+	const paneLog = path.join(stateDir, "pane.log");
+	expect(Bun.spawnSync(["tmux", "pipe-pane", "-t", `${session}:0.0`, `cat >> '${paneLog}'`]).exitCode).toBe(0);
+}
+
 afterEach(async () => {
 	for (const session of tmuxSessions.splice(0)) {
 		Bun.spawnSync(["tmux", "kill-session", "-t", session], { stderr: "pipe", stdout: "pipe" });
@@ -235,6 +240,7 @@ sleep 60
 			]).exitCode,
 		).toBe(0);
 		await Bun.sleep(500);
+		startPaneLog(session, stateDir);
 
 		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "do work"], {
 			env: {
@@ -269,6 +275,7 @@ sleep 60
 			]).exitCode,
 		).toBe(0);
 		await Bun.sleep(500);
+		startPaneLog(session, stateDir);
 
 		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "new prompt that sleeping process will not accept"], {
 			env: {
@@ -284,6 +291,46 @@ sleep 60
 		expect(result.stderr.toString()).toContain("prompt acceptance failed: no durable turn evidence appeared");
 		expect(result.stdout.toString()).not.toContain("sent to");
 	}, 20000);
+	test("prompt echo cannot satisfy durable turn evidence", async () => {
+		const session = `gjc_issue_1496_prompt_echo_${process.pid}_${Date.now()}`;
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-prompt-echo-"));
+		tempRoots.push(root);
+		const stateDir = path.join(root, "state");
+		await fs.mkdir(stateDir, { recursive: true });
+		await Bun.write(path.join(stateDir, "pane.log"), "");
+		tmuxSessions.push(session);
+		expect(
+			Bun.spawnSync([
+				"tmux",
+				"new-session",
+				"-d",
+				"-s",
+				session,
+				"printf 'Gajae forge\\n> Type your message\\n'; sleep 20",
+			]).exitCode,
+		).toBe(0);
+		await Bun.sleep(500);
+		startPaneLog(session, stateDir);
+
+		const rawPrompt = "Working Tool prompt echo must not count";
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, rawPrompt], {
+			env: {
+				...process.env,
+				GJC_SESSION_STATE_DIR: stateDir,
+				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr.toString()).toContain("prompt acceptance failed: no durable turn evidence appeared");
+		expect(result.stdout.toString()).not.toContain("sent to");
+		expect(result.stdout.toString()).not.toContain(rawPrompt);
+		expect(result.stderr.toString()).not.toContain(rawPrompt);
+		expect(await Bun.file(path.join(stateDir, "prompt-accepted.json")).exists()).toBe(false);
+	}, 20000);
+
 
 	test("prompt ignores stale evidence when capture window shifts after send", async () => {
 		const session = `gjc_issue_1385_prompt_window_${process.pid}_${Date.now()}`;
@@ -296,6 +343,7 @@ sleep 60
 		const script = `for i in $(seq 1 150); do if [ "$i" = 120 ]; then printf 'Working on previous prompt\n'; else printf 'filler %03d\n' "$i"; fi; done; printf '> Type your message\n'; sleep 20`;
 		expect(Bun.spawnSync(["tmux", "new-session", "-d", "-s", session, "bash", "-lc", script]).exitCode).toBe(0);
 		await Bun.sleep(500);
+		startPaneLog(session, stateDir);
 
 		const result = Bun.spawnSync(
 			["bash", "scripts/gjc-session/prompt.sh", session, "new prompt sleeping process should not accept"],
@@ -334,8 +382,10 @@ sleep 60
 			]).exitCode,
 		).toBe(0);
 		await Bun.sleep(500);
+		startPaneLog(session, stateDir);
 
-		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "do accepted work"], {
+		const rawPrompt = "Working Tool accepted prompt still needs owner output";
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, rawPrompt], {
 			env: {
 				...process.env,
 				GJC_SESSION_STATE_DIR: stateDir,
@@ -347,5 +397,118 @@ sleep 60
 
 		expect(result.exitCode).toBe(0);
 		expect(result.stdout.toString()).toContain("sent to");
+		expect(result.stdout.toString()).not.toContain(rawPrompt);
+		expect(await Bun.file(path.join(stateDir, "prompt-accepted.json")).exists()).toBe(true);
+	}, 20000);
+	test("prompt accepts durable evidence when owner exits immediately after output", async () => {
+		const session = `gjc_issue_1496_prompt_exit_after_evidence_${process.pid}_${Date.now()}`;
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-prompt-exit-after-evidence-"));
+		tempRoots.push(root);
+		const stateDir = path.join(root, "state");
+		await fs.mkdir(stateDir, { recursive: true });
+		await Bun.write(path.join(stateDir, "pane.log"), "");
+		tmuxSessions.push(session);
+		expect(
+			Bun.spawnSync([
+				"tmux",
+				"new-session",
+				"-d",
+				"-s",
+				session,
+				"bash -lc \"printf 'Gajae forge\\n> Type your message\\n'; IFS= read -r line; printf '\\nWorking then exiting\\n'\"",
+			]).exitCode,
+		).toBe(0);
+		await Bun.sleep(500);
+		startPaneLog(session, stateDir);
+
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "exit after evidence"], {
+			env: {
+				...process.env,
+				GJC_SESSION_STATE_DIR: stateDir,
+				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "2",
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.toString()).toContain("sent to");
+		expect(await Bun.file(path.join(stateDir, "prompt-accepted.json")).exists()).toBe(true);
+		expect(await Bun.file(path.join(stateDir, "pane.log")).text()).toContain("Working then exiting");
+	}, 20000);
+	test("prompt echo after submit cannot satisfy durable turn evidence", async () => {
+		const session = `gjc_issue_1496_prompt_post_submit_echo_${process.pid}_${Date.now()}`;
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-prompt-post-submit-echo-"));
+		tempRoots.push(root);
+		const stateDir = path.join(root, "state");
+		await fs.mkdir(stateDir, { recursive: true });
+		await Bun.write(path.join(stateDir, "pane.log"), "");
+		tmuxSessions.push(session);
+		expect(
+			Bun.spawnSync([
+				"tmux",
+				"new-session",
+				"-d",
+				"-s",
+				session,
+				"bash -lc \"printf 'Gajae forge\\n> Type your message\\n'; IFS= read -r line; printf '%s\\n' \\\"$line\\\"; sleep 20\"",
+			]).exitCode,
+		).toBe(0);
+		await Bun.sleep(500);
+		startPaneLog(session, stateDir);
+
+		const rawPrompt = "Working Tool post submit echo only";
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, rawPrompt], {
+			env: {
+				...process.env,
+				GJC_SESSION_STATE_DIR: stateDir,
+				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr.toString()).toContain("prompt acceptance failed: no durable turn evidence appeared");
+		expect(result.stdout.toString()).not.toContain("sent to");
+		expect(result.stdout.toString()).not.toContain(rawPrompt);
+		expect(result.stderr.toString()).not.toContain(rawPrompt);
+		expect(await Bun.file(path.join(stateDir, "prompt-accepted.json")).exists()).toBe(false);
+	}, 20000);
+	test("prompt uses discovered durable pane log without state dir", async () => {
+		const session = `gjc_issue_1496_prompt_discovery_${process.pid}_${Date.now()}`;
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-prompt-discovery-"));
+		tempRoots.push(root);
+		const stateDir = path.join(root, ".gjc-session-state", session);
+		await fs.mkdir(stateDir, { recursive: true });
+		await Bun.write(path.join(stateDir, "pane.log"), "");
+		tmuxSessions.push(session);
+		expect(
+			Bun.spawnSync([
+				"tmux",
+				"new-session",
+				"-d",
+				"-s",
+				session,
+				"bash -lc \"printf 'Gajae forge\\n> Type your message\\n'; IFS= read -r line; printf '\\nWorking from discovered durable log\\n'; sleep 20\"",
+			]).exitCode,
+		).toBe(0);
+		await Bun.sleep(500);
+		startPaneLog(session, stateDir);
+
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "discovery prompt"], {
+			env: {
+				...process.env,
+				GJC_SESSION_LOG_SEARCH_ROOT: root,
+				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.toString()).toContain("sent to");
+		expect(await Bun.file(path.join(stateDir, "prompt-accepted.json")).exists()).toBe(true);
+		expect(await Bun.file(path.join(stateDir, "pane.log")).text()).toContain("Working from discovered durable log");
 	}, 20000);
 });

--- a/scripts/gjc-session/create.test.ts
+++ b/scripts/gjc-session/create.test.ts
@@ -160,6 +160,62 @@ exit 0
 		expect(vanished.runtimeState).toBe(path.join(stateDir, "runtime-state.json"));
 		expect(await Bun.file(routerLog).text()).toContain("tmux stale --session");
 	});
+	test("external monitor records vanished sessions after prompt acceptance", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-post-accept-vanish-"));
+		tempRoots.push(root);
+		const session = `gjc_issue_1496_post_accept_${process.pid}_${Date.now()}`;
+		tmuxSessions.push(session);
+		const worktree = await makeGitWorktree(root);
+		const stateDir = path.join(root, "state");
+		const fakeGjc = path.join(root, "bin", "gjc");
+		await makeExecutable(
+			fakeGjc,
+			`#!/usr/bin/env bash
+printf 'Gajae forge\\n> Type your message\\n'
+IFS= read -r line
+printf '\\nWorking on accepted prompt\\n'
+sleep 60
+`,
+		);
+
+		const created = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree], {
+			env: {
+				...process.env,
+				GJC_BIN: fakeGjc,
+				GJC_SESSION_MONITOR_INTERVAL: "1",
+				GJC_SESSION_SKIP_ROUTER: "1",
+				GJC_SESSION_STATE_DIR: stateDir,
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		expect(created.exitCode).toBe(0);
+
+		const prompted = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "do accepted work"], {
+			env: {
+				...process.env,
+				GJC_SESSION_STATE_DIR: stateDir,
+				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		expect(prompted.exitCode).toBe(0);
+
+		Bun.spawnSync(["tmux", "kill-session", "-t", session], { stderr: "pipe", stdout: "pipe" });
+		await waitForFile(path.join(stateDir, "vanished.json"));
+
+		const vanished = (await Bun.file(path.join(stateDir, "vanished.json")).json()) as {
+			promptAccepted: boolean;
+			reason: string;
+			severity: string;
+		};
+		expect(vanished).toMatchObject({
+			promptAccepted: true,
+			reason: "tmux_session_missing_after_prompt_acceptance",
+			severity: "failure",
+		});
+	}, 20000);
 	test("prompt refuses success without durable turn evidence", async () => {
 		const session = `gjc_issue_1385_prompt_${process.pid}_${Date.now()}`;
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-prompt-"));

--- a/scripts/gjc-session/prompt.sh
+++ b/scripts/gjc-session/prompt.sh
@@ -24,6 +24,49 @@ find_durable_pane_logs() {
   fi
 }
 
+prompt_accepted_path() {
+  if [[ -n "${GJC_SESSION_STATE_DIR:-}" ]]; then
+    printf '%s\n' "$GJC_SESSION_STATE_DIR/prompt-accepted.json"
+    return 0
+  fi
+  local candidates=()
+  mapfile -t candidates < <(find_durable_pane_logs)
+  if [[ "${#candidates[@]}" -gt 0 ]]; then
+    printf '%s\n' "$(dirname "${candidates[0]}")/prompt-accepted.json"
+  fi
+}
+
+record_prompt_accepted() {
+  local accepted_path
+  accepted_path="$(prompt_accepted_path)"
+  if [[ -z "$accepted_path" ]]; then
+    return 0
+  fi
+  local accepted_at
+  accepted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  mkdir -p "$(dirname "$accepted_path")"
+  local accepted_dir
+  accepted_dir="$(dirname "$accepted_path")"
+  python3 - "$accepted_path" "$SESSION" "$accepted_at" "$accepted_dir/pane.log" <<'PY'
+import json
+import sys
+
+path, session, accepted_at, pane_log = sys.argv[1:]
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(
+        {
+            "session": session,
+            "acceptedAt": accepted_at,
+            "evidence": "durable_turn_evidence",
+            "paneLog": pane_log,
+        },
+        handle,
+        indent=2,
+    )
+    handle.write("\n")
+PY
+}
+
 has_turn_evidence() {
   local log_path="${1:-}"
   local log_offset="${2:-0}"
@@ -117,6 +160,7 @@ for _ in $(seq 1 "$PROMPT_EVIDENCE_ATTEMPTS"); do
     exit 1
   fi
   if has_turn_evidence "$EVIDENCE_LOG" "$EVIDENCE_LOG_OFFSET"; then
+    record_prompt_accepted
     echo "sent to $SESSION with durable turn evidence: ${TEXT:0:80}..."
     exit 0
   fi

--- a/scripts/gjc-session/prompt.sh
+++ b/scripts/gjc-session/prompt.sh
@@ -67,17 +67,79 @@ with open(path, "w", encoding="utf-8") as handle:
 PY
 }
 
+file_size_bytes() {
+  local file_path="${1:-}"
+  python3 - "$file_path" <<'PY'
+import os
+import sys
+
+try:
+    print(os.path.getsize(sys.argv[1]))
+except OSError:
+    print(0)
+PY
+}
+
+wait_for_evidence_log_quiet() {
+  local previous_size="-1"
+  local current_size="0"
+  for _ in $(seq 1 20); do
+    current_size="$(file_size_bytes "$EVIDENCE_LOG")"
+    if [[ "$current_size" == "$previous_size" ]]; then
+      printf '%s\n' "$current_size"
+      return 0
+    fi
+    previous_size="$current_size"
+    sleep 0.1
+  done
+  printf '%s\n' "$(file_size_bytes "$EVIDENCE_LOG")"
+}
+
 has_turn_evidence() {
   local log_path="${1:-}"
   local log_offset="${2:-0}"
+  local prompt_text="${3:-}"
   if [[ -n "$log_path" && -f "$log_path" ]]; then
-    local log_size
-    log_size="$(wc -c <"$log_path" | tr -d ' ')"
-    if [[ "$log_size" -gt "$log_offset" ]] && tail -c +$((log_offset + 1)) "$log_path" | grep -Eiq "$TURN_EVIDENCE_PATTERN"; then
-      return 0
-    fi
+    python3 - "$log_path" "$log_offset" "$TURN_EVIDENCE_PATTERN" "$prompt_text" <<'PY'
+import re
+import sys
+
+log_path, offset_raw, pattern, prompt_text = sys.argv[1:]
+try:
+    offset = int(offset_raw)
+except ValueError:
+    offset = 0
+try:
+    with open(log_path, "rb") as handle:
+        handle.seek(max(offset, 0))
+        data = handle.read()
+except OSError:
+    sys.exit(1)
+
+text = data.decode("utf-8", errors="replace")
+if prompt_text:
+    text = text.replace(prompt_text, "")
+if re.search(pattern, text, re.IGNORECASE):
+    sys.exit(0)
+sys.exit(1)
+PY
+    return $?
   fi
   return 1
+}
+
+print_redacted_tail() {
+  local prompt_text="${TEXT:-}"
+  python3 - "$prompt_text" <<'PY'
+import sys
+
+prompt = sys.argv[1]
+text = sys.stdin.read()
+if prompt:
+    text = text.replace(prompt, "[prompt redacted]")
+for line in text.splitlines()[-40:]:
+    print(line)
+PY
 }
 
 show_missing_session_diagnostics() {
@@ -95,7 +157,7 @@ show_missing_session_diagnostics() {
     echo "durable events: $state_dir/events.log" >&2
   fi
   echo "--- durable pane log tail ---" >&2
-  tail -40 "$log_path" >&2
+  tail -40 "$log_path" | print_redacted_tail >&2
 }
 
 if [[ "$TEXT_ARG" == @* ]]; then
@@ -119,36 +181,63 @@ fi
 if ! printf '%s\n' "$PANE_TEXT" | grep -qE 'Gajae forge|Type your message|> Type your message|Working'; then
   echo "refusing to paste prompt: GJC TUI is not ready in session $SESSION" >&2
   echo "--- pane tail ---" >&2
-  printf '%s\n' "$PANE_TEXT" | tail -40 >&2
+  printf '%s\n' "$PANE_TEXT" | print_redacted_tail >&2
   exit 1
 fi
 
-# Establish freshness before sending. Prompt acceptance must come from output
-# captured after this boundary. Do not use a later capture-pane slice as the
-# freshness source: tmux's scrollback window can move and reclassify stale lines
-# as "new" after we paste a long prompt. A temporary pipe-pane log records only
-# bytes emitted after the boundary.
-EVIDENCE_LOG="$(mktemp "${TMPDIR:-/tmp}/gjc-session-prompt-evidence.XXXXXX")"
+# Establish freshness before submission. Prompt acceptance must come from bytes
+# captured after the local paste echo has drained, but before Enter submits the
+# turn. Prefer the durable pane log when session state provides one so this
+# script does not replace an existing tmux pipe-pane logger.
+EVIDENCE_LOG=""
+EVIDENCE_LOG_IS_TEMP=0
+if [[ -n "${GJC_SESSION_STATE_DIR:-}" && -f "$GJC_SESSION_STATE_DIR/pane.log" ]]; then
+  EVIDENCE_LOG="$GJC_SESSION_STATE_DIR/pane.log"
+else
+  durable_log_candidates=()
+  mapfile -t durable_log_candidates < <(find_durable_pane_logs)
+  if [[ "${#durable_log_candidates[@]}" -gt 0 ]]; then
+    EVIDENCE_LOG="${durable_log_candidates[0]}"
+  else
+    EVIDENCE_LOG="$(mktemp "${TMPDIR:-/tmp}/gjc-session-prompt-evidence.XXXXXX")"
+    EVIDENCE_LOG_IS_TEMP=1
+  fi
+fi
 EVIDENCE_LOG_OFFSET=0
 cleanup_evidence_log() {
-  "${TMUX_CMD[@]}" pipe-pane -t "$SESSION":0.0 2>/dev/null || true
-  rm -f "$EVIDENCE_LOG"
+  if [[ "$EVIDENCE_LOG_IS_TEMP" == "1" ]]; then
+    "${TMUX_CMD[@]}" pipe-pane -t "$SESSION":0.0 2>/dev/null || true
+    rm -f "$EVIDENCE_LOG"
+  fi
 }
 trap cleanup_evidence_log EXIT
-"${TMUX_CMD[@]}" pipe-pane -t "$SESSION":0.0 "cat >> '$EVIDENCE_LOG'"
+if [[ "$EVIDENCE_LOG_IS_TEMP" == "1" ]]; then
+  "${TMUX_CMD[@]}" pipe-pane -t "$SESSION":0.0 "cat >> '$EVIDENCE_LOG'"
+fi
 
 "${TMUX_CMD[@]}" send-keys -t "$SESSION" -l "$TEXT"
 sleep 0.5
+EVIDENCE_LOG_OFFSET="$(wait_for_evidence_log_quiet)"
 # Multiple Enters work around terminal focus/submission edge cases. Prompt visibility is not acceptance;
 # verify Working/tool activity afterwards.
 "${TMUX_CMD[@]}" send-keys -t "$SESSION" Enter
 sleep 1
-"${TMUX_CMD[@]}" send-keys -t "$SESSION" Enter
+if has_turn_evidence "$EVIDENCE_LOG" "$EVIDENCE_LOG_OFFSET" "$TEXT"; then
+  record_prompt_accepted
+  echo "sent to $SESSION with durable turn evidence"
+  exit 0
+fi
+"${TMUX_CMD[@]}" send-keys -t "$SESSION" Enter 2>/dev/null || true
 sleep 1
-"${TMUX_CMD[@]}" send-keys -t "$SESSION" Enter
+"${TMUX_CMD[@]}" send-keys -t "$SESSION" Enter 2>/dev/null || true
 
 for _ in $(seq 1 "$PROMPT_EVIDENCE_ATTEMPTS"); do
   sleep 1
+  if has_turn_evidence "$EVIDENCE_LOG" "$EVIDENCE_LOG_OFFSET" "$TEXT"; then
+    record_prompt_accepted
+    echo "sent to $SESSION with durable turn evidence"
+    exit 0
+  fi
   PANE_TEXT="$(${TMUX_CMD[@]} capture-pane -t "$SESSION":0.0 -p -S -120 2>/dev/null || true)"
   if [[ -z "$PANE_TEXT" ]]; then
     mapfile -t candidates < <(find_durable_pane_logs)
@@ -159,14 +248,14 @@ for _ in $(seq 1 "$PROMPT_EVIDENCE_ATTEMPTS"); do
     fi
     exit 1
   fi
-  if has_turn_evidence "$EVIDENCE_LOG" "$EVIDENCE_LOG_OFFSET"; then
+  if has_turn_evidence "$EVIDENCE_LOG" "$EVIDENCE_LOG_OFFSET" "$TEXT"; then
     record_prompt_accepted
-    echo "sent to $SESSION with durable turn evidence: ${TEXT:0:80}..."
+    echo "sent to $SESSION with durable turn evidence"
     exit 0
   fi
 done
 
 echo "prompt acceptance failed: no durable turn evidence appeared in session $SESSION" >&2
 echo "--- pane tail ---" >&2
-printf '%s\n' "$PANE_TEXT" | tail -40 >&2
+printf '%s\n' "$PANE_TEXT" | print_redacted_tail >&2
 exit 1


### PR DESCRIPTION
## Summary
- Record durable `prompt-accepted.json` when `gjc-session/prompt.sh` sees fresh turn evidence after sending a prompt.
- Teach the external `gjc-session` monitor to classify missing tmux sessions after accepted prompts as `tmux_session_missing_after_prompt_acceptance`.
- Add regression coverage for the post-acceptance raw tmux vanish path.

## Verification
- `bun test scripts/gjc-session/create.test.ts --timeout 30000`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`

Fixes #1496

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*