### PR TITLE
feat(prompts): distinguish informational questions from change requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ gjc setup defaults --check
 | Claw Code | `gjc --tmux --worktree <name>` | GJC does not install into or replace Claw Code. |
 | External controller / bot | `gjc --mode rpc` for a subprocess worker, or Bridge/HTTPS surfaces where configured | External controllers drive GJC through generic RPC/bridge contracts, not scrollback scraping. |
 
-For standalone MCP support boundaries, see [`docs/standalone-mcp.md`](docs/standalone-mcp.md). For evaluating Aside as an opt-in search/context retrieval sidecar, see [`docs/aside-integration.md`](docs/aside-integration.md). For generic third-party bot setup and provider-independent smokes, see [`docs/bot-integration.md`](docs/bot-integration.md). For the readiness classification across RPC, ACP, and Bridge/HTTPS surfaces, see [`docs/external-control-readiness.md`](docs/external-control-readiness.md). For lower-level protocol details, see [`docs/hermes-mcp-bridge.md`](docs/hermes-mcp-bridge.md), [`docs/rpc.md`](docs/rpc.md), and [`docs/bridge.md`](docs/bridge.md).
+For evaluating Aside as an opt-in search/context retrieval sidecar, see [`docs/aside-integration.md`](docs/aside-integration.md). For generic third-party bot setup and provider-independent smokes, see [`docs/bot-integration.md`](docs/bot-integration.md). For the readiness classification across RPC, ACP, and Bridge/HTTPS surfaces, see [`docs/external-control-readiness.md`](docs/external-control-readiness.md). For lower-level protocol details, see [`docs/rpc.md`](docs/rpc.md) and [`docs/bridge.md`](docs/bridge.md).
 
 ## Configuration
 

--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -20,6 +20,7 @@ Deep Interview implements Ouroboros-inspired Socratic questioning with mathemati
 - User says "ouroboros", "socratic", "I have a vague idea", "not sure exactly what I want"
 - User wants to avoid "that's not what I meant" outcomes from autonomous execution
 - Task is complex enough that jumping to code would waste cycles on scope discovery
+- User asks for implementation but the target, scope, acceptance criteria, or safety boundary is ambiguous enough that mutation would require guessing
 - User wants mathematically-validated clarity before committing to execution
 - User explicitly requests deep-interview even after being told the request is already clear, bounded, and low-risk
 - User requests a trace/research pre-step before the interview, e.g. `/skill:deep-interview --trace <idea>`
@@ -27,6 +28,7 @@ Deep Interview implements Ouroboros-inspired Socratic questioning with mathemati
 
 <Do_Not_Use_When>
 - User has a detailed, specific request with file paths, function names, or acceptance criteria -- execute directly
+- User has an explicit concrete low-risk implementation request with enough target, scope, and acceptance criteria to execute safely -- execute directly
 - User wants to explore options or brainstorm -- use `ralplan` skill instead
 - User wants a quick fix or single change -- use direct execution, not deep-interview or role-agent delegation
 - User says "just do it" or "skip the questions" without an explicit execution path -- respect their intent by exiting deep-interview, not by writing a `pending approval` spec
@@ -52,6 +54,7 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 - When the locked topology has multiple active components, score and target each component explicitly so depth-first clarity on one component cannot hide ambiguity in siblings
 - Keep prompt payloads budgeted: summarize or trim oversized initial context/history before composing question, scoring, spec, or handoff prompts
 - If the user's initial context is oversized, create a concise prompt-safe summary first and wait for that summary before ambiguity scoring, question generation, or downstream execution handoff
+- Route ambiguous implementation asks to clarification, deep-interview, or downstream `ralplan` before mutation; do not infer missing target, scope, acceptance criteria, or safety boundary just to start coding.
 - Do not proceed to execution until ambiguity ≤ the resolved threshold for this run and the user explicitly approves a scoped execution path
 - Treat user wording such as `implementation`, "implementation plan", Korean `구현`, or "구현 계획" as describing the eventual target, not permission to implement now.
 - While still in deep-interview, do not implement, edit/write code, launch implementation workers, or start task/skill/ultragoal implementation; continue interviewing for scope, risks, acceptance criteria, and unknowns.

--- a/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/team/SKILL.md
@@ -112,7 +112,7 @@ Before launching `gjc team`, require a grounded context snapshot:
    - unknowns/open questions
    - likely codebase touchpoints
 4. If ambiguity remains high, gather brownfield facts with focused repo inspection or a canonical read-only role agent first, then run `$deep-interview --quick <task>` before team launch.
-5. If current correctness depends on official docs, version-aware framework guidance, best practices, or external dependency behavior, auto-delegate `researcher` as an evidence lane before or alongside worker launch instead of relying on repo-local recall alone.
+5. If current correctness depends on official docs, version-aware framework guidance, best practices, or external dependency behavior, gather evidence before or alongside worker launch using supported surfaces only: focused repo inspection for local facts, `planner` for broad context mapping/sequencing, `architect` for architecture or external-doc-risk assessment, and direct web/search tools when configured.
 
 Do not start the worker pane until this gate is satisfied; if forced to proceed quickly, state explicit scope/risk limitations in the launch report.
 

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -60,9 +60,11 @@ Use for read-only plan critique. It approves only when execution can proceed wit
 
 <routing>
 - Clear, low-risk implementation request → implement directly with focused verification.
+- Informational questions, bare `?`, and unambiguous explanatory prompts are answer-only/read-only: answer from available context and do not modify files, run commands, or execute workflows unless the user explicitly asks to change, run, implement, or execute something.
 - Do not invoke `deep-interview`, `ralplan`, `ultragoal`, `team`, or role agents for simple clear implementation requests; direct tools and the default launch path are enough.
 - The runtime records a `workflow-intent-diff` CustomEntry for direct-path traceability; it does not participate in LLM context and is not a reason to slow down direct execution.
 - When a task is clear, bounded, and low-risk, the default action is to make the smallest correct change and verify it, not to interview, plan, open a durable ledger, or delegate.
+- Ambiguous implementation asks with missing target, scope, acceptance criteria, or safety boundary require clarification or the appropriate planning workflow before mutation.
 - Small verification needs do not make a task a planning workflow. Escalate only for real ambiguity, non-trivial architecture/sequence risk, durable multi-goal tracking, or useful coordinated workers.
 - Root-cause phase schema is active only for contradiction, regression, or high-risk transition work; otherwise keep ordinary verification and do not add root-cause ceremony.
 - Vague requirements → use `deep-interview` before planning or execution.
@@ -98,6 +100,7 @@ Use for read-only plan critique. It approves only when execution can proceed wit
 - Be concise and information-dense.
 - Do not narrate progress, ceremony, timing, scope inflation, or session limits.
 - If the user's intent is clear, act without asking. Ask only when the next step is destructive or requires a missing choice that materially changes the outcome.
+- Treat an informational question as a request for an answer, not implicit permission to take action; answer read-only unless the user explicitly asks for a concrete change or command execution.
 - When the user proposes something wrong, say what breaks and what to do instead once; then defer to their call.
 - Never use permission-begging or deferral phrasing ("if you want", "if you'd like", "shall I", "I will now", "next I plan to"). For a destructive next step, state the recommended action and stop for approval. For a non-destructive, clearly correct next step, do it directly in the same turn.
 - Do not defer actionable work. Underpromise and overdeliver: report only what is done or in progress, never announce remaining work instead of doing it.

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -83,6 +83,11 @@ describe("default GJC definitions", () => {
 			"skill-fragments/deep-interview/lateral-review-panel.md",
 			"skill-fragments/ultragoal/ai-slop-cleaner.md",
 		]);
+		const team = workflowDefinitions.find(definition => definition.name === "team");
+		expect(team?.content).toContain("supported surfaces only");
+		expect(team?.content).toContain("`planner` for broad context mapping/sequencing");
+		expect(team?.content).toContain("`architect` for architecture or external-doc-risk assessment");
+		expect(team?.content).not.toMatch(/auto-delegate `researcher`|`researcher` as an evidence lane/i);
 	});
 
 	it("exposes deep-interview fragments only through the parent-scoped fragment accessor", () => {
@@ -336,6 +341,11 @@ Project executor override body.
 			expect(routing).toContain(escalationTrigger);
 		}
 
+		expect(routing).toMatch(
+			/Informational questions, bare `\?`, and unambiguous explanatory prompts[\s\S]*answer-only\/read-only/i,
+		);
+		expect(routing).toMatch(/unless the user explicitly asks to change, run, implement, or execute/i);
+		expect(routing).toMatch(/Ambiguous implementation asks[\s\S]*require clarification[\s\S]*before mutation/i);
 		expect(decomposition).toMatch(/skip it for one-step or obvious two-step fixes/i);
 		expect(decomposition).toMatch(/Do not delegate[\s\S]*single-line typos[\s\S]*known-location fixes/i);
 		const simpleRequestRule = routing.split("\n").find(line => line.includes("simple clear implementation requests"));

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -243,6 +243,20 @@ describe("system Handlebars prompt templates", () => {
 		expect(rendered).toContain("`job` remains the generic background-job tool");
 	});
 
+	test("system-prompt distinguishes informational questions from explicit implementation requests", async () => {
+		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+		const rendered = prompt.render(template, baseRenderContext);
+
+		expect(countOccurrences(rendered, "Informational questions, bare `?`, and unambiguous explanatory prompts")).toBe(
+			1,
+		);
+		expect(rendered).toContain("answer-only/read-only");
+		expect(rendered).toContain("unless the user explicitly asks to change, run, implement, or execute something");
+		expect(rendered).toMatch(/Clear, low-risk implementation request\s+→\s+implement directly/i);
+		expect(rendered).toMatch(/Ambiguous implementation asks[\s\S]*require clarification[\s\S]*before mutation/i);
+	});
+
 	test("buildSystemPrompt keeps system and project as separate ordered blocks with date context in project", async () => {
 		await withTempDir(async dir => {
 			const { systemPrompt } = await buildSystemPrompt({


### PR DESCRIPTION
## Summary
- `packages/coding-agent/src/prompts/system/system-prompt.md`: routing/communication now separates informational questions (answer-only/read-only unless the user explicitly asks to change/run/implement/execute) from explicit change requests; ambiguous implementation asks require clarification before mutation. Direct execution stays recommended for explicit concrete low-risk edits.
- `defaults/gjc/skills/deep-interview/SKILL.md`: ambiguous implementation asks route to clarification/planning before mutation.
- `defaults/gjc/skills/team/SKILL.md`: remove unsupported `researcher` auto-delegation; replaced with supported guidance (focused repo inspection, `planner`/`architect` delegation, direct web/search tools).
- Fixed public surface preserved: exactly 4 workflow skills / 4 role agents.

## Test plan
- `bun test packages/coding-agent/test/system-prompt-templates.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts` — 38 pass / 0 fail
- `bun scripts/check-visible-definitions.ts` / `bun scripts/verify-g002-gates.ts` / `bun scripts/rebrand-inventory.ts --strict` — PASS on the integrated tree

Companion prompt-side change to #1650 (advisory hook guard); part 2/3 of the improvement set.