### PR TITLE
Hide invalid Antigravity Gemini 3.1 Pro high selector

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Hid the non-callable `google-antigravity/gemini-3.1-pro-high` selector from bundled and dynamic Antigravity catalogs after live Cloud Code Assist calls returned HTTP 400; `google-antigravity/gemini-3.1-pro-low:high` remains the working high-thinking path.
+
 ## [0.9.2] - 2026-07-09
 ### Added
 

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -63,9 +63,10 @@ function createAzureOpenAICatalogModels(): Model<"azure-openai-responses">[] {
 }
 
 const packageRoot = path.join(import.meta.dir, "..");
-// Claude Fable 5 was temporarily retired during its June 2026 suspension; it
-// was redeployed on 2026-07-01, so no models are currently retired.
-const RETIRED_BUNDLED_MODEL_KEYS = new Set<string>();
+// Antigravity advertises gemini-3.1-pro-high, but Cloud Code Assist rejects it
+// at request time. Retire the bundled entry so the TUI/catalog does not present
+// a selector that cannot complete; gemini-3.1-pro-low:high remains callable.
+const RETIRED_BUNDLED_MODEL_KEYS = new Set<string>(["google-antigravity/gemini-3.1-pro-high"]);
 
 function isRetiredBundledModel(model: Pick<Model, "provider" | "id">): boolean {
 	return RETIRED_BUNDLED_MODEL_KEYS.has(`${model.provider}/${model.id}`);

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -13,6 +13,7 @@ import { isClaudeForcedToolChoiceIncapableModelId } from "./utils/tool-choice-ca
  */
 const providerNames = Object.keys(MODELS) as KnownProvider[];
 const providerModelRegistry: Map<string, Map<string, Model<Api>>> = new Map();
+const RETIRED_BUNDLED_MODEL_KEYS = new Set(["google-antigravity/gemini-3.1-pro-high"]);
 
 function getProviderModels(provider: GeneratedProvider): Map<string, Model<Api>> | undefined {
 	const cached = providerModelRegistry.get(provider);
@@ -21,6 +22,9 @@ function getProviderModels(provider: GeneratedProvider): Map<string, Model<Api>>
 	if (!models) return undefined;
 	const providerModels = new Map<string, Model<Api>>();
 	for (const [id, model] of Object.entries(models)) {
+		if (RETIRED_BUNDLED_MODEL_KEYS.has(`${provider}/${id}`)) {
+			continue;
+		}
 		providerModels.set(id, applyBundledCompatDefaults(enrichModelThinking(model as Model<Api>)));
 	}
 	providerModelRegistry.set(provider, providerModels);

--- a/packages/ai/src/utils/discovery/antigravity.ts
+++ b/packages/ai/src/utils/discovery/antigravity.ts
@@ -1,7 +1,6 @@
 import * as z from "zod/v4";
 import { getAntigravityUserAgent } from "../../providers/google-gemini-headers";
 import type { Model } from "../../types";
-import { toPositiveNumber } from "../../utils";
 
 const DEFAULT_ANTIGRAVITY_DISCOVERY_ENDPOINTS = [
 	"https://daily-cloudcode-pa.googleapis.com",
@@ -11,10 +10,13 @@ const FETCH_AVAILABLE_MODELS_PATH = "/v1internal:fetchAvailableModels";
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 const DEFAULT_MAX_TOKENS = 64_000;
+// Antigravity advertises this selector, but Cloud Code Assist rejects live calls
+// with HTTP 400. Keep the callable high-thinking path as gemini-3.1-pro-low:high.
 const ANTIGRAVITY_DISCOVERY_DENYLIST = new Set([
 	"chat_20706",
 	"chat_23310",
 	"gemini-2.5-flash-thinking",
+	"gemini-3.1-pro-high",
 	"gemini-3-pro-low",
 	"gemini-2.5-pro",
 ]);
@@ -254,6 +256,13 @@ function parseAntigravityDiscoveryResponse(value: unknown): AntigravityDiscovery
 		return null;
 	}
 	return parsed.data;
+}
+
+function toPositiveNumber(value: unknown, fallback: number): number {
+	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+		return fallback;
+	}
+	return value;
 }
 
 function trimTrailingSlashes(value: string): string {

--- a/packages/ai/test/antigravity-discovery.test.ts
+++ b/packages/ai/test/antigravity-discovery.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { fetchAntigravityDiscoveryModels } from "../src/utils/discovery/antigravity";
+
+describe("Antigravity model discovery", () => {
+	it("filters the advertised but non-callable gemini-3.1-pro-high selector", async () => {
+		const fetcher = (async () =>
+			new Response(
+				JSON.stringify({
+					models: {
+						"gemini-3.1-pro-high": {
+							displayName: "Gemini 3.1 Pro (High)",
+							supportsImages: true,
+							supportsThinking: true,
+							maxTokens: 1_048_576,
+							maxOutputTokens: 65_535,
+						},
+						"gemini-3.1-pro-low": {
+							displayName: "Gemini 3.1 Pro (Low)",
+							supportsImages: true,
+							supportsThinking: true,
+							maxTokens: 1_048_576,
+							maxOutputTokens: 65_535,
+						},
+					},
+				}),
+				{ headers: { "content-type": "application/json" } },
+			)) as unknown as typeof fetch;
+
+		const models = await fetchAntigravityDiscoveryModels({
+			token: "test-token",
+			endpoint: "https://antigravity.example.test",
+			fetcher,
+		});
+
+		expect(models?.map(model => model.id)).toEqual(["gemini-3.1-pro-low"]);
+	});
+});


### PR DESCRIPTION
## Summary
- Hide `google-antigravity/gemini-3.1-pro-high` from runtime bundled model enumeration.
- Filter the same selector from Antigravity dynamic discovery responses.
- Keep `google-antigravity/gemini-3.1-pro-low:high` as the callable high-thinking path and add a regression test.

## Why
The model catalog/TUI can currently present `google-antigravity/gemini-3.1-pro-high` as selectable even though live Cloud Code Assist calls reject it. That makes the model picker look like "Gemini high-high" is usable and is easy to misconfigure.

Live repro on 2026-07-09 KST with gjc 0.9.1:

```text
gjc -p --no-session --no-tools --model google-antigravity/gemini-3.1-pro-high "Reply exactly: OK"
# Cloud Code Assist API error (400): Request contains an invalid argument.

gjc -p --no-session --no-tools --model google-antigravity/gemini-3.1-pro-high:high "Reply exactly: OK"
# Cloud Code Assist API error (400): Request contains an invalid argument.

gjc -p --no-session --no-tools --model google-antigravity/gemini-3.1-pro-low:high "Reply exactly: OK"
# OK
```

This matches the existing upstream guidance in `docs/multi-vendor-profiles.md`, which already says Antigravity high reasoning should use `google-antigravity/gemini-3.1-pro-low:high` because `gemini-3.1-pro-high` returns HTTP 400.

## Verification
- `bun test packages/ai/test/antigravity-discovery.test.ts`
- `bun --cwd=packages/ai run check`

Not run successfully here:
- `bun --cwd=packages/ai run generate-models` is blocked in this checkout because the native addon is absent and local Rust/Cargo is unavailable (`Failed to load pi_natives native addon`, then `cargo: command not found` while trying to build it). The generator source is updated so the next normal regeneration retires the bundled entry.
