### PR TITLE
fix(tui): empty-after-filtering paste no longer records a ghost undo snapshot

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1910,45 +1910,48 @@ export class Editor implements Component, Focusable {
 	#handlePaste(pastedText: string): void {
 		this.#historyIndex = -1; // Exit history browsing mode
 		this.#resetKillSequence();
-		this.#recordUndoState();
 		const hadAutocomplete = this.#autocompleteState !== null;
 		this.#cancelAutocomplete();
 		if (hadAutocomplete) {
 			this.onAutocompleteUpdate?.();
 		}
 
+		// Some terminals (e.g. tmux popups with extended-keys-format=csi-u) re-encode
+		// control bytes inside bracketed paste as CSI-u Ctrl+<letter> sequences
+		// (ESC [ <codepoint> ; 5 u). Decode those back to their literal byte so the
+		// per-char filter below preserves newlines instead of stripping ESC and
+		// leaking the printable tail (e.g. "[106;5u") into the editor.
+		const decodedText = pastedText.replace(/\x1b\[(\d+);5u/g, (match, code) => {
+			const cp = Number(code);
+			if (cp >= 97 && cp <= 122) return String.fromCharCode(cp - 96);
+			if (cp >= 65 && cp <= 90) return String.fromCharCode(cp - 64);
+			return match;
+		});
+
+		// Clean the pasted text. NFC-normalize so macOS Finder drag-drops of
+		// Korean filenames (which arrive as NFD: e.g. `ᄒ`+`ᅪ` instead of `화`)
+		// land in the buffer as the same precomposed syllables a terminal
+		// renders — without this, cursor column accounting drifts by
+		// `(NFD cells − NFC cells)` and the visible glyph desyncs from the
+		// hardware cursor. Matches the `Input` component's prior fix; this
+		// is the same fix on the real GJC prompt component (`Editor`).
+		const cleanText = decodedText.replace(/\r\n?/g, "\n").normalize("NFC");
+
+		// Convert tabs to spaces (4 spaces per tab)
+		const tabExpandedText = cleanText.replace(/\t/g, "    ");
+
+		// Filter out non-printable characters except newlines
+		const filteredText = tabExpandedText
+			.split("")
+			.filter(char => char === "\n" || char.charCodeAt(0) >= 32)
+			.join("");
+
+		// Nothing survived filtering: the buffer is untouched, so don't record
+		// an undo snapshot — a no-op entry would make the next undo appear dead.
+		if (filteredText.length === 0) return;
+
+		this.#recordUndoState();
 		this.#withUndoSuspended(() => {
-			// Some terminals (e.g. tmux popups with extended-keys-format=csi-u) re-encode
-			// control bytes inside bracketed paste as CSI-u Ctrl+<letter> sequences
-			// (ESC [ <codepoint> ; 5 u). Decode those back to their literal byte so the
-			// per-char filter below preserves newlines instead of stripping ESC and
-			// leaking the printable tail (e.g. "[106;5u") into the editor.
-			const decodedText = pastedText.replace(/\x1b\[(\d+);5u/g, (match, code) => {
-				const cp = Number(code);
-				if (cp >= 97 && cp <= 122) return String.fromCharCode(cp - 96);
-				if (cp >= 65 && cp <= 90) return String.fromCharCode(cp - 64);
-				return match;
-			});
-
-			// Clean the pasted text. NFC-normalize so macOS Finder drag-drops of
-			// Korean filenames (which arrive as NFD: e.g. `ᄒ`+`ᅪ` instead of `화`)
-			// land in the buffer as the same precomposed syllables a terminal
-			// renders — without this, cursor column accounting drifts by
-			// `(NFD cells − NFC cells)` and the visible glyph desyncs from the
-			// hardware cursor. Matches the `Input` component's prior fix; this
-			// is the same fix on the real GJC prompt component (`Editor`).
-			const cleanText = decodedText.replace(/\r\n?/g, "\n").normalize("NFC");
-
-			// Convert tabs to spaces (4 spaces per tab)
-			const tabExpandedText = cleanText.replace(/\t/g, "    ");
-
-			// Filter out non-printable characters except newlines
-			const filteredText = tabExpandedText
-				.split("")
-				.filter(char => char === "\n" || char.charCodeAt(0) >= 32)
-				.join("");
-
-			if (filteredText.length === 0) return;
 			// Split into lines
 			const pastedLines = filteredText.split("\n");
 

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2441,6 +2441,21 @@ describe("Editor component", () => {
 			editor.handleInput("\x1b[B"); // Down to line 1
 			expect(editor.getCursor()).toEqual({ line: 1, col: 15 });
 		});
+		it("does not record a ghost undo snapshot for a paste that filters to nothing", () => {
+			const editor = new Editor(defaultEditorTheme);
+
+			editor.handleInput("\x1b[200~hello\x1b[201~");
+			expect(editor.getText()).toBe("hello");
+
+			// A paste of only non-printable characters inserts nothing…
+			editor.handleInput("\x1b[200~\x07\x07\x1b[201~");
+			expect(editor.getText()).toBe("hello");
+
+			// …so a single undo must revert the previous edit, not a no-op snapshot.
+			editor.handleInput("\x1b[45;5u"); // Ctrl+- (undo)
+			expect(editor.getText()).toBe("");
+		});
+
 		it("expands large pasted content literally in getExpandedText", () => {
 			const editor = new Editor(defaultEditorTheme);
 			const pastedText = [


### PR DESCRIPTION
## Summary

`Editor.#handlePaste` calls `#recordUndoState()` before the text is decoded/filtered, but the early return for pastes that filter to nothing (`filteredText.length === 0`) sits *after* that. A paste containing only non-printable characters — e.g. a stray BEL/control sequence from a terminal, which the per-char filter strips — inserts nothing yet still pushes an undo snapshot identical to the current state (`#recordUndoState` pushes unconditionally). The next undo pops that no-op snapshot: the user presses the undo key and nothing visibly happens.

## Change

Move the decode → NFC-normalize → tab-expand → filter pipeline out of the `#withUndoSuspended` callback so the empty check runs first, and record the undo snapshot only when there is something to insert. The pipeline is pure string work, so hoisting it out of the suspended block changes nothing else; `#cancelAutocomplete()` (which now runs before the snapshot) only touches autocomplete bookkeeping, never `#state`, so the captured snapshot is byte-identical to before.

## Tests

- New test in `editor.test.ts`: paste `hello`, then paste `\x07\x07` (filters to empty, buffer unchanged), then a single undo must restore the empty buffer. Fails on `dev` (undo pops the ghost snapshot and the text stays `hello`), passes with the fix.
- Full `packages/tui` suite: 673/673 pass. `bun run check` (biome + tsgo) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)