### PR TITLE
fix(install): make install.ps1 compatible with Windows PowerShell 5.1

### DIFF
--- a/scripts/install-tests/install-ps1-compat.test.ts
+++ b/scripts/install-tests/install-ps1-compat.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+
+const repoRoot = path.join(import.meta.dir, "..", "..");
+const installPs1Path = path.join(repoRoot, "scripts", "install.ps1");
+const pwsh = Bun.which("pwsh");
+
+describe("install.ps1 Windows PowerShell 5.1 compatibility", () => {
+	test("avoids parameters that only exist on PowerShell 6+", async () => {
+		const installer = await Bun.file(installPs1Path).text();
+
+		// The documented install path (`irm ... | iex`) runs under Windows
+		// PowerShell 5.1. ConvertFrom-Json -AsHashtable was added in PowerShell
+		// 6.0; on 5.1 it throws a parameter binding error, and the surrounding
+		// catch used to reset $settings to @{} and silently drop every existing
+		// settings.json key.
+		expect(installer).not.toContain("-AsHashtable");
+	});
+
+	test("opts in to TLS 1.2 before any network call", async () => {
+		const installer = await Bun.file(installPs1Path).text();
+
+		// .NET Framework-based PowerShell 5.1 can default to TLS 1.0, which
+		// GitHub and bun.sh reject; every download then fails with "Could not
+		// create SSL/TLS secure channel".
+		const tlsIndex = installer.indexOf("[Net.SecurityProtocolType]::Tls12");
+		expect(tlsIndex).toBeGreaterThan(-1);
+		for (const networkCall of ["Invoke-RestMethod", "Invoke-WebRequest", "irm bun.sh"]) {
+			const callIndex = installer.indexOf(networkCall);
+			expect(callIndex).toBeGreaterThan(-1);
+			expect(tlsIndex).toBeLessThan(callIndex);
+		}
+	});
+
+	test.skipIf(!pwsh)("parses without syntax errors under PowerShell", async () => {
+		const script = [
+			"$errors = $null",
+			`[System.Management.Automation.Language.Parser]::ParseFile('${installPs1Path}', [ref]$null, [ref]$errors) | Out-Null`,
+			"if ($errors -and $errors.Count -gt 0) { $errors | ForEach-Object { Write-Output $_.Message }; exit 1 }",
+			"exit 0",
+		].join("; ");
+		const proc = Bun.spawn([pwsh as string, "-NoProfile", "-Command", script], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+		expect(stdout.trim()).toBe("");
+		expect(exitCode).toBe(0);
+	});
+});

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -16,6 +16,12 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# Windows PowerShell 5.1 runs on .NET Framework, which may still default to
+# TLS 1.0; GitHub and bun.sh both require TLS 1.2+, so opt in explicitly.
+try {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+} catch {}
+
 $Repo = "Yeachan-Heo/gajae-code"
 $Package = "@gajae-code/coding-agent"
 $InstallDir = if ($env:GJC_INSTALL_DIR) { $env:GJC_INSTALL_DIR } else { "$env:LOCALAPPDATA\gjc" }
@@ -128,11 +134,19 @@ function Configure-BashShell {
                 New-Item -ItemType Directory -Force -Path $settingsDir | Out-Null
             }
 
-            # Read existing settings or create new
+            # Read existing settings or create new. ConvertFrom-Json's AsHashtable
+            # switch only exists on PowerShell 6+; the documented `irm | iex`
+            # install path runs under Windows PowerShell 5.1, where that parameter
+            # throws and the catch below used to wipe every existing settings key.
             $settings = @{}
             if (Test-Path $settingsFile) {
                 try {
-                    $settings = Get-Content $settingsFile -Raw | ConvertFrom-Json -AsHashtable
+                    $parsed = Get-Content $settingsFile -Raw | ConvertFrom-Json
+                    if ($parsed) {
+                        foreach ($prop in $parsed.PSObject.Properties) {
+                            $settings[$prop.Name] = $prop.Value
+                        }
+                    }
                 } catch {
                     $settings = @{}
                 }


### PR DESCRIPTION
## Summary
- The documented Windows install path (`irm https://raw.githubusercontent.com/.../install.ps1 | iex`) runs under **Windows PowerShell 5.1** (the default `powershell.exe` on Windows 10/11), but `Configure-BashShell` read `settings.json` with `ConvertFrom-Json -AsHashtable` — a parameter introduced in PowerShell 6.0. On 5.1 that line throws a parameter binding error, the surrounding `catch` resets `$settings` to `@{}`, and writing `shellPath` then **silently discards every other key** the user had in `~/.gjc/agent/settings.json`. Replaced with a `PSObject.Properties` copy that behaves identically on 5.1 and 7+ (verified: existing keys and nested objects survive the merge).
- Opt in to TLS 1.2 before any network call: .NET Framework-based PowerShell 5.1 can default to TLS 1.0, which GitHub and bun.sh reject — every `Invoke-RestMethod`/`Invoke-WebRequest`/`irm` in the installer then fails with `Could not create SSL/TLS secure channel`. This is the standard `ServicePointManager` opt-in, wrapped in try/catch so PowerShell 7 (which ignores it) is unaffected.
- Added `scripts/install-tests/install-ps1-compat.test.ts`, which pins both fixes (no PS6-only parameters; TLS opt-in precedes all network calls) and parses the script with `[System.Management.Automation.Language.Parser]` when `pwsh` is available on the test host (GitHub-hosted runners include it; skipped otherwise).

## Verification
- `bun test scripts/install-tests/install-ps1-compat.test.ts` (3 pass with pwsh 7.6.3 on the host, including the parser check)
- Functional check of the new read/merge logic under pwsh: `{"theme":"dark","editor":{"tabSize":2}}` + `shellPath` round-trips with all keys preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)