### PR TITLE
fix(update): fsync downloaded binary before verify to fix NFS rollback

### DIFF
--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -552,6 +552,30 @@ async function updateViaNpm(packageName: string, expectedVersion: string): Promi
 }
 
 /**
+ * Flush a freshly written file's data to stable storage.
+ *
+ * Critical on network filesystems (e.g. NFS home directories): `pipeline`
+ * resolving does not guarantee the downloaded bytes are durable on the
+ * server, so the post-install `gjc --version` check can exec a binary whose
+ * pages are not yet consistent. The child then faults, the version check
+ * fails, and the update is rolled back with "could not verify updated
+ * version" even though the download itself succeeded. Explicitly fsyncing
+ * before the rename/exec avoids the race.
+ */
+async function fsyncFile(filePath: string): Promise<void> {
+	const handle = await fs.promises.open(filePath, "r+");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+export async function fsyncFileForTest(filePath: string): Promise<void> {
+	return fsyncFile(filePath);
+}
+
+/**
  * Download a release binary to a target path, replacing an existing file.
  */
 async function updateViaBinaryAt(targetPath: string, expectedVersion: string): Promise<void> {
@@ -568,6 +592,7 @@ async function updateViaBinaryAt(targetPath: string, expectedVersion: string): P
 	}
 	const fileStream = fs.createWriteStream(tempPath, { mode: 0o755 });
 	await pipeline(response.body, fileStream);
+	await fsyncFile(tempPath);
 
 	console.log(chalk.dim("Installing update..."));
 	const verification = await replaceBinaryForUpdate({

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -8,6 +8,7 @@ import {
 	formatBinaryDownloadFailureMessageForTest,
 	formatManualUpdateInstructionsForTest,
 	formatVerificationFailureForTest,
+	fsyncFileForTest,
 	replaceBinaryForUpdate,
 	resolveNpmManagedTargetForTest,
 	resolveUpdateMethodForTest,
@@ -303,5 +304,22 @@ describe("update-cli binary replacement", () => {
 		expect(await Bun.file(targetPath).text()).toBe("new binary");
 		expect(await Bun.file(tempPath).exists()).toBe(false);
 		expect(await Bun.file(backupPath).exists()).toBe(false);
+	});
+});
+
+describe("update-cli download durability", () => {
+	it("fsyncs a written file without altering its contents", async () => {
+		const dir = await makeTempDir();
+		const filePath = path.join(dir, "gjc.new");
+		await Bun.write(filePath, "downloaded binary bytes");
+
+		await fsyncFileForTest(filePath);
+
+		expect(await Bun.file(filePath).text()).toBe("downloaded binary bytes");
+	});
+
+	it("rejects when the target file does not exist", async () => {
+		const dir = await makeTempDir();
+		await expect(fsyncFileForTest(path.join(dir, "missing.new"))).rejects.toThrow();
 	});
 });


### PR DESCRIPTION
## What

`gjc update` (binary install path) downloads the release asset with `fetch` + a
stream `pipeline`, renames it into place, then immediately execs `gjc --version`
(`verifyInstalledRuntime` → `verifyInstalledVersion`) to confirm the install.

This PR fsyncs the downloaded temp file before that rename/exec so its data is
durable before the post-install version check runs.

## Why

On network filesystems (NFS home dirs are common on HPC/cluster login nodes),
`pipeline` resolving does **not** guarantee the written bytes are durable on the
server. The verification process then execs/mmaps a not-yet-consistent binary,
faults, `--version` yields no parseable version, and `replaceBinaryForUpdate`
rolls the update back with:

    Update failed: Error: could not verify updated version at <path>; restored previous gjc binary

Reproduced **deterministically** on an NFS `~/.local/bin`:

- The downloaded `v0.8.2` `gjc-linux-x64` asset runs fine standalone
  (`gjc/0.8.2`, `--smoke-test: ok`).
- `gjc update --force` fails every time with the message above.
- A manual `cp` + `sync` + atomic `mv` install of the same asset succeeds.

The only material difference between the failing updater and the working manual
install is an explicit flush to stable storage before the binary is exec'd — so
an `fsync` on the downloaded temp file is the targeted fix.

## How

- New `fsyncFile(path)` helper: `open(path, "r+")` → `handle.sync()` → `close()`.
- Called in `updateViaBinaryAt` right after the download `pipeline`, before
  `replaceBinaryForUpdate` renames + execs.

## Testing

- `bun test packages/coding-agent/test/update-cli.test.ts` → **22 pass / 0 fail**
  (added `update-cli download durability` covering the new `fsyncFileForTest`
  hook: content preserved after fsync; rejects on missing file).
- Full `bun run check` passes (`check:ts` and `check:rs` both exit 0). The only
  remaining lint note is a pre-existing biome warning in
  `src/notifications/index.ts`, an unrelated file this PR does not touch.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)