### PR TITLE
Fail closed on orphaned image placeholders

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -23,6 +23,7 @@ import {
 import { agentLoop, agentLoopContinue } from "./agent-loop";
 import type { AppendOnlyContextManager } from "./append-only-context";
 import type { HarmonyAuditEvent } from "./harmony-leak";
+import { assertImagePlaceholdersHavePayload } from "./image-placeholder-guard";
 import type {
 	AgentContext,
 	AgentEvent,
@@ -34,6 +35,23 @@ import type {
 	StreamFn,
 	ToolCallContext,
 } from "./types";
+
+function assertUserImagePlaceholdersHavePayload(messages: readonly AgentMessage[]): void {
+	for (const message of messages) {
+		if (!("role" in message) || message.role !== "user") continue;
+		const content = message.content;
+		if (typeof content === "string") {
+			assertImagePlaceholdersHavePayload(content, undefined);
+			continue;
+		}
+		if (!Array.isArray(content)) continue;
+		const text = content
+			.filter(part => part.type === "text")
+			.map(part => part.text)
+			.join("\n");
+		assertImagePlaceholdersHavePayload(text, content);
+	}
+}
 
 /**
  * Default convertToLlm: Keep only LLM-compatible messages, convert attachments.
@@ -860,6 +878,7 @@ export class Agent {
 	 * Delivered after current tool execution, skips remaining tools.
 	 */
 	steer(m: AgentMessage) {
+		assertUserImagePlaceholdersHavePayload([m]);
 		this.#steeringQueue.push(m);
 	}
 
@@ -872,6 +891,7 @@ export class Agent {
 	 * other integration paths.
 	 */
 	followUp(m: AgentMessage, options?: { forceOneAtATime?: boolean }) {
+		assertUserImagePlaceholdersHavePayload([m]);
 		if (options?.forceOneAtATime) {
 			this.#followUpForceOneAtATime.add(m);
 		}
@@ -1117,6 +1137,8 @@ export class Agent {
 			msgs = [input];
 			promptOptions = imagesOrOptions as AgentPromptOptions | undefined;
 		}
+
+		assertUserImagePlaceholdersHavePayload(msgs);
 
 		await this.#runLoop(msgs, promptOptions);
 	}

--- a/packages/agent/src/image-placeholder-guard.ts
+++ b/packages/agent/src/image-placeholder-guard.ts
@@ -1,0 +1,20 @@
+import type { ImageContent, TextContent } from "@gajae-code/ai";
+
+export const IMAGE_PLACEHOLDER_ATTACHMENT_GUIDANCE =
+	"Image placeholder text was submitted without an image payload. Paste the image with #paste-image, attach it with @path/to/image.png, or save the image and provide the saved file path.";
+
+const IMAGE_PLACEHOLDER_ONLY_PATTERN = /^\s*(?:\[image\s+\d+\]\s*)+$/i;
+
+export function isImagePlaceholderOnlyText(text: string): boolean {
+	return IMAGE_PLACEHOLDER_ONLY_PATTERN.test(text);
+}
+
+export function assertImagePlaceholdersHavePayload(
+	text: string,
+	content: readonly (TextContent | ImageContent)[] | undefined,
+): void {
+	if (!isImagePlaceholderOnlyText(text)) return;
+	const hasImagePayload = content?.some(part => part.type === "image") ?? false;
+	if (hasImagePayload) return;
+	throw new Error(IMAGE_PLACEHOLDER_ATTACHMENT_GUIDANCE);
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -7,6 +7,7 @@ export * from "./append-only-context";
 // Compaction
 export * from "./compaction";
 export * from "./harmony-leak";
+export * from "./image-placeholder-guard";
 // Proxy utilities
 export * from "./proxy";
 // Run-level telemetry collector + aggregators

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { Agent, type AgentTool, ThinkingLevel } from "@gajae-code/agent-core";
-import type { SimpleStreamOptions } from "@gajae-code/ai";
+import type { ImageContent, SimpleStreamOptions } from "@gajae-code/ai";
 import { z } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { createAssistantMessage } from "./helpers";
@@ -119,6 +119,34 @@ describe("Agent", () => {
 		expect(mock.calls.length).toBe(2);
 	});
 
+	it("prompt() rejects image-placeholder-only text without image payload", async () => {
+		const mock = createMockModel({ responses: [{ content: ["unreachable"] }] });
+		const agent = new Agent({ streamFn: mock.stream });
+
+		await expect(agent.prompt("[image 1]")).rejects.toThrow("#paste-image");
+		await expect(agent.prompt("[image 1]\n[image 2]", [])).rejects.toThrow("@path/to/image.png");
+		expect(mock.calls).toHaveLength(0);
+	});
+
+	it("prompt() allows image-placeholder-only text when image payload is attached", async () => {
+		const mock = createMockModel({ responses: [{ content: ["ok"] }] });
+		const agent = new Agent({ streamFn: mock.stream });
+		const image: ImageContent = { type: "image", data: "aW1hZ2U=", mimeType: "image/png" };
+
+		await expect(agent.prompt("[image 1]", [image])).resolves.toBeUndefined();
+
+		expect(mock.calls).toHaveLength(1);
+		expect(mock.calls[0].context.messages[0].content).toEqual([{ type: "text", text: "[image 1]" }, image]);
+	});
+
+	it("prompt() allows normal text that mentions an image placeholder", async () => {
+		const mock = createMockModel({ responses: [{ content: ["ok"] }] });
+		const agent = new Agent({ streamFn: mock.stream });
+
+		await expect(agent.prompt("Please explain why [image 1] is missing.")).resolves.toBeUndefined();
+
+		expect(mock.calls).toHaveLength(1);
+	});
 	it("prompt() refreshes tools and system prompt between same-turn model calls", async () => {
 		const toolSchema = z.object({ value: z.string() });
 		type Details = { value: string };

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -26,6 +26,7 @@ import {
 	type AgentMessage,
 	type AgentState,
 	type AgentTool,
+	assertImagePlaceholdersHavePayload,
 	resolveTelemetry,
 	type StablePrefixSnapshot,
 	ThinkingLevel,
@@ -5397,6 +5398,7 @@ export class AgentSession {
 
 		// Expand file-based prompt templates if requested
 		const expandedText = expandPromptTemplates ? expandPromptTemplate(text, [...this.#promptTemplates]) : text;
+		assertImagePlaceholdersHavePayload(expandedText, options?.images);
 		const workflowIntentDiff = options?.synthetic ? null : buildWorkflowIntentDiff(expandedText);
 
 		// If streaming, queue via steer() or followUp() based on option
@@ -5883,6 +5885,7 @@ export class AgentSession {
 		}
 
 		const expandedText = expandPromptTemplate(text, [...this.#promptTemplates]);
+		assertImagePlaceholdersHavePayload(expandedText, images);
 		await this.#queueSteer(expandedText, images);
 	}
 
@@ -5899,6 +5902,7 @@ export class AgentSession {
 		}
 
 		const expandedText = expandPromptTemplate(text, [...this.#promptTemplates]);
+		assertImagePlaceholdersHavePayload(expandedText, images);
 		await this.#queueFollowUp(expandedText, images, {
 			forceOneAtATime: options?.followUpQueuePolicy === "sequential",
 		});
@@ -5908,6 +5912,7 @@ export class AgentSession {
 	 * Internal: Queue a steering message (already expanded, no extension command check).
 	 */
 	async #queueSteer(text: string, images?: ImageContent[]): Promise<void> {
+		assertImagePlaceholdersHavePayload(text, images);
 		const displayText = text || (images && images.length > 0 ? "[Image]" : "");
 		this.#steeringMessages.push(this.#createQueuedDisplayEntry(displayText));
 		const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
@@ -5939,6 +5944,7 @@ export class AgentSession {
 	 * Internal: Queue a follow-up message (already expanded, no extension command check).
 	 */
 	async #queueFollowUp(text: string, images?: ImageContent[], options?: { forceOneAtATime?: boolean }): Promise<void> {
+		assertImagePlaceholdersHavePayload(text, images);
 		const displayText = text || (images && images.length > 0 ? "[Image]" : "");
 		this.#followUpMessages.push(this.#createQueuedDisplayEntry(displayText));
 		const content: (TextContent | ImageContent)[] = [{ type: "text", text }];

--- a/packages/coding-agent/src/utils/pasted-image-path.ts
+++ b/packages/coding-agent/src/utils/pasted-image-path.ts
@@ -1,12 +1,11 @@
 /**
  * Resolve pasted editor text to an image file path.
  *
- * Terminals insert a shell-escaped filesystem path when a file is drag-dropped
- * onto them (e.g. macOS `Screenshot\ 2026-07-07\ at\ 11.06.38 PM.png`, where
- * the visible "space" before AM/PM is U+202F and stays unescaped). When the
- * entire paste is a single path to an existing image file, the interactive
- * editor attaches the image and inserts an `[image N]` placeholder instead of
- * leaving the raw path in the prompt.
+ * Some terminal/clipboard integrations paste a temporary filesystem path after a
+ * copied image is pasted into the editor (for example `/tmp/clipboard-...png`).
+ * Only those recognized clipboard temp files are auto-attached and replaced with
+ * an `[image N]` placeholder. Ordinary image paths remain literal prompt text;
+ * users attach saved files explicitly with `@path/to/image.png`.
  */
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -14,6 +13,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const IMAGE_FILE_EXTENSION_PATTERN = /\.(?:png|jpe?g|gif|webp)$/i;
+const CLIPBOARD_TEMP_BASENAME_PATTERN = /^clipboard-\d{4}-\d{2}-\d{2}-\d{6}-[A-Za-z0-9-]+\.(?:png|jpe?g|gif|webp)$/i;
 
 export interface DecodePastedPathOptions {
 	/**
@@ -150,16 +150,25 @@ function hasSupportedImageMagic(filePath: string): boolean {
 	}
 }
 
+function isRecognizedClipboardTempPath(filePath: string): boolean {
+	const resolved = path.resolve(filePath);
+	const tempRoot = path.resolve(os.tmpdir());
+	if (resolved !== tempRoot && !resolved.startsWith(`${tempRoot}${path.sep}`)) return false;
+	return CLIPBOARD_TEMP_BASENAME_PATTERN.test(path.basename(resolved));
+}
+
 /**
- * Returns the resolved path when the whole pasted text is a single path to an
- * existing image file (verified by extension AND content signature),
- * otherwise `undefined` (the paste is inserted as text).
+ * Returns the resolved path when the whole pasted text is a recognized clipboard
+ * temp path to an existing image file, otherwise `undefined` (the paste is
+ * inserted as text). Arbitrary saved image paths are not auto-attached here;
+ * users attach them explicitly with `@path/to/image.png`.
  */
 export function resolvePastedImagePath(text: string, options?: ResolvePastedImagePathOptions): string | undefined {
 	const candidate = decodePastedPathCandidate(text, options);
 	if (!candidate || !IMAGE_FILE_EXTENSION_PATTERN.test(candidate)) return undefined;
 
 	const resolved = path.resolve(options?.cwd ?? process.cwd(), candidate);
+	if (!isRecognizedClipboardTempPath(resolved)) return undefined;
 	try {
 		if (!fs.statSync(resolved).isFile()) return undefined;
 	} catch {

--- a/packages/coding-agent/test/pasted-image-path.test.ts
+++ b/packages/coding-agent/test/pasted-image-path.test.ts
@@ -25,51 +25,38 @@ describe("resolvePastedImagePath", () => {
 		return filePath;
 	}
 
-	it("resolves a plain absolute path to an existing image", () => {
+	it("does not auto-attach arbitrary absolute image paths", () => {
 		const filePath = writeImage("plain.png");
-		expect(resolvePastedImagePath(filePath)).toBe(filePath);
+		expect(resolvePastedImagePath(filePath)).toBeUndefined();
 	});
 
-	it("resolves a shell-escaped drag-drop path with U+202F before PM", () => {
-		// macOS screenshot drag-drop: ASCII spaces are `\ `-escaped, the U+202F
-		// before "PM" is left as-is.
+	it("does not auto-attach shell-escaped drag-drop image paths", () => {
+		// Saved image paths remain literal text; attach them explicitly with @path/to/image.png.
 		const filePath = writeImage(`Screenshot 2026-07-07 at 11.06.38${NNBSP}PM.png`);
 		const pasted = filePath.replaceAll(" ", "\\ ");
 		expect(pasted).not.toBe(filePath);
-		expect(resolvePastedImagePath(pasted)).toBe(filePath);
+		expect(resolvePastedImagePath(pasted)).toBeUndefined();
 	});
 
-	it("resolves shell-escaped parentheses", () => {
-		const filePath = writeImage("shot (1).png");
-		const pasted = filePath.replaceAll(" ", "\\ ").replaceAll("(", "\\(").replaceAll(")", "\\)");
-		expect(resolvePastedImagePath(pasted)).toBe(filePath);
-	});
-
-	it("resolves single- and double-quoted paths", () => {
+	it("does not auto-attach quoted arbitrary image paths", () => {
 		const filePath = writeImage("quoted image.jpg");
-		expect(resolvePastedImagePath(`'${filePath}'`)).toBe(filePath);
-		expect(resolvePastedImagePath(`"${filePath}"`)).toBe(filePath);
+		expect(resolvePastedImagePath(`'${filePath}'`)).toBeUndefined();
+		expect(resolvePastedImagePath(`"${filePath}"`)).toBeUndefined();
 	});
 
-	it("resolves file:// URIs with percent-encoding", () => {
+	it("does not auto-attach arbitrary file:// image URIs", () => {
 		const filePath = writeImage("uri image.webp");
 		const uri = `file://${filePath.split("/").map(encodeURIComponent).join("/")}`;
-		expect(resolvePastedImagePath(uri)).toBe(filePath);
+		expect(resolvePastedImagePath(uri)).toBeUndefined();
 	});
 
-	it("resolves file://localhost URIs", () => {
-		const filePath = writeImage("localhost.png");
-		expect(resolvePastedImagePath(`file://localhost${filePath}`)).toBe(filePath);
-	});
-
-	it("expands ~/ against the provided homedir", () => {
-		const filePath = writeImage("home.png");
-		expect(resolvePastedImagePath("~/home.png", { homedir: testDir })).toBe(filePath);
-	});
-
-	it("resolves relative paths against the provided cwd", () => {
-		const filePath = writeImage("relative.png");
-		expect(resolvePastedImagePath("./relative.png", { cwd: testDir })).toBe(filePath);
+	it("does not auto-attach arbitrary ~/ or relative image paths", () => {
+		const homeImage = writeImage("home.png");
+		const relativeImage = writeImage("relative.png");
+		expect(resolvePastedImagePath("~/home.png", { homedir: testDir })).toBeUndefined();
+		expect(resolvePastedImagePath("./relative.png", { cwd: testDir })).toBeUndefined();
+		expect(homeImage).toBeTruthy();
+		expect(relativeImage).toBeTruthy();
 	});
 
 	it("still accepts legacy clipboard temp paths", () => {
@@ -107,12 +94,15 @@ describe("resolvePastedImagePath", () => {
 		expect(resolvePastedImagePath(filePath)).toBeUndefined();
 	});
 
-	it("accepts each supported image signature", () => {
+	it("accepts each supported image signature for recognized clipboard temp paths", () => {
 		const signatures: Array<[string, Buffer]> = [
-			["sig.png", Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])],
-			["sig.jpg", Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46])],
-			["sig.gif", Buffer.from("GIF89a", "latin1")],
-			["sig.webp", Buffer.concat([Buffer.from("RIFF", "latin1"), Buffer.alloc(4), Buffer.from("WEBP", "latin1")])],
+			["clipboard-2026-07-07-123456-png.png", Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])],
+			["clipboard-2026-07-07-123456-jpg.jpg", Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46])],
+			["clipboard-2026-07-07-123456-gif.gif", Buffer.from("GIF89a", "latin1")],
+			[
+				"clipboard-2026-07-07-123456-webp.webp",
+				Buffer.concat([Buffer.from("RIFF", "latin1"), Buffer.alloc(4), Buffer.from("WEBP", "latin1")]),
+			],
 		];
 		for (const [name, magic] of signatures) {
 			const filePath = path.join(testDir, name);
@@ -121,8 +111,8 @@ describe("resolvePastedImagePath", () => {
 		}
 	});
 
-	it("accepts mismatched extension when content is a supported image (loader sniffs real mime)", () => {
-		const filePath = path.join(testDir, "actually-png.jpg");
+	it("accepts mismatched extension when recognized clipboard temp content is a supported image", () => {
+		const filePath = path.join(testDir, "clipboard-2026-07-07-123456-actually-png.jpg");
 		fs.writeFileSync(filePath, PNG_SIGNATURE);
 		expect(resolvePastedImagePath(filePath)).toBe(filePath);
 	});


### PR DESCRIPTION
Closes #1893.

## Summary
- Added a shared guard for placeholder-only image text submitted without image payloads.
- Applied the guard at Agent and AgentSession prompt/queue boundaries so API, RPC, and interactive paths fail closed before silent model submission.
- Kept valid image payload submissions working and tightened TUI text-paste auto-attach to recognized clipboard temp image paths only.

## Validation
- `bun test packages/agent/test/agent.test.ts packages/coding-agent/test/pasted-image-path.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts`
- `bun --cwd=packages/agent run check:types`
- `bun --cwd=packages/coding-agent run check:types`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*