### PR TITLE
Clear Telegram reply routes on ask cleanup

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1459,6 +1459,7 @@ export class TelegramNotificationDaemon {
 			clearIntervalImpl(session.pingTimer);
 			session.pingTimer = undefined;
 		}
+		this.deleteMessageRoutes(session.sessionId);
 		if (this.sessions.get(session.sessionId) === session) {
 			this.sessions.delete(session.sessionId);
 		}
@@ -1466,6 +1467,14 @@ export class TelegramNotificationDaemon {
 			try {
 				session.ws.close();
 			} catch {}
+		}
+	}
+
+	private deleteMessageRoutes(sessionId: string, actionId?: string): void {
+		for (const [messageId, route] of this.messageRoutes.entries()) {
+			if (route.sessionId === sessionId && (actionId === undefined || route.actionId === actionId)) {
+				this.messageRoutes.delete(messageId);
+			}
 		}
 	}
 
@@ -1994,6 +2003,7 @@ export class TelegramNotificationDaemon {
 			await this.persistAliases();
 		} else if (msg.type === "action_resolved" && msg.id) {
 			session.pending.delete(msg.id);
+			this.deleteMessageRoutes(session.sessionId, msg.id);
 			for (const [alias, route] of this.aliasTable.entries()) {
 				if (route.sessionId === session.sessionId && route.actionId === msg.id) this.aliasTable.delete(alias);
 			}

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -575,6 +575,41 @@ describe("telegram daemon", () => {
 		expect(bot.calls.some(c => c.method === "sendMessage" && String(c.body.text).includes("stale"))).toBe(true);
 	});
 
+	test("action_resolved clears reply message routes for that ask", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+		});
+		daemon.connectSession("S", "ws://s", "ts");
+		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
+			type: "action_needed",
+			kind: "ask",
+			id: "ask",
+			question: "Q",
+			options: ["Y"],
+		});
+		const askMessageId = [...daemon.messageRoutes.entries()].find(
+			([, route]) => route.sessionId === "S" && route.actionId === "ask",
+		)?.[0];
+		expect(askMessageId).toBeDefined();
+		daemon.messageRoutes.set("same-session-other", { sessionId: "S", actionId: "other" });
+		daemon.messageRoutes.set("other-session", { sessionId: "T", actionId: "ask" });
+
+		await daemon.handleSessionMessage(daemon.sessions.get("S")!, { type: "action_resolved", id: "ask" });
+
+		expect(daemon.messageRoutes.has(askMessageId!)).toBe(false);
+		expect(daemon.messageRoutes.get("same-session-other")).toEqual({ sessionId: "S", actionId: "other" });
+		expect(daemon.messageRoutes.get("other-session")).toEqual({ sessionId: "T", actionId: "ask" });
+	});
+
 	test("reply_to_message routes and non-paired chat leaks nothing", async () => {
 		FakeWs.instances = [];
 		const agentDir = tempAgentDir();
@@ -1680,6 +1715,31 @@ test("session_closed deletes the topic and resume creates a fresh visible topic"
 	expect(bot.calls.some(c => c.method === "sendMessage" && String(c.body.text).includes("queued-before-delete"))).toBe(
 		false,
 	);
+});
+
+test("session_closed clears reply message routes for the closed session", async () => {
+	FakeWs.instances = [];
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+	});
+	daemon.connectSession("S", "ws://s", "ts");
+	daemon.connectSession("T", "ws://t", "tt");
+	daemon.messageRoutes.set("s-ask", { sessionId: "S", actionId: "ask" });
+	daemon.messageRoutes.set("s-other", { sessionId: "S", actionId: "other" });
+	daemon.messageRoutes.set("t-ask", { sessionId: "T", actionId: "ask" });
+
+	await daemon.handleSessionMessage(daemon.sessions.get("S")!, { type: "session_closed", sessionId: "S" });
+
+	expect([...daemon.messageRoutes.values()].some(route => route.sessionId === "S")).toBe(false);
+	expect(daemon.messageRoutes.get("t-ask")).toEqual({ sessionId: "T", actionId: "ask" });
 });
 
 test("session_closed tombstones its endpoint generation so scans do not recreate an empty topic", async () => {


### PR DESCRIPTION
## What
- Clear Telegram reply-to message routes when an ask is resolved.
- Clear all reply-to message routes for a session when that session is dropped/closed.
- Keep unrelated same-daemon routes intact.

## Why
Stale `messageRoutes` entries retained old session/action ids after asks resolved or sessions closed, so long-lived daemons could keep routing replies through obsolete metadata and grow the in-memory route map.

## Testing
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun node_modules/.bin/biome check packages/coding-agent/src/notifications/telegram-daemon.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
