### PR TITLE
fix(ai): treat ZAI weekly/monthly exhaustion as usage exhaustion

### DIFF
--- a/packages/ai/src/rate-limit-utils.ts
+++ b/packages/ai/src/rate-limit-utils.ts
@@ -93,8 +93,10 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 }
 
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
+// ZAI reports durable token exhaustion as "[1310][Weekly/Monthly Limit Exhausted...]".
+// Keep this explicit so generic "rate limit exhausted, retry..." throttles remain retryable.
 const USAGE_LIMIT_PATTERN =
-	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|model.?limit|model_limit_reached|message.?limit|message_limit_reached|limit for this model|quota.?exceeded|out_of_credits|request would exceed your account.?s rate limit|resource has been exhausted[^\n]*(?:quota|limit)/i;
+	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|model.?limit|model_limit_reached|message.?limit|message_limit_reached|limit for this model|weekly\/monthly\s+limit\s+exhausted|quota.?exceeded|out_of_credits|request would exceed your account.?s rate limit|resource has been exhausted[^\n]*(?:quota|limit)/i;
 export function isUsageLimitError(errorMessage: string): boolean {
 	return USAGE_LIMIT_PATTERN.test(errorMessage);
 }

--- a/packages/ai/test/auth-storage-api-key-rate-limit.test.ts
+++ b/packages/ai/test/auth-storage-api-key-rate-limit.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { AuthStorage, SqliteAuthCredentialStore } from "../src/auth-storage";
+
+describe("AuthStorage api-key usage-limit fallback", () => {
+	let tempDir = "";
+	let store: SqliteAuthCredentialStore | null = null;
+	let authStorage: AuthStorage | null = null;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-api-key-rate-limit-"));
+		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		authStorage = new AuthStorage(store);
+		await authStorage.set("zai", [
+			{ type: "api_key", key: "zai-key-1" },
+			{ type: "api_key", key: "zai-key-2" },
+			{ type: "api_key", key: "zai-key-3" },
+		]);
+	});
+
+	afterEach(async () => {
+		store?.close();
+		store = null;
+		authStorage = null;
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	it("switches an api-key session away from the credential that hit a usage limit", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		const sessionId = "zai-api-key-usage-limit-session";
+		const firstKey = await authStorage.getApiKey("zai", sessionId);
+
+		const switched = await authStorage.markUsageLimitReached("zai", sessionId, { retryAfterMs: 60_000 });
+		const retryKey = await authStorage.getApiKey("zai", sessionId);
+
+		expect(switched).toBe(true);
+		expect(retryKey).toBeDefined();
+		expect(retryKey).not.toBe(firstKey);
+		expect(new Set([firstKey, retryKey]).size).toBe(2);
+	});
+});

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -59,6 +59,12 @@ describe("parseRateLimitReason", () => {
 			"QUOTA_EXHAUSTED",
 		);
 	});
+
+	it("classifies ZAI weekly/monthly limit exhaustion as QUOTA_EXHAUSTED", () => {
+		expect(
+			parseRateLimitReason("[1310][Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-14 07:49:08]"),
+		).toBe("QUOTA_EXHAUSTED");
+	});
 });
 
 describe("calculateRateLimitBackoffMs", () => {
@@ -93,8 +99,18 @@ describe("isUsageLimitError", () => {
 		expect(isUsageLimitError("429 rate limit exceeded retry-after-ms=5000")).toBe(false);
 	});
 
+	it("detects ZAI weekly/monthly limit exhaustion as persistent usage exhaustion", () => {
+		expect(
+			isUsageLimitError(
+				'429 {"type":"error","error":{"type":"rate_limit_error","code":"1310","message":"[1310][Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-14 07:49:08]"}} retry-after-ms=504641000',
+			),
+		).toBe(true);
+	});
+
 	it("does not classify generic rate limits as usage exhaustion", () => {
 		expect(isUsageLimitError("429 rate limit exceeded, please retry in 5s")).toBe(false);
 		expect(isUsageLimitError("Requests per minute limit reached")).toBe(false);
+		expect(isUsageLimitError("429 rate limit exhausted, retry after 5s")).toBe(false);
+		expect(isUsageLimitError("rate limit exhausted, retry after 5 seconds")).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary
- classify ZAI `Weekly/Monthly Limit Exhausted` 429s as persistent usage exhaustion in `isUsageLimitError()`
- add regression coverage for the real ZAI `code: 1310` / long `retry-after-ms` error shape
- add an AuthStorage API-key fallback test showing a blocked ZAI key is skipped and another configured key is selected

## Motivation
ZAI GLM sessions can return a persistent quota-exhaustion 429 like:

```text
[1310][Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-14 07:49:08]
```

The coding-agent retry path only calls `AuthStorage.markUsageLimitReached(...)` when `isUsageLimitError()` returns true. Because this ZAI wording was not matched, sessions with multiple ZAI API keys could keep treating the exhausted key as a generic rate limit instead of blocking it and failing over to another key.

This keeps generic transient 429s out of the persistent usage-limit classifier while recognizing ZAI's explicit weekly/monthly quota exhaustion.

## Verification
- `bun --cwd=packages/natives run build`
- `bun test packages/ai/test/rate-limit-utils.test.ts packages/ai/test/auth-storage-api-key-rate-limit.test.ts` — 19 pass

## References
- Fixes #1821
