### PR TITLE
fix(notifications): harden config privacy boundaries

### DIFF
--- a/packages/coding-agent/src/notifications/config.ts
+++ b/packages/coding-agent/src/notifications/config.ts
@@ -38,13 +38,17 @@ export function getNotificationConfig(settings: Settings): NotificationConfig {
 	};
 }
 
+function hasText(value: string | undefined): boolean {
+	return !!value?.trim().length;
+}
+
 /** Is global config sufficient for auto-on (enabled + at least one configured adapter)? */
 export function isGloballyConfigured(cfg: NotificationConfig): boolean {
 	return (
 		cfg.enabled &&
-		((Boolean(cfg.botToken) && Boolean(cfg.chatId)) ||
-			(Boolean(cfg.discord.botToken) && Boolean(cfg.discord.channelId)) ||
-			(Boolean(cfg.slack.botToken) && Boolean(cfg.slack.channelId)))
+		((hasText(cfg.botToken) && hasText(cfg.chatId)) ||
+			(hasText(cfg.discord.botToken) && hasText(cfg.discord.channelId)) ||
+			(hasText(cfg.slack.botToken) && hasText(cfg.slack.channelId)))
 	);
 }
 
@@ -88,6 +92,7 @@ export function isSessionNotificationsEnabled(input: {
 /** Mask a bot token for display: first 4 chars + "…" + "(len N)"; "(unset)" when undefined/empty. Never reveal full token. */
 export function maskToken(token: string | undefined): string {
 	if (!token) return "(unset)";
+	if (token.length <= 4) return `${"•".repeat(token.length)}…(len ${token.length})`;
 	return `${token.slice(0, 4)}…(len ${token.length})`;
 }
 
@@ -131,6 +136,6 @@ export function buildRedactedAction(
 	// Asks stay fully readable/answerable even under redaction.
 	if (action.kind === "ask") return action;
 
-	const { summary: _summary, question: _question, ...base } = action;
+	const { summary: _summary, question: _question, options: _options, ...base } = action;
 	return base;
 }

--- a/packages/coding-agent/test/notifications-config-boundary.test.ts
+++ b/packages/coding-agent/test/notifications-config-boundary.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildRedactedAction,
+	isGloballyConfigured,
+	maskToken,
+	type NotificationConfig,
+	type RedactableAction,
+} from "../src/notifications/config";
+
+const BASE_CFG: NotificationConfig = {
+	enabled: true,
+	botToken: undefined,
+	chatId: undefined,
+	discord: {
+		botToken: undefined,
+		channelId: undefined,
+	},
+	slack: {
+		botToken: undefined,
+		channelId: undefined,
+	},
+	redact: false,
+	verbosity: "lean",
+	idleTimeoutMs: 60000,
+};
+
+describe("notification config privacy boundaries", () => {
+	test("does not treat whitespace-only adapter credentials as configured", () => {
+		expect(isGloballyConfigured({ ...BASE_CFG, botToken: "   ", chatId: "chat-1" })).toBe(false);
+		expect(isGloballyConfigured({ ...BASE_CFG, botToken: "token-1", chatId: "   " })).toBe(false);
+		expect(
+			isGloballyConfigured({
+				...BASE_CFG,
+				discord: { botToken: "   ", channelId: "discord-channel" },
+			}),
+		).toBe(false);
+		expect(
+			isGloballyConfigured({
+				...BASE_CFG,
+				slack: { botToken: "slack-token", channelId: "   " },
+			}),
+		).toBe(false);
+	});
+
+	test("maskToken does not reveal short tokens in full", () => {
+		expect(maskToken("abc")).toBe("•••…(len 3)");
+		expect(maskToken("abc")).not.toContain("abc");
+		expect(maskToken("abcd")).toBe("••••…(len 4)");
+		expect(maskToken("abcd")).not.toContain("abcd");
+	});
+
+	test("redacted non-ask actions drop option text", () => {
+		const action: RedactableAction = {
+			id: "i1",
+			kind: "idle",
+			sessionId: "session-abcdef",
+			question: "Sensitive question",
+			options: ["secret option"],
+			summary: "Sensitive idle summary",
+		};
+
+		expect(buildRedactedAction(action, { redact: true, sessionTag: "abcdef" })).toEqual({
+			id: "i1",
+			kind: "idle",
+			sessionId: "session-abcdef",
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- require non-blank notification adapter credentials before auto-enabling notification surfaces
- avoid fully revealing short bot tokens in display masks
- strip option text from redacted non-ask notification actions
- add a pure focused regression test for these privacy boundaries

## Tests
- bun test packages/coding-agent/test/notifications-config-boundary.test.ts
- bun --cwd=packages/coding-agent run check
- bun run check:ts