### PR TITLE
fix(tui): skip cursor position when jumping backward from column 0

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Fixed backward jump-to-character (`ctrl+alt+]`) matching the character under the cursor when the cursor is at column 0: `lastIndexOf` clamps a negative start position to 0, so the jump stopped in place instead of skipping the cursor position and continuing into earlier lines.
 - GJC-launched psmux panes are now treated as multiplexer sessions even when they do not expose `$TMUX`, so resize and forced redraw paths repaint the live viewport instead of replaying/clearing scrollback and leaving the bottom-pinned composer area above stale blank rows.
 
 ## [0.8.0] - 2026-07-04

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2602,6 +2602,12 @@ export class Editor implements Component, Focusable {
 					: this.#state.cursorCol - 1
 				: undefined;
 
+			// Backward from column 0: lastIndexOf clamps a negative position to 0,
+			// which would match the character under the cursor instead of skipping it
+			if (!isForward && searchFrom !== undefined && searchFrom < 0) {
+				continue;
+			}
+
 			const idx = isForward ? line.indexOf(char, searchFrom) : line.lastIndexOf(char, searchFrom);
 
 			if (idx !== -1) {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2326,4 +2326,54 @@ describe("Editor component", () => {
 			expect(rendered).not.toMatch(/[\u1100-\u1112]/);
 		});
 	});
+
+	describe("Jump to character", () => {
+		it("jumps backward to an earlier occurrence on the same line", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("abca");
+			expect(editor.getCursor()).toEqual({ line: 0, col: 4 });
+
+			editor.handleInput("\x1b[93;7u"); // ctrl+alt+] - enter jump-backward mode
+			editor.handleInput("b");
+
+			expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
+		});
+
+		it("jumps backward into the previous line when the cursor is at column 0", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("xa\nab");
+			editor.handleInput("\x01"); // ctrl+a - move to start of current line
+			expect(editor.getCursor()).toEqual({ line: 1, col: 0 });
+
+			editor.handleInput("\x1b[93;7u"); // ctrl+alt+] - enter jump-backward mode
+			editor.handleInput("a"); // must skip the 'a' under the cursor
+
+			expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
+		});
+
+		it("stays in place when jumping backward from column 0 with no earlier match", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("xb\nab");
+			editor.handleInput("\x01"); // ctrl+a - move to start of current line
+			expect(editor.getCursor()).toEqual({ line: 1, col: 0 });
+
+			editor.handleInput("\x1b[93;7u"); // ctrl+alt+] - enter jump-backward mode
+			editor.handleInput("a"); // only occurrence is under the cursor - no match
+
+			expect(editor.getCursor()).toEqual({ line: 1, col: 0 });
+		});
+
+		it("jumps forward across lines from the cursor position", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("ab\nxa");
+			editor.handleInput("\x1b[A"); // up arrow
+			editor.handleInput("\x01"); // ctrl+a - move to start of current line
+			expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+
+			editor.handleInput("\x1b[93;5u"); // ctrl+] - enter jump-forward mode
+			editor.handleInput("a"); // must skip the 'a' under the cursor
+
+			expect(editor.getCursor()).toEqual({ line: 1, col: 1 });
+		});
+	});
 });


### PR DESCRIPTION
## What

- Skip the current line in `#jumpToChar`'s backward search when the computed start position is negative (cursor at column 0), instead of letting `lastIndexOf` clamp it to 0 and match the character under the cursor.
- Add regression tests for backward jump within a line, backward jump across lines from column 0, no-match-at-column-0 behavior, and forward jump across lines.

## Why

`#jumpToChar` documents "Skips the current cursor position", but the backward path computes `searchFrom = cursorCol - 1`, which is `-1` when the cursor sits at column 0. Per spec, `String.prototype.lastIndexOf` clamps a negative position to 0, so it checks the character AT index 0 — the one the cursor is sitting on. If that character is the jump target, the search "matches" in place and returns immediately, never continuing into earlier lines where a real match exists.

Concretely: with lines `xa` / `ab` and the cursor at the start of `ab`, jump-backward (`ctrl+alt+]`) to `a` should land on the `a` in `xa` (`{line: 0, col: 1}`); instead the cursor does not move at all. The forward path is unaffected (`indexOf` has no negative-position clamping).

The new "jumps backward into the previous line when the cursor is at column 0" test fails on current `dev` (cursor stays at `{line: 1, col: 0}`) and passes with this change.

## Testing

- `bun test packages/tui/test/editor.test.ts` (130 pass; the new cross-line backward test fails before the fix, passes after)
- `bun node_modules/.bin/biome check packages/tui/src/components/editor.ts packages/tui/test/editor.test.ts`
- `bun --cwd=packages/tui run check:types`
- `git diff --check`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
