### PR TITLE
Classify non-terminal gjc-session runtime exits

### DIFF
--- a/scripts/gjc-session/create.sh
+++ b/scripts/gjc-session/create.sh
@@ -144,42 +144,6 @@ for _ in $(seq 1 20); do
   [[ "$turn_evidence" == "true" ]] || break
   sleep 0.1
 done
-owner_exit_reason="normal_exit"
-owner_exit_severity="normal"
-runtime_terminal=false
-runtime_terminal_state=""
-runtime_terminal_source=""
-if [[ -s "${GJC_COORDINATOR_SESSION_STATE_FILE:-}" ]]; then
-  runtime_summary="$(python3 - "$GJC_COORDINATOR_SESSION_STATE_FILE" "$GJC_SESSION_NAME" "$GJC_SESSION_WORKDIR" <<'PY' 2>/dev/null || true
-import json
-import os
-import sys
-state_file, expected_session, expected_cwd = sys.argv[1:]
-try:
-    with open(state_file, encoding="utf-8") as handle:
-        data = json.load(handle)
-except Exception:
-    data = {}
-state = data.get("state")
-session_id = data.get("session_id")
-cwd = data.get("cwd") or data.get("workdir")
-source = (data.get("final_response") or {}).get("source")
-session_matches = not session_id or session_id == expected_session
-cwd_matches = not cwd or os.path.abspath(str(cwd)) == os.path.abspath(expected_cwd)
-if state in {"completed", "errored"} and session_matches and cwd_matches:
-    print("true")
-    print(state)
-    print(source or "runtime_state")
-else:
-    print("false")
-    print("")
-    print("")
-PY
-)"
-  runtime_terminal="$(printf '%s\n' "$runtime_summary" | sed -n '1p')"
-  runtime_terminal_state="$(printf '%s\n' "$runtime_summary" | sed -n '2p')"
-  runtime_terminal_source="$(printf '%s\n' "$runtime_summary" | sed -n '3p')"
-fi
 worktree_baseline_dirty="${GJC_SESSION_WORKTREE_BASELINE_DIRTY:-null}"
 if [[ "$prompt_accepted" == "true" && -s "${GJC_SESSION_PROMPT_ACCEPTED_JSON:-}" ]]; then
   prompt_baseline="$(python3 - "$GJC_SESSION_PROMPT_ACCEPTED_JSON" <<'PY' 2>/dev/null || true
@@ -202,30 +166,119 @@ worktree_changed_since_baseline=false
 if [[ "$worktree_baseline_dirty" == "false" && "$worktree_current_dirty" == "true" ]]; then
   worktree_changed_since_baseline=true
 fi
-if [[ "$runtime_terminal" == "true" ]]; then
-  owner_exit_reason="terminal_runtime_cleanup"
-  owner_exit_severity="normal"
-elif [[ "$turn_evidence" != "true" ]]; then
-  owner_exit_reason="owner_exited_before_turn_evidence"
-  owner_exit_severity="failure"
-elif [[ "$prompt_accepted" == "true" && "$worktree_changed_since_baseline" == "true" ]]; then
-  owner_exit_reason="accepted_prompt_observed_recoverable_worktree_changes"
-  owner_exit_severity="failure"
-elif [[ "$prompt_accepted" == "true" && "$worktree_current_dirty" == "true" ]]; then
-  owner_exit_reason="accepted_prompt_dirty_worktree_observed_without_new_change_proof"
-  owner_exit_severity="failure"
-elif [[ "$prompt_accepted" == "true" ]]; then
-  owner_exit_reason="accepted_prompt_no_useful_output"
-  owner_exit_severity="failure"
-elif [[ "$prompt_accepted" != "true" ]]; then
-  owner_exit_reason="owner_exited_before_prompt_acceptance"
-  owner_exit_severity="failure"
-fi
-python3 - "$GJC_SESSION_FINAL_JSON" "$GJC_SESSION_NAME" "$rc" "$started_at" "$finished_at" "$GJC_SESSION_PANE_LOG" "$GJC_COORDINATOR_SESSION_STATE_FILE" "$turn_evidence" "$prompt_accepted" "$owner_exit_reason" "$owner_exit_severity" "$runtime_terminal" "$runtime_terminal_state" "$runtime_terminal_source" "$worktree_baseline_dirty" "$worktree_current_dirty" "$worktree_changed_since_baseline" <<'PY'
+python3 - "$GJC_SESSION_FINAL_JSON" "$GJC_SESSION_NAME" "$rc" "$started_at" "$finished_at" "$GJC_SESSION_PANE_LOG" "$GJC_COORDINATOR_SESSION_STATE_FILE" "$turn_evidence" "$prompt_accepted" "$GJC_SESSION_WORKDIR" "$worktree_baseline_dirty" "$worktree_current_dirty" "$worktree_changed_since_baseline" <<'PY'
 import json
+import os
 import sys
 
-path, session, status, started_at, finished_at, pane_log, runtime_state, turn_evidence, prompt_accepted, owner_exit_reason, owner_exit_severity, runtime_terminal, runtime_terminal_state, runtime_terminal_source, baseline_dirty, current_dirty, changed_since_baseline = sys.argv[1:]
+(
+    path,
+    session,
+    status,
+    started_at,
+    finished_at,
+    pane_log,
+    runtime_state,
+    turn_evidence,
+    prompt_accepted,
+    expected_cwd,
+    baseline_dirty,
+    current_dirty,
+    changed_since_baseline,
+) = sys.argv[1:]
+
+turn_evidence_present = turn_evidence == "true"
+prompt_accepted_present = prompt_accepted == "true"
+
+runtime_summary = {
+    "present": False,
+    "valid": False,
+    "state": None,
+    "source": None,
+    "event": None,
+    "reason": None,
+    "terminal": False,
+    "terminalState": None,
+    "terminalSource": None,
+    "finalResponsePresent": False,
+    "previousRuntimeState": None,
+    "sessionMatches": True,
+    "cwdMatches": True,
+}
+if runtime_state and os.path.exists(runtime_state) and os.path.getsize(runtime_state) > 0:
+    runtime_summary["present"] = True
+    try:
+        with open(runtime_state, encoding="utf-8") as handle:
+            runtime_payload = json.load(handle)
+        final_response = runtime_payload.get("final_response")
+        final_response_present = False
+        final_response_source = None
+        if isinstance(final_response, dict):
+            text = final_response.get("text")
+            artifact_path = final_response.get("artifact_path")
+            final_response_present = (
+                (isinstance(text, str) and text.strip() != "")
+                or (isinstance(artifact_path, str) and artifact_path.strip() != "")
+            )
+            if isinstance(final_response.get("source"), str):
+                final_response_source = final_response["source"]
+        runtime_state_value = runtime_payload.get("state")
+        session_id = runtime_payload.get("session_id")
+        cwd = runtime_payload.get("cwd") or runtime_payload.get("workdir")
+        session_matches = not session_id or session_id == session
+        cwd_matches = not cwd or os.path.abspath(str(cwd)) == os.path.abspath(expected_cwd)
+        terminal = runtime_state_value in ("completed", "errored") and session_matches and cwd_matches
+        runtime_source = runtime_payload.get("source") if isinstance(runtime_payload.get("source"), str) else None
+        runtime_summary.update(
+            {
+                "valid": True,
+                "state": runtime_state_value if isinstance(runtime_state_value, str) else None,
+                "source": runtime_source,
+                "event": runtime_payload.get("event") if isinstance(runtime_payload.get("event"), str) else None,
+                "reason": runtime_payload.get("reason") if isinstance(runtime_payload.get("reason"), str) else None,
+                "terminal": terminal,
+                "terminalState": runtime_state_value if terminal and isinstance(runtime_state_value, str) else None,
+                "terminalSource": final_response_source or runtime_source or ("runtime_state" if terminal else None),
+                "finalResponsePresent": final_response_present,
+                "previousRuntimeState": runtime_payload.get("previous_runtime_state")
+                if isinstance(runtime_payload.get("previous_runtime_state"), str)
+                else None,
+                "sessionMatches": session_matches,
+                "cwdMatches": cwd_matches,
+            }
+        )
+    except Exception:
+        runtime_summary["valid"] = False
+
+owner_exit_reason = "normal_exit"
+owner_exit_severity = "normal"
+runtime_state_value = runtime_summary["state"]
+runtime_matches = runtime_summary["valid"] and runtime_summary["sessionMatches"] and runtime_summary["cwdMatches"]
+
+if runtime_summary["terminal"]:
+    owner_exit_reason = "terminal_runtime_cleanup"
+    owner_exit_severity = "normal"
+elif not turn_evidence_present:
+    owner_exit_reason = "owner_exited_before_turn_evidence"
+    owner_exit_severity = "failure"
+elif runtime_matches and runtime_state_value in ("running", "needs_user_input"):
+    owner_exit_reason = "owner_exited_after_runtime_acknowledgement_before_terminal_status"
+    owner_exit_severity = "failure"
+elif prompt_accepted_present and changed_since_baseline == "true":
+    owner_exit_reason = "accepted_prompt_observed_recoverable_worktree_changes"
+    owner_exit_severity = "failure"
+elif prompt_accepted_present and current_dirty == "true":
+    owner_exit_reason = "accepted_prompt_dirty_worktree_observed_without_new_change_proof"
+    owner_exit_severity = "failure"
+elif prompt_accepted_present:
+    owner_exit_reason = "accepted_prompt_no_useful_output"
+    owner_exit_severity = "failure"
+else:
+    owner_exit_reason = "owner_exited_before_prompt_acceptance"
+    owner_exit_severity = "failure"
+
+runtime_summary["ownerExitReason"] = owner_exit_reason
+runtime_summary["severity"] = owner_exit_severity
 with open(path, "w", encoding="utf-8") as handle:
     json.dump(
         {
@@ -235,16 +288,17 @@ with open(path, "w", encoding="utf-8") as handle:
             "finishedAt": finished_at,
             "paneLog": pane_log,
             "runtimeState": runtime_state,
-            "turnEvidencePresent": turn_evidence == "true",
-            "promptAccepted": prompt_accepted == "true",
+            "turnEvidencePresent": turn_evidence_present,
+            "promptAccepted": prompt_accepted_present,
             "ownerExitReason": owner_exit_reason,
             "severity": owner_exit_severity,
-            "runtimeTerminal": runtime_terminal == "true",
-            "runtimeTerminalState": runtime_terminal_state or None,
-            "runtimeTerminalSource": runtime_terminal_source or None,
+            "runtimeTerminal": runtime_summary["terminal"],
+            "runtimeTerminalState": runtime_summary["terminalState"],
+            "runtimeTerminalSource": runtime_summary["terminalSource"],
             "worktreeBaselineDirty": None if baseline_dirty == "null" else baseline_dirty == "true",
             "observedRecoverableWorktreeChanges": current_dirty == "true",
             "worktreeChangedSinceBaseline": changed_since_baseline == "true",
+            "runtimeStateSummary": runtime_summary,
         },
         handle,
         indent=2,

--- a/scripts/gjc-session/create.test.ts
+++ b/scripts/gjc-session/create.test.ts
@@ -288,6 +288,76 @@ exit 0
 		});
 	});
 
+	test("runner treats non-terminal runtime state as failed even without prompt marker", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-runtime-running-"));
+		tempRoots.push(root);
+		const session = `gjc_issue_1496_runtime_running_${process.pid}_${Date.now()}`;
+		tmuxSessions.push(session);
+		const worktree = await makeGitWorktree(root);
+		const stateDir = path.join(root, "state");
+		const fakeGjc = path.join(root, "bin", "gjc");
+		await makeExecutable(
+			fakeGjc,
+			`#!/usr/bin/env bash
+printf 'Gajae forge\\n> Type your message\\nWorking on accepted prompt\\n'
+python3 - <<'PY'
+import json
+import os
+
+with open(os.environ["GJC_COORDINATOR_SESSION_STATE_FILE"], "w", encoding="utf-8") as handle:
+    json.dump(
+        {
+            "schema_version": 1,
+            "session_id": os.environ["GJC_COORDINATOR_SESSION_ID"],
+            "state": "running",
+            "ready_for_input": False,
+            "source": "agent_session_event",
+            "event": "turn_start",
+            "reason": None,
+        },
+        handle,
+        indent=2,
+    )
+    handle.write("\\n")
+PY
+exit 0
+`,
+		);
+
+		const result = Bun.spawnSync(["bash", "scripts/gjc-session/create.sh", session, worktree], {
+			env: isolatedEnv({
+				GJC_BIN: fakeGjc,
+				GJC_SESSION_MONITOR_DISABLE: "1",
+				GJC_SESSION_SKIP_ROUTER: "1",
+				GJC_SESSION_STATE_DIR: stateDir,
+			}),
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).toBe(0);
+		await waitForFile(path.join(stateDir, "final.json"));
+		const finalStatus = (await Bun.file(path.join(stateDir, "final.json")).json()) as {
+			ownerExitReason: string;
+			promptAccepted: boolean;
+			runtimeStateSummary: { present: boolean; valid: boolean; state: string; terminal: boolean };
+			severity: string;
+			turnEvidencePresent: boolean;
+		};
+		expect(finalStatus).toMatchObject({
+			ownerExitReason: "owner_exited_after_runtime_acknowledgement_before_terminal_status",
+			promptAccepted: false,
+			severity: "failure",
+			turnEvidencePresent: true,
+			runtimeStateSummary: {
+				present: true,
+				valid: true,
+				state: "running",
+				terminal: false,
+			},
+		});
+	}, 20000);
+
 	test("external monitor records vanished tmux sessions and alerts the router", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-vanish-"));
 		tempRoots.push(root);


### PR DESCRIPTION
## Summary
- classify raw `gjc-session` owner exits with matching non-terminal `runtime-state.json` as durable failures before falling back to generic pre-prompt/no-output reasons
- include a public-safe `runtimeStateSummary` in `final.json` while preserving existing runtime-terminal and worktree-dirty fields
- add regression coverage for `running` runtime state without a prompt marker

## Verification
- `bash -n scripts/gjc-session/create.sh scripts/gjc-session/prompt.sh scripts/gjc-session/postmortem.sh`
- `bun test scripts/gjc-session/create.test.ts --timeout 30000 --test-name-pattern "runtime state|pre-acceptance pane evidence"` with a fake tmux shim because this workstation has no real `tmux`
- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/session-state-sidecar.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check scripts/gjc-session/create.test.ts --no-errors-on-unmatched`
- `git diff --check`

Refs #1496