### PR TITLE
fix(gjc-session): record vanished tmux postmortems

### DIFF
--- a/scripts/gjc-session/create.sh
+++ b/scripts/gjc-session/create.sh
@@ -17,6 +17,9 @@
 #   GJC_SESSION_MONITOR_DISABLE=1 disable external vanished-session monitor
 
 set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=postmortem.sh
+source "$SCRIPT_DIR/postmortem.sh"
 
 SESSION="${1:?Usage: $0 <session-name> <worktree-path> [channel-id] [mention]}"
 WORKDIR="${2:?Usage: $0 <session-name> <worktree-path> [channel-id] [mention]}"
@@ -154,6 +157,8 @@ chmod +x "$STATE_DIR/runner.sh"
 cat >"$STATE_DIR/monitor.sh" <<'MONITOR'
 #!/usr/bin/env bash
 set +e
+# shellcheck source=postmortem.sh
+source "${GJC_SESSION_POSTMORTEM_SH:?}"
 interval="${GJC_SESSION_MONITOR_INTERVAL:-5}"
 case "$interval" in
   ''|*[!0-9]*) interval=5 ;;
@@ -170,59 +175,42 @@ while true; do
   detected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   final_present=false
   [[ -s "$GJC_SESSION_FINAL_JSON" ]] && final_present=true
-  final_severity=""
   if [[ "$final_present" == "true" ]]; then
-    final_severity="$(python3 - "$GJC_SESSION_FINAL_JSON" <<'PYFINAL'
-import json
-import sys
-try:
-    with open(sys.argv[1], encoding="utf-8") as handle:
-        data = json.load(handle)
-    print(data.get("severity") or "normal")
-except Exception:
-    print("unreadable_final_status")
-PYFINAL
-)"
+    printf '[%s] tmux session closed after final status; no vanished failure marker written\n' "$detected_at" >>"$GJC_SESSION_EVENTS_LOG"
+    exit 0
   fi
   prompt_accepted=false
   [[ -s "${GJC_SESSION_PROMPT_ACCEPTED_JSON:-}" ]] && prompt_accepted=true
-  vanish_reason="tmux_session_missing"
-  if [[ "$prompt_accepted" == "true" && "$final_present" != "true" ]]; then
+  tui_ready=false
+  if [[ -s "$GJC_SESSION_PANE_LOG" ]] && grep -Eq 'Gajae forge|Type your message|> Type your message|Working' "$GJC_SESSION_PANE_LOG"; then
+    tui_ready=true
+  fi
+  vanish_phase="before_tui_readiness"
+  vanish_reason="tmux_session_missing_before_tui_readiness"
+  if [[ "$prompt_accepted" == "true" ]]; then
+    vanish_phase="after_prompt_acceptance"
     vanish_reason="tmux_session_missing_after_prompt_acceptance"
+  elif [[ "$tui_ready" == "true" ]]; then
+    vanish_phase="before_prompt_acceptance"
+    vanish_reason="tmux_session_missing_before_prompt_acceptance"
   fi
   severity="failure"
-  if [[ "$final_present" == "true" && "$final_severity" == "normal" ]]; then
-    severity="closed_after_final"
-  fi
-  printf '[%s] tmux session vanished final_present=%s prompt_accepted=%s severity=%s reason=%s\n' "$detected_at" "$final_present" "$prompt_accepted" "$severity" "$vanish_reason" >>"$GJC_SESSION_EVENTS_LOG"
-  python3 - "$GJC_SESSION_VANISHED_JSON" "$GJC_SESSION_NAME" "$detected_at" "$GJC_SESSION_WORKDIR" "$GJC_SESSION_BRANCH" "$GJC_SESSION_PANE_LOG" "$GJC_SESSION_EVENTS_LOG" "$GJC_SESSION_FINAL_JSON" "$GJC_COORDINATOR_SESSION_STATE_FILE" "$final_present" "$severity" "$final_severity" "$prompt_accepted" "$vanish_reason" "${GJC_SESSION_PROMPT_ACCEPTED_JSON:-}" <<'PYINNER'
-import json
-import sys
-
-(path, session, detected_at, workdir, branch, pane_log, events_log, final_json, runtime_state, final_present, severity, final_severity, prompt_accepted, reason, prompt_accepted_json) = sys.argv[1:]
-with open(path, "w", encoding="utf-8") as handle:
-    json.dump(
-        {
-            "session": session,
-            "detectedAt": detected_at,
-            "workdir": workdir,
-            "branch": branch,
-            "paneLog": pane_log,
-            "eventsLog": events_log,
-            "finalStatus": final_json,
-            "runtimeState": runtime_state,
-            "finalPresent": final_present == "true",
-            "severity": severity,
-            "reason": reason,
-            "finalSeverity": final_severity,
-            "promptAccepted": prompt_accepted == "true",
-            "promptAcceptedStatus": prompt_accepted_json or None,
-        },
-        handle,
-        indent=2,
-    )
-    handle.write("\n")
-PYINNER
+  printf '[%s] tmux session vanished final_present=%s prompt_accepted=%s tui_ready=%s phase=%s severity=%s reason=%s\n' "$detected_at" "$final_present" "$prompt_accepted" "$tui_ready" "$vanish_phase" "$severity" "$vanish_reason" >>"$GJC_SESSION_EVENTS_LOG"
+  gjc_session_write_vanished_json \
+    "$GJC_SESSION_VANISHED_JSON" \
+    "$GJC_SESSION_NAME" \
+    "$GJC_SESSION_WORKDIR" \
+    "$vanish_reason" \
+    "$vanish_phase" \
+    "$severity" \
+    "$prompt_accepted" \
+    false \
+    "$tui_ready" \
+    "$GJC_SESSION_PANE_LOG" \
+    "$GJC_SESSION_EVENTS_LOG" \
+    "$GJC_SESSION_FINAL_JSON" \
+    "$GJC_COORDINATOR_SESSION_STATE_FILE" \
+    "${GJC_SESSION_PROMPT_ACCEPTED_JSON:-}"
   if [[ "$severity" == "failure" && -n "${GJC_SESSION_ROUTER_BIN:-}" && -n "${GJC_SESSION_CHANNEL:-}" ]]; then
     "$GJC_SESSION_ROUTER_BIN" tmux stale \
       --session "$GJC_SESSION_NAME" \
@@ -285,6 +273,7 @@ if [[ "${GJC_SESSION_MONITOR_DISABLE:-0}" != "1" ]]; then
     "GJC_SESSION_PROMPT_ACCEPTED_JSON=$STATE_DIR/prompt-accepted.json"
     "GJC_COORDINATOR_SESSION_STATE_FILE=$RUNTIME_STATE_JSON"
     "GJC_SESSION_TMUX_BIN=$TMUX_BIN"
+    "GJC_SESSION_POSTMORTEM_SH=$SCRIPT_DIR/postmortem.sh"
     "GJC_SESSION_MONITOR_INTERVAL=${GJC_SESSION_MONITOR_INTERVAL:-5}"
     "GJC_SESSION_ROUTER_BIN=$ROUTER_BIN"
     "GJC_SESSION_CHANNEL=$CHANNEL"

--- a/scripts/gjc-session/create.test.ts
+++ b/scripts/gjc-session/create.test.ts
@@ -159,10 +159,12 @@ exit 0
 		};
 		expect(vanished).toMatchObject({
 			finalPresent: false,
-			reason: "tmux_session_missing",
+			reason: "tmux_session_missing_before_prompt_acceptance",
+			phase: "before_prompt_acceptance",
 			severity: "failure",
+			tuiReadyObserved: true,
 		});
-		expect(vanished.runtimeState).toBe(path.join(stateDir, "runtime-state.json"));
+		expect(vanished.runtimeState).toBe(path.relative(worktree, path.join(stateDir, "runtime-state.json")));
 		expect(await Bun.file(routerLog).text()).toContain("tmux stale --session");
 	});
 	test("external monitor records vanished sessions after prompt acceptance", async () => {
@@ -221,6 +223,45 @@ sleep 60
 			severity: "failure",
 		});
 	}, 20000);
+
+	test("prompt records vanished status and refuses to paste when tmux session is missing", async () => {
+		const session = `gjc_issue_1496_prompt_missing_${process.pid}_${Date.now()}`;
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-prompt-missing-"));
+		tempRoots.push(root);
+		const worktree = await makeGitWorktree(root);
+		const stateDir = path.join(root, "state");
+		await fs.mkdir(stateDir, { recursive: true });
+		await Bun.write(path.join(stateDir, "pane.log"), "Gajae forge\n> Type your message\n");
+		await Bun.write(path.join(stateDir, "metadata.json"), JSON.stringify({ session, workdir: worktree }, null, 2));
+
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "do not paste this prompt"], {
+			env: {
+				...process.env,
+				GJC_SESSION_STATE_DIR: stateDir,
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr.toString()).toContain("refusing to paste prompt: tmux session");
+		expect(result.stderr.toString()).not.toContain("do not paste this prompt");
+		const vanished = (await Bun.file(path.join(stateDir, "vanished.json")).json()) as {
+			phase: string;
+			reason: string;
+			promptAccepted: boolean;
+			finalPresent: boolean;
+			runtimeState: string;
+		};
+		expect(vanished).toMatchObject({
+			phase: "before_prompt_injection",
+			reason: "tmux_session_missing_before_prompt_injection",
+			promptAccepted: false,
+			finalPresent: false,
+		});
+		expect(vanished.runtimeState).toBe(path.relative(worktree, path.join(stateDir, "runtime-state.json")));
+	}, 20000);
+
 	test("prompt refuses success without durable turn evidence", async () => {
 		const session = `gjc_issue_1385_prompt_${process.pid}_${Date.now()}`;
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-prompt-"));

--- a/scripts/gjc-session/create.test.ts
+++ b/scripts/gjc-session/create.test.ts
@@ -46,6 +46,13 @@ function startPaneLog(session: string, stateDir: string): void {
 	expect(Bun.spawnSync(["tmux", "pipe-pane", "-t", `${session}:0.0`, `cat >> '${paneLog}'`]).exitCode).toBe(0);
 }
 
+function isolatedEnv(overrides: Record<string, string | undefined>): Record<string, string | undefined> {
+	const env = { ...process.env };
+	delete env.GJC_SESSION_WORKDIR;
+	delete env.GJC_SESSION_STATE_DIR;
+	return { ...env, ...overrides };
+}
+
 afterEach(async () => {
 	for (const session of tmuxSessions.splice(0)) {
 		Bun.spawnSync(["tmux", "kill-session", "-t", session], { stderr: "pipe", stdout: "pipe" });
@@ -81,13 +88,12 @@ exit 0
 		);
 
 		const result = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree], {
-			env: {
-				...process.env,
+			env: isolatedEnv({
 				GJC_BIN: fakeGjc,
 				GJC_SESSION_MONITOR_DISABLE: "1",
 				GJC_SESSION_SKIP_ROUTER: "1",
 				GJC_SESSION_STATE_DIR: stateDir,
-			},
+			}),
 			stderr: "pipe",
 			stdout: "pipe",
 		});
@@ -135,14 +141,13 @@ exit 0
 		await makeExecutable(fakeRouter, `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> '${routerLog}'\nexit 0\n`);
 
 		const created = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree, "C-test"], {
-			env: {
-				...process.env,
+			env: isolatedEnv({
 				GJC_BIN: fakeGjc,
 				GJC_SESSION_MONITOR_INTERVAL: "1",
 				GJC_SESSION_ROUTER: fakeRouter,
 				GJC_SESSION_SKIP_ROUTER: "1",
 				GJC_SESSION_STATE_DIR: stateDir,
-			},
+			}),
 			stderr: "pipe",
 			stdout: "pipe",
 		});
@@ -186,24 +191,22 @@ sleep 60
 		);
 
 		const created = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree], {
-			env: {
-				...process.env,
+			env: isolatedEnv({
 				GJC_BIN: fakeGjc,
 				GJC_SESSION_MONITOR_INTERVAL: "1",
 				GJC_SESSION_SKIP_ROUTER: "1",
 				GJC_SESSION_STATE_DIR: stateDir,
-			},
+			}),
 			stderr: "pipe",
 			stdout: "pipe",
 		});
 		expect(created.exitCode).toBe(0);
 
 		const prompted = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "do accepted work"], {
-			env: {
-				...process.env,
+			env: isolatedEnv({
 				GJC_SESSION_STATE_DIR: stateDir,
 				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
-			},
+			}),
 			stderr: "pipe",
 			stdout: "pipe",
 		});
@@ -233,12 +236,14 @@ sleep 60
 		await fs.mkdir(stateDir, { recursive: true });
 		await Bun.write(path.join(stateDir, "pane.log"), "Gajae forge\n> Type your message\n");
 		await Bun.write(path.join(stateDir, "metadata.json"), JSON.stringify({ session, workdir: worktree }, null, 2));
+		const unrelatedWorkdir = path.join(root, "unrelated-workdir");
+
 
 		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "do not paste this prompt"], {
-			env: {
-				...process.env,
+			env: isolatedEnv({
 				GJC_SESSION_STATE_DIR: stateDir,
-			},
+				GJC_SESSION_WORKDIR: unrelatedWorkdir,
+			}),
 			stderr: "pipe",
 			stdout: "pipe",
 		});
@@ -284,12 +289,11 @@ sleep 60
 		startPaneLog(session, stateDir);
 
 		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "do work"], {
-			env: {
-				...process.env,
+			env: isolatedEnv({
 				GJC_SESSION_TURN_EVIDENCE_PATTERN: "__NO_TURN_EVIDENCE__",
 				GJC_SESSION_STATE_DIR: stateDir,
 				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
-			},
+			}),
 			stderr: "pipe",
 			stdout: "pipe",
 		});
@@ -319,11 +323,10 @@ sleep 60
 		startPaneLog(session, stateDir);
 
 		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "new prompt that sleeping process will not accept"], {
-			env: {
-				...process.env,
+			env: isolatedEnv({
 				GJC_SESSION_STATE_DIR: stateDir,
 				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
-			},
+			}),
 			stderr: "pipe",
 			stdout: "pipe",
 		});
@@ -355,11 +358,10 @@ sleep 60
 
 		const rawPrompt = "Working Tool prompt echo must not count";
 		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, rawPrompt], {
-			env: {
-				...process.env,
+			env: isolatedEnv({
 				GJC_SESSION_STATE_DIR: stateDir,
 				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
-			},
+			}),
 			stderr: "pipe",
 			stdout: "pipe",
 		});
@@ -389,11 +391,10 @@ sleep 60
 		const result = Bun.spawnSync(
 			["bash", "scripts/gjc-session/prompt.sh", session, "new prompt sleeping process should not accept"],
 			{
-				env: {
-					...process.env,
+				env: isolatedEnv({
 					GJC_SESSION_STATE_DIR: stateDir,
 					GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
-				},
+				}),
 				stderr: "pipe",
 				stdout: "pipe",
 			},
@@ -427,11 +428,10 @@ sleep 60
 
 		const rawPrompt = "Working Tool accepted prompt still needs owner output";
 		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, rawPrompt], {
-			env: {
-				...process.env,
+			env: isolatedEnv({
 				GJC_SESSION_STATE_DIR: stateDir,
 				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
-			},
+			}),
 			stderr: "pipe",
 			stdout: "pipe",
 		});
@@ -463,11 +463,10 @@ sleep 60
 		startPaneLog(session, stateDir);
 
 		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "exit after evidence"], {
-			env: {
-				...process.env,
+			env: isolatedEnv({
 				GJC_SESSION_STATE_DIR: stateDir,
 				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "2",
-			},
+			}),
 			stderr: "pipe",
 			stdout: "pipe",
 		});
@@ -500,11 +499,10 @@ sleep 60
 
 		const rawPrompt = "Working Tool post submit echo only";
 		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, rawPrompt], {
-			env: {
-				...process.env,
+			env: isolatedEnv({
 				GJC_SESSION_STATE_DIR: stateDir,
 				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
-			},
+			}),
 			stderr: "pipe",
 			stdout: "pipe",
 		});
@@ -523,6 +521,10 @@ sleep 60
 		const stateDir = path.join(root, ".gjc-session-state", session);
 		await fs.mkdir(stateDir, { recursive: true });
 		await Bun.write(path.join(stateDir, "pane.log"), "");
+		const unrelatedStateDir = path.join(root, "unrelated-state");
+		await fs.mkdir(unrelatedStateDir, { recursive: true });
+		await Bun.write(path.join(unrelatedStateDir, "pane.log"), "Working from unrelated ambient session\n");
+
 		tmuxSessions.push(session);
 		expect(
 			Bun.spawnSync([
@@ -538,11 +540,11 @@ sleep 60
 		startPaneLog(session, stateDir);
 
 		const result = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "discovery prompt"], {
-			env: {
-				...process.env,
+			env: isolatedEnv({
 				GJC_SESSION_LOG_SEARCH_ROOT: root,
+				GJC_SESSION_STATE_DIR: unrelatedStateDir,
 				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "1",
-			},
+			}),
 			stderr: "pipe",
 			stdout: "pipe",
 		});

--- a/scripts/gjc-session/postmortem.sh
+++ b/scripts/gjc-session/postmortem.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Public-safe GJC session postmortem helpers. Do not include raw prompt text,
+# pane text, tokens, config, or logs in JSON markers written by this file.
+
+json_escape() {
+  python3 -c 'import json,sys; print(json.dumps(sys.stdin.read())[1:-1])'
+}
+
+gjc_session_write_vanished_json() {
+  local vanished_json="${1:?vanished json path required}"
+  local session="${2:?session required}"
+  local workdir="${3:?workdir required}"
+  local reason="${4:?reason required}"
+  local phase="${5:?phase required}"
+  local severity="${6:-failure}"
+  local prompt_accepted="${7:-false}"
+  local final_present="${8:-false}"
+  local tui_ready="${9:-false}"
+  local pane_log="${10:-}"
+  local events_log="${11:-}"
+  local final_json="${12:-}"
+  local runtime_state="${13:-}"
+  local prompt_accepted_json="${14:-}"
+  local detected_at
+  detected_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  mkdir -p "$(dirname "$vanished_json")"
+  python3 - "$vanished_json" "$session" "$detected_at" "$workdir" "$reason" "$phase" "$severity" "$prompt_accepted" "$final_present" "$tui_ready" "$pane_log" "$events_log" "$final_json" "$runtime_state" "$prompt_accepted_json" <<'PY'
+import json
+import os
+import sys
+
+(
+    path,
+    session,
+    detected_at,
+    workdir,
+    reason,
+    phase,
+    severity,
+    prompt_accepted,
+    final_present,
+    tui_ready,
+    pane_log,
+    events_log,
+    final_json,
+    runtime_state,
+    prompt_accepted_json,
+) = sys.argv[1:]
+
+def rel_to_workdir(value: str) -> str | None:
+    if not value:
+        return None
+    try:
+        return os.path.relpath(value, workdir)
+    except ValueError:
+        return None
+
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(
+        {
+            "session": session,
+            "detectedAt": detected_at,
+            "phase": phase,
+            "reason": reason,
+            "severity": severity,
+            "promptAccepted": prompt_accepted == "true",
+            "finalPresent": final_present == "true",
+            "tuiReadyObserved": tui_ready == "true",
+            "statePath": rel_to_workdir(os.path.dirname(path)),
+            "paneLog": rel_to_workdir(pane_log),
+            "eventsLog": rel_to_workdir(events_log),
+            "finalStatus": rel_to_workdir(final_json),
+            "runtimeState": rel_to_workdir(runtime_state),
+            "promptAcceptedStatus": rel_to_workdir(prompt_accepted_json),
+        },
+        handle,
+        indent=2,
+    )
+    handle.write("\n")
+PY
+}

--- a/scripts/gjc-session/prompt.sh
+++ b/scripts/gjc-session/prompt.sh
@@ -3,6 +3,9 @@
 # Usage: prompt.sh <session-name> "<prompt-text>" OR prompt.sh <session-name> @/path/to/prompt.md
 
 set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=postmortem.sh
+source "$SCRIPT_DIR/postmortem.sh"
 SESSION="${1:?Usage: $0 <session-name> <text|@file>}"
 TEXT_ARG="${2:?Usage: $0 <session-name> <text|@file>}"
 TMUX_BIN="${GJC_SESSION_TMUX_BIN:-tmux}"
@@ -160,6 +163,59 @@ show_missing_session_diagnostics() {
   tail -40 "$log_path" | print_redacted_tail >&2
 }
 
+
+state_dir_from_log() {
+  local log_path="${1:-}"
+  [[ -n "$log_path" ]] && dirname "$log_path"
+}
+
+write_pre_prompt_vanished() {
+  local reason="${1:?reason required}"
+  local phase="${2:?phase required}"
+  local tui_ready="${3:-false}"
+  local log_path="${4:-}"
+  local state_dir=""
+  state_dir="$(state_dir_from_log "$log_path")"
+  if [[ -z "$state_dir" && -n "${GJC_SESSION_STATE_DIR:-}" ]]; then
+    state_dir="$GJC_SESSION_STATE_DIR"
+    log_path="$state_dir/pane.log"
+  fi
+  [[ -n "$state_dir" ]] || return 0
+  mkdir -p "$state_dir"
+  local workdir="${GJC_SESSION_WORKDIR:-}"
+  if [[ -z "$workdir" && -f "$state_dir/metadata.json" ]]; then
+    workdir="$(python3 - "$state_dir/metadata.json" <<'PYMETA'
+import json
+import sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        print(json.load(handle).get("workdir") or "")
+except Exception:
+    print("")
+PYMETA
+)"
+  fi
+  if [[ -z "$workdir" ]]; then
+    workdir="$state_dir"
+  fi
+  printf '[%s] prompt preflight vanished phase=%s reason=%s tui_ready=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$phase" "$reason" "$tui_ready" >>"$state_dir/events.log"
+  gjc_session_write_vanished_json \
+    "$state_dir/vanished.json" \
+    "$SESSION" \
+    "$workdir" \
+    "$reason" \
+    "$phase" \
+    failure \
+    false \
+    false \
+    "$tui_ready" \
+    "$log_path" \
+    "$state_dir/events.log" \
+    "$state_dir/final.json" \
+    "$state_dir/runtime-state.json" \
+    "$state_dir/prompt-accepted.json"
+}
+
 if [[ "$TEXT_ARG" == @* ]]; then
   FILE="${TEXT_ARG#@}"
   [[ -f "$FILE" ]] || { echo "prompt file not found: $FILE" >&2; exit 1; }
@@ -172,13 +228,21 @@ PANE_TEXT="$(${TMUX_CMD[@]} capture-pane -t "$SESSION":0.0 -p -S -80 2>/dev/null
 if [[ -z "$PANE_TEXT" ]]; then
   mapfile -t candidates < <(find_durable_pane_logs)
   if [[ "${#candidates[@]}" -gt 0 ]]; then
+    write_pre_prompt_vanished "tmux_session_missing_before_prompt_injection" "before_prompt_injection" false "${candidates[0]}"
     show_missing_session_diagnostics "${candidates[0]}"
   else
+    write_pre_prompt_vanished "tmux_session_missing_before_prompt_injection" "before_prompt_injection" false ""
     echo "refusing to paste prompt: tmux session $SESSION is not readable and no durable pane log was found" >&2
   fi
   exit 1
 fi
 if ! printf '%s\n' "$PANE_TEXT" | grep -qE 'Gajae forge|Type your message|> Type your message|Working'; then
+  mapfile -t candidates < <(find_durable_pane_logs)
+  if [[ "${#candidates[@]}" -gt 0 ]]; then
+    write_pre_prompt_vanished "tmux_session_unready_before_prompt_injection" "before_prompt_injection" false "${candidates[0]}"
+  else
+    write_pre_prompt_vanished "tmux_session_unready_before_prompt_injection" "before_prompt_injection" false ""
+  fi
   echo "refusing to paste prompt: GJC TUI is not ready in session $SESSION" >&2
   echo "--- pane tail ---" >&2
   printf '%s\n' "$PANE_TEXT" | print_redacted_tail >&2
@@ -242,8 +306,10 @@ for _ in $(seq 1 "$PROMPT_EVIDENCE_ATTEMPTS"); do
   if [[ -z "$PANE_TEXT" ]]; then
     mapfile -t candidates < <(find_durable_pane_logs)
     if [[ "${#candidates[@]}" -gt 0 ]]; then
+      write_pre_prompt_vanished "tmux_session_missing_before_prompt_acceptance" "before_prompt_acceptance" true "${candidates[0]}"
       show_missing_session_diagnostics "${candidates[0]}"
     else
+      write_pre_prompt_vanished "tmux_session_missing_before_prompt_acceptance" "before_prompt_acceptance" true ""
       echo "prompt acceptance failed: tmux session $SESSION vanished before durable turn evidence" >&2
     fi
     exit 1

--- a/scripts/gjc-session/prompt.sh
+++ b/scripts/gjc-session/prompt.sh
@@ -20,7 +20,7 @@ if [[ "$PROMPT_EVIDENCE_ATTEMPTS" -lt 1 ]]; then
 fi
 
 find_durable_pane_logs() {
-  if [[ -n "${GJC_SESSION_STATE_DIR:-}" && -f "$GJC_SESSION_STATE_DIR/pane.log" ]]; then
+  if [[ -n "${GJC_SESSION_STATE_DIR:-}" && -z "${GJC_SESSION_LOG_SEARCH_ROOT:-}" && -f "$GJC_SESSION_STATE_DIR/pane.log" ]]; then
     printf '%s\n' "$GJC_SESSION_STATE_DIR/pane.log"
   else
     find "${GJC_SESSION_LOG_SEARCH_ROOT:-$HOME/Workspace}" \( -path "*/.gjc-session-state/$SESSION/pane.log" -o -path "*/$SESSION/pane.log" \) -type f 2>/dev/null | sort
@@ -28,7 +28,7 @@ find_durable_pane_logs() {
 }
 
 prompt_accepted_path() {
-  if [[ -n "${GJC_SESSION_STATE_DIR:-}" ]]; then
+  if [[ -n "${GJC_SESSION_STATE_DIR:-}" && -z "${GJC_SESSION_LOG_SEARCH_ROOT:-}" ]]; then
     printf '%s\n' "$GJC_SESSION_STATE_DIR/prompt-accepted.json"
     return 0
   fi
@@ -182,8 +182,8 @@ write_pre_prompt_vanished() {
   fi
   [[ -n "$state_dir" ]] || return 0
   mkdir -p "$state_dir"
-  local workdir="${GJC_SESSION_WORKDIR:-}"
-  if [[ -z "$workdir" && -f "$state_dir/metadata.json" ]]; then
+  local workdir=""
+  if [[ -f "$state_dir/metadata.json" ]]; then
     workdir="$(python3 - "$state_dir/metadata.json" <<'PYMETA'
 import json
 import sys
@@ -255,7 +255,7 @@ fi
 # script does not replace an existing tmux pipe-pane logger.
 EVIDENCE_LOG=""
 EVIDENCE_LOG_IS_TEMP=0
-if [[ -n "${GJC_SESSION_STATE_DIR:-}" && -f "$GJC_SESSION_STATE_DIR/pane.log" ]]; then
+if [[ -n "${GJC_SESSION_STATE_DIR:-}" && -z "${GJC_SESSION_LOG_SEARCH_ROOT:-}" && -f "$GJC_SESSION_STATE_DIR/pane.log" ]]; then
   EVIDENCE_LOG="$GJC_SESSION_STATE_DIR/pane.log"
 else
   durable_log_candidates=()


### PR DESCRIPTION
## Summary
- add a shared public-safe postmortem helper for vanished GJC tmux session markers
- record phase-specific vanished status for monitor-detected losses before/after prompt acceptance
- make prompt injection fail closed and write `vanished.json` when the tmux pane is gone before paste/acceptance

Fixes #1496.

## Verification
- `bun test scripts/gjc-session/create.test.ts` ✅ 12 pass
- `bun run build` ⚠️ blocked by existing missing workspace deps in this worktree: `vite` and `tailwindcss/index.css`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
