### PR TITLE
fix(notifications): persist ask replies before ack

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -2483,6 +2483,7 @@ export class TelegramNotificationDaemon {
 								token: session.token,
 							}),
 						);
+						await this.rememberSeenUpdateId(inbound.updateId);
 						await this.botApi
 							.call("sendMessage", {
 								chat_id: this.opts.chatId,
@@ -2492,7 +2493,6 @@ export class TelegramNotificationDaemon {
 							.catch(error => {
 								logger.warn(`telegram: failed to acknowledge pending ask reply: ${String(error)}`);
 							});
-						await this.rememberSeenUpdateId(inbound.updateId);
 						if (inbound.messageId !== undefined) await this.setReaction(inbound.messageId, QUEUED_REACTION);
 						return;
 					}

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -803,6 +803,67 @@ describe("telegram daemon", () => {
 		expect(ackSend).toBeDefined();
 	});
 
+	test("marks pending ask text seen before awaiting Telegram acknowledgement", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		let markAckStarted: () => void = () => {};
+		const ackStarted = new Promise<void>(resolve => {
+			markAckStarted = resolve;
+		});
+		let releaseAck: () => void = () => {};
+		const ackGate = new Promise<unknown>(resolve => {
+			releaseAck = () => resolve({ ok: true, result: { message_id: 999 } });
+		});
+		class BlockingAckBotApi extends FakeBotApi {
+			override async call(method: string, body: unknown): Promise<unknown> {
+				if (
+					method === "sendMessage" &&
+					(body as { text?: unknown }).text === "Received as an answer to the pending ask."
+				) {
+					this.calls.push({ method, body });
+					markAckStarted();
+					return ackGate;
+				}
+				return super.call(method, body);
+			}
+		}
+		const bot = new BlockingAckBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+		});
+		daemon.connectSession("S", "ws://s", "ts");
+		await daemon.handleSessionMessage(daemon.sessions.get("S")!, {
+			type: "action_needed",
+			kind: "ask",
+			id: "ask1",
+			question: "Name it?",
+			options: ["a", "b"],
+		});
+		const askSend = bot.calls.find(c => c.method === "sendMessage");
+		const threadId = askSend!.body.message_thread_id;
+		const update = {
+			update_id: 1,
+			message: { chat: { id: 42 }, message_thread_id: threadId, text: "my typed answer", message_id: 99 },
+		};
+		const first = daemon.handleTelegramUpdate(update);
+		await ackStarted;
+		const duplicate = daemon.handleTelegramUpdate(update);
+		await Promise.resolve();
+		const repliesBeforeAck = FakeWs.instances[0]!.sent
+			.map(frame => JSON.parse(frame))
+			.filter(frame => frame.type === "reply" && frame.id === "ask1");
+		expect(repliesBeforeAck).toHaveLength(1);
+		releaseAck();
+		await first;
+		await duplicate;
+	});
+
 	test("no-topic plain text does not answer the only pending ask", async () => {
 		FakeWs.instances = [];
 		const agentDir = tempAgentDir();

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -855,9 +855,9 @@ describe("telegram daemon", () => {
 		await ackStarted;
 		const duplicate = daemon.handleTelegramUpdate(update);
 		await Promise.resolve();
-		const repliesBeforeAck = FakeWs.instances[0]!.sent
-			.map(frame => JSON.parse(frame))
-			.filter(frame => frame.type === "reply" && frame.id === "ask1");
+		const repliesBeforeAck = FakeWs.instances[0]!.sent.map(frame => JSON.parse(frame)).filter(
+			frame => frame.type === "reply" && frame.id === "ask1",
+		);
 		expect(repliesBeforeAck).toHaveLength(1);
 		releaseAck();
 		await first;


### PR DESCRIPTION
## Summary

Follow-up to #1865. The original PR was merged at head `2c1b03519e` before the review fix commit landed, so this PR carries only the missing race fix.

## Problem

#1865 added a best-effort Telegram acknowledgement after pending ask plaintext is consumed as an ask reply. In the merged version, the order is:

```text
ws.send(reply)
await send Telegram acknowledgement
await rememberSeenUpdateId(updateId)
```

If the acknowledgement Bot API call is slow/retrying, or the daemon stops after the websocket reply but before the acknowledgement resolves, the Telegram update has not been persisted as seen. On restart, the same Telegram update can be polled again and the pending ask answer can be submitted twice.

## Fix

Move `rememberSeenUpdateId(inbound.updateId)` immediately after the successful websocket reply and before the best-effort acknowledgement/reaction side effects:

```text
ws.send(reply)
await rememberSeenUpdateId(updateId)
await send Telegram acknowledgement best-effort
await set reaction best-effort
```

This keeps the important ordering properties:

- Do not mark the update seen before the ask reply is handed to the session.
- Do mark it seen before waiting on optional Telegram UX side effects.
- Preserve #1865's acknowledgement behavior.

## Tests

Added a regression test that blocks the acknowledgement `sendMessage`, processes the same Telegram update again before the acknowledgement completes, and asserts only one pending-ask `reply` frame is sent.

Verification:

```text
bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts -t "pending ask"
bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts packages/coding-agent/test/tools/ask.test.ts
```

Results:

```text
3 pass, 103 filtered, 0 fail
159 pass, 0 fail, 652 expect() calls
```