### PR TITLE
fix: preserve streamed Anthropic tool args

### DIFF
--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -229,6 +229,68 @@ describe("anthropic stream envelope handling", () => {
 		expect(result.content).toEqual([{ type: "text", text: "hello" }]);
 	});
 
+	it("preserves streamed tool-call arguments through Anthropic partial JSON deltas", async () => {
+		const args = {
+			command: "printf hi",
+			cwd: "/tmp/worktree",
+			timeout: 5,
+		};
+		vi.spyOn(Messages.prototype, "create").mockImplementation(
+			() =>
+				createMockRequest([
+					{
+						type: "message_start",
+						message: {
+							id: "msg_tool_args",
+							usage: {
+								input_tokens: 12,
+								output_tokens: 0,
+								cache_read_input_tokens: 0,
+								cache_creation_input_tokens: 0,
+							},
+						},
+					},
+					{
+						type: "content_block_start",
+						index: 0,
+						content_block: { type: "tool_use", id: "tool_args", name: "bash", input: {} },
+					},
+					{
+						type: "content_block_delta",
+						index: 0,
+						delta: { type: "input_json_delta", partial_json: '{"command":"printf' },
+					},
+					{
+						type: "content_block_delta",
+						index: 0,
+						delta: { type: "input_json_delta", partial_json: ' hi","cwd":"/tmp/worktree","timeout":5}' },
+					},
+					{ type: "content_block_stop", index: 0 },
+					{
+						type: "message_delta",
+						delta: { stop_reason: "tool_use" },
+						usage: { output_tokens: 7 },
+					},
+					{ type: "message_stop" },
+				]) as never,
+		);
+
+		const stream = streamAnthropic(model, context, { apiKey: "sk-ant-test" });
+		const events: AssistantMessageEvent[] = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const result = await stream.result();
+		const deltaEvents = events.filter(event => event.type === "toolcall_delta");
+		const endEvent = events.find(event => event.type === "toolcall_end");
+
+		expect(deltaEvents).toHaveLength(2);
+		expect(endEvent?.type).toBe("toolcall_end");
+		if (endEvent?.type !== "toolcall_end") throw new Error("Expected toolcall_end");
+		expect(endEvent.toolCall.arguments).toEqual(args);
+		expect(result.content).toEqual([{ type: "toolCall", id: "tool_args", name: "bash", arguments: args }]);
+	});
+
 	it("ignores ping before message_start and streams the response once", async () => {
 		let attempt = 0;
 		vi.spyOn(Messages.prototype, "create").mockImplementation(() => {

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -36,17 +36,27 @@ interface RenderInitialMessagesOptions {
 	preserveExistingChat?: boolean;
 }
 
+function cloneRenderArgs(args: Record<string, unknown>): Record<string, unknown> {
+	try {
+		return structuredClone(args);
+	} catch {
+		return { ...args };
+	}
+}
+
 export function argsWithPartialJson(args: unknown, partialJson: unknown): unknown {
 	if (typeof partialJson !== "string" || !args || typeof args !== "object" || Array.isArray(args)) return args;
-	// Non-enumerable so the transient streaming buffer reaches renderers via direct
-	// property read but never serializes into persisted/wire message content.
-	Object.defineProperty(args, "__partialJson", {
+	// Keep the transient streaming buffer on a renderer-only snapshot. The live
+	// assistant message args are later validated/executed, so UI-only metadata or
+	// renderer mutations must never share that object reference.
+	const renderArgs = cloneRenderArgs(args as Record<string, unknown>);
+	Object.defineProperty(renderArgs, "__partialJson", {
 		value: partialJson,
 		enumerable: false,
 		configurable: true,
 		writable: true,
 	});
-	return args;
+	return renderArgs;
 }
 
 type QueuedMessages = {

--- a/packages/coding-agent/test/g004-streamed-tool-args-qa.test.ts
+++ b/packages/coding-agent/test/g004-streamed-tool-args-qa.test.ts
@@ -186,12 +186,13 @@ describe("G004 streamed tool args QA", () => {
 		component.dispose();
 	});
 
-	it("PARTIALJSON-LEAK keeps streaming partial JSON out of serialized message content", async () => {
+	it("PARTIALJSON-LEAK keeps streaming partial JSON out of serialized and executable message content", async () => {
+		const originalArgs = { command: "echo done" };
 		const content = {
 			type: "toolCall",
 			id: "leak",
 			name: "bash",
-			arguments: { command: "echo done" },
+			arguments: originalArgs,
 			partialJson: '{"command":"echo part',
 		};
 		const message = assistantMessage([content]);
@@ -203,14 +204,52 @@ describe("G004 streamed tool args QA", () => {
 			message,
 			assistantMessageEvent: { contentIndex: 0 },
 		} as any);
-		expect((message.content[0].arguments as any).__partialJson).toBe(content.partialJson);
+		expect(message.content[0].arguments).toBe(originalArgs);
+		expect(message.content[0].arguments).toEqual({ command: "echo done" });
+		expect((message.content[0].arguments as any).__partialJson).toBeUndefined();
 		expect(JSON.stringify(message.content)).not.toContain("__partialJson");
 		await controller.handleEvent({ type: "message_end", message } as any);
-		expect((message.content[0].arguments as any).__partialJson).toBe(content.partialJson);
+		expect(message.content[0].arguments).toBe(originalArgs);
+		expect(message.content[0].arguments).toEqual({ command: "echo done" });
+		expect((message.content[0].arguments as any).__partialJson).toBeUndefined();
 		expect(JSON.stringify(message.content)).not.toContain("__partialJson");
 		ctx.pendingTools.forEach((component: any) => {
 			component.dispose?.();
 		});
+	});
+
+	it("EXECUTION-ARGS-SNAPSHOT preserves streamed final args for validation after UI rendering", async () => {
+		for (const [toolName, args, partialJson] of [
+			["bash", { command: "printf hi", timeout: 5 }, '{"command":"printf hi"'],
+			["edit", { input: "§tmp/issue-1870.txt\n»EOF\nhello" }, '{"input":"§tmp/issue-1870.txt'],
+			["find", { paths: ["packages/coding-agent/src/**/*.ts"], limit: 3 }, '{"paths":["packages/coding-agent'],
+		] as const) {
+			const content = {
+				type: "toolCall",
+				id: `preserve-${toolName}`,
+				name: toolName,
+				arguments: args,
+				partialJson,
+			};
+			const message = assistantMessage([content]);
+			const ctx = makeCtx();
+			ctx.streamingMessage = message;
+			await new EventController(ctx).handleEvent({
+				type: "message_update",
+				message,
+				assistantMessageEvent: { contentIndex: 0 },
+			} as any);
+			const beforeEnd = structuredClone(message.content[0].arguments);
+			await new EventController(ctx).handleEvent({ type: "message_end", message } as any);
+			expect(message.content[0].arguments).toBe(args);
+			expect(message.content[0].arguments).toEqual(beforeEnd);
+			expect(message.content[0].arguments).not.toEqual({});
+			expect((message.content[0].arguments as any).__partialJson).toBeUndefined();
+			expect(JSON.stringify(message.content[0].arguments)).not.toContain("__partialJson");
+			ctx.pendingTools.forEach((component: any) => {
+				component.dispose?.();
+			});
+		}
 	});
 
 	it("COALESCE-SKIP recomputes edit preview for same-length changed content via args identity version", async () => {
@@ -252,10 +291,11 @@ describe("G004 streamed tool args QA", () => {
 			partialJson: '{"command":"echo restored',
 		} as any;
 		// Restore path must use the shared non-enumerable helper so persisted content stays clean.
-		argsWithPartialJson(restoredContent.arguments, restoredContent.partialJson);
+		const renderArgs = argsWithPartialJson(restoredContent.arguments, restoredContent.partialJson);
 		expect(JSON.stringify(restoredContent)).not.toContain("__partialJson");
-		expect((restoredContent.arguments as any).__partialJson).toBe(restoredContent.partialJson);
-		const restore = new ToolExecutionComponent("bash", restoredContent.arguments, {}, undefined, ui);
+		expect((restoredContent.arguments as any).__partialJson).toBeUndefined();
+		expect((renderArgs as any).__partialJson).toBe(restoredContent.partialJson);
+		const restore = new ToolExecutionComponent("bash", renderArgs, {}, undefined, ui);
 		expect(rendered(restore)).toBe(rendered(live));
 		live.dispose();
 		restore.dispose();


### PR DESCRIPTION
## Summary
- snapshot streaming renderer args before adding non-enumerable `__partialJson` so UI/renderers cannot mutate the assistant message args later used for validation/execution
- add Anthropic partial JSON stream regression coverage for final bash arguments
- add coding-agent regression coverage for bash/edit/find final args staying non-empty and unmodified after streaming UI rendering

## Verification
- bun test packages/coding-agent/test/g004-streamed-tool-args-qa.test.ts
- bun test packages/ai/test/anthropic-stream-envelope.test.ts
- bun --cwd=packages/coding-agent run check
- bun --cwd=packages/ai run check

Fixes #1870

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*