### PR TITLE
Fix subagent Telegram notification threads

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -205,6 +205,7 @@ export class ExtensionRunner {
 		private readonly cwd: string,
 		private readonly sessionManager: SessionManager,
 		private readonly modelRegistry: ModelRegistry,
+		private readonly sessionMetadata?: ExtensionContext["sessionMetadata"],
 	) {
 		this.#uiContext = noOpUIContext;
 	}
@@ -458,6 +459,7 @@ export class ExtensionRunner {
 			hasUI: this.hasUI(),
 			cwd: this.cwd,
 			sessionManager: this.sessionManager,
+			sessionMetadata: this.sessionMetadata,
 			modelRegistry: this.modelRegistry,
 			get model() {
 				return getModel();

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -285,6 +285,13 @@ export interface CompactOptions {
 	onError?: (error: Error) => void;
 }
 
+export interface ExtensionSessionMetadata {
+	kind: "main" | "sub";
+	taskDepth: number;
+	parentTaskPrefix?: string;
+	currentAgentType?: string;
+}
+
 /**
  * Context passed to extension event handlers.
  */
@@ -306,6 +313,8 @@ export interface ExtensionContext {
 	cwd: string;
 	/** Session manager (read-only) */
 	sessionManager: ReadonlySessionManager;
+	/** Session classification supplied by the SDK for extension policy decisions. */
+	sessionMetadata?: ExtensionSessionMetadata;
 	/** Model registry for API key resolution */
 	modelRegistry: ModelRegistry;
 	/** Current model (may be undefined) */

--- a/packages/coding-agent/src/notifications/config.ts
+++ b/packages/coding-agent/src/notifications/config.ts
@@ -56,8 +56,10 @@ export function shouldRegisterNotificationsExtension(input: {
 	taskDepth?: number;
 	/** Parent subagent id/prefix; present for helper/subagent sessions even when depth is omitted. */
 	parentTaskPrefix?: string;
+	/** Role-agent type/name; present for task sessions even if depth metadata is lost. */
+	currentAgentType?: string;
 }): boolean {
-	if ((input.taskDepth ?? 0) > 0 || input.parentTaskPrefix) return false;
+	if ((input.taskDepth ?? 0) > 0 || input.parentTaskPrefix || input.currentAgentType) return false;
 	if (input.env.GJC_NOTIFICATIONS === "0") return false;
 	if (input.env.GJC_NOTIFICATIONS === "1" || input.env.GJC_NOTIFICATIONS_TOKEN) return true;
 	return input.cfg ? isGloballyConfigured(input.cfg) : false;

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -531,10 +531,14 @@ export function createNotificationsExtension(api: ExtensionAPI, options: { setti
 		return isSessionNotificationsEnabled({ cfg, env: process.env, sessionDisabled: disabledSessions.has(id) });
 	}
 
+	function isNotificationEligibleContext(ctx: ExtensionContext): boolean {
+		return ctx.sessionMetadata?.kind !== "sub";
+	}
+
 	async function startSession(ctx: ExtensionContext): Promise<"started" | "already" | "disabled" | "failed"> {
 		const id = sessionId(ctx);
 		const { settings, cfg, settingsAvailable } = resolveSettings(options.settings);
-		if (!isEnabledForSession(id, cfg)) return "disabled";
+		if (!isNotificationEligibleContext(ctx) || !isEnabledForSession(id, cfg)) return "disabled";
 		if (runtimes.has(id)) return "already";
 
 		const stateRoot = path.join(ctx.cwd, ".gjc", "state");
@@ -783,6 +787,10 @@ export function createNotificationsExtension(api: ExtensionAPI, options: { setti
 			}
 
 			if (command === "on") {
+				if (!isNotificationEligibleContext(ctx)) {
+					ctx.ui.notify("Notifications are disabled for subagent sessions.", "warning");
+					return;
+				}
 				if (process.env.GJC_NOTIFICATIONS === "0") {
 					ctx.ui.notify(
 						"Notifications remain disabled: GJC_NOTIFICATIONS=0 is an authoritative opt-out.",

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1214,8 +1214,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 	const agentRegistry = options.agentRegistry ?? AgentRegistry.global();
 	const resolvedAgentId = options.agentId ?? options.parentTaskPrefix ?? MAIN_AGENT_ID;
-	const resolvedAgentDisplayName =
-		options.agentDisplayName ?? ((options.taskDepth ?? 0) > 0 || options.parentTaskPrefix ? "sub" : "main");
+	const isSubSession = taskDepth > 0 || Boolean(options.parentTaskPrefix) || Boolean(options.currentAgentType);
+	const resolvedAgentDisplayName = options.agentDisplayName ?? (isSubSession ? "sub" : "main");
 	const evalKernelOwnerId = `agent-session:${Snowflake.next()}`;
 
 	try {
@@ -1530,6 +1530,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				cfg: notificationCfg,
 				taskDepth,
 				parentTaskPrefix: options.parentTaskPrefix,
+				currentAgentType: options.currentAgentType,
 			})
 		) {
 			inlineExtensions.push(api => createNotificationsExtension(api, { settings }));
@@ -1639,6 +1640,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				cwd,
 				sessionManager,
 				modelRegistry,
+				{
+					kind: isSubSession ? "sub" : "main",
+					taskDepth,
+					...(options.parentTaskPrefix ? { parentTaskPrefix: options.parentTaskPrefix } : {}),
+					...(options.currentAgentType ? { currentAgentType: options.currentAgentType } : {}),
+				},
 			);
 		}
 
@@ -1931,7 +1938,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		agentRegistry.register({
 			id: resolvedAgentId,
 			displayName: resolvedAgentDisplayName,
-			kind: (options.taskDepth ?? 0) > 0 || options.parentTaskPrefix ? "sub" : "main",
+			kind: isSubSession ? "sub" : "main",
 			parentId: options.parentTaskPrefix,
 			session: null,
 			sessionFile: sessionManager.getSessionFile() ?? null,

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -16,6 +16,7 @@ import {
 	shouldRegisterNotificationsExtension,
 	tokenFingerprint,
 } from "../src/notifications/config";
+import { createNotificationsExtension } from "../src/notifications/index";
 import { createAgentSession } from "../src/sdk";
 import { SessionManager } from "../src/session/session-manager";
 
@@ -174,6 +175,13 @@ describe("notifications config", () => {
 				parentTaskPrefix: "0-Sub",
 			}),
 		).toBe(false);
+		expect(
+			shouldRegisterNotificationsExtension({
+				cfg: GLOBAL_CFG,
+				env: { GJC_NOTIFICATIONS: "1" },
+				currentAgentType: "executor",
+			}),
+		).toBe(false);
 	});
 	test("settings-enabled subagent sessions do not register the notifications extension", async () => {
 		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notifications-subagent-"));
@@ -242,9 +250,45 @@ describe("notifications config", () => {
 				parentTaskPrefix: "0-Sub",
 			});
 			disposers.push(() => parentPrefixSubagent.session.dispose());
+			const agentTypeOnlySubagent = await createAgentSession({
+				cwd,
+				agentDir: cwd,
+				sessionManager: SessionManager.inMemory(cwd),
+				settings,
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				extensions: [],
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				currentAgentType: "executor",
+			});
+			disposers.push(() => agentTypeOnlySubagent.session.dispose());
+			const explicitExtensionSubagent = await createAgentSession({
+				cwd,
+				agentDir: cwd,
+				sessionManager: SessionManager.inMemory(cwd),
+				settings,
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				extensions: [api => createNotificationsExtension(api, { settings })],
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				taskDepth: 1,
+			});
+			disposers.push(() => explicitExtensionSubagent.session.dispose());
 			await topLevel.session.extensionRunner?.emit({ type: "session_start" });
 			await subagent.session.extensionRunner?.emit({ type: "session_start" });
 			await parentPrefixSubagent.session.extensionRunner?.emit({ type: "session_start" });
+			await agentTypeOnlySubagent.session.extensionRunner?.emit({ type: "session_start" });
+			await explicitExtensionSubagent.session.extensionRunner?.emit({ type: "session_start" });
 			const topLevelEndpoint = path.join(
 				cwd,
 				".gjc",
@@ -266,9 +310,25 @@ describe("notifications config", () => {
 				"notifications",
 				`${parentPrefixSubagent.session.sessionId}.json`,
 			);
+			const agentTypeOnlySubagentEndpoint = path.join(
+				cwd,
+				".gjc",
+				"state",
+				"notifications",
+				`${agentTypeOnlySubagent.session.sessionId}.json`,
+			);
+			const explicitExtensionSubagentEndpoint = path.join(
+				cwd,
+				".gjc",
+				"state",
+				"notifications",
+				`${explicitExtensionSubagent.session.sessionId}.json`,
+			);
 			expect(fs.existsSync(topLevelEndpoint)).toBe(true);
 			expect(fs.existsSync(subagentEndpoint)).toBe(false);
 			expect(fs.existsSync(parentPrefixSubagentEndpoint)).toBe(false);
+			expect(fs.existsSync(agentTypeOnlySubagentEndpoint)).toBe(false);
+			expect(fs.existsSync(explicitExtensionSubagentEndpoint)).toBe(false);
 		} finally {
 			await Promise.all(disposers.reverse().map(dispose => dispose()));
 			if (previous === undefined) {
@@ -278,7 +338,7 @@ describe("notifications config", () => {
 			}
 			resetSettingsForTest();
 		}
-	});
+	}, 30000);
 
 	test("maskToken handles unset tokens and never reveals the raw token", () => {
 		expect(maskToken(undefined)).toBe("(unset)");


### PR DESCRIPTION
## Summary
- classify SDK-created role/task sessions as sub sessions using taskDepth, parentTaskPrefix, or currentAgentType
- expose session metadata to extensions and make the notifications extension fail closed for subagent contexts, including explicitly supplied notification extensions
- add regression coverage for taskDepth, parentTaskPrefix, currentAgentType, and explicit-extension subagent paths while preserving top-level notification endpoint creation

Fixes #1570

## Verification
- bun test packages/coding-agent/test/notifications-config.test.ts
- bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts
- bun test packages/coding-agent/test/notifications-config.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts
- bun run check:ts
- git diff --check