### PR TITLE
feat(coding-agent): add user-global standalone MCP startup opt-in

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Added a default-off, user-global `mcp.enableStandalone` opt-in that connects explicitly configured standalone MCP servers (`native` + `mcp-json` sources) into top-level sessions; project `.mcp.json` requires user-global `mcp.enableProjectConfig`, standalone stdio defaults to `noInheritEnv:true`, and startup is capped at 8 servers / 4 concurrent connects.
 
 - Queued message selector entries can now be reordered with `Ctrl+Up` / `Ctrl+Down`, with `Ctrl+Shift+Up` / `Ctrl+Shift+Down` still accepted when the terminal forwards them, while keeping the current draft intact.
 

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -67,6 +67,12 @@ export function registerProvider<T>(capabilityId: string, provider: Provider<T>)
 		throw new Error(`Unknown capability: "${capabilityId}". Define it first with defineCapability().`);
 	}
 
+	const providers = capability.providers as Provider<T>[];
+	if (providers.some(p => p.id === provider.id)) {
+		logger.warn("Ignoring duplicate provider registration", { capability: capabilityId, provider: provider.id });
+		return;
+	}
+
 	// Store provider metadata (for cross-capability display)
 	if (!providerMeta.has(provider.id)) {
 		providerMeta.set(provider.id, {
@@ -82,7 +88,6 @@ export function registerProvider<T>(capabilityId: string, provider: Provider<T>)
 	providerCapabilities.get(provider.id)!.add(capabilityId);
 
 	// Insert in priority order (highest first)
-	const providers = capability.providers as Provider<T>[];
 	const idx = providers.findIndex(p => p.priority < provider.priority);
 	if (idx === -1) {
 		providers.push(provider);

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2518,6 +2518,11 @@ export const SETTINGS_SCHEMA = {
 		default: false,
 	},
 
+	"mcp.enableStandalone": {
+		type: "boolean",
+		default: false,
+	},
+
 	"mcp.discoveryMode": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/runtime-mcp/config.ts
+++ b/packages/coding-agent/src/runtime-mcp/config.ts
@@ -4,13 +4,13 @@
  * Uses the capability system to load MCP servers from multiple sources.
  */
 
-import { getMCPConfigPath } from "@gajae-code/utils";
+import { getMCPConfigPath, logger } from "@gajae-code/utils";
 import { mcpCapability } from "../capability/mcp";
 import type { SourceMeta } from "../capability/types";
 import type { MCPServer } from "../discovery";
 import { loadCapability } from "../discovery";
 import { readDisabledServers } from "./config-writer";
-import type { MCPServerConfig } from "./types";
+import type { MCPServerConfig, MCPStdioServerConfig } from "./types";
 
 /** Options for loading MCP configs */
 export interface LoadMCPConfigsOptions {
@@ -22,6 +22,12 @@ export interface LoadMCPConfigsOptions {
 	filterBrowser?: boolean;
 	/** Only include servers eligible for startup connection, i.e. autoload !== false (default: false) */
 	autoloadOnly?: boolean;
+	/** Capability provider id allow-list. When omitted, all registered providers are loaded. */
+	providers?: string[];
+	/** Maximum number of eligible servers to return after filtering. */
+	maxServers?: number;
+	/** Force stdio servers to receive only the minimal inherited environment plus explicit env. */
+	forceNoInheritEnvForStdio?: boolean;
 }
 
 /** Result of loading MCP configs */
@@ -37,6 +43,10 @@ export interface LoadMCPConfigsResult {
 /**
  * Convert canonical MCPServer to legacy MCPServerConfig.
  */
+function isStdioConfig(config: MCPServerConfig): config is MCPStdioServerConfig {
+	return config.type === "stdio" || (!config.type && "command" in config);
+}
+
 function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
 	// Determine transport type
 	const transport = server.transport ?? (server.command ? "stdio" : server.url ? "http" : "stdio");
@@ -100,9 +110,10 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 	const filterExa = options?.filterExa ?? true;
 	const filterBrowser = options?.filterBrowser ?? false;
 	const autoloadOnly = options?.autoloadOnly ?? false;
+	const loadOptions = options?.providers === undefined ? { cwd } : { cwd, providers: options.providers };
 
 	// Load MCP servers via capability system
-	const result = await loadCapability<MCPServer>(mcpCapability.id, { cwd });
+	const result = await loadCapability<MCPServer>(mcpCapability.id, loadOptions);
 
 	// Filter out project-level configs if disabled
 	const servers = enableProjectConfig
@@ -139,6 +150,35 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 		const browserResult = filterBrowserMCPServers(configs, sources);
 		configs = browserResult.configs;
 		sources = browserResult.sources;
+	}
+
+	if (options?.forceNoInheritEnvForStdio) {
+		for (const config of Object.values(configs)) {
+			if (isStdioConfig(config)) {
+				config.noInheritEnv = true;
+			}
+		}
+	}
+
+	if (typeof options?.maxServers === "number" && Object.keys(configs).length > options.maxServers) {
+		const keptNames = Object.keys(configs).sort().slice(0, Math.max(0, options.maxServers));
+		const kept = new Set(keptNames);
+		const droppedNames = Object.keys(configs).filter(name => !kept.has(name)).sort();
+		const cappedConfigs: Record<string, MCPServerConfig> = {};
+		const cappedSources: Record<string, SourceMeta> = {};
+		for (const name of keptNames) {
+			cappedConfigs[name] = configs[name];
+			if (sources[name]) {
+				cappedSources[name] = sources[name];
+			}
+		}
+		configs = cappedConfigs;
+		sources = cappedSources;
+		logger.warn("Standalone MCP server cap exceeded", {
+			kept: keptNames.length,
+			dropped: droppedNames.length,
+			skipped: droppedNames.map(name => `mcp:${name}`),
+		});
 	}
 
 	return { configs, exaApiKeys, sources };

--- a/packages/coding-agent/src/runtime-mcp/manager.ts
+++ b/packages/coding-agent/src/runtime-mcp/manager.ts
@@ -149,6 +149,14 @@ export interface MCPDiscoverOptions {
 	filterBrowser?: boolean;
 	/** Only connect servers with autoload !== false (default: false) */
 	autoloadOnly?: boolean;
+	/** Capability provider id allow-list. When omitted, all registered providers are loaded. */
+	providers?: string[];
+	/** Maximum number of eligible servers to return after filtering. */
+	maxServers?: number;
+	/** Maximum number of concurrent connection attempts. When omitted, existing parallel behavior is preserved. */
+	maxConcurrentConnects?: number;
+	/** Force stdio servers to receive only the minimal inherited environment plus explicit env. */
+	forceNoInheritEnvForStdio?: boolean;
 	/** Called when starting to connect to servers */
 	onConnecting?: (serverNames: string[]) => void;
 }
@@ -328,8 +336,11 @@ export class MCPManager {
 			filterExa: options?.filterExa,
 			filterBrowser: options?.filterBrowser,
 			autoloadOnly: options?.autoloadOnly,
+			providers: options?.providers,
+			maxServers: options?.maxServers,
+			forceNoInheritEnvForStdio: options?.forceNoInheritEnvForStdio,
 		});
-		const result = await this.connectServers(configs, sources, options?.onConnecting);
+		const result = await this.connectServers(configs, sources, options?.onConnecting, options?.maxConcurrentConnects);
 		result.exaApiKeys = exaApiKeys;
 		return result;
 	}
@@ -342,6 +353,7 @@ export class MCPManager {
 		configs: Record<string, MCPServerConfig>,
 		sources: Record<string, SourceMeta>,
 		onConnecting?: (serverNames: string[]) => void,
+		maxConcurrentConnects?: number,
 	): Promise<MCPLoadResult> {
 		type ConnectionTask = {
 			name: string;
@@ -359,6 +371,41 @@ export class MCPManager {
 		const reportedErrors = new Set<string>();
 		let allowBackgroundLogging = false;
 		let shouldPublishToolSnapshot = true;
+		const connectionLimit =
+			typeof maxConcurrentConnects === "number" && Number.isInteger(maxConcurrentConnects) && maxConcurrentConnects > 0
+				? maxConcurrentConnects
+				: undefined;
+		let activeConnectionStarts = 0;
+		const waitingConnectionStarts: Array<() => void> = [];
+		const acquireConnectionSlot = async (signal: AbortSignal): Promise<() => void> => {
+			if (connectionLimit === undefined) return () => {};
+			if (signal.aborted) throw new Error("MCP connection aborted before start");
+			if (activeConnectionStarts < connectionLimit) {
+				activeConnectionStarts += 1;
+			} else {
+				await new Promise<void>((resolve, reject) => {
+					const wake = () => {
+						signal.removeEventListener("abort", abort);
+						resolve();
+					};
+					const abort = () => {
+						const index = waitingConnectionStarts.indexOf(wake);
+						if (index >= 0) waitingConnectionStarts.splice(index, 1);
+						reject(new Error("MCP connection aborted before start"));
+					};
+					signal.addEventListener("abort", abort, { once: true });
+					waitingConnectionStarts.push(wake);
+				});
+				activeConnectionStarts += 1;
+			}
+			let released = false;
+			return () => {
+				if (released) return;
+				released = true;
+				activeConnectionStarts -= 1;
+				waitingConnectionStarts.shift()?.();
+			};
+		};
 
 		// Prepare connection tasks
 		const connectionTasks: ConnectionTask[] = [];
@@ -404,16 +451,21 @@ export class MCPManager {
 			this.#pendingConnectionControllers.set(name, connectionAbort);
 			// Resolve auth config before connecting, but do so per-server in parallel.
 			const connectionPromise = (async () => {
-				const resolvedConfig = await this.#resolveAuthConfig(config);
-				return connectToServer(name, resolvedConfig, {
-					signal: connectionAbort.signal,
-					onNotification: (method, params) => {
-						this.#handleServerNotification(name, method, params);
-					},
-					onRequest: (method, params) => {
-						return this.#handleServerRequest(method, params);
-					},
-				});
+				const releaseConnectionSlot = await acquireConnectionSlot(connectionAbort.signal);
+				try {
+					const resolvedConfig = await this.#resolveAuthConfig(config);
+					return await connectToServer(name, resolvedConfig, {
+						signal: connectionAbort.signal,
+						onNotification: (method, params) => {
+							this.#handleServerNotification(name, method, params);
+						},
+						onRequest: (method, params) => {
+							return this.#handleServerRequest(method, params);
+						},
+					});
+				} finally {
+					releaseConnectionSlot();
+				}
 			})().then(
 				async connection => {
 					// Store original config (without resolved tokens) to keep

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -581,6 +581,10 @@ const TOOL_DEFINITION_MARKER = Symbol("__isToolDefinition");
 
 /** Matches the truncation applied to per-server instructions inside `rebuildSystemPrompt`. */
 const MAX_MCP_INSTRUCTIONS_LENGTH = 4000;
+const STANDALONE_STARTUP_MCP_PROVIDERS = ["native", "mcp-json"] as const;
+const STANDALONE_STARTUP_MCP_MAX_SERVERS = 8;
+const STANDALONE_STARTUP_MCP_MAX_CONCURRENT_CONNECTS = 4;
+
 
 let sshCleanupRegistered = false;
 
@@ -1365,6 +1369,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// always-on tools per the plugin product contract.
 		let mcpManager: MCPManager | undefined = options.mcpManager;
 		let ownsMcpManager = false;
+		let installedMcpManagerSingleton: MCPManager | undefined;
 		const customTools: CustomTool[] = [];
 
 		// Add image tools when the active model or configured image providers can generate images.
@@ -1491,11 +1496,57 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				}
 			}
 		}
+		const standaloneMcpEnabled = settings.getGlobal("mcp.enableStandalone") === true;
+		const standaloneProjectMcpEnabled = settings.getGlobal("mcp.enableProjectConfig") === true;
+		// Standalone MCP can execute configured commands; this gate intentionally uses getGlobal so
+		// project settings cannot enable standalone MCP or authorize project MCP. Never weaken to
+		// merged settings.get.
+		if (standaloneMcpEnabled && !options.parentTaskPrefix) {
+			const target = mcpManager ?? new MCPManager(cwd);
+			const createdForStandalone = !mcpManager;
+			target.setAuthStorage(authStorage);
+			const preexistingServers = new Set(target.getConnectedServers());
+			try {
+				const result = await target.discoverAndConnect({
+					providers: [...STANDALONE_STARTUP_MCP_PROVIDERS],
+					enableProjectConfig: standaloneProjectMcpEnabled,
+					filterExa: true,
+					filterBrowser: builtinTools.some(tool => tool.name === "browser"),
+					autoloadOnly: true,
+					maxServers: STANDALONE_STARTUP_MCP_MAX_SERVERS,
+					maxConcurrentConnects: STANDALONE_STARTUP_MCP_MAX_CONCURRENT_CONNECTS,
+					forceNoInheritEnvForStdio: true,
+				});
+				for (const [server, error] of result.errors) {
+					logger.warn("Standalone MCP connect failed", { path: `mcp:${server}`, error });
+				}
+				if (result.connectedServers.length > 0) {
+					mcpManager = target;
+					if (createdForStandalone) ownsMcpManager = true;
+					customTools.push(...(result.tools as CustomTool[]));
+				} else if (createdForStandalone) {
+					await target.disconnectAll().catch(() => {});
+				}
+			} catch (error) {
+				if (createdForStandalone) {
+					await target.disconnectAll().catch(() => {});
+				} else {
+					for (const name of target.getConnectedServers()) {
+						if (!preexistingServers.has(name)) await target.disconnectServer(name).catch(() => {});
+					}
+				}
+				logger.warn("Failed to wire standalone MCP servers", { error });
+			}
+		}
+
 		// Only top-level sessions own the global MCPManager. Subagents already
 		// receive the parent's manager via options.mcpManager; reassigning the
 		// singleton to the same value is a no-op. Keep the gate explicit to mirror
 		// the AsyncJobManager ownership rule.
-		if (mcpManager && !options.parentTaskPrefix) MCPManager.setInstance(mcpManager);
+		if (mcpManager && !options.parentTaskPrefix) {
+			MCPManager.setInstance(mcpManager);
+			installedMcpManagerSingleton = mcpManager;
+		}
 
 		// Custom tool and extension discovery is quarantined from the public GJC utility surface.
 		// Explicit SDK extension factories are still honored; callers use them to
@@ -2268,6 +2319,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				try {
 					await originalDispose();
 				} finally {
+					if (installedMcpManagerSingleton && MCPManager.instance() === installedMcpManagerSingleton) {
+						MCPManager.setInstance(undefined);
+					}
 					agentRegistry.unregister(resolvedAgentId);
 					unsubscribeCredentialDisabled?.();
 				}

--- a/packages/coding-agent/test/config/standalone-mcp-settings.test.ts
+++ b/packages/coding-agent/test/config/standalone-mcp-settings.test.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, test } from "bun:test";
+
+import { defineCapability, getCapability, registerProvider } from "../../src/capability";
+import type { LoadContext, LoadResult, Provider } from "../../src/capability/types";
+import { SETTINGS_SCHEMA } from "../../src/config/settings-schema";
+
+interface TestItem {
+	name: string;
+}
+
+function provider(id: string, displayName: string, priority: number): Provider<TestItem> {
+	return {
+		id,
+		displayName,
+		description: `${displayName} description`,
+		priority,
+		load: (_ctx: LoadContext): Promise<LoadResult<TestItem>> => Promise.resolve({ items: [{ name: displayName }] }),
+	};
+}
+
+describe("standalone MCP settings", () => {
+	test("exposes mcp.enableStandalone as a config-only default-false boolean setting", () => {
+		const setting = SETTINGS_SCHEMA["mcp.enableStandalone"];
+
+		expect(setting.type).toBe("boolean");
+		expect(setting.default).toBe(false);
+		expect(Object.hasOwn(setting, "ui")).toBe(false);
+	});
+
+	test("keeps config JSON schema in sync with additionalProperties locked down", async () => {
+		const schema = await Bun.file(`${import.meta.dir}/../../../../schemas/config.schema.json`).json();
+		const mcp = schema.properties.mcp;
+		const enableStandalone = mcp.properties.enableStandalone;
+
+		expect(enableStandalone.type).toBe("boolean");
+		expect(enableStandalone.default).toBe(false);
+		expect(mcp.additionalProperties).toBe(false);
+	});
+});
+
+describe("capability provider registration", () => {
+	test("keeps the first provider when a duplicate provider id registers for the same capability", () => {
+		const capabilityId = `standalone-mcp-duplicate-provider-${randomUUID()}`;
+		defineCapability<TestItem>({
+			id: capabilityId,
+			displayName: "Standalone MCP duplicate provider test",
+			description: "Test-only capability for duplicate provider registration",
+			key: item => item.name,
+		});
+
+		const first = provider("duplicate-provider", "First provider", 10);
+		const second = provider("duplicate-provider", "Second provider", 100);
+
+		registerProvider(capabilityId, first);
+		registerProvider(capabilityId, second);
+
+		const capability = getCapability<TestItem>(capabilityId);
+		expect(capability?.providers).toHaveLength(1);
+		expect(capability?.providers[0]).toBe(first);
+		expect(capability?.providers[0]?.displayName).toBe("First provider");
+	});
+});

--- a/packages/coding-agent/test/gjc-standalone-mcp-redteam.test.ts
+++ b/packages/coding-agent/test/gjc-standalone-mcp-redteam.test.ts
@@ -1,0 +1,365 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getBundledModel } from "@gajae-code/ai";
+import { logger } from "@gajae-code/utils";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test, vi } from "bun:test";
+import * as z from "zod/v4";
+
+import { defineCapability, getCapability, registerProvider } from "../src/capability";
+import { mcpCapability } from "../src/capability/mcp";
+import type { CapabilityResult, LoadContext, LoadResult, Provider } from "../src/capability/types";
+import { Settings } from "../src/config/settings";
+import * as discovery from "../src/discovery";
+import type { MCPServer } from "../src/discovery";
+import type { CustomTool } from "../src/extensibility/custom-tools/types";
+import { loadAllMCPConfigs } from "../src/runtime-mcp/config";
+import * as configWriter from "../src/runtime-mcp/config-writer";
+import { MCPManager } from "../src/runtime-mcp/manager";
+import type { JsonRpcMessage, MCPServerConfig } from "../src/runtime-mcp/types";
+import { createAgentSession } from "../src/sdk";
+import { SessionManager } from "../src/session/session-manager";
+
+const tempDirs: string[] = [];
+const source = {
+	provider: "native",
+	providerName: "Native",
+	path: "mcp:redteam",
+	level: "user" as const,
+};
+
+interface TestItem {
+	name: string;
+}
+
+function makeTempDir(prefix: string): string {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(cwd);
+	return cwd;
+}
+
+function createStandaloneTool(serverName = "standalone", toolName = "lookup"): CustomTool {
+	return {
+		name: `mcp__${serverName}_${toolName}`,
+		label: `${serverName}/${toolName}`,
+		description: "Standalone MCP red-team fixture tool",
+		mcpServerName: serverName,
+		mcpToolName: toolName,
+		parameters: z.object({ query: z.string() }),
+		async execute() {
+			return { content: [{ type: "text", text: "ok" }] };
+		},
+	} as CustomTool;
+}
+
+function connectedResult(serverName = "standalone") {
+	return {
+		tools: [createStandaloneTool(serverName)],
+		errors: new Map<string, string>(),
+		connectedServers: [serverName],
+		exaApiKeys: [],
+	};
+}
+
+function createGlobalStandaloneSettings(): Settings {
+	const settings = Settings.isolated();
+	settings.set("mcp.enableStandalone", true);
+	return settings;
+}
+
+function createProjectScopedOnlySettings(): Settings {
+	return Settings.isolated({
+		"mcp.enableStandalone": true,
+		"mcp.enableProjectConfig": true,
+	});
+}
+
+function baseOptions(cwd: string, settings: Settings) {
+	return {
+		cwd,
+		settings,
+		sessionManager: SessionManager.inMemory(cwd),
+		model: getBundledModel("openai", "gpt-4o-mini"),
+		enableMCP: false,
+	};
+}
+
+function capabilityResult(items: Array<MCPServer & { _source: typeof source }>): CapabilityResult<MCPServer> {
+	return { items, all: items, warnings: [], providers: ["native"] };
+}
+
+function itemProvider(id: string, displayName: string, priority: number): Provider<TestItem> {
+	return {
+		id,
+		displayName,
+		description: `${displayName} description`,
+		priority,
+		load: (_ctx: LoadContext): Promise<LoadResult<TestItem>> => Promise.resolve({ items: [{ name: displayName }] }),
+	};
+}
+
+beforeEach(() => {
+	MCPManager.resetForTests();
+	spyOn(configWriter, "readDisabledServers").mockResolvedValue([]);
+});
+
+afterEach(() => {
+	mock.restore();
+	vi.restoreAllMocks();
+	MCPManager.resetForTests();
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("standalone MCP red-team adversarial cases", () => {
+	test("PROJECT-CONFIG COERCION: project-scoped flags do not authorize standalone discovery", async () => {
+		const cwd = makeTempDir("gjc-standalone-mcp-redteam-project-");
+		const discover = vi.spyOn(MCPManager.prototype, "discoverAndConnect").mockResolvedValue(connectedResult());
+		const settings = createProjectScopedOnlySettings();
+
+		expect(settings.get("mcp.enableStandalone")).toBe(true);
+		expect(settings.get("mcp.enableProjectConfig")).toBe(true);
+		expect(settings.getGlobal("mcp.enableStandalone")).toBeUndefined();
+		expect(settings.getGlobal("mcp.enableProjectConfig")).toBeUndefined();
+
+		const { session, mcpManager } = await createAgentSession(baseOptions(cwd, settings));
+		try {
+			expect(discover).not.toHaveBeenCalled();
+			expect(mcpManager).toBeUndefined();
+			expect(MCPManager.instance()).toBeUndefined();
+			expect(session.getAllToolNames().filter(name => name.startsWith("mcp__"))).toEqual([]);
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	test("PROVIDER MASQUERADE: duplicate trusted MCP provider id is ignored first-wins", () => {
+		const capability = getCapability<MCPServer>(mcpCapability.id);
+		const trustedNative = capability?.providers.find(provider => provider.id === "native");
+		if (!trustedNative) throw new Error("expected trusted native provider to be registered");
+
+		const foreignProvider: Provider<MCPServer> = {
+			id: "native",
+			displayName: "Foreign native masquerade",
+			description: "Attempts to outrank the trusted native provider",
+			priority: Number.MAX_SAFE_INTEGER,
+			load: (_ctx: LoadContext): Promise<LoadResult<MCPServer>> =>
+				Promise.resolve({
+					items: [
+						{
+							name: "foreign",
+							transport: "stdio" as const,
+							command: "foreign-binary",
+						} as MCPServer,
+					],
+				}),
+		};
+
+		registerProvider(mcpCapability.id, foreignProvider);
+
+		const after = getCapability<MCPServer>(mcpCapability.id);
+		const nativeProviders = after?.providers.filter(provider => provider.id === "native") ?? [];
+		expect(nativeProviders).toHaveLength(1);
+		expect(nativeProviders[0]).toBe(trustedNative);
+		expect(after?.providers).not.toContain(foreignProvider);
+	});
+
+	test("CAP BYPASS: more than eight eligible servers are capped deterministically with sanitized warning and max four connects", async () => {
+		let activeInitializations = 0;
+		let peakInitializations = 0;
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				if (req.method !== "POST") return new Response(null, { status: 405 });
+				let body: JsonRpcMessage;
+				try {
+					body = (await req.json()) as JsonRpcMessage;
+				} catch {
+					return new Response(null, { status: 400 });
+				}
+				const id = "id" in body ? body.id : 0;
+				if ("method" in body && body.method === "initialize") {
+					activeInitializations += 1;
+					peakInitializations = Math.max(peakInitializations, activeInitializations);
+					await Bun.sleep(25);
+					activeInitializations -= 1;
+					return Response.json({
+						jsonrpc: "2.0",
+						id,
+						result: {
+							protocolVersion: "2025-03-26",
+							capabilities: { tools: {} },
+							serverInfo: { name: "redteam", version: "1" },
+						},
+					});
+				}
+				if ("method" in body && body.method === "tools/list") {
+					return Response.json({ jsonrpc: "2.0", id, result: { tools: [] } });
+				}
+				return Response.json({ jsonrpc: "2.0", id, result: {} });
+			},
+		});
+
+		try {
+			const items = Array.from({ length: 10 }, (_, index) => {
+				const name = `server-${String(index).padStart(2, "0")}`;
+				return {
+					name,
+					transport: "http" as const,
+					url: server.url.href,
+					headers: { Authorization: `Bearer secret-${index}` },
+					_source: source,
+				};
+			});
+			const loadSpy = spyOn(discovery, "loadCapability").mockResolvedValue(capabilityResult(items));
+			const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+
+			const loaded = await loadAllMCPConfigs(process.cwd(), {
+				providers: ["native", "mcp-json"],
+				maxServers: 8,
+				autoloadOnly: true,
+			});
+
+			expect(loadSpy).toHaveBeenCalledTimes(1);
+			expect(Object.keys(loaded.configs)).toEqual([
+				"server-00",
+				"server-01",
+				"server-02",
+				"server-03",
+				"server-04",
+				"server-05",
+				"server-06",
+				"server-07",
+			]);
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+			expect(warnSpy.mock.calls[0]?.[0]).toBe("Standalone MCP server cap exceeded");
+			expect(warnSpy.mock.calls[0]?.[1]).toEqual({ kept: 8, dropped: 2, skipped: ["mcp:server-08", "mcp:server-09"] });
+			expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("secret-");
+
+			const manager = new MCPManager(process.cwd());
+			const result = await manager.connectServers(loaded.configs, loaded.sources, undefined, 4);
+			expect(result.errors.size).toBe(0);
+			expect(result.connectedServers.sort()).toEqual(Object.keys(loaded.configs));
+			expect(peakInitializations).toBeLessThanOrEqual(4);
+			await manager.disconnectAll();
+		} finally {
+			await server.stop(true);
+		}
+	});
+
+	test("NOINHERITENV: standalone startup stdio is hardened while explicit env and http/sse are preserved", async () => {
+		const items: Array<MCPServer & { _source: typeof source }> = [
+			{
+				name: "stdio",
+				transport: "stdio",
+				command: "node",
+				env: { KEEP_ME: "yes" },
+				_source: source,
+			},
+			{
+				name: "http",
+				transport: "http",
+				url: "http://example.test/mcp",
+				_source: source,
+			},
+			{
+				name: "sse",
+				transport: "sse",
+				url: "http://example.test/sse",
+				_source: source,
+			},
+		];
+		spyOn(discovery, "loadCapability").mockResolvedValue(capabilityResult(items));
+
+		const result = await loadAllMCPConfigs(process.cwd(), { forceNoInheritEnvForStdio: true });
+
+		expect(result.configs.stdio).toMatchObject({ type: "stdio", command: "node", noInheritEnv: true, env: { KEEP_ME: "yes" } });
+		expect(result.configs.http).toMatchObject({ type: "http", url: "http://example.test/mcp" });
+		expect(result.configs.http).not.toHaveProperty("noInheritEnv");
+		expect(result.configs.sse).toMatchObject({ type: "sse", url: "http://example.test/sse" });
+		expect(result.configs.sse).not.toHaveProperty("noInheritEnv");
+	});
+
+	test("SINGLETON/OWNERSHIP: reused managers are unowned but standalone-created managers are disposed", async () => {
+		const callerCwd = makeTempDir("gjc-standalone-mcp-redteam-caller-");
+		const callerManager = new MCPManager(callerCwd);
+		const callerDiscover = vi.spyOn(callerManager, "discoverAndConnect").mockResolvedValue(connectedResult("caller"));
+		const callerDisconnectAll = vi.spyOn(callerManager, "disconnectAll").mockResolvedValue();
+
+		const callerSession = await createAgentSession({
+			...baseOptions(callerCwd, createGlobalStandaloneSettings()),
+			mcpManager: callerManager,
+		});
+		try {
+			expect(callerDiscover).toHaveBeenCalledTimes(1);
+			expect(callerSession.mcpManager).toBe(callerManager);
+			expect(MCPManager.instance()).toBe(callerManager);
+		} finally {
+			await callerSession.session.dispose();
+		}
+		expect(MCPManager.instance()).toBeUndefined();
+		expect(callerDisconnectAll).not.toHaveBeenCalled();
+
+		const ownedCwd = makeTempDir("gjc-standalone-mcp-redteam-owned-");
+		const ownedDiscover = vi.spyOn(MCPManager.prototype, "discoverAndConnect").mockResolvedValue(connectedResult("owned"));
+		const ownedDisconnectAll = vi.spyOn(MCPManager.prototype, "disconnectAll").mockResolvedValue();
+		const ownedSession = await createAgentSession(baseOptions(ownedCwd, createGlobalStandaloneSettings()));
+		try {
+			expect(ownedDiscover).toHaveBeenCalled();
+			expect(ownedSession.mcpManager).toBeDefined();
+			expect(MCPManager.instance()).toBe(ownedSession.mcpManager);
+		} finally {
+			await ownedSession.session.dispose();
+		}
+		expect(ownedDisconnectAll).toHaveBeenCalled();
+		expect(MCPManager.instance()).toBeUndefined();
+	});
+
+	test("FAILURE ISOLATION/ROLLBACK: thrown connect is contained and reused manager rolls back only new servers", async () => {
+		const cwd = makeTempDir("gjc-standalone-mcp-redteam-rollback-");
+		const callerManager = new MCPManager(cwd);
+		vi.spyOn(callerManager, "discoverAndConnect").mockImplementation(async () => {
+			throw new Error("redteam connect failure");
+		});
+		vi.spyOn(callerManager, "getConnectedServers")
+			.mockReturnValueOnce(["preexisting"])
+			.mockReturnValueOnce(["preexisting", "newly_connected"]);
+		const disconnectServer = vi.spyOn(callerManager, "disconnectServer").mockResolvedValue();
+		const disconnectAll = vi.spyOn(callerManager, "disconnectAll").mockResolvedValue();
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		const { session, mcpManager } = await createAgentSession({
+			...baseOptions(cwd, createGlobalStandaloneSettings()),
+			mcpManager: callerManager,
+		});
+		try {
+			expect(mcpManager).toBe(callerManager);
+			expect(disconnectServer).toHaveBeenCalledTimes(1);
+			expect(disconnectServer).toHaveBeenCalledWith("newly_connected");
+			expect(disconnectAll).not.toHaveBeenCalled();
+			expect(warnSpy.mock.calls[0]?.[0]).toBe("Failed to wire standalone MCP servers");
+			expect(warnSpy.mock.calls[0]?.[1]).toMatchObject({ error: new Error("redteam connect failure") });
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	test("provider first-wins behavior remains capability-local for new capabilities", () => {
+		const capabilityId = `standalone-mcp-redteam-duplicate-${randomUUID()}`;
+		defineCapability<TestItem>({
+			id: capabilityId,
+			displayName: "Red-team duplicate provider capability",
+			description: "Verifies first-wins provider registration",
+			key: item => item.name,
+		});
+		const first = itemProvider("duplicate-provider", "First", 10);
+		const second = itemProvider("duplicate-provider", "Second", 100);
+
+		registerProvider(capabilityId, first);
+		registerProvider(capabilityId, second);
+
+		const capability = getCapability<TestItem>(capabilityId);
+		expect(capability?.providers).toHaveLength(1);
+		expect(capability?.providers[0]).toBe(first);
+	});
+});

--- a/packages/coding-agent/test/gjc-standalone-mcp-session.test.ts
+++ b/packages/coding-agent/test/gjc-standalone-mcp-session.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getBundledModel } from "@gajae-code/ai";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import type { CustomTool } from "@gajae-code/coding-agent/extensibility/custom-tools/types";
+import { MCPManager } from "../src/runtime-mcp";
+import type { MCPLoadResult } from "../src/runtime-mcp/manager";
+import { createAgentSession } from "@gajae-code/coding-agent/sdk";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import * as z from "zod/v4";
+
+const tempDirs: string[] = [];
+
+function createStandaloneTool(name = "mcp__standalone_lookup"): CustomTool {
+	return {
+		name,
+		label: "standalone/lookup",
+		description: "Standalone MCP fixture tool",
+		mcpServerName: "standalone",
+		mcpToolName: "lookup",
+		parameters: z.object({ query: z.string() }),
+		async execute() {
+			return { content: [{ type: "text", text: "ok" }] };
+		},
+	} as CustomTool;
+}
+
+function connectedResult(tool = createStandaloneTool()): MCPLoadResult {
+	return {
+		tools: [tool],
+		errors: new Map(),
+		connectedServers: ["standalone"],
+		exaApiKeys: [],
+	};
+}
+
+function makeTempDir(prefix: string): string {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(cwd);
+	return cwd;
+}
+
+function createSettings(globalStandalone = false): Settings {
+	const settings = Settings.isolated();
+	if (globalStandalone) settings.set("mcp.enableStandalone", true);
+	return settings;
+}
+
+function createProjectScopedOnlySettings(): Settings {
+	return Settings.isolated({
+		"mcp.enableStandalone": true,
+		"mcp.enableProjectConfig": true,
+	});
+}
+
+function baseOptions(cwd: string, settings: Settings) {
+	return {
+		cwd,
+		agentDir: cwd,
+		sessionManager: SessionManager.inMemory(cwd),
+		settings,
+		model: getBundledModel("openai", "gpt-4o-mini"),
+		disableExtensionDiscovery: true,
+		extensions: [],
+		skills: [],
+		contextFiles: [],
+		promptTemplates: [],
+		slashCommands: [],
+		enableMCP: false,
+		enableLsp: false,
+	};
+}
+
+beforeEach(() => {
+	MCPManager.resetForTests();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	MCPManager.resetForTests();
+	for (const d of tempDirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+describe("standalone MCP session bootstrap", () => {
+	test("default-off is a pure no-op", async () => {
+		const cwd = makeTempDir("gjc-standalone-mcp-off-");
+		const discover = vi.spyOn(MCPManager.prototype, "discoverAndConnect");
+
+		const { session, mcpManager } = await createAgentSession(baseOptions(cwd, createSettings()));
+		try {
+			expect(mcpManager).toBeUndefined();
+			expect(session.getAllToolNames()).not.toContain("mcp__standalone_lookup");
+			expect(discover).not.toHaveBeenCalled();
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	test("project-scoped flags cannot enable standalone MCP", async () => {
+		const cwd = makeTempDir("gjc-standalone-mcp-project-");
+		const discover = vi.spyOn(MCPManager.prototype, "discoverAndConnect");
+		const settings = createProjectScopedOnlySettings();
+		expect(settings.get("mcp.enableStandalone")).toBe(true);
+		expect(settings.getGlobal("mcp.enableStandalone")).toBeUndefined();
+
+		const { session, mcpManager } = await createAgentSession(baseOptions(cwd, settings));
+		try {
+			expect(mcpManager).toBeUndefined();
+			expect(session.getAllToolNames()).not.toContain("mcp__standalone_lookup");
+			expect(discover).not.toHaveBeenCalled();
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	test("user-global opt-in wires standalone tools and disposes owned manager", async () => {
+		const cwd = makeTempDir("gjc-standalone-mcp-on-");
+		const discover = vi.spyOn(MCPManager.prototype, "discoverAndConnect").mockResolvedValue(connectedResult());
+		const disconnectAll = vi.spyOn(MCPManager.prototype, "disconnectAll").mockResolvedValue();
+
+		const { session, mcpManager } = await createAgentSession(baseOptions(cwd, createSettings(true)));
+		try {
+			expect(discover).toHaveBeenCalledWith(
+				expect.objectContaining({
+					providers: ["native", "mcp-json"],
+					enableProjectConfig: false,
+					autoloadOnly: true,
+					maxServers: 8,
+					maxConcurrentConnects: 4,
+					forceNoInheritEnvForStdio: true,
+				}),
+			);
+			expect(mcpManager).toBeDefined();
+			expect(MCPManager.instance()).toBe(mcpManager);
+			expect(session.getAllToolNames()).toContain("mcp__standalone_lookup");
+		} finally {
+			await session.dispose();
+		}
+		expect(disconnectAll).toHaveBeenCalled();
+		expect(MCPManager.instance()).toBeUndefined();
+	});
+
+	test("subagent sessions do not spawn standalone MCP", async () => {
+		const cwd = makeTempDir("gjc-standalone-mcp-sub-");
+		const discover = vi.spyOn(MCPManager.prototype, "discoverAndConnect").mockResolvedValue(connectedResult());
+
+		const { session, mcpManager } = await createAgentSession({
+			...baseOptions(cwd, createSettings(true)),
+			parentTaskPrefix: "0-Sub",
+		});
+		try {
+			expect(mcpManager).toBeUndefined();
+			expect(discover).not.toHaveBeenCalled();
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	test("caller-supplied manager is installed but remains unowned", async () => {
+		const cwd = makeTempDir("gjc-standalone-mcp-caller-");
+		const callerManager = new MCPManager(cwd);
+		const discover = vi.spyOn(callerManager, "discoverAndConnect").mockResolvedValue(connectedResult());
+		const disconnectAll = vi.spyOn(callerManager, "disconnectAll").mockResolvedValue();
+
+		const { session, mcpManager } = await createAgentSession({
+			...baseOptions(cwd, createSettings(true)),
+			mcpManager: callerManager,
+		});
+		try {
+			expect(discover).toHaveBeenCalled();
+			expect(mcpManager).toBe(callerManager);
+			expect(MCPManager.instance()).toBe(callerManager);
+			expect(session.getAllToolNames()).toContain("mcp__standalone_lookup");
+		} finally {
+			await session.dispose();
+		}
+		expect(MCPManager.instance()).toBeUndefined();
+		expect(disconnectAll).not.toHaveBeenCalled();
+	});
+
+	test("reused manager rollback disconnects only newly connected servers", async () => {
+		const cwd = makeTempDir("gjc-standalone-mcp-rollback-");
+		const callerManager = new MCPManager(cwd);
+		vi.spyOn(callerManager, "discoverAndConnect").mockRejectedValue(new Error("partial connect"));
+		vi.spyOn(callerManager, "getConnectedServers")
+			.mockReturnValueOnce(["preexisting"])
+			.mockReturnValueOnce(["preexisting", "newly_connected"]);
+		const disconnectServer = vi.spyOn(callerManager, "disconnectServer").mockResolvedValue();
+		const disconnectAll = vi.spyOn(callerManager, "disconnectAll").mockResolvedValue();
+
+		const { session, mcpManager } = await createAgentSession({
+			...baseOptions(cwd, createSettings(true)),
+			mcpManager: callerManager,
+		});
+		try {
+			expect(mcpManager).toBe(callerManager);
+			expect(disconnectServer).toHaveBeenCalledTimes(1);
+			expect(disconnectServer).toHaveBeenCalledWith("newly_connected");
+			expect(disconnectAll).not.toHaveBeenCalled();
+		} finally {
+			await session.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/runtime-mcp/standalone-mcp-config.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/standalone-mcp-config.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { logger } from "@gajae-code/utils";
+import * as discovery from "../../src/discovery";
+import type { CapabilityResult } from "../../src/capability/types";
+import { loadAllMCPConfigs } from "../../src/runtime-mcp/config";
+import * as configWriter from "../../src/runtime-mcp/config-writer";
+import { MCPManager } from "../../src/runtime-mcp/manager";
+import type { JsonRpcMessage, MCPServerConfig } from "../../src/runtime-mcp/types";
+import type { MCPServer } from "../../src/discovery";
+
+const source = {
+	provider: "native",
+	providerName: "Native",
+	path: "mcp:test",
+	level: "user" as const,
+};
+
+function capabilityResult(items: Array<MCPServer & { _source: typeof source }>): CapabilityResult<MCPServer> {
+	return { items, all: items, warnings: [], providers: ["native"] };
+}
+
+beforeEach(() => {
+	spyOn(configWriter, "readDisabledServers").mockResolvedValue([]);
+});
+
+afterEach(() => {
+	mock.restore();
+});
+
+describe("standalone MCP runtime config options", () => {
+	it("threads provider allow-lists into capability loading", async () => {
+		const loadSpy = spyOn(discovery, "loadCapability").mockResolvedValue(capabilityResult([]));
+
+		await loadAllMCPConfigs(process.cwd(), { providers: ["native", "mcp-json"] });
+
+		expect(loadSpy).toHaveBeenCalledTimes(1);
+		expect(loadSpy.mock.calls[0]?.[1]).toEqual({ cwd: process.cwd(), providers: ["native", "mcp-json"] });
+	});
+
+	it("caps eligible servers deterministically and logs only sanitized skipped names", async () => {
+		const items: Array<MCPServer & { _source: typeof source }> = ["zeta", "alpha", "middle"].map(name => ({
+			name,
+			command: "node",
+			env: { SECRET_TOKEN: `secret-${name}` },
+			_source: source,
+		}));
+		spyOn(discovery, "loadCapability").mockResolvedValue(capabilityResult(items));
+		const warnSpy = spyOn(logger, "warn").mockImplementation(() => undefined);
+
+		const result = await loadAllMCPConfigs(process.cwd(), { maxServers: 2 });
+
+		expect(Object.keys(result.configs)).toEqual(["alpha", "middle"]);
+		expect(Object.keys(result.sources)).toEqual(["alpha", "middle"]);
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy.mock.calls[0]?.[0]).toBe("Standalone MCP server cap exceeded");
+		expect(warnSpy.mock.calls[0]?.[1]).toEqual({ kept: 2, dropped: 1, skipped: ["mcp:zeta"] });
+		expect(JSON.stringify(warnSpy.mock.calls[0])).not.toContain("secret-");
+	});
+
+	it("forces noInheritEnv only for stdio configs and preserves explicit env", async () => {
+		spyOn(discovery, "loadCapability").mockResolvedValue(
+			capabilityResult([
+				{ name: "stdio", command: "node", env: { KEEP: "yes" }, _source: source },
+				{ name: "http", transport: "http", url: "http://example.test/mcp", _source: source },
+				{ name: "sse", transport: "sse", url: "http://example.test/sse", _source: source },
+			]),
+		);
+
+		const result = await loadAllMCPConfigs(process.cwd(), { forceNoInheritEnvForStdio: true });
+
+		expect(result.configs.stdio).toMatchObject({ type: "stdio", noInheritEnv: true, env: { KEEP: "yes" } });
+		expect(result.configs.http).not.toHaveProperty("noInheritEnv");
+		expect(result.configs.sse).not.toHaveProperty("noInheritEnv");
+	});
+});
+
+describe("standalone MCP connection concurrency", () => {
+	it("never exceeds maxConcurrentConnects while connecting servers", async () => {
+		let activeInitializations = 0;
+		let peakInitializations = 0;
+		const server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				if (req.method !== "POST") {
+					return new Response(null, { status: 405 });
+				}
+				let body: JsonRpcMessage;
+				try {
+					body = (await req.json()) as JsonRpcMessage;
+				} catch {
+					return new Response(null, { status: 400 });
+				}
+				const id = "id" in body ? body.id : 0;
+				if ("method" in body && body.method === "initialize") {
+					activeInitializations += 1;
+					peakInitializations = Math.max(peakInitializations, activeInitializations);
+					await Bun.sleep(50);
+					activeInitializations -= 1;
+					return Response.json({
+						jsonrpc: "2.0",
+						id,
+						result: {
+							protocolVersion: "2025-03-26",
+							capabilities: { tools: {} },
+							serverInfo: { name: "test", version: "1" },
+						},
+					});
+				}
+				if ("method" in body && body.method === "tools/list") {
+					return Response.json({ jsonrpc: "2.0", id, result: { tools: [] } });
+				}
+				return Response.json({ jsonrpc: "2.0", id, result: {} });
+			},
+		});
+		try {
+			const manager = new MCPManager(process.cwd());
+			const configs: Record<string, MCPServerConfig> = Object.fromEntries(
+				Array.from({ length: 5 }, (_, index) => [`server-${index}`, { type: "http" as const, url: server.url.href, timeout: 1_000 }]),
+			);
+
+			const result = await manager.connectServers(configs, {}, undefined, 2);
+
+			expect(result.errors.size).toBe(0);
+			expect(result.connectedServers.sort()).toEqual(["server-0", "server-1", "server-2", "server-3", "server-4"]);
+			expect(peakInitializations).toBeLessThanOrEqual(2);
+			await manager.disconnectAll();
+		} finally {
+			await server.stop(true);
+		}
+	});
+});

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1936,6 +1936,10 @@
 					"type": "boolean",
 					"default": false
 				},
+				"enableStandalone": {
+					"type": "boolean",
+					"default": false
+				},
 				"discoveryMode": {
 					"type": "boolean",
 					"default": false


### PR DESCRIPTION
## Summary

Adds a default-off, config-file-only **`mcp.enableStandalone`** setting that, when enabled in **user/global** config, connects standalone MCP servers (`native` + `mcp-json` sources — i.e. `~/.gjc/agent/mcp.json` and project `.mcp.json` registered via `gjc mcp add`) into **top-level** sessions at startup.

This productizes, as a proper opt-in, what was previously a local monkey-patch that hot-edited the installed `sdk.ts` after every reinstall. Default behavior is unchanged: with the flag off, there is zero discovery, connection, tool exposure, manager creation, or logging.

## Security posture (why this is safe to re-open a quarantined surface)

Standalone MCP can execute configured stdio commands, so the opt-in is deliberately narrow and adversarially reviewed:

- **User-global authorization only.** Both `mcp.enableStandalone` and `mcp.enableProjectConfig` are read via `settings.getGlobal(...)`, never merged `settings.get(...)`. A checked-in project config can therefore **never** enable or authorize standalone MCP — closing a repo-clone → arbitrary-command-execution vector.
- **Trusted provider allow-list.** Startup is limited to the `native` and `mcp-json` providers; the marketplace `claude-plugins` provider is excluded (it already has its own always-on path). `registerProvider` now ignores a duplicate provider id for a capability (first-registration-wins), blocking a foreign provider from masquerading as `native`/`mcp-json`.
- **Reduced env exposure.** Standalone startup stdio defaults to `noInheritEnv: true` (minimal OS allowlist + explicit per-server `env`).
- **Bounded startup.** Hard caps of 8 eligible servers and 4 concurrent connects; extras are skipped with a sanitized warning (counts + `mcp:<name>` only).
- **Lifecycle correctness.** Singleton install is tracked separately from ownership and cleared on dispose **without** disconnecting unowned/caller-supplied managers; a reused manager's failure rollback disconnects only newly-connected servers (never `disconnectAll` a reused manager).
- **Subagents never spawn** — they inherit the parent manager via the existing singleton path.
- `mcpDiscoveryEnabled` stays `false`; no `/settings` UI in this PR.

## Usage

```
gjc config set mcp.enableStandalone true          # user/global config
gjc config set mcp.enableProjectConfig true       # optional: also allow project .mcp.json
```

## Changes

- `config/settings-schema.ts` + `schemas/config.schema.json` (regenerated) — new `mcp.enableStandalone` boolean, default false.
- `sdk.ts` — gated standalone wiring before the singleton gate; ownership/singleton/dispose/rollback; startup constants.
- `runtime-mcp/config.ts` + `manager.ts` — optional `providers` / `maxServers` / `maxConcurrentConnects` / `forceNoInheritEnvForStdio` threading + bounded connection semaphore (fully backward-compatible; existing callers unchanged).
- `capability/index.ts` — first-wins duplicate provider-id guard.
- `CHANGELOG.md`.

## Testing

New suites (all passing) covering: default-off no-op (spy asserts no discovery), project-scope coercion no-op, provider masquerade rejection, provider allow-list, server/concurrency caps, `noInheritEnv`, subagent no-spawn, singleton clear without disconnecting caller managers, and reused-manager rollback.

```
bun test packages/coding-agent/test/gjc-standalone-mcp-redteam.test.ts \
         packages/coding-agent/test/config/standalone-mcp-settings.test.ts \
         packages/coding-agent/test/runtime-mcp/standalone-mcp-config.test.ts \
         packages/coding-agent/test/gjc-standalone-mcp-session.test.ts \
         packages/coding-agent/test/gjc-plugin-mcp-session.test.ts
# 23 pass, 0 fail

bun --cwd=packages/coding-agent run check:types   # no new errors
bun run check:schemas                              # config.schema.json in sync
```

## Notes

- Targets `dev`.
- Out of scope: the local patch also bumped a specific remote server's `timeout`; that is a separate per-server/UX follow-up and is intentionally not bundled here.
