### PR TITLE
Fix inline slash command autocomplete

### DIFF
--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -154,6 +154,10 @@ function sortSlashCommandSuggestions(
 	return { ...suggestions, items };
 }
 
+function isRootPathSuggestionResult(suggestions: { items: AutocompleteItem[]; prefix: string } | null): boolean {
+	return suggestions?.prefix.startsWith("/") === true && suggestions.items.some(item => item.value.startsWith("/"));
+}
+
 function withoutSkillCommandSuggestions(
 	suggestions: { items: AutocompleteItem[]; prefix: string } | null,
 ): { items: AutocompleteItem[]; prefix: string } | null {
@@ -227,6 +231,7 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 			const baseSuggestions = withoutSkillCommandSuggestions(
 				await this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol),
 			);
+			if (isRootPathSuggestionResult(baseSuggestions)) return baseSuggestions;
 			const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor, {
 				includeEmpty: slashPrefix === "/",
 			});

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -1,5 +1,12 @@
-import type { AutocompleteItem, AutocompleteProvider, SlashCommand } from "@gajae-code/tui";
-import { CombinedAutocompleteProvider, getKeybindings, getSlashCommandMatchRank } from "@gajae-code/tui";
+import {
+	type AutocompleteItem,
+	type AutocompleteProvider,
+	CombinedAutocompleteProvider,
+	extractSlashCommandTokenPrefix,
+	getKeybindings,
+	getSlashCommandMatchRank,
+	type SlashCommand,
+} from "@gajae-code/tui";
 import type { KeybindingsManager } from "../config/keybindings";
 import { formatKeyHints } from "../config/keybindings";
 import { isSettingsInitialized, settings } from "../config/settings";
@@ -168,18 +175,9 @@ function getPromptActionPrefix(textBeforeCursor: string): string | null {
 }
 
 function getSlashTokenPrefix(textBeforeCursor: string): string | null {
-	const slashIndex = textBeforeCursor.lastIndexOf("/");
-	if (slashIndex === -1) return null;
-	const beforeSlash = textBeforeCursor.slice(0, slashIndex);
-	if (beforeSlash && !/\s$/.test(beforeSlash)) return null;
-	const token = textBeforeCursor.slice(slashIndex);
-	if (/[\s]/.test(token)) return null;
-	return token;
+	return extractSlashCommandTokenPrefix(textBeforeCursor);
 }
 
-function isLeadingSlashToken(textBeforeCursor: string, slashPrefix: string): boolean {
-	return textBeforeCursor.trimStart() === slashPrefix;
-}
 export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 	#baseProvider: CombinedAutocompleteProvider;
 	#actions: PromptActionDefinition[];
@@ -226,14 +224,12 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 
 		const slashPrefix = getSlashTokenPrefix(textBeforeCursor);
 		if (slashPrefix) {
-			const isLeading = isLeadingSlashToken(textBeforeCursor, slashPrefix);
-			const baseSuggestions = isLeading
-				? withoutSkillCommandSuggestions(await this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol))
-				: null;
-			const skillCommandSuggestions =
-				isLeading || slashPrefix.startsWith("/skill")
-					? this.#getSkillCommandSuggestions(textBeforeCursor, { includeEmpty: isLeading })
-					: null;
+			const baseSuggestions = withoutSkillCommandSuggestions(
+				await this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol),
+			);
+			const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor, {
+				includeEmpty: slashPrefix === "/",
+			});
 			return sortSlashCommandSuggestions(
 				mergeAutocompleteSuggestions(baseSuggestions, skillCommandSuggestions),
 				this.#commands,

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import type { SlashCommand } from "@gajae-code/tui";
 import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "@gajae-code/tui";
+import { Editor } from "@gajae-code/tui/components/editor";
+import { defaultEditorTheme } from "../../tui/test/test-themes";
 import { KeybindingsManager as AppKeybindingsManager } from "../src/config/keybindings";
 import { createPromptActionAutocompleteProvider } from "../src/modes/prompt-action-autocomplete";
 
@@ -114,6 +116,51 @@ describe("prompt action autocomplete", () => {
 		expect(suggestions?.items.find(item => item.value === "session")?.description).toBe(
 			"Show current session info or delete current session",
 		);
+	});
+
+	it("offers slash command names from inline prompt text", async () => {
+		const provider = createNoopProvider([{ name: "help", description: "Learn commands and beginner workflows" }]);
+		const line = "please /he";
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+
+		expect(suggestions?.prefix).toBe("/he");
+		expect(suggestions?.items.map(item => item.value)).toContain("help");
+	});
+
+	it("offers slash command names from adjacent inline prompt text", async () => {
+		const provider = createNoopProvider([{ name: "help", description: "Learn commands and beginner workflows" }]);
+		const line = "please/hel";
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+
+		expect(suggestions?.prefix).toBe("/hel");
+		expect(suggestions?.items.map(item => item.value)).toContain("help");
+	});
+
+	it("opens the composer autocomplete list from an adjacent inline slash", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			createNoopProvider([{ name: "help", description: "Learn commands and beginner workflows" }]),
+		);
+
+		editor.handleInput("please/");
+		await Bun.sleep(0);
+
+		expect(editor.isShowingAutocomplete()).toBe(true);
+	});
+
+	it("applies adjacent inline slash command completion without replacing prompt text", async () => {
+		const provider = createNoopProvider([{ name: "help", description: "Learn commands and beginner workflows" }]);
+		const line = "please/hel";
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+		const item = suggestions?.items.find(entry => entry.value === "help");
+		expect(item).toBeDefined();
+		if (!item || !suggestions) {
+			throw new Error("expected help suggestion");
+		}
+
+		const applied = provider.applyCompletion([line], 0, line.length, item, suggestions.prefix);
+		expect(applied.lines[0]).toBe("please/help ");
+		expect(applied.cursorCol).toBe("please/help ".length);
 	});
 
 	it("passes the typed trigger to undo and leaves text removal to the editor", async () => {

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -136,6 +136,16 @@ describe("prompt action autocomplete", () => {
 		expect(suggestions?.items.map(item => item.value)).toContain("help");
 	});
 
+	it("preserves root path suggestions for bare absolute inline slash", async () => {
+		const provider = createNoopProvider([{ name: "model", description: "Switch model" }]);
+		const line = "open /";
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+
+		expect(suggestions?.prefix).toBe("/");
+		expect(suggestions?.items.some(item => item.value.startsWith("/"))).toBe(true);
+		expect(suggestions?.items.map(item => item.value)).not.toContain("model");
+	});
+
 	it("opens the composer autocomplete list from an adjacent inline slash", async () => {
 		const editor = new Editor(defaultEditorTheme);
 		editor.setAutocompleteProvider(

--- a/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
@@ -50,9 +50,9 @@ describe("prompt action skill autocomplete", () => {
 		expect(applied.lines[0]).toBe("/skill:deep-interview first /skill:deep-interview ");
 	});
 
-	it("offers slash command completions from a bare slash token after prompt text", async () => {
+	it("offers slash command completions from an adjacent slash token after prompt text", async () => {
 		const provider = createProvider();
-		const line = "please use /";
+		const line = "please use/";
 		const suggestions = await provider.getSuggestions([line], 0, line.length);
 		expect(suggestions?.prefix).toBe("/");
 		expect(suggestions?.items.map(item => item.value)).toEqual(expect.arrayContaining(["model", "skill:team"]));

--- a/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
@@ -50,11 +50,12 @@ describe("prompt action skill autocomplete", () => {
 		expect(applied.lines[0]).toBe("/skill:deep-interview first /skill:deep-interview ");
 	});
 
-	it("does not offer skill completions from a bare slash token after prompt text", async () => {
+	it("offers slash command completions from a bare slash token after prompt text", async () => {
 		const provider = createProvider();
 		const line = "please use /";
 		const suggestions = await provider.getSuggestions([line], 0, line.length);
-		expect(suggestions).toBeNull();
+		expect(suggestions?.prefix).toBe("/");
+		expect(suggestions?.items.map(item => item.value)).toEqual(expect.arrayContaining(["model", "skill:team"]));
 	});
 
 	it("offers skill completions from an inline /skill token after prompt text", async () => {

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -272,6 +272,55 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		this.#basePath = basePath;
 	}
 
+	#getCommandName(cmd: SlashCommand | AutocompleteItem): string {
+		return "name" in cmd ? cmd.name : cmd.value;
+	}
+
+	#getSlashCommandNameSuggestions(prefix: string): AutocompleteItem[] {
+		const lowerPrefix = prefix.toLowerCase();
+
+		return this.#commands
+			.filter(cmd => {
+				const name = this.#getCommandName(cmd);
+				if (!name) return false;
+				if (fuzzyMatch(lowerPrefix, name.toLowerCase())) return true;
+				if (getSlashCommandMatchRank(lowerPrefix, name.toLowerCase()) < 4) return true;
+				const desc = cmd.description?.toLowerCase();
+				return desc ? fuzzyMatch(lowerPrefix, desc) : false;
+			})
+			.map((cmd, index) => {
+				const name = this.#getCommandName(cmd);
+				const lowerName = name?.toLowerCase() ?? "";
+				const lowerDesc = cmd.description?.toLowerCase() ?? "";
+				const nameScore = fuzzyMatch(lowerPrefix, lowerName) ? fuzzyScore(lowerPrefix, lowerName) : 0;
+				const descScore = fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
+				const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
+				const desc = cmd.description ?? "";
+				const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
+				const priority = "priority" in cmd && typeof cmd.priority === "number" ? cmd.priority : 0;
+				return {
+					value: name,
+					label: "name" in cmd ? cmd.name : cmd.label,
+					score: Math.max(nameScore, descScore),
+					priority,
+					matchRank: getSlashCommandMatchRank(lowerPrefix, lowerName),
+					index,
+					...(fullDesc && { description: fullDesc }),
+				} as AutocompleteItem & { score: number; priority: number; matchRank: number; index: number };
+			})
+			.sort((a, b) => a.matchRank - b.matchRank || b.priority - a.priority || b.score - a.score || a.index - b.index)
+			.map(({ score: _score, priority: _priority, matchRank: _matchRank, index: _index, ...rest }) => rest);
+	}
+
+	#extractSlashCommandPrefix(text: string): string | null {
+		const match = text.match(/(?:^|\s)(\/[^/\s]*)$/);
+		return match?.[1] ?? null;
+	}
+
+	#isKnownCommandItem(item: AutocompleteItem): boolean {
+		return this.#commands.some(cmd => this.#getCommandName(cmd) === item.value);
+	}
+
 	async getSuggestions(
 		lines: string[],
 		cursorLine: number,
@@ -301,52 +350,14 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			};
 		}
 
-		// Check for slash commands
+		// Check for slash commands at the submitted-message start
 		if (textBeforeCursor.startsWith("/")) {
 			const spaceIndex = textBeforeCursor.indexOf(" ");
 
 			if (spaceIndex === -1) {
 				// No space yet - complete command names
 				const prefix = textBeforeCursor.slice(1); // Remove the "/"
-				const lowerPrefix = prefix.toLowerCase();
-
-				// Filter commands using fuzzy matching (subsequence match)
-				const matches = this.#commands
-					.filter(cmd => {
-						const name = "name" in cmd ? cmd.name : cmd.value;
-						if (!name) return false;
-						// Match name, normalized slash-name aliases, or description.
-						if (fuzzyMatch(lowerPrefix, name.toLowerCase())) return true;
-						if (getSlashCommandMatchRank(lowerPrefix, name.toLowerCase()) < 4) return true;
-						const desc = cmd.description?.toLowerCase();
-						return desc ? fuzzyMatch(lowerPrefix, desc) : false;
-					})
-					.map((cmd, index) => {
-						const name = "name" in cmd ? cmd.name : cmd.value;
-						const lowerName = name?.toLowerCase() ?? "";
-						const lowerDesc = cmd.description?.toLowerCase() ?? "";
-						// Score name matches higher than description matches
-						const nameScore = fuzzyMatch(lowerPrefix, lowerName) ? fuzzyScore(lowerPrefix, lowerName) : 0;
-						const descScore = fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
-						const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
-						const desc = cmd.description ?? "";
-						const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
-						const priority = "priority" in cmd && typeof cmd.priority === "number" ? cmd.priority : 0;
-						return {
-							value: name,
-							label: "name" in cmd ? cmd.name : cmd.label,
-							score: Math.max(nameScore, descScore),
-							priority,
-							matchRank: getSlashCommandMatchRank(lowerPrefix, lowerName),
-							index,
-							...(fullDesc && { description: fullDesc }),
-						};
-					})
-					.sort(
-						(a, b) =>
-							a.matchRank - b.matchRank || b.priority - a.priority || b.score - a.score || a.index - b.index,
-					)
-					.map(({ score: _score, priority: _priority, matchRank: _matchRank, index: _index, ...rest }) => rest);
+				const matches = this.#getSlashCommandNameSuggestions(prefix);
 
 				if (matches.length === 0) return null;
 
@@ -354,29 +365,37 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					items: matches,
 					prefix: textBeforeCursor,
 				};
-			} else {
-				// Space found - complete command arguments
-				const commandName = textBeforeCursor.slice(1, spaceIndex); // Command without "/"
-				const argumentText = textBeforeCursor.slice(spaceIndex + 1); // Text after space
-
-				const command = this.#commands.find(cmd => {
-					const name = "name" in cmd ? cmd.name : cmd.value;
-					return name === commandName;
-				});
-				if (!command || !("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
-					return null; // No argument completion for this command
-				}
-
-				const argumentSuggestions = await command.getArgumentCompletions(argumentText);
-				if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
-					return null;
-				}
-
-				return {
-					items: argumentSuggestions,
-					prefix: argumentText,
-				};
 			}
+
+			// Space found - complete command arguments
+			const commandName = textBeforeCursor.slice(1, spaceIndex); // Command without "/"
+			const argumentText = textBeforeCursor.slice(spaceIndex + 1); // Text after space
+
+			const command = this.#commands.find(cmd => this.#getCommandName(cmd) === commandName);
+			if (!command || !("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
+				return null; // No argument completion for this command
+			}
+
+			const argumentSuggestions = await command.getArgumentCompletions(argumentText);
+			if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
+				return null;
+			}
+
+			return {
+				items: argumentSuggestions,
+				prefix: argumentText,
+			};
+		}
+
+		const slashPrefix = this.#extractSlashCommandPrefix(textBeforeCursor);
+		if (slashPrefix) {
+			const matches = this.#getSlashCommandNameSuggestions(slashPrefix.slice(1));
+			if (matches.length === 0) return null;
+
+			return {
+				items: matches,
+				prefix: slashPrefix,
+			};
 		}
 
 		// Check for file paths - triggered by Tab or if we detect a path pattern
@@ -418,9 +437,12 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const beforePrefix = currentLine.slice(0, cursorCol - prefix.length);
 		const afterCursor = currentLine.slice(cursorCol);
 
-		// Check if we're completing a slash command (prefix starts with "/" but NOT a file path)
-		// Slash commands are at the start of the line and don't contain path separators after the first /
-		const isSlashCommand = prefix.startsWith("/") && beforePrefix.trim() === "" && !prefix.slice(1).includes("/");
+		// Check if we're completing a slash command name. Start-of-line commands
+		// execute on submit; inline slash tokens are completed as ordinary text.
+		const isSlashCommand =
+			prefix.startsWith("/") &&
+			!prefix.slice(1).includes("/") &&
+			(beforePrefix.trim() === "" || (/\s$/.test(beforePrefix) && this.#isKnownCommandItem(item)));
 		if (isSlashCommand) {
 			// This is a command name completion
 			const newLine = `${beforePrefix}/${item.value} ${afterCursor}`;
@@ -855,40 +877,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		if (textBeforeCursor.length <= 1) return null; // Bare "/" alone, don't auto-complete
 		if (textBeforeCursor.includes(" ")) return null; // Only complete command name, not args
 
-		const prefix = textBeforeCursor.slice(1);
-		const lowerPrefix = prefix.toLowerCase();
-
-		const matches = this.#commands
-			.filter(cmd => {
-				const name = "name" in cmd ? cmd.name : cmd.value;
-				if (!name) return false;
-				if (fuzzyMatch(lowerPrefix, name.toLowerCase())) return true;
-				if (getSlashCommandMatchRank(lowerPrefix, name.toLowerCase()) < 4) return true;
-				const desc = cmd.description?.toLowerCase();
-				return desc ? fuzzyMatch(lowerPrefix, desc) : false;
-			})
-			.map((cmd, index) => {
-				const name = "name" in cmd ? cmd.name : cmd.value;
-				const lowerName = name?.toLowerCase() ?? "";
-				const lowerDesc = cmd.description?.toLowerCase() ?? "";
-				const nameScore = fuzzyMatch(lowerPrefix, lowerName) ? fuzzyScore(lowerPrefix, lowerName) : 0;
-				const descScore = fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
-				const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
-				const desc = cmd.description ?? "";
-				const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
-				const priority = "priority" in cmd && typeof cmd.priority === "number" ? cmd.priority : 0;
-				return {
-					value: name,
-					label: "name" in cmd ? cmd.name : cmd.label,
-					score: Math.max(nameScore, descScore),
-					priority,
-					matchRank: getSlashCommandMatchRank(lowerPrefix, lowerName),
-					index,
-					...(fullDesc && { description: fullDesc }),
-				} as AutocompleteItem & { score: number; priority: number; matchRank: number; index: number };
-			})
-			.sort((a, b) => a.matchRank - b.matchRank || b.priority - a.priority || b.score - a.score || a.index - b.index)
-			.map(({ score: _score, priority: _priority, matchRank: _matchRank, index: _index, ...rest }) => rest);
+		const matches = this.#getSlashCommandNameSuggestions(textBeforeCursor.slice(1));
 
 		if (matches.length === 0) return null;
 		return { items: matches, prefix: textBeforeCursor };

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -189,7 +189,20 @@ function normalizeSlashCommandText(value: string): string {
 		.trim()
 		.replace(/\s+/g, " ");
 }
+const NON_COMMAND_SLASH_PREFIX_PRECEDERS = new Set(["/", "\\", ":", ".", "~"]);
 
+export function extractSlashCommandTokenPrefix(text: string): string | null {
+	const slashIndex = text.lastIndexOf("/");
+	if (slashIndex === -1) return null;
+
+	const token = text.slice(slashIndex);
+	if (/[\s]/.test(token)) return null;
+
+	const charBeforeSlash = text[slashIndex - 1];
+	if (charBeforeSlash && NON_COMMAND_SLASH_PREFIX_PRECEDERS.has(charBeforeSlash)) return null;
+
+	return token;
+}
 export interface AutocompleteItem {
 	value: string;
 	label: string;
@@ -325,8 +338,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	}
 
 	#extractSlashCommandPrefix(text: string): string | null {
-		const match = text.match(/(?:^|\s)(\/[^/\s]*)$/);
-		return match?.[1] ?? null;
+		return extractSlashCommandTokenPrefix(text);
 	}
 
 	#isKnownCommandItem(item: AutocompleteItem): boolean {
@@ -402,12 +414,12 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const slashPrefix = this.#extractSlashCommandPrefix(textBeforeCursor);
 		if (slashPrefix) {
 			const matches = this.#getInlineSlashCommandNameSuggestions(slashPrefix.slice(1));
-			if (matches.length === 0) return null;
-
-			return {
-				items: matches,
-				prefix: slashPrefix,
-			};
+			if (matches.length > 0) {
+				return {
+					items: matches,
+					prefix: slashPrefix,
+				};
+			}
 		}
 
 		// Check for file paths - triggered by Tab or if we detect a path pattern
@@ -454,7 +466,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const isSlashCommand =
 			prefix.startsWith("/") &&
 			!prefix.slice(1).includes("/") &&
-			(beforePrefix.trim() === "" || (/\s$/.test(beforePrefix) && this.#isKnownCommandItem(item)));
+			(beforePrefix.trim() === "" || this.#isKnownCommandItem(item));
 		if (isSlashCommand) {
 			// This is a command name completion
 			const newLine = `${beforePrefix}/${item.value} ${afterCursor}`;

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -312,6 +312,18 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			.map(({ score: _score, priority: _priority, matchRank: _matchRank, index: _index, ...rest }) => rest);
 	}
 
+	#getInlineSlashCommandNameSuggestions(prefix: string): AutocompleteItem[] {
+		if (prefix.length === 0) return this.#getSlashCommandNameSuggestions(prefix);
+
+		const normalizedPrefix = normalizeSlashCommandText(prefix);
+		return this.#getSlashCommandNameSuggestions(prefix).filter(item => {
+			const lowerValue = item.value.toLowerCase();
+			if (lowerValue.startsWith(prefix.toLowerCase())) return true;
+			if (!normalizedPrefix) return true;
+			return normalizeSlashCommandText(item.value).startsWith(normalizedPrefix);
+		});
+	}
+
 	#extractSlashCommandPrefix(text: string): string | null {
 		const match = text.match(/(?:^|\s)(\/[^/\s]*)$/);
 		return match?.[1] ?? null;
@@ -389,7 +401,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 		const slashPrefix = this.#extractSlashCommandPrefix(textBeforeCursor);
 		if (slashPrefix) {
-			const matches = this.#getSlashCommandNameSuggestions(slashPrefix.slice(1));
+			const matches = this.#getInlineSlashCommandNameSuggestions(slashPrefix.slice(1));
 			if (matches.length === 0) return null;
 
 			return {

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -411,8 +411,20 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			};
 		}
 
+		const pathMatch = this.#extractPathPrefix(textBeforeCursor, false);
+		let pathSuggestions: AutocompleteItem[] | null = null;
 		const slashPrefix = this.#extractSlashCommandPrefix(textBeforeCursor);
 		if (slashPrefix) {
+			if (pathMatch === slashPrefix && slashPrefix.startsWith("/")) {
+				pathSuggestions = await this.#getFileSuggestions(pathMatch);
+				if (pathSuggestions.length > 0) {
+					return {
+						items: pathSuggestions,
+						prefix: pathMatch,
+					};
+				}
+			}
+
 			const matches = this.#getInlineSlashCommandNameSuggestions(slashPrefix.slice(1));
 			if (matches.length > 0) {
 				return {
@@ -423,10 +435,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		}
 
 		// Check for file paths - triggered by Tab or if we detect a path pattern
-		const pathMatch = this.#extractPathPrefix(textBeforeCursor, false);
-
 		if (pathMatch !== null) {
-			const suggestions = await this.#getFileSuggestions(pathMatch);
+			const suggestions = pathSuggestions ?? (await this.#getFileSuggestions(pathMatch));
 			if (suggestions.length === 0) return null;
 
 			// Check if we have an exact match that is a directory

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1728,9 +1728,8 @@ export class Editor implements Component, Focusable {
 
 		// Check if we should trigger or update autocomplete
 		if (!this.#autocompleteState) {
-			// Auto-trigger for "/" at the start of a submitted command.
-			// Inline skill autocomplete starts after the token becomes "/skill...".
-			if (char === "/" && this.#isAtStartOfSubmittedMessage()) {
+			// Auto-trigger for slash command tokens.
+			if (char === "/" && (this.#isAtStartOfSubmittedMessage() || this.#isInSlashTokenContext())) {
 				this.#tryTriggerAutocomplete();
 			}
 			// Auto-trigger for "@" file reference (fuzzy search)
@@ -2656,7 +2655,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#isInSlashTokenContext(): boolean {
-		return this.#getSlashTokenBeforeCursor()?.startsWith("/skill") === true;
+		return this.#getSlashTokenBeforeCursor() !== null;
 	}
 
 	#isSlashCommandNameAutocompleteSelection(): boolean {
@@ -2740,7 +2739,10 @@ export class Editor implements Component, Focusable {
 		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
 
 		// Check if we're in a slash command context
-		if (this.#isInSubmittedSlashCommandContext() && !beforeCursor.trimStart().includes(" ")) {
+		if (
+			(this.#isInSubmittedSlashCommandContext() && !beforeCursor.trimStart().includes(" ")) ||
+			this.#isInSlashTokenContext()
+		) {
 			this.#handleSlashCommandCompletion();
 		} else {
 			this.#forceFileAutocomplete(true);

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,5 +1,9 @@
 import { getProjectDir, logger } from "@gajae-code/utils";
-import type { AutocompleteProvider, CombinedAutocompleteProvider } from "../autocomplete";
+import {
+	type AutocompleteProvider,
+	type CombinedAutocompleteProvider,
+	extractSlashCommandTokenPrefix,
+} from "../autocomplete";
 import { BracketedPasteHandler } from "../bracketed-paste";
 import { getKeybindings, type KeybindingsManager } from "../keybindings";
 import { extractPrintableText, matchesKey } from "../keys";
@@ -2650,8 +2654,7 @@ export class Editor implements Component, Focusable {
 	#getSlashTokenBeforeCursor(): string | null {
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
-		const match = beforeCursor.match(/(?:^|\s)(\/[^\s]*)$/);
-		return match?.[1] ?? null;
+		return extractSlashCommandTokenPrefix(beforeCursor);
 	}
 
 	#isInSlashTokenContext(): boolean {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -210,6 +210,20 @@ describe("inline slash command suggestions", () => {
 		expect(result?.items.map(item => item.value) ?? []).not.toContain("template");
 	});
 
+	it("lets bare absolute root paths use file suggestions before slash commands", async () => {
+		const line = "open /";
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "model", description: "Switch model", value: "model" }],
+			"/tmp",
+		);
+		const result = await provider.getSuggestions([line], 0, line.length);
+
+		expect(result).not.toBeNull();
+		expect(result!.prefix).toBe("/");
+		expect(result!.items.some(item => item.value.startsWith("/"))).toBe(true);
+		expect(result!.items.map(item => item.value)).not.toContain("model");
+	});
+
 	it("matches normalized inline slash command prefixes", async () => {
 		const provider = new CombinedAutocompleteProvider(
 			[{ name: "skill:team", description: "Run team workflow", value: "skill:team" }],

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -183,6 +183,19 @@ describe("inline slash command suggestions", () => {
 		expect(result!.items.map(item => item.value)).toEqual(["model"]);
 	});
 
+	it("suggests command names for slash tokens adjacent to prompt text", async () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "help", description: "Learn commands", value: "help" }],
+			"/tmp",
+		);
+		const line = "explain this/hel";
+		const result = await provider.getSuggestions([line], 0, line.length);
+
+		expect(result).not.toBeNull();
+		expect(result!.prefix).toBe("/hel");
+		expect(result!.items.map(item => item.value)).toEqual(["help"]);
+	});
+
 	it("lets absolute paths use file suggestions when the inline slash token is not a command prefix", async () => {
 		const line = "open /tmp";
 		const pathOnlyProvider = new CombinedAutocompleteProvider([], "/tmp");
@@ -220,6 +233,18 @@ describe("inline slash command suggestions", () => {
 
 		expect(result.lines[0]).toBe("explain this /model ");
 		expect(result.cursorCol).toBe("explain this /model ".length);
+	});
+
+	it("applies adjacent inline slash command completion without replacing prior text", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "help", description: "Learn commands", value: "help" }],
+			"/tmp",
+		);
+		const line = "explain this/hel";
+		const result = provider.applyCompletion([line], 0, line.length, { value: "help", label: "help" }, "/hel");
+
+		expect(result.lines[0]).toBe("explain this/help ");
+		expect(result.cursorCol).toBe("explain this/help ".length);
 	});
 });
 describe("trySyncSlashCompletion", () => {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -183,6 +183,33 @@ describe("inline slash command suggestions", () => {
 		expect(result!.items.map(item => item.value)).toEqual(["model"]);
 	});
 
+	it("lets absolute paths use file suggestions when the inline slash token is not a command prefix", async () => {
+		const line = "open /tmp";
+		const pathOnlyProvider = new CombinedAutocompleteProvider([], "/tmp");
+		const pathOnlyResult = await pathOnlyProvider.getSuggestions([line], 0, line.length);
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "template", description: "Temporary prompt template", value: "template" }],
+			"/tmp",
+		);
+		const result = await provider.getSuggestions([line], 0, line.length);
+
+		expect(result).toEqual(pathOnlyResult);
+		expect(result?.items.map(item => item.value) ?? []).not.toContain("template");
+	});
+
+	it("matches normalized inline slash command prefixes", async () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "skill:team", description: "Run team workflow", value: "skill:team" }],
+			"/tmp",
+		);
+		const line = "explain this /skill-te";
+		const result = await provider.getSuggestions([line], 0, line.length);
+
+		expect(result).not.toBeNull();
+		expect(result!.prefix).toBe("/skill-te");
+		expect(result!.items.map(item => item.value)).toEqual(["skill:team"]);
+	});
+
 	it("applies inline slash command completion without replacing prior text", () => {
 		const provider = new CombinedAutocompleteProvider(
 			[{ name: "model", description: "Switch AI model", value: "model" }],

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -168,6 +168,33 @@ describe("CombinedAutocompleteProvider", () => {
 		});
 	});
 });
+
+describe("inline slash command suggestions", () => {
+	it("suggests command names for slash tokens after existing prompt text", async () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "model", description: "Switch AI model", value: "model" }],
+			"/tmp",
+		);
+		const line = "explain this /mo";
+		const result = await provider.getSuggestions([line], 0, line.length);
+
+		expect(result).not.toBeNull();
+		expect(result!.prefix).toBe("/mo");
+		expect(result!.items.map(item => item.value)).toEqual(["model"]);
+	});
+
+	it("applies inline slash command completion without replacing prior text", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "model", description: "Switch AI model", value: "model" }],
+			"/tmp",
+		);
+		const line = "explain this /mo";
+		const result = provider.applyCompletion([line], 0, line.length, { value: "model", label: "model" }, "/mo");
+
+		expect(result.lines[0]).toBe("explain this /model ");
+		expect(result.cursorCol).toBe("explain this /model ".length);
+	});
+});
 describe("trySyncSlashCompletion", () => {
 	it("returns null for bare '/' (no prefix to match)", () => {
 		const provider = new CombinedAutocompleteProvider([], "/tmp");

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -149,13 +149,13 @@ class InlineSkillProvider implements AutocompleteProvider {
 	suggestionCalls = 0;
 }
 describe("Editor Enter handler sync slash completion", () => {
-	it("auto-triggers slash command autocomplete from a bare slash after prompt text", async () => {
+	it("auto-triggers slash command autocomplete from an inline slash after prompt text", async () => {
 		const editor = new Editor(defaultEditorTheme);
 		editor.setAutocompleteProvider(
 			new CombinedAutocompleteProvider([{ name: "model", description: "Switch model", value: "model" }], "/tmp"),
 		);
 
-		editor.handleInput("explain this /");
+		editor.handleInput("explain this/");
 		await Bun.sleep(0);
 
 		expect(editor.isShowingAutocomplete()).toBe(true);

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -161,6 +161,18 @@ describe("Editor Enter handler sync slash completion", () => {
 		expect(editor.isShowingAutocomplete()).toBe(true);
 	});
 
+	it("auto-triggers slash command autocomplete from an adjacent slash after prompt text", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider([{ name: "help", description: "Learn commands", value: "help" }], "/tmp"),
+		);
+
+		editor.handleInput("explain this/");
+		await Bun.sleep(0);
+
+		expect(editor.isShowingAutocomplete()).toBe(true);
+	});
+
 	it("auto-triggers inline slash skill autocomplete after prompt text", async () => {
 		const provider = new InlineSkillProvider();
 		const editor = new Editor(defaultEditorTheme);

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import type { AutocompleteItem, AutocompleteProvider } from "@gajae-code/tui/autocomplete";
+import {
+	type AutocompleteItem,
+	type AutocompleteProvider,
+	CombinedAutocompleteProvider,
+} from "@gajae-code/tui/autocomplete";
 import { Editor } from "@gajae-code/tui/components/editor";
 import { defaultEditorTheme } from "./test-themes";
 
@@ -145,26 +149,16 @@ class InlineSkillProvider implements AutocompleteProvider {
 	suggestionCalls = 0;
 }
 describe("Editor Enter handler sync slash completion", () => {
-	it("does not auto-trigger slash autocomplete from a bare slash after prior prompt text", async () => {
-		let suggestionCalls = 0;
+	it("auto-triggers slash command autocomplete from a bare slash after prompt text", async () => {
 		const editor = new Editor(defaultEditorTheme);
-		editor.setAutocompleteProvider({
-			async getSuggestions(lines, cursorLine, cursorCol) {
-				suggestionCalls += 1;
-				const currentLine = lines[cursorLine] ?? "";
-				return { prefix: currentLine.slice(0, cursorCol), items: [{ value: "model", label: "/model" }] };
-			},
-			applyCompletion(lines, cursorLine, cursorCol) {
-				return { lines, cursorLine, cursorCol };
-			},
-		});
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider([{ name: "model", description: "Switch model", value: "model" }], "/tmp"),
+		);
 
-		editor.setText("explain this\n");
-		editor.handleInput("/");
+		editor.handleInput("explain this /");
 		await Bun.sleep(0);
 
-		expect(suggestionCalls).toBe(0);
-		expect(editor.isShowingAutocomplete()).toBe(false);
+		expect(editor.isShowingAutocomplete()).toBe(true);
 	});
 
 	it("auto-triggers inline slash skill autocomplete after prompt text", async () => {


### PR DESCRIPTION
## Summary
- Enable slash-command autocomplete for inline composer text, including adjacent tokens such as `message/hel`.
- Keep Tab completion on inline slash selections without replacing the earlier prompt text.
- Preserve ordinary absolute path/file suggestions for `open /` and `open /tmp` before slash-command suggestions.

## Verification
- `bun test packages/tui/test/autocomplete.test.ts packages/tui/test/editor-autocomplete-actions.test.ts packages/coding-agent/test/prompt-action-autocomplete.test.ts packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts`
- `bun --cwd=packages/tui run check`
- `bun --cwd=packages/coding-agent run check`

This revision addresses the previous feedback on #1536 by adding explicit `open /` root-path coverage while keeping inline command autocomplete available in regular composer text.