### PR TITLE
Fix Windows Terminal clear-on-shrink viewport repaint

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1849,7 +1849,11 @@ export class TUI extends Container {
 		// Configurable via setClearOnShrink() or PI_CLEAR_ON_SHRINK=0 env var
 		if (this.#clearOnShrink && newLines.length < this.#previousLines.length && this.overlayStack.length === 0) {
 			logRedraw(`clearOnShrink (prev=${this.#previousLines.length}, new=${newLines.length})`);
-			fullRender(true, "clearOnShrink");
+			if (useViewportRepaintPath()) {
+				viewportRepaint(`clearOnShrink (prev=${this.#previousLines.length}, new=${newLines.length})`);
+			} else {
+				fullRender(true, "clearOnShrink");
+			}
 			return;
 		}
 

--- a/packages/tui/test/viewport-scroll.test.ts
+++ b/packages/tui/test/viewport-scroll.test.ts
@@ -17,6 +17,10 @@ class Lines implements Component {
 		this.#lines = this.#lines.map((value, currentIndex) => (currentIndex === index ? line : value));
 	}
 
+	replace(lines: string[]): void {
+		this.#lines = [...lines];
+	}
+
 	render(_width: number): string[] {
 		return this.#lines;
 	}
@@ -103,6 +107,36 @@ describe("TUI manual viewport paging", () => {
 			await settle(term);
 
 			expect(visible(term)).toEqual(["line-7", "line-8", "line-9", "line-10", "line-11"]);
+			expect(term.getWriteLog().join("")).not.toContain("\x1b[2J\x1b[H");
+		} finally {
+			tui.stop();
+			if (previousWtSession === undefined) {
+				delete Bun.env.WT_SESSION;
+			} else {
+				Bun.env.WT_SESSION = previousWtSession;
+			}
+		}
+	});
+
+	it("keeps Windows Terminal pinned when offscreen status lines disappear", async () => {
+		const term = new VirtualTerminal(30, 5);
+		const tui = new TUI(term);
+		const content = new Lines(["status-0", ...Array.from({ length: 11 }, (_value, index) => `line-${index}`)]);
+		tui.addChild(content);
+		const previousWtSession = Bun.env.WT_SESSION;
+		Bun.env.WT_SESSION = "test-windows-terminal-session";
+
+		try {
+			tui.start();
+			await settle(term);
+			expect(visible(term)).toEqual(["line-6", "line-7", "line-8", "line-9", "line-10"]);
+			term.clearWriteLog();
+
+			content.replace(Array.from({ length: 11 }, (_value, index) => `line-${index}`));
+			tui.requestRender();
+			await settle(term);
+
+			expect(visible(term)).toEqual(["line-6", "line-7", "line-8", "line-9", "line-10"]);
 			expect(term.getWriteLog().join("")).not.toContain("\x1b[2J\x1b[H");
 		} finally {
 			tui.stop();


### PR DESCRIPTION
## Summary
- Route Windows Terminal/tmux-style clear-on-shrink redraws through the viewport repaint path instead of full transcript replay.
- Add a regression where an offscreen transient status line disappears while the live viewport remains pinned.

## Verification
- `bunx biome check packages/tui/src/tui.ts packages/tui/test/viewport-scroll.test.ts`
- `bun --cwd=packages/tui run check:types`
- `bun test packages/tui/test/viewport-scroll.test.ts packages/tui/test/resize-replay-storm.test.ts`
- `bun test packages/tui/test/render-regressions.test.ts --test-name-pattern "offscreen changes in tmux|legacy full-render|Windows Terminal"`

## Context
#1745 guarded Windows Terminal for offscreen changes and resize/force redraw paths, but clear-on-shrink still called `fullRender(true)` unconditionally. When a streaming/transient status row above the live viewport disappears, that path can still emit `\x1b[2J\x1b[H` and replay the transcript in Windows Terminal.