### PR TITLE
test: tolerate Python dispose wait timer rounding

### DIFF
--- a/packages/coding-agent/test/agent-session-python-cleanup.test.ts
+++ b/packages/coding-agent/test/agent-session-python-cleanup.test.ts
@@ -84,10 +84,12 @@ const emptyWorkspaceTree = (cwd: string): WorkspaceTree => ({
 });
 
 const PYTHON_DISPOSE_WAIT_MS = 3_000;
+const isPythonDisposeWaitDuration = (duration: unknown): duration is number =>
+	typeof duration === "number" && duration >= PYTHON_DISPOSE_WAIT_MS - 1 && duration <= PYTHON_DISPOSE_WAIT_MS;
 const mockLongPythonDisposeSleepsImmediate = () => {
 	const realSleep = Bun.sleep.bind(Bun);
 	return vi.spyOn(Bun, "sleep").mockImplementation((duration?: number | Date) => {
-		if (typeof duration === "number" && duration === PYTHON_DISPOSE_WAIT_MS) {
+		if (isPythonDisposeWaitDuration(duration)) {
 			return Promise.resolve();
 		}
 		return realSleep(duration ?? 0);
@@ -416,9 +418,7 @@ describe("AgentSession python cleanup", () => {
 
 		const [toolResult] = await Promise.all([toolExecution, disposeSession]);
 
-		expect(
-			sleepSpy.mock.calls.some(([duration]) => typeof duration === "number" && duration === PYTHON_DISPOSE_WAIT_MS),
-		).toBe(true);
+		expect(sleepSpy.mock.calls.some(([duration]) => isPythonDisposeWaitDuration(duration))).toBe(true);
 
 		expect(disposed).toBe(true);
 		expect(toolExecutionSettled).toBe(true);
@@ -463,7 +463,7 @@ describe("AgentSession python cleanup", () => {
 			firstDisposed = true;
 		});
 		await disposeFirst;
-		expect(sleepSpy).toHaveBeenCalledWith(PYTHON_DISPOSE_WAIT_MS);
+		expect(sleepSpy.mock.calls.some(([duration]) => isPythonDisposeWaitDuration(duration))).toBe(true);
 
 		expect(firstDisposed).toBe(true);
 		expect(firstExecutionSettled).toBe(false);
@@ -705,7 +705,7 @@ describe("AgentSession python cleanup", () => {
 		const sleepSpy = mockLongPythonDisposeSleepsImmediate();
 
 		await session.dispose();
-		expect(sleepSpy).toHaveBeenCalledWith(PYTHON_DISPOSE_WAIT_MS);
+		expect(sleepSpy.mock.calls.some(([duration]) => isPythonDisposeWaitDuration(duration))).toBe(true);
 		const [firstResult, secondResult] = await Promise.all([firstExecution, secondExecution]);
 
 		expect(firstResult.cancelled).toBe(true);


### PR DESCRIPTION
## Summary
- Fixes the post-merge dev CI flake from run 28743385456 after PR #1641 by making the Python dispose wait test tolerate fake-clock rounding from 3000ms to 2999ms.
- Keeps product dispose behavior unchanged; the implementation still waits 3000ms before abort and 1000ms after abort.
- Limits the assertion helper to 2999..3000ms so unrelated 1000ms/5000ms sleeps do not satisfy the check.

## Validation
- Built local native addon first because this worktree was missing the generated native binary: `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/agent-session-python-cleanup.test.ts` → 11 pass, 0 fail, 70 expect() calls
- `bun --cwd=packages/coding-agent run check` → biome check passed; tsgo typecheck passed
- Architect review lane: CLEAR/CLEAR/CLEAR, APPROVE
- Executor QA/red-team lane: passed

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*