### PR TITLE
Limit telegram_send file size

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `gjc completion inshellisense`, which generates or installs a Fig/withfig-compatible `gjc` completion spec for Microsoft inshellisense without adding inshellisense as a runtime dependency.
 
 ### Fixed
+- `telegram_send` now rejects files over Telegram's document upload limit before reading them into memory or handing them to the notification sink.
 - Telegram notify setup now hides the interactive BotFather token prompt input, preventing the raw bot token from being echoed into terminal scrollback while pairing notifications.
 - Telegram unattended workflow-gate listeners are now disposed when a notification session stops, preventing stale stopped servers from retaining future gate emissions after shutdown or notification restart.
 - Telegram notification setup and daemon delivery now reject non-private Telegram chat ids before saving configuration, creating forum topics, or sending session content, preserving the private-chat-only routing boundary.

--- a/packages/coding-agent/src/tools/telegram-send.ts
+++ b/packages/coding-agent/src/tools/telegram-send.ts
@@ -6,6 +6,9 @@ import { getTelegramFileSink } from "../notifications/attachment-registry";
 import { getNotificationConfig, isGloballyConfigured } from "../notifications/config";
 import type { ToolSession } from "./index";
 
+const TELEGRAM_SEND_MAX_FILE_BYTES = 50 * 1024 * 1024;
+const TELEGRAM_SEND_MAX_FILE_MIB = TELEGRAM_SEND_MAX_FILE_BYTES / (1024 * 1024);
+
 const telegramSendSchema = z.object({
 	path: z
 		.string()
@@ -74,6 +77,9 @@ export class TelegramSendTool implements AgentTool<typeof telegramSendSchema, Te
 		}
 		if (!stat.isFile()) {
 			return { ok: false, error: "not a regular file" };
+		}
+		if (stat.size > TELEGRAM_SEND_MAX_FILE_BYTES) {
+			return { ok: false, error: `file exceeds Telegram document limit (${TELEGRAM_SEND_MAX_FILE_MIB} MiB)` };
 		}
 		return { ok: true, path: real };
 	}

--- a/packages/coding-agent/test/telegram-send-tool.test.ts
+++ b/packages/coding-agent/test/telegram-send-tool.test.ts
@@ -78,4 +78,17 @@ describe("telegram_send egress containment", () => {
 		expect(res.isError).toBe(true);
 		expect(sinkCalls).toHaveLength(0);
 	});
+
+	it("rejects oversized files before invoking the Telegram sink", async () => {
+		const { root, tool } = setup();
+		const bigPath = path.join(root, "too-large.bin");
+		fs.writeFileSync(bigPath, "");
+		fs.truncateSync(bigPath, 50 * 1024 * 1024 + 1);
+
+		const res = await tool.execute("c", { path: "too-large.bin" });
+
+		expect(res.isError).toBe(true);
+		expect(res.details?.error ?? "").toContain("Telegram document limit");
+		expect(sinkCalls).toHaveLength(0);
+	});
 });


### PR DESCRIPTION
## What
- Reject `telegram_send` files larger than Telegram's 50 MiB document upload limit.
- Check `stat.size` after workspace containment/regular-file validation and before invoking the Telegram file sink.
- Add regression coverage using a sparse oversized file so the sink is never called.
- Add an Unreleased changelog entry.

## Why
`telegram_send` previously accepted any regular workspace file and delegated it to the notification sink, which reads the whole file and base64-encodes it before the daemon uploads it. Oversized files could allocate large in-memory copies only to be rejected by Telegram later.

## Testing
- `bun test packages/coding-agent/test/telegram-send-tool.test.ts`
- `bun node_modules/.bin/biome check packages/coding-agent/src/tools/telegram-send.ts packages/coding-agent/test/telegram-send-tool.test.ts packages/coding-agent/CHANGELOG.md`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
