### PR TITLE
Improve queued message editing and splash hints

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -954,6 +954,12 @@ export class Agent {
 	popLastSteer(): AgentMessage | undefined {
 		return this.#steeringQueue.pop();
 	}
+	removeSteerAt(index: number): AgentMessage | undefined {
+		if (index < 0 || index >= this.#steeringQueue.length) return undefined;
+		const [removed] = this.#steeringQueue.splice(index, 1);
+		return removed;
+	}
+
 
 	/**
 	 * Remove and return the last follow-up message from the queue (LIFO).
@@ -961,6 +967,11 @@ export class Agent {
 	 */
 	popLastFollowUp(): AgentMessage | undefined {
 		return this.#followUpQueue.pop();
+	}
+	removeFollowUpAt(index: number): AgentMessage | undefined {
+		if (index < 0 || index >= this.#followUpQueue.length) return undefined;
+		const [removed] = this.#followUpQueue.splice(index, 1);
+		return removed;
 	}
 
 	/** Remove queued steering+follow-up messages matching `predicate`, preserving order of the rest. */

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -134,8 +134,8 @@ export const KEYBINDINGS = {
 		description: "Queue message for next turn",
 	},
 	"app.message.dequeue": {
-		defaultKeys: "alt+up",
-		description: "Dequeue message",
+		defaultKeys: ["alt+up", "alt+down"],
+		description: "Select queued message to edit",
 	},
 	"app.clipboard.pasteImage": {
 		defaultKeys: process.platform === "win32" ? "alt+v" : "ctrl+v",

--- a/packages/coding-agent/src/modes/components/queued-message-selector.ts
+++ b/packages/coding-agent/src/modes/components/queued-message-selector.ts
@@ -1,0 +1,60 @@
+import { Container, matchesKey, type SelectItem, SelectList, Spacer, Text } from "@gajae-code/tui";
+import type { QueuedMessageEditEntry } from "../../session/agent-session";
+import { getSelectListTheme, theme } from "../theme/theme";
+import { DynamicBorder } from "./dynamic-border";
+
+const MAX_VISIBLE_QUEUED_MESSAGES = 8;
+const RAW_UP = "\x1b[A";
+const RAW_DOWN = "\x1b[B";
+
+export class QueuedMessageSelectorComponent extends Container {
+	#selectList: SelectList;
+
+	constructor(
+		entries: QueuedMessageEditEntry[],
+		onSelect: (entry: QueuedMessageEditEntry) => void,
+		onCancel: () => void,
+	) {
+		super();
+
+		const byId = new Map(entries.map(entry => [entry.id, entry]));
+		const items: SelectItem[] = entries.map((entry, index) => ({
+			value: entry.id,
+			label: `${entry.label} ${index + 1}`,
+			description: entry.text,
+			hint: "Enter to edit",
+		}));
+
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(theme.bold("Queued messages"), 1, 0));
+		this.addChild(new Text(theme.fg("muted", "Select a queued message to restore into the composer"), 1, 0));
+		this.addChild(new Spacer(1));
+		this.addChild(new DynamicBorder());
+
+		this.#selectList = new SelectList(items, MAX_VISIBLE_QUEUED_MESSAGES, getSelectListTheme());
+		this.#selectList.onSelect = item => {
+			const entry = byId.get(item.value);
+			if (entry) onSelect(entry);
+		};
+		this.#selectList.onCancel = onCancel;
+
+		this.addChild(this.#selectList);
+		this.addChild(new DynamicBorder());
+	}
+
+	handleInput(keyData: string): void {
+		if (matchesKey(keyData, "alt+up")) {
+			this.#selectList.handleInput(RAW_UP);
+			return;
+		}
+		if (matchesKey(keyData, "alt+down")) {
+			this.#selectList.handleInput(RAW_DOWN);
+			return;
+		}
+		this.#selectList.handleInput(keyData);
+	}
+
+	getSelectList(): SelectList {
+		return this.#selectList;
+	}
+}

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -21,9 +21,21 @@ export interface WelcomeComponentOptions {
 	collapseChangelog?: boolean;
 }
 
-const WELCOME_FIXED_RIGHT_ROWS_EXCLUDING_DYNAMIC_SECTIONS = 13;
+const WELCOME_STATIC_RIGHT_ROWS_EXCLUDING_DYNAMIC_SECTIONS = 9;
 const DEFAULT_WHATS_NEW_ROWS = 3;
 const MAX_WHATS_NEW_ROWS = 12;
+const FLOW_KEY_ITEMS: ReadonlyArray<{ key: string; label: string }> = [
+	{ key: "/", label: "commands" },
+	{ key: "#", label: "actions" },
+	{ key: "!", label: "shell" },
+	{ key: "$", label: "python" },
+	{ key: "?", label: "keymap" },
+	{ key: "ctrl+l", label: "model" },
+	{ key: "shift+tab", label: "reasoning" },
+	{ key: "tab", label: "complete" },
+	{ key: "alt+enter", label: "newline" },
+	{ key: "ctrl+c", label: "clear" },
+];
 
 /**
  * GJC-native launch surface with compact command affordances, project
@@ -163,9 +175,22 @@ export class WelcomeComponent implements Component {
 			}
 		}
 
-		const changelogRowLimit = this.#whatsNewRowLimit(targetContentRows, lspLines.length);
+		const flowPreferredRows = this.#flowKeyRows(rightColumnWidth).length;
+		const changelogRowLimit = this.#whatsNewRowLimit(targetContentRows, lspLines.length, flowPreferredRows);
 		const changelogLines = this.#whatsNewLines(rightColumnWidth, changelogRowLimit);
-		const sessionLimit = this.#sessionTrailLimit(targetContentRows, changelogLines.length, lspLines.length);
+		const flowRowLimit = this.#flowKeyRowLimit(
+			targetContentRows,
+			changelogLines.length,
+			lspLines.length,
+			rightColumnWidth,
+		);
+		const flowLines = this.#flowKeyLines(rightColumnWidth, flowRowLimit);
+		const sessionLimit = this.#sessionTrailLimit(
+			targetContentRows,
+			changelogLines.length,
+			lspLines.length,
+			flowLines.length,
+		);
 		const sessionLines = this.#sessionTrailLines(rightColumnWidth, sessionLimit);
 
 		const rightLines = [
@@ -174,19 +199,7 @@ export class WelcomeComponent implements Component {
 			...changelogLines,
 			separator,
 			` ${theme.bold(theme.fg("accent", "Flow keys"))}`,
-			` ${theme.fg("dim", "/")}${theme.fg("muted", " commands")} ${theme.fg("dim", "·")} ${theme.fg(
-				"dim",
-				"#",
-			)}${theme.fg("muted", " actions")}`,
-			` ${theme.fg("dim", "!")}${theme.fg("muted", " shell")} ${theme.fg("dim", "·")} ${theme.fg("dim", "$")}${theme.fg(
-				"muted",
-				" python",
-			)}`,
-			` ${theme.fg("dim", "?")}${theme.fg("muted", " keymap")} ${theme.fg("dim", "·")} ${theme.fg(
-				"dim",
-				"ctrl+l",
-			)}${theme.fg("muted", " model")}`,
-			` ${theme.fg("dim", "shift+tab")}${theme.fg("muted", " reasoning")}`,
+			...flowLines,
 			separator,
 			` ${theme.bold(theme.fg("accent", "Project pulse"))}`,
 			...lspLines,
@@ -305,13 +318,67 @@ export class WelcomeComponent implements Component {
 		return [...Array.from({ length: topPad }, () => ""), ...clipped, ...Array.from({ length: bottomPad }, () => "")];
 	}
 
-	#whatsNewRowLimit(targetContentRows: number | undefined, lspLineCount: number): number {
+	#flowKeyItemText(item: { key: string; label: string }): string {
+		return `${theme.fg("dim", item.key)}${theme.fg("muted", ` ${item.label}`)}`;
+	}
+
+	#flowKeyRows(width: number): string[] {
+		const contentWidth = Math.max(1, width - 1);
+		const separator = ` ${theme.fg("dim", "·")} `;
+		const rows: string[] = [];
+		let current = "";
+		for (const item of FLOW_KEY_ITEMS) {
+			const segment = this.#flowKeyItemText(item);
+			const next = current ? `${current}${separator}${segment}` : segment;
+			if (current && visibleWidth(next) > contentWidth) {
+				rows.push(` ${current}`);
+				current = segment;
+			} else {
+				current = next;
+			}
+		}
+		if (current) rows.push(` ${current}`);
+		return rows.length > 0 ? rows : [` ${theme.fg("dim", "No flow keys")}`];
+	}
+
+	#flowKeyLines(width: number, maxRows: number): string[] {
+		const rows = this.#flowKeyRows(width);
+		const rowLimit = Math.max(1, Math.floor(maxRows));
+		if (rows.length <= rowLimit) return rows;
+		if (rowLimit === 1) {
+			const firstItem = FLOW_KEY_ITEMS[0];
+			const firstSegment = firstItem ? this.#flowKeyItemText(firstItem) : theme.fg("dim", "keys");
+			return [this.#fitToWidth(` ${firstSegment} ${theme.fg("dim", "· … ")}${theme.bold("/help")}`, width)];
+		}
+		return [...rows.slice(0, rowLimit - 1), ` ${theme.fg("dim", `… ${theme.bold("/help")} for more`)}`];
+	}
+
+	#flowKeyRowLimit(
+		targetContentRows: number | undefined,
+		changelogLineCount: number,
+		lspLineCount: number,
+		rightColumnWidth: number,
+	): number {
+		const preferredRows = this.#flowKeyRows(rightColumnWidth).length;
+		if (targetContentRows === undefined) return preferredRows;
+
+		const sessionBaselineRows = this.recentSessions.length === 0 ? 1 : Math.min(3, this.recentSessions.length);
+		const availableRows =
+			targetContentRows -
+			WELCOME_STATIC_RIGHT_ROWS_EXCLUDING_DYNAMIC_SECTIONS -
+			changelogLineCount -
+			lspLineCount -
+			sessionBaselineRows;
+		return Math.max(1, Math.min(preferredRows, availableRows));
+	}
+
+	#whatsNewRowLimit(targetContentRows: number | undefined, lspLineCount: number, flowLineCount: number): number {
 		if (targetContentRows === undefined) return 5;
 
 		const sessionBaselineRows = this.recentSessions.length === 0 ? 1 : Math.min(3, this.recentSessions.length);
 		const dynamicRows = Math.max(
 			1,
-			targetContentRows - WELCOME_FIXED_RIGHT_ROWS_EXCLUDING_DYNAMIC_SECTIONS - lspLineCount,
+			targetContentRows - WELCOME_STATIC_RIGHT_ROWS_EXCLUDING_DYNAMIC_SECTIONS - flowLineCount - lspLineCount,
 		);
 		const rowsAfterBaselineSessions = Math.max(1, dynamicRows - sessionBaselineRows);
 		const spareRows = Math.max(0, rowsAfterBaselineSessions - DEFAULT_WHATS_NEW_ROWS);
@@ -321,14 +388,23 @@ export class WelcomeComponent implements Component {
 		);
 	}
 
-	#sessionTrailLimit(targetContentRows: number | undefined, changelogLineCount: number, lspLineCount: number): number {
+	#sessionTrailLimit(
+		targetContentRows: number | undefined,
+		changelogLineCount: number,
+		lspLineCount: number,
+		flowLineCount: number,
+	): number {
 		if (this.recentSessions.length === 0) return 0;
 
 		const defaultLimit = Math.min(3, this.recentSessions.length);
 		if (targetContentRows === undefined) return defaultLimit;
 
 		const rowsWithDefaultTrail =
-			WELCOME_FIXED_RIGHT_ROWS_EXCLUDING_DYNAMIC_SECTIONS + changelogLineCount + lspLineCount + defaultLimit;
+			WELCOME_STATIC_RIGHT_ROWS_EXCLUDING_DYNAMIC_SECTIONS +
+			changelogLineCount +
+			flowLineCount +
+			lspLineCount +
+			defaultLimit;
 		const extraRows = Math.max(0, targetContentRows - rowsWithDefaultTrail);
 		return Math.min(this.recentSessions.length, defaultLimit + extraRows);
 	}
@@ -510,7 +586,6 @@ interface ShineConfig {
 	/** Center of the shine band along the diagonal, in [0, 1]. */
 	pos: number;
 }
-
 /**
  * Apply a multi-stop diagonal gradient (bottom-left → top-right) plus an
  * optional sliding shine band across multi-line art. `phase` (0..1) shifts the

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -11,7 +11,7 @@ import { createPromptActionAutocompleteProvider } from "../../modes/prompt-actio
 import { theme } from "../../modes/theme/theme";
 import { scrollTmuxToPreviousUserInput as scrollTmuxPaneToPreviousUserInput } from "../../modes/tmux-scroll";
 import type { InteractiveModeContext } from "../../modes/types";
-import type { AgentSessionEvent } from "../../session/agent-session";
+import type { AgentSessionEvent, QueuedMessageEditEntry } from "../../session/agent-session";
 import { SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../../session/messages";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
 import { copyToClipboard, readImageFromClipboard } from "../../utils/clipboard";
@@ -19,6 +19,7 @@ import { getEditorCommand, openInEditor } from "../../utils/external-editor";
 import { ensureSupportedImageInput, ImageInputTooLargeError, loadImageInput } from "../../utils/image-loading";
 import { resizeImage } from "../../utils/image-resize";
 import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
+import { QueuedMessageSelectorComponent } from "../components/queued-message-selector";
 
 interface Expandable {
 	setExpanded(expanded: boolean): void;
@@ -607,12 +608,95 @@ export class InputController {
 	}
 
 	handleDequeue(): void {
-		const restored = this.restoreLatestQueuedMessageToEditor();
-		if (restored === 0) {
+		const entries = this.#getEditableQueuedMessages();
+		if (entries.length === 0) {
+			this.ctx.updatePendingMessagesDisplay();
 			this.ctx.showStatus("No queued messages to restore");
-		} else {
-			this.ctx.showStatus(`Restored ${restored} queued message${restored > 1 ? "s" : ""} to editor`);
+			return;
 		}
+		if (entries.length === 1) {
+			const restored = this.#restoreQueuedMessageToEditor(entries[0]);
+			this.ctx.showStatus(
+				restored === 0 ? "Queued message is no longer available" : "Restored queued message to editor",
+			);
+			return;
+		}
+		this.#showQueuedMessageSelector(entries);
+	}
+
+	#compactionQueuedMessageId(index: number): string {
+		return `compaction:${index}`;
+	}
+
+	#getEditableQueuedMessages(): QueuedMessageEditEntry[] {
+		const compactionEntries = this.ctx.compactionQueuedMessages
+			.map((entry, index): QueuedMessageEditEntry => {
+				const label = entry.mode === "steer" ? "Steer" : "Queued";
+				return {
+					id: this.#compactionQueuedMessageId(index),
+					text: entry.text,
+					mode: entry.mode,
+					label,
+				};
+			})
+			.reverse();
+		return [...compactionEntries, ...this.ctx.session.getQueuedMessageEntries()];
+	}
+
+	#restoreEditorFocus(): void {
+		this.ctx.editorContainer.clear();
+		this.ctx.editorContainer.addChild(this.ctx.editor);
+		this.ctx.ui.setFocus(this.ctx.editor);
+	}
+
+	#showQueuedMessageSelector(entries: QueuedMessageEditEntry[]): void {
+		const selector = new QueuedMessageSelectorComponent(
+			entries,
+			entry => {
+				const restored = this.#restoreQueuedMessageToEditor(entry);
+				this.#restoreEditorFocus();
+				this.ctx.showStatus(
+					restored === 0 ? "Queued message is no longer available" : "Restored queued message to editor",
+				);
+				this.ctx.ui.requestRender();
+			},
+			() => {
+				this.#restoreEditorFocus();
+				this.ctx.ui.requestRender();
+			},
+		);
+		this.ctx.editorContainer.clear();
+		this.ctx.editorContainer.addChild(selector);
+		this.ctx.ui.setFocus(selector);
+		this.ctx.ui.requestRender();
+	}
+
+	#removeQueuedMessageForEditing(id: string): string | undefined {
+		const compactionPrefix = "compaction:";
+		if (id.startsWith(compactionPrefix)) {
+			const index = Number(id.slice(compactionPrefix.length));
+			if (!Number.isInteger(index)) return undefined;
+			const [entry] = this.ctx.compactionQueuedMessages.splice(index, 1);
+			return entry?.text;
+		}
+		return this.ctx.session.removeQueuedMessageForEditing(id);
+	}
+
+	#restoreQueuedMessageToEditor(entry: QueuedMessageEditEntry | undefined): number {
+		if (!entry) {
+			this.ctx.updatePendingMessagesDisplay();
+			return 0;
+		}
+		const queuedText = this.#removeQueuedMessageForEditing(entry.id);
+		if (!queuedText) {
+			this.ctx.updatePendingMessagesDisplay();
+			return 0;
+		}
+
+		this.ctx.locallySubmittedUserSignatures.delete(`${queuedText}\u00000`);
+		this.ctx.editor.setText(queuedText);
+		this.ctx.updatePendingMessagesDisplay();
+		return 1;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -118,7 +118,7 @@ import { UiHelpers } from "./utils/ui-helpers";
 
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
 const COMPOSER_NEWLINE_HINT = process.platform === "win32" ? "Alt+Enter/Ctrl+J" : "Shift+Enter/Ctrl+J";
-const DEFAULT_COMPOSER_PLACEHOLDER = `Type your message... ${COMPOSER_NEWLINE_HINT}: New line · Ctrl+C: Clear`;
+const DEFAULT_COMPOSER_PLACEHOLDER = `Type your message... ${COMPOSER_NEWLINE_HINT}: New line · Ctrl+C: Clear · Shift+Tab: Reasoning`;
 const WELCOME_RESERVED_CONTAINER_CHILD_LIMIT = 8;
 const FRIENDLY_KEY_PARTS: Record<string, string> = {
 	alt: "Alt",

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -23,6 +23,7 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		"|-----|--------|",
 		"| `Enter` | Send / queue while busy |",
 		`| \`${appKey(bindings, "app.message.queue")}\` | Queue message for next turn |`,
+		`| \`${appKey(bindings, "app.message.dequeue")}\` | Select queued message to edit |`,
 		"| `Shift+Enter` / `Ctrl+J` | New line |",
 		"| `Ctrl+W` / `Option+Backspace` | Delete word backwards |",
 		"| `Ctrl+U` | Delete to start of line |",

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -599,8 +599,8 @@ export class UiHelpers {
 				const queuedText = theme.fg("dim", `${entry.label}: ${entry.message}`);
 				this.ctx.pendingMessagesContainer.addChild(new TruncatedText(queuedText, 1, 0));
 			}
-			const dequeueKey = this.ctx.keybindings.getDisplayString("app.message.dequeue") || "Alt+Up";
-			const hintText = theme.fg("dim", `${theme.tree.hook} ${dequeueKey} to edit`);
+			const dequeueKey = this.ctx.keybindings.getDisplayString("app.message.dequeue") || "Alt+Up/Alt+Down";
+			const hintText = theme.fg("dim", `${theme.tree.hook} ${dequeueKey} to select/edit`);
 			this.ctx.pendingMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
 		}
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -908,6 +908,14 @@ function extractPermissionLocations(
  *  rely on the existing text-equality match. `sequence` preserves cross-queue
  *  insertion order for one-at-a-time dequeue/edit UX. */
 type QueuedDisplayEntry = { text: string; tag?: string; sequence: number };
+export type QueuedMessageEditMode = "steer" | "followUp";
+
+export interface QueuedMessageEditEntry {
+	id: string;
+	text: string;
+	mode: QueuedMessageEditMode;
+	label: string;
+}
 
 /** A custom message contributed at the before-agent-start point. */
 export type BeforeAgentStartInternalMessage = Pick<
@@ -1645,6 +1653,9 @@ export class AgentSession {
 		return entry;
 	}
 
+	#queuedMessageEditId(mode: QueuedMessageEditMode, sequence: number): string {
+		return `${mode}:${sequence}`;
+	}
 	/** Register a compact display string for a custom message that the caller is
 	 *  about to dispatch via `promptCustomMessage` / `sendCustomMessage`.
 	 *  Returns a stable tag the caller MUST embed in
@@ -5719,6 +5730,50 @@ export class AgentSession {
 		};
 	}
 
+	getQueuedMessageEntries(): QueuedMessageEditEntry[] {
+		const entries: Array<QueuedMessageEditEntry & { sequence: number }> = [];
+		for (const entry of this.#steeringMessages) {
+			entries.push({
+				id: this.#queuedMessageEditId("steer", entry.sequence),
+				text: entry.text,
+				mode: "steer",
+				label: "Steer",
+				sequence: entry.sequence,
+			});
+		}
+		for (const entry of this.#followUpMessages) {
+			entries.push({
+				id: this.#queuedMessageEditId("followUp", entry.sequence),
+				text: entry.text,
+				mode: "followUp",
+				label: "Queued",
+				sequence: entry.sequence,
+			});
+		}
+		return entries
+			.sort((a, b) => b.sequence - a.sequence)
+			.map(({ id, text, mode, label }) => ({ id, text, mode, label }));
+	}
+
+	removeQueuedMessageForEditing(id: string): string | undefined {
+		const [mode, sequenceText] = id.split(":");
+		if ((mode !== "steer" && mode !== "followUp") || sequenceText === undefined) return undefined;
+		const sequence = Number(sequenceText);
+		if (!Number.isInteger(sequence)) return undefined;
+
+		const queue = mode === "steer" ? this.#steeringMessages : this.#followUpMessages;
+		const index = queue.findIndex(entry => entry.sequence === sequence);
+		if (index === -1) return undefined;
+
+		const [entry] = queue.splice(index, 1);
+		if (mode === "steer") {
+			this.agent.removeSteerAt(index);
+		} else {
+			this.agent.removeFollowUpAt(index);
+		}
+		return entry?.text;
+	}
+
 	/**
 	 * Pop the newest queued message across steering and follow-up queues.
 	 * Used by dequeue keybinding to restore messages to editor one at a time.
@@ -5730,15 +5785,11 @@ export class AgentSession {
 		const followUpEntry = this.#followUpMessages.at(-1);
 
 		if (steeringEntry && (!followUpEntry || steeringEntry.sequence > followUpEntry.sequence)) {
-			const entry = this.#steeringMessages.pop();
-			this.agent.popLastSteer();
-			return entry?.text;
+			return this.removeQueuedMessageForEditing(this.#queuedMessageEditId("steer", steeringEntry.sequence));
 		}
 
 		if (followUpEntry) {
-			const entry = this.#followUpMessages.pop();
-			this.agent.popLastFollowUp();
-			return entry?.text;
+			return this.removeQueuedMessageForEditing(this.#queuedMessageEditId("followUp", followUpEntry.sequence));
 		}
 
 		return undefined;

--- a/packages/coding-agent/test/agent-session-queued-prompts.test.ts
+++ b/packages/coding-agent/test/agent-session-queued-prompts.test.ts
@@ -147,4 +147,37 @@ describe("AgentSession queued prompts (issue #434)", () => {
 		// after it. Submission order across both is preserved.
 		expect(userTexts(session)).toEqual(["p1", "steer me", "queue me"]);
 	});
+
+	it("removes an arbitrary queued prompt selected for editing", async () => {
+		const gate = Promise.withResolvers<void>();
+		session = buildSession([
+			async () => {
+				await gate.promise;
+				return { content: ["turn 1"] };
+			},
+			{ content: ["after steer"] },
+			{ content: ["after remaining queue"] },
+		]);
+
+		const first = session.prompt("p1");
+		await waitUntil(() => session!.isStreaming);
+
+		await session.prompt("steer me", { streamingBehavior: "steer" });
+		await session.prompt("queue older", { streamingBehavior: "followUp" });
+		await session.prompt("queue newest", { streamingBehavior: "followUp" });
+
+		const entries = session.getQueuedMessageEntries();
+		expect(entries.map(entry => entry.text)).toEqual(["queue newest", "queue older", "steer me"]);
+		const removed = session.removeQueuedMessageForEditing(entries[1]?.id ?? "");
+
+		expect(removed).toBe("queue older");
+		expect(session.getQueuedMessages().steering).toEqual(["steer me"]);
+		expect(session.getQueuedMessages().followUp).toEqual(["queue newest"]);
+
+		gate.resolve();
+		await first;
+		await session.waitForIdle();
+
+		expect(userTexts(session)).toEqual(["p1", "steer me", "queue newest"]);
+	});
 });

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it, vi } from "bun:test";
+import { beforeAll, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
+import { QueuedMessageSelectorComponent } from "../src/modes/components/queued-message-selector";
 import { InputController } from "../src/modes/controllers/input-controller";
+import { initTheme } from "../src/modes/theme/theme";
 import type { CompactionQueuedMessage, InteractiveModeContext } from "../src/modes/types";
+import type { QueuedMessageEditEntry } from "../src/session/agent-session";
 
 type FakeEditor = {
 	onEscape?: () => void;
@@ -44,6 +47,7 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 		"app.model.select": ["ctrl+l"],
 		"app.message.queue": ["alt+enter"],
 		"app.message.followUp": options?.followUpKeys ?? [],
+		"app.message.dequeue": ["alt+up", "alt+down"],
 	};
 
 	const setActionKeys = vi.fn();
@@ -62,6 +66,26 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 		showStatus("Queued message for after compaction");
 	});
 	const popLastQueuedMessage = vi.fn(() => sessionQueuedMessages.pop());
+	const getQueuedMessageEntries = vi.fn(() =>
+		sessionQueuedMessages
+			.map(
+				(text, index): QueuedMessageEditEntry => ({
+					id: `followUp:${index}`,
+					text,
+					mode: "followUp",
+					label: "Queued",
+				}),
+			)
+			.reverse(),
+	);
+	const removeQueuedMessageForEditing = vi.fn((id: string) => {
+		const [mode, indexText] = id.split(":");
+		if (mode !== "followUp" || indexText === undefined) return undefined;
+		const index = Number(indexText);
+		if (!Number.isInteger(index)) return undefined;
+		const [removed] = sessionQueuedMessages.splice(index, 1);
+		return removed;
+	});
 	const clearQueue = vi.fn(() => {
 		const followUp = [...sessionQueuedMessages];
 		sessionQueuedMessages.length = 0;
@@ -82,9 +106,19 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 		setCustomKeyHandler: vi.fn(),
 		clearCustomKeyHandlers: vi.fn(),
 	};
+	const editorContainerChildren: unknown[] = [];
+	const editorContainer = {
+		clear: vi.fn(() => {
+			editorContainerChildren.length = 0;
+		}),
+		addChild: vi.fn((child: unknown) => {
+			editorContainerChildren.push(child);
+		}),
+	};
 	const ctx = {
 		editor: editor as unknown as InteractiveModeContext["editor"],
-		ui: { requestRender: vi.fn() } as unknown as InteractiveModeContext["ui"],
+		ui: { requestRender: vi.fn(), setFocus: vi.fn() } as unknown as InteractiveModeContext["ui"],
+		editorContainer: editorContainer as unknown as InteractiveModeContext["editorContainer"],
 		loadingAnimation: undefined,
 		autoCompactionLoader: undefined,
 		retryLoader: undefined,
@@ -102,6 +136,8 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 			popLastQueuedMessage,
 			clearQueue,
 			getQueuedMessages: () => ({ steering: [], followUp: [...sessionQueuedMessages] }),
+			getQueuedMessageEntries,
+			removeQueuedMessageForEditing,
 		} as unknown as InteractiveModeContext["session"],
 		keybindings: {
 			getKeys(action: string) {
@@ -186,13 +222,20 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 			queueCompactionMessage,
 			popLastQueuedMessage,
 			clearQueue,
+			getQueuedMessageEntries,
+			removeQueuedMessageForEditing,
 		},
 		queues: {
 			compactionQueuedMessages,
 			sessionQueuedMessages,
+			editorContainerChildren,
 		},
 	};
 }
+
+beforeAll(() => {
+	initTheme();
+});
 
 describe("InputController keybinding setup", () => {
 	it("registers temporary and persisted model selector actions separately", async () => {
@@ -226,6 +269,7 @@ describe("InputController keybinding setup", () => {
 		await Bun.sleep(0);
 
 		expect(spies.setActionKeys).toHaveBeenCalledWith("app.message.queue", ["alt+enter"]);
+		expect(spies.setActionKeys).toHaveBeenCalledWith("app.message.dequeue", ["alt+up", "alt+down"]);
 		expect(ctx.locallySubmittedUserSignatures.has("queue after current response\u00000")).toBe(true);
 		expect(spies.prompt).toHaveBeenCalledWith("queue after current response", {
 			streamingBehavior: "followUp",
@@ -328,24 +372,36 @@ describe("InputController keybinding setup", () => {
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 	});
 
-	it("restores only the newest compaction queued message for editing", async () => {
+	it("restores a single compaction queued message for editing", async () => {
 		const { InputController, ctx, editor, spies, queues } = await createContext();
-		queues.compactionQueuedMessages.push(
-			{ text: "older compaction queue", mode: "followUp" },
-			{ text: "newest compaction queue", mode: "followUp" },
-		);
+		queues.compactionQueuedMessages.push({ text: "single compaction queue", mode: "followUp" });
 		editor.setText("current draft");
 		const controller = new InputController(ctx);
 
 		controller.handleDequeue();
 
-		expect(editor.getText()).toBe("newest compaction queue");
-		expect(queues.compactionQueuedMessages.map(entry => entry.text)).toEqual(["older compaction queue"]);
+		expect(editor.getText()).toBe("single compaction queue");
+		expect(queues.compactionQueuedMessages).toEqual([]);
 		expect(spies.popLastQueuedMessage).not.toHaveBeenCalled();
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 	});
 
-	it("restores only the newest session queued message for editing", async () => {
+	it("restores a single session queued message for editing", async () => {
+		const { InputController, ctx, editor, spies, queues } = await createContext();
+		queues.sessionQueuedMessages.push("single session queue");
+		editor.setText("current draft");
+		const controller = new InputController(ctx);
+
+		controller.handleDequeue();
+
+		expect(editor.getText()).toBe("single session queue");
+		expect(queues.sessionQueuedMessages).toEqual([]);
+		expect(spies.clearQueue).not.toHaveBeenCalled();
+		expect(spies.removeQueuedMessageForEditing).toHaveBeenCalledWith("followUp:0");
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("opens a selector so older queued messages can be restored", async () => {
 		const { InputController, ctx, editor, spies, queues } = await createContext();
 		queues.sessionQueuedMessages.push("older session queue", "newest session queue");
 		editor.setText("current draft");
@@ -353,9 +409,17 @@ describe("InputController keybinding setup", () => {
 
 		controller.handleDequeue();
 
-		expect(editor.getText()).toBe("newest session queue");
-		expect(queues.sessionQueuedMessages).toEqual(["older session queue"]);
-		expect(spies.clearQueue).not.toHaveBeenCalled();
+		const selector = queues.editorContainerChildren[0];
+		if (!(selector instanceof QueuedMessageSelectorComponent)) {
+			throw new Error("Expected queued message selector to be shown");
+		}
+		expect(editor.getText()).toBe("current draft");
+		selector.getSelectList().setSelectedIndex(1);
+		selector.getSelectList().handleInput("\n");
+
+		expect(editor.getText()).toBe("older session queue");
+		expect(queues.sessionQueuedMessages).toEqual(["newest session queue"]);
+		expect(spies.removeQueuedMessageForEditing).toHaveBeenCalledWith("followUp:0");
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 	});
 

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -96,6 +96,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(rendered).toContain("Type your message...");
 		expect(rendered).toContain(expectedNewlineShortcutHint());
 		expect(rendered).toContain("Ctrl+C: Clear");
+		expect(rendered).toContain("Shift+Tab: Reasoning");
 		expect(rendered).not.toContain("Enter: Steer");
 		expect(rendered).not.toContain(expectedQueueShortcutHint());
 

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -35,7 +35,16 @@ describe("message keybinding defaults", () => {
 
 		expect(keybindings.getKeys("app.message.followUp")).toEqual([]);
 		expect(keybindings.getDisplayString("app.message.followUp")).toBe("");
-		expect(keybindings.getDisplayString("app.message.queue")).toBe("Alt+Enter");
+		expect(keybindings.getDisplayString("app.message.queue")).toBe(
+			process.platform === "win32" ? "Alt+Q" : "Alt+Enter",
+		);
+	});
+
+	it("binds queue editing to both Alt+Up and Alt+Down by default", () => {
+		const keybindings = KeybindingsManager.inMemory();
+
+		expect(keybindings.getKeys("app.message.dequeue")).toEqual(["alt+up", "alt+down"]);
+		expect(keybindings.getDisplayString("app.message.dequeue")).toBe("Alt+Up/Alt+Down");
 	});
 
 	it("uses Alt+Q for the native Windows queue shortcut", () => {

--- a/packages/coding-agent/test/welcome-viewport.test.ts
+++ b/packages/coding-agent/test/welcome-viewport.test.ts
@@ -28,6 +28,26 @@ function renderedColumnWidths(lines: string[]): { left: number; right: number } 
 	throw new Error("Expected two-column welcome layout");
 }
 
+function renderedRightColumn(lines: string[]): string[] {
+	return lines.map(stripRenderControls).flatMap(line => {
+		const separators = Array.from(line.matchAll(/│/g), match => match.index ?? -1);
+		if (separators.length < 3) return [];
+		const [, divider, rightEdge] = separators;
+		return [line.slice(divider + 1, rightEdge)];
+	});
+}
+
+function flowKeyContentRows(lines: string[]): string[] {
+	const rightColumn = renderedRightColumn(lines);
+	const start = rightColumn.findIndex(line => line.includes("Flow keys"));
+	const end = rightColumn.findIndex((line, index) => index > start && line.includes("Project pulse"));
+	if (start === -1 || end === -1) throw new Error("Expected Flow keys and Project pulse sections");
+	return rightColumn.slice(start + 1, end).filter(line => {
+		const text = line.trim();
+		return text.length > 0 && !/[─━-]{3,}/.test(text);
+	});
+}
+
 describe("WelcomeComponent viewport sizing", () => {
 	it("uses the full terminal width on wide initial forge viewports", () => {
 		const welcome = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii");
@@ -68,7 +88,6 @@ describe("WelcomeComponent viewport sizing", () => {
 		expect(lines.some(line => line.includes("GJC Forge"))).toBe(true);
 		expect(lines.some(line => line.includes("What's New"))).toBe(true);
 	});
-
 	it("integrates changelog highlights without overflowing narrow CJK content", () => {
 		const welcome = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii", {
 			getViewportRows: () => 16,
@@ -151,8 +170,39 @@ describe("WelcomeComponent viewport sizing", () => {
 		const compactText = compact.render(100).join("\n");
 		const roomyText = roomy.render(100).join("\n");
 
-		expect(compactText).toContain("trail-session-3");
-		expect(compactText).not.toContain("trail-session-4");
+		expect(compactText).toContain("trail-session-4");
+		expect(compactText).not.toContain("trail-session-5");
 		expect(roomyText).toContain("trail-session-8");
+	});
+
+	it("packs Flow keys across the available section width", () => {
+		const narrow = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii");
+		const wide = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii");
+
+		const narrowFlowRows = flowKeyContentRows(narrow.render(70));
+		const wideFlowRows = flowKeyContentRows(wide.render(160));
+		const wideText = wideFlowRows.join("\n");
+
+		expect(wideFlowRows.length).toBeLessThan(narrowFlowRows.length);
+		expect(wideText).toContain("/ commands");
+		expect(wideText).toContain("ctrl+c clear");
+	});
+
+	it("clips Flow keys to the viewport row budget before session trail rows", () => {
+		const recentSessions = Array.from({ length: 6 }, (_, index) => ({
+			name: `trail-session-${index + 1}`,
+			timeAgo: `${index + 1}m ago`,
+		}));
+		const compact = new WelcomeComponent("1.2.3", "test-model", "test-provider", recentSessions, [], "ascii", {
+			getViewportRows: () => 18,
+			getReservedBottomRows: () => 4,
+		});
+
+		const lines = compact.render(80);
+		const flowRows = flowKeyContentRows(lines);
+
+		expect(lines).toHaveLength(14);
+		expect(flowRows.length).toBeLessThanOrEqual(2);
+		expect(lines.join("\n")).toContain("/help");
 	});
 });


### PR DESCRIPTION
## Summary
- Add a queued-message selector so Alt+Up/Alt+Down can open pending queued messages and Enter restores the selected item into the composer.
- Preserve draft replacement semantics when restoring a queued message, and keep remaining queued messages in order.
- Add Shift+Tab to the composer placeholder and document queue-editing shortcuts in hotkeys/pending-message hints.
- Keep the splash Flow keys content responsive to available space.

## Verification
- bun --cwd=packages/coding-agent run check
- bun test packages/coding-agent/test/input-controller-keybindings.test.ts -t "queue action"
- bun test packages/coding-agent/test/input-controller-keybindings.test.ts -t "single session"
- bun test packages/coding-agent/test/input-controller-keybindings.test.ts -t "opens a selector"
- bun test packages/coding-agent/test/agent-session-queued-prompts.test.ts -t "removes an arbitrary"
- bun test packages/coding-agent/test/interactive-mode-editor-component.test.ts -t "busy steering"
- bun test packages/coding-agent/test/keybindings-display.test.ts
- bun test packages/coding-agent/test/welcome-viewport.test.ts

## Notes
- A full local run of input-controller-keybindings still hits the pre-existing Windows clipboard-temp /tmp expectation; the new queue-selection coverage above passes.