### PR TITLE
Clear Telegram reply routes on ask cleanup

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1453,19 +1453,31 @@ export class TelegramNotificationDaemon {
 	 * (so a delayed old close cannot delete a replacement), and best-effort closes
 	 * the socket. `scanRoots()` then reconnects the session.
 	 */
-	private dropSession(session: SessionSocket, _reason: string): void {
+	private dropSession(session: SessionSocket, reason: string): void {
 		const clearIntervalImpl = this.opts.clearIntervalImpl ?? clearInterval;
 		if (session.pingTimer) {
 			clearIntervalImpl(session.pingTimer);
 			session.pingTimer = undefined;
 		}
-		if (this.sessions.get(session.sessionId) === session) {
+		const isCurrentSession = this.sessions.get(session.sessionId) === session;
+		if (isCurrentSession || reason === "session_closed") {
+			this.deleteMessageRoutes(session.sessionId);
+		}
+		if (isCurrentSession) {
 			this.sessions.delete(session.sessionId);
 		}
 		if (session.ws.readyState !== WebSocket.CLOSED) {
 			try {
 				session.ws.close();
 			} catch {}
+		}
+	}
+
+	private deleteMessageRoutes(sessionId: string, actionId?: string): void {
+		for (const [messageId, route] of this.messageRoutes.entries()) {
+			if (route.sessionId === sessionId && (actionId === undefined || route.actionId === actionId)) {
+				this.messageRoutes.delete(messageId);
+			}
 		}
 	}
 
@@ -1994,6 +2006,7 @@ export class TelegramNotificationDaemon {
 			await this.persistAliases();
 		} else if (msg.type === "action_resolved" && msg.id) {
 			session.pending.delete(msg.id);
+			this.deleteMessageRoutes(session.sessionId, msg.id);
 			for (const [alias, route] of this.aliasTable.entries()) {
 				if (route.sessionId === session.sessionId && route.actionId === msg.id) this.aliasTable.delete(alias);
 			}

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -575,6 +575,86 @@ describe("telegram daemon", () => {
 		expect(bot.calls.some(c => c.method === "sendMessage" && String(c.body.text).includes("stale"))).toBe(true);
 	});
 
+	test("action_resolved clears reply message routes for that ask", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+		});
+		daemon.connectSession("S", "ws://s", "ts");
+		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
+			type: "action_needed",
+			kind: "ask",
+			id: "ask",
+			question: "Q",
+			options: ["Y"],
+		});
+		const askMessageId = [...daemon.messageRoutes.entries()].find(
+			([, route]) => route.sessionId === "S" && route.actionId === "ask",
+		)?.[0];
+		expect(askMessageId).toBeDefined();
+		daemon.messageRoutes.set("same-session-other", { sessionId: "S", actionId: "other" });
+		daemon.messageRoutes.set("other-session", { sessionId: "T", actionId: "ask" });
+
+		await daemon.handleSessionMessage(daemon.sessions.get("S")!, { type: "action_resolved", id: "ask" });
+
+		expect(daemon.messageRoutes.has(askMessageId!)).toBe(false);
+		expect(daemon.messageRoutes.get("same-session-other")).toEqual({ sessionId: "S", actionId: "other" });
+		expect(daemon.messageRoutes.get("other-session")).toEqual({ sessionId: "T", actionId: "ask" });
+	});
+
+	test("delayed close from replaced socket preserves fresh reply message routes", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+		});
+		daemon.connectSession("S", "ws://old", "old-token");
+		const oldSocket = FakeWs.instances[0]!;
+		daemon.connectSession("S", "ws://new", "new-token");
+		const newSocket = FakeWs.instances[1]!;
+		const newSession = daemon.sessions.get("S")!;
+		await daemon.handleSessionMessage(newSession, {
+			type: "action_needed",
+			kind: "ask",
+			id: "ask-new",
+			question: "Q",
+			options: ["Y"],
+		});
+		const askMessageId = [...daemon.messageRoutes.entries()].find(
+			([, route]) => route.sessionId === "S" && route.actionId === "ask-new",
+		)?.[0];
+		expect(askMessageId).toBeDefined();
+
+		oldSocket.close();
+
+		expect(daemon.sessions.get("S")).toBe(newSession);
+		expect(daemon.messageRoutes.has(askMessageId!)).toBe(true);
+		await daemon.handleTelegramUpdate({
+			message: { chat: { id: 42 }, text: "ok", reply_to_message: { message_id: Number(askMessageId) } },
+		});
+		expect(JSON.parse(newSocket.sent.at(-1)!)).toEqual({
+			type: "reply",
+			id: "ask-new",
+			answer: "ok",
+			token: "new-token",
+		});
+	});
+
 	test("reply_to_message routes and non-paired chat leaks nothing", async () => {
 		FakeWs.instances = [];
 		const agentDir = tempAgentDir();
@@ -1682,6 +1762,31 @@ test("session_closed deletes the topic and resume creates a fresh visible topic"
 	);
 });
 
+test("session_closed clears reply message routes for the closed session", async () => {
+	FakeWs.instances = [];
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+	});
+	daemon.connectSession("S", "ws://s", "ts");
+	daemon.connectSession("T", "ws://t", "tt");
+	daemon.messageRoutes.set("s-ask", { sessionId: "S", actionId: "ask" });
+	daemon.messageRoutes.set("s-other", { sessionId: "S", actionId: "other" });
+	daemon.messageRoutes.set("t-ask", { sessionId: "T", actionId: "ask" });
+
+	await daemon.handleSessionMessage(daemon.sessions.get("S")!, { type: "session_closed", sessionId: "S" });
+
+	expect([...daemon.messageRoutes.values()].some(route => route.sessionId === "S")).toBe(false);
+	expect(daemon.messageRoutes.get("t-ask")).toEqual({ sessionId: "T", actionId: "ask" });
+});
+
 test("session_closed tombstones its endpoint generation so scans do not recreate an empty topic", async () => {
 	FakeWs.instances = [];
 	const agentDir = tempAgentDir();
@@ -2279,6 +2384,10 @@ test("requestStop aborts the active long poll and run() exits, releasing ownersh
 		pid: process.pid,
 		randomId: () => "owner",
 	});
+	let markPollStarted!: () => void;
+	const pollStarted = new Promise<void>(resolve => {
+		markPollStarted = resolve;
+	});
 	const bot = {
 		call: (method: string, _body: unknown, opts?: { signal?: AbortSignal }) => {
 			if (method === "getUpdates") {
@@ -2286,6 +2395,7 @@ test("requestStop aborts the active long poll and run() exits, releasing ownersh
 					opts?.signal?.addEventListener("abort", () =>
 						reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
 					);
+					markPollStarted();
 				});
 			}
 			return Promise.resolve({ ok: true, result: true });
@@ -2308,7 +2418,7 @@ test("requestStop aborts the active long poll and run() exits, releasing ownersh
 	});
 	daemon.connectSession("S", "ws://s", "t");
 	const runPromise = daemon.run();
-	await new Promise(resolve => setTimeout(resolve, 5));
+	await pollStarted;
 	daemon.requestStop("signal");
 	await runPromise;
 	expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(false);


### PR DESCRIPTION
## What
- Clear Telegram reply-to message routes when an ask is resolved.
- Clear all reply-to message routes for a session when that current session is dropped/closed.
- Preserve fresh replacement-session reply routes when a delayed close from a superseded socket fires.

## Why
Supersedes #1617. That PR correctly scoped `action_resolved` cleanup by `(sessionId, actionId)`, but review found that `dropSession()` cleanup could run from an old socket close after a replacement session had already rendered fresh asks. This retry keeps explicit `session_closed` cleanup, but gates socket/liveness cleanup behind the same current-session identity check that protects session deletion.

## Testing
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun node_modules/.bin/biome check packages/coding-agent/src/notifications/telegram-daemon.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
