### PR TITLE
fix(ai): omit disabled thinking for Anthropic

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2281,8 +2281,6 @@ function buildParams(
 					params.output_config = { effort } as typeof params.output_config;
 				}
 			}
-		} else if (options?.thinkingEnabled === false) {
-			params.thinking = { type: "disabled" };
 		}
 	}
 

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1028,7 +1028,7 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.thinking).toBeUndefined();
 	});
 
-	it("sends disabled thinking for reasoning models when thinking is explicitly disabled", async () => {
+	it("omits thinking for reasoning models when thinking is explicitly disabled", async () => {
 		const payload = (await captureAnthropicPayload(
 			ANTHROPIC_MODEL,
 			{
@@ -1038,7 +1038,7 @@ describe("Anthropic request fingerprint alignment", () => {
 			{ thinkingEnabled: false },
 		)) as { thinking?: { type?: string } };
 
-		expect(payload.thinking).toEqual({ type: "disabled" });
+		expect(payload.thinking).toBeUndefined();
 	});
 
 	it("drops temperature and sampling params for Opus 4.7 without enabled thinking", async () => {


### PR DESCRIPTION
## Summary
- Stop sending `thinking: { type: "disabled" }` for Anthropic requests when thinking is explicitly disabled
- Let Anthropic models default to adaptive thinking when `thinking` is omitted
- Update the Anthropic alignment test expectation

## Why
Anthropic models such as `claude-fable-5` reject `thinking.type.disabled` with:

```
"thinking.type.disabled" is not supported for this model. Thinking defaults to adaptive mode when not specified; use "thinking.type.enabled" with "budget_tokens" for extended thinking.
```

## Verification
- `bun test packages/ai/test/anthropic-alignment.test.ts` → 44 pass, 0 fail
- `bun --cwd=packages/ai run check` → biome check + `tsgo -p tsconfig.json --noEmit` passed
- Minimal payload capture on this branch verified `thinkingEnabled: false` omits the `thinking` field for `claude-fable-5`
- Local installed-package hotfix verified with `gjc --model anthropic/claude-fable-5:off -p "ping" --mode json`; request no longer fails with 400
