### PR TITLE
test: format MCP discovery assertion

### DIFF
--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -521,9 +521,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			});
 			try {
 				expect(resumedSession.getSelectedMCPToolNames()).toEqual([]);
-				expect(resumedSession.getActiveToolNames()).toEqual(
-					expect.arrayContaining(["read", "search_tool_bm25"]),
-				);
+				expect(resumedSession.getActiveToolNames()).toEqual(expect.arrayContaining(["read", "search_tool_bm25"]));
 				expect(resumedSession.getActiveToolNames()).not.toContain("mcp__github_create_issue");
 				expect(resumedSession.getActiveToolNames()).not.toContain("mcp__slack_post_message");
 			} finally {


### PR DESCRIPTION
## Summary

Fix the post-merge dev CI formatting failure from #1819. Biome requires the `sdk-mcp-discovery.test.ts` assertion to be on one line.

## Verification

- `bun --cwd packages/coding-agent run check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*