### PR TITLE
Prevent Telegram notification threads for subagent sessions

### DIFF
--- a/packages/coding-agent/src/notifications/config.ts
+++ b/packages/coding-agent/src/notifications/config.ts
@@ -52,7 +52,12 @@ export function isGloballyConfigured(cfg: NotificationConfig): boolean {
 export function shouldRegisterNotificationsExtension(input: {
 	env: NodeJS.ProcessEnv;
 	cfg?: NotificationConfig;
+	/** Task recursion depth; helper/subagent sessions must not spawn remote surfaces. */
+	taskDepth?: number;
+	/** Parent subagent id/prefix; present for helper/subagent sessions even when depth is omitted. */
+	parentTaskPrefix?: string;
 }): boolean {
+	if ((input.taskDepth ?? 0) > 0 || input.parentTaskPrefix) return false;
 	if (input.env.GJC_NOTIFICATIONS === "0") return false;
 	if (input.env.GJC_NOTIFICATIONS === "1" || input.env.GJC_NOTIFICATIONS_TOKEN) return true;
 	return input.cfg ? isGloballyConfigured(input.cfg) : false;

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -28,7 +28,7 @@ import type { ImageContent, TextContent } from "@gajae-code/ai";
 import { NotificationServer } from "@gajae-code/natives";
 import { logger, postmortem } from "@gajae-code/utils";
 import { Settings } from "../config/settings";
-import type { ExtensionCommandContext, ExtensionContext, ExtensionFactory } from "../extensibility/extensions";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "../extensibility/extensions";
 import { registerAskAnswerSource } from "../tools/ask-answer-registry";
 import { registerTelegramFileSink } from "./attachment-registry";
 import {
@@ -379,7 +379,9 @@ export function notificationsEnabled(): boolean {
 	return process.env.GJC_NOTIFICATIONS === "1" || Boolean(process.env.GJC_NOTIFICATIONS_TOKEN);
 }
 
-function resolveSettings(): ResolvedSettings {
+function resolveSettings(settingsOverride?: Settings): ResolvedSettings {
+	if (settingsOverride)
+		return { settings: settingsOverride, cfg: getNotificationConfig(settingsOverride), settingsAvailable: true };
 	try {
 		const settings = Settings.instance;
 		return { settings, cfg: getNotificationConfig(settings), settingsAvailable: true };
@@ -491,7 +493,7 @@ function sessionIdFromFile(file: string | undefined): string | undefined {
 	return underscore >= 0 ? base.slice(underscore + 1) : undefined;
 }
 
-export const createNotificationsExtension: ExtensionFactory = api => {
+export function createNotificationsExtension(api: ExtensionAPI, options: { settings?: Settings } = {}): void {
 	const runtimes = new Map<string, SessionRuntime>();
 	const disabledSessions = new Set<string>();
 	const sessionId = (ctx: ExtensionContext): string => ctx.sessionManager.getSessionId();
@@ -531,7 +533,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 
 	async function startSession(ctx: ExtensionContext): Promise<"started" | "already" | "disabled" | "failed"> {
 		const id = sessionId(ctx);
-		const { settings, cfg, settingsAvailable } = resolveSettings();
+		const { settings, cfg, settingsAvailable } = resolveSettings(options.settings);
 		if (!isEnabledForSession(id, cfg)) return "disabled";
 		if (runtimes.has(id)) return "already";
 
@@ -761,7 +763,7 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 		async handler(args: string, ctx: ExtensionCommandContext): Promise<void> {
 			const id = sessionId(ctx);
 			const command = args.trim().split(/\s+/, 1)[0]?.toLowerCase() || "status";
-			const resolved = resolveSettings();
+			const resolved = resolveSettings(options.settings);
 			const enabledWithoutLocalOff = isSessionNotificationsEnabled({
 				cfg: resolved.cfg,
 				env: process.env,
@@ -1099,4 +1101,4 @@ export const createNotificationsExtension: ExtensionFactory = api => {
 	api.on("session_shutdown", async (_event, ctx) => {
 		await stopSession(sessionId(ctx));
 	});
-};
+}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1520,12 +1520,19 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		}
 		let notificationCfg: NotificationConfig | undefined;
 		try {
-			notificationCfg = getNotificationConfig(Settings.instance);
+			notificationCfg = getNotificationConfig(settings);
 		} catch {
 			notificationCfg = undefined;
 		}
-		if (shouldRegisterNotificationsExtension({ env: process.env, cfg: notificationCfg })) {
-			inlineExtensions.push(createNotificationsExtension);
+		if (
+			shouldRegisterNotificationsExtension({
+				env: process.env,
+				cfg: notificationCfg,
+				taskDepth,
+				parentTaskPrefix: options.parentTaskPrefix,
+			})
+		) {
+			inlineExtensions.push(api => createNotificationsExtension(api, { settings }));
 		}
 
 		// Extension/module discovery is quarantined; retain only the private

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from "bun:test";
-import { Settings } from "../src/config/settings";
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getBundledModel } from "@gajae-code/ai";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
 import {
 	buildRedactedAction,
 	getNotificationConfig,
@@ -12,6 +16,8 @@ import {
 	shouldRegisterNotificationsExtension,
 	tokenFingerprint,
 } from "../src/notifications/config";
+import { createAgentSession } from "../src/sdk";
+import { SessionManager } from "../src/session/session-manager";
 
 const BASE_CFG: NotificationConfig = {
 	enabled: false,
@@ -36,6 +42,11 @@ const GLOBAL_CFG: NotificationConfig = {
 	botToken: "1234567890:abc",
 	chatId: "chat-1",
 };
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
 
 describe("notifications config", () => {
 	test("getNotificationConfig reads defaults", () => {
@@ -149,6 +160,124 @@ describe("notifications config", () => {
 		expect(shouldRegisterNotificationsExtension({ cfg: GLOBAL_CFG, env: {} })).toBe(true);
 		expect(shouldRegisterNotificationsExtension({ cfg: BASE_CFG, env: {} })).toBe(false);
 		expect(shouldRegisterNotificationsExtension({ env: {} })).toBe(false);
+		expect(
+			shouldRegisterNotificationsExtension({
+				cfg: GLOBAL_CFG,
+				env: { GJC_NOTIFICATIONS: "1", GJC_NOTIFICATIONS_TOKEN: "legacy-token" },
+				taskDepth: 1,
+			}),
+		).toBe(false);
+		expect(
+			shouldRegisterNotificationsExtension({
+				cfg: GLOBAL_CFG,
+				env: { GJC_NOTIFICATIONS: "1" },
+				parentTaskPrefix: "0-Sub",
+			}),
+		).toBe(false);
+	});
+	test("settings-enabled subagent sessions do not register the notifications extension", async () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notifications-subagent-"));
+		tempDirs.push(cwd);
+		const previous = process.env.GJC_NOTIFICATIONS;
+		delete process.env.GJC_NOTIFICATIONS;
+		const settings = Settings.isolated({
+			"notifications.enabled": true,
+			"notifications.discord.botToken": "discord-token",
+			"notifications.discord.channelId": "discord-channel",
+		});
+
+		const disposers: Array<() => Promise<void>> = [];
+
+		try {
+			resetSettingsForTest();
+			await Settings.init({ inMemory: true, cwd, agentDir: cwd });
+			const topLevel = await createAgentSession({
+				cwd,
+				agentDir: cwd,
+				sessionManager: SessionManager.inMemory(cwd),
+				settings,
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				extensions: [],
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+			});
+			disposers.push(() => topLevel.session.dispose());
+
+			const subagent = await createAgentSession({
+				cwd,
+				agentDir: cwd,
+				sessionManager: SessionManager.inMemory(cwd),
+				settings,
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				extensions: [],
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				taskDepth: 1,
+			});
+			disposers.push(() => subagent.session.dispose());
+			const parentPrefixSubagent = await createAgentSession({
+				cwd,
+				agentDir: cwd,
+				sessionManager: SessionManager.inMemory(cwd),
+				settings,
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				extensions: [],
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				parentTaskPrefix: "0-Sub",
+			});
+			disposers.push(() => parentPrefixSubagent.session.dispose());
+			await topLevel.session.extensionRunner?.emit({ type: "session_start" });
+			await subagent.session.extensionRunner?.emit({ type: "session_start" });
+			await parentPrefixSubagent.session.extensionRunner?.emit({ type: "session_start" });
+			const topLevelEndpoint = path.join(
+				cwd,
+				".gjc",
+				"state",
+				"notifications",
+				`${topLevel.session.sessionId}.json`,
+			);
+			const subagentEndpoint = path.join(
+				cwd,
+				".gjc",
+				"state",
+				"notifications",
+				`${subagent.session.sessionId}.json`,
+			);
+			const parentPrefixSubagentEndpoint = path.join(
+				cwd,
+				".gjc",
+				"state",
+				"notifications",
+				`${parentPrefixSubagent.session.sessionId}.json`,
+			);
+			expect(fs.existsSync(topLevelEndpoint)).toBe(true);
+			expect(fs.existsSync(subagentEndpoint)).toBe(false);
+			expect(fs.existsSync(parentPrefixSubagentEndpoint)).toBe(false);
+		} finally {
+			await Promise.all(disposers.reverse().map(dispose => dispose()));
+			if (previous === undefined) {
+				delete process.env.GJC_NOTIFICATIONS;
+			} else {
+				process.env.GJC_NOTIFICATIONS = previous;
+			}
+			resetSettingsForTest();
+		}
 	});
 
 	test("maskToken handles unset tokens and never reveals the raw token", () => {


### PR DESCRIPTION
## Summary

Fixes helper/subagent sessions creating notification endpoints that can lead to Telegram forum threads/topics.

The notification extension was registered for every session whenever notifications were globally/env enabled. Subagent/helper sessions then exposed their own notification endpoint, so the Telegram daemon could discover them and create a thread even when there was no useful conversation content.

## Changes

- Treat helper/subagent sessions as notification-ineligible when:
  - `taskDepth > 0`, or
  - `parentTaskPrefix` is present
- Pass `taskDepth` and `parentTaskPrefix` into notification extension registration from the SDK.
- Use the session-supplied `settings` object for notification registration instead of the global singleton.
- Bind the notifications extension runtime to the same supplied settings so registration and `session_start` enablement agree.
- Add regression coverage proving:
  - top-level settings-enabled sessions still create notification endpoints
  - `taskDepth: 1` subagent sessions do not
  - `parentTaskPrefix`-only helper/subagent sessions do not
  - env opt-in does not override subagent ineligibility

## Test cases

- Registration gate rejects helper/subagent sessions even under env opt-in:
  - `taskDepth: 1`
  - `parentTaskPrefix` present
- Runtime regression covers the actual endpoint-creation path:
  - top-level settings-enabled session emits `session_start` and creates `.gjc/state/notifications/<sessionId>.json`
  - `taskDepth: 1` subagent emits `session_start` and creates no endpoint
  - `parentTaskPrefix`-only helper/subagent emits `session_start` and creates no endpoint

## Review

- Architect review: CLEAR / APPROVE
- Critic final review: APPROVE, no remaining actionable issues

## Verification

- `bun test packages/coding-agent/test/notifications-config.test.ts`
- `bun --cwd=packages/coding-agent run check`