### PR TITLE
fix(notifications): deliver full finalized turns by default

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Mac Option+Enter no longer collides with the queue-message binding.
 - Telegram completion notifications suppress dot-only messages, and Telegram-originated input is shown immediately and recorded in prompt history.
 - The computer red-team CI gate avoids false positives from non-computer-control changes.
+- Finalized notification turn mirrors now default to the bounded full-turn cap so Telegram's existing chunked delivery can send long assistant answers instead of receiving an already-truncated 3500-character summary; `GJC_NOTIFICATIONS_TURN_MAX` remains available to lower the cap for summary-style mirrors, and live previews stay capped as one editable message.
 
 ## [0.9.0] - 2026-07-07
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Finalized notification turn mirrors now default to the bounded full-turn cap so Telegram's existing chunked delivery can send long assistant answers instead of receiving an already-truncated 3500-character summary; `GJC_NOTIFICATIONS_TURN_MAX` remains available to lower the cap for summary-style mirrors, and live previews stay capped as one editable message.
 
 ## [0.9.1] - 2026-07-08
 
@@ -25,7 +28,6 @@
 - Mac Option+Enter no longer collides with the queue-message binding.
 - Telegram completion notifications suppress dot-only messages, and Telegram-originated input is shown immediately and recorded in prompt history.
 - The computer red-team CI gate avoids false positives from non-computer-control changes.
-- Finalized notification turn mirrors now default to the bounded full-turn cap so Telegram's existing chunked delivery can send long assistant answers instead of receiving an already-truncated 3500-character summary; `GJC_NOTIFICATIONS_TURN_MAX` remains available to lower the cap for summary-style mirrors, and live previews stay capped as one editable message.
 
 ## [0.9.0] - 2026-07-07
 ### Added

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -407,20 +407,18 @@ function streamIntervalMs(): number {
 	return Math.max(200, Number(process.env.GJC_NOTIFICATIONS_STREAM_INTERVAL_MS) || 500);
 }
 // Max chars of a turn's assistant text carried by the FINALIZED turn_stream (and
-// the pre-ask capture). Default 3500 keeps the mirror a glanceable per-turn
-// summary; a client that splits long messages (the Telegram daemon does so via
-// splitTelegramHtml, scheduling each chunk through the shared rate-limit pool so
-// the fan-out never bypasses the per-chat limit) can raise it with
-// GJC_NOTIFICATIONS_TURN_MAX to deliver full turns. The value is clamped to a
-// finite [280, TURN_TEXT_MAX_CEILING] range: a non-finite or non-positive env
-// (unset, NaN, Infinity, <= 0) falls back to the default, so the cap can never
-// be unbounded. Live frames are intentionally NOT raised — they stay one
+// the pre-ask capture). Finalized turns default to the bounded full-turn ceiling
+// because split-capable clients such as the Telegram daemon schedule each
+// splitTelegramHtml chunk through the shared rate-limit pool. Operators who want
+// glanceable summaries can lower this with GJC_NOTIFICATIONS_TURN_MAX. The value
+// is always clamped to a finite [280, TURN_TEXT_MAX_CEILING] range so the cap can
+// never be unbounded. Live frames are intentionally NOT raised — they stay one
 // editable preview message rather than fanning a long in-progress turn across
 // sends.
 const TURN_TEXT_MAX_CEILING = 40_000;
 function turnTextMax(): number {
 	const raw = Number(process.env.GJC_NOTIFICATIONS_TURN_MAX);
-	if (!Number.isFinite(raw) || raw <= 0) return 3500;
+	if (!Number.isFinite(raw) || raw <= 0) return TURN_TEXT_MAX_CEILING;
 	return Math.min(TURN_TEXT_MAX_CEILING, Math.max(280, raw));
 }
 function resolveSettings(settingsOverride?: Settings): ResolvedSettings {

--- a/packages/coding-agent/src/notifications/rich-render.ts
+++ b/packages/coding-agent/src/notifications/rich-render.ts
@@ -49,6 +49,7 @@ export function shouldPromoteRich(input: { enabled?: boolean; send: ThreadedSend
 		send.editable !== true &&
 		typeof send.richMarkdown === "string" &&
 		send.richMarkdown.trim().length > 0 &&
+		send.richMarkdown.length <= RICH_MESSAGE_LIMIT &&
 		typeof send.text === "string" &&
 		send.text.length > 0
 	);

--- a/packages/coding-agent/test/notifications-live-stream.test.ts
+++ b/packages/coding-agent/test/notifications-live-stream.test.ts
@@ -295,9 +295,9 @@ test("a finalized turn frame without a messageRef posts a fresh message (no in-p
 	expect(bot.calls.some(c => c.method === "sendMessage" && String(c.body.text).includes("All done"))).toBe(true);
 });
 // ---------------------------------------------------------------------------
-// 4) Finalized turn-text cap: default keeps the mirror a glanceable summary;
-//    GJC_NOTIFICATIONS_TURN_MAX raises it so full turns reach split-capable
-//    clients (Telegram daemon / Slack bridge) instead of being truncated.
+// 4) Finalized turn-text cap: default lets full turns reach split-capable
+//    clients (Telegram daemon / Slack bridge) instead of being truncated;
+//    GJC_NOTIFICATIONS_TURN_MAX can lower the cap for summary-style mirrors.
 // ---------------------------------------------------------------------------
 
 const longAssistantTurn = (chars: number) => ({
@@ -317,16 +317,16 @@ async function finalizedTextFor(
 	return frames.find(f => f.type === "turn_stream" && f.phase === "finalized")!.text ?? "";
 }
 
-test("finalized turn text is capped at 3500 chars by default (mirror stays a summary)", async () => {
+test("finalized turn text defaults to full-turn delivery for split-capable clients", async () => {
 	const text = await finalizedTextFor({ GJC_NOTIFICATIONS: "1" });
-	expect(text.length).toBeLessThanOrEqual(3500);
-	expect(text.endsWith("…")).toBe(true); // truncated with an ellipsis
-});
-
-test("GJC_NOTIFICATIONS_TURN_MAX raises the finalized cap for full-turn delivery", async () => {
-	const text = await finalizedTextFor({ GJC_NOTIFICATIONS: "1", GJC_NOTIFICATIONS_TURN_MAX: "40000" });
 	expect(text.length).toBe(5000); // full turn, untruncated
 	expect(text.endsWith("…")).toBe(false);
+});
+
+test("GJC_NOTIFICATIONS_TURN_MAX can lower the finalized cap for summary mirrors", async () => {
+	const text = await finalizedTextFor({ GJC_NOTIFICATIONS: "1", GJC_NOTIFICATIONS_TURN_MAX: "3500" });
+	expect(text.length).toBeLessThanOrEqual(3500);
+	expect(text.endsWith("…")).toBe(true); // truncated with an ellipsis
 });
 
 test("GJC_NOTIFICATIONS_TURN_MAX is clamped to a finite ceiling (never unbounded)", async () => {
@@ -335,10 +335,10 @@ test("GJC_NOTIFICATIONS_TURN_MAX is clamped to a finite ceiling (never unbounded
 	expect(text.endsWith("…")).toBe(true); // still truncated at the ceiling
 });
 
-test("non-finite GJC_NOTIFICATIONS_TURN_MAX falls back to the 3500 default", async () => {
+test("non-finite GJC_NOTIFICATIONS_TURN_MAX falls back to the full-turn ceiling", async () => {
 	const text = await finalizedTextFor({ GJC_NOTIFICATIONS: "1", GJC_NOTIFICATIONS_TURN_MAX: "Infinity" });
-	expect(text.length).toBeLessThanOrEqual(3500); // Infinity is rejected, default applies
-	expect(text.endsWith("…")).toBe(true);
+	expect(text.length).toBe(5000); // invalid env does not force summary truncation
+	expect(text.endsWith("…")).toBe(false);
 });
 
 test("live frames are NOT raised by the turn cap (stay one editable preview)", async () => {

--- a/packages/coding-agent/test/notifications-rich-redteam.test.ts
+++ b/packages/coding-agent/test/notifications-rich-redteam.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "../src/config/settings";
-import { markdownToTelegramHtml } from "../src/notifications/html-format";
+import { markdownToTelegramHtml, splitTelegramHtml } from "../src/notifications/html-format";
 import { buildRichMessage, deliverRichWithFallback, shouldPromoteRich } from "../src/notifications/rich-render";
 import type { BotApi } from "../src/notifications/telegram-daemon";
 import { TelegramNotificationDaemon } from "../src/notifications/telegram-daemon";
@@ -171,7 +171,7 @@ describe("redteam(b): rich body carries hostile raw verbatim with no HTML-path p
 		expect(markdownToTelegramHtml(hostileRaw)).not.toBe(hostileRaw);
 	});
 
-	test("RT-B1: daemon promotes hostile final answer to rich only; sendMessage(HTML) is never called", async () => {
+	test("RT-B1: daemon keeps oversized hostile final answer on HTML chunk path", async () => {
 		const bot = new RedTeamBot();
 		const daemon = makeRichDaemon(bot, { enabled: true });
 		const session = richSession();
@@ -183,12 +183,12 @@ describe("redteam(b): rich body carries hostile raw verbatim with no HTML-path p
 			finalAnswer: true,
 			text: hostileRaw,
 		});
-		expect(countMethod(bot, "sendRichMessage")).toBe(1);
-		expect(countMethod(bot, "sendMessage")).toBe(0); // no HTML-path pollution
-		const body = findMethod(bot, "sendRichMessage")!.body;
-		expect(body.rich_message.markdown).toBe(hostileRaw); // raw verbatim, unescaped
-		expect(body.rich_message.markdown.length).toBe(hostileRaw.length); // not truncated at 4096
+		expect(countMethod(bot, "sendRichMessage")).toBe(0);
+		expect(countMethod(bot, "sendMessage")).toBe(1);
+		const body = findMethod(bot, "sendMessage")!.body;
+		expect(body.text).toBe(splitTelegramHtml(markdownToTelegramHtml(hostileRaw))[0]);
 		expect(body.message_thread_id).toBe(555); // correct topic attribution
+		expect(body.parse_mode).toBe("HTML");
 	});
 });
 

--- a/packages/coding-agent/test/notifications-rich-render.test.ts
+++ b/packages/coding-agent/test/notifications-rich-render.test.ts
@@ -96,6 +96,9 @@ describe("shouldPromoteRich truth table", () => {
 		expect(shouldPromoteRich(baseInput({ send: makeSend({ richMarkdown: undefined }) }))).toBe(false);
 	});
 
+	test("oversized richMarkdown -> false (HTML chunk path owns long finalized turns)", () => {
+		expect(shouldPromoteRich(baseInput({ send: makeSend({ richMarkdown: "x".repeat(4097) }) }))).toBe(false);
+	});
 	test("send.text empty string -> false", () => {
 		expect(shouldPromoteRich(baseInput({ send: makeSend({ text: "" }) }))).toBe(false);
 	});

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -3223,7 +3223,7 @@ describe("telegram daemon rich final-answer promotion (Rev 3 verification)", () 
 		expect(sends.every(c => c.body.parse_mode === TELEGRAM_PARSE_MODE)).toBe(true);
 	});
 
-	test("(d) sendRichMessage throw falls back to chunk 0 now and requeues the rest (fairness)", async () => {
+	test("(d) oversized rich finals skip promotion and drain HTML chunks through the pool", async () => {
 		const raw = "B".repeat(9000);
 		const chunks = splitTelegramHtml(markdownToTelegramHtml(raw));
 		expect(chunks.length).toBeGreaterThan(1);
@@ -3232,8 +3232,9 @@ describe("telegram daemon rich final-answer promotion (Rev 3 verification)", () 
 		const daemon = makeRichDaemon(bot, { enabled: true });
 		const session = richSession();
 		await driveFinalizedTurn(daemon, bot, session, raw);
-		expect(countMethod(bot, "sendRichMessage")).toBe(1);
-		// Fairness: only the first HTML chunk is delivered on this token; the rest are requeued.
+		expect(countMethod(bot, "sendRichMessage")).toBe(0);
+		// Fairness: oversized rich payloads stay on the HTML path, where only the
+		// first chunk is delivered on this token and the rest are requeued.
 		const first = bot.calls.filter(c => c.method === "sendMessage");
 		expect(first).toHaveLength(1);
 		expect(first[0]!.body.text).toBe(chunks[0]);
@@ -3404,18 +3405,14 @@ describe("telegram daemon rich final-answer promotion (Rev 3 verification)", () 
 });
 
 // ---------------------------------------------------------------------------
-// G006: rich overflow boundary. Production caps the final answer at 3500 chars
-// (summaryFromMessage(..., 3500)), so a promoted sendRichMessage never overflows
-// under normal traffic and RICH_MESSAGE_LIMIT (rich-render.ts) stays a purely
-// non-behavioral marker. These tests pin the defended-but-prod-unreachable case:
-// an oversized (4096+) rich payload the Bot API rejects with {ok:false} MUST
-// degrade to the chunked HTML splitTelegramHtml fallback — N chunks, each
-// <= TELEGRAM_MESSAGE_LIMIT, with exactly one diagnostic warn — while normal
-// (<= limit) traffic stays a single send. Purely additive: no existing test case
-// is modified.
+// G006: rich overflow boundary. Oversized finalized answers stay on the HTML
+// chunk path instead of probing rich and then falling back in the same pool
+// drain. The lower-level fallback helper still degrades oversized rich failures
+// to split HTML when called directly; the daemon-level contract is that normal
+// routing avoids the predictable over-limit rich miss entirely.
 // ---------------------------------------------------------------------------
 describe("telegram daemon rich overflow boundary (G006)", () => {
-	test("(g) rich {ok:false} on a 4096+ payload falls back to N HTML chunks, each <= TELEGRAM_MESSAGE_LIMIT", async () => {
+	test("(g) 4096+ finalized payload skips rich and drains HTML chunks through the pool", async () => {
 		const raw = "D".repeat(9000);
 		const html = markdownToTelegramHtml(raw);
 		const chunks = splitTelegramHtml(html);
@@ -3428,9 +3425,9 @@ describe("telegram daemon rich overflow boundary (G006)", () => {
 		const session = richSession();
 		await driveFinalizedTurn(daemon, bot, session, raw);
 
-		// Rich attempted once, then the REAL daemon sendHtmlFallback closure runs:
-		// chunk 0 on this token, the rest requeued (fairness) and drained next flush.
-		expect(countMethod(bot, "sendRichMessage")).toBe(1);
+		// Oversized rich payloads are not promoted, so the granted pool slot maps to
+		// one HTML sendMessage and continuations are drained on later slots.
+		expect(countMethod(bot, "sendRichMessage")).toBe(0);
 		const first = bot.calls.filter(c => c.method === "sendMessage");
 		expect(first).toHaveLength(1);
 		expect(first[0]!.body.text).toBe(chunks[0]);


### PR DESCRIPTION
## Problem

PR #1711 added `GJC_NOTIFICATIONS_TURN_MAX` and made Telegram split oversized finalized turn messages through the shared rate-limit pool. That fixed the unsafe fan-out path, but it intentionally preserved the old default: finalized notification turns are still summarized to 3500 characters before Telegram chunking sees the text.

A real v0.9.0 Telegram session showed the remaining UX problem: the local assistant answer was about 3951 characters, but the Telegram mirror ended around the 3500-character cutoff with `…`. Because the notification core truncated first, the existing Telegram chunker could not deliver the tail.

## Why this changes the default

This is a follow-up policy change on top of #1711, not a replacement for it:

- #1706 correctly identified the pre-chunking 3500-character finalized-turn cap, but was closed because raising the cap exposed an unsafe Telegram fan-out path: one rate-limit pool slot could send many split chunks.
- #1711 fixed that safety issue by scheduling split Telegram chunks through the shared rate-limit pool and bounding `GJC_NOTIFICATIONS_TURN_MAX` to `[280, 40000]`.
- With that safety work in place, the remaining default behavior is now the issue: split-capable Telegram still receives a lossy 3500-character finalized answer unless the operator already knows to set an env var.

For Telegram users, a finalized agent turn mirror is expected to preserve the final answer, not silently drop the tail by default. Summary-style mirrors are still supported by setting `GJC_NOTIFICATIONS_TURN_MAX=3500` or another lower finite value.

## Change

- Default finalized `turn_stream` / pre-ask capture cap to the existing bounded full-turn ceiling (`40000`) instead of `3500`.
- Keep `GJC_NOTIFICATIONS_TURN_MAX` as the operator override, now allowing summary-style mirrors to lower the cap explicitly.
- Leave live `message_update` previews capped at 3500 so streaming still edits one preview message and does not fan out in-progress turns.
- Update the notification live-stream regression tests and changelog.

This intentionally does not change Telegram's `4096` message limit or lower chunking to `3500`; the root issue is the pre-chunking finalized-turn cap. #1711 already made chunked finalized delivery rate-limit safe.

## Scope / risk

This changes the default finalized notification payload cap at the notification core layer, not only inside Telegram. The cap remains finite (`40000`) and redaction/live-preview behavior is unchanged. The tradeoff is intentional: finalized mirrors become lossless-by-default within the existing bounded ceiling, while operators who prefer glanceable summaries can opt down with `GJC_NOTIFICATIONS_TURN_MAX`.

## Related prior work

- #1706 identified the original 3500-character finalized-turn cap and introduced an opt-in env override, but was closed due to the then-unsafe split fan-out/rate-limit behavior.
- #1711 merged the safer version with bounded `GJC_NOTIFICATIONS_TURN_MAX` plus rate-limit-pool scheduling for split Telegram chunks. This PR addresses the remaining default behavior after that safety work.

## Verification

- `bun test packages/coding-agent/test/notifications-live-stream.test.ts -t "finalized turn text|GJC_NOTIFICATIONS_TURN_MAX|live frames"`
- `bun test packages/coding-agent/test/notifications-live-stream.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun --cwd=packages/coding-agent run check` (passes; Biome reports existing informational suggestions in `telegram-daemon.ts` and `notifications-live-stream.test.ts`)
