### PR TITLE
Buffer split bracketed paste markers

### DIFF
--- a/packages/tui/src/bracketed-paste.ts
+++ b/packages/tui/src/bracketed-paste.ts
@@ -23,15 +23,32 @@ export class BracketedPasteHandler {
 	 *          paste has been assembled; omitted when still buffering.
 	 */
 	process(data: string): PasteResult {
-		if (data.includes(PASTE_START)) {
-			this.#active = true;
+		if (!this.#active) {
+			const hadBufferedPrefix = this.#buffer.length > 0;
+			const combined = this.#buffer + data;
 			this.#buffer = "";
-			data = data.replace(PASTE_START, "");
+
+			const startIndex = combined.indexOf(PASTE_START);
+			if (startIndex === -1) {
+				if (PASTE_START.startsWith(combined)) {
+					this.#buffer = combined;
+					return { handled: true, remaining: "" };
+				}
+				if (hadBufferedPrefix) {
+					return { handled: true, remaining: combined };
+				}
+				return { handled: false };
+			}
+
+			if (startIndex > 0) {
+				return { handled: false };
+			}
+
+			this.#active = true;
+			this.#buffer = combined.slice(PASTE_START.length);
+		} else {
+			this.#buffer += data;
 		}
-
-		if (!this.#active) return { handled: false };
-
-		this.#buffer += data;
 
 		const endIndex = this.#buffer.indexOf(PASTE_END);
 		if (endIndex === -1) return { handled: true, remaining: "" };

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1077,9 +1077,9 @@ export class Editor implements Component, Focusable {
 		if (paste.handled) {
 			if (paste.pasteContent !== undefined) {
 				this.#handlePaste(paste.pasteContent);
-				if (paste.remaining.length > 0) {
-					this.handleInput(paste.remaining);
-				}
+			}
+			if (paste.remaining.length > 0) {
+				this.handleInput(paste.remaining);
 			}
 			return;
 		}

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -68,9 +68,9 @@ export class Input implements Component, Focusable {
 		if (paste.handled) {
 			if (paste.pasteContent !== undefined) {
 				this.#handlePaste(paste.pasteContent);
-				if (paste.remaining.length > 0) {
-					this.handleInput(paste.remaining);
-				}
+			}
+			if (paste.remaining.length > 0) {
+				this.handleInput(paste.remaining);
 			}
 			return;
 		}

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2301,6 +2301,17 @@ describe("Editor component", () => {
 
 			expect(submitted).toBe(pastedText);
 		});
+
+		it("handles bracketed paste start markers split across input chunks", () => {
+			const editor = new Editor(defaultEditorTheme);
+
+			editor.handleInput("\x1b[200");
+			editor.handleInput("~hello");
+			expect(editor.getText()).toBe("");
+
+			editor.handleInput("\x1b[201~");
+			expect(editor.getText()).toBe("hello");
+		});
 	});
 
 	describe("Korean NFC paste normalization", () => {


### PR DESCRIPTION
## Summary

Buffers bracketed-paste start marker prefixes across input chunks before normal input handling.

`BracketedPasteHandler` documented that markers may arrive split, but it only recognized a complete `ESC[200~` in the current chunk. A split marker like `ESC[200` then `~hello` was processed as ordinary editor input instead of starting paste buffering.

This change buffers partial start-marker prefixes and lets `Editor`/`Input` process any non-paste remainder returned by the handler.

## Verification

- `bun test test/editor.test.ts` in `packages/tui` → 132 pass
- `bun run check:types` in `packages/tui`
- `bunx biome check src/bracketed-paste.ts src/components/editor.ts src/components/input.ts test/editor.test.ts`
- `git diff --check`
