### PR TITLE
Fix Telegram notification private-chat test fixtures

### DIFF
--- a/packages/coding-agent/test/notifications-html-format.test.ts
+++ b/packages/coding-agent/test/notifications-html-format.test.ts
@@ -277,6 +277,8 @@ class CapturingBotApi {
 	calls: Array<{ method: string; body: any }> = [];
 	async call(method: string, body: unknown): Promise<unknown> {
 		this.calls.push({ method, body });
+		if (method === "getChat")
+			return { ok: true, result: { id: (body as { chat_id?: unknown } | null)?.chat_id, type: "private" } };
 		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: this.calls.length } };
 		if (method === "sendMessage") return { ok: true, result: { message_id: this.calls.length } };
 		return { ok: true, result: true };

--- a/packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts
@@ -32,6 +32,7 @@ function spyBot(): { calls: Call[]; api: never } {
 	const api = {
 		call: async (method: string, body: Record<string, unknown> | null) => {
 			calls.push({ method, body });
+			if (method === "getChat") return { ok: true, result: { id: body?.chat_id, type: "private" } };
 			return { ok: true, result: [] };
 		},
 	} as never;


### PR DESCRIPTION
## Summary
- Stub `getChat` as a private chat in Telegram notification send-site test helpers that exercise paired-chat happy paths.
- Preserve the production non-private fail-closed guard added by #1614; only the test fixtures now model the expected private chat.

## Validation
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun test packages/coding-agent/test/notifications-html-format.test.ts packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun --cwd=packages/coding-agent run check`

CI failure fixed: https://github.com/Yeachan-Heo/gajae-code/actions/runs/28735221090

Note: the broader affected shard was attempted and hit an unrelated local timeout in `notifications-telegram-daemon.test.ts > requestStop aborts the active long poll...`; the full daemon file and focused 3-file set both passed immediately on direct re-run before opening this PR.