### PR TITLE
feat(auth): pin stored credentials from CLI

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added runtime credential selectors so callers can pin stored multi-account credentials by id, email, account id, or project id instead of using automatic rotation/ranking.
 
 ## [0.9.1] - 2026-07-08
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -493,7 +493,16 @@ type AuthApiKeyOptions = {
 	 * stranding the caller for `timeoutMs * (maxRetries + 1)`.
 	 */
 	signal?: AbortSignal;
+	/** Pin selection to one stored credential instead of using round-robin/ranking. */
+	credentialSelector?: AuthCredentialSelector;
 };
+export type AuthCredentialSelectorKind = "id" | "email" | "account" | "project";
+
+export interface AuthCredentialSelector {
+	kind: AuthCredentialSelectorKind;
+	value: string;
+}
+
 type OAuthResolutionResult = { apiKey: string; credential: OAuthCredential };
 
 /**
@@ -696,6 +705,7 @@ export class AuthStorage {
 	#data: Map<string, StoredCredential[]> = new Map();
 	#runtimeOverrides: Map<string, string> = new Map();
 	#configOverrides: Map<string, string> = new Map();
+	#runtimeCredentialSelectors: Map<string, AuthCredentialSelector> = new Map();
 	/** Tracks next credential index per provider:type key for round-robin distribution (non-session use). */
 	#providerRoundRobinIndex: Map<string, number> = new Map();
 	/** Tracks the last used credential per provider for a session (used for rate-limit switching). */
@@ -844,6 +854,23 @@ export class AuthStorage {
 	 */
 	setRuntimeApiKey(provider: string, apiKey: string): void {
 		this.#runtimeOverrides.set(provider, apiKey);
+	}
+
+	/**
+	 * Pin credential selection for a provider (not persisted to disk).
+	 * Used for CLI --credential.
+	 */
+	setRuntimeCredentialSelector(provider: string, selector: AuthCredentialSelector): void {
+		const storageProvider = resolveOAuthStorageProvider(provider);
+		this.#assertCredentialSelectorUsable(storageProvider, selector);
+		this.#runtimeCredentialSelectors.set(storageProvider, selector);
+	}
+
+	/**
+	 * Remove a runtime credential selector.
+	 */
+	removeRuntimeCredentialSelector(provider: string): void {
+		this.#runtimeCredentialSelectors.delete(resolveOAuthStorageProvider(provider));
 	}
 
 	/**
@@ -1122,6 +1149,72 @@ export class AuthStorage {
 		}
 	}
 
+	#formatCredentialSelector(selector: AuthCredentialSelector): string {
+		return `${selector.kind}:${selector.value}`;
+	}
+
+	#credentialMatchesSelector(entry: StoredCredential, selector: AuthCredentialSelector): boolean {
+		switch (selector.kind) {
+			case "id":
+				return String(entry.id) === selector.value;
+			case "email":
+				return (
+					entry.credential.type === "oauth" &&
+					typeof entry.credential.email === "string" &&
+					entry.credential.email.toLowerCase() === selector.value.toLowerCase()
+				);
+			case "account":
+				return entry.credential.type === "oauth" && entry.credential.accountId === selector.value;
+			case "project":
+				return entry.credential.type === "oauth" && entry.credential.projectId === selector.value;
+		}
+	}
+
+	#findCredentialBySelector(
+		provider: string,
+		selector: AuthCredentialSelector,
+	): ({ index: number } & StoredCredential) | undefined {
+		const stored = this.#getStoredCredentials(provider);
+		for (let index = 0; index < stored.length; index++) {
+			const entry = stored[index];
+			if (entry && this.#credentialMatchesSelector(entry, selector)) return { ...entry, index };
+		}
+		return undefined;
+	}
+
+	#getCredentialSelector(provider: string, options?: AuthApiKeyOptions): AuthCredentialSelector | undefined {
+		return options?.credentialSelector ?? this.#runtimeCredentialSelectors.get(resolveOAuthStorageProvider(provider));
+	}
+
+	#assertCredentialSelectorUsable(provider: string, selector: AuthCredentialSelector): void {
+		if (this.#runtimeOverrides.has(provider)) {
+			throw new Error(
+				`Credential selector ${this.#formatCredentialSelector(selector)} cannot be used for ${provider} while a runtime API key override is active`,
+			);
+		}
+		if (this.#configOverrides.has(provider)) {
+			throw new Error(
+				`Credential selector ${this.#formatCredentialSelector(selector)} cannot be used for ${provider} while a config API key override is active`,
+			);
+		}
+		if (!this.#findCredentialBySelector(provider, selector)) {
+			throw new Error(`No credential found for ${provider} matching ${this.#formatCredentialSelector(selector)}`);
+		}
+	}
+
+	#resolveSelectedStoredCredential(
+		provider: string,
+		options?: AuthApiKeyOptions,
+	): ({ index: number } & StoredCredential) | undefined {
+		const selector = this.#getCredentialSelector(provider, options);
+		if (!selector) return undefined;
+		this.#assertCredentialSelectorUsable(resolveOAuthStorageProvider(provider), selector);
+		const selected = this.#findCredentialBySelector(provider, selector);
+		if (!selected) {
+			throw new Error(`No credential found for ${provider} matching ${this.#formatCredentialSelector(selector)}`);
+		}
+		return selected;
+	}
 	/**
 	 * Selects a credential of the specified type for a provider.
 	 * Returns both the credential and its index in the original array (for updates/removal).
@@ -2734,17 +2827,28 @@ export class AuthStorage {
 		sessionId?: string,
 		options?: AuthApiKeyOptions,
 	): Promise<OAuthResolutionResult | undefined> {
-		const credentials = this.#getCredentialsForProvider(provider)
-			.map((credential, index) => ({ credential, index }))
-			.filter((entry): entry is { credential: OAuthCredential; index: number } => entry.credential.type === "oauth");
+		const selectedCredential = this.#resolveSelectedStoredCredential(provider, options);
+		const selectedOAuthCredential =
+			selectedCredential?.credential.type === "oauth"
+				? { credential: selectedCredential.credential, index: selectedCredential.index }
+				: undefined;
+		if (selectedCredential && !selectedOAuthCredential) return undefined;
+		const credentials = selectedOAuthCredential
+			? [selectedOAuthCredential]
+			: this.#getCredentialsForProvider(provider)
+					.map((credential, index) => ({ credential, index }))
+					.filter(
+						(entry): entry is { credential: OAuthCredential; index: number } => entry.credential.type === "oauth",
+					);
 
 		if (credentials.length === 0) return undefined;
 
 		const providerKey = this.#getProviderTypeKey(provider, "oauth");
-		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
+		const order = selectedCredential ? [0] : this.#getCredentialOrder(providerKey, sessionId, credentials.length);
 		const strategy = this.#rankingStrategyResolver?.(provider);
 		const requiresProModel = requiresOpenAICodexProModel(provider, options?.modelId);
-		const checkUsage = strategy !== undefined && (credentials.length > 1 || requiresProModel);
+		const checkUsage =
+			strategy !== undefined && (selectedCredential !== undefined || credentials.length > 1 || requiresProModel);
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
 		const sessionPreferredIndex = sessionCredential?.type === "oauth" ? sessionCredential.index : undefined;
 		// Skip ranking only when the session already has a working preferred credential — re-ranking
@@ -2753,7 +2857,7 @@ export class AuthStorage {
 		// with the most headroom proactively and fall back intelligently when rate-limited.
 		const sessionPreferredIsAvailable =
 			sessionPreferredIndex !== undefined && !this.#isCredentialBlocked(providerKey, sessionPreferredIndex);
-		const shouldRank = checkUsage && (!sessionPreferredIsAvailable || requiresProModel);
+		const shouldRank = !selectedCredential && checkUsage && (!sessionPreferredIsAvailable || requiresProModel);
 		const candidates = shouldRank
 			? await this.#rankOAuthSelections({ providerKey, provider, order, credentials, options, strategy: strategy! })
 			: order
@@ -2761,7 +2865,7 @@ export class AuthStorage {
 					.filter((selection): selection is { credential: OAuthCredential; index: number } => Boolean(selection))
 					.map(selection => ({ selection, usage: null, usageChecked: false }));
 
-		if (sessionPreferredIndex !== undefined && !requiresProModel) {
+		if (!selectedCredential && sessionPreferredIndex !== undefined && !requiresProModel) {
 			const sessionPreferredCandidate = candidates.findIndex(
 				candidate =>
 					!this.#isCredentialBlocked(providerKey, candidate.selection.index) &&
@@ -3118,13 +3222,22 @@ export class AuthStorage {
 					await this.reload();
 					return this.#resolveOAuthSelection(provider, sessionId, options);
 				}
-				if (this.#getCredentialsForProvider(provider).some(credential => credential.type === "oauth")) {
+				if (
+					!this.#getCredentialSelector(provider, options) &&
+					this.#getCredentialsForProvider(provider).some(credential => credential.type === "oauth")
+				) {
 					return this.#resolveOAuthSelection(provider, sessionId, options);
 				}
 			} else {
 				// Block temporarily for transient failures (5 minutes)
 				this.#markCredentialBlocked(providerKey, selection.index, Date.now() + 5 * 60 * 1000);
 			}
+		}
+		if (this.#getCredentialSelector(provider, options)) {
+			const selector = this.#getCredentialSelector(provider, options);
+			throw new Error(
+				`Selected credential for ${provider} (${selector ? this.#formatCredentialSelector(selector) : "unknown"}) is unavailable`,
+			);
 		}
 
 		return undefined;
@@ -3184,6 +3297,8 @@ export class AuthStorage {
 	 * 6. Fallback resolver (models.yml custom providers, last-resort)
 	 */
 	async getApiKey(provider: string, sessionId?: string, options?: AuthApiKeyOptions): Promise<string | undefined> {
+		const selectedCredential = this.#resolveSelectedStoredCredential(provider, options);
+
 		// Runtime override takes highest priority
 		const runtimeKey = this.#runtimeOverrides.get(provider);
 		if (runtimeKey) {
@@ -3200,10 +3315,17 @@ export class AuthStorage {
 			return configKey;
 		}
 
-		const apiKeySelection = this.#selectCredentialByType(provider, "api_key", sessionId);
-		if (apiKeySelection) {
-			this.#recordSessionCredential(provider, sessionId, "api_key", apiKeySelection.index);
-			return this.#configValueResolver(apiKeySelection.credential.key);
+		if (selectedCredential?.credential.type === "api_key") {
+			this.#recordSessionCredential(provider, sessionId, "api_key", selectedCredential.index);
+			return this.#configValueResolver(selectedCredential.credential.key);
+		}
+
+		if (!selectedCredential) {
+			const apiKeySelection = this.#selectCredentialByType(provider, "api_key", sessionId);
+			if (apiKeySelection) {
+				this.#recordSessionCredential(provider, sessionId, "api_key", apiKeySelection.index);
+				return this.#configValueResolver(apiKeySelection.credential.key);
+			}
 		}
 
 		const oauthResolved = await this.#resolveOAuthSelection(provider, sessionId, options);

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -506,6 +506,29 @@ describe("AuthStorage codex oauth ranking", () => {
 		expect(maxConcurrent).toBe(3);
 		expect(elapsedMs).toBeLessThan(refreshDelayMs * 2);
 	});
+	test("runtime credential selector pins Codex oauth by email instead of ranking", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-near", "near@example.com") },
+			{ type: "oauth", ...createCredential("acct-far", "far@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-near",
+			createCodexUsageReport({
+				accountId: "acct-near",
+				primary: { usedFraction: 0.1, resetInMs: 10 * 60 * 1000 },
+				secondary: { usedFraction: 0.1, resetInMs: 20 * 60 * 1000 },
+			}),
+		);
+
+		authStorage.setRuntimeCredentialSelector("openai-codex", { kind: "email", value: "far@example.com" });
+
+		const apiKey = await authStorage.getApiKey("openai-codex", "session-pinned-codex-email");
+		expect(apiKey).toBe("api-acct-far");
+		expect(authStorage.getOAuthAccountId("openai-codex", "session-pinned-codex-email")).toBe("acct-far");
+	});
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -757,5 +780,39 @@ describe("AuthStorage claude oauth ranking", () => {
 
 		const apiKey = await authStorage.getApiKey("anthropic", "session-claude-single");
 		expect(apiKey).toBe("api-acct-solo");
+	});
+	test("runtime credential selector pins oauth by email instead of ranking", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("anthropic", [
+			{ type: "oauth", ...createCredential("acct-near", "near@example.com") },
+			{ type: "oauth", ...createCredential("acct-far", "far@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-near",
+			createClaudeUsageReport({
+				accountId: "acct-near",
+				primary: { usedFraction: 0.1, resetInMs: 10 * 60 * 1000 },
+				secondary: { usedFraction: 0.1, resetInMs: 20 * 60 * 1000 },
+			}),
+		);
+
+		authStorage.setRuntimeCredentialSelector("anthropic", { kind: "email", value: "far@example.com" });
+
+		const apiKey = await authStorage.getApiKey("anthropic", "session-pinned-email");
+		expect(apiKey).toBe("api-acct-far");
+		expect(authStorage.getOAuthAccountId("anthropic", "session-pinned-email")).toBe("acct-far");
+	});
+
+	test("runtime credential selector fails when the credential is missing", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		const storage = authStorage;
+
+		await storage.set("anthropic", [{ type: "oauth", ...createCredential("acct-a", "a@example.com") }]);
+
+		expect(() =>
+			storage.setRuntimeCredentialSelector("anthropic", { kind: "email", value: "missing@example.com" }),
+		).toThrow("No credential found for anthropic matching email:missing@example.com");
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added `gjc --credential <selector>` for pinning a stored provider credential by `email:`, `id:`, `account:`, `project:`, or `provider/email:` during a session.
+
 ### Fixed
 
 - Finalized notification turn mirrors now default to the bounded full-turn cap so Telegram's existing chunked delivery can send long assistant answers instead of receiving an already-truncated 3500-character summary; `GJC_NOTIFICATIONS_TURN_MAX` remains available to lower the cap for summary-style mirrors, and live previews stay capped as one editable message.

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -146,6 +146,10 @@ export class RootHelpCommand extends Command {
 		default: Flags.boolean({ description: "Persist --mpreset as the default model profile" }),
 		provider: Flags.string({ description: "Provider to use (legacy; prefer --model)" }),
 		"api-key": Flags.string({ description: "API key (defaults to env vars)" }),
+		credential: Flags.string({
+			description:
+				"Stored credential selector: email:<addr>, id:<n>, account:<id>, project:<id>, or provider/email:<addr>",
+		}),
 		"system-prompt": Flags.string({ description: "System prompt (default: coding assistant prompt)" }),
 		"append-system-prompt": Flags.string({ description: "Append text or file contents to the system prompt" }),
 		"allow-home": Flags.boolean({ description: "Allow starting in ~ without auto-switching to a temp dir" }),
@@ -191,6 +195,7 @@ export class RootHelpCommand extends Command {
 		`# Launch in a sibling git worktree\n  ${APP_NAME} --worktree`,
 		`# Use different model (fuzzy matching)\n  ${APP_NAME} --model opus "Help me refactor this code"`,
 		`# Limit model cycling to specific models\n  ${APP_NAME} --models claude-sonnet,claude-haiku,gpt-4o`,
+		`# Pin a stored credential for this session\n  ${APP_NAME} --credential email:me@example.com`,
 		`# Activate a model profile for this session\n  ${APP_NAME} --mpreset codex-medium`,
 		`# Persist a model profile as the default\n  ${APP_NAME} --mpreset opencodego --default`,
 		`# Export a session file to HTML\n  ${APP_NAME} --export ~/.gjc/agent/sessions/--path--/session.jsonl`,

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -20,6 +20,7 @@ export interface Args {
 	mpreset?: string;
 	default?: boolean;
 	apiKey?: string;
+	credential?: string;
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
 	thinking?: Effort;
@@ -136,6 +137,8 @@ export function parseArgs(args: string[]): Args {
 			result.default = true;
 		} else if (arg === "--api-key" && i + 1 < args.length) {
 			result.apiKey = args[++i];
+		} else if (arg === "--credential" && i + 1 < args.length) {
+			result.credential = args[++i];
 		} else if (arg === "--system-prompt" && i + 1 < args.length) {
 			result.systemPrompt = args[++i];
 		} else if (arg === "--append-system-prompt" && i + 1 < args.length) {

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -87,6 +87,10 @@ export default class Index extends Command {
 		"api-key": Flags.string({
 			description: "API key (defaults to env vars)",
 		}),
+		credential: Flags.string({
+			description:
+				"Stored credential selector: email:<addr>, id:<n>, account:<id>, project:<id>, or provider/email:<addr>",
+		}),
 		"system-prompt": Flags.string({
 			description: "System prompt (default: coding assistant prompt)",
 		}),
@@ -181,6 +185,7 @@ export default class Index extends Command {
 		`# Launch in a sibling git worktree\n  ${APP_NAME} --worktree`,
 		`# Use different model (fuzzy matching)\n  ${APP_NAME} --model opus "Help me refactor this code"`,
 		`# Limit model cycling to specific models\n  ${APP_NAME} --models claude-sonnet,claude-haiku,gpt-4o`,
+		`# Pin a stored credential for this session\n  ${APP_NAME} --credential email:me@example.com`,
 		`# Activate a model profile for this session\n  ${APP_NAME} --mpreset codex-medium`,
 		`# Persist a model profile as the default\n  ${APP_NAME} --mpreset opencodego --default`,
 		`# Export a session file to HTML\n  ${APP_NAME} --export ~/.gjc/agent/sessions/--path--/session.jsonl`,

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import {
 	type Api,
 	type AssistantMessageEventStream,
+	type AuthCredentialSelector,
 	type CacheRetention,
 	type Context,
 	createModelManager,
@@ -2667,21 +2668,37 @@ export class ModelRegistry {
 	/**
 	 * Get API key for a model.
 	 */
-	async getApiKey(model: Model<Api>, sessionId?: string): Promise<string | undefined> {
+	async getApiKey(
+		model: Model<Api>,
+		sessionId?: string,
+		options: { credentialSelector?: AuthCredentialSelector } = {},
+	): Promise<string | undefined> {
 		if (this.#keylessProviders.has(model.provider) && !this.authStorage.hasAuth(model.provider)) {
 			return kNoAuth;
 		}
-		return this.authStorage.getApiKey(model.provider, sessionId, { baseUrl: model.baseUrl, modelId: model.id });
+		return this.authStorage.getApiKey(model.provider, sessionId, {
+			baseUrl: model.baseUrl,
+			modelId: model.id,
+			credentialSelector: options.credentialSelector,
+		});
 	}
 
 	/**
 	 * Get API key for a provider (e.g., "openai").
 	 */
-	async getApiKeyForProvider(provider: string, sessionId?: string, baseUrl?: string): Promise<string | undefined> {
+	async getApiKeyForProvider(
+		provider: string,
+		sessionId?: string,
+		baseUrl?: string,
+		options: { credentialSelector?: AuthCredentialSelector } = {},
+	): Promise<string | undefined> {
 		if (this.#keylessProviders.has(provider) && !this.authStorage.hasAuth(provider)) {
 			return kNoAuth;
 		}
-		return this.authStorage.getApiKey(provider, sessionId, { baseUrl });
+		return this.authStorage.getApiKey(provider, sessionId, {
+			baseUrl,
+			credentialSelector: options.credentialSelector,
+		});
 	}
 
 	async #peekApiKeyForProvider(provider: string): Promise<string | undefined> {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -38,6 +38,7 @@ import type { InteractiveMode } from "./modes/interactive-mode";
 import { initTheme, stopThemeWatcher } from "./modes/theme/theme";
 import type { SubmittedUserInput } from "./modes/types";
 import { applyCliRuntimeApiKeyOverride } from "./runtime-api-key";
+import { parseCliCredentialSelector } from "./runtime-credential-selector";
 import type { MCPManager } from "./runtime-mcp";
 import {
 	type CreateAgentSessionOptions,
@@ -1010,6 +1011,20 @@ export async function runRootCommand(
 	deps.rlmPreset?.applyOptions(sessionOptions, settingsInstance);
 
 	// Handle CLI --api-key as runtime override (not persisted)
+	if (parsedArgs.apiKey && parsedArgs.credential) {
+		process.stderr.write(`${chalk.red("--api-key and --credential cannot be used together")}\n`);
+		process.exit(1);
+	}
+
+	if (parsedArgs.credential) {
+		try {
+			sessionOptions.credentialSelector = parseCliCredentialSelector(parsedArgs.credential);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			process.stderr.write(`${chalk.red(message)}\n`);
+			process.exit(1);
+		}
+	}
 	if (parsedArgs.apiKey) {
 		if (!sessionOptions.model && !sessionOptions.modelPattern) {
 			process.stderr.write(

--- a/packages/coding-agent/src/runtime-credential-selector.ts
+++ b/packages/coding-agent/src/runtime-credential-selector.ts
@@ -1,0 +1,35 @@
+import type { AuthCredentialSelector, AuthCredentialSelectorKind } from "@gajae-code/ai";
+
+export interface CliCredentialSelector {
+	provider?: string;
+	selector: AuthCredentialSelector;
+	raw: string;
+}
+
+const SELECTOR_KINDS = new Set<AuthCredentialSelectorKind>(["id", "email", "account", "project"]);
+
+function parseSelectorBody(body: string): AuthCredentialSelector | undefined {
+	const separator = body.indexOf(":");
+	if (separator === -1) {
+		if (body.includes("@")) return { kind: "email", value: body };
+		return undefined;
+	}
+	const rawKind = body.slice(0, separator);
+	const value = body.slice(separator + 1).trim();
+	if (!SELECTOR_KINDS.has(rawKind as AuthCredentialSelectorKind) || value.length === 0) return undefined;
+	return { kind: rawKind as AuthCredentialSelectorKind, value };
+}
+
+export function parseCliCredentialSelector(raw: string): CliCredentialSelector {
+	const trimmed = raw.trim();
+	const slash = trimmed.indexOf("/");
+	const provider = slash === -1 ? undefined : trimmed.slice(0, slash).trim();
+	const body = slash === -1 ? trimmed : trimmed.slice(slash + 1).trim();
+	const selector = parseSelectorBody(body);
+	if (!selector || provider === "") {
+		throw new Error(
+			`Invalid --credential selector "${raw}". Use email:name@example.com, id:123, account:<id>, project:<id>, or provider/email:name@example.com.`,
+		);
+	}
+	return { ...(provider ? { provider } : {}), selector, raw };
+}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -9,6 +9,7 @@ import {
 	type ThinkingLevel,
 } from "@gajae-code/agent-core";
 import {
+	type AuthCredentialSelector,
 	type CredentialDisabledEvent,
 	type Message,
 	type Model,
@@ -39,7 +40,7 @@ import {
 import { type AsyncJob, AsyncJobManager, isBackgroundJobSupportEnabled, jobElapsedMs } from "./async";
 import { loadCapability } from "./capability";
 import { type Rule, ruleCapability, setActiveRules } from "./capability/rule";
-import { ModelRegistry } from "./config/model-registry";
+import { kNoAuth, ModelRegistry } from "./config/model-registry";
 import {
 	formatModelString,
 	parseModelPattern,
@@ -272,6 +273,8 @@ export interface CreateAgentSessionOptions {
 	/** Optional provider-facing session identifier for prompt caches and sticky auth selection.
 	 * Keeps persisted session files isolated while reusing provider-side caches. */
 	providerSessionId?: string;
+	/** Runtime credential selector for multi-account auth pools. */
+	credentialSelector?: { provider?: string; selector: AuthCredentialSelector; raw: string };
 
 	/** Custom tools to register (in addition to built-in tools). Accepts both CustomTool and ToolDefinition. */
 	customTools?: (CustomTool | ToolDefinition)[];
@@ -903,10 +906,22 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			startupCredentialDisabledEvents.push(event);
 		}
 	});
+	let runtimeCredentialSelectorInstalled = false;
+	const installRuntimeCredentialSelector = (provider: string): void => {
+		if (!options.credentialSelector || runtimeCredentialSelectorInstalled) return;
+		authStorage.setRuntimeCredentialSelector(provider, options.credentialSelector.selector);
+		runtimeCredentialSelectorInstalled = true;
+	};
+	const earlyCredentialSelectorProvider = options.credentialSelector?.provider ?? options.model?.provider;
+	if (earlyCredentialSelectorProvider) {
+		installRuntimeCredentialSelector(earlyCredentialSelectorProvider);
+	}
 	const settings = options.settings ?? (await logger.time("settings", Settings.init, { cwd, agentDir }));
 	modelRegistry.applyConfiguredModelBindings(settings);
 	logger.time("initializeWithSettings", initializeWithSettings, settings);
-	if (!options.modelRegistry) {
+	const canRefreshModelsBeforeCredentialSelector =
+		!options.credentialSelector || runtimeCredentialSelectorInstalled || options.modelRegistry !== undefined;
+	if (!options.modelRegistry && canRefreshModelsBeforeCredentialSelector) {
 		modelRegistry.refreshInBackground();
 	}
 	// Kick off workspace tree discovery early. The native workspace scan returns
@@ -972,7 +987,29 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			return cached;
 		}
 
-		const hasKey = !!(await modelRegistry.getApiKey(candidate, providerSessionId));
+		const credentialSelector =
+			options.credentialSelector && !runtimeCredentialSelectorInstalled
+				? options.credentialSelector.provider === undefined ||
+					options.credentialSelector.provider === candidate.provider
+					? options.credentialSelector.selector
+					: undefined
+				: undefined;
+		if (options.credentialSelector?.provider && options.credentialSelector.provider !== candidate.provider) {
+			modelApiKeyAvailability.set(availabilityKey, false);
+			return false;
+		}
+		const key = await modelRegistry.getApiKey(candidate, providerSessionId, { credentialSelector }).catch(error => {
+			if (credentialSelector) {
+				logger.debug("Credential selector did not match model availability candidate", {
+					provider: candidate.provider,
+					model: candidate.id,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				return undefined;
+			}
+			throw error;
+		});
+		const hasKey = Boolean(key) && (!credentialSelector || key !== kNoAuth);
 		modelApiKeyAvailability.set(availabilityKey, hasKey);
 		return hasKey;
 	};
@@ -1653,6 +1690,18 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}
 		}
 
+		if (options.credentialSelector && !runtimeCredentialSelectorInstalled) {
+			const credentialProvider = options.credentialSelector.provider ?? model?.provider;
+			if (!credentialProvider) {
+				throw new Error(
+					`--credential ${options.credentialSelector.raw} requires a resolved model or an explicit provider prefix`,
+				);
+			}
+			installRuntimeCredentialSelector(credentialProvider);
+			if (!options.modelRegistry && !canRefreshModelsBeforeCredentialSelector) {
+				modelRegistry.refreshInBackground();
+			}
+		}
 		const customCommandsResult: CustomCommandsLoadResult = { commands: [], errors: [] };
 
 		let extensionRunner: ExtensionRunner | undefined;

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -5,6 +5,7 @@ import { parseArgs } from "../src/cli/args";
 import type { ModelProfileDefinition } from "../src/config/model-profiles";
 import { Settings } from "../src/config/settings";
 import { applyStartupModelProfiles, createAcpSessionFactory } from "../src/main";
+import { parseCliCredentialSelector } from "../src/runtime-credential-selector";
 import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "../src/sdk";
 import type { AgentSession } from "../src/session/agent-session";
 
@@ -71,6 +72,26 @@ describe("CLI model profile args", () => {
 
 	test("rejects --default without --mpreset", () => {
 		expect(() => parseArgs(["--default"])).toThrow("--default requires --mpreset <name>");
+	});
+});
+
+describe("CLI credential selector args", () => {
+	test("parses --credential with provider-qualified email selector", () => {
+		const parsed = parseArgs(["--credential", "openai-codex/email:me@example.com"]);
+		expect(parsed.credential).toBe("openai-codex/email:me@example.com");
+
+		const selector = parseCliCredentialSelector(parsed.credential ?? "");
+		expect(selector.provider).toBe("openai-codex");
+		expect(selector.selector).toEqual({ kind: "email", value: "me@example.com" });
+	});
+
+	test("parses bare email credential selector as email shorthand", () => {
+		const selector = parseCliCredentialSelector("me@example.com");
+		expect(selector.selector).toEqual({ kind: "email", value: "me@example.com" });
+	});
+
+	test("rejects malformed credential selector", () => {
+		expect(() => parseCliCredentialSelector("openai-codex/nope")).toThrow("Invalid --credential selector");
 	});
 });
 


### PR DESCRIPTION
## Summary

- Add provider-agnostic `--credential` selectors (`email:`, `id:`, `account:`, `project:`, and `provider/email:`) for pinning one stored credential in multi-account auth pools.
- Wire the selector through CLI startup into `AuthStorage`, where explicit selectors bypass round-robin/ranking and fail fast on missing, blocked, or unavailable credentials instead of silently falling back to another account.
- Document the new flag in root/launch help and changelogs.

## Tests

- `bun test packages/ai/test/auth-storage-codex-selection.test.ts packages/coding-agent/test/cli-args-mpreset.test.ts`
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/coding-agent run check`

## Notes

- Built native addon locally with `bun run build:native` before tests because this fresh worktree did not have `pi_natives.darwin-arm64.node`.
