### PR TITLE
Require force for lifecycle session close

### DIFF
--- a/crates/gjc-notifications/src/lifecycle.rs
+++ b/crates/gjc-notifications/src/lifecycle.rs
@@ -103,7 +103,7 @@ pub struct SessionClose {
 	pub token:      String,
 	/// Which session to close.
 	pub target:     SessionCloseTarget,
-	/// Hard-kill even if a live pane is attached (GJC-managed only).
+	/// Required force-only close flag; `false` is rejected by daemon policy.
 	#[serde(default)]
 	pub force:      bool,
 }

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -100,7 +100,7 @@ export interface SessionCloseFrame {
 	chatId: string;
 	token: string;
 	target: SessionCloseTarget;
-	/** Hard-kill even if a live pane is attached (GJC-managed only). */
+	/** Required force-only close flag; false/omitted is rejected by daemon policy. */
 	force?: boolean;
 }
 

--- a/packages/coding-agent/src/notifications/lifecycle-orchestrator.ts
+++ b/packages/coding-agent/src/notifications/lifecycle-orchestrator.ts
@@ -252,7 +252,17 @@ export async function handleLifecycleRequest(
 		return { status: "error", reason: "rate_limited", message: "create rate limit exceeded" };
 	}
 
-	// 4. Preallocate ids + write in_progress (fsynced) BEFORE any spawn.
+	// 4. Close is intentionally force-only until a graceful close contract exists.
+	if (frame.type === "session_close" && frame.force !== true) {
+		await deps.audit({ ...baseAudit, event: "rejected", reason: "invalid_target" });
+		return {
+			status: "error",
+			reason: "invalid_target",
+			message: "session_close requires force=true; graceful close is not supported",
+		};
+	}
+
+	// 5. Preallocate ids + write in_progress (fsynced) BEFORE any spawn.
 	const lifecycleRequestId = frame.type === "session_create" ? frame.lifecycleRequestId : deps.newLifecycleRequestId();
 	const intendedSessionId =
 		frame.type === "session_create" ? frame.intendedSessionId || deps.newSessionId() : deps.newSessionId();
@@ -344,15 +354,18 @@ export async function handleLifecycleRequest(
 		await deps.audit({ ...baseAudit, event: "success", sessionId: resumed.sessionId });
 		return { status: "ok", entry, mode: resumed.mode };
 	} catch (err) {
-		// A side effect may have occurred; do not auto-respawn. Mark terminal
-		// uncertain so a retry reconciles instead of duplicating.
+		// A side effect may have occurred; do not repeat it automatically. Mark
+		// terminal-uncertain so a retry reconciles instead of duplicating work.
+		let reason: LifecycleErrorReason = "terminal_uncertain";
+		if (frame.type === "session_create") reason = "spawn_failed";
+		if (frame.type === "session_close") reason = "close_refused";
 		Object.assign(entry, {
 			state: "terminal_uncertain",
 			updatedAt: deps.now(),
-			reason: "spawn_failed",
+			reason,
 		});
 		await deps.store.write(doc);
-		await deps.audit({ ...baseAudit, event: "terminal_uncertain", reason: "spawn_failed" });
-		return { status: "error", reason: "terminal_uncertain", message: `lifecycle effect failed: ${String(err)}` };
+		await deps.audit({ ...baseAudit, event: "terminal_uncertain", reason });
+		return { status: "error", reason: "terminal_uncertain", message: `${frame.type} effect failed: ${String(err)}` };
 	}
 }

--- a/packages/coding-agent/test/notifications-lifecycle-orchestrator.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-orchestrator.test.ts
@@ -204,8 +204,71 @@ describe("lifecycle orchestrator", () => {
 		expect(audit.some(e => e.event === "failure" && e.reason === "not_found")).toBe(true);
 	});
 
-	it("closes a session", async () => {
-		const { deps: d } = deps();
+	it("rejects session_close without force before any close side effect", async () => {
+		const { deps: d, audit, store } = deps();
+		let closed = false;
+		const frame: SessionCloseFrame = {
+			type: "session_close",
+			requestId: "lc_c_no_force",
+			updateId: 299,
+			chatId: PAIRED,
+			token: "control-token",
+			target: { sessionId: "sess-1", tmuxSession: "gjc-1" },
+		};
+		const out = await handleLifecycleRequest(frame, {
+			...d,
+			closeSession: async () => {
+				closed = true;
+				throw new Error("must not close");
+			},
+		});
+		expect(out.status).toBe("error");
+		if (out.status === "error") {
+			expect(out.reason).toBe("invalid_target");
+			expect(out.message).toBe("session_close requires force=true; graceful close is not supported");
+		}
+		expect(closed).toBe(false);
+		expect((await store.read()).entries[`${PAIRED}:299`]).toBeUndefined();
+		expect(audit.at(-1)).toMatchObject({ event: "rejected", reason: "invalid_target" });
+	});
+
+	it("rejects session_close with force=false before any close side effect", async () => {
+		const { deps: d, audit, store } = deps();
+		let closed = false;
+		const frame: SessionCloseFrame = {
+			type: "session_close",
+			requestId: "lc_c_force_false",
+			updateId: 301,
+			chatId: PAIRED,
+			token: "control-token",
+			target: { sessionId: "sess-1", tmuxSession: "gjc-1" },
+			force: false,
+		};
+		const out = await handleLifecycleRequest(frame, {
+			...d,
+			closeSession: async () => {
+				closed = true;
+				throw new Error("must not close");
+			},
+		});
+		expect(out.status).toBe("error");
+		if (out.status === "error") {
+			expect(out.reason).toBe("invalid_target");
+			expect(out.message).toBe("session_close requires force=true; graceful close is not supported");
+		}
+		expect(closed).toBe(false);
+		expect((await store.read()).entries[`${PAIRED}:301`]).toBeUndefined();
+		expect(audit.at(-1)).toMatchObject({ event: "rejected", reason: "invalid_target" });
+	});
+
+	it("closes a session when force is true", async () => {
+		let closeCalls = 0;
+		const { deps: d } = deps({
+			closeSession: async () => {
+				closeCalls++;
+				return { processGone: true };
+			},
+		});
 		const frame: SessionCloseFrame = {
 			type: "session_close",
 			requestId: "lc_c",
@@ -217,6 +280,36 @@ describe("lifecycle orchestrator", () => {
 		};
 		const out = await handleLifecycleRequest(frame, d);
 		expect(out.status).toBe("ok");
+		expect(closeCalls).toBe(1);
+	});
+
+	it("records close failures as close_refused diagnostics, not spawn failures", async () => {
+		const {
+			deps: d,
+			audit,
+			store,
+		} = deps({
+			closeSession: async () => {
+				throw new Error("tmux session mismatch");
+			},
+		});
+		const frame: SessionCloseFrame = {
+			type: "session_close",
+			requestId: "lc_c_refused",
+			updateId: 302,
+			chatId: PAIRED,
+			token: "control-token",
+			target: { sessionId: "sess-1", tmuxSession: "gjc-1" },
+			force: true,
+		};
+		const out = await handleLifecycleRequest(frame, d);
+		expect(out.status).toBe("error");
+		if (out.status === "error") {
+			expect(out.reason).toBe("terminal_uncertain");
+			expect(out.message).toContain("session_close effect failed");
+		}
+		expect((await store.read()).entries[`${PAIRED}:302`]?.reason).toBe("close_refused");
+		expect(audit.at(-1)).toMatchObject({ event: "terminal_uncertain", reason: "close_refused" });
 	});
 
 	it("classifyDuplicate / requestHash / summarizeTarget are stable", () => {


### PR DESCRIPTION
## Summary
- Enforce the lifecycle `session_close` force-only contract in the orchestrator before ledger acceptance or close side effects.
- Return an explicit `invalid_target` lifecycle error when `force` is false or omitted.
- Preserve Telegram-originated close behavior by keeping daemon close frames on `force: true`.
- Record close effect failures with `close_refused` diagnostics instead of spawn-specific wording.

Closes #1629

## Verification
- `bun test packages/coding-agent/test/notifications-lifecycle-orchestrator.test.ts` — 14 pass
- `bunx biome check packages/coding-agent/src/notifications/lifecycle-orchestrator.ts packages/coding-agent/src/notifications/index.ts packages/coding-agent/test/notifications-lifecycle-orchestrator.test.ts` — OK
- `bun run check:types` in `packages/coding-agent` — OK
- `git diff --check origin/dev...HEAD` — OK

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*