### PR TITLE
Fix macOS Option+Enter queue shortcut

### DIFF
--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -61,7 +61,7 @@ declare module "@gajae-code/tui" {
 }
 
 export function defaultMessageQueueKeysForPlatform(platform: NodeJS.Platform = process.platform): KeyId {
-	return platform === "win32" ? "alt+q" : "alt+enter";
+	return platform === "win32" || platform === "darwin" ? "alt+q" : "alt+enter";
 }
 
 /**

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -139,6 +139,22 @@ describe("CustomEditor queue keybinding", () => {
 		expect(editor.getText()).toBe("a\n");
 	});
 
+	it("keeps macOS Option+Enter legacy CR sequence as newline when queue uses Alt+Q", () => {
+		const editor = createEditor();
+		const onQueue = vi.fn();
+		const onSubmit = vi.fn();
+		editor.onQueue = onQueue;
+		editor.onSubmit = onSubmit;
+		editor.setActionKeys("app.message.queue", [defaultMessageQueueKeysForPlatform("darwin")]);
+
+		editor.handleInput("a");
+		editor.handleInput("\x1b\r");
+
+		expect(onQueue).not.toHaveBeenCalled();
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("a\n");
+	});
+
 	it("submits plain Enter", () => {
 		const editor = createEditor();
 		const onSubmit = vi.fn();

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -36,7 +36,7 @@ describe("message keybinding defaults", () => {
 		expect(keybindings.getKeys("app.message.followUp")).toEqual([]);
 		expect(keybindings.getDisplayString("app.message.followUp")).toBe("");
 		expect(keybindings.getDisplayString("app.message.queue")).toBe(
-			process.platform === "win32" ? "Alt+Q" : "Alt+Enter",
+			process.platform === "win32" || process.platform === "darwin" ? "Alt+Q" : "Alt+Enter",
 		);
 	});
 
@@ -47,10 +47,10 @@ describe("message keybinding defaults", () => {
 		expect(keybindings.getDisplayString("app.message.dequeue")).toBe("Alt+Up/Alt+Down");
 	});
 
-	it("uses Alt+Q for the native Windows queue shortcut", () => {
+	it("uses Alt+Q for native Windows and macOS queue shortcuts", () => {
 		expect(defaultMessageQueueKeysForPlatform("win32")).toBe("alt+q");
 		expect(defaultMessageQueueKeysForPlatform("linux")).toBe("alt+enter");
-		expect(defaultMessageQueueKeysForPlatform("darwin")).toBe("alt+enter");
+		expect(defaultMessageQueueKeysForPlatform("darwin")).toBe("alt+q");
 	});
 });
 


### PR DESCRIPTION
Fixes #1814.

## Summary
- move the default queue/steering shortcut on macOS from Alt+Enter to Alt+Q
- preserve Alt+Enter queue on Linux and Alt+Q on Windows
- add regression coverage for the legacy macOS Option+Enter CR sequence falling through to newline when queue is Alt+Q

## Verification
- bun test packages/coding-agent/test/custom-editor-keybindings.test.ts packages/coding-agent/test/keybindings-display.test.ts packages/tui/test/keys.test.ts
- bun --cwd=packages/coding-agent run check:types
- bunx biome check packages/coding-agent/src/config/keybindings.ts packages/coding-agent/test/custom-editor-keybindings.test.ts packages/coding-agent/test/keybindings-display.test.ts