### PR TITLE
fix(natives): declare glibc requirement on linux platform packages

### DIFF
--- a/packages/natives-linux-arm64/package.json
+++ b/packages/natives-linux-arm64/package.json
@@ -20,6 +20,9 @@
 	"cpu": [
 		"arm64"
 	],
+	"libc": [
+		"glibc"
+	],
 	"files": [
 		"native",
 		"README.md"

--- a/packages/natives-linux-x64/package.json
+++ b/packages/natives-linux-x64/package.json
@@ -20,6 +20,9 @@
 	"cpu": [
 		"x64"
 	],
+	"libc": [
+		"glibc"
+	],
 	"files": [
 		"native",
 		"README.md"

--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -12,6 +12,7 @@ interface PackageManifest {
 	files?: string[];
 	os?: string[];
 	cpu?: string[];
+	libc?: string[];
 }
 
 const repoRoot = path.join(import.meta.dir, "..");
@@ -180,6 +181,23 @@ describe("native release binary coverage", () => {
 		expect(workflow).toContain("{ os: macos-14, platform: darwin, arch: arm64 }");
 		expect(workflow).toContain("target_id: darwin-arm64");
 		expect(workflow).toContain("pattern: pi-natives-${{ matrix.platform }}-${{ matrix.arch }}*-h${{ needs.rust-hash.outputs.hash }}");
+	});
+
+	test("linux native platform packages declare their glibc requirement", async () => {
+		// The linux native addons are built against *-unknown-linux-gnu targets
+		// only (see the ci.yml build matrix), so the platform packages must set
+		// "libc" to keep npm/bun from installing a glibc-linked .node on musl
+		// systems (e.g. Alpine), where dlopen fails with raw relocation errors.
+		for (const dir of ["packages/natives-linux-x64", "packages/natives-linux-arm64"]) {
+			const manifest = await readManifest(dir);
+			expect(manifest.libc).toEqual(["glibc"]);
+		}
+
+		// libc is a linux-only selector; other platform packages must not set it.
+		for (const dir of ["packages/natives-darwin-arm64", "packages/natives-darwin-x64", "packages/natives-win32-x64"]) {
+			const manifest = await readManifest(dir);
+			expect(manifest.libc).toBeUndefined();
+		}
 	});
 
 	test("installer explains missing release assets with fallback guidance", async () => {


### PR DESCRIPTION
## Summary
- `@gajae-code/natives-linux-x64` / `@gajae-code/natives-linux-arm64` only declare `os`/`cpu`, so they match every linux install — including musl systems like Alpine — even though the shipped `.node` addons are built exclusively against `x86_64-unknown-linux-gnu` / `aarch64-unknown-linux-gnu` (see the ci.yml native build matrix; there are no `*-musl` targets anywhere in the release pipeline).
- On Alpine (`node:22-alpine`, `oven/bun:alpine`, etc.) the package manager installs the glibc-linked addon and the natives loader dies at `dlopen` with raw `Error relocating … symbol not found` errors. Because `linux-x64`/`linux-arm64` are in the loader's `SUPPORTED_PLATFORMS` list, users never reach the loader's friendly unsupported-platform guidance either. The existing install smoke tests all run on `debian:bookworm-slim`, so this path is never exercised in CI.
- Add `"libc": ["glibc"]` to both linux platform packages — npm and bun honor this manifest selector and skip the optional dependency on musl, letting the loader surface its clear guidance instead of a raw dlopen crash. This matches the manifest shape napi-rs generates for gnu-target platform packages.
- Extend the release coverage tests to pin the requirement: linux platform packages must declare `libc: ["glibc"]`, and non-linux platform packages must not set the (linux-only) selector.

## Verification
- `bun test scripts/release-publish-order.test.ts` (12 pass, including the new `linux native platform packages declare their glibc requirement` test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)