### PR TITLE
Stabilize LSP lifecycle exit assertion

### DIFF
--- a/packages/coding-agent/test/lsp/lsp-lifecycle.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-lifecycle.test.ts
@@ -70,8 +70,8 @@ describe("LSP lifecycle behavior", () => {
 			expect(second.proc.killed).toBe(false);
 			expect(cachedAfterFirstExit).toBe(second);
 			await shutdownAll();
-			await second.proc.exited;
-			expect(second.proc.exitCode).not.toBeNull();
+			const secondExitCode = await second.proc.exited;
+			expect(secondExitCode).not.toBeNull();
 			expect(first.pendingRequests.size).toBe(0);
 		} finally {
 			await fs.rm(cwd, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Await the Bun process exit promise result for the reacquired LSP client shutdown assertion instead of reading `proc.exitCode` synchronously after `proc.exited`.
- Keeps the lifecycle test focused on proving shutdown completed while avoiding the CI race where `exitCode` is populated later.

## Verification
- `bun test packages/coding-agent/test/lsp/lsp-lifecycle.test.ts`
- `bun run check` from `packages/coding-agent` (passes; existing Biome info diagnostics reported in unrelated files)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*