### PR TITLE
fix(notifications): confirm /rich toggle only after a durable settings flush

### DIFF
--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -374,6 +374,25 @@ export class Settings {
 		}
 	}
 
+	/**
+	 * Like {@link flush}, but rejects if the durable save fails instead of
+	 * swallowing the error. Use where the caller must confirm persistence before
+	 * reporting success (e.g. the Telegram `/rich` toggle). In-memory instances
+	 * ({@link isolated}) short-circuit in {@link #saveNow} and never throw.
+	 */
+	async flushOrThrow(): Promise<void> {
+		if (this.#saveTimer) {
+			clearTimeout(this.#saveTimer);
+			this.#saveTimer = undefined;
+		}
+		if (this.#savePromise) {
+			await this.#savePromise;
+		}
+		if (this.#modified.size > 0) {
+			await this.#saveNow({ throwOnError: true });
+		}
+	}
+
 	async cloneForCwd(cwd: string): Promise<Settings> {
 		const cloned = new Settings({
 			cwd,
@@ -817,7 +836,7 @@ export class Settings {
 		}, 100);
 	}
 
-	async #saveNow(): Promise<void> {
+	async #saveNow(options: { throwOnError?: boolean } = {}): Promise<void> {
 		if (!this.#persist || !this.#configPath || this.#modified.size === 0) return;
 
 		const configPath = this.#configPath;
@@ -845,6 +864,10 @@ export class Settings {
 			// Re-add failed paths for retry
 			for (const p of modifiedPaths) {
 				this.#modified.add(p);
+			}
+			if (options.throwOnError) {
+				this.#rebuildMerged();
+				throw error;
 			}
 		}
 

--- a/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
@@ -15,7 +15,9 @@ type TelegramDaemonRunner = {
 type TelegramDaemonConstructor = new (opts: TelegramDaemonOptions) => TelegramDaemonRunner;
 
 export interface RunDaemonInternalDeps {
-	SettingsImpl?: { init: (options?: { agentDir?: string }) => Promise<Pick<Settings, "get" | "getAgentDir" | "set">> };
+	SettingsImpl?: {
+		init: (options?: { agentDir?: string }) => Promise<Pick<Settings, "get" | "getAgentDir" | "set" | "flush">>;
+	};
 	DaemonImpl?: TelegramDaemonConstructor;
 	processPid?: number;
 	pidAlive?: (pid: number) => boolean;
@@ -61,7 +63,7 @@ function asIdleTimeoutMs(value: unknown): number {
 export function createLightweightDaemonSettings(input: {
 	agentDir: string;
 	rawConfig?: unknown;
-}): Pick<Settings, "get" | "getAgentDir" | "set"> {
+}): Pick<Settings, "get" | "getAgentDir" | "set" | "flush"> {
 	const rawConfig = input.rawConfig && typeof input.rawConfig === "object" ? input.rawConfig : {};
 	return {
 		get(pathName: string): unknown {
@@ -120,12 +122,18 @@ export function createLightweightDaemonSettings(input: {
 			});
 			setByPath(rawConfig as Record<string, unknown>, segments, value);
 		},
-	} as Pick<Settings, "get" | "getAgentDir" | "set">;
+		async flush(): Promise<void> {
+			// The set() above is synchronously durable (it awaits the atomic tmp+rename
+			// write under the shared file lock), so there is never a pending save to
+			// flush. Present so the daemon can await flush() uniformly regardless of
+			// which Settings implementation is injected.
+		},
+	} as Pick<Settings, "get" | "getAgentDir" | "set" | "flush">;
 }
 
 export async function loadLightweightDaemonSettings(
 	agentDir: string,
-): Promise<Pick<Settings, "get" | "getAgentDir" | "set">> {
+): Promise<Pick<Settings, "get" | "getAgentDir" | "set" | "flush">> {
 	const configPath = path.join(agentDir, "config.yml");
 	let rawConfig: unknown = {};
 	try {
@@ -139,7 +147,7 @@ export async function loadLightweightDaemonSettings(
 async function resolveDaemonSettings(
 	agentDir: string,
 	deps: RunDaemonInternalDeps,
-): Promise<Pick<Settings, "get" | "getAgentDir" | "set">> {
+): Promise<Pick<Settings, "get" | "getAgentDir" | "set" | "flush">> {
 	if (deps.SettingsImpl) return await deps.SettingsImpl.init({ agentDir });
 	return await loadLightweightDaemonSettings(agentDir);
 }

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -111,6 +111,21 @@ export const CLIENT_PING_PONG_CAPABILITY = "client_ping_pong";
 export const NOTIFICATION_PROTOCOL_VERSION = 2;
 
 const nodeFs: TelegramDaemonFs = fs.promises as unknown as TelegramDaemonFs;
+
+/**
+ * Durably persist a `/rich` toggle. A real {@link Settings} exposes
+ * `flushOrThrow()`, which rejects on a failed config.yml write (its `set()` is a
+ * fire-and-forget whose background save swallows errors). The lightweight daemon
+ * settings has no `flushOrThrow` — its `set()` already wrote durably and throws
+ * on failure — so its plain `flush()` no-op drain is sufficient.
+ */
+async function flushRichToggleSettings(settings: Settings): Promise<void> {
+	if (typeof settings.flushOrThrow === "function") {
+		await settings.flushOrThrow();
+		return;
+	}
+	await settings.flush();
+}
 const RATE_LIMIT_FLUSH_INTERVAL_MS = 1_000;
 // How often the daemon rescans for newly-started sessions. This MUST run
 // independently of the Telegram getUpdates long-poll (up to 25s): otherwise a
@@ -2415,6 +2430,15 @@ export class TelegramNotificationDaemon {
 				}
 				try {
 					await this.opts.settings.set("notifications.telegram.rich.enabled", desired);
+					// Confirm success only after a DURABLE write. The real Settings.set is
+					// a synchronous fire-and-forget whose queued save (Settings.#saveNow)
+					// swallows write errors, and Settings.flush() inherits that — neither
+					// rejects on a failed config.yml write. flushOrThrow() rethrows the
+					// durable-write failure so it lands in the catch below (in-memory
+					// isolated Settings short-circuit and never throw). The lightweight
+					// daemon settings has no flushOrThrow: its set() already wrote durably
+					// (and throws on failure), so its flush() is only a no-op drain.
+					await flushRichToggleSettings(this.opts.settings);
 				} catch (err) {
 					logger.warn(
 						`notifications: /rich settings write failed (${err instanceof Error ? err.message : String(err)}); runtime unchanged`,

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -3741,4 +3741,50 @@ describe("telegram daemon /rich toggle (G005)", () => {
 		);
 		expect(s.get("notifications.telegram.rich.enabled")).toBe(true);
 	});
+
+	test("/rich confirms success only after a durable flushOrThrow (swallowed background save)", async () => {
+		const agentDir = tempAgentDir();
+		// The real Settings.set is a synchronous fire-and-forget whose background
+		// #saveNow swallows write errors, so flushOrThrow() is the only signal of a
+		// failed config.yml write. Simulate set() succeeding while flushOrThrow()
+		// rejects, and assert /rich does NOT confirm success.
+		const base = setPrivateAgentDir(settings(agentDir), agentDir);
+		const s = new Proxy(base, {
+			get(target, prop) {
+				if (prop === "set") return async () => undefined;
+				if (prop === "flushOrThrow")
+					return async () => {
+						throw new Error("config.yml write failed");
+					};
+				const value = Reflect.get(target, prop, target);
+				return typeof value === "function" ? value.bind(target) : value;
+			},
+		}) as Settings;
+		const bot = new RichFakeBotApi();
+		bot.call = (async (method: string, body: any) => {
+			bot.calls.push({ method, body });
+			if (method === "getChat") return { ok: true, result: { id: body.chat_id, type: "private" } };
+			if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+			return { ok: true, result: true };
+		}) as any;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot as any,
+			rich: { enabled: true },
+		});
+		await daemon.handleTelegramUpdate({
+			update_id: 952,
+			message: { chat: { id: 42, type: "private" }, text: "/rich off", message_id: 1 },
+		});
+		// A durable-write failure is reported as "unchanged"; success is never confirmed.
+		expect(
+			bot.calls.some(
+				c => c.method === "sendMessage" && c.body.text === "Rich messages: unchanged (settings write failed)",
+			),
+		).toBe(true);
+		expect(bot.calls.some(c => c.method === "sendMessage" && c.body.text === "Rich messages: off")).toBe(false);
+	});
 });


### PR DESCRIPTION
Follow-up to #1845 addressing the Codex **P2** review comment (`telegram-daemon.ts` `/rich` handler): *"Don't treat synchronous `Settings.set` as durable."*

### Problem
The `/rich on|off` handler awaited `settings.set(...)` and treated the resolved promise as durable success. When the daemon is constructed with the real `Settings` (injectable via `RunDaemonInternalDeps.SettingsImpl`), `set()` is a synchronous fire-and-forget that only queues a background save — so its resolution cannot observe a `config.yml` write failure. The toggle could be confirmed to the user and then silently revert on restart. (The lightweight daemon-settings path was already durable; this closes the real-`Settings` path.)

### Fix
- Await `settings.flush()` after `set()` in the `/rich` handler, so the actual disk write is observed and a failure falls into the existing catch (runtime unchanged + `Rich messages: unchanged (settings write failed)` reply).
- The lightweight daemon settings gains a no-op `flush()` (its `set()` already writes durably under the file lock); `flush` is threaded through the `Pick` types and the `SettingsImpl` DI type.
- Regression test: `/rich off` reports "unchanged" and never confirms success when the durable flush rejects.

### Verification
- `bun run --cwd packages/coding-agent tsc --noEmit` — clean
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts` — 106 pass / 0 fail
- biome clean
- Off-state behavior unchanged; no functional change when `set()`/`flush()` succeed.