### PR TITLE
fix(coding-agent): avoid false computer red-team CI gating

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -4544,6 +4544,15 @@ function parseGitNameStatus(output: string): UltragoalChangeSetPath[] {
 	return rows;
 }
 
+function categorizeCiChangedPath(value: string): UltragoalChangeCategory {
+	// CI_DEV_CHANGED_PATHS intentionally carries path names only. Mixed registries
+	// such as settings-schema.ts require diff-level narrowing; without the diff,
+	// treating the whole registry as computer-control source forces the mandatory
+	// computer red-team suite on unrelated settings changes.
+	if (isSettingsSchemaPath(value)) return "other";
+	return categorizeComputerChangePath(value);
+}
+
 function ciDevChangedPathRows(): UltragoalChangeSetPath[] {
 	const raw = process.env.CI_DEV_CHANGED_PATHS;
 	if (!raw) return [];
@@ -4554,7 +4563,7 @@ function ciDevChangedPathRows(): UltragoalChangeSetPath[] {
 		.map(pathValue => ({
 			path: normalizeRepoPath(pathValue),
 			status: "unknown" as UltragoalChangeStatus,
-			category: categorizeComputerChangePath(pathValue),
+			category: categorizeCiChangedPath(pathValue),
 		}));
 }
 

--- a/packages/coding-agent/test/gjc-runtime/computer-red-team-fixtures.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/computer-red-team-fixtures.test.ts
@@ -397,6 +397,25 @@ export function isToolAllowed(name: string): boolean {
 		expect(await checkpoint(root, qa)).toContain("Checkpointed G001 as complete");
 	});
 
+	it("does not trigger from CI path-only non-computer settings-schema edit", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "@goal computer gate fixture" });
+		await startNextUltragoalGoal({ cwd: root });
+		await writeQaArtifacts(root);
+		const savedChangedPaths = process.env.CI_DEV_CHANGED_PATHS;
+		process.env.CI_DEV_CHANGED_PATHS = "packages/coding-agent/src/config/settings-schema.ts";
+		try {
+			const cases = (executorQa().adversarialCases as Record<string, unknown>[]).filter(
+				row => row.id !== "blast-radius",
+			);
+			const qa = executorQa({ computerTouching: false, cases, surface: "native" });
+			expect(await checkpoint(root, qa)).toContain("Checkpointed G001 as complete");
+		} finally {
+			if (savedChangedPaths === undefined) delete process.env.CI_DEV_CHANGED_PATHS;
+			else process.env.CI_DEV_CHANGED_PATHS = savedChangedPaths;
+		}
+	});
+
 	it("triggers from a computer-specific settings-schema diff", async () => {
 		const root = await tempDir();
 		await initRepo(root);


### PR DESCRIPTION
## Summary
- Avoid treating CI path-only settings-schema changes as mandatory computer red-team changes when no diff is available for narrowing.
- Add regression coverage for CI_DEV_CHANGED_PATHS containing settings-schema without computer-specific diff context.

## Verification
- `bun install --frozen-lockfile`
- `bun --cwd=packages/natives run build`
- `CI_DEV_CHANGED_PATHS=$'packages/coding-agent/src/config/settings-schema.ts\\npackages/coding-agent/src/notifications/config-commands.ts' bun test packages/coding-agent/test/gjc-runtime/computer-red-team-fixtures.test.ts packages/coding-agent/test/gjc-runtime/ultragoal-dogfood.test.ts packages/coding-agent/test/gjc-skill-state-hooks.test.ts --timeout 30000`\n\n—\n*[repo owner's gaebal-gajae (clawdbot) 🦞]*