### PR TITLE
Persist Telegram seen update ids

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - `telegram_send` now rejects files over Telegram's document upload limit before reading them into memory or handing them to the notification sink.
 - `telegram_send` now rejects file attachments while Telegram notification redaction is enabled, preventing explicit file sends from bypassing the redaction boundary.
+- Telegram notification daemons now persist consumed update ids so threaded replies are not reinjected after a daemon restart replays old `getUpdates` entries.
 - Telegram notify setup now hides the interactive BotFather token prompt input, preventing the raw bot token from being echoed into terminal scrollback while pairing notifications.
 - Telegram unattended workflow-gate listeners are now disposed when a notification session stops, preventing stale stopped servers from retaining future gate emissions after shutdown or notification restart.
 - Telegram notification setup and daemon delivery now reject non-private Telegram chat ids before saving configuration, creating forum topics, or sending session content, preserving the private-chat-only routing boundary.

--- a/packages/coding-agent/src/notifications/daemon-paths.ts
+++ b/packages/coding-agent/src/notifications/daemon-paths.ts
@@ -7,6 +7,7 @@ export interface DaemonPaths {
 	roots: string;
 	steal: string;
 	aliases: string;
+	seenUpdates: string;
 }
 
 export function daemonPaths(agentDir: string): DaemonPaths {
@@ -18,5 +19,6 @@ export function daemonPaths(agentDir: string): DaemonPaths {
 		roots: path.join(dir, "telegram-daemon.roots.json"),
 		steal: path.join(dir, "telegram-daemon.steal"),
 		aliases: path.join(dir, "telegram-callback-aliases.json"),
+		seenUpdates: path.join(dir, "telegram-seen-updates.json"),
 	};
 }

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -126,6 +126,7 @@ const TYPING_REFRESH_INTERVAL_MS = 4_000;
 // messages: queued on receipt, consumed once a turn picks the message up.
 const QUEUED_REACTION = "👀";
 const PENDING_TOPIC_FRAME_LIMIT = 20;
+const SEEN_UPDATE_ID_LIMIT = 1_000;
 const CONSUMED_REACTION = "✅";
 
 function splitTelegramPlainText(text: string, max = TELEGRAM_MESSAGE_LIMIT): string[] {
@@ -1187,7 +1188,7 @@ export class TelegramNotificationDaemon {
 			return true;
 		}
 		if (updateId !== undefined && this.dispatchState.seenUpdateIds.has(updateId)) return true;
-		if (updateId !== undefined) this.dispatchState.seenUpdateIds.add(updateId);
+		if (updateId !== undefined) await this.rememberSeenUpdateId(updateId);
 
 		if (parsed.kind === "usage" || parsed.kind === "reject") {
 			await reply(parsed.message);
@@ -1332,6 +1333,51 @@ export class TelegramNotificationDaemon {
 		const paths = daemonPaths(this.opts.settings.getAgentDir());
 		await ensureDir(this.fsImpl, paths.dir);
 		await writeJsonAtomic(this.fsImpl, paths.aliases, this.aliasTable.serialize());
+	}
+
+	async loadSeenUpdateIds(): Promise<void> {
+		const raw = await readJson<{ updateIds?: unknown }>(
+			this.fsImpl,
+			daemonPaths(this.opts.settings.getAgentDir()).seenUpdates,
+		);
+		this.dispatchState.seenUpdateIds.clear();
+		const updateIds = Array.isArray(raw?.updateIds) ? raw.updateIds : [];
+		for (const updateId of updateIds) {
+			if (Number.isSafeInteger(updateId) && Number(updateId) >= 0) {
+				this.dispatchState.seenUpdateIds.add(Number(updateId));
+			}
+		}
+		this.pruneSeenUpdateIds();
+	}
+
+	async persistSeenUpdateIds(): Promise<void> {
+		const paths = daemonPaths(this.opts.settings.getAgentDir());
+		await ensureDir(this.fsImpl, paths.dir);
+		await writeJsonAtomic(this.fsImpl, paths.seenUpdates, {
+			version: 1,
+			updateIds: [...this.dispatchState.seenUpdateIds].slice(-SEEN_UPDATE_ID_LIMIT),
+		});
+	}
+
+	private pruneSeenUpdateIds(): void {
+		let extra = this.dispatchState.seenUpdateIds.size - SEEN_UPDATE_ID_LIMIT;
+		if (extra <= 0) return;
+		for (const updateId of this.dispatchState.seenUpdateIds) {
+			this.dispatchState.seenUpdateIds.delete(updateId);
+			extra -= 1;
+			if (extra <= 0) break;
+		}
+	}
+
+	private async rememberSeenUpdateId(updateId: number): Promise<void> {
+		if (!Number.isSafeInteger(updateId) || updateId < 0) return;
+		this.dispatchState.seenUpdateIds.add(updateId);
+		this.pruneSeenUpdateIds();
+		try {
+			await this.persistSeenUpdateIds();
+		} catch (err) {
+			logger.warn(`notifications: failed to persist Telegram update id ${updateId}: ${String(err)}`);
+		}
 	}
 
 	async scanRoots(): Promise<void> {
@@ -2080,7 +2126,6 @@ export class TelegramNotificationDaemon {
 			});
 			if (inbound.kind === "duplicate") return;
 			if (inbound.kind === "inject") {
-				this.dispatchState.seenUpdateIds.add(inbound.updateId);
 				const session = this.sessions.get(inbound.sessionId);
 				if (session?.ws.readyState === WebSocket.OPEN) {
 					const attachmentResult = inbound.attachment
@@ -2105,6 +2150,7 @@ export class TelegramNotificationDaemon {
 								token: session.token,
 							}),
 						);
+						await this.rememberSeenUpdateId(inbound.updateId);
 						if (inbound.messageId !== undefined) await this.setReaction(inbound.messageId, QUEUED_REACTION);
 						return;
 					}
@@ -2123,6 +2169,7 @@ export class TelegramNotificationDaemon {
 									},
 						),
 					);
+					await this.rememberSeenUpdateId(inbound.updateId);
 					// User turns get a native delivery double-check: queued on receipt,
 					// flipped to consumed when the session acks the turn that picks it
 					// up. Config commands are not user turns and get no reaction.
@@ -2196,6 +2243,7 @@ export class TelegramNotificationDaemon {
 			await this.registerBotCommands();
 			await this.loadAliases();
 			await this.loadTopics();
+			await this.loadSeenUpdateIds();
 			await this.runScan();
 			// Owner-only: start the session-lifecycle control server now that
 			// ownership is confirmed (singleton-safe). Best-effort; degrades.
@@ -2256,6 +2304,7 @@ export class TelegramNotificationDaemon {
 			// (e.g. after reload) reloads aliases/topics seamlessly.
 			await this.persistAliases().catch(() => undefined);
 			await this.persistTopics().catch(() => undefined);
+			await this.persistSeenUpdateIds().catch(() => undefined);
 			await this.opts.control?.clear?.(this.opts.ownerId).catch(() => undefined);
 			await releaseDaemonOwnership({
 				settings: this.opts.settings,

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -786,6 +786,61 @@ describe("telegram daemon", () => {
 		expect(sent.some(frame => frame.type === "reply")).toBe(false);
 	});
 
+	test("persisted seen update ids suppress duplicate threaded injection after restart", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+		});
+		daemon.connectSession("S", "ws://s", "ts");
+		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
+			type: "identity_header",
+			sessionId: "S",
+			repo: "r",
+			branch: "b",
+		});
+		const threadId = bot.calls.find(c => c.method === "sendMessage")!.body.message_thread_id;
+
+		await daemon.handleTelegramUpdate({
+			update_id: 77,
+			message: { chat: { id: 42 }, message_thread_id: threadId, text: "repeat once", message_id: 100 },
+		});
+
+		const sent = FakeWs.instances[0]!.sent.map(frame => JSON.parse(frame));
+		expect(sent.some(frame => frame.type === "user_message" && frame.text === "repeat once")).toBe(true);
+		const seenState = JSON.parse(fs.readFileSync(daemonPaths(agentDir).seenUpdates, "utf8")) as {
+			updateIds: number[];
+		};
+		expect(seenState.updateIds).toContain(77);
+
+		FakeWs.instances = [];
+		const restarted = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner-2",
+			botToken: "tok",
+			chatId: "42",
+			botApi: new FakeBotApi(),
+			WebSocketImpl: FakeWs as any,
+		});
+		await restarted.loadTopics();
+		await restarted.loadSeenUpdateIds();
+		restarted.connectSession("S", "ws://s2", "ts2");
+
+		await restarted.handleTelegramUpdate({
+			update_id: 77,
+			message: { chat: { id: 42 }, message_thread_id: threadId, text: "repeat once", message_id: 101 },
+		});
+
+		expect(FakeWs.instances[0]!.sent).toHaveLength(0);
+	});
+
 	test("runDaemonSmoke exits without polling and emits no token", async () => {
 		const agentDir = tempAgentDir();
 		await runDaemonSmoke({ agentDir });


### PR DESCRIPTION
## Summary
- persist the bounded set of consumed Telegram update ids under the daemon state directory
- reload seen update ids on daemon startup so replayed threaded messages are treated as duplicates
- record update ids after threaded delivery and lifecycle command consumption, with final persistence on shutdown

Supersedes closed #1622 after rebasing onto current `dev` following #1621.

## Verification
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun node_modules/.bin/biome check packages/coding-agent/src/notifications/daemon-paths.ts packages/coding-agent/src/notifications/telegram-daemon.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts packages/coding-agent/CHANGELOG.md`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`
