### PR TITLE
fix(ci): split full workspace affected tests

### DIFF
--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -453,4 +453,23 @@ describe("push-mode broad planning still runs the fuller suite", () => {
 		const entries = describeTasks(tasks);
 		expect(entries.find(entry => entry.key === "test:@gajae-code/coding-agent:shard-1-of-8")?.native).toBe(true);
 	});
+
+	test("full-workspace changes partition root tests into matrix shards", () => {
+		const tasks = planTasks(["tsconfig.json"], [codingAgent]);
+		const keys = tasks.map(task => task.key);
+
+		expect(keys).toContain("root-check");
+		expect(keys).toContain("root-test:release");
+		expect(keys).not.toContain("root-test");
+		expect(tasks.filter(task => task.key.startsWith("test:@gajae-code/coding-agent:shard-")).map(task => task.key)).toEqual([
+			"test:@gajae-code/coding-agent:shard-1-of-8",
+			"test:@gajae-code/coding-agent:shard-2-of-8",
+			"test:@gajae-code/coding-agent:shard-3-of-8",
+			"test:@gajae-code/coding-agent:shard-4-of-8",
+			"test:@gajae-code/coding-agent:shard-5-of-8",
+			"test:@gajae-code/coding-agent:shard-6-of-8",
+			"test:@gajae-code/coding-agent:shard-7-of-8",
+			"test:@gajae-code/coding-agent:shard-8-of-8",
+		]);
+	});
 });

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -9,8 +9,9 @@ const ZERO_SHA = /^0+$/;
 const PACKAGE_SCOPES = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] as const;
 const PYTHON_DEV_SETUP =
 	"python3 -m pip install --user --upgrade 'pip>=24' 'setuptools>=69' wheel && python3 -m pip install --user -e python/gjc-rpc -e 'python/robogjc[dev]'";
-// The coding-agent package has hundreds of test files; keep dev affected push
-// validation below the 30m shard timeout by splitting its package-wide suite.
+// The coding-agent package has hundreds of test files; keep dev affected
+// validation below the shard timeout by splitting package-wide/full-workspace
+// TypeScript suites across the matrix instead of one root-test runner.
 const CODING_AGENT_TEST_SHARDS = 8;
 
 // Keys for tasks that compile the @gajae-code/natives addon. They run once in
@@ -444,7 +445,7 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 	if (fullWorkspace) {
 		add(tasks, "root-check", "Root TypeScript/tooling check", ["bun", "run", "check:ts"]);
 		addNativeBuild(tasks);
-		add(tasks, "root-test", "Root workspace TypeScript tests", ["bun", "run", "test:ts"]);
+		addWorkspaceTestTasks(tasks, packages);
 	} else if (!ciOnly && !workflowHarnessOnly) {
 		const affectedPackages = expandWithDependents(touchedPackages, packages);
 		if (affectedPackages.some(workspacePackage => workspacePackage.manifest.scripts?.test)) {
@@ -527,7 +528,7 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 	if (fullWorkspace) {
 		add(tasks, "root-check", "Root TypeScript/tooling check", ["bun", "run", "check:ts"]);
 		addNativeBuild(tasks);
-		add(tasks, "root-test", "Root workspace TypeScript tests", ["bun", "run", "test:ts"]);
+		addWorkspaceTestTasks(tasks, packages);
 	}
 
 	for (const changedPath of relevant) {
@@ -616,6 +617,15 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 // so the matrix shard name stays small and directly traceable to the file.
 function addTestFileTask(tasks: Map<string, Task>, testFile: string): void {
 	add(tasks, `test:${testFile}`, `Test ${testFile}`, ["bun", "test", testFile]);
+}
+
+function addWorkspaceTestTasks(tasks: Map<string, Task>, packages: readonly WorkspacePackage[]): void {
+	add(tasks, "root-test:release", "Root release contract tests", ["bun", "run", "test:release"]);
+	for (const workspacePackage of packages) {
+		if (workspacePackage.manifest.scripts?.test) {
+			addPackageTestTasks(tasks, workspacePackage);
+		}
+	}
 }
 
 function addPackageTestTasks(tasks: Map<string, Task>, workspacePackage: WorkspacePackage): void {


### PR DESCRIPTION
## Summary
- Cherry-picked/adapted the minimal CI sharding repair from 7174c4f734ff04a33f4ad3068c3dc37736a235c9 onto current dev.
- Replaces the monolithic full-workspace `root-test` affected task with release contract tests plus package test tasks, preserving coverage while matrix-sharding `@gajae-code/coding-agent` into 8 shards.
- Adds regression coverage that full-workspace changes no longer schedule the single `root-test` runner.

## Validation
- `bun test scripts/ci-dev-affected.test.ts`
- `CI_DEV_CHANGED_PATHS=tsconfig.json CI_DEV_PLAN_MODE=push bun scripts/ci-dev-affected.ts --dry-run`
- `CI_DEV_CHANGED_PATHS=tsconfig.json CI_DEV_PLAN_MODE=push bun scripts/ci-dev-affected.ts --matrix-json`
- `bun run test:release`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*