### PR TITLE
fix(notifications): acknowledge Telegram ask replies

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -2227,6 +2227,15 @@ export class TelegramNotificationDaemon {
 								token: session.token,
 							}),
 						);
+						await this.botApi
+							.call("sendMessage", {
+								chat_id: this.opts.chatId,
+								message_thread_id: Number(inbound.threadId),
+								text: "Received as an answer to the pending ask.",
+							})
+							.catch(error => {
+								logger.warn(`telegram: failed to acknowledge pending ask reply: ${String(error)}`);
+							});
 						await this.rememberSeenUpdateId(inbound.updateId);
 						if (inbound.messageId !== undefined) await this.setReaction(inbound.messageId, QUEUED_REACTION);
 						return;

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -778,6 +778,13 @@ describe("telegram daemon", () => {
 		expect(sent).toContainEqual({ type: "reply", id: "ask1", answer: "my typed answer", token: "ts" });
 		// ...and must NOT be injected as a new user turn.
 		expect(sent.some(frame => frame.type === "user_message")).toBe(false);
+		const ackSend = bot.calls.find(
+			c =>
+				c.method === "sendMessage" &&
+				c.body.message_thread_id === threadId &&
+				c.body.text === "Received as an answer to the pending ask.",
+		);
+		expect(ackSend).toBeDefined();
 	});
 
 	test("no-topic plain text does not answer the only pending ask", async () => {


### PR DESCRIPTION
## Summary

This PR adds a small Telegram-side acknowledgement when a plain text message in a session topic is consumed as the answer to a pending `ask` action.

The routing semantics are intentionally unchanged:

- If an ask is pending, plain topic text still answers that ask as free input.
- The same text is still **not** injected as a new `user_message` turn.
- Existing Deep Interview clarification behavior is preserved.

The only product-visible change is that Telegram now posts this acknowledgement in the same thread:

```text
Received as an answer to the pending ask.
```

## Background

During a v0.9.0 Deep Interview dogfood session over Telegram, the user saw this confusing flow:

1. Deep Interview displayed numbered choices including synthetic actions such as:
   - `Other (type your own)`
   - `Ask about these choices`
2. The user typed a question/answer in the Telegram topic while an ask was pending.
3. GJC correctly consumed the text as the pending ask reply, so the local GJC session showed it in the ask result.
4. Telegram did not show any explicit confirmation that the text had been consumed by the pending ask.
5. When Deep Interview re-asked the same round after clarification, the Telegram thread looked like the message had disappeared or the round had looped.

The root issue is not that pending ask routing is wrong. The routing is deliberate and already covered by tests. The UX gap is that Telegram gives no visible receipt for the consumed ask answer.

## Reproduced behavior

The investigation reproduced the AskTool boundary with a remote answer source matching the Telegram path:

- Selecting `Other (type your own)` and typing question-shaped text results in `customInput` and is recorder-eligible.
- Selecting `Ask about these choices` and typing the same text results in `clarificationQuestion` and skips Deep Interview recorder writes.
- Telegram daemon plain topic text while an ask is pending sends a `reply` frame and does not send `user_message`.

That means the safest minimal fix is to make the Telegram ask-consumption visible without changing answer classification.

## Implementation

In `TelegramNotificationDaemon.handleTelegramUpdate`, when the daemon takes this branch:

- known session topic
- no callback query
- not a reply to a specific ask message
- no in-thread config command
- no media attachment
- a pending ask exists

it still sends the existing websocket frame:

```json
{ "type": "reply", "id": "ask1", "answer": "...", "token": "..." }
```

Then it best-effort sends a same-thread Telegram acknowledgement before marking the update seen and returning.

The acknowledgement send is non-fatal: Bot API failures are logged and do not block the already-valid ask reply path.

## User-visible before / after

Before:

```text
User types in Telegram topic
→ local GJC ask receives the text
→ Telegram shows no confirmation
→ next repeated Deep Interview ask can look like a loop/missing reply
```

After:

```text
User types in Telegram topic
→ local GJC ask receives the text
→ Telegram thread shows: "Received as an answer to the pending ask."
→ repeated clarification ask is easier to understand as expected ask flow
```

## Tests

Regression was first updated and failed before the implementation because no acknowledgement was sent.

Passing verification after the fix:

```text
bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts -t "plain text answers a pending ask"
bun test packages/coding-agent/test/tools/ask.test.ts -t "clarification"
bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts packages/coding-agent/test/tools/ask.test.ts
```

Final relevant run:

```text
129 pass
0 fail
497 expect() calls
```

## Scope / non-goals

This PR does **not**:

- reinterpret `Other (type your own)` question-shaped text as clarification;
- remove Deep Interview's intentional re-ask after `clarificationQuestion`;
- change Telegram pending ask plaintext routing into normal user-message injection;
- change AskTool answer classification.

Those would be larger UX/contract changes. This PR is the minimal targeted receipt/visibility fix.

Related investigation issue: snowykr/gajae-code#1