### PR TITLE
Fix home screen build label metadata

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - `RpcClient.onSessionEvent()` now exposes the full renderer-facing agent-wire event stream instead of dropping non-core session events such as notices, todo reminders, retry events, subagent steering, thinking-level changes, and goal updates, while `onEvent()` remains the filtered legacy `AgentEvent` subscription path.
 - Clarified `/session delete` help, confirmation, and completion wording to specify current vs. selected session transcript/artifact deletion and that other sessions plus topic/history metadata are not removed (#1913).
+- Home screen build labels now come from install/build metadata, so release binaries and package installs no longer show a misleading dev build label (#1911).
 
 ## [0.9.3] - 2026-07-09
 

--- a/packages/coding-agent/scripts/compile-args.ts
+++ b/packages/coding-agent/scripts/compile-args.ts
@@ -14,7 +14,10 @@ export const compileAutoloadDisableFlags = [
 	"--no-compile-autoload-package-json",
 ];
 
-export const compiledDefineFlags = ['process.env.PI_COMPILED="true"'];
+const compiledDefineFlags = ['process.env.PI_COMPILED="true"'];
+const releaseDefineFlags = [...compiledDefineFlags, 'process.env.GJC_BUILD_CHANNEL="release"'];
+const devDefineFlags = [...compiledDefineFlags, 'process.env.GJC_BUILD_CHANNEL="dev"'];
+
 export const compiledExternalPackages = ["mupdf"];
 
 export const releaseEntrypoints = [
@@ -45,7 +48,8 @@ export function buildReleaseCompileArgs(target: string, outfile: string): string
 		entrypoints: releaseEntrypoints,
 		outfile,
 		target,
-		defines: compiledDefineFlags,
+		defines: releaseDefineFlags,
+
 		externals: compiledExternalPackages,
 	});
 }
@@ -55,7 +59,7 @@ export function buildDevCompileArgs(outfile = "dist/gjc"): string[] {
 		root: "../..",
 		entrypoints: devEntrypoints,
 		outfile,
-		defines: compiledDefineFlags,
+		defines: devDefineFlags,
 		externals: compiledExternalPackages,
 	});
 }

--- a/packages/coding-agent/src/build-metadata.ts
+++ b/packages/coding-agent/src/build-metadata.ts
@@ -1,0 +1,104 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { isCompiledBinary } from "@gajae-code/utils/env";
+
+export type BuildChannel = "release" | "dev" | "local-source" | "package-install" | "compiled" | "unknown";
+
+export interface BuildMetadata {
+	channel: BuildChannel;
+	label: string;
+}
+
+const REPO_MARKERS = [".git", "bun.lock"];
+const SOURCE_REPO_PACKAGE_NAME = "gajae-code";
+
+export function resolveBuildMetadata(moduleDir: string = import.meta.dir): BuildMetadata {
+	const explicitChannel = normalizeBuildChannel(process.env.GJC_BUILD_CHANNEL);
+	if (explicitChannel) {
+		return metadataForChannel(explicitChannel);
+	}
+
+	if (isCompiledBinary()) {
+		return metadataForChannel("compiled");
+	}
+
+	if (isLocalSourceTree(moduleDir)) {
+		return metadataForChannel("local-source");
+	}
+
+	return metadataForChannel("package-install");
+}
+
+export function formatBuildLabel(metadata: BuildMetadata = resolveBuildMetadata()): string {
+	return metadata.label;
+}
+
+function normalizeBuildChannel(value: string | undefined): BuildChannel | undefined {
+	const normalized = value?.trim().toLowerCase();
+	if (!normalized) return undefined;
+	switch (normalized) {
+		case "release":
+		case "stable":
+			return "release";
+		case "dev":
+		case "development":
+			return "dev";
+		case "local-source":
+		case "source":
+		case "local":
+			return "local-source";
+		case "package-install":
+		case "package":
+		case "npm":
+			return "package-install";
+		case "compiled":
+			return "compiled";
+		case "unknown":
+			return "unknown";
+		default:
+			return "unknown";
+	}
+}
+
+function metadataForChannel(channel: BuildChannel): BuildMetadata {
+	switch (channel) {
+		case "release":
+			return { channel, label: "release build" };
+		case "dev":
+			return { channel, label: "dev build" };
+		case "local-source":
+			return { channel, label: "local source" };
+		case "package-install":
+			return { channel, label: "package install" };
+		case "compiled":
+			return { channel, label: "compiled build" };
+		case "unknown":
+			return { channel, label: "build unknown" };
+	}
+}
+
+function isLocalSourceTree(startDir: string): boolean {
+	let current = path.resolve(startDir);
+	while (true) {
+		if (hasRepoMarkers(current)) return true;
+		const parent = path.dirname(current);
+		if (parent === current) return false;
+		current = parent;
+	}
+}
+
+function hasRepoMarkers(dir: string): boolean {
+	if (!REPO_MARKERS.every(marker => fs.existsSync(path.join(dir, marker)))) return false;
+	return readPackageName(path.join(dir, "package.json")) === SOURCE_REPO_PACKAGE_NAME;
+}
+
+function readPackageName(packageJsonPath: string): string | undefined {
+	try {
+		const parsed: unknown = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+		if (typeof parsed !== "object" || parsed === null || !("name" in parsed)) return undefined;
+		const name = parsed.name;
+		return typeof name === "string" ? name : undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -1,5 +1,6 @@
 import { type Component, padding, TERMINAL, truncateToWidth, visibleWidth } from "@gajae-code/tui";
 import { APP_NAME } from "@gajae-code/utils";
+import { formatBuildLabel } from "../../build-metadata";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
 
 export interface RecentSession {
@@ -19,6 +20,7 @@ export interface WelcomeComponentOptions {
 	getReservedBottomRows?: (termWidth: number) => number;
 	changelogMarkdown?: string;
 	collapseChangelog?: boolean;
+	buildLabel?: string;
 }
 
 const WELCOME_STATIC_RIGHT_ROWS_EXCLUDING_DYNAMIC_SECTIONS = 9;
@@ -227,7 +229,8 @@ export class WelcomeComponent implements Component {
 		const br = theme.fg("dim", theme.boxRound.bottomRight);
 
 		const lines: string[] = [];
-		const title = ` ${APP_NAME} v${this.version} · GJC Forge `;
+		const buildLabel = this.options.buildLabel ?? formatBuildLabel();
+		const title = ` ${APP_NAME} v${this.version} · ${buildLabel} · GJC Forge `;
 		const titlePrefixRaw = hChar.repeat(3);
 		const titleStyled = theme.fg("dim", titlePrefixRaw) + theme.fg("muted", title);
 		const titleVisLen = visibleWidth(titlePrefixRaw) + visibleWidth(title);

--- a/packages/coding-agent/test/build-metadata.test.ts
+++ b/packages/coding-agent/test/build-metadata.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { formatBuildLabel, resolveBuildMetadata } from "../src/build-metadata";
+
+const originalBuildChannel = process.env.GJC_BUILD_CHANNEL;
+
+afterEach(() => {
+	if (originalBuildChannel === undefined) {
+		delete process.env.GJC_BUILD_CHANNEL;
+	} else {
+		process.env.GJC_BUILD_CHANNEL = originalBuildChannel;
+	}
+});
+
+describe("build metadata", () => {
+	it("uses explicit release metadata instead of treating compiled release binaries as dev", () => {
+		process.env.GJC_BUILD_CHANNEL = "release";
+
+		expect(resolveBuildMetadata("/not/a/source/tree")).toEqual({ channel: "release", label: "release build" });
+		expect(formatBuildLabel()).toBe("release build");
+	});
+
+	it("uses neutral diagnostic wording for unknown explicit metadata", () => {
+		process.env.GJC_BUILD_CHANNEL = "surprise-channel";
+
+		expect(resolveBuildMetadata("/not/a/source/tree")).toEqual({ channel: "unknown", label: "build unknown" });
+	});
+
+	it("classifies local source trees as local source without using dev wording", async () => {
+		delete process.env.GJC_BUILD_CHANNEL;
+		const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-build-metadata-"));
+		await fs.mkdir(path.join(repoRoot, ".git"));
+		await Bun.write(path.join(repoRoot, "bun.lock"), "");
+		await Bun.write(path.join(repoRoot, "package.json"), JSON.stringify({ name: "gajae-code" }));
+
+		expect(resolveBuildMetadata(path.join(repoRoot, "packages/coding-agent/src"))).toEqual({
+			channel: "local-source",
+			label: "local source",
+		});
+	});
+
+	it("classifies unmarked user installs as package installs instead of dev", () => {
+		delete process.env.GJC_BUILD_CHANNEL;
+
+		expect(resolveBuildMetadata("/opt/homebrew/lib/node_modules/@gajae-code/coding-agent/src")).toEqual({
+			channel: "package-install",
+			label: "package install",
+		});
+	});
+
+	it("does not classify package installs inside another Bun repo as local source", async () => {
+		delete process.env.GJC_BUILD_CHANNEL;
+		const consumerRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-consumer-project-"));
+		await fs.mkdir(path.join(consumerRoot, ".git"));
+		await Bun.write(path.join(consumerRoot, "bun.lock"), "");
+		await Bun.write(path.join(consumerRoot, "package.json"), JSON.stringify({ name: "consumer-app" }));
+
+		expect(resolveBuildMetadata(path.join(consumerRoot, "node_modules/@gajae-code/coding-agent/src"))).toEqual({
+			channel: "package-install",
+			label: "package install",
+		});
+	});
+});

--- a/packages/coding-agent/test/release-build-args.test.ts
+++ b/packages/coding-agent/test/release-build-args.test.ts
@@ -27,6 +27,18 @@ describe("release build compile args", () => {
 		expect(releaseArgs).toContain("--minify");
 	});
 
+	it("marks release binaries with release build metadata", () => {
+		expect(valuesAfter(releaseArgs, "--define")).toContain('process.env.PI_COMPILED="true"');
+		expect(valuesAfter(releaseArgs, "--define")).toContain('process.env.GJC_BUILD_CHANNEL="release"');
+		expect(valuesAfter(releaseArgs, "--define")).not.toContain('process.env.GJC_BUILD_CHANNEL="dev"');
+	});
+
+	it("marks dev-compiled binaries as dev builds explicitly", () => {
+		const devDefines = valuesAfter(buildDevCompileArgs(), "--define");
+		expect(devDefines).toContain('process.env.PI_COMPILED="true"');
+		expect(devDefines).toContain('process.env.GJC_BUILD_CHANNEL="dev"');
+	});
+
 	it("includes worker and lazy CommonJS entrypoints in release args", () => {
 		expect(releaseEntrypoints).toContain("./packages/stats/src/sync-worker.ts");
 		expect(releaseEntrypoints).toContain("./packages/coding-agent/src/tools/browser/tab-worker-entry.ts");

--- a/packages/coding-agent/test/welcome-viewport.test.ts
+++ b/packages/coding-agent/test/welcome-viewport.test.ts
@@ -1,9 +1,18 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import { visibleWidth } from "@gajae-code/tui";
 import { WelcomeComponent } from "../src/modes/components/welcome";
 import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
 
+const originalBuildChannel = process.env.GJC_BUILD_CHANNEL;
+
+afterEach(() => {
+	if (originalBuildChannel === undefined) {
+		delete process.env.GJC_BUILD_CHANNEL;
+	} else {
+		process.env.GJC_BUILD_CHANNEL = originalBuildChannel;
+	}
+});
 beforeAll(async () => {
 	const theme = await getThemeByName("red-claw");
 	if (!theme) throw new Error("Failed to load red-claw theme");
@@ -57,6 +66,25 @@ describe("WelcomeComponent viewport sizing", () => {
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBe(200);
 		}
+	});
+
+	it("renders the build label from metadata instead of defaulting to dev", () => {
+		const welcome = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii", {
+			buildLabel: "release build",
+		});
+		const rendered = welcome.render(120).map(stripRenderControls).join("\n");
+
+		expect(rendered).toContain("gjc v1.2.3 · release build · GJC Forge");
+		expect(rendered).not.toContain("dev build");
+	});
+
+	it("renders the production metadata resolver label when no override is provided", () => {
+		process.env.GJC_BUILD_CHANNEL = "release";
+		const welcome = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii");
+		const rendered = welcome.render(120).map(stripRenderControls).join("\n");
+
+		expect(rendered).toContain("gjc v1.2.3 · release build · GJC Forge");
+		expect(rendered).not.toContain("dev build");
 	});
 
 	it("splits the forge and details columns evenly on wide viewports", () => {


### PR DESCRIPTION
Closes #1911

## Summary
- Add explicit build metadata resolution for the home screen build label.
- Mark release compile args with `GJC_BUILD_CHANNEL=release` and dev compile args with `GJC_BUILD_CHANNEL=dev`.
- Render neutral diagnostic wording for unknown build metadata instead of defaulting to a misleading dev label.
- Add regression coverage for metadata resolution, compile args, and welcome rendering.

## Validation
- `bun test packages/coding-agent/test/build-metadata.test.ts packages/coding-agent/test/release-build-args.test.ts packages/coding-agent/test/welcome-viewport.test.ts`
- `cd packages/coding-agent && bun run check`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*