### PR TITLE
fix(model): refresh role assignment UI state

### DIFF
--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -475,6 +475,28 @@ export class Settings {
 			this.override("modelRoles", { ...shallowStringRecord(runtimeOverrides), [role]: modelId });
 		}
 	}
+	/**
+	 * Set an agent model override while keeping any live runtime override aligned.
+	 *
+	 * Runtime model profiles override `task.agentModelOverrides` for the current
+	 * session. A user-selected role assignment must win immediately in that same
+	 * session, but only the explicit agent change should be persisted.
+	 */
+	setAgentModelOverride(agentName: string, modelId: string): void {
+		const current = shallowStringRecord(getByPath(this.#global, ["task", "agentModelOverrides"]));
+		const runtimeOverrides = getByPath(this.#overrides, ["task", "agentModelOverrides"]);
+		const updateRuntimeOverride =
+			!!runtimeOverrides && typeof runtimeOverrides === "object" && !Array.isArray(runtimeOverrides);
+
+		this.set("task.agentModelOverrides", { ...current, [agentName]: modelId });
+
+		if (updateRuntimeOverride) {
+			this.override("task.agentModelOverrides", {
+				...shallowStringRecord(runtimeOverrides),
+				[agentName]: modelId,
+			});
+		}
+	}
 
 	/**
 	 * Get a model role (helper for modelRoles record).

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1783,7 +1783,7 @@ export class ModelSelectorComponent extends Container {
 function requiresExplicitThinkingChoice(model: Model, role: GjcModelAssignmentTargetId | null): boolean {
 	if (model.reasoning !== true) return false;
 	if (model.provider === "openai" || model.provider === "openai-codex") return true;
-	return role !== null;
+	return role !== null && GJC_MODEL_ASSIGNMENT_TARGETS[role].settingsPath === "task.agentModelOverrides";
 }
 
 function getSelectableThinkingLevels(model: Model): ThinkingLevel[] {

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1699,6 +1699,21 @@ export class ModelSelectorComponent extends Container {
 			this.#updateList();
 		}
 	}
+	#getInitialThinkingChoiceIndex(item: ModelItem | CanonicalModelItem, levels: ThinkingLevel[]): number {
+		const preferred = this.#getPreferredThinkingLevel(item);
+		if (preferred && preferred !== ThinkingLevel.Inherit) {
+			const index = levels.indexOf(preferred);
+			if (index !== -1) return index;
+		}
+		return 0;
+	}
+
+	#getPreferredThinkingLevel(item: ModelItem | CanonicalModelItem): ThinkingLevel | undefined {
+		if (item.thinkingLevel && item.thinkingLevel !== ThinkingLevel.Inherit) {
+			return item.thinkingLevel;
+		}
+		return undefined;
+	}
 
 	#handleSelect(
 		item: ModelItem | CanonicalModelItem,
@@ -1707,9 +1722,10 @@ export class ModelSelectorComponent extends Container {
 	): void {
 		const itemThinkingLevel = thinkingLevel ?? item.thinkingLevel;
 		const hasExplicitThinkingChoice = thinkingLevel !== undefined || item.explicitThinkingLevel === true;
-		if (!hasExplicitThinkingChoice && requiresExplicitThinkingChoice(item.model)) {
-			this.#pendingThinkingChoice = { item, role, levels: getSelectableThinkingLevels(item.model) };
-			this.#selectedThinkingIndex = 0;
+		if (!hasExplicitThinkingChoice && requiresExplicitThinkingChoice(item.model, role)) {
+			const levels = getSelectableThinkingLevels(item.model);
+			this.#pendingThinkingChoice = { item, role, levels };
+			this.#selectedThinkingIndex = this.#getInitialThinkingChoiceIndex(item, levels);
 			this.#updateList();
 			return;
 		}
@@ -1764,8 +1780,10 @@ export class ModelSelectorComponent extends Container {
 	}
 }
 
-function requiresExplicitThinkingChoice(model: Model): boolean {
-	return model.reasoning === true && (model.provider === "openai" || model.provider === "openai-codex");
+function requiresExplicitThinkingChoice(model: Model, role: GjcModelAssignmentTargetId | null): boolean {
+	if (model.reasoning !== true) return false;
+	if (model.provider === "openai" || model.provider === "openai-codex") return true;
+	return role !== null;
 }
 
 function getSelectableThinkingLevels(model: Model): ThinkingLevel[] {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -907,8 +907,7 @@ export class SelectorController {
 								if (target.settingsPath === "modelRoles") {
 									this.ctx.settings.setModelRole(role, value);
 								} else {
-									const overrides = this.ctx.settings.get("task.agentModelOverrides");
-									this.ctx.settings.set("task.agentModelOverrides", { ...overrides, [role]: value });
+									this.ctx.settings.setAgentModelOverride(role, value);
 								}
 							}
 							modelSelector.refreshRoleAssignments({
@@ -918,6 +917,9 @@ export class SelectorController {
 									this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
 							});
 							this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
+							this.ctx.statusLine.invalidate();
+							this.ctx.updateEditorBorderColor();
+							await this.ctx.notifyConfigChanged?.();
 							this.ctx.showStatus(`${role} agent model: ${value}`);
 							done();
 							this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1338,29 +1338,8 @@ export async function executeBuiltinSlashCommand(
 		return true;
 	}
 	if (command.handle) {
-		// No TUI-specific override → adapt the ACP/text-mode `handle` to the
-		// TUI by routing `runtime.output` through `ctx.showStatus`, clearing
-		// the editor after the call, and reusing the active session's plugin
-		// reload pipeline. Spec authors get a single body usable from either
-		// dispatcher without forcing every TUI test to construct the full
-		// `SlashCommandRuntime` shape.
 		const ctx = runtime.ctx;
-		const adapted: SlashCommandRuntime = {
-			session: ctx.session,
-			sessionManager: ctx.sessionManager,
-			settings: ctx.settings,
-			cwd: ctx.sessionManager.getCwd(),
-			output: (text: string) => {
-				ctx.showStatus(text);
-			},
-			refreshCommands: () => ctx.refreshSlashCommandState(),
-			reloadPlugins: async () => {
-				const projectPath = await resolveActiveProjectRegistryPath(ctx.sessionManager.getCwd());
-				clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-				await ctx.refreshSlashCommandState();
-				await ctx.session.refreshSshTool({ activateIfAvailable: true });
-			},
-		};
+		const adapted = toSlashCommandRuntime(runtime);
 		const result = await command.handle(parsed, adapted);
 		ctx.editor.setText("");
 		if (result && typeof result === "object" && "prompt" in result) return result.prompt;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -59,6 +59,32 @@ function fastStatusRoleTargets(): Array<{ id: GjcModelAssignmentTargetId; label:
 	}));
 }
 
+function toSlashCommandRuntime(runtime: TuiSlashCommandRuntime): SlashCommandRuntime {
+	const ctx = runtime.ctx;
+	return {
+		session: ctx.session,
+		sessionManager: ctx.sessionManager,
+		settings: ctx.settings,
+		cwd: ctx.sessionManager.getCwd(),
+		output: (text: string) => {
+			ctx.showStatus(text);
+		},
+		refreshCommands: () => ctx.refreshSlashCommandState(),
+		reloadPlugins: async () => {
+			const projectPath = await resolveActiveProjectRegistryPath(ctx.sessionManager.getCwd());
+			clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
+			await ctx.refreshSlashCommandState();
+			await ctx.session.refreshSshTool({ activateIfAvailable: true });
+		},
+		notifyTitleChanged: () => {
+			ctx.statusLine.invalidate();
+			ctx.updateEditorBorderColor();
+			ctx.ui.requestRender();
+		},
+		notifyConfigChanged: () => ctx.notifyConfigChanged?.(),
+	};
+}
+
 function parseProviderSetupSlashArgs(args: string): {
 	preset?: string;
 	compat?: string;
@@ -300,7 +326,7 @@ function modelSelectionUsage(runtime: SlashCommandRuntime, currentModelLine?: st
 	return [
 		currentModelLine,
 		formatModelAssignmentSummary(runtime),
-		"ACP/text mode: use /model <model> for DEFAULT, or /model <target> <model> for EXECUTOR, ARCHITECT, PLANNER, or CRITIC.",
+		"Use /model <model> for DEFAULT, or /model <target> <model[:effort]> for EXECUTOR, ARCHITECT, PLANNER, or CRITIC.",
 		formatModelOnboardingGuidance(),
 	]
 		.filter((line): line is string => Boolean(line))
@@ -372,6 +398,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		acpDescription: "Show current model selection",
 		inlineHint: "[target] <model>",
 		acpInputHint: "[target] <model>",
+		allowArgs: true,
 		handle: async (command, runtime) => {
 			if (command.args) {
 				const parsedArgs = parseModelCommandArgs(command.args);
@@ -429,10 +456,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 							if (target.settingsPath === "modelRoles") {
 								runtime.settings.setModelRole(parsedArgs.targetId, roleSelector);
 							} else {
-								runtime.settings.set("task.agentModelOverrides", {
-									...overrides,
-									[parsedArgs.targetId]: roleSelector,
-								});
+								runtime.settings.setAgentModelOverride(parsedArgs.targetId, roleSelector);
 							}
 						}
 						runtime.settings.getStorage()?.recordModelUsage(`${selection.model.provider}/${selection.model.id}`);
@@ -454,7 +478,18 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			);
 			return commandConsumed();
 		},
-		handleTui: (_command, runtime) => {
+		handleTui: async (command, runtime) => {
+			if (command.args.trim()) {
+				const result = await BUILTIN_SLASH_COMMAND_LOOKUP.get(command.name)?.handle?.(
+					command,
+					toSlashCommandRuntime(runtime),
+				);
+				runtime.ctx.statusLine.invalidate();
+				runtime.ctx.updateEditorBorderColor();
+				runtime.ctx.editor.setText("");
+				runtime.ctx.ui.requestRender();
+				return result;
+			}
 			runtime.ctx.showModelSelector();
 			runtime.ctx.editor.setText("");
 		},

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -5,6 +5,7 @@ import { getThemeByName, setThemeInstance, theme } from "../src/modes/theme/them
 import type { AgentSession } from "../src/session/agent-session";
 import type { SessionManager } from "../src/session/session-manager";
 import { ACP_BUILTIN_SLASH_COMMANDS, executeAcpBuiltinSlashCommand } from "../src/slash-commands/acp-builtins";
+import { executeBuiltinSlashCommand } from "../src/slash-commands/builtin-registry";
 import * as sshConfig from "../src/ssh/config-writer";
 
 interface FakeAcpBuiltinSession {
@@ -409,13 +410,14 @@ describe("ACP builtin slash commands", () => {
 		expect(output[0]).not.toContain("Quick");
 	});
 
-	it("model: returns ACP usage message when args provided", async () => {
+	it("model: returns model usage message when args cannot resolve", async () => {
 		const { output, runtime } = createRuntime();
 
 		const result = await executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet", runtime);
 
 		expect(result).toEqual({ consumed: true });
-		expect(output[0]?.toLowerCase()).toContain("acp");
+		expect(output[0]).toContain("Unknown model: claude-3-5-sonnet");
+		expect(output[0]).toContain("/model <target> <model[:effort]>");
 	});
 
 	it("model: applies known id and emits both title + config change notifications", async () => {
@@ -535,6 +537,33 @@ describe("ACP builtin slash commands", () => {
 		});
 	});
 
+	it("model: updates the live role-agent override when a runtime profile is active", async () => {
+		const { runtime, session } = createRuntime();
+		session.getAvailableModels = () => [{ provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 }];
+		runtime.settings.set("task.agentModelOverrides", {
+			executor: "anthropic/persisted-executor:low",
+		});
+		runtime.settings.override("task.agentModelOverrides", {
+			executor: "anthropic/profile-executor:high",
+			planner: "anthropic/profile-planner:low",
+		});
+
+		const result = await executeAcpBuiltinSlashCommand("/model planner anthropic/claude-3-5-sonnet:high", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(runtime.settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/profile-executor:high",
+			planner: "anthropic/claude-3-5-sonnet:high",
+		});
+
+		runtime.settings.clearOverride("task.agentModelOverrides");
+
+		expect(runtime.settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/persisted-executor:low",
+			planner: "anthropic/claude-3-5-sonnet:high",
+		});
+	});
+
 	it("model: preserves canonical selectors for text role-agent assignments", async () => {
 		const { output, runtime, session } = createRuntime();
 		const available = [{ provider: "anthropic", id: "claude-sonnet-4-5", contextWindow: 200_000 }];
@@ -549,6 +578,44 @@ describe("ACP builtin slash commands", () => {
 			executor: "claude-sonnet:low",
 		});
 		expect(output[0]).toContain("executor agent model set to claude-sonnet:low");
+	});
+
+	it("model: TUI args assign a role-agent target instead of reopening the selector", async () => {
+		const { runtime, session } = createRuntime();
+		session.getAvailableModels = () => [{ provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 }];
+
+		const statuses: string[] = [];
+		let configNotified = 0;
+		const showModelSelector = spyOn({ showModelSelector() {} }, "showModelSelector");
+		const ctx = {
+			session: runtime.session,
+			sessionManager: runtime.sessionManager,
+			settings: runtime.settings,
+			showStatus: (text: string) => statuses.push(text),
+			showError: (_text: string) => {},
+			showModelSelector,
+			editor: { setText: spyOn({ setText(_text: string) {} }, "setText") },
+			statusLine: { invalidate: spyOn({ invalidate() {} }, "invalidate") },
+			updateEditorBorderColor: spyOn({ updateEditorBorderColor() {} }, "updateEditorBorderColor"),
+			ui: { requestRender: spyOn({ requestRender() {} }, "requestRender") },
+			refreshSlashCommandState: async () => {},
+			notifyConfigChanged: () => {
+				configNotified++;
+			},
+		};
+
+		const result = await executeBuiltinSlashCommand("/model executor anthropic/claude-3-5-sonnet:low", {
+			ctx: ctx as never,
+			handleBackgroundCommand: () => {},
+		});
+
+		expect(result).toBe(true);
+		expect(showModelSelector).not.toHaveBeenCalled();
+		expect(runtime.settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet:low",
+		});
+		expect(statuses[0]).toContain("executor agent model set to anthropic/claude-3-5-sonnet:low");
+		expect(configNotified).toBe(1);
 	});
 
 	it("model: does not emit config change when id is unknown", async () => {

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -187,12 +187,6 @@ describe("ModelSelector canonical model selection", () => {
 		expect(actionRendered).not.toContain("Set as TASK");
 
 		selector.handleInput("\n");
-		expect(selected).toBeUndefined();
-		const thinkingRendered = normalizeRenderedText(selector.render(220).join("\n"));
-		expect(thinkingRendered).toContain("Reasoning for Default");
-		expect(thinkingRendered).toContain("low");
-		installTestTheme();
-		selector.handleInput("\n");
 		const selectedAfterEnter = selected;
 		if (!selectedAfterEnter) throw new Error("Expected Enter to select a model");
 		expect(selectedAfterEnter.model).toBe(model);

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -187,7 +187,12 @@ describe("ModelSelector canonical model selection", () => {
 		expect(actionRendered).not.toContain("Set as TASK");
 
 		selector.handleInput("\n");
+		expect(selected).toBeUndefined();
+		const thinkingRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(thinkingRendered).toContain("Reasoning for Default");
+		expect(thinkingRendered).toContain("low");
 		installTestTheme();
+		selector.handleInput("\n");
 		const selectedAfterEnter = selected;
 		if (!selectedAfterEnter) throw new Error("Expected Enter to select a model");
 		expect(selectedAfterEnter.model).toBe(model);
@@ -220,12 +225,60 @@ describe("ModelSelector canonical model selection", () => {
 		selector.handleInput("\n");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
+		expect(selected).toBeUndefined();
+		const thinkingRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(thinkingRendered).toContain("Reasoning for Executor");
+		expect(thinkingRendered).toContain("xhigh");
+		selector.handleInput("\n");
 
 		const selectedAfterEnter = selected;
 		if (!selectedAfterEnter) throw new Error("Expected role-agent selection");
 		expect(selectedAfterEnter.role).toBe("executor");
 		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Off);
 		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}:off`);
+	});
+
+	test("role assignment updates live runtime override for next selector render", async () => {
+		installTestTheme();
+		const model = createOpenAIModel("openai", "gpt-live-override-test");
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", {
+			planner: `${model.provider}/${model.id}:low`,
+		});
+		settings.override("task.agentModelOverrides", {
+			planner: `${model.provider}/${model.id}:low`,
+		});
+
+		const selector = createSelector(model, settings, selection => {
+			if (selection.kind === "assignment" && selection.role) {
+				settings.setAgentModelOverride(selection.role, selection.selector ?? `${model.provider}/${model.id}`);
+			}
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+
+		const nextSelector = createSelector(model, settings);
+		await Bun.sleep(0);
+		installTestTheme();
+		const rendered = normalizeRenderedText(nextSelector.render(220).join("\n"));
+
+		expect(rendered).toContain("PLANNER (high)");
+
+		settings.clearOverride("task.agentModelOverrides");
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			planner: `${model.provider}/${model.id}:high`,
+		});
 	});
 
 	test("temporary scoped model selection carries selected reasoning", async () => {
@@ -299,6 +352,7 @@ describe("ModelSelector canonical model selection", () => {
 		selector.handleInput("\t");
 		selector.handleInput("\n");
 		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
 		selector.handleInput("\n");
 
 		const selectedAfterEnter = selected;
@@ -525,9 +579,9 @@ describe("ModelSelector canonical model selection", () => {
 		selector.handleInput("\n");
 
 		const selectedAfterThinking = selected;
-		if (!selectedAfterThinking) throw new Error("Expected OpenAI selection after explicit off choice");
+		if (!selectedAfterThinking) throw new Error("Expected OpenAI selection after scoped reasoning choice");
 		expect(selectedAfterThinking.role).toBe("default");
-		expect(selectedAfterThinking.thinkingLevel).toBe(ThinkingLevel.Off);
+		expect(selectedAfterThinking.thinkingLevel).toBe(ThinkingLevel.High);
 		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}`);
 	});
 

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -212,6 +212,30 @@ describe("Settings", () => {
 
 			expect(settings.getModelRole("default")).toBe("anthropic/claude-opus-4-5");
 		});
+
+		it("keeps live agent model overrides aligned without persisting profile entries", () => {
+			const settings = Settings.isolated();
+
+			settings.set("task.agentModelOverrides", { executor: "persisted/executor" });
+			settings.override("task.agentModelOverrides", {
+				executor: "profile/executor",
+				planner: "profile/planner",
+			});
+
+			settings.setAgentModelOverride("planner", "user/planner:high");
+
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "profile/executor",
+				planner: "user/planner:high",
+			});
+
+			settings.clearOverride("task.agentModelOverrides");
+
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "persisted/executor",
+				planner: "user/planner:high",
+			});
+		});
 	});
 
 	describe("migrations", () => {


### PR DESCRIPTION
## Summary
- route `/model <role> <model[:effort]>` through the TUI command path instead of reopening the selector
- keep role-agent model assignments aligned with active runtime overrides so reopening `/model` shows the newly selected role/effort immediately
- prompt for effort when assigning reasoning-capable non-OpenAI models to role-agent targets

## Verification
- `bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts packages/coding-agent/test/acp-builtins.test.ts packages/coding-agent/test/settings-manager.test.ts`
- `bun --cwd=packages/coding-agent run check`
