### PR TITLE
chore(config): demote unsafe default-off optimization knobs

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -551,9 +551,9 @@ export const SETTINGS_SCHEMA = {
 		default: 0,
 		ui: {
 			tab: "tools",
-			label: "Read-tool artifact spill threshold (KB)",
+			label: "Experimental read-tool artifact spill threshold (KB)",
 			description:
-				"Combined-size cap for `read` output across all requested ranges. Above this the full output is saved as an artifact and a bounded head+tail snippet is kept inline. Higher than the general spill threshold so ordinary inspection reads stay inline; 0 disables read spill (falls back to the absolute inline backstop only).",
+				"Advanced opt-in only: combined-size cap for `read` output across all requested ranges. Above this the full output is saved as an artifact and a bounded head+tail snippet is kept inline. Live layofflabs/gpt-5.5 medium evidence on 2026-07-07 found no token savings and a lower cache-hit rate at 50 KB, so normal coding sessions should leave this Off unless intentionally measuring large-read behavior.",
 			options: [
 				{ value: "0", label: "Off", description: "Default; no read-specific spill (backstop only)" },
 				{ value: "50", label: "50 KB", description: "~12.5K tokens" },
@@ -1440,31 +1440,14 @@ export const SETTINGS_SCHEMA = {
 
 	"compaction.remoteEndpoint": { type: "string", default: undefined },
 
-	// Below-threshold maintenance pruning (Finding 13). DEFAULT-OFF and BLOCKED
-	// from default-on until live TaskTokenLog (#6) evidence justifies it: pruning
-	// rewrites already-sent history and forces a provider cache-epoch reset, so it
-	// only pays off when the estimated stale savings clearly exceed that reset.
-	"compaction.maintenancePruningEnabled": {
-		type: "boolean",
-		default: false,
-		ui: {
-			tab: "context",
-			label: "Below-threshold maintenance pruning",
-			description:
-				"Opt-in: prune stale tool outputs BELOW the compaction threshold when the estimated savings are large enough to outweigh a prompt-cache-epoch reset. Off by default (evidence-gated); enabling it trades one cache reset for reclaimed context.",
-		},
-	},
+	// Below-threshold maintenance pruning (Finding 13). Internal/measurement-only:
+	// keep the runtime setting for targeted experiments, but do not expose it in
+	// settings UI. Live layofflabs/gpt-5.5 medium evidence on 2026-07-07 showed no
+	// savings and a cache-hit regression; pruning rewrites already-sent history and
+	// can force a provider cache-epoch reset.
+	"compaction.maintenancePruningEnabled": { type: "boolean", default: false },
 
-	"compaction.maintenancePruningMinSavingsTokens": {
-		type: "number",
-		default: 8000,
-		ui: {
-			tab: "context",
-			label: "Maintenance pruning min savings (tokens)",
-			description:
-				"Minimum estimated stale-prunable token savings required before below-threshold maintenance pruning runs. Kept high so a cache-epoch reset is only spent for a large reclaim.",
-		},
-	},
+	"compaction.maintenancePruningMinSavingsTokens": { type: "number", default: 8000 },
 
 	// Idle compaction
 	"compaction.idleEnabled": {

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -340,7 +340,7 @@
 				},
 				"readArtifactSpillThreshold": {
 					"type": "number",
-					"description": "Combined-size cap for `read` output across all requested ranges. Above this the full output is saved as an artifact and a bounded head+tail snippet is kept inline. Higher than the general spill threshold so ordinary inspection reads stay inline; 0 disables read spill (falls back to the absolute inline backstop only).",
+					"description": "Advanced opt-in only: combined-size cap for `read` output across all requested ranges. Above this the full output is saved as an artifact and a bounded head+tail snippet is kept inline. Live layofflabs/gpt-5.5 medium evidence on 2026-07-07 found no token savings and a lower cache-hit rate at 50 KB, so normal coding sessions should leave this Off unless intentionally measuring large-read behavior.",
 					"default": 0
 				},
 				"fileMentionInlineBytes": {
@@ -982,12 +982,10 @@
 				},
 				"maintenancePruningEnabled": {
 					"type": "boolean",
-					"description": "Opt-in: prune stale tool outputs BELOW the compaction threshold when the estimated savings are large enough to outweigh a prompt-cache-epoch reset. Off by default (evidence-gated); enabling it trades one cache reset for reclaimed context.",
 					"default": false
 				},
 				"maintenancePruningMinSavingsTokens": {
 					"type": "number",
-					"description": "Minimum estimated stale-prunable token savings required before below-threshold maintenance pruning runs. Kept high so a cache-epoch reset is only spent for a large reclaim.",
 					"default": 8000
 				},
 				"idleEnabled": {


### PR DESCRIPTION
## Summary

- Demote `tools.readArtifactSpillThreshold` in settings UI copy to explicitly experimental/advanced, with the 2026-07-07 live `layofflabs/gpt-5.5 --thinking medium` result called out.
- Remove public UI metadata for `compaction.maintenancePruningEnabled` and `compaction.maintenancePruningMinSavingsTokens`, keeping the runtime settings available for internal/measurement-only experiments.
- Regenerate `schemas/config.schema.json`.

## Rationale

Live A/B checks after #1779 showed these knobs should not be presented as normal default-on candidates:

- `tools.readArtifactSpillThreshold=50KB`: task succeeded, but total tokens slightly increased and cache-hit rate dropped materially in the large-read fixture.
- `compaction.maintenancePruningEnabled=true`: task succeeded, but showed no savings and a small cache-hit regression; the feature can also rewrite already-sent history and force a cache-epoch reset.

This keeps the measurement paths available while making the product surface match the evidence: read spill is advanced/experimental, maintenance pruning is internal/measurement-only.

## Verification

- `bun test packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/tools/read-artifact-spill.test.ts packages/orchestration-token-benchmark/test/live-runner.test.ts` — 32 pass / 0 fail
- `bun --cwd=packages/coding-agent run check` — biome + tsgo clean
- `bun scripts/generate-json-schemas.ts --check`

## Notes

No behavior-changing defaults are flipped.
