### PR TITLE
ci: extend affected shard timeout

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -120,7 +120,11 @@ jobs:
     needs: [affected-plan, affected-native]
     if: ${{ always() && needs.affected-plan.outputs.relevant == 'true' && needs.affected-plan.outputs.has_tasks == 'true' && needs.affected-native.result != 'failure' && needs.affected-native.result != 'cancelled' }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    # Broad push-mode coding-agent/root test shards have repeatedly reached the
+    # previous 30m cap without assertion failures. Give the affected shard runner
+    # enough room to finish those known-heavy shards while preserving a bounded
+    # timeout for genuine hangs.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.affected-plan.outputs.matrix) }}


### PR DESCRIPTION
## Summary
- Align dev-ci affected shard timeout with the 60m full TypeScript test budget.
- Prevent push-mode coding-agent/root test shards from being cancelled at 30m after otherwise-green work.

## Evidence
- Dev CI run 28967281996 on `dev` cancelled exactly at the 30m affected shard timeout for `test:@gajae-code/coding-agent:shard-1-of-8`.
- PR #1721 root-test showed the same timeout pattern before this fix was tested there.

## Verification
- `bun scripts/check-workflow-yaml.ts`
- `bun test scripts/ci-dev-affected.test.ts`
