### PR TITLE
Cancel stale autocomplete on submit

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2025,6 +2025,7 @@ export class Editor implements Component, Focusable {
 		this.#resetKillSequence();
 
 		const result = this.#expandPasteMarkers(this.#state.lines.join("\n")).trim();
+		this.#cancelAutocomplete();
 
 		this.#state = { lines: [""], cursorLine: 0, cursorCol: 0 };
 		this.#bumpDocumentVersion();

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -319,6 +319,50 @@ describe("Editor component", () => {
 			await expect(promise).resolves.toBe("@");
 		});
 
+		it("ignores late non-slash autocomplete suggestions after submit resets the editor", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const { promise, resolve } = Promise.withResolvers<{
+				items: Array<{ label: string; value: string }>;
+				prefix: string;
+			} | null>();
+			const submissions: string[] = [];
+			const applied: string[] = [];
+
+			editor.onSubmit = text => {
+				submissions.push(text);
+			};
+			editor.setAutocompleteProvider({
+				async getSuggestions() {
+					return promise;
+				},
+				applyCompletion(_lines, cursorLine, cursorCol, item, prefix) {
+					applied.push(`applied:${prefix}:${item.value}`);
+					return {
+						lines: [item.value],
+						cursorLine,
+						cursorCol,
+					};
+				},
+			});
+
+			editor.handleInput("#");
+			editor.handleInput("\r");
+
+			expect(submissions).toEqual(["#"]);
+			expect(editor.getText()).toBe("");
+
+			resolve({ prefix: "#", items: [{ label: "old", value: "old" }] });
+			await Bun.sleep(0);
+
+			expect(editor.isAutocompleteOpen()).toBe(false);
+			editor.disableSubmit = true;
+			editor.handleInput("\r");
+
+			expect(applied).toEqual([]);
+			expect(submissions).toEqual(["#"]);
+			expect(editor.getText()).toBe("");
+		});
+
 		it("chains into argument completions after tab-completing slash command names", async () => {
 			const editor = new Editor(defaultEditorTheme);
 			editor.setAutocompleteProvider(


### PR DESCRIPTION
## Summary

Prevents stale non-slash autocomplete results from reopening after the editor submits and resets.

Before this change, a pending `#` autocomplete request could resolve after submit, reopen suggestions on the empty editor, and let Enter apply the stale item.

## Changes

- cancel/invalidate autocomplete requests inside `#submitValue()` after capturing submitted text and before resetting state
- add a regression test where a pending `#` completion resolves after submit and must not open/apply

## Verification

- `bun test test/editor.test.ts` in `packages/tui` → 140 pass
- `bun run check:types` in `packages/tui`
- `bunx biome check src/components/editor.ts test/editor.test.ts`
- `git diff --check`
- additional repro probe: late `#` suggestions after submit keep autocomplete closed and cannot apply stale text
