### PR TITLE
Split multiline Editor insertText

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1819,18 +1819,7 @@ export class Editor implements Component, Focusable {
 	/** Insert text at the current cursor position */
 	insertText(text: string): void {
 		this.#exitHistoryForEditing();
-		this.#resetKillSequence();
-		this.#recordUndoState();
-
-		const line = this.#state.lines[this.#state.cursorLine] || "";
-		const inserted = insertTextNfcAt(line, this.#state.cursorCol, text);
-
-		this.#state.lines[this.#state.cursorLine] = inserted.line;
-		this.#setCursorCol(inserted.cursorCol);
-
-		if (this.onChange) {
-			this.onChange(this.getText());
-		}
+		this.#insertTextAtCursor(text);
 	}
 
 	// All the editor methods from before...

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -737,6 +737,28 @@ describe("Editor component", () => {
 
 			expect(editor.getText()).toBe("foo\tbar");
 		});
+		it("splits embedded newlines inserted through insertText", () => {
+			const editor = new Editor(defaultEditorTheme);
+			const changes: string[] = [];
+			editor.onChange = text => changes.push(text);
+
+			editor.insertText("a\nb");
+
+			expect(editor.getLines()).toEqual(["a", "b"]);
+			expect(editor.getCursor()).toEqual({ line: 1, col: 1 });
+			expect(changes).toEqual(["a\nb"]);
+		});
+
+		it("keeps suffix text after the final line when insertText inserts newlines mid-line", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("xz");
+			editor.handleInput("\x1b[D"); // Move between x and z
+
+			editor.insertText("a\r\nb\rc");
+
+			expect(editor.getLines()).toEqual(["xa", "b", "cz"]);
+			expect(editor.getCursor()).toEqual({ line: 2, col: 1 });
+		});
 
 		it("recomputes tab-containing input prefix width when the default tab width changes", () => {
 			try {


### PR DESCRIPTION
## Summary

Fixes the public `Editor.insertText(text)` path so embedded newlines create logical editor lines instead of being stored inside one line.

The public API now reuses the existing multiline cursor insertion path, preserving NFC/CRLF normalization, suffix placement on the final inserted line, cursor placement, undo bookkeeping, and one `onChange` notification.

## Verification

- `bun test test/editor.test.ts` in `packages/tui` → 139 pass
- `bun run check:types` in `packages/tui`
- `bunx biome check src/components/editor.ts test/editor.test.ts`
- `git diff --check`
