### PR TITLE
Hint history search in composer placeholder

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -118,7 +118,7 @@ import { UiHelpers } from "./utils/ui-helpers";
 
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
 const COMPOSER_NEWLINE_HINT = process.platform === "win32" ? "Alt+Enter/Ctrl+J" : "Shift+Enter/Ctrl+J";
-const DEFAULT_COMPOSER_PLACEHOLDER = `Type your message... ${COMPOSER_NEWLINE_HINT}: New line · Ctrl+C: Clear · Shift+Tab: Reasoning`;
+export const DEFAULT_COMPOSER_PLACEHOLDER = `Type your message... ${COMPOSER_NEWLINE_HINT}: New line · Ctrl+C: Clear · Ctrl+R: Search history · Shift+Tab: Reasoning`;
 const WELCOME_RESERVED_CONTAINER_CHILD_LIMIT = 8;
 const FRIENDLY_KEY_PARTS: Record<string, string> = {
 	alt: "Alt",

--- a/packages/coding-agent/test/composer-placeholder.test.ts
+++ b/packages/coding-agent/test/composer-placeholder.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_COMPOSER_PLACEHOLDER } from "../src/modes/interactive-mode";
+
+describe("composer placeholder", () => {
+	it("advertises history search shortcut", () => {
+		expect(DEFAULT_COMPOSER_PLACEHOLDER).toContain("Ctrl+R: Search history");
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -112,6 +112,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(rendered).toContain("Type your message...");
 		expect(rendered).toContain(expectedNewlineShortcutHint());
 		expect(rendered).toContain("Ctrl+C: Clear");
+		expect(rendered).toContain("Ctrl+R: Search history");
 		expect(rendered).toContain("Shift+Tab: Reasoning");
 		expect(rendered).not.toContain("Enter: Steer");
 		expect(rendered).not.toContain(expectedQueueShortcutHint());


### PR DESCRIPTION
## Title
Hint history search in composer placeholder

## Problem summary
The composer already supports history search via Ctrl+R, but the placeholder only advertised newline, clear, and reasoning shortcuts. Users who rely on arrow-key history browsing may miss the faster searchable history flow.

## Reproduction / context
Open the interactive composer with an empty input. The placeholder mentions the existing shortcuts but does not mention `Ctrl+R: Search history`.

## Proposed fix / implementation
- Add `Ctrl+R: Search history` to the default composer placeholder.
- Keep the existing busy-state placeholder behavior, so the history hint remains visible alongside Enter queue/steer hints when applicable.
- Add focused coverage for the exported default placeholder and the existing rendered composer placeholder test.

## Affected files
- `packages/coding-agent/src/modes/interactive-mode.ts`
- `packages/coding-agent/test/interactive-mode-editor-component.test.ts`
- `packages/coding-agent/test/composer-placeholder.test.ts`

## Tests run
- `git diff --check origin/dev..HEAD`
- `bun test packages/coding-agent/test/composer-placeholder.test.ts`
- `bun --cwd=packages/coding-agent run check`

## Uncertainty / remaining risks
No known blockers. The full interactive-mode editor component test still hits a local Windows temp-dir EBUSY cleanup issue in this workstation, so the focused placeholder assertion was added in a lightweight unit test and the package type/format check was run successfully.