### PR TITLE
Fix /btw panel manual viewport scrolling

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -530,19 +530,13 @@ export class TUI extends Container {
 		const pageStep = Math.max(1, height - 1);
 		const targetViewportTop = Math.max(0, Math.min(maxViewportTop, currentViewportTop + direction * pageStep));
 
-		if (targetViewportTop >= maxViewportTop) {
-			this.#manualViewportTop = undefined;
-		} else {
-			this.#manualViewportTop = targetViewportTop;
-		}
-
-		const cursorPos = this.#manualViewportTop === undefined ? this.#lastCursorPosition : null;
+		this.#manualViewportTop = targetViewportTop;
 		return this.#repaintViewportFromLines(
 			this.#previousLines,
 			width,
 			height,
 			targetViewportTop,
-			cursorPos,
+			null,
 			"manual viewport scroll",
 		);
 	}
@@ -1695,9 +1689,8 @@ export class TUI extends Container {
 		if (this.#manualViewportTop !== undefined) {
 			const maxViewportTop = Math.max(0, newLines.length - height);
 			const nextViewportTop = Math.max(0, Math.min(maxViewportTop, this.#manualViewportTop));
-			const followingLive = nextViewportTop >= maxViewportTop;
-			this.#manualViewportTop = followingLive ? undefined : nextViewportTop;
-			const repaintCursorPos = followingLive ? cursorPos : null;
+			this.#manualViewportTop = nextViewportTop;
+			const repaintCursorPos = null;
 			if (
 				this.#repaintViewportFromLines(
 					newLines,

--- a/packages/tui/test/viewport-scroll.test.ts
+++ b/packages/tui/test/viewport-scroll.test.ts
@@ -87,6 +87,45 @@ describe("TUI manual viewport paging", () => {
 		}
 	});
 
+	it("keeps manual viewport control after paging to live while transient panel streams", async () => {
+		const term = new VirtualTerminal(30, 6);
+		const tui = new TUI(term);
+		const content = new Lines(Array.from({ length: 12 }, (_value, index) => `line-${index}`));
+		const transientPanel = new Lines([]);
+		const status = new Lines(["status"]);
+		const editor = new Lines(["editor"]);
+		tui.addChild(content);
+		tui.addChild(transientPanel);
+		tui.addChild(status);
+		tui.addChild(editor);
+		tui.setBottomPinnedComponent(status);
+
+		try {
+			tui.start();
+			await settle(term);
+			expect(visible(term)).toEqual(["line-8", "line-9", "line-10", "line-11", "status", "editor"]);
+
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			expect(visible(term)).toEqual(["line-3", "line-4", "line-5", "line-6", "line-7", "line-8"]);
+
+			expect(tui.scrollViewportPages(1)).toBe(true);
+			await term.flush();
+			expect(visible(term)).toEqual(["line-8", "line-9", "line-10", "line-11", "status", "editor"]);
+
+			transientPanel.replace(["btw-0", "btw-1"]);
+			tui.requestRender();
+			await settle(term);
+
+			expect(visible(term)).toEqual(["line-8", "line-9", "line-10", "line-11", "btw-0", "btw-1"]);
+			expect(tui.followLiveViewport()).toBe(true);
+			await term.flush();
+			expect(visible(term)).toEqual(["line-10", "line-11", "btw-0", "btw-1", "status", "editor"]);
+		} finally {
+			tui.stop();
+		}
+	});
+
 	it("keeps Windows Terminal live output pinned when offscreen lines change during streaming", async () => {
 		const term = new VirtualTerminal(30, 5);
 		const tui = new TUI(term);


### PR DESCRIPTION
## Summary
- Keep manual transcript viewport mode active even after paging back to the current live bottom.
- Preserve manual viewport position across transient /btw-style panel streaming before bottom-pinned status/editor rows.
- Add a focused viewport regression test for the pinned/transient-panel state transition.

## Validation
- `bun test packages/tui/test/viewport-scroll.test.ts`
- `bun test packages/coding-agent/test/modes/controllers/btw-controller.test.ts packages/coding-agent/test/modes/controllers/btw-escape-dismiss.test.ts packages/coding-agent/test/slash-commands/btw.test.ts packages/coding-agent/test/input-controller-escape.test.ts`
- `bun --cwd=packages/tui run check`

Closes #1793

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*