### PR TITLE
Fix computer screenshot options

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `gjc completion inshellisense`, which generates or installs a Fig/withfig-compatible `gjc` completion spec for Microsoft inshellisense without adding inshellisense as a runtime dependency.
 
 ### Fixed
+- `computer` now honors `include_screenshot` and `computer.autoScreenshot` by returning bounded post-action screenshots, and batch steps now respect nested per-step `timeout` values.
 - Custom-provider `gpt-5.5` entries without an explicit `contextWindow` now default to the 272K Codex prompt budget unless the provider uses first-party `openai-responses`, so Codex passthrough proxies (e.g. CLIProxyAPI) compact in time instead of dying with `context_length_exceeded` at ~272K while the registry advertises 1M.
 - `telegram_send` now rejects files over Telegram's document upload limit before reading them into memory or handing them to the notification sink.
 - `telegram_send` now rejects file attachments while Telegram notification redaction is enabled, preventing explicit file sends from bypassing the redaction boundary.

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -285,6 +285,8 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 					timeoutMs,
 					hotkey,
 					latestScreenshotContexts.get(this.session),
+					shouldCapturePostActionScreenshot(params, this.session),
+					Boolean(this.session.settings.get("computer.autoScreenshot")),
 				);
 				details.steps = batchResult.steps;
 				if (batchResult.screenshot) {
@@ -317,12 +319,15 @@ export class ComputerTool implements AgentTool<typeof computerSchema, ComputerTo
 							.done()
 					: toolResult(details).text(details.message).done();
 			}
-			const result = await dispatchComputerAction(
+			let result = await dispatchComputerAction(
 				controller,
 				params,
 				timeoutMs,
 				latestScreenshotContexts.get(this.session),
 			);
+			if (shouldCapturePostActionScreenshot(params, this.session)) {
+				result = await captureScreenshot(controller);
+			}
 			const screenshot = normalizeScreenshot(result);
 			if (screenshot) {
 				details.screenshot = screenshot;
@@ -395,6 +400,20 @@ function rememberLatestScreenshot(session: ToolSession, screenshot: ComputerScre
 	});
 }
 
+function captureScreenshot(controller: NativeController): Promise<unknown> | unknown {
+	return controller.screenshot?.();
+}
+
+function shouldCapturePostActionScreenshot(
+	params: Pick<ComputerParams, "action" | "include_screenshot">,
+	session: Pick<ToolSession, "settings">,
+): boolean {
+	return (
+		params.action !== "screenshot" &&
+		(params.include_screenshot === true || Boolean(session.settings.get("computer.autoScreenshot")))
+	);
+}
+
 function dispatchComputerAction(
 	controller: NativeController,
 	params: SingleComputerParams,
@@ -443,6 +462,8 @@ async function dispatchBatchComputerActions(
 	timeoutMs: number | undefined,
 	hotkey?: string,
 	initialContext?: ScreenshotContext,
+	includeBatchScreenshot = false,
+	autoScreenshot = false,
 ): Promise<BatchDispatchResult> {
 	const steps: ComputerToolDetails[] = [];
 	let lastScreenshot: ComputerScreenshotDetails | undefined;
@@ -451,7 +472,12 @@ async function dispatchBatchComputerActions(
 	for (const single of actions) {
 		const stepDetails = detailsFromParams(single);
 		try {
-			const result = await dispatchComputerAction(controller, single, timeoutMs, context);
+			const stepTimeoutMs = stepTimeoutFromParams(single, timeoutMs);
+			let result = await dispatchComputerAction(controller, single, stepTimeoutMs, context);
+			if (single.action !== "screenshot" && (single.include_screenshot === true || autoScreenshot)) {
+				result = await captureScreenshot(controller);
+			}
+
 			const screenshot = normalizeScreenshot(result);
 			if (screenshot) {
 				stepDetails.screenshot = screenshot;
@@ -477,7 +503,17 @@ async function dispatchBatchComputerActions(
 		}
 		steps.push(stepDetails);
 	}
+	if (includeBatchScreenshot) {
+		lastScreenshotSource = await captureScreenshot(controller);
+		lastScreenshot = normalizeScreenshot(lastScreenshotSource) ?? lastScreenshot;
+	}
 	return { steps, screenshot: lastScreenshot, screenshotSource: lastScreenshotSource };
+}
+
+function stepTimeoutFromParams(params: SingleComputerParams, batchTimeoutMs: number | undefined): number | undefined {
+	if (params.timeout === undefined) return batchTimeoutMs;
+	const timeoutSeconds = clampTimeout("computer", params.timeout);
+	return timeoutSeconds > 0 ? timeoutSeconds * 1000 : undefined;
 }
 
 function detailsFromParams(params: ComputerParams): ComputerToolDetails {

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -412,6 +412,119 @@ describe("computer tool dispatch", () => {
 		}
 	});
 
+	it("captures a bounded post-action screenshot when include_screenshot is requested", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		const calls: string[] = [];
+		setComputerControllerFactoryForTests(() => ({
+			click: () => {
+				calls.push("click");
+			},
+			screenshot: () => {
+				calls.push("screenshot");
+				return { widthPx: 40, heightPx: 30, png: new Uint8Array([4, 5, 6]) };
+			},
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+		const result = await tool.execute("click-shot", { action: "click", x: 1, y: 2, include_screenshot: true });
+
+		expect(result.isError).not.toBe(true);
+		expect(calls).toEqual(["click", "screenshot"]);
+		expect(result.details?.screenshot).toMatchObject({ widthPx: 40, heightPx: 30, pngBytes: 3 });
+		expect(result.content.find(block => block.type === "image")).toMatchObject({
+			type: "image",
+			mimeType: "image/png",
+			data: "BAUG",
+		});
+	});
+
+	it("uses computer.autoScreenshot for post-action screenshots", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		const calls: string[] = [];
+		setComputerControllerFactoryForTests(() => ({
+			type: () => {
+				calls.push("type");
+			},
+			screenshot: () => {
+				calls.push("screenshot");
+				return { widthPx: 80, heightPx: 60, png: new Uint8Array([7, 8, 9]) };
+			},
+		}));
+		const tool = new ComputerTool(
+			createSession(Settings.isolated({ "computer.enabled": true, "computer.autoScreenshot": true })),
+		);
+
+		const result = await tool.execute("auto-shot", { action: "type", text: "hello" });
+
+		expect(result.isError).not.toBe(true);
+		expect(calls).toEqual(["type", "screenshot"]);
+		expect(result.details?.screenshot).toMatchObject({ widthPx: 80, heightPx: 60, pngBytes: 3 });
+		expect(result.content.find(block => block.type === "image")).toMatchObject({ data: "BwgJ" });
+	});
+
+	it("captures batch and per-step screenshots according to explicit options", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		let capture = 0;
+		const calls: string[] = [];
+		setComputerControllerFactoryForTests(() => ({
+			click: () => {
+				calls.push("click");
+			},
+			type: () => {
+				calls.push("type");
+			},
+			screenshot: () => {
+				capture += 1;
+				calls.push(`screenshot-${capture}`);
+				return { widthPx: 100 + capture, heightPx: 50 + capture, png: new Uint8Array([capture]) };
+			},
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+		const result = await tool.execute("batch-shot", {
+			action: "batch",
+			include_screenshot: true,
+			actions: [
+				{ action: "click", x: 1, y: 2, include_screenshot: true },
+				{ action: "type", text: "done" },
+			],
+		});
+
+		expect(result.isError).not.toBe(true);
+		expect(calls).toEqual(["click", "screenshot-1", "type", "screenshot-2"]);
+		expect(result.details?.steps?.[0]?.screenshot).toMatchObject({ widthPx: 101, heightPx: 51 });
+		expect(result.details?.steps?.[1]?.screenshot).toBeUndefined();
+		expect(result.details?.screenshot).toMatchObject({ widthPx: 102, heightPx: 52 });
+		expect(result.content.find(block => block.type === "image")).toMatchObject({ data: "Ag==" });
+	});
+
+	it("honors nested per-step timeout values inside batches", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		const waits: number[] = [];
+		setComputerControllerFactoryForTests(() => ({
+			wait: (_expectedEpoch, ms) => {
+				waits.push(ms);
+			},
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+		const result = await tool.execute("batch-timeouts", {
+			action: "batch",
+			timeout: 5,
+			actions: [
+				{ action: "wait", ms: 10_000 },
+				{ action: "wait", ms: 10_000, timeout: 1 },
+			],
+		});
+
+		expect(result.isError).not.toBe(true);
+		expect(waits).toEqual([5_000, 1_000]);
+	});
+
 	it("executes batch actions sequentially and reports per-step results", async () => {
 		setComputerPlatformForTests("darwin");
 		setComputerArchForTests("arm64");


### PR DESCRIPTION
## Summary
- Honor `include_screenshot` and `computer.autoScreenshot` by capturing bounded post-action screenshots through the existing screenshot normalization/inline/fallback paths.
- Respect nested per-step `timeout` values in `batch.actions[]`, falling back to the top-level batch timeout when omitted.
- Add focused regression coverage and changelog entry.

Fixes #1637.

## Validation
- `bun test packages/coding-agent/test/tools/computer.test.ts`
- `bun --cwd=packages/coding-agent run check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*