### PR TITLE
Refine inline skill autocomplete

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `gjc completion inshellisense`, which generates or installs a Fig/withfig-compatible `gjc` completion spec for Microsoft inshellisense without adding inshellisense as a runtime dependency.
 
 ### Fixed
+- Skill autocomplete now supports direct skill-name prefixes after prompt text (for example, `please /ra` → `/skill:ralplan`) while keeping bare `/` menus free of skill entries.
 - `gjc --tmux` on native Windows/psmux now keeps the status line and composer pinned to the bottom after viewport redraws by honoring the GJC tmux launch marker as a multiplexer signal even when `$TMUX` is absent.
 
 - `gjc config list`, `gjc config get`, and `gjc config set` now redact secret-like string settings by default, with `--show-secrets` as an explicit unsafe opt-in.

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -233,7 +233,7 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 			);
 			if (isRootPathSuggestionResult(baseSuggestions)) return baseSuggestions;
 			const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor, {
-				includeEmpty: slashPrefix === "/",
+				includeEmpty: false,
 			});
 			return sortSlashCommandSuggestions(
 				mergeAutocompleteSuggestions(baseSuggestions, skillCommandSuggestions),

--- a/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
@@ -8,6 +8,8 @@ function createProvider() {
 			{ name: "fast", description: "Built-in fast mode" },
 			{ name: "model", description: "Select model" },
 			{ name: "skill:deep-interview", description: "Deep interview" },
+			{ name: "skill:ralplan", description: "Consensus planning" },
+			{ name: "skill:ultragoal", description: "Durable goal execution" },
 			{ name: "skill:fast", description: "Colliding skill" },
 			{ name: "skill:mode", description: "Mode skill" },
 			{ name: "skill:team", description: "Multi-worker team orchestration" },
@@ -40,6 +42,16 @@ describe("prompt action skill autocomplete", () => {
 		expect(applied.lines[0]).toBe("/skill:deep-interview ");
 	});
 
+	it("normalizes inline direct skill-name typing to the canonical skill command", async () => {
+		const provider = createProvider();
+		const line = "please use /ra";
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+		expect(suggestions?.prefix).toBe("/ra");
+		expect(suggestions?.items[0]?.value).toBe("skill:ralplan");
+		const applied = provider.applyCompletion([line], 0, line.length, suggestions!.items[0]!, suggestions!.prefix);
+		expect(applied.lines[0]).toBe("please use /skill:ralplan ");
+	});
+
 	it("normalizes slash-skill-name typing at intermediate positions", async () => {
 		const provider = createProvider();
 		const line = "/skill:deep-interview first /skill-deep";
@@ -50,12 +62,23 @@ describe("prompt action skill autocomplete", () => {
 		expect(applied.lines[0]).toBe("/skill:deep-interview first /skill:deep-interview ");
 	});
 
-	it("offers slash command completions from an adjacent slash token after prompt text", async () => {
+	it("does not offer skill completions from a bare top-level slash token", async () => {
+		const provider = createProvider();
+		const suggestions = await provider.getSuggestions(["/"], 0, 1);
+		const values = suggestions?.items.map(item => item.value) ?? [];
+		expect(suggestions?.prefix).toBe("/");
+		expect(values).toEqual(expect.arrayContaining(["fast", "model"]));
+		expect(values.some(value => value.startsWith("skill:"))).toBe(false);
+	});
+
+	it("does not offer skill completions from an adjacent bare slash token after prompt text", async () => {
 		const provider = createProvider();
 		const line = "please use/";
 		const suggestions = await provider.getSuggestions([line], 0, line.length);
+		const values = suggestions?.items.map(item => item.value) ?? [];
 		expect(suggestions?.prefix).toBe("/");
-		expect(suggestions?.items.map(item => item.value)).toEqual(expect.arrayContaining(["model", "skill:team"]));
+		expect(values).toEqual(expect.arrayContaining(["model"]));
+		expect(values.some(value => value.startsWith("skill:"))).toBe(false);
 	});
 
 	it("offers skill completions from an inline /skill token after prompt text", async () => {


### PR DESCRIPTION
## Summary
- allow inline direct skill-prefix completion such as `please /ra` to normalize to `/skill:ralplan`
- keep bare `/` menus free of skill entries at both top-level and inline positions
- add regression coverage for direct inline skill completion and bare slash behavior

## QA
- `bun test packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts packages/coding-agent/test/prompt-action-autocomplete.test.ts`
- `bun test packages/coding-agent/test/input-controller-skill-queue.test.ts packages/coding-agent/test/skills.test.ts`
- `bun node_modules/.bin/biome check packages/coding-agent/src/modes/prompt-action-autocomplete.ts packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts packages/coding-agent/CHANGELOG.md`
- `bun run check:ts`
- `git diff --check`