### PR TITLE
Harden robogjc status APIs

### DIFF
--- a/python/robogjc/src/server.py
+++ b/python/robogjc/src/server.py
@@ -486,6 +486,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         if token != cfg.replay_token.get_secret_value():
             raise HTTPException(401, "invalid replay token")
 
+    def _require_dashboard_token(cfg: Settings, token: str | None) -> None:
+        if cfg.replay_token is None:
+            return
+        if token != cfg.replay_token.get_secret_value():
+            raise HTTPException(401, "invalid replay token")
+
     @app.get("/api/github/issues")
     async def api_github_issues(
         request: Request,
@@ -663,7 +669,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         )
 
     @app.get("/events")
-    async def events(request: Request, limit: int = 50) -> dict[str, Any]:
+    async def events(
+        request: Request,
+        limit: int = 50,
+        x_robogjc_token: str | None = Header(None, alias="X-Robogjc-Replay-Token"),
+    ) -> dict[str, Any]:
+        cfg: Settings = request.app.state.bag["settings"]
+        _require_dashboard_token(cfg, x_robogjc_token)
         rows = request.app.state.bag["db"].list_events(limit=limit)
         return {
             "events": [
@@ -682,7 +694,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         }
 
     @app.get("/issues")
-    async def issues(request: Request, limit: int = 100) -> dict[str, Any]:
+    async def issues(
+        request: Request,
+        limit: int = 100,
+        x_robogjc_token: str | None = Header(None, alias="X-Robogjc-Replay-Token"),
+    ) -> dict[str, Any]:
+        cfg: Settings = request.app.state.bag["settings"]
+        _require_dashboard_token(cfg, x_robogjc_token)
         rows = request.app.state.bag["db"].list_issues(limit=limit)
         return {
             "issues": [
@@ -706,9 +724,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         return HTMLResponse(render_index(cfg.replay_token is not None))
 
     @app.get("/api/status")
-    async def api_status(request: Request) -> dict[str, Any]:
+    async def api_status(
+        request: Request,
+        x_robogjc_token: str | None = Header(None, alias="X-Robogjc-Replay-Token"),
+    ) -> dict[str, Any]:
         bag = request.app.state.bag
         cfg: Settings = bag["settings"]
+        _require_dashboard_token(cfg, x_robogjc_token)
         db: Database = bag["db"]
         pool: WorkerPool = bag["pool"]
         started = float(bag.get("started_at") or time.time())
@@ -772,8 +794,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         }
 
     @app.get("/api/logs")
-    async def api_logs(request: Request, limit: int = 400) -> dict[str, Any]:
+    async def api_logs(
+        request: Request,
+        limit: int = 400,
+        x_robogjc_token: str | None = Header(None, alias="X-Robogjc-Replay-Token"),
+    ) -> dict[str, Any]:
         cfg: Settings = request.app.state.bag["settings"]
+        _require_dashboard_token(cfg, x_robogjc_token)
         capped = max(1, min(int(limit), 2000))
         entries = tail_jsonl(cfg.log_dir / "robogjc.log.jsonl", limit=capped)
         return {"entries": entries, "count": len(entries), "limit": capped}

--- a/python/robogjc/tests/test_server.py
+++ b/python/robogjc/tests/test_server.py
@@ -95,6 +95,42 @@ def test_index_does_not_expose_replay_token(env, monkeypatch: pytest.MonkeyPatch
         close_database()
 
 
+def test_dashboard_read_apis_reject_missing_token_when_replay_enabled(
+    env,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_replay(monkeypatch)
+    cfg = Settings()  # type: ignore[call-arg]
+    cfg.ensure_paths()
+    app = create_app(cfg)
+    try:
+        with TestClient(app) as client:
+            for path in ("/api/status", "/api/logs", "/events", "/issues"):
+                resp = client.get(path)
+                assert resp.status_code == 401, path
+    finally:
+        close_database()
+
+
+def test_dashboard_read_apis_accept_configured_replay_token(
+    env,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _enable_replay(monkeypatch)
+    cfg = Settings()  # type: ignore[call-arg]
+    cfg.ensure_paths()
+    app = create_app(cfg)
+    try:
+        with TestClient(app) as client:
+            _seed_db(cfg)
+            headers = {"X-Robogjc-Replay-Token": token}
+            for path in ("/api/status", "/api/logs", "/events", "/issues"):
+                resp = client.get(path, headers=headers)
+                assert resp.status_code == 200, path
+    finally:
+        close_database()
+
+
 def test_api_status_reports_runtime_counts_and_inflight(settings: Settings) -> None:
     app = create_app(settings)
     with TestClient(app) as client:

--- a/python/robogjc/web/src/api.ts
+++ b/python/robogjc/web/src/api.ts
@@ -50,10 +50,11 @@ function jsonHeaders(): Record<string, string> {
 
 export const api = {
   status(signal?: AbortSignal): Promise<StatusResponse> {
-    return fetch("/api/status", { signal }).then(unwrap<StatusResponse>);
+    return fetch("/api/status", { headers: authHeaders(), signal }).then(unwrap<StatusResponse>);
   },
   logs(limit = 400, signal?: AbortSignal): Promise<LogsResponse> {
-    return fetch(`/api/logs?limit=${limit}`, { signal }).then(unwrap<LogsResponse>);
+    const qs = new URLSearchParams({ limit: String(limit) });
+    return fetch(`/api/logs?${qs.toString()}`, { headers: authHeaders(), signal }).then(unwrap<LogsResponse>);
   },
   browse(state: string, refresh = false, signal?: AbortSignal): Promise<BrowseResponse> {
     const qs = new URLSearchParams({ state, limit: "50" });


### PR DESCRIPTION
## Summary
- require/validate robogjc status API auth consistently for dashboard-facing endpoints
- return typed auth errors through the web API client instead of treating unauthenticated status responses as ordinary data
- add regression coverage for authenticated and unauthenticated status/API flows

Split out of closed #1675 as a focused dev-based PR.

## Verification
- `python3 -m pytest -x python/robogjc/tests/test_server.py` — 64 passed, 1 existing FastAPI/Starlette deprecation warning
- `bun --cwd=python/robogjc/web run typecheck`
- `ruff check python/robogjc`
- `ruff format --check python/robogjc`

Note: root `biome check python/robogjc/web/src/api.ts` reports the path is ignored by the root Biome config, so web verification is via the package typecheck.