### PR TITLE
fix: ask tool deepInterview metadata triggers phase lock without active skill check

### DIFF
--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -581,6 +581,8 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 	): Promise<void> {
 		const meta = q.deepInterview;
 		if (!meta) return;
+		const activeSkill = this.session.getActiveSkillState?.()?.skill?.trim();
+		if (activeSkill !== "deep-interview") return;
 		const cwd = this.session.cwd;
 		const sessionId = this.session.getSessionId?.() ?? undefined;
 		const statePath = deepInterviewStatePath(cwd, sessionId);
@@ -745,8 +747,10 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 				};
 			}
 			try {
-				const deepInterviewPrompt = formatDeepInterviewSelectorPrompt(q.question);
-				const isDeepInterviewQuestion = deepInterviewPrompt !== null || q.deepInterview !== undefined;
+			const deepInterviewPrompt = formatDeepInterviewSelectorPrompt(q.question);
+			const activeSkill = this.session.getActiveSkillState?.()?.skill?.trim();
+			const isDeepInterviewActive = activeSkill === "deep-interview";
+			const isDeepInterviewQuestion = isDeepInterviewActive && (deepInterviewPrompt !== null || q.deepInterview !== undefined);
 				const displayQuestion = deepInterviewPrompt ?? q.question;
 				const shouldNumberOptions = isDeepInterviewQuestion || isDeepInterviewAskQuestion(q.question);
 				const optionLabels = shouldNumberOptions ? numberOptionLabels(rawOptionLabels) : rawOptionLabels;


### PR DESCRIPTION
## Problem

Calling `ask` tool with `deepInterview` metadata accidentally triggers the deep-interview workflow, locking the phase to `interviewing` and blocking all code mutations. This happens even when deep-interview is not the active skill.

## Reproduction (2026-07-08)

1. Call `ask` with `deepInterview` metadata on a regular question (not in a deep-interview session)
2. GJC interprets it as deep-interview workflow trigger  
3. Phase locks to `interviewing` → all mutations blocked
4. Escape: `gjc state deep-interview write --input '{"current_phase":"complete"}' --json`

## Root Cause

`packages/coding-agent/src/tools/ask.ts`:

- Line 749: `isDeepInterviewQuestion = deepInterviewPrompt !== null || q.deepInterview !== undefined` — does NOT verify deep-interview is the active skill
- `#recordDeepInterviewRound`: writes to deep-interview state unconditionally on metadata presence

## Fix

Add active skill guard in two places, following the existing `assertUltragoalAskAllowed` pattern:

1. `isDeepInterviewQuestion` (L749): only treat metadata as deep-interview when `activeSkill === 'deep-interview'`
2. `#recordDeepInterviewRound` (L583): skip state recording when deep-interview is not active

## Prior Occurrences

This bug has been encountered 2+ times in real GJC sessions (documented in user wiki `deep-interview-gotchas.md`).