### PR TITLE
Warn on low macOS file descriptor limit

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -76,6 +76,9 @@ async function installRuntimeGlobals(): Promise<void> {
 	// `HTTP2Unsupported`. See @gajae-code/ai/utils/h2-fetch for details.
 	installH2Fetch();
 
+	const { warnIfMacOSNoFileLimitTooLow } = await import("./cli/nofile-limit");
+	warnIfMacOSNoFileLimitTooLow();
+
 	// Strip macOS malloc-stack-logging env vars before any subprocess is spawned.
 	// Otherwise every child bun process (subagents, plugin installs, ptree spawns,
 	// etc.) prints a `MallocStackLogging: can't turn off …` warning to stderr.

--- a/packages/coding-agent/src/cli/nofile-limit.ts
+++ b/packages/coding-agent/src/cli/nofile-limit.ts
@@ -1,0 +1,48 @@
+import { execFileSync } from "node:child_process";
+
+export const RECOMMENDED_MACOS_NOFILE_LIMIT = 4096;
+
+export function parseNoFileLimit(text: string): number | undefined {
+	const trimmed = text.trim();
+	if (!trimmed || trimmed === "unlimited") return undefined;
+	const value = Number(trimmed);
+	return Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
+export function buildMacOSNoFileLimitWarning(currentLimit: number): string {
+	return [
+		`Warning: macOS file descriptor limit is low (ulimit -n = ${currentLimit}).`,
+		'GJC and project dev servers can hit EMFILE / "too many open files" while scanning or watching repositories.',
+		"For this terminal session, run:",
+		`  ulimit -n ${RECOMMENDED_MACOS_NOFILE_LIMIT}`,
+		"If your shell refuses that value, raise the per-user launchd limit and restart the terminal:",
+		`  sudo launchctl limit maxfiles ${RECOMMENDED_MACOS_NOFILE_LIMIT} 65536`,
+		"Avoid using huge values such as 2147483646 on macOS; they are commonly rejected or clamped.",
+		"Set GJC_SKIP_NOFILE_CHECK=1 to silence this preflight warning.",
+	].join("\n");
+}
+
+export interface WarnIfMacOSNoFileLimitTooLowDeps {
+	platform?: NodeJS.Platform;
+	env?: NodeJS.ProcessEnv;
+	execFileSync?: typeof execFileSync;
+	writeStderr?: (text: string) => void;
+}
+
+export function warnIfMacOSNoFileLimitTooLow(deps: WarnIfMacOSNoFileLimitTooLowDeps = {}): void {
+	const platform = deps.platform ?? process.platform;
+	if (platform !== "darwin") return;
+	const env = deps.env ?? process.env;
+	if (env.GJC_SKIP_NOFILE_CHECK === "1" || env.GJC_SKIP_NOFILE_CHECK === "true") return;
+
+	const run = deps.execFileSync ?? execFileSync;
+	let currentLimit: number | undefined;
+	try {
+		currentLimit = parseNoFileLimit(run("/bin/sh", ["-lc", "ulimit -n"], { encoding: "utf8" }));
+	} catch {
+		return;
+	}
+	if (currentLimit === undefined || currentLimit >= RECOMMENDED_MACOS_NOFILE_LIMIT) return;
+	const write = deps.writeStderr ?? (text => process.stderr.write(text));
+	write(`${buildMacOSNoFileLimitWarning(currentLimit)}\n`);
+}

--- a/packages/coding-agent/test/nofile-limit.test.ts
+++ b/packages/coding-agent/test/nofile-limit.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { buildMacOSNoFileLimitWarning, parseNoFileLimit, warnIfMacOSNoFileLimitTooLow } from "../src/cli/nofile-limit";
+
+describe("macOS nofile limit preflight", () => {
+	it("parses finite ulimit output", () => {
+		expect(parseNoFileLimit("256\n")).toBe(256);
+		expect(parseNoFileLimit("4096")).toBe(4096);
+		expect(parseNoFileLimit("unlimited\n")).toBeUndefined();
+		expect(parseNoFileLimit("not-a-number")).toBeUndefined();
+	});
+
+	it("warns with realistic macOS remediation for low limits", () => {
+		const chunks: string[] = [];
+		warnIfMacOSNoFileLimitTooLow({
+			platform: "darwin",
+			env: {},
+			execFileSync: (() => "256\n") as never,
+			writeStderr: text => chunks.push(text),
+		});
+		const output = chunks.join("");
+		expect(output).toContain("ulimit -n = 256");
+		expect(output).toContain("ulimit -n 4096");
+		expect(output).toContain("sudo launchctl limit maxfiles 4096 65536");
+		expect(output).toContain("Avoid using huge values such as 2147483646");
+	});
+
+	it("does not warn on non-macOS, skipped, or adequate limits", () => {
+		for (const deps of [
+			{ platform: "linux" as const, env: {}, execFileSync: (() => "256\n") as never },
+			{ platform: "darwin" as const, env: { GJC_SKIP_NOFILE_CHECK: "1" }, execFileSync: (() => "256\n") as never },
+			{ platform: "darwin" as const, env: {}, execFileSync: (() => "4096\n") as never },
+		]) {
+			const chunks: string[] = [];
+			warnIfMacOSNoFileLimitTooLow({ ...deps, writeStderr: text => chunks.push(text) });
+			expect(chunks).toEqual([]);
+		}
+	});
+
+	it("keeps the standalone message actionable", () => {
+		expect(buildMacOSNoFileLimitWarning(256)).toContain("Set GJC_SKIP_NOFILE_CHECK=1");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1702.

Adds a macOS startup preflight that detects very low `ulimit -n` values before users hit opaque downstream EMFILE / "too many open files" failures from file watching, browser/image workflows, or broad repo scans.

When the inherited soft limit is below 4096, GJC now prints realistic guidance:

```text
ulimit -n 4096
sudo launchctl limit maxfiles 4096 65536
```

It also explicitly tells users not to use huge values like `2147483646`, which are commonly rejected or clamped on macOS, and provides `GJC_SKIP_NOFILE_CHECK=1` for opt-out.

## Verification

- `npx tsc -p packages/coding-agent/tsconfig.json --noEmit --pretty false`
- `npx biome check packages/coding-agent/src/cli.ts packages/coding-agent/src/cli/nofile-limit.ts packages/coding-agent/test/nofile-limit.test.ts --no-errors-on-unmatched`
- `npx --yes bun@1.3.14 test packages/coding-agent/test/nofile-limit.test.ts`
