### PR TITLE
fix(ai): preserve Anthropic start-block tool args

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Hid the non-callable `google-antigravity/gemini-3.1-pro-high` selector from bundled, dynamic, and cached Antigravity catalogs after live Cloud Code Assist calls returned HTTP 400; `google-antigravity/gemini-3.1-pro-low:high` remains the working high-thinking path.
+- Preserved Anthropic tool-use arguments supplied on `content_block_start` when no `input_json_delta` chunks follow, preventing finished tool calls from collapsing back to `{}`.
 
 ## [0.9.1] - 2026-07-08
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1513,7 +1513,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 										partial: output,
 									});
 								} else if (block.type === "toolCall") {
-									block.arguments = parseStreamingJson(block.partialJson);
+									if (block.partialJson.trim()) {
+										block.arguments = parseStreamingJson(block.partialJson);
+									}
 									delete (block as { partialJson?: string }).partialJson;
 									stream.push({
 										type: "toolcall_end",

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -290,6 +290,57 @@ describe("anthropic stream envelope handling", () => {
 		expect(endEvent.toolCall.arguments).toEqual(args);
 		expect(result.content).toEqual([{ type: "toolCall", id: "tool_args", name: "bash", arguments: args }]);
 	});
+	it("preserves non-delta tool-call input from Anthropic content_block_start", async () => {
+		const args = {
+			command: "printf hi",
+			cwd: "/tmp/worktree",
+			timeout: 5,
+		};
+		vi.spyOn(Messages.prototype, "create").mockImplementation(
+			() =>
+				createMockRequest([
+					{
+						type: "message_start",
+						message: {
+							id: "msg_tool_start_input",
+							usage: {
+								input_tokens: 12,
+								output_tokens: 0,
+								cache_read_input_tokens: 0,
+								cache_creation_input_tokens: 0,
+							},
+						},
+					},
+					{
+						type: "content_block_start",
+						index: 0,
+						content_block: { type: "tool_use", id: "tool_start_input", name: "bash", input: args },
+					},
+					{ type: "content_block_stop", index: 0 },
+					{
+						type: "message_delta",
+						delta: { stop_reason: "tool_use" },
+						usage: { output_tokens: 7 },
+					},
+					{ type: "message_stop" },
+				]) as never,
+		);
+
+		const stream = streamAnthropic(model, context, { apiKey: "sk-ant-test" });
+		const events: AssistantMessageEvent[] = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const result = await stream.result();
+		const deltaEvents = events.filter(event => event.type === "toolcall_delta");
+		const endEvent = events.find(event => event.type === "toolcall_end");
+
+		expect(deltaEvents).toHaveLength(0);
+		expect(endEvent?.type).toBe("toolcall_end");
+		if (endEvent?.type !== "toolcall_end") throw new Error("Expected toolcall_end");
+		expect(endEvent.toolCall.arguments).toEqual(args);
+		expect(result.content).toEqual([{ type: "toolCall", id: "tool_start_input", name: "bash", arguments: args }]);
+	});
 
 	it("ignores ping before message_start and streams the response once", async () => {
 		let attempt = 0;


### PR DESCRIPTION
## Summary
- Preserve Anthropic `content_block_start` `tool_use.input` arguments when a stream finishes without any `input_json_delta` chunks.
- Keep the existing streamed-delta path unchanged: once deltas arrive, they remain the source of truth.
- Add regression coverage for the non-delta start-input shape that v0.9.2 could collapse back to `{}` at `content_block_stop`.

## Why
Follow-up to #1870 / #1871. The previous fix protected live args from renderer mutation, but `streamAnthropic` still unconditionally did `parseStreamingJson(block.partialJson)` on `content_block_stop`. For Anthropic-compatible streams that supply complete tool input on `content_block_start` and emit no `input_json_delta`, `partialJson` is empty, so final bash/read/find args become `{}` and validation fails with missing fields.

## Verification
- `bun test packages/ai/test/anthropic-stream-envelope.test.ts`
- `bun --cwd=packages/ai run check`
- `git diff --check`