### PR TITLE
ci: check public site version drift

### DIFF
--- a/.github/workflows/public-site-sync.yml
+++ b/.github/workflows/public-site-sync.yml
@@ -28,7 +28,7 @@ jobs:
 
   live-public-sync:
     name: Live public homepage version
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/public-site-sync.yml
+++ b/.github/workflows/public-site-sync.yml
@@ -1,0 +1,40 @@
+name: Public site sync
+
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev, main]
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  local-public-sync:
+    name: Local public surfaces
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.3"
+      - name: Check local public docs/site/version metadata
+        run: bun run check:public-sync
+
+  live-public-sync:
+    name: Live public homepage version
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.3"
+      - name: Compare live homepage version with repository version
+        run: bun run check:public-live-sync

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "generate-schemas": "bun scripts/generate-json-schemas.ts",
     "check:schemas": "bun scripts/generate-json-schemas.ts --check",
     "check:public-sync": "bun scripts/check-public-version-sync.ts",
+    "check:public-live-sync": "bun scripts/check-public-version-sync.ts --live",
     "generate-plugins": "bun scripts/generate-gjc-plugins.ts",
     "check:plugins": "bun scripts/generate-gjc-plugins.ts --check && bun scripts/verify-gjc-plugins.ts",
     "test:rs": "bun scripts/run-rs-task.ts test:rs",

--- a/scripts/check-public-version-sync.test.ts
+++ b/scripts/check-public-version-sync.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { buildDocsIndexOutput, checkPublicVersionSync } from "./check-public-version-sync";
+import { buildDocsIndexOutput, checkLivePublicVersionSync, checkPublicVersionSync } from "./check-public-version-sync";
 
 const tempRoots: string[] = [];
 
@@ -76,5 +76,31 @@ describe("public docs/site/version sync guard", () => {
 		expect(violations.some(violation => violation.path === "package.json" && violation.message.includes("catalog gajae-code"))).toBe(true);
 		expect(violations.some(violation => violation.path === "README.md" && violation.message.includes("Visible marketing version 1.2.2"))).toBe(true);
 		expect(violations.some(violation => violation.path.includes("docs-index.generated.ts") && violation.message.includes("stale"))).toBe(true);
+	});
+
+	test("live check passes when public homepage version matches canonical package version", async () => {
+		const root = await createRepo({
+			"package.json": rootPackage("1.2.3"),
+			"packages/coding-agent/package.json": packageJson("@gajae-code/coding-agent", "1.2.3"),
+		});
+		const fetchImpl = async () => new Response("<main>🦀 v1.2.3 · beta</main>");
+
+		await expect(checkLivePublicVersionSync(root, fetchImpl)).resolves.toEqual([]);
+	});
+
+	test("live check fails when deployed homepage exposes a stale version", async () => {
+		const root = await createRepo({
+			"package.json": rootPackage("1.2.3"),
+			"packages/coding-agent/package.json": packageJson("@gajae-code/coding-agent", "1.2.3"),
+		});
+		const fetchImpl = async () => new Response("<main>🦀 v1.2.2 · beta</main>");
+
+		const violations = await checkLivePublicVersionSync(root, fetchImpl);
+		expect(violations).toEqual([
+			{
+				path: "https://gajae-code.com",
+				message: "Public homepage version 1.2.2 does not match canonical 1.2.3. Redeploy or update the public site metadata.",
+			},
+		]);
 	});
 });

--- a/scripts/check-public-version-sync.test.ts
+++ b/scripts/check-public-version-sync.test.ts
@@ -88,6 +88,21 @@ describe("public docs/site/version sync guard", () => {
 		await expect(checkLivePublicVersionSync(root, fetchImpl)).resolves.toEqual([]);
 	});
 
+	test("live check sends a bounded timeout signal to the homepage fetch", async () => {
+		const root = await createRepo({
+			"package.json": rootPackage("1.2.3"),
+			"packages/coding-agent/package.json": packageJson("@gajae-code/coding-agent", "1.2.3"),
+		});
+		let observedSignal: AbortSignal | undefined;
+		const fetchImpl = async (_input: string | URL, init?: RequestInit) => {
+			observedSignal = init?.signal ?? undefined;
+			return new Response("<main>🦀 v1.2.3 · beta</main>");
+		};
+
+		await expect(checkLivePublicVersionSync(root, fetchImpl, 50)).resolves.toEqual([]);
+		expect(observedSignal).toBeInstanceOf(AbortSignal);
+	});
+
 	test("live check fails when deployed homepage exposes a stale version", async () => {
 		const root = await createRepo({
 			"package.json": rootPackage("1.2.3"),

--- a/scripts/check-public-version-sync.ts
+++ b/scripts/check-public-version-sync.ts
@@ -25,6 +25,7 @@ const PUBLIC_HOMEPAGE = "https://gajae-code.com";
 const GENERATED_DOCS_INDEX = "packages/coding-agent/src/internal-urls/docs-index.generated.ts";
 const VERSIONED_MARKETING_RE = /\b(?:New in|Also new in|Gajae Code|Gajae-Code|Feature card for the)\s+(\d+\.\d+\.\d+)\b/gi;
 const MARKETING_VERSION_FILES = ["README.md", "docs/**/*.md", "packages/*/README.md"];
+const LIVE_FETCH_TIMEOUT_MS = 5_000;
 
 async function pathExists(candidate: string): Promise<boolean> {
 	try {
@@ -183,7 +184,7 @@ export async function checkPublicVersionSync(repoRoot = path.join(import.meta.di
 	return violations;
 }
 
-export async function checkLivePublicVersionSync(repoRoot = path.join(import.meta.dir, ".."), fetchImpl: PublicFetch = fetch): Promise<SyncViolation[]> {
+export async function checkLivePublicVersionSync(repoRoot = path.join(import.meta.dir, ".."), fetchImpl: PublicFetch = fetch, timeoutMs = LIVE_FETCH_TIMEOUT_MS): Promise<SyncViolation[]> {
 	const violations: SyncViolation[] = [];
 	const canonicalVersion = await canonicalVersionForRepo(repoRoot);
 
@@ -196,6 +197,7 @@ export async function checkLivePublicVersionSync(repoRoot = path.join(import.met
 	try {
 		response = await fetchImpl(PUBLIC_HOMEPAGE, {
 			headers: { "User-Agent": "gajae-code-public-version-sync/1.0" },
+			signal: AbortSignal.timeout(timeoutMs),
 		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/scripts/check-public-version-sync.ts
+++ b/scripts/check-public-version-sync.ts
@@ -19,6 +19,7 @@ export interface SyncViolation {
 	message: string;
 	line?: number;
 }
+type PublicFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
 
 const PUBLIC_HOMEPAGE = "https://gajae-code.com";
 const GENERATED_DOCS_INDEX = "packages/coding-agent/src/internal-urls/docs-index.generated.ts";
@@ -86,6 +87,11 @@ export async function buildDocsIndexOutput(repoRoot: string): Promise<string> {
 		`};`,
 		"",
 	].join("\n");
+}
+
+async function canonicalVersionForRepo(repoRoot: string): Promise<string | undefined> {
+	const rootPackage = await readJson<PackageJson>(path.join(repoRoot, "package.json"));
+	return rootPackage.workspaces?.catalog?.["@gajae-code/coding-agent"];
 }
 
 export async function checkPublicVersionSync(repoRoot = path.join(import.meta.dir, "..")): Promise<SyncViolation[]> {
@@ -177,8 +183,50 @@ export async function checkPublicVersionSync(repoRoot = path.join(import.meta.di
 	return violations;
 }
 
+export async function checkLivePublicVersionSync(repoRoot = path.join(import.meta.dir, ".."), fetchImpl: PublicFetch = fetch): Promise<SyncViolation[]> {
+	const violations: SyncViolation[] = [];
+	const canonicalVersion = await canonicalVersionForRepo(repoRoot);
+
+	if (!canonicalVersion) {
+		violations.push({ path: "package.json", message: "Missing canonical @gajae-code/coding-agent catalog version." });
+		return violations;
+	}
+
+	let response: Response;
+	try {
+		response = await fetchImpl(PUBLIC_HOMEPAGE, {
+			headers: { "User-Agent": "gajae-code-public-version-sync/1.0" },
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		violations.push({ path: PUBLIC_HOMEPAGE, message: `Failed to fetch public homepage: ${message}` });
+		return violations;
+	}
+
+	if (!response.ok) {
+		violations.push({ path: PUBLIC_HOMEPAGE, message: `Public homepage returned HTTP ${response.status}.` });
+		return violations;
+	}
+
+	const homepage = await response.text();
+	const visibleVersion = homepage.match(/\bv(\d+\.\d+\.\d+)\b/i)?.[1];
+	if (!visibleVersion) {
+		violations.push({ path: PUBLIC_HOMEPAGE, message: "Public homepage does not expose a visible vX.Y.Z version marker." });
+	} else if (visibleVersion !== canonicalVersion) {
+		violations.push({
+			path: PUBLIC_HOMEPAGE,
+			message: `Public homepage version ${visibleVersion} does not match canonical ${canonicalVersion}. Redeploy or update the public site metadata.`,
+		});
+	}
+
+	return violations;
+}
 if (import.meta.main) {
-	const violations = await checkPublicVersionSync();
+	const live = process.argv.includes("--live");
+	const violations = [
+		...(await checkPublicVersionSync()),
+		...(live ? await checkLivePublicVersionSync() : []),
+	];
 	if (violations.length === 0) {
 		console.log("Public docs/site/version surfaces are in sync.");
 		process.exit(0);


### PR DESCRIPTION
## Summary
- add a live public homepage version drift check behind check:public-live-sync with a bounded fetch timeout
- add a public-site-sync workflow: local public surface checks run on PR/push; live deployed drift detection runs only on schedule/manual dispatch so PR/push merge gates stay stable while the current site is stale
- keep the existing local check-public-version-sync default behavior unchanged

## Scope note
This PR does not claim to deploy/update gajae-code.com because no safe repository-owned website deployment path is present in this branch. It adds the automated drift detector requested by the issue and leaves #1714 open for the actual site update/deploy wiring.

## Verification
- bun test scripts/check-public-version-sync.test.ts
- bun run check:public-sync
- bun scripts/check-workflow-yaml.ts
- bun run check:tools (passes with existing info-level noUselessEscapeInRegex notice in deep-interview-mutation-guard.ts)
- bun run check:ts (passes with same existing info-level Biome notice)
- bun run check:public-live-sync (expected failure today: live homepage is v0.7.2 while repo canonical is v0.8.2)