### PR TITLE
fix(providers): bound OpenAI SDK 429 retries for usage-limit exhaustion

### DIFF
--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -35,6 +35,7 @@ import {
 	markToolChoiceIncapability,
 	resolveToolChoice,
 } from "../utils/tool-choice-capability";
+import { wrapOpenAIFetchForBoundedRateLimits } from "./openai-bounded-rate-limits";
 import { normalizeOpenAIResponsesPromptCacheKey, supportsDeveloperRole } from "./openai-responses";
 import {
 	appendResponsesToolResultMessages,
@@ -272,7 +273,7 @@ function createClient(model: Model<"azure-openai-responses">, apiKey: string, op
 
 	const { baseUrl, apiVersion } = resolveAzureConfig(model, options);
 
-	const baseFetch = options?.fetch ?? fetch;
+	const baseFetch = wrapOpenAIFetchForBoundedRateLimits(options?.fetch ?? fetch, options?.maxRetryDelayMs);
 	const onSseEvent = options?.onSseEvent;
 	return new AzureOpenAI({
 		apiKey,

--- a/packages/ai/src/providers/openai-bounded-rate-limits.ts
+++ b/packages/ai/src/providers/openai-bounded-rate-limits.ts
@@ -1,0 +1,57 @@
+import type { FetchImpl } from "../types";
+import { getRetryAfterMsFromHeaders } from "../utils/retry-after";
+
+const OPENAI_RETRY_DELAY_CAP_MS = 60_000;
+
+// Mirror of `wrapAnthropicFetchForBoundedRateLimits`: OpenAI-compatible providers
+// (e.g. opencode-go) return HTTP 429 for *permanent* usage/quota exhaustion — a
+// monthly-cap reset that can be days away. The OpenAI SDK treats 429 as transient
+// and retries up to `maxRetries`, honoring an out-of-range `Retry-After`; the
+// `create()` call then hangs before the error can surface to the agent loop, so
+// no assistant error is produced and the session-level retry/fallback never runs.
+// Detect exhaustion and set `x-should-retry: false` so the SDK gives up at once
+// and the session retry layer applies its own fail-fast (retry-after > maxDelayMs).
+//
+// Shared by every adapter that drives a raw OpenAI SDK client — openai-completions,
+// openai-responses, and azure-openai-responses. Adapters that route through
+// `fetchWithRetry` (codex, bedrock, ollama, gemini-cli) already bound 429 retries
+// themselves and do not need this wrapper.
+export function isOpenAIUsageExhaustionResponse(
+	bodyText: string,
+	retryAfterMs: number | undefined,
+	retryDelayCapMs: number,
+): boolean {
+	if (retryAfterMs !== undefined && retryAfterMs > retryDelayCapMs) return true;
+	return /monthly usage limit|usage limit reached|usage_limit_reached|out_of_credits|insufficient_quota|quota[ _]?exceeded/i.test(
+		bodyText,
+	);
+}
+
+export function wrapOpenAIFetchForBoundedRateLimits(
+	baseFetch: FetchImpl,
+	maxRetryDelayMs: number | undefined,
+): FetchImpl {
+	const retryDelayCapMs = maxRetryDelayMs ?? OPENAI_RETRY_DELAY_CAP_MS;
+	return Object.assign(
+		async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			const response = await baseFetch(input, init);
+			if (response.status !== 429 || retryDelayCapMs === 0) return response;
+
+			const headers = new Headers(response.headers);
+			const retryAfterMs = getRetryAfterMsFromHeaders(headers);
+			const bodyText = await response
+				.clone()
+				.text()
+				.catch(() => "");
+			if (!isOpenAIUsageExhaustionResponse(bodyText, retryAfterMs, retryDelayCapMs)) return response;
+
+			headers.set("x-should-retry", "false");
+			return new Response(bodyText, {
+				status: response.status,
+				statusText: response.statusText,
+				headers,
+			});
+		},
+		baseFetch.preconnect ? { preconnect: baseFetch.preconnect } : {},
+	);
+}

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -72,6 +72,7 @@ import {
 	hasCopilotVisionInput,
 	resolveGitHubCopilotBaseUrl,
 } from "./github-copilot-headers";
+import { wrapOpenAIFetchForBoundedRateLimits } from "./openai-bounded-rate-limits";
 import { detectOpenAICompat, type ResolvedOpenAICompat, resolveOpenAICompat } from "./openai-completions-compat";
 import {
 	applyOpenAIRequestTransformBody,
@@ -454,6 +455,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				options?.authCredentialType,
 				options?.requestMaxRetries,
 				options?.sessionId,
+				options?.maxRetryDelayMs,
 			);
 			const premiumRequestsTotal = copilotPremiumRequests;
 			getCapturedErrorResponse = captureErrorResponse;
@@ -956,6 +958,7 @@ async function createClient(
 	authCredentialType?: OpenAICompletionsOptions["authCredentialType"],
 	requestMaxRetries?: number,
 	sessionId?: string,
+	maxRetryDelayMs?: number,
 ): Promise<{
 	client: OpenAI;
 	copilotPremiumRequests: number | undefined;
@@ -1063,8 +1066,9 @@ async function createClient(
 		},
 		baseFetch.preconnect ? { preconnect: baseFetch.preconnect } : {},
 	);
+	const boundedFetch = wrapOpenAIFetchForBoundedRateLimits(wrappedFetch, maxRetryDelayMs);
 	const transformedFetch = wrapFetchForOpenAIRequestTransform(
-		wrappedFetch,
+		boundedFetch,
 		model.requestTransform,
 		`Gajae-Code/${packageJson.version}`,
 	);

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -71,6 +71,7 @@ import {
 	resolveGitHubCopilotBaseUrl,
 } from "./github-copilot-headers";
 import { compactGrammarDefinition } from "./grammar";
+import { wrapOpenAIFetchForBoundedRateLimits } from "./openai-bounded-rate-limits";
 import {
 	applyOpenAIRequestTransformBody,
 	applyOpenAIRequestTransformHeaders,
@@ -274,6 +275,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 				options?.fetch,
 				options?.authCredentialType,
 				options?.requestMaxRetries,
+				options?.maxRetryDelayMs,
 			);
 			const premiumRequestsTotal = copilotPremiumRequests;
 			const providerSessionState = getOpenAIResponsesProviderSessionState(model, options?.providerSessionState);
@@ -400,6 +402,7 @@ function createClient(
 	fetchOverride?: FetchImpl,
 	authCredentialType?: OpenAIResponsesOptions["authCredentialType"],
 	requestMaxRetries?: number,
+	maxRetryDelayMs?: number,
 ): {
 	client: OpenAI;
 	copilotPremiumRequests: number | undefined;
@@ -446,8 +449,9 @@ function createClient(
 		headers["x-client-request-id"] ??= sessionId;
 	}
 	const baseFetch = fetchOverride ?? fetch;
+	const boundedFetch = wrapOpenAIFetchForBoundedRateLimits(baseFetch, maxRetryDelayMs);
 	const transformedFetch = wrapFetchForOpenAIRequestTransform(
-		baseFetch,
+		boundedFetch,
 		model.requestTransform,
 		`Gajae-Code/${packageJson.version}`,
 	);

--- a/packages/ai/test/openai-bounded-rate-limits.test.ts
+++ b/packages/ai/test/openai-bounded-rate-limits.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import {
+	isOpenAIUsageExhaustionResponse,
+	wrapOpenAIFetchForBoundedRateLimits,
+} from "@gajae-code/ai/providers/openai-bounded-rate-limits";
+
+describe("isOpenAIUsageExhaustionResponse", () => {
+	it("flags an out-of-range Retry-After as exhaustion", () => {
+		expect(isOpenAIUsageExhaustionResponse("", 20 * 60_000, 60_000)).toBe(true);
+	});
+
+	it("does not flag a short Retry-After without a body marker", () => {
+		expect(isOpenAIUsageExhaustionResponse("", 5_000, 60_000)).toBe(false);
+	});
+
+	it("flags monthly usage-limit body copy (opencode-go)", () => {
+		expect(
+			isOpenAIUsageExhaustionResponse("Monthly usage limit reached. Resets in 15 days.", undefined, 60_000),
+		).toBe(true);
+	});
+
+	it("flags out_of_credits / insufficient_quota bodies", () => {
+		expect(isOpenAIUsageExhaustionResponse('{"error":{"type":"insufficient_quota"}}', undefined, 60_000)).toBe(true);
+		expect(isOpenAIUsageExhaustionResponse("out_of_credits", undefined, 60_000)).toBe(true);
+	});
+
+	it("does not flag a plain transient 429 body", () => {
+		expect(isOpenAIUsageExhaustionResponse("Too Many Requests", 1_000, 60_000)).toBe(false);
+	});
+});
+
+describe("wrapOpenAIFetchForBoundedRateLimits", () => {
+	const makeFetch =
+		(status: number, body: string, headers: Record<string, string> = {}) =>
+		async (): Promise<Response> =>
+			new Response(body, { status, headers });
+
+	it("injects x-should-retry:false on a usage-exhaustion 429", async () => {
+		const wrapped = wrapOpenAIFetchForBoundedRateLimits(
+			makeFetch(429, "Monthly usage limit reached. Resets in 15 days."),
+			60_000,
+		);
+		const res = await wrapped("https://example/v1/chat/completions");
+		expect(res.status).toBe(429);
+		expect(res.headers.get("x-should-retry")).toBe("false");
+		// Body is preserved so the surfaced error still explains the cause.
+		expect(await res.text()).toContain("Monthly usage limit reached");
+	});
+
+	it("leaves a transient 429 untouched so the SDK may still retry", async () => {
+		const wrapped = wrapOpenAIFetchForBoundedRateLimits(
+			makeFetch(429, "Too Many Requests", { "retry-after": "1" }),
+			60_000,
+		);
+		const res = await wrapped("https://example/v1/chat/completions");
+		expect(res.headers.get("x-should-retry")).toBeNull();
+	});
+
+	it("passes non-429 responses through unchanged", async () => {
+		const wrapped = wrapOpenAIFetchForBoundedRateLimits(makeFetch(200, "ok"), 60_000);
+		const res = await wrapped("https://example/v1/chat/completions");
+		expect(res.status).toBe(200);
+		expect(res.headers.get("x-should-retry")).toBeNull();
+	});
+
+	it("is disabled when the retry-delay cap is 0", async () => {
+		const wrapped = wrapOpenAIFetchForBoundedRateLimits(makeFetch(429, "Monthly usage limit reached."), 0);
+		const res = await wrapped("https://example/v1/chat/completions");
+		expect(res.headers.get("x-should-retry")).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary
- add a shared `wrapOpenAIFetchForBoundedRateLimits` (+ `isOpenAIUsageExhaustionResponse`) mirroring the existing anthropic guard: on a permanent usage/quota 429 — `Retry-After` beyond the cap, or an exhaustion body marker (`monthly usage limit`, `insufficient_quota`, `out_of_credits`, …) — it injects `x-should-retry: false` so the OpenAI SDK stops retrying and the session retry layer fails fast
- wire it into every adapter that drives a raw OpenAI SDK client: `openai-completions`, `openai-responses`, `azure-openai-responses` (threading `maxRetryDelayMs` through each `createClient` fetch chain)
- leave `fetchWithRetry`-based adapters (`codex`, `bedrock`, `ollama`, `gemini-cli`) and `anthropic` untouched — they already bound 429 retries

## Motivation
On a monthly usage-limit 429 the server returns a `Retry-After` that can be ~15 days out. The OpenAI SDK treats 429 as transient and retries up to `maxRetries`, honoring that delay, so `client.responses.create()` / `chat.completions.create()` hangs before the error can surface — no assistant message, and the session-level retry/fallback never runs. 401s are non-retryable and surface normally, which is what isolates this to 429. `anthropic` already guards this via `wrapAnthropicFetchForBoundedRateLimits`; this restores the same symmetry for the three OpenAI-SDK adapters.

## Verification
- `bun test packages/ai/test/openai-bounded-rate-limits.test.ts packages/ai/test/openai-completions-compat.test.ts packages/ai/test/openai-completions-tool-choice.test.ts packages/ai/test/openai-responses-tool-choice.test.ts packages/ai/test/openai-responses-system-prompt.test.ts packages/ai/test/azure-openai-responses-stream.test.ts packages/ai/test/azure-openai-responses-tool-choice.test.ts` — 69 pass
- `bun --cwd=packages/ai run check:types` — tsgo, no errors
- `bunx biome check` on the 5 changed files — clean
