### PR TITLE
Fix ultragoal review gh fallback CI timeout

### DIFF
--- a/packages/coding-agent/test/gjc-runtime/ultragoal-review.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-review.test.ts
@@ -208,6 +208,21 @@ async function writeQa(root: string, qa: Record<string, unknown>): Promise<strin
 	return file;
 }
 
+async function withUnavailableGh<T>(root: string, callback: () => Promise<T>): Promise<T> {
+	const fakeBin = path.join(root, "fake-bin");
+	await fs.mkdir(fakeBin, { recursive: true });
+	const fakeGh = path.join(fakeBin, "gh");
+	await Bun.write(fakeGh, "#!/bin/sh\necho 'gh unavailable in test' >&2\nexit 127\n");
+	await fs.chmod(fakeGh, 0o755);
+	const originalPath = process.env.PATH;
+	process.env.PATH = `${fakeBin}${path.delimiter}${originalPath ?? ""}`;
+	try {
+		return await callback();
+	} finally {
+		if (originalPath === undefined) delete process.env.PATH;
+		else process.env.PATH = originalPath;
+	}
+}
 async function review(root: string, args: string[]): Promise<Record<string, unknown>> {
 	const result = await runNativeUltragoalCommand(["review", ...args, "--json"], root);
 	expect(result.status).toBe(0);
@@ -274,9 +289,11 @@ describe("ultragoal review command", () => {
 		expect((await review(root, ["--branch", "HEAD", "--executor-qa-json", qaPath])).source).toMatchObject({
 			kind: "branch",
 		});
-		expect((await review(root, ["--pr", "123", "--executor-qa-json", qaPath])).source).toMatchObject({
-			kind: "pr",
-			prSource: "gh-unavailable",
+		await withUnavailableGh(root, async () => {
+			expect((await review(root, ["--pr", "123", "--executor-qa-json", qaPath])).source).toMatchObject({
+				kind: "pr",
+				prSource: "gh-unavailable",
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Make the ultragoal review PR fallback test isolate `gh` with a fast fake executable that exits non-zero.
- Keep production `gh` fallback behavior unchanged; the test now covers the unavailable path without depending on CI host `gh` auth/network behavior or the 5s subprocess timeout.

## CI failure
- https://github.com/Yeachan-Heo/gajae-code/actions/runs/29005992292
- Failing job: Affected path validation / test:@gajae-code/coding-agent:shard-4-of-8

## Root cause
The test expected `--pr` review to hit the `gh-unavailable` fallback, but it allowed the real `gh` lookup/probe to run. On CI, an installed but unauthenticated or slow `gh` can consume the 5s production probe timeout, racing Bun's 5s test timeout and leaving the review helper to fail between tests. The fallback semantics were correct; the test harness was timing/environment-sensitive.

## Validation
- `bun test packages/coding-agent/test/gjc-runtime/ultragoal-review.test.ts -t "parses branch and worktree sources and falls back when gh is unavailable for pr"` (5 repeats passed)
- `bun test packages/coding-agent/test/gjc-runtime/ultragoal-review.test.ts`
- `bun biome check packages/coding-agent/test/gjc-runtime/ultragoal-review.test.ts`
- `bun test --shard=4/8` from `packages/coding-agent`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*