### PR TITLE
Fix composer paste autocomplete triggers

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1911,6 +1911,11 @@ export class Editor implements Component, Focusable {
 		this.#historyIndex = -1; // Exit history browsing mode
 		this.#resetKillSequence();
 		this.#recordUndoState();
+		const hadAutocomplete = this.#autocompleteState !== null;
+		this.#cancelAutocomplete();
+		if (hadAutocomplete) {
+			this.onAutocompleteUpdate?.();
+		}
 
 		this.#withUndoSuspended(() => {
 			// Some terminals (e.g. tmux popups with extended-keys-format=csi-u) re-encode
@@ -1938,21 +1943,12 @@ export class Editor implements Component, Focusable {
 			const tabExpandedText = cleanText.replace(/\t/g, "    ");
 
 			// Filter out non-printable characters except newlines
-			let filteredText = tabExpandedText
+			const filteredText = tabExpandedText
 				.split("")
 				.filter(char => char === "\n" || char.charCodeAt(0) >= 32)
 				.join("");
 
-			// If pasting a file path (starts with /, ~, or .) and the character before
-			// the cursor is a word character, prepend a space for better readability
-			if (/^[/~.]/.test(filteredText)) {
-				const currentLine = this.#state.lines[this.#state.cursorLine] || "";
-				const charBeforeCursor = this.#state.cursorCol > 0 ? currentLine[this.#state.cursorCol - 1] : "";
-				if (charBeforeCursor && /\w/.test(charBeforeCursor)) {
-					filteredText = ` ${filteredText}`;
-				}
-			}
-
+			if (filteredText.length === 0) return;
 			// Split into lines
 			const pastedLines = filteredText.split("\n");
 
@@ -1974,15 +1970,10 @@ export class Editor implements Component, Focusable {
 				return;
 			}
 
-			if (pastedLines.length === 1) {
-				// Single line - insert character by character to trigger autocomplete
-				for (const char of filteredText) {
-					this.#insertCharacter(char);
-				}
-				return;
-			}
-
-			// Multi-line paste - use insertTextAtCursor for proper handling
+			// Paste is literal input, not typed input. Insert atomically so leading
+			// trigger characters such as "/", "#", "@", ":", or path-like text do
+			// not open or update autocomplete lists while preserving normal typed
+			// trigger behavior.
 			this.#insertTextAtCursor(filteredText);
 		});
 	}

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -319,6 +319,140 @@ describe("Editor component", () => {
 			await expect(promise).resolves.toBe("@");
 		});
 
+		it("triggers prompt-action autocomplete when typing hash", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const { promise, resolve } = Promise.withResolvers<string>();
+
+			editor.setAutocompleteProvider({
+				async getSuggestions(lines, cursorLine, cursorCol) {
+					const currentLine = lines[cursorLine] ?? "";
+					resolve(currentLine.slice(0, cursorCol));
+					return { items: [{ label: "#undo", value: "#undo" }], prefix: "#" };
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			editor.handleInput("#");
+
+			await expect(promise).resolves.toBe("#");
+		});
+
+		it("inserts trigger-leading bracketed paste literally without autocomplete", async () => {
+			const cases = [
+				"# Heading",
+				"/not-a-command prompt",
+				"@literal file mention",
+				":literal shortcode",
+				"./relative/path prompt",
+				"~/literal/path prompt",
+				"# Heading\nbody with /slash and @mention",
+			];
+
+			for (const pasted of cases) {
+				const editor = new Editor(defaultEditorTheme);
+				const suggestionCalls: string[] = [];
+				editor.setAutocompleteProvider({
+					async getSuggestions(lines, cursorLine, cursorCol) {
+						const currentLine = lines[cursorLine] ?? "";
+						suggestionCalls.push(currentLine.slice(0, cursorCol));
+						return { items: [{ label: "suggestion", value: "suggestion" }], prefix: pasted[0] ?? "" };
+					},
+					applyCompletion(lines, cursorLine, cursorCol) {
+						return { lines, cursorLine, cursorCol };
+					},
+				});
+
+				editor.handleInput(`\x1b[200~${pasted}\x1b[201~`);
+				await Bun.sleep(120);
+
+				expect(editor.getText()).toBe(pasted);
+				expect(editor.isShowingAutocomplete()).toBe(false);
+				expect(suggestionCalls).toEqual([]);
+			}
+		});
+
+		it("cancels stale autocomplete before applying bracketed paste", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const pending = Promise.withResolvers<{
+				items: Array<{ label: string; value: string }>;
+				prefix: string;
+			} | null>();
+			let suggestionCalls = 0;
+
+			editor.setAutocompleteProvider({
+				async getSuggestions() {
+					suggestionCalls += 1;
+					return pending.promise;
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			editor.handleInput("/");
+			await Bun.sleep(0);
+			expect(suggestionCalls).toBe(1);
+
+			editor.handleInput("\x1b[200~# pasted prompt\x1b[201~");
+			pending.resolve({ items: [{ label: "/help", value: "help" }], prefix: "/" });
+			await Bun.sleep(0);
+
+			expect(editor.getText()).toBe("/# pasted prompt");
+			expect(editor.isShowingAutocomplete()).toBe(false);
+			expect(suggestionCalls).toBe(1);
+		});
+
+		it("closes open autocomplete before applying bracketed paste", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			let suggestionCalls = 0;
+
+			editor.setAutocompleteProvider({
+				async getSuggestions() {
+					suggestionCalls += 1;
+					return { items: [{ label: "/help", value: "help" }], prefix: "/" };
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			editor.handleInput("/");
+			await Bun.sleep(0);
+			expect(editor.isShowingAutocomplete()).toBe(true);
+
+			editor.handleInput("\x1b[200~# pasted prompt\x1b[201~");
+			await Bun.sleep(120);
+
+			expect(editor.getText()).toBe("/# pasted prompt");
+			expect(editor.isShowingAutocomplete()).toBe(false);
+			expect(suggestionCalls).toBe(1);
+		});
+
+		it("preserves exact pasted text after existing content", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const suggestionCalls: string[] = [];
+			editor.setText("prefix");
+			editor.setAutocompleteProvider({
+				async getSuggestions(lines, cursorLine, cursorCol) {
+					const currentLine = lines[cursorLine] ?? "";
+					suggestionCalls.push(currentLine.slice(0, cursorCol));
+					return { items: [{ label: "path", value: "path" }], prefix: "/" };
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			editor.handleInput("\x1b[200~/tmp/copied\x1b[201~");
+			await Bun.sleep(120);
+
+			expect(editor.getText()).toBe("prefix/tmp/copied");
+			expect(editor.isShowingAutocomplete()).toBe(false);
+			expect(suggestionCalls).toEqual([]);
+		});
+
 		it("chains into argument completions after tab-completing slash command names", async () => {
 			const editor = new Editor(defaultEditorTheme);
 			editor.setAutocompleteProvider(


### PR DESCRIPTION
## Title
Fix composer paste autocomplete triggers

## Problem summary
Pasting copied prompts into the GJC composer could be corrupted when the pasted text started with trigger characters such as `#`, `/`, `@`, `:`, `./`, or `~/`. The editor treated single-line bracketed paste like typed input, so autocomplete/dropdown state could open, update, or remain stale while paste content was being inserted.

## Reproduction / context
Examples covered by the regression tests:
- Paste `# Heading` into an empty composer
- Paste `/not-a-command prompt` into an empty composer
- Paste `@literal file mention`, `:literal shortcode`, `./relative/path prompt`, or `~/literal/path prompt`
- Paste a multiline markdown prompt beginning with `# Heading`
- Paste while slash autocomplete is pending or already open
- Paste `/tmp/copied` after existing text and expect exact insertion without an injected space

## Proposed fix / implementation
- Cancel and invalidate autocomplete before applying bracketed paste.
- Insert sanitized paste content atomically via the paste insertion path instead of replaying single-line paste character-by-character through typed-input handling.
- Remove the path-leading auto-space mutation for pasted text so copied content is preserved exactly under the editor's existing normalization/sanitization behavior.
- Keep typed trigger behavior unchanged for normal `/`, `@`, and `#` keystrokes.

## Affected files
- `packages/tui/src/components/editor.ts`
- `packages/tui/test/editor.test.ts`

## Tests run
- `git diff --check`
- `bun --cwd=packages/tui run check`
- `bun test packages/tui/test/editor.test.ts` — 144 pass, 442 assertions

## Uncertainty / remaining risks
No known blockers. The change is scoped to bracketed paste handling in the TUI editor. Large paste marker behavior remains on the existing marker path, but autocomplete is cancelled before the marker is inserted.