### PR TITLE
fix(ai): refresh imported OAuth credentials

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Refreshed matching existing OAuth credentials during `importCredentialIfAbsent` and cleared provider usage caches after the write, so external credential import no longer keeps stale tokens or stale usage-limit reports for the same account.
+
 ## [0.7.9] - 2026-07-01
 
 ### Fixed

--- a/packages/ai/src/auth-broker/remote-store.ts
+++ b/packages/ai/src/auth-broker/remote-store.ts
@@ -86,6 +86,7 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 	#cache: Map<string, CacheEntry> = new Map();
 	#usageCache?: UsageCacheEntry;
 	#usageInflight?: Promise<UsageReport[] | null>;
+	#usageCacheEpoch = 0;
 	#closed = false;
 	/**
 	 * `true` once the SSE consumer received its first frame and hasn't dropped
@@ -465,6 +466,19 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 		}
 	}
 
+	deleteCachePrefix(prefix: string): void {
+		for (const key of this.#cache.keys()) {
+			if (key.startsWith(prefix)) this.#cache.delete(key);
+		}
+		if (prefix.startsWith("usage_cache:")) this.#invalidateUsageCache();
+	}
+
+	#invalidateUsageCache(): void {
+		this.#usageCache = undefined;
+		this.#usageInflight = undefined;
+		this.#usageCacheEpoch += 1;
+	}
+
 	/**
 	 * Store-level hook consumed by `AuthStorage` — routes refresh through the
 	 * broker so the actual refresh token never leaves the broker host. Returns
@@ -561,10 +575,11 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 			return Promise.resolve(cached.reports);
 		}
 		if (this.#usageInflight) return this.#usageInflight;
+		const epoch = this.#usageCacheEpoch;
 		const inflight = this.#client
 			.fetchUsage()
 			.then(body => {
-				this.#usageCache = { reports: body.reports, fetchedAt: Date.now() };
+				if (this.#usageCacheEpoch === epoch) this.#usageCache = { reports: body.reports, fetchedAt: Date.now() };
 				return body.reports;
 			})
 			.catch(error => {
@@ -572,7 +587,7 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 				return null;
 			})
 			.finally(() => {
-				this.#usageInflight = undefined;
+				if (this.#usageCacheEpoch === epoch) this.#usageInflight = undefined;
 			});
 		this.#usageInflight = inflight;
 		return inflight;

--- a/packages/ai/src/auth-broker/wire-schemas.ts
+++ b/packages/ai/src/auth-broker/wire-schemas.ts
@@ -187,6 +187,7 @@ export const credentialDisableResponseSchema = z
 // ─── Upload ────────────────────────────────────────────────────────────────
 const credentialIfAbsentReasonSchema = z.enum([
 	"inserted",
+	"updated-existing",
 	"skipped-existing",
 	"skipped-existing-runtime",
 	"skipped-existing-config",

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -154,6 +154,7 @@ export interface AuthCredentialSnapshotEntry {
 
 export type AuthCredentialIfAbsentReason =
 	| "inserted"
+	| "updated-existing"
 	| "skipped-existing"
 	| "skipped-existing-runtime"
 	| "skipped-existing-config"
@@ -210,6 +211,7 @@ export interface AuthCredentialStore {
 	deleteAuthCredentialsForProvider(provider: string, disabledCause: string): void;
 	getCache(key: string, options?: { includeExpired?: boolean }): string | null;
 	setCache(key: string, value: string, expiresAtSec: number): void;
+	deleteCachePrefix?(prefix: string): void;
 	cleanExpiredCache(): void;
 	/**
 	 * Optional store-supplied OAuth refresh. When present, `AuthStorage` uses
@@ -472,6 +474,7 @@ interface UsageCache {
 	get<T>(key: string): UsageCacheEntry<T> | undefined;
 	getStale<T>(key: string): UsageCacheEntry<T> | undefined;
 	set<T>(key: string, entry: UsageCacheEntry<T>): void;
+	deletePrefix?(prefix: string): void;
 	cleanup?(): void;
 }
 
@@ -660,6 +663,10 @@ class AuthStorageUsageCache implements UsageCache {
 		const durableExpiresAt =
 			entry.value === null ? entry.expiresAt : Math.max(entry.expiresAt, Date.now() + USAGE_LAST_GOOD_RETENTION_MS);
 		this.store.setCache(`${USAGE_CACHE_PREFIX}${key}`, payload, Math.floor(durableExpiresAt / 1000));
+	}
+
+	deletePrefix(prefix: string): void {
+		this.store.deleteCachePrefix?.(`${USAGE_CACHE_PREFIX}${prefix}`);
 	}
 
 	cleanup(): void {
@@ -1297,8 +1304,6 @@ export class AuthStorage {
 			return this.#snapshotSkipResult(storageProvider, "skipped-existing-runtime");
 		if (this.#configOverrides.has(storageProvider))
 			return this.#snapshotSkipResult(storageProvider, "skipped-existing-config");
-		if (this.#getCredentialsForProvider(storageProvider).length > 0)
-			return this.#snapshotSkipResult(storageProvider, "skipped-existing");
 		if (getEnvApiKey(storageProvider)) return this.#snapshotSkipResult(storageProvider, "skipped-existing-env");
 		if (this.#fallbackResolver?.(storageProvider))
 			return this.#snapshotSkipResult(storageProvider, "skipped-existing-fallback");
@@ -1311,6 +1316,7 @@ export class AuthStorage {
 			result.entries.map(entry => ({ id: entry.id, credential: entry.credential })),
 		);
 		this.#resetProviderAssignments(storageProvider);
+		if (result.inserted) this.#invalidateUsageCacheForProvider(storageProvider);
 		return {
 			inserted: result.inserted,
 			reason: result.reason,
@@ -1328,6 +1334,13 @@ export class AuthStorage {
 			stored.map(record => ({ id: record.id, credential: record.credential })),
 		);
 		this.#resetProviderAssignments(provider);
+		this.#invalidateUsageCacheForProvider(provider);
+	}
+
+	#invalidateUsageCacheForProvider(provider: string): void {
+		this.#usageRequestInFlight.clear();
+		this.#usageReportsInFlight.clear();
+		this.#usageCache.deletePrefix?.(`report:${provider}:`);
 	}
 
 	/**
@@ -3705,6 +3718,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#getCacheStmt: Statement;
 	#getCacheIncludingExpiredStmt: Statement;
 	#upsertCacheStmt: Statement;
+	#deleteCachePrefixStmt: Statement;
 	#deleteExpiredCacheStmt: Statement;
 	#closed = false;
 
@@ -3744,6 +3758,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		this.#upsertCacheStmt = this.#db.prepare(
 			"INSERT INTO cache (key, value, expires_at) VALUES (?, ?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value, expires_at = excluded.expires_at",
 		);
+		this.#deleteCachePrefixStmt = this.#db.prepare("DELETE FROM cache WHERE substr(key, 1, ?) = ?");
 		this.#deleteExpiredCacheStmt = this.#db.prepare(`DELETE FROM cache WHERE expires_at <= ${SQLITE_NOW_EPOCH}`);
 	}
 
@@ -4102,16 +4117,58 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		}
 
 		const writeIfAbsent = this.#db.transaction(
-			(providerName: string, record: SerializedCredentialRecord): AuthCredentialIfAbsentResult => {
+			(
+				providerName: string,
+				item: AuthCredential,
+				record: SerializedCredentialRecord,
+			): AuthCredentialIfAbsentResult => {
 				const existingRows = this.#listActiveByProviderStmt.all(providerName) as AuthRow[];
-				const existing: StoredAuthCredential[] = [];
+				const existing: Array<{
+					id: number;
+					credential: AuthCredential;
+					identityKey: string | null;
+				}> = [];
 				for (const row of existingRows) {
 					const activeCredential = deserializeCredential(row);
 					if (!activeCredential) continue;
-					existing.push(toStoredAuthCredential(row, activeCredential));
+					existing.push({
+						id: row.id,
+						credential: activeCredential,
+						identityKey: resolveRowCredentialIdentityKey(providerName, row),
+					});
 				}
 				if (existing.length > 0) {
-					return { inserted: false, reason: "skipped-existing", provider: providerName, entries: existing };
+					let targetId: number | null = null;
+					for (const row of existing) {
+						if (!matchesReplacementCredential(providerName, row.credential, row.identityKey, item)) continue;
+						if (targetId === null) {
+							targetId = row.id;
+							this.#updateStmt.run(record.credentialType, record.data, record.identityKey, row.id);
+						} else {
+							this.#deleteStmt.run("replaced by newer credential", row.id);
+						}
+					}
+
+					if (targetId !== null) {
+						return {
+							inserted: true,
+							reason: "updated-existing",
+							provider: providerName,
+							entries: this.listAuthCredentials(providerName),
+						};
+					}
+
+					return {
+						inserted: false,
+						reason: "skipped-existing",
+						provider: providerName,
+						entries: existing.map(row => ({
+							id: row.id,
+							provider: providerName,
+							credential: row.credential,
+							disabledCause: null,
+						})),
+					};
 				}
 
 				this.#insertStmt.get(providerName, record.credentialType, record.data, record.identityKey);
@@ -4124,7 +4181,9 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 			},
 		);
 
-		return writeIfAbsent.immediate(provider, serialized);
+		const result = writeIfAbsent.immediate(provider, credential, serialized);
+		if (result.inserted) this.#purgeSupersededDisabledRows(provider, result.entries);
+		return result;
 	}
 
 	/**
@@ -4221,6 +4280,13 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		}
 	}
 
+	deleteCachePrefix(prefix: string): void {
+		if (prefix.length === 0) return;
+		try {
+			this.#deleteCachePrefixStmt.run(prefix.length, prefix);
+		} catch {}
+	}
+
 	cleanExpiredCache(): void {
 		try {
 			this.#deleteExpiredCacheStmt.run();
@@ -4311,6 +4377,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		this.#getCacheStmt.finalize();
 		this.#getCacheIncludingExpiredStmt.finalize();
 		this.#upsertCacheStmt.finalize();
+		this.#deleteCachePrefixStmt.finalize();
 		this.#deleteExpiredCacheStmt.finalize();
 		this.#db.close();
 	}

--- a/packages/ai/test/auth-storage-if-absent.test.ts
+++ b/packages/ai/test/auth-storage-if-absent.test.ts
@@ -8,6 +8,7 @@ import {
 	type AuthCredentialIfAbsentResult,
 	type AuthCredentialStore,
 	AuthStorage,
+	type OAuthCredential,
 	REMOTE_REFRESH_SENTINEL,
 	SqliteAuthCredentialStore,
 } from "../src/auth-storage";
@@ -18,7 +19,7 @@ const SUPPRESS_ANTHROPIC_ENV = {
 	ANTHROPIC_OAUTH_TOKEN: undefined,
 } as const;
 
-function oauth(suffix = "1"): AuthCredential {
+function oauth(suffix = "1"): OAuthCredential {
 	return {
 		type: "oauth",
 		access: `access-${suffix}`,
@@ -50,6 +51,10 @@ class CountingStore implements AuthCredentialStore {
 	}
 	upsertAuthCredentialForProviderIfAbsent(provider: string, credential: AuthCredential): AuthCredentialIfAbsentResult {
 		this.ifAbsentCalls += 1;
+		const existing = this.rows.filter(row => row.provider === provider && row.disabledCause === null);
+		if (existing.length > 0) {
+			return { inserted: false, reason: "skipped-existing", provider, entries: existing };
+		}
 		this.rows = [{ id: 1, provider, credential, disabledCause: null }];
 		return { inserted: true, reason: "inserted", provider, entries: this.rows };
 	}
@@ -58,6 +63,10 @@ class CountingStore implements AuthCredentialStore {
 		credential: AuthCredential,
 	): Promise<AuthCredentialIfAbsentResult> {
 		this.remoteIfAbsentCalls += 1;
+		const existing = this.rows.filter(row => row.provider === provider && row.disabledCause === null);
+		if (existing.length > 0) {
+			return { inserted: false, reason: "skipped-existing", provider, entries: existing };
+		}
 		this.rows = [{ id: 2, provider, credential, disabledCause: null }];
 		return { inserted: true, reason: "inserted", provider, entries: this.rows };
 	}
@@ -66,6 +75,7 @@ class CountingStore implements AuthCredentialStore {
 		return null;
 	}
 	setCache(): void {}
+	deleteCachePrefix(): void {}
 	cleanExpiredCache(): void {}
 }
 
@@ -81,7 +91,7 @@ describe("if-absent auth credential writes", () => {
 		await fs.rm(tempDir, { recursive: true, force: true });
 	});
 
-	test("SqliteAuthCredentialStore inserts when empty and skips when any active row exists", async () => {
+	test("SqliteAuthCredentialStore inserts when empty, skips other identities, and updates matching OAuth rows", async () => {
 		const store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
 		try {
 			const inserted = store.upsertAuthCredentialForProviderIfAbsent("anthropic", oauth("a"));
@@ -93,6 +103,23 @@ describe("if-absent auth credential writes", () => {
 			expect(skippedOauth.inserted).toBe(false);
 			expect(skippedOauth.reason).toBe("skipped-existing");
 			expect(skippedOauth.entries).toHaveLength(1);
+
+			const refreshed = store.upsertAuthCredentialForProviderIfAbsent("anthropic", {
+				...oauth("fresh"),
+				accountId: "acct-a",
+				email: "user-a@example.com",
+			});
+			expect(refreshed.inserted).toBe(true);
+			expect(refreshed.reason).toBe("updated-existing");
+			expect(refreshed.entries).toHaveLength(1);
+			expect(refreshed.entries[0]?.id).toBe(inserted.entries[0]?.id);
+			expect(refreshed.entries[0]?.credential).toMatchObject({
+				type: "oauth",
+				access: "access-fresh",
+				refresh: "refresh-fresh",
+				accountId: "acct-a",
+				email: "user-a@example.com",
+			});
 
 			const apiStore = await SqliteAuthCredentialStore.open(path.join(tempDir, "api.db"));
 			try {
@@ -267,7 +294,7 @@ try {
 			expect((await stored.importCredentialIfAbsent("anthropic", oauth("incoming"))).reason).toBe(
 				"skipped-existing",
 			);
-			expect(storedStore.ifAbsentCalls).toBe(0);
+			expect(storedStore.remoteIfAbsentCalls).toBe(1);
 
 			const fallbackStore = new CountingStore();
 			const fallback = new AuthStorage(fallbackStore);
@@ -314,6 +341,62 @@ try {
 				expect(result.reason).toBe("inserted");
 				expect(storage.has("anthropic")).toBe(true);
 				expect(result.entries).toHaveLength(1);
+			} finally {
+				storage.close();
+			}
+		});
+	});
+
+	test("AuthStorage.importCredentialIfAbsent refreshes matching local OAuth and clears provider usage cache", async () => {
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			const store = await SqliteAuthCredentialStore.open(path.join(tempDir, "refresh.db"));
+			const storage = new AuthStorage(store);
+			try {
+				await storage.reload();
+				const initial = await storage.importCredentialIfAbsent("anthropic", oauth("cached"));
+				expect(initial.reason).toBe("inserted");
+
+				const cacheKey =
+					"usage_cache:report:anthropic:default:oauth|account:acct-cached|email:user-cached@example.com";
+				store.setCache(
+					cacheKey,
+					JSON.stringify({
+						value: {
+							provider: "anthropic",
+							fetchedAt: Date.now(),
+							limits: [
+								{
+									id: "weekly",
+									label: "Weekly",
+									scope: { provider: "anthropic" },
+									amount: { unit: "unknown" },
+								},
+							],
+							metadata: { email: "user-cached@example.com" },
+						},
+						expiresAt: Date.now() + 3_600_000,
+					}),
+					Math.floor((Date.now() + 3_600_000) / 1000),
+				);
+				expect(store.getCache(cacheKey, { includeExpired: true })).not.toBeNull();
+
+				const refreshed = await storage.importCredentialIfAbsent("anthropic", {
+					...oauth("refreshed"),
+					accountId: "acct-cached",
+					email: "user-cached@example.com",
+				});
+
+				expect(refreshed.inserted).toBe(true);
+				expect(refreshed.reason).toBe("updated-existing");
+				expect(refreshed.entries).toHaveLength(1);
+				expect(refreshed.entries[0]?.id).toBe(initial.entries[0]?.id);
+				expect(refreshed.entries[0]?.credential).toMatchObject({
+					type: "oauth",
+					access: "access-refreshed",
+					accountId: "acct-cached",
+					email: "user-cached@example.com",
+				});
+				expect(store.getCache(cacheKey, { includeExpired: true })).toBeNull();
 			} finally {
 				storage.close();
 			}

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -420,6 +420,10 @@ FROM model_usage_legacy
 		this.#authStore.setCache(key, value, expiresAtSec);
 	}
 
+	deleteCachePrefix(prefix: string): void {
+		this.#authStore.deleteCachePrefix?.(prefix);
+	}
+
 	/**
 	 * Deletes expired cache entries. Call periodically for cleanup.
 	 */


### PR DESCRIPTION
Fixes #1594

## Summary

- Refresh a matching existing OAuth credential during `importCredentialIfAbsent` instead of provider-wide skipping before identity matching.
- Keep the existing safe behavior for different active identities: they still return `skipped-existing` and do not insert a new account.
- Invalidate provider usage caches after credential writes, including remote broker client caches, so stale limit reports do not survive a refreshed credential.
- Add focused coverage for matching-row refresh and stale usage-cache clearing, plus an Unreleased changelog entry.

## Tests

- `bun install`
- `bun run build:native`
- `bun test packages/ai/test/auth-storage-if-absent.test.ts`
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/coding-agent run check`
- `bun run check:tools`
- `bun run check`

## Notes

- `bun run dev:doctor` was also tried. It failed because this local checkout's `gjc` resolves to the package bin rather than the source entry expected by the doctor. I did not run `bun run dev:link` because that would mutate the developer machine's active `gjc` link.