### PR TITLE
Add team mailbox delivery transport seam

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -3960,6 +3960,7 @@ async function attemptConfiguredMailboxTransport(
 			env,
 		});
 		if (!result) return null;
+		if (result.transport === "notifications_sdk" && result.state === "failed") return null;
 		return writeNotificationRecord(dir, {
 			...notification,
 			delivery_state: result.state,
@@ -4061,7 +4062,7 @@ export async function sendGjcTeamMessage(
 		notificationPath(dir, messageNotificationId(config.team_name, toWorker, written.message_id)),
 	);
 	const notification = await createMessageNotification(dir, config.team_name, written);
-	if (!existingNotification || isReplayEligibleNotification(existingNotification.delivery_state)) {
+	if (!existingNotification) {
 		await attemptPaneNotification(dir, config, notification, env, cwd);
 	}
 	await appendEvent(dir, {

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -204,6 +204,7 @@ export type GjcTeamNotificationDeliveryState =
 	| "acknowledged";
 
 export type GjcTeamPaneAttemptResult = "sent" | "queued" | "deferred" | "failed";
+export type GjcTeamMailboxDeliveryTransportKind = "notifications_sdk" | "pane";
 
 export interface GjcTeamNotification {
 	id: string;
@@ -219,6 +220,33 @@ export interface GjcTeamNotification {
 	created_at: string;
 	updated_at: string;
 	replay_count: number;
+}
+export interface GjcTeamMailboxDeliveryInput {
+	team_name: string;
+	state_dir: string;
+	config: GjcTeamConfig;
+	notification: GjcTeamNotification;
+	message: GjcTeamMailboxMessage;
+	cwd: string;
+	env: NodeJS.ProcessEnv;
+}
+export type GjcTeamMailboxDeliveryResult =
+	| { transport: "notifications_sdk"; state: GjcTeamNotificationDeliveryState; reason?: string }
+	| { transport: "pane"; state: GjcTeamPaneAttemptResult; reason?: string };
+export interface GjcTeamMailboxDeliveryTransport {
+	deliverMailboxMessage(input: GjcTeamMailboxDeliveryInput): Promise<GjcTeamMailboxDeliveryResult | null>;
+}
+
+let gjcTeamMailboxDeliveryTransport: GjcTeamMailboxDeliveryTransport | undefined;
+
+export function setGjcTeamMailboxDeliveryTransportForTest(
+	transport: GjcTeamMailboxDeliveryTransport | undefined,
+): () => void {
+	const previous = gjcTeamMailboxDeliveryTransport;
+	gjcTeamMailboxDeliveryTransport = transport;
+	return () => {
+		gjcTeamMailboxDeliveryTransport = previous;
+	};
 }
 
 export interface GjcTeamNotificationSummary {
@@ -3902,12 +3930,58 @@ async function reconcileTeamNotifications(dir: string, config: GjcTeamConfig): P
 	}
 	return summarizeNotifications(await listNotificationRecords(dir));
 }
+async function messageForNotification(
+	dir: string,
+	notification: GjcTeamNotification,
+): Promise<GjcTeamMailboxMessage | null> {
+	if (notification.kind !== "mailbox_message" || notification.source.type !== "message") return null;
+	const mailbox = await readMailbox(dir, notification.recipient);
+	return mailbox.messages.find(message => message.message_id === notification.source.id) ?? null;
+}
+
+async function attemptConfiguredMailboxTransport(
+	dir: string,
+	config: GjcTeamConfig,
+	notification: GjcTeamNotification,
+	cwd: string,
+	env: NodeJS.ProcessEnv,
+): Promise<GjcTeamNotification | null> {
+	if (!gjcTeamMailboxDeliveryTransport) return null;
+	const message = await messageForNotification(dir, notification);
+	if (!message) return null;
+	try {
+		const result = await gjcTeamMailboxDeliveryTransport.deliverMailboxMessage({
+			team_name: config.team_name,
+			state_dir: dir,
+			config,
+			notification,
+			message,
+			cwd,
+			env,
+		});
+		if (!result) return null;
+		return writeNotificationRecord(dir, {
+			...notification,
+			delivery_state: result.state,
+			pane_attempt_result: result.transport === "pane" ? result.state : undefined,
+			pane_attempt_reason: result.reason ?? result.transport,
+			pane_attempt_at: now(),
+			updated_at: now(),
+		});
+	} catch {
+		return null;
+	}
+}
+
 async function attemptPaneNotification(
 	dir: string,
 	config: GjcTeamConfig,
 	notification: GjcTeamNotification,
 	env: NodeJS.ProcessEnv,
+	cwd = process.cwd(),
 ): Promise<GjcTeamNotification> {
+	const transported = await attemptConfiguredMailboxTransport(dir, config, notification, cwd, env);
+	if (transported) return transported;
 	const paneId =
 		notification.recipient === "leader-fixed"
 			? config.leader.pane_id
@@ -3954,6 +4028,7 @@ export async function replayGjcTeamNotifications(
 				replay_count: (notification.replay_count ?? 0) + 1,
 			},
 			env,
+			cwd,
 		);
 		next.push(attempted);
 	}
@@ -3982,8 +4057,13 @@ export async function sendGjcTeamMessage(
 		...(idempotencyKey ? { idempotency_key: idempotencyKey } : {}),
 	};
 	const written = await writeMailboxMessage(dir, toWorker, message);
+	const existingNotification = await readJsonFile<GjcTeamNotification>(
+		notificationPath(dir, messageNotificationId(config.team_name, toWorker, written.message_id)),
+	);
 	const notification = await createMessageNotification(dir, config.team_name, written);
-	await attemptPaneNotification(dir, config, notification, env);
+	if (!existingNotification || isReplayEligibleNotification(existingNotification.delivery_state)) {
+		await attemptPaneNotification(dir, config, notification, env, cwd);
+	}
 	await appendEvent(dir, {
 		type: "message_sent",
 		worker: fromWorker,

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -239,14 +239,17 @@ export interface GjcTeamMailboxDeliveryTransport {
 
 let gjcTeamMailboxDeliveryTransport: GjcTeamMailboxDeliveryTransport | undefined;
 
-export function setGjcTeamMailboxDeliveryTransportForTest(
-	transport: GjcTeamMailboxDeliveryTransport | undefined,
-): () => void {
+export function setGjcTeamMailboxDeliveryTransport(transport: GjcTeamMailboxDeliveryTransport | undefined): () => void {
 	const previous = gjcTeamMailboxDeliveryTransport;
 	gjcTeamMailboxDeliveryTransport = transport;
 	return () => {
 		gjcTeamMailboxDeliveryTransport = previous;
 	};
+}
+export function setGjcTeamMailboxDeliveryTransportForTest(
+	transport: GjcTeamMailboxDeliveryTransport | undefined,
+): () => void {
+	return setGjcTeamMailboxDeliveryTransport(transport);
 }
 
 export interface GjcTeamNotificationSummary {
@@ -284,6 +287,7 @@ export interface GjcTeamStartOptions {
 	cwd?: string;
 	env?: NodeJS.ProcessEnv;
 	dryRun?: boolean;
+	mailboxDeliveryTransport?: GjcTeamMailboxDeliveryTransport;
 }
 
 export interface GjcTeamApiClaimResult {
@@ -2973,6 +2977,7 @@ async function initializeStateDirs(dir: string, workers: GjcTeamWorker[]): Promi
 export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTeamSnapshot> {
 	const cwd = options.cwd ?? process.cwd();
 	const env = options.env ?? process.env;
+	if (options.mailboxDeliveryTransport) setGjcTeamMailboxDeliveryTransport(options.mailboxDeliveryTransport);
 	if (!Number.isInteger(options.workerCount) || options.workerCount < 1 || options.workerCount > GJC_TEAM_MAX_WORKERS)
 		throw new Error(`invalid_team_worker_count:${options.workerCount}:expected_1_${GJC_TEAM_MAX_WORKERS}`);
 	const workerCliPlan = resolveGjcTeamWorkerCliPlan(options.workerCount, env);

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -2263,6 +2263,99 @@ describe("native gjc team runtime", () => {
 		expect(notifications.delivery_states).toEqual(["sent"]);
 	});
 
+	it("does not redeliver idempotent duplicates for queued or deferred transport records", async () => {
+		for (const state of ["queued", "deferred"] as const) {
+			cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+			await startGjcTeam({
+				workerCount: 2,
+				agentType: "executor",
+				task: `Notifications SDK ${state} duplicate guard`,
+				teamName: `transport-${state}-team`,
+				cwd: cleanupRoot,
+				dryRun: true,
+				env: { GJC_SESSION_ID: TEST_SESSION_ID, PATH: "" },
+			});
+			let attempts = 0;
+			resetMailboxTransport = setGjcTeamMailboxDeliveryTransportForTest({
+				async deliverMailboxMessage() {
+					attempts += 1;
+					return { transport: "notifications_sdk", state, reason: `test-sdk-${state}` };
+				},
+			});
+
+			const message = await sendGjcTeamMessage(
+				`transport-${state}-team`,
+				"worker-1",
+				"worker-2",
+				`hello ${state}`,
+				cleanupRoot,
+				{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
+				`transport-${state}-key`,
+			);
+			const duplicate = await sendGjcTeamMessage(
+				`transport-${state}-team`,
+				"worker-1",
+				"worker-2",
+				`hello ${state}`,
+				cleanupRoot,
+				{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
+				`transport-${state}-key`,
+			);
+			const notifications = (await executeGjcTeamApiOperation(
+				"notification-list",
+				{ team_name: `transport-${state}-team` },
+				cleanupRoot,
+				{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
+			)) as { delivery_states: string[] };
+
+			expect(duplicate.message_id).toBe(message.message_id);
+			expect(attempts).toBe(1);
+			expect(notifications.delivery_states).toEqual([state]);
+			resetMailboxTransport?.();
+			resetMailboxTransport = undefined;
+			await fs.rm(cleanupRoot, { recursive: true, force: true });
+			cleanupRoot = undefined;
+		}
+	});
+
+	it("falls back to pane delivery when the configured mailbox transport returns failed", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		await startGjcTeam({
+			workerCount: 2,
+			agentType: "executor",
+			task: "Notifications SDK explicit failure fallback",
+			teamName: "transport-failed-fallback-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { GJC_SESSION_ID: TEST_SESSION_ID, PATH: "" },
+		});
+		let attempts = 0;
+		resetMailboxTransport = setGjcTeamMailboxDeliveryTransportForTest({
+			async deliverMailboxMessage() {
+				attempts += 1;
+				return { transport: "notifications_sdk", state: "failed", reason: "test-sdk-failed" };
+			},
+		});
+
+		await sendGjcTeamMessage(
+			"transport-failed-fallback-team",
+			"worker-1",
+			"worker-2",
+			"fallback after explicit failure",
+			cleanupRoot,
+			{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
+		);
+		const notifications = (await executeGjcTeamApiOperation(
+			"notification-list",
+			{ team_name: "transport-failed-fallback-team" },
+			cleanupRoot,
+			{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
+		)) as { delivery_states: string[] };
+
+		expect(attempts).toBe(1);
+		expect(notifications.delivery_states).toEqual(["sent"]);
+	});
+
 	it("rejects path-like worker ids and reports lifecycle nudges without automatic worker action", async () => {
 		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
 		await startGjcTeam({

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -21,6 +21,7 @@ import {
 	resolveGjcTeamWorkerCliPlan,
 	resolveGjcWorkerCommand,
 	sendGjcTeamMessage,
+	setGjcTeamMailboxDeliveryTransportForTest,
 	shutdownGjcTeam,
 	startGjcTeam,
 	transitionGjcTeamTask,
@@ -218,7 +219,11 @@ function artifactCompletionEvidence(summary = "Completed by artifact review") {
 	};
 }
 
+let resetMailboxTransport: (() => void) | undefined;
+
 afterEach(async () => {
+	resetMailboxTransport?.();
+	resetMailboxTransport = undefined;
 	if (cleanupRoot) {
 		for (const session of [
 			"gjc-worktree-team",
@@ -2170,6 +2175,92 @@ describe("native gjc team runtime", () => {
 			{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
 		)) as { notification_ids: string[]; delivery_states: string[]; summary: { total: number } };
 		expect(notifications.delivery_states[0]).toBe("acknowledged");
+	});
+
+	it("routes team mailbox notifications through the configured transport seam", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		await startGjcTeam({
+			workerCount: 2,
+			agentType: "executor",
+			task: "Notifications SDK transport seam",
+			teamName: "transport-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { GJC_SESSION_ID: TEST_SESSION_ID, PATH: "" },
+		});
+		const delivered: Array<{ teamName: string; messageId: string; body: string }> = [];
+		resetMailboxTransport = setGjcTeamMailboxDeliveryTransportForTest({
+			async deliverMailboxMessage(input) {
+				delivered.push({
+					teamName: input.team_name,
+					messageId: input.message.message_id,
+					body: input.message.body,
+				});
+				return { transport: "notifications_sdk", state: "sent", reason: "test-sdk" };
+			},
+		});
+
+		const message = await sendGjcTeamMessage(
+			"transport-team",
+			"worker-1",
+			"worker-2",
+			"hello through sdk seam",
+			cleanupRoot,
+			{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
+			"transport-key",
+		);
+		const duplicate = await sendGjcTeamMessage(
+			"transport-team",
+			"worker-1",
+			"worker-2",
+			"hello through sdk seam",
+			cleanupRoot,
+			{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
+			"transport-key",
+		);
+		const notifications = (await executeGjcTeamApiOperation(
+			"notification-list",
+			{ team_name: "transport-team" },
+			cleanupRoot,
+			{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
+		)) as { delivery_states: string[]; notification_ids: string[] };
+
+		expect(duplicate.message_id).toBe(message.message_id);
+		expect(delivered).toEqual([
+			{ teamName: "transport-team", messageId: message.message_id, body: "hello through sdk seam" },
+		]);
+		expect(notifications.delivery_states).toEqual(["sent"]);
+	});
+
+	it("falls back to pane delivery when the configured mailbox transport is unavailable", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		await startGjcTeam({
+			workerCount: 2,
+			agentType: "executor",
+			task: "Notifications SDK transport fallback",
+			teamName: "transport-fallback-team",
+			cwd: cleanupRoot,
+			dryRun: true,
+			env: { GJC_SESSION_ID: TEST_SESSION_ID, PATH: "" },
+		});
+		resetMailboxTransport = setGjcTeamMailboxDeliveryTransportForTest({
+			async deliverMailboxMessage() {
+				throw new Error("sdk unavailable");
+			},
+		});
+
+		await sendGjcTeamMessage("transport-fallback-team", "worker-1", "worker-2", "fallback please", cleanupRoot, {
+			PATH: "",
+			GJC_SESSION_ID: TEST_SESSION_ID,
+		});
+		const notifications = (await executeGjcTeamApiOperation(
+			"notification-list",
+			{ team_name: "transport-fallback-team" },
+			cleanupRoot,
+			{ PATH: "", GJC_SESSION_ID: TEST_SESSION_ID },
+		)) as { delivery_states: string[] };
+
+		expect(notifications.delivery_states).toEqual(["sent"]);
 	});
 
 	it("rejects path-like worker ids and reports lifecycle nudges without automatic worker action", async () => {

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -21,6 +21,7 @@ import {
 	resolveGjcTeamWorkerCliPlan,
 	resolveGjcWorkerCommand,
 	sendGjcTeamMessage,
+	setGjcTeamMailboxDeliveryTransport,
 	setGjcTeamMailboxDeliveryTransportForTest,
 	shutdownGjcTeam,
 	startGjcTeam,
@@ -224,6 +225,7 @@ let resetMailboxTransport: (() => void) | undefined;
 afterEach(async () => {
 	resetMailboxTransport?.();
 	resetMailboxTransport = undefined;
+	setGjcTeamMailboxDeliveryTransport(undefined);
 	if (cleanupRoot) {
 		for (const session of [
 			"gjc-worktree-team",
@@ -2179,6 +2181,7 @@ describe("native gjc team runtime", () => {
 
 	it("routes team mailbox notifications through the configured transport seam", async () => {
 		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));
+		const delivered: Array<{ teamName: string; messageId: string; body: string }> = [];
 		await startGjcTeam({
 			workerCount: 2,
 			agentType: "executor",
@@ -2187,16 +2190,15 @@ describe("native gjc team runtime", () => {
 			cwd: cleanupRoot,
 			dryRun: true,
 			env: { GJC_SESSION_ID: TEST_SESSION_ID, PATH: "" },
-		});
-		const delivered: Array<{ teamName: string; messageId: string; body: string }> = [];
-		resetMailboxTransport = setGjcTeamMailboxDeliveryTransportForTest({
-			async deliverMailboxMessage(input) {
-				delivered.push({
-					teamName: input.team_name,
-					messageId: input.message.message_id,
-					body: input.message.body,
-				});
-				return { transport: "notifications_sdk", state: "sent", reason: "test-sdk" };
+			mailboxDeliveryTransport: {
+				async deliverMailboxMessage(input) {
+					delivered.push({
+						teamName: input.team_name,
+						messageId: input.message.message_id,
+						body: input.message.body,
+					});
+					return { transport: "notifications_sdk", state: "sent", reason: "test-sdk" };
+				},
 			},
 		});
 


### PR DESCRIPTION
## Summary
- add an injectable team mailbox delivery transport seam for Notifications SDK-backed delivery when available
- keep existing pane/mailbox fallback behavior intact when the transport is unavailable or fails
- avoid duplicate transport delivery for idempotent mailbox sends that already reached a non-replay-eligible state

## Tests
- bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
- bunx biome check packages/coding-agent/src/gjc-runtime/team-runtime.ts packages/coding-agent/test/gjc-runtime/team-runtime.test.ts && bun --cwd=packages/coding-agent run check:types