### PR TITLE
fix(ci): shard coding-agent affected tests

### DIFF
--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -430,11 +430,27 @@ describe("push-mode broad planning still runs the fuller suite", () => {
 		manifest: { name: "@gajae-code/coding-agent", scripts: { check: "biome check .", test: "bun test" } },
 	};
 
-	test("push mode plans the package-wide test for a coding-agent change", () => {
+	test("push mode splits the package-wide coding-agent test across bounded shards", () => {
 		const tasks = planTasks(["packages/coding-agent/src/edit/foo.ts"], [codingAgent]);
 		const keys = tasks.map(task => task.key);
-		// Broad planner keeps the package-wide test (the post-merge fuller suite).
-		expect(keys).toContain("test:@gajae-code/coding-agent");
+		const testShards = tasks.filter(task => task.key.startsWith("test:@gajae-code/coding-agent:shard-"));
+		// Broad planner keeps the post-merge fuller suite, but not as one 30m shard.
+		expect(testShards.map(task => task.key)).toEqual([
+			"test:@gajae-code/coding-agent:shard-1-of-8",
+			"test:@gajae-code/coding-agent:shard-2-of-8",
+			"test:@gajae-code/coding-agent:shard-3-of-8",
+			"test:@gajae-code/coding-agent:shard-4-of-8",
+			"test:@gajae-code/coding-agent:shard-5-of-8",
+			"test:@gajae-code/coding-agent:shard-6-of-8",
+			"test:@gajae-code/coding-agent:shard-7-of-8",
+			"test:@gajae-code/coding-agent:shard-8-of-8",
+		]);
+		expect(testShards[0]?.command).toEqual(["bun", "test", "--shard=1/8"]);
+		expect(testShards[0]?.cwd).toBe(resolvePackageCwd("packages/coding-agent"));
+		expect(keys).not.toContain("test:@gajae-code/coding-agent");
 		expect(keys).toContain("check:@gajae-code/coding-agent");
+
+		const entries = describeTasks(tasks);
+		expect(entries.find(entry => entry.key === "test:@gajae-code/coding-agent:shard-1-of-8")?.native).toBe(true);
 	});
 });

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -9,6 +9,10 @@ const ZERO_SHA = /^0+$/;
 const PACKAGE_SCOPES = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] as const;
 const PYTHON_DEV_SETUP =
 	"python3 -m pip install --user --upgrade 'pip>=24' 'setuptools>=69' wheel && python3 -m pip install --user -e python/gjc-rpc -e 'python/robogjc[dev]'";
+// The coding-agent package has hundreds of test files; keep dev affected push
+// validation below the 30m shard timeout by splitting its package-wide suite.
+const CODING_AGENT_TEST_SHARDS = 8;
+
 // Keys for tasks that compile the @gajae-code/natives addon. They run once in
 // the dedicated dev-ci native-build job (not as matrix shards) and publish the
 // built `.node` files as an artifact the runtime-dependent shards download.
@@ -451,7 +455,7 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 				add(tasks, `check:${workspacePackage.name}`, `Check ${workspacePackage.name}`, packageScriptCommand("check"), resolvePackageCwd(workspacePackage.dir));
 			}
 			if (workspacePackage.manifest.scripts?.test) {
-				add(tasks, `test:${workspacePackage.name}`, `Test ${workspacePackage.name}`, packageScriptCommand("test"), resolvePackageCwd(workspacePackage.dir));
+				addPackageTestTasks(tasks, workspacePackage);
 			}
 		}
 	}
@@ -612,6 +616,23 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 // so the matrix shard name stays small and directly traceable to the file.
 function addTestFileTask(tasks: Map<string, Task>, testFile: string): void {
 	add(tasks, `test:${testFile}`, `Test ${testFile}`, ["bun", "test", testFile]);
+}
+
+function addPackageTestTasks(tasks: Map<string, Task>, workspacePackage: WorkspacePackage): void {
+	if (workspacePackage.name !== "@gajae-code/coding-agent") {
+		add(tasks, `test:${workspacePackage.name}`, `Test ${workspacePackage.name}`, packageScriptCommand("test"), resolvePackageCwd(workspacePackage.dir));
+		return;
+	}
+
+	for (let shard = 1; shard <= CODING_AGENT_TEST_SHARDS; shard++) {
+		add(
+			tasks,
+			`test:${workspacePackage.name}:shard-${shard}-of-${CODING_AGENT_TEST_SHARDS}`,
+			`Test ${workspacePackage.name} shard ${shard}/${CODING_AGENT_TEST_SHARDS}`,
+			["bun", "test", `--shard=${shard}/${CODING_AGENT_TEST_SHARDS}`],
+			resolvePackageCwd(workspacePackage.dir),
+		);
+	}
 }
 
 // Resolve the directly-named test(s) for a changed path: the changed file itself


### PR DESCRIPTION
## Summary

Fix the repeated dev affected CI cancellation where the package-wide `@gajae-code/coding-agent` test shard runs until the 30m job cancellation window and then makes the aggregate fail with `affected-shards: cancelled`.

The broad push planner still keeps the fuller coding-agent suite, but now emits 8 bounded `bun test --shard=N/8` tasks instead of one monolithic `bun test` matrix entry.

Observed failures this addresses:
- Dev CI run `28868745672` on `3aa1ce00` cancelled twice in `Affected path validation / test:@gajae-code/coding-agent` after ~29m30s.
- PR #1721 has the same aggregate failure shape (`affected-shards: cancelled`) on a broad root/coding-agent affected plan.

## Verification

- `bun test scripts/ci-dev-affected.test.ts` — 30 pass / 0 fail
- `git diff --check`

Notes:
- `bunx biome check scripts/ci-dev-affected.ts scripts/ci-dev-affected.test.ts` is not applicable because the repo biome config ignores those paths.
- A direct `tsc` file invocation is also not used as validation because the workspace tsconfig is intentionally not loaded when files are specified directly.

Closes #1721 only if the failed PR is updated/re-run and the aggregate cancellation is resolved; this PR itself fixes the shared CI planning cause.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*