### PR TITLE
fix: stop task-tool subagent sessions from creating their own Telegram topics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Task-tool subagent sessions no longer register the notifications extension, so they no longer open their own notification endpoints or per-session Telegram topics; only the top-level session surfaces in Telegram.
+
 ## [0.8.1] - 2026-07-04
 
 ### Added

--- a/packages/coding-agent/src/notifications/config.ts
+++ b/packages/coding-agent/src/notifications/config.ts
@@ -48,11 +48,21 @@ export function isGloballyConfigured(cfg: NotificationConfig): boolean {
 	);
 }
 
-/** Resolve whether the notifications extension should be registered at SDK startup. */
+/**
+ * Resolve whether the notifications extension should be registered at SDK startup.
+ *
+ * Subagent (task-tool helper) sessions never register: they share the parent
+ * process env and repo state root, so registering would give every helper its
+ * own notification endpoint — and therefore its own Telegram topic — even
+ * though only the top-level session is remotely steerable.
+ */
 export function shouldRegisterNotificationsExtension(input: {
 	env: NodeJS.ProcessEnv;
 	cfg?: NotificationConfig;
+	/** True for task-tool subagent sessions (`parentTaskPrefix` present). */
+	isSubagent?: boolean;
 }): boolean {
+	if (input.isSubagent) return false;
 	if (input.env.GJC_NOTIFICATIONS === "0") return false;
 	if (input.env.GJC_NOTIFICATIONS === "1" || input.env.GJC_NOTIFICATIONS_TOKEN) return true;
 	return input.cfg ? isGloballyConfigured(input.cfg) : false;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1524,7 +1524,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		} catch {
 			notificationCfg = undefined;
 		}
-		if (shouldRegisterNotificationsExtension({ env: process.env, cfg: notificationCfg })) {
+		// Subagent sessions never own a notification endpoint: one Telegram
+		// topic per top-level session, not per task-tool helper.
+		if (
+			shouldRegisterNotificationsExtension({
+				env: process.env,
+				cfg: notificationCfg,
+				isSubagent: (options.taskDepth ?? 0) > 0 || Boolean(options.parentTaskPrefix),
+			})
+		) {
 			inlineExtensions.push(createNotificationsExtension);
 		}
 

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -149,6 +149,15 @@ describe("notifications config", () => {
 		expect(shouldRegisterNotificationsExtension({ cfg: GLOBAL_CFG, env: {} })).toBe(true);
 		expect(shouldRegisterNotificationsExtension({ cfg: BASE_CFG, env: {} })).toBe(false);
 		expect(shouldRegisterNotificationsExtension({ env: {} })).toBe(false);
+		expect(shouldRegisterNotificationsExtension({ cfg: GLOBAL_CFG, env: {}, isSubagent: true })).toBe(false);
+		expect(
+			shouldRegisterNotificationsExtension({
+				cfg: GLOBAL_CFG,
+				env: { GJC_NOTIFICATIONS: "1", GJC_NOTIFICATIONS_TOKEN: "token" },
+				isSubagent: true,
+			}),
+		).toBe(false);
+		expect(shouldRegisterNotificationsExtension({ cfg: GLOBAL_CFG, env: {}, isSubagent: false })).toBe(true);
 	});
 
 	test("maskToken handles unset tokens and never reveals the raw token", () => {


### PR DESCRIPTION
## What

Task-tool subagent sessions no longer register the notifications extension, so they no longer open per-session notification endpoints or Telegram forum topics. Only the top-level session surfaces in Telegram.

## Why

With notifications globally configured, `createAgentSession` registered `createNotificationsExtension` for every session — including task-tool subagents (`parentTaskPrefix`, `src/task/executor.ts`). Each helper wrote an endpoint file under `.gjc/state/notifications`, and the daemon's `scanRoots()` loop connected to every live endpoint and created a topic per subagent, cluttering the paired chat with helper-session topics that are not remotely steerable anyway. #1367 only hid internal sessions from `/session_recent`; the topic-creation path had no filter.

The gate is an explicit `isSubagent` input on `shouldRegisterNotificationsExtension()`, checked before the `GJC_NOTIFICATIONS` env overrides because subagents run in the parent process and share its env — an env-based opt-out cannot distinguish them. `sdk.ts` passes the same sub-session predicate already used for agent-registry `kind` (`taskDepth > 0 || parentTaskPrefix`). Since subagents never own an endpoint, the daemon needs no changes: topic creation, deletion, and orphan cleanup are untouched.

Trade-off: `telegram_send` and remote ask answering inside subagent sessions are disabled along with the endpoint; subagents don't use `ask`, so nothing user-facing is lost.

## Testing

- `bun test test/notifications-config.test.ts` — new cases: `isSubagent: true` is refused even with `GJC_NOTIFICATIONS=1` + token; `isSubagent: false` keeps global auto-on (11 pass)
- `bun test test/notifications-{config,postmortem-close,session-switch,turn-ordering,lifecycle-control-runtime}.test.ts` — 36 pass
- `bun run check:types` (tsgo) and workspace `biome check` on touched files — clean

---

- [x] `bun check` passes (check:types + biome on touched files)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
