### PR TITLE
test: fix current dev affected CI after #1898

### DIFF
--- a/packages/ai/test/google-gemini-cli-user-agent.test.ts
+++ b/packages/ai/test/google-gemini-cli-user-agent.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { getGeminiCliUserAgent } from "../src/providers/google-gemini-cli";
+import { DEFAULT_GEMINI_CLI_VERSION } from "../src/providers/google-gemini-headers";
 
 describe("Google Gemini CLI user agent", () => {
 	const originalGjcVersion = process.env.GJC_AI_GEMINI_CLI_VERSION;
@@ -22,7 +23,9 @@ describe("Google Gemini CLI user agent", () => {
 		delete process.env.GJC_AI_GEMINI_CLI_VERSION;
 		delete process.env.PI_AI_GEMINI_CLI_VERSION;
 
-		expect(getGeminiCliUserAgent("gemini-2.5-flash")).toContain("GeminiCLI/0.49.0/gemini-2.5-flash");
+		expect(getGeminiCliUserAgent("gemini-2.5-flash")).toContain(
+			`GeminiCLI/${DEFAULT_GEMINI_CLI_VERSION}/gemini-2.5-flash`,
+		);
 	});
 
 	it("prefers the documented GJC Gemini CLI version override", () => {

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -717,7 +717,7 @@ describe("InputController pasted clipboard image paths", () => {
 	const RED_1X1_PNG_BASE64 =
 		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
 
-	it("attaches terminal-pasted clipboard temp images and inserts a compact placeholder", async () => {
+	it("attaches terminal-pasted clipboard temp images and preserves the source path in the placeholder", async () => {
 		const imagePath = `/tmp/clipboard-2026-06-04-120441-${process.pid.toString(36)}CAC144E7.png`;
 		await Bun.write(imagePath, Buffer.from(RED_1X1_PNG_BASE64, "base64"));
 		try {
@@ -728,7 +728,7 @@ describe("InputController pasted clipboard image paths", () => {
 			const handled = await editor.onPasteText?.(`${imagePath}\n`);
 
 			expect(handled).toBe(true);
-			expect(editor.getText()).toBe("[image 1] ");
+			expect(editor.getText()).toBe(`[image 1] source="${imagePath}" `);
 			expect(ctx.pendingImages).toHaveLength(1);
 			expect(ctx.pendingImages[0]?.mimeType).toBe("image/png");
 			expect(spies.showStatus).toHaveBeenCalledWith(`Attached image: ${imagePath.split("/").at(-1)}`, { dim: true });


### PR DESCRIPTION
## Summary
- Align the Gemini CLI user-agent test with the shared default version constant bumped by #1898.
- Align the input-controller pasted image regression test with the #1898 behavior that preserves the source path in the inserted placeholder.

## Reproduction
- `bun test packages/ai/test/google-gemini-cli-3x-thinking.test.ts packages/ai/test/google-gemini-cli-429.test.ts packages/ai/test/google-gemini-cli-alignment.test.ts packages/ai/test/google-gemini-cli-tool-choice.test.ts packages/ai/test/google-gemini-cli-user-agent.test.ts` reproduced the stale `0.49.0` expectation before the fix.
- `bun test --shard=4/8` in `packages/coding-agent` reproduced the stale compact placeholder expectation before the fix.

## Validation
- `bun test packages/ai/test/google-gemini-cli-user-agent.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/pasted-image-path.test.ts`
- `bun test packages/ai/test/google-gemini-cli-3x-thinking.test.ts packages/ai/test/google-gemini-cli-429.test.ts packages/ai/test/google-gemini-cli-alignment.test.ts packages/ai/test/google-gemini-cli-tool-choice.test.ts packages/ai/test/google-gemini-cli-user-agent.test.ts`
- `bun test --shard=4/8` from `packages/coding-agent`
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/coding-agent run check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*