### PR TITLE
Buffer split bracketed paste markers

### DIFF
--- a/packages/tui/src/bracketed-paste.ts
+++ b/packages/tui/src/bracketed-paste.ts
@@ -1,7 +1,10 @@
 const PASTE_START = "\x1b[200~";
 const PASTE_END = "\x1b[201~";
+const PASTE_PREFIX_TIMEOUT_MS = 10;
 
-export type PasteResult = { handled: false } | { handled: true; pasteContent?: string; remaining: string };
+export type PasteResult =
+	| { handled: false; data: string }
+	| { handled: true; pasteContent?: string; remaining: string; prefix?: string };
 
 /**
  * Handles bracketed paste mode buffering for terminal input components.
@@ -13,26 +16,94 @@ export type PasteResult = { handled: false } | { handled: true; pasteContent?: s
 export class BracketedPasteHandler {
 	#buffer = "";
 	#active = false;
+	#pendingStart = "";
+	#pendingStartTimer?: NodeJS.Timeout;
+	#timedOutStart = "";
+
+	constructor(private readonly onPendingStartTimeout?: (data: string) => void) {}
+
+	#findPendingStart(data: string): string {
+		for (let length = Math.min(PASTE_START.length - 1, data.length); length > 0; length--) {
+			const suffix = data.slice(data.length - length);
+			if (PASTE_START.startsWith(suffix)) return suffix;
+		}
+		return "";
+	}
+
+	#clearPendingStartTimer(): void {
+		if (this.#pendingStartTimer) {
+			clearTimeout(this.#pendingStartTimer);
+			this.#pendingStartTimer = undefined;
+		}
+	}
+
+	#clearPendingStart(): string {
+		this.#clearPendingStartTimer();
+		const pending = this.#pendingStart;
+		this.#pendingStart = "";
+		return pending;
+	}
+
+	#bufferPendingStart(pendingStart: string): void {
+		this.#pendingStart = pendingStart;
+		this.#clearPendingStartTimer();
+		const onTimeout = this.onPendingStartTimeout;
+		if (!onTimeout) return;
+		this.#pendingStartTimer = setTimeout(() => {
+			const timedOut = this.#clearPendingStart();
+			if (timedOut.length === 0) return;
+			this.#timedOutStart = timedOut;
+			onTimeout(timedOut);
+		}, PASTE_PREFIX_TIMEOUT_MS);
+	}
 
 	/**
 	 * Process incoming terminal data for bracketed paste sequences.
 	 *
-	 * @returns `{ handled: false }` if the data contains no paste sequence and
+	 * @returns `{ handled: false, data }` if the data contains no paste sequence and
 	 *          should be processed normally. `{ handled: true }` if the data was
 	 *          consumed by paste buffering — `pasteContent` is set when a complete
 	 *          paste has been assembled; omitted when still buffering.
 	 */
 	process(data: string): PasteResult {
-		if (data.includes(PASTE_START)) {
-			this.#active = true;
-			this.#buffer = "";
-			data = data.replace(PASTE_START, "");
+		if (this.#active) {
+			this.#buffer += data;
+			return this.#flushActivePaste();
 		}
 
-		if (!this.#active) return { handled: false };
+		if (this.#timedOutStart && data === this.#timedOutStart) {
+			this.#timedOutStart = "";
+			return { handled: false, data };
+		}
 
-		this.#buffer += data;
+		if (this.#pendingStart) {
+			this.#clearPendingStartTimer();
+			data = this.#pendingStart + data;
+			this.#pendingStart = "";
+		}
 
+		const startIndex = data.indexOf(PASTE_START);
+		if (startIndex !== -1) {
+			this.#active = true;
+			this.#buffer = data.slice(startIndex + PASTE_START.length);
+			const result = this.#flushActivePaste();
+			if (!result.handled) return result;
+			const prefix = data.slice(0, startIndex);
+			return prefix.length > 0 ? { ...result, prefix } : result;
+		}
+
+		const pendingStart = this.#findPendingStart(data);
+		if (pendingStart) {
+			this.#bufferPendingStart(pendingStart);
+			const normalData = data.slice(0, data.length - pendingStart.length);
+			if (normalData.length > 0) return { handled: false, data: normalData };
+			return { handled: true, remaining: "" };
+		}
+
+		return { handled: false, data };
+	}
+
+	#flushActivePaste(): PasteResult {
 		const endIndex = this.#buffer.indexOf(PASTE_END);
 		if (endIndex === -1) return { handled: true, remaining: "" };
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -467,7 +467,7 @@ export class Editor implements Component, Focusable {
 	#pasteCounter: number = 0;
 
 	// Bracketed paste mode buffering
-	#pasteHandler = new BracketedPasteHandler();
+	#pasteHandler = new BracketedPasteHandler(data => this.handleInput(data));
 
 	// Prompt history for up/down navigation
 	#history: string[] = [];
@@ -1117,6 +1117,10 @@ export class Editor implements Component, Focusable {
 	}
 
 	handleInput(data: string): void {
+		this.#handleInput(data, false);
+	}
+
+	#handleInput(data: string, skipPaste: boolean): void {
 		const kb = getKeybindings();
 
 		// Handle character jump mode (awaiting next character to jump to)
@@ -1139,16 +1143,22 @@ export class Editor implements Component, Focusable {
 			this.#jumpMode = null;
 		}
 
-		// Handle bracketed paste mode
-		const paste = this.#pasteHandler.process(data);
-		if (paste.handled) {
-			if (paste.pasteContent !== undefined) {
-				this.#handlePaste(paste.pasteContent);
-				if (paste.remaining.length > 0) {
-					this.handleInput(paste.remaining);
+		if (!skipPaste) {
+			// Handle bracketed paste mode
+			const paste = this.#pasteHandler.process(data);
+			if (paste.handled) {
+				if (paste.prefix) {
+					this.#handleInput(paste.prefix, true);
 				}
+				if (paste.pasteContent !== undefined) {
+					this.#handlePaste(paste.pasteContent);
+					if (paste.remaining.length > 0) {
+						this.handleInput(paste.remaining);
+					}
+				}
+				return;
 			}
-			return;
+			data = paste.data;
 		}
 
 		// Handle special key combinations first

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -42,7 +42,7 @@ export class Input implements Component, Focusable {
 	focused: boolean = false;
 
 	// Bracketed paste mode buffering
-	#pasteHandler = new BracketedPasteHandler();
+	#pasteHandler = new BracketedPasteHandler(data => this.handleInput(data));
 
 	// Kill ring for Emacs-style kill/yank operations
 	#killRing = new KillRing();
@@ -63,16 +63,26 @@ export class Input implements Component, Focusable {
 	}
 
 	handleInput(data: string): void {
-		// Handle bracketed paste mode
-		const paste = this.#pasteHandler.process(data);
-		if (paste.handled) {
-			if (paste.pasteContent !== undefined) {
-				this.#handlePaste(paste.pasteContent);
-				if (paste.remaining.length > 0) {
-					this.handleInput(paste.remaining);
+		this.#handleInput(data, false);
+	}
+
+	#handleInput(data: string, skipPaste: boolean): void {
+		if (!skipPaste) {
+			// Handle bracketed paste mode
+			const paste = this.#pasteHandler.process(data);
+			if (paste.handled) {
+				if (paste.prefix) {
+					this.#handleInput(paste.prefix, true);
 				}
+				if (paste.pasteContent !== undefined) {
+					this.#handlePaste(paste.pasteContent);
+					if (paste.remaining.length > 0) {
+						this.handleInput(paste.remaining);
+					}
+				}
+				return;
 			}
-			return;
+			data = paste.data;
 		}
 
 		const kb = getKeybindings();

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2078,6 +2078,37 @@ describe("Editor component", () => {
 			expect(editor.getCursor()).toEqual({ line: 0, col: 2 });
 		});
 
+		it("buffers a bracketed paste with a split start marker and handles remaining input", () => {
+			const editor = new Editor(defaultEditorTheme);
+
+			editor.handleInput("\x1b[200");
+			expect(editor.getText()).toBe("");
+
+			editor.handleInput("~hello");
+			expect(editor.getText()).toBe("");
+
+			editor.handleInput("\x1b[201~!");
+			expect(editor.getText()).toBe("hello!");
+		});
+		it("buffers a bracketed paste whose start marker is split after escape", () => {
+			const editor = new Editor(defaultEditorTheme);
+
+			editor.handleInput("\x1b");
+			expect(editor.getText()).toBe("");
+
+			editor.handleInput("[200~hello\x1b[201~!");
+			expect(editor.getText()).toBe("hello!");
+		});
+		it("preserves ordinary input before an incomplete paste marker in one chunk", () => {
+			const editor = new Editor(defaultEditorTheme);
+
+			editor.handleInput("ab\x1b[200~cd");
+			expect(editor.getText()).toBe("ab");
+
+			editor.handleInput("\x1b[201~ef");
+			expect(editor.getText()).toBe("abcdef");
+		});
+
 		it("undoes the last paste when a transient #undo trigger is executed", () => {
 			const editor = new Editor(defaultEditorTheme);
 

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -4,6 +4,7 @@ import { Input } from "@gajae-code/tui/components/input";
 import { setKittyProtocolActive } from "@gajae-code/tui/keys";
 import { visibleWidth } from "@gajae-code/tui/utils";
 import { getIndentation } from "@gajae-code/utils";
+import { BracketedPasteHandler } from "../src/bracketed-paste";
 
 function renderedWidth(input: Input, width: number): number {
 	const [line] = input.render(width);
@@ -180,6 +181,88 @@ describe("Input component", () => {
 
 		input.handleInput("c\x1b[201~");
 		expect(input.getValue()).toBe(`a${" ".repeat(getIndentation())}bc`);
+	});
+
+	it("buffers a bracketed paste whose start marker is split across chunks", () => {
+		const input = setupAtEnd("");
+
+		input.handleInput("\x1b[200");
+		expect(input.getValue()).toBe("");
+
+		input.handleInput("~hello");
+		expect(input.getValue()).toBe("");
+
+		input.handleInput("\x1b[201~!");
+		expect(input.getValue()).toBe("hello!");
+	});
+	it("buffers a bracketed paste whose start marker is split after escape", () => {
+		const input = setupAtEnd("");
+
+		input.handleInput("\x1b");
+		expect(input.getValue()).toBe("");
+
+		input.handleInput("[200~hello\x1b[201~!");
+		expect(input.getValue()).toBe("hello!");
+	});
+	it("preserves ordinary input before and after a complete paste marker in one chunk", () => {
+		const input = setupAtEnd("");
+
+		input.handleInput("ab\x1b[200~cd\x1b[201~ef");
+
+		expect(input.getValue()).toBe("abcdef");
+	});
+	it("preserves ordinary input before an incomplete paste marker in one chunk", () => {
+		const input = setupAtEnd("");
+
+		input.handleInput("ab\x1b[200~cd");
+		expect(input.getValue()).toBe("ab");
+
+		input.handleInput("\x1b[201~ef");
+		expect(input.getValue()).toBe("abcdef");
+	});
+
+	it("still handles a lone escape as cancel input", async () => {
+		const input = setupAtEnd("");
+		let escaped = false;
+		input.onEscape = () => {
+			escaped = true;
+		};
+
+		input.handleInput("\x1b");
+		expect(escaped).toBe(false);
+
+		await Bun.sleep(15);
+
+		expect(escaped).toBe(true);
+		expect(input.getValue()).toBe("");
+	});
+
+	it("releases a timed-out partial paste marker prefix back to normal input", async () => {
+		const input = setupAtEnd("");
+
+		input.handleInput("\x1b[200");
+		await Bun.sleep(15);
+		input.handleInput("x");
+
+		expect(input.getValue()).toBe("x");
+	});
+
+	it("returns a partial paste marker prefix when it stops matching the start marker", () => {
+		const handler = new BracketedPasteHandler();
+
+		expect(handler.process("\x1b[200")).toEqual({ handled: true, remaining: "" });
+		expect(handler.process("x")).toEqual({ handled: false, data: "\x1b[200x" });
+	});
+
+	it("calls the pending-prefix timeout callback", async () => {
+		const timedOut: string[] = [];
+		const handler = new BracketedPasteHandler(data => timedOut.push(data));
+
+		expect(handler.process("\x1b[200")).toEqual({ handled: true, remaining: "" });
+		await Bun.sleep(15);
+
+		expect(timedOut).toEqual(["\x1b[200"]);
+		expect(handler.process("x")).toEqual({ handled: false, data: "x" });
 	});
 
 	it("never renders a line wider than the terminal width (wide chars)", () => {


### PR DESCRIPTION
## Summary

Supersedes #1755.

Buffers bracketed-paste start marker prefixes across input chunks while preserving legacy non-paste behavior:

- split start marker chunks like `ESC` + `[200~hello` + `ESC[201~` or `ESC[200` + `~hello` + `ESC[201~` are assembled as one paste
- lone Escape is released on timeout and still reaches `Input.onEscape`
- partial start prefixes that time out are released back to normal input
- mismatched partial prefixes are returned to normal handling
- ordinary input before a paste marker and remaining input after a completed paste are preserved
- ordinary input before an incomplete paste marker is handled before the paste buffer starts

## Verification

- `bun test test/input.test.ts test/editor.test.ts` in `packages/tui` → 163 pass
- `bun run check:types` in `packages/tui`
- `bunx biome check src/bracketed-paste.ts src/components/editor.ts src/components/input.ts test/editor.test.ts test/input.test.ts`
- `git diff --check`
