### PR TITLE
Harden MCP trust boundaries

### DIFF
--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -118,7 +118,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 		const data = tryParseJson<{ mcpServers?: Record<string, unknown> }>(content);
 		if (!data?.mcpServers) return result;
 
-		const expanded = expandEnvVarsDeep(data.mcpServers);
+		const expanded = level === "project" ? data.mcpServers : expandEnvVarsDeep(data.mcpServers);
 		for (const [serverName, config] of Object.entries(expanded)) {
 			const serverConfig = config as Record<string, unknown>;
 

--- a/packages/coding-agent/src/discovery/claude.ts
+++ b/packages/coding-agent/src/discovery/claude.ts
@@ -23,7 +23,6 @@ import {
 	calculateDepth,
 	createSourceMeta,
 	discoverExtensionModulePaths,
-	expandEnvVarsDeep,
 	getExtensionNameFromPath,
 	loadFilesFromDir,
 	scanSkillsFromDir,
@@ -53,7 +52,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 		const json = tryParseJson<{ mcpServers?: Record<string, unknown> }>(content);
 		if (!json?.mcpServers) return [];
 
-		const mcpServers = expandEnvVarsDeep(json.mcpServers);
+		const mcpServers = json.mcpServers;
 		return Object.entries(mcpServers).map(([name, config]) => {
 			const serverConfig = config as Record<string, unknown>;
 			return {

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -109,15 +109,18 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 				_source: source,
 			};
 
-			// Expand environment variables
-			if (server.command) server.command = expandEnvVarsDeep(server.command);
-			if (server.args) server.args = expandEnvVarsDeep(server.args);
-			if (server.env) server.env = expandEnvVarsDeep(server.env);
-			if (server.cwd) server.cwd = expandEnvVarsDeep(server.cwd);
-			if (server.url) server.url = expandEnvVarsDeep(server.url);
-			if (server.headers) server.headers = expandEnvVarsDeep(server.headers);
-			if (server.auth) server.auth = expandEnvVarsDeep(server.auth);
-			if (server.oauth) server.oauth = expandEnvVarsDeep(server.oauth);
+			if (source.level !== "project") {
+				// Project MCP configs are untrusted input. Preserve ${VAR} literally so
+				// manager/transport source-trust gates can prevent host-secret flow.
+				if (server.command) server.command = expandEnvVarsDeep(server.command);
+				if (server.args) server.args = expandEnvVarsDeep(server.args);
+				if (server.env) server.env = expandEnvVarsDeep(server.env);
+				if (server.cwd) server.cwd = expandEnvVarsDeep(server.cwd);
+				if (server.url) server.url = expandEnvVarsDeep(server.url);
+				if (server.headers) server.headers = expandEnvVarsDeep(server.headers);
+				if (server.auth) server.auth = expandEnvVarsDeep(server.auth);
+				if (server.oauth) server.oauth = expandEnvVarsDeep(server.oauth);
+			}
 			servers.push(server);
 		}
 	}

--- a/packages/coding-agent/src/modes/controllers/runtime-mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/runtime-mcp-command-controller.ts
@@ -66,6 +66,15 @@ interface OAuthFlowResult {
 }
 
 type MCPAddScope = "user" | "project";
+
+function mcpConfigSource(scope: MCPAddScope, filePath: string): SourceMeta {
+	return {
+		provider: "mcp-json",
+		providerName: scope === "project" ? "Project MCP config" : "User MCP config",
+		path: filePath,
+		level: scope,
+	};
+}
 type MCPAddTransport = "http" | "sse";
 
 type MCPAddParsed = {
@@ -205,6 +214,7 @@ export class MCPCommandController {
 
 		let name: string | undefined;
 		let scope: MCPAddScope = "project";
+		let scopeExplicit = false;
 		let url: string | undefined;
 		let transport: MCPAddTransport = "http";
 		let authToken: string | undefined;
@@ -228,6 +238,7 @@ export class MCPCommandController {
 					return { scope, error: r.error };
 				}
 				scope = r.scope;
+				scopeExplicit = true;
 				i += 2;
 				continue;
 			}
@@ -273,6 +284,9 @@ export class MCPCommandController {
 		}
 		if (authToken && !url) {
 			return { scope, error: "--token requires --url (HTTP/SSE transport)." };
+		}
+		if (authToken && !scopeExplicit) {
+			scope = "user";
 		}
 
 		if (commandTokens && commandTokens.length > 0) {
@@ -650,16 +664,16 @@ export class MCPCommandController {
 	 * Test connection to an MCP server.
 	 * Throws an error if connection fails (used for auto-detection).
 	 */
-	async #handleTestConnection(config: MCPServerConfig): Promise<void> {
+	async #handleTestConnection(config: MCPServerConfig, source?: SourceMeta): Promise<void> {
 		// Create temporary connection using a test name
 		const testName = `test_${Date.now()}`;
 		let resolvedConfig: MCPServerConfig;
 		if (this.ctx.mcpManager) {
-			resolvedConfig = await this.ctx.mcpManager.prepareConfig(config);
+			resolvedConfig = await this.ctx.mcpManager.prepareConfig(config, source);
 		} else {
 			const tempManager = new MCPManager(getProjectDir());
 			tempManager.setAuthStorage(this.ctx.session.modelRegistry.authStorage);
-			resolvedConfig = await tempManager.prepareConfig(config);
+			resolvedConfig = await tempManager.prepareConfig(config, source);
 		}
 
 		const connection = await connectToServer(testName, resolvedConfig);
@@ -805,10 +819,10 @@ export class MCPCommandController {
 		}
 	}
 
-	async #syncManagerConnection(name: string, config: MCPServerConfig): Promise<void> {
+	async #syncManagerConnection(name: string, config: MCPServerConfig, source: SourceMeta): Promise<void> {
 		if (!this.ctx.mcpManager) return;
 		if (this.ctx.mcpManager.getConnectionStatus(name) !== "disconnected") return;
-		await this.ctx.mcpManager.connectServers({ [name]: config }, {});
+		await this.ctx.mcpManager.connectServers({ [name]: config }, { [name]: source });
 		if (this.ctx.mcpManager.getConnectionStatus(name) === "connected") {
 			await this.ctx.session.refreshMCPTools(this.ctx.mcpManager.getTools());
 		}
@@ -836,9 +850,9 @@ export class MCPCommandController {
 			// report as connected to avoid false-negative messaging.
 			if (!isConnected && !isConnecting && config.enabled !== false) {
 				try {
-					await this.#handleTestConnection(config);
+					await this.#handleTestConnection(config, mcpConfigSource(scope, filePath));
 					isConnected = true;
-					await this.#syncManagerConnection(name, config);
+					await this.#syncManagerConnection(name, config, mcpConfigSource(scope, filePath));
 				} catch {
 					// Keep disconnected status
 				}
@@ -1115,7 +1129,7 @@ export class MCPCommandController {
 				return;
 			}
 
-			const { config } = found;
+			const { config, filePath, scope } = found;
 			if (config.enabled === false) {
 				this.ctx.showError(`Server "${name}" is disabled. Run /mcp enable ${name} first.`);
 				return;
@@ -1128,11 +1142,11 @@ export class MCPCommandController {
 			// Resolve auth config if needed
 			let resolvedConfig: MCPServerConfig;
 			if (this.ctx.mcpManager) {
-				resolvedConfig = await this.ctx.mcpManager.prepareConfig(config);
+				resolvedConfig = await this.ctx.mcpManager.prepareConfig(config, mcpConfigSource(scope, filePath));
 			} else {
 				const tempManager = new MCPManager(getProjectDir());
 				tempManager.setAuthStorage(this.ctx.session.modelRegistry.authStorage);
-				resolvedConfig = await tempManager.prepareConfig(config);
+				resolvedConfig = await tempManager.prepareConfig(config, mcpConfigSource(scope, filePath));
 			}
 
 			// Create temporary connection
@@ -1159,7 +1173,7 @@ export class MCPCommandController {
 			}
 
 			lines.push("");
-			await this.#syncManagerConnection(name, config);
+			await this.#syncManagerConnection(name, config, mcpConfigSource(scope, filePath));
 			this.#showMessage(lines.join("\n"));
 		} catch (error) {
 			if (abortController.signal.aborted || (error instanceof Error && error.name === "AbortError")) {

--- a/packages/coding-agent/src/runtime-mcp/config-writer.ts
+++ b/packages/coding-agent/src/runtime-mcp/config-writer.ts
@@ -3,6 +3,7 @@
  *
  * Utilities for reading/writing .gjc/mcp.json files at user or project level.
  */
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { isEnoent } from "@gajae-code/utils";
@@ -44,14 +45,36 @@ export async function writeMCPConfigFile(filePath: string, config: MCPConfigFile
 	// Ensure parent directory exists
 	const dir = path.dirname(filePath);
 	await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
+	const dirStat = await fs.promises.lstat(dir);
+	if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) {
+		throw new Error(`Refusing to write MCP config through non-directory or symlink parent: ${dir}`);
+	}
 
-	// Write to temp file first (atomic write)
-	const tmpPath = `${filePath}.tmp`;
 	const content = JSON.stringify(withSchema(config), null, 2);
-	await fs.promises.writeFile(tmpPath, content, { encoding: "utf-8", mode: 0o600 });
+	const tmpPath = path.join(
+		dir,
+		`.${path.basename(filePath)}.${process.pid}.${Date.now()}.${crypto.randomUUID()}.tmp`,
+	);
+	let fileHandle: fs.promises.FileHandle | undefined;
+	try {
+		fileHandle = await fs.promises.open(tmpPath, "wx", 0o600);
+		await fileHandle.writeFile(content, { encoding: "utf-8" });
+		await fileHandle.sync();
+		await fileHandle.close();
+		fileHandle = undefined;
+	} catch (error) {
+		await fileHandle?.close().catch(() => {});
+		await fs.promises.rm(tmpPath, { force: true }).catch(() => {});
+		throw error;
+	}
 
 	// Rename to final path (atomic on most systems)
-	await fs.promises.rename(tmpPath, filePath);
+	try {
+		await fs.promises.rename(tmpPath, filePath);
+	} catch (error) {
+		await fs.promises.rm(tmpPath, { force: true }).catch(() => {});
+		throw error;
+	}
 	// Invalidate the capability fs cache so subsequent reads see the new content
 	invalidateFsCache(filePath);
 }

--- a/packages/coding-agent/src/runtime-mcp/config.ts
+++ b/packages/coding-agent/src/runtime-mcp/config.ts
@@ -14,13 +14,13 @@ import type { MCPServerConfig } from "./types";
 
 /** Options for loading MCP configs */
 export interface LoadMCPConfigsOptions {
-	/** Whether to load project-level config (default: true) */
+	/** Whether to load project-level config (default: false) */
 	enableProjectConfig?: boolean;
 	/** Whether to filter out Exa MCP servers (default: true) */
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
-	/** Only include servers eligible for startup connection, i.e. autoload !== false (default: false) */
+	/** Only include servers eligible for startup connection, i.e. autoload !== false (default: true) */
 	autoloadOnly?: boolean;
 }
 
@@ -54,6 +54,7 @@ function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
 			type: "stdio" as const,
 			command: server.command ?? "",
 		};
+		if (server._source.level === "project") config.noInheritEnv = true;
 		if (server.args) config.args = server.args;
 		if (server.env) config.env = server.env;
 		if (server.cwd) config.cwd = server.cwd;
@@ -96,10 +97,10 @@ function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
  * @param options Load options
  */
 export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOptions): Promise<LoadMCPConfigsResult> {
-	const enableProjectConfig = options?.enableProjectConfig ?? true;
+	const enableProjectConfig = options?.enableProjectConfig ?? false;
 	const filterExa = options?.filterExa ?? true;
 	const filterBrowser = options?.filterBrowser ?? false;
-	const autoloadOnly = options?.autoloadOnly ?? false;
+	const autoloadOnly = options?.autoloadOnly ?? true;
 
 	// Load MCP servers via capability system
 	const result = await loadCapability<MCPServer>(mcpCapability.id, { cwd });

--- a/packages/coding-agent/src/runtime-mcp/loader.ts
+++ b/packages/coding-agent/src/runtime-mcp/loader.ts
@@ -28,13 +28,13 @@ export interface MCPToolsLoadResult {
 export interface MCPToolsLoadOptions {
 	/** Called when starting to connect to servers */
 	onConnecting?: (serverNames: string[]) => void;
-	/** Whether to load project-level config (default: true) */
+	/** Whether to load project-level config (default: false) */
 	enableProjectConfig?: boolean;
 	/** Whether to filter out Exa MCP servers (default: true) */
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
-	/** Only connect servers with autoload !== false (default: false) */
+	/** Only connect servers with autoload !== false (default: true) */
 	autoloadOnly?: boolean;
 	/** SQLite storage for MCP tool cache (null disables cache) */
 	cacheStorage?: AgentStorage | null;

--- a/packages/coding-agent/src/runtime-mcp/manager.ts
+++ b/packages/coding-agent/src/runtime-mcp/manager.ts
@@ -118,6 +118,10 @@ export function sortMCPToolsByName<T extends { name: string }>(tools: T[]): T[] 
 	return tools;
 }
 
+function canResolveConfigValuesFromSource(source: SourceMeta | undefined): boolean {
+	return source?.level !== "project";
+}
+
 export function resolveSubscriptionPostAction(
 	notificationsEnabled: boolean,
 	currentEpoch: number,
@@ -141,13 +145,13 @@ export interface MCPLoadResult {
 
 /** Options for discovering and connecting to MCP servers */
 export interface MCPDiscoverOptions {
-	/** Whether to load project-level config (default: true) */
+	/** Whether to load project-level config (default: false) */
 	enableProjectConfig?: boolean;
 	/** Whether to filter out Exa MCP servers (default: true) */
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
-	/** Only connect servers with autoload !== false (default: false) */
+	/** Only connect servers with autoload !== false (default: true) */
 	autoloadOnly?: boolean;
 	/** Called when starting to connect to servers */
 	onConnecting?: (serverNames: string[]) => void;
@@ -404,7 +408,7 @@ export class MCPManager {
 			this.#pendingConnectionControllers.set(name, connectionAbort);
 			// Resolve auth config before connecting, but do so per-server in parallel.
 			const connectionPromise = (async () => {
-				const resolvedConfig = await this.#resolveAuthConfig(config);
+				const resolvedConfig = await this.#resolveAuthConfig(config, false, sources[name]);
 				return connectToServer(name, resolvedConfig, {
 					signal: connectionAbort.signal,
 					onNotification: (method, params) => {
@@ -442,7 +446,7 @@ export class MCPManager {
 					// Wire auth refresh for HTTP transports so 401s trigger token refresh.
 					if (connection.transport instanceof HttpTransport && config.auth?.type === "oauth") {
 						connection.transport.onAuthError = async () => {
-							const refreshed = await this.#resolveAuthConfig(config, true);
+							const refreshed = await this.#resolveAuthConfig(config, true, sources[name]);
 							if (refreshed.type === "http" || refreshed.type === "sse") {
 								return refreshed.headers ?? null;
 							}
@@ -747,8 +751,8 @@ export class MCPManager {
 	/**
 	 * Resolve auth and shell-command substitutions in config before connecting.
 	 */
-	async prepareConfig(config: MCPServerConfig): Promise<MCPServerConfig> {
-		return this.#resolveAuthConfig(config);
+	async prepareConfig(config: MCPServerConfig, source?: SourceMeta): Promise<MCPServerConfig> {
+		return this.#resolveAuthConfig(config, false, source);
 	}
 
 	/**
@@ -947,7 +951,7 @@ export class MCPManager {
 		globalEpoch: number,
 		disconnectEpoch: number,
 	): Promise<MCPServerConnection> {
-		const resolvedConfig = await this.#resolveAuthConfig(config);
+		const resolvedConfig = await this.#resolveAuthConfig(config, false, source);
 		const connectionAbort = new AbortController();
 		this.#pendingConnectionControllers.set(name, connectionAbort);
 		let connection: MCPServerConnection;
@@ -986,7 +990,7 @@ export class MCPManager {
 		// Wire auth refresh for HTTP transports, and reconnect for any transport.
 		if (connection.transport instanceof HttpTransport && config.auth?.type === "oauth") {
 			connection.transport.onAuthError = async () => {
-				const refreshed = await this.#resolveAuthConfig(config, true);
+				const refreshed = await this.#resolveAuthConfig(config, true, source);
 				if (refreshed.type === "http" || refreshed.type === "sse") {
 					return refreshed.headers ?? null;
 				}
@@ -1217,6 +1221,7 @@ export class MCPManager {
 	getServerInstructions(): Map<string, string> {
 		const instructions = new Map<string, string>();
 		for (const [name, connection] of this.#connections) {
+			if (connection._source?.level === "project") continue;
 			if (connection.instructions) {
 				instructions.set(name, connection.instructions);
 			}
@@ -1235,13 +1240,18 @@ export class MCPManager {
 	}
 
 	/**
-	 * Resolve OAuth credentials and shell commands in config.
+	 * Resolve OAuth credentials and shell/env references for trusted non-project configs.
 	 */
-	async #resolveAuthConfig(config: MCPServerConfig, forceRefresh = false): Promise<MCPServerConfig> {
+	async #resolveAuthConfig(
+		config: MCPServerConfig,
+		forceRefresh = false,
+		source?: SourceMeta,
+	): Promise<MCPServerConfig> {
 		let resolved: MCPServerConfig = { ...config };
+		const allowTrustedSecretResolution = canResolveConfigValuesFromSource(source);
 
 		const auth = config.auth;
-		if (auth?.type === "oauth" && auth.credentialId && this.#authStorage) {
+		if (allowTrustedSecretResolution && auth?.type === "oauth" && auth.credentialId && this.#authStorage) {
 			const credentialId = auth.credentialId;
 			try {
 				let credential = this.#authStorage.get(credentialId);
@@ -1293,6 +1303,9 @@ export class MCPManager {
 			}
 		}
 
+		if (!allowTrustedSecretResolution) {
+			return resolved;
+		}
 		if (resolved.type !== "http" && resolved.type !== "sse") {
 			if (resolved.env) {
 				const nextEnv: Record<string, string> = {};

--- a/packages/coding-agent/src/slash-commands/helpers/mcp.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/mcp.ts
@@ -1,4 +1,5 @@
 import { getMCPConfigPath, logger } from "@gajae-code/utils";
+import type { SourceMeta } from "../../capability/types";
 import { connectToServer, disconnectServer, listPrompts, listResources, listTools } from "../../runtime-mcp/client";
 import {
 	addMCPServer,
@@ -18,9 +19,26 @@ import { commandConsumed, errorMessage, parseNamedScopeArgs, parseSubcommand, us
 
 type AcpMcpScope = "user" | "project";
 
+function mcpConfigSource(scope: AcpMcpScope, filePath: string): SourceMeta {
+	return {
+		provider: "mcp-json",
+		providerName: scope === "project" ? "Project MCP config" : "User MCP config",
+		path: filePath,
+		level: scope,
+	};
+}
+
+type ConfiguredMcpServer = {
+	name: string;
+	config: MCPServerConfig;
+	scope: AcpMcpScope;
+	source: SourceMeta;
+};
+
 interface ParsedMcpAddArgs {
 	name?: string;
 	scope: AcpMcpScope;
+	scopeExplicit?: boolean;
 	url?: string;
 	transport: "http" | "sse";
 	authToken?: string;
@@ -47,6 +65,7 @@ const MCP_ADD_OPTION_PARSERS = new Map<string, McpAddOptionParser>([
 		(parsed, value) => {
 			if (!value || (value !== "project" && value !== "user")) return "Invalid --scope value. Use project or user.";
 			parsed.scope = value;
+			parsed.scopeExplicit = true;
 			return undefined;
 		},
 	],
@@ -76,22 +95,34 @@ const MCP_ADD_OPTION_PARSERS = new Map<string, McpAddOptionParser>([
 	],
 ]);
 
-async function getMcpConfiguredServers(
-	cwd: string,
-): Promise<Array<{ name: string; config: MCPServerConfig; scope: AcpMcpScope }>> {
+async function getMcpConfiguredServers(cwd: string, includeProjectConfig: boolean): Promise<ConfiguredMcpServer[]> {
 	const userPath = getMCPConfigPath("user", cwd);
 	const projectPath = getMCPConfigPath("project", cwd);
 	const [userConfig, projectConfig] = await Promise.all([readMCPConfigFile(userPath), readMCPConfigFile(projectPath)]);
-	const servers: Array<{ name: string; config: MCPServerConfig; scope: AcpMcpScope }> = [];
+	const servers: ConfiguredMcpServer[] = [];
 	const seen = new Set<string>();
-	for (const [name, config] of Object.entries(projectConfig.mcpServers ?? {})) {
-		if (config.enabled !== false) {
-			servers.push({ name, config, scope: "project" });
-			seen.add(name);
+	if (includeProjectConfig) {
+		for (const [name, config] of Object.entries(projectConfig.mcpServers ?? {})) {
+			if (config.enabled !== false) {
+				servers.push({
+					name,
+					config,
+					scope: "project",
+					source: mcpConfigSource("project", projectPath),
+				});
+				seen.add(name);
+			}
 		}
 	}
 	for (const [name, config] of Object.entries(userConfig.mcpServers ?? {})) {
-		if (!seen.has(name) && config.enabled !== false) servers.push({ name, config, scope: "user" });
+		if (!seen.has(name) && config.enabled !== false) {
+			servers.push({
+				name,
+				config,
+				scope: "user",
+				source: mcpConfigSource("user", userPath),
+			});
+		}
 	}
 	return servers;
 }
@@ -108,6 +139,7 @@ function validateParsedMcpAddArgs(parsed: ParsedMcpAddArgs): ParsedMcpAddArgs {
 	if (!parsed.name) return { ...parsed, error: "Server name required. Usage: /mcp add <name> ..." };
 	if (hasCommand && hasUrl) return { ...parsed, error: "Use either --url or -- <command...>, not both." };
 	if (parsed.authToken && !hasUrl) return { ...parsed, error: "--token requires --url (HTTP/SSE transport)." };
+	if (parsed.authToken && !parsed.scopeExplicit) return { ...parsed, scope: "user" };
 	return parsed;
 }
 
@@ -199,6 +231,7 @@ async function withPreparedMcpConnection<T>(
 	runtime: SlashCommandRuntime,
 	name: string,
 	config: MCPServerConfig,
+	source: SourceMeta,
 	fn: (connection: MCPServerConnection) => Promise<T>,
 ): Promise<T> {
 	let connection: MCPServerConnection | undefined;
@@ -209,7 +242,7 @@ async function withPreparedMcpConnection<T>(
 		// Without this, `/mcp test|resources|prompts` silently fails for any
 		// server saved by the TUI/reauth path.
 		manager.setAuthStorage(runtime.session.modelRegistry.authStorage);
-		const resolvedConfig = await manager.prepareConfig(config);
+		const resolvedConfig = await manager.prepareConfig(config, source);
 		connection = await connectToServer(name, resolvedConfig);
 		return await fn(connection);
 	} finally {
@@ -231,13 +264,13 @@ async function collectConnectedMcpLines(
 	runtime: SlashCommandRuntime,
 	collect: (serverName: string, connection: MCPServerConnection) => Promise<string[]>,
 ): Promise<string[] | undefined> {
-	const servers = await getMcpConfiguredServers(runtime.cwd);
+	const servers = await getMcpConfiguredServers(runtime.cwd, runtime.settings.get("mcp.enableProjectConfig"));
 	if (servers.length === 0) return undefined;
 
 	const lines: string[] = [];
-	for (const { name, config } of servers) {
+	for (const { name, config, source } of servers) {
 		try {
-			const collected = await withPreparedMcpConnection(runtime, name, config, connection =>
+			const collected = await withPreparedMcpConnection(runtime, name, config, source, connection =>
 				collect(name, connection),
 			);
 			lines.push(...collected);
@@ -277,12 +310,12 @@ async function handlePromptsCommand(runtime: SlashCommandRuntime): Promise<Slash
 async function handleTestCommand(rest: string, runtime: SlashCommandRuntime): Promise<SlashCommandResult> {
 	const name = rest.split(/\s+/)[0]?.trim() ?? "";
 	if (!name) return usage("Usage: /mcp test <name>", runtime);
-	const servers = await getMcpConfiguredServers(runtime.cwd);
+	const servers = await getMcpConfiguredServers(runtime.cwd, runtime.settings.get("mcp.enableProjectConfig"));
 	const server = servers.find(item => item.name === name);
 	if (!server) return usage(`Server "${name}" not found. Run /mcp list to see configured servers.`, runtime);
 
 	try {
-		return await withPreparedMcpConnection(runtime, name, server.config, async connection => {
+		return await withPreparedMcpConnection(runtime, name, server.config, server.source, async connection => {
 			const tools = await listTools(connection);
 			const lines = [`Server "${name}" connected (${tools.length} tools).`];
 			for (const tool of tools) lines.push(`  - ${tool.name}`);

--- a/packages/coding-agent/test/discovery/mcp-json.test.ts
+++ b/packages/coding-agent/test/discovery/mcp-json.test.ts
@@ -13,11 +13,19 @@ async function loadStandaloneMcpConfig(cwd: string): Promise<MCPServer[]> {
 	return result.items;
 }
 
+async function loadNativeMcpConfig(cwd: string): Promise<MCPServer[]> {
+	const result = await loadCapability<MCPServer>(mcpCapability.id, {
+		cwd,
+		providers: ["native"],
+	});
+	return result.items;
+}
+
 function envPlaceholder(name: string): string {
 	return `\${${name}}`;
 }
 
-describe("standalone mcp.json oauth env expansion", () => {
+describe("standalone mcp.json project env trust boundary", () => {
 	let tempDir = "";
 	const originalEnv = {
 		PI_OAUTH_TOKEN_URL: process.env.PI_OAUTH_TOKEN_URL,
@@ -53,7 +61,7 @@ describe("standalone mcp.json oauth env expansion", () => {
 		}
 	});
 
-	test("expands standalone auth and oauth fields alongside existing env-expanded fields", async () => {
+	test("preserves project auth and oauth env placeholders literally", async () => {
 		await fs.writeFile(
 			path.join(tempDir, "mcp.json"),
 			JSON.stringify({
@@ -82,25 +90,25 @@ describe("standalone mcp.json oauth env expansion", () => {
 
 		const [server] = await loadStandaloneMcpConfig(tempDir);
 		expect(server).toBeDefined();
-		expect(server?.url).toBe("https://mcp.example.com/mcp");
-		expect(server?.headers).toEqual({ Authorization: "Bearer test-token" });
-		expect(server?.env).toEqual({ MCP_VALUE: "env-value" });
+		expect(server?.url).toBe(`${envPlaceholder("PI_MCP_URL")}/mcp`);
+		expect(server?.headers).toEqual({ Authorization: envPlaceholder("PI_MCP_HEADER") });
+		expect(server?.env).toEqual({ MCP_VALUE: envPlaceholder("PI_MCP_ENV") });
 		expect(server?.auth).toEqual({
 			type: "oauth",
-			tokenUrl: "https://provider.example/token",
-			clientId: "oauth-client-id",
-			clientSecret: "oauth-client-secret",
+			tokenUrl: envPlaceholder("PI_OAUTH_TOKEN_URL"),
+			clientId: envPlaceholder("PI_OAUTH_CLIENT_ID"),
+			clientSecret: envPlaceholder("PI_OAUTH_CLIENT_SECRET"),
 		});
 		expect(server?.oauth).toEqual({
-			clientId: "oauth-client-id",
-			clientSecret: "oauth-client-secret",
-			redirectUri: "https://public.example/oauth/callback",
+			clientId: envPlaceholder("PI_OAUTH_CLIENT_ID"),
+			clientSecret: envPlaceholder("PI_OAUTH_CLIENT_SECRET"),
+			redirectUri: envPlaceholder("PI_OAUTH_REDIRECT_URI"),
 			callbackPort: 4317,
-			callbackPath: "/oauth/callback",
+			callbackPath: envPlaceholder("PI_OAUTH_CALLBACK_PATH"),
 		});
 	});
 
-	test("expands only the standalone oauth fields that are present", async () => {
+	test("preserves partial project oauth env placeholders literally", async () => {
 		await fs.writeFile(
 			path.join(tempDir, ".mcp.json"),
 			JSON.stringify({
@@ -119,9 +127,61 @@ describe("standalone mcp.json oauth env expansion", () => {
 		const [server] = await loadStandaloneMcpConfig(tempDir);
 		expect(server).toBeDefined();
 		expect(server?.oauth).toEqual({
-			redirectUri: "https://public.example/oauth/callback",
-			callbackPath: "/oauth/callback",
+			redirectUri: envPlaceholder("PI_OAUTH_REDIRECT_URI"),
+			callbackPath: envPlaceholder("PI_OAUTH_CALLBACK_PATH"),
 		});
 		expect(server?.auth).toBeUndefined();
+	});
+});
+
+describe("native .gjc project env trust boundary", () => {
+	let tempDir = "";
+	const originalEnv = {
+		PI_MCP_HEADER: process.env.PI_MCP_HEADER,
+		PI_MCP_COMMAND: process.env.PI_MCP_COMMAND,
+		PI_MCP_ENV: process.env.PI_MCP_ENV,
+	};
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-native-mcp-"));
+		process.env.PI_MCP_HEADER = "Bearer native-secret";
+		process.env.PI_MCP_COMMAND = "native-secret-command";
+		process.env.PI_MCP_ENV = "native-env-value";
+	});
+
+	afterEach(async () => {
+		await fs.rm(tempDir, { recursive: true, force: true });
+		for (const [key, value] of Object.entries(originalEnv)) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	});
+
+	test("preserves project placeholders loaded from .gjc/mcp.json literally", async () => {
+		await fs.mkdir(path.join(tempDir, ".gjc"), { recursive: true });
+		await fs.writeFile(
+			path.join(tempDir, ".gjc", "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					native: {
+						command: envPlaceholder("PI_MCP_COMMAND"),
+						args: [envPlaceholder("PI_MCP_ENV")],
+						env: { MCP_VALUE: envPlaceholder("PI_MCP_ENV") },
+						headers: { Authorization: envPlaceholder("PI_MCP_HEADER") },
+					},
+				},
+			}),
+		);
+
+		const [server] = await loadNativeMcpConfig(tempDir);
+
+		expect(server).toBeDefined();
+		expect(server?.command).toBe(envPlaceholder("PI_MCP_COMMAND"));
+		expect(server?.args).toEqual([envPlaceholder("PI_MCP_ENV")]);
+		expect(server?.env).toEqual({ MCP_VALUE: envPlaceholder("PI_MCP_ENV") });
+		expect(server?.headers).toEqual({ Authorization: envPlaceholder("PI_MCP_HEADER") });
 	});
 });

--- a/packages/coding-agent/test/runtime-mcp/config-writer.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/config-writer.test.ts
@@ -32,6 +32,33 @@ describe("upsertMCPServer", () => {
 		expect(await getMCPServer(configPath, "alpha")).toEqual(stdio("alpha-bin"));
 	});
 
+	test("does not follow a preexisting predictable temp symlink", async () => {
+		const predictableTmp = `${configPath}.tmp`;
+		const victimPath = path.join(tmpDir, "victim.txt");
+		await fs.writeFile(victimPath, "keep me", "utf-8");
+		await fs.symlink(victimPath, predictableTmp);
+
+		const result = await upsertMCPServer(configPath, "alpha", stdio("alpha-bin"));
+
+		expect(result).toEqual({ status: "added" });
+		expect(await getMCPServer(configPath, "alpha")).toEqual(stdio("alpha-bin"));
+		expect(await fs.readFile(victimPath, "utf-8")).toBe("keep me");
+	});
+
+	test("rejects writes through a symlinked config parent", async () => {
+		const projectDir = path.join(tmpDir, "project");
+		const externalDir = path.join(tmpDir, "external");
+		const symlinkDir = path.join(projectDir, ".gjc");
+		await fs.mkdir(projectDir, { recursive: true });
+		await fs.mkdir(externalDir, { recursive: true });
+		await fs.symlink(externalDir, symlinkDir);
+
+		await expect(upsertMCPServer(path.join(symlinkDir, "mcp.json"), "alpha", stdio("alpha-bin"))).rejects.toThrow(
+			"Refusing to write MCP config through non-directory or symlink parent",
+		);
+		await expect(fs.stat(path.join(externalDir, "mcp.json"))).rejects.toThrow();
+	});
+
 	test("skips an existing server without force and does not overwrite", async () => {
 		await upsertMCPServer(configPath, "alpha", stdio("alpha-bin"));
 		const result = await upsertMCPServer(configPath, "alpha", stdio("changed-bin"));

--- a/packages/coding-agent/test/runtime-mcp/config.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/config.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadAllMCPConfigs } from "../../src/runtime-mcp/config";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+	tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-config-defaults-"));
+	await Bun.write(
+		path.join(tmpDir, ".mcp.json"),
+		`${JSON.stringify(
+			{
+				mcpServers: {
+					project_auto: { command: "project-auto" },
+					project_manual: { command: "project-manual", autoload: false },
+				},
+			},
+			null,
+			2,
+		)}\n`,
+	);
+});
+
+afterEach(async () => {
+	await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("loadAllMCPConfigs security defaults", () => {
+	test("excludes project configs and non-autoload servers unless explicitly enabled", async () => {
+		const safeDefault = await loadAllMCPConfigs(tmpDir);
+		expect(safeDefault.configs.project_auto).toBeUndefined();
+		expect(safeDefault.configs.project_manual).toBeUndefined();
+
+		const projectEnabled = await loadAllMCPConfigs(tmpDir, { enableProjectConfig: true });
+		expect(projectEnabled.configs.project_auto).toHaveProperty("command", "project-auto");
+		expect(projectEnabled.configs.project_manual).toBeUndefined();
+
+		const projectAll = await loadAllMCPConfigs(tmpDir, { enableProjectConfig: true, autoloadOnly: false });
+		expect(projectAll.configs.project_auto).toHaveProperty("command", "project-auto");
+		expect(projectAll.configs.project_manual).toHaveProperty("command", "project-manual");
+	});
+});

--- a/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadAllMCPConfigs } from "../../src/runtime-mcp/config";
 import { MCPManager } from "../../src/runtime-mcp/manager";
 import type { JsonRpcMessage } from "../../src/runtime-mcp/types";
+import type { AuthStorage } from "../../src/session/auth-storage";
 
 async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 3_000): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
@@ -48,6 +53,26 @@ setInterval(() => {}, 1000);
 `;
 }
 
+function envCaptureServerScript(outputPath: string, envName = "API_KEY"): string {
+	return `
+const fs = require('node:fs');
+const readline = require('node:readline');
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', line => {
+  const msg = JSON.parse(line);
+  if (msg.method === 'initialize') {
+    fs.writeFileSync(${JSON.stringify(outputPath)}, process.env[${JSON.stringify(envName)}] || '');
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { protocolVersion: '2025-03-26', capabilities: { tools: {} }, serverInfo: { name: 'test', version: '1' }, instructions: 'project-controlled instructions' } }) + '\\n');
+  } else if (msg.method === 'tools/list') {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { tools: [] } }) + '\\n');
+  } else if (msg.id !== undefined) {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} }) + '\\n');
+  }
+});
+setInterval(() => {}, 1000);
+`;
+}
+
 describe("MCP manager lifecycle cleanup", () => {
 	test("initial listTools failure closes transport and does not register server", async () => {
 		const manager = new MCPManager(process.cwd());
@@ -62,6 +87,148 @@ describe("MCP manager lifecycle cleanup", () => {
 		expect(result.errors.get("bad")).toContain("boom");
 		expect(manager.getConnectedServers()).toEqual([]);
 		await expect(manager.waitForConnection("bad")).rejects.toThrow("MCP server not connected: bad");
+	});
+
+	test("does not resolve project MCP env references or expose project server instructions", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-project-source-"));
+		const capturePath = path.join(tempDir, "captured-env.txt");
+		const previous = process.env.SECRET_FOR_MCP;
+		process.env.SECRET_FOR_MCP = "leaked-secret";
+		const manager = new MCPManager(process.cwd());
+		try {
+			const result = await manager.connectServers(
+				{
+					projected: {
+						command: process.execPath,
+						args: ["-e", envCaptureServerScript(capturePath)],
+						env: { API_KEY: "SECRET_FOR_MCP" },
+						timeout: 1_000,
+					},
+				},
+				{
+					projected: {
+						provider: "test",
+						providerName: "Test Project",
+						path: path.join(tempDir, ".mcp.json"),
+						level: "project",
+					},
+				},
+			);
+
+			expect(result.errors.size).toBe(0);
+			expect(await Bun.file(capturePath).text()).toBe("SECRET_FOR_MCP");
+			expect(manager.getServerInstructions().size).toBe(0);
+		} finally {
+			if (previous === undefined) delete process.env.SECRET_FOR_MCP;
+			else process.env.SECRET_FOR_MCP = previous;
+			await manager.disconnectAll();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("project MCP stdio servers do not inherit unrelated host environment", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-project-no-inherit-"));
+		const capturePath = path.join(tempDir, "captured-secret.txt");
+		const previous = process.env.SECRET_FOR_MCP;
+		process.env.SECRET_FOR_MCP = "host-secret";
+		const manager = new MCPManager(tempDir);
+		try {
+			await Bun.write(
+				path.join(tempDir, ".mcp.json"),
+				`${JSON.stringify({
+					mcpServers: {
+						projected: {
+							command: process.execPath,
+							args: ["-e", envCaptureServerScript(capturePath, "SECRET_FOR_MCP")],
+						},
+					},
+				})}\n`,
+			);
+			const { configs, sources } = await loadAllMCPConfigs(tempDir, { enableProjectConfig: true });
+			expect(configs.projected).toHaveProperty("noInheritEnv", true);
+
+			const result = await manager.connectServers(configs, sources);
+
+			expect(result.errors.size).toBe(0);
+			expect(await Bun.file(capturePath).text()).toBe("");
+		} finally {
+			if (previous === undefined) delete process.env.SECRET_FOR_MCP;
+			else process.env.SECRET_FOR_MCP = previous;
+			await manager.disconnectAll();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("does not inject stored OAuth credentials into project MCP servers", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-project-oauth-"));
+		const capturePath = path.join(tempDir, "captured-oauth.txt");
+		const lookups: string[] = [];
+		const manager = new MCPManager(process.cwd());
+		manager.setAuthStorage({
+			get(provider: string) {
+				lookups.push(provider);
+				return { type: "oauth", access: "secret-token", refresh: "refresh-token", expires: Date.now() + 60_000 };
+			},
+			async set() {
+				throw new Error("project OAuth credentials must not refresh");
+			},
+		} as unknown as AuthStorage);
+		try {
+			const result = await manager.connectServers(
+				{
+					projected: {
+						command: process.execPath,
+						args: ["-e", envCaptureServerScript(capturePath, "OAUTH_ACCESS_TOKEN")],
+						auth: { type: "oauth", credentialId: "project-secret" },
+						timeout: 1_000,
+					},
+				},
+				{
+					projected: {
+						provider: "test",
+						providerName: "Test Project",
+						path: path.join(tempDir, ".mcp.json"),
+						level: "project",
+					},
+				},
+			);
+
+			expect(result.errors.size).toBe(0);
+			expect(lookups).toEqual([]);
+			expect(await Bun.file(capturePath).text()).toBe("");
+		} finally {
+			await manager.disconnectAll();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("prepareConfig does not resolve project-source OAuth credentials", async () => {
+		const lookups: string[] = [];
+		const manager = new MCPManager(process.cwd());
+		manager.setAuthStorage({
+			get(provider: string) {
+				lookups.push(provider);
+				return { type: "oauth", access: "secret-token", refresh: "refresh-token", expires: Date.now() + 60_000 };
+			},
+			async set() {
+				throw new Error("project OAuth credentials must not refresh");
+			},
+		} as unknown as AuthStorage);
+
+		const resolved = await manager.prepareConfig(
+			{ command: process.execPath, auth: { type: "oauth", credentialId: "project-secret" } },
+			{
+				provider: "mcp-json",
+				providerName: "Project MCP config",
+				path: path.join(process.cwd(), ".mcp.json"),
+				level: "project",
+			},
+		);
+
+		expect(lookups).toEqual([]);
+		if (resolved.type !== "http" && resolved.type !== "sse") {
+			expect(resolved.env?.OAUTH_ACCESS_TOKEN).toBeUndefined();
+		}
 	});
 
 	test("disconnect cancels an in-flight reconnect backoff", async () => {

--- a/packages/coding-agent/test/runtime-mcp/slash-mcp-add.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/slash-mcp-add.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getConfigRootDir, getMCPConfigPath, setAgentDir } from "@gajae-code/utils";
+import { readMCPConfigFile } from "../../src/runtime-mcp/config-writer";
+import { handleMcpAcp } from "../../src/slash-commands/helpers/mcp";
+import type { SlashCommandRuntime } from "../../src/slash-commands/types";
+
+let tmpDir = "";
+let agentDir = "";
+let projectDir = "";
+
+const originalAgentDir = process.env.GJC_CODING_AGENT_DIR;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+function runtime(): SlashCommandRuntime {
+	return {
+		cwd: projectDir,
+		settings: { get: () => false },
+		output: () => undefined,
+		refreshCommands: () => undefined,
+		reloadPlugins: async () => undefined,
+	} as unknown as SlashCommandRuntime;
+}
+
+describe("ACP MCP add trust boundaries", () => {
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-mcp-acp-add-"));
+		agentDir = path.join(tmpDir, "agent");
+		projectDir = path.join(tmpDir, "project");
+		await fs.mkdir(projectDir, { recursive: true });
+		setAgentDir(agentDir);
+	});
+
+	afterEach(async () => {
+		if (originalAgentDir) {
+			setAgentDir(originalAgentDir);
+		} else {
+			setAgentDir(fallbackAgentDir);
+			delete process.env.GJC_CODING_AGENT_DIR;
+		}
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	test("stores token-bearing quick add in user scope by default", async () => {
+		await handleMcpAcp(
+			{
+				name: "mcp",
+				args: "add remote --url https://example.test/mcp --token secret-token",
+				text: "/mcp add remote --url https://example.test/mcp --token secret-token",
+			},
+			runtime(),
+		);
+
+		const userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
+		const projectConfig = await readMCPConfigFile(getMCPConfigPath("project", projectDir));
+
+		expect(userConfig.mcpServers?.remote).toEqual({
+			type: "http",
+			url: "https://example.test/mcp",
+			headers: { Authorization: "Bearer secret-token" },
+		});
+		expect(projectConfig.mcpServers?.remote).toBeUndefined();
+	});
+
+	test("honors explicit project scope for token-bearing quick add", async () => {
+		await handleMcpAcp(
+			{
+				name: "mcp",
+				args: "add remote --scope project --url https://example.test/mcp --token secret-token",
+				text: "/mcp add remote --scope project --url https://example.test/mcp --token secret-token",
+			},
+			runtime(),
+		);
+
+		const userConfig = await readMCPConfigFile(getMCPConfigPath("user", projectDir));
+		const projectConfig = await readMCPConfigFile(getMCPConfigPath("project", projectDir));
+
+		expect(userConfig.mcpServers?.remote).toBeUndefined();
+		expect(projectConfig.mcpServers?.remote).toEqual({
+			type: "http",
+			url: "https://example.test/mcp",
+			headers: { Authorization: "Bearer secret-token" },
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- preserve project MCP env placeholders as literals and prevent project stdio MCPs from inheriting host env by default
- harden project MCP config writes against symlink-parent paths
- make `/mcp add --token` quick-add store tokens in user scope unless project scope is explicit
- keep startup/runtime loading scoped to autoload-eligible servers by default while preserving explicit connect paths

Split out of closed #1675 as a focused dev-based PR.

## Verification
- `bun test packages/coding-agent/test/discovery/mcp-json.test.ts packages/coding-agent/test/runtime-mcp/config-writer.test.ts packages/coding-agent/test/runtime-mcp/config.test.ts packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts packages/coding-agent/test/runtime-mcp/slash-mcp-add.test.ts` — 29 pass
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/discovery/builtin.ts packages/coding-agent/src/discovery/claude.ts packages/coding-agent/src/discovery/mcp-json.ts packages/coding-agent/src/modes/controllers/runtime-mcp-command-controller.ts packages/coding-agent/src/runtime-mcp/config-writer.ts packages/coding-agent/src/runtime-mcp/config.ts packages/coding-agent/src/runtime-mcp/loader.ts packages/coding-agent/src/runtime-mcp/manager.ts packages/coding-agent/src/slash-commands/helpers/mcp.ts packages/coding-agent/test/discovery/mcp-json.test.ts packages/coding-agent/test/runtime-mcp/config-writer.test.ts packages/coding-agent/test/runtime-mcp/config.test.ts packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts packages/coding-agent/test/runtime-mcp/slash-mcp-add.test.ts`