### PR TITLE
Fix team worker command for packaged bunfs entrypoints

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `gjc completion inshellisense`, which generates or installs a Fig/withfig-compatible `gjc` completion spec for Microsoft inshellisense without adding inshellisense as a runtime dependency.
 
 ### Fixed
+- `gjc team` packaged binaries now avoid persisting Bun virtual `/$bunfs/...` entrypoints as worker commands, so tmux worker panes launch through a real executable or the `gjc` fallback instead of immediately disappearing (#1661).
 - `computer` now honors `include_screenshot` and `computer.autoScreenshot` by returning bounded post-action screenshots, and batch steps now respect nested per-step `timeout` values.
 - Custom-provider `gpt-5.5` entries without an explicit `contextWindow` now default to the 272K Codex prompt budget unless the provider uses first-party `openai-responses`, so Codex passthrough proxies (e.g. CLIProxyAPI) compact in time instead of dying with `context_length_exceeded` at ~272K while the registry advertises 1M.
 - `telegram_send` now rejects files over Telegram's document upload limit before reading them into memory or handing them to the notification sink.

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -1896,16 +1896,39 @@ function readCurrentTmuxLeaderContext(tmuxCommand: string, env: NodeJS.ProcessEn
 	}
 	return { sessionName, windowIndex, leaderPaneId, target: `${sessionName}:${windowIndex}` };
 }
+type CommandPathResolver = (command: string) => string | null;
+
+function isBunVirtualPath(candidate: string | undefined): boolean {
+	const normalized = candidate?.trim().replace(/\\/g, "/");
+	return normalized === "/$bunfs" || normalized?.startsWith("/$bunfs/") === true;
+}
+
+function resolveFallbackGjcWorkerCommand(
+	platform: NodeJS.Platform,
+	execPath: string,
+	which: CommandPathResolver,
+): string {
+	const pathModule = platform === "win32" ? path.win32 : path;
+	const quote = platform === "win32" ? powershellQuote : shellQuote;
+	const executable = execPath.trim();
+	if (executable && !isBunVirtualPath(executable) && pathModule.isAbsolute(executable)) return quote(executable);
+	const gjcPath = which("gjc")?.trim();
+	if (gjcPath && !isBunVirtualPath(gjcPath)) return quote(gjcPath);
+	return "gjc";
+}
+
 export function resolveGjcWorkerCommand(
 	cwd = process.cwd(),
 	env: NodeJS.ProcessEnv = process.env,
 	platform: NodeJS.Platform = process.platform,
 	argv: string[] = process.argv,
 	execPath = process.execPath,
+	which: CommandPathResolver = Bun.which,
 ): string {
 	const explicit = env.GJC_TEAM_WORKER_COMMAND?.trim();
 	if (explicit) return explicit;
 	const entrypoint = argv[1];
+	if (isBunVirtualPath(entrypoint)) return resolveFallbackGjcWorkerCommand(platform, execPath, which);
 	if (!entrypoint) return "gjc";
 	const pathModule = platform === "win32" ? path.win32 : path;
 	const resolvedEntrypoint = pathModule.isAbsolute(entrypoint) ? entrypoint : pathModule.resolve(cwd, entrypoint);

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -2834,4 +2834,49 @@ describe("resolveGjcWorkerCommand bun prefix for script entrypoints", () => {
 		expect(out).toContain("bun");
 		expect(out).toContain("cli.mjs");
 	});
+
+	it("does not emit Bun virtual packaged entrypoints as POSIX worker executables", async () => {
+		process.argv = ["gjc", "/$bunfs/root/gjc-linux-x64"];
+		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
+		const out = resolveGjcWorkerCommand("/repo", {}, "linux", process.argv, "/opt/gjc/gjc-linux-x64", () => null);
+
+		expect(out).toBe("'/opt/gjc/gjc-linux-x64'");
+		expect(out).not.toContain("$bunfs");
+	});
+
+	it("falls back to a PATH-resolved gjc when the packaged process executable is also virtual", async () => {
+		process.argv = ["gjc", "/$bunfs/root/gjc-linux-x64"];
+		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
+		const out = resolveGjcWorkerCommand("/repo", {}, "linux", process.argv, "/$bunfs/root/gjc-linux-x64", command =>
+			command === "gjc" ? "/usr/local/bin/gjc" : null,
+		);
+
+		expect(out).toBe("'/usr/local/bin/gjc'");
+		expect(out).not.toContain("$bunfs");
+	});
+
+	it("falls back to plain gjc when packaged entrypoint and PATH probe are not usable", async () => {
+		process.argv = ["gjc", "/$bunfs/root/gjc-linux-x64"];
+		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
+		const out = resolveGjcWorkerCommand("/repo", {}, "linux", process.argv, "/$bunfs/root/gjc-linux-x64", () => null);
+
+		expect(out).toBe("gjc");
+		expect(out).not.toContain("$bunfs");
+	});
+
+	it("does not emit Bun virtual packaged entrypoints as Windows worker executables", async () => {
+		process.argv = ["gjc", "\\$bunfs\\root\\gjc-windows-x64.exe"];
+		const { resolveGjcWorkerCommand } = await import("../../src/gjc-runtime/team-runtime");
+		const out = resolveGjcWorkerCommand(
+			"C:\\repo",
+			{},
+			"win32",
+			process.argv,
+			"C:\\Program Files\\gjc\\gjc.exe",
+			() => null,
+		);
+
+		expect(out).toBe("'C:\\Program Files\\gjc\\gjc.exe'");
+		expect(out).not.toContain("$bunfs");
+	});
 });


### PR DESCRIPTION
## Summary
- avoid persisting Bun virtual /$bunfs entrypoints as gjc team worker commands
- fall back to a real process executable, PATH-resolved gjc, or plain gjc
- add focused resolver coverage for POSIX/Windows packaged binary paths

Fixes #1661

## Validation
- bun --cwd=packages/coding-agent run check
- bun test test/gjc-runtime/team-runtime.test.ts (from packages/coding-agent)