### PR TITLE
Improve CLI help surface and goal card spacing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -28,6 +28,10 @@
 - The main composer now uses `PageUp` / `PageDown` to page the visible transcript viewport instead of duplicating prompt-history navigation; `Up` / `Down` and `Ctrl+R` remain the prompt-history paths, and autocomplete lists keep their own page navigation.
 - Shared the duplicated two-column dashboard renderer used by agent and extension dashboards, keeping narrow-width truncation behavior in one tested component.
 - Avoided duplicate line splitting when formatting `ast_grep` matches, reducing allocation in large structural-search result rendering.
+- `/contribute-pr` in the interactive TUI now prepares the redacted manifest and worker prompt without spawning a second GJC process on the same terminal, avoiding competing TUI renderers that make the chat viewport jump around. Run the generated worker prompt from a separate terminal instead.
+- The interactive MCP add wizard now returns from no-auth scope selection to the URL/args step on Escape instead of jumping into the unrelated HTTP header-name prompt.
+
+### Fixed
 
 - Tab now queues prompt drafts immediately while the agent is streaming or compacting instead of opening/applying forced file autocomplete first.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - The Telegram notification daemon now tombstones a session endpoint generation after `session_closed`, preventing the scan loop from reconnecting to the still-live old endpoint and recreating an empty topic immediately after deleting the original topic.
 - `/contribute-pr` in the interactive TUI now prepares the redacted manifest and worker prompt without spawning a second GJC process on the same terminal, avoiding competing TUI renderers that make the chat viewport jump around. Run the generated worker prompt from a separate terminal instead.
+- `gjc stats --help`, `gjc auth-broker --help`, `gjc auth-gateway --help`, and `gjc commit --help` now route to their command-specific help instead of falling back to root launch help; root help also documents the accepted `--worktree` flag, current thinking levels, and the renamed `search` / `eval` tool names.
+- Goal tool result cards now include a top breathing row inside the colored block, making completed goal summaries less visually cramped in the TUI transcript.
 
 ## [0.8.0] - 2026-07-04
 

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -4,6 +4,7 @@
  * CLI entry point — registers all commands explicitly and delegates to the
  * lightweight CLI runner from pi-utils.
  */
+import { THINKING_EFFORTS } from "@gajae-code/ai";
 import { Args, type CliConfig, Command, type CommandEntry, Flags, run } from "@gajae-code/utils/cli";
 import { APP_NAME, formatBunRuntimeError, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
 
@@ -28,7 +29,10 @@ export const commands: CommandEntry[] = [
 	{ name: "setup", load: () => import("./commands/setup").then(m => m.default) },
 	{ name: "acp", load: () => import("./commands/acp").then(m => m.default) },
 	{ name: "skills", load: () => import("./commands/skills").then(m => m.default) },
+	{ name: "agents", load: () => import("./commands/agents").then(m => m.default) },
 	{ name: "session", load: () => import("./commands/session").then(m => m.default) },
+	{ name: "stats", load: () => import("./commands/stats").then(m => m.default) },
+	{ name: "worktree", aliases: ["wt"], load: () => import("./commands/worktree").then(m => m.default) },
 	{ name: "harness", load: () => import("./commands/harness").then(m => m.default) },
 	{ name: "coordinator", load: () => import("./commands/coordinator").then(m => m.default) },
 	{ name: "team", load: () => import("./commands/team").then(m => m.default) },
@@ -36,10 +40,17 @@ export const commands: CommandEntry[] = [
 	{ name: "gc", load: () => import("./commands/gc").then(m => m.default) },
 	{ name: "ralplan", load: () => import("./commands/ralplan").then(m => m.default) },
 	{ name: "config", load: () => import("./commands/config").then(m => m.default) },
+	{ name: "auth-broker", load: () => import("./commands/auth-broker").then(m => m.default) },
+	{ name: "auth-gateway", load: () => import("./commands/auth-gateway").then(m => m.default) },
+	{ name: "local-provider", load: () => import("./commands/local-provider").then(m => m.default) },
+	{ name: "ssh", load: () => import("./commands/ssh").then(m => m.default) },
 	{ name: "notify", load: () => import("./commands/notify").then(m => m.default) },
 	{ name: "daemon", load: () => import("./commands/daemon").then(m => m.default) },
 	{ name: "web-search", aliases: ["q"], load: () => import("./commands/web-search").then(m => m.default) },
-	{ name: "local-provider", load: () => import("./commands/local-provider").then(m => m.default) },
+	{ name: "read", load: () => import("./commands/read").then(m => m.default) },
+	{ name: "grep", load: () => import("./commands/grep").then(m => m.default) },
+	{ name: "shell", load: () => import("./commands/shell").then(m => m.default) },
+	{ name: "commit", load: () => import("./commands/commit").then(m => m.default) },
 	{ name: "mcp-serve", load: () => import("./commands/mcp-serve").then(m => m.default) },
 	{ name: "mcp", load: () => import("./commands/mcp").then(m => m.default) },
 	{
@@ -146,10 +157,16 @@ class RootHelpCommand extends Command {
 		"no-lsp": Flags.boolean({ description: "Disable LSP tools, formatting, and diagnostics" }),
 		"no-pty": Flags.boolean({ description: "Disable PTY-based interactive bash execution" }),
 		tmux: Flags.boolean({ description: "Launch interactive startup inside tmux" }),
+		worktree: Flags.string({
+			char: "w",
+			description: "Launch in a GJC-managed sibling git worktree; optional name creates/reuses that branch",
+			valueName: "name",
+			optionalValue: true,
+		}),
 		tools: Flags.string({ description: "Comma-separated list of tools to enable (default: all)" }),
 		thinking: Flags.string({
-			description: "Set thinking level: ultra, high, medium, low",
-			options: ["ultra", "high", "medium", "low"],
+			description: `Set thinking level: ${THINKING_EFFORTS.join(", ")}`,
+			options: [...THINKING_EFFORTS],
 		}),
 		hook: Flags.string({ description: "Load a hook/extension file (can be used multiple times)", multiple: true }),
 		extension: Flags.string({

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -265,8 +265,6 @@ export function getExtraHelpText(): string {
   GJC_SLOW_MODEL              - Override slow/reasoning model (see --slow)
   GJC_PLAN_MODEL              - Override planning model (see --plan)
   GJC_NO_PTY                  - Disable PTY-based interactive bash execution
-  --tmux                       - Launch interactive startup inside a fresh tmux session
-  gjc session                  - List, inspect, create, remove, or attach tagged GJC-managed tmux sessions
   GJC_LAUNCH_POLICY           - Launch policy for --tmux startup: tmux or direct
   GJC_TMUX_SESSION            - Explicit tmux session name override for --tmux startup
   GJC_TMUX_PROFILE            - Apply GJC tmux scroll/mouse/clipboard profile to --tmux sessions (set 0/off to skip)
@@ -274,16 +272,21 @@ export function getExtraHelpText(): string {
 
   For complete environment variable reference, see:
   ${chalk.dim("docs/environment-variables.md")}
+
+${chalk.bold("Launch Helpers:")}
+  --tmux                      - Launch interactive startup inside a fresh tmux session
+  --worktree[=<name>]         - Launch inside a GJC-managed sibling git worktree
+  gjc session                 - List, inspect, create, remove, or attach tagged GJC-managed tmux sessions
+
 ${chalk.bold("Available Tools (default-enabled unless noted):")}
   read          - Read file contents
   bash          - Execute bash commands
-  edit          - Edit files with find/replace
+  edit          - Edit files with line-anchored patches
   write         - Write files (creates/overwrites)
-  grep          - Search file contents
+  search        - Search file contents
   find          - Find files by glob pattern
+  eval          - Execute Python or JavaScript snippets when enabled
   lsp           - Language server protocol (code intelligence)
-  python        - Execute Python code (requires: ${APP_NAME} setup python)
-  notebook      - Edit Jupyter notebooks
   browser       - Browser automation (Puppeteer)
   task          - Launch sub-agents for parallel tasks
   todo_write    - Manage todo/task lists

--- a/packages/coding-agent/src/cli/fast-help.ts
+++ b/packages/coding-agent/src/cli/fast-help.ts
@@ -5,7 +5,10 @@ export function getExtraHelpText(): string {
   ${APP_NAME} [prompt]             - Start an interactive coding session (default launch command)
   ${APP_NAME} launch               - Start an explicit launch/session workflow
   ${APP_NAME} setup                - Install GJC defaults or optional dependencies
+  ${APP_NAME} acp                  - Run Agent Client Protocol mode
   ${APP_NAME} session              - List, inspect, create, remove, or attach sessions
+  ${APP_NAME} stats                - View usage statistics
+  ${APP_NAME} worktree             - List or clear agent-managed git worktrees (alias: wt)
   ${APP_NAME} state                - Inspect or manage persisted GJC state
   ${APP_NAME} harness              - Run harness control-plane commands
   ${APP_NAME} coordinator          - Manage coordinator/runtime coordination helpers
@@ -14,7 +17,12 @@ export function getExtraHelpText(): string {
   ${APP_NAME} ralplan              - Run consensus planning workflow
   ${APP_NAME} deep-interview       - Run requirements interview workflow
   ${APP_NAME} skills               - List/read embedded workflow skills
+  ${APP_NAME} agents               - Manage bundled task agents
   ${APP_NAME} config               - List, get, and set configuration values
+  ${APP_NAME} auth-broker          - Manage the credential vault
+  ${APP_NAME} auth-gateway         - Run a broker-backed auth forward proxy
+  ${APP_NAME} local-provider       - Manage local provider helpers
+  ${APP_NAME} ssh                  - Manage SSH host configurations
   ${APP_NAME} notify               - Send or test notifications
   ${APP_NAME} daemon               - Manage background daemon helpers
   ${APP_NAME} mcp                  - Manage MCP server registrations
@@ -25,6 +33,10 @@ export function getExtraHelpText(): string {
   ${APP_NAME} update               - Update GJC installation artifacts
   ${APP_NAME} plugin               - Install, remove, and list plugins
   ${APP_NAME} web-search           - Search the web from the CLI (alias: q)
+  ${APP_NAME} read                 - Preview read-tool output for a path or URL
+  ${APP_NAME} grep                 - Test native grep search
+  ${APP_NAME} shell                - Open an interactive shell console
+  ${APP_NAME} commit               - Generate a commit message and changelogs
   ${APP_NAME} codex-native-hook    - Run Codex native hook integration
   ${APP_NAME} gc                   - Run garbage-collection/cleanup helpers
   ${APP_NAME} <command> --help     - Show command-specific help
@@ -78,8 +90,6 @@ Environment Variables:
   GJC_SLOW_MODEL              - Override slow/reasoning model (see --slow)
   GJC_PLAN_MODEL              - Override planning model (see --plan)
   GJC_NO_PTY                  - Disable PTY-based interactive bash execution
-  --tmux                       - Launch interactive startup inside a fresh tmux session
-  gjc session                  - List, inspect, create, remove, or attach tagged GJC-managed tmux sessions
   GJC_LAUNCH_POLICY           - Launch policy for --tmux startup: tmux or direct
   GJC_TMUX_SESSION            - Explicit tmux session name override for --tmux startup
   GJC_TMUX_PROFILE            - Apply GJC tmux scroll/mouse/clipboard profile to --tmux sessions (set 0/off to skip)
@@ -87,16 +97,21 @@ Environment Variables:
 
   For complete environment variable reference, see:
   docs/environment-variables.md
+
+Launch Helpers:
+  --tmux                      - Launch interactive startup inside a fresh tmux session
+  --worktree[=<name>]         - Launch inside a GJC-managed sibling git worktree
+  gjc session                 - List, inspect, create, remove, or attach tagged GJC-managed tmux sessions
+
 Available Tools (default-enabled unless noted):
   read          - Read file contents
   bash          - Execute bash commands
-  edit          - Edit files with find/replace
+  edit          - Edit files with line-anchored patches
   write         - Write files (creates/overwrites)
-  grep          - Search file contents
+  search        - Search file contents
   find          - Find files by glob pattern
+  eval          - Execute Python or JavaScript snippets when enabled
   lsp           - Language server protocol (code intelligence)
-  python        - Execute Python code (requires: ${APP_NAME} setup python)
-  notebook      - Edit Jupyter notebooks
   browser       - Browser automation (Puppeteer)
   task          - Launch sub-agents for parallel tasks
   todo_write    - Manage todo/task lists

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -133,6 +133,12 @@ export default class Index extends Command {
 		tmux: Flags.boolean({
 			description: "Launch interactive startup inside tmux",
 		}),
+		worktree: Flags.string({
+			char: "w",
+			description: "Launch in a GJC-managed sibling git worktree; optional name creates/reuses that branch",
+			valueName: "name",
+			optionalValue: true,
+		}),
 		tools: Flags.string({
 			description: "Comma-separated list of tools to enable (default: all)",
 		}),

--- a/packages/coding-agent/src/goals/tools/goal-tool.ts
+++ b/packages/coding-agent/src/goals/tools/goal-tool.ts
@@ -1,6 +1,5 @@
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
-import type { Component } from "@gajae-code/tui";
-import { Text } from "@gajae-code/tui";
+import { type Component, Container, Spacer, Text } from "@gajae-code/tui";
 import { formatNumber, prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
@@ -194,6 +193,13 @@ interface GoalRenderArgs {
 	objective?: string;
 }
 
+function renderGoalTextBlock(text: string): Component {
+	const container = new Container();
+	container.addChild(new Spacer(1));
+	container.addChild(new Text(text, 0, 0));
+	return container;
+}
+
 export const goalToolRenderer = {
 	renderCall(args: GoalRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
 		const description = describeOp(args.op);
@@ -204,7 +210,7 @@ export const goalToolRenderer = {
 			meta.push(uiTheme.italic(uiTheme.fg("muted", `"${objective}"`)));
 		}
 		const text = renderStatusLine({ icon: "pending", title: "Goal", description, meta }, uiTheme);
-		return new Text(text, 0, 0);
+		return renderGoalTextBlock(text);
 	},
 
 	renderResult(
@@ -221,14 +227,14 @@ export const goalToolRenderer = {
 		if (result.isError) {
 			const header = renderStatusLine({ icon: "error", title: "Goal", description }, uiTheme);
 			const body = formatErrorMessage(fallbackText || "Goal tool failed", uiTheme);
-			return new Text([header, body].join("\n"), 0, 0);
+			return renderGoalTextBlock([header, body].join("\n"));
 		}
 
 		const goal = details?.goal ?? null;
 		if (!goal) {
 			const header = renderStatusLine({ icon: "warning", title: "Goal", description }, uiTheme);
 			const body = uiTheme.fg("muted", "No active goal.");
-			return new Text([header, body].join("\n"), 0, 0);
+			return renderGoalTextBlock([header, body].join("\n"));
 		}
 
 		const lines: string[] = [];
@@ -252,7 +258,7 @@ export const goalToolRenderer = {
 			lines.push(`  ${uiTheme.fg("dim", `${formatDuration(goal.timeUsedSeconds * 1000)} elapsed`)}`);
 		}
 
-		return new Text(lines.join("\n"), 0, 0);
+		return renderGoalTextBlock(lines.join("\n"));
 	},
 
 	mergeCallAndResult: true,

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -241,6 +241,9 @@ export class CustomEditor extends Editor {
 		if (this.onPasteText) {
 			const paste = this.#pasteHandler.process(data);
 			if (paste.handled) {
+				if (paste.normalText) {
+					this.handleInput(paste.normalText);
+				}
 				if (paste.pasteContent !== undefined) {
 					this.#handleBracketedPaste(paste.pasteContent, paste.remaining);
 				}

--- a/packages/coding-agent/src/modes/components/runtime-mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/runtime-mcp-add-wizard.ts
@@ -817,8 +817,16 @@ export class MCPAddWizard extends Container {
 				}
 				break;
 			case "scope":
-				// Go back to last authentication step
-				if (this.#state.authMethod === "oauth") {
+				// Go back to the last configuration step. No-auth flows come straight
+				// from the transport connection step; manual/OAuth flows come from
+				// their respective auth detail steps.
+				if (this.#state.authMethod === "none") {
+					if (this.#state.transport === "stdio") {
+						this.#currentStep = "args";
+					} else {
+						this.#currentStep = "url";
+					}
+				} else if (this.#state.authMethod === "oauth") {
 					this.#currentStep = "oauth-scopes";
 				} else {
 					// manual - go back to env var name or header name

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -22,7 +22,10 @@ describe("GJC public CLI command surface", () => {
 			"setup",
 			"acp",
 			"skills",
+			"agents",
 			"session",
+			"stats",
+			"worktree",
 			"harness",
 			"coordinator",
 			"team",
@@ -30,10 +33,17 @@ describe("GJC public CLI command surface", () => {
 			"gc",
 			"ralplan",
 			"config",
+			"auth-broker",
+			"auth-gateway",
+			"local-provider",
+			"ssh",
 			"notify",
 			"daemon",
 			"web-search",
-			"local-provider",
+			"read",
+			"grep",
+			"shell",
+			"commit",
 			"mcp-serve",
 			"mcp",
 			"contribute-pr",
@@ -60,6 +70,42 @@ describe("GJC public CLI command surface", () => {
 		expect(stdout).toContain("Check for and install updates");
 		expect(combined).not.toContain("What's New");
 		expect(combined).not.toContain("chatContainer");
+	}, 30_000);
+
+	it("routes documented utility command help instead of falling back to root launch help", () => {
+		for (const [command, expected] of [
+			["stats", "View usage statistics"],
+			["auth-broker", "Manage the gjc auth-broker"],
+			["auth-gateway", "Run an auth-gateway forward proxy"],
+			["commit", "Generate a commit message"],
+		]) {
+			const result = Bun.spawnSync(["bun", cliEntry, command, "--help"], {
+				cwd: repoRoot,
+				stderr: "pipe",
+				stdout: "pipe",
+			});
+			const output = `${result.stdout.toString()}\n${result.stderr.toString()}`;
+
+			expect(result.exitCode, output).toBe(0);
+			expect(output).toContain(expected);
+			expect(output).not.toContain("USAGE\n  $ gjc [COMMAND]");
+		}
+	}, 30_000);
+
+	it("keeps root launch help aligned with accepted flags and current tool names", () => {
+		const result = Bun.spawnSync(["bun", cliEntry, "--help"], {
+			cwd: repoRoot,
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		const output = `${result.stdout.toString()}\n${result.stderr.toString()}`;
+
+		expect(result.exitCode, output).toBe(0);
+		expect(output).toContain("-w, --worktree[=<name>]");
+		expect(output).toContain("Set thinking level: minimal, low, medium, high, xhigh, max");
+		expect(output).toContain("search        - Search file contents");
+		expect(output).not.toContain("grep          - Search file contents");
+		expect(output).not.toContain("python        - Execute Python code");
 	}, 30_000);
 
 	it("documents the native CLI surface in command help", async () => {

--- a/packages/coding-agent/test/runtime-mcp-add-wizard.test.ts
+++ b/packages/coding-agent/test/runtime-mcp-add-wizard.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { MCPAddWizard } from "../src/modes/components/runtime-mcp-add-wizard";
+
+function visibleText(component: { render(width: number): string[] }): string {
+	return Bun.stripANSI(component.render(160).join("\n"));
+}
+
+function typeText(component: { handleInput(input: string): void }, text: string): void {
+	for (const char of text) component.handleInput(char);
+}
+
+async function flushAsync(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("MCP add wizard", () => {
+	beforeEach(async () => {
+		vi.useFakeTimers();
+		await initTheme(false);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("returns from no-auth scope selection to the transport connection step", async () => {
+		const wizard = new MCPAddWizard(
+			() => undefined,
+			() => undefined,
+			undefined,
+			async () => undefined,
+			undefined,
+			"example-server",
+		);
+
+		wizard.handleInput("\x1b[B"); // http transport
+		wizard.handleInput("\n");
+		expect(visibleText(wizard)).toContain("Step 3: Server URL");
+
+		typeText(wizard, "https://example.test/mcp");
+		wizard.handleInput("\n");
+		await flushAsync();
+		vi.advanceTimersByTime(1_000);
+		await flushAsync();
+		expect(visibleText(wizard)).toContain("Step: Configuration Scope");
+
+		wizard.handleInput("\x1b");
+		const afterBack = visibleText(wizard);
+		expect(afterBack).toContain("Step 3: Server URL");
+		expect(afterBack).not.toContain("Step: HTTP Header Name");
+	});
+});

--- a/packages/coding-agent/test/tool-execution-spacing.test.ts
+++ b/packages/coding-agent/test/tool-execution-spacing.test.ts
@@ -1,0 +1,44 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AgentTool } from "@gajae-code/agent-core";
+import { ToolExecutionComponent } from "@gajae-code/coding-agent/modes/components/tool-execution";
+import * as themeModule from "@gajae-code/coding-agent/modes/theme/theme";
+import type { TUI } from "@gajae-code/tui";
+
+beforeAll(async () => {
+	await themeModule.initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+});
+
+describe("ToolExecutionComponent spacing", () => {
+	it("adds a top breathing row inside goal result blocks", () => {
+		const uiStub = { requestRender() {} } as unknown as TUI;
+		const goalTool = { name: "goal", label: "Goal" } as unknown as AgentTool;
+		const component = new ToolExecutionComponent("goal", { op: "complete" }, {}, goalTool, uiStub);
+
+		component.updateResult(
+			{
+				content: [
+					{
+						type: "text",
+						text: 'Goal: "Red-team Gajae usability"\nStatus: complete\nTokens used: 326K',
+					},
+				],
+				details: {
+					op: "complete",
+					goal: {
+						objective: "Red-team Gajae usability",
+						status: "complete",
+						tokensUsed: 326000,
+						timeUsedSeconds: 720,
+					},
+				},
+			},
+			false,
+		);
+
+		const lines = component.render(120).map(line => Bun.stripANSI(line));
+		expect(lines[0]?.trim()).toBe("");
+		expect(lines[1]?.trim()).toBe("");
+		expect(lines[2]).toContain("Goal");
+		expect(lines[3]).toContain('"Red-team Gajae usability"');
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added manual transcript viewport paging support so applications can repaint older terminal output with PageUp/PageDown without reusing editor history navigation.
 
 - Empty select/settings lists now still honor cancel while preserving populated-list keybinding precedence, and settings lists keep selection indices clamped when items disappear or submenus close after list shrinkage.
+- Bracketed paste handling now buffers a start marker split across input chunks instead of leaking raw `\x1b[200~` fragments into editors/search fields.
 
 - Fixed Windows Hangul/CJK IME composition breaking the queue-message shortcut (Alt+Enter/Alt+Q): the app no longer enables the xterm `modifyOtherKeys` fallback on win32, where Windows Terminal/conhost do not support the Kitty keyboard protocol anyway. `modifyOtherKeys` made modified-key chords bypass the IME commit, so a syllable still being composed was dropped and the queue action fired on empty text unless the user typed a trailing space first. Legacy encodings still deliver Alt+Enter and the newline chords; opt back into the enhancement with `GJC_TUI_KEYBOARD_PROTOCOL`.
 

--- a/packages/tui/src/bracketed-paste.ts
+++ b/packages/tui/src/bracketed-paste.ts
@@ -1,7 +1,16 @@
 const PASTE_START = "\x1b[200~";
 const PASTE_END = "\x1b[201~";
 
-export type PasteResult = { handled: false } | { handled: true; pasteContent?: string; remaining: string };
+type HandledPasteResult = { handled: true; normalText?: string; pasteContent?: string; remaining: string };
+export type PasteResult = { handled: false } | HandledPasteResult;
+
+function trailingPasteStartPrefixLength(value: string): number {
+	const maxLength = Math.min(PASTE_START.length - 1, value.length);
+	for (let length = maxLength; length >= 2; length--) {
+		if (PASTE_START.startsWith(value.slice(-length))) return length;
+	}
+	return 0;
+}
 
 /**
  * Handles bracketed paste mode buffering for terminal input components.
@@ -13,6 +22,7 @@ export type PasteResult = { handled: false } | { handled: true; pasteContent?: s
 export class BracketedPasteHandler {
 	#buffer = "";
 	#active = false;
+	#pendingStart = "";
 
 	/**
 	 * Process incoming terminal data for bracketed paste sequences.
@@ -23,14 +33,41 @@ export class BracketedPasteHandler {
 	 *          paste has been assembled; omitted when still buffering.
 	 */
 	process(data: string): PasteResult {
-		if (data.includes(PASTE_START)) {
-			this.#active = true;
-			this.#buffer = "";
-			data = data.replace(PASTE_START, "");
+		if (this.#active) {
+			return this.#consumeActivePaste(data);
 		}
 
-		if (!this.#active) return { handled: false };
+		const hadPendingStart = this.#pendingStart.length > 0;
+		const input = `${this.#pendingStart}${data}`;
+		this.#pendingStart = "";
 
+		const startIndex = input.indexOf(PASTE_START);
+		if (startIndex !== -1) {
+			this.#active = true;
+			this.#buffer = "";
+			const normalText = input.slice(0, startIndex);
+			const paste = this.#consumeActivePaste(input.slice(startIndex + PASTE_START.length));
+			if (normalText.length > 0) {
+				return { ...paste, normalText };
+			}
+			return paste;
+		}
+
+		const pendingLength = trailingPasteStartPrefixLength(input);
+		if (pendingLength > 0) {
+			this.#pendingStart = input.slice(-pendingLength);
+			const normalText = input.slice(0, -pendingLength);
+			return normalText.length > 0 ? { handled: true, normalText, remaining: "" } : { handled: true, remaining: "" };
+		}
+
+		if (hadPendingStart) {
+			return { handled: true, normalText: input, remaining: "" };
+		}
+
+		return { handled: false };
+	}
+
+	#consumeActivePaste(data: string): HandledPasteResult {
 		this.#buffer += data;
 
 		const endIndex = this.#buffer.indexOf(PASTE_END);

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1057,6 +1057,9 @@ export class Editor implements Component, Focusable {
 		// Handle bracketed paste mode
 		const paste = this.#pasteHandler.process(data);
 		if (paste.handled) {
+			if (paste.normalText) {
+				this.handleInput(paste.normalText);
+			}
 			if (paste.pasteContent !== undefined) {
 				this.#handlePaste(paste.pasteContent);
 				if (paste.remaining.length > 0) {

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -66,6 +66,9 @@ export class Input implements Component, Focusable {
 		// Handle bracketed paste mode
 		const paste = this.#pasteHandler.process(data);
 		if (paste.handled) {
+			if (paste.normalText) {
+				this.handleInput(paste.normalText);
+			}
 			if (paste.pasteContent !== undefined) {
 				this.#handlePaste(paste.pasteContent);
 				if (paste.remaining.length > 0) {

--- a/packages/tui/test/bracketed-paste.test.ts
+++ b/packages/tui/test/bracketed-paste.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { BracketedPasteHandler } from "../src/bracketed-paste";
+
+describe("BracketedPasteHandler", () => {
+	it("assembles a paste when the start marker arrives in one chunk", () => {
+		const handler = new BracketedPasteHandler();
+
+		expect(handler.process("\x1b[200~hello\x1b[201~")).toEqual({
+			handled: true,
+			pasteContent: "hello",
+			remaining: "",
+		});
+	});
+	it("does not treat a standalone Escape key as a pending paste", () => {
+		const handler = new BracketedPasteHandler();
+
+		expect(handler.process("\x1b")).toEqual({ handled: false });
+	});
+
+	it("buffers a split start marker before collecting paste content", () => {
+		const handler = new BracketedPasteHandler();
+
+		expect(handler.process("\x1b[200")).toEqual({ handled: true, remaining: "" });
+		expect(handler.process("~hello\x1b[201~")).toEqual({
+			handled: true,
+			pasteContent: "hello",
+			remaining: "",
+		});
+	});
+
+	it("keeps normal text before a split start marker replayable", () => {
+		const handler = new BracketedPasteHandler();
+
+		expect(handler.process("prefix\x1b[200")).toEqual({
+			handled: true,
+			normalText: "prefix",
+			remaining: "",
+		});
+		expect(handler.process("~payload\x1b[201~suffix")).toEqual({
+			handled: true,
+			pasteContent: "payload",
+			remaining: "suffix",
+		});
+	});
+
+	it("keeps split end marker buffering intact", () => {
+		const handler = new BracketedPasteHandler();
+
+		expect(handler.process("\x1b[200~hello\x1b[201")).toEqual({ handled: true, remaining: "" });
+		expect(handler.process("~tail")).toEqual({
+			handled: true,
+			pasteContent: "hello",
+			remaining: "tail",
+		});
+	});
+});

--- a/packages/utils/src/cli.ts
+++ b/packages/utils/src/cli.ts
@@ -23,6 +23,8 @@ export interface FlagDescriptor<K extends "string" | "boolean" | "integer" = "st
 	multiple?: boolean;
 	options?: readonly string[];
 	required?: boolean;
+	valueName?: string;
+	optionalValue?: boolean;
 }
 
 export interface ArgDescriptor {
@@ -40,6 +42,8 @@ interface FlagInput {
 	multiple?: boolean;
 	options?: readonly string[];
 	required?: boolean;
+	valueName?: string;
+	optionalValue?: boolean;
 }
 
 interface ArgInput {
@@ -317,7 +321,9 @@ function renderCommandBody(lines: string[], Cmd: CommandCtor): void {
 		for (const [name, desc] of flagEntries) {
 			const charPart = desc.char ? `-${desc.char}, ` : "    ";
 			const namePart = `--${name}`;
-			const typePart = desc.kind === "boolean" ? "" : desc.kind === "integer" ? "=<int>" : "=<value>";
+			const valueName = desc.valueName ?? (desc.kind === "integer" ? "int" : "value");
+			const typePart =
+				desc.kind === "boolean" ? "" : desc.optionalValue ? `[=<${valueName}>]` : `=<${valueName}>`;
 			formatted.push([`  ${charPart}${namePart}${typePart}`, desc.description ?? ""]);
 		}
 		const maxLeft = Math.max(...formatted.map(([l]) => l.length));


### PR DESCRIPTION
## Summary
- Register shipped CLI command modules so their command-level help is reachable.
- Refresh root/launch help output for current commands, tools, thinking levels, and optional-value flags.
- Add a top breathing row to goal tool result cards to reduce cramped TUI spacing.

## Verification
- bun test packages/coding-agent/test/cli-command-surface.test.ts packages/coding-agent/test/cli-command-registry.test.ts packages/coding-agent/test/tool-execution-spacing.test.ts
- bun run check (packages/coding-agent)
- git diff --check