### PR TITLE
Redact secret-like values in config output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Fixed
 
+- `gjc config list`, `gjc config get`, and `gjc config set` now redact secret-like string settings by default, with `--show-secrets` as an explicit unsafe opt-in.
+
 - `/new` session-start notifications now render directly under the welcome panel instead of leaving an extra blank row above the confirmation line.
 - Goal completion now preserves the terminal `goal({op: "complete"})` state even when a `goal_updated` extension hook throws, preventing hook-side write errors from trapping a verified ultragoal run in the continuation loop.
 - Ultragoal completion no longer requires the computer-use red-team suite for non-computer changes that only touch the shared `tools/index.ts` registration file.

--- a/packages/coding-agent/src/cli/config-cli.ts
+++ b/packages/coding-agent/src/cli/config-cli.ts
@@ -33,6 +33,7 @@ export interface ConfigCommandArgs {
 	value?: string;
 	flags: {
 		json?: boolean;
+		showSecrets?: boolean;
 	};
 }
 // =============================================================================
@@ -47,6 +48,19 @@ type CliSettingDef = {
 };
 
 const ALL_SETTING_PATHS = Object.keys(SETTINGS_SCHEMA) as SettingPath[];
+const REDACTED_SECRET_VALUE = "<redacted>";
+const SECRET_SETTING_SEGMENT_PATTERN = /(?:api[-_]?key|token|secret|password|passwd|pwd|credential)/i;
+
+function isSecretSettingPath(path: string): boolean {
+	return path.split(".").some(segment => SECRET_SETTING_SEGMENT_PATTERN.test(segment));
+}
+
+function redactConfigValue(path: string, value: unknown, showSecrets?: boolean): unknown {
+	if (showSecrets || typeof value !== "string" || !isSecretSettingPath(path)) {
+		return value;
+	}
+	return REDACTED_SECRET_VALUE;
+}
 
 /** Find setting definition by path */
 function findSettingDef(path: string): CliSettingDef | undefined {
@@ -105,6 +119,8 @@ export function parseConfigArgs(args: string[]): ConfigCommandArgs | undefined {
 		const arg = args[i];
 		if (arg === "--json") {
 			result.flags.json = true;
+		} else if (arg === "--show-secrets") {
+			result.flags.showSecrets = true;
 		} else if (!arg.startsWith("-")) {
 			positionalArgs.push(arg);
 		}
@@ -265,14 +281,15 @@ export async function runConfigCommand(cmd: ConfigCommandArgs): Promise<void> {
 	}
 }
 
-function handleList(flags: { json?: boolean }): void {
+function handleList(flags: { json?: boolean; showSecrets?: boolean }): void {
 	const defs = ALL_SETTING_PATHS.map(path => findSettingDef(path)).filter((def): def is CliSettingDef => !!def);
 
 	if (flags.json) {
 		const result: Record<string, { value: unknown; type: string; description: string }> = {};
 		for (const def of defs) {
+			const value = settings.get(def.path);
 			result[def.path] = {
-				value: settings.get(def.path),
+				value: redactConfigValue(def.path, value, flags.showSecrets),
 				type: def.type,
 				description: def.description,
 			};
@@ -301,7 +318,8 @@ function handleList(flags: { json?: boolean }): void {
 		console.log(chalk.bold.blue(`[${group}]`));
 		for (const def of groups[group]) {
 			const value = settings.get(def.path);
-			const valueStr = formatValue(value);
+			const displayValue = redactConfigValue(def.path, value, flags.showSecrets);
+			const valueStr = formatValue(displayValue);
 			const typeStr = getTypeDisplay(def);
 			console.log(`  ${chalk.white(def.path)} = ${valueStr} ${chalk.dim(typeStr)}`);
 		}
@@ -309,7 +327,7 @@ function handleList(flags: { json?: boolean }): void {
 	}
 }
 
-function handleGet(key: string | undefined, flags: { json?: boolean }): void {
+function handleGet(key: string | undefined, flags: { json?: boolean; showSecrets?: boolean }): void {
 	if (!key) {
 		console.error(chalk.red(`Usage: ${APP_NAME} config get <key>`));
 		console.error(chalk.dim(`\nRun '${APP_NAME} config list' to see available keys`));
@@ -324,16 +342,23 @@ function handleGet(key: string | undefined, flags: { json?: boolean }): void {
 	}
 
 	const value = settings.get(def.path);
+	const displayValue = redactConfigValue(def.path, value, flags.showSecrets);
 
 	if (flags.json) {
-		console.log(JSON.stringify({ key: def.path, value, type: def.type, description: def.description }, null, 2));
+		console.log(
+			JSON.stringify({ key: def.path, value: displayValue, type: def.type, description: def.description }, null, 2),
+		);
 		return;
 	}
 
-	console.log(formatValue(value));
+	console.log(formatValue(displayValue));
 }
 
-async function handleSet(key: string | undefined, value: string | undefined, flags: { json?: boolean }): Promise<void> {
+async function handleSet(
+	key: string | undefined,
+	value: string | undefined,
+	flags: { json?: boolean; showSecrets?: boolean },
+): Promise<void> {
 	if (!key || value === undefined) {
 		console.error(chalk.red(`Usage: ${APP_NAME} config set <key> <value>`));
 		console.error(chalk.dim(`\nRun '${APP_NAME} config list' to see available keys`));
@@ -355,11 +380,12 @@ async function handleSet(key: string | undefined, value: string | undefined, fla
 	}
 
 	const newValue = settings.get(def.path);
+	const displayValue = redactConfigValue(def.path, newValue, flags.showSecrets);
 
 	if (flags.json) {
-		console.log(JSON.stringify({ key: def.path, value: newValue }));
+		console.log(JSON.stringify({ key: def.path, value: displayValue }));
 	} else {
-		console.log(chalk.green(`${theme.status.success} Set ${def.path} = ${formatValue(newValue)}`));
+		console.log(chalk.green(`${theme.status.success} Set ${def.path} = ${formatValue(displayValue)}`));
 	}
 }
 
@@ -409,6 +435,7 @@ ${chalk.bold("Commands:")}
 
 ${chalk.bold("Options:")}
   --json             Output as JSON
+  --show-secrets     Show secret-like setting values without redaction (unsafe)
 
 ${chalk.bold("Examples:")}
   ${APP_NAME} config list
@@ -418,6 +445,7 @@ ${chalk.bold("Examples:")}
   ${APP_NAME} config set defaultThinkingLevel medium
   ${APP_NAME} config reset steeringMode
   ${APP_NAME} config list --json
+  ${APP_NAME} config get auth.broker.token --show-secrets
   ${APP_NAME} config init-xdg
 
 ${chalk.bold("Boolean Values:")}

--- a/packages/coding-agent/src/commands/config.ts
+++ b/packages/coding-agent/src/commands/config.ts
@@ -29,6 +29,7 @@ export default class Config extends Command {
 
 	static flags = {
 		json: Flags.boolean({ description: "Output JSON" }),
+		"show-secrets": Flags.boolean({ description: "Show secret-like setting values without redaction (unsafe)" }),
 	};
 
 	async run(): Promise<void> {
@@ -42,6 +43,7 @@ export default class Config extends Command {
 			value,
 			flags: {
 				json: flags.json,
+				showSecrets: flags["show-secrets"],
 			},
 		};
 

--- a/packages/coding-agent/test/config-cli.test.ts
+++ b/packages/coding-agent/test/config-cli.test.ts
@@ -127,4 +127,80 @@ describe("config CLI schema coverage", () => {
 			value: 600,
 		});
 	});
+
+	describe("secret redaction", () => {
+		it("redacts secret-like values in list, get, and set output by default", async () => {
+			const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+			const brokerSecret = "broker-token-secret-123";
+			const apiSecret = "hindsight-api-token-secret-123";
+
+			await runConfigCommand({
+				action: "set",
+				key: "auth.broker.token",
+				value: brokerSecret,
+				flags: { json: true },
+			});
+			await runConfigCommand({ action: "set", key: "hindsight.apiToken", value: apiSecret, flags: { json: true } });
+			await runConfigCommand({ action: "get", key: "auth.broker.token", flags: { json: true } });
+			await runConfigCommand({ action: "list", flags: { json: true } });
+
+			const setPayload = JSON.parse(String(logSpy.mock.calls.at(-4)?.[0])) as { value: unknown };
+			const apiTokenSetPayload = JSON.parse(String(logSpy.mock.calls.at(-3)?.[0])) as { value: unknown };
+			const getPayload = JSON.parse(String(logSpy.mock.calls.at(-2)?.[0])) as { value: unknown };
+			const listPayload = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0])) as Record<string, { value: unknown }>;
+
+			expect(setPayload.value).toBe("<redacted>");
+			expect(apiTokenSetPayload.value).toBe("<redacted>");
+			expect(getPayload.value).toBe("<redacted>");
+			expect(listPayload["auth.broker.token"]?.value).toBe("<redacted>");
+			expect(listPayload["hindsight.apiToken"]?.value).toBe("<redacted>");
+			expect(JSON.stringify(setPayload)).not.toContain(brokerSecret);
+			expect(JSON.stringify(apiTokenSetPayload)).not.toContain(apiSecret);
+			expect(JSON.stringify(getPayload)).not.toContain(brokerSecret);
+			expect(JSON.stringify(listPayload)).not.toContain(brokerSecret);
+			expect(JSON.stringify(listPayload)).not.toContain(apiSecret);
+		});
+
+		it("keeps non-secret booleans visible while redacting secret-shaped keys in text output", async () => {
+			const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+			const secret = "telegram-token-secret-456";
+
+			await runConfigCommand({
+				action: "set",
+				key: "notifications.telegram.botToken",
+				value: secret,
+				flags: { json: true },
+			});
+			await runConfigCommand({ action: "set", key: "notifications.enabled", value: "true", flags: { json: true } });
+			await runConfigCommand({ action: "get", key: "notifications.enabled", flags: {} });
+			const enabledGet = Bun.stripANSI(String(logSpy.mock.calls.at(-1)?.[0]));
+			await runConfigCommand({ action: "list", flags: {} });
+
+			const listOutput = logSpy.mock.calls.map(call => Bun.stripANSI(String(call[0] ?? ""))).join("\n");
+
+			expect(enabledGet).toBe("true");
+			expect(listOutput).toContain("notifications.enabled = true");
+			expect(listOutput).toContain("notifications.telegram.botToken = <redacted>");
+			expect(listOutput).not.toContain(secret);
+		});
+
+		it("shows secret-like values only with the explicit unsafe opt-in", async () => {
+			const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+			const secret = "broker-token-secret-789";
+
+			await runConfigCommand({
+				action: "set",
+				key: "auth.broker.token",
+				value: secret,
+				flags: { json: true, showSecrets: true },
+			});
+			await runConfigCommand({ action: "get", key: "auth.broker.token", flags: { json: true, showSecrets: true } });
+
+			const setPayload = JSON.parse(String(logSpy.mock.calls.at(-2)?.[0])) as { value: unknown };
+			const getPayload = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0])) as { value: unknown };
+
+			expect(setPayload.value).toBe(secret);
+			expect(getPayload.value).toBe(secret);
+		});
+	});
 });


### PR DESCRIPTION
Fixes #1556.

## Summary
- redact secret-like string settings in `gjc config list`, `gjc config get`, and `gjc config set` output by default
- add `--show-secrets` as an explicit unsafe opt-in for config output
- add regression coverage for token/API-token settings and non-secret boolean visibility
- document the fix in the coding-agent changelog

## Verification
- `bun test test/config-cli.test.ts`
- `bunx biome check src/cli/config-cli.ts src/commands/config.ts test/config-cli.test.ts CHANGELOG.md`
- `bun run check:types`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*