### PR TITLE
fix(ai): point Fugu login at Sakana platform console and fish_ key prefix

### DIFF
--- a/packages/ai/src/utils/oauth/fugu.ts
+++ b/packages/ai/src/utils/oauth/fugu.ts
@@ -3,10 +3,10 @@ import { createApiKeyLogin } from "./api-key-login";
 
 export const loginFugu = createApiKeyLogin({
 	providerLabel: "Sakana Fugu",
-	authUrl: "https://fugu.sakana.ai/",
+	authUrl: "https://console.sakana.ai/api-keys",
 	instructions: "Create or copy your Sakana Fugu API key",
 	promptMessage: "Paste your Sakana Fugu API key",
-	placeholder: "fugu_...",
+	placeholder: "fish_...",
 	validation: {
 		kind: "models-endpoint",
 		provider: "Sakana Fugu",


### PR DESCRIPTION
## Summary

`loginFugu` (`packages/ai/src/utils/oauth/fugu.ts`) still references Sakana's **legacy standalone Fugu product**, but Sakana has since migrated to a unified platform. The API endpoint and model transport are unchanged and still work, so the only thing that's stale is the login-flow guidance — which misleads users pasting valid keys.

## Root cause

Sakana migrated from the standalone Fugu product to the unified Sakana platform:

| | Legacy | Current |
|---|---|---|
| Console | `fugu.sakana.ai` | `console.sakana.ai` |
| Key prefix | `fugu_...` | `fish_...` (`sakana` = "fish") |
| API endpoint | `api.sakana.ai/v1` | `api.sakana.ai/v1` (unchanged) |

`fugu.ts` was added in #1090 against the legacy console/key format. The endpoint and bundled models already point at the current `api.sakana.ai/v1`, so model requests authenticate fine — but the login placeholder (`fugu_...`) and `authUrl` (`https://fugu.sakana.ai/`) are pre-migration.

## Measured evidence

- `fugu.sakana.ai` → **301 redirect** → `console.sakana.ai/`
- `console.sakana.ai/api-keys` issues `fish_`-prefixed keys (key obtained from the console and confirmed to authenticate)
- `api.sakana.ai/v1/models` strictly validates credentials:
  - valid `fish_` key → `200`
  - garbage key → `401`
  - no auth header → `401`

So `/login fugu` with a valid `fish_` key already **succeeds** (validation hits the models endpoint → `200`), but the `fugu_...` placeholder makes users doubt a correct key.

## Changes

```diff
-	authUrl: "https://fugu.sakana.ai/",
+	authUrl: "https://console.sakana.ai/api-keys",
  ...
-	placeholder: "fugu_...",
+	placeholder: "fish_...",
```

Validation logic (`models-endpoint` against `api.sakana.ai/v1/models`) is unchanged.

## Limitation / caveat

I could not obtain a legacy `fugu_`-prefixed key to test whether Sakana still accepts them for backward compatibility. The `fish_` prefix is what the current console (`console.sakana.ai`) issues, so `fish_...` is the accurate placeholder today. If legacy `fugu_` keys are still honored, the placeholder could be `fish_... / fugu_...` instead — happy to adjust if a maintainer can confirm.
