### PR TITLE
Fix Telegram daemon owner identity mismatch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `gjc completion inshellisense`, which generates or installs a Fig/withfig-compatible `gjc` completion spec for Microsoft inshellisense without adding inshellisense as a runtime dependency.
 
 ### Fixed
+- Telegram daemon autostart now refuses to attach a new session to a live daemon whose persisted bot-token fingerprint or chat id differs from the current settings, and it avoids registering the session root until ownership is trusted so rotated Telegram credentials cannot keep leaking through the old daemon.
 - Skill autocomplete now supports direct skill-name prefixes after prompt text (for example, `please /ra` → `/skill:ralplan`) while keeping bare `/` menus free of skill entries.
 - `gjc --tmux` on native Windows/psmux now keeps the status line and composer pinned to the bottom after viewport redraws by honoring the GJC tmux launch marker as a multiplexer signal even when `$TMUX` is absent.
 

--- a/packages/coding-agent/src/notifications/telegram-daemon-control.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-control.ts
@@ -269,6 +269,7 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 				{ settings: this.settings, roots, tokenFingerprint: fp, chatId },
 				this.spawnDeps(),
 			);
+			warnings.push(...spawned.warnings);
 			const after = await this.status();
 			return this.result(
 				action,
@@ -351,6 +352,7 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 			{ settings: this.settings, roots, tokenFingerprint: fp, chatId },
 			this.spawnDeps(),
 		);
+		warnings.push(...spawned.warnings);
 		const after = await this.status();
 		if (spawned.result === "attached") {
 			// A live owner already exists; attaching to it is a valid running end-state.
@@ -360,7 +362,7 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 		}
 		return this.result(
 			action,
-			spawned.result !== "disabled",
+			spawned.result !== "disabled" && spawned.result !== "blocked",
 			`reloaded telegram daemon (${spawned.result})`,
 			before,
 			after,

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -56,7 +56,7 @@ import { decideThreadedInbound, type InboundAttachment } from "./threaded-inboun
 import { renderThreadedFrame, type ThreadedSend } from "./threaded-render";
 import { TopicRegistry, type TopicRegistryState } from "./topic-registry";
 
-export type EnsureDaemonResult = "owner_spawned" | "attached" | "disabled";
+export type EnsureDaemonResult = "owner_spawned" | "attached" | "disabled" | "blocked";
 
 export interface DaemonState {
 	pid: number;
@@ -267,7 +267,7 @@ export async function registerNotificationRoot(input: {
 	const fsImpl = input.fs ?? nodeFs;
 	const paths = daemonPaths(input.settings.getAgentDir());
 	await ensureDir(fsImpl, paths.dir);
-	const root = path.join(input.cwd, ".gjc", "state");
+	const root = notificationRootForCwd(input.cwd);
 	await withFileLock(
 		paths.roots,
 		async () => {
@@ -286,6 +286,29 @@ export async function registerNotificationRoot(input: {
 	return root;
 }
 
+function notificationRootForCwd(cwd: string): string {
+	return path.join(cwd, ".gjc", "state");
+}
+
+function ownerIdentityMatches(state: DaemonState, tokenFingerprint: string, chatId: string): boolean {
+	return state.tokenFingerprint === tokenFingerprint && state.chatId === chatId;
+}
+
+function liveOwnerUsesDifferentIdentity(input: {
+	state: DaemonState | undefined;
+	tokenFingerprint: string;
+	chatId: string;
+	pidAlive: (pid: number) => boolean;
+}): boolean {
+	const { state } = input;
+	return Boolean(
+		state &&
+			state.version === DAEMON_VERSION &&
+			!ownerIdentityMatches(state, input.tokenFingerprint, input.chatId) &&
+			input.pidAlive(state.pid),
+	);
+}
+
 export function isFreshLiveOwner(input: {
 	state: DaemonState | undefined;
 	now: number;
@@ -297,8 +320,7 @@ export function isFreshLiveOwner(input: {
 	return Boolean(
 		state &&
 			state.version === DAEMON_VERSION &&
-			state.tokenFingerprint === input.tokenFingerprint &&
-			state.chatId === input.chatId &&
+			ownerIdentityMatches(state, input.tokenFingerprint, input.chatId) &&
 			input.now - state.heartbeatAt <= HEARTBEAT_TTL_MS &&
 			input.pidAlive(state.pid),
 	);
@@ -314,7 +336,13 @@ export async function acquireDaemonOwnership(input: {
 	pid?: number;
 	pidAlive?: (pid: number) => boolean;
 	randomId?: () => string;
-}): Promise<{ acquired: boolean; ownerId?: string; attached?: boolean }> {
+}): Promise<{
+	acquired: boolean;
+	ownerId?: string;
+	attached?: boolean;
+	blocked?: boolean;
+	reason?: "identity_mismatch";
+}> {
 	const fsImpl = input.fs ?? nodeFs;
 	const now = input.now ?? Date.now;
 	const pid = input.pid ?? process.pid;
@@ -324,6 +352,16 @@ export async function acquireDaemonOwnership(input: {
 	const ownerId = input.randomId?.() ?? `${pid}-${now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 	const roots = input.roots ?? (await readJson<{ roots?: string[] }>(fsImpl, paths.roots))?.roots ?? [];
 	const existing = await readJson<DaemonState>(fsImpl, paths.state);
+	if (
+		liveOwnerUsesDifferentIdentity({
+			state: existing,
+			tokenFingerprint: input.tokenFingerprint,
+			chatId: input.chatId,
+			pidAlive,
+		})
+	) {
+		return { acquired: false, blocked: true, reason: "identity_mismatch" };
+	}
 	if (
 		isFreshLiveOwner({
 			state: existing,
@@ -350,6 +388,16 @@ export async function acquireDaemonOwnership(input: {
 	}
 	const afterLock = await readJson<DaemonState>(fsImpl, paths.state);
 	if (
+		liveOwnerUsesDifferentIdentity({
+			state: afterLock,
+			tokenFingerprint: input.tokenFingerprint,
+			chatId: input.chatId,
+			pidAlive,
+		})
+	) {
+		return { acquired: false, blocked: true, reason: "identity_mismatch" };
+	}
+	if (
 		isFreshLiveOwner({
 			state: afterLock,
 			now: now(),
@@ -374,6 +422,16 @@ export async function acquireDaemonOwnership(input: {
 			})
 		) {
 			return { acquired: false, attached: true };
+		}
+		if (
+			liveOwnerUsesDifferentIdentity({
+				state: rechecked,
+				tokenFingerprint: input.tokenFingerprint,
+				chatId: input.chatId,
+				pidAlive,
+			})
+		) {
+			return { acquired: false, blocked: true, reason: "identity_mismatch" };
 		}
 		if (rechecked && pidAlive(rechecked.pid)) {
 			return { acquired: false, attached: true };
@@ -552,7 +610,16 @@ export async function spawnTelegramDaemonOwner(
 		ownerId: ownership.ownerId ?? "",
 		agentDir,
 	});
-	if (!ownership.acquired) return { result: "attached", runtime, warnings: [] };
+	if (!ownership.acquired) {
+		if (ownership.blocked) {
+			return {
+				result: "blocked",
+				runtime,
+				warnings: ["live telegram daemon uses a different bot token or chat; refusing to attach"],
+			};
+		}
+		return { result: "attached", runtime, warnings: [] };
+	}
 	const spawnImpl = deps.spawn ?? defaultDaemonSpawn;
 	const child = spawnImpl(command, args, {
 		detached: true,
@@ -569,12 +636,17 @@ export async function ensureTelegramDaemonRunning(
 ): Promise<EnsureDaemonResult> {
 	const cfg = getNotificationConfig(input.settings);
 	if (!isGloballyConfigured(cfg) || !cfg.botToken || !cfg.chatId) return "disabled";
-	const root = await registerNotificationRoot({ ...input, fs: deps.fs });
+	const root = notificationRootForCwd(input.cwd);
 	const fp = tokenFingerprint(cfg.botToken);
 	const spawned = await spawnTelegramDaemonOwner(
 		{ settings: input.settings, roots: [root], tokenFingerprint: fp, chatId: cfg.chatId },
 		deps,
 	);
+	if (spawned.result === "blocked") {
+		logger.warn(`notifications: failed to ensure Telegram daemon: ${spawned.warnings.join("; ")}`);
+		return spawned.result;
+	}
+	await registerNotificationRoot({ ...input, fs: deps.fs });
 	return spawned.result;
 }
 

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -291,6 +291,49 @@ describe("telegram daemon", () => {
 		expect(result).toEqual({ acquired: false, attached: true });
 	});
 
+	test("live owner token/chat mismatch blocks attach without registering a root", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const paths = daemonPaths(agentDir);
+		fs.mkdirSync(paths.dir, { recursive: true });
+		fs.writeFileSync(paths.lock, "");
+		fs.writeFileSync(
+			paths.state,
+			JSON.stringify({
+				pid: 999,
+				ownerId: "old",
+				tokenFingerprint: "old-fp",
+				chatId: "old-chat",
+				startedAt: 100,
+				heartbeatAt: 100,
+				roots: [],
+				version: DAEMON_VERSION,
+			}),
+		);
+
+		let spawns = 0;
+		const result = await ensureTelegramDaemonRunning(
+			{ settings: s, cwd: path.join(agentDir, "new-session"), sessionId: "new-session" },
+			{
+				now: () => 101,
+				pidAlive: pid => pid === 999,
+				spawn: () => {
+					spawns++;
+					return { unref() {} };
+				},
+			},
+		);
+
+		expect(result).toBe("blocked");
+		expect(spawns).toBe(0);
+		expect(fs.existsSync(paths.roots)).toBe(false);
+		expect(JSON.parse(fs.readFileSync(paths.state, "utf8"))).toMatchObject({
+			ownerId: "old",
+			tokenFingerprint: "old-fp",
+			chatId: "old-chat",
+		});
+	});
+
 	test("idle self-exit after timeout releases ownership", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);


### PR DESCRIPTION
## What

Fixes Telegram daemon autostart so a new session is not attached to a live daemon whose persisted bot-token fingerprint or chat id differs from the current Telegram settings.

Changes:
- detect live owner identity mismatches before treating an existing daemon as attachable;
- return a blocked daemon-start result instead of silently attaching across the Telegram trust boundary;
- delay notification-root registration until ownership is trusted, so a session root is not exposed to the old mismatched daemon;
- propagate blocked spawn warnings through daemon control paths.

## Why

When Telegram settings are rotated while an old daemon still owns the lock, the old code could register the new session root and then report `attached` even though the live daemon was using the old token/chat. That lets new sessions keep sending/receiving through the old paired chat and makes the new setup look active while the trust boundary is stale.

## Testing

- `bun run build:native`
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun node_modules/.bin/biome check packages/coding-agent/src/notifications/telegram-daemon.ts packages/coding-agent/src/notifications/telegram-daemon-control.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts packages/coding-agent/CHANGELOG.md`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
