### PR TITLE
fix: compact slash autocomplete layout

### DIFF
--- a/packages/tui/src/autocomplete-layout.ts
+++ b/packages/tui/src/autocomplete-layout.ts
@@ -1,0 +1,10 @@
+import type { SelectListLayoutOptions } from "./components/select-list";
+
+export const SLASH_COMMAND_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
+	minPrimaryColumnWidth: 12,
+	maxPrimaryColumnWidth: 32,
+};
+
+export function resolveAutocompleteSelectListLayout(prefix: string): SelectListLayoutOptions | undefined {
+	return prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
+}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -4,6 +4,7 @@ import {
 	type CombinedAutocompleteProvider,
 	extractSlashCommandTokenPrefix,
 } from "../autocomplete";
+import { resolveAutocompleteSelectListLayout } from "../autocomplete-layout";
 import { BracketedPasteHandler } from "../bracketed-paste";
 import { getKeybindings, type KeybindingsManager } from "../keybindings";
 import { extractPrintableText, matchesKey } from "../keys";
@@ -22,12 +23,7 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "../utils";
-import { SelectList, type SelectListLayoutOptions, type SelectListTheme } from "./select-list";
-
-const SLASH_COMMAND_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
-	minPrimaryColumnWidth: 12,
-	maxPrimaryColumnWidth: 32,
-};
+import { SelectList, type SelectListTheme } from "./select-list";
 
 function sanitizeLoadedText(text: string): string {
 	// Normalize CRLF/CR → LF, then strip C0 control chars except \n.
@@ -2725,11 +2721,8 @@ export class Editor implements Component, Focusable {
 		prefix: string,
 		items: Array<{ value: string; label: string; description?: string }>,
 	): SelectList {
-		// Layout options prepared for future SelectList enhancements (e.g., for slash commands)
-		const layout = prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
-		// TODO: Pass layout to SelectList when constructor is updated to support it
-		void layout; // Use layout variable to avoid lint warnings
-		return new SelectList(items, this.#autocompleteMaxVisible, this.#theme.selectList);
+		const layout = resolveAutocompleteSelectListLayout(prefix);
+		return new SelectList(items, this.#autocompleteMaxVisible, this.#theme.selectList, layout);
 	}
 
 	#handleTabCompletion(): void {

--- a/packages/tui/test/autocomplete-layout.test.ts
+++ b/packages/tui/test/autocomplete-layout.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { resolveAutocompleteSelectListLayout } from "../src/autocomplete-layout";
+
+describe("resolveAutocompleteSelectListLayout", () => {
+	it("uses the compact layout for slash-command autocomplete", () => {
+		expect(resolveAutocompleteSelectListLayout("/he")).toEqual({
+			minPrimaryColumnWidth: 12,
+			maxPrimaryColumnWidth: 32,
+		});
+	});
+
+	it("keeps the default wider layout for non-slash autocomplete", () => {
+		expect(resolveAutocompleteSelectListLayout("he")).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
- Move slash autocomplete layout selection into a small tested helper.
- Pass the compact slash-command layout into `SelectList` instead of computing and discarding it.
- Preserve default autocomplete layout for non-slash prefixes.

## Tests
- `bunx biome check packages/tui/src/components/editor.ts packages/tui/src/autocomplete-layout.ts packages/tui/test/autocomplete-layout.test.ts`
- `bun test packages/tui/test/autocomplete-layout.test.ts`