### PR TITLE
Fix computer screenshot coordinate frame

### DIFF
--- a/crates/pi-natives/src/computer/capture.rs
+++ b/crates/pi-natives/src/computer/capture.rs
@@ -48,6 +48,7 @@ struct CgRect {
 
 type CgDirectDisplayId = u32;
 type CgImageRef = *mut c_void;
+type CgDisplayModeRef = *mut c_void;
 type CgColorSpaceRef = *mut c_void;
 type CgContextRef = *mut c_void;
 
@@ -64,6 +65,10 @@ unsafe extern "C" {
 	fn CGDisplayCreateImage(display: CgDirectDisplayId) -> CgImageRef;
 	fn CGDisplayPixelsWide(display: CgDirectDisplayId) -> usize;
 	fn CGDisplayPixelsHigh(display: CgDirectDisplayId) -> usize;
+	fn CGDisplayCopyDisplayMode(display: CgDirectDisplayId) -> CgDisplayModeRef;
+	fn CGDisplayModeGetPixelWidth(mode: CgDisplayModeRef) -> usize;
+	fn CGDisplayModeGetPixelHeight(mode: CgDisplayModeRef) -> usize;
+	fn CGDisplayModeRelease(mode: CgDisplayModeRef);
 	fn CGImageGetWidth(image: CgImageRef) -> usize;
 	fn CGImageGetHeight(image: CgImageRef) -> usize;
 	fn CGImageRelease(image: CgImageRef);
@@ -133,15 +138,11 @@ pub struct CapturedFrame {
 pub fn capture_primary_display() -> Result<CapturedFrame, CaptureError> {
 	// SAFETY: pure Core Graphics geometry queries for the active primary display;
 	// no image capture occurs before `CGDisplayCreateImage` below.
-	let (display_id, display) = unsafe {
+	let (display_id, bounds) = unsafe {
 		let id = CGMainDisplayID();
-		let bounds = CGDisplayBounds(id);
-		let pixels_wide = CGDisplayPixelsWide(id);
-		let pixels_high = CGDisplayPixelsHigh(id);
-		(id, display_descriptor(pixels_wide, pixels_high, bounds))
+		(id, CGDisplayBounds(id))
 	};
 
-	let display_epoch = display_epoch(&display);
 	let capture_id = next_capture_id();
 
 	// SAFETY: `display_id` is a valid primary-display id. The returned image is
@@ -151,7 +152,7 @@ pub fn capture_primary_display() -> Result<CapturedFrame, CaptureError> {
 		return Err(CaptureError::CaptureFailed);
 	}
 
-	let result = frame_from_image(image, display, display_epoch, capture_id);
+	let result = frame_from_image(image, bounds, capture_id);
 
 	// SAFETY: `image` is non-null (checked above) and not used after release.
 	unsafe { CGImageRelease(image) };
@@ -168,8 +169,7 @@ pub fn current_display_epoch() -> u64 {
 /// `image`; the caller owns its lifetime.
 fn frame_from_image(
 	image: CgImageRef,
-	display: NormalizedDisplay,
-	display_epoch: u64,
+	bounds: CgRect,
 	capture_id: u32,
 ) -> Result<CapturedFrame, CaptureError> {
 	// SAFETY: `image` is non-null per the caller's check.
@@ -177,6 +177,9 @@ fn frame_from_image(
 	if width == 0 || height == 0 {
 		return Err(CaptureError::CaptureFailed);
 	}
+
+	let display = display_descriptor(width, height, bounds);
+	let display_epoch = display_epoch(&display);
 
 	let bytes_per_row = width * BYTES_PER_PIXEL;
 	let mut buffer = vec![0u8; bytes_per_row * height];
@@ -237,8 +240,25 @@ fn current_display_descriptor() -> NormalizedDisplay {
 	unsafe {
 		let display_id = CGMainDisplayID();
 		let bounds = CGDisplayBounds(display_id);
-		display_descriptor(CGDisplayPixelsWide(display_id), CGDisplayPixelsHigh(display_id), bounds)
+		let (width, height) = display_mode_pixels(display_id)
+			.unwrap_or_else(|| (CGDisplayPixelsWide(display_id), CGDisplayPixelsHigh(display_id)));
+		display_descriptor(width, height, bounds)
 	}
+}
+
+unsafe fn display_mode_pixels(display_id: CgDirectDisplayId) -> Option<(usize, usize)> {
+	// SAFETY: Core Graphics returns either null or an owned display-mode reference
+	// for this display id. Non-null references are released exactly once below.
+	let mode = unsafe { CGDisplayCopyDisplayMode(display_id) };
+	if mode.is_null() {
+		return None;
+	}
+	// SAFETY: `mode` is non-null and valid until released below.
+	let width = unsafe { CGDisplayModeGetPixelWidth(mode) };
+	let height = unsafe { CGDisplayModeGetPixelHeight(mode) };
+	// SAFETY: `mode` is non-null and is not used after release.
+	unsafe { CGDisplayModeRelease(mode) };
+	(width > 0 && height > 0).then_some((width, height))
 }
 
 fn display_descriptor(width: usize, height: usize, bounds: CgRect) -> NormalizedDisplay {
@@ -285,7 +305,7 @@ fn encode_png(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, CaptureEr
 
 #[cfg(test)]
 mod tests {
-	use super::{capture_primary_display, display_epoch};
+	use super::{capture_primary_display, current_display_epoch, display_epoch};
 	use crate::computer::coords::NormalizedDisplay;
 
 	#[test]
@@ -309,6 +329,7 @@ mod tests {
 		let decoded = image::load_from_memory(&frame.png).expect("captured bytes decode as PNG");
 		assert_eq!(decoded.width(), frame.display.width_px);
 		assert_eq!(decoded.height(), frame.display.height_px);
+		assert_eq!(current_display_epoch(), frame.display_epoch);
 
 		let rgba = decoded.to_rgba8();
 		let first = rgba.pixels().next().copied();

--- a/crates/pi-natives/src/computer/controller.rs
+++ b/crates/pi-natives/src/computer/controller.rs
@@ -10,7 +10,7 @@ use napi_derive::napi;
 use crate::computer::{
 	ComputerScreenshot,
 	capture::capture_primary_display,
-	executor::{ExecError, InputAction, MacDisplayContext, MacPermissionGate, execute_input},
+	executor::{DisplayContext, ExecError, InputAction, MacPermissionGate, execute_input},
 	hotkey,
 	input::{MouseButton, guarded_controller},
 	supervisor::Supervisor,
@@ -125,6 +125,7 @@ impl ComputerController {
 		let frame =
 			capture_primary_display().map_err(|err| napi::Error::from_reason(format!("{err}")))?;
 		let display = frame.display;
+		let display_ctx = CapturedDisplayContext { epoch: frame.display_epoch };
 		let mut controller = guarded_controller()
 			.map_err(|err| napi_error("COMPUTER_PERMISSION_REQUIRED", err.to_string()))?;
 		let cancel = || Supervisor::global().is_suspended();
@@ -132,13 +133,23 @@ impl ComputerController {
 			&action,
 			Supervisor::global(),
 			&MacPermissionGate,
-			&MacDisplayContext,
+			&display_ctx,
 			expected_epoch.map(epoch_from_f64),
 			&display,
 			&mut controller,
 			&cancel,
 		)
 		.map_err(exec_error)
+	}
+}
+
+struct CapturedDisplayContext {
+	epoch: u64,
+}
+
+impl DisplayContext for CapturedDisplayContext {
+	fn current_epoch(&self) -> u64 {
+		self.epoch
 	}
 }
 


### PR DESCRIPTION
## Summary
- derive the native screenshot coordinate descriptor from the actual `CGImage` dimensions that are encoded into the PNG
- make the no-capture display epoch path use CoreGraphics display-mode pixels, with `CGDisplayPixelsWide/High` only as fallback
- compare stale-display epochs against the action capture frame in the N-API controller so valid follow-up coordinate actions are not rejected by a mismatched descriptor
- extend the ignored real capture test to assert PNG dimensions and current epoch match the returned display descriptor

Fixes #1644

## Verification
- `bun test packages/coding-agent/test/tools/computer.test.ts`
- `cargo test -p pi-natives display_epoch_roundtrips_through_javascript_number`
- `cargo test -p pi-natives captures_non_uniform_primary_display -- --ignored --nocapture`
- `cargo check -p pi-natives`
- `bun run check:types` (packages/coding-agent)
- `bunx biome check packages/coding-agent/src/tools/computer.ts packages/coding-agent/test/tools/computer.test.ts packages/coding-agent/src/prompts/tools/computer.md`
- `git diff --check`

## Reproduction
On current `origin/dev` before this patch, the real ignored capture test failed on this host with decoded PNG width `5120` while `frame.display.width_px` was `2560`. After this patch, the same real capture E2E passes.