### PR TITLE
test(ai): update Fugu login expectations

### DIFF
--- a/packages/ai/test/fugu-provider.test.ts
+++ b/packages/ai/test/fugu-provider.test.ts
@@ -68,11 +68,11 @@ describe("Sakana Fugu provider support", () => {
 			const authStorage = new AuthStorage(store);
 			await authStorage.login("fugu", {
 				onAuth: info => {
-					expect(info.url).toBe("https://fugu.sakana.ai/");
+					expect(info.url).toBe("https://console.sakana.ai/api-keys");
 				},
 				onPrompt: async prompt => {
 					expect(prompt.message).toContain("Sakana Fugu");
-					return " fugu-test-key ";
+					return " fish-test-key ";
 				},
 			});
 
@@ -80,10 +80,10 @@ describe("Sakana Fugu provider support", () => {
 				"https://api.sakana.ai/v1/models",
 				expect.objectContaining({
 					method: "GET",
-					headers: { Authorization: "Bearer fugu-test-key" },
+					headers: { Authorization: "Bearer fish-test-key" },
 				}),
 			);
-			expect(await authStorage.getApiKey("fugu")).toBe("fugu-test-key");
+			expect(await authStorage.getApiKey("fugu")).toBe("fish-test-key");
 		} finally {
 			store.close();
 			await fs.rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes the post-merge Dev CI failure from #1831 by updating the focused Fugu provider test expectations to the accepted Sakana console API-key URL and fish key prefix.

## Validation

- Attempted `bun test packages/ai/test/fugu-provider.test.ts` locally; this worktree still lacks built native addon artifacts, so CI is the authoritative validation.
- Failure source confirmed from stale assertions in `packages/ai/test/fugu-provider.test.ts` (`https://fugu.sakana.ai/`, `fugu-test-key`).

Related: #1831

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
