### PR TITLE
feat(model): batch role-model assignment for /model and TUI selector

### DIFF
--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -76,6 +76,34 @@ export interface MaterializeModelProfileAssignmentOptions {
 	selector: string;
 }
 
+export interface MaterializeModelProfileAssignmentsOptions {
+	session: Pick<
+		ModelProfileActivationSession,
+		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile"
+	>;
+	settings: Pick<Settings, "clearOverride" | "get" | "override" | "set">;
+	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string> | Partial<Record<GjcModelAssignmentTargetId, string>>;
+}
+
+function isReadonlyAssignmentMap(
+	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string> | Partial<Record<GjcModelAssignmentTargetId, string>>,
+): assignments is ReadonlyMap<GjcModelAssignmentTargetId, string> {
+	return typeof (assignments as { entries?: unknown }).entries === "function";
+}
+
+function getMaterializedAssignments(
+	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string> | Partial<Record<GjcModelAssignmentTargetId, string>>,
+): Array<[GjcModelAssignmentTargetId, string]> {
+	if (isReadonlyAssignmentMap(assignments)) return [...assignments.entries()];
+	const assignmentRecord: Partial<Record<GjcModelAssignmentTargetId, string>> = assignments;
+	const result: Array<[GjcModelAssignmentTargetId, string]> = [];
+	for (const role of Object.keys(assignmentRecord) as GjcModelAssignmentTargetId[]) {
+		const selector = assignmentRecord[role];
+		if (selector !== undefined) result.push([role, selector]);
+	}
+	return result;
+}
+
 export function materializeActiveModelProfileAssignment(options: MaterializeModelProfileAssignmentOptions): boolean {
 	const activeProfile = options.session.getActiveModelProfile?.() ?? options.settings.get("modelProfile.default");
 	if (!activeProfile) return false;
@@ -97,6 +125,43 @@ export function materializeActiveModelProfileAssignment(options: MaterializeMode
 		nextModelRoles[options.role] = options.selector;
 	} else {
 		nextAgentModelOverrides[options.role] = options.selector;
+	}
+
+	options.settings.set("modelRoles", nextModelRoles);
+	options.settings.set("task.agentModelOverrides", nextAgentModelOverrides);
+	options.settings.set("modelProfile.default", undefined);
+	options.settings.clearOverride("modelProfile.default");
+	options.settings.override("modelRoles", nextModelRoles);
+	options.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
+	options.session.setActiveModelProfile?.(undefined);
+	return true;
+}
+
+export function materializeActiveModelProfileAssignments(options: MaterializeModelProfileAssignmentsOptions): boolean {
+	const activeProfile = options.session.getActiveModelProfile?.() ?? options.settings.get("modelProfile.default");
+	if (!activeProfile) return false;
+
+	const materializedAssignments = getMaterializedAssignments(options.assignments);
+	if (materializedAssignments.length === 0) return true;
+
+	const nextModelRoles = { ...options.settings.get("modelRoles") };
+	const nextAgentModelOverrides = { ...options.settings.get("task.agentModelOverrides") };
+	const includesDefault = materializedAssignments.some(([role]) => role === "default");
+
+	if (!includesDefault && !nextModelRoles.default && options.session.model) {
+		nextModelRoles.default = formatModelSelectorValue(
+			`${options.session.model.provider}/${options.session.model.id}`,
+			options.session.thinkingLevel,
+		);
+	}
+
+	for (const [role, selector] of materializedAssignments) {
+		const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+		if (target.settingsPath === "modelRoles") {
+			nextModelRoles[role] = selector;
+		} else {
+			nextAgentModelOverrides[role] = selector;
+		}
 	}
 
 	options.settings.set("modelRoles", nextModelRoles);

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1788,6 +1788,11 @@ export class ModelSelectorComponent extends Container {
 	async __testSelectProfile(profileName: string, setDefault: boolean): Promise<void> {
 		await this.#onSelectCallback({ kind: "profile", profileName, setDefault });
 	}
+	async __testSelectAssignment(
+		selection: Omit<Extract<ModelSelectorSelection, { kind: "assignment" }>, "kind">,
+	): Promise<void> {
+		await this.#onSelectCallback({ kind: "assignment", ...selection });
+	}
 	async __testSelectPresetAction(profileName: string, action: "rename" | "delete"): Promise<void> {
 		await this.#onSelectCallback({
 			kind: action === "rename" ? "renameProfile" : "deleteProfile",

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -96,6 +96,7 @@ export type ModelSelectorSelection =
 			kind: "assignment";
 			model: Model;
 			role: GjcModelAssignmentTargetId | null;
+			roles?: readonly GjcModelAssignmentTargetId[];
 			thinkingLevel?: ThinkingLevel;
 			selector?: string;
 	  }
@@ -1360,7 +1361,11 @@ export class ModelSelectorComponent extends Container {
 		for (let i = 0; i < actionCount; i++) {
 			const prefix = i === this.#selectedActionIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
 			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[i];
-			const label = `Set as ${GJC_MODEL_ASSIGNMENT_TARGETS[role].tag ?? role.toUpperCase()} (${GJC_MODEL_ASSIGNMENT_TARGETS[role].name})`;
+			const label = role
+				? `Set as ${GJC_MODEL_ASSIGNMENT_TARGETS[role].tag ?? role.toUpperCase()} (${GJC_MODEL_ASSIGNMENT_TARGETS[role].name})`
+				: i === GJC_MODEL_ASSIGNMENT_TARGET_IDS.length
+					? "Set for all role agents"
+					: "Set for all targets";
 			this.#listContainer.addChild(
 				new Text(`${prefix}${i === this.#selectedActionIndex ? theme.fg("accent", label) : label}`, 0, 0),
 			);
@@ -1389,7 +1394,7 @@ export class ModelSelectorComponent extends Container {
 		return this.#roles[role]?.thinkingLevel ?? ThinkingLevel.Inherit;
 	}
 	#getActionCount(_model: Model): number {
-		return GJC_MODEL_ASSIGNMENT_TARGET_IDS.length;
+		return GJC_MODEL_ASSIGNMENT_TARGET_IDS.length + 2;
 	}
 
 	#getSelectedItem(): ModelItem | CanonicalModelItem | undefined {
@@ -1660,7 +1665,15 @@ export class ModelSelectorComponent extends Container {
 		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
 			this.#pendingActionItem = undefined;
 			const role = GJC_MODEL_ASSIGNMENT_TARGET_IDS[this.#selectedActionIndex];
-			if (role) this.#handleSelect(item, role);
+			if (role) {
+				this.#handleSelect(item, role);
+				return;
+			}
+			const roles =
+				this.#selectedActionIndex === GJC_MODEL_ASSIGNMENT_TARGET_IDS.length
+					? (["executor", "architect", "planner", "critic"] as const)
+					: GJC_MODEL_ASSIGNMENT_TARGET_IDS;
+			this.#handleSelect(item, "default", undefined, roles);
 			return;
 		}
 		if (getKeybindings().matches(keyData, "tui.select.cancel")) {
@@ -1719,6 +1732,7 @@ export class ModelSelectorComponent extends Container {
 		item: ModelItem | CanonicalModelItem,
 		role: GjcModelAssignmentTargetId | null,
 		thinkingLevel?: ThinkingLevel,
+		roles?: readonly GjcModelAssignmentTargetId[],
 	): void {
 		const itemThinkingLevel = thinkingLevel ?? item.thinkingLevel;
 		const hasExplicitThinkingChoice = thinkingLevel !== undefined || item.explicitThinkingLevel === true;
@@ -1743,17 +1757,23 @@ export class ModelSelectorComponent extends Container {
 		}
 
 		const selectedThinkingLevel = itemThinkingLevel ?? this.#getCurrentRoleThinkingLevel(role);
-		const selectorValue =
-			role === "default" ? item.selector : formatModelSelectorValue(item.selector, selectedThinkingLevel);
+		const selectorValue = roles
+			? formatModelSelectorValue(item.selector, selectedThinkingLevel)
+			: role === "default"
+				? item.selector
+				: formatModelSelectorValue(item.selector, selectedThinkingLevel);
 
 		// Update local state for UI
-		this.#roles[role] = { model: item.model, thinkingLevel: selectedThinkingLevel };
+		for (const targetRole of roles ?? [role]) {
+			this.#roles[targetRole] = { model: item.model, thinkingLevel: selectedThinkingLevel };
+		}
 
 		// Notify caller (for updating agent state if needed)
 		this.#onSelectCallback({
 			kind: "assignment",
 			model: item.model,
 			role,
+			roles,
 			thinkingLevel: selectedThinkingLevel,
 			selector: selectorValue,
 		});

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -8,11 +8,12 @@ import {
 	activateModelProfile,
 	type MaterializeModelProfileForDeletionResult,
 	materializeActiveModelProfileAssignment,
+	materializeActiveModelProfileAssignments,
 	materializeModelProfileForDeletion,
 	restoreMaterializedModelProfileForDeletion,
 } from "../../config/model-profile-activation";
 import { formatModelProfileDisplayLabel, recommendModelProfileForProvider } from "../../config/model-profiles";
-import { GJC_MODEL_ASSIGNMENT_TARGETS } from "../../config/model-registry";
+import { GJC_MODEL_ASSIGNMENT_TARGETS, type GjcModelAssignmentTargetId } from "../../config/model-registry";
 import { formatModelSelectorValue } from "../../config/model-resolver";
 import type { ModelProfileConfig } from "../../config/models-config-schema";
 import { type Settings, settings } from "../../config/settings";
@@ -894,20 +895,31 @@ export class SelectorController {
 							if (!apiKey) {
 								throw new Error(`No API key for ${model.provider}/${model.id}`);
 							}
+							const targetRoles: readonly GjcModelAssignmentTargetId[] = selection.roles ?? [role];
 							const value =
 								selectedSelector ?? formatModelSelectorValue(`${model.provider}/${model.id}`, thinkingLevel);
-							const materializedProfile = materializeActiveModelProfileAssignment({
+							const assignments = new Map<GjcModelAssignmentTargetId, string>();
+							for (const targetRole of targetRoles) assignments.set(targetRole, value);
+							const materializedProfile = materializeActiveModelProfileAssignments({
 								session: this.ctx.session,
 								settings: this.ctx.settings,
-								role,
-								selector: value,
+								assignments,
 							});
 							if (!materializedProfile) {
-								const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
-								if (target.settingsPath === "modelRoles") {
-									this.ctx.settings.setModelRole(role, value);
-								} else {
-									this.ctx.settings.setAgentModelOverride(role, value);
+								const overrides = this.ctx.settings.get("task.agentModelOverrides");
+								const nextOverrides = { ...overrides };
+								let writesOverrides = false;
+								for (const targetRole of targetRoles) {
+									const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetRole];
+									if (target.settingsPath === "modelRoles") {
+										this.ctx.settings.setModelRole(targetRole, value);
+									} else {
+										nextOverrides[targetRole] = value;
+										writesOverrides = true;
+									}
+								}
+								if (writesOverrides) {
+									this.ctx.settings.set("task.agentModelOverrides", nextOverrides);
 								}
 							}
 							modelSelector.refreshRoleAssignments({
@@ -920,7 +932,18 @@ export class SelectorController {
 							this.ctx.statusLine.invalidate();
 							this.ctx.updateEditorBorderColor();
 							await this.ctx.notifyConfigChanged?.();
-							this.ctx.showStatus(`${role} agent model: ${value}`);
+							if (selection.roles) {
+								const labels = targetRoles.map(
+									targetRole => GJC_MODEL_ASSIGNMENT_TARGETS[targetRole].tag ?? targetRole.toUpperCase(),
+								);
+								this.ctx.showStatus(
+									targetRoles.includes("default")
+										? `All model targets set to ${value} for ${labels.join(", ")}.`
+										: `Role-agent models set to ${value} for ${labels.join(", ")}.`,
+								);
+							} else {
+								this.ctx.showStatus(`${role} agent model: ${value}`);
+							}
 							done();
 							this.ctx.ui.requestRender();
 						}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -860,6 +860,79 @@ export class SelectorController {
 							this.ctx.showStatus(`Temporary model: ${selectedSelector ?? model.id}`);
 							done();
 							this.ctx.ui.requestRender();
+						} else if (selection.roles) {
+							const targetRoles: readonly GjcModelAssignmentTargetId[] = selection.roles;
+							const includesDefault = targetRoles.includes("default");
+							const includesRoleAgent = targetRoles.some(targetRole => targetRole !== "default");
+							if (includesRoleAgent) {
+								const apiKey = await this.ctx.session.modelRegistry.getApiKey(
+									model,
+									this.ctx.session.sessionId,
+								);
+								if (!apiKey) {
+									throw new Error(`No API key for ${model.provider}/${model.id}`);
+								}
+							}
+							const value =
+								selectedSelector ?? formatModelSelectorValue(`${model.provider}/${model.id}`, thinkingLevel);
+							const assignments = new Map<GjcModelAssignmentTargetId, string>();
+							for (const targetRole of targetRoles) assignments.set(targetRole, value);
+							const defaultSelector =
+								selectedSelector && thinkingLevel && selectedSelector.endsWith(`:${thinkingLevel}`)
+									? selectedSelector.slice(0, -thinkingLevel.length - 1)
+									: selectedSelector;
+
+							if (includesDefault) {
+								await this.ctx.session.setModel(model, "default", {
+									selector: defaultSelector,
+									thinkingLevel,
+								});
+								if (thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit) {
+									this.ctx.session.setThinkingLevel(thinkingLevel);
+								}
+							}
+							const materializedProfile = materializeActiveModelProfileAssignments({
+								session: this.ctx.session,
+								settings: this.ctx.settings,
+								assignments,
+							});
+							if (!materializedProfile) {
+								const overrides = this.ctx.settings.get("task.agentModelOverrides");
+								const nextOverrides = { ...overrides };
+								let writesOverrides = false;
+								for (const targetRole of targetRoles) {
+									const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetRole];
+									if (target.settingsPath === "modelRoles") {
+										this.ctx.settings.setModelRole(targetRole, value);
+									} else {
+										nextOverrides[targetRole] = value;
+										writesOverrides = true;
+									}
+								}
+								if (writesOverrides) {
+									this.ctx.settings.set("task.agentModelOverrides", nextOverrides);
+								}
+							}
+							modelSelector.refreshRoleAssignments({
+								currentModel: this.ctx.session.model,
+								currentThinkingLevel: this.ctx.session.thinkingLevel,
+								activeModelProfile:
+									this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
+							});
+							this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
+							this.ctx.statusLine.invalidate();
+							this.ctx.updateEditorBorderColor();
+							await this.ctx.notifyConfigChanged?.();
+							const labels = targetRoles.map(
+								targetRole => GJC_MODEL_ASSIGNMENT_TARGETS[targetRole].tag ?? targetRole.toUpperCase(),
+							);
+							this.ctx.showStatus(
+								includesDefault
+									? `All model targets set to ${value} for ${labels.join(", ")}.`
+									: `Role-agent models set to ${value} for ${labels.join(", ")}.`,
+							);
+							done();
+							this.ctx.ui.requestRender();
 						} else if (role === "default") {
 							// Default: update agent state and persist as the active default model.
 							await this.ctx.session.setModel(model, role, {
@@ -895,31 +968,23 @@ export class SelectorController {
 							if (!apiKey) {
 								throw new Error(`No API key for ${model.provider}/${model.id}`);
 							}
-							const targetRoles: readonly GjcModelAssignmentTargetId[] = selection.roles ?? [role];
 							const value =
 								selectedSelector ?? formatModelSelectorValue(`${model.provider}/${model.id}`, thinkingLevel);
-							const assignments = new Map<GjcModelAssignmentTargetId, string>();
-							for (const targetRole of targetRoles) assignments.set(targetRole, value);
+							const assignments = new Map<GjcModelAssignmentTargetId, string>([[role, value]]);
 							const materializedProfile = materializeActiveModelProfileAssignments({
 								session: this.ctx.session,
 								settings: this.ctx.settings,
 								assignments,
 							});
 							if (!materializedProfile) {
-								const overrides = this.ctx.settings.get("task.agentModelOverrides");
-								const nextOverrides = { ...overrides };
-								let writesOverrides = false;
-								for (const targetRole of targetRoles) {
-									const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetRole];
-									if (target.settingsPath === "modelRoles") {
-										this.ctx.settings.setModelRole(targetRole, value);
-									} else {
-										nextOverrides[targetRole] = value;
-										writesOverrides = true;
-									}
-								}
-								if (writesOverrides) {
-									this.ctx.settings.set("task.agentModelOverrides", nextOverrides);
+								const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+								if (target.settingsPath === "modelRoles") {
+									this.ctx.settings.setModelRole(role, value);
+								} else {
+									this.ctx.settings.set("task.agentModelOverrides", {
+										...this.ctx.settings.get("task.agentModelOverrides"),
+										[role]: value,
+									});
 								}
 							}
 							modelSelector.refreshRoleAssignments({
@@ -932,18 +997,7 @@ export class SelectorController {
 							this.ctx.statusLine.invalidate();
 							this.ctx.updateEditorBorderColor();
 							await this.ctx.notifyConfigChanged?.();
-							if (selection.roles) {
-								const labels = targetRoles.map(
-									targetRole => GJC_MODEL_ASSIGNMENT_TARGETS[targetRole].tag ?? targetRole.toUpperCase(),
-								);
-								this.ctx.showStatus(
-									targetRoles.includes("default")
-										? `All model targets set to ${value} for ${labels.join(", ")}.`
-										: `Role-agent models set to ${value} for ${labels.join(", ")}.`,
-								);
-							} else {
-								this.ctx.showStatus(`${role} agent model: ${value}`);
-							}
+							this.ctx.showStatus(`${role} agent model: ${value}`);
 							done();
 							this.ctx.ui.requestRender();
 						}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -480,7 +480,13 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 
 					const overrides = runtime.settings.get("task.agentModelOverrides");
 					const assignments = new Map<GjcModelAssignmentTargetId, string>();
-					const persistedSelector = formatModelSelectorValue(selection.selector, selection.thinkingLevel);
+					const existingDefaultThinkingLevel =
+						selection.thinkingLevel !== undefined
+							? selection.thinkingLevel
+							: runtime.session.getActiveModelProfile?.()
+								? undefined
+								: extractExplicitThinkingSelector(runtime.settings.getModelRole("default"), runtime.settings);
+					const persistedSelector = formatModelSelectorValue(selection.selector, existingDefaultThinkingLevel);
 					for (const targetId of targetIds) {
 						if (targetId === "default") {
 							assignments.set(targetId, persistedSelector);
@@ -494,10 +500,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 					if (includesDefault) {
 						await runtime.session.setModel(selection.model, "default", {
 							selector: selection.selector,
-							thinkingLevel: selection.thinkingLevel,
+							thinkingLevel: existingDefaultThinkingLevel,
 						});
-						if (selection.thinkingLevel) {
-							runtime.session.setThinkingLevel(selection.thinkingLevel);
+						if (existingDefaultThinkingLevel) {
+							runtime.session.setThinkingLevel(existingDefaultThinkingLevel);
 						}
 					}
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -6,12 +6,13 @@ import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import { Spacer, Text } from "@gajae-code/tui";
 import { setProjectDir } from "@gajae-code/utils";
 import { jobElapsedMs } from "../async";
-import { materializeActiveModelProfileAssignment } from "../config/model-profile-activation";
+import { materializeActiveModelProfileAssignments } from "../config/model-profile-activation";
 import {
 	GJC_MODEL_ASSIGNMENT_TARGET_IDS,
 	GJC_MODEL_ASSIGNMENT_TARGETS,
 	type GjcModelAssignmentTargetId,
 } from "../config/model-registry";
+
 import {
 	extractExplicitThinkingSelector,
 	formatModelSelectorValue,
@@ -50,6 +51,13 @@ export type { BuiltinSlashCommand, SubcommandDef } from "./types";
 
 /** TUI-specific runtime accepted by `executeBuiltinSlashCommand`. */
 export type BuiltinSlashCommandRuntime = TuiSlashCommandRuntime;
+
+type GjcModelBatchAssignmentTargetId = "all-role-agents" | "all-targets";
+type ParsedModelCommandArgs =
+	| { kind: "summary" }
+	| { kind: "assign"; targetId: GjcModelAssignmentTargetId | GjcModelBatchAssignmentTargetId; selector: string };
+
+const GJC_MODEL_ROLE_AGENT_TARGET_IDS: GjcModelAssignmentTargetId[] = ["executor", "architect", "planner", "critic"];
 
 function fastStatusRoleTargets(): Array<{ id: GjcModelAssignmentTargetId; label: string; isSubagentRole: boolean }> {
 	return GJC_MODEL_ASSIGNMENT_TARGET_IDS.map(id => ({
@@ -172,22 +180,37 @@ function formatModelAssignmentSummary(runtime: SlashCommandRuntime): string {
 	return lines.join("\n");
 }
 
-function parseModelCommandArgs(args: string): { targetId: GjcModelAssignmentTargetId; selector: string } {
+function parseModelCommandArgs(args: string): ParsedModelCommandArgs {
 	const tokens = args.trim().split(/\s+/).filter(Boolean);
 	const first = tokens[0]?.toLowerCase();
-	const explicitTarget = GJC_MODEL_ASSIGNMENT_TARGET_IDS.includes(first as GjcModelAssignmentTargetId)
-		? (first as GjcModelAssignmentTargetId)
-		: undefined;
+	if (first === "roles" || first === "assignments") return { kind: "summary" };
+
+	const parseTarget = (
+		token: string | undefined,
+	): GjcModelAssignmentTargetId | GjcModelBatchAssignmentTargetId | undefined => {
+		const normalized = token?.toLowerCase();
+		if (GJC_MODEL_ASSIGNMENT_TARGET_IDS.includes(normalized as GjcModelAssignmentTargetId)) {
+			return normalized as GjcModelAssignmentTargetId;
+		}
+		if (normalized === "all-role-agents" || normalized === "all-targets") return normalized;
+		return undefined;
+	};
+
+	if (first === "assign") {
+		const targetId = parseTarget(tokens[1]);
+		if (targetId) return { kind: "assign", targetId, selector: tokens.slice(2).join(" ") };
+		return { kind: "assign", targetId: "default", selector: tokens.slice(1).join(" ") };
+	}
+
+	const explicitTarget = parseTarget(first);
 	if (explicitTarget) {
-		return { targetId: explicitTarget, selector: tokens.slice(1).join(" ") };
+		return { kind: "assign", targetId: explicitTarget, selector: tokens.slice(1).join(" ") };
 	}
 	if (first === "set") {
-		const second = tokens[1]?.toLowerCase();
-		if (GJC_MODEL_ASSIGNMENT_TARGET_IDS.includes(second as GjcModelAssignmentTargetId)) {
-			return { targetId: second as GjcModelAssignmentTargetId, selector: tokens.slice(2).join(" ") };
-		}
+		const targetId = parseTarget(tokens[1]);
+		if (targetId) return { kind: "assign", targetId, selector: tokens.slice(2).join(" ") };
 	}
-	return { targetId: "default", selector: args.trim() };
+	return { kind: "assign", targetId: "default", selector: args.trim() };
 }
 
 function splitExplicitThinkingSelector(selector: string): { baseSelector: string; thinkingLevel?: ThinkingLevel } {
@@ -322,6 +345,28 @@ async function resolveModelCommandSelection(
 	};
 }
 
+function getModelAssignmentTargetIds(
+	targetId: GjcModelAssignmentTargetId | GjcModelBatchAssignmentTargetId,
+): GjcModelAssignmentTargetId[] {
+	if (targetId === "all-role-agents") return [...GJC_MODEL_ROLE_AGENT_TARGET_IDS];
+	if (targetId === "all-targets") return [...GJC_MODEL_ASSIGNMENT_TARGET_IDS];
+	return [targetId];
+}
+
+function formatModelAssignmentSuccess(
+	targetId: GjcModelAssignmentTargetId | GjcModelBatchAssignmentTargetId,
+	selector: string,
+): string {
+	if (targetId === "all-role-agents") {
+		return `Role-agent models set to ${selector} for EXECUTOR, ARCHITECT, PLANNER, CRITIC.`;
+	}
+	if (targetId === "all-targets") {
+		return `All model targets set to ${selector} for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.`;
+	}
+	if (targetId === "default") return `DEFAULT model set to ${selector}.`;
+	return `${targetId.toUpperCase()} agent model set to ${selector}.`;
+}
+
 function modelSelectionUsage(runtime: SlashCommandRuntime, currentModelLine?: string): string {
 	return [
 		currentModelLine,
@@ -402,6 +447,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		handle: async (command, runtime) => {
 			if (command.args) {
 				const parsedArgs = parseModelCommandArgs(command.args);
+				if (parsedArgs.kind === "summary") {
+					await runtime.output(formatModelAssignmentSummary(runtime));
+					return commandConsumed();
+				}
+
+				const targetIds = getModelAssignmentTargetIds(parsedArgs.targetId);
 				const modelId = parsedArgs.selector;
 				if (!modelId) {
 					return usage(
@@ -415,24 +466,9 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				}
 				const { selection } = resolution;
 				try {
-					const persistedSelector = formatModelSelectorValue(selection.selector, selection.thinkingLevel);
-					if (parsedArgs.targetId === "default") {
-						await runtime.session.setModel(selection.model, "default", {
-							selector: selection.selector,
-							thinkingLevel: selection.thinkingLevel,
-						});
-						materializeActiveModelProfileAssignment({
-							session: runtime.session,
-							settings: runtime.settings,
-							role: parsedArgs.targetId,
-							selector: persistedSelector,
-						});
-						if (selection.thinkingLevel) {
-							runtime.session.setThinkingLevel(selection.thinkingLevel);
-						}
-						await runtime.output(`Default model set to ${persistedSelector}.`);
-						await runtime.notifyTitleChanged?.();
-					} else {
+					const includesDefault = targetIds.includes("default");
+					const includesRoleAgent = targetIds.some(role => role !== "default");
+					if (includesRoleAgent) {
 						const apiKey = await runtime.session.modelRegistry.getApiKey(
 							selection.model,
 							runtime.session.sessionId,
@@ -440,28 +476,62 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						if (!apiKey) {
 							throw new Error(`No API key for ${selection.model.provider}/${selection.model.id}`);
 						}
-						const overrides = runtime.settings.get("task.agentModelOverrides");
+					}
+
+					const overrides = runtime.settings.get("task.agentModelOverrides");
+					const assignments = new Map<GjcModelAssignmentTargetId, string>();
+					const persistedSelector = formatModelSelectorValue(selection.selector, selection.thinkingLevel);
+					for (const targetId of targetIds) {
+						if (targetId === "default") {
+							assignments.set(targetId, persistedSelector);
+							continue;
+						}
 						const thinkingLevel =
-							selection.thinkingLevel ??
-							extractExplicitThinkingSelector(overrides[parsedArgs.targetId], runtime.settings);
-						const roleSelector = formatModelSelectorValue(selection.selector, thinkingLevel);
-						const materializedProfile = materializeActiveModelProfileAssignment({
-							session: runtime.session,
-							settings: runtime.settings,
-							role: parsedArgs.targetId,
-							selector: roleSelector,
+							selection.thinkingLevel ?? extractExplicitThinkingSelector(overrides[targetId], runtime.settings);
+						assignments.set(targetId, formatModelSelectorValue(selection.selector, thinkingLevel));
+					}
+
+					if (includesDefault) {
+						await runtime.session.setModel(selection.model, "default", {
+							selector: selection.selector,
+							thinkingLevel: selection.thinkingLevel,
 						});
-						if (!materializedProfile) {
-							const target = GJC_MODEL_ASSIGNMENT_TARGETS[parsedArgs.targetId];
+						if (selection.thinkingLevel) {
+							runtime.session.setThinkingLevel(selection.thinkingLevel);
+						}
+					}
+
+					const materializedProfile = materializeActiveModelProfileAssignments({
+						session: runtime.session,
+						settings: runtime.settings,
+						assignments,
+					});
+					if (!materializedProfile) {
+						const nextOverrides = { ...overrides };
+						for (const [targetId, selector] of assignments) {
+							const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetId];
 							if (target.settingsPath === "modelRoles") {
-								runtime.settings.setModelRole(parsedArgs.targetId, roleSelector);
+								runtime.settings.setModelRole(targetId, selector);
 							} else {
-								runtime.settings.setAgentModelOverride(parsedArgs.targetId, roleSelector);
+								nextOverrides[targetId] = selector;
 							}
 						}
-						runtime.settings.getStorage()?.recordModelUsage(`${selection.model.provider}/${selection.model.id}`);
-						await runtime.output(`${parsedArgs.targetId} agent model set to ${roleSelector}.`);
+						if (
+							targetIds.some(
+								targetId => GJC_MODEL_ASSIGNMENT_TARGETS[targetId].settingsPath === "task.agentModelOverrides",
+							)
+						) {
+							runtime.settings.set("task.agentModelOverrides", nextOverrides);
+						}
 					}
+					runtime.settings.getStorage()?.recordModelUsage(`${selection.model.provider}/${selection.model.id}`);
+					await runtime.output(
+						formatModelAssignmentSuccess(
+							parsedArgs.targetId,
+							assignments.get(targetIds[0] ?? "default") ?? persistedSelector,
+						),
+					);
+					if (includesDefault) await runtime.notifyTitleChanged?.();
 					await runtime.notifyConfigChanged?.();
 					return commandConsumed();
 				} catch (err) {

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -6,6 +6,7 @@ import {
 	applyPreparedModelProfileActivation,
 	formatModelProfileCredentialError,
 	materializeActiveModelProfileAssignment,
+	materializeActiveModelProfileAssignments,
 	prepareModelProfileActivation,
 } from "../src/config/model-profile-activation";
 import type { ModelProfileDefinition } from "../src/config/model-profiles";
@@ -232,6 +233,55 @@ describe("model profile activation", () => {
 			default: "provider-c/default:low",
 		});
 		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(session.getActiveModelProfile()).toBeUndefined();
+	});
+
+	test("batch materialization writes role agents once and clears the active profile once", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({
+			"modelProfile.default": "profile-a",
+			"task.agentModelOverrides": { critic: "provider-a/old-critic" },
+		});
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+		let clearedActiveProfile = 0;
+		const originalSetActiveModelProfile = session.setActiveModelProfile.bind(session);
+		session.setActiveModelProfile = (name: string | undefined) => {
+			if (name === undefined) clearedActiveProfile++;
+			originalSetActiveModelProfile(name);
+		};
+
+		const materialized = materializeActiveModelProfileAssignments({
+			session,
+			settings,
+			assignments: new Map([
+				["executor", "provider-c/executor:low"],
+				["architect", "provider-c/architect:medium"],
+			]),
+		});
+
+		expect(materialized).toBe(true);
+		expect(clearedActiveProfile).toBe(1);
+		expect(settings.get("modelRoles")).toEqual({ default: "provider-a/default:high" });
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			critic: "provider-a/old-critic",
+			executor: "provider-c/executor:low",
+			architect: "provider-c/architect:medium",
+		});
+		expect(session.getActiveModelProfile()).toBeUndefined();
+	});
+
+	test("batch materialization is inactive without an active profile", () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({ "task.agentModelOverrides": { critic: "provider-a/old-critic" } });
+
+		const materialized = materializeActiveModelProfileAssignments({
+			session,
+			settings,
+			assignments: { executor: "provider-c/executor:low" },
+		});
+
+		expect(materialized).toBe(false);
+		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "provider-a/old-critic" });
 		expect(session.getActiveModelProfile()).toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/model-selector-controller-batch.test.ts
+++ b/packages/coding-agent/test/model-selector-controller-batch.test.ts
@@ -1,0 +1,142 @@
+import { beforeAll, describe, expect, test, vi } from "bun:test";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import type { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
+import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+
+let testTheme = await getThemeByName("red-claw");
+
+function installTestTheme(): void {
+	if (!testTheme) throw new Error("Failed to load test theme");
+	setThemeInstance(testTheme);
+}
+
+const model = (provider: string, id: string): Model =>
+	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
+
+const selectedModel = model("provider-a", "selected");
+
+function createControllerContext() {
+	const settings = Settings.isolated();
+	settings.set("modelRoles", { default: "provider-a/original-default:medium" });
+	settings.set("task.agentModelOverrides", { executor: "provider-a/original-executor:low" });
+	settings.set("modelProfile.default", undefined);
+	const setModelCalls: Array<{
+		model: Model;
+		role: string;
+		options?: { selector?: string; thinkingLevel?: ThinkingLevel };
+	}> = [];
+	const session = {
+		model: model("provider-a", "current") as Model | undefined,
+		thinkingLevel: ThinkingLevel.Medium as ThinkingLevel | undefined,
+		sessionId: "session-1",
+		scopedModels: [],
+		modelRegistry: {
+			getAvailable: () => [selectedModel],
+			refresh: vi.fn(async () => {}),
+			getAll: () => [selectedModel],
+			getError: () => undefined,
+			getCanonicalModels: () => [],
+			getDiscoverableProviders: () => [],
+			getAvailableModelProfileNames: () => [],
+			getModelProfiles: () => new Map(),
+			resolveCanonicalModel: () => undefined,
+			getApiKey: vi.fn(async () => "key"),
+		},
+		async setModel(nextModel: Model, role: string, options?: { selector?: string; thinkingLevel?: ThinkingLevel }) {
+			setModelCalls.push({ model: nextModel, role, options });
+			this.model = nextModel;
+			if (options?.thinkingLevel) this.thinkingLevel = options.thinkingLevel;
+		},
+		async setModelTemporary() {},
+		setThinkingLevel(thinkingLevel: ThinkingLevel) {
+			this.thinkingLevel = thinkingLevel;
+		},
+		getActiveModelProfile: () => undefined,
+		isFastForProvider: () => false,
+		isFastForSubagentProvider: () => false,
+		isFastModeActive: () => false,
+	};
+	const ctx = {
+		ui: { setFocus: vi.fn(), requestRender: vi.fn() },
+		editorContainer: { clear: vi.fn(), addChild: vi.fn() },
+		editor: {},
+		settings,
+		session,
+		statusLine: { invalidate: vi.fn() },
+		updateEditorBorderColor: vi.fn(),
+		showStatus: vi.fn(),
+		showError: vi.fn(),
+		notifyConfigChanged: vi.fn(async () => {}),
+	};
+	return { ctx, settings, session, setModelCalls };
+}
+
+async function openSelector(ctx: ReturnType<typeof createControllerContext>["ctx"]): Promise<ModelSelectorComponent> {
+	new SelectorController(ctx as never).showModelSelector();
+	return ctx.editorContainer.addChild.mock.calls[0]?.[0] as ModelSelectorComponent;
+}
+
+describe("SelectorController model batch assignments", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("red-claw");
+		installTestTheme();
+	});
+	test("all role agents selection writes every role-agent override and leaves DEFAULT unchanged", async () => {
+		const { ctx, settings, setModelCalls } = createControllerContext();
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			roles: ["executor", "architect", "planner", "critic"],
+			thinkingLevel: ThinkingLevel.Low,
+			selector: "provider-a/selected:low",
+		});
+
+		expect(setModelCalls).toEqual([]);
+		expect(settings.getModelRole("default")).toBe("provider-a/original-default:medium");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:low",
+			architect: "provider-a/selected:low",
+			planner: "provider-a/selected:low",
+			critic: "provider-a/selected:low",
+		});
+		expect(ctx.showStatus).toHaveBeenCalledWith(
+			"Role-agent models set to provider-a/selected:low for EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+		);
+	});
+
+	test("all targets selection writes DEFAULT plus every role-agent override", async () => {
+		const { ctx, settings, setModelCalls } = createControllerContext();
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			roles: ["default", "executor", "architect", "planner", "critic"],
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(setModelCalls).toEqual([
+			{
+				model: selectedModel,
+				role: "default",
+				options: { selector: "provider-a/selected", thinkingLevel: ThinkingLevel.High },
+			},
+		]);
+		expect(settings.getModelRole("default")).toBe("provider-a/selected:high");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:high",
+			architect: "provider-a/selected:high",
+			planner: "provider-a/selected:high",
+			critic: "provider-a/selected:high",
+		});
+		expect(ctx.showStatus).toHaveBeenCalledWith(
+			"All model targets set to provider-a/selected:high for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+		);
+	});
+});

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -29,6 +29,7 @@ interface SelectionCapture {
 	role: GjcModelAssignmentTargetId | null;
 	thinkingLevel?: ThinkingLevel;
 	selector?: string;
+	roles?: readonly GjcModelAssignmentTargetId[];
 }
 
 type TestModelSelectorSelection = {
@@ -37,6 +38,7 @@ type TestModelSelectorSelection = {
 	role: GjcModelAssignmentTargetId | null;
 	thinkingLevel?: ThinkingLevel;
 	selector?: string;
+	roles?: readonly GjcModelAssignmentTargetId[];
 };
 
 interface CreateSelectorOptions {
@@ -182,6 +184,8 @@ describe("ModelSelector canonical model selection", () => {
 		expect(actionRendered).toContain("Set as ARCHITECT (Architect)");
 		expect(actionRendered).toContain("Set as PLANNER (Planner)");
 		expect(actionRendered).toContain("Set as CRITIC (Critic)");
+		expect(actionRendered).toContain("Set for all role agents");
+		expect(actionRendered).toContain("Set for all targets");
 		expect(actionRendered).not.toContain("Set as custom-fast");
 		expect(actionRendered).not.toContain("Set as SMOL");
 		expect(actionRendered).not.toContain("Set as TASK");
@@ -273,6 +277,52 @@ describe("ModelSelector canonical model selection", () => {
 		expect(settings.get("task.agentModelOverrides")).toEqual({
 			planner: `${model.provider}/${model.id}:high`,
 		});
+	});
+
+	test("selects batch role-agent assignment action", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(model, Settings.isolated(), selection => {
+			if (selection.kind === "assignment") selected = selection;
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		for (let i = 0; i < 5; i++) selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+
+		const selectedAfterEnter = selected;
+		if (!selectedAfterEnter) throw new Error("Expected batch role-agent selection");
+		expect(selectedAfterEnter.role).toBe("default");
+		expect(selectedAfterEnter.roles).toEqual(["executor", "architect", "planner", "critic"]);
+		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}:off`);
+	});
+
+	test("selects batch all-targets assignment action", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(model, Settings.isolated(), selection => {
+			if (selection.kind === "assignment") selected = selection;
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		for (let i = 0; i < 6; i++) selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+
+		const selectedAfterEnter = selected;
+		if (!selectedAfterEnter) throw new Error("Expected all-targets selection");
+		expect(selectedAfterEnter.role).toBe("default");
+		expect(selectedAfterEnter.roles).toEqual(["default", "executor", "architect", "planner", "critic"]);
+		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}:off`);
 	});
 
 	test("temporary scoped model selection carries selected reasoning", async () => {

--- a/packages/coding-agent/test/slash-commands/model.test.ts
+++ b/packages/coding-agent/test/slash-commands/model.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { Settings } from "../../src/config/settings";
+import type { AgentSession } from "../../src/session/agent-session";
+import type { SessionManager } from "../../src/session/session-manager";
+import { executeAcpBuiltinSlashCommand } from "../../src/slash-commands/acp-builtins";
+
+function createRuntime() {
+	const output: string[] = [];
+	const settings = Settings.isolated();
+	let activeModelProfile: string | undefined;
+	const availableModel = { provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 };
+	const session = {
+		sessionId: "session-1",
+		model: undefined as { provider: string; id: string; contextWindow?: number } | undefined,
+		thinkingLevel: undefined as string | undefined,
+		modelRegistry: {
+			async getApiKey(_model: { provider: string; id: string }, _sessionId?: string) {
+				return "test-api-key";
+			},
+			resolveCanonicalModel: (
+				selector: string,
+				options?: { candidates?: Array<{ provider: string; id: string }> },
+			) => (selector === "claude-sonnet" ? options?.candidates?.[0] : undefined),
+		},
+		getAvailableModels: () => [availableModel],
+		async setModel(model: { provider: string; id: string }, _role: "default", _options?: unknown) {
+			this.model = model;
+		},
+		setThinkingLevel(thinkingLevel: string) {
+			this.thinkingLevel = thinkingLevel;
+		},
+		getActiveModelProfile() {
+			return activeModelProfile;
+		},
+		setActiveModelProfile(name: string | undefined) {
+			activeModelProfile = name;
+		},
+	};
+	const sessionManager = {
+		getSessionId: () => "session-1",
+		getSessionFile: () => undefined,
+		getCwd: () => "/tmp/project",
+		getEntries: () => [],
+		getBranch: () => [],
+		appendCustomEntry: () => "entry-1",
+		flush: async () => {},
+		buildSessionContext: () => ({ messages: [], thinkingLevel: "off", models: {}, injectedTtsrRules: [] }),
+		getUsageStatistics: () => ({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, premiumRequests: 0, cost: 0 }),
+	};
+	return {
+		output,
+		settings,
+		session,
+		runtime: {
+			session: session as unknown as AgentSession,
+			sessionManager: sessionManager as unknown as SessionManager,
+			settings,
+			cwd: "/tmp/project",
+			output: (text: string) => {
+				output.push(text);
+			},
+			refreshCommands: () => {},
+			reloadPlugins: async () => {},
+			notifyTitleChanged: undefined as (() => Promise<void> | void) | undefined,
+			notifyConfigChanged: undefined as (() => Promise<void> | void) | undefined,
+		},
+		setActiveModelProfile(name: string | undefined) {
+			activeModelProfile = name;
+		},
+	};
+}
+
+describe("/model batch assignments", () => {
+	test("roles and assignments print the five-row summary without mutating settings", async () => {
+		const { output, runtime, settings } = createRuntime();
+		settings.setModelRole("default", "anthropic/default-model:medium");
+		settings.set("task.agentModelOverrides", { executor: "anthropic/executor-model:low" });
+
+		await expect(executeAcpBuiltinSlashCommand("/model roles", runtime)).resolves.toEqual({ consumed: true });
+		await expect(executeAcpBuiltinSlashCommand("/model assignments", runtime)).resolves.toEqual({ consumed: true });
+
+		const expected = [
+			"Model assignments:",
+			"  DEFAULT (Default): anthropic/default-model:medium",
+			"  EXECUTOR (Executor): anthropic/executor-model:low",
+			"  ARCHITECT (Architect): (unset)",
+			"  PLANNER (Planner): (unset)",
+			"  CRITIC (Critic): (unset)",
+		].join("\n");
+		expect(output).toEqual([expected, expected]);
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "anthropic/executor-model:low" });
+	});
+
+	test("assign all-role-agents writes only role-agent overrides with no active profile", async () => {
+		const { output, runtime, settings } = createRuntime();
+		settings.setModelRole("default", "anthropic/default-model:medium");
+
+		await expect(
+			executeAcpBuiltinSlashCommand("/model assign all-role-agents claude-3-5-sonnet:low", runtime),
+		).resolves.toEqual({ consumed: true });
+
+		expect(settings.getModelRole("default")).toBe("anthropic/default-model:medium");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet:low",
+			architect: "anthropic/claude-3-5-sonnet:low",
+			planner: "anthropic/claude-3-5-sonnet:low",
+			critic: "anthropic/claude-3-5-sonnet:low",
+		});
+		expect(output).toEqual([
+			"Role-agent models set to anthropic/claude-3-5-sonnet:low for EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+		]);
+	});
+
+	test("assign all-targets materializes an active profile exactly once", async () => {
+		const { output, runtime, session, settings, setActiveModelProfile } = createRuntime();
+		session.model = { provider: "anthropic", id: "current-model" };
+		settings.set("modelProfile.default", "profile-a");
+		setActiveModelProfile("profile-a");
+		const setActiveSpy = spyOn(session, "setActiveModelProfile");
+
+		await expect(
+			executeAcpBuiltinSlashCommand("/model assign all-targets claude-sonnet:low", runtime),
+		).resolves.toEqual({ consumed: true });
+
+		expect(setActiveSpy).toHaveBeenCalledTimes(1);
+		expect(setActiveSpy).toHaveBeenCalledWith(undefined);
+		expect(settings.getModelRole("default")).toBe("claude-sonnet:low");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "claude-sonnet:low",
+			architect: "claude-sonnet:low",
+			planner: "claude-sonnet:low",
+			critic: "claude-sonnet:low",
+		});
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(output).toEqual([
+			"All model targets set to claude-sonnet:low for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+		]);
+	});
+});

--- a/packages/coding-agent/test/slash-commands/model.test.ts
+++ b/packages/coding-agent/test/slash-commands/model.test.ts
@@ -136,4 +136,17 @@ describe("/model batch assignments", () => {
 			"All model targets set to claude-sonnet:low for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
 		]);
 	});
+
+	test("/model preserves existing DEFAULT effort when selector has no explicit effort", async () => {
+		const { output, runtime, settings, session } = createRuntime();
+		settings.setModelRole("default", "anthropic/original-model:high");
+
+		await expect(executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet", runtime)).resolves.toEqual({
+			consumed: true,
+		});
+
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:high");
+		expect(session.thinkingLevel).toBe("high");
+		expect(output).toEqual(["DEFAULT model set to anthropic/claude-3-5-sonnet:high."]);
+	});
 });


### PR DESCRIPTION
## Summary
- `config/model-profile-activation.ts`: add `materializeActiveModelProfileAssignments` batch helper — computes `nextModelRoles` + `task.agentModelOverrides` once for the full target set and clears the active profile exactly once (avoids the first-iteration-clears-profile bug of looping the single-role helper).
- `slash-commands/builtin-registry.ts`: extend `/model`:
  - `/model roles` / `/model assignments` — read-only five-row `Model assignments:` summary in `GJC_MODEL_ASSIGNMENT_TARGET_IDS` order
  - `/model assign <target> <model>` with `default|executor|architect|planner|critic|all-role-agents|all-targets`
  - existing `/model <model>`, `/model <target> <model>`, `/model set <target> <model>` remain backward-compatible
- TUI: `modes/components/model-selector.ts` adds “Set for all role agents” / “Set for all targets” actions; `modes/controllers/selector-controller.ts` handles the batch selection through the same helper.
- No settings schema changes; writes stay within `modelRoles` + `task.agentModelOverrides`.

## Test plan
- `bun test packages/coding-agent/test/model-profile-activation.test.ts packages/coding-agent/test/slash-commands/model.test.ts packages/coding-agent/test/model-selector-role-badge-thinking.test.ts` — 47 pass / 0 fail
- Covers active-profile and no-active-profile batch cases for both slash and TUI paths

Part 3/3 of the improvement set (siblings: #1650, #1651).