### PR TITLE
Add /clear slash command preserving session ID

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added a `/clear` slash command that clears the active conversation context while preserving the current session id and durable session history (#1677).
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -935,6 +935,42 @@ export class CommandController {
 		await this.#runNewSessionFlow();
 	}
 
+	async handleContextClearCommand(): Promise<void> {
+		if (this.ctx.loadingAnimation) {
+			this.ctx.loadingAnimation.stop();
+			this.ctx.loadingAnimation = undefined;
+		}
+		this.ctx.statusContainer.clear();
+
+		if (this.ctx.session.isCompacting) {
+			this.ctx.session.abortCompaction();
+			while (this.ctx.session.isCompacting) {
+				await Bun.sleep(10);
+			}
+		}
+		if (!(await this.ctx.session.clearContext())) return;
+		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+
+		this.ctx.statusLine.invalidate();
+		this.ctx.statusLine.setSessionStartTime(Date.now());
+		this.ctx.updateEditorTopBorder();
+		this.ctx.updateEditorBorderColor();
+		this.ctx.ui.requestRender();
+
+		this.ctx.chatContainer.clear();
+		this.ctx.pendingMessagesContainer.clear();
+		this.ctx.compactionQueuedMessages = [];
+		this.ctx.streamingComponent = undefined;
+		this.ctx.streamingMessage = undefined;
+		this.ctx.pendingTools.clear();
+
+		this.ctx.chatContainer.addChild(
+			new Text(`${theme.fg("accent", `${theme.status.success} Context cleared`)}`, 1, 0),
+		);
+		await this.ctx.reloadTodos();
+		this.ctx.ui.requestRender();
+	}
+
 	async handleDropCommand(): Promise<void> {
 		if (!this.ctx.sessionManager.getSessionFile()) {
 			this.ctx.showError("Nothing to drop (in-memory session)");

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2363,6 +2363,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#commandController.handleClearCommand();
 	}
 
+	handleContextClearCommand(): Promise<void> {
+		this.#prepareSessionSwitch();
+		return this.#commandController.handleContextClearCommand();
+	}
+
 	handleDropCommand(): Promise<void> {
 		this.#prepareSessionSwitch();
 		return this.#commandController.handleDropCommand();

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -216,6 +216,7 @@ export interface InteractiveModeContext {
 	handleDumpCommand(): void;
 	handleDebugTranscriptCommand(): Promise<void>;
 	handleClearCommand(): Promise<void>;
+	handleContextClearCommand(): Promise<void>;
 	handleDropCommand(): Promise<void>;
 	handleForkCommand(): Promise<void>;
 	handleBashCommand(command: string, excludeFromContext?: boolean): Promise<void>;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1736,6 +1736,16 @@ export class AgentSession {
 		manager.cancelAll({ ownerId: this.#agentId });
 	}
 
+	#suppressOwnAsyncJobDeliveries(): void {
+		if (!this.#agentId) return;
+		const manager = AsyncJobManager.instance();
+		if (!manager) return;
+		const pendingJobIds = manager.getDeliveryState({ ownerId: this.#agentId }).pendingJobIds;
+		if (pendingJobIds.length > 0) {
+			manager.acknowledgeDeliveries(pendingJobIds);
+		}
+	}
+
 	// =========================================================================
 	// Event Subscription
 	// =========================================================================
@@ -6094,6 +6104,41 @@ export class AgentSession {
 			});
 		}
 
+		return true;
+	}
+
+	/**
+	 * Clear active conversational/model context while preserving the current
+	 * session identity and durable history trail.
+	 */
+	async clearContext(): Promise<boolean> {
+		const sessionId = this.sessionId;
+		this.#disconnectFromAgent();
+		await this.abort();
+		this.#cancelOwnAsyncJobs();
+		this.#suppressOwnAsyncJobDeliveries();
+		this.yieldQueue.clear();
+		this.#pendingBackgroundExchanges = [];
+		this.#closeAllProviderSessions("context clear");
+		this.agent.reset();
+		await this.sessionManager.flush();
+		this.sessionManager.appendContextClearEntry({ sessionId });
+		this.setTodoPhases([]);
+		this.#syncAgentSessionId(sessionId);
+		this.#steeringMessages = [];
+		this.#followUpMessages = [];
+		this.#pendingNextTurnMessages = [];
+		this.#scheduledHiddenNextTurnGeneration = undefined;
+
+		this.sessionManager.appendThinkingLevelChange(this.thinkingLevel);
+		if (this.model) {
+			this.sessionManager.appendModelChange(`${this.model.provider}/${this.model.id}`);
+		}
+		this.sessionManager.appendServiceTierChange(this.serviceTier ?? null);
+		this.#todoReminderCount = 0;
+		this.#planReferenceSent = false;
+		this.#planReferencePath = "local://PLAN.md";
+		this.#reconnectToAgent();
 		return true;
 	}
 

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -3958,6 +3958,25 @@ export class SessionManager {
 	}
 
 	/**
+	 * Append a root marker that starts a fresh active branch without changing the
+	 * session id or deleting earlier durable entries. Subsequent messages descend
+	 * from this marker, so provider context is clear while history remains
+	 * available for diagnostics/export.
+	 */
+	appendContextClearEntry(data?: Record<string, unknown>): string {
+		const entry: CustomEntry = {
+			type: "custom",
+			customType: "context_clear",
+			data,
+			id: generateId(this.#byId),
+			parentId: null,
+			timestamp: new Date().toISOString(),
+		};
+		this.#appendEntry(entry);
+		return entry.id;
+	}
+
+	/**
 	 * Write mutated message entries back into the canonical entry store by id.
 	 *
 	 * `getBranch()` materializes resident-blob entries into copies, so in-place

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1118,6 +1118,22 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "clear",
+		priority: 97,
+		description: "Clear context while preserving this session ID",
+		acpDescription: "Clear context while preserving this session ID",
+		handle: async (_command, runtime) => {
+			const beforeSessionId = runtime.session.sessionId;
+			await runtime.session.clearContext();
+			await runtime.output(`Context cleared. Session preserved: ${beforeSessionId}`);
+			return commandConsumed();
+		},
+		handleTui: async (_command, runtime) => {
+			runtime.ctx.editor.setText("");
+			await runtime.ctx.handleContextClearCommand();
+		},
+	},
+	{
 		name: "new",
 		priority: 96,
 		description: "Start a new session",

--- a/packages/coding-agent/test/session-manager/session-id.test.ts
+++ b/packages/coding-agent/test/session-manager/session-id.test.ts
@@ -73,3 +73,19 @@ describe("SessionManager session ids", () => {
 		expect(session.getHeader()?.id).toBe(existingId);
 	});
 });
+
+describe("context clear", () => {
+	it("preserves session id while clearing the active branch context", () => {
+		const session = SessionManager.inMemory();
+		const sessionId = expectUuidV7SessionId(session);
+		session.appendMessage({ role: "user", content: "before clear", timestamp: 1 });
+
+		session.appendContextClearEntry({ sessionId });
+		session.appendMessage({ role: "user", content: "after clear", timestamp: 2 });
+
+		expect(session.getSessionId()).toBe(sessionId);
+		expect(session.getHeader()?.id).toBe(sessionId);
+		expect(session.getEntries().filter(entry => entry.type === "message")).toHaveLength(2);
+		expect(session.buildSessionContext().messages).toEqual([{ role: "user", content: "after clear", timestamp: 2 }]);
+	});
+});

--- a/packages/coding-agent/test/slash-command-builtin-registry.test.ts
+++ b/packages/coding-agent/test/slash-command-builtin-registry.test.ts
@@ -24,16 +24,32 @@ function createTuiRuntime() {
 	};
 }
 
+function createClearTuiRuntime() {
+	const handleContextClearCommand = vi.fn(async () => {});
+	const setText = vi.fn();
+	const ctx = {
+		handleContextClearCommand,
+		editor: { setText },
+	} as unknown as InteractiveModeContext;
+
+	return {
+		runtime: { ctx, handleBackgroundCommand: () => undefined },
+		handleContextClearCommand,
+		setText,
+	};
+}
+
 describe("builtin /copy slash command", () => {
-	it("is discoverable as a TUI builtin without public subcommands and does not register /clear", () => {
+	it("is discoverable as a TUI builtin without public subcommands", () => {
 		const copyCommand = BUILTIN_SLASH_COMMAND_DEFS.find(command => command.name === "copy");
+		const clearCommand = BUILTIN_SLASH_COMMAND_DEFS.find(command => command.name === "clear");
 
 		expect(copyCommand).toBeDefined();
 		expect(copyCommand?.description).toBe("Copy the last response for review or sharing");
 		expect(copyCommand?.subcommands).toBeUndefined();
 		expect(copyCommand?.inlineHint).toBeUndefined();
-		expect(BUILTIN_SLASH_COMMAND_DEFS.some(command => command.name === "clear")).toBe(false);
-		expect(BUILTIN_SLASH_COMMANDS_INTERNAL.some(command => command.name === "clear")).toBe(false);
+		expect(clearCommand?.description).toBe("Clear context while preserving this session ID");
+		expect(BUILTIN_SLASH_COMMANDS_INTERNAL.some(command => command.name === "clear")).toBe(true);
 	});
 
 	it("surfaces beginner session commands with clear labels", () => {
@@ -144,6 +160,17 @@ describe("builtin /changelog slash command", () => {
 	});
 });
 
+describe("builtin /clear slash command", () => {
+	it("dispatches to context clear without starting the /new flow", async () => {
+		const { runtime, handleContextClearCommand, setText } = createClearTuiRuntime();
+
+		const result = await executeBuiltinSlashCommand("/clear", runtime);
+
+		expect(result).toBe(true);
+		expect(handleContextClearCommand).toHaveBeenCalled();
+		expect(setText).toHaveBeenCalledWith("");
+	});
+});
 function createGoalTuiRuntime(goalModeEnabled: boolean) {
 	const handleGoalModeCommand = vi.fn(async () => {});
 	const addToHistory = vi.fn();


### PR DESCRIPTION
## Summary
- add a builtin /clear command for ACP and TUI that clears active conversation context without allocating a new session id
- add a root context-clear marker so subsequent provider-visible context starts fresh while prior durable session entries remain available
- suppress owner async deliveries and clear queued background context during clear to avoid stale pre-clear output leaking back in
- cover session-id preservation, active-context reset, durable history retention, and slash-command dispatch in focused tests

## Verification
- bunx biome check CHANGELOG.md src/modes/controllers/command-controller.ts src/modes/interactive-mode.ts src/modes/types.ts src/session/agent-session.ts src/session/session-manager.ts src/slash-commands/builtin-registry.ts test/session-manager/session-id.test.ts test/slash-command-builtin-registry.test.ts
- bun test test/session-manager/session-id.test.ts test/slash-command-builtin-registry.test.ts
- bun run check:types