### PR TITLE
fix(token-log): bind root logs to current session

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -34,8 +34,6 @@ import { BUNDLED_GROK_BUILD_EXTENSION_ID, getBundledGrokBuildExtensionFactory } 
 import { initializeWithSettings } from "./discovery";
 import { exportFromFile } from "./export/html";
 import type { ExtensionUIContext } from "./extensibility/extensions/types";
-import { sessionRoot } from "./gjc-runtime/session-layout";
-import { resolveGjcSessionForRead, SessionResolutionError } from "./gjc-runtime/session-resolution";
 import type { InteractiveMode } from "./modes/interactive-mode";
 import { initTheme, stopThemeWatcher } from "./modes/theme/theme";
 import type { SubmittedUserInput } from "./modes/types";
@@ -54,7 +52,7 @@ import { runStartupCredentialAutoImportIfNeeded } from "./setup/credential-auto-
 import { formatModelOnboardingGuidance } from "./setup/model-onboarding-guidance";
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { resolvePromptInput } from "./system-prompt";
-import { persistTaskTokenLog, taskTokenLogFromUsage } from "./task/token-log";
+import { persistTaskTokenLog, resolveTaskTokenLogDir, taskTokenLogFromUsage } from "./task/token-log";
 import type { LspStartupServerInfo } from "./tools";
 import { getDisplayChangelogEntries, getInstalledVersionChangelogEntry, getNewEntries } from "./utils/changelog";
 import type { EventBus } from "./utils/event-bus";
@@ -104,26 +102,6 @@ const RPC_DEFAULTED_SETTING_PATHS: SettingPath[] = [
 	"memories.enabled",
 ];
 
-async function resolveTaskTokenLogDir(
-	cwd: string,
-	sessionManager: SessionManager | undefined,
-): Promise<string | undefined> {
-	// Prefer the canonical SessionManager id so root turns land in the SAME
-	// `<session>/token-logs` dir the task executor uses for subagent turns and
-	// that `gjc --fixture <id>` reads from. Fall back to the env/latest-active
-	// session only when no manager id is available (e.g. a fresh launch whose
-	// session the SDK creates lazily). Never let a best-effort telemetry side
-	// channel crash startup — swallow every SessionResolutionError.
-	const managerId = sessionManager?.getSessionId();
-	if (managerId) return path.join(sessionRoot(cwd, managerId), "token-logs");
-	try {
-		const session = await resolveGjcSessionForRead(cwd, { envSessionId: process.env.GJC_SESSION_ID });
-		return path.join(session.sessionRoot, "token-logs");
-	} catch (error) {
-		if (error instanceof SessionResolutionError) return undefined;
-		throw error;
-	}
-}
 function applyRpcDefaultSettingOverrides(targetSettings: Settings = settings): void {
 	for (const settingPath of RPC_DEFAULTED_SETTING_PATHS) {
 		targetSettings.override(settingPath, getDefault(settingPath));
@@ -536,8 +514,8 @@ export async function createSessionManager(
 		}
 		return manager;
 	}
-	// Default case (new session) returns undefined, SDK will create one
-	return undefined;
+	const sessionDir = parsed.sessionDir ?? SessionManager.getDefaultSessionDir(cwd, activeSettings.getAgentDir());
+	return SessionManager.create(cwd, sessionDir);
 }
 
 async function maybeAutoChdir(parsed: Args): Promise<void> {

--- a/packages/coding-agent/src/task/token-log.test.ts
+++ b/packages/coding-agent/src/task/token-log.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "bun:test";
-import { appendFile, mkdtemp, rm } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { GJC_SESSION_ACTIVITY_FILE, sessionRoot } from "../gjc-runtime/session-layout";
 import {
 	computeCacheHitRate,
 	persistTaskTokenLog,
 	readTaskTokenLogs,
+	resolveTaskTokenLogDir,
 	taskTokenLogFromChat,
 	taskTokenLogFromUsage,
 } from "./token-log";
@@ -89,6 +91,32 @@ describe("task token log", () => {
 			await persistTaskTokenLog(second, { dir });
 
 			expect(await readTaskTokenLogs(dir)).toEqual([first, second]);
+		});
+	});
+
+	it("prefers the current session manager over a stale latest-active session", async () => {
+		await withTempDir(async cwd => {
+			const currentSessionId = "current-session";
+			const staleSessionId = "stale-session";
+			for (const [sessionId, updatedAt] of [
+				[currentSessionId, "2026-01-01T00:00:00.000Z"],
+				[staleSessionId, "2026-01-01T00:00:10.000Z"],
+			] as const) {
+				const markerPath = join(sessionRoot(cwd, sessionId), GJC_SESSION_ACTIVITY_FILE);
+				await mkdir(join(markerPath, ".."), { recursive: true });
+				await writeFile(
+					markerPath,
+					`${JSON.stringify({ session_id: sessionId, updated_at: updatedAt })}\n`,
+					"utf-8",
+				);
+			}
+
+			await expect(resolveTaskTokenLogDir(cwd, undefined, "")).resolves.toBe(
+				join(sessionRoot(cwd, staleSessionId), "token-logs"),
+			);
+			await expect(resolveTaskTokenLogDir(cwd, { getSessionId: () => currentSessionId }, "")).resolves.toBe(
+				join(sessionRoot(cwd, currentSessionId), "token-logs"),
+			);
 		});
 	});
 

--- a/packages/coding-agent/src/task/token-log.ts
+++ b/packages/coding-agent/src/task/token-log.ts
@@ -1,6 +1,8 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ChatUsageSnapshot, CostEstimate } from "@gajae-code/agent-core";
+import { sessionRoot } from "../gjc-runtime/session-layout";
+import { resolveGjcSessionForRead, SessionResolutionError } from "../gjc-runtime/session-resolution";
 import type { TaskTokenLog, TaskTokenMetrics } from "./types";
 
 const TOKEN_LOG_FILE = "token-log.jsonl";
@@ -11,6 +13,10 @@ export interface TaskTokenLogChatBuckets {
 	readonly cachedInputTokens: number;
 	readonly cacheWriteTokens: number;
 	readonly costUsd?: number;
+}
+
+export interface TaskTokenLogSessionManager {
+	getSessionId(): string;
 }
 
 export interface TaskTokenLogContext {
@@ -65,6 +71,27 @@ export function taskTokenLogFromUsage(
 	);
 }
 
+export async function resolveTaskTokenLogDir(
+	cwd: string,
+	sessionManager: TaskTokenLogSessionManager | undefined,
+	envSessionId: string | undefined = process.env.GJC_SESSION_ID,
+): Promise<string | undefined> {
+	// Prefer the canonical SessionManager id so root turns land in the SAME
+	// `<session>/token-logs` dir the task executor uses for subagent turns and
+	// that `gjc --fixture <id>` reads from. Fall back to the env/latest-active
+	// session only when no manager id is available (e.g. lifecycle launches where
+	// the SDK adopts a pre-allocated id internally). Never let a best-effort
+	// telemetry side channel crash startup — swallow every SessionResolutionError.
+	const managerId = sessionManager?.getSessionId();
+	if (managerId) return path.join(sessionRoot(cwd, managerId), "token-logs");
+	try {
+		const session = await resolveGjcSessionForRead(cwd, { envSessionId });
+		return path.join(session.sessionRoot, "token-logs");
+	} catch (error) {
+		if (error instanceof SessionResolutionError) return undefined;
+		throw error;
+	}
+}
 export async function persistTaskTokenLog(entry: TaskTokenLog, opts: { dir: string }): Promise<void> {
 	await fs.mkdir(opts.dir, { recursive: true });
 	await fs.appendFile(path.join(opts.dir, TOKEN_LOG_FILE), `${JSON.stringify(entry)}\n`, "utf-8");

--- a/packages/coding-agent/test/notifications-lifecycle-create-autoresume.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-create-autoresume.test.ts
@@ -16,6 +16,23 @@ afterEach(() => {
 	for (const k of LIFECYCLE_ENV) delete process.env[k];
 });
 
+test("normal root launch creates a current SessionManager for root token logs", async () => {
+	const agentDir = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-root-token-session-"));
+	setAgentDir(agentDir);
+	const cwd = path.join(agentDir, "repo");
+	fs.mkdirSync(cwd, { recursive: true });
+
+	const settings = Settings.isolated();
+	settings.set("autoResume", false);
+
+	const created = await createSessionManager({} as Args, cwd, settings);
+	expect(created).toBeDefined();
+	expect(created?.getSessionId()).toBeTruthy();
+	expect(created?.getCwd()).toBe(cwd);
+
+	await fsp.rm(agentDir, { recursive: true, force: true });
+});
+
 // Regression for the PR #1148 stage-17 blocker: a `/session_create` child is a
 // bare `gjc` launch with GJC_SESSION_ID/GJC_LIFECYCLE_REQUEST_ID. With autoResume
 // enabled and existing history in the cwd, the child must NOT auto-resume the old


### PR DESCRIPTION
## Summary
- create a root SessionManager for normal fresh launches so root token telemetry can use the current session id instead of latest-active fallback
- move root token-log directory resolution into token-log utilities and keep manager-id precedence over latest-active
- add regressions for stale latest-active resolution and fresh root launch session creation

## Verification
- `bun test packages/coding-agent/src/task/token-log.test.ts packages/coding-agent/test/notifications-lifecycle-create-autoresume.test.ts`
- `bun run check` (packages/coding-agent)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*