### PR TITLE
Hide invalid Antigravity Gemini 3.1 Pro high selector

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 - Added runtime credential selectors so callers can pin stored multi-account credentials by id, email, account id, or project id instead of using automatic rotation/ranking.
 
+### Fixed
+
+- Hid the non-callable `google-antigravity/gemini-3.1-pro-high` selector from bundled, dynamic, and cached Antigravity catalogs after live Cloud Code Assist calls returned HTTP 400; `google-antigravity/gemini-3.1-pro-low:high` remains the working high-thinking path.
+
 ## [0.9.1] - 2026-07-08
 
 ### Fixed

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -13,6 +13,7 @@ import * as path from "node:path";
 import { $env } from "@gajae-code/utils";
 import { AuthStorage, type OAuthAccess, SqliteAuthCredentialStore } from "../src/auth-storage";
 import { createModelManager } from "../src/model-manager";
+import { RETIRED_MODEL_KEYS } from "../src/model-retirements";
 import {
 	applyGeneratedModelPolicies,
 	CLOUDFLARE_FALLBACK_MODEL,
@@ -63,9 +64,8 @@ function createAzureOpenAICatalogModels(): Model<"azure-openai-responses">[] {
 }
 
 const packageRoot = path.join(import.meta.dir, "..");
-// Claude Fable 5 was temporarily retired during its June 2026 suspension; it
-// was redeployed on 2026-07-01, so no models are currently retired.
-const RETIRED_BUNDLED_MODEL_KEYS = new Set<string>();
+// Keep retired selectors out of regenerated bundled catalogs.
+const RETIRED_BUNDLED_MODEL_KEYS = new Set<string>(RETIRED_MODEL_KEYS);
 
 function isRetiredBundledModel(model: Pick<Model, "provider" | "id">): boolean {
 	return RETIRED_BUNDLED_MODEL_KEYS.has(`${model.provider}/${model.id}`);

--- a/packages/ai/src/model-cache.ts
+++ b/packages/ai/src/model-cache.ts
@@ -3,7 +3,7 @@
  * Replaces per-provider JSON files with a single cache.db.
  */
 import { Database } from "bun:sqlite";
-import { getModelDbPath } from "@gajae-code/utils";
+import { getModelDbPath } from "@gajae-code/utils/dirs";
 import type { Api, Model } from "./types";
 
 const CACHE_SCHEMA_VERSION = 3;

--- a/packages/ai/src/model-manager.ts
+++ b/packages/ai/src/model-manager.ts
@@ -1,8 +1,8 @@
 import { readModelCache, writeModelCache } from "./model-cache";
+import { isRetiredModel, isRetiredModelKey } from "./model-retirements";
 import { applyGeneratedModelPolicies, enrichModelThinking } from "./model-thinking";
 import { type GeneratedProvider, getBundledModels } from "./models";
 import type { Api, Model, Provider } from "./types";
-import { isRecord } from "./utils";
 
 const DEFAULT_CACHE_TTL_MS = 2 * 60 * 60 * 1000;
 const NON_AUTHORITATIVE_RETRY_MS = 5 * 60 * 1000;
@@ -85,7 +85,14 @@ function passModelList<TApi extends Api>(value: unknown): Model<TApi>[] {
 	}
 	const out: Model<TApi>[] = [];
 	for (const item of value) {
-		if (item === null || typeof item !== "object" || typeof (item as { id: unknown }).id !== "string") {
+		if (item === null || typeof item !== "object") {
+			continue;
+		}
+		const candidate = item as { id?: unknown; provider?: unknown };
+		if (typeof candidate.id !== "string") {
+			continue;
+		}
+		if (typeof candidate.provider === "string" && isRetiredModelKey(candidate.provider, candidate.id)) {
 			continue;
 		}
 		out.push(enrichModelThinking(item as Model<TApi>));
@@ -382,7 +389,7 @@ function normalizeModelList<TApi extends Api>(value: unknown): Model<TApi>[] {
 	}
 	const models: Model<TApi>[] = [];
 	for (const item of value) {
-		if (isModelLike(item)) {
+		if (isModelLike(item) && !isRetiredModel(item)) {
 			models.push(enrichModelThinking(item as Model<TApi>));
 		}
 	}
@@ -439,6 +446,10 @@ function isModelLike(value: unknown): value is Model<Api> {
 		return false;
 	}
 	return true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
 }
 
 function isModelInputArray(value: unknown): value is ("text" | "image")[] {

--- a/packages/ai/src/model-retirements.ts
+++ b/packages/ai/src/model-retirements.ts
@@ -1,0 +1,13 @@
+// Retired from advertised catalogs because Cloud Code Assist rejects live calls
+// with HTTP 400. The callable high-thinking path is gemini-3.1-pro-low:high.
+export const RETIRED_MODEL_KEYS = ["google-antigravity/gemini-3.1-pro-high"] as const;
+
+const RETIRED_MODEL_KEY_SET = new Set<string>(RETIRED_MODEL_KEYS);
+
+export function isRetiredModelKey(provider: string, modelId: string): boolean {
+	return RETIRED_MODEL_KEY_SET.has(`${provider}/${modelId}`);
+}
+
+export function isRetiredModel(model: { provider: string; id: string }): boolean {
+	return isRetiredModelKey(model.provider, model.id);
+}

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -10978,35 +10978,6 @@
 				]
 			}
 		},
-		"gemini-3.1-pro-high": {
-			"id": "gemini-3.1-pro-high",
-			"name": "Gemini 3.1 Pro (High) (Antigravity)",
-			"api": "google-gemini-cli",
-			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 65535,
-			"thinking": {
-				"mode": "google-level",
-				"minLevel": "low",
-				"maxLevel": "high",
-				"levels": [
-					"low",
-					"high"
-				]
-			}
-		},
 		"gemini-3.1-pro-low": {
 			"id": "gemini-3.1-pro-low",
 			"name": "Gemini 3.1 Pro (Low) (Antigravity)",

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { isRetiredModelKey } from "./model-retirements";
 import { applyGeneratedModelPolicies, enrichModelThinking } from "./model-thinking";
 import type { Api, KnownProvider, Model, Usage } from "./types";
 import { isClaudeForcedToolChoiceIncapableModelId } from "./utils/tool-choice-capability";
@@ -33,6 +34,9 @@ function getProviderModels(provider: GeneratedProvider): Map<string, Model<Api>>
 	if (!models) return undefined;
 	const providerModels = new Map<string, Model<Api>>();
 	for (const [id, model] of Object.entries(models)) {
+		if (isRetiredModelKey(provider, id)) {
+			continue;
+		}
 		providerModels.set(id, applyBundledCompatDefaults(enrichModelThinking(model as Model<Api>)));
 	}
 	providerModelRegistry.set(provider, providerModels);

--- a/packages/ai/src/provider-models/google.ts
+++ b/packages/ai/src/provider-models/google.ts
@@ -75,6 +75,7 @@ export function googleGeminiCliModelManagerOptions(
 						const models = await fetchAntigravityDiscoveryModels({
 							token,
 							endpoint,
+							targetProvider: "google-gemini-cli",
 						});
 						if (models === null) {
 							return null;

--- a/packages/ai/src/utils/discovery/antigravity.ts
+++ b/packages/ai/src/utils/discovery/antigravity.ts
@@ -1,7 +1,7 @@
 import * as z from "zod/v4";
+import { isRetiredModelKey } from "../../model-retirements";
 import { getAntigravityUserAgent } from "../../providers/google-gemini-headers";
 import type { Model } from "../../types";
-import { toPositiveNumber } from "../../utils";
 
 const DEFAULT_ANTIGRAVITY_DISCOVERY_ENDPOINTS = [
 	"https://daily-cloudcode-pa.googleapis.com",
@@ -162,6 +162,12 @@ export interface FetchAntigravityDiscoveryModelsOptions {
 	signal?: AbortSignal;
 	/** Optional fetch implementation override for tests. */
 	fetcher?: typeof fetch;
+	/**
+	 * Provider id the caller assigns to returned models. Scopes retired-selector
+	 * filtering (e.g. `google-gemini-cli` reuses this helper and remaps rows).
+	 * Default: `google-antigravity`.
+	 */
+	targetProvider?: "google-antigravity" | "google-gemini-cli";
 }
 
 /**
@@ -174,6 +180,7 @@ export async function fetchAntigravityDiscoveryModels(
 	options: FetchAntigravityDiscoveryModelsOptions,
 ): Promise<Model<"google-gemini-cli">[] | null> {
 	const fetcher = options.fetcher ?? fetch;
+	const targetProvider = options.targetProvider ?? "google-antigravity";
 	const endpoints = options.endpoint
 		? [trimTrailingSlashes(options.endpoint)]
 		: DEFAULT_ANTIGRAVITY_DISCOVERY_ENDPOINTS.map(trimTrailingSlashes);
@@ -214,7 +221,7 @@ export async function fetchAntigravityDiscoveryModels(
 		const models: Model<"google-gemini-cli">[] = [];
 
 		for (const [modelId, model] of Object.entries(parsed.models ?? {})) {
-			if (ANTIGRAVITY_DISCOVERY_DENYLIST.has(modelId)) {
+			if (ANTIGRAVITY_DISCOVERY_DENYLIST.has(modelId) || isRetiredModelKey(targetProvider, modelId)) {
 				continue;
 			}
 			if (model.isInternal === true) {
@@ -254,6 +261,13 @@ function parseAntigravityDiscoveryResponse(value: unknown): AntigravityDiscovery
 		return null;
 	}
 	return parsed.data;
+}
+
+function toPositiveNumber(value: unknown, fallback: number): number {
+	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+		return fallback;
+	}
+	return value;
 }
 
 function trimTrailingSlashes(value: string): string {

--- a/packages/ai/test/antigravity-discovery.test.ts
+++ b/packages/ai/test/antigravity-discovery.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeModelCache } from "../src/model-cache";
+import { resolveProviderModels } from "../src/model-manager";
+import { getBundledModel, getBundledModels } from "../src/models";
+import type { Api, Model } from "../src/types";
+import { fetchAntigravityDiscoveryModels } from "../src/utils/discovery/antigravity";
+
+const cacheDirs: string[] = [];
+
+afterEach(() => {
+	for (const cacheDir of cacheDirs.splice(0)) {
+		rmSync(cacheDir, { recursive: true, force: true });
+	}
+});
+
+function createAntigravityModel(id: string, name: string): Model<Api> {
+	return {
+		id,
+		name,
+		api: "google-gemini-cli",
+		provider: "google-antigravity",
+		baseUrl: "https://daily-cloudcode-pa.sandbox.googleapis.com",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_048_576,
+		maxTokens: 65_535,
+	};
+}
+
+describe("Antigravity model discovery", () => {
+	function createDiscoveryFetcher(): typeof fetch {
+		return (async () =>
+			new Response(
+				JSON.stringify({
+					models: {
+						"gemini-3.1-pro-high": {
+							displayName: "Gemini 3.1 Pro (High)",
+							supportsImages: true,
+							supportsThinking: true,
+							maxTokens: 1_048_576,
+							maxOutputTokens: 65_535,
+						},
+						"gemini-3.1-pro-low": {
+							displayName: "Gemini 3.1 Pro (Low)",
+							supportsImages: true,
+							supportsThinking: true,
+							maxTokens: 1_048_576,
+							maxOutputTokens: 65_535,
+						},
+					},
+				}),
+				{ headers: { "content-type": "application/json" } },
+			)) as unknown as typeof fetch;
+	}
+
+	it("filters the advertised but non-callable gemini-3.1-pro-high selector", async () => {
+		const models = await fetchAntigravityDiscoveryModels({
+			token: "test-token",
+			endpoint: "https://antigravity.example.test",
+			fetcher: createDiscoveryFetcher(),
+		});
+
+		expect(models?.map(model => model.id)).toEqual(["gemini-3.1-pro-low"]);
+	});
+
+	it("keeps gemini-3.1-pro-high when discovery targets google-gemini-cli", async () => {
+		const models = await fetchAntigravityDiscoveryModels({
+			token: "test-token",
+			endpoint: "https://antigravity.example.test",
+			fetcher: createDiscoveryFetcher(),
+			targetProvider: "google-gemini-cli",
+		});
+
+		expect(models?.map(model => model.id)).toEqual(["gemini-3.1-pro-high", "gemini-3.1-pro-low"]);
+	});
+
+	it("does not expose retired selectors from the bundled registry", () => {
+		expect(getBundledModel("google-antigravity", "gemini-3.1-pro-high")).toBeUndefined();
+		expect(getBundledModels("google-antigravity").map(model => model.id)).not.toContain("gemini-3.1-pro-high");
+		expect(getBundledModel("google-antigravity", "gemini-3.1-pro-low")?.id).toBe("gemini-3.1-pro-low");
+	});
+
+	it("filters retired selectors from fresh authoritative model caches", async () => {
+		const cacheDir = mkdtempSync(join(tmpdir(), "pi-ai-antigravity-model-cache-"));
+		cacheDirs.push(cacheDir);
+		const cacheDbPath = join(cacheDir, "models.db");
+		const low = createAntigravityModel("gemini-3.1-pro-low", "Gemini 3.1 Pro (Low)");
+		const high = createAntigravityModel("gemini-3.1-pro-high", "Gemini 3.1 Pro (High)");
+		const staticModels: Model<Api>[] = [low];
+		const cachedModels: Model<Api>[] = [low, high];
+		const now = () => 1_800_000_000_000;
+		const staticFingerprint = Bun.hash(JSON.stringify(staticModels)).toString(36);
+		writeModelCache("google-antigravity", now(), cachedModels, true, staticFingerprint, cacheDbPath);
+
+		const { models, stale } = await resolveProviderModels<Api>(
+			{
+				providerId: "google-antigravity",
+				staticModels,
+				cacheDbPath,
+				now,
+				fetchDynamicModels: async () => {
+					throw new Error("fresh authoritative cache should skip network fetch");
+				},
+			},
+			"online-if-uncached",
+		);
+
+		expect(stale).toBe(false);
+		expect(models.map(model => model.id)).toEqual(["gemini-3.1-pro-low"]);
+	});
+});


### PR DESCRIPTION
## Summary
- Hide `google-antigravity/gemini-3.1-pro-high` from runtime bundled model enumeration and the exported `packages/ai/src/models.json` catalog.
- Filter the same selector from Antigravity dynamic discovery responses and fresh authoritative model-cache rows.
- Keep `google-antigravity/gemini-3.1-pro-low:high` as the callable high-thinking path and add regression coverage.

## Why
Replaces #1890, reopened against `dev` per `CONTRIBUTING.md`.

The model catalog/TUI can currently present `google-antigravity/gemini-3.1-pro-high` as selectable even though live Cloud Code Assist calls reject it. That makes the model picker look like "Gemini high-high" is usable and is easy to misconfigure.

Live repro on 2026-07-09 KST with gjc 0.9.1:

```text
gjc -p --no-session --no-tools --model google-antigravity/gemini-3.1-pro-high "Reply exactly: OK"
# Cloud Code Assist API error (400): Request contains an invalid argument.

gjc -p --no-session --no-tools --model google-antigravity/gemini-3.1-pro-high:high "Reply exactly: OK"
# Cloud Code Assist API error (400): Request contains an invalid argument.

gjc -p --no-session --no-tools --model google-antigravity/gemini-3.1-pro-low:high "Reply exactly: OK"
# OK
```

This matches the existing upstream guidance in `docs/multi-vendor-profiles.md`, which already says Antigravity high reasoning should use `google-antigravity/gemini-3.1-pro-low:high` because `gemini-3.1-pro-high` returns HTTP 400.

## Verification
- `bun test packages/ai/test/issue-489-repro.test.ts packages/ai/test/antigravity-discovery.test.ts`
- `bun --cwd=packages/ai run check`

Not run successfully here:
- `bun --cwd=packages/ai run generate-models` is blocked in this checkout because the native addon is absent and local Rust/Cargo is unavailable (`Failed to load pi_natives native addon`, then `cargo: command not found` while trying to build it). The generator retirement list is updated, and the matching exported `models.json` delta is included directly.
