### PR TITLE
feat(coding-agent): ultragoal aggregate validation batches (stacked on #1701)

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
@@ -41,6 +41,7 @@ For corrupt, tampered, unreadable, or stale current-session ralplan state, run `
 Ralplan is planning only. It may inspect context and draft plan/spec/proposal artifacts, but those remain `pending approval` until explicit current-turn or structured-UI execution approval. Before that approval, do not mutate product source, run mutation-oriented shell, commit, push, open PRs, invoke execution skills, or delegate implementation.
 
 Persist planning artifacts and handoffs through the ralplan CLI writer, never direct `.gjc/` edits:
+Direct `write`, `edit`, or `ast_edit` calls against `.gjc/_session-{sessionid}/specs`, `.gjc/_session-{sessionid}/plans`, `.gjc/_session-{sessionid}/state`, or any other `.gjc/` path are forbidden unless an explicit force override is active.
 
 ```bash
 gjc ralplan --write --stage <type> --stage_n <N> --artifact "markdown file path or markdown string"

--- a/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md
@@ -87,6 +87,17 @@ Durable completion is single-source: `goals.json` defines which goals exist and 
    - `gjc ultragoal create-goals --gjc-goal-mode per-story --brief "<brief>"` only when one GJC goal context per story is explicitly preferred
 3. Inspect `.gjc/_session-{sessionid}/ultragoal/goals.json` and refine if needed.
 
+### Create-goals granularity: merge validation-coupled stories
+
+Before splitting a brief into many thin stories, check whether the candidate stories are **validation-coupled**. Merge validation-coupled stories into one goal and fan out executor slices inside that goal instead of creating one goal per slice. Two stories are validation-coupled when they share any of:
+
+- the same feature stack (one story's code cannot be meaningfully verified without the other's),
+- the same acceptance surface,
+- the same red-team surface, or
+- the same final review boundary (they can only be signed off as a unit).
+
+Fanning out executor slices inside a single merged goal keeps one review/QA boundary while preserving parallel implementation. When validation-coupled stories must stay as separate goals for scheduling reasons, use an aggregate-mode **validation batch** (below) so the coupled review happens once at the final member.
+
 ## Complete goals
 
 Loop until `gjc ultragoal status` reports all goals complete:
@@ -229,6 +240,30 @@ Runtime-backed pipelining is deliberately narrow:
 
 Team remains explicit and separate: Team is not auto-launched, not a hidden pipeline scheduler, and never owns Ultragoal goals, checkpoints, or ledger state.
 
+## Validation batches (aggregate-only)
+
+Validation batches let several aggregate-mode goals that share one review/QA boundary defer their heavyweight architect + executor QA/red-team review to a single **final member**, while each non-final member still proves targeted verification and cleanup. Validation batches are **aggregate-only**, **explicit-only**, and **fail-closed**. They are created only through `--validation-batch-json`; there is no inference from brief prose and no per-story batching.
+
+Batches and #1701 pipeline metadata/overlap are **mutually exclusive**: `--validation-batch-json` and `--goal-metadata-json` cannot be combined, and a goal may not carry both `validationBatch` and eligible `pipelineMetadata`. There is no batch/pipeline mixing.
+
+Create a batch explicitly:
+
+```sh
+gjc ultragoal create-goals --brief-file <path> --validation-batch-json '[{"schemaVersion":1,"batchId":"VB001","memberIds":["G001","G002","G003"],"finalGoalId":"G003"}]'
+```
+
+Checkpoint contract:
+
+- **Non-final members** checkpoint `complete` with a single top-level `deferredToBatch` quality gate (kind `validation-batch-deferred`): targeted verification, ai-slop-cleaner pass, and a rerun iteration, plus a cumulative-since-base change set. A `deferredToBatch` gate must NOT contain `architectReview`, `executorQa`, or `validationBatchClose` — deferring never manufactures fake review approvals.
+- **The final member** (`finalGoalId`) checkpoints `complete` with the normal full strict gate PLUS a top-level `validationBatchClose` proof that covers all member IDs, member metadata hashes, member receipt/checkpoint-ledger-event IDs, per-member change-set hashes, and union change-set coverage. The final close only starts once every non-final member is already `complete` with a structurally fresh deferred receipt (out-of-order close is rejected).
+- Close state is append-only proof: it lives in the final member's checkpoint receipt and matching `goal_checkpointed` ledger row only. Never stamp `closedReceiptId`/`closedAt` or any close-state field onto member goals, and never append a separate close ledger event.
+- Change sets are cumulative-since-base: each member's `changeSet.paths` is the whole-worktree diff vs base (`cumulativeFromBase: true`), `memberGoalId` is a label not a per-path attribution, and `unionChangeSet.paths` carries no per-goal attribution.
+- Batch invalidation is fail-closed: steering mutations that would invalidate a batch are rejected while any member holds a fresh deferred receipt.
+
+### Intra-goal validation-lane parallelism
+
+Within a single goal (including a single-goal run or one validation-batch member), architect review and the executor QA/red-team lane MAY run in parallel, but only on the same **frozen post-cleaner change set**: run the ai-slop-cleaner to a zero-blocker pass and rerun verification first, then hand both lanes the identical frozen change-set summary. Parallel architect + executor QA/red-team lanes must **join before checkpoint** — neither lane may checkpoint independently. Fall back to **sequential** lanes when code is still changing, when the two lanes would see divergent snapshots, when the red-team lane depends on architect fixes, or when architect findings gate the QA scope.
+
 ## Use Ultragoal and Team together
 
 Use ultragoal and team together for a durable Ultragoal story that benefits from one visible tmux worker session. Ultragoal remains leader-owned: `.gjc/_session-{sessionid}/ultragoal/goals.json` stores the story plan and `.gjc/_session-{sessionid}/ultragoal/ledger.jsonl` stores checkpoints. Team is the single-worker tmux execution engine and returns task/evidence status to the leader.
@@ -336,6 +371,7 @@ Receipts are freshness-scoped:
 - Per-goal receipts remain fresh for their target goal unless that goal, its blocker metadata, or its supersession metadata changes.
 - Normal later `goal_started` or clean receipt-backed `goal_checkpointed` events for other goals do not stale older per-goal receipts.
 - Appending required goals or changing final required-goal state stales final aggregate receipts. Final aggregate completion requires a fresh final aggregate receipt proving no incomplete, blocked, or `review_blocked` required goals remain.
+- Deferred per-goal receipts (validation-batch members) are incomplete until a matching fresh batch-close receipt exists on the batch's `finalGoalId`; a story-scope query for a deferred member stays blocked until that close, and mutating a member after close stales the batch-close and final aggregate receipts.
 
 ## Handoff back to planning
 

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts
@@ -1,17 +1,15 @@
 import * as fs from "node:fs/promises";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
 import { resolveGjcSessionForRead, SessionResolutionError } from "./session-resolution";
+import { validateDeferredMemberReceiptFresh, validateReceiptFreshBase } from "./ultragoal-receipt-freshness";
 import {
-	computeUltragoalPlanGeneration,
 	getUltragoalPaths,
 	getUltragoalRunCompletionState,
-	hashStructuredValue,
 	readUltragoalLedger,
 	readUltragoalPlan,
 	recordUltragoalNudgeIfBudgetRemaining,
 	resolveUltragoalNudgeBudget,
 	selectUltragoalNudgeTarget,
-	type UltragoalCompletionVerification,
 	type UltragoalGoal,
 	type UltragoalLedgerEvent,
 	type UltragoalNudgeSurface,
@@ -176,26 +174,6 @@ function findReceiptGoal(
 	return storyGoal ? { goal: storyGoal, receiptKind: "per-goal" } : null;
 }
 
-function findLedgerReceiptEvent(
-	ledger: readonly UltragoalLedgerEvent[],
-	receipt: UltragoalCompletionVerification,
-): UltragoalLedgerEvent | null {
-	return (
-		ledger.find(event => {
-			if (event.eventId !== receipt.checkpointLedgerEventId) return false;
-			if (event.event !== "goal_checkpointed") return false;
-			if (event.goalId !== receipt.goalId) return false;
-			const eventReceipt = event.completionVerification as UltragoalCompletionVerification | undefined;
-			return (
-				event.status === "complete" &&
-				eventReceipt?.receiptId === receipt.receiptId &&
-				eventReceipt.receiptKind === receipt.receiptKind &&
-				eventReceipt.planGeneration === receipt.planGeneration
-			);
-		}) ?? null
-	);
-}
-
 export function validateCompletionReceipt(input: {
 	plan: UltragoalPlan;
 	ledger: readonly UltragoalLedgerEvent[];
@@ -210,55 +188,66 @@ export function validateCompletionReceipt(input: {
 			goalId: input.goal.id,
 		};
 	}
-	if (
-		receipt.schemaVersion !== 1 ||
-		receipt.goalId !== input.goal.id ||
-		receipt.receiptKind !== input.receiptKind ||
-		!receipt.planGeneration ||
-		!receipt.checkpointLedgerEventId
-	) {
-		return {
-			state: "active_stale_receipt",
-			message: `Ultragoal ${input.goal.id} receipt is malformed or stale.`,
-			goalId: input.goal.id,
-		};
+	if (receipt.validationBatch?.role === "deferred-member") {
+		return validateDeferredMemberReceiptFresh({
+			plan: input.plan,
+			ledger: input.ledger,
+			goal: input.goal,
+			receipt,
+			receiptKind: input.receiptKind,
+			requireClose: true,
+		});
 	}
-	const event = findLedgerReceiptEvent(input.ledger, receipt);
-	if (!event) {
-		return {
-			state: "active_stale_receipt",
-			message: `Ultragoal ${input.goal.id} receipt ledger event is missing.`,
-			goalId: input.goal.id,
-		};
-	}
-	const generation = computeUltragoalPlanGeneration({
+	const baseDiagnostic = validateReceiptFreshBase({
 		plan: input.plan,
 		ledger: input.ledger,
 		goal: input.goal,
+		receipt,
 		receiptKind: input.receiptKind,
-		beforeStatus: receipt.goalStatusBeforeCheckpoint,
-		excludeEventId: receipt.checkpointLedgerEventId,
 	});
-	if (generation.planGeneration !== receipt.planGeneration) {
-		return {
-			state: "active_stale_receipt",
-			message: `Ultragoal ${input.goal.id} receipt generation is stale.`,
-			goalId: input.goal.id,
-		};
-	}
-	if (hashStructuredValue(event.qualityGateJson) !== receipt.qualityGateHash) {
-		return {
-			state: "active_dirty_quality_gate",
-			message: `Ultragoal ${input.goal.id} receipt quality-gate hash does not match ledger.`,
-			goalId: input.goal.id,
-		};
-	}
-	if (input.goal.updatedAt !== receipt.verifiedAt) {
-		return {
-			state: "active_stale_receipt",
-			message: `Ultragoal ${input.goal.id} receipt target changed after verification.`,
-			goalId: input.goal.id,
-		};
+	if (baseDiagnostic) return baseDiagnostic;
+	if (receipt.validationBatch?.role === "batch-close") {
+		for (const memberId of receipt.validationBatch.memberIds) {
+			const member = input.plan.goals.find(goal => goal.id === memberId);
+			if (
+				!member?.validationBatch ||
+				member.validationBatch.metadataHash !== receipt.validationBatch.memberMetadataHashes[memberId]
+			) {
+				return {
+					state: "active_stale_receipt",
+					message: `Ultragoal ${input.goal.id} batch-close receipt has stale member metadata for ${memberId}.`,
+					goalId: input.goal.id,
+				};
+			}
+			if (memberId === receipt.validationBatch.finalGoalId) continue;
+			const memberReceipt = member.completionVerification;
+			if (memberReceipt?.validationBatch?.role !== "deferred-member") {
+				return {
+					state: "active_missing_final_receipt",
+					message: `Ultragoal ${input.goal.id} batch-close receipt requires deferred member receipt for ${memberId}.`,
+					goalId: input.goal.id,
+				};
+			}
+			const memberDiagnostic = validateDeferredMemberReceiptFresh({
+				plan: input.plan,
+				ledger: input.ledger,
+				goal: member,
+				receipt: memberReceipt,
+				receiptKind: "per-goal",
+				requireClose: false,
+			});
+			if (memberDiagnostic.state !== "active_verified_complete") return memberDiagnostic;
+			if (
+				receipt.validationBatch.memberReceiptIds[memberId] !== memberReceipt.receiptId ||
+				receipt.validationBatch.memberChangeSetHashes[memberId] !== memberReceipt.validationBatch.changeSetHash
+			) {
+				return {
+					state: "active_stale_receipt",
+					message: `Ultragoal ${input.goal.id} batch-close receipt is stale for deferred member ${memberId}.`,
+					goalId: input.goal.id,
+				};
+			}
+		}
 	}
 	if (input.receiptKind === "final-aggregate") {
 		const incomplete = requiredGoals(input.plan).filter(goal => goal.status !== "complete");

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts
@@ -1,0 +1,315 @@
+import * as crypto from "node:crypto";
+import type {
+	UltragoalCompletionVerification,
+	UltragoalGoal,
+	UltragoalGoalStatus,
+	UltragoalLedgerEvent,
+	UltragoalPlan,
+	UltragoalReceiptKind,
+} from "./ultragoal-runtime";
+
+export type UltragoalReceiptFreshnessDiagnostic = {
+	state:
+		| "inactive"
+		| "unrelated_goal"
+		| "active_verified_complete"
+		| "active_missing_receipt"
+		| "active_stale_receipt"
+		| "active_missing_final_receipt"
+		| "active_dirty_quality_gate"
+		| "active_review_blocked_unrecorded"
+		| "active_review_blocked_recorded"
+		| "unreadable_fail_closed";
+	message: string;
+	goalId?: string;
+};
+function stableStructuredValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(item => stableStructuredValue(item));
+	if (typeof value !== "object" || value === null) return value;
+	const record = value as Record<string, unknown>;
+	const sorted: Record<string, unknown> = {};
+	for (const key of Object.keys(record).sort()) {
+		const item = record[key];
+		if (item !== undefined) sorted[key] = stableStructuredValue(item);
+	}
+	return sorted;
+}
+
+function hashStructuredValue(value: unknown): string {
+	return crypto
+		.createHash("sha256")
+		.update(JSON.stringify(stableStructuredValue(value)))
+		.digest("hex");
+}
+
+export function requiredUltragoalGoals(plan: UltragoalPlan): UltragoalGoal[] {
+	return plan.goals.filter(goal => goal.status !== "superseded");
+}
+
+export function receiptRelevantGoals(
+	plan: UltragoalPlan,
+	goal: UltragoalGoal,
+	receiptKind: UltragoalReceiptKind,
+): UltragoalGoal[] {
+	if (goal.validationBatch?.finalGoalId === goal.id) {
+		return goal.validationBatch.memberIds.map(memberId => {
+			const member = plan.goals.find(item => item.id === memberId);
+			if (!member)
+				throw new Error(`validation batch ${goal.validationBatch?.batchId} references missing goal ${memberId}`);
+			return member;
+		});
+	}
+	return receiptKind === "final-aggregate" ? requiredUltragoalGoals(plan) : [goal];
+}
+
+function ledgerEventId(event: UltragoalLedgerEvent): string | null {
+	return typeof event.eventId === "string" && event.eventId.trim().length > 0 ? event.eventId : null;
+}
+
+function isReceiptFreshnessBookkeepingEvent(event: UltragoalLedgerEvent): boolean {
+	return event.event === "nudge";
+}
+
+function latestRelevantLedgerEventId(
+	ledger: readonly UltragoalLedgerEvent[],
+	relevantGoalIds: readonly string[],
+	excludeEventId?: string,
+): string | null {
+	const relevant = new Set(relevantGoalIds);
+	for (const event of [...ledger].reverse()) {
+		const eventId = ledgerEventId(event);
+		if (eventId && eventId === excludeEventId) continue;
+		if (isReceiptFreshnessBookkeepingEvent(event)) continue;
+		const goalId = typeof event.goalId === "string" ? event.goalId.trim() : "";
+		if (goalId && relevant.has(goalId)) return eventId;
+	}
+	return null;
+}
+
+function planSnapshotForReceipt(input: {
+	plan: UltragoalPlan;
+	goal: UltragoalGoal;
+	beforeStatus: UltragoalGoalStatus;
+	targetGoalUpdatedAt: string;
+	receiptKind: UltragoalReceiptKind;
+}): unknown {
+	const targetGoalSnapshot = {
+		...input.goal,
+		status: input.beforeStatus,
+		updatedAt: input.targetGoalUpdatedAt,
+		evidence: undefined,
+		completedAt: undefined,
+		completionVerification: undefined,
+	};
+	const goals =
+		input.receiptKind === "final-aggregate"
+			? input.plan.goals.map(goal => ({
+					...goal,
+					status: goal.id === input.goal.id ? input.beforeStatus : goal.status,
+					updatedAt: goal.id === input.goal.id ? input.targetGoalUpdatedAt : goal.updatedAt,
+					evidence: goal.id === input.goal.id ? undefined : goal.evidence,
+					completedAt: goal.id === input.goal.id ? undefined : goal.completedAt,
+					completionVerification: undefined,
+				}))
+			: [targetGoalSnapshot];
+	return {
+		version: input.plan.version,
+		brief: input.plan.brief,
+		gjcGoalMode: input.plan.gjcGoalMode,
+		gjcObjective: input.plan.gjcObjective,
+		gjcObjectiveAliases: input.plan.gjcObjectiveAliases,
+		createdAt: input.plan.createdAt,
+		goals,
+	};
+}
+
+export function computeUltragoalPlanGeneration(input: {
+	plan: UltragoalPlan;
+	ledger: readonly UltragoalLedgerEvent[];
+	goal: UltragoalGoal;
+	receiptKind: UltragoalReceiptKind;
+	beforeStatus: UltragoalGoalStatus;
+	excludeEventId?: string;
+	targetGoalUpdatedAt?: string;
+}): {
+	planGeneration: string;
+	basis: UltragoalCompletionVerification["basis"];
+} {
+	const relevantGoals = receiptRelevantGoals(input.plan, input.goal, input.receiptKind);
+	const relevantGoalIds = relevantGoals.map(goal => goal.id);
+	const targetGoalUpdatedAt = input.targetGoalUpdatedAt ?? input.goal.updatedAt;
+	const planHashBeforeCheckpoint = hashStructuredValue(
+		planSnapshotForReceipt({
+			plan: input.plan,
+			goal: input.goal,
+			beforeStatus: input.beforeStatus,
+			targetGoalUpdatedAt,
+			receiptKind: input.receiptKind,
+		}),
+	);
+	const requiredGoalSetHashBeforeCheckpoint = hashStructuredValue(
+		relevantGoals.map(goal => ({
+			id: goal.id,
+			status: goal.id === input.goal.id ? input.beforeStatus : goal.status,
+			updatedAt: goal.id === input.goal.id ? targetGoalUpdatedAt : goal.updatedAt,
+		})),
+	);
+	const basis: UltragoalCompletionVerification["basis"] = {
+		planHashBeforeCheckpoint,
+		latestRelevantLedgerEventIdBeforeCheckpoint: latestRelevantLedgerEventId(
+			input.ledger,
+			relevantGoalIds,
+			input.excludeEventId,
+		),
+		goalUpdatedAtBeforeCheckpoint: targetGoalUpdatedAt,
+		relevantGoalIdsBeforeCheckpoint: relevantGoalIds,
+		requiredGoalSetHashBeforeCheckpoint,
+	};
+	return { planGeneration: hashStructuredValue(basis), basis };
+}
+
+export function findLedgerReceiptEvent(
+	ledger: readonly UltragoalLedgerEvent[],
+	receipt: UltragoalCompletionVerification,
+): UltragoalLedgerEvent | null {
+	return (
+		ledger.find(event => {
+			if (event.eventId !== receipt.checkpointLedgerEventId) return false;
+			if (event.event !== "goal_checkpointed") return false;
+			if (event.goalId !== receipt.goalId) return false;
+			const eventReceipt = event.completionVerification as UltragoalCompletionVerification | undefined;
+			return (
+				event.status === "complete" &&
+				eventReceipt?.receiptId === receipt.receiptId &&
+				eventReceipt.receiptKind === receipt.receiptKind &&
+				eventReceipt.planGeneration === receipt.planGeneration
+			);
+		}) ?? null
+	);
+}
+
+export function validateReceiptFreshBase(input: {
+	plan: UltragoalPlan;
+	ledger: readonly UltragoalLedgerEvent[];
+	goal: UltragoalGoal;
+	receipt: UltragoalCompletionVerification;
+	receiptKind: UltragoalReceiptKind;
+}): UltragoalReceiptFreshnessDiagnostic | null {
+	if (
+		input.receipt.schemaVersion !== 1 ||
+		input.receipt.goalId !== input.goal.id ||
+		input.receipt.receiptKind !== input.receiptKind ||
+		!input.receipt.planGeneration ||
+		!input.receipt.checkpointLedgerEventId
+	) {
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} receipt is malformed or stale.`,
+			goalId: input.goal.id,
+		};
+	}
+	const event = findLedgerReceiptEvent(input.ledger, input.receipt);
+	if (!event)
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} receipt ledger event is missing.`,
+			goalId: input.goal.id,
+		};
+	const generation = computeUltragoalPlanGeneration({
+		plan: input.plan,
+		ledger: input.ledger,
+		goal: input.goal,
+		receiptKind: input.receiptKind,
+		beforeStatus: input.receipt.goalStatusBeforeCheckpoint,
+		excludeEventId: input.receipt.checkpointLedgerEventId,
+	});
+	if (generation.planGeneration !== input.receipt.planGeneration)
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} receipt generation is stale.`,
+			goalId: input.goal.id,
+		};
+	if (hashStructuredValue(event.qualityGateJson) !== input.receipt.qualityGateHash)
+		return {
+			state: "active_dirty_quality_gate",
+			message: `Ultragoal ${input.goal.id} receipt quality-gate hash does not match ledger.`,
+			goalId: input.goal.id,
+		};
+	if (input.goal.updatedAt !== input.receipt.verifiedAt)
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} receipt target changed after verification.`,
+			goalId: input.goal.id,
+		};
+	return null;
+}
+
+export function findFreshBatchCloseReceipt(input: {
+	plan: UltragoalPlan;
+	ledger: readonly UltragoalLedgerEvent[];
+	deferredGoal: UltragoalGoal;
+	deferredReceipt: UltragoalCompletionVerification;
+}): UltragoalCompletionVerification | null {
+	const batch = input.deferredReceipt.validationBatch;
+	if (batch?.role !== "deferred-member") return null;
+	const finalGoal = input.plan.goals.find(goal => goal.id === batch.finalGoalId);
+	const finalReceipt = finalGoal?.completionVerification;
+	if (!finalGoal || finalReceipt?.validationBatch?.role !== "batch-close") return null;
+	if (
+		finalReceipt.validationBatch.batchId !== batch.batchId ||
+		finalReceipt.validationBatch.memberReceiptIds[input.deferredGoal.id] !== input.deferredReceipt.receiptId
+	)
+		return null;
+	const diagnostic = validateReceiptFreshBase({
+		plan: input.plan,
+		ledger: input.ledger,
+		goal: finalGoal,
+		receipt: finalReceipt,
+		receiptKind: finalReceipt.receiptKind,
+	});
+	return diagnostic ? null : finalReceipt;
+}
+
+export function validateDeferredMemberReceiptFresh(input: {
+	plan: UltragoalPlan;
+	ledger: readonly UltragoalLedgerEvent[];
+	goal: UltragoalGoal;
+	receipt: UltragoalCompletionVerification;
+	receiptKind: UltragoalReceiptKind;
+	requireClose: boolean;
+}): UltragoalReceiptFreshnessDiagnostic {
+	const batch = input.receipt.validationBatch;
+	if (
+		batch?.role !== "deferred-member" ||
+		input.goal.validationBatch?.metadataHash !== batch.metadataHash ||
+		input.goal.validationBatch.batchId !== batch.batchId
+	) {
+		return {
+			state: "active_stale_receipt",
+			message: `Ultragoal ${input.goal.id} deferred receipt is malformed or stale.`,
+			goalId: input.goal.id,
+		};
+	}
+	const base = validateReceiptFreshBase(input);
+	if (base) return base;
+	if (
+		input.requireClose &&
+		!findFreshBatchCloseReceipt({
+			plan: input.plan,
+			ledger: input.ledger,
+			deferredGoal: input.goal,
+			deferredReceipt: input.receipt,
+		})
+	) {
+		return {
+			state: "active_missing_final_receipt",
+			message: `Ultragoal ${input.goal.id} is deferred to validation batch ${batch.batchId} until final goal ${batch.finalGoalId} closes the batch`,
+			goalId: input.goal.id,
+		};
+	}
+	return {
+		state: "active_verified_complete",
+		message: `Ultragoal ${input.goal.id} has a fresh deferred validation batch receipt.`,
+		goalId: input.goal.id,
+	};
+}

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -3410,11 +3410,13 @@ function requireChangeSetCoverage(
 	fieldName: string,
 ): void {
 	if (!expected) return;
-	const declaredKeys = new Set(declared.map(row => `${row.oldPath ?? ""}\u0000${row.path}\u0000${row.status}`));
+	const declaredExactKeys = new Set(declared.map(row => `${row.oldPath ?? ""}\u0000${row.path}\u0000${row.status}`));
+	const declaredPathKeys = new Set(declared.map(row => `${row.oldPath ?? ""}\u0000${row.path}`));
 	for (const row of expected.paths) {
-		const key = `${row.oldPath ?? ""}\u0000${row.path}\u0000${row.status}`;
-		if (!declaredKeys.has(key))
-			throw new Error(`${fieldName} does not cover computed checkpoint change-set path ${row.path}`);
+		const pathKey = `${row.oldPath ?? ""}\u0000${row.path}`;
+		const exactKey = `${pathKey}\u0000${row.status}`;
+		const covered = row.status === "unknown" ? declaredPathKeys.has(pathKey) : declaredExactKeys.has(exactKey);
+		if (!covered) throw new Error(`${fieldName} does not cover computed checkpoint change-set path ${row.path}`);
 	}
 }
 
@@ -4487,6 +4489,20 @@ function parseGitNameStatus(output: string): UltragoalChangeSetPath[] {
 	return rows;
 }
 
+function ciDevChangedPathRows(): UltragoalChangeSetPath[] {
+	const raw = process.env.CI_DEV_CHANGED_PATHS;
+	if (!raw) return [];
+	return raw
+		.split(/\r?\n/)
+		.map(row => row.trim())
+		.filter(Boolean)
+		.map(pathValue => ({
+			path: normalizeRepoPath(pathValue),
+			status: "unknown" as UltragoalChangeStatus,
+			category: categorizeComputerChangePath(pathValue),
+		}));
+}
+
 function mergeChangeSetPaths(groups: UltragoalChangeSetPath[][]): UltragoalChangeSetPath[] {
 	const byKey = new Map<string, UltragoalChangeSetPath>();
 	for (const row of groups.flat()) byKey.set(`${row.oldPath ?? ""}\u0000${row.path}`, row);
@@ -4494,8 +4510,12 @@ function mergeChangeSetPaths(groups: UltragoalChangeSetPath[][]): UltragoalChang
 }
 
 async function computeCheckpointChangeSet(cwd: string): Promise<UltragoalChangeSet | undefined> {
+	const ciChangedPaths = ciDevChangedPathRows();
 	const inGit = await spawnText(["git", "rev-parse", "--is-inside-work-tree"], { cwd, timeoutMs: 3000 });
-	if (!inGit.ok || inGit.stdout.trim() !== "true") return undefined;
+	if (!inGit.ok || inGit.stdout.trim() !== "true") {
+		if (ciChangedPaths.length === 0) return undefined;
+		return { source: "checkpoint-git", paths: ciChangedPaths, trusted: true };
+	}
 	const baseRef = await resolveGitBase(cwd);
 	const base = baseRef;
 	const mergeBase = await spawnText(["git", "merge-base", "HEAD", baseRef], { cwd, timeoutMs: 3000 });
@@ -4508,17 +4528,19 @@ async function computeCheckpointChangeSet(cwd: string): Promise<UltragoalChangeS
 		spawnText(["git", "diff"], { cwd, timeoutMs: 5000 }),
 		spawnText(["git", "diff", "--cached"], { cwd, timeoutMs: 5000 }),
 	]);
-	if (!committed.ok && !unstaged.ok && !staged.ok) return undefined;
+	if (!committed.ok && !unstaged.ok && !staged.ok && ciChangedPaths.length === 0) return undefined;
+	const gitPaths = mergeChangeSetPaths([
+		parseGitNameStatus(committed.stdout),
+		parseGitNameStatus(unstaged.stdout),
+		parseGitNameStatus(staged.stdout),
+	]);
+	const paths = gitPaths.length > 0 ? gitPaths : ciChangedPaths;
 	return {
 		source: "checkpoint-git",
 		baseRef,
 		mergeBase: mergeBase.ok && mergeBase.stdout.trim() ? mergeBase.stdout.trim() : undefined,
 		headRef: "HEAD",
-		paths: mergeChangeSetPaths([
-			parseGitNameStatus(committed.stdout),
-			parseGitNameStatus(unstaged.stdout),
-			parseGitNameStatus(staged.stdout),
-		]),
+		paths,
 		rawDiffStat: stat.stdout,
 		rawDiff: [committedDiff.stdout, unstagedDiff.stdout, stagedDiff.stdout].filter(Boolean).join("\n"),
 		trusted: true,

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -6,6 +6,16 @@ import type { WorkflowHudSummary } from "../skill-state/active-state";
 import { buildUltragoalHudSummary as buildWorkflowUltragoalHudSummary } from "../skill-state/workflow-hud";
 import { renderCliWriteReceipt } from "./cli-write-receipt";
 import { DEFAULT_ULTRAGOAL_OBJECTIVE } from "./goal-mode-request";
+import {
+	computeUltragoalPlanGeneration,
+	findFreshBatchCloseReceipt,
+	requiredUltragoalGoals,
+	validateDeferredMemberReceiptFresh,
+	validateReceiptFreshBase,
+} from "./ultragoal-receipt-freshness";
+
+export { computeUltragoalPlanGeneration, receiptRelevantGoals } from "./ultragoal-receipt-freshness";
+
 import { gjcRoot, sessionUltragoalDir } from "./session-layout";
 import { resolveGjcSessionForRead, resolveGjcSessionForWrite, writeSessionActivityMarker } from "./session-resolution";
 import { renderUltragoalStatusMarkdown } from "./state-renderer";
@@ -69,6 +79,22 @@ export interface UltragoalGoalMetadataInput {
 	targets?: Partial<UltragoalPipelineTargets>;
 }
 
+export interface UltragoalValidationBatchMetadata extends JsonObject {
+	schemaVersion: 1;
+	batchId: string;
+	memberIds: string[];
+	finalGoalId: string;
+	mode: "aggregate-only";
+	metadataHash: string;
+}
+
+export interface UltragoalValidationBatchInput {
+	schemaVersion: 1;
+	batchId: string;
+	memberIds: string[];
+	finalGoalId: string;
+}
+
 export interface UltragoalPipelineOverlapHandles extends JsonObject {
 	review: JsonObject;
 	qa: JsonObject;
@@ -115,6 +141,7 @@ export interface UltragoalGoal {
 	steering?: Record<string, unknown>;
 	completionVerification?: UltragoalCompletionVerification;
 	pipelineMetadata?: UltragoalPipelineMetadata;
+	validationBatch?: UltragoalValidationBatchMetadata;
 }
 
 export interface UltragoalPlan {
@@ -150,7 +177,36 @@ export interface UltragoalCompletionVerification {
 		requiredGoalSetHashBeforeCheckpoint: string;
 	};
 	checkpointLedgerEventId: string;
+	validationBatch?:
+		| {
+				schemaVersion: 1;
+				role: "deferred-member";
+				batchId: string;
+				memberIds: string[];
+				finalGoalId: string;
+				metadataHash: string;
+				changeSetHash: string;
+		  }
+		| {
+				schemaVersion: 1;
+				role: "batch-close";
+				batchId: string;
+				memberIds: string[];
+				finalGoalId: string;
+				memberMetadataHashes: Record<string, string>;
+				memberReceiptIds: Record<string, string>;
+				memberCheckpointLedgerEventIds: Record<string, string>;
+				memberChangeSetHashes: Record<string, string>;
+				unionHash: string;
+		  };
 }
+
+type UltragoalDeferredCompletionVerification = UltragoalCompletionVerification & {
+	validationBatch: Extract<
+		NonNullable<UltragoalCompletionVerification["validationBatch"]>,
+		{ role: "deferred-member" }
+	>;
+};
 
 export interface UltragoalLedgerEvent extends JsonObject {
 	eventId?: string;
@@ -509,124 +565,6 @@ async function writePlan(cwd: string, plan: UltragoalPlan, sessionId?: string | 
 	await writeSessionActivityMarker(cwd, resolvedSessionId, { writer: "ultragoal-runtime", path: paths.goalsPath });
 }
 
-function requiredUltragoalGoals(plan: UltragoalPlan): UltragoalGoal[] {
-	return plan.goals.filter(goal => goal.status !== "superseded");
-}
-
-function receiptRelevantGoals(
-	plan: UltragoalPlan,
-	goal: UltragoalGoal,
-	receiptKind: UltragoalReceiptKind,
-): UltragoalGoal[] {
-	return receiptKind === "final-aggregate" ? requiredUltragoalGoals(plan) : [goal];
-}
-
-function ledgerEventId(event: UltragoalLedgerEvent): string | null {
-	return typeof event.eventId === "string" && event.eventId.trim().length > 0 ? event.eventId : null;
-}
-
-function isReceiptFreshnessBookkeepingEvent(event: UltragoalLedgerEvent): boolean {
-	return event.event === "nudge";
-}
-
-function latestRelevantLedgerEventId(
-	ledger: readonly UltragoalLedgerEvent[],
-	relevantGoalIds: readonly string[],
-	excludeEventId?: string,
-): string | null {
-	const relevant = new Set(relevantGoalIds);
-	for (const event of [...ledger].reverse()) {
-		const eventId = ledgerEventId(event);
-		if (eventId && eventId === excludeEventId) continue;
-		if (isReceiptFreshnessBookkeepingEvent(event)) continue;
-		const goalId = typeof event.goalId === "string" ? event.goalId.trim() : "";
-		if (goalId && relevant.has(goalId)) return eventId;
-	}
-	return null;
-}
-
-function planSnapshotForReceipt(input: {
-	plan: UltragoalPlan;
-	goal: UltragoalGoal;
-	beforeStatus: UltragoalGoalStatus;
-	targetGoalUpdatedAt: string;
-	receiptKind: UltragoalReceiptKind;
-}): unknown {
-	const targetGoalSnapshot = {
-		...input.goal,
-		status: input.beforeStatus,
-		updatedAt: input.targetGoalUpdatedAt,
-		evidence: undefined,
-		completedAt: undefined,
-		completionVerification: undefined,
-	};
-	const goals =
-		input.receiptKind === "final-aggregate"
-			? input.plan.goals.map(goal => ({
-					...goal,
-					status: goal.id === input.goal.id ? input.beforeStatus : goal.status,
-					updatedAt: goal.id === input.goal.id ? input.targetGoalUpdatedAt : goal.updatedAt,
-					evidence: goal.id === input.goal.id ? undefined : goal.evidence,
-					completedAt: goal.id === input.goal.id ? undefined : goal.completedAt,
-					completionVerification: undefined,
-				}))
-			: [targetGoalSnapshot];
-	return {
-		version: input.plan.version,
-		brief: input.plan.brief,
-		gjcGoalMode: input.plan.gjcGoalMode,
-		gjcObjective: input.plan.gjcObjective,
-		gjcObjectiveAliases: input.plan.gjcObjectiveAliases,
-		createdAt: input.plan.createdAt,
-		goals,
-	};
-}
-
-export function computeUltragoalPlanGeneration(input: {
-	plan: UltragoalPlan;
-	ledger: readonly UltragoalLedgerEvent[];
-	goal: UltragoalGoal;
-	receiptKind: UltragoalReceiptKind;
-	beforeStatus: UltragoalGoalStatus;
-	excludeEventId?: string;
-	targetGoalUpdatedAt?: string;
-}): {
-	planGeneration: string;
-	basis: UltragoalCompletionVerification["basis"];
-} {
-	const relevantGoals = receiptRelevantGoals(input.plan, input.goal, input.receiptKind);
-	const relevantGoalIds = relevantGoals.map(goal => goal.id);
-	const targetGoalUpdatedAt = input.targetGoalUpdatedAt ?? input.goal.updatedAt;
-	const planHashBeforeCheckpoint = hashStructuredValue(
-		planSnapshotForReceipt({
-			plan: input.plan,
-			goal: input.goal,
-			beforeStatus: input.beforeStatus,
-			targetGoalUpdatedAt,
-			receiptKind: input.receiptKind,
-		}),
-	);
-	const requiredGoalSetHashBeforeCheckpoint = hashStructuredValue(
-		relevantGoals.map(goal => ({
-			id: goal.id,
-			status: goal.id === input.goal.id ? input.beforeStatus : goal.status,
-			updatedAt: goal.id === input.goal.id ? targetGoalUpdatedAt : goal.updatedAt,
-		})),
-	);
-	const basis: UltragoalCompletionVerification["basis"] = {
-		planHashBeforeCheckpoint,
-		latestRelevantLedgerEventIdBeforeCheckpoint: latestRelevantLedgerEventId(
-			input.ledger,
-			relevantGoalIds,
-			input.excludeEventId,
-		),
-		goalUpdatedAtBeforeCheckpoint: targetGoalUpdatedAt,
-		relevantGoalIdsBeforeCheckpoint: relevantGoalIds,
-		requiredGoalSetHashBeforeCheckpoint,
-	};
-	return { planGeneration: hashStructuredValue(basis), basis };
-}
-
 function chooseReceiptKind(
 	plan: UltragoalPlan,
 	goal: UltragoalGoal,
@@ -659,6 +597,54 @@ function buildCompletionReceipt(input: {
 		targetGoalUpdatedAt: input.now,
 		excludeEventId: input.checkpointLedgerEventId,
 	});
+	let validationBatch: UltragoalCompletionVerification["validationBatch"];
+	if (input.goal.validationBatch) {
+		if (input.goal.id !== input.goal.validationBatch.finalGoalId) {
+			const deferred = qualityGateObject(input.qualityGateJson.deferredToBatch);
+			const changeSet = qualityGateObject(deferred?.changeSet);
+			validationBatch = {
+				schemaVersion: 1,
+				role: "deferred-member",
+				batchId: input.goal.validationBatch.batchId,
+				memberIds: [...input.goal.validationBatch.memberIds],
+				finalGoalId: input.goal.validationBatch.finalGoalId,
+				metadataHash: input.goal.validationBatch.metadataHash,
+				changeSetHash: String(changeSet?.changeSetHash ?? ""),
+			};
+		} else {
+			const close = qualityGateObject(input.qualityGateJson.validationBatchClose);
+			const union = qualityGateObject(close?.unionChangeSet);
+			const memberReceiptIds: Record<string, string> = {};
+			const memberCheckpointLedgerEventIds: Record<string, string> = {};
+			const rows = Array.isArray(close?.memberReceipts) ? close.memberReceipts : [];
+			for (const row of rows) {
+				if (typeof row === "object" && row !== null && !Array.isArray(row)) {
+					const record = row as JsonObject;
+					const goalId = nonEmptyString(record.goalId);
+					if (goalId) {
+						memberReceiptIds[goalId] = String(record.receiptId ?? "");
+						memberCheckpointLedgerEventIds[goalId] = String(record.checkpointLedgerEventId ?? "");
+					}
+				}
+			}
+			validationBatch = {
+				schemaVersion: 1,
+				role: "batch-close",
+				batchId: input.goal.validationBatch.batchId,
+				memberIds: [...input.goal.validationBatch.memberIds],
+				finalGoalId: input.goal.validationBatch.finalGoalId,
+				memberMetadataHashes: {
+					...(qualityGateObject(close?.memberMetadataHashes) as Record<string, string> | undefined),
+				},
+				memberReceiptIds,
+				memberCheckpointLedgerEventIds,
+				memberChangeSetHashes: {
+					...(qualityGateObject(union?.memberChangeSetHashes) as Record<string, string> | undefined),
+				},
+				unionHash: String(union?.unionHash ?? ""),
+			};
+		}
+	}
 	return {
 		schemaVersion: 1,
 		receiptId: crypto.randomUUID(),
@@ -672,6 +658,7 @@ function buildCompletionReceipt(input: {
 		planGeneration: generation.planGeneration,
 		basis: generation.basis,
 		checkpointLedgerEventId: input.checkpointLedgerEventId,
+		validationBatch,
 	};
 }
 
@@ -737,7 +724,257 @@ function withPipelineMetadataHash(
 ): UltragoalPipelineMetadata {
 	return { ...metadata, metadataHash: hashPipelineMetadata(metadata) } as UltragoalPipelineMetadata;
 }
+function validationBatchHashBasis(metadata: Omit<UltragoalValidationBatchMetadata, "metadataHash">): JsonObject {
+	return {
+		schemaVersion: metadata.schemaVersion,
+		batchId: metadata.batchId,
+		memberIds: metadata.memberIds,
+		finalGoalId: metadata.finalGoalId,
+		mode: metadata.mode,
+	};
+}
 
+function hashValidationBatch(metadata: Omit<UltragoalValidationBatchMetadata, "metadataHash">): string {
+	return hashStructuredValue(validationBatchHashBasis(metadata));
+}
+
+function withValidationBatchHash(
+	metadata: Omit<UltragoalValidationBatchMetadata, "metadataHash">,
+): UltragoalValidationBatchMetadata {
+	return { ...metadata, metadataHash: hashValidationBatch(metadata) } as UltragoalValidationBatchMetadata;
+}
+
+function parseValidationBatchInput(
+	value: unknown,
+	goalIds: ReadonlySet<string>,
+	gjcGoalMode: UltragoalGjcGoalMode,
+): UltragoalValidationBatchMetadata[] {
+	if (!Array.isArray(value)) throw new Error("validation batch JSON must be an array");
+	if (value.length === 0) return [];
+	if (gjcGoalMode !== "aggregate") throw new Error("validation batches require aggregate ultragoal mode");
+	const goalOrder = new Map([...goalIds].map((id, index) => [id, index]));
+	const assigned = new Set<string>();
+	const batches: UltragoalValidationBatchMetadata[] = [];
+	for (const row of value) {
+		if (typeof row !== "object" || row === null || Array.isArray(row))
+			throw new Error("validation batch rows must be objects");
+		const record = row as JsonObject;
+		if (record.schemaVersion !== 1) throw new Error("validation batch schemaVersion must be 1");
+		const batchId = nonEmptyString(record.batchId);
+		if (!batchId) throw new Error("validation batch batchId is required");
+		const finalGoalId = nonEmptyString(record.finalGoalId);
+		if (!finalGoalId || !goalIds.has(finalGoalId))
+			throw new Error(`validation batch ${batchId} references unknown finalGoalId ${finalGoalId ?? ""}`);
+		const memberIds = stringArray(record.memberIds);
+		if (!memberIds || memberIds.length === 0)
+			throw new Error(`validation batch ${batchId} memberIds must be non-empty`);
+		if (memberIds.some(id => id.length === 0))
+			throw new Error(`validation batch ${batchId} memberIds must contain only non-empty strings`);
+		if (new Set(memberIds).size !== memberIds.length)
+			throw new Error(`validation batch ${batchId} contains duplicate memberIds`);
+		for (const memberId of memberIds) {
+			if (!goalIds.has(memberId))
+				throw new Error(`validation batch ${batchId} references unknown member ${memberId}`);
+			if (assigned.has(memberId)) throw new Error(`Goal ${memberId} belongs to more than one validation batch`);
+		}
+		if (!memberIds.includes(finalGoalId))
+			throw new Error(`validation batch ${batchId} memberIds must contain finalGoalId ${finalGoalId}`);
+		for (const memberId of memberIds) assigned.add(memberId);
+		const canonicalMemberIds = [...memberIds].sort(
+			(left, right) => (goalOrder.get(left) ?? 0) - (goalOrder.get(right) ?? 0),
+		);
+		batches.push(
+			withValidationBatchHash({
+				schemaVersion: 1,
+				batchId,
+				memberIds: canonicalMemberIds,
+				finalGoalId,
+				mode: "aggregate-only",
+			}),
+		);
+	}
+	return batches;
+}
+
+function normalizeSavedValidationBatch(record: unknown, id: string): UltragoalValidationBatchMetadata | undefined {
+	if (typeof record !== "object" || record === null || Array.isArray(record)) return undefined;
+	const value = record as JsonObject;
+	if (value.schemaVersion !== 1) throw new Error(`Goal ${id} validation batch schemaVersion must be 1`);
+	const batchId = nonEmptyString(value.batchId);
+	if (!batchId) throw new Error(`Goal ${id} validation batch batchId is required`);
+	const memberIds = stringArray(value.memberIds);
+	if (!memberIds || memberIds.length === 0) throw new Error(`Goal ${id} validation batch memberIds must be non-empty`);
+	if (new Set(memberIds).size !== memberIds.length || memberIds.some(memberId => memberId.length === 0)) {
+		throw new Error(`Goal ${id} validation batch memberIds must be unique non-empty strings`);
+	}
+	if (!memberIds.includes(id)) throw new Error(`Goal ${id} validation batch must include its goal id`);
+	const finalGoalId = nonEmptyString(value.finalGoalId);
+	if (!finalGoalId || !memberIds.includes(finalGoalId))
+		throw new Error(`Goal ${id} validation batch finalGoalId must be a member`);
+	if (value.mode !== "aggregate-only") throw new Error(`Goal ${id} validation batch mode must be aggregate-only`);
+	const basis: Omit<UltragoalValidationBatchMetadata, "metadataHash"> = {
+		schemaVersion: 1,
+		batchId,
+		memberIds,
+		finalGoalId,
+		mode: "aggregate-only",
+	};
+	const metadataHash = nonEmptyString(value.metadataHash);
+	if (!metadataHash) throw new Error(`Goal ${id} validation batch metadataHash is required`);
+	const normalized = { ...basis, metadataHash } as UltragoalValidationBatchMetadata;
+	if (metadataHash !== hashValidationBatch(basis))
+		throw new Error(`Goal ${id} has stale validation batch metadata hash`);
+	return normalized;
+}
+
+function pipelineMetadataConflictsWithValidationBatch(metadata: UltragoalPipelineMetadata | undefined): boolean {
+	return metadata?.eligible === true || metadata?.source === "original_plan_graph" || metadata?.source === "steering";
+}
+
+function validateValidationBatchPipelineExclusion(goal: UltragoalGoal): void {
+	if (goal.validationBatch && pipelineMetadataConflictsWithValidationBatch(goal.pipelineMetadata)) {
+		throw new Error(`Goal ${goal.id} cannot combine validationBatch with eligible pipeline metadata`);
+	}
+}
+function requireFreshValidationBatchMetadata(goal: UltragoalGoal): UltragoalValidationBatchMetadata | undefined {
+	const metadata = goal.validationBatch;
+	if (!metadata) return undefined;
+	const { metadataHash, ...basis } = metadata;
+	if (metadataHash !== hashValidationBatch(basis))
+		throw new Error(`Goal ${goal.id} has stale validation batch metadata hash`);
+	validateValidationBatchPipelineExclusion(goal);
+	return metadata;
+}
+
+function findFreshValidationBatchClose(
+	plan: UltragoalPlan,
+	metadata: UltragoalValidationBatchMetadata,
+	member: UltragoalGoal,
+	ledger: readonly UltragoalLedgerEvent[],
+): UltragoalGoal | undefined {
+	const receipt = member.completionVerification;
+	if (!receipt) return undefined;
+	const finalReceipt = findFreshBatchCloseReceipt({ plan, ledger, deferredGoal: member, deferredReceipt: receipt });
+	if (!finalReceipt) return undefined;
+	const finalGoal = plan.goals.find(goal => goal.id === metadata.finalGoalId);
+	const close = finalReceipt.validationBatch;
+	if (!finalGoal || close?.role !== "batch-close") return undefined;
+	if (close.batchId !== metadata.batchId || close.finalGoalId !== metadata.finalGoalId) return undefined;
+	if (
+		close.memberIds.length !== metadata.memberIds.length ||
+		close.memberIds.some((id, index) => id !== metadata.memberIds[index])
+	)
+		return undefined;
+	if (close.memberMetadataHashes[member.id] !== metadata.metadataHash) return undefined;
+	return finalGoal;
+}
+
+function requireDeferredMemberReceiptFresh(
+	plan: UltragoalPlan,
+	ledger: readonly UltragoalLedgerEvent[],
+	member: UltragoalGoal,
+	fieldName: string,
+): UltragoalDeferredCompletionVerification {
+	const receipt = member.completionVerification;
+	if (!receipt) throw new Error(`${fieldName} requires fresh deferred receipt for ${member.id}`);
+	if (receipt.validationBatch?.role !== "deferred-member")
+		throw new Error(`${fieldName} requires fresh deferred receipt for ${member.id}`);
+	const diagnostic = validateDeferredMemberReceiptFresh({
+		plan,
+		ledger,
+		goal: member,
+		receipt,
+		receiptKind: "per-goal",
+		requireClose: false,
+	});
+	if (diagnostic.state !== "active_verified_complete")
+		throw new Error(`${fieldName}.${member.id} ${diagnostic.message}`);
+	return receipt as UltragoalDeferredCompletionVerification;
+}
+
+function requireFreshBatchCloseReceiptBasis(
+	plan: UltragoalPlan,
+	ledger: readonly UltragoalLedgerEvent[],
+	goal: UltragoalGoal,
+	receipt: UltragoalCompletionVerification,
+	event: UltragoalLedgerEvent,
+): void {
+	const batch = receipt.validationBatch;
+	if (batch?.role !== "batch-close") return;
+	const base = validateReceiptFreshBase({ plan, ledger, goal, receipt, receiptKind: receipt.receiptKind });
+	if (base) throw new Error(base.message);
+	for (const memberId of batch.memberIds) {
+		const member = plan.goals.find(item => item.id === memberId);
+		if (
+			!member?.validationBatch ||
+			member.validationBatch.batchId !== batch.batchId ||
+			member.validationBatch.metadataHash !== batch.memberMetadataHashes[memberId]
+		) {
+			throw new Error(`Goal ${goal.id} has stale validation batch close receipt for ${batch.batchId}`);
+		}
+		if (memberId === batch.finalGoalId) continue;
+		const memberReceipt = requireDeferredMemberReceiptFresh(
+			plan,
+			ledger,
+			member,
+			`Goal ${goal.id} batch-close receipt`,
+		);
+		if (
+			batch.memberReceiptIds[memberId] !== memberReceipt.receiptId ||
+			batch.memberCheckpointLedgerEventIds[memberId] !== memberReceipt.checkpointLedgerEventId ||
+			batch.memberChangeSetHashes[memberId] !== memberReceipt.validationBatch!.changeSetHash
+		) {
+			throw new Error(`Goal ${goal.id} batch-close receipt is stale for deferred member ${memberId}`);
+		}
+	}
+	const close = qualityGateObject(qualityGateObject(event.qualityGateJson)?.validationBatchClose);
+	const unionHash = String(qualityGateObject(close?.unionChangeSet)?.unionHash ?? "");
+	if (batch.unionHash !== unionHash)
+		throw new Error(`Goal ${goal.id} validation batch close receipt union hash is stale`);
+}
+
+function clearValidationBatchForBatch(
+	plan: UltragoalPlan,
+	metadata: UltragoalValidationBatchMetadata | undefined,
+): void {
+	if (!metadata) return;
+	for (const member of plan.goals) {
+		if (member.validationBatch?.batchId === metadata.batchId) delete member.validationBatch;
+	}
+}
+
+function freshDeferredValidationBatchBlocker(
+	plan: UltragoalPlan,
+	metadata: UltragoalValidationBatchMetadata,
+	ledger: readonly UltragoalLedgerEvent[],
+): UltragoalGoal | undefined {
+	for (const memberId of metadata.memberIds) {
+		const member = plan.goals.find(goal => goal.id === memberId);
+		if (!member?.validationBatch || member.status !== "complete") continue;
+		try {
+			requireDeferredMemberReceiptFresh(plan, ledger, member, "validation batch steering");
+		} catch {
+			continue;
+		}
+		if (!findFreshValidationBatchClose(plan, member.validationBatch, member, ledger)) return member;
+	}
+	return undefined;
+}
+
+function requireValidationBatchSteeringAllowed(
+	plan: UltragoalPlan,
+	goal: UltragoalGoal,
+	kind: UltragoalSteeringKind,
+	ledger: readonly UltragoalLedgerEvent[],
+): void {
+	const metadata = goal.validationBatch;
+	if (!metadata) return;
+	const blocker = freshDeferredValidationBatchBlocker(plan, metadata, ledger);
+	if (blocker)
+		throw new Error(
+			`steer ${kind} cannot invalidate validation batch ${metadata.batchId} while member ${blocker.id} has a fresh deferred receipt`,
+		);
+}
 function legacyPipelineMetadata(goalId: string): UltragoalPipelineMetadata {
 	const basis: Omit<UltragoalPipelineMetadata, "metadataHash"> = {
 		schemaVersion: 1,
@@ -1018,6 +1255,7 @@ function normalizePlan(raw: unknown): UltragoalPlan {
 		const objective = nonEmptyString(goalRecord.objective) ?? title;
 		const goalCreatedAt = nonEmptyString(goalRecord.createdAt) ?? createdAt;
 		const pipelineMetadata = normalizeSavedPipelineMetadata(goalRecord.pipelineMetadata, id);
+		const validationBatch = normalizeSavedValidationBatch(goalRecord.validationBatch, id);
 		return {
 			...goalRecord,
 			id,
@@ -1038,6 +1276,7 @@ function normalizePlan(raw: unknown): UltragoalPlan {
 					? (goalRecord.completionVerification as UltragoalCompletionVerification)
 					: undefined,
 			pipelineMetadata,
+			validationBatch,
 		};
 	});
 	const aliases = Array.isArray(record.gjcObjectiveAliases)
@@ -1210,6 +1449,8 @@ export async function createUltragoalPlan(input: {
 	sessionId?: string | null;
 	goalMetadata?: UltragoalGoalMetadataInput[];
 	goalMetadataJson?: string;
+	validationBatches?: UltragoalValidationBatchInput[];
+	validationBatchJson?: string;
 }): Promise<UltragoalPlan> {
 	const brief = input.brief.trim();
 	if (!brief) throw new Error("ultragoal brief is required");
@@ -1229,9 +1470,29 @@ export async function createUltragoalPlan(input: {
 	const metadataInput = input.goalMetadataJson
 		? await readStructuredValue(input.cwd, input.goalMetadataJson)
 		: input.goalMetadata;
+	const validationBatchInput = input.validationBatchJson
+		? await readStructuredValue(input.cwd, input.validationBatchJson)
+		: input.validationBatches;
+	if (metadataInput !== undefined && validationBatchInput !== undefined) {
+		const metadataRows = Array.isArray(metadataInput) ? metadataInput : [];
+		const batchRows = Array.isArray(validationBatchInput) ? validationBatchInput : [];
+		if (metadataRows.length > 0 && batchRows.length > 0)
+			throw new Error("validation-batch-json and goal-metadata-json are mutually exclusive");
+	}
 	const metadata = metadataInput === undefined ? [] : parseGoalMetadataInput(metadataInput, goalIds);
+	const validationBatches =
+		validationBatchInput === undefined
+			? []
+			: parseValidationBatchInput(validationBatchInput, goalIds, input.gjcGoalMode ?? "aggregate");
 	const metadataByGoalId = new Map(metadata.map(item => [item.goalId, item]));
-	for (const goal of goals) goal.pipelineMetadata = metadataByGoalId.get(goal.id) ?? legacyPipelineMetadata(goal.id);
+	const validationBatchByGoalId = new Map<string, UltragoalValidationBatchMetadata>();
+	for (const batch of validationBatches)
+		for (const memberId of batch.memberIds) validationBatchByGoalId.set(memberId, batch);
+	for (const goal of goals) {
+		goal.pipelineMetadata = metadataByGoalId.get(goal.id) ?? legacyPipelineMetadata(goal.id);
+		goal.validationBatch = validationBatchByGoalId.get(goal.id);
+		validateValidationBatchPipelineExclusion(goal);
+	}
 	const plan: UltragoalPlan = {
 		version: 1,
 		brief,
@@ -1297,6 +1558,10 @@ function requirePipelineStartable(plan: UltragoalPlan, prior: UltragoalGoal, nex
 		throw new Error(`Prior goal ${prior.id} must be active before pipeline overlap starts`);
 	if (next.status !== "pending" && next.status !== "failed")
 		throw new Error(`Next goal ${next.id} must be pending or retryable failed`);
+	validateValidationBatchPipelineExclusion(prior);
+	validateValidationBatchPipelineExclusion(next);
+	if (prior.validationBatch || next.validationBatch)
+		throw new Error("pipeline overlap cannot start for validation batch goals");
 	const priorMetadata = requireFreshPipelineMetadata(prior);
 	const nextMetadata = requireFreshPipelineMetadata(next);
 	if (!priorMetadata.eligible || !nextMetadata.eligible)
@@ -3120,18 +3385,139 @@ export async function validateExecutorQaRedTeamEvidenceForReview(
 	await validateExecutorQaRedTeamEvidenceInternal(cwd, executorQa as JsonObject, options);
 }
 
+function canonicalChangeSetRows(value: unknown, fieldName: string): UltragoalChangeSetPath[] {
+	if (!Array.isArray(value)) throw new Error(`${fieldName} must be an array`);
+	return value.map((row, index) => {
+		if (typeof row !== "object" || row === null || Array.isArray(row))
+			throw new Error(`${fieldName}[${index}] must be an object`);
+		const record = row as JsonObject;
+		const pathValue = nonEmptyString(record.path);
+		if (!pathValue) throw new Error(`${fieldName}[${index}].path is required`);
+		if ("goalId" in record) throw new Error(`${fieldName}[${index}] must not contain goalId attribution`);
+		const status = nonEmptyString(record.status);
+		if (!status) throw new Error(`${fieldName}[${index}].status is required`);
+		return { path: normalizeRepoPath(pathValue), status: status as UltragoalChangeStatus };
+	});
+}
+
+function changeSetHashForPaths(paths: readonly UltragoalChangeSetPath[]): string {
+	return hashStructuredValue(paths.map(row => ({ path: row.path, status: row.status, oldPath: row.oldPath })));
+}
+
+function requireChangeSetCoverage(
+	expected: UltragoalChangeSet | undefined,
+	declared: readonly UltragoalChangeSetPath[],
+	fieldName: string,
+): void {
+	if (!expected) return;
+	const declaredKeys = new Set(declared.map(row => `${row.oldPath ?? ""}\u0000${row.path}\u0000${row.status}`));
+	for (const row of expected.paths) {
+		const key = `${row.oldPath ?? ""}\u0000${row.path}\u0000${row.status}`;
+		if (!declaredKeys.has(key))
+			throw new Error(`${fieldName} does not cover computed checkpoint change-set path ${row.path}`);
+	}
+}
+
+function requireValidationBatchTuple(
+	metadata: UltragoalValidationBatchMetadata,
+	record: JsonObject,
+	fieldName: string,
+): void {
+	if (record.schemaVersion !== 1) throw new Error(`${fieldName}.schemaVersion must be 1`);
+	if (record.batchId !== metadata.batchId) throw new Error(`${fieldName}.batchId must match durable validationBatch`);
+	if (record.finalGoalId !== metadata.finalGoalId)
+		throw new Error(`${fieldName}.finalGoalId must match durable validationBatch`);
+	if (record.metadataHash !== metadata.metadataHash)
+		throw new Error(`${fieldName}.metadataHash must match durable validationBatch`);
+	const memberIds = stringArray(record.memberIds);
+	if (
+		!memberIds ||
+		memberIds.length !== metadata.memberIds.length ||
+		memberIds.some((id, index) => id !== metadata.memberIds[index])
+	) {
+		throw new Error(`${fieldName}.memberIds must match durable validationBatch order`);
+	}
+}
+
+function validateDeferredCompletionQualityGate(
+	gate: JsonObject,
+	goal: UltragoalGoal,
+	metadata: UltragoalValidationBatchMetadata,
+	changeSet?: UltragoalChangeSet,
+): void {
+	const allowedKeys = new Set(["deferredToBatch"]);
+	const unsupportedKeys = Object.keys(gate).filter(key => !allowedKeys.has(key));
+	if (unsupportedKeys.length > 0)
+		throw new Error(`deferred qualityGate contains unsupported keys: ${unsupportedKeys.join(", ")}`);
+	const deferred = qualityGateObject(gate.deferredToBatch);
+	if (!deferred) throw new Error("deferred qualityGate requires deferredToBatch object");
+	if (deferred.kind !== "validation-batch-deferred")
+		throw new Error("deferredToBatch.kind must be validation-batch-deferred");
+	requireValidationBatchTuple(metadata, deferred, "deferredToBatch");
+	if (goal.id === metadata.finalGoalId)
+		throw new Error("final validation batch goal cannot use deferredToBatch quality gate");
+	const deferredLanes = stringArray(deferred.deferredLanes)?.filter(Boolean).sort();
+	if (deferredLanes?.join(",") !== "architectReview,executorQa")
+		throw new Error("deferredToBatch.deferredLanes must be architectReview and executorQa");
+	const targeted = qualityGateObject(deferred.targetedVerification);
+	if (!targeted || targeted.status !== PASSED_STATUS || !nonEmptyStringArray(targeted.commands))
+		throw new Error("deferredToBatch.targetedVerification must pass with non-empty commands");
+	requireNonEmptyString(targeted.evidence, "deferredToBatch.targetedVerification.evidence");
+	const cleaner = qualityGateObject(deferred.aiSlopCleaner);
+	if (!cleaner || cleaner.status !== PASSED_STATUS) throw new Error("deferredToBatch.aiSlopCleaner must pass");
+	requireNonEmptyString(cleaner.evidence, "deferredToBatch.aiSlopCleaner.evidence");
+	const iteration = qualityGateObject(deferred.iteration);
+	if (!iteration || iteration.status !== PASSED_STATUS || iteration.fullRerun !== true)
+		throw new Error("deferredToBatch.iteration must pass with fullRerun true");
+	if (!nonEmptyStringArray(iteration.rerunCommands))
+		throw new Error("deferredToBatch.iteration.rerunCommands must be non-empty");
+	requireNonEmptyString(iteration.evidence, "deferredToBatch.iteration.evidence");
+	requireEmptyBlockers(iteration.blockers, "deferredToBatch.iteration.blockers");
+	const declaredChangeSet = qualityGateObject(deferred.changeSet);
+	if (!declaredChangeSet) throw new Error("deferredToBatch.changeSet is required");
+	if (declaredChangeSet.memberGoalId !== goal.id)
+		throw new Error("deferredToBatch.changeSet.memberGoalId must label the checkpointed goal");
+	if (declaredChangeSet.cumulativeFromBase !== true)
+		throw new Error("deferredToBatch.changeSet.cumulativeFromBase must be true");
+	const paths = canonicalChangeSetRows(declaredChangeSet.paths, "deferredToBatch.changeSet.paths");
+	requireChangeSetCoverage(changeSet, paths, "deferredToBatch.changeSet.paths");
+	if (declaredChangeSet.changeSetHash !== changeSetHashForPaths(paths))
+		throw new Error("deferredToBatch.changeSet.changeSetHash does not match declared paths");
+}
 async function validateCompletionQualityGate(
 	cwd: string,
 	gate: JsonObject,
-	options: { changeSet?: UltragoalChangeSet } = {},
+	options: {
+		changeSet?: UltragoalChangeSet;
+		plan?: UltragoalPlan;
+		goal?: UltragoalGoal;
+		ledger?: readonly UltragoalLedgerEvent[];
+	} = {},
 ): Promise<void> {
+	const batchMode = options.goal?.validationBatch;
+	if (batchMode && options.goal && options.goal.id !== batchMode.finalGoalId) {
+		validateDeferredCompletionQualityGate(gate, options.goal, batchMode, options.changeSet);
+		return;
+	}
+	if (batchMode && options.goal && options.goal.id === batchMode.finalGoalId) {
+		const allowedKeys = new Set(["architectReview", "executorQa", "iteration", "validationBatchClose"]);
+		const unsupportedKeys = Object.keys(gate).filter(key => !allowedKeys.has(key));
+		if (unsupportedKeys.length > 0)
+			throw new Error(`qualityGate contains unsupported keys: ${unsupportedKeys.join(", ")}`);
+		if (!qualityGateObject(gate.validationBatchClose))
+			throw new Error("final validation batch goal requires validationBatchClose");
+	}
 	const codeReview = qualityGateObject(gate.codeReview);
 	if (codeReview) {
 		throw new Error(
 			"checkpoint --status complete requires architect review approval through architectReview, executorQa, and iteration quality-gate evidence; legacy codeReview-only gates are not sufficient",
 		);
 	}
-	const allowedKeys = new Set(["architectReview", "executorQa", "iteration"]);
+	const allowedKeys = new Set(
+		batchMode
+			? ["architectReview", "executorQa", "iteration", "validationBatchClose"]
+			: ["architectReview", "executorQa", "iteration"],
+	);
 	const unsupportedKeys = Object.keys(gate).filter(key => !allowedKeys.has(key));
 	if (unsupportedKeys.length > 0) {
 		throw new Error(`qualityGate contains unsupported keys: ${unsupportedKeys.join(", ")}`);
@@ -3178,12 +3564,105 @@ async function validateCompletionQualityGate(
 	}
 	requireNonEmptyString(iteration.evidence, "iteration.evidence");
 	requireEmptyBlockers(iteration.blockers, "iteration.blockers");
+	if (batchMode && options.goal && options.plan && options.ledger) {
+		validateBatchCloseQualityGate(gate, options.plan, batchMode, options.ledger, options.changeSet);
+	}
 }
 
+function validateBatchCloseQualityGate(
+	gate: JsonObject,
+	plan: UltragoalPlan,
+	metadata: UltragoalValidationBatchMetadata,
+	ledger: readonly UltragoalLedgerEvent[],
+	changeSet?: UltragoalChangeSet,
+): void {
+	const close = qualityGateObject(gate.validationBatchClose);
+	if (!close) throw new Error("validationBatchClose is required");
+	if (close.schemaVersion !== 1 || close.kind !== "validation-batch-close")
+		throw new Error("validationBatchClose.kind must be validation-batch-close");
+	if (close.batchId !== metadata.batchId || close.finalGoalId !== metadata.finalGoalId)
+		throw new Error("validationBatchClose tuple must match durable validationBatch");
+	const memberIds = stringArray(close.memberIds);
+	if (
+		!memberIds ||
+		memberIds.length !== metadata.memberIds.length ||
+		memberIds.some((id, index) => id !== metadata.memberIds[index])
+	)
+		throw new Error("validationBatchClose.memberIds must match durable validationBatch order");
+	const memberMetadataHashes = qualityGateObject(close.memberMetadataHashes);
+	const memberChangeSetHashes = qualityGateObject(qualityGateObject(close.unionChangeSet)?.memberChangeSetHashes);
+	if (!memberMetadataHashes || !memberChangeSetHashes)
+		throw new Error("validationBatchClose member metadata and change-set hashes are required");
+	const seenReceipts = new Set<string>();
+	const receiptRows = Array.isArray(close.memberReceipts) ? close.memberReceipts : [];
+	const nonFinalIds = metadata.memberIds.filter(memberId => memberId !== metadata.finalGoalId);
+	for (const memberId of metadata.memberIds) {
+		const member = plan.goals.find(item => item.id === memberId);
+		if (!member?.validationBatch) throw new Error(`validationBatchClose references missing batch member ${memberId}`);
+		if (member.validationBatch.metadataHash !== memberMetadataHashes[memberId])
+			throw new Error(`validationBatchClose.memberMetadataHashes.${memberId} does not match durable metadata`);
+		if (memberId !== metadata.finalGoalId && member.status !== "complete")
+			throw new Error(`validationBatchClose cannot close before ${memberId} is complete`);
+	}
+	if (receiptRows.length !== nonFinalIds.length)
+		throw new Error("validationBatchClose.memberReceipts must list every non-final member exactly once");
+	for (const row of receiptRows) {
+		if (typeof row !== "object" || row === null || Array.isArray(row))
+			throw new Error("validationBatchClose.memberReceipts rows must be objects");
+		const record = row as JsonObject;
+		const memberId = nonEmptyString(record.goalId);
+		if (!memberId || !nonFinalIds.includes(memberId))
+			throw new Error("validationBatchClose.memberReceipts contains invalid member goalId");
+		if (seenReceipts.has(memberId))
+			throw new Error(`validationBatchClose.memberReceipts contains duplicate member ${memberId}`);
+		seenReceipts.add(memberId);
+		const member = plan.goals.find(item => item.id === memberId)!;
+		const receipt = requireDeferredMemberReceiptFresh(plan, ledger, member, "validationBatchClose.memberReceipts");
+		if (
+			record.role !== "deferred-member" ||
+			record.receiptId !== receipt.receiptId ||
+			record.qualityGateHash !== receipt.qualityGateHash ||
+			record.changeSetHash !== receipt.validationBatch.changeSetHash ||
+			record.checkpointLedgerEventId !== receipt.checkpointLedgerEventId
+		) {
+			throw new Error(`validationBatchClose.memberReceipts.${memberId} does not match deferred receipt`);
+		}
+		if (memberChangeSetHashes[memberId] !== receipt.validationBatch.changeSetHash)
+			throw new Error(
+				`validationBatchClose.unionChangeSet.memberChangeSetHashes.${memberId} does not match deferred receipt`,
+			);
+	}
+	if (seenReceipts.size !== nonFinalIds.length)
+		throw new Error("validationBatchClose.memberReceipts is missing a non-final member");
+	const union = qualityGateObject(close.unionChangeSet);
+	if (union?.source !== "validation-batch")
+		throw new Error("validationBatchClose.unionChangeSet.source must be validation-batch");
+	const unionPaths = canonicalChangeSetRows(union.paths, "validationBatchClose.unionChangeSet.paths");
+	requireChangeSetCoverage(changeSet, unionPaths, "validationBatchClose.unionChangeSet.paths");
+	const finalHash = changeSetHashForPaths(unionPaths);
+	if (memberChangeSetHashes[metadata.finalGoalId] !== finalHash)
+		throw new Error(
+			"validationBatchClose.unionChangeSet.memberChangeSetHashes final member hash does not match current change set",
+		);
+	if (
+		union.unionHash !==
+		hashStructuredValue({
+			memberChangeSetHashes,
+			paths: unionPaths.map(row => ({ path: row.path, status: row.status, oldPath: row.oldPath })),
+		})
+	)
+		throw new Error("validationBatchClose.unionChangeSet.unionHash does not match declared union");
+	requireNonEmptyString(close.coverageEvidence, "validationBatchClose.coverageEvidence");
+}
 async function readRequiredCompletionQualityGate(
 	cwd: string,
 	value: string | undefined,
-	options: { changeSet?: UltragoalChangeSet } = {},
+	options: {
+		changeSet?: UltragoalChangeSet;
+		plan?: UltragoalPlan;
+		goal?: UltragoalGoal;
+		ledger?: readonly UltragoalLedgerEvent[];
+	} = {},
 ): Promise<unknown> {
 	if (!value?.trim()) {
 		throw new Error(
@@ -3193,7 +3672,12 @@ async function readRequiredCompletionQualityGate(
 	const gate = await readStructuredValue(cwd, value);
 	const gateObject = qualityGateObject(gate);
 	if (!gateObject) throw new Error("qualityGate must be a JSON object");
-	await validateCompletionQualityGate(cwd, gateObject, { changeSet: options.changeSet });
+	await validateCompletionQualityGate(cwd, gateObject, {
+		changeSet: options.changeSet,
+		plan: options.plan,
+		goal: options.goal,
+		ledger: options.ledger,
+	});
 	return gate;
 }
 
@@ -3204,6 +3688,7 @@ function validatePipelineCheckpointSafety(
 ): void {
 	const metadata = goal.pipelineMetadata;
 	if (!metadata) return;
+	validateValidationBatchPipelineExclusion(goal);
 	requireFreshPipelineMetadata(goal);
 	if (metadata.overlap === "open") {
 		throw new Error(
@@ -3270,17 +3755,51 @@ export async function checkpointUltragoalGoal(input: {
 	const evidence = input.evidence.trim();
 	if (!evidence) throw new Error("checkpoint evidence is required");
 	const ledgerBefore = await readUltragoalLedger(input.cwd);
-	if (
-		goal.status === input.status &&
-		goal.evidence === evidence &&
-		ledgerBefore.some(
-			event =>
-				event.event === "goal_checkpointed" &&
-				event.goalId === goal.id &&
-				event.status === input.status &&
-				event.evidence === evidence,
-		)
-	) {
+	const matchingIdempotentEvent = ledgerBefore.find(
+		event =>
+			event.event === "goal_checkpointed" &&
+			event.goalId === goal.id &&
+			event.status === input.status &&
+			event.evidence === evidence,
+	);
+	const batchMetadata = input.status === "complete" ? requireFreshValidationBatchMetadata(goal) : undefined;
+	if (batchMetadata && goal.completionVerification?.validationBatch) {
+		const receiptBatch = goal.completionVerification.validationBatch;
+		if (receiptBatch.role === "deferred-member" && receiptBatch.metadataHash !== batchMetadata.metadataHash) {
+			throw new Error(`Goal ${goal.id} has stale validation batch completion receipt for ${batchMetadata.batchId}`);
+		}
+		if (
+			receiptBatch.role === "batch-close" &&
+			receiptBatch.memberMetadataHashes[goal.id] !== batchMetadata.metadataHash
+		) {
+			throw new Error(`Goal ${goal.id} has stale validation batch close receipt for ${batchMetadata.batchId}`);
+		}
+	}
+	if (input.status === "complete" && goal.completionVerification?.validationBatch && !batchMetadata) {
+		throw new Error(`Goal ${goal.id} has stale validation batch completion receipt`);
+	}
+	if (goal.status === input.status && goal.evidence === evidence && matchingIdempotentEvent) {
+		if (batchMetadata) {
+			const receipt = goal.completionVerification;
+			const receiptBatch = receipt?.validationBatch;
+			if (!receipt || !receiptBatch)
+				throw new Error(
+					`Goal ${goal.id} has validation batch ${batchMetadata.batchId} but no matching completion receipt`,
+				);
+			if (receipt.checkpointLedgerEventId !== matchingIdempotentEvent.eventId)
+				throw new Error(`Goal ${goal.id} validation batch receipt does not match prior checkpoint event`);
+			if (hashStructuredValue(matchingIdempotentEvent.qualityGateJson) !== receipt.qualityGateHash)
+				throw new Error(`Goal ${goal.id} validation batch receipt quality gate is stale`);
+			if (receiptBatch.role === "deferred-member" && receiptBatch.metadataHash !== batchMetadata.metadataHash)
+				throw new Error(`Goal ${goal.id} has stale validation batch metadata hash in deferred receipt`);
+			if (receiptBatch.role === "batch-close")
+				requireFreshBatchCloseReceiptBasis(plan, ledgerBefore, goal, receipt, matchingIdempotentEvent);
+			if (
+				receiptBatch.role === "batch-close" &&
+				receiptBatch.memberMetadataHashes[goal.id] !== batchMetadata.metadataHash
+			)
+				throw new Error(`Goal ${goal.id} has stale validation batch metadata hash in close receipt`);
+		}
 		// Idempotent re-checkpoint: this goal is already recorded in the target status with the same
 		// evidence, so skip the plan rewrite and ledger append to avoid duplicate goal_checkpointed
 		// events. The ledger is the dedup source of truth because it is exactly what a duplicate write
@@ -3296,7 +3815,12 @@ export async function checkpointUltragoalGoal(input: {
 	}
 	const qualityGateJson =
 		input.status === "complete"
-			? await readRequiredCompletionQualityGate(input.cwd, input.qualityGateJson, { changeSet })
+			? await readRequiredCompletionQualityGate(input.cwd, input.qualityGateJson, {
+					changeSet,
+					plan,
+					goal,
+					ledger: ledgerBefore,
+				})
 			: input.qualityGateJson
 				? await readStructuredValue(input.cwd, input.qualityGateJson)
 				: undefined;
@@ -3586,6 +4110,8 @@ async function splitUltragoalSubgoal(input: {
 	});
 	const target = findGoalOrThrow(input.plan, input.goalId, kind);
 	requireGoalStatus(target, ["pending"], kind);
+	const ledger = await readUltragoalLedger(input.cwd);
+	requireValidationBatchSteeringAllowed(input.plan, target, kind, ledger);
 	const replacements = parseReplacementSpecs(input.replacementsJson, kind);
 	const now = new Date().toISOString();
 	const replacementGoalIds = replacements.map((_, index) => nextUltragoalGoalId(input.plan, index + 1));
@@ -3594,6 +4120,7 @@ async function splitUltragoalSubgoal(input: {
 	target.updatedAt = now;
 	target.steering = { kind, evidence, rationale, replacementGoalIds };
 	invalidatePipelineMetadata(target, "split_subgoal_superseded", now);
+	clearValidationBatchForBatch(input.plan, target.validationBatch);
 	const replacementGoals = replacements.map(
 		(replacement, index): UltragoalGoal => ({
 			id: replacementGoalIds[index]!,
@@ -3681,6 +4208,8 @@ async function revisePendingUltragoalWording(input: {
 	});
 	const goal = findGoalOrThrow(input.plan, input.goalId, kind);
 	requireGoalStatus(goal, ["pending"], kind);
+	const ledger = await readUltragoalLedger(input.cwd);
+	requireValidationBatchSteeringAllowed(input.plan, goal, kind, ledger);
 	const title = input.title === undefined ? undefined : input.title.trim();
 	const objective = input.objective === undefined ? undefined : input.objective.trim();
 	if (input.title !== undefined && !title)
@@ -3701,6 +4230,7 @@ async function revisePendingUltragoalWording(input: {
 	goal.updatedAt = now;
 	goal.steering = { kind, evidence, rationale, changedFields };
 	invalidatePipelineMetadata(goal, "revised_pending_wording", now);
+	clearValidationBatchForBatch(input.plan, goal.validationBatch);
 	input.plan.updatedAt = now;
 	await writePlan(input.cwd, input.plan);
 	await appendLedger(input.cwd, {
@@ -3745,6 +4275,8 @@ async function markBlockedUltragoalSuperseded(input: {
 	});
 	const goal = findGoalOrThrow(input.plan, input.goalId, kind);
 	requireGoalStatus(goal, ["blocked", "review_blocked"], kind);
+	const ledger = await readUltragoalLedger(input.cwd);
+	requireValidationBatchSteeringAllowed(input.plan, goal, kind, ledger);
 	const remainingRequiredGoals = requiredUltragoalGoals(input.plan).filter(item => item.id !== goal.id);
 	if (remainingRequiredGoals.length === 0) {
 		throw new Error(`steer ${kind} cannot supersede ${goal.id} because it is the only remaining required goal`);
@@ -3754,6 +4286,7 @@ async function markBlockedUltragoalSuperseded(input: {
 	goal.evidence = evidence;
 	goal.updatedAt = now;
 	goal.steering = { kind, evidence, rationale, noReplacementRequired: true };
+	clearValidationBatchForBatch(input.plan, goal.validationBatch);
 	input.plan.updatedAt = now;
 	await writePlan(input.cwd, input.plan);
 	await appendLedger(input.cwd, {
@@ -4260,6 +4793,7 @@ const FLAGS_WITH_VALUES = new Set([
 	"--order-json",
 	"--classification",
 	"--goal-metadata-json",
+	"--validation-batch-json",
 	"--prior-goal-id",
 	"--next-goal-id",
 	"--review-handles-json",
@@ -4619,12 +5153,19 @@ async function dispatchUltragoalCommand(args: string[], cwd: string): Promise<Ul
 				return { status: 0, stdout: renderStatus(await getUltragoalStatus(cwd, sessionId), json) };
 			case "create":
 			case "create-goals": {
+				if (
+					flagValue(args, "--goal-metadata-json") !== undefined &&
+					flagValue(args, "--validation-batch-json") !== undefined
+				) {
+					throw new Error("--validation-batch-json and --goal-metadata-json are mutually exclusive");
+				}
 				const mode = flagValue(args, "--gjc-goal-mode") === "per-story" ? "per-story" : "aggregate";
 				const plan = await createUltragoalPlan({
 					cwd,
 					brief: await readBrief(cwd, args),
 					gjcGoalMode: mode,
 					goalMetadataJson: flagValue(args, "--goal-metadata-json"),
+					validationBatchJson: flagValue(args, "--validation-batch-json"),
 				});
 				return {
 					status: 0,

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
@@ -1437,6 +1437,13 @@
       },
       {
         "appliesToVerbs": [
+          "create-goals"
+        ],
+        "name": "validation-batch-json",
+        "type": "string"
+      },
+      {
+        "appliesToVerbs": [
           "complete-goals"
         ],
         "name": "retry-failed",

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
@@ -259,6 +259,7 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 				enumValues: ["aggregate", "per-story"],
 				appliesToVerbs: ["create-goals"],
 			},
+			{ name: "validation-batch-json", type: "string", appliesToVerbs: ["create-goals"] },
 			{ name: "retry-failed", type: "boolean", appliesToVerbs: ["complete-goals"] },
 			{ name: "goal-id", type: "string", required: true, appliesToVerbs: ["checkpoint", "record-review-blockers"] },
 			{

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -60,12 +60,17 @@ Use for read-only plan critique. It approves only when execution can proceed wit
 
 <routing>
 - Clear, low-risk implementation request → implement directly with focused verification.
+- For simple clear implementation requests, direct tools are the default launch path. Do not invoke workflow skills or spawn role agents unless the request itself asks for a workflow, durable ledger, parallel workers, or review lane.
+- The workflow-intent-diff CustomEntry does not participate in LLM context; do not infer hidden workflow intent from launch plumbing.
 - Informational questions, bare `?`, and unambiguous explanatory prompts are answer-only/read-only: answer from available context and do not modify files, run commands, or execute workflows unless the user explicitly asks to change, run, implement, or execute something.
 - When a task is clear, bounded, and low-risk, make the smallest correct change and verify it; do not escalate to interviews, durable ledgers, or delegation for ceremony.
+- Small verification needs do not make a clear implementation request into a planning workflow.
 - Ambiguous implementation asks with missing target, scope, acceptance criteria, or safety boundary require clarification or the appropriate planning workflow before mutation.
 - Vague requirements → use `deep-interview`; clear requirements with non-trivial architecture/sequence risk → use `ralplan --deliberate` and stop at pending approval.
+- Architecture/sequence risk that is clear enough to plan but not safe to execute directly → use `ralplan --deliberate` and stop at pending approval.
 - Durable goal ledger needed → use `ultragoal`; approved work that benefits from coordinated persistent workers → use `team`.
 - Large enough implementation work → delegate bounded slices to `executor`; use `planner`, `architect`, and `critic` for bounded planning/review lanes when a full workflow is unnecessary.
+- Treat root-cause phase schema workflows as special-purpose gates only for contradiction, regression, or high-risk transition analysis; do not apply them to ordinary clear fixes.
 - Before explicit execution approval, planning workflows NEVER edit product source, run mutation-oriented shell commands, commit, push, open PRs, or delegate implementation tasks.
 </routing>
 

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -343,6 +343,51 @@ Project executor override body.
 		expect(ultragoal).toContain("not a hidden pipeline scheduler");
 	});
 
+	it("documents validation-batch granularity, contract, and intra-goal lane parallelism in the ultragoal prompt", async () => {
+		const ultragoal = await Bun.file(
+			path.join(repoRoot, "packages", "coding-agent", "src", "defaults", "gjc", "skills", "ultragoal", "SKILL.md"),
+		).text();
+
+		// A: create-goals granularity — merge validation-coupled stories, fan out executor slices.
+		expect(ultragoal).toContain("validation-coupled");
+		expect(ultragoal).toContain("Merge validation-coupled stories into one goal");
+		expect(ultragoal).toContain("fan out executor slices");
+		expect(ultragoal).toContain("the same feature stack");
+		expect(ultragoal).toContain("the same red-team surface");
+		expect(ultragoal).toContain("the same final review boundary");
+
+		// B: validation-batch contract.
+		expect(ultragoal).toContain("## Validation batches (aggregate-only)");
+		expect(ultragoal).toContain("--validation-batch-json");
+		expect(ultragoal).toContain("aggregate-only");
+		expect(ultragoal).toContain("fail-closed");
+		expect(ultragoal).toContain("deferredToBatch");
+		expect(ultragoal).toContain("validation-batch-deferred");
+		expect(ultragoal).toContain("validationBatchClose");
+		expect(ultragoal).toContain("mutually exclusive");
+		expect(ultragoal).toContain("no batch/pipeline mixing");
+		expect(ultragoal).toContain("out-of-order close is rejected");
+		expect(ultragoal).toContain("append-only proof");
+		expect(ultragoal).toContain("Never stamp");
+		expect(ultragoal).toContain("cumulative-since-base");
+		expect(ultragoal).toContain("`cumulativeFromBase: true`");
+		expect(ultragoal).toContain("`memberGoalId` is a label not a per-path attribution");
+		expect(ultragoal).toContain("Batch invalidation is fail-closed");
+
+		// B: receipts freshness for deferred members.
+		expect(ultragoal).toContain(
+			"Deferred per-goal receipts (validation-batch members) are incomplete until a matching fresh batch-close receipt exists",
+		);
+
+		// C: intra-goal validation-lane parallelism.
+		expect(ultragoal).toContain("### Intra-goal validation-lane parallelism");
+		expect(ultragoal).toContain("frozen post-cleaner change set");
+		expect(ultragoal).toContain("architect review and the executor QA/red-team lane MAY run in parallel");
+		expect(ultragoal).toContain("join before checkpoint");
+		expect(ultragoal).toContain("Fall back to **sequential** lanes");
+		expect(ultragoal).toContain("red-team lane depends on architect fixes");
+	});
+
 	it("routes simple clear implementation requests directly without contradictory workflow escalation", async () => {
 		const systemPrompt = await Bun.file(
 			path.join(repoRoot, "packages", "coding-agent", "src", "prompts", "system", "system-prompt.md"),

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -18,6 +18,7 @@ import {
 	checkpointUltragoalGoal,
 	createUltragoalPlan,
 	getUltragoalStatus,
+	hashStructuredValue,
 	readUltragoalLedger,
 	readUltragoalPlan,
 	resolveGitBase,
@@ -396,6 +397,108 @@ function webExecutorQa(overrides: Record<string, unknown> = {}): Record<string, 
 async function passingLiveQualityGate(root: string): Promise<string> {
 	await writeStructuralArtifacts(root);
 	return passingQualityGate();
+}
+
+function batchChangeSetPaths(): Array<{ path: string; status: string }> {
+	return [
+		{ path: "packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts", status: "modified" },
+		{ path: "packages/coding-agent/src/gjc-runtime/ultragoal-guard.ts", status: "modified" },
+		{ path: "packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts", status: "added" },
+		{ path: "packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts", status: "modified" },
+		{ path: "packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md", status: "modified" },
+		{ path: "packages/coding-agent/test/default-gjc-definitions.test.ts", status: "modified" },
+		{ path: "packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json", status: "modified" },
+		{ path: "packages/coding-agent/src/gjc-runtime/workflow-manifest.ts", status: "modified" },
+	];
+}
+
+function deferredBatchGate(
+	goalId: string,
+	validationBatch: { batchId: string; memberIds: string[]; finalGoalId: string; metadataHash: string },
+): string {
+	const paths = batchChangeSetPaths();
+	return JSON.stringify({
+		deferredToBatch: {
+			schemaVersion: 1,
+			kind: "validation-batch-deferred",
+			batchId: validationBatch.batchId,
+			memberIds: validationBatch.memberIds,
+			finalGoalId: validationBatch.finalGoalId,
+			metadataHash: validationBatch.metadataHash,
+			deferredLanes: ["architectReview", "executorQa"],
+			targetedVerification: {
+				status: "passed",
+				commands: ["bun test validation batch"],
+				evidence: `Targeted verification passed for ${goalId}.`,
+			},
+			aiSlopCleaner: { status: "passed", evidence: `Cleaner found no blockers for ${goalId}.` },
+			iteration: {
+				status: "passed",
+				fullRerun: true,
+				rerunCommands: ["bun test validation batch"],
+				evidence: "Rerun passed after cleaner.",
+				blockers: [],
+			},
+			changeSet: {
+				memberGoalId: goalId,
+				cumulativeFromBase: true,
+				paths,
+				changeSetHash: hashStructuredValue(paths.map(row => ({ ...row, oldPath: undefined }))),
+			},
+		},
+	});
+}
+
+function batchCloseGate(plan: NonNullable<Awaited<ReturnType<typeof readUltragoalPlan>>>): string {
+	const finalGoal = plan.goals.find(goal => goal.id === "G003")!;
+	const validationBatch = finalGoal.validationBatch!;
+	const paths = batchChangeSetPaths();
+	const memberChangeSetHashes: Record<string, string> = {};
+	const memberMetadataHashes: Record<string, string> = {};
+	const memberReceipts = [];
+	for (const goal of plan.goals) {
+		memberMetadataHashes[goal.id] = goal.validationBatch!.metadataHash;
+		if (
+			goal.id !== validationBatch.finalGoalId &&
+			goal.completionVerification?.validationBatch?.role === "deferred-member"
+		) {
+			memberChangeSetHashes[goal.id] = goal.completionVerification.validationBatch.changeSetHash;
+			memberReceipts.push({
+				goalId: goal.id,
+				receiptId: goal.completionVerification.receiptId,
+				checkpointLedgerEventId: goal.completionVerification.checkpointLedgerEventId,
+				qualityGateHash: goal.completionVerification.qualityGateHash,
+				changeSetHash: goal.completionVerification.validationBatch.changeSetHash,
+				role: "deferred-member",
+			});
+		}
+	}
+	memberChangeSetHashes[validationBatch.finalGoalId] = hashStructuredValue(
+		paths.map(row => ({ ...row, oldPath: undefined })),
+	);
+	const baseGate = JSON.parse(passingQualityGate());
+	return JSON.stringify({
+		...baseGate,
+		validationBatchClose: {
+			schemaVersion: 1,
+			kind: "validation-batch-close",
+			batchId: validationBatch.batchId,
+			finalGoalId: validationBatch.finalGoalId,
+			memberIds: validationBatch.memberIds,
+			memberMetadataHashes,
+			memberReceipts,
+			unionChangeSet: {
+				source: "validation-batch",
+				memberChangeSetHashes,
+				paths,
+				unionHash: hashStructuredValue({
+					memberChangeSetHashes,
+					paths: paths.map(row => ({ ...row, oldPath: undefined })),
+				}),
+			},
+			coverageEvidence: "Union validation covered the validation batch.",
+		},
+	});
 }
 
 async function appendTestLedgerEntry(root: string, entry: Record<string, unknown>): Promise<void> {
@@ -825,6 +928,626 @@ describe("native GJC ultragoal runtime", () => {
 		});
 		expect(receipt).not.toHaveProperty("brief");
 		expect(receipt).not.toHaveProperty("goals");
+	});
+
+	it("validation batch: accepts valid --validation-batch-json and persists validationBatch on all members", async () => {
+		const root = await tempDir();
+		const metadata = JSON.stringify([
+			{ schemaVersion: 1, batchId: "VB001", memberIds: ["G003", "G001", "G002"], finalGoalId: "G003" },
+		]);
+
+		const create = await runNativeUltragoalCommand(
+			[
+				"create-goals",
+				"--brief",
+				"@goal: A\na\n@goal: B\nb\n@goal: C\nc",
+				"--validation-batch-json",
+				metadata,
+				"--json",
+			],
+			root,
+		);
+		const plan = await readUltragoalPlan(root);
+		const batches = plan?.goals.map(goal => goal.validationBatch);
+
+		expect(create.status).toBe(0);
+		expect(batches).toHaveLength(3);
+		expect(batches?.every(batch => batch !== undefined)).toBe(true);
+		expect(batches?.map(batch => batch?.memberIds)).toEqual([
+			["G001", "G002", "G003"],
+			["G001", "G002", "G003"],
+			["G001", "G002", "G003"],
+		]);
+		expect(batches?.map(batch => batch?.finalGoalId)).toEqual(["G003", "G003", "G003"]);
+		expect(new Set(batches?.map(batch => batch?.metadataHash))).toHaveProperty("size", 1);
+		expect(batches?.[0]).toMatchObject({ schemaVersion: 1, batchId: "VB001", mode: "aggregate-only" });
+	});
+
+	it("validation batch: rejects per-story mode", async () => {
+		const root = await tempDir();
+		const result = await runNativeUltragoalCommand(
+			[
+				"create-goals",
+				"--gjc-goal-mode",
+				"per-story",
+				"--brief",
+				"@goal: A\na\n@goal: B\nb",
+				"--validation-batch-json",
+				JSON.stringify([{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002"], finalGoalId: "G002" }]),
+			],
+			root,
+		);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("validation batches require aggregate ultragoal mode");
+	});
+
+	it("validation batch: rejects simultaneous --validation-batch-json and --goal-metadata-json", async () => {
+		const root = await tempDir();
+		const result = await runNativeUltragoalCommand(
+			[
+				"create-goals",
+				"--brief",
+				"@goal: A\na\n@goal: B\nb",
+				"--validation-batch-json",
+				JSON.stringify([{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002"], finalGoalId: "G002" }]),
+				"--goal-metadata-json",
+				JSON.stringify([
+					{
+						schemaVersion: 1,
+						goalId: "G001",
+						source: "original_plan_graph",
+						targets: { files: ["a.ts"], surfaces: ["a"] },
+					},
+				]),
+			],
+			root,
+		);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("--validation-batch-json and --goal-metadata-json are mutually exclusive");
+	});
+
+	it("validation batch: rejects invalid metadata", async () => {
+		const cases: Array<[string, string]> = [
+			[
+				JSON.stringify([{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G003"], finalGoalId: "G001" }]),
+				"unknown member G003",
+			],
+			[
+				JSON.stringify([{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G001"], finalGoalId: "G001" }]),
+				"duplicate memberIds",
+			],
+			[
+				JSON.stringify([{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001"], finalGoalId: "G002" }]),
+				"memberIds must contain finalGoalId G002",
+			],
+			[
+				JSON.stringify([
+					{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002"], finalGoalId: "G002" },
+					{ schemaVersion: 1, batchId: "VB002", memberIds: ["G002"], finalGoalId: "G002" },
+				]),
+				"belongs to more than one validation batch",
+			],
+		];
+		for (const [metadata, error] of cases) {
+			const root = await tempDir();
+			const result = await runNativeUltragoalCommand(
+				["create-goals", "--brief", "@goal: A\na\n@goal: B\nb", "--validation-batch-json", metadata],
+				root,
+			);
+			expect(result.status).toBe(1);
+			expect(result.stderr).toContain(error);
+		}
+
+		const root = await tempDir();
+		await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: A\na\n@goal: B\nb",
+			validationBatches: [{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002"], finalGoalId: "G002" }],
+		});
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const saved = JSON.parse(await Bun.file(goalsPath).text());
+		saved.goals[0].validationBatch.metadataHash = "stale";
+		await fs.writeFile(goalsPath, `${JSON.stringify(saved, null, 2)}\n`);
+
+		await expect(readUltragoalPlan(root)).rejects.toThrow("Goal G001 has stale validation batch metadata hash");
+	});
+
+	it("validation batch deferred: accepts deferred gate and rejects strict keys/uncovered paths", async () => {
+		const root = await tempDir();
+		await writeStructuralArtifacts(root);
+		const plan = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: A\na\n@goal: B\nb\n@goal: C\nc",
+			validationBatches: [
+				{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002", "G003"], finalGoalId: "G003" },
+			],
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G001",
+				status: "complete",
+				evidence: "fake strict gate",
+				qualityGateJson: JSON.stringify({
+					...JSON.parse(deferredBatchGate("G001", plan.goals[0]!.validationBatch!)),
+					architectReview: {},
+				}),
+			}),
+		).rejects.toThrow("unsupported keys");
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G001",
+				status: "complete",
+				evidence: "fake executor qa",
+				qualityGateJson: JSON.stringify({
+					...JSON.parse(deferredBatchGate("G001", plan.goals[0]!.validationBatch!)),
+					executorQa: { status: "passed" },
+				}),
+			}),
+		).rejects.toThrow("unsupported keys");
+		const uncovered = JSON.parse(deferredBatchGate("G001", plan.goals[0]!.validationBatch!));
+		uncovered.deferredToBatch.changeSet.paths = [
+			{ path: "packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts", status: "modified" },
+		];
+		uncovered.deferredToBatch.changeSet.changeSetHash = hashStructuredValue(
+			uncovered.deferredToBatch.changeSet.paths.map((row: Record<string, unknown>) => ({
+				...row,
+				oldPath: undefined,
+			})),
+		);
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G001",
+				status: "complete",
+				evidence: "uncovered path",
+				qualityGateJson: JSON.stringify(uncovered),
+			}),
+		).rejects.toThrow("does not cover computed checkpoint change-set path");
+		const accepted = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "targeted verification passed",
+			qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+		});
+		expect(accepted.goals[0]!.completionVerification?.validationBatch?.role).toBe("deferred-member");
+		expect(
+			validateCompletionReceipt({
+				plan: accepted,
+				ledger: await readUltragoalLedger(root),
+				goal: accepted.goals[0]!,
+				receiptKind: "per-goal",
+			}).state,
+		).toBe("active_missing_final_receipt");
+	});
+
+	it("validation batch close: rejects out-of-order, accepts close, keeps members deferred, and stales after member mutation", async () => {
+		const root = await tempDir();
+		await writeStructuralArtifacts(root);
+		let plan = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: A\na\n@goal: B\nb\n@goal: C\nc",
+			validationBatches: [
+				{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002", "G003"], finalGoalId: "G003" },
+			],
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "g001 deferred",
+			qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const saved = JSON.parse(await Bun.file(goalsPath).text());
+		saved.goals[2].status = "active";
+		await fs.writeFile(goalsPath, `${JSON.stringify(saved, null, 2)}\n`);
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G003",
+				status: "complete",
+				evidence: "premature close",
+				qualityGateJson: batchCloseGate(plan),
+			}),
+		).rejects.toThrow("cannot close before G002 is complete");
+		saved.goals[2].status = "pending";
+		await fs.writeFile(goalsPath, `${JSON.stringify(saved, null, 2)}\n`);
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G002",
+			status: "complete",
+			evidence: "g002 same cumulative path",
+			qualityGateJson: deferredBatchGate("G002", plan.goals[1]!.validationBatch!),
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G003",
+			status: "complete",
+			evidence: "batch close",
+			qualityGateJson: batchCloseGate(plan),
+		});
+		const ledger = await readUltragoalLedger(root);
+		expect(plan.goals[2]!.completionVerification?.validationBatch?.role).toBe("batch-close");
+		expect(plan.goals[0]!.completionVerification?.validationBatch?.role).toBe("deferred-member");
+		expect(
+			validateCompletionReceipt({ plan, ledger, goal: plan.goals[2]!, receiptKind: "final-aggregate" }).state,
+		).toBe("active_verified_complete");
+		expect(validateCompletionReceipt({ plan, ledger, goal: plan.goals[0]!, receiptKind: "per-goal" }).state).toBe(
+			"active_verified_complete",
+		);
+		plan.goals[0]!.updatedAt = new Date(Date.now() + 1000).toISOString();
+		expect(
+			validateCompletionReceipt({ plan, ledger, goal: plan.goals[2]!, receiptKind: "final-aggregate" }).state,
+		).toBe("active_stale_receipt");
+	});
+
+	it("validation batch idempotent replay rejects stale durable metadata before early return", async () => {
+		const root = await tempDir();
+		await writeStructuralArtifacts(root);
+		let plan = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: A\na\n@goal: B\nb\n@goal: C\nc",
+			validationBatches: [
+				{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002", "G003"], finalGoalId: "G003" },
+			],
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "g001 deferred",
+			qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+		});
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const saved = JSON.parse(await Bun.file(goalsPath).text());
+		saved.goals[0].validationBatch.memberIds = ["G001", "G003"];
+		await fs.writeFile(goalsPath, `${JSON.stringify(saved, null, 2)}\n`);
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G001",
+				status: "complete",
+				evidence: "g001 deferred",
+				qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+			}),
+		).rejects.toThrow("stale validation batch metadata hash");
+	});
+
+	it("validation batch idempotent replay rejects deleted durable metadata before early return", async () => {
+		const root = await tempDir();
+		await writeStructuralArtifacts(root);
+		let plan = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: A\na\n@goal: B\nb\n@goal: C\nc",
+			validationBatches: [
+				{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002", "G003"], finalGoalId: "G003" },
+			],
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "g001 deferred",
+			qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+		});
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const saved = JSON.parse(await Bun.file(goalsPath).text());
+		delete saved.goals[0].validationBatch;
+		await fs.writeFile(goalsPath, `${JSON.stringify(saved, null, 2)}\n`);
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G001",
+				status: "complete",
+				evidence: "g001 deferred",
+				qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+			}),
+		).rejects.toThrow("stale validation batch completion receipt");
+	});
+
+	it("validation batch close rejects receipt-stale deferred member", async () => {
+		const root = await tempDir();
+		await writeStructuralArtifacts(root);
+		let plan = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: A\na\n@goal: B\nb\n@goal: C\nc",
+			validationBatches: [
+				{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002", "G003"], finalGoalId: "G003" },
+			],
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "g001 deferred",
+			qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G002",
+			status: "complete",
+			evidence: "g002 deferred",
+			qualityGateJson: deferredBatchGate("G002", plan.goals[1]!.validationBatch!),
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const saved = JSON.parse(await Bun.file(goalsPath).text());
+		saved.goals[0].updatedAt = new Date(Date.now() + 1000).toISOString();
+		await fs.writeFile(goalsPath, `${JSON.stringify(saved, null, 2)}\n`);
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G003",
+				status: "complete",
+				evidence: "batch close",
+				qualityGateJson: batchCloseGate(plan),
+			}),
+		).rejects.toThrow("receipt generation is stale");
+	});
+
+	it("validation batch close idempotent replay rejects changed member basis", async () => {
+		const root = await tempDir();
+		await writeStructuralArtifacts(root);
+		let plan = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: A\na\n@goal: B\nb\n@goal: C\nc",
+			validationBatches: [
+				{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002", "G003"], finalGoalId: "G003" },
+			],
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "g001 deferred",
+			qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G002",
+			status: "complete",
+			evidence: "g002 deferred",
+			qualityGateJson: deferredBatchGate("G002", plan.goals[1]!.validationBatch!),
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G003",
+			status: "complete",
+			evidence: "batch close",
+			qualityGateJson: batchCloseGate(plan),
+		});
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const saved = JSON.parse(await Bun.file(goalsPath).text());
+		saved.goals[0].updatedAt = new Date(Date.now() + 1000).toISOString();
+		await fs.writeFile(goalsPath, `${JSON.stringify(saved, null, 2)}\n`);
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G003",
+				status: "complete",
+				evidence: "batch close",
+				qualityGateJson: batchCloseGate(plan),
+			}),
+		).rejects.toThrow("receipt generation is stale");
+	});
+
+	it("validation batch close idempotent replay rejects stale final receipt", async () => {
+		const root = await tempDir();
+		await writeStructuralArtifacts(root);
+		let plan = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: A\na\n@goal: B\nb\n@goal: C\nc",
+			validationBatches: [
+				{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002", "G003"], finalGoalId: "G003" },
+			],
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "g001 deferred",
+			qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G002",
+			status: "complete",
+			evidence: "g002 deferred",
+			qualityGateJson: deferredBatchGate("G002", plan.goals[1]!.validationBatch!),
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G003",
+			status: "complete",
+			evidence: "batch close",
+			qualityGateJson: batchCloseGate(plan),
+		});
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const saved = JSON.parse(await Bun.file(goalsPath).text());
+		saved.goals[2].updatedAt = new Date(Date.now() + 1000).toISOString();
+		await fs.writeFile(goalsPath, `${JSON.stringify(saved, null, 2)}\n`);
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G003",
+				status: "complete",
+				evidence: "batch close",
+				qualityGateJson: batchCloseGate(plan),
+			}),
+		).rejects.toThrow("receipt generation is stale");
+	});
+
+	it("validation batch close rejects member durable receipt when ledger payload differs", async () => {
+		const root = await tempDir();
+		await writeStructuralArtifacts(root);
+		let plan = await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: A\na\n@goal: B\nb\n@goal: C\nc",
+			validationBatches: [
+				{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002", "G003"], finalGoalId: "G003" },
+			],
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "g001 deferred",
+			qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		plan = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G002",
+			status: "complete",
+			evidence: "g002 deferred",
+			qualityGateJson: deferredBatchGate("G002", plan.goals[1]!.validationBatch!),
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const saved = JSON.parse(await Bun.file(goalsPath).text());
+		saved.goals[0].completionVerification.receiptId = "tampered-receipt-id";
+		await fs.writeFile(goalsPath, `${JSON.stringify(saved, null, 2)}\n`);
+		const tamperedPlan = (await readUltragoalPlan(root))!;
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G003",
+				status: "complete",
+				evidence: "batch close",
+				qualityGateJson: batchCloseGate(tamperedPlan),
+			}),
+		).rejects.toThrow("receipt ledger event is missing");
+	});
+
+	it("validation batch steering invalidation rejects after deferred receipt and allows before deferred receipt", async () => {
+		const splitArgs = [
+			"steer",
+			"--kind",
+			"split_subgoal",
+			"--goal-id",
+			"G002",
+			"--replacements-json",
+			JSON.stringify([
+				{ title: "Replacement A", objective: "Do replacement A." },
+				{ title: "Replacement B", objective: "Do replacement B." },
+			]),
+			"--evidence",
+			"batch member needs split",
+			"--rationale",
+			"split before validation is safe",
+			"--json",
+		];
+		const allowedRoot = await tempDir();
+		await createUltragoalPlan({
+			cwd: allowedRoot,
+			brief: "@goal: A\na\n@goal: B\nb\n@goal: C\nc",
+			validationBatches: [
+				{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002", "G003"], finalGoalId: "G003" },
+			],
+		});
+		const allowed = await runNativeUltragoalCommand(splitArgs, allowedRoot);
+		expect(allowed.status).toBe(0);
+		const allowedPlan = await readUltragoalPlan(allowedRoot);
+		expect(allowedPlan?.goals.find(goal => goal.id === "G001")?.validationBatch).toBeUndefined();
+		expect(allowedPlan?.goals.find(goal => goal.id === "G002")?.validationBatch).toBeUndefined();
+		expect(allowedPlan?.goals.find(goal => goal.id === "G003")?.validationBatch).toBeUndefined();
+		expect(allowedPlan?.goals.find(goal => goal.id === "G004")?.validationBatch).toBeUndefined();
+		await startNextUltragoalGoal({ cwd: allowedRoot });
+		const activeAfterClear = (await readUltragoalPlan(allowedRoot))!.goals.find(goal => goal.status === "active")!;
+		expect(activeAfterClear.validationBatch).toBeUndefined();
+		await expect(
+			checkpointUltragoalGoal({
+				cwd: allowedRoot,
+				goalId: activeAfterClear.id,
+				status: "complete",
+				evidence: "cannot force close",
+				qualityGateJson: JSON.stringify({ ...JSON.parse(passingQualityGate()), validationBatchClose: {} }),
+			}),
+		).rejects.toThrow("unsupported keys");
+
+		const rejectedRoot = await tempDir();
+		await writeStructuralArtifacts(rejectedRoot);
+		let plan = await createUltragoalPlan({
+			cwd: rejectedRoot,
+			brief: "@goal: A\na\n@goal: B\nb\n@goal: C\nc",
+			validationBatches: [
+				{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002", "G003"], finalGoalId: "G003" },
+			],
+		});
+		await startNextUltragoalGoal({ cwd: rejectedRoot });
+		plan = await checkpointUltragoalGoal({
+			cwd: rejectedRoot,
+			goalId: "G001",
+			status: "complete",
+			evidence: "g001 deferred",
+			qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+		});
+		const split = await runNativeUltragoalCommand(splitArgs, rejectedRoot);
+		expect(split.status).toBe(1);
+		expect(split.stderr).toContain("validation batch VB001");
+		expect(split.stderr).toContain("member G001");
+		const revise = await runNativeUltragoalCommand(
+			[
+				"steer",
+				"--kind",
+				"revise_pending_wording",
+				"--goal-id",
+				"G002",
+				"--title",
+				"Revised B",
+				"--evidence",
+				"batch member wording changed",
+				"--rationale",
+				"wording would invalidate batch",
+				"--json",
+			],
+			rejectedRoot,
+		);
+		expect(revise.status).toBe(1);
+		expect(revise.stderr).toContain("validation batch VB001");
+		await checkpointUltragoalGoal({
+			cwd: rejectedRoot,
+			goalId: "G003",
+			status: "blocked",
+			evidence: "final goal obsolete",
+		});
+		const supersede = await runNativeUltragoalCommand(
+			[
+				"steer",
+				"--kind",
+				"mark_blocked_superseded",
+				"--goal-id",
+				"G003",
+				"--evidence",
+				"final goal replacement requested",
+				"--rationale",
+				"supersede would invalidate batch",
+				"--json",
+			],
+			rejectedRoot,
+		);
+		expect(supersede.status).toBe(1);
+		expect(supersede.stderr).toContain("validation batch VB001");
 	});
 
 	it("stores explicit pipeline metadata and starts one eligible overlap", async () => {

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -406,6 +406,8 @@ function batchChangeSetPaths(): Array<{ path: string; status: string }> {
 		{ path: "packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts", status: "added" },
 		{ path: "packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts", status: "modified" },
 		{ path: "packages/coding-agent/src/defaults/gjc/skills/ultragoal/SKILL.md", status: "modified" },
+		{ path: "packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md", status: "modified" },
+		{ path: "packages/coding-agent/src/prompts/system/system-prompt.md", status: "modified" },
 		{ path: "packages/coding-agent/test/default-gjc-definitions.test.ts", status: "modified" },
 		{ path: "packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json", status: "modified" },
 		{ path: "packages/coding-agent/src/gjc-runtime/workflow-manifest.ts", status: "modified" },

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import { deflateSync } from "node:zlib";
 import {
@@ -1056,6 +1057,54 @@ describe("native GJC ultragoal runtime", () => {
 		await expect(readUltragoalPlan(root)).rejects.toThrow("Goal G001 has stale validation batch metadata hash");
 	});
 
+	it("validation batch deferred: uses CI changed paths when git diff is unavailable", async () => {
+		const savedChangedPaths = process.env.CI_DEV_CHANGED_PATHS;
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "ultragoal-runtime-ci-paths-"));
+		tempRoots.push(root);
+		process.env.CI_DEV_CHANGED_PATHS = batchChangeSetPaths()
+			.map(row => row.path)
+			.join("\n");
+		try {
+			await writeStructuralArtifacts(root);
+			const plan = await createUltragoalPlan({
+				cwd: root,
+				brief: "@goal: A\na\n@goal: B\nb\n@goal: C\nc",
+				validationBatches: [
+					{ schemaVersion: 1, batchId: "VB001", memberIds: ["G001", "G002", "G003"], finalGoalId: "G003" },
+				],
+			});
+			await startNextUltragoalGoal({ cwd: root });
+			const uncovered = JSON.parse(deferredBatchGate("G001", plan.goals[0]!.validationBatch!));
+			uncovered.deferredToBatch.changeSet.paths = [
+				{ path: "packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts", status: "modified" },
+			];
+			uncovered.deferredToBatch.changeSet.changeSetHash = hashStructuredValue(
+				uncovered.deferredToBatch.changeSet.paths.map((row: Record<string, unknown>) => ({
+					...row,
+					oldPath: undefined,
+				})),
+			);
+			await expect(
+				checkpointUltragoalGoal({
+					cwd: root,
+					goalId: "G001",
+					status: "complete",
+					evidence: "uncovered path",
+					qualityGateJson: JSON.stringify(uncovered),
+				}),
+			).rejects.toThrow("does not cover computed checkpoint change-set path");
+			await checkpointUltragoalGoal({
+				cwd: root,
+				goalId: "G001",
+				status: "complete",
+				evidence: "targeted verification passed",
+				qualityGateJson: deferredBatchGate("G001", plan.goals[0]!.validationBatch!),
+			});
+		} finally {
+			if (savedChangedPaths === undefined) delete process.env.CI_DEV_CHANGED_PATHS;
+			else process.env.CI_DEV_CHANGED_PATHS = savedChangedPaths;
+		}
+	});
 	it("validation batch deferred: accepts deferred gate and rejects strict keys/uncovered paths", async () => {
 		const root = await tempDir();
 		await writeStructuralArtifacts(root);


### PR DESCRIPTION
## Summary

Adds **aggregate-only validation batches** to ultragoal, per the ralplan-approved plan. Validation-coupled goals defer heavyweight architect + executor QA/red-team review to a single **final member**, while each non-final member still proves targeted verification + cleanup.

> ⚠️ **Stacked on #1701** (`feat/ultragoal-parllelism`). `dev` does not yet contain #1701, so this PR's diff includes the pipeline-scheduling commit `9d166345`. **Merge #1701 first**, then this PR's diff reduces to the validation-batch commit `b3d8f69d`. (Rebase/retarget onto the #1701 branch instead if preferred.)

## What ships
- **create-goals**: explicit `--validation-batch-json` flag + runtime input; durable hash-bound `goal.validationBatch` (aggregate-only); mutually exclusive with #1701 `--goal-metadata-json` at CLI + runtime.
- **checkpoint gate**: strict / deferred (`deferredToBatch`) / strict-with-close (`validationBatchClose`) validator split. Deferred gates never manufacture fake approvals; final close proves union coverage, rejects out-of-order close, and appends **no** extra ledger event (close state is receipt-only, never stamped on members).
- **receipt symmetry**: `receiptRelevantGoals` derives batch members from durable final-goal metadata; checkpoint-time and guard-time freshness now share one `ultragoal-receipt-freshness` module so they cannot drift.
- **guard**: story-scope deferred receipts stay blocked until a matching fresh batch-close receipt exists.
- **fail-closed**: idempotency validates batch metadata before the early return; steering that would invalidate a batch is rejected while any member holds a fresh deferred receipt (else the whole batch is cleared as a unit).
- change sets are **cumulative-since-base** (no per-goal path attribution).
- SKILL guidance (validation-coupled merge + intra-goal validation-lane parallelism), manifest flag, and focused tests.

## Resolved review items (from planning)
- **NEW-1**: cumulative-since-base change sets; `memberGoalId` is a label; `unionChangeSet.paths` carries no goalId.
- **NEW-2**: batch invalidation is fail-closed while deferred receipts exist.

## Verification (focused only; no project-wide runs)
- `bun test packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts` — 125 pass / 0 fail
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts` — 24 pass / 0 fail
- ultragoal-scoped regression suites (review/dogfood/durable-completion/nudge/pause guards): green (193 pass across 8 files)
- Architect review: initial BLOCK (3 P1 findings) → fixed (incl. the shared freshness module) → re-review **CLEAR / APPROVE**.

## Files
`ultragoal-runtime.ts`, `ultragoal-guard.ts`, new `ultragoal-receipt-freshness.ts`, `workflow-manifest.ts` (+ generated json), `skills/ultragoal/SKILL.md`, and the two focused test files.