### PR TITLE
Cover generated image open replay regression

### DIFF
--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -939,6 +939,42 @@ describe("OpenAI responses history payload", () => {
 		});
 	});
 
+	it("strips image_generation_call action when opening a generated image after incremental replay", async () => {
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "이미지 만들어줘", timestamp: Date.now() },
+				makeAssistantMessage(
+					[
+						{ type: "reasoning", encrypted_content: "enc_image_turn", summary: [] },
+						{
+							type: "image_generation_call",
+							id: "ig_123",
+							status: "generating",
+							action: "generate",
+							background: "opaque",
+							output_format: "png",
+							quality: "medium",
+							revised_prompt: "A safe revised prompt",
+							size: "1024x1536",
+							result: "base64-image-data",
+						},
+					],
+					true,
+				),
+				{ role: "user", content: "이미지 열어봐", timestamp: Date.now() },
+			],
+		};
+		const model = getOpenAIReasoningModel("openai", "gpt-5-mini");
+		const payload = (await captureResponsesPayload(model, context)) as { input?: unknown[] };
+		const imageItem = payload.input?.[2] as Record<string, unknown> | undefined;
+
+		expect(imageItem).toEqual({
+			type: "image_generation_call",
+			status: "generating",
+			result: "base64-image-data",
+		});
+	});
+
 	it("converts orphan function_call_output replayed from providerPayload into an assistant note (issue #1351)", async () => {
 		// Reproduces the symptom: a previous turn's snapshot carries a
 		// `function_call_output` whose matching `function_call` was wiped by an


### PR DESCRIPTION
## Summary

Fixes #1691.

Adds a focused regression test for the smaller real-world workflow behind #1688:

1. User asks for an image (`이미지 만들어줘`).
2. Assistant native Responses history is replayed incrementally and contains a `reasoning` item followed by an `image_generation_call` item.
3. User asks to open/inspect it (`이미지 열어봐`).
4. The replayed image item previously surfaced as `input[2]` with `action: "generate"`, causing:

```text
400 Unknown parameter: 'input[2].action'
```

The test asserts that replay preserves the useful image context (`type`, `status`, `result`) while stripping output/request-only generation fields.

## Verification

- `npx tsc -p packages/ai/tsconfig.json --noEmit --pretty false`
- `npx biome check packages/ai/test/openai-responses-history-payload.test.ts --no-errors-on-unmatched`
