### PR TITLE
fix: stale usage cache and Claude effort selection

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped stale usage-cache snapshots from poisoning Codex/Anthropic credential rotation: reports older than the routing freshness window no longer block or demote credentials, past-reset exhausted windows are ignored for routing, and expired last-good usage reports are retired instead of being resurrected after repeated probe failures.
+
 ## [0.7.9] - 2026-07-01
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -432,6 +432,9 @@ const USAGE_CACHE_PREFIX = "usage_cache:";
 // data (5h / 7d / monthly limits) is fine being a few minutes stale.
 const USAGE_REPORT_TTL_MS = 5 * 60_000;
 const USAGE_LAST_GOOD_RETENTION_MS = 24 * 60 * 60_000;
+// Usage older than the display TTL can still render, but it must not drive
+// credential routing.
+const USAGE_ROUTING_MAX_AGE_MS = 15 * 60_000;
 /**
  * Per-credential cool-down after a usage fetch fails. While this window is
  * active we serve the last successful value to avoid dropping the credential
@@ -655,6 +658,8 @@ class AuthStorageUsageCache implements UsageCache {
 		return parseUsageCacheEntry<T>(raw);
 	}
 
+	// Row expiry is advisory because `getStale` intentionally reads expired rows;
+	// `#fetchUsageCached` enforces the last-good retention window on read.
 	set<T>(key: string, entry: UsageCacheEntry<T>): void {
 		const payload = JSON.stringify({ value: entry.value, expiresAt: entry.expiresAt });
 		const durableExpiresAt =
@@ -2053,6 +2058,20 @@ export class AuthStorage {
 			// don't write — let the next poll retry.
 			const lastGood = this.#usageCache.getStale<UsageReport | null>(cacheKey)?.value ?? null;
 			if (lastGood !== null) {
+				// `getStale` can read expired rows, so the last-good retention bound is
+				// enforced here before a failed probe can re-serve the value.
+				const fetchedAt = lastGood.fetchedAt;
+				const retired =
+					typeof fetchedAt !== "number" ||
+					!Number.isFinite(fetchedAt) ||
+					Date.now() - fetchedAt > USAGE_LAST_GOOD_RETENTION_MS;
+				if (retired) {
+					this.#usageLogger?.debug("Usage last-good retired (age)", {
+						cacheKey,
+						ageMs: typeof fetchedAt === "number" ? Date.now() - fetchedAt : undefined,
+					});
+					return null;
+				}
 				const backoffJitter = USAGE_FAILURE_BACKOFF_MS * (Math.random() * 0.5 - 0.25);
 				const coolDown = Date.now() + USAGE_FAILURE_BACKOFF_MS + backoffJitter;
 				this.#usageCache.set(cacheKey, { value: lastGood, expiresAt: coolDown });
@@ -2254,6 +2273,58 @@ export class AuthStorage {
 		}
 		if (candidates.length === 0) return undefined;
 		return Math.min(...candidates);
+	}
+
+	/** Age of a usage report in ms; undefined when fetchedAt is missing/non-finite (legacy/corrupt cache row). */
+	#usageAgeMs(report: UsageReport, nowMs: number): number | undefined {
+		const fetchedAt = report.fetchedAt;
+		if (typeof fetchedAt !== "number" || !Number.isFinite(fetchedAt)) return undefined;
+		return nowMs - fetchedAt;
+	}
+
+	/** Freshness gate for usage-driven routing decisions. */
+	#isUsageFreshForRouting(report: UsageReport, nowMs: number): boolean {
+		const ageMs = this.#usageAgeMs(report, nowMs);
+		return ageMs !== undefined && ageMs <= USAGE_ROUTING_MAX_AGE_MS;
+	}
+
+	#usageForRouting(report: UsageReport | null | undefined, nowMs: number): UsageReport | undefined {
+		if (!report || !this.#isUsageFreshForRouting(report, nowMs)) return undefined;
+		return report;
+	}
+
+	#isUsageLimitAuthoritativeForRouting(limit: UsageLimit | undefined, nowMs: number): limit is UsageLimit {
+		if (!limit) return false;
+		if (!this.#isUsageLimitExhausted(limit)) return true;
+		const resetsAt = limit.window?.resetsAt;
+		return !(typeof resetsAt === "number" && Number.isFinite(resetsAt) && resetsAt <= nowMs);
+	}
+
+	#hasOpenAICodexProPlanForRouting(report: UsageReport | null | undefined, nowMs: number): boolean {
+		return this.#usageForRouting(report, nowMs) !== undefined && hasOpenAICodexProPlan(report ?? null);
+	}
+
+	/** Routing variant that ignores exhausted windows whose reset already passed. */
+	#isUsageLimitReachedForRouting(report: UsageReport, nowMs: number): boolean {
+		return report.limits.some(
+			limit => this.#isUsageLimitExhausted(limit) && this.#isUsageLimitAuthoritativeForRouting(limit, nowMs),
+		);
+	}
+
+	/** durationMs of the exhausted limit with the earliest future reset — the window the block-extension clamp anchors to. */
+	#exhaustedWindowDurationMs(report: UsageReport, nowMs: number): number | undefined {
+		let bestReset: number | undefined;
+		let bestDuration: number | undefined;
+		for (const limit of report.limits) {
+			if (!this.#isUsageLimitExhausted(limit)) continue;
+			const resetsAt = limit.window?.resetsAt;
+			if (typeof resetsAt !== "number" || !Number.isFinite(resetsAt) || resetsAt <= nowMs) continue;
+			if (bestReset === undefined || resetsAt < bestReset) {
+				bestReset = resetsAt;
+				bestDuration = limit.window?.durationMs;
+			}
+		}
+		return typeof bestDuration === "number" && Number.isFinite(bestDuration) ? bestDuration : undefined;
 	}
 
 	async #getUsageReport(
@@ -2508,12 +2579,26 @@ export class AuthStorage {
 		if (sessionCredential.type === "oauth" && this.#rankingStrategyResolver?.(provider)) {
 			const credential = this.#getCredentialsForProvider(provider)[sessionCredential.index];
 			if (credential?.type === "oauth") {
+				const nowForExtension = Date.now();
 				const report = await this.#getUsageReport(provider, credential, options);
-				if (report && this.#isUsageLimitReached(report)) {
-					const resetAtMs = this.#getUsageResetAtMs(report, Date.now());
+				// Usage can only extend the reactive block when it is fresh and still
+				// points at a current exhausted window.
+				if (
+					report &&
+					this.#isUsageFreshForRouting(report, nowForExtension) &&
+					this.#isUsageLimitReachedForRouting(report, nowForExtension)
+				) {
+					const resetAtMs = this.#getUsageResetAtMs(report, nowForExtension);
 					if (resetAtMs && resetAtMs > blockedUntil) {
-						blockedUntil = resetAtMs;
+						const windowDurationMs = this.#exhaustedWindowDurationMs(report, nowForExtension);
+						const cap = nowForExtension + (windowDurationMs ?? USAGE_ROUTING_MAX_AGE_MS);
+						blockedUntil = Math.min(resetAtMs, cap);
 					}
+				} else if (report && !this.#isUsageFreshForRouting(report, nowForExtension)) {
+					this.#usageLogger?.debug("Block extension rejected: stale usage", {
+						provider,
+						ageMs: this.#usageAgeMs(report, nowForExtension),
+					});
 				}
 			}
 		}
@@ -2590,6 +2675,7 @@ export class AuthStorage {
 			selection: { credential: OAuthCredential; index: number };
 			usage: UsageReport | null;
 			usageChecked: boolean;
+			routingUsage?: UsageReport;
 			blocked: boolean;
 			blockedUntil?: number;
 			hasPriorityBoost: boolean;
@@ -2642,20 +2728,36 @@ export class AuthStorage {
 			const { selection, usage, usageChecked } = result;
 			let { blockedUntil } = result;
 			let blocked = blockedUntil !== undefined;
-			if (!blocked && usage && this.#isUsageLimitReached(usage)) {
-				const resetAtMs = this.#getUsageResetAtMs(usage, nowMs);
+			const usageForRouting = this.#usageForRouting(usage, nowMs);
+			if (!blocked && usageForRouting && this.#isUsageLimitReachedForRouting(usageForRouting, nowMs)) {
+				const resetAtMs = this.#getUsageResetAtMs(usageForRouting, nowMs);
 				blockedUntil = resetAtMs ?? Date.now() + AuthStorage.#defaultBackoffMs;
 				this.#markCredentialBlocked(args.providerKey, selection.index, blockedUntil);
 				blocked = true;
+			} else if (!blocked && usage && !usageForRouting && this.#isUsageLimitReached(usage)) {
+				this.#usageLogger?.debug("Routing ignored stale usage", {
+					provider: args.provider,
+					ageMs: this.#usageAgeMs(usage, nowMs),
+					maxAgeMs: USAGE_ROUTING_MAX_AGE_MS,
+					decision: "not-blocked",
+				});
 			}
-			const windows = usage ? strategy.findWindowLimits(usage) : undefined;
-			const primary = windows?.primary;
-			const secondary = windows?.secondary;
+			// Past-reset exhausted windows are not routing-authoritative.
+			const windows = usageForRouting ? strategy.findWindowLimits(usageForRouting) : undefined;
+			const primaryCandidate = windows?.primary;
+			const secondaryCandidate = windows?.secondary;
+			const primary = this.#isUsageLimitAuthoritativeForRouting(primaryCandidate, nowMs)
+				? primaryCandidate
+				: undefined;
+			const secondary = this.#isUsageLimitAuthoritativeForRouting(secondaryCandidate, nowMs)
+				? secondaryCandidate
+				: undefined;
 			const secondaryTarget = secondary ?? primary;
 			ranked.push({
 				selection,
 				usage,
 				usageChecked,
+				routingUsage: usageForRouting,
 				blocked,
 				blockedUntil,
 				hasPriorityBoost: strategy.hasPriorityBoost?.(primary) ?? false,
@@ -2683,8 +2785,8 @@ export class AuthStorage {
 				return left.orderPos - right.orderPos;
 			}
 			if (requiresOpenAICodexProModel(args.provider, args.options?.modelId)) {
-				const leftPlanPriority = getOpenAICodexPlanPriority(left.usage);
-				const rightPlanPriority = getOpenAICodexPlanPriority(right.usage);
+				const leftPlanPriority = getOpenAICodexPlanPriority(left.routingUsage ?? null);
+				const rightPlanPriority = getOpenAICodexPlanPriority(right.routingUsage ?? null);
 				if (leftPlanPriority !== rightPlanPriority) return leftPlanPriority - rightPlanPriority;
 			}
 			if (left.hasPriorityBoost !== right.hasPriorityBoost) return left.hasPriorityBoost ? -1 : 1;
@@ -2788,8 +2890,10 @@ export class AuthStorage {
 
 		// Skip the Pro-plan filter when no candidate is confirmed Pro, so users with only
 		// non-Pro accounts can still attempt Spark requests (e.g. trial/grandfathered access).
+		const proRequirementNow = Date.now();
 		const enforceProRequirement =
-			requiresProModel && candidates.some(candidate => hasOpenAICodexProPlan(candidate.usage));
+			requiresProModel &&
+			candidates.some(candidate => this.#hasOpenAICodexProPlanForRouting(candidate.usage, proRequirementNow));
 
 		const fallback = candidates[0];
 
@@ -2969,10 +3073,16 @@ export class AuthStorage {
 				});
 				usageChecked = true;
 			}
-			if (applyProFilter && !hasOpenAICodexProPlan(usage)) {
+			if (applyProFilter && !this.#hasOpenAICodexProPlanForRouting(usage, Date.now())) {
 				return undefined;
 			}
-			if (checkUsage && !allowBlocked && usage && this.#isUsageLimitReached(usage)) {
+			if (
+				checkUsage &&
+				!allowBlocked &&
+				usage &&
+				this.#isUsageFreshForRouting(usage, Date.now()) &&
+				this.#isUsageLimitReachedForRouting(usage, Date.now())
+			) {
 				const resetAtMs = this.#getUsageResetAtMs(usage, Date.now());
 				this.#markCredentialBlocked(
 					providerKey,
@@ -3035,10 +3145,16 @@ export class AuthStorage {
 					});
 					usageChecked = true;
 				}
-				if (applyProFilter && !hasOpenAICodexProPlan(usage)) {
+				if (applyProFilter && !this.#hasOpenAICodexProPlanForRouting(usage, Date.now())) {
 					return undefined;
 				}
-				if (checkUsage && !allowBlocked && usage && this.#isUsageLimitReached(usage)) {
+				if (
+					checkUsage &&
+					!allowBlocked &&
+					usage &&
+					this.#isUsageFreshForRouting(usage, Date.now()) &&
+					this.#isUsageLimitReachedForRouting(usage, Date.now())
+				) {
 					const resetAtMs = this.#getUsageResetAtMs(usage, Date.now());
 					this.#markCredentialBlocked(
 						providerKey,

--- a/packages/ai/test/auth-storage-usage-staleness.test.ts
+++ b/packages/ai/test/auth-storage-usage-staleness.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, setSystemTime, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage } from "../src/auth-storage";
+import type { UsageProvider, UsageReport } from "../src/usage";
+import * as oauth from "../src/utils/oauth";
+import type { OAuthCredentials } from "../src/utils/oauth/types";
+
+// Routing-freshness / cache-poisoning regression suite.
+//
+// Guards the fix for the incident where a stale "exhausted" usage snapshot (from a
+// persistently failing /usage probe) sidelined a genuinely healthy credential:
+//   - stale usage must NOT block/deprioritize a credential in routing (freshness gate)
+//   - an exhausted window whose reset is already in the past must NOT block (routing variant)
+//   - a fresh exhausted window with a future reset STILL blocks (legit case preserved)
+//   - past-reset exhausted windows must NOT influence ordering/reset priority
+//   - stale Codex plan metadata must NOT promote/filter credentials for Spark routing
+//   - a last-good snapshot older than the 24h retention is RETIRED, not re-served forever
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+type Scenario = "throw" | UsageReport;
+let scenarios: Record<string, Scenario> = {};
+
+function makeReport(
+	accountId: string,
+	opts: {
+		fetchedAtMsAgo?: number;
+		usedFraction?: number;
+		exhausted?: boolean;
+		resetsInMs?: number;
+		planType?: string;
+	},
+): UsageReport {
+	const now = Date.now();
+	const usedFraction = opts.exhausted ? 1 : (opts.usedFraction ?? 0);
+	return {
+		provider: "openai-codex",
+		fetchedAt: now - (opts.fetchedAtMsAgo ?? 0),
+		limits: [
+			{
+				id: "openai-codex:primary",
+				label: "Primary",
+				scope: { provider: "openai-codex", accountId, windowId: "5h" },
+				amount: { unit: "requests", used: Math.round(usedFraction * 100), limit: 100, usedFraction },
+				status: opts.exhausted ? "exhausted" : "ok",
+				...(opts.resetsInMs !== undefined
+					? { window: { id: "5h", label: "5 Hour", durationMs: 5 * HOUR, resetsAt: now + opts.resetsInMs } }
+					: {}),
+			},
+		],
+		...(opts.planType !== undefined ? { metadata: { planType: opts.planType } } : {}),
+	};
+}
+
+const usageProvider: UsageProvider = {
+	id: "openai-codex",
+	async fetchUsage(params) {
+		const accountId = params.credential.accountId ?? "unknown";
+		const scenario = scenarios[accountId];
+		if (scenario === undefined) return null;
+		if (scenario === "throw") throw new Error(`simulated probe failure for ${accountId}`);
+		return scenario;
+	},
+};
+
+describe("AuthStorage usage staleness / routing freshness", () => {
+	let tempDir = "";
+	let authStorage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-usage-staleness-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		scenarios = {};
+		authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"), {
+			usageProviderResolver: provider => (provider === "openai-codex" ? usageProvider : undefined),
+		});
+		vi.spyOn(oauth, "refreshOAuthToken").mockImplementation(async (_provider, credential) => credential);
+		vi.spyOn(oauth, "getOAuthApiKey").mockImplementation(async (_provider, credentials) => {
+			const credential = credentials["openai-codex"] as OAuthCredentials | undefined;
+			if (!credential) return null;
+			return { apiKey: `api-${credential.accountId ?? "unknown"}`, newCredentials: credential };
+		});
+	});
+
+	afterEach(() => {
+		setSystemTime();
+		vi.restoreAllMocks();
+		authStorage.close();
+		if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+	});
+
+	async function seedTwo(a: string, b: string): Promise<void> {
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", access: `access-${a}`, refresh: `refresh-${a}`, expires: Date.now() + HOUR, accountId: a },
+			{ type: "oauth", access: `access-${b}`, refresh: `refresh-${b}`, expires: Date.now() + HOUR, accountId: b },
+		]);
+	}
+
+	async function useEarliestResetRanking(): Promise<void> {
+		authStorage.close();
+		authStorage = await AuthStorage.create(path.join(tempDir, "auth-earliest-reset.db"), {
+			usageProviderResolver: provider => (provider === "openai-codex" ? usageProvider : undefined),
+			credentialRankingMode: "earliest-reset",
+		});
+	}
+
+	test("stale 'exhausted' snapshot does NOT block; the genuinely fresh-capped account is avoided instead", async () => {
+		// The incident: acct-poison looks exhausted but the evidence is 20min old (a frozen
+		// snapshot from a failing probe). acct-realcap is exhausted on a FRESH report with a
+		// future reset. Only acct-realcap should be blocked; acct-poison must stay selectable.
+		await seedTwo("poison", "realcap");
+		scenarios.poison = makeReport("poison", { fetchedAtMsAgo: 20 * MIN, exhausted: true, resetsInMs: 2 * HOUR });
+		scenarios.realcap = makeReport("realcap", { fetchedAtMsAgo: 0, exhausted: true, resetsInMs: 1 * HOUR });
+
+		const key = await authStorage.getApiKey("openai-codex", "session-incident", { modelId: "gpt-5.5" });
+		expect(key).toBe("api-poison");
+	});
+
+	test("fresh exhausted window with a PAST reset is not authoritative for routing (Change 3)", async () => {
+		// acct-past is exhausted on a fresh report but its window already reset (resetsAt in
+		// the past) — the exhaustion claim is stale, so it must not block. acct-future is a
+		// live cap. Selection must land on acct-past.
+		await seedTwo("past", "future");
+		scenarios.past = makeReport("past", { fetchedAtMsAgo: 0, exhausted: true, resetsInMs: -1 * HOUR });
+		scenarios.future = makeReport("future", { fetchedAtMsAgo: 0, exhausted: true, resetsInMs: 1 * HOUR });
+
+		const key = await authStorage.getApiKey("openai-codex", "session-pastreset", { modelId: "gpt-5.5" });
+		expect(key).toBe("api-past");
+	});
+
+	test("past-reset exhausted window does not win earliest-reset ordering", async () => {
+		// The past-reset exhausted window is non-authoritative for all routing, not only
+		// block detection. Under earliest-reset mode it must degrade to unknown instead of
+		// winning just because its reset timestamp is already in the past.
+		await useEarliestResetRanking();
+		await seedTwo("pastbusy", "healthy");
+		scenarios.pastbusy = makeReport("pastbusy", { fetchedAtMsAgo: 0, exhausted: true, resetsInMs: -1 * HOUR });
+		scenarios.healthy = makeReport("healthy", { fetchedAtMsAgo: 0, usedFraction: 0.1 });
+
+		const key = await authStorage.getApiKey("openai-codex", "session-pastreset-order", { modelId: "gpt-5.5" });
+		expect(key).toBe("api-healthy");
+	});
+
+	test("fresh exhausted window with a FUTURE reset STILL blocks — legit cap preserved (regression)", async () => {
+		// Guard against the fix over-opening: a genuinely fresh cap must still be avoided in
+		// favour of the healthy account.
+		await seedTwo("cap", "ok");
+		scenarios.cap = makeReport("cap", { fetchedAtMsAgo: 0, exhausted: true, resetsInMs: 1 * HOUR });
+		scenarios.ok = makeReport("ok", { fetchedAtMsAgo: 0, usedFraction: 0.1 });
+
+		const key = await authStorage.getApiKey("openai-codex", "session-legit", { modelId: "gpt-5.5" });
+		expect(key).toBe("api-ok");
+	});
+
+	test("stale high-usage report degrades to unknown for ordering, not treated as busy (Change 2)", async () => {
+		// acct-stalebusy reads 95% used but the report is 20min old; acct-freshbusy reads a
+		// real 60% used. Neither is exhausted, so neither is blocked. Stale usage must degrade
+		// to the unknown-ordering default (~0.5) rather than its frozen 0.95, so it is NOT
+		// deprioritized behind the genuinely-busier fresh account.
+		await seedTwo("stalebusy", "freshbusy");
+		scenarios.stalebusy = makeReport("stalebusy", { fetchedAtMsAgo: 20 * MIN, usedFraction: 0.95 });
+		scenarios.freshbusy = makeReport("freshbusy", { fetchedAtMsAgo: 0, usedFraction: 0.6 });
+
+		const key = await authStorage.getApiKey("openai-codex", "session-ordering", { modelId: "gpt-5.5" });
+		expect(key).toBe("api-stalebusy");
+	});
+
+	test("stale Codex Pro metadata does not drive Spark routing priority or filtering", async () => {
+		// Spark routing may display old plan metadata, but stale planType must not promote
+		// or filter a credential. With no fresh Pro confirmation, the lower-usage fresh
+		// unknown-plan report is attempted instead of the stale "pro" report.
+		await seedTwo("stalepro", "freshunknown");
+		scenarios.stalepro = makeReport("stalepro", {
+			fetchedAtMsAgo: 20 * MIN,
+			usedFraction: 0.95,
+			planType: "pro",
+		});
+		scenarios.freshunknown = makeReport("freshunknown", {
+			fetchedAtMsAgo: 0,
+			usedFraction: 0.1,
+		});
+
+		const key = await authStorage.getApiKey("openai-codex", "session-stale-pro", { modelId: "gpt-5.5-spark" });
+		expect(key).toBe("api-freshunknown");
+	});
+
+	test("last-good within the 24h retention is still served for display when the probe fails", async () => {
+		const t0 = Date.UTC(2026, 0, 1, 12, 0, 0);
+		setSystemTime(t0);
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", access: "a", refresh: "r", expires: t0 + 1000 * HOUR, accountId: "acct" },
+		]);
+		scenarios.acct = makeReport("acct", { fetchedAtMsAgo: 0, usedFraction: 0.4 });
+
+		const first = await authStorage.fetchUsageReports();
+		expect(first?.some(r => r.limits[0]?.scope.accountId === "acct")).toBe(true);
+
+		// Probe now fails; 23h later the last-good is stale-for-fresh but within retention.
+		scenarios.acct = "throw";
+		setSystemTime(t0 + 23 * HOUR);
+		const served = await authStorage.fetchUsageReports();
+		expect(served?.some(r => r.limits[0]?.scope.accountId === "acct")).toBe(true);
+	});
+
+	test("last-good older than the 24h retention is RETIRED, not resurrected (Change 1)", async () => {
+		const t0 = Date.UTC(2026, 0, 1, 12, 0, 0);
+		setSystemTime(t0);
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", access: "a", refresh: "r", expires: t0 + 1000 * HOUR, accountId: "acct" },
+		]);
+		scenarios.acct = makeReport("acct", { fetchedAtMsAgo: 0, usedFraction: 0.4 });
+
+		const first = await authStorage.fetchUsageReports();
+		expect(first?.some(r => r.limits[0]?.scope.accountId === "acct")).toBe(true);
+
+		// Probe fails for good; 25h later the last-good has aged past retention and must be
+		// dropped rather than re-served (the resurrection loop the fix kills).
+		scenarios.acct = "throw";
+		setSystemTime(t0 + 25 * HOUR);
+		const retired = await authStorage.fetchUsageReports();
+		expect(retired?.some(r => r.limits[0]?.scope.accountId === "acct")).toBe(false);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The model selector now asks for an explicit reasoning level when assigning Claude reasoning models, matching the existing OpenAI/Codex reasoning-model flow.
+
 ## [0.8.1] - 2026-07-04
 
 ### Added

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1765,7 +1765,13 @@ export class ModelSelectorComponent extends Container {
 }
 
 function requiresExplicitThinkingChoice(model: Model): boolean {
-	return model.reasoning === true && (model.provider === "openai" || model.provider === "openai-codex");
+	if (model.reasoning !== true) return false;
+	return (
+		model.provider === "openai" ||
+		model.provider === "openai-codex" ||
+		model.api === "anthropic-messages" ||
+		(model.api === "bedrock-converse-stream" && /(?:^|[/.])claude[-.]/i.test(model.id))
+	);
 }
 
 function getSelectableThinkingLevels(model: Model): ThinkingLevel[] {

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -161,9 +161,14 @@ describe("ModelSelector canonical model selection", () => {
 		});
 
 		let selected: SelectionCapture | undefined;
-		const selector = createSelector(model, settings, selection => {
-			if (selection.kind === "assignment") selected = selection;
-		});
+		const selector = createSelector(
+			model,
+			settings,
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
+			},
+			{ explicitThinkingLevel: true },
+		);
 		await Bun.sleep(0);
 		installTestTheme();
 
@@ -211,9 +216,14 @@ describe("ModelSelector canonical model selection", () => {
 		});
 
 		let selected: SelectionCapture | undefined;
-		const selector = createSelector(model, settings, selection => {
-			if (selection.kind === "assignment") selected = selection;
-		});
+		const selector = createSelector(
+			model,
+			settings,
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
+			},
+			{ explicitThinkingLevel: true },
+		);
 		await Bun.sleep(0);
 		installTestTheme();
 
@@ -246,7 +256,7 @@ describe("ModelSelector canonical model selection", () => {
 			selection => {
 				if (selection.kind === "assignment") selected = selection;
 			},
-			{ temporaryOnly: true, thinkingLevel: ThinkingLevel.Low },
+			{ temporaryOnly: true, thinkingLevel: ThinkingLevel.Low, explicitThinkingLevel: true },
 		);
 		await Bun.sleep(0);
 		installTestTheme();
@@ -291,7 +301,7 @@ describe("ModelSelector canonical model selection", () => {
 			selection => {
 				if (selection.kind === "assignment") selected = selection;
 			},
-			{ modelRegistry, thinkingLevel: ThinkingLevel.Medium },
+			{ modelRegistry, thinkingLevel: ThinkingLevel.Medium, explicitThinkingLevel: true },
 		);
 		await Bun.sleep(0);
 		installTestTheme();
@@ -429,6 +439,46 @@ describe("ModelSelector canonical model selection", () => {
 		if (!selectedAfterThinking) throw new Error("Expected OpenAI selection after off choice");
 		expect(selectedAfterThinking.role).toBe("default");
 		expect(selectedAfterThinking.thinkingLevel).toBe(ThinkingLevel.Off);
+		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}`);
+	});
+
+	test("prompts for reasoning before assigning Claude default models", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+		const settings = Settings.isolated({});
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
+			},
+			{ thinkingLevel: null },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+
+		expect(selected).toBeUndefined();
+		const thinkingRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(thinkingRendered).toContain("Reasoning for Default");
+		expect(thinkingRendered).toContain("off");
+		expect(thinkingRendered).toContain("xhigh");
+
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+
+		const selectedAfterThinking = selected;
+		if (!selectedAfterThinking) throw new Error("Expected Claude selection after reasoning choice");
+		expect(selectedAfterThinking.role).toBe("default");
+		expect(selectedAfterThinking.thinkingLevel).toBe(ThinkingLevel.High);
 		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}`);
 	});
 


### PR DESCRIPTION
## PR
- Base: `dev`.
- Head: `jason931225:fix/usage-cache-rotation-poisoning`.
- Issues: fixes #1561 and fixes #1562.
- Commit history is two atomic commits:
  - `fix: stop stale usage cache from poisoning credential rotation`
  - `fix: prompt for Claude reasoning selection`

## Fix
- Treat stale usage reports as display-only; they no longer block, rank, plan-gate, or extend OAuth routing.
- Retire last-good usage rows older than 24h when probes keep failing.
- Ignore past-reset exhausted windows for routing decisions.
- Prompt for an explicit reasoning/effort level when assigning Claude reasoning models.

## Triage
- A stale `exhausted` usage snapshot can survive repeated `/usage` failures and route away from a recovered Codex/Anthropic credential.
- Stale Codex Pro metadata can affect Spark routing.
- Claude reasoning models currently skip the explicit reasoning menu that OpenAI/Codex models already use.

## Refactor
- Added routing-fresh usage helpers and applied them at existing usage-routing use sites.
- Kept Claude selection to the existing explicit-reasoning predicate; no broader selector rewrite.
- Comments are limited to touched non-obvious behavior.

## Test
Recreate #1561:
1. Configure two OpenAI Codex OAuth credentials.
2. Serve credential A from a stale `exhausted` last-good usage row while `/usage` fails.
3. Serve credential B with a fresh exhausted report.
4. Request a Codex model; A should remain selectable because stale usage is non-authoritative.

Recreate #1562:
1. Open the model selector.
2. Select `anthropic/claude-sonnet-4-5`.
3. Choose `Set as DEFAULT`; the selector should open `Reasoning for Default` before saving.

## CI
- `bun test test/auth-storage-usage-staleness.test.ts` from `packages/ai` — 9 pass, 0 fail.
- `bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts` — 22 pass, 0 fail.
- `bunx @biomejs/biome check packages/ai/src/auth-storage.ts packages/ai/test/auth-storage-usage-staleness.test.ts packages/coding-agent/src/modes/components/model-selector.ts packages/coding-agent/test/model-selector-role-badge-thinking.test.ts packages/ai/CHANGELOG.md packages/coding-agent/CHANGELOG.md`.
- `bun run check` from `packages/ai`.
- `bun run check` from `packages/coding-agent` — passed with an unrelated Biome info in `src/gjc-runtime/deep-interview-runtime.ts`.
- `git diff --check origin/dev...HEAD`.
