### PR TITLE
Fix composer right-edge gutter

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -106,6 +106,9 @@
 ### Changed
 
 - `web_search` latency overhaul: provider hard timeouts are now class-based (pure search APIs 15s, LLM-mediated providers 120s, Kimi 35s aligned to its upstream 30s budget, replacing the uniform 300s ceiling; an explicitly configured `web_search.timeout` still overrides — the schema default no longer reinstalls 300s), DuckDuckGo is fired as a background hedge 3s into a slower primary so a failing primary falls back to an already-settled result, the Gemini 429/5xx retry-delay budget dropped from 5 minutes to 30 seconds, resolved provider chains are cached per AuthStorage for 60s keyed on the credential generation (availability probes skipped on repeat searches; login/logout invalidates immediately), and `WebSearchTool` prewarms the chain at construction. Measured: hung-primary fallback 301s → 15s, slow-failing-primary fallback ~7s → 6s, repeat chain resolution ~26ms → ~0.01ms.
+### Fixed
+
+- Kept the default composer border one cell inside the terminal edge to avoid the right rounded input corner protruding in narrow/macOS terminal renderers.
 
 ## [0.7.10] - 2026-07-02
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -163,6 +163,7 @@ function configureDefaultComposerChrome(editor: CustomEditor): void {
 	editor.setInputPrefix(getDefaultInputPrefix());
 	editor.setPlaceholder(DEFAULT_COMPOSER_PLACEHOLDER);
 	editor.setPaddingX(1);
+	editor.setRightGutterWidth(1);
 	editor.setTopBorder(undefined);
 }
 

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -4,7 +4,7 @@ import { stripVTControlCharacters } from "node:util";
 import { Agent } from "@gajae-code/agent-core";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { initTheme, theme } from "@gajae-code/coding-agent/modes/theme/theme";
-import { CURSOR_MARKER, Text } from "@gajae-code/tui";
+import { CURSOR_MARKER, Text, visibleWidth } from "@gajae-code/tui";
 import { TempDir } from "@gajae-code/utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import { CustomEditor } from "../src/modes/components/custom-editor";
@@ -72,11 +72,13 @@ describe("InteractiveMode.setEditorComponent", () => {
 	it("renders the default composer as a closed rounded input box", () => {
 		const lines = mode.editor.render(48).map(stripRenderControls);
 
-		expect(lines[0]).toStartWith("╭");
-		expect(lines[0]).toEndWith("╮");
-		expect(lines.at(-1)).toStartWith("╰");
-		expect(lines.at(-1)).toEndWith("╯");
-		expect(lines.some(line => line.startsWith("│") && line.includes(">") && line.endsWith("│"))).toBe(true);
+		expect(lines.every(line => visibleWidth(line) === 48)).toBe(true);
+		expect(lines.every(line => line.endsWith(" "))).toBe(true);
+		expect(lines[0].trimEnd()).toStartWith("╭");
+		expect(lines[0].trimEnd()).toEndWith("╮");
+		expect(lines.at(-1)!.trimEnd()).toStartWith("╰");
+		expect(lines.at(-1)!.trimEnd()).toEndWith("╯");
+		expect(lines.some(line => line.startsWith("│") && line.includes(">") && line.trimEnd().endsWith("│"))).toBe(true);
 		expect(lines.join("\n")).toContain("Type your message...");
 		expect(lines.join("\n")).not.toContain("›");
 	});
@@ -85,6 +87,20 @@ describe("InteractiveMode.setEditorComponent", () => {
 		const shortcut = process.platform === "win32" ? "Alt+Enter/Ctrl+J" : "Shift+Enter/Ctrl+J";
 		return `${shortcut}: New line`;
 	}
+
+	it("keeps the composer right border inside a trailing gutter for CJK input", () => {
+		mode.editor.focused = true;
+		mode.editor.setText("이전 커밋들");
+
+		const lines = mode.editor.render(48).map(stripRenderControls);
+		const promptLine = lines.find(line => line.includes("이전 커밋들"));
+
+		expect(promptLine).toBeDefined();
+		expect(lines.every(line => visibleWidth(line) === 48)).toBe(true);
+		expect(lines.every(line => line.endsWith(" "))).toBe(true);
+		expect(promptLine!.trimEnd()).toEndWith("│");
+		expect(promptLine!).toContain("이전 커밋들");
+	});
 
 	function expectedQueueShortcutHint(): string {
 		const shortcut = process.platform === "win32" ? "Alt+Q" : "Alt+Enter";
@@ -172,11 +188,15 @@ describe("InteractiveMode.setEditorComponent", () => {
 			mode.editor.setText(text);
 			const lines = mode.editor.render(width).map(stripRenderControls);
 
-			expect(lines[0]).toStartWith("╭");
-			expect(lines[0]).toEndWith("╮");
-			expect(lines.at(-1)).toStartWith("╰");
-			expect(lines.at(-1)).toEndWith("╯");
-			expect(lines.some(line => line.startsWith("│") && line.includes(">") && line.endsWith("│"))).toBe(true);
+			expect(lines.every(line => visibleWidth(line) === width)).toBe(true);
+			expect(lines.every(line => line.endsWith(" "))).toBe(true);
+			expect(lines[0].trimEnd()).toStartWith("╭");
+			expect(lines[0].trimEnd()).toEndWith("╮");
+			expect(lines.at(-1)!.trimEnd()).toStartWith("╰");
+			expect(lines.at(-1)!.trimEnd()).toEndWith("╯");
+			expect(lines.some(line => line.startsWith("│") && line.includes(">") && line.trimEnd().endsWith("│"))).toBe(
+				true,
+			);
 			expect(lines.join("\n")).not.toContain("Type your message...");
 		}
 	});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -23,6 +23,9 @@
 ### Fixed
 
 - Kept the terminal stdout error handler armed briefly after TUI shutdown so late `EIO`/closed-PTY errors from SSH or Windows Terminal detach do not crash tmux-backed GJC panes.
+### Fixed
+
+- Added an editor right-gutter render option so bordered input chrome can stay one cell inside the terminal edge without changing component width.
 
 ## [0.7.9] - 2026-07-01
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -404,6 +404,7 @@ export class Editor implements Component, Focusable {
 	// Store last layout width for cursor navigation
 	#lastLayoutWidth: number = 80;
 	#paddingXOverride: number | undefined;
+	#rightGutterWidth = 0;
 	#maxHeight?: number;
 	#scrollOffset: number = 0;
 	#wrappedLineCache: CachedWrappedLine[] = [];
@@ -524,12 +525,14 @@ export class Editor implements Component, Focusable {
 
 	/**
 	 * Get the available width for top border content given a total terminal width.
-	 * Accounts for the border characters and horizontal padding when visible.
+	 * Accounts for right gutter, border characters, and horizontal padding when visible.
 	 */
 	getTopBorderAvailableWidth(terminalWidth: number): number {
+		const rightGutterWidth = Math.min(this.#rightGutterWidth, Math.max(0, terminalWidth - 1));
+		const renderWidth = Math.max(1, terminalWidth - rightGutterWidth);
 		const paddingX = this.#getEditorPaddingX();
 		const borderWidth = this.#getHorizontalChromeWidth(paddingX);
-		return Math.max(0, terminalWidth - borderWidth * 2);
+		return Math.max(0, renderWidth - borderWidth * 2);
 	}
 
 	/**
@@ -551,6 +554,10 @@ export class Editor implements Component, Focusable {
 
 	setPaddingX(paddingX: number): void {
 		this.#paddingXOverride = Math.max(0, paddingX);
+	}
+
+	setRightGutterWidth(width: number): void {
+		this.#rightGutterWidth = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : 0;
 	}
 
 	getAutocompleteMaxVisible(): number {
@@ -789,12 +796,14 @@ export class Editor implements Component, Focusable {
 	}
 
 	render(width: number): string[] {
+		const rightGutterWidth = Math.min(this.#rightGutterWidth, Math.max(0, width - 1));
+		const renderWidth = Math.max(1, width - rightGutterWidth);
 		const paddingX = this.#getEditorPaddingX();
 		const borderVisible = this.#borderVisible;
-		const promptGutter = this.#getPromptGutter(width, paddingX);
-		const contentAreaWidth = this.#getContentWidth(width, paddingX);
+		const promptGutter = this.#getPromptGutter(renderWidth, paddingX);
+		const contentAreaWidth = this.#getContentWidth(renderWidth, paddingX);
 		const inputPrefixWidth = this.#inputPrefixWidth;
-		const layoutWidth = Math.max(1, this.#getLayoutWidth(width, paddingX) - inputPrefixWidth);
+		const layoutWidth = Math.max(1, this.#getLayoutWidth(renderWidth, paddingX) - inputPrefixWidth);
 		this.#lastLayoutWidth = layoutWidth;
 
 		// Box-drawing characters for the configured input box shape.
@@ -815,7 +824,7 @@ export class Editor implements Component, Focusable {
 
 		if (borderVisible) {
 			// Render top border: ╭─ [status content] ────────────────╮
-			const topFillWidth = Math.max(0, width - borderWidth * 2);
+			const topFillWidth = Math.max(0, renderWidth - borderWidth * 2);
 			if (this.#topBorderContent) {
 				const { content, width: statusWidth } = this.#topBorderContent;
 				if (statusWidth <= topFillWidth) {
@@ -1020,7 +1029,7 @@ export class Editor implements Component, Focusable {
 		}
 
 		if (borderVisible && this.#closedBorderBox) {
-			const bottomFillWidth = Math.max(0, width - borderWidth * 2);
+			const bottomFillWidth = Math.max(0, renderWidth - borderWidth * 2);
 			const bottomLeftClosed = this.borderColor(`${box.bottomLeft}${box.horizontal.repeat(paddingX)}`);
 			const bottomRightClosed = this.borderColor(`${box.horizontal.repeat(paddingX)}${box.bottomRight}`);
 			result.push(bottomLeftClosed + horizontal.repeat(bottomFillWidth) + bottomRightClosed);
@@ -1028,8 +1037,13 @@ export class Editor implements Component, Focusable {
 
 		// Add autocomplete list if active
 		if (this.#autocompleteState && this.#autocompleteList) {
-			const autocompleteResult = this.#autocompleteList.render(width);
+			const autocompleteResult = this.#autocompleteList.render(renderWidth);
 			result.push(...autocompleteResult);
+		}
+
+		if (rightGutterWidth > 0) {
+			const rightGutter = padding(rightGutterWidth);
+			return result.map(line => line + rightGutter);
 		}
 
 		return result;

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -970,6 +970,22 @@ describe("Editor component", () => {
 			expect(visibleWidth(contentLine)).toBeLessThanOrEqual(width);
 		});
 
+		it("keeps bordered editor chrome inside a configured right gutter", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setRightGutterWidth(1);
+			editor.setInputPrefix("> ");
+			editor.setClosedBorderBox(true);
+			editor.setText("이전 커밋들");
+
+			const lines = editor.render(24).map(line => stripVTControlCharacters(line));
+
+			expect(lines.every(line => visibleWidth(line) === 24)).toBeTrue();
+			expect(lines.every(line => line.endsWith(" "))).toBeTrue();
+			expect(lines[0]!.trimEnd()).toEndWith(defaultEditorTheme.symbols.boxRound.topRight);
+			expect(lines.at(-1)!.trimEnd()).toEndWith(defaultEditorTheme.symbols.boxRound.bottomRight);
+			expect(lines.some(line => line.includes("이전 커밋들") && line.trimEnd().endsWith("|"))).toBeTrue();
+		});
+
 		it("shows cursor at end before wrap and wraps on next char", () => {
 			for (const paddingX of [0, 1]) {
 				const editor = new Editor({ ...defaultEditorTheme, editorPaddingX: paddingX });


### PR DESCRIPTION
## Summary
- add an optional right gutter to the TUI Editor render path
- enable a 1-column gutter for the default GJC composer so the rounded right border no longer touches the terminal edge
- add CJK composer regression coverage for the right border staying inside the gutter

## Verification
- `bun test packages/tui/test/editor.test.ts packages/coding-agent/test/interactive-mode-editor-component.test.ts` — 139 pass
- `bun --cwd=packages/tui test` — 594 pass
- `bun --cwd=packages/tui run check:types`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/tui/src/components/editor.ts packages/tui/test/editor.test.ts packages/tui/CHANGELOG.md packages/coding-agent/src/modes/interactive-mode.ts packages/coding-agent/test/interactive-mode-editor-component.test.ts packages/coding-agent/CHANGELOG.md`
- manual render scenario for `이전 커밋들`: all lines remain width 48 and end with a trailing gutter space after `╮/│/╯`

Note: full TUI test run emitted an existing `MaxListenersExceededWarning` in `terminal-appearance.test.ts`, but completed with 594 pass / 0 fail.