### PR TITLE
Preserve vanished tmux session recovery state

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -193,29 +193,50 @@ function numericProcessExitCode(defaultCode: number | null): number | null {
 	return typeof process.exitCode === "number" ? process.exitCode : defaultCode;
 }
 
-function postmortemExitDetails(reason: postmortem.Reason): {
+function postmortemExitDetails(
+	reason: postmortem.Reason,
+	previous: RuntimeStateSidecarPayload,
+): {
 	state: RuntimeState;
 	reason: string;
 	exitKind: string;
 	exitCode: number | null;
 	signal: string | null;
 	error?: { code: string; message: string; recoverable: true };
+	recovery?: { action: string; reason: string };
 } {
 	if (reason === postmortem.Reason.EXIT || reason === postmortem.Reason.MANUAL) {
 		const exitCode = numericProcessExitCode(0) ?? 0;
-		const state: RuntimeState = exitCode === 0 ? "completed" : "errored";
+		const exitedBeforeTerminalState =
+			exitCode === 0 && reason === postmortem.Reason.EXIT && previous.state === "running";
+		const state: RuntimeState = exitCode === 0 && !exitedBeforeTerminalState ? "completed" : "errored";
+		const exitReason = exitedBeforeTerminalState
+			? "process_exit_before_terminal_state"
+			: reason === postmortem.Reason.EXIT
+				? "process_exit"
+				: "manual_cleanup";
 		return {
 			state,
-			reason: reason === postmortem.Reason.EXIT ? "process_exit" : "manual_cleanup",
+			reason: exitReason,
 			exitKind: reason,
 			exitCode,
 			signal: null,
 			...(state === "errored"
 				? {
 						error: {
-							code: "process_exit",
-							message: publicSafeErrorMessage(`GJC process exited with code ${exitCode}`),
+							code: exitReason,
+							message: publicSafeErrorMessage(
+								exitedBeforeTerminalState
+									? "GJC process exited before emitting terminal agent state"
+									: `GJC process exited with code ${exitCode}`,
+							),
 							recoverable: true,
+						},
+						recovery: {
+							action: "recover_or_resume_session",
+							reason: exitedBeforeTerminalState
+								? "previous runtime state was non-terminal; preserve the worktree and inspect the session before retrying"
+								: "process exited with a non-zero status",
 						},
 					}
 				: {}),
@@ -233,6 +254,7 @@ function postmortemExitDetails(reason: postmortem.Reason): {
 		exitCode: numericProcessExitCode(null),
 		signal: signalByReason[reason] ?? null,
 		error: { code: reason, message: errorMessageForPostmortem(reason), recoverable: true },
+		recovery: { action: "recover_or_resume_session", reason: "process cleanup ran before terminal agent state" },
 	};
 }
 
@@ -287,7 +309,7 @@ export function persistCoordinatorRuntimeStateFromPostmortem(
 	const previous = readPreviousPayload(stateFile);
 	if (shouldPreserveTerminalPayload(previous as RuntimeStateSidecarPayload)) return;
 	const now = new Date().toISOString();
-	const details = postmortemExitDetails(reason);
+	const details = postmortemExitDetails(reason, previous as RuntimeStateSidecarPayload);
 	const payload = {
 		...basePayload({
 			context,
@@ -304,6 +326,8 @@ export function persistCoordinatorRuntimeStateFromPostmortem(
 		exit_code: details.exitCode,
 		signal: details.signal,
 		...(details.error ? { error: details.error } : {}),
+		...(details.recovery ? { recovery: details.recovery } : {}),
+		previous_runtime_state: typeof previous.state === "string" ? previous.state : null,
 	};
 	try {
 		writeStateFileSync(stateFile, payload);

--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -23,6 +23,11 @@ async function tempRoot(): Promise<string> {
 	return dir;
 }
 
+function git(cwd: string, args: string[]): void {
+	const proc = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	if (proc.exitCode !== 0) throw new Error(proc.stderr.toString() || `git ${args.join(" ")} failed`);
+}
+
 afterEach(async () => {
 	if (ORIGINAL_STATE_FILE === undefined) delete process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV];
 	else process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = ORIGINAL_STATE_FILE;
@@ -149,6 +154,63 @@ describe("coordinator runtime state sidecar", () => {
 			session_file: path.join(root, "session.jsonl"),
 			error: { code: "sigterm", recoverable: true },
 		});
+		expect(payload).not.toHaveProperty("messages");
+		expect(payload).not.toHaveProperty("transcript");
+		expect(payload).not.toHaveProperty("paneLog");
+	});
+
+	it("marks zero-code post-acceptance process exit as recoverable instead of completed", async () => {
+		const root = await tempRoot();
+		const workspace = path.join(root, "worktree");
+		await fs.mkdir(workspace);
+		git(workspace, ["init"]);
+		git(workspace, ["config", "user.email", "test@example.com"]);
+		git(workspace, ["config", "user.name", "Test User"]);
+		await Bun.write(path.join(workspace, "README.md"), "base\n");
+		git(workspace, ["add", "README.md"]);
+		git(workspace, ["commit", "-m", "init"]);
+		await Bun.write(path.join(workspace, "README.md"), "base\nrecoverable dirty change\n");
+		const stateFile = path.join(root, "state.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "post-acceptance-session";
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "post-acceptance-session",
+				state: "running",
+				ready_for_input: false,
+				cwd: workspace,
+				session_file: path.join(root, "session.jsonl"),
+				current_turn_id: "turn-after-prompt-acceptance",
+			}),
+		);
+		const previousExitCode = process.exitCode;
+		process.exitCode = 0;
+		try {
+			persistCoordinatorRuntimeStateFromPostmortem(postmortem.Reason.EXIT, {
+				sessionId: "fallback",
+				cwd: workspace,
+				sessionFile: path.join(root, "session.jsonl"),
+			});
+		} finally {
+			process.exitCode = previousExitCode;
+		}
+
+		const payload = JSON.parse(await Bun.file(stateFile).text());
+		expect(payload).toMatchObject({
+			schema_version: 1,
+			session_id: "post-acceptance-session",
+			state: "errored",
+			ready_for_input: false,
+			source: "process_postmortem",
+			reason: "process_exit_before_terminal_state",
+			exit_code: 0,
+			previous_runtime_state: "running",
+			error: { code: "process_exit_before_terminal_state", recoverable: true },
+			recovery: { action: "recover_or_resume_session" },
+		});
+		expect(await Bun.file(path.join(workspace, "README.md")).text()).toContain("recoverable dirty change");
 		expect(payload).not.toHaveProperty("messages");
 		expect(payload).not.toHaveProperty("transcript");
 		expect(payload).not.toHaveProperty("paneLog");


### PR DESCRIPTION
## Summary
- Treat a zero-exit postmortem from a previously running tmux-resident GJC session as `errored` when no terminal `agent_end` state was emitted.
- Persist machine-readable recovery guidance and `previous_runtime_state` instead of falsely marking the session completed.
- Add regression coverage for the post-acceptance vanish case with a dirty recoverable worktree preserved on disk.

Fixes #1496.

## Verification
- `bun test packages/coding-agent/test/session-state-sidecar.test.ts`
- `bun --cwd=packages/coding-agent run check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*