### PR TITLE
fix(tui): re-anchor macOS IME cursor after repaints

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "ci:build:native": "bun scripts/ci-build-native.ts",
     "ci:test:full": "bun run test",
     "ci:test:smoke": "bun packages/coding-agent/src/cli.ts --version && bun packages/coding-agent/src/cli.ts --help && bun packages/coding-agent/src/cli.ts stats --help && bun packages/coding-agent/src/cli.ts --smoke-test",
+    "smoke:tui:iterm-ime": "bun packages/tui/test/iterm-ime-smoke.ts",
     "ci:test:install-methods": "bash scripts/install-tests/run-ci.sh",
     "ci:release:build-binaries": "bun scripts/ci-release-build-binaries.ts",
     "ci:release:publish": "bun scripts/ci-release-publish.ts",

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1616,7 +1616,7 @@ export class TUI extends Container {
 		this.#hardwareCursorRow = cursorToRow;
 		buffer += cursorSeq;
 		buffer += "\x1b[?2026l";
-		if (!this.#writeTerminal(buffer)) return false;
+		if (!this.#writeRenderBufferAndReanchorImeCursor(buffer, cursorPos, lines.length)) return false;
 
 		if (this.#debugRedraw) {
 			const msg = `[${new Date().toISOString()}] viewportRepaint: ${reason} (lines=${lines.length}, height=${height}, viewportTop=${nextViewportTop})\n`;
@@ -1761,7 +1761,7 @@ export class TUI extends Container {
 			this.#hardwareCursorRow = toRow;
 			buffer += seq;
 			buffer += "\x1b[?2026l"; // End synchronized output
-			if (!this.#writeTerminal(buffer)) return;
+			if (!this.#writeRenderBufferAndReanchorImeCursor(buffer, cursorPos, newLines.length)) return;
 			// Reset max lines when clearing, otherwise track growth
 			if (clear) {
 				this.#maxLinesRendered = newLines.length;
@@ -1811,7 +1811,7 @@ export class TUI extends Container {
 			this.#hardwareCursorRow = cursorToRow;
 			buffer += cursorSeq;
 			buffer += "\x1b[?2026l";
-			if (!this.#writeTerminal(buffer)) return;
+			if (!this.#writeRenderBufferAndReanchorImeCursor(buffer, cursorPos, newLines.length)) return;
 
 			if (this.#debugRedraw) {
 				const msg = `[${new Date().toISOString()}] viewportRepaint: ${reason} (prev=${this.#previousLines.length}, new=${newLines.length}, height=${height}, viewportTop=${nextViewportTop})\n`;
@@ -1963,7 +1963,7 @@ export class TUI extends Container {
 				this.#hardwareCursorRow = toRow;
 				buffer += seq;
 				buffer += "\x1b[?2026l";
-				if (!this.#writeTerminal(buffer)) return;
+				if (!this.#writeRenderBufferAndReanchorImeCursor(buffer, cursorPos, newLines.length)) return;
 			}
 			this.#previousLines = newLines;
 			this.#previousWidth = width;
@@ -2108,7 +2108,7 @@ export class TUI extends Container {
 		}
 
 		// Write entire buffer at once
-		if (!this.#writeTerminal(buffer)) return;
+		if (!this.#writeRenderBufferAndReanchorImeCursor(buffer, cursorPos, newLines.length)) return;
 
 		// Track cursor position for next render.
 		// cursorRow tracks end of content (for viewport calculation).
@@ -2163,19 +2163,25 @@ export class TUI extends Container {
 		return { seq, toRow: targetRow };
 	}
 
+	#writeRenderBufferAndReanchorImeCursor(
+		buffer: string,
+		cursorPos: { row: number; col: number } | null,
+		totalLines: number,
+	): boolean {
+		if (!this.#writeTerminal(buffer)) return false;
+		if (!this.#imeCursorActive) return true;
+		return this.#writeCursorPosition(cursorPos, totalLines);
+	}
+
 	/**
 	 * Write the hardware cursor position to the terminal as a standalone
 	 * synchronized output block. Use when there is no surrounding render buffer
 	 * to embed the sequences into.
 	 */
-	#writeCursorPosition(cursorPos: { row: number; col: number } | null, totalLines: number): void {
-		if (!cursorPos || totalLines <= 0) {
-			this.#hideCursor();
-			return;
-		}
+	#writeCursorPosition(cursorPos: { row: number; col: number } | null, totalLines: number): boolean {
 		const { seq, toRow } = this.#cursorControlSequence(cursorPos, totalLines, this.#hardwareCursorRow);
 		this.#hardwareCursorRow = toRow;
 		// No \x1b[?2026h/l wrapper: synchronized output flushes terminal state and discards macOS IME composition.
-		this.#writeTerminal(seq);
+		return this.#writeTerminal(seq);
 	}
 }

--- a/packages/tui/test/input-render-redteam.test.ts
+++ b/packages/tui/test/input-render-redteam.test.ts
@@ -1,12 +1,32 @@
 // MUST be first: pins terminal-capability env before @gajae-code/tui evaluates.
 import "./render-goldens-env";
 import { describe, expect, it } from "bun:test";
-import { Editor, Text, TUI } from "@gajae-code/tui";
+import { type Component, Editor, Text, TUI } from "@gajae-code/tui";
 import { defaultEditorTheme } from "./test-themes";
 import { VirtualTerminal } from "./virtual-terminal";
 
 const nextTick = (): Promise<void> => new Promise<void>(r => process.nextTick(r));
 const macro0 = (): Promise<void> => new Promise<void>(r => setTimeout(r, 0));
+
+class MutableTranscript implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	setLines(lines: string[]): void {
+		this.#lines = [...lines];
+	}
+
+	invalidate(): void {
+		// No cached state
+	}
+
+	render(): string[] {
+		return [...this.#lines];
+	}
+}
 
 interface Harness {
 	term: VirtualTerminal;
@@ -179,6 +199,40 @@ describe("keyboard input priority scheduler red-team", () => {
 			expect(bytes).toBeLessThan(typed.length * 600);
 		} finally {
 			h.tui.stop();
+		}
+	}, 30000);
+
+	it("re-anchors the macOS IME cursor after transcript repaint when the prompt draft is unchanged", async () => {
+		const previousIme = Bun.env.GJC_TUI_IME_CURSOR;
+		Bun.env.GJC_TUI_IME_CURSOR = "1";
+		const term = new VirtualTerminal(40, 6);
+		const tui = new TUI(term, false);
+		const transcript = new MutableTranscript(Array.from({ length: 10 }, (_v, i) => `row-${i}`));
+		const editor = new Editor(defaultEditorTheme);
+		tui.addChild(transcript);
+		tui.addChild(editor);
+		tui.setFocus(editor);
+		try {
+			tui.start();
+			await term.waitForRender();
+			editor.setText("하");
+			tui.requestRender(false, "test.seed-draft");
+			await term.waitForRender();
+			term.clearWriteLog();
+
+			transcript.setLines(Array.from({ length: 11 }, (_v, i) => `row-${i}`));
+			tui.requestRender(false, "stream.chunk");
+			await term.waitForRender();
+
+			const writes = term.getWriteLog();
+			expect(writes.length).toBeGreaterThanOrEqual(2);
+			expect(writes.at(-2)).toContain("\x1b[?2026h");
+			expect(writes.at(-2)).toContain("\x1b[?2026l");
+			expect(writes.at(-1)).toBe("\x1b[6G\x1b[2 q\x1b[?25h");
+		} finally {
+			tui.stop();
+			if (previousIme === undefined) delete Bun.env.GJC_TUI_IME_CURSOR;
+			else Bun.env.GJC_TUI_IME_CURSOR = previousIme;
 		}
 	}, 30000);
 });

--- a/packages/tui/test/iterm-ime-smoke.ts
+++ b/packages/tui/test/iterm-ime-smoke.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env bun
+
+Bun.env.GJC_TUI_IME_CURSOR ??= "1";
+
+const { matchesKey } = await import("@gajae-code/tui/keys");
+const { Editor } = await import("@gajae-code/tui/components/editor");
+const { Text } = await import("@gajae-code/tui/components/text");
+const { ProcessTerminal } = await import("@gajae-code/tui/terminal");
+const { TUI } = await import("@gajae-code/tui/tui");
+const { defaultEditorTheme } = await import("./test-themes");
+
+function readNumberFlag(name: string, fallback: number): number {
+	const args = process.argv.slice(2);
+	const inline = args.find(arg => arg.startsWith(`--${name}=`));
+	if (inline) {
+		const value = Number.parseInt(inline.slice(name.length + 3), 10);
+		return Number.isFinite(value) && value >= 0 ? value : fallback;
+	}
+	const index = args.indexOf(`--${name}`);
+	if (index >= 0) {
+		const value = Number.parseInt(args[index + 1] ?? "", 10);
+		return Number.isFinite(value) && value >= 0 ? value : fallback;
+	}
+	return fallback;
+}
+
+class MutableTranscript {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	append(line: string): void {
+		this.#lines.push(line);
+	}
+
+	appendMany(lines: string[]): void {
+		this.#lines.push(...lines);
+	}
+
+	invalidate(): void {
+		// No cached state.
+	}
+
+	render(): string[] {
+		return [...this.#lines];
+	}
+}
+
+const initialLines = readNumberFlag("initial-lines", 72);
+const appendMs = Math.max(100, readNumberFlag("append-ms", 700));
+const burstSize = Math.max(1, readNumberFlag("burst-size", 12));
+const autoExitMs = readNumberFlag("auto-exit-ms", 0);
+const startedAt = Date.now();
+
+const motifs = [
+	"steady repaint anchor probe",
+	"한글 조합 candidate 위치 확인",
+	"cursor-only re-anchor after repaint",
+	"mixed width 가나 abc 123",
+];
+
+let sequence = 0;
+function nextLine(origin: string): string {
+	const motif = motifs[sequence % motifs.length];
+	const line = `${origin} ${String(sequence).padStart(4, "0")} :: ${motif}`;
+	sequence += 1;
+	return line;
+}
+
+const transcript = new MutableTranscript(Array.from({ length: initialLines }, () => nextLine("seed")));
+const terminal = new ProcessTerminal();
+const tui = new TUI(terminal, false);
+const instructions = new Text(
+	[
+		"iTerm Hangul IME smoke",
+		"Compose Hangul in the prompt while transcript repaint continues above.",
+		`Ctrl+S pause/resume stream · Ctrl+B append ${burstSize} lines · Ctrl+C exit`,
+		`soft-cursor IME mode: GJC_TUI_IME_CURSOR=${Bun.env.GJC_TUI_IME_CURSOR ?? "0"}`,
+	].join("\n"),
+	1,
+	0,
+);
+const editor = new Editor(defaultEditorTheme);
+
+tui.addChild(transcript);
+tui.addChild(instructions);
+tui.addChild(editor);
+tui.setFocus(editor);
+
+let streamTimer: ReturnType<typeof setInterval> | undefined;
+let autoExitTimer: ReturnType<typeof setTimeout> | undefined;
+let streaming = true;
+let stopped = false;
+
+function appendOne(origin = "stream"): void {
+	transcript.append(nextLine(origin));
+	tui.requestRender(false, `smoke.${origin}`);
+}
+
+function appendBurst(origin = "burst"): void {
+	transcript.appendMany(Array.from({ length: burstSize }, () => nextLine(origin)));
+	tui.requestRender(false, `smoke.${origin}`);
+}
+
+function syncStreamTimer(): void {
+	if (streaming) {
+		if (!streamTimer) {
+			streamTimer = setInterval(() => appendOne("stream"), appendMs);
+		}
+		return;
+	}
+	if (streamTimer) {
+		clearInterval(streamTimer);
+		streamTimer = undefined;
+	}
+}
+
+function stopAndExit(code = 0): void {
+	if (stopped) return;
+	stopped = true;
+	if (streamTimer) {
+		clearInterval(streamTimer);
+		streamTimer = undefined;
+	}
+	if (autoExitTimer) {
+		clearTimeout(autoExitTimer);
+		autoExitTimer = undefined;
+	}
+	try {
+		tui.stop();
+	} catch {
+		// Best effort on teardown.
+	}
+	const elapsedMs = Date.now() - startedAt;
+	console.log(`\n[iTerm IME smoke] stopped after ${elapsedMs}ms with ${sequence - initialLines} appended lines.`);
+	process.exit(code);
+}
+
+tui.addInputListener(data => {
+	if (matchesKey(data, "ctrl+c")) {
+		stopAndExit(0);
+		return { consume: true };
+	}
+	if (matchesKey(data, "ctrl+s")) {
+		streaming = !streaming;
+		syncStreamTimer();
+		tui.requestRender(false, "smoke.toggle-stream");
+		return { consume: true };
+	}
+	if (matchesKey(data, "ctrl+b")) {
+		appendBurst();
+		return { consume: true };
+	}
+	return undefined;
+});
+
+process.on("SIGINT", () => stopAndExit(0));
+process.on("SIGTERM", () => stopAndExit(0));
+
+tui.start();
+syncStreamTimer();
+
+if (autoExitMs > 0) {
+	autoExitTimer = setTimeout(() => stopAndExit(0), autoExitMs);
+}

--- a/packages/tui/test/overlay-scroll.test.ts
+++ b/packages/tui/test/overlay-scroll.test.ts
@@ -95,6 +95,7 @@ describe("TUI overlays", () => {
 	let previousGjcTmuxLaunched: string | undefined;
 	let previousTerm: string | undefined;
 	let previousLegacyFullRender: string | undefined;
+	let previousImeCursor: string | undefined;
 
 	beforeEach(() => {
 		previousTmux = Bun.env.TMUX;
@@ -104,12 +105,14 @@ describe("TUI overlays", () => {
 		previousTmuxPane = Bun.env.TMUX_PANE;
 		previousGjcTmuxLaunched = Bun.env.GJC_TMUX_LAUNCHED;
 		previousTerm = Bun.env.TERM;
+		previousImeCursor = Bun.env.GJC_TUI_IME_CURSOR;
 		delete Bun.env.TMUX;
 		delete Bun.env.STY;
 		delete Bun.env.ZELLIJ;
 		delete Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
 		delete Bun.env.TMUX_PANE;
 		delete Bun.env.GJC_TMUX_LAUNCHED;
+		delete Bun.env.GJC_TUI_IME_CURSOR;
 		Bun.env.TERM = "xterm-256color";
 	});
 
@@ -148,6 +151,11 @@ describe("TUI overlays", () => {
 			delete Bun.env.TERM;
 		} else {
 			Bun.env.TERM = previousTerm;
+		}
+		if (previousImeCursor === undefined) {
+			delete Bun.env.GJC_TUI_IME_CURSOR;
+		} else {
+			Bun.env.GJC_TUI_IME_CURSOR = previousImeCursor;
 		}
 	});
 
@@ -363,6 +371,28 @@ describe("TUI overlays", () => {
 			const viewport = term.getViewport();
 			expect(viewport[0]?.trim()).toBe("cursor-anchor");
 			expect(term.getScrollBuffer().length - before).toBeLessThan(2);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("anchors macOS IME cursor-only updates with a steady block cursor in soft-cursor mode", async () => {
+		Bun.env.GJC_TUI_IME_CURSOR = "1";
+		const term = new VirtualTerminal(40, 6);
+		const tui = new TUI(term, false);
+		const component = new CursorOnlyComponent();
+		tui.addChild(component);
+		try {
+			tui.start();
+			await flushRender(term);
+			term.clearWriteLog();
+
+			component.setCursorCol(5);
+			tui.requestRender();
+			await flushRender(term);
+
+			expect(term.getWriteLog()).toEqual(["\x1b[6G\x1b[2 q\x1b[?25h"]);
+			expect(term.getViewport()[0]?.trim()).toBe("cursor-anchor");
 		} finally {
 			tui.stop();
 		}


### PR DESCRIPTION
## DEV-20260708-001

### Bug fix: Re-anchor the macOS IME cursor after TUI repaints
- Re-anchor the steady block cursor after synchronized TUI repaint paths when `GJC_TUI_IME_CURSOR=1` is active.
- Keep the IME candidate anchor stable when overflowed transcript repaints occur without changing the prompt draft.

### Tests: Add focused regression coverage for the IME anchor paths
- Add a red-team regression for transcript repaint with an unchanged Hangul draft in soft-cursor IME mode.
- Add an overlay regression that asserts cursor-only updates emit the steady block cursor anchor sequence.

### Smoke prep: Add a runnable real-iTerm reproduction harness
- Add `bun run smoke:tui:iterm-ime` so the repaint/IME-anchor scenario can be exercised on real macOS + iTerm + Hangul IME.
- Provide app-level controls for pause/resume, burst append, and clean exit during manual verification.

### Tests
- 신규: `packages/tui/test/input-render-redteam.test.ts` (1개 테스트)
- 신규: `packages/tui/test/overlay-scroll.test.ts` (1개 테스트)
- 신규: `packages/tui/test/iterm-ime-smoke.ts` (manual smoke harness)
- 전체: 233/233 통과
- Build: 성공 (`bun --cwd=packages/natives run build`)
- Smoke sanity: 성공 (`bun run smoke:tui:iterm-ime -- --auto-exit-ms 900 --append-ms 150 --initial-lines 16`)

### Changed files
- `package.json`
- `packages/tui/src/tui.ts`
- `packages/tui/test/input-render-redteam.test.ts`
- `packages/tui/test/iterm-ime-smoke.ts` (new)
- `packages/tui/test/overlay-scroll.test.ts`
