### PR TITLE
fix(print-mode): actionable diagnostic + distinct exit code on context overflow

### DIFF
--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -5,7 +5,7 @@
  * - `gjc -p "prompt"` - text output
  * - `gjc --mode json "prompt"` - JSON event stream
  */
-import type { AssistantMessage, ImageContent } from "@gajae-code/ai";
+import { type AssistantMessage, type ImageContent, isContextOverflow } from "@gajae-code/ai";
 import { logger, sanitizeText } from "@gajae-code/utils";
 import type { AgentSession } from "../session/agent-session";
 import { isSilentAbort } from "../session/messages";
@@ -29,6 +29,29 @@ export interface PrintModeOptions {
 	 * finalization/cleanup before the process exits.
 	 */
 	suppressProcessExit?: boolean;
+}
+
+/**
+ * Exit code used when a non-interactive run terminates because the model context
+ * window is exhausted and automatic compaction could not bring the request under
+ * the limit. Distinct from the generic failure code (1) so batch/automation callers
+ * (`gjc -p`, `--mode json`, autonomous workers) can detect context exhaustion
+ * specifically instead of parsing a raw provider error string.
+ */
+export const CONTEXT_OVERFLOW_EXIT_CODE = 2;
+
+/**
+ * Build an actionable stderr diagnostic for a terminal context-overflow error.
+ * The raw provider message is preserved (appended) for debugging, but the leading
+ * guidance explains what happened and what the operator can do — tailored to whether
+ * auto-compaction was even enabled.
+ */
+function formatContextOverflowError(message: AssistantMessage, autoCompactionEnabled: boolean): string {
+	const providerDetail = message.errorMessage ? ` (provider error: ${sanitizeText(message.errorMessage)})` : "";
+	const guidance = autoCompactionEnabled
+		? "Context window exhausted: automatic compaction ran but could not reduce the request below the model's context limit. Reduce the input size (smaller file reads / tool output), raise the compaction threshold, or switch to a larger-context model."
+		: "Context window exhausted and automatic compaction is disabled. Enable it (compaction.enabled=true with a non-off compaction.strategy) so GJC can compact and continue, reduce the input size, or switch to a larger-context model.";
+	return `${guidance}${providerDetail}`;
 }
 
 /**
@@ -88,15 +111,25 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 				(assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") &&
 				!isSilentAbort(assistantMsg.errorMessage)
 			) {
-				const errorLine = sanitizeText(assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`);
+				// Context-overflow is an expected, recoverable-in-principle condition — not an
+				// opaque crash. Auto-compaction has already run inside session.prompt(); if we
+				// still land here the request could not be made to fit. Surface an actionable
+				// diagnostic and a distinct exit code so batch/automation callers can detect
+				// context exhaustion instead of parsing the raw provider error string.
+				const isOverflow =
+					assistantMsg.stopReason === "error" && isContextOverflow(assistantMsg, session.model?.contextWindow);
+				const errorLine = isOverflow
+					? formatContextOverflowError(assistantMsg, session.autoCompactionEnabled)
+					: sanitizeText(assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`);
+				const exitCode = isOverflow ? CONTEXT_OVERFLOW_EXIT_CODE : 1;
 				const flushed = process.stderr.write(`${errorLine}\n`);
 				// When the caller owns finalization (RLM autonomous), return instead of
 				// exiting so its cleanup runs; the caller surfaces a non-zero exit itself.
 				if (!options.suppressProcessExit) {
 					if (flushed) {
-						process.exit(1);
+						process.exit(exitCode);
 					} else {
-						process.stderr.once("drain", () => process.exit(1));
+						process.stderr.once("drain", () => process.exit(exitCode));
 					}
 				}
 			}

--- a/packages/coding-agent/test/silent-abort-print-mode.test.ts
+++ b/packages/coding-agent/test/silent-abort-print-mode.test.ts
@@ -32,9 +32,14 @@ function makeAssistantMessage(overrides: Partial<AssistantMessage> = {}): Assist
 }
 
 /** Minimal mock of AgentSession for print-mode text output path */
-function createMockSession(messages: Message[]): AgentSession {
+function createMockSession(
+	messages: Message[],
+	opts?: { contextWindow?: number; autoCompactionEnabled?: boolean },
+): AgentSession {
 	return {
 		state: { messages },
+		model: opts?.contextWindow !== undefined ? { contextWindow: opts.contextWindow } : undefined,
+		autoCompactionEnabled: opts?.autoCompactionEnabled ?? false,
 		sessionManager: {
 			getHeader: () => undefined,
 		},
@@ -150,5 +155,88 @@ describe("Print-mode last-assistant output regression (#484)", () => {
 
 		const stdoutText = stdoutOutput.join("");
 		expect(stdoutText).toContain("@gajae-code/coding-agent");
+	});
+});
+
+describe("Print-mode context-overflow terminal handling", () => {
+	let exitSpy: ReturnType<typeof vi.spyOn>;
+	let stderrOutput: string[];
+
+	beforeEach(() => {
+		stderrOutput = [];
+		vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+			stderrOutput.push(String(chunk));
+			return true;
+		});
+		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+		vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
+			const last = args[args.length - 1];
+			if (typeof last === "function") last();
+			return true;
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("emits an actionable diagnostic and a distinct exit code on context overflow", async () => {
+		const { runPrintMode, CONTEXT_OVERFLOW_EXIT_CODE } = await import("../src/modes/print-mode");
+
+		// The exact string a Codex/OpenAI-code backend surfaces on context_length_exceeded.
+		const overflowMsg = makeAssistantMessage({
+			stopReason: "error",
+			errorMessage:
+				"Codex error event: Your input exceeds the context window of this model. Please adjust your input and try again. (code=context_length_exceeded)",
+			content: [],
+		});
+
+		const session = createMockSession([overflowMsg], { contextWindow: 272000, autoCompactionEnabled: true });
+		await runPrintMode(session, { mode: "text" });
+
+		const stderrText = stderrOutput.join("");
+		// Actionable guidance replaces the opaque provider crash line.
+		expect(stderrText).toContain("Context window exhausted");
+		expect(stderrText).toContain("larger-context model");
+		// Raw provider detail is preserved for debugging.
+		expect(stderrText).toContain("context_length_exceeded");
+		// Distinct exit code so automation can detect context exhaustion specifically.
+		expect(exitSpy).toHaveBeenCalledWith(CONTEXT_OVERFLOW_EXIT_CODE);
+		expect(exitSpy).not.toHaveBeenCalledWith(1);
+	});
+
+	it("tells the operator to enable auto-compaction when it is disabled", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+
+		const overflowMsg = makeAssistantMessage({
+			stopReason: "error",
+			errorMessage: "prompt is too long: 300000 tokens > 272000 maximum",
+			content: [],
+		});
+
+		const session = createMockSession([overflowMsg], { contextWindow: 272000, autoCompactionEnabled: false });
+		await runPrintMode(session, { mode: "text" });
+
+		const stderrText = stderrOutput.join("");
+		expect(stderrText).toContain("automatic compaction is disabled");
+	});
+
+	it("still exits 1 with the raw message for non-overflow errors", async () => {
+		const { runPrintMode, CONTEXT_OVERFLOW_EXIT_CODE } = await import("../src/modes/print-mode");
+
+		const errorMsg = makeAssistantMessage({
+			stopReason: "error",
+			errorMessage: "Internal server error (status=500)",
+			content: [],
+		});
+
+		const session = createMockSession([errorMsg], { contextWindow: 272000, autoCompactionEnabled: true });
+		await runPrintMode(session, { mode: "text" });
+
+		const stderrText = stderrOutput.join("");
+		expect(stderrText).toContain("Internal server error");
+		expect(stderrText).not.toContain("Context window exhausted");
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(exitSpy).not.toHaveBeenCalledWith(CONTEXT_OVERFLOW_EXIT_CODE);
 	});
 });


### PR DESCRIPTION
## Problem

Non-interactive runs — `gjc -p`, `--mode json`, and autonomous/background workers —
terminate with `process.exit(1)` and a **raw provider error string** when the model
context window fills and auto-compaction cannot reduce the request below the limit.

Observed in the field with the OpenAI-code/Codex backend, where a captured worker's
entire output was:

```
Codex error event: Your input exceeds the context window of this model.
Please adjust your input and try again. (code=context_length_exceeded)
```

For batch/automation (which is exactly what `-p` is for), a context-full condition
should be an **expected, detectable** event — not an opaque crash that callers have to
grep out of stderr.

## Root cause

`runPrintMode` (`packages/coding-agent/src/modes/print-mode.ts`) treats *any* final
assistant message with `stopReason === "error"` identically: it writes `errorMessage`
verbatim to stderr and exits `1`. Context-overflow recovery (detect → auto-compact →
retry) already runs and is awaited inside `session.prompt()` via
`#waitForPostPromptRecovery`, so by the time print mode reaches this branch the overflow
was genuinely unrecoverable by current means — but the terminal handling gives the
operator no actionable signal and no way to distinguish context exhaustion from any
other failure.

## What this changes

In the text-mode terminal-error branch of `runPrintMode`:

- Detect a terminal context-overflow via `isContextOverflow(msg, session.model?.contextWindow)`.
- Emit an **actionable diagnostic** instead of the opaque provider line, tailored to
  whether auto-compaction is enabled:
  - enabled → "compaction ran but could not reduce below the limit; reduce input, raise
    the threshold, or use a larger-context model";
  - disabled → "enable `compaction.enabled` with a non-off `compaction.strategy` so GJC
    can compact and continue".
  The raw provider message is **preserved** (appended as `(provider error: …)`) for
  debugging.
- Exit with a **distinct, documented code**, `CONTEXT_OVERFLOW_EXIT_CODE = 2`, so batch
  callers can branch on context exhaustion instead of parsing stderr.

Non-overflow errors are unchanged (raw message, exit `1`). JSON mode is unaffected (it
streams the error event and returns).

## Tests

Extends `packages/coding-agent/test/silent-abort-print-mode.test.ts` with:
- the exact Codex `context_length_exceeded` string → actionable guidance, raw detail
  preserved, exit code `2` (not `1`);
- auto-compaction-disabled → "enable it" guidance;
- non-overflow error → still exit `1`, no overflow guidance.

### Verification (local)
- `bun test test/silent-abort-print-mode.test.ts` → 6 pass / 0 fail (3 existing + 3 new)
- `tsgo -p tsconfig.json --noEmit` (coding-agent) → clean
- `biome check` on the changed files → clean

## Scope / follow-ups (intentionally not in this PR)

This PR makes the *terminal* behavior clear and machine-detectable. Two deeper,
higher-risk improvements are worth separate PRs and would reduce how often the terminal
state is hit at all:

- **(A) Prevention:** the proactive/threshold compaction estimate is a `chars/4`
  heuristic against the configured `contextWindow` (Codex/GPT-5.x = `272000`) with zero
  output-token reserve (`autoCompactionOutputReserveTokens = 0`). For backends whose real
  tokenizer/effective limit is tighter, threshold compaction under-fires and the provider
  rejects. An effective-input budget / per-provider inflation would compact *before* the
  hard rejection.
- **(C) Robustness:** bound the overflow→compact→retry loop so a retained tail message
  that still exceeds the window produces a single deterministic terminal state rather than
  re-scheduling an identical overflowing turn.

I kept those out here because they involve token-accounting judgments I couldn't validate
against a live Codex backend; happy to follow up if you'd like the direction.
