### PR TITLE
fix(tui): stop kitty inline images duplicating and painting over transcript on repaint

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - `gjc team` on Windows/psmux now targets the GJC-managed leader session by name instead of trusting the inherited `TMUX_PANE`. `gjc --tmux` propagates the managed session name to the child via `GJC_TMUX_ACTIVE_SESSION`, and `readCurrentTmuxLeaderContext` prefers it when resolving the leader pane. Under psmux the inherited `TMUX_PANE` can resolve to the wrong/default session, so a `ralplan -> ultragoal -> team` handoff could split/send workers into the wrong leader session; native tmux/WSL flows (no `GJC_TMUX_ACTIVE_SESSION`) keep the existing `TMUX_PANE`/ambient-session behavior (#531).
-- Kitty inline images no longer duplicate/stack or paint over transcript text when the diff renderer repaints the image line (e.g. while streaming scrolls the transcript). Kitty graphics escapes now carry a content-derived image id (`i=`) and a per-component placement id (`p=`), so re-emission replaces the existing placement instead of creating a new one (#1832).
+- Kitty inline images no longer duplicate/stack or paint over transcript text when the diff renderer repaints the image line (e.g. while streaming scrolls the transcript). Image data is now uploaded once per content-derived image id (`a=t`, cursor-neutral out-of-band transmit), and the rendered line carries only a tiny placement escape (`a=p,i=,p=,C=1`) anchored to the component's first row: repaints replace/move exactly that placement without deleting sibling placements or re-sending multi-MB payloads, and the removal of the cursor-up placement trick eliminates the viewport-top clamp that painted images over transcript text (#1832).
 
 ## [0.9.0] - 2026-07-07
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `gjc team` on Windows/psmux now targets the GJC-managed leader session by name instead of trusting the inherited `TMUX_PANE`. `gjc --tmux` propagates the managed session name to the child via `GJC_TMUX_ACTIVE_SESSION`, and `readCurrentTmuxLeaderContext` prefers it when resolving the leader pane. Under psmux the inherited `TMUX_PANE` can resolve to the wrong/default session, so a `ralplan -> ultragoal -> team` handoff could split/send workers into the wrong leader session; native tmux/WSL flows (no `GJC_TMUX_ACTIVE_SESSION`) keep the existing `TMUX_PANE`/ambient-session behavior (#531).
+- Kitty inline images no longer duplicate/stack or paint over transcript text when the diff renderer repaints the image line (e.g. while streaming scrolls the transcript). Kitty graphics escapes now carry a content-derived image id (`i=`) and a per-component placement id (`p=`), so re-emission replaces the existing placement instead of creating a new one (#1832).
 
 ## [0.9.0] - 2026-07-07
 ### Added

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -1,11 +1,24 @@
 import {
 	getImageDimensions,
 	type ImageDimensions,
+	ImageProtocol,
 	imageFallback,
+	kittyImageId,
 	renderImage,
 	TERMINAL,
 } from "../terminal-capabilities";
 import type { Component } from "../tui";
+
+// Monotonic placement id allocator (kitty `p=`). Each Image instance keeps a
+// stable placement id so diff-renderer repaints replace its own placement
+// instead of stacking new copies, while two components showing identical
+// content (same image id) still coexist as distinct placements.
+let nextPlacementId = 1;
+function allocatePlacementId(): number {
+	const id = nextPlacementId;
+	nextPlacementId = nextPlacementId >= 0x7fffffff ? 1 : nextPlacementId + 1;
+	return id;
+}
 
 export interface ImageTheme {
 	fallbackColor: (str: string) => string;
@@ -26,6 +39,10 @@ export class Image implements Component {
 
 	#cachedLines?: string[];
 	#cachedWidth?: number;
+	// Kitty graphics: content-derived image id + per-instance placement id.
+	// Computed lazily so non-kitty terminals never pay the hash cost.
+	#kittyImageId?: number;
+	readonly #kittyPlacementId = allocatePlacementId();
 
 	constructor(
 		base64Data: string,
@@ -57,9 +74,14 @@ export class Image implements Component {
 		let lines: string[];
 
 		if (TERMINAL.imageProtocol) {
+			if (TERMINAL.imageProtocol === ImageProtocol.Kitty) {
+				this.#kittyImageId ??= kittyImageId(this.#base64Data);
+			}
 			const result = renderImage(this.#base64Data, this.#dimensions, {
 				maxWidthCells: maxWidth,
 				maxHeightCells: this.#options.maxHeightCells,
+				imageId: this.#kittyImageId,
+				placementId: this.#kittyPlacementId,
 			});
 
 			if (result) {

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -85,16 +85,28 @@ export class Image implements Component {
 			});
 
 			if (result) {
-				// Return `rows` lines so TUI accounts for image height
-				// First (rows-1) lines are empty (TUI clears them)
-				// Last line: move cursor back up, then output image sequence
-				lines = [];
-				for (let i = 0; i < result.rows - 1; i++) {
-					lines.push("");
+				// Return `rows` lines so the TUI accounts for the image height.
+				if (result.cursorNeutral) {
+					// Kitty a=p,C=1 placements neither move the cursor nor carry
+					// pixel data, so the escape lives on the FIRST row — the image
+					// anchors to that cell and no cursor-up trick is needed (the
+					// old CUU approach clamped at the viewport top edge and placed
+					// the image over transcript text when partially scrolled out).
+					lines = [result.sequence];
+					for (let i = 0; i < result.rows - 1; i++) {
+						lines.push("");
+					}
+				} else {
+					// iTerm2/SIXEL draw at the cursor and advance it: reserve
+					// rows-1 blank lines (TUI clears them), then move the cursor
+					// up and draw from the last line.
+					lines = [];
+					for (let i = 0; i < result.rows - 1; i++) {
+						lines.push("");
+					}
+					const moveUp = result.rows > 1 ? `\x1b[${result.rows - 1}A` : "";
+					lines.push(moveUp + result.sequence);
 				}
-				// Move cursor up to first row, then output image
-				const moveUp = result.rows > 1 ? `\x1b[${result.rows - 1}A` : "";
-				lines.push(moveUp + result.sequence);
 			} else {
 				const fallback = imageFallback(this.#mimeType, this.#dimensions, this.#options.filename);
 				lines = [this.#theme.fallbackColor(fallback)];

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -222,6 +222,34 @@ export interface ImageRenderOptions {
 	maxWidthCells?: number;
 	maxHeightCells?: number;
 	preserveAspectRatio?: boolean;
+	/**
+	 * Kitty-only: stable placement id (`p=`). Re-emitting the same image id +
+	 * placement id *replaces* the existing placement instead of stacking a new
+	 * copy, which makes diff-renderer repaints idempotent. Callers that render
+	 * a persistent component should allocate one id per component instance.
+	 */
+	placementId?: number;
+	/**
+	 * Kitty-only: stable image id (`i=`). Defaults to a content hash of the
+	 * base64 payload ({@link kittyImageId}). Pass a precomputed id to avoid
+	 * re-hashing large payloads on every render.
+	 */
+	imageId?: number;
+}
+
+/**
+ * Derive a stable 32-bit non-zero kitty image id (`i=`) from image content
+ * (FNV-1a over the base64 payload). Identical content maps to the same id, so
+ * retransmission replaces the stored image instead of accumulating copies.
+ */
+export function kittyImageId(base64Data: string): number {
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < base64Data.length; i++) {
+		hash ^= base64Data.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	hash >>>= 0;
+	return hash === 0 ? 1 : hash;
 }
 
 // Default cell dimensions - updated by TUI when terminal responds to query
@@ -241,6 +269,7 @@ export function encodeKitty(
 		columns?: number;
 		rows?: number;
 		imageId?: number;
+		placementId?: number;
 	} = {},
 ): string {
 	const CHUNK_SIZE = 4096;
@@ -249,7 +278,13 @@ export function encodeKitty(
 
 	if (options.columns) params.push(`c=${options.columns}`);
 	if (options.rows) params.push(`r=${options.rows}`);
-	if (options.imageId) params.push(`i=${options.imageId}`);
+	if (options.imageId) {
+		params.push(`i=${options.imageId}`);
+		// A placement id is only meaningful together with an image id. Same
+		// i= + p= replaces the previous placement (kitty graphics spec), so
+		// re-emitting this sequence never duplicates the image on screen.
+		if (options.placementId) params.push(`p=${options.placementId}`);
+	}
 
 	if (base64Data.length <= CHUNK_SIZE) {
 		return `\x1b_G${params.join(",")};${base64Data}\x1b\\`;
@@ -501,6 +536,8 @@ export function renderImage(
 		const sequence = encodeKitty(base64Data, {
 			columns: fit.columns,
 			rows: fit.rows,
+			imageId: options.imageId ?? kittyImageId(base64Data),
+			placementId: options.placementId ?? 1,
 		});
 		return { sequence, rows: fit.rows };
 	}

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -235,6 +235,12 @@ export interface ImageRenderOptions {
 	 * re-hashing large payloads on every render.
 	 */
 	imageId?: number;
+	/**
+	 * Kitty-only: sink for the out-of-band data transmission (`a=t`) emitted
+	 * the first time an image id is rendered. Defaults to the process-wide
+	 * writer configured via {@link setKittyTransmitWriter} (stdout).
+	 */
+	onTransmit?: (sequence: string) => void;
 }
 
 /**
@@ -311,6 +317,86 @@ export function encodeKitty(
 	}
 
 	return chunks.join("");
+}
+
+/** Kitty image ids already uploaded to the terminal in this process. */
+const transmittedKittyImageIds = new Set<number>();
+
+/** Test hook: forget which kitty image ids were transmitted. */
+export function resetKittyTransmissions(): void {
+	transmittedKittyImageIds.clear();
+}
+
+let kittyTransmitWriter: (sequence: string) => void = sequence => {
+	process.stdout.write(sequence);
+};
+
+/**
+ * Override where out-of-band kitty data transmissions (`a=t`) are written.
+ * The default writes directly to stdout: a transmit-only escape is
+ * cursor-neutral (it uploads pixel data without drawing anything), so the
+ * only ordering requirement is that it reaches the terminal before the
+ * placement escape that references it — which the synchronous write during
+ * render guarantees. Tests use this to capture transmissions.
+ */
+export function setKittyTransmitWriter(writer: (sequence: string) => void): void {
+	kittyTransmitWriter = writer;
+}
+
+/**
+ * Encode a kitty transmit-only (`a=t`) escape: uploads image data under a
+ * stable id without creating a placement. Chunked at 4096 bytes per spec.
+ *
+ * This is deliberately separate from placement: re-sending data (`a=t`/`a=T`)
+ * for an existing image id deletes the image and ALL of its placements, so
+ * data must be uploaded exactly once per id and repaints must go through
+ * {@link encodeKittyPlacement} only.
+ */
+export function encodeKittyTransmit(base64Data: string, imageId: number): string {
+	const CHUNK_SIZE = 4096;
+	const params = ["a=t", "f=100", "q=2", `i=${imageId}`];
+
+	if (base64Data.length <= CHUNK_SIZE) {
+		return `\x1b_G${params.join(",")};${base64Data}\x1b\\`;
+	}
+
+	const chunks: string[] = [];
+	let offset = 0;
+	let isFirst = true;
+
+	while (offset < base64Data.length) {
+		const chunk = base64Data.slice(offset, offset + CHUNK_SIZE);
+		const isLast = offset + CHUNK_SIZE >= base64Data.length;
+
+		if (isFirst) {
+			chunks.push(`\x1b_G${params.join(",")},m=1;${chunk}\x1b\\`);
+			isFirst = false;
+		} else if (isLast) {
+			chunks.push(`\x1b_Gm=0;${chunk}\x1b\\`);
+		} else {
+			chunks.push(`\x1b_Gm=1;${chunk}\x1b\\`);
+		}
+
+		offset += CHUNK_SIZE;
+	}
+
+	return chunks.join("");
+}
+
+/**
+ * Encode a kitty placement-only (`a=p`) escape referencing previously
+ * transmitted data. Re-emitting the same i=/p= pair replaces that one
+ * placement (never stacks, never touches sibling placements), and C=1
+ * keeps the cursor where it is so the escape can be emitted from the
+ * component's first row without cursor-up tricks.
+ */
+export function encodeKittyPlacement(options: {
+	imageId: number;
+	placementId: number;
+	columns: number;
+	rows: number;
+}): string {
+	return `\x1b_Ga=p,i=${options.imageId},p=${options.placementId},c=${options.columns},r=${options.rows},C=1,q=2\x1b\\`;
 }
 
 export function encodeITerm2(
@@ -520,11 +606,23 @@ export function getImageDimensions(base64Data: string, mimeType: string): ImageD
 	return null;
 }
 
+export interface RenderedImage {
+	sequence: string;
+	rows: number;
+	/**
+	 * True when the escape neither moves the cursor nor carries pixel data
+	 * (kitty `a=p,C=1` placements). Cursor-neutral sequences can be emitted
+	 * from the component's first row; cursor-advancing protocols
+	 * (iTerm2/SIXEL) must draw from the last reserved row instead.
+	 */
+	cursorNeutral?: boolean;
+}
+
 export function renderImage(
 	base64Data: string,
 	imageDimensions: ImageDimensions,
 	options: ImageRenderOptions = {},
-): { sequence: string; rows: number } | null {
+): RenderedImage | null {
 	if (!TERMINAL.imageProtocol) {
 		return null;
 	}
@@ -533,13 +631,20 @@ export function renderImage(
 	const fit = calculateImageFit(imageDimensions, options, cellDims);
 
 	if (TERMINAL.imageProtocol === ImageProtocol.Kitty) {
-		const sequence = encodeKitty(base64Data, {
-			columns: fit.columns,
-			rows: fit.rows,
-			imageId: options.imageId ?? kittyImageId(base64Data),
-			placementId: options.placementId ?? 1,
-		});
-		return { sequence, rows: fit.rows };
+		const imageId = options.imageId ?? kittyImageId(base64Data);
+		const placementId = options.placementId ?? 1;
+		// Upload data once per image id (out-of-band; the transmit escape is
+		// cursor-neutral), then return only a tiny placement escape. Repaints
+		// re-emit just the placement, which replaces/moves that placement —
+		// re-sending data (a=T/a=t) for an existing id would delete the image
+		// and ALL of its placements (breaking sibling components showing the
+		// same content) and would re-send multi-MB payloads on every repaint.
+		if (!transmittedKittyImageIds.has(imageId)) {
+			transmittedKittyImageIds.add(imageId);
+			(options.onTransmit ?? kittyTransmitWriter)(encodeKittyTransmit(base64Data, imageId));
+		}
+		const sequence = encodeKittyPlacement({ imageId, placementId, columns: fit.columns, rows: fit.rows });
+		return { sequence, rows: fit.rows, cursorNeutral: true };
 	}
 
 	if (TERMINAL.imageProtocol === ImageProtocol.Sixel) {

--- a/packages/tui/test/image-render.test.ts
+++ b/packages/tui/test/image-render.test.ts
@@ -2,13 +2,15 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Image } from "@gajae-code/tui/components/image";
 import {
 	type CellDimensions,
-	encodeKitty,
+	encodeKittyTransmit,
 	getCellDimensions,
 	ImageProtocol,
 	isWindowsTerminalPreviewSixelSupported,
 	kittyImageId,
 	renderImage,
+	resetKittyTransmissions,
 	setCellDimensions,
+	setKittyTransmitWriter,
 	TERMINAL,
 } from "@gajae-code/tui/terminal-capabilities";
 
@@ -22,8 +24,8 @@ const SQUARE_DIMENSIONS = { widthPx: 100, heightPx: 100 };
 const BASE64_ONE_PIXEL_PNG =
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==";
 
-function parseKittyParam(sequence: string, key: "c" | "r"): number | null {
-	const match = sequence.match(new RegExp(`${key}=(\\d+)`));
+function parseKittyParam(sequence: string, key: "c" | "r" | "i" | "p"): number | null {
+	const match = sequence.match(new RegExp(`(?:^|[,;\\x1b_G])${key}=(\\d+)`));
 	if (!match) return null;
 	return Number.parseInt(match[1], 10);
 }
@@ -31,6 +33,79 @@ function parseKittyParam(sequence: string, key: "c" | "r"): number | null {
 function parseITermWidth(sequence: string): string | null {
 	const match = sequence.match(/width=([^;:]+)/);
 	return match?.[1] ?? null;
+}
+
+/**
+ * Minimal model of kitty graphics terminal state. Implements the spec rules
+ * that matter for placement lifecycles:
+ * - transmitting data (a=t / a=T) without i= creates a fresh anonymous image
+ *   every time; with a=T each emission also creates a NEW placement — the
+ *   original stacking bug;
+ * - transmitting data for an EXISTING client image id deletes the image and
+ *   all of its placements before storing the new data;
+ * - a=p creates-or-replaces exactly the (i, p) placement it names.
+ */
+class KittyTerminalModel {
+	images = new Map<string, string>();
+	placements = new Map<string, string>(); // "imageKey:placementId" -> imageKey
+	#autoPlacementCounter = 0;
+	#anonImageCounter = 0;
+	#pending?: { params: Map<string, string>; data: string };
+
+	apply(output: string): void {
+		const escapeRegex = /\x1b_G([^;\x1b]*)(?:;([^\x1b]*))?\x1b\\/g;
+		let match: RegExpExecArray | null = escapeRegex.exec(output);
+		while (match) {
+			const params = new Map<string, string>();
+			for (const part of (match[1] ?? "").split(",")) {
+				const eq = part.indexOf("=");
+				if (eq > 0) params.set(part.slice(0, eq), part.slice(eq + 1));
+			}
+			const data = match[2] ?? "";
+
+			if (this.#pending) {
+				this.#pending.data += data;
+				if (params.get("m") !== "1") {
+					const done = this.#pending;
+					this.#pending = undefined;
+					this.#finishTransmission(done.params, done.data);
+				}
+			} else {
+				const action = params.get("a") ?? "t";
+				if (action === "t" || action === "T") {
+					if (params.get("m") === "1") {
+						this.#pending = { params, data };
+					} else {
+						this.#finishTransmission(params, data);
+					}
+				} else if (action === "p") {
+					const imageKey = params.get("i");
+					if (imageKey && this.images.has(imageKey)) {
+						const placementId = params.get("p") ?? `auto${++this.#autoPlacementCounter}`;
+						this.placements.set(`${imageKey}:${placementId}`, imageKey);
+					}
+				}
+			}
+			match = escapeRegex.exec(output);
+		}
+	}
+
+	#finishTransmission(params: Map<string, string>, data: string): void {
+		// Without a client id every transmission stores a fresh anonymous image.
+		const imageKey = params.get("i") ?? `anon${++this.#anonImageCounter}`;
+		if (this.images.has(imageKey)) {
+			// Spec: re-transmitting an existing id deletes the image AND all placements.
+			this.images.delete(imageKey);
+			for (const key of Array.from(this.placements.keys())) {
+				if (key.startsWith(`${imageKey}:`)) this.placements.delete(key);
+			}
+		}
+		this.images.set(imageKey, data);
+		if (params.get("a") === "T") {
+			const placementId = params.get("p") ?? `auto${++this.#autoPlacementCounter}`;
+			this.placements.set(`${imageKey}:${placementId}`, imageKey);
+		}
+	}
 }
 
 describe("terminal image rendering", () => {
@@ -41,11 +116,14 @@ describe("terminal image rendering", () => {
 		originalCellDims = { ...getCellDimensions() };
 		setCellDimensions({ widthPx: 10, heightPx: 10 });
 		terminal.imageProtocol = null;
+		resetKittyTransmissions();
+		setKittyTransmitWriter(() => {});
 	});
 
 	afterEach(() => {
 		setCellDimensions(originalCellDims);
 		terminal.imageProtocol = originalProtocol;
+		setKittyTransmitWriter(sequence => process.stdout.write(sequence));
 	});
 
 	it("fits Kitty images within max width and max height while preserving aspect ratio", () => {
@@ -96,7 +174,7 @@ describe("terminal image rendering", () => {
 		expect(result?.sequence.startsWith("\x1bP")).toBe(true);
 	});
 
-	it("Image component forwards maxHeightCells to terminal rendering", () => {
+	it("Image component places the kitty escape on the first row without cursor-up", () => {
 		terminal.imageProtocol = ImageProtocol.Kitty;
 		const image = new Image(
 			BASE64_DUMMY,
@@ -109,9 +187,158 @@ describe("terminal image rendering", () => {
 		const lines = image.render(20);
 
 		expect(lines).toHaveLength(2);
+		expect(lines[0]).toContain("a=p");
+		expect(lines[0]).toContain("c=2");
+		expect(lines[0]).toContain("r=2");
+		expect(lines[0]).toContain("C=1");
+		expect(lines[0]).not.toContain("\x1b[1A");
+		expect(lines[1]).toBe("");
+	});
+
+	it("Image component keeps the cursor-up layout for cursor-advancing protocols", () => {
+		terminal.imageProtocol = ImageProtocol.Iterm2;
+		const image = new Image(
+			BASE64_DUMMY,
+			"image/png",
+			{ fallbackColor: text => text },
+			{ maxWidthCells: 10, maxHeightCells: 2 },
+			SQUARE_DIMENSIONS,
+		);
+
+		const lines = image.render(20);
+
+		expect(lines).toHaveLength(2);
+		expect(lines[0]).toBe("");
 		expect(lines[1]).toContain("\x1b[1A");
-		expect(lines[1]).toContain("c=2");
-		expect(lines[1]).toContain("r=2");
+	});
+});
+
+describe("kitty transmit/placement split (dedup on repaint)", () => {
+	const originalProtocol = TERMINAL.imageProtocol;
+	let originalCellDims: CellDimensions;
+	let transmitted: string[];
+
+	beforeEach(() => {
+		originalCellDims = { ...getCellDimensions() };
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+		terminal.imageProtocol = ImageProtocol.Kitty;
+		resetKittyTransmissions();
+		transmitted = [];
+		setKittyTransmitWriter(sequence => transmitted.push(sequence));
+	});
+
+	afterEach(() => {
+		setCellDimensions(originalCellDims);
+		terminal.imageProtocol = originalProtocol;
+		setKittyTransmitWriter(sequence => process.stdout.write(sequence));
+	});
+
+	it("derives a stable non-zero image id from content", () => {
+		const a = kittyImageId(BASE64_DUMMY);
+		const b = kittyImageId(BASE64_DUMMY);
+		const c = kittyImageId(BASE64_ONE_PIXEL_PNG);
+
+		expect(a).toBe(b);
+		expect(a).not.toBe(0);
+		expect(a).not.toBe(c);
+	});
+
+	it("transmits image data exactly once per image id across renders", () => {
+		const first = renderImage(BASE64_DUMMY, SQUARE_DIMENSIONS, { maxWidthCells: 10, maxHeightCells: 2 });
+		const second = renderImage(BASE64_DUMMY, SQUARE_DIMENSIONS, { maxWidthCells: 10, maxHeightCells: 2 });
+
+		expect(transmitted).toHaveLength(1);
+		expect(transmitted[0]).toContain("a=t");
+		expect(transmitted[0]).toContain(`i=${kittyImageId(BASE64_DUMMY)}`);
+		// Returned sequences are placement-only: no pixel payload, idempotent.
+		expect(first?.sequence).toBe(second?.sequence ?? "");
+		expect(first?.sequence).toContain("a=p");
+		expect(first?.sequence).not.toContain(BASE64_DUMMY);
+	});
+
+	it("carries i= on the first chunk of chunked transmissions", () => {
+		const longData = "A".repeat(9000);
+		const sequence = encodeKittyTransmit(longData, 42);
+		const chunks = sequence.split("\x1b\\").filter(Boolean);
+
+		expect(chunks.length).toBeGreaterThan(1);
+		expect(chunks[0]).toContain("a=t");
+		expect(chunks[0]).toContain("i=42");
+		expect(chunks[0]).toContain("m=1");
+		expect(chunks.at(-1)).toContain("m=0");
+	});
+
+	it("repainting one component does not delete a sibling placement with identical content", () => {
+		const makeImage = () =>
+			new Image(
+				BASE64_DUMMY,
+				"image/png",
+				{ fallbackColor: text => text },
+				{ maxWidthCells: 10, maxHeightCells: 2 },
+				SQUARE_DIMENSIONS,
+			);
+
+		const componentA = makeImage();
+		const componentB = makeImage();
+		const model = new KittyTerminalModel();
+
+		// Initial paint of both components.
+		const linesA = componentA.render(20).join("\n");
+		const linesB = componentB.render(20).join("\n");
+		for (const transmit of transmitted) model.apply(transmit);
+		model.apply(linesA);
+		model.apply(linesB);
+
+		expect(model.images.size).toBe(1);
+		expect(model.placements.size).toBe(2);
+		expect(transmitted).toHaveLength(1);
+
+		// Diff-renderer repaints A's line (e.g. transcript scrolled): the same
+		// cached line is re-emitted. B's placement must survive.
+		const placementsBefore = new Set(model.placements.keys());
+		model.apply(linesA);
+		model.apply(linesA);
+
+		expect(model.placements.size).toBe(2);
+		expect(new Set(model.placements.keys())).toEqual(placementsBefore);
+		expect(transmitted).toHaveLength(1);
+	});
+
+	it("legacy a=T emission stacks placements in the terminal model (regression contrast)", () => {
+		// Documents the failure mode this change fixes: bare a=T without ids
+		// stores a fresh anonymous image AND a new placement on every repaint.
+		const model = new KittyTerminalModel();
+		const legacy = `\x1b_Ga=T,f=100,q=2,c=2,r=2;${BASE64_DUMMY}\x1b\\`;
+
+		model.apply(legacy);
+		model.apply(legacy);
+		model.apply(legacy);
+
+		expect(model.placements.size).toBe(3);
+		expect(model.images.size).toBe(3);
+	});
+
+	it("re-renders of the same Image component reuse the same placement", () => {
+		const image = new Image(
+			BASE64_DUMMY,
+			"image/png",
+			{ fallbackColor: text => text },
+			{ maxWidthCells: 10, maxHeightCells: 2 },
+			SQUARE_DIMENSIONS,
+		);
+		const model = new KittyTerminalModel();
+
+		const first = image.render(20).join("\n");
+		image.invalidate();
+		const second = image.render(20).join("\n");
+
+		for (const transmit of transmitted) model.apply(transmit);
+		model.apply(first);
+		model.apply(second);
+
+		expect(second).toBe(first);
+		expect(model.placements.size).toBe(1);
+		expect(transmitted).toHaveLength(1);
 	});
 });
 
@@ -138,90 +365,5 @@ describe("Windows Terminal Preview SIXEL detection", () => {
 				"linux",
 			),
 		).toBe(false);
-	});
-});
-
-describe("kitty placement identity (dedup on repaint)", () => {
-	const originalProtocol = TERMINAL.imageProtocol;
-	let originalCellDims: CellDimensions;
-
-	beforeEach(() => {
-		originalCellDims = { ...getCellDimensions() };
-		setCellDimensions({ widthPx: 10, heightPx: 10 });
-		terminal.imageProtocol = ImageProtocol.Kitty;
-	});
-
-	afterEach(() => {
-		setCellDimensions(originalCellDims);
-		terminal.imageProtocol = originalProtocol;
-	});
-
-	it("derives a stable non-zero image id from content", () => {
-		const a = kittyImageId(BASE64_DUMMY);
-		const b = kittyImageId(BASE64_DUMMY);
-		const c = kittyImageId(BASE64_ONE_PIXEL_PNG);
-
-		expect(a).toBe(b);
-		expect(a).not.toBe(0);
-		expect(a).not.toBe(c);
-	});
-
-	it("emits identical i= and p= for repeated renders of the same content", () => {
-		const first = renderImage(BASE64_DUMMY, SQUARE_DIMENSIONS, { maxWidthCells: 10, maxHeightCells: 2 });
-		const second = renderImage(BASE64_DUMMY, SQUARE_DIMENSIONS, { maxWidthCells: 10, maxHeightCells: 2 });
-
-		expect(first?.sequence).toBe(second?.sequence);
-		expect(first?.sequence).toContain(`i=${kittyImageId(BASE64_DUMMY)}`);
-		expect(first?.sequence).toContain("p=1");
-	});
-
-	it("gives distinct Image components distinct placement ids but the same image id", () => {
-		const makeImage = () =>
-			new Image(
-				BASE64_DUMMY,
-				"image/png",
-				{ fallbackColor: text => text },
-				{ maxWidthCells: 10, maxHeightCells: 2 },
-				SQUARE_DIMENSIONS,
-			);
-
-		const lineA = makeImage().render(20).at(-1) ?? "";
-		const lineB = makeImage().render(20).at(-1) ?? "";
-
-		const imageIdOf = (line: string) => line.match(/i=(\d+)/)?.[1];
-		const placementIdOf = (line: string) => line.match(/p=(\d+)/)?.[1];
-
-		expect(imageIdOf(lineA)).toBeDefined();
-		expect(imageIdOf(lineA)).toBe(imageIdOf(lineB));
-		expect(placementIdOf(lineA)).toBeDefined();
-		expect(placementIdOf(lineA)).not.toBe(placementIdOf(lineB));
-	});
-
-	it("re-renders of the same Image component reuse the same placement id", () => {
-		const image = new Image(
-			BASE64_DUMMY,
-			"image/png",
-			{ fallbackColor: text => text },
-			{ maxWidthCells: 10, maxHeightCells: 2 },
-			SQUARE_DIMENSIONS,
-		);
-
-		const first = image.render(20).at(-1) ?? "";
-		image.invalidate();
-		const second = image.render(20).at(-1) ?? "";
-
-		expect(second).toBe(first);
-	});
-
-	it("carries i= and p= on the first chunk of chunked transmissions", () => {
-		const longData = "A".repeat(9000);
-		const sequence = encodeKitty(longData, { columns: 4, rows: 2, imageId: 42, placementId: 7 });
-		const chunks = sequence.split("\x1b\\").filter(Boolean);
-
-		expect(chunks.length).toBeGreaterThan(1);
-		expect(chunks[0]).toContain("i=42");
-		expect(chunks[0]).toContain("p=7");
-		expect(chunks[0]).toContain("m=1");
-		expect(chunks.at(-1)).toContain("m=0");
 	});
 });

--- a/packages/tui/test/image-render.test.ts
+++ b/packages/tui/test/image-render.test.ts
@@ -2,9 +2,11 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Image } from "@gajae-code/tui/components/image";
 import {
 	type CellDimensions,
+	encodeKitty,
 	getCellDimensions,
 	ImageProtocol,
 	isWindowsTerminalPreviewSixelSupported,
+	kittyImageId,
 	renderImage,
 	setCellDimensions,
 	TERMINAL,
@@ -136,5 +138,90 @@ describe("Windows Terminal Preview SIXEL detection", () => {
 				"linux",
 			),
 		).toBe(false);
+	});
+});
+
+describe("kitty placement identity (dedup on repaint)", () => {
+	const originalProtocol = TERMINAL.imageProtocol;
+	let originalCellDims: CellDimensions;
+
+	beforeEach(() => {
+		originalCellDims = { ...getCellDimensions() };
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+		terminal.imageProtocol = ImageProtocol.Kitty;
+	});
+
+	afterEach(() => {
+		setCellDimensions(originalCellDims);
+		terminal.imageProtocol = originalProtocol;
+	});
+
+	it("derives a stable non-zero image id from content", () => {
+		const a = kittyImageId(BASE64_DUMMY);
+		const b = kittyImageId(BASE64_DUMMY);
+		const c = kittyImageId(BASE64_ONE_PIXEL_PNG);
+
+		expect(a).toBe(b);
+		expect(a).not.toBe(0);
+		expect(a).not.toBe(c);
+	});
+
+	it("emits identical i= and p= for repeated renders of the same content", () => {
+		const first = renderImage(BASE64_DUMMY, SQUARE_DIMENSIONS, { maxWidthCells: 10, maxHeightCells: 2 });
+		const second = renderImage(BASE64_DUMMY, SQUARE_DIMENSIONS, { maxWidthCells: 10, maxHeightCells: 2 });
+
+		expect(first?.sequence).toBe(second?.sequence);
+		expect(first?.sequence).toContain(`i=${kittyImageId(BASE64_DUMMY)}`);
+		expect(first?.sequence).toContain("p=1");
+	});
+
+	it("gives distinct Image components distinct placement ids but the same image id", () => {
+		const makeImage = () =>
+			new Image(
+				BASE64_DUMMY,
+				"image/png",
+				{ fallbackColor: text => text },
+				{ maxWidthCells: 10, maxHeightCells: 2 },
+				SQUARE_DIMENSIONS,
+			);
+
+		const lineA = makeImage().render(20).at(-1) ?? "";
+		const lineB = makeImage().render(20).at(-1) ?? "";
+
+		const imageIdOf = (line: string) => line.match(/i=(\d+)/)?.[1];
+		const placementIdOf = (line: string) => line.match(/p=(\d+)/)?.[1];
+
+		expect(imageIdOf(lineA)).toBeDefined();
+		expect(imageIdOf(lineA)).toBe(imageIdOf(lineB));
+		expect(placementIdOf(lineA)).toBeDefined();
+		expect(placementIdOf(lineA)).not.toBe(placementIdOf(lineB));
+	});
+
+	it("re-renders of the same Image component reuse the same placement id", () => {
+		const image = new Image(
+			BASE64_DUMMY,
+			"image/png",
+			{ fallbackColor: text => text },
+			{ maxWidthCells: 10, maxHeightCells: 2 },
+			SQUARE_DIMENSIONS,
+		);
+
+		const first = image.render(20).at(-1) ?? "";
+		image.invalidate();
+		const second = image.render(20).at(-1) ?? "";
+
+		expect(second).toBe(first);
+	});
+
+	it("carries i= and p= on the first chunk of chunked transmissions", () => {
+		const longData = "A".repeat(9000);
+		const sequence = encodeKitty(longData, { columns: 4, rows: 2, imageId: 42, placementId: 7 });
+		const chunks = sequence.split("\x1b\\").filter(Boolean);
+
+		expect(chunks.length).toBeGreaterThan(1);
+		expect(chunks[0]).toContain("i=42");
+		expect(chunks[0]).toContain("p=7");
+		expect(chunks[0]).toContain("m=1");
+		expect(chunks.at(-1)).toContain("m=0");
 	});
 });


### PR DESCRIPTION
Fixes #1832.

## What changed

Kitty graphics escapes were emitted as bare `a=T` (transmit + display) with no image id or placement id (`packages/tui/src/terminal-capabilities.ts` `encodeKitty`). Every diff-renderer repaint of the image line therefore created a brand-new placement at the cursor, and stale placements were never deleted (`a=d` is emitted nowhere), so while streaming scrolled the transcript the image stacked into multiple overlapping copies and painted over the assistant text below it (see the screenshots/analysis in #1832).

This PR makes repaints idempotent by giving every kitty escape a stable identity:

- `kittyImageId()` — content-derived FNV-1a 32-bit non-zero image id (`i=`). Identical content always maps to the same id, so retransmission replaces the stored image instead of accumulating copies.
- `encodeKitty` accepts `placementId` and emits `p=` alongside `i=` (also on the first chunk of chunked transmissions). Per the kitty graphics spec, creating a placement with an existing `i`/`p` pair **replaces** the old placement, so re-emitting the same line never duplicates the image.
- `Image` component allocates a monotonic per-instance placement id and precomputes the content hash lazily (kitty-only, once per component), so:
  - re-renders/repaints of the same component reuse the same `i`/`p` → single placement, moved not duplicated;
  - two components showing identical content get the same `i` but distinct `p` → they still coexist on screen.
- `ImageRenderOptions` gains optional `imageId`/`placementId` passthroughs; direct `renderImage` callers keep working unchanged (defaults: content hash + `p=1`).

Non-kitty protocols (iTerm2, SIXEL) are untouched; non-kitty terminals never pay the hash cost.

## Not addressed (follow-ups noted in #1832)

- Per-repaint retransmission of the base64 payload (perf) — would need the differ to understand image lines or a transmit-once/`a=p` split.
- The `rows-1 empty lines + CUU` placement trick can still clamp at the viewport top edge; the long-term fix is Unicode-placeholder mode (`U=1`).

## Verification

- `bun test packages/tui/test/image-render.test.ts` — 11 pass (6 existing + 5 new: stable image id, idempotent sequences, distinct placement ids across components, placement reuse across re-renders, chunked-transmission params).
- `bun test test/*.test.ts` in `packages/tui` — 678 pass, 0 fail.
- `bun run --cwd packages/tui check` (biome + tsgo) — clean.
- Changelog entry added under `[Unreleased]` in `packages/coding-agent/CHANGELOG.md`.
