### PR TITLE
fix(tui): avoid Windows terminal scroll jumps

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Native Windows console hosts now use the live-viewport repaint path even when `WT_SESSION` is missing, and full clears avoid `3J` there, preventing Windows Terminal/PowerShell from jumping to the transcript top during forced redraws such as prompt bells and context compaction.
 
 ## [0.8.2] - 2026-07-06
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -88,6 +88,9 @@ export interface Terminal {
 	// Whether terminal output is still writable
 	get available(): boolean;
 
+	// True for the real process stdin/stdout terminal (not virtual test terminals).
+	readonly isProcessTerminal?: boolean;
+
 	// Get terminal dimensions
 	get columns(): number;
 	get rows(): number;
@@ -197,6 +200,10 @@ export class ProcessTerminal implements Terminal {
 	#osc11PollTimer?: Timer;
 	#mode2031DebounceTimer?: Timer;
 	#progressTimer?: ReturnType<typeof setInterval>;
+
+	get isProcessTerminal(): boolean {
+		return true;
+	}
 
 	get kittyProtocolActive(): boolean {
 		return this.#kittyProtocolActive;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -137,16 +137,22 @@ function parseSizeValue(value: SizeValue | undefined, referenceSize: number): nu
 	return undefined;
 }
 
-function isTermuxSession(): boolean {
-	return Boolean(process.env.TERMUX_VERSION);
+function isTermuxSession(env: Record<string, string | undefined> = Bun.env): boolean {
+	return Boolean(env.TERMUX_VERSION);
 }
 
 const GJC_TMUX_LAUNCHED_ENV = "GJC_TMUX_LAUNCHED";
 const DISABLED_ENV_VALUES = new Set(["0", "false", "off", "no"]);
+const TRUTHY_ENV_VALUES = new Set(["1", "true", "yes", "on", "y"]);
 
 function envIsEnabled(value: string | undefined): boolean {
 	const normalized = value?.trim().toLowerCase();
 	return normalized !== undefined && normalized.length > 0 && !DISABLED_ENV_VALUES.has(normalized);
+}
+
+function envFlagEnabled(value: string | undefined): boolean {
+	const normalized = value?.trim().toLowerCase();
+	return normalized !== undefined && TRUTHY_ENV_VALUES.has(normalized);
 }
 
 function termLooksMultiplexed(value: string | undefined): boolean {
@@ -154,32 +160,60 @@ function termLooksMultiplexed(value: string | undefined): boolean {
 	return term.startsWith("tmux") || term.startsWith("screen");
 }
 
-function isWindowsTerminalSession(): boolean {
-	return envIsEnabled(Bun.env.WT_SESSION) || Bun.env.TERM_PROGRAM === "Windows_Terminal";
-}
-
-function isViewportRepaintSession(): boolean {
-	return isMultiplexerSession() || isWindowsTerminalSession();
+function isWindowsTerminalSession(env: Record<string, string | undefined> = Bun.env): boolean {
+	return envIsEnabled(env.WT_SESSION) || env.TERM_PROGRAM === "Windows_Terminal";
 }
 
 /** Detect terminal multiplexers where scrollback clearing and height-change redraws are hostile. */
-function isMultiplexerSession(): boolean {
+function isMultiplexerSession(env: Record<string, string | undefined> = Bun.env): boolean {
 	return Boolean(
-		envIsEnabled(Bun.env.TMUX) ||
-			envIsEnabled(Bun.env.TMUX_PANE) ||
-			envIsEnabled(Bun.env.STY) ||
-			envIsEnabled(Bun.env.ZELLIJ) ||
-			envIsEnabled(Bun.env[GJC_TMUX_LAUNCHED_ENV]) ||
-			termLooksMultiplexed(Bun.env.TERM),
+		envIsEnabled(env.TMUX) ||
+			envIsEnabled(env.TMUX_PANE) ||
+			envIsEnabled(env.STY) ||
+			envIsEnabled(env.ZELLIJ) ||
+			envIsEnabled(env[GJC_TMUX_LAUNCHED_ENV]) ||
+			termLooksMultiplexed(env.TERM),
 	);
 }
 
-function useLegacyMultiplexerFullRender(): boolean {
-	return $flag("PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER");
+function useLegacyMultiplexerFullRender(env: Record<string, string | undefined> = Bun.env): boolean {
+	return envFlagEnabled(env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER);
 }
 
-function useViewportRepaintPath(): boolean {
-	return isViewportRepaintSession() && !(isMultiplexerSession() && useLegacyMultiplexerFullRender());
+function isViewportSensitiveHost(
+	env: Record<string, string | undefined>,
+	platform: NodeJS.Platform,
+	includeNativeWindows: boolean,
+): boolean {
+	return isMultiplexerSession(env) || isWindowsTerminalSession(env) || (includeNativeWindows && platform === "win32");
+}
+/**
+ * True when repainting only the live viewport is safer than clearing/replaying
+ * the full transcript. Native Windows console hosts are included even when
+ * WT_SESSION is absent because PowerShell/ConPTY launch chains can drop terminal
+ * identity variables while keeping the same scroll-jump behavior.
+ */
+export function shouldUseViewportRepaintForHost(
+	env: Record<string, string | undefined> = Bun.env,
+	platform: NodeJS.Platform = process.platform,
+	options: { includeNativeWindows?: boolean } = {},
+): boolean {
+	const multiplexed = isMultiplexerSession(env);
+	const includeNativeWindows = options.includeNativeWindows ?? true;
+	return (
+		isViewportSensitiveHost(env, platform, includeNativeWindows) &&
+		!(multiplexed && useLegacyMultiplexerFullRender(env))
+	);
+}
+
+function useViewportRepaintPath(terminal: Terminal): boolean {
+	return shouldUseViewportRepaintForHost(Bun.env, process.platform, {
+		includeNativeWindows: terminal.isProcessTerminal === true,
+	});
+}
+
+function shouldPreserveScrollbackOnFullClear(terminal: Terminal): boolean {
+	return isViewportSensitiveHost(Bun.env, process.platform, terminal.isProcessTerminal === true);
 }
 
 /**
@@ -908,13 +942,13 @@ export class TUI extends Container {
 	 * `fullRender` path. In terminal multiplexers that path skips the scrollback-clearing
 	 * `3J` escape (users navigate scrollback history), so replaying every transcript line
 	 * piles it back on top of scrollback — the "top of screen scrolls down to the prompt at
-	 * high speed" resize storm. Windows Terminal can also visibly jump to the
-	 * transcript top during streaming redraws, so viewport-repaint sessions keep
-	 * force off and let `#doRender` repaint only the live viewport. Set
+	 * high speed" resize storm. Windows Terminal/ConPTY can also visibly jump to
+	 * the transcript top during streaming redraws, so viewport-repaint sessions
+	 * keep force off and let `#doRender` repaint only the live viewport. Set
 	 * `PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER=1` to restore the legacy tmux redraw.
 	 */
 	requestResizeRender(): void {
-		this.requestRender(!useViewportRepaintPath() && !isTermuxSession(), "resize");
+		this.requestRender(!useViewportRepaintPath(this.terminal) && !isTermuxSession(), "resize");
 	}
 
 	requestRender(force = false, source = "unknown"): void {
@@ -924,7 +958,7 @@ export class TUI extends Container {
 		}
 		if (renderMetrics.enabled) renderMetrics.recordRequest(source);
 		if (force) {
-			const preserveViewportCursor = useViewportRepaintPath();
+			const preserveViewportCursor = useViewportRepaintPath(this.terminal);
 			// A forced full redraw supersedes any queued input-priority render.
 			this.#inputRenderPending = false;
 			this.#previousLines = [];
@@ -1712,8 +1746,10 @@ export class TUI extends Container {
 			this.#fullRedrawCount += 1;
 			if (renderMetrics.enabled) renderMetrics.recordFullRedraw(reason);
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
-			// Skip clearing scrollback (3J) in multiplexers — users actively navigate scrollback history
-			if (clear) buffer += isMultiplexerSession() ? "\x1b[2J\x1b[H" : "\x1b[2J\x1b[H\x1b[3J";
+			// Skip clearing scrollback (3J) in hosts where clear/replay can snap the
+			// native viewport away from the live prompt (tmux/screen, Windows ConPTY).
+			if (clear)
+				buffer += shouldPreserveScrollbackOnFullClear(this.terminal) ? "\x1b[2J\x1b[H" : "\x1b[2J\x1b[H\x1b[3J";
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
 				// Lines were pre-terminated/normalized by #applyLineResets; image
@@ -1810,7 +1846,7 @@ export class TUI extends Container {
 		// Width changes always need a full re-render because wrapping changes.
 		if (widthChanged) {
 			logRedraw(`terminal width changed (${this.#previousWidth} -> ${width})`);
-			if (useViewportRepaintPath()) {
+			if (useViewportRepaintPath(this.terminal)) {
 				// In viewport-repaint sessions a full replay can either pile the transcript
 				// back onto scrollback (tmux/screen) or visibly jump to the transcript top
 				// (Windows Terminal). Repaint the viewport only, mirroring the height-change
@@ -1826,7 +1862,7 @@ export class TUI extends Container {
 		// but Termux changes height when the software keyboard shows or hides.
 		// In that environment, a full redraw causes the entire history to replay on every toggle.
 		if (heightChanged) {
-			if (useViewportRepaintPath()) {
+			if (useViewportRepaintPath(this.terminal)) {
 				viewportRepaint(`terminal height changed (${this.#previousHeight} -> ${height})`);
 				return;
 			}
@@ -1842,7 +1878,7 @@ export class TUI extends Container {
 		// Configurable via setClearOnShrink() or PI_CLEAR_ON_SHRINK=0 env var
 		if (this.#clearOnShrink && newLines.length < this.#previousLines.length && this.overlayStack.length === 0) {
 			logRedraw(`clearOnShrink (prev=${this.#previousLines.length}, new=${newLines.length})`);
-			if (useViewportRepaintPath()) {
+			if (useViewportRepaintPath(this.terminal)) {
 				viewportRepaint(`clearOnShrink (prev=${this.#previousLines.length}, new=${newLines.length})`);
 			} else {
 				fullRender(true, "clearOnShrink");
@@ -1903,7 +1939,7 @@ export class TUI extends Container {
 				const extraLines = this.#previousLines.length - newLines.length;
 				if (extraLines > height) {
 					logRedraw(`extraLines > height (${extraLines} > ${height})`);
-					if (useViewportRepaintPath()) {
+					if (useViewportRepaintPath(this.terminal)) {
 						viewportRepaint(`extraLines > height (${extraLines} > ${height})`);
 					} else {
 						fullRender(true, "extraLines > height");
@@ -1945,7 +1981,7 @@ export class TUI extends Container {
 		// back to live.
 		if (firstChanged < prevViewportTop) {
 			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			if (useViewportRepaintPath()) {
+			if (useViewportRepaintPath(this.terminal)) {
 				viewportRepaint(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
 				return;
 			}

--- a/packages/tui/test/resize-replay-storm.test.ts
+++ b/packages/tui/test/resize-replay-storm.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Text } from "../src/components/text";
-import { TUI } from "../src/tui";
+import { shouldUseViewportRepaintForHost, TUI } from "../src/tui";
 import { VirtualTerminal } from "./virtual-terminal";
 
 // Regression test for the multiplexer scrollback replay storm.
@@ -40,6 +40,26 @@ function distinctReplayedLineMarkers(out: string): number {
 }
 
 describe("multiplexer resize replay storm regression", () => {
+	describe("viewport-sensitive host detection", () => {
+		it("uses viewport repaint for native Windows even when WT_SESSION is missing", () => {
+			expect(shouldUseViewportRepaintForHost({ TERM: "xterm-256color" }, "win32")).toBe(true);
+		});
+
+		it("keeps the legacy full-render opt-in scoped to multiplexers", () => {
+			expect(
+				shouldUseViewportRepaintForHost(
+					{ TERM: "tmux-256color", PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER: "1" },
+					"linux",
+				),
+			).toBe(false);
+			expect(
+				shouldUseViewportRepaintForHost(
+					{ WT_SESSION: "windows-terminal", PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER: "1" },
+					"linux",
+				),
+			).toBe(true);
+		});
+	});
 	describe("in a multiplexer (TMUX set)", () => {
 		let origTmux: string | undefined;
 
@@ -117,6 +137,70 @@ describe("multiplexer resize replay storm regression", () => {
 
 			const out = term.getWriteLog().join("");
 			expect(distinctReplayedLineMarkers(out)).toBeLessThanOrEqual(term.rows + 2);
+
+			tui.stop();
+		});
+	});
+
+	describe("in Windows Terminal", () => {
+		let origWtSession: string | undefined;
+		let origTermProgram: string | undefined;
+		let origTmux: string | undefined;
+		let origTmuxPane: string | undefined;
+		let origSty: string | undefined;
+		let origZellij: string | undefined;
+		let origLaunched: string | undefined;
+
+		beforeEach(() => {
+			origWtSession = Bun.env.WT_SESSION;
+			origTermProgram = Bun.env.TERM_PROGRAM;
+			origTmux = Bun.env.TMUX;
+			origTmuxPane = Bun.env.TMUX_PANE;
+			origSty = Bun.env.STY;
+			origZellij = Bun.env.ZELLIJ;
+			origLaunched = Bun.env.GJC_TMUX_LAUNCHED;
+			Bun.env.WT_SESSION = "test-windows-terminal-session";
+			delete Bun.env.TMUX;
+			delete Bun.env.TMUX_PANE;
+			delete Bun.env.STY;
+			delete Bun.env.ZELLIJ;
+			delete Bun.env.GJC_TMUX_LAUNCHED;
+		});
+
+		afterEach(() => {
+			if (origWtSession === undefined) delete Bun.env.WT_SESSION;
+			else Bun.env.WT_SESSION = origWtSession;
+			if (origTermProgram === undefined) delete Bun.env.TERM_PROGRAM;
+			else Bun.env.TERM_PROGRAM = origTermProgram;
+			if (origTmux === undefined) delete Bun.env.TMUX;
+			else Bun.env.TMUX = origTmux;
+			if (origTmuxPane === undefined) delete Bun.env.TMUX_PANE;
+			else Bun.env.TMUX_PANE = origTmuxPane;
+			if (origSty === undefined) delete Bun.env.STY;
+			else Bun.env.STY = origSty;
+			if (origZellij === undefined) delete Bun.env.ZELLIJ;
+			else Bun.env.ZELLIJ = origZellij;
+			if (origLaunched === undefined) delete Bun.env.GJC_TMUX_LAUNCHED;
+			else Bun.env.GJC_TMUX_LAUNCHED = origLaunched;
+		});
+
+		it("requestRender(true) repaints only the viewport without clearing scrollback", async () => {
+			const term = new VirtualTerminal(COLS, 30);
+			const tui = new TUI(term);
+			tui.start();
+			await term.waitForRender();
+
+			await buildTranscript(tui, term, 60);
+			term.clearWriteLog();
+
+			// Prompt bells and compaction rebuilds can force a render while the
+			// transcript is long. Windows Terminal must not receive a 2J/H/3J full replay.
+			tui.requestRender(true, "test.windows.force");
+			await term.waitForRender();
+
+			const out = term.getWriteLog().join("");
+			expect(distinctReplayedLineMarkers(out)).toBeLessThanOrEqual(term.rows + 2);
+			expect(out).not.toContain("\x1b[3J");
 
 			tui.stop();
 		});
@@ -224,6 +308,8 @@ describe("multiplexer resize replay storm regression", () => {
 		let origZellij: string | undefined;
 		let origLaunched: string | undefined;
 		let origTerm: string | undefined;
+		let origWtSession: string | undefined;
+		let origTermProgram: string | undefined;
 
 		beforeEach(() => {
 			origTmux = process.env.TMUX;
@@ -232,11 +318,15 @@ describe("multiplexer resize replay storm regression", () => {
 			origZellij = process.env.ZELLIJ;
 			origLaunched = process.env.GJC_TMUX_LAUNCHED;
 			origTerm = process.env.TERM;
+			origWtSession = process.env.WT_SESSION;
+			origTermProgram = process.env.TERM_PROGRAM;
 			delete process.env.TMUX;
 			delete process.env.TMUX_PANE;
 			delete process.env.STY;
 			delete process.env.ZELLIJ;
 			delete process.env.GJC_TMUX_LAUNCHED;
+			delete process.env.WT_SESSION;
+			delete process.env.TERM_PROGRAM;
 			process.env.TERM = "xterm-256color";
 		});
 
@@ -253,9 +343,13 @@ describe("multiplexer resize replay storm regression", () => {
 			else process.env.GJC_TMUX_LAUNCHED = origLaunched;
 			if (origTerm === undefined) delete process.env.TERM;
 			else process.env.TERM = origTerm;
+			if (origWtSession === undefined) delete process.env.WT_SESSION;
+			else process.env.WT_SESSION = origWtSession;
+			if (origTermProgram === undefined) delete process.env.TERM_PROGRAM;
+			else process.env.TERM_PROGRAM = origTermProgram;
 		});
 
-		it("requestRender(true) replays the whole transcript (fullRender + 3J clears scrollback cleanly)", async () => {
+		it("uses the host-appropriate forced redraw policy without multiplexer markers", async () => {
 			const term = new VirtualTerminal(COLS, 30);
 			const tui = new TUI(term);
 			tui.start();
@@ -268,10 +362,19 @@ describe("multiplexer resize replay storm regression", () => {
 			await term.waitForRender();
 
 			const out = term.getWriteLog().join("");
-			// Outside multiplexers fullRender replays every line (and 3J clears the
-			// scrollback, so it is visually clean). This pins that the guard only
-			// changes behavior under multiplexers.
-			expect(distinctReplayedLineMarkers(out)).toBeGreaterThanOrEqual(55);
+			const shouldViewportRepaint = shouldUseViewportRepaintForHost({ TERM: "xterm-256color" }, process.platform, {
+				includeNativeWindows: false,
+			});
+			if (shouldViewportRepaint) {
+				expect(distinctReplayedLineMarkers(out)).toBeLessThanOrEqual(term.rows + 2);
+				expect(out).not.toContain("\x1b[3J");
+			} else {
+				// Outside viewport-sensitive hosts, fullRender replays every line and
+				// 3J clears scrollback cleanly. This pins that non-Windows plain terminals
+				// keep the historical clear/replay path.
+				expect(distinctReplayedLineMarkers(out)).toBeGreaterThanOrEqual(55);
+				expect(out).toContain("\x1b[3J");
+			}
 
 			tui.stop();
 		});


### PR DESCRIPTION
## Summary
- Treat native Windows process terminals as viewport-sensitive even when WT_SESSION is absent, so forced redraws repaint only the live viewport instead of replaying the full transcript.
- Preserve scrollback on full clears for tmux/screen and Windows ConPTY by avoiding 3J in those hosts.
- Add regression coverage for Windows Terminal forced redraws, native Windows host detection, and legacy tmux opt-in behavior.

## Verification
- bun test packages/tui/test/resize-replay-storm.test.ts packages/tui/test/viewport-scroll.test.ts
- bun --cwd=packages/tui run check

Note: `gjc contribute-pr --no-spawn` was run locally to prepare contribution artifacts; generated `.gjc/contribution-prep` files were not committed.