### PR TITLE
Add /effort command and selector

### DIFF
--- a/packages/coding-agent/src/modes/components/thinking-selector.ts
+++ b/packages/coding-agent/src/modes/components/thinking-selector.ts
@@ -1,7 +1,7 @@
-import type { Effort } from "@gajae-code/ai";
+import { ThinkingLevel, type ThinkingLevel as ThinkingLevelValue } from "@gajae-code/agent-core";
 import { Container, type SelectItem, SelectList } from "@gajae-code/tui";
 import { getSelectListTheme } from "../../modes/theme/theme";
-import { getThinkingLevelMetadata } from "../../thinking";
+import { getThinkingLevelMetadata, type ThinkingLevelValue as ThinkingMetadataValue } from "../../thinking-metadata";
 import { DynamicBorder } from "./dynamic-border";
 
 /**
@@ -11,14 +11,16 @@ export class ThinkingSelectorComponent extends Container {
 	#selectList: SelectList;
 
 	constructor(
-		currentLevel: Effort,
-		availableLevels: Effort[],
-		onSelect: (level: Effort) => void,
+		currentLevel: ThinkingLevelValue | undefined,
+		availableLevels: ThinkingLevelValue[],
+		onSelect: (level: ThinkingLevelValue) => void,
 		onCancel: () => void,
 	) {
 		super();
 
-		const thinkingLevels: SelectItem[] = availableLevels.map(getThinkingLevelMetadata);
+		const thinkingLevels: SelectItem[] = availableLevels.map(level =>
+			getThinkingLevelMetadata(level as ThinkingMetadataValue),
+		);
 
 		// Add top border
 		this.addChild(new DynamicBorder());
@@ -27,13 +29,13 @@ export class ThinkingSelectorComponent extends Container {
 		this.#selectList = new SelectList(thinkingLevels, thinkingLevels.length, getSelectListTheme());
 
 		// Preselect current level
-		const currentIndex = thinkingLevels.findIndex(item => item.value === currentLevel);
+		const currentIndex = thinkingLevels.findIndex(item => item.value === (currentLevel ?? ThinkingLevel.Off));
 		if (currentIndex !== -1) {
 			this.#selectList.setSelectedIndex(currentIndex);
 		}
 
 		this.#selectList.onSelect = item => {
-			onSelect(item.value as Effort);
+			onSelect(item.value as ThinkingLevelValue);
 		};
 
 		this.#selectList.onCancel = () => {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -88,6 +88,7 @@ import { SessionSelectorComponent } from "../components/session-selector";
 import { SettingsSelectorComponent } from "../components/settings-selector";
 import type { StatusLineSettings } from "../components/status-line";
 import { ThemeSelectorComponent } from "../components/theme-selector";
+import { ThinkingSelectorComponent } from "../components/thinking-selector";
 import { ToolExecutionComponent } from "../components/tool-execution";
 import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
@@ -428,6 +429,46 @@ export class SelectorController {
 				() => this.ctx.ui.requestRender(),
 			);
 			return { component: wizard, focus: wizard };
+		});
+	}
+
+	showEffortSelector(): void {
+		const availableLevels = [
+			ThinkingLevel.Inherit,
+			ThinkingLevel.Off,
+			...this.ctx.session.getAvailableThinkingLevels(),
+		];
+
+		this.showSelector(done => {
+			const selector = new ThinkingSelectorComponent(
+				this.ctx.session.thinkingLevel,
+				availableLevels,
+				level => {
+					done();
+
+					const configuredDefault = this.ctx.settings.get("defaultThinkingLevel");
+					const levelToApply = level === ThinkingLevel.Inherit ? configuredDefault : level;
+					this.ctx.session.setThinkingLevel(levelToApply, false);
+					const effectiveLevel = this.ctx.session.thinkingLevel ?? ThinkingLevel.Off;
+					const requestedLabel =
+						level === ThinkingLevel.Inherit ? `${level} (configured default: ${configuredDefault})` : level;
+					const clampedSuffix =
+						effectiveLevel === levelToApply ? "" : ` Requested ${levelToApply}; effective ${effectiveLevel}.`;
+
+					this.ctx.statusLine.invalidate();
+					this.ctx.updateEditorBorderColor();
+					this.ctx.updateEditorTopBorder();
+					this.ctx.ui.requestRender();
+					this.ctx.showStatus(
+						`Reasoning effort set to ${requestedLabel}. Effective effort: ${effectiveLevel}.${clampedSuffix}`,
+					);
+				},
+				() => {
+					done();
+					this.ctx.ui.requestRender();
+				},
+			);
+			return { component: selector, focus: selector.getSelectList() };
 		});
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2552,6 +2552,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#selectorController.showModelSelector(options);
 	}
 
+	showEffortSelector(): void {
+		this.#selectorController.showEffortSelector();
+	}
+
 	showProviderOnboarding(): void {
 		this.#selectorController.showProviderOnboarding();
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -243,6 +243,7 @@ export interface InteractiveModeContext {
 	showExtensionsDashboard(): void;
 	showAgentsDashboard(): void;
 	showModelSelector(options?: { temporaryOnly?: boolean }): void;
+	showEffortSelector(): void;
 	showProviderOnboarding(): void;
 	showPluginSelector(mode?: "install" | "uninstall"): void;
 	showUserMessageSelector(): void;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import type { ThinkingLevel } from "@gajae-code/agent-core";
+import { ThinkingLevel } from "@gajae-code/agent-core";
 import { type Model, modelsAreEqual } from "@gajae-code/ai";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import { Spacer, Text } from "@gajae-code/tui";
@@ -378,6 +378,60 @@ function modelSelectionUsage(runtime: SlashCommandRuntime, currentModelLine?: st
 		.join("\n\n");
 }
 
+const EFFORT_COMMAND_INPUT_HINT = "[inherit|off|minimal|low|medium|high|xhigh|max]";
+const EFFORT_COMMAND_ACCEPTED_VALUES = ["inherit", "off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
+function effortCommandUsage(prefix?: string): string {
+	return [prefix, `Usage: /effort ${EFFORT_COMMAND_INPUT_HINT}`]
+		.filter((line): line is string => Boolean(line))
+		.join("\n");
+}
+
+function formatEffortStatus(runtime: SlashCommandRuntime): string {
+	const current = runtime.session.thinkingLevel ?? ThinkingLevel.Off;
+	const configuredDefault = runtime.settings.get("defaultThinkingLevel");
+	const supported = runtime.session.getAvailableThinkingLevels();
+	return [
+		`Current effective effort: ${current}`,
+		`Configured default effort: ${configuredDefault}`,
+		`Accepted values: ${EFFORT_COMMAND_ACCEPTED_VALUES.join(", ")}`,
+		`Current-model supported levels: ${supported.length > 0 ? supported.join(", ") : "(none reported)"}`,
+	].join("\n");
+}
+
+async function handleEffortCommand(
+	command: ParsedSlashCommand,
+	runtime: SlashCommandRuntime,
+): Promise<SlashCommandResult> {
+	const tokens = command.args.trim().split(/\s+/).filter(Boolean);
+	if (tokens.length === 0) {
+		await runtime.output(formatEffortStatus(runtime));
+		return commandConsumed();
+	}
+	if (tokens.length !== 1) {
+		return usage(effortCommandUsage("Invalid effort input."), runtime);
+	}
+
+	const requestedToken = tokens[0];
+	const requestedLevel = parseThinkingLevel(requestedToken);
+	if (!requestedToken || !requestedLevel) {
+		return usage(effortCommandUsage(`Invalid effort: ${tokens[0] ?? ""}.`), runtime);
+	}
+
+	const levelToApply =
+		requestedLevel === ThinkingLevel.Inherit ? runtime.settings.get("defaultThinkingLevel") : requestedLevel;
+	runtime.session.setThinkingLevel(levelToApply, false);
+	const effectiveLevel = runtime.session.thinkingLevel ?? ThinkingLevel.Off;
+	const requestedLabel =
+		requestedLevel === ThinkingLevel.Inherit ? `${requestedLevel} (${levelToApply})` : requestedLevel;
+	const clampedSuffix =
+		effectiveLevel === levelToApply ? "" : ` Requested ${levelToApply}; effective ${effectiveLevel}.`;
+	await runtime.output(
+		`Reasoning effort set to ${requestedLabel}. Effective effort: ${effectiveLevel}.${clampedSuffix}`,
+	);
+	return commandConsumed();
+}
+
 function refreshStatusLine(ctx: InteractiveModeContext): void {
 	ctx.statusLine.invalidate();
 	ctx.updateEditorTopBorder();
@@ -559,6 +613,29 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return result;
 			}
 			runtime.ctx.showModelSelector();
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "effort",
+		description: "Show or set model reasoning effort",
+		acpDescription: "Show or set model reasoning effort",
+		inlineHint: EFFORT_COMMAND_INPUT_HINT,
+		acpInputHint: EFFORT_COMMAND_INPUT_HINT,
+		allowArgs: true,
+		handle: handleEffortCommand,
+		handleTui: async (command, runtime) => {
+			if (command.args.trim()) {
+				const result = await handleEffortCommand(command, toSlashCommandRuntime(runtime));
+				runtime.ctx.statusLine.invalidate();
+				runtime.ctx.updateEditorBorderColor();
+				runtime.ctx.updateEditorTopBorder();
+				runtime.ctx.editor.setText("");
+				runtime.ctx.ui.requestRender();
+				return result;
+			}
+
+			runtime.ctx.showEffortSelector();
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, spyOn } from "bun:test";
-import type { AgentMessage } from "@gajae-code/agent-core";
+import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
 import { Settings } from "../src/config/settings";
 import { getThemeByName, setThemeInstance, theme } from "../src/modes/theme/theme";
 import type { AgentSession } from "../src/session/agent-session";
@@ -16,6 +16,8 @@ interface FakeAcpBuiltinSession {
 	sessionId: string;
 	sessionName: string;
 	_todoPhases: Array<{ name: string; tasks: Array<{ content: string; status: string }> }>;
+	thinkingLevel: ThinkingLevel | undefined;
+	thinkingLevelCalls: Array<{ thinkingLevel: ThinkingLevel | undefined; persist: boolean | undefined }>;
 	toggleFastMode(): boolean;
 	setFastMode(enabled: boolean): void;
 	isFastModeEnabled(): boolean;
@@ -56,8 +58,9 @@ interface FakeAcpBuiltinSession {
 	compact(args?: string): Promise<void>;
 	getContextUsage(): { tokens?: number; contextWindow: number } | undefined;
 	getAvailableModels(): Array<{ provider: string; id: string; contextWindow?: number }>;
+	getAvailableThinkingLevels(): ThinkingLevel[];
 	setModel(model: unknown): Promise<void>;
-	setThinkingLevel(thinkingLevel: unknown): void;
+	setThinkingLevel(thinkingLevel: ThinkingLevel | undefined, persist?: boolean): void;
 }
 
 function createRuntime() {
@@ -71,6 +74,8 @@ function createRuntime() {
 		sessionId: "fake-session-id",
 		sessionName: "Fake Session",
 		_todoPhases: [],
+		thinkingLevel: ThinkingLevel.Low,
+		thinkingLevelCalls: [],
 		toggleFastMode() {
 			this.fastMode = !this.fastMode;
 			return this.fastMode;
@@ -130,8 +135,12 @@ function createRuntime() {
 		async compact(_args?: string) {},
 		getContextUsage: () => undefined,
 		getAvailableModels: () => [] as Array<{ provider: string; id: string; contextWindow?: number }>,
+		getAvailableThinkingLevels: () => [ThinkingLevel.Low, ThinkingLevel.Medium, ThinkingLevel.High],
 		async setModel(_model: unknown) {},
-		setThinkingLevel(_thinkingLevel: unknown) {},
+		setThinkingLevel(thinkingLevel: ThinkingLevel | undefined, persist?: boolean) {
+			this.thinkingLevel = thinkingLevel;
+			this.thinkingLevelCalls.push({ thinkingLevel, persist });
+		},
 		async refreshSshTool(_options?: { activateIfAvailable?: boolean }) {},
 	};
 	const typedSession = session as unknown as AgentSession & FakeAcpBuiltinSession;
@@ -628,6 +637,154 @@ describe("ACP builtin slash commands", () => {
 		await executeAcpBuiltinSlashCommand("/model nonexistent", runtime);
 
 		expect(configNotified).toBe(0);
+	});
+
+	it("effort: advertises ACP command with the exact accepted-value hint and no thinking alias", () => {
+		const advertised = ACP_BUILTIN_SLASH_COMMANDS.find(command => command.name === "effort");
+		expect(advertised?.description).toBe("Show or set model reasoning effort");
+		expect(advertised?.input?.hint).toBe("[inherit|off|minimal|low|medium|high|xhigh|max]");
+		expect(ACP_BUILTIN_SLASH_COMMANDS.some(command => command.name === "thinking")).toBe(false);
+	});
+
+	it("effort: bare command reports current, default, accepted values, and supported guidance", async () => {
+		const { output, runtime, session } = createRuntime();
+		session.thinkingLevel = ThinkingLevel.Medium;
+		runtime.settings.set("defaultThinkingLevel", ThinkingLevel.High);
+		session.getAvailableThinkingLevels = () => [ThinkingLevel.Low, ThinkingLevel.High];
+
+		const result = await executeAcpBuiltinSlashCommand("/effort", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("Current effective effort: medium");
+		expect(output[0]).toContain("Configured default effort: high");
+		expect(output[0]).toContain("Accepted values: inherit, off, minimal, low, medium, high, xhigh, max");
+		expect(output[0]).toContain("Current-model supported levels: low, high");
+	});
+
+	it("effort: inherit applies configured default to the current session without persistence", async () => {
+		const { output, runtime, session } = createRuntime();
+		runtime.settings.set("defaultThinkingLevel", ThinkingLevel.High);
+
+		const result = await executeAcpBuiltinSlashCommand("/effort inherit", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(session.thinkingLevelCalls).toEqual([{ thinkingLevel: ThinkingLevel.High, persist: false }]);
+		expect(output[0]).toContain("Reasoning effort set to inherit (high)");
+		expect(output[0]).toContain("Effective effort: high");
+	});
+
+	it("effort: off and typed efforts set the current session without persistence", async () => {
+		const { runtime, session } = createRuntime();
+
+		const offResult = await executeAcpBuiltinSlashCommand("/effort off", runtime);
+		const xhighResult = await executeAcpBuiltinSlashCommand("/effort xhigh", runtime);
+
+		expect(offResult).toEqual({ consumed: true });
+		expect(xhighResult).toEqual({ consumed: true });
+		expect(session.thinkingLevelCalls).toEqual([
+			{ thinkingLevel: ThinkingLevel.Off, persist: false },
+			{ thinkingLevel: ThinkingLevel.XHigh, persist: false },
+		]);
+	});
+
+	it("effort: accepts parseable efforts outside current-model guidance and reports requested/effective clamp", async () => {
+		const { output, runtime, session } = createRuntime();
+		session.getAvailableThinkingLevels = () => [ThinkingLevel.Low];
+		session.setThinkingLevel = (thinkingLevel, persist) => {
+			session.thinkingLevelCalls.push({ thinkingLevel, persist });
+			session.thinkingLevel = ThinkingLevel.Low;
+		};
+
+		const result = await executeAcpBuiltinSlashCommand("/effort max", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(session.thinkingLevelCalls).toEqual([{ thinkingLevel: ThinkingLevel.Max, persist: false }]);
+		expect(output[0]).toContain("Requested max; effective low.");
+	});
+
+	it("effort: invalid and malformed inputs consume with usage and do not mutate thinking level", async () => {
+		for (const command of ["/effort turbo", "/effort low high"]) {
+			const { output, runtime, session } = createRuntime();
+
+			const result = await executeAcpBuiltinSlashCommand(command, runtime);
+
+			expect(result).toEqual({ consumed: true });
+			expect(session.thinkingLevelCalls).toEqual([]);
+			expect(output[0]).toContain("Usage: /effort [inherit|off|minimal|low|medium|high|xhigh|max]");
+		}
+	});
+
+	it("effort: /thinking is not resolved as an effort alias", async () => {
+		const { output, runtime } = createRuntime();
+
+		const result = await executeAcpBuiltinSlashCommand("/thinking high", runtime);
+
+		expect(result).toBe(false);
+		expect(output).toEqual([]);
+	});
+	it("effort: TUI bare command opens selector instead of printing status", async () => {
+		const { runtime } = createRuntime();
+		const statuses: string[] = [];
+		const showEffortSelector = spyOn({ showEffortSelector() {} }, "showEffortSelector");
+		const ctx = {
+			session: runtime.session,
+			sessionManager: runtime.sessionManager,
+			settings: runtime.settings,
+			showStatus: (text: string) => statuses.push(text),
+			showError: (_text: string) => {},
+			showEffortSelector,
+			editor: { setText: spyOn({ setText(_text: string) {} }, "setText") },
+			statusLine: { invalidate: spyOn({ invalidate() {} }, "invalidate") },
+			updateEditorBorderColor: spyOn({ updateEditorBorderColor() {} }, "updateEditorBorderColor"),
+			updateEditorTopBorder: spyOn({ updateEditorTopBorder() {} }, "updateEditorTopBorder"),
+			ui: { requestRender: spyOn({ requestRender() {} }, "requestRender") },
+			refreshSlashCommandState: async () => {},
+		};
+
+		const result = await executeBuiltinSlashCommand("/effort", {
+			ctx: ctx as never,
+			handleBackgroundCommand: () => {},
+		});
+
+		expect(result).toBe(true);
+		expect(showEffortSelector).toHaveBeenCalledTimes(1);
+		expect(statuses).toEqual([]);
+		expect(ctx.editor.setText).toHaveBeenCalledWith("");
+	});
+
+	it("effort: TUI args delegate to shared typed handler and do not open selector", async () => {
+		const { runtime, session } = createRuntime();
+		const statuses: string[] = [];
+		const showEffortSelector = spyOn({ showEffortSelector() {} }, "showEffortSelector");
+		const ctx = {
+			session: runtime.session,
+			sessionManager: runtime.sessionManager,
+			settings: runtime.settings,
+			showStatus: (text: string) => statuses.push(text),
+			showError: (_text: string) => {},
+			showEffortSelector,
+			editor: { setText: spyOn({ setText(_text: string) {} }, "setText") },
+			statusLine: { invalidate: spyOn({ invalidate() {} }, "invalidate") },
+			updateEditorBorderColor: spyOn({ updateEditorBorderColor() {} }, "updateEditorBorderColor"),
+			updateEditorTopBorder: spyOn({ updateEditorTopBorder() {} }, "updateEditorTopBorder"),
+			ui: { requestRender: spyOn({ requestRender() {} }, "requestRender") },
+			refreshSlashCommandState: async () => {},
+		};
+
+		const result = await executeBuiltinSlashCommand("/effort high", {
+			ctx: ctx as never,
+			handleBackgroundCommand: () => {},
+		});
+
+		expect(result).toBe(true);
+		expect(showEffortSelector).not.toHaveBeenCalled();
+		expect(session.thinkingLevelCalls).toEqual([{ thinkingLevel: ThinkingLevel.High, persist: false }]);
+		expect(statuses[0]).toContain("Reasoning effort set to high");
+		expect(ctx.statusLine.invalidate).toHaveBeenCalled();
+		expect(ctx.updateEditorBorderColor).toHaveBeenCalled();
+		expect(ctx.updateEditorTopBorder).toHaveBeenCalled();
+		expect(ctx.ui.requestRender).toHaveBeenCalled();
+		expect(ctx.editor.setText).toHaveBeenCalledWith("");
 	});
 	it("does not advertise /copy to ACP clients", () => {
 		expect(ACP_BUILTIN_SLASH_COMMANDS.some(command => command.name === "copy")).toBe(false);

--- a/packages/coding-agent/test/modes/components/thinking-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/thinking-selector.test.ts
@@ -1,0 +1,144 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { ThinkingSelectorComponent } from "@gajae-code/coding-agent/modes/components/thinking-selector";
+import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+
+beforeAll(async () => {
+	await initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+});
+
+describe("ThinkingSelectorComponent", () => {
+	it("selects inherit, off, and effort values", () => {
+		const selections: ThinkingLevel[] = [];
+		const component = new ThinkingSelectorComponent(
+			ThinkingLevel.Inherit,
+			[ThinkingLevel.Inherit, ThinkingLevel.Off, ThinkingLevel.Low],
+			level => selections.push(level),
+			() => {},
+		);
+
+		component.getSelectList().handleInput("\n");
+		component.getSelectList().handleInput("\x1b[B");
+		component.getSelectList().handleInput("\n");
+		component.getSelectList().handleInput("\x1b[B");
+		component.getSelectList().handleInput("\n");
+
+		expect(selections).toEqual([ThinkingLevel.Inherit, ThinkingLevel.Off, ThinkingLevel.Low]);
+	});
+
+	it("preselects off when the session has no effective level", () => {
+		const selections: ThinkingLevel[] = [];
+		const component = new ThinkingSelectorComponent(
+			undefined,
+			[ThinkingLevel.Inherit, ThinkingLevel.Off, ThinkingLevel.Low],
+			level => selections.push(level),
+			() => {},
+		);
+
+		component.getSelectList().handleInput("\n");
+
+		expect(selections).toEqual([ThinkingLevel.Off]);
+	});
+});
+
+describe("SelectorController effort selector", () => {
+	it("applies inherit through the configured default and refreshes chrome", () => {
+		const editorContainer = {
+			children: [] as unknown[],
+			clear() {
+				this.children = [];
+			},
+			addChild(child: unknown) {
+				this.children.push(child);
+			},
+		};
+		const settings = Settings.isolated({ defaultThinkingLevel: ThinkingLevel.High });
+		const statuses: string[] = [];
+		const thinkingLevelCalls: Array<{ level: ThinkingLevel | undefined; persist: boolean | undefined }> = [];
+		const session = {
+			thinkingLevel: ThinkingLevel.Inherit as ThinkingLevel | undefined,
+			getAvailableThinkingLevels: () => [ThinkingLevel.Low, ThinkingLevel.High],
+			setThinkingLevel(level: ThinkingLevel | undefined, persist?: boolean) {
+				thinkingLevelCalls.push({ level, persist });
+				this.thinkingLevel = level;
+			},
+		};
+		const ctx = {
+			editorContainer,
+			editor: {},
+			session,
+			settings,
+			ui: {
+				setFocus: vi.fn(),
+				requestRender: vi.fn(),
+			},
+			statusLine: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			updateEditorTopBorder: vi.fn(),
+			showStatus: (text: string) => statuses.push(text),
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(ctx);
+
+		controller.showEffortSelector();
+
+		const selector = editorContainer.children[0];
+		if (!(selector instanceof ThinkingSelectorComponent)) {
+			throw new Error("Expected /effort to mount ThinkingSelectorComponent");
+		}
+		expect(ctx.ui.setFocus).toHaveBeenLastCalledWith(selector.getSelectList());
+
+		selector.getSelectList().handleInput("\n");
+
+		expect(thinkingLevelCalls).toEqual([{ level: ThinkingLevel.High, persist: false }]);
+		expect(statuses[0]).toContain("configured default: high");
+		expect(statuses[0]).toContain("Effective effort: high");
+		expect(ctx.statusLine.invalidate).toHaveBeenCalled();
+		expect(ctx.updateEditorBorderColor).toHaveBeenCalled();
+		expect(ctx.updateEditorTopBorder).toHaveBeenCalled();
+		expect(ctx.ui.requestRender).toHaveBeenCalled();
+		expect(ctx.ui.setFocus).toHaveBeenLastCalledWith(ctx.editor);
+	});
+
+	it("cancels without mutating thinking level", () => {
+		const editorContainer = {
+			children: [] as unknown[],
+			clear() {
+				this.children = [];
+			},
+			addChild(child: unknown) {
+				this.children.push(child);
+			},
+		};
+		const session = {
+			thinkingLevel: ThinkingLevel.Off as ThinkingLevel | undefined,
+			getAvailableThinkingLevels: () => [ThinkingLevel.Low],
+			setThinkingLevel: vi.fn(),
+		};
+		const ctx = {
+			editorContainer,
+			editor: {},
+			session,
+			settings: Settings.isolated(),
+			ui: { setFocus: vi.fn(), requestRender: vi.fn() },
+			statusLine: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			updateEditorTopBorder: vi.fn(),
+			showStatus: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(ctx);
+
+		controller.showEffortSelector();
+		const selector = editorContainer.children[0];
+		if (!(selector instanceof ThinkingSelectorComponent)) {
+			throw new Error("Expected /effort to mount ThinkingSelectorComponent");
+		}
+		selector.getSelectList().handleInput("\x1b");
+
+		expect(session.setThinkingLevel).not.toHaveBeenCalled();
+		expect(ctx.ui.requestRender).toHaveBeenCalled();
+		expect(ctx.ui.setFocus).toHaveBeenLastCalledWith(ctx.editor);
+	});
+});


### PR DESCRIPTION
## Summary

This PR adds `/effort` as the user-facing command for inspecting and changing model reasoning effort in GJC, across ACP/text slash-command usage and the interactive TUI.

## Context

The existing reasoning-effort controls were not exposed through the requested `/effort` UX. The new command needs to be explicit, non-persistent by default, safe for ACP clients, and integrated with the TUI selector flow without introducing `/thinking` as a public alias.

## Changes

### Slash command behavior

- Registers `/effort` as a built-in command with the exact accepted-value hint:
  - `[inherit|off|minimal|low|medium|high|xhigh|max]`
- Supports bare `/effort` in ACP/text mode by printing:
  - current effective effort
  - configured default effort
  - accepted values
  - current-model supported effort guidance
- Supports typed values:
  - `/effort inherit`
  - `/effort off`
  - `/effort minimal|low|medium|high|xhigh|max`
- Applies changes to the current session with `persist: false`, so this command does not silently rewrite the configured default.
- Maps `inherit` to the configured `defaultThinkingLevel` before applying it to the session.
- Accepts parseable values even when the current model reports a narrower supported set, then reports requested vs. effective effort when the session clamps the value.
- Consumes invalid or malformed inputs with usage output and no state mutation.
- Does not add `/thinking` as an alias.

### TUI behavior

- Bare `/effort` opens the reasoning-effort selector instead of printing status text.
- Typed `/effort <value>` delegates to the shared command handler and refreshes TUI chrome/status state.
- Adds `showEffortSelector()` to the interactive mode context and selector controller.
- Extends the selector to include `inherit` and `off` alongside model-supported effort levels.
- Preselects the current session effort, defaulting undefined state to `off`.
- Selector cancel restores focus/rendering without mutating effort state.

### Tests

- Extends ACP built-in slash-command coverage for:
  - ACP advertisement and accepted-value hint
  - bare `/effort` status output
  - `inherit`, `off`, and typed effort application with `persist: false`
  - parseable unsupported values and requested/effective clamp reporting
  - invalid/malformed input handling
  - absence of `/thinking` alias
  - TUI bare command vs. typed command behavior
- Adds TUI selector component/controller coverage for:
  - selecting `inherit`, `off`, and effort values
  - undefined current effort preselecting `off`
  - inherit applying the configured default
  - chrome refresh/focus restoration
  - cancel without mutation

## Verification

Local verification run:

- `bun test packages/coding-agent/test/acp-builtins.test.ts packages/coding-agent/test/modes/components/thinking-selector.test.ts packages/coding-agent/test/agent-session-role-thinking.test.ts`
- `bun test packages/coding-agent/test/modes/components/thinking-selector.test.ts packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts packages/coding-agent/test/modes/controllers/session-selector-delete.test.ts --test-name-pattern "effort|thinking"`
- `bun --cwd=packages/coding-agent run check`

CI verification observed on this PR:

- Affected path validation: passed
- `check:@gajae-code/coding-agent`: passed
- CLI smoke: passed
- native build: passed
- targeted changed-file tests: passed
- gjc-state-gates: passed
- Local public surfaces: passed
- Live public homepage version: skipped by workflow

## Notes

- The PR targets `dev`.
- The implementation intentionally keeps `/effort` session-scoped and non-persistent.
- The public command surface remains `/effort`; `/thinking` remains unavailable as an alias.