### PR TITLE
fix(print-mode): actionable diagnostic + distinct exit code on context overflow (text mode)

### DIFF
--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -5,7 +5,7 @@
  * - `gjc -p "prompt"` - text output
  * - `gjc --mode json "prompt"` - JSON event stream
  */
-import type { AssistantMessage, ImageContent } from "@gajae-code/ai";
+import { type AssistantMessage, type ImageContent, isContextOverflow } from "@gajae-code/ai";
 import { logger, sanitizeText } from "@gajae-code/utils";
 import type { AgentSession } from "../session/agent-session";
 import { isSilentAbort } from "../session/messages";
@@ -29,6 +29,33 @@ export interface PrintModeOptions {
 	 * finalization/cleanup before the process exits.
 	 */
 	suppressProcessExit?: boolean;
+}
+
+/**
+ * Exit code used when a non-interactive **text-mode** run (`gjc -p`) terminates
+ * because the model context window is exhausted and automatic compaction could
+ * not bring the request under the limit. Distinct from the generic failure code
+ * (1) so text-mode callers can detect context exhaustion specifically instead of
+ * parsing the raw provider error string.
+ *
+ * Scope: text-mode final-response path only. JSON mode (`--mode json`) streams
+ * events from the subscription and does not run this terminal-error branch, so
+ * it is intentionally NOT covered by this exit code.
+ */
+export const CONTEXT_OVERFLOW_EXIT_CODE = 2;
+
+/**
+ * Build an actionable stderr diagnostic for a terminal context-overflow error in
+ * text mode. The raw provider message is preserved (appended) for debugging, but
+ * the leading guidance explains what happened and what the operator can do —
+ * tailored to whether auto-compaction was even enabled.
+ */
+function formatContextOverflowError(message: AssistantMessage, autoCompactionEnabled: boolean): string {
+	const providerDetail = message.errorMessage ? ` (provider error: ${sanitizeText(message.errorMessage)})` : "";
+	const guidance = autoCompactionEnabled
+		? "Context window exhausted: automatic compaction ran but could not reduce the request below the model's context limit. Reduce the input size (smaller file reads / tool output), raise the compaction threshold, or switch to a larger-context model."
+		: "Context window exhausted and automatic compaction is disabled. Enable it (compaction.enabled=true with a non-off compaction.strategy) so GJC can compact and continue, reduce the input size, or switch to a larger-context model.";
+	return `${guidance}${providerDetail}`;
 }
 
 /**
@@ -88,15 +115,27 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 				(assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") &&
 				!isSilentAbort(assistantMsg.errorMessage)
 			) {
-				const errorLine = sanitizeText(assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`);
+				// Context-overflow is an expected, recoverable-in-principle condition — not
+				// an opaque crash. Auto-compaction has already run inside session.prompt();
+				// if we still land here the request could not be made to fit. In this
+				// text-mode final-response path, surface an actionable diagnostic and a
+				// distinct exit code so text-mode (`gjc -p`) callers can detect context
+				// exhaustion instead of parsing the raw provider error string. (JSON mode
+				// does not reach this branch and is intentionally out of scope.)
+				const isOverflow =
+					assistantMsg.stopReason === "error" && isContextOverflow(assistantMsg, session.model?.contextWindow);
+				const errorLine = isOverflow
+					? formatContextOverflowError(assistantMsg, session.autoCompactionEnabled)
+					: sanitizeText(assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`);
+				const exitCode = isOverflow ? CONTEXT_OVERFLOW_EXIT_CODE : 1;
 				const flushed = process.stderr.write(`${errorLine}\n`);
 				// When the caller owns finalization (RLM autonomous), return instead of
 				// exiting so its cleanup runs; the caller surfaces a non-zero exit itself.
 				if (!options.suppressProcessExit) {
 					if (flushed) {
-						process.exit(1);
+						process.exit(exitCode);
 					} else {
-						process.stderr.once("drain", () => process.exit(1));
+						process.stderr.once("drain", () => process.exit(exitCode));
 					}
 				}
 			}

--- a/packages/coding-agent/test/silent-abort-print-mode.test.ts
+++ b/packages/coding-agent/test/silent-abort-print-mode.test.ts
@@ -32,9 +32,14 @@ function makeAssistantMessage(overrides: Partial<AssistantMessage> = {}): Assist
 }
 
 /** Minimal mock of AgentSession for print-mode text output path */
-function createMockSession(messages: Message[]): AgentSession {
+function createMockSession(
+	messages: Message[],
+	opts?: { contextWindow?: number; autoCompactionEnabled?: boolean },
+): AgentSession {
 	return {
 		state: { messages },
+		model: opts?.contextWindow !== undefined ? { contextWindow: opts.contextWindow } : undefined,
+		autoCompactionEnabled: opts?.autoCompactionEnabled ?? false,
 		sessionManager: {
 			getHeader: () => undefined,
 		},
@@ -150,5 +155,115 @@ describe("Print-mode last-assistant output regression (#484)", () => {
 
 		const stdoutText = stdoutOutput.join("");
 		expect(stdoutText).toContain("@gajae-code/coding-agent");
+	});
+});
+
+/**
+ * Contract: in TEXT mode only, a terminal context-overflow assistant message is
+ * surfaced with an actionable diagnostic and a distinct exit code
+ * (CONTEXT_OVERFLOW_EXIT_CODE) so `gjc -p` callers can detect context exhaustion.
+ * JSON mode is intentionally out of scope (it streams events and never runs this
+ * terminal branch) — the last test documents that boundary.
+ */
+describe("Print-mode context-overflow terminal handling (text mode)", () => {
+	let exitSpy: ReturnType<typeof vi.spyOn>;
+	let stderrOutput: string[];
+
+	beforeEach(() => {
+		stderrOutput = [];
+		vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+			stderrOutput.push(String(chunk));
+			return true;
+		});
+		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+		vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
+			const last = args[args.length - 1];
+			if (typeof last === "function") last();
+			return true;
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("emits an actionable diagnostic and a distinct exit code on context overflow", async () => {
+		const { runPrintMode, CONTEXT_OVERFLOW_EXIT_CODE } = await import("../src/modes/print-mode");
+
+		// The exact string a Codex/OpenAI-code backend surfaces on context_length_exceeded.
+		const overflowMsg = makeAssistantMessage({
+			stopReason: "error",
+			errorMessage:
+				"Codex error event: Your input exceeds the context window of this model. Please adjust your input and try again. (code=context_length_exceeded)",
+			content: [],
+		});
+
+		const session = createMockSession([overflowMsg], { contextWindow: 272000, autoCompactionEnabled: true });
+		await runPrintMode(session, { mode: "text" });
+
+		const stderrText = stderrOutput.join("");
+		// Actionable guidance replaces the opaque provider crash line.
+		expect(stderrText).toContain("Context window exhausted");
+		expect(stderrText).toContain("larger-context model");
+		// Raw provider detail is preserved for debugging.
+		expect(stderrText).toContain("context_length_exceeded");
+		// Distinct exit code so text-mode automation can detect context exhaustion.
+		expect(exitSpy).toHaveBeenCalledWith(CONTEXT_OVERFLOW_EXIT_CODE);
+		expect(exitSpy).not.toHaveBeenCalledWith(1);
+	});
+
+	it("tells the operator to enable auto-compaction when it is disabled", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+
+		const overflowMsg = makeAssistantMessage({
+			stopReason: "error",
+			errorMessage: "prompt is too long: 300000 tokens > 272000 maximum",
+			content: [],
+		});
+
+		const session = createMockSession([overflowMsg], { contextWindow: 272000, autoCompactionEnabled: false });
+		await runPrintMode(session, { mode: "text" });
+
+		const stderrText = stderrOutput.join("");
+		expect(stderrText).toContain("automatic compaction is disabled");
+	});
+
+	it("still exits 1 with the raw message for non-overflow errors", async () => {
+		const { runPrintMode, CONTEXT_OVERFLOW_EXIT_CODE } = await import("../src/modes/print-mode");
+
+		const errorMsg = makeAssistantMessage({
+			stopReason: "error",
+			errorMessage: "Internal server error (status=500)",
+			content: [],
+		});
+
+		const session = createMockSession([errorMsg], { contextWindow: 272000, autoCompactionEnabled: true });
+		await runPrintMode(session, { mode: "text" });
+
+		const stderrText = stderrOutput.join("");
+		expect(stderrText).toContain("Internal server error");
+		expect(stderrText).not.toContain("Context window exhausted");
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(exitSpy).not.toHaveBeenCalledWith(CONTEXT_OVERFLOW_EXIT_CODE);
+	});
+
+	it("scope boundary: JSON mode does not apply the context-overflow exit code", async () => {
+		const { runPrintMode, CONTEXT_OVERFLOW_EXIT_CODE } = await import("../src/modes/print-mode");
+
+		// Same terminal overflow message, but JSON mode streams events and never runs
+		// the text-mode terminal-error branch, so the exit code is intentionally not applied.
+		const overflowMsg = makeAssistantMessage({
+			stopReason: "error",
+			errorMessage:
+				"Codex error event: Your input exceeds the context window of this model. (code=context_length_exceeded)",
+			content: [],
+		});
+
+		const session = createMockSession([overflowMsg], { contextWindow: 272000, autoCompactionEnabled: true });
+		await runPrintMode(session, { mode: "json" });
+
+		const stderrText = stderrOutput.join("");
+		expect(stderrText).not.toContain("Context window exhausted");
+		expect(exitSpy).not.toHaveBeenCalledWith(CONTEXT_OVERFLOW_EXIT_CODE);
 	});
 });


### PR DESCRIPTION
Revision of #1668 (closed with requested changes). This narrows the contract to
**text mode only**, addressing the reviewer's blocker, and targets `dev`.

## Problem (evidence-backed)

Non-interactive `gjc -p` runs terminate with `process.exit(1)` and a **raw provider
error string** when the model context window fills and auto-compaction cannot reduce
the request below the limit. Captured in the field on the OpenAI-code/Codex backend —
a worker's entire log was:

```
Codex error event: Your input exceeds the context window of this model.
Please adjust your input and try again. (code=context_length_exceeded)
```

For `-p`/automation, a context-full condition should be an expected, **detectable**
event, not an opaque crash callers have to grep out of stderr.

## What changed (text-mode final-response path)

In `runPrintMode`'s `mode === "text"` terminal-error branch:

- Detect terminal context-overflow via `isContextOverflow(msg, session.model?.contextWindow)`.
- Emit an **actionable diagnostic** instead of the opaque provider line, tailored to
  whether auto-compaction is enabled (enabled → "reduce input / raise threshold / use
  a larger-context model"; disabled → "enable `compaction.enabled` with a non-off
  strategy"). The raw provider message is **preserved** (`(provider error: …)`).
- Exit with a **distinct, documented code** `CONTEXT_OVERFLOW_EXIT_CODE = 2` so
  text-mode callers can branch on context exhaustion instead of parsing stderr.

Non-overflow errors are unchanged (raw message, exit `1`).

## Addressing the review feedback (#1668)

> the patch's contract/comment explicitly says batch/automation callers including
> `--mode json` can detect context exhaustion … JSON mode only streams events … does
> not get the new behavior.

Correct catch. This revision **narrows the contract to text mode only**:

- All comments and the `CONTEXT_OVERFLOW_EXIT_CODE` doc now state the scope is the
  text-mode final-response path, and that JSON mode (`--mode json`) is intentionally
  **not** covered (it streams events and never runs this terminal branch).
- Added a **scope-boundary test** asserting JSON mode does **not** apply the overflow
  exit code, so the boundary is explicit and locked.
- No `--mode json` support is claimed anywhere.

JSON-mode exit-code coverage can follow as a separate change if desired (it changes
JSON consumers' exit semantics more broadly, so it's kept out of this focused patch).

## Tests

`packages/coding-agent/test/silent-abort-print-mode.test.ts` (extends the existing
print-mode regressions):
- text-mode overflow (exact Codex `context_length_exceeded` string) → actionable
  guidance, raw provider detail preserved, exit code `2` (not `1`);
- auto-compaction-disabled → "enable it" guidance;
- non-overflow error → still exit `1`, no overflow guidance;
- **scope boundary**: JSON mode → overflow exit code not applied.

### Local validation (native addon built)
- `bun test packages/coding-agent/test/silent-abort-print-mode.test.ts` → **7 pass / 0 fail**
- `bun --cwd=packages/coding-agent run check:types` → clean
- `biome check` on the changed files → clean

## Scope / follow-ups (intentionally not here)

This makes the terminal (unrecovered) overflow clear and machine-detectable. The deeper
work — making `-p` reliably compact-and-continue *to completion* on strict backends
(bounded/escalating recovery so the retry doesn't re-overflow, and capping the
compaction-summary input below the model limit) — touches shared recovery logic and
warrants validation against a live Codex backend, so it's proposed as a separate PR.
