### PR TITLE
fix(coding-agent): forward session mpreset as split argv

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `--mpreset <profile>` option to the Telegram `/session_create` command, allowing users to specify a model profile preset when creating a session remotely (e.g. `/session_create path /repo --mpreset codex-eco`). Both `--mpreset <name>` and `--mpreset=<name>` forms are supported. The preset is passed as a regular `--mpreset` CLI flag to the spawned `gjc` child, where the existing `applyStartupModelProfiles` flow activates it.
+
 ### Fixed
 
 - `gjc team` on Windows/psmux now targets the GJC-managed leader session by name instead of trusting the inherited `TMUX_PANE`. `gjc --tmux` propagates the managed session name to the child via `GJC_TMUX_ACTIVE_SESSION`, and `readCurrentTmuxLeaderContext` prefers it when resolving the leader pane. Under psmux the inherited `TMUX_PANE` can resolve to the wrong/default session, so a `ralplan -> ultragoal -> team` handoff could split/send workers into the wrong leader session; native tmux/WSL flows (no `GJC_TMUX_ACTIVE_SESSION`) keep the existing `TMUX_PANE`/ambient-session behavior (#531).

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -90,6 +90,8 @@ export interface SessionCreateFrame {
 	target: SessionCreateTarget;
 	/** Reference to the daemon-written, once-consumed startup-prompt file. */
 	startupPromptRef?: string;
+	/** Model profile preset to activate for the spawned session (--mpreset). */
+	modelPreset?: string;
 }
 
 /** Close (hard-kill, history preserved) a session. */

--- a/packages/coding-agent/src/notifications/lifecycle-commands.ts
+++ b/packages/coding-agent/src/notifications/lifecycle-commands.ts
@@ -31,7 +31,7 @@ function normalizeLifecycleCommandToken(
 
 /** A parsed, validated lifecycle command (transport identity added by caller). */
 export type ParsedLifecycleCommand =
-	| { kind: "create"; target: SessionCreateTarget }
+	| { kind: "create"; target: SessionCreateTarget; modelPreset?: string }
 	| { kind: "close"; target: SessionCloseTarget }
 	| { kind: "resume"; target: SessionResumeTarget }
 	| { kind: "recent"; which: "create" | "resume" | "all" }
@@ -41,9 +41,9 @@ export type ParsedLifecycleCommand =
 
 const USAGE = [
 	"Session commands:",
-	"/session_create path <dir>",
-	"/session_create worktree <repo> <branch>",
-	"/session_create dir <newdir>",
+	"/session_create path <dir> [--mpreset <profile>]",
+	"/session_create worktree <repo> <branch> [--mpreset <profile>]",
+	"/session_create dir <newdir> [--mpreset <profile>]",
 	"/session_close <sessionId>",
 	"/session_resume <sessionId|prefix>",
 	"/session_recent [create|resume]",
@@ -67,6 +67,23 @@ export function isLifecycleCommandText(
 	if (!text) return false;
 	const [rawCommand] = text.trim().split(/\s+/, 1);
 	return normalizeLifecycleCommandToken(rawCommand ?? "", ctx) !== undefined;
+}
+
+/** Extract `--mpreset <name>` (or `--mpreset=<name>`) from args, returning remaining positional args. */
+function extractModelPreset(args: string[]): { positional: string[]; modelPreset?: string } {
+	const positional: string[] = [];
+	let modelPreset: string | undefined;
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i]!;
+		if (arg === "--mpreset" && i + 1 < args.length) {
+			modelPreset = args[++i]!;
+		} else if (arg.startsWith("--mpreset=")) {
+			modelPreset = arg.slice("--mpreset=".length);
+		} else {
+			positional.push(arg);
+		}
+	}
+	return { positional, modelPreset };
 }
 
 /**
@@ -121,29 +138,33 @@ export function parseLifecycleCommand(
 		return { kind: "resume", target: { sessionIdOrPrefix: idOrPrefix } };
 	}
 
-	// /session_create <kind> ...
-	const kind = args[0];
+	// /session_create <kind> ... [--mpreset <profile>]
+	const { positional, modelPreset } = extractModelPreset(args);
+	if (modelPreset !== undefined && !isSafeIdentifier(modelPreset)) {
+		return { kind: "reject", reason: "invalid_target", message: `Invalid model preset name.\n\n${USAGE}` };
+	}
+	const kind = positional[0];
 	if (kind === "path") {
-		if (args.length !== 2) return { kind: "usage", message: USAGE };
-		const p = normalizeLifecyclePath(args[1]!);
+		if (positional.length !== 2) return { kind: "usage", message: USAGE };
+		const p = normalizeLifecyclePath(positional[1]!);
 		if (!p) return { kind: "reject", reason: "invalid_target", message: `Invalid path.\n\n${USAGE}` };
-		return { kind: "create", target: { kind: "existing_path", path: p } };
+		return { kind: "create", target: { kind: "existing_path", path: p }, modelPreset };
 	}
 	if (kind === "dir") {
-		if (args.length !== 2) return { kind: "usage", message: USAGE };
-		const p = normalizeLifecyclePath(args[1]!);
+		if (positional.length !== 2) return { kind: "usage", message: USAGE };
+		const p = normalizeLifecyclePath(positional[1]!);
 		if (!p) return { kind: "reject", reason: "invalid_target", message: `Invalid dir.\n\n${USAGE}` };
-		return { kind: "create", target: { kind: "plain_dir", path: p } };
+		return { kind: "create", target: { kind: "plain_dir", path: p }, modelPreset };
 	}
 	if (kind === "worktree") {
-		if (args.length !== 3) return { kind: "usage", message: USAGE };
-		const repo = normalizeLifecyclePath(args[1]!);
-		const branch = args[2]!;
+		if (positional.length !== 3) return { kind: "usage", message: USAGE };
+		const repo = normalizeLifecyclePath(positional[1]!);
+		const branch = positional[2]!;
 		if (!repo) return { kind: "reject", reason: "invalid_target", message: `Invalid repo path.\n\n${USAGE}` };
 		if (!isSafeBranch(branch)) {
 			return { kind: "reject", reason: "invalid_target", message: `Invalid branch name.\n\n${USAGE}` };
 		}
-		return { kind: "create", target: { kind: "worktree", repo, branch } };
+		return { kind: "create", target: { kind: "worktree", repo, branch }, modelPreset };
 	}
 	return { kind: "usage", message: USAGE };
 }

--- a/packages/coding-agent/src/notifications/lifecycle-control-runtime.ts
+++ b/packages/coding-agent/src/notifications/lifecycle-control-runtime.ts
@@ -127,22 +127,29 @@ function tmuxSessionNameFor(sessionId: string): string {
  *  The launched session id is carried via `GJC_SESSION_ID` in the child env (see
  *  {@link daemonSpawnCreate}); the root `gjc` launcher has no `--session-id`
  *  flag, so it must never appear in argv. Only flags the launch parser actually
- *  supports are emitted (`--worktree <branch>` for worktree targets). */
+ *  supports are emitted (`--worktree <branch>` for worktree targets,
+ *  `--mpreset <profile>` for model presets). */
 export function buildCreateArgv(
 	frame: SessionCreateFrame,
 	_ids: { intendedSessionId: string; startupPromptRef?: string },
 ): { cwd: string; args: string[] } {
+	const extraArgs: string[] = [];
+	if (frame.modelPreset) {
+		// Use `--mpreset=<name>` form so the preset name is a single argv token
+		// and a leading-hyphen preset name can never be mis-parsed.
+		extraArgs.push(`--mpreset=${frame.modelPreset}`);
+	}
 	if (frame.target.kind === "worktree") {
 		const cwd = normalizeLifecyclePath(frame.target.repo);
 		if (!cwd) throw new Error("invalid_lifecycle_repo_path");
 		// Use the `--worktree=<branch>` form so the branch is a single argv token:
 		// a flag-shaped branch (e.g. `-x`) can never be mis-parsed as a separate
 		// launcher flag / detached-mode trigger.
-		return { cwd, args: [`--worktree=${frame.target.branch}`] };
+		return { cwd, args: [`--worktree=${frame.target.branch}`, ...extraArgs] };
 	}
 	const cwd = normalizeLifecyclePath(frame.target.path);
 	if (!cwd) throw new Error("invalid_lifecycle_path");
-	return { cwd, args: [] };
+	return { cwd, args: extraArgs };
 }
 
 /** Real daemon-safe tmux launcher: detached `tmux new-session -d` + GJC tags. */

--- a/packages/coding-agent/src/notifications/lifecycle-control-runtime.ts
+++ b/packages/coding-agent/src/notifications/lifecycle-control-runtime.ts
@@ -135,9 +135,7 @@ export function buildCreateArgv(
 ): { cwd: string; args: string[] } {
 	const extraArgs: string[] = [];
 	if (frame.modelPreset) {
-		// Use `--mpreset=<name>` form so the preset name is a single argv token
-		// and a leading-hyphen preset name can never be mis-parsed.
-		extraArgs.push(`--mpreset=${frame.modelPreset}`);
+		extraArgs.push("--mpreset", frame.modelPreset);
 	}
 	if (frame.target.kind === "worktree") {
 		const cwd = normalizeLifecyclePath(frame.target.repo);

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1120,7 +1120,7 @@ export class TelegramNotificationDaemon {
 	/** Build an authenticated lifecycle frame from a parsed command + identity. */
 	private buildLifecycleFrame(
 		parsed:
-			| { kind: "create"; target: SessionCreateTarget }
+			| { kind: "create"; target: SessionCreateTarget; modelPreset?: string }
 			| { kind: "close"; target: SessionCloseTarget }
 			| { kind: "resume"; target: SessionResumeTarget },
 		updateId: number,
@@ -1138,6 +1138,7 @@ export class TelegramNotificationDaemon {
 				chatId,
 				token,
 				target: parsed.target,
+				modelPreset: parsed.modelPreset,
 			};
 		}
 		if (parsed.kind === "close") {
@@ -2291,7 +2292,7 @@ export class TelegramNotificationDaemon {
 					{ command: "verbose", description: "Mirror full tool output + reasoning in this thread" },
 					{ command: "lean", description: "Mirror assistant text + tool names only (default)" },
 					{ command: "redact", description: "Toggle redaction of streamed content: /redact <on|off>" },
-					{ command: "session_create", description: "Create a GJC session: path, worktree, or dir" },
+					{ command: "session_create", description: "Create a GJC session: path, worktree, or dir [--mpreset]" },
 					{ command: "session_recent", description: "List recent GJC sessions" },
 					{ command: "session_close", description: "Close a GJC-managed session" },
 					{ command: "session_resume", description: "Resume or reattach a session" },

--- a/packages/coding-agent/test/notifications-lifecycle-commands.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-commands.test.ts
@@ -236,4 +236,47 @@ describe("lifecycle command parser (G009)", () => {
 		expect(amb).toContain("a");
 		expect(amb).toContain("b");
 	});
+
+	it("parses --mpreset for all create target kinds (space-separated)", () => {
+		expect(parseLifecycleCommand("/session_create path /repo --mpreset codex-eco")).toEqual({
+			kind: "create",
+			target: { kind: "existing_path", path: "/repo" },
+			modelPreset: "codex-eco",
+		});
+		expect(parseLifecycleCommand("/session_create dir /new/dir --mpreset claude-opus")).toEqual({
+			kind: "create",
+			target: { kind: "plain_dir", path: "/new/dir" },
+			modelPreset: "claude-opus",
+		});
+		expect(parseLifecycleCommand("/session_create worktree /repo feat/x --mpreset opencodego")).toEqual({
+			kind: "create",
+			target: { kind: "worktree", repo: "/repo", branch: "feat/x" },
+			modelPreset: "opencodego",
+		});
+	});
+
+	it("parses --mpreset=<name> (equals-separated) form", () => {
+		expect(parseLifecycleCommand("/session_create path /repo --mpreset=codex-medium")).toEqual({
+			kind: "create",
+			target: { kind: "existing_path", path: "/repo" },
+			modelPreset: "codex-medium",
+		});
+	});
+
+	it("omits modelPreset when --mpreset is not given", () => {
+		const out = parseLifecycleCommand("/session_create path /repo");
+		expect(out.kind).toBe("create");
+		if (out.kind === "create") {
+			expect(out.modelPreset).toBeUndefined();
+		}
+	});
+
+	it("rejects injection-shaped --mpreset values", () => {
+		expect(parseLifecycleCommand("/session_create path /repo --mpreset 'bad;rm'").kind).toBe("reject");
+		expect(parseLifecycleCommand("/session_create path /repo --mpreset a$(whoami)").kind).toBe("reject");
+	});
+
+	it("usage text includes --mpreset", () => {
+		expect(lifecycleUsage()).toContain("--mpreset");
+	});
 });

--- a/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
@@ -113,6 +113,23 @@ describe("lifecycle control runtime", () => {
 		expect(remainingArgs).toEqual([]);
 	});
 
+	it("buildCreateArgv emits --mpreset when modelPreset is set", () => {
+		expect(
+			buildCreateArgv(createFrame({ modelPreset: "codex-eco" }), { intendedSessionId: "x" }),
+		).toEqual({ cwd: "/repo", args: ["--mpreset=codex-eco"] });
+
+		expect(
+			buildCreateArgv(
+				createFrame({ target: { kind: "worktree", repo: "/r", branch: "feat/y" }, modelPreset: "claude-opus" }),
+				{ intendedSessionId: "x" },
+			),
+		).toEqual({ cwd: "/r", args: ["--worktree=feat/y", "--mpreset=claude-opus"] });
+	});
+
+	it("buildCreateArgv omits --mpreset when modelPreset is undefined", () => {
+		expect(buildCreateArgv(createFrame(), { intendedSessionId: "x" }).args).toEqual([]);
+	});
+
 	it("outcomeToResponse maps ok create to a create_response frame", () => {
 		const entry: LedgerEntry = {
 			requestHash: "h",

--- a/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
@@ -113,17 +113,19 @@ describe("lifecycle control runtime", () => {
 		expect(remainingArgs).toEqual([]);
 	});
 
-	it("buildCreateArgv emits --mpreset when modelPreset is set", () => {
-		expect(
-			buildCreateArgv(createFrame({ modelPreset: "codex-eco" }), { intendedSessionId: "x" }),
-		).toEqual({ cwd: "/repo", args: ["--mpreset=codex-eco"] });
+	it("buildCreateArgv emits root-parser-compatible --mpreset argv when modelPreset is set", () => {
+		const pathLaunch = buildCreateArgv(createFrame({ modelPreset: "codex-eco" }), { intendedSessionId: "x" });
+		expect(pathLaunch).toEqual({ cwd: "/repo", args: ["--mpreset", "codex-eco"] });
+		expect(pathLaunch.args).not.toContain("--mpreset=codex-eco");
 
-		expect(
-			buildCreateArgv(
-				createFrame({ target: { kind: "worktree", repo: "/r", branch: "feat/y" }, modelPreset: "claude-opus" }),
-				{ intendedSessionId: "x" },
-			),
-		).toEqual({ cwd: "/r", args: ["--worktree=feat/y", "--mpreset=claude-opus"] });
+		const worktreeLaunch = buildCreateArgv(
+			createFrame({ target: { kind: "worktree", repo: "/r", branch: "feat/y" }, modelPreset: "claude-opus" }),
+			{ intendedSessionId: "x" },
+		);
+		expect(worktreeLaunch).toEqual({ cwd: "/r", args: ["--worktree=feat/y", "--mpreset", "claude-opus"] });
+		const { mode, remainingArgs } = parseLaunchWorktreeMode(worktreeLaunch.args);
+		expect(mode).toEqual({ enabled: true, detached: false, name: "feat/y" });
+		expect(remainingArgs).toEqual(["--mpreset", "claude-opus"]);
 	});
 
 	it("buildCreateArgv omits --mpreset when modelPreset is undefined", () => {


### PR DESCRIPTION
## Summary

Maintainer-carried replacement for the blocker found on external PR #1830.

PR #1830's head branch is `xmilex-git:gajae-code/feat/session-create-model-preset` with `maintainerCanModify=false`, so the repair commit could not be pushed to the contributor branch. This PR carries the same minimal fix from the upstream branch `pr-1830-mpreset-equals-fix`.

Fix:
- change lifecycle `/session_create --mpreset <profile>` spawned `gjc` argv from the rejected `--mpreset=<profile>` form to root-parser-compatible split tokens: `--mpreset`, `<profile>`
- preserve nearby `--worktree=<branch>` behavior
- add focused regression coverage for path + modelPreset, worktree + modelPreset ordering, omitted modelPreset, and the no-`--mpreset=<profile>` guard

## Validation

- `bun test packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts packages/coding-agent/test/notifications-lifecycle-commands.test.ts packages/coding-agent/test/cli-args-mpreset.test.ts` — 39 pass / 0 fail
- `bun run check` from `packages/coding-agent` — biome + `tsgo -p tsconfig.json --noEmit` passed
- GJC architect lane: CLEAR / APPROVE
- GJC executor QA: passed, no blockers

Related: #1830

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*