### PR TITLE
fix(model): align slash agent override updates

### DIFF
--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -363,8 +363,8 @@ function formatModelAssignmentSuccess(
 	if (targetId === "all-targets") {
 		return `All model targets set to ${selector} for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.`;
 	}
-	if (targetId === "default") return `DEFAULT model set to ${selector}.`;
-	return `${targetId.toUpperCase()} agent model set to ${selector}.`;
+	if (targetId === "default") return `Default model set to ${selector}.`;
+	return `${targetId} agent model set to ${selector}.`;
 }
 
 function modelSelectionUsage(runtime: SlashCommandRuntime, currentModelLine?: string): string {
@@ -513,21 +513,13 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						assignments,
 					});
 					if (!materializedProfile) {
-						const nextOverrides = { ...overrides };
 						for (const [targetId, selector] of assignments) {
 							const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetId];
 							if (target.settingsPath === "modelRoles") {
 								runtime.settings.setModelRole(targetId, selector);
 							} else {
-								nextOverrides[targetId] = selector;
+								runtime.settings.setAgentModelOverride(targetId, selector);
 							}
-						}
-						if (
-							targetIds.some(
-								targetId => GJC_MODEL_ASSIGNMENT_TARGETS[targetId].settingsPath === "task.agentModelOverrides",
-							)
-						) {
-							runtime.settings.set("task.agentModelOverrides", nextOverrides);
 						}
 					}
 					runtime.settings.getStorage()?.recordModelUsage(`${selection.model.provider}/${selection.model.id}`);

--- a/packages/coding-agent/test/slash-commands/model.test.ts
+++ b/packages/coding-agent/test/slash-commands/model.test.ts
@@ -147,6 +147,6 @@ describe("/model batch assignments", () => {
 
 		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:high");
 		expect(session.thinkingLevel).toBe("high");
-		expect(output).toEqual(["DEFAULT model set to anthropic/claude-3-5-sonnet:high."]);
+		expect(output).toEqual(["Default model set to anthropic/claude-3-5-sonnet:high."]);
 	});
 });


### PR DESCRIPTION
## Summary
- update slash `/model assign` writes for agent roles to use `Settings.setAgentModelOverride`
- keep live runtime agent-model overrides aligned with persisted settings for explicit role changes
- normalize slash command output casing for default/agent assignment messages

## Verification
- `bun test packages/coding-agent/test/slash-commands/model.test.ts`
- `bun --cwd=packages/coding-agent run check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*