### PR TITLE
Harden workflow state writers

### DIFF
--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -12,13 +12,17 @@ import { launchDefaultTmuxIfNeeded } from "../gjc-runtime/launch-tmux";
 import { prepareLaunchWorktree } from "../gjc-runtime/launch-worktree";
 import {
 	GJC_COORDINATOR_SESSION_ID_ENV,
-	GJC_COORDINATOR_SESSION_STATE_FILE_ENV,
+	resolveCoordinatorRuntimeStateFile,
 } from "../gjc-runtime/session-state-sidecar";
 import { runRootCommand } from "../main";
 import { prepareAcpTerminalAuthArgs } from "../modes/acp/terminal-auth";
 
 async function persistCoordinatorLaunchFailure(error: unknown, cwd: string): Promise<void> {
-	const stateFile = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim();
+	const stateFile = resolveCoordinatorRuntimeStateFile({
+		sessionId: process.env.GJC_SESSION_ID?.trim() || process.env[GJC_COORDINATOR_SESSION_ID_ENV]?.trim() || "launch",
+		cwd,
+		sessionFile: null,
+	});
 	if (!stateFile) return;
 	const message = error instanceof Error ? error.message : String(error);
 	const code = message.split(":", 1)[0] || "launch_failed";

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -630,7 +630,25 @@ export class ExtensionRunner {
 
 			for (const handler of handlers) {
 				try {
-					const handlerResult = await handler(event, ctx);
+					const handlerResult = await Promise.race([
+						Promise.resolve(handler(event, ctx)),
+						Bun.sleep(extensionHandlerTimeoutMs).then(() => EXTENSION_HANDLER_TIMEOUT),
+					]);
+
+					if (handlerResult === EXTENSION_HANDLER_TIMEOUT) {
+						const error = `handler timed out after ${extensionHandlerTimeoutMs}ms`;
+						logger.warn("Extension handler timed out", {
+							extensionPath: ext.path,
+							event: "tool_call",
+							timeoutMs: extensionHandlerTimeoutMs,
+						});
+						this.emitError({
+							extensionPath: ext.path,
+							event: "tool_call",
+							error,
+						});
+						return { block: true, reason: `Extension ${ext.path} timed out handling tool_call.` };
+					}
 
 					if (handlerResult) {
 						result = handlerResult as ToolCallEventResult;

--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -53,6 +53,26 @@ function sameResolvedPath(left: string, right: string): boolean {
 	return path.resolve(left) === path.resolve(right);
 }
 
+function isWithinOrEqualPath(root: string, candidate: string): boolean {
+	const relative = path.relative(root, candidate);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export function resolveCoordinatorRuntimeStateFile(context: RuntimeStateContext): string | null {
+	const stateFile = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim();
+	if (!stateFile) return null;
+	const runtimeRoot = path.resolve(sessionRuntimeDir(context.cwd, context.sessionId));
+	const resolved = path.resolve(stateFile);
+	if (!isWithinOrEqualPath(runtimeRoot, resolved)) {
+		logger.warn("Ignoring coordinator runtime state file outside session runtime root", {
+			stateFile: resolved,
+			runtimeRoot,
+		});
+		return null;
+	}
+	return resolved;
+}
+
 export async function readTerminalRuntimeStateMarker(input: {
 	stateFile?: string | null;
 	sessionId?: string | null;
@@ -73,15 +93,17 @@ export async function readTerminalRuntimeStateMarker(input: {
 		};
 	}
 	if (payload.session_id !== sessionId) return { terminal: false, reason: "session_id_mismatch" };
-	if (input.cwd && typeof payload.cwd === "string" && !sameResolvedPath(payload.cwd, input.cwd)) {
-		return { terminal: false, reason: "cwd_mismatch" };
+	if (input.cwd) {
+		if (typeof payload.cwd !== "string") return { terminal: false, reason: "cwd_mismatch" };
+		if (!sameResolvedPath(payload.cwd, input.cwd)) {
+			return { terminal: false, reason: "cwd_mismatch" };
+		}
 	}
-	if (
-		input.sessionFile &&
-		typeof payload.session_file === "string" &&
-		!sameResolvedPath(payload.session_file, input.sessionFile)
-	) {
-		return { terminal: false, reason: "session_file_mismatch" };
+	if (input.sessionFile) {
+		if (typeof payload.session_file !== "string") return { terminal: false, reason: "session_file_mismatch" };
+		if (!sameResolvedPath(payload.session_file, input.sessionFile)) {
+			return { terminal: false, reason: "session_file_mismatch" };
+		}
 	}
 	if (payload.state === "completed" || payload.state === "errored") return { terminal: true, state: payload.state };
 	return { terminal: false, reason: "non_terminal_state" };
@@ -151,7 +173,7 @@ function shouldPreserveTerminalPayload(previous: RuntimeStateSidecarPayload): bo
 
 function runtimeStateFileForContext(context: RuntimeStateContext): string | null {
 	const explicit = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim();
-	if (explicit) return explicit;
+	if (explicit) return resolveCoordinatorRuntimeStateFile(context);
 	if (!context.sessionId.trim()) return null;
 	return path.join(sessionRuntimeDir(context.cwd, context.sessionId), "runtime-state.json");
 }

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -18,7 +18,7 @@ import {
 	auditPath as layoutAuditPath,
 	transactionJournalPath as layoutTransactionJournalPath,
 } from "./session-layout";
-import { RequiredOnWriteEnvelopeSchema } from "./state-schema";
+import { type RequiredOnWriteEnvelope, RequiredOnWriteEnvelopeSchema } from "./state-schema";
 
 /**
  * Sole sanctioned project `.gjc/**` writer module (gate G1).
@@ -207,16 +207,105 @@ function cwdForOptions(options?: StateWriterOptions): string {
 	return path.resolve(options?.cwd ?? process.cwd());
 }
 
+function isWithinOrEqualPath(root: string, candidate: string): boolean {
+	const relative = path.relative(root, candidate);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
 function resolveGjcTarget(targetPath: string, cwd = process.cwd()): string {
 	if (!targetPath.trim()) throw new Error("targetPath is required");
 	const projectRoot = path.resolve(cwd);
 	const gjcRoot = path.join(projectRoot, ".gjc");
 	const resolved = path.resolve(projectRoot, targetPath);
-	const relative = path.relative(gjcRoot, resolved);
-	if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+	if (!isWithinOrEqualPath(gjcRoot, resolved)) {
 		throw new Error(`target path must be within project .gjc/**: ${targetPath}`);
 	}
 	return resolved;
+}
+
+function gjcRootFromResolvedTarget(filePath: string): string {
+	const resolved = path.resolve(filePath);
+	const parsed = path.parse(resolved);
+	const segments = path.relative(parsed.root, resolved).split(path.sep).filter(Boolean);
+	const gjcIndex = segments.lastIndexOf(".gjc");
+	if (gjcIndex < 0) {
+		throw new Error(`resolved target path must include project .gjc/**: ${filePath}`);
+	}
+	return path.join(parsed.root, ...segments.slice(0, gjcIndex + 1));
+}
+
+async function lstatIfPresent(filePath: string): Promise<Stats | undefined> {
+	try {
+		return await fs.lstat(filePath);
+	} catch (error) {
+		if (isErrno(error, "ENOENT")) return undefined;
+		throw error;
+	}
+}
+
+async function ensureExistingDirectoryWithoutSymlink(dirPath: string): Promise<void> {
+	let stat = await lstatIfPresent(dirPath);
+	if (!stat) {
+		try {
+			await fs.mkdir(dirPath, { mode: 0o700 });
+		} catch (error) {
+			if (!isErrno(error, "EEXIST")) throw error;
+		}
+		stat = await fs.lstat(dirPath);
+	}
+	assertDirectoryStatWithoutSymlink(dirPath, stat);
+}
+
+function assertDirectoryStatWithoutSymlink(dirPath: string, stat: Stats): void {
+	if (stat.isSymbolicLink()) {
+		throw new Error(`state path contains symlink: ${dirPath}`);
+	}
+	if (!stat.isDirectory()) {
+		throw new Error(`state path parent is not a directory: ${dirPath}`);
+	}
+}
+
+async function ensureResolvedGjcParent(filePath: string): Promise<void> {
+	const resolved = path.resolve(filePath);
+	const gjcRoot = gjcRootFromResolvedTarget(resolved);
+	const parent = path.dirname(resolved);
+	if (!isWithinOrEqualPath(gjcRoot, parent)) {
+		throw new Error(`resolved target path must stay within project .gjc/**: ${filePath}`);
+	}
+	await ensureExistingDirectoryWithoutSymlink(gjcRoot);
+	const relativeParent = path.relative(gjcRoot, parent);
+	let current = gjcRoot;
+	for (const segment of relativeParent.split(path.sep).filter(Boolean)) {
+		current = path.join(current, segment);
+		await ensureExistingDirectoryWithoutSymlink(current);
+	}
+}
+
+async function assertResolvedGjcParentConfined(filePath: string): Promise<void> {
+	const resolved = path.resolve(filePath);
+	const gjcRoot = gjcRootFromResolvedTarget(resolved);
+	const parent = path.dirname(resolved);
+	if (!isWithinOrEqualPath(gjcRoot, parent)) {
+		throw new Error(`resolved target path must stay within project .gjc/**: ${filePath}`);
+	}
+	const rootStat = await lstatIfPresent(gjcRoot);
+	if (!rootStat) return;
+	assertDirectoryStatWithoutSymlink(gjcRoot, rootStat);
+	const relativeParent = path.relative(gjcRoot, parent);
+	let current = gjcRoot;
+	for (const segment of relativeParent.split(path.sep).filter(Boolean)) {
+		current = path.join(current, segment);
+		const stat = await lstatIfPresent(current);
+		if (!stat) return;
+		assertDirectoryStatWithoutSymlink(current, stat);
+	}
+}
+
+async function assertResolvedGjcTargetIsNotSymlink(filePath: string): Promise<void> {
+	const stat = await lstatIfPresent(filePath);
+	if (stat?.isSymbolicLink()) {
+		throw new Error(`state path target is a symlink: ${filePath}`);
+	}
 }
 
 function tempPathFor(filePath: string): string {
@@ -277,6 +366,8 @@ export function stampWorkflowEnvelopeChecksum<T>(value: T, filePath: string, com
 export async function detectWorkflowEnvelopeIntegrityMismatch(
 	filePath: string,
 ): Promise<WorkflowEnvelopeIntegrityMismatch | undefined> {
+	await assertResolvedGjcParentConfined(filePath);
+	await assertResolvedGjcTargetIsNotSymlink(filePath);
 	const current = await readJsonIfPresent(filePath);
 	if (!current || typeof current !== "object" || Array.isArray(current)) return undefined;
 	const receipt = (current as Record<string, unknown>).receipt;
@@ -365,6 +456,7 @@ function buildActiveSnapshot(entries: SkillActiveEntry[]): SkillActiveState {
 }
 
 async function atomicRemove(filePath: string): Promise<boolean> {
+	await ensureResolvedGjcParent(filePath);
 	const tmpPath = tempPathFor(filePath);
 	try {
 		await fs.rename(filePath, tmpPath);
@@ -481,7 +573,7 @@ async function maybeAudit(mutatedPath: string, options?: StateWriterOptions): Pr
 }
 
 async function atomicWrite(filePath: string, content: string): Promise<string> {
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await ensureResolvedGjcParent(filePath);
 	const tmpPath = tempPathFor(filePath);
 	try {
 		await fs.writeFile(tmpPath, content, "utf-8");
@@ -501,6 +593,7 @@ async function writeGuardedResolvedJsonAtomic(
 	return lockResolvedWorkflowTarget(
 		filePath,
 		async () => {
+			await assertResolvedGjcTargetIsNotSymlink(filePath);
 			const current = await readJsonIfPresentTolerant(filePath);
 			const currentRevision = persistedStateRevision(current);
 
@@ -572,6 +665,7 @@ export async function writeGuardedWorkflowEnvelopeAtomic(
 							.join("; ")}`,
 					);
 				}
+				await enforceWorkflowEnvelopePhaseInvariants(filePath, parsed.data, options);
 				await atomicWrite(filePath, jsonText(next));
 				await maybeAudit(filePath, options);
 				return { path: filePath, written: true, revision: currentRevision + 1, stamped: next };
@@ -597,6 +691,7 @@ export async function writeGuardedWorkflowEnvelopeAtomic(
 						.join("; ")}`,
 				);
 			}
+			await enforceWorkflowEnvelopePhaseInvariants(filePath, parsed.data, options);
 			await atomicWrite(filePath, jsonText(next));
 			await maybeAudit(filePath, options);
 			return { path: filePath, written: true, revision: currentRevision + 1, stamped: next };
@@ -611,13 +706,21 @@ export async function writeJsonAtomic(
 	options?: StateWriterOptions,
 ): Promise<string> {
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
-	await atomicWrite(filePath, jsonText(withWorkflowReceipt(value, buildReceipt(options))));
-	await maybeAudit(filePath, options);
-	return filePath;
+	return lockResolvedWorkflowTarget(
+		filePath,
+		async () => {
+			await atomicWrite(filePath, jsonText(withWorkflowReceipt(value, buildReceipt(options))));
+			await maybeAudit(filePath, options);
+			return filePath;
+		},
+		options?.lock,
+	);
 }
 
 async function readPersistedPhase(filePath: string): Promise<string | undefined> {
 	try {
+		await ensureResolvedGjcParent(filePath);
+		await assertResolvedGjcTargetIsNotSymlink(filePath);
 		const existing = await readJsonIfPresent(filePath);
 		if (!isPlainObject(existing)) return undefined;
 		// Only an *active* prior envelope is a transition source. A cleared / handed-off
@@ -667,6 +770,60 @@ async function recordInvalidWorkflowTransition(args: {
 	}
 }
 
+async function enforceWorkflowEnvelopePhaseInvariants(
+	filePath: string,
+	envelope: RequiredOnWriteEnvelope,
+	options?: StateWriterOptions,
+): Promise<void> {
+	// #658: internal runtime writers (ralplan/ultragoal/deep-interview/team) persist
+	// envelopes directly, bypassing the `gjc state` CLI transition gate (`isValidTransition`,
+	// historically the sole call site in state-runtime.ts). Re-assert that gate on every
+	// sanctioned envelope write so internal writes cannot persist invalid state-machine phase
+	// transitions silently. Forced writes (`gjc state ... --force`, reconcile repairs) carry
+	// `audit.forced` and bypass, mirroring the CLI's `use --force to bypass`.
+	//
+	// The gate governs ACTIVE workflow progression only. Deactivation/teardown writes
+	// (`active: false`, e.g. `gjc state clear`, which persists the universal `complete`
+	// sentinel that is not a per-skill manifest state) leave the transition graph and are
+	// intentionally exempt.
+	if (options?.audit?.forced === true || envelope.active !== true) return;
+
+	const toPhase = envelope.current_phase.trim();
+	if (!toPhase) return;
+
+	// Lazy import: workflow-manifest dereferences CANONICAL_GJC_WORKFLOW_SKILLS at
+	// module load, and active-state -> state-writer -> workflow-manifest -> active-state
+	// is a load-time cycle. Importing at call time (after init) avoids the TDZ.
+	const { isKnownWorkflowState, isValidTransition } = await import("./workflow-manifest");
+	const skill = envelope.skill;
+
+	// Structural invariant (hard): a `current_phase` absent from the skill's manifest is
+	// never a legitimate internal write, matching the CLI/reconcile unknown-phase gate.
+	if (!isKnownWorkflowState(skill, toPhase)) {
+		throw new Error(
+			`Refusing to write unknown ${skill} phase "${toPhase}" to ${filePath}: not a known ${skill} manifest state (forced writes bypass via audit.forced)`,
+		);
+	}
+
+	// Transition invariant (#658): resolve the prior phase (caller-supplied
+	// `audit.fromPhase`, else the active persisted envelope on disk) and fail closed
+	// when the manifest does not define the edge. Forced repair/reconcile writes carry
+	// `audit.forced` and bypass this block above; ordinary runtime writers must not
+	// skip approval or completion gates by jumping between known states.
+	const fromPhase = (options?.audit?.fromPhase ?? (await readPersistedPhase(filePath)))?.trim();
+	if (
+		fromPhase &&
+		fromPhase !== toPhase &&
+		isKnownWorkflowState(skill, fromPhase) &&
+		!isValidTransition(skill, fromPhase, toPhase)
+	) {
+		await recordInvalidWorkflowTransition({ filePath, skill, fromPhase, toPhase, options });
+		throw new Error(
+			`Refusing to write invalid ${skill} phase transition "${fromPhase}" -> "${toPhase}" to ${filePath}: not a valid ${skill} manifest edge (forced writes bypass via audit.forced)`,
+		);
+	}
+}
+
 export async function writeWorkflowEnvelopeAtomic(
 	targetPath: string,
 	value: unknown,
@@ -683,50 +840,7 @@ export async function writeWorkflowEnvelopeAtomic(
 				.join("; ")}`,
 		);
 	}
-	// #658: internal runtime writers (ralplan/ultragoal/deep-interview/team) persist
-	// envelopes directly, bypassing the `gjc state` CLI transition gate (`isValidTransition`,
-	// historically the sole call site in state-runtime.ts). Re-assert that gate on every
-	// sanctioned envelope write so internal writes cannot persist invalid state-machine phase
-	// transitions silently. Forced writes (`gjc state ... --force`, reconcile repairs) carry
-	// `audit.forced` and bypass, mirroring the CLI's `use --force to bypass`.
-	//
-	// The gate governs ACTIVE workflow progression only. Deactivation/teardown writes
-	// (`active: false`, e.g. `gjc state clear`, which persists the universal `complete`
-	// sentinel that is not a per-skill manifest state) leave the transition graph and are
-	// intentionally exempt.
-	if (options?.audit?.forced !== true && parsed.data.active === true) {
-		const toPhase = parsed.data.current_phase.trim();
-		if (toPhase) {
-			// Lazy import: workflow-manifest dereferences CANONICAL_GJC_WORKFLOW_SKILLS at
-			// module load, and active-state -> state-writer -> workflow-manifest -> active-state
-			// is a load-time cycle. Importing at call time (after init) avoids the TDZ.
-			const { isKnownWorkflowState, isValidTransition } = await import("./workflow-manifest");
-			const skill = parsed.data.skill;
-			// Structural invariant (hard): a `current_phase` absent from the skill's manifest is
-			// never a legitimate internal write, matching the CLI/reconcile unknown-phase gate.
-			if (!isKnownWorkflowState(skill, toPhase)) {
-				throw new Error(
-					`Refusing to write unknown ${skill} phase "${toPhase}" to ${filePath}: not a known ${skill} manifest state (forced writes bypass via audit.forced)`,
-				);
-			}
-			// Transition invariant (#658, diagnostic-only safety net): resolve the prior phase
-			// (caller-supplied `audit.fromPhase`, else the active persisted envelope on disk) and
-			// flag edges the manifest does not define. Intentionally NON-blocking and audit-only
-			// — the CLI path already hard-fails invalid edges before reaching here, and legitimate
-			// internal repairs / ralplan short-mode stage skips move between valid states without a
-			// direct manifest edge. It records an `invalid_transition_detected` audit entry (no
-			// stderr) so such transitions are non-silent without breaking those flows.
-			const fromPhase = (options?.audit?.fromPhase ?? (await readPersistedPhase(filePath)))?.trim();
-			if (
-				fromPhase &&
-				fromPhase !== toPhase &&
-				isKnownWorkflowState(skill, fromPhase) &&
-				!isValidTransition(skill, fromPhase, toPhase)
-			) {
-				await recordInvalidWorkflowTransition({ filePath, skill, fromPhase, toPhase, options });
-			}
-		}
-	}
+	await enforceWorkflowEnvelopePhaseInvariants(filePath, parsed.data, options);
 	await atomicWrite(filePath, jsonText(stamped));
 	await maybeAudit(filePath, options);
 	return filePath;
@@ -767,7 +881,7 @@ async function lockResolvedWorkflowTarget<T>(
 ): Promise<T> {
 	// `withFileLock` creates the lock dir next to the target with a non-recursive
 	// mkdir, so the parent directory must exist before the lock is acquired.
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await ensureResolvedGjcParent(filePath);
 	return withFileLock(filePath, fn, lockOptions);
 }
 
@@ -780,6 +894,7 @@ export async function updateJsonAtomic<T = unknown>(
 	return lockResolvedWorkflowTarget(
 		filePath,
 		async () => {
+			await assertResolvedGjcTargetIsNotSymlink(filePath);
 			const current = (await readJsonIfPresent(filePath)) as T | undefined;
 			const next = await mutator(current);
 			await atomicWrite(filePath, jsonText(withWorkflowReceipt(next, buildReceipt(options))));
@@ -792,7 +907,8 @@ export async function updateJsonAtomic<T = unknown>(
 
 export async function appendJsonl(targetPath: string, entry: unknown, options?: StateWriterOptions): Promise<string> {
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await ensureResolvedGjcParent(filePath);
+	await assertResolvedGjcTargetIsNotSymlink(filePath);
 	await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, "utf-8");
 	await maybeAudit(filePath, options);
 	return filePath;
@@ -891,6 +1007,7 @@ export async function appendJsonlIdempotent(
 	return lockResolvedWorkflowTarget(
 		filePath,
 		async () => {
+			await assertResolvedGjcTargetIsNotSymlink(filePath);
 			const existing = await readJsonlEntries(filePath);
 			const duplicate = findJsonlDuplicate(existing, entry, options);
 			if (duplicate !== undefined) {
@@ -906,7 +1023,8 @@ export async function appendJsonlIdempotent(
 
 export async function appendText(targetPath: string, text: string, options?: StateWriterOptions): Promise<string> {
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await ensureResolvedGjcParent(filePath);
+	await assertResolvedGjcTargetIsNotSymlink(filePath);
 	await fs.appendFile(filePath, text, "utf-8");
 	await maybeAudit(filePath, options);
 	return filePath;
@@ -918,7 +1036,7 @@ export async function createJsonNoClobber(
 	options?: StateWriterOptions,
 ): Promise<string> {
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await ensureResolvedGjcParent(filePath);
 	let handle: fs.FileHandle | undefined;
 	try {
 		handle = await fs.open(filePath, "wx");
@@ -940,12 +1058,19 @@ export async function deleteIfOwned(
 	const options = typeof predicateOrOptions === "function" ? undefined : predicateOrOptions;
 	const predicate = typeof predicateOrOptions === "function" ? predicateOrOptions : predicateOrOptions?.predicate;
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
-	const current = await readJsonIfPresent(filePath);
-	if (current === undefined) return { path: filePath, deleted: false };
-	if (predicate && !(await predicate(current))) return { path: filePath, deleted: false };
-	const deleted = await atomicRemove(filePath);
-	if (deleted) await maybeAudit(filePath, options);
-	return { path: filePath, deleted };
+	return lockResolvedWorkflowTarget(
+		filePath,
+		async () => {
+			await assertResolvedGjcTargetIsNotSymlink(filePath);
+			const current = await readJsonIfPresent(filePath);
+			if (current === undefined) return { path: filePath, deleted: false };
+			if (predicate && !(await predicate(current))) return { path: filePath, deleted: false };
+			const deleted = await atomicRemove(filePath);
+			if (deleted) await maybeAudit(filePath, options);
+			return { path: filePath, deleted };
+		},
+		options?.lock,
+	);
 }
 
 export async function removeFileAudited(targetPath: string, options?: StateWriterOptions): Promise<DeleteResult> {
@@ -969,6 +1094,8 @@ export async function writeActiveEntry(
 	options?: StateWriterOptions,
 ): Promise<string> {
 	const filePath = activeEntryPath(path.resolve(cwd), sessionScope, skill);
+	await ensureResolvedGjcParent(filePath);
+	await assertResolvedGjcTargetIsNotSymlink(filePath);
 	await writeGuardedResolvedJsonAtomic(
 		filePath,
 		{ ...entry, skill },
@@ -992,6 +1119,7 @@ export async function removeActiveEntry(
 	return lockResolvedWorkflowTarget(
 		filePath,
 		async () => {
+			await assertResolvedGjcTargetIsNotSymlink(filePath);
 			const current = await readJsonIfPresent(filePath);
 			const incomingSourceRevision = options?.sourceRevision;
 			if (
@@ -1134,6 +1262,8 @@ export async function hardPrune(
 	const removed: string[] = [];
 	for (const target of targets) {
 		const filePath = resolveGjcTarget(target.path, cwd);
+		await ensureResolvedGjcParent(filePath);
+		await assertResolvedGjcTargetIsNotSymlink(filePath);
 		let stat: Stats;
 		try {
 			stat = await fs.stat(filePath);
@@ -1208,7 +1338,8 @@ export async function appendAuditEntry(
 	const entry = typeof sessionIdOrEntry === "string" ? maybeEntry : sessionIdOrEntry;
 	if (!entry) throw new Error("audit entry is required");
 	const filePath = resolveGjcTarget(layoutAuditPath(cwd, sessionId), cwd);
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await ensureResolvedGjcParent(filePath);
+	await assertResolvedGjcTargetIsNotSymlink(filePath);
 	await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, "utf-8");
 	return filePath;
 }
@@ -1264,6 +1395,8 @@ export async function updateWorkflowTransactionJournal(
 	patch: Partial<WorkflowTransactionJournal>,
 ): Promise<string> {
 	const filePath = transactionJournalPath(cwd, sessionId, mutationId);
+	await ensureResolvedGjcParent(filePath);
+	await assertResolvedGjcTargetIsNotSymlink(filePath);
 	const current = ((await readJsonIfPresent(filePath)) ?? {}) as WorkflowTransactionJournal;
 	const next = { ...current, ...patch, updated_at: new Date().toISOString() } as WorkflowTransactionJournal;
 	await atomicWrite(filePath, jsonText(next));

--- a/packages/coding-agent/src/task/gjc-command.ts
+++ b/packages/coding-agent/src/task/gjc-command.ts
@@ -1,7 +1,5 @@
 import process from "node:process";
 
-import { $env } from "@gajae-code/utils";
-
 interface GjcCommand {
 	cmd: string;
 	args: string[];
@@ -12,11 +10,6 @@ const DEFAULT_CMD = process.platform === "win32" ? "gjc.cmd" : "gjc";
 const DEFAULT_SHELL = process.platform === "win32";
 
 export function resolveGjcCommand(): GjcCommand {
-	const envCmd = $env.PI_SUBPROCESS_CMD;
-	if (envCmd?.trim()) {
-		return { cmd: envCmd, args: [], shell: DEFAULT_SHELL };
-	}
-
 	const entry = process.argv[1];
 	if (entry && (entry.endsWith(".ts") || entry.endsWith(".js"))) {
 		return { cmd: process.execPath, args: [entry], shell: false };

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as path from "node:path";
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
 import type { Component } from "@gajae-code/tui";
 import { ImageProtocol, TERMINAL, Text } from "@gajae-code/tui";
@@ -46,6 +47,15 @@ const READ_ONLY_BASH_ENV: Record<string, string> = {
 	GREP_COLORS: "",
 	RIPGREP_CONFIG_PATH: "",
 };
+
+function isWithinOrEqualPath(root: string, candidate: string): boolean {
+	const relative = path.relative(root, candidate);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function commandHasRalplanArtifactEnvFlag(command: string): boolean {
+	return new RegExp(`(?:^|\\s)--artifact-env\\s+${GJC_RALPLAN_ARTIFACT_ENV}(?:\\s|$)`, "u").test(command);
+}
 
 export async function saveBashOriginalArtifactForTests(
 	session: ToolSession,
@@ -540,16 +550,19 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			env &&
 			Object.keys(env).length === 1 &&
 			Object.hasOwn(env, GJC_RALPLAN_ARTIFACT_ENV) &&
-			rawCommand.includes(`--artifact-env ${GJC_RALPLAN_ARTIFACT_ENV}`);
+			commandHasRalplanArtifactEnvFlag(rawCommand);
+		if (this.session.bashRestrictionProfile === "read-only" && env && Object.keys(env).length > 0) {
+			throw new ToolError("Read-only bash does not allow per-command env overrides.");
+		}
 		if (
-			(this.session.bashRestrictionProfile === "read-only" || (allowedPrefixes && allowedPrefixes.length > 0)) &&
+			allowedPrefixes &&
+			allowedPrefixes.length > 0 &&
 			env &&
 			Object.keys(env).length > 0 &&
 			!isRestrictedRalplanArtifactEnv
 		) {
-			const mode = this.session.bashRestrictionProfile === "read-only" ? "Read-only" : "Restricted role-agent";
 			throw new ToolError(
-				`${mode} bash only allows the ${GJC_RALPLAN_ARTIFACT_ENV} env override for --artifact-env.`,
+				`Restricted role-agent bash only allows the ${GJC_RALPLAN_ARTIFACT_ENV} env override when command includes --artifact-env ${GJC_RALPLAN_ARTIFACT_ENV}.`,
 			);
 		}
 		if (allowedPrefixes && allowedPrefixes.length > 0) {
@@ -649,6 +662,16 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		}
 		if (!cwdStat.isDirectory()) {
 			throw new ToolError(`Working directory is not a directory: ${commandCwd}`);
+		}
+		if (this.session.bashRestrictionProfile === "read-only" || (allowedPrefixes && allowedPrefixes.length > 0)) {
+			const [sessionRealpath, commandRealpath] = await Promise.all([
+				fs.promises.realpath(this.session.cwd),
+				fs.promises.realpath(commandCwd),
+			]);
+			if (!isWithinOrEqualPath(sessionRealpath, commandRealpath)) {
+				const mode = this.session.bashRestrictionProfile === "read-only" ? "Read-only" : "Restricted role-agent";
+				throw new ToolError(`${mode} bash cwd must stay within the session workspace.`);
+			}
 		}
 
 		const requestedTimeoutSec = input.timeout ?? 300;

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -144,6 +144,33 @@ describe("contribution prep", () => {
 		}
 	});
 
+	it("ignores PI_SUBPROCESS_CMD when spawning contribution workers", async () => {
+		const tempDir = TempDir.createSync("@gjc-contribution-prep-env-spawn-");
+		const previous = process.env.PI_SUBPROCESS_CMD;
+		process.env.PI_SUBPROCESS_CMD = "/tmp/evil-gjc";
+		try {
+			const spawns: Array<{ args: string[]; cwd: string }> = [];
+			await prepareContributionPrep(
+				{ sessionId: "source-session", cwd: tempDir.path(), messages: [] },
+				{
+					artifactRoot: path.join(tempDir.path(), "artifacts"),
+					spawnWorker: true,
+					spawn: async (args, cwd) => {
+						spawns.push({ args, cwd });
+					},
+				},
+			);
+
+			expect(spawns).toHaveLength(1);
+			expect(spawns[0]?.args[0]).not.toBe("/tmp/evil-gjc");
+			expect(spawns[0]?.args).toContain("--no-skills");
+		} finally {
+			if (previous === undefined) delete process.env.PI_SUBPROCESS_CMD;
+			else process.env.PI_SUBPROCESS_CMD = previous;
+			tempDir.remove();
+		}
+	});
+
 	it("resolves worker spawn argv through the GJC command and prompt file", async () => {
 		const tempDir = TempDir.createSync("@gjc-contribution-prep-real-spawn-");
 		try {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -676,6 +676,61 @@ describe("ExtensionRunner", () => {
 
 			warnSpy.mockRestore();
 		});
+
+		it("fails closed when a tool_call handler times out", async () => {
+			const hangExtensionPath = path.join(tempDir.path(), "hang-tool-call.ts");
+			fs.writeFileSync(
+				hangExtensionPath,
+				`
+					export default function(pi) {
+						pi.on("tool_call", async () => {
+							await Promise.withResolvers().promise;
+						});
+					}
+				`,
+			);
+
+			const result = await loadTestExtensions([hangExtensionPath]);
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+			const errors: Array<{ extensionPath: string; event: string; error: string }> = [];
+			runner.onError(err => {
+				errors.push(err);
+			});
+			testSetExtensionHandlerTimeoutMs(10);
+
+			const toolCallResult = await runner.emitToolCall({
+				type: "tool_call",
+				toolName: "bash",
+				toolCallId: "call-timeout",
+				input: {},
+			});
+
+			expect(toolCallResult).toEqual({
+				block: true,
+				reason: `Extension ${hangExtensionPath} timed out handling tool_call.`,
+			});
+			expect(warnSpy).toHaveBeenCalledWith("Extension handler timed out", {
+				extensionPath: hangExtensionPath,
+				event: "tool_call",
+				timeoutMs: 10,
+			});
+			expect(errors).toEqual([
+				{
+					extensionPath: hangExtensionPath,
+					event: "tool_call",
+					error: "handler timed out after 10ms",
+				},
+			]);
+
+			warnSpy.mockRestore();
+		});
 	});
 
 	describe("session name API", () => {

--- a/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { modeStatePath, sessionStateDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
+import { modeStatePath, sessionDirName, sessionStateDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
 
 const TEST_SESSION_ID = "test-session";
@@ -70,6 +70,19 @@ describe("gjc state write hardening", () => {
 		const result = await writeState(root, "ralplan", { current_phase: "final" });
 		expect(result.status).not.toBe(0);
 		expect(result.stderr).toContain("invalid ralplan phase transition from planner to final");
+	});
+
+	it("rejects writes through symlinked state parents", async () => {
+		const root = await tempDir();
+		const victim = await tempDir();
+		await fs.mkdir(path.join(root, ".gjc"), { recursive: true });
+		await fs.symlink(victim, path.join(root, ".gjc", sessionDirName(TEST_SESSION_ID)));
+
+		const result = await writeState(root, "ralplan", { current_phase: "planner" });
+
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain("state path contains symlink");
+		await expect(fs.readFile(path.join(victim, "state", "ralplan-state.json"), "utf-8")).rejects.toThrow();
 	});
 
 	it("allows --force to bypass a known-bad jump", async () => {

--- a/packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts
@@ -390,7 +390,7 @@ describe("workflow state writer drift guard", () => {
 		expect(persisted.current_phase).toBe("bogus-phase");
 	});
 
-	it("flags an invalid phase transition on an internal write but still persists it (#658 transition invariant)", async () => {
+	it("rejects an invalid phase transition on an internal write (#658 transition invariant)", async () => {
 		const root = await tempDir();
 		const statePath = modeStatePath(root, TEST_SESSION_ID, "ralplan");
 		const base = {
@@ -419,24 +419,13 @@ describe("workflow state writer drift guard", () => {
 		// Seed a valid active prior phase, then jump planner -> final (no manifest edge).
 		await writeWorkflowEnvelopeAtomic(statePath, { ...base, current_phase: "planner" }, opts);
 
-		// The diagnostic-only path must NOT touch stderr (callers may treat stderr as failure
-		// or parse machine output): capture stderr across the invalid-edge write.
-		const originalWrite = process.stderr.write.bind(process.stderr);
-		let stderrCaptured = "";
-		process.stderr.write = ((chunk: unknown) => {
-			stderrCaptured += typeof chunk === "string" ? chunk : String(chunk);
-			return true;
-		}) as typeof process.stderr.write;
-		try {
-			await writeWorkflowEnvelopeAtomic(statePath, { ...base, current_phase: "final" }, opts);
-		} finally {
-			process.stderr.write = originalWrite;
-		}
-		expect(stderrCaptured).toBe("");
+		// Invalid known-state edges fail closed at the writer boundary; audit evidence
+		// is supplementary and must not be the only enforcement.
+		await expect(writeWorkflowEnvelopeAtomic(statePath, { ...base, current_phase: "final" }, opts)).rejects.toThrow(
+			'Refusing to write invalid ralplan phase transition "planner" -> "final"',
+		);
 
-		// The invalid edge is recorded as audit evidence, not blocked.
-		await expectPersistedEnvelope(statePath);
-		expect((await readJson(statePath)).current_phase).toBe("final");
+		expect((await readJson(statePath)).current_phase).toBe("planner");
 		const flagged = (await readAuditEntries(root)).filter(e => e.verb === "invalid_transition_detected");
 		expect(flagged.length).toBe(1);
 		expect(flagged[0]?.from_phase).toBe("planner");

--- a/packages/coding-agent/test/gjc-state-writer-policy.test.ts
+++ b/packages/coding-agent/test/gjc-state-writer-policy.test.ts
@@ -3,12 +3,14 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+	deleteIfOwned,
 	detectWorkflowEnvelopeIntegrityMismatch,
 	removeActiveEntry,
 	StateWriteConflictError,
 	writeActiveEntry,
 	writeGuardedJsonAtomic,
 	writeGuardedWorkflowEnvelopeAtomic,
+	writeJsonAtomic,
 } from "../src/gjc-runtime/state-writer";
 
 describe("GJC state writer revision policy", () => {
@@ -148,6 +150,72 @@ describe("GJC state writer revision policy", () => {
 		).rejects.toBeInstanceOf(StateWriteConflictError);
 
 		await expect(readJson(root, target)).resolves.toMatchObject({ current_phase: "handoff", state_revision: 2 });
+	});
+
+	it("rejects unknown active phases in guarded workflow envelopes", async () => {
+		const root = await cwd();
+		const target = ".gjc/_session-sess/state/mode-state/deep-interview.json";
+
+		await expect(
+			writeGuardedWorkflowEnvelopeAtomic(target, modeEnvelope("stale"), {
+				cwd: root,
+				policy: "source",
+				receipt: receipt(root),
+			}),
+		).rejects.toThrow('Refusing to write unknown deep-interview phase "stale"');
+
+		await expect(fs.stat(path.join(root, target))).rejects.toThrow();
+	});
+
+	it("rejects invalid known transitions in guarded workflow envelopes", async () => {
+		const root = await cwd();
+		const target = ".gjc/_session-sess/state/mode-state/ralplan.json";
+		const base = {
+			skill: "ralplan",
+			current_phase: "planner",
+			active: true,
+			version: 2,
+			updated_at: "2026-01-01T00:00:00.000Z",
+		};
+		const ralplanReceipt = {
+			cwd: root,
+			skill: "ralplan" as const,
+			owner: "gjc-runtime" as const,
+			command: "test",
+			sessionId: "sess",
+			nowIso: "2026-01-01T00:00:00.000Z",
+		};
+
+		await writeGuardedWorkflowEnvelopeAtomic(target, base, { cwd: root, policy: "source", receipt: ralplanReceipt });
+		await expect(
+			writeGuardedWorkflowEnvelopeAtomic(
+				target,
+				{ ...base, current_phase: "final" },
+				{ cwd: root, policy: "source", expectedRevision: 1, receipt: ralplanReceipt },
+			),
+		).rejects.toThrow('Refusing to write invalid ralplan phase transition "planner" -> "final"');
+
+		await expect(readJson(root, target)).resolves.toMatchObject({ current_phase: "planner", state_revision: 1 });
+	});
+
+	it("serializes owned deletes against atomic json replacement", async () => {
+		const root = await cwd();
+		const target = ".gjc/_session-sess/state/claims/task.json";
+		await writeJsonAtomic(target, { token: "old" }, { cwd: root });
+		let replacement: Promise<string> | undefined;
+
+		const deleted = await deleteIfOwned(target, {
+			cwd: root,
+			predicate: current => {
+				if ((current as { token?: string }).token !== "old") return false;
+				replacement = writeJsonAtomic(target, { token: "new" }, { cwd: root });
+				return true;
+			},
+		});
+		await replacement;
+
+		expect(deleted.deleted).toBe(true);
+		await expect(readJson(root, target)).resolves.toMatchObject({ token: "new" });
 	});
 
 	it("guarded workflow envelope checksum covers final receipt and state_revision", async () => {

--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -29,6 +29,10 @@ function git(cwd: string, args: string[]): void {
 	if (proc.exitCode !== 0) throw new Error(proc.stderr.toString() || `git ${args.join(" ")} failed`);
 }
 
+function stateFileFor(root: string, sessionId: string): string {
+	return path.join(sessionRuntimeDir(root, sessionId), "state.json");
+}
+
 afterEach(async () => {
 	if (ORIGINAL_STATE_FILE === undefined) delete process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV];
 	else process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = ORIGINAL_STATE_FILE;
@@ -42,7 +46,7 @@ afterEach(async () => {
 describe("coordinator runtime state sidecar", () => {
 	it("persists final assistant text on agent_end", async () => {
 		const root = await tempRoot();
-		const stateFile = path.join(root, "state.json");
+		const stateFile = stateFileFor(root, "fallback");
 		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
 		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "visible-session";
 
@@ -74,6 +78,29 @@ describe("coordinator runtime state sidecar", () => {
 		});
 	});
 
+	it("ignores env-supplied state files outside the session runtime root", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "outside-state.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "visible-session";
+
+		await persistCoordinatorRuntimeStateFromEvent(
+			{
+				type: "agent_end",
+				messages: [
+					{
+						role: "assistant",
+						content: [{ type: "text", text: "Done from runtime" }],
+						stopReason: "stop",
+					},
+				],
+			},
+			{ sessionId: "fallback", cwd: root, sessionFile: null },
+		);
+
+		expect(await Bun.file(stateFile).exists()).toBe(false);
+	});
+
 	it("recognizes only matching completed or errored runtime markers as terminal", async () => {
 		const root = await tempRoot();
 		const stateFile = path.join(root, "state.json");
@@ -102,6 +129,45 @@ describe("coordinator runtime state sidecar", () => {
 		});
 	});
 
+	it("rejects terminal markers missing caller-provided cwd or session file bindings", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "session-a",
+				state: "completed",
+			}),
+		);
+
+		await expect(
+			readTerminalRuntimeStateMarker({
+				stateFile,
+				sessionId: "session-a",
+				cwd: root,
+				sessionFile: path.join(root, "session.jsonl"),
+			}),
+		).resolves.toEqual({ terminal: false, reason: "cwd_mismatch" });
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "session-a",
+				state: "completed",
+				cwd: root,
+			}),
+		);
+		await expect(
+			readTerminalRuntimeStateMarker({
+				stateFile,
+				sessionId: "session-a",
+				cwd: root,
+				sessionFile: path.join(root, "session.jsonl"),
+			}),
+		).resolves.toEqual({ terminal: false, reason: "session_file_mismatch" });
+	});
+
 	it("rejects non-terminal and mismatched runtime markers", async () => {
 		const root = await tempRoot();
 		const stateFile = path.join(root, "state.json");
@@ -127,7 +193,7 @@ describe("coordinator runtime state sidecar", () => {
 
 	it("writes public-safe postmortem exit evidence without transcript payloads", async () => {
 		const root = await tempRoot();
-		const stateFile = path.join(root, "state.json");
+		const stateFile = stateFileFor(root, "fallback");
 		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
 		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "postmortem-session";
 		process.env[GJC_COORDINATOR_SESSION_BRANCH_ENV] = "issue-1496";
@@ -171,7 +237,8 @@ describe("coordinator runtime state sidecar", () => {
 		git(workspace, ["add", "README.md"]);
 		git(workspace, ["commit", "-m", "init"]);
 		await Bun.write(path.join(workspace, "README.md"), "base\nrecoverable dirty change\n");
-		const stateFile = path.join(root, "state.json");
+		const stateFile = stateFileFor(workspace, "fallback");
+		await fs.mkdir(path.dirname(stateFile), { recursive: true });
 		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
 		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "post-acceptance-session";
 		await Bun.write(
@@ -265,7 +332,8 @@ describe("coordinator runtime state sidecar", () => {
 
 	it("does not overwrite richer terminal agent_end evidence during postmortem", async () => {
 		const root = await tempRoot();
-		const stateFile = path.join(root, "state.json");
+		const stateFile = stateFileFor(root, "fallback");
+		await fs.mkdir(path.dirname(stateFile), { recursive: true });
 		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
 		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "preserved-session";
 		await Bun.write(

--- a/packages/coding-agent/test/tools/bash-interceptor.test.ts
+++ b/packages/coding-agent/test/tools/bash-interceptor.test.ts
@@ -175,6 +175,23 @@ describe("BashTool restricted role-agent allowlist", () => {
 			"restricted role-agent bash only allows commands starting with",
 		);
 	});
+	it("blocks restricted role-agent cwd outside the session workspace", async () => {
+		const root = await fs.mkdtemp(path.join(process.cwd(), ".tmp-restricted-cwd-root-"));
+		const outside = await fs.mkdtemp(path.join(process.cwd(), ".tmp-restricted-cwd-outside-"));
+		try {
+			const tool = createRestrictedBashTool(root, ["gjc state"]);
+
+			await expect(
+				tool.execute("tool-call", {
+					command: "gjc state read --json",
+					cwd: outside,
+				}),
+			).rejects.toThrow("Restricted role-agent bash cwd must stay within the session workspace");
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+			await fs.rm(outside, { recursive: true, force: true });
+		}
+	});
 
 	it("surfaces read-only bash restrictions in the tool description", () => {
 		const tool = createRestrictedBashTool(process.cwd(), ["grep", "rg", "tree", "ls"], "read-only");
@@ -197,7 +214,7 @@ describe("BashTool restricted role-agent allowlist", () => {
 				"read-only bash only allows commands starting with",
 			);
 			await expect(tool.execute("tool-call", { command: "ls", env: { PATH: "/tmp/fake" } })).rejects.toThrow(
-				"Read-only bash only allows the GJC_RALPLAN_ARTIFACT env override for --artifact-env.",
+				"Read-only bash does not allow per-command env overrides.",
 			);
 		} finally {
 			await fs.rm(root, { recursive: true, force: true });
@@ -258,6 +275,17 @@ describe("BashTool restricted role-agent allowlist", () => {
 			tool.execute("tool-call", {
 				command: "gjc ralplan --write --stage architect --stage_n 1 --artifact ok",
 				env: { PATH: "/tmp/fake" },
+			}),
+		).rejects.toThrow("only allows the GJC_RALPLAN_ARTIFACT env override");
+	});
+
+	it("blocks artifact env overrides when --artifact-env only matches as a substring", async () => {
+		const tool = createRestrictedBashTool();
+
+		await expect(
+			tool.execute("tool-call", {
+				command: "gjc ralplan --write --stage architect --stage_n 1 --artifact-env GJC_RALPLAN_ARTIFACT_EVIL",
+				env: { GJC_RALPLAN_ARTIFACT: "payload" },
 			}),
 		).rejects.toThrow("only allows the GJC_RALPLAN_ARTIFACT env override");
 	});


### PR DESCRIPTION
## Summary
- harden GJC workflow state writes/deletes with stricter locking and path boundaries
- restrict role-agent/bash env override and artifact handling paths
- validate coordinator runtime-state sidecar paths and persist recoverable launch/postmortem errors safely
- remove direct handoff and unsafe state-clear command shapes from restricted workflow command execution

Split out of closed #1675 as a focused dev-based PR.

## Verification
- `bun test packages/coding-agent/test/contribution-prep.test.ts packages/coding-agent/test/extensions-runner.test.ts packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts packages/coding-agent/test/gjc-state-writer-policy.test.ts packages/coding-agent/test/session-state-sidecar.test.ts packages/coding-agent/test/tools/bash-interceptor.test.ts` — 105 pass
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/commands/launch.ts packages/coding-agent/src/extensibility/extensions/runner.ts packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts packages/coding-agent/src/gjc-runtime/state-writer.ts packages/coding-agent/src/task/gjc-command.ts packages/coding-agent/src/tools/bash.ts packages/coding-agent/test/contribution-prep.test.ts packages/coding-agent/test/extensions-runner.test.ts packages/coding-agent/test/gjc-runtime/state-write-hardening.test.ts packages/coding-agent/test/gjc-runtime/state-writer-drift.test.ts packages/coding-agent/test/gjc-state-writer-policy.test.ts packages/coding-agent/test/session-state-sidecar.test.ts packages/coding-agent/test/tools/bash-interceptor.test.ts`