### PR TITLE
fix: apply CLI API keys after lazy model resolution

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -37,6 +37,7 @@ import type { ExtensionUIContext } from "./extensibility/extensions/types";
 import type { InteractiveMode } from "./modes/interactive-mode";
 import { initTheme, stopThemeWatcher } from "./modes/theme/theme";
 import type { SubmittedUserInput } from "./modes/types";
+import { applyCliRuntimeApiKeyOverride } from "./runtime-api-key";
 import type { MCPManager } from "./runtime-mcp";
 import {
 	type CreateAgentSessionOptions,
@@ -296,9 +297,7 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 			startupModel: args.baseOptions.model,
 			startupThinkingLevel: args.baseOptions.thinkingLevel,
 		});
-		if (args.parsedArgs.apiKey && !args.baseOptions.model && nextSession.model) {
-			args.authStorage.setRuntimeApiKey(nextSession.model.provider, args.parsedArgs.apiKey);
-		}
+		applyCliRuntimeApiKeyOverride(args.authStorage, args.parsedArgs.apiKey, nextSession.model);
 		applyExtensionFlagValues(nextSession, args.rawArgs);
 		return nextSession;
 	};
@@ -969,9 +968,7 @@ export async function runRootCommand(
 			);
 			process.exit(1);
 		}
-		if (sessionOptions.model) {
-			authStorage.setRuntimeApiKey(sessionOptions.model.provider, parsedArgs.apiKey);
-		}
+		applyCliRuntimeApiKeyOverride(authStorage, parsedArgs.apiKey, sessionOptions.model);
 	}
 
 	const createAgentSessionImpl = deps.createAgentSession ?? createAgentSession;
@@ -1004,9 +1001,7 @@ export async function runRootCommand(
 			sessionOptions,
 			{ skipPostCreateModelRefresh: hasRootStartupProfile },
 		);
-		if (parsedArgs.apiKey && !sessionOptions.model && session.model) {
-			authStorage.setRuntimeApiKey(session.model.provider, parsedArgs.apiKey);
-		}
+		applyCliRuntimeApiKeyOverride(authStorage, parsedArgs.apiKey, session.model);
 
 		// Research-mode (RLM) preset: hard tool-boundary assertion after the registry is assembled.
 		if (deps.rlmPreset?.onSessionCreated) {

--- a/packages/coding-agent/src/runtime-api-key.ts
+++ b/packages/coding-agent/src/runtime-api-key.ts
@@ -1,0 +1,16 @@
+export interface RuntimeApiKeyTarget {
+	setRuntimeApiKey(provider: string, apiKey: string): void;
+}
+
+export interface RuntimeApiKeyModel {
+	provider: string;
+}
+
+export function applyCliRuntimeApiKeyOverride(
+	target: RuntimeApiKeyTarget,
+	apiKey: string | undefined,
+	model: RuntimeApiKeyModel | undefined,
+): void {
+	if (!apiKey || !model) return;
+	target.setRuntimeApiKey(model.provider, apiKey);
+}

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -13,6 +13,7 @@ import {
 import type { Model } from "@gajae-code/ai";
 import { TempDir } from "@gajae-code/utils";
 import { Settings } from "../src/config/settings";
+import type { ExtensionAPI } from "../src/extensibility/extensions";
 import { createAcpConnection } from "../src/modes/acp/acp-mode";
 import type { AgentSession } from "../src/session/agent-session";
 import { AuthStorage } from "../src/session/auth-storage";
@@ -186,30 +187,28 @@ describe("ACP lazy startup", () => {
 		}
 	});
 
-	it.skip("applies CLI runtime API keys after ACP lazy session creation resolves extension models", async () => {
+	it("applies CLI runtime API keys after ACP lazy session creation resolves extension models", async () => {
 		using tempDir = TempDir.createSync("@gjc-acp-lazy-api-key-");
 		const cwd = tempDir.path();
 
-		await Bun.write(
-			path.join(cwd, "runtime-provider.ts"),
-			`export default function(pi) {
-	pi.registerProvider("runtime-provider", {
-		baseUrl: "https://runtime.example.com/v1",
-		apiKey: "extension-key",
-		api: "openai-completions",
-		models: [{
-			id: "runtime-model",
-			name: "Runtime Model",
-			reasoning: false,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 128000,
-			maxTokens: 8192,
-		}],
-	});
-}
-`,
-		);
+		const registerRuntimeProvider = (api: ExtensionAPI): void => {
+			api.registerProvider("runtime-provider", {
+				baseUrl: "https://runtime.example.com/v1",
+				apiKey: "extension-key",
+				api: "openai-completions",
+				models: [
+					{
+						id: "runtime-model",
+						name: "Runtime Model",
+						reasoning: false,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 128000,
+						maxTokens: 8192,
+					},
+				],
+			});
+		};
 
 		const authStorage = await AuthStorage.create(path.join(cwd, "auth.db"));
 		try {
@@ -230,13 +229,17 @@ describe("ACP lazy startup", () => {
 					noTools: true,
 					noLsp: true,
 					sessionDir: cwd,
-					extensions: [path.join(cwd, "runtime-provider.ts")],
+
 					model: "runtime-provider/runtime-model",
 				},
 				[],
 				{
 					discoverAuthStorage: async () => authStorage,
-					createAgentSession,
+					createAgentSession: options =>
+						createAgentSession({
+							...options,
+							extensions: [...(options.extensions ?? []), registerRuntimeProvider],
+						}),
 					settings,
 					runAcpMode: async createAcpSession => {
 						session = await createAcpSession(cwd);

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -237,8 +237,8 @@ describe("ACP lazy startup", () => {
 					discoverAuthStorage: async () => authStorage,
 					createAgentSession: options =>
 						createAgentSession({
-							...options,
-							extensions: [...(options.extensions ?? []), registerRuntimeProvider],
+							...(options ?? {}),
+							extensions: [...(options?.extensions ?? []), registerRuntimeProvider],
 						}),
 					settings,
 					runAcpMode: async createAcpSession => {

--- a/packages/coding-agent/test/runtime-api-key.test.ts
+++ b/packages/coding-agent/test/runtime-api-key.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { applyCliRuntimeApiKeyOverride } from "../src/runtime-api-key";
+
+describe("applyCliRuntimeApiKeyOverride", () => {
+	it("applies the CLI runtime API key once a model resolves", () => {
+		const calls: Array<{ provider: string; apiKey: string }> = [];
+		const target = {
+			setRuntimeApiKey(provider: string, apiKey: string) {
+				calls.push({ provider, apiKey });
+			},
+		};
+
+		applyCliRuntimeApiKeyOverride(target, "cli-runtime-key", { provider: "runtime-provider" });
+
+		expect(calls).toEqual([{ provider: "runtime-provider", apiKey: "cli-runtime-key" }]);
+	});
+
+	it("does nothing when the model has not resolved yet", () => {
+		const calls: Array<{ provider: string; apiKey: string }> = [];
+		const target = {
+			setRuntimeApiKey(provider: string, apiKey: string) {
+				calls.push({ provider, apiKey });
+			},
+		};
+
+		applyCliRuntimeApiKeyOverride(target, "cli-runtime-key", undefined);
+
+		expect(calls).toEqual([]);
+	});
+
+	it("does nothing when no CLI runtime API key was supplied", () => {
+		const calls: Array<{ provider: string; apiKey: string }> = [];
+		const target = {
+			setRuntimeApiKey(provider: string, apiKey: string) {
+				calls.push({ provider, apiKey });
+			},
+		};
+
+		applyCliRuntimeApiKeyOverride(target, undefined, { provider: "runtime-provider" });
+
+		expect(calls).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
- Centralize CLI runtime API-key override application in a small helper.
- Apply the override after lazy ACP session/model resolution so extension-provided models receive the CLI key.
- Re-enable the ACP lazy startup regression and add focused helper coverage.

## Tests
- `bunx biome check packages/coding-agent/src/main.ts packages/coding-agent/src/runtime-api-key.ts packages/coding-agent/test/runtime-api-key.test.ts packages/coding-agent/test/acp-lazy-startup.test.ts`
- `bun test packages/coding-agent/test/runtime-api-key.test.ts packages/coding-agent/test/acp-lazy-startup.test.ts`