### PR TITLE
Hide Telegram setup token prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `gjc completion inshellisense`, which generates or installs a Fig/withfig-compatible `gjc` completion spec for Microsoft inshellisense without adding inshellisense as a runtime dependency.
 
 ### Fixed
+- Telegram notify setup now hides the interactive BotFather token prompt input, preventing the raw bot token from being echoed into terminal scrollback while pairing notifications.
 - Telegram unattended workflow-gate listeners are now disposed when a notification session stops, preventing stale stopped servers from retaining future gate emissions after shutdown or notification restart.
 - Telegram notification setup and daemon delivery now reject non-private Telegram chat ids before saving configuration, creating forum topics, or sending session content, preserving the private-chat-only routing boundary.
 - Telegram daemon autostart now refuses to attach a new session to a live daemon whose persisted bot-token fingerprint or chat id differs from the current settings, and it avoids registering the session root until ownership is trusted so rotated Telegram credentials cannot keep leaking through the old daemon.

--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -176,16 +176,76 @@ async function runSetup(deps: NotifyCommandDeps): Promise<void> {
 	);
 }
 
-async function promptForToken(): Promise<string> {
-	if (!process.stdin.isTTY) {
+type TokenPromptInput = NodeJS.ReadStream & {
+	isRaw?: boolean;
+	setRawMode?: (mode: boolean) => unknown;
+};
+
+type TokenPromptOutput = Pick<NodeJS.WriteStream, "write">;
+
+export async function promptForToken(
+	input: TokenPromptInput = process.stdin,
+	output: TokenPromptOutput = process.stdout,
+): Promise<string> {
+	if (!input.isTTY) {
 		throw new Error("notify setup requires an interactive TTY unless setupToken is injected.");
 	}
-	const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: true });
-	try {
-		return (await rl.question("Telegram BotFather token: ")).trim();
-	} finally {
-		rl.close();
+	if (typeof input.setRawMode !== "function") {
+		throw new Error("notify setup requires a TTY with raw input support unless setupToken is injected.");
 	}
+
+	output.write("Telegram BotFather token: ");
+	const wasRaw = input.isRaw === true;
+	input.setRawMode(true);
+
+	return await new Promise<string>((resolve, reject) => {
+		let value = "";
+		let settled = false;
+
+		const cleanup = () => {
+			input.off("data", onData);
+			input.off("error", onError);
+			input.setRawMode?.(wasRaw);
+			output.write("\n");
+		};
+
+		const finish = (callback: () => void) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			callback();
+		};
+
+		const accept = () => finish(() => resolve(value.trim()));
+		const cancel = () => finish(() => reject(new Error("Telegram bot token prompt cancelled.")));
+		const onError = (error: Error) => finish(() => reject(error));
+		const onData = (chunk: Buffer | string) => {
+			for (const char of String(chunk)) {
+				if (char === "\r" || char === "\n") {
+					accept();
+					return;
+				}
+				if (char === "\u0003") {
+					cancel();
+					return;
+				}
+				if (char === "\u0004") {
+					if (value) accept();
+					else cancel();
+					return;
+				}
+				if (char === "\u007f" || char === "\b") {
+					value = value.slice(0, -1);
+					continue;
+				}
+				if (char >= " ") value += char;
+			}
+		};
+
+		input.on("data", onData);
+		input.once("error", onError);
+		input.resume();
+	});
 }
 
 const THREADED_ENABLED_SUCCESS =

--- a/packages/coding-agent/test/notify-setup.test.ts
+++ b/packages/coding-agent/test/notify-setup.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { parseNotifyArgs, runNotifyCommand } from "../src/cli/notify-cli";
+import { parseNotifyArgs, promptForToken, runNotifyCommand } from "../src/cli/notify-cli";
 import { Settings } from "../src/config/settings";
 import { getNotificationConfig, maskToken } from "../src/notifications/config";
 import {
@@ -60,6 +61,31 @@ async function captureOutput(run: () => Promise<void>): Promise<{ stdout: string
 
 const token = "1234:super-secret-token";
 
+class FakeTokenInput extends EventEmitter {
+	isTTY = true;
+	isRaw = false;
+	resumeCalls = 0;
+
+	setRawMode(mode: boolean): this {
+		this.isRaw = mode;
+		return this;
+	}
+
+	resume(): this {
+		this.resumeCalls++;
+		return this;
+	}
+}
+
+class FakeTokenOutput {
+	text = "";
+
+	write(chunk: string | Uint8Array): boolean {
+		this.text += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+		return true;
+	}
+}
+
 describe("notify setup cli", () => {
 	test("parseNotifyArgs recognizes notify subcommands", () => {
 		expect(parseNotifyArgs(["shell"])).toBeUndefined();
@@ -75,6 +101,22 @@ describe("notify setup cli", () => {
 			smoke: true,
 			rawArgs: ["--smoke"],
 		});
+	});
+
+	test("interactive token prompt disables echo and does not write raw token", async () => {
+		const input = new FakeTokenInput();
+		const output = new FakeTokenOutput();
+
+		const prompt = promptForToken(input as unknown as NodeJS.ReadStream, output);
+		expect(input.isRaw).toBe(true);
+		input.emit("data", Buffer.from(token));
+		input.emit("data", Buffer.from("\n"));
+
+		await expect(prompt).resolves.toBe(token);
+		expect(input.isRaw).toBe(false);
+		expect(input.resumeCalls).toBe(1);
+		expect(output.text).toContain("Telegram BotFather token: ");
+		expect(output.text).not.toContain(token);
 	});
 
 	test("getMe ok plus private message writes settings and reads via config helper", async () => {


### PR DESCRIPTION
## What
- Replace the interactive Telegram BotFather token prompt with a raw-mode hidden input reader.
- Restore the terminal raw-mode state and print only the prompt/newline, not the typed token.
- Add regression coverage that the prompt enters raw mode and does not write the raw token.
- Add an Unreleased changelog entry.

## Why
`gjc notify setup` treated the BotFather token as a secret in later output, but the interactive prompt used normal readline input, which lets the terminal echo the raw token into scrollback while pairing notifications.

## Testing
- `bun test packages/coding-agent/test/notify-setup.test.ts`
- `bun node_modules/.bin/biome check packages/coding-agent/src/cli/notify-cli.ts packages/coding-agent/test/notify-setup.test.ts packages/coding-agent/CHANGELOG.md`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
