### PR TITLE
fix(tui): show Telegram input immediately and record it in prompt history

### DIFF
--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -24,6 +24,7 @@ import { isSilentAbort, readPendingDisplayTag } from "../../session/messages";
 import type { ResolveToolDetails } from "../../tools/resolve";
 import { interruptHint } from "../shared";
 import { buildAbortDisplayMessage } from "../utils/abort-message";
+import { consumeInjectedOptimisticSignature } from "../utils/injected-user-submission";
 import { ringTerminalBell } from "../utils/terminal-bell";
 import { argsWithPartialJson } from "../utils/ui-helpers";
 
@@ -292,12 +293,17 @@ export class EventController {
 			const signature = `${textContent}\u0000${imageCount}`;
 
 			this.#resetReadGroup();
-			const wasOptimistic = this.ctx.optimisticUserMessageSignature === signature;
+			const wasSingleOptimistic = this.ctx.optimisticUserMessageSignature === signature;
+			const wasInjectedOptimistic = !wasSingleOptimistic && consumeInjectedOptimisticSignature(this.ctx, signature);
+			const wasOptimistic = wasSingleOptimistic || wasInjectedOptimistic;
 			const wasLocallySubmitted = this.ctx.locallySubmittedUserSignatures.delete(signature) || wasOptimistic;
 			if (!wasOptimistic) {
 				this.ctx.addMessageToChat(event.message);
 			}
-			if (wasOptimistic) {
+			// Only clear the single local slot when IT matched; an injected match is
+			// consumed from the counting Map above and must not clobber a coexisting
+			// pending local optimistic signature.
+			if (wasSingleOptimistic) {
 				this.ctx.optimisticUserMessageSignature = undefined;
 			}
 

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -23,6 +23,7 @@ import { HookSelectorComponent } from "../../modes/components/hook-selector";
 import { getAvailableThemesWithPaths, getThemeByName, setTheme, type Theme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext } from "../../modes/types";
 import { setSessionTerminalTitle, setTerminalTitle } from "../../utils/title-generator";
+import { applyInjectedUserSubmission } from "../utils/injected-user-submission";
 import { classifyHookSelectorBellEvent, ringTerminalBell } from "../utils/terminal-bell";
 
 const MAX_WIDGET_LINES = 10;
@@ -954,7 +955,13 @@ export class ExtensionUiController {
 	}
 
 	#sendExtensionUserMessage: SendUserMessageHandler = (content, options) => {
-		this.ctx.session.sendUserMessage(content, options).catch((err: unknown) => {
+		// Compute queued BEFORE send: prompt() may flip session.isStreaming synchronously.
+		const queued = Boolean(options?.deliverAs) || this.ctx.session.isStreaming;
+		// Call send first so the busy/queued path finds the session queue populated
+		// (queueSteer/queueFollowUp push synchronously) before refreshing pending display.
+		const send = this.ctx.session.sendUserMessage(content, options);
+		applyInjectedUserSubmission(this.ctx, { content, queued });
+		send.catch((err: unknown) => {
 			this.ctx.showError(`Extension sendUserMessage failed: ${err instanceof Error ? err.message : String(err)}`);
 		});
 	};

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -330,6 +330,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	onInputCallback?: (input: SubmittedUserInput) => void;
 	optimisticUserMessageSignature: string | undefined = undefined;
 	locallySubmittedUserSignatures: Set<string> = new Set();
+	optimisticInjectedSignatures: Map<string, number> = new Map();
 	#pendingSubmittedInput: SubmittedUserInput | undefined;
 	#pendingSubmissionDispose: (() => void) | undefined;
 	lastSigintTime = 0;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -116,6 +116,7 @@ export interface InteractiveModeContext {
 	onInputCallback?: (input: SubmittedUserInput) => void;
 	optimisticUserMessageSignature: string | undefined;
 	locallySubmittedUserSignatures: Set<string>;
+	optimisticInjectedSignatures: Map<string, number>;
 	lastSigintTime: number;
 	lastEscapeTime: number;
 	lastComposerClearEscapeTime: number;

--- a/packages/coding-agent/src/modes/utils/injected-user-submission.ts
+++ b/packages/coding-agent/src/modes/utils/injected-user-submission.ts
@@ -1,0 +1,70 @@
+import type { ImageContent, TextContent } from "@gajae-code/ai";
+import type { InteractiveModeContext } from "../types";
+
+/**
+ * Normalize the content passed to an extension `sendUserMessage` call into a
+ * plain text string plus its image attachments. Mirrors the normalization in
+ * `AgentSession.sendUserMessage` (text parts joined with "\n") so the resulting
+ * text matches the eventual user `message_start` payload.
+ */
+export function normalizeInjectedUserContent(content: string | (TextContent | ImageContent)[]): {
+	text: string;
+	images: ImageContent[];
+	imageCount: number;
+} {
+	if (typeof content === "string") {
+		return { text: content, images: [], imageCount: 0 };
+	}
+	const textParts: string[] = [];
+	const images: ImageContent[] = [];
+	for (const part of content) {
+		if (part.type === "text") textParts.push(part.text);
+		else images.push(part);
+	}
+	const text = textParts.join("\n");
+	return { text, images, imageCount: images.length };
+}
+
+/**
+ * Record a remotely/programmatically injected user message (e.g. Telegram
+ * inbound routed through the extension API) into the interactive TUI, so it is
+ * captured in prompt history and shown immediately instead of only appearing
+ * once the eventual `message_start` event lands.
+ *
+ * Local TUI submissions never reach this path (they go through
+ * `session.prompt(...)` / `startPendingSubmission`), so this cannot double-add
+ * local prompt history.
+ *
+ * - Always adds the injected text to editor prompt history.
+ * - Idle injections optimistically render the user message and set
+ *   `optimisticUserMessageSignature`; the later user `message_start` recognizes
+ *   the signature and skips both the duplicate chat add and the defensive
+ *   editor clear (so a locally typed draft is preserved).
+ * - Busy/queued injections refresh the pending-message display, which the
+ *   caller has already populated by invoking `session.sendUserMessage(...)`
+ *   before this helper.
+ *
+ * This helper never clears the editor text.
+ */
+export function applyInjectedUserSubmission(
+	ctx: InteractiveModeContext,
+	input: { content: string | (TextContent | ImageContent)[]; queued: boolean },
+): void {
+	const { text, images, imageCount } = normalizeInjectedUserContent(input.content);
+	ctx.editor.addToHistory(text);
+
+	if (input.queued) {
+		ctx.updatePendingMessagesDisplay();
+		ctx.ui.requestRender();
+		return;
+	}
+
+	ctx.optimisticUserMessageSignature = `${text}\u0000${imageCount}`;
+	ctx.addMessageToChat({
+		role: "user",
+		content: [{ type: "text", text }, ...images],
+		attribution: "user",
+		timestamp: Date.now(),
+	});
+	ctx.ui.requestRender();
+}

--- a/packages/coding-agent/src/modes/utils/injected-user-submission.ts
+++ b/packages/coding-agent/src/modes/utils/injected-user-submission.ts
@@ -36,10 +36,11 @@ export function normalizeInjectedUserContent(content: string | (TextContent | Im
  * local prompt history.
  *
  * - Always adds the injected text to editor prompt history.
- * - Idle injections optimistically render the user message and set
- *   `optimisticUserMessageSignature`; the later user `message_start` recognizes
- *   the signature and skips both the duplicate chat add and the defensive
- *   editor clear (so a locally typed draft is preserved).
+ * - Idle injections optimistically render the user message and record a pending
+ *   injected optimistic signature (a counting Map, so multiple idle injections
+ *   before the first `message_start` do not clobber each other); the later user
+ *   `message_start` consumes one count and skips both the duplicate chat add and
+ *   the defensive editor clear (so a locally typed draft is preserved).
  * - Busy/queued injections refresh the pending-message display, which the
  *   caller has already populated by invoking `session.sendUserMessage(...)`
  *   before this helper.
@@ -59,7 +60,7 @@ export function applyInjectedUserSubmission(
 		return;
 	}
 
-	ctx.optimisticUserMessageSignature = `${text}\u0000${imageCount}`;
+	incrementInjectedOptimisticSignature(ctx, `${text}\u0000${imageCount}`);
 	ctx.addMessageToChat({
 		role: "user",
 		content: [{ type: "text", text }, ...images],
@@ -67,4 +68,27 @@ export function applyInjectedUserSubmission(
 		timestamp: Date.now(),
 	});
 	ctx.ui.requestRender();
+}
+
+/**
+ * Record one pending optimistic render for an injected user message.
+ *
+ * Injected sends are fire-and-forget and multiple idle injections can be
+ * rendered before the first `message_start` arrives, so a counting Map (not a
+ * single slot) tracks how many optimistic renders are outstanding per signature.
+ */
+export function incrementInjectedOptimisticSignature(ctx: InteractiveModeContext, signature: string): void {
+	ctx.optimisticInjectedSignatures.set(signature, (ctx.optimisticInjectedSignatures.get(signature) ?? 0) + 1);
+}
+
+/**
+ * Consume one pending injected optimistic render for `signature`. Decrements the
+ * count (deleting the key at zero) and returns whether one was outstanding.
+ */
+export function consumeInjectedOptimisticSignature(ctx: InteractiveModeContext, signature: string): boolean {
+	const count = ctx.optimisticInjectedSignatures.get(signature) ?? 0;
+	if (count <= 0) return false;
+	if (count === 1) ctx.optimisticInjectedSignatures.delete(signature);
+	else ctx.optimisticInjectedSignatures.set(signature, count - 1);
+	return true;
 }

--- a/packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
@@ -118,6 +118,27 @@ describe("EventController message_start (user role)", () => {
 		expect(setText).not.toHaveBeenCalled();
 		expect(ctx.optimisticUserMessageSignature).toBeUndefined();
 	});
+
+	it("skips the duplicate add and preserves the draft for an optimistic-only injected message", async () => {
+		// Injected (e.g. Telegram) messages set ONLY optimisticUserMessageSignature via
+		// applyInjectedUserSubmission. Since wasLocallySubmitted derives from `|| wasOptimistic`,
+		// message_start must skip the duplicate chat add, must NOT clear the local draft, and
+		// must consume the optimistic signature.
+		const message = createUserMessage("remote injected");
+		const signature = "remote injected\u00000";
+		const { ctx, editor, setText, addMessageToChat } = createContext({
+			editorText: "local draft in progress",
+			optimisticSignature: signature,
+		});
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent({ type: "message_start", message });
+
+		expect(addMessageToChat).not.toHaveBeenCalled();
+		expect(setText).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("local draft in progress");
+		expect(ctx.optimisticUserMessageSignature).toBeUndefined();
+	});
 });
 
 function createIrcMessage(timestamp: number): CustomMessage<{ from: string; message: string }> {

--- a/packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
@@ -24,6 +24,7 @@ function createContext(options: {
 	editorText: string;
 	optimisticSignature?: string;
 	locallySubmittedSignatures?: string[];
+	injectedSignatures?: Array<[string, number]>;
 }) {
 	let currentEditorText = options.editorText;
 	const setText = vi.fn((text: string) => {
@@ -52,6 +53,7 @@ function createContext(options: {
 						.join(""),
 		optimisticUserMessageSignature: options.optimisticSignature,
 		locallySubmittedUserSignatures: new Set<string>(options.locallySubmittedSignatures ?? []),
+		optimisticInjectedSignatures: new Map<string, number>(options.injectedSignatures ?? []),
 	} as unknown as InteractiveModeContext;
 	return { ctx, editor, setText, addMessageToChat, updatePendingMessagesDisplay };
 }
@@ -119,16 +121,35 @@ describe("EventController message_start (user role)", () => {
 		expect(ctx.optimisticUserMessageSignature).toBeUndefined();
 	});
 
-	it("skips the duplicate add and preserves the draft for an optimistic-only injected message", async () => {
-		// Injected (e.g. Telegram) messages set ONLY optimisticUserMessageSignature via
-		// applyInjectedUserSubmission. Since wasLocallySubmitted derives from `|| wasOptimistic`,
-		// message_start must skip the duplicate chat add, must NOT clear the local draft, and
-		// must consume the optimistic signature.
+	it("prefers local optimistic slot over matching injected map entry", async () => {
+		const message = createUserMessage("coexisting optimistic");
+		const signature = "coexisting optimistic\u00000";
+		const { ctx, setText, addMessageToChat } = createContext({
+			editorText: "",
+			optimisticSignature: signature,
+			locallySubmittedSignatures: [signature],
+			injectedSignatures: [[signature, 1]],
+		});
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent({ type: "message_start", message });
+
+		expect(addMessageToChat).not.toHaveBeenCalled();
+		expect(setText).not.toHaveBeenCalled();
+		expect(ctx.optimisticUserMessageSignature).toBeUndefined();
+		expect(ctx.optimisticInjectedSignatures.get(signature)).toBe(1);
+		expect(ctx.optimisticInjectedSignatures.size).toBe(1);
+	});
+
+	it("consumes a pending injected optimistic signature and preserves the draft", async () => {
+		// Injected (e.g. Telegram) messages record a pending injected optimistic signature
+		// (counting Map) via applyInjectedUserSubmission. message_start must consume it,
+		// skip the duplicate chat add, and NOT clear the local draft.
 		const message = createUserMessage("remote injected");
 		const signature = "remote injected\u00000";
 		const { ctx, editor, setText, addMessageToChat } = createContext({
 			editorText: "local draft in progress",
-			optimisticSignature: signature,
+			injectedSignatures: [[signature, 1]],
 		});
 		const controller = new EventController(ctx);
 
@@ -137,7 +158,59 @@ describe("EventController message_start (user role)", () => {
 		expect(addMessageToChat).not.toHaveBeenCalled();
 		expect(setText).not.toHaveBeenCalled();
 		expect(editor.getText()).toBe("local draft in progress");
-		expect(ctx.optimisticUserMessageSignature).toBeUndefined();
+		expect(ctx.optimisticInjectedSignatures.size).toBe(0);
+	});
+
+	it("de-dupes two back-to-back idle injections without duplicating chat or clearing the draft", async () => {
+		// Regression for the single-slot race: two idle injections were optimistically
+		// rendered before the first message_start; with a single slot the first message_start
+		// re-added a duplicate bubble and cleared the draft. The counting Map fixes this.
+		const first = createUserMessage("first remote");
+		const second = createUserMessage("second remote");
+		const { ctx, editor, setText, addMessageToChat } = createContext({
+			editorText: "local draft in progress",
+			injectedSignatures: [
+				["first remote\u00000", 1],
+				["second remote\u00000", 1],
+			],
+		});
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent({ type: "message_start", message: first });
+		await controller.handleEvent({ type: "message_start", message: second });
+
+		// Neither injected message_start re-adds a bubble (both were rendered optimistically).
+		expect(addMessageToChat).not.toHaveBeenCalled();
+		// The local draft is never cleared by either injected message_start.
+		expect(setText).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("local draft in progress");
+		// Both pending injected signatures are fully consumed.
+		expect(ctx.optimisticInjectedSignatures.size).toBe(0);
+	});
+
+	it("consumes only the injected map and leaves a coexisting local optimistic slot untouched", async () => {
+		// Coexistence guard: a local optimistic submission is pending (single slot) while an
+		// injected message with a DIFFERENT signature arrives. The injected message_start must
+		// consume only the injected map entry and must NOT clear the unrelated local slot.
+		const injectedMessage = createUserMessage("remote injected");
+		const injectedSignature = "remote injected\u00000";
+		const localSignature = "local pending\u00000";
+		const { ctx, editor, setText, addMessageToChat } = createContext({
+			editorText: "local draft in progress",
+			optimisticSignature: localSignature,
+			injectedSignatures: [[injectedSignature, 1]],
+		});
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent({ type: "message_start", message: injectedMessage });
+
+		expect(addMessageToChat).not.toHaveBeenCalled();
+		expect(setText).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("local draft in progress");
+		// The local optimistic slot is NOT cleared by the injected match.
+		expect(ctx.optimisticUserMessageSignature).toBe(localSignature);
+		// The injected entry is consumed.
+		expect(ctx.optimisticInjectedSignatures.size).toBe(0);
 	});
 });
 

--- a/packages/coding-agent/test/modes/utils/injected-user-submission.test.ts
+++ b/packages/coding-agent/test/modes/utils/injected-user-submission.test.ts
@@ -3,6 +3,8 @@ import type { ImageContent, TextContent } from "@gajae-code/ai";
 import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
 import {
 	applyInjectedUserSubmission,
+	consumeInjectedOptimisticSignature,
+	incrementInjectedOptimisticSignature,
 	normalizeInjectedUserContent,
 } from "@gajae-code/coding-agent/modes/utils/injected-user-submission";
 
@@ -12,14 +14,24 @@ function createContext() {
 	const addMessageToChat = vi.fn();
 	const updatePendingMessagesDisplay = vi.fn();
 	const requestRender = vi.fn();
+	const optimisticInjectedSignatures = new Map<string, number>();
 	const ctx = {
 		editor: { addToHistory, setText },
 		addMessageToChat,
 		updatePendingMessagesDisplay,
 		ui: { requestRender },
 		optimisticUserMessageSignature: undefined,
+		optimisticInjectedSignatures,
 	} as unknown as InteractiveModeContext;
-	return { ctx, addToHistory, setText, addMessageToChat, updatePendingMessagesDisplay, requestRender };
+	return {
+		ctx,
+		addToHistory,
+		setText,
+		addMessageToChat,
+		updatePendingMessagesDisplay,
+		requestRender,
+		optimisticInjectedSignatures,
+	};
 }
 
 const image: ImageContent = { type: "image", data: "AAAA", mimeType: "image/png" };
@@ -70,16 +82,47 @@ describe("normalizeInjectedUserContent", () => {
 	});
 });
 
+describe("injected optimistic signature counting", () => {
+	it("increments and consumes with multiplicity, deleting the key at zero", () => {
+		const { ctx, optimisticInjectedSignatures } = createContext();
+		const sig = "dup\u00000";
+
+		expect(consumeInjectedOptimisticSignature(ctx, sig)).toBe(false);
+
+		incrementInjectedOptimisticSignature(ctx, sig);
+		incrementInjectedOptimisticSignature(ctx, sig);
+		incrementInjectedOptimisticSignature(ctx, sig);
+		expect(optimisticInjectedSignatures.get(sig)).toBe(3);
+
+		expect(consumeInjectedOptimisticSignature(ctx, sig)).toBe(true);
+		expect(optimisticInjectedSignatures.get(sig)).toBe(2);
+		expect(consumeInjectedOptimisticSignature(ctx, sig)).toBe(true);
+		expect(optimisticInjectedSignatures.get(sig)).toBe(1);
+		expect(consumeInjectedOptimisticSignature(ctx, sig)).toBe(true);
+		expect(optimisticInjectedSignatures.has(sig)).toBe(false);
+	});
+});
+
 describe("applyInjectedUserSubmission", () => {
 	it("records history and renders optimistically for an idle injection", () => {
-		const { ctx, addToHistory, setText, addMessageToChat, updatePendingMessagesDisplay, requestRender } =
-			createContext();
+		const {
+			ctx,
+			addToHistory,
+			setText,
+			addMessageToChat,
+			updatePendingMessagesDisplay,
+			requestRender,
+			optimisticInjectedSignatures,
+		} = createContext();
 
 		applyInjectedUserSubmission(ctx, { content: "idle telegram prompt", queued: false });
 
 		expect(addToHistory).toHaveBeenCalledTimes(1);
 		expect(addToHistory).toHaveBeenCalledWith("idle telegram prompt");
-		expect(ctx.optimisticUserMessageSignature).toBe("idle telegram prompt\u00000");
+		// Idle injections record a pending injected optimistic signature in the counting
+		// Map, leaving the single local slot untouched.
+		expect(optimisticInjectedSignatures.get("idle telegram prompt\u00000")).toBe(1);
+		expect(ctx.optimisticUserMessageSignature).toBeUndefined();
 		expect(addMessageToChat).toHaveBeenCalledTimes(1);
 		expect(addMessageToChat.mock.calls[0][0]).toMatchObject({
 			role: "user",
@@ -92,14 +135,22 @@ describe("applyInjectedUserSubmission", () => {
 		expect(updatePendingMessagesDisplay).not.toHaveBeenCalled();
 	});
 	it("records image-only idle injection without clearing the editor", () => {
-		const { ctx, addToHistory, setText, addMessageToChat, updatePendingMessagesDisplay } = createContext();
+		const {
+			ctx,
+			addToHistory,
+			setText,
+			addMessageToChat,
+			updatePendingMessagesDisplay,
+			optimisticInjectedSignatures,
+		} = createContext();
 
 		applyInjectedUserSubmission(ctx, { content: [image], queued: false });
 
 		expect(addToHistory).toHaveBeenCalledTimes(1);
 		expect(addToHistory).toHaveBeenCalledWith("");
 		// imageCount is 1, matching EventController's signature (event-controller.ts:288-292).
-		expect(ctx.optimisticUserMessageSignature).toBe("\u00001");
+		expect(optimisticInjectedSignatures.get("\u00001")).toBe(1);
+		expect(ctx.optimisticUserMessageSignature).toBeUndefined();
 		expect(addMessageToChat).toHaveBeenCalledTimes(1);
 		expect(addMessageToChat.mock.calls[0][0]).toMatchObject({
 			role: "user",
@@ -111,8 +162,15 @@ describe("applyInjectedUserSubmission", () => {
 	});
 
 	it("records history and refreshes pending display only for a busy/queued injection", () => {
-		const { ctx, addToHistory, setText, addMessageToChat, updatePendingMessagesDisplay, requestRender } =
-			createContext();
+		const {
+			ctx,
+			addToHistory,
+			setText,
+			addMessageToChat,
+			updatePendingMessagesDisplay,
+			requestRender,
+			optimisticInjectedSignatures,
+		} = createContext();
 
 		applyInjectedUserSubmission(ctx, { content: "busy telegram prompt", queued: true });
 
@@ -120,8 +178,9 @@ describe("applyInjectedUserSubmission", () => {
 		expect(addToHistory).toHaveBeenCalledWith("busy telegram prompt");
 		expect(updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
 		expect(requestRender).toHaveBeenCalled();
-		// Queued injection must not optimistically render, set a signature, or clear the editor.
+		// Queued injection must not optimistically render, record a signature, or clear the editor.
 		expect(addMessageToChat).not.toHaveBeenCalled();
+		expect(optimisticInjectedSignatures.size).toBe(0);
 		expect(ctx.optimisticUserMessageSignature).toBeUndefined();
 		expect(setText).not.toHaveBeenCalled();
 	});

--- a/packages/coding-agent/test/modes/utils/injected-user-submission.test.ts
+++ b/packages/coding-agent/test/modes/utils/injected-user-submission.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { ImageContent, TextContent } from "@gajae-code/ai";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import {
+	applyInjectedUserSubmission,
+	normalizeInjectedUserContent,
+} from "@gajae-code/coding-agent/modes/utils/injected-user-submission";
+
+function createContext() {
+	const addToHistory = vi.fn();
+	const setText = vi.fn();
+	const addMessageToChat = vi.fn();
+	const updatePendingMessagesDisplay = vi.fn();
+	const requestRender = vi.fn();
+	const ctx = {
+		editor: { addToHistory, setText },
+		addMessageToChat,
+		updatePendingMessagesDisplay,
+		ui: { requestRender },
+		optimisticUserMessageSignature: undefined,
+	} as unknown as InteractiveModeContext;
+	return { ctx, addToHistory, setText, addMessageToChat, updatePendingMessagesDisplay, requestRender };
+}
+
+const image: ImageContent = { type: "image", data: "AAAA", mimeType: "image/png" };
+
+describe("normalizeInjectedUserContent", () => {
+	it("returns string content unchanged with no images", () => {
+		expect(normalizeInjectedUserContent("hello from telegram")).toEqual({
+			text: "hello from telegram",
+			images: [],
+			imageCount: 0,
+		});
+	});
+
+	it("joins text parts with newlines and collects images from array content", () => {
+		const content: (TextContent | ImageContent)[] = [
+			{ type: "text", text: "line one" },
+			image,
+			{ type: "text", text: "line two" },
+		];
+		expect(normalizeInjectedUserContent(content)).toEqual({
+			text: "line one\nline two",
+			images: [image],
+			imageCount: 1,
+		});
+	});
+	it("keeps image-only content as empty text with image count", () => {
+		expect(normalizeInjectedUserContent([image])).toEqual({
+			text: "",
+			images: [image],
+			imageCount: 1,
+		});
+	});
+
+	it("joins multiple text parts and counts multiple images", () => {
+		const secondImage: ImageContent = { type: "image", data: "BBBB", mimeType: "image/jpeg" };
+		const content: (TextContent | ImageContent)[] = [
+			{ type: "text", text: "line one" },
+			image,
+			{ type: "text", text: "line two" },
+			secondImage,
+		];
+
+		expect(normalizeInjectedUserContent(content)).toEqual({
+			text: "line one\nline two",
+			images: [image, secondImage],
+			imageCount: 2,
+		});
+	});
+});
+
+describe("applyInjectedUserSubmission", () => {
+	it("records history and renders optimistically for an idle injection", () => {
+		const { ctx, addToHistory, setText, addMessageToChat, updatePendingMessagesDisplay, requestRender } =
+			createContext();
+
+		applyInjectedUserSubmission(ctx, { content: "idle telegram prompt", queued: false });
+
+		expect(addToHistory).toHaveBeenCalledTimes(1);
+		expect(addToHistory).toHaveBeenCalledWith("idle telegram prompt");
+		expect(ctx.optimisticUserMessageSignature).toBe("idle telegram prompt\u00000");
+		expect(addMessageToChat).toHaveBeenCalledTimes(1);
+		expect(addMessageToChat.mock.calls[0][0]).toMatchObject({
+			role: "user",
+			content: [{ type: "text", text: "idle telegram prompt" }],
+			attribution: "user",
+		});
+		expect(requestRender).toHaveBeenCalled();
+		// Idle injection must not clear the editor draft or touch the pending list.
+		expect(setText).not.toHaveBeenCalled();
+		expect(updatePendingMessagesDisplay).not.toHaveBeenCalled();
+	});
+	it("records image-only idle injection without clearing the editor", () => {
+		const { ctx, addToHistory, setText, addMessageToChat, updatePendingMessagesDisplay } = createContext();
+
+		applyInjectedUserSubmission(ctx, { content: [image], queued: false });
+
+		expect(addToHistory).toHaveBeenCalledTimes(1);
+		expect(addToHistory).toHaveBeenCalledWith("");
+		// imageCount is 1, matching EventController's signature (event-controller.ts:288-292).
+		expect(ctx.optimisticUserMessageSignature).toBe("\u00001");
+		expect(addMessageToChat).toHaveBeenCalledTimes(1);
+		expect(addMessageToChat.mock.calls[0][0]).toMatchObject({
+			role: "user",
+			content: [{ type: "text", text: "" }, image],
+			attribution: "user",
+		});
+		expect(setText).not.toHaveBeenCalled();
+		expect(updatePendingMessagesDisplay).not.toHaveBeenCalled();
+	});
+
+	it("records history and refreshes pending display only for a busy/queued injection", () => {
+		const { ctx, addToHistory, setText, addMessageToChat, updatePendingMessagesDisplay, requestRender } =
+			createContext();
+
+		applyInjectedUserSubmission(ctx, { content: "busy telegram prompt", queued: true });
+
+		expect(addToHistory).toHaveBeenCalledTimes(1);
+		expect(addToHistory).toHaveBeenCalledWith("busy telegram prompt");
+		expect(updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+		expect(requestRender).toHaveBeenCalled();
+		// Queued injection must not optimistically render, set a signature, or clear the editor.
+		expect(addMessageToChat).not.toHaveBeenCalled();
+		expect(ctx.optimisticUserMessageSignature).toBeUndefined();
+		expect(setText).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Supersedes #1838 (closed). This re-submits the Telegram→TUI fix with the requested review change applied.

## Summary

Two TUI bugs for Telegram (and other extension-injected) input:

1. **Not recorded in prompt history** — messages sent from Telegram were not added to the TUI prompt history (up/down navigation, Ctrl-R search, backed by the `HistoryStorage` sqlite store).
2. **Not immediately visible** — messages sent from Telegram only appeared once the turn reached `message_start`, not right away.

## Root cause

Local TUI input goes through `session.prompt()`, which records history (`editor.addToHistory`) and renders optimistically via `startPendingSubmission`. Telegram inbound instead flows through the notifications extension API `sendUserMessage` → `ExtensionUiController.#sendExtensionUserMessage` → `session.sendUserMessage(...)`, which did neither.

## Fix

A small utility `applyInjectedUserSubmission` at the extension-injection boundary, invoked from `#sendExtensionUserMessage`:

- Always record injected text via `editor.addToHistory(text)` → history + Ctrl-R search.
- **Idle** injection: render immediately via `addMessageToChat` and track a pending optimistic signature; the later `message_start` consumes it and skips both the duplicate render and the `setText("")` that would clear the draft.
- **Busy/queued** injection: refresh the pending chip after `session.sendUserMessage(...)` has synchronously populated the queue.
- Never calls `editor.setText`, so an in-progress local draft is preserved.

Local submissions never traverse this helper, so there is no history double-add. Remote text is unexpanded (`expandPromptTemplates: false`), so the optimistic signature `${text}\u0000${imageCount}` matches the eventual `message_start` (including image-only messages). RPC/ACP/background modes have no TUI editor and are out of scope. Other extensions that use `sendUserMessage` (autoresearch/reload-runtime) get the same treatment — intentionally accepted, since there is no separate origin flag.

## Review follow-up addressed (the reason #1838 requested changes)

The reviewer noted the optimistic de-dup used a **single** `ctx.optimisticUserMessageSignature`: because `#sendExtensionUserMessage` is fire-and-forget and `session.isStreaming` doesn't flip synchronously, **two back-to-back idle injections before the first `message_start`** overwrote each other's signature, causing a duplicate bubble + cleared draft.

Fixed in `ce8bd0c5` with a **counting Map** `optimisticInjectedSignatures: Map<string, number>`:
- `applyInjectedUserSubmission` idle → `incrementInjectedOptimisticSignature(ctx, sig)`.
- `EventController#handleMessageStart` consumes one count per matching `message_start` via `!wasSingleOptimistic && consumeInjectedOptimisticSignature(...)`.
- The single-slot clear stays gated on `wasSingleOptimistic`, so a coexisting **local** optimistic signature is never wrongly cleared/consumed. The local path (`startPendingSubmission`) is unchanged. A counting Map also handles **identical** back-to-back injected messages.

## Tests

```
bun test packages/coding-agent/test/modes/utils/injected-user-submission.test.ts \
         packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
# 18 pass / 0 fail
```

- `normalizeInjectedUserContent`: string / array (multi-text, multi-image) / image-only.
- `applyInjectedUserSubmission`: idle (history + optimistic render, no `setText`/pending), busy (history + pending, no render), image-only idle (signature encodes `imageCount`).
- Counting-helper multiplicity (increment ×3 / consume ×3, identical-duplicate, absent → `false`).
- `EventController` `message_start`: injected consumption preserves the draft; **two back-to-back idle injections** → no duplicate add, draft preserved, map consumed; **local/injected coexistence** (different sig consumes only the map; same-sig collision consumes the local slot only).

`biome@2.5.2 check` and `tsgo` are clean on the changed files.

## Changed files

- `packages/coding-agent/src/modes/utils/injected-user-submission.ts` (new)
- `packages/coding-agent/src/modes/controllers/extension-ui-controller.ts`
- `packages/coding-agent/src/modes/controllers/event-controller.ts`
- `packages/coding-agent/src/modes/types.ts`
- `packages/coding-agent/src/modes/interactive-mode.ts`
- `packages/coding-agent/test/modes/utils/injected-user-submission.test.ts` (new)
- `packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts`
