### PR TITLE
fix(discovery): register the claude-plugins provider so marketplace plugin commands/skills load

### DIFF
--- a/packages/coding-agent/src/discovery/index.ts
+++ b/packages/coding-agent/src/discovery/index.ts
@@ -22,6 +22,7 @@ import "../capability/tool";
 // Import providers (each registers itself on import)
 import "./agents-md";
 import "./builtin";
+import "./claude-plugins";
 import "./cline";
 import "./agents";
 import "./cursor";


### PR DESCRIPTION
## Summary

`discovery/index.ts` is the barrel that wires every capability provider by importing it for its top-level `registerProvider()` side effects. The **GJC Marketplace provider** (`discovery/claude-plugins.ts`) is missing from that import list, so it is **never registered in the running app** — it only self-registers on import, and nothing in the production path imports it (only test files do).

### Consequence

Installed marketplace (`.claude-plugin`) plugins contribute **nothing** to a session. Their `commands/*.md`, skills, hooks, tools, and `.mcp.json` servers are all silently dropped. So `gjc plugin install <name>@<marketplace>` "succeeds", the plugin shows in `gjc plugin list`, but its `/<plugin>:<command>` slash commands never appear in any session — regardless of restart.

### Evidence (verified on 0.8.2)

Drove `gjc acp` over ndjson stdio and read `available_commands_update` after `initialize` + `session/new`:

- **Before:** 27 commands advertised — only builtins + native `skill:*`. **Zero** marketplace-plugin commands, for every installed plugin (`oh-my-gjc:*`, `codex-cli-control:ask`, `insane-review:review`, …).
- Copying a plugin command into the native dir (`~/.gjc/agent/commands/`) makes it appear immediately — confirming the capability loading works; only the provider registration is missing.

### Why this is a fix, not a behavior change

The `claude-plugins` provider is **intended to be active**. The test suite exercises it by importing the module manually and asserting it loads the surfaces:

- `test/discovery/claude-plugins.test.ts` — `import "@gajae-code/coding-agent/discovery/claude-plugins";`
- `test/gjc-plugin-no-surface.test.ts` — `import "../src/discovery/claude-plugins";`, then `loadCapability(slashCommandCapability.id, { providers: ["claude-plugins"] })` and asserts marketplace plugins load while `gajae-plugin.json` roots are excluded.
- `test/issue-851-repro.test.ts` — `import "@gajae-code/coding-agent/discovery/claude-plugins";` for marketplace `.mcp.json` loading.

Those tests pass because they import the provider themselves. Production never does. This PR adds the one missing barrel import so the running app matches what the tests already assume. The `rootContainsGjcManifest` guard that keeps native `gajae-plugin.json` roots from double-surfacing lives inside `claude-plugins.ts` itself, so the no-surface guarantee is preserved.

## Change

```diff
 // Import providers (each registers itself on import)
 import "./agents-md";
 import "./builtin";
+import "./claude-plugins";
 import "./cline";
```

## Test plan

- [ ] Existing `test/discovery/claude-plugins.test.ts`, `test/gjc-plugin-no-surface.test.ts`, `test/issue-851-repro.test.ts` still pass (they import the provider directly, so they are unaffected).
- [ ] Optional regression guard: after `import "@gajae-code/coding-agent/discovery"` (the barrel), `getProviderInfo("claude-plugins")` is defined and its `capabilities` include the slash-command and skill capability ids.
- [ ] Manual: install a marketplace plugin with a `commands/*.md`, start a session, confirm `/<plugin>:<command>` now appears in the palette.

I verified the runtime gap empirically via ACP (above) and the provider's behavior via the existing tests; I did not rebuild the release binary.
