### PR TITLE
Fix vanished tmux classification after runtime ack

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Skill autocomplete now supports direct skill-name prefixes after prompt text (for example, `please /ra` → `/skill:ralplan`) while keeping bare `/` menus free of skill entries.
 - `gjc --tmux` on native Windows/psmux now keeps the status line and composer pinned to the bottom after viewport redraws by honoring the GJC tmux launch marker as a multiplexer signal even when `$TMUX` is absent.
 - Provider safety refusals (e.g. Anthropic `stop_reason: "refusal"` → `Refusal (<category>): …`, and `sensitive` → `Content flagged by safety filters`) are now classified as terminal retry errors and surface immediately. They previously fell through to the unbounded `"unknown"` retry class, and because a refusal is deterministic for the submitted context, the session looped refusal → retry → refusal forever — resubmitting the full context every `retry.maxDelayMs` and re-billing it as a prompt-cache write whenever the backoff outlived the cache TTL (#1655).
+- Coordinator event watches now wake on runtime sidecar state changes and emit a bounded `turn.acknowledged` event, so a tmux-resident session that accepts a prompt and then vanishes is durably classified as recoverable `tmux_session_missing_after_prompt_acknowledgement` instead of leaving only a watch registration with no terminal verdict (#1496).
 
 - `gjc config list`, `gjc config get`, and `gjc config set` now redact secret-like string settings by default, with `--show-secrets` as an explicit unsafe opt-in.
 

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -175,6 +175,7 @@ type CoordinatorEventKind =
 	| "turn.queued"
 	| "turn.delivering"
 	| "turn.active"
+	| "turn.acknowledged"
 	| "turn.waiting_for_answer"
 	| "turn.completed"
 	| "turn.failed"
@@ -1121,6 +1122,18 @@ async function markTurnAcknowledgedFromRuntimeState(
 	};
 	await writeTurnRecord(namespaceDir, acknowledged);
 	await writeActiveTurn(namespaceDir, acknowledged);
+	await appendCoordinatorEvent(namespaceDir, {
+		kind: "turn.acknowledged",
+		sessionId: acknowledged.session_id,
+		turnId: acknowledged.turn_id,
+		summary: `Turn ${acknowledged.turn_id} was acknowledged by the GJC runtime`,
+		payloadRef: path.relative(namespaceDir, turnFile(namespaceDir, acknowledged.turn_id)),
+		metadata: {
+			status: acknowledged.status,
+			tmux_keys_sent: acknowledged.delivery.tmux_keys_sent ?? null,
+			prompt_acknowledged: true,
+		},
+	});
 	return acknowledged;
 }
 
@@ -1533,14 +1546,27 @@ async function waitForCoordinatorEvents(namespaceDir: string, timeoutMs: number)
 	};
 	const timer = setTimeout(finish, Math.max(timeoutMs, 0));
 	timer.unref?.();
-	await ensureDir(eventsDir(namespaceDir));
-	try {
-		const watcher = nodeFs.watch(eventsDir(namespaceDir), (_eventType, filename) => {
-			if (filename === "event-journal.jsonl" || filename === "latest-seq.json") finish();
-		});
-		watchers.push(watcher);
-	} catch {
-		// Directory may not exist yet; the timeout remains a bounded fallback.
+	const eventDir = eventsDir(namespaceDir);
+	const watchedDirs = [
+		eventDir,
+		turnsDir(namespaceDir),
+		path.join(namespaceDir, "active-turns"),
+		path.join(namespaceDir, "session-states"),
+	];
+	for (const dir of watchedDirs) {
+		await ensureDir(dir);
+		try {
+			const watcher = nodeFs.watch(dir, (_eventType, filename) => {
+				if (dir === eventDir) {
+					if (filename === "event-journal.jsonl" || filename === "latest-seq.json") finish();
+					return;
+				}
+				if (typeof filename === "string" && filename.endsWith(".json")) finish();
+			});
+			watchers.push(watcher);
+		} catch {
+			// Directory may not be watchable on this platform; the timeout remains a bounded fallback.
+		}
 	}
 	return deferred.promise;
 }

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -711,6 +711,98 @@ describe("Coordinator MCP server protocol", () => {
 		);
 	});
 
+	it("wakes watch on runtime ack and records vanished tmux after prompt acceptance", async () => {
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "state", "watch-ack-vanish");
+		let tmuxLive = true;
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+			},
+			services: {
+				commandRunner: async command => {
+					if (command[1] === "has-session") return { exitCode: tmuxLive ? 0 : 1, stdout: "", stderr: "" };
+					if (command[1] === "display-message") return { exitCode: 0, stdout: "%24\n", stderr: "" };
+					if (isTmuxPromptDeliveryCommand(command)) return { exitCode: 0, stdout: "", stderr: "" };
+					return { exitCode: 0, stdout: "", stderr: "" };
+				},
+			},
+		});
+		await server.callTool("gjc_coordinator_register_session", {
+			session_id: "omx-issue-3059-state-root-resolution",
+			cwd: root,
+			tmux_session: "omx-issue-3059-state-root-resolution",
+			tmux_target: "omx-issue-3059-state-root-resolution:0.0",
+			visible: true,
+			allow_mutation: true,
+		});
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "omx-issue-3059-state-root-resolution",
+			prompt: "/skill:ralplan plan OmX #3059 fix",
+			allow_mutation: true,
+		});
+		const turnId = sent.turn_id as string;
+		const ackWatch = server.callTool("gjc_coordinator_watch_events", {
+			after_seq: 0,
+			event_types: ["turn.acknowledged"],
+			timeout_ms: 1000,
+		});
+		const sessionStatePath = path.join(
+			stateRoot,
+			"local",
+			"repo",
+			"session-states",
+			"omx-issue-3059-state-root-resolution.json",
+		);
+		await Bun.sleep(25);
+		await Bun.write(
+			sessionStatePath,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "omx-issue-3059-state-root-resolution",
+				state: "running",
+				ready_for_input: false,
+				current_turn_id: turnId,
+				last_turn_id: null,
+				updated_at: "2026-07-05T18:58:00.000Z",
+				source: "agent_session_event",
+				live: true,
+				reason: "turn_start",
+			}),
+		);
+		const acknowledged = await ackWatch;
+		expect(acknowledged).toMatchObject({ ok: true, timed_out: false });
+		expect(acknowledged.events as Array<{ kind: string; turn_id?: string }>).toContainEqual(
+			expect.objectContaining({ kind: "turn.acknowledged", turn_id: turnId }),
+		);
+
+		tmuxLive = false;
+		const failed = await server.callTool("gjc_coordinator_watch_events", {
+			after_seq: (acknowledged.latest_seq as number) ?? 0,
+			event_types: ["turn.failed"],
+			timeout_ms: 5,
+		});
+
+		expect(failed).toMatchObject({ ok: true, timed_out: false });
+		expect(failed.events as Array<{ kind: string; turn_id?: string }>).toContainEqual(
+			expect.objectContaining({ kind: "turn.failed", turn_id: turnId }),
+		);
+		const read = await server.callTool("gjc_coordinator_read_turn", {
+			session_id: "omx-issue-3059-state-root-resolution",
+			turn_id: turnId,
+		});
+		expect(read).toMatchObject({
+			turn: {
+				status: "failed",
+				error: { message: "tmux_session_missing_after_prompt_acknowledgement" },
+			},
+		});
+	});
+
 	it("preserves session-missing failure precedence over runtime ack timeout", async () => {
 		const root = await tempRoot();
 		const stateRoot = path.join(root, ".gjc", "state", "missing-session-precedence");


### PR DESCRIPTION
## Summary
- Wake coordinator event watches on runtime sidecar, active-turn, and turn-file changes instead of only event-journal writes.
- Emit a bounded `turn.acknowledged` coordinator event when the runtime accepts a prompt, giving watchers durable public-safe evidence before any terminal response.
- Preserve the OmX #3059-style vanished-session verdict by classifying a missing tmux session after acknowledgement as recoverable `tmux_session_missing_after_prompt_acknowledgement`.

Fixes #1496.

## Verification
- `bun test test/coordinator-mcp-server.test.ts` (from `packages/coding-agent`)
- `bun --cwd=packages/coding-agent run check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
