### PR TITLE
Fix psmux bottom-pinned redraws

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Queued message selector entries can now be reordered with `Ctrl+Up` / `Ctrl+Down`, with `Ctrl+Shift+Up` / `Ctrl+Shift+Down` still accepted when the terminal forwards them, while keeping the current draft intact.
 
 ### Fixed
+- `gjc --tmux` on native Windows/psmux now keeps the status line and composer pinned to the bottom after viewport redraws by honoring the GJC tmux launch marker as a multiplexer signal even when `$TMUX` is absent.
 
 - Goal completion now preserves the terminal `goal({op: "complete"})` state even when a `goal_updated` extension hook throws, preventing hook-side write errors from trapping a verified ultragoal run in the continuation loop.
 - Ultragoal completion no longer requires the computer-use red-team suite for non-computer changes that only touch the shared `tools/index.ts` registration file.

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- GJC-launched psmux panes are now treated as multiplexer sessions even when they do not expose `$TMUX`, so resize and forced redraw paths repaint the live viewport instead of replaying/clearing scrollback and leaving the bottom-pinned composer area above stale blank rows.
 
 ## [0.8.0] - 2026-07-04
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -139,9 +139,29 @@ function isTermuxSession(): boolean {
 	return Boolean(process.env.TERMUX_VERSION);
 }
 
+const GJC_TMUX_LAUNCHED_ENV = "GJC_TMUX_LAUNCHED";
+const DISABLED_ENV_VALUES = new Set(["0", "false", "off", "no"]);
+
+function envIsEnabled(value: string | undefined): boolean {
+	const normalized = value?.trim().toLowerCase();
+	return normalized !== undefined && normalized.length > 0 && !DISABLED_ENV_VALUES.has(normalized);
+}
+
+function termLooksMultiplexed(value: string | undefined): boolean {
+	const term = value?.trim().toLowerCase() ?? "";
+	return term.startsWith("tmux") || term.startsWith("screen");
+}
+
 /** Detect terminal multiplexers where scrollback clearing and height-change redraws are hostile. */
 function isMultiplexerSession(): boolean {
-	return Boolean(Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ);
+	return Boolean(
+		envIsEnabled(Bun.env.TMUX) ||
+			envIsEnabled(Bun.env.TMUX_PANE) ||
+			envIsEnabled(Bun.env.STY) ||
+			envIsEnabled(Bun.env.ZELLIJ) ||
+			envIsEnabled(Bun.env[GJC_TMUX_LAUNCHED_ENV]) ||
+			termLooksMultiplexed(Bun.env.TERM),
+	);
 }
 
 function useLegacyMultiplexerFullRender(): boolean {

--- a/packages/tui/test/bottom-pinned-layout.test.ts
+++ b/packages/tui/test/bottom-pinned-layout.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { type Component, TUI } from "@gajae-code/tui";
 import { VirtualTerminal } from "./virtual-terminal";
 
@@ -56,5 +56,58 @@ describe("TUI bottom-pinned layout", () => {
 		} finally {
 			tui.stop();
 		}
+	});
+
+	describe("with the GJC psmux launch marker", () => {
+		let origTmux: string | undefined;
+		let origTmuxPane: string | undefined;
+		let origLaunched: string | undefined;
+
+		beforeEach(() => {
+			origTmux = process.env.TMUX;
+			origTmuxPane = process.env.TMUX_PANE;
+			origLaunched = process.env.GJC_TMUX_LAUNCHED;
+			delete process.env.TMUX;
+			delete process.env.TMUX_PANE;
+			process.env.GJC_TMUX_LAUNCHED = "1";
+		});
+
+		afterEach(() => {
+			if (origTmux === undefined) delete process.env.TMUX;
+			else process.env.TMUX = origTmux;
+			if (origTmuxPane === undefined) delete process.env.TMUX_PANE;
+			else process.env.TMUX_PANE = origTmuxPane;
+			if (origLaunched === undefined) delete process.env.GJC_TMUX_LAUNCHED;
+			else process.env.GJC_TMUX_LAUNCHED = origLaunched;
+		});
+
+		it("keeps the pinned group on the last row after a viewport resize", async () => {
+			const term = new VirtualTerminal(40, 6);
+			const tui = new TUI(term);
+			const header = new LinesComponent(["forge"]);
+			const pinned = new LinesComponent(["status", "composer"]);
+
+			tui.addChild(header);
+			tui.addChild(pinned);
+			tui.setBottomPinnedComponent(pinned);
+
+			try {
+				tui.start();
+				await term.waitForRender();
+
+				term.clearWriteLog();
+				term.resize(40, 9);
+				await term.waitForRender();
+
+				const viewport = term.getViewport().map(line => line.trimEnd());
+				expect(viewport[0]).toBe("forge");
+				expect(viewport.slice(1, 7)).toEqual(["", "", "", "", "", ""]);
+				expect(viewport[7]).toBe("status");
+				expect(viewport[8]).toBe("composer");
+				expect(term.getWriteLog().join("")).not.toContain("\x1b[3J");
+			} finally {
+				tui.stop();
+			}
+		});
 	});
 });

--- a/packages/tui/test/resize-replay-storm.test.ts
+++ b/packages/tui/test/resize-replay-storm.test.ts
@@ -121,17 +121,85 @@ describe("multiplexer resize replay storm regression", () => {
 		});
 	});
 
-	describe("in a plain terminal (no TMUX)", () => {
+	describe("in a GJC-launched psmux pane without TMUX env", () => {
 		let origTmux: string | undefined;
+		let origTmuxPane: string | undefined;
+		let origLaunched: string | undefined;
 
 		beforeEach(() => {
 			origTmux = process.env.TMUX;
+			origTmuxPane = process.env.TMUX_PANE;
+			origLaunched = process.env.GJC_TMUX_LAUNCHED;
 			delete process.env.TMUX;
+			delete process.env.TMUX_PANE;
+			process.env.GJC_TMUX_LAUNCHED = "1";
 		});
 
 		afterEach(() => {
 			if (origTmux === undefined) delete process.env.TMUX;
 			else process.env.TMUX = origTmux;
+			if (origTmuxPane === undefined) delete process.env.TMUX_PANE;
+			else process.env.TMUX_PANE = origTmuxPane;
+			if (origLaunched === undefined) delete process.env.GJC_TMUX_LAUNCHED;
+			else process.env.GJC_TMUX_LAUNCHED = origLaunched;
+		});
+
+		it("treats the launched pane as a multiplexer for forced redraws", async () => {
+			const term = new VirtualTerminal(COLS, 30);
+			const tui = new TUI(term);
+			tui.start();
+			await term.waitForRender();
+
+			await buildTranscript(tui, term, 60);
+			term.clearWriteLog();
+
+			tui.requestRender(true, "test.psmux.force");
+			await term.waitForRender();
+
+			const out = term.getWriteLog().join("");
+			expect(distinctReplayedLineMarkers(out)).toBeLessThanOrEqual(term.rows + 2);
+			expect(out).not.toContain("\x1b[3J");
+
+			tui.stop();
+		});
+	});
+
+	describe("in a plain terminal (no multiplexer markers)", () => {
+		let origTmux: string | undefined;
+		let origTmuxPane: string | undefined;
+		let origSty: string | undefined;
+		let origZellij: string | undefined;
+		let origLaunched: string | undefined;
+		let origTerm: string | undefined;
+
+		beforeEach(() => {
+			origTmux = process.env.TMUX;
+			origTmuxPane = process.env.TMUX_PANE;
+			origSty = process.env.STY;
+			origZellij = process.env.ZELLIJ;
+			origLaunched = process.env.GJC_TMUX_LAUNCHED;
+			origTerm = process.env.TERM;
+			delete process.env.TMUX;
+			delete process.env.TMUX_PANE;
+			delete process.env.STY;
+			delete process.env.ZELLIJ;
+			delete process.env.GJC_TMUX_LAUNCHED;
+			process.env.TERM = "xterm-256color";
+		});
+
+		afterEach(() => {
+			if (origTmux === undefined) delete process.env.TMUX;
+			else process.env.TMUX = origTmux;
+			if (origTmuxPane === undefined) delete process.env.TMUX_PANE;
+			else process.env.TMUX_PANE = origTmuxPane;
+			if (origSty === undefined) delete process.env.STY;
+			else process.env.STY = origSty;
+			if (origZellij === undefined) delete process.env.ZELLIJ;
+			else process.env.ZELLIJ = origZellij;
+			if (origLaunched === undefined) delete process.env.GJC_TMUX_LAUNCHED;
+			else process.env.GJC_TMUX_LAUNCHED = origLaunched;
+			if (origTerm === undefined) delete process.env.TERM;
+			else process.env.TERM = origTerm;
 		});
 
 		it("requestRender(true) replays the whole transcript (fullRender + 3J clears scrollback cleanly)", async () => {


### PR DESCRIPTION
## Summary
- Treat GJC-launched tmux/psmux panes as multiplexer sessions even when `TMUX` is absent.
- Include `TMUX_PANE` and tmux/screen-like `TERM` markers in multiplexer detection.
- Add regression coverage proving bottom-pinned content stays on the last row after psmux-style resize redraws and forced redraws avoid scrollback clearing/replay.

## Verification
- `bun test packages/tui/test/bottom-pinned-layout.test.ts packages/tui/test/resize-replay-storm.test.ts`
- `bun --cwd=packages/tui run check`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`

## UI/Terminal QA
- Existing design branch: this is a targeted TUI regression fix using the current bottom-pinned layout grammar.
- Evidence is terminal-semantic automated coverage via the virtual terminal tests above; no raw third-party visual material was added.