### PR TITLE
fix(tmux): track renamed session titles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Finalized notification turn mirrors now default to the bounded full-turn cap so Telegram's existing chunked delivery can send long assistant answers instead of receiving an already-truncated 3500-character summary; `GJC_NOTIFICATIONS_TURN_MAX` remains available to lower the cap for summary-style mirrors, and live previews stay capped as one editable message.
 - `gjc --tmux` now wraps the inner GJC command with a durable `tmux-exit.json` marker next to `runtime-state.json`, so a tmux-resident session that exits before normal runtime-state finalization leaves a public-safe exit timestamp/code for silent-vanish diagnosis (#1746).
+- `gjc --tmux` terminal titles now track live tmux session renames while preserving the friendly project/branch title for untouched generated session ids.
 
 ## [0.9.1] - 2026-07-08
 

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -448,6 +448,9 @@ function truncateVisibleTail(value: string, maxWidth: number): string {
 const GJC_TMUX_WINDOW_BRANCH_SEPARATOR = "-";
 const GJC_TMUX_WINDOW_TITLE_PREFIX = "GJC-";
 const GJC_TMUX_TERMINAL_TITLE_PREFIX = "GJC: ";
+const GJC_TMUX_ROOT_TERMINAL_TITLE_OPTION = "@gjc-root-terminal-title";
+const GJC_TMUX_ROOT_TERMINAL_TITLE_SESSION_OPTION = "@gjc-root-terminal-title-session";
+const GJC_TMUX_DYNAMIC_SESSION_TITLE = "GJC: #{session_name}";
 
 function sanitizeTmuxWindowTitleSegment(value: string): string {
 	return value.replace(/:+/g, "-");
@@ -489,17 +492,31 @@ function sanitizeGjcTmuxRootTerminalTitle(title: string): string {
 	return title.replace(TERMINAL_TITLE_CONTROL_CHARS, "").trim() || "GJC";
 }
 
-function escapeTmuxFormatLiteral(value: string): string {
-	return value.replace(/#/g, "##");
+function buildGjcTmuxRootTerminalTitleFormat(sessionName: string): string {
+	if (!sessionName.startsWith(GJC_TMUX_SESSION_PREFIX)) return GJC_TMUX_DYNAMIC_SESSION_TITLE;
+	return `#{?#{==:#{${GJC_TMUX_ROOT_TERMINAL_TITLE_SESSION_OPTION}},#{session_name}},#{${GJC_TMUX_ROOT_TERMINAL_TITLE_OPTION}},${GJC_TMUX_DYNAMIC_SESSION_TITLE}}`;
 }
 
-function buildGjcTmuxRootTerminalTitleCommands(target: string, title: string): GjcTmuxProfileCommand[] {
-	const sanitized = escapeTmuxFormatLiteral(sanitizeGjcTmuxRootTerminalTitle(title));
+function buildGjcTmuxRootTerminalTitleCommands(
+	target: string,
+	sessionName: string,
+	title: string,
+): GjcTmuxProfileCommand[] {
+	const sanitized = sanitizeGjcTmuxRootTerminalTitle(title);
+	const format = buildGjcTmuxRootTerminalTitleFormat(sessionName);
 	return [
+		{
+			description: "remember tmux client terminal title fallback",
+			args: ["set-option", "-t", target, GJC_TMUX_ROOT_TERMINAL_TITLE_OPTION, sanitized],
+		},
+		{
+			description: "remember tmux client terminal title session",
+			args: ["set-option", "-t", target, GJC_TMUX_ROOT_TERMINAL_TITLE_SESSION_OPTION, sessionName],
+		},
 		{ description: "enable tmux client terminal title", args: ["set-option", "-t", target, "set-titles", "on"] },
 		{
-			description: "set tmux client terminal title",
-			args: ["set-option", "-t", target, "set-titles-string", sanitized],
+			description: "set dynamic tmux client terminal title",
+			args: ["set-option", "-t", target, "set-titles-string", format],
 		},
 	];
 }
@@ -512,10 +529,8 @@ function applyGjcTmuxRootTerminalTitleProfile(context: {
 	options: TmuxSpawnOptions;
 }): void {
 	if (!context.title) return;
-	for (const command of buildGjcTmuxRootTerminalTitleCommands(
-		buildGjcTmuxExactOptionTarget(context.target, { env: context.options.env }),
-		context.title,
-	)) {
+	const optionTarget = buildGjcTmuxExactOptionTarget(context.target, { env: context.options.env });
+	for (const command of buildGjcTmuxRootTerminalTitleCommands(optionTarget, context.target, context.title)) {
 		context.spawnSync(context.tmuxCommand, command.args, context.options);
 	}
 }

--- a/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts
@@ -169,13 +169,50 @@ describe("default GJC tmux launch", () => {
 			"-t",
 			expect.stringMatching(/^=gajae_code_.*:$/),
 			"set-titles-string",
-			"GJC: repo-feature/demo",
+			"#{?#{==:#{@gjc-root-terminal-title-session},#{session_name}},#{@gjc-root-terminal-title},GJC: #{session_name}}",
 		]);
+		expect(
+			calls.some(call => call.args[3] === "@gjc-root-terminal-title" && call.args[4] === "GJC: repo-feature/demo"),
+		).toBe(true);
+		expect(
+			calls.some(
+				call => call.args[3] === "@gjc-root-terminal-title-session" && /^gajae_code_/.test(call.args[4] ?? ""),
+			),
+		).toBe(true);
 		expect(calls.some(call => call.args[3] === "set-titles" && call.args[4] === "on")).toBe(true);
 		expect(writeSpy).not.toHaveBeenCalled();
 	});
+	it("uses the live tmux session name for already renamed managed sessions", () => {
+		const calls: Array<{ command: string; args: string[] }> = [];
 
-	it("escapes tmux format markers in client terminal titles", () => {
+		const handled = launchDefaultTmuxIfNeeded({
+			parsed: args({ messages: ["hello world"], tmux: true, continue: true }),
+			rawArgs: ["--tmux", "--continue", "hello world"],
+			cwd: "/repo",
+			env: {},
+			argv: ["bun", "packages/coding-agent/src/cli.ts"],
+			execPath: "/bin/bun",
+			platform: "darwin",
+			tty: interactiveTty,
+			tmuxAvailable: true,
+			existingBranchSessionName: "office-renamed",
+			currentBranch: "feature/demo",
+			spawnSync: (command, spawnArgs) => {
+				calls.push({ command, args: spawnArgs });
+				return { exitCode: 0 };
+			},
+		});
+
+		expect(handled).toBe(true);
+		expect(calls.find(call => call.args[3] === "set-titles-string")?.args.at(-1)).toBe("GJC: #{session_name}");
+		expect(calls.find(call => call.args[0] === "attach-session")?.args).toEqual([
+			"attach-session",
+			"-t",
+			"=office-renamed",
+		]);
+	});
+
+	it("stores literal fallback titles outside the tmux title format", () => {
 		const calls: Array<{ command: string; args: string[] }> = [];
 		const handled = launchDefaultTmuxIfNeeded({
 			parsed: args({ messages: ["hello world"], tmux: true }),
@@ -196,7 +233,14 @@ describe("default GJC tmux launch", () => {
 		});
 
 		expect(handled).toBe(true);
-		expect(calls.find(call => call.args[3] === "set-titles-string")?.args.at(-1)).toBe("GJC: repo-feature/##S/demo");
+		expect(
+			calls.some(
+				call => call.args[3] === "@gjc-root-terminal-title" && call.args[4] === "GJC: repo-feature/#S/demo",
+			),
+		).toBe(true);
+		expect(calls.find(call => call.args[3] === "set-titles-string")?.args.at(-1)).toBe(
+			"#{?#{==:#{@gjc-root-terminal-title-session},#{session_name}},#{@gjc-root-terminal-title},GJC: #{session_name}}",
+		);
 	});
 
 	it("honors title opt-out while launching managed tmux", () => {


### PR DESCRIPTION
## What

- Store the friendly generated `gjc --tmux` terminal title in a tmux user option instead of embedding it directly in `set-titles-string`.
- Use a tmux format that keeps the friendly project/branch title while the generated `gajae_code_*` session name is unchanged, then falls back to `GJC: #{session_name}` after the user renames the tmux session.
- Cover existing renamed-session attach and literal `#` fallback title behavior.

## Why

Double-click renaming the tmux session updates the tmux status bar, but the terminal tab title stayed fixed at the launch-time `GJC: <project-branch>` literal. Using the live tmux session name after rename makes Windows Terminal and Ghostty tabs follow the session label.

## Testing

- `bun test packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/gjc-runtime/launch-tmux.ts packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/CHANGELOG.md`
- `git diff --check`
- Real tmux smoke: evaluated `set-titles-string` before and after `rename-session` (`GJC: repo-main` -> `GJC: office title pr ...`)
- `bun --cwd=packages/coding-agent run check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
