### PR TITLE
fix(update): fsync downloaded binary before verify to fix NFS rollback

### DIFF
--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -552,31 +552,107 @@ async function updateViaNpm(packageName: string, expectedVersion: string): Promi
 }
 
 /**
- * Download a release binary to a target path, replacing an existing file.
+ * Flush a freshly written file's data to stable storage.
+ *
+ * Critical on network filesystems (e.g. NFS home directories): `pipeline`
+ * resolving does not guarantee the downloaded bytes are durable on the
+ * server, so the post-install `gjc --version` check can exec a binary whose
+ * pages are not yet consistent. The child then faults, the version check
+ * fails, and the update is rolled back with "could not verify updated
+ * version" even though the download itself succeeded. Explicitly fsyncing
+ * before the rename/exec avoids the race.
  */
-async function updateViaBinaryAt(targetPath: string, expectedVersion: string): Promise<void> {
-	const binaryName = getBinaryName();
-	const url = buildReleaseBinaryUrl(expectedVersion);
+async function fsyncFile(filePath: string): Promise<void> {
+	const handle = await fs.promises.open(filePath, "r+");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
 
-	const tempPath = `${targetPath}.new`;
-	const backupPath = `${targetPath}.bak`;
-	console.log(chalk.dim(`Downloading ${binaryName}…`));
+export async function fsyncFileForTest(filePath: string): Promise<void> {
+	return fsyncFile(filePath);
+}
 
+/**
+ * Download a release binary to a temp path, throwing a friendly error when the
+ * release asset cannot be fetched.
+ */
+async function downloadBinaryTo(url: string, tempPath: string, binaryName: string): Promise<void> {
 	const response = await fetch(url, { redirect: "follow" });
 	if (!response.ok || !response.body) {
 		throw new Error(formatBinaryDownloadFailureMessage(binaryName, url, response.statusText || response.status));
 	}
 	const fileStream = fs.createWriteStream(tempPath, { mode: 0o755 });
 	await pipeline(response.body, fileStream);
+}
 
-	console.log(chalk.dim("Installing update..."));
-	const verification = await replaceBinaryForUpdate({
+/** Injectable steps of the binary update flow (seams for testing ordering). */
+export interface BinaryUpdateFlow {
+	download(url: string, tempPath: string): Promise<void>;
+	fsync(filePath: string): Promise<void>;
+	replace(options: BinaryReplacementOptions): Promise<InstalledVersionVerification>;
+	verifyInstalledVersion(expectedVersion: string): Promise<InstalledVersionVerification>;
+	/** Best-effort cleanup of the temp file when the flow aborts before replace. */
+	removeTemp?(filePath: string): Promise<void>;
+	/** Called once fsync has succeeded, right before replacement begins. */
+	beforeReplace?(): void;
+}
+
+/**
+ * Orchestrate download → fsync → replace → verify with a strict ordering
+ * contract: the downloaded temp binary MUST be flushed to stable storage
+ * before it is published (renamed into place) or exec'd for verification.
+ *
+ * If fsync fails the temp bytes are not durable, so we abort before
+ * replacement/verification and clean up the temp file rather than installing a
+ * possibly-truncated binary.
+ */
+export async function runBinaryUpdateFlow(
+	targetPath: string,
+	url: string,
+	expectedVersion: string,
+	flow: BinaryUpdateFlow,
+): Promise<InstalledVersionVerification> {
+	const tempPath = `${targetPath}.new`;
+	const backupPath = `${targetPath}.bak`;
+
+	await flow.download(url, tempPath);
+	try {
+		await flow.fsync(tempPath);
+	} catch (err) {
+		if (flow.removeTemp) await flow.removeTemp(tempPath);
+		throw err;
+	}
+
+	flow.beforeReplace?.();
+	return flow.replace({
 		targetPath,
 		tempPath,
 		backupPath,
 		expectedVersion,
-		verifyInstalledVersion: verifyInstalledRuntime,
+		verifyInstalledVersion: flow.verifyInstalledVersion,
 	});
+}
+
+/**
+ * Download a release binary to a target path, replacing an existing file.
+ */
+async function updateViaBinaryAt(targetPath: string, expectedVersion: string): Promise<void> {
+	const binaryName = getBinaryName();
+	const url = buildReleaseBinaryUrl(expectedVersion);
+	console.log(chalk.dim(`Downloading ${binaryName}…`));
+
+	const verification = await runBinaryUpdateFlow(targetPath, url, expectedVersion, {
+		download: (downloadUrl, tempPath) => downloadBinaryTo(downloadUrl, tempPath, binaryName),
+		fsync: fsyncFile,
+		replace: replaceBinaryForUpdate,
+		verifyInstalledVersion: verifyInstalledRuntime,
+		removeTemp: unlinkIfExists,
+		beforeReplace: () => console.log(chalk.dim("Installing update...")),
+	});
+
 	printVerifiedVersion(expectedVersion);
 	if (verification.cleanupWarning) console.warn(chalk.yellow(verification.cleanupWarning));
 	printRestartGuidance();

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -3,14 +3,17 @@ import * as fsNode from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { BinaryUpdateFlow } from "../src/cli/update-cli";
 import {
 	buildReleaseBinaryUrlForTest,
 	formatBinaryDownloadFailureMessageForTest,
 	formatManualUpdateInstructionsForTest,
 	formatVerificationFailureForTest,
+	fsyncFileForTest,
 	replaceBinaryForUpdate,
 	resolveNpmManagedTargetForTest,
 	resolveUpdateMethodForTest,
+	runBinaryUpdateFlow,
 	runPackageManagerUpdateForTest,
 } from "../src/cli/update-cli";
 
@@ -303,5 +306,126 @@ describe("update-cli binary replacement", () => {
 		expect(await Bun.file(targetPath).text()).toBe("new binary");
 		expect(await Bun.file(tempPath).exists()).toBe(false);
 		expect(await Bun.file(backupPath).exists()).toBe(false);
+	});
+});
+
+describe("update-cli download durability", () => {
+	it("fsyncs a written file without altering its contents", async () => {
+		const dir = await makeTempDir();
+		const filePath = path.join(dir, "gjc.new");
+		await Bun.write(filePath, "downloaded binary bytes");
+
+		await fsyncFileForTest(filePath);
+
+		expect(await Bun.file(filePath).text()).toBe("downloaded binary bytes");
+	});
+
+	it("rejects when the target file does not exist", async () => {
+		const dir = await makeTempDir();
+		await expect(fsyncFileForTest(path.join(dir, "missing.new"))).rejects.toThrow();
+	});
+
+	it("closes the fsync file descriptor on success", async () => {
+		const close = vi.fn(async () => {});
+		const open = vi.spyOn(fsNode.promises, "open").mockResolvedValue({
+			sync: async () => {},
+			close,
+		} as unknown as Awaited<ReturnType<typeof fsNode.promises.open>>);
+		try {
+			await fsyncFileForTest("/irrelevant/path");
+			expect(close).toHaveBeenCalledTimes(1);
+		} finally {
+			open.mockRestore();
+		}
+	});
+
+	it("closes the fsync file descriptor even when sync fails", async () => {
+		const close = vi.fn(async () => {});
+		const open = vi.spyOn(fsNode.promises, "open").mockResolvedValue({
+			sync: async () => {
+				throw new Error("EIO: sync failed");
+			},
+			close,
+		} as unknown as Awaited<ReturnType<typeof fsNode.promises.open>>);
+		try {
+			await expect(fsyncFileForTest("/irrelevant/path")).rejects.toThrow("sync failed");
+			expect(close).toHaveBeenCalledTimes(1);
+		} finally {
+			open.mockRestore();
+		}
+	});
+});
+
+describe("update-cli binary update flow", () => {
+	it("downloads, fsyncs, then replaces and verifies in that order", async () => {
+		const calls: string[] = [];
+		const targetPath = "/opt/gjc/bin/gjc";
+		const flow: BinaryUpdateFlow = {
+			download: async (url, tempPath) => {
+				calls.push(`download ${url} -> ${tempPath}`);
+			},
+			fsync: async filePath => {
+				calls.push(`fsync ${filePath}`);
+			},
+			replace: async options => {
+				calls.push(`replace ${options.tempPath} -> ${options.targetPath}`);
+				return options.verifyInstalledVersion(options.expectedVersion);
+			},
+			verifyInstalledVersion: async expected => {
+				calls.push(`verify ${expected}`);
+				return { ok: true, actual: expected, path: targetPath };
+			},
+			removeTemp: async filePath => {
+				calls.push(`removeTemp ${filePath}`);
+			},
+			beforeReplace: () => {
+				calls.push("beforeReplace");
+			},
+		};
+
+		const result = await runBinaryUpdateFlow(targetPath, "https://example.test/gjc", "1.2.3", flow);
+
+		expect(result.ok).toBe(true);
+		expect(calls).toEqual([
+			`download https://example.test/gjc -> ${targetPath}.new`,
+			`fsync ${targetPath}.new`,
+			"beforeReplace",
+			`replace ${targetPath}.new -> ${targetPath}`,
+			"verify 1.2.3",
+		]);
+		expect(calls).not.toContain(`removeTemp ${targetPath}.new`);
+	});
+
+	it("aborts before replacement/verification when fsync fails", async () => {
+		const calls: string[] = [];
+		const targetPath = "/opt/gjc/bin/gjc";
+		const flow: BinaryUpdateFlow = {
+			download: async (_url, tempPath) => {
+				calls.push(`download ${tempPath}`);
+			},
+			fsync: async () => {
+				calls.push("fsync");
+				throw new Error("EIO: fsync failed");
+			},
+			replace: async () => {
+				calls.push("replace");
+				return { ok: true };
+			},
+			verifyInstalledVersion: async () => {
+				calls.push("verify");
+				return { ok: true };
+			},
+			removeTemp: async filePath => {
+				calls.push(`removeTemp ${filePath}`);
+			},
+		};
+
+		await expect(runBinaryUpdateFlow(targetPath, "https://example.test/gjc", "1.2.3", flow)).rejects.toThrow(
+			"fsync failed",
+		);
+
+		expect(calls).toEqual([`download ${targetPath}.new`, "fsync", `removeTemp ${targetPath}.new`]);
+		expect(calls).not.toContain("replace");
+		expect(calls).not.toContain("verify");
 	});
 });


### PR DESCRIPTION
Follow-up to #1712 (closed after review). Adds the flow-level ordering and
fsync-failure coverage the reviewer required.

## What

`gjc update` (binary install path) downloads the release asset with `fetch` + a
stream `pipeline`, renames it into place, then execs `gjc --version`
(`verifyInstalledRuntime` → `verifyInstalledVersion`) to confirm the install.

This PR fsyncs the downloaded temp file before that rename/exec, and refactors
`updateViaBinaryAt` into an injectable flow so the ordering contract is actually
tested.

## Why

On network filesystems (NFS home dirs are common on HPC/cluster login nodes),
`pipeline` resolving does **not** guarantee the written bytes are durable on the
server. The verification process then execs/mmaps a not-yet-consistent binary,
faults, `--version` yields no parseable version, and `replaceBinaryForUpdate`
rolls the update back with:

    Update failed: Error: could not verify updated version at <path>; restored previous gjc binary

Reproduced **deterministically** on an NFS `~/.local/bin`:

- The downloaded `v0.8.2` `gjc-linux-x64` asset runs fine standalone
  (`gjc/0.8.2`, `--smoke-test: ok`).
- `gjc update --force` fails every time with the message above.
- A manual `cp` + `sync` + atomic `mv` install of the same asset succeeds.

The only material difference between the failing updater and the working manual
install is an explicit flush to stable storage before the binary is exec'd.

## How

- New `fsyncFile(path)` helper: `open(path, "r+")` → `handle.sync()` →
  `close()` in a `try/finally` (fd closed on both success and failure).
- Extracted `runBinaryUpdateFlow(targetPath, url, version, flow)` with injectable
  steps `download → fsync → replace → verify`. The temp binary is fsynced
  **before** replacement/verification; if fsync fails the flow aborts before
  `replaceBinaryForUpdate` and removes the temp file rather than publishing or
  verifying unflushed bytes.
- `updateViaBinaryAt` now wires the real steps into that flow.

## Testing

Addresses the review requirements with flow-level coverage:

- **Ordering**: `runBinaryUpdateFlow` fsyncs the temp file *before* replace/verify
  begin (asserts exact call order `download → fsync → beforeReplace → replace →
  verify`). Fails if fsync is dropped or moved after replacement.
- **fsync failure**: an fsync error aborts before `replace`/`verify` run and
  removes the temp file (asserts `replace`/`verify` are never called).
- **fd safety**: the fsync fd is closed on both the success path and when
  `sync()` throws.
- Helper coverage: content preserved after fsync; missing file rejects.
- `bun test packages/coding-agent/test/update-cli.test.ts` → **26 pass / 0 fail**.
- Full `bun run check` passes (`check:ts` and `check:rs` both exit 0). The only
  remaining lint note is a pre-existing biome warning in
  `src/notifications/index.ts`, an unrelated file this PR does not touch.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)