### PR TITLE
Fix OpenCode Go Kimi xhigh and forced tool_choice requests

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Capped OpenCode Go Kimi reasoning efforts that the Go chat-completions endpoint rejects (`kimi-k2.5:minimal` → `low`, `kimi-k2.7-code:xhigh|max` → `high`) and degraded forced `tool_choice` for those models so Kimi Go sessions and title-generation turns no longer fail with generic upstream 400s.
+
 ## [0.8.2] - 2026-07-06
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -104,6 +104,10 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		baseUrl.includes("opencode.ai");
 	const isOpenCodeProvider = provider === "opencode-go" || provider === "opencode-zen";
 	const isOpenCodeGoReasoning = provider === "opencode-go" && Boolean(model.reasoning);
+	const isOpenCodeGoKimiReasoning = provider === "opencode-go" && isKimiModel && Boolean(model.reasoning);
+	const isOpenCodeGoKimi25Reasoning = isOpenCodeGoKimiReasoning && model.id === "kimi-k2.5";
+	const isOpenCodeGoKimi27CodeReasoning = isOpenCodeGoKimiReasoning && model.id === "kimi-k2.7-code";
+	const needsOpenCodeGoKimiEffortMap = isOpenCodeGoKimi25Reasoning || isOpenCodeGoKimi27CodeReasoning;
 
 	const useMaxTokens =
 		provider === "mistral" ||
@@ -170,22 +174,31 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 					xhigh: "default",
 					max: "default",
 				} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
-			: isDeepseekFamily && model.reasoning
+			: needsOpenCodeGoKimiEffortMap
 				? ({
-						minimal: "high",
-						low: "high",
-						medium: "high",
-						high: "high",
-						xhigh: "max",
-						max: "max",
+						// Live Go probes (2026-07-06) showed model-specific effort gaps:
+						// kimi-k2.5 rejects "minimal", while kimi-k2.7-code rejects
+						// OpenAI-style "xhigh" and "max"; all other Kimi efforts tested
+						// successfully and should pass through unchanged.
+						...(isOpenCodeGoKimi25Reasoning ? { minimal: "low" } : {}),
+						...(isOpenCodeGoKimi27CodeReasoning ? { xhigh: "high", max: "high" } : {}),
 					} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
-				: isFireworks
+				: isDeepseekFamily && model.reasoning
 					? ({
-							// Fireworks' OpenAI-compatible endpoint rejects OpenAI's
-							// `minimal` literal but accepts `none` for the lowest setting.
-							minimal: "none",
+							minimal: "high",
+							low: "high",
+							medium: "high",
+							high: "high",
+							xhigh: "max",
+							max: "max",
 						} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
-					: {};
+					: isFireworks
+						? ({
+								// Fireworks' OpenAI-compatible endpoint rejects OpenAI's
+								// `minimal` literal but accepts `none` for the lowest setting.
+								minimal: "none",
+							} satisfies Partial<Record<OpenAIReasoningEffort, string>>)
+						: {};
 
 	return {
 		supportsStore: !isNonStandard,
@@ -198,7 +211,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		disableReasoningOnForcedToolChoice: isKimiModel || isAnthropicModel || isOpenCodeGoReasoning,
 		disableReasoningOnToolChoice: isDeepseekFamily && Boolean(model.reasoning) && !isOpenRouter,
 		supportsToolChoice: !isDirectDeepseekReasoning,
-		supportsForcedToolChoice: true,
+		supportsForcedToolChoice: !isOpenCodeGoKimiReasoning,
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
 		requiresToolResultName: isMistral,
 		requiresAssistantAfterToolResult: false,

--- a/packages/ai/test/issue-827-repro.test.ts
+++ b/packages/ai/test/issue-827-repro.test.ts
@@ -1,11 +1,9 @@
 /**
- * Repro for #827 — `opencode-go/kimi-k2.6` returns 400 with
- * `tool_choice 'specified' is incompatible with thinking enabled`
- * whenever the agent forces a tool call while reasoning is on.
- *
- * The fix follows the Anthropic pattern (`disableThinkingIfToolChoiceForced`)
- * — when a forced tool_choice is sent to a Kimi reasoning model, we strip
- * reasoning for that single turn rather than dropping `tool_choice` outright.
+ * Repro lineage for #827 — OpenCode Go Kimi models reject forced `tool_choice`
+ * while thinking is enabled. Later Go captures also showed generic upstream
+ * 400s for forced `tool_choice` even when reasoning was omitted, so the
+ * OpenCode Go Kimi path now degrades forced choices to auto/no explicit
+ * `tool_choice` instead of forwarding the forced directive.
  */
 import { afterEach, describe, expect, it } from "bun:test";
 import { getBundledModel } from "@gajae-code/ai/models";
@@ -36,14 +34,14 @@ function abortedSignal(): AbortSignal {
 	return controller.signal;
 }
 
-function kimiOpencodeGoModel(): Model<"openai-completions"> {
+function kimiOpencodeGoModel(id = "kimi-k2.6"): Model<"openai-completions"> {
 	return {
 		...getBundledModel("openai", "gpt-4o-mini"),
 		api: "openai-completions",
 		provider: "opencode-go",
 		baseUrl: "https://opencode.ai/zen/v1",
-		id: "kimi-k2.6",
-		name: "Kimi K2.6",
+		id,
+		name: id === "kimi-k2.7-code" ? "Kimi K2.7 Code" : id === "kimi-k2.5" ? "Kimi K2.5" : "Kimi K2.6",
 		reasoning: true,
 	};
 }
@@ -82,17 +80,17 @@ interface CompletionsBody {
 	thinking?: unknown;
 }
 
-describe("issue #827 — kimi reasoning models drop reasoning under forced tool_choice", () => {
-	it("strips reasoning_effort when toolChoice is forced on direct Kimi (Moonshot-style id)", async () => {
-		const body = (await captureBody(kimiOpencodeGoModel(), {
-			reasoning: "high",
-			toolChoice: "any",
-		})) as CompletionsBody;
+describe("issue #827 lineage — kimi reasoning models avoid incompatible forced tool_choice", () => {
+	it("omits forced tool_choice on every OpenCode Go Kimi variant and keeps supported reasoning", async () => {
+		for (const modelId of ["kimi-k2.5", "kimi-k2.6", "kimi-k2.7-code"]) {
+			const body = (await captureBody(kimiOpencodeGoModel(modelId), {
+				reasoning: "high",
+				toolChoice: "any",
+			})) as CompletionsBody;
 
-		// Forced choice still forwarded so the model must pick a tool…
-		expect(body.tool_choice).toBe("required");
-		// …but reasoning is suppressed to satisfy Kimi's "thinking incompatible with forced tool_choice" rule.
-		expect(body.reasoning_effort).toBeUndefined();
+			expect(body.tool_choice).toBeUndefined();
+			expect(body.reasoning_effort).toBe("high");
+		}
 	});
 
 	it("preserves reasoning_effort when toolChoice is auto", async () => {

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -511,6 +511,7 @@ describe("kimi model detection via detectCompat", () => {
 
 	async function captureOpenCodeGoPayload(
 		options: Parameters<typeof streamOpenAICompletions>[2],
+		modelId = "kimi-k2.7-code",
 	): Promise<Record<string, unknown>> {
 		const tool: Tool = {
 			name: "search",
@@ -519,7 +520,7 @@ describe("kimi model detection via detectCompat", () => {
 		};
 		const { promise, resolve } = Promise.withResolvers<unknown>();
 		streamOpenAICompletions(
-			getBundledModel("opencode-go", "kimi-k2.5") as Model<"openai-completions">,
+			getBundledModel("opencode-go", modelId) as Model<"openai-completions">,
 			{ ...baseContext(), tools: [tool] },
 			{
 				...options,
@@ -530,26 +531,40 @@ describe("kimi model detection via detectCompat", () => {
 		);
 		return (await promise) as Record<string, unknown>;
 	}
-	it("disables reasoning for forced tool_choice on official OpenCode Go models", () => {
-		const model = getBundledModel("opencode-go", "kimi-k2.5");
-		expect(model.provider).toBe("opencode-go");
-		expect(model.reasoning).toBe(true);
+	it("captures OpenCode Go Kimi effort gaps and forced tool_choice support per variant", () => {
+		const cases = [
+			{ id: "kimi-k2.5", effortMap: { minimal: "low" } },
+			{ id: "kimi-k2.6", effortMap: {} },
+			{ id: "kimi-k2.7-code", effortMap: { xhigh: "high", max: "high" } },
+		] as const;
 
-		const compat = detectCompat(model as Model<"openai-completions">);
+		for (const { id, effortMap } of cases) {
+			const model = getBundledModel("opencode-go", id);
+			expect(model.provider).toBe("opencode-go");
+			expect(model.reasoning).toBe(true);
 
-		expect(compat.disableReasoningOnForcedToolChoice).toBe(true);
+			const compat = detectCompat(model as Model<"openai-completions">);
+
+			expect(compat.reasoningEffortMap).toEqual(expect.objectContaining(effortMap));
+			expect(compat.disableReasoningOnForcedToolChoice).toBe(true);
+			expect(compat.supportsForcedToolChoice).toBe(false);
+		}
 	});
 
-	it("drops reasoning, not forced tool_choice, for OpenCode Go forced tool_choice payloads", async () => {
-		const payload = await captureOpenCodeGoPayload({
-			reasoning: "high",
-			toolChoice: { type: "function", function: { name: "search" } },
-		});
+	it("omits forced tool_choice for every OpenCode Go Kimi payload", async () => {
+		for (const modelId of ["kimi-k2.5", "kimi-k2.6", "kimi-k2.7-code"]) {
+			const payload = await captureOpenCodeGoPayload(
+				{
+					reasoning: "high",
+					toolChoice: { type: "function", function: { name: "search" } },
+				},
+				modelId,
+			);
 
-		expect(payload.tools).toBeDefined();
-		expect(payload.tool_choice).toEqual({ type: "function", function: { name: "search" } });
-		expect(payload.reasoning_effort).toBeUndefined();
-		expect(payload.reasoning).toBeUndefined();
+			expect(payload.tools).toBeDefined();
+			expect(payload.tool_choice).toBeUndefined();
+			expect(payload.reasoning_effort).toBe("high");
+		}
 	});
 
 	it("preserves reasoning for OpenCode Go auto tool_choice payloads", async () => {
@@ -558,6 +573,23 @@ describe("kimi model detection via detectCompat", () => {
 		expect(payload.tools).toBeDefined();
 		expect(payload.tool_choice).toBe("auto");
 		expect(payload.reasoning_effort).toBe("high");
+	});
+
+	it("maps only the OpenCode Go Kimi efforts rejected in live probes", async () => {
+		const k25MinimalPayload = await captureOpenCodeGoPayload(
+			{ reasoning: "minimal", toolChoice: "auto" },
+			"kimi-k2.5",
+		);
+		const k25MaxPayload = await captureOpenCodeGoPayload({ reasoning: "max", toolChoice: "auto" }, "kimi-k2.5");
+		const k26MaxPayload = await captureOpenCodeGoPayload({ reasoning: "max", toolChoice: "auto" }, "kimi-k2.6");
+		const k27XhighPayload = await captureOpenCodeGoPayload({ reasoning: "xhigh", toolChoice: "auto" });
+		const k27MaxPayload = await captureOpenCodeGoPayload({ reasoning: "max", toolChoice: "auto" });
+
+		expect(k25MinimalPayload.reasoning_effort).toBe("low");
+		expect(k25MaxPayload.reasoning_effort).toBe("max");
+		expect(k26MaxPayload.reasoning_effort).toBe("max");
+		expect(k27XhighPayload.reasoning_effort).toBe("high");
+		expect(k27MaxPayload.reasoning_effort).toBe("high");
 	});
 
 	it("does not inject reasoning_content placeholder for kimi on opencode-go", () => {


### PR DESCRIPTION
## Summary

- Add model-specific OpenCode Go Kimi effort compatibility based on live probes:
  - `kimi-k2.5:minimal` maps to `low`
  - `kimi-k2.7-code:xhigh|max` maps to `high`
  - other probed Kimi efforts pass through unchanged
- Mark OpenCode Go Kimi variants as not supporting forced `tool_choice`, so title-generation and other forced-tool turns omit the explicit forced directive instead of sending request shapes that return generic upstream 400s.
- Broaden regression coverage across all currently listed OpenCode Go Kimi models: `kimi-k2.5`, `kimi-k2.6`, and `kimi-k2.7-code`.

## Context / evidence

This retargets the previously closed main-base PR to `dev`.

OpenCode Go currently lists these Kimi models from `https://opencode.ai/zen/go/v1/models`:

- `kimi-k2.5`
- `kimi-k2.6`
- `kimi-k2.7-code`

The official OpenCode Go endpoint table lists Kimi K2.7 Code as model id `kimi-k2.7-code` on `https://opencode.ai/zen/go/v1/chat/completions`: https://opencode.ai/docs/go/#endpoints

Observed with `gjc/0.8.2` against the documented Go chat-completions route:

```text
400 Error from provider (Console Go): Upstream request failed
Error from provider (Console Go): Upstream request failed (type=invalid_request_error param=invalid_request_error)
```

The saved local request dump for the original failure showed the failing wire payload included:

```json
{
  "model": "kimi-k2.7-code",
  "url": "https://opencode.ai/zen/go/v1/chat/completions",
  "reasoning_effort": "xhigh"
}
```

Expanded local probe matrix for the same simple prompt with `--no-title --no-tools`:

| Model selection | Result |
| --- | --- |
| `opencode-go/kimi-k2.5:minimal` | 400 upstream request failed |
| `opencode-go/kimi-k2.5:low` | OK |
| `opencode-go/kimi-k2.5:medium` | OK |
| `opencode-go/kimi-k2.5:high` | OK |
| `opencode-go/kimi-k2.5:xhigh` | OK |
| `opencode-go/kimi-k2.5:max` | OK |
| `opencode-go/kimi-k2.6:minimal` | OK |
| `opencode-go/kimi-k2.6:low` | OK |
| `opencode-go/kimi-k2.6:medium` | OK |
| `opencode-go/kimi-k2.6:high` | OK |
| `opencode-go/kimi-k2.6:xhigh` | OK |
| `opencode-go/kimi-k2.6:max` | OK |
| `opencode-go/kimi-k2.7-code:minimal` | OK |
| `opencode-go/kimi-k2.7-code:low` | OK |
| `opencode-go/kimi-k2.7-code:medium` | OK |
| `opencode-go/kimi-k2.7-code:high` | OK |
| `opencode-go/kimi-k2.7-code:xhigh` | 400 upstream request failed |
| `opencode-go/kimi-k2.7-code:max` | 400 upstream request failed |

So the compatibility issue is model-specific rather than model availability. The patch only rewrites the observed rejected efforts and leaves accepted Kimi efforts untouched.

The forced `tool_choice` change covers the same OpenCode Go Kimi request-shape family observed in title-generation turns, where the endpoint rejected the explicit forced tool directive with a generic upstream 400. Regression tests now assert forced choices are omitted for `kimi-k2.5`, `kimi-k2.6`, and `kimi-k2.7-code`.

## Testing

- `bun test packages/ai/test/openai-completions-compat.test.ts packages/ai/test/issue-827-repro.test.ts packages/ai/test/issue-887-repro.test.ts packages/ai/test/issue-489-repro.test.ts`
- `bun run check:tools` (reports pre-existing warnings on `origin/dev`: `deep-interview-mutation-guard.ts` regex escape and `notifications/index.ts` optional-chain suggestion; no errors)