### PR TITLE
fix(compaction): bound summarization request input so gjc -p overflow recovery can compact-and-continue

### DIFF
--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -679,6 +679,49 @@ export interface SummaryOptions {
 	preferWebsockets?: boolean;
 }
 
+/**
+ * Cap the serialized conversation fed to a summarization request so the request
+ * itself fits inside the model's context window.
+ *
+ * Without this, summarizing a near-full context serializes (nearly) the entire
+ * history back into a single summary request; on strict backends (e.g.
+ * OpenAI-code/Codex `context_length_exceeded`) that request itself overflows and
+ * throws, so context-overflow recovery cannot produce a summary and the agent
+ * fails to compact-and-continue — a non-interactive `gjc -p` run then terminates
+ * on the very overflow the recovery was meant to absorb.
+ *
+ * The budget reserves the summary's own output tokens plus prompt/system/template
+ * overhead, and applies a conservative safety factor because the chars/4 heuristic
+ * undercounts dense or CJK text (the reason the original overflow was missed).
+ * Truncation keeps the head (origin/goals) and the tail (most recent state) and
+ * elides the middle; it is a last resort that only triggers when the input would
+ * otherwise not fit.
+ */
+export function boundConversationTextForSummary(
+	conversationText: string,
+	model: Model,
+	outputMaxTokens: number,
+): string {
+	const contextWindow = model.contextWindow;
+	if (!Number.isFinite(contextWindow) || contextWindow <= 0) return conversationText;
+
+	const OVERHEAD_TOKENS = 4096;
+	const SAFETY_FACTOR = 0.6;
+	const inputBudgetTokens = Math.floor(
+		(contextWindow - Math.max(0, outputMaxTokens) - OVERHEAD_TOKENS) * SAFETY_FACTOR,
+	);
+	if (inputBudgetTokens <= 0) return conversationText;
+	if (estimateTextTokensHeuristic(conversationText) <= inputBudgetTokens) return conversationText;
+
+	const budgetChars = inputBudgetTokens * HEURISTIC_BYTES_PER_TOKEN;
+	const headChars = Math.floor(budgetChars * 0.35);
+	const tailChars = Math.max(0, budgetChars - headChars);
+	const head = conversationText.slice(0, headChars);
+	const tail = tailChars > 0 ? conversationText.slice(conversationText.length - tailChars) : "";
+	const elided = conversationText.length - head.length - tail.length;
+	return `${head}\n\n[... ${elided} characters of older conversation elided so this summarization request fits within the model context window ...]\n\n${tail}`;
+}
+
 export async function generateSummary(
 	currentMessages: AgentMessage[],
 	model: Model,
@@ -703,7 +746,7 @@ export async function generateSummary(
 	// Serialize conversation to text so model doesn't try to continue it
 	// Convert to LLM messages first (handles custom app messages when caller provides a transformer).
 	const llmMessages = (options?.convertToLlm ?? convertToLlm)(currentMessages);
-	const conversationText = serializeConversation(llmMessages);
+	const conversationText = boundConversationTextForSummary(serializeConversation(llmMessages), model, maxTokens);
 
 	// Build the prompt with conversation wrapped in tags
 	let promptText = `<conversation>\n${conversationText}\n</conversation>\n\n`;
@@ -859,7 +902,7 @@ async function generateShortSummary(
 ): Promise<string> {
 	const maxTokens = Math.min(512, Math.floor(0.2 * reserveTokens));
 	const llmMessages = (options?.convertToLlm ?? convertToLlm)(recentMessages);
-	const conversationText = serializeConversation(llmMessages);
+	const conversationText = boundConversationTextForSummary(serializeConversation(llmMessages), model, maxTokens);
 
 	let promptText = `<conversation>\n${conversationText}\n</conversation>\n\n`;
 	if (historySummary) {
@@ -1235,7 +1278,7 @@ async function generateTurnPrefixSummary(
 	const maxTokens = Math.floor(0.5 * reserveTokens); // Smaller budget for turn prefix
 
 	const llmMessages = (options?.convertToLlm ?? convertToLlm)(messages);
-	const conversationText = serializeConversation(llmMessages);
+	const conversationText = boundConversationTextForSummary(serializeConversation(llmMessages), model, maxTokens);
 	const promptText = `<conversation>\n${conversationText}\n</conversation>\n\n${TURN_PREFIX_SUMMARIZATION_PROMPT}`;
 	const summarizationMessages = [
 		{

--- a/packages/agent/test/compaction-summary-input-bound.test.ts
+++ b/packages/agent/test/compaction-summary-input-bound.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression: the compaction summary request must not itself overflow the model
+ * context window.
+ *
+ * When a near-full context is compacted, `generateSummary` serializes (nearly) the
+ * entire history into a single summary request. On strict backends (e.g.
+ * OpenAI-code/Codex `context_length_exceeded`) that request itself overflowed and
+ * threw, so context-overflow recovery could not produce a summary and a
+ * non-interactive `gjc -p` run terminated on the very overflow it was meant to
+ * absorb. `boundConversationTextForSummary` caps the serialized input so the
+ * summary request fits.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AssistantMessage, Context, Model, Usage } from "@gajae-code/ai";
+import * as ai from "@gajae-code/ai";
+import { boundConversationTextForSummary, generateSummary } from "../src/compaction/compaction";
+import type { AgentMessage } from "../src/types";
+
+const MODEL: Model = {
+	id: "mock-model",
+	name: "mock-model",
+	api: "mock",
+	provider: "mock",
+	baseUrl: "mock://",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 20_000,
+	maxTokens: 4_096,
+};
+
+const HEURISTIC_BYTES_PER_TOKEN = 4;
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function makeUsage(): Usage {
+	return {
+		input: 10,
+		output: 5,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 15,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function makeAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "mock",
+		provider: "mock",
+		model: "mock-model",
+		usage: makeUsage(),
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+/** Spy on completeSimple, capturing the request Context (messages) it receives. */
+function spyCompleteSimple(): Context[] {
+	const captured: Context[] = [];
+	vi.spyOn(ai, "completeSimple").mockImplementation(async (_model, ctx) => {
+		captured.push(ctx as Context);
+		return makeAssistantMessage("summary text");
+	});
+	return captured;
+}
+
+describe("boundConversationTextForSummary", () => {
+	it("returns short input unchanged", () => {
+		const text = "a short conversation";
+		expect(boundConversationTextForSummary(text, MODEL, 1_000)).toBe(text);
+	});
+
+	it("truncates input that would exceed the model context window", () => {
+		const outputMaxTokens = 1_600;
+		const huge = "x".repeat(400_000); // ~100k heuristic tokens, far above any 20k-window budget
+		const bounded = boundConversationTextForSummary(huge, MODEL, outputMaxTokens);
+
+		expect(bounded.length).toBeLessThan(huge.length);
+		expect(bounded).toContain("elided so this summarization request fits");
+
+		// The bounded text must fit the conservative input budget in tokens.
+		const overhead = 4096;
+		const safety = 0.6;
+		const budgetTokens = Math.floor((MODEL.contextWindow - outputMaxTokens - overhead) * safety);
+		// heuristic tokens = chars / 4; the elision marker adds a small constant.
+		const markerSlackChars = 200;
+		expect(Math.ceil((bounded.length - markerSlackChars) / HEURISTIC_BYTES_PER_TOKEN)).toBeLessThanOrEqual(
+			budgetTokens,
+		);
+	});
+
+	it("does not bound when the context window is unknown", () => {
+		const huge = "y".repeat(400_000);
+		const unknownWindow: Model = { ...MODEL, contextWindow: 0 };
+		expect(boundConversationTextForSummary(huge, unknownWindow, 1_000)).toBe(huge);
+	});
+});
+
+describe("generateSummary request stays within the context window", () => {
+	it("does not send an oversized summarization request for a near-full context", async () => {
+		const captured = spyCompleteSimple();
+
+		// A large history that, serialized verbatim, would blow past the 20k window.
+		const messages: AgentMessage[] = [];
+		for (let i = 0; i < 100; i++) {
+			messages.push({ role: "user", content: "u".repeat(3_000), timestamp: Date.now() + i });
+			messages.push(makeAssistantMessage("a".repeat(3_000)));
+		}
+
+		const summary = await generateSummary(messages, MODEL, 2_000, "test-key");
+		expect(summary).toBe("summary text");
+
+		// Exactly one summary request was issued, and its input was bounded.
+		expect(captured).toHaveLength(1);
+		const req = captured[0];
+		const promptText = req.messages
+			.map(m => {
+				const content = (m as { content?: unknown }).content;
+				if (typeof content === "string") return content;
+				if (!Array.isArray(content)) return "";
+				return content
+					.filter((c): c is { type: "text"; text: string } => (c as { type?: string })?.type === "text")
+					.map(c => c.text)
+					.join("");
+			})
+			.join("");
+
+		// The raw history is ~600k chars; the request must be a small fraction of that.
+		expect(promptText).toContain("elided so this summarization request fits");
+		const outputMaxTokens = Math.floor(0.8 * 2_000);
+		const budgetTokens = Math.floor((MODEL.contextWindow - outputMaxTokens - 4096) * 0.6);
+		// Prompt = bounded conversation + template/tags overhead; keep a generous slack for the template.
+		const templateSlackTokens = 2_000;
+		expect(Math.ceil(promptText.length / HEURISTIC_BYTES_PER_TOKEN)).toBeLessThanOrEqual(
+			budgetTokens + templateSlackTokens,
+		);
+	});
+});


### PR DESCRIPTION
Follow-up to #1669 (merged). #1669 made a terminal context-overflow in `gjc -p`
clear and detectable; **this PR fixes the underlying cause** so overflow recovery
actually compacts and continues instead of terminating.

## Root cause (evidence-backed)

Real failure: a non-interactive `gjc -p` worker on the OpenAI-code/Codex backend
died mid-run with its entire log being:

```
Codex error event: Your input exceeds the context window of this model.
Please adjust your input and try again. (code=context_length_exceeded)
```

The runtime *does* trigger overflow recovery (auto-compaction + continue), but
compaction fails: when the context is near-full, `generateSummary` serializes
**(nearly) the entire history** into a single summary request, and on a strict
backend that summary request **itself** exceeds the window and throws. The session
then records the oversized-maintenance signature and **skips** further compaction to
avoid an infinite loop (`agent-session.ts`: *"previous unchanged maintenance request
exceeded the model context window; change or reduce the conversation before retrying
maintenance"*). So recovery gives up and, in headless `-p`, the process terminates on
the overflow it was meant to absorb.

This is on the critical path even for Codex: OpenAI remote compaction only populates
provider-side `preserveData` (best-effort, caught on failure) — the summary text is
**always** produced locally by `generateSummary` (`compact()` calls it
unconditionally after the remote attempt).

## Fix

Add `boundConversationTextForSummary(conversationText, model, outputMaxTokens)` and
apply it at all three summarization call sites (`generateSummary`,
`generateShortSummary`, `generateTurnPrefixSummary`). It caps the serialized
conversation to a conservative input budget:

```
budget = floor((contextWindow - summaryOutputTokens - overhead) * 0.6)
```

- Reserves the summary's own output tokens + prompt/system/template overhead.
- The `0.6` safety factor guards against the `chars/4` heuristic undercounting
  dense/CJK text — the exact reason the original overflow slipped past the
  proactive check.
- On exceed, truncation keeps the head (origin/goals) and tail (most recent state)
  and elides the middle with a marker. It only triggers when the input would
  otherwise not fit, so normal compaction is unchanged.
- Unknown context window (`0`) → no bound (unchanged behavior).

Net effect: the compaction summary request now fits, so overflow recovery produces a
summary and the agent compacts-and-continues — headless `-p` runs no longer terminate
on a recoverable overflow.

## Tests

`packages/agent/test/compaction-summary-input-bound.test.ts`:
- `boundConversationTextForSummary`: short input unchanged; oversized input truncated
  under the token budget with the elision marker; unknown window not bounded.
- integration: spy `completeSimple` and assert `generateSummary` no longer issues an
  oversized request for a near-full context (raw ~600k-char history → bounded request).

### Local validation
- `bun test packages/agent/test/compaction-summary-input-bound.test.ts` → 4 pass
- full compaction suite (`compaction-transport`, `remote-compaction`,
  `compaction-no-native-tokenizer`, `compaction-telemetry`, `compaction-estimate-cache`,
  `emergency-compaction`, `run-summary` + this file) → **57 pass / 0 fail**
- `bun --cwd=packages/agent run check:types` → clean
- `biome check` on the changed files → clean

## Validation caveat

Exercised via a mock backend that enforces the context window. I could not validate
end-to-end compact-and-continue against a live OpenAI-code/Codex backend, so a single
real-backend run (reproduce the near-full `gjc -p` overflow, confirm it now compacts
and finishes) is recommended before relying on it in production. The bound is
conservative by design to fail safe (smaller summary request) rather than risk another
overflow.
