### PR TITLE
feat(plugins): sanctioned command hooks for GJC plugin bundles (opt-in, operator-approved)

### DIFF
--- a/docs/gjc-plugins.md
+++ b/docs/gjc-plugins.md
@@ -19,7 +19,8 @@ A GJC plugin bundle may only **extend** existing skills/agents — it can never 
     { "name": "domain_note", "path": "tools/domain-note.ts", "description": "..." }
   ],
   "hooks": [
-    { "name": "audit-read", "event": "tool_call", "target": "read", "phase": "before", "path": "hooks/audit-read.ts" }
+    { "name": "audit-read", "event": "tool_call", "target": "read", "phase": "before", "path": "hooks/audit-read.ts" },
+    { "name": "policy-gate", "event": "tool_call", "command": "bun", "args": ["hooks/gate.js"], "timeoutMs": 10000 }
   ],
   "mcps": [
     { "name": "domain_docs", "transport": "stdio", "command": "bun", "args": ["mcp/domain-docs.ts"], "cwd": "." }
@@ -35,7 +36,7 @@ A GJC plugin bundle may only **extend** existing skills/agents — it can never 
 |---------|---------|---------------|
 | `subskills` | Inline sub-skills bound to an existing skill/agent (`binds_to`/`phase`/`activation_arg`) | Two-tier (see below) |
 | `tools` | Always-on custom tools (object entries) or legacy subskill-scoped string paths | Additive; manifest-declared name is authoritative, never overwrites an existing tool |
-| `hooks` | Constrained event hooks bound to a declared `event`/`target`/`phase` | Additive; run alongside built-ins, never replace |
+| `hooks` | Constrained event hooks: a module hook (`path`) or an operator-approved command hook (`command`) bound to a declared `event`/`target`/`phase` | Additive; run alongside built-ins, never replace |
 | `mcps` | MCP servers (`stdio`/`http`/`sse`) | Additive; server-name collisions are hard errors |
 | `system_appendix` | Lower-authority text appended to the default agent system prompt | Append-only, never overrides base |
 | `agent-appendix` | Lower-authority text appended to an existing role agent's prompt | Append-only per named agent |
@@ -54,6 +55,8 @@ gjc plugin install <path|git-url|tarball> --project   # install into the project
 
 Exactly one of `--user` / `--project` is required for GJC plugin bundles (there is no default root). A source containing `gajae-plugin.json` is classified as a GJC bundle and routed to the bundle installer **before** the marketplace/npm path; non-bundle sources fall through to the legacy flow.
 
+Bundles that declare **command hooks** additionally require `--allow-command-hooks` (explicit operator approval of the subprocess-spawn capability); install fails with `security_policy` otherwise. The approval is recorded on the registry entry and participates in the install fingerprint, so approving previously-installed content is an explicit re-install (`--force`).
+
 Install is **compile-validate-then-copy**:
 
 1. The bundle is compiled and validated **without importing any plugin code** (manifest, frontmatter, and declared files are read as bytes only).
@@ -67,6 +70,7 @@ Idempotency: re-installing identical content is a no-op; different content requi
 - **Install validation never executes plugin code.** Tool/hook names are manifest-declared; at runtime the loaded factory must return/register exactly the declared name/event or the surface is quarantined (`runtime_mismatch`).
 - **MCP policy** (install + runtime connect): HTTPS-only for `http`/`sse`; private/loopback/link-local/unique-local/multicast and the `169.254.169.254` metadata endpoint are denied across IPv4, IPv6, IPv4-mapped/compatible, zone-id and trailing-dot forms; URL credentials and CRLF headers are rejected; DNS is re-resolved before connect (rebinding defence). `stdio` servers are confined to the plugin root (allowed launchers `node`/`bun` or a root-confined executable; required bundled script argument; no eval/loader flags; no env expansion).
 - **Hooks** run through a *constrained* API: only a handler for the declared event may be registered. `registerCommand`, `sendMessage`, `appendEntry`, renderer registration, and shell `exec` are denied (`security_policy`). The broad first-party hook API is never exposed to bundle hooks.
+- **Command hooks** (`command` instead of `path`) are the sanctioned seam for external governance/policy tools: GJC itself spawns the declared command (argv array, never a shell) with the event JSON on stdin and honors an optional `{"block":true,"reason":"..."}` verdict on stdout for `tool_call` (fail-closed: spawn error, timeout, non-zero exit, or unparseable output block the call; every other event is observe-only). The spawn spec passes the same confinement policy as `stdio` MCP servers (allowlisted `node`/`bun` launcher or root-confined executable, bundled script argument, no eval/loader flags, no env expansion), runs with a minimal no-inherit environment (no host secrets), inside the plugin root, under a self-deadline (`timeoutMs`, default 10 s, max 60 s). They additionally require explicit operator approval at install time (`--allow-command-hooks`); a bundle declaring command hooks fails install loudly without it, and un-approved surfaces quarantine at session load. A command hook may be target-less for `tool_call` so a governance gate can observe every tool call (matcher-less hooks, as in other agent runtimes); module hooks keep their required `target`/`phase` contract.
 - **Appendices** render as lower-authority, delimited `<gjc-plugin-system-appendix>` / `<gjc-plugin-agent-appendix>` blocks appended after the base/project prompt; size-capped (8 KiB/appendix, 32 KiB total) fail-closed; content is escaped and control-char sanitized. They can never override base/developer instructions.
 - **Hash drift**: installed files are re-verified against the registry at session start; any drift quarantines the plugin (`runtime_mismatch`).
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- GJC plugin bundles can now declare **command hooks** (`{ "event": "tool_call", "command": "bun", "args": ["hooks/gate.js"] }`): GJC spawns the declared, plugin-root-confined command with the event JSON on stdin and honors a `{block,reason}` verdict on stdout for `tool_call` (fail-closed on spawn error/timeout/non-zero exit/unparseable output; observe-only for all other events). Command hooks reuse the stdio-MCP subprocess confinement policy, run with a minimal no-inherit environment, and require explicit operator approval at install time via the new `gjc plugin install --allow-command-hooks` flag; module hooks and existing bundles are unaffected. This gives external governance/policy tools a sanctioned command seam instead of relying on module-scope `child_process` imports inside constrained hook modules.
+
 ## [0.9.2] - 2026-07-09
 ### Added
 

--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -45,6 +45,7 @@ export interface PluginCommandArgs {
 		force?: boolean;
 		dryRun?: boolean;
 		local?: boolean;
+		allowCommandHooks?: boolean;
 		enable?: string;
 		disable?: string;
 		set?: string;
@@ -110,6 +111,8 @@ export function parsePluginArgs(args: string[]): PluginCommandArgs | undefined {
 			result.flags.force = true;
 		} else if (arg === "--dry-run") {
 			result.flags.dryRun = true;
+		} else if (arg === "--allow-command-hooks") {
+			result.flags.allowCommandHooks = true;
 		} else if (arg === "-l" || arg === "--local") {
 			result.flags.local = true;
 		} else if (arg === "--user") {
@@ -359,6 +362,7 @@ async function handleInstall(
 		scope?: "user" | "project";
 		user?: boolean;
 		project?: boolean;
+		allowCommandHooks?: boolean;
 	},
 ): Promise<void> {
 	if (packages.length === 0) {
@@ -385,7 +389,12 @@ async function handleInstall(
 			}
 			const scope: "user" | "project" = flags.user ? "user" : "project";
 			try {
-				const res = await installGjcPluginBundle(spec, { scope, cwd: process.cwd(), force: flags.force });
+				const res = await installGjcPluginBundle(spec, {
+					scope,
+					cwd: process.cwd(),
+					force: flags.force,
+					allowCommandHooks: flags.allowCommandHooks,
+				});
 				if (flags.json) {
 					console.log(JSON.stringify({ name: res.entry.name, status: res.status, scope }, null, 2));
 				} else {
@@ -992,6 +1001,7 @@ ${chalk.bold("Options:")}
   --force          Overwrite without prompting (install)
   --scope <scope>  Install scope: user (default) or project (install name@marketplace)
   --dry-run        Preview changes without applying (install)
+  --allow-command-hooks  Approve a GJC plugin bundle's command hooks (subprocess spawn on hook events)
   -l, --local      Use project-local overrides
 
 ${chalk.bold("Examples:")}

--- a/packages/coding-agent/src/extensibility/gjc-plugins/command-hooks.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/command-hooks.ts
@@ -1,0 +1,204 @@
+import * as path from "node:path";
+import { logger } from "@gajae-code/utils";
+import type { Subprocess } from "bun";
+
+/**
+ * Command-hook runtime: GJC itself spawns the declared, root-confined command
+ * with the event JSON on stdin and reads an optional `{block,reason}` verdict
+ * from stdout. This is the sanctioned seam for external governance/policy
+ * tools; plugin hook modules never gain an exec capability (the constrained
+ * API keeps denying `exec`), and the spawn spec is validated by the same
+ * confinement policy as stdio MCP servers (mcp-policy.ts) plus an explicit
+ * install-time operator approval.
+ *
+ * Semantics (mirrors command hooks in other agent runtimes):
+ * - `tool_call`: fail-closed. Spawn error, timeout, non-zero exit, or
+ *   unparseable stdout all block the tool call. Empty stdout + exit 0 allows.
+ *   `{"block":true,"reason":"..."}` blocks with that reason.
+ * - every other event: observe-only. Output is discarded and failures are
+ *   logged; a command hook can never break non-enforcement events.
+ */
+
+export const COMMAND_HOOK_DEFAULT_TIMEOUT_MS = 10_000;
+
+export interface CommandHookSpec {
+	plugin: string;
+	name: string;
+	event: string;
+	command: string;
+	args?: string[];
+	timeoutMs?: number;
+	pluginRoot: string;
+}
+
+interface CommandHookSessionManagerLike {
+	getSessionId?: () => string;
+	getSessionFile?: () => string | undefined;
+}
+
+interface CommandHookContextLike {
+	cwd?: string;
+	sessionManager?: CommandHookSessionManagerLike;
+}
+
+interface CommandHookBlockVerdict {
+	block: true;
+	reason: string;
+}
+
+type CommandHookOutcome =
+	| { kind: "allow" }
+	| { kind: "block"; verdict: CommandHookBlockVerdict }
+	| { kind: "failure"; detail: string };
+
+/**
+ * Minimal environment for command-hook children. Parity with the no-inherit
+ * stdio MCP policy (runtime-mcp/transports/stdio.ts buildMinimalStdioEnv):
+ * only OS-level keys needed to locate/run an interpreter are copied from the
+ * host; API keys/tokens/secrets are withheld.
+ */
+function buildMinimalCommandHookEnv(): Record<string, string> {
+	const allow = [
+		"PATH",
+		"HOME",
+		"TMPDIR",
+		"TEMP",
+		"TMP",
+		"LANG",
+		"LC_ALL",
+		"LC_CTYPE",
+		"SHELL",
+		"USER",
+		"SystemRoot",
+		"SYSTEMROOT",
+		"PATHEXT",
+		"COMSPEC",
+		"WINDIR",
+	];
+	const env: Record<string, string> = {};
+	for (const key of allow) {
+		const value = Bun.env[key];
+		if (typeof value === "string") env[key] = value;
+	}
+	return env;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Bare allowlisted launchers stay bare (PATH lookup); paths resolve within the plugin root. */
+function resolveCommandArgv(spec: CommandHookSpec): string[] {
+	const head = spec.command.includes("/") ? path.resolve(spec.pluginRoot, spec.command) : spec.command;
+	return [head, ...(spec.args ?? [])];
+}
+
+function buildPayload(spec: CommandHookSpec, event: unknown, ctx: CommandHookContextLike | undefined): string {
+	const sessionId = ctx?.sessionManager?.getSessionId?.();
+	const sessionFile = ctx?.sessionManager?.getSessionFile?.();
+	return JSON.stringify({
+		event: spec.event,
+		plugin: spec.plugin,
+		hook: spec.name,
+		data: event ?? {},
+		session: {
+			id: typeof sessionId === "string" ? sessionId : "",
+			file: typeof sessionFile === "string" ? sessionFile : "",
+		},
+		cwd: typeof ctx?.cwd === "string" ? ctx.cwd : "",
+	});
+}
+
+async function runCommandHook(
+	spec: CommandHookSpec,
+	event: unknown,
+	ctx: CommandHookContextLike | undefined,
+): Promise<CommandHookOutcome> {
+	let payload: string;
+	try {
+		payload = buildPayload(spec, event, ctx);
+	} catch (error) {
+		return {
+			kind: "failure",
+			detail: `payload serialization: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+
+	const timeoutMs = spec.timeoutMs ?? COMMAND_HOOK_DEFAULT_TIMEOUT_MS;
+	let proc: Subprocess;
+	try {
+		proc = Bun.spawn({
+			cmd: resolveCommandArgv(spec),
+			cwd: spec.pluginRoot,
+			env: buildMinimalCommandHookEnv(),
+			stdin: Buffer.from(payload, "utf8"),
+			stdout: "pipe",
+			stderr: "ignore",
+		});
+	} catch (error) {
+		return { kind: "failure", detail: `spawn: ${error instanceof Error ? error.message : String(error)}` };
+	}
+
+	let timedOut = false;
+	const timer = setTimeout(() => {
+		timedOut = true;
+		try {
+			proc.kill();
+		} catch {
+			// already exited
+		}
+	}, timeoutMs);
+	try {
+		const [exitCode, stdout] = await Promise.all([
+			proc.exited,
+			proc.stdout instanceof ReadableStream ? new Response(proc.stdout).text() : Promise.resolve(""),
+		]);
+		if (timedOut) return { kind: "failure", detail: `timeout after ${timeoutMs}ms` };
+		if (exitCode !== 0) return { kind: "failure", detail: `exit code ${exitCode}` };
+		const out = stdout.trim();
+		if (!out) return { kind: "allow" };
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(out);
+		} catch {
+			return { kind: "failure", detail: "unparseable verdict on stdout" };
+		}
+		if (isRecord(parsed) && parsed.block === true) {
+			const reason =
+				typeof parsed.reason === "string" && parsed.reason.length > 0
+					? parsed.reason
+					: `blocked by plugin command hook "${spec.plugin}/${spec.name}"`;
+			return { kind: "block", verdict: { block: true, reason } };
+		}
+		return { kind: "allow" };
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/**
+ * Build the constrained-hook handler for a declared command hook. Verdicts are
+ * honored for `tool_call` only (fail-closed); every other event is
+ * observe-only and can never block.
+ */
+export function createCommandHookHandler(spec: CommandHookSpec): (...args: unknown[]) => Promise<unknown> {
+	return async (event: unknown, ctx?: unknown) => {
+		const outcome = await runCommandHook(spec, event, ctx as CommandHookContextLike | undefined);
+		if (spec.event !== "tool_call") {
+			if (outcome.kind === "failure") {
+				logger.warn(
+					`GJC plugin command hook "${spec.plugin}/${spec.name}" failed on ${spec.event} (observe-only): ${outcome.detail}`,
+				);
+			}
+			return undefined;
+		}
+		if (outcome.kind === "failure") {
+			return {
+				block: true,
+				reason: `Plugin command hook "${spec.plugin}/${spec.name}" failed (fail-closed): ${outcome.detail}`,
+			};
+		}
+		if (outcome.kind === "block") return outcome.verdict;
+		return undefined;
+	};
+}

--- a/packages/coding-agent/src/extensibility/gjc-plugins/compiler.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/compiler.ts
@@ -2,11 +2,13 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { parseFrontmatter, pathIsWithin } from "@gajae-code/utils";
+import { assertCommandHookAllowed } from "./mcp-policy";
 import { resolveWithinRoot } from "./paths";
 import { parseManifest, parseSubskillFrontmatter } from "./schema";
 import {
 	GJC_PLUGIN_MANIFEST_FILENAME,
 	type GjcPluginAppendixManifestEntry,
+	type GjcPluginHookManifestEntry,
 	GjcPluginLoadError,
 	type GjcPluginMcpManifestEntry,
 	type NormalizedAgentAppendixSurface,
@@ -96,6 +98,19 @@ async function hashFile(
 		throw new GjcPluginLoadError("hash_mismatch", `GJC plugin file hash mismatch for ${rel}`);
 	}
 	return { sha256: digest, bytes: buf.byteLength };
+}
+
+function commandHookConfigHash(hook: GjcPluginHookManifestEntry): string {
+	const canonical = JSON.stringify({
+		name: hook.name,
+		event: hook.event,
+		target: hook.target ?? null,
+		phase: hook.phase ?? null,
+		command: hook.command ?? null,
+		args: hook.args ?? null,
+		timeoutMs: hook.timeoutMs ?? null,
+	});
+	return sha256(canonical);
 }
 
 function mcpConfigHash(entry: GjcPluginMcpManifestEntry): string {
@@ -228,6 +243,42 @@ export async function compileGjcPluginBundle(root: string): Promise<NormalizedGj
 
 	const hooks: NormalizedHookSurface[] = [];
 	for (const hook of manifest.hooks) {
+		if (hook.command !== undefined) {
+			// Command hook: no factory module. Apply the same subprocess confinement
+			// policy stdio MCP servers get (pure check, no spawn), then hash any
+			// bundled script args so the copied-file boundary owns them.
+			assertCommandHookAllowed(hook, { pluginRoot });
+			for (const arg of hook.args ?? []) {
+				if (arg.startsWith("-")) continue;
+				if (!arg.startsWith(".") && !arg.includes("/")) continue;
+				const argAbs = await resolveDeclaredFile(pluginRoot, arg);
+				const { sha256: argDigest, bytes: argBytes } = await hashFile(argAbs, arg, undefined);
+				files.set(arg, { sha256: argDigest, bytes: argBytes });
+			}
+			const configHash = commandHookConfigHash(hook);
+			if (hook.sha256 !== undefined && hook.sha256.toLowerCase() !== configHash) {
+				throw new GjcPluginLoadError("hash_mismatch", `GJC plugin hook config hash mismatch for "${hook.name}"`);
+			}
+			// A governance command hook may be target-less: it then observes every
+			// tool_call (mirrors matcher-less hooks in other agent runtimes). The
+			// module-hook target/phase contract below stays unchanged.
+			hooks.push({
+				extensionId: surfaceIds.hook(hook.event, hook.phase, hook.target, hook.name),
+				name: hook.name,
+				event: hook.event,
+				target: hook.target,
+				phase: hook.phase,
+				command: hook.command,
+				args: hook.args,
+				timeoutMs: hook.timeoutMs,
+				sha256: configHash,
+			});
+			continue;
+		}
+		if (hook.path === undefined) {
+			// Unreachable after schema validation; kept as an honest guard.
+			throw new GjcPluginLoadError("invalid_hook", `GJC plugin hook "${hook.name}": missing path`);
+		}
 		// Path safety first: resolve/hash before semantic checks so traversal and
 		// missing-file failures take precedence over contract validation.
 		const abs = await resolveDeclaredFile(pluginRoot, hook.path);

--- a/packages/coding-agent/src/extensibility/gjc-plugins/constrained-hooks.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/constrained-hooks.ts
@@ -1,5 +1,7 @@
 import { logger } from "@gajae-code/utils";
 
+import { createCommandHookHandler } from "./command-hooks";
+import { assertCommandHookAllowed } from "./mcp-policy";
 import { loadEffectiveGjcPluginRegistry } from "./registry";
 import { type SessionQuarantine, validateSessionBundles, verifyEntryHashes } from "./session-validation";
 import { GjcPluginLoadError, type GjcPluginRegistryEntry } from "./types";
@@ -43,14 +45,63 @@ interface DeclaredHook {
 	relativePath: string;
 }
 
-function collectDeclaredHooks(entries: readonly GjcPluginRegistryEntry[]): DeclaredHook[] {
-	const out: DeclaredHook[] = [];
+function collectDeclaredHooks(entries: readonly GjcPluginRegistryEntry[]): {
+	declared: DeclaredHook[];
+	commandHooks: ConstrainedPluginHook[];
+	quarantine: SessionQuarantine[];
+} {
+	const declared: DeclaredHook[] = [];
+	const commandHooks: ConstrainedPluginHook[] = [];
+	const quarantine: SessionQuarantine[] = [];
 	for (const entry of entries) {
 		if (!entry.enabled) continue;
 		const disabled = new Set(entry.disabledSurfaceIds);
 		for (const h of entry.surfaces.hooks) {
 			if (disabled.has(h.extensionId)) continue;
-			out.push({
+			if (h.command !== undefined) {
+				// Command hooks spawn a subprocess; they activate ONLY when the
+				// operator approved them at install time (--allow-command-hooks).
+				if (entry.commandHooksApproved !== true) {
+					quarantine.push({
+						plugin: entry.name,
+						surfaceId: h.extensionId,
+						code: "security_policy",
+						message: `Command hook "${h.name}" is not approved; reinstall the plugin with --allow-command-hooks`,
+					});
+					continue;
+				}
+				// Re-apply the install-time confinement policy before any spawn
+				// (mirrors buildPluginMcpConfigs re-running assertMcpInstallPolicy).
+				try {
+					assertCommandHookAllowed(h, { pluginRoot: entry.pluginRoot });
+				} catch (error) {
+					quarantine.push({
+						plugin: entry.name,
+						surfaceId: h.extensionId,
+						code: "security_policy",
+						message: error instanceof Error ? error.message : String(error),
+					});
+					continue;
+				}
+				commandHooks.push({
+					plugin: entry.name,
+					event: h.event,
+					target: h.target,
+					phase: h.phase,
+					handler: createCommandHookHandler({
+						plugin: entry.name,
+						name: h.name,
+						event: h.event,
+						command: h.command,
+						args: h.args,
+						timeoutMs: h.timeoutMs,
+						pluginRoot: entry.pluginRoot,
+					}),
+				});
+				continue;
+			}
+			if (h.relativePath === undefined) continue; // malformed surface; nothing to import
+			declared.push({
 				plugin: entry.name,
 				event: h.event,
 				target: h.target,
@@ -59,7 +110,7 @@ function collectDeclaredHooks(entries: readonly GjcPluginRegistryEntry[]): Decla
 			});
 		}
 	}
-	return out;
+	return { declared, commandHooks, quarantine };
 }
 
 async function loadOneHook(
@@ -159,9 +210,10 @@ export async function loadConstrainedPluginHooks(input: { cwd: string }): Promis
 		if (drift) preQuarantine.push(drift);
 	}
 	const { active, quarantine } = validateSessionBundles(effective, {}, preQuarantine);
-	const declared = collectDeclaredHooks(active);
-	const hooks: ConstrainedPluginHook[] = [];
-	for (const d of declared) {
+	const collected = collectDeclaredHooks(active);
+	quarantine.push(...collected.quarantine);
+	const hooks: ConstrainedPluginHook[] = [...collected.commandHooks];
+	for (const d of collected.declared) {
 		const { hook, quarantine: q } = await loadOneHook(d);
 		if (hook) hooks.push(hook);
 		if (q) quarantine.push(q);

--- a/packages/coding-agent/src/extensibility/gjc-plugins/index.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/index.ts
@@ -1,4 +1,5 @@
 export * from "./activation";
+export * from "./command-hooks";
 export * from "./compiler";
 export * from "./constrained-hooks";
 export * from "./injection";

--- a/packages/coding-agent/src/extensibility/gjc-plugins/installer.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/installer.ts
@@ -27,6 +27,13 @@ export interface InstallGjcPluginOptions {
 	scope: GjcPluginScope;
 	cwd: string;
 	force?: boolean;
+	/**
+	 * Explicit operator approval for command hooks (subprocess-spawning hook
+	 * entries). Installing a bundle that declares command hooks without this
+	 * approval fails with security_policy; the hooks are never silently
+	 * activated or silently dropped.
+	 */
+	allowCommandHooks?: boolean;
 }
 
 export interface InstallGjcPluginResult {
@@ -277,6 +284,7 @@ function bundleToRegistryEntry(
 	scope: GjcPluginScope,
 	source: GjcPluginRegistrySource,
 	now: string,
+	commandHooksApproved: boolean,
 ): GjcPluginRegistryEntry {
 	return {
 		name: bundle.name,
@@ -292,6 +300,7 @@ function bundleToRegistryEntry(
 		copiedFiles: bundle.files,
 		surfaces: bundle.surfaces,
 		disabledSurfaceIds: [],
+		...(commandHooksApproved ? { commandHooksApproved: true } : {}),
 	};
 }
 
@@ -342,6 +351,16 @@ export async function installGjcPluginBundle(
 	try {
 		// 1. Compile + validate (never imports plugin code).
 		const bundle = await compileGjcPluginBundle(resolved.dir);
+		// Command hooks spawn a bundle-confined subprocess on hook events; that
+		// capability requires explicit operator approval at install time.
+		const commandHookNames = bundle.surfaces.hooks.filter(h => h.command !== undefined).map(h => h.name);
+		if (commandHookNames.length > 0 && !options.allowCommandHooks) {
+			throw new GjcPluginLoadError(
+				"security_policy",
+				`GJC plugin "${bundle.name}" declares command hook(s) [${commandHookNames.join(", ")}] that run a bundled subprocess on hook events; re-run install with --allow-command-hooks to approve`,
+			);
+		}
+		const commandHooksApproved = commandHookNames.length > 0 && options.allowCommandHooks === true;
 		const dirName = safeDirSegment(bundle.name);
 		const root = scopeRoot(options.scope, options.cwd);
 		const finalDir = path.join(root, dirName);
@@ -363,6 +382,7 @@ export async function installGjcPluginBundle(
 				options.scope,
 				resolved.source,
 				new Date().toISOString(),
+				commandHooksApproved,
 			);
 			if (existing) {
 				const sameContent = registryEntryFingerprint(existing) === registryEntryFingerprint(candidate);

--- a/packages/coding-agent/src/extensibility/gjc-plugins/mcp-policy.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/mcp-policy.ts
@@ -1,7 +1,7 @@
 import { lookup } from "node:dns/promises";
 import * as path from "node:path";
 import { pathIsWithin } from "@gajae-code/utils";
-import { GjcPluginLoadError, type GjcPluginMcpManifestEntry } from "./types";
+import { type GjcPluginHookManifestEntry, GjcPluginLoadError, type GjcPluginMcpManifestEntry } from "./types";
 
 /**
  * Shared MCP security policy applied at BOTH install validation and runtime
@@ -172,10 +172,22 @@ const DANGEROUS_LAUNCHER_FLAGS = [
 	"--input-type",
 ];
 
-/** stdio launcher/path confinement policy. */
-export function assertStdioAllowed(entry: GjcPluginMcpManifestEntry, ctx: StdioPolicyContext): void {
-	const command = entry.command ?? "";
-	if (!command) fail(`MCP "${entry.name}": stdio requires a command`);
+export interface ConfinedSpawnSpec {
+	command: string;
+	args?: string[];
+	cwd?: string;
+}
+
+/**
+ * Shared launcher/path confinement policy for every subprocess a third-party
+ * bundle may declare (stdio MCP servers and command hooks). Deny-first: the
+ * command must be a bare allowlisted launcher (node/bun) with a root-confined
+ * script argument, or an executable inside the plugin root; no eval/loader
+ * flags, no env expansion, cwd confined to the plugin root.
+ */
+export function assertConfinedSpawnAllowed(spec: ConfinedSpawnSpec, ctx: StdioPolicyContext, label: string): void {
+	const command = spec.command ?? "";
+	if (!command) fail(`${label} requires a command`);
 	const root = path.resolve(ctx.pluginRoot);
 	const base = path.basename(command);
 	const isBareLauncher = !command.includes("/") && ALLOWED_STDIO_LAUNCHERS.has(base);
@@ -183,44 +195,69 @@ export function assertStdioAllowed(entry: GjcPluginMcpManifestEntry, ctx: StdioP
 	// Absolute or relative paths must stay inside the plugin root; bare launchers
 	// must be in the allowlist. An absolute /bin/node is rejected (outside root).
 	if (!isBareLauncher && !isRootConfinedExecutable) {
-		fail(`MCP "${entry.name}": stdio command not allowed: ${command}`);
+		fail(`${label} command not allowed: ${command}`);
 	}
 	const usesNodeLauncher = isBareLauncher || ALLOWED_STDIO_LAUNCHERS.has(base);
-	const args = entry.args ?? [];
+	const args = spec.args ?? [];
 	// Reject code-eval/loader flags for node/bun launchers.
 	if (usesNodeLauncher) {
 		for (const arg of args) {
 			const flag = arg.split("=")[0];
 			if (DANGEROUS_LAUNCHER_FLAGS.includes(flag)) {
-				fail(`MCP "${entry.name}": stdio launcher flag not allowed: ${arg}`);
+				fail(`${label} launcher flag not allowed: ${arg}`);
 			}
 		}
 		// Require a root-confined script as the first non-flag argument.
 		const firstScript = args.find(a => !a.startsWith("-"));
 		if (!firstScript) {
-			fail(`MCP "${entry.name}": node/bun stdio launcher requires a bundled script argument`);
+			fail(`${label} node/bun launcher requires a bundled script argument`);
 		}
 		if (!pathIsWithin(root, path.resolve(root, firstScript))) {
-			fail(`MCP "${entry.name}": stdio script escapes plugin root: ${firstScript}`);
+			fail(`${label} script escapes plugin root: ${firstScript}`);
 		}
 	}
 	// cwd must resolve within the plugin root.
-	const cwd = entry.cwd ? path.resolve(root, entry.cwd) : root;
+	const cwd = spec.cwd ? path.resolve(root, spec.cwd) : root;
 	if (!pathIsWithin(root, cwd) && cwd !== root) {
-		fail(`MCP "${entry.name}": stdio cwd escapes plugin root: ${entry.cwd}`);
+		fail(`${label} cwd escapes plugin root: ${spec.cwd}`);
 	}
 	// File-like args must resolve within the plugin root; reject env-expansion.
 	for (const arg of args) {
 		if (/\$\{?[A-Za-z_]/.test(arg) || arg.includes("`") || arg.includes("$(")) {
-			fail(`MCP "${entry.name}": stdio arg expansion not allowed: ${arg}`);
+			fail(`${label} arg expansion not allowed: ${arg}`);
 		}
 		if (arg.startsWith("-")) continue;
 		if (!arg.startsWith(".") && !arg.includes("/")) continue;
 		const resolvedArg = path.resolve(root, arg);
 		if (!pathIsWithin(root, resolvedArg)) {
-			fail(`MCP "${entry.name}": stdio arg escapes plugin root: ${arg}`);
+			fail(`${label} arg escapes plugin root: ${arg}`);
 		}
 	}
+}
+
+/** stdio launcher/path confinement policy. */
+export function assertStdioAllowed(entry: GjcPluginMcpManifestEntry, ctx: StdioPolicyContext): void {
+	assertConfinedSpawnAllowed(
+		{ command: entry.command ?? "", args: entry.args, cwd: entry.cwd },
+		ctx,
+		`MCP "${entry.name}": stdio`,
+	);
+}
+
+/**
+ * Command-hook confinement policy: identical subprocess discipline to stdio MCP
+ * servers. Applied at compile/install time (pure) and re-applied at session
+ * load before any spawn.
+ */
+export function assertCommandHookAllowed(
+	hook: Pick<GjcPluginHookManifestEntry, "name" | "command" | "args">,
+	ctx: StdioPolicyContext,
+): void {
+	assertConfinedSpawnAllowed(
+		{ command: hook.command ?? "", args: hook.args },
+		ctx,
+		`plugin hook "${hook.name}": command`,
+	);
 }
 
 /**

--- a/packages/coding-agent/src/extensibility/gjc-plugins/registry.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/registry.ts
@@ -175,6 +175,10 @@ export function registryEntryFingerprint(entry: GjcPluginRegistryEntry): string 
 		name: entry.name,
 		manifestHash: entry.manifestHash,
 		files: entry.copiedFiles.map(f => [f.relativePath, f.sha256]).sort(),
+		// Approval participates so re-installing with --allow-command-hooks is
+		// never short-circuited as "unchanged"; undefined is dropped by
+		// JSON.stringify, keeping fingerprints stable for existing entries.
+		commandHooksApproved: entry.commandHooksApproved,
 	});
 	return createHash("sha256").update(canonical).digest("hex");
 }

--- a/packages/coding-agent/src/extensibility/gjc-plugins/schema.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/schema.ts
@@ -121,6 +121,9 @@ function parseTools(value: unknown, manifestPath: string): GjcPluginToolManifest
 	});
 }
 
+const COMMAND_HOOK_MAX_TIMEOUT_MS = 60_000;
+const COMMAND_HOOK_MIN_TIMEOUT_MS = 100;
+
 function parseHooks(value: unknown, manifestPath: string): GjcPluginHookManifestEntry[] {
 	const raw = optionalArray(value, "hooks", manifestPath);
 	return raw.map((entry, index) => {
@@ -132,7 +135,54 @@ function parseHooks(value: unknown, manifestPath: string): GjcPluginHookManifest
 		}
 		const name = manifestString(entry.name, `hooks[${index}].name`, manifestPath);
 		const event = manifestString(entry.event, `hooks[${index}].event`, manifestPath);
-		const path = manifestString(entry.path, `hooks[${index}].path`, manifestPath);
+		// Exactly one of `path` (module hook) or `command` (command hook).
+		const hasPath = entry.path !== undefined;
+		const hasCommand = entry.command !== undefined;
+		if (hasPath === hasCommand) {
+			throw new GjcPluginLoadError(
+				"invalid_manifest",
+				`Invalid GJC plugin manifest at ${manifestPath}: hooks[${index}] requires exactly one of "path" or "command"`,
+			);
+		}
+		const path = hasPath ? manifestString(entry.path, `hooks[${index}].path`, manifestPath) : undefined;
+		const command = hasCommand ? manifestString(entry.command, `hooks[${index}].command`, manifestPath) : undefined;
+		let args: string[] | undefined;
+		if (entry.args !== undefined) {
+			if (!hasCommand) {
+				throw new GjcPluginLoadError(
+					"invalid_manifest",
+					`Invalid GJC plugin manifest at ${manifestPath}: hooks[${index}].args requires "command"`,
+				);
+			}
+			if (!Array.isArray(entry.args) || !entry.args.every(item => typeof item === "string")) {
+				throw new GjcPluginLoadError(
+					"invalid_manifest",
+					`Invalid GJC plugin manifest at ${manifestPath}: hooks[${index}].args must be a string array`,
+				);
+			}
+			args = [...(entry.args as string[])];
+		}
+		let timeoutMs: number | undefined;
+		if (entry.timeoutMs !== undefined) {
+			if (!hasCommand) {
+				throw new GjcPluginLoadError(
+					"invalid_manifest",
+					`Invalid GJC plugin manifest at ${manifestPath}: hooks[${index}].timeoutMs requires "command"`,
+				);
+			}
+			if (
+				typeof entry.timeoutMs !== "number" ||
+				!Number.isInteger(entry.timeoutMs) ||
+				entry.timeoutMs < COMMAND_HOOK_MIN_TIMEOUT_MS ||
+				entry.timeoutMs > COMMAND_HOOK_MAX_TIMEOUT_MS
+			) {
+				throw new GjcPluginLoadError(
+					"invalid_manifest",
+					`Invalid GJC plugin manifest at ${manifestPath}: hooks[${index}].timeoutMs must be an integer between ${COMMAND_HOOK_MIN_TIMEOUT_MS} and ${COMMAND_HOOK_MAX_TIMEOUT_MS}`,
+				);
+			}
+			timeoutMs = entry.timeoutMs;
+		}
 		const target =
 			entry.target === undefined ? undefined : manifestString(entry.target, `hooks[${index}].target`, manifestPath);
 		let phase: "before" | "after" | undefined;
@@ -147,7 +197,7 @@ function parseHooks(value: unknown, manifestPath: string): GjcPluginHookManifest
 		}
 		const sha256 =
 			entry.sha256 === undefined ? undefined : manifestString(entry.sha256, `hooks[${index}].sha256`, manifestPath);
-		return { name, event, target, phase, path, sha256 };
+		return { name, event, target, phase, path, command, args, timeoutMs, sha256 };
 	});
 }
 

--- a/packages/coding-agent/src/extensibility/gjc-plugins/types.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/types.ts
@@ -37,7 +37,19 @@ export interface GjcPluginHookManifestEntry {
 	event: string;
 	target?: string;
 	phase?: "before" | "after";
-	path: string;
+	/** Module hook: bundled factory file (exactly one of `path` / `command`). */
+	path?: string;
+	/**
+	 * Command hook: root-confined executable or allowlisted launcher (node/bun)
+	 * spawned by GJC itself with the event JSON on stdin; a `{block,reason}`
+	 * verdict on stdout is honored for `tool_call`. Requires explicit install
+	 * approval (`--allow-command-hooks`).
+	 */
+	command?: string;
+	/** Extra argv entries for `command` (never shell-interpreted). */
+	args?: string[];
+	/** Self-deadline for `command` in ms (default 10000, max 60000). */
+	timeoutMs?: number;
 	sha256?: string;
 }
 
@@ -199,7 +211,13 @@ export interface NormalizedHookSurface {
 	event: string;
 	target?: string;
 	phase?: "before" | "after";
-	relativePath: string;
+	/** Present for module hooks only. */
+	relativePath?: string;
+	/** Present for command hooks only (see GjcPluginHookManifestEntry). */
+	command?: string;
+	args?: string[];
+	timeoutMs?: number;
+	/** Module hooks: file hash. Command hooks: canonical config hash. */
 	sha256: string;
 }
 
@@ -277,6 +295,12 @@ export interface GjcPluginRegistryEntry {
 	copiedFiles: GjcPluginCopiedFile[];
 	surfaces: NormalizedGjcPluginSurfaces;
 	disabledSurfaceIds: string[];
+	/**
+	 * True only when the operator approved this bundle's command hooks at
+	 * install time (`--allow-command-hooks`). Command hooks never activate
+	 * without it.
+	 */
+	commandHooksApproved?: boolean;
 	quarantine?: GjcPluginQuarantineEntry[];
 }
 

--- a/packages/coding-agent/test/gjc-plugin-command-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-command-hooks.test.ts
@@ -1,0 +1,361 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	createCommandHookHandler,
+	GjcPluginLoadError,
+	type GjcPluginLoadErrorCode,
+	type GjcPluginRegistry,
+	installGjcPluginBundle,
+	loadConstrainedPluginHooks,
+	parseManifest,
+} from "../src/extensibility/gjc-plugins";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	for (const d of tempDirs.splice(0)) await fs.rm(d, { recursive: true, force: true });
+});
+
+async function mkCwd(): Promise<string> {
+	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-cmdhooks-"));
+	tempDirs.push(cwd);
+	return cwd;
+}
+
+/** Verdict script: blocks `rm -rf /`, echoes session id for other bash input, silent otherwise. */
+const GATE_SCRIPT = `const chunks = [];
+process.stdin.on("data", c => chunks.push(c));
+process.stdin.on("end", () => {
+	let payload = {};
+	try {
+		payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+	} catch {}
+	const input = payload?.data?.input;
+	if (input?.command === "rm -rf /") {
+		process.stdout.write(JSON.stringify({ block: true, reason: "denied by policy" }));
+	} else if (input?.command === "echo session") {
+		process.stdout.write(JSON.stringify({ block: true, reason: "sid=" + payload.session.id }));
+	} else if (input?.command === "echo env") {
+		process.stdout.write(JSON.stringify({ block: true, reason: "secret=" + (process.env.GJC_TEST_SECRET ?? "unset") }));
+	}
+	process.exit(0);
+});
+`;
+
+async function bundleWithCommandHook(over?: { hook?: Record<string, unknown>; script?: string }): Promise<string> {
+	const src = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-cmdhooksrc-"));
+	tempDirs.push(src);
+	await fs.mkdir(path.join(src, "hooks"), { recursive: true });
+	await fs.writeFile(path.join(src, "hooks", "gate.js"), over?.script ?? GATE_SCRIPT);
+	await fs.writeFile(
+		path.join(src, "gajae-plugin.json"),
+		JSON.stringify({
+			kind: "gajae-code-plugin",
+			name: "command-hook-bundle",
+			version: "1.0.0",
+			hooks: [over?.hook ?? { name: "gate", event: "tool_call", command: "bun", args: ["hooks/gate.js"] }],
+		}),
+	);
+	return src;
+}
+
+function expectLoadError(fn: () => unknown, code: GjcPluginLoadErrorCode): void {
+	try {
+		fn();
+	} catch (error) {
+		expect(error).toBeInstanceOf(GjcPluginLoadError);
+		expect((error as GjcPluginLoadError).code).toBe(code);
+		return;
+	}
+	throw new Error(`Expected ${code} load error`);
+}
+
+async function expectAsyncLoadError(fn: () => Promise<unknown>, code: GjcPluginLoadErrorCode): Promise<void> {
+	try {
+		await fn();
+	} catch (error) {
+		expect(error).toBeInstanceOf(GjcPluginLoadError);
+		expect((error as GjcPluginLoadError).code).toBe(code);
+		return;
+	}
+	throw new Error(`Expected ${code} load error`);
+}
+
+function manifestWithHook(hook: Record<string, unknown>): Record<string, unknown> {
+	return { kind: "gajae-code-plugin", name: "m", version: "1.0.0", hooks: [hook] };
+}
+
+describe("GJC plugin command hooks: manifest schema", () => {
+	test("rejects a hook with both path and command", () => {
+		expectLoadError(
+			() =>
+				parseManifest(
+					manifestWithHook({ name: "h", event: "tool_call", path: "hooks/h.ts", command: "bun" }),
+					"/p/gajae-plugin.json",
+				),
+			"invalid_manifest",
+		);
+	});
+
+	test("rejects a hook with neither path nor command", () => {
+		expectLoadError(
+			() => parseManifest(manifestWithHook({ name: "h", event: "tool_call" }), "/p/gajae-plugin.json"),
+			"invalid_manifest",
+		);
+	});
+
+	test("rejects args without command", () => {
+		expectLoadError(
+			() =>
+				parseManifest(
+					manifestWithHook({ name: "h", event: "tool_call", path: "hooks/h.ts", args: ["x"] }),
+					"/p/gajae-plugin.json",
+				),
+			"invalid_manifest",
+		);
+	});
+
+	test("rejects timeoutMs out of bounds", () => {
+		for (const timeoutMs of [0, 99, 60_001, 1.5]) {
+			expectLoadError(
+				() =>
+					parseManifest(
+						manifestWithHook({ name: "h", event: "tool_call", command: "bun", args: ["h.js"], timeoutMs }),
+						"/p/gajae-plugin.json",
+					),
+				"invalid_manifest",
+			);
+		}
+	});
+
+	test("accepts a target-less command hook (governance hooks observe every tool call)", () => {
+		const manifest = parseManifest(
+			manifestWithHook({ name: "h", event: "tool_call", command: "bun", args: ["h.js"], timeoutMs: 5000 }),
+			"/p/gajae-plugin.json",
+		);
+		expect(manifest.hooks[0]?.command).toBe("bun");
+		expect(manifest.hooks[0]?.target).toBeUndefined();
+	});
+});
+
+describe("GJC plugin command hooks: confinement policy at install", () => {
+	test("denies a command outside the plugin root", async () => {
+		const cwd = await mkCwd();
+		const src = await bundleWithCommandHook({
+			hook: { name: "gate", event: "tool_call", command: "/bin/sh", args: ["hooks/gate.js"] },
+		});
+		await expectAsyncLoadError(
+			() => installGjcPluginBundle(src, { scope: "project", cwd, allowCommandHooks: true }),
+			"security_policy",
+		);
+	});
+
+	test("denies script args escaping the plugin root", async () => {
+		const cwd = await mkCwd();
+		const src = await bundleWithCommandHook({
+			hook: { name: "gate", event: "tool_call", command: "bun", args: ["../../etc/gate.js"] },
+		});
+		await expectAsyncLoadError(
+			() => installGjcPluginBundle(src, { scope: "project", cwd, allowCommandHooks: true }),
+			"security_policy",
+		);
+	});
+
+	test("denies env expansion and eval flags in args", async () => {
+		const cwd = await mkCwd();
+		for (const args of [[`$${"{HOME}"}/gate.js`], ["-e", "hooks/gate.js"]]) {
+			const src = await bundleWithCommandHook({
+				hook: { name: "gate", event: "tool_call", command: "bun", args },
+			});
+			await expectAsyncLoadError(
+				() => installGjcPluginBundle(src, { scope: "project", cwd, allowCommandHooks: true }),
+				"security_policy",
+			);
+		}
+	});
+});
+
+describe("GJC plugin command hooks: install-time approval", () => {
+	test("install without --allow-command-hooks fails loudly", async () => {
+		const cwd = await mkCwd();
+		const src = await bundleWithCommandHook();
+		try {
+			await installGjcPluginBundle(src, { scope: "project", cwd });
+			throw new Error("expected security_policy");
+		} catch (error) {
+			expect(error).toBeInstanceOf(GjcPluginLoadError);
+			expect((error as GjcPluginLoadError).code).toBe("security_policy");
+			expect((error as GjcPluginLoadError).message).toContain("--allow-command-hooks");
+		}
+	});
+
+	test("install with approval records commandHooksApproved and pins the script", async () => {
+		const cwd = await mkCwd();
+		const src = await bundleWithCommandHook();
+		const res = await installGjcPluginBundle(src, { scope: "project", cwd, allowCommandHooks: true });
+		expect(res.status).toBe("installed");
+		expect(res.entry.commandHooksApproved).toBe(true);
+		expect(res.entry.copiedFiles.some(f => f.relativePath === "hooks/gate.js")).toBe(true);
+		const surface = res.entry.surfaces.hooks[0];
+		expect(surface?.command).toBe("bun");
+		expect(surface?.relativePath).toBeUndefined();
+	});
+
+	test("module-hook-only bundles never record approval", async () => {
+		const cwd = await mkCwd();
+		const src = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-cmdhooksrc-"));
+		tempDirs.push(src);
+		await fs.mkdir(path.join(src, "hooks"), { recursive: true });
+		await fs.writeFile(
+			path.join(src, "hooks", "h.ts"),
+			"export default function(api){ api.on('tool_call', ()=>({})); }\n",
+		);
+		await fs.writeFile(
+			path.join(src, "gajae-plugin.json"),
+			JSON.stringify({
+				kind: "gajae-code-plugin",
+				name: "module-hook-bundle",
+				version: "1.0.0",
+				hooks: [{ name: "h", event: "tool_call", target: "read", phase: "before", path: "hooks/h.ts" }],
+			}),
+		);
+		const res = await installGjcPluginBundle(src, { scope: "project", cwd, allowCommandHooks: true });
+		expect(res.entry.commandHooksApproved).toBeUndefined();
+	});
+});
+
+describe("GJC plugin command hooks: session load", () => {
+	test("approved command hooks load with a spawn-backed handler", async () => {
+		const cwd = await mkCwd();
+		const src = await bundleWithCommandHook();
+		await installGjcPluginBundle(src, { scope: "project", cwd, allowCommandHooks: true });
+		const res = await loadConstrainedPluginHooks({ cwd });
+		expect(res.quarantine).toHaveLength(0);
+		expect(res.hooks).toHaveLength(1);
+		expect(res.hooks[0]?.event).toBe("tool_call");
+		expect(typeof res.hooks[0]?.handler).toBe("function");
+	});
+
+	test("stripping approval from the registry quarantines the hook (fail-visible)", async () => {
+		const cwd = await mkCwd();
+		const src = await bundleWithCommandHook();
+		await installGjcPluginBundle(src, { scope: "project", cwd, allowCommandHooks: true });
+		const registryPath = path.join(cwd, ".gjc", "gjc-plugins", "registry.json");
+		const registry = JSON.parse(await fs.readFile(registryPath, "utf8")) as GjcPluginRegistry;
+		for (const p of registry.plugins) delete (p as { commandHooksApproved?: boolean }).commandHooksApproved;
+		await fs.writeFile(registryPath, JSON.stringify(registry, null, 2));
+		const res = await loadConstrainedPluginHooks({ cwd });
+		expect(res.hooks).toHaveLength(0);
+		expect(res.quarantine.some(q => q.code === "security_policy")).toBe(true);
+	});
+});
+
+describe("GJC plugin command hooks: runtime verdicts", () => {
+	async function loadedGateHandler(cwd: string): Promise<(...args: unknown[]) => unknown> {
+		const src = await bundleWithCommandHook();
+		await installGjcPluginBundle(src, { scope: "project", cwd, allowCommandHooks: true });
+		const res = await loadConstrainedPluginHooks({ cwd });
+		const handler = res.hooks[0]?.handler;
+		if (!handler) throw new Error("gate handler did not load");
+		return handler;
+	}
+
+	const ctx = {
+		cwd: "/workspace",
+		sessionManager: { getSessionId: () => "sess-1", getSessionFile: () => "/tmp/sess-1.jsonl" },
+	};
+
+	test("honors a block verdict and allows otherwise (end to end through install + load)", async () => {
+		const cwd = await mkCwd();
+		const handler = await loadedGateHandler(cwd);
+		const blocked = (await handler(
+			{ type: "tool_call", toolName: "bash", toolCallId: "t1", input: { command: "rm -rf /" } },
+			ctx,
+		)) as { block?: boolean; reason?: string } | undefined;
+		expect(blocked?.block).toBe(true);
+		expect(blocked?.reason).toBe("denied by policy");
+		const allowed = await handler(
+			{ type: "tool_call", toolName: "bash", toolCallId: "t2", input: { command: "ls" } },
+			ctx,
+		);
+		expect(allowed).toBeUndefined();
+	});
+
+	test("delivers the event envelope (session id) on stdin", async () => {
+		const cwd = await mkCwd();
+		const handler = await loadedGateHandler(cwd);
+		const res = (await handler(
+			{ type: "tool_call", toolName: "bash", toolCallId: "t3", input: { command: "echo session" } },
+			ctx,
+		)) as { reason?: string };
+		expect(res?.reason).toBe("sid=sess-1");
+	});
+
+	test("withholds host env from the hook subprocess", async () => {
+		const cwd = await mkCwd();
+		process.env.GJC_TEST_SECRET = "leaky";
+		try {
+			const handler = await loadedGateHandler(cwd);
+			const res = (await handler(
+				{ type: "tool_call", toolName: "bash", toolCallId: "t4", input: { command: "echo env" } },
+				ctx,
+			)) as { reason?: string };
+			expect(res?.reason).toBe("secret=unset");
+		} finally {
+			delete process.env.GJC_TEST_SECRET;
+		}
+	});
+
+	function directHandler(root: string, over?: { event?: string; timeoutMs?: number; script?: string }) {
+		return createCommandHookHandler({
+			plugin: "p",
+			name: "gate",
+			event: over?.event ?? "tool_call",
+			command: "bun",
+			args: ["gate.js"],
+			timeoutMs: over?.timeoutMs,
+			pluginRoot: root,
+		});
+	}
+
+	async function scriptRoot(script: string): Promise<string> {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-cmdhookrt-"));
+		tempDirs.push(root);
+		await fs.writeFile(path.join(root, "gate.js"), script);
+		return root;
+	}
+
+	test("fail-closed: non-zero exit blocks tool_call", async () => {
+		const root = await scriptRoot("process.exit(3);\n");
+		const res = (await directHandler(root)({ type: "tool_call", toolName: "bash" }, ctx)) as {
+			block?: boolean;
+			reason?: string;
+		};
+		expect(res?.block).toBe(true);
+		expect(res?.reason).toContain("fail-closed");
+	});
+
+	test("fail-closed: unparseable stdout blocks tool_call", async () => {
+		const root = await scriptRoot('process.stdout.write("not json"); process.exit(0);\n');
+		const res = (await directHandler(root)({ type: "tool_call", toolName: "bash" }, ctx)) as { block?: boolean };
+		expect(res?.block).toBe(true);
+	});
+
+	test("fail-closed: timeout blocks tool_call", async () => {
+		const root = await scriptRoot("setTimeout(() => process.exit(0), 3_600_000);\n");
+		const res = (await directHandler(root, { timeoutMs: 300 })({ type: "tool_call", toolName: "bash" }, ctx)) as {
+			block?: boolean;
+			reason?: string;
+		};
+		expect(res?.block).toBe(true);
+		expect(res?.reason).toContain("timeout");
+	});
+
+	test("observe-only events never block, even on failure", async () => {
+		const root = await scriptRoot("process.exit(3);\n");
+		const res = await directHandler(root, { event: "session_start" })({ reason: "startup" }, ctx);
+		expect(res).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Proposal: sanctioned command hooks for GJC plugin bundles (opt-in, operator-approved)

Hi! This is a draft proposal PR — happy to rework any of it to fit your plans for the plugin-bundle system, or to close it if you have a different direction in mind for this seam.

### Motivation

We build an external governance/policy tool (a control plane that gates agent tool calls across several agent runtimes). To govern gjc sessions we attach through the gjc-plugin bundle `tool_call` hook — which works great: the constrained loader, hash pinning, and the runner's exception-to-block conversion give exactly the fail-closed semantics a policy gate needs.

The one wart: the constrained hook API (rightly) denies `exec`, so a hook that needs an out-of-process verdict has to import `node:child_process` at module scope inside the hook module. That works today, but it sits outside the sanctioned API surface, and if plugin hook modules are ever sandboxed (worker isolation, import allowlist), every governed tool call would fail closed with no upstream-visible contract having changed.

This PR proposes the sanctioned alternative: a **declarative command hook**, where **gjc itself** spawns the verdict process. Bundles can declare:

```json
{
  "hooks": [
    { "name": "policy-gate", "event": "tool_call", "command": "bun", "args": ["hooks/gate.js"], "timeoutMs": 10000 }
  ]
}
```

gjc spawns the command (argv array, never a shell) with the event JSON on stdin and honors an optional `{"block":true,"reason":"..."}` verdict on stdout for `tool_call`. This is the same shape gjc already speaks elsewhere: it emits Codex-managed command hooks (`hooks/codex-native-hooks-config.ts`) and acts as a native Claude Code command hook (`hooks/native-skill-hook.ts`) — this just makes the bundle hook surface symmetric with that vocabulary.

### Security scoping (the important part)

The design goal was: **no new capability class, and nothing changes for ordinary plugins.**

1. **Same confinement policy as stdio MCP servers.** Bundles can already spawn subprocesses — stdio MCP servers — under the deny-first policy in `mcp-policy.ts`. Command hooks pass the *identical* policy (shared via a new `assertConfinedSpawnAllowed` core; `assertStdioAllowed` delegates to it unchanged): allowlisted bare `node`/`bun` launcher or root-confined executable, required bundled script argument, no eval/loader flags, no env expansion, cwd confined to the plugin root. The policy is applied at compile/install time and re-applied at session load before any spawn (mirroring `buildPluginMcpConfigs` re-running `assertMcpInstallPolicy`).
2. **Explicit operator approval at install.** Because a `tool_call` command hook runs automatically on every tool call (unlike an MCP server, which runs when the model calls its tools), it is gated harder than MCP: `gjc plugin install --allow-command-hooks` is required, installs fail loudly with `security_policy` otherwise (never silently dropped or silently activated), the approval is recorded on the registry entry, participates in the install fingerprint, and is re-checked at session load — un-approved surfaces quarantine visibly.
3. **Minimal no-inherit environment.** The child gets the same OS-essentials-only env as `noInheritEnv` stdio MCP servers (PATH/HOME/temp/locale); host secrets are withheld.
4. **Fail-closed, self-deadlined.** For `tool_call`: spawn error, timeout (`timeoutMs`, default 10s, max 60s), non-zero exit, or unparseable stdout all block the call — matching the runner's existing exception-to-block posture. Since the extension runner imposes no timeout on `tool_call` handlers, the built-in deadline also means a hung verdict process can no longer hang the session (an improvement over what an in-module `spawnSync` escape can guarantee). Every other event is observe-only and can never block.
5. **Constrained module hooks untouched.** `exec` and the other denied API methods stay denied; the module-hook `tool_call` target/phase contract is unchanged; bundles that declare no command hook are byte-for-byte unaffected.
6. **Hash integrity preserved.** Bundled script args are hashed into `copiedFiles` (drift quarantines, as today); the command config itself is pinned by the manifest hash plus a canonical config hash stored as the surface `sha256`.

One deliberate, reviewable decision: a **command** hook may be target-less for `tool_call` so a governance gate can observe every tool call (matcher-less hooks, as in the other runtimes' hook systems). Module hooks keep their required `target` + `phase`. If you would rather require an explicit `"target": "*"` opt-in for that, happy to change it.

### What this is NOT

- Not an exec grant to marketplace/npm plugins (different plugin family, untouched).
- Not a change to default behavior: no flag, no command hooks, no new spawns.
- Not a shell surface: argv arrays only, no interpolation, expansion rejected at install.

### Changes

- `gjc-plugins/types.ts`, `schema.ts` — hook entries accept exactly one of `path` / `command` (+ `args`, `timeoutMs` with bounds validation).
- `gjc-plugins/mcp-policy.ts` — extracted `assertConfinedSpawnAllowed` shared core + `assertCommandHookAllowed`; `assertStdioAllowed` behavior unchanged.
- `gjc-plugins/compiler.ts` — command-hook compile branch (policy check, script-arg hashing, config hash).
- `gjc-plugins/installer.ts`, `registry.ts` — `allowCommandHooks` install option, `commandHooksApproved` registry field, fingerprint participation (stable for existing entries).
- `gjc-plugins/constrained-hooks.ts` — approved command surfaces load as spawn-backed handlers (no module import); un-approved quarantine.
- `gjc-plugins/command-hooks.ts` (new) — the spawn/verdict runtime.
- `cli/plugin-cli.ts` — `--allow-command-hooks` flag + help.
- `docs/gjc-plugins.md`, `CHANGELOG.md`, and a new test file (20 tests: schema XOR/bounds, confinement denials, approval flow, registry-tamper quarantine, end-to-end verdicts through install + load, stdin envelope, env withholding, fail-closed exit/parse/timeout, observe-only events).

### Verification

- `bun test` — 20 new tests pass; all 27 existing plugin suites pass (186/186 relevant; the one unrelated `plugin-command.test.ts` list test fails identically on unmodified `main` in my environment).
- `bun run check` in `packages/coding-agent` — biome + `tsgo` clean.

Thanks for the thoughtful plugin sandbox design — the compile-never-imports / registry-as-authority / quarantine model made this straightforward to slot into. Feedback very welcome; marked as draft until you have had a chance to weigh in on the approach.
