### PR TITLE
feat(coding-agent): add workflow intent reports

### DIFF
--- a/packages/coding-agent/src/workflow/workflow-intent-diff.ts
+++ b/packages/coding-agent/src/workflow/workflow-intent-diff.ts
@@ -1,3 +1,9 @@
+import {
+	buildWorkflowIntentReport,
+	type WorkflowClaimsLedger,
+	type WorkflowConsensusReport,
+} from "./workflow-intent-report";
+
 export const WORKFLOW_INTENT_DIFF_CUSTOM_TYPE = "workflow-intent-diff";
 
 export type WorkflowIntentRoute = "direct" | "deep-interview" | "ralplan" | "ultragoal" | "team";
@@ -16,6 +22,8 @@ export interface WorkflowIntentDiff {
 		readonly status: RootCausePhaseStatus;
 		readonly triggers: readonly string[];
 	};
+	readonly claimsLedger: WorkflowClaimsLedger;
+	readonly consensusReport: WorkflowConsensusReport;
 	readonly promptPreview: string;
 }
 
@@ -182,6 +190,19 @@ export function buildWorkflowIntentDiff(text: string): WorkflowIntentDiff | null
 	const rootCauseTriggers = collectRootCauseTriggers(text);
 	const rootCauseActive = rootCauseTriggers.length > 0;
 	const direct = route.route === "direct";
+	const rootCauseStatus: RootCausePhaseStatus = rootCauseActive ? "active" : "inactive";
+	const rootCausePhase = {
+		status: rootCauseStatus,
+		triggers: rootCauseTriggers,
+	};
+	const report = buildWorkflowIntentReport({
+		route: route.route,
+		reason: route.reason,
+		direct,
+		recommendedInvocation: route.recommendedInvocation,
+		triggers: route.triggers,
+		rootCausePhase,
+	});
 
 	return {
 		version: 1,
@@ -190,10 +211,9 @@ export function buildWorkflowIntentDiff(text: string): WorkflowIntentDiff | null
 		directTracking: direct ? "custom-entry-only" : "not-direct",
 		...(direct ? {} : { recommendedSkill: route.route, recommendedInvocation: route.recommendedInvocation }),
 		triggers: route.triggers,
-		rootCausePhase: {
-			status: rootCauseActive ? "active" : "inactive",
-			triggers: rootCauseTriggers,
-		},
+		rootCausePhase,
+		claimsLedger: report.claimsLedger,
+		consensusReport: report.consensusReport,
 		promptPreview,
 	};
 }

--- a/packages/coding-agent/src/workflow/workflow-intent-report.ts
+++ b/packages/coding-agent/src/workflow/workflow-intent-report.ts
@@ -1,0 +1,135 @@
+import type { RootCausePhaseStatus, WorkflowIntentRoute } from "./workflow-intent-diff";
+
+export type WorkflowConfidence = "high";
+export type WorkflowClaimStatus = "confirmed";
+export type WorkflowEscalationGateStatus = "required" | "not-required";
+export type WorkflowSignalObserver = "intent-router" | "root-cause-schema" | "escalation-gate";
+
+export interface WorkflowClaim {
+	readonly id: "workflow-route" | "root-cause-phase" | "escalation-gate";
+	readonly statement: string;
+	readonly status: WorkflowClaimStatus;
+	readonly confidence: WorkflowConfidence;
+	readonly evidence: readonly string[];
+}
+
+export interface WorkflowClaimsLedger {
+	readonly version: 1;
+	readonly claims: readonly WorkflowClaim[];
+}
+
+export interface WorkflowObserverSignal {
+	readonly observer: WorkflowSignalObserver;
+	readonly conclusion: string;
+	readonly evidence: readonly string[];
+}
+
+export interface WorkflowConsensusReport {
+	readonly version: 1;
+	readonly route: WorkflowIntentRoute;
+	readonly confidence: WorkflowConfidence;
+	readonly summary: string;
+	readonly observerSignals: readonly WorkflowObserverSignal[];
+	readonly escalationGate: {
+		readonly status: WorkflowEscalationGateStatus;
+		readonly reason: string;
+	};
+}
+
+export interface WorkflowIntentReport {
+	readonly claimsLedger: WorkflowClaimsLedger;
+	readonly consensusReport: WorkflowConsensusReport;
+}
+
+export interface WorkflowIntentReportInput {
+	readonly route: WorkflowIntentRoute;
+	readonly reason: string;
+	readonly direct: boolean;
+	readonly recommendedInvocation?: string;
+	readonly triggers: readonly string[];
+	readonly rootCausePhase: {
+		readonly status: RootCausePhaseStatus;
+		readonly triggers: readonly string[];
+	};
+}
+
+function triggerEvidence(triggers: readonly string[]): readonly string[] {
+	return triggers.map(trigger => `trigger: ${trigger}`);
+}
+
+function rootCauseEvidence(input: WorkflowIntentReportInput): readonly string[] {
+	if (input.rootCausePhase.status === "inactive") return ["root-cause: inactive"];
+	return ["root-cause: active", ...input.rootCausePhase.triggers.map(trigger => `root-cause-trigger: ${trigger}`)];
+}
+
+function escalationEvidence(input: WorkflowIntentReportInput): readonly string[] {
+	if (input.direct) return ["escalation: not-required", `reason: ${input.reason}`];
+	return ["escalation: required", `invocation: ${input.recommendedInvocation ?? input.route}`];
+}
+
+function escalationGate(input: WorkflowIntentReportInput): WorkflowConsensusReport["escalationGate"] {
+	if (input.direct) {
+		return {
+			status: "not-required",
+			reason: input.reason,
+		};
+	}
+	return {
+		status: "required",
+		reason: input.recommendedInvocation ?? input.route,
+	};
+}
+
+function consensusSummary(input: WorkflowIntentReportInput): string {
+	if (input.direct) return "Consensus: direct implementation with CustomEntry-only workflow traceability.";
+	return `Consensus: route through ${input.recommendedInvocation ?? input.route} because ${input.reason}.`;
+}
+
+export function buildWorkflowIntentReport(input: WorkflowIntentReportInput): WorkflowIntentReport {
+	const confidence: WorkflowConfidence = "high";
+	const gate = escalationGate(input);
+	const routeEvidence = [`route: ${input.route}`, `reason: ${input.reason}`, ...triggerEvidence(input.triggers)];
+	const causeEvidence = rootCauseEvidence(input);
+	const gateEvidence = escalationEvidence(input);
+
+	return {
+		claimsLedger: {
+			version: 1,
+			claims: [
+				{
+					id: "workflow-route",
+					statement: `Prompt should follow the ${input.route} workflow route.`,
+					status: "confirmed",
+					confidence,
+					evidence: routeEvidence,
+				},
+				{
+					id: "root-cause-phase",
+					statement: `Root-cause phase is ${input.rootCausePhase.status}.`,
+					status: "confirmed",
+					confidence,
+					evidence: causeEvidence,
+				},
+				{
+					id: "escalation-gate",
+					statement: `Escalation gate is ${gate.status}.`,
+					status: "confirmed",
+					confidence,
+					evidence: gateEvidence,
+				},
+			],
+		},
+		consensusReport: {
+			version: 1,
+			route: input.route,
+			confidence,
+			summary: consensusSummary(input),
+			observerSignals: [
+				{ observer: "intent-router", conclusion: input.route, evidence: routeEvidence },
+				{ observer: "root-cause-schema", conclusion: input.rootCausePhase.status, evidence: causeEvidence },
+				{ observer: "escalation-gate", conclusion: gate.status, evidence: gateEvidence },
+			],
+			escalationGate: gate,
+		},
+	};
+}

--- a/packages/coding-agent/test/agent-session-workflow-intent-diff.test.ts
+++ b/packages/coding-agent/test/agent-session-workflow-intent-diff.test.ts
@@ -8,18 +8,10 @@ import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { type CustomEntry, SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import type { WorkflowIntentDiff } from "@gajae-code/coding-agent/workflow/workflow-intent-diff";
 import { TempDir } from "@gajae-code/utils";
 
-type WorkflowIntentDiffEntry = CustomEntry<{
-	readonly route: string;
-	readonly recommendedSkill?: string;
-	readonly recommendedInvocation?: string;
-	readonly directTracking: string;
-	readonly rootCausePhase: {
-		readonly status: string;
-		readonly triggers: readonly string[];
-	};
-}>;
+type WorkflowIntentDiffEntry = CustomEntry<WorkflowIntentDiff>;
 
 describe("AgentSession workflow intent-diff tracking", () => {
 	let tempDir: TempDir;
@@ -77,6 +69,43 @@ describe("AgentSession workflow intent-diff tracking", () => {
 			directTracking: "custom-entry-only",
 			rootCausePhase: { status: "inactive", triggers: [] },
 		});
+		expect(entry?.data?.claimsLedger.claims).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "workflow-route",
+					evidence: expect.arrayContaining(["route: direct", "trigger: low-risk direct"]),
+				}),
+				expect.objectContaining({
+					id: "root-cause-phase",
+					evidence: expect.arrayContaining(["root-cause: inactive"]),
+				}),
+			]),
+		);
+		expect(entry?.data?.consensusReport).toMatchObject({
+			version: 1,
+			route: "direct",
+			confidence: "high",
+			escalationGate: {
+				status: "not-required",
+				reason: "clear low-risk prompt stays on direct implementation path",
+			},
+		});
+		expect(entry?.data?.consensusReport.observerSignals).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					observer: "intent-router",
+					conclusion: "direct",
+				}),
+				expect.objectContaining({
+					observer: "root-cause-schema",
+					conclusion: "inactive",
+				}),
+				expect.objectContaining({
+					observer: "escalation-gate",
+					conclusion: "not-required",
+				}),
+			]),
+		);
 		expect(session.agent.state.messages).not.toEqual(
 			expect.arrayContaining([expect.objectContaining({ customType: "workflow-intent-diff" })]),
 		);
@@ -93,7 +122,23 @@ describe("AgentSession workflow intent-diff tracking", () => {
 			recommendedInvocation: "/skill:ralplan --deliberate",
 			directTracking: "not-direct",
 			rootCausePhase: { status: "active" },
+			consensusReport: {
+				route: "ralplan",
+				confidence: "high",
+				escalationGate: {
+					status: "required",
+					reason: "/skill:ralplan --deliberate",
+				},
+			},
 		});
+		expect(combinedRisk?.data?.claimsLedger.claims).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "escalation-gate",
+					evidence: expect.arrayContaining(["escalation: required", "invocation: /skill:ralplan --deliberate"]),
+				}),
+			]),
+		);
 		expect(combinedRisk?.data?.rootCausePhase.triggers).toEqual(
 			expect.arrayContaining(["regression", "high-risk transition"]),
 		);


### PR DESCRIPTION
## Summary
- Add a deterministic report builder for `workflow-intent-diff` CustomEntries.
- Store `claimsLedger` and `consensusReport` payloads for accepted prompts.
- Keep the payload out of LLM context and preserve synthetic/rejected-busy prompt guards.
- Extend AgentSession workflow-intent tests for direct and escalated routes.

## Continuity
- Builds on the workflow-intent routing contract already present on `dev`.
- This PR adds the reporting layer only: route policy stays the same, and direct low-risk prompts still use CustomEntry-only tracking.

## Verification
- `bun test packages/coding-agent/test/agent-session-workflow-intent-diff.test.ts`
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`
- `bun run --cwd packages/coding-agent check`
