### PR TITLE
Preserve viewport cursor on forced repaint

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -869,6 +869,7 @@ export class TUI extends Container {
 		}
 		if (renderMetrics.enabled) renderMetrics.recordRequest(source);
 		if (force) {
+			const preserveViewportCursor = useViewportRepaintPath();
 			// A forced full redraw supersedes any queued input-priority render.
 			this.#inputRenderPending = false;
 			this.#previousLines = [];
@@ -879,10 +880,12 @@ export class TUI extends Container {
 			this.#previousHeight = -1; // -1 triggers heightChanged, forcing a full clear
 			this.#lineNormalizationCacheLimit = 0;
 			this.#lineTruncationCacheLimit = 0;
-			this.#cursorRow = 0;
-			this.#hardwareCursorRow = 0;
-			this.#viewportTopRow = 0;
-			this.#maxLinesRendered = 0;
+			if (!preserveViewportCursor) {
+				this.#cursorRow = 0;
+				this.#hardwareCursorRow = 0;
+				this.#viewportTopRow = 0;
+				this.#maxLinesRendered = 0;
+			}
 			if (this.#renderTimer) {
 				clearTimeout(this.#renderTimer);
 				this.#renderTimer = undefined;

--- a/packages/tui/test/resize-replay-storm.test.ts
+++ b/packages/tui/test/resize-replay-storm.test.ts
@@ -94,6 +94,7 @@ describe("multiplexer resize replay storm regression", () => {
 			// now routes to viewport repaint: at most `rows` distinct lines, never the
 			// full 60-line transcript.
 			expect(distinctReplayedLineMarkers(out)).toBeLessThanOrEqual(term.rows + 2);
+			expect(out).toContain("\x1b[29A\r");
 
 			tui.stop();
 		});


### PR DESCRIPTION
## Summary

Preserves the known physical viewport cursor state when `requestRender(true)` is routed through the viewport repaint path in tmux/screen/Windows Terminal-style sessions.

Before this change, forced renders reset `#hardwareCursorRow` and `#viewportTopRow` to `0` without moving the real terminal cursor. The subsequent viewport repaint believed it was already at the screen top and started clearing/writing from the physical bottom row, which could scroll/duplicate the live viewport.

## Verification

- `bun test test/resize-replay-storm.test.ts` in `packages/tui` → 5 pass
- `bun run check:types` in `packages/tui`
- `bunx biome check src/tui.ts test/resize-replay-storm.test.ts`
- `git diff --check`
