### PR TITLE
fix(notifications): retry atomic state write on Windows rename EPERM

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -245,7 +245,30 @@ async function writeJsonAtomic(fsImpl: TelegramDaemonFs, file: string, data: unk
 	const tmp = `${file}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
 	await fsImpl.writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o600 });
 	await fsImpl.chmod(tmp, 0o600).catch(() => undefined);
-	await fsImpl.rename(tmp, file);
+	// Windows: renaming the tmp file onto an existing target throws EPERM/EACCES/
+	// EBUSY when the destination is concurrently opened (another owner/reader, the
+	// reload controller, or antivirus). POSIX replaces atomically; Windows does not.
+	// A single failure here previously crashed the daemon heartbeat with an uncaught
+	// exception. Retry with bounded backoff so a transient lock is tolerated, and drop
+	// a stubborn target so the next rename has a clear path.
+	const RETRYABLE = new Set(["EPERM", "EACCES", "EBUSY", "EEXIST"]);
+	const maxAttempts = 12;
+	for (let attempt = 1; ; attempt++) {
+		try {
+			await fsImpl.rename(tmp, file);
+			return;
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code ?? "";
+			if (!RETRYABLE.has(code) || attempt >= maxAttempts) {
+				await fsImpl.unlink(tmp).catch(() => undefined);
+				throw error;
+			}
+			if ((code === "EEXIST" || code === "EPERM") && attempt >= 3) {
+				await fsImpl.unlink(file).catch(() => undefined);
+			}
+			await new Promise(resolve => setTimeout(resolve, 25 * attempt));
+		}
+	}
 }
 
 async function tryOpenWx(fsImpl: TelegramDaemonFs, file: string): Promise<boolean> {


### PR DESCRIPTION
## Problem

On Windows, `fs.rename` onto an existing target throws EPERM/EACCES/EBUSY when the destination is concurrently open (another owner/reader, the reload controller, or antivirus). POSIX replaces atomically; Windows does not. In `writeJsonAtomic` a single `fs.rename` failure crashed the notification daemon heartbeat with an uncaught exception.

## Fix

Retry the rename with bounded backoff (12 attempts). After a few `EEXIST`/`EPERM` attempts, unlink the stubborn target so the next rename has a clear path. Non-retryable errors and exhausted retries still throw after cleaning up the temp file, preserving the previous failure semantics for genuine errors.

## Testing

- `bun run --cwd=packages/coding-agent check:types` → clean
- `biome check` on the changed file → clean
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts` → the daemon suite passes (one pre-existing Windows-only file-mode assertion, `0o600` vs `0o666`, also fails on unmodified `dev` and is unrelated to this change).