### PR TITLE
fix(tui): hide markdown html comments

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Markdown terminal rendering now treats HTML comments as invisible markup, preventing React-style `<!-- -->` text separators from leaking into chat output while preserving visible HTML-like model text.
+
 ## [0.9.1] - 2026-07-08
 ### Fixed
 

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -198,6 +198,29 @@ function formatHyperlink(text: string, target: string): string {
 	return `\x1b]8;;${safeTarget}\x07${text}\x1b]8;;\x07`;
 }
 
+function stripHtmlComments(raw: string): string {
+	let result = "";
+	let index = 0;
+
+	while (index < raw.length) {
+		const start = raw.indexOf("<!--", index);
+		if (start < 0) {
+			result += raw.slice(index);
+			break;
+		}
+
+		result += raw.slice(index, start);
+		const end = raw.indexOf("-->", start + 4);
+		if (end < 0) {
+			result += raw.slice(start);
+			break;
+		}
+		index = end + 3;
+	}
+
+	return result;
+}
+
 export class Markdown implements Component {
 	#text: string;
 	#paddingX: number; // Left/right padding
@@ -672,12 +695,15 @@ export class Markdown implements Component {
 				}
 				break;
 
-			case "html":
-				// Render HTML as plain text (escaped for terminal)
-				if ("raw" in token && typeof token.raw === "string") {
-					lines.push(this.#applyDefaultStyle(token.raw.trim()));
+			case "html": {
+				// HTML comments are invisible markup (React/SSR text separators often emit "<!-- -->").
+				// Keep other HTML-like model text visible as plain terminal text.
+				const visibleHtml = "raw" in token && typeof token.raw === "string" ? stripHtmlComments(token.raw) : "";
+				if (visibleHtml.trim().length > 0) {
+					lines.push(this.#applyDefaultStyle(visibleHtml.trim()));
 				}
 				break;
+			}
 
 			case "space":
 				// Space tokens represent blank lines in markdown
@@ -763,12 +789,14 @@ export class Markdown implements Component {
 					break;
 				}
 
-				case "html":
-					// Render inline HTML as plain text
-					if ("raw" in token && typeof token.raw === "string") {
-						result += applyTextWithNewlines(token.raw);
+				case "html": {
+					// HTML comments are markup-only separators; keep other inline HTML visible as text.
+					const visibleHtml = "raw" in token && typeof token.raw === "string" ? stripHtmlComments(token.raw) : "";
+					if (visibleHtml.trim().length > 0) {
+						result += applyTextWithNewlines(visibleHtml);
 					}
 					break;
+				}
 
 				default:
 					// Handle any other inline token types as plain text
@@ -1109,6 +1137,11 @@ export function renderInlineMarkdown(text: string, mdTheme: MarkdownTheme, baseC
 					return `${applyText(prefix)}${content}`;
 				})
 				.join(applyText(" "));
+		} else if (token.type === "html" && "raw" in token && typeof token.raw === "string") {
+			const visibleHtml = stripHtmlComments(token.raw);
+			if (visibleHtml.trim().length > 0) {
+				result += applyText(visibleHtml);
+			}
 		} else if ("text" in token && typeof token.text === "string") {
 			result += applyText(token.text);
 		}
@@ -1143,6 +1176,13 @@ function renderInlineTokens(tokens: Token[], mdTheme: MarkdownTheme, applyText: 
 			case "link": {
 				const linkText = renderInlineTokens(token.tokens || [], mdTheme, applyText);
 				result += mdTheme.link(mdTheme.underline(linkText)) + styleReset;
+				break;
+			}
+			case "html": {
+				const visibleHtml = "raw" in token && typeof token.raw === "string" ? stripHtmlComments(token.raw) : "";
+				if (visibleHtml.trim().length > 0) {
+					result += applyText(visibleHtml);
+				}
 				break;
 			}
 			default:

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -27,6 +27,14 @@ describe("renderInlineMarkdown", () => {
 
 		expect(plain).toBe("1. Review against a base branch (PR Style)");
 	});
+	it("omits HTML comments from inline markdown", () => {
+		const rendered = renderInlineMarkdown("alpha<!-- -->beta", defaultMarkdownTheme);
+		const plain = rendered.replace(/\x1b\[[0-9;]*m/g, "");
+
+		expect(plain).toBe("alphabeta");
+		const commentOnly = renderInlineMarkdown("<!-- -->", defaultMarkdownTheme).replace(/\x1b\[[0-9;]*m/g, "");
+		expect(commentOnly).toBe("");
+	});
 
 	it("returns empty string for undefined input (streaming guard)", () => {
 		// During streaming, partial JSON can leave option label fields as undefined.
@@ -1150,6 +1158,40 @@ bar`,
 				joinedPlain.includes("hidden content") || joinedPlain.includes("<thinking>"),
 				"Should render HTML-like tags or their content as text, not hide them",
 			).toBeTruthy();
+		});
+
+		it("should omit HTML comments while preserving non-comment HTML-like text", () => {
+			const markdown = new Markdown(
+				"Before\n\n<!-- react text separator -->\n\nAfter <thinking>visible</thinking><!-- -->tail",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const lines = markdown.render(80);
+			const plainLines = lines.map(stripTerminalSequences);
+			const joinedPlain = plainLines.join(" ");
+
+			expect(joinedPlain).not.toContain("<!--");
+			expect(joinedPlain).not.toContain("-->");
+			expect(joinedPlain).toContain("Before");
+			expect(joinedPlain).toContain("After");
+			expect(joinedPlain).toContain("visible");
+			expect(joinedPlain).toContain("tail");
+			expect(joinedPlain).toContain("<thinking>");
+			expect(joinedPlain).toContain("</thinking>");
+
+			const mixedMarkdown = new Markdown(
+				"<!-- leading --> <div>html stays visible</div>",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+			const mixedPlain = mixedMarkdown.render(80).map(stripTerminalSequences).join(" ");
+
+			expect(mixedPlain).not.toContain("<!--");
+			expect(mixedPlain).not.toContain("-->");
+			expect(mixedPlain).toContain("<div>html stays visible</div>");
 		});
 
 		it("should render HTML tags in code blocks correctly", () => {


### PR DESCRIPTION
## Summary
- Treat complete HTML comments as invisible Markdown markup in TUI block and inline render paths.
- Preserve visible HTML-like model text and code-block contents while stripping React/SSR separator comments such as `<!-- -->`.
- Add regression coverage for inline, block, mixed comment+HTML, and code-block HTML cases.

## Root cause
Marked emits HTML comments as `html` tokens, and the terminal Markdown renderer intentionally rendered all HTML tokens as plain text so model-emitted tags stayed visible. That policy lacked a comment-specific exception, so zero-width renderer separators like React/SSR `<!-- -->` leaked into chat output.

## Verification
- `bun test packages/tui/test/markdown.test.ts --test-name-pattern 'HTML comments'`
- `bun test packages/tui/test/markdown.test.ts`
- `bun --cwd=packages/tui run check`
- `bun --cwd=packages/tui test`
- Fresh-context architect review: CLEAR