### PR TITLE
Fix Telegram callback ack failure dropping replies

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1921,10 +1921,21 @@ export class TelegramNotificationDaemon {
 		return result;
 	};
 
-	private async sendStaleGuidance(callbackId: unknown): Promise<void> {
-		if (typeof callbackId === "string") {
-			await this.botApi.call("answerCallbackQuery", { callback_query_id: callbackId, text: "Button is stale" });
+	private async answerCallbackQueryBestEffort(callbackId: unknown, text?: string): Promise<void> {
+		if (typeof callbackId !== "string") return;
+		try {
+			await this.botApi.call("answerCallbackQuery", {
+				callback_query_id: callbackId,
+				...(text === undefined ? {} : { text }),
+			});
+		} catch {
+			// Telegram callback acknowledgements only dismiss the client-side spinner;
+			// they must never block the already-validated local reply path.
 		}
+	}
+
+	private async sendStaleGuidance(callbackId: unknown): Promise<void> {
+		await this.answerCallbackQueryBestEffort(callbackId, "Button is stale");
 		await this.botApi.call("sendMessage", {
 			chat_id: this.opts.chatId,
 			text: "This button is stale after notification daemon restart. Please answer locally in the GJC session or wait for a fresh notification.",
@@ -2042,11 +2053,10 @@ export class TelegramNotificationDaemon {
 				await this.sendStaleGuidance(callbackId);
 				return;
 			}
-			if (typeof callbackId === "string")
-				await this.botApi.call("answerCallbackQuery", { callback_query_id: callbackId });
 			session.ws.send(
 				JSON.stringify({ type: "reply", id: decision.actionId, answer: decision.answer, token: session.token }),
 			);
+			await this.answerCallbackQueryBestEffort(callbackId);
 		} else if (decision.kind === "stale") {
 			await this.sendStaleGuidance(callbackId);
 		}

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -93,6 +93,16 @@ class FakeBotApi {
 	}
 }
 
+class FailingCallbackAckBotApi extends FakeBotApi {
+	override async call(method: string, body: unknown): Promise<unknown> {
+		if (method === "answerCallbackQuery") {
+			this.calls.push({ method, body });
+			throw new Error("callback ack failed");
+		}
+		return super.call(method, body);
+	}
+}
+
 describe("telegram daemon", () => {
 	test("N concurrent ensureTelegramDaemonRunning creates exactly one owner", async () => {
 		const agentDir = tempAgentDir();
@@ -365,6 +375,40 @@ describe("telegram daemon", () => {
 		});
 		expect(FakeWs.instances[0]!.sent).toHaveLength(0);
 		expect(JSON.parse(FakeWs.instances[1]!.sent[0]!)).toEqual({ type: "reply", id: "askB", answer: 0, token: "tb" });
+		expect(bot.calls.some(c => c.method === "answerCallbackQuery")).toBe(true);
+	});
+
+	test("callback alias reply is delivered when Telegram callback ack fails", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const bot = new FailingCallbackAckBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+		});
+		daemon.connectSession("S", "ws://s", "ts");
+		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
+			type: "action_needed",
+			kind: "ask",
+			id: "ask",
+			question: "Q",
+			options: ["Y"],
+		});
+		const alias = bot.calls.find(c => c.method === "sendMessage")!.body.reply_markup.inline_keyboard[0][0]
+			.callback_data;
+
+		await daemon.handleTelegramUpdate({
+			update_id: 1,
+			callback_query: { id: "cb", data: alias, message: { chat: { id: 42 } } },
+		});
+
+		expect(JSON.parse(FakeWs.instances[0]!.sent[0]!)).toEqual({ type: "reply", id: "ask", answer: 0, token: "ts" });
+		expect(bot.calls.some(c => c.method === "answerCallbackQuery")).toBe(true);
 	});
 
 	test("unknown and expired aliases are stale guidance with zero frames", async () => {


### PR DESCRIPTION
## Summary
- Make Telegram `answerCallbackQuery` best-effort in the daemon so a validated callback alias sends the local reply frame even when the Telegram UI ack fails.
- Send the local reply before awaiting the best-effort callback ack.
- Add a focused regression test for callback ack failure while preserving valid callback behavior coverage.

Fixes #1603

## Validation
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts packages/coding-agent/test/notifications-telegram-reference.test.ts`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*