### PR TITLE
Fail computer actions when native methods are missing

### DIFF
--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -407,9 +407,14 @@ function captureScreenshot(
 	deadline: ComputerDeadline | undefined,
 	signal?: AbortSignal,
 ): Promise<unknown> {
-	const screenshot = controller.screenshot;
-	if (!screenshot) missingNativeMethod("screenshot", "screenshot");
-	return runComputerOperation(() => screenshot(), deadline, signal);
+	return runComputerOperation(
+		() => {
+			if (!controller.screenshot) missingNativeMethod("screenshot", "screenshot");
+			return controller.screenshot();
+		},
+		deadline,
+		signal,
+	);
 }
 
 function missingNativeMethod(action: string, method: string): never {

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -407,7 +407,15 @@ function captureScreenshot(
 	deadline: ComputerDeadline | undefined,
 	signal?: AbortSignal,
 ): Promise<unknown> {
-	return runComputerOperation(() => controller.screenshot?.(), deadline, signal);
+	const screenshot = controller.screenshot;
+	if (!screenshot) missingNativeMethod("screenshot", "screenshot");
+	return runComputerOperation(() => screenshot(), deadline, signal);
+}
+
+function missingNativeMethod(action: string, method: string): never {
+	throw new ToolError(`COMPUTER_UNAVAILABLE: Native ComputerController.${method} is unavailable for ${action}.`, {
+		code: "COMPUTER_UNAVAILABLE",
+	});
 }
 
 function shouldCapturePostActionScreenshot(
@@ -508,20 +516,25 @@ function dispatchComputerAction(
 		() => {
 			switch (params.action) {
 				case "screenshot":
-					return controller.screenshot?.();
+					if (!controller.screenshot) missingNativeMethod("screenshot", "screenshot");
+					return controller.screenshot();
 				case "click":
 					validatePointerCoordinates("click", params.x, params.y, context);
-					return controller.click?.(expectedEpoch, params.x, params.y, params.button ?? "left");
+					if (!controller.click) missingNativeMethod("click", "click");
+					return controller.click(expectedEpoch, params.x, params.y, params.button ?? "left");
 				case "double_click":
 					validatePointerCoordinates("double_click", params.x, params.y, context);
-					return controller.doubleClick?.(expectedEpoch, params.x, params.y, params.button ?? "left");
+					if (!controller.doubleClick) missingNativeMethod("double_click", "doubleClick");
+					return controller.doubleClick(expectedEpoch, params.x, params.y, params.button ?? "left");
 				case "move":
 					validatePointerCoordinates("move", params.x, params.y, context);
-					return controller.move?.(expectedEpoch, params.x, params.y);
+					if (!controller.move) missingNativeMethod("move", "move");
+					return controller.move(expectedEpoch, params.x, params.y);
 				case "drag":
 					validatePointerCoordinates("drag start", params.x, params.y, context);
 					validatePointerCoordinates("drag end", params.to_x, params.to_y, context);
-					return controller.drag?.(
+					if (!controller.drag) missingNativeMethod("drag", "drag");
+					return controller.drag(
 						expectedEpoch,
 						params.x,
 						params.y,
@@ -531,13 +544,17 @@ function dispatchComputerAction(
 					);
 				case "scroll":
 					validatePointerCoordinates("scroll", params.x, params.y, context);
-					return controller.scroll?.(expectedEpoch, params.x, params.y, params.scroll_x, params.scroll_y);
+					if (!controller.scroll) missingNativeMethod("scroll", "scroll");
+					return controller.scroll(expectedEpoch, params.x, params.y, params.scroll_x, params.scroll_y);
 				case "type":
-					return controller.type?.(undefined, params.text);
+					if (!controller.type) missingNativeMethod("type", "type");
+					return controller.type(undefined, params.text);
 				case "keypress":
-					return controller.keypress?.(undefined, params.keys);
+					if (!controller.keypress) missingNativeMethod("keypress", "keypress");
+					return controller.keypress(undefined, params.keys);
 				case "wait":
-					return controller.wait?.(undefined, capWaitMs(params.ms, remainingComputerTimeoutMs(deadline)));
+					if (!controller.wait) missingNativeMethod("wait", "wait");
+					return controller.wait(undefined, capWaitMs(params.ms, remainingComputerTimeoutMs(deadline)));
 			}
 		},
 		deadline,

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -318,6 +318,19 @@ describe("computer tool dispatch", () => {
 		expect(calls).toEqual([{ method: "click", args: [undefined, 1, 2, "left"] }]);
 	});
 
+	it("fails closed when a native controller method is missing", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		setComputerControllerFactoryForTests(() => ({}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+		const result = await tool.execute("missing-click", { action: "click", x: 1, y: 2 });
+
+		expect(result.isError).toBe(true);
+		expect(result.details?.code).toBe("COMPUTER_UNAVAILABLE");
+		expect(textOf(result)).toContain("ComputerController.click is unavailable");
+	});
+
 	it("bounds oversized screenshot images sent inline while preserving the full-resolution artifact", async () => {
 		setComputerPlatformForTests("darwin");
 		setComputerArchForTests("arm64");

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -318,17 +318,81 @@ describe("computer tool dispatch", () => {
 		expect(calls).toEqual([{ method: "click", args: [undefined, 1, 2, "left"] }]);
 	});
 
-	it("fails closed when a native controller method is missing", async () => {
+	it("fails closed when native controller methods are missing", async () => {
+		const cases: Array<{ name: string; params: Parameters<ComputerTool["execute"]>[1]; method: string }> = [
+			{ name: "screenshot", params: { action: "screenshot" }, method: "screenshot" },
+			{ name: "click", params: { action: "click", x: 1, y: 2 }, method: "click" },
+			{ name: "double-click", params: { action: "double_click", x: 1, y: 2 }, method: "doubleClick" },
+			{ name: "move", params: { action: "move", x: 1, y: 2 }, method: "move" },
+			{ name: "drag", params: { action: "drag", x: 1, y: 2, to_x: 3, to_y: 4 }, method: "drag" },
+			{ name: "scroll", params: { action: "scroll", x: 1, y: 2, scroll_x: 0, scroll_y: -1 }, method: "scroll" },
+			{ name: "type", params: { action: "type", text: "hello" }, method: "type" },
+			{ name: "keypress", params: { action: "keypress", keys: ["Meta", "K"] }, method: "keypress" },
+			{ name: "wait", params: { action: "wait", ms: 1 }, method: "wait" },
+		];
+
+		for (const testCase of cases) {
+			setComputerPlatformForTests("darwin");
+			setComputerArchForTests("arm64");
+			setComputerControllerFactoryForTests(() => ({}));
+			const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+			const result = await tool.execute(`missing-${testCase.name}`, testCase.params);
+
+			expect(result.isError).toBe(true);
+			expect(result.details?.code).toBe("COMPUTER_UNAVAILABLE");
+			expect(textOf(result)).toContain(`ComputerController.${testCase.method} is unavailable`);
+		}
+	});
+
+	it("fails closed when a requested post-action screenshot method is missing", async () => {
 		setComputerPlatformForTests("darwin");
 		setComputerArchForTests("arm64");
-		setComputerControllerFactoryForTests(() => ({}));
+		const calls: string[] = [];
+		setComputerControllerFactoryForTests(() => ({
+			click: () => {
+				calls.push("click");
+			},
+		}));
 		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
 
-		const result = await tool.execute("missing-click", { action: "click", x: 1, y: 2 });
+		const result = await tool.execute("missing-post-action-shot", {
+			action: "click",
+			x: 1,
+			y: 2,
+			include_screenshot: true,
+		});
 
 		expect(result.isError).toBe(true);
 		expect(result.details?.code).toBe("COMPUTER_UNAVAILABLE");
-		expect(textOf(result)).toContain("ComputerController.click is unavailable");
+		expect(textOf(result)).toContain("ComputerController.screenshot is unavailable");
+		expect(calls).toEqual(["click"]);
+	});
+
+	it("fails closed when batch auto-screenshot requires a missing screenshot method", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		const calls: string[] = [];
+		setComputerControllerFactoryForTests(() => ({
+			click: () => {
+				calls.push("click");
+			},
+		}));
+		const tool = new ComputerTool(
+			createSession(Settings.isolated({ "computer.enabled": true, "computer.autoScreenshot": true })),
+		);
+
+		const result = await tool.execute("missing-batch-auto-shot", {
+			action: "batch",
+			actions: [{ action: "click", x: 1, y: 2 }],
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.details?.code).toBe("COMPUTER_UNAVAILABLE");
+		expect(result.details?.steps).toHaveLength(1);
+		expect(result.details?.steps?.[0]?.code).toBe("COMPUTER_UNAVAILABLE");
+		expect(textOf(result)).toContain("ComputerController.screenshot is unavailable");
+		expect(calls).toEqual(["click"]);
 	});
 
 	it("bounds oversized screenshot images sent inline while preserving the full-resolution artifact", async () => {


### PR DESCRIPTION
## Summary
- replace optional-chained native computer method dispatch with explicit method availability checks
- return a bounded `COMPUTER_UNAVAILABLE` tool error when a required native method is missing
- cover the packaging/binding-regression case where `click` was previously reported as successful despite no native method existing

Fixes #1648

## Verification
- `bun test packages/coding-agent/test/tools/computer.test.ts`
- `bun run check:types` (packages/coding-agent)
- `bunx biome check packages/coding-agent/src/tools/computer.ts packages/coding-agent/test/tools/computer.test.ts packages/coding-agent/src/prompts/tools/computer.md`
- `git diff --check`

## Reproduction
On current `origin/dev`, injecting an empty native controller and executing `click` returned success with `Computer click completed.`. This patch fails closed with `COMPUTER_UNAVAILABLE` instead.