### PR TITLE
docs(ai): fix misleading capacity-jitter comment (±15s → +0–30s)

### DIFF
--- a/packages/ai/src/rate-limit-utils.ts
+++ b/packages/ai/src/rate-limit-utils.ts
@@ -13,7 +13,7 @@ export type RateLimitReason =
 const QUOTA_EXHAUSTED_BACKOFF_MS = 30 * 60 * 1000; // 30 min
 const RATE_LIMIT_EXCEEDED_BACKOFF_MS = 30 * 1000; // 30s
 const MODEL_CAPACITY_BASE_MS = 45 * 1000; // 45s base
-const MODEL_CAPACITY_JITTER_MS = 30 * 1000; // ±15s
+const MODEL_CAPACITY_JITTER_MS = 30 * 1000; // uniform +0–30s above base → 45–75s total
 const SERVER_ERROR_BACKOFF_MS = 20 * 1000; // 20s
 
 /**


### PR DESCRIPTION
## Summary

One-line comment fix in `packages/ai/src/rate-limit-utils.ts`. No behavior change.

`MODEL_CAPACITY_JITTER_MS` is annotated `// ±15s`, but the code applies it one-sidedly:

```ts
return MODEL_CAPACITY_BASE_MS + Math.random() * MODEL_CAPACITY_JITTER_MS; // 45s + [0,30s) = [45s,75s)
```

The actual distribution is uniform **+0–30s above the 45s base (45–75s total)** — which is exactly what the existing test pins (`rate-limit-utils.test.ts`: "returns 45–75s range for MODEL_CAPACITY_EXHAUSTED (jitter)"). So the code and test agree; only the comment claims a symmetric ±15s around the base.

Why it matters: the comment makes correct code look wrong. Reading the constant alone suggests the intended range is [30s,60s) and that `calculateRateLimitBackoffMs` has a one-sided-jitter bug — an audit pass here flagged it as exactly that before the test proved otherwise. Aligning the comment with the pinned behavior prevents a future "fix" that would actually be a regression.

## Tests

- `bun run check` (biome + tsgo) green in `packages/ai`.
- `bun test test/rate-limit-utils.test.ts`: 16/16 pass (unchanged — this is a comment-only diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)