### PR TITLE
Add deterministic ambiguity floor to deep-interview scoring

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -385,11 +385,22 @@ Ambiguity-raising triggers:
 
 Use **mechanism A** for every ambiguity rise: a trigger LOWERS the affected component/dimension clarity score, and the existing weighted formula raises ambiguity. There is **no separate penalty term**; ambiguity remains bounded by the same greenfield/brownfield formula.
 
+**Deterministic ambiguity floor (runtime-enforced).** The runtime independently computes a code-level floor from persisted state and clamps every reported ambiguity to `max(reported, floor)` at write time — the scorer cannot under-report below what code can objectively measure:
+
+- `+0.10` per established fact marked `disputed` that has no `superseded_by` resolution (contradiction pressure)
+- `+0.05` per active topology component whose goal/constraints/criteria clarity is still unscored (gap pressure — persist `topology.components[].clarity_scores` every round or the floor blocks convergence)
+- `+0.05 × (auto-answered rounds / scored rounds)` (assumption dilution)
+
+Cooperate with the floor rather than fight it:
+- Replacing an already-scored answer for the same round (a retraction/pivot) automatically marks that round's established facts as disputed; ambiguity rises mechanically even when no trigger is reported. Treat a floor-driven rise as trigger evidence and score the affected dimensions accordingly.
+- A disputed fact keeps the floor at or above `0.10` — above the default threshold — so convergence is blocked until the dispute is resolved: either the user re-confirms the original fact (set `disputed: false`) or the superseding decision is recorded as a new established fact and the old fact gets `superseded_by: <new fact id>`. Never delete the contradicted fact.
+- When the effective score was clamped upward, the persisted round carries `reported_ambiguity` (your raw score) and `ambiguity_floor`; report the floor and its dominant cause in the Step 2d table instead of pretending the raw score held.
+
 The rise is SILENT: no modal, no forced-resolution step, and no dedicated conflict UI. Surface it through the normal per-round report and by targeting the next question at the affected component/dimension.
 
 Structured scorer output is required. Include `triggers`, `trigger_status`, `affected_component`, `affected_dimension`, `prior_dimension_score`, `new_dimension_score`, `prior_ambiguity`, `new_ambiguity`, `evidence`, `contradicted_established_fact` when relevant, and `disputed_unresolved_rationale` when applicable.
 
-Established-facts maintenance: promote stable confirmed decisions into `state.established_facts` with source/evidence; when a new answer contradicts an established fact, mark the fact disputed and preserve the contradicted fact instead of deleting it.
+Established-facts maintenance: promote stable confirmed decisions into `state.established_facts` with source/evidence; when a new answer contradicts an established fact, mark the fact disputed and preserve the contradicted fact instead of deleting it. When the user later confirms the new direction, record the superseding decision as a new established fact and set `superseded_by: <new fact id>` on the disputed fact — that is the only way to release the deterministic floor pressure while keeping the audit trail.
 
 TRANSITION VALIDATION: if a trigger is present, the affected dimension must not improve and overall ambiguity must rise vs the prior scored round, unless the trigger is explicitly marked disputed or unresolved with rationale.
 
@@ -483,6 +494,7 @@ Round {n} complete.
 | Success Criteria | {s} | {w} | {s*w} | {gap or "Clear"} |
 | Context (brownfield) | {s} | {w} | {s*w} | {gap or "Clear"} |
 | **Ambiguity** | | | **{prior_score}% -> {score}% {up|down|flat}** | {if up: trigger name such as "A direct contradiction"} |
+| **Floor** (only when clamped) | | | **{floor}%** | {dominant cause: disputed fact / unscored component / auto-answer dilution} |
 
 **Topology:** Targeted {target_component_name} | Active: {active_component_count} | Deferred: {deferred_component_count} | Next rotation after: {last_targeted_component_id}
 
@@ -543,7 +555,7 @@ When ambiguity ≤ threshold (or hard cap / early exit):
 
 **Before generating the spec, two gates must pass, in order:**
 
-**4a. Closure / Acceptance Guard.** Even when ambiguity ≤ threshold, do not treat the math as completion. Run an independent readiness audit from the full main-session perspective (including explore findings, established facts, and triggers the scorer may not have fully weighed). Confirm every active topology component has goal/constraint/criteria coverage, no unresolved or disputed trigger remains on a path that matters, and no low-confidence auto-answer is standing in for user-confirmed truth above the clarity cap. If a material gap exists, explicitly override the gate to the user — "The math says ready, but I am not accepting it yet because {gap}" — and ask the single highest-impact follow-up, returning to Phase 2. Record any override in `state.closure_overrides`.
+**4a. Closure / Acceptance Guard.** Even when ambiguity ≤ threshold, do not treat the math as completion. Run an independent readiness audit from the full main-session perspective (including explore findings, established facts, and triggers the scorer may not have fully weighed). Confirm every active topology component has goal/constraint/criteria coverage, no unresolved or disputed trigger remains on a path that matters, no disputed established fact lacks a `superseded_by` resolution, and no low-confidence auto-answer is standing in for user-confirmed truth above the clarity cap. If a material gap exists, explicitly override the gate to the user — "The math says ready, but I am not accepting it yet because {gap}" — and ask the single highest-impact follow-up, returning to Phase 2. Record any override in `state.closure_overrides`.
 
 **4b. Restate gate.** Once closure passes, collapse the agreed answers into ONE sentence goal that covers every active component, and confirm it with a single `ask`: "If someone read only this line, would they reach the same outcome you have in mind?" Offer **Yes, crystallize**, **Adjust wording**, and **Missing scope**, plus free-text, applying `language.instruction` when present. Because this gate has options, it MUST go through `ask`: do not print the Restate question and options as assistant prose with `Question:`/`Options:` labels. If the Restate gate was already printed that way, immediately call `ask` with the same question/options before accepting or waiting for any answer. On "Adjust wording" / "Missing scope", collect the exact correction with one follow-up `ask`, route it back through Step 2c scoring and established-facts maintenance (a correction can change ambiguity), then re-run closure and ask the Restate gate again. Cap at two loops; if alignment is not reached, return to Phase 2 with a targeted question instead of forcing a goal line. Persist the confirmed line as `state.restated_goal`.
 

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-ambiguity.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-ambiguity.ts
@@ -1,0 +1,206 @@
+import {
+	type DeepInterviewEstablishedFact,
+	type DeepInterviewRoundRecord,
+	type DeepInterviewStateEnvelope,
+	normalizeDeepInterviewEnvelope,
+} from "./deep-interview-state";
+
+/**
+ * Deterministic ambiguity floor for deep-interview.
+ *
+ * The interview's ambiguity score is reported by an LLM scorer, which anchors on
+ * prior scores and under-reports rises when the user pivots or contradicts earlier
+ * answers. Following the Ouroboros `max(llm_score, deterministic_floor(ledger))`
+ * principle, this pure leaf module computes a code-level lower bound from evidence
+ * already persisted in deep-interview state, so the reported score can never fall
+ * below what code can objectively measure:
+ *
+ * - `0.10` per established fact marked disputed with no `superseded_by` resolution
+ *   (contradiction pressure — a pivot keeps ambiguity elevated until resolved);
+ * - `0.05` per active topology component whose goal/constraints/criteria clarity
+ *   is still unscored (gap pressure — a sibling component cannot hide);
+ * - `0.05 × (auto-answered rounds / scored rounds)` (assumption dilution).
+ *
+ * Like `deep-interview-state`, this module MUST stay pure and dependency-free
+ * (no filesystem, no state-writer, no CLI runtime) so every writer can apply it.
+ */
+
+// =============================================================================
+// Weights (mirrors the Ouroboros deterministic_floor coefficients)
+// =============================================================================
+
+const DISPUTED_FACT_WEIGHT = 0.1;
+const UNSCORED_COMPONENT_WEIGHT = 0.05;
+const AUTO_ANSWER_DILUTION_WEIGHT = 0.05;
+
+const CORE_CLARITY_DIMENSIONS = ["goal", "constraints", "criteria"] as const;
+
+export interface AmbiguityFloorBreakdown {
+	floor: number;
+	disputed_fact_count: number;
+	unscored_active_component_count: number;
+	auto_answer_ratio: number;
+}
+
+export interface AmbiguityClampResult {
+	effective: number;
+	clamped: boolean;
+}
+
+// =============================================================================
+// Pure helpers
+// =============================================================================
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function asArray(value: unknown): unknown[] {
+	return Array.isArray(value) ? value : [];
+}
+
+function round2(value: number): number {
+	return Math.round(value * 100) / 100;
+}
+
+/** A disputed fact contributes pressure until it is resolved via `superseded_by` or re-confirmation. */
+function isUnresolvedDisputedFact(value: unknown): boolean {
+	if (!isPlainObject(value)) return false;
+	const fact = value as Partial<DeepInterviewEstablishedFact>;
+	if (fact.disputed !== true) return false;
+	return typeof fact.superseded_by !== "string" || fact.superseded_by.trim() === "";
+}
+
+/**
+ * An active component is unscored while any core clarity dimension lacks a finite
+ * numeric score. Deferred components are excluded (they are outside ambiguity math),
+ * and the gate only arms once the topology was explicitly confirmed in Round 0.
+ */
+function countUnscoredActiveComponents(topology: unknown): number {
+	if (!isPlainObject(topology) || topology.status !== "confirmed") return 0;
+	let unscored = 0;
+	for (const component of asArray(topology.components)) {
+		if (!isPlainObject(component) || component.status === "deferred") continue;
+		const clarity = isPlainObject(component.clarity_scores) ? component.clarity_scores : {};
+		const incomplete = CORE_CLARITY_DIMENSIONS.some(dimension => {
+			const score = clarity[dimension];
+			return typeof score !== "number" || !Number.isFinite(score);
+		});
+		if (incomplete) unscored += 1;
+	}
+	return unscored;
+}
+
+function autoAnswerRatio(inner: Record<string, unknown>): number {
+	const autoAnswered = asArray(inner.auto_answered_rounds).length;
+	if (autoAnswered === 0) return 0;
+	const scored = asArray(inner.rounds).filter(round => isPlainObject(round) && round.lifecycle === "scored").length;
+	return Math.min(1, autoAnswered / Math.max(scored, 1));
+}
+
+// =============================================================================
+// Floor computation + clamping
+// =============================================================================
+
+/** Compute the deterministic floor from the inner deep-interview `state` object. */
+export function computeAmbiguityFloor(inner: unknown): AmbiguityFloorBreakdown {
+	const state = isPlainObject(inner) ? inner : {};
+	const disputedFactCount = asArray(state.established_facts).filter(isUnresolvedDisputedFact).length;
+	const unscoredActiveComponentCount = countUnscoredActiveComponents(state.topology);
+	const ratio = autoAnswerRatio(state);
+	const floor =
+		DISPUTED_FACT_WEIGHT * disputedFactCount +
+		UNSCORED_COMPONENT_WEIGHT * unscoredActiveComponentCount +
+		AUTO_ANSWER_DILUTION_WEIGHT * ratio;
+	return {
+		floor: round2(Math.min(1, Math.max(0, floor))),
+		disputed_fact_count: disputedFactCount,
+		unscored_active_component_count: unscoredActiveComponentCount,
+		auto_answer_ratio: round2(ratio),
+	};
+}
+
+/** Clamp an LLM-reported ambiguity to the deterministic floor: `max(reported, floor)`. */
+export function clampReportedAmbiguity(reported: number, floor: number): AmbiguityClampResult {
+	const bounded = Math.min(1, Math.max(0, reported));
+	if (floor > bounded) return { effective: Math.min(1, floor), clamped: true };
+	return { effective: bounded, clamped: false };
+}
+
+/**
+ * Mark every established fact recorded in `retractedRound` as disputed. This is the
+ * mechanical contradiction signal for answer retraction: when the user replaces an
+ * already-scored answer (A -> B pivot), the facts that answer established can no
+ * longer be trusted, so they raise the floor until re-confirmed or superseded.
+ * Returns new arrays/objects; never mutates the input.
+ */
+export function disputeFactsFromRetractedRound(
+	facts: readonly unknown[],
+	retractedRound: number,
+): { facts: Record<string, unknown>[]; disputedIds: string[] } {
+	const disputedIds: string[] = [];
+	const next = facts.filter(isPlainObject).map(fact => {
+		const record = fact as Record<string, unknown>;
+		if (record.round !== retractedRound || record.disputed === true) return { ...record };
+		if (typeof record.superseded_by === "string" && record.superseded_by.trim() !== "") return { ...record };
+		if (typeof record.id === "string") disputedIds.push(record.id);
+		return { ...record, disputed: true };
+	});
+	return { facts: next, disputedIds };
+}
+
+export interface AppliedAmbiguityFloor {
+	envelope: DeepInterviewStateEnvelope;
+	breakdown: AmbiguityFloorBreakdown;
+	clamped: boolean;
+}
+
+/**
+ * Enforce the floor invariant on a full deep-interview envelope: recompute the floor
+ * from persisted evidence, clamp `state.current_ambiguity`, and clamp the latest
+ * scored round (preserving the original value as `reported_ambiguity` for audit).
+ * Historical rounds are never rewritten. Idempotent and non-mutating; every writer
+ * (state CLI write/reconcile, recorder) applies this immediately before persisting.
+ */
+export function applyAmbiguityFloorToEnvelope(value: unknown): AppliedAmbiguityFloor {
+	const envelope = normalizeDeepInterviewEnvelope(value);
+	const inner = { ...(envelope.state as Record<string, unknown>) };
+	const breakdown = computeAmbiguityFloor(inner);
+	let clamped = false;
+
+	const rounds = asArray(inner.rounds).filter(isPlainObject) as unknown as DeepInterviewRoundRecord[];
+	let latestScoredIndex = -1;
+	for (let index = 0; index < rounds.length; index += 1) {
+		const candidate = rounds[index];
+		if (candidate.lifecycle !== "scored" || !Number.isFinite(candidate.round)) continue;
+		if (latestScoredIndex < 0 || candidate.round >= rounds[latestScoredIndex].round) latestScoredIndex = index;
+	}
+	if (latestScoredIndex >= 0) {
+		const latest = rounds[latestScoredIndex];
+		if (typeof latest.ambiguity === "number") {
+			const clampedRound = clampReportedAmbiguity(latest.ambiguity, breakdown.floor);
+			if (clampedRound.clamped) {
+				const nextRounds = [...rounds];
+				nextRounds[latestScoredIndex] = {
+					...latest,
+					reported_ambiguity: latest.reported_ambiguity ?? latest.ambiguity,
+					ambiguity: clampedRound.effective,
+					ambiguity_floor: breakdown.floor,
+				};
+				inner.rounds = nextRounds;
+				clamped = true;
+			}
+		}
+	}
+
+	if (typeof inner.current_ambiguity === "number") {
+		const clampedCurrent = clampReportedAmbiguity(inner.current_ambiguity, breakdown.floor);
+		if (clampedCurrent.clamped) {
+			inner.current_ambiguity = clampedCurrent.effective;
+			clamped = true;
+		}
+	}
+
+	inner.ambiguity_floor = breakdown;
+	return { envelope: { ...envelope, state: inner }, breakdown, clamped };
+}

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-recorder.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-recorder.ts
@@ -2,6 +2,11 @@ import { syncSkillActiveState } from "../skill-state/active-state";
 import { deriveDeepInterviewHud } from "../skill-state/workflow-hud";
 import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
 import {
+	clampReportedAmbiguity,
+	computeAmbiguityFloor,
+	disputeFactsFromRetractedRound,
+} from "./deep-interview-ambiguity";
+import {
 	answerHash,
 	type DeepInterviewEstablishedFact,
 	type DeepInterviewRoundRecord,
@@ -14,6 +19,7 @@ import {
 import { writeSessionActivityMarker } from "./session-resolution";
 import { readExistingStateForMutation, writeGuardedWorkflowEnvelopeAtomic } from "./state-writer";
 
+export * from "./deep-interview-ambiguity";
 export * from "./deep-interview-state";
 
 /**
@@ -395,30 +401,55 @@ export async function syncDeepInterviewRecorderHud(
 	await syncRecorderHud(cwd, normalizeDeepInterviewEnvelope(read.value), sessionId);
 }
 
-/** Record an `answered` shell for one round (append-or-merge by durable key). */
+/**
+ * Record an `answered` shell for one round (append-or-merge by durable key).
+ *
+ * Retraction dynamics: replacing an already-`scored` answer is a mechanical
+ * contradiction signal (the user pivoted). The facts that round established are
+ * marked disputed, which raises the deterministic ambiguity floor immediately —
+ * without waiting for the LLM scorer to self-report a trigger.
+ */
 export async function appendOrMergeDeepInterviewRound(
 	cwd: string,
 	statePath: string,
 	input: DeepInterviewAnswerInput,
 	options: { sessionId?: string } = {},
-): Promise<{ action: AppendOrMergeAction; record: DeepInterviewRoundRecord }> {
+): Promise<{ action: AppendOrMergeAction; record: DeepInterviewRoundRecord; disputedFactIds?: string[] }> {
 	const envelope = await readEnvelope(statePath);
 	const interviewId = input.interviewId ?? interviewIdOf(envelope);
 	const shell = buildAnswerShell({ ...input, interviewId });
 	const rounds = readRounds(envelope);
+	const priorRecord = rounds.find(r => r.round_key === shell.round_key);
 	const result = appendOrMergeRound(rounds, shell);
 	if (result.action === "noop") {
 		await repairRecorderHudFromPersisted(cwd, statePath, options.sessionId);
 		return { action: result.action, record: result.record };
 	}
-	(envelope.state as Record<string, unknown>).rounds = result.rounds;
+	const inner = envelope.state as Record<string, unknown>;
+	inner.rounds = result.rounds;
+	let disputedFactIds: string[] | undefined;
+	if (result.action === "replaced" && priorRecord?.lifecycle === "scored") {
+		const facts = Array.isArray(inner.established_facts) ? inner.established_facts : [];
+		const disputed = disputeFactsFromRetractedRound(facts, shell.round);
+		if (disputed.disputedIds.length > 0) {
+			inner.established_facts = disputed.facts;
+			disputedFactIds = disputed.disputedIds;
+			// Surface the rise right away: the retraction changed the evidence, so the
+			// gating score must reflect the new floor before the next scoring pass.
+			const breakdown = computeAmbiguityFloor(inner);
+			inner.ambiguity_floor = breakdown;
+			if (typeof inner.current_ambiguity === "number") {
+				inner.current_ambiguity = clampReportedAmbiguity(inner.current_ambiguity, breakdown.floor).effective;
+			}
+		}
+	}
 	await persistEnvelope(cwd, statePath, envelope, options.sessionId, "gjc deep-interview record-answer");
 	try {
 		await syncRecorderHud(cwd, envelope, options.sessionId);
 	} catch {
 		// HUD sync is best-effort cache maintenance and must not change record semantics.
 	}
-	return { action: result.action, record: result.record };
+	return { action: result.action, record: result.record, disputedFactIds };
 }
 
 /**
@@ -459,12 +490,34 @@ export async function enrichDeepInterviewRoundScoring(
 	const envelope = await readEnvelope(statePath);
 	const interviewId = input.interviewId ?? interviewIdOf(envelope);
 	const rounds = readRounds(envelope);
-	const { rounds: nextRounds, record } = enrichRoundWithScoring(rounds, { ...input, interviewId });
+	const { rounds: enrichedRounds, record: reportedRecord } = enrichRoundWithScoring(rounds, {
+		...input,
+		interviewId,
+	});
+	// Deterministic floor (Ouroboros principle): the LLM-reported ambiguity is only a
+	// lower-bound input. Evidence persisted in state — unresolved disputed facts,
+	// unscored active components, auto-answer dilution — sets a code-computed floor
+	// the reported score can never fall under, so a pivot mechanically raises the
+	// gating score even when the scorer omits triggers.
+	const inner = envelope.state as Record<string, unknown>;
+	const breakdown = computeAmbiguityFloor({ ...inner, rounds: enrichedRounds });
+	const clampResult = clampReportedAmbiguity(input.ambiguity, breakdown.floor);
+	let record = reportedRecord;
+	let nextRounds = enrichedRounds;
+	if (clampResult.clamped) {
+		record = {
+			...reportedRecord,
+			ambiguity: clampResult.effective,
+			reported_ambiguity: input.ambiguity,
+			ambiguity_floor: breakdown.floor,
+		};
+		nextRounds = enrichedRounds.map(item => (item.round_key === record.round_key ? record : item));
+	}
 	// Fail closed: a scored transition that violates the bidirectional invariant
 	// (an active trigger that improves the affected dimension or fails to raise
 	// overall ambiguity, or a disputed/unresolved trigger lacking a rationale) must
 	// never be persisted — storing it lets the interview falsely converge. Validate
-	// against the most recent prior scored round before writing any durable state.
+	// the effective (floor-clamped) record against the most recent prior scored round.
 	const prior = latestPriorScoredRound(rounds, record.round_key, record.round);
 	const validation = validateDeepInterviewScoredTransition(prior, record);
 	if (!validation.ok) {
@@ -472,8 +525,9 @@ export async function enrichDeepInterviewRoundScoring(
 			`deep-interview scored transition for round ${record.round} is invalid and was refused: ${validation.violations.join("; ")}`,
 		);
 	}
-	(envelope.state as Record<string, unknown>).rounds = nextRounds;
-	(envelope.state as Record<string, unknown>).current_ambiguity = input.ambiguity;
+	inner.rounds = nextRounds;
+	inner.current_ambiguity = clampResult.effective;
+	inner.ambiguity_floor = breakdown;
 	await persistEnvelope(cwd, statePath, envelope, options.sessionId, "gjc deep-interview score-round");
 	await syncRecorderHud(cwd, envelope, options.sessionId);
 	return { record };

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
@@ -31,6 +31,13 @@ export interface DeepInterviewEstablishedFact {
 	dimension?: string;
 	evidence?: string;
 	disputed: boolean;
+	/**
+	 * Resolution pointer for a disputed fact: the id of the fact that replaced it
+	 * after the user confirmed a pivot. A disputed fact without `superseded_by`
+	 * keeps the deterministic ambiguity floor elevated; setting it releases the
+	 * pressure while preserving the contradicted fact for audit.
+	 */
+	superseded_by?: string;
 }
 
 export interface DeepInterviewTriggerMetadata {
@@ -66,7 +73,12 @@ export interface DeepInterviewRoundRecord {
 	answered_at: string;
 	scored_at?: string;
 	scores?: Record<string, number>;
+	/** Effective ambiguity after the deterministic floor clamp (`max(reported, floor)`). */
 	ambiguity?: number;
+	/** Original LLM-reported ambiguity, preserved for audit when the floor clamped it. */
+	reported_ambiguity?: number;
+	/** Deterministic floor in effect when this round was scored, when it clamped. */
+	ambiguity_floor?: number;
 	triggers?: DeepInterviewTriggerMetadata[];
 }
 
@@ -125,6 +137,7 @@ const TRANSCRIPT_STATE_FIELDS = [
 	"rounds",
 	"established_facts",
 	"current_ambiguity",
+	"ambiguity_floor",
 	"topology",
 	"ontology_snapshots",
 	"auto_researched_rounds",

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -26,6 +26,7 @@ import {
 	type WorkflowStateReceipt,
 } from "../skill-state/workflow-state-contract";
 import { renderCliWriteReceipt } from "./cli-write-receipt";
+import { applyAmbiguityFloorToEnvelope } from "./deep-interview-ambiguity";
 import { mergeDeepInterviewEnvelope, normalizeDeepInterviewEnvelope } from "./deep-interview-state";
 import { activeSnapshotPath, auditPath, modeStatePath, sessionStateDir } from "./session-layout";
 import {
@@ -1158,7 +1159,12 @@ export async function reconcileWorkflowSkillState(options: {
 
 	const merged =
 		mode === "deep-interview"
-			? (mergeDeepInterviewEnvelope(existingPayload, payload) as Record<string, unknown>)
+			? // Enforce the deterministic ambiguity floor on every reconcile so a
+				// self-reported score can never undercut persisted contradiction evidence.
+				(applyAmbiguityFloorToEnvelope(mergeDeepInterviewEnvelope(existingPayload, payload)).envelope as Record<
+					string,
+					unknown
+				>)
 			: mergeWithNullDelete(existingPayload, payload);
 	merged.skill = mode;
 	merged.current_phase = trimmedPhase;
@@ -1355,7 +1361,11 @@ async function handleWrite(
 	if (mode === "deep-interview") {
 		// Deep-interview keeps interview data nested under `state` and merges rounds
 		// losslessly by durable key; never flatten or delete `state` (that drops recorder history).
-		merged = mergeDeepInterviewEnvelope(existingPayload, payload, { replace: hasFlag(args, "--replace") });
+		// The deterministic ambiguity floor is applied after the merge so a reported
+		// score written through the CLI can never undercut persisted contradiction evidence.
+		merged = applyAmbiguityFloorToEnvelope(
+			mergeDeepInterviewEnvelope(existingPayload, payload, { replace: hasFlag(args, "--replace") }),
+		).envelope;
 	} else if (hasFlag(args, "--replace")) {
 		merged = { ...payload };
 	} else {

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-ambiguity.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-ambiguity.test.ts
@@ -1,0 +1,259 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+	appendOrMergeDeepInterviewRound,
+	applyAmbiguityFloorToEnvelope,
+	clampReportedAmbiguity,
+	computeAmbiguityFloor,
+	disputeFactsFromRetractedRound,
+	enrichDeepInterviewRoundScoring,
+} from "@gajae-code/coding-agent/gjc-runtime/deep-interview-recorder";
+import { modeStatePath } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
+
+const TEST_SESSION_ID = "test-session";
+const tempRoots: string[] = [];
+let priorSessionId: string | undefined;
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-deep-interview-ambiguity-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+beforeAll(() => {
+	priorSessionId = process.env.GJC_SESSION_ID;
+	process.env.GJC_SESSION_ID = TEST_SESSION_ID;
+});
+
+afterAll(() => {
+	if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
+	else delete process.env.GJC_SESSION_ID;
+});
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+function fact(over: Record<string, unknown> = {}): Record<string, unknown> {
+	return { id: "f1", statement: "Core entity is Task", round: 1, disputed: false, ...over };
+}
+
+describe("deep-interview ambiguity: deterministic floor", () => {
+	it("is zero for empty state", () => {
+		expect(computeAmbiguityFloor({}).floor).toBe(0);
+		expect(computeAmbiguityFloor(undefined).floor).toBe(0);
+	});
+
+	it("adds 0.10 per unresolved disputed fact", () => {
+		const breakdown = computeAmbiguityFloor({
+			established_facts: [fact({ disputed: true }), fact({ id: "f2", disputed: true }), fact({ id: "f3" })],
+		});
+		expect(breakdown.floor).toBe(0.2);
+		expect(breakdown.disputed_fact_count).toBe(2);
+	});
+
+	it("releases contradiction pressure when a disputed fact is superseded", () => {
+		const breakdown = computeAmbiguityFloor({
+			established_facts: [
+				fact({ disputed: true, superseded_by: "f9" }),
+				fact({ id: "f9", statement: "Core entity is Project" }),
+			],
+		});
+		expect(breakdown.floor).toBe(0);
+		expect(breakdown.disputed_fact_count).toBe(0);
+	});
+
+	it("adds 0.05 per unscored active component once topology is confirmed", () => {
+		const topology = {
+			status: "confirmed",
+			components: [
+				{ id: "a", status: "active", clarity_scores: { goal: 0.9, constraints: 0.8, criteria: 0.9 } },
+				{ id: "b", status: "active", clarity_scores: { goal: 0.9, constraints: null, criteria: 0.9 } },
+				{ id: "c", status: "deferred", clarity_scores: {} },
+				{ id: "d", status: "active" },
+			],
+		};
+		const breakdown = computeAmbiguityFloor({ topology });
+		expect(breakdown.unscored_active_component_count).toBe(2);
+		expect(breakdown.floor).toBe(0.1);
+		// Unconfirmed topology must not arm the gap pressure.
+		expect(computeAmbiguityFloor({ topology: { ...topology, status: "pending" } }).floor).toBe(0);
+	});
+
+	it("adds bounded auto-answer dilution", () => {
+		const rounds = [
+			{ round_key: "k1", round: 1, lifecycle: "scored" },
+			{ round_key: "k2", round: 2, lifecycle: "scored" },
+		];
+		const breakdown = computeAmbiguityFloor({ rounds, auto_answered_rounds: [2] });
+		expect(breakdown.auto_answer_ratio).toBe(0.5);
+		expect(breakdown.floor).toBe(0.03);
+		// Ratio (and thus the dilution term) is capped at 1 even with more auto rounds than scored rounds.
+		const saturated = computeAmbiguityFloor({ rounds, auto_answered_rounds: [1, 2, 3, 4] });
+		expect(saturated.auto_answer_ratio).toBe(1);
+		expect(saturated.floor).toBe(0.05);
+	});
+
+	it("clamps reported ambiguity to max(reported, floor) within [0, 1]", () => {
+		expect(clampReportedAmbiguity(0.03, 0.2)).toEqual({ effective: 0.2, clamped: true });
+		expect(clampReportedAmbiguity(0.5, 0.2)).toEqual({ effective: 0.5, clamped: false });
+		expect(clampReportedAmbiguity(-1, 0)).toEqual({ effective: 0, clamped: false });
+		expect(clampReportedAmbiguity(2, 0)).toEqual({ effective: 1, clamped: false });
+	});
+});
+
+describe("deep-interview ambiguity: retraction disputes facts", () => {
+	it("disputes only facts from the retracted round, preserving resolved and foreign facts", () => {
+		const facts = [
+			fact({ id: "f1", round: 2 }),
+			fact({ id: "f2", round: 2, disputed: true, superseded_by: "f9" }),
+			fact({ id: "f3", round: 3 }),
+		];
+		const result = disputeFactsFromRetractedRound(facts, 2);
+		expect(result.disputedIds).toEqual(["f1"]);
+		expect(result.facts[0].disputed).toBe(true);
+		expect(result.facts[1].disputed).toBe(true);
+		expect(result.facts[1].superseded_by).toBe("f9");
+		expect(result.facts[2].disputed).toBe(false);
+		// Input is never mutated.
+		expect(facts[0].disputed).toBe(false);
+	});
+});
+
+describe("deep-interview ambiguity: envelope floor application", () => {
+	it("clamps current_ambiguity and the latest scored round, preserving the reported value", () => {
+		const envelope = {
+			state: {
+				current_ambiguity: 0.04,
+				established_facts: [fact({ disputed: true })],
+				rounds: [
+					{ round_key: "k1", round: 1, lifecycle: "scored", ambiguity: 0.3, answered_at: "t" },
+					{ round_key: "k2", round: 2, lifecycle: "scored", ambiguity: 0.04, answered_at: "t" },
+				],
+			},
+		};
+		const applied = applyAmbiguityFloorToEnvelope(envelope);
+		expect(applied.clamped).toBe(true);
+		expect(applied.breakdown.floor).toBe(0.1);
+		const inner = applied.envelope.state as Record<string, unknown>;
+		expect(inner.current_ambiguity).toBe(0.1);
+		const rounds = inner.rounds as Record<string, unknown>[];
+		// Historical round untouched; latest scored round clamped with audit trail.
+		expect(rounds[0].ambiguity).toBe(0.3);
+		expect(rounds[1].ambiguity).toBe(0.1);
+		expect(rounds[1].reported_ambiguity).toBe(0.04);
+		expect(rounds[1].ambiguity_floor).toBe(0.1);
+		// Original envelope is not mutated.
+		expect(envelope.state.current_ambiguity).toBe(0.04);
+	});
+
+	it("is a no-op when the reported score already exceeds the floor, and is idempotent", () => {
+		const envelope = {
+			state: {
+				current_ambiguity: 0.5,
+				established_facts: [fact({ disputed: true })],
+				rounds: [{ round_key: "k1", round: 1, lifecycle: "scored", ambiguity: 0.5, answered_at: "t" }],
+			},
+		};
+		const first = applyAmbiguityFloorToEnvelope(envelope);
+		expect(first.clamped).toBe(false);
+		expect((first.envelope.state as Record<string, unknown>).current_ambiguity).toBe(0.5);
+		const second = applyAmbiguityFloorToEnvelope(first.envelope);
+		expect(second.clamped).toBe(false);
+		expect(second.envelope.state).toEqual(first.envelope.state);
+	});
+});
+
+describe("deep-interview ambiguity: recorder integration (dynamic rise and fall)", () => {
+	function statePathFor(cwd: string): string {
+		return modeStatePath(cwd, TEST_SESSION_ID, "deep-interview");
+	}
+
+	it("scoring is clamped by the floor when disputed facts exist", async () => {
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+		await appendOrMergeDeepInterviewRound(
+			cwd,
+			statePath,
+			{ round: 1, questionId: "q1", questionText: "Q1?" },
+			{ sessionId: TEST_SESSION_ID },
+		);
+		// Seed a disputed fact directly into persisted state (as the skill's state write would).
+		const persisted = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		persisted.state.established_facts = [fact({ disputed: true })];
+		await fs.writeFile(statePath, JSON.stringify(persisted));
+
+		const { record } = await enrichDeepInterviewRoundScoring(
+			cwd,
+			statePath,
+			{ round: 1, questionId: "q1", scores: { goal: 0.95 }, ambiguity: 0.03 },
+			{ sessionId: TEST_SESSION_ID },
+		);
+		expect(record.ambiguity).toBe(0.1);
+		expect(record.reported_ambiguity).toBe(0.03);
+		expect(record.ambiguity_floor).toBe(0.1);
+		const after = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		expect(after.state.current_ambiguity).toBe(0.1);
+		expect(after.state.ambiguity_floor.disputed_fact_count).toBe(1);
+	});
+
+	it("retracting a scored answer disputes that round's facts and raises current_ambiguity (A -> B pivot)", async () => {
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+		const input = { round: 1, questionId: "q1", questionText: "Q1?", selectedOptions: ["A"] };
+		await appendOrMergeDeepInterviewRound(cwd, statePath, input, { sessionId: TEST_SESSION_ID });
+		await enrichDeepInterviewRoundScoring(
+			cwd,
+			statePath,
+			{ round: 1, questionId: "q1", scores: { goal: 0.9 }, ambiguity: 0.06 },
+			{ sessionId: TEST_SESSION_ID },
+		);
+		// The scored round established a fact.
+		const persisted = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		persisted.state.established_facts = [fact({ round: 1 })];
+		await fs.writeFile(statePath, JSON.stringify(persisted));
+
+		// The user changes the round-1 answer: A -> B.
+		const replaced = await appendOrMergeDeepInterviewRound(
+			cwd,
+			statePath,
+			{ ...input, selectedOptions: ["B"] },
+			{ sessionId: TEST_SESSION_ID },
+		);
+		expect(replaced.action).toBe("replaced");
+		expect(replaced.disputedFactIds).toEqual(["f1"]);
+		const after = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		expect(after.state.established_facts[0].disputed).toBe(true);
+		// Ambiguity rose mechanically from 0.06 to the 0.10 floor without any scorer trigger.
+		expect(after.state.current_ambiguity).toBe(0.1);
+	});
+
+	it("superseding the disputed fact releases the floor so convergence can resume", async () => {
+		const cwd = await tempDir();
+		const statePath = statePathFor(cwd);
+		await appendOrMergeDeepInterviewRound(
+			cwd,
+			statePath,
+			{ round: 1, questionId: "q1", questionText: "Q1?" },
+			{ sessionId: TEST_SESSION_ID },
+		);
+		const persisted = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		persisted.state.established_facts = [
+			fact({ disputed: true, superseded_by: "f9" }),
+			fact({ id: "f9", statement: "Core entity is Project", round: 2 }),
+		];
+		await fs.writeFile(statePath, JSON.stringify(persisted));
+
+		const { record } = await enrichDeepInterviewRoundScoring(
+			cwd,
+			statePath,
+			{ round: 1, questionId: "q1", scores: { goal: 0.97 }, ambiguity: 0.03 },
+			{ sessionId: TEST_SESSION_ID },
+		);
+		expect(record.ambiguity).toBe(0.03);
+		expect(record.reported_ambiguity).toBeUndefined();
+		const after = JSON.parse(await fs.readFile(statePath, "utf-8"));
+		expect(after.state.current_ambiguity).toBe(0.03);
+	});
+});


### PR DESCRIPTION
## Summary
- Add `deep-interview-ambiguity.ts`, a pure leaf module that computes a deterministic ambiguity floor from evidence already persisted in deep-interview state: `+0.10` per unresolved disputed established fact, `+0.05` per active topology component with unscored goal/constraints/criteria clarity, `+0.05 × (auto-answered rounds / scored rounds)`.
- Clamp every reported ambiguity to `max(reported, floor)` at all three write paths (recorder scoring enrichment, `gjc state write`, reconcile). Clamped rounds keep `reported_ambiguity` and `ambiguity_floor` so the raw LLM score stays auditable.
- Consume the previously unused `replaced` append-or-merge action: retracting an already-scored answer (an A → B pivot) now auto-disputes that round's established facts, so ambiguity rises mechanically without scorer cooperation.
- Add `superseded_by` to established facts as the only way to release contradiction pressure — the disputed fact is preserved for audit, and convergence below the default threshold (0.05) stays blocked until the pivot is explicitly resolved (one disputed fact alone floors the score at 0.10).
- Document the floor and the `superseded_by` resolution protocol in the deep-interview SKILL so the scorer cooperates with the clamp instead of fighting it.

## Problem
The interview's ambiguity score was 100% LLM self-reported (`1 - Σ weighted dimension scores`), and the convergence gate compared the threshold against that self-reported number. The SKILL declares scoring "BIDIRECTIONAL and NON-MONOTONIC" with ambiguity-raising triggers (contradiction / inconsistency / evasive answer / scope expansion), but no mechanism enforced it: `validateDeepInterviewScoredTransition` only fires when the scorer *claims* a trigger, so silently omitting triggers passes validation. Since LLM scorers anchor on the prior score and prefer a convergence narrative, ambiguity decayed monotonically in practice — a user pivot (narrowing A → A', then reversing into B) never pushed the score back up, allowing false convergence over unresolved contradictions. It also inverted incentives: honestly reporting a trigger without raising the score made the scoring write fail closed, while omitting the trigger sailed through.

## Design notes (Ouroboros)
This ports the measurement principle from the [Ouroboros project](https://github.com/Q00/ouroboros) that already inspired this skill: its auto pipeline computes `ambiguity = max(llm_reported_score, deterministic_floor(ledger))`, where the floor is derived from structured ledger state (`0.05` per open gap, `0.10` per conflicting entry, `0.05 × assumption ratio`) so the LLM can never under-report below what code can objectively measure. The weights here mirror those coefficients, mapped onto state deep-interview already persists (disputed facts ≈ conflicting entries, unscored components ≈ open gaps, auto-answer ratio ≈ assumption dilution). The existing durable-round-key substrate made the retraction signal free: `appendOrMergeRound` already returned `replaced` — it was just never consumed. With the floor in place, the one-sided validator becomes complementary rather than the sole guard: an honestly reported trigger now passes because the floor raises the effective score first.

## Verification
- `bun test test/gjc-runtime/deep-interview-ambiguity.test.ts` (from `packages/coding-agent`) — 12 new tests covering floor math, envelope clamping/idempotence, retraction → dispute → rise, and `superseded_by` → release cycles
- `bun test test/gjc-runtime/deep-interview-recorder.test.ts test/gjc-runtime/deep-interview-recorder-redteam.test.ts test/gjc-runtime/deep-interview-state.test.ts test/gjc-runtime/deep-interview-state-redteam.test.ts test/gjc-runtime/deep-interview-hud-sync.test.ts test/gjc-runtime/deep-interview-runtime.test.ts test/gjc-runtime/state-runtime.test.ts test/gjc-runtime/workflow-state-command.test.ts test/default-gjc-definitions.test.ts test/deep-interview-skill-contract.test.ts` (from `packages/coding-agent`) — 166 pass, 0 fail
- `bun run check:types` (from `packages/coding-agent`)
- `git diff --check`
