### PR TITLE
Persist reasoning effort defaults

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `gjc --tmux` now wraps the inner GJC command with a durable `tmux-exit.json` marker next to `runtime-state.json`, so a tmux-resident session that exits before normal runtime-state finalization leaves a public-safe exit timestamp/code for silent-vanish diagnosis (#1746).
 - `gjc --tmux` terminal titles now track live tmux session renames while preserving the friendly project/branch title for untouched generated session ids.
 - Telegram session forum-topic renames now remain retryable after a transient `editForumTopic` failure, so topics do not get stuck at the provisional `GJC <session>` name while the daemon incorrectly records the final title locally.
+- `/effort` selector choices now show the current reasoning effort and mirror `/model` by asking whether to apply the selected effort for the current session or save it as the default, including support for persisting `off`. Default model presets also sync their encoded effort into the persisted effort default so later `/effort` defaults are not overwritten on restart.
 
 ## [0.9.1] - 2026-07-08
 

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -1,4 +1,4 @@
-import type { ThinkingLevel } from "@gajae-code/agent-core";
+import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Api, Model } from "@gajae-code/ai";
 import type { AgentSession } from "../session/agent-session";
 import { formatClampedModelSelector } from "../thinking";
@@ -43,7 +43,10 @@ export interface PrepareModelProfileActivationOptions {
 	settings: Pick<Settings, "get">;
 	profileName: string;
 }
-
+export interface ApplyModelProfileActivationOptions {
+	persistDefault?: boolean;
+	thinkingLevelOverride?: ThinkingLevel;
+}
 export interface PreparedModelProfileActivation {
 	profileName: string;
 	session: ModelProfileActivationSession & { setModelTemporary: AgentSession["setModelTemporary"] };
@@ -345,25 +348,31 @@ export async function prepareModelProfileActivation(
 
 export async function applyPreparedModelProfileActivation(
 	prepared: PreparedModelProfileActivation,
-	options: { persistDefault?: boolean } = {},
+	options: ApplyModelProfileActivationOptions = {},
 ): Promise<void> {
 	const previousModel = prepared.previousModel;
 	const previousThinkingLevel = prepared.previousThinkingLevel;
 	const previousAgentModelOverrides = prepared.previousAgentModelOverrides;
 	const previousModelRoles = prepared.previousModelRoles;
 	const previousPersistedDefault = prepared.settings.get("modelProfile.default");
+	const previousDefaultThinkingLevel = prepared.settings.get("defaultThinkingLevel");
 	const previousActiveModelProfile = prepared.previousActiveModelProfile;
 	const previousSessionDefaultModel = prepared.previousSessionDefaultModel;
 	let modelChanged = false;
 	let overridesChanged = false;
 	let defaultChanged = false;
 	let modelRolesChanged = false;
+	let defaultThinkingChanged = false;
 
 	try {
 		if (prepared.defaultModel) {
-			await prepared.session.setModelTemporary(prepared.defaultModel, prepared.defaultThinkingLevel, {
-				persistAsSessionDefault: true,
-			});
+			await prepared.session.setModelTemporary(
+				prepared.defaultModel,
+				options.thinkingLevelOverride ?? prepared.defaultThinkingLevel,
+				{
+					persistAsSessionDefault: true,
+				},
+			);
 			modelChanged = true;
 		}
 		if (Object.keys(prepared.modelRoles).length > 0) {
@@ -380,6 +389,10 @@ export async function applyPreparedModelProfileActivation(
 		if (options.persistDefault) {
 			prepared.settings.set("modelRoles", {});
 			prepared.settings.set("task.agentModelOverrides", {});
+			if (prepared.defaultThinkingLevel !== undefined && prepared.defaultThinkingLevel !== ThinkingLevel.Inherit) {
+				prepared.settings.set("defaultThinkingLevel", prepared.defaultThinkingLevel);
+				defaultThinkingChanged = true;
+			}
 			prepared.settings.set("modelProfile.default", prepared.profileName);
 			defaultChanged = true;
 			await prepared.settings.flush();
@@ -390,6 +403,9 @@ export async function applyPreparedModelProfileActivation(
 			prepared.settings.set("modelProfile.default", previousPersistedDefault);
 			prepared.settings.set("modelRoles", previousModelRoles);
 			prepared.settings.set("task.agentModelOverrides", previousAgentModelOverrides);
+			if (defaultThinkingChanged) {
+				prepared.settings.set("defaultThinkingLevel", previousDefaultThinkingLevel);
+			}
 		}
 		if (modelRolesChanged) {
 			prepared.settings.override("modelRoles", previousModelRoles);
@@ -505,7 +521,7 @@ export async function restoreMaterializedModelProfileForDeletion(options: {
 
 export async function activateModelProfile(
 	options: PrepareModelProfileActivationOptions,
-	applyOptions: { persistDefault?: boolean } = {},
+	applyOptions: ApplyModelProfileActivationOptions = {},
 ): Promise<void> {
 	const prepared = await prepareModelProfileActivation(options);
 	await applyPreparedModelProfileActivation(prepared, applyOptions);

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -3,15 +3,7 @@
  */
 
 import { ThinkingLevel } from "@gajae-code/agent-core";
-import {
-	type Api,
-	clampThinkingLevelForModel,
-	DEFAULT_MODEL_PER_PROVIDER,
-	type Effort,
-	type KnownProvider,
-	type Model,
-	modelsAreEqual,
-} from "@gajae-code/ai";
+import { type Api, DEFAULT_MODEL_PER_PROVIDER, type KnownProvider, type Model, modelsAreEqual } from "@gajae-code/ai";
 import { fuzzyMatch } from "@gajae-code/tui";
 import { logger } from "@gajae-code/utils";
 import chalk from "chalk";
@@ -1197,7 +1189,7 @@ export async function findInitialModel(options: {
 	isContinuing: boolean;
 	defaultProvider?: string;
 	defaultModelId?: string;
-	defaultThinkingSelector?: Effort;
+	defaultThinkingSelector?: ThinkingLevel;
 	modelRegistry: InitialModelRegistry;
 }): Promise<InitialModelResult> {
 	const {
@@ -1212,7 +1204,7 @@ export async function findInitialModel(options: {
 	} = options;
 
 	let model: Model<Api> | undefined;
-	let thinkingLevel: Effort | undefined;
+	let thinkingLevel: ThinkingLevel | undefined;
 
 	// 1. CLI args take priority
 	if (cliProvider && cliModel) {
@@ -1233,10 +1225,7 @@ export async function findInitialModel(options: {
 				: (scoped.thinkingLevel ?? defaultThinkingSelector);
 		return {
 			model: scoped.model,
-			thinkingLevel:
-				scopedThinkingSelector === ThinkingLevel.Off
-					? ThinkingLevel.Off
-					: clampThinkingLevelForModel(scoped.model, scopedThinkingSelector),
+			thinkingLevel: resolveThinkingLevelForModel(scoped.model, scopedThinkingSelector),
 			fallbackMessage: undefined,
 		};
 	}
@@ -1246,7 +1235,7 @@ export async function findInitialModel(options: {
 		const found = modelRegistry.find(defaultProvider, defaultModelId);
 		if (found) {
 			model = found;
-			thinkingLevel = clampThinkingLevelForModel(found, defaultThinkingSelector);
+			thinkingLevel = resolveThinkingLevelForModel(found, defaultThinkingSelector);
 			return { model, thinkingLevel, fallbackMessage: undefined };
 		}
 	}

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -5,6 +5,7 @@ import { EDIT_MODES } from "../utils/edit-mode";
 import { CONFIGURABLE_SEARCH_PROVIDER_IDS } from "../web/search/types";
 
 const THINKING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max"] as readonly Effort[];
+const DEFAULT_THINKING_LEVELS = ["off", ...THINKING_EFFORTS] as const;
 
 import {
 	DEFAULT_DISABLED_EXTENSIONS,
@@ -804,13 +805,13 @@ export const SETTINGS_SCHEMA = {
 	// Reasoning and prompts
 	defaultThinkingLevel: {
 		type: "enum",
-		values: THINKING_EFFORTS,
+		values: DEFAULT_THINKING_LEVELS,
 		default: THINKING_EFFORTS[3],
 		ui: {
 			tab: "model",
 			label: "Thinking Level",
 			description: "Reasoning depth for thinking-capable models",
-			options: [...THINKING_EFFORTS.map(getThinkingLevelMetadata)],
+			options: [...DEFAULT_THINKING_LEVELS.map(getThinkingLevelMetadata)],
 		},
 	},
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -217,10 +217,14 @@ export async function applyStartupModelProfiles(args: {
 	startupModel?: CreateAgentSessionOptions["model"];
 	startupThinkingLevel?: CreateAgentSessionOptions["thinkingLevel"];
 }): Promise<void> {
-	const applyProfile = async (profileName: string, persistDefault: boolean): Promise<void> => {
+	const applyProfile = async (
+		profileName: string,
+		persistDefault: boolean,
+		options: { thinkingLevelOverride?: CreateAgentSessionOptions["thinkingLevel"] } = {},
+	): Promise<void> => {
 		await activateModelProfile(
 			{ session: args.session, modelRegistry: args.modelRegistry, settings: args.settings, profileName },
-			{ persistDefault },
+			{ persistDefault, thinkingLevelOverride: options.thinkingLevelOverride },
 		);
 	};
 
@@ -234,7 +238,11 @@ export async function applyStartupModelProfiles(args: {
 	}
 
 	if (defaultProfile) {
-		await applyProfile(defaultProfile, false);
+		await applyProfile(defaultProfile, false, {
+			thinkingLevelOverride: args.settings.has("defaultThinkingLevel")
+				? args.settings.get("defaultThinkingLevel")
+				: undefined,
+		});
 	}
 	if (args.parsedArgs.mpreset) {
 		await applyProfile(args.parsedArgs.mpreset, args.parsedArgs.default === true);

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -1,4 +1,4 @@
-import type { ThinkingLevel } from "@gajae-code/agent-core";
+import { ThinkingLevel, type ThinkingLevel as ThinkingLevelValue } from "@gajae-code/agent-core";
 import type { Effort } from "@gajae-code/ai";
 import {
 	Container,
@@ -654,7 +654,7 @@ export interface SettingsRuntimeContext {
 	/** Available thinking levels (from session) */
 	availableThinkingLevels: Effort[];
 	/** Current thinking level (from session) */
-	thinkingLevel: ThinkingLevel | undefined;
+	thinkingLevel: ThinkingLevelValue | undefined;
 	/** Available themes */
 	availableThemes: string[];
 	/** Available model profile names (from the model registry) */
@@ -843,7 +843,7 @@ export class SettingsSelectorComponent extends Container {
 
 		// Special case: inject runtime options for thinking level
 		if (def.path === "defaultThinkingLevel") {
-			options = this.context.availableThinkingLevels.map(level => {
+			options = [ThinkingLevel.Off, ...this.context.availableThinkingLevels].map(level => {
 				const baseOpt = options.find(o => o.value === level);
 				return baseOpt || { value: level, label: level };
 			});

--- a/packages/coding-agent/src/modes/components/thinking-selector.ts
+++ b/packages/coding-agent/src/modes/components/thinking-selector.ts
@@ -1,51 +1,112 @@
 import { ThinkingLevel, type ThinkingLevel as ThinkingLevelValue } from "@gajae-code/agent-core";
-import { Container, type SelectItem, SelectList } from "@gajae-code/tui";
-import { getSelectListTheme } from "../../modes/theme/theme";
+import { Container, type SelectItem, SelectList, Text } from "@gajae-code/tui";
+import { getSelectListTheme, theme } from "../../modes/theme/theme";
 import { getThinkingLevelMetadata, type ThinkingLevelValue as ThinkingMetadataValue } from "../../thinking-metadata";
 import { DynamicBorder } from "./dynamic-border";
+
+const SCOPE_ITEMS = [
+	{
+		value: "session",
+		label: "Apply for this session",
+		description: "Use this effort until the session changes it again",
+	},
+	{
+		value: "default",
+		label: "Set as default",
+		description: "Save this effort for future sessions",
+	},
+] as const satisfies readonly SelectItem[];
+
+export interface ThinkingSelectorSelection {
+	level: ThinkingLevelValue;
+	persistDefault: boolean;
+}
 
 /**
  * Component that renders a thinking level selector with borders
  */
 export class ThinkingSelectorComponent extends Container {
 	#selectList: SelectList;
+	#levelList: SelectList;
+	#selectedLevel: ThinkingLevelValue | undefined;
+	readonly #onSelect: (selection: ThinkingSelectorSelection) => void;
+	readonly #onCancel: () => void;
 
 	constructor(
 		currentLevel: ThinkingLevelValue | undefined,
 		availableLevels: ThinkingLevelValue[],
-		onSelect: (level: ThinkingLevelValue) => void,
+		onSelect: (selection: ThinkingSelectorSelection) => void,
 		onCancel: () => void,
 	) {
 		super();
 
-		const thinkingLevels: SelectItem[] = availableLevels.map(level =>
-			getThinkingLevelMetadata(level as ThinkingMetadataValue),
-		);
+		this.#onSelect = onSelect;
+		this.#onCancel = onCancel;
 
-		// Add top border
-		this.addChild(new DynamicBorder());
+		const currentValue = currentLevel ?? ThinkingLevel.Off;
+		const thinkingLevels: SelectItem[] = availableLevels.map(level => {
+			const metadata = getThinkingLevelMetadata(level as ThinkingMetadataValue);
+			return level === currentValue
+				? { ...metadata, label: metadata.label + theme.fg("muted", " (current)") }
+				: metadata;
+		});
 
-		// Create selector
-		this.#selectList = new SelectList(thinkingLevels, thinkingLevels.length, getSelectListTheme());
+		this.#levelList = new SelectList(thinkingLevels, thinkingLevels.length, getSelectListTheme());
+		this.#selectList = this.#levelList;
 
 		// Preselect current level
-		const currentIndex = thinkingLevels.findIndex(item => item.value === (currentLevel ?? ThinkingLevel.Off));
+		const currentIndex = thinkingLevels.findIndex(item => item.value === currentValue);
 		if (currentIndex !== -1) {
-			this.#selectList.setSelectedIndex(currentIndex);
+			this.#levelList.setSelectedIndex(currentIndex);
 		}
 
-		this.#selectList.onSelect = item => {
-			onSelect(item.value as ThinkingLevelValue);
+		this.#levelList.onSelect = item => {
+			this.#selectedLevel = item.value as ThinkingLevelValue;
+			this.#renderScopeList();
 		};
 
-		this.#selectList.onCancel = () => {
-			onCancel();
+		this.#levelList.onCancel = () => {
+			this.#onCancel();
 		};
 
-		this.addChild(this.#selectList);
+		this.#renderLevelList();
+	}
 
-		// Add bottom border
+	#renderLevelList(): void {
+		this.detachAll();
+		this.#selectedLevel = undefined;
+		this.#selectList = this.#levelList;
 		this.addChild(new DynamicBorder());
+		this.addChild(this.#levelList);
+		this.addChild(new DynamicBorder());
+	}
+
+	#renderScopeList(): void {
+		const level = this.#selectedLevel;
+		if (!level) return;
+
+		const scopeList = new SelectList(SCOPE_ITEMS, SCOPE_ITEMS.length, getSelectListTheme());
+		scopeList.onSelect = item => {
+			this.#onSelect({
+				level,
+				persistDefault: item.value === "default",
+			});
+		};
+		scopeList.onCancel = () => {
+			this.#renderLevelList();
+		};
+
+		const metadata = getThinkingLevelMetadata(level as ThinkingMetadataValue);
+		this.detachAll();
+		this.#selectList = scopeList;
+		this.addChild(new DynamicBorder());
+		this.addChild(new Text(theme.fg("muted", `  Reasoning effort: ${metadata.label}`), 0, 0));
+		this.addChild(scopeList);
+		this.addChild(new DynamicBorder());
+	}
+
+	handleInput(data: string): void {
+		this.#selectList.handleInput(data);
 	}
 
 	getSelectList(): SelectList {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -443,12 +443,13 @@ export class SelectorController {
 			const selector = new ThinkingSelectorComponent(
 				this.ctx.session.thinkingLevel,
 				availableLevels,
-				level => {
+				selection => {
 					done();
 
+					const { level, persistDefault } = selection;
 					const configuredDefault = this.ctx.settings.get("defaultThinkingLevel");
 					const levelToApply = level === ThinkingLevel.Inherit ? configuredDefault : level;
-					this.ctx.session.setThinkingLevel(levelToApply, false);
+					this.ctx.session.setThinkingLevel(levelToApply, persistDefault);
 					const effectiveLevel = this.ctx.session.thinkingLevel ?? ThinkingLevel.Off;
 					const requestedLabel =
 						level === ThinkingLevel.Inherit ? `${level} (configured default: ${configuredDefault})` : level;
@@ -458,9 +459,11 @@ export class SelectorController {
 					this.ctx.statusLine.invalidate();
 					this.ctx.updateEditorBorderColor();
 					this.ctx.updateEditorTopBorder();
+					if (persistDefault) void this.ctx.notifyConfigChanged?.();
 					this.ctx.ui.requestRender();
+					const scopeLabel = persistDefault ? "Default reasoning effort" : "Reasoning effort";
 					this.ctx.showStatus(
-						`Reasoning effort set to ${requestedLabel}. Effective effort: ${effectiveLevel}.${clampedSuffix}`,
+						`${scopeLabel} set to ${requestedLabel}. Effective effort: ${effectiveLevel}.${clampedSuffix}`,
 					);
 				},
 				() => {
@@ -468,10 +471,9 @@ export class SelectorController {
 					this.ctx.ui.requestRender();
 				},
 			);
-			return { component: selector, focus: selector.getSelectList() };
+			return { component: selector, focus: selector };
 		});
 	}
-
 	showSettingsSelector(): void {
 		getAvailableThemes().then(availableThemes => {
 			this.showSelector(done => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1047,6 +1047,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const taskDepth = options.taskDepth ?? 0;
 
 	let thinkingLevel = options.thinkingLevel;
+	const hasExplicitDefaultThinkingLevel = settings.has("defaultThinkingLevel");
+	let thinkingLevelFromSchemaDefault = false;
 
 	// If session has data and includes a thinking entry, restore it
 	if (thinkingLevel === undefined && hasExistingSession && hasThinkingEntry) {
@@ -1057,13 +1059,20 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		thinkingLevel = defaultRoleSpec.thinkingLevel;
 	}
 
-	// Prefer the selected model's configured defaultLevel, otherwise fall back
-	// to the global settings default.
+	// An explicit user/project default should win over the model's bundled
+	// defaultLevel. The schema default is only a final fallback so model metadata
+	// can keep driving first-run behavior until the user chooses "Set as default".
+	if (thinkingLevel === undefined && hasExplicitDefaultThinkingLevel) {
+		thinkingLevel = settings.get("defaultThinkingLevel");
+	}
+
 	if (thinkingLevel === undefined && model?.thinking?.defaultLevel !== undefined) {
 		thinkingLevel = model.thinking.defaultLevel;
 	}
+
 	if (thinkingLevel === undefined) {
 		thinkingLevel = settings.get("defaultThinkingLevel");
+		thinkingLevelFromSchemaDefault = true;
 	}
 	if (model) {
 		const resolvedModel = model;
@@ -1608,6 +1617,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			if (resolved) {
 				model = resolved;
 				modelFallbackMessage = undefined;
+				if (thinkingLevelFromSchemaDefault && resolved.thinking?.defaultLevel !== undefined) {
+					thinkingLevel = resolved.thinking.defaultLevel;
+					thinkingLevelFromSchemaDefault = false;
+				}
+				thinkingLevel = resolveThinkingLevelForModel(resolved, thinkingLevel);
 			} else {
 				modelFallbackMessage = `Model "${options.modelPattern}" not found`;
 			}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6953,7 +6953,7 @@ export class AgentSession {
 
 	/**
 	 * Set thinking level.
-	 * Saves the effective metadata-clamped level to session and settings only if it changes.
+	 * Saves the effective metadata-clamped level to the session, and to settings when requested.
 	 */
 	setThinkingLevel(level: ThinkingLevel | undefined, persist: boolean = false): void {
 		const effectiveLevel = resolveThinkingLevelForModel(this.model, level);
@@ -6962,11 +6962,12 @@ export class AgentSession {
 		this.#thinkingLevel = effectiveLevel;
 		this.agent.setThinkingLevel(toReasoningEffort(effectiveLevel));
 
+		if (persist && effectiveLevel !== undefined) {
+			this.settings.set("defaultThinkingLevel", effectiveLevel);
+		}
+
 		if (isChanging) {
 			this.sessionManager.appendThinkingLevelChange(effectiveLevel);
-			if (persist && effectiveLevel !== undefined && effectiveLevel !== ThinkingLevel.Off) {
-				this.settings.set("defaultThinkingLevel", effectiveLevel);
-			}
 			this.#emit({ type: "thinking_level_changed", thinkingLevel: effectiveLevel });
 		}
 	}

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -170,6 +170,34 @@ test("ACP session factory applies default profile and --mpreset before returning
 		session.setModelTemporaryCalls.map(call => `${call.model.provider}/${call.model.id}:${call.thinkingLevel}`),
 	).toEqual(["profile-provider/default:medium", "cli-provider/explicit:high"]);
 });
+test("persisted default thinking overrides startup default profile effort", async () => {
+	const settings = Settings.isolated({
+		"modelProfile.default": "default-profile",
+		defaultThinkingLevel: ThinkingLevel.XHigh,
+	});
+	const session = fakeSession();
+	const registry = fakeRegistry([
+		{
+			name: "default-profile",
+			requiredProviders: ["profile-provider"],
+			modelMapping: { default: "profile-provider/default:medium" },
+			source: "user",
+		},
+	]) as never;
+
+	await applyStartupModelProfiles({
+		session,
+		settings,
+		modelRegistry: registry,
+		parsedArgs: {},
+		startupModel: undefined,
+		startupThinkingLevel: undefined,
+	});
+
+	expect(
+		session.setModelTemporaryCalls.map(call => `${call.model.provider}/${call.model.id}:${call.thinkingLevel}`),
+	).toEqual(["profile-provider/default:xhigh"]);
+});
 
 test("ACP session factory refreshes registry before applying project default profile", async () => {
 	const settings = Settings.isolated();

--- a/packages/coding-agent/test/issue-775-repro.test.ts
+++ b/packages/coding-agent/test/issue-775-repro.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
-import { Agent } from "@gajae-code/agent-core";
+import { Agent, ThinkingLevel } from "@gajae-code/agent-core";
 import { Effort, getBundledModel, type Model } from "@gajae-code/ai";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
@@ -96,5 +96,27 @@ describe("issue #775: per-model defaultLevel", () => {
 		await session.setModel(opus);
 
 		expect(session.thinkingLevel).toBe(Effort.Low);
+	});
+
+	it("persists a default thinking level even when the effective level is unchanged", async () => {
+		const sonnet = getSonnet();
+		const settings = Settings.isolated();
+		settings.set("defaultThinkingLevel", Effort.Medium);
+		await createSession(sonnet, settings);
+
+		session.setThinkingLevel(Effort.Low, true);
+
+		expect(settings.get("defaultThinkingLevel")).toBe(Effort.Low);
+	});
+
+	it("persists off as the default thinking level", async () => {
+		const sonnet = getSonnet();
+		const settings = Settings.isolated();
+		settings.set("defaultThinkingLevel", Effort.Medium);
+		await createSession(sonnet, settings);
+
+		session.setThinkingLevel(ThinkingLevel.Off, true);
+
+		expect(settings.get("defaultThinkingLevel")).toBe(ThinkingLevel.Off);
 	});
 });

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -304,7 +304,13 @@ describe("model profile activation", () => {
 			{ persistDefault: true },
 		);
 
-		expect(setCalls).toEqual(["modelRoles", "task.agentModelOverrides", "modelProfile.default"]);
+		expect(setCalls).toEqual([
+			"modelRoles",
+			"task.agentModelOverrides",
+			"defaultThinkingLevel",
+			"modelProfile.default",
+		]);
+		expect(settings.get("defaultThinkingLevel")).toBe(ThinkingLevel.High);
 		expect(settings.get("modelProfile.default")).toBe("profile-a");
 		expect(flushCount).toBe(1);
 		expect(session.getActiveModelProfile()).toBe("profile-a");
@@ -352,7 +358,10 @@ describe("model profile activation", () => {
 
 	test("apply rolls back runtime changes when persistence throws", async () => {
 		const session = fakeSession();
-		const settings = Settings.isolated({ "task.agentModelOverrides": { executor: "provider-a/original" } });
+		const settings = Settings.isolated({
+			"task.agentModelOverrides": { executor: "provider-a/original" },
+			defaultThinkingLevel: ThinkingLevel.Low,
+		});
 		const prepared = await prepareModelProfileActivation({
 			session,
 			modelRegistry: fakeRegistry(),
@@ -371,6 +380,7 @@ describe("model profile activation", () => {
 		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
 		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/original" });
 		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(settings.get("defaultThinkingLevel")).toBe(ThinkingLevel.Low);
 		expect(session.getActiveModelProfile()).toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/model-profile-legacy-alias.test.ts
+++ b/packages/coding-agent/test/model-profile-legacy-alias.test.ts
@@ -100,6 +100,7 @@ describe("legacy model profile aliases", () => {
 
 		expect(session.getActiveModelProfile()).toBe("codex-medium");
 		expect(settings.get("modelProfile.default")).toBe("codex-medium");
+		expect(settings.get("defaultThinkingLevel")).toBe(ThinkingLevel.Medium);
 	});
 
 	test("preparation exposes the canonical replacement profile name", async () => {

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -211,6 +211,7 @@ describe("model selector profile red-team", () => {
 		await selectProfileThroughController(new SelectorController(persistent.ctx as never), true);
 
 		expect(persistent.setCalls).toContainEqual({ path: "modelProfile.default", value: "profile-a" });
+		expect(persistent.setCalls).toContainEqual({ path: "defaultThinkingLevel", value: ThinkingLevel.High });
 		expect(persistent.flush).toHaveBeenCalledTimes(1);
 		expect(persistent.ctx.showStatus).toHaveBeenCalledWith("Default model profile: Profile Alpha");
 	});

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -334,6 +334,7 @@ describe("model selector profiles", () => {
 
 		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: Profile Alpha");
 		expect(setCalls).toContainEqual({ path: "modelProfile.default", value: "profile-a" });
+		expect(setCalls).toContainEqual({ path: "defaultThinkingLevel", value: ThinkingLevel.High });
 		expect(flush).toHaveBeenCalledTimes(1);
 		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: Profile Alpha");
 	});
@@ -363,6 +364,7 @@ describe("model selector profiles", () => {
 		expect(session.setModelTemporaryCalls).toHaveLength(1);
 		expect(session.model?.id).toBe("default");
 		expect(setCalls).toContainEqual({ path: "modelProfile.default", value: "profile-a" });
+		expect(setCalls).toContainEqual({ path: "defaultThinkingLevel", value: ThinkingLevel.High });
 		expect(flush).toHaveBeenCalledTimes(1);
 		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: Profile Alpha");
 	});

--- a/packages/coding-agent/test/modes/components/thinking-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/thinking-selector.test.ts
@@ -6,41 +6,77 @@ import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/s
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
 
+function stripAnsi(text: string): string {
+	return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function renderText(component: ThinkingSelectorComponent): string {
+	return component.render(80).join("\n");
+}
+
 beforeAll(async () => {
 	await initTheme(false, undefined, undefined, "red-claw", "blue-crab");
 });
 
 describe("ThinkingSelectorComponent", () => {
-	it("selects inherit, off, and effort values", () => {
-		const selections: ThinkingLevel[] = [];
+	it("shows scope actions before applying a selected effort", () => {
+		const selections: Array<{ level: ThinkingLevel; persistDefault: boolean }> = [];
 		const component = new ThinkingSelectorComponent(
 			ThinkingLevel.Inherit,
 			[ThinkingLevel.Inherit, ThinkingLevel.Off, ThinkingLevel.Low],
-			level => selections.push(level),
+			selection => selections.push(selection),
 			() => {},
 		);
 
-		component.getSelectList().handleInput("\n");
-		component.getSelectList().handleInput("\x1b[B");
-		component.getSelectList().handleInput("\n");
-		component.getSelectList().handleInput("\x1b[B");
-		component.getSelectList().handleInput("\n");
+		const rendered = renderText(component);
+		expect(stripAnsi(rendered)).toContain("inherit (current)");
+		expect(rendered).toMatch(/\x1b\[[0-9;]*m \(current\)\x1b\[39m/);
 
-		expect(selections).toEqual([ThinkingLevel.Inherit, ThinkingLevel.Off, ThinkingLevel.Low]);
+		component.handleInput("\n");
+
+		expect(selections).toEqual([]);
+		expect(stripAnsi(renderText(component))).toContain("Apply for this session");
+
+		component.handleInput("\n");
+
+		expect(selections).toEqual([{ level: ThinkingLevel.Inherit, persistDefault: false }]);
+	});
+
+	it("supports setting an effort as the default", () => {
+		const selections: Array<{ level: ThinkingLevel; persistDefault: boolean }> = [];
+		const component = new ThinkingSelectorComponent(
+			ThinkingLevel.Inherit,
+			[ThinkingLevel.Inherit, ThinkingLevel.Off, ThinkingLevel.Low],
+			selection => selections.push(selection),
+			() => {},
+		);
+
+		component.handleInput("\x1b[B");
+		component.handleInput("\x1b[B");
+		component.handleInput("\n");
+		component.handleInput("\x1b[B");
+		component.handleInput("\n");
+
+		expect(selections).toEqual([{ level: ThinkingLevel.Low, persistDefault: true }]);
 	});
 
 	it("preselects off when the session has no effective level", () => {
-		const selections: ThinkingLevel[] = [];
+		const selections: Array<{ level: ThinkingLevel; persistDefault: boolean }> = [];
 		const component = new ThinkingSelectorComponent(
 			undefined,
 			[ThinkingLevel.Inherit, ThinkingLevel.Off, ThinkingLevel.Low],
-			level => selections.push(level),
+			selection => selections.push(selection),
 			() => {},
 		);
 
-		component.getSelectList().handleInput("\n");
+		const rendered = renderText(component);
+		expect(stripAnsi(rendered)).toContain("off (current)");
+		expect(rendered).toMatch(/\x1b\[[0-9;]*m \(current\)\x1b\[39m/);
 
-		expect(selections).toEqual([ThinkingLevel.Off]);
+		component.handleInput("\n");
+		component.handleInput("\n");
+
+		expect(selections).toEqual([{ level: ThinkingLevel.Off, persistDefault: false }]);
 	});
 });
 
@@ -88,9 +124,12 @@ describe("SelectorController effort selector", () => {
 		if (!(selector instanceof ThinkingSelectorComponent)) {
 			throw new Error("Expected /effort to mount ThinkingSelectorComponent");
 		}
-		expect(ctx.ui.setFocus).toHaveBeenLastCalledWith(selector.getSelectList());
+		expect(ctx.ui.setFocus).toHaveBeenLastCalledWith(selector);
 
-		selector.getSelectList().handleInput("\n");
+		selector.handleInput("\n");
+		expect(thinkingLevelCalls).toEqual([]);
+
+		selector.handleInput("\n");
 
 		expect(thinkingLevelCalls).toEqual([{ level: ThinkingLevel.High, persist: false }]);
 		expect(statuses[0]).toContain("configured default: high");
@@ -100,6 +139,62 @@ describe("SelectorController effort selector", () => {
 		expect(ctx.updateEditorTopBorder).toHaveBeenCalled();
 		expect(ctx.ui.requestRender).toHaveBeenCalled();
 		expect(ctx.ui.setFocus).toHaveBeenLastCalledWith(ctx.editor);
+	});
+
+	it("can persist the selected effort as the default", () => {
+		const editorContainer = {
+			children: [] as unknown[],
+			clear() {
+				this.children = [];
+			},
+			addChild(child: unknown) {
+				this.children.push(child);
+			},
+		};
+		const settings = Settings.isolated({ defaultThinkingLevel: ThinkingLevel.High });
+		const statuses: string[] = [];
+		const thinkingLevelCalls: Array<{ level: ThinkingLevel | undefined; persist: boolean | undefined }> = [];
+		const session = {
+			thinkingLevel: ThinkingLevel.Off as ThinkingLevel | undefined,
+			getAvailableThinkingLevels: () => [ThinkingLevel.Low, ThinkingLevel.High],
+			setThinkingLevel(level: ThinkingLevel | undefined, persist?: boolean) {
+				thinkingLevelCalls.push({ level, persist });
+				this.thinkingLevel = level;
+			},
+		};
+		const notifyConfigChanged = vi.fn();
+		const ctx = {
+			editorContainer,
+			editor: {},
+			session,
+			settings,
+			ui: {
+				setFocus: vi.fn(),
+				requestRender: vi.fn(),
+			},
+			statusLine: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			updateEditorTopBorder: vi.fn(),
+			notifyConfigChanged,
+			showStatus: (text: string) => statuses.push(text),
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(ctx);
+
+		controller.showEffortSelector();
+		const selector = editorContainer.children[0];
+		if (!(selector instanceof ThinkingSelectorComponent)) {
+			throw new Error("Expected /effort to mount ThinkingSelectorComponent");
+		}
+
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+
+		expect(thinkingLevelCalls).toEqual([{ level: ThinkingLevel.Low, persist: true }]);
+		expect(notifyConfigChanged).toHaveBeenCalled();
+		expect(statuses[0]).toContain("Default reasoning effort");
+		expect(statuses[0]).toContain("Effective effort: low");
 	});
 
 	it("cancels without mutating thinking level", () => {
@@ -135,7 +230,7 @@ describe("SelectorController effort selector", () => {
 		if (!(selector instanceof ThinkingSelectorComponent)) {
 			throw new Error("Expected /effort to mount ThinkingSelectorComponent");
 		}
-		selector.getSelectList().handleInput("\x1b");
+		selector.handleInput("\x1b");
 
 		expect(session.setThinkingLevel).not.toHaveBeenCalled();
 		expect(ctx.ui.requestRender).toHaveBeenCalled();

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -1,32 +1,40 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Effort, getBundledModel, type Model } from "@gajae-code/ai";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
-import { createAgentSession, type ExtensionFactory } from "@gajae-code/coding-agent/sdk";
+import { createAgentSession } from "@gajae-code/coding-agent/sdk";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import { Snowflake } from "@gajae-code/utils";
 
+setDefaultTimeout(20_000);
+
 describe("createAgentSession deferred model pattern resolution", () => {
 	let tempDir: string;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		tempDir = path.join(os.tmpdir(), `pi-sdk-model-selection-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
+		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+		registerRuntimeProvider(modelRegistry);
 	});
 
 	afterEach(() => {
+		authStorage?.close();
 		if (tempDir && fs.existsSync(tempDir)) {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
 
-	const providerExtension: ExtensionFactory = pi => {
-		pi.registerProvider("runtime-provider", {
-			baseUrl: "https://runtime.example.com/v1",
+	function registerRuntimeProvider(target: ModelRegistry): void {
+		target.registerProvider("runtime-provider", {
+			baseUrl: "http://127.0.0.1:9/v1",
 			apiKey: "RUNTIME_KEY",
 			api: "openai-completions",
 			models: [
@@ -47,10 +55,16 @@ describe("createAgentSession deferred model pattern resolution", () => {
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 					contextWindow: 128000,
 					maxTokens: 8192,
+					thinking: {
+						minLevel: Effort.Minimal,
+						maxLevel: Effort.High,
+						mode: "effort",
+						defaultLevel: Effort.Low,
+					},
 				},
 			],
 		});
-	};
+	}
 
 	function buildSessionOptions(modelPattern: string) {
 		return {
@@ -58,18 +72,22 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			agentDir: tempDir,
 			sessionManager: SessionManager.inMemory(),
 			disableExtensionDiscovery: true,
-			extensions: [providerExtension],
+			extensions: [],
 			skills: [],
 			contextFiles: [],
 			promptTemplates: [],
 			slashCommands: [],
 			enableMCP: false,
 			enableLsp: false,
+			workspaceTree: { rootPath: tempDir, rendered: "", truncated: false, totalLines: 0, agentsMdFiles: [] },
+			toolNames: [],
+			rules: [],
+			modelRegistry,
 			modelPattern,
 		};
 	}
 
-	test("resolves explicit modelPattern after extension providers register", async () => {
+	test("resolves explicit modelPattern after runtime providers are available", async () => {
 		const { session, modelFallbackMessage } = await createAgentSession(
 			buildSessionOptions("runtime-provider/runtime-model"),
 		);
@@ -78,6 +96,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		expect(session.model?.provider).toBe("runtime-provider");
 		expect(session.model?.id).toBe("runtime-model");
 		expect(modelFallbackMessage).toBeUndefined();
+		await session.dispose();
 	});
 
 	test("does not silently fallback when explicit modelPattern is unresolved", async () => {
@@ -87,6 +106,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 
 		expect(session.model).toBeUndefined();
 		expect(modelFallbackMessage).toBe('Model "missing-provider/missing-model" not found');
+		await session.dispose();
 	});
 
 	test("does not apply default role thinking override when modelPattern is explicit", async () => {
@@ -101,6 +121,30 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		expect(session.model?.provider).toBe("runtime-provider");
 		expect(session.model?.id).toBe("runtime-reasoning-model");
 		expect(session.thinkingLevel).toBe("off");
+		await session.dispose();
+	});
+
+	test("uses model defaultLevel when default thinking is not configured", async () => {
+		const { session } = await createAgentSession(buildSessionOptions("runtime-provider/runtime-reasoning-model"));
+
+		expect(session.model?.provider).toBe("runtime-provider");
+		expect(session.model?.id).toBe("runtime-reasoning-model");
+		expect(session.thinkingLevel).toBe(Effort.Low);
+		await session.dispose();
+	});
+
+	test("uses explicit defaultThinkingLevel over model defaultLevel", async () => {
+		const settings = Settings.isolated({ defaultThinkingLevel: Effort.Minimal });
+
+		const { session } = await createAgentSession({
+			...buildSessionOptions("runtime-provider/runtime-reasoning-model"),
+			settings,
+		});
+
+		expect(session.model?.provider).toBe("runtime-provider");
+		expect(session.model?.id).toBe("runtime-reasoning-model");
+		expect(session.thinkingLevel).toBe(Effort.Minimal);
+		await session.dispose();
 	});
 
 	test("selects the settings default model without synchronously validating auth", async () => {
@@ -134,6 +178,9 @@ describe("createAgentSession deferred model pattern resolution", () => {
 				slashCommands: [],
 				enableMCP: false,
 				enableLsp: false,
+				workspaceTree: { rootPath: tempDir, rendered: "", truncated: false, totalLines: 0, agentsMdFiles: [] },
+				toolNames: [],
+				rules: [],
 			});
 
 			try {

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -512,6 +512,7 @@
 		"defaultThinkingLevel": {
 			"type": "string",
 			"enum": [
+				"off",
 				"minimal",
 				"low",
 				"medium",


### PR DESCRIPTION
## Summary

This PR fixes reasoning-effort persistence so `/effort` behaves like `/model` and so model profile presets no longer accidentally undo the user's saved effort choice on restart.

### User-facing changes

- `/effort` now mirrors `/model` after an effort is selected:
  - `Apply for this session`
  - `Set as default`
- The effort picker marks the active value with a muted gray `(current)` suffix, matching the model selector's current-state affordance.
- `Set as default` now persists the selected effort, including `off`, instead of only affecting the current process.
- Default model profile selection now also persists the profile's encoded default effort, so choosing a preset such as a medium/pro profile keeps the intended default effort across new runs.
- A saved `/effort` default now wins over bundled model metadata and startup default-profile effort when the user has explicitly configured it.
- Added a changelog entry under `packages/coding-agent/CHANGELOG.md`.

## Why

The old `/effort` flow let users select a reasoning effort, but it only updated the current session. After restarting `gjc`, startup model/default-profile resolution could re-derive effort from model metadata or a model preset and silently revert the user's choice.

The issue was especially visible with model presets:

1. A model profile encodes effort in selectors like `provider/model:medium`.
2. Profile activation applies that effort correctly for the running session.
3. But the default effort setting was not kept in sync, and startup could later reapply profile/model metadata over the user's expected default.

This PR makes the persistence model explicit:

- `/effort -> Set as default` writes `defaultThinkingLevel`.
- `/model` preset `Set as default` writes both `modelProfile.default` and the preset's default effort into `defaultThinkingLevel`.
- Startup only lets model metadata/profile defaults drive first-run behavior until the user has explicitly configured `defaultThinkingLevel`.

## Implementation notes

- Reworked `ThinkingSelectorComponent` into a two-step selector: first choose the effort, then choose session-only vs default persistence.
- Added a muted `(current)` marker to the effort list.
- Allowed `off` as a valid persisted `defaultThinkingLevel` in the config schema and settings UI.
- Preserved model metadata default-level behavior when no explicit `defaultThinkingLevel` exists.
- Updated model profile activation so persistent profile selection also persists the profile default effort and rolls that setting back if persistence fails.
- Added startup-profile handling so a user-saved effort default is not overwritten by default-profile activation.

## Verification

Focused tests/checks run:

```bash
bun test packages/coding-agent/test/cli-args-mpreset.test.ts packages/coding-agent/test/model-profile-activation.test.ts packages/coding-agent/test/model-profile-legacy-alias.test.ts packages/coding-agent/test/model-selector-profiles.test.ts packages/coding-agent/test/model-selector-profiles-redteam.test.ts packages/coding-agent/test/sdk-model-selection.test.ts packages/coding-agent/test/modes/components/thinking-selector.test.ts packages/coding-agent/test/issue-775-repro.test.ts
```

Result: `76 pass, 0 fail`.

```bash
bun --cwd=packages/coding-agent run check
```

Result: passed (`biome check` + `tsgo -p tsconfig.json --noEmit`).

```bash
git diff --check
```

Result: passed with no whitespace errors.