### PR TITLE
Fix JS eval ToolError output

### DIFF
--- a/packages/coding-agent/src/eval/js/executor.ts
+++ b/packages/coding-agent/src/eval/js/executor.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_MAX_BYTES, OutputSink } from "../../session/streaming-output";
 import type { ToolSession } from "../../tools";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../../tools/output-meta";
+import { ToolError } from "../../tools/tool-errors";
 import { executeInVmContext, type JsDisplayOutput } from "./context-manager";
 
 export interface JsExecutorOptions {
@@ -117,7 +118,12 @@ export async function executeJs(code: string, options: JsExecutorOptions): Promi
 				displayOutputs,
 			};
 		}
-		const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+		const message =
+			error instanceof ToolError || (error instanceof Error && error.name === "ToolError")
+				? error.message
+				: error instanceof Error
+					? (error.stack ?? error.message)
+					: String(error);
 		outputSink.push(message);
 		const summary = await outputSink.dump();
 		return {


### PR DESCRIPTION
## Summary
- render JS eval ToolError failures with their safe message instead of preferring stack traces
- preserves stack output for ordinary user-code errors

## Verification
- bun test packages/coding-agent/test/core/js-executor.test.ts --test-name-pattern "rejects protocol paths and directory reads from native read"
- bun --cwd=packages/coding-agent run check
- bun test --shard=5/8 (cwd: packages/coding-agent)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*