### PR TITLE
fix(gjc-session): preserve accepted prompt vanish evidence

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -8,6 +8,8 @@ import { sessionRuntimeDir } from "./session-layout";
 export const GJC_COORDINATOR_SESSION_STATE_FILE_ENV = "GJC_COORDINATOR_SESSION_STATE_FILE";
 export const GJC_COORDINATOR_SESSION_ID_ENV = "GJC_COORDINATOR_SESSION_ID";
 export const GJC_COORDINATOR_SESSION_BRANCH_ENV = "GJC_COORDINATOR_SESSION_BRANCH";
+const GJC_SESSION_PROMPT_ACCEPTED_JSON_ENV = "GJC_SESSION_PROMPT_ACCEPTED_JSON";
+const GJC_SESSION_WORKTREE_BASELINE_DIRTY_ENV = "GJC_SESSION_WORKTREE_BASELINE_DIRTY";
 
 export type RuntimeState = "ready_for_input" | "running" | "needs_user_input" | "completed" | "errored";
 
@@ -32,6 +34,7 @@ interface RuntimeStateSidecarPayload {
 	state?: unknown;
 	ready_for_input?: unknown;
 	cwd?: unknown;
+	workdir?: unknown;
 	session_file?: unknown;
 	final_response?: { source?: unknown };
 }
@@ -143,10 +146,24 @@ function readPreviousPayload(stateFile: string): Record<string, unknown> {
 	}
 }
 
-function shouldPreserveTerminalPayload(previous: RuntimeStateSidecarPayload): boolean {
+function shouldPreserveTerminalPayload(
+	previous: RuntimeStateSidecarPayload,
+	input: { sessionId: string; cwd: string; sessionFile?: string | null },
+): boolean {
 	if (previous.state !== "completed" && previous.state !== "errored") return false;
 	const source = previous.final_response?.source;
-	return source === "agent_end" || source === "launch_error";
+	if (source !== "agent_end" && source !== "launch_error") return false;
+	if (typeof previous.session_id === "string" && previous.session_id !== input.sessionId) return false;
+	if (typeof previous.cwd === "string" && !sameResolvedPath(previous.cwd, input.cwd)) return false;
+	if (typeof previous.workdir === "string" && !sameResolvedPath(previous.workdir, input.cwd)) return false;
+	if (
+		input.sessionFile &&
+		typeof previous.session_file === "string" &&
+		!sameResolvedPath(previous.session_file, input.sessionFile)
+	) {
+		return false;
+	}
+	return true;
 }
 
 function runtimeStateFileForContext(context: RuntimeStateContext): string | null {
@@ -187,6 +204,56 @@ function basePayload(input: {
 		session_file: input.context.sessionFile ?? null,
 	};
 }
+function booleanFromUnknown(value: unknown): boolean | null {
+	if (typeof value === "boolean") return value;
+	if (typeof value === "string") {
+		const normalized = value.trim().toLowerCase();
+		if (normalized === "true") return true;
+		if (normalized === "false") return false;
+	}
+	return null;
+}
+
+function promptAcceptedFromEnv(): boolean {
+	const promptAcceptedJson = process.env[GJC_SESSION_PROMPT_ACCEPTED_JSON_ENV]?.trim();
+	if (!promptAcceptedJson) return false;
+	try {
+		return fsSync.statSync(promptAcceptedJson).size > 0;
+	} catch {
+		return false;
+	}
+}
+
+function readJsonFileSync(file: string): Record<string, unknown> | null {
+	try {
+		return JSON.parse(fsSync.readFileSync(file, "utf8")) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+function worktreeBaselineDirtyFromEnvOrMarker(): boolean | null {
+	const promptAcceptedJson = process.env[GJC_SESSION_PROMPT_ACCEPTED_JSON_ENV]?.trim();
+	if (promptAcceptedJson) {
+		const promptAccepted = readJsonFileSync(promptAcceptedJson);
+		const promptBaseline = booleanFromUnknown(promptAccepted?.worktreeBaselineDirty);
+		if (promptBaseline !== null) return promptBaseline;
+	}
+	const envValue = booleanFromUnknown(process.env[GJC_SESSION_WORKTREE_BASELINE_DIRTY_ENV]);
+	if (envValue !== null) return envValue;
+	return null;
+}
+
+function observedRecoverableWorktreeChanges(cwd: string): boolean {
+	if (!cwd.trim()) return false;
+	try {
+		const proc = Bun.spawnSync(["git", "status", "--porcelain"], { cwd, stdout: "pipe", stderr: "pipe" });
+		return proc.exitCode === 0 && proc.stdout.byteLength > 0;
+	} catch {
+		return false;
+	}
+}
+
 function publicSafeErrorMessage(message: string): string {
 	const normalized = message.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, " ").trim();
 	if (normalized.length <= MAX_PUBLIC_ERROR_MESSAGE_LENGTH) return normalized;
@@ -204,6 +271,7 @@ function numericProcessExitCode(defaultCode: number | null): number | null {
 function postmortemExitDetails(
 	reason: postmortem.Reason,
 	previous: RuntimeStateSidecarPayload,
+	cwd: string,
 ): {
 	state: RuntimeState;
 	reason: string;
@@ -212,7 +280,15 @@ function postmortemExitDetails(
 	signal: string | null;
 	error?: { code: string; message: string; recoverable: true };
 	recovery?: { action: string; reason: string };
+	promptAccepted: boolean;
+	observedRecoverableWorktreeChanges: boolean;
+	worktreeBaselineDirty: boolean | null;
+	worktreeChangedSinceBaseline: boolean;
 } {
+	const promptAccepted = promptAcceptedFromEnv();
+	const observedChanges = observedRecoverableWorktreeChanges(typeof previous.cwd === "string" ? previous.cwd : cwd);
+	const worktreeBaselineDirty = worktreeBaselineDirtyFromEnvOrMarker();
+	const worktreeChangedSinceBaseline = worktreeBaselineDirty === false && observedChanges;
 	if (reason === postmortem.Reason.EXIT || reason === postmortem.Reason.MANUAL) {
 		const exitCode = numericProcessExitCode(0) ?? 0;
 		const exitedBeforeTerminalState =
@@ -223,16 +299,25 @@ function postmortemExitDetails(
 			: reason === postmortem.Reason.EXIT
 				? "process_exit"
 				: "manual_cleanup";
+		let classifiedReason = exitReason;
+		if (exitedBeforeTerminalState) {
+			if (!promptAccepted) classifiedReason = "process_exit_before_prompt_acceptance";
+			else if (worktreeChangedSinceBaseline)
+				classifiedReason = "accepted_prompt_observed_recoverable_worktree_changes";
+			else if (observedChanges)
+				classifiedReason = "accepted_prompt_dirty_worktree_observed_without_new_change_proof";
+			else classifiedReason = "accepted_prompt_no_useful_output";
+		}
 		return {
 			state,
-			reason: exitReason,
+			reason: classifiedReason,
 			exitKind: reason,
 			exitCode,
 			signal: null,
 			...(state === "errored"
 				? {
 						error: {
-							code: exitReason,
+							code: classifiedReason,
 							message: publicSafeErrorMessage(
 								exitedBeforeTerminalState
 									? "GJC process exited before emitting terminal agent state"
@@ -248,6 +333,10 @@ function postmortemExitDetails(
 						},
 					}
 				: {}),
+			promptAccepted,
+			observedRecoverableWorktreeChanges: observedChanges,
+			worktreeBaselineDirty,
+			worktreeChangedSinceBaseline,
 		};
 	}
 	const signalByReason: Partial<Record<postmortem.Reason, string>> = {
@@ -263,6 +352,10 @@ function postmortemExitDetails(
 		signal: signalByReason[reason] ?? null,
 		error: { code: reason, message: errorMessageForPostmortem(reason), recoverable: true },
 		recovery: { action: "recover_or_resume_session", reason: "process cleanup ran before terminal agent state" },
+		promptAccepted,
+		observedRecoverableWorktreeChanges: observedChanges,
+		worktreeBaselineDirty,
+		worktreeChangedSinceBaseline,
 	};
 }
 
@@ -327,12 +420,25 @@ export function persistCoordinatorRuntimeStateFromPostmortem(
 	const stateFile = runtimeStateFileForContext(context);
 	if (!stateFile) return;
 	const previous = readPreviousPayload(stateFile);
-	if (shouldPreserveTerminalPayload(previous as RuntimeStateSidecarPayload)) return;
-	const now = new Date().toISOString();
-	const details = postmortemExitDetails(reason, previous as RuntimeStateSidecarPayload);
 	const sessionId = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim()
 		? process.env[GJC_COORDINATOR_SESSION_ID_ENV]?.trim() || context.sessionId
 		: context.sessionId;
+	if (
+		shouldPreserveTerminalPayload(previous as RuntimeStateSidecarPayload, {
+			sessionId,
+			cwd: context.cwd,
+			sessionFile: context.sessionFile,
+		})
+	) {
+		return;
+	}
+	const previousForDetails: RuntimeStateSidecarPayload =
+		(previous as RuntimeStateSidecarPayload).state === "completed" ||
+		(previous as RuntimeStateSidecarPayload).state === "errored"
+			? { ...(previous as RuntimeStateSidecarPayload), state: "running" }
+			: (previous as RuntimeStateSidecarPayload);
+	const now = new Date().toISOString();
+	const details = postmortemExitDetails(reason, previousForDetails, context.cwd);
 	const payload = {
 		...basePayload({
 			context,
@@ -352,6 +458,10 @@ export function persistCoordinatorRuntimeStateFromPostmortem(
 		...(details.error ? { error: details.error } : {}),
 		...(details.recovery ? { recovery: details.recovery } : {}),
 		previous_runtime_state: typeof previous.state === "string" ? previous.state : null,
+		prompt_accepted: details.promptAccepted,
+		observed_recoverable_worktree_changes: details.observedRecoverableWorktreeChanges,
+		worktree_baseline_dirty: details.worktreeBaselineDirty,
+		worktree_changed_since_baseline: details.worktreeChangedSinceBaseline,
 	};
 	try {
 		writeStateFileSync(stateFile, payload);

--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -17,6 +17,10 @@ const tempDirs: string[] = [];
 const ORIGINAL_STATE_FILE = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV];
 const ORIGINAL_SESSION_ID = process.env[GJC_COORDINATOR_SESSION_ID_ENV];
 const ORIGINAL_BRANCH = process.env[GJC_COORDINATOR_SESSION_BRANCH_ENV];
+const PROMPT_ACCEPTED_ENV = "GJC_SESSION_PROMPT_ACCEPTED_JSON";
+const BASELINE_DIRTY_ENV = "GJC_SESSION_WORKTREE_BASELINE_DIRTY";
+const ORIGINAL_PROMPT_ACCEPTED = process.env[PROMPT_ACCEPTED_ENV];
+const ORIGINAL_BASELINE_DIRTY = process.env[BASELINE_DIRTY_ENV];
 
 async function tempRoot(): Promise<string> {
 	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-sidecar-"));
@@ -36,6 +40,10 @@ afterEach(async () => {
 	else process.env[GJC_COORDINATOR_SESSION_ID_ENV] = ORIGINAL_SESSION_ID;
 	if (ORIGINAL_BRANCH === undefined) delete process.env[GJC_COORDINATOR_SESSION_BRANCH_ENV];
 	else process.env[GJC_COORDINATOR_SESSION_BRANCH_ENV] = ORIGINAL_BRANCH;
+	if (ORIGINAL_PROMPT_ACCEPTED === undefined) delete process.env[PROMPT_ACCEPTED_ENV];
+	else process.env[PROMPT_ACCEPTED_ENV] = ORIGINAL_PROMPT_ACCEPTED;
+	if (ORIGINAL_BASELINE_DIRTY === undefined) delete process.env[BASELINE_DIRTY_ENV];
+	else process.env[BASELINE_DIRTY_ENV] = ORIGINAL_BASELINE_DIRTY;
 	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -174,6 +182,13 @@ describe("coordinator runtime state sidecar", () => {
 		const stateFile = path.join(root, "state.json");
 		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
 		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "post-acceptance-session";
+		const promptAccepted = path.join(root, "prompt-accepted.json");
+		await Bun.write(
+			promptAccepted,
+			JSON.stringify({ evidence: "durable_turn_evidence", worktreeBaselineDirty: false }),
+		);
+		process.env[PROMPT_ACCEPTED_ENV] = promptAccepted;
+		process.env[BASELINE_DIRTY_ENV] = "false";
 		await Bun.write(
 			stateFile,
 			JSON.stringify({
@@ -205,13 +220,128 @@ describe("coordinator runtime state sidecar", () => {
 			state: "errored",
 			ready_for_input: false,
 			source: "process_postmortem",
-			reason: "process_exit_before_terminal_state",
+			reason: "accepted_prompt_observed_recoverable_worktree_changes",
 			exit_code: 0,
 			previous_runtime_state: "running",
-			error: { code: "process_exit_before_terminal_state", recoverable: true },
+			error: { code: "accepted_prompt_observed_recoverable_worktree_changes", recoverable: true },
 			recovery: { action: "recover_or_resume_session" },
+			prompt_accepted: true,
+			observed_recoverable_worktree_changes: true,
+			worktree_baseline_dirty: false,
+			worktree_changed_since_baseline: true,
 		});
 		expect(await Bun.file(path.join(workspace, "README.md")).text()).toContain("recoverable dirty change");
+		expect(payload).not.toHaveProperty("messages");
+		expect(payload).not.toHaveProperty("transcript");
+		expect(payload).not.toHaveProperty("paneLog");
+	});
+
+	it("classifies accepted clean worktree exit as no useful output", async () => {
+		const root = await tempRoot();
+		const workspace = path.join(root, "worktree");
+		await fs.mkdir(workspace);
+		git(workspace, ["init"]);
+		git(workspace, ["config", "user.email", "test@example.com"]);
+		git(workspace, ["config", "user.name", "Test User"]);
+		await Bun.write(path.join(workspace, "README.md"), "base\n");
+		git(workspace, ["add", "README.md"]);
+		git(workspace, ["commit", "-m", "init"]);
+		const stateFile = path.join(root, "state.json");
+		const promptAccepted = path.join(root, "prompt-accepted.json");
+		await Bun.write(
+			promptAccepted,
+			JSON.stringify({ evidence: "durable_turn_evidence", worktreeBaselineDirty: false }),
+		);
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "no-output-session";
+		process.env[PROMPT_ACCEPTED_ENV] = promptAccepted;
+		process.env[BASELINE_DIRTY_ENV] = "false";
+		await Bun.write(
+			stateFile,
+			JSON.stringify({ schema_version: 1, session_id: "no-output-session", state: "running", cwd: workspace }),
+		);
+		const previousExitCode = process.exitCode;
+		process.exitCode = 0;
+		try {
+			persistCoordinatorRuntimeStateFromPostmortem(postmortem.Reason.EXIT, {
+				sessionId: "fallback",
+				cwd: workspace,
+				sessionFile: null,
+			});
+		} finally {
+			process.exitCode = previousExitCode;
+		}
+
+		const payload = JSON.parse(await Bun.file(stateFile).text());
+		expect(payload).toMatchObject({
+			state: "errored",
+			reason: "accepted_prompt_no_useful_output",
+			error: { code: "accepted_prompt_no_useful_output", recoverable: true },
+			prompt_accepted: true,
+			observed_recoverable_worktree_changes: false,
+			worktree_baseline_dirty: false,
+			worktree_changed_since_baseline: false,
+		});
+		expect(JSON.stringify(payload)).not.toContain("base\\n");
+		expect(payload).not.toHaveProperty("messages");
+		expect(payload).not.toHaveProperty("transcript");
+		expect(payload).not.toHaveProperty("paneLog");
+	});
+
+	it("does not overclaim pre-existing dirty worktree as new recoverable work", async () => {
+		const root = await tempRoot();
+		const workspace = path.join(root, "worktree");
+		await fs.mkdir(workspace);
+		git(workspace, ["init"]);
+		git(workspace, ["config", "user.email", "test@example.com"]);
+		git(workspace, ["config", "user.name", "Test User"]);
+		await Bun.write(path.join(workspace, "README.md"), "base\n");
+		git(workspace, ["add", "README.md"]);
+		git(workspace, ["commit", "-m", "init"]);
+		await Bun.write(path.join(workspace, "README.md"), "base\npreexisting private filename should not appear\n");
+		const stateFile = path.join(root, "state.json");
+		const promptAccepted = path.join(root, "prompt-accepted.json");
+		await Bun.write(
+			promptAccepted,
+			JSON.stringify({ evidence: "durable_turn_evidence", worktreeBaselineDirty: true }),
+		);
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "preexisting-dirty-session";
+		process.env[PROMPT_ACCEPTED_ENV] = promptAccepted;
+		process.env[BASELINE_DIRTY_ENV] = "false";
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "preexisting-dirty-session",
+				state: "running",
+				cwd: workspace,
+			}),
+		);
+		const previousExitCode = process.exitCode;
+		process.exitCode = 0;
+		try {
+			persistCoordinatorRuntimeStateFromPostmortem(postmortem.Reason.EXIT, {
+				sessionId: "fallback",
+				cwd: workspace,
+				sessionFile: null,
+			});
+		} finally {
+			process.exitCode = previousExitCode;
+		}
+
+		const payload = JSON.parse(await Bun.file(stateFile).text());
+		expect(payload).toMatchObject({
+			state: "errored",
+			reason: "accepted_prompt_dirty_worktree_observed_without_new_change_proof",
+			error: { code: "accepted_prompt_dirty_worktree_observed_without_new_change_proof", recoverable: true },
+			prompt_accepted: true,
+			observed_recoverable_worktree_changes: true,
+			worktree_baseline_dirty: true,
+			worktree_changed_since_baseline: false,
+		});
+		expect(JSON.stringify(payload)).not.toContain("preexisting private");
+		expect(payload.reason).not.toContain("partial");
 		expect(payload).not.toHaveProperty("messages");
 		expect(payload).not.toHaveProperty("transcript");
 		expect(payload).not.toHaveProperty("paneLog");
@@ -253,14 +383,93 @@ describe("coordinator runtime state sidecar", () => {
 			session_id: sessionId,
 			state: "errored",
 			source: "process_postmortem",
-			reason: "process_exit_before_terminal_state",
+			reason: "process_exit_before_prompt_acceptance",
 			exit_code: 0,
 			previous_runtime_state: "running",
-			error: { code: "process_exit_before_terminal_state", recoverable: true },
+			error: { code: "process_exit_before_prompt_acceptance", recoverable: true },
 		});
 		expect(payload).not.toHaveProperty("messages");
 		expect(payload).not.toHaveProperty("transcript");
 		expect(payload).not.toHaveProperty("paneLog");
+	});
+
+	it("overwrites mismatched terminal payloads instead of preserving stale evidence", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		const promptAccepted = path.join(root, "prompt-accepted.json");
+		await Bun.write(
+			promptAccepted,
+			JSON.stringify({ evidence: "durable_turn_evidence", worktreeBaselineDirty: false }),
+		);
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "current-session";
+		process.env[PROMPT_ACCEPTED_ENV] = promptAccepted;
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "stale-session",
+				state: "completed",
+				cwd: root,
+				final_response: { source: "agent_end", text: "Stale done" },
+			}),
+		);
+		const previousExitCode = process.exitCode;
+		process.exitCode = 0;
+		try {
+			persistCoordinatorRuntimeStateFromPostmortem(postmortem.Reason.EXIT, {
+				sessionId: "fallback",
+				cwd: root,
+				sessionFile: null,
+			});
+		} finally {
+			process.exitCode = previousExitCode;
+		}
+
+		const payload = JSON.parse(await Bun.file(stateFile).text());
+		expect(payload).toMatchObject({
+			session_id: "current-session",
+			state: "errored",
+			source: "process_postmortem",
+			reason: "accepted_prompt_no_useful_output",
+			error: { code: "accepted_prompt_no_useful_output", recoverable: true },
+		});
+		expect(payload.final_response?.text).not.toBe("Stale done");
+	});
+
+	it("overwrites terminal payloads with mismatched cwd or session file", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "current-session";
+		for (const stale of [
+			{ cwd: path.join(root, "other"), session_file: path.join(root, "session.jsonl") },
+			{ cwd: root, session_file: path.join(root, "other-session.jsonl") },
+		]) {
+			await Bun.write(
+				stateFile,
+				JSON.stringify({
+					schema_version: 1,
+					session_id: "current-session",
+					state: "errored",
+					...stale,
+					final_response: { source: "launch_error", text: "Stale launch" },
+				}),
+			);
+			persistCoordinatorRuntimeStateFromPostmortem(postmortem.Reason.SIGTERM, {
+				sessionId: "fallback",
+				cwd: root,
+				sessionFile: path.join(root, "session.jsonl"),
+			});
+			const payload = JSON.parse(await Bun.file(stateFile).text());
+			expect(payload).toMatchObject({
+				session_id: "current-session",
+				state: "errored",
+				source: "process_postmortem",
+				reason: "sigterm",
+			});
+			expect(payload.final_response?.text).not.toBe("Stale launch");
+		}
 	});
 
 	it("does not overwrite richer terminal agent_end evidence during postmortem", async () => {
@@ -288,6 +497,35 @@ describe("coordinator runtime state sidecar", () => {
 		expect(payload).toMatchObject({
 			state: "completed",
 			final_response: { source: "agent_end", text: "Already done" },
+		});
+		expect(payload.source).not.toBe("process_postmortem");
+	});
+
+	it("does not overwrite richer terminal launch_error evidence during postmortem", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "launch-error-session";
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "launch-error-session",
+				state: "errored",
+				final_response: { source: "launch_error", text: "Launch failed" },
+			}),
+		);
+
+		persistCoordinatorRuntimeStateFromPostmortem(postmortem.Reason.EXIT, {
+			sessionId: "fallback",
+			cwd: root,
+			sessionFile: null,
+		});
+
+		const payload = JSON.parse(await Bun.file(stateFile).text());
+		expect(payload).toMatchObject({
+			state: "errored",
+			final_response: { source: "launch_error", text: "Launch failed" },
 		});
 		expect(payload.source).not.toBe("process_postmortem");
 	});

--- a/scripts/gjc-session/create.sh
+++ b/scripts/gjc-session/create.sh
@@ -53,8 +53,7 @@ show_recovery_hint() {
   echo "durable vanished status: $STATE_DIR/vanished.json" >&2
   echo "durable runtime state: $RUNTIME_STATE_JSON" >&2
   if [[ -s "$STATE_DIR/pane.log" ]]; then
-    echo "--- durable pane log tail ---" >&2
-    tail -40 "$STATE_DIR/pane.log" >&2
+    echo "durable pane log tail omitted from diagnostics to preserve public-safe boundaries" >&2
   fi
 }
 
@@ -81,6 +80,7 @@ STATE_DIR="${GJC_SESSION_STATE_DIR:-$WORKDIR/.gjc-session-state/$SESSION}"
 RUNTIME_STATE_JSON="$STATE_DIR/runtime-state.json"
 mkdir -p "$STATE_DIR"
 CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+WORKTREE_BASELINE_DIRTY="$(gjc_session_git_dirty_boolean "$WORKDIR")"
 {
   printf '{\n'
   printf '  "session": "%s",\n' "$(printf '%s' "$SESSION" | json_escape)"
@@ -94,7 +94,8 @@ CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   printf '  "finalStatus": "%s",\n' "$(printf '%s' "$STATE_DIR/final.json" | json_escape)"
   printf '  "runtimeState": "%s",\n' "$(printf '%s' "$RUNTIME_STATE_JSON" | json_escape)"
   printf '  "vanishedStatus": "%s",\n' "$(printf '%s' "$STATE_DIR/vanished.json" | json_escape)"
-  printf '  "promptAcceptedStatus": "%s"\n' "$(printf '%s' "$STATE_DIR/prompt-accepted.json" | json_escape)"
+  printf '  "promptAcceptedStatus": "%s",\n' "$(printf '%s' "$STATE_DIR/prompt-accepted.json" | json_escape)"
+  printf '  "worktreeBaselineDirty": %s\n' "$WORKTREE_BASELINE_DIRTY"
   printf '}\n'
 } >"$STATE_DIR/metadata.json"
 : >"$STATE_DIR/pane.log"
@@ -103,6 +104,22 @@ printf '[%s] create requested session=%s workdir=%s branch=%s\n' "$CREATED_AT" "
 cat >"$STATE_DIR/runner.sh" <<'RUNNER'
 #!/usr/bin/env bash
 set +e
+gjc_session_git_dirty_boolean() {
+  local workdir="${1:-}"
+  if [[ -z "$workdir" ]]; then
+    printf 'null\n'
+    return 0
+  fi
+  if ! git -C "$workdir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    printf 'null\n'
+    return 0
+  fi
+  if [[ -n "$(git -C "$workdir" status --porcelain 2>/dev/null)" ]]; then
+    printf 'true\n'
+  else
+    printf 'false\n'
+  fi
+}
 cd "$GJC_SESSION_WORKDIR" || exit 127
 started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 printf '[%s] runner started session=%s branch=%s cwd=%s\n' "$started_at" "$GJC_SESSION_NAME" "$GJC_SESSION_BRANCH" "$GJC_SESSION_WORKDIR" >>"$GJC_SESSION_EVENTS_LOG"
@@ -129,18 +146,86 @@ for _ in $(seq 1 20); do
 done
 owner_exit_reason="normal_exit"
 owner_exit_severity="normal"
-if [[ "$turn_evidence" != "true" ]]; then
+runtime_terminal=false
+runtime_terminal_state=""
+runtime_terminal_source=""
+if [[ -s "${GJC_COORDINATOR_SESSION_STATE_FILE:-}" ]]; then
+  runtime_summary="$(python3 - "$GJC_COORDINATOR_SESSION_STATE_FILE" "$GJC_SESSION_NAME" "$GJC_SESSION_WORKDIR" <<'PY' 2>/dev/null || true
+import json
+import os
+import sys
+state_file, expected_session, expected_cwd = sys.argv[1:]
+try:
+    with open(state_file, encoding="utf-8") as handle:
+        data = json.load(handle)
+except Exception:
+    data = {}
+state = data.get("state")
+session_id = data.get("session_id")
+cwd = data.get("cwd") or data.get("workdir")
+source = (data.get("final_response") or {}).get("source")
+session_matches = not session_id or session_id == expected_session
+cwd_matches = not cwd or os.path.abspath(str(cwd)) == os.path.abspath(expected_cwd)
+if state in {"completed", "errored"} and session_matches and cwd_matches:
+    print("true")
+    print(state)
+    print(source or "runtime_state")
+else:
+    print("false")
+    print("")
+    print("")
+PY
+)"
+  runtime_terminal="$(printf '%s\n' "$runtime_summary" | sed -n '1p')"
+  runtime_terminal_state="$(printf '%s\n' "$runtime_summary" | sed -n '2p')"
+  runtime_terminal_source="$(printf '%s\n' "$runtime_summary" | sed -n '3p')"
+fi
+worktree_baseline_dirty="${GJC_SESSION_WORKTREE_BASELINE_DIRTY:-null}"
+if [[ "$prompt_accepted" == "true" && -s "${GJC_SESSION_PROMPT_ACCEPTED_JSON:-}" ]]; then
+  prompt_baseline="$(python3 - "$GJC_SESSION_PROMPT_ACCEPTED_JSON" <<'PY' 2>/dev/null || true
+import json
+import sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        value = json.load(handle).get("worktreeBaselineDirty")
+    print("true" if value is True else "false" if value is False else "null")
+except Exception:
+    print("null")
+PY
+)"
+  if [[ "$prompt_baseline" == "true" || "$prompt_baseline" == "false" ]]; then
+    worktree_baseline_dirty="$prompt_baseline"
+  fi
+fi
+worktree_current_dirty="$(gjc_session_git_dirty_boolean "${GJC_SESSION_WORKDIR:-}")"
+worktree_changed_since_baseline=false
+if [[ "$worktree_baseline_dirty" == "false" && "$worktree_current_dirty" == "true" ]]; then
+  worktree_changed_since_baseline=true
+fi
+if [[ "$runtime_terminal" == "true" ]]; then
+  owner_exit_reason="terminal_runtime_cleanup"
+  owner_exit_severity="normal"
+elif [[ "$turn_evidence" != "true" ]]; then
   owner_exit_reason="owner_exited_before_turn_evidence"
   owner_exit_severity="failure"
+elif [[ "$prompt_accepted" == "true" && "$worktree_changed_since_baseline" == "true" ]]; then
+  owner_exit_reason="accepted_prompt_observed_recoverable_worktree_changes"
+  owner_exit_severity="failure"
+elif [[ "$prompt_accepted" == "true" && "$worktree_current_dirty" == "true" ]]; then
+  owner_exit_reason="accepted_prompt_dirty_worktree_observed_without_new_change_proof"
+  owner_exit_severity="failure"
 elif [[ "$prompt_accepted" == "true" ]]; then
-  owner_exit_reason="owner_exited_after_prompt_acceptance_before_terminal_status"
+  owner_exit_reason="accepted_prompt_no_useful_output"
+  owner_exit_severity="failure"
+elif [[ "$prompt_accepted" != "true" ]]; then
+  owner_exit_reason="owner_exited_before_prompt_acceptance"
   owner_exit_severity="failure"
 fi
-python3 - "$GJC_SESSION_FINAL_JSON" "$GJC_SESSION_NAME" "$rc" "$started_at" "$finished_at" "$GJC_SESSION_PANE_LOG" "$GJC_COORDINATOR_SESSION_STATE_FILE" "$turn_evidence" "$prompt_accepted" "$owner_exit_reason" "$owner_exit_severity" <<'PY'
+python3 - "$GJC_SESSION_FINAL_JSON" "$GJC_SESSION_NAME" "$rc" "$started_at" "$finished_at" "$GJC_SESSION_PANE_LOG" "$GJC_COORDINATOR_SESSION_STATE_FILE" "$turn_evidence" "$prompt_accepted" "$owner_exit_reason" "$owner_exit_severity" "$runtime_terminal" "$runtime_terminal_state" "$runtime_terminal_source" "$worktree_baseline_dirty" "$worktree_current_dirty" "$worktree_changed_since_baseline" <<'PY'
 import json
 import sys
 
-path, session, status, started_at, finished_at, pane_log, runtime_state, turn_evidence, prompt_accepted, owner_exit_reason, owner_exit_severity = sys.argv[1:]
+path, session, status, started_at, finished_at, pane_log, runtime_state, turn_evidence, prompt_accepted, owner_exit_reason, owner_exit_severity, runtime_terminal, runtime_terminal_state, runtime_terminal_source, baseline_dirty, current_dirty, changed_since_baseline = sys.argv[1:]
 with open(path, "w", encoding="utf-8") as handle:
     json.dump(
         {
@@ -154,6 +239,12 @@ with open(path, "w", encoding="utf-8") as handle:
             "promptAccepted": prompt_accepted == "true",
             "ownerExitReason": owner_exit_reason,
             "severity": owner_exit_severity,
+            "runtimeTerminal": runtime_terminal == "true",
+            "runtimeTerminalState": runtime_terminal_state or None,
+            "runtimeTerminalSource": runtime_terminal_source or None,
+            "worktreeBaselineDirty": None if baseline_dirty == "null" else baseline_dirty == "true",
+            "observedRecoverableWorktreeChanges": current_dirty == "true",
+            "worktreeChangedSinceBaseline": changed_since_baseline == "true",
         },
         handle,
         indent=2,
@@ -209,6 +300,40 @@ PY
 )"
     final_severity="$(printf '%s\n' "$final_summary" | sed -n '1p')"
     final_prompt_accepted="$(printf '%s\n' "$final_summary" | sed -n '2p')"
+  fi
+  runtime_terminal_state=""
+  runtime_terminal_source=""
+  if [[ -s "${GJC_COORDINATOR_SESSION_STATE_FILE:-}" ]]; then
+    runtime_summary="$(python3 - "$GJC_COORDINATOR_SESSION_STATE_FILE" "$GJC_SESSION_NAME" "$GJC_SESSION_WORKDIR" <<'PY' 2>/dev/null || true
+import json
+import os
+import sys
+state_file, expected_session, expected_cwd = sys.argv[1:]
+try:
+    with open(state_file, encoding="utf-8") as handle:
+        data = json.load(handle)
+except Exception:
+    data = {}
+state = data.get("state")
+session_id = data.get("session_id")
+cwd = data.get("cwd") or data.get("workdir")
+source = (data.get("final_response") or {}).get("source")
+session_matches = not session_id or session_id == expected_session
+cwd_matches = not cwd or os.path.abspath(str(cwd)) == os.path.abspath(expected_cwd)
+if state in {"completed", "errored"} and session_matches and cwd_matches:
+    print(state)
+    print(source or "runtime_state")
+else:
+    print("")
+    print("")
+PY
+)"
+    runtime_terminal_state="$(printf '%s\n' "$runtime_summary" | sed -n '1p')"
+    runtime_terminal_source="$(printf '%s\n' "$runtime_summary" | sed -n '2p')"
+  fi
+  if [[ "$final_present" != "true" && -n "$runtime_terminal_state" ]]; then
+    printf '[%s] tmux session closed after terminal runtime state=%s source=%s; no vanished failure marker written\n' "$detected_at" "$runtime_terminal_state" "${runtime_terminal_source:-unknown}" >>"$GJC_SESSION_EVENTS_LOG"
+    exit 0
   fi
   if [[ "$final_present" == "true" ]]; then
     if [[ "$final_severity" != "failure" ]]; then
@@ -287,6 +412,7 @@ LAUNCH_CMD=(
   "GJC_COORDINATOR_SESSION_STATE_FILE=$RUNTIME_STATE_JSON"
   "GJC_COORDINATOR_SESSION_BRANCH=$BRANCH"
   "GJC_SESSION_TURN_EVIDENCE_PATTERN=$TURN_EVIDENCE_PATTERN"
+  "GJC_SESSION_WORKTREE_BASELINE_DIRTY=$WORKTREE_BASELINE_DIRTY"
   "GJC_SESSION_GJC_BIN=$GJC_BIN"
   "GJC_SESSION_FLAGS=$GJC_FLAGS"
   bash "$STATE_DIR/runner.sh"
@@ -322,6 +448,7 @@ if [[ "${GJC_SESSION_MONITOR_DISABLE:-0}" != "1" ]]; then
     "GJC_SESSION_ROUTER_BIN=$ROUTER_BIN"
     "GJC_SESSION_CHANNEL=$CHANNEL"
     "GJC_SESSION_TURN_EVIDENCE_PATTERN=$TURN_EVIDENCE_PATTERN"
+    "GJC_SESSION_WORKTREE_BASELINE_DIRTY=$WORKTREE_BASELINE_DIRTY"
     bash "$STATE_DIR/monitor.sh"
   )
   nohup "${MONITOR_CMD[@]}" >>"$STATE_DIR/monitor.log" 2>&1 &
@@ -353,7 +480,26 @@ if ! "${TMUX_CMD[@]}" has-session -t "$SESSION" 2>/dev/null; then
   show_recovery_hint
   exit 1
 fi
-if [[ -s "$STATE_DIR/final.json" ]] && ! has_turn_evidence; then
+if ! has_turn_evidence; then
+  for _ in $(seq 1 20); do
+    [[ -s "$STATE_DIR/final.json" ]] && break
+    sleep 0.1
+  done
+fi
+final_severity=""
+if [[ -s "$STATE_DIR/final.json" ]]; then
+  final_severity="$(python3 - "$STATE_DIR/final.json" <<'PY' 2>/dev/null || true
+import json
+import sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        print(json.load(handle).get("severity") or "")
+except Exception:
+    print("")
+PY
+)"
+fi
+if [[ -s "$STATE_DIR/final.json" && "$final_severity" == "failure" ]] && ! has_turn_evidence; then
   echo "GJC owner exited before durable turn evidence: $SESSION" >&2
   show_recovery_hint
   exit 1

--- a/scripts/gjc-session/create.test.ts
+++ b/scripts/gjc-session/create.test.ts
@@ -127,6 +127,167 @@ exit 0
 		});
 	});
 
+	test("runner treats completed runtime state as normal terminal cleanup", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-runtime-completed-"));
+		tempRoots.push(root);
+		const session = `gjc_issue_1496_runtime_completed_${process.pid}_${Date.now()}`;
+		tmuxSessions.push(session);
+		const worktree = await makeGitWorktree(root);
+		const stateDir = path.join(root, "state");
+		const fakeGjc = path.join(root, "bin", "gjc");
+		await makeExecutable(
+			fakeGjc,
+			`#!/usr/bin/env bash
+python3 - <<'PY'
+import json
+import os
+with open(os.environ["GJC_COORDINATOR_SESSION_STATE_FILE"], "w", encoding="utf-8") as handle:
+    json.dump({"session_id": os.environ["GJC_COORDINATOR_SESSION_ID"], "state": "completed", "final_response": {"source": "agent_end"}}, handle)
+PY
+exit 0
+`,
+		);
+
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree], {
+			env: isolatedEnv({
+				GJC_BIN: fakeGjc,
+				GJC_SESSION_MONITOR_DISABLE: "1",
+				GJC_SESSION_SKIP_ROUTER: "1",
+				GJC_SESSION_STATE_DIR: stateDir,
+			}),
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(0);
+		const finalStatus = (await Bun.file(path.join(stateDir, "final.json")).json()) as Record<string, unknown>;
+		expect(finalStatus).toMatchObject({
+			ownerExitReason: "terminal_runtime_cleanup",
+			severity: "normal",
+			runtimeTerminal: true,
+			runtimeTerminalState: "completed",
+			runtimeTerminalSource: "agent_end",
+		});
+	});
+
+	test("runner treats launch_error runtime state as normal terminal cleanup", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-runtime-errored-"));
+		tempRoots.push(root);
+		const session = `gjc_issue_1496_runtime_errored_${process.pid}_${Date.now()}`;
+		tmuxSessions.push(session);
+		const worktree = await makeGitWorktree(root);
+		const stateDir = path.join(root, "state");
+		const fakeGjc = path.join(root, "bin", "gjc");
+		await makeExecutable(
+			fakeGjc,
+			`#!/usr/bin/env bash
+python3 - <<'PY'
+import json
+import os
+with open(os.environ["GJC_COORDINATOR_SESSION_STATE_FILE"], "w", encoding="utf-8") as handle:
+    json.dump({"session_id": os.environ["GJC_COORDINATOR_SESSION_ID"], "state": "errored", "final_response": {"source": "launch_error"}}, handle)
+PY
+exit 1
+`,
+		);
+
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree], {
+			env: isolatedEnv({
+				GJC_BIN: fakeGjc,
+				GJC_SESSION_MONITOR_DISABLE: "1",
+				GJC_SESSION_SKIP_ROUTER: "1",
+				GJC_SESSION_STATE_DIR: stateDir,
+			}),
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(0);
+		const finalStatus = (await Bun.file(path.join(stateDir, "final.json")).json()) as Record<string, unknown>;
+		expect(finalStatus).toMatchObject({
+			ownerExitReason: "terminal_runtime_cleanup",
+			severity: "normal",
+			runtimeTerminal: true,
+			runtimeTerminalState: "errored",
+			runtimeTerminalSource: "launch_error",
+		});
+	});
+
+	test("runner rejects terminal runtime state for a mismatched session id", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-runtime-mismatch-"));
+		tempRoots.push(root);
+		const session = `gjc_issue_1496_runtime_mismatch_${process.pid}_${Date.now()}`;
+		tmuxSessions.push(session);
+		const worktree = await makeGitWorktree(root);
+		const stateDir = path.join(root, "state");
+		const fakeGjc = path.join(root, "bin", "gjc");
+		await makeExecutable(
+			fakeGjc,
+			`#!/usr/bin/env bash
+python3 - <<'PY'
+import json
+import os
+with open(os.environ["GJC_COORDINATOR_SESSION_STATE_FILE"], "w", encoding="utf-8") as handle:
+    json.dump({"session_id": "unrelated-session", "state": "completed", "final_response": {"source": "agent_end"}}, handle)
+PY
+printf 'Gajae forge\nWorking before prompt but no accepted marker\n'
+exit 0
+`,
+		);
+
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree], {
+			env: isolatedEnv({
+				GJC_BIN: fakeGjc,
+				GJC_SESSION_MONITOR_DISABLE: "1",
+				GJC_SESSION_SKIP_ROUTER: "1",
+				GJC_SESSION_STATE_DIR: stateDir,
+			}),
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(0);
+		await waitForFile(path.join(stateDir, "final.json"));
+		const finalStatus = (await Bun.file(path.join(stateDir, "final.json")).json()) as Record<string, unknown>;
+		expect(finalStatus).toMatchObject({
+			ownerExitReason: "owner_exited_before_prompt_acceptance",
+			severity: "failure",
+			runtimeTerminal: false,
+		});
+	});
+
+	test("runner treats pre-acceptance pane evidence exit as failure, not normal", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-preaccept-evidence-"));
+		tempRoots.push(root);
+		const session = `gjc_issue_1496_preaccept_evidence_${process.pid}_${Date.now()}`;
+		tmuxSessions.push(session);
+		const worktree = await makeGitWorktree(root);
+		const stateDir = path.join(root, "state");
+		const fakeGjc = path.join(root, "bin", "gjc");
+		await makeExecutable(fakeGjc, "#!/usr/bin/env bash\nprintf 'Gajae forge\\nWorking before prompt acceptance\\n'\nexit 0\n");
+
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree], {
+			env: isolatedEnv({
+				GJC_BIN: fakeGjc,
+				GJC_SESSION_MONITOR_DISABLE: "1",
+				GJC_SESSION_SKIP_ROUTER: "1",
+				GJC_SESSION_STATE_DIR: stateDir,
+			}),
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(0);
+		await waitForFile(path.join(stateDir, "final.json"));
+		const finalStatus = (await Bun.file(path.join(stateDir, "final.json")).json()) as Record<string, unknown>;
+		expect(finalStatus).toMatchObject({
+			turnEvidencePresent: true,
+			promptAccepted: false,
+			ownerExitReason: "owner_exited_before_prompt_acceptance",
+			severity: "failure",
+		});
+	});
+
 	test("external monitor records vanished tmux sessions and alerts the router", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-vanish-"));
 		tempRoots.push(root);
@@ -164,14 +325,17 @@ exit 0
 		};
 		expect(vanished).toMatchObject({
 			finalPresent: false,
-			reason: "tmux_session_missing_before_prompt_acceptance",
-			phase: "before_prompt_acceptance",
+			reason: vanished.tuiReadyObserved
+				? "tmux_session_missing_before_prompt_acceptance"
+				: "tmux_session_missing_before_tui_readiness",
+			phase: vanished.tuiReadyObserved ? "before_prompt_acceptance" : "before_tui_readiness",
 			severity: "failure",
-			tuiReadyObserved: true,
+			tuiReadyObserved: vanished.tuiReadyObserved,
 		});
 		expect(vanished.runtimeState).toBe(path.relative(worktree, path.join(stateDir, "runtime-state.json")));
+		await waitForFile(routerLog);
 		expect(await Bun.file(routerLog).text()).toContain("tmux stale --session");
-	});
+	}, 20000);
 	test("external monitor records vanished sessions after prompt acceptance", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-post-accept-vanish-"));
 		tempRoots.push(root);
@@ -491,9 +655,119 @@ exit 0
 		expect(finalStatus).toMatchObject({
 			promptAccepted: true,
 			turnEvidencePresent: true,
-			ownerExitReason: "owner_exited_after_prompt_acceptance_before_terminal_status",
+			ownerExitReason: "accepted_prompt_no_useful_output",
 			severity: "failure",
+			observedRecoverableWorktreeChanges: false,
+			worktreeChangedSinceBaseline: false,
 		});
+	}, 20000);
+	test("runner reports new recoverable worktree changes after prompt acceptance", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-owner-exit-dirty-"));
+		tempRoots.push(root);
+		const session = `gjc_issue_1496_owner_exit_dirty_${process.pid}_${Date.now()}`;
+		tmuxSessions.push(session);
+		const worktree = await makeGitWorktree(root);
+		const stateDir = path.join(root, "state");
+		const fakeGjc = path.join(root, "bin", "gjc");
+		await makeExecutable(
+			fakeGjc,
+			`#!/usr/bin/env bash
+printf 'Gajae forge\n> Type your message\n'
+IFS= read -r line
+printf '\nWorking then writing recoverable work\n'
+printf 'fixture\nrecoverable private diff text\n' > README.md
+exit 0
+`,
+		);
+
+		const created = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree], {
+			env: isolatedEnv({
+				GJC_BIN: fakeGjc,
+				GJC_SESSION_MONITOR_DISABLE: "1",
+				GJC_SESSION_SKIP_ROUTER: "1",
+				GJC_SESSION_STATE_DIR: stateDir,
+			}),
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		expect(created.exitCode).toBe(0);
+
+		const prompted = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "accepted then dirty"], {
+			env: isolatedEnv({
+				GJC_SESSION_STATE_DIR: stateDir,
+				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "2",
+			}),
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		expect(prompted.exitCode).toBe(0);
+		await waitForFile(path.join(stateDir, "final.json"));
+
+		const finalStatus = (await Bun.file(path.join(stateDir, "final.json")).json()) as Record<string, unknown>;
+		expect(finalStatus).toMatchObject({
+			promptAccepted: true,
+			ownerExitReason: "accepted_prompt_observed_recoverable_worktree_changes",
+			severity: "failure",
+			worktreeBaselineDirty: false,
+			observedRecoverableWorktreeChanges: true,
+			worktreeChangedSinceBaseline: true,
+		});
+		expect(JSON.stringify(finalStatus)).not.toContain("recoverable private diff text");
+	}, 20000);
+
+	test("runner does not overclaim pre-existing dirty worktree as new work", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-owner-exit-preexisting-dirty-"));
+		tempRoots.push(root);
+		const session = `gjc_issue_1496_owner_exit_preexisting_dirty_${process.pid}_${Date.now()}`;
+		tmuxSessions.push(session);
+		const worktree = await makeGitWorktree(root);
+		await Bun.write(path.join(worktree, "README.md"), "fixture\npreexisting dirty text\n");
+		const stateDir = path.join(root, "state");
+		const fakeGjc = path.join(root, "bin", "gjc");
+		await makeExecutable(
+			fakeGjc,
+			`#!/usr/bin/env bash
+printf 'Gajae forge\n> Type your message\n'
+IFS= read -r line
+printf '\nWorking without new worktree changes\n'
+exit 0
+`,
+		);
+
+		const created = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree], {
+			env: isolatedEnv({
+				GJC_BIN: fakeGjc,
+				GJC_SESSION_MONITOR_DISABLE: "1",
+				GJC_SESSION_SKIP_ROUTER: "1",
+				GJC_SESSION_STATE_DIR: stateDir,
+			}),
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		expect(created.exitCode).toBe(0);
+
+		const prompted = Bun.spawnSync(["bash", "scripts/gjc-session/prompt.sh", session, "accepted preexisting dirty"], {
+			env: isolatedEnv({
+				GJC_SESSION_STATE_DIR: stateDir,
+				GJC_SESSION_PROMPT_EVIDENCE_ATTEMPTS: "2",
+			}),
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		expect(prompted.exitCode).toBe(0);
+		await waitForFile(path.join(stateDir, "final.json"));
+
+		const finalStatus = (await Bun.file(path.join(stateDir, "final.json")).json()) as Record<string, unknown>;
+		expect(finalStatus).toMatchObject({
+			promptAccepted: true,
+			ownerExitReason: "accepted_prompt_dirty_worktree_observed_without_new_change_proof",
+			severity: "failure",
+			worktreeBaselineDirty: true,
+			observedRecoverableWorktreeChanges: true,
+			worktreeChangedSinceBaseline: false,
+		});
+		expect(String(finalStatus.ownerExitReason)).not.toContain("partial");
+		expect(JSON.stringify(finalStatus)).not.toContain("preexisting dirty text");
 	}, 20000);
 
 	test("monitor preserves vanished marker when failure-final hold disappears after prompt acceptance", async () => {

--- a/scripts/gjc-session/postmortem.sh
+++ b/scripts/gjc-session/postmortem.sh
@@ -6,6 +6,23 @@ json_escape() {
   python3 -c 'import json,sys; print(json.dumps(sys.stdin.read())[1:-1])'
 }
 
+gjc_session_git_dirty_boolean() {
+  local workdir="${1:-}"
+  if [[ -z "$workdir" ]]; then
+    printf 'null\n'
+    return 0
+  fi
+  if ! git -C "$workdir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    printf 'null\n'
+    return 0
+  fi
+  if [[ -n "$(git -C "$workdir" status --porcelain 2>/dev/null)" ]]; then
+    printf 'true\n'
+  else
+    printf 'false\n'
+  fi
+}
+
 gjc_session_write_vanished_json() {
   local vanished_json="${1:?vanished json path required}"
   local session="${2:?session required}"
@@ -55,6 +72,50 @@ def rel_to_workdir(value: str) -> str | None:
     except ValueError:
         return None
 
+runtime_terminal_state = None
+runtime_terminal_source = None
+if runtime_state:
+    try:
+        with open(runtime_state, encoding="utf-8") as runtime_handle:
+            runtime_data = json.load(runtime_handle)
+        state = runtime_data.get("state")
+        session_id = runtime_data.get("session_id")
+        cwd = runtime_data.get("cwd") or runtime_data.get("workdir")
+        session_matches = not session_id or session_id == session
+        cwd_matches = not cwd or os.path.abspath(str(cwd)) == os.path.abspath(workdir)
+        if state in {"completed", "errored"} and session_matches and cwd_matches:
+            runtime_terminal_state = state
+            runtime_terminal_source = (runtime_data.get("final_response") or {}).get("source") or "runtime_state"
+    except Exception:
+        pass
+current_dirty_raw = "null"
+try:
+    import subprocess
+    probe = subprocess.run(["git", "-C", workdir, "status", "--porcelain"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False)
+    if probe.returncode == 0:
+        current_dirty_raw = "true" if probe.stdout else "false"
+except Exception:
+    pass
+baseline_dirty = None
+try:
+    if prompt_accepted_json:
+        with open(prompt_accepted_json, encoding="utf-8") as prompt_handle:
+            value = json.load(prompt_handle).get("worktreeBaselineDirty")
+        if isinstance(value, bool):
+            baseline_dirty = value
+except Exception:
+    pass
+if baseline_dirty is None:
+    try:
+        metadata_path = os.path.join(os.path.dirname(path), "metadata.json")
+        with open(metadata_path, encoding="utf-8") as metadata_handle:
+            value = json.load(metadata_handle).get("worktreeBaselineDirty")
+        if isinstance(value, bool):
+            baseline_dirty = value
+    except Exception:
+        pass
+current_dirty = None if current_dirty_raw == "null" else current_dirty_raw == "true"
+changed_since_baseline = baseline_dirty is False and current_dirty is True
 with open(path, "w", encoding="utf-8") as handle:
     json.dump(
         {
@@ -72,6 +133,12 @@ with open(path, "w", encoding="utf-8") as handle:
             "finalStatus": rel_to_workdir(final_json),
             "runtimeState": rel_to_workdir(runtime_state),
             "promptAcceptedStatus": rel_to_workdir(prompt_accepted_json),
+            "runtimeTerminal": runtime_terminal_state in {"completed", "errored"},
+            "runtimeTerminalState": runtime_terminal_state,
+            "runtimeTerminalSource": runtime_terminal_source,
+            "worktreeBaselineDirty": baseline_dirty,
+            "observedRecoverableWorktreeChanges": current_dirty is True,
+            "worktreeChangedSinceBaseline": changed_since_baseline,
         },
         handle,
         indent=2,

--- a/scripts/gjc-session/prompt.sh
+++ b/scripts/gjc-session/prompt.sh
@@ -50,11 +50,30 @@ record_prompt_accepted() {
   mkdir -p "$(dirname "$accepted_path")"
   local accepted_dir
   accepted_dir="$(dirname "$accepted_path")"
-  python3 - "$accepted_path" "$SESSION" "$accepted_at" "$accepted_dir/pane.log" <<'PY'
+  local worktree_baseline_dirty="${GJC_SESSION_PROMPT_WORKTREE_BASELINE_DIRTY:-null}"
+  if [[ "$worktree_baseline_dirty" != "true" && "$worktree_baseline_dirty" != "false" ]]; then
+    local workdir=""
+    if [[ -f "$accepted_dir/metadata.json" ]]; then
+      workdir="$(python3 - "$accepted_dir/metadata.json" <<'PYMETA'
+import json
+import sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        print(json.load(handle).get("workdir") or "")
+except Exception:
+    print("")
+PYMETA
+)"
+    fi
+    if [[ -n "$workdir" ]]; then
+      worktree_baseline_dirty="$(gjc_session_git_dirty_boolean "$workdir")"
+    fi
+  fi
+  python3 - "$accepted_path" "$SESSION" "$accepted_at" "$accepted_dir/pane.log" "$worktree_baseline_dirty" <<'PY'
 import json
 import sys
 
-path, session, accepted_at, pane_log = sys.argv[1:]
+path, session, accepted_at, pane_log, worktree_baseline_dirty = sys.argv[1:]
 with open(path, "w", encoding="utf-8") as handle:
     json.dump(
         {
@@ -62,6 +81,7 @@ with open(path, "w", encoding="utf-8") as handle:
             "acceptedAt": accepted_at,
             "evidence": "durable_turn_evidence",
             "paneLog": pane_log,
+            "worktreeBaselineDirty": None if worktree_baseline_dirty == "null" else worktree_baseline_dirty == "true",
         },
         handle,
         indent=2,
@@ -131,19 +151,6 @@ PY
   return 1
 }
 
-print_redacted_tail() {
-  local prompt_text="${TEXT:-}"
-  python3 - "$prompt_text" <<'PY'
-import sys
-
-prompt = sys.argv[1]
-text = sys.stdin.read()
-if prompt:
-    text = text.replace(prompt, "[prompt redacted]")
-for line in text.splitlines()[-40:]:
-    print(line)
-PY
-}
 
 show_missing_session_diagnostics() {
   local log_path="$1"
@@ -159,8 +166,7 @@ show_missing_session_diagnostics() {
   if [[ -f "$state_dir/events.log" ]]; then
     echo "durable events: $state_dir/events.log" >&2
   fi
-  echo "--- durable pane log tail ---" >&2
-  tail -40 "$log_path" | print_redacted_tail >&2
+  echo "durable pane log tail omitted from diagnostics to preserve public-safe boundaries" >&2
 }
 
 
@@ -244,8 +250,7 @@ if ! printf '%s\n' "$PANE_TEXT" | grep -qE 'Gajae forge|Type your message|> Type
     write_pre_prompt_vanished "tmux_session_unready_before_prompt_injection" "before_prompt_injection" false ""
   fi
   echo "refusing to paste prompt: GJC TUI is not ready in session $SESSION" >&2
-  echo "--- pane tail ---" >&2
-  printf '%s\n' "$PANE_TEXT" | print_redacted_tail >&2
+  echo "pane tail omitted from diagnostics to preserve public-safe boundaries" >&2
   exit 1
 fi
 
@@ -277,6 +282,23 @@ cleanup_evidence_log() {
 trap cleanup_evidence_log EXIT
 if [[ "$EVIDENCE_LOG_IS_TEMP" == "1" ]]; then
   "${TMUX_CMD[@]}" pipe-pane -t "$SESSION":0.0 "cat >> '$EVIDENCE_LOG'"
+fi
+GJC_SESSION_PROMPT_WORKTREE_BASELINE_DIRTY="null"
+prompt_baseline_path="$(prompt_accepted_path)"
+if [[ -n "$prompt_baseline_path" && -f "$(dirname "$prompt_baseline_path")/metadata.json" ]]; then
+  prompt_baseline_workdir="$(python3 - "$(dirname "$prompt_baseline_path")/metadata.json" <<'PYMETA'
+import json
+import sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        print(json.load(handle).get("workdir") or "")
+except Exception:
+    print("")
+PYMETA
+)"
+  if [[ -n "$prompt_baseline_workdir" ]]; then
+    GJC_SESSION_PROMPT_WORKTREE_BASELINE_DIRTY="$(gjc_session_git_dirty_boolean "$prompt_baseline_workdir")"
+  fi
 fi
 
 "${TMUX_CMD[@]}" send-keys -t "$SESSION" -l "$TEXT"
@@ -322,6 +344,5 @@ for _ in $(seq 1 "$PROMPT_EVIDENCE_ATTEMPTS"); do
 done
 
 echo "prompt acceptance failed: no durable turn evidence appeared in session $SESSION" >&2
-echo "--- pane tail ---" >&2
-printf '%s\n' "$PANE_TEXT" | print_redacted_tail >&2
+echo "pane tail omitted from diagnostics to preserve public-safe boundaries" >&2
 exit 1


### PR DESCRIPTION
## Summary
- classify prompt-accepted owner exits without terminal output as recoverable failures instead of silent/normal completion
- preserve public-safe worktree-change evidence without dumping pane logs or raw transcript payloads
- add postmortem helpers/tests for terminal runtime-state matching, preexisting dirty worktrees, vanished monitor markers, and prompt evidence windows

## Verification
- `bun test packages/coding-agent/test/session-state-sidecar.test.ts scripts/gjc-session/create.test.ts`
- `bash -n scripts/gjc-session/create.sh scripts/gjc-session/prompt.sh scripts/gjc-session/postmortem.sh`
- `bun check`

Closes #1496

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*