### PR TITLE
fix(install): download release binaries atomically to protect existing installs

### DIFF
--- a/scripts/install-tests/install-sh-binary-upgrade.test.ts
+++ b/scripts/install-tests/install-sh-binary-upgrade.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const repoRoot = path.join(import.meta.dir, "..", "..");
+const installScript = path.join(repoRoot, "scripts", "install.sh");
+
+const EXISTING_BINARY = '#!/bin/sh\necho "gjc 0.8.1 (existing install)"\n';
+const RELEASE_JSON = '{"tag_name": "v0.9.0"}';
+const NEW_BINARY_CONTENT = "#!/bin/sh\necho new-binary\n";
+
+interface Sandbox {
+	root: string;
+	shimDir: string;
+	installDir: string;
+}
+
+let sandbox: Sandbox;
+
+function writeCurlShim(dir: string, options: { downloadFails: boolean }): void {
+	// Emulates curl just enough for install.sh: the GitHub API call returns a
+	// release tag, and the asset download either succeeds (writing to the -o
+	// target) or fails like `curl -f` does on an HTTP 404 (exit 22).
+	const downloadBranch = options.downloadFails
+		? "exit 22"
+		: 'printf \'%s\' "$NEW_BINARY_CONTENT" > "$out"\nexit 0';
+	const shim = [
+		"#!/bin/sh",
+		'for arg in "$@"; do',
+		'  case "$arg" in',
+		"    https://api.github.com/*)",
+		`      printf '%s\\n' '${RELEASE_JSON}'`,
+		"      exit 0",
+		"      ;;",
+		"  esac",
+		"done",
+		'out=""',
+		'prev=""',
+		'for arg in "$@"; do',
+		'  if [ "$prev" = "-o" ]; then out="$arg"; fi',
+		'  prev="$arg"',
+		"done",
+		'if [ -z "$out" ]; then exit 22; fi',
+		downloadBranch,
+		"",
+	].join("\n");
+	const shimPath = path.join(dir, "curl");
+	fs.writeFileSync(shimPath, shim);
+	fs.chmodSync(shimPath, 0o755);
+}
+
+async function runInstaller(): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+	const proc = Bun.spawn(["sh", installScript, "--binary"], {
+		env: {
+			...process.env,
+			PATH: `${sandbox.shimDir}:/usr/bin:/bin`,
+			GJC_INSTALL_DIR: sandbox.installDir,
+			NEW_BINARY_CONTENT,
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	return { exitCode, stdout, stderr };
+}
+
+beforeEach(() => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-install-sh-"));
+	const shimDir = path.join(root, "shim-bin");
+	const installDir = path.join(root, "install");
+	fs.mkdirSync(shimDir, { recursive: true });
+	fs.mkdirSync(installDir, { recursive: true });
+	sandbox = { root, shimDir, installDir };
+});
+
+afterEach(() => {
+	fs.rmSync(sandbox.root, { recursive: true, force: true });
+});
+
+describe("install.sh binary upgrades", () => {
+	test("a failed download leaves the existing gjc binary untouched", async () => {
+		const existingPath = path.join(sandbox.installDir, "gjc");
+		fs.writeFileSync(existingPath, EXISTING_BINARY);
+		fs.chmodSync(existingPath, 0o755);
+		writeCurlShim(sandbox.shimDir, { downloadFails: true });
+
+		const result = await runInstaller();
+
+		expect(result.exitCode).not.toBe(0);
+		expect(fs.existsSync(existingPath)).toBe(true);
+		expect(fs.readFileSync(existingPath, "utf8")).toBe(EXISTING_BINARY);
+	});
+
+	test("a successful download replaces the binary and leaves no temp files", async () => {
+		const existingPath = path.join(sandbox.installDir, "gjc");
+		fs.writeFileSync(existingPath, EXISTING_BINARY);
+		fs.chmodSync(existingPath, 0o755);
+		writeCurlShim(sandbox.shimDir, { downloadFails: false });
+
+		const result = await runInstaller();
+
+		expect(result.exitCode).toBe(0);
+		expect(fs.readFileSync(existingPath, "utf8")).toBe(NEW_BINARY_CONTENT);
+		// The install must be executable and must not leave partial download
+		// artifacts next to the binary.
+		expect(fs.statSync(existingPath).mode & 0o100).toBe(0o100);
+		expect(fs.readdirSync(sandbox.installDir)).toEqual(["gjc"]);
+	});
+});

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -256,11 +256,19 @@ function Install-Binary {
 
     New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
-    # Download binary
+    # Download binary to a temp file first so a failed or partial download
+    # never clobbers an existing working install at $InstallDir\gjc.exe.
     $BinaryUrl = "https://github.com/$Repo/releases/download/$Latest/$BinaryName"
     Write-Host "Downloading $BinaryName..."
     $OutPath = Join-Path $InstallDir "gjc.exe"
-    Invoke-WebRequest -Uri $BinaryUrl -OutFile $OutPath
+    $DownloadTmp = Join-Path $InstallDir (".gjc.download." + [System.Guid]::NewGuid().ToString("N"))
+    try {
+        Invoke-WebRequest -Uri $BinaryUrl -OutFile $DownloadTmp
+    } catch {
+        Remove-Item -Force $DownloadTmp -ErrorAction SilentlyContinue
+        throw
+    }
+    Move-Item -Force $DownloadTmp $OutPath
 
     Write-Host ""
     Write-Host "✓ Installed gjc to $OutPath" -ForegroundColor Green

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -225,11 +225,13 @@ install_binary() {
     echo "Using version: $LATEST"
 
     mkdir -p "$INSTALL_DIR"
-    # Download binary
+    # Download binary to a temp file first so a failed or partial download
+    # never clobbers an existing working install at ${INSTALL_DIR}/gjc.
     BINARY_URL="https://github.com/${REPO}/releases/download/${LATEST}/${BINARY}"
+    DOWNLOAD_TMP="${INSTALL_DIR}/.gjc.download.$$"
     echo "Downloading ${BINARY}..."
-    if ! curl -fsSL "$BINARY_URL" -o "${INSTALL_DIR}/gjc"; then
-        rm -f "${INSTALL_DIR}/gjc"
+    if ! curl -fsSL "$BINARY_URL" -o "$DOWNLOAD_TMP"; then
+        rm -f "$DOWNLOAD_TMP"
         echo ""
         echo "No prebuilt GJC binary was found for ${PLATFORM}-${ARCH} in ${LATEST}."
         echo "Fallback options:"
@@ -239,7 +241,8 @@ install_binary() {
         echo "Expected asset URL: $BINARY_URL"
         exit 1
     fi
-    chmod +x "${INSTALL_DIR}/gjc"
+    chmod +x "$DOWNLOAD_TMP"
+    mv -f "$DOWNLOAD_TMP" "${INSTALL_DIR}/gjc"
     echo ""
     echo "✓ Installed gjc to ${INSTALL_DIR}/gjc"
 


### PR DESCRIPTION
## Summary
- `install.sh` downloaded release assets directly to `${INSTALL_DIR}/gjc` and ran `rm -f` on that same path when the download failed, so a failed upgrade (missing release asset for the platform, network error, GitHub API hiccup) deleted the user's existing working `gjc` binary. A partial download could also leave a truncated/corrupt binary at the live path.
- `install.ps1` had the same defect class: `Invoke-WebRequest -OutFile` wrote straight to `gjc.exe`, so an interrupted download leaves a partial file where the working binary used to be.
- Both installers now download to a temp file inside the install directory and promote it with an atomic rename (`mv -f` / `Move-Item -Force`) only after the download (and `chmod` on POSIX) succeed; failure cleans up only the temp file and leaves any existing install untouched.
- Added a hermetic regression test (`scripts/install-tests/install-sh-binary-upgrade.test.ts`) that drives `install.sh --binary` with a shimmed `curl`: the failed-download case asserts the pre-existing binary survives byte-for-byte (fails before this fix — the binary was deleted), and the success case asserts the binary is replaced, executable, and no temp artifacts remain.

## Verification
- `bun test scripts/install-tests/install-sh-binary-upgrade.test.ts` (new; the failed-upgrade test reproduces the deletion on the previous `install.sh` and passes with the fix)
- `bun test scripts/release-publish-order.test.ts` (guards the installer's missing-asset fallback messaging, which is preserved verbatim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)