### PR TITLE
fix(providers): unify the Cursor client version across agent runs and discovery

### DIFF
--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -31,6 +31,7 @@ import { parseStreamingJson } from "../utils/json-parse";
 import { formatErrorMessageWithRetryAfter } from "../utils/retry-after";
 import { flattenToolRootCombinators, toolWireSchema } from "../utils/schema";
 import { COMPOSER_EDIT_DISCIPLINE_PROMPT, isComposerHarnessModel } from "./composer-discipline";
+import { CURSOR_CLIENT_VERSION } from "./cursor/client-version";
 import type { McpToolDefinition } from "./cursor/gen/agent_pb";
 import {
 	AgentClientMessageSchema,
@@ -131,7 +132,7 @@ import {
 } from "./cursor/gen/agent_pb";
 
 export const CURSOR_API_URL = "https://api2.cursor.sh";
-export const CURSOR_CLIENT_VERSION = "cli-2026.01.09-231024f";
+export { CURSOR_CLIENT_VERSION };
 
 const conversationStateCache = new Map<string, ConversationStateStructure>();
 const conversationBlobStores = new Map<string, Map<string, Uint8Array>>();

--- a/packages/ai/src/providers/cursor/client-version.ts
+++ b/packages/ai/src/providers/cursor/client-version.ts
@@ -1,0 +1,10 @@
+/**
+ * The Cursor client version reported to api2.cursor.sh.
+ *
+ * Every call against the Cursor backend must send the same
+ * x-cursor-client-version: the backend gates features and minimum versions on
+ * it, so a drift between the agent Run path and model discovery makes one of
+ * them fail while the other keeps working. Keep this as the single source of
+ * truth for the header value.
+ */
+export const CURSOR_CLIENT_VERSION = "cli-2026.02.13-41ac335";

--- a/packages/ai/src/utils/discovery/cursor.ts
+++ b/packages/ai/src/utils/discovery/cursor.ts
@@ -2,11 +2,11 @@ import * as http2 from "node:http2";
 import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
 import * as z from "zod/v4";
 import { getBundledModels } from "../../models";
+import { CURSOR_CLIENT_VERSION } from "../../providers/cursor/client-version";
 import { GetUsableModelsRequestSchema, GetUsableModelsResponseSchema } from "../../providers/cursor/gen/agent_pb";
 import type { Model } from "../../types";
 
 const CURSOR_DEFAULT_BASE_URL = "https://api2.cursor.sh";
-const CURSOR_DEFAULT_CLIENT_VERSION = "cli-2026.02.13-41ac335";
 const CURSOR_GET_USABLE_MODELS_PATH = "/agent.v1.AgentService/GetUsableModels";
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
@@ -91,7 +91,7 @@ function buildRequestHeaders(options: CursorModelDiscoveryOptions): Record<strin
 		te: "trailers",
 		authorization: `Bearer ${options.apiKey}`,
 		"x-ghost-mode": "true",
-		"x-cursor-client-version": options.clientVersion ?? CURSOR_DEFAULT_CLIENT_VERSION,
+		"x-cursor-client-version": options.clientVersion ?? CURSOR_CLIENT_VERSION,
 		"x-cursor-client-type": "cli",
 	};
 }

--- a/packages/ai/test/cursor-client-version.test.ts
+++ b/packages/ai/test/cursor-client-version.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { CURSOR_CLIENT_VERSION } from "../src/providers/cursor/client-version";
+
+const srcRoot = path.join(import.meta.dir, "..", "src");
+const CLIENT_VERSION_MODULE = path.join("providers", "cursor", "client-version.ts");
+const CLIENT_VERSION_LITERAL = /["']cli-\d{4}\.\d{2}\.\d{2}-[0-9a-f]+["']/;
+
+describe("cursor client version", () => {
+	it("is a well-formed cli build identifier", () => {
+		expect(CURSOR_CLIENT_VERSION).toMatch(/^cli-\d{4}\.\d{2}\.\d{2}-[0-9a-f]+$/);
+	});
+
+	it("has a single source of truth across the ai package", async () => {
+		// The Cursor backend gates on x-cursor-client-version. A second hardcoded
+		// version drifts silently and splits the integration: model discovery
+		// keeps working while agent runs fail (or vice versa) once the backend
+		// deprecates the older build.
+		const offenders: string[] = [];
+		const glob = new Bun.Glob("**/*.ts");
+		for await (const rel of glob.scan(srcRoot)) {
+			if (rel === CLIENT_VERSION_MODULE) continue;
+			const text = await Bun.file(path.join(srcRoot, rel)).text();
+			if (CLIENT_VERSION_LITERAL.test(text)) {
+				offenders.push(rel);
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
- The Cursor integration sent two different `x-cursor-client-version` headers to the same `api2.cursor.sh` backend: agent runs used `cli-2026.01.09-231024f` (`packages/ai/src/providers/cursor.ts`) while model discovery used `cli-2026.02.13-41ac335` (`packages/ai/src/utils/discovery/cursor.ts`). The backend gates behavior on the client version (the discovery module already documents protocol gating, e.g. HTTP/1.1 being rejected with 464), so this drift splits the integration the moment Cursor deprecates the older build: model discovery keeps listing models while every agent run fails — or vice versa — which is a confusing partial outage to debug.
- Moved the version literal to a single shared module (`packages/ai/src/providers/cursor/client-version.ts`), standardized on the newer build, and kept the existing `CURSOR_CLIENT_VERSION` re-export from `providers/cursor.ts` so the public surface is unchanged.
- Added a regression test that (a) validates the version shape and (b) scans the ai package for stray hardcoded `cli-<date>-<hash>` literals outside the shared module, so a second copy cannot silently drift again.

## Verification
- `bun test packages/ai/test/cursor-client-version.test.ts packages/ai/test/cursor-exec-handlers.test.ts` (10 pass)
- `bun --cwd=packages/ai run check` (biome + tsgo, exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)