### PR TITLE
Dispose Telegram unattended gate listeners

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `gjc completion inshellisense`, which generates or installs a Fig/withfig-compatible `gjc` completion spec for Microsoft inshellisense without adding inshellisense as a runtime dependency.
 
 ### Fixed
+- Telegram unattended workflow-gate listeners are now disposed when a notification session stops, preventing stale stopped servers from retaining future gate emissions after shutdown or notification restart.
 - Telegram notification setup and daemon delivery now reject non-private Telegram chat ids before saving configuration, creating forum topics, or sending session content, preserving the private-chat-only routing boundary.
 - Telegram daemon autostart now refuses to attach a new session to a live daemon whose persisted bot-token fingerprint or chat id differs from the current settings, and it avoids registering the session root until ownership is trusted so rotated Telegram credentials cannot keep leaking through the old daemon.
 - Skill autocomplete now supports direct skill-name prefixes after prompt text (for example, `please /ra` → `/skill:ralplan`) while keeping bare `/` menus free of skill entries.

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -336,6 +336,8 @@ interface SessionRuntime {
 	disposeAnswerSource: () => void;
 	/** Deregisters this session's Telegram file sink. */
 	disposeFileSink: () => void;
+	/** Deregisters this session's unattended workflow-gate listener. */
+	disposeGateListener: () => void;
 	redact: boolean;
 	verbosity: "lean" | "verbose";
 	sessionTag: string;
@@ -505,8 +507,15 @@ export function createNotificationsExtension(api: ExtensionAPI, options: { setti
 		runtimes.delete(id);
 		try {
 			rt.cancelPostmortemCleanup();
+		} catch {}
+		try {
 			rt.disposeAnswerSource();
+		} catch {}
+		try {
 			rt.disposeFileSink();
+		} catch {}
+		try {
+			rt.disposeGateListener();
 		} catch {}
 		// Resolve any still-pending interactive asks so the ask tool is not left hanging.
 		for (const pending of rt.pendingInteractive.values()) pending.resolve(undefined);
@@ -689,6 +698,7 @@ export function createNotificationsExtension(api: ExtensionAPI, options: { setti
 				pendingInteractive,
 				disposeAnswerSource,
 				disposeFileSink,
+				disposeGateListener: () => {},
 				cancelPostmortemCleanup: () => {},
 				redact,
 				verbosity,
@@ -732,7 +742,7 @@ export function createNotificationsExtension(api: ExtensionAPI, options: { setti
 
 			// Unattended: a real ask emits a workflow gate; register it repliable by gate_id.
 			if (unattended && gate?.onGateEmitted) {
-				gate.onGateEmitted(g => {
+				runtime.disposeGateListener = gate.onGateEmitted(g => {
 					const options = (g.options ?? []).map(o => String((o as { label?: unknown }).label ?? ""));
 					gateOptions.set(g.gate_id, options);
 					const promptCtx = g.context as { prompt?: unknown; title?: unknown } | undefined;

--- a/packages/coding-agent/test/notifications-unattended-gate-disposer.test.ts
+++ b/packages/coding-agent/test/notifications-unattended-gate-disposer.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createNotificationsExtension } from "../src/notifications/index";
+
+/**
+ * Regression for unattended workflow-gate listener leaks: notifications register
+ * `workflowGate.onGateEmitted()` so real unattended asks can be answered from
+ * Telegram, but the returned disposer must be retained and called when the
+ * notification session stops. Otherwise `/notify off`, `session_shutdown`, or a
+ * resume restart leaves a stale listener closing over a stopped
+ * NotificationServer and future gates try to register duplicate/stale asks.
+ */
+
+type Handler = (event: unknown, ctx: unknown) => unknown;
+type GateListener = (gate: {
+	gate_id: string;
+	options?: Array<{ label?: string }>;
+	context?: { prompt?: string; title?: string };
+}) => void;
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+async function withNotifications<T>(fn: () => Promise<T>): Promise<T> {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		return await fn();
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
+	}
+}
+
+function createGateHarness() {
+	const handlers = new Map<string, Handler>();
+	const listeners = new Set<GateListener>();
+	let disposeCalls = 0;
+	const workflowGate = {
+		isUnattended: () => true,
+		onGateEmitted(listener: GateListener): () => void {
+			listeners.add(listener);
+			return () => {
+				disposeCalls += 1;
+				listeners.delete(listener);
+			};
+		},
+		resolveGate: async () => ({ ok: true }),
+	};
+	const api = {
+		on: (event: string, handler: Handler) => {
+			handlers.set(event, handler);
+		},
+		registerCommand: () => {},
+		sendUserMessage: () => {},
+	} as never;
+	createNotificationsExtension(api);
+
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-gate-disposer-"));
+	tempDirs.push(cwd);
+	const sid = `gate-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	const ctx = {
+		cwd,
+		workflowGate,
+		sessionManager: {
+			getSessionId: () => sid,
+			getSessionName: () => "Unattended",
+			getArtifactsDir: () => cwd,
+			getCwd: () => cwd,
+		},
+	} as never;
+	return {
+		handlers,
+		ctx,
+		listeners,
+		get disposeCalls() {
+			return disposeCalls;
+		},
+	};
+}
+
+test("unattended workflow-gate listener is disposed when notifications stop", async () => {
+	await withNotifications(async () => {
+		const harness = createGateHarness();
+
+		await harness.handlers.get("session_start")!({ type: "session_start" }, harness.ctx);
+		expect(harness.listeners.size).toBe(1);
+
+		await harness.handlers.get("session_shutdown")!({ type: "session_shutdown" }, harness.ctx);
+
+		expect(harness.listeners.size).toBe(0);
+		expect(harness.disposeCalls).toBe(1);
+	});
+});


### PR DESCRIPTION
## What

Fixes Telegram unattended notification sessions so the workflow-gate listener registered through `workflowGate.onGateEmitted()` is retained and disposed when the notification session stops.

Changes:
- add an unattended gate-listener disposer to the notification session runtime;
- call that disposer from `stopSession()` alongside the answer-source, file-sink, and postmortem cleanup disposers;
- keep the default disposer as a no-op for interactive/non-unattended sessions;
- add focused regression coverage that starts an unattended notification session and verifies `session_shutdown` removes the registered gate listener exactly once.

## Why

Unattended sessions register a gate listener so real workflow gates can be mirrored as remotely answerable Telegram asks. The previous code ignored the disposer returned by `onGateEmitted()`, so `/notify off`, `session_shutdown`, or a notification restart could leave a stale listener closing over the stopped `NotificationServer`. Future gates could then attempt duplicate/stale `registerAsk()` calls and retain old runtime/server state.

## Testing

- `bun install`
- `bun run build:native`
- `bun test packages/coding-agent/test/notifications-unattended-gate-disposer.test.ts packages/coding-agent/test/notifications-postmortem-close.test.ts packages/coding-agent/test/notifications-session-switch.test.ts`
- `bun node_modules/.bin/biome check packages/coding-agent/src/notifications/index.ts packages/coding-agent/test/notifications-unattended-gate-disposer.test.ts packages/coding-agent/CHANGELOG.md`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
