### PR TITLE
fix(task): reserve output ids from sidecar artifacts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Task subagent output-ID allocation now reserves numeric prefixes from `.jsonl` session artifacts and `.patch` sidecars as well as final `.md` outputs, preventing resumed or partial subagent runs from reusing an existing artifact stem (#1733).
 - Restored `/changelog` as a built-in slash command, including autocomplete and `/changelog --full`/`/changelog full`, so the What's New prompt no longer points at a missing command.
 - Corrected the Extragoal template's read-only enforcement claim: the `--tools` allowlist governs the built-in tool surface, while the runtime injects the session `goal` tool (when `goal.enabled` is on) and `generate_image` (when an image credential exists) beyond it. Because goal's mutating ops persist session mode state, disabling it is now a mandatory gate precondition (`goal.enabled: false` in the review working directory's `.gjc/config.yml`), and reviewer calls outside the allowlist are gate-failing contract violations.
 - Corrected the GJC dogfood template's user-level install instructions (`docs/gjc-dogfood-skill-template.md`): the documented verbatim `cp` wrote to `~/.gjc/skills/`, which is not the user-level scan location (`~/.gjc/agent/skills/`), and left the YAML frontmatter mid-file, so the scan's required `description` never parsed and the installed skill was silently skipped. The template now documents the same frontmatter-first `sed` extraction into the scanned location that the Extragoal template ships with, pinned by `test/gjc-dogfood-template.test.ts`.

--- a/packages/coding-agent/src/task/output-manager.ts
+++ b/packages/coding-agent/src/task/output-manager.ts
@@ -14,6 +14,8 @@ function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+const RESERVED_OUTPUT_EXTENSIONS_PATTERN = "(?:md|jsonl|patch)";
+
 /**
  * Manages agent output ID allocation to ensure uniqueness.
  *
@@ -62,8 +64,8 @@ export class AgentOutputManager {
 		}
 
 		const pattern = this.#parentPrefix
-			? new RegExp(`^${escapeRegExp(this.#parentPrefix)}\\.(\\d+)-.*\\.md$`)
-			: /^(\d+)-.*\.md$/;
+			? new RegExp(`^${escapeRegExp(this.#parentPrefix)}\\.(\\d+)-.*\\.${RESERVED_OUTPUT_EXTENSIONS_PATTERN}$`)
+			: new RegExp(`^(\\d+)-.*\\.${RESERVED_OUTPUT_EXTENSIONS_PATTERN}$`);
 
 		let maxId = -1;
 		for (const file of files) {

--- a/packages/coding-agent/test/task/output-manager.test.ts
+++ b/packages/coding-agent/test/task/output-manager.test.ts
@@ -27,6 +27,24 @@ describe("AgentOutputManager", () => {
 		expect(await mgr.allocateBatch(["Alpha", "Beta"])).toEqual(["3-Alpha", "4-Beta"]);
 	});
 
+	it("reserves ids from session sidecar artifacts without markdown outputs", async () => {
+		const dir = await makeArtifactsDir(["0-Foo.jsonl", "1-Bar.patch"]);
+		const mgr = new AgentOutputManager(() => dir);
+
+		expect(await mgr.allocate("Alpha")).toBe("2-Alpha");
+	});
+
+	it("reserves nested child ids from sidecar artifacts under the parent prefix", async () => {
+		const dir = await makeArtifactsDir([
+			"0-Parent.0-Child.jsonl",
+			"0-Parent.1-Review.patch",
+			"1-Other.9-Ignored.jsonl",
+		]);
+		const mgr = new AgentOutputManager(() => dir, { parentPrefix: "0-Parent" });
+
+		expect(await mgr.allocate("Next")).toBe("0-Parent.2-Next");
+	});
+
 	it("does not reuse or duplicate ids when allocations race on a shared instance", async () => {
 		// Regression: #ensureInitialized previously set a boolean flag BEFORE the
 		// awaited readdir, so a second concurrent allocate short-circuited init and


### PR DESCRIPTION
## Summary

- Reserve task output numeric prefixes from `.jsonl` session files and `.patch` sidecar artifacts, in addition to final `.md` output files.
- Preserve nested parent-prefix allocation behavior for child subagent artifacts.
- Add regression coverage for sidecar-only and nested sidecar reservation cases.

Fixes #1733.

## Verification

- `bun test packages/coding-agent/test/task/output-manager.test.ts`
- `bun --cwd=packages/coding-agent run check` (passes; existing Biome warning/info remain in unrelated files `deep-interview-mutation-guard.ts` and `notifications/index.ts`)
- `bun run check:ts` (passes; same unrelated Biome warning/info)
