### PR TITLE
Support Telegram forum supergroup topics

### DIFF
--- a/docs/notifications-sdk.md
+++ b/docs/notifications-sdk.md
@@ -228,7 +228,9 @@ gjc notify setup
 The wizard validates the bot token with Telegram, verifies private-chat Threaded
 Mode capability via `getMe.has_topics_enabled`, waits for a private DM to the bot,
 and writes canonical global Settings under `config.yml` in the GJC agent
-directory. It enables:
+directory. Non-interactive setup may also pair an explicitly supplied
+forum-enabled supergroup `--chat-id`; the daemon then creates one Telegram forum
+topic per session in that group. It enables:
 
 - `notifications.enabled`
 - `notifications.telegram.botToken`

--- a/docs/telegram-onboarding.md
+++ b/docs/telegram-onboarding.md
@@ -43,7 +43,7 @@ gjc notify setup
 
 Current implementation path: `packages/coding-agent/src/cli/notify-cli.ts`.
 
-The wizard does this:
+The wizard does this for the default private-chat pairing path:
 
 1. prompts for `Telegram BotFather token:`;
 2. validates the token with Telegram `getMe`;
@@ -54,17 +54,23 @@ The wizard does this:
 5. polls Telegram `getUpdates` until it sees a private chat message;
 6. writes the paired chat id and enables notifications.
 
-The setup pairing flow is private-chat only. If setup sees a `group`,
+The interactive setup pairing flow is private-chat only. If setup sees a `group`,
 `supergroup`, or `channel`, it rejects that chat and keeps waiting for a private
 DM. This is intentional for safe local discovery: group chats must not receive
-session names, action ids, or pending status by accident.
+session names, action ids, or pending status by accident. Advanced users may pair
+a known forum-enabled supergroup explicitly with
+`gjc notify setup --token <botToken> --chat-id <forumSupergroupId>`; GJC verifies
+that `getChat` reports `type: "supergroup"` and `is_forum: true` before saving it.
 
-Telegram private-chat topics: the managed daemon's per-session delivery uses
-Telegram forum topics (`createForumTopic` + `message_thread_id`). Telegram now
-supports forum topics in **private chats** when the bot owner enables **Threaded
-Mode** for the bot in @BotFather. GJC cannot enable Threaded Mode through the Bot
-API; setup only detects the capability (`getMe.has_topics_enabled`) and guides the
-manual BotFather toggle. A forum-enabled supergroup is no longer required.
+Telegram topics: the managed daemon's per-session delivery uses Telegram forum
+topics (`createForumTopic` + `message_thread_id`). There are two supported
+topic-capable targets:
+
+- private chats, when the bot owner enables **Threaded Mode** for the bot in
+  @BotFather; setup detects this capability with `getMe.has_topics_enabled`;
+- forum-enabled supergroups supplied explicitly with `--chat-id`, where Telegram's
+  normal group forum topics are already enabled and the bot has permission to
+  create/manage topics.
 
 Note: enabling topics in private chats may require an additional Telegram Stars
 purchase fee, per Telegram's Terms of Service for Bot Developers.
@@ -80,17 +86,21 @@ and otherwise deliver notifications flat to the paired private chat with the
 one-time nudge shown below.
 
 Setup verification is capability verification, not a delivery guarantee: even when
-setup reports `threaded=verified`, the first runtime `createForumTopic` for the
-paired chat can still fail if Telegram refuses it. When per-session topics are
-unavailable, the daemon does **not** drop notifications — it routes them to the
-normal (flat) paired chat and posts a one-time nudge: `turn on threaded mode from
-botfather miniapp to receive gjc notification!`. Because pairing is private-only,
-flat delivery lands in your own private DM with the bot.
+setup reports `threaded=verified` or `threaded=forum`, the first runtime
+`createForumTopic` for the paired chat can still fail if Telegram refuses it or the
+bot lacks permissions. When private-chat topics are unavailable, the daemon does
+**not** drop notifications — it routes them to the normal (flat) paired private
+chat and posts a one-time nudge: `turn on threaded mode from botfather miniapp to
+receive gjc notification!`. Because flat fallback is private-only, a forum
+supergroup configuration fails closed instead of leaking session content into the
+shared chat.
 
 The final setup line reports a `threaded=` status:
 
 - `threaded=verified`: the bot has Threaded Mode capability (`has_topics_enabled`
   was true during setup);
+- `threaded=forum`: setup verified an explicitly supplied forum-enabled
+  supergroup chat id; private-chat BotFather Threaded Mode is not required.
 - `threaded=unverified`: Threaded Mode was off and you skipped, or setup ran
   non-interactively; setup is saved, topics are attempted when available, and
   runtime delivery falls back to the paired flat private chat when Telegram

--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -61,10 +61,12 @@ interface TelegramUser {
 interface TelegramChat {
 	id?: number | string;
 	type?: string;
+	is_forum?: boolean;
 }
 
-type ThreadedModeState = "enabled" | "disabled" | "unknown";
-type ThreadedModeFinalLabel = "verified" | "unverified" | "unknown";
+type SetupChatKind = "private" | "forum";
+type ThreadedModeState = "enabled" | "disabled" | "unknown" | "forum";
+type ThreadedModeFinalLabel = "verified" | "unverified" | "unknown" | "forum";
 
 const DEFAULT_API_BASE = "https://api.telegram.org";
 const DEFAULT_POLL_TIMEOUT_MS = 60_000;
@@ -142,20 +144,30 @@ async function runSetup(deps: NotifyCommandDeps): Promise<void> {
 	}
 
 	const user = await getMe(fetchImpl, apiBase, token);
-	const threadedState = await verifyThreadedMode(fetchImpl, apiBase, token, user, {
-		interactive: resolveSetupInteractive(deps),
-		prompt: deps.threadedModePrompt ?? promptForThreadedMode,
-	});
-	process.stdout.write(
-		"Token validated. Message your bot now from the private Telegram chat to pair notifications.\n",
-	);
 
 	let chatId: string;
+	let threadedState: ThreadedModeState;
 	if (deps.setupChatId?.trim()) {
 		chatId = deps.setupChatId.trim();
-		await verifyPrivateChatId(fetchImpl, apiBase, token, chatId);
-		process.stdout.write(`Using provided chat id ${chatId} (non-interactive).\n`);
+		const chatKind = await verifySetupChatId(fetchImpl, apiBase, token, chatId);
+		threadedState =
+			chatKind === "forum"
+				? "forum"
+				: await verifyThreadedMode(fetchImpl, apiBase, token, user, {
+						interactive: resolveSetupInteractive(deps),
+						prompt: deps.threadedModePrompt ?? promptForThreadedMode,
+					});
+		process.stdout.write(
+			`Using provided ${chatKind === "forum" ? "forum supergroup" : "private"} chat id ${chatId} (non-interactive).\n`,
+		);
 	} else {
+		threadedState = await verifyThreadedMode(fetchImpl, apiBase, token, user, {
+			interactive: resolveSetupInteractive(deps),
+			prompt: deps.threadedModePrompt ?? promptForThreadedMode,
+		});
+		process.stdout.write(
+			"Token validated. Message your bot now from the private Telegram chat to pair notifications.\n",
+		);
 		const stale = await getUpdates(fetchImpl, apiBase, token, { timeout: 0, allowed_updates: ["message"] });
 		const offset = nextOffset(stale);
 		chatId = await waitForPrivateChat(fetchImpl, apiBase, token, {
@@ -289,22 +301,25 @@ async function getMe(fetchImpl: typeof fetch, apiBase: string, token: string): P
 	return user;
 }
 
-async function verifyPrivateChatId(
+async function verifySetupChatId(
 	fetchImpl: typeof fetch,
 	apiBase: string,
 	token: string,
 	chatId: string,
-): Promise<void> {
+): Promise<SetupChatKind> {
 	const chat = (await callTelegram<unknown>(fetchImpl, apiBase, token, "getChat", { chat_id: chatId })) as
 		| TelegramChat
 		| undefined;
 	if (!chat || typeof chat !== "object") {
 		throw new Error("Telegram getChat returned invalid Telegram response: missing valid Chat result.");
 	}
-	if (chat.type !== "private") {
-		const type = typeof chat.type === "string" && chat.type ? chat.type : "unknown";
-		throw new Error(`Provided chat id ${chatId} is a ${type} chat; pairing requires a private Telegram chat.`);
-	}
+	if (chat.type === "private") return "private";
+	if (chat.type === "supergroup" && chat.is_forum === true) return "forum";
+	const type = typeof chat.type === "string" && chat.type ? chat.type : "unknown";
+	const suffix = chat.type === "supergroup" ? " without forum topics enabled" : "";
+	throw new Error(
+		`Provided chat id ${chatId} is a ${type}${suffix} chat; pairing requires a private Telegram chat or forum-enabled supergroup.`,
+	);
 }
 
 function threadedModeState(user: TelegramUser): ThreadedModeState {
@@ -316,6 +331,7 @@ function threadedModeState(user: TelegramUser): ThreadedModeState {
 function threadedLabel(state: ThreadedModeState): ThreadedModeFinalLabel {
 	if (state === "enabled") return "verified";
 	if (state === "disabled") return "unverified";
+	if (state === "forum") return "forum";
 	return "unknown";
 }
 
@@ -490,7 +506,7 @@ ${chalk.bold("Usage:")}
   ${APP_NAME} notify status
 
 ${chalk.bold("Subcommands:")}
-  setup     Pair a Telegram bot token with a private chat and verify Threaded Mode capability
+  setup     Pair a Telegram bot token with a private chat or forum supergroup
   status    Show notification configuration without secrets
 
 ${chalk.bold("Examples:")}
@@ -499,9 +515,10 @@ ${chalk.bold("Examples:")}
   ${APP_NAME} notify status
 
 ${chalk.bold("Threaded Mode:")}
-  GJC uses Telegram private-chat topics for per-session threads. Setup verifies the bot
-  capability via getMe.has_topics_enabled. If it is off, enable Threaded Mode in @BotFather;
-  bots cannot toggle it through the Bot API. If Telegram refuses topic creation at runtime,
-  GJC delivers flat to the paired private chat and nudges you to enable Threaded Mode.
+  GJC uses Telegram topics for per-session threads. Private-chat pairing verifies the bot
+  capability via getMe.has_topics_enabled; forum supergroups supplied with --chat-id use
+  Telegram's existing forum topics instead. If private-chat Threaded Mode is off, enable it
+  in @BotFather; bots cannot toggle it through the Bot API. If Telegram refuses private-topic
+  creation at runtime, GJC delivers flat to the paired private chat and nudges you.
 `);
 }

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -57,6 +57,7 @@ import { renderThreadedFrame, type ThreadedSend } from "./threaded-render";
 import { TopicRegistry, type TopicRegistryState } from "./topic-registry";
 
 export type EnsureDaemonResult = "owner_spawned" | "attached" | "disabled" | "blocked";
+type ChatDeliveryMode = "private" | "forum" | "unsupported";
 
 export interface DaemonState {
 	pid: number;
@@ -893,8 +894,8 @@ export class TelegramNotificationDaemon {
 	private threadedFallbackNoticeSent = false;
 	/** Sessions whose identity header was already sent flat (Threaded Mode off). */
 	private readonly flatIdentitySent = new Set<string>();
-	/** Cached result of whether the paired chat is a private chat (flat-fallback gate). */
-	private pairedChatPrivate: boolean | undefined;
+	/** Cached delivery capability for the configured chat. */
+	private chatDeliveryMode: ChatDeliveryMode | undefined;
 	/** Bot username from getMe, cached once at owner startup for group/forum command targeting. */
 	private botUsername: string | undefined;
 	/** Sessions whose agent loop is currently busy (drives the typing indicator). */
@@ -1598,8 +1599,8 @@ export class TelegramNotificationDaemon {
 		await this.flushPool();
 	}
 
-	private async existingTopicForPrivateChat(sessionId: string): Promise<string | undefined> {
-		if (!(await this.pairedChatIsPrivate())) return undefined;
+	private async existingTopicForThreadedChat(sessionId: string): Promise<string | undefined> {
+		if (!(await this.chatSupportsTopics())) return undefined;
 		return this.topics.get(sessionId)?.topicId;
 	}
 
@@ -1619,12 +1620,13 @@ export class TelegramNotificationDaemon {
 
 	/**
 	 * Resolve (creating once via `createForumTopic`) the forum topic for a
-	 * session. On capability failure (e.g. Threaded Mode off) this returns
-	 * `undefined`; callers then flat-deliver to a private paired chat (with a
-	 * one-time nudge) or drop fail-closed for a non-private chat.
+	 * session. Private chats require BotFather Threaded Mode; forum supergroups
+	 * require a forum-enabled chat plus bot permissions. On capability failure
+	 * this returns `undefined`; callers then flat-deliver only to a private paired
+	 * chat (with a one-time nudge) or fail closed for shared chats.
 	 */
 	private async ensureTopic(sessionId: string, name: string): Promise<string | undefined> {
-		if (!(await this.pairedChatIsPrivate())) return undefined;
+		if (!(await this.chatSupportsTopics())) return undefined;
 		const existing = this.topics.get(sessionId);
 		if (existing) return existing.topicId;
 		try {
@@ -1813,8 +1815,12 @@ export class TelegramNotificationDaemon {
 		}
 		for (const item of batch) {
 			const { send, topicId } = item.payload;
-			if (topicId && !(await this.pairedChatIsPrivate())) continue;
-			// Threaded topic when available; otherwise deliver flat to the paired chat.
+			if (topicId) {
+				if (!(await this.chatSupportsTopics())) continue;
+			} else if (!(await this.pairedChatIsPrivate())) {
+				continue;
+			}
+			// Threaded topic when available; otherwise deliver flat to the paired private chat.
 			const threadField = topicId ? { message_thread_id: Number(topicId) } : {};
 			const ckey = send.editable ? item.coalesceKey : undefined;
 			const editKey = ckey !== undefined ? `${item.sessionId}:${ckey}` : undefined;
@@ -1933,23 +1939,39 @@ export class TelegramNotificationDaemon {
 	}
 
 	/**
-	 * Resolve (and cache successful resolution of) whether the paired `chatId` is a
-	 * private chat. Topic and flat delivery are only safe in a private DM; any
-	 * non-private chat fails closed, while a transient `getChat` failure fails closed
-	 * for the current attempt and is retried later.
+	 * Resolve (and cache successful resolution of) whether the configured `chatId`
+	 * supports per-session forum topics. Private chats rely on BotFather Threaded
+	 * Mode and may flat-fallback when topic creation is refused. Forum supergroups
+	 * are shared surfaces, so they may use topics but never flat fallback.
 	 */
-	private async pairedChatIsPrivate(): Promise<boolean> {
-		if (this.pairedChatPrivate !== undefined) return this.pairedChatPrivate;
+	private async telegramChatDeliveryMode(): Promise<ChatDeliveryMode> {
+		if (this.chatDeliveryMode !== undefined) return this.chatDeliveryMode;
 		try {
 			const res = (await this.botApi.call("getChat", { chat_id: this.opts.chatId })) as {
-				result?: { type?: string };
+				result?: { type?: string; is_forum?: boolean };
 			};
-			this.pairedChatPrivate = res.result?.type === "private";
-			return this.pairedChatPrivate;
+			const chat = res.result;
+			if (chat?.type === "private") {
+				this.chatDeliveryMode = "private";
+			} else if (chat?.type === "supergroup" && chat.is_forum === true) {
+				this.chatDeliveryMode = "forum";
+			} else {
+				this.chatDeliveryMode = "unsupported";
+			}
+			return this.chatDeliveryMode;
 		} catch (e) {
-			logger.warn(`notifications: getChat failed while checking Telegram chat privacy: ${String(e)}`);
-			return false;
+			logger.warn(`notifications: getChat failed while checking Telegram chat delivery mode: ${String(e)}`);
+			return "unsupported";
 		}
+	}
+
+	private async chatSupportsTopics(): Promise<boolean> {
+		const mode = await this.telegramChatDeliveryMode();
+		return mode === "private" || mode === "forum";
+	}
+
+	private async pairedChatIsPrivate(): Promise<boolean> {
+		return (await this.telegramChatDeliveryMode()) === "private";
 	}
 
 	/** Tell the user once (per daemon run) how to enable Threaded Mode. */
@@ -1999,7 +2021,7 @@ export class TelegramNotificationDaemon {
 	/** Send a single `typing` chat action into a busy session's topic (best-effort). */
 	private async sendTyping(sessionId: string): Promise<void> {
 		const topicId = this.topics.get(sessionId)?.topicId;
-		if (!topicId || !(await this.pairedChatIsPrivate())) return;
+		if (!topicId || !(await this.chatSupportsTopics())) return;
 		try {
 			await this.botApi.call("sendChatAction", {
 				chat_id: this.opts.chatId,
@@ -2013,7 +2035,7 @@ export class TelegramNotificationDaemon {
 
 	/** Set a native reaction on an inbound thread message (best-effort). */
 	private async setReaction(messageId: number, emoji: string): Promise<void> {
-		if (!(await this.pairedChatIsPrivate())) return;
+		if (!(await this.chatSupportsTopics())) return;
 		try {
 			await this.botApi.call("setMessageReaction", {
 				chat_id: this.opts.chatId,
@@ -2041,7 +2063,7 @@ export class TelegramNotificationDaemon {
 		if (typeof msg?.type === "string" && TelegramNotificationDaemon.THREADED_FRAMES.has(msg.type)) {
 			const send = renderThreadedFrame(msg);
 			if (!send) return;
-			const existingTopic = await this.existingTopicForPrivateChat(session.sessionId);
+			const existingTopic = await this.existingTopicForThreadedChat(session.sessionId);
 			if (!send.identity && !existingTopic && !this.flatIdentitySent.has(session.sessionId)) {
 				this.rememberPendingThreadedFrame(session.sessionId, send, msg as Record<string, unknown>);
 				return;

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -2091,15 +2091,17 @@ test("inbound document is saved to a tmp file and its path injected into the tex
 	expect(match).toBeTruthy();
 	expect(fs.existsSync(match![1]!)).toBe(true);
 	expect(fs.readFileSync(match![1]!)).toEqual(Buffer.from([9, 9, 9]));
-	// Security: the saved file must be private (0600, no group/other access) inside
-	// a private 0700 per-session directory under the system temp root — not a
-	// predictable, world-readable /tmp path.
+	// Security: the saved file must stay in an unguessable per-session temp
+	// directory. POSIX permission bits are meaningful on Unix; Windows reports
+	// compatibility mode bits that do not reflect the ACL privacy boundary.
 	const dest = match![1]!;
 	const fileMode = fs.statSync(dest).mode & 0o777;
 	const dirMode = fs.statSync(path.dirname(dest)).mode & 0o777;
-	expect(fileMode).toBe(0o600);
-	expect(fileMode & 0o077).toBe(0);
-	expect(dirMode & 0o077).toBe(0);
+	if (process.platform !== "win32") {
+		expect(fileMode).toBe(0o600);
+		expect(fileMode & 0o077).toBe(0);
+		expect(dirMode & 0o077).toBe(0);
+	}
 	expect(dest.startsWith(os.tmpdir())).toBe(true);
 });
 

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -1642,17 +1642,55 @@ test("threaded mode off: image_attachment uploads flat without message_thread_id
 	expect(notice).toHaveLength(1);
 });
 
-test("non-private chat: fails closed before topic creation or flat delivery", async () => {
-	for (const chatType of ["supergroup", "group", "channel"]) {
+test("forum supergroup chat creates per-session topics and never falls back flat", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 777 } };
+		if (method === "getChat") return { ok: true, result: { type: "supergroup", is_forum: true } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	await daemon.handleSessionMessage(session as any, {
+		type: "action_needed",
+		sessionId: "S",
+		id: "ask1",
+		kind: "ask",
+		question: "Proceed?",
+		options: ["Yes"],
+	});
+
+	const creates = bot.calls.filter(c => c.method === "createForumTopic");
+	const messages = bot.calls.filter(c => c.method === "sendMessage");
+	expect(creates).toHaveLength(1);
+	expect(messages.length).toBeGreaterThanOrEqual(2);
+	expect(messages.every(c => c.body.message_thread_id === 777)).toBe(true);
+});
+
+test("unsupported non-private chat: fails closed before topic creation or flat delivery", async () => {
+	for (const chat of [{ type: "supergroup", is_forum: false }, { type: "group" }, { type: "channel" }]) {
 		const agentDir = tempAgentDir();
 		const bot = new FakeBotApi();
-		// Even if the target chat would accept forum topic creation, the paired chat
-		// contract is private-only, so the daemon must fail closed before creating
-		// topics or sending session content into a shared chat.
 		bot.call = (async (method: string, body: any) => {
 			bot.calls.push({ method, body });
 			if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 777 } };
-			if (method === "getChat") return { ok: true, result: { type: chatType } };
+			if (method === "getChat") return { ok: true, result: chat };
 			if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
 			return { ok: true, result: true };
 		}) as any;

--- a/packages/coding-agent/test/notify-setup.test.ts
+++ b/packages/coding-agent/test/notify-setup.test.ts
@@ -282,18 +282,38 @@ test("non-interactive setup with --token and --chat-id verifies private chat wit
 	expect(getUpdatesCalls).toBe(0);
 });
 
-test("non-interactive setup rejects non-private chat ids without writing config", async () => {
-	for (const type of ["group", "supergroup", "channel"]) {
+test("non-interactive setup accepts forum supergroup chat ids without private Threaded Mode", async () => {
+	const settings = Settings.isolated({});
+	const { fetchImpl, calls } = makeFetch({
+		getMe: [{ ok: true, result: { id: 1, is_bot: true, has_topics_enabled: false } }],
+		getChat: [{ ok: true, result: { id: -100, type: "supergroup", is_forum: true } }],
+	});
+	const cmd = parseNotifyArgs(["notify", "setup", "--token", "123:abc", "--chat-id", "-100"]);
+
+	const { stdout } = await captureOutput(() =>
+		runNotifyCommand(cmd!, { settings, fetchImpl, setupInteractive: false }),
+	);
+
+	const cfg = getNotificationConfig(settings);
+	expect(cfg.enabled).toBe(true);
+	expect(cfg.chatId).toBe("-100");
+	expect(stdout).toContain("forum supergroup");
+	expect(stdout).toContain("threaded=forum");
+	expect(calls.filter(call => call.method === "getUpdates")).toHaveLength(0);
+});
+
+test("non-interactive setup rejects unsupported non-private chat ids without writing config", async () => {
+	for (const chat of [{ type: "group" }, { type: "supergroup", is_forum: false }, { type: "channel" }]) {
 		const settings = Settings.isolated({});
 		const { fetchImpl, calls } = makeFetch({
 			getMe: [{ ok: true, result: { id: 1, is_bot: true, has_topics_enabled: true } }],
-			getChat: [{ ok: true, result: { id: -100, type } }],
+			getChat: [{ ok: true, result: { id: -100, ...chat } }],
 		});
 		const cmd = parseNotifyArgs(["notify", "setup", "--token", "123:abc", "--chat-id", "-100"]);
 
 		await expect(
 			captureOutput(() => runNotifyCommand(cmd!, { settings, fetchImpl, setupInteractive: false })),
-		).rejects.toThrow(`Provided chat id -100 is a ${type} chat`);
+		).rejects.toThrow("pairing requires a private Telegram chat or forum-enabled supergroup");
 
 		expect(getNotificationConfig(settings).enabled).toBe(false);
 		expect(getNotificationConfig(settings).botToken).toBeUndefined();


### PR DESCRIPTION
## Summary

Hello! While verifying the Telegram session-topic flow on Windows, I found two related issues:

1. A configured forum supergroup chat (`getChat.type = supergroup`, `is_forum = true`) was treated as unsupported, so per-session Telegram topics were not created there even though `createForumTopic` works for that chat type when the bot has permission.
2. The Telegram daemon attachment test assumed POSIX mode bits exactly on Windows, where Node reports compatibility permission bits rather than the actual ACL privacy boundary.

This PR updates the Telegram daemon to support two topic-capable targets:

- private chats with BotFather Threaded Mode enabled; and
- explicitly configured forum-enabled supergroups.

Forum supergroups now create/reuse one topic per GJC session and deliver messages with `message_thread_id`. Unsupported shared chats still fail closed, and flat fallback remains private-only so session content is not leaked into a group when topic creation fails.

It also updates `gjc notify setup --token ... --chat-id ...` to accept a forum-enabled supergroup after verifying `getChat.is_forum === true`, while keeping interactive discovery private-only for safety. Docs and tests were updated accordingly.

## Verification

Local environment check against the configured Telegram chat:

- `getMe.has_topics_enabled`: `false` (private-chat Threaded Mode is off)
- `getChat.type`: `supergroup`
- `getChat.is_forum`: `true`
- Temporary `createForumTopic` + `deleteForumTopic`: both succeeded

Test/format/type checks:

- `bun test packages/coding-agent/test/notify-setup.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts packages/coding-agent/test/telegram-onboarding-docs.test.ts packages/coding-agent/test/notifications-threaded-render.test.ts packages/coding-agent/test/notifications-threaded-inbound.test.ts packages/coding-agent/test/telegram-send-tool.test.ts`
  - `132 pass, 0 fail`
- `bun x biome check packages/coding-agent/src/notifications/telegram-daemon.ts packages/coding-agent/src/cli/notify-cli.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts packages/coding-agent/test/notify-setup.test.ts docs/telegram-onboarding.md docs/notifications-sdk.md`
  - `No fixes applied`
- `bun --cwd=packages/coding-agent run check:types`
  - passed