### PR TITLE
Fix ACP startup model profile refresh for project settings

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -191,6 +191,10 @@ function applyExtensionFlagValues(session: AgentSession, rawArgs: string[]): Map
 
 type AcpSessionFactory = (cwd: string) => Promise<AgentSession>;
 
+function hasStartupModelProfile(settings: Settings, parsedArgs: Pick<Args, "mpreset">): boolean {
+	return Boolean(settings.get("modelProfile.default") || parsedArgs.mpreset);
+}
+
 export interface AcpSessionFactoryOptions {
 	baseOptions: CreateAgentSessionOptions;
 	settings: Settings;
@@ -263,6 +267,9 @@ export async function applyStartupModelProfilesOrExit(
 export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSessionFactory {
 	return async cwd => {
 		const nextSettings = await args.settings.cloneForCwd(cwd);
+		if (hasStartupModelProfile(nextSettings, args.parsedArgs)) {
+			await args.modelRegistry.refresh("online-if-uncached");
+		}
 		const nextSessionManager = SessionManager.create(cwd, args.sessionDir);
 		const agentId = `acp:${nextSessionManager.getSessionId()}`;
 		const { session: nextSession } = await args.createSession({
@@ -961,13 +968,24 @@ export async function runRootCommand(
 		}
 	}
 
+	const startupModelProfileRefreshNeeded = mode !== "acp" && hasStartupModelProfile(settingsInstance, parsedArgs);
+	if (startupModelProfileRefreshNeeded) {
+		await modelRegistry.refresh("online-if-uncached");
+	}
+
 	const createAgentSessionImpl = deps.createAgentSession ?? createAgentSession;
 	const createSession = async (options: CreateAgentSessionOptions): Promise<CreateAgentSessionResult> => {
 		const result = await logger.time("createAgentSession", createAgentSessionImpl, options);
 		// Kick off background model discovery only after createAgentSession finishes its parallel
 		// discovery arms; running these concurrently contends for the event loop and stretches
 		// every parallel arm by ~30ms.
-		modelRegistry.refreshInBackground();
+		const sessionStartupModelProfileRefreshNeeded = hasStartupModelProfile(
+			options.settings ?? settingsInstance,
+			parsedArgs,
+		);
+		if (!sessionStartupModelProfileRefreshNeeded) {
+			modelRegistry.refreshInBackground();
+		}
 		return result;
 	};
 

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -1,24 +1,42 @@
 import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
+import { TempDir } from "@gajae-code/utils";
 import { parseArgs } from "../src/cli/args";
 import type { ModelProfileDefinition } from "../src/config/model-profiles";
+import { ModelRegistry } from "../src/config/model-registry";
 import { Settings } from "../src/config/settings";
-import { applyStartupModelProfiles, createAcpSessionFactory } from "../src/main";
+import { applyStartupModelProfiles, createAcpSessionFactory, runRootCommand } from "../src/main";
 import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "../src/sdk";
 import type { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
 
 const model = (provider: string, id: string): Model =>
 	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
 
-function fakeRegistry(profiles: ModelProfileDefinition[]) {
+const antigravityProfile = (): ModelProfileDefinition => ({
+	name: "antigravity-flash",
+	requiredProviders: ["google-antigravity"],
+	modelMapping: { default: "google-antigravity/gemini-3.5-flash-low" },
+	source: "user",
+});
+
+function fakeRegistry(
+	profiles: ModelProfileDefinition[],
+	options?: { afterRefreshModels?: Model[]; initialModels?: Model[] },
+) {
 	const profileMap = new Map(profiles.map(profile => [profile.name, profile]));
+	let models = options?.initialModels ?? [model("profile-provider", "default"), model("cli-provider", "explicit")];
 	return {
 		getModelProfile: (name: string) => profileMap.get(name),
 		getModelProfiles: () => new Map(profileMap),
 		getAvailableModelProfileNames: () => [...profileMap.keys()].sort(),
 		getApiKeyForProvider: async () => "key",
-		getAll: () => [model("profile-provider", "default"), model("cli-provider", "explicit")],
+		getAll: () => models,
+		refresh: async () => {
+			models = options?.afterRefreshModels ?? models;
+		},
 	};
 }
 
@@ -36,22 +54,83 @@ function fakeSession(initial = model("initial-provider", "initial")) {
 	};
 	return session as AgentSession & { setModelTemporaryCalls: Array<{ model: Model; thinkingLevel?: ThinkingLevel }> };
 }
+
+async function runAcpProfileHarness(options: {
+	readonly settings: Settings;
+	readonly session: ReturnType<typeof fakeSession>;
+	readonly profile: ModelProfileDefinition;
+	readonly models: (refreshed: boolean) => Model[];
+	readonly cloneForCwdSettings?: Settings;
+}): Promise<{ readonly backgroundRefreshCount: number; readonly refreshStrategies: readonly string[] }> {
+	const refreshStrategies: string[] = [];
+	let backgroundRefreshCount = 0;
+	let refreshed = false;
+	const originalRefresh = ModelRegistry.prototype.refresh;
+	const originalRefreshInBackground = ModelRegistry.prototype.refreshInBackground;
+	const originalGetModelProfile = ModelRegistry.prototype.getModelProfile;
+	const originalGetModelProfiles = ModelRegistry.prototype.getModelProfiles;
+	const originalGetAvailableModelProfileNames = ModelRegistry.prototype.getAvailableModelProfileNames;
+	const originalGetAll = ModelRegistry.prototype.getAll;
+	const originalGetApiKeyForProvider = ModelRegistry.prototype.getApiKeyForProvider;
+	using tempDir = TempDir.createSync("@gjc-mpreset-refresh-");
+	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+
+	if (options.cloneForCwdSettings) {
+		options.settings.cloneForCwd = async () => options.cloneForCwdSettings ?? options.settings;
+	}
+	ModelRegistry.prototype.refresh = async (strategy = "online-if-uncached") => {
+		refreshStrategies.push(strategy);
+		refreshed = true;
+	};
+	ModelRegistry.prototype.refreshInBackground = () => {
+		backgroundRefreshCount += 1;
+	};
+	ModelRegistry.prototype.getModelProfile = (name: string) =>
+		name === options.profile.name ? options.profile : undefined;
+	ModelRegistry.prototype.getModelProfiles = () => new Map([[options.profile.name, options.profile]]);
+	ModelRegistry.prototype.getAvailableModelProfileNames = () => [options.profile.name];
+	ModelRegistry.prototype.getAll = () => options.models(refreshed);
+	ModelRegistry.prototype.getApiKeyForProvider = async () => "key";
+
+	try {
+		await runRootCommand(parseArgs(["--mode", "acp", "--no-tools", "--no-lsp", "--no-skills", "--no-rules"]), [], {
+			discoverAuthStorage: async () => authStorage,
+			createAgentSession: async (): Promise<CreateAgentSessionResult> =>
+				({
+					session: options.session,
+					setToolUIContext: () => {},
+					extensionsResult: {},
+					eventBus: {},
+				}) as unknown as CreateAgentSessionResult,
+			settings: options.settings,
+			runAcpMode: async createAcpSession => {
+				const nextSession = await createAcpSession(process.cwd());
+				expect(nextSession).toBe(options.session);
+			},
+			suppressProcessExit: true,
+		});
+	} finally {
+		authStorage.close();
+		ModelRegistry.prototype.refresh = originalRefresh;
+		ModelRegistry.prototype.refreshInBackground = originalRefreshInBackground;
+		ModelRegistry.prototype.getModelProfile = originalGetModelProfile;
+		ModelRegistry.prototype.getModelProfiles = originalGetModelProfiles;
+		ModelRegistry.prototype.getAvailableModelProfileNames = originalGetAvailableModelProfileNames;
+		ModelRegistry.prototype.getAll = originalGetAll;
+		ModelRegistry.prototype.getApiKeyForProvider = originalGetApiKeyForProvider;
+	}
+
+	return { backgroundRefreshCount, refreshStrategies };
+}
 describe("CLI model profile args", () => {
-	test("parses --mpreset with separate value", () => {
+	test("parses --mpreset forms and --default", () => {
 		const parsed = parseArgs(["--mpreset", "codex-medium"]);
 		expect(parsed.mpreset).toBe("codex-medium");
 		expect(parsed.default).toBeUndefined();
-	});
-
-	test("parses --mpreset=value", () => {
-		const parsed = parseArgs(["--mpreset=codex-pro"]);
-		expect(parsed.mpreset).toBe("codex-pro");
-	});
-
-	test("parses --default with --mpreset", () => {
-		const parsed = parseArgs(["--mpreset", "opencodego", "--default"]);
-		expect(parsed.mpreset).toBe("opencodego");
-		expect(parsed.default).toBe(true);
+		expect(parseArgs(["--mpreset=codex-pro"]).mpreset).toBe("codex-pro");
+		const parsedDefault = parseArgs(["--mpreset", "opencodego", "--default"]);
+		expect(parsedDefault.mpreset).toBe("opencodego");
+		expect(parsedDefault.default).toBe(true);
 	});
 
 	test("rejects --default without --mpreset", () => {
@@ -112,6 +191,39 @@ test("deferred explicit CLI --model is reapplied after --mpreset activation", as
 	).toEqual(["profile-provider/default:high", "cli-provider/explicit:undefined"]);
 	expect(session.setModelTemporaryCalls.at(-1)?.model).toBe(explicitModel);
 	expect(session.model).toBe(explicitModel);
+});
+
+test("runRootCommand foreground-refreshes startup profiles without background refresh", async () => {
+	const session = fakeSession();
+	const settings = Settings.isolated({ "modelProfile.default": "antigravity-flash" });
+	const liveModel = model("google-antigravity", "gemini-3.5-flash-low");
+	const profile = antigravityProfile();
+	const result = await runAcpProfileHarness({ settings, session, profile, models: () => [liveModel] });
+
+	expect(result.refreshStrategies).toEqual(["online-if-uncached"]);
+	expect(result.backgroundRefreshCount).toBe(0);
+	expect(session.setModelTemporaryCalls).toHaveLength(1);
+	expect(session.model).toBe(liveModel);
+});
+
+test("ACP session/new refreshes project-scoped default profiles before activation", async () => {
+	const session = fakeSession();
+	const settings = Settings.isolated();
+	const projectSettings = Settings.isolated({ "modelProfile.default": "antigravity-flash" });
+	const liveModel = model("google-antigravity", "gemini-3.5-flash-low");
+	const profile = antigravityProfile();
+	const result = await runAcpProfileHarness({
+		settings,
+		session,
+		profile,
+		cloneForCwdSettings: projectSettings,
+		models: refreshed => (refreshed ? [liveModel] : []),
+	});
+
+	expect(result.refreshStrategies).toEqual(["online-if-uncached"]);
+	expect(result.backgroundRefreshCount).toBe(0);
+	expect(session.setModelTemporaryCalls).toHaveLength(1);
+	expect(session.model).toBe(liveModel);
 });
 
 test("ACP session factory applies default profile and --mpreset before returning session", async () => {


### PR DESCRIPTION
## Summary
Follow-up to #1454. This keeps the normal startup coalescing from the previous PR and fixes the remaining ACP/session-new case called out in review.

ACP session creation clones settings per cwd via `settings.cloneForCwd(cwd)`. If the initial ACP process settings do not contain `modelProfile.default`, but the per-session `nextSettings` does, the old precomputed refresh decision can miss the foreground refresh and activate the profile against a stale registry.

This change makes the refresh decision from the settings actually used for the session:

- non-ACP startup still performs one foreground `modelRegistry.refresh("online-if-uncached")` before session creation when needed
- ACP session/new refreshes after `cloneForCwd(cwd)` and before creating/applying the session profile when `nextSettings` or `--mpreset` requires it
- the post-create background refresh suppression now checks the per-session `options.settings` instead of only the initial root settings

## Regression coverage
- Added an ACP `session/new` regression where the initial settings have no default profile, but `cloneForCwd()` returns project-scoped settings with `modelProfile.default`.
- Confirmed the test fails before the ACP fix with `Model profile "antigravity-flash" default selector did not resolve`.
- The regression asserts foreground refresh runs once and `refreshInBackground()` is not called for that startup-profile path.

## Verification
- `bun test packages/coding-agent/test/cli-args-mpreset.test.ts`
- `bunx biome check packages/coding-agent/src/main.ts packages/coding-agent/test/cli-args-mpreset.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun run check:node20-baseline`
- `git diff --check HEAD -- packages/coding-agent/src/main.ts packages/coding-agent/test/cli-args-mpreset.test.ts`

Thank you.