### PR TITLE
fix(coding-agent): default custom gpt-5.5 context to Codex-safe 272K

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `gjc completion inshellisense`, which generates or installs a Fig/withfig-compatible `gjc` completion spec for Microsoft inshellisense without adding inshellisense as a runtime dependency.
 
 ### Fixed
+- Custom-provider `gpt-5.5` entries without an explicit `contextWindow` now default to the 272K Codex prompt budget unless the provider uses first-party `openai-responses`, so Codex passthrough proxies (e.g. CLIProxyAPI) compact in time instead of dying with `context_length_exceeded` at ~272K while the registry advertises 1M.
 - `telegram_send` now rejects files over Telegram's document upload limit before reading them into memory or handing them to the notification sink.
 - `telegram_send` now rejects file attachments while Telegram notification redaction is enabled, preventing explicit file sends from bypassing the redaction boundary.
 - Telegram notification daemons now persist consumed update ids so threaded replies are not reinjected after a daemon restart replays old `getUpdates` entries.

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -923,10 +923,22 @@ function resolveCustomModelReference(modelId: string): Model<Api> | undefined {
 }
 
 function applyStandaloneCustomModelPolicies(model: CustomModelOverlay): CustomModelOverlay {
-	if (model.id !== "gpt-5.4" || model.provider === "github-copilot" || model.contextWindow !== undefined) {
+	if (model.contextWindow !== undefined) {
 		return model;
 	}
-	return { ...model, contextWindow: 1_000_000 };
+	if (model.id === "gpt-5.4" && model.provider !== "github-copilot") {
+		return { ...model, contextWindow: 1_000_000 };
+	}
+	// Custom GPT-5.5 endpoints that are not first-party `openai-responses` are
+	// typically Codex passthrough proxies (e.g. CLIProxyAPI fronting
+	// chatgpt.com/backend-api/codex), where the request path enforces the 272K
+	// prompt budget even though the model advertises a 1M total window.
+	// Without this default the bundled reference resolves to 1M, compaction
+	// never fires in time, and requests die with context_length_exceeded.
+	if (model.id === "gpt-5.5" && model.api !== "openai-responses") {
+		return { ...model, contextWindow: 272_000 };
+	}
+	return model;
 }
 
 function finalizeCustomModel(model: CustomModelOverlay, options: CustomModelBuildOptions): Model<Api> {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1151,6 +1151,50 @@ describe("ModelRegistry", () => {
 			expect(registry.find("openai", "gpt-5.4")?.contextWindow).toBe(256000);
 		});
 
+		test("custom-only gpt-5.5 completions provider defaults to the Codex-safe context window", () => {
+			writeRawModelsJson({
+				"my-proxy": {
+					baseUrl: "http://127.0.0.1:8317/v1",
+					apiKey: "TEST_KEY",
+					api: "openai-completions",
+					models: [{ id: "gpt-5.5" }],
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const model = registry.find("my-proxy", "gpt-5.5");
+			expect(model?.contextWindow).toBe(272_000);
+			expect(model?.baseUrl).toBe("http://127.0.0.1:8317/v1");
+		});
+
+		test("custom gpt-5.5 responses provider keeps the first-party context window when contextWindow is omitted", () => {
+			writeRawModelsJson({
+				"my-proxy": {
+					baseUrl: "https://my-proxy.example.com/v1",
+					apiKey: "TEST_KEY",
+					api: "openai-responses",
+					models: [{ id: "gpt-5.5" }],
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			expect(registry.find("my-proxy", "gpt-5.5")?.contextWindow).toBe(1_000_000);
+		});
+
+		test("custom gpt-5.5 completions provider preserves its explicit context window", () => {
+			writeRawModelsJson({
+				"my-proxy": {
+					baseUrl: "http://127.0.0.1:8317/v1",
+					apiKey: "TEST_KEY",
+					api: "openai-completions",
+					models: [{ id: "gpt-5.5", contextWindow: 400000 }],
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			expect(registry.find("my-proxy", "gpt-5.5")?.contextWindow).toBe(400000);
+		});
+
 		test("modelOverrides can still patch a custom gpt-5.4 replacement", () => {
 			writeRawModelsJson({
 				openai: {


### PR DESCRIPTION
## What changed

`applyStandaloneCustomModelPolicies` now defaults omitted `contextWindow` on custom-provider `gpt-5.5` entries to **272,000** unless the provider api is first-party `openai-responses` (which keeps the existing 1M reference). Explicit `contextWindow` values in `models.yml` still win, and the existing custom `gpt-5.4` → 1M policy is unchanged.

## Why

Custom providers that expose `gpt-5.5` without an explicit `contextWindow` inherit the largest bundled reference for that id, which resolves to 1M. But non-`openai-responses` custom endpoints fronting gpt-5.5 are, in practice, Codex passthrough proxies (e.g. CLIProxyAPI forwarding to `chatgpt.com/backend-api/codex/responses`), where the request path enforces the 272K prompt budget — the same reason the bundled `openai-codex` provider is clamped to 272K (#873, #1231, #1232, issue #1230).

With the 1M default, compaction is paced against capacity the request path doesn't have, so sessions hard-die with `400 Your input exceeds the context window of this model` instead of compacting. Real-world data from an affected setup (CLIProxyAPI on `openai-completions`): 234 captured HTTP-400 request dumps and 219 session deaths, with the context size recorded at failure clustering exactly at the Codex cap — median 269K, p25 266K, p75 271K, max 288K, zero failures at or above 400K.

This is the custom-provider analogue of #1230: the registry should not advertise capacity the effective request path cannot use. A conservative default fails safe (earlier compaction); the optimistic default fails hard (session death). Users who genuinely have a larger window behind their proxy can still declare `contextWindow` explicitly.

## Tests

- `bun test packages/coding-agent/test/model-registry.test.ts` — 122 pass (3 new: completions-api default → 272K, responses-api default keeps 1M, explicit value preserved)
- `bun run check` — clean

## Changelog

Added an entry under `packages/coding-agent/CHANGELOG.md` → Unreleased → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)