### PR TITLE
fix(tools): run bisect's git mutations under the per-repo write lock

### DIFF
--- a/packages/coding-agent/src/tools/bisect.ts
+++ b/packages/coding-agent/src/tools/bisect.ts
@@ -266,58 +266,68 @@ export class BisectTool implements AgentTool<typeof bisectSchema, BisectToolDeta
 			);
 		}
 
-		let outcome: BisectOutcome;
-		// Defensive reset in case a previous aborted bisect left state behind; a
-		// no-op when not bisecting (reset never throws).
-		await git.bisect.reset(cwd, signal);
-		try {
-			await git.bisect.start(cwd, signal);
-			const badMark = await git.bisect.bad(cwd, badSha, signal);
-			if (badMark.exitCode !== 0) {
-				throw new ToolError(`git bisect bad failed: ${badMark.stderr.trim() || badMark.stdout.trim()}`);
-			}
-			const goodMark = await git.bisect.good(cwd, goodSha, signal);
-			if (goodMark.exitCode !== 0) {
-				throw new ToolError(`git bisect good failed: ${goodMark.stderr.trim() || goodMark.stdout.trim()}`);
-			}
-			// A tiny good..bad range can converge on the seeding marks themselves.
-			const seededCulprit = parseFirstBadCommit(`${goodMark.stdout}\n${goodMark.stderr}`);
-			if (seededCulprit) {
-				outcome = { culprit: seededCulprit, steps: [], concluded: true };
-			} else {
-				outcome = await runBisectController(
-					{
-						maxSteps: params.maxSteps,
-						currentRev: async () => (await git.head.sha(cwd, signal)) ?? "HEAD",
-						evaluate: async () =>
-							classifyExit(
-								await evaluatePredicate(params.run, cwd, params.stepTimeoutMs, signal),
-								params.invert,
-							),
-						mark: async verdict => {
-							const result =
-								verdict === "good"
-									? await git.bisect.good(cwd, undefined, signal)
-									: verdict === "bad"
-										? await git.bisect.bad(cwd, undefined, signal)
-										: await git.bisect.skip(cwd, signal);
-							return { exitCode: result.exitCode, output: `${result.stdout}\n${result.stderr}` };
+		// Everything from here to teardown mutates repo state — bisect metadata,
+		// checkouts between candidate commits, the closing resets — so it runs
+		// under the per-repo write lock. That keeps concurrent in-process callers
+		// (worktree checkouts, commits) from colliding on git's O_EXCL lock files
+		// or mutating a tree bisect is moving. The read-only prechecks above stay
+		// outside the lock so they never queue behind another writer.
+		const outcome = await git.withRepoLock(
+			cwd,
+			async (): Promise<BisectOutcome> => {
+				// Defensive reset in case a previous aborted bisect left state behind; a
+				// no-op when not bisecting (reset never throws).
+				await git.bisect.reset(cwd, signal);
+				try {
+					await git.bisect.start(cwd, signal);
+					const badMark = await git.bisect.bad(cwd, badSha, signal);
+					if (badMark.exitCode !== 0) {
+						throw new ToolError(`git bisect bad failed: ${badMark.stderr.trim() || badMark.stdout.trim()}`);
+					}
+					const goodMark = await git.bisect.good(cwd, goodSha, signal);
+					if (goodMark.exitCode !== 0) {
+						throw new ToolError(`git bisect good failed: ${goodMark.stderr.trim() || goodMark.stdout.trim()}`);
+					}
+					// A tiny good..bad range can converge on the seeding marks themselves.
+					const seededCulprit = parseFirstBadCommit(`${goodMark.stdout}\n${goodMark.stderr}`);
+					if (seededCulprit) {
+						return { culprit: seededCulprit, steps: [], concluded: true };
+					}
+					return await runBisectController(
+						{
+							maxSteps: params.maxSteps,
+							currentRev: async () => (await git.head.sha(cwd, signal)) ?? "HEAD",
+							evaluate: async () =>
+								classifyExit(
+									await evaluatePredicate(params.run, cwd, params.stepTimeoutMs, signal),
+									params.invert,
+								),
+							mark: async verdict => {
+								const result =
+									verdict === "good"
+										? await git.bisect.good(cwd, undefined, signal)
+										: verdict === "bad"
+											? await git.bisect.bad(cwd, undefined, signal)
+											: await git.bisect.skip(cwd, signal);
+								return { exitCode: result.exitCode, output: `${result.stdout}\n${result.stderr}` };
+							},
 						},
-					},
-					signal,
-				);
-			}
-		} finally {
-			// Always restore the working tree, even on error/abort. `git bisect
-			// reset` returns HEAD to the original branch/commit but leaves behind
-			// any tracked-file edits the `sh -c` predicate made mid-run. The tracked
-			// tree was verified clean before we started (precondition above), so
-			// discarding tracked modifications (reset --hard) only reverts the
-			// predicate's side effects, never user work; then bisect reset restores
-			// the original HEAD. Both are best-effort and must not throw here.
-			await git.reset(cwd, { hard: true }).catch(() => {});
-			await git.bisect.reset(cwd);
-		}
+						signal,
+					);
+				} finally {
+					// Always restore the working tree, even on error/abort. `git bisect
+					// reset` returns HEAD to the original branch/commit but leaves behind
+					// any tracked-file edits the `sh -c` predicate made mid-run. The tracked
+					// tree was verified clean before we started (precondition above), so
+					// discarding tracked modifications (reset --hard) only reverts the
+					// predicate's side effects, never user work; then bisect reset restores
+					// the original HEAD. Both are best-effort and must not throw here.
+					await git.reset(cwd, { hard: true }).catch(() => {});
+					await git.bisect.reset(cwd);
+				}
+			},
+			signal,
+		);
 
 		// Never claim a clean restore we did not actually achieve.
 		const restoreLine = await describeRestore(cwd);

--- a/packages/coding-agent/test/tools/bisect.test.ts
+++ b/packages/coding-agent/test/tools/bisect.test.ts
@@ -250,12 +250,21 @@ describe("BisectTool.execute", () => {
 		await commitFlag(repo, "PASS\n", "c1 still ok");
 		const bug = await commitFlag(repo, "FAIL\n", "c2 introduce bug");
 		await commitFlag(repo, "FAIL\n", "c3 head");
+		const originalHead = await gitRun(repo, ["rev-parse", "HEAD"]);
+		const originalBranch = await gitRun(repo, ["rev-parse", "--abbrev-ref", "HEAD"]);
 
 		// Hold the repo write lock while bisect launches: bisect checks out
 		// candidate commits and resets the tree, so it must queue behind the
-		// holder instead of mutating the repo alongside it.
+		// holder instead of mutating the repo alongside it. The `entered`
+		// handshake guarantees the holder owns the lock before execute() starts,
+		// so the test proves queuing rather than racing on timing.
+		const entered = Promise.withResolvers<void>();
 		const gate = Promise.withResolvers<void>();
-		const holder = git.withRepoLock(repo, () => gate.promise);
+		const holder = git.withRepoLock(repo, () => {
+			entered.resolve();
+			return gate.promise;
+		});
+		await entered.promise;
 
 		const execution = new BisectTool(session(repo)).execute("call", {
 			good,
@@ -265,13 +274,24 @@ describe("BisectTool.execute", () => {
 			maxSteps: 40,
 			stepTimeoutMs: 60_000,
 		});
+		let settled = false;
+		void execution.finally(() => {
+			settled = true;
+		});
 
 		try {
-			const first = await Promise.race([
-				execution.then(() => "bisect-finished"),
-				new Promise<string>(resolve => setTimeout(() => resolve("still-queued"), 750)),
-			]);
-			expect(first).toBe("still-queued");
+			// Give a mis-ordered implementation (mutate first, acquire the lock
+			// later) time to touch the repo, then assert the contract: while the
+			// holder is active, bisect has neither started (no bisect state, HEAD
+			// and worktree untouched) nor finished (a completed run would also
+			// leave a clean tree, so cleanliness alone proves nothing).
+			await new Promise(resolve => setTimeout(resolve, 750));
+			expect(settled).toBe(false);
+			expect(await gitRun(repo, ["rev-parse", "HEAD"])).toBe(originalHead);
+			expect(await gitRun(repo, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe(originalBranch);
+			expect(await Bun.file(path.join(repo, ".git", "BISECT_START")).exists()).toBe(false);
+			expect(await Bun.file(path.join(repo, ".git", "BISECT_LOG")).exists()).toBe(false);
+			expect(await gitRun(repo, ["status", "--porcelain"])).toBe("");
 		} finally {
 			gate.resolve();
 			await holder;
@@ -280,6 +300,10 @@ describe("BisectTool.execute", () => {
 		const result = await execution;
 		expect(result.details?.concluded).toBe(true);
 		expect(result.details?.culprit).toBe(bug);
+		// The queued run still converges and restores cleanly after the holder releases.
+		expect(await gitRun(repo, ["rev-parse", "HEAD"])).toBe(originalHead);
+		expect(await Bun.file(path.join(repo, ".git", "BISECT_LOG")).exists()).toBe(false);
+		expect(await gitRun(repo, ["status", "--porcelain"])).toBe("");
 	});
 
 	it("restores the repo when invoked from a subdirectory a candidate deletes", async () => {

--- a/packages/coding-agent/test/tools/bisect.test.ts
+++ b/packages/coding-agent/test/tools/bisect.test.ts
@@ -12,6 +12,7 @@ import {
 	runBisectController,
 	type ToolSession,
 } from "@gajae-code/coding-agent/tools";
+import * as git from "@gajae-code/coding-agent/utils/git";
 
 const FORTY_HEX = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678";
 
@@ -241,6 +242,44 @@ describe("BisectTool.execute", () => {
 		// discard the predicate's tracked-file edit and fully restore the worktree.
 		expect(await gitRun(repo, ["status", "--porcelain"])).toBe("");
 		expect(await Bun.file(path.join(repo, "sentinel.txt")).text()).toBe("base\n");
+	});
+
+	it("queues its git mutations behind the per-repo write lock", async () => {
+		const repo = await makeRepo();
+		const good = await commitFlag(repo, "PASS\n", "c0 baseline");
+		await commitFlag(repo, "PASS\n", "c1 still ok");
+		const bug = await commitFlag(repo, "FAIL\n", "c2 introduce bug");
+		await commitFlag(repo, "FAIL\n", "c3 head");
+
+		// Hold the repo write lock while bisect launches: bisect checks out
+		// candidate commits and resets the tree, so it must queue behind the
+		// holder instead of mutating the repo alongside it.
+		const gate = Promise.withResolvers<void>();
+		const holder = git.withRepoLock(repo, () => gate.promise);
+
+		const execution = new BisectTool(session(repo)).execute("call", {
+			good,
+			bad: "HEAD",
+			run: "grep -q PASS flag.txt",
+			invert: false,
+			maxSteps: 40,
+			stepTimeoutMs: 60_000,
+		});
+
+		try {
+			const first = await Promise.race([
+				execution.then(() => "bisect-finished"),
+				new Promise<string>(resolve => setTimeout(() => resolve("still-queued"), 750)),
+			]);
+			expect(first).toBe("still-queued");
+		} finally {
+			gate.resolve();
+			await holder;
+		}
+
+		const result = await execution;
+		expect(result.details?.concluded).toBe(true);
+		expect(result.details?.culprit).toBe(bug);
 	});
 
 	it("restores the repo when invoked from a subdirectory a candidate deletes", async () => {


### PR DESCRIPTION
## Summary

`BisectTool.execute` checks out candidate commits, writes bisect metadata, and tears down with `git reset --hard` + `git bisect reset` — all without `git.withRepoLock`. `utils/git.ts` documents the contract ("any block that mutates repo state should hold this lock so unrelated callers cannot collide on git's internal locks"), and `gh.ts` `pr_checkout` already follows it. An in-process caller running concurrently with a bisect (a parallel `pr_checkout`, a commit) can therefore lose races on git's O_EXCL lock files ("Another git process seems to be running"), or worse, mutate a working tree that bisect is actively moving between commits — and bisect's teardown `reset --hard` would then discard that caller's work.

## Change

Wrap the mutating section — from the defensive `bisect reset` through the `finally` teardown — in `git.withRepoLock(cwd, …, signal)`. The read-only prechecks (repo root, clean-tree check, ref resolution, ancestry) stay outside the lock so they never queue behind another writer. The lock is intentionally held for the whole run: yielding it between predicate steps would invite exactly the interleaved mutations the lock exists to prevent, and `pr_checkout` already holds it across fetch + worktree setup. No re-entrancy issue: git helpers never self-acquire, and the predicate runs as an external `sh -c` process.

Semantics otherwise unchanged: same defensive reset, same seeded-culprit short-circuit, same teardown ordering (`outcome` is now the lock callback's return value).

## Tests

- New test "queues its git mutations behind the per-repo write lock": holds the repo lock via `git.withRepoLock` with a deferred promise, launches a bisect, and asserts the bisect is still queued 750ms later, then completes correctly (finds the seeded culprit) once the holder releases. Fails on `dev` (bisect finishes without waiting), passes with the fix.
- Full `bisect.test.ts`: 20/20 pass (covers convergence, teardown restore, subdirectory deletion, abort paths). `gh.test.ts` (existing `withRepoLock` serialization coverage): 43/43 pass. `bun run check` (biome + tsgo) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)