### PR TITLE
fix(team): target GJC-managed leader session by name on Windows/psmux (#531)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `gjc team` on Windows/psmux now targets the GJC-managed leader session by name instead of trusting the inherited `TMUX_PANE`. `gjc --tmux` propagates the managed session name to the child via `GJC_TMUX_ACTIVE_SESSION`, and `readCurrentTmuxLeaderContext` prefers it when resolving the leader pane. Under psmux the inherited `TMUX_PANE` can resolve to the wrong/default session, so a `ralplan -> ultragoal -> team` handoff could split/send workers into the wrong leader session; native tmux/WSL flows (no `GJC_TMUX_ACTIVE_SESSION`) keep the existing `TMUX_PANE`/ambient-session behavior (#531).
+
 ## [0.9.0] - 2026-07-07
 ### Added
 

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -13,6 +13,7 @@ import {
 	buildGjcTmuxSessionName,
 	buildGjcTmuxSessionSlug,
 	GJC_DEFAULT_TMUX_SESSION,
+	GJC_TMUX_ACTIVE_SESSION_ENV,
 	GJC_TMUX_COMMAND_ENV,
 	GJC_TMUX_MOUSE_ENV,
 	GJC_TMUX_PROFILE_ENV,
@@ -688,6 +689,11 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 			extraEnv: {
 				[GJC_COORDINATOR_SESSION_ID_ENV]: sessionId,
 				[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]: sessionStateFile,
+				// Carry the GJC-managed session name into the child so `gjc team`
+				// can target the correct leader session by name. Under psmux on
+				// Windows the inherited TMUX_PANE can resolve to the wrong/default
+				// session, which would split/send workers into the wrong session.
+				[GJC_TMUX_ACTIVE_SESSION_ENV]: sessionName,
 			},
 			platform,
 		},

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -22,6 +22,7 @@ import {
 import {
 	buildGjcTmuxExactOptionTarget,
 	buildGjcTmuxUntaggedSessionHint,
+	GJC_TMUX_ACTIVE_SESSION_ENV,
 	GJC_TMUX_PROFILE_OPTION,
 	GJC_TMUX_PROFILE_VALUE,
 	resolveGjcTmuxCommand,
@@ -1922,16 +1923,22 @@ function tagTmuxSessionAsGjcLeader(tmuxCommand: string, sessionName: string): bo
 function readCurrentTmuxLeaderContext(tmuxCommand: string, env: NodeJS.ProcessEnv): GjcTmuxLeaderContext {
 	if (Bun.which(tmuxCommand) === null)
 		throw new Error(buildTeamTmuxLeaderRequirementMessage(`tmux_not_installed:${tmuxCommand}`));
-	const paneTarget = env.TMUX_PANE?.trim();
-	const args = paneTarget
-		? ["display-message", "-p", "-t", paneTarget, "#S:#I #{pane_id}"]
+	// Prefer the explicit GJC-managed session name propagated by `gjc --tmux`
+	// (GJC_TMUX_ACTIVE_SESSION). Under psmux on Windows the inherited TMUX_PANE
+	// can resolve to the wrong/default session, so querying the tagged session
+	// by name is authoritative for GJC-launched leaders. Fall back to TMUX_PANE,
+	// then to the ambient session, to keep native tmux/WSL flows unchanged.
+	const activeSession = env[GJC_TMUX_ACTIVE_SESSION_ENV]?.trim();
+	const displayTarget = activeSession ? buildGjcTmuxExactOptionTarget(activeSession, { env }) : env.TMUX_PANE?.trim();
+	const args = displayTarget
+		? ["display-message", "-p", "-t", displayTarget, "#S:#I #{pane_id}"]
 		: ["display-message", "-p", "#S:#I #{pane_id}"];
 	const result = Bun.spawnSync([tmuxCommand, ...args], { stdout: "pipe", stderr: "pipe" });
 	if (result.exitCode !== 0) {
 		// Distinguish "you are not inside any tmux session" from a genuine tmux
 		// query failure so the caller gets actionable guidance instead of raw
 		// tmux stderr. `gjc team` needs a tmux leader; outside tmux there is none.
-		const insideTmux = Boolean(env.TMUX?.trim() || env.TMUX_PANE?.trim());
+		const insideTmux = Boolean(env.TMUX?.trim() || env.TMUX_PANE?.trim() || activeSession);
 		const stderr = result.stderr.toString().trim();
 		throw new Error(
 			buildTeamTmuxLeaderRequirementMessage(

--- a/packages/coding-agent/src/gjc-runtime/tmux-common.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-common.ts
@@ -4,6 +4,7 @@ import { resolveGjcTmuxBinary } from "./psmux-detect";
 export const GJC_DEFAULT_TMUX_SESSION = "gajae_code";
 export const GJC_TMUX_SESSION_PREFIX = `${GJC_DEFAULT_TMUX_SESSION}_`;
 export const GJC_TMUX_COMMAND_ENV = "GJC_TMUX_COMMAND";
+export const GJC_TMUX_ACTIVE_SESSION_ENV = "GJC_TMUX_ACTIVE_SESSION";
 export const GJC_TMUX_PROFILE_ENV = "GJC_TMUX_PROFILE";
 export const GJC_TMUX_MOUSE_ENV = "GJC_MOUSE";
 export const GJC_TMUX_PROFILE_OPTION = "@gjc-profile";

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -88,6 +88,8 @@ case "$1" in
       %2) echo "test-session:0 %2" ;;
       %9) echo "other-session:0 %9" ;;
       %1) echo "test-session:0 %1" ;;
+      =test-session:*|=test-session|test-session:*|test-session) echo "test-session:0 %1" ;;
+      =other-session:*|=other-session|other-session:*|other-session) echo "other-session:0 %9" ;;
       *) echo "test-session:0 %1" ;;
     esac
     `
@@ -607,6 +609,38 @@ describe("native gjc team runtime", () => {
 		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
 		expect(tmuxLog).toContain("display-message -p #S:#I #{pane_id}");
 		expect(tmuxLog).not.toContain("send-keys -l");
+	});
+
+	it("targets the GJC-managed leader session from GJC_TMUX_ACTIVE_SESSION over a stale TMUX_PANE", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakeTmux = await createFakeTmuxBin(cleanupRoot);
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Resolve leader from active session, not stale pane",
+			teamName: "active-session-team",
+			cwd: cleanupRoot,
+			env: {
+				GJC_SESSION_ID: TEST_SESSION_ID,
+				PATH: process.env.PATH ?? "",
+				GJC_TEAM_WORKER_COMMAND: "true",
+				GJC_TEAM_TMUX_COMMAND: fakeTmux,
+				// A stale/ambiguous inherited pane points at the wrong session; the
+				// explicit GJC-managed session name must win so workers land in the
+				// intended leader session (issue #531).
+				TMUX_PANE: "%9",
+				GJC_TMUX_ACTIVE_SESSION: "test-session",
+			},
+		});
+
+		const config = await Bun.file(path.join(snapshot.state_dir, "config.json")).json();
+		expect(config.tmux_session).toBe("test-session");
+		expect(config.tmux_target).toBe("test-session:0");
+		expect(config.leader.pane_id).toBe("%1");
+		expect(snapshot.tmux_target).toBe("test-session:0");
+		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
+		expect(tmuxLog).toContain("display-message -p -t =test-session: #S:#I #{pane_id}");
+		expect(tmuxLog).not.toContain("display-message -p -t %9 #S:#I #{pane_id}");
 	});
 
 	it("starts multiple runtime workers before tmux state mutation", async () => {


### PR DESCRIPTION
## Summary

Fixes the remaining Windows/psmux failure mode in #531: `gjc team` could split/send workers into the **wrong** leader session because leader detection trusted only the inherited `TMUX_PANE`.

Under psmux on Windows, an inherited `TMUX_PANE` can resolve to the wrong/default psmux session, so a `ralplan -> ultragoal -> team` handoff lands workers in a session that is not the GJC-managed leader. The PowerShell/`send-keys` worker-launch path is already on `dev`; this PR adds the **explicit active-session** piece the reopened issue calls out.

## What changed

- `gjc --tmux` now propagates the GJC-managed session name to the child process via a new `GJC_TMUX_ACTIVE_SESSION` env var (`buildDefaultTmuxLaunchPlan` `extraEnv`).
- `readCurrentTmuxLeaderContext` prefers `GJC_TMUX_ACTIVE_SESSION` when present, querying the tagged session **by name** (`buildGjcTmuxExactOptionTarget`) instead of the ambiguous `TMUX_PANE`.
- Native tmux / WSL flows (no `GJC_TMUX_ACTIVE_SESSION`) keep the existing `TMUX_PANE` / ambient-session behavior — no change.
- The "not inside tmux" diagnostic also treats an explicit active session as inside-tmux.

## Why this shape

Matches the maintainer's expected fix shape in #531 (capability-detect + explicit active-session) and the reference fork behavior (`phdgil/gajae-code@5cea001b`), scoped to the session-targeting gap without touching the fragile new-session/attach race handling.

## Tests

Added a focused test in `team-runtime.test.ts`: with a stale `TMUX_PANE=%9` (fake maps to `other-session`) plus `GJC_TMUX_ACTIVE_SESSION=test-session`, the leader resolves to `test-session:0` / pane `%1` and the `display-message` query targets `=test-session:`, never `-t %9`. The fake tmux helper learned to answer session-name targets.

Verified on Linux (this suite is POSIX-only; Windows lacks executable-bit fakes), matching CI:

```
test/gjc-runtime/team-runtime.test.ts   65 pass, 0 fail
test/gjc-runtime/launch-tmux.test.ts    68 pass, 0 fail
test/gjc-runtime/tmux-common + psmux-detect  19 pass, 0 fail
```

Also `tsgo -p tsconfig.json --noEmit` and `biome check` clean on the changed files.

Closes #531
