### PR TITLE
fix(agent): preserve fork seed after child compaction

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 - Agent queues now expose ordered move helpers for steering and follow-up messages so callers can reorder pending work without removing and re-adding messages.
 
+### Fixed
+
+- Preserved inherited fork-context seed messages when a compacted child rebase receives only child-local normalized messages, avoiding seed loss after task-child compaction (#1567).
+
 ## [0.7.7] - 2026-06-28
 
 ### Fixed

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -252,7 +252,7 @@ export class AppendOnlyContextManager {
 			if (this.#seededPrefixCount > 0) {
 				// F9: a seeded fork whose inherited prefix changed (e.g. after compaction)
 				// rebases onto the new provider context instead of throwing.
-				this.#rebaseToBaseline(messagesToSync);
+				this.#rebaseToBaseline(messagesToSync, seededPrefixLength);
 				return;
 			}
 			this.log.clear();
@@ -265,7 +265,7 @@ export class AppendOnlyContextManager {
 		// while a seed prefix is active; a genuine seeded compaction rebases (F9).
 		if (messagesToSync.length < this.#lastSyncCount) {
 			if (this.#seededPrefixCount > 0) {
-				this.#rebaseToBaseline(messagesToSync);
+				this.#rebaseToBaseline(messagesToSync, seededPrefixLength);
 				return;
 			}
 			this.log.clear();
@@ -359,12 +359,12 @@ export class AppendOnlyContextManager {
 		return false;
 	}
 
-	/** F9: reset the seeded log to a new provider-visible baseline (seeded compaction/rebase). */
-	#rebaseToBaseline(messages: readonly unknown[]): void {
+	/** F9: reset the log to a new provider-visible baseline after seeded compaction/rebase. */
+	#rebaseToBaseline(messages: readonly unknown[], seededPrefixCount = 0): void {
 		this.log.clear();
 		this.log.extend([...messages]);
 		this.#lastSyncCount = messages.length;
-		this.#seededPrefixCount = 0;
+		this.#seededPrefixCount = seededPrefixCount;
 		this.#syncedHashes = this.#hashRange(messages, 0, messages.length);
 	}
 }

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -252,7 +252,7 @@ export class AppendOnlyContextManager {
 			if (this.#seededPrefixCount > 0) {
 				// F9: a seeded fork whose inherited prefix changed (e.g. after compaction)
 				// rebases onto the new provider context instead of throwing.
-				this.#rebaseToBaseline(normalizedMessages);
+				this.#rebaseToBaseline(messagesToSync);
 				return;
 			}
 			this.log.clear();
@@ -265,7 +265,7 @@ export class AppendOnlyContextManager {
 		// while a seed prefix is active; a genuine seeded compaction rebases (F9).
 		if (messagesToSync.length < this.#lastSyncCount) {
 			if (this.#seededPrefixCount > 0) {
-				this.#rebaseToBaseline(normalizedMessages);
+				this.#rebaseToBaseline(messagesToSync);
 				return;
 			}
 			this.log.clear();

--- a/packages/agent/test/append-only-seeded-rebase.test.ts
+++ b/packages/agent/test/append-only-seeded-rebase.test.ts
@@ -47,4 +47,34 @@ describe("AppendOnlyContextManager seeded-fork rebase (W4 / F9)", () => {
 		mgr.syncMessages([...seed, msg("a", "assistant"), msg("b")]);
 		expect(contents(mgr)).toEqual(["s1", "a", "b"]);
 	});
+
+	it("preserves inherited seed when compacted child context omits the seed prefix", () => {
+		const seed = [msg("s1"), msg("s2", "assistant")];
+		const mgr = AppendOnlyContextManager.forkFromSeed({ messages: seed, options: BUILD_OPTS });
+		mgr.syncMessages([...seed, msg("c1"), msg("c2", "assistant"), msg("c3")]);
+
+		// Real forked task sessions can compact child-local entries without persisting
+		// the inherited seed as session messages. The manager must rebase to the
+		// synthetic seed + compacted child context, not the seedless normalized input.
+		expect(() => mgr.syncMessages([msg("child-summary"), msg("c3")])).not.toThrow();
+		expect(contents(mgr)).toEqual(["s1", "s2", "child-summary", "c3"]);
+	});
+
+	it("does not duplicate inherited seed when compacted child context includes the seed prefix", () => {
+		const seed = [msg("s1"), msg("s2", "assistant")];
+		const mgr = AppendOnlyContextManager.forkFromSeed({ messages: seed, options: BUILD_OPTS });
+		mgr.syncMessages([...seed, msg("c1"), msg("c2", "assistant")]);
+
+		expect(() => mgr.syncMessages([...seed, msg("child-summary")])).not.toThrow();
+		expect(contents(mgr)).toEqual(["s1", "s2", "child-summary"]);
+	});
+
+	it("keeps ordinary no-seed compaction behavior unchanged", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.syncMessages([msg("a"), msg("b", "assistant"), msg("c")]);
+		expect(contents(mgr)).toEqual(["a", "b", "c"]);
+
+		expect(() => mgr.syncMessages([msg("summary")])).not.toThrow();
+		expect(contents(mgr)).toEqual(["summary"]);
+	});
 });

--- a/packages/agent/test/append-only-seeded-rebase.test.ts
+++ b/packages/agent/test/append-only-seeded-rebase.test.ts
@@ -24,7 +24,7 @@ describe("AppendOnlyContextManager seeded-fork rebase (W4 / F9)", () => {
 		expect(() => mgr.syncMessages([...seed, msg("c1")])).not.toThrow();
 		expect(contents(mgr)).toEqual(["s1", "s2", "c1"]);
 
-		// After rebase the seed binding is gone; further syncs behave as a normal baseline.
+		// After rebase the inherited seed remains active, and explicit seed input is not duplicated.
 		mgr.syncMessages([...seed, msg("c1"), msg("c4", "assistant")]);
 		expect(contents(mgr)).toEqual(["s1", "s2", "c1", "c4"]);
 	});
@@ -58,6 +58,18 @@ describe("AppendOnlyContextManager seeded-fork rebase (W4 / F9)", () => {
 		// synthetic seed + compacted child context, not the seedless normalized input.
 		expect(() => mgr.syncMessages([msg("child-summary"), msg("c3")])).not.toThrow();
 		expect(contents(mgr)).toEqual(["s1", "s2", "child-summary", "c3"]);
+	});
+
+	it("preserves inherited seed across successive seedless child compactions", () => {
+		const seed = [msg("s1"), msg("s2", "assistant")];
+		const mgr = AppendOnlyContextManager.forkFromSeed({ messages: seed, options: BUILD_OPTS });
+		mgr.syncMessages([...seed, msg("c1"), msg("c2", "assistant"), msg("c3")]);
+
+		expect(() => mgr.syncMessages([msg("child-summary-1"), msg("c3")])).not.toThrow();
+		expect(contents(mgr)).toEqual(["s1", "s2", "child-summary-1", "c3"]);
+
+		expect(() => mgr.syncMessages([msg("child-summary-2")])).not.toThrow();
+		expect(contents(mgr)).toEqual(["s1", "s2", "child-summary-2"]);
 	});
 
 	it("does not duplicate inherited seed when compacted child context includes the seed prefix", () => {


### PR DESCRIPTION
## Summary
- Rebase seeded fork context against the synthetic seed-plus-child message list after child compaction or in-place rewrite.
- Add regression coverage for seedless compacted child context, no duplicate seed when the compacted input already includes seed, and ordinary no-seed compaction.
- Update the agent changelog for #1567.

Fixes #1567.

## Verification
- bun test packages/agent/test/append-only-seeded-rebase.test.ts packages/agent/test/append-only-context.test.ts
- bun --cwd=packages/agent run check
- git diff --check

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*