### PR TITLE
fix(rpc): restore RpcListenRefusedError so duplicate --listen exits cleanly (issues/19)

### DIFF
--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -173,15 +173,9 @@ function auditOutcomeFor(event: string): "accepted" | "rejected" | "denied" | "e
 	return "info";
 }
 
-export class RpcListenRefusedError extends Error {
-	constructor(socketPath: string) {
-		super(
-			`RPC --listen refused: a live server is already listening on ${socketPath}. ` +
-				"Stop it first or choose a different --listen path.",
-		);
-		this.name = "RpcListenRefusedError";
-	}
-}
+// Thrown by prepareRpcSocketPath when the --listen path has a live owner;
+// re-exported here because main.ts catches it at the RPC launch boundary.
+export { RpcListenRefusedError } from "./rpc-socket-security";
 
 /**
  * Probe whether a unix-domain socket path has a live server accepting

--- a/packages/coding-agent/src/modes/rpc/rpc-socket-security.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-socket-security.ts
@@ -9,6 +9,18 @@ export class RpcSocketSecurityError extends Error {
 	}
 }
 
+// The launch boundary in main.ts catches exactly this class to turn a
+// duplicate --listen into a clean stderr diagnostic + non-zero exit (issue 19).
+export class RpcListenRefusedError extends Error {
+	constructor(socketPath: string) {
+		super(
+			`RPC --listen refused: a live server is already listening on ${socketPath}. ` +
+				"Stop it first or choose a different --listen path.",
+		);
+		this.name = "RpcListenRefusedError";
+	}
+}
+
 const unsafeBits = 0o077;
 
 function currentUid(): number | undefined {
@@ -53,7 +65,7 @@ export async function prepareRpcSocketPath(socketPath: string): Promise<void> {
 	if (!existing.isSocket()) throw new RpcSocketSecurityError(`RPC socket path is not a socket: ${socketPath}`);
 	assertPrivateMode(existing.mode, socketPath);
 	if (await probeUnixSocketAlive(socketPath)) {
-		throw new RpcSocketSecurityError(`RPC socket path is live: ${socketPath}`);
+		throw new RpcListenRefusedError(socketPath);
 	}
 	await fs.unlink(socketPath);
 }

--- a/packages/coding-agent/test/rpc-listen-socket-guard.test.ts
+++ b/packages/coding-agent/test/rpc-listen-socket-guard.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdtemp, rm } from "node:fs/promises";
+import * as net from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
-import { isUnixSocketAlive } from "@gajae-code/coding-agent/modes/rpc/rpc-mode";
+import { isUnixSocketAlive, RpcListenRefusedError } from "@gajae-code/coding-agent/modes/rpc/rpc-mode";
+import { prepareRpcSocketPath } from "@gajae-code/coding-agent/modes/rpc/rpc-socket-security";
 
 let dir: string;
 
@@ -64,5 +66,24 @@ describe("isUnixSocketAlive (--listen live-owner probe, #606)", () => {
 		}) as typeof Bun.connect;
 
 		expect(await isUnixSocketAlive(path.join(dir, "permission.sock"))).toBe(true);
+	});
+});
+
+describe("--listen duplicate refusal boundary (issue 19)", () => {
+	it("prepareRpcSocketPath throws the RpcListenRefusedError class main.ts catches at launch", async () => {
+		// main.ts imports RpcListenRefusedError from rpc-mode and only exits cleanly
+		// for that class; the refusal thrown on a live socket must be that instance.
+		const socketPath = path.join(dir, "duplicate.sock");
+		const server = net.createServer();
+		await new Promise<void>((resolve, reject) => {
+			server.once("error", reject);
+			server.listen(socketPath, resolve);
+		});
+		try {
+			await chmod(socketPath, 0o600);
+			await expect(prepareRpcSocketPath(socketPath)).rejects.toBeInstanceOf(RpcListenRefusedError);
+		} finally {
+			await new Promise<void>(resolve => server.close(() => resolve()));
+		}
 	});
 });

--- a/packages/coding-agent/test/rpc-socket-security.test.ts
+++ b/packages/coding-agent/test/rpc-socket-security.test.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import {
 	assertSafeClientSocket,
 	prepareRpcSocketPath,
+	RpcListenRefusedError,
 	RpcSocketSecurityError,
 	verifyRpcSocketAfterListen,
 } from "@gajae-code/coding-agent/modes/rpc/rpc-socket-security";
@@ -63,6 +64,22 @@ describe("rpc socket security", () => {
 		});
 		try {
 			await expect(prepareRpcSocketPath(socketPath)).rejects.toThrow(/live/);
+			expect((await lstat(socketPath)).isSocket()).toBe(true);
+		} finally {
+			await new Promise<void>(resolve => server.close(() => resolve()));
+		}
+	});
+
+	test("live-socket refusal is an RpcListenRefusedError (the class the launch boundary catches, issue 19)", async () => {
+		const socketPath = path.join(dir, "duplicate-owner.sock");
+		const server = net.createServer();
+		await new Promise<void>((resolve, reject) => {
+			server.once("error", reject);
+			server.listen(socketPath, resolve);
+		});
+		try {
+			await chmod(socketPath, 0o600);
+			await expect(prepareRpcSocketPath(socketPath)).rejects.toThrow(RpcListenRefusedError);
 			expect((await lstat(socketPath)).isSocket()).toBe(true);
 		} finally {
 			await new Promise<void>(resolve => server.close(() => resolve()));


### PR DESCRIPTION
Recreation of #1809 against `dev` (closed for targeting `main`). Same single commit, rebased onto `dev` — the touched files are identical between `main` and `dev`, so the diff is unchanged.

## Summary

Fixes the remaining half of `issues/19-rpc-listen-refusal-uncaught-and-socket-probe-over-broad.md`.

The launch boundary at `packages/coding-agent/src/main.ts` catches `RpcListenRefusedError` to turn a duplicate `gjc --mode rpc --listen <sock>` into a clean stderr diagnostic + non-zero exit. But when the socket guard was refactored into `rpc-socket-security.ts`, the live-socket refusal started throwing `RpcSocketSecurityError("RPC socket path is live: …")` instead — and `RpcListenRefusedError` became dead code that is never thrown anywhere (`grep 'new RpcListenRefusedError'` → 0 hits on dev). The refusal therefore escapes the boundary and surfaces as an uncaught exception with a stack trace.

## Change

- Move `RpcListenRefusedError` into `rpc-socket-security.ts` and throw it from `prepareRpcSocketPath` for the live-owner case (probe still hardened per part 2 of the issue, unchanged).
- Re-export it from `rpc-mode.ts` so the existing `main.ts` import and catch keep working unchanged.
- `main.ts` needs no modification — the original boundary design now functions as intended.

## Tests

- `rpc-socket-security.test.ts`: new test asserting the live-socket refusal is an `RpcListenRefusedError` instance (fails without the fix, passes here). Note: the pre-existing "refuses a live socket" test was passing incidentally — the `/live/` regex matched the `live.sock` path inside the *permissions* error message; the new test `chmod 0o600`s the socket first so the actual live-probe refusal path is exercised.
- `rpc-listen-socket-guard.test.ts`: boundary-wiring test asserting `prepareRpcSocketPath`'s refusal is an instance of the exact class `main.ts` imports from `rpc-mode`.
- On this branch (rebased onto `dev`): `bun run check` (biome + tsgo) green; `rpc-socket-security.test.ts` 11/11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
