### PR TITLE
fix(coding-agent): inject native user-global AGENTS.md into the system prompt

### DIFF
--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -242,9 +242,12 @@ function dedupeExactContextFiles(
 }
 
 /**
- * Load all project context files using the capability API.
+ * Load all context files using the capability API.
  * Returns {path, content, depth} entries for all discovered context files.
- * Files are sorted by depth (descending) so files closer to cwd appear last/more prominent.
+ * Native user-global files (`~/.gjc/agent/AGENTS.md`) come first, then project
+ * files sorted by depth (descending) so files closer to cwd appear last/more
+ * prominent. User-home files from foreign providers (`~/.claude/CLAUDE.md`,
+ * `~/.codex/AGENTS.md`, …) stay excluded — only gjc's own user config applies.
  */
 export async function loadProjectContextFiles(
 	options: LoadContextFilesOptions = {},
@@ -252,28 +255,32 @@ export async function loadProjectContextFiles(
 	const resolvedCwd = options.cwd ?? getProjectDir();
 
 	const result = await loadCapability(contextFileCapability.id, { cwd: resolvedCwd });
+	const items = result.items as ContextFile[];
+
+	// Native user-global context applies everywhere and is least specific, so it
+	// renders first — project files rendered later take precedence over it.
+	const userFiles = items
+		.filter(item => item.level === "user" && item._source.provider === "native")
+		.map(item => ({ path: item.path, content: item.content }));
 
 	// Convert project-level ContextFile items and preserve depth info
-	const files = result.items
-		.filter(item => (item as ContextFile).level === "project")
-		.map(item => {
-			const contextFile = item as ContextFile;
-			return {
-				path: contextFile.path,
-				content: contextFile.content,
-				depth: contextFile.depth,
-			};
-		});
+	const projectFiles = items
+		.filter(item => item.level === "project")
+		.map(item => ({
+			path: item.path,
+			content: item.content,
+			depth: item.depth,
+		}));
 
 	// Sort by depth (descending): higher depth (farther from cwd) comes first,
 	// so files closer to cwd appear later and are more prominent
-	files.sort((a, b) => {
+	projectFiles.sort((a, b) => {
 		const depthA = a.depth ?? -1;
 		const depthB = b.depth ?? -1;
 		return depthB - depthA;
 	});
 
-	return dedupeExactContextFiles(files);
+	return dedupeExactContextFiles([...userFiles, ...projectFiles]);
 }
 
 /**

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -88,6 +88,36 @@ describe("SYSTEM.md prompt assembly", () => {
 		await expect(loadProjectContextFiles({ cwd: projectDir })).resolves.toEqual([]);
 	});
 
+	it("loads gjc's own user-global AGENTS.md before project context files", async () => {
+		const projectDir = path.join(tempDir, "project");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.writeFileSync(path.join(projectDir, "AGENTS.md"), "Project instructions");
+		const userAgentsPath = path.join(tempHomeDir, ".gjc", "agent", "AGENTS.md");
+		fs.mkdirSync(path.dirname(userAgentsPath), { recursive: true });
+		fs.writeFileSync(userAgentsPath, "User-global instructions");
+
+		const files = await loadProjectContextFiles({ cwd: projectDir });
+		const paths = files.map(file => file.path);
+
+		expect(paths[0]).toBe(userAgentsPath);
+		expect(files[0]?.content).toBe("User-global instructions");
+		expect(paths).toContain(path.join(projectDir, "AGENTS.md"));
+	});
+
+	it("includes the native user-global file while still excluding foreign user-home files", async () => {
+		const projectDir = path.join(tempDir, "project");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.mkdirSync(path.join(tempHomeDir, ".claude"), { recursive: true });
+		fs.writeFileSync(path.join(tempHomeDir, ".claude", "CLAUDE.md"), "Home Claude instructions");
+		const userAgentsPath = path.join(tempHomeDir, ".gjc", "agent", "AGENTS.md");
+		fs.mkdirSync(path.dirname(userAgentsPath), { recursive: true });
+		fs.writeFileSync(userAgentsPath, "User-global instructions");
+
+		const files = await loadProjectContextFiles({ cwd: projectDir });
+
+		expect(files.map(file => file.path)).toEqual([userAgentsPath]);
+	});
+
 	it("keeps project-level Gemini context files", async () => {
 		const projectDir = path.join(tempDir, "project");
 		const geminiDir = path.join(projectDir, ".gemini");


### PR DESCRIPTION
### Problem

`~/.gjc/agent/AGENTS.md` is discovered as a user-level context file (`discovery/builtin.ts`, native provider) — but `loadProjectContextFiles` (`system-prompt.ts`) filters context files to `level === "project"` only, so gjc's own user-global instructions are silently dropped and never reach the model. Every-turn user-global guidance therefore has no effect, contradicting the ecosystem convention (Claude Code honors `~/.claude/CLAUDE.md`, Codex honors `~/.codex/AGENTS.md` user-globally in their own CLIs).

Empirical repro on the 0.8.2 binary: a distinctive marker block written to `~/.gjc/agent/AGENTS.md` is invisible to a headless probe (`gjc -p --no-session --no-tools "...is rule X in your injected context?"` → NO), while the same block in `~/.gjc/agent/SYSTEM.md` is injected (YES, correct bullet count echoed back) — AGENTS.md is the odd one out.

### Fix

Include user-level context files **from the native provider only** in `loadProjectContextFiles`, rendered *before* project files so project context keeps precedence (byte-identical content still dedupes to the closest copy via `dedupeExactContextFiles`).

User-home files from foreign providers (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.config/opencode/AGENTS.md`, `~/.gemini/GEMINI.md`) **remain excluded** — the existing test "does not load user-home context or prompt files into project context" passes unchanged, so the intent of that exclusion is preserved.

### Tests

- new: `loads gjc's own user-global AGENTS.md before project context files`
- new: `includes the native user-global file while still excluding foreign user-home files`
- `bun test test/system-prompt-dedup.test.ts` → 18 pass / 0 fail
- `bun test test/discovery/` → 93 pass / 0 fail
- `bun test test/system-prompt-templates.test.ts` → 15 pass / 0 fail
- `bun run check` (biome + tsgo) → clean (1 pre-existing lint warning in `notifications/index.ts`, untouched by this PR)

### Notes

- Related dormant surface, intentionally left out to keep this PR minimal: rules with `alwaysApply: true` are only rendered by `custom-system-prompt.md`, never by the default `system-prompt.md` template. Happy to file separately if useful.
