### PR TITLE
Diagnose tmux session exits

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Finalized notification turn mirrors now default to the bounded full-turn cap so Telegram's existing chunked delivery can send long assistant answers instead of receiving an already-truncated 3500-character summary; `GJC_NOTIFICATIONS_TURN_MAX` remains available to lower the cap for summary-style mirrors, and live previews stay capped as one editable message.
+- `gjc --tmux` now wraps the inner GJC command with a durable `tmux-exit.json` marker next to `runtime-state.json`, so a tmux-resident session that exits before normal runtime-state finalization leaves a public-safe exit timestamp/code for silent-vanish diagnosis (#1746).
 
 ## [0.9.1] - 2026-07-08
 

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -158,11 +158,43 @@ export interface GjcTmuxProfileContext {
 	version?: string | null;
 }
 
+function tmuxExitMarkerPath(sessionStateFile: string): string {
+	return path.join(path.dirname(sessionStateFile), "tmux-exit.json");
+}
+
+function buildPosixTmuxExitMarkerPrefix(markerPath: string): string {
+	const markerDir = path.dirname(markerPath);
+	return [
+		`__gjc_tmux_exit_marker=${shellQuote(markerPath)}`,
+		"__gjc_tmux_write_exit_marker() { __gjc_tmux_status=$?",
+		"__gjc_tmux_ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date)",
+		`mkdir -p ${shellQuote(markerDir)} 2>/dev/null || true`,
+		'printf \'{"schema_version":1,"source":"tmux_inner_shell","ended_at":"%s","exit_code":%s}\\n\' "$__gjc_tmux_ended_at" "$__gjc_tmux_status" > "$__gjc_tmux_exit_marker" 2>/dev/null || true',
+		"}",
+		"trap __gjc_tmux_write_exit_marker EXIT",
+	].join("; ");
+}
+
+function buildPowerShellTmuxExitMarkerFinally(markerPath: string): string {
+	const markerDir = path.win32.dirname(markerPath);
+	return [
+		"} finally {",
+		"\ttry {",
+		`\t\tNew-Item -ItemType Directory -Force -Path ${powershellQuote(markerDir)} -ErrorAction Stop | Out-Null`,
+		"\t\t$__gjcTmuxExitMarker = @{ schema_version = 1; source = 'tmux_inner_shell'; ended_at = (Get-Date).ToUniversalTime().ToString('o'); exit_code = $__gjcTmuxExitCode } | ConvertTo-Json -Compress",
+		`\t\tSet-Content -LiteralPath ${powershellQuote(markerPath)} -Value $__gjcTmuxExitMarker -Encoding UTF8 -ErrorAction Stop`,
+		"\t} catch {",
+		"\t}",
+		"}",
+	].join("\n");
+}
+
 interface CommandResolutionContext {
 	cwd: string;
 	argv: string[];
 	execPath: string;
 	extraEnv?: Record<string, string>;
+	tmuxExitMarkerPath?: string;
 	platform?: NodeJS.Platform;
 }
 
@@ -286,7 +318,17 @@ function buildWindowsPowerShellInnerCommand(context: CommandResolutionContext, r
 	const innerArgs = stripRootTmuxFlag(rawArgs).map(powershellQuote).join(" ");
 	const invocation = `& ${resolvedCommand} ${innerArgs}`;
 	const exitLine = "if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 }";
-	const script = [...envLines, invocation, exitLine].join("\n");
+	const script = context.tmuxExitMarkerPath
+		? [
+				...envLines,
+				"$__gjcTmuxExitCode = 1",
+				"try {",
+				`\t${invocation}`,
+				"\tif ($null -ne $LASTEXITCODE) { $__gjcTmuxExitCode = $LASTEXITCODE } else { $__gjcTmuxExitCode = 1 }",
+				buildPowerShellTmuxExitMarkerFinally(context.tmuxExitMarkerPath),
+				"exit $__gjcTmuxExitCode",
+			].join("\n")
+		: [...envLines, invocation, exitLine].join("\n");
 	// Encode the script as UTF-16LE base64 for pwsh -EncodedCommand. Do NOT
 	// prepend a UTF-16LE BOM (0xFF 0xFE): the BOM survives the decode and is
 	// inserted as a literal U+FEFF character in front of the first script
@@ -366,7 +408,9 @@ function buildInnerCommand(context: CommandResolutionContext, rawArgs: string[])
 	if (isWindowsPlatform(context.platform)) return buildWindowsPowerShellInnerCommand(context, rawArgs);
 	const command = resolveCurrentGjcCommand(context);
 	const quoted = [...command, ...stripRootTmuxFlag(rawArgs)].map(shellQuote).join(" ");
-	return `exec env ${GJC_TMUX_LAUNCHED_ENV}=1${buildEnvAssignments(context.extraEnv)} ${quoted}`;
+	const invocation = `env ${GJC_TMUX_LAUNCHED_ENV}=1${buildEnvAssignments(context.extraEnv)} ${quoted}`;
+	if (!context.tmuxExitMarkerPath) return `exec ${invocation}`;
+	return `${buildPosixTmuxExitMarkerPrefix(context.tmuxExitMarkerPath)}; ${invocation}; exit $?`;
 }
 
 function visibleWidth(value: string): number {
@@ -695,6 +739,7 @@ export function buildDefaultTmuxLaunchPlan(context: TmuxLaunchContext): TmuxLaun
 				// session, which would split/send workers into the wrong session.
 				[GJC_TMUX_ACTIVE_SESSION_ENV]: sessionName,
 			},
+			tmuxExitMarkerPath: tmuxExitMarkerPath(sessionStateFile),
 			platform,
 		},
 		context.rawArgs,

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -346,6 +346,51 @@ describe("default GJC tmux launch", () => {
 		expect(plan?.innerCommand).not.toContain("'--tmux'");
 		expect(plan.innerCommand).toContain("GJC_COORDINATOR_SESSION_ID=");
 		expect(plan.innerCommand).toContain("GJC_COORDINATOR_SESSION_STATE_FILE=");
+		expect(plan.innerCommand).toContain("tmux-exit.json");
+		expect(plan.innerCommand).toContain("trap __gjc_tmux_write_exit_marker EXIT");
+		expect(plan.innerCommand).not.toStartWith("exec ");
+	});
+
+	it("POSIX tmux inner wrapper writes a public-safe exit marker and preserves exit status", () => {
+		if (process.platform === "win32") return;
+		const cwd = fs.mkdtempSync(path.join("/tmp", "gjc-tmux-exit-marker-"));
+		try {
+			const plan = buildDefaultTmuxLaunchPlan({
+				parsed: args({ messages: ["-c", "exit 7"], tmux: true }),
+				rawArgs: ["--tmux", "-c", "exit 7"],
+				cwd,
+				env: {},
+				argv: ["bun", "/bin/sh"],
+				execPath: "/bin/bun",
+				platform: "linux",
+				tty: interactiveTty,
+				tmuxAvailable: true,
+				currentBranch: "",
+				existingBranchSessionName: null,
+			});
+			expect(plan).toBeDefined();
+			if (!plan) throw new Error("expected tmux plan");
+
+			const result = Bun.spawnSync(["/bin/sh", "-c", plan.innerCommand], {
+				cwd,
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			expect(result.exitCode).toBe(7);
+
+			expect(plan.sessionStateFile).toBeTruthy();
+			if (!plan.sessionStateFile) throw new Error("expected session state file");
+			const markerPath = path.join(path.dirname(plan.sessionStateFile), "tmux-exit.json");
+			const marker = JSON.parse(fs.readFileSync(markerPath, "utf8")) as Record<string, unknown>;
+			expect(marker).toEqual({
+				schema_version: 1,
+				source: "tmux_inner_shell",
+				ended_at: expect.any(String),
+				exit_code: 7,
+			});
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
 	});
 
 	it("sizes detached tmux new-session to the caller terminal when dimensions are known", () => {
@@ -1690,6 +1735,9 @@ it("emits a BOM-less UTF-16LE encoded command and a direct `&` invocation for na
 	// is `& 'cmd' 'arg1' 'arg2'`, which is exactly what buildWindowsPowerShell
 	// InnerCommand produces below.
 	expect(script).toMatch(/&\s+'/);
+	expect(script).toContain("tmux-exit.json");
+	expect(script).toContain("finally {");
+	expect(script).toContain("Set-Content -LiteralPath");
 });
 
 it("captures psmux stderr in the attach-failed diagnostic", () => {


### PR DESCRIPTION
## Summary
- Add a durable `tmux-exit.json` marker beside `runtime-state.json` for `gjc --tmux` inner commands.
- Preserve inner command exit status while recording only public-safe metadata: schema version, source, UTC end timestamp, and exit code.
- Cover POSIX wrapper execution and Windows encoded-command wrapper shape in launch-tmux tests.

## Verification
- `bunx biome check packages/coding-agent/src/gjc-runtime/launch-tmux.ts packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/CHANGELOG.md`
- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `git diff --check`

Fixes #1746