### PR TITLE
fix(ai): point Fugu login at Sakana platform console and fish_ key prefix

### DIFF
--- a/packages/ai/src/utils/oauth/fugu.ts
+++ b/packages/ai/src/utils/oauth/fugu.ts
@@ -3,10 +3,10 @@ import { createApiKeyLogin } from "./api-key-login";
 
 export const loginFugu = createApiKeyLogin({
 	providerLabel: "Sakana Fugu",
-	authUrl: "https://fugu.sakana.ai/",
+	authUrl: "https://console.sakana.ai/api-keys",
 	instructions: "Create or copy your Sakana Fugu API key",
 	promptMessage: "Paste your Sakana Fugu API key",
-	placeholder: "fugu_...",
+	placeholder: "fish_...",
 	validation: {
 		kind: "models-endpoint",
 		provider: "Sakana Fugu",


### PR DESCRIPTION
Retarget of #1829 to the active dev branch.

#1829 was opened against main and then closed unmerged. This PR carries the same single commit onto dev.

Evidence before opening:
- `main...dev`: dev is 22 commits ahead, 0 behind main.
- `dev...VC-Kyeongmin:fix/fugu-login-sakana-platform-migration`: one ahead commit; one modified file: `packages/ai/src/utils/oauth/fugu.ts` (+2/-2).
- No broad main/dev merge is included.