### PR TITLE
fix(ai): embed models.json via file-type import so compiled release binaries can load the bundled catalog (v0.9.3 startup crash)

### DIFF
--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -1,6 +1,12 @@
-import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
 import { isRetiredModelKey } from "./model-retirements";
 import { applyGeneratedModelPolicies, enrichModelThinking } from "./model-thinking";
+// `with { type: "file" }` is embedded by `bun build --compile` and resolves to
+// the bunfs path inside standalone binaries (and to the on-disk path in dev).
+// A plain `createRequire` of a `.json` listed as an extra compile entrypoint is
+// NOT emitted into the bunfs, and its cwd-fallback masks the failure whenever
+// the process runs inside a repo checkout — see PR body for the minimal repro.
+import modelsJsonPath from "./models.json" with { type: "file" };
 import type { Api, KnownProvider, Model, Usage } from "./types";
 import { isClaudeForcedToolChoiceIncapableModelId } from "./utils/tool-choice-capability";
 
@@ -14,16 +20,14 @@ import { isClaudeForcedToolChoiceIncapableModelId } from "./utils/tool-choice-ca
  */
 type BundledCatalog = typeof import("./models.json");
 
-const require = createRequire(import.meta.url);
-const COMPILED_MODELS_PATH = "./packages/ai/src/models.json";
 let bundledCatalog: BundledCatalog | undefined;
 let providerNames: KnownProvider[] | undefined;
 const providerModelRegistry: Map<string, Map<string, Model<Api>>> = new Map();
 
 function getBundledCatalog(): BundledCatalog {
-	bundledCatalog ??= require(
-		process.env.PI_COMPILED === "true" ? COMPILED_MODELS_PATH : "./models.json",
-	) as BundledCatalog;
+	// TS types a .json import as its contents; at runtime `with { type: "file" }`
+	// yields the file path (bunfs path in compiled binaries, disk path in dev).
+	bundledCatalog ??= JSON.parse(readFileSync(modelsJsonPath as unknown as string, "utf8")) as BundledCatalog;
 	return bundledCatalog;
 }
 

--- a/packages/ai/test/models-lazy.test.ts
+++ b/packages/ai/test/models-lazy.test.ts
@@ -22,23 +22,35 @@ function runIsolationScript(script: string): unknown {
 }
 
 describe("bundled models catalog lazy loading", () => {
-	it("does not require models.json until the first synchronous accessor call", () => {
+	it("does not read models.json until the first synchronous accessor call", () => {
 		const modelsUrl = pathToFileURL(path.resolve(import.meta.dir, "../src/models.ts")).href;
 		const modelsJsonPath = path.resolve(import.meta.dir, "../src/models.json");
+		// The catalog is embedded via `import ... with { type: "file" }` and read
+		// lazily with fs.readFileSync. The lazy contract is therefore observable as
+		// "no filesystem read of models.json at import time; exactly one read on
+		// first accessor use" (module-cache presence no longer discriminates,
+		// because the file-type import registers the path eagerly without parsing).
 		const result = runIsolationScript(`
 import { createRequire } from "node:module";
-import * as fs from "node:fs";
 const require = createRequire(${JSON.stringify(modelsUrl)});
-const modelsJsonPath = require.resolve(${JSON.stringify(modelsJsonPath)});
+const fs = require("node:fs");
+const realReadFileSync = fs.readFileSync;
+let catalogReads = 0;
+fs.readFileSync = function (file, ...args) {
+	if (String(file).endsWith("models.json")) catalogReads += 1;
+	return realReadFileSync.call(this, file, ...args);
+};
 const modelsModule = await import(${JSON.stringify(modelsUrl)});
-const before = Boolean(require.cache[modelsJsonPath]);
-const directCatalog = JSON.parse(fs.readFileSync(modelsJsonPath, "utf8"));
+const before = catalogReads > 0;
+const directCatalog = JSON.parse(realReadFileSync(${JSON.stringify(modelsJsonPath)}, "utf8"));
 const providers = modelsModule.getBundledProviders();
 const model = modelsModule.getBundledModel("openai", "gpt-4o-mini");
-const after = Boolean(require.cache[modelsJsonPath]);
+const after = catalogReads > 0;
+modelsModule.getBundledProviders();
 console.log(JSON.stringify({
 	before,
 	after,
+	catalogReads,
 	providers,
 	directProviders: Object.keys(directCatalog),
 	model,
@@ -46,7 +58,7 @@ console.log(JSON.stringify({
 }));
 `);
 
-		expect(result).toMatchObject({ before: false, after: true });
+		expect(result).toMatchObject({ before: false, after: true, catalogReads: 1 });
 		expect((result as { providers: string[]; directProviders: string[] }).providers).toEqual(
 			(result as { providers: string[]; directProviders: string[] }).directProviders,
 		);

--- a/packages/ai/test/startup-imports.test.ts
+++ b/packages/ai/test/startup-imports.test.ts
@@ -24,13 +24,23 @@ function runIsolationScript(script: string): unknown {
 describe("AI package startup imports", () => {
 	it("does not parse the bundled model catalog when importing the barrel", () => {
 		const indexUrl = pathToFileURL(path.resolve(import.meta.dir, "../src/index.ts")).href;
-		const modelsJsonPath = path.resolve(import.meta.dir, "../src/models.json");
+		// The catalog is embedded via `import ... with { type: "file" }` and parsed
+		// lazily with fs.readFileSync, so the startup contract is observable as
+		// "importing the barrel performs no filesystem read of models.json"
+		// (module-cache presence no longer discriminates, because the file-type
+		// import registers the path eagerly without parsing).
 		const result = runIsolationScript(`
 import { createRequire } from "node:module";
 const require = createRequire(${JSON.stringify(indexUrl)});
-const modelsJsonPath = require.resolve(${JSON.stringify(modelsJsonPath)});
+const fs = require("node:fs");
+const realReadFileSync = fs.readFileSync;
+let catalogReads = 0;
+fs.readFileSync = function (file, ...args) {
+	if (String(file).endsWith("models.json")) catalogReads += 1;
+	return realReadFileSync.call(this, file, ...args);
+};
 await import(${JSON.stringify(indexUrl)});
-console.log(JSON.stringify({ catalogLoaded: Boolean(require.cache[modelsJsonPath]) }));
+console.log(JSON.stringify({ catalogLoaded: catalogReads > 0 }));
 `);
 
 		expect(result).toEqual({ catalogLoaded: false });

--- a/packages/coding-agent/scripts/compile-args.ts
+++ b/packages/coding-agent/scripts/compile-args.ts
@@ -24,7 +24,9 @@ export const releaseEntrypoints = [
 	"./packages/coding-agent/src/eval/js/worker-entry.ts",
 	"./packages/natives/native/index.js",
 	"./packages/coding-agent/src/notifications/telegram-daemon-cli.ts",
-	"./packages/ai/src/models.json",
+	// NOTE: models.json must NOT be listed here — `bun build --compile` does not
+	// emit `.json` extra entrypoints into the bunfs. It is embedded via the
+	// `with { type: "file" }` import in packages/ai/src/models.ts instead.
 	"./node_modules/handlebars/lib/index.js",
 ];
 
@@ -34,7 +36,6 @@ export const devEntrypoints = [
 	"./src/tools/browser/tab-worker-entry.ts",
 	"./src/eval/js/worker-entry.ts",
 	"./src/notifications/telegram-daemon-cli.ts",
-	"../ai/src/models.json",
 	"../../node_modules/handlebars/lib/index.js",
 ];
 


### PR DESCRIPTION
## Summary
- Every **v0.9.3 standalone release binary** crashes on any command that loads the model registry:
  ```
  [Uncaught Exception] ResolveMessage: Cannot find module './packages/ai/src/models.json' from '/$bunfs/root/gjc-linux-x64'
  ```
- Root cause: #1721 switched `packages/ai/src/models.ts` to a lazy `createRequire("./packages/ai/src/models.json")` under `PI_COMPILED`, relying on the `.json` being embedded via `releaseEntrypoints`. **`bun build --compile` does not emit `.json` extra entrypoints into the standalone bunfs**, so the require can never resolve in a compiled binary.
- Fix: import the catalog with `{ type: "file" }` — bun embeds file-type imports into the standalone binary and the import resolves to the bunfs path (disk path in dev). This **preserves the lazy-load memory/size win of #1721** (binary stays ~169MB). The now-inert `models.json` compile entrypoints are removed with a warning comment.

## Why nothing caught it
When the bunfs resolve fails, Bun's `createRequire` **falls back to resolving against the process cwd**. Any invocation from inside a gajae-code checkout silently reads the real `packages/ai/src/models.json` from disk and works — so repo-cwd testing (and the CI release smoke, which only runs `--version` / `--smoke-test`, neither of which touches the catalog) passes on a binary that crashes everywhere else.

Minimal repro of the mask (bun 1.3.14):
```sh
mkdir -p /tmp/repro/pkg/src && cd /tmp/repro
printf '{"hello":"world"}' > pkg/src/x.json
cat > pkg/src/main.ts <<'TS'
import { createRequire } from "node:module";
const require = createRequire(import.meta.url);
console.log(require("./pkg/src/x.json"));
TS
bun build --compile --root . ./pkg/src/main.ts ./pkg/src/x.json --outfile app
./app                    # OK  <- cwd fallback reads the file from disk
cd / && /tmp/repro/app   # FAIL: Cannot find module './pkg/src/x.json' from '/$bunfs/root/app'
```

## Affected scope
- **Standalone compiled release binaries: broken** (all platforms by construction; linux-x64 verified end-to-end — local build with the exact `ci-release-build-binaries` command reproduces the release asset failure byte-for-byte in behavior).
- **npm channel (`gajae-code`, `bin/gjc.js` → `runCli` from source): NOT affected** (`PI_COMPILED` never set; resolves real files). Explains "works on my machine" reports.

## Verification
- **v0.9.3 + this fix**, built with the exact release command (`bun 1.3.14`, `bun-linux-x64-baseline`): `--list-models` exits 0 **from a neutral cwd** (the previously-masked failure path); binary size 169,478,272 (size win preserved).
- `bun --cwd=packages/ai run check` clean; `bun test packages/ai/test/issue-489-repro.test.ts` 5/5.
- **dev HEAD + this fix**: the models.json failure is resolved; the compiled binary then surfaces a **separate pre-existing dev-only startup regression** (`Cannot find package 'handlebars' from '/$bunfs/root/…'`) which reproduces identically on **unpatched dev HEAD** and is not present in v0.9.3. It looks like the same masked-resolve class via `packages/utils/src/prompt.ts`. Out of scope here — happy to file it separately with the repro.

## Suggested follow-up (out of scope)
Extend the release-binary smoke to run a catalog-touching command **from a neutral working directory** (e.g. `cd "$(mktemp -d)" && "${binary_path}" --list-models`), so cwd fallback can never mask a missing embedded asset again.
