### PR TITLE
feat(deep-interview): add trace pre-skill option

### DIFF
--- a/packages/coding-agent/src/commands/deep-interview.ts
+++ b/packages/coding-agent/src/commands/deep-interview.ts
@@ -8,6 +8,7 @@ export default class DeepInterview extends Command {
 		quick: Flags.boolean({ description: "Seed a quick deep-interview run" }),
 		standard: Flags.boolean({ description: "Seed a standard deep-interview run" }),
 		deep: Flags.boolean({ description: "Seed a deep deep-interview run" }),
+		trace: Flags.boolean({ description: "Run a bounded trace evidence pre-step before interview questions" }),
 		threshold: Flags.string({ description: "Override ambiguity threshold for kickoff" }),
 		"threshold-source": Flags.string({ description: "Describe the threshold override source" }),
 		"session-id": Flags.string({
@@ -25,7 +26,7 @@ export default class DeepInterview extends Command {
 		json: Flags.boolean({ description: "Output JSON" }),
 	};
 	static examples = [
-		'$ gjc deep-interview --standard "<idea>"',
+		'$ gjc deep-interview --trace --standard "<idea>"',
 		"$ gjc deep-interview --write --stage final --slug my-feature --spec ./final-spec.md",
 		"$ gjc deep-interview --write --stage final --slug my-feature --spec ./final-spec.md --deliberate",
 	];

--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deep-interview
 description: Socratic deep interview with mathematical ambiguity gating before explicit execution approval
-argument-hint: "[--quick|--standard|--deep] <idea or vague description>"
+argument-hint: "[--trace] [--quick|--standard|--deep] <idea or vague description>"
 pipeline: [deep-interview, plan]
 handoff-policy: approval-required
 handoff: .gjc/_session-{sessionid}/specs/deep-interview-{slug}.md
@@ -22,6 +22,7 @@ Deep Interview implements Ouroboros-inspired Socratic questioning with mathemati
 - Task is complex enough that jumping to code would waste cycles on scope discovery
 - User wants mathematically-validated clarity before committing to execution
 - User explicitly requests deep-interview even after being told the request is already clear, bounded, and low-risk
+- User requests a trace/research pre-step before the interview, e.g. `/skill:deep-interview --trace <idea>`
 </Use_When>
 
 <Do_Not_Use_When>
@@ -62,6 +63,7 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 - Refine free-text answers into a structured interpretation and confirm nothing is lost before scoring
 - After 3 consecutive agent-resolved answers (accepted auto-research candidates or auto-answers), route the next question to the user (dialectic rhythm guard)
 - Run an independent closure audit and a one-sentence goal restatement, each requiring explicit user confirmation, before crystallizing the spec
+- When `--trace` is active, use the bounded trace evidence summary as pre-question context; never dump raw logs, raw files, or unbounded search output into questions, scoring, specs, or handoffs
 </Execution_Policy>
 
 <Internal_Auto_Mode_Protocol>
@@ -133,6 +135,16 @@ If `{{ARGUMENTS}}` is already clear, bounded, low-risk, and asks for a quick fix
 
 This gate exists to prevent deep-interview from making easy problems harder. A small verification need does not make a request interview-worthy.
 
+## Phase 0.75: Optional Trace Pre-Step
+
+Run this phase only when the active deep-interview state or invocation indicates `--trace` / `state.trace.enabled === true`. It is a pre-interview research step, not an implementation phase.
+
+1. Read the native trace summary from active deep-interview state (`trace`, `state.trace`, or `state.trace_summary`). The native seed must have produced this summary before any interview question.
+2. Treat the summary as compact evidence: project hints, relevant paths, and path-level findings only. Do not expand it by dumping raw files, raw logs, or unbounded command output.
+3. Store or preserve it under `state.trace_summary` and fold it into `codebase_context` with citations to the summarized paths.
+4. Use trace findings to influence Round 0 topology, Phase 2 question targeting, requirement wording, acceptance criteria, and final Technical Context. Normal no-trace interviews must behave exactly as before.
+5. If `--trace` was requested but no valid bounded summary exists, increment `architect_failures` or record an internal audit note, then continue with the normal no-trace path without surfacing tool noise.
+
 ## Phase 1: Initialize
 
 1. **Parse the user's idea** from `{{ARGUMENTS}}`
@@ -177,6 +189,7 @@ This gate exists to prevent deep-interview from making easy problems harder. A s
     "threshold": <resolvedThreshold>,
     "threshold_source": "<resolvedThresholdSource>",
     "language": "<existing language object from active state, if present>",
+    "trace_summary": "<bounded trace summary when --trace is active, else null>",
     "codebase_context": null,
     "topology": {
       "status": "pending|confirmed|legacy_missing",
@@ -222,6 +235,7 @@ Run this gate exactly once after Phase 1 initialization and before any Phase 2 a
    - Extract top-level verbs/nouns, workstreams, surfaces, integrations, or deliverables that can succeed or fail independently.
    - Prefer 1-6 components. If more than 6 candidates appear, group siblings at the highest useful level and note the grouping rationale.
    - Do not treat implementation tasks, fields, or sub-features as top-level components unless the user framed them as independent outcomes.
+   - When `--trace` is active, include trace-summarized paths as topology evidence, but do not add implementation sub-tasks as top-level components solely because trace found files.
 2. **Ask one confirmation question** before Round 1:
 
 ```
@@ -289,6 +303,7 @@ Build the question generation prompt with:
 - Current clarity scores per dimension (which is weakest?)
 - Lateral-review panel findings (if convened this round -- see Phase 3)
 - Brownfield codebase context (if applicable), summarized to cited paths/symbols/patterns instead of raw dumps
+- Bounded trace summary (when `--trace` is active): project hints, relevant paths, and findings only; cite paths instead of raw content
 - Locked topology from Round 0, including active components, deferred components, prior per-component scores, and `last_targeted_component_id`
 
 - `language` from active state when present; apply `language.instruction` to all natural-language user-facing question text, rationale, and options
@@ -395,6 +410,9 @@ Locked topology:
 
 Established facts:
 {state.established_facts}
+
+Trace summary:
+{state.trace_summary if --trace was active, else "not requested"}
 
 Score each active component on each dimension, then provide the overall dimension scores as the minimum or coverage-weighted weakest score across active components. Deferred components are excluded from ambiguity math but must remain listed in topology and the final spec.
 
@@ -615,8 +633,8 @@ Spec structure:
 | {assumption} | {how it was questioned} | {what was decided} |
 
 ## Technical Context
-{brownfield: relevant codebase findings from focused repo inspection or canonical role-agent fact-finding}
-{greenfield: technology choices and constraints}
+{brownfield: relevant codebase findings from focused repo inspection, canonical role-agent fact-finding, and bounded trace summary when --trace was active}
+{greenfield: technology choices and constraints, plus bounded trace findings when --trace was active and relevant}
 
 ## Ontology (Key Entities)
 {Fill from the FINAL round's ontology extraction, not just crystallization-time generation}

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { YAML } from "bun";
 import { syncSkillActiveState } from "../skill-state/active-state";
 import { deriveDeepInterviewHud } from "../skill-state/workflow-hud";
 import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
@@ -19,7 +20,7 @@ export * from "./deep-interview-recorder";
  *
  * The CLI itself does not run the Socratic interview; that lives inside the `/skill:deep-interview`
  * skill executed by the agent. This handler validates the documented argument-hint surface
- * (`[--quick|--standard|--deep] <idea>`), seeds `.gjc/state/deep-interview-state.json`, and
+ * (`[--trace] [--quick|--standard|--deep] <idea>`), seeds `.gjc/state/deep-interview-state.json`, and
  * updates the shared HUD rail via `syncSkillActiveState` so the active interview is visible to
  * the TUI.
  */
@@ -39,6 +40,68 @@ const RESOLUTION_THRESHOLDS = {
 	standard: 0.5,
 	deep: 0.35,
 } as const;
+
+const TRACE_MAX_RELEVANT_PATHS = 12;
+const TRACE_MAX_PACKAGE_HINTS = 8;
+const TRACE_MAX_DIRECTORY_VISITS = 1200;
+const TRACE_MAX_ENTRY_VISITS = 5000;
+const TRACE_MAX_PENDING_DIRECTORIES = 1200;
+const TRACE_SKIP_DIRS = new Set([
+	".git",
+	".gjc",
+	"node_modules",
+	"dist",
+	"build",
+	"coverage",
+	".next",
+	".turbo",
+	".cache",
+	"vendor",
+	"target",
+	".venv",
+	"venv",
+	"__pycache__",
+	".pytest_cache",
+	"tmp",
+	"temp",
+	"logs",
+	"out",
+]);
+const TRACE_SOURCE_EXTENSIONS = new Set([
+	".ts",
+	".tsx",
+	".js",
+	".jsx",
+	".mts",
+	".cts",
+	".py",
+	".rs",
+	".go",
+	".java",
+	".kt",
+	".swift",
+	".md",
+	".json",
+	".yml",
+	".yaml",
+]);
+
+interface DeepInterviewTraceSummary {
+	enabled: true;
+	generated_at: string;
+	bounded: true;
+	limits: {
+		max_relevant_paths: number;
+		max_package_hints: number;
+		max_directory_visits: number;
+		max_entry_visits: number;
+		max_pending_directories: number;
+	};
+	idea_terms: string[];
+	project_hints: string[];
+	relevant_paths: Array<{ path: string; reason: string }>;
+	findings: string[];
+}
 
 type DeepInterviewResolution = keyof typeof RESOLUTION_THRESHOLDS;
 
@@ -107,6 +170,136 @@ async function resolveSpecContent(rawSpec: string, cwd: string): Promise<string>
 	return rawSpec;
 }
 
+function traceTerms(idea: string): string[] {
+	const terms = new Set<string>();
+	for (const match of idea.toLowerCase().matchAll(/[a-z0-9][a-z0-9_-]{2,}/g)) {
+		const value = match[0];
+		if (["the", "and", "for", "with", "that", "this", "from", "into", "should", "would"].includes(value)) continue;
+		terms.add(value);
+		if (terms.size >= 12) break;
+	}
+	return [...terms];
+}
+
+function relativePathReason(relativePath: string, terms: readonly string[]): string | undefined {
+	const normalized = relativePath.toLowerCase();
+	const matched = terms.find(term => normalized.includes(term));
+	if (matched) return `path matches idea term "${matched}"`;
+	if (/deep[-_]?interview/i.test(relativePath)) return "path matches deep-interview workflow surface";
+	if (/skill|workflow|runtime|state/i.test(relativePath)) return "path matches workflow/runtime surface";
+	return undefined;
+}
+
+async function readPackageHints(cwd: string): Promise<string[]> {
+	const packagePath = path.join(cwd, "package.json");
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(await fs.readFile(packagePath, "utf-8"));
+	} catch {
+		return [];
+	}
+	const manifest = parsed as {
+		name?: unknown;
+		workspaces?: unknown;
+		scripts?: Record<string, unknown>;
+		dependencies?: Record<string, unknown>;
+		devDependencies?: Record<string, unknown>;
+	};
+	const hints: string[] = [];
+	if (typeof manifest.name === "string") hints.push(`package: ${manifest.name}`);
+	if (manifest.workspaces) hints.push("workspace: package.json declares workspaces");
+	const scripts = Object.keys(manifest.scripts ?? {}).slice(0, TRACE_MAX_PACKAGE_HINTS);
+	if (scripts.length > 0) hints.push(`scripts: ${scripts.join(", ")}`);
+	const deps = [...Object.keys(manifest.dependencies ?? {}), ...Object.keys(manifest.devDependencies ?? {})]
+		.filter(name => /typescript|bun|react|vite|zod|winston|commander|oclif/i.test(name))
+		.slice(0, TRACE_MAX_PACKAGE_HINTS);
+	if (deps.length > 0) hints.push(`notable dependencies: ${deps.join(", ")}`);
+	return hints.slice(0, TRACE_MAX_PACKAGE_HINTS);
+}
+
+async function collectRelevantTracePaths(
+	cwd: string,
+	terms: readonly string[],
+): Promise<Array<{ path: string; reason: string }>> {
+	const results: Array<{ path: string; reason: string; score: number }> = [];
+	const pending: Array<{ absolutePath: string; depth: number }> = [{ absolutePath: cwd, depth: 0 }];
+	let visitedDirectories = 0;
+	let visitedEntries = 0;
+	while (
+		pending.length > 0 &&
+		visitedDirectories < TRACE_MAX_DIRECTORY_VISITS &&
+		visitedEntries < TRACE_MAX_ENTRY_VISITS
+	) {
+		const current = pending.shift();
+		if (!current) break;
+		visitedDirectories += 1;
+		try {
+			const directory = await fs.opendir(current.absolutePath);
+			for await (const entry of directory) {
+				visitedEntries += 1;
+				if (visitedEntries > TRACE_MAX_ENTRY_VISITS) break;
+				if (TRACE_SKIP_DIRS.has(entry.name)) continue;
+				const absolutePath = path.join(current.absolutePath, entry.name);
+				const relativePath = path.relative(cwd, absolutePath).split(path.sep).join("/");
+				if (entry.isDirectory()) {
+					if (current.depth < 6 && pending.length < TRACE_MAX_PENDING_DIRECTORIES) {
+						pending.push({ absolutePath, depth: current.depth + 1 });
+					}
+					continue;
+				}
+				if (!entry.isFile() || !TRACE_SOURCE_EXTENSIONS.has(path.extname(entry.name))) continue;
+				const reason = relativePathReason(relativePath, terms);
+				if (!reason) continue;
+				const termScore = terms.reduce(
+					(score, term) => score + (relativePath.toLowerCase().includes(term) ? 2 : 0),
+					0,
+				);
+				const surfaceScore = /deep[-_]?interview|skill|workflow|runtime|state/i.test(relativePath) ? 1 : 0;
+				results.push({ path: relativePath, reason, score: termScore + surfaceScore });
+			}
+		} catch {
+			continue;
+		}
+	}
+	return results
+		.sort((a, b) => b.score - a.score || a.path.localeCompare(b.path))
+		.slice(0, TRACE_MAX_RELEVANT_PATHS)
+		.map(({ path: relativePath, reason }) => ({ path: relativePath, reason }));
+}
+
+async function buildDeepInterviewTraceSummary(cwd: string, idea: string): Promise<DeepInterviewTraceSummary> {
+	const terms = traceTerms(idea);
+	const [projectHints, relevantPaths] = await Promise.all([
+		readPackageHints(cwd),
+		collectRelevantTracePaths(cwd, terms),
+	]);
+	const findings = [
+		projectHints.length > 0
+			? "Project manifest was summarized into bounded package/script/dependency hints."
+			: "No readable package.json manifest was found at the project root.",
+		relevantPaths.length > 0
+			? `Relevant path scan captured ${relevantPaths.length} bounded path hint(s) before interview questions.`
+			: "Relevant path scan found no matching source/documentation paths before interview questions.",
+		"Trace summary intentionally stores path-level evidence only; raw files and logs are excluded.",
+	];
+	return {
+		enabled: true,
+		generated_at: new Date().toISOString(),
+		bounded: true,
+		limits: {
+			max_relevant_paths: TRACE_MAX_RELEVANT_PATHS,
+			max_package_hints: TRACE_MAX_PACKAGE_HINTS,
+			max_directory_visits: TRACE_MAX_DIRECTORY_VISITS,
+			max_entry_visits: TRACE_MAX_ENTRY_VISITS,
+			max_pending_directories: TRACE_MAX_PENDING_DIRECTORIES,
+		},
+		idea_terms: terms,
+		project_hints: projectHints,
+		relevant_paths: relevantPaths,
+		findings,
+	};
+}
+
 interface ResolvedDeepInterviewArgs {
 	resolution: DeepInterviewResolution;
 	threshold: number;
@@ -114,6 +307,7 @@ interface ResolvedDeepInterviewArgs {
 	sessionId: string;
 	idea: string;
 	language?: DeepInterviewLanguagePreference;
+	trace?: DeepInterviewTraceSummary;
 	json: boolean;
 }
 
@@ -199,7 +393,7 @@ async function readModernSettingsAmbiguityThreshold(): Promise<{ threshold: numb
 	const modernConfigPath = modernSettingsPath();
 	let parsed: unknown;
 	try {
-		parsed = (await import("bun")).YAML.parse(await fs.readFile(modernConfigPath, "utf-8"));
+		parsed = YAML.parse(await fs.readFile(modernConfigPath, "utf-8"));
 	} catch {
 		return undefined;
 	}
@@ -371,6 +565,7 @@ async function resolveDeepInterviewArgs(args: readonly string[], cwd: string): P
 			skipNext = true;
 			continue;
 		}
+		if (arg === "--trace") continue;
 		if (arg === "--quick" || arg === "--standard" || arg === "--deep" || arg === "--json") continue;
 		if (arg.startsWith("-")) {
 			throw new DeepInterviewCommandError(2, `unknown flag for gjc deep-interview: ${arg}`);
@@ -379,6 +574,7 @@ async function resolveDeepInterviewArgs(args: readonly string[], cwd: string): P
 	}
 	const idea = ideaParts.join(" ").trim();
 	const effectiveResolution: DeepInterviewResolution = resolution ?? "standard";
+	const trace = hasFlag(args, "--trace") && idea ? await buildDeepInterviewTraceSummary(cwd, idea) : undefined;
 	return {
 		resolution: effectiveResolution,
 		threshold,
@@ -386,6 +582,7 @@ async function resolveDeepInterviewArgs(args: readonly string[], cwd: string): P
 		sessionId,
 		idea,
 		language: resolveDeepInterviewLanguagePreference(idea),
+		trace,
 		json: hasFlag(args, "--json"),
 	};
 }
@@ -507,6 +704,17 @@ async function seedDeepInterviewState(cwd: string, resolved: ResolvedDeepIntervi
 		},
 		updated_at: now,
 	};
+	if (resolved.trace) {
+		payload.trace = resolved.trace;
+		(payload.state as Record<string, unknown>).trace = resolved.trace;
+		(payload.state as Record<string, unknown>).trace_summary = resolved.trace;
+		(payload.state as Record<string, unknown>).codebase_context = {
+			source: "trace",
+			summary: resolved.trace.findings,
+			relevant_paths: resolved.trace.relevant_paths,
+			project_hints: resolved.trace.project_hints,
+		};
+	}
 	if (resolved.language) {
 		payload.language = resolved.language;
 		(payload.state as Record<string, unknown>).language = resolved.language;
@@ -646,6 +854,7 @@ export async function runNativeDeepInterviewCommand(
 			threshold_source: resolved.thresholdSource,
 			idea: resolved.idea,
 			language: resolved.language,
+			trace: resolved.trace,
 			state_path: statePath,
 			handoff: "/skill:deep-interview",
 		};
@@ -654,6 +863,7 @@ export async function runNativeDeepInterviewCommand(
 			: [
 					`deep-interview seed state_path=${statePath}`,
 					`resolution=${resolved.resolution} threshold=${resolved.threshold} threshold_source=${resolved.thresholdSource}`,
+					resolved.trace ? `trace=enabled bounded_paths=${resolved.trace.relevant_paths.length}` : undefined,
 					"handoff=/skill:deep-interview",
 					"",
 				].join("\n");

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts
@@ -62,6 +62,7 @@ describe("native gjc deep-interview runtime", () => {
 		expect(source).toContain("slug: Flags.string");
 		expect(source).toContain("spec: Flags.string");
 		expect(source).toContain("deliberate: Flags.boolean");
+		expect(source).toContain("trace: Flags.boolean");
 		expect(source).toContain("handoff: Flags.string");
 	});
 
@@ -272,6 +273,84 @@ describe("native gjc deep-interview runtime", () => {
 		expect(state.threshold_source).toBe("default");
 		expect(state.state.initial_idea).toBe("my vague idea");
 		expect(state.state.established_facts).toEqual([]);
+	});
+
+	it("runs an optional bounded trace pre-step before deep-interview questions", async () => {
+		const root = await tempDir();
+		await fs.mkdir(path.join(root, "packages/coding-agent/src/gjc-runtime"), { recursive: true });
+		await fs.writeFile(
+			path.join(root, "package.json"),
+			JSON.stringify({ name: "trace-fixture", scripts: { test: "bun test", check: "bun check" } }),
+		);
+		await fs.writeFile(
+			path.join(root, "packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts"),
+			"raw content must not be copied into the trace summary\n".repeat(200),
+		);
+
+		const result = await runNativeDeepInterviewCommand(
+			["--trace", "--json", "Add trace pre-skill option to deep-interview"],
+			root,
+		);
+
+		expect(result.status).toBe(0);
+		const payload = JSON.parse(result.stdout ?? "{}");
+		expect(payload.trace).toMatchObject({ enabled: true, bounded: true });
+		expect(payload.trace.relevant_paths.length).toBeLessThanOrEqual(12);
+		expect(
+			payload.trace.relevant_paths.some((entry: { path: string }) =>
+				entry.path.includes("deep-interview-runtime.ts"),
+			),
+		).toBe(true);
+
+		const state = JSON.parse(await fs.readFile(modeStatePath(root, TEST_SESSION_ID, "deep-interview"), "utf-8"));
+		expect(state.state.rounds).toEqual([]);
+		expect(state.state.trace_summary).toEqual(payload.trace);
+		expect(state.state.codebase_context).toMatchObject({ source: "trace" });
+		expect(JSON.stringify(state.state.trace_summary)).not.toContain("raw content must not be copied");
+	});
+
+	it("keeps trace path scanning on a hard budget and skips heavy directories", async () => {
+		const root = await tempDir();
+		await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "trace-budget-fixture" }));
+		await fs.mkdir(path.join(root, "vendor", "deep-interview"), { recursive: true });
+		await fs.writeFile(path.join(root, "vendor", "deep-interview", "secret-token.ts"), "token should not be listed");
+		await fs.mkdir(path.join(root, "target", "deep-interview"), { recursive: true });
+		await fs.writeFile(path.join(root, "target", "deep-interview", "generated.ts"), "generated should not be listed");
+		for (let index = 0; index < 80; index += 1) {
+			await fs.mkdir(path.join(root, `src-${index}`), { recursive: true });
+			await fs.writeFile(path.join(root, `src-${index}`, `deep-interview-${index}.ts`), "bounded path hint only");
+		}
+
+		const result = await runNativeDeepInterviewCommand(["--trace", "--json", "deep interview budget"], root);
+
+		expect(result.status).toBe(0);
+		const payload = JSON.parse(result.stdout ?? "{}");
+		expect(payload.trace.limits).toMatchObject({
+			max_directory_visits: 1200,
+			max_entry_visits: 5000,
+			max_pending_directories: 1200,
+		});
+		expect(payload.trace.relevant_paths.length).toBeLessThanOrEqual(12);
+		expect(payload.trace.relevant_paths.map((entry: { path: string }) => entry.path)).not.toContain(
+			"vendor/deep-interview/secret-token.ts",
+		);
+		expect(payload.trace.relevant_paths.map((entry: { path: string }) => entry.path)).not.toContain(
+			"target/deep-interview/generated.ts",
+		);
+	});
+
+	it("keeps the normal no-trace deep-interview seed path unchanged", async () => {
+		const root = await tempDir();
+		const result = await runNativeDeepInterviewCommand(["--json", "my vague idea"], root);
+		expect(result.status).toBe(0);
+		const payload = JSON.parse(result.stdout ?? "{}");
+		expect(payload.trace).toBeUndefined();
+
+		const state = JSON.parse(await fs.readFile(modeStatePath(root, TEST_SESSION_ID, "deep-interview"), "utf-8"));
+		expect(state.trace).toBeUndefined();
+		expect(state.state.trace).toBeUndefined();
+		expect(state.state.trace_summary).toBeUndefined();
+		expect(state.state.codebase_context).toBeUndefined();
 	});
 
 	it("honors gjc.deepInterview.ambiguityThreshold in project .gjc/settings.json", async () => {


### PR DESCRIPTION
## Summary
- add `--trace` to native deep-interview seeding
- run a bounded path/package evidence pre-step before interview state is written
- expose compact trace/codebase context in deep-interview state and update SKILL guidance
- add regression coverage proving trace-before-interview and unchanged no-trace behavior

## Testing
- `git diff --check dev...HEAD && git diff --check`
- `bun test packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts`
- `bun --cwd=packages/coding-agent run check`

Closes #1551

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*