### PR TITLE
feat(ai): parse Anthropic weekly_scoped usage limits

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Anthropic usage now parses the modern `limits[]` array's `weekly_scoped` entries (model-scoped weekly limits such as a "Claude Fable 5" weekly cap) that the legacy `seven_day_opus`/`seven_day_sonnet` buckets no longer report. Each entry is emitted as an `anthropic:7d:<model>` limit with the model display name as its tier, and a payload carrying only modern scoped limits now counts as usage data instead of being retried and dropped.
+
 - Capped OpenCode Go Kimi reasoning efforts that the Go chat-completions endpoint rejects (`kimi-k2.5:minimal` → `low`, `kimi-k2.7-code:xhigh|max` → `high`) and degraded forced `tool_choice` for those models so Kimi Go sessions and title-generation turns no longer fail with generic upstream 400s.
 
 ## [0.8.2] - 2026-07-06

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Anthropic usage now parses the modern `limits[]` array's `weekly_scoped` entries (model-scoped weekly limits such as a "Claude Fable 5" weekly cap) that the legacy `seven_day_opus`/`seven_day_sonnet` buckets no longer report. Each entry is emitted as an `anthropic:7d:<model>` limit with the model display name as its tier, and a payload carrying only modern scoped limits now counts as usage data instead of being retried and dropped.
+- Anthropic usage now parses the modern `limits[]` array's `weekly_scoped` entries (model-scoped weekly limits such as a "Claude Fable 5" weekly cap) that the legacy `seven_day_opus`/`seven_day_sonnet` buckets no longer report. Each entry is emitted as an `anthropic:7d:<model>` limit with the model display name as its tier, and a payload carrying only modern scoped limits now counts as usage data instead of being retried and dropped. Fail-closed: entries without a numeric percent and a derivable model identity are ignored and never satisfy the usage-data gate.
 
 - Capped OpenCode Go Kimi reasoning efforts that the Go chat-completions endpoint rejects (`kimi-k2.5:minimal` → `low`, `kimi-k2.7-code:xhigh|max` → `high`) and degraded forced `tool_choice` for those models so Kimi Go sessions and title-generation turns no longer fail with generic upstream 400s.
 

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -63,6 +63,8 @@ interface ClaudeUsageResponse {
 	seven_day?: ClaudeUsageBucket | null;
 	seven_day_opus?: ClaudeUsageBucket | null;
 	seven_day_sonnet?: ClaudeUsageBucket | null;
+	/** Modern limits[] array carrying e.g. model-scoped weekly limits. */
+	limits?: unknown[] | null;
 }
 
 type ClaudeUsagePayload = {
@@ -126,7 +128,8 @@ function hasUsageData(payload: ClaudeUsageResponse): boolean {
 		parseBucket(payload.five_hour)?.utilization !== undefined ||
 		parseBucket(payload.seven_day)?.utilization !== undefined ||
 		parseBucket(payload.seven_day_opus)?.utilization !== undefined ||
-		parseBucket(payload.seven_day_sonnet)?.utilization !== undefined
+		parseBucket(payload.seven_day_sonnet)?.utilization !== undefined ||
+		parseScopedWeeklyLimits(payload).length > 0
 	);
 }
 
@@ -325,6 +328,44 @@ function buildUsageLimit(args: {
 	};
 }
 
+/**
+ * Parse the modern `limits[]` array's `weekly_scoped` entries: model-scoped
+ * weekly limits (e.g. a "Claude Fable 5" weekly cap) that the legacy
+ * seven_day_opus/seven_day_sonnet buckets no longer report. Each entry becomes
+ * an `anthropic:7d:<model>` limit with the model display name as its tier.
+ */
+function parseScopedWeeklyLimits(payload: ClaudeUsageResponse): UsageLimit[] {
+	const entries = Array.isArray(payload.limits) ? payload.limits : [];
+	const scoped: UsageLimit[] = [];
+	for (const entry of entries) {
+		if (!isRecord(entry) || entry.kind !== "weekly_scoped") continue;
+		const percent = toNumber(entry.percent);
+		if (percent === undefined) continue;
+		const scope = isRecord(entry.scope) ? entry.scope : undefined;
+		const model = scope && isRecord(scope.model) ? scope.model : undefined;
+		const displayName =
+			model && typeof model.display_name === "string" && model.display_name.trim()
+				? model.display_name.trim()
+				: undefined;
+		const tier = displayName ? displayName.toLowerCase() : "scoped";
+		const limit = buildUsageLimit({
+			id: `anthropic:7d:${tier}`,
+			label: displayName ? `Claude 7 Day (${displayName})` : "Claude 7 Day (scoped)",
+			windowId: "7d",
+			windowLabel: "7 Day",
+			durationMs: SEVEN_DAYS_MS,
+			bucket: {
+				utilization: percent,
+				resetsAt: parseIsoTime(typeof entry.resets_at === "string" ? entry.resets_at : undefined),
+			},
+			provider: "anthropic",
+			tier,
+		});
+		if (limit) scoped.push(limit);
+	}
+	return scoped;
+}
+
 async function fetchClaudeUsage(params: UsageFetchParams, ctx: UsageFetchContext): Promise<UsageReport | null> {
 	if (params.provider !== "anthropic") return null;
 	const credential = params.credential;
@@ -388,6 +429,7 @@ async function fetchClaudeUsage(params: UsageFetchParams, ctx: UsageFetchContext
 			tier: "sonnet",
 		}),
 	].filter((limit): limit is UsageLimit => limit !== null);
+	limits.push(...parseScopedWeeklyLimits(payload));
 
 	if (limits.length === 0) return null;
 	const identity = extractUsageIdentity(payload, orgId);

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -333,6 +333,9 @@ function buildUsageLimit(args: {
  * weekly limits (e.g. a "Claude Fable 5" weekly cap) that the legacy
  * seven_day_opus/seven_day_sonnet buckets no longer report. Each entry becomes
  * an `anthropic:7d:<model>` limit with the model display name as its tier.
+ * Fail-closed: an entry without a numeric percent AND a derivable model
+ * identity is ignored, so malformed scoped entries are never trusted as usage
+ * data (and never satisfy the hasUsageData gate).
  */
 function parseScopedWeeklyLimits(payload: ClaudeUsageResponse): UsageLimit[] {
 	const entries = Array.isArray(payload.limits) ? payload.limits : [];
@@ -347,10 +350,11 @@ function parseScopedWeeklyLimits(payload: ClaudeUsageResponse): UsageLimit[] {
 			model && typeof model.display_name === "string" && model.display_name.trim()
 				? model.display_name.trim()
 				: undefined;
-		const tier = displayName ? displayName.toLowerCase() : "scoped";
+		if (!displayName) continue;
+		const tier = displayName.toLowerCase();
 		const limit = buildUsageLimit({
 			id: `anthropic:7d:${tier}`,
-			label: displayName ? `Claude 7 Day (${displayName})` : "Claude 7 Day (scoped)",
+			label: `Claude 7 Day (${displayName})`,
 			windowId: "7d",
 			windowLabel: "7 Day",
 			durationMs: SEVEN_DAYS_MS,

--- a/packages/ai/test/claude-usage-headers.test.ts
+++ b/packages/ai/test/claude-usage-headers.test.ts
@@ -111,4 +111,74 @@ describe("claude usage request headers", () => {
 
 		expect(report?.limits[0]?.window?.resetsAt).toBeUndefined();
 	});
+
+	it("parses modern limits[] weekly_scoped entries as model-scoped 7d limits", async () => {
+		const now = Date.now();
+		const resetsAt = new Date(now + 3 * 24 * 60 * 60 * 1000).toISOString();
+		const fetchMock = (async () => {
+			return new Response(
+				JSON.stringify({
+					five_hour: { utilization: 42 },
+					limits: [
+						{
+							kind: "weekly_scoped",
+							percent: 63,
+							resets_at: resetsAt,
+							scope: { model: { display_name: "Fable" } },
+						},
+						// Unknown kinds and malformed entries are ignored.
+						{ kind: "monthly_total", percent: 10 },
+						{ kind: "weekly_scoped" },
+						"garbage",
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const report = await claudeUsageProvider.fetchUsage(
+			{
+				provider: "anthropic",
+				credential: {
+					type: "oauth",
+					accessToken: "oat-test-access-token",
+					expiresAt: Date.now() + 60_000,
+				},
+			},
+			{ fetch: fetchMock },
+		);
+
+		const scoped = report?.limits.find(limit => limit.id === "anthropic:7d:fable");
+		expect(scoped).toBeDefined();
+		expect(scoped?.label).toBe("Claude 7 Day (Fable)");
+		expect(scoped?.scope.tier).toBe("fable");
+		expect(scoped?.amount.used).toBe(63);
+		expect(scoped?.window?.resetsAt).toBe(Date.parse(resetsAt));
+		expect(report?.limits.map(limit => limit.id)).toEqual(["anthropic:5h", "anthropic:7d:fable"]);
+	});
+
+	it("accepts a payload that only carries modern weekly_scoped limits", async () => {
+		const fetchMock = (async () => {
+			return new Response(
+				JSON.stringify({
+					limits: [{ kind: "weekly_scoped", percent: 5, scope: { model: { display_name: "Fable" } } }],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const report = await claudeUsageProvider.fetchUsage(
+			{
+				provider: "anthropic",
+				credential: {
+					type: "oauth",
+					accessToken: "oat-test-access-token",
+					expiresAt: Date.now() + 60_000,
+				},
+			},
+			{ fetch: fetchMock },
+		);
+
+		expect(report?.limits.map(limit => limit.id)).toEqual(["anthropic:7d:fable"]);
+	});
 });

--- a/packages/ai/test/claude-usage-headers.test.ts
+++ b/packages/ai/test/claude-usage-headers.test.ts
@@ -126,9 +126,13 @@ describe("claude usage request headers", () => {
 							resets_at: resetsAt,
 							scope: { model: { display_name: "Fable" } },
 						},
-						// Unknown kinds and malformed entries are ignored.
+						// Unknown kinds and malformed entries are ignored, including
+						// scoped entries whose model identity cannot be derived.
 						{ kind: "monthly_total", percent: 10 },
 						{ kind: "weekly_scoped" },
+						{ kind: "weekly_scoped", percent: 10 },
+						{ kind: "weekly_scoped", percent: 10, scope: { model: {} } },
+						{ kind: "weekly_scoped", percent: 10, scope: { model: { display_name: "   " } } },
 						"garbage",
 					],
 				}),
@@ -180,5 +184,30 @@ describe("claude usage request headers", () => {
 		);
 
 		expect(report?.limits.map(limit => limit.id)).toEqual(["anthropic:7d:fable"]);
+	});
+
+	it("rejects a modern payload whose weekly_scoped entries carry no model identity", async () => {
+		const fetchMock = (async () => {
+			return new Response(
+				JSON.stringify({
+					limits: [{ kind: "weekly_scoped", percent: 5 }],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const report = await claudeUsageProvider.fetchUsage(
+			{
+				provider: "anthropic",
+				credential: {
+					type: "oauth",
+					accessToken: "oat-test-access-token",
+					expiresAt: Date.now() + 60_000,
+				},
+			},
+			{ fetch: fetchMock, retryWait: async () => {} },
+		);
+
+		expect(report).toBeNull();
 	});
 });


### PR DESCRIPTION
## What

Anthropic usage parsing now handles the modern `limits[]` array's `weekly_scoped` entries: model-scoped weekly limits (e.g. a "Claude Fable 5" weekly cap). Each entry is emitted as an `anthropic:7d:<model>` limit with the model display name (lowercased) as its tier. `hasUsageData` also counts scoped entries, so a payload carrying only modern limits is accepted instead of being retried and then dropped.

## Why

Anthropic's usage payload moved model-scoped weekly windows out of the legacy `seven_day_opus`/`seven_day_sonnet` buckets into a `limits[]` array of `{ kind: "weekly_scoped", percent, resets_at, scope: { model: { display_name } } }` entries. The current parser only reads the legacy buckets, so those windows silently vanish from usage reports: accounts with model-scoped weekly limits show no 7d window for that model in the status line or usage surfaces. Verified against live Anthropic OAuth usage responses.

Unknown `kind`s and malformed entries are ignored (fail-closed), matching the defensive parsing style of `parseBucket`.

## Testing

- New tests in `packages/ai/test/claude-usage-headers.test.ts`:
  - `parses modern limits[] weekly_scoped entries as model-scoped 7d limits` (id/label/tier/percent/resetsAt, and unknown kinds / malformed entries / non-object entries are skipped).
  - `accepts a payload that only carries modern weekly_scoped limits` (the `hasUsageData` gate).
- `bun test packages/ai/test/claude-usage-headers.test.ts` - 4 pass.
- `tsgo -p packages/ai/tsconfig.json --noEmit` and `biome check` - clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
