### PR TITLE
Fix YouTube URL variant parsing boundaries

### DIFF
--- a/packages/coding-agent/src/web/scrapers/youtube.ts
+++ b/packages/coding-agent/src/web/scrapers/youtube.ts
@@ -10,44 +10,56 @@ import { extractWithParallel, findParallelApiKey, getParallelExtractContent } fr
 import type { RenderResult, SpecialHandler } from "./types";
 import { buildResult, formatMediaDuration, formatNumber } from "./types";
 
-interface YouTubeUrl {
+export interface YouTubeUrl {
 	videoId: string;
 	playlistId?: string;
+}
+
+const YOUTUBE_VIDEO_ID_PATTERN = /^[a-zA-Z0-9_-]{11}$/;
+
+function isYouTubeHost(hostname: string): boolean {
+	return hostname === "youtube.com" || hostname === "m.youtube.com" || hostname === "music.youtube.com";
+}
+
+function isYouTubeEmbedHost(hostname: string): boolean {
+	return isYouTubeHost(hostname) || hostname === "youtube-nocookie.com";
 }
 
 /**
  * Parse YouTube URL into components
  */
-function parseYouTubeUrl(url: string): YouTubeUrl | null {
+export function parseYouTubeUrl(url: string): YouTubeUrl | null {
 	try {
 		const parsed = new URL(url);
 		const hostname = parsed.hostname.replace(/^www\./, "");
 
-		// youtube.com/watch?v=VIDEO_ID
-		if ((hostname === "youtube.com" || hostname === "m.youtube.com") && parsed.pathname === "/watch") {
+		// youtube.com/watch?v=VIDEO_ID and music.youtube.com/watch?v=VIDEO_ID
+		if (isYouTubeHost(hostname) && parsed.pathname === "/watch") {
 			const videoId = parsed.searchParams.get("v");
 			const playlistId = parsed.searchParams.get("list") || undefined;
-			if (videoId) return { videoId, playlistId };
+			if (videoId && YOUTUBE_VIDEO_ID_PATTERN.test(videoId)) return { videoId, playlistId };
 		}
 
-		// youtube.com/v/VIDEO_ID or youtube.com/embed/VIDEO_ID
-		if (hostname === "youtube.com" || hostname === "m.youtube.com") {
-			const match = parsed.pathname.match(/^\/(v|embed)\/([a-zA-Z0-9_-]{11})/);
+		// youtube.com/v/VIDEO_ID, youtube.com/embed/VIDEO_ID, youtube.com/live/VIDEO_ID,
+		// and youtube-nocookie.com/embed/VIDEO_ID. Require the id segment to end
+		// before matching so malformed overlong ids are not silently truncated.
+		if (isYouTubeEmbedHost(hostname)) {
+			const match = parsed.pathname.match(/^\/(v|embed|live)\/([a-zA-Z0-9_-]{11})(?:$|\/)/);
 			if (match) return { videoId: match[2] };
 		}
 
 		// youtu.be/VIDEO_ID
 		if (hostname === "youtu.be") {
 			const videoId = parsed.pathname.slice(1).split("/")[0];
-			if (videoId && /^[a-zA-Z0-9_-]{11}$/.test(videoId)) {
+			if (videoId && YOUTUBE_VIDEO_ID_PATTERN.test(videoId)) {
 				return { videoId };
 			}
 		}
 
-		// youtube.com/shorts/VIDEO_ID
-		if (hostname === "youtube.com" && parsed.pathname.startsWith("/shorts/")) {
+		// youtube.com/shorts/VIDEO_ID and m.youtube.com/shorts/VIDEO_ID
+		if (isYouTubeHost(hostname) && parsed.pathname.startsWith("/shorts/")) {
 			const videoId = parsed.pathname.replace("/shorts/", "").split("/")[0];
-			if (videoId && /^[a-zA-Z0-9_-]{11}$/.test(videoId)) {
+			if (videoId && YOUTUBE_VIDEO_ID_PATTERN.test(videoId)) {
 				return { videoId };
 			}
 		}

--- a/packages/coding-agent/test/tools/web-scrapers/youtube.test.ts
+++ b/packages/coding-agent/test/tools/web-scrapers/youtube.test.ts
@@ -1,7 +1,35 @@
 import { describe, expect, it } from "bun:test";
-import { handleYouTube } from "@gajae-code/coding-agent/web/scrapers/youtube";
+import { handleYouTube, parseYouTubeUrl } from "@gajae-code/coding-agent/web/scrapers/youtube";
 
 const SKIP = !Bun.env.WEB_FETCH_INTEGRATION;
+
+describe("parseYouTubeUrl", () => {
+	const validCases = [
+		["youtube live URLs", "https://www.youtube.com/live/dQw4w9WgXcQ?si=share"],
+		["music.youtube.com watch URLs", "https://music.youtube.com/watch?v=dQw4w9WgXcQ"],
+		["youtube-nocookie embed URLs", "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"],
+		["mobile shorts URLs", "https://m.youtube.com/shorts/dQw4w9WgXcQ"],
+	] as const;
+
+	for (const [label, url] of validCases) {
+		it(`parses ${label}`, () => {
+			expect(parseYouTubeUrl(url)?.videoId).toBe("dQw4w9WgXcQ");
+		});
+	}
+
+	const invalidCases = [
+		["lookalike host", "https://youtube.com.evil.test/watch?v=dQw4w9WgXcQ"],
+		["overlong live id", "https://www.youtube.com/live/dQw4w9WgXcQextra"],
+		["overlong embed id", "https://www.youtube.com/embed/dQw4w9WgXcQextra"],
+		["overlong nocookie embed id", "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQextra"],
+	] as const;
+
+	for (const [label, url] of invalidCases) {
+		it(`rejects ${label}`, () => {
+			expect(parseYouTubeUrl(url)).toBeNull();
+		});
+	}
+});
 
 describe.skipIf(SKIP)("handleYouTube", () => {
 	it("returns null for non-YouTube URLs", async () => {


### PR DESCRIPTION
## What

- Support common YouTube URL variants in the scraper parser:
  - `youtube.com/live/<videoId>`
  - `music.youtube.com/watch?v=<videoId>`
  - `youtube-nocookie.com/embed/<videoId>`
  - `m.youtube.com/shorts/<videoId>`
- Require exact 11-character video ids for `watch`, `youtu.be`, and `shorts`.
- Add an end-or-slash boundary after `/v`, `/embed`, and `/live` ids so overlong path segments are rejected instead of silently truncated.
- Add non-network parser tests for valid variants, lookalike hosts, and malformed overlong live/embed/nocookie ids.

## Why

Follow-up to #1727. The previous parser expansion correctly avoided arbitrary-host fetches because `handleYouTube` canonicalizes to `https://www.youtube.com/watch?v=<id>`, but the shared path regex accepted overlong live/embed/nocookie id segments by truncating to the first 11 characters. This version fixes that boundary issue and covers it with negative tests.

## Testing

- `bun test packages/coding-agent/test/tools/web-scrapers/youtube.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun --cwd=packages/coding-agent run check` (exit 0; reports existing Biome warning/info outside touched files)

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
