### PR TITLE
Guard long-form media ingestion fallback

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -251,6 +251,13 @@ For image understanding, call `{{toolRefs.read}}` on the image path; the image i
 - For multi-file work, plan before editing and research existing conventions before writing new code.
 </scope>
 
+<media-ingestion>
+- For YouTube, podcasts, webinars, screen recordings, and other long-form video/audio tasks, separate source recovery from the requested deliverable. Do not let "recover the full transcript" silently replace the user's requested report, summary, or analysis.
+- First pass: identify available metadata, transcript/caption availability, and alternate evidence such as screenshots, user notes, public summaries, chapters, descriptions, comments, or partial clips.
+- If stable transcript/caption retrieval fails after two attempts or a short bounded pass, switch to the best available evidence and produce an evidence-scoped draft with explicit `Evidence used` and `Limitations`. Treat full transcript recovery as follow-up verification, not a prerequisite for all progress.
+- Never spend an extended turn repeatedly trying to ingest the same blocked video without producing an intermediate deliverable or asking for missing evidence.
+</media-ingestion>
+
 <before-editing>
 - Reuse existing patterns; parallel conventions are prohibited.
 {{#has tools "lsp"}}- Run `{{toolRefs.lsp}} references` before modifying exported symbols.{{/has}}

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -243,6 +243,21 @@ describe("system Handlebars prompt templates", () => {
 		expect(rendered).toContain("`job` remains the generic background-job tool");
 	});
 
+	test("system-prompt bounds long-form media ingestion before fallback drafting", async () => {
+		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+		const rendered = prompt.render(template, baseRenderContext);
+
+		expect(rendered).toContain("<media-ingestion>");
+		expect(rendered).toContain("For YouTube, podcasts, webinars, screen recordings");
+		expect(rendered).toContain("Do not let \"recover the full transcript\" silently replace");
+		expect(rendered).toContain("transcript/caption retrieval fails after two attempts");
+		expect(rendered).toContain("produce an evidence-scoped draft");
+		expect(rendered).toContain("Evidence used");
+		expect(rendered).toContain("Limitations");
+		expect(rendered).toContain("Never spend an extended turn repeatedly trying to ingest the same blocked video");
+	});
+
 	test("system-prompt distinguishes informational questions from explicit implementation requests", async () => {
 		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
 		const template = await Bun.file(templatePath).text();


### PR DESCRIPTION
## What

- Add a `<media-ingestion>` guard to the base coding-agent system prompt.
- Bound YouTube/long-form video/audio source recovery so blocked transcript retrieval falls back to evidence-scoped drafting instead of replacing the requested deliverable.
- Add a prompt rendering regression test for the new guidance.

## Why

Long-form media tasks can stall when the agent keeps trying to recover a full transcript before producing the requested report, summary, or analysis. This makes fallback behavior explicit: use metadata/partial evidence, state `Evidence used` and `Limitations`, and treat full transcript recovery as follow-up verification.

## Testing

- `bun test packages/coding-agent/test/system-prompt-templates.test.ts`

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
