### PR TITLE
Remove blank row above new session notice

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- `/new` session-start notifications now render directly under the welcome panel instead of leaving an extra blank row above the confirmation line.
 - Goal completion now preserves the terminal `goal({op: "complete"})` state even when a `goal_updated` extension hook throws, preventing hook-side write errors from trapping a verified ultragoal run in the continuation loop.
 - Ultragoal completion no longer requires the computer-use red-team suite for non-computer changes that only touch the shared `tools/index.ts` registration file.
 - Task subagent output-ID allocation (`AgentOutputManager`) is now concurrency-safe. `#ensureInitialized` previously set a boolean flag *before* the awaited `readdir`, so when two `task` calls are dispatched in the same turn (they run concurrently as shared-concurrency tools on one session-scoped manager) the second allocation short-circuited initialization and started from index `0` while the first scan was still in flight — colliding with existing `N-*.md` outputs and duplicating ids across batches, which overwrote prior subagent outputs on resume. The scan is now memoized as a promise so concurrent `allocate`/`allocateBatch`/`peekNextIndex` calls await the same `readdir` before `#nextId` is derived.

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-runtime.ts
@@ -257,9 +257,7 @@ async function collectRelevantTracePaths(
 				const surfaceScore = /deep[-_]?interview|skill|workflow|runtime|state/i.test(relativePath) ? 1 : 0;
 				results.push({ path: relativePath, reason, score: termScore + surfaceScore });
 			}
-		} catch {
-			continue;
-		}
+		} catch {}
 	}
 	return results
 		.sort((a, b) => b.score - a.score || a.path.localeCompare(b.path))

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -926,8 +926,7 @@ export class CommandController {
 		this.ctx.streamingMessage = undefined;
 		this.ctx.pendingTools.clear();
 
-		this.ctx.chatContainer.addChild(new Spacer(1));
-		this.ctx.chatContainer.addChild(new Text(`${theme.fg("accent", `${theme.status.success} ${label}`)}`, 1, 1));
+		this.ctx.chatContainer.addChild(new Text(`${theme.fg("accent", `${theme.status.success} ${label}`)}`, 1, 0));
 		await this.ctx.reloadTodos();
 		this.ctx.ui.requestRender();
 	}

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -191,9 +191,8 @@ export class ExtensionUiController {
 				this.ctx.streamingMessage = undefined;
 				this.ctx.pendingTools.clear();
 
-				this.ctx.chatContainer.addChild(new Spacer(1));
 				this.ctx.chatContainer.addChild(
-					new Text(`${theme.fg("accent", `${theme.status.success} New session started`)}`, 1, 1),
+					new Text(`${theme.fg("accent", `${theme.status.success} New session started`)}`, 1, 0),
 				);
 				await this.ctx.reloadTodos();
 				this.ctx.ui.requestRender();
@@ -430,9 +429,8 @@ export class ExtensionUiController {
 				this.ctx.streamingMessage = undefined;
 				this.ctx.pendingTools.clear();
 
-				this.ctx.chatContainer.addChild(new Spacer(1));
 				this.ctx.chatContainer.addChild(
-					new Text(`${theme.fg("accent", `${theme.status.success} New session started`)}`, 1, 1),
+					new Text(`${theme.fg("accent", `${theme.status.success} New session started`)}`, 1, 0),
 				);
 				await this.ctx.reloadTodos();
 				this.ctx.ui.requestRender();

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -4,7 +4,7 @@ import { stripVTControlCharacters } from "node:util";
 import { Agent } from "@gajae-code/agent-core";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { initTheme, theme } from "@gajae-code/coding-agent/modes/theme/theme";
-import { CURSOR_MARKER, Spacer, Text } from "@gajae-code/tui";
+import { CURSOR_MARKER, Text } from "@gajae-code/tui";
 import { TempDir } from "@gajae-code/utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import { CustomEditor } from "../src/modes/components/custom-editor";
@@ -149,16 +149,17 @@ describe("InteractiveMode.setEditorComponent", () => {
 		await mode.init();
 
 		mode.chatContainer.clear();
-		mode.chatContainer.addChild(new Spacer(1));
 		mode.chatContainer.addChild(
-			new Text(`${theme.fg("accent", `${theme.status.success} New session started`)}`, 1, 1),
+			new Text(`${theme.fg("accent", `${theme.status.success} New session started`)}`, 1, 0),
 		);
 
 		const rendered = mode.ui.render(width).map(stripRenderControls);
 		const renderedText = rendered.join("\n");
-
+		const noticeIndex = rendered.findIndex(line => line.includes("New session started"));
 		expect(rendered.length).toBeLessThanOrEqual(rows);
 		expect(renderedText).toContain("GJC Forge");
+		expect(noticeIndex).toBeGreaterThan(0);
+		expect(rendered[noticeIndex - 1]?.trim()).not.toBe("");
 		expect(renderedText).toContain("New session started");
 	});
 


### PR DESCRIPTION
## Summary
- Render `/new` session-start notifications without the extra leading spacer/top padding so the confirmation appears directly under the welcome panel.
- Apply the same compact notification rendering to extension-triggered new-session flows.
- Add a viewport regression assertion that the line above `New session started` is not blank.
- Remove a stale no-op `continue` flagged by the package check.

## Verification
- `bun test packages/coding-agent/test/interactive-mode-editor-component.test.ts -t "welcome splash viewport-bound"`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`