### PR TITLE
fix(notifications): suppress dot-only Telegram completion messages

### DIFF
--- a/packages/coding-agent/src/notifications/threaded-render.ts
+++ b/packages/coding-agent/src/notifications/threaded-render.ts
@@ -75,6 +75,10 @@ function str(v: unknown): string | undefined {
 	return typeof v === "string" && v.length > 0 ? v : undefined;
 }
 
+function isDotOnlyText(value: string): boolean {
+	return /^[.\s]+$/.test(value);
+}
+
 /** Format the one-time identity header as pinned bullets. */
 export function formatIdentityHeader(frame: {
 	repo?: unknown;
@@ -139,6 +143,7 @@ export function renderThreadedFrame(frame: ThreadedFrame): ThreadedSend | undefi
 		case "turn_stream": {
 			const raw = str(frame.text);
 			if (!raw) return undefined;
+			if (frame.phase === "finalized" && isDotOnlyText(raw)) return undefined;
 			const text = markdownToTelegramHtml(raw);
 			const finalized = frame.phase === "finalized";
 			// A per-turn ref ties the streamed live edits and the finalized text to

--- a/packages/coding-agent/test/notifications-threaded-render.test.ts
+++ b/packages/coding-agent/test/notifications-threaded-render.test.ts
@@ -27,6 +27,32 @@ describe("renderThreadedFrame", () => {
 		expect(send?.coalesceKey).toBeUndefined();
 	});
 
+	test("finalized turn_stream suppresses dot-only placeholders", () => {
+		expect(
+			renderThreadedFrame({ type: "turn_stream", sessionId: "s", phase: "finalized", text: "." }),
+		).toBeUndefined();
+		expect(
+			renderThreadedFrame({ type: "turn_stream", sessionId: "s", phase: "finalized", text: " . \n" }),
+		).toBeUndefined();
+		expect(
+			renderThreadedFrame({ type: "turn_stream", sessionId: "s", phase: "finalized", text: "   " }),
+		).toBeUndefined();
+	});
+
+	test("finalized turn_stream preserves meaningful completion summaries", () => {
+		const send = renderThreadedFrame({
+			type: "turn_stream",
+			sessionId: "s",
+			phase: "finalized",
+			text: "Background job completed: tests passed",
+		});
+		expect(send).toMatchObject({
+			method: "sendMessage",
+			lane: "finalized",
+			text: "Background job completed: tests passed",
+		});
+	});
+
 	test("live turn_stream uses live lane and a coalesce key from messageRef", () => {
 		const send = renderThreadedFrame({
 			type: "turn_stream",


### PR DESCRIPTION
## Summary

Fixes #1837 by suppressing finalized notification turn-stream payloads that are only placeholder dots/whitespace, while preserving meaningful completion summaries.

## Validation

- `bun test packages/coding-agent/test/notifications-threaded-render.test.ts` — 13 pass / 0 fail
- Attempted package check locally; blocked by missing local `biome` binary in this worktree, so GitHub affected-path CI is the authoritative check.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
