### PR TITLE
fix(tui): show Telegram input immediately and record it in prompt history

### DIFF
--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -23,6 +23,7 @@ import { HookSelectorComponent } from "../../modes/components/hook-selector";
 import { getAvailableThemesWithPaths, getThemeByName, setTheme, type Theme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext } from "../../modes/types";
 import { setSessionTerminalTitle, setTerminalTitle } from "../../utils/title-generator";
+import { applyInjectedUserSubmission } from "../utils/injected-user-submission";
 import { classifyHookSelectorBellEvent, ringTerminalBell } from "../utils/terminal-bell";
 
 const MAX_WIDGET_LINES = 10;
@@ -954,7 +955,13 @@ export class ExtensionUiController {
 	}
 
 	#sendExtensionUserMessage: SendUserMessageHandler = (content, options) => {
-		this.ctx.session.sendUserMessage(content, options).catch((err: unknown) => {
+		// Compute queued BEFORE send: prompt() may flip session.isStreaming synchronously.
+		const queued = Boolean(options?.deliverAs) || this.ctx.session.isStreaming;
+		// Call send first so the busy/queued path finds the session queue populated
+		// (queueSteer/queueFollowUp push synchronously) before refreshing pending display.
+		const send = this.ctx.session.sendUserMessage(content, options);
+		applyInjectedUserSubmission(this.ctx, { content, queued });
+		send.catch((err: unknown) => {
 			this.ctx.showError(`Extension sendUserMessage failed: ${err instanceof Error ? err.message : String(err)}`);
 		});
 	};

--- a/packages/coding-agent/src/modes/utils/injected-user-submission.ts
+++ b/packages/coding-agent/src/modes/utils/injected-user-submission.ts
@@ -1,0 +1,70 @@
+import type { ImageContent, TextContent } from "@gajae-code/ai";
+import type { InteractiveModeContext } from "../types";
+
+/**
+ * Normalize the content passed to an extension `sendUserMessage` call into a
+ * plain text string plus its image attachments. Mirrors the normalization in
+ * `AgentSession.sendUserMessage` (text parts joined with "\n") so the resulting
+ * text matches the eventual user `message_start` payload.
+ */
+export function normalizeInjectedUserContent(content: string | (TextContent | ImageContent)[]): {
+	text: string;
+	images: ImageContent[];
+	imageCount: number;
+} {
+	if (typeof content === "string") {
+		return { text: content, images: [], imageCount: 0 };
+	}
+	const textParts: string[] = [];
+	const images: ImageContent[] = [];
+	for (const part of content) {
+		if (part.type === "text") textParts.push(part.text);
+		else images.push(part);
+	}
+	const text = textParts.join("\n");
+	return { text, images, imageCount: images.length };
+}
+
+/**
+ * Record a remotely/programmatically injected user message (e.g. Telegram
+ * inbound routed through the extension API) into the interactive TUI, so it is
+ * captured in prompt history and shown immediately instead of only appearing
+ * once the eventual `message_start` event lands.
+ *
+ * Local TUI submissions never reach this path (they go through
+ * `session.prompt(...)` / `startPendingSubmission`), so this cannot double-add
+ * local prompt history.
+ *
+ * - Always adds the injected text to editor prompt history.
+ * - Idle injections optimistically render the user message and set
+ *   `optimisticUserMessageSignature`; the later user `message_start` recognizes
+ *   the signature and skips both the duplicate chat add and the defensive
+ *   editor clear (so a locally typed draft is preserved).
+ * - Busy/queued injections refresh the pending-message display, which the
+ *   caller has already populated by invoking `session.sendUserMessage(...)`
+ *   before this helper.
+ *
+ * This helper never clears the editor text.
+ */
+export function applyInjectedUserSubmission(
+	ctx: InteractiveModeContext,
+	input: { content: string | (TextContent | ImageContent)[]; queued: boolean },
+): void {
+	const { text, images, imageCount } = normalizeInjectedUserContent(input.content);
+	ctx.editor.addToHistory(text);
+
+	if (input.queued) {
+		ctx.updatePendingMessagesDisplay();
+		ctx.ui.requestRender();
+		return;
+	}
+
+	ctx.optimisticUserMessageSignature = `${text}\u0000${imageCount}`;
+	ctx.addMessageToChat({
+		role: "user",
+		content: [{ type: "text", text }, ...images],
+		attribution: "user",
+		timestamp: Date.now(),
+	});
+	ctx.ui.requestRender();
+}

--- a/packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
@@ -118,6 +118,27 @@ describe("EventController message_start (user role)", () => {
 		expect(setText).not.toHaveBeenCalled();
 		expect(ctx.optimisticUserMessageSignature).toBeUndefined();
 	});
+
+	it("skips the duplicate add and preserves the draft for an optimistic-only injected message", async () => {
+		// Injected (e.g. Telegram) messages set ONLY optimisticUserMessageSignature via
+		// applyInjectedUserSubmission. Since wasLocallySubmitted derives from `|| wasOptimistic`,
+		// message_start must skip the duplicate chat add, must NOT clear the local draft, and
+		// must consume the optimistic signature.
+		const message = createUserMessage("remote injected");
+		const signature = "remote injected\u00000";
+		const { ctx, editor, setText, addMessageToChat } = createContext({
+			editorText: "local draft in progress",
+			optimisticSignature: signature,
+		});
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent({ type: "message_start", message });
+
+		expect(addMessageToChat).not.toHaveBeenCalled();
+		expect(setText).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("local draft in progress");
+		expect(ctx.optimisticUserMessageSignature).toBeUndefined();
+	});
 });
 
 function createIrcMessage(timestamp: number): CustomMessage<{ from: string; message: string }> {

--- a/packages/coding-agent/test/modes/utils/injected-user-submission.test.ts
+++ b/packages/coding-agent/test/modes/utils/injected-user-submission.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { ImageContent, TextContent } from "@gajae-code/ai";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import {
+	applyInjectedUserSubmission,
+	normalizeInjectedUserContent,
+} from "@gajae-code/coding-agent/modes/utils/injected-user-submission";
+
+function createContext() {
+	const addToHistory = vi.fn();
+	const setText = vi.fn();
+	const addMessageToChat = vi.fn();
+	const updatePendingMessagesDisplay = vi.fn();
+	const requestRender = vi.fn();
+	const ctx = {
+		editor: { addToHistory, setText },
+		addMessageToChat,
+		updatePendingMessagesDisplay,
+		ui: { requestRender },
+		optimisticUserMessageSignature: undefined,
+	} as unknown as InteractiveModeContext;
+	return { ctx, addToHistory, setText, addMessageToChat, updatePendingMessagesDisplay, requestRender };
+}
+
+const image: ImageContent = { type: "image", data: "AAAA", mimeType: "image/png" };
+
+describe("normalizeInjectedUserContent", () => {
+	it("returns string content unchanged with no images", () => {
+		expect(normalizeInjectedUserContent("hello from telegram")).toEqual({
+			text: "hello from telegram",
+			images: [],
+			imageCount: 0,
+		});
+	});
+
+	it("joins text parts with newlines and collects images from array content", () => {
+		const content: (TextContent | ImageContent)[] = [
+			{ type: "text", text: "line one" },
+			image,
+			{ type: "text", text: "line two" },
+		];
+		expect(normalizeInjectedUserContent(content)).toEqual({
+			text: "line one\nline two",
+			images: [image],
+			imageCount: 1,
+		});
+	});
+	it("keeps image-only content as empty text with image count", () => {
+		expect(normalizeInjectedUserContent([image])).toEqual({
+			text: "",
+			images: [image],
+			imageCount: 1,
+		});
+	});
+
+	it("joins multiple text parts and counts multiple images", () => {
+		const secondImage: ImageContent = { type: "image", data: "BBBB", mimeType: "image/jpeg" };
+		const content: (TextContent | ImageContent)[] = [
+			{ type: "text", text: "line one" },
+			image,
+			{ type: "text", text: "line two" },
+			secondImage,
+		];
+
+		expect(normalizeInjectedUserContent(content)).toEqual({
+			text: "line one\nline two",
+			images: [image, secondImage],
+			imageCount: 2,
+		});
+	});
+});
+
+describe("applyInjectedUserSubmission", () => {
+	it("records history and renders optimistically for an idle injection", () => {
+		const { ctx, addToHistory, setText, addMessageToChat, updatePendingMessagesDisplay, requestRender } =
+			createContext();
+
+		applyInjectedUserSubmission(ctx, { content: "idle telegram prompt", queued: false });
+
+		expect(addToHistory).toHaveBeenCalledTimes(1);
+		expect(addToHistory).toHaveBeenCalledWith("idle telegram prompt");
+		expect(ctx.optimisticUserMessageSignature).toBe("idle telegram prompt\u00000");
+		expect(addMessageToChat).toHaveBeenCalledTimes(1);
+		expect(addMessageToChat.mock.calls[0][0]).toMatchObject({
+			role: "user",
+			content: [{ type: "text", text: "idle telegram prompt" }],
+			attribution: "user",
+		});
+		expect(requestRender).toHaveBeenCalled();
+		// Idle injection must not clear the editor draft or touch the pending list.
+		expect(setText).not.toHaveBeenCalled();
+		expect(updatePendingMessagesDisplay).not.toHaveBeenCalled();
+	});
+	it("records image-only idle injection without clearing the editor", () => {
+		const { ctx, addToHistory, setText, addMessageToChat, updatePendingMessagesDisplay } = createContext();
+
+		applyInjectedUserSubmission(ctx, { content: [image], queued: false });
+
+		expect(addToHistory).toHaveBeenCalledTimes(1);
+		expect(addToHistory).toHaveBeenCalledWith("");
+		// imageCount is 1, matching EventController's signature (event-controller.ts:288-292).
+		expect(ctx.optimisticUserMessageSignature).toBe("\u00001");
+		expect(addMessageToChat).toHaveBeenCalledTimes(1);
+		expect(addMessageToChat.mock.calls[0][0]).toMatchObject({
+			role: "user",
+			content: [{ type: "text", text: "" }, image],
+			attribution: "user",
+		});
+		expect(setText).not.toHaveBeenCalled();
+		expect(updatePendingMessagesDisplay).not.toHaveBeenCalled();
+	});
+
+	it("records history and refreshes pending display only for a busy/queued injection", () => {
+		const { ctx, addToHistory, setText, addMessageToChat, updatePendingMessagesDisplay, requestRender } =
+			createContext();
+
+		applyInjectedUserSubmission(ctx, { content: "busy telegram prompt", queued: true });
+
+		expect(addToHistory).toHaveBeenCalledTimes(1);
+		expect(addToHistory).toHaveBeenCalledWith("busy telegram prompt");
+		expect(updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+		expect(requestRender).toHaveBeenCalled();
+		// Queued injection must not optimistically render, set a signature, or clear the editor.
+		expect(addMessageToChat).not.toHaveBeenCalled();
+		expect(ctx.optimisticUserMessageSignature).toBeUndefined();
+		expect(setText).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes two TUI bugs for Telegram (and other extension-injected) input.

1. **Not recorded in prompt history** — messages sent from Telegram were not recorded in the TUI prompt history (up/down-arrow navigation, Ctrl-R search, backed by the `HistoryStorage` sqlite store).
2. **Not immediately visible** — messages sent from Telegram did not appear in the TUI right away; they only showed up at the delayed `message_start`.

## Root cause

Local TUI input goes through `session.prompt()`, which calls `editor.addToHistory(...)` and renders optimistically via `startPendingSubmission`. Telegram inbound instead flows through the notifications extension API `sendUserMessage` → `ExtensionUiController.#sendExtensionUserMessage` → `session.sendUserMessage(...)`, which does neither. As a result the message never enters prompt history and stays invisible until the turn starts and `message_start` arrives.

## Fix

Add a small utility `applyInjectedUserSubmission` at the extension-injection boundary and call it from `#sendExtensionUserMessage`.

- Always record the injected text via `editor.addToHistory(text)` → history and Ctrl-R search.
- **Idle** injection: set `optimisticUserMessageSignature` and render immediately via `addMessageToChat`. The subsequent user `message_start` recognizes the signature and skips both the duplicate render and the `setText("")` that would clear the draft (`event-controller.ts`: `wasLocallySubmitted = ... || wasOptimistic`).
- **Busy/queued** injection: after `session.sendUserMessage(...)` has synchronously populated the queue, call `updatePendingMessagesDisplay()` to refresh the pending chip immediately.
- Ordering: compute `queued` before `send` (because `prompt()` can change `isStreaming`), and run the helper after `send` (so the queue is populated before the pending refresh, and the optimistic signature is set before the async `message_start`).
- Never calls `editor.setText`, so an in-progress local draft is preserved.

Local TUI submissions never traverse this helper, so there is no history double-add. Remote text is unexpanded (`expandPromptTemplates: false`), so the optimistic signature `${text}\u0000${imageCount}` matches the eventual `message_start` payload exactly (including image-only messages).

RPC/ACP/background modes have no TUI editor/prompt history and are out of scope. Other extensions that use `sendUserMessage` (autoresearch/reload-runtime) receive the same treatment — intentionally accepted, since there is no separate origin flag.

## Tests

```
bun test packages/coding-agent/test/modes/utils/injected-user-submission.test.ts \
         packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
# 14 pass / 0 fail
```

- `normalizeInjectedUserContent`: string / array (multi-text, multi-image) / image-only normalization.
- `applyInjectedUserSubmission`: idle (history + optimistic render, no `setText`, no pending refresh), busy (history + pending refresh, no `addMessageToChat`/signature/`setText`), image-only idle (signature encodes `imageCount`).
- `event-controller` `message_start`: an injected message with only `optimisticUserMessageSignature` set skips the duplicate add, preserves the draft, and consumes the signature.

`tsgo` type-checks clean for the changed files.

## Changed files

- `packages/coding-agent/src/modes/utils/injected-user-submission.ts` (new)
- `packages/coding-agent/src/modes/controllers/extension-ui-controller.ts`
- `packages/coding-agent/test/modes/utils/injected-user-submission.test.ts` (new)
- `packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts`
