### PR TITLE
feat(coding-agent): add workflow intent report consumer

### DIFF
--- a/packages/coding-agent/src/workflow/workflow-intent-diff.ts
+++ b/packages/coding-agent/src/workflow/workflow-intent-diff.ts
@@ -5,8 +5,11 @@ import {
 } from "./workflow-intent-report";
 
 export const WORKFLOW_INTENT_DIFF_CUSTOM_TYPE = "workflow-intent-diff";
+export const WORKFLOW_INTENT_ROUTES = ["direct", "deep-interview", "ralplan", "ultragoal", "team"] as const;
+export const WORKFLOW_ESCALATION_ROUTES = ["deep-interview", "ralplan", "ultragoal", "team"] as const;
 
-export type WorkflowIntentRoute = "direct" | "deep-interview" | "ralplan" | "ultragoal" | "team";
+export type WorkflowIntentRoute = (typeof WORKFLOW_INTENT_ROUTES)[number];
+export type WorkflowEscalationRoute = (typeof WORKFLOW_ESCALATION_ROUTES)[number];
 export type DirectTrackingMode = "custom-entry-only" | "not-direct";
 export type RootCausePhaseStatus = "active" | "inactive";
 
@@ -15,7 +18,7 @@ export interface WorkflowIntentDiff {
 	readonly route: WorkflowIntentRoute;
 	readonly reason: string;
 	readonly directTracking: DirectTrackingMode;
-	readonly recommendedSkill?: Exclude<WorkflowIntentRoute, "direct">;
+	readonly recommendedSkill?: WorkflowEscalationRoute;
 	readonly recommendedInvocation?: string;
 	readonly triggers: readonly string[];
 	readonly rootCausePhase: {

--- a/packages/coding-agent/src/workflow/workflow-intent-report-consumer.ts
+++ b/packages/coding-agent/src/workflow/workflow-intent-report-consumer.ts
@@ -1,0 +1,221 @@
+import type { SessionEntry } from "../session/session-manager";
+import {
+	WORKFLOW_INTENT_DIFF_CUSTOM_TYPE,
+	WORKFLOW_INTENT_ROUTES,
+	type WorkflowIntentDiff,
+	type WorkflowIntentRoute,
+} from "./workflow-intent-diff";
+import type { WorkflowSignalObserver } from "./workflow-intent-report";
+import { parseWorkflowIntentDiffPayload } from "./workflow-intent-report-schema";
+
+export type WorkflowConsumerConfidence = "none" | "low" | "medium" | "high";
+
+export interface WorkflowRouteCounts {
+	readonly direct: number;
+	readonly "deep-interview": number;
+	readonly ralplan: number;
+	readonly ultragoal: number;
+	readonly team: number;
+}
+
+export interface WorkflowIntentReportEntry {
+	readonly entryId: string;
+	readonly timestamp: string;
+	readonly intent: WorkflowIntentDiff;
+}
+
+export interface WorkflowIntentReportTotals {
+	readonly total: number;
+	readonly byRoute: WorkflowRouteCounts;
+	readonly escalationRequired: number;
+	readonly rootCauseActive: number;
+}
+
+export interface WorkflowIntentReportCollection {
+	readonly entries: readonly WorkflowIntentReportEntry[];
+	readonly latest: WorkflowIntentReportEntry | undefined;
+	readonly totals: WorkflowIntentReportTotals;
+}
+
+export interface WorkflowObserverSignalSummary {
+	readonly observer: WorkflowSignalObserver;
+	readonly conclusion: string;
+	readonly count: number;
+}
+
+export interface WorkflowConsensusSummary {
+	readonly total: number;
+	readonly dominantRoute: WorkflowIntentRoute | undefined;
+	readonly confidence: WorkflowConsumerConfidence;
+	readonly escalationGate: {
+		readonly required: boolean;
+		readonly count: number;
+		readonly latestReason: string | undefined;
+	};
+	readonly rootCausePhase: {
+		readonly active: boolean;
+		readonly count: number;
+		readonly triggers: readonly string[];
+	};
+	readonly observerSignals: readonly WorkflowObserverSignalSummary[];
+}
+
+function emptyRouteCounts(): WorkflowRouteCounts {
+	return {
+		direct: 0,
+		"deep-interview": 0,
+		ralplan: 0,
+		ultragoal: 0,
+		team: 0,
+	};
+}
+
+function parseWorkflowIntentDiffEntry(entry: SessionEntry): WorkflowIntentReportEntry | undefined {
+	if (entry.type !== "custom" || entry.customType !== WORKFLOW_INTENT_DIFF_CUSTOM_TYPE) return undefined;
+	const intent = parseWorkflowIntentDiffPayload(entry.data);
+	if (!intent) return undefined;
+	return { entryId: entry.id, timestamp: entry.timestamp, intent };
+}
+
+function incrementRoute(counts: WorkflowRouteCounts, route: WorkflowIntentRoute): WorkflowRouteCounts {
+	switch (route) {
+		case "direct":
+			return { ...counts, direct: counts.direct + 1 };
+		case "deep-interview":
+			return { ...counts, "deep-interview": counts["deep-interview"] + 1 };
+		case "ralplan":
+			return { ...counts, ralplan: counts.ralplan + 1 };
+		case "ultragoal":
+			return { ...counts, ultragoal: counts.ultragoal + 1 };
+		case "team":
+			return { ...counts, team: counts.team + 1 };
+	}
+}
+
+function routeCount(counts: WorkflowRouteCounts, route: WorkflowIntentRoute): number {
+	switch (route) {
+		case "direct":
+			return counts.direct;
+		case "deep-interview":
+			return counts["deep-interview"];
+		case "ralplan":
+			return counts.ralplan;
+		case "ultragoal":
+			return counts.ultragoal;
+		case "team":
+			return counts.team;
+	}
+}
+
+export function collectWorkflowIntentReports(entries: readonly SessionEntry[]): WorkflowIntentReportCollection {
+	const reports: WorkflowIntentReportEntry[] = [];
+	let byRoute = emptyRouteCounts();
+	let escalationRequired = 0;
+	let rootCauseActive = 0;
+
+	for (const entry of entries) {
+		const report = parseWorkflowIntentDiffEntry(entry);
+		if (!report) continue;
+		reports.push(report);
+		byRoute = incrementRoute(byRoute, report.intent.route);
+		if (report.intent.consensusReport.escalationGate.status === "required") escalationRequired += 1;
+		if (report.intent.rootCausePhase.status === "active") rootCauseActive += 1;
+	}
+
+	return {
+		entries: reports,
+		latest: reports[reports.length - 1],
+		totals: {
+			total: reports.length,
+			byRoute,
+			escalationRequired,
+			rootCauseActive,
+		},
+	};
+}
+
+function dominantRouteFor(counts: WorkflowRouteCounts, total: number): WorkflowIntentRoute | undefined {
+	if (total === 0) return undefined;
+	let dominant: WorkflowIntentRoute | undefined;
+	let dominantCount = 0;
+	let tied = false;
+
+	for (const route of WORKFLOW_INTENT_ROUTES) {
+		const count = routeCount(counts, route);
+		if (count > dominantCount) {
+			dominant = route;
+			dominantCount = count;
+			tied = false;
+			continue;
+		}
+		if (count === dominantCount && count > 0) tied = true;
+	}
+
+	return tied ? undefined : dominant;
+}
+
+function confidenceFor(
+	total: number,
+	dominantCount: number,
+	dominantRoute: WorkflowIntentRoute | undefined,
+): WorkflowConsumerConfidence {
+	if (total === 0) return "none";
+	if (!dominantRoute) return "low";
+	const ratio = dominantCount / total;
+	if (ratio === 1) return "high";
+	if (ratio >= 0.5) return "medium";
+	return "low";
+}
+
+export function summarizeWorkflowConsensus(intents: readonly WorkflowIntentDiff[]): WorkflowConsensusSummary {
+	let byRoute = emptyRouteCounts();
+	let escalationCount = 0;
+	let latestEscalationReason: string | undefined;
+	let activeRootCauseCount = 0;
+	const rootCauseTriggers: string[] = [];
+	const observerSignalCounts = new Map<string, WorkflowObserverSignalSummary>();
+
+	for (const intent of intents) {
+		byRoute = incrementRoute(byRoute, intent.route);
+		if (intent.consensusReport.escalationGate.status === "required") {
+			escalationCount += 1;
+			latestEscalationReason = intent.consensusReport.escalationGate.reason;
+		}
+		if (intent.rootCausePhase.status === "active") {
+			activeRootCauseCount += 1;
+			for (const trigger of intent.rootCausePhase.triggers) {
+				if (!rootCauseTriggers.includes(trigger)) rootCauseTriggers.push(trigger);
+			}
+		}
+		for (const signal of intent.consensusReport.observerSignals) {
+			const key = `${signal.observer}\u0000${signal.conclusion}`;
+			const existing = observerSignalCounts.get(key);
+			observerSignalCounts.set(key, {
+				observer: signal.observer,
+				conclusion: signal.conclusion,
+				count: existing ? existing.count + 1 : 1,
+			});
+		}
+	}
+
+	const total = intents.length;
+	const dominantRoute = dominantRouteFor(byRoute, total);
+	const dominantCount = dominantRoute ? routeCount(byRoute, dominantRoute) : 0;
+
+	return {
+		total,
+		dominantRoute,
+		confidence: confidenceFor(total, dominantCount, dominantRoute),
+		escalationGate: {
+			required: escalationCount > 0,
+			count: escalationCount,
+			latestReason: latestEscalationReason,
+		},
+		rootCausePhase: {
+			active: activeRootCauseCount > 0,
+			count: activeRootCauseCount,
+			triggers: rootCauseTriggers,
+		},
+		observerSignals: Array.from(observerSignalCounts.values()),
+	};
+}

--- a/packages/coding-agent/src/workflow/workflow-intent-report-schema.ts
+++ b/packages/coding-agent/src/workflow/workflow-intent-report-schema.ts
@@ -1,0 +1,129 @@
+import * as z from "zod/v4";
+import { WORKFLOW_ESCALATION_ROUTES, WORKFLOW_INTENT_ROUTES, type WorkflowIntentDiff } from "./workflow-intent-diff";
+
+const WORKFLOW_CLAIM_IDS = ["workflow-route", "root-cause-phase", "escalation-gate"] as const;
+const WORKFLOW_OBSERVERS = ["intent-router", "root-cause-schema", "escalation-gate"] as const;
+
+const WorkflowIntentRouteSchema = z.enum(WORKFLOW_INTENT_ROUTES);
+const WorkflowEscalationRouteSchema = z.enum(WORKFLOW_ESCALATION_ROUTES);
+const WorkflowRootCausePhaseSchema = z.object({
+	status: z.enum(["active", "inactive"]),
+	triggers: z.array(z.string()),
+});
+const WorkflowClaimsLedgerSchema = z.object({
+	version: z.literal(1),
+	claims: z.array(
+		z.object({
+			id: z.enum(WORKFLOW_CLAIM_IDS),
+			statement: z.string(),
+			status: z.literal("confirmed"),
+			confidence: z.literal("high"),
+			evidence: z.array(z.string()),
+		}),
+	),
+});
+const WorkflowConsensusReportSchema = z.object({
+	version: z.literal(1),
+	route: WorkflowIntentRouteSchema,
+	confidence: z.literal("high"),
+	summary: z.string(),
+	observerSignals: z.array(
+		z.object({
+			observer: z.enum(WORKFLOW_OBSERVERS),
+			conclusion: z.string(),
+			evidence: z.array(z.string()),
+		}),
+	),
+	escalationGate: z.object({
+		status: z.enum(["required", "not-required"]),
+		reason: z.string(),
+	}),
+});
+
+const WorkflowIntentDiffSchema = z
+	.object({
+		version: z.literal(1),
+		route: WorkflowIntentRouteSchema,
+		reason: z.string(),
+		directTracking: z.enum(["custom-entry-only", "not-direct"]),
+		recommendedSkill: WorkflowEscalationRouteSchema.optional(),
+		recommendedInvocation: z.string().optional(),
+		triggers: z.array(z.string()),
+		rootCausePhase: WorkflowRootCausePhaseSchema,
+		claimsLedger: WorkflowClaimsLedgerSchema,
+		consensusReport: WorkflowConsensusReportSchema,
+		promptPreview: z.string(),
+	})
+	.superRefine((intent, ctx) => {
+		const direct = intent.route === "direct";
+		const expectedTracking = direct ? "custom-entry-only" : "not-direct";
+		const expectedGateStatus = direct ? "not-required" : "required";
+
+		if (intent.directTracking !== expectedTracking) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["directTracking"],
+				message: `directTracking must be ${expectedTracking} for route ${intent.route}`,
+			});
+		}
+		if (intent.consensusReport.route !== intent.route) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["consensusReport", "route"],
+				message: "consensus route must match the top-level workflow route",
+			});
+		}
+		if (intent.consensusReport.escalationGate.status !== expectedGateStatus) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["consensusReport", "escalationGate", "status"],
+				message: `escalation gate must be ${expectedGateStatus} for route ${intent.route}`,
+			});
+		}
+		if (direct) {
+			if (intent.recommendedSkill !== undefined || intent.recommendedInvocation !== undefined) {
+				ctx.addIssue({
+					code: "custom",
+					path: ["recommendedSkill"],
+					message: "direct workflow reports must not carry escalation recommendations",
+				});
+			}
+		} else {
+			if (intent.recommendedSkill !== intent.route || intent.recommendedInvocation === undefined) {
+				ctx.addIssue({
+					code: "custom",
+					path: ["recommendedSkill"],
+					message: "escalated workflow reports must carry matching recommendations",
+				});
+			}
+		}
+
+		for (const signal of intent.consensusReport.observerSignals) {
+			if (signal.observer === "intent-router" && signal.conclusion !== intent.route) {
+				ctx.addIssue({
+					code: "custom",
+					path: ["consensusReport", "observerSignals"],
+					message: "intent-router signal must match the top-level workflow route",
+				});
+			}
+			if (signal.observer === "root-cause-schema" && signal.conclusion !== intent.rootCausePhase.status) {
+				ctx.addIssue({
+					code: "custom",
+					path: ["consensusReport", "observerSignals"],
+					message: "root-cause-schema signal must match the root-cause phase status",
+				});
+			}
+			if (signal.observer === "escalation-gate" && signal.conclusion !== expectedGateStatus) {
+				ctx.addIssue({
+					code: "custom",
+					path: ["consensusReport", "observerSignals"],
+					message: "escalation-gate signal must match the escalation gate status",
+				});
+			}
+		}
+	});
+
+export function parseWorkflowIntentDiffPayload(value: unknown): WorkflowIntentDiff | undefined {
+	const result = WorkflowIntentDiffSchema.safeParse(value);
+	return result.success ? result.data : undefined;
+}

--- a/packages/coding-agent/test/workflow-intent-report-consumer.test.ts
+++ b/packages/coding-agent/test/workflow-intent-report-consumer.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "bun:test";
+import type { CustomEntry, SessionEntry } from "@gajae-code/coding-agent/session/session-manager";
+import {
+	buildWorkflowIntentDiff,
+	WORKFLOW_INTENT_DIFF_CUSTOM_TYPE,
+	type WorkflowIntentDiff,
+} from "@gajae-code/coding-agent/workflow/workflow-intent-diff";
+import {
+	collectWorkflowIntentReports,
+	summarizeWorkflowConsensus,
+} from "@gajae-code/coding-agent/workflow/workflow-intent-report-consumer";
+
+function mustBuildIntent(prompt: string): WorkflowIntentDiff {
+	const intent = buildWorkflowIntentDiff(prompt);
+	if (!intent) throw new Error(`Expected workflow intent for prompt: ${prompt}`);
+	return intent;
+}
+
+function customEntry(id: string, data: unknown, customType = WORKFLOW_INTENT_DIFF_CUSTOM_TYPE): CustomEntry<unknown> {
+	return {
+		type: "custom",
+		id,
+		parentId: null,
+		timestamp: `2026-07-06T00:00:0${id.length}.000Z`,
+		customType,
+		data,
+	};
+}
+
+function workflowEntry(id: string, prompt: string): CustomEntry<unknown> {
+	return customEntry(id, mustBuildIntent(prompt));
+}
+
+describe("workflow intent report consumer", () => {
+	it("collects workflow intent CustomEntries and summarizes consensus signals", () => {
+		const directIntent = mustBuildIntent("fix the typo in the workflow settings page");
+		const directIntentWithExtras = {
+			...directIntent,
+			ignoredExtra: true,
+			consensusReport: {
+				...directIntent.consensusReport,
+				ignoredNestedExtra: true,
+			},
+		};
+		const entries: readonly SessionEntry[] = [
+			customEntry("direct-1", directIntentWithExtras),
+			customEntry("ignored-custom", { route: "ralplan" }, "other-extension"),
+			workflowEntry("ralplan-1", "plan the architecture sequence before implementation"),
+			workflowEntry("ralplan-2", "plan the auth migration sequence and regression risk"),
+		];
+
+		const collection = collectWorkflowIntentReports(entries);
+		expect(collection.entries.map(entry => entry.entryId)).toEqual(["direct-1", "ralplan-1", "ralplan-2"]);
+		expect(collection.latest?.entryId).toBe("ralplan-2");
+		const [firstEntry] = collection.entries;
+		if (!firstEntry) throw new Error("Expected a sanitized first workflow intent report");
+		expect("ignoredExtra" in firstEntry.intent).toBe(false);
+		expect("ignoredNestedExtra" in firstEntry.intent.consensusReport).toBe(false);
+		expect(collection.totals).toEqual({
+			total: 3,
+			byRoute: {
+				direct: 1,
+				"deep-interview": 0,
+				ralplan: 2,
+				ultragoal: 0,
+				team: 0,
+			},
+			escalationRequired: 2,
+			rootCauseActive: 1,
+		});
+
+		const summary = summarizeWorkflowConsensus(collection.entries.map(entry => entry.intent));
+		expect(summary).toEqual({
+			total: 3,
+			dominantRoute: "ralplan",
+			confidence: "medium",
+			escalationGate: {
+				required: true,
+				count: 2,
+				latestReason: "/skill:ralplan --deliberate",
+			},
+			rootCausePhase: {
+				active: true,
+				count: 1,
+				triggers: ["regression", "high-risk transition"],
+			},
+			observerSignals: expect.arrayContaining([
+				{ observer: "intent-router", conclusion: "ralplan", count: 2 },
+				{ observer: "escalation-gate", conclusion: "required", count: 2 },
+				{ observer: "root-cause-schema", conclusion: "active", count: 1 },
+			]),
+		});
+	});
+
+	it("ignores non-workflow and malformed entries without throwing", () => {
+		const directIntent = mustBuildIntent("fix a direct typo");
+		const contradictoryIntent = {
+			...directIntent,
+			consensusReport: {
+				...directIntent.consensusReport,
+				route: "team",
+				escalationGate: { status: "required", reason: "/skill:team" },
+				observerSignals: directIntent.consensusReport.observerSignals.map(signal => {
+					if (signal.observer === "intent-router") return { ...signal, conclusion: "team" };
+					if (signal.observer === "escalation-gate") return { ...signal, conclusion: "required" };
+					return signal;
+				}),
+			},
+		};
+		const nonCustom: SessionEntry = {
+			type: "label",
+			id: "label-1",
+			parentId: null,
+			timestamp: "2026-07-06T00:01:00.000Z",
+			targetId: "direct-1",
+			label: "reviewed",
+		};
+		const entries: readonly SessionEntry[] = [
+			nonCustom,
+			customEntry("wrong-custom-type", directIntent, "other-extension"),
+			customEntry("missing-report-shape", { version: 1, route: "direct" }),
+			customEntry("contradictory-report", contradictoryIntent),
+			customEntry("wrong-route", {
+				version: 1,
+				route: "unknown",
+				rootCausePhase: { status: "inactive", triggers: [] },
+				claimsLedger: { version: 1, claims: [] },
+				consensusReport: {
+					version: 1,
+					observerSignals: [],
+					escalationGate: { status: "not-required", reason: "invalid" },
+				},
+			}),
+		];
+
+		const collection = collectWorkflowIntentReports(entries);
+		expect(collection).toEqual({
+			entries: [],
+			latest: undefined,
+			totals: {
+				total: 0,
+				byRoute: {
+					direct: 0,
+					"deep-interview": 0,
+					ralplan: 0,
+					ultragoal: 0,
+					team: 0,
+				},
+				escalationRequired: 0,
+				rootCauseActive: 0,
+			},
+		});
+		expect(summarizeWorkflowConsensus([])).toEqual({
+			total: 0,
+			dominantRoute: undefined,
+			confidence: "none",
+			escalationGate: {
+				required: false,
+				count: 0,
+				latestReason: undefined,
+			},
+			rootCausePhase: {
+				active: false,
+				count: 0,
+				triggers: [],
+			},
+			observerSignals: [],
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This PR is the final follow-up in the workflow-intent routing series.

Sequence:
- #1671 added workflow intent reports to session history: direct intent-diff tracking, claims ledger, consensus report, escalation gate, and root-cause phase metadata.
- This PR adds the internal consumer boundary for those reports so later UI, diagnostics, review tooling, and automated summaries can read them without re-parsing raw session entries or trusting malformed payloads.

Note: #1673 was created from an earlier follow-up branch, but the GitHub PR object stayed pinned to the previous head SHA after the branch was updated. This clean branch is based directly on current `dev` and contains only the consumer commit on top of #1671/#1672.

## Problem

#1671 made the agent emit useful workflow-intent evidence, but downstream readers still had no stable contract for using it:

- Consumers would need to scan arbitrary `SessionEntry` values and hand-roll checks for `workflow-intent-diff` entries.
- Raw `CustomEntry.data` is an untrusted boundary, so malformed or contradictory reports could leak into summaries.
- Claims-ledger and consensus signals existed, but there was no reusable way to aggregate them into a current workflow view.
- Escalation-gate and root-cause state were persisted, but not exposed as machine-readable rollups.

## Solution

- Adds a Zod-backed parser for persisted workflow-intent report payloads.
- Centralizes route constants so producer and consumer share the same route vocabulary.
- Adds `collectWorkflowIntentReports(entries)` to extract valid reports, preserve chronological order, expose the latest report, and compute totals by route/escalation/root-cause state.
- Adds `summarizeWorkflowConsensus(intents)` to produce a compact machine-readable consensus summary: dominant route, confidence, escalation gate status, root-cause triggers, unique triggers, and observer-signal counts.
- Rejects semantically contradictory reports at the boundary, not just structurally invalid ones.

## Verification

- `bun test packages/coding-agent/test/workflow-intent-report-consumer.test.ts packages/coding-agent/test/agent-session-workflow-intent-diff.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun x biome check packages/coding-agent/src/workflow/workflow-intent-diff.ts packages/coding-agent/src/workflow/workflow-intent-report-consumer.ts packages/coding-agent/src/workflow/workflow-intent-report-schema.ts packages/coding-agent/test/workflow-intent-report-consumer.test.ts --no-errors-on-unmatched`
- `git diff --check`
