### PR TITLE
fix: reuse overflow detector for maintenance guard

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7789,8 +7789,26 @@ export class AgentSession {
 	}
 
 	#isOversizedMaintenanceError(errorMessage: string): boolean {
-		return /context_length_exceeded|exceeds? (the )?context window|maximum context length|payload too large|request entity too large/i.test(
-			errorMessage,
+		return isContextOverflow(
+			{
+				role: "assistant",
+				content: [],
+				api: this.model?.api ?? "anthropic-messages",
+				provider: this.model?.provider ?? "unknown",
+				model: this.model?.id ?? "unknown",
+				stopReason: "error",
+				errorMessage,
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				timestamp: Date.now(),
+			} as AssistantMessage,
+			this.model?.contextWindow,
 		);
 	}
 

--- a/packages/coding-agent/test/agent-session-auto-compaction-oversized.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-oversized.test.ts
@@ -74,7 +74,7 @@ describe("AgentSession oversized auto-maintenance guard", () => {
 		});
 		const compactSpy = vi
 			.spyOn(compactionModule, "compact")
-			.mockRejectedValue(new Error("context_length_exceeded: request exceeds the context window"));
+			.mockRejectedValue(new Error("prompt is too long: 213462 tokens > 200000 maximum"));
 
 		await session.runIdleCompaction();
 		await session.runIdleCompaction();
@@ -84,7 +84,7 @@ describe("AgentSession oversized auto-maintenance guard", () => {
 		expect(compactSpy).toHaveBeenCalledTimes(2);
 		expect(events).toHaveLength(2);
 		expect(events[0]).toMatchObject({
-			errorMessage: expect.stringContaining("context_length_exceeded"),
+			errorMessage: expect.stringContaining("prompt is too long"),
 			willRetry: false,
 		});
 		expect(events[0].skipped).toBeUndefined();
@@ -97,9 +97,7 @@ describe("AgentSession oversized auto-maintenance guard", () => {
 
 	it("allows a new oversized maintenance attempt after the conversation changes", async () => {
 		appendConversation("initial");
-		const compactSpy = vi
-			.spyOn(compactionModule, "compact")
-			.mockRejectedValue(new Error("maximum context length exceeded"));
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockRejectedValue(new Error("request_too_large"));
 
 		await session.runIdleCompaction();
 		await session.runIdleCompaction();


### PR DESCRIPTION
## Summary
- follow up #1664 by using the shared `isContextOverflow(...)` detector for oversized maintenance failure classification
- cover Anthropic `prompt is too long` and `request_too_large` payload overflow messages in the retry guard regression tests

## Tests
- `bun test packages/coding-agent/test/agent-session-auto-compaction-oversized.test.ts`
- `bun test packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts packages/coding-agent/test/agent-session-compaction.test.ts packages/coding-agent/test/agent-session-handoff.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`

Follow-up to #1664 / #1662.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*