### PR TITLE
fix(computer-use): default off — no longer enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The bundled Telegram flow adds a threaded per-session surface with context updat
   <img src="assets/computer-use.png" alt="computer-use desktop control — See. Click. Type. Control." width="100%" />
 </p>
 
-**`computer-use`** — an experimental, opt-in desktop-control tool surface. Backed by native screenshot/input bindings and gated through settings/tool registration, it lets the agent see the screen and drive mouse/keyboard for local desktop coordination.
+**`computer-use`** — an experimental, opt-in desktop-control tool surface. Off by default; backed by native screenshot/input bindings and gated through settings/tool registration, it must be explicitly enabled via `computer.enabled` or `computer.alwaysOn` to let the agent see the screen and drive mouse/keyboard for local desktop coordination.
 
 ## Website
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2328,7 +2328,7 @@ export const SETTINGS_SCHEMA = {
 		ui: {
 			tab: "tools",
 			label: "Computer",
-			description: "Enable the macOS computer tool for this session. Off by default.",
+			description: "Enable the macOS computer tool for this session. Off by default; must be explicitly enabled.",
 		},
 	},
 

--- a/packages/coding-agent/src/prompts/tools/computer.md
+++ b/packages/coding-agent/src/prompts/tools/computer.md
@@ -1,11 +1,11 @@
 # computer
 
-`computer` is available by default on supported Apple Silicon macOS. It controls the real desktop, so use it only when the task genuinely needs real desktop screenshot or input control.
+`computer` is off by default. It must be explicitly enabled via `computer.enabled=true` or `computer.alwaysOn=true` on supported Apple Silicon macOS. It controls the real desktop, so use it only when the task genuinely needs real desktop screenshot or input control.
 
 ## Safety contract
 
 - Disabled means disabled: when the tool is disabled (`computer.alwaysOn=false` with `computer.enabled` unset/false) or the platform is unsupported, every action including `screenshot` fails with `COMPUTER_DISABLED` and captures nothing.
-- Callable only on Apple Silicon macOS (`arm64` darwin); available by default there, with `computer.alwaysOn=false` as the off-switch and `computer.enabled=true` as the manual enable path.
+- Callable only on Apple Silicon macOS (`arm64` darwin); off by default. Set `computer.enabled=true` for per-session enable or `computer.alwaysOn=true` for persistent enable. Use `computer.alwaysOn=false` with `computer.enabled` unset/false to keep it off.
 - Native execution remains supervisor-gated. If the stop/suspend supervisor is unavailable, stale, suspended, permissioned off, display-stale, or cancelled, the action fails closed with a `COMPUTER_*` code. Coordinate actions carry the latest known screenshot display epoch when one is available so display-topology changes fail with `COMPUTER_DISPLAY_STALE`.
 - Respect the user's stop/suspend request immediately. Do not loop desktop actions after a stop/suspend/error.
 - The user can stop or suspend the session at any time with the configured kill-switch hotkey (default `Control+Option+Command+Escape`). If you see `COMPUTER_CANCELLED` or `COMPUTER_SUPERVISOR_NOT_LIVE`, stop and wait for the user.

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -266,7 +266,7 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 			details.status = "disabled";
 			details.code = COMPUTER_DISABLED_CODE;
 			details.message =
-						"The computer tool is disabled or unsupported. It requires Apple Silicon macOS; set computer.enabled=true or computer.alwaysOn=true to enable on a supported host.";
+				"The computer tool is disabled or unsupported. It requires Apple Silicon macOS; set computer.enabled=true or computer.alwaysOn=true to enable on a supported host.";
 			await writeComputerAuditLog(this.session, details);
 			return { ...toolResult(details).text(`${COMPUTER_DISABLED_CODE}: ${details.message}`).done(), isError: true };
 		}

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -221,7 +221,7 @@ export function isComputerEnabled(session: Pick<ToolSession, "settings">): boole
 	if (session.settings.get("computer.enabled")) return true;
 	if (session.settings.has("computer.enabled")) return false;
 	if (session.settings.has("computer.alwaysOn")) return Boolean(session.settings.get("computer.alwaysOn"));
-	return true;
+	return false;
 }
 
 export function isComputerCallable(
@@ -237,7 +237,7 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 	readonly label = "Computer";
 	readonly loadMode = "discoverable";
 	readonly summary =
-		"Control the macOS desktop (Apple Silicon) with screenshot, pointer, keyboard, scroll, and wait actions; available by default on supported hosts and supervisor-gated";
+		"Control the macOS desktop (Apple Silicon) with screenshot, pointer, keyboard, scroll, and wait actions; off by default — set computer.enabled=true or computer.alwaysOn=true to enable; supervisor-gated when active";
 	readonly parameters = computerSchema;
 	readonly strict = true;
 	#description?: string;
@@ -266,7 +266,7 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 			details.status = "disabled";
 			details.code = COMPUTER_DISABLED_CODE;
 			details.message =
-				"The computer tool is disabled or unsupported. It requires Apple Silicon macOS; set computer.alwaysOn=false to disable, or computer.enabled=true to manually enable on a supported host.";
+						"The computer tool is disabled or unsupported. It requires Apple Silicon macOS; set computer.enabled=true or computer.alwaysOn=true to enable on a supported host.";
 			await writeComputerAuditLog(this.session, details);
 			return { ...toolResult(details).text(`${COMPUTER_DISABLED_CODE}: ${details.message}`).done(), isError: true };
 		}

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -370,10 +370,10 @@ export const BUILTIN_CAPABILITY_CATALOG: readonly BuiltinCapabilityCatalogEntry[
 				name: "computer",
 				label: "Computer",
 				summary:
-					"Apple Silicon macOS desktop screenshot and input control; enabled by default on supported hosts and supervisor-gated.",
+					"Apple Silicon macOS desktop screenshot and input control; off by default and must be explicitly enabled via computer.enabled or computer.alwaysOn; supervisor-gated when active.",
 				docsPath: "docs/tools/computer.md",
 				callableBuiltin: false,
-				defaultEnabled: true,
+				defaultEnabled: false,
 			},
 		]
 	: [];

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -172,24 +172,24 @@ describe("computer tool gating", () => {
 		setComputerArchForTests(undefined);
 	});
 
-	it("is callable and discoverable by default on Apple Silicon macOS", async () => {
+	it("is not callable or discoverable by default on Apple Silicon macOS (off by default)", async () => {
 		setComputerPlatformForTests("darwin");
 		setComputerArchForTests("arm64");
 		const session = createSession(Settings.isolated({ "tools.discoveryMode": "all" }));
 		const tools = await createTools(session);
 		const names = tools.map(t => t.name);
-		expect(names).toContain("computer");
+		expect(names).not.toContain("computer");
 		const discoverable = tools.filter(t => t.loadMode === "discoverable").map(t => t.name);
-		expect(discoverable).toContain("computer");
+		expect(discoverable).not.toContain("computer");
 	});
 
 	it("exposes honest static capability catalog metadata for computer", () => {
 		const catalogEntry = BUILTIN_CAPABILITY_CATALOG.find(entry => entry.name === "computer");
 		if (isComputerLoadablePlatform()) {
-			expect(catalogEntry).toMatchObject({ callableBuiltin: false, defaultEnabled: true });
+			expect(catalogEntry).toMatchObject({ callableBuiltin: false, defaultEnabled: false });
 			expect(catalogEntry?.summary ?? "").not.toBe("");
-			expect((catalogEntry?.summary ?? "").toLowerCase()).not.toContain("off by default");
-			expect(catalogEntry?.summary ?? "").not.toContain("Explicitly enabled");
+			expect((catalogEntry?.summary ?? "").toLowerCase()).toContain("off by default");
+			expect(catalogEntry?.summary ?? "").not.toContain("enabled by default");
 		} else {
 			expect(catalogEntry).toBeUndefined();
 		}


### PR DESCRIPTION
## Summary

The `computer` tool (desktop screenshot + input injection on Apple Silicon macOS) was **enabled by default**. This PR makes it **off by default** — users must explicitly opt in via `computer.enabled=true` or `computer.alwaysOn=true`.

## Problem

`isComputerEnabled()` returned `true` when neither `computer.enabled` nor `computer.alwaysOn` was explicitly set:

```ts
// Before — returns true when no setting is present
export function isComputerEnabled(session): boolean {
  if (session.settings.get("computer.enabled")) return true;
  if (session.settings.has("computer.enabled")) return false;
  if (session.settings.has("computer.alwaysOn")) return Boolean(session.settings.get("computer.alwaysOn"));
  return true;  // ← BUG: tool is callable out of the box
}
```

This contradicted the documented intent ("Off by default") and the `settings-schema.ts` default of `false`. It also contradicted `docs/tools/computer.md` which already said "not a callable tool by default" — the code didn't match the docs.

A desktop input-injection tool that controls the real screen, mouse, and keyboard should be opt-in, not on until someone remembers to turn it off.

## Changes

| File | Change |
|------|--------|
| `packages/coding-agent/src/tools/computer.ts` | `isComputerEnabled()`: `return true` → `return false`; fix disabled-state message wording; update `summary` |
| `packages/coding-agent/src/tools/index.ts` | `BUILTIN_CAPABILITY_CATALOG`: `defaultEnabled: true` → `false`; fix `summary` text |
| `packages/coding-agent/src/config/settings-schema.ts` | Clarify description: "must be explicitly enabled" |
| `packages/coding-agent/src/prompts/tools/computer.md` | Model-facing prompt: "available by default" → "off by default" |
| `README.md` | Add "Off by default" to computer-use description |
| `packages/coding-agent/test/tools/computer.test.ts` | Assert `defaultEnabled: false`, not-callable-by-default, summary contains "off by default" |

## Test changes

- `"is callable and discoverable by default on Apple Silicon macOS"` → `"is not callable or discoverable by default on Apple Silicon macOS (off by default)"` — assertions flipped from `toContain` to `not.toContain`
- Catalog metadata test: `defaultEnabled: true` → `false`; summary must contain "off by default"; must not contain "enabled by default"

## Checklist

- [x] `isComputerEnabled()` returns `false` by default
- [x] `BUILTIN_CAPABILITY_CATALOG.defaultEnabled` is `false`
- [x] No "enabled by default" or "available by default" text remains in computer-related source/docs
- [x] Tests updated to match new behavior
- [x] No functional change to the tool itself — only the default gating