### PR TITLE
fix(notifications): harden redaction config boundaries

### DIFF
--- a/packages/coding-agent/src/notifications/config.ts
+++ b/packages/coding-agent/src/notifications/config.ts
@@ -38,13 +38,17 @@ export function getNotificationConfig(settings: Settings): NotificationConfig {
 	};
 }
 
+function hasNonBlankValue(value: string | undefined): boolean {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
 /** Is global config sufficient for auto-on (enabled + at least one configured adapter)? */
 export function isGloballyConfigured(cfg: NotificationConfig): boolean {
 	return (
 		cfg.enabled &&
-		((Boolean(cfg.botToken) && Boolean(cfg.chatId)) ||
-			(Boolean(cfg.discord.botToken) && Boolean(cfg.discord.channelId)) ||
-			(Boolean(cfg.slack.botToken) && Boolean(cfg.slack.channelId)))
+		((hasNonBlankValue(cfg.botToken) && hasNonBlankValue(cfg.chatId)) ||
+			(hasNonBlankValue(cfg.discord.botToken) && hasNonBlankValue(cfg.discord.channelId)) ||
+			(hasNonBlankValue(cfg.slack.botToken) && hasNonBlankValue(cfg.slack.channelId)))
 	);
 }
 
@@ -88,6 +92,7 @@ export function isSessionNotificationsEnabled(input: {
 /** Mask a bot token for display: first 4 chars + "…" + "(len N)"; "(unset)" when undefined/empty. Never reveal full token. */
 export function maskToken(token: string | undefined): string {
 	if (!token) return "(unset)";
+	if (token.length <= 4) return `…(len ${token.length})`;
 	return `${token.slice(0, 4)}…(len ${token.length})`;
 }
 
@@ -131,6 +136,6 @@ export function buildRedactedAction(
 	// Asks stay fully readable/answerable even under redaction.
 	if (action.kind === "ask") return action;
 
-	const { summary: _summary, question: _question, ...base } = action;
+	const { summary: _summary, question: _question, options: _options, ...base } = action;
 	return base;
 }

--- a/packages/coding-agent/src/notifications/config.ts
+++ b/packages/coding-agent/src/notifications/config.ts
@@ -38,15 +38,22 @@ export function getNotificationConfig(settings: Settings): NotificationConfig {
 	};
 }
 
-function hasNonBlankValue(value: string | undefined): boolean {
+export function hasNonBlankValue(value: string | undefined): boolean {
 	return typeof value === "string" && value.trim().length > 0;
+}
+
+/** Is Telegram configured with usable non-blank boundary credentials? */
+export function isTelegramConfigured(
+	cfg: NotificationConfig,
+): cfg is NotificationConfig & { botToken: string; chatId: string } {
+	return cfg.enabled && hasNonBlankValue(cfg.botToken) && hasNonBlankValue(cfg.chatId);
 }
 
 /** Is global config sufficient for auto-on (enabled + at least one configured adapter)? */
 export function isGloballyConfigured(cfg: NotificationConfig): boolean {
 	return (
 		cfg.enabled &&
-		((hasNonBlankValue(cfg.botToken) && hasNonBlankValue(cfg.chatId)) ||
+		(isTelegramConfigured(cfg) ||
 			(hasNonBlankValue(cfg.discord.botToken) && hasNonBlankValue(cfg.discord.channelId)) ||
 			(hasNonBlankValue(cfg.slack.botToken) && hasNonBlankValue(cfg.slack.channelId)))
 	);

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -33,8 +33,8 @@ import { registerAskAnswerSource } from "../tools/ask-answer-registry";
 import { registerTelegramFileSink } from "./attachment-registry";
 import {
 	getNotificationConfig,
-	isGloballyConfigured,
 	isSessionNotificationsEnabled,
+	isTelegramConfigured,
 	type NotificationConfig,
 	sessionTag,
 } from "./config";
@@ -758,7 +758,7 @@ export function createNotificationsExtension(api: ExtensionAPI, options: { setti
 			});
 			logger.info(`notifications: serving session ${id} at ${endpoint.url} (unattended=${unattended})`);
 
-			if (settingsAvailable && settings && isGloballyConfigured(cfg)) {
+			if (settingsAvailable && settings && isTelegramConfigured(cfg)) {
 				try {
 					await ensureTelegramDaemonRunning({ settings, cwd: ctx.cwd, sessionId: id });
 				} catch (e) {
@@ -1147,7 +1147,7 @@ export function createNotificationsExtension(api: ExtensionAPI, options: { setti
 	api.on("message_update", (event, ctx) => {
 		const id = sessionId(ctx);
 		const rt = runtimes.get(id);
-		if (!rt || !rt.stream || rt.redact) return;
+		if (!rt?.stream || rt.redact) return;
 		if ((event.message as { role?: unknown }).role !== "assistant") return;
 		if (rt.liveRef === undefined) {
 			rt.turnSeq = (rt.turnSeq ?? 0) + 1;

--- a/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { YAML } from "bun";
 import type { Settings } from "../config/settings";
-import { getNotificationConfig, isGloballyConfigured } from "./config";
+import { getNotificationConfig, isTelegramConfigured } from "./config";
 import { daemonPaths } from "./daemon-paths";
 import type { TelegramDaemonOptions } from "./telegram-daemon";
 
@@ -146,7 +146,7 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 	const resolvedAgentDir = agentDir ?? process.env.GJC_CODING_AGENT_DIR ?? path.join(process.cwd(), ".gjc", "agent");
 	const settings = await resolveDaemonSettings(resolvedAgentDir, deps);
 	const cfg = getNotificationConfig(settings as Settings);
-	if (!isGloballyConfigured(cfg) || !cfg.botToken || !cfg.chatId) return;
+	if (!isTelegramConfigured(cfg)) return;
 	const { clearTelegramControlRequest, readTelegramControlRequest } = await import("./telegram-daemon-control");
 	const Daemon: TelegramDaemonConstructor =
 		deps.DaemonImpl ?? (await import("./telegram-daemon")).TelegramNotificationDaemon;

--- a/packages/coding-agent/src/notifications/telegram-daemon-control.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-control.ts
@@ -20,7 +20,7 @@ import type {
 	DaemonStatus,
 } from "../daemon/control-types";
 import { resolveGjcRuntimeSpawnInfo } from "../daemon/runtime";
-import { getNotificationConfig, isGloballyConfigured, tokenFingerprint } from "./config";
+import { getNotificationConfig, isTelegramConfigured, tokenFingerprint } from "./config";
 import {
 	daemonPaths,
 	isFreshLiveOwner,
@@ -159,7 +159,7 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 	async status(): Promise<DaemonStatus> {
 		const runtime = this.runtimeInfo();
 		const cfg = getNotificationConfig(this.settings);
-		const configured = isGloballyConfigured(cfg) && Boolean(cfg.botToken) && Boolean(cfg.chatId);
+		const configured = isTelegramConfigured(cfg);
 		if (!configured) {
 			return { kind: this.kind, configured: false, health: "not_configured", runtime };
 		}

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -8,7 +8,7 @@ import { withFileLock } from "../config/file-lock";
 import type { Settings } from "../config/settings";
 import type { DaemonRuntimeInfo } from "../daemon/control-types";
 import { resolveGjcRuntimeSpawnInfo } from "../daemon/runtime";
-import { getNotificationConfig, isGloballyConfigured, tokenFingerprint } from "./config";
+import { getNotificationConfig, isTelegramConfigured, tokenFingerprint } from "./config";
 import { parseInThreadConfigCommand } from "./config-commands";
 import { daemonPaths } from "./daemon-paths";
 import {
@@ -636,7 +636,7 @@ export async function ensureTelegramDaemonRunning(
 	deps: TelegramDaemonDeps = {},
 ): Promise<EnsureDaemonResult> {
 	const cfg = getNotificationConfig(input.settings);
-	if (!isGloballyConfigured(cfg) || !cfg.botToken || !cfg.chatId) return "disabled";
+	if (!isTelegramConfigured(cfg)) return "disabled";
 	const root = notificationRootForCwd(input.cwd);
 	const fp = tokenFingerprint(cfg.botToken);
 	const spawned = await spawnTelegramDaemonOwner(

--- a/packages/coding-agent/test/daemon-control.test.ts
+++ b/packages/coding-agent/test/daemon-control.test.ts
@@ -171,6 +171,24 @@ describe("TelegramDaemonController.status", () => {
 		expect(status.health).toBe("not_configured");
 	});
 
+	test("reports not_configured for blank Telegram credentials even when another adapter is configured", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(
+			Settings.isolated({
+				"notifications.enabled": true,
+				"notifications.telegram.botToken": " ",
+				"notifications.telegram.chatId": "\t",
+				"notifications.discord.botToken": "discord-token",
+				"notifications.discord.channelId": "discord-channel",
+			}) as Settings,
+			agentDir,
+		);
+		const status = await new TelegramDaemonController(s).status();
+
+		expect(status.configured).toBe(false);
+		expect(status.health).toBe("not_configured");
+	});
+
 	test("reports running for a fresh live owner and stale for a dead one", async () => {
 		const agentDir = tempAgentDir();
 		const s = settings(agentDir);

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -9,6 +9,7 @@ import {
 	getNotificationConfig,
 	isGloballyConfigured,
 	isSessionNotificationsEnabled,
+	isTelegramConfigured,
 	maskToken,
 	type NotificationConfig,
 	type RedactableAction,
@@ -17,6 +18,7 @@ import {
 	tokenFingerprint,
 } from "../src/notifications/config";
 import { createNotificationsExtension } from "../src/notifications/index";
+import { daemonPaths } from "../src/notifications/telegram-daemon";
 import { createAgentSession } from "../src/sdk";
 import { SessionManager } from "../src/session/session-manager";
 
@@ -125,6 +127,19 @@ describe("notifications config", () => {
 		).toBe(false);
 	});
 
+	test("isTelegramConfigured rejects blank Telegram credentials even when another adapter is configured", () => {
+		const mixedAdapterCfg: NotificationConfig = {
+			...BASE_CFG,
+			enabled: true,
+			botToken: " ",
+			chatId: "\t",
+			discord: { botToken: "discord-token", channelId: "discord-channel" },
+		};
+
+		expect(isGloballyConfigured(mixedAdapterCfg)).toBe(true);
+		expect(isTelegramConfigured(mixedAdapterCfg)).toBe(false);
+	});
+
 	test("isSessionNotificationsEnabled applies precedence", () => {
 		expect(
 			isSessionNotificationsEnabled({
@@ -200,6 +215,8 @@ describe("notifications config", () => {
 		delete process.env.GJC_NOTIFICATIONS;
 		const settings = Settings.isolated({
 			"notifications.enabled": true,
+			"notifications.telegram.botToken": " ",
+			"notifications.telegram.chatId": "\t",
 			"notifications.discord.botToken": "discord-token",
 			"notifications.discord.channelId": "discord-channel",
 		});
@@ -339,6 +356,7 @@ describe("notifications config", () => {
 			expect(fs.existsSync(parentPrefixSubagentEndpoint)).toBe(false);
 			expect(fs.existsSync(agentTypeOnlySubagentEndpoint)).toBe(false);
 			expect(fs.existsSync(explicitExtensionSubagentEndpoint)).toBe(false);
+			expect(fs.existsSync(daemonPaths(cwd).roots)).toBe(false);
 		} finally {
 			await Promise.all(disposers.reverse().map(dispose => dispose()));
 			if (previous === undefined) {

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -92,6 +92,16 @@ describe("notifications config", () => {
 		expect(isGloballyConfigured({ ...GLOBAL_CFG, botToken: "" })).toBe(false);
 		expect(isGloballyConfigured({ ...GLOBAL_CFG, chatId: undefined })).toBe(false);
 		expect(isGloballyConfigured({ ...GLOBAL_CFG, chatId: "" })).toBe(false);
+		expect(isGloballyConfigured({ ...GLOBAL_CFG, botToken: " " })).toBe(false);
+		expect(isGloballyConfigured({ ...GLOBAL_CFG, chatId: "\t" })).toBe(false);
+		expect(
+			isGloballyConfigured({
+				...BASE_CFG,
+				enabled: true,
+				botToken: " ",
+				chatId: "\t",
+			}),
+		).toBe(false);
 		expect(
 			isGloballyConfigured({
 				...BASE_CFG,
@@ -343,6 +353,8 @@ describe("notifications config", () => {
 	test("maskToken handles unset tokens and never reveals the raw token", () => {
 		expect(maskToken(undefined)).toBe("(unset)");
 		expect(maskToken("")).toBe("(unset)");
+		expect(maskToken("abc")).toBe("…(len 3)");
+		expect(maskToken("abc")).not.toContain("abc");
 
 		const token = "1234567890:super-secret-token";
 		const masked = maskToken(token);
@@ -388,6 +400,23 @@ describe("notifications config", () => {
 		};
 
 		expect(buildRedactedAction(action, { redact: false, sessionTag: "abcdef" })).toBe(action);
+	});
+
+	test("buildRedactedAction strips question and options for non-ask actions", () => {
+		const action: RedactableAction = {
+			id: "custom-1",
+			kind: "custom",
+			sessionId: "session-abcdef",
+			question: "Sensitive question?",
+			options: ["Sensitive option"],
+			summary: "Sensitive summary",
+		};
+
+		expect(buildRedactedAction(action, { redact: true, sessionTag: "abcdef" })).toEqual({
+			id: "custom-1",
+			kind: "custom",
+			sessionId: "session-abcdef",
+		});
 	});
 
 	test("buildRedactedAction strips only summary for idle actions", () => {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -131,6 +131,36 @@ describe("telegram daemon", () => {
 		expect(spawns).toBe(1);
 	});
 
+	test("ensureTelegramDaemonRunning ignores blank Telegram credentials when another adapter enables notifications", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(
+			Settings.isolated({
+				"notifications.enabled": true,
+				"notifications.telegram.botToken": " ",
+				"notifications.telegram.chatId": "\t",
+				"notifications.discord.botToken": "discord-token",
+				"notifications.discord.channelId": "discord-channel",
+			}) as Settings,
+			agentDir,
+		);
+		let spawns = 0;
+		const result = await ensureTelegramDaemonRunning(
+			{ settings: s, cwd: path.join(agentDir, "cwd"), sessionId: "s1" },
+			{
+				spawn: () => {
+					spawns++;
+					return { unref() {} };
+				},
+				pidAlive: () => true,
+				pid: 111,
+			},
+		);
+
+		expect(result).toBe("disabled");
+		expect(spawns).toBe(0);
+		expect(fs.existsSync(daemonPaths(agentDir).roots)).toBe(false);
+	});
+
 	test("concurrent root registrations persist every root", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
@@ -389,6 +419,36 @@ describe("telegram daemon", () => {
 		};
 		expect(state.pid).toBe(222);
 		expect(state.ownerId).toBe("owner");
+	});
+
+	test("runDaemonInternal exits before constructing daemon for blank Telegram credentials with another adapter configured", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(
+			Settings.isolated({
+				"notifications.enabled": true,
+				"notifications.telegram.botToken": " ",
+				"notifications.telegram.chatId": "\t",
+				"notifications.discord.botToken": "discord-token",
+				"notifications.discord.channelId": "discord-channel",
+			}) as Settings,
+			agentDir,
+		);
+		let daemonConstructed = false;
+		class StubDaemon {
+			constructor() {
+				daemonConstructed = true;
+			}
+			async run(): Promise<void> {}
+			requestStop(): void {}
+		}
+
+		await runDaemonInternal(["--agent-dir", agentDir, "--owner-id", "owner"], {
+			SettingsImpl: { init: async () => s },
+			DaemonImpl: StubDaemon,
+			pidAlive: () => true,
+		});
+
+		expect(daemonConstructed).toBe(false);
 	});
 
 	test("callback alias from session B routes only to session B", async () => {


### PR DESCRIPTION
Fixes #1735.

Summary:
- require non-blank trimmed adapter credentials before treating global notifications as configured
- avoid fully revealing short tokens in display masks
- strip `options` as well as `summary`/`question` for redacted non-ask actions while preserving ask actions

Verification:
- `bun test packages/coding-agent/test/notifications-config.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun --cwd=packages/coding-agent biome check src/notifications/config.ts test/notifications-config.test.ts`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*