### PR TITLE
Fix empty fork context seed notices

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1555,6 +1555,10 @@ export class AgentSession {
 						recordSkip(`unsupported-content-${block.type}`);
 					}
 				}
+				if (sanitizedContent.length === 0) {
+					recordSkip("empty-content");
+					return undefined;
+				}
 				return { ...cloned, content: sanitizedContent } as Message;
 			}
 			return cloned;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1233,9 +1233,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			const { normalized: normalizedOutputSchema } = normalizeSchema(outputSchema);
 
-			const forkContextNotice = options.forkContextSeed
-				? `This subagent was started with a forked snapshot of the parent conversation. Included ${options.forkContextSeed.metadata.includedMessages} message(s), skipped ${options.forkContextSeed.metadata.skippedMessages}, approximately ${options.forkContextSeed.metadata.approximateTokens} tokens. The snapshot is not live.${ircEnabled ? " Use IRC for live coordination." : " Rely on the explicit assignment and supplied context for coordination."}`
-				: "";
+			const forkContextNotice =
+				options.forkContextSeed && options.forkContextSeed.metadata.includedMessages > 0
+					? `This subagent was started with a forked snapshot of the parent conversation. Included ${options.forkContextSeed.metadata.includedMessages} message(s), skipped ${options.forkContextSeed.metadata.skippedMessages}, approximately ${options.forkContextSeed.metadata.approximateTokens} tokens. The snapshot is not live.${ircEnabled ? " Use IRC for live coordination." : " Rely on the explicit assignment and supplied context for coordination."}`
+					: "";
 
 			const agentSubskillBlock = await buildAgentSubskillInjection({
 				cwd,

--- a/packages/coding-agent/test/task-fork-context.test.ts
+++ b/packages/coding-agent/test/task-fork-context.test.ts
@@ -410,6 +410,40 @@ describe("fork context policy surface", () => {
 		expect(renderedPrompt?.join("\n")).toContain("forked snapshot of the parent conversation");
 	});
 
+	test("suppresses fork-context prompt notice for zero-message seeds", async () => {
+		mockAgents([createAgent("executor", "allowed")]);
+		const seed = createSeed();
+		seed.messages = [];
+		seed.agentMessages = [];
+		seed.metadata.includedMessages = 0;
+		seed.metadata.skippedMessages = 1;
+		seed.metadata.approximateTokens = 0;
+		seed.metadata.skippedReasons = { "empty-content": 1 };
+		const seedBuilder = vi.fn(async () => seed);
+		const { getOptions } = mockCreateAgentSession();
+		const tool = await TaskTool.create(createSession({ "task.forkContext.enabled": true }, seedBuilder));
+
+		await executeDetached(tool, {
+			agent: "executor",
+			tasks: [
+				{
+					id: "EmptyForkSeed",
+					description: "seed",
+					assignment: "Use inherited context.",
+					inheritContext: "bounded",
+				},
+			],
+		});
+
+		expect(getOptions()?.forkContextSeed).toBe(seed);
+		const systemPromptOption = getOptions()?.systemPrompt;
+		const renderedPrompt =
+			typeof systemPromptOption === "function" ? systemPromptOption(["base", "tail"]) : systemPromptOption;
+		const rendered = renderedPrompt?.join("\n") ?? "";
+		expect(rendered).not.toContain("Forked Conversation Snapshot");
+		expect(rendered).not.toContain("forked snapshot of the parent conversation");
+	});
+
 	test("uses configured maxMessages to cap bounded fork-context seeds", async () => {
 		mockAgents([createAgent("executor", "allowed")]);
 		const seed = createSeed();

--- a/packages/coding-agent/test/task/fork-context-seed.test.ts
+++ b/packages/coding-agent/test/task/fork-context-seed.test.ts
@@ -3,7 +3,8 @@ import { Agent } from "@gajae-code/agent-core";
 import { getBundledModel, getBundledModels } from "@gajae-code/ai";
 import { ModelRegistry } from "../../src/config/model-registry";
 import { Settings } from "../../src/config/settings";
-import { AgentSession } from "../../src/session/agent-session";
+import { AgentSession, type ForkContextSeed } from "../../src/session/agent-session";
+
 import { AuthStorage } from "../../src/session/auth-storage";
 import { SessionManager } from "../../src/session/session-manager";
 
@@ -28,6 +29,11 @@ const assistant = (text: string) =>
 		stopReason: "stop",
 		timestamp: Date.now(),
 	}) as never;
+const thinkingOnlyAssistant = () => {
+	const message = assistant("hidden") as { content: unknown };
+	message.content = [{ type: "thinking", thinking: "hidden chain of thought" }];
+	return message as never;
+};
 
 async function sessionWith(messages: never[]): Promise<{ session: AgentSession; authStorage: AuthStorage }> {
 	const agent = new Agent({ initialState: { model, systemPrompt: ["sys"], tools: [], messages } });
@@ -42,8 +48,8 @@ async function sessionWith(messages: never[]): Promise<{ session: AgentSession; 
 }
 
 interface SeededResult {
-	messages: Array<{ content?: unknown; providerPayload?: unknown }>;
-	metadata: { includedMessages: number; skippedReasons: Record<string, number> };
+	messages: Array<{ content?: unknown }>;
+	metadata: Pick<ForkContextSeed["metadata"], "includedMessages" | "skippedMessages" | "skippedReasons">;
 }
 
 function buildSeed(session: AgentSession, maxMessages: number, maxTokens: number): Promise<SeededResult> {
@@ -112,6 +118,34 @@ describe("buildForkContextSeed selection", () => {
 			expect(seedTexts(seed)).toEqual(["payload should be stripped"]);
 			expect(seed.messages).toHaveLength(1);
 			expect(seed.messages.every(message => !("providerPayload" in message))).toBe(true);
+		} finally {
+			await session.dispose?.();
+			authStorage.close?.();
+		}
+	});
+
+	it("skips messages whose sanitized content is empty", async () => {
+		const { session, authStorage } = await sessionWith([user("A-old"), thinkingOnlyAssistant(), user("C-recent")]);
+		try {
+			const seed = await buildSeed(session, 10, 10_000);
+			expect(seedTexts(seed)).toEqual(["A-old", "C-recent"]);
+			expect(seed.metadata.includedMessages).toBe(2);
+			expect(seed.metadata.skippedMessages).toBe(1);
+			expect(seed.metadata.skippedReasons["empty-content"]).toBe(1);
+		} finally {
+			await session.dispose?.();
+			authStorage.close?.();
+		}
+	});
+
+	it("returns a zero-message seed when every recent message sanitizes to empty", async () => {
+		const { session, authStorage } = await sessionWith([thinkingOnlyAssistant()]);
+		try {
+			const seed = await buildSeed(session, 10, 10_000);
+			expect(seed.messages).toEqual([]);
+			expect(seed.metadata.includedMessages).toBe(0);
+			expect(seed.metadata.skippedMessages).toBe(1);
+			expect(seed.metadata.skippedReasons["empty-content"]).toBe(1);
 		} finally {
 			await session.dispose?.();
 			authStorage.close?.();


### PR DESCRIPTION
## Summary
- Skip fork-context messages whose sanitized content would be empty and record `empty-content` in existing skip metadata.
- Suppress the executor fork-context prompt notice when a seed includes zero messages.
- Add regressions for empty sanitized messages and zero-message notice behavior.

## Verification
- `bun test packages/coding-agent/test/task/fork-context-seed.test.ts packages/coding-agent/test/task-fork-context.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`

Closes #1585

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*