### PR TITLE
fix(skill-tool): fail fast on glob/wildcard skill names

### DIFF
--- a/packages/coding-agent/src/prompts/tools/skill.md
+++ b/packages/coding-agent/src/prompts/tools/skill.md
@@ -16,6 +16,7 @@ Invoke another available skill in the current turn.
 <critical>
 - Do NOT use this tool to "remind yourself" of a skill you're already running. The current SKILL.md is already in your context.
 - Do NOT chain into the same skill recursively. If a skill's flow needs another iteration, follow its in-document instructions.
+- `name` MUST be one concrete skill name, NOT a glob or wildcard. Passing `*`, `?`, or a pattern like `git-*` is rejected immediately — the `--skills '*'` launch filter is unrelated to this tool's `name`.
 - The chained skill's planning/execution-boundary rules still apply. Chaining does not grant execution approval.
 </critical>
 

--- a/packages/coding-agent/src/tools/skill.ts
+++ b/packages/coding-agent/src/tools/skill.ts
@@ -37,6 +37,8 @@ function normalizeSkillName(name: string | undefined): string {
 	return (name ?? "").trim();
 }
 
+const SKILL_NAME_GLOB_PATTERN = /[*?[\]{}]/;
+
 type SkillToolInput = z.infer<typeof skillSchema>;
 
 export interface SkillToolDetails {
@@ -86,6 +88,19 @@ export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails
 			const requestedName = normalizeSkillName(input.name);
 			if (!requestedName) {
 				throw new ToolError("skill tool: `name` is required");
+			}
+			// Fail fast on glob/wildcard names (e.g. `*`). A model that sees the
+			// `--skills '*'` launch filter may echo the glob into the skill tool.
+			// Without this guard `*` slips through to the generic unknown-skill
+			// path only because no skill is literally named `*`, so a future
+			// odd skill name could get dispatched — and the actionable signal
+			// that names are concrete (not globs) is lost. Reject before any
+			// dispatch or handoff state mutation so the call ends immediately
+			// instead of spawning skill work that burns the whole turn budget.
+			if (SKILL_NAME_GLOB_PATTERN.test(requestedName)) {
+				throw new ToolError(
+					`skill tool: "${requestedName}" is not a valid skill name. The name must be a single concrete skill (e.g. "ralplan"), not a glob or wildcard pattern. Pass one exact skill name as shown in /skill:<name>.`,
+				);
 			}
 			const activeState = this.#session.getActiveSkillState?.();
 			const activeSkill = normalizeSkillName(activeState?.skill);

--- a/packages/coding-agent/test/tools/skill.test.ts
+++ b/packages/coding-agent/test/tools/skill.test.ts
@@ -185,6 +185,23 @@ describe("SkillTool", () => {
 		expect(content).not.toContain("User:");
 	});
 
+	it("rejects wildcard/glob skill names immediately without dispatching", async () => {
+		const cwd = await makeTempCwd();
+		const ultragoal = await makeSkill("ultragoal", "---\nname: ultragoal\n---\nBody");
+		const captured: CapturedSend[] = [];
+		const session = createSession(cwd, [ultragoal], captured, {
+			getActiveSkillState: () => ({ skill: "deep-interview", session_id: "s1" }),
+			getActiveSkillPhase: () => "interviewing",
+		});
+		const tool = SkillTool.createIf(session)!;
+
+		await expect(tool.execute("call-1", { name: "*" })).rejects.toBeInstanceOf(ToolError);
+		await expect(tool.execute("call-1", { name: "*" })).rejects.toThrow(/not a valid skill name/);
+		await expect(tool.execute("call-1", { name: "git-*" })).rejects.toThrow(/glob or wildcard/);
+		// Guard runs before the phase/handoff path, so no dispatch and no state I/O.
+		expect(captured).toHaveLength(0);
+	});
+
 	it("rejects chaining into the currently active skill (recursive-self guard)", async () => {
 		const cwd = await makeTempCwd();
 		const deepInterview = await makeSkill("deep-interview", "---\nname: deep-interview\n---\nBody");


### PR DESCRIPTION
## What

Make the `skill` tool fail fast when `name` is a glob/wildcard pattern such as `*`, `?`, or `git-*`. The tool now rejects invalid names before any skill dispatch or handoff state mutation, and the tool prompt documents that `name` must be one concrete skill name.

## Why

A model can see the `--skills '*'` launch filter and echo `*` into the `skill` tool's `name` argument. That bad call should terminate immediately. Without an explicit wildcard guard, the invalid request falls into less-specific handling and can lead to skill dispatch behavior that burns the whole turn or harness timeout instead of producing a fast, actionable tool error.

This change makes wildcard/glob skill names an explicit validation failure and prevents malformed `skill('*')`-style calls from spawning skill work.

## Testing

```bash
cd packages/coding-agent
bun test test/tools/skill.test.ts
```

Result: 21 pass, 0 fail.

Also ran Biome check on the changed TypeScript files:

```bash
bunx @biomejs/biome check packages/coding-agent/src/tools/skill.ts packages/coding-agent/test/tools/skill.test.ts
```

Result: no issues.

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)