### PR TITLE
Add runtime skill discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,9 @@
 ### Changed
 
 - Upgraded the Extragoal review template with a stronger reviewer lane and optional maximalist N-of-N review recipe.
+- Added `--mpreset <profile>` option to the Telegram `/session_create` command, allowing users to specify a model profile preset when creating a session remotely (e.g. `/session_create path /repo --mpreset codex-eco`). Both `--mpreset <name>` and `--mpreset=<name>` forms are supported. The preset is passed as a regular `--mpreset` CLI flag to the spawned `gjc` child, where the existing `applyStartupModelProfiles` flow activates it.
+- Added the built-in `skill_discovery` tool for runtime discovery of custom project `.gjc/skills` and user `~/.gjc/skills` without injecting the full skill catalog into the core prompt; selected discovered skills are loaded narrowly through the existing `skill` invocation path (#1815).
+- Pasting or drag-dropping a path to any existing image file into the interactive editor now attaches the image and inserts an `[image N]` placeholder instead of leaving the raw path in the prompt. Previously this only worked for clipboard temp files (`/tmp/clipboard-*` or `/var/folders/xx/yy/T/clipboard-*`); terminal drag-drop paths — including shell-escaped spaces and the U+202F narrow no-break space in macOS screenshot names — pasted as long raw path text. Quoted paths, `file://` URIs (decoded via Node's `fileURLToPath` semantics, including Windows drive-letter, `file://localhost`, and UNC forms), and `~/` expansion are handled; the whole paste must be a single path to an existing image file whose content carries a supported image signature (PNG/JPEG/GIF/WEBP), so prose containing paths and non-image files with image-looking extensions are inserted unchanged. When attachment still fails (unsupported content, oversized image, load error), the original pasted text is replayed into the editor instead of being consumed.
 
 ### Fixed
 

--- a/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
+++ b/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Skill as CapabilitySkill } from "../capability/skill";
+import type { SkillsSettings } from "../config/settings-schema";
 import { compareSkillOrder, scanSkillsFromDir } from "../discovery/helpers";
 import type { Skill } from "./skills";
 
@@ -21,6 +22,7 @@ export interface DiscoverRuntimeSkillsOptions {
 	query?: string;
 	limit?: number;
 	source?: RuntimeSkillDiscoverySource | "all";
+	policy?: SkillsSettings;
 }
 
 function getRuntimeHome(): string {
@@ -77,7 +79,38 @@ function toRuntimeSkill(skill: CapabilitySkill, source: RuntimeSkillDiscoverySou
 		_source: { ...skill._source, providerName: "Runtime skill discovery" },
 	};
 }
+function sourceEnabled(source: RuntimeSkillDiscoverySource, policy: SkillsSettings | undefined): boolean {
+	if (policy?.enabled !== true) return false;
+	if (source === "project") return policy.enablePiProject === true;
+	if (source === "user") return policy.enablePiUser === true;
+	return false;
+}
 
+function matchesIncludePatterns(name: string, includeSkills: string[] | undefined): boolean {
+	if (!includeSkills || includeSkills.length === 0) return true;
+	return includeSkills.some(pattern => new Bun.Glob(pattern).match(name));
+}
+
+function matchesIgnorePatterns(name: string, ignoredSkills: string[] | undefined): boolean {
+	if (!ignoredSkills || ignoredSkills.length === 0) return false;
+	return ignoredSkills.some(pattern => new Bun.Glob(pattern).match(name));
+}
+
+function isDisabledSkill(name: string, disabledExtensions: string[] | undefined): boolean {
+	return (disabledExtensions ?? []).some(id => id === `skill:${name}`);
+}
+
+function isAllowedByPolicy(
+	skill: CapabilitySkill,
+	source: RuntimeSkillDiscoverySource,
+	policy: SkillsSettings | undefined,
+): boolean {
+	if (!sourceEnabled(source, policy)) return false;
+	if (isDisabledSkill(skill.name, policy?.disabledExtensions)) return false;
+	if (matchesIgnorePatterns(skill.name, policy?.ignoredSkills)) return false;
+	if (!matchesIncludePatterns(skill.name, policy?.includeSkills)) return false;
+	return true;
+}
 function matchesQuery(candidate: RuntimeSkillDiscoveryCandidate, query: string): boolean {
 	const normalized = query.trim().toLowerCase();
 	if (!normalized) return true;
@@ -103,8 +136,9 @@ export async function discoverRuntimeSkills(
 ): Promise<RuntimeSkillDiscoveryCandidate[]> {
 	const home = options.home ?? getRuntimeHome();
 	const source = options.source ?? "all";
+	const policy = options.policy;
 	const scanJobs: Array<Promise<{ skill: CapabilitySkill; source: RuntimeSkillDiscoverySource }[]>> = [];
-	if (source === "all" || source === "project") {
+	if ((source === "all" || source === "project") && sourceEnabled("project", policy)) {
 		for (const dir of getProjectSkillDirs(options.cwd, home)) {
 			scanJobs.push(
 				scanSkillsFromDir(
@@ -114,7 +148,7 @@ export async function discoverRuntimeSkills(
 			);
 		}
 	}
-	if (source === "all" || source === "user") {
+	if ((source === "all" || source === "user") && sourceEnabled("user", policy)) {
 		scanJobs.push(
 			scanSkillsFromDir(
 				{ cwd: options.cwd, home, repoRoot: home },
@@ -127,6 +161,7 @@ export async function discoverRuntimeSkills(
 	const seenPaths = new Set<string>();
 	const candidates: RuntimeSkillDiscoveryCandidate[] = [];
 	for (const entry of (await Promise.all(scanJobs)).flat()) {
+		if (!isAllowedByPolicy(entry.skill, entry.source, policy)) continue;
 		const realPath = await realPathOrSelf(entry.skill.path);
 		if (seenPaths.has(realPath) || seenNames.has(entry.skill.name)) continue;
 		seenPaths.add(realPath);
@@ -148,24 +183,34 @@ export async function discoverRuntimeSkills(
 export async function findRuntimeSkillByName(
 	cwd: string,
 	name: string,
+	policy?: SkillsSettings,
 	home = getRuntimeHome(),
 ): Promise<Skill | undefined> {
 	const normalized = name.trim();
 	if (!normalized) return undefined;
-	const scanJobs = [
-		...getProjectSkillDirs(cwd, home).map(dir =>
+	const scanJobs: Array<Promise<{ skill: CapabilitySkill; source: RuntimeSkillDiscoverySource }[]>> = [];
+	if (sourceEnabled("project", policy)) {
+		scanJobs.push(
+			...getProjectSkillDirs(cwd, home).map(dir =>
+				scanSkillsFromDir(
+					{ cwd, home, repoRoot: home },
+					{ dir, providerId: "runtime", level: "project", requireDescription: true },
+				).then(result => result.items.map(skill => ({ skill, source: "project" as const }))),
+			),
+		);
+	}
+	if (sourceEnabled("user", policy)) {
+		scanJobs.push(
 			scanSkillsFromDir(
 				{ cwd, home, repoRoot: home },
-				{ dir, providerId: "runtime", level: "project", requireDescription: true },
-			).then(result => result.items.map(skill => ({ skill, source: "project" as const }))),
-		),
-		scanSkillsFromDir(
-			{ cwd, home, repoRoot: home },
-			{ dir: path.join(home, ".gjc", "skills"), providerId: "runtime", level: "user", requireDescription: true },
-		).then(result => result.items.map(skill => ({ skill, source: "user" as const }))),
-	];
+				{ dir: path.join(home, ".gjc", "skills"), providerId: "runtime", level: "user", requireDescription: true },
+			).then(result => result.items.map(skill => ({ skill, source: "user" as const }))),
+		);
+	}
 	for (const entry of (await Promise.all(scanJobs)).flat()) {
-		if (entry.skill.name === normalized) return toRuntimeSkill(entry.skill, entry.source);
+		if (entry.skill.name === normalized && isAllowedByPolicy(entry.skill, entry.source, policy)) {
+			return toRuntimeSkill(entry.skill, entry.source);
+		}
 	}
 	return undefined;
 }

--- a/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
+++ b/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
@@ -1,0 +1,171 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Skill as CapabilitySkill } from "../capability/skill";
+import { compareSkillOrder, scanSkillsFromDir } from "../discovery/helpers";
+import type { Skill } from "./skills";
+
+export type RuntimeSkillDiscoverySource = "project" | "user";
+
+export interface RuntimeSkillDiscoveryCandidate {
+	name: string;
+	description: string;
+	source: RuntimeSkillDiscoverySource;
+	path: string;
+	useWhen?: string[];
+}
+
+export interface DiscoverRuntimeSkillsOptions {
+	cwd: string;
+	home?: string;
+	query?: string;
+	limit?: number;
+	source?: RuntimeSkillDiscoverySource | "all";
+}
+
+function getRuntimeHome(): string {
+	return process.env.HOME || os.homedir();
+}
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+
+function normalizeLimit(limit: number | undefined): number {
+	if (limit === undefined || !Number.isFinite(limit)) return DEFAULT_LIMIT;
+	return Math.max(1, Math.min(MAX_LIMIT, Math.trunc(limit)));
+}
+
+function getProjectSkillDirs(cwd: string, stopAt: string): string[] {
+	const dirs: string[] = [];
+	let current = path.resolve(cwd);
+	const stop = path.resolve(stopAt);
+	while (true) {
+		dirs.push(path.join(current, ".gjc", "skills"));
+		if (current === stop) break;
+		const parent = path.dirname(current);
+		if (parent === current) break;
+		current = parent;
+	}
+	return dirs;
+}
+
+function getUseWhen(skill: CapabilitySkill): string[] | undefined {
+	const frontmatter = skill.frontmatter as Record<string, unknown> | undefined;
+	const values: string[] = [];
+	const globs = frontmatter?.globs;
+	if (Array.isArray(globs)) {
+		values.push(...globs.filter((value): value is string => typeof value === "string"));
+	} else if (typeof globs === "string") {
+		values.push(globs);
+	}
+	for (const key of ["use_when", "useWhen", "conditions"]) {
+		const raw = frontmatter?.[key];
+		if (typeof raw === "string") values.push(raw);
+		if (Array.isArray(raw)) values.push(...raw.filter((value): value is string => typeof value === "string"));
+	}
+	return values.length > 0 ? values : undefined;
+}
+
+function toRuntimeSkill(skill: CapabilitySkill, source: RuntimeSkillDiscoverySource): Skill {
+	return {
+		name: skill.name,
+		description: typeof skill.frontmatter?.description === "string" ? skill.frontmatter.description : "",
+		filePath: skill.path,
+		baseDir: skill.path.replace(/[\\/]SKILL\.md$/, ""),
+		source: `runtime:${source}`,
+		hide: skill.frontmatter?.hide === true,
+		_source: { ...skill._source, providerName: "Runtime skill discovery" },
+	};
+}
+
+function matchesQuery(candidate: RuntimeSkillDiscoveryCandidate, query: string): boolean {
+	const normalized = query.trim().toLowerCase();
+	if (!normalized) return true;
+	const haystack = [candidate.name, candidate.description, candidate.source, ...(candidate.useWhen ?? [])]
+		.join("\n")
+		.toLowerCase();
+	return normalized
+		.split(/\s+/)
+		.filter(Boolean)
+		.every(term => haystack.includes(term));
+}
+
+async function realPathOrSelf(filePath: string): Promise<string> {
+	try {
+		return await fs.realpath(filePath);
+	} catch {
+		return filePath;
+	}
+}
+
+export async function discoverRuntimeSkills(
+	options: DiscoverRuntimeSkillsOptions,
+): Promise<RuntimeSkillDiscoveryCandidate[]> {
+	const home = options.home ?? getRuntimeHome();
+	const source = options.source ?? "all";
+	const scanJobs: Array<Promise<{ skill: CapabilitySkill; source: RuntimeSkillDiscoverySource }[]>> = [];
+	if (source === "all" || source === "project") {
+		for (const dir of getProjectSkillDirs(options.cwd, home)) {
+			scanJobs.push(
+				scanSkillsFromDir(
+					{ cwd: options.cwd, home, repoRoot: home },
+					{ dir, providerId: "runtime", level: "project", requireDescription: true },
+				).then(result => result.items.map(skill => ({ skill, source: "project" as const }))),
+			);
+		}
+	}
+	if (source === "all" || source === "user") {
+		scanJobs.push(
+			scanSkillsFromDir(
+				{ cwd: options.cwd, home, repoRoot: home },
+				{ dir: path.join(home, ".gjc", "skills"), providerId: "runtime", level: "user", requireDescription: true },
+			).then(result => result.items.map(skill => ({ skill, source: "user" as const }))),
+		);
+	}
+
+	const seenNames = new Set<string>();
+	const seenPaths = new Set<string>();
+	const candidates: RuntimeSkillDiscoveryCandidate[] = [];
+	for (const entry of (await Promise.all(scanJobs)).flat()) {
+		const realPath = await realPathOrSelf(entry.skill.path);
+		if (seenPaths.has(realPath) || seenNames.has(entry.skill.name)) continue;
+		seenPaths.add(realPath);
+		seenNames.add(entry.skill.name);
+		const candidate: RuntimeSkillDiscoveryCandidate = {
+			name: entry.skill.name,
+			description:
+				typeof entry.skill.frontmatter?.description === "string" ? entry.skill.frontmatter.description : "",
+			source: entry.source,
+			path: entry.skill.path,
+			useWhen: getUseWhen(entry.skill),
+		};
+		if (matchesQuery(candidate, options.query ?? "")) candidates.push(candidate);
+	}
+	candidates.sort((a, b) => compareSkillOrder(a.name, a.path, b.name, b.path));
+	return candidates.slice(0, normalizeLimit(options.limit));
+}
+
+export async function findRuntimeSkillByName(
+	cwd: string,
+	name: string,
+	home = getRuntimeHome(),
+): Promise<Skill | undefined> {
+	const normalized = name.trim();
+	if (!normalized) return undefined;
+	const scanJobs = [
+		...getProjectSkillDirs(cwd, home).map(dir =>
+			scanSkillsFromDir(
+				{ cwd, home, repoRoot: home },
+				{ dir, providerId: "runtime", level: "project", requireDescription: true },
+			).then(result => result.items.map(skill => ({ skill, source: "project" as const }))),
+		),
+		scanSkillsFromDir(
+			{ cwd, home, repoRoot: home },
+			{ dir: path.join(home, ".gjc", "skills"), providerId: "runtime", level: "user", requireDescription: true },
+		).then(result => result.items.map(skill => ({ skill, source: "user" as const }))),
+	];
+	for (const entry of (await Promise.all(scanJobs)).flat()) {
+		if (entry.skill.name === normalized) return toRuntimeSkill(entry.skill, entry.source);
+	}
+	return undefined;
+}

--- a/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
+++ b/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { findRepoRoot } from "../capability/fs";
 import type { Skill as CapabilitySkill } from "../capability/skill";
 import type { SkillsSettings } from "../config/settings-schema";
 import { compareSkillOrder, scanSkillsFromDir } from "../discovery/helpers";
@@ -37,18 +38,22 @@ function normalizeLimit(limit: number | undefined): number {
 	return Math.max(1, Math.min(MAX_LIMIT, Math.trunc(limit)));
 }
 
-function getProjectSkillDirs(cwd: string, stopAt: string): string[] {
+async function getProjectSkillDirs(cwd: string, home: string): Promise<{ dirs: string[]; repoRoot: string | null }> {
 	const dirs: string[] = [];
 	let current = path.resolve(cwd);
-	const stop = path.resolve(stopAt);
+	const resolvedHome = path.resolve(home);
+	const repoRoot = await findRepoRoot(current);
+	const stop = path.resolve(repoRoot ?? current);
 	while (true) {
-		dirs.push(path.join(current, ".gjc", "skills"));
+		if (current !== resolvedHome) {
+			dirs.push(path.join(current, ".gjc", "skills"));
+		}
 		if (current === stop) break;
 		const parent = path.dirname(current);
 		if (parent === current) break;
 		current = parent;
 	}
-	return dirs;
+	return { dirs, repoRoot };
 }
 
 function getUseWhen(skill: CapabilitySkill): string[] | undefined {
@@ -138,13 +143,17 @@ export async function discoverRuntimeSkills(
 	const source = options.source ?? "all";
 	const policy = options.policy;
 	const scanJobs: Array<Promise<{ skill: CapabilitySkill; source: RuntimeSkillDiscoverySource }[]>> = [];
+	const projectSkills = await getProjectSkillDirs(options.cwd, home);
+	const projectContext = { cwd: options.cwd, home, repoRoot: projectSkills.repoRoot };
 	if ((source === "all" || source === "project") && sourceEnabled("project", policy)) {
-		for (const dir of getProjectSkillDirs(options.cwd, home)) {
+		for (const dir of projectSkills.dirs) {
 			scanJobs.push(
-				scanSkillsFromDir(
-					{ cwd: options.cwd, home, repoRoot: home },
-					{ dir, providerId: "runtime", level: "project", requireDescription: true },
-				).then(result => result.items.map(skill => ({ skill, source: "project" as const }))),
+				scanSkillsFromDir(projectContext, {
+					dir,
+					providerId: "runtime",
+					level: "project",
+					requireDescription: true,
+				}).then(result => result.items.map(skill => ({ skill, source: "project" as const }))),
 			);
 		}
 	}
@@ -189,13 +198,17 @@ export async function findRuntimeSkillByName(
 	const normalized = name.trim();
 	if (!normalized) return undefined;
 	const scanJobs: Array<Promise<{ skill: CapabilitySkill; source: RuntimeSkillDiscoverySource }[]>> = [];
+	const projectSkills = await getProjectSkillDirs(cwd, home);
+	const projectContext = { cwd, home, repoRoot: projectSkills.repoRoot };
 	if (sourceEnabled("project", policy)) {
 		scanJobs.push(
-			...getProjectSkillDirs(cwd, home).map(dir =>
-				scanSkillsFromDir(
-					{ cwd, home, repoRoot: home },
-					{ dir, providerId: "runtime", level: "project", requireDescription: true },
-				).then(result => result.items.map(skill => ({ skill, source: "project" as const }))),
+			...projectSkills.dirs.map(dir =>
+				scanSkillsFromDir(projectContext, {
+					dir,
+					providerId: "runtime",
+					level: "project",
+					requireDescription: true,
+				}).then(result => result.items.map(skill => ({ skill, source: "project" as const }))),
 			),
 		);
 	}

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1928,7 +1928,7 @@ export class TelegramNotificationDaemon {
 					// upstream edit/send path, so off behavior is byte-identical.
 					if (
 						shouldPromoteRich({
-							enabled: this.opts.rich?.enabled === false ? false : true,
+							enabled: this.opts.rich?.enabled !== false,
 							send,
 						})
 					) {

--- a/packages/coding-agent/src/prompts/tools/skill-discovery.md
+++ b/packages/coding-agent/src/prompts/tools/skill-discovery.md
@@ -1,0 +1,13 @@
+Discover project and user runtime skills without loading full skill content.
+
+<instruction>
+- Searches only custom runtime skill locations: project `.gjc/skills` and user `~/.gjc/skills`.
+- Built-in, bundled, and internal workflow skills are intentionally excluded.
+- Returns thin metadata only: name, description, source scope, path, and use conditions when present.
+- To load a selected skill's full `SKILL.md`, invoke it through the existing `skill` tool with the exact `name` returned here.
+</instruction>
+
+Input:
+- `query` (optional): words to match against skill name, description, source, or use conditions.
+- `source` (optional): `all`, `project`, or `user`.
+- `limit` (optional): maximum results, 1-50.

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -507,7 +507,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 				? loadSkills({ ...skillsSettings, cwd: resolvedCwd }).then(result => result.skills)
 				: Promise.resolve([]);
 
-	const [resolvedCustomPrompt, resolvedAppendPrompt, systemPromptCustomization, contextFiles, skills, workspaceTree] =
+	const [resolvedCustomPrompt, resolvedAppendPrompt, systemPromptCustomization, contextFiles, , workspaceTree] =
 		await Promise.all([
 			withDeadline(
 				"customPrompt",
@@ -581,11 +581,9 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		description: tools?.get(name)?.description ?? "",
 	}));
 
-	// Filter skills for the rendered system prompt:
-	// - require the `read` tool so the model can actually fetch skill content;
-	// - drop skills with frontmatter `hide: true` (still loadable via skill:// and /skill:<name>).
-	const hasRead = tools?.has("read");
-	const filteredSkills = hasRead ? skills.filter(skill => skill.hide !== true) : [];
+	// Runtime skills are discovered by `skill_discovery` and loaded narrowly through
+	// `skill`; do not dump the full custom skill catalog into the core prompt.
+	const filteredSkills: Skill[] = [];
 
 	const effectiveSystemPromptCustomization = dedupePromptSource(systemPromptCustomization, [
 		resolvedCustomPrompt,

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -56,6 +56,7 @@ import { reportFindingTool } from "./review";
 import { SearchTool } from "./search";
 import { SearchToolBm25Tool } from "./search-tool-bm25";
 import { SkillTool } from "./skill";
+import { SkillDiscoveryTool } from "./skill-discovery";
 import { loadSshTool } from "./ssh";
 import { SubagentTool } from "./subagent";
 import { TelegramSendTool } from "./telegram-send";
@@ -95,6 +96,7 @@ export * from "./review";
 export * from "./search";
 export * from "./search-tool-bm25";
 export * from "./skill";
+export * from "./skill-discovery";
 export * from "./ssh";
 export * from "./subagent";
 export * from "./telegram-send";
@@ -411,6 +413,7 @@ export const BUILTIN_TOOLS: Record<string, ToolFactory> = {
 	todo_write: s => new TodoWriteTool(s),
 	web_search: s => new WebSearchTool(s),
 	search_tool_bm25: SearchToolBm25Tool.createIf,
+	skill_discovery: SkillDiscoveryTool.createIf,
 	telegram_send: TelegramSendTool.createIf,
 	write: s => new WriteTool(s),
 	skill: SkillTool.createIf,
@@ -570,6 +573,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		if (name === "search_tool_bm25") return discoveryActive;
 		if (name === "calc") return session.settings.get("calc.enabled");
 		if (name === "skill") return session.settings.get("skill.enabled");
+		if (name === "skill_discovery") return session.settings.get("skill.enabled");
 		if (name === "browser") return session.settings.get("browser.enabled");
 		if (name === "computer") return isComputerCallable(session);
 		if (name === "checkpoint" || name === "rewind") return session.settings.get("checkpoint.enabled");

--- a/packages/coding-agent/src/tools/skill-discovery.ts
+++ b/packages/coding-agent/src/tools/skill-discovery.ts
@@ -1,0 +1,65 @@
+import type { AgentTool, AgentToolResult } from "@gajae-code/agent-core";
+import { prompt, untilAborted } from "@gajae-code/utils";
+import * as z from "zod/v4";
+import { discoverRuntimeSkills, type RuntimeSkillDiscoveryCandidate } from "../extensibility/runtime-skill-discovery";
+import skillDiscoveryDescription from "../prompts/tools/skill-discovery.md" with { type: "text" };
+import type { ToolSession } from ".";
+
+const skillDiscoverySchema = z
+	.object({
+		query: z
+			.string()
+			.optional()
+			.describe("words to match against skill name, description, source, or use conditions"),
+		source: z.enum(["all", "project", "user"]).default("all").optional().describe("skill source scope to search"),
+		limit: z.number().min(1).max(50).default(20).optional().describe("maximum results"),
+	})
+	.strict();
+
+export type SkillDiscoveryToolInput = z.infer<typeof skillDiscoverySchema>;
+
+export interface SkillDiscoveryToolDetails {
+	candidates: RuntimeSkillDiscoveryCandidate[];
+	count: number;
+}
+
+export class SkillDiscoveryTool implements AgentTool<typeof skillDiscoverySchema, SkillDiscoveryToolDetails> {
+	readonly name = "skill_discovery";
+	readonly label = "SkillDiscovery";
+	readonly summary = "Discover project and user runtime skills by thin metadata";
+	readonly loadMode = "essential";
+	readonly description: string;
+	readonly parameters = skillDiscoverySchema;
+	readonly strict = true;
+
+	readonly #session: ToolSession;
+
+	constructor(session: ToolSession) {
+		this.#session = session;
+		this.description = prompt.render(skillDiscoveryDescription);
+	}
+
+	static createIf(session: ToolSession): SkillDiscoveryTool | null {
+		if (session.settings.get("skill.enabled") === false) return null;
+		return new SkillDiscoveryTool(session);
+	}
+
+	async execute(
+		_toolCallId: string,
+		input: SkillDiscoveryToolInput,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult<SkillDiscoveryToolDetails>> {
+		return untilAborted(signal, async () => {
+			const candidates = await discoverRuntimeSkills({
+				cwd: this.#session.cwd,
+				query: input.query,
+				source: input.source ?? "all",
+				limit: input.limit,
+			});
+			return {
+				content: [{ type: "text", text: JSON.stringify({ candidates, count: candidates.length }, null, 2) }],
+				details: { candidates, count: candidates.length },
+			};
+		});
+	}
+}

--- a/packages/coding-agent/src/tools/skill-discovery.ts
+++ b/packages/coding-agent/src/tools/skill-discovery.ts
@@ -39,6 +39,13 @@ export class SkillDiscoveryTool implements AgentTool<typeof skillDiscoverySchema
 		this.description = prompt.render(skillDiscoveryDescription);
 	}
 
+	#getRuntimeSkillPolicy() {
+		return {
+			...this.#session.settings.getGroup("skills"),
+			disabledExtensions: this.#session.settings.get("disabledExtensions"),
+		};
+	}
+
 	static createIf(session: ToolSession): SkillDiscoveryTool | null {
 		if (session.settings.get("skill.enabled") === false) return null;
 		return new SkillDiscoveryTool(session);
@@ -55,6 +62,7 @@ export class SkillDiscoveryTool implements AgentTool<typeof skillDiscoverySchema
 				query: input.query,
 				source: input.source ?? "all",
 				limit: input.limit,
+				policy: this.#getRuntimeSkillPolicy(),
 			});
 			return {
 				content: [{ type: "text", text: JSON.stringify({ candidates, count: candidates.length }, null, 2) }],

--- a/packages/coding-agent/src/tools/skill.ts
+++ b/packages/coding-agent/src/tools/skill.ts
@@ -19,6 +19,7 @@ import type { AgentTool, AgentToolResult } from "@gajae-code/agent-core";
 import { prompt, untilAborted } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import { resolveSubskillActivationForSkillInvocation } from "../extensibility/gjc-plugins";
+import { findRuntimeSkillByName } from "../extensibility/runtime-skill-discovery";
 import { buildSkillPromptMessage } from "../extensibility/skills";
 import { runNativeStateCommand } from "../gjc-runtime/state-runtime";
 import skillDescription from "../prompts/tools/skill.md" with { type: "text" };
@@ -110,10 +111,15 @@ export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails
 				);
 			}
 
-			const skill = skills.find(s => s.name === requestedName);
+			const skill =
+				skills.find(s => s.name === requestedName) ??
+				(await findRuntimeSkillByName(this.#session.cwd, requestedName));
 			if (!skill) {
 				const available = skills.map(s => s.name).sort();
-				const hint = available.length > 0 ? ` Available: ${available.join(", ")}` : "";
+				const hint =
+					available.length > 0
+						? ` Available: ${available.join(", ")}. Use skill_discovery to find project/user runtime skills.`
+						: " Use skill_discovery to find project/user runtime skills.";
 				throw new ToolError(`skill tool: unknown skill "${requestedName}".${hint}`);
 			}
 

--- a/packages/coding-agent/src/tools/skill.ts
+++ b/packages/coding-agent/src/tools/skill.ts
@@ -65,6 +65,13 @@ export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails
 		this.description = prompt.render(skillDescription);
 	}
 
+	#getRuntimeSkillPolicy() {
+		return {
+			...this.#session.settings.getGroup("skills"),
+			disabledExtensions: this.#session.settings.get("disabledExtensions"),
+		};
+	}
+
 	static createIf(session: ToolSession): SkillTool | null {
 		// The tool can only chain when the session can deliver the same-turn
 		// custom message. Without `sendCustomMessage` (e.g. minimal tool
@@ -113,7 +120,7 @@ export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails
 
 			const skill =
 				skills.find(s => s.name === requestedName) ??
-				(await findRuntimeSkillByName(this.#session.cwd, requestedName));
+				(await findRuntimeSkillByName(this.#session.cwd, requestedName, this.#getRuntimeSkillPolicy()));
 			if (!skill) {
 				const available = skills.map(s => s.name).sort();
 				const hint =

--- a/packages/coding-agent/test/notifications-live-stream.test.ts
+++ b/packages/coding-agent/test/notifications-live-stream.test.ts
@@ -386,7 +386,7 @@ test("a split live preview edits one message and never fans out continuation sen
 		type: "turn_stream",
 		sessionId: "S",
 		phase: "live",
-		text: "가".repeat(9000) + " more",
+		text: `${"가".repeat(9000)} more`,
 		messageRef: "1",
 	});
 	expect(bot.calls.filter(c => c.method === "sendMessage").length).toBe(0);

--- a/packages/coding-agent/test/tools/skill-discovery.test.ts
+++ b/packages/coding-agent/test/tools/skill-discovery.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import type { Skill } from "@gajae-code/coding-agent/extensibility/skills";
+import { buildSystemPrompt } from "@gajae-code/coding-agent/system-prompt";
+import type { ToolSession } from "@gajae-code/coding-agent/tools";
+import { SkillTool } from "@gajae-code/coding-agent/tools/skill";
+import { SkillDiscoveryTool } from "@gajae-code/coding-agent/tools/skill-discovery";
+
+async function makeSkill(root: string, name: string, description: string, body = "Skill body"): Promise<string> {
+	const dir = path.join(root, name);
+	await fs.mkdir(dir, { recursive: true });
+	const filePath = path.join(dir, "SKILL.md");
+	await fs.writeFile(
+		filePath,
+		`---
+name: ${name}
+description: ${description}
+globs:
+  - "**/*.ts"
+---
+
+# ${name}
+
+${body}
+`,
+		"utf8",
+	);
+	return filePath;
+}
+
+function createSession(cwd: string, overrides: Partial<ToolSession> = {}): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		skills: [],
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated({ "skill.enabled": true }),
+		...overrides,
+	};
+}
+
+describe("SkillDiscoveryTool", () => {
+	it("discovers project runtime skills from .gjc/skills", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-project-skills-"));
+		await makeSkill(path.join(cwd, ".gjc", "skills"), "project-helper", "Project helper skill");
+
+		const tool = new SkillDiscoveryTool(createSession(cwd));
+		const result = await tool.execute("call", { query: "project helper" });
+		const details = result.details;
+		expect(details).toBeDefined();
+
+		expect(details!.candidates).toEqual([
+			expect.objectContaining({ name: "project-helper", description: "Project helper skill", source: "project" }),
+		]);
+		expect(details!.candidates[0]?.useWhen).toContain("**/*.ts");
+	});
+
+	it("discovers user runtime skills from ~/.gjc/skills", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-user-skills-cwd-"));
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-user-skills-home-"));
+		const originalHome = process.env.HOME;
+		process.env.HOME = home;
+		try {
+			await makeSkill(path.join(home, ".gjc", "skills"), "user-helper", "User helper skill");
+
+			const tool = new SkillDiscoveryTool(createSession(cwd));
+			const result = await tool.execute("call", { source: "user" });
+			const details = result.details;
+			expect(details).toBeDefined();
+
+			expect(details!.candidates.map(candidate => candidate.name)).toContain("user-helper");
+			expect(details!.candidates.find(candidate => candidate.name === "user-helper")?.source).toBe("user");
+		} finally {
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+		}
+	});
+
+	it("does not return bundled built-in skills or grow the core prompt catalog", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-builtins-suppressed-"));
+		await makeSkill(path.join(cwd, ".gjc", "skills"), "project-helper", "Project helper skill");
+		const builtInSkill: Skill = {
+			name: "ralplan",
+			description: "Built-in planning workflow",
+			filePath: "embedded:gjc/skills/ralplan/SKILL.md",
+			baseDir: "embedded:gjc/skills/ralplan",
+			source: "embedded",
+		};
+
+		const tool = new SkillDiscoveryTool(createSession(cwd, { skills: [builtInSkill] }));
+		const result = await tool.execute("call", {});
+		const details = result.details;
+		expect(details).toBeDefined();
+		const names = details!.candidates.map(candidate => candidate.name);
+		expect(names).toContain("project-helper");
+		expect(names).not.toContain("ralplan");
+
+		const prompt = await buildSystemPrompt({
+			cwd,
+			customPrompt: "base instructions",
+			skills: [
+				builtInSkill,
+				{
+					name: "project-helper",
+					description: "Project helper skill",
+					filePath: path.join(cwd, ".gjc", "skills", "project-helper", "SKILL.md"),
+					baseDir: path.join(cwd, ".gjc", "skills", "project-helper"),
+					source: "runtime:project",
+				},
+			],
+			contextFiles: [],
+			workspaceTree: { rootPath: cwd, rendered: "", truncated: false, totalLines: 0, agentsMdFiles: [] },
+		});
+		const joined = prompt.systemPrompt.join("\n");
+		expect(joined).not.toContain("Project helper skill");
+		expect(joined).not.toContain('<skill name="project-helper">');
+	});
+
+	it("loads selected discovered skill content through the skill invocation path", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-selected-skill-"));
+		await makeSkill(path.join(cwd, ".gjc", "skills"), "project-helper", "Project helper skill", "Loaded narrowly.");
+		const sent: Array<{ content: string; details?: unknown }> = [];
+		const tool = new SkillTool(
+			createSession(cwd, {
+				skills: [],
+				sendCustomMessage: async message => {
+					sent.push({ content: String(message.content), details: message.details });
+				},
+			}),
+		);
+
+		await tool.execute("call", { name: "project-helper" });
+
+		expect(sent).toHaveLength(1);
+		expect(sent[0]?.content).toContain("Loaded narrowly.");
+		expect(sent[0]?.details).toEqual(expect.objectContaining({ name: "project-helper" }));
+	});
+});

--- a/packages/coding-agent/test/tools/skill-discovery.test.ts
+++ b/packages/coding-agent/test/tools/skill-discovery.test.ts
@@ -42,13 +42,23 @@ function createSession(cwd: string, overrides: Partial<ToolSession> = {}): ToolS
 		...overrides,
 	};
 }
+function runtimeSkillSettings(overrides: Record<string, unknown> = {}): Settings {
+	return Settings.isolated({
+		"skill.enabled": true,
+		"skills.enabled": true,
+		"skills.enablePiProject": true,
+		"skills.enablePiUser": true,
+		...overrides,
+	});
+}
 
 describe("SkillDiscoveryTool", () => {
 	it("discovers project runtime skills from .gjc/skills", async () => {
 		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-project-skills-"));
 		await makeSkill(path.join(cwd, ".gjc", "skills"), "project-helper", "Project helper skill");
+		const settings = runtimeSkillSettings();
 
-		const tool = new SkillDiscoveryTool(createSession(cwd));
+		const tool = new SkillDiscoveryTool(createSession(cwd, { settings }));
 		const result = await tool.execute("call", { query: "project helper" });
 		const details = result.details;
 		expect(details).toBeDefined();
@@ -66,8 +76,9 @@ describe("SkillDiscoveryTool", () => {
 		process.env.HOME = home;
 		try {
 			await makeSkill(path.join(home, ".gjc", "skills"), "user-helper", "User helper skill");
+			const settings = runtimeSkillSettings();
 
-			const tool = new SkillDiscoveryTool(createSession(cwd));
+			const tool = new SkillDiscoveryTool(createSession(cwd, { settings }));
 			const result = await tool.execute("call", { source: "user" });
 			const details = result.details;
 			expect(details).toBeDefined();
@@ -83,6 +94,7 @@ describe("SkillDiscoveryTool", () => {
 	it("does not return bundled built-in skills or grow the core prompt catalog", async () => {
 		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-builtins-suppressed-"));
 		await makeSkill(path.join(cwd, ".gjc", "skills"), "project-helper", "Project helper skill");
+		const settings = runtimeSkillSettings();
 		const builtInSkill: Skill = {
 			name: "ralplan",
 			description: "Built-in planning workflow",
@@ -91,7 +103,7 @@ describe("SkillDiscoveryTool", () => {
 			source: "embedded",
 		};
 
-		const tool = new SkillDiscoveryTool(createSession(cwd, { skills: [builtInSkill] }));
+		const tool = new SkillDiscoveryTool(createSession(cwd, { skills: [builtInSkill], settings }));
 		const result = await tool.execute("call", {});
 		const details = result.details;
 		expect(details).toBeDefined();
@@ -123,10 +135,12 @@ describe("SkillDiscoveryTool", () => {
 	it("loads selected discovered skill content through the skill invocation path", async () => {
 		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-selected-skill-"));
 		await makeSkill(path.join(cwd, ".gjc", "skills"), "project-helper", "Project helper skill", "Loaded narrowly.");
+		const settings = runtimeSkillSettings();
 		const sent: Array<{ content: string; details?: unknown }> = [];
 		const tool = new SkillTool(
 			createSession(cwd, {
 				skills: [],
+				settings,
 				sendCustomMessage: async message => {
 					sent.push({ content: String(message.content), details: message.details });
 				},
@@ -138,5 +152,78 @@ describe("SkillDiscoveryTool", () => {
 		expect(sent).toHaveLength(1);
 		expect(sent[0]?.content).toContain("Loaded narrowly.");
 		expect(sent[0]?.details).toEqual(expect.objectContaining({ name: "project-helper" }));
+	});
+
+	it("does not discover or invoke runtime skills when skills.enabled is false", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-skills-disabled-"));
+		await makeSkill(path.join(cwd, ".gjc", "skills"), "project-helper", "Project helper skill", "Blocked body.");
+		const settings = runtimeSkillSettings({ "skills.enabled": false });
+
+		const discovery = await new SkillDiscoveryTool(createSession(cwd, { settings })).execute("call", {});
+		expect(discovery.details?.candidates).toEqual([]);
+
+		const sent: Array<{ content: string; details?: unknown }> = [];
+		const tool = new SkillTool(
+			createSession(cwd, {
+				skills: [],
+				settings,
+				sendCustomMessage: async message => {
+					sent.push({ content: String(message.content), details: message.details });
+				},
+			}),
+		);
+		await expect(tool.execute("call", { name: "project-helper" })).rejects.toThrow(/unknown skill/);
+		expect(sent).toHaveLength(0);
+	});
+
+	it("applies source enable flags and skill filters to discovery and invocation", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-skills-policy-"));
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-skills-policy-home-"));
+		await makeSkill(path.join(cwd, ".gjc", "skills"), "project-helper", "Project helper skill", "Project body.");
+		await makeSkill(path.join(home, ".gjc", "skills"), "user-helper", "User helper skill", "User body.");
+		const originalHome = process.env.HOME;
+		process.env.HOME = home;
+		try {
+			const projectDisabled = runtimeSkillSettings({ "skills.enablePiProject": false });
+			let result = await new SkillDiscoveryTool(createSession(cwd, { settings: projectDisabled })).execute(
+				"call",
+				{},
+			);
+			expect(result.details?.candidates.map(candidate => candidate.name)).toEqual(["user-helper"]);
+			await expect(
+				new SkillTool(
+					createSession(cwd, { skills: [], settings: projectDisabled, sendCustomMessage: async () => {} }),
+				).execute("call", { name: "project-helper" }),
+			).rejects.toThrow(/unknown skill/);
+
+			const userDisabled = runtimeSkillSettings({ "skills.enablePiUser": false });
+			result = await new SkillDiscoveryTool(createSession(cwd, { settings: userDisabled })).execute("call", {});
+			expect(result.details?.candidates.map(candidate => candidate.name)).toEqual(["project-helper"]);
+			await expect(
+				new SkillTool(
+					createSession(cwd, { skills: [], settings: userDisabled, sendCustomMessage: async () => {} }),
+				).execute("call", { name: "user-helper" }),
+			).rejects.toThrow(/unknown skill/);
+
+			for (const settings of [
+				runtimeSkillSettings({ "skills.ignoredSkills": ["project-*"] }),
+				runtimeSkillSettings({ "skills.includeSkills": ["user-*"] }),
+				runtimeSkillSettings({ disabledExtensions: ["skill:project-helper"] }),
+			]) {
+				result = await new SkillDiscoveryTool(createSession(cwd, { settings })).execute("call", {
+					source: "project",
+				});
+				expect(result.details?.candidates).toEqual([]);
+				await expect(
+					new SkillTool(createSession(cwd, { skills: [], settings, sendCustomMessage: async () => {} })).execute(
+						"call",
+						{ name: "project-helper" },
+					),
+				).rejects.toThrow(/unknown skill/);
+			}
+		} finally {
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+		}
 	});
 });

--- a/packages/coding-agent/test/tools/skill-discovery.test.ts
+++ b/packages/coding-agent/test/tools/skill-discovery.test.ts
@@ -91,6 +91,47 @@ describe("SkillDiscoveryTool", () => {
 		}
 	});
 
+	it("does not classify home .gjc skills as project skills while walking up", async () => {
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-home-skill-boundary-"));
+		const cwd = path.join(home, "work", "project", "nested");
+		await fs.mkdir(cwd, { recursive: true });
+		await makeSkill(path.join(home, ".gjc", "skills"), "home-helper", "Home helper skill", "Home body.");
+		const originalHome = process.env.HOME;
+		process.env.HOME = home;
+		try {
+			const projectOnly = runtimeSkillSettings({ "skills.enablePiUser": false });
+			const discovery = await new SkillDiscoveryTool(createSession(cwd, { settings: projectOnly })).execute("call", {
+				source: "project",
+			});
+			expect(discovery.details?.candidates).toEqual([]);
+
+			const sent: Array<{ content: string; details?: unknown }> = [];
+			const tool = new SkillTool(
+				createSession(cwd, {
+					skills: [],
+					settings: projectOnly,
+					sendCustomMessage: async message => {
+						sent.push({ content: String(message.content), details: message.details });
+					},
+				}),
+			);
+			await expect(tool.execute("call", { name: "home-helper" })).rejects.toThrow(/unknown skill/);
+			expect(sent).toHaveLength(0);
+
+			const userEnabled = runtimeSkillSettings({ "skills.enablePiProject": false });
+			const userDiscovery = await new SkillDiscoveryTool(createSession(cwd, { settings: userEnabled })).execute(
+				"call",
+				{ source: "user" },
+			);
+			expect(userDiscovery.details?.candidates).toEqual([
+				expect.objectContaining({ name: "home-helper", source: "user" }),
+			]);
+		} finally {
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+		}
+	});
+
 	it("does not return bundled built-in skills or grow the core prompt catalog", async () => {
 		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-builtins-suppressed-"));
 		await makeSkill(path.join(cwd, ".gjc", "skills"), "project-helper", "Project helper skill");


### PR DESCRIPTION
## Summary
- add built-in `skill_discovery` tool for project/user runtime skills only
- keep custom skill catalogs out of the rendered core prompt
- lazily load selected discovered skills through the existing `skill` tool path

## Tests
- `bun test packages/coding-agent/test/tools/skill-discovery.test.ts packages/coding-agent/test/tools/skill.test.ts packages/coding-agent/test/sdk-skills.test.ts packages/coding-agent/test/tools/index.test.ts`
- `bun --cwd=packages/coding-agent run check`

Fixes #1815