### PR TITLE
fix(gjc-state): fail open on corrupt per-skill active-state entry files (Failed to load skill: JSON Parse error: Unrecognized token '')

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import type { Stats } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import * as logger from "@gajae-code/utils/logger";
 import { type FileLockOptions, withFileLock } from "../config/file-lock";
 import type { ActiveSubskillEntry, SkillActiveEntry, SkillActiveState } from "../skill-state/active-state";
 import {
@@ -1024,7 +1025,22 @@ export async function readActiveEntries(
 	const entries: SkillActiveEntry[] = [];
 	for (const name of names.sort()) {
 		if (!name.endsWith(".json")) continue;
-		const raw = await readJsonIfPresent(path.join(dir, name));
+		const filePath = path.join(dir, name);
+		let raw: unknown;
+		try {
+			raw = await readJsonIfPresent(filePath);
+		} catch (error) {
+			// Fail open: a single corrupt per-skill entry file (e.g. a zero-filled or
+			// truncated file left by an interrupted / rename-crashed write, common on
+			// exFAT and network volumes) must not break active-state reads or block
+			// skill loading. Skip it; the next authoritative write overwrites it.
+			logger.warn(
+				`gjc skill-state: skipping corrupt active-state entry at ${filePath}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			continue;
+		}
 		if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
 		const skill = safeString((raw as SkillActiveEntry).skill).trim();
 		if (!skill) continue;

--- a/packages/coding-agent/test/gjc-runtime/read-active-entries-corrupt.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/read-active-entries-corrupt.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { logger } from "@gajae-code/utils";
+import { activeEntryPath } from "../../src/gjc-runtime/session-layout";
+import { readActiveEntries } from "../../src/gjc-runtime/state-writer";
+import { readVisibleSkillActiveState } from "../../src/skill-state/active-state";
+
+const SID = "session-corrupt-active-entry";
+const tempRoots: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-corrupt-active-entry-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+async function writeEntry(root: string, skill: string, content: string): Promise<void> {
+	const filePath = activeEntryPath(root, SID, skill);
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, content);
+}
+
+afterAll(async () => {
+	await Promise.all(tempRoots.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+// Regression: an interrupted / rename-crashed write on exFAT or a network volume
+// can leave a per-skill active-state file (`.gjc/_session-*/state/active/<skill>.json`)
+// zero-filled or truncated. `JSON.parse` of a leading NUL byte throws the JSC error
+// `JSON Parse error: Unrecognized token ''`, which used to propagate out of
+// readActiveEntries -> readVisibleSkillActiveState -> buildSubskillInjection and
+// surface as "Failed to load skill: JSON Parse error: Unrecognized token ''",
+// permanently blocking every `/skill:` invocation. The read path must fail open.
+describe("readActiveEntries: corrupt per-skill entry files (issue: Failed to load skill)", () => {
+	it("skips a NUL-corrupted entry, keeps valid entries, and warns once", async () => {
+		const root = await tempDir();
+		await writeEntry(root, "team", JSON.stringify({ skill: "team", active: true, session_id: SID }));
+		await writeEntry(root, "ultragoal", "\u0000"); // exFAT zero-fill
+
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const entries = await readActiveEntries(root, { sessionId: SID });
+			expect(entries.map(e => e.skill)).toEqual(["team"]);
+			expect(warn).toHaveBeenCalledTimes(1);
+			const message = String(warn.mock.calls[0]?.[0] ?? "");
+			expect(message).toContain("skipping corrupt active-state entry");
+			expect(message).toContain(activeEntryPath(root, SID, "ultragoal"));
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("does not throw for a fully zero-filled or truncated entry", async () => {
+		const root = await tempDir();
+		await writeEntry(root, "ralplan", "\u0000".repeat(64)); // zero-filled cluster
+		await writeEntry(root, "ultragoal", '{"skill":'); // truncated mid-write
+
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			await expect(readActiveEntries(root, { sessionId: SID })).resolves.toEqual([]);
+			expect(warn).toHaveBeenCalledTimes(2);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("readVisibleSkillActiveState (the /skill: load path) fails open, still surfacing valid state", async () => {
+		const root = await tempDir();
+		await writeEntry(
+			root,
+			"team",
+			JSON.stringify({ skill: "team", active: true, phase: "running", session_id: SID }),
+		);
+		await writeEntry(root, "ultragoal", "\u0000"); // corrupt sibling entry
+
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const state = await readVisibleSkillActiveState(root, SID);
+			expect(state).not.toBeNull();
+			expect(state?.active_skills?.map(e => e.skill)).toContain("team");
+		} finally {
+			warn.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## Symptom

Every `/skill:` invocation fails with:

```
Failed to load skill: JSON Parse error: Unrecognized token ''
```

(or the sibling `... Unexpected EOF` for a truncated file). The error is permanent — it does not clear on retry — and blocks all skill loading in the session.

## Root cause

The message is the **raw Bun/JSC `JSON.parse` error**, not a wrapped `GjcPluginLoadError`. On Bun/JSC, `JSON.parse("\u0000…")` yields exactly `JSON Parse error: Unrecognized token ''` (empty quotes = a leading NUL/control byte), and a truncated document yields `Unexpected EOF`.

The unguarded parse is in `readActiveEntries` (`gjc-runtime/state-writer.ts`), which reads every per-skill entry file `.gjc/_session-*/state/active/<skill>.json` via `readJsonIfPresent`. That helper **rethrows any non-`ENOENT` error**, including a `SyntaxError` from a corrupt file. The error then propagates through the `/skill:` load path:

```
readJsonIfPresent (state-writer.ts:381)
  -> readActiveEntries (state-writer.ts)
  -> mergeVisibleEntries (skill-state/active-state.ts:608)
  -> readVisibleSkillActiveState (active-state.ts:627)
  -> resolveCurrentPhaseForParent / readActiveSubskillsForParent
  -> buildSubskillInjection (gjc-plugins/injection.ts)   // not wrapped in try/catch
  -> buildSkillPromptMessage (extensibility/skills.ts)
  -> controller catch -> showError("Failed to load skill: " + err.message)
```

A per-skill entry file gets left **zero-filled or truncated** when a write is interrupted (crash / kill / power loss). This is especially common on **exFAT** and network volumes, which can expose a file whose size metadata is updated before the data blocks are flushed — i.e. NUL bytes. (Originally reported from a working dir on an exFAT volume mounted via macOS `fskit`.)

Every other reader on this path already fails open (`readModeStatePhase`, `readRawActiveStateForHandoff` non-strict, `readActivityMs`); `readActiveEntries` was the single hole.

## Fix

Make `readActiveEntries` **fail open**: skip a corrupt per-skill entry file and log a warning instead of throwing. This matches the project convention (reads fail open, writes fail closed) and mirrors the existing `readJsonIfPresentTolerant` twin already used by the write path's revision computation. The corrupt file is naturally overwritten by the next authoritative write.

The shared `readJsonIfPresent` is intentionally left strict — the write-path CAS/revision callers rely on surfacing corruption.

## Reproduction

Planting `"\u0000"` at `active/ultragoal.json` and calling `readVisibleSkillActiveState` throws `JSON Parse error: Unrecognized token ''` before the fix; returns the valid siblings after. Covered by the new test.

## Testing

- New: `test/gjc-runtime/read-active-entries-corrupt.test.ts` (leading-NUL / zero-filled / truncated entries; verified it fails before the fix and passes after).
- `bun test` across state-writer, skill-state hooks, gjc-plugin activation/injection, and skills suites: **122 pass / 0 fail**.
- `bun run check:types`: clean. `biome check`: clean.
