### PR TITLE
Fix computer stale display epoch forwarding

### DIFF
--- a/crates/pi-natives/src/computer/capture.rs
+++ b/crates/pi-natives/src/computer/capture.rs
@@ -109,6 +109,8 @@ impl fmt::Display for CaptureError {
 impl std::error::Error for CaptureError {}
 
 static NEXT_CAPTURE_ID: AtomicU64 = AtomicU64::new(1);
+const JS_SAFE_INTEGER_BITS: u32 = 53;
+const DISPLAY_EPOCH_MASK: u64 = (1_u64 << JS_SAFE_INTEGER_BITS) - 1;
 
 /// A captured primary-display frame.
 pub struct CapturedFrame {
@@ -260,7 +262,10 @@ fn display_epoch(display: &NormalizedDisplay) -> u64 {
 	display.scale_y.to_bits().hash(&mut hasher);
 	display.origin_x.to_bits().hash(&mut hasher);
 	display.origin_y.to_bits().hash(&mut hasher);
-	hasher.finish()
+	// The N-API surface transports display epochs as JavaScript numbers. Keep the
+	// hash within the 53-bit safe-integer range so screenshot -> action roundtrips
+	// exactly and the stale-display gate can compare epochs without false rejects.
+	hasher.finish() & DISPLAY_EPOCH_MASK
 }
 
 fn next_capture_id() -> u32 {
@@ -280,7 +285,16 @@ fn encode_png(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, CaptureEr
 
 #[cfg(test)]
 mod tests {
-	use super::capture_primary_display;
+	use super::{capture_primary_display, display_epoch};
+	use crate::computer::coords::NormalizedDisplay;
+
+	#[test]
+	fn display_epoch_roundtrips_through_javascript_number() {
+		let display = NormalizedDisplay::new(3024, 1964, 2.0, 2.0, -1728.0, 0.0);
+		let epoch = display_epoch(&display);
+
+		assert_eq!((epoch as f64) as u64, epoch);
+	}
 
 	/// Exercises the real OS capture path, so it is ignored by default and run
 	/// explicitly (`cargo test -p pi-natives --ignored`) on a macOS host with

--- a/packages/coding-agent/src/prompts/tools/computer.md
+++ b/packages/coding-agent/src/prompts/tools/computer.md
@@ -6,7 +6,7 @@
 
 - Disabled means disabled: when the tool is disabled (`computer.alwaysOn=false` with `computer.enabled` unset/false) or the platform is unsupported, every action including `screenshot` fails with `COMPUTER_DISABLED` and captures nothing.
 - Callable only on Apple Silicon macOS (`arm64` darwin); available by default there, with `computer.alwaysOn=false` as the off-switch and `computer.enabled=true` as the manual enable path.
-- Native execution remains supervisor-gated. If the stop/suspend supervisor is unavailable, stale, suspended, permissioned off, display-stale, or cancelled, the action fails closed with a `COMPUTER_*` code.
+- Native execution remains supervisor-gated. If the stop/suspend supervisor is unavailable, stale, suspended, permissioned off, display-stale, or cancelled, the action fails closed with a `COMPUTER_*` code. Coordinate actions carry the latest known screenshot display epoch when one is available so display-topology changes fail with `COMPUTER_DISPLAY_STALE`.
 - Respect the user's stop/suspend request immediately. Do not loop desktop actions after a stop/suspend/error.
 - The user can stop or suspend the session at any time with the configured kill-switch hotkey (default `Control+Option+Command+Escape`). If you see `COMPUTER_CANCELLED` or `COMPUTER_SUPERVISOR_NOT_LIVE`, stop and wait for the user.
 
@@ -14,7 +14,7 @@
 
 Coordinates are screenshot pixels, not CSS pixels and not normalized fractions. Use the latest successful `screenshot` dimensions and origin/scale metadata as the coordinate frame. Do not guess coordinates outside the screenshot bounds.
 
-When you send a sequence of actions in one `batch` call, pointer coordinates in later steps are validated against the most recent screenshot from that batch. If a coordinate is out of bounds, the batch stops and reports `COMPUTER_COORD_INVALID`. Always capture a fresh screenshot before acting if the display may have changed.
+For stale-display protection to apply, derive pointer coordinates from a successful screenshot in the same tool session; a screenshot-first `batch` is preferred because later coordinate steps are validated against that screenshot and carry its display epoch into native execution. If a coordinate is out of bounds, the batch stops and reports `COMPUTER_COORD_INVALID`. Always capture a fresh screenshot before acting if the display may have changed.
 
 ## Actions
 

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -98,7 +98,7 @@ export interface ComputerScreenshotDetails {
 	scaleY?: number;
 	originX?: number;
 	originY?: number;
-	displayEpoch?: string;
+	displayEpoch?: number;
 	captureId?: string;
 	pngBytes?: number;
 	path?: string;
@@ -144,7 +144,7 @@ type NativeScreenshot = {
 	scaleY?: number;
 	originX?: number;
 	originY?: number;
-	displayEpoch?: string;
+	displayEpoch?: number;
 	captureId?: string;
 };
 
@@ -175,6 +175,7 @@ let controllerFactory: ComputerControllerFactory = createNativeComputerControlle
 let platformOverrideForTests: NodeJS.Platform | undefined;
 let archOverrideForTests: NodeJS.Architecture | undefined;
 const screenshotFallbackDirs = new WeakMap<ToolSession, Promise<string>>();
+const latestScreenshotContexts = new WeakMap<ToolSession, ScreenshotContext>();
 
 const COMPUTER_INLINE_SCREENSHOT_MAX_WIDTH = 1568;
 const COMPUTER_INLINE_SCREENSHOT_MAX_HEIGHT = 1568;
@@ -278,9 +279,18 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 			// Native ComputerController methods are synchronous and accept no AbortSignal,
 			// so cancellation is honored before dispatch and wait() is bounded by timeoutMs.
 			if (params.action === "batch") {
-				const batchResult = await dispatchBatchComputerActions(controller, params.actions, timeoutMs, hotkey);
+				const batchResult = await dispatchBatchComputerActions(
+					controller,
+					params.actions,
+					timeoutMs,
+					hotkey,
+					latestScreenshotContexts.get(this.session),
+				);
 				details.steps = batchResult.steps;
-				if (batchResult.screenshot) details.screenshot = batchResult.screenshot;
+				if (batchResult.screenshot) {
+					details.screenshot = batchResult.screenshot;
+					rememberLatestScreenshot(this.session, batchResult.screenshot);
+				}
 				details.status = batchResult.failedStep ? "error" : "success";
 				if (batchResult.failedStep) {
 					details.code = batchResult.failedStep.code;
@@ -307,9 +317,17 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 							.done()
 					: toolResult(details).text(details.message).done();
 			}
-			const result = await dispatchComputerAction(controller, params, timeoutMs);
+			const result = await dispatchComputerAction(
+				controller,
+				params,
+				timeoutMs,
+				latestScreenshotContexts.get(this.session),
+			);
 			const screenshot = normalizeScreenshot(result);
-			if (screenshot) details.screenshot = screenshot;
+			if (screenshot) {
+				details.screenshot = screenshot;
+				rememberLatestScreenshot(this.session, screenshot);
+			}
 			details.status = "success";
 			details.message = describeComputerSuccess(details);
 			if (screenshot) {
@@ -342,6 +360,10 @@ interface CoordinateBounds {
 	originY?: number;
 }
 
+interface ScreenshotContext extends CoordinateBounds {
+	displayEpoch?: number;
+}
+
 function validatePointerCoordinates(action: string, x: number, y: number, bounds: CoordinateBounds | undefined): void {
 	if (!bounds) return;
 	const minX = bounds.originX ?? 0;
@@ -355,33 +377,50 @@ function validatePointerCoordinates(action: string, x: number, y: number, bounds
 	}
 }
 
+function expectedEpochFromContext(context: ScreenshotContext | undefined): number | undefined {
+	return typeof context?.displayEpoch === "number" &&
+		Number.isFinite(context.displayEpoch) &&
+		context.displayEpoch >= 0
+		? context.displayEpoch
+		: undefined;
+}
+
+function rememberLatestScreenshot(session: ToolSession, screenshot: ComputerScreenshotDetails): void {
+	latestScreenshotContexts.set(session, {
+		widthPx: screenshot.widthPx,
+		heightPx: screenshot.heightPx,
+		originX: screenshot.originX,
+		originY: screenshot.originY,
+		displayEpoch: screenshot.displayEpoch,
+	});
+}
+
 function dispatchComputerAction(
 	controller: NativeController,
 	params: SingleComputerParams,
 	timeoutMs: number | undefined,
-	bounds?: CoordinateBounds,
+	context?: ScreenshotContext,
 ): Promise<unknown> | unknown {
-	// expectedEpoch is undefined until lossless epoch transport lands (follow-up):
-	// the native gate skips the stale-display check when the epoch is absent.
+	const expectedEpoch = expectedEpochFromContext(context);
 	switch (params.action) {
 		case "screenshot":
 			return controller.screenshot?.();
 		case "click":
-			validatePointerCoordinates("click", params.x, params.y, bounds);
-			return controller.click?.(undefined, params.x, params.y, params.button ?? "left");
+			validatePointerCoordinates("click", params.x, params.y, context);
+			return controller.click?.(expectedEpoch, params.x, params.y, params.button ?? "left");
 		case "double_click":
-			validatePointerCoordinates("double_click", params.x, params.y, bounds);
-			return controller.doubleClick?.(undefined, params.x, params.y, params.button ?? "left");
+			validatePointerCoordinates("double_click", params.x, params.y, context);
+			return controller.doubleClick?.(expectedEpoch, params.x, params.y, params.button ?? "left");
 		case "move":
-			validatePointerCoordinates("move", params.x, params.y, bounds);
-			return controller.move?.(undefined, params.x, params.y);
+			validatePointerCoordinates("move", params.x, params.y, context);
+			return controller.move?.(expectedEpoch, params.x, params.y);
 		case "drag":
-			validatePointerCoordinates("drag start", params.x, params.y, bounds);
-			validatePointerCoordinates("drag end", params.to_x, params.to_y, bounds);
-			return controller.drag?.(undefined, params.x, params.y, params.to_x, params.to_y, params.button ?? "left");
+			validatePointerCoordinates("drag start", params.x, params.y, context);
+			validatePointerCoordinates("drag end", params.to_x, params.to_y, context);
+			return controller.drag?.(expectedEpoch, params.x, params.y, params.to_x, params.to_y, params.button ?? "left");
 		case "scroll":
-			validatePointerCoordinates("scroll", params.x, params.y, bounds);
-			return controller.scroll?.(undefined, params.x, params.y, params.scroll_x, params.scroll_y);
+			validatePointerCoordinates("scroll", params.x, params.y, context);
+			return controller.scroll?.(expectedEpoch, params.x, params.y, params.scroll_x, params.scroll_y);
 		case "type":
 			return controller.type?.(undefined, params.text);
 		case "keypress":
@@ -403,21 +442,22 @@ async function dispatchBatchComputerActions(
 	actions: readonly SingleComputerParams[],
 	timeoutMs: number | undefined,
 	hotkey?: string,
+	initialContext?: ScreenshotContext,
 ): Promise<BatchDispatchResult> {
 	const steps: ComputerToolDetails[] = [];
 	let lastScreenshot: ComputerScreenshotDetails | undefined;
 	let lastScreenshotSource: unknown;
-	let bounds: CoordinateBounds | undefined;
+	let context = initialContext;
 	for (const single of actions) {
 		const stepDetails = detailsFromParams(single);
 		try {
-			const result = await dispatchComputerAction(controller, single, timeoutMs, bounds);
+			const result = await dispatchComputerAction(controller, single, timeoutMs, context);
 			const screenshot = normalizeScreenshot(result);
 			if (screenshot) {
 				stepDetails.screenshot = screenshot;
 				lastScreenshot = screenshot;
 				lastScreenshotSource = result;
-				bounds = screenshot;
+				context = screenshot;
 			}
 			stepDetails.status = "success";
 			stepDetails.message = describeComputerSuccess(stepDetails);
@@ -476,10 +516,14 @@ function normalizeScreenshot(value: unknown): ComputerScreenshotDetails | undefi
 		scaleY: shot.scaleY,
 		originX: shot.originX,
 		originY: shot.originY,
-		displayEpoch: shot.displayEpoch,
+		displayEpoch: normalizeDisplayEpoch(shot.displayEpoch),
 		captureId: shot.captureId,
 		pngBytes: getPngByteLength(shot.png),
 	};
+}
+
+function normalizeDisplayEpoch(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
 function fullResolutionImageContentFromNativeResult(value: unknown): ImageContent | undefined {

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -258,7 +258,7 @@ describe("computer tool dispatch", () => {
 		setComputerControllerFactoryForTests(() => ({
 			screenshot: () => {
 				calls.push({ method: "screenshot", args: [] });
-				return { widthPx: 20, heightPx: 10, png: new Uint8Array([1, 2, 3]), captureId: "cap-1" };
+				return { widthPx: 20, heightPx: 10, png: new Uint8Array([1, 2, 3]), displayEpoch: 42, captureId: "cap-1" };
 			},
 			doubleClick: (...args) => {
 				calls.push({ method: "doubleClick", args });
@@ -278,7 +278,13 @@ describe("computer tool dispatch", () => {
 		await tool.execute("drag", { action: "drag", x: 1, y: 2, to_x: 3, to_y: 4 });
 		await tool.execute("scroll", { action: "scroll", x: 1, y: 2, scroll_x: 5, scroll_y: -6 });
 
-		expect(shot.details?.screenshot).toMatchObject({ widthPx: 20, heightPx: 10, pngBytes: 3, captureId: "cap-1" });
+		expect(shot.details?.screenshot).toMatchObject({
+			widthPx: 20,
+			heightPx: 10,
+			displayEpoch: 42,
+			pngBytes: 3,
+			captureId: "cap-1",
+		});
 		expect(shot.content.some(block => block.type === "image")).toBe(true);
 		const image = shot.content.find(block => block.type === "image");
 		expect(image).toMatchObject({ type: "image", mimeType: "image/png", data: "AQID" });
@@ -286,9 +292,26 @@ describe("computer tool dispatch", () => {
 		expect(await fs.stat(shot.details?.screenshot?.path ?? "")).toMatchObject({ size: 3 });
 		expect(calls.map(call => call.method)).toEqual(["screenshot", "doubleClick", "drag", "scroll"]);
 		// Positional native ABI: (expectedEpoch, x, y, ...rest)
-		expect(calls[1].args).toEqual([undefined, 1, 2, "right"]);
-		expect(calls[2].args).toEqual([undefined, 1, 2, 3, 4, "left"]);
-		expect(calls[3].args).toEqual([undefined, 1, 2, 5, -6]);
+		expect(calls[1].args).toEqual([42, 1, 2, "right"]);
+		expect(calls[2].args).toEqual([42, 1, 2, 3, 4, "left"]);
+		expect(calls[3].args).toEqual([42, 1, 2, 5, -6]);
+	});
+
+	it("does not invent a display epoch before any screenshot context exists", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		const calls: Array<{ method: string; args: unknown[] }> = [];
+		setComputerControllerFactoryForTests(() => ({
+			click: (...args) => {
+				calls.push({ method: "click", args });
+			},
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+		const result = await tool.execute("click", { action: "click", x: 1, y: 2 });
+
+		expect(result.isError).not.toBe(true);
+		expect(calls).toEqual([{ method: "click", args: [undefined, 1, 2, "left"] }]);
 	});
 
 	it("bounds oversized screenshot images sent inline while preserving the full-resolution artifact", async () => {
@@ -396,7 +419,7 @@ describe("computer tool dispatch", () => {
 		setComputerControllerFactoryForTests(() => ({
 			screenshot: () => {
 				calls.push({ method: "screenshot", args: [] });
-				return { widthPx: 100, heightPx: 50, png: new Uint8Array([1, 2, 3]) };
+				return { widthPx: 100, heightPx: 50, png: new Uint8Array([1, 2, 3]), displayEpoch: 99 };
 			},
 			click: (...args) => {
 				calls.push({ method: "click", args });
@@ -423,6 +446,45 @@ describe("computer tool dispatch", () => {
 		expect(result.details?.screenshot?.path).toBeTruthy();
 		expect(await fs.stat(result.details?.screenshot?.path ?? "")).toMatchObject({ size: 3 });
 		expect(calls.map(call => call.method)).toEqual(["screenshot", "click", "type"]);
+		expect(calls[1].args).toEqual([99, 10, 20, "left"]);
+		expect(calls[2].args).toEqual([undefined, "hello"]);
+	});
+
+	it("stops batch when native reports a stale display", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		const calls: Array<{ method: string; args: unknown[] }> = [];
+		setComputerControllerFactoryForTests(() => ({
+			screenshot: () => {
+				calls.push({ method: "screenshot", args: [] });
+				return { widthPx: 100, heightPx: 50, png: new Uint8Array([1, 2, 3]), displayEpoch: 123 };
+			},
+			click: (...args) => {
+				calls.push({ method: "click", args });
+				const error = new Error("COMPUTER_DISPLAY_STALE: display epoch changed") as Error & {
+					code: string;
+				};
+				error.code = "GenericFailure";
+				throw error;
+			},
+			type: (...args) => {
+				calls.push({ method: "type", args });
+			},
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+		const result = await tool.execute("batch", {
+			action: "batch",
+			actions: [{ action: "screenshot" }, { action: "click", x: 10, y: 20 }, { action: "type", text: "skipped" }],
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.details?.steps).toHaveLength(2);
+		expect(result.details?.steps?.[0]?.status).toBe("success");
+		expect(result.details?.steps?.[1]?.code).toBe("COMPUTER_DISPLAY_STALE");
+		expect(result.details?.code).toBe("COMPUTER_DISPLAY_STALE");
+		expect(calls.map(call => call.method)).toEqual(["screenshot", "click"]);
+		expect(calls[1].args).toEqual([123, 10, 20, "left"]);
 	});
 
 	it("stops batch execution on first failure and reports the failing step", async () => {


### PR DESCRIPTION
## Summary
- store the latest screenshot coordinate context per tool session and forward its display epoch to coordinate actions
- keep native display epochs inside the JavaScript safe-integer range so screenshot -> action round-trips exactly
- document the screenshot-derived stale-display contract and cover stale-display failures in focused tests

Fixes #1635

## Verification
- `bun test packages/coding-agent/test/tools/computer.test.ts`
- `cargo test -p pi-natives display_epoch_roundtrips_through_javascript_number`
- `bun run check:types` (packages/coding-agent)
- `bunx biome check packages/coding-agent/src/tools/computer.ts packages/coding-agent/test/tools/computer.test.ts packages/coding-agent/src/prompts/tools/computer.md`
- `cargo check -p pi-natives`
- `git diff --check`