### PR TITLE
fix(tools): make todo_write default-registered instead of discoverable

### DIFF
--- a/packages/coding-agent/src/tools/todo-write.ts
+++ b/packages/coding-agent/src/tools/todo-write.ts
@@ -499,7 +499,7 @@ export class TodoWriteTool implements AgentTool<typeof todoWriteSchema, TodoWrit
 	readonly parameters = todoWriteSchema;
 	readonly concurrency = "exclusive";
 	readonly strict = true;
-	readonly loadMode = "discoverable";
+	readonly loadMode = "essential";
 	constructor(private readonly session: ToolSession) {
 		this.description = prompt.render(todoWriteDescription);
 	}


### PR DESCRIPTION
Resubmission of #1577 against `dev` (the correct contribution branch; the previous PR targeted `main` and was closed for that reason).

## Summary
- `todo_write` was `loadMode = "discoverable"` (`todo-write.ts:502`), so it was hidden behind BM25 tool discovery and had to be activated via `search_tool_bm25` before use.
- But the phased-todo system-reminder forces the model to call `todo_write` **first** in a turn. When the tool isn't yet activated, the emitted call (proxied as `proxy_todo_write`) is not in the provided tools set, and the provider rejects the request with a 400:
  ```
  400 invalid_request_error: Tool 'proxy_todo_write' not found in provided tools
  ```
- This mirrors exactly the fix in #1513 (skill tool). Since `todo_write` is force-called by a system-reminder, it should be resident, not discoverable. This changes its `loadMode` to `"essential"`.

## Why class-level `loadMode` is sufficient
The sdk retention logic checks the class-level flag first:
```ts
// sdk.ts:1912
if (tool.loadMode === "essential") return true;
if (essentialBuiltinNames.has(name)) return true;   // list/override checked after
```
So flipping the class flag keeps `todo_write` resident unconditionally, independent of `tools.essentialOverride` — matching how `goal-tool.ts` and `skill.ts` (#1513) self-declare essential. No change to `DEFAULT_ESSENTIAL_TOOL_NAMES` is needed.

## Change
- `packages/coding-agent/src/tools/todo-write.ts`: `loadMode` `"discoverable"` → `"essential"` (one line).


## Reproduction
Occurs **when the first session prompt is sent**: the phased-todo system-reminder fires on the very first turn and forces a `todo_write` call before tool discovery has activated it. The emitted call (`proxy_todo_write`) is therefore absent from the provided tools set, and the provider rejects the request with the 400 above.
