### PR TITLE
fix(ultragoal): allow identical complete checkpoint retry to repair a missing ledger row

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `gjc completion inshellisense`, which generates or installs a Fig/withfig-compatible `gjc` completion spec for Microsoft inshellisense without adding inshellisense as a runtime dependency.
 
 ### Fixed
+- Retrying an identical `ultragoal` complete checkpoint after a crash between the plan write and the ledger append now repairs the missing `goal_checkpointed` ledger row instead of permanently failing with "already complete", so completion verification can recover.
 - `computer` now honors `include_screenshot` and `computer.autoScreenshot` by returning bounded post-action screenshots, and batch steps now respect nested per-step `timeout` values.
 - Custom-provider `gpt-5.5` entries without an explicit `contextWindow` now default to the 272K Codex prompt budget unless the provider uses first-party `openai-responses`, so Codex passthrough proxies (e.g. CLIProxyAPI) compact in time instead of dying with `context_length_exceeded` at ~272K while the registry advertises 1M.
 - `telegram_send` now rejects files over Telegram's document upload limit before reading them into memory or handing them to the notification sink.

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -2568,10 +2568,17 @@ export async function checkpointUltragoalGoal(input: {
 				? await readStructuredValue(input.cwd, input.qualityGateJson)
 				: undefined;
 	if (input.status === "complete" && isLedgerRepairRetry) {
-		// A ledger repair must not become a back door for rewriting the completion receipt: when the
-		// goal already carries a receipt, the resubmitted quality gate has to hash to the same value.
+		// A ledger repair must not become a back door for rewriting the completion receipt: the retry
+		// is only trusted when the goal still carries its persisted receipt and the resubmitted
+		// quality gate hashes to the receipt's value. Fail closed when the receipt is missing, since
+		// there is nothing durable left to compare the resubmitted gate against.
 		const persistedHash = goal.completionVerification?.qualityGateHash;
-		if (persistedHash !== undefined && hashStructuredValue(qualityGateJson) !== persistedHash) {
+		if (persistedHash === undefined) {
+			throw new Error(
+				`Cannot repair the ${goal.id} complete checkpoint because its durable completion receipt is missing; only checkpoints whose persisted receipt matches the resubmitted quality gate can be repaired.`,
+			);
+		}
+		if (hashStructuredValue(qualityGateJson) !== persistedHash) {
 			throw new Error(
 				`Cannot repair the ${goal.id} complete checkpoint with a different quality gate; resubmit the quality gate recorded in its completion receipt.`,
 			);

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -2554,7 +2554,12 @@ export async function checkpointUltragoalGoal(input: {
 		// instead of silently dropping it.
 		return plan;
 	}
-	if (input.status === "complete") validateCompleteCheckpointTargetGoal(goal);
+	// A same-status, same-evidence retry only reaches this point when the matching goal_checkpointed
+	// ledger row is missing (plan persisted, ledger append lost). Skip the pre-status validation so
+	// the retry can repair the ledger as the guard above documents, instead of rejecting the goal as
+	// already complete.
+	const isLedgerRepairRetry = goal.status === input.status && goal.evidence === evidence;
+	if (input.status === "complete" && !isLedgerRepairRetry) validateCompleteCheckpointTargetGoal(goal);
 	const changeSet = input.status === "complete" ? await computeCheckpointChangeSet(input.cwd) : undefined;
 	const qualityGateJson =
 		input.status === "complete"

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -2567,6 +2567,16 @@ export async function checkpointUltragoalGoal(input: {
 			: input.qualityGateJson
 				? await readStructuredValue(input.cwd, input.qualityGateJson)
 				: undefined;
+	if (input.status === "complete" && isLedgerRepairRetry) {
+		// A ledger repair must not become a back door for rewriting the completion receipt: when the
+		// goal already carries a receipt, the resubmitted quality gate has to hash to the same value.
+		const persistedHash = goal.completionVerification?.qualityGateHash;
+		if (persistedHash !== undefined && hashStructuredValue(qualityGateJson) !== persistedHash) {
+			throw new Error(
+				`Cannot repair the ${goal.id} complete checkpoint with a different quality gate; resubmit the quality gate recorded in its completion receipt.`,
+			);
+		}
+	}
 	const now = new Date().toISOString();
 	const beforeStatus = goal.status;
 	if (input.status === "complete") {

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -2569,20 +2569,57 @@ export async function checkpointUltragoalGoal(input: {
 				: undefined;
 	if (input.status === "complete" && isLedgerRepairRetry) {
 		// A ledger repair must not become a back door for rewriting the completion receipt: the retry
-		// is only trusted when the goal still carries its persisted receipt and the resubmitted
-		// quality gate hashes to the receipt's value. Fail closed when the receipt is missing, since
-		// there is nothing durable left to compare the resubmitted gate against.
-		const persistedHash = goal.completionVerification?.qualityGateHash;
-		if (persistedHash === undefined) {
+		// is only trusted when the goal still carries its durable, well-formed receipt whose identity
+		// matches this goal and whose quality-gate hash matches the resubmitted gate. Fail closed
+		// otherwise, and repair by re-appending the missing ledger row for the persisted receipt
+		// instead of minting a replacement receipt.
+		const receipt = goal.completionVerification;
+		if (!receipt) {
 			throw new Error(
-				`Cannot repair the ${goal.id} complete checkpoint because its durable completion receipt is missing; only checkpoints whose persisted receipt matches the resubmitted quality gate can be repaired.`,
+				`Cannot repair the ${goal.id} complete checkpoint because its durable completion receipt is missing or malformed; only checkpoints with a valid persisted receipt can be repaired.`,
 			);
 		}
-		if (hashStructuredValue(qualityGateJson) !== persistedHash) {
+		if (
+			receipt.schemaVersion !== 1 ||
+			!nonEmptyString(receipt.receiptId) ||
+			receipt.goalId !== goal.id ||
+			receipt.receiptKind !== chooseReceiptKind(plan, goal, input.status) ||
+			!nonEmptyString(receipt.planGeneration) ||
+			!nonEmptyString(receipt.checkpointLedgerEventId) ||
+			receipt.verifiedAt !== goal.updatedAt
+		) {
+			throw new Error(
+				`Cannot repair the ${goal.id} complete checkpoint because its durable completion receipt is missing or malformed; only checkpoints with a valid persisted receipt can be repaired.`,
+			);
+		}
+		if (hashStructuredValue(qualityGateJson) !== receipt.qualityGateHash) {
 			throw new Error(
 				`Cannot repair the ${goal.id} complete checkpoint with a different quality gate; resubmit the quality gate recorded in its completion receipt.`,
 			);
 		}
+		const generation = computeUltragoalPlanGeneration({
+			plan,
+			ledger: ledgerBefore,
+			goal,
+			receiptKind: receipt.receiptKind,
+			beforeStatus: receipt.goalStatusBeforeCheckpoint,
+			excludeEventId: receipt.checkpointLedgerEventId,
+		});
+		if (generation.planGeneration !== receipt.planGeneration) {
+			throw new Error(
+				`Cannot repair the ${goal.id} complete checkpoint because its durable completion receipt is stale for the current plan state.`,
+			);
+		}
+		await appendLedger(input.cwd, {
+			eventId: receipt.checkpointLedgerEventId,
+			event: "goal_checkpointed",
+			goalId: goal.id,
+			status: input.status,
+			evidence,
+			qualityGateJson,
+			completionVerification: receipt,
+		});
+		return plan;
 	}
 	const now = new Date().toISOString();
 	const beforeStatus = goal.status;

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -1366,6 +1366,53 @@ describe("native GJC ultragoal runtime", () => {
 		expect(await countCheckpoints()).toBe(2);
 	});
 
+	it("re-appends a missing complete checkpoint ledger row on an identical retry", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "tests passed",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+
+		// Simulate a crash between the plan write and the ledger append: goals.json already says
+		// complete, but the goal_checkpointed row never made it into the ledger.
+		const ledgerPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl");
+		const withoutCheckpoint = (await Bun.file(ledgerPath).text())
+			.split("\n")
+			.filter(line => line.length > 0 && !line.includes('"goal_checkpointed"'))
+			.map(line => `${line}\n`)
+			.join("");
+		await Bun.write(ledgerPath, withoutCheckpoint);
+
+		// Retrying the identical checkpoint must repair the missing ledger row instead of rejecting
+		// the goal as already complete.
+		const plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "tests passed",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+
+		const checkpoints = (await readUltragoalLedger(root)).filter(
+			event => event.event === "goal_checkpointed" && event.goalId === "G001" && event.status === "complete",
+		);
+		expect(checkpoints).toHaveLength(1);
+		expect(plan.goals[0]?.status).toBe("complete");
+		const diagnostic = validateCompletionReceipt({
+			plan,
+			ledger: await readUltragoalLedger(root),
+			goal: plan.goals[0]!,
+			receiptKind: "final-aggregate",
+		});
+		expect(diagnostic.state).toBe("active_verified_complete");
+	});
+
 	it("completes from durable active goal state", async () => {
 		const root = await tempDir();
 		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -1388,6 +1388,10 @@ describe("native GJC ultragoal runtime", () => {
 			.map(line => `${line}\n`)
 			.join("");
 		await Bun.write(ledgerPath, withoutCheckpoint);
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const goalsBeforeRepair = await Bun.file(goalsPath).text();
+		const persistedReceipt = (await readUltragoalPlan(root))?.goals[0]?.completionVerification;
+		expect(persistedReceipt).toBeDefined();
 
 		// Retrying the identical checkpoint must repair the missing ledger row instead of rejecting
 		// the goal as already complete.
@@ -1404,6 +1408,11 @@ describe("native GJC ultragoal runtime", () => {
 		);
 		expect(checkpoints).toHaveLength(1);
 		expect(plan.goals[0]?.status).toBe("complete");
+		// The repair re-appends the missing row for the persisted receipt identity - it must not
+		// mint a replacement receipt or rewrite the plan.
+		expect(checkpoints[0]?.eventId).toBe(persistedReceipt?.checkpointLedgerEventId);
+		expect(plan.goals[0]?.completionVerification?.receiptId).toBe(persistedReceipt?.receiptId);
+		expect(await Bun.file(goalsPath).text()).toBe(goalsBeforeRepair);
 		const diagnostic = validateCompletionReceipt({
 			plan,
 			ledger: await readUltragoalLedger(root),
@@ -1496,6 +1505,56 @@ describe("native GJC ultragoal runtime", () => {
 				qualityGateJson: JSON.stringify(divergentGate),
 			}),
 		).rejects.toThrow("Cannot repair the G001 complete checkpoint because its durable completion receipt is missing");
+
+		const checkpoints = (await readUltragoalLedger(root)).filter(
+			event => event.event === "goal_checkpointed" && event.goalId === "G001" && event.status === "complete",
+		);
+		expect(checkpoints).toHaveLength(0);
+	});
+
+	it("rejects a ledger repair retry whose persisted receipt is malformed", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+
+		const qualityGateJson = await passingLiveQualityGate(root);
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "tests passed",
+			qualityGateJson,
+		});
+
+		// Strip the ledger row and replace the persisted receipt with a hash-only object: a matching
+		// qualityGateHash alone must not authorize the repair to mint a full replacement receipt.
+		const ledgerPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl");
+		const withoutCheckpoint = (await Bun.file(ledgerPath).text())
+			.split("\n")
+			.filter(line => line.length > 0 && !line.includes('"goal_checkpointed"'))
+			.map(line => `${line}\n`)
+			.join("");
+		await Bun.write(ledgerPath, withoutCheckpoint);
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const goalsDoc = (await Bun.file(goalsPath).json()) as {
+			goals: Array<{ completionVerification?: { qualityGateHash: string } }>;
+		};
+		const persistedHash = goalsDoc.goals[0]?.completionVerification?.qualityGateHash;
+		expect(persistedHash).toBeDefined();
+		goalsDoc.goals[0]!.completionVerification = { qualityGateHash: persistedHash! };
+		await Bun.write(goalsPath, JSON.stringify(goalsDoc, null, 2));
+
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G001",
+				status: "complete",
+				evidence: "tests passed",
+				qualityGateJson: await passingLiveQualityGate(root),
+			}),
+		).rejects.toThrow(
+			"Cannot repair the G001 complete checkpoint because its durable completion receipt is missing or malformed",
+		);
 
 		const checkpoints = (await readUltragoalLedger(root)).filter(
 			event => event.event === "goal_checkpointed" && event.goalId === "G001" && event.status === "complete",

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -1413,6 +1413,49 @@ describe("native GJC ultragoal runtime", () => {
 		expect(diagnostic.state).toBe("active_verified_complete");
 	});
 
+	it("rejects a ledger repair retry whose quality gate diverges from the completion receipt", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "tests passed",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+
+		const ledgerPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl");
+		const withoutCheckpoint = (await Bun.file(ledgerPath).text())
+			.split("\n")
+			.filter(line => line.length > 0 && !line.includes('"goal_checkpointed"'))
+			.map(line => `${line}\n`)
+			.join("");
+		await Bun.write(ledgerPath, withoutCheckpoint);
+
+		// Same status and evidence, but a quality gate that hashes differently from the persisted
+		// completion receipt: the repair path must not let it rewrite the receipt.
+		const divergentGate = JSON.parse(await passingLiveQualityGate(root)) as Record<string, Record<string, unknown>>;
+		divergentGate.executorQa = { ...divergentGate.executorQa, evidence: "executor reran a different QA suite" };
+
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G001",
+				status: "complete",
+				evidence: "tests passed",
+				qualityGateJson: JSON.stringify(divergentGate),
+			}),
+		).rejects.toThrow("Cannot repair the G001 complete checkpoint with a different quality gate");
+
+		// The divergent attempt must not have appended a checkpoint row.
+		const checkpoints = (await readUltragoalLedger(root)).filter(
+			event => event.event === "goal_checkpointed" && event.goalId === "G001" && event.status === "complete",
+		);
+		expect(checkpoints).toHaveLength(0);
+	});
+
 	it("completes from durable active goal state", async () => {
 		const root = await tempDir();
 		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -1456,6 +1456,53 @@ describe("native GJC ultragoal runtime", () => {
 		expect(checkpoints).toHaveLength(0);
 	});
 
+	it("rejects a ledger repair retry when the completion receipt is missing", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "tests passed",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+
+		// Strip both the goal_checkpointed ledger row and the persisted completion receipt: with no
+		// durable receipt left to compare against, the repair path must fail closed instead of
+		// accepting an arbitrary replacement quality gate.
+		const ledgerPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl");
+		const withoutCheckpoint = (await Bun.file(ledgerPath).text())
+			.split("\n")
+			.filter(line => line.length > 0 && !line.includes('"goal_checkpointed"'))
+			.map(line => `${line}\n`)
+			.join("");
+		await Bun.write(ledgerPath, withoutCheckpoint);
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const goalsDoc = (await Bun.file(goalsPath).json()) as { goals: Array<Record<string, unknown>> };
+		delete goalsDoc.goals[0]?.completionVerification;
+		await Bun.write(goalsPath, JSON.stringify(goalsDoc, null, 2));
+
+		const divergentGate = JSON.parse(await passingLiveQualityGate(root)) as Record<string, Record<string, unknown>>;
+		divergentGate.executorQa = { ...divergentGate.executorQa, evidence: "executor reran a different QA suite" };
+
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G001",
+				status: "complete",
+				evidence: "tests passed",
+				qualityGateJson: JSON.stringify(divergentGate),
+			}),
+		).rejects.toThrow("Cannot repair the G001 complete checkpoint because its durable completion receipt is missing");
+
+		const checkpoints = (await readUltragoalLedger(root)).filter(
+			event => event.event === "goal_checkpointed" && event.goalId === "G001" && event.status === "complete",
+		);
+		expect(checkpoints).toHaveLength(0);
+	});
+
 	it("completes from durable active goal state", async () => {
 		const root = await tempDir();
 		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });


### PR DESCRIPTION
## What

- Allow an identical (same goal, same status, same evidence) `complete` checkpoint retry to proceed when the matching `goal_checkpointed` ledger row is missing, so it repairs the ledger instead of throwing.
- Keep rejecting genuine re-completion: a `complete` checkpoint with different evidence on an already-complete goal still fails with the existing error.
- Add a regression test that simulates a crash between the plan write and the ledger append, then retries the identical checkpoint and asserts the ledger row is restored and `validateCompletionReceipt` reports `active_verified_complete`.

## Why

`checkpointUltragoalGoal`'s idempotency guard intentionally requires a matching ledger row before short-circuiting, and its comment documents why: "Requiring a matching ledger row means an interrupted prior write (plan persisted, ledger append lost) still re-appends the event instead of silently dropping it."

That repair path was unreachable for `complete` checkpoints. When `goals.json` already says `complete` but the `goal_checkpointed` row is missing (process died between `writePlan` and `appendLedger`), the retry falls through the guard as designed — and then `validateCompleteCheckpointTargetGoal` unconditionally throws `Cannot checkpoint ... because its durable goals.json status is already complete`. The goal is then permanently stuck: `validateCompletionReceipt` requires the ledger event to verify completion, and every repair attempt throws forever. This is the same interrupted-write bug class as #638/#645.

The new test fails on current `dev` with exactly that error and passes with this change.

## Testing

- `bun test packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts` (109 pass; the new repair test fails before the fix with the "already complete" error, passes after)
- `bun test packages/coding-agent/test/gjc-runtime/ultragoal-durable-completion-release.test.ts packages/coding-agent/test/gjc-runtime/ultragoal-review.test.ts packages/coding-agent/test/gjc-runtime/ultragoal-dogfood.test.ts` (17 pass)
- `bun node_modules/.bin/biome check packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
