### PR TITLE
fix(agent,coding-agent): harden #1722 caches per review (ino-keyed drift check, bounded hash memo, suffix-equivalence test)

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -365,6 +365,16 @@ function stableCacheString(value: unknown): string | undefined {
 	}
 }
 
+/**
+ * Hash a message by full content serialization.
+ *
+ * Deliberately NOT memoized by object identity: callers mutate messages in
+ * place (compaction rewrites, obfuscation, abort markers) and the cache's
+ * correctness contract requires detecting those mutations. The per-turn
+ * serialization cost is the price of that contract; the win is skipping
+ * convertToLlm + normalize on stable contexts, which dominates for
+ * image-heavy histories.
+ */
 function hashMessageContent(message: AgentMessage): string | undefined {
 	return stableCacheString(message);
 }
@@ -419,6 +429,14 @@ async function convertAndNormalizeMessages(
 		if (stablePrefixLength === keys.messageHashes.length && stablePrefixLength === previous.messageHashes.length) {
 			return previous.normalizedMessages;
 		}
+		// Append-only fast path: convert only the new suffix and concatenate.
+		// CONTRACT: `convertToLlm` must be per-message (each output message
+		// derived solely from its input message). The bundled converters
+		// satisfy this — they map/filter message-by-message. A converter that
+		// merges adjacent messages or pairs across the suffix boundary would
+		// diverge from a full rebuild; such converters must not be combined
+		// with appendOnlyContext. Covered by the suffix-equivalence test in
+		// agent-loop-context-cache.test.ts.
 		if (
 			config.appendOnlyContext &&
 			stablePrefixLength === previous.messageHashes.length &&

--- a/packages/agent/test/agent-loop-context-cache.test.ts
+++ b/packages/agent/test/agent-loop-context-cache.test.ts
@@ -231,8 +231,10 @@ describe("agent loop converted context cache", () => {
 		const convertPerMessage = (messages: AgentMessage[]): Message[] =>
 			messages.filter((m): m is Message => m.role === "user" || m.role === "assistant" || m.role === "toolResult");
 
+		const userMessage = createUserMessage("do it");
+
 		// Incremental run: prefix cached, then suffix converted in isolation.
-		const incrementalContext = makeContext([createUserMessage("do it"), toolCalls, resultOne]);
+		const incrementalContext = makeContext([userMessage, toolCalls, resultOne]);
 		const incrementalCaptured: Context[] = [];
 		const incrementalConfig: AgentLoopConfig = {
 			model: mock.model,
@@ -244,7 +246,7 @@ describe("agent loop converted context cache", () => {
 		await runOnce(incrementalContext, incrementalConfig, incrementalCaptured);
 
 		// Cold run: identical messages converted in a single full pass.
-		const coldContext = makeContext([createUserMessage("do it"), toolCalls, resultOne, resultTwo]);
+		const coldContext = makeContext([userMessage, toolCalls, resultOne, resultTwo]);
 		const coldCaptured: Context[] = [];
 		const coldConfig: AgentLoopConfig = {
 			model: mock.model,

--- a/packages/agent/test/agent-loop-context-cache.test.ts
+++ b/packages/agent/test/agent-loop-context-cache.test.ts
@@ -189,4 +189,69 @@ describe("agent loop converted context cache", () => {
 		expect(convertSizes).toEqual([1, 1]);
 		expect(captured[1]!.messages[0]!.content).toBe("second transform");
 	});
+
+	it("append-only suffix conversion is equivalent to a full rebuild across tool-result boundaries", async () => {
+		const mock = createMockModel();
+		const toolCalls = {
+			role: "assistant" as const,
+			content: [
+				{ type: "toolCall" as const, id: "call-1", name: "read", arguments: { path: "a.ts" } },
+				{ type: "toolCall" as const, id: "call-2", name: "read", arguments: { path: "b.ts" } },
+			],
+			api: "mock",
+			provider: "mock",
+			model: "mock-model",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse" as const,
+			timestamp: Date.now(),
+		} as AgentMessage;
+		const makeToolResult = (id: string, text: string): AgentMessage =>
+			({
+				role: "toolResult" as const,
+				toolCallId: id,
+				toolName: "read",
+				content: [{ type: "text" as const, text }],
+				isError: false,
+				timestamp: Date.now(),
+			}) as AgentMessage;
+		const resultOne = makeToolResult("call-1", "contents of a.ts");
+		const resultTwo = makeToolResult("call-2", "contents of b.ts");
+
+		// The assistant tool-call message and the first result land in the
+		// cached prefix; the second result for the SAME assistant message
+		// arrives as the appended suffix. A per-message converter must produce
+		// identical output whether it saw the group together or split there.
+		const convertPerMessage = (messages: AgentMessage[]): Message[] =>
+			messages.filter((m): m is Message => m.role === "user" || m.role === "assistant" || m.role === "toolResult");
+
+		// Incremental run: prefix cached, then suffix converted in isolation.
+		const incrementalContext = makeContext([createUserMessage("do it"), toolCalls, resultOne]);
+		const incrementalCaptured: Context[] = [];
+		const incrementalConfig: AgentLoopConfig = {
+			model: mock.model,
+			appendOnlyContext: new AppendOnlyContextManager(),
+			convertToLlm: convertPerMessage,
+		};
+		await runOnce(incrementalContext, incrementalConfig, incrementalCaptured);
+		incrementalContext.messages.push(resultTwo);
+		await runOnce(incrementalContext, incrementalConfig, incrementalCaptured);
+
+		// Cold run: identical messages converted in a single full pass.
+		const coldContext = makeContext([createUserMessage("do it"), toolCalls, resultOne, resultTwo]);
+		const coldCaptured: Context[] = [];
+		const coldConfig: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: convertPerMessage,
+		};
+		await runOnce(coldContext, coldConfig, coldCaptured);
+
+		expect(incrementalCaptured[1]!.messages).toEqual(coldCaptured[0]!.messages);
+	});
 });

--- a/packages/coding-agent/src/extensibility/gjc-plugins/runtime-adapters.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/runtime-adapters.ts
@@ -17,6 +17,7 @@ interface FileSnapshot {
 	mtimeMs: number;
 	ctimeMs: number;
 	size: number;
+	ino: number;
 }
 
 interface ValidatedPluginRegistry {
@@ -35,12 +36,15 @@ interface CachedValidatedPluginRegistry extends ValidatedPluginRegistry {
 
 const validatedRegistryCache = new Map<string, CachedValidatedPluginRegistry>();
 const hashCache = new Map<string, string>();
+// Bound the digest memo so long sessions with plugin churn cannot grow it
+// unboundedly; entries are re-derivable from disk at the cost of one read.
+const HASH_CACHE_MAX_ENTRIES = 512;
 const registryScopes: GjcPluginScope[] = ["user", "project"];
 
 async function snapshotExistingFile(filePath: string): Promise<FileSnapshot | null> {
 	try {
 		const stat = await fs.stat(filePath);
-		return { path: filePath, mtimeMs: stat.mtimeMs, ctimeMs: stat.ctimeMs, size: stat.size };
+		return { path: filePath, mtimeMs: stat.mtimeMs, ctimeMs: stat.ctimeMs, size: stat.size, ino: stat.ino };
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return null;
 		throw error;
@@ -48,7 +52,7 @@ async function snapshotExistingFile(filePath: string): Promise<FileSnapshot | nu
 }
 
 function snapshotsKey(snapshots: readonly FileSnapshot[]): string {
-	return snapshots.map(s => `${s.path}:${s.mtimeMs}:${s.ctimeMs}:${s.size}`).join("|");
+	return snapshots.map(s => `${s.path}:${s.mtimeMs}:${s.ctimeMs}:${s.size}:${s.ino}`).join("|");
 }
 
 async function snapshotRegistryFiles(cwd: string): Promise<FileSnapshot[]> {
@@ -66,7 +70,7 @@ async function snapshotPluginFiles(entries: readonly GjcPluginRegistryEntry[]): 
 			const abs = path.join(entry.pluginRoot, file.relativePath);
 			const snapshot = await snapshotExistingFile(abs);
 			if (!snapshot) {
-				snapshots.push({ path: abs, mtimeMs: Number.NaN, ctimeMs: Number.NaN, size: Number.NaN });
+				snapshots.push({ path: abs, mtimeMs: Number.NaN, ctimeMs: Number.NaN, size: Number.NaN, ino: Number.NaN });
 			} else {
 				snapshots.push(snapshot);
 			}
@@ -80,10 +84,16 @@ function sha256(buf: Buffer): string {
 }
 
 async function hashFile(snapshot: FileSnapshot): Promise<string> {
-	const key = `${snapshot.path}:${snapshot.mtimeMs}:${snapshot.ctimeMs}:${snapshot.size}`;
+	const key = `${snapshot.path}:${snapshot.mtimeMs}:${snapshot.ctimeMs}:${snapshot.size}:${snapshot.ino}`;
 	const cached = hashCache.get(key);
 	if (cached) return cached;
 	const digest = sha256(await fs.readFile(snapshot.path));
+	if (hashCache.size >= HASH_CACHE_MAX_ENTRIES) {
+		// FIFO eviction is sufficient: the memo only avoids re-reads within a
+		// session; correctness never depends on a hit.
+		const oldest = hashCache.keys().next().value;
+		if (oldest !== undefined) hashCache.delete(oldest);
+	}
 	hashCache.set(key, digest);
 	return digest;
 }


### PR DESCRIPTION
Follow-up to the review comments on #1722 (merged before amendment, so this lands as a separate PR off dev).

## Changes

1. **Plugin hash-drift quarantine hardening** (`runtime-adapters.ts`): the digest memo trusted `path:mtimeMs:ctimeMs:size`. Adding `ino` to snapshot and hash-cache keys closes the replace-file vector (write same-size payload to a new inode, rename over, roll mtime back via `utimes()` — ctime protects in-place edits but a fresh inode gets fresh ctime that could coincide). Also bounds the previously unbounded module-level `hashCache` at 512 entries (FIFO; misses only cost one re-read).

2. **Append-only suffix-conversion contract** (`agent-loop.ts`): documented that the fast path requires `convertToLlm` to be per-message, and added a regression test proving incremental suffix conversion ≡ cold full rebuild when a tool-call/tool-result group is split at the cache boundary.

3. **Cache-key hashing cost**: investigated WeakMap memoization of per-message hashes; rejected because callers mutate messages in place (compaction rewrites, obfuscation, abort markers) and mutation detection is the cache's correctness contract — there is a dedicated test asserting in-place mutations invalidate. Documented the tradeoff at `hashMessageContent` instead.

## Verification

- `packages/agent` agent-loop-context-cache suite: 7 pass (new equivalence test included)
- `packages/coding-agent` gjc-plugin-runtime-adapters suite: 9 pass
- `tsgo --noEmit` clean for both packages; biome clean