### PR TITLE
Preserve input before bracketed paste

### DIFF
--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -348,6 +348,9 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 				for (const sequence of result.sequences) {
 					this.#emitDataSequence(sequence);
 				}
+				if (result.remainder.length > 0) {
+					this.#emitDataSequence(result.remainder);
+				}
 			}
 
 			this.#pendingKittyPrintableCodepoint = undefined;

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -292,6 +292,14 @@ describe("StdinBuffer", () => {
 			expect(emittedPaste).toEqual(["pasted"]);
 		});
 
+		it("emits incomplete input before a bracketed paste marker instead of dropping it", () => {
+			processInput("\x1b[<35\x1b[200~pasted\x1b[201~");
+
+			expect(emittedSequences).toEqual(["\x1b[<35"]);
+			expect(emittedPaste).toEqual(["pasted"]);
+			expect(buffer.getBuffer()).toBe("");
+		});
+
 		it("should handle paste with newlines", () => {
 			processInput("\x1b[200~line1\nline2\nline3\x1b[201~");
 


### PR DESCRIPTION
## Summary

Preserves incomplete input that appears immediately before a bracketed paste marker in `StdinBuffer`.

When `StdinBuffer` found `ESC[200~`, it emitted complete sequences before the marker but ignored `extractCompleteSequences(beforePaste).remainder`. That dropped partial input such as an incomplete SGR mouse/escape prefix if a paste marker arrived after it.

This change emits the remainder before entering paste mode so the input is retained instead of silently discarded.

## Verification

- `bun test test/stdin-buffer.test.ts` in `packages/tui` → 42 pass
- `bun run check:types` in `packages/tui`
- `bunx biome check src/stdin-buffer.ts test/stdin-buffer.test.ts`
- `git diff --check`
