### PR TITLE
feat(status-line): show token percentage inline next to model/reasoning

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Changed
 
-- The status line (information bar) token-percentage now renders inline within the model segment, right after the reasoning-effort indicator, instead of as a trailing segment at the far end of the line, so the context usage percentage stays grouped with the model it describes. The standalone `context_pct` segment was removed from the `default`, `default-usage`, `compact`, `full`, `nerd`, `ascii`, and `custom` presets (it remains available for `minimal` and custom configs); the inline percentage is color-coded by context-usage level and can be disabled per-preset with `segmentOptions.model.showContextPercent: false`.
+- The status line (information bar) token-percentage now renders inline within the model segment, right after the reasoning-effort indicator, instead of as a trailing segment at the far end of the line, so the context usage percentage stays grouped with the model it describes. The standalone `context_pct` segment was removed from the `default`, `default-usage`, `compact`, `full`, `nerd`, `ascii`, and `custom` presets (it remains available for `minimal` and custom configs); the inline percentage is color-coded by context-usage level, can be disabled per-preset with `segmentOptions.model.showContextPercent: false`, and is auto-suppressed when a standalone `context_pct` segment is also active so the value is never shown twice.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 - Added `gjc --credential <selector>` for pinning a stored provider credential by `email:`, `id:`, `account:`, `project:`, or `provider/email:` during a session.
 
+### Changed
+
+- The status line (information bar) token-percentage now renders inline within the model segment, right after the reasoning-effort indicator, instead of as a trailing segment at the far end of the line, so the context usage percentage stays grouped with the model it describes. The standalone `context_pct` segment was removed from the `default`, `default-usage`, `compact`, `full`, `nerd`, `ascii`, and `custom` presets (it remains available for `minimal` and custom configs); the inline percentage is color-coded by context-usage level and can be disabled per-preset with `segmentOptions.model.showContextPercent: false`.
+
 ### Fixed
 
 - Finalized notification turn mirrors now default to the bounded full-turn cap so Telegram's existing chunked delivery can send long assistant answers instead of receiving an already-truncated 3500-character summary; `GJC_NOTIFICATIONS_TURN_MAX` remains available to lower the cap for summary-style mirrors, and live previews stay capped as one editable message.

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -700,6 +700,11 @@ export class StatusLineComponent implements Component {
 		const contextTokens = breakdown.usedTokens;
 		const contextWindow = breakdown.contextWindow || state.model?.contextWindow || 0;
 		const contextPercent = contextWindow > 0 ? (contextTokens / contextWindow) * 100 : 0;
+		// Suppress the inline model percentage when a standalone context_pct
+		// segment is also rendered, so the value is not shown twice.
+		const contextPctSegmentActive =
+			effectiveSettings.leftSegments.includes("context_pct") ||
+			effectiveSettings.rightSegments.includes("context_pct");
 
 		return {
 			session: this.session,
@@ -710,6 +715,7 @@ export class StatusLineComponent implements Component {
 			usageStats,
 			contextPercent,
 			contextWindow,
+			contextPctSegmentActive,
 			autoCompactEnabled: this.#autoCompactEnabled,
 			subagentCount: this.#subagentCount,
 			jobs: this.#jobs,

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -29,7 +29,7 @@ import { calculateTokensPerSecond } from "./status-line/token-rate";
 import type { SeparatorDef } from "./status-line/types";
 
 export interface StatusLineSegmentOptions {
-	model?: { showThinkingLevel?: boolean };
+	model?: { showThinkingLevel?: boolean; showContextPercent?: boolean };
 	path?: { abbreviate?: boolean; maxLength?: number; stripWorkPrefix?: boolean };
 	git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };
 	time?: { format?: "12h" | "24h"; showSeconds?: boolean };

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -3,7 +3,7 @@ import type { PresetDef, StatusLinePreset } from "./types";
 export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	default: {
 		leftSegments: ["model", "mode", "git", "pr", "path"],
-		rightSegments: ["session_name", "jobs", "token_rate", "context_pct", "cost"],
+		rightSegments: ["session_name", "jobs", "token_rate", "cost"],
 		separator: "slash",
 		segmentOptions: {
 			model: { showThinkingLevel: true },
@@ -14,7 +14,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	"default-usage": {
 		leftSegments: ["model", "mode", "git", "pr", "path"],
-		rightSegments: ["session_name", "jobs", "token_rate", "usage", "context_pct", "cost"],
+		rightSegments: ["session_name", "jobs", "token_rate", "usage", "cost"],
 		separator: "slash",
 		segmentOptions: {
 			model: { showThinkingLevel: true },
@@ -35,7 +35,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	compact: {
 		leftSegments: ["model", "mode", "git", "pr"],
-		rightSegments: ["session_name", "jobs", "cost", "context_pct"],
+		rightSegments: ["session_name", "jobs", "cost"],
 		separator: "slash",
 		segmentOptions: {
 			model: { showThinkingLevel: false },
@@ -53,7 +53,6 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 			"token_rate",
 			"cache_read",
 			"cost",
-			"context_pct",
 			"time_spent",
 			"time",
 		],
@@ -78,7 +77,6 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 			"cache_write",
 			"token_rate",
 			"cost",
-			"context_pct",
 			"context_total",
 			"time_spent",
 			"time",
@@ -95,7 +93,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	ascii: {
 		// No Nerd Font dependencies
 		leftSegments: ["model", "mode", "path", "git", "pr"],
-		rightSegments: ["session_name", "jobs", "token_total", "cost", "context_pct"],
+		rightSegments: ["session_name", "jobs", "token_total", "cost"],
 		separator: "ascii",
 		segmentOptions: {
 			model: { showThinkingLevel: true },
@@ -107,7 +105,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	custom: {
 		// User-defined - these are just defaults that get overridden
 		leftSegments: ["model", "mode", "path", "git", "pr"],
-		rightSegments: ["session_name", "jobs", "token_total", "cost", "context_pct"],
+		rightSegments: ["session_name", "jobs", "token_total", "cost"],
 		separator: "slash",
 		segmentOptions: {},
 	},

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -105,6 +105,18 @@ const modelSegment: StatusLineSegment = {
 				}
 			}
 		}
+		// Show the context-window token percentage right next to the model /
+		// reasoning effort (rather than as a trailing segment) so it stays
+		// grouped with the model it describes. Disable per-preset with
+		// `segmentOptions.model.showContextPercent: false`.
+		if (opts.showContextPercent !== false) {
+			const pct = ctx.contextPercent;
+			const window = ctx.contextWindow;
+			if (window > 0 && Number.isFinite(pct)) {
+				const color = getContextUsageThemeColor(getContextUsageLevel(pct, window));
+				content += `${theme.sep.dot}${theme.fg(color, `${pct.toFixed(1)}%`)}`;
+			}
+		}
 
 		return { content: theme.fg("statusLineModel", content), visible: true };
 	},

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -108,8 +108,10 @@ const modelSegment: StatusLineSegment = {
 		// Show the context-window token percentage right next to the model /
 		// reasoning effort (rather than as a trailing segment) so it stays
 		// grouped with the model it describes. Disable per-preset with
-		// `segmentOptions.model.showContextPercent: false`.
-		if (opts.showContextPercent !== false) {
+		// `segmentOptions.model.showContextPercent: false`. Suppressed
+		// automatically when a standalone context_pct segment is also in the
+		// active layout, so the value is never shown twice.
+		if (opts.showContextPercent !== false && ctx.contextPctSegmentActive !== true) {
 			const pct = ctx.contextPercent;
 			const window = ctx.contextWindow;
 			if (window > 0 && Number.isFinite(pct)) {

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -41,6 +41,12 @@ export interface SegmentContext {
 	};
 	contextPercent: number;
 	contextWindow: number;
+	/**
+	 * True when a standalone `context_pct` segment is also part of the active
+	 * layout. The model segment suppresses its inline percentage in that case to
+	 * avoid showing the same value twice.
+	 */
+	contextPctSegmentActive?: boolean;
 	autoCompactEnabled: boolean;
 	subagentCount: number;
 	jobs: JobsSnapshot;

--- a/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
+++ b/packages/coding-agent/test/modes/components/redesigned-shell.test.ts
@@ -219,6 +219,7 @@ describe("redesigned interactive shell chrome", () => {
 
 		expect(statusRendered).toContain("very-long-model-name-for-footer-budget");
 		expect(statusRendered).toContain("forge-session");
+		expect(statusRendered).toMatch(/very-long-model-name-for-footer-budget[^\n]*\d+(\.\d+)?%/);
 		expect(editorRendered).toContain("› draft");
 		expect(editorRendered).not.toContain("very-long-model-name-for-footer-budget");
 		expect(editorRendered).not.toContain("╭");
@@ -289,13 +290,7 @@ describe("redesigned interactive shell chrome", () => {
 
 	it("keeps the default status preset dense and pulse-forward", () => {
 		expect(STATUS_LINE_PRESETS.default.leftSegments).toEqual(["model", "mode", "git", "pr", "path"]);
-		expect(STATUS_LINE_PRESETS.default.rightSegments).toEqual([
-			"session_name",
-			"jobs",
-			"token_rate",
-			"context_pct",
-			"cost",
-		]);
+		expect(STATUS_LINE_PRESETS.default.rightSegments).toEqual(["session_name", "jobs", "token_rate", "cost"]);
 		expect(STATUS_LINE_PRESETS.default.segmentOptions?.path?.maxLength).toBe(32);
 	});
 
@@ -306,7 +301,6 @@ describe("redesigned interactive shell chrome", () => {
 			"jobs",
 			"token_rate",
 			"usage",
-			"context_pct",
 			"cost",
 		]);
 		expect(STATUS_LINE_PRESETS["default-usage"].segmentOptions).toEqual(STATUS_LINE_PRESETS.default.segmentOptions);

--- a/packages/coding-agent/test/status-line-model-percent.test.ts
+++ b/packages/coding-agent/test/status-line-model-percent.test.ts
@@ -76,6 +76,19 @@ describe("model segment inline context percentage", () => {
 		expect(rendered).not.toContain("42.5%");
 		expect(rendered).toContain("Sonnet");
 	});
+	it("suppresses the inline percentage when a standalone context_pct segment is active", () => {
+		const ctx = makeCtx({
+			contextPercent: 42.5,
+			contextWindow: 200_000,
+			contextPctSegmentActive: true,
+		});
+		const rendered = Bun.stripANSI(renderSegment("model", ctx).content);
+
+		// Avoids showing the same percentage twice in custom layouts that keep
+		// both the model segment and a standalone context_pct segment.
+		expect(rendered).not.toContain("42.5%");
+		expect(rendered).toContain("Sonnet");
+	});
 
 	it("still shows the percentage when the reasoning effort is off", () => {
 		const ctx = makeCtx({

--- a/packages/coding-agent/test/status-line-model-percent.test.ts
+++ b/packages/coding-agent/test/status-line-model-percent.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
+import { renderSegment, type SegmentContext } from "../src/modes/components/status-line/segments";
+import { EMPTY_JOBS_SNAPSHOT } from "../src/modes/jobs-observer";
+import { initTheme } from "../src/modes/theme/theme";
+
+function makeCtx(overrides: Partial<SegmentContext> = {}): SegmentContext {
+	return {
+		session: {
+			state: {
+				model: { id: "sonnet", name: "Sonnet", thinking: true, contextWindow: 200_000 },
+				thinkingLevel: ThinkingLevel.High,
+			},
+			isFastModeActive: () => false,
+		} as unknown as SegmentContext["session"],
+		width: 120,
+		options: {},
+		planMode: null,
+		goalMode: null,
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			premiumRequests: 0,
+			cost: 0,
+			tokensPerSecond: null,
+		},
+		contextPercent: 0,
+		contextWindow: 0,
+		autoCompactEnabled: false,
+		subagentCount: 0,
+		jobs: EMPTY_JOBS_SNAPSHOT,
+		sessionStartTime: Date.now(),
+		git: { branch: null, status: null, pr: null },
+		usage: null,
+		...overrides,
+	};
+}
+
+beforeAll(async () => {
+	await initTheme();
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+});
+afterAll(() => {
+	resetSettingsForTest();
+});
+
+describe("model segment inline context percentage", () => {
+	it("renders the token percentage right after the model / reasoning effort", () => {
+		const ctx = makeCtx({ contextPercent: 42.5, contextWindow: 200_000 });
+		const rendered = Bun.stripANSI(renderSegment("model", ctx).content);
+
+		// Percentage appears, and after the model name + reasoning effort.
+		expect(rendered).toContain("42.5%");
+		expect(rendered).toMatch(/Sonnet.*42\.5%/);
+	});
+
+	it("omits the percentage when contextWindow is unknown", () => {
+		const ctx = makeCtx({ contextPercent: 42.5, contextWindow: 0 });
+		const rendered = Bun.stripANSI(renderSegment("model", ctx).content);
+
+		expect(rendered).not.toContain("%");
+		expect(rendered).toContain("Sonnet");
+	});
+
+	it("can be disabled with segmentOptions.model.showContextPercent: false", () => {
+		const ctx = makeCtx({
+			contextPercent: 42.5,
+			contextWindow: 200_000,
+			options: { model: { showContextPercent: false } },
+		});
+		const rendered = Bun.stripANSI(renderSegment("model", ctx).content);
+
+		expect(rendered).not.toContain("42.5%");
+		expect(rendered).toContain("Sonnet");
+	});
+
+	it("still shows the percentage when the reasoning effort is off", () => {
+		const ctx = makeCtx({
+			contextPercent: 7.3,
+			contextWindow: 200_000,
+			session: {
+				state: {
+					model: { id: "sonnet", name: "Sonnet", thinking: true, contextWindow: 200_000 },
+					thinkingLevel: ThinkingLevel.Off,
+				},
+				isFastModeActive: () => false,
+			} as unknown as SegmentContext["session"],
+		});
+		const rendered = Bun.stripANSI(renderSegment("model", ctx).content);
+
+		expect(rendered).toContain("7.3%");
+		expect(rendered).toMatch(/Sonnet.*7\.3%/);
+	});
+});


### PR DESCRIPTION
## Summary

The information bar (status line) token percentage now renders **inline within the model segment, right after the reasoning-effort indicator**, instead of as a trailing `context_pct` segment at the far end of the line. The percentage is grouped with the model it describes.

Before: `◆ Sonnet 4.5 · high …  …  ⟲ feat-branch  📁 path …  session  ⚡  →rate  0.0%/200K  $0.42`
After:  `◆ Sonnet 4.5 · high · 0.0%  …  ⟲ feat-branch  📁 path …  session  ⚡  →rate  $0.42`

## Why inline (not a moved segment)

I first tried moving the standalone `context_pct` segment to immediately after `model`. That made the **left** rail wider, and because the overflow logic drops right-side segments first, it pushed the right-side `usage` segment out of the `default-usage` preset at common terminal widths (120–160) — defeating that preset's purpose. Inlining the percentage into the model segment satisfies the request most literally **and** reduces total rail width (one fewer segment), so it's a net improvement for narrow terminals.

## Changes

- `modelSegment` (`segments.ts`): appends a color-coded context percentage (color by context-usage level, same helper as the old segment) after the reasoning-effort indicator. Gated by `segmentOptions.model.showContextPercent` (default `on`).
- `StatusLineSegmentOptions.model` (`status-line.ts`): add optional `showContextPercent`.
- `presets.ts`: remove the standalone `context_pct` from the `default`, `default-usage`, `compact`, `full`, `nerd`, `ascii`, and `custom` presets. It remains available for `minimal` and custom configs.
- Updated pinned layout tests; added `status-line-model-percent.test.ts` (renders, unknown-window omission, opt-out, reasoning-off).

## Verification

- `bun test` on all status-line test files + redesigned-shell/skill-hud/jobs/ui-redesign/perf — 102 pass, 0 fail.
- `bun run --filter @gajae-code/coding-agent check` (tsgo + biome) — clean.
- `bun run check:ts` (full repo gates: tools/node20-baseline/public-sync/schemas/plugins/ui-redesign/rebrand + all workspace checks) — clean.

## Notes

- `minimal` is unchanged (it has no `model` segment, so it keeps the standalone `context_pct`).
- One composition test width stayed at 140 (no longer needs widening since the rail is narrower now) and gained a regex assertion that the percentage follows the model name.