### PR TITLE
Fix Telegram chat id privacy validation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `gjc completion inshellisense`, which generates or installs a Fig/withfig-compatible `gjc` completion spec for Microsoft inshellisense without adding inshellisense as a runtime dependency.
 
 ### Fixed
+- Telegram notification setup and daemon delivery now reject non-private Telegram chat ids before saving configuration, creating forum topics, or sending session content, preserving the private-chat-only routing boundary.
 - Telegram daemon autostart now refuses to attach a new session to a live daemon whose persisted bot-token fingerprint or chat id differs from the current settings, and it avoids registering the session root until ownership is trusted so rotated Telegram credentials cannot keep leaking through the old daemon.
 - Skill autocomplete now supports direct skill-name prefixes after prompt text (for example, `please /ra` → `/skill:ralplan`) while keeping bare `/` menus free of skill entries.
 - `gjc --tmux` on native Windows/psmux now keeps the status line and composer pinned to the bottom after viewport redraws by honoring the GJC tmux launch marker as a multiplexer signal even when `$TMUX` is absent.

--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -58,6 +58,11 @@ interface TelegramUser {
 	allows_users_to_create_topics?: boolean;
 }
 
+interface TelegramChat {
+	id?: number | string;
+	type?: string;
+}
+
 type ThreadedModeState = "enabled" | "disabled" | "unknown";
 type ThreadedModeFinalLabel = "verified" | "unverified" | "unknown";
 
@@ -148,6 +153,7 @@ async function runSetup(deps: NotifyCommandDeps): Promise<void> {
 	let chatId: string;
 	if (deps.setupChatId?.trim()) {
 		chatId = deps.setupChatId.trim();
+		await verifyPrivateChatId(fetchImpl, apiBase, token, chatId);
 		process.stdout.write(`Using provided chat id ${chatId} (non-interactive).\n`);
 	} else {
 		const stale = await getUpdates(fetchImpl, apiBase, token, { timeout: 0, allowed_updates: ["message"] });
@@ -221,6 +227,24 @@ async function getMe(fetchImpl: typeof fetch, apiBase: string, token: string): P
 		throw new Error("Telegram getMe returned invalid Telegram response: missing valid User result.");
 	}
 	return user;
+}
+
+async function verifyPrivateChatId(
+	fetchImpl: typeof fetch,
+	apiBase: string,
+	token: string,
+	chatId: string,
+): Promise<void> {
+	const chat = (await callTelegram<unknown>(fetchImpl, apiBase, token, "getChat", { chat_id: chatId })) as
+		| TelegramChat
+		| undefined;
+	if (!chat || typeof chat !== "object") {
+		throw new Error("Telegram getChat returned invalid Telegram response: missing valid Chat result.");
+	}
+	if (chat.type !== "private") {
+		const type = typeof chat.type === "string" && chat.type ? chat.type : "unknown";
+		throw new Error(`Provided chat id ${chatId} is a ${type} chat; pairing requires a private Telegram chat.`);
+	}
 }
 
 function threadedModeState(user: TelegramUser): ThreadedModeState {

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1537,6 +1537,11 @@ export class TelegramNotificationDaemon {
 		await this.flushPool();
 	}
 
+	private async existingTopicForPrivateChat(sessionId: string): Promise<string | undefined> {
+		if (!(await this.pairedChatIsPrivate())) return undefined;
+		return this.topics.get(sessionId)?.topicId;
+	}
+
 	private rememberPendingThreadedFrame(sessionId: string, send: ThreadedSend, msg: Record<string, unknown>): void {
 		const frames = this.pendingThreadedFrames.get(sessionId) ?? [];
 		frames.push({ send, msg });
@@ -1558,6 +1563,7 @@ export class TelegramNotificationDaemon {
 	 * one-time nudge) or drop fail-closed for a non-private chat.
 	 */
 	private async ensureTopic(sessionId: string, name: string): Promise<string | undefined> {
+		if (!(await this.pairedChatIsPrivate())) return undefined;
 		const existing = this.topics.get(sessionId);
 		if (existing) return existing.topicId;
 		try {
@@ -1732,6 +1738,7 @@ export class TelegramNotificationDaemon {
 	private async flushPool(): Promise<void> {
 		for (const item of this.pool.drain()) {
 			const { send, topicId } = item.payload;
+			if (topicId && !(await this.pairedChatIsPrivate())) continue;
 			// Threaded topic when available; otherwise deliver flat to the paired chat.
 			const threadField = topicId ? { message_thread_id: Number(topicId) } : {};
 			try {
@@ -1790,9 +1797,10 @@ export class TelegramNotificationDaemon {
 	}
 
 	/**
-	 * Resolve once (cached) whether the paired `chatId` is a private chat. Flat
-	 * fallback is only safe in a private DM; any non-private chat or an unresolvable
-	 * `getChat` is treated as not-private so delivery fails closed.
+	 * Resolve (and cache successful resolution of) whether the paired `chatId` is a
+	 * private chat. Topic and flat delivery are only safe in a private DM; any
+	 * non-private chat fails closed, while a transient `getChat` failure fails closed
+	 * for the current attempt and is retried later.
 	 */
 	private async pairedChatIsPrivate(): Promise<boolean> {
 		if (this.pairedChatPrivate !== undefined) return this.pairedChatPrivate;
@@ -1801,10 +1809,11 @@ export class TelegramNotificationDaemon {
 				result?: { type?: string };
 			};
 			this.pairedChatPrivate = res.result?.type === "private";
-		} catch {
-			this.pairedChatPrivate = false;
+			return this.pairedChatPrivate;
+		} catch (e) {
+			logger.warn(`notifications: getChat failed while checking Telegram chat privacy: ${String(e)}`);
+			return false;
 		}
-		return this.pairedChatPrivate;
 	}
 
 	/** Tell the user once (per daemon run) how to enable Threaded Mode. */
@@ -1854,7 +1863,7 @@ export class TelegramNotificationDaemon {
 	/** Send a single `typing` chat action into a busy session's topic (best-effort). */
 	private async sendTyping(sessionId: string): Promise<void> {
 		const topicId = this.topics.get(sessionId)?.topicId;
-		if (!topicId) return;
+		if (!topicId || !(await this.pairedChatIsPrivate())) return;
 		try {
 			await this.botApi.call("sendChatAction", {
 				chat_id: this.opts.chatId,
@@ -1868,6 +1877,7 @@ export class TelegramNotificationDaemon {
 
 	/** Set a native reaction on an inbound thread message (best-effort). */
 	private async setReaction(messageId: number, emoji: string): Promise<void> {
+		if (!(await this.pairedChatIsPrivate())) return;
 		try {
 			await this.botApi.call("setMessageReaction", {
 				chat_id: this.opts.chatId,
@@ -1895,7 +1905,7 @@ export class TelegramNotificationDaemon {
 		if (typeof msg?.type === "string" && TelegramNotificationDaemon.THREADED_FRAMES.has(msg.type)) {
 			const send = renderThreadedFrame(msg);
 			if (!send) return;
-			const existingTopic = this.topics.get(session.sessionId)?.topicId;
+			const existingTopic = await this.existingTopicForPrivateChat(session.sessionId);
 			if (!send.identity && !existingTopic && !this.flatIdentitySent.has(session.sessionId)) {
 				this.rememberPendingThreadedFrame(session.sessionId, send, msg as Record<string, unknown>);
 				return;

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -86,6 +86,8 @@ class FakeBotApi {
 		}
 		if (method === "getMe")
 			return { ok: true, result: this.botUsername ? { id: 1, username: this.botUsername } : { id: 1 } };
+		if (method === "getChat")
+			return { ok: true, result: { id: (body as { chat_id?: unknown }).chat_id, type: "private" } };
 		if (method === "getFile") return { ok: true, result: { file_path: "docs/file_7.bin" } };
 		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: this.calls.length } };
 		if (method === "sendMessage") return { ok: true, result: { message_id: this.calls.length } };
@@ -1280,7 +1282,9 @@ test("stale identity after loadTopics reuses the persisted repo branch owner", a
 	});
 
 	expect(bot.calls.filter(c => c.method === "createForumTopic").map(c => c.body.name)).toEqual(["gajae-code/dev"]);
-	expect(bot.calls.filter(c => c.method === "sendMessage").map(c => c.body.message_thread_id)).toEqual([1]);
+	const threadedSends = bot.calls.filter(c => c.method === "sendMessage").map(c => c.body.message_thread_id);
+	expect(threadedSends).toHaveLength(1);
+	expect(Number(threadedSends[0])).toBeGreaterThan(0);
 });
 
 test("threaded mode off: frames fall back to the flat paired chat with a one-time notice", async () => {
@@ -1409,15 +1413,16 @@ test("threaded mode off: image_attachment uploads flat without message_thread_id
 	expect(notice).toHaveLength(1);
 });
 
-test("threaded off + non-private chat: fails closed (no flat send, no notice)", async () => {
+test("non-private chat: fails closed before topic creation or flat delivery", async () => {
 	for (const chatType of ["supergroup", "group", "channel"]) {
 		const agentDir = tempAgentDir();
 		const bot = new FakeBotApi();
-		// Topics off AND the paired chat is not a private DM: must drop fail-closed
-		// so session content never lands in a shared chat.
+		// Even if the target chat would accept forum topic creation, the paired chat
+		// contract is private-only, so the daemon must fail closed before creating
+		// topics or sending session content into a shared chat.
 		bot.call = (async (method: string, body: any) => {
 			bot.calls.push({ method, body });
-			if (method === "createForumTopic") return { ok: true, result: {} };
+			if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 777 } };
 			if (method === "getChat") return { ok: true, result: { type: chatType } };
 			if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
 			return { ok: true, result: true };
@@ -1451,8 +1456,8 @@ test("threaded off + non-private chat: fails closed (no flat send, no notice)", 
 			options: ["Yes"],
 		});
 
-		const sends = bot.calls.filter(c => c.method === "sendMessage");
-		expect(sends).toHaveLength(0);
+		expect(bot.calls.filter(c => c.method === "createForumTopic")).toHaveLength(0);
+		expect(bot.calls.filter(c => c.method === "sendMessage")).toHaveLength(0);
 	}
 });
 

--- a/packages/coding-agent/test/notify-setup.test.ts
+++ b/packages/coding-agent/test/notify-setup.test.ts
@@ -22,7 +22,12 @@ function makeFetch(results: Record<string, unknown[]>): { fetchImpl: typeof fetc
 		const body = init?.body ? JSON.parse(String(init.body)) : {};
 		calls.push({ method, body });
 		const queue = results[method] ?? [];
-		const payload = queue.length > 0 ? queue.shift() : { ok: true, result: [] };
+		const payload =
+			queue.length > 0
+				? queue.shift()
+				: method === "getChat"
+					? { ok: true, result: { id: body.chat_id, type: "private" } }
+					: { ok: true, result: [] };
 		return new Response(JSON.stringify(payload), {
 			status: (payload as { ok?: boolean }).ok === false ? 400 : 200,
 			headers: { "content-type": "application/json" },
@@ -189,15 +194,23 @@ describe("notify setup cli", () => {
 	});
 });
 
-test("non-interactive setup with --token and --chat-id writes config without polling", async () => {
+test("non-interactive setup with --token and --chat-id verifies private chat without polling", async () => {
 	const settings = Settings.isolated({});
 	let getUpdatesCalls = 0;
-	const fetchImpl = (async (url: any) => {
+	let getChatCalls = 0;
+	const fetchImpl = (async (url: any, init?: RequestInit) => {
 		const u = String(url);
+		const body = init?.body ? JSON.parse(String(init.body)) : {};
 		if (u.includes("/getMe"))
 			return new Response(JSON.stringify({ ok: true, result: { id: 1, is_bot: true } }), {
 				headers: { "content-type": "application/json" },
 			});
+		if (u.includes("/getChat")) {
+			getChatCalls++;
+			return new Response(JSON.stringify({ ok: true, result: { id: body.chat_id, type: "private" } }), {
+				headers: { "content-type": "application/json" },
+			});
+		}
 		if (u.includes("/getUpdates")) {
 			getUpdatesCalls++;
 			return new Response(JSON.stringify({ ok: true, result: [] }), {
@@ -216,7 +229,28 @@ test("non-interactive setup with --token and --chat-id writes config without pol
 	expect(cfg.chatId).toBe("999");
 	expect(cfg.redact).toBe(true);
 	expect(cfg.botToken).toBe("123:abc");
+	expect(getChatCalls).toBe(1);
 	expect(getUpdatesCalls).toBe(0);
+});
+
+test("non-interactive setup rejects non-private chat ids without writing config", async () => {
+	for (const type of ["group", "supergroup", "channel"]) {
+		const settings = Settings.isolated({});
+		const { fetchImpl, calls } = makeFetch({
+			getMe: [{ ok: true, result: { id: 1, is_bot: true, has_topics_enabled: true } }],
+			getChat: [{ ok: true, result: { id: -100, type } }],
+		});
+		const cmd = parseNotifyArgs(["notify", "setup", "--token", "123:abc", "--chat-id", "-100"]);
+
+		await expect(runNotifyCommand(cmd!, { settings, fetchImpl, setupInteractive: false })).rejects.toThrow(
+			`Provided chat id -100 is a ${type} chat`,
+		);
+
+		expect(getNotificationConfig(settings).enabled).toBe(false);
+		expect(getNotificationConfig(settings).botToken).toBeUndefined();
+		expect(getNotificationConfig(settings).chatId).toBeUndefined();
+		expect(calls.filter(call => call.method === "getUpdates")).toHaveLength(0);
+	}
 });
 
 function privateUpdates(chatId = 555111): unknown[] {


### PR DESCRIPTION
## What

Fixes Telegram notification setup and daemon delivery so non-private Telegram chat ids cannot be used as the paired notification target.

Changes:
- validate non-interactive `gjc notify setup --chat-id` with `getChat` and reject any chat whose type is not `private` before writing notification settings;
- require the live daemon to confirm the paired chat is private before reusing or creating per-session topics;
- fail closed before `createForumTopic`/threaded sends for group, supergroup, or channel chat ids, including persisted legacy topic state;
- treat transient `getChat` failures as fail-closed for the current attempt without caching the failure forever.

## Why

The documented Telegram contract is private-chat-only. Interactive setup already enforces that by waiting for a private DM, but non-interactive setup accepted an arbitrary `--chat-id`. If that id was a forum supergroup/channel where `createForumTopic` succeeded, the daemon could create a topic and send session identity/actions into a shared chat before the existing flat-fallback private-chat guard ever ran.

## Testing

- `bun install`
- `bun run build:native`
- `bun test packages/coding-agent/test/notify-setup.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun node_modules/.bin/biome check packages/coding-agent/src/cli/notify-cli.ts packages/coding-agent/src/notifications/telegram-daemon.ts packages/coding-agent/test/notify-setup.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts packages/coding-agent/CHANGELOG.md`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
