### PR TITLE
fix: keep coding-agent tests hermetic

### DIFF
--- a/packages/coding-agent/test/agent-session-before-agent-start-attribution.test.ts
+++ b/packages/coding-agent/test/agent-session-before-agent-start-attribution.test.ts
@@ -51,6 +51,7 @@ describe("AgentSession before_agent_start attribution fallback", () => {
 		const extensionRunner = {
 			emitBeforeAgentStart,
 			emit: vi.fn().mockResolvedValue(undefined),
+			hasHandlers: vi.fn().mockReturnValue(false),
 		} as unknown as ExtensionRunner;
 
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");

--- a/packages/coding-agent/test/notify-setup.test.ts
+++ b/packages/coding-agent/test/notify-setup.test.ts
@@ -36,8 +36,14 @@ function makeFetch(results: Record<string, unknown[]>): { fetchImpl: typeof fetc
 	}) as typeof fetch;
 	return { fetchImpl, calls };
 }
-
+let captureOutputQueue: Promise<void> = Promise.resolve();
 async function captureOutput(run: () => Promise<void>): Promise<{ stdout: string; stderr: string }> {
+	const previous = captureOutputQueue;
+	let release!: () => void;
+	captureOutputQueue = new Promise<void>(resolve => {
+		release = resolve;
+	});
+	await previous;
 	const originalStdout = process.stdout.write.bind(process.stdout);
 	const originalStderr = process.stderr.write.bind(process.stderr);
 	let stdout = "";
@@ -55,6 +61,7 @@ async function captureOutput(run: () => Promise<void>): Promise<{ stdout: string
 	} finally {
 		process.stdout.write = originalStdout;
 		process.stderr.write = originalStderr;
+		release();
 	}
 	return { stdout, stderr };
 }
@@ -265,7 +272,7 @@ test("non-interactive setup with --token and --chat-id verifies private chat wit
 	}) as any;
 	const cmd = parseNotifyArgs(["notify", "setup", "--token", "123:abc", "--chat-id", "999", "--redact"]);
 	expect(cmd).toBeTruthy();
-	await runNotifyCommand(cmd!, { settings, fetchImpl, apiBase: "https://api.telegram.org" });
+	await captureOutput(() => runNotifyCommand(cmd!, { settings, fetchImpl, apiBase: "https://api.telegram.org" }));
 	const cfg = getNotificationConfig(settings);
 	expect(cfg.enabled).toBe(true);
 	expect(cfg.chatId).toBe("999");
@@ -284,9 +291,9 @@ test("non-interactive setup rejects non-private chat ids without writing config"
 		});
 		const cmd = parseNotifyArgs(["notify", "setup", "--token", "123:abc", "--chat-id", "-100"]);
 
-		await expect(runNotifyCommand(cmd!, { settings, fetchImpl, setupInteractive: false })).rejects.toThrow(
-			`Provided chat id -100 is a ${type} chat`,
-		);
+		await expect(
+			captureOutput(() => runNotifyCommand(cmd!, { settings, fetchImpl, setupInteractive: false })),
+		).rejects.toThrow(`Provided chat id -100 is a ${type} chat`);
 
 		expect(getNotificationConfig(settings).enabled).toBe(false);
 		expect(getNotificationConfig(settings).botToken).toBeUndefined();


### PR DESCRIPTION
## Summary
- Complete the mocked ExtensionRunner in `agent-session-before-agent-start-attribution.test.ts` so session event emission does not throw while focused tests are running.
- Capture all notify setup CLI output in `notify-setup.test.ts` and serialize the stdout/stderr capture helper so fake Telegram pairing prompts cannot leak across parallel test execution.

## Evidence
- Reproduced the focused offending test failure locally: `CI=1 GJC_NOTIFICATIONS=0 GJC_NOTIFICATIONS_TOKEN= bun test test/agent-session-before-agent-start-attribution.test.ts` failed on missing `hasHandlers`.
- `CI=1 GJC_NOTIFICATIONS=0 GJC_NOTIFICATIONS_TOKEN= bun test test/agent-session-before-agent-start-attribution.test.ts`
- `CI=1 GJC_NOTIFICATIONS=0 GJC_NOTIFICATIONS_TOKEN= bun test test/notify-setup.test.ts`
- `CI=1 GJC_NOTIFICATIONS=0 GJC_NOTIFICATIONS_TOKEN= bun test test/agent-session-before-agent-start-attribution.test.ts test/notify-setup.test.ts test/notifications-config.test.ts test/notifications-telegram-daemon.test.ts`
- `bun run check` from `packages/coding-agent` (passes with existing Biome warnings in unrelated files).

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*