### PR TITLE
fix: harden frontmatter and file-lock cleanup

### DIFF
--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -1,3 +1,4 @@
+import type { Stats } from "node:fs";
 import * as fs from "node:fs/promises";
 import { isEnoent } from "@gajae-code/utils/fs-error";
 
@@ -22,9 +23,10 @@ function getLockPath(filePath: string): string {
 	return `${filePath}.lock`;
 }
 
-async function writeLockInfo(lockPath: string): Promise<void> {
+async function writeLockInfo(lockPath: string): Promise<LockInfo> {
 	const info: LockInfo = { pid: process.pid, timestamp: Date.now() };
 	await Bun.write(`${lockPath}/info`, JSON.stringify(info));
+	return info;
 }
 
 async function readLockInfo(lockPath: string): Promise<LockInfo | null> {
@@ -51,17 +53,30 @@ export interface FileLockOwnerToken {
 	timestamp: number;
 }
 
-/** Outcome of a guarded GC removal attempt (`removeFileLockDirForGc`). */
+/** Outcome of a guarded lock-dir removal attempt (`removeFileLockDirForGc`). */
 export type FileLockGcRemoval = "removed" | "owner_changed" | "missing";
+
+interface LockDirStatToken {
+	dev: number;
+	ino: number;
+	mtimeMs: number;
+	ctimeMs: number;
+}
+
+type LockStaleSnapshot =
+	| { stale: false }
+	| { stale: true; owner: FileLockOwnerToken }
+	| { stale: true; owner: null; stat: LockDirStatToken };
 
 /**
  * @internal
- * Fail-closed removal of a dead lock dir for GC. Re-reads the on-disk owner
- * token as close to the unlink as possible and only deletes the dir when it
- * STILL holds the exact `{pid, timestamp}` identity the caller observed dead.
+ * Fail-closed removal of a lock dir whose owner is expected to be dead or
+ * finished. Re-reads the on-disk owner token as close to the unlink as possible
+ * and only deletes the dir when it STILL holds the exact `{pid, timestamp}`
+ * identity the caller observed.
  *
- * Closes the prune-time TOCTOU window (#606): between GC's dead re-read/probe
- * and the unlink, a live process can reclaim a stale lock at the same path
+ * Closes stale-cleanup TOCTOU windows (#606): between a dead/stale re-read and
+ * the unlink, a live process can reclaim a stale lock at the same path
  * (`acquireLock` rms the stale dir, then re-`mkdir`s and rewrites `info` with a
  * fresh pid+timestamp). Deleting by path alone would reap that LIVE lock. Any
  * mismatch (`owner_changed`) or absent/unreadable info (`missing` — e.g. a
@@ -99,14 +114,28 @@ function ownerLiveness(pid: number): OwnerLiveness {
 	}
 }
 
-async function isLockStale(lockPath: string, staleMs: number): Promise<boolean> {
+function statToken(stats: Stats): LockDirStatToken {
+	return {
+		dev: stats.dev,
+		ino: stats.ino,
+		mtimeMs: stats.mtimeMs,
+		ctimeMs: stats.ctimeMs,
+	};
+}
+
+function sameStatToken(a: LockDirStatToken, b: LockDirStatToken): boolean {
+	return a.dev === b.dev && a.ino === b.ino && a.mtimeMs === b.mtimeMs && a.ctimeMs === b.ctimeMs;
+}
+
+async function staleLockSnapshot(lockPath: string, staleMs: number): Promise<LockStaleSnapshot> {
 	const info = await readLockInfo(lockPath);
 	if (!info) {
 		try {
 			const stats = await fs.stat(lockPath);
-			return Date.now() - stats.mtimeMs > staleMs;
+			if (Date.now() - stats.mtimeMs <= staleMs) return { stale: false };
+			return { stale: true, owner: null, stat: statToken(stats) };
 		} catch (err) {
-			if (isEnoent(err)) return false;
+			if (isEnoent(err)) return { stale: false };
 			throw err;
 		}
 	}
@@ -115,35 +144,25 @@ async function isLockStale(lockPath: string, staleMs: number): Promise<boolean> 
 	// not have its lock stolen (#652). Reclaim a dead owner immediately. Only when owner
 	// liveness is indeterminate do we fall back to the staleMs elapsed-time heuristic.
 	const liveness = ownerLiveness(info.pid);
-	if (liveness === "dead") return true;
-	if (liveness === "alive") return false;
-	return Date.now() - info.timestamp > staleMs;
-}
-
-async function tryAcquireLock(lockPath: string): Promise<boolean> {
-	try {
-		await fs.mkdir(lockPath);
-		await writeLockInfo(lockPath);
-		return true;
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "EEXIST") {
-			return false;
-		}
-		throw error;
+	if (liveness === "alive") return { stale: false };
+	if (liveness === "dead" || Date.now() - info.timestamp > staleMs) {
+		return { stale: true, owner: { pid: info.pid, timestamp: info.timestamp } };
 	}
+	return { stale: false };
 }
 
-async function releaseLock(lockPath: string): Promise<void> {
-	try {
-		await fs.rm(lockPath, { recursive: true });
-	} catch {
-		// Ignore errors on release
+async function removeStaleLockForAcquire(lockPath: string, snapshot: LockStaleSnapshot): Promise<boolean> {
+	if (!snapshot.stale) return false;
+	if (snapshot.owner) {
+		return (await removeFileLockDirForGc(lockPath, snapshot.owner)) === "removed";
 	}
-}
 
-async function lockExists(lockPath: string): Promise<boolean> {
+	const currentInfo = await readLockInfo(lockPath);
+	if (currentInfo) return false;
 	try {
-		await fs.stat(lockPath);
+		const currentStats = await fs.stat(lockPath);
+		if (!sameStatToken(statToken(currentStats), snapshot.stat)) return false;
+		await fs.rm(lockPath, { recursive: true, force: true });
 		return true;
 	} catch (err) {
 		if (isEnoent(err)) return false;
@@ -151,17 +170,37 @@ async function lockExists(lockPath: string): Promise<boolean> {
 	}
 }
 
+async function tryAcquireLock(lockPath: string): Promise<LockInfo | null> {
+	try {
+		await fs.mkdir(lockPath);
+		return await writeLockInfo(lockPath);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+			return null;
+		}
+		throw error;
+	}
+}
+
+async function releaseLock(lockPath: string, owner: FileLockOwnerToken): Promise<void> {
+	try {
+		await removeFileLockDirForGc(lockPath, owner);
+	} catch {
+		// Ignore errors on release
+	}
+}
 async function acquireLock(filePath: string, options: FileLockOptions = {}): Promise<() => Promise<void>> {
 	const opts = { ...DEFAULT_OPTIONS, ...options };
 	const lockPath = getLockPath(filePath);
 
 	for (let attempt = 0; attempt < opts.retries; attempt++) {
-		if (await tryAcquireLock(lockPath)) {
-			return () => releaseLock(lockPath);
+		const owner = await tryAcquireLock(lockPath);
+		if (owner) {
+			return () => releaseLock(lockPath, owner);
 		}
 
-		if ((await lockExists(lockPath)) && (await isLockStale(lockPath, opts.staleMs))) {
-			await releaseLock(lockPath);
+		const stale = await staleLockSnapshot(lockPath, opts.staleMs);
+		if (await removeStaleLockForAcquire(lockPath, stale)) {
 			continue;
 		}
 

--- a/packages/coding-agent/test/discovery/helpers.test.ts
+++ b/packages/coding-agent/test/discovery/helpers.test.ts
@@ -138,6 +138,28 @@ Body content`;
 			/Failed to parse YAML frontmatter/,
 		);
 	});
+	test("rejects top-level YAML arrays instead of coercing numeric keys", () => {
+		const content = `---
+- one
+- two
+---
+Body content`;
+
+		expect(() => parseFrontmatter(content, { source: "tests:frontmatter", level: "fatal" })).toThrow(
+			/Failed to parse YAML frontmatter.*root must be an object/s,
+		);
+	});
+
+	test("rejects scalar YAML roots instead of accepting empty metadata", () => {
+		const content = `---
+true
+---
+Body content`;
+
+		expect(() => parseFrontmatter(content, { source: "tests:frontmatter", level: "fatal" })).toThrow(
+			/Failed to parse YAML frontmatter.*root must be an object/s,
+		);
+	});
 
 	test("handles missing frontmatter", () => {
 		const content = "Just body content";

--- a/packages/coding-agent/test/file-lock-gc-toctou.test.ts
+++ b/packages/coding-agent/test/file-lock-gc-toctou.test.ts
@@ -101,8 +101,23 @@ describe("withFileLock stale owner liveness (#652)", () => {
 		expect(acquired).toBe(true);
 		expect(await fs.exists(lockDir)).toBe(false);
 	});
+
+	test("release refuses to remove a lock that no longer has this owner token", async () => {
+		const base = await makeTemp();
+		const lockedFile = path.join(base, "state.json");
+		const lockDir = `${lockedFile}.lock`;
+		const replacement = { pid: LIVE_PID, timestamp: Date.now() + 1_000 };
+
+		await withFileLock(lockedFile, async () => {
+			await writeInfo(lockDir, replacement);
+		});
+
+		expect(await fs.exists(lockDir)).toBe(true);
+		const onDisk = JSON.parse(await fs.readFile(path.join(lockDir, "info"), "utf8"));
+		expect(onDisk).toEqual(replacement);
+	});
 });
-describe("removeFileLockDirForGc owner-token guard (#606)", () => {
+describe("file lock owner-token removal guard (#606)", () => {
 	test("removes the dir when the on-disk token matches the expected owner", async () => {
 		const base = await makeTemp();
 		const lockDir = path.join(base, "match.lock");

--- a/packages/utils/src/frontmatter.ts
+++ b/packages/utils/src/frontmatter.ts
@@ -17,15 +17,27 @@ function stripLooseScalarTrailingCommas(metadata: string): string {
 		.join("\n");
 }
 
+function asFrontmatterRecord(parsed: unknown): Record<string, unknown> | null {
+	if (parsed === null) return null;
+	if (typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("YAML frontmatter root must be an object");
+	}
+	const prototype = Object.getPrototypeOf(parsed);
+	if (prototype !== Object.prototype && prototype !== null) {
+		throw new Error("YAML frontmatter root must be an object");
+	}
+	return parsed as Record<string, unknown>;
+}
+
 function parseYamlMetadata(metadata: string): Record<string, unknown> | null {
 	const normalized = metadata.replaceAll("\t", "  ");
 	try {
-		return YAML.parse(normalized) as Record<string, unknown> | null;
+		return asFrontmatterRecord(YAML.parse(normalized));
 	} catch (strictError) {
 		const loose = stripLooseScalarTrailingCommas(normalized);
 		if (loose === normalized) throw strictError;
 		try {
-			return YAML.parse(loose) as Record<string, unknown> | null;
+			return asFrontmatterRecord(YAML.parse(loose));
 		} catch {
 			throw strictError;
 		}


### PR DESCRIPTION
## Summary
- reject non-object YAML frontmatter roots instead of coercing arrays/scalars into metadata
- guard file-lock stale-acquire cleanup with the observed owner token before deleting
- guard normal lock release with the acquired owner token so a reclaimed lock at the same path is not removed

Closes #1610

## Verification
- `bun test packages/coding-agent/test/discovery/helpers.test.ts`
- `bun test packages/coding-agent/test/file-lock-gc-toctou.test.ts`
- `bun test packages/coding-agent/test/credential-import.test.ts packages/coding-agent/test/file-lock-gc-toctou.test.ts packages/coding-agent/test/rpc-listen-socket-guard.test.ts packages/coding-agent/test/gjc-runtime/state-writer-cas.test.ts packages/coding-agent/test/discovery/helpers.test.ts`
- `bun run check:ts`