### PR TITLE
fix(rpc): expose full client event stream

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
-- `RpcClient.onEvent()` now accepts the full renderer-facing agent-wire event stream instead of dropping non-core session events such as notices, todo reminders, retry events, subagent steering, thinking-level changes, and goal updates.
+- `RpcClient.onEvent()` now accepts the full renderer-facing agent-wire event stream instead of dropping non-core session events such as notices, todo reminders, retry events, subagent steering, thinking-level changes, and goal updates; `onCoreEvent()` preserves filtered legacy `AgentEvent` subscriptions.
 
 ## [0.9.3] - 2026-07-09
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- `RpcClient.onEvent()` now accepts the full renderer-facing agent-wire event stream instead of dropping non-core session events such as notices, todo reminders, retry events, subagent steering, thinking-level changes, and goal updates.
 
 ## [0.9.3] - 2026-07-09
 

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -8,7 +8,8 @@ import type { CompactionResult } from "@gajae-code/agent-core/compaction";
 import type { ImageContent, Model } from "@gajae-code/ai";
 import { isRecord, ptree, readJsonl } from "@gajae-code/utils";
 import type { BashResult } from "../../exec/bash-executor";
-import type { SessionStats } from "../../session/agent-session";
+import type { AgentSessionEvent, SessionStats } from "../../session/agent-session";
+import { AGENT_WIRE_EVENT_TYPES, type AgentWireEventType } from "../shared/agent-wire/event-contract";
 import type {
 	RpcCommand,
 	RpcExtensionUIRequest,
@@ -63,7 +64,7 @@ export interface RpcClientOptions {
 
 export type ModelInfo = Pick<Model, "provider" | "id" | "contextWindow" | "reasoning" | "thinking">;
 
-export type RpcEventListener = (event: AgentEvent) => void;
+export type RpcEventListener = { bivarianceHack(event: AgentSessionEvent): void }["bivarianceHack"];
 
 export interface RpcClientToolContext<TDetails = unknown> {
 	toolCallId: string;
@@ -91,7 +92,8 @@ export function defineRpcClientTool<
 	return tool;
 }
 
-const agentEventTypes = new Set<AgentEvent["type"]>([
+const agentWireEventTypes = new Set<AgentWireEventType>(AGENT_WIRE_EVENT_TYPES);
+const coreAgentEventTypes = new Set<AgentEvent["type"]>([
 	"agent_start",
 	"agent_end",
 	"turn_start",
@@ -116,13 +118,16 @@ function isRpcResponse(value: unknown): value is RpcResponse {
 	return true;
 }
 
-function isAgentEvent(value: unknown): value is AgentEvent {
+function isAgentSessionEvent(value: unknown): value is AgentSessionEvent {
 	if (!isRecord(value)) return false;
 	const type = value.type;
 	if (typeof type !== "string") return false;
-	return agentEventTypes.has(type as AgentEvent["type"]);
+	return agentWireEventTypes.has(type as AgentWireEventType);
 }
 
+function isCoreAgentEvent(value: AgentSessionEvent): value is AgentEvent {
+	return coreAgentEventTypes.has(value.type as AgentEvent["type"]);
+}
 function isRpcHostToolCallRequest(value: unknown): value is RpcHostToolCallRequest {
 	if (!isRecord(value)) return false;
 	return (
@@ -442,12 +447,17 @@ export class RpcClient {
 	}
 
 	/**
-	 * Subscribe to agent events.
+	 * Subscribe to all renderer-facing agent session events.
 	 */
-	onEvent(listener: RpcEventListener): () => void {
-		this.#eventListeners.push(listener);
+	onEvent(listener: RpcEventListener): () => void;
+	/**
+	 * Backward-compatible overload for callers that typed listeners to the core AgentEvent subset.
+	 */
+	onEvent(listener: (event: AgentEvent) => void): () => void;
+	onEvent(listener: RpcEventListener | ((event: AgentEvent) => void)): () => void {
+		this.#eventListeners.push(listener as RpcEventListener);
 		return () => {
-			const index = this.#eventListeners.indexOf(listener);
+			const index = this.#eventListeners.indexOf(listener as RpcEventListener);
 			if (index !== -1) {
 				this.#eventListeners.splice(index, 1);
 			}
@@ -859,7 +869,7 @@ export class RpcClient {
 		const events: AgentEvent[] = [];
 		let settled = false;
 		const unsubscribe = this.onEvent(event => {
-			events.push(event);
+			if (isCoreAgentEvent(event)) events.push(event);
 			if (event.type === "agent_end") {
 				settled = true;
 				unsubscribe();
@@ -928,7 +938,7 @@ export class RpcClient {
 
 		// Canonical agent-wire event frame: { type:"event", payload:{ event_type, event } }.
 		const event = unwrapAgentWireEventFrame(data);
-		if (!isAgentEvent(event)) return;
+		if (!isAgentSessionEvent(event)) return;
 
 		for (const listener of this.#eventListeners) {
 			listener(event);

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -64,7 +64,7 @@ export interface RpcClientOptions {
 
 export type ModelInfo = Pick<Model, "provider" | "id" | "contextWindow" | "reasoning" | "thinking">;
 
-export type RpcEventListener = { bivarianceHack(event: AgentSessionEvent): void }["bivarianceHack"];
+export type RpcEventListener = (event: AgentSessionEvent) => void;
 
 export interface RpcClientToolContext<TDetails = unknown> {
 	toolCallId: string;
@@ -449,19 +449,23 @@ export class RpcClient {
 	/**
 	 * Subscribe to all renderer-facing agent session events.
 	 */
-	onEvent(listener: RpcEventListener): () => void;
-	/**
-	 * Backward-compatible overload for callers that typed listeners to the core AgentEvent subset.
-	 */
-	onEvent(listener: (event: AgentEvent) => void): () => void;
-	onEvent(listener: RpcEventListener | ((event: AgentEvent) => void)): () => void {
-		this.#eventListeners.push(listener as RpcEventListener);
+	onEvent(listener: RpcEventListener): () => void {
+		this.#eventListeners.push(listener);
 		return () => {
-			const index = this.#eventListeners.indexOf(listener as RpcEventListener);
+			const index = this.#eventListeners.indexOf(listener);
 			if (index !== -1) {
 				this.#eventListeners.splice(index, 1);
 			}
 		};
+	}
+
+	/**
+	 * Subscribe to the legacy core AgentEvent subset.
+	 */
+	onCoreEvent(listener: (event: AgentEvent) => void): () => void {
+		return this.onEvent(event => {
+			if (isCoreAgentEvent(event)) listener(event);
+		});
 	}
 
 	/**
@@ -868,8 +872,8 @@ export class RpcClient {
 		const { promise, resolve, reject } = Promise.withResolvers<AgentEvent[]>();
 		const events: AgentEvent[] = [];
 		let settled = false;
-		const unsubscribe = this.onEvent(event => {
-			if (isCoreAgentEvent(event)) events.push(event);
+		const unsubscribe = this.onCoreEvent(event => {
+			events.push(event);
 			if (event.type === "agent_end") {
 				settled = true;
 				unsubscribe();

--- a/packages/coding-agent/test/checkpoint-rpc-qa.ts
+++ b/packages/coding-agent/test/checkpoint-rpc-qa.ts
@@ -44,7 +44,7 @@ async function main() {
 	});
 
 	const streamedEvents: AgentEvent[] = [];
-	client.onEvent((event: AgentEvent) => {
+	client.onCoreEvent(event => {
 		streamedEvents.push(event);
 	});
 

--- a/packages/coding-agent/test/checkpoint-rpc-qa.ts
+++ b/packages/coding-agent/test/checkpoint-rpc-qa.ts
@@ -44,7 +44,7 @@ async function main() {
 	});
 
 	const streamedEvents: AgentEvent[] = [];
-	client.onEvent(event => {
+	client.onEvent((event: AgentEvent) => {
 		streamedEvents.push(event);
 	});
 

--- a/packages/coding-agent/test/rpc-client-uds.test.ts
+++ b/packages/coding-agent/test/rpc-client-uds.test.ts
@@ -3,7 +3,12 @@ import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import * as net from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
-import { defineRpcClientTool, RpcClient } from "@gajae-code/coding-agent/modes/rpc/rpc-client";
+import type { AgentEvent } from "@gajae-code/agent-core";
+import { defineRpcClientTool, RpcClient, type RpcEventListener } from "@gajae-code/coding-agent/modes/rpc/rpc-client";
+import { AGENT_WIRE_EVENT_TYPES } from "../src/modes/shared/agent-wire/event-contract";
+import { AgentWireFrameSequencer, toAgentWireEventFrame } from "../src/modes/shared/agent-wire/event-envelope";
+import type { AgentSessionEvent } from "../src/session/agent-session";
+import { EVENT_FIXTURES } from "./agent-wire/fixtures";
 import { createHarnessCliEnv, type HarnessCliEnv } from "./harness-control-plane/cli-workspace-env";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
@@ -225,6 +230,96 @@ describe("RpcClient UDS transport", () => {
 			});
 			client.stop();
 			expect(toolCalls).toBe(1);
+		} finally {
+			serverSocket?.end();
+			server.close();
+		}
+	}, 30_000);
+
+	test("dispatches every registered agent-wire event type through onEvent", async () => {
+		const socketPath = path.join(workspace, "full-event-stream.sock");
+		const sequencer = new AgentWireFrameSequencer("rpc-client-full-events");
+		const requiredRendererEvents = [
+			"notice",
+			"subagent_steer_message",
+			"todo_reminder",
+			"auto_retry_start",
+			"auto_retry_end",
+			"thinking_level_changed",
+			"goal_updated",
+		] as const;
+		let serverSocket: net.Socket | undefined;
+		const server = await new Promise<net.Server>((resolve, reject) => {
+			const srv = net.createServer(socket => {
+				serverSocket = socket;
+				socket.unref();
+				socket.write(`${JSON.stringify({ type: "ready" })}\n`);
+				for (const type of AGENT_WIRE_EVENT_TYPES) {
+					socket.write(`${JSON.stringify(toAgentWireEventFrame(EVENT_FIXTURES[type], sequencer))}\n`);
+				}
+			});
+			srv.once("error", reject);
+			srv.unref();
+			srv.listen(socketPath, () => resolve(srv));
+		});
+		try {
+			const client = new RpcClient({ transport: "uds", socketPath });
+			const events: AgentSessionEvent[] = [];
+			client.onEvent((event: AgentSessionEvent) => events.push(event));
+			await client.start();
+			await Bun.sleep(50);
+
+			expect(events.map(event => event.type)).toEqual([...AGENT_WIRE_EVENT_TYPES]);
+			for (const type of requiredRendererEvents) {
+				expect(events.map(event => event.type)).toContain(type);
+			}
+			client.stop();
+		} finally {
+			serverSocket?.end();
+			server.close();
+		}
+	}, 30_000);
+	test("collectEvents keeps legacy core-only event collection while onEvent receives the full stream", async () => {
+		const socketPath = path.join(workspace, "collect-events-core-filter.sock");
+		const sequencer = new AgentWireFrameSequencer("rpc-client-collect-core");
+		let serverSocket: net.Socket | undefined;
+		const server = await new Promise<net.Server>((resolve, reject) => {
+			const srv = net.createServer(socket => {
+				serverSocket = socket;
+				socket.unref();
+				socket.write(`${JSON.stringify({ type: "ready" })}\n`);
+				setTimeout(() => {
+					for (const type of ["notice", "tool_execution_start", "agent_end"] as const) {
+						socket.write(`${JSON.stringify(toAgentWireEventFrame(EVENT_FIXTURES[type], sequencer))}\n`);
+					}
+				}, 20);
+			});
+			srv.once("error", reject);
+			srv.unref();
+			srv.listen(socketPath, () => resolve(srv));
+		});
+		try {
+			const client = new RpcClient({ transport: "uds", socketPath });
+			const streamedEvents: AgentSessionEvent[] = [];
+			const reusableCoreListener: RpcEventListener = (_event: AgentEvent) => {};
+			const unsubscribeCoreListener = client.onEvent(reusableCoreListener);
+			const unsubscribeDirectCoreListener = client.onEvent((_event: AgentEvent) => {});
+			let inferredNotice = false;
+			client.onEvent((event: AgentSessionEvent) => streamedEvents.push(event));
+			const unsubscribeInferredFullListener = client.onEvent(event => {
+				if (event.type === "notice") inferredNotice = true;
+			});
+			await client.start();
+
+			const collectedEvents = await client.collectEvents(3000);
+
+			expect(streamedEvents.map(event => event.type)).toEqual(["notice", "tool_execution_start", "agent_end"]);
+			expect(collectedEvents.map(event => event.type)).toEqual(["tool_execution_start", "agent_end"]);
+			expect(inferredNotice).toBe(true);
+			unsubscribeInferredFullListener();
+			unsubscribeDirectCoreListener();
+			unsubscribeCoreListener();
+			client.stop();
 		} finally {
 			serverSocket?.end();
 			server.close();

--- a/packages/coding-agent/test/rpc-client-uds.test.ts
+++ b/packages/coding-agent/test/rpc-client-uds.test.ts
@@ -301,11 +301,11 @@ describe("RpcClient UDS transport", () => {
 		try {
 			const client = new RpcClient({ transport: "uds", socketPath });
 			const streamedEvents: AgentSessionEvent[] = [];
-			const reusableCoreListener: RpcEventListener = (_event: AgentEvent) => {};
-			const unsubscribeCoreListener = client.onEvent(reusableCoreListener);
-			const unsubscribeDirectCoreListener = client.onEvent((_event: AgentEvent) => {});
+			const reusableFullListener: RpcEventListener = event => streamedEvents.push(event);
+			const unsubscribeFullListener = client.onEvent(reusableFullListener);
+			const coreEvents: AgentEvent[] = [];
+			const unsubscribeCoreListener = client.onCoreEvent(event => coreEvents.push(event));
 			let inferredNotice = false;
-			client.onEvent((event: AgentSessionEvent) => streamedEvents.push(event));
 			const unsubscribeInferredFullListener = client.onEvent(event => {
 				if (event.type === "notice") inferredNotice = true;
 			});
@@ -316,9 +316,10 @@ describe("RpcClient UDS transport", () => {
 			expect(streamedEvents.map(event => event.type)).toEqual(["notice", "tool_execution_start", "agent_end"]);
 			expect(collectedEvents.map(event => event.type)).toEqual(["tool_execution_start", "agent_end"]);
 			expect(inferredNotice).toBe(true);
+			expect(coreEvents.map(event => event.type)).toEqual(["tool_execution_start", "agent_end"]);
 			unsubscribeInferredFullListener();
-			unsubscribeDirectCoreListener();
 			unsubscribeCoreListener();
+			unsubscribeFullListener();
 			client.stop();
 		} finally {
 			serverSocket?.end();


### PR DESCRIPTION
## Summary

`RpcClient.onEvent()` now delivers the full renderer-facing canonical agent-wire event stream instead of silently dropping non-core session events.

The RPC server already emits canonical `{ type: "event", payload: { event_type, event } }` frames for the full `AgentSessionEvent` contract. The bundled TypeScript client was still validating the unwrapped event against the smaller legacy `AgentEvent` set, which meant renderer-relevant events such as `notice`, `todo_reminder`, `auto_retry_start/end`, `subagent_steer_message`, `thinking_level_changed`, and `goal_updated` never reached `onEvent()` listeners.

## What changed

- Widened `RpcClient.onEvent()` runtime dispatch to accept any event type registered in `AGENT_WIRE_EVENT_TYPES`.
- Kept legacy/core collection behavior by filtering inside `collectEvents()` so it still returns `AgentEvent[]`.
- Preserved core listener source compatibility with an `AgentEvent` overload and typed regression coverage.
- Added UDS tests that:
  - send every registered agent-wire event fixture through canonical event frames;
  - assert `onEvent()` receives the complete ordered event stream;
  - explicitly cover `notice`, `subagent_steer_message`, `todo_reminder`, `auto_retry_start`, `auto_retry_end`, `thinking_level_changed`, and `goal_updated`;
  - assert `collectEvents()` remains core-only when mixed with non-core events.
- Added an Unreleased changelog entry.

## Why this is scoped separately

This is not a new renderer-state or GUI contract. It only aligns the existing TypeScript RPC client with the already-declared agent-wire event contract by stopping client-side event loss. Broader GUI/TUI parity work can still define higher-level renderer state separately.

## Verification

Passed:

- `bun test packages/coding-agent/test/rpc-client-uds.test.ts packages/coding-agent/test/rpc/rpc-client-envelope.redteam.test.ts packages/coding-agent/test/agent-wire-conformance.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun run ci:check:full`
- `CI=1 CI_DEV_PLAN_MODE=pr CI_DEV_CHANGED_PATHS="packages/coding-agent/CHANGELOG.md packages/coding-agent/src/modes/rpc/rpc-client.ts packages/coding-agent/test/checkpoint-rpc-qa.ts packages/coding-agent/test/rpc-client-uds.test.ts" bun scripts/ci-dev-affected.ts`

Also attempted full local `bun run ci:test:full`; it did not complete cleanly because this workstation lacks `cargo nextest` for `test:rs` and the unrelated full coding-agent suite currently reports pre-existing notification/python lifecycle failures outside this diff. The PR-mode affected CI plan for these changed files is green locally.

Closes snowykr/gajae-code#2