### PR TITLE
fix(deep-interview): strip leaked envelope keys from nested state (recursive state.state corruption)

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
@@ -151,12 +151,38 @@ const HOISTED_STATE_FIELDS = [
 ] as const;
 
 /**
+ * Envelope-reserved keys that are never legitimate interview `state` fields.
+ *
+ * A malformed write that wraps a whole envelope under `state`
+ * (`gjc state deep-interview write --input '{"state": <envelope>}'`) leaks these
+ * into the nested state. Because normalization otherwise preserves unknown
+ * nested fields, they would accrete a recursive `state.state` chain (plus stale
+ * `receipt`/`skill`/`version`/... duplicates) that no later merge or write ever
+ * removes, permanently corrupting the shape. They are stripped from `state` on
+ * normalize so the canonical envelope self-heals on the next write.
+ */
+const ENVELOPE_RESERVED_STATE_KEYS = [
+	"state",
+	"receipt",
+	"skill",
+	"version",
+	"updated_at",
+	"active",
+	"current_phase",
+	"state_revision",
+	"session_id",
+] as const;
+
+/**
  * Canonicalize a deep-interview envelope: interview data nested under `state`,
  * legacy flattened fields hoisted in losslessly, transcript duplicates removed
  * from the top level, and `rounds`/`established_facts` guaranteed to be arrays.
  *
- * Idempotent: a canonical envelope is returned unchanged in shape. Never deletes
- * unknown envelope or nested fields, and never mutates the input.
+ * Idempotent: a canonical envelope is returned unchanged in shape. Preserves all
+ * unknown envelope and nested fields except the envelope-reserved keys that leak
+ * into `state` (see `ENVELOPE_RESERVED_STATE_KEYS`), which are stripped so a
+ * malformed envelope-in-state write cannot permanently nest state. Never mutates
+ * the input.
  */
 export function normalizeDeepInterviewEnvelope(value: unknown): DeepInterviewStateEnvelope {
 	const envelope: DeepInterviewStateEnvelope = isPlainObject(value) ? { ...value } : {};
@@ -168,6 +194,9 @@ export function normalizeDeepInterviewEnvelope(value: unknown): DeepInterviewSta
 	}
 	for (const field of HOISTED_STATE_FIELDS) {
 		if (inner[field] === undefined && envelope[field] !== undefined) inner[field] = envelope[field];
+	}
+	for (const field of ENVELOPE_RESERVED_STATE_KEYS) {
+		if (field in inner) delete inner[field];
 	}
 
 	if (!Array.isArray(inner.rounds)) inner.rounds = [];

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-state-redteam.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-state-redteam.test.ts
@@ -188,6 +188,104 @@ describe("deep-interview redteam: idempotency and lossless shape normalization",
 			answer_hash: "answer-shell-hash",
 		});
 	});
+
+	it("strips leaked envelope-reserved keys from nested state and self-heals recursive nesting", () => {
+		// Reproduces the real corruption: a write wrapped a whole envelope under
+		// `state`, leaking `state.state`/`state.receipt`/`state.skill`/... into the
+		// nested state where they accreted forever. Good top-level interview data
+		// coexists with a stale nested duplicate.
+		const corrupt = {
+			skill: "deep-interview",
+			active: true,
+			current_phase: "interviewing",
+			version: 2,
+			updated_at: "2026-07-06T06:47:40.342Z",
+			receipt: { owner: "gjc-state-cli", command: "gjc state deep-interview write" },
+			state_revision: 3,
+			state: {
+				rounds: [
+					{ round_key: "iv::r:1::q:q1", round: 1, lifecycle: "scored", ambiguity: 0.62 },
+					{ round_key: "iv::r:2::q:q2", round: 2, lifecycle: "scored", ambiguity: 0.61 },
+				],
+				established_facts: [{ id: "f1", statement: "confirmed fact", round: 1, disputed: false }],
+				interview_id: "iv",
+				current_ambiguity: 0.61,
+				topology: { status: "confirmed", last_targeted_component_id: "supabase-backend" },
+				custom_extension: { keep: true },
+				// Leaked envelope-reserved keys (junk from an envelope-in-state write):
+				active: true,
+				current_phase: "interviewing",
+				skill: "deep-interview",
+				version: 2,
+				updated_at: "2026-07-06T06:38:03.375Z",
+				receipt: { owner: "stale" },
+				state_revision: 1,
+				session_id: "sess",
+				state: {
+					rounds: [],
+					established_facts: [{ id: "old", statement: "stale fact", round: 0, disputed: false }],
+					current_ambiguity: 1,
+					topology: { status: "pending" },
+				},
+			},
+		};
+
+		const normalized = normalizeDeepInterviewEnvelope(corrupt);
+		const state = inner(normalized);
+		for (const reserved of [
+			"state",
+			"receipt",
+			"skill",
+			"version",
+			"updated_at",
+			"active",
+			"current_phase",
+			"state_revision",
+			"session_id",
+		]) {
+			expect(Object.hasOwn(state, reserved)).toBe(false);
+		}
+		// Good interview data survives untouched; the stale nested duplicate is gone.
+		expect((state.rounds as Array<Record<string, unknown>>).map(round => round.round)).toEqual([1, 2]);
+		expect(state.established_facts).toEqual([{ id: "f1", statement: "confirmed fact", round: 1, disputed: false }]);
+		expect(state.current_ambiguity).toBe(0.61);
+		expect(state.topology).toEqual({ status: "confirmed", last_targeted_component_id: "supabase-backend" });
+		expect(state.interview_id).toBe("iv");
+		// Non-reserved unknown nested fields are still preserved (free-form extension).
+		expect(state.custom_extension).toEqual({ keep: true });
+		// Envelope-level reserved keys remain legitimately at the top level.
+		expect(normalized.skill).toBe("deep-interview");
+		expect(normalized.receipt).toEqual({ owner: "gjc-state-cli", command: "gjc state deep-interview write" });
+		// Idempotent: a second normalization pass is a fixed point.
+		expect(normalizeDeepInterviewEnvelope(clone(normalized))).toEqual(normalized);
+	});
+
+	it("self-heals leaked reserved keys through a partial merge without dropping rounds", () => {
+		const corruptExisting = {
+			skill: "deep-interview",
+			active: true,
+			current_phase: "interviewing",
+			state: {
+				rounds: [{ round_key: "iv::r:1::q:q1", round: 1, lifecycle: "scored", ambiguity: 0.62 }],
+				established_facts: [{ id: "f1", statement: "fact", round: 1, disputed: false }],
+				current_ambiguity: 0.62,
+				// Leaked junk a plain merge would otherwise carry forward forever:
+				state: { rounds: [], current_ambiguity: 1 },
+				receipt: { owner: "stale" },
+				skill: "deep-interview",
+			},
+		};
+		// A normal partial update (e.g. a topology write) that carries no reserved keys.
+		const merged = mergeDeepInterviewEnvelope(corruptExisting, { state: { topology: { status: "confirmed" } } });
+		const state = inner(merged);
+		expect(Object.hasOwn(state, "state")).toBe(false);
+		expect(Object.hasOwn(state, "receipt")).toBe(false);
+		expect(Object.hasOwn(state, "skill")).toBe(false);
+		expect((state.rounds as Array<Record<string, unknown>>).map(round => round.round)).toEqual([1]);
+		expect(state.established_facts).toEqual([{ id: "f1", statement: "fact", round: 1, disputed: false }]);
+		expect(state.topology).toEqual({ status: "confirmed" });
+		expect(state.current_ambiguity).toBe(0.62);
+	});
 });
 
 describe("deep-interview redteam: writer and recorder integration", () => {


### PR DESCRIPTION
## Problem

A deep-interview envelope is `{ active, current_phase, version, updated_at, receipt, state_revision, session_id, skill, state: { …interview fields… } }` — interview data lives under `state`.

The contract for updates is `gjc state deep-interview write --input '{"state": { …interview fields… }}'`. It's easy for an agent to instead read the **current full envelope** and write it back as the `state` value:

```
gjc state deep-interview write --input '{"state": <the entire envelope it just read>}'
```

That leaks envelope-reserved keys — `state.state`, `state.receipt`, `state.skill`, `state.version`, `state.updated_at`, `state.active`, `state.current_phase`, `state_revision`, `session_id` — **into the nested interview state**.

The real corruption I hit while running a deep interview (top-level `state` is correct and current, but it carries a stale nested envelope duplicate):

```jsonc
{
  "skill": "deep-interview", "active": true, "current_phase": "interviewing",
  "state": {
    "rounds": [ /* r1, r2 – GOOD */ ],
    "established_facts": [ /* 7 facts – GOOD */ ],
    "topology": { "status": "confirmed", ... },
    // leaked envelope junk that never goes away:
    "active": true, "current_phase": "interviewing", "skill": "deep-interview",
    "version": 2, "updated_at": "…", "receipt": { … },
    "state": { "rounds": [], "established_facts": [ /* stale */ ], ... }
  }
}
```

### Why it's structural (not just a bad write)

`normalizeDeepInterviewEnvelope` — the single chokepoint every writer flows through (recorder, `state-runtime` write/reconcile, seed, handoff) — **deliberately preserved all unknown nested fields** ("Never deletes unknown envelope or nested fields"). So once a nested `state.state`/`state.receipt`/… exists, **every subsequent `record-answer`/merge carries it forward forever**. There is no self-healing path; recovery requires manual JSON surgery on runtime-owned `.gjc` state (which is otherwise mutation-guarded), and even `--replace` only helps if the incoming `state` is itself already clean.

## Fix

Strip a fixed set of **envelope-reserved keys** from `state` during normalization. These keys are structurally envelope-level and are never legitimate interview `state` fields (verified against the `state` shape documented in `SKILL.md`):

`state`, `receipt`, `skill`, `version`, `updated_at`, `active`, `current_phase`, `state_revision`, `session_id`.

Because normalization is the shared chokepoint, the canonical envelope now **self-heals on the next write** and the merge path can no longer accrete nesting. Genuine free-form extension fields (arbitrary unknown keys inside `state`) are still preserved — only the reserved set is removed.

The observed corruption heals **losslessly**: the correct top-level interview data (rounds, facts, confirmed topology, ambiguity) survives untouched; only the stale nested duplicate and reserved junk are dropped.

## Tests

Added two redteam cases in `deep-interview-state-redteam.test.ts`:
- reproduces the real corruption and asserts every reserved key is stripped from nested state, all good data + non-reserved unknown fields survive, input isn't mutated, and normalization is idempotent (fixed point);
- asserts a normal partial merge (`{state:{topology}}`) into a corrupt existing state self-heals without dropping rounds/facts.

## Verification

```
bun test test/gjc-runtime/deep-interview-state.test.ts \
         test/gjc-runtime/deep-interview-state-redteam.test.ts \
         test/gjc-runtime/deep-interview-recorder.test.ts
# 49 pass, 0 fail
biome check <changed files>  # clean
```

(`deep-interview-recorder-redteam.test.ts` is unrelated — it fails to load the `pi_natives` native addon in this environment.)