### PR TITLE
fix(ai): stop stale usage cache from poisoning credential rotation

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped stale usage-cache snapshots from poisoning Codex/Anthropic credential rotation: reports older than the routing freshness window no longer block or demote credentials, past-reset exhausted windows are ignored for routing, and expired last-good usage reports are retired instead of being resurrected after repeated probe failures.
+
 ## [0.7.9] - 2026-07-01
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -432,6 +432,12 @@ const USAGE_CACHE_PREFIX = "usage_cache:";
 // data (5h / 7d / monthly limits) is fine being a few minutes stale.
 const USAGE_REPORT_TTL_MS = 5 * 60_000;
 const USAGE_LAST_GOOD_RETENTION_MS = 24 * 60 * 60_000;
+// Routing decisions (block / deprioritize a credential) trust usage evidence only
+// this fresh. The display tolerates staleness up to USAGE_LAST_GOOD_RETENTION_MS, but a
+// stale "exhausted" snapshot (e.g. from a persistently failing /usage probe) must never
+// DEMOTE a credential in selection — otherwise a frozen snapshot sidelines a genuinely
+// healthy account. 3x the report TTL: fresh, with generous margin against TTL jitter.
+const USAGE_ROUTING_MAX_AGE_MS = 15 * 60_000;
 /**
  * Per-credential cool-down after a usage fetch fails. While this window is
  * active we serve the last successful value to avoid dropping the credential
@@ -655,6 +661,11 @@ class AuthStorageUsageCache implements UsageCache {
 		return parseUsageCacheEntry<T>(raw);
 	}
 
+	// NOTE: `durableExpiresAt` row-expiry is advisory only. `cleanup()` (below) has no
+	// caller on the selection/poll paths and `getStale` reads with includeExpired, so
+	// expired rows are never actually deleted by this math. Authority to stop serving a
+	// stale value lives in the READ path (#fetchUsageCached failure branch), gated on
+	// `UsageReport.fetchedAt` age — not here.
 	set<T>(key: string, entry: UsageCacheEntry<T>): void {
 		const payload = JSON.stringify({ value: entry.value, expiresAt: entry.expiresAt });
 		const durableExpiresAt =
@@ -2053,6 +2064,25 @@ export class AuthStorage {
 			// don't write — let the next poll retry.
 			const lastGood = this.#usageCache.getStale<UsageReport | null>(cacheKey)?.value ?? null;
 			if (lastGood !== null) {
+				// Retire last-good that has aged past the retention bound instead of
+				// re-serving it. `cleanup()` has no caller and `getStale` reads with
+				// includeExpired, so durable row-expiry never deletes anything — the
+				// authority to STOP serving a stale value lives here, on fetchedAt age.
+				// Without this, a persistently failing probe re-serves (and via set()
+				// re-extends) a stale "exhausted" snapshot every backoff cycle forever,
+				// poisoning both the /usage display and credential routing.
+				const fetchedAt = lastGood.fetchedAt;
+				const retired =
+					typeof fetchedAt !== "number" ||
+					!Number.isFinite(fetchedAt) ||
+					Date.now() - fetchedAt > USAGE_LAST_GOOD_RETENTION_MS;
+				if (retired) {
+					this.#usageLogger?.debug("Usage last-good retired (age)", {
+						cacheKey,
+						ageMs: typeof fetchedAt === "number" ? Date.now() - fetchedAt : undefined,
+					});
+					return null;
+				}
 				const backoffJitter = USAGE_FAILURE_BACKOFF_MS * (Math.random() * 0.5 - 0.25);
 				const coolDown = Date.now() + USAGE_FAILURE_BACKOFF_MS + backoffJitter;
 				this.#usageCache.set(cacheKey, { value: lastGood, expiresAt: coolDown });
@@ -2254,6 +2284,69 @@ export class AuthStorage {
 		}
 		if (candidates.length === 0) return undefined;
 		return Math.min(...candidates);
+	}
+
+	/** Age of a usage report in ms; undefined when fetchedAt is missing/non-finite (legacy/corrupt cache row). */
+	#usageAgeMs(report: UsageReport, nowMs: number): number | undefined {
+		const fetchedAt = report.fetchedAt;
+		if (typeof fetchedAt !== "number" || !Number.isFinite(fetchedAt)) return undefined;
+		return nowMs - fetchedAt;
+	}
+
+	/**
+	 * True when a usage report is fresh enough to drive ROUTING decisions (block,
+	 * order, or plan-gate a credential). Stale or undated reports are not trusted
+	 * for routing — they still populate the /usage display, but must never demote
+	 * or promote a credential in selection. A future fetchedAt (clock skew) is fresh.
+	 */
+	#isUsageFreshForRouting(report: UsageReport, nowMs: number): boolean {
+		const ageMs = this.#usageAgeMs(report, nowMs);
+		return ageMs !== undefined && ageMs <= USAGE_ROUTING_MAX_AGE_MS;
+	}
+
+	#usageForRouting(report: UsageReport | null | undefined, nowMs: number): UsageReport | undefined {
+		if (!report || !this.#isUsageFreshForRouting(report, nowMs)) return undefined;
+		return report;
+	}
+
+	#isUsageLimitAuthoritativeForRouting(limit: UsageLimit | undefined, nowMs: number): limit is UsageLimit {
+		if (!limit) return false;
+		if (!this.#isUsageLimitExhausted(limit)) return true;
+		const resetsAt = limit.window?.resetsAt;
+		return !(typeof resetsAt === "number" && Number.isFinite(resetsAt) && resetsAt <= nowMs);
+	}
+
+	#hasOpenAICodexProPlanForRouting(report: UsageReport | null | undefined, nowMs: number): boolean {
+		return this.#usageForRouting(report, nowMs) !== undefined && hasOpenAICodexProPlan(report ?? null);
+	}
+
+	/**
+	 * Routing-authoritative variant of #isUsageLimitReached. An exhausted limit whose
+	 * window has already reset (`resetsAt <= nowMs`) is skipped: either the window rolled
+	 * over or the provider reported a past/garbage reset, so the exhaustion claim is not
+	 * current and must not block selection. An exhausted limit with a future reset, or
+	 * with no resetsAt at all (a fresh hard cap), still counts.
+	 */
+	#isUsageLimitReachedForRouting(report: UsageReport, nowMs: number): boolean {
+		return report.limits.some(
+			limit => this.#isUsageLimitExhausted(limit) && this.#isUsageLimitAuthoritativeForRouting(limit, nowMs),
+		);
+	}
+
+	/** durationMs of the exhausted limit with the earliest future reset — the window the block-extension clamp anchors to. */
+	#exhaustedWindowDurationMs(report: UsageReport, nowMs: number): number | undefined {
+		let bestReset: number | undefined;
+		let bestDuration: number | undefined;
+		for (const limit of report.limits) {
+			if (!this.#isUsageLimitExhausted(limit)) continue;
+			const resetsAt = limit.window?.resetsAt;
+			if (typeof resetsAt !== "number" || !Number.isFinite(resetsAt) || resetsAt <= nowMs) continue;
+			if (bestReset === undefined || resetsAt < bestReset) {
+				bestReset = resetsAt;
+				bestDuration = limit.window?.durationMs;
+			}
+		}
+		return typeof bestDuration === "number" && Number.isFinite(bestDuration) ? bestDuration : undefined;
 	}
 
 	async #getUsageReport(
@@ -2508,12 +2601,31 @@ export class AuthStorage {
 		if (sessionCredential.type === "oauth" && this.#rankingStrategyResolver?.(provider)) {
 			const credential = this.#getCredentialsForProvider(provider)[sessionCredential.index];
 			if (credential?.type === "oauth") {
+				const nowForExtension = Date.now();
 				const report = await this.#getUsageReport(provider, credential, options);
-				if (report && this.#isUsageLimitReached(report)) {
-					const resetAtMs = this.#getUsageResetAtMs(report, Date.now());
+				// Only let the usage report EXTEND the reactive block when it is fresh
+				// enough to trust for routing AND still reports the limit reached with a
+				// current (future) reset. A stale or past-reset report must not stretch a
+				// retry-after/default block into a multi-hour park on a credential that has
+				// actually recovered; the provider retry-after (folded into the base above)
+				// stays the floor. Clamp any extension to at most one full window from now
+				// so a far-future reset can't over-park either.
+				if (
+					report &&
+					this.#isUsageFreshForRouting(report, nowForExtension) &&
+					this.#isUsageLimitReachedForRouting(report, nowForExtension)
+				) {
+					const resetAtMs = this.#getUsageResetAtMs(report, nowForExtension);
 					if (resetAtMs && resetAtMs > blockedUntil) {
-						blockedUntil = resetAtMs;
+						const windowDurationMs = this.#exhaustedWindowDurationMs(report, nowForExtension);
+						const cap = nowForExtension + (windowDurationMs ?? USAGE_ROUTING_MAX_AGE_MS);
+						blockedUntil = Math.min(resetAtMs, cap);
 					}
+				} else if (report && !this.#isUsageFreshForRouting(report, nowForExtension)) {
+					this.#usageLogger?.debug("Block extension rejected: stale usage", {
+						provider,
+						ageMs: this.#usageAgeMs(report, nowForExtension),
+					});
 				}
 			}
 		}
@@ -2590,6 +2702,7 @@ export class AuthStorage {
 			selection: { credential: OAuthCredential; index: number };
 			usage: UsageReport | null;
 			usageChecked: boolean;
+			routingUsage?: UsageReport;
 			blocked: boolean;
 			blockedUntil?: number;
 			hasPriorityBoost: boolean;
@@ -2642,20 +2755,38 @@ export class AuthStorage {
 			const { selection, usage, usageChecked } = result;
 			let { blockedUntil } = result;
 			let blocked = blockedUntil !== undefined;
-			if (!blocked && usage && this.#isUsageLimitReached(usage)) {
-				const resetAtMs = this.#getUsageResetAtMs(usage, nowMs);
+			const usageForRouting = this.#usageForRouting(usage, nowMs);
+			if (!blocked && usageForRouting && this.#isUsageLimitReachedForRouting(usageForRouting, nowMs)) {
+				const resetAtMs = this.#getUsageResetAtMs(usageForRouting, nowMs);
 				blockedUntil = resetAtMs ?? Date.now() + AuthStorage.#defaultBackoffMs;
 				this.#markCredentialBlocked(args.providerKey, selection.index, blockedUntil);
 				blocked = true;
+			} else if (!blocked && usage && !usageForRouting && this.#isUsageLimitReached(usage)) {
+				this.#usageLogger?.debug("Routing ignored stale usage", {
+					provider: args.provider,
+					ageMs: this.#usageAgeMs(usage, nowMs),
+					maxAgeMs: USAGE_ROUTING_MAX_AGE_MS,
+					decision: "not-blocked",
+				});
 			}
-			const windows = usage ? strategy.findWindowLimits(usage) : undefined;
-			const primary = windows?.primary;
-			const secondary = windows?.secondary;
+			// Ordering inputs only trust routing-authoritative usage; a stale snapshot
+			// or past-reset exhausted window degrades to the unknown path (undefined
+			// windows) so frozen quota data never ranks a healthy account last/first.
+			const windows = usageForRouting ? strategy.findWindowLimits(usageForRouting) : undefined;
+			const primaryCandidate = windows?.primary;
+			const secondaryCandidate = windows?.secondary;
+			const primary = this.#isUsageLimitAuthoritativeForRouting(primaryCandidate, nowMs)
+				? primaryCandidate
+				: undefined;
+			const secondary = this.#isUsageLimitAuthoritativeForRouting(secondaryCandidate, nowMs)
+				? secondaryCandidate
+				: undefined;
 			const secondaryTarget = secondary ?? primary;
 			ranked.push({
 				selection,
 				usage,
 				usageChecked,
+				routingUsage: usageForRouting,
 				blocked,
 				blockedUntil,
 				hasPriorityBoost: strategy.hasPriorityBoost?.(primary) ?? false,
@@ -2683,8 +2814,8 @@ export class AuthStorage {
 				return left.orderPos - right.orderPos;
 			}
 			if (requiresOpenAICodexProModel(args.provider, args.options?.modelId)) {
-				const leftPlanPriority = getOpenAICodexPlanPriority(left.usage);
-				const rightPlanPriority = getOpenAICodexPlanPriority(right.usage);
+				const leftPlanPriority = getOpenAICodexPlanPriority(left.routingUsage ?? null);
+				const rightPlanPriority = getOpenAICodexPlanPriority(right.routingUsage ?? null);
 				if (leftPlanPriority !== rightPlanPriority) return leftPlanPriority - rightPlanPriority;
 			}
 			if (left.hasPriorityBoost !== right.hasPriorityBoost) return left.hasPriorityBoost ? -1 : 1;
@@ -2788,8 +2919,10 @@ export class AuthStorage {
 
 		// Skip the Pro-plan filter when no candidate is confirmed Pro, so users with only
 		// non-Pro accounts can still attempt Spark requests (e.g. trial/grandfathered access).
+		const proRequirementNow = Date.now();
 		const enforceProRequirement =
-			requiresProModel && candidates.some(candidate => hasOpenAICodexProPlan(candidate.usage));
+			requiresProModel &&
+			candidates.some(candidate => this.#hasOpenAICodexProPlanForRouting(candidate.usage, proRequirementNow));
 
 		const fallback = candidates[0];
 
@@ -2969,10 +3102,16 @@ export class AuthStorage {
 				});
 				usageChecked = true;
 			}
-			if (applyProFilter && !hasOpenAICodexProPlan(usage)) {
+			if (applyProFilter && !this.#hasOpenAICodexProPlanForRouting(usage, Date.now())) {
 				return undefined;
 			}
-			if (checkUsage && !allowBlocked && usage && this.#isUsageLimitReached(usage)) {
+			if (
+				checkUsage &&
+				!allowBlocked &&
+				usage &&
+				this.#isUsageFreshForRouting(usage, Date.now()) &&
+				this.#isUsageLimitReachedForRouting(usage, Date.now())
+			) {
 				const resetAtMs = this.#getUsageResetAtMs(usage, Date.now());
 				this.#markCredentialBlocked(
 					providerKey,
@@ -3035,10 +3174,16 @@ export class AuthStorage {
 					});
 					usageChecked = true;
 				}
-				if (applyProFilter && !hasOpenAICodexProPlan(usage)) {
+				if (applyProFilter && !this.#hasOpenAICodexProPlanForRouting(usage, Date.now())) {
 					return undefined;
 				}
-				if (checkUsage && !allowBlocked && usage && this.#isUsageLimitReached(usage)) {
+				if (
+					checkUsage &&
+					!allowBlocked &&
+					usage &&
+					this.#isUsageFreshForRouting(usage, Date.now()) &&
+					this.#isUsageLimitReachedForRouting(usage, Date.now())
+				) {
 					const resetAtMs = this.#getUsageResetAtMs(usage, Date.now());
 					this.#markCredentialBlocked(
 						providerKey,

--- a/packages/ai/test/auth-storage-usage-staleness.test.ts
+++ b/packages/ai/test/auth-storage-usage-staleness.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, setSystemTime, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage } from "../src/auth-storage";
+import type { UsageProvider, UsageReport } from "../src/usage";
+import * as oauth from "../src/utils/oauth";
+import type { OAuthCredentials } from "../src/utils/oauth/types";
+
+// Routing-freshness / cache-poisoning regression suite.
+//
+// Guards the fix for the incident where a stale "exhausted" usage snapshot (from a
+// persistently failing /usage probe) sidelined a genuinely healthy credential:
+//   - stale usage must NOT block/deprioritize a credential in routing (freshness gate)
+//   - an exhausted window whose reset is already in the past must NOT block (routing variant)
+//   - a fresh exhausted window with a future reset STILL blocks (legit case preserved)
+//   - past-reset exhausted windows must NOT influence ordering/reset priority
+//   - stale Codex plan metadata must NOT promote/filter credentials for Spark routing
+//   - a last-good snapshot older than the 24h retention is RETIRED, not re-served forever
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+type Scenario = "throw" | UsageReport;
+let scenarios: Record<string, Scenario> = {};
+
+function makeReport(
+	accountId: string,
+	opts: {
+		fetchedAtMsAgo?: number;
+		usedFraction?: number;
+		exhausted?: boolean;
+		resetsInMs?: number;
+		planType?: string;
+	},
+): UsageReport {
+	const now = Date.now();
+	const usedFraction = opts.exhausted ? 1 : (opts.usedFraction ?? 0);
+	return {
+		provider: "openai-codex",
+		fetchedAt: now - (opts.fetchedAtMsAgo ?? 0),
+		limits: [
+			{
+				id: "openai-codex:primary",
+				label: "Primary",
+				scope: { provider: "openai-codex", accountId, windowId: "5h" },
+				amount: { unit: "requests", used: Math.round(usedFraction * 100), limit: 100, usedFraction },
+				status: opts.exhausted ? "exhausted" : "ok",
+				...(opts.resetsInMs !== undefined
+					? { window: { id: "5h", label: "5 Hour", durationMs: 5 * HOUR, resetsAt: now + opts.resetsInMs } }
+					: {}),
+			},
+		],
+		...(opts.planType !== undefined ? { metadata: { planType: opts.planType } } : {}),
+	};
+}
+
+const usageProvider: UsageProvider = {
+	id: "openai-codex",
+	async fetchUsage(params) {
+		const accountId = params.credential.accountId ?? "unknown";
+		const scenario = scenarios[accountId];
+		if (scenario === undefined) return null;
+		if (scenario === "throw") throw new Error(`simulated probe failure for ${accountId}`);
+		return scenario;
+	},
+};
+
+describe("AuthStorage usage staleness / routing freshness", () => {
+	let tempDir = "";
+	let authStorage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-usage-staleness-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		scenarios = {};
+		authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"), {
+			usageProviderResolver: provider => (provider === "openai-codex" ? usageProvider : undefined),
+		});
+		vi.spyOn(oauth, "refreshOAuthToken").mockImplementation(async (_provider, credential) => credential);
+		vi.spyOn(oauth, "getOAuthApiKey").mockImplementation(async (_provider, credentials) => {
+			const credential = credentials["openai-codex"] as OAuthCredentials | undefined;
+			if (!credential) return null;
+			return { apiKey: `api-${credential.accountId ?? "unknown"}`, newCredentials: credential };
+		});
+	});
+
+	afterEach(() => {
+		setSystemTime();
+		vi.restoreAllMocks();
+		authStorage.close();
+		if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+	});
+
+	async function seedTwo(a: string, b: string): Promise<void> {
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", access: `access-${a}`, refresh: `refresh-${a}`, expires: Date.now() + HOUR, accountId: a },
+			{ type: "oauth", access: `access-${b}`, refresh: `refresh-${b}`, expires: Date.now() + HOUR, accountId: b },
+		]);
+	}
+
+	async function useEarliestResetRanking(): Promise<void> {
+		authStorage.close();
+		authStorage = await AuthStorage.create(path.join(tempDir, "auth-earliest-reset.db"), {
+			usageProviderResolver: provider => (provider === "openai-codex" ? usageProvider : undefined),
+			credentialRankingMode: "earliest-reset",
+		});
+	}
+
+	test("stale 'exhausted' snapshot does NOT block; the genuinely fresh-capped account is avoided instead", async () => {
+		// The incident: acct-poison looks exhausted but the evidence is 20min old (a frozen
+		// snapshot from a failing probe). acct-realcap is exhausted on a FRESH report with a
+		// future reset. Only acct-realcap should be blocked; acct-poison must stay selectable.
+		await seedTwo("poison", "realcap");
+		scenarios.poison = makeReport("poison", { fetchedAtMsAgo: 20 * MIN, exhausted: true, resetsInMs: 2 * HOUR });
+		scenarios.realcap = makeReport("realcap", { fetchedAtMsAgo: 0, exhausted: true, resetsInMs: 1 * HOUR });
+
+		const key = await authStorage.getApiKey("openai-codex", "session-incident", { modelId: "gpt-5.5" });
+		expect(key).toBe("api-poison");
+	});
+
+	test("fresh exhausted window with a PAST reset is not authoritative for routing (Change 3)", async () => {
+		// acct-past is exhausted on a fresh report but its window already reset (resetsAt in
+		// the past) — the exhaustion claim is stale, so it must not block. acct-future is a
+		// live cap. Selection must land on acct-past.
+		await seedTwo("past", "future");
+		scenarios.past = makeReport("past", { fetchedAtMsAgo: 0, exhausted: true, resetsInMs: -1 * HOUR });
+		scenarios.future = makeReport("future", { fetchedAtMsAgo: 0, exhausted: true, resetsInMs: 1 * HOUR });
+
+		const key = await authStorage.getApiKey("openai-codex", "session-pastreset", { modelId: "gpt-5.5" });
+		expect(key).toBe("api-past");
+	});
+
+	test("past-reset exhausted window does not win earliest-reset ordering", async () => {
+		// The past-reset exhausted window is non-authoritative for all routing, not only
+		// block detection. Under earliest-reset mode it must degrade to unknown instead of
+		// winning just because its reset timestamp is already in the past.
+		await useEarliestResetRanking();
+		await seedTwo("pastbusy", "healthy");
+		scenarios.pastbusy = makeReport("pastbusy", { fetchedAtMsAgo: 0, exhausted: true, resetsInMs: -1 * HOUR });
+		scenarios.healthy = makeReport("healthy", { fetchedAtMsAgo: 0, usedFraction: 0.1 });
+
+		const key = await authStorage.getApiKey("openai-codex", "session-pastreset-order", { modelId: "gpt-5.5" });
+		expect(key).toBe("api-healthy");
+	});
+
+	test("fresh exhausted window with a FUTURE reset STILL blocks — legit cap preserved (regression)", async () => {
+		// Guard against the fix over-opening: a genuinely fresh cap must still be avoided in
+		// favour of the healthy account.
+		await seedTwo("cap", "ok");
+		scenarios.cap = makeReport("cap", { fetchedAtMsAgo: 0, exhausted: true, resetsInMs: 1 * HOUR });
+		scenarios.ok = makeReport("ok", { fetchedAtMsAgo: 0, usedFraction: 0.1 });
+
+		const key = await authStorage.getApiKey("openai-codex", "session-legit", { modelId: "gpt-5.5" });
+		expect(key).toBe("api-ok");
+	});
+
+	test("stale high-usage report degrades to unknown for ordering, not treated as busy (Change 2)", async () => {
+		// acct-stalebusy reads 95% used but the report is 20min old; acct-freshbusy reads a
+		// real 60% used. Neither is exhausted, so neither is blocked. Stale usage must degrade
+		// to the unknown-ordering default (~0.5) rather than its frozen 0.95, so it is NOT
+		// deprioritized behind the genuinely-busier fresh account.
+		await seedTwo("stalebusy", "freshbusy");
+		scenarios.stalebusy = makeReport("stalebusy", { fetchedAtMsAgo: 20 * MIN, usedFraction: 0.95 });
+		scenarios.freshbusy = makeReport("freshbusy", { fetchedAtMsAgo: 0, usedFraction: 0.6 });
+
+		const key = await authStorage.getApiKey("openai-codex", "session-ordering", { modelId: "gpt-5.5" });
+		expect(key).toBe("api-stalebusy");
+	});
+
+	test("stale Codex Pro metadata does not drive Spark routing priority or filtering", async () => {
+		// Spark routing may display old plan metadata, but stale planType must not promote
+		// or filter a credential. With no fresh Pro confirmation, the lower-usage fresh
+		// unknown-plan report is attempted instead of the stale "pro" report.
+		await seedTwo("stalepro", "freshunknown");
+		scenarios.stalepro = makeReport("stalepro", {
+			fetchedAtMsAgo: 20 * MIN,
+			usedFraction: 0.95,
+			planType: "pro",
+		});
+		scenarios.freshunknown = makeReport("freshunknown", {
+			fetchedAtMsAgo: 0,
+			usedFraction: 0.1,
+		});
+
+		const key = await authStorage.getApiKey("openai-codex", "session-stale-pro", { modelId: "gpt-5.5-spark" });
+		expect(key).toBe("api-freshunknown");
+	});
+
+	test("last-good within the 24h retention is still served for display when the probe fails", async () => {
+		const t0 = Date.UTC(2026, 0, 1, 12, 0, 0);
+		setSystemTime(t0);
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", access: "a", refresh: "r", expires: t0 + 1000 * HOUR, accountId: "acct" },
+		]);
+		scenarios.acct = makeReport("acct", { fetchedAtMsAgo: 0, usedFraction: 0.4 });
+
+		const first = await authStorage.fetchUsageReports();
+		expect(first?.some(r => r.limits[0]?.scope.accountId === "acct")).toBe(true);
+
+		// Probe now fails; 23h later the last-good is stale-for-fresh but within retention.
+		scenarios.acct = "throw";
+		setSystemTime(t0 + 23 * HOUR);
+		const served = await authStorage.fetchUsageReports();
+		expect(served?.some(r => r.limits[0]?.scope.accountId === "acct")).toBe(true);
+	});
+
+	test("last-good older than the 24h retention is RETIRED, not resurrected (Change 1)", async () => {
+		const t0 = Date.UTC(2026, 0, 1, 12, 0, 0);
+		setSystemTime(t0);
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", access: "a", refresh: "r", expires: t0 + 1000 * HOUR, accountId: "acct" },
+		]);
+		scenarios.acct = makeReport("acct", { fetchedAtMsAgo: 0, usedFraction: 0.4 });
+
+		const first = await authStorage.fetchUsageReports();
+		expect(first?.some(r => r.limits[0]?.scope.accountId === "acct")).toBe(true);
+
+		// Probe fails for good; 25h later the last-good has aged past retention and must be
+		// dropped rather than re-served (the resurrection loop the fix kills).
+		scenarios.acct = "throw";
+		setSystemTime(t0 + 25 * HOUR);
+		const retired = await authStorage.fetchUsageReports();
+		expect(retired?.some(r => r.limits[0]?.scope.accountId === "acct")).toBe(false);
+	});
+});


### PR DESCRIPTION
## What

Stop stale usage-cache snapshots from poisoning Codex/Anthropic credential rotation.

- Add a routing freshness window so stale usage reports can still inform display but cannot block, deprioritize, promote, or plan-gate OAuth credentials.
- Retire last-good usage reports once they exceed the 24h retention bound instead of resurrecting them forever after repeated `/usage` probe failures.
- Ignore exhausted usage windows whose reset time is already in the past for routing block and ordering decisions.
- Clamp usage-derived block extensions to the active window, while preserving provider retry-after/default reactive blocking.
- Add regression coverage for stale exhausted snapshots, past-reset windows, legit fresh caps, stale ordering input, stale Codex plan metadata, and last-good retirement.

## Why

A persistently failing `/usage` probe could keep re-serving an old “exhausted” snapshot and make credential selection route away from a healthy account while repeatedly trying capped or invalid accounts. Routing now treats stale usage as non-authoritative, so real completion 429s remain the source of truth for currently exhausted credentials without letting frozen cache evidence sideline recovered capacity indefinitely.

## Testing

- `bunx @biomejs/biome check packages/ai/CHANGELOG.md packages/ai/src/auth-storage.ts packages/ai/test/auth-storage-usage-staleness.test.ts`
- `bun run check` from `packages/ai`
- `bun test test/auth-storage-usage-staleness.test.ts` from `packages/ai` — 8 pass, 0 fail
- Earlier full `bun test` from `packages/ai` reached 1578 pass / 336 skip / 1 fail; the lone failure is the existing local llama.cpp `context-overflow.test.ts` 404 environmental failure, reproduced on baseline with the auth-storage changes stashed.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
