### PR TITLE
Fix ask inline Esc aborting workflow streams

### DIFF
--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -434,6 +434,10 @@ export class HookSelectorComponent extends Container {
 		this.#updateList();
 	}
 
+	hasActiveInlineInput(): boolean {
+		return this.#inlineEditor !== undefined;
+	}
+
 	#updateList(): void {
 		if (this.#wrapFocused && this.#focusAwareList) {
 			this.#focusAwareList.setState(this.#options, this.#selectedIndex, this.#maxVisible);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -149,6 +149,12 @@ export class InputController {
 				return { consume: true };
 			}
 			const hookDialogActive = this.#hasHookDialog();
+			if (this.ctx.hookSelector?.hasActiveInlineInput?.() === true) {
+				// Inline ask/custom-input editors use Esc to return to the option list.
+				// Let the focused selector see the key instead of converting a typo
+				// into a full workflow/session abort while the agent is streaming.
+				return undefined;
+			}
 			if (
 				this.#handleCancellableWorkEscape({
 					loading: hookDialogActive,

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -437,6 +437,20 @@ describe("InputController escape behavior", () => {
 		expect(spies.abort).toHaveBeenCalledTimes(1);
 		expect(spies.abort).toHaveBeenCalledWith(expect.objectContaining({ cause: "user_interrupt" }));
 	});
+	it("lets hook selector inline input handle Esc locally during a workflow stream", () => {
+		const { ctx, inputListeners, spies } = createContext();
+		(ctx.session as { isStreaming: boolean }).isStreaming = true;
+		ctx.hookSelector = {
+			hasActiveInlineInput: () => true,
+		} as InteractiveModeContext["hookSelector"];
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		const result = inputListeners[0]?.("\x1b");
+
+		expect(result).toBeUndefined();
+		expect(spies.abort).not.toHaveBeenCalled();
+	});
 
 	it("does not globally steal draft-clearing Esc from a normal stream", () => {
 		const { ctx, editor, inputListeners, spies } = createContext();


### PR DESCRIPTION
## Summary
- Keep Esc local to the ask tool's inline custom-input editor while it is open.
- Prevent the global workflow-stream interrupt handler from aborting the whole session when the user meant to return from `Other (type your own)` to the option list.
- Add regression coverage for hook selector inline input during an active workflow stream.

## Problem
Deep-interview/ask selector help text says Esc backs out of inline custom input to the option list. During workflow streams, the global app interrupt listener receives Esc first and calls `session.abort()`, causing `Ask input was cancelled` / `Operation aborted` instead of returning to the choices.

## Fix
- Expose `HookSelectorComponent.hasActiveInlineInput()`.
- In `InputController`'s global interrupt listener, let the focused hook selector handle Esc when inline input is active.
- Preserve the existing behavior where Esc still cancels a normal hook dialog/workflow stream when inline input is not active.

## Tests
- `bun test packages/coding-agent/test/input-controller-escape.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/modes/components/hook-selector.ts packages/coding-agent/src/modes/controllers/input-controller.ts packages/coding-agent/test/input-controller-escape.test.ts`

## Notes
- Target branch follows CONTRIBUTING.md: `dev`.
- User-facing behavior change is limited to the inline custom-input editor's documented Esc behavior.

## Risks
Low. The change only bypasses the global interrupt path when the hook selector has an active inline input editor; other Esc paths remain covered by existing tests.