### PR TITLE
feat(hooks): advisory answer-only guard for bare `?` and informational prompts

### DIFF
--- a/packages/coding-agent/src/hooks/native-skill-hook.ts
+++ b/packages/coding-agent/src/hooks/native-skill-hook.ts
@@ -143,6 +143,34 @@ function readPromptText(payload: HookPayload): string {
 	return safeString(payload.prompt ?? payload.user_prompt ?? payload.userPrompt).trim();
 }
 
+const QUESTION_ONLY_ADVISORY_CONTEXT =
+	"Question-only prompt advisory: Treat bare '?' and unambiguous informational questions as answer-only/read-only; do not modify files, run commands, or execute workflow changes unless the user explicitly asks for action.";
+
+const QUESTION_EXPLICIT_ACTION_PATTERN =
+	/\b(add|apply|build|change|commit|create|delete|edit|execute|fix|implement|install|merge|modify|move|patch|refactor|remove|rename|replace|run|ship|start|stop|test|update|write)\b/i;
+const QUESTION_START_PATTERN =
+	/^(what|why|how|when|where|who|which|does|do|did|is|are|was|were|can|could|should|would)\b/i;
+
+function classifyQuestionOnlyPrompt(prompt: string): string | null {
+	const normalized = prompt.trim().replace(/\s+/g, " ");
+	if (!normalized) {
+		return null;
+	}
+	if (normalized === "?") {
+		return QUESTION_ONLY_ADVISORY_CONTEXT;
+	}
+	if (!normalized.endsWith("?")) {
+		return null;
+	}
+	if (QUESTION_EXPLICIT_ACTION_PATTERN.test(normalized)) {
+		return null;
+	}
+	if (!QUESTION_START_PATTERN.test(normalized)) {
+		return null;
+	}
+	return QUESTION_ONLY_ADVISORY_CONTEXT;
+}
+
 function readSessionId(payload: HookPayload): string | undefined {
 	return safeString(payload.session_id ?? payload.sessionId).trim() || undefined;
 }
@@ -221,6 +249,7 @@ export async function dispatchGjcNativeSkillHook(
 		const additionalContext = [
 			skillState ? buildSkillActivationAdditionalContext(skillState, effectiveSkillConfig) : activeUltragoalContext,
 			recoveryContext,
+			classifyQuestionOnlyPrompt(prompt),
 		]
 			.filter((value): value is string => Boolean(value))
 			.join(" ");

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -207,6 +207,41 @@ describe("GJC native skill-state hooks", () => {
 		expect(detectSkillKeywords("please run a consensus plan")[0]?.skill).toBe("ralplan");
 	});
 
+	it("UserPromptSubmit adds advisory answer-only context for question-only prompts", async () => {
+		const root = await cwd();
+		for (const prompt of ["?", "what does /model planner mean?"]) {
+			const result = await dispatchGjcNativeSkillHook({
+				hookEventName: "UserPromptSubmit",
+				userPrompt: prompt,
+				cwd: root,
+				sessionId: `session-question-${prompt === "?" ? "bare" : "model"}`,
+			});
+			const context = String(
+				(result.outputJson?.hookSpecificOutput as { additionalContext?: unknown } | undefined)?.additionalContext ??
+					"",
+			);
+			expect(result.outputJson).not.toMatchObject({ decision: "block" });
+			expect(context).toContain("Question-only prompt advisory");
+			expect(context).toContain("answer-only/read-only");
+		}
+	});
+
+	it("UserPromptSubmit does not add question-only advisory context for explicit action prompts", async () => {
+		const root = await cwd();
+		const result = await dispatchGjcNativeSkillHook({
+			hookEventName: "UserPromptSubmit",
+			userPrompt: "fix the failing model selector test",
+			cwd: root,
+			sessionId: "session-question-action",
+		});
+		const context = String(
+			(result.outputJson?.hookSpecificOutput as { additionalContext?: unknown } | undefined)?.additionalContext ??
+				"",
+		);
+		expect(result.outputJson).not.toEqual(expect.objectContaining({ decision: "block" }));
+		expect(context).not.toContain("Question-only prompt advisory");
+	});
+
 	it("UserPromptSubmit persists session-scoped skill-active and mode state", async () => {
 		const root = await cwd();
 		const result = await dispatchGjcNativeSkillHook(


### PR DESCRIPTION
## Summary
- Add `classifyQuestionOnlyPrompt` to the native `UserPromptSubmit` hook (`packages/coding-agent/src/hooks/native-skill-hook.ts`)
- Bare `?` and unambiguous explanatory questions inject advisory answer-only/read-only `additionalContext` so the agent answers instead of starting work
- Prompts containing explicit action verbs (fix/implement/change/run/...) are excluded from the guard
- Guard is advisory and fail-open: it never returns `decision: "block"` and does not claim hard mutation prevention

## Test plan
- `bun test packages/coding-agent/test/gjc-skill-state-hooks.test.ts` — 48 pass / 0 fail
  - positive: `"?"`, `"what does /model planner mean?"` → advisory context present
  - negative: `"fix the failing model selector test"` → no advisory context
  - never emits `decision: block`

Related: #— (part 1/3 of the question-guard / eager-action / model-UX improvement set; see also the sibling PRs)