### PR TITLE
docs(compaction): correct prune-policy accuracy for read + notice format

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -125,11 +125,12 @@ Default prune policy:
 
 - Protect newest `40_000` tool-output tokens.
 - Require at least `20_000` total estimated savings.
-- Never prune tool results from `skill` or `read`.
+- Never prune `skill` tool results. `read` results are protected too, **except** when superseded — a later `read` of the same file, or a later successful edit/write to that file, waives `read` protection so the stale result may be pruned (`staleOverridableTools: ["read"]`). The most recent result per target is never treated as superseded.
 
-Pruned tool results are replaced with:
+Pruned tool results are replaced with a truncation notice:
 
-- `[Output truncated - N tokens]`
+- generic form: `[Output truncated - N tokens]`
+- for `bash`/`search`/`grep`, a short digest is appended: `[Output truncated - N tokens; <digest>]` (e.g. `exit=…; tail=…` for `bash`, `matches=…; files=…` for `search`/`grep`).
 
 If pruning changes entries, session storage is rewritten and agent message state is refreshed before compaction decisions.
 


### PR DESCRIPTION
## What

Docs-only. Corrects two inaccuracies in `docs/compaction.md`'s pre-compaction pruning section so it matches `packages/agent/src/compaction/pruning.ts`.

### 1. `read` protection is overstated

The doc said:

> - Never prune tool results from `skill` or `read`.

But `DEFAULT_PRUNE_CONFIG` lists `read` in `staleOverridableTools`, and the protection check waives it for superseded results:

```ts
// pruning.ts
staleOverridableTools: ["read"],
...
const isProtected =
  config.protectedTools.includes(message.toolName) && !(isStale && staleOverridable.has(message.toolName));
```

So a **superseded** `read` (the same file read again later, or a later successful edit/write to that file) loses protection and can be pruned even inside the recency window. Only `skill` is unconditionally protected.

### 2. Prune notice format is simplified

The doc showed only:

> - `[Output truncated - N tokens]`

But `createPrunedNotice` appends a digest for `bash`/`search`/`grep`:

```ts
const prefix = `[Output truncated - ${tokens} tokens; `;
...
return `${prefix}${truncateField(digest, maxChars)}${suffix}`;
```

The generic form is only the fallback for other tools.

## Change

- Clarifies that `skill` is never pruned, `read` is protected **except when superseded** (`staleOverridableTools: ["read"]`), and the most recent result per target is never treated as superseded.
- Documents both notice forms (generic + digest-augmented for bash/search/grep).

## Checks

Docs-only change; no code, tests, or changelog entry. Verified against `packages/agent/src/compaction/pruning.ts` (`DEFAULT_PRUNE_CONFIG`, `pruneToolOutputs`, `createPrunedNotice`, `resultDigest`).
