### PR TITLE
Fix ultragoal nudge receipt freshness

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -449,6 +449,10 @@ function ledgerEventId(event: UltragoalLedgerEvent): string | null {
 	return typeof event.eventId === "string" && event.eventId.trim().length > 0 ? event.eventId : null;
 }
 
+function isReceiptFreshnessBookkeepingEvent(event: UltragoalLedgerEvent): boolean {
+	return event.event === "nudge";
+}
+
 function latestRelevantLedgerEventId(
 	ledger: readonly UltragoalLedgerEvent[],
 	relevantGoalIds: readonly string[],
@@ -458,6 +462,7 @@ function latestRelevantLedgerEventId(
 	for (const event of [...ledger].reverse()) {
 		const eventId = ledgerEventId(event);
 		if (eventId && eventId === excludeEventId) continue;
+		if (isReceiptFreshnessBookkeepingEvent(event)) continue;
 		const goalId = typeof event.goalId === "string" ? event.goalId.trim() : "";
 		if (goalId && relevant.has(goalId)) return eventId;
 	}

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -1556,7 +1556,7 @@ describe("native GJC ultragoal runtime", () => {
 		expect(diagnostic.state).toBe("active_verified_complete");
 	});
 
-	it("treats receipts as stale after goal-scoped ledger events", async () => {
+	it("keeps receipts fresh after same-goalId final receipt nudge but stales after real mutation", async () => {
 		const root = await tempDir();
 		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
 		await startNextUltragoalGoal({ cwd: root });
@@ -1571,17 +1571,33 @@ describe("native GJC ultragoal runtime", () => {
 		await appendTestLedgerEntry(root, {
 			event: "nudge",
 			goalId: "G001",
-			surface: "ask",
-			reason: "goal-scoped post-verification event must invalidate completion freshness",
+			targetKind: "final_aggregate_receipt",
+			surface: "premature_complete",
+			reason: "refusal bookkeeping for stale final aggregate receipt prompt must not invalidate freshness",
 		});
-		const diagnostic = validateCompletionReceipt({
+		const afterRefusalNudge = validateCompletionReceipt({
 			plan,
 			ledger: await readUltragoalLedger(root),
 			goal: plan.goals[0]!,
 			receiptKind: "final-aggregate",
 		});
 
-		expect(diagnostic.state).toBe("active_stale_receipt");
+		expect(afterRefusalNudge.state).toBe("active_verified_complete");
+
+		await appendTestLedgerEntry(root, {
+			event: "goal_checkpointed",
+			goalId: "G001",
+			status: "complete",
+			evidence: "real post-receipt checkpoint mutation must invalidate completion freshness",
+		});
+		const afterMutation = validateCompletionReceipt({
+			plan,
+			ledger: await readUltragoalLedger(root),
+			goal: plan.goals[0]!,
+			receiptKind: "final-aggregate",
+		});
+
+		expect(afterMutation.state).toBe("active_stale_receipt");
 	});
 
 	it("treats receipts as stale after target goal mutation", async () => {


### PR DESCRIPTION
## Summary
- Exclude bookkeeping `nudge` ledger events from ultragoal receipt freshness generation, including same-goal final aggregate refusal nudges.
- Preserve staleness for real same-goal checkpoint mutations.
- Add regression coverage for issue #1687.

Fixes #1687

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts`
- `bun --cwd=packages/coding-agent run check`