### PR TITLE
test(utils): CLI 필수 인자/플래그 누락이 스택 트레이스 대신 사용법으로 처리되는지 회귀 테스트 추가 (#1759 후속)

### DIFF
--- a/packages/utils/test/cli.test.ts
+++ b/packages/utils/test/cli.test.ts
@@ -27,10 +27,37 @@ class Boom extends Command {
 	}
 }
 
+// Mirrors `gjc harness`: a single required positional "verb" and no required
+// flags — the exact shape that crashed with an uncaught "Missing required
+// argument" stack trace before run() learned to catch CliParseError.
+class Verbed extends Command {
+	static description = "requires a verb";
+	static args = {
+		verb: Args.string({ description: "verb", required: true }),
+	};
+	async run(): Promise<void> {
+		await this.parse(Verbed);
+		sideEffect.ran = true;
+	}
+}
+
+// Covers the sibling required-flag validation path.
+class Tokened extends Command {
+	static description = "requires a token";
+	static flags = {
+		token: Flags.string({ description: "token", required: true }),
+	};
+	async run(): Promise<void> {
+		await this.parse(Tokened);
+		sideEffect.ran = true;
+	}
+}
+
 const sideEffect: { ran: boolean; action?: string } = { ran: false };
 const commands: CommandEntry[] = [
 	{ name: "demo", load: async () => Demo },
 	{ name: "boom", load: async () => Boom },
+	{ name: "verbed", load: async () => Verbed },
 ];
 
 /** Run the CLI while capturing stdout/stderr and isolating process.exitCode. */
@@ -86,6 +113,18 @@ describe("cli parse — CliParseError for invalid input", () => {
 		await expect(cmd.parse(Strict)).rejects.toBeInstanceOf(CliParseError);
 	});
 
+	it("throws CliParseError when a required positional argument is missing (the `gjc harness` no-verb case)", async () => {
+		const cmd = new Verbed([], CFG);
+		await expect(cmd.parse(Verbed)).rejects.toBeInstanceOf(CliParseError);
+		await expect(cmd.parse(Verbed)).rejects.toThrow(/Missing required argument: verb/);
+	});
+
+	it("throws CliParseError when a required flag is missing", async () => {
+		const cmd = new Tokened([], CFG);
+		await expect(cmd.parse(Tokened)).rejects.toBeInstanceOf(CliParseError);
+		await expect(cmd.parse(Tokened)).rejects.toThrow(/Missing required flag: --token/);
+	});
+
 	it("accepts a valid action", async () => {
 		const cmd = new Demo(["build"], CFG);
 		const { args } = await cmd.parse(Demo);
@@ -109,6 +148,15 @@ describe("cli run — usage instead of uncaught crash", () => {
 		expect(sideEffect.ran).toBe(true);
 		expect(sideEffect.action).toBe("build");
 		expect(exitCode).toBe(0);
+	});
+
+	it("renders usage + exits 2 (no throw) when a required argument is missing (mirrors `gjc harness`)", async () => {
+		sideEffect.ran = false;
+		const { err, out, exitCode } = await runCapturing(["verbed"]);
+		expect(err).toContain("Missing required argument: verb");
+		expect(out.toLowerCase()).toContain("usage");
+		expect(exitCode).toBe(2);
+		expect(sideEffect.ran).toBe(false); // command body never ran
 	});
 
 	it("still propagates genuine (non-parse) runtime errors", async () => {

--- a/packages/utils/test/cli.test.ts
+++ b/packages/utils/test/cli.test.ts
@@ -58,6 +58,7 @@ const commands: CommandEntry[] = [
 	{ name: "demo", load: async () => Demo },
 	{ name: "boom", load: async () => Boom },
 	{ name: "verbed", load: async () => Verbed },
+	{ name: "tokened", load: async () => Tokened },
 ];
 
 /** Run the CLI while capturing stdout/stderr and isolating process.exitCode. */
@@ -154,6 +155,15 @@ describe("cli run — usage instead of uncaught crash", () => {
 		sideEffect.ran = false;
 		const { err, out, exitCode } = await runCapturing(["verbed"]);
 		expect(err).toContain("Missing required argument: verb");
+		expect(out.toLowerCase()).toContain("usage");
+		expect(exitCode).toBe(2);
+		expect(sideEffect.ran).toBe(false); // command body never ran
+	});
+
+	it("renders usage + exits 2 (no throw) when a required flag is missing", async () => {
+		sideEffect.ran = false;
+		const { err, out, exitCode } = await runCapturing(["tokened"]);
+		expect(err).toContain("Missing required flag: --token");
 		expect(out.toLowerCase()).toContain("usage");
 		expect(exitCode).toBe(2);
 		expect(sideEffect.ran).toBe(false); // command body never ran


### PR DESCRIPTION
#1759 리뷰(REQUEST_CHANGES) 반영 후속 PR입니다. #1759는 재오픈이 거부되어 동일 브랜치로 새로 엽니다.

`gjc harness`처럼 **필수 위치 인자를 하나도 주지 않고** 실행하면 `Missing required argument: verb`가 raw 스택 트레이스(`packages/utils/src/cli.ts` + Bun 소스 스니펫)로 터지던 크래시가 있었습니다. 이 크래시 자체는 `dev`에서 `CliParseError` + `run()`의 캐치(사용법 출력 후 exit 2)로 이미 고쳐졌지만, 그 회귀 테스트(`packages/utils/test/cli.test.ts`)는 "잘못된 옵션값 / 알 수 없는 플래그" 경로만 커버하고 "필수 인자 누락 / 필수 플래그 누락" 경로(`cli.ts` 라인 257/238)는 무방비였습니다.

이 PR은 그 두 분기를 parse 레벨과 run 레벨 모두에서 잠그는 회귀 테스트만 추가합니다. 소스 변경은 없습니다.

### 변경
- `packages/utils/test/cli.test.ts`
  - `Verbed`(required 위치 인자 1개, 필수 플래그 없음 — `gjc harness` 무-verb와 동일 형태), `Tokened`(required 플래그 1개) 테스트 커맨드 추가, 둘 다 `commands` 맵에 등록
  - parse 레벨: 필수 인자 누락 → `CliParseError`(`Missing required argument: verb`), 필수 플래그 누락 → `CliParseError`(`Missing required flag: --token`)
  - run 레벨: 필수 인자 누락(`runCapturing(["verbed"])`)과 필수 플래그 누락(`runCapturing(["tokened"])`) 모두 — 사용법을 stderr로 출력, exit 2, 커맨드 본문 미실행, 스택 트레이스 없음 (기존 invalid-option 테스트와 동일 계약)

### 테스트
- `bun test packages/utils/test/cli.test.ts` → 11 pass / 0 fail (기존 7 + 신규 4)
- red→green 의미성 검증: `cli.ts`의 required-arg/flag `throw new CliParseError(...)`를 임시로 plain `Error`로 되돌리면 해당 신규 테스트가 실패하며 `error: Missing required argument: verb`(cli.ts:257) / `error: Missing required flag: --token`(cli.ts:238)가 uncaught로 터짐 — 리포트된 크래시와 정확히 일치. 원복 후 전부 통과
- `@biomejs/biome@2.5.2 check packages/utils/test/cli.test.ts` 통과 (No fixes applied)
