### PR TITLE
fix(provider): show concrete login hint

### DIFF
--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1020,8 +1020,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return commandConsumed();
 			}
 			if (args === "login" || args.startsWith("login ")) {
+				const providerId = args.slice("login".length).trim();
+				const loginCommand = providerId ? `/login ${providerId}` : "/login [provider-id]";
 				await runtime.output(
-					"Use the terminal UI /login selector for browser, device-code, or manual callback provider login.",
+					`Open the terminal UI and run ${loginCommand} for OAuth/subscription account login. Paste callbacks with /login <redirect URL or code>.`,
 				);
 				return commandConsumed();
 			}

--- a/packages/coding-agent/test/provider-slash-command.test.ts
+++ b/packages/coding-agent/test/provider-slash-command.test.ts
@@ -26,6 +26,32 @@ describe("provider slash command", () => {
 		expect(command?.allowArgs).toBe(true);
 	});
 
+	it("points generic provider login users to /login provider selection", async () => {
+		const outputs: string[] = [];
+		const command = BUILTIN_SLASH_COMMANDS_INTERNAL.find(entry => entry.name === "provider");
+
+		await command?.handle?.({ name: "provider", args: "login", text: "/provider login" }, {
+			output: (text: string) => outputs.push(text),
+		} as unknown as SlashCommandRuntime);
+
+		const output = outputs.join("\n");
+		expect(output).toContain("/login [provider-id]");
+		expect(output).toMatch(/OAuth|account/);
+	});
+
+	it("points provider-specific login users to the matching /login command", async () => {
+		const outputs: string[] = [];
+		const command = BUILTIN_SLASH_COMMANDS_INTERNAL.find(entry => entry.name === "provider");
+
+		await command?.handle?.({ name: "provider", args: "login kagi", text: "/provider login kagi" }, {
+			output: (text: string) => outputs.push(text),
+		} as unknown as SlashCommandRuntime);
+
+		const output = outputs.join("\n");
+		expect(output).toContain("/login kagi");
+		expect(output).toMatch(/OAuth|account/);
+	});
+
 	it("reports the /provicer typo without falling through to model bootstrap", async () => {
 		const errors: string[] = [];
 		const result = await executeBuiltinSlashCommand("/provicer add --compat anthropic", {


### PR DESCRIPTION
## Summary
- Add a concrete `/login [provider-id]` next-step hint for ACP/non-TUI `/provider login` output.
- Include provider-specific guidance such as `/login kagi` when `/provider login <provider>` is used.
- Preserve existing `/provider help`, `/provider add`, and TUI OAuth routing behavior.

Closes #1912.

## Validation
- `bun test packages/coding-agent/test/provider-slash-command.test.ts` — 9 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — passed (`biome check` + `tsgo -p tsconfig.json --noEmit`)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*