### PR TITLE
feat(notifications): 옵트인 라이브 턴 스트리밍 + 텔레그램 제자리 메시지 편집

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Added a `/clear` slash command that clears the active conversation context while preserving the current session id and durable session history (#1677).
 - Added an Extragoal local skill template (`docs/extragoal-skill-template.md`) documenting an external final review gate on top of `ultragoal` — a fresh-context, cross-family, tool-restricted read-only reviewer with a machine-parsable verdict contract, mandatory bundle secret scan, prompt-injection stance, explicit findings triage, and a bounded re-sign loop — plus a `reviewer` stance profile and cross-session review-gate recipe in `docs/multi-vendor-profiles.md`, pinned by `test/extragoal-template.test.ts`.
+- Added opt-in live turn streaming to the notifications surface. With `GJC_NOTIFICATIONS_STREAM=1` the session WebSocket now emits throttled non-finalized `turn_stream` frames (each carrying a per-turn `messageRef`) as the assistant message streams, and the Telegram threaded daemon edits ONE message in place — via `editMessageText` keyed by `(session, coalesceKey)` — so the finalized text lands on the same message instead of posting a new one. Off by default; without a `messageRef` finalized turns keep their legacy one-message-per-turn behaviour. Throttle interval is `GJC_NOTIFICATIONS_STREAM_INTERVAL_MS` (default 500ms); streamed frames remain suppressed under redaction.
 
 ### Fixed
 

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -350,6 +350,12 @@ interface SessionRuntime {
 	/** Assistant text already flushed before an ask this turn (turn-scoped dedupe
 	 * so turn_end does not re-emit the pre-ask lead-in). Reset each turn. */
 	preAskFlushedText?: string;
+	/** Live streaming: opt-in flag, monotonic per-turn ref, and emit throttle state. */
+	stream: boolean;
+	turnSeq?: number;
+	liveRef?: string;
+	lastLiveAt?: number;
+	lastLiveText?: string;
 	/** Cancels the postmortem cleanup that emits `session_closed` on process teardown. */
 	cancelPostmortemCleanup: () => void;
 }
@@ -383,6 +389,16 @@ export function notificationsEnabled(): boolean {
 	return process.env.GJC_NOTIFICATIONS === "1" || Boolean(process.env.GJC_NOTIFICATIONS_TOKEN);
 }
 
+// Live streaming (opt-in): emit throttled non-finalized `turn_stream` frames as
+// the assistant message streams so remote clients can edit ONE message live. The
+// finalized frame (turn_end) carries the same messageRef and stays authoritative,
+// so a dropped live frame self-heals. Off unless GJC_NOTIFICATIONS_STREAM=1.
+function streamingEnabled(): boolean {
+	return process.env.GJC_NOTIFICATIONS_STREAM === "1";
+}
+function streamIntervalMs(): number {
+	return Math.max(200, Number(process.env.GJC_NOTIFICATIONS_STREAM_INTERVAL_MS) || 500);
+}
 function resolveSettings(settingsOverride?: Settings): ResolvedSettings {
 	if (settingsOverride)
 		return { settings: settingsOverride, cfg: getNotificationConfig(settingsOverride), settingsAvailable: true };
@@ -708,6 +724,7 @@ export function createNotificationsExtension(api: ExtensionAPI, options: { setti
 				cancelPostmortemCleanup: () => {},
 				redact,
 				verbosity,
+				stream: streamingEnabled(),
 				sessionTag: tag,
 				busy: false,
 				pendingInbound: new Set<number>(),
@@ -1063,7 +1080,15 @@ export function createNotificationsExtension(api: ExtensionAPI, options: { setti
 		if (!text || text === rt.preAskFlushedText) return;
 		rt.preAskFlushedText = text;
 		try {
-			rt.server.pushFrame(JSON.stringify({ type: "turn_stream", sessionId: id, phase: "finalized", text }));
+			rt.server.pushFrame(
+				JSON.stringify({
+					type: "turn_stream",
+					sessionId: id,
+					phase: "finalized",
+					text,
+					...(rt.liveRef ? { messageRef: rt.liveRef } : {}),
+				}),
+			);
 		} catch (e) {
 			logger.warn(`notifications: pushFrame (turn) failed: ${String(e)}`);
 		}
@@ -1093,6 +1118,37 @@ export function createNotificationsExtension(api: ExtensionAPI, options: { setti
 		// turn with identical text is not falsely deduped.
 		rt.currentTurnText = undefined;
 		rt.preAskFlushedText = undefined;
+		rt.liveRef = undefined;
+		rt.lastLiveAt = undefined;
+		rt.lastLiveText = undefined;
+	});
+
+	// Live streaming (opt-in): push throttled in-progress assistant text as
+	// non-finalized turn_stream frames so remote clients edit one message as the
+	// turn streams. The finalized frame (turn_end) carries the same messageRef and
+	// lands the authoritative text. Suppressed under redaction.
+	api.on("message_update", (event, ctx) => {
+		const id = sessionId(ctx);
+		const rt = runtimes.get(id);
+		if (!rt || !rt.stream || rt.redact) return;
+		if ((event.message as { role?: unknown }).role !== "assistant") return;
+		if (rt.liveRef === undefined) {
+			rt.turnSeq = (rt.turnSeq ?? 0) + 1;
+			rt.liveRef = String(rt.turnSeq);
+		}
+		const now = Date.now();
+		if (now - (rt.lastLiveAt ?? 0) < streamIntervalMs()) return;
+		const text = summaryFromMessage(event.message, 3500);
+		if (!text || text === rt.lastLiveText) return;
+		rt.lastLiveAt = now;
+		rt.lastLiveText = text;
+		try {
+			rt.server.pushFrame(
+				JSON.stringify({ type: "turn_stream", sessionId: id, phase: "live", text, messageRef: rt.liveRef }),
+			);
+		} catch (e) {
+			logger.warn(`notifications: pushFrame (live) failed: ${String(e)}`);
+		}
 	});
 
 	// Stream agent-produced images (computer/browser/tool screenshots) as

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -869,6 +869,8 @@ interface PendingThreadedFrame {
 export class TelegramNotificationDaemon {
 	readonly aliasTable: AliasTable;
 	readonly messageRoutes = new Map<string | number, CallbackRoute | Omit<CallbackRoute, "answer">>();
+	/** Telegram message id backing each streamed `${sessionId}:${coalesceKey}`, for in-place edits. */
+	private readonly liveMessages = new Map<string, number>();
 	readonly sessions = new Map<string, SessionSocket>();
 	private readonly runtime: NotificationOperatorRuntime;
 	private readonly sessionRouter: OperatorEventRouter<SessionSocket>;
@@ -1666,6 +1668,9 @@ export class TelegramNotificationDaemon {
 			})) as { ok?: boolean };
 			if (res?.ok === false) return;
 			this.topics.delete(sessionId);
+			for (const k of [...this.liveMessages.keys()]) {
+				if (k.startsWith(`${sessionId}:`)) this.liveMessages.delete(k);
+			}
 			this.topicOwnerByIdentity.forEach((ownerSessionId, identityKey) => {
 				if (ownerSessionId === sessionId) this.topicOwnerByIdentity.delete(identityKey);
 			});
@@ -1795,11 +1800,25 @@ export class TelegramNotificationDaemon {
 
 	/** Drain the shared rate-limit pool and deliver each granted send to its topic. */
 	private async flushPool(): Promise<void> {
-		for (const item of this.pool.drain()) {
+		const batch = this.pool.drain();
+		// Within a batch a finalized frame supersedes any still-queued live frame for
+		// the same streamed message (finalized outranks live), so drop the stale live
+		// edit — otherwise the authoritative final text could be overwritten by an
+		// older partial delivered right after it.
+		const finalizedKeys = new Set<string>();
+		for (const item of batch) {
+			if (item.lane === "finalized" && item.coalesceKey !== undefined) {
+				finalizedKeys.add(`${item.sessionId}:${item.coalesceKey}`);
+			}
+		}
+		for (const item of batch) {
 			const { send, topicId } = item.payload;
 			if (topicId && !(await this.pairedChatIsPrivate())) continue;
 			// Threaded topic when available; otherwise deliver flat to the paired chat.
 			const threadField = topicId ? { message_thread_id: Number(topicId) } : {};
+			const ckey = send.editable ? item.coalesceKey : undefined;
+			const editKey = ckey !== undefined ? `${item.sessionId}:${ckey}` : undefined;
+			if (item.lane === "live" && editKey && finalizedKeys.has(editKey)) continue;
 			try {
 				if (send.method === "sendPhoto" && send.photoBase64) {
 					// Real photo upload (the default botApi multiparts base64 -> file).
@@ -1822,19 +1841,52 @@ export class TelegramNotificationDaemon {
 						parse_mode: TELEGRAM_PARSE_MODE,
 					});
 				} else if (send.text) {
-					for (const text of splitTelegramHtml(send.text)) {
-						await this.botApi.call("sendMessage", {
+					const chunks = splitTelegramHtml(send.text);
+					const existingId = editKey ? this.liveMessages.get(editKey) : undefined;
+					if (editKey && existingId !== undefined && chunks.length === 1) {
+						// In-place edit of the streamed message. An unchanged edit is
+						// rejected by Telegram ("message is not modified") and swallowed.
+						await this.botApi.call("editMessageText", {
 							chat_id: this.opts.chatId,
-							...threadField,
-							text,
+							message_id: existingId,
+							text: chunks[0],
 							parse_mode: TELEGRAM_PARSE_MODE,
 						});
+					} else {
+						let firstMessageId: number | undefined;
+						for (let i = 0; i < chunks.length; i++) {
+							const res = (await this.botApi.call("sendMessage", {
+								chat_id: this.opts.chatId,
+								...threadField,
+								text: chunks[i]!,
+								parse_mode: TELEGRAM_PARSE_MODE,
+							})) as { result?: { message_id?: number } };
+							if (i === 0) firstMessageId = res?.result?.message_id;
+						}
+						if (editKey && ckey !== undefined && firstMessageId !== undefined) {
+							this.recordLiveMessage(item.sessionId, ckey, firstMessageId);
+						}
 					}
 				}
 			} catch {
-				// Best-effort: a failed send must never stop the daemon.
+				// Best-effort: a failed send/edit must never stop the daemon.
 			}
 		}
+	}
+
+	/**
+	 * Track the Telegram message id backing a streamed `(sessionId, coalesceKey)`
+	 * so later live/finalized frames edit it in place. Evicts this session's stale
+	 * same-category entries (e.g. prior turns) so the map stays bounded.
+	 */
+	private recordLiveMessage(sessionId: string, coalesceKey: string, messageId: number): void {
+		const mapKey = `${sessionId}:${coalesceKey}`;
+		const category = coalesceKey.split(":")[0] ?? "";
+		const prefix = `${sessionId}:${category}:`;
+		for (const k of [...this.liveMessages.keys()]) {
+			if (k !== mapKey && k.startsWith(prefix)) this.liveMessages.delete(k);
+		}
+		this.liveMessages.set(mapKey, messageId);
 	}
 
 	/**

--- a/packages/coding-agent/src/notifications/threaded-render.ts
+++ b/packages/coding-agent/src/notifications/threaded-render.ts
@@ -32,6 +32,12 @@ export interface ThreadedSend {
 	coalesceKey?: string;
 	/** True for the one-time identity header (the daemon pins it once). */
 	identity?: boolean;
+	/**
+	 * When true the daemon may deliver this as an in-place edit of the message
+	 * previously sent under the same `(sessionId, coalesceKey)` instead of a new
+	 * message. Set for streamed turn frames so live + finalized share one message.
+	 */
+	editable?: boolean;
 }
 
 interface ThreadedFrame {
@@ -135,11 +141,21 @@ export function renderThreadedFrame(frame: ThreadedFrame): ThreadedSend | undefi
 			if (!raw) return undefined;
 			const text = markdownToTelegramHtml(raw);
 			const finalized = frame.phase === "finalized";
+			// A per-turn ref ties the streamed live edits and the finalized text to
+			// ONE message. Without a ref (streaming off), finalized keeps its legacy
+			// keyless behaviour: a fresh message per turn.
+			const ref = str(frame.messageRef);
+			const coalesceKey = finalized
+				? ref
+					? `turn:${ref}`
+					: undefined
+				: `turn:${ref ?? str(frame.sessionId) ?? ""}`;
 			return {
 				method: "sendMessage",
 				lane: finalized ? "finalized" : "live",
 				text,
-				coalesceKey: finalized ? undefined : `turn:${str(frame.messageRef) ?? str(frame.sessionId) ?? ""}`,
+				coalesceKey,
+				editable: coalesceKey !== undefined,
 			};
 		}
 		case "image_attachment": {

--- a/packages/coding-agent/test/notifications-live-stream.test.ts
+++ b/packages/coding-agent/test/notifications-live-stream.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "../src/config/settings";
+import { createNotificationsExtension } from "../src/notifications/index";
+import { TelegramNotificationDaemon } from "../src/notifications/telegram-daemon";
+import { readEndpoint } from "../src/notifications/telegram-reference";
+import { renderThreadedFrame } from "../src/notifications/threaded-render";
+
+// ---------------------------------------------------------------------------
+// 1) Pure render contract: streamed turn frames become editable, and live +
+//    finalized share ONE coalesce key when a messageRef is present.
+// ---------------------------------------------------------------------------
+
+test("turn_stream live and finalized share one coalesce key when a messageRef is present", () => {
+	const live = renderThreadedFrame({
+		type: "turn_stream",
+		sessionId: "S",
+		phase: "live",
+		text: "partial",
+		messageRef: "7",
+	});
+	const final = renderThreadedFrame({
+		type: "turn_stream",
+		sessionId: "S",
+		phase: "finalized",
+		text: "done",
+		messageRef: "7",
+	});
+	expect(live?.lane).toBe("live");
+	expect(final?.lane).toBe("finalized");
+	expect(live?.coalesceKey).toBe("turn:7");
+	expect(final?.coalesceKey).toBe("turn:7"); // same message -> edited in place
+	expect(live?.editable).toBe(true);
+	expect(final?.editable).toBe(true);
+});
+
+test("finalized turn_stream without a messageRef keeps legacy keyless behaviour (fresh message)", () => {
+	const final = renderThreadedFrame({ type: "turn_stream", sessionId: "S", phase: "finalized", text: "done" });
+	expect(final?.coalesceKey).toBeUndefined();
+	expect(final?.editable).toBeFalsy(); // not editable -> daemon posts a fresh message
+});
+
+// ---------------------------------------------------------------------------
+// 2) Core emit: message_update -> throttled live turn_stream frames, opt-in and
+//    redaction-aware, with the finalized turn carrying the same messageRef.
+// ---------------------------------------------------------------------------
+
+const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+async function waitFor(pred: () => boolean, ms = 4000, label = "condition"): Promise<void> {
+	const deadline = Date.now() + ms;
+	while (Date.now() < deadline) {
+		if (pred()) return;
+		await sleep(25);
+	}
+	throw new Error(`timeout waiting for ${label}`);
+}
+
+type Handler = (event: unknown, ctx: unknown) => unknown;
+type Frame = { type: string; phase?: string; text?: string; messageRef?: string };
+
+const tempDirs: string[] = [];
+const openSockets: WebSocket[] = [];
+const envKeys = ["GJC_NOTIFICATIONS", "GJC_NOTIFICATIONS_STREAM", "GJC_NOTIFICATIONS_STREAM_INTERVAL_MS"] as const;
+let savedEnv: Record<string, string | undefined> = {};
+
+afterEach(() => {
+	for (const ws of openSockets.splice(0)) {
+		try {
+			ws.close();
+		} catch {}
+	}
+	for (const dir of tempDirs.splice(0)) {
+		try {
+			fs.rmSync(dir, { recursive: true, force: true });
+		} catch {}
+	}
+	for (const k of envKeys) {
+		if (savedEnv[k] === undefined) delete process.env[k];
+		else process.env[k] = savedEnv[k];
+	}
+	savedEnv = {};
+});
+
+function setEnv(over: Partial<Record<(typeof envKeys)[number], string>>): void {
+	for (const k of envKeys) savedEnv[k] = process.env[k];
+	for (const k of envKeys) delete process.env[k];
+	for (const [k, v] of Object.entries(over)) process.env[k] = v;
+}
+
+async function bootSession(): Promise<{ handlers: Map<string, Handler>; ctx: unknown; frames: Frame[] }> {
+	const handlers = new Map<string, Handler>();
+	const api = {
+		on: (event: string, handler: Handler) => handlers.set(event, handler),
+		registerCommand: () => {},
+		sendUserMessage: () => {},
+	} as never;
+	createNotificationsExtension(api);
+
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notif-stream-"));
+	tempDirs.push(cwd);
+	const sid = `stream-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	const ctx = {
+		cwd,
+		sessionManager: {
+			getSessionId: () => sid,
+			getSessionName: () => "Stream Test",
+			getArtifactsDir: () => cwd,
+			getCwd: () => cwd,
+		},
+		getContextUsage: () => undefined,
+		getModel: () => undefined,
+	} as never;
+
+	await handlers.get("session_start")!({ type: "session_start" }, ctx);
+	const endpointFile = path.join(cwd, ".gjc", "state", "notifications", `${sid}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), 4000, "endpoint file");
+	const { url, token } = readEndpoint(endpointFile);
+
+	const frames: Frame[] = [];
+	const ws = new WebSocket(`${url}/?token=${encodeURIComponent(token)}`);
+	openSockets.push(ws);
+	ws.addEventListener("message", ev => frames.push(JSON.parse(String((ev as MessageEvent).data))));
+	await new Promise<void>((resolve, reject) => {
+		ws.addEventListener("open", () => resolve());
+		ws.addEventListener("error", () => reject(new Error("ws error")));
+	});
+	await sleep(250);
+	return { handlers, ctx, frames };
+}
+
+const assistant = (content: string) => ({ type: "message_update", message: { role: "assistant", content } });
+
+test("message_update emits a live turn_stream whose messageRef matches the finalized turn", async () => {
+	setEnv({ GJC_NOTIFICATIONS: "1", GJC_NOTIFICATIONS_STREAM: "1", GJC_NOTIFICATIONS_STREAM_INTERVAL_MS: "100000" });
+	const { handlers, ctx, frames } = await bootSession();
+	const streams = () => frames.filter(f => f.type === "turn_stream");
+
+	await handlers.get("message_update")!(assistant("Hello, streaming"), ctx);
+	await waitFor(() => streams().some(f => f.phase === "live"), 3000, "live frame");
+	const live = streams().find(f => f.phase === "live")!;
+	expect(live.text).toContain("Hello, streaming");
+	expect(live.messageRef).toBe("1");
+
+	await handlers.get("turn_end")!(
+		{ type: "turn_end", turnIndex: 0, message: { role: "assistant", content: "Hello, streaming — done" } },
+		ctx,
+	);
+	await waitFor(() => streams().some(f => f.phase === "finalized"), 3000, "finalized frame");
+	const final = streams().find(f => f.phase === "finalized")!;
+	expect(final.text).toContain("done");
+	expect(final.messageRef).toBe("1"); // same message as the live edits
+});
+
+test("rapid live updates are throttled to a single frame within the interval", async () => {
+	setEnv({ GJC_NOTIFICATIONS: "1", GJC_NOTIFICATIONS_STREAM: "1", GJC_NOTIFICATIONS_STREAM_INTERVAL_MS: "100000" });
+	const { handlers, ctx, frames } = await bootSession();
+	const live = () => frames.filter(f => f.type === "turn_stream" && f.phase === "live");
+
+	await handlers.get("message_update")!(assistant("one"), ctx);
+	await handlers.get("message_update")!(assistant("one two"), ctx);
+	await handlers.get("message_update")!(assistant("one two three"), ctx);
+	await waitFor(() => live().length >= 1, 3000, "first live frame");
+	await sleep(200);
+	expect(live().length).toBe(1); // later updates fall inside the throttle window
+});
+
+test("no live frames are emitted when streaming is disabled, and finalized carries no messageRef", async () => {
+	setEnv({ GJC_NOTIFICATIONS: "1" }); // GJC_NOTIFICATIONS_STREAM unset -> off
+	const { handlers, ctx, frames } = await bootSession();
+
+	await handlers.get("message_update")!(assistant("should not stream"), ctx);
+	await sleep(200);
+	expect(frames.filter(f => f.type === "turn_stream" && f.phase === "live").length).toBe(0);
+
+	await handlers.get("turn_end")!(
+		{ type: "turn_end", turnIndex: 0, message: { role: "assistant", content: "final only" } },
+		ctx,
+	);
+	await waitFor(() => frames.some(f => f.type === "turn_stream" && f.phase === "finalized"), 3000, "finalized");
+	const final = frames.find(f => f.type === "turn_stream" && f.phase === "finalized")!;
+	expect(final.messageRef).toBeUndefined();
+});
+
+// ---------------------------------------------------------------------------
+// 3) Telegram delivery: streamed frames edit ONE message in place; a keyless
+//    finalized frame still posts a fresh message (no regression when off).
+// ---------------------------------------------------------------------------
+
+function daemonSettings(agentDir: string): Settings {
+	const s = Settings.isolated({
+		"notifications.enabled": true,
+		"notifications.telegram.botToken": "123456:secret-token",
+		"notifications.telegram.chatId": "42",
+		"notifications.daemon.idleTimeoutMs": 20,
+	}) as Settings;
+	return new Proxy(s, {
+		get(target, prop) {
+			if (prop === "getAgentDir") return () => agentDir;
+			const value = Reflect.get(target, prop, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	}) as Settings;
+}
+
+class FakeBotApi {
+	calls: Array<{ method: string; body: any }> = [];
+	async call(method: string, body: unknown): Promise<unknown> {
+		this.calls.push({ method, body });
+		if (method === "getChat")
+			return { ok: true, result: { id: (body as { chat_id?: unknown }).chat_id, type: "private" } };
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: this.calls.length } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: this.calls.length } };
+		return { ok: true, result: true };
+	}
+}
+
+async function bootDaemon() {
+	const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-stream-daemon-"));
+	tempDirs.push(agentDir);
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: daemonSettings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot as never,
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	await daemon.handleSessionMessage(session as never, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+	});
+	return { daemon, bot, session };
+}
+
+test("streamed turn frames edit ONE Telegram message in place (send once, then edit)", async () => {
+	const { daemon, bot, session } = await bootDaemon();
+
+	await daemon.handleSessionMessage(session as never, {
+		type: "turn_stream",
+		sessionId: "S",
+		phase: "live",
+		text: "Hello",
+		messageRef: "1",
+	});
+	await daemon.handleSessionMessage(session as never, {
+		type: "turn_stream",
+		sessionId: "S",
+		phase: "live",
+		text: "Hello world",
+		messageRef: "1",
+	});
+	await daemon.handleSessionMessage(session as never, {
+		type: "turn_stream",
+		sessionId: "S",
+		phase: "finalized",
+		text: "Hello world!",
+		messageRef: "1",
+	});
+
+	// The identity header is also a sendMessage, so scope to the turn's text.
+	const turnSends = bot.calls.filter(c => c.method === "sendMessage" && String(c.body.text).includes("Hello"));
+	const edits = bot.calls.filter(c => c.method === "editMessageText");
+	expect(turnSends.length).toBe(1); // exactly one message created for the turn
+	expect(edits.length).toBe(2); // subsequent live + finalized edit it in place
+	// Every edit targets the same single message.
+	const editIds = new Set(edits.map(e => e.body.message_id));
+	expect(editIds.size).toBe(1);
+	expect(typeof edits[0]!.body.message_id).toBe("number");
+	expect(edits.at(-1)!.body.text).toContain("Hello world!");
+	// Ordering: the turn's send precedes every edit.
+	const turnSendIdx = bot.calls.findIndex(c => c.method === "sendMessage" && String(c.body.text).includes("Hello"));
+	const firstEditIdx = bot.calls.findIndex(c => c.method === "editMessageText");
+	expect(turnSendIdx).toBeLessThan(firstEditIdx);
+});
+
+test("a finalized turn frame without a messageRef posts a fresh message (no in-place edit)", async () => {
+	const { daemon, bot, session } = await bootDaemon();
+	await daemon.handleSessionMessage(session as never, {
+		type: "turn_stream",
+		sessionId: "S",
+		phase: "finalized",
+		text: "All done",
+	});
+	expect(bot.calls.filter(c => c.method === "editMessageText").length).toBe(0);
+	expect(bot.calls.some(c => c.method === "sendMessage" && String(c.body.text).includes("All done"))).toBe(true);
+});


### PR DESCRIPTION
notifications WS는 turn당 `phase:"finalized"` 프레임 하나만 방출해, 원격(텔레그램 등)에는 turn이 끝난 뒤 완성 텍스트가 한 번에 도착했습니다. 정작 소비 측인 텔레그램 threaded 렌더러(`threaded-render.ts`)와 공용 rate-limit 풀(`rate-limit-pool.ts`)에는 이미 `"live"` 레인과 coalesce 배선이 있는데도, 이를 채워줄 **프로듀서(부분 프레임 방출)** 와 실제 **제자리 편집 delivery** 가 비어 있어 아무도 live 프레임을 만들지도, 편집으로 소비하지도 않았습니다.

즉 `/settings` 모델 프로필(#1548)·`gjc stats` 등록(#1628)과 같은 계열의 "선언은 됐지만 배선을 안 한(declared-but-not-wired)" 누락입니다. 이 PR은 그 양쪽 반쪽을 채워, 한 turn이 **하나의 메시지로 스트리밍**되도록 완성합니다. 기존 동작에 영향을 주지 않도록 **기본 off의 옵트인**이며, `messageRef`가 없으면 finalized는 지금과 똑같이 turn당 새 메시지로 동작합니다.

### 변경
- `notifications/index.ts`
  - `message_update` 핸들러 추가: 스트리밍 중 스로틀된 non-finalized `turn_stream` 프레임을 방출. `GJC_NOTIFICATIONS_STREAM=1` 옵트인, 간격 `GJC_NOTIFICATIONS_STREAM_INTERVAL_MS`(기본 500ms), assistant role 한정, dedup, redaction 시 suppress.
  - live·finalized 프레임에 monotonic per-turn `messageRef`를 실어 모든 편집과 최종 텍스트가 한 메시지로 묶이게 함. `turn_end`에서 상태 리셋.
  - 테스트 가능성을 위해 게이트/간격은 모듈 상수가 아닌 런타임 env 읽기(`streamingEnabled()`/`streamIntervalMs()`)로 구성 — 기존 `notificationsEnabled()`와 동일 관용구.
- `notifications/threaded-render.ts`
  - finalized turn 프레임이 `messageRef`가 있을 때 live와 동일한 `turn:<ref>` coalesceKey + `editable` 플래그를 갖게 함 → 최종 텍스트가 스트리밍 메시지를 제자리 편집. `messageRef`가 없으면 레거시 keyless(= turn당 새 메시지) 동작 보존.
- `notifications/telegram-daemon.ts`
  - `flushPool`이 `(session, coalesceKey)`별 텔레그램 message id를 추적해 editable 프레임을 `editMessageText`로 제자리 편집(없으면 최초 1회 `sendMessage` 후 id 기록). 같은 drain 배치에서 finalized가 lane 우선순위상 stale live 편집을 앞지를 수 있어, 해당 키의 잔여 live 편집을 배치 내에서 스킵. message id는 세션/카테고리별 evict + 토픽 teardown 시 정리해 무한 증가 방지.
- `packages/coding-agent/CHANGELOG.md` (Unreleased → Added) 항목 추가.

### 테스트
- `test/notifications-live-stream.test.ts` (신규, 7):
  - **렌더 계약** — live/finalized가 `messageRef` 있을 때 `turn:<ref>` coalesceKey 공유 + `editable`; `messageRef` 없는 finalized는 keyless(새 메시지) 유지
  - **코어 방출** — `message_update`가 live `turn_stream` 방출 + finalized와 `messageRef` 일치, 간격 내 rapid 업데이트는 1프레임으로 스로틀, 스트리밍 off면 live 0 + finalized에 `messageRef` 없음
  - **데몬 delivery** — 스트리밍 프레임이 한 메시지를 제자리 편집(send-once → edit·edit, 모든 edit이 동일 message id, 최종 edit에 최종 텍스트), `messageRef` 없는 finalized는 새 메시지 전송(회귀 없음)
- 회귀: `notifications-turn-ordering` / `notifications-threaded-render` / `notifications-telegram-daemon` / `notifications-rate-limit-pool` **95/95 pass**
- `bun run check:types`(tsgo --noEmit) / biome 통과, 변경 파일 4개 포맷 통과

### 주의
텔레그램 제자리 편집 경로는 **fake `BotApi` 유닛 테스트까지 검증**했고, 실제 텔레그램 봇 대상 e2e는 이 PR에서 돌리지 못했습니다. 동일한 post-once/edit-many + finalized-wins 패턴은 별도 슬랙 브리지에서 `chat.update`로 실사용 검증한 근거가 있습니다. 실봇 확인은 리뷰어/메인테이너 환경을 부탁드립니다.
