### PR TITLE
fix(notifications): reap orphaned Telegram forum topics for dead session endpoints

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Finalized notification turn mirrors now default to the bounded full-turn cap so Telegram's existing chunked delivery can send long assistant answers instead of receiving an already-truncated 3500-character summary; `GJC_NOTIFICATIONS_TURN_MAX` remains available to lower the cap for summary-style mirrors, and live previews stay capped as one editable message.
+- The Telegram notification daemon now reaps forum topics whose owning session endpoint has been dead (missing endpoint record, stale record, or dead PID) for over a minute, so killed panes, crashes, and power loss no longer leave permanent orphaned topics — including provisional `GJC <session>` topics — that the user cannot delete from the Telegram client. Clean shutdowns keep deleting the topic immediately, live endpoints are never touched, and reaping fail-closes for a scan when any notifications root is unreadable.
 - `gjc --tmux` now wraps the inner GJC command with a durable `tmux-exit.json` marker next to `runtime-state.json`, so a tmux-resident session that exits before normal runtime-state finalization leaves a public-safe exit timestamp/code for silent-vanish diagnosis (#1746).
 - `gjc --tmux` terminal titles now track live tmux session renames while preserving the friendly project/branch title for untouched generated session ids.
 - Telegram session forum-topic renames now remain retryable after a transient `editForumTopic` failure, so topics do not get stuck at the provisional `GJC <session>` name while the daemon incorrectly records the final title locally.

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -146,6 +146,13 @@ const TYPING_REFRESH_INTERVAL_MS = 4_000;
 const QUEUED_REACTION = "👀";
 const PENDING_TOPIC_FRAME_LIMIT = 20;
 const SEEN_UPDATE_ID_LIMIT = 1_000;
+/**
+ * How long a session's notification endpoint must stay dead (missing endpoint
+ * record, stale record, or dead PID) before its forum topic is reaped. Clean
+ * shutdowns delete the topic immediately via `session_closed`; this grace
+ * window keeps transient restarts/reconnects from losing a live topic.
+ */
+const ORPHAN_TOPIC_GRACE_MS = 60_000;
 const CONSUMED_REACTION = "✅";
 
 function splitTelegramPlainText(text: string, max = TELEGRAM_MESSAGE_LIMIT): string[] {
@@ -916,6 +923,8 @@ export class TelegramNotificationDaemon {
 	private readonly pendingThreadedFrames = new Map<string, PendingThreadedFrame[]>();
 	/** Endpoint generation tombstones for sessions that already sent session_closed. */
 	private readonly closedEndpointKeys = new Map<string, string>();
+	/** First scan time (ms) each topic-owning session was seen with a dead endpoint. */
+	private readonly orphanTopicSince = new Map<string, number>();
 	/** True once the daemon has nudged the user to enable Threaded Mode. */
 	private threadedFallbackNoticeSent = false;
 	/** Sessions whose identity header was already sent flat (Threaded Mode off). */
@@ -1414,12 +1423,21 @@ export class TelegramNotificationDaemon {
 	async scanRoots(): Promise<void> {
 		const paths = daemonPaths(this.opts.settings.getAgentDir());
 		const rootState = await readJson<{ roots?: string[] }>(this.fsImpl, paths.roots);
+		// Sessions whose endpoint record is owned by a live process. Feeds the
+		// orphan-topic reap below; currently-connected sessions are tracked
+		// separately via `this.sessions`.
+		const liveEndpointSessions = new Set<string>();
+		let sawUnreadableRoot = false;
 		for (const root of rootState?.roots ?? []) {
 			const dir = path.join(root, "notifications");
 			let files: string[];
 			try {
 				files = await this.fsImpl.readdir(dir);
-			} catch {
+			} catch (err) {
+				// A missing notifications dir simply means no endpoints under this
+				// root; any other readdir failure hides potentially-live sessions,
+				// so orphan-topic reaping must skip this scan (fail closed).
+				if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") sawUnreadableRoot = true;
 				continue;
 			}
 			for (const file of files.filter(item => item.endsWith(".json"))) {
@@ -1432,11 +1450,49 @@ export class TelegramNotificationDaemon {
 					// would chase a dead, token-bearing record forever.
 					const pidAlive = this.opts.pidAlive ?? defaultPidAlive;
 					if (endpoint.stale || (endpoint.pid !== undefined && !pidAlive(endpoint.pid))) continue;
+					liveEndpointSessions.add(sessionId);
 					const endpointKey = endpointGenerationKey(endpoint.url, endpoint.token);
 					if (this.closedEndpointKeys.get(sessionId) === endpointKey) continue;
 					this.closedEndpointKeys.delete(sessionId);
 					this.connectSession(sessionId, endpoint.url, endpoint.token);
-				} catch {}
+				} catch (err) {
+					// An endpoint file that vanished between readdir and read is a
+					// genuine dead sighting (the grace window will confirm it). Any
+					// other failure — malformed JSON, schema violation, permission
+					// error — is UNKNOWN liveness, not death: protect the session
+					// from reaping this scan by counting it as live (fail closed).
+					if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") liveEndpointSessions.add(sessionId);
+				}
+			}
+		}
+		if (!sawUnreadableRoot) await this.reapOrphanTopics(liveEndpointSessions);
+	}
+
+	/**
+	 * Delete topics whose owning session endpoint has been dead (missing, stale,
+	 * or dead-PID) for longer than {@link ORPHAN_TOPIC_GRACE_MS}. Clean shutdowns
+	 * delete their topic immediately via `session_closed`; this reaper covers
+	 * killed panes, crashes, and power loss, which otherwise leave topics behind
+	 * forever (the user cannot delete bot-owned private-chat topics themselves).
+	 */
+	private async reapOrphanTopics(liveEndpointSessions: ReadonlySet<string>): Promise<void> {
+		const now = this.runtime.now();
+		for (const sessionId of this.topics.sessionIds()) {
+			if (liveEndpointSessions.has(sessionId) || this.sessions.has(sessionId)) {
+				this.orphanTopicSince.delete(sessionId);
+				continue;
+			}
+			const since = this.orphanTopicSince.get(sessionId);
+			if (since === undefined) {
+				this.orphanTopicSince.set(sessionId, now);
+				continue;
+			}
+			if (now - since < ORPHAN_TOPIC_GRACE_MS) continue;
+			await this.deleteTopic(sessionId);
+			if (this.topics.get(sessionId)) {
+				// Telegram refused the delete (e.g. missing topic permissions);
+				// retry after a fresh grace window instead of every scan tick.
+				this.orphanTopicSince.set(sessionId, now);
 			}
 		}
 	}
@@ -1705,6 +1761,7 @@ export class TelegramNotificationDaemon {
 				if (ownerSessionId === sessionId) this.topicOwnerByIdentity.delete(identityKey);
 			});
 			this.pendingThreadedFrames.delete(sessionId);
+			this.orphanTopicSince.delete(sessionId);
 			await this.persistTopics();
 		} catch {
 			// Best-effort: missing Telegram topic permissions must not stop teardown.

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -4022,3 +4022,172 @@ describe("telegram daemon /rich toggle (G005)", () => {
 		expect(bot.calls.some(c => c.method === "sendMessage" && c.body.text === "Rich messages: off")).toBe(false);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Orphan topic reaping: sessions that die without a clean `session_closed`
+// (killed panes, crashes, power loss) must not leave their forum topic behind
+// forever — the user cannot delete bot-owned private-chat topics themselves.
+// ---------------------------------------------------------------------------
+describe("telegram daemon orphan topic reaping", () => {
+	const GRACE = 60_000;
+
+	function seedTopics(agentDir: string, sessionId: string, topicId: string) {
+		const dir = daemonPaths(agentDir).dir;
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(dir, "telegram-topics.json"),
+			JSON.stringify({ topics: { [sessionId]: { topicId, identitySent: true, createdAt: 0, name: "GJC S" } } }),
+		);
+	}
+
+	function reapDaemon(
+		s: Settings,
+		bot: FakeBotApi,
+		now: () => number,
+		pidAlive: (pid: number) => boolean = () => false,
+	) {
+		return new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			pidAlive,
+			now,
+		});
+	}
+
+	test("a topic whose endpoint record is gone is deleted only after the grace window", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		await registerNotificationRoot({ settings: s, cwd: path.join(agentDir, "repo"), sessionId: "S" });
+		seedTopics(agentDir, "S", "777");
+		let now = 0;
+		const bot = new FakeBotApi();
+		const daemon = reapDaemon(s, bot, () => now);
+		await daemon.loadTopics();
+
+		await daemon.scanRoots(); // first dead sighting only marks the orphan
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+
+		now += GRACE - 1;
+		await daemon.scanRoots(); // still inside the grace window
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+
+		now += 1;
+		await daemon.scanRoots();
+		const del = bot.calls.find(c => c.method === "deleteForumTopic");
+		expect(del?.body.message_thread_id).toBe(777);
+		const topicsFile = path.join(daemonPaths(agentDir).dir, "telegram-topics.json");
+		expect(fs.readFileSync(topicsFile, "utf8").includes('"S"')).toBe(false);
+	});
+
+	test("a live endpoint keeps its topic across the grace window", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const cwd = path.join(agentDir, "repo");
+		await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
+		const endpointDir = path.join(cwd, ".gjc", "state", "notifications");
+		fs.mkdirSync(endpointDir, { recursive: true });
+		fs.writeFileSync(path.join(endpointDir, "S.json"), JSON.stringify({ url: "ws://live", token: "t", pid: 4242 }));
+		seedTopics(agentDir, "S", "778");
+		let now = 0;
+		const bot = new FakeBotApi();
+		const daemon = reapDaemon(s, bot, () => now, pid => pid === 4242);
+		await daemon.loadTopics();
+
+		await daemon.scanRoots();
+		now += GRACE + 1;
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	});
+
+	test("an endpoint that comes back within the grace window resets the reap clock", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const cwd = path.join(agentDir, "repo");
+		await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
+		const endpointDir = path.join(cwd, ".gjc", "state", "notifications");
+		fs.mkdirSync(endpointDir, { recursive: true });
+		seedTopics(agentDir, "S", "779");
+		let now = 0;
+		const bot = new FakeBotApi();
+		const daemon = reapDaemon(s, bot, () => now, pid => pid === 4242);
+		await daemon.loadTopics();
+
+		await daemon.scanRoots(); // dead: mark at t=0
+
+		now = 30_000; // session resumes inside the grace window
+		fs.writeFileSync(path.join(endpointDir, "S.json"), JSON.stringify({ url: "ws://live", token: "t", pid: 4242 }));
+		await daemon.scanRoots(); // live again: mark cleared, session connects
+		expect(daemon.sessions.has("S")).toBe(true);
+
+		// The session dies again (dead PID + closed socket).
+		fs.writeFileSync(path.join(endpointDir, "S.json"), JSON.stringify({ url: "ws://live", token: "t", pid: 9999 }));
+		FakeWs.instances[0]!.close();
+		expect(daemon.sessions.has("S")).toBe(false);
+
+		now = 61_000;
+		await daemon.scanRoots(); // fresh mark at t=61s — old t=0 mark must not fire
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+
+		now = 61_000 + GRACE + 1;
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(true);
+	});
+
+	test("an unreadable notifications root fail-closes reaping for that scan", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const cwd = path.join(agentDir, "repo");
+		const root = await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
+		// Make `<root>/notifications` fail readdir with something other than
+		// ENOENT (here: ENOTDIR), which must suppress reaping entirely.
+		fs.mkdirSync(root, { recursive: true });
+		fs.writeFileSync(path.join(root, "notifications"), "not a directory");
+		seedTopics(agentDir, "S", "780");
+		let now = 0;
+		const bot = new FakeBotApi();
+		const daemon = reapDaemon(s, bot, () => now);
+		await daemon.loadTopics();
+
+		await daemon.scanRoots();
+		now += GRACE + 1;
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	});
+
+	test("a malformed endpoint file protects its session from reaping (unknown, not dead)", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const cwd = path.join(agentDir, "repo");
+		await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
+		const endpointDir = path.join(cwd, ".gjc", "state", "notifications");
+		fs.mkdirSync(endpointDir, { recursive: true });
+		// Present but unparseable: liveness is UNKNOWN, so reaping must not fire.
+		fs.writeFileSync(path.join(endpointDir, "S.json"), "{not json");
+		seedTopics(agentDir, "S", "781");
+		let now = 0;
+		const bot = new FakeBotApi();
+		const daemon = reapDaemon(s, bot, () => now);
+		await daemon.loadTopics();
+
+		await daemon.scanRoots();
+		now += GRACE + 1;
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+
+		// Once the malformed record is actually removed, the normal reap applies.
+		fs.rmSync(path.join(endpointDir, "S.json"));
+		await daemon.scanRoots(); // dead sighting: mark
+		now += GRACE + 1;
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(true);
+	});
+});


### PR DESCRIPTION
## What

The Telegram notification daemon only deleted a session's forum topic on the clean `session_closed` frame. Sessions that die without one — killed tmux panes, crashes, power loss — left their topic behind permanently: `scanRoots` skipped dead-PID/stale endpoint records but never reconciled the persisted topic registry against them, and bot-owned private-chat topics cannot be deleted from the Telegram client UI, so orphans (including provisional `GJC <session>` topics) accumulated without bound.

This PR is item (1) of #1901.

## How

`scanRoots` now builds the set of topic-owning sessions that still look alive — a connected socket, or an endpoint record that is present, non-stale, and PID-alive — and a new `reapOrphanTopics` pass deletes topics whose session has stayed dead for a 60s grace window (`ORPHAN_TOPIC_GRACE_MS`), through the existing `deleteTopic` path (queued-send purge, registry delete, persistence).

Safety properties:

- **Fail closed on unknown liveness.** A per-root `readdir` failure other than ENOENT suppresses reaping for that scan; an endpoint file that exists but cannot be read/parsed (malformed JSON, schema violation, permission error) counts as *live* for that scan instead of dead. Only a genuinely missing (ENOENT), stale, or dead-PID endpoint is a dead sighting.
- **Grace window resets on resume.** An endpoint that comes back within the window clears the mark; the clock restarts on the next dead sighting.
- **No retry storm.** When Telegram refuses the delete, the mark is reset so the retry happens after a fresh grace window, not on every 1s scan tick.
- **Clean shutdown unchanged.** `session_closed` still deletes the topic immediately; connect/skip behavior in `scanRoots` is otherwise byte-for-byte the original logic.

## Tests

`bun test test/notifications-telegram-daemon.test.ts` — 116 pass (5 new):

- reap fires only after the grace window and removes the persisted record;
- a live endpoint is never reaped;
- an endpoint that resumes mid-window resets the reap clock (and a later real death still reaps);
- an unreadable notifications root (ENOTDIR) fail-closes reaping for that scan;
- a malformed endpoint file protects its session (unknown ≠ dead), and reap applies once the record is actually gone.

Full `bun test test/notifications-` suite: 474 pass / 0 fail; `bunx tsc --noEmit` clean. CHANGELOG entry included.
