### PR TITLE
fix(tui): treat Ctrl+Z as no-op on Windows instead of crashing

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -594,6 +594,14 @@ export class InputController {
 	}
 
 	handleCtrlZ(): void {
+		// POSIX job control (SIGTSTP suspend / SIGCONT resume) does not exist on
+		// Windows: process.kill(0, "SIGTSTP") throws "Unknown signal: SIGTSTP" and
+		// crashes the TUI as an uncaught exception. Treat Ctrl+Z as a no-op there,
+		// mirroring the win32 guard already used by the background-fold path below.
+		if (process.platform === "win32") {
+			this.ctx.showStatus("Suspend (Ctrl+Z) is not supported on Windows");
+			return;
+		}
 		// Set up handler to restore TUI when resumed
 		process.once("SIGCONT", () => {
 			this.ctx.ui.start();


### PR DESCRIPTION
## Problem

`process.kill(0, "SIGTSTP")` throws `Unknown signal: SIGTSTP` on Windows because POSIX job control (SIGTSTP/SIGCONT) does not exist there. Pressing Ctrl+Z in the interactive TUI on Windows therefore crashes the app with an uncaught exception.

## Fix

`handleCtrlZ()` now returns early on `process.platform === "win32"` with a status message, mirroring the win32 guard the background-fold suspend path (`if (process.platform === "win32" || !process.stdout.isTTY) { … return; }`) already uses a few methods below in the same file. Non-Windows platforms keep job-control suspend unchanged.

## Testing

- `bun run --cwd=packages/coding-agent check:types` → clean
- `biome check` on the changed file → clean
- Manual: Ctrl+Z on Windows 11 no longer crashes the TUI.