### PR TITLE
Restore /changelog slash command

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored `/changelog` as a built-in slash command, including autocomplete and `/changelog --full`/`/changelog full`, so the What's New prompt no longer points at a missing command.
+
 ## [0.8.2] - 2026-07-06
 ### Added
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -540,7 +540,7 @@ export class CommandController {
 		const title = showFull ? "Full Changelog" : "Recent Changes";
 		const hint = showFull
 			? ""
-			: `\n\n${theme.fg("dim", "Use")} ${theme.bold("/changelog full")} ${theme.fg("dim", "to view the complete changelog.")}`;
+			: `\n\n${theme.fg("dim", "Use")} ${theme.bold("/changelog --full")} ${theme.fg("dim", "to view the complete changelog.")}`;
 
 		this.ctx.chatContainer.addChild(new Spacer(1));
 		this.ctx.chatContainer.addChild(new DynamicBorder());

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -32,6 +32,7 @@ import {
 	parseProviderCompatibility,
 } from "../setup/provider-onboarding";
 import { parseThinkingLevel } from "../thinking";
+import { getDisplayChangelogEntries } from "../utils/changelog";
 import { buildContextReportText } from "./helpers/context-report";
 import { buildFastStatusReport } from "./helpers/fast-status-report";
 import { formatDuration } from "./helpers/format";
@@ -382,6 +383,30 @@ function refreshStatusLine(ctx: InteractiveModeContext): void {
 	ctx.statusLine.invalidate();
 	ctx.updateEditorTopBorder();
 	ctx.ui.requestRender();
+}
+
+type ChangelogCommandArgs = { showFull: boolean } | { error: string };
+
+function parseChangelogCommandArgs(args: string): ChangelogCommandArgs {
+	const normalized = args.trim().toLowerCase();
+	if (!normalized) return { showFull: false };
+	if (normalized === "full" || normalized === "--full") return { showFull: true };
+	return { error: "Usage: /changelog [full|--full]" };
+}
+
+function buildChangelogCommandOutput(showFull: boolean): string {
+	const allEntries = getDisplayChangelogEntries();
+	const entriesToShow = showFull ? allEntries : allEntries.slice(0, 3);
+	const changelogMarkdown =
+		entriesToShow.length > 0
+			? [...entriesToShow]
+					.reverse()
+					.map(entry => entry.content)
+					.join("\n\n")
+			: "No changelog entries found.";
+	const title = showFull ? "Full Changelog" : "Recent Changes";
+	const hint = showFull ? "" : "\n\nUse `/changelog --full` to view the complete changelog.";
+	return `${title}\n\n${changelogMarkdown}${hint}`;
 }
 
 const shutdownHandlerTui = (_command: ParsedSlashCommand, runtime: TuiSlashCommandRuntime): SlashCommandResult => {
@@ -819,6 +844,29 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 		handleTui: async (_command, runtime) => {
 			await runtime.ctx.handleUsageCommand();
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "changelog",
+		description: "Show release notes and changelog entries",
+		inlineHint: "[full|--full]",
+		subcommands: [{ name: "full", description: "Show complete changelog" }],
+		allowArgs: true,
+		handle: async (command, runtime) => {
+			const parsed = parseChangelogCommandArgs(command.args);
+			if ("error" in parsed) return usage(parsed.error, runtime);
+			await runtime.output(buildChangelogCommandOutput(parsed.showFull));
+			return commandConsumed();
+		},
+		handleTui: async (command, runtime) => {
+			const parsed = parseChangelogCommandArgs(command.args);
+			if ("error" in parsed) {
+				runtime.ctx.showError(parsed.error);
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			await runtime.ctx.handleChangelogCommand(parsed.showFull);
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -313,6 +313,24 @@ describe("ACP builtin slash commands", () => {
 		expect(result).toBe(false);
 	});
 
+	it("changelog: advertises and renders recent or full changelog output", async () => {
+		const advertised = ACP_BUILTIN_SLASH_COMMANDS.find(command => command.name === "changelog");
+		expect(advertised?.description).toBe("Show release notes and changelog entries");
+		expect(advertised?.input?.hint).toBe("[full|--full]");
+
+		const recent = createRuntime();
+		await expect(executeAcpBuiltinSlashCommand("/changelog", recent.runtime)).resolves.toEqual({ consumed: true });
+		expect(recent.output[0]).toContain("Recent Changes");
+		expect(recent.output[0]).toContain("Use `/changelog --full`");
+
+		const full = createRuntime();
+		await expect(executeAcpBuiltinSlashCommand("/changelog --full", full.runtime)).resolves.toEqual({
+			consumed: true,
+		});
+		expect(full.output[0]).toContain("Full Changelog");
+		expect(full.output[0]).not.toContain("Use `/changelog --full`");
+	});
+
 	// /jobs
 	it("jobs: shows informative message when snapshot is null", async () => {
 		const { output, runtime } = createRuntime();
@@ -641,7 +659,6 @@ describe("ACP builtin slash commands", () => {
 			"/tree",
 			"/branch",
 			"/browser",
-			"/changelog",
 			"/plan",
 			"/share",
 			"/hotkeys",

--- a/packages/coding-agent/test/slash-command-builtin-registry.test.ts
+++ b/packages/coding-agent/test/slash-command-builtin-registry.test.ts
@@ -82,6 +82,68 @@ describe("builtin /copy slash command", () => {
 	});
 });
 
+function createChangelogTuiRuntime() {
+	const handleChangelogCommand = vi.fn(async (_showFull?: boolean) => {});
+	const showError = vi.fn();
+	const setText = vi.fn();
+	const ctx = {
+		handleChangelogCommand,
+		showError,
+		editor: { setText },
+	} as unknown as InteractiveModeContext;
+
+	return {
+		runtime: { ctx, handleBackgroundCommand: () => undefined },
+		handleChangelogCommand,
+		showError,
+		setText,
+	};
+}
+
+describe("builtin /changelog slash command", () => {
+	it("is discoverable with full-history completion metadata", () => {
+		const changelogCommand = BUILTIN_SLASH_COMMAND_DEFS.find(command => command.name === "changelog");
+
+		expect(changelogCommand).toBeDefined();
+		expect(changelogCommand?.description).toBe("Show release notes and changelog entries");
+		expect(changelogCommand?.inlineHint).toBe("[full|--full]");
+		expect(changelogCommand?.subcommands?.map(command => command.name)).toEqual(["full"]);
+	});
+
+	it("dispatches /changelog to the existing TUI changelog controller path", async () => {
+		const { runtime, handleChangelogCommand, showError, setText } = createChangelogTuiRuntime();
+
+		const result = await executeBuiltinSlashCommand("/changelog", runtime);
+
+		expect(result).toBe(true);
+		expect(handleChangelogCommand).toHaveBeenCalledWith(false);
+		expect(showError).not.toHaveBeenCalled();
+		expect(setText).toHaveBeenCalledWith("");
+	});
+
+	it("accepts full and --full changelog arguments", async () => {
+		const shortForm = createChangelogTuiRuntime();
+		const longForm = createChangelogTuiRuntime();
+
+		expect(await executeBuiltinSlashCommand("/changelog full", shortForm.runtime)).toBe(true);
+		expect(await executeBuiltinSlashCommand("/changelog --full", longForm.runtime)).toBe(true);
+
+		expect(shortForm.handleChangelogCommand).toHaveBeenCalledWith(true);
+		expect(longForm.handleChangelogCommand).toHaveBeenCalledWith(true);
+	});
+
+	it("rejects unknown changelog arguments locally instead of falling through", async () => {
+		const { runtime, handleChangelogCommand, showError, setText } = createChangelogTuiRuntime();
+
+		const result = await executeBuiltinSlashCommand("/changelog nope", runtime);
+
+		expect(result).toBe(true);
+		expect(handleChangelogCommand).not.toHaveBeenCalled();
+		expect(showError).toHaveBeenCalledWith("Usage: /changelog [full|--full]");
+		expect(setText).toHaveBeenCalledWith("");
+	});
+});
+
 function createGoalTuiRuntime(goalModeEnabled: boolean) {
 	const handleGoalModeCommand = vi.fn(async () => {});
 	const addToHistory = vi.fn();


### PR DESCRIPTION
## Summary
- restore `/changelog` as a built-in slash command for the What's New prompt
- support `/changelog`, `/changelog full`, and `/changelog --full` in TUI and ACP/text mode
- add autocomplete metadata and regression coverage

## Verification
- `bun test packages/coding-agent/test/slash-command-builtin-registry.test.ts packages/coding-agent/test/acp-builtins.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/slash-commands/builtin-registry.ts packages/coding-agent/src/modes/controllers/command-controller.ts packages/coding-agent/test/slash-command-builtin-registry.test.ts packages/coding-agent/test/acp-builtins.test.ts`
- `git diff --check`

Supersedes #1680, which was closed because it initially targeted `main`.