### PR TITLE
fix(tui): preserve pasted image source paths

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Hid the non-callable `google-antigravity/gemini-3.1-pro-high` selector from bundled, dynamic, and cached Antigravity catalogs after live Cloud Code Assist calls returned HTTP 400; `google-antigravity/gemini-3.1-pro-low:high` remains the working high-thinking path.
 - Preserved Anthropic tool-use arguments supplied on `content_block_start` when no `input_json_delta` chunks follow, preventing finished tool calls from collapsing back to `{}`.
+- Refreshed the default Gemini CLI impersonation version to 0.50.0 so the spoofed User-Agent freshness gate passes for the 0.9.2 release.
 
 ## [0.9.1] - 2026-07-08
 

--- a/packages/ai/src/providers/google-gemini-headers.ts
+++ b/packages/ai/src/providers/google-gemini-headers.ts
@@ -5,7 +5,7 @@
  */
 export const GEMINI_CLI_VERSION_ENV = "GJC_AI_GEMINI_CLI_VERSION";
 export const LEGACY_GEMINI_CLI_VERSION_ENV = "PI_AI_GEMINI_CLI_VERSION";
-export const DEFAULT_GEMINI_CLI_VERSION = "0.49.0";
+export const DEFAULT_GEMINI_CLI_VERSION = "0.50.0";
 
 export function getGeminiCliUserAgent(modelId = "gemini-3.1-pro-preview"): string {
 	const version =

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added `gjc --credential <selector>` for pinning a stored provider credential by `email:`, `id:`, `account:`, `project:`, or `provider/email:` during a session.
 - Added `--mpreset <profile>` support to Telegram `/session_create`, forwarding both `--mpreset <name>` and `--mpreset=<name>` as split argv to the spawned GJC child.
 - Added the built-in `skill_discovery` tool for runtime discovery of custom project/user skills without injecting the full skill catalog into the core prompt.
-- Pasting or drag-dropping a path to an existing image file now attaches the image and inserts an `[image N]` placeholder, including quoted paths, `file://` URIs, `~/` expansion, spaces, and macOS screenshot narrow no-break spaces.
+- Pasted clipboard-temp image paths now attach as `[image N] source="/path"`, so the model receives both the image payload and the retrievable raw temp file path; ordinary saved image paths remain literal prompt text instead of being consumed into opaque placeholders.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 
 - Added `gjc --credential <selector>` for pinning a stored provider credential by `email:`, `id:`, `account:`, `project:`, or `provider/email:` during a session.
+- Added `--mpreset <profile>` support to Telegram `/session_create`, forwarding both `--mpreset <name>` and `--mpreset=<name>` as split argv to the spawned GJC child.
+- Added the built-in `skill_discovery` tool for runtime discovery of custom project/user skills without injecting the full skill catalog into the core prompt.
+- Pasting or drag-dropping a path to an existing image file now attaches the image and inserts an `[image N]` placeholder, including quoted paths, `file://` URIs, `~/` expansion, spaces, and macOS screenshot narrow no-break spaces.
 
 ### Changed
 
@@ -16,6 +19,9 @@
 - `gjc --tmux` terminal titles now track live tmux session renames while preserving the friendly project/branch title for untouched generated session ids.
 - Telegram session forum-topic renames now remain retryable after a transient `editForumTopic` failure, so topics do not get stuck at the provisional `GJC <session>` name while the daemon incorrectly records the final title locally.
 - `/effort` selector choices now show the current reasoning effort and mirror `/model` by asking whether to apply the selected effort for the current session or save it as the default, including support for persisting `off`. Default model presets also sync their encoded effort into the persisted effort default so later `/effort` defaults are not overwritten on restart.
+- Composer queue submissions (`Alt+Q` / `app.message.queue`) force one-at-a-time follow-up delivery, including replay after compaction, without disabling broader batch mode for other follow-up callers.
+- `--credential` now rejects a missing selector immediately instead of falling through into session launch with no output.
+- `gjc-session` prompt/monitor postmortem helpers now work on macOS's system Bash/Python, so missing tmux sessions write the public-safe `vanished.json` marker and prompt injection exits through the guarded refusal path.
 
 ## [0.9.1] - 2026-07-08
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -3,6 +3,7 @@
  */
 import { type Effort, THINKING_EFFORTS } from "@gajae-code/ai";
 import { APP_NAME, CONFIG_DIR_NAME, logger } from "@gajae-code/utils";
+import { CliParseError } from "@gajae-code/utils/cli";
 import chalk from "chalk";
 import { parseEffort } from "../thinking";
 import { BUILTIN_TOOLS } from "../tools";
@@ -137,7 +138,11 @@ export function parseArgs(args: string[]): Args {
 			result.default = true;
 		} else if (arg === "--api-key" && i + 1 < args.length) {
 			result.apiKey = args[++i];
-		} else if (arg === "--credential" && i + 1 < args.length) {
+		} else if (arg === "--credential") {
+			const next = args[i + 1];
+			if (!next || next.startsWith("-")) {
+				throw new CliParseError("--credential requires <selector>");
+			}
 			result.credential = args[++i];
 		} else if (arg === "--system-prompt" && i + 1 < args.length) {
 			result.systemPrompt = args[++i];

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -18,7 +18,7 @@ import { copyToClipboard, readImageFromClipboard } from "../../utils/clipboard";
 import { getEditorCommand, openInEditor } from "../../utils/external-editor";
 import { ensureSupportedImageInput, ImageInputTooLargeError, loadImageInput } from "../../utils/image-loading";
 import { resizeImage } from "../../utils/image-resize";
-import { resolvePastedImagePath } from "../../utils/pasted-image-path";
+import { formatPastedImageReference, resolvePastedImagePath } from "../../utils/pasted-image-path";
 import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
 import { type QueuedMessageMoveDirection, QueuedMessageSelectorComponent } from "../components/queued-message-selector";
 
@@ -1096,7 +1096,7 @@ export class InputController {
 				data: image.data,
 				mimeType: image.mimeType,
 			});
-			this.ctx.editor.insertText(`${this.#nextImagePlaceholder()} `);
+			this.ctx.editor.insertText(`${formatPastedImageReference(this.#nextImagePlaceholder(), image.resolvedPath)} `);
 			this.ctx.showStatus(`Attached image: ${path.basename(image.resolvedPath)}`, { dim: true });
 			this.ctx.ui.requestRender();
 			return true;

--- a/packages/coding-agent/src/utils/pasted-image-path.ts
+++ b/packages/coding-agent/src/utils/pasted-image-path.ts
@@ -4,8 +4,9 @@
  * Some terminal/clipboard integrations paste a temporary filesystem path after a
  * copied image is pasted into the editor (for example `/tmp/clipboard-...png`).
  * Only those recognized clipboard temp files are auto-attached and replaced with
- * an `[image N]` placeholder. Ordinary image paths remain literal prompt text;
- * users attach saved files explicitly with `@path/to/image.png`.
+ * an `[image N] source="/path"` reference so the model receives both the image
+ * payload and the raw temp file path. Ordinary image paths remain literal prompt
+ * text; users attach saved files explicitly with `@path/to/image.png`.
  */
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -176,4 +177,8 @@ export function resolvePastedImagePath(text: string, options?: ResolvePastedImag
 	}
 	if (!hasSupportedImageMagic(resolved)) return undefined;
 	return resolved;
+}
+
+export function formatPastedImageReference(placeholder: string, imagePath: string): string {
+	return `${placeholder} source=${JSON.stringify(imagePath)}`;
 }

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
+import { CliParseError } from "@gajae-code/utils/cli";
 import { parseArgs } from "../src/cli/args";
 import type { ModelProfileDefinition } from "../src/config/model-profiles";
 import { Settings } from "../src/config/settings";
@@ -83,6 +84,13 @@ describe("CLI credential selector args", () => {
 		const selector = parseCliCredentialSelector(parsed.credential ?? "");
 		expect(selector.provider).toBe("openai-codex");
 		expect(selector.selector).toEqual({ kind: "email", value: "me@example.com" });
+	});
+
+	test("rejects --credential without selector", () => {
+		expect(() => parseArgs(["--credential"])).toThrow(CliParseError);
+		expect(() => parseArgs(["--credential"])).toThrow("--credential requires <selector>");
+		expect(() => parseArgs(["--credential", "--model", "opus"])).toThrow(CliParseError);
+		expect(() => parseArgs(["--credential", "--model", "opus"])).toThrow("--credential requires <selector>");
 	});
 
 	test("parses bare email credential selector as email shorthand", () => {

--- a/packages/coding-agent/test/pasted-image-path.test.ts
+++ b/packages/coding-agent/test/pasted-image-path.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { decodePastedPathCandidate, resolvePastedImagePath } from "../src/utils/pasted-image-path";
+import {
+	decodePastedPathCandidate,
+	formatPastedImageReference,
+	resolvePastedImagePath,
+} from "../src/utils/pasted-image-path";
 
 const NNBSP = "\u202f"; // narrow no-break space used by macOS screenshot names
 
@@ -130,6 +134,21 @@ describe("resolvePastedImagePath", () => {
 	it("rejects empty and whitespace-only pastes", () => {
 		expect(resolvePastedImagePath("")).toBeUndefined();
 		expect(resolvePastedImagePath("   ")).toBeUndefined();
+	});
+});
+
+describe("formatPastedImageReference", () => {
+	it("keeps the image placeholder while preserving the exact source path", () => {
+		const imagePath = `/tmp/Screenshot 2026-07-09 at 10.00.00${NNBSP}PM.png`;
+		expect(formatPastedImageReference("[image 1]", imagePath)).toBe(
+			`[image 1] source="/tmp/Screenshot 2026-07-09 at 10.00.00${NNBSP}PM.png"`,
+		);
+	});
+
+	it("JSON-escapes paths so spaces, quotes, and backslashes stay model-readable", () => {
+		expect(formatPastedImageReference("[image 2]", String.raw`C:\Users\me\shot "final".png`)).toBe(
+			String.raw`[image 2] source="C:\\Users\\me\\shot \"final\".png"`,
+		);
 	});
 });
 

--- a/scripts/gjc-session/postmortem.sh
+++ b/scripts/gjc-session/postmortem.sh
@@ -64,7 +64,8 @@ import sys
     prompt_accepted_json,
 ) = sys.argv[1:]
 
-def rel_to_workdir(value: str) -> str | None:
+
+def rel_to_workdir(value):
     if not value:
         return None
     try:

--- a/scripts/gjc-session/prompt.sh
+++ b/scripts/gjc-session/prompt.sh
@@ -26,16 +26,25 @@ find_durable_pane_logs() {
     find "${GJC_SESSION_LOG_SEARCH_ROOT:-$HOME/Workspace}" \( -path "*/.gjc-session-state/$SESSION/pane.log" -o -path "*/$SESSION/pane.log" \) -type f 2>/dev/null | sort
   fi
 }
+first_durable_pane_log() {
+  local candidate
+  while IFS= read -r candidate; do
+    printf '%s\n' "$candidate"
+    return 0
+  done < <(find_durable_pane_logs)
+  return 1
+}
+
 
 prompt_accepted_path() {
   if [[ -n "${GJC_SESSION_STATE_DIR:-}" && -z "${GJC_SESSION_LOG_SEARCH_ROOT:-}" ]]; then
     printf '%s\n' "$GJC_SESSION_STATE_DIR/prompt-accepted.json"
     return 0
   fi
-  local candidates=()
-  mapfile -t candidates < <(find_durable_pane_logs)
-  if [[ "${#candidates[@]}" -gt 0 ]]; then
-    printf '%s\n' "$(dirname "${candidates[0]}")/prompt-accepted.json"
+  local candidate
+  candidate="$(first_durable_pane_log || true)"
+  if [[ -n "$candidate" ]]; then
+    printf '%s\n' "$(dirname "$candidate")/prompt-accepted.json"
   fi
 }
 
@@ -232,10 +241,10 @@ fi
 
 PANE_TEXT="$(${TMUX_CMD[@]} capture-pane -t "$SESSION":0.0 -p -S -80 2>/dev/null || true)"
 if [[ -z "$PANE_TEXT" ]]; then
-  mapfile -t candidates < <(find_durable_pane_logs)
-  if [[ "${#candidates[@]}" -gt 0 ]]; then
-    write_pre_prompt_vanished "tmux_session_missing_before_prompt_injection" "before_prompt_injection" false "${candidates[0]}"
-    show_missing_session_diagnostics "${candidates[0]}"
+  candidate="$(first_durable_pane_log || true)"
+  if [[ -n "$candidate" ]]; then
+    write_pre_prompt_vanished "tmux_session_missing_before_prompt_injection" "before_prompt_injection" false "$candidate"
+    show_missing_session_diagnostics "$candidate"
   else
     write_pre_prompt_vanished "tmux_session_missing_before_prompt_injection" "before_prompt_injection" false ""
     echo "refusing to paste prompt: tmux session $SESSION is not readable and no durable pane log was found" >&2
@@ -243,9 +252,9 @@ if [[ -z "$PANE_TEXT" ]]; then
   exit 1
 fi
 if ! printf '%s\n' "$PANE_TEXT" | grep -qE 'Gajae forge|Type your message|> Type your message|Working'; then
-  mapfile -t candidates < <(find_durable_pane_logs)
-  if [[ "${#candidates[@]}" -gt 0 ]]; then
-    write_pre_prompt_vanished "tmux_session_unready_before_prompt_injection" "before_prompt_injection" false "${candidates[0]}"
+  candidate="$(first_durable_pane_log || true)"
+  if [[ -n "$candidate" ]]; then
+    write_pre_prompt_vanished "tmux_session_unready_before_prompt_injection" "before_prompt_injection" false "$candidate"
   else
     write_pre_prompt_vanished "tmux_session_unready_before_prompt_injection" "before_prompt_injection" false ""
   fi
@@ -263,10 +272,9 @@ EVIDENCE_LOG_IS_TEMP=0
 if [[ -n "${GJC_SESSION_STATE_DIR:-}" && -z "${GJC_SESSION_LOG_SEARCH_ROOT:-}" && -f "$GJC_SESSION_STATE_DIR/pane.log" ]]; then
   EVIDENCE_LOG="$GJC_SESSION_STATE_DIR/pane.log"
 else
-  durable_log_candidates=()
-  mapfile -t durable_log_candidates < <(find_durable_pane_logs)
-  if [[ "${#durable_log_candidates[@]}" -gt 0 ]]; then
-    EVIDENCE_LOG="${durable_log_candidates[0]}"
+  durable_log_candidate="$(first_durable_pane_log || true)"
+  if [[ -n "$durable_log_candidate" ]]; then
+    EVIDENCE_LOG="$durable_log_candidate"
   else
     EVIDENCE_LOG="$(mktemp "${TMPDIR:-/tmp}/gjc-session-prompt-evidence.XXXXXX")"
     EVIDENCE_LOG_IS_TEMP=1
@@ -326,10 +334,10 @@ for _ in $(seq 1 "$PROMPT_EVIDENCE_ATTEMPTS"); do
   fi
   PANE_TEXT="$(${TMUX_CMD[@]} capture-pane -t "$SESSION":0.0 -p -S -120 2>/dev/null || true)"
   if [[ -z "$PANE_TEXT" ]]; then
-    mapfile -t candidates < <(find_durable_pane_logs)
-    if [[ "${#candidates[@]}" -gt 0 ]]; then
-      write_pre_prompt_vanished "tmux_session_missing_before_prompt_acceptance" "before_prompt_acceptance" true "${candidates[0]}"
-      show_missing_session_diagnostics "${candidates[0]}"
+    candidate="$(first_durable_pane_log || true)"
+    if [[ -n "$candidate" ]]; then
+      write_pre_prompt_vanished "tmux_session_missing_before_prompt_acceptance" "before_prompt_acceptance" true "$candidate"
+      show_missing_session_diagnostics "$candidate"
     else
       write_pre_prompt_vanished "tmux_session_missing_before_prompt_acceptance" "before_prompt_acceptance" true ""
       echo "prompt acceptance failed: tmux session $SESSION vanished before durable turn evidence" >&2

--- a/scripts/gjc-session/tail.sh
+++ b/scripts/gjc-session/tail.sh
@@ -35,9 +35,13 @@ if [[ -n "${GJC_SESSION_STATE_DIR:-}" && -f "$GJC_SESSION_STATE_DIR/pane.log" ]]
   show_durable_state "$GJC_SESSION_STATE_DIR/pane.log"
   exit 0
 fi
-mapfile -t candidates < <(find "${GJC_SESSION_LOG_SEARCH_ROOT:-$HOME/Workspace}" \( -path "*/.gjc-session-state/$SESSION/pane.log" -o -path "*/$SESSION/pane.log" \) -type f 2>/dev/null | sort)
-if [[ "${#candidates[@]}" -gt 0 ]]; then
-  show_durable_state "${candidates[0]}"
+candidate=""
+while IFS= read -r found; do
+  candidate="$found"
+  break
+done < <(find "${GJC_SESSION_LOG_SEARCH_ROOT:-$HOME/Workspace}" \( -path "*/.gjc-session-state/$SESSION/pane.log" -o -path "*/$SESSION/pane.log" \) -type f 2>/dev/null | sort)
+if [[ -n "$candidate" ]]; then
+  show_durable_state "$candidate"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- keep pasted image placeholders attached to image payloads while adding an exact source path annotation
- make pasted image context model-readable as `[image N] source="/path"` instead of losing the raw path
- add regression coverage for source-path formatting

## Verification
- bun test packages/coding-agent/test/pasted-image-path.test.ts
- bun run check