### PR TITLE
Clarify /session delete wording

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - `RpcClient.onSessionEvent()` now exposes the full renderer-facing agent-wire event stream instead of dropping non-core session events such as notices, todo reminders, retry events, subagent steering, thinking-level changes, and goal updates, while `onEvent()` remains the filtered legacy `AgentEvent` subscription path.
+- Clarified `/session delete` help, confirmation, and completion wording to specify current vs. selected session transcript/artifact deletion and that other sessions plus topic/history metadata are not removed (#1913).
 
 ## [0.9.3] - 2026-07-09
 

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -188,11 +188,11 @@ export const KEYBINDINGS = {
 	},
 	"app.session.delete": {
 		defaultKeys: "ctrl+d",
-		description: "Delete session",
+		description: "Delete current session transcript/artifacts",
 	},
 	"app.session.deleteNoninvasive": {
 		defaultKeys: "ctrl+backspace",
-		description: "Delete session (non-invasive)",
+		description: "Delete selected session transcript/artifacts (non-invasive)",
 	},
 	"app.tree.foldOrUp": {
 		defaultKeys: ["ctrl+left", "alt+left"],

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -180,7 +180,7 @@ class SessionList implements Component {
 
 		// Add keybinding hint
 		lines.push("");
-		lines.push(theme.fg("muted", "  [Del to delete, Enter to select, Esc to cancel]"));
+		lines.push(theme.fg("muted", "  [Del to delete selected transcript/artifacts, Enter to select, Esc to cancel]"));
 
 		return lines;
 	}
@@ -307,7 +307,7 @@ export class SessionSelectorComponent extends Container {
 	#showDeleteConfirmation(session: SessionInfo): void {
 		const displayName = session.title || session.firstMessage.slice(0, 40) || session.id;
 		this.#confirmationDialog = new HookSelectorComponent(
-			`Delete session?\n${displayName}`,
+			`Delete selected session transcript and artifacts?\n${displayName}\nThis cannot be undone. Other sessions and topic/history metadata are not deleted.`,
 			["Yes", "No"],
 			async (option: string) => {
 				if (option === "Yes" && this.#onDelete) {

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -567,7 +567,7 @@ export class CommandController {
 			`| Start a fresh session | \`${sessionNewKey}\` or \`/new\` |`,
 			"| Resume another session | `/resume` |",
 			"| Show session details | `/session info` |",
-			"| Delete current session | `/session delete` |",
+			"| Delete current session transcript/artifacts | `/session delete` |",
 			"| Select a model | `/model` or `Ctrl+L` |",
 			"| Show all shortcuts | `?` on an empty prompt or `/hotkeys` |",
 			"",

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1431,8 +1431,12 @@ export class SelectorController {
 		}
 
 		const confirmed = await this.ctx.showHookConfirm(
-			"Delete Session",
-			"This will permanently delete the current session.\nYou will be returned to the session selector.",
+			"Delete current session transcript and artifacts?",
+			[
+				"This permanently deletes only the current session transcript file and its artifacts directory.",
+				"Other sessions and topic/history metadata are not deleted.",
+				"You will be moved to a fresh session and returned to the session selector.",
+			].join("\n"),
 		);
 
 		if (!confirmed) {
@@ -1449,7 +1453,7 @@ export class SelectorController {
 		await storage.deleteSessionWithArtifacts(sessionFile);
 
 		// Show session selector
-		this.ctx.showStatus("Session deleted");
+		this.ctx.showStatus("Current session transcript and artifacts deleted");
 		await this.showSessionSelector();
 	}
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -810,12 +810,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "session",
 		priority: 88,
-		description: "Show current session info or delete current session",
+		description: "Show session info or delete the current session transcript/artifacts",
 		acpDescription: "Show session information",
 		acpInputHint: "info|delete",
 		subcommands: [
 			{ name: "info", description: "Show current session id, title, and workspace" },
-			{ name: "delete", description: "Delete current session and return to selector" },
+			{ name: "delete", description: "Delete current session transcript and artifacts" },
 		],
 		allowArgs: true,
 		handle: async (command, runtime) => {
@@ -844,7 +844,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 					return usage(`Failed to delete session: ${errorMessage(err)}`, runtime);
 				}
 				await runtime.output(
-					`Session deleted: ${sessionFile}. Use ACP \`session/load\` to switch to another session.`,
+					[
+						`Deleted current session transcript and artifacts: ${sessionFile}`,
+						"Other sessions and topic/history metadata were not deleted.",
+					].join("\n"),
 				);
 				return commandConsumed();
 			}

--- a/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
@@ -246,8 +246,12 @@ describe("SelectorController session deletion", () => {
 
 		expect(exists).toHaveBeenCalledWith(activeSessionPath);
 		expect(showHookConfirm).toHaveBeenCalledWith(
-			"Delete Session",
-			"This will permanently delete the current session.\nYou will be returned to the session selector.",
+			"Delete current session transcript and artifacts?",
+			[
+				"This permanently deletes only the current session transcript file and its artifacts directory.",
+				"Other sessions and topic/history metadata are not deleted.",
+				"You will be moved to a fresh session and returned to the session selector.",
+			].join("\n"),
 		);
 		expect(newSession).toHaveBeenCalledTimes(1);
 		expect(deleteSessionWithArtifacts).toHaveBeenCalledWith(activeSessionPath);
@@ -265,7 +269,7 @@ describe("SelectorController session deletion", () => {
 			"reloadTodos",
 			"ui.requestRender",
 			`delete:${activeSessionPath}`,
-			"showStatus:Session deleted",
+			"showStatus:Current session transcript and artifacts deleted",
 			"editorContainer.clear",
 			"editorContainer.addChild",
 			"ui.requestRender",

--- a/packages/coding-agent/test/modes/controllers/session-selector-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/session-selector-delete.test.ts
@@ -51,8 +51,11 @@ describe("SessionSelectorComponent delete confirmation", () => {
 		const selector = createSelector(onDelete);
 
 		selector.handleInput("\x1b[3~");
-		expect(renderText(selector)).toContain("Delete session?");
+		expect(renderText(selector)).toContain("Delete selected session transcript and artifacts?");
 		expect(renderText(selector)).toContain("Alpha");
+		expect(renderText(selector)).toContain(
+			"This cannot be undone. Other sessions and topic/history metadata are not deleted.",
+		);
 
 		selector.handleInput("\n");
 		await Bun.sleep(0);
@@ -62,7 +65,7 @@ describe("SessionSelectorComponent delete confirmation", () => {
 		expect(rendered).toContain("Error: disk failed");
 		expect(rendered).toContain("Alpha");
 		expect(rendered).toContain("Beta");
-		expect(rendered).not.toContain("Delete session?");
+		expect(rendered).not.toContain("Delete selected session transcript and artifacts?");
 	});
 
 	it("keeps the session visible when delete is canceled upstream", async () => {

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -97,7 +97,11 @@ describe("prompt action autocomplete", () => {
 		const provider = createNoopProvider([
 			{ name: "grok-build-usage", description: "Advanced provider diagnostics" },
 			{ name: "settings", description: "Open settings and preferences", priority: 40 },
-			{ name: "session", description: "Show current session info or delete current session", priority: 88 },
+			{
+				name: "session",
+				description: "Show session info or delete the current session transcript/artifacts",
+				priority: 88,
+			},
 			{ name: "resume", description: "Resume a previous session", priority: 92 },
 			{ name: "new", description: "Start a new session", priority: 96 },
 			{ name: "help", description: "Learn commands and beginner workflows", priority: 100 },
@@ -114,7 +118,7 @@ describe("prompt action autocomplete", () => {
 			"grok-build-usage",
 		]);
 		expect(suggestions?.items.find(item => item.value === "session")?.description).toBe(
-			"Show current session info or delete current session",
+			"Show session info or delete the current session transcript/artifacts",
 		);
 	});
 

--- a/packages/coding-agent/test/slash-command-builtin-registry.test.ts
+++ b/packages/coding-agent/test/slash-command-builtin-registry.test.ts
@@ -61,7 +61,7 @@ describe("builtin /copy slash command", () => {
 		expect(helpCommand?.description).toContain("beginner workflows");
 		expect(helpCommand?.priority).toBeGreaterThan(newCommand?.priority ?? 0);
 		expect(newCommand?.description).toBe("Start a new session");
-		expect(sessionCommand?.description).toBe("Show current session info or delete current session");
+		expect(sessionCommand?.description).toBe("Show session info or delete the current session transcript/artifacts");
 		expect(sessionCommand?.subcommands?.map(command => command.name)).toEqual(["info", "delete"]);
 	});
 

--- a/packages/coding-agent/test/slash-commands/session.test.ts
+++ b/packages/coding-agent/test/slash-commands/session.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "bun:test";
 import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
-import { executeBuiltinSlashCommand } from "@gajae-code/coding-agent/slash-commands/builtin-registry";
+import {
+	executeBuiltinSlashCommand,
+	lookupBuiltinSlashCommand,
+} from "@gajae-code/coding-agent/slash-commands/builtin-registry";
 
 function createRuntimeHarness(options?: {
 	handleSessionCommand?: InteractiveModeContext["handleSessionCommand"];
@@ -105,5 +108,37 @@ describe("/session slash command", () => {
 		await expect(executeBuiltinSlashCommand("/session delete", harness.runtime)).rejects.toBe(deleteError);
 		expect(handleSessionDeleteCommand).toHaveBeenCalledTimes(1);
 		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("reports the exact ACP delete target and retained metadata", async () => {
+		const command = lookupBuiltinSlashCommand("session");
+		const output = vi.fn();
+		const dropSession = vi.fn(async () => undefined);
+		const runtime = {
+			cwd: "/tmp/project",
+			output,
+			refreshCommands: vi.fn(),
+			reloadPlugins: vi.fn(),
+			session: { isStreaming: false, sessionId: "session-a", sessionName: "Session A" },
+			sessionManager: {
+				getSessionFile: () => "/tmp/project/sessions/session-a.jsonl",
+				dropSession,
+			},
+			settings: {},
+		};
+
+		const result = await command?.handle?.(
+			{ name: "session", args: "delete", text: "/session delete" },
+			runtime as never,
+		);
+
+		expect(result).toEqual({ consumed: true });
+		expect(dropSession).toHaveBeenCalledWith("/tmp/project/sessions/session-a.jsonl");
+		expect(output).toHaveBeenCalledWith(
+			[
+				"Deleted current session transcript and artifacts: /tmp/project/sessions/session-a.jsonl",
+				"Other sessions and topic/history metadata were not deleted.",
+			].join("\n"),
+		);
 	});
 });


### PR DESCRIPTION
Closes #1913

## Summary
- Clarifies /session delete help, keybinding, confirmation, and completion text to say the current/selected session transcript and artifacts are deleted.
- Calls out that other sessions and topic/history metadata remain intact.
- Updates focused regression coverage for slash command, selector, autocomplete, and registry wording.

## Validation
- bun test packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts packages/coding-agent/test/modes/controllers/session-selector-delete.test.ts packages/coding-agent/test/prompt-action-autocomplete.test.ts packages/coding-agent/test/slash-command-builtin-registry.test.ts packages/coding-agent/test/slash-commands/session.test.ts
- bun run check (packages/coding-agent)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*