### PR TITLE
fix(coding-agent): exit gjc notify setup cleanly on cancel

### DIFF
--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -31,6 +31,9 @@ export interface NotifyCommandDeps {
 	setupRedact?: boolean;
 	setupInteractive?: boolean;
 	threadedModePrompt?: (message: string) => Promise<string>;
+	tokenPrompt?: () => Promise<string>;
+	setExitCode?: (code: number) => void;
+	exitProcess?: (code: number) => void;
 }
 
 interface TelegramApiResponse<T> {
@@ -126,6 +129,27 @@ export async function runNotifyCommand(cmd: NotifyCommandArgs, deps: NotifyComma
 	}
 }
 
+export async function runNotifyCliCommand(cmd: NotifyCommandArgs, deps: NotifyCommandDeps = {}): Promise<void> {
+	try {
+		await runNotifyCommand(cmd, deps);
+	} catch (error) {
+		if (cmd.action !== "setup" || !(error instanceof Error)) {
+			throw error;
+		}
+
+		const cancelled = error.message === "Telegram bot token prompt cancelled.";
+		process.stderr.write(cancelled ? "Telegram notify setup cancelled.\n" : `Error: ${error.message}\n`);
+		const code = cancelled ? 130 : 1;
+		if (deps.setExitCode) {
+			deps.setExitCode(code);
+		} else {
+			process.exitCode = code;
+		}
+		const exitProcess = deps.exitProcess ?? (deps.setExitCode ? undefined : process.exit);
+		exitProcess?.(code);
+	}
+}
+
 async function getSettings(deps: NotifyCommandDeps): Promise<Settings> {
 	if (deps.settings) return deps.settings;
 	const { Settings } = await import("../config/settings");
@@ -136,7 +160,7 @@ async function runSetup(deps: NotifyCommandDeps): Promise<void> {
 	const settings = await getSettings(deps);
 	const fetchImpl = deps.fetchImpl ?? globalThis.fetch;
 	const apiBase = deps.apiBase ?? DEFAULT_API_BASE;
-	const token = deps.setupToken ?? (await promptForToken());
+	const token = deps.setupToken ?? (await (deps.tokenPrompt ?? promptForToken)());
 	if (!token.trim()) {
 		throw new Error("Telegram bot token is required.");
 	}
@@ -179,6 +203,7 @@ async function runSetup(deps: NotifyCommandDeps): Promise<void> {
 type TokenPromptInput = NodeJS.ReadStream & {
 	isRaw?: boolean;
 	setRawMode?: (mode: boolean) => unknown;
+	pause?: () => unknown;
 };
 
 type TokenPromptOutput = Pick<NodeJS.WriteStream, "write">;
@@ -206,6 +231,7 @@ export async function promptForToken(
 			input.off("data", onData);
 			input.off("error", onError);
 			input.setRawMode?.(wasRaw);
+			input.pause?.();
 			output.write("\n");
 		};
 

--- a/packages/coding-agent/src/commands/notify.ts
+++ b/packages/coding-agent/src/commands/notify.ts
@@ -2,7 +2,7 @@
  * Configure Telegram notifications.
  */
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
-import { type NotifyAction, type NotifyCommandArgs, runNotifyCommand } from "../cli/notify-cli";
+import { type NotifyAction, type NotifyCommandArgs, runNotifyCliCommand } from "../cli/notify-cli";
 import { initTheme } from "../modes/theme/theme";
 
 const ACTIONS: NotifyAction[] = ["setup", "status", "daemon-internal"];
@@ -56,6 +56,6 @@ export default class Notify extends Command {
 		};
 
 		if (action !== "daemon-internal") await initTheme();
-		await runNotifyCommand(cmd);
+		await runNotifyCliCommand(cmd);
 	}
 }

--- a/packages/coding-agent/test/notify-setup.test.ts
+++ b/packages/coding-agent/test/notify-setup.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { parseNotifyArgs, promptForToken, runNotifyCommand } from "../src/cli/notify-cli";
+import { parseNotifyArgs, promptForToken, runNotifyCliCommand, runNotifyCommand } from "../src/cli/notify-cli";
 import { Settings } from "../src/config/settings";
 import { getNotificationConfig, maskToken } from "../src/notifications/config";
 import {
@@ -72,6 +72,7 @@ class FakeTokenInput extends EventEmitter {
 	isTTY = true;
 	isRaw = false;
 	resumeCalls = 0;
+	pauseCalls = 0;
 
 	setRawMode(mode: boolean): this {
 		this.isRaw = mode;
@@ -80,6 +81,10 @@ class FakeTokenInput extends EventEmitter {
 
 	resume(): this {
 		this.resumeCalls++;
+		return this;
+	}
+	pause(): this {
+		this.pauseCalls++;
 		return this;
 	}
 }
@@ -122,8 +127,23 @@ describe("notify setup cli", () => {
 		await expect(prompt).resolves.toBe(token);
 		expect(input.isRaw).toBe(false);
 		expect(input.resumeCalls).toBe(1);
+		expect(input.pauseCalls).toBe(1);
 		expect(output.text).toContain("Telegram BotFather token: ");
 		expect(output.text).not.toContain(token);
+	});
+
+	test("interactive token prompt pauses input when cancelled", async () => {
+		const input = new FakeTokenInput();
+		const output = new FakeTokenOutput();
+
+		const prompt = promptForToken(input as unknown as NodeJS.ReadStream, output);
+		input.emit("data", Buffer.from("\u0003"));
+
+		await expect(prompt).rejects.toThrow("Telegram bot token prompt cancelled.");
+		expect(input.isRaw).toBe(false);
+		expect(input.resumeCalls).toBe(1);
+		expect(input.pauseCalls).toBe(1);
+		expect(output.text).toContain("Telegram BotFather token: ");
 	});
 
 	test("getMe ok plus private message writes settings and reads via config helper", async () => {
@@ -223,6 +243,65 @@ describe("notify setup cli", () => {
 				),
 			),
 		).rejects.toThrow("Timed out waiting for a private Telegram message");
+		expect(getNotificationConfig(settings).enabled).toBe(false);
+	});
+	test("cli setup reports pairing timeout without uncaught stack", async () => {
+		const settings = Settings.isolated();
+		const { fetchImpl } = makeFetch({
+			getMe: [{ ok: true, result: { id: 1 } }],
+			getUpdates: [
+				{ ok: true, result: [] },
+				{ ok: true, result: [] },
+			],
+		});
+		let exitCode: number | undefined;
+
+		const { stderr } = await captureOutput(() =>
+			runNotifyCliCommand(
+				{ action: "setup", rawArgs: [] },
+				{
+					fetchImpl,
+					settings,
+					setupToken: token,
+					pollTimeoutMs: 1,
+					pollIntervalMs: 0,
+					setExitCode: code => {
+						exitCode = code;
+					},
+				},
+			),
+		);
+
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("Error: Timed out waiting for a private Telegram message");
+		expect(stderr).not.toContain("[Uncaught Exception]");
+		expect(stderr).not.toContain("at waitForPrivateChat");
+		expect(getNotificationConfig(settings).enabled).toBe(false);
+	});
+
+	test("cli setup reports token prompt cancellation cleanly", async () => {
+		const settings = Settings.isolated();
+		let exitCode: number | undefined;
+
+		const { stderr } = await captureOutput(() =>
+			runNotifyCliCommand(
+				{ action: "setup", rawArgs: [] },
+				{
+					settings,
+					tokenPrompt: async () => {
+						throw new Error("Telegram bot token prompt cancelled.");
+					},
+					setExitCode: code => {
+						exitCode = code;
+					},
+				},
+			),
+		);
+
+		expect(exitCode).toBe(130);
+		expect(stderr).toBe("Telegram notify setup cancelled.\n");
+		expect(stderr).not.toContain("[Uncaught Exception]");
+		expect(stderr).not.toContain("Telegram bot token prompt cancelled.");
 		expect(getNotificationConfig(settings).enabled).toBe(false);
 	});
 


### PR DESCRIPTION
## Problem summary

gjc notify setup did not exit cleanly when the Telegram bot token prompt was cancelled with Ctrl-C. The prompt restored raw mode, but the TTY input stream could remain resumed, leaving the process hanging until another interrupt. Setup failures could also surface as uncaught-style stack output instead of a concise CLI error.

## Reproduction/context

1. Run:

```sh
gjc notify setup
```

2. At `Telegram BotFather token:`, press Ctrl-C.

Before the fix, cancellation could leave the process alive and require a second Ctrl-C. The desired behavior is immediate CLI termination with a clean cancellation message and exit code 130.

## Proposed fix / implementation plan

- Add a CLI-facing wrapper, `runNotifyCliCommand`, around the lower-level notify command runner.
- For setup errors:
  - Print concise stderr output.
  - Return exit code 130 for token prompt cancellation.
  - Return exit code 1 for other setup failures.
  - Preserve lower-level `runNotifyCommand` behavior for tests/internal callers.
- Inject `tokenPrompt`, `setExitCode`, and `exitProcess` dependencies for testability.
- During token prompt cleanup, call `input.pause?.()` after removing listeners and restoring raw mode.

## Affected files

- `packages/coding-agent/src/cli/notify-cli.ts`
- `packages/coding-agent/src/commands/notify.ts`
- `packages/coding-agent/test/notify-setup.test.ts`

## Tests run

```sh
bun test packages/coding-agent/test/notify-setup.test.ts
bun --cwd=packages/coding-agent run check
```

Focused test result: 29 pass, 0 fail.

`check` completed successfully; it reported two unrelated lint info items.

## Manual smoke

```sh
gjc notify setup
# Press Ctrl-C at the token prompt
```

Expected:

```text
Telegram notify setup cancelled.
```

Expected process behavior:

- Does not hang.
- Exits with code 130.

## Uncertainty / remaining risks

- Manual TTY behavior should be rechecked in the maintainer’s local shell because stdin lifecycle bugs can be environment-sensitive.
