### PR TITLE
Support more YouTube URL variants

### DIFF
--- a/packages/coding-agent/src/web/scrapers/youtube.ts
+++ b/packages/coding-agent/src/web/scrapers/youtube.ts
@@ -10,29 +10,38 @@ import { extractWithParallel, findParallelApiKey, getParallelExtractContent } fr
 import type { RenderResult, SpecialHandler } from "./types";
 import { buildResult, formatMediaDuration, formatNumber } from "./types";
 
-interface YouTubeUrl {
+export interface YouTubeUrl {
 	videoId: string;
 	playlistId?: string;
+}
+
+function isYouTubeHost(hostname: string): boolean {
+	return hostname === "youtube.com" || hostname === "m.youtube.com" || hostname === "music.youtube.com";
+}
+
+function isYouTubeEmbedHost(hostname: string): boolean {
+	return isYouTubeHost(hostname) || hostname === "youtube-nocookie.com";
 }
 
 /**
  * Parse YouTube URL into components
  */
-function parseYouTubeUrl(url: string): YouTubeUrl | null {
+export function parseYouTubeUrl(url: string): YouTubeUrl | null {
 	try {
 		const parsed = new URL(url);
 		const hostname = parsed.hostname.replace(/^www\./, "");
 
-		// youtube.com/watch?v=VIDEO_ID
-		if ((hostname === "youtube.com" || hostname === "m.youtube.com") && parsed.pathname === "/watch") {
+		// youtube.com/watch?v=VIDEO_ID and music.youtube.com/watch?v=VIDEO_ID
+		if (isYouTubeHost(hostname) && parsed.pathname === "/watch") {
 			const videoId = parsed.searchParams.get("v");
 			const playlistId = parsed.searchParams.get("list") || undefined;
-			if (videoId) return { videoId, playlistId };
+			if (videoId && /^[a-zA-Z0-9_-]{11}$/.test(videoId)) return { videoId, playlistId };
 		}
 
-		// youtube.com/v/VIDEO_ID or youtube.com/embed/VIDEO_ID
-		if (hostname === "youtube.com" || hostname === "m.youtube.com") {
-			const match = parsed.pathname.match(/^\/(v|embed)\/([a-zA-Z0-9_-]{11})/);
+		// youtube.com/v/VIDEO_ID, youtube.com/embed/VIDEO_ID, youtube.com/live/VIDEO_ID,
+		// and youtube-nocookie.com/embed/VIDEO_ID
+		if (isYouTubeEmbedHost(hostname)) {
+			const match = parsed.pathname.match(/^\/(v|embed|live)\/([a-zA-Z0-9_-]{11})/);
 			if (match) return { videoId: match[2] };
 		}
 
@@ -44,8 +53,8 @@ function parseYouTubeUrl(url: string): YouTubeUrl | null {
 			}
 		}
 
-		// youtube.com/shorts/VIDEO_ID
-		if (hostname === "youtube.com" && parsed.pathname.startsWith("/shorts/")) {
+		// youtube.com/shorts/VIDEO_ID and m.youtube.com/shorts/VIDEO_ID
+		if (isYouTubeHost(hostname) && parsed.pathname.startsWith("/shorts/")) {
 			const videoId = parsed.pathname.replace("/shorts/", "").split("/")[0];
 			if (videoId && /^[a-zA-Z0-9_-]{11}$/.test(videoId)) {
 				return { videoId };

--- a/packages/coding-agent/test/tools/web-scrapers/youtube.test.ts
+++ b/packages/coding-agent/test/tools/web-scrapers/youtube.test.ts
@@ -1,7 +1,26 @@
 import { describe, expect, it } from "bun:test";
-import { handleYouTube } from "@gajae-code/coding-agent/web/scrapers/youtube";
+import { handleYouTube, parseYouTubeUrl } from "@gajae-code/coding-agent/web/scrapers/youtube";
 
 const SKIP = !Bun.env.WEB_FETCH_INTEGRATION;
+
+describe("parseYouTubeUrl", () => {
+	const cases = [
+		["youtube live URLs", "https://www.youtube.com/live/dQw4w9WgXcQ?si=share"],
+		["music.youtube.com watch URLs", "https://music.youtube.com/watch?v=dQw4w9WgXcQ"],
+		["youtube-nocookie embed URLs", "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"],
+		["mobile shorts URLs", "https://m.youtube.com/shorts/dQw4w9WgXcQ"],
+	] as const;
+
+	for (const [label, url] of cases) {
+		it(`parses ${label}`, () => {
+			expect(parseYouTubeUrl(url)?.videoId).toBe("dQw4w9WgXcQ");
+		});
+	}
+
+	it("rejects lookalike YouTube hosts", () => {
+		expect(parseYouTubeUrl("https://youtube.com.evil.test/watch?v=dQw4w9WgXcQ")).toBeNull();
+	});
+});
 
 describe.skipIf(SKIP)("handleYouTube", () => {
 	it("returns null for non-YouTube URLs", async () => {


### PR DESCRIPTION
## What

- Teach the YouTube scraper URL parser to recognize common variants it previously missed:
  - `youtube.com/live/<videoId>`
  - `music.youtube.com/watch?v=<videoId>`
  - `youtube-nocookie.com/embed/<videoId>`
  - `m.youtube.com/shorts/<videoId>`
- Validate `watch?v=` IDs before accepting them.
- Add non-network parser coverage, including a lookalike-host rejection case.

## Why

These URLs point at normal YouTube videos, but the scraper only recognized the narrower watch/embed/v/shorts host set. Missing them makes the read path skip YouTube-specific handling and fall back to generic web reading.

## Testing

- `bun test packages/coding-agent/test/tools/web-scrapers/youtube.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun --cwd=packages/coding-agent run check`

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
