### PR TITLE
Fix OpenCode Go Kimi xhigh and forced tool_choice requests

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Capped OpenCode Go Kimi reasoning efforts that the Go chat-completions endpoint rejects (`xhigh`/`max` → `high`) and degraded forced `tool_choice` for those models so `opencode-go/kimi-k2.7-code:xhigh` sessions and title-generation turns no longer fail with generic upstream 400s.
+
 ## [0.8.2] - 2026-07-06
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -104,6 +104,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		baseUrl.includes("opencode.ai");
 	const isOpenCodeProvider = provider === "opencode-go" || provider === "opencode-zen";
 	const isOpenCodeGoReasoning = provider === "opencode-go" && Boolean(model.reasoning);
+	const isOpenCodeGoKimiReasoning = provider === "opencode-go" && isKimiModel && Boolean(model.reasoning);
 
 	const useMaxTokens =
 		provider === "mistral" ||
@@ -170,22 +171,30 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 					xhigh: "default",
 					max: "default",
 				} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
-			: isDeepseekFamily && model.reasoning
+			: isOpenCodeGoKimiReasoning
 				? ({
-						minimal: "high",
-						low: "high",
-						medium: "high",
-						high: "high",
-						xhigh: "max",
-						max: "max",
+						// OpenCode Go's Kimi chat-completions endpoint currently rejects
+						// the OpenAI-style "xhigh" and "max" effort literals with a generic
+						// upstream 400, while "minimal" through "high" are accepted.
+						xhigh: "high",
+						max: "high",
 					} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
-				: isFireworks
+				: isDeepseekFamily && model.reasoning
 					? ({
-							// Fireworks' OpenAI-compatible endpoint rejects OpenAI's
-							// `minimal` literal but accepts `none` for the lowest setting.
-							minimal: "none",
+							minimal: "high",
+							low: "high",
+							medium: "high",
+							high: "high",
+							xhigh: "max",
+							max: "max",
 						} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
-					: {};
+					: isFireworks
+						? ({
+								// Fireworks' OpenAI-compatible endpoint rejects OpenAI's
+								// `minimal` literal but accepts `none` for the lowest setting.
+								minimal: "none",
+							} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
+						: {};
 
 	return {
 		supportsStore: !isNonStandard,
@@ -198,7 +207,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		disableReasoningOnForcedToolChoice: isKimiModel || isAnthropicModel || isOpenCodeGoReasoning,
 		disableReasoningOnToolChoice: isDeepseekFamily && Boolean(model.reasoning) && !isOpenRouter,
 		supportsToolChoice: !isDirectDeepseekReasoning,
-		supportsForcedToolChoice: true,
+		supportsForcedToolChoice: !isOpenCodeGoKimiReasoning,
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
 		requiresToolResultName: isMistral,
 		requiresAssistantAfterToolResult: false,

--- a/packages/ai/test/issue-827-repro.test.ts
+++ b/packages/ai/test/issue-827-repro.test.ts
@@ -1,11 +1,9 @@
 /**
- * Repro for #827 — `opencode-go/kimi-k2.6` returns 400 with
- * `tool_choice 'specified' is incompatible with thinking enabled`
- * whenever the agent forces a tool call while reasoning is on.
- *
- * The fix follows the Anthropic pattern (`disableThinkingIfToolChoiceForced`)
- * — when a forced tool_choice is sent to a Kimi reasoning model, we strip
- * reasoning for that single turn rather than dropping `tool_choice` outright.
+ * Repro lineage for #827 — OpenCode Go Kimi models reject forced `tool_choice`
+ * while thinking is enabled. Later Go captures also showed generic upstream
+ * 400s for forced `tool_choice` even when reasoning was omitted, so the
+ * OpenCode Go Kimi path now degrades forced choices to auto/no explicit
+ * `tool_choice` instead of forwarding the forced directive.
  */
 import { afterEach, describe, expect, it } from "bun:test";
 import { getBundledModel } from "@gajae-code/ai/models";
@@ -82,17 +80,15 @@ interface CompletionsBody {
 	thinking?: unknown;
 }
 
-describe("issue #827 — kimi reasoning models drop reasoning under forced tool_choice", () => {
-	it("strips reasoning_effort when toolChoice is forced on direct Kimi (Moonshot-style id)", async () => {
+describe("issue #827 lineage — kimi reasoning models avoid incompatible forced tool_choice", () => {
+	it("omits forced tool_choice on OpenCode Go Kimi and keeps supported reasoning", async () => {
 		const body = (await captureBody(kimiOpencodeGoModel(), {
 			reasoning: "high",
 			toolChoice: "any",
 		})) as CompletionsBody;
 
-		// Forced choice still forwarded so the model must pick a tool…
-		expect(body.tool_choice).toBe("required");
-		// …but reasoning is suppressed to satisfy Kimi's "thinking incompatible with forced tool_choice" rule.
-		expect(body.reasoning_effort).toBeUndefined();
+		expect(body.tool_choice).toBeUndefined();
+		expect(body.reasoning_effort).toBe("high");
 	});
 
 	it("preserves reasoning_effort when toolChoice is auto", async () => {

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -511,6 +511,7 @@ describe("kimi model detection via detectCompat", () => {
 
 	async function captureOpenCodeGoPayload(
 		options: Parameters<typeof streamOpenAICompletions>[2],
+		modelId = "kimi-k2.7-code",
 	): Promise<Record<string, unknown>> {
 		const tool: Tool = {
 			name: "search",
@@ -519,7 +520,7 @@ describe("kimi model detection via detectCompat", () => {
 		};
 		const { promise, resolve } = Promise.withResolvers<unknown>();
 		streamOpenAICompletions(
-			getBundledModel("opencode-go", "kimi-k2.5") as Model<"openai-completions">,
+			getBundledModel("opencode-go", modelId) as Model<"openai-completions">,
 			{ ...baseContext(), tools: [tool] },
 			{
 				...options,
@@ -530,26 +531,27 @@ describe("kimi model detection via detectCompat", () => {
 		);
 		return (await promise) as Record<string, unknown>;
 	}
-	it("disables reasoning for forced tool_choice on official OpenCode Go models", () => {
-		const model = getBundledModel("opencode-go", "kimi-k2.5");
+	it("caps OpenCode Go Kimi reasoning effort and forced tool_choice support", () => {
+		const model = getBundledModel("opencode-go", "kimi-k2.7-code");
 		expect(model.provider).toBe("opencode-go");
 		expect(model.reasoning).toBe(true);
 
 		const compat = detectCompat(model as Model<"openai-completions">);
 
+		expect(compat.reasoningEffortMap).toMatchObject({ xhigh: "high", max: "high" });
 		expect(compat.disableReasoningOnForcedToolChoice).toBe(true);
+		expect(compat.supportsForcedToolChoice).toBe(false);
 	});
 
-	it("drops reasoning, not forced tool_choice, for OpenCode Go forced tool_choice payloads", async () => {
+	it("omits forced tool_choice for OpenCode Go Kimi payloads", async () => {
 		const payload = await captureOpenCodeGoPayload({
 			reasoning: "high",
 			toolChoice: { type: "function", function: { name: "search" } },
 		});
 
 		expect(payload.tools).toBeDefined();
-		expect(payload.tool_choice).toEqual({ type: "function", function: { name: "search" } });
-		expect(payload.reasoning_effort).toBeUndefined();
-		expect(payload.reasoning).toBeUndefined();
+		expect(payload.tool_choice).toBeUndefined();
+		expect(payload.reasoning_effort).toBe("high");
 	});
 
 	it("preserves reasoning for OpenCode Go auto tool_choice payloads", async () => {
@@ -558,6 +560,14 @@ describe("kimi model detection via detectCompat", () => {
 		expect(payload.tools).toBeDefined();
 		expect(payload.tool_choice).toBe("auto");
 		expect(payload.reasoning_effort).toBe("high");
+	});
+
+	it("maps OpenCode Go Kimi xhigh and max reasoning down to high", async () => {
+		const xhighPayload = await captureOpenCodeGoPayload({ reasoning: "xhigh", toolChoice: "auto" });
+		const maxPayload = await captureOpenCodeGoPayload({ reasoning: "max", toolChoice: "auto" });
+
+		expect(xhighPayload.reasoning_effort).toBe("high");
+		expect(maxPayload.reasoning_effort).toBe("high");
 	});
 
 	it("does not inject reasoning_content placeholder for kimi on opencode-go", () => {


### PR DESCRIPTION
## Summary

- Cap OpenCode Go Kimi `reasoning_effort` values that the Go chat-completions endpoint rejects: `xhigh` and `max` now map to `high`.
- Mark OpenCode Go Kimi as not supporting forced `tool_choice`, so title-generation and other forced-tool turns omit the explicit forced directive instead of sending a request shape that returns a generic upstream 400.
- Update the existing Kimi/OpenCode regression coverage and changelog.

## Context

Observed with `gjc/0.8.2` and `opencode-go/kimi-k2.7-code:xhigh`: the upstream returned `400 Error from provider (Console Go): Upstream request failed`. Local repro showed:

- `opencode-go/kimi-k2.7-code` succeeds
- `:minimal`, `:low`, `:medium`, and `:high` succeed
- `:xhigh` and `:max` fail with the same generic upstream 400
- title-generation forced `set_title` tool turns also fail when the explicit forced `tool_choice` is sent

## Testing

- `bun test packages/ai/test/openai-completions-compat.test.ts packages/ai/test/issue-827-repro.test.ts packages/ai/test/issue-887-repro.test.ts packages/ai/test/issue-489-repro.test.ts`
- `bun run check:tools`