### PR TITLE
Allow deleting queued messages from selector

### DIFF
--- a/packages/coding-agent/src/modes/components/queued-message-selector.ts
+++ b/packages/coding-agent/src/modes/components/queued-message-selector.ts
@@ -9,25 +9,33 @@ const RAW_DOWN = "\x1b[B";
 
 export class QueuedMessageSelectorComponent extends Container {
 	#selectList: SelectList;
+	#selectedEntry: QueuedMessageEditEntry | undefined;
+	#selectedIndex = 0;
+	#onDelete: (entry: QueuedMessageEditEntry, selectedIndex: number) => void;
 
 	constructor(
 		entries: QueuedMessageEditEntry[],
 		onSelect: (entry: QueuedMessageEditEntry) => void,
+		onDelete: (entry: QueuedMessageEditEntry, selectedIndex: number) => void,
 		onCancel: () => void,
+		options?: { selectedIndex?: number },
 	) {
 		super();
 
+		this.#onDelete = onDelete;
 		const byId = new Map(entries.map(entry => [entry.id, entry]));
+		this.#selectedIndex = Math.max(0, Math.min(options?.selectedIndex ?? 0, entries.length - 1));
+		this.#selectedEntry = entries[this.#selectedIndex];
 		const items: SelectItem[] = entries.map((entry, index) => ({
 			value: entry.id,
 			label: `${entry.label} ${index + 1}`,
 			description: entry.text,
-			hint: "Enter to edit",
+			hint: "Enter edit · Del remove",
 		}));
 
 		this.addChild(new Spacer(1));
 		this.addChild(new Text(theme.bold("Queued messages"), 1, 0));
-		this.addChild(new Text(theme.fg("muted", "Select a queued message to restore into the composer"), 1, 0));
+		this.addChild(new Text(theme.fg("muted", "Enter to edit · Delete to remove · Esc to cancel"), 1, 0));
 		this.addChild(new Spacer(1));
 		this.addChild(new DynamicBorder());
 
@@ -36,6 +44,12 @@ export class QueuedMessageSelectorComponent extends Container {
 			const entry = byId.get(item.value);
 			if (entry) onSelect(entry);
 		};
+		this.#selectList.onSelectionChange = item => {
+			const index = entries.findIndex(entry => entry.id === item.value);
+			this.#selectedIndex = index === -1 ? this.#selectedIndex : index;
+			this.#selectedEntry = byId.get(item.value);
+		};
+		this.#selectList.setSelectedIndex(this.#selectedIndex);
 		this.#selectList.onCancel = onCancel;
 
 		this.addChild(this.#selectList);
@@ -49,6 +63,10 @@ export class QueuedMessageSelectorComponent extends Container {
 		}
 		if (matchesKey(keyData, "alt+down")) {
 			this.#selectList.handleInput(RAW_DOWN);
+			return;
+		}
+		if (matchesKey(keyData, "delete")) {
+			if (this.#selectedEntry) this.#onDelete(this.#selectedEntry, this.#selectedIndex);
 			return;
 		}
 		this.#selectList.handleInput(keyData);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -649,7 +649,7 @@ export class InputController {
 		this.ctx.ui.setFocus(this.ctx.editor);
 	}
 
-	#showQueuedMessageSelector(entries: QueuedMessageEditEntry[]): void {
+	#showQueuedMessageSelector(entries: QueuedMessageEditEntry[], selectedIndex = 0): void {
 		const selector = new QueuedMessageSelectorComponent(
 			entries,
 			entry => {
@@ -660,10 +660,23 @@ export class InputController {
 				);
 				this.ctx.ui.requestRender();
 			},
+			(entry, index) => {
+				const deleted = this.#deleteQueuedMessage(entry);
+				const nextEntries = this.#getEditableQueuedMessages();
+				if (nextEntries.length === 0) {
+					this.#restoreEditorFocus();
+					this.ctx.showStatus(deleted ? "Deleted queued message" : "Queued message is no longer available");
+					this.ctx.ui.requestRender();
+					return;
+				}
+				this.ctx.showStatus(deleted ? "Deleted queued message" : "Queued message is no longer available");
+				this.#showQueuedMessageSelector(nextEntries, Math.min(index, nextEntries.length - 1));
+			},
 			() => {
 				this.#restoreEditorFocus();
 				this.ctx.ui.requestRender();
 			},
+			{ selectedIndex },
 		);
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(selector);
@@ -680,6 +693,14 @@ export class InputController {
 			return entry?.text;
 		}
 		return this.ctx.session.removeQueuedMessageForEditing(id);
+	}
+
+	#deleteQueuedMessage(entry: QueuedMessageEditEntry): boolean {
+		const queuedText = this.#removeQueuedMessageForEditing(entry.id);
+		this.ctx.updatePendingMessagesDisplay();
+		if (!queuedText) return false;
+		this.ctx.locallySubmittedUserSignatures.delete(`${queuedText}\u00000`);
+		return true;
 	}
 
 	#restoreQueuedMessageToEditor(entry: QueuedMessageEditEntry | undefined): number {

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -423,6 +423,28 @@ describe("InputController keybinding setup", () => {
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 	});
 
+	it("deletes the selected queued message from the selector", async () => {
+		const { InputController, ctx, editor, spies, queues } = await createContext();
+		queues.sessionQueuedMessages.push("older session queue", "newest session queue");
+		editor.setText("current draft");
+		const controller = new InputController(ctx);
+
+		controller.handleDequeue();
+
+		const selector = queues.editorContainerChildren[0];
+		if (!(selector instanceof QueuedMessageSelectorComponent)) {
+			throw new Error("Expected queued message selector to be shown");
+		}
+		selector.handleInput("\x1b[3~");
+
+		expect(editor.getText()).toBe("current draft");
+		expect(queues.sessionQueuedMessages).toEqual(["older session queue"]);
+		expect(spies.removeQueuedMessageForEditing).toHaveBeenCalledWith("followUp:1");
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+		expect(spies.showStatus).toHaveBeenCalledWith("Deleted queued message");
+		expect(queues.editorContainerChildren[0]).toBeInstanceOf(QueuedMessageSelectorComponent);
+	});
+
 	it("steers streaming Enter submissions by default", async () => {
 		const { InputController, ctx, editor, spies } = await createContext();
 		const session = ctx.session as unknown as { isStreaming: boolean };


### PR DESCRIPTION
## Summary
- Add Delete-key handling to the queued-message selector opened by Alt+Up/Alt+Down.
- Remove the selected queued item without replacing the current composer draft, then keep the selector focused on remaining queued items.
- Add focused coverage for selector deletion.

## Verification
- bun test packages/coding-agent/test/input-controller-keybindings.test.ts -t "deletes the selected"
- bun test packages/coding-agent/test/input-controller-keybindings.test.ts -t "opens a selector"
- bun --cwd=packages/coding-agent run check