### PR TITLE
fix(task): reserve output ids from session artifacts

### DIFF
--- a/packages/coding-agent/src/task/output-manager.ts
+++ b/packages/coding-agent/src/task/output-manager.ts
@@ -14,6 +14,8 @@ function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+const RESERVED_OUTPUT_EXTENSIONS_PATTERN = "\\.(?:md|jsonl|patch)$";
+
 /**
  * Manages agent output ID allocation to ensure uniqueness.
  *
@@ -62,8 +64,8 @@ export class AgentOutputManager {
 		}
 
 		const pattern = this.#parentPrefix
-			? new RegExp(`^${escapeRegExp(this.#parentPrefix)}\\.(\\d+)-.*\\.md$`)
-			: /^(\d+)-.*\.md$/;
+			? new RegExp(`^${escapeRegExp(this.#parentPrefix)}\\.(\\d+)-.*${RESERVED_OUTPUT_EXTENSIONS_PATTERN}`)
+			: new RegExp(`^(\\d+)-.*${RESERVED_OUTPUT_EXTENSIONS_PATTERN}`);
 
 		let maxId = -1;
 		for (const file of files) {

--- a/packages/coding-agent/test/task/output-manager.test.ts
+++ b/packages/coding-agent/test/task/output-manager.test.ts
@@ -27,6 +27,13 @@ describe("AgentOutputManager", () => {
 		expect(await mgr.allocateBatch(["Alpha", "Beta"])).toEqual(["3-Alpha", "4-Beta"]);
 	});
 
+	it("reserves ids from child session files before markdown output exists", async () => {
+		const dir = await makeArtifactsDir(["0-Foo.jsonl"]);
+		const mgr = new AgentOutputManager(() => dir);
+
+		expect(await mgr.allocate("Bar")).toBe("1-Bar");
+	});
+
 	it("does not reuse or duplicate ids when allocations race on a shared instance", async () => {
 		// Regression: #ensureInitialized previously set a boolean flag BEFORE the
 		// awaited readdir, so a second concurrent allocate short-circuited init and
@@ -54,5 +61,12 @@ describe("AgentOutputManager", () => {
 		// peek observes the scanned cursor, not the pre-scan default of 0.
 		expect(peeked).toBeGreaterThanOrEqual(3);
 		expect(Number.parseInt(allocated.split("-")[0] ?? "", 10)).toBeGreaterThanOrEqual(3);
+	});
+
+	it("reserves nested ids from child session files before markdown output exists", async () => {
+		const dir = await makeArtifactsDir(["0-Parent.0-Foo.jsonl"]);
+		const mgr = new AgentOutputManager(() => dir, { parentPrefix: "0-Parent" });
+
+		expect(await mgr.allocate("Bar")).toBe("0-Parent.1-Bar");
 	});
 });


### PR DESCRIPTION
## Summary
- reserve task output ids from existing child session artifacts, not only final markdown outputs
- include nested parent-prefix session artifacts in resume scanning
- add regression coverage for .jsonl-reserved ids

## Tests
- bun test packages/coding-agent/test/task/output-manager.test.ts
- bun --cwd=packages/coding-agent run check