### PR TITLE
Fix ACP startup profile registry refresh

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -189,6 +189,11 @@ function applyExtensionFlagValues(session: AgentSession, rawArgs: string[]): Map
 	return extensionRunner.getFlagValues();
 }
 
+type CreateSessionForMain = (
+	options: CreateAgentSessionOptions,
+	context?: { skipPostCreateModelRefresh?: boolean },
+) => Promise<CreateAgentSessionResult>;
+
 type AcpSessionFactory = (cwd: string) => Promise<AgentSession>;
 
 export interface AcpSessionFactoryOptions {
@@ -199,7 +204,7 @@ export interface AcpSessionFactoryOptions {
 	modelRegistry: ModelRegistry;
 	parsedArgs: Pick<Args, "apiKey" | "default" | "model" | "mpreset" | "thinking">;
 	rawArgs: string[];
-	createSession: (options: CreateAgentSessionOptions) => Promise<CreateAgentSessionResult>;
+	createSession: CreateSessionForMain;
 }
 
 export async function applyStartupModelProfiles(args: {
@@ -221,8 +226,11 @@ export async function applyStartupModelProfiles(args: {
 	// override it. startupModel covers the eager path; session.model covers the
 	// deferred `--model <pattern>` path resolved inside createAgentSession.
 	const explicitModel = args.parsedArgs.model ? (args.startupModel ?? args.session.model) : undefined;
-
 	const defaultProfile = args.settings.get("modelProfile.default");
+	if (defaultProfile || args.parsedArgs.mpreset) {
+		await args.modelRegistry.refresh("online-if-uncached");
+	}
+
 	if (defaultProfile) {
 		await applyProfile(defaultProfile, false);
 	}
@@ -263,19 +271,23 @@ export async function applyStartupModelProfilesOrExit(
 export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSessionFactory {
 	return async cwd => {
 		const nextSettings = await args.settings.cloneForCwd(cwd);
+		const hasStartupProfile = Boolean(nextSettings.get("modelProfile.default") || args.parsedArgs.mpreset);
 		const nextSessionManager = SessionManager.create(cwd, args.sessionDir);
 		const agentId = `acp:${nextSessionManager.getSessionId()}`;
-		const { session: nextSession } = await args.createSession({
-			...args.baseOptions,
-			cwd,
-			sessionManager: nextSessionManager,
-			settings: nextSettings,
-			authStorage: args.authStorage,
-			modelRegistry: args.modelRegistry,
-			agentId,
-			hasUI: false,
-			enableMCP: false,
-		});
+		const { session: nextSession } = await args.createSession(
+			{
+				...args.baseOptions,
+				cwd,
+				sessionManager: nextSessionManager,
+				settings: nextSettings,
+				authStorage: args.authStorage,
+				modelRegistry: args.modelRegistry,
+				agentId,
+				hasUI: false,
+				enableMCP: false,
+			},
+			{ skipPostCreateModelRefresh: hasStartupProfile },
+		);
 		await applyStartupModelProfilesOrExit({
 			session: nextSession,
 			settings: nextSettings,
@@ -944,6 +956,7 @@ export async function runRootCommand(
 	sessionOptions.modelRegistry = modelRegistry;
 	sessionOptions.hasUI = isInteractive || mode === "rpc-ui";
 	sessionOptions.settings = settingsInstance;
+	const hasRootStartupProfile = Boolean(settingsInstance.get("modelProfile.default") || parsedArgs.mpreset);
 
 	// Research-mode (RLM) preset: augment session options before session creation.
 	deps.rlmPreset?.applyOptions(sessionOptions, settingsInstance);
@@ -962,12 +975,15 @@ export async function runRootCommand(
 	}
 
 	const createAgentSessionImpl = deps.createAgentSession ?? createAgentSession;
-	const createSession = async (options: CreateAgentSessionOptions): Promise<CreateAgentSessionResult> => {
+	const createSession: CreateSessionForMain = async (options, context): Promise<CreateAgentSessionResult> => {
 		const result = await logger.time("createAgentSession", createAgentSessionImpl, options);
 		// Kick off background model discovery only after createAgentSession finishes its parallel
 		// discovery arms; running these concurrently contends for the event loop and stretches
-		// every parallel arm by ~30ms.
-		modelRegistry.refreshInBackground();
+		// every parallel arm by ~30ms. Startup model profiles do their own foreground refresh
+		// before activation so project-scoped defaults can resolve freshly discovered models.
+		if (!context?.skipPostCreateModelRefresh) {
+			modelRegistry.refreshInBackground();
+		}
 		return result;
 	};
 
@@ -984,8 +1000,10 @@ export async function runRootCommand(
 		});
 		await (deps.runAcpMode ?? (await import("./modes/acp")).runAcpMode)(createAcpSession);
 	} else {
-		const { session, setToolUIContext, modelFallbackMessage, lspServers, mcpManager, eventBus } =
-			await createSession(sessionOptions);
+		const { session, setToolUIContext, modelFallbackMessage, lspServers, mcpManager, eventBus } = await createSession(
+			sessionOptions,
+			{ skipPostCreateModelRefresh: hasRootStartupProfile },
+		);
 		if (parsedArgs.apiKey && !sessionOptions.model && session.model) {
 			authStorage.setRuntimeApiKey(session.model.provider, parsedArgs.apiKey);
 		}

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -11,15 +11,30 @@ import type { AgentSession } from "../src/session/agent-session";
 const model = (provider: string, id: string): Model =>
 	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
 
-function fakeRegistry(profiles: ModelProfileDefinition[]) {
-	const profileMap = new Map(profiles.map(profile => [profile.name, profile]));
-	return {
-		getModelProfile: (name: string) => profileMap.get(name),
-		getModelProfiles: () => new Map(profileMap),
-		getAvailableModelProfileNames: () => [...profileMap.keys()].sort(),
+function fakeRegistry(
+	profiles: ModelProfileDefinition[],
+	options: { profilesAfterRefresh?: ModelProfileDefinition[]; modelsAfterRefresh?: Model[] } = {},
+) {
+	let activeProfiles = profiles;
+	let activeModels = [model("profile-provider", "default"), model("cli-provider", "explicit")];
+	const registry = {
+		refreshCalls: [] as string[],
+		refreshInBackgroundCalls: [] as string[],
+		getModelProfile: (name: string) => new Map(activeProfiles.map(profile => [profile.name, profile])).get(name),
+		getModelProfiles: () => new Map(activeProfiles.map(profile => [profile.name, profile])),
+		getAvailableModelProfileNames: () => activeProfiles.map(profile => profile.name).sort(),
 		getApiKeyForProvider: async () => "key",
-		getAll: () => [model("profile-provider", "default"), model("cli-provider", "explicit")],
+		getAll: () => activeModels,
+		async refresh(strategy = "online-if-uncached") {
+			registry.refreshCalls.push(strategy);
+			activeProfiles = options.profilesAfterRefresh ?? activeProfiles;
+			activeModels = options.modelsAfterRefresh ?? activeModels;
+		},
+		refreshInBackground(strategy = "online-if-uncached") {
+			registry.refreshInBackgroundCalls.push(strategy);
+		},
 	};
+	return registry;
 }
 
 function fakeSession(initial = model("initial-provider", "initial")) {
@@ -154,4 +169,58 @@ test("ACP session factory applies default profile and --mpreset before returning
 	expect(
 		session.setModelTemporaryCalls.map(call => `${call.model.provider}/${call.model.id}:${call.thinkingLevel}`),
 	).toEqual(["profile-provider/default:medium", "cli-provider/explicit:high"]);
+});
+
+test("ACP session factory refreshes registry before applying project default profile", async () => {
+	const settings = Settings.isolated();
+	const projectSettings = Settings.isolated({ "modelProfile.default": "project-profile" });
+	const settingsWithProjectClone = settings as Settings & { cloneForCwd: (cwd: string) => Promise<Settings> };
+	settingsWithProjectClone.cloneForCwd = async () => projectSettings;
+	const session = fakeSession();
+	const registry = fakeRegistry([], {
+		profilesAfterRefresh: [
+			{
+				name: "project-profile",
+				requiredProviders: ["project-provider"],
+				modelMapping: { default: "project-provider/discovered:medium" },
+				source: "user",
+			},
+		],
+		modelsAfterRefresh: [model("project-provider", "discovered")],
+	});
+	const createSessionContexts: Array<{ skipPostCreateModelRefresh?: boolean } | undefined> = [];
+	const createSession = async (
+		_options: CreateAgentSessionOptions,
+		context?: { skipPostCreateModelRefresh?: boolean },
+	): Promise<CreateAgentSessionResult> => {
+		createSessionContexts.push(context);
+		if (!context?.skipPostCreateModelRefresh) {
+			registry.refreshInBackground();
+		}
+		return {
+			session,
+			setToolUIContext: () => {},
+			extensionsResult: {},
+			eventBus: {},
+		} as unknown as CreateAgentSessionResult;
+	};
+	const factory = createAcpSessionFactory({
+		baseOptions: {} as CreateAgentSessionOptions,
+		settings,
+		authStorage: { setRuntimeApiKey: () => {} } as never,
+		modelRegistry: registry as never,
+		parsedArgs: {},
+		rawArgs: [],
+		createSession,
+	});
+
+	const result = await factory(process.cwd());
+
+	expect(result).toBe(session);
+	expect(createSessionContexts).toEqual([{ skipPostCreateModelRefresh: true }]);
+	expect(registry.refreshCalls).toEqual(["online-if-uncached"]);
+	expect(registry.refreshInBackgroundCalls).toEqual([]);
+	expect(
+		session.setModelTemporaryCalls.map(call => `${call.model.provider}/${call.model.id}:${call.thinkingLevel}`),
+	).toEqual(["project-provider/discovered:medium"]);
 });


### PR DESCRIPTION
## Summary
- Refresh the model registry in the startup profile path before applying default/--mpreset profiles.
- Suppress the post-create background refresh when that same startup-profile path will perform the foreground refresh.
- Add ACP regression coverage for project-scoped modelProfile.default from cloneForCwd whose profile/model only exists after refresh.

## Verification
- bun test packages/coding-agent/test/cli-args-mpreset.test.ts
- bunx biome check packages/coding-agent/src/main.ts packages/coding-agent/test/cli-args-mpreset.test.ts
- bun --cwd=packages/coding-agent run check:types
- bun run check:node20-baseline
- git diff --check

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*