### PR TITLE
Fix Dev CI shard-8 status-line usage overflow

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -929,11 +929,8 @@ export class StatusLineComponent implements Component {
 		const totalWidth = () => leftWidth + rightWidth + (left.length > 0 && right.length > 0 ? 1 : 0);
 
 		if (topFillWidth > 0) {
-			while (totalWidth() > topFillWidth && right.length > 0) {
-				right.pop();
-				rightWidth = this.#groupWidth(right, rightCapWidth, rightSepWidth);
-			}
-			// Shrink path before dropping left segments — path is the only elastic segment
+			// Shrink path before dropping right-side telemetry — path is the only elastic segment,
+			// and presets such as default-usage should not hide usage just because cwd is long.
 			const pathIdx = leftIds.indexOf("path");
 			if (pathIdx >= 0 && totalWidth() > topFillWidth) {
 				const overflow = totalWidth() - topFillWidth;
@@ -942,6 +939,10 @@ export class StatusLineComponent implements Component {
 					left[pathIdx] = previewHighlightSegment === "path" ? `\x1b[7m${shrunk}\x1b[27m` : shrunk;
 					leftWidth = this.#groupWidth(left, leftCapWidth, leftSepWidth);
 				}
+			}
+			while (totalWidth() > topFillWidth && right.length > 0) {
+				right.pop();
+				rightWidth = this.#groupWidth(right, rightCapWidth, rightSepWidth);
 			}
 			while (totalWidth() > topFillWidth && left.length > 0) {
 				left.pop();


### PR DESCRIPTION
## Summary
- Fixes the post-merge Dev CI failure from run 29022679698, job 86133993446 (`Affected path validation / test:@gajae-code/coding-agent:shard-8-of-8`).
- Shrinks the path segment before dropping right-side telemetry so the `default-usage` status-line preset keeps provider usage visible on long worktree paths.

## Reproduction
- `bun scripts/ci-dev-affected.ts --task="test:@gajae-code/coding-agent:shard-8-of-8"` reproduced the failure in `test/status-line-usage.test.ts`: expected `5h 76% (3h)`, but the status line dropped usage and rendered only the long path/cwd segments.

## Validation
- `bun test test/status-line-usage.test.ts` — 5 pass, 0 fail.
- `bun scripts/ci-dev-affected.ts --task="test:@gajae-code/coding-agent:shard-8-of-8"` — 1168 pass, 39 skip, 0 fail.
- `bun run check` in `packages/coding-agent` — passed (`biome check .` and `tsgo -p tsconfig.json --noEmit`).

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*