### PR TITLE
fix(gjc-session): flag owner exit after prompt acceptance

### DIFF
--- a/scripts/gjc-session/create.sh
+++ b/scripts/gjc-session/create.sh
@@ -118,17 +118,29 @@ turn_evidence=false
 if [[ -s "$GJC_SESSION_PANE_LOG" ]] && grep -Eiq "$GJC_SESSION_TURN_EVIDENCE_PATTERN" "$GJC_SESSION_PANE_LOG"; then
   turn_evidence=true
 fi
+prompt_accepted=false
+for _ in $(seq 1 20); do
+  if [[ -s "${GJC_SESSION_PROMPT_ACCEPTED_JSON:-}" ]]; then
+    prompt_accepted=true
+    break
+  fi
+  [[ "$turn_evidence" == "true" ]] || break
+  sleep 0.1
+done
 owner_exit_reason="normal_exit"
 owner_exit_severity="normal"
 if [[ "$turn_evidence" != "true" ]]; then
   owner_exit_reason="owner_exited_before_turn_evidence"
   owner_exit_severity="failure"
+elif [[ "$prompt_accepted" == "true" ]]; then
+  owner_exit_reason="owner_exited_after_prompt_acceptance_before_terminal_status"
+  owner_exit_severity="failure"
 fi
-python3 - "$GJC_SESSION_FINAL_JSON" "$GJC_SESSION_NAME" "$rc" "$started_at" "$finished_at" "$GJC_SESSION_PANE_LOG" "$GJC_COORDINATOR_SESSION_STATE_FILE" "$turn_evidence" "$owner_exit_reason" "$owner_exit_severity" <<'PY'
+python3 - "$GJC_SESSION_FINAL_JSON" "$GJC_SESSION_NAME" "$rc" "$started_at" "$finished_at" "$GJC_SESSION_PANE_LOG" "$GJC_COORDINATOR_SESSION_STATE_FILE" "$turn_evidence" "$prompt_accepted" "$owner_exit_reason" "$owner_exit_severity" <<'PY'
 import json
 import sys
 
-path, session, status, started_at, finished_at, pane_log, runtime_state, turn_evidence, owner_exit_reason, owner_exit_severity = sys.argv[1:]
+path, session, status, started_at, finished_at, pane_log, runtime_state, turn_evidence, prompt_accepted, owner_exit_reason, owner_exit_severity = sys.argv[1:]
 with open(path, "w", encoding="utf-8") as handle:
     json.dump(
         {
@@ -139,6 +151,7 @@ with open(path, "w", encoding="utf-8") as handle:
             "paneLog": pane_log,
             "runtimeState": runtime_state,
             "turnEvidencePresent": turn_evidence == "true",
+            "promptAccepted": prompt_accepted == "true",
             "ownerExitReason": owner_exit_reason,
             "severity": owner_exit_severity,
         },
@@ -239,6 +252,7 @@ LAUNCH_CMD=(
   "GJC_SESSION_EVENTS_LOG=$STATE_DIR/events.log"
   "GJC_SESSION_FINAL_JSON=$STATE_DIR/final.json"
   "GJC_SESSION_VANISHED_JSON=$STATE_DIR/vanished.json"
+  "GJC_SESSION_PROMPT_ACCEPTED_JSON=$STATE_DIR/prompt-accepted.json"
   "GJC_COORDINATOR_SESSION_ID=$SESSION"
   "GJC_COORDINATOR_SESSION_STATE_FILE=$RUNTIME_STATE_JSON"
   "GJC_COORDINATOR_SESSION_BRANCH=$BRANCH"

--- a/scripts/gjc-session/create.test.ts
+++ b/scripts/gjc-session/create.test.ts
@@ -441,6 +441,61 @@ sleep 60
 		expect(result.stdout.toString()).not.toContain(rawPrompt);
 		expect(await Bun.file(path.join(stateDir, "prompt-accepted.json")).exists()).toBe(true);
 	}, 20000);
+	test("runner marks owner exit after prompt acceptance as failure final", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-owner-exit-post-accept-"));
+		tempRoots.push(root);
+		const session = `gjc_issue_1496_owner_exit_post_accept_${process.pid}_${Date.now()}`;
+		tmuxSessions.push(session);
+		const worktree = await makeGitWorktree(root);
+		const stateDir = path.join(root, "state");
+		const fakeGjc = path.join(root, "bin", "gjc");
+		await makeExecutable(
+			fakeGjc,
+			`#!/usr/bin/env bash
+printf 'Gajae forge\n> Type your message\n'
+IFS= read -r line
+printf '\nWorking then owner exits before terminal status\n'
+exit 0
+`,
+		);
+
+		const created = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree], {
+			env: isolatedEnv({
+				GJC_BIN: fakeGjc,
+				GJC_SESSION_MONITOR_DISABLE: "1",
+				GJC_SESSION_SKIP_ROUTER: "1",
+				GJC_SESSION_STATE_DIR: stateDir,
+			}),
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		expect(created.exitCode).toBe(0);
+
+		const prompted = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "accepted then exit"], {
+			env: isolatedEnv({
+				GJC_SESSION_STATE_DIR: stateDir,
+				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "2",
+			}),
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		expect(prompted.exitCode).toBe(0);
+		await waitForFile(path.join(stateDir, "final.json"));
+
+		const finalStatus = (await Bun.file(path.join(stateDir, "final.json")).json()) as {
+			promptAccepted: boolean;
+			ownerExitReason: string;
+			severity: string;
+			turnEvidencePresent: boolean;
+		};
+		expect(finalStatus).toMatchObject({
+			promptAccepted: true,
+			turnEvidencePresent: true,
+			ownerExitReason: "owner_exited_after_prompt_acceptance_before_terminal_status",
+			severity: "failure",
+		});
+	}, 20000);
+
 	test("prompt accepts durable evidence when owner exits immediately after output", async () => {
 		const session = `gjc_issue_1496_prompt_exit_after_evidence_${process.pid}_${Date.now()}`;
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-prompt-exit-after-evidence-"));


### PR DESCRIPTION
## Summary
- mark raw `gjc-session` owner exits after a durable prompt-acceptance marker as failure finals instead of normal exits
- pass `GJC_SESSION_PROMPT_ACCEPTED_JSON` into the runner so finalization can distinguish post-acceptance owner disappearance
- add a regression test for owner exit immediately after accepted prompt evidence

Fixes #1496.

## Verification
- `bun test scripts/gjc-session/create.test.ts --timeout 30000` ✅ 13 pass
- `git diff --check` ✅
- `bun run build` ✅

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
