### PR TITLE
fix(task): make AgentOutputManager id allocation concurrency-safe

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Goal completion now preserves the terminal `goal({op: "complete"})` state even when a `goal_updated` extension hook throws, preventing hook-side write errors from trapping a verified ultragoal run in the continuation loop.
 - Ultragoal completion no longer requires the computer-use red-team suite for non-computer changes that only touch the shared `tools/index.ts` registration file.
+- Task subagent output-ID allocation (`AgentOutputManager`) is now concurrency-safe. `#ensureInitialized` previously set a boolean flag *before* the awaited `readdir`, so when two `task` calls are dispatched in the same turn (they run concurrently as shared-concurrency tools on one session-scoped manager) the second allocation short-circuited initialization and started from index `0` while the first scan was still in flight — colliding with existing `N-*.md` outputs and duplicating ids across batches, which overwrote prior subagent outputs on resume. The scan is now memoized as a promise so concurrent `allocate`/`allocateBatch`/`peekNextIndex` calls await the same `readdir` before `#nextId` is derived.
 
 ## [0.8.1] - 2026-07-04
 

--- a/packages/coding-agent/src/task/output-manager.ts
+++ b/packages/coding-agent/src/task/output-manager.ts
@@ -24,7 +24,7 @@ function escapeRegExp(value: string): string {
  */
 export class AgentOutputManager {
 	#nextId = 0;
-	#initialized = false;
+	#initPromise: Promise<void> | undefined;
 	readonly #getArtifactsDir: () => string | null;
 	readonly #parentPrefix: string | undefined;
 
@@ -34,13 +34,23 @@ export class AgentOutputManager {
 	}
 
 	/**
+	 * Memoize the in-flight scan so concurrent `allocate*`/`peekNextIndex`
+	 * calls await the SAME `readdir` before `#nextId` is derived. Assigning the
+	 * promise synchronously (before any `await`) closes the TOCTOU window where a
+	 * boolean "initialized" flag, flipped ahead of the awaited scan, let a second
+	 * caller allocate at `#nextId === 0` while the first was still scanning —
+	 * producing duplicate indices that overwrite prior outputs on resume.
+	 */
+	#ensureInitialized(): Promise<void> {
+		this.#initPromise ??= this.#scanExistingOutputs();
+		return this.#initPromise;
+	}
+
+	/**
 	 * Scan existing agent output files to find the next available ID.
 	 * This ensures we don't overwrite outputs when resuming a session.
 	 */
-	async #ensureInitialized(): Promise<void> {
-		if (this.#initialized) return;
-		this.#initialized = true;
-
+	async #scanExistingOutputs(): Promise<void> {
 		const dir = this.#getArtifactsDir();
 		if (!dir) return;
 
@@ -103,6 +113,6 @@ export class AgentOutputManager {
 	 */
 	reset(): void {
 		this.#nextId = 0;
-		this.#initialized = false;
+		this.#initPromise = undefined;
 	}
 }

--- a/packages/coding-agent/test/task/output-manager.test.ts
+++ b/packages/coding-agent/test/task/output-manager.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AgentOutputManager } from "../../src/task/output-manager";
+
+const tempDirs: string[] = [];
+
+async function makeArtifactsDir(existing: string[]): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-output-manager-"));
+	tempDirs.push(dir);
+	for (const file of existing) await fs.writeFile(path.join(dir, file), "x");
+	return dir;
+}
+
+afterEach(async () => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (dir) await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
+describe("AgentOutputManager", () => {
+	it("continues past existing outputs so resume does not overwrite", async () => {
+		const dir = await makeArtifactsDir(["0-Foo.md", "1-Bar.md", "2-Baz.md"]);
+		const mgr = new AgentOutputManager(() => dir);
+		expect(await mgr.allocateBatch(["Alpha", "Beta"])).toEqual(["3-Alpha", "4-Beta"]);
+	});
+
+	it("does not reuse or duplicate ids when allocations race on a shared instance", async () => {
+		// Regression: #ensureInitialized previously set a boolean flag BEFORE the
+		// awaited readdir, so a second concurrent allocate short-circuited init and
+		// allocated at #nextId === 0 while the first scan was still in flight —
+		// colliding with existing 0-/1-/2- outputs and duplicating indices across
+		// the two batches. The memoized init promise makes both awaits share one
+		// scan, so #nextId is derived before either allocates.
+		const dir = await makeArtifactsDir(["0-Foo.md", "1-Bar.md", "2-Baz.md"]);
+		const mgr = new AgentOutputManager(() => dir);
+
+		const [first, second] = await Promise.all([mgr.allocateBatch(["Alpha"]), mgr.allocateBatch(["Beta"])]);
+		const indices = [...first, ...second].map(id => Number.parseInt(id.split("-")[0] ?? "", 10));
+
+		// Every id continues past the existing 0/1/2 outputs...
+		expect(indices.every(index => index >= 3)).toBe(true);
+		// ...and no two allocations collide.
+		expect(new Set(indices).size).toBe(indices.length);
+	});
+
+	it("keeps peekNextIndex consistent with concurrent allocation", async () => {
+		const dir = await makeArtifactsDir(["0-Foo.md", "1-Bar.md", "2-Baz.md"]);
+		const mgr = new AgentOutputManager(() => dir);
+
+		const [peeked, allocated] = await Promise.all([mgr.peekNextIndex(), mgr.allocate("Alpha")]);
+		// peek observes the scanned cursor, not the pre-scan default of 0.
+		expect(peeked).toBeGreaterThanOrEqual(3);
+		expect(Number.parseInt(allocated.split("-")[0] ?? "", 10)).toBeGreaterThanOrEqual(3);
+	});
+});


### PR DESCRIPTION
## What

Makes task-subagent output-ID allocation (`AgentOutputManager`) concurrency-safe.

`#ensureInitialized` set its `#initialized` boolean **before** the awaited `readdir`:

```ts
async #ensureInitialized(): Promise<void> {
  if (this.#initialized) return;
  this.#initialized = true;      // flipped before the await
  ...
  files = await fs.readdir(dir); // suspends here
  ...
  this.#nextId = maxId + 1;
}
```

So a second `allocate` / `allocateBatch` / `peekNextIndex` running **concurrently** on the shared, session-scoped manager short-circuits at `if (this.#initialized) return` and allocates from `#nextId === 0` while the first scan is still in flight.

This is reachable in normal operation: `TaskTool` declares no `concurrency`, so it defaults to `"shared"`, and the agent loop runs shared-concurrency tools concurrently (`Promise.allSettled`). Two `task` calls emitted in one turn therefore hit the same `AgentOutputManager` at once. The race causes:

- ids that **collide with existing `N-*.md` outputs** (start from `0` again), and
- **duplicate indices across the two batches**,

which overwrite prior subagent outputs on resume and break the "unique output IDs / prevents artifact collisions" invariant documented on the class.

## Fix

Memoize the directory scan as a promise. The promise is assigned synchronously (before any `await`), so concurrent callers await the **same** `readdir` and observe `#nextId` only after it is derived.

```ts
#ensureInitialized(): Promise<void> {
  this.#initPromise ??= this.#scanExistingOutputs();
  return this.#initPromise;
}
```

`reset()` clears `#initPromise` instead of the old boolean.

## Tests / checks

- Added `packages/coding-agent/test/task/output-manager.test.ts`:
  - concurrent `allocateBatch` on a shared instance never reuses existing indices or duplicates ids,
  - sequential allocation continues past existing outputs,
  - `peekNextIndex` stays consistent under concurrency.
- `bun test packages/coding-agent/test/task/output-manager.test.ts` → 3 pass
- `bun test packages/coding-agent/test/task/id.test.ts` (existing `AgentOutputManager` usage) → 4 pass, no regression
- `bun run --cwd=packages/coding-agent check:types` (tsgo) → clean
- biome check → clean

## Changelog

Added under `packages/coding-agent/CHANGELOG.md` → `## [Unreleased]` → `### Fixed`.
