### PR TITLE
feat(coding-agent): edit existing custom model preset

### DIFF
--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -4,6 +4,7 @@ import type { AgentSession } from "../session/agent-session";
 import { formatClampedModelSelector } from "../thinking";
 import {
 	aggregateModelProfileRequiredProviders,
+	deriveRequiredProviders,
 	formatAvailableProfileNames,
 	formatModelProfileDisplayLabel,
 	resolveProfileBindings,
@@ -15,6 +16,7 @@ import {
 	type ModelRegistry,
 } from "./model-registry";
 import { formatModelSelectorValue, resolveModelRoleValue } from "./model-resolver";
+import { type ModelProfileConfig, ProfileDefinitionSchema } from "./models-config-schema";
 import type { Settings } from "./settings";
 
 const LEGACY_MODEL_PROFILE_ALIASES: ReadonlyMap<string, string> = new Map([["codex-standard", "codex-medium"]]);
@@ -509,4 +511,77 @@ export async function activateModelProfile(
 ): Promise<void> {
 	const prepared = await prepareModelProfileActivation(options);
 	await applyPreparedModelProfileActivation(prepared, applyOptions);
+}
+
+export interface ValidateModelProfileCandidateOptions {
+	profileName: string;
+	profile: ModelProfileConfig;
+	modelRegistry: Pick<
+		ModelRegistry,
+		"getAll" | "getApiKeyForProvider" | "resolveCanonicalModel" | "getCanonicalVariants" | "getCanonicalId"
+	>;
+	settings: Pick<Settings, "get">;
+	sessionId?: string;
+}
+
+export type ValidateModelProfileCandidateResult =
+	| {
+			ok: true;
+			profile: ModelProfileConfig;
+			requiredProviders: string[];
+			normalizedMapping: ModelProfileConfig["model_mapping"];
+	  }
+	| { ok: false; reason: string };
+
+/**
+ * Validate an unsaved custom model profile candidate before any config write.
+ * Checks schema, non-empty role mapping, selector resolution, effort clamping
+ * (clamp is accepted, not rejected), and per-provider credentials.
+ */
+export async function validateModelProfileCandidate(
+	options: ValidateModelProfileCandidateOptions,
+): Promise<ValidateModelProfileCandidateResult> {
+	const parsed = ProfileDefinitionSchema.safeParse(options.profile);
+	if (!parsed.success) {
+		const first = parsed.error.issues[0];
+		const where = first?.path.length ? `/${first.path.map(String).join("/")}` : "root";
+		return { ok: false, reason: `Invalid model profile at ${where}: ${first?.message ?? "unknown schema error"}` };
+	}
+	const candidate = parsed.data;
+
+	const mappingEntries = Object.entries(candidate.model_mapping).filter(
+		(entry): entry is [string, string] => typeof entry[1] === "string" && entry[1].length > 0,
+	);
+	if (mappingEntries.length === 0) {
+		return { ok: false, reason: "Model profile must map at least one role." };
+	}
+
+	const availableModels = options.modelRegistry.getAll();
+	const normalizedMapping: Record<string, string> = {};
+	for (const [role, selector] of mappingEntries) {
+		const resolved = resolveModelRoleValue(selector, availableModels, {
+			settings: options.settings as Settings,
+			modelRegistry: options.modelRegistry,
+		});
+		if (!resolved.model) {
+			return { ok: false, reason: `Model profile ${role} selector did not resolve: ${selector}` };
+		}
+		normalizedMapping[role] = formatClampedModelSelector(selector, resolved.model);
+	}
+
+	const requiredProviders = deriveRequiredProviders(candidate.model_mapping);
+	for (const provider of requiredProviders) {
+		const apiKey = await options.modelRegistry.getApiKeyForProvider(provider, options.sessionId);
+		if (!isAuthenticated(apiKey)) {
+			return { ok: false, reason: formatModelProfileCredentialError(options.profileName, [provider]) };
+		}
+	}
+
+	const normalized = normalizedMapping as ModelProfileConfig["model_mapping"];
+	return {
+		ok: true,
+		profile: { ...candidate, required_providers: requiredProviders, model_mapping: normalized },
+		requiredProviders,
+		normalizedMapping: normalized,
+	};
 }

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -1,6 +1,6 @@
 import { sanitizeText } from "@gajae-code/utils";
 import type { GjcModelAssignmentTargetId } from "./model-registry";
-import type { ModelsConfig } from "./models-config-schema";
+import type { ModelProfileConfig, ModelsConfig } from "./models-config-schema";
 
 export type ModelProfileRole = GjcModelAssignmentTargetId;
 
@@ -32,6 +32,16 @@ function parseModelSelectorProvider(selector: string): string | undefined {
 	const slashIdx = selector.indexOf("/");
 	if (slashIdx <= 0) return undefined;
 	return selector.slice(0, slashIdx);
+}
+
+export function deriveRequiredProviders(modelMapping: ModelProfileConfig["model_mapping"]): string[] {
+	const providers = new Set<string>();
+	for (const selector of Object.values(modelMapping)) {
+		if (!selector) continue;
+		const provider = parseModelSelectorProvider(selector);
+		if (provider) providers.add(provider);
+	}
+	return [...providers].sort((a, b) => a.localeCompare(b));
 }
 
 export function deriveModelProfileMappedProviders(definition: Pick<ModelProfileDefinition, "modelMapping">): string[] {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -48,6 +48,7 @@ import {
 } from "./model-equivalence";
 import {
 	aggregateModelProfileRequiredProviders,
+	deriveRequiredProviders,
 	type ModelProfileDefinition,
 	mergeModelProfiles,
 } from "./model-profiles";
@@ -999,6 +1000,12 @@ function getConfiguredProviderOrderFromSettings(): string[] {
 	}
 }
 
+export interface CustomModelProfileEditSnapshot {
+	profileName: string;
+	previousProfile: ModelProfileConfig;
+	previousModelsConfigText: string;
+}
+
 /**
  * Model registry - loads and manages models, resolves API keys via AuthStorage.
  */
@@ -1664,9 +1671,73 @@ export class ModelRegistry {
 		return profile;
 	}
 
+	async editCustomModelProfile(
+		name: string,
+		definition: ModelProfileConfig,
+	): Promise<{ profile: ModelProfileDefinition; snapshot: CustomModelProfileEditSnapshot }> {
+		const normalizedName = name.trim();
+		if (!normalizedName) throw new Error("Profile name is required.");
+		const checkedDefinition = ProfileDefinitionSchema.safeParse(definition);
+		if (!checkedDefinition.success) {
+			const first = checkedDefinition.error.issues[0];
+			const where = first?.path.length ? `/${first.path.map(String).join("/")}` : "root";
+			throw new Error(`Custom model profile is invalid at ${where}: ${first?.message ?? "unknown schema error"}`);
+		}
+		const { current, profile: previousProfile } = this.#loadCustomProfileForMutation(normalizedName, "edit");
+		const previousModelsConfigText = await this.#readModelsConfigText();
+		const modelMapping = { ...definition.model_mapping };
+		const requiredProviders = deriveRequiredProviders(modelMapping);
+		const nextDefinition: ModelProfileConfig = {
+			...previousProfile,
+			required_providers: requiredProviders,
+			model_mapping: modelMapping,
+		};
+		const nextProfiles = {
+			...(current.profiles ?? {}),
+			[normalizedName]: nextDefinition,
+		};
+		const checkedConfig = ModelsConfigSchema.safeParse({ ...current, profiles: nextProfiles });
+		if (!checkedConfig.success) {
+			const first = checkedConfig.error.issues[0];
+			const where = first?.path.length ? `/${first.path.map(String).join("/")}` : "root";
+			throw new Error(`Generated models config is invalid at ${where}: ${first?.message ?? "unknown schema error"}`);
+		}
+		await this.#writeCheckedModelsConfig(checkedConfig.data);
+		// Force a fresh reload so getModelProfiles() reflects the edit before activation,
+		// defeating the mtime cache guard when the write lands in the same millisecond.
+		this.#lastStaticLoadMtime = null;
+		this.#reloadStaticModels();
+		const profile: ModelProfileDefinition = {
+			name: normalizedName,
+			displayName: previousProfile.display_name,
+			requiredProviders,
+			modelMapping,
+			source: "user",
+		};
+		return { profile, snapshot: { profileName: normalizedName, previousProfile, previousModelsConfigText } };
+	}
+
+	async restoreCustomModelProfileEdit(snapshot: CustomModelProfileEditSnapshot): Promise<void> {
+		const modelsPath = this.#modelsConfigFile.path();
+		await fs.mkdir(path.dirname(modelsPath), { recursive: true });
+		await Bun.write(modelsPath, snapshot.previousModelsConfigText);
+		this.#modelsConfigFile.invalidate();
+		// Force a full reload regardless of mtime so getModelProfiles() reflects the restore.
+		this.#lastStaticLoadMtime = null;
+		this.#reloadStaticModels();
+	}
+
+	async #readModelsConfigText(): Promise<string> {
+		try {
+			return await fs.readFile(this.#modelsConfigFile.path(), "utf8");
+		} catch {
+			return "";
+		}
+	}
+
 	#loadCustomProfileForMutation(
 		normalizedName: string,
-		action: "rename" | "delete",
+		action: "edit" | "rename" | "delete",
 	): { current: ModelsConfig; profile: ModelProfileConfig } {
 		const loaded = this.#modelsConfigFile.tryLoad();
 		if (loaded.status === "error") {

--- a/packages/coding-agent/src/modes/components/custom-model-preset-wizard.ts
+++ b/packages/coding-agent/src/modes/components/custom-model-preset-wizard.ts
@@ -1,12 +1,37 @@
+import { getSupportedEfforts, type Model } from "@gajae-code/ai";
 import { Container, Input, matchesKey, Spacer, Text, TruncatedText } from "@gajae-code/tui";
-import { MODEL_PROFILE_NAME_PATTERN } from "../../config/model-registry";
+import { deriveRequiredProviders } from "../../config/model-profiles";
+import type { GjcModelAssignmentTargetId, ModelRegistry } from "../../config/model-registry";
+import { GJC_MODEL_ASSIGNMENT_TARGETS, MODEL_PROFILE_NAME_PATTERN } from "../../config/model-registry";
 import type { ModelProfileConfig } from "../../config/models-config-schema";
 import { theme } from "../theme/theme";
 import { matchesAppInterrupt } from "../utils/keybinding-matchers";
 import { DynamicBorder } from "./dynamic-border";
+import { PROFILE_ROLE_PREVIEW_ORDER } from "./model-selector";
+
 export interface CustomModelPresetWizardSubmit {
 	name: string;
 	profile: ModelProfileConfig;
+}
+
+/**
+ * Options that switch the wizard from the default single-input create form into
+ * the draft picker used to edit an existing custom preset. Providing this keeps
+ * every create call site (which omits it) byte-identical.
+ */
+export interface CustomModelPresetWizardEditContext {
+	mode: "edit";
+	profileName: string;
+	modelRegistry: Pick<ModelRegistry, "getAll">;
+}
+
+type EditPickerView = "roleList" | "modelPick" | "effortPick";
+
+const NO_EXPLICIT_EFFORT = "__no_explicit_effort__";
+const MODEL_PICK_WINDOW = 8;
+
+function isPrintableCharacter(keyData: string): boolean {
+	return keyData.length === 1 && keyData >= " " && keyData !== "\x7f";
 }
 
 export class CustomModelPresetWizardComponent extends Container {
@@ -19,24 +44,55 @@ export class CustomModelPresetWizardComponent extends Container {
 	#onCancel: () => void;
 	#onRender: () => void;
 
+	// Edit-mode state (unused in create mode).
+	#mode: "create" | "edit";
+	#profileName = "";
+	#displayName: string | undefined;
+	#modelRegistry: Pick<ModelRegistry, "getAll"> | null = null;
+	#draftMapping: Partial<Record<GjcModelAssignmentTargetId, string>> = {};
+	#view: EditPickerView = "roleList";
+	#roleCursor = 0;
+	#modelCursor = 0;
+	#modelFilter = "";
+	#effortCursor = 0;
+	#pendingRole: GjcModelAssignmentTargetId | null = null;
+	#pendingModel: Model | null = null;
+
 	constructor(
 		snapshot: ModelProfileConfig,
 		onSubmit: (input: CustomModelPresetWizardSubmit) => void,
 		onCancel: () => void,
 		onRender: () => void = () => {},
+		editContext?: CustomModelPresetWizardEditContext,
 	) {
 		super();
 		this.#snapshot = snapshot;
 		this.#onSubmit = onSubmit;
 		this.#onCancel = onCancel;
 		this.#onRender = onRender;
+		this.#mode = editContext?.mode ?? "create";
+		if (editContext) {
+			this.#profileName = editContext.profileName;
+			this.#modelRegistry = editContext.modelRegistry;
+			this.#displayName = snapshot.display_name;
+			this.#draftMapping = { ...snapshot.model_mapping };
+		}
 
 		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
-		this.addChild(new TruncatedText(theme.bold("Create custom model preset")));
 		this.addChild(
 			new TruncatedText(
-				theme.fg("muted", "  Save the current default and explicit role models as a selectable profile."),
+				theme.bold(this.#mode === "edit" ? "Edit custom model preset" : "Create custom model preset"),
+			),
+		);
+		this.addChild(
+			new TruncatedText(
+				theme.fg(
+					"muted",
+					this.#mode === "edit"
+						? `  Update role model mappings for ${this.#profileName}. Preset id and display name stay the same.`
+						: "  Save the current default and explicit role models as a selectable profile.",
+				),
 				0,
 				0,
 			),
@@ -56,6 +112,11 @@ export class CustomModelPresetWizardComponent extends Container {
 	}
 
 	handleInput(keyData: string): void {
+		if (this.#mode === "edit") {
+			this.#handleEditInput(keyData);
+			return;
+		}
+
 		if (matchesAppInterrupt(keyData)) {
 			this.#onCancel();
 			return;
@@ -71,6 +132,10 @@ export class CustomModelPresetWizardComponent extends Container {
 	}
 
 	#renderStep(): void {
+		if (this.#mode === "edit") {
+			this.#renderEditStep();
+			return;
+		}
 		this.#contentContainer.clear();
 		this.#input = null;
 		this.#contentContainer.addChild(new Text(theme.fg("accent", "Preset id")));
@@ -128,5 +193,254 @@ export class CustomModelPresetWizardComponent extends Container {
 				required_providers: [...this.#snapshot.required_providers],
 			},
 		});
+	}
+
+	// ---- Edit mode (draft picker) ----
+
+	#roleListLength(): number {
+		return PROFILE_ROLE_PREVIEW_ORDER.length + 1; // +1 for the Save row
+	}
+
+	#filteredModels(): Model[] {
+		const all = this.#modelRegistry?.getAll() ?? [];
+		const filter = this.#modelFilter.trim().toLowerCase();
+		if (!filter) return [...all];
+		return all.filter(model => `${model.provider}/${model.id}`.toLowerCase().includes(filter));
+	}
+
+	#effortOptions(): string[] {
+		let efforts: readonly string[] = [];
+		if (this.#pendingModel) {
+			try {
+				efforts = getSupportedEfforts(this.#pendingModel);
+			} catch {
+				efforts = [];
+			}
+		}
+		return [...efforts, NO_EXPLICIT_EFFORT];
+	}
+
+	#handleEditInput(keyData: string): void {
+		if (this.#view === "roleList") {
+			this.#handleRoleListInput(keyData);
+			return;
+		}
+		if (this.#view === "modelPick") {
+			this.#handleModelPickInput(keyData);
+			return;
+		}
+		this.#handleEffortPickInput(keyData);
+	}
+
+	#handleRoleListInput(keyData: string): void {
+		if (matchesAppInterrupt(keyData)) {
+			this.#onCancel();
+			return;
+		}
+		const total = this.#roleListLength();
+		if (matchesKey(keyData, "up")) {
+			this.#roleCursor = this.#roleCursor === 0 ? total - 1 : this.#roleCursor - 1;
+			this.#renderStep();
+			this.#onRender();
+			return;
+		}
+		if (matchesKey(keyData, "down")) {
+			this.#roleCursor = (this.#roleCursor + 1) % total;
+			this.#renderStep();
+			this.#onRender();
+			return;
+		}
+		if (keyData === "s" || keyData === "S") {
+			this.#submitEdit();
+			return;
+		}
+		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
+			if (this.#roleCursor >= PROFILE_ROLE_PREVIEW_ORDER.length) {
+				this.#submitEdit();
+				return;
+			}
+			const role = PROFILE_ROLE_PREVIEW_ORDER[this.#roleCursor];
+			if (!role) return;
+			this.#pendingRole = role;
+			this.#view = "modelPick";
+			this.#modelFilter = "";
+			this.#modelCursor = 0;
+			this.#renderStep();
+			this.#onRender();
+		}
+	}
+
+	#handleModelPickInput(keyData: string): void {
+		if (matchesAppInterrupt(keyData)) {
+			this.#pendingRole = null;
+			this.#modelFilter = "";
+			this.#view = "roleList";
+			this.#renderStep();
+			this.#onRender();
+			return;
+		}
+		const models = this.#filteredModels();
+		if (matchesKey(keyData, "up")) {
+			if (models.length > 0) this.#modelCursor = this.#modelCursor === 0 ? models.length - 1 : this.#modelCursor - 1;
+			this.#renderStep();
+			this.#onRender();
+			return;
+		}
+		if (matchesKey(keyData, "down")) {
+			if (models.length > 0) this.#modelCursor = (this.#modelCursor + 1) % models.length;
+			this.#renderStep();
+			this.#onRender();
+			return;
+		}
+		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
+			const model = models[this.#modelCursor];
+			if (!model) return;
+			this.#pendingModel = model;
+			this.#view = "effortPick";
+			this.#effortCursor = 0;
+			this.#renderStep();
+			this.#onRender();
+			return;
+		}
+		if (keyData === "\x7f" || keyData === "\b") {
+			this.#modelFilter = this.#modelFilter.slice(0, -1);
+			this.#modelCursor = 0;
+			this.#renderStep();
+			this.#onRender();
+			return;
+		}
+		if (isPrintableCharacter(keyData)) {
+			this.#modelFilter += keyData;
+			this.#modelCursor = 0;
+			this.#renderStep();
+			this.#onRender();
+		}
+	}
+
+	#handleEffortPickInput(keyData: string): void {
+		if (matchesAppInterrupt(keyData)) {
+			this.#pendingModel = null;
+			this.#view = "modelPick";
+			this.#renderStep();
+			this.#onRender();
+			return;
+		}
+		const efforts = this.#effortOptions();
+		if (matchesKey(keyData, "up")) {
+			this.#effortCursor = this.#effortCursor === 0 ? efforts.length - 1 : this.#effortCursor - 1;
+			this.#renderStep();
+			this.#onRender();
+			return;
+		}
+		if (matchesKey(keyData, "down")) {
+			this.#effortCursor = (this.#effortCursor + 1) % efforts.length;
+			this.#renderStep();
+			this.#onRender();
+			return;
+		}
+		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
+			const effort = efforts[this.#effortCursor];
+			if (effort === undefined || this.#pendingRole === null || !this.#pendingModel) return;
+			const base = `${this.#pendingModel.provider}/${this.#pendingModel.id}`;
+			this.#draftMapping[this.#pendingRole] = effort === NO_EXPLICIT_EFFORT ? base : `${base}:${effort}`;
+			this.#pendingRole = null;
+			this.#pendingModel = null;
+			this.#view = "roleList";
+			this.#renderStep();
+			this.#onRender();
+		}
+	}
+
+	#submitEdit(): void {
+		this.#lastError = null;
+		const mapping = { ...this.#draftMapping };
+		this.#onSubmit({
+			name: this.#profileName,
+			profile: {
+				...(this.#displayName !== undefined ? { display_name: this.#displayName } : {}),
+				model_mapping: mapping,
+				required_providers: deriveRequiredProviders(mapping),
+			},
+		});
+	}
+
+	#renderEditStep(): void {
+		this.#contentContainer.clear();
+		this.#input = null;
+		if (this.#lastError) {
+			this.#contentContainer.addChild(new Text(theme.fg("error", this.#lastError), 0, 0));
+			this.#contentContainer.addChild(new Spacer(1));
+		}
+		if (this.#view === "roleList") {
+			this.#renderRoleList();
+			return;
+		}
+		if (this.#view === "modelPick") {
+			this.#renderModelPick();
+			return;
+		}
+		this.#renderEffortPick();
+	}
+
+	#renderRoleList(): void {
+		this.#contentContainer.addChild(new Text(theme.fg("accent", "Roles"), 0, 0));
+		this.#contentContainer.addChild(new Spacer(1));
+		PROFILE_ROLE_PREVIEW_ORDER.forEach((role, index) => {
+			const label = GJC_MODEL_ASSIGNMENT_TARGETS[role].tag ?? role.toUpperCase();
+			const selector = this.#draftMapping[role] ?? "(inherit)";
+			const selected = index === this.#roleCursor;
+			const prefix = selected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+			const line = `${prefix}${label}: ${selector}`;
+			this.#contentContainer.addChild(new Text(selected ? theme.fg("accent", line) : line, 0, 0));
+		});
+		const saveSelected = this.#roleCursor === PROFILE_ROLE_PREVIEW_ORDER.length;
+		const savePrefix = saveSelected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+		const saveLine = `${savePrefix}Save`;
+		this.#contentContainer.addChild(new Spacer(1));
+		this.#contentContainer.addChild(new Text(saveSelected ? theme.fg("accent", saveLine) : saveLine, 0, 0));
+		this.#contentContainer.addChild(new Spacer(1));
+		this.#addHelp("[Up/Down to move, Enter to edit role, s to save, Esc to cancel]");
+	}
+
+	#renderModelPick(): void {
+		const role = this.#pendingRole;
+		const roleLabel = role ? (GJC_MODEL_ASSIGNMENT_TARGETS[role].tag ?? role.toUpperCase()) : "";
+		this.#contentContainer.addChild(new Text(theme.fg("accent", `Model for ${roleLabel}`), 0, 0));
+		this.#contentContainer.addChild(new Spacer(1));
+		this.#contentContainer.addChild(new Text(`Filter: ${this.#modelFilter || "(type to filter)"}`, 0, 0));
+		this.#contentContainer.addChild(new Spacer(1));
+		const models = this.#filteredModels();
+		if (models.length === 0) {
+			this.#contentContainer.addChild(new Text(theme.fg("muted", "No matching models."), 0, 0));
+		}
+		const cursor = models.length === 0 ? 0 : Math.min(this.#modelCursor, models.length - 1);
+		const start = Math.max(
+			0,
+			Math.min(cursor - Math.floor(MODEL_PICK_WINDOW / 2), Math.max(0, models.length - MODEL_PICK_WINDOW)),
+		);
+		models.slice(start, start + MODEL_PICK_WINDOW).forEach((model, offset) => {
+			const index = start + offset;
+			const selected = index === cursor;
+			const prefix = selected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+			const line = `${prefix}${model.provider}/${model.id}`;
+			this.#contentContainer.addChild(new Text(selected ? theme.fg("accent", line) : line, 0, 0));
+		});
+		this.#contentContainer.addChild(new Spacer(1));
+		this.#addHelp("[Up/Down to move, Enter to choose, type to filter, Esc to go back]");
+	}
+
+	#renderEffortPick(): void {
+		const base = this.#pendingModel ? `${this.#pendingModel.provider}/${this.#pendingModel.id}` : "";
+		this.#contentContainer.addChild(new Text(theme.fg("accent", `Effort for ${base}`), 0, 0));
+		this.#contentContainer.addChild(new Spacer(1));
+		this.#effortOptions().forEach((effort, index) => {
+			const selected = index === this.#effortCursor;
+			const prefix = selected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+			const label = effort === NO_EXPLICIT_EFFORT ? "No explicit effort" : effort;
+			const line = `${prefix}${label}`;
+			this.#contentContainer.addChild(new Text(selected ? theme.fg("accent", line) : line, 0, 0));
+		});
+		this.#contentContainer.addChild(new Spacer(1));
+		this.#addHelp("[Up/Down to move, Enter to set, Esc to go back]");
 	}
 }

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -13,6 +13,7 @@ import {
 	type TUI,
 } from "@gajae-code/tui";
 import {
+	deriveRequiredProviders,
 	getModelProfilePresentation,
 	groupModelProfilesForPresetLanding,
 	type ModelProfileDefinition,
@@ -114,6 +115,10 @@ export type ModelSelectorSelection =
 			profileName: string;
 	  }
 	| {
+			kind: "editProfile";
+			profileName: string;
+	  }
+	| {
 			kind: "deleteProfile";
 			profileName: string;
 	  };
@@ -208,15 +213,28 @@ function presetRowIdentity(row: PresetLandingRow): string {
 	}
 }
 
-const PROFILE_ROLE_PREVIEW_ORDER: GjcModelAssignmentTargetId[] = [
+export const PROFILE_ROLE_PREVIEW_ORDER: GjcModelAssignmentTargetId[] = [
 	"default",
 	"executor",
 	"planner",
 	"critic",
 	"architect",
 ];
-const PRESET_SCOPE_LABELS = ["Apply for this session", "Set as default"];
-const CUSTOM_PRESET_SCOPE_LABELS = ["Apply for this session", "Set as default", "Rename", "Delete"];
+export type PresetScopeActionId = "apply" | "setDefault" | "edit" | "rename" | "delete";
+export interface PresetScopeAction {
+	id: PresetScopeActionId;
+	label: string;
+}
+const BUILTIN_PRESET_SCOPE_ACTIONS = [
+	{ id: "apply", label: "Apply for this session" },
+	{ id: "setDefault", label: "Set as default" },
+] as const satisfies readonly PresetScopeAction[];
+const CUSTOM_PRESET_SCOPE_ACTIONS = [
+	...BUILTIN_PRESET_SCOPE_ACTIONS,
+	{ id: "edit", label: "Edit" },
+	{ id: "rename", label: "Rename" },
+	{ id: "delete", label: "Delete" },
+] as const satisfies readonly PresetScopeAction[];
 
 function isPrintableCharacter(keyData: string): boolean {
 	return keyData.length === 1 && keyData >= " " && keyData !== "\x7f";
@@ -235,20 +253,6 @@ function getDefaultAliasThinkingLevel(value: string | undefined): ThinkingLevel 
 	const normalized = value?.trim();
 	if (!normalized?.startsWith("pi/default:")) return undefined;
 	return parseThinkingLevel(normalized.slice("pi/default:".length));
-}
-
-function getSelectorProvider(selector: string): string | undefined {
-	const slashIndex = selector.indexOf("/");
-	return slashIndex > 0 ? selector.slice(0, slashIndex) : undefined;
-}
-
-function deriveRequiredProviders(modelMapping: ModelProfileConfig["model_mapping"]): string[] {
-	const providers = new Set<string>();
-	for (const selector of Object.values(modelMapping)) {
-		const provider = getSelectorProvider(selector);
-		if (provider) providers.add(provider);
-	}
-	return [...providers].sort((a, b) => a.localeCompare(b));
 }
 
 function sameStringRecord(
@@ -1152,9 +1156,9 @@ export class ModelSelectorComponent extends Container {
 		}
 		this.#listContainer.addChild(new Spacer(1));
 		if (this.#presetScopeMenuOpen) {
-			const actionLabels = this.#getPresetScopeLabels(profile);
-			for (let i = 0; i < actionLabels.length; i++) {
-				const label = actionLabels[i] ?? "";
+			const actions = this.#getPresetScopeActions(profile);
+			for (let i = 0; i < actions.length; i++) {
+				const label = actions[i]?.label ?? "";
 				const prefix = i === this.#presetScopeIndex ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
 				this.#listContainer.addChild(
 					new Text(`${prefix}${i === this.#presetScopeIndex ? theme.fg("accent", label) : label}`, 0, 0),
@@ -1469,7 +1473,7 @@ export class ModelSelectorComponent extends Container {
 			const rows = this.#getPresetRows();
 			if (rows.length === 0) return;
 			if (this.#presetScopeMenuOpen) {
-				const actionCount = this.#getPreviewPresetScopeLabels().length;
+				const actionCount = this.#getPreviewPresetScopeActions().length;
 				this.#presetScopeIndex = this.#presetScopeIndex === 0 ? actionCount - 1 : this.#presetScopeIndex - 1;
 			} else {
 				this.#presetCursor = this.#presetCursor === 0 ? rows.length - 1 : this.#presetCursor - 1;
@@ -1484,7 +1488,7 @@ export class ModelSelectorComponent extends Container {
 			const rows = this.#getPresetRows();
 			if (rows.length === 0) return;
 			if (this.#presetScopeMenuOpen) {
-				this.#presetScopeIndex = (this.#presetScopeIndex + 1) % this.#getPreviewPresetScopeLabels().length;
+				this.#presetScopeIndex = (this.#presetScopeIndex + 1) % this.#getPreviewPresetScopeActions().length;
 			} else {
 				this.#presetCursor = (this.#presetCursor + 1) % rows.length;
 				this.#previewProfileName = undefined;
@@ -1541,25 +1545,17 @@ export class ModelSelectorComponent extends Container {
 		if (this.#presetScopeMenuOpen && this.#previewProfileName) {
 			const profile = this.#getProfileByName(this.#previewProfileName);
 			if (!profile) return;
-			if (this.#presetScopeIndex === 2 && isCustomUserProfile(profile)) {
-				this.#onSelectCallback({ kind: "renameProfile", profileName: this.#previewProfileName });
-				return;
+			const action = this.#getPresetScopeActions(profile)[this.#presetScopeIndex];
+			if (!action) return;
+			if (action.id === "apply" || action.id === "setDefault") {
+				const missing = this.#getMissingProviders(profile);
+				if (missing.length > 0) {
+					this.#presetLoginHint = `Run ${missing.map(provider => `/login ${provider}`).join(", ")}`;
+					this.#renderPresetLanding();
+					return;
+				}
 			}
-			if (this.#presetScopeIndex === 3 && isCustomUserProfile(profile)) {
-				this.#onSelectCallback({ kind: "deleteProfile", profileName: this.#previewProfileName });
-				return;
-			}
-			const missing = this.#getMissingProviders(profile);
-			if (missing.length > 0) {
-				this.#presetLoginHint = `Run ${missing.map(provider => `/login ${provider}`).join(", ")}`;
-				this.#renderPresetLanding();
-				return;
-			}
-			this.#onSelectCallback({
-				kind: "profile",
-				profileName: this.#previewProfileName,
-				setDefault: this.#presetScopeIndex === 1,
-			});
+			this.#emitPresetScopeAction(this.#previewProfileName, action.id);
 			return;
 		}
 		if (this.#previewProfileName) {
@@ -1613,13 +1609,28 @@ export class ModelSelectorComponent extends Container {
 		this.#renderPresetLanding();
 	}
 
-	#getPresetScopeLabels(profile: ModelProfileDefinition): string[] {
-		return isCustomUserProfile(profile) ? CUSTOM_PRESET_SCOPE_LABELS : PRESET_SCOPE_LABELS;
+	#getPresetScopeActions(profile: ModelProfileDefinition): readonly PresetScopeAction[] {
+		return isCustomUserProfile(profile) ? CUSTOM_PRESET_SCOPE_ACTIONS : BUILTIN_PRESET_SCOPE_ACTIONS;
 	}
 
-	#getPreviewPresetScopeLabels(): string[] {
+	#getPreviewPresetScopeActions(): readonly PresetScopeAction[] {
 		const profile = this.#getProfileByName(this.#previewProfileName);
-		return profile ? this.#getPresetScopeLabels(profile) : PRESET_SCOPE_LABELS;
+		return profile ? this.#getPresetScopeActions(profile) : BUILTIN_PRESET_SCOPE_ACTIONS;
+	}
+
+	#emitPresetScopeAction(profileName: string, actionId: PresetScopeActionId): void | Promise<void> {
+		switch (actionId) {
+			case "edit":
+				return this.#onSelectCallback({ kind: "editProfile", profileName });
+			case "rename":
+				return this.#onSelectCallback({ kind: "renameProfile", profileName });
+			case "delete":
+				return this.#onSelectCallback({ kind: "deleteProfile", profileName });
+			case "setDefault":
+				return this.#onSelectCallback({ kind: "profile", profileName, setDefault: true });
+			default:
+				return this.#onSelectCallback({ kind: "profile", profileName, setDefault: false });
+		}
 	}
 
 	refreshPresetProfiles(profileName?: string): void {
@@ -1793,11 +1804,12 @@ export class ModelSelectorComponent extends Container {
 	): Promise<void> {
 		await this.#onSelectCallback({ kind: "assignment", ...selection });
 	}
-	async __testSelectPresetAction(profileName: string, action: "rename" | "delete"): Promise<void> {
-		await this.#onSelectCallback({
-			kind: action === "rename" ? "renameProfile" : "deleteProfile",
-			profileName,
-		});
+	async __testSelectPresetAction(profileName: string, action: PresetScopeActionId): Promise<void> {
+		const profile = this.#getProfileByName(profileName);
+		const actions = profile ? this.#getPresetScopeActions(profile) : BUILTIN_PRESET_SCOPE_ACTIONS;
+		const matched = actions.find(candidate => candidate.id === action);
+		if (!matched) throw new Error(`Preset scope action not available: ${action}`);
+		await this.#emitPresetScopeAction(profileName, matched.id);
 	}
 	__testSelectedPresetRowIdentity(): string | undefined {
 		const row = this.#getSelectedPresetRow();

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -11,9 +11,14 @@ import {
 	materializeActiveModelProfileAssignments,
 	materializeModelProfileForDeletion,
 	restoreMaterializedModelProfileForDeletion,
+	validateModelProfileCandidate,
 } from "../../config/model-profile-activation";
 import { formatModelProfileDisplayLabel, recommendModelProfileForProvider } from "../../config/model-profiles";
-import { GJC_MODEL_ASSIGNMENT_TARGETS, type GjcModelAssignmentTargetId } from "../../config/model-registry";
+import {
+	type CustomModelProfileEditSnapshot,
+	GJC_MODEL_ASSIGNMENT_TARGETS,
+	type GjcModelAssignmentTargetId,
+} from "../../config/model-registry";
 import { formatModelSelectorValue } from "../../config/model-resolver";
 import type { ModelProfileConfig } from "../../config/models-config-schema";
 import { type Settings, settings } from "../../config/settings";
@@ -400,6 +405,117 @@ export class SelectorController {
 			}
 			this.ctx.showError(`Preset delete failed: ${err instanceof Error ? err.message : String(err)}`);
 		}
+	}
+
+	async #editCustomModelPreset(profileName: string, modelSelector: ModelSelectorComponent): Promise<void> {
+		const existing = this.ctx.session.modelRegistry.getModelProfile(profileName);
+		if (!existing) {
+			this.ctx.showError(`Custom model preset does not exist: ${profileName}`);
+			this.ctx.ui.requestRender();
+			return;
+		}
+		const editSnapshot: ModelProfileConfig = {
+			...(existing.displayName !== undefined ? { display_name: existing.displayName } : {}),
+			model_mapping: { ...existing.modelMapping },
+			required_providers: [...existing.requiredProviders],
+		};
+		this.showSelector(done => {
+			let wizard: CustomModelPresetWizardComponent;
+			const submit = async (input: CustomModelPresetWizardSubmit): Promise<void> => {
+				const validation = await validateModelProfileCandidate({
+					profileName,
+					profile: input.profile,
+					modelRegistry: this.ctx.session.modelRegistry,
+					settings: this.ctx.settings,
+					sessionId: this.ctx.session.sessionId,
+				});
+				if (!validation.ok) {
+					wizard.setSubmitError(validation.reason);
+					return;
+				}
+				const activeProfileName = this.ctx.session.getActiveModelProfile?.();
+				const persistedDefault = this.ctx.settings.get("modelProfile.default");
+				const isActive = activeProfileName === profileName;
+				const isPersistedDefault = persistedDefault === profileName;
+				let snapshot: CustomModelProfileEditSnapshot;
+				try {
+					const result = await this.ctx.session.modelRegistry.editCustomModelProfile(
+						profileName,
+						validation.profile,
+					);
+					snapshot = result.snapshot;
+				} catch (err) {
+					wizard.setSubmitError(`Preset edit failed: ${err instanceof Error ? err.message : String(err)}`);
+					return;
+				}
+				try {
+					if (isActive) {
+						await activateModelProfile(
+							{
+								session: this.ctx.session,
+								modelRegistry: this.ctx.session.modelRegistry,
+								settings: this.ctx.settings,
+								profileName,
+							},
+							{ persistDefault: isPersistedDefault },
+						);
+					}
+					await this.ctx.session.modelRegistry.refresh("offline");
+					await this.ctx.notifyConfigChanged?.();
+				} catch (postWriteErr) {
+					await this.#restoreEditedModelPreset(snapshot, modelSelector);
+					this.ctx.showError(
+						`Preset edit failed: ${postWriteErr instanceof Error ? postWriteErr.message : String(postWriteErr)}`,
+					);
+					this.ctx.ui.requestRender();
+					return;
+				}
+				this.#refreshEditedSelectorState(modelSelector, profileName);
+				this.ctx.showStatus(
+					`Custom model preset updated: ${formatModelProfileDisplayLabel(
+						this.ctx.session.modelRegistry.getModelProfile(profileName) ?? { name: profileName },
+					)}`,
+				);
+				done();
+				this.ctx.ui.requestRender();
+			};
+			wizard = new CustomModelPresetWizardComponent(
+				editSnapshot,
+				input => {
+					void submit(input);
+				},
+				() => {
+					done();
+					this.ctx.ui.requestRender();
+				},
+				() => this.ctx.ui.requestRender(),
+				{ mode: "edit", profileName, modelRegistry: this.ctx.session.modelRegistry },
+			);
+			return { component: wizard, focus: wizard };
+		});
+	}
+
+	#refreshEditedSelectorState(modelSelector: ModelSelectorComponent, profileName?: string): void {
+		modelSelector.refreshRoleAssignments({
+			currentModel: this.ctx.session.model,
+			currentThinkingLevel: this.ctx.session.thinkingLevel,
+			activeModelProfile:
+				this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
+		});
+		modelSelector.refreshPresetProfiles(profileName);
+	}
+
+	async #restoreEditedModelPreset(
+		snapshot: CustomModelProfileEditSnapshot,
+		modelSelector: ModelSelectorComponent,
+	): Promise<void> {
+		try {
+			await this.ctx.session.modelRegistry.restoreCustomModelProfileEdit(snapshot);
+			await this.ctx.session.modelRegistry.refresh("offline");
+		} catch {
+			// Best-effort config restore; the triggering error is surfaced by the caller.
+		}
+		this.#refreshEditedSelectorState(modelSelector, snapshot.profileName);
 	}
 
 	showCustomProviderWizard(): void {
@@ -876,6 +992,10 @@ export class SelectorController {
 						if (selection.kind === "createProfile") {
 							done();
 							this.showCustomModelPresetWizard(selection.profile);
+							return;
+						}
+						if (selection.kind === "editProfile") {
+							await this.#editCustomModelPreset(selection.profileName, modelSelector);
 							return;
 						}
 						if (selection.kind === "renameProfile") {

--- a/packages/coding-agent/test/custom-model-preset-creation.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-creation.test.ts
@@ -4,15 +4,19 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
+import * as modelProfileActivation from "@gajae-code/coding-agent/config/model-profile-activation";
 import {
 	materializeModelProfileForDeletion,
 	restoreMaterializedModelProfileForDeletion,
 } from "@gajae-code/coding-agent/config/model-profile-activation";
 import type { ModelProfileDefinition } from "@gajae-code/coding-agent/config/model-profiles";
-import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { type CustomModelProfileEditSnapshot, ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import type { ModelProfileConfig } from "@gajae-code/coding-agent/config/models-config-schema";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
-import { CustomModelPresetWizardComponent } from "@gajae-code/coding-agent/modes/components/custom-model-preset-wizard";
+import {
+	CustomModelPresetWizardComponent,
+	type CustomModelPresetWizardSubmit,
+} from "@gajae-code/coding-agent/modes/components/custom-model-preset-wizard";
 import {
 	ModelSelectorComponent,
 	type ModelSelectorSelection,
@@ -85,6 +89,138 @@ function createRegistry(profiles: Iterable<[string, ModelProfileDefinition]> = [
 		getModelProfile: (name: string) => profileMap.get(name),
 		getApiKeyForProvider: async (providerId: string) => options.apiKeyForProvider?.(providerId) ?? "key",
 	} as unknown as ModelRegistry;
+}
+
+const editableUserProfile: ModelProfileDefinition = {
+	name: "my-fast",
+	displayName: "My Fast",
+	requiredProviders: ["my-oai"],
+	modelMapping: { default: "my-oai/gpt-custom:low" },
+	source: "user",
+};
+
+function createEditControllerHarness(config: {
+	profileName: string;
+	profile: ModelProfileDefinition;
+	activeModelProfile?: string;
+	defaultModelProfile?: string;
+	notifyConfigChanged?: () => Promise<void>;
+}) {
+	const profiles = new Map<string, ModelProfileDefinition>([[config.profileName, config.profile]]);
+	const editCalls: Array<{ name: string; definition: ModelProfileConfig }> = [];
+	const restoreCalls: CustomModelProfileEditSnapshot[] = [];
+	const registry = {
+		...createRegistry(profiles),
+		getModelProfiles: () => new Map(profiles),
+		getModelProfile: (name: string) => profiles.get(name),
+		getAvailableModelProfileNames: () => [...profiles.keys()],
+		editCustomModelProfile: async (name: string, definition: ModelProfileConfig) => {
+			editCalls.push({ name, definition });
+			const previous = profiles.get(name);
+			const snapshot: CustomModelProfileEditSnapshot = {
+				profileName: name,
+				previousProfile: {
+					...(previous?.displayName !== undefined ? { display_name: previous.displayName } : {}),
+					required_providers: previous ? [...previous.requiredProviders] : [],
+					model_mapping: previous ? { ...previous.modelMapping } : {},
+				},
+				previousModelsConfigText: "PREVIOUS_MODELS_YAML",
+			};
+			profiles.set(name, {
+				name,
+				displayName: definition.display_name,
+				requiredProviders: [...definition.required_providers],
+				modelMapping: { ...definition.model_mapping },
+				source: "user",
+			});
+			return { profile: profiles.get(name) as ModelProfileDefinition, snapshot };
+		},
+		restoreCustomModelProfileEdit: async (snapshot: CustomModelProfileEditSnapshot) => {
+			restoreCalls.push(snapshot);
+			const prev = snapshot.previousProfile;
+			profiles.set(snapshot.profileName, {
+				name: snapshot.profileName,
+				displayName: prev.display_name,
+				requiredProviders: [...prev.required_providers],
+				modelMapping: { ...prev.model_mapping },
+				source: "user",
+			});
+		},
+		refresh: async () => {},
+	};
+	const settings = Settings.isolated(
+		config.defaultModelProfile ? { "modelProfile.default": config.defaultModelProfile } : {},
+	);
+	const activeProfiles: (string | undefined)[] = [config.activeModelProfile];
+	const statuses: string[] = [];
+	const errors: string[] = [];
+	let selector: ModelSelectorComponent | undefined;
+	let wizard: CustomModelPresetWizardComponent | undefined;
+	const ctx = {
+		ui: { setFocus: () => {}, requestRender: () => {} },
+		editorContainer: {
+			clear: () => {},
+			addChild: (child: unknown) => {
+				if (child instanceof ModelSelectorComponent) selector = child;
+				if (child instanceof CustomModelPresetWizardComponent) wizard = child;
+			},
+		},
+		editor: {},
+		settings,
+		session: {
+			model: currentModel("my-oai", "gpt-custom"),
+			thinkingLevel: ThinkingLevel.Low,
+			sessionId: "session",
+			scopedModels: [],
+			modelRegistry: registry,
+			getActiveModelProfile: () => activeProfiles.at(-1),
+			setActiveModelProfile: (name?: string) => activeProfiles.push(name),
+			isFastForProvider: () => false,
+			isFastForSubagentProvider: () => false,
+			isFastModeActive: () => false,
+		},
+		statusLine: { invalidate: () => {} },
+		updateEditorBorderColor: () => {},
+		showStatus: (message: string) => statuses.push(message),
+		showError: (message: string) => errors.push(message),
+		notifyConfigChanged: config.notifyConfigChanged ?? (async () => {}),
+	};
+	return {
+		ctx,
+		settings,
+		registry,
+		editCalls,
+		restoreCalls,
+		statuses,
+		errors,
+		getSelector: () => selector,
+		getWizard: () => wizard,
+	};
+}
+
+async function runCustomPresetEditSave(
+	harness: ReturnType<typeof createEditControllerHarness>,
+	profileName: string,
+): Promise<void> {
+	new SelectorController(harness.ctx as never).showModelSelector();
+	await Bun.sleep(0);
+	const selector = harness.getSelector();
+	if (!selector) throw new Error("selector not mounted");
+	await selector.__testSelectPresetAction(profileName, "edit");
+	await Bun.sleep(0);
+	const wizard = harness.getWizard();
+	if (!wizard) throw new Error("edit wizard not mounted");
+	wizard.handleInput("s");
+	await Bun.sleep(10);
+}
+
+function spyValidateCandidateOk() {
+	return spyOn(modelProfileActivation, "validateModelProfileCandidate").mockImplementation(async options => ({
+		ok: true,
+		profile: options.profile,
+		requiredProviders: options.profile.required_providers,
+		normalizedMapping: options.profile.model_mapping,
+	}));
 }
 
 describe("custom model preset creation", () => {
@@ -793,5 +929,224 @@ describe("custom model preset creation", () => {
 		expect(settings.get("modelRoles")).toEqual({ default: "old/default" });
 		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });
 		expect(activeProfiles.at(-1)).toBe("custom-default");
+	});
+
+	it("edit wizard prepopulates roles in preset preview order", () => {
+		const editSnapshot: ModelProfileConfig = {
+			display_name: "My Fast",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/gpt-custom:low" },
+		};
+		const wizard = new CustomModelPresetWizardComponent(
+			editSnapshot,
+			() => {},
+			() => {},
+			() => {},
+			{
+				mode: "edit",
+				profileName: "my-fast",
+				modelRegistry: createRegistry(),
+			},
+		);
+		const text = normalizeRenderedText(wizard.render(120).join("\n"));
+		let last = -1;
+		for (const label of ["DEFAULT:", "EXECUTOR:", "PLANNER:", "CRITIC:", "ARCHITECT:"]) {
+			const idx = text.indexOf(label);
+			expect(idx).toBeGreaterThan(last);
+			last = idx;
+		}
+	});
+
+	it("edit wizard Save emits onSubmit with unchanged name and derived providers", () => {
+		const editSnapshot: ModelProfileConfig = {
+			display_name: "My Fast",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/gpt-custom:low" },
+		};
+		const registry = createRegistry([], { models: [currentModel("anthropic", "claude")] });
+		let submitted: CustomModelPresetWizardSubmit | undefined;
+		const wizard = new CustomModelPresetWizardComponent(
+			editSnapshot,
+			input => {
+				submitted = input;
+			},
+			() => {},
+			() => {},
+			{ mode: "edit", profileName: "my-fast", modelRegistry: registry },
+		);
+		wizard.handleInput("\n"); // DEFAULT role -> model pick
+		wizard.handleInput("\n"); // choose anthropic/claude -> effort pick
+		wizard.handleInput("\n"); // choose no-explicit-effort
+		wizard.handleInput("s"); // save
+		expect(submitted).toBeDefined();
+		expect(submitted?.name).toBe("my-fast");
+		expect(submitted?.profile.display_name).toBe("My Fast");
+		expect(submitted?.profile.model_mapping).toEqual({ default: "anthropic/claude" });
+		expect(submitted?.profile.required_providers).toEqual(["anthropic"]);
+	});
+
+	it("create-mode wizard still renders the single-input snapshot form", () => {
+		const wizard = new CustomModelPresetWizardComponent(
+			snapshot,
+			() => {},
+			() => {},
+			() => {},
+		);
+		const text = normalizeRenderedText(wizard.render(120).join("\n"));
+		expect(text).toContain("Enter a unique preset id:");
+		expect(text).toContain("Snapshot:");
+		expect(text).not.toContain("Roles");
+	});
+
+	it("edit controller blocks the config write when candidate validation fails", async () => {
+		const validateSpy = spyOn(modelProfileActivation, "validateModelProfileCandidate").mockResolvedValue({
+			ok: false,
+			reason: "Selector cannot resolve",
+		});
+		try {
+			const harness = createEditControllerHarness({
+				profileName: "my-fast",
+				profile: editableUserProfile,
+				activeModelProfile: "my-fast",
+				defaultModelProfile: "my-fast",
+			});
+			await runCustomPresetEditSave(harness, "my-fast");
+			expect(harness.editCalls).toEqual([]);
+			expect(harness.statuses).toEqual([]);
+			const rendered = normalizeRenderedText(harness.getWizard()!.render(120).join("\n"));
+			expect(rendered).toContain("Selector cannot resolve");
+		} finally {
+			validateSpy.mockRestore();
+		}
+	});
+
+	it("edit controller re-applies once with persistDefault true when active and default", async () => {
+		const validateSpy = spyValidateCandidateOk();
+		const activateSpy = spyOn(modelProfileActivation, "activateModelProfile").mockResolvedValue(undefined);
+		try {
+			const harness = createEditControllerHarness({
+				profileName: "my-fast",
+				profile: editableUserProfile,
+				activeModelProfile: "my-fast",
+				defaultModelProfile: "my-fast",
+			});
+			await runCustomPresetEditSave(harness, "my-fast");
+			expect(harness.editCalls).toHaveLength(1);
+			expect(activateSpy).toHaveBeenCalledTimes(1);
+			expect(activateSpy.mock.calls[0]?.[1]).toEqual({ persistDefault: true });
+			expect(harness.errors).toEqual([]);
+			expect(harness.statuses.length).toBeGreaterThan(0);
+		} finally {
+			validateSpy.mockRestore();
+			activateSpy.mockRestore();
+		}
+	});
+
+	it("edit controller does not re-apply when default but not active", async () => {
+		const validateSpy = spyValidateCandidateOk();
+		const activateSpy = spyOn(modelProfileActivation, "activateModelProfile").mockResolvedValue(undefined);
+		try {
+			const harness = createEditControllerHarness({
+				profileName: "my-fast",
+				profile: editableUserProfile,
+				activeModelProfile: "other-active",
+				defaultModelProfile: "my-fast",
+			});
+			await runCustomPresetEditSave(harness, "my-fast");
+			expect(harness.editCalls).toHaveLength(1);
+			expect(activateSpy).not.toHaveBeenCalled();
+			expect(harness.settings.get("modelProfile.default")).toBe("my-fast");
+			expect(harness.statuses.length).toBeGreaterThan(0);
+		} finally {
+			validateSpy.mockRestore();
+			activateSpy.mockRestore();
+		}
+	});
+
+	it("edit controller re-applies once with persistDefault false when active only", async () => {
+		const validateSpy = spyValidateCandidateOk();
+		const activateSpy = spyOn(modelProfileActivation, "activateModelProfile").mockResolvedValue(undefined);
+		try {
+			const harness = createEditControllerHarness({
+				profileName: "my-fast",
+				profile: editableUserProfile,
+				activeModelProfile: "my-fast",
+				defaultModelProfile: "other-default",
+			});
+			await runCustomPresetEditSave(harness, "my-fast");
+			expect(activateSpy).toHaveBeenCalledTimes(1);
+			expect(activateSpy.mock.calls[0]?.[1]).toEqual({ persistDefault: false });
+			expect(harness.statuses.length).toBeGreaterThan(0);
+		} finally {
+			validateSpy.mockRestore();
+			activateSpy.mockRestore();
+		}
+	});
+
+	it("edit controller does not re-apply when inactive and not default", async () => {
+		const validateSpy = spyValidateCandidateOk();
+		const activateSpy = spyOn(modelProfileActivation, "activateModelProfile").mockResolvedValue(undefined);
+		try {
+			const harness = createEditControllerHarness({
+				profileName: "my-fast",
+				profile: editableUserProfile,
+				activeModelProfile: "other-active",
+				defaultModelProfile: "other-default",
+			});
+			await runCustomPresetEditSave(harness, "my-fast");
+			expect(harness.editCalls).toHaveLength(1);
+			expect(activateSpy).not.toHaveBeenCalled();
+			expect(harness.statuses.length).toBeGreaterThan(0);
+		} finally {
+			validateSpy.mockRestore();
+			activateSpy.mockRestore();
+		}
+	});
+
+	it("edit controller restores config and suppresses success when activation prepare fails", async () => {
+		const validateSpy = spyValidateCandidateOk();
+		const activateSpy = spyOn(modelProfileActivation, "activateModelProfile").mockRejectedValue(
+			new Error("prepare exploded"),
+		);
+		try {
+			const harness = createEditControllerHarness({
+				profileName: "my-fast",
+				profile: editableUserProfile,
+				activeModelProfile: "my-fast",
+				defaultModelProfile: "my-fast",
+			});
+			await runCustomPresetEditSave(harness, "my-fast");
+			expect(harness.editCalls).toHaveLength(1);
+			expect(harness.restoreCalls).toHaveLength(1);
+			expect(harness.restoreCalls[0]?.previousModelsConfigText).toBe("PREVIOUS_MODELS_YAML");
+			expect(harness.statuses).toEqual([]);
+			expect(harness.errors.some(message => message.includes("prepare exploded"))).toBe(true);
+		} finally {
+			validateSpy.mockRestore();
+			activateSpy.mockRestore();
+		}
+	});
+
+	it("edit controller restores config and suppresses success when activation apply fails", async () => {
+		const validateSpy = spyValidateCandidateOk();
+		const activateSpy = spyOn(modelProfileActivation, "activateModelProfile").mockRejectedValue(
+			new Error("apply exploded"),
+		);
+		try {
+			const harness = createEditControllerHarness({
+				profileName: "my-fast",
+				profile: editableUserProfile,
+				activeModelProfile: "my-fast",
+				defaultModelProfile: "my-fast",
+			});
+			await runCustomPresetEditSave(harness, "my-fast");
+			expect(harness.editCalls).toHaveLength(1);
+			expect(harness.restoreCalls).toHaveLength(1);
+			expect(harness.statuses).toEqual([]);
+			expect(harness.errors.some(message => message.includes("apply exploded"))).toBe(true);
+		} finally {
+			validateSpy.mockRestore();
+			activateSpy.mockRestore();
+		}
 	});
 });

--- a/packages/coding-agent/test/custom-model-preset-edit-redteam.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-edit-redteam.test.ts
@@ -1,0 +1,595 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import * as modelProfileActivation from "@gajae-code/coding-agent/config/model-profile-activation";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import type { ModelProfileConfig } from "@gajae-code/coding-agent/config/models-config-schema";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import {
+	CustomModelPresetWizardComponent,
+	type CustomModelPresetWizardSubmit,
+} from "@gajae-code/coding-agent/modes/components/custom-model-preset-wizard";
+import { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
+import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+
+// Adversarial (red-team) coverage for the "edit existing custom model preset" feature.
+// Goal: try to BREAK the safety/transaction guarantees, not re-confirm the happy path.
+// Implementation is FROZEN; this file only adds tests. It intentionally exercises the
+// REAL ModelRegistry (real models.yml writes/restores) at the controller layer, which
+// the committed controller tests do not (they use an in-memory mock registry).
+
+let tempDir: string;
+let authStorage: AuthStorage;
+
+const currentModel = (provider: string, id: string): Model =>
+	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
+
+const effortModel = (provider: string, id: string, thinking?: Model["thinking"]): Model =>
+	({
+		provider,
+		id,
+		name: id,
+		api: "openai-responses",
+		contextWindow: 1000,
+		maxTokens: 1000,
+		thinking,
+		reasoning: thinking !== undefined,
+	}) as Model;
+
+const createSnapshot: ModelProfileConfig = {
+	required_providers: ["my-oai"],
+	model_mapping: { default: "my-oai/gpt-custom:low" },
+};
+
+beforeEach(async () => {
+	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-preset-redteam-"));
+	authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+	setThemeInstance((await getThemeByName("red-claw"))!);
+});
+
+afterEach(async () => {
+	authStorage.close();
+	await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+function normalizeRenderedText(text: string): string {
+	return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function typeText(component: { handleInput(input: string): void }, value: string): void {
+	for (const char of value) component.handleInput(char);
+	component.handleInput("\n");
+}
+
+type CandidateRegistry = Pick<
+	ModelRegistry,
+	"getAll" | "getApiKeyForProvider" | "resolveCanonicalModel" | "getCanonicalVariants" | "getCanonicalId"
+>;
+
+// Registry surface for the pure validator (mirrors the committed validation suite),
+// including an effort-capped model (max level xhigh) so clamp behaviour is exercised.
+function candidateRegistry(options?: { missingProviders?: string[] }): CandidateRegistry {
+	const missing = new Set(options?.missingProviders ?? []);
+	return {
+		getAll: () => [
+			effortModel("my-oai", "gpt-custom"),
+			effortModel("anthropic", "claude"),
+			effortModel("openai-codex", "gpt-5.5", {
+				mode: "effort",
+				minLevel: ThinkingLevel.Low,
+				maxLevel: ThinkingLevel.XHigh,
+			}),
+		],
+		getApiKeyForProvider: async (provider: string) => (missing.has(provider) ? undefined : `key-${provider}`),
+		resolveCanonicalModel: () => undefined,
+		getCanonicalVariants: () => [],
+		getCanonicalId: () => undefined,
+	} as unknown as CandidateRegistry;
+}
+
+interface RealEditHarness {
+	ctx: unknown;
+	registry: ModelRegistry;
+	modelsPath: string;
+	before: string;
+	statuses: string[];
+	errors: string[];
+	getSelector: () => ModelSelectorComponent | undefined;
+	getWizard: () => CustomModelPresetWizardComponent | undefined;
+}
+
+// Controller harness backed by a REAL ModelRegistry writing a REAL models.yml.
+async function createRealEditHarness(config: {
+	activeModelProfile?: string;
+	defaultModelProfile?: string;
+}): Promise<RealEditHarness> {
+	const modelsPath = path.join(tempDir, "models.yml");
+	const registry = new ModelRegistry(authStorage, modelsPath);
+	await registry.saveCustomModelProfile("my-fast", {
+		display_name: "My Fast",
+		required_providers: ["my-oai"],
+		model_mapping: { default: "my-oai/gpt-custom:low" },
+	});
+	const before = await Bun.file(modelsPath).text();
+	const settings = Settings.isolated(
+		config.defaultModelProfile ? { "modelProfile.default": config.defaultModelProfile } : {},
+	);
+	const activeProfiles: (string | undefined)[] = [config.activeModelProfile];
+	const statuses: string[] = [];
+	const errors: string[] = [];
+	let selector: ModelSelectorComponent | undefined;
+	let wizard: CustomModelPresetWizardComponent | undefined;
+	const ctx = {
+		ui: { setFocus: () => {}, requestRender: () => {} },
+		editorContainer: {
+			clear: () => {},
+			addChild: (child: unknown) => {
+				if (child instanceof ModelSelectorComponent) selector = child;
+				if (child instanceof CustomModelPresetWizardComponent) wizard = child;
+			},
+		},
+		editor: {},
+		settings,
+		session: {
+			model: currentModel("my-oai", "gpt-custom"),
+			thinkingLevel: ThinkingLevel.Low,
+			sessionId: "session",
+			scopedModels: [],
+			modelRegistry: registry,
+			getActiveModelProfile: () => activeProfiles.at(-1),
+			setActiveModelProfile: (name?: string) => activeProfiles.push(name),
+			isFastForProvider: () => false,
+			isFastForSubagentProvider: () => false,
+			isFastModeActive: () => false,
+		},
+		statusLine: { invalidate: () => {} },
+		updateEditorBorderColor: () => {},
+		showStatus: (message: string) => statuses.push(message),
+		showError: (message: string) => errors.push(message),
+		notifyConfigChanged: async () => {},
+	};
+	return {
+		ctx,
+		registry,
+		modelsPath,
+		before,
+		statuses,
+		errors,
+		getSelector: () => selector,
+		getWizard: () => wizard,
+	};
+}
+
+async function runEditSave(harness: RealEditHarness, profileName: string): Promise<void> {
+	new SelectorController(harness.ctx as never).showModelSelector();
+	await Bun.sleep(0);
+	const selector = harness.getSelector();
+	if (!selector) throw new Error("selector not mounted");
+	await selector.__testSelectPresetAction(profileName, "edit");
+	await Bun.sleep(0);
+	const wizard = harness.getWizard();
+	if (!wizard) throw new Error("edit wizard not mounted");
+	wizard.handleInput("s");
+	await Bun.sleep(20);
+}
+
+// ok:true validator that echoes the wizard's submitted profile (no mutation).
+function spyValidateEcho() {
+	return spyOn(modelProfileActivation, "validateModelProfileCandidate").mockImplementation(async options => ({
+		ok: true,
+		profile: options.profile,
+		requiredProviders: options.profile.required_providers,
+		normalizedMapping: options.profile.model_mapping,
+	}));
+}
+
+// ok:true validator that injects a CHANGED normalized profile, forcing a real models.yml
+// mutation through the controller (simulates the user editing the default selector).
+function spyValidateMutated(mutated: ModelProfileConfig) {
+	return spyOn(modelProfileActivation, "validateModelProfileCandidate").mockImplementation(async () => ({
+		ok: true,
+		profile: mutated,
+		requiredProviders: mutated.required_providers,
+		normalizedMapping: mutated.model_mapping,
+	}));
+}
+
+describe("custom model preset edit — red team", () => {
+	// (a) primitive: real edit mutates models.yml; restore reverts byte-exact + refreshes profile.
+	it("(a) editCustomModelProfile mutates models.yml then restore reverts byte-exact and refreshes getModelProfiles", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("my-fast", {
+			display_name: "My Fast",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/gpt-custom:low" },
+		});
+		const before = await Bun.file(modelsPath).text();
+
+		const { snapshot } = await registry.editCustomModelProfile("my-fast", {
+			required_providers: ["anthropic"],
+			model_mapping: { default: "anthropic/claude:high", executor: "my-oai/gpt-custom" },
+		});
+		const afterEdit = await Bun.file(modelsPath).text();
+		expect(afterEdit).not.toBe(before);
+		expect(afterEdit).toContain("anthropic/claude:high");
+		expect(snapshot.previousModelsConfigText).toBe(before);
+		expect(registry.getModelProfiles().get("my-fast")?.modelMapping.default).toBe("anthropic/claude:high");
+
+		await registry.restoreCustomModelProfileEdit(snapshot);
+		const afterRestore = await Bun.file(modelsPath).text();
+		expect(afterRestore).toBe(before); // byte-exact restore
+		expect(afterRestore).not.toContain("anthropic/claude:high"); // zero residual mutation
+
+		const restored = registry.getModelProfiles().get("my-fast");
+		expect(restored?.displayName).toBe("My Fast");
+		expect(restored?.modelMapping.default).toBe("my-oai/gpt-custom:low");
+		expect(restored?.modelMapping.executor).toBeUndefined();
+		expect(restored?.requiredProviders).toEqual(["my-oai"]);
+	});
+
+	// (a) transaction robustness: a normal edit re-serializes YAML (dropping comments and
+	// reordering keys), but a failed activation must restore the ORIGINAL bytes exactly,
+	// including a hand-authored comment and the untouched providers block.
+	it("(a) restore rewrites the exact prior bytes including comments a normal edit would drop", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const original = [
+			"# hand-authored config",
+			"providers:",
+			"  my-oai:",
+			"    baseUrl: https://proxy.example.com/v1",
+			"    apiKeyEnv: MY_OAI_KEY",
+			"profiles:",
+			"  my-fast:",
+			"    display_name: My Fast",
+			"    required_providers: [my-oai]",
+			"    model_mapping:",
+			"      default: my-oai/gpt-custom:low",
+			"",
+		].join("\n");
+		await Bun.write(modelsPath, original);
+		const registry = new ModelRegistry(authStorage, modelsPath);
+
+		const { snapshot } = await registry.editCustomModelProfile("my-fast", {
+			required_providers: ["anthropic"],
+			model_mapping: { default: "anthropic/claude:high" },
+		});
+		const afterEdit = await Bun.file(modelsPath).text();
+		expect(afterEdit).not.toBe(original);
+		expect(afterEdit).not.toContain("# hand-authored config"); // edit re-serialization drops the comment
+		expect(snapshot.previousModelsConfigText).toBe(original); // exact prior bytes captured
+
+		await registry.restoreCustomModelProfileEdit(snapshot);
+		const afterRestore = await Bun.file(modelsPath).text();
+		expect(afterRestore).toBe(original); // byte-exact incl comment + providers block
+		expect(afterRestore).toContain("# hand-authored config"); // comment fully restored
+		expect(registry.getModelProfiles().get("my-fast")?.modelMapping.default).toBe("my-oai/gpt-custom:low");
+	});
+
+	// (a) controller wiring: activation PREPARE failure -> byte-exact restore of the real file.
+	it("(a) controller restores byte-exact models.yml when activation PREPARE fails (real registry)", async () => {
+		const harness = await createRealEditHarness({ activeModelProfile: "my-fast", defaultModelProfile: "my-fast" });
+		const mutated: ModelProfileConfig = {
+			display_name: "My Fast",
+			required_providers: ["anthropic"],
+			model_mapping: { default: "anthropic/claude:high" },
+		};
+		const validateSpy = spyValidateMutated(mutated);
+		const activateSpy = spyOn(modelProfileActivation, "activateModelProfile").mockRejectedValue(
+			new Error("prepare exploded"),
+		);
+		try {
+			await runEditSave(harness, "my-fast");
+			const afterRestore = await Bun.file(harness.modelsPath).text();
+			expect(afterRestore).toBe(harness.before); // byte-exact
+			expect(afterRestore).not.toContain("anthropic/claude:high"); // mutation reverted
+			const restored = harness.registry.getModelProfiles().get("my-fast");
+			expect(restored?.displayName).toBe("My Fast");
+			expect(restored?.modelMapping.default).toBe("my-oai/gpt-custom:low");
+			expect(restored?.requiredProviders).toEqual(["my-oai"]);
+			expect(activateSpy).toHaveBeenCalledTimes(1);
+			expect(harness.statuses).toEqual([]); // success suppressed
+			expect(harness.errors.some(message => message.includes("prepare exploded"))).toBe(true);
+		} finally {
+			validateSpy.mockRestore();
+			activateSpy.mockRestore();
+		}
+	});
+
+	// (a) controller wiring: activation APPLY failure -> byte-exact restore of the real file.
+	it("(a) controller restores byte-exact models.yml when activation APPLY fails (real registry)", async () => {
+		const harness = await createRealEditHarness({ activeModelProfile: "my-fast", defaultModelProfile: "my-fast" });
+		const mutated: ModelProfileConfig = {
+			display_name: "My Fast",
+			required_providers: ["anthropic"],
+			model_mapping: { default: "anthropic/claude:high" },
+		};
+		const validateSpy = spyValidateMutated(mutated);
+		const activateSpy = spyOn(modelProfileActivation, "activateModelProfile").mockRejectedValue(
+			new Error("apply exploded"),
+		);
+		try {
+			await runEditSave(harness, "my-fast");
+			const afterRestore = await Bun.file(harness.modelsPath).text();
+			expect(afterRestore).toBe(harness.before); // byte-exact
+			expect(afterRestore).not.toContain("anthropic/claude:high");
+			expect(harness.registry.getModelProfiles().get("my-fast")?.modelMapping.default).toBe("my-oai/gpt-custom:low");
+			expect(activateSpy).toHaveBeenCalledTimes(1);
+			expect(harness.statuses).toEqual([]);
+			expect(harness.errors.some(message => message.includes("apply exploded"))).toBe(true);
+		} finally {
+			validateSpy.mockRestore();
+			activateSpy.mockRestore();
+		}
+	});
+
+	// (b) unit: the real validator rejects each invalid candidate.
+	it("(b) validator rejects an unresolvable selector (ok:false)", async () => {
+		const result = await modelProfileActivation.validateModelProfileCandidate({
+			profileName: "bad",
+			profile: { required_providers: ["ghost"], model_mapping: { default: "ghost/does-not-exist:high" } },
+			modelRegistry: candidateRegistry(),
+			settings: Settings.isolated(),
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toContain("did not resolve");
+	});
+
+	it("(b) validator rejects a missing-credential provider (ok:false)", async () => {
+		const result = await modelProfileActivation.validateModelProfileCandidate({
+			profileName: "needs-key",
+			profile: { required_providers: ["my-oai"], model_mapping: { default: "my-oai/gpt-custom:low" } },
+			modelRegistry: candidateRegistry({ missingProviders: ["my-oai"] }),
+			settings: Settings.isolated(),
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toContain("my-oai");
+	});
+
+	it("(b) validator rejects zero mapped roles (ok:false)", async () => {
+		const result = await modelProfileActivation.validateModelProfileCandidate({
+			profileName: "empty",
+			profile: { required_providers: ["my-oai"], model_mapping: {} },
+			modelRegistry: candidateRegistry(),
+			settings: Settings.isolated(),
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toContain("at least one role");
+	});
+
+	it("(b) validator rejects an unknown effort suffix :ultra (ok:false)", async () => {
+		const result = await modelProfileActivation.validateModelProfileCandidate({
+			profileName: "ultra",
+			profile: { required_providers: ["openai-codex"], model_mapping: { default: "openai-codex/gpt-5.5:ultra" } },
+			modelRegistry: candidateRegistry(),
+			settings: Settings.isolated(),
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason.toLowerCase()).toContain("invalid");
+	});
+
+	// (b) controller: validate-before-write. When validation fails, editCustomModelProfile is
+	// NEVER invoked and models.yml is left byte-identical. Reason-agnostic guard, so probe all 4.
+	const guardCases = [
+		{
+			id: "unresolvable-selector",
+			reason: "Model profile default selector did not resolve: ghost/x:high",
+			contains: "did not resolve",
+		},
+		{
+			id: "missing-credential",
+			reason:
+				'Model profile "my-fast" requires credentials for: my-oai. Run /login and configure the missing provider(s), then retry.',
+			contains: "requires credentials",
+		},
+		{ id: "zero-roles", reason: "Model profile must map at least one role.", contains: "at least one role" },
+		{
+			id: "unknown-effort",
+			reason: "Invalid model profile at /model_mapping/default: unknown effort",
+			contains: "Invalid model profile",
+		},
+	] as const;
+
+	for (const guard of guardCases) {
+		it(`(b) controller never writes models.yml or calls editCustomModelProfile when validation fails: ${guard.id}`, async () => {
+			const harness = await createRealEditHarness({
+				activeModelProfile: "my-fast",
+				defaultModelProfile: "my-fast",
+			});
+			const editSpy = spyOn(harness.registry, "editCustomModelProfile");
+			const validateSpy = spyOn(modelProfileActivation, "validateModelProfileCandidate").mockResolvedValue({
+				ok: false,
+				reason: guard.reason,
+			});
+			try {
+				await runEditSave(harness, "my-fast");
+				expect(editSpy).not.toHaveBeenCalled(); // no config write attempted
+				expect(await Bun.file(harness.modelsPath).text()).toBe(harness.before); // file untouched
+				expect(harness.statuses).toEqual([]); // no success surfaced
+				const rendered = normalizeRenderedText(harness.getWizard()!.render(120).join("\n"));
+				expect(rendered).toContain(guard.contains);
+			} finally {
+				validateSpy.mockRestore();
+				editSpy.mockRestore();
+			}
+		});
+	}
+
+	// (c) 4-case activation matrix — exact activateModelProfile call counts + persistDefault flag.
+	it("(c) active+default -> activate called exactly once with persistDefault:true (no double-mutate)", async () => {
+		const harness = await createRealEditHarness({ activeModelProfile: "my-fast", defaultModelProfile: "my-fast" });
+		const validateSpy = spyValidateEcho();
+		const activateSpy = spyOn(modelProfileActivation, "activateModelProfile").mockResolvedValue(undefined);
+		try {
+			await runEditSave(harness, "my-fast");
+			expect(activateSpy).toHaveBeenCalledTimes(1);
+			expect(activateSpy.mock.calls[0]?.[1]).toEqual({ persistDefault: true });
+			expect(harness.errors).toEqual([]);
+			expect(harness.statuses.length).toBeGreaterThan(0);
+		} finally {
+			validateSpy.mockRestore();
+			activateSpy.mockRestore();
+		}
+	});
+
+	it("(c) active-only -> activate called exactly once with persistDefault:false", async () => {
+		const harness = await createRealEditHarness({
+			activeModelProfile: "my-fast",
+			defaultModelProfile: "other-default",
+		});
+		const validateSpy = spyValidateEcho();
+		const activateSpy = spyOn(modelProfileActivation, "activateModelProfile").mockResolvedValue(undefined);
+		try {
+			await runEditSave(harness, "my-fast");
+			expect(activateSpy).toHaveBeenCalledTimes(1);
+			expect(activateSpy.mock.calls[0]?.[1]).toEqual({ persistDefault: false });
+			expect(harness.statuses.length).toBeGreaterThan(0);
+		} finally {
+			validateSpy.mockRestore();
+			activateSpy.mockRestore();
+		}
+	});
+
+	it("(c) default-but-not-active -> activate NEVER called", async () => {
+		const harness = await createRealEditHarness({
+			activeModelProfile: "other-active",
+			defaultModelProfile: "my-fast",
+		});
+		const validateSpy = spyValidateEcho();
+		const activateSpy = spyOn(modelProfileActivation, "activateModelProfile").mockResolvedValue(undefined);
+		try {
+			await runEditSave(harness, "my-fast");
+			expect(activateSpy).not.toHaveBeenCalled();
+			expect(harness.statuses.length).toBeGreaterThan(0);
+		} finally {
+			validateSpy.mockRestore();
+			activateSpy.mockRestore();
+		}
+	});
+
+	it("(c) inactive+not-default -> activate NEVER called", async () => {
+		const harness = await createRealEditHarness({
+			activeModelProfile: "other-active",
+			defaultModelProfile: "other-default",
+		});
+		const validateSpy = spyValidateEcho();
+		const activateSpy = spyOn(modelProfileActivation, "activateModelProfile").mockResolvedValue(undefined);
+		try {
+			await runEditSave(harness, "my-fast");
+			expect(activateSpy).not.toHaveBeenCalled();
+			expect(harness.statuses.length).toBeGreaterThan(0);
+		} finally {
+			validateSpy.mockRestore();
+			activateSpy.mockRestore();
+		}
+	});
+
+	// (d) clamp-not-reject: above-max effort accepted+normalized; unknown suffix rejected.
+	it("(d) above-max effort :max is accepted and normalizedMapping holds the clamped :xhigh selector", async () => {
+		const result = await modelProfileActivation.validateModelProfileCandidate({
+			profileName: "clamp",
+			profile: { required_providers: ["openai-codex"], model_mapping: { default: "openai-codex/gpt-5.5:max" } },
+			modelRegistry: candidateRegistry(),
+			settings: Settings.isolated(),
+		});
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.normalizedMapping.default).toBe("openai-codex/gpt-5.5:xhigh");
+			expect(result.normalizedMapping.default).not.toBe("openai-codex/gpt-5.5:max");
+		}
+	});
+
+	it("(d) :ultra is rejected even when paired with an otherwise-valid role (no partial clamp)", async () => {
+		const result = await modelProfileActivation.validateModelProfileCandidate({
+			profileName: "mixed",
+			profile: {
+				required_providers: ["openai-codex", "anthropic"],
+				model_mapping: { default: "openai-codex/gpt-5.5:max", executor: "openai-codex/gpt-5.5:ultra" },
+			},
+			modelRegistry: candidateRegistry(),
+			settings: Settings.isolated(),
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason.toLowerCase()).toContain("invalid");
+	});
+
+	it("(d) a clamped role and an exact-effort role are both accepted and normalized per role", async () => {
+		const result = await modelProfileActivation.validateModelProfileCandidate({
+			profileName: "per-role",
+			profile: {
+				required_providers: ["openai-codex", "anthropic"],
+				model_mapping: { default: "openai-codex/gpt-5.5:max", executor: "openai-codex/gpt-5.5:high" },
+			},
+			modelRegistry: candidateRegistry(),
+			settings: Settings.isolated(),
+		});
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.normalizedMapping.default).toBe("openai-codex/gpt-5.5:xhigh"); // clamped
+			expect(result.normalizedMapping.executor).toBe("openai-codex/gpt-5.5:high"); // untouched
+		}
+	});
+
+	// (e) edit preserves key + display_name even when a different display_name/key is supplied.
+	it("(e) edit preserves the profile key and original display_name, ignoring a supplied display_name", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("keep-me", {
+			display_name: "Original Name",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/gpt-custom:low" },
+		});
+
+		const { profile } = await registry.editCustomModelProfile("keep-me", {
+			display_name: "Attempted New Name",
+			required_providers: ["anthropic"],
+			model_mapping: { default: "anthropic/claude:high" },
+		});
+
+		expect(profile.name).toBe("keep-me");
+		expect(profile.displayName).toBe("Original Name"); // supplied display_name ignored
+		expect(profile.modelMapping.default).toBe("anthropic/claude:high"); // mapping still updated
+
+		const profiles = registry.getModelProfiles();
+		expect(profiles.get("keep-me")?.displayName).toBe("Original Name");
+		expect(profiles.get("keep-me")?.modelMapping.default).toBe("anthropic/claude:high");
+		expect(profiles.get("Attempted New Name")).toBeUndefined(); // no rogue key created
+		expect(registry.getModelProfile("Attempted New Name")).toBeUndefined();
+	});
+
+	// (f) create-mode wizard is unchanged: single id input, no roles/secrets, one create submit.
+	it("(f) create-mode wizard still emits the single-input create submit unchanged", () => {
+		const submitted: CustomModelPresetWizardSubmit[] = [];
+		const wizard = new CustomModelPresetWizardComponent(
+			createSnapshot,
+			input => submitted.push(input),
+			() => {},
+			() => {},
+		);
+
+		typeText(wizard, "Bad Name");
+		const rejected = normalizeRenderedText(wizard.render(120).join("\n"));
+		expect(rejected).toContain("Preset id must use lowercase letters, numbers, dots, underscores, or hyphens.");
+		expect(rejected).not.toContain("Roles");
+		expect(rejected).not.toContain("API key");
+		expect(rejected).not.toContain("secret");
+		expect(submitted).toEqual([]);
+
+		typeText(wizard, "my-fast");
+		expect(submitted).toEqual([
+			{
+				name: "my-fast",
+				profile: {
+					display_name: "my-fast",
+					required_providers: ["my-oai"],
+					model_mapping: { default: "my-oai/gpt-custom:low" },
+				},
+			},
+		]);
+	});
+});

--- a/packages/coding-agent/test/custom-model-preset-edit.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-edit.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { YAML } from "bun";
+
+let tempDir: string;
+let authStorage: AuthStorage;
+
+beforeEach(async () => {
+	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-preset-edit-"));
+	authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+});
+
+afterEach(async () => {
+	authStorage.close();
+	await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+describe("editCustomModelProfile", () => {
+	it("edits a custom model profile in place preserving identity and display name", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("my-fast", {
+			display_name: "My Fast",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/gpt-custom:low" },
+		});
+
+		const { profile, snapshot } = await registry.editCustomModelProfile("my-fast", {
+			display_name: "should-be-ignored",
+			required_providers: ["stale-provider"],
+			model_mapping: { default: "anthropic/claude:high", executor: "my-oai/gpt-custom" },
+		});
+
+		expect(profile.name).toBe("my-fast");
+		expect(profile.displayName).toBe("My Fast");
+		expect(profile.modelMapping.default).toBe("anthropic/claude:high");
+		expect(profile.modelMapping.executor).toBe("my-oai/gpt-custom");
+		expect(profile.requiredProviders).toEqual(["anthropic", "my-oai"]);
+
+		const fresh = registry.getModelProfile("my-fast");
+		expect(fresh?.displayName).toBe("My Fast");
+		expect(fresh?.modelMapping.default).toBe("anthropic/claude:high");
+		expect(fresh?.modelMapping.executor).toBe("my-oai/gpt-custom");
+		expect(fresh?.requiredProviders).toEqual(["anthropic", "my-oai"]);
+		expect(registry.getModelProfile("should-be-ignored")).toBeUndefined();
+
+		expect(snapshot.profileName).toBe("my-fast");
+		expect(snapshot.previousProfile.model_mapping.default).toBe("my-oai/gpt-custom:low");
+		expect(snapshot.previousProfile.display_name).toBe("My Fast");
+		expect(snapshot.previousModelsConfigText.length).toBeGreaterThan(0);
+
+		const parsed = YAML.parse(await Bun.file(modelsPath).text()) as {
+			profiles: Record<
+				string,
+				{ display_name?: string; required_providers: string[]; model_mapping: Record<string, string> }
+			>;
+		};
+		expect(parsed.profiles["my-fast"].display_name).toBe("My Fast");
+		expect(parsed.profiles["my-fast"].model_mapping.default).toBe("anthropic/claude:high");
+		expect(parsed.profiles["my-fast"].required_providers).toEqual(["anthropic", "my-oai"]);
+	});
+
+	it("getModelProfiles is fresh immediately after custom profile edit", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("p", {
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/gpt-custom:low" },
+		});
+		await registry.editCustomModelProfile("p", {
+			required_providers: ["anthropic"],
+			model_mapping: { default: "anthropic/claude:high" },
+		});
+		const profiles = registry.getModelProfiles();
+		expect(profiles.get("p")?.modelMapping.default).toBe("anthropic/claude:high");
+		expect(profiles.get("p")?.requiredProviders).toEqual(["anthropic"]);
+	});
+
+	it("rejects editing a profile that does not exist", async () => {
+		const registry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+		await expect(
+			registry.editCustomModelProfile("ghost", {
+				required_providers: ["my-oai"],
+				model_mapping: { default: "my-oai/gpt-custom" },
+			}),
+		).rejects.toThrow("Custom model profile does not exist: ghost.");
+	});
+});
+
+describe("restoreCustomModelProfileEdit", () => {
+	it("restores custom profile edit snapshot to exact previous models config bytes", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("my-fast", {
+			display_name: "My Fast",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/gpt-custom:low" },
+		});
+		const before = await Bun.file(modelsPath).text();
+
+		const { snapshot } = await registry.editCustomModelProfile("my-fast", {
+			required_providers: ["anthropic"],
+			model_mapping: { default: "anthropic/claude:high" },
+		});
+		const afterEdit = await Bun.file(modelsPath).text();
+		expect(afterEdit).not.toBe(before);
+		expect(snapshot.previousModelsConfigText).toBe(before);
+
+		await registry.restoreCustomModelProfileEdit(snapshot);
+		const afterRestore = await Bun.file(modelsPath).text();
+		expect(afterRestore).toBe(before);
+
+		const restored = registry.getModelProfile("my-fast");
+		expect(restored?.displayName).toBe("My Fast");
+		expect(restored?.modelMapping.default).toBe("my-oai/gpt-custom:low");
+		expect(restored?.requiredProviders).toEqual(["my-oai"]);
+	});
+});

--- a/packages/coding-agent/test/model-profile-candidate-validation.test.ts
+++ b/packages/coding-agent/test/model-profile-candidate-validation.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "bun:test";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import { validateModelProfileCandidate } from "@gajae-code/coding-agent/config/model-profile-activation";
+import type { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+
+const model = (provider: string, id: string, thinking?: Model["thinking"]): Model =>
+	({
+		provider,
+		id,
+		name: id,
+		api: "openai-responses",
+		contextWindow: 1000,
+		maxTokens: 1000,
+		thinking,
+		reasoning: thinking !== undefined,
+	}) as Model;
+
+type CandidateRegistry = Pick<
+	ModelRegistry,
+	"getAll" | "getApiKeyForProvider" | "resolveCanonicalModel" | "getCanonicalVariants" | "getCanonicalId"
+>;
+
+function candidateRegistry(options?: { missingProviders?: string[] }): CandidateRegistry {
+	const missing = new Set(options?.missingProviders ?? []);
+	return {
+		getAll: () => [
+			model("my-oai", "gpt-custom"),
+			model("anthropic", "claude"),
+			model("openai-codex", "gpt-5.5", {
+				mode: "effort",
+				minLevel: ThinkingLevel.Low,
+				maxLevel: ThinkingLevel.XHigh,
+			}),
+		],
+		getApiKeyForProvider: async (provider: string) => (missing.has(provider) ? undefined : `key-${provider}`),
+		resolveCanonicalModel: () => undefined,
+		getCanonicalVariants: () => [],
+		getCanonicalId: () => undefined,
+	} as unknown as CandidateRegistry;
+}
+
+describe("validateModelProfileCandidate", () => {
+	it("rejects a candidate with zero mapped roles", async () => {
+		const result = await validateModelProfileCandidate({
+			profileName: "empty",
+			profile: { required_providers: ["my-oai"], model_mapping: {} },
+			modelRegistry: candidateRegistry(),
+			settings: Settings.isolated(),
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toContain("at least one role");
+	});
+
+	it("rejects an unresolvable selector before any credential check", async () => {
+		const result = await validateModelProfileCandidate({
+			profileName: "bad",
+			profile: { required_providers: ["ghost"], model_mapping: { default: "ghost/does-not-exist:high" } },
+			modelRegistry: candidateRegistry(),
+			settings: Settings.isolated(),
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toContain("did not resolve");
+	});
+
+	it("rejects a provider without credentials", async () => {
+		const result = await validateModelProfileCandidate({
+			profileName: "needs-key",
+			profile: { required_providers: ["my-oai"], model_mapping: { default: "my-oai/gpt-custom:low" } },
+			modelRegistry: candidateRegistry({ missingProviders: ["my-oai"] }),
+			settings: Settings.isolated(),
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toContain("my-oai");
+	});
+
+	it("accepts a supported effort unchanged and returns derived sorted providers", async () => {
+		const result = await validateModelProfileCandidate({
+			profileName: "ok",
+			profile: {
+				required_providers: ["stale"],
+				model_mapping: { default: "openai-codex/gpt-5.5:high", executor: "anthropic/claude" },
+			},
+			modelRegistry: candidateRegistry(),
+			settings: Settings.isolated(),
+		});
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.normalizedMapping.default).toBe("openai-codex/gpt-5.5:high");
+			expect(result.normalizedMapping.executor).toBe("anthropic/claude");
+			expect(result.requiredProviders).toEqual(["anthropic", "openai-codex"]);
+			expect(result.profile.required_providers).toEqual(["anthropic", "openai-codex"]);
+		}
+	});
+
+	it("accepts and normalizes an above-max effort by clamping instead of rejecting", async () => {
+		const result = await validateModelProfileCandidate({
+			profileName: "clamp",
+			profile: { required_providers: ["openai-codex"], model_mapping: { default: "openai-codex/gpt-5.5:max" } },
+			modelRegistry: candidateRegistry(),
+			settings: Settings.isolated(),
+		});
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.normalizedMapping.default).toBe("openai-codex/gpt-5.5:xhigh");
+			expect(result.normalizedMapping.default).not.toBe("openai-codex/gpt-5.5:max");
+		}
+	});
+
+	it("rejects an unknown effort suffix at the schema layer", async () => {
+		const result = await validateModelProfileCandidate({
+			profileName: "ultra",
+			profile: { required_providers: ["openai-codex"], model_mapping: { default: "openai-codex/gpt-5.5:ultra" } },
+			modelRegistry: candidateRegistry(),
+			settings: Settings.isolated(),
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason.toLowerCase()).toContain("invalid");
+	});
+});

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -6,6 +6,7 @@ import { Settings } from "@gajae-code/coding-agent/config/settings";
 import {
 	ModelSelectorComponent,
 	type ModelSelectorSelection,
+	PROFILE_ROLE_PREVIEW_ORDER,
 } from "@gajae-code/coding-agent/modes/components/model-selector";
 import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
@@ -380,5 +381,83 @@ describe("model selector profiles", () => {
 		expect(session.setModelTemporaryCalls).toEqual([]);
 		expect(session.model).toBe(alternateModel);
 		expect(settings.get("modelProfile.default")).toBe("old-profile");
+	});
+
+	test("PROFILE_ROLE_PREVIEW_ORDER matches the preset preview role order", () => {
+		expect(PROFILE_ROLE_PREVIEW_ORDER).toEqual(["default", "executor", "planner", "critic", "architect"]);
+	});
+
+	test("custom preset action tuple routes apply, set default, edit, rename, and delete by action id", async () => {
+		installTestTheme();
+		const emitted: ModelSelectorSelection[] = [];
+		const selector = createSelector(selection => {
+			emitted.push(selection);
+		});
+		await Bun.sleep(10);
+		installTestTheme();
+
+		await selector.__testSelectPresetAction("profile-a", "apply");
+		await selector.__testSelectPresetAction("profile-a", "setDefault");
+		await selector.__testSelectPresetAction("profile-a", "edit");
+		await selector.__testSelectPresetAction("profile-a", "rename");
+		await selector.__testSelectPresetAction("profile-a", "delete");
+
+		expect(emitted).toEqual([
+			{ kind: "profile", profileName: "profile-a", setDefault: false },
+			{ kind: "profile", profileName: "profile-a", setDefault: true },
+			{ kind: "editProfile", profileName: "profile-a" },
+			{ kind: "renameProfile", profileName: "profile-a" },
+			{ kind: "deleteProfile", profileName: "profile-a" },
+		]);
+	});
+
+	test("built-in preset action tuple omits edit, rename, and delete", async () => {
+		installTestTheme();
+		const builtin: ModelProfileDefinition = {
+			name: "codex-medium",
+			displayName: "Codex Medium",
+			requiredProviders: ["provider-a"],
+			modelMapping: { default: "provider-a/default" },
+			source: "builtin",
+		};
+		const profiles = new Map<string, ModelProfileDefinition>([[builtin.name, builtin]]);
+		const registry = {
+			...createRegistry(),
+			getModelProfiles: () => new Map(profiles),
+			getModelProfile: (name: string) => profiles.get(name),
+			getAvailableModelProfileNames: () => [...profiles.keys()],
+		};
+		const ui = { requestRender: vi.fn() } as unknown as TUI;
+		const emitted: ModelSelectorSelection[] = [];
+		const selector = new ModelSelectorComponent(
+			ui,
+			undefined,
+			Settings.isolated(),
+			registry as never,
+			[],
+			selection => {
+				emitted.push(selection);
+			},
+			() => {},
+			{},
+		);
+		await Bun.sleep(10);
+		installTestTheme();
+
+		await expect(selector.__testSelectPresetAction("codex-medium", "edit")).rejects.toThrow(
+			"Preset scope action not available: edit",
+		);
+		await expect(selector.__testSelectPresetAction("codex-medium", "rename")).rejects.toThrow(
+			"Preset scope action not available: rename",
+		);
+		await expect(selector.__testSelectPresetAction("codex-medium", "delete")).rejects.toThrow(
+			"Preset scope action not available: delete",
+		);
+		await selector.__testSelectPresetAction("codex-medium", "apply");
+		await selector.__testSelectPresetAction("codex-medium", "setDefault");
+		expect(emitted).toEqual([
+			{ kind: "profile", profileName: "codex-medium", setDefault: false },
+			{ kind: "profile", profileName: "codex-medium", setDefault: true },
+		]);
 	});
 });


### PR DESCRIPTION
## Problem

Custom model presets can be created, renamed, or deleted, but changing a preset's models means delete + recreate. There is no in-place edit.

## What

Adds an **Edit** preset action that opens the custom-preset wizard in edit mode, pre-populated with the preset's per-role mappings.

- One wizard component with a `create | edit` mode flag; create mode is unchanged.
- Edit mode is a compact draft picker: role list over the shared preview order, per-role model selection, effort submenu constrained to the model's supported efforts.
- Saving preserves the preset's key and `display_name`.

## Safety / transactional guarantees

- Validated before any write: `validateModelProfileCandidate` resolves every selector, requires provider credentials, and clamps (never rejects) supported-but-above-max efforts. An invalid candidate never reaches the registry.
- On save the config is written, then the profile is re-activated only when it is the active profile (persisting default only when it is also the persisted default).
- Any post-write activation failure restores the exact prior models-config bytes, so no edited config survives a failed activation.

## Refactors (no behavior change)

- Selector preset actions dispatch by action id (tuple) instead of a magic index, so adding Edit is a structured change.
- `deriveRequiredProviders` lifted to a single shared helper; `PROFILE_ROLE_PREVIEW_ORDER` exported. No parallel copies.

## Files

- `src/config/model-profile-activation.ts`, `src/config/model-profiles.ts`, `src/config/model-registry.ts`
- `src/modes/components/custom-model-preset-wizard.ts`, `src/modes/components/model-selector.ts`, `src/modes/controllers/selector-controller.ts`
- Tests: `custom-model-preset-creation`, `custom-model-preset-edit`, `custom-model-preset-edit-redteam`, `model-profile-candidate-validation`, `model-selector-profiles`

## Verification (rebased on current `main`)

- `packages/coding-agent`: `bun run check` (biome + tsgo --noEmit) clean.
- Feature suites: 79 pass / 0 fail across the 5 files above.
