### PR TITLE
Gate subagent IRC guidance on tool availability

### DIFF
--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -139,6 +139,8 @@ export interface ExecutorOptions {
 	artifactsDir?: string;
 	/** Path to parent conversation context file */
 	contextFile?: string;
+	/** Whether the parent runtime actually exposes IRC coordination. */
+	ircAvailable?: boolean;
 	eventBus?: EventBus;
 	contextFiles?: ContextFileEntry[];
 	skills?: Skill[];
@@ -623,7 +625,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				: agent.spawns.join(",");
 
 	const lspEnabled = enableLsp ?? true;
-	const ircEnabled = subagentSettings.get("irc.enabled") === true;
+	const ircEnabled = options.ircAvailable === true;
 	const contextFileForPrompt = ircEnabled ? undefined : options.contextFile;
 	const skipPythonPreflight = Array.isArray(toolNames) && !toolNames.includes("eval");
 
@@ -1232,7 +1234,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			const { normalized: normalizedOutputSchema } = normalizeSchema(outputSchema);
 
 			const forkContextNotice = options.forkContextSeed
-				? `This subagent was started with a forked snapshot of the parent conversation. Included ${options.forkContextSeed.metadata.includedMessages} message(s), skipped ${options.forkContextSeed.metadata.skippedMessages}, approximately ${options.forkContextSeed.metadata.approximateTokens} tokens. The snapshot is not live; use IRC for live coordination when enabled.`
+				? `This subagent was started with a forked snapshot of the parent conversation. Included ${options.forkContextSeed.metadata.includedMessages} message(s), skipped ${options.forkContextSeed.metadata.skippedMessages}, approximately ${options.forkContextSeed.metadata.approximateTokens} tokens. The snapshot is not live.${ircEnabled ? " Use IRC for live coordination." : " Rely on the explicit assignment and supplied context for coordination."}`
 				: "";
 
 			const agentSubskillBlock = await buildAgentSubskillInjection({

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -178,6 +178,10 @@ export {
 /**
  * Render the tool description from a cached agent list and current settings.
  */
+function hasAvailableIrcTool(session: ToolSession): boolean {
+	return session.settings.get("irc.enabled") === true && session.getToolByName?.("irc") !== undefined;
+}
+
 function renderDescription(
 	agents: AgentDefinition[],
 	maxConcurrency: number,
@@ -381,7 +385,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			true,
 			disabledAgents,
 			this.#getTaskSimpleMode(),
-			this.session.settings.get("irc.enabled") === true,
+			hasAvailableIrcTool(this.session),
 			this.session.getSessionSpawns() ?? "*",
 		);
 	}
@@ -814,7 +818,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				? ` Failed to schedule ${failedSchedules.length} task${failedSchedules.length === 1 ? "" : "s"}.`
 				: "";
 
-		const ircEnabled = this.session.settings.get("irc.enabled") === true;
+		const ircEnabled = hasAvailableIrcTool(this.session);
 		const taskIdByItemId = new Map<string, string>();
 		for (let i = 0; i < taskItems.length; i++) {
 			taskIdByItemId.set(taskItems[i].id, uniqueIds[i]);
@@ -1171,7 +1175,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			// Write parent conversation context for subagents. When IRC is available,
 			// subagents should ask live peers instead of reading a stale markdown dump.
 			await fs.mkdir(effectiveArtifactsDir, { recursive: true });
-			const shouldWriteConversationContext = this.session.settings.get("irc.enabled") !== true;
+			const shouldWriteConversationContext = !hasAvailableIrcTool(this.session);
 			const compactContext = shouldWriteConversationContext ? this.session.getCompactContext?.() : undefined;
 			let contextFilePath: string | undefined;
 			if (compactContext) {
@@ -1298,6 +1302,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						persistArtifacts: !!artifactsDir,
 						artifactsDir: effectiveArtifactsDir,
 						contextFile: contextFilePath,
+						ircAvailable: hasAvailableIrcTool(this.session),
 						enableLsp: subagentLspEnabled,
 						signal,
 						eventBus: this.session.eventBus,
@@ -1360,6 +1365,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						persistArtifacts: !!artifactsDir,
 						artifactsDir: effectiveArtifactsDir,
 						contextFile: contextFilePath,
+						ircAvailable: hasAvailableIrcTool(this.session),
 						enableLsp: subagentLspEnabled,
 						signal,
 						eventBus: this.session.eventBus,

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -5,7 +5,7 @@ import { Settings } from "../../src/config/settings";
 import type { ExtensionActions, LoadExtensionsResult } from "../../src/extensibility/extensions/types";
 import type { CreateAgentSessionResult } from "../../src/sdk";
 import * as sdkModule from "../../src/sdk";
-import type { AgentSession, AgentSessionEvent, PromptOptions } from "../../src/session/agent-session";
+import type { AgentSession, AgentSessionEvent, ForkContextSeed, PromptOptions } from "../../src/session/agent-session";
 import type { AuthStorage } from "../../src/session/auth-storage";
 import { runSubprocess, SUBAGENT_WARNING_MISSING_YIELD } from "../../src/task/executor";
 import type { AgentDefinition } from "../../src/task/types";
@@ -114,6 +114,23 @@ describe("runSubprocess yield reminders", () => {
 		modelRegistry: { refresh: async () => {} } as unknown as import("../../src/config/model-registry").ModelRegistry,
 		enableLsp: false,
 	};
+
+	function createForkContextSeed(): ForkContextSeed {
+		return {
+			messages: [],
+			agentMessages: [],
+			metadata: {
+				sourceSessionId: "parent-session",
+				parentMessageCount: 3,
+				includedMessages: 1,
+				skippedMessages: 2,
+				approximateTokens: 64,
+				maxMessages: 5,
+				maxTokens: 100,
+				skippedReasons: {},
+			},
+		};
+	}
 
 	it("waits for session_start extension user messages before prompting the subagent", async () => {
 		let extensionSendUserMessage: ExtensionActions["sendUserMessage"] | undefined;
@@ -232,6 +249,68 @@ describe("runSubprocess yield reminders", () => {
 		expect(systemPrompt?.[3]).toBe("now");
 		expect(userPrompt).not.toContain("[CONTEXT]");
 		expect(userPrompt).not.toContain("Shared task background");
+	});
+
+	it("does not mention IRC in fork-context notice when IRC is unavailable", async () => {
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-fork-context-no-irc",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		const createAgentSessionSpy = mockCreateAgentSession(session);
+
+		await runSubprocess({
+			...baseOptions,
+			id: "subagent-fork-context-no-irc",
+			forkContextSeed: createForkContextSeed(),
+			ircAvailable: false,
+		});
+
+		const systemPromptBuilder = createAgentSessionSpy.mock.calls[0]?.[0]?.systemPrompt;
+		expect(systemPromptBuilder).toBeFunction();
+		if (typeof systemPromptBuilder !== "function") throw new Error("Expected system prompt builder");
+		const systemPrompt = systemPromptBuilder(["system", "now"]);
+
+		expect(systemPrompt.join("\n")).toContain("forked snapshot of the parent conversation");
+		expect(systemPrompt.join("\n")).not.toContain("IRC");
+		expect(systemPrompt.join("\n")).toContain("Rely on the explicit assignment and supplied context");
+	});
+
+	it("mentions IRC in fork-context notice when IRC is available", async () => {
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-fork-context-irc",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		const createAgentSessionSpy = mockCreateAgentSession(session);
+
+		await runSubprocess({
+			...baseOptions,
+			id: "subagent-fork-context-irc",
+			forkContextSeed: createForkContextSeed(),
+			ircAvailable: true,
+		});
+
+		const systemPromptBuilder = createAgentSessionSpy.mock.calls[0]?.[0]?.systemPrompt;
+		expect(systemPromptBuilder).toBeFunction();
+		if (typeof systemPromptBuilder !== "function") throw new Error("Expected system prompt builder");
+		const systemPrompt = systemPromptBuilder(["system", "now"]);
+
+		expect(systemPrompt.join("\n")).toContain("Use IRC for live coordination.");
 	});
 
 	it("sends reminder prompt when subagent stops without yield", async () => {

--- a/packages/coding-agent/test/tools/task-simple-mode.test.ts
+++ b/packages/coding-agent/test/tools/task-simple-mode.test.ts
@@ -110,6 +110,71 @@ describe("task.simple", () => {
 			expect(properties.spawnPlan).toBeDefined();
 		}
 	});
+	it("hides IRC guidance when the IRC tool is not available", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: TEST_AGENTS,
+			projectAgentsDir: null,
+		});
+
+		const tool = await TaskTool.create(createSession({ "irc.enabled": true }, { getToolByName: () => undefined }));
+
+		expect(tool.description).not.toContain("Coordinate with running tasks via `irc`");
+		expect(tool.description).not.toContain("via the `irc` tool");
+		expect(tool.description).toContain("Use `subagent` action `inspect` or `list`");
+	});
+
+	it("shows IRC guidance when the IRC tool is available", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: TEST_AGENTS,
+			projectAgentsDir: null,
+		});
+
+		const tool = await TaskTool.create(
+			createSession(
+				{ "irc.enabled": true },
+				{ getToolByName: name => (name === "irc" ? ({ name: "irc" } as never) : undefined) },
+			),
+		);
+
+		expect(tool.description).toContain("Coordinate with running tasks via `irc`");
+		expect(tool.description).toContain("via the `irc` tool");
+		expect(tool.description).not.toContain("Use `subagent` action `inspect` or `list`");
+	});
+
+	it("omits IRC launch hints when tool lookup metadata is missing", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: TEST_AGENTS,
+			projectAgentsDir: null,
+		});
+		const captured: CapturedRegister[] = [];
+		const manager = {
+			register: (
+				type: "bash" | "task",
+				label: string,
+				_run: (ctx: {
+					jobId: string;
+					signal: AbortSignal;
+					reportProgress: (text: string, details?: Record<string, unknown>) => Promise<void>;
+				}) => Promise<string>,
+				options?: AsyncJobRegisterOptions,
+			): string => {
+				captured.push({ type, label, options });
+				return options?.id ?? label;
+			},
+		};
+		AsyncJobManager.setInstance(manager as unknown as AsyncJobManager);
+
+		const tool = await TaskTool.create(createSession({ "irc.enabled": true }));
+		const result = await tool.execute("tool-no-irc", {
+			agent: "task",
+			tasks: [{ id: "One", description: "label", assignment: "Do work." }],
+		} as TaskParams);
+
+		expect(captured).toHaveLength(1);
+		const text = getFirstText(result);
+		expect(text).not.toContain("DM these ids via `irc`");
+		expect(text).toContain("Use `subagent` to list, inspect, or await");
+	});
 
 	it("rejects a five-task batch before scheduling without spawnPlan", async () => {
 		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({


### PR DESCRIPTION
## Summary
- Gate task/subagent IRC guidance on both `irc.enabled` and the actual `irc` tool being registered.
- Pass resolved IRC availability into subprocess prompts so fork-context notices do not mention IRC when unavailable.
- Add regression coverage for task simple-mode launch guidance and executor fork-context reminders.

## Verification
- `bun test packages/coding-agent/test/tools/task-simple-mode.test.ts packages/coding-agent/test/task/executor-subagent-reminders.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`
- `git status --short` showed only the intended four source/test files before commit; no generated native files were dirty.

Closes #1575

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*