### PR TITLE
Repaint TUI viewport on tail shrink

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1783,6 +1783,11 @@ export class TUI extends Container {
 			return;
 		}
 
+		const nextLiveViewportTop = Math.max(0, newLines.length - height);
+		if (firstChanged >= newLines.length && nextLiveViewportTop !== prevViewportTop) {
+			viewportRepaint(`tail shrink changed viewport top (${prevViewportTop} -> ${nextLiveViewportTop})`);
+			return;
+		}
 		// All changes are in deleted lines (nothing to render, just clear)
 		if (firstChanged >= newLines.length) {
 			if (this.#previousLines.length > newLines.length) {

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -166,6 +166,28 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 
+		it("repaints live viewport when overflowed content shrinks only at the tail", async () => {
+			const term = new VirtualTerminal(20, 5);
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(rows("row-", 10));
+			tui.setClearOnShrink(false);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				expect(visible(term)).toEqual(["row-5", "row-6", "row-7", "row-8", "row-9"]);
+
+				component.setLines(rows("row-", 8));
+				tui.requestRender(false, "test.tail-shrink");
+				await settle(term);
+
+				expect(visible(term)).toEqual(["row-3", "row-4", "row-5", "row-6", "row-7"]);
+			} finally {
+				tui.stop();
+			}
+		});
+
 		it("clears row 0 when content shrinks to empty without clearOnShrink", async () => {
 			const term = new VirtualTerminal(40, 10);
 			const tui = new TUI(term);


### PR DESCRIPTION
## Summary

Fixes #1748.

When a tail-only shrink changes the live viewport top, the renderer now repaints the live viewport instead of taking the deleted-tail fast path that only clears old bottom rows. This keeps the physical screen aligned with the new live tail after small overflowed shrinks.

## Verification

- `bun test test/render-regressions.test.ts` in `packages/tui` → 31 pass
- `bun run check:types` in `packages/tui`
- `bunx biome check src/tui.ts test/render-regressions.test.ts`
- `git diff --check`
