### PR TITLE
fix(utils): anchor slash-containing gitignore patterns to their gitignore directory

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Deduplicated `globPaths` results so a path is returned at most once even when overlapping glob patterns (e.g. `["**/*.ts", "src/*.ts"]`) both match the same file.
+- Anchored slash-containing `.gitignore` patterns (e.g. `sub/skip.ts`) to their `.gitignore`'s directory per git semantics instead of matching them at any depth, so `globPaths` with `gitignore: true` no longer drops same-named paths (e.g. `other/sub/skip.ts`) that git actually tracks.
 
 ### Fixed
 

--- a/packages/utils/src/glob.ts
+++ b/packages/utils/src/glob.ts
@@ -70,20 +70,25 @@ function parseGitignorePatterns(content: string, gitignoreDir: string, baseDir: 
 			} else {
 				patterns.push(pattern);
 			}
+		} else if (pattern.includes("/") && !pattern.startsWith("**/")) {
+			// Separator in the middle: git anchors these to the .gitignore's
+			// directory, same as rooted patterns
+			const absolutePattern = path.join(gitignoreDir, pattern);
+			const relativeToBase = path.relative(baseDir, absolutePattern);
+			if (relativeToBase.startsWith("..")) {
+				// Pattern is outside the search directory, skip
+				continue;
+			}
+			pattern = relativeToBase.replace(/\\/g, "/");
+			patterns.push(pattern);
+			if (isDirectoryOnly) {
+				patterns.push(`${pattern}/**`);
+			}
 		} else {
-			// Unrooted pattern: match anywhere in the tree
-			if (pattern.includes("/")) {
-				// Contains slash: match from any directory level
-				patterns.push(`**/${pattern}`);
-				if (isDirectoryOnly) {
-					patterns.push(`**/${pattern}/**`);
-				}
-			} else {
-				// No slash: match file/dir name anywhere
-				patterns.push(`**/${pattern}`);
-				if (isDirectoryOnly) {
-					patterns.push(`**/${pattern}/**`);
-				}
+			// No middle separator: match file/dir name anywhere in the tree
+			patterns.push(`**/${pattern}`);
+			if (isDirectoryOnly) {
+				patterns.push(`**/${pattern}/**`);
 			}
 		}
 	}

--- a/packages/utils/test/glob.test.ts
+++ b/packages/utils/test/glob.test.ts
@@ -54,4 +54,72 @@ describe("globPaths", () => {
 		expect(results.sort()).toEqual(["src/a.ts", "src/b.ts"]);
 		expect(results.length).toBe(new Set(results).size);
 	});
+
+	it("anchors slash-containing gitignore patterns to the gitignore directory", async () => {
+		const cwd = await makeTempDir();
+		await mkdir(join(cwd, "sub"), { recursive: true });
+		await mkdir(join(cwd, "other", "sub"), { recursive: true });
+		await writeFile(join(cwd, ".gitignore"), "sub/skip.ts\n");
+		await writeFile(join(cwd, "sub", "skip.ts"), "export {};\n");
+		await writeFile(join(cwd, "other", "sub", "skip.ts"), "export {};\n");
+
+		const results = await globPaths("**/*.ts", { cwd, gitignore: true });
+
+		expect(results.sort()).toEqual(["other/sub/skip.ts"]);
+	});
+
+	it("anchors slash-containing directory gitignore patterns to the gitignore directory", async () => {
+		const cwd = await makeTempDir();
+		await mkdir(join(cwd, "sub", "dist"), { recursive: true });
+		await mkdir(join(cwd, "other", "sub", "dist"), { recursive: true });
+		await writeFile(join(cwd, ".gitignore"), "sub/dist/\n");
+		await writeFile(join(cwd, "sub", "dist", "skip.ts"), "export {};\n");
+		await writeFile(join(cwd, "other", "sub", "dist", "keep.ts"), "export {};\n");
+
+		const results = await globPaths("**/*.ts", { cwd, gitignore: true });
+
+		expect(results.sort()).toEqual(["other/sub/dist/keep.ts"]);
+	});
+
+	it("matches slash-free gitignore patterns at any depth", async () => {
+		const cwd = await makeTempDir();
+		await mkdir(join(cwd, "sub"), { recursive: true });
+		await mkdir(join(cwd, "other", "sub"), { recursive: true });
+		await writeFile(join(cwd, ".gitignore"), "skip.ts\n");
+		await writeFile(join(cwd, "sub", "skip.ts"), "export {};\n");
+		await writeFile(join(cwd, "other", "sub", "skip.ts"), "export {};\n");
+		await writeFile(join(cwd, "sub", "keep.ts"), "export {};\n");
+
+		const results = await globPaths("**/*.ts", { cwd, gitignore: true });
+
+		expect(results.sort()).toEqual(["sub/keep.ts"]);
+	});
+
+	it("matches **/-prefixed gitignore patterns at any depth", async () => {
+		const cwd = await makeTempDir();
+		await mkdir(join(cwd, "sub"), { recursive: true });
+		await mkdir(join(cwd, "other", "sub"), { recursive: true });
+		await writeFile(join(cwd, ".gitignore"), "**/sub/skip.ts\n");
+		await writeFile(join(cwd, "sub", "skip.ts"), "export {};\n");
+		await writeFile(join(cwd, "other", "sub", "skip.ts"), "export {};\n");
+		await writeFile(join(cwd, "sub", "keep.ts"), "export {};\n");
+
+		const results = await globPaths("**/*.ts", { cwd, gitignore: true });
+
+		expect(results.sort()).toEqual(["sub/keep.ts"]);
+	});
+
+	it("anchors parent-directory gitignore patterns relative to that gitignore", async () => {
+		const root = await makeTempDir();
+		const cwd = join(root, "proj");
+		await mkdir(join(cwd, "sub"), { recursive: true });
+		await mkdir(join(cwd, "other", "sub"), { recursive: true });
+		await writeFile(join(root, ".gitignore"), "proj/sub/skip.ts\n");
+		await writeFile(join(cwd, "sub", "skip.ts"), "export {};\n");
+		await writeFile(join(cwd, "other", "sub", "skip.ts"), "export {};\n");
+
+		const results = await globPaths("**/*.ts", { cwd, gitignore: true });
+
+		expect(results.sort()).toEqual(["other/sub/skip.ts"]);
+	});
 });


### PR DESCRIPTION
## What

- Anchor slash-containing unrooted `.gitignore` patterns (e.g. `sub/skip.ts`) to the directory of the `.gitignore` that declares them, matching git's documented semantics, instead of rewriting them to `**/<pattern>`.
- Keep name-only patterns (`skip.ts`) and `**/`-prefixed patterns matching at any depth, unchanged.
- Add regression tests covering anchored file patterns, anchored directory-only patterns (`sub/dist/`), name-only patterns, `**/`-prefixed patterns, and anchoring for a parent-directory `.gitignore`.

## Why

In `parseGitignorePatterns` (`packages/utils/src/glob.ts`), the `pattern.includes("/")` and no-slash branches were byte-for-byte identical: both emitted `**/${pattern}`. Per gitignore semantics ("If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular .gitignore file itself"), a pattern like `sub/skip.ts` must only ignore `./sub/skip.ts` — but `globPaths` with `gitignore: true` also dropped `./other/sub/skip.ts`, a path git actually tracks (verified against real `git status --ignored`).

Since `globPaths({ gitignore: true })` backs file-mention autocomplete, `grep-cli`, discovery, and `workspace-tree`, those surfaces silently omitted real, tracked files whenever a repo's `.gitignore` used slash-containing unrooted patterns.

The new "anchors slash-containing gitignore patterns" tests fail on current `dev` (both files are dropped; expected only the anchored one) and pass with this change.

## Testing

- `bun test packages/utils/test/glob.test.ts` (new tests fail before the fix, pass after; 8 pass)
- `bun test packages/utils/test/` (full package suite, 115 pass)
- `bun test packages/coding-agent/test/file-mentions.test.ts packages/coding-agent/test/workspace-tree.test.ts` (downstream consumers, 11 pass)
- `bun test packages/tui/test/autocomplete.test.ts packages/coding-agent/test/discovery/` (downstream consumers, 122 pass)
- `bun node_modules/.bin/biome check packages/utils/src/glob.ts packages/utils/test/glob.test.ts`
- `bun --cwd=packages/utils run check:types`
- `git diff --check`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
