### PR TITLE
fix(acp): honor configured permission mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- ACP permission prompts now honor `clientCapabilities._meta.gjc.permissionHandling` and the `GJC_ACP_PERMISSION_MODE` fallback, so `auto` and `always-allow` no longer emit `session/request_permission` calls while invalid values fail safely to `prompt`.
 
 ## [0.9.4] - 2026-07-09
 ### Fixed

--- a/packages/coding-agent/src/modes/acp/acp-client-bridge.ts
+++ b/packages/coding-agent/src/modes/acp/acp-client-bridge.ts
@@ -22,18 +22,38 @@ import type {
 	ClientBridgeTerminalHandle,
 } from "../../session/client-bridge";
 
+type AcpPermissionMode = "auto" | "prompt" | "always-allow";
+
+const ACP_PERMISSION_MODE_ENV = "GJC_ACP_PERMISSION_MODE";
+
+function parseAcpPermissionMode(value: unknown): AcpPermissionMode {
+	if (value === "auto" || value === "prompt" || value === "always-allow") return value;
+	return "prompt";
+}
+
+/** Client metadata is authoritative; the process environment is only a fallback when that field is absent. */
+function resolveAcpPermissionMode(clientCapabilities: ClientCapabilities | undefined): AcpPermissionMode {
+	const meta = clientCapabilities?._meta;
+	if (typeof meta === "object" && meta !== null) {
+		const gjc = (meta as { gjc?: unknown }).gjc;
+		if (typeof gjc === "object" && gjc !== null && "permissionHandling" in gjc) {
+			return parseAcpPermissionMode((gjc as { permissionHandling?: unknown }).permissionHandling);
+		}
+	}
+	return parseAcpPermissionMode(process.env[ACP_PERMISSION_MODE_ENV]);
+}
+
 export function createAcpClientBridge(
 	connection: AgentSideConnection,
 	sessionId: string,
 	clientCapabilities: ClientCapabilities | undefined,
 ): ClientBridge {
+	const promptPermission = resolveAcpPermissionMode(clientCapabilities) === "prompt";
 	const capabilities: ClientBridgeCapabilities = {
 		readTextFile: clientCapabilities?.fs?.readTextFile === true,
 		writeTextFile: clientCapabilities?.fs?.writeTextFile === true,
 		terminal: clientCapabilities?.terminal === true,
-		// Permission requests are always usable on the connection; gating is
-		// the agent's policy choice rather than a client capability.
-		requestPermission: true,
+		requestPermission: promptPermission,
 	};
 
 	const bridge: ClientBridge = { capabilities, deferAgentInitiatedTurns: true };
@@ -65,8 +85,10 @@ export function createAcpClientBridge(
 			createTerminalHandle(connection, sessionId, params);
 	}
 
-	bridge.requestPermission = (toolCall, options, signal) =>
-		requestPermission(connection, sessionId, toolCall, options, signal);
+	if (promptPermission) {
+		bridge.requestPermission = (toolCall, options, signal) =>
+			requestPermission(connection, sessionId, toolCall, options, signal);
+	}
 
 	return bridge;
 }

--- a/packages/coding-agent/test/acp-client-bridge.test.ts
+++ b/packages/coding-agent/test/acp-client-bridge.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import type { AgentSideConnection, RequestPermissionRequest } from "@agentclientprotocol/sdk";
+import type { AgentSideConnection, ClientCapabilities, RequestPermissionRequest } from "@agentclientprotocol/sdk";
 import { createAcpClientBridge } from "../src/modes/acp/acp-client-bridge";
+
+function expectPermissionPrompt(clientCapabilities: ClientCapabilities | undefined, enabled: boolean): void {
+	const bridge = createAcpClientBridge({} as AgentSideConnection, "session-1", clientCapabilities);
+	expect(bridge.capabilities.requestPermission).toBe(enabled);
+	expect(typeof bridge.requestPermission === "function").toBe(enabled);
+}
 
 describe("ACP client bridge permission requests", () => {
 	it("forwards pending tool-call status to session/request_permission", async () => {
@@ -12,7 +18,9 @@ describe("ACP client bridge permission requests", () => {
 			},
 		} as unknown as AgentSideConnection;
 
-		const bridge = createAcpClientBridge(connection, "session-1", {});
+		const bridge = createAcpClientBridge(connection, "session-1", {
+			_meta: { gjc: { permissionHandling: "prompt" } },
+		});
 
 		await bridge.requestPermission!(
 			{
@@ -35,5 +43,50 @@ describe("ACP client bridge permission requests", () => {
 			rawInput: { command: "echo hi" },
 			content: [{ type: "content", content: { type: "text", text: "$ echo hi" } }],
 		});
+	});
+
+	it("only enables ACP permission requests in prompt mode", () => {
+		expectPermissionPrompt({ _meta: { gjc: { permissionHandling: "prompt" } } }, true);
+		expectPermissionPrompt({ _meta: { gjc: { permissionHandling: "auto" } } }, false);
+		expectPermissionPrompt({ _meta: { gjc: { permissionHandling: "always-allow" } } }, false);
+	});
+
+	it("uses GJC_ACP_PERMISSION_MODE when client metadata is absent", () => {
+		const previous = process.env.GJC_ACP_PERMISSION_MODE;
+		try {
+			process.env.GJC_ACP_PERMISSION_MODE = "auto";
+			expectPermissionPrompt(undefined, false);
+			process.env.GJC_ACP_PERMISSION_MODE = "always-allow";
+			expectPermissionPrompt({}, false);
+			process.env.GJC_ACP_PERMISSION_MODE = "prompt";
+			expectPermissionPrompt({}, true);
+			process.env.GJC_ACP_PERMISSION_MODE = "invalid";
+			expectPermissionPrompt({}, true);
+			process.env.GJC_ACP_PERMISSION_MODE = "AUTO";
+			expectPermissionPrompt({}, true);
+			process.env.GJC_ACP_PERMISSION_MODE = " always-allow ";
+			expectPermissionPrompt({}, true);
+		} finally {
+			if (previous === undefined) delete process.env.GJC_ACP_PERMISSION_MODE;
+			else process.env.GJC_ACP_PERMISSION_MODE = previous;
+		}
+	});
+
+	it("prefers client metadata and fails safely for invalid explicit values", () => {
+		const previous = process.env.GJC_ACP_PERMISSION_MODE;
+		try {
+			process.env.GJC_ACP_PERMISSION_MODE = "prompt";
+			expectPermissionPrompt({ _meta: { gjc: { permissionHandling: "auto" } } }, false);
+			expectPermissionPrompt({ _meta: { gjc: { permissionHandling: "always-allow" } } }, false);
+			process.env.GJC_ACP_PERMISSION_MODE = "always-allow";
+			expectPermissionPrompt({ _meta: { gjc: { permissionHandling: "prompt" } } }, true);
+			expectPermissionPrompt({ _meta: { gjc: { permissionHandling: "invalid" } } }, true);
+			expectPermissionPrompt({ _meta: { gjc: { permissionHandling: "AUTO" } } }, true);
+			expectPermissionPrompt({ _meta: { gjc: { permissionHandling: " always-allow " } } }, true);
+			expectPermissionPrompt({ _meta: { gjc: { permissionHandling: null } } }, true);
+		} finally {
+			if (previous === undefined) delete process.env.GJC_ACP_PERMISSION_MODE;
+			else process.env.GJC_ACP_PERMISSION_MODE = previous;
+		}
 	});
 });


### PR DESCRIPTION
## What

- resolve ACP permission handling from `clientCapabilities._meta.gjc.permissionHandling`
- fall back to `GJC_ACP_PERMISSION_MODE` only when client metadata is absent
- enable and install `requestPermission` only for `prompt` mode
- fail safely to `prompt` for invalid explicit values
- add focused regression coverage and an Unreleased changelog entry

## Why

The ACP bridge currently hard-codes `requestPermission: true`. As a result, clients configured for `auto` or `always-allow` still receive `session/request_permission` calls and display permission dialogs.

This keeps the existing prompt flow intact while preventing permission requests from being created when GJC is configured to handle permissions without ACP prompts.

## Testing

- `bun test packages/coding-agent/test/acp-client-bridge.test.ts`
- `bun run check`
- independent architecture review: CLEAR

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)