### PR TITLE
fix(coding-agent): keep Esc in hook selector inline input from aborting the turn

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Team worker auto-checkpoints now exclude the entire `.gjc/_session-*/` session subtree instead of nine enumerated subdirectories, so extragoal gate receipts and the session activity marker are no longer committed with `--no-verify` and merged into the leader branch on repos that do not gitignore `.gjc/_session-*/`.
 - The Telegram threaded daemon now schedules each split chunk of an oversized message through the shared rate-limit pool: a granted send slot maps to exactly one Bot API send, and continuation chunks are re-queued (one token each) rather than fanned out against a single token. This keeps a long finalized turn (e.g. raised via `GJC_NOTIFICATIONS_TURN_MAX`) within the documented per-chat rate-limit / round-robin fairness invariant instead of bursting many `sendMessage` calls on one slot.
 
+### Fixed
+- Pressing `Escape` inside a hook selector's inline "Other (type your own)" editor now backs out to the option list instead of aborting the whole turn. The global interrupt listener added in #1478 consumed `Escape` whenever a hook dialog was streaming, so deep-interview/ralplan custom-input entry was killed with "Operation aborted"; it now defers to the focused selector while still aborting from option-selection mode.
+
 ## [0.8.2] - 2026-07-06
 ### Added
 

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -474,6 +474,16 @@ export class HookSelectorComponent extends Container {
 		}
 	}
 
+	/**
+	 * True while the inline "Other (type your own)" editor is open below the
+	 * option list. Escape in this sub-mode backs out to the option list (see
+	 * `#handleInputModeKey`), so the global interrupt listener must defer to
+	 * this component instead of consuming Escape and aborting the turn.
+	 */
+	isInlineInputActive(): boolean {
+		return this.#inlineEditor !== undefined;
+	}
+
 	handleInput(keyData: string): void {
 		// Reset countdown on any interaction
 		this.#countdown?.reset();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -148,6 +148,12 @@ export class InputController {
 				return { consume: true };
 			}
 			const hookDialogActive = this.#hasHookDialog();
+			// A hook selector in its inline "Other (type your own)" input mode
+			// handles Escape itself (back out to the option list). Defer to the
+			// focused component instead of consuming Escape and aborting the turn.
+			if (this.ctx.hookSelector?.isInlineInputActive()) {
+				return undefined;
+			}
 			if (
 				this.#handleCancellableWorkEscape({
 					loading: hookDialogActive,

--- a/packages/coding-agent/test/hook-selector-inline-input.test.ts
+++ b/packages/coding-agent/test/hook-selector-inline-input.test.ts
@@ -218,6 +218,16 @@ describe("HookSelectorComponent inline custom input", () => {
 		expect(calls.selected).toEqual(["2. Option B"]);
 	});
 
+	it("reports inline-input state via isInlineInputActive across enter/escape", () => {
+		const { component } = createSelector();
+		expect(component.isInlineInputActive()).toBe(false);
+		moveToOther(component);
+		component.handleInput("\r");
+		expect(component.isInlineInputActive()).toBe(true);
+		component.handleInput("\x1b");
+		expect(component.isInlineInputActive()).toBe(false);
+	});
+
 	it("escape in selection mode still cancels the dialog", () => {
 		const { component, calls } = createSelector();
 		component.handleInput("\x1b");

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -427,7 +427,7 @@ describe("InputController escape behavior", () => {
 	it("globally aborts a workflow stream while a hook dialog has focus", () => {
 		const { ctx, inputListeners, spies } = createContext();
 		(ctx.session as { isStreaming: boolean }).isStreaming = true;
-		ctx.hookSelector = {} as InteractiveModeContext["hookSelector"];
+		ctx.hookSelector = { isInlineInputActive: () => false } as unknown as InteractiveModeContext["hookSelector"];
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
@@ -436,6 +436,19 @@ describe("InputController escape behavior", () => {
 		expect(result).toEqual({ consume: true });
 		expect(spies.abort).toHaveBeenCalledTimes(1);
 		expect(spies.abort).toHaveBeenCalledWith(expect.objectContaining({ cause: "user_interrupt" }));
+	});
+
+	it("defers Esc to the hook selector while its inline custom-input editor is open", () => {
+		const { ctx, inputListeners, spies } = createContext();
+		(ctx.session as { isStreaming: boolean }).isStreaming = true;
+		ctx.hookSelector = { isInlineInputActive: () => true } as unknown as InteractiveModeContext["hookSelector"];
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		const result = inputListeners[0]?.("\x1b");
+
+		expect(result).toBeUndefined();
+		expect(spies.abort).not.toHaveBeenCalled();
 	});
 
 	it("does not globally steal draft-clearing Esc from a normal stream", () => {


### PR DESCRIPTION
## Problem

During `deep-interview` (and other `ask`-tool dialogs such as `ralplan`), selecting **"Other (type your own)"** opens the inline custom-input editor below the option list. Pressing **Esc** there is supposed to back out to the option list — but instead the whole turn is killed with **"Operation aborted"**.

## Root cause

Regression from #1478 (`fix(coding-agent): make escape cancel workflow tasks reliably`, commit `bae1b202`).

That commit added `InputController#installGlobalInterruptListener`, registered via `ui.addInputListener`. In `tui.ts#handleInput`, input listeners run **before** the focused component and, when a listener returns `{ consume: true }`, the key never reaches the focused component.

The listener treats any active hook dialog (`#hasHookDialog()`) plus a streaming session as a cancellable workflow:

```ts
const hookDialogActive = this.#hasHookDialog();
this.#handleCancellableWorkEscape({
    loading: hookDialogActive,
    processes: hookDialogActive,
    streaming: hookDialogActive,   // -> #abortInteractive() when isStreaming
    maintenance: true, retry: true,
});
```

`app.interrupt` defaults to `escape`, so while the selector is in inline-input mode and the turn is still streaming, Esc is consumed and aborts the turn before `HookSelectorComponent.#handleInputModeKey` -> `#exitInputMode` can return to the options.

## Fix

- Expose `HookSelectorComponent.isInlineInputActive()` (reflects the `#inlineEditor` sub-mode).
- In the global interrupt listener, short-circuit with `return undefined` (do not consume) when the selector is in inline-input mode, so Esc falls through to the focused component and backs out to the option list.
- Option-selection mode still aborts the streaming workflow, preserving #1478's intended behavior.

## Tests

- `input-controller-escape.test.ts`: new case asserting Esc is deferred (returns `undefined`, no abort) while the inline editor is open; existing "globally aborts … while a hook dialog has focus" case retained for option mode.
- `hook-selector-inline-input.test.ts`: `isInlineInputActive()` state transitions across enter/escape.

## Verification

- `bun test packages/coding-agent/test/input-controller-escape.test.ts packages/coding-agent/test/hook-selector-inline-input.test.ts` → 44 pass
- `bun run check:ts` → all package typechecks + biome + rebrand/plugin/UI gates pass
