### PR TITLE
Harden workflow state, team runtime, MCP trust boundaries, and robogjc APIs

### DIFF
--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -15,6 +15,8 @@ export interface MCPServer {
 	name: string;
 	/** Whether this server is enabled (default: true) */
 	enabled?: boolean;
+	/** Whether this server should autoload at startup (default: true) */
+	autoload?: boolean;
 	/** Connection timeout in milliseconds */
 	timeout?: number;
 	/** Command to run (for stdio transport) */

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -12,13 +12,17 @@ import { launchDefaultTmuxIfNeeded } from "../gjc-runtime/launch-tmux";
 import { prepareLaunchWorktree } from "../gjc-runtime/launch-worktree";
 import {
 	GJC_COORDINATOR_SESSION_ID_ENV,
-	GJC_COORDINATOR_SESSION_STATE_FILE_ENV,
+	resolveCoordinatorRuntimeStateFile,
 } from "../gjc-runtime/session-state-sidecar";
 import { runRootCommand } from "../main";
 import { prepareAcpTerminalAuthArgs } from "../modes/acp/terminal-auth";
 
 async function persistCoordinatorLaunchFailure(error: unknown, cwd: string): Promise<void> {
-	const stateFile = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim();
+	const stateFile = resolveCoordinatorRuntimeStateFile({
+		sessionId: process.env.GJC_SESSION_ID?.trim() || process.env[GJC_COORDINATOR_SESSION_ID_ENV]?.trim() || "launch",
+		cwd,
+		sessionFile: null,
+	});
 	if (!stateFile) return;
 	const message = error instanceof Error ? error.message : String(error);
 	const code = message.split(":", 1)[0] || "launch_failed";

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -118,7 +118,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 		const data = tryParseJson<{ mcpServers?: Record<string, unknown> }>(content);
 		if (!data?.mcpServers) return result;
 
-		const expanded = expandEnvVarsDeep(data.mcpServers);
+		const expanded = level === "project" ? data.mcpServers : expandEnvVarsDeep(data.mcpServers);
 		for (const [serverName, config] of Object.entries(expanded)) {
 			const serverConfig = config as Record<string, unknown>;
 
@@ -165,9 +165,21 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 				timeout = undefined;
 			}
 
+			// Validate autoload: boolean only, warn on other types
+			let autoload: boolean | undefined;
+			if (serverConfig.autoload === undefined || serverConfig.autoload === null) {
+				autoload = undefined;
+			} else if (typeof serverConfig.autoload === "boolean") {
+				autoload = serverConfig.autoload;
+			} else {
+				logger.warn(`MCP server "${serverName}": invalid autoload type ${typeof serverConfig.autoload}, ignoring`);
+				autoload = undefined;
+			}
+
 			result.push({
 				name: serverName,
 				enabled,
+				autoload,
 				timeout,
 				command: serverConfig.command as string | undefined,
 				args: serverConfig.args as string[] | undefined,

--- a/packages/coding-agent/src/discovery/claude.ts
+++ b/packages/coding-agent/src/discovery/claude.ts
@@ -23,7 +23,6 @@ import {
 	calculateDepth,
 	createSourceMeta,
 	discoverExtensionModulePaths,
-	expandEnvVarsDeep,
 	getExtensionNameFromPath,
 	loadFilesFromDir,
 	scanSkillsFromDir,
@@ -53,7 +52,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 		const json = tryParseJson<{ mcpServers?: Record<string, unknown> }>(content);
 		if (!json?.mcpServers) return [];
 
-		const mcpServers = expandEnvVarsDeep(json.mcpServers);
+		const mcpServers = json.mcpServers;
 		return Object.entries(mcpServers).map(([name, config]) => {
 			const serverConfig = config as Record<string, unknown>;
 			return {

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -25,6 +25,7 @@ interface MCPConfigFile {
 		string,
 		{
 			enabled?: boolean;
+			autoload?: boolean;
 			timeout?: number;
 			command?: string;
 			args?: string[];
@@ -82,9 +83,19 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 				}
 			}
 
+			let autoload: boolean | undefined;
+			if (serverConfig.autoload !== undefined) {
+				if (typeof serverConfig.autoload === "boolean") {
+					autoload = serverConfig.autoload;
+				} else {
+					logger.warn("MCP server has invalid 'autoload' value, ignoring", { name, value: serverConfig.autoload });
+				}
+			}
+
 			const server: MCPServer = {
 				name,
 				enabled,
+				autoload,
 				timeout,
 				command: serverConfig.command,
 				args: serverConfig.args,
@@ -98,15 +109,18 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 				_source: source,
 			};
 
-			// Expand environment variables
-			if (server.command) server.command = expandEnvVarsDeep(server.command);
-			if (server.args) server.args = expandEnvVarsDeep(server.args);
-			if (server.env) server.env = expandEnvVarsDeep(server.env);
-			if (server.cwd) server.cwd = expandEnvVarsDeep(server.cwd);
-			if (server.url) server.url = expandEnvVarsDeep(server.url);
-			if (server.headers) server.headers = expandEnvVarsDeep(server.headers);
-			if (server.auth) server.auth = expandEnvVarsDeep(server.auth);
-			if (server.oauth) server.oauth = expandEnvVarsDeep(server.oauth);
+			if (source.level !== "project") {
+				// Project MCP configs are untrusted input. Preserve ${VAR} literally so
+				// manager/transport source-trust gates can prevent host-secret flow.
+				if (server.command) server.command = expandEnvVarsDeep(server.command);
+				if (server.args) server.args = expandEnvVarsDeep(server.args);
+				if (server.env) server.env = expandEnvVarsDeep(server.env);
+				if (server.cwd) server.cwd = expandEnvVarsDeep(server.cwd);
+				if (server.url) server.url = expandEnvVarsDeep(server.url);
+				if (server.headers) server.headers = expandEnvVarsDeep(server.headers);
+				if (server.auth) server.auth = expandEnvVarsDeep(server.auth);
+				if (server.oauth) server.oauth = expandEnvVarsDeep(server.oauth);
+			}
 			servers.push(server);
 		}
 	}

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -627,7 +627,25 @@ export class ExtensionRunner {
 
 			for (const handler of handlers) {
 				try {
-					const handlerResult = await handler(event, ctx);
+					const handlerResult = await Promise.race([
+						Promise.resolve(handler(event, ctx)),
+						Bun.sleep(extensionHandlerTimeoutMs).then(() => EXTENSION_HANDLER_TIMEOUT),
+					]);
+
+					if (handlerResult === EXTENSION_HANDLER_TIMEOUT) {
+						const error = `handler timed out after ${extensionHandlerTimeoutMs}ms`;
+						logger.warn("Extension handler timed out", {
+							extensionPath: ext.path,
+							event: "tool_call",
+							timeoutMs: extensionHandlerTimeoutMs,
+						});
+						this.emitError({
+							extensionPath: ext.path,
+							event: "tool_call",
+							error,
+						});
+						return { block: true, reason: `Extension ${ext.path} timed out handling tool_call.` };
+					}
 
 					if (handlerResult) {
 						result = handlerResult as ToolCallEventResult;

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -81,6 +81,7 @@ const VALUE_FLAGS = new Set([
 	"--stage",
 	"--stage_n",
 	"--artifact",
+	"--artifact-env",
 	"--run-id",
 	"--session-id",
 	"--architect",
@@ -92,6 +93,8 @@ const VALUE_FLAGS = new Set([
 	"--fallback-stage-n",
 	"--fallback-receipt-path",
 ]);
+
+const ARTIFACT_ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 function flagValue(args: readonly string[], flag: string): string | undefined {
 	const index = args.indexOf(flag);
@@ -408,7 +411,31 @@ async function resolveArtifactArgs(args: readonly string[], cwd: string): Promis
 
 	const stageN = parseStageN(flagValue(args, "--stage_n"));
 
-	const rawArtifact = flagValue(args, "--artifact");
+	const rawArtifactEnvFlagPresent = hasFlag(args, "--artifact-env");
+	const rawArtifactEnv = flagValue(args, "--artifact-env")?.trim();
+	if (rawArtifactEnvFlagPresent && !rawArtifactEnv) {
+		throw new RalplanCommandError(2, "--artifact-env is required for ralplan --write when the flag is present");
+	}
+	if (rawArtifactEnv !== undefined && !ARTIFACT_ENV_NAME_RE.test(rawArtifactEnv)) {
+		throw new RalplanCommandError(2, `invalid --artifact-env: ${rawArtifactEnv}`);
+	}
+
+	let rawArtifact = flagValue(args, "--artifact");
+	let artifactFromEnv = false;
+	if ((rawArtifact === undefined || rawArtifact === "") && rawArtifactEnv === undefined) {
+		throw new RalplanCommandError(2, "--artifact is required for ralplan --write");
+	}
+	if (rawArtifact !== undefined && rawArtifact !== "" && rawArtifactEnv !== undefined) {
+		throw new RalplanCommandError(2, "Use either --artifact or --artifact-env for ralplan --write, not both.");
+	}
+	if (rawArtifactEnv !== undefined) {
+		const value = process.env[rawArtifactEnv];
+		if (value === undefined) {
+			throw new RalplanCommandError(2, `environment variable ${rawArtifactEnv} from --artifact-env is not set`);
+		}
+		rawArtifact = value;
+		artifactFromEnv = true;
+	}
 	if (rawArtifact === undefined || rawArtifact === "") {
 		throw new RalplanCommandError(2, "--artifact is required for ralplan --write");
 	}
@@ -430,7 +457,7 @@ async function resolveArtifactArgs(args: readonly string[], cwd: string): Promis
 	const runId = explicitRunId || (await readActiveRunId(cwd, sessionId)) || sessionIdRaw || defaultRunId();
 	assertSafePathComponent(runId, "run-id");
 
-	const artifact = await resolveArtifactContent(rawArtifact, cwd);
+	const artifact = artifactFromEnv ? rawArtifact : await resolveArtifactContent(rawArtifact, cwd);
 	return { stage: stage as RalplanStage, stageN, runId, artifact, sessionId, json: hasFlag(args, "--json") };
 }
 

--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AssistantMessage } from "@gajae-code/ai";
 import { logger } from "@gajae-code/utils";
+import { sessionRuntimeDir } from "./session-layout";
 
 export const GJC_COORDINATOR_SESSION_STATE_FILE_ENV = "GJC_COORDINATOR_SESSION_STATE_FILE";
 export const GJC_COORDINATOR_SESSION_ID_ENV = "GJC_COORDINATOR_SESSION_ID";
@@ -45,6 +46,26 @@ function sameResolvedPath(left: string, right: string): boolean {
 	return path.resolve(left) === path.resolve(right);
 }
 
+function isWithinOrEqualPath(root: string, candidate: string): boolean {
+	const relative = path.relative(root, candidate);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export function resolveCoordinatorRuntimeStateFile(context: RuntimeStateContext): string | null {
+	const stateFile = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim();
+	if (!stateFile) return null;
+	const runtimeRoot = path.resolve(sessionRuntimeDir(context.cwd, context.sessionId));
+	const resolved = path.resolve(stateFile);
+	if (!isWithinOrEqualPath(runtimeRoot, resolved)) {
+		logger.warn("Ignoring coordinator runtime state file outside session runtime root", {
+			stateFile: resolved,
+			runtimeRoot,
+		});
+		return null;
+	}
+	return resolved;
+}
+
 export async function readTerminalRuntimeStateMarker(input: {
 	stateFile?: string | null;
 	sessionId?: string | null;
@@ -65,15 +86,17 @@ export async function readTerminalRuntimeStateMarker(input: {
 		};
 	}
 	if (payload.session_id !== sessionId) return { terminal: false, reason: "session_id_mismatch" };
-	if (input.cwd && typeof payload.cwd === "string" && !sameResolvedPath(payload.cwd, input.cwd)) {
-		return { terminal: false, reason: "cwd_mismatch" };
+	if (input.cwd) {
+		if (typeof payload.cwd !== "string") return { terminal: false, reason: "cwd_mismatch" };
+		if (!sameResolvedPath(payload.cwd, input.cwd)) {
+			return { terminal: false, reason: "cwd_mismatch" };
+		}
 	}
-	if (
-		input.sessionFile &&
-		typeof payload.session_file === "string" &&
-		!sameResolvedPath(payload.session_file, input.sessionFile)
-	) {
-		return { terminal: false, reason: "session_file_mismatch" };
+	if (input.sessionFile) {
+		if (typeof payload.session_file !== "string") return { terminal: false, reason: "session_file_mismatch" };
+		if (!sameResolvedPath(payload.session_file, input.sessionFile)) {
+			return { terminal: false, reason: "session_file_mismatch" };
+		}
 	}
 	if (payload.state === "completed" || payload.state === "errored") return { terminal: true, state: payload.state };
 	return { terminal: false, reason: "non_terminal_state" };
@@ -131,7 +154,7 @@ export async function persistCoordinatorRuntimeStateFromEvent(
 	event: RuntimeStateEvent,
 	context: RuntimeStateContext,
 ): Promise<void> {
-	const stateFile = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim();
+	const stateFile = resolveCoordinatorRuntimeStateFile(context);
 	if (!stateFile) return;
 	const state = stateForEvent(event);
 	if (!state) return;

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -18,7 +18,7 @@ import {
 	auditPath as layoutAuditPath,
 	transactionJournalPath as layoutTransactionJournalPath,
 } from "./session-layout";
-import { RequiredOnWriteEnvelopeSchema } from "./state-schema";
+import { type RequiredOnWriteEnvelope, RequiredOnWriteEnvelopeSchema } from "./state-schema";
 
 /**
  * Sole sanctioned project `.gjc/**` writer module (gate G1).
@@ -207,16 +207,105 @@ function cwdForOptions(options?: StateWriterOptions): string {
 	return path.resolve(options?.cwd ?? process.cwd());
 }
 
+function isWithinOrEqualPath(root: string, candidate: string): boolean {
+	const relative = path.relative(root, candidate);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
 function resolveGjcTarget(targetPath: string, cwd = process.cwd()): string {
 	if (!targetPath.trim()) throw new Error("targetPath is required");
 	const projectRoot = path.resolve(cwd);
 	const gjcRoot = path.join(projectRoot, ".gjc");
 	const resolved = path.resolve(projectRoot, targetPath);
-	const relative = path.relative(gjcRoot, resolved);
-	if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+	if (!isWithinOrEqualPath(gjcRoot, resolved)) {
 		throw new Error(`target path must be within project .gjc/**: ${targetPath}`);
 	}
 	return resolved;
+}
+
+function gjcRootFromResolvedTarget(filePath: string): string {
+	const resolved = path.resolve(filePath);
+	const parsed = path.parse(resolved);
+	const segments = path.relative(parsed.root, resolved).split(path.sep).filter(Boolean);
+	const gjcIndex = segments.lastIndexOf(".gjc");
+	if (gjcIndex < 0) {
+		throw new Error(`resolved target path must include project .gjc/**: ${filePath}`);
+	}
+	return path.join(parsed.root, ...segments.slice(0, gjcIndex + 1));
+}
+
+async function lstatIfPresent(filePath: string): Promise<Stats | undefined> {
+	try {
+		return await fs.lstat(filePath);
+	} catch (error) {
+		if (isErrno(error, "ENOENT")) return undefined;
+		throw error;
+	}
+}
+
+async function ensureExistingDirectoryWithoutSymlink(dirPath: string): Promise<void> {
+	let stat = await lstatIfPresent(dirPath);
+	if (!stat) {
+		try {
+			await fs.mkdir(dirPath, { mode: 0o700 });
+		} catch (error) {
+			if (!isErrno(error, "EEXIST")) throw error;
+		}
+		stat = await fs.lstat(dirPath);
+	}
+	assertDirectoryStatWithoutSymlink(dirPath, stat);
+}
+
+function assertDirectoryStatWithoutSymlink(dirPath: string, stat: Stats): void {
+	if (stat.isSymbolicLink()) {
+		throw new Error(`state path contains symlink: ${dirPath}`);
+	}
+	if (!stat.isDirectory()) {
+		throw new Error(`state path parent is not a directory: ${dirPath}`);
+	}
+}
+
+async function ensureResolvedGjcParent(filePath: string): Promise<void> {
+	const resolved = path.resolve(filePath);
+	const gjcRoot = gjcRootFromResolvedTarget(resolved);
+	const parent = path.dirname(resolved);
+	if (!isWithinOrEqualPath(gjcRoot, parent)) {
+		throw new Error(`resolved target path must stay within project .gjc/**: ${filePath}`);
+	}
+	await ensureExistingDirectoryWithoutSymlink(gjcRoot);
+	const relativeParent = path.relative(gjcRoot, parent);
+	let current = gjcRoot;
+	for (const segment of relativeParent.split(path.sep).filter(Boolean)) {
+		current = path.join(current, segment);
+		await ensureExistingDirectoryWithoutSymlink(current);
+	}
+}
+
+async function assertResolvedGjcParentConfined(filePath: string): Promise<void> {
+	const resolved = path.resolve(filePath);
+	const gjcRoot = gjcRootFromResolvedTarget(resolved);
+	const parent = path.dirname(resolved);
+	if (!isWithinOrEqualPath(gjcRoot, parent)) {
+		throw new Error(`resolved target path must stay within project .gjc/**: ${filePath}`);
+	}
+	const rootStat = await lstatIfPresent(gjcRoot);
+	if (!rootStat) return;
+	assertDirectoryStatWithoutSymlink(gjcRoot, rootStat);
+	const relativeParent = path.relative(gjcRoot, parent);
+	let current = gjcRoot;
+	for (const segment of relativeParent.split(path.sep).filter(Boolean)) {
+		current = path.join(current, segment);
+		const stat = await lstatIfPresent(current);
+		if (!stat) return;
+		assertDirectoryStatWithoutSymlink(current, stat);
+	}
+}
+
+async function assertResolvedGjcTargetIsNotSymlink(filePath: string): Promise<void> {
+	const stat = await lstatIfPresent(filePath);
+	if (stat?.isSymbolicLink()) {
+		throw new Error(`state path target is a symlink: ${filePath}`);
+	}
 }
 
 function tempPathFor(filePath: string): string {
@@ -277,6 +366,8 @@ export function stampWorkflowEnvelopeChecksum<T>(value: T, filePath: string, com
 export async function detectWorkflowEnvelopeIntegrityMismatch(
 	filePath: string,
 ): Promise<WorkflowEnvelopeIntegrityMismatch | undefined> {
+	await assertResolvedGjcParentConfined(filePath);
+	await assertResolvedGjcTargetIsNotSymlink(filePath);
 	const current = await readJsonIfPresent(filePath);
 	if (!current || typeof current !== "object" || Array.isArray(current)) return undefined;
 	const receipt = (current as Record<string, unknown>).receipt;
@@ -365,6 +456,7 @@ function buildActiveSnapshot(entries: SkillActiveEntry[]): SkillActiveState {
 }
 
 async function atomicRemove(filePath: string): Promise<boolean> {
+	await ensureResolvedGjcParent(filePath);
 	const tmpPath = tempPathFor(filePath);
 	try {
 		await fs.rename(filePath, tmpPath);
@@ -481,7 +573,7 @@ async function maybeAudit(mutatedPath: string, options?: StateWriterOptions): Pr
 }
 
 async function atomicWrite(filePath: string, content: string): Promise<string> {
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await ensureResolvedGjcParent(filePath);
 	const tmpPath = tempPathFor(filePath);
 	try {
 		await fs.writeFile(tmpPath, content, "utf-8");
@@ -501,6 +593,7 @@ async function writeGuardedResolvedJsonAtomic(
 	return lockResolvedWorkflowTarget(
 		filePath,
 		async () => {
+			await assertResolvedGjcTargetIsNotSymlink(filePath);
 			const current = await readJsonIfPresentTolerant(filePath);
 			const currentRevision = persistedStateRevision(current);
 
@@ -572,6 +665,7 @@ export async function writeGuardedWorkflowEnvelopeAtomic(
 							.join("; ")}`,
 					);
 				}
+				await enforceWorkflowEnvelopePhaseInvariants(filePath, parsed.data, options);
 				await atomicWrite(filePath, jsonText(next));
 				await maybeAudit(filePath, options);
 				return { path: filePath, written: true, revision: currentRevision + 1 };
@@ -597,6 +691,7 @@ export async function writeGuardedWorkflowEnvelopeAtomic(
 						.join("; ")}`,
 				);
 			}
+			await enforceWorkflowEnvelopePhaseInvariants(filePath, parsed.data, options);
 			await atomicWrite(filePath, jsonText(next));
 			await maybeAudit(filePath, options);
 			return { path: filePath, written: true, revision: currentRevision + 1 };
@@ -611,13 +706,21 @@ export async function writeJsonAtomic(
 	options?: StateWriterOptions,
 ): Promise<string> {
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
-	await atomicWrite(filePath, jsonText(withWorkflowReceipt(value, buildReceipt(options))));
-	await maybeAudit(filePath, options);
-	return filePath;
+	return lockResolvedWorkflowTarget(
+		filePath,
+		async () => {
+			await atomicWrite(filePath, jsonText(withWorkflowReceipt(value, buildReceipt(options))));
+			await maybeAudit(filePath, options);
+			return filePath;
+		},
+		options?.lock,
+	);
 }
 
 async function readPersistedPhase(filePath: string): Promise<string | undefined> {
 	try {
+		await ensureResolvedGjcParent(filePath);
+		await assertResolvedGjcTargetIsNotSymlink(filePath);
 		const existing = await readJsonIfPresent(filePath);
 		if (!isPlainObject(existing)) return undefined;
 		// Only an *active* prior envelope is a transition source. A cleared / handed-off
@@ -667,6 +770,60 @@ async function recordInvalidWorkflowTransition(args: {
 	}
 }
 
+async function enforceWorkflowEnvelopePhaseInvariants(
+	filePath: string,
+	envelope: RequiredOnWriteEnvelope,
+	options?: StateWriterOptions,
+): Promise<void> {
+	// #658: internal runtime writers (ralplan/ultragoal/deep-interview/team) persist
+	// envelopes directly, bypassing the `gjc state` CLI transition gate (`isValidTransition`,
+	// historically the sole call site in state-runtime.ts). Re-assert that gate on every
+	// sanctioned envelope write so internal writes cannot persist invalid state-machine phase
+	// transitions silently. Forced writes (`gjc state ... --force`, reconcile repairs) carry
+	// `audit.forced` and bypass, mirroring the CLI's `use --force to bypass`.
+	//
+	// The gate governs ACTIVE workflow progression only. Deactivation/teardown writes
+	// (`active: false`, e.g. `gjc state clear`, which persists the universal `complete`
+	// sentinel that is not a per-skill manifest state) leave the transition graph and are
+	// intentionally exempt.
+	if (options?.audit?.forced === true || envelope.active !== true) return;
+
+	const toPhase = envelope.current_phase.trim();
+	if (!toPhase) return;
+
+	// Lazy import: workflow-manifest dereferences CANONICAL_GJC_WORKFLOW_SKILLS at
+	// module load, and active-state -> state-writer -> workflow-manifest -> active-state
+	// is a load-time cycle. Importing at call time (after init) avoids the TDZ.
+	const { isKnownWorkflowState, isValidTransition } = await import("./workflow-manifest");
+	const skill = envelope.skill;
+
+	// Structural invariant (hard): a `current_phase` absent from the skill's manifest is
+	// never a legitimate internal write, matching the CLI/reconcile unknown-phase gate.
+	if (!isKnownWorkflowState(skill, toPhase)) {
+		throw new Error(
+			`Refusing to write unknown ${skill} phase "${toPhase}" to ${filePath}: not a known ${skill} manifest state (forced writes bypass via audit.forced)`,
+		);
+	}
+
+	// Transition invariant (#658): resolve the prior phase (caller-supplied
+	// `audit.fromPhase`, else the active persisted envelope on disk) and fail closed
+	// when the manifest does not define the edge. Forced repair/reconcile writes carry
+	// `audit.forced` and bypass this block above; ordinary runtime writers must not
+	// skip approval or completion gates by jumping between known states.
+	const fromPhase = (options?.audit?.fromPhase ?? (await readPersistedPhase(filePath)))?.trim();
+	if (
+		fromPhase &&
+		fromPhase !== toPhase &&
+		isKnownWorkflowState(skill, fromPhase) &&
+		!isValidTransition(skill, fromPhase, toPhase)
+	) {
+		await recordInvalidWorkflowTransition({ filePath, skill, fromPhase, toPhase, options });
+		throw new Error(
+			`Refusing to write invalid ${skill} phase transition "${fromPhase}" -> "${toPhase}" to ${filePath}: not a valid ${skill} manifest edge (forced writes bypass via audit.forced)`,
+		);
+	}
+}
+
 export async function writeWorkflowEnvelopeAtomic(
 	targetPath: string,
 	value: unknown,
@@ -683,50 +840,7 @@ export async function writeWorkflowEnvelopeAtomic(
 				.join("; ")}`,
 		);
 	}
-	// #658: internal runtime writers (ralplan/ultragoal/deep-interview/team) persist
-	// envelopes directly, bypassing the `gjc state` CLI transition gate (`isValidTransition`,
-	// historically the sole call site in state-runtime.ts). Re-assert that gate on every
-	// sanctioned envelope write so internal writes cannot persist invalid state-machine phase
-	// transitions silently. Forced writes (`gjc state ... --force`, reconcile repairs) carry
-	// `audit.forced` and bypass, mirroring the CLI's `use --force to bypass`.
-	//
-	// The gate governs ACTIVE workflow progression only. Deactivation/teardown writes
-	// (`active: false`, e.g. `gjc state clear`, which persists the universal `complete`
-	// sentinel that is not a per-skill manifest state) leave the transition graph and are
-	// intentionally exempt.
-	if (options?.audit?.forced !== true && parsed.data.active === true) {
-		const toPhase = parsed.data.current_phase.trim();
-		if (toPhase) {
-			// Lazy import: workflow-manifest dereferences CANONICAL_GJC_WORKFLOW_SKILLS at
-			// module load, and active-state -> state-writer -> workflow-manifest -> active-state
-			// is a load-time cycle. Importing at call time (after init) avoids the TDZ.
-			const { isKnownWorkflowState, isValidTransition } = await import("./workflow-manifest");
-			const skill = parsed.data.skill;
-			// Structural invariant (hard): a `current_phase` absent from the skill's manifest is
-			// never a legitimate internal write, matching the CLI/reconcile unknown-phase gate.
-			if (!isKnownWorkflowState(skill, toPhase)) {
-				throw new Error(
-					`Refusing to write unknown ${skill} phase "${toPhase}" to ${filePath}: not a known ${skill} manifest state (forced writes bypass via audit.forced)`,
-				);
-			}
-			// Transition invariant (#658, diagnostic-only safety net): resolve the prior phase
-			// (caller-supplied `audit.fromPhase`, else the active persisted envelope on disk) and
-			// flag edges the manifest does not define. Intentionally NON-blocking and audit-only
-			// — the CLI path already hard-fails invalid edges before reaching here, and legitimate
-			// internal repairs / ralplan short-mode stage skips move between valid states without a
-			// direct manifest edge. It records an `invalid_transition_detected` audit entry (no
-			// stderr) so such transitions are non-silent without breaking those flows.
-			const fromPhase = (options?.audit?.fromPhase ?? (await readPersistedPhase(filePath)))?.trim();
-			if (
-				fromPhase &&
-				fromPhase !== toPhase &&
-				isKnownWorkflowState(skill, fromPhase) &&
-				!isValidTransition(skill, fromPhase, toPhase)
-			) {
-				await recordInvalidWorkflowTransition({ filePath, skill, fromPhase, toPhase, options });
-			}
-		}
-	}
+	await enforceWorkflowEnvelopePhaseInvariants(filePath, parsed.data, options);
 	await atomicWrite(filePath, jsonText(stamped));
 	await maybeAudit(filePath, options);
 	return filePath;
@@ -767,7 +881,7 @@ async function lockResolvedWorkflowTarget<T>(
 ): Promise<T> {
 	// `withFileLock` creates the lock dir next to the target with a non-recursive
 	// mkdir, so the parent directory must exist before the lock is acquired.
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await ensureResolvedGjcParent(filePath);
 	return withFileLock(filePath, fn, lockOptions);
 }
 
@@ -780,6 +894,7 @@ export async function updateJsonAtomic<T = unknown>(
 	return lockResolvedWorkflowTarget(
 		filePath,
 		async () => {
+			await assertResolvedGjcTargetIsNotSymlink(filePath);
 			const current = (await readJsonIfPresent(filePath)) as T | undefined;
 			const next = await mutator(current);
 			await atomicWrite(filePath, jsonText(withWorkflowReceipt(next, buildReceipt(options))));
@@ -792,7 +907,8 @@ export async function updateJsonAtomic<T = unknown>(
 
 export async function appendJsonl(targetPath: string, entry: unknown, options?: StateWriterOptions): Promise<string> {
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await ensureResolvedGjcParent(filePath);
+	await assertResolvedGjcTargetIsNotSymlink(filePath);
 	await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, "utf-8");
 	await maybeAudit(filePath, options);
 	return filePath;
@@ -891,6 +1007,7 @@ export async function appendJsonlIdempotent(
 	return lockResolvedWorkflowTarget(
 		filePath,
 		async () => {
+			await assertResolvedGjcTargetIsNotSymlink(filePath);
 			const existing = await readJsonlEntries(filePath);
 			const duplicate = findJsonlDuplicate(existing, entry, options);
 			if (duplicate !== undefined) {
@@ -906,7 +1023,8 @@ export async function appendJsonlIdempotent(
 
 export async function appendText(targetPath: string, text: string, options?: StateWriterOptions): Promise<string> {
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await ensureResolvedGjcParent(filePath);
+	await assertResolvedGjcTargetIsNotSymlink(filePath);
 	await fs.appendFile(filePath, text, "utf-8");
 	await maybeAudit(filePath, options);
 	return filePath;
@@ -918,7 +1036,7 @@ export async function createJsonNoClobber(
 	options?: StateWriterOptions,
 ): Promise<string> {
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await ensureResolvedGjcParent(filePath);
 	let handle: fs.FileHandle | undefined;
 	try {
 		handle = await fs.open(filePath, "wx");
@@ -940,12 +1058,19 @@ export async function deleteIfOwned(
 	const options = typeof predicateOrOptions === "function" ? undefined : predicateOrOptions;
 	const predicate = typeof predicateOrOptions === "function" ? predicateOrOptions : predicateOrOptions?.predicate;
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
-	const current = await readJsonIfPresent(filePath);
-	if (current === undefined) return { path: filePath, deleted: false };
-	if (predicate && !(await predicate(current))) return { path: filePath, deleted: false };
-	const deleted = await atomicRemove(filePath);
-	if (deleted) await maybeAudit(filePath, options);
-	return { path: filePath, deleted };
+	return lockResolvedWorkflowTarget(
+		filePath,
+		async () => {
+			await assertResolvedGjcTargetIsNotSymlink(filePath);
+			const current = await readJsonIfPresent(filePath);
+			if (current === undefined) return { path: filePath, deleted: false };
+			if (predicate && !(await predicate(current))) return { path: filePath, deleted: false };
+			const deleted = await atomicRemove(filePath);
+			if (deleted) await maybeAudit(filePath, options);
+			return { path: filePath, deleted };
+		},
+		options?.lock,
+	);
 }
 
 export async function removeFileAudited(targetPath: string, options?: StateWriterOptions): Promise<DeleteResult> {
@@ -969,6 +1094,8 @@ export async function writeActiveEntry(
 	options?: StateWriterOptions,
 ): Promise<string> {
 	const filePath = activeEntryPath(path.resolve(cwd), sessionScope, skill);
+	await ensureResolvedGjcParent(filePath);
+	await assertResolvedGjcTargetIsNotSymlink(filePath);
 	await writeGuardedResolvedJsonAtomic(
 		filePath,
 		{ ...entry, skill },
@@ -992,6 +1119,7 @@ export async function removeActiveEntry(
 	return lockResolvedWorkflowTarget(
 		filePath,
 		async () => {
+			await assertResolvedGjcTargetIsNotSymlink(filePath);
 			const current = await readJsonIfPresent(filePath);
 			const incomingSourceRevision = options?.sourceRevision;
 			if (
@@ -1134,6 +1262,8 @@ export async function hardPrune(
 	const removed: string[] = [];
 	for (const target of targets) {
 		const filePath = resolveGjcTarget(target.path, cwd);
+		await ensureResolvedGjcParent(filePath);
+		await assertResolvedGjcTargetIsNotSymlink(filePath);
 		let stat: Stats;
 		try {
 			stat = await fs.stat(filePath);
@@ -1208,7 +1338,8 @@ export async function appendAuditEntry(
 	const entry = typeof sessionIdOrEntry === "string" ? maybeEntry : sessionIdOrEntry;
 	if (!entry) throw new Error("audit entry is required");
 	const filePath = resolveGjcTarget(layoutAuditPath(cwd, sessionId), cwd);
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await ensureResolvedGjcParent(filePath);
+	await assertResolvedGjcTargetIsNotSymlink(filePath);
 	await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, "utf-8");
 	return filePath;
 }
@@ -1264,6 +1395,8 @@ export async function updateWorkflowTransactionJournal(
 	patch: Partial<WorkflowTransactionJournal>,
 ): Promise<string> {
 	const filePath = transactionJournalPath(cwd, sessionId, mutationId);
+	await ensureResolvedGjcParent(filePath);
+	await assertResolvedGjcTargetIsNotSymlink(filePath);
 	const current = ((await readJsonIfPresent(filePath)) ?? {}) as WorkflowTransactionJournal;
 	const next = { ...current, ...patch, updated_at: new Date().toISOString() } as WorkflowTransactionJournal;
 	await atomicWrite(filePath, jsonText(next));

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -44,6 +44,7 @@ export const GJC_TEAM_DEFAULT_WORKERS = 3;
 export const GJC_TEAM_MAX_WORKERS = 20;
 const GJC_TEAM_WORKER_CLI_ENV = "GJC_TEAM_WORKER_CLI";
 const GJC_TEAM_WORKER_CLI_MAP_ENV = "GJC_TEAM_WORKER_CLI_MAP";
+const GJC_TEAM_WORKER_ID_ENV = "GJC_TEAM_WORKER_ID";
 
 export type GjcTeamWorkerCli = "gjc";
 type GjcTeamWorkerCliMode = "auto" | GjcTeamWorkerCli;
@@ -123,6 +124,10 @@ export interface GjcTeamTask {
 	updated_at: string;
 	completed_at?: string;
 }
+
+type GjcTeamApiTask = Omit<GjcTeamTask, "claim"> & {
+	claim?: Omit<GjcTeamTaskClaim, "token">;
+};
 
 export type GjcTeamWorktreeMode =
 	| { enabled: false }
@@ -302,6 +307,16 @@ function taskReceiptFields(teamName: string, task: GjcTeamTask): Record<string, 
 		owner: task.owner,
 		worker_id: task.claim?.owner ?? task.owner ?? task.assignee,
 	};
+}
+
+function taskForWorkerApi(task: GjcTeamTask): GjcTeamApiTask {
+	if (!task.claim) return task;
+	const { token: _token, ...claim } = task.claim;
+	return { ...task, claim };
+}
+
+function tasksForWorkerApi(tasks: GjcTeamTask[]): GjcTeamApiTask[] {
+	return tasks.map(taskForWorkerApi);
 }
 
 function mailboxMessageReceiptFields(teamName: string, message: GjcTeamMailboxMessage): Record<string, unknown> {
@@ -612,6 +627,9 @@ function safePathSegment(kind: string, value: string): string {
 function taskPath(dir: string, taskId: string): string {
 	return path.join(dir, "tasks", `${safePathSegment("task_id", taskId)}.json`);
 }
+function taskClaimPath(dir: string, taskId: string): string {
+	return path.join(dir, "claims", `${safePathSegment("task_id", taskId)}.json`);
+}
 function mailboxPath(dir: string, worker: string): string {
 	return path.join(dir, "mailbox", `${safePathSegment("worker_id", worker)}.json`);
 }
@@ -656,6 +674,31 @@ function assertKnownWorker(config: GjcTeamConfig, worker: string, allowLeader = 
 	assertSafeId("worker_id", worker);
 	if (allowLeader && isLeaderRecipient(worker)) return;
 	if (!config.workers.some(candidate => candidate.id === worker)) throw new Error(`unknown_worker:${worker}`);
+}
+
+function workerIdFromApiEnv(env: NodeJS.ProcessEnv, teamName: string): string | undefined {
+	const envWorker = env[GJC_TEAM_WORKER_ID_ENV]?.trim();
+	if (!envWorker) return undefined;
+	const envTeam = env.GJC_TEAM_NAME?.trim();
+	if (envTeam && envTeam !== teamName) throw new Error(`team_worker_context_mismatch:${teamName}:${envTeam}`);
+	assertSafeId("worker_id", envWorker);
+	return envWorker;
+}
+
+function resolveWorkerScopedApiCaller(
+	config: GjcTeamConfig,
+	teamName: string,
+	inputWorker: unknown,
+	env: NodeJS.ProcessEnv,
+): { worker: string; envWorker?: string } {
+	const envWorker = workerIdFromApiEnv(env, teamName);
+	const explicitWorker = inputWorker == null ? undefined : String(inputWorker);
+	const worker = envWorker ?? explicitWorker ?? "worker-1";
+	assertKnownWorker(config, worker);
+	if (envWorker && explicitWorker && explicitWorker !== envWorker) {
+		throw new Error(`worker_context_mismatch:${envWorker}:${explicitWorker}`);
+	}
+	return { worker, envWorker };
 }
 function findKnownWorker(config: GjcTeamConfig, worker: string): GjcTeamWorker {
 	assertKnownWorker(config, worker);
@@ -1294,7 +1337,7 @@ async function reconcileGjcTeamStaleClaims(
 	const recoveredClaims: GjcTeamRecoveredClaim[] = [];
 	for (const task of await readTasks(dir)) {
 		if (task.status === "completed" || task.status === "failed") continue;
-		const claimPath = path.join(dir, "claims", `${task.id}.json`);
+		const claimPath = taskClaimPath(dir, task.id);
 		const diskClaim = readClaimRecord(await readJsonFile<unknown>(claimPath));
 		const claim = task.claim ?? diskClaim;
 		if (!claim) continue;
@@ -1303,7 +1346,7 @@ async function reconcileGjcTeamStaleClaims(
 		if (isPastTimestamp(claim.leased_until)) appendLivenessRecoveryReason(reasons, "claim_expired");
 		if (reasons.length === 0) continue;
 
-		await fs.rm(claimPath, { force: true });
+		await removeFileAudited(claimPath, stateWriterOptions(claimPath, "prune", "stale-claim"));
 		recoveredClaims.push({ task_id: task.id, worker: claim.owner, reasons });
 		if (task.status !== "in_progress") {
 			await appendEvent(dir, {
@@ -1620,7 +1663,7 @@ function getGjcTeamTaskClaimEligibilityReason(
 }
 
 async function getActiveClaimReason(dir: string, task: GjcTeamTask): Promise<string | null> {
-	const claimPath = path.join(dir, "claims", `${task.id}.json`);
+	const claimPath = taskClaimPath(dir, task.id);
 	const diskClaim = readClaimRecord(await readJsonFile<unknown>(claimPath));
 	const claim = task.claim ?? diskClaim;
 	if (!claim || isPastTimestamp(claim.leased_until)) return null;
@@ -1630,6 +1673,7 @@ function isGjcTeamTaskRecord(value: unknown): value is GjcTeamTask {
 	return (
 		isRecord(value) &&
 		typeof value.id === "string" &&
+		isSafeId(value.id) &&
 		typeof value.status === "string" &&
 		(isGjcTeamTaskStatus(value.status) || value.status === "complete") &&
 		(typeof value.subject === "string" || typeof value.title === "string") &&
@@ -1960,7 +2004,7 @@ export function buildWorkerCommand(
 		envAssignment("GJC_TEAM_WORKER", `${config.team_name}/${worker.id}`),
 		envAssignment("GJC_TEAM_INTERNAL_WORKER", `${config.team_name}/${worker.id}`),
 		envAssignment("GJC_TEAM_NAME", config.team_name),
-		envAssignment("GJC_TEAM_WORKER_ID", worker.id),
+		envAssignment(GJC_TEAM_WORKER_ID_ENV, worker.id),
 		envAssignment("GJC_TEAM_STATE_ROOT", config.state_root),
 		envAssignment("GJC_TEAM_LEADER_CWD", config.leader.cwd),
 		envAssignment("GJC_TEAM_DISPLAY_NAME", config.display_name),
@@ -3492,13 +3536,16 @@ export async function claimGjcTeamTask(
 		token,
 		leased_until: new Date(Date.now() + 30 * 60_000).toISOString(),
 	};
-	const claimPath = path.join(dir, "claims", `${task.id}.json`);
+	const claimPath = taskClaimPath(dir, task.id);
 	const created = await writeJsonFileNoClobber(claimPath, claim);
 	if (!created) return { ok: false, reason: `task_already_claimed:${task.id}` };
 	const current = await readGjcTeamTask(teamName, task.id, cwd, env);
 	const currentEligibilityReason = getGjcTeamTaskClaimEligibilityReason(current, teamWorker, await readTasks(dir));
 	if (currentEligibilityReason) {
-		await fs.rm(claimPath, { force: true });
+		await deleteIfOwned(claimPath, {
+			...stateWriterOptions(claimPath, "prune", "rollback"),
+			predicate: current => (current as GjcTeamTaskClaim).token === token,
+		});
 		return { ok: false, reason: currentEligibilityReason };
 	}
 	if (current.status !== "pending") {
@@ -3571,7 +3618,7 @@ export async function transitionGjcTeamTaskStatus(
 	};
 	await writeTask(dir, updated);
 	if (terminal) {
-		const claimPath = path.join(dir, "claims", `${taskId}.json`);
+		const claimPath = taskClaimPath(dir, taskId);
 		await removeFileAudited(claimPath, stateWriterOptions(claimPath, "prune", "terminal"));
 	}
 	const eventData: Record<string, unknown> = { status };
@@ -3632,7 +3679,7 @@ export async function releaseGjcTeamTaskClaim(
 		updated_at: now(),
 	};
 	await writeTask(dir, updated);
-	const claimPath = path.join(dir, "claims", `${taskId}.json`);
+	const claimPath = taskClaimPath(dir, taskId);
 	await deleteIfOwned(claimPath, {
 		...stateWriterOptions(claimPath, "prune", "release"),
 		predicate: current => (current as GjcTeamTaskClaim).token === claimToken,
@@ -4134,6 +4181,20 @@ export async function readGjcMonitorSnapshot(
 ): Promise<unknown> {
 	return readJsonFile<unknown>(monitorSnapshotPath(await findTeamDir(teamName, cwd, env)));
 }
+function normalizeGjcTaskApproval(taskId: string, approval: Record<string, unknown>): Record<string, unknown> {
+	const status = typeof approval.status === "string" ? approval.status.trim() : "";
+	if (status !== "approved" && status !== "rejected") throw new Error(`invalid_task_approval:${taskId}:status`);
+	const reviewer = typeof approval.reviewer === "string" ? approval.reviewer.trim() : "";
+	if (!reviewer || reviewer.startsWith("worker-")) throw new Error(`invalid_task_approval:${taskId}:reviewer`);
+	return {
+		...approval,
+		task_id: taskId,
+		status,
+		reviewer,
+		reviewed_at: typeof approval.reviewed_at === "string" ? approval.reviewed_at : now(),
+	};
+}
+
 export async function writeGjcTaskApproval(
 	teamName: string,
 	taskId: string,
@@ -4142,8 +4203,11 @@ export async function writeGjcTaskApproval(
 	env: NodeJS.ProcessEnv = process.env,
 ): Promise<Record<string, unknown>> {
 	assertSafeId("task_id", taskId);
-	await writeJsonFile(path.join(await findTeamDir(teamName, cwd, env), "approvals", `${taskId}.json`), approval);
-	return approval;
+	const dir = await findTeamDir(teamName, cwd, env);
+	await readGjcTeamTask(teamName, taskId, cwd, env);
+	const normalized = normalizeGjcTaskApproval(taskId, approval);
+	await writeJsonFile(path.join(dir, "approvals", `${taskId}.json`), normalized);
+	return normalized;
 }
 export async function readGjcTaskApproval(
 	teamName: string,
@@ -4205,14 +4269,17 @@ export async function executeGjcTeamApiOperation(
 ): Promise<unknown> {
 	const teamName = String(input.team_name ?? input.teamName ?? "").trim();
 	if (!teamName) throw new Error("missing_team_name");
+	const config = await readConfig(await findTeamDir(teamName, cwd, env));
 	const workerInput = input.worker ?? input.worker_id ?? input.workerId;
-	const worker = String(workerInput ?? "worker-1");
-	const explicitWorker = workerInput == null ? undefined : String(workerInput);
+	const { worker, envWorker } = resolveWorkerScopedApiCaller(config, teamName, workerInput, env);
+	const transitionWorker = envWorker ?? (workerInput == null ? undefined : worker);
 	switch (operation) {
 		case "list-tasks":
-			return { tasks: await listGjcTeamTasks(teamName, cwd, env) };
+			return { tasks: tasksForWorkerApi(await listGjcTeamTasks(teamName, cwd, env)) };
 		case "read-task":
-			return { task: await readGjcTeamTask(teamName, String(input.task_id ?? input.taskId), cwd, env) };
+			return {
+				task: taskForWorkerApi(await readGjcTeamTask(teamName, String(input.task_id ?? input.taskId), cwd, env)),
+			};
 		case "create-task": {
 			const task = await createGjcTeamTask(
 				teamName,
@@ -4265,13 +4332,13 @@ export async function executeGjcTeamApiOperation(
 				cwd,
 				env,
 				typeof input.claim_token === "string" ? input.claim_token : undefined,
-				explicitWorker,
+				transitionWorker,
 				input.completion_evidence ?? input.completionEvidence,
 			);
 			return {
 				ok: true,
 				...taskReceiptFields(teamName, task),
-				worker_id: explicitWorker ?? task.owner ?? task.assignee,
+				worker_id: transitionWorker ?? task.owner ?? task.assignee,
 			};
 		}
 		case "release-task-claim": {
@@ -4439,8 +4506,10 @@ export async function executeGjcTeamApiOperation(
 			return writeGjcMonitorSnapshot(teamName, input.snapshot ?? {}, cwd, env);
 		case "read-monitor-snapshot":
 			return readGjcMonitorSnapshot(teamName, cwd, env);
-		case "write-task-approval":
+		case "write-task-approval": {
+			if (envWorker) throw new Error("leader_only_operation:write-task-approval");
 			return writeGjcTaskApproval(teamName, String(input.task_id), input, cwd, env);
+		}
 		case "read-task-approval":
 			return readGjcTaskApproval(teamName, String(input.task_id), cwd, env);
 		case "write-shutdown-request": {

--- a/packages/coding-agent/src/modes/controllers/runtime-mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/runtime-mcp-command-controller.ts
@@ -66,6 +66,15 @@ interface OAuthFlowResult {
 }
 
 type MCPAddScope = "user" | "project";
+
+function mcpConfigSource(scope: MCPAddScope, filePath: string): SourceMeta {
+	return {
+		provider: "mcp-json",
+		providerName: scope === "project" ? "Project MCP config" : "User MCP config",
+		path: filePath,
+		level: scope,
+	};
+}
 type MCPAddTransport = "http" | "sse";
 
 type MCPAddParsed = {
@@ -205,6 +214,7 @@ export class MCPCommandController {
 
 		let name: string | undefined;
 		let scope: MCPAddScope = "project";
+		let scopeExplicit = false;
 		let url: string | undefined;
 		let transport: MCPAddTransport = "http";
 		let authToken: string | undefined;
@@ -228,6 +238,7 @@ export class MCPCommandController {
 					return { scope, error: r.error };
 				}
 				scope = r.scope;
+				scopeExplicit = true;
 				i += 2;
 				continue;
 			}
@@ -273,6 +284,9 @@ export class MCPCommandController {
 		}
 		if (authToken && !url) {
 			return { scope, error: "--token requires --url (HTTP/SSE transport)." };
+		}
+		if (authToken && !scopeExplicit) {
+			scope = "user";
 		}
 
 		if (commandTokens && commandTokens.length > 0) {
@@ -650,16 +664,16 @@ export class MCPCommandController {
 	 * Test connection to an MCP server.
 	 * Throws an error if connection fails (used for auto-detection).
 	 */
-	async #handleTestConnection(config: MCPServerConfig): Promise<void> {
+	async #handleTestConnection(config: MCPServerConfig, source?: SourceMeta): Promise<void> {
 		// Create temporary connection using a test name
 		const testName = `test_${Date.now()}`;
 		let resolvedConfig: MCPServerConfig;
 		if (this.ctx.mcpManager) {
-			resolvedConfig = await this.ctx.mcpManager.prepareConfig(config);
+			resolvedConfig = await this.ctx.mcpManager.prepareConfig(config, source);
 		} else {
 			const tempManager = new MCPManager(getProjectDir());
 			tempManager.setAuthStorage(this.ctx.session.modelRegistry.authStorage);
-			resolvedConfig = await tempManager.prepareConfig(config);
+			resolvedConfig = await tempManager.prepareConfig(config, source);
 		}
 
 		const connection = await connectToServer(testName, resolvedConfig);
@@ -805,10 +819,10 @@ export class MCPCommandController {
 		}
 	}
 
-	async #syncManagerConnection(name: string, config: MCPServerConfig): Promise<void> {
+	async #syncManagerConnection(name: string, config: MCPServerConfig, source: SourceMeta): Promise<void> {
 		if (!this.ctx.mcpManager) return;
 		if (this.ctx.mcpManager.getConnectionStatus(name) !== "disconnected") return;
-		await this.ctx.mcpManager.connectServers({ [name]: config }, {});
+		await this.ctx.mcpManager.connectServers({ [name]: config }, { [name]: source });
 		if (this.ctx.mcpManager.getConnectionStatus(name) === "connected") {
 			await this.ctx.session.refreshMCPTools(this.ctx.mcpManager.getTools());
 		}
@@ -836,9 +850,9 @@ export class MCPCommandController {
 			// report as connected to avoid false-negative messaging.
 			if (!isConnected && !isConnecting && config.enabled !== false) {
 				try {
-					await this.#handleTestConnection(config);
+					await this.#handleTestConnection(config, mcpConfigSource(scope, filePath));
 					isConnected = true;
-					await this.#syncManagerConnection(name, config);
+					await this.#syncManagerConnection(name, config, mcpConfigSource(scope, filePath));
 				} catch {
 					// Keep disconnected status
 				}
@@ -1115,7 +1129,7 @@ export class MCPCommandController {
 				return;
 			}
 
-			const { config } = found;
+			const { config, filePath, scope } = found;
 			if (config.enabled === false) {
 				this.ctx.showError(`Server "${name}" is disabled. Run /mcp enable ${name} first.`);
 				return;
@@ -1128,11 +1142,11 @@ export class MCPCommandController {
 			// Resolve auth config if needed
 			let resolvedConfig: MCPServerConfig;
 			if (this.ctx.mcpManager) {
-				resolvedConfig = await this.ctx.mcpManager.prepareConfig(config);
+				resolvedConfig = await this.ctx.mcpManager.prepareConfig(config, mcpConfigSource(scope, filePath));
 			} else {
 				const tempManager = new MCPManager(getProjectDir());
 				tempManager.setAuthStorage(this.ctx.session.modelRegistry.authStorage);
-				resolvedConfig = await tempManager.prepareConfig(config);
+				resolvedConfig = await tempManager.prepareConfig(config, mcpConfigSource(scope, filePath));
 			}
 
 			// Create temporary connection
@@ -1159,7 +1173,7 @@ export class MCPCommandController {
 			}
 
 			lines.push("");
-			await this.#syncManagerConnection(name, config);
+			await this.#syncManagerConnection(name, config, mcpConfigSource(scope, filePath));
 			this.#showMessage(lines.join("\n"));
 		} catch (error) {
 			if (abortController.signal.aborted || (error instanceof Error && error.name === "AbortError")) {

--- a/packages/coding-agent/src/runtime-mcp/config-writer.ts
+++ b/packages/coding-agent/src/runtime-mcp/config-writer.ts
@@ -3,6 +3,7 @@
  *
  * Utilities for reading/writing .gjc/mcp.json files at user or project level.
  */
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { isEnoent } from "@gajae-code/utils";
@@ -44,14 +45,36 @@ export async function writeMCPConfigFile(filePath: string, config: MCPConfigFile
 	// Ensure parent directory exists
 	const dir = path.dirname(filePath);
 	await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
+	const dirStat = await fs.promises.lstat(dir);
+	if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) {
+		throw new Error(`Refusing to write MCP config through non-directory or symlink parent: ${dir}`);
+	}
 
-	// Write to temp file first (atomic write)
-	const tmpPath = `${filePath}.tmp`;
 	const content = JSON.stringify(withSchema(config), null, 2);
-	await fs.promises.writeFile(tmpPath, content, { encoding: "utf-8", mode: 0o600 });
+	const tmpPath = path.join(
+		dir,
+		`.${path.basename(filePath)}.${process.pid}.${Date.now()}.${crypto.randomUUID()}.tmp`,
+	);
+	let fileHandle: fs.promises.FileHandle | undefined;
+	try {
+		fileHandle = await fs.promises.open(tmpPath, "wx", 0o600);
+		await fileHandle.writeFile(content, { encoding: "utf-8" });
+		await fileHandle.sync();
+		await fileHandle.close();
+		fileHandle = undefined;
+	} catch (error) {
+		await fileHandle?.close().catch(() => {});
+		await fs.promises.rm(tmpPath, { force: true }).catch(() => {});
+		throw error;
+	}
 
 	// Rename to final path (atomic on most systems)
-	await fs.promises.rename(tmpPath, filePath);
+	try {
+		await fs.promises.rename(tmpPath, filePath);
+	} catch (error) {
+		await fs.promises.rm(tmpPath, { force: true }).catch(() => {});
+		throw error;
+	}
 	// Invalidate the capability fs cache so subsequent reads see the new content
 	invalidateFsCache(filePath);
 }

--- a/packages/coding-agent/src/runtime-mcp/config.ts
+++ b/packages/coding-agent/src/runtime-mcp/config.ts
@@ -14,12 +14,14 @@ import type { MCPServerConfig } from "./types";
 
 /** Options for loading MCP configs */
 export interface LoadMCPConfigsOptions {
-	/** Whether to load project-level config (default: true) */
+	/** Whether to load project-level config (default: false) */
 	enableProjectConfig?: boolean;
 	/** Whether to filter out Exa MCP servers (default: true) */
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
+	/** Only include servers eligible for startup connection, i.e. autoload !== false (default: true) */
+	autoloadOnly?: boolean;
 }
 
 /** Result of loading MCP configs */
@@ -40,6 +42,7 @@ function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
 	const transport = server.transport ?? (server.command ? "stdio" : server.url ? "http" : "stdio");
 	const shared = {
 		enabled: server.enabled,
+		autoload: server.autoload,
 		timeout: server.timeout,
 		auth: server.auth,
 		oauth: server.oauth,
@@ -51,6 +54,7 @@ function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
 			type: "stdio" as const,
 			command: server.command ?? "",
 		};
+		if (server._source.level === "project") config.noInheritEnv = true;
 		if (server.args) config.args = server.args;
 		if (server.env) config.env = server.env;
 		if (server.cwd) config.cwd = server.cwd;
@@ -93,9 +97,10 @@ function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
  * @param options Load options
  */
 export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOptions): Promise<LoadMCPConfigsResult> {
-	const enableProjectConfig = options?.enableProjectConfig ?? true;
+	const enableProjectConfig = options?.enableProjectConfig ?? false;
 	const filterExa = options?.filterExa ?? true;
 	const filterBrowser = options?.filterBrowser ?? false;
+	const autoloadOnly = options?.autoloadOnly ?? true;
 
 	// Load MCP servers via capability system
 	const result = await loadCapability<MCPServer>(mcpCapability.id, { cwd });
@@ -113,6 +118,9 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 	for (const server of servers) {
 		const config = convertToLegacyConfig(server);
 		if (config.enabled === false || disabledServers.has(server.name)) {
+			continue;
+		}
+		if (autoloadOnly && config.autoload === false) {
 			continue;
 		}
 		configs[server.name] = config;

--- a/packages/coding-agent/src/runtime-mcp/loader.ts
+++ b/packages/coding-agent/src/runtime-mcp/loader.ts
@@ -28,12 +28,14 @@ export interface MCPToolsLoadResult {
 export interface MCPToolsLoadOptions {
 	/** Called when starting to connect to servers */
 	onConnecting?: (serverNames: string[]) => void;
-	/** Whether to load project-level config (default: true) */
+	/** Whether to load project-level config (default: false) */
 	enableProjectConfig?: boolean;
 	/** Whether to filter out Exa MCP servers (default: true) */
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
+	/** Only connect servers with autoload !== false (default: true) */
+	autoloadOnly?: boolean;
 	/** SQLite storage for MCP tool cache (null disables cache) */
 	cacheStorage?: AgentStorage | null;
 	/** Auth storage used to resolve OAuth credentials before initial MCP connect */
@@ -72,6 +74,7 @@ export async function discoverAndLoadMCPTools(cwd: string, options?: MCPToolsLoa
 			enableProjectConfig: options?.enableProjectConfig,
 			filterExa: options?.filterExa,
 			filterBrowser: options?.filterBrowser,
+			autoloadOnly: options?.autoloadOnly,
 		});
 	} catch (error) {
 		// If discovery fails entirely, return empty result

--- a/packages/coding-agent/src/runtime-mcp/manager.ts
+++ b/packages/coding-agent/src/runtime-mcp/manager.ts
@@ -118,6 +118,10 @@ export function sortMCPToolsByName<T extends { name: string }>(tools: T[]): T[] 
 	return tools;
 }
 
+function canResolveConfigValuesFromSource(source: SourceMeta | undefined): boolean {
+	return source?.level !== "project";
+}
+
 export function resolveSubscriptionPostAction(
 	notificationsEnabled: boolean,
 	currentEpoch: number,
@@ -141,12 +145,14 @@ export interface MCPLoadResult {
 
 /** Options for discovering and connecting to MCP servers */
 export interface MCPDiscoverOptions {
-	/** Whether to load project-level config (default: true) */
+	/** Whether to load project-level config (default: false) */
 	enableProjectConfig?: boolean;
 	/** Whether to filter out Exa MCP servers (default: true) */
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
+	/** Only connect servers with autoload !== false (default: true) */
+	autoloadOnly?: boolean;
 	/** Called when starting to connect to servers */
 	onConnecting?: (serverNames: string[]) => void;
 }
@@ -325,6 +331,7 @@ export class MCPManager {
 			enableProjectConfig: options?.enableProjectConfig,
 			filterExa: options?.filterExa,
 			filterBrowser: options?.filterBrowser,
+			autoloadOnly: options?.autoloadOnly,
 		});
 		const result = await this.connectServers(configs, sources, options?.onConnecting);
 		result.exaApiKeys = exaApiKeys;
@@ -401,7 +408,7 @@ export class MCPManager {
 			this.#pendingConnectionControllers.set(name, connectionAbort);
 			// Resolve auth config before connecting, but do so per-server in parallel.
 			const connectionPromise = (async () => {
-				const resolvedConfig = await this.#resolveAuthConfig(config);
+				const resolvedConfig = await this.#resolveAuthConfig(config, false, sources[name]);
 				return connectToServer(name, resolvedConfig, {
 					signal: connectionAbort.signal,
 					onNotification: (method, params) => {
@@ -439,7 +446,7 @@ export class MCPManager {
 					// Wire auth refresh for HTTP transports so 401s trigger token refresh.
 					if (connection.transport instanceof HttpTransport && config.auth?.type === "oauth") {
 						connection.transport.onAuthError = async () => {
-							const refreshed = await this.#resolveAuthConfig(config, true);
+							const refreshed = await this.#resolveAuthConfig(config, true, sources[name]);
 							if (refreshed.type === "http" || refreshed.type === "sse") {
 								return refreshed.headers ?? null;
 							}
@@ -744,8 +751,8 @@ export class MCPManager {
 	/**
 	 * Resolve auth and shell-command substitutions in config before connecting.
 	 */
-	async prepareConfig(config: MCPServerConfig): Promise<MCPServerConfig> {
-		return this.#resolveAuthConfig(config);
+	async prepareConfig(config: MCPServerConfig, source?: SourceMeta): Promise<MCPServerConfig> {
+		return this.#resolveAuthConfig(config, false, source);
 	}
 
 	/**
@@ -944,7 +951,7 @@ export class MCPManager {
 		globalEpoch: number,
 		disconnectEpoch: number,
 	): Promise<MCPServerConnection> {
-		const resolvedConfig = await this.#resolveAuthConfig(config);
+		const resolvedConfig = await this.#resolveAuthConfig(config, false, source);
 		const connectionAbort = new AbortController();
 		this.#pendingConnectionControllers.set(name, connectionAbort);
 		let connection: MCPServerConnection;
@@ -983,7 +990,7 @@ export class MCPManager {
 		// Wire auth refresh for HTTP transports, and reconnect for any transport.
 		if (connection.transport instanceof HttpTransport && config.auth?.type === "oauth") {
 			connection.transport.onAuthError = async () => {
-				const refreshed = await this.#resolveAuthConfig(config, true);
+				const refreshed = await this.#resolveAuthConfig(config, true, source);
 				if (refreshed.type === "http" || refreshed.type === "sse") {
 					return refreshed.headers ?? null;
 				}
@@ -1214,6 +1221,7 @@ export class MCPManager {
 	getServerInstructions(): Map<string, string> {
 		const instructions = new Map<string, string>();
 		for (const [name, connection] of this.#connections) {
+			if (connection._source?.level === "project") continue;
 			if (connection.instructions) {
 				instructions.set(name, connection.instructions);
 			}
@@ -1232,13 +1240,18 @@ export class MCPManager {
 	}
 
 	/**
-	 * Resolve OAuth credentials and shell commands in config.
+	 * Resolve OAuth credentials and shell/env references for trusted non-project configs.
 	 */
-	async #resolveAuthConfig(config: MCPServerConfig, forceRefresh = false): Promise<MCPServerConfig> {
+	async #resolveAuthConfig(
+		config: MCPServerConfig,
+		forceRefresh = false,
+		source?: SourceMeta,
+	): Promise<MCPServerConfig> {
 		let resolved: MCPServerConfig = { ...config };
+		const allowTrustedSecretResolution = canResolveConfigValuesFromSource(source);
 
 		const auth = config.auth;
-		if (auth?.type === "oauth" && auth.credentialId && this.#authStorage) {
+		if (allowTrustedSecretResolution && auth?.type === "oauth" && auth.credentialId && this.#authStorage) {
 			const credentialId = auth.credentialId;
 			try {
 				let credential = this.#authStorage.get(credentialId);
@@ -1290,6 +1303,9 @@ export class MCPManager {
 			}
 		}
 
+		if (!allowTrustedSecretResolution) {
+			return resolved;
+		}
 		if (resolved.type !== "http" && resolved.type !== "sse") {
 			if (resolved.env) {
 				const nextEnv: Record<string, string> = {};

--- a/packages/coding-agent/src/runtime-mcp/types.ts
+++ b/packages/coding-agent/src/runtime-mcp/types.ts
@@ -61,6 +61,8 @@ export interface MCPAuthConfig {
 interface MCPServerConfigBase {
 	/** Whether this server is enabled (default: true) */
 	enabled?: boolean;
+	/** Whether this server should autoload at startup (default: true) */
+	autoload?: boolean;
 	/** Connection timeout in milliseconds (default: 30000) */
 	timeout?: number;
 	/** Authentication configuration (optional) */

--- a/packages/coding-agent/src/slash-commands/helpers/mcp.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/mcp.ts
@@ -1,4 +1,5 @@
 import { getMCPConfigPath, logger } from "@gajae-code/utils";
+import type { SourceMeta } from "../../capability/types";
 import { connectToServer, disconnectServer, listPrompts, listResources, listTools } from "../../runtime-mcp/client";
 import {
 	addMCPServer,
@@ -18,9 +19,26 @@ import { commandConsumed, errorMessage, parseNamedScopeArgs, parseSubcommand, us
 
 type AcpMcpScope = "user" | "project";
 
+function mcpConfigSource(scope: AcpMcpScope, filePath: string): SourceMeta {
+	return {
+		provider: "mcp-json",
+		providerName: scope === "project" ? "Project MCP config" : "User MCP config",
+		path: filePath,
+		level: scope,
+	};
+}
+
+type ConfiguredMcpServer = {
+	name: string;
+	config: MCPServerConfig;
+	scope: AcpMcpScope;
+	source: SourceMeta;
+};
+
 interface ParsedMcpAddArgs {
 	name?: string;
 	scope: AcpMcpScope;
+	scopeExplicit?: boolean;
 	url?: string;
 	transport: "http" | "sse";
 	authToken?: string;
@@ -47,6 +65,7 @@ const MCP_ADD_OPTION_PARSERS = new Map<string, McpAddOptionParser>([
 		(parsed, value) => {
 			if (!value || (value !== "project" && value !== "user")) return "Invalid --scope value. Use project or user.";
 			parsed.scope = value;
+			parsed.scopeExplicit = true;
 			return undefined;
 		},
 	],
@@ -76,22 +95,34 @@ const MCP_ADD_OPTION_PARSERS = new Map<string, McpAddOptionParser>([
 	],
 ]);
 
-async function getMcpConfiguredServers(
-	cwd: string,
-): Promise<Array<{ name: string; config: MCPServerConfig; scope: AcpMcpScope }>> {
+async function getMcpConfiguredServers(cwd: string, includeProjectConfig: boolean): Promise<ConfiguredMcpServer[]> {
 	const userPath = getMCPConfigPath("user", cwd);
 	const projectPath = getMCPConfigPath("project", cwd);
 	const [userConfig, projectConfig] = await Promise.all([readMCPConfigFile(userPath), readMCPConfigFile(projectPath)]);
-	const servers: Array<{ name: string; config: MCPServerConfig; scope: AcpMcpScope }> = [];
+	const servers: ConfiguredMcpServer[] = [];
 	const seen = new Set<string>();
-	for (const [name, config] of Object.entries(projectConfig.mcpServers ?? {})) {
-		if (config.enabled !== false) {
-			servers.push({ name, config, scope: "project" });
-			seen.add(name);
+	if (includeProjectConfig) {
+		for (const [name, config] of Object.entries(projectConfig.mcpServers ?? {})) {
+			if (config.enabled !== false) {
+				servers.push({
+					name,
+					config,
+					scope: "project",
+					source: mcpConfigSource("project", projectPath),
+				});
+				seen.add(name);
+			}
 		}
 	}
 	for (const [name, config] of Object.entries(userConfig.mcpServers ?? {})) {
-		if (!seen.has(name) && config.enabled !== false) servers.push({ name, config, scope: "user" });
+		if (!seen.has(name) && config.enabled !== false) {
+			servers.push({
+				name,
+				config,
+				scope: "user",
+				source: mcpConfigSource("user", userPath),
+			});
+		}
 	}
 	return servers;
 }
@@ -108,6 +139,7 @@ function validateParsedMcpAddArgs(parsed: ParsedMcpAddArgs): ParsedMcpAddArgs {
 	if (!parsed.name) return { ...parsed, error: "Server name required. Usage: /mcp add <name> ..." };
 	if (hasCommand && hasUrl) return { ...parsed, error: "Use either --url or -- <command...>, not both." };
 	if (parsed.authToken && !hasUrl) return { ...parsed, error: "--token requires --url (HTTP/SSE transport)." };
+	if (parsed.authToken && !parsed.scopeExplicit) return { ...parsed, scope: "user" };
 	return parsed;
 }
 
@@ -199,6 +231,7 @@ async function withPreparedMcpConnection<T>(
 	runtime: SlashCommandRuntime,
 	name: string,
 	config: MCPServerConfig,
+	source: SourceMeta,
 	fn: (connection: MCPServerConnection) => Promise<T>,
 ): Promise<T> {
 	let connection: MCPServerConnection | undefined;
@@ -209,7 +242,7 @@ async function withPreparedMcpConnection<T>(
 		// Without this, `/mcp test|resources|prompts` silently fails for any
 		// server saved by the TUI/reauth path.
 		manager.setAuthStorage(runtime.session.modelRegistry.authStorage);
-		const resolvedConfig = await manager.prepareConfig(config);
+		const resolvedConfig = await manager.prepareConfig(config, source);
 		connection = await connectToServer(name, resolvedConfig);
 		return await fn(connection);
 	} finally {
@@ -231,13 +264,13 @@ async function collectConnectedMcpLines(
 	runtime: SlashCommandRuntime,
 	collect: (serverName: string, connection: MCPServerConnection) => Promise<string[]>,
 ): Promise<string[] | undefined> {
-	const servers = await getMcpConfiguredServers(runtime.cwd);
+	const servers = await getMcpConfiguredServers(runtime.cwd, runtime.settings.get("mcp.enableProjectConfig"));
 	if (servers.length === 0) return undefined;
 
 	const lines: string[] = [];
-	for (const { name, config } of servers) {
+	for (const { name, config, source } of servers) {
 		try {
-			const collected = await withPreparedMcpConnection(runtime, name, config, connection =>
+			const collected = await withPreparedMcpConnection(runtime, name, config, source, connection =>
 				collect(name, connection),
 			);
 			lines.push(...collected);
@@ -277,12 +310,12 @@ async function handlePromptsCommand(runtime: SlashCommandRuntime): Promise<Slash
 async function handleTestCommand(rest: string, runtime: SlashCommandRuntime): Promise<SlashCommandResult> {
 	const name = rest.split(/\s+/)[0]?.trim() ?? "";
 	if (!name) return usage("Usage: /mcp test <name>", runtime);
-	const servers = await getMcpConfiguredServers(runtime.cwd);
+	const servers = await getMcpConfiguredServers(runtime.cwd, runtime.settings.get("mcp.enableProjectConfig"));
 	const server = servers.find(item => item.name === name);
 	if (!server) return usage(`Server "${name}" not found. Run /mcp list to see configured servers.`, runtime);
 
 	try {
-		return await withPreparedMcpConnection(runtime, name, server.config, async connection => {
+		return await withPreparedMcpConnection(runtime, name, server.config, server.source, async connection => {
 			const tools = await listTools(connection);
 			const lines = [`Server "${name}" connected (${tools.length} tools).`];
 			for (const tool of tools) lines.push(`  - ${tool.name}`);

--- a/packages/coding-agent/src/task/gjc-command.ts
+++ b/packages/coding-agent/src/task/gjc-command.ts
@@ -1,7 +1,5 @@
 import process from "node:process";
 
-import { $env } from "@gajae-code/utils";
-
 interface GjcCommand {
 	cmd: string;
 	args: string[];
@@ -12,11 +10,6 @@ const DEFAULT_CMD = process.platform === "win32" ? "gjc.cmd" : "gjc";
 const DEFAULT_SHELL = process.platform === "win32";
 
 export function resolveGjcCommand(): GjcCommand {
-	const envCmd = $env.PI_SUBPROCESS_CMD;
-	if (envCmd?.trim()) {
-		return { cmd: envCmd, args: [], shell: DEFAULT_SHELL };
-	}
-
 	const entry = process.argv[1];
 	if (entry && (entry.endsWith(".ts") || entry.endsWith(".js"))) {
 		return { cmd: process.execPath, args: [entry], shell: false };

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as path from "node:path";
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
 import type { Component } from "@gajae-code/tui";
 import { ImageProtocol, TERMINAL, Text } from "@gajae-code/tui";
@@ -36,6 +37,7 @@ import { clampTimeout, TOOL_TIMEOUTS } from "./tool-timeouts";
 export const BASH_DEFAULT_PREVIEW_LINES = 10;
 
 const BASH_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const GJC_RALPLAN_ARTIFACT_ENV = "GJC_RALPLAN_ARTIFACT";
 const DEFAULT_AUTO_BACKGROUND_THRESHOLD_MS = 60_000;
 const READ_ONLY_BASH_ENV: Record<string, string> = {
 	GREP_OPTIONS: "",
@@ -43,6 +45,15 @@ const READ_ONLY_BASH_ENV: Record<string, string> = {
 	GREP_COLORS: "",
 	RIPGREP_CONFIG_PATH: "",
 };
+
+function isWithinOrEqualPath(root: string, candidate: string): boolean {
+	const relative = path.relative(root, candidate);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function commandHasRalplanArtifactEnvFlag(command: string): boolean {
+	return new RegExp(`(?:^|\\s)--artifact-env\\s+${GJC_RALPLAN_ARTIFACT_ENV}(?:\\s|$)`, "u").test(command);
+}
 
 export async function saveBashOriginalArtifactForTests(
 	session: ToolSession,
@@ -530,13 +541,27 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 
 		const rawCommand = input.command;
 		const allowedPrefixes = this.session.bashAllowedPrefixes;
-		if (
-			(this.session.bashRestrictionProfile === "read-only" || (allowedPrefixes && allowedPrefixes.length > 0)) &&
+		const isRestrictedRalplanArtifactEnv =
+			allowedPrefixes &&
+			allowedPrefixes.length > 0 &&
+			this.session.bashRestrictionProfile !== "read-only" &&
 			env &&
-			Object.keys(env).length > 0
+			Object.keys(env).length === 1 &&
+			Object.hasOwn(env, GJC_RALPLAN_ARTIFACT_ENV) &&
+			commandHasRalplanArtifactEnvFlag(rawCommand);
+		if (this.session.bashRestrictionProfile === "read-only" && env && Object.keys(env).length > 0) {
+			throw new ToolError("Read-only bash does not allow per-command env overrides.");
+		}
+		if (
+			allowedPrefixes &&
+			allowedPrefixes.length > 0 &&
+			env &&
+			Object.keys(env).length > 0 &&
+			!isRestrictedRalplanArtifactEnv
 		) {
-			const mode = this.session.bashRestrictionProfile === "read-only" ? "Read-only" : "Restricted role-agent";
-			throw new ToolError(`${mode} bash does not allow per-command env overrides.`);
+			throw new ToolError(
+				"Restricted role-agent bash only allows the GJC_RALPLAN_ARTIFACT env override when command includes --artifact-env GJC_RALPLAN_ARTIFACT.",
+			);
 		}
 		if (allowedPrefixes && allowedPrefixes.length > 0) {
 			const commandsToCheck = rawCommand === command ? [command] : [rawCommand, command];
@@ -633,6 +658,16 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		}
 		if (!cwdStat.isDirectory()) {
 			throw new ToolError(`Working directory is not a directory: ${commandCwd}`);
+		}
+		if (this.session.bashRestrictionProfile === "read-only" || (allowedPrefixes && allowedPrefixes.length > 0)) {
+			const [sessionRealpath, commandRealpath] = await Promise.all([
+				fs.promises.realpath(this.session.cwd),
+				fs.promises.realpath(commandCwd),
+			]);
+			if (!isWithinOrEqualPath(sessionRealpath, commandRealpath)) {
+				const mode = this.session.bashRestrictionProfile === "read-only" ? "Read-only" : "Restricted role-agent";
+				throw new ToolError(`${mode} bash cwd must stay within the session workspace.`);
+			}
 		}
 
 		const requestedTimeoutSec = input.timeout ?? 300;

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -144,6 +144,33 @@ describe("contribution prep", () => {
 		}
 	});
 
+	it("ignores PI_SUBPROCESS_CMD when spawning contribution workers", async () => {
+		const tempDir = TempDir.createSync("@gjc-contribution-prep-env-spawn-");
+		const previous = process.env.PI_SUBPROCESS_CMD;
+		process.env.PI_SUBPROCESS_CMD = "/tmp/evil-gjc";
+		try {
+			const spawns: Array<{ args: string[]; cwd: string }> = [];
+			await prepareContributionPrep(
+				{ sessionId: "source-session", cwd: tempDir.path(), messages: [] },
+				{
+					artifactRoot: path.join(tempDir.path(), "artifacts"),
+					spawnWorker: true,
+					spawn: async (args, cwd) => {
+						spawns.push({ args, cwd });
+					},
+				},
+			);
+
+			expect(spawns).toHaveLength(1);
+			expect(spawns[0]?.args[0]).not.toBe("/tmp/evil-gjc");
+			expect(spawns[0]?.args).toContain("--no-skills");
+		} finally {
+			if (previous === undefined) delete process.env.PI_SUBPROCESS_CMD;
+			else process.env.PI_SUBPROCESS_CMD = previous;
+			tempDir.remove();
+		}
+	});
+
 	it("resolves worker spawn argv through the GJC command and prompt file", async () => {
 		const tempDir = TempDir.createSync("@gjc-contribution-prep-real-spawn-");
 		try {

--- a/packages/coding-agent/test/discovery/mcp-json.test.ts
+++ b/packages/coding-agent/test/discovery/mcp-json.test.ts
@@ -13,11 +13,19 @@ async function loadStandaloneMcpConfig(cwd: string): Promise<MCPServer[]> {
 	return result.items;
 }
 
+async function loadNativeMcpConfig(cwd: string): Promise<MCPServer[]> {
+	const result = await loadCapability<MCPServer>(mcpCapability.id, {
+		cwd,
+		providers: ["native"],
+	});
+	return result.items;
+}
+
 function envPlaceholder(name: string): string {
 	return `\${${name}}`;
 }
 
-describe("standalone mcp.json oauth env expansion", () => {
+describe("standalone mcp.json project env trust boundary", () => {
 	let tempDir = "";
 	const originalEnv = {
 		PI_OAUTH_TOKEN_URL: process.env.PI_OAUTH_TOKEN_URL,
@@ -53,7 +61,7 @@ describe("standalone mcp.json oauth env expansion", () => {
 		}
 	});
 
-	test("expands standalone auth and oauth fields alongside existing env-expanded fields", async () => {
+	test("preserves project auth and oauth env placeholders literally", async () => {
 		await fs.writeFile(
 			path.join(tempDir, "mcp.json"),
 			JSON.stringify({
@@ -82,25 +90,25 @@ describe("standalone mcp.json oauth env expansion", () => {
 
 		const [server] = await loadStandaloneMcpConfig(tempDir);
 		expect(server).toBeDefined();
-		expect(server?.url).toBe("https://mcp.example.com/mcp");
-		expect(server?.headers).toEqual({ Authorization: "Bearer test-token" });
-		expect(server?.env).toEqual({ MCP_VALUE: "env-value" });
+		expect(server?.url).toBe(`${envPlaceholder("PI_MCP_URL")}/mcp`);
+		expect(server?.headers).toEqual({ Authorization: envPlaceholder("PI_MCP_HEADER") });
+		expect(server?.env).toEqual({ MCP_VALUE: envPlaceholder("PI_MCP_ENV") });
 		expect(server?.auth).toEqual({
 			type: "oauth",
-			tokenUrl: "https://provider.example/token",
-			clientId: "oauth-client-id",
-			clientSecret: "oauth-client-secret",
+			tokenUrl: envPlaceholder("PI_OAUTH_TOKEN_URL"),
+			clientId: envPlaceholder("PI_OAUTH_CLIENT_ID"),
+			clientSecret: envPlaceholder("PI_OAUTH_CLIENT_SECRET"),
 		});
 		expect(server?.oauth).toEqual({
-			clientId: "oauth-client-id",
-			clientSecret: "oauth-client-secret",
-			redirectUri: "https://public.example/oauth/callback",
+			clientId: envPlaceholder("PI_OAUTH_CLIENT_ID"),
+			clientSecret: envPlaceholder("PI_OAUTH_CLIENT_SECRET"),
+			redirectUri: envPlaceholder("PI_OAUTH_REDIRECT_URI"),
 			callbackPort: 4317,
-			callbackPath: "/oauth/callback",
+			callbackPath: envPlaceholder("PI_OAUTH_CALLBACK_PATH"),
 		});
 	});
 
-	test("expands only the standalone oauth fields that are present", async () => {
+	test("preserves partial project oauth env placeholders literally", async () => {
 		await fs.writeFile(
 			path.join(tempDir, ".mcp.json"),
 			JSON.stringify({
@@ -119,9 +127,61 @@ describe("standalone mcp.json oauth env expansion", () => {
 		const [server] = await loadStandaloneMcpConfig(tempDir);
 		expect(server).toBeDefined();
 		expect(server?.oauth).toEqual({
-			redirectUri: "https://public.example/oauth/callback",
-			callbackPath: "/oauth/callback",
+			redirectUri: envPlaceholder("PI_OAUTH_REDIRECT_URI"),
+			callbackPath: envPlaceholder("PI_OAUTH_CALLBACK_PATH"),
 		});
 		expect(server?.auth).toBeUndefined();
+	});
+});
+
+describe("native .gjc project env trust boundary", () => {
+	let tempDir = "";
+	const originalEnv = {
+		PI_MCP_HEADER: process.env.PI_MCP_HEADER,
+		PI_MCP_COMMAND: process.env.PI_MCP_COMMAND,
+		PI_MCP_ENV: process.env.PI_MCP_ENV,
+	};
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-native-mcp-"));
+		process.env.PI_MCP_HEADER = "Bearer native-secret";
+		process.env.PI_MCP_COMMAND = "native-secret-command";
+		process.env.PI_MCP_ENV = "native-env-value";
+	});
+
+	afterEach(async () => {
+		await fs.rm(tempDir, { recursive: true, force: true });
+		for (const [key, value] of Object.entries(originalEnv)) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	});
+
+	test("preserves project placeholders loaded from .gjc/mcp.json literally", async () => {
+		await fs.mkdir(path.join(tempDir, ".gjc"), { recursive: true });
+		await fs.writeFile(
+			path.join(tempDir, ".gjc", "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					native: {
+						command: envPlaceholder("PI_MCP_COMMAND"),
+						args: [envPlaceholder("PI_MCP_ENV")],
+						env: { MCP_VALUE: envPlaceholder("PI_MCP_ENV") },
+						headers: { Authorization: envPlaceholder("PI_MCP_HEADER") },
+					},
+				},
+			}),
+		);
+
+		const [server] = await loadNativeMcpConfig(tempDir);
+
+		expect(server).toBeDefined();
+		expect(server?.command).toBe(envPlaceholder("PI_MCP_COMMAND"));
+		expect(server?.args).toEqual([envPlaceholder("PI_MCP_ENV")]);
+		expect(server?.env).toEqual({ MCP_VALUE: envPlaceholder("PI_MCP_ENV") });
+		expect(server?.headers).toEqual({ Authorization: envPlaceholder("PI_MCP_HEADER") });
 	});
 });

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -676,6 +676,61 @@ describe("ExtensionRunner", () => {
 
 			warnSpy.mockRestore();
 		});
+
+		it("fails closed when a tool_call handler times out", async () => {
+			const hangExtensionPath = path.join(tempDir.path(), "hang-tool-call.ts");
+			fs.writeFileSync(
+				hangExtensionPath,
+				`
+					export default function(pi) {
+						pi.on("tool_call", async () => {
+							await Promise.withResolvers().promise;
+						});
+					}
+				`,
+			);
+
+			const result = await loadTestExtensions([hangExtensionPath]);
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+			const errors: Array<{ extensionPath: string; event: string; error: string }> = [];
+			runner.onError(err => {
+				errors.push(err);
+			});
+			testSetExtensionHandlerTimeoutMs(10);
+
+			const toolCallResult = await runner.emitToolCall({
+				type: "tool_call",
+				toolName: "bash",
+				toolCallId: "call-timeout",
+				input: {},
+			});
+
+			expect(toolCallResult).toEqual({
+				block: true,
+				reason: `Extension ${hangExtensionPath} timed out handling tool_call.`,
+			});
+			expect(warnSpy).toHaveBeenCalledWith("Extension handler timed out", {
+				extensionPath: hangExtensionPath,
+				event: "tool_call",
+				timeoutMs: 10,
+			});
+			expect(errors).toEqual([
+				{
+					extensionPath: hangExtensionPath,
+					event: "tool_call",
+					error: "handler timed out after 10ms",
+				},
+			]);
+
+			warnSpy.mockRestore();
+		});
 	});
 
 	describe("session name API", () => {

--- a/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { modeStatePath, sessionStateDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
+import { modeStatePath, sessionDirName, sessionStateDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
 
 const TEST_SESSION_ID = "test-session";
@@ -70,6 +70,19 @@ describe("gjc state write hardening", () => {
 		const result = await writeState(root, "ralplan", { current_phase: "final" });
 		expect(result.status).not.toBe(0);
 		expect(result.stderr).toContain("invalid ralplan phase transition from planner to final");
+	});
+
+	it("rejects writes through symlinked state parents", async () => {
+		const root = await tempDir();
+		const victim = await tempDir();
+		await fs.mkdir(path.join(root, ".gjc"), { recursive: true });
+		await fs.symlink(victim, path.join(root, ".gjc", sessionDirName(TEST_SESSION_ID)));
+
+		const result = await writeState(root, "ralplan", { current_phase: "planner" });
+
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain("state path contains symlink");
+		await expect(fs.readFile(path.join(victim, "state", "ralplan-state.json"), "utf-8")).rejects.toThrow();
 	});
 
 	it("allows --force to bypass a known-bad jump", async () => {

--- a/packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts
@@ -390,7 +390,7 @@ describe("workflow state writer drift guard", () => {
 		expect(persisted.current_phase).toBe("bogus-phase");
 	});
 
-	it("flags an invalid phase transition on an internal write but still persists it (#658 transition invariant)", async () => {
+	it("rejects an invalid phase transition on an internal write (#658 transition invariant)", async () => {
 		const root = await tempDir();
 		const statePath = modeStatePath(root, TEST_SESSION_ID, "ralplan");
 		const base = {
@@ -419,24 +419,13 @@ describe("workflow state writer drift guard", () => {
 		// Seed a valid active prior phase, then jump planner -> final (no manifest edge).
 		await writeWorkflowEnvelopeAtomic(statePath, { ...base, current_phase: "planner" }, opts);
 
-		// The diagnostic-only path must NOT touch stderr (callers may treat stderr as failure
-		// or parse machine output): capture stderr across the invalid-edge write.
-		const originalWrite = process.stderr.write.bind(process.stderr);
-		let stderrCaptured = "";
-		process.stderr.write = ((chunk: unknown) => {
-			stderrCaptured += typeof chunk === "string" ? chunk : String(chunk);
-			return true;
-		}) as typeof process.stderr.write;
-		try {
-			await writeWorkflowEnvelopeAtomic(statePath, { ...base, current_phase: "final" }, opts);
-		} finally {
-			process.stderr.write = originalWrite;
-		}
-		expect(stderrCaptured).toBe("");
+		// Invalid known-state edges fail closed at the writer boundary; audit evidence
+		// is supplementary and must not be the only enforcement.
+		await expect(writeWorkflowEnvelopeAtomic(statePath, { ...base, current_phase: "final" }, opts)).rejects.toThrow(
+			'Refusing to write invalid ralplan phase transition "planner" -> "final"',
+		);
 
-		// The invalid edge is recorded as audit evidence, not blocked.
-		await expectPersistedEnvelope(statePath);
-		expect((await readJson(statePath)).current_phase).toBe("final");
+		expect((await readJson(statePath)).current_phase).toBe("planner");
 		const flagged = (await readAuditEntries(root)).filter(e => e.verb === "invalid_transition_detected");
 		expect(flagged.length).toBe(1);
 		expect(flagged[0]?.from_phase).toBe("planner");

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -1602,6 +1602,50 @@ describe("native gjc team runtime", () => {
 		expect(await readEvents(stateDir)).toContain("claim_expired");
 	});
 
+	it("ignores task records with unsafe ids during stale claim recovery", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Ignore unsafe task",
+			teamName: "unsafe-task-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { GJC_SESSION_ID: TEST_SESSION_ID, PATH: "" },
+		});
+		const stateDir = teamStateDir(cleanupRoot, "unsafe-task-team");
+		const victimPath = path.join(stateDir, "victim.json");
+		const expiredClaim = {
+			owner: "worker-1",
+			token: "evil-token",
+			leased_until: new Date(Date.now() - 60_000).toISOString(),
+		};
+		await Bun.write(victimPath, `${JSON.stringify({ keep: true }, null, 2)}\n`);
+		await Bun.write(
+			path.join(stateDir, "tasks", "evil.json"),
+			`${JSON.stringify(
+				{
+					id: "../victim",
+					status: "in_progress",
+					subject: "unsafe",
+					description: "unsafe",
+					claim: expiredClaim,
+				},
+				null,
+				2,
+			)}\n`,
+		);
+
+		const claim = await claimGjcTeamTask("unsafe-task-team", "worker-1", cleanupRoot, {
+			PATH: "",
+			GJC_SESSION_ID: TEST_SESSION_ID,
+		});
+
+		expect(claim.ok).toBe(true);
+		expect(await Bun.file(victimPath).exists()).toBe(true);
+		expect(await readEvents(stateDir)).not.toContain('task_id":"../victim');
+	});
+
 	it("recovers stale heartbeat claims during monitor and blocks stale workers from reclaiming", async () => {
 		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
 		await startGjcTeam({
@@ -1925,6 +1969,38 @@ describe("native gjc team runtime", () => {
 			cleanupRoot,
 			{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
 		)) as { claim_token: string };
+		const listedWithClaim = (await executeGjcTeamApiOperation("list-tasks", { team_name: "api-team" }, cleanupRoot, {
+			PATH: "",
+			GJC_SESSION_ID: TEST_SESSION_ID,
+		})) as { tasks: unknown[] };
+		expect(JSON.stringify(listedWithClaim)).not.toContain(claimed.claim_token);
+		const readWithClaim = (await executeGjcTeamApiOperation(
+			"read-task",
+			{ team_name: "api-team", task_id: created.task_id },
+			cleanupRoot,
+			{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
+		)) as { task: unknown };
+		expect(JSON.stringify(readWithClaim.task)).not.toContain(claimed.claim_token);
+		await expect(
+			executeGjcTeamApiOperation(
+				"transition-task-status",
+				{
+					team_name: "api-team",
+					task_id: created.task_id,
+					worker: "worker-1",
+					to: "completed",
+					claim_token: claimed.claim_token,
+					completionEvidence: artifactCompletionEvidence("forged completion"),
+				},
+				cleanupRoot,
+				{
+					PATH: "",
+					GJC_SESSION_ID: TEST_SESSION_ID,
+					GJC_TEAM_NAME: "api-team",
+					GJC_TEAM_WORKER_ID: "worker-2",
+				},
+			),
+		).rejects.toThrow("worker_context_mismatch:worker-2:worker-1");
 		await executeGjcTeamApiOperation(
 			"transition-task-status",
 			{
@@ -2029,6 +2105,19 @@ describe("native gjc team runtime", () => {
 			{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
 		)) as { status: string };
 		expect(approval.status).toBe("approved");
+		await expect(
+			executeGjcTeamApiOperation(
+				"write-task-approval",
+				{ team_name: "api-team", task_id: created.task_id, status: "approved", reviewer: "leader" },
+				cleanupRoot,
+				{
+					PATH: "",
+					GJC_SESSION_ID: TEST_SESSION_ID,
+					GJC_TEAM_NAME: "api-team",
+					GJC_TEAM_WORKER_ID: "worker-1",
+				},
+			),
+		).rejects.toThrow("leader_only_operation:write-task-approval");
 		await executeGjcTeamApiOperation(
 			"write-shutdown-request",
 			{ team_name: "api-team", worker: "worker-1", requested_by: "leader-fixed" },

--- a/packages/coding-agent/test/gjc-state-writer-policy.test.ts
+++ b/packages/coding-agent/test/gjc-state-writer-policy.test.ts
@@ -3,12 +3,14 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+	deleteIfOwned,
 	detectWorkflowEnvelopeIntegrityMismatch,
 	removeActiveEntry,
 	StateWriteConflictError,
 	writeActiveEntry,
 	writeGuardedJsonAtomic,
 	writeGuardedWorkflowEnvelopeAtomic,
+	writeJsonAtomic,
 } from "../src/gjc-runtime/state-writer";
 
 describe("GJC state writer revision policy", () => {
@@ -143,6 +145,72 @@ describe("GJC state writer revision policy", () => {
 		).rejects.toBeInstanceOf(StateWriteConflictError);
 
 		await expect(readJson(root, target)).resolves.toMatchObject({ current_phase: "handoff", state_revision: 2 });
+	});
+
+	it("rejects unknown active phases in guarded workflow envelopes", async () => {
+		const root = await cwd();
+		const target = ".gjc/_session-sess/state/mode-state/deep-interview.json";
+
+		await expect(
+			writeGuardedWorkflowEnvelopeAtomic(target, modeEnvelope("stale"), {
+				cwd: root,
+				policy: "source",
+				receipt: receipt(root),
+			}),
+		).rejects.toThrow('Refusing to write unknown deep-interview phase "stale"');
+
+		await expect(fs.stat(path.join(root, target))).rejects.toThrow();
+	});
+
+	it("rejects invalid known transitions in guarded workflow envelopes", async () => {
+		const root = await cwd();
+		const target = ".gjc/_session-sess/state/mode-state/ralplan.json";
+		const base = {
+			skill: "ralplan",
+			current_phase: "planner",
+			active: true,
+			version: 2,
+			updated_at: "2026-01-01T00:00:00.000Z",
+		};
+		const ralplanReceipt = {
+			cwd: root,
+			skill: "ralplan" as const,
+			owner: "gjc-runtime" as const,
+			command: "test",
+			sessionId: "sess",
+			nowIso: "2026-01-01T00:00:00.000Z",
+		};
+
+		await writeGuardedWorkflowEnvelopeAtomic(target, base, { cwd: root, policy: "source", receipt: ralplanReceipt });
+		await expect(
+			writeGuardedWorkflowEnvelopeAtomic(
+				target,
+				{ ...base, current_phase: "final" },
+				{ cwd: root, policy: "source", expectedRevision: 1, receipt: ralplanReceipt },
+			),
+		).rejects.toThrow('Refusing to write invalid ralplan phase transition "planner" -> "final"');
+
+		await expect(readJson(root, target)).resolves.toMatchObject({ current_phase: "planner", state_revision: 1 });
+	});
+
+	it("serializes owned deletes against atomic json replacement", async () => {
+		const root = await cwd();
+		const target = ".gjc/_session-sess/state/claims/task.json";
+		await writeJsonAtomic(target, { token: "old" }, { cwd: root });
+		let replacement: Promise<string> | undefined;
+
+		const deleted = await deleteIfOwned(target, {
+			cwd: root,
+			predicate: current => {
+				if ((current as { token?: string }).token !== "old") return false;
+				replacement = writeJsonAtomic(target, { token: "new" }, { cwd: root });
+				return true;
+			},
+		});
+		await replacement;
+
+		expect(deleted.deleted).toBe(true);
+		await expect(readJson(root, target)).resolves.toMatchObject({ token: "new" });
 	});
 
 	it("guarded workflow envelope checksum covers final receipt and state_revision", async () => {

--- a/packages/coding-agent/test/runtime-mcp/config-writer.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/config-writer.test.ts
@@ -31,6 +31,33 @@ describe("upsertMCPServer", () => {
 		expect(await getMCPServer(configPath, "alpha")).toEqual(stdio("alpha-bin"));
 	});
 
+	test("does not follow a preexisting predictable temp symlink", async () => {
+		const predictableTmp = `${configPath}.tmp`;
+		const victimPath = path.join(tmpDir, "victim.txt");
+		await fs.writeFile(victimPath, "keep me", "utf-8");
+		await fs.symlink(victimPath, predictableTmp);
+
+		const result = await upsertMCPServer(configPath, "alpha", stdio("alpha-bin"));
+
+		expect(result).toEqual({ status: "added" });
+		expect(await getMCPServer(configPath, "alpha")).toEqual(stdio("alpha-bin"));
+		expect(await fs.readFile(victimPath, "utf-8")).toBe("keep me");
+	});
+
+	test("rejects writes through a symlinked config parent", async () => {
+		const projectDir = path.join(tmpDir, "project");
+		const externalDir = path.join(tmpDir, "external");
+		const symlinkDir = path.join(projectDir, ".gjc");
+		await fs.mkdir(projectDir, { recursive: true });
+		await fs.mkdir(externalDir, { recursive: true });
+		await fs.symlink(externalDir, symlinkDir);
+
+		await expect(upsertMCPServer(path.join(symlinkDir, "mcp.json"), "alpha", stdio("alpha-bin"))).rejects.toThrow(
+			"Refusing to write MCP config through non-directory or symlink parent",
+		);
+		await expect(fs.stat(path.join(externalDir, "mcp.json"))).rejects.toThrow();
+	});
+
 	test("skips an existing server without force and does not overwrite", async () => {
 		await upsertMCPServer(configPath, "alpha", stdio("alpha-bin"));
 		const result = await upsertMCPServer(configPath, "alpha", stdio("changed-bin"));

--- a/packages/coding-agent/test/runtime-mcp/config.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/config.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadAllMCPConfigs } from "../../src/runtime-mcp/config";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+	tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-config-defaults-"));
+	await Bun.write(
+		path.join(tmpDir, ".mcp.json"),
+		`${JSON.stringify(
+			{
+				mcpServers: {
+					project_auto: { command: "project-auto" },
+					project_manual: { command: "project-manual", autoload: false },
+				},
+			},
+			null,
+			2,
+		)}\n`,
+	);
+});
+
+afterEach(async () => {
+	await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("loadAllMCPConfigs security defaults", () => {
+	test("excludes project configs and non-autoload servers unless explicitly enabled", async () => {
+		const safeDefault = await loadAllMCPConfigs(tmpDir);
+		expect(safeDefault.configs.project_auto).toBeUndefined();
+		expect(safeDefault.configs.project_manual).toBeUndefined();
+
+		const projectEnabled = await loadAllMCPConfigs(tmpDir, { enableProjectConfig: true });
+		expect(projectEnabled.configs.project_auto).toHaveProperty("command", "project-auto");
+		expect(projectEnabled.configs.project_manual).toBeUndefined();
+
+		const projectAll = await loadAllMCPConfigs(tmpDir, { enableProjectConfig: true, autoloadOnly: false });
+		expect(projectAll.configs.project_auto).toHaveProperty("command", "project-auto");
+		expect(projectAll.configs.project_manual).toHaveProperty("command", "project-manual");
+	});
+});

--- a/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadAllMCPConfigs } from "../../src/runtime-mcp/config";
 import { MCPManager } from "../../src/runtime-mcp/manager";
 import type { JsonRpcMessage } from "../../src/runtime-mcp/types";
+import type { AuthStorage } from "../../src/session/auth-storage";
 
 async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 3_000): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
@@ -48,6 +53,26 @@ setInterval(() => {}, 1000);
 `;
 }
 
+function envCaptureServerScript(outputPath: string, envName = "API_KEY"): string {
+	return `
+const fs = require('node:fs');
+const readline = require('node:readline');
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', line => {
+  const msg = JSON.parse(line);
+  if (msg.method === 'initialize') {
+    fs.writeFileSync(${JSON.stringify(outputPath)}, process.env[${JSON.stringify(envName)}] || '');
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { protocolVersion: '2025-03-26', capabilities: { tools: {} }, serverInfo: { name: 'test', version: '1' }, instructions: 'project-controlled instructions' } }) + '\\n');
+  } else if (msg.method === 'tools/list') {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { tools: [] } }) + '\\n');
+  } else if (msg.id !== undefined) {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} }) + '\\n');
+  }
+});
+setInterval(() => {}, 1000);
+`;
+}
+
 describe("MCP manager lifecycle cleanup", () => {
 	test("initial listTools failure closes transport and does not register server", async () => {
 		const manager = new MCPManager(process.cwd());
@@ -62,6 +87,148 @@ describe("MCP manager lifecycle cleanup", () => {
 		expect(result.errors.get("bad")).toContain("boom");
 		expect(manager.getConnectedServers()).toEqual([]);
 		await expect(manager.waitForConnection("bad")).rejects.toThrow("MCP server not connected: bad");
+	});
+
+	test("does not resolve project MCP env references or expose project server instructions", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-project-source-"));
+		const capturePath = path.join(tempDir, "captured-env.txt");
+		const previous = process.env.SECRET_FOR_MCP;
+		process.env.SECRET_FOR_MCP = "leaked-secret";
+		const manager = new MCPManager(process.cwd());
+		try {
+			const result = await manager.connectServers(
+				{
+					projected: {
+						command: process.execPath,
+						args: ["-e", envCaptureServerScript(capturePath)],
+						env: { API_KEY: "SECRET_FOR_MCP" },
+						timeout: 1_000,
+					},
+				},
+				{
+					projected: {
+						provider: "test",
+						providerName: "Test Project",
+						path: path.join(tempDir, ".mcp.json"),
+						level: "project",
+					},
+				},
+			);
+
+			expect(result.errors.size).toBe(0);
+			expect(await Bun.file(capturePath).text()).toBe("SECRET_FOR_MCP");
+			expect(manager.getServerInstructions().size).toBe(0);
+		} finally {
+			if (previous === undefined) delete process.env.SECRET_FOR_MCP;
+			else process.env.SECRET_FOR_MCP = previous;
+			await manager.disconnectAll();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("project MCP stdio servers do not inherit unrelated host environment", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-project-no-inherit-"));
+		const capturePath = path.join(tempDir, "captured-secret.txt");
+		const previous = process.env.SECRET_FOR_MCP;
+		process.env.SECRET_FOR_MCP = "host-secret";
+		const manager = new MCPManager(tempDir);
+		try {
+			await Bun.write(
+				path.join(tempDir, ".mcp.json"),
+				`${JSON.stringify({
+					mcpServers: {
+						projected: {
+							command: process.execPath,
+							args: ["-e", envCaptureServerScript(capturePath, "SECRET_FOR_MCP")],
+						},
+					},
+				})}\n`,
+			);
+			const { configs, sources } = await loadAllMCPConfigs(tempDir, { enableProjectConfig: true });
+			expect(configs.projected).toHaveProperty("noInheritEnv", true);
+
+			const result = await manager.connectServers(configs, sources);
+
+			expect(result.errors.size).toBe(0);
+			expect(await Bun.file(capturePath).text()).toBe("");
+		} finally {
+			if (previous === undefined) delete process.env.SECRET_FOR_MCP;
+			else process.env.SECRET_FOR_MCP = previous;
+			await manager.disconnectAll();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("does not inject stored OAuth credentials into project MCP servers", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-project-oauth-"));
+		const capturePath = path.join(tempDir, "captured-oauth.txt");
+		const lookups: string[] = [];
+		const manager = new MCPManager(process.cwd());
+		manager.setAuthStorage({
+			get(provider: string) {
+				lookups.push(provider);
+				return { type: "oauth", access: "secret-token", refresh: "refresh-token", expires: Date.now() + 60_000 };
+			},
+			async set() {
+				throw new Error("project OAuth credentials must not refresh");
+			},
+		} as unknown as AuthStorage);
+		try {
+			const result = await manager.connectServers(
+				{
+					projected: {
+						command: process.execPath,
+						args: ["-e", envCaptureServerScript(capturePath, "OAUTH_ACCESS_TOKEN")],
+						auth: { type: "oauth", credentialId: "project-secret" },
+						timeout: 1_000,
+					},
+				},
+				{
+					projected: {
+						provider: "test",
+						providerName: "Test Project",
+						path: path.join(tempDir, ".mcp.json"),
+						level: "project",
+					},
+				},
+			);
+
+			expect(result.errors.size).toBe(0);
+			expect(lookups).toEqual([]);
+			expect(await Bun.file(capturePath).text()).toBe("");
+		} finally {
+			await manager.disconnectAll();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("prepareConfig does not resolve project-source OAuth credentials", async () => {
+		const lookups: string[] = [];
+		const manager = new MCPManager(process.cwd());
+		manager.setAuthStorage({
+			get(provider: string) {
+				lookups.push(provider);
+				return { type: "oauth", access: "secret-token", refresh: "refresh-token", expires: Date.now() + 60_000 };
+			},
+			async set() {
+				throw new Error("project OAuth credentials must not refresh");
+			},
+		} as unknown as AuthStorage);
+
+		const resolved = await manager.prepareConfig(
+			{ command: process.execPath, auth: { type: "oauth", credentialId: "project-secret" } },
+			{
+				provider: "mcp-json",
+				providerName: "Project MCP config",
+				path: path.join(process.cwd(), ".mcp.json"),
+				level: "project",
+			},
+		);
+
+		expect(lookups).toEqual([]);
+		if (resolved.type !== "http" && resolved.type !== "sse") {
+			expect(resolved.env?.OAUTH_ACCESS_TOKEN).toBeUndefined();
+		}
 	});
 
 	test("disconnect cancels an in-flight reconnect backoff", async () => {

--- a/packages/coding-agent/test/runtime-mcp/slash-mcp-add.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/slash-mcp-add.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getConfigRootDir, getMCPConfigPath, setAgentDir } from "@gajae-code/utils";
+import { readMCPConfigFile } from "../../src/runtime-mcp/config-writer";
+import { handleMcpAcp } from "../../src/slash-commands/helpers/mcp";
+import type { SlashCommandRuntime } from "../../src/slash-commands/types";
+
+let tmpDir = "";
+let agentDir = "";
+let projectDir = "";
+
+const originalAgentDir = process.env.GJC_CODING_AGENT_DIR;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+function runtime(): SlashCommandRuntime {
+	return {
+		cwd: projectDir,
+		settings: { get: () => false },
+		output: () => undefined,
+		refreshCommands: () => undefined,
+		reloadPlugins: async () => undefined,
+	} as unknown as SlashCommandRuntime;
+}
+
+describe("ACP MCP add trust boundaries", () => {
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-mcp-acp-add-"));
+		agentDir = path.join(tmpDir, "agent");
+		projectDir = path.join(tmpDir, "project");
+		await fs.mkdir(projectDir, { recursive: true });
+		setAgentDir(agentDir);
+	});
+
+	afterEach(async () => {
+		if (originalAgentDir) {
+			setAgentDir(originalAgentDir);
+		} else {
+			setAgentDir(fallbackAgentDir);
+			delete process.env.GJC_CODING_AGENT_DIR;
+		}
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	test("stores token-bearing quick add in user scope by default", async () => {
+		await handleMcpAcp(
+			{
+				name: "mcp",
+				args: "add remote --url https://example.test/mcp --token secret-token",
+				text: "/mcp add remote --url https://example.test/mcp --token secret-token",
+			},
+			runtime(),
+		);
+
+		const userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
+		const projectConfig = await readMCPConfigFile(getMCPConfigPath("project", projectDir));
+
+		expect(userConfig.mcpServers?.remote).toEqual({
+			type: "http",
+			url: "https://example.test/mcp",
+			headers: { Authorization: "Bearer secret-token" },
+		});
+		expect(projectConfig.mcpServers?.remote).toBeUndefined();
+	});
+
+	test("honors explicit project scope for token-bearing quick add", async () => {
+		await handleMcpAcp(
+			{
+				name: "mcp",
+				args: "add remote --scope project --url https://example.test/mcp --token secret-token",
+				text: "/mcp add remote --scope project --url https://example.test/mcp --token secret-token",
+			},
+			runtime(),
+		);
+
+		const userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
+		const projectConfig = await readMCPConfigFile(getMCPConfigPath("project", projectDir));
+
+		expect(userConfig.mcpServers?.remote).toBeUndefined();
+		expect(projectConfig.mcpServers?.remote).toEqual({
+			type: "http",
+			url: "https://example.test/mcp",
+			headers: { Authorization: "Bearer secret-token" },
+		});
+	});
+});

--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { sessionRuntimeDir } from "../src/gjc-runtime/session-layout";
 import {
 	GJC_COORDINATOR_SESSION_ID_ENV,
 	GJC_COORDINATOR_SESSION_STATE_FILE_ENV,
@@ -19,6 +20,10 @@ async function tempRoot(): Promise<string> {
 	return dir;
 }
 
+function stateFileFor(root: string, sessionId: string): string {
+	return path.join(sessionRuntimeDir(root, sessionId), "state.json");
+}
+
 afterEach(async () => {
 	if (ORIGINAL_STATE_FILE === undefined) delete process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV];
 	else process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = ORIGINAL_STATE_FILE;
@@ -30,7 +35,7 @@ afterEach(async () => {
 describe("coordinator runtime state sidecar", () => {
 	it("persists final assistant text on agent_end", async () => {
 		const root = await tempRoot();
-		const stateFile = path.join(root, "state.json");
+		const stateFile = stateFileFor(root, "fallback");
 		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
 		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "visible-session";
 
@@ -62,6 +67,29 @@ describe("coordinator runtime state sidecar", () => {
 		});
 	});
 
+	it("ignores env-supplied state files outside the session runtime root", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "outside-state.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "visible-session";
+
+		await persistCoordinatorRuntimeStateFromEvent(
+			{
+				type: "agent_end",
+				messages: [
+					{
+						role: "assistant",
+						content: [{ type: "text", text: "Done from runtime" }],
+						stopReason: "stop",
+					},
+				],
+			},
+			{ sessionId: "fallback", cwd: root, sessionFile: null },
+		);
+
+		expect(await Bun.file(stateFile).exists()).toBe(false);
+	});
+
 	it("recognizes only matching completed or errored runtime markers as terminal", async () => {
 		const root = await tempRoot();
 		const stateFile = path.join(root, "state.json");
@@ -88,6 +116,45 @@ describe("coordinator runtime state sidecar", () => {
 			terminal: false,
 			reason: "session_id_mismatch",
 		});
+	});
+
+	it("rejects terminal markers missing caller-provided cwd or session file bindings", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "session-a",
+				state: "completed",
+			}),
+		);
+
+		await expect(
+			readTerminalRuntimeStateMarker({
+				stateFile,
+				sessionId: "session-a",
+				cwd: root,
+				sessionFile: path.join(root, "session.jsonl"),
+			}),
+		).resolves.toEqual({ terminal: false, reason: "cwd_mismatch" });
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "session-a",
+				state: "completed",
+				cwd: root,
+			}),
+		);
+		await expect(
+			readTerminalRuntimeStateMarker({
+				stateFile,
+				sessionId: "session-a",
+				cwd: root,
+				sessionFile: path.join(root, "session.jsonl"),
+			}),
+		).resolves.toEqual({ terminal: false, reason: "session_file_mismatch" });
 	});
 
 	it("rejects non-terminal and mismatched runtime markers", async () => {

--- a/packages/coding-agent/test/tools/bash-interceptor.test.ts
+++ b/packages/coding-agent/test/tools/bash-interceptor.test.ts
@@ -175,6 +175,23 @@ describe("BashTool restricted role-agent allowlist", () => {
 			"restricted role-agent bash only allows commands starting with",
 		);
 	});
+	it("blocks restricted role-agent cwd outside the session workspace", async () => {
+		const root = await fs.mkdtemp(path.join(process.cwd(), ".tmp-restricted-cwd-root-"));
+		const outside = await fs.mkdtemp(path.join(process.cwd(), ".tmp-restricted-cwd-outside-"));
+		try {
+			const tool = createRestrictedBashTool(root, ["gjc state"]);
+
+			await expect(
+				tool.execute("tool-call", {
+					command: "gjc state read --json",
+					cwd: outside,
+				}),
+			).rejects.toThrow("Restricted role-agent bash cwd must stay within the session workspace");
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+			await fs.rm(outside, { recursive: true, force: true });
+		}
+	});
 
 	it("surfaces read-only bash restrictions in the tool description", () => {
 		const tool = createRestrictedBashTool(process.cwd(), ["grep", "rg", "tree", "ls"], "read-only");
@@ -259,7 +276,52 @@ describe("BashTool restricted role-agent allowlist", () => {
 				command: "gjc ralplan --write --stage architect --stage_n 1 --artifact ok",
 				env: { PATH: "/tmp/fake" },
 			}),
-		).rejects.toThrow("does not allow per-command env overrides");
+		).rejects.toThrow("only allows the GJC_RALPLAN_ARTIFACT env override");
+	});
+
+	it("blocks artifact env overrides when --artifact-env only matches as a substring", async () => {
+		const tool = createRestrictedBashTool();
+
+		await expect(
+			tool.execute("tool-call", {
+				command: "gjc ralplan --write --stage architect --stage_n 1 --artifact-env GJC_RALPLAN_ARTIFACT_EVIL",
+				env: { GJC_RALPLAN_ARTIFACT: "payload" },
+			}),
+		).rejects.toThrow("only allows the GJC_RALPLAN_ARTIFACT env override");
+	});
+
+	it("allows the sanctioned ralplan artifact env override in restricted mode", async () => {
+		const root = await fs.mkdtemp(path.join(process.cwd(), ".tmp-restricted-env-bash-"));
+		try {
+			const cliPath = path.resolve(import.meta.dir, "..", "..", "src", "cli.ts");
+			const bunPath = process.execPath;
+			const tool = createRestrictedBashTool(root, [`${bunPath} ${cliPath} ralplan --write`]);
+			const result = await tool.execute("tool-call", {
+				command: `${bunPath} ${cliPath} ralplan --write --stage critic --stage_n 1 --artifact-env GJC_RALPLAN_ARTIFACT --run-id env-marker --session-id restricted-bash-test`,
+				env: {
+					GJC_RALPLAN_ARTIFACT: '# Review\n\nContains `"studio"`, `use client`, $VALUE, and C:\\tmp.\n',
+				},
+				timeout: 30,
+			});
+
+			expect(result.content.find(part => part.type === "text")?.text).toContain("stage-01-critic.md");
+			const persisted = await fs.readFile(
+				path.join(
+					root,
+					".gjc",
+					sessionDirName("restricted-bash-test"),
+					"plans",
+					"ralplan",
+					"env-marker",
+					"stage-01-critic.md",
+				),
+				"utf-8",
+			);
+			expect(persisted).toContain('Contains `"studio"`, `use client`, $VALUE');
+			expect(persisted).toContain("C:\\tmp");
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
 	});
 
 	it("marks restricted CLI subprocesses so ralplan does not ingest artifact file paths", async () => {

--- a/python/robogjc/src/server.py
+++ b/python/robogjc/src/server.py
@@ -486,6 +486,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         if token != cfg.replay_token.get_secret_value():
             raise HTTPException(401, "invalid replay token")
 
+    def _require_dashboard_token(cfg: Settings, token: str | None) -> None:
+        if cfg.replay_token is None:
+            return
+        if token != cfg.replay_token.get_secret_value():
+            raise HTTPException(401, "invalid replay token")
+
     @app.get("/api/github/issues")
     async def api_github_issues(
         request: Request,
@@ -663,7 +669,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         )
 
     @app.get("/events")
-    async def events(request: Request, limit: int = 50) -> dict[str, Any]:
+    async def events(
+        request: Request,
+        limit: int = 50,
+        x_robogjc_token: str | None = Header(None, alias="X-Robogjc-Replay-Token"),
+    ) -> dict[str, Any]:
+        cfg: Settings = request.app.state.bag["settings"]
+        _require_dashboard_token(cfg, x_robogjc_token)
         rows = request.app.state.bag["db"].list_events(limit=limit)
         return {
             "events": [
@@ -682,7 +694,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         }
 
     @app.get("/issues")
-    async def issues(request: Request, limit: int = 100) -> dict[str, Any]:
+    async def issues(
+        request: Request,
+        limit: int = 100,
+        x_robogjc_token: str | None = Header(None, alias="X-Robogjc-Replay-Token"),
+    ) -> dict[str, Any]:
+        cfg: Settings = request.app.state.bag["settings"]
+        _require_dashboard_token(cfg, x_robogjc_token)
         rows = request.app.state.bag["db"].list_issues(limit=limit)
         return {
             "issues": [
@@ -706,9 +724,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         return HTMLResponse(render_index(cfg.replay_token is not None))
 
     @app.get("/api/status")
-    async def api_status(request: Request) -> dict[str, Any]:
+    async def api_status(
+        request: Request,
+        x_robogjc_token: str | None = Header(None, alias="X-Robogjc-Replay-Token"),
+    ) -> dict[str, Any]:
         bag = request.app.state.bag
         cfg: Settings = bag["settings"]
+        _require_dashboard_token(cfg, x_robogjc_token)
         db: Database = bag["db"]
         pool: WorkerPool = bag["pool"]
         started = float(bag.get("started_at") or time.time())
@@ -772,8 +794,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         }
 
     @app.get("/api/logs")
-    async def api_logs(request: Request, limit: int = 400) -> dict[str, Any]:
+    async def api_logs(
+        request: Request,
+        limit: int = 400,
+        x_robogjc_token: str | None = Header(None, alias="X-Robogjc-Replay-Token"),
+    ) -> dict[str, Any]:
         cfg: Settings = request.app.state.bag["settings"]
+        _require_dashboard_token(cfg, x_robogjc_token)
         capped = max(1, min(int(limit), 2000))
         entries = tail_jsonl(cfg.log_dir / "robogjc.log.jsonl", limit=capped)
         return {"entries": entries, "count": len(entries), "limit": capped}

--- a/python/robogjc/tests/test_server.py
+++ b/python/robogjc/tests/test_server.py
@@ -95,6 +95,42 @@ def test_index_does_not_expose_replay_token(env, monkeypatch: pytest.MonkeyPatch
         close_database()
 
 
+def test_dashboard_read_apis_reject_missing_token_when_replay_enabled(
+    env,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_replay(monkeypatch)
+    cfg = Settings()  # type: ignore[call-arg]
+    cfg.ensure_paths()
+    app = create_app(cfg)
+    try:
+        with TestClient(app) as client:
+            for path in ("/api/status", "/api/logs", "/events", "/issues"):
+                resp = client.get(path)
+                assert resp.status_code == 401, path
+    finally:
+        close_database()
+
+
+def test_dashboard_read_apis_accept_configured_replay_token(
+    env,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _enable_replay(monkeypatch)
+    cfg = Settings()  # type: ignore[call-arg]
+    cfg.ensure_paths()
+    app = create_app(cfg)
+    try:
+        with TestClient(app) as client:
+            _seed_db(cfg)
+            headers = {"X-Robogjc-Replay-Token": token}
+            for path in ("/api/status", "/api/logs", "/events", "/issues"):
+                resp = client.get(path, headers=headers)
+                assert resp.status_code == 200, path
+    finally:
+        close_database()
+
+
 def test_api_status_reports_runtime_counts_and_inflight(settings: Settings) -> None:
     app = create_app(settings)
     with TestClient(app) as client:

--- a/python/robogjc/web/src/api.ts
+++ b/python/robogjc/web/src/api.ts
@@ -50,10 +50,11 @@ function jsonHeaders(): Record<string, string> {
 
 export const api = {
   status(signal?: AbortSignal): Promise<StatusResponse> {
-    return fetch("/api/status", { signal }).then(unwrap<StatusResponse>);
+    return fetch("/api/status", { headers: authHeaders(), signal }).then(unwrap<StatusResponse>);
   },
   logs(limit = 400, signal?: AbortSignal): Promise<LogsResponse> {
-    return fetch(`/api/logs?limit=${limit}`, { signal }).then(unwrap<LogsResponse>);
+    const qs = new URLSearchParams({ limit: String(limit) });
+    return fetch(`/api/logs?${qs.toString()}`, { headers: authHeaders(), signal }).then(unwrap<LogsResponse>);
   },
   browse(state: string, refresh = false, signal?: AbortSignal): Promise<BrowseResponse> {
     const qs = new URLSearchParams({ state, limit: "50" });


### PR DESCRIPTION
## Summary
- Harden restricted bash, extension tool-call timeouts, sidecar state file confinement, and PI subprocess command handling.
- Harden GJC workflow state writes/deletes, invalid phase transitions, and team task API claim/worker/approval boundaries.
- Harden MCP project trust boundaries: project env placeholders remain literal, project stdio avoids host env inheritance, project MCP defaults stay opt-in/autoload-only, token quick-add defaults to user scope, and MCP config writes reject symlink parents.
- Gate robogjc dashboard/status/log/event APIs behind replay auth and send authenticated dashboard requests.

## Verification
- `PATH="/tmp/gjc-fake-bin:$PATH" bun test packages/coding-agent/test/tools/bash-interceptor.test.ts packages/coding-agent/test/extensions-runner.test.ts packages/coding-agent/test/session-state-sidecar.test.ts packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts packages/coding-agent/test/gjc-state-writer-policy.test.ts packages/coding-agent/test/gjc-runtime/team-runtime.test.ts packages/coding-agent/test/contribution-prep.test.ts packages/coding-agent/test/discovery/mcp-json.test.ts packages/coding-agent/test/runtime-mcp/config.test.ts packages/coding-agent/test/runtime-mcp/config-writer.test.ts packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts packages/coding-agent/test/runtime-mcp/slash-mcp-add.test.ts` — 182 pass
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check ...changed files...`
- `python3 -m pytest -x python/robogjc/tests/test_server.py` — 64 passed, 1 upstream StarletteDeprecationWarning
- `bun --cwd=python/robogjc/web run typecheck`
- `ruff check python/robogjc && ruff format --check python/robogjc`

## Note
- Full `bun run lint:py` was not used as a merge gate because unrelated `python/gjc-rpc` files currently have existing Ruff format drift; the touched `python/robogjc` subtree is clean.