### PR TITLE
Fix contribute-pr help native load order

### DIFF
--- a/packages/coding-agent/src/commands/contribution-prep.ts
+++ b/packages/coding-agent/src/commands/contribution-prep.ts
@@ -1,5 +1,4 @@
 import { Command, Flags } from "@gajae-code/utils/cli";
-import { prepareContributionPrep } from "../session/contribution-prep";
 
 function writeText(lines: string[]): void {
 	process.stdout.write(`${lines.join("\n")}\n`);
@@ -19,6 +18,7 @@ export default class ContributionPrep extends Command {
 
 	async run(): Promise<void> {
 		const { flags } = await this.parse(ContributionPrep);
+		const { prepareContributionPrep } = await import("../session/contribution-prep");
 		const cwd = process.cwd();
 		const result = await prepareContributionPrep(
 			{

--- a/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/deep-interview-mutation-guard.ts
@@ -342,7 +342,7 @@ function shellWords(argsText: string): string[] {
 }
 
 function cleanShellWord(value: string): string {
-	return value.replace(/^[\'"]|[\'"]$/g, "");
+	return value.replace(/^['"]|['"]$/g, "");
 }
 
 function extractBashTargets(args: unknown): ExtractedTargets {

--- a/packages/coding-agent/test/cli-help-load-order.test.ts
+++ b/packages/coding-agent/test/cli-help-load-order.test.ts
@@ -122,6 +122,49 @@ describe("CLI help load order", () => {
 		expect(combined).not.toContain("http-400-requests");
 	}, 15_000);
 
+	it("renders contribute-pr --help without loading native-dependent commands", async () => {
+		if (Bun.semver.order(Bun.version, "1.3.14") < 0) {
+			return;
+		}
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-contribute-pr-help-native-"));
+		cleanupRoot = root;
+		const home = path.join(root, "home");
+		const xdg = path.join(root, "xdg");
+		const agentDir = path.join(root, "agent");
+		await fs.mkdir(home, { recursive: true });
+		await fs.mkdir(xdg, { recursive: true });
+		await fs.mkdir(agentDir, { recursive: true });
+
+		const proc = Bun.spawn([process.execPath, cliEntry, "contribute-pr", "--help"], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: {
+				...process.env,
+				HOME: home,
+				XDG_CONFIG_HOME: xdg,
+				XDG_DATA_HOME: xdg,
+				GJC_CODING_AGENT_DIR: agentDir,
+				PI_CODING_AGENT_DIR: agentDir,
+				PI_NO_TITLE: "1",
+				NO_COLOR: "1",
+			},
+		});
+
+		const [stdout, stderr, exitCode] = await Promise.all([
+			readStream(proc.stdout as ReadableStream<Uint8Array>),
+			readStream(proc.stderr as ReadableStream<Uint8Array>),
+			proc.exited,
+		]);
+		const combined = `${stdout}\n${stderr}`;
+
+		expect(exitCode, combined).toBe(0);
+		expect(stdout).toContain("USAGE");
+		expect(stdout).toContain("$ gjc contribute-pr");
+		expect(stdout).toContain("--no-spawn");
+		expect(combined).not.toContain("Failed to load pi_natives native addon");
+	}, 15_000);
+
 	it("lists representative commands in root --help", async () => {
 		if (Bun.semver.order(Bun.version, "1.3.14") < 0) {
 			return;

--- a/packages/utils/src/cli.ts
+++ b/packages/utils/src/cli.ts
@@ -433,7 +433,7 @@ export async function run(opts: RunOptions): Promise<void> {
 			const instance = new Cmd(commandArgv, config);
 			await instance.run();
 		} else {
-			const config = await loadAllCommands(opts);
+			const config: CliConfig = { bin, version, commands: new Map([[entry.name, Cmd]]) };
 			renderCommandHelp(bin, entry.name, config.commands.get(entry.name) ?? Cmd);
 		}
 		return;


### PR DESCRIPTION
## Summary
- Avoid loading every registered command when rendering command-specific help.
- Lazy-load contribute-pr runtime preparation only when the command executes.
- Add regression coverage for `contribute-pr --help` without native addon loading.

## Verification
- `bun test packages/coding-agent/test/cli-help-load-order.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun packages/coding-agent/src/cli.ts contribute-pr --help`
- `bun packages/coding-agent/src/cli.ts completion inshellisense --json`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*