### PR TITLE
Allow reordering queued messages

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Agent queues now expose ordered move helpers for steering and follow-up messages so callers can reorder pending work without removing and re-adding messages.
 
 ## [0.7.7] - 2026-06-28
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -960,6 +960,10 @@ export class Agent {
 		return removed;
 	}
 
+	moveSteer(fromIndex: number, toIndex: number): boolean {
+		return this.#moveQueuedMessage(this.#steeringQueue, fromIndex, toIndex);
+	}
+
 	/**
 	 * Remove and return the last follow-up message from the queue (LIFO).
 	 * Used by dequeue keybinding.
@@ -971,6 +975,20 @@ export class Agent {
 		if (index < 0 || index >= this.#followUpQueue.length) return undefined;
 		const [removed] = this.#followUpQueue.splice(index, 1);
 		return removed;
+	}
+
+	moveFollowUp(fromIndex: number, toIndex: number): boolean {
+		return this.#moveQueuedMessage(this.#followUpQueue, fromIndex, toIndex);
+	}
+
+	#moveQueuedMessage<T>(queue: T[], fromIndex: number, toIndex: number): boolean {
+		if (fromIndex < 0 || fromIndex >= queue.length) return false;
+		if (toIndex < 0 || toIndex >= queue.length) return false;
+		if (fromIndex === toIndex) return true;
+		const [item] = queue.splice(fromIndex, 1);
+		if (item === undefined) return false;
+		queue.splice(toIndex, 0, item);
+		return true;
 	}
 
 	/** Remove queued steering+follow-up messages matching `predicate`, preserving order of the rest. */

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Queued message selector entries can now be reordered with `Ctrl+Up` / `Ctrl+Down`, with `Ctrl+Shift+Up` / `Ctrl+Shift+Down` still accepted when the terminal forwards them, while keeping the current draft intact.
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/components/queued-message-selector.ts
+++ b/packages/coding-agent/src/modes/components/queued-message-selector.ts
@@ -6,23 +6,29 @@ import { DynamicBorder } from "./dynamic-border";
 const MAX_VISIBLE_QUEUED_MESSAGES = 8;
 const RAW_UP = "\x1b[A";
 const RAW_DOWN = "\x1b[B";
+type QueuedMessageMoveDirection = "up" | "down";
+
+export type { QueuedMessageMoveDirection };
 
 export class QueuedMessageSelectorComponent extends Container {
 	#selectList: SelectList;
 	#selectedEntry: QueuedMessageEditEntry | undefined;
 	#selectedIndex = 0;
 	#onDelete: (entry: QueuedMessageEditEntry, selectedIndex: number) => void;
+	#onMove: (entry: QueuedMessageEditEntry, selectedIndex: number, direction: QueuedMessageMoveDirection) => void;
 
 	constructor(
 		entries: QueuedMessageEditEntry[],
 		onSelect: (entry: QueuedMessageEditEntry) => void,
 		onDelete: (entry: QueuedMessageEditEntry, selectedIndex: number) => void,
+		onMove: (entry: QueuedMessageEditEntry, selectedIndex: number, direction: QueuedMessageMoveDirection) => void,
 		onCancel: () => void,
 		options?: { selectedIndex?: number },
 	) {
 		super();
 
 		this.#onDelete = onDelete;
+		this.#onMove = onMove;
 		const byId = new Map(entries.map(entry => [entry.id, entry]));
 		this.#selectedIndex = Math.max(0, Math.min(options?.selectedIndex ?? 0, entries.length - 1));
 		this.#selectedEntry = entries[this.#selectedIndex];
@@ -30,12 +36,12 @@ export class QueuedMessageSelectorComponent extends Container {
 			value: entry.id,
 			label: `${entry.label} ${index + 1}`,
 			description: entry.text,
-			hint: "Enter edit · Del remove",
+			hint: "Enter edit · Del remove · Ctrl+↑/↓ move",
 		}));
 
 		this.addChild(new Spacer(1));
 		this.addChild(new Text(theme.bold("Queued messages"), 1, 0));
-		this.addChild(new Text(theme.fg("muted", "Enter to edit · Delete to remove · Esc to cancel"), 1, 0));
+		this.addChild(new Text(theme.fg("muted", "Enter edit · Del remove · Ctrl+↑/↓ move · Esc cancel"), 1, 0));
 		this.addChild(new Spacer(1));
 		this.addChild(new DynamicBorder());
 
@@ -63,6 +69,14 @@ export class QueuedMessageSelectorComponent extends Container {
 		}
 		if (matchesKey(keyData, "alt+down")) {
 			this.#selectList.handleInput(RAW_DOWN);
+			return;
+		}
+		if (matchesKey(keyData, "ctrl+up") || matchesKey(keyData, "ctrl+shift+up")) {
+			if (this.#selectedEntry) this.#onMove(this.#selectedEntry, this.#selectedIndex, "up");
+			return;
+		}
+		if (matchesKey(keyData, "ctrl+down") || matchesKey(keyData, "ctrl+shift+down")) {
+			if (this.#selectedEntry) this.#onMove(this.#selectedEntry, this.#selectedIndex, "down");
 			return;
 		}
 		if (matchesKey(keyData, "delete")) {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -19,7 +19,7 @@ import { getEditorCommand, openInEditor } from "../../utils/external-editor";
 import { ensureSupportedImageInput, ImageInputTooLargeError, loadImageInput } from "../../utils/image-loading";
 import { resizeImage } from "../../utils/image-resize";
 import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
-import { QueuedMessageSelectorComponent } from "../components/queued-message-selector";
+import { type QueuedMessageMoveDirection, QueuedMessageSelectorComponent } from "../components/queued-message-selector";
 
 interface Expandable {
 	setExpanded(expanded: boolean): void;
@@ -621,7 +621,7 @@ export class InputController {
 			);
 			return;
 		}
-		this.#showQueuedMessageSelector(entries);
+		this.#showQueuedMessageSelector(entries, this.#newestQueuedMessageIndex(entries));
 	}
 
 	#compactionQueuedMessageId(index: number): string {
@@ -629,18 +629,36 @@ export class InputController {
 	}
 
 	#getEditableQueuedMessages(): QueuedMessageEditEntry[] {
-		const compactionEntries = this.ctx.compactionQueuedMessages
-			.map((entry, index): QueuedMessageEditEntry => {
-				const label = entry.mode === "steer" ? "Steer" : "Queued";
-				return {
-					id: this.#compactionQueuedMessageId(index),
-					text: entry.text,
-					mode: entry.mode,
-					label,
-				};
-			})
-			.reverse();
+		const compactionEntries = this.ctx.compactionQueuedMessages.map((entry, index): QueuedMessageEditEntry => {
+			const label = entry.mode === "steer" ? "Steer" : "Queued";
+			return {
+				id: this.#compactionQueuedMessageId(index),
+				text: entry.text,
+				mode: entry.mode,
+				label,
+			};
+		});
 		return [...compactionEntries, ...this.ctx.session.getQueuedMessageEntries()];
+	}
+
+	#queuedMessageStableSequence(entry: QueuedMessageEditEntry): number | undefined {
+		const [mode, sequenceText] = entry.id.split(":");
+		if ((mode !== "steer" && mode !== "followUp") || sequenceText === undefined) return undefined;
+		const sequence = Number(sequenceText);
+		return Number.isInteger(sequence) ? sequence : undefined;
+	}
+
+	#newestQueuedMessageIndex(entries: QueuedMessageEditEntry[]): number {
+		let selectedIndex = entries.length - 1;
+		let newestSequence = Number.NEGATIVE_INFINITY;
+		for (let index = 0; index < entries.length; index += 1) {
+			const sequence = this.#queuedMessageStableSequence(entries[index]);
+			if (sequence !== undefined && sequence > newestSequence) {
+				newestSequence = sequence;
+				selectedIndex = index;
+			}
+		}
+		return Math.max(0, selectedIndex);
 	}
 
 	#restoreEditorFocus(): void {
@@ -672,6 +690,23 @@ export class InputController {
 				this.ctx.showStatus(deleted ? "Deleted queued message" : "Queued message is no longer available");
 				this.#showQueuedMessageSelector(nextEntries, Math.min(index, nextEntries.length - 1));
 			},
+			(entry, index, direction) => {
+				const moved = this.#moveQueuedMessage(entry, direction);
+				const nextEntries = this.#getEditableQueuedMessages();
+				if (nextEntries.length === 0) {
+					this.#restoreEditorFocus();
+					this.ctx.showStatus("Queued message is no longer available");
+					this.ctx.ui.requestRender();
+					return;
+				}
+				const nextIndex = direction === "up" ? index - 1 : index + 1;
+				const selectedNextIndex = moved ? nextIndex : index;
+				this.ctx.showStatus(moved ? "Moved queued message" : "Queued message cannot move further");
+				this.#showQueuedMessageSelector(
+					nextEntries,
+					Math.max(0, Math.min(selectedNextIndex, nextEntries.length - 1)),
+				);
+			},
 			() => {
 				this.#restoreEditorFocus();
 				this.ctx.ui.requestRender();
@@ -693,6 +728,37 @@ export class InputController {
 			return entry?.text;
 		}
 		return this.ctx.session.removeQueuedMessageForEditing(id);
+	}
+	#parseCompactionQueuedMessageId(id: string): number | undefined {
+		const compactionPrefix = "compaction:";
+		if (!id.startsWith(compactionPrefix)) return undefined;
+		const index = Number(id.slice(compactionPrefix.length));
+		return Number.isInteger(index) ? index : undefined;
+	}
+
+	#moveCompactionQueuedMessage(index: number, direction: QueuedMessageMoveDirection): boolean {
+		const targetIndex = direction === "up" ? index - 1 : index + 1;
+		if (index < 0 || index >= this.ctx.compactionQueuedMessages.length) return false;
+		if (targetIndex < 0 || targetIndex >= this.ctx.compactionQueuedMessages.length) return false;
+		const current = this.ctx.compactionQueuedMessages[index];
+		const target = this.ctx.compactionQueuedMessages[targetIndex];
+		if (!current || !target) return false;
+		this.ctx.compactionQueuedMessages[index] = target;
+		this.ctx.compactionQueuedMessages[targetIndex] = current;
+		this.ctx.updatePendingMessagesDisplay();
+		return true;
+	}
+
+	#moveQueuedMessage(entry: QueuedMessageEditEntry, direction: QueuedMessageMoveDirection): boolean {
+		const compactionIndex = this.#parseCompactionQueuedMessageId(entry.id);
+		if (compactionIndex !== undefined) {
+			return this.#moveCompactionQueuedMessage(compactionIndex, direction);
+		}
+		const moved = this.ctx.session.moveQueuedMessageForEditing(entry.id, direction);
+		if (moved) {
+			this.ctx.updatePendingMessagesDisplay();
+		}
+		return moved;
 	}
 
 	#deleteQueuedMessage(entry: QueuedMessageEditEntry): boolean {

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -600,7 +600,7 @@ export class UiHelpers {
 				this.ctx.pendingMessagesContainer.addChild(new TruncatedText(queuedText, 1, 0));
 			}
 			const dequeueKey = this.ctx.keybindings.getDisplayString("app.message.dequeue") || "Alt+Up/Alt+Down";
-			const hintText = theme.fg("dim", `${theme.tree.hook} ${dequeueKey} to select/edit`);
+			const hintText = theme.fg("dim", `${theme.tree.hook} ${dequeueKey} to select/edit/reorder`);
 			this.ctx.pendingMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
 		}
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -905,8 +905,8 @@ function extractPermissionLocations(
  *  `tag` is set only by `enqueueCustomMessageDisplay` (used for skill-prompt
  *  custom messages queued during streaming) and is matched by the custom-role
  *  `message_start` dequeue branch; user-message pushes leave it undefined and
- *  rely on the existing text-equality match. `sequence` preserves cross-queue
- *  insertion order for one-at-a-time dequeue/edit UX. */
+ *  rely on the existing text-equality match. `sequence` gives each queued chip a
+ *  stable edit id while the display arrays preserve delivery order. */
 type QueuedDisplayEntry = { text: string; tag?: string; sequence: number };
 export type QueuedMessageEditMode = "steer" | "followUp";
 
@@ -5736,14 +5736,13 @@ export class AgentSession {
 	}
 
 	getQueuedMessageEntries(): QueuedMessageEditEntry[] {
-		const entries: Array<QueuedMessageEditEntry & { sequence: number }> = [];
+		const entries: QueuedMessageEditEntry[] = [];
 		for (const entry of this.#steeringMessages) {
 			entries.push({
 				id: this.#queuedMessageEditId("steer", entry.sequence),
 				text: entry.text,
 				mode: "steer",
 				label: "Steer",
-				sequence: entry.sequence,
 			});
 		}
 		for (const entry of this.#followUpMessages) {
@@ -5752,12 +5751,9 @@ export class AgentSession {
 				text: entry.text,
 				mode: "followUp",
 				label: "Queued",
-				sequence: entry.sequence,
 			});
 		}
-		return entries
-			.sort((a, b) => b.sequence - a.sequence)
-			.map(({ id, text, mode, label }) => ({ id, text, mode, label }));
+		return entries;
 	}
 
 	removeQueuedMessageForEditing(id: string): string | undefined {
@@ -5777,6 +5773,32 @@ export class AgentSession {
 			this.agent.removeFollowUpAt(index);
 		}
 		return entry?.text;
+	}
+
+	moveQueuedMessageForEditing(id: string, direction: "up" | "down"): boolean {
+		const [mode, sequenceText] = id.split(":");
+		if ((mode !== "steer" && mode !== "followUp") || sequenceText === undefined) return false;
+		const sequence = Number(sequenceText);
+		if (!Number.isInteger(sequence)) return false;
+
+		const queue = mode === "steer" ? this.#steeringMessages : this.#followUpMessages;
+		const fromIndex = queue.findIndex(entry => entry.sequence === sequence);
+		if (fromIndex === -1) return false;
+		const toIndex = direction === "up" ? fromIndex - 1 : fromIndex + 1;
+		const agentMoved =
+			mode === "steer" ? this.agent.moveSteer(fromIndex, toIndex) : this.agent.moveFollowUp(fromIndex, toIndex);
+		if (!agentMoved) return false;
+		return this.#moveQueuedDisplayEntry(queue, fromIndex, toIndex);
+	}
+
+	#moveQueuedDisplayEntry(queue: QueuedDisplayEntry[], fromIndex: number, toIndex: number): boolean {
+		if (fromIndex < 0 || fromIndex >= queue.length) return false;
+		if (toIndex < 0 || toIndex >= queue.length) return false;
+		if (fromIndex === toIndex) return true;
+		const [entry] = queue.splice(fromIndex, 1);
+		if (!entry) return false;
+		queue.splice(toIndex, 0, entry);
+		return true;
 	}
 
 	/**

--- a/packages/coding-agent/test/agent-session-queued-prompts.test.ts
+++ b/packages/coding-agent/test/agent-session-queued-prompts.test.ts
@@ -167,7 +167,7 @@ describe("AgentSession queued prompts (issue #434)", () => {
 		await session.prompt("queue newest", { streamingBehavior: "followUp" });
 
 		const entries = session.getQueuedMessageEntries();
-		expect(entries.map(entry => entry.text)).toEqual(["queue newest", "queue older", "steer me"]);
+		expect(entries.map(entry => entry.text)).toEqual(["steer me", "queue older", "queue newest"]);
 		const removed = session.removeQueuedMessageForEditing(entries[1]?.id ?? "");
 
 		expect(removed).toBe("queue older");
@@ -179,5 +179,34 @@ describe("AgentSession queued prompts (issue #434)", () => {
 		await session.waitForIdle();
 
 		expect(userTexts(session)).toEqual(["p1", "steer me", "queue newest"]);
+	});
+
+	it("reorders queued follow-up prompts selected for editing", async () => {
+		const gate = Promise.withResolvers<void>();
+		session = buildSession([
+			async () => {
+				await gate.promise;
+				return { content: ["turn 1"] };
+			},
+			{ content: ["after moved queue"] },
+			{ content: ["after remaining queue"] },
+		]);
+
+		const first = session.prompt("p1");
+		await waitUntil(() => session!.isStreaming);
+
+		await session.prompt("queue older", { streamingBehavior: "followUp" });
+		await session.prompt("queue newest", { streamingBehavior: "followUp" });
+
+		const entries = session.getQueuedMessageEntries();
+		expect(entries.map(entry => entry.text)).toEqual(["queue older", "queue newest"]);
+		expect(session.moveQueuedMessageForEditing(entries[1]?.id ?? "", "up")).toBe(true);
+		expect(session.getQueuedMessages().followUp).toEqual(["queue newest", "queue older"]);
+
+		gate.resolve();
+		await first;
+		await session.waitForIdle();
+
+		expect(userTexts(session)).toEqual(["p1", "queue newest", "queue older"]);
 	});
 });

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -67,16 +67,14 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 	});
 	const popLastQueuedMessage = vi.fn(() => sessionQueuedMessages.pop());
 	const getQueuedMessageEntries = vi.fn(() =>
-		sessionQueuedMessages
-			.map(
-				(text, index): QueuedMessageEditEntry => ({
-					id: `followUp:${index}`,
-					text,
-					mode: "followUp",
-					label: "Queued",
-				}),
-			)
-			.reverse(),
+		sessionQueuedMessages.map(
+			(text, index): QueuedMessageEditEntry => ({
+				id: `followUp:${index}`,
+				text,
+				mode: "followUp",
+				label: "Queued",
+			}),
+		),
 	);
 	const removeQueuedMessageForEditing = vi.fn((id: string) => {
 		const [mode, indexText] = id.split(":");
@@ -85,6 +83,19 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 		if (!Number.isInteger(index)) return undefined;
 		const [removed] = sessionQueuedMessages.splice(index, 1);
 		return removed;
+	});
+	const moveQueuedMessageForEditing = vi.fn((id: string, direction: "up" | "down") => {
+		const [mode, indexText] = id.split(":");
+		if (mode !== "followUp" || indexText === undefined) return false;
+		const index = Number(indexText);
+		if (!Number.isInteger(index)) return false;
+		const targetIndex = direction === "up" ? index - 1 : index + 1;
+		if (index < 0 || index >= sessionQueuedMessages.length) return false;
+		if (targetIndex < 0 || targetIndex >= sessionQueuedMessages.length) return false;
+		const [entry] = sessionQueuedMessages.splice(index, 1);
+		if (entry === undefined) return false;
+		sessionQueuedMessages.splice(targetIndex, 0, entry);
+		return true;
 	});
 	const clearQueue = vi.fn(() => {
 		const followUp = [...sessionQueuedMessages];
@@ -138,6 +149,7 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 			getQueuedMessages: () => ({ steering: [], followUp: [...sessionQueuedMessages] }),
 			getQueuedMessageEntries,
 			removeQueuedMessageForEditing,
+			moveQueuedMessageForEditing,
 		} as unknown as InteractiveModeContext["session"],
 		keybindings: {
 			getKeys(action: string) {
@@ -224,6 +236,7 @@ async function createContext(options?: { busyPromptMode?: "steer" | "queue"; fol
 			clearQueue,
 			getQueuedMessageEntries,
 			removeQueuedMessageForEditing,
+			moveQueuedMessageForEditing,
 		},
 		queues: {
 			compactionQueuedMessages,
@@ -414,7 +427,7 @@ describe("InputController keybinding setup", () => {
 			throw new Error("Expected queued message selector to be shown");
 		}
 		expect(editor.getText()).toBe("current draft");
-		selector.getSelectList().setSelectedIndex(1);
+		selector.getSelectList().setSelectedIndex(0);
 		selector.getSelectList().handleInput("\n");
 
 		expect(editor.getText()).toBe("older session queue");
@@ -443,6 +456,83 @@ describe("InputController keybinding setup", () => {
 		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 		expect(spies.showStatus).toHaveBeenCalledWith("Deleted queued message");
 		expect(queues.editorContainerChildren[0]).toBeInstanceOf(QueuedMessageSelectorComponent);
+	});
+
+	it("opens the selector focused on the newest queued message across queue types", async () => {
+		const { InputController, ctx, editor, spies, queues } = await createContext();
+		spies.getQueuedMessageEntries.mockReturnValue([
+			{
+				id: "steer:2",
+				text: "newer steer",
+				mode: "steer",
+				label: "Steer",
+			},
+			{
+				id: "followUp:1",
+				text: "older follow-up",
+				mode: "followUp",
+				label: "Queued",
+			},
+		]);
+		spies.removeQueuedMessageForEditing.mockImplementation(id => {
+			if (id === "steer:2") return "newer steer";
+			if (id === "followUp:1") return "older follow-up";
+			return undefined;
+		});
+		editor.setText("current draft");
+		const controller = new InputController(ctx);
+
+		controller.handleDequeue();
+
+		const selector = queues.editorContainerChildren[0];
+		if (!(selector instanceof QueuedMessageSelectorComponent)) {
+			throw new Error("Expected queued message selector to be shown");
+		}
+		selector.getSelectList().handleInput("\n");
+
+		expect(editor.getText()).toBe("newer steer");
+		expect(spies.removeQueuedMessageForEditing).toHaveBeenCalledWith("steer:2");
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("moves the selected queued message from the selector", async () => {
+		const { InputController, ctx, editor, spies, queues } = await createContext();
+		queues.sessionQueuedMessages.push("first session queue", "second session queue", "third session queue");
+		editor.setText("current draft");
+		const controller = new InputController(ctx);
+
+		controller.handleDequeue();
+
+		const selector = queues.editorContainerChildren[0];
+		if (!(selector instanceof QueuedMessageSelectorComponent)) {
+			throw new Error("Expected queued message selector to be shown");
+		}
+		selector.handleInput("\x1b[1;6A");
+
+		expect(editor.getText()).toBe("current draft");
+		expect(queues.sessionQueuedMessages).toEqual([
+			"first session queue",
+			"third session queue",
+			"second session queue",
+		]);
+		expect(spies.moveQueuedMessageForEditing).toHaveBeenCalledWith("followUp:2", "up");
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+		expect(spies.showStatus).toHaveBeenCalledWith("Moved queued message");
+
+		const nextSelector = queues.editorContainerChildren[0];
+		if (!(nextSelector instanceof QueuedMessageSelectorComponent)) {
+			throw new Error("Expected queued message selector to remain shown");
+		}
+		nextSelector.handleInput("\x1b[1;5B");
+
+		expect(queues.sessionQueuedMessages).toEqual([
+			"first session queue",
+			"second session queue",
+			"third session queue",
+		]);
+		expect(spies.moveQueuedMessageForEditing).toHaveBeenLastCalledWith("followUp:1", "down");
+		expect(spies.updatePendingMessagesDisplay).toHaveBeenCalledTimes(2);
+		expect(spies.showStatus).toHaveBeenLastCalledWith("Moved queued message");
 	});
 
 	it("steers streaming Enter submissions by default", async () => {


### PR DESCRIPTION
## Summary
- Add Ctrl+Shift+Up/Down handling to the queued-message selector so selected queued prompts can be reordered without touching the current composer draft.
- Keep the session display queues and underlying agent steering/follow-up queues in sync when moving entries.
- Update queued-message hints and add focused regressions for selector movement and delivery order.

## Verification
- bun --cwd=packages/agent run check
- bun --cwd=packages/coding-agent run check
- bun test packages/coding-agent/test/input-controller-keybindings.test.ts -t "opens a selector|deletes the selected|moves the selected queued message"
- bun test packages/coding-agent/test/agent-session-queued-prompts.test.ts -t "removes an arbitrary"
- bun test packages/coding-agent/test/agent-session-queued-prompts.test.ts -t "reorders queued"
- git diff --check