### PR TITLE
Fix Telegram topic rename retry

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Finalized notification turn mirrors now default to the bounded full-turn cap so Telegram's existing chunked delivery can send long assistant answers instead of receiving an already-truncated 3500-character summary; `GJC_NOTIFICATIONS_TURN_MAX` remains available to lower the cap for summary-style mirrors, and live previews stay capped as one editable message.
 - `gjc --tmux` now wraps the inner GJC command with a durable `tmux-exit.json` marker next to `runtime-state.json`, so a tmux-resident session that exits before normal runtime-state finalization leaves a public-safe exit timestamp/code for silent-vanish diagnosis (#1746).
 - `gjc --tmux` terminal titles now track live tmux session renames while preserving the friendly project/branch title for untouched generated session ids.
+- Telegram session forum-topic renames now remain retryable after a transient `editForumTopic` failure, so topics do not get stuck at the provisional `GJC <session>` name while the daemon incorrectly records the final title locally.
 
 ## [0.9.1] - 2026-07-08
 

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -2235,16 +2235,22 @@ export class TelegramNotificationDaemon {
 				// Rename the topic if the title changed (e.g. the session title was
 				// auto-generated after the topic was first created). This runs on
 				// every identity frame, but does NOT re-send the bulleted message.
+				// Only commit the new registry name after Telegram accepts the edit:
+				// a transient editForumTopic failure must remain retryable on the
+				// next identity re-assert instead of leaving the remote topic stuck
+				// at the provisional "GJC <id>" name forever.
 				const name = this.topicNameFor(session.sessionId, msg);
-				if (this.topics.applyName(session.sessionId, name)) {
+				if (this.topics.needsRename(session.sessionId, name)) {
 					try {
 						await this.botApi.call("editForumTopic", {
 							chat_id: this.opts.chatId,
 							message_thread_id: Number(topicId),
 							name,
 						});
+						this.topics.markNameApplied(session.sessionId, name);
 					} catch {
-						// Best-effort rename; never block delivery.
+						// Best-effort rename; never block delivery. Leave the old
+						// registry name intact so a later identity frame retries.
 					}
 				}
 				// Send the full bulleted identity header EXACTLY ONCE per topic.

--- a/packages/coding-agent/src/notifications/topic-registry.ts
+++ b/packages/coding-agent/src/notifications/topic-registry.ts
@@ -120,15 +120,16 @@ export class TopicRegistry {
 		return record ? !record.identitySent : true;
 	}
 
-	/**
-	 * Record the topic's applied title. Returns `true` when it changed (so the
-	 * caller should `editForumTopic`), `false` when already current or unknown.
-	 */
-	applyName(sessionId: string, name: string): boolean {
+	/** Whether a known session topic's applied title differs from `name`. */
+	needsRename(sessionId: string, name: string): boolean {
 		const record = this.topics.get(sessionId);
-		if (!record || record.name === name) return false;
-		record.name = name;
-		return true;
+		return record !== undefined && record.name !== name;
+	}
+
+	/** Commit a successfully-applied Telegram topic title. */
+	markNameApplied(sessionId: string, name: string): void {
+		const record = this.topics.get(sessionId);
+		if (record) record.name = name;
 	}
 
 	/** Remove a session topic record after Telegram deletes the topic. */

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -1604,6 +1604,59 @@ test("identity-less threaded frames wait for identity instead of creating fallba
 	expect(photo).toBeTruthy();
 	expect(photo!.body.message_thread_id).toBeGreaterThan(0);
 });
+test("transient topic rename failure is retried on the next identity header", async () => {
+	class RetryRenameBotApi extends FakeBotApi {
+		editAttempts = 0;
+		override async call(method: string, body: unknown): Promise<unknown> {
+			if (method === "editForumTopic") {
+				this.editAttempts++;
+				this.calls.push({ method, body });
+				if (this.editAttempts === 1) throw new Error("temporary rename failure");
+				return { ok: true, result: true };
+			}
+			return super.call(method, body);
+		}
+	}
+
+	const agentDir = tempAgentDir();
+	const bot = new RetryRenameBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "action_needed",
+		kind: "ask",
+		id: "ask1",
+		question: "Name it?",
+		options: ["a", "b"],
+	});
+	expect(bot.calls.find(c => c.method === "createForumTopic")!.body.name).toBe("GJC S");
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+		title: "Readable title",
+	});
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+		title: "Readable title",
+	});
+
+	const edits = bot.calls.filter(c => c.method === "editForumTopic");
+	expect(edits).toHaveLength(2);
+	expect(edits.map(c => c.body.name)).toEqual(["gajae-code/dev - Readable title", "gajae-code/dev - Readable title"]);
+});
 
 test("live sessions with the same repo branch create distinct topics", async () => {
 	const agentDir = tempAgentDir();

--- a/packages/coding-agent/test/notifications-topic-registry.test.ts
+++ b/packages/coding-agent/test/notifications-topic-registry.test.ts
@@ -34,6 +34,23 @@ describe("TopicRegistry", () => {
 		expect(reg.needsIdentity("s1")).toBe(false);
 	});
 
+	test("separates rename detection from successful name commit", async () => {
+		const reg = new TopicRegistry();
+		await reg.getOrCreateTopic(
+			"s1",
+			async () => "t1",
+			() => 1000,
+			"GJC abc123",
+		);
+
+		expect(reg.needsRename("s1", "repo/main")).toBe(true);
+		expect(reg.needsRename("missing", "repo/main")).toBe(false);
+
+		reg.markNameApplied("s1", "repo/main");
+		expect(reg.needsRename("s1", "repo/main")).toBe(false);
+		expect(reg.get("s1")?.name).toBe("repo/main");
+	});
+
 	test("resolves session for a topic id (inbound routing)", async () => {
 		const reg = new TopicRegistry();
 		await reg.getOrCreateTopic("s1", async () => "t-99");


### PR DESCRIPTION
## Summary
- Fix Telegram session topics getting stuck at the provisional `GJC <session>` name after a transient rename failure.
- Commit the local topic registry name only after `editForumTopic` succeeds.
- Add regression coverage for retrying the rename on the next identity reassertion.

## Problem
Telegram notification topics are created eagerly with a provisional name such as `GJC <session>`. Once session identity/title information is available, the daemon renames the topic via `editForumTopic`.

The daemon previously updated the local topic registry before the Telegram rename succeeded. If `editForumTopic` failed transiently, the remote topic kept its provisional name, but the registry recorded the final name. Later `identity_header` reassertions compared against that registry value, treated the rename as already applied, and skipped retrying.

This could leave a live session topic stuck at `GJC <session>` until the topic was recreated.

## Fix
Keep the previous registry name until Telegram accepts the rename. On failure, delivery continues as before, and the next identity reassertion naturally retries the rename through the existing control flow.

## Regression test
Added coverage for:
1. creating a provisional topic,
2. failing the first `editForumTopic` call,
3. sending the same `identity_header` again,
4. asserting a second `editForumTopic` attempt is made.

Without the fix, the regression test fails with only one rename attempt.

## Verification
- Reproduced the pre-fix failure with the new regression test:
  - expected 2 `editForumTopic` attempts
  - observed 1 attempt before the fix
- `bun test packages/coding-agent/test/notifications-topic-registry.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun test packages/coding-agent/test/notifications-rich-redteam.test.ts packages/coding-agent/test/notifications-threaded-inbound.test.ts`
- `git diff --check`

Note: `packages/coding-agent/test/notifications-rich-e2e.test.ts` currently fails with `timed out waiting for: final answer promoted to sendRichMessage`; the same failure reproduces after removing this patch, so it is not introduced by this change.