### PR TITLE
Fix agent package formatting after queued selector merge

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -960,7 +960,6 @@ export class Agent {
 		return removed;
 	}
 
-
 	/**
 	 * Remove and return the last follow-up message from the queue (LIFO).
 	 * Used by dequeue keybinding.


### PR DESCRIPTION
## Summary
- Fix the `packages/agent/src/agent.ts` formatting drift that broke the post-merge Dev CI after #1544.

## Verification
- `cd packages/agent && bun run check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*