### PR TITLE
fix(utils): render usage instead of crashing on invalid CLI args

### DIFF
--- a/packages/utils/src/cli.ts
+++ b/packages/utils/src/cli.ts
@@ -68,6 +68,18 @@ export const Args = {
 	},
 };
 
+/**
+ * Thrown when CLI argument/flag parsing or validation fails (unknown flag,
+ * bad option value, missing required arg, etc.). `run()` catches this to print
+ * the message and render usage instead of crashing as an uncaught exception.
+ */
+export class CliParseError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CliParseError";
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Parse result types — mirrors oclif's typed output from this.parse()
 // ---------------------------------------------------------------------------
@@ -174,12 +186,22 @@ export abstract class Command {
 
 		// strict=false when command declares args (positionals must pass through)
 		// or when the command itself opts out
-		const { values: rawValues, positionals } = nodeParseArgs({
-			args: this.argv,
-			options,
-			allowPositionals: true,
-			strict,
-		});
+		let rawValues: Record<string, string | boolean | Array<string | boolean> | undefined>;
+		let positionals: string[];
+		try {
+			const parsed = nodeParseArgs({
+				args: this.argv,
+				options,
+				allowPositionals: true,
+				strict,
+			});
+			rawValues = parsed.values;
+			positionals = parsed.positionals;
+		} catch (err) {
+			// node:util parseArgs throws on unknown flags / malformed input — surface
+			// it as a CliParseError so run() renders usage instead of crashing.
+			throw new CliParseError(err instanceof Error ? err.message : String(err));
+		}
 
 		// Convert raw values to proper types and validate
 		const flags: Record<string, unknown> = {};
@@ -191,7 +213,7 @@ export abstract class Command {
 				} else {
 					const n = Number.parseInt(raw as string, 10);
 					if (Number.isNaN(n)) {
-						throw new Error(`Expected integer for --${name}, got "${raw}"`);
+						throw new CliParseError(`Expected integer for --${name}, got "${raw}"`);
 					}
 					flags[name] = n;
 				}
@@ -204,14 +226,16 @@ export abstract class Command {
 				// Validate options constraint
 				if (val !== undefined && desc.options && !Array.isArray(val)) {
 					if (!desc.options.includes(val as string)) {
-						throw new Error(`Expected --${name} to be one of: ${[...desc.options].join(", ")}; got "${val}"`);
+						throw new CliParseError(
+							`Expected --${name} to be one of: ${[...desc.options].join(", ")}; got "${val}"`,
+						);
 					}
 				}
 				flags[name] = val;
 			}
 			// Validate required
 			if (desc.required && flags[name] === undefined) {
-				throw new Error(`Missing required flag: --${name}`);
+				throw new CliParseError(`Missing required flag: --${name}`);
 			}
 		}
 
@@ -230,13 +254,15 @@ export abstract class Command {
 			}
 			// Validate required
 			if (desc.required && args[argName] === undefined) {
-				throw new Error(`Missing required argument: ${argName}`);
+				throw new CliParseError(`Missing required argument: ${argName}`);
 			}
 			// Validate options constraint
 			const argVal = args[argName];
 			if (argVal !== undefined && desc.options && typeof argVal === "string") {
 				if (!desc.options.includes(argVal)) {
-					throw new Error(`Expected ${argName} to be one of: ${[...desc.options].join(", ")}; got "${argVal}"`);
+					throw new CliParseError(
+						`Expected ${argName} to be one of: ${[...desc.options].join(", ")}; got "${argVal}"`,
+					);
 				}
 			}
 		}
@@ -425,7 +451,19 @@ export async function run(opts: RunOptions): Promise<void> {
 	const Cmd = await entry.load();
 	const config: CliConfig = { bin, version, commands: new Map([[entry.name, Cmd]]) };
 	const instance = new Cmd(commandArgv, config);
-	await instance.run();
+	try {
+		await instance.run();
+	} catch (err) {
+		if (err instanceof CliParseError) {
+			// Invalid args/flags for a real command: print the problem + usage and
+			// exit with a usage error, instead of crashing as an uncaught exception.
+			process.stderr.write(`${err.message}\n\n`);
+			renderCommandHelp(bin, entry.name, Cmd);
+			process.exitCode = 2;
+			return;
+		}
+		throw err;
+	}
 }
 
 /** Resolve all command loaders for help/alias display. */

--- a/packages/utils/test/cli.test.ts
+++ b/packages/utils/test/cli.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import { Args, type CliConfig, CliParseError, Command, type CommandEntry, Flags, run } from "../src/cli";
+
+const CFG: CliConfig = { bin: "gjc", version: "1.0.0", commands: new Map() };
+
+// A command with a constrained positional action and a constrained flag, mirroring
+// the real `plugin` command that surfaced the crash (`gjc plugin help`).
+class Demo extends Command {
+	static description = "demo command";
+	static args = {
+		action: Args.string({ description: "action", required: false, options: ["build", "clean"] }),
+	};
+	static flags = {
+		scope: Flags.string({ description: "scope", options: ["user", "project"] }),
+	};
+	async run(): Promise<void> {
+		const { args } = await this.parse(Demo);
+		sideEffect.ran = true;
+		sideEffect.action = (args.action as string) ?? "(default)";
+	}
+}
+
+class Boom extends Command {
+	static description = "throws a non-parse error";
+	async run(): Promise<void> {
+		throw new Error("boom: genuine runtime failure");
+	}
+}
+
+const sideEffect: { ran: boolean; action?: string } = { ran: false };
+const commands: CommandEntry[] = [
+	{ name: "demo", load: async () => Demo },
+	{ name: "boom", load: async () => Boom },
+];
+
+/** Run the CLI while capturing stdout/stderr and isolating process.exitCode. */
+async function runCapturing(
+	argv: string[],
+): Promise<{ out: string; err: string; exitCode: number | string | undefined }> {
+	const origOut = process.stdout.write.bind(process.stdout);
+	const origErr = process.stderr.write.bind(process.stderr);
+	const origExit = process.exitCode;
+	let out = "";
+	let err = "";
+	type Writer = { write: (s: string) => boolean };
+	(process.stdout as unknown as Writer).write = (s: string) => {
+		out += String(s);
+		return true;
+	};
+	(process.stderr as unknown as Writer).write = (s: string) => {
+		err += String(s);
+		return true;
+	};
+	try {
+		process.exitCode = 0; // clean baseline so "left unset by run()" reads back as 0
+		await run({ bin: "gjc", version: "1.0.0", argv, commands });
+		return { out, err, exitCode: process.exitCode };
+	} finally {
+		process.stdout.write = origOut;
+		process.stderr.write = origErr;
+		process.exitCode = origExit;
+	}
+}
+
+describe("cli parse — CliParseError for invalid input", () => {
+	it("throws CliParseError for a positional action outside its options", async () => {
+		const cmd = new Demo(["help"], CFG); // e.g. `gjc plugin help`
+		await expect(cmd.parse(Demo)).rejects.toBeInstanceOf(CliParseError);
+		await expect(cmd.parse(Demo)).rejects.toThrow(/Expected action to be one of: build, clean; got "help"/);
+	});
+
+	it("throws CliParseError for a flag value outside its options", async () => {
+		const cmd = new Demo(["build", "--scope", "porject"], CFG);
+		await expect(cmd.parse(Demo)).rejects.toBeInstanceOf(CliParseError);
+		await expect(cmd.parse(Demo)).rejects.toThrow(/Expected --scope to be one of: user, project/);
+	});
+
+	it("wraps node:util unknown-flag errors as CliParseError (strict command)", async () => {
+		class Strict extends Command {
+			static flags = { verbose: Flags.boolean({}) };
+			async run(): Promise<void> {
+				await this.parse(Strict);
+			}
+		}
+		const cmd = new Strict(["--nope"], CFG);
+		await expect(cmd.parse(Strict)).rejects.toBeInstanceOf(CliParseError);
+	});
+
+	it("accepts a valid action", async () => {
+		const cmd = new Demo(["build"], CFG);
+		const { args } = await cmd.parse(Demo);
+		expect(args.action).toBe("build");
+	});
+});
+
+describe("cli run — usage instead of uncaught crash", () => {
+	it("renders usage + exits 2 (no throw) when a command gets an invalid action", async () => {
+		sideEffect.ran = false;
+		const { err, out, exitCode } = await runCapturing(["demo", "help"]);
+		expect(err).toContain(`Expected action to be one of: build, clean; got "help"`);
+		expect(out.toLowerCase()).toContain("usage"); // renderCommandHelp printed the command usage
+		expect(exitCode).toBe(2);
+		expect(sideEffect.ran).toBe(false); // command body never ran
+	});
+
+	it("runs the command normally for valid input and leaves exitCode unset", async () => {
+		sideEffect.ran = false;
+		const { exitCode } = await runCapturing(["demo", "build"]);
+		expect(sideEffect.ran).toBe(true);
+		expect(sideEffect.action).toBe("build");
+		expect(exitCode).toBe(0);
+	});
+
+	it("still propagates genuine (non-parse) runtime errors", async () => {
+		await expect(runCapturing(["boom"])).rejects.toThrow(/boom: genuine runtime failure/);
+	});
+});


### PR DESCRIPTION
## Summary

`gjc <cmd>` with an out-of-range **positional action** or **flag value** crashes the process with an uncaught exception + stack dump (and an error-level `"Uncaught exception"` log) instead of printing usage.

Concrete repro:
```sh
gjc plugin help
# Error: Expected action to be one of: install, uninstall, list, ...; got "help"
#     at parse (/$bunfs/root/gjc-linux-x64:...)   → uncaught → exit 1
```
`help` (or any unknown action/flag value) is a natural thing to type; it should show usage, not crash. Surfaced via dogfooding logs (`~/.gjc/logs`).

## Root cause

- `Command.parse()` (`packages/utils/src/cli.ts`) throws a plain `Error` when a positional/flag value isn't in its `options` allowlist (and `node:util` `parseArgs` throws on unknown flags in strict mode).
- `run()` calls `await instance.run()` (which triggers `parse()`) with **no try/catch**, so the throw propagates to the top-level `await runCli(...)` → postmortem's `uncaughtException` handler logs an error and `process.exit(1)`.
- Only `--help`/`-h` route to per-command help; a bare `help` token doesn't, so `plugin help` hits the options-validation throw.

(Note: `plugin-cli.ts` already handles unknown actions gracefully, but the oclif-style `Command.parse` validation throws first, bypassing it.)

## Fix

- Add `CliParseError`; throw it for all arg/flag validation failures and wrap `node:util` `parseArgs` errors in it.
- `run()` catches `CliParseError`: print the message + render the command's usage, set `process.exitCode = 2`. **Genuine (non-parse) runtime errors still propagate unchanged**, so real bugs aren't masked.

This converts the crash class into a clean usage error across every command with an `options` allowlist (also fixes the `Unknown option` unknown-flag crash).

## Verification

- `bun --cwd=packages/utils test` — **122 pass / 0 fail** (incl. new `test/cli.test.ts`)
- `bun --cwd=packages/utils run check:types` — clean (tsgo)
- `biome check src/cli.ts test/cli.test.ts` — clean

New `packages/utils/test/cli.test.ts` covers: `parse()` throws `CliParseError` for bad action / bad flag value / unknown flag; `run()` renders usage + exit 2 without throwing on invalid input; valid input still runs; non-parse runtime errors still propagate.

## Possible follow-up (not in this PR)

Route a leading `help` token (`gjc <cmd> help`) to per-command help like `--help`, so it exits 0 with help rather than exit 2 with a usage error. Kept out to keep this change focused on the crash.
