### PR TITLE
Fix Telegram topic identity collisions

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1426,10 +1426,27 @@ export class TelegramNotificationDaemon {
 		return `${repo}\0${branch}`;
 	}
 
+	private topicIdentityBase(msg: { repo?: unknown; branch?: unknown }): string | undefined {
+		const repo = typeof msg?.repo === "string" && msg.repo.trim() ? msg.repo.trim() : undefined;
+		if (!repo) return undefined;
+		const branch = typeof msg?.branch === "string" && msg.branch.trim() ? msg.branch.trim() : undefined;
+		return branch ? `${repo}/${branch}` : repo;
+	}
+
 	private topicOwnerForIdentity(msg: { repo?: unknown; branch?: unknown }): string | undefined {
 		const identityKey = this.topicIdentityKey(msg);
 		const remembered = identityKey ? this.topicOwnerByIdentity.get(identityKey) : undefined;
-		return remembered && this.topics.get(remembered) ? remembered : undefined;
+		if (remembered && this.topics.get(remembered)) return remembered;
+		const base = this.topicIdentityBase(msg);
+		if (!identityKey || !base) return undefined;
+		for (const sessionId of this.topics.sessionIds()) {
+			const name = this.topics.get(sessionId)?.name;
+			if (name === base || name?.startsWith(`${base} - `)) {
+				this.topicOwnerByIdentity.set(identityKey, sessionId);
+				return sessionId;
+			}
+		}
+		return undefined;
 	}
 
 	private sessionCanClaimIdentity(session: SessionSocket, msg: { repo?: unknown; branch?: unknown }): boolean {

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1426,27 +1426,17 @@ export class TelegramNotificationDaemon {
 		return `${repo}\0${branch}`;
 	}
 
-	private topicIdentityBase(msg: { repo?: unknown; branch?: unknown }): string | undefined {
-		const repo = typeof msg?.repo === "string" && msg.repo.trim() ? msg.repo.trim() : undefined;
-		if (!repo) return undefined;
-		const branch = typeof msg?.branch === "string" && msg.branch.trim() ? msg.branch.trim() : undefined;
-		return branch ? `${repo}/${branch}` : repo;
-	}
-
 	private topicOwnerForIdentity(msg: { repo?: unknown; branch?: unknown }): string | undefined {
 		const identityKey = this.topicIdentityKey(msg);
 		const remembered = identityKey ? this.topicOwnerByIdentity.get(identityKey) : undefined;
-		if (remembered && this.topics.get(remembered)) return remembered;
-		const base = this.topicIdentityBase(msg);
-		if (!identityKey || !base) return undefined;
-		for (const sessionId of this.topics.sessionIds()) {
-			const name = this.topics.get(sessionId)?.name;
-			if (name === base || name?.startsWith(`${base} - `)) {
-				this.topicOwnerByIdentity.set(identityKey, sessionId);
-				return sessionId;
-			}
-		}
-		return undefined;
+		return remembered && this.topics.get(remembered) ? remembered : undefined;
+	}
+
+	private sessionCanClaimIdentity(session: SessionSocket, msg: { repo?: unknown; branch?: unknown }): boolean {
+		const current = this.sessions.get(session.sessionId);
+		if (current) return current === session;
+		const ownerId = this.topicOwnerForIdentity(msg);
+		return !ownerId || ownerId === session.sessionId;
 	}
 
 	private async submitThreadedFrame(sessionId: string, send: ThreadedSend, topicId: string): Promise<void> {
@@ -1822,7 +1812,7 @@ export class TelegramNotificationDaemon {
 				this.rememberPendingThreadedFrame(session.sessionId, send, msg as Record<string, unknown>);
 				return;
 			}
-			if (send.identity) {
+			if (send.identity && !this.sessionCanClaimIdentity(session, msg)) {
 				const ownerId = this.topicOwnerForIdentity(msg);
 				const ownerTopic = ownerId ? this.topics.get(ownerId) : undefined;
 				if (ownerId && ownerId !== session.sessionId && ownerTopic) {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -1053,6 +1053,49 @@ test("identity-less threaded frames wait for identity instead of creating fallba
 	expect(photo!.body.message_thread_id).toBeGreaterThan(0);
 });
 
+test("live sessions with the same repo branch create distinct topics", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+	});
+	daemon.connectSession("S1", "ws://s1", "t1");
+	daemon.connectSession("S2", "ws://s2", "t2");
+	const first = daemon.sessions.get("S1")!;
+	const second = daemon.sessions.get("S2")!;
+
+	await daemon.handleSessionMessage(first, {
+		type: "identity_header",
+		sessionId: "S1",
+		repo: "gajae-code",
+		branch: "dev",
+	});
+	await daemon.handleSessionMessage(second, {
+		type: "identity_header",
+		sessionId: "S2",
+		repo: "gajae-code",
+		branch: "dev",
+	});
+	await daemon.handleSessionMessage(second, {
+		type: "turn_stream",
+		sessionId: "S2",
+		text: "second session output",
+	});
+
+	const creates = bot.calls.filter(c => c.method === "createForumTopic");
+	const sends = bot.calls.filter(c => c.method === "sendMessage");
+	expect(creates).toHaveLength(2);
+	expect(creates.map(c => c.body.name)).toEqual(["gajae-code/dev", "gajae-code/dev"]);
+	expect(sends).toHaveLength(3);
+	expect(sends[0]!.body.message_thread_id).not.toBe(sends[1]!.body.message_thread_id);
+	expect(sends[2]!.body.message_thread_id).toBe(sends[1]!.body.message_thread_id);
+});
+
 test("transient identity for an existing repo branch does not create a duplicate topic", async () => {
 	const agentDir = tempAgentDir();
 	const bot = new FakeBotApi();

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -1126,6 +1126,44 @@ test("transient identity for an existing repo branch does not create a duplicate
 	expect(bot.calls.filter(c => c.method === "sendMessage")).toHaveLength(1);
 });
 
+test("stale identity after loadTopics reuses the persisted repo branch owner", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const firstDaemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const live = { sessionId: "LIVE", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	await firstDaemon.handleSessionMessage(live as any, {
+		type: "identity_header",
+		sessionId: "LIVE",
+		repo: "gajae-code",
+		branch: "dev",
+	});
+
+	const restartedDaemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	await restartedDaemon.loadTopics();
+	const stale = { sessionId: "DEAD", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	await restartedDaemon.handleSessionMessage(stale as any, {
+		type: "identity_header",
+		sessionId: "DEAD",
+		repo: "gajae-code",
+		branch: "dev",
+	});
+
+	expect(bot.calls.filter(c => c.method === "createForumTopic").map(c => c.body.name)).toEqual(["gajae-code/dev"]);
+	expect(bot.calls.filter(c => c.method === "sendMessage").map(c => c.body.message_thread_id)).toEqual([1]);
+});
+
 test("threaded mode off: frames fall back to the flat paired chat with a one-time notice", async () => {
 	const agentDir = tempAgentDir();
 	const bot = new FakeBotApi();


### PR DESCRIPTION
## Summary
- Keep repo/branch as Telegram topic display metadata while limiting identity-owner suppression to stale/non-current session frames.
- Allow two live sessions with the same repo/branch label to create and route through distinct forum topics.
- Add focused regression coverage for same repo/branch live-session routing while preserving transient duplicate suppression for stale identities.

Fixes #1604

## Validation
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*