### PR TITLE
Bound task receipt review correctness

### DIFF
--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -77,6 +77,28 @@ function truncateText(value: string | undefined, maxChars: number): string | und
 	return value.length > maxChars ? value.slice(0, maxChars) : value;
 }
 
+const SAFE_REVIEW_SEVERITIES = new Set(["blocker", "critical", "error", "high", "medium", "warning", "low", "info"]);
+const SAFE_REVIEW_PRIORITIES = new Set(["P0", "P1", "P2", "P3"]);
+
+function normalizeReviewFindingSeverity(severity: unknown, priority: unknown): string | undefined {
+	if (typeof severity === "string") {
+		const normalizedPriority = severity.toUpperCase();
+		if (SAFE_REVIEW_PRIORITIES.has(normalizedPriority)) return normalizedPriority;
+		const normalizedSeverity = severity.toLowerCase();
+		if (SAFE_REVIEW_SEVERITIES.has(normalizedSeverity)) return normalizedSeverity;
+	}
+	if (typeof priority === "string") {
+		const normalizedPriority = priority.toUpperCase();
+		if (SAFE_REVIEW_PRIORITIES.has(normalizedPriority)) return normalizedPriority;
+		const normalizedSeverity = priority.toLowerCase();
+		if (SAFE_REVIEW_SEVERITIES.has(normalizedSeverity)) return normalizedSeverity;
+	}
+	if (typeof priority === "number" && Number.isInteger(priority) && priority >= 0 && priority <= 3) {
+		return `P${priority}`;
+	}
+	return undefined;
+}
+
 function buildSafeSynopsis(raw: SingleResult, outputRef: TaskResultReceipt["outputRef"]): string {
 	const status = getStatus(raw);
 	if (raw.modelSubstitutionWarning) {
@@ -117,19 +139,16 @@ function buildReview(raw: SingleResult): TaskResultReceipt["review"] | undefined
 	const rawFindings = Array.isArray(data.report_finding) ? data.report_finding : [];
 	const findings = rawFindings.slice(0, 20).map(item => {
 		const value = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
-		const severity =
-			typeof value.severity === "string"
-				? value.severity
-				: typeof value.priority === "string"
-					? value.priority
-					: undefined;
+		const severity = normalizeReviewFindingSeverity(value.severity, value.priority);
 		const summaryValue = value.summary ?? value.title ?? value.message ?? value.body ?? "finding";
 		return { severity, summary: truncateText(String(summaryValue), 200) ?? "finding" };
 	});
 	if (!reviewYield && findings.length === 0) return undefined;
 	return {
-		overallCorrectness:
+		overallCorrectness: truncateText(
 			typeof reviewYield?.overall_correctness === "string" ? reviewYield.overall_correctness : undefined,
+			200,
+		),
 		findingCount: rawFindings.length,
 		findings: findings.length > 0 ? findings : undefined,
 	};

--- a/packages/coding-agent/test/task/receipt.test.ts
+++ b/packages/coding-agent/test/task/receipt.test.ts
@@ -104,6 +104,47 @@ describe("task result receipts", () => {
 		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
 	});
 
+	it("bounds child-controlled overall correctness in review receipts", () => {
+		const oversizedCorrectness = `${"safe ".repeat(40)}LEAK_SENTINEL_DO_NOT_DIGEST`;
+		const receipt = buildTaskReceipt(
+			makeRaw({
+				extractedToolData: {
+					yield: [{ data: { overall_correctness: oversizedCorrectness } }],
+					report_finding: [{ severity: "medium", summary: `${"finding ".repeat(40)}LEAK_SENTINEL_DO_NOT_DIGEST` }],
+				},
+			}),
+		);
+
+		expect(receipt.review?.overallCorrectness).toBe(oversizedCorrectness.slice(0, 200));
+		expect(receipt.review?.overallCorrectness).toHaveLength(200);
+		expect(receipt.review?.findings?.[0]?.summary).toHaveLength(200);
+		expect(JSON.stringify(receipt)).not.toContain("LEAK_SENTINEL_DO_NOT_DIGEST");
+		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
+	});
+
+	it("normalizes hostile review finding severity and priority values", () => {
+		const hostileSeverity = `${"x".repeat(1000)}LEAK_SENTINEL_DO_NOT_DIGEST`;
+		const hostilePriority = `${"P".repeat(1000)}LEAK_SENTINEL_DO_NOT_DIGEST`;
+		const receipt = buildTaskReceipt(
+			makeRaw({
+				extractedToolData: {
+					report_finding: [
+						{ severity: hostileSeverity, summary: "short" },
+						{ priority: hostilePriority, summary: "short" },
+						{ severity: hostileSeverity, priority: "p2", summary: "short" },
+						{ priority: 1, summary: "short" },
+					],
+				},
+			}),
+		);
+
+		expect(receipt.review?.findings?.map(finding => finding.severity)).toEqual([undefined, undefined, "P2", "P1"]);
+		expect(JSON.stringify(receipt)).not.toContain("LEAK_SENTINEL_DO_NOT_DIGEST");
+		expect(JSON.stringify(receipt)).not.toContain("x".repeat(1000));
+		expect(JSON.stringify(receipt)).not.toContain("P".repeat(1000));
+		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
+	});
+
 	it("buildTaskReceipt marks output unavailable when no artifact metadata is present", () => {
 		const receipt = buildTaskReceipt(makeRaw());
 		expect(receipt.outputRef).toBeUndefined();

--- a/packages/coding-agent/test/task/roi-reconciliation.test.ts
+++ b/packages/coding-agent/test/task/roi-reconciliation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { TaskResultReceipt } from "../../src/task/receipt";
+import { buildTaskReceipt, type TaskResultReceipt } from "../../src/task/receipt";
 import { reconcileSpawnRoi } from "../../src/task/roi-reconciliation";
 import type { SpawnPlanReceipt } from "../../src/task/spawn-gate";
 
@@ -182,6 +182,32 @@ describe("spawn ROI reconciliation", () => {
 
 		expect(result?.children[0]?.inlineTokens).toBe(4);
 		expect(result?.overBudgetChildIds).toEqual(["reviewed-child"]);
+	});
+
+	it("counts bounded review correctness from task receipts", () => {
+		const receipt = buildTaskReceipt({
+			index: 0,
+			id: "reviewed-child",
+			agent: "executor",
+			agentSource: "bundled",
+			task: "task",
+			exitCode: 0,
+			output: "small",
+			stderr: "",
+			truncated: false,
+			durationMs: 1,
+			tokens: 10,
+			extractedToolData: {
+				yield: [{ data: { overall_correctness: "x".repeat(50_000) } }],
+			},
+		});
+
+		const result = reconcileSpawnRoi(plan(60), [receipt]);
+
+		expect(receipt.review?.overallCorrectness).toHaveLength(200);
+		expect(result?.children[0]?.inlineTokens).toBe(61);
+		expect(result?.overBudgetChildIds).toEqual(["reviewed-child"]);
+		expect(result?.totalOverageTokens).toBe(1);
 	});
 
 	it("is advisory-only and does not mutate receipts or expose status mutation fields", () => {


### PR DESCRIPTION
## Summary
- Cap child-controlled `review.overallCorrectness` with the existing 200-character task receipt truncation policy used for review findings.
- Add regression coverage for oversized review verdict/finding payloads and sentinel non-leakage.
- Add ROI reconciliation coverage proving inline token accounting uses the bounded receipt field rather than the raw child yield string.

Fixes #1559.

## Verification
- `bun --cwd=packages/coding-agent test test/task/receipt.test.ts test/task/roi-reconciliation.test.ts`
- `bunx biome check packages/coding-agent/src/task/receipt.ts packages/coding-agent/test/task/receipt.test.ts packages/coding-agent/test/task/roi-reconciliation.test.ts`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*