### PR TITLE
Fix Windows psmux team worktree paths

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/psmux-detect.ts
+++ b/packages/coding-agent/src/gjc-runtime/psmux-detect.ts
@@ -115,6 +115,20 @@ function outputMentionsPsmux(output: string): boolean {
 	return PSMUX_VERSION_MARKERS.some(marker => output.includes(marker));
 }
 
+function normalizedCommandBaseName(command: string): string {
+	const normalized = command
+		.trim()
+		.replace(/^['"]|['"]$/g, "")
+		.replace(/\\/g, "/");
+	const basename = normalized.slice(normalized.lastIndexOf("/") + 1).toLowerCase();
+	return basename.endsWith(".exe") ? basename.slice(0, -4) : basename;
+}
+
+function isNamedPsmuxCommand(command: string): boolean {
+	const basename = normalizedCommandBaseName(command);
+	return basename === "psmux" || basename === "pmux";
+}
+
 function resolveBinaryPath(candidate: string): string | null {
 	return activeBinaryResolver(candidate);
 }
@@ -194,13 +208,14 @@ export function resolveGjcTmuxBinary(options: ResolveGjcTmuxBinaryOptions = {}):
 	const runner = options.runner ?? readSpawnRunner();
 	const explicit = env.GJC_TMUX_COMMAND?.trim() || env.GJC_TEAM_TMUX_COMMAND?.trim();
 	if (explicit) {
-		const isPsmux = detectPsmux(explicit, { env, runner });
+		const isPsmux =
+			platform === "win32" && isNamedPsmuxCommand(explicit) ? true : detectPsmux(explicit, { env, runner });
 		return { command: explicit, isPsmux, viaExplicitOverride: true };
 	}
 	if (platform === "win32") {
 		for (const candidate of PSMUX_BINARY_NAMES) {
 			if (resolveBinaryPath(candidate)) {
-				const isPsmux = detectPsmux(candidate, { env, runner });
+				const isPsmux = isNamedPsmuxCommand(candidate) ? true : detectPsmux(candidate, { env, runner });
 				return { command: candidate, isPsmux, viaExplicitOverride: false };
 			}
 		}

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { getWorktreesDir } from "@gajae-code/utils/dirs";
 import type { WorkflowHudSummary } from "../skill-state/active-state";
 import { buildTeamHudSummary as buildWorkflowTeamHudSummary } from "../skill-state/workflow-hud";
 import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
@@ -25,6 +26,7 @@ import {
 	GJC_TMUX_ACTIVE_SESSION_ENV,
 	GJC_TMUX_PROFILE_OPTION,
 	GJC_TMUX_PROFILE_VALUE,
+	resolveGjcTmuxBinary,
 	resolveGjcTmuxCommand,
 } from "./tmux-common";
 
@@ -288,6 +290,7 @@ export interface GjcTeamStartOptions {
 	cwd?: string;
 	env?: NodeJS.ProcessEnv;
 	dryRun?: boolean;
+	platform?: NodeJS.Platform;
 	mailboxDeliveryTransport?: GjcTeamMailboxDeliveryTransport;
 }
 
@@ -1844,18 +1847,41 @@ function findWorktreePath(repoRoot: string, worktreePath: string): string | null
 		if (line.startsWith("worktree ") && path.resolve(line.slice("worktree ".length)) === resolved) return resolved;
 	return null;
 }
+export function resolveWorkerWorktreePath(input: {
+	repoRoot: string;
+	stateDir: string;
+	teamName: string;
+	workerId: string;
+	platform: NodeJS.Platform;
+	isPsmux: boolean;
+}): string {
+	if (input.platform === "win32" && input.isPsmux) {
+		const slug = stableHash([input.repoRoot, input.stateDir, input.teamName].join("\0")).slice(0, 12);
+		return path.join(getWorktreesDir(), `team-${slug}-${input.workerId}`);
+	}
+	return path.join(input.stateDir, "worktrees", input.workerId);
+}
 async function ensureWorkerWorktree(
 	cwd: string,
 	dir: string,
 	teamName: string,
 	worker: GjcTeamWorker,
 	mode: GjcTeamWorktreeMode,
+	platform: NodeJS.Platform,
+	isPsmux: boolean,
 ): Promise<GjcTeamWorker> {
 	if (!mode.enabled) return worker;
 	if (!isGitRepository(cwd)) throw new Error(`team_worktree_requires_git_repo:${cwd}`);
 	const repoRoot = runGit(cwd, ["rev-parse", "--show-toplevel"]);
 	const baseRef = runGit(repoRoot, ["rev-parse", "HEAD"]);
-	const worktreePath = path.join(dir, "worktrees", worker.id);
+	const worktreePath = resolveWorkerWorktreePath({
+		repoRoot,
+		stateDir: dir,
+		teamName,
+		workerId: worker.id,
+		platform,
+		isPsmux,
+	});
 	const existing = findWorktreePath(repoRoot, worktreePath);
 	let created = false;
 	const branchName = mode.detached
@@ -2994,7 +3020,9 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 	const dir = teamDir(stateRoot, teamName);
 	const createdAt = now();
 	const worktreeMode = resolveDefaultWorktreeMode(options.worktreeMode);
-	const tmuxCommand = resolveGjcTmuxCommand(env);
+	const platform = options.platform ?? process.platform;
+	const tmuxBinary = resolveGjcTmuxBinary({ env, platform });
+	const tmuxCommand = tmuxBinary.command;
 	const tmuxContext = options.dryRun
 		? { sessionName: "dry-run", windowIndex: "0", leaderPaneId: "%dry-run-leader", target: "dry-run:0" }
 		: readCurrentTmuxLeaderContext(tmuxCommand, env);
@@ -3003,7 +3031,11 @@ export async function startGjcTeam(options: GjcTeamStartOptions): Promise<GjcTea
 	const workers: GjcTeamWorker[] = [];
 	try {
 		for (const worker of initialWorkers)
-			workers.push(options.dryRun ? worker : await ensureWorkerWorktree(cwd, dir, teamName, worker, worktreeMode));
+			workers.push(
+				options.dryRun
+					? worker
+					: await ensureWorkerWorktree(cwd, dir, teamName, worker, worktreeMode, platform, tmuxBinary.isPsmux),
+			);
 	} catch (error) {
 		await rollbackCreatedWorktrees(workers);
 		throw error;

--- a/packages/coding-agent/test/gjc-runtime/psmux-detect.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/psmux-detect.test.ts
@@ -180,6 +180,27 @@ describe("resolveGjcTmuxBinary", () => {
 		});
 		expect(resolved.isPsmux).toBe(true);
 	});
+
+	it("treats a selected Windows psmux executable as psmux even with a generic tmux banner", () => {
+		const resolved = resolveGjcTmuxBinary({
+			platform: "win32",
+			env: {},
+			runner: buildRunner(tmuxVersionOutput()),
+		});
+		expect(resolved.command).toBe("psmux");
+		expect(resolved.isPsmux).toBe(true);
+	});
+
+	it("treats an explicit Windows psmux path as psmux without relying on the version banner", () => {
+		const resolved = resolveGjcTmuxBinary({
+			platform: "win32",
+			env: { GJC_TEAM_TMUX_COMMAND: "C:\\tools\\psmux.exe" },
+			runner: buildRunner(tmuxVersionOutput()),
+		});
+		expect(resolved.command).toBe("C:\\tools\\psmux.exe");
+		expect(resolved.viaExplicitOverride).toBe(true);
+		expect(resolved.isPsmux).toBe(true);
+	});
 });
 
 describe("probePsmux", () => {

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { getWorktreesDir } from "@gajae-code/utils/dirs";
 import { sessionReportsDir, teamStateRoot } from "../../src/gjc-runtime/session-layout";
 import {
 	buildWorkerCommand,
@@ -20,6 +21,7 @@ import {
 	resolveGjcTeamWorkerCli,
 	resolveGjcTeamWorkerCliPlan,
 	resolveGjcWorkerCommand,
+	resolveWorkerWorktreePath,
 	sendGjcTeamMessage,
 	setGjcTeamMailboxDeliveryTransport,
 	setGjcTeamMailboxDeliveryTransportForTest,
@@ -276,6 +278,49 @@ describe("native gjc team runtime", () => {
 		const telemetry = await Bun.file(path.join(snapshot.state_dir, "telemetry.jsonl")).text();
 		expect(telemetry).toContain("Native gjc team dry-run state initialized");
 		expect(telemetry).toContain('"dry_run":true');
+	});
+
+	it("uses a short default worker worktree root on Windows psmux", () => {
+		const repoRoot = path.resolve("C:/Users/alice/source/really/deep/repository");
+		const stateDir = path.join(
+			repoRoot,
+			".gjc",
+			"_session-019f40f8-b6df-7000-8529-9227933daf5a",
+			"state",
+			"team",
+			"windows-psmux-team",
+		);
+
+		const workerPath = resolveWorkerWorktreePath({
+			repoRoot,
+			stateDir,
+			teamName: "windows-psmux-team",
+			workerId: "worker-1",
+			platform: "win32",
+			isPsmux: true,
+		});
+
+		expect(workerPath.startsWith(getWorktreesDir())).toBe(true);
+		expect(workerPath).toContain("team-");
+		expect(workerPath.endsWith("worker-1")).toBe(true);
+		expect(workerPath).not.toContain("_session-019f40f8-b6df-7000-8529-9227933daf5a");
+		expect(workerPath).not.toContain(`${path.sep}state${path.sep}team${path.sep}`);
+	});
+
+	it("keeps the session-scoped worker worktree root outside Windows psmux", () => {
+		const repoRoot = path.resolve("/tmp/gjc-team-runtime");
+		const stateDir = path.join(repoRoot, ".gjc", "_session-test-session", "state", "team", "posix-team");
+
+		const workerPath = resolveWorkerWorktreePath({
+			repoRoot,
+			stateDir,
+			teamName: "posix-team",
+			workerId: "worker-1",
+			platform: "linux",
+			isPsmux: false,
+		});
+
+		expect(workerPath).toBe(path.join(stateDir, "worktrees", "worker-1"));
 	});
 
 	it("separates managed worker lifecycle from worker-reported status", async () => {

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -65,6 +65,7 @@ async function createFakeTmuxBin(
 		gjcProfile?: boolean;
 		untaggableProfile?: boolean;
 		commandName?: string;
+		versionOutput?: string;
 	} = {},
 ): Promise<string> {
 	const binDir = path.join(root, ".test-bin");
@@ -74,6 +75,9 @@ async function createFakeTmuxBin(
 	const script = `#!/usr/bin/env bash
 echo "$@" >> ${JSON.stringify(logPath)}
 case "$1" in
+  -V|--version)
+    echo ${JSON.stringify(options.versionOutput ?? "tmux 3.3.5")}
+    ;;
   display-message)
     ${
 			options.failDisplay
@@ -744,6 +748,37 @@ describe("native gjc team runtime", () => {
 		expect(tmuxLog).toContain("send-keys -l -t %2");
 		expect(tmuxLog).toContain("worker-startup-ack");
 		expect(tmuxLog).toContain("send-keys -t %2 Enter");
+	});
+
+	it("uses the short worker worktree root for Windows psmux even when -V prints a generic tmux banner", async () => {
+		cleanupRoot = await createGitRepo();
+		const fakePsmux = await createFakeTmuxBin(cleanupRoot, { commandName: "psmux", versionOutput: "tmux 3.3.5" });
+
+		const snapshot = await startGjcTeam({
+			workerCount: 1,
+			agentType: "executor",
+			task: "Start Windows psmux worker",
+			teamName: "windows-generic-psmux-team",
+			cwd: cleanupRoot,
+			platform: "win32",
+			env: {
+				GJC_SESSION_ID: TEST_SESSION_ID,
+				PATH: process.env.PATH ?? "",
+				GJC_TEAM_WORKER_COMMAND: "true",
+				GJC_TEAM_TMUX_COMMAND: fakePsmux,
+			},
+		});
+
+		const workerPath = snapshot.workers[0]?.worktree_path ?? "";
+		expect(workerPath.startsWith(getWorktreesDir())).toBe(true);
+		expect(workerPath).toContain("team-");
+		expect(workerPath).toContain("worker-1");
+		expect(workerPath).not.toContain("_session-test-session");
+		expect(workerPath).not.toContain(`${path.sep}state${path.sep}team${path.sep}`);
+
+		const tmuxLog = await Bun.file(path.join(cleanupRoot, "tmux.log")).text();
+		expect(tmuxLog).toContain("split-window -h -t %1 -d -P -F #{pane_id} -c ");
+		expect(tmuxLog).toContain("send-keys -l -t %2");
 	});
 	it("distributes explicit markdown lane sections into worker-owned initial tasks", async () => {
 		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-team-runtime-"));


### PR DESCRIPTION
## Summary
- Route Windows + psmux `gjc team` worker worktrees through the short agent worktree root instead of the session state tree.
- Preserve the existing session-scoped worktree path for non-Windows/non-psmux flows.
- Add focused regression coverage for the path policy.

Closes #1849

## Verification
- `bun --cwd=packages/coding-agent biome check src/gjc-runtime/team-runtime.ts test/gjc-runtime/team-runtime.test.ts`
- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*