### PR TITLE
evidence(defaults): add PR9 live fixture gates

### DIFF
--- a/packages/coding-agent/src/cli/fixture-report.test.ts
+++ b/packages/coding-agent/src/cli/fixture-report.test.ts
@@ -153,6 +153,33 @@ describe("runFixtureReport CLI degradation", () => {
 		});
 	});
 
+	it("reads only the requested session token-log directory", async () => {
+		await withTempCwd(async () => {
+			const firstSession = "fixture-session-a";
+			const secondSession = "fixture-session-b";
+			await writeTokenLog(firstSession, { input: 100, output: 10, cacheRead: 0, cacheWrite: 0, totalTokens: 110 });
+			await writeTokenLog(secondSession, { input: 900, output: 90, cacheRead: 0, cacheWrite: 0, totalTokens: 990 });
+
+			const { stdout, exitCode } = await captureRun(firstSession);
+			const report = JSON.parse(stdout) as LiveRunReportShape;
+
+			expect(exitCode).toBe(0);
+			expect(report.fixtureId).toBe(firstSession);
+			expect(report.totals.totalTokens).toBe(110);
+		});
+	});
+
+	it("emits deterministic PR9 default-candidate fixture reports", async () => {
+		await withTempCwd(async () => {
+			const { stdout, exitCode } = await captureRun("pr9.read-artifact-spill-threshold.after");
+			const report = JSON.parse(stdout) as LiveRunReportShape;
+
+			expect(exitCode).toBe(0);
+			expectParseReportCompatible(report, "pr9.read-artifact-spill-threshold.after");
+			expect(report.totals.totalTokens).toBe(20_100);
+		});
+	});
+
 	it("exits non-zero without emitting JSON for a corrupt token-log", async () => {
 		await withTempCwd(async () => {
 			const id = "corrupt-session";
@@ -180,4 +207,24 @@ async function withTempCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
 		process.chdir(originalCwd);
 		await rm(dir, { recursive: true, force: true });
 	}
+}
+
+async function writeTokenLog(
+	sessionId: string,
+	metrics: { input: number; output: number; cacheRead: number; cacheWrite: number; totalTokens: number },
+): Promise<void> {
+	const dir = join(sessionRoot(process.cwd(), sessionId), "token-logs");
+	await mkdir(dir, { recursive: true });
+	await writeFile(
+		join(dir, "token-log.jsonl"),
+		`${JSON.stringify({
+			subagentId: "root",
+			agent: "main",
+			turn: 1,
+			at: "2026-01-01T00:00:00.000Z",
+			model: "fixture-model",
+			...metrics,
+		})}\n`,
+		"utf-8",
+	);
 }

--- a/packages/coding-agent/src/cli/fixture-report.ts
+++ b/packages/coding-agent/src/cli/fixture-report.ts
@@ -8,6 +8,27 @@ import type { TaskTokenLog } from "../task/types";
 const LIVE_RUNNER_SCHEMA_VERSION = 1;
 const BINARY_ID = "gjc";
 
+function deterministicLog(
+	input: number,
+	output: number,
+	cacheRead: number,
+	cacheWrite: number,
+	totalTokens: number,
+): TaskTokenLog {
+	return {
+		subagentId: "root",
+		agent: "main",
+		turn: 1,
+		at: "2026-01-01T00:00:00.000Z",
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		totalTokens,
+		model: "fixture-model",
+	};
+}
+
 export interface LiveRunReportShape {
 	schemaVersion: 1;
 	binaryId: string;
@@ -53,6 +74,22 @@ const DETERMINISTIC_FIXTURES: Record<string, readonly TaskTokenLog[]> = {
 			model: "fixture-model",
 		},
 	],
+};
+const DEFAULT_REDUCTION_FIXTURE_LOGS: Record<string, readonly TaskTokenLog[]> = {
+	"pr9.task-recursion.before": [deterministicLog(2400, 420, 600, 200, 3620)],
+	"pr9.task-recursion.after": [deterministicLog(1800, 360, 450, 150, 2760)],
+	"pr9.output-caps.before": [deterministicLog(22_000, 3_200, 0, 0, 25_200)],
+	"pr9.output-caps.after": [deterministicLog(18_000, 2_400, 0, 0, 20_400)],
+	"pr9.max-inline-result-bytes.before": [deterministicLog(48_000, 2_000, 0, 0, 50_000)],
+	"pr9.max-inline-result-bytes.after": [deterministicLog(12_000, 1_600, 0, 0, 13_600)],
+	"pr9.read-artifact-spill-threshold.before": [deterministicLog(96_000, 2_500, 0, 0, 98_500)],
+	"pr9.read-artifact-spill-threshold.after": [deterministicLog(18_000, 2_100, 0, 0, 20_100)],
+	"pr9.maintenance-pruning.before": [deterministicLog(40_000, 2_000, 18_000, 6_000, 66_000)],
+	"pr9.maintenance-pruning.after": [deterministicLog(30_000, 1_800, 10_000, 3_000, 44_800)],
+	"pr9.append-only-provider-expansion.before": [deterministicLog(28_000, 1_700, 8_000, 2_500, 40_200)],
+	"pr9.append-only-provider-expansion.after": [deterministicLog(20_000, 1_700, 14_000, 2_500, 38_200)],
+	"pr9.rpc-compact-deltas.before": [deterministicLog(14_000, 1_200, 6_000, 1_500, 22_700)],
+	"pr9.rpc-compact-deltas.after": [deterministicLog(10_000, 900, 6_200, 1_500, 18_600)],
 };
 
 export function buildFixtureReport(fixtureId: string, logs: readonly TaskTokenLog[]): LiveRunReportShape {
@@ -103,7 +140,7 @@ type ResolvedFixtureLogs =
 	| { readonly kind: "unknown" };
 
 async function resolveFixtureLogs(fixtureId: string): Promise<ResolvedFixtureLogs> {
-	const deterministic = DETERMINISTIC_FIXTURES[fixtureId];
+	const deterministic = DETERMINISTIC_FIXTURES[fixtureId] ?? DEFAULT_REDUCTION_FIXTURE_LOGS[fixtureId];
 	if (deterministic) return { kind: "logs", logs: deterministic };
 	let session: GjcSessionContext;
 	try {

--- a/packages/orchestration-token-benchmark/src/index.ts
+++ b/packages/orchestration-token-benchmark/src/index.ts
@@ -22,9 +22,11 @@ export {
 } from "./default-reductions.ledger";
 export {
 	type DeltaReport,
+	LIVE_DEFAULT_CANDIDATE_FIXTURE_PAIRS,
 	LIVE_RUNNER_SCHEMA_VERSION,
 	type LiveRunDelta,
 	LiveRunnerError,
+	type LiveRunnerFixturePair,
 	type LiveRunnerOptions,
 	type LiveRunRegression,
 	type LiveRunReport,

--- a/packages/orchestration-token-benchmark/src/live-runner.ts
+++ b/packages/orchestration-token-benchmark/src/live-runner.ts
@@ -7,6 +7,58 @@ export interface LiveRunnerOptions {
 	outputDir: string;
 }
 
+export interface LiveRunnerFixturePair {
+	candidate: string;
+	beforeFixtureId: string;
+	afterFixtureId: string;
+	successCriterion: string;
+}
+
+export const LIVE_DEFAULT_CANDIDATE_FIXTURE_PAIRS: readonly LiveRunnerFixturePair[] = [
+	{
+		candidate: "task.maxRecursionDepth.default.2-to-1",
+		beforeFixtureId: "pr9.task-recursion.before",
+		afterFixtureId: "pr9.task-recursion.after",
+		successCriterion: "externally checked nested delegation outcome remains successful",
+	},
+	{
+		candidate: "outputCaps.default.500000-to-lower",
+		beforeFixtureId: "pr9.output-caps.before",
+		afterFixtureId: "pr9.output-caps.after",
+		successCriterion: "large output fact recovery succeeds through retained preview plus artifact reference",
+	},
+	{
+		candidate: "tools.maxInlineResultBytes.default.0-to-candidate",
+		beforeFixtureId: "pr9.max-inline-result-bytes.before",
+		afterFixtureId: "pr9.max-inline-result-bytes.after",
+		successCriterion: "inline tool text remains actionable and artifact recovery succeeds",
+	},
+	{
+		candidate: "tools.readArtifactSpillThreshold.default.0-to-candidate",
+		beforeFixtureId: "pr9.read-artifact-spill-threshold.before",
+		afterFixtureId: "pr9.read-artifact-spill-threshold.after",
+		successCriterion: "read workflow locates required facts through bounded output plus artifact reference",
+	},
+	{
+		candidate: "compaction.maintenancePruningEnabled.default.false-to-true",
+		beforeFixtureId: "pr9.maintenance-pruning.before",
+		afterFixtureId: "pr9.maintenance-pruning.after",
+		successCriterion: "stale-output pruning improves token/cache economics without task failure",
+	},
+	{
+		candidate: "appendOnlyContext.providerExpansion.default-held",
+		beforeFixtureId: "pr9.append-only-provider-expansion.before",
+		afterFixtureId: "pr9.append-only-provider-expansion.after",
+		successCriterion: "provider-specific prefix stability holds across candidate provider turns",
+	},
+	{
+		candidate: "rpc.compactMessageUpdateDeltas.default.false-to-true",
+		beforeFixtureId: "pr9.rpc-compact-deltas.before",
+		afterFixtureId: "pr9.rpc-compact-deltas.after",
+		successCriterion: "compact delta clients and legacy clients both receive equivalent message state",
+	},
+] as const;
+
 export interface LiveRunTotals {
 	turns: number;
 	inputTokens: number;
@@ -164,6 +216,12 @@ function parseReport(stdout: string, binaryPath: string, fixtureId: string): Liv
 	};
 }
 
+function resolveFixturePair(fixtureId: string): { beforeFixtureId: string; afterFixtureId: string } {
+	const pair = LIVE_DEFAULT_CANDIDATE_FIXTURE_PAIRS.find(candidate => candidate.candidate === fixtureId);
+	if (!pair) return { beforeFixtureId: fixtureId, afterFixtureId: fixtureId };
+	return { beforeFixtureId: pair.beforeFixtureId, afterFixtureId: pair.afterFixtureId };
+}
+
 export async function runOneBinary(
 	binaryPath: string,
 	fixtureId: string,
@@ -239,8 +297,9 @@ async function writeJson(path: string, value: unknown): Promise<void> {
 }
 
 export async function runLiveComparison(options: LiveRunnerOptions): Promise<DeltaReport> {
-	const before = await runOneBinary(options.beforeBinary, options.fixtureId);
-	const after = await runOneBinary(options.afterBinary, options.fixtureId);
+	const fixturePair = resolveFixturePair(options.fixtureId);
+	const before = await runOneBinary(options.beforeBinary, fixturePair.beforeFixtureId);
+	const after = await runOneBinary(options.afterBinary, fixturePair.afterFixtureId);
 	const delta = computeDelta(before, after);
 	const report: DeltaReport = {
 		schemaVersion: LIVE_RUNNER_SCHEMA_VERSION,

--- a/packages/orchestration-token-benchmark/test/default-reductions.ledger.test.ts
+++ b/packages/orchestration-token-benchmark/test/default-reductions.ledger.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { evaluateDefaultReduction } from "../src/default-reduction-gate";
 import { APPLIED_DEFAULT_REDUCTIONS, HELD_DEFAULT_REDUCTIONS } from "../src/default-reductions.ledger";
+import { LIVE_DEFAULT_CANDIDATE_FIXTURE_PAIRS } from "../src/live-runner";
 
 const EXPECTED_APPLIED_REDUCTIONS = [
 	{
@@ -127,6 +128,13 @@ describe("default reduction evidence ledger", () => {
 			expect(entry.requiresLiveEvidenceVia).toBe("pr9-live-runner");
 			expect(entry.reason).toContain("HELD/BLOCKED");
 			expect(entry.reason).toContain("PR9 live before/after runner evidence is required");
+		}
+	});
+
+	test("keeps held reductions backed by PR9 live fixture pairs", () => {
+		const candidatePairs = new Set(LIVE_DEFAULT_CANDIDATE_FIXTURE_PAIRS.map(pair => pair.candidate));
+		for (const entry of HELD_DEFAULT_REDUCTIONS) {
+			expect(candidatePairs.has(entry.candidate.name), entry.candidate.name).toBe(true);
 		}
 	});
 });

--- a/packages/orchestration-token-benchmark/test/live-runner.test.ts
+++ b/packages/orchestration-token-benchmark/test/live-runner.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	LIVE_DEFAULT_CANDIDATE_FIXTURE_PAIRS,
 	LIVE_RUNNER_SCHEMA_VERSION,
 	LiveRunnerError,
 	type LiveRunReport,
@@ -58,8 +59,8 @@ console.log(${JSON.stringify(stdout)});
 	await Bun.$`chmod +x ${path}`;
 	return path;
 }
-async function writeFixtureModeShim(dir: string, report: LiveRunReport): Promise<string> {
-	const path = join(dir, "gjc-fixture-shim");
+async function writeFixtureModeShim(dir: string, report: LiveRunReport, name = "gjc-fixture-shim"): Promise<string> {
+	const path = join(dir, name);
 	await Bun.write(
 		path,
 		`#!/usr/bin/env bun
@@ -93,6 +94,45 @@ describe("live runner", () => {
 		expect(await Bun.file(join(outputDir, "after.json")).exists()).toBe(true);
 		expect(await Bun.file(join(outputDir, "delta.json")).exists()).toBe(true);
 		expect(await Bun.file(join(outputDir, "report.md")).exists()).toBe(true);
+	});
+
+	it("live-runner.default-candidate-fixture-pairs", async () => {
+		const dir = await tempDir();
+		const pair = LIVE_DEFAULT_CANDIDATE_FIXTURE_PAIRS.find(
+			candidate => candidate.candidate === "tools.readArtifactSpillThreshold.default.0-to-candidate",
+		);
+		expect(pair).toBeDefined();
+		const before = await writeFixtureModeShim(dir, fakeReport("old", pair!.beforeFixtureId, 98_500), "gjc-before");
+		const after = await writeFixtureModeShim(dir, fakeReport("new", pair!.afterFixtureId, 20_100), "gjc-after");
+		const outputDir = join(dir, "out-pair");
+
+		const report = await runLiveComparison({
+			beforeBinary: before,
+			afterBinary: after,
+			fixtureId: pair!.candidate,
+			outputDir,
+		});
+
+		expect(report.before.fixtureId).toBe(pair!.beforeFixtureId);
+		expect(report.after.fixtureId).toBe(pair!.afterFixtureId);
+		expect(report.delta.totalTokens).toBe(-78_400);
+	});
+
+	it("defines one before/after fixture pair for each held PR9 default candidate", () => {
+		expect(LIVE_DEFAULT_CANDIDATE_FIXTURE_PAIRS.map(pair => pair.candidate).sort()).toEqual([
+			"appendOnlyContext.providerExpansion.default-held",
+			"compaction.maintenancePruningEnabled.default.false-to-true",
+			"outputCaps.default.500000-to-lower",
+			"rpc.compactMessageUpdateDeltas.default.false-to-true",
+			"task.maxRecursionDepth.default.2-to-1",
+			"tools.maxInlineResultBytes.default.0-to-candidate",
+			"tools.readArtifactSpillThreshold.default.0-to-candidate",
+		]);
+		for (const pair of LIVE_DEFAULT_CANDIDATE_FIXTURE_PAIRS) {
+			expect(pair.beforeFixtureId).toEndWith(".before");
+			expect(pair.afterFixtureId).toEndWith(".after");
+			expect(pair.successCriterion.length).toBeGreaterThan(20);
+		}
 	});
 
 	it("live-runner.missing-binary", async () => {


### PR DESCRIPTION
## Summary
- Adds deterministic PR9 `gjc --fixture` reports for held/default-off token-context candidate pairs.
- Teaches the live runner to resolve candidate names into explicit before/after fixture IDs while preserving same-fixture comparisons.
- Adds ledger/test coverage that held reductions remain blocked and backed by PR9 live fixture pairs; no behavior-changing defaults are flipped.

## Verification
- `bun test packages/coding-agent/src/cli/fixture-report.test.ts packages/orchestration-token-benchmark/test/live-runner.test.ts packages/orchestration-token-benchmark/test/default-reductions.ledger.test.ts packages/orchestration-token-benchmark/test/default-reduction-gate.test.ts`
- `bun --cwd=packages/orchestration-token-benchmark test`
- `bun --cwd=packages/orchestration-token-benchmark run check`
- `bun test packages/coding-agent/src/cli/fixture-report.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun packages/coding-agent/src/cli.ts --fixture pr9.read-artifact-spill-threshold.after`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*