### PR TITLE
Fix fork context provider payload stripping

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1541,10 +1541,9 @@ export class AgentSession {
 				recordSkip("unsupported-role");
 				return undefined;
 			}
-			const cloned = cloneJsonValueForForkSeed(message) as Message;
-			if ("providerPayload" in cloned) {
-				delete (cloned as { providerPayload?: unknown }).providerPayload;
-			}
+			const messageWithoutProviderPayload = { ...message } as Message & { providerPayload?: unknown };
+			delete messageWithoutProviderPayload.providerPayload;
+			const cloned = cloneJsonValueForForkSeed(messageWithoutProviderPayload) as Message;
 			if (Array.isArray(cloned.content)) {
 				const sanitizedContent: TextContent[] = [];
 				for (const block of cloned.content) {

--- a/packages/coding-agent/test/task/fork-context-seed.test.ts
+++ b/packages/coding-agent/test/task/fork-context-seed.test.ts
@@ -42,7 +42,7 @@ async function sessionWith(messages: never[]): Promise<{ session: AgentSession; 
 }
 
 interface SeededResult {
-	messages: Array<{ content?: unknown }>;
+	messages: Array<{ content?: unknown; providerPayload?: unknown }>;
 	metadata: { includedMessages: number; skippedReasons: Record<string, number> };
 }
 
@@ -93,6 +93,25 @@ describe("buildForkContextSeed selection", () => {
 			const seed = await buildSeed(session, 10, 10_000);
 			expect(seedTexts(seed)).toEqual(["A-old", "B-mid", "C-recent"]);
 			expect(seed.metadata.includedMessages).toBe(3);
+		} finally {
+			await session.dispose?.();
+			authStorage.close?.();
+		}
+	});
+
+	it("omits non-JSON provider payloads before cloning seeded messages", async () => {
+		const { session, authStorage } = await sessionWith([
+			{
+				role: "user",
+				content: [{ type: "text", text: "payload should be stripped" }],
+				providerPayload: { type: "openaiResponsesHistory", items: [{ id: 1584n }] },
+			} as never,
+		]);
+		try {
+			const seed = await buildSeed(session, 10, 10_000);
+			expect(seedTexts(seed)).toEqual(["payload should be stripped"]);
+			expect(seed.messages).toHaveLength(1);
+			expect(seed.messages.every(message => !("providerPayload" in message))).toBe(true);
 		} finally {
 			await session.dispose?.();
 			authStorage.close?.();


### PR DESCRIPTION
## Summary
- strip `providerPayload` before JSON cloning fork-context seed messages
- add a regression covering BigInt provider payloads and asserting seeded messages omit provider transport state

Fixes #1584.

## Verification
- `bun --cwd=packages/coding-agent test test/task/fork-context-seed.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*