### PR TITLE
fix(tui): footer git watcher leaks when dispose() outruns async setup

### DIFF
--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -16,6 +16,7 @@ import { resolveCurrentBranch } from "./status-line/git-utils";
 export class FooterComponent implements Component {
 	#cachedBranch: string | null | undefined = undefined; // undefined = not checked yet, null = not in git repo, string = branch name
 	#gitWatcher: fs.FSWatcher | null = null;
+	#gitWatcherGeneration = 0;
 	#onBranchChange: (() => void) | null = null;
 	#autoCompactEnabled: boolean = true;
 	#extensionStatuses: Map<string, string> = new Map();
@@ -51,7 +52,10 @@ export class FooterComponent implements Component {
 	}
 
 	#setupGitWatcher(): void {
-		// Clean up existing watcher
+		// Clean up existing watcher. The generation guard below keeps a stale
+		// in-flight resolve — one that dispose() or a newer setup already
+		// superseded — from installing a watcher nothing would ever close.
+		const generation = ++this.#gitWatcherGeneration;
 		if (this.#gitWatcher) {
 			this.#gitWatcher.close();
 			this.#gitWatcher = null;
@@ -60,7 +64,7 @@ export class FooterComponent implements Component {
 		void git.head
 			.resolve(getProjectDir())
 			.then(head => {
-				if (!head) {
+				if (!head || generation !== this.#gitWatcherGeneration) {
 					return;
 				}
 
@@ -84,6 +88,7 @@ export class FooterComponent implements Component {
 	 * Clean up the file watcher
 	 */
 	dispose(): void {
+		this.#gitWatcherGeneration++;
 		if (this.#gitWatcher) {
 			this.#gitWatcher.close();
 			this.#gitWatcher = null;

--- a/packages/coding-agent/test/modes/components/footer-git-watcher-dispose.test.ts
+++ b/packages/coding-agent/test/modes/components/footer-git-watcher-dispose.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getProjectDir, setProjectDir } from "@gajae-code/utils";
+import { FooterComponent } from "../../../src/modes/components/footer";
+import type { AgentSession } from "../../../src/session/agent-session";
+
+function makeTempRepo(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "footer-git-watch-"));
+	fs.mkdirSync(path.join(dir, ".git"));
+	fs.writeFileSync(path.join(dir, ".git", "HEAD"), "ref: refs/heads/main\n");
+	return dir;
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 2000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (condition()) return true;
+		await new Promise(resolve => setTimeout(resolve, 10));
+	}
+	return condition();
+}
+
+describe("FooterComponent git watcher lifecycle", () => {
+	const previousProjectDir = getProjectDir();
+	let tempDir: string | null = null;
+
+	afterEach(() => {
+		setProjectDir(previousProjectDir);
+		if (tempDir) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+			tempDir = null;
+		}
+	});
+
+	it("does not install a watcher when dispose() outruns the async setup", async () => {
+		tempDir = makeTempRepo();
+		setProjectDir(tempDir);
+
+		const realWatch = fs.watch;
+		const created: fs.FSWatcher[] = [];
+		const watchSpy = spyOn(fs, "watch").mockImplementation(((
+			filename: fs.PathLike,
+			listener: (event: fs.WatchEventType, name: string | null) => void,
+		) => {
+			const watcher = realWatch(filename, listener);
+			created.push(watcher);
+			return watcher;
+		}) as typeof fs.watch);
+
+		try {
+			const footer = new FooterComponent({} as unknown as AgentSession);
+			// dispose() runs while git.head.resolve() is still in flight — the
+			// watcher must not be installed afterwards (it would leak the fd and
+			// keep firing branch-change callbacks on a disposed component).
+			footer.watchBranch(() => {});
+			footer.dispose();
+
+			await new Promise(resolve => setTimeout(resolve, 200));
+			expect(created.length).toBe(0);
+		} finally {
+			for (const watcher of created) watcher.close();
+			watchSpy.mockRestore();
+		}
+	});
+
+	it("still fires onBranchChange for HEAD changes after setup completes", async () => {
+		tempDir = makeTempRepo();
+		setProjectDir(tempDir);
+
+		const realWatch = fs.watch;
+		const created: fs.FSWatcher[] = [];
+		const watchSpy = spyOn(fs, "watch").mockImplementation(((
+			filename: fs.PathLike,
+			listener: (event: fs.WatchEventType, name: string | null) => void,
+		) => {
+			const watcher = realWatch(filename, listener);
+			created.push(watcher);
+			return watcher;
+		}) as typeof fs.watch);
+
+		const footer = new FooterComponent({} as unknown as AgentSession);
+		try {
+			let branchChanges = 0;
+			footer.watchBranch(() => {
+				branchChanges++;
+			});
+
+			expect(await waitFor(() => created.length === 1)).toBe(true);
+
+			fs.writeFileSync(path.join(tempDir, ".git", "HEAD"), "ref: refs/heads/other\n");
+			expect(await waitFor(() => branchChanges > 0)).toBe(true);
+		} finally {
+			footer.dispose();
+			for (const watcher of created) watcher.close();
+			watchSpy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

`FooterComponent.#setupGitWatcher` creates its `fs.watch` inside the async `git.head.resolve(...).then(...)` callback. `dispose()` only closes the watcher that exists *at call time* — so when `dispose()` runs while the resolve is still in flight (the component is torn down right after mount, e.g. a fast mode switch), the callback lands afterwards and installs a watcher that nothing will ever close. Result: a leaked fd and a disposed footer that keeps firing `onBranchChange` on every HEAD change.

The same window exists between two back-to-back `watchBranch()` calls: the first resolve can land after the second setup and overwrite `#gitWatcher`, orphaning one watcher.

Note: `modes/components/status-line.ts` is *not* affected — its setup uses `git.repo.resolveSync`, so watcher creation is synchronous with `watchBranch()`.

## Change

Generation token: `#setupGitWatcher` captures `++this.#gitWatcherGeneration`, and the resolve callback installs the watcher only if the generation is still current. `dispose()` bumps the generation before closing. The check and the `fs.watch` call run in the same microtask, so no new window opens.

## Tests

`footer-git-watcher-dispose.test.ts` (new):
- **dispose races setup** — `watchBranch()` then `dispose()` synchronously; asserts no watcher is ever installed. Fails on `dev` (a watcher is created ~after 200ms), passes with the fix.
- **positive control** — without dispose, the watcher installs and `onBranchChange` fires on a real HEAD edit in a temp repo, guarding against the generation check accidentally suppressing normal setup.

Local: `bun run check` (biome + tsgo) green; new tests 2/2 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)