### PR TITLE
fix(retry): classify provider safety refusals as terminal instead of unbounded-retryable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Telegram daemon autostart now refuses to attach a new session to a live daemon whose persisted bot-token fingerprint or chat id differs from the current settings, and it avoids registering the session root until ownership is trusted so rotated Telegram credentials cannot keep leaking through the old daemon.
 - Skill autocomplete now supports direct skill-name prefixes after prompt text (for example, `please /ra` → `/skill:ralplan`) while keeping bare `/` menus free of skill entries.
 - `gjc --tmux` on native Windows/psmux now keeps the status line and composer pinned to the bottom after viewport redraws by honoring the GJC tmux launch marker as a multiplexer signal even when `$TMUX` is absent.
+- Provider safety refusals (e.g. Anthropic `stop_reason: "refusal"` → `Refusal (<category>): …`, and `sensitive` → `Content flagged by safety filters`) are now classified as terminal retry errors and surface immediately. They previously fell through to the unbounded `"unknown"` retry class, and because a refusal is deterministic for the submitted context, the session looped refusal → retry → refusal forever — resubmitting the full context every `retry.maxDelayMs` and re-billing it as a prompt-cache write whenever the backoff outlived the cache TTL (#1655).
 
 - `gjc config list`, `gjc config get`, and `gjc config set` now redact secret-like string settings by default, with `--show-secrets` as an explicit unsafe opt-in.
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8467,6 +8467,16 @@ export class AgentSession {
 		);
 	}
 
+	#isRefusalErrorMessage(errorMessage: string): boolean {
+		// Provider safety-refusal stops. Matches the engine-generated Anthropic
+		// labels from packages/ai ("Refusal (<category>): …", "Refusal (no
+		// details provided)", "Content flagged by safety filters") plus generic
+		// usage-policy refusal copy.
+		return /^refusal(\s*\(|:|$)|content flagged by safety filters|blocked under .{0,40}usage policy/i.test(
+			errorMessage,
+		);
+	}
+
 	#extractExplicitHttpStatusFromErrorMessage(errorMessage: string): number | undefined {
 		// Parse only explicit HTTP/status wording. Do not treat generic
 		// `error: 400` as an HTTP status because rate-limit copy can say
@@ -8487,6 +8497,13 @@ export class AgentSession {
 		const contextWindow = this.model?.contextWindow ?? 0;
 		if (isContextOverflow(message, contextWindow)) return "overflow";
 		const err = message.errorMessage;
+		// Provider safety refusals (e.g. Anthropic stop_reason "refusal" /
+		// "sensitive") are deterministic for the submitted context: replaying
+		// the identical conversation re-triggers the identical refusal, so an
+		// auto-retry loop can never succeed and only re-bills the full context
+		// on every attempt (#1655). Surface immediately instead of joining the
+		// unbounded "unknown" retry class.
+		if (this.#isRefusalErrorMessage(err)) return "terminal";
 		if (isLocalModelEndpoint(this.model) && this.#isLocalProviderAvailabilityErrorMessage(err)) {
 			return "local_unavailable";
 		}

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -241,6 +241,49 @@ describe("AgentSession resilient retry", () => {
 		expect(last.errorMessage).toContain("401");
 	});
 
+	it("surfaces provider safety refusals without retrying", async () => {
+		// Anthropic stop_reason "refusal"/"sensitive" maps to stopReason "error"
+		// with an engine-generated label (packages/ai anthropic.ts). Refusals are
+		// deterministic for the submitted context, so every retry re-sends the
+		// full conversation and deterministically refuses again (#1655).
+		const refusals = [
+			"Refusal (cyber): This request triggered restrictions on violative cyber content and was blocked under Anthropic's Usage Policy. To learn more, see https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback.",
+			"Refusal (no details provided)",
+			"Content flagged by safety filters",
+		];
+		for (const refusal of refusals) {
+			session = buildSession({ responses: [{ throw: refusal }] });
+			vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+			const { retryStartEvents } = track(session);
+
+			await session.prompt("trigger provider refusal");
+			await session.waitForIdle();
+
+			expect(retryStartEvents).toHaveLength(0);
+			const last = lastAssistant(session);
+			expect(last.stopReason).toBe("error");
+			expect(last.errorMessage).toBe(refusal);
+			await session.dispose();
+			session = undefined;
+		}
+	});
+
+	it("still retries errors that merely mention a refusal mid-sentence", async () => {
+		// Guard the anchored match: transient copy that contains the word
+		// "refusal" in passing must not be terminalized.
+		session = buildSession({
+			responses: [{ throw: "connection error after upstream refusal handshake" }, { content: ["recovered"] }],
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents } = track(session);
+
+		await session.prompt("mid-sentence refusal mention");
+		await session.waitForIdle();
+
+		expect(retryStartEvents.length).toBeGreaterThanOrEqual(1);
+		expect(lastAssistant(session).stopReason).toBe("stop");
+	});
+
 	it("surfaces deliberate request aborts without retrying", async () => {
 		session = buildSession({ responses: [{ throw: "Request was aborted." }] });
 		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);


### PR DESCRIPTION
Fixes #1655.

## What changed

Provider safety refusals are now classified as **terminal** retry errors and surface immediately, instead of falling through to the unbounded `"unknown"` retry class.

- `packages/coding-agent/src/session/agent-session.ts`
  - New `#isRefusalErrorMessage`: matches the engine-generated Anthropic labels from `packages/ai/src/providers/anthropic.ts` — `Refusal (<category>): …`, `Refusal (no details provided)`, `Content flagged by safety filters` — plus generic "blocked under … usage policy" copy. The `Refusal` match is anchored to the start of the message so transient errors that merely mention a refusal mid-sentence keep retrying.
  - `#classifyErrorForRetry` returns `"terminal"` for refusal messages before any retry class is considered.
- `packages/coding-agent/test/agent-session-resilient-retry.test.ts`
  - `surfaces provider safety refusals without retrying` — all three engine-generated labels produce zero `auto_retry_start` events and surface as `stopReason: "error"` with the message intact.
  - `still retries errors that merely mention a refusal mid-sentence` — guards the anchored match against false positives.
- `packages/coding-agent/CHANGELOG.md` — Unreleased → Fixed entry.

## Why

A usage-policy refusal is deterministic for the submitted context: replaying the identical conversation re-triggers the identical refusal, so an auto-retry loop can never succeed. Before this change the loop:

1. never surfaced a terminal error (the TUI showed empty assistant turns),
2. re-sent the entire context every `retry.maxDelayMs`, and
3. re-billed the full context as a prompt-cache **write** whenever the backoff outlived the provider cache TTL.

In the incident behind #1655, one session accumulated **131 consecutive empty refusal turns over ~10 hours** (~476K–513K tokens per attempt, cache-miss attempts at ~$6 each, ~$521 total) with zero forward progress.

This follows the same reasoning as the ollama-cloud first-event-timeout bounding (#713): unbounded continuation retries that re-issue the full request against a billable backend must not run without a termination condition — and for refusals the correct bound is zero, since the outcome is deterministic.

## Verification

```
cd packages/coding-agent
bun test test/agent-session-resilient-retry.test.ts test/agent-session-retry-cap.test.ts test/agent-session-retry-fallback.test.ts
# 38 pass, 0 fail

bun run check:ts   # biome + tsgo across workspaces: clean
```

## Follow-ups (not in this PR, discussed in #1655)

- Structured `errorKind: "refusal" | "safety"` on the assistant-message envelope in `packages/ai`, so classification does not depend on engine-generated strings.
- User-facing guidance when a refusal terminalizes (suggest editing/compacting the conversation or switching models).
- Whether goal-mode continuation should pause after a terminal refusal instead of re-prompting into the same context.
