### PR TITLE
Reap orphaned Telegram session topics

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -146,6 +146,7 @@ const TYPING_REFRESH_INTERVAL_MS = 4_000;
 const QUEUED_REACTION = "👀";
 const PENDING_TOPIC_FRAME_LIMIT = 20;
 const SEEN_UPDATE_ID_LIMIT = 1_000;
+const ORPHAN_TOPIC_GRACE_MS = 60_000;
 const CONSUMED_REACTION = "✅";
 
 function splitTelegramPlainText(text: string, max = TELEGRAM_MESSAGE_LIMIT): string[] {
@@ -1414,29 +1415,44 @@ export class TelegramNotificationDaemon {
 	async scanRoots(): Promise<void> {
 		const paths = daemonPaths(this.opts.settings.getAgentDir());
 		const rootState = await readJson<{ roots?: string[] }>(this.fsImpl, paths.roots);
+		const endpointSessionIds = new Set<string>();
+		let allRootsReadable = true;
 		for (const root of rootState?.roots ?? []) {
 			const dir = path.join(root, "notifications");
 			let files: string[];
 			try {
 				files = await this.fsImpl.readdir(dir);
 			} catch {
+				allRootsReadable = false;
 				continue;
 			}
 			for (const file of files.filter(item => item.endsWith(".json"))) {
 				const sessionId = path.basename(file, ".json");
+				endpointSessionIds.add(sessionId);
 				if (this.sessions.has(sessionId)) continue;
 				try {
 					const endpoint = readEndpoint(path.join(dir, file));
 					// Skip endpoint files whose owning process is gone or that are
 					// explicitly stale (e.g. a hard-closed session): reconnecting
-					// would chase a dead, token-bearing record forever.
+					// would chase a dead, token-bearing record forever. Once the
+					// associated topic is past the grace window, reap it through the
+					// same best-effort delete path as graceful session shutdown.
 					const pidAlive = this.opts.pidAlive ?? defaultPidAlive;
-					if (endpoint.stale || (endpoint.pid !== undefined && !pidAlive(endpoint.pid))) continue;
+					if (endpoint.stale || (endpoint.pid !== undefined && !pidAlive(endpoint.pid))) {
+						await this.deleteOrphanedTopic(sessionId);
+						continue;
+					}
 					const endpointKey = endpointGenerationKey(endpoint.url, endpoint.token);
 					if (this.closedEndpointKeys.get(sessionId) === endpointKey) continue;
 					this.closedEndpointKeys.delete(sessionId);
 					this.connectSession(sessionId, endpoint.url, endpoint.token);
 				} catch {}
+			}
+		}
+		if (allRootsReadable) {
+			for (const sessionId of this.topics.sessionIds()) {
+				if (!this.sessions.has(sessionId) && !endpointSessionIds.has(sessionId))
+					await this.deleteOrphanedTopic(sessionId);
 			}
 		}
 	}
@@ -1681,6 +1697,16 @@ export class TelegramNotificationDaemon {
 		} catch {
 			return undefined;
 		}
+	}
+
+	private topicPastOrphanGrace(sessionId: string): boolean {
+		const record = this.topics.get(sessionId);
+		return record !== undefined && this.runtime.now() - record.createdAt >= ORPHAN_TOPIC_GRACE_MS;
+	}
+
+	private async deleteOrphanedTopic(sessionId: string): Promise<void> {
+		if (!this.topicPastOrphanGrace(sessionId)) return;
+		await this.deleteTopic(sessionId);
 	}
 
 	/** Best-effort delete of a session topic once its local notification endpoint shuts down. */

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -2985,6 +2985,102 @@ test("scanRoots connects only live endpoints (skips stale + dead-PID records)", 
 	expect(FakeWs.instances.every(ws => ws.url.startsWith("ws://live"))).toBe(true);
 });
 
+test("scanRoots reaps stale and dead-PID session topics after the orphan grace window", async () => {
+	FakeWs.instances = [];
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const cwd = path.join(agentDir, "repo");
+	await registerNotificationRoot({ settings: s, cwd, sessionId: "stale" });
+	await registerNotificationRoot({ settings: s, cwd, sessionId: "dead" });
+	const endpointDir = path.join(cwd, ".gjc", "state", "notifications");
+	fs.mkdirSync(endpointDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(endpointDir, "stale.json"),
+		JSON.stringify({ url: "ws://stale", token: "t", stale: true }),
+	);
+	fs.writeFileSync(path.join(endpointDir, "dead.json"), JSON.stringify({ url: "ws://dead", token: "t", pid: 999999 }));
+	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+		JSON.stringify({
+			topics: {
+				stale: { topicId: "101", identitySent: true, createdAt: 0, name: "stale" },
+				dead: { topicId: "102", identitySent: true, createdAt: 0, name: "dead" },
+			},
+		}),
+	);
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+		pidAlive: () => false,
+		now: () => 120_000,
+	});
+	await daemon.loadTopics();
+	await daemon.scanRoots();
+	expect(
+		bot.calls
+			.filter(c => c.method === "deleteForumTopic")
+			.map(c => c.body.message_thread_id)
+			.sort(),
+	).toEqual([101, 102]);
+	expect(daemon.sessions.size).toBe(0);
+});
+
+test("scanRoots reaps missing endpoint topics only when all roots are readable and grace has elapsed", async () => {
+	const agentDir = tempAgentDir();
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const cwd = path.join(agentDir, "repo");
+	await registerNotificationRoot({ settings: s, cwd, sessionId: "missing" });
+	fs.mkdirSync(path.join(cwd, ".gjc", "state", "notifications"), { recursive: true });
+	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+		JSON.stringify({ topics: { missing: { topicId: "201", identitySent: true, createdAt: 0, name: "missing" } } }),
+	);
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		now: () => 120_000,
+	});
+	await daemon.loadTopics();
+	await daemon.scanRoots();
+	expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([201]);
+
+	const blockedAgentDir = tempAgentDir();
+	const blockedSettings = setPrivateAgentDir(settings(blockedAgentDir), blockedAgentDir);
+	await registerNotificationRoot({
+		settings: blockedSettings,
+		cwd: path.join(blockedAgentDir, "unreadable"),
+		sessionId: "kept",
+	});
+	fs.mkdirSync(daemonPaths(blockedAgentDir).dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(daemonPaths(blockedAgentDir).dir, "telegram-topics.json"),
+		JSON.stringify({ topics: { kept: { topicId: "202", identitySent: true, createdAt: 0, name: "kept" } } }),
+	);
+	const blockedBot = new FakeBotApi();
+	const blockedDaemon = new TelegramNotificationDaemon({
+		settings: blockedSettings,
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: blockedBot,
+		now: () => 120_000,
+	});
+	await blockedDaemon.loadTopics();
+	await blockedDaemon.scanRoots();
+	expect(blockedBot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+});
+
 test("runDaemonInternal wires SIGTERM to the daemon stop method", async () => {
 	const agentDir = tempAgentDir();
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);


### PR DESCRIPTION
## Summary
- reap Telegram forum topics for stale/dead notification endpoints after a 60s orphan grace window
- reap missing-endpoint topics only when every registered notification root is readable
- preserve graceful shutdown deletion behavior and add focused scanRoots coverage

## Verification
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts -t "scanRoots"`
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts`
- `bun --cwd=packages/coding-agent run check`

Closes #1901

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
