### PR TITLE
fix: avoid repeated oversized auto-maintenance attempts

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1153,6 +1153,8 @@ export class AgentSession {
 	#obfuscator: SecretObfuscator | undefined;
 	#checkpointState: CheckpointState | undefined = undefined;
 	#providerReplaySourceCache = new WeakMap<AgentMessage, ProviderReplaySourceCacheEntry>();
+	#lastOversizedAutoMaintenanceAttemptSignature: string | undefined = undefined;
+
 	#pendingRewindReport: string | undefined = undefined;
 	#lastSuccessfulYieldToolCallId: string | undefined = undefined;
 	#promptGeneration = 0;
@@ -7757,6 +7759,41 @@ export class AgentSession {
 		return false;
 	}
 
+	#buildAutoMaintenanceAttemptSignature(
+		action: "context-full" | "handoff",
+		preparation: CompactionPreparation,
+		hookPrompt: string | undefined,
+		hookContext: string[] | undefined,
+		candidateModels: readonly Model[],
+	): string {
+		const source = JSON.stringify({
+			action,
+			model: this.model ? this.#getModelKey(this.model) : undefined,
+			candidates: candidateModels.map(model => this.#getModelKey(model)),
+			isSplitTurn: preparation.isSplitTurn,
+			previousSummary: preparation.previousSummary,
+			previousPreserveData: preparation.previousPreserveData,
+			hookPrompt,
+			hookContext,
+			messagesToSummarize: preparation.messagesToSummarize.map(message =>
+				this.#normalizeSessionMessageForProviderReplay(message),
+			),
+			turnPrefixMessages: preparation.turnPrefixMessages.map(message =>
+				this.#normalizeSessionMessageForProviderReplay(message),
+			),
+			recentMessages: preparation.recentMessages.map(message =>
+				this.#normalizeSessionMessageForProviderReplay(message),
+			),
+		});
+		return `${this.#hashProviderReplaySource(source).toString(16)}:${source.length}`;
+	}
+
+	#isOversizedMaintenanceError(errorMessage: string): boolean {
+		return /context_length_exceeded|exceeds? (the )?context window|maximum context length|payload too large|request entity too large/i.test(
+			errorMessage,
+		);
+	}
+
 	#getModelKey(model: Model): string {
 		return `${model.provider}/${model.id}`;
 	}
@@ -8027,6 +8064,7 @@ export class AgentSession {
 		const autoCompactionAbortController = new AbortController();
 		this.#autoCompactionAbortController = autoCompactionAbortController;
 		const autoCompactionSignal = autoCompactionAbortController.signal;
+		let maintenanceAttemptSignature: string | undefined;
 
 		try {
 			if (compactionSettings.strategy === "handoff" && reason !== "overflow") {
@@ -8174,6 +8212,26 @@ export class AgentSession {
 				preserveData = compactionPrep.preserveData;
 			} else {
 				const candidates = this.#getCompactionModelCandidates(availableModels);
+				maintenanceAttemptSignature = this.#buildAutoMaintenanceAttemptSignature(
+					action,
+					preparation,
+					compactionPrep.hookPrompt,
+					compactionPrep.hookContext,
+					candidates,
+				);
+				if (this.#lastOversizedAutoMaintenanceAttemptSignature === maintenanceAttemptSignature) {
+					await this.#emitSessionEvent({
+						type: "auto_compaction_end",
+						action,
+						result: undefined,
+						aborted: false,
+						willRetry: false,
+						skipped: true,
+						errorMessage:
+							"Auto-compaction skipped: previous unchanged maintenance request exceeded the model context window; change or reduce the conversation before retrying maintenance.",
+					});
+					return;
+				}
 				const retrySettings = this.settings.getGroup("retry");
 				const telemetry = resolveTelemetry(this.agent.telemetry, this.sessionId);
 				let compactResult: CompactionResult | undefined;
@@ -8306,6 +8364,8 @@ export class AgentSession {
 				details,
 				preserveData,
 			};
+			this.#lastOversizedAutoMaintenanceAttemptSignature = undefined;
+
 			const continuationSkipReason = willRetry ? this.#detectOverflowRetryContinuationSkip() : undefined;
 			await this.#emitSessionEvent({
 				type: "auto_compaction_end",
@@ -8343,6 +8403,9 @@ export class AgentSession {
 				return;
 			}
 			const errorMessage = error instanceof Error ? error.message : "compaction failed";
+			if (maintenanceAttemptSignature && this.#isOversizedMaintenanceError(errorMessage)) {
+				this.#lastOversizedAutoMaintenanceAttemptSignature = maintenanceAttemptSignature;
+			}
 			await this.#emitSessionEvent({
 				type: "auto_compaction_end",
 				action,

--- a/packages/coding-agent/test/agent-session-auto-compaction-oversized.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-oversized.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import * as compactionModule from "@gajae-code/agent-core/compaction";
+import { getBundledModel } from "@gajae-code/ai";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession, type AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+import { assistantMsg, userMsg } from "./utilities";
+
+describe("AgentSession oversized auto-maintenance guard", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let modelRegistry: ModelRegistry;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-oversized-maintenance-");
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled test model to exist");
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey(model.provider, "test-key");
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		sessionManager = SessionManager.inMemory();
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.keepRecentTokens": 1,
+				"contextPromotion.enabled": false,
+				"retry.enabled": false,
+				"todo.reminders": false,
+			}),
+			modelRegistry,
+		});
+		session.subscribe(() => {});
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	function appendConversation(seed = "seed"): void {
+		for (let i = 0; i < 4; i++) {
+			const user = userMsg(`${seed} user ${i}`);
+			const assistant = assistantMsg(`${seed} assistant ${i}`);
+			session.agent.appendMessage(user);
+			sessionManager.appendMessage(user);
+			session.agent.appendMessage(assistant);
+			sessionManager.appendMessage(assistant);
+		}
+	}
+
+	it("skips an unchanged oversized auto-maintenance retry after a context-length failure", async () => {
+		appendConversation();
+		const events: Extract<AgentSessionEvent, { type: "auto_compaction_end" }>[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_end") events.push(event);
+		});
+		const compactSpy = vi
+			.spyOn(compactionModule, "compact")
+			.mockRejectedValue(new Error("context_length_exceeded: request exceeds the context window"));
+
+		await session.runIdleCompaction();
+		await session.runIdleCompaction();
+
+		// One maintenance attempt may try multiple model candidates. The retry must
+		// not start a second attempt with the same unchanged request.
+		expect(compactSpy).toHaveBeenCalledTimes(2);
+		expect(events).toHaveLength(2);
+		expect(events[0]).toMatchObject({
+			errorMessage: expect.stringContaining("context_length_exceeded"),
+			willRetry: false,
+		});
+		expect(events[0].skipped).toBeUndefined();
+		expect(events[1]).toMatchObject({
+			skipped: true,
+			willRetry: false,
+			errorMessage: expect.stringContaining("previous unchanged maintenance request exceeded"),
+		});
+	});
+
+	it("allows a new oversized maintenance attempt after the conversation changes", async () => {
+		appendConversation("initial");
+		const compactSpy = vi
+			.spyOn(compactionModule, "compact")
+			.mockRejectedValue(new Error("maximum context length exceeded"));
+
+		await session.runIdleCompaction();
+		await session.runIdleCompaction();
+
+		const user = userMsg("new reduced context boundary");
+		session.agent.appendMessage(user);
+		sessionManager.appendMessage(user);
+
+		await session.runIdleCompaction();
+
+		expect(compactSpy).toHaveBeenCalledTimes(4);
+	});
+});


### PR DESCRIPTION
## Summary
- add an auto-maintenance attempt signature for context-full compaction requests
- skip unchanged retries after context-length/payload-size maintenance failures
- clear the guard after successful maintenance and allow retries when conversation content changes

## Tests
- bun test packages/coding-agent/test/agent-session-auto-compaction-oversized.test.ts
- bun test packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts
- bun --cwd=packages/coding-agent run check

Fixes #1662

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*