### PR TITLE
feat(acp): expose automatic compaction phase metadata

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixed
 
 - ACP permission prompts now honor `clientCapabilities._meta.gjc.permissionHandling` and the `GJC_ACP_PERMISSION_MODE` fallback, so `auto` and `always-allow` no longer emit `session/request_permission` calls while invalid values fail safely to `prompt`.
+### Added
+
+- ACP clients now receive GJC automatic-compaction start/end state through additive `session_info_update` metadata, including the compaction action, trigger, retry/abort/error outcome, and busy-to-idle phase transitions.
 
 ## [0.9.4] - 2026-07-09
 ### Fixed

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -152,8 +152,8 @@ type ManagedSessionRecord = {
 	liveMessageProgress: { textEmitted: boolean; thoughtEmitted: boolean } | undefined;
 	toolArgsById: Map<string, unknown>;
 	extensionsConfigured: boolean;
-	// Installed inside `#scheduleBootstrapUpdates` (post-race-guard); released
-	// in `#disposeSessionRecord`. Lives independent of any prompt turn.
+	// Installed after the bootstrap race guard or eagerly when the client starts a prompt;
+	// released in `#disposeSessionRecord`. Lives independent of any prompt turn.
 	lifetimeUnsubscribe: (() => void) | undefined;
 };
 
@@ -619,6 +619,7 @@ export class AcpAgent implements Agent {
 				promise: pendingPrompt.promise,
 			};
 
+			this.#ensureLifetimeSubscription(record);
 			record.promptTurn.unsubscribe = record.session.subscribe(event => {
 				void this.#handlePromptEvent(record, event);
 			});
@@ -831,6 +832,7 @@ export class AcpAgent implements Agent {
 		}
 		promptTurn.cancelRequested = true;
 		promptTurn.unsubscribe?.();
+		void this.#emitCancelledPromptIdleUpdate(record);
 		const cleanup = this.#runCancelCleanup(record, promptTurn);
 		promptTurn.cleanup = cleanup;
 		this.#finishPrompt(record, {
@@ -1043,8 +1045,8 @@ export class AcpAgent implements Agent {
 	async #registerPreparedSession(session: AgentSession, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
 		const record = this.#createManagedSessionRecord(session);
 		session.setClientBridge(createAcpClientBridge(this.#connection, session.sessionId, this.#clientCapabilities));
-		// `record.lifetimeUnsubscribe` is installed in `#scheduleBootstrapUpdates`
-		// so it shares the bootstrap race guard — see that comment for why.
+		// The lifetime subscription normally follows the bootstrap race guard, but
+		// prompt() installs it eagerly once the client has demonstrated session ownership.
 		try {
 			await this.#configureExtensions(record);
 			await this.#configureMcpServers(record, mcpServers);
@@ -1070,7 +1072,38 @@ export class AcpAgent implements Agent {
 		};
 	}
 
+	#ensureLifetimeSubscription(record: ManagedSessionRecord): void {
+		if (record.lifetimeUnsubscribe) {
+			return;
+		}
+		record.lifetimeUnsubscribe = record.session.subscribe(event => {
+			void this.#handleLifetimeEvent(record, event);
+		});
+	}
+
 	async #handleLifetimeEvent(record: ManagedSessionRecord, event: AgentSessionEvent): Promise<void> {
+		if (event.type === "auto_compaction_start" || event.type === "auto_compaction_end") {
+			// Prompt-bound compaction is normally forwarded by #handlePromptEvent. The lifetime
+			// subscription covers idle maintenance and the end event after prompt cancellation.
+			const promptTurn = record.promptTurn;
+			if (
+				isPromptTurnInFlight(promptTurn) &&
+				(!promptTurn.cancelRequested || event.type === "auto_compaction_start")
+			) {
+				return;
+			}
+			for (const notification of mapAgentWireEventPayloadToAcpSessionUpdates(
+				toAgentWireEventPayload(event),
+				record.session.sessionId,
+				{
+					cwd: record.session.sessionManager.getCwd(),
+					compactionEndPhase: "idle",
+				},
+			)) {
+				await this.#connection.sessionUpdate(notification);
+			}
+			return;
+		}
 		if (event.type !== "thinking_level_changed") {
 			return;
 		}
@@ -1140,6 +1173,7 @@ export class AcpAgent implements Agent {
 				getMessageProgress: message => this.#getLiveMessageProgress(record, message),
 				getToolArgs: toolCallId => record.toolArgsById.get(toolCallId),
 				cwd: record.session.sessionManager.getCwd(),
+				compactionEndPhase: "responding",
 			},
 		)) {
 			await this.#connection.sessionUpdate(notification);
@@ -1551,13 +1585,10 @@ export class AcpAgent implements Agent {
 		// enough that the response future has scheduled before our timer fires
 		// on stdio-only transports.
 		//
-		// The session-lifetime subscription is installed inside the same timer
-		// so it shares this guard — without it, an extension's `session_start`
-		// handler (or any async work it schedules) calling `setThinkingLevel`
-		// would push a `config_option_update` for a session id the client
-		// hasn't been told about yet. The pre-bootstrap thinking level is
-		// reported in the response's `configOptions`, so deferring the
-		// notification loses no state.
+		// The session-lifetime subscription normally shares this guard so extension
+		// work cannot notify an unknown session id. prompt() may install it earlier:
+		// receipt of a prompt proves the client already owns the returned session id,
+		// and closes the cancellation window before this timer fires.
 		setTimeout(() => {
 			if (this.#connection.signal.aborted) {
 				return;
@@ -1566,11 +1597,7 @@ export class AcpAgent implements Agent {
 			if (!record) {
 				return;
 			}
-			if (!record.lifetimeUnsubscribe) {
-				record.lifetimeUnsubscribe = record.session.subscribe(event => {
-					void this.#handleLifetimeEvent(record, event);
-				});
-			}
+			this.#ensureLifetimeSubscription(record);
 			void this.#emitBootstrapUpdates(sessionId, record);
 		}, ACP_BOOTSTRAP_RACE_GUARD_MS);
 	}
@@ -1604,6 +1631,30 @@ export class AcpAgent implements Agent {
 				availableCommands: await this.#buildAvailableCommands(record.session),
 			},
 		});
+	}
+
+	/** Ensure cancellation clears a previously emitted busy/compacting phase even if abort never produces an end event. */
+	async #emitCancelledPromptIdleUpdate(record: ManagedSessionRecord): Promise<void> {
+		if (this.#connection.signal.aborted) {
+			return;
+		}
+		try {
+			await this.#connection.sessionUpdate({
+				sessionId: record.session.sessionId,
+				update: {
+					sessionUpdate: "session_info_update",
+					title: record.session.sessionName,
+					updatedAt: new Date().toISOString(),
+					_meta: {
+						gjcPhase: "idle",
+						running: false,
+						gjcRunning: false,
+					},
+				},
+			});
+		} catch (error) {
+			logger.warn("Failed to emit cancelled ACP prompt idle update", { error });
+		}
 	}
 
 	/**
@@ -1647,6 +1698,11 @@ export class AcpAgent implements Agent {
 				sessionUpdate: "session_info_update",
 				title: record.session.sessionName,
 				updatedAt: new Date().toISOString(),
+				_meta: {
+					gjcPhase: "idle",
+					running: false,
+					gjcRunning: false,
+				},
 			},
 		});
 	}

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -27,6 +27,8 @@ interface AcpEventMapperOptions {
 	 * before emitting `ToolCallLocation` entries.
 	 */
 	cwd?: string;
+	/** Phase to expose after compaction ends. Prompt-bound compaction resumes responding; idle maintenance returns idle. */
+	compactionEndPhase?: "responding" | "idle";
 }
 
 interface ContentArrayContainer {
@@ -236,8 +238,44 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 		case "turn_start":
 		case "turn_end":
 		case "message_start":
+			return [];
 		case "auto_compaction_start":
-		case "auto_compaction_end":
+			return [
+				toSessionNotification(sessionId, {
+					sessionUpdate: "session_info_update",
+					_meta: {
+						gjcPhase: "compacting",
+						gjcCompactionState: "start",
+						gjcCompactionTrigger: event.reason,
+						gjcCompactionAction: event.action,
+						running: true,
+						gjcRunning: true,
+					},
+				}),
+			];
+		case "auto_compaction_end": {
+			const phase = options.compactionEndPhase ?? "responding";
+			const running = phase !== "idle";
+			const meta: Record<string, unknown> = {
+				gjcPhase: phase,
+				gjcCompactionState: "end",
+				gjcCompactionAction: event.action,
+				gjcCompactionAborted: event.aborted,
+				gjcCompactionWillRetry: event.willRetry,
+				running,
+				gjcRunning: running,
+			};
+			if (event.skipped !== undefined) {
+				meta.gjcCompactionSkipped = event.skipped;
+			}
+			if (event.errorMessage !== undefined) {
+				meta.gjcCompactionErrorMessage = event.errorMessage;
+			}
+			if (event.continuationSkipReason !== undefined) {
+				meta.gjcCompactionContinuationSkipReason = event.continuationSkipReason;
+			}
+			return [toSessionNotification(sessionId, { sessionUpdate: "session_info_update", _meta: meta })];
+		}
 		case "auto_retry_start":
 		case "auto_retry_end":
 		case "retry_fallback_applied":

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -976,6 +976,190 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("forwards prompt compaction once and returns the session phase to idle", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		await waitForBootstrapGuard();
+
+		session.prompt = async (text: string): Promise<void> => {
+			session.promptCalls.push(text);
+			session.isStreaming = true;
+			for (const listener of session.listeners()) {
+				listener({
+					type: "auto_compaction_start",
+					reason: "overflow",
+					action: "context-full",
+				} as AgentSessionEvent);
+			}
+			for (const listener of session.listeners()) {
+				listener({
+					type: "auto_compaction_end",
+					action: "context-full",
+					result: undefined,
+					aborted: false,
+					willRetry: true,
+				} as AgentSessionEvent);
+			}
+			const assistantMessage = makeAssistantMessage("continued after compaction");
+			session.sessionManager.appendMessage(assistantMessage);
+			for (const listener of session.listeners()) {
+				listener({ type: "agent_end", messages: [assistantMessage] } as AgentSessionEvent);
+			}
+			session.isStreaming = false;
+		};
+
+		await harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-0000000000cc",
+			prompt: [{ type: "text", text: "trigger compaction" }],
+		} as PromptRequest);
+
+		const sessionInfoUpdates = harness.updates
+			.filter(
+				update => update.sessionId === created.sessionId && update.update.sessionUpdate === "session_info_update",
+			)
+			.map(notification => notification.update);
+		const compactionUpdates = sessionInfoUpdates.filter(update => update._meta?.gjcCompactionState !== undefined);
+		expect(compactionUpdates).toHaveLength(2);
+		expect(compactionUpdates[0]?._meta).toMatchObject({
+			gjcPhase: "compacting",
+			gjcCompactionState: "start",
+			gjcCompactionTrigger: "overflow",
+			running: true,
+		});
+		expect(compactionUpdates[1]?._meta).toMatchObject({
+			gjcPhase: "responding",
+			gjcCompactionState: "end",
+			gjcCompactionWillRetry: true,
+			running: true,
+		});
+		expect(sessionInfoUpdates.at(-1)?._meta).toMatchObject({
+			gjcPhase: "idle",
+			running: false,
+			gjcRunning: false,
+		});
+		expectAcpNotifications(harness.updates);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("forwards idle compaction through the session lifetime subscription", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		await waitForBootstrapGuard();
+		const before = harness.updates.length;
+
+		for (const listener of session.listeners()) {
+			listener({ type: "auto_compaction_start", reason: "idle", action: "handoff" } as AgentSessionEvent);
+		}
+		for (const listener of session.listeners()) {
+			listener({
+				type: "auto_compaction_end",
+				action: "handoff",
+				result: undefined,
+				aborted: false,
+				willRetry: false,
+			} as AgentSessionEvent);
+		}
+		await Bun.sleep(0);
+
+		const compactionUpdates = harness.updates
+			.slice(before)
+			.filter(update => update.update.sessionUpdate === "session_info_update")
+			.filter(update => update.update._meta?.gjcCompactionState !== undefined)
+			.map(notification => notification.update);
+		expect(compactionUpdates).toHaveLength(2);
+		expect(compactionUpdates[0]?._meta).toMatchObject({
+			gjcPhase: "compacting",
+			gjcCompactionTrigger: "idle",
+			gjcCompactionAction: "handoff",
+			running: true,
+		});
+		expect(compactionUpdates[1]?._meta).toMatchObject({
+			gjcPhase: "idle",
+			gjcCompactionState: "end",
+			gjcCompactionAction: "handoff",
+			running: false,
+		});
+		expectAcpNotifications(harness.updates);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("reports aborted compaction and clears phase when a prompt is cancelled", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		const { promise: compactionStarted, resolve: markCompactionStarted } = Promise.withResolvers<void>();
+		const { promise: releasePrompt, resolve: finishPrompt } = Promise.withResolvers<void>();
+
+		session.prompt = async (text: string): Promise<void> => {
+			session.promptCalls.push(text);
+			session.isStreaming = true;
+			for (const listener of session.listeners()) {
+				listener({
+					type: "auto_compaction_start",
+					reason: "threshold",
+					action: "context-full",
+				} as AgentSessionEvent);
+			}
+			markCompactionStarted();
+			await releasePrompt;
+			session.isStreaming = false;
+		};
+		session.abort = async (): Promise<void> => {
+			for (const listener of session.listeners()) {
+				listener({
+					type: "auto_compaction_end",
+					action: "context-full",
+					result: undefined,
+					aborted: true,
+					willRetry: false,
+				} as AgentSessionEvent);
+			}
+			finishPrompt();
+			session.isStreaming = false;
+		};
+
+		const prompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-0000000000ca",
+			prompt: [{ type: "text", text: "cancel compaction" }],
+		} as PromptRequest);
+		await compactionStarted;
+		await harness.agent.cancel({ sessionId: created.sessionId });
+		expect((await prompt).stopReason).toBe("cancelled");
+		await Bun.sleep(0);
+
+		const sessionInfoUpdates = harness.updates
+			.filter(
+				update => update.sessionId === created.sessionId && update.update.sessionUpdate === "session_info_update",
+			)
+			.map(notification => notification.update);
+		const compactionUpdates = sessionInfoUpdates.filter(update => update._meta?.gjcCompactionState !== undefined);
+		expect(compactionUpdates).toHaveLength(2);
+		expect(compactionUpdates[1]?._meta).toMatchObject({
+			gjcPhase: "idle",
+			gjcCompactionState: "end",
+			gjcCompactionAborted: true,
+			gjcCompactionWillRetry: false,
+			running: false,
+			gjcRunning: false,
+		});
+		expect(sessionInfoUpdates.at(-1)?._meta).toMatchObject({
+			gjcPhase: "idle",
+			running: false,
+			gjcRunning: false,
+		});
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("emits ACP plan updates from live todo_write results", async () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
@@ -1500,6 +1684,13 @@ describe("ACP agent", () => {
 		expect(returnedBeforeCleanup).toBe(true);
 		const cancelledResponse = await firstPrompt;
 		expect(cancelledResponse.stopReason).toBe("cancelled");
+		const afterCancelUpdates = harness.updates.length;
+		expect(afterCancelUpdates).toBeGreaterThan(beforeCancelUpdates);
+		expect(harness.updates.at(-1)?.update._meta).toMatchObject({
+			gjcPhase: "idle",
+			running: false,
+			gjcRunning: false,
+		});
 
 		for (const listener of session.listeners()) {
 			listener({
@@ -1508,7 +1699,7 @@ describe("ACP agent", () => {
 				assistantMessageEvent: { type: "text_delta", delta: "late" },
 			} as AgentSessionEvent);
 		}
-		expect(harness.updates).toHaveLength(beforeCancelUpdates);
+		expect(harness.updates).toHaveLength(afterCancelUpdates);
 
 		const secondPrompt = harness.agent.prompt({
 			sessionId: created.sessionId,

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -167,6 +167,88 @@ describe("ACP event mapper", () => {
 		).toEqual([]);
 	});
 
+	it("maps automatic compaction lifecycle events to ACP session metadata", () => {
+		const start = mapAgentSessionEventToAcpSessionUpdates(
+			{ type: "auto_compaction_start", reason: "threshold", action: "context-full" } as AgentSessionEvent,
+			"session-1",
+		);
+		const end = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "auto_compaction_end",
+				action: "context-full",
+				result: undefined,
+				aborted: false,
+				willRetry: true,
+				skipped: true,
+				errorMessage: "retrying after maintenance",
+				continuationSkipReason: "auto_continue_disabled_non_resumable_tail",
+			} as AgentSessionEvent,
+			"session-1",
+		);
+
+		expect(start).toEqual([
+			{
+				sessionId: "session-1",
+				update: {
+					sessionUpdate: "session_info_update",
+					_meta: {
+						gjcPhase: "compacting",
+						gjcCompactionState: "start",
+						gjcCompactionTrigger: "threshold",
+						gjcCompactionAction: "context-full",
+						running: true,
+						gjcRunning: true,
+					},
+				},
+			},
+		]);
+		expect(end).toEqual([
+			{
+				sessionId: "session-1",
+				update: {
+					sessionUpdate: "session_info_update",
+					_meta: {
+						gjcPhase: "responding",
+						gjcCompactionState: "end",
+						gjcCompactionAction: "context-full",
+						gjcCompactionAborted: false,
+						gjcCompactionWillRetry: true,
+						gjcCompactionSkipped: true,
+						gjcCompactionErrorMessage: "retrying after maintenance",
+						gjcCompactionContinuationSkipReason: "auto_continue_disabled_non_resumable_tail",
+						running: true,
+						gjcRunning: true,
+					},
+				},
+			},
+		]);
+		expectAcpNotifications([...start, ...end]);
+	});
+
+	it("returns idle metadata when compaction finishes outside a prompt", () => {
+		const [notification] = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "auto_compaction_end",
+				action: "handoff",
+				result: undefined,
+				aborted: true,
+				willRetry: false,
+			} as AgentSessionEvent,
+			"session-1",
+			{ compactionEndPhase: "idle" },
+		);
+
+		expect(notification?.update._meta).toMatchObject({
+			gjcPhase: "idle",
+			gjcCompactionState: "end",
+			gjcCompactionAction: "handoff",
+			gjcCompactionAborted: true,
+			running: false,
+			gjcRunning: false,
+		});
+		expectAcpNotifications(notification ? [notification] : []);
+	});
+
 	it("emits final assistant text when no text deltas were observed", () => {
 		const assistantMessage = makeAssistantMessage("final response");
 		const progress = { textEmitted: false, thoughtEmitted: false };

--- a/packages/coding-agent/test/acp/acp-canonical-payload.redteam.test.ts
+++ b/packages/coding-agent/test/acp/acp-canonical-payload.redteam.test.ts
@@ -17,8 +17,6 @@ const WHITELISTED_EMPTY_EVENT_TYPES = [
 	"turn_start",
 	"turn_end",
 	"message_start",
-	"auto_compaction_start",
-	"auto_compaction_end",
 	"auto_retry_start",
 	"auto_retry_end",
 	"retry_fallback_applied",


### PR DESCRIPTION
## What

- map `auto_compaction_start` and `auto_compaction_end` into additive ACP `session_info_update` metadata
- expose compaction phase, action, trigger, retry, abort, skip, and error outcomes without adding transcript messages
- forward prompt-bound and idle maintenance exactly once, including cancellation before the bootstrap guard
- restore `gjcPhase: "idle"` and `running: false` on normal completion and cancellation

## Why

GJC already knows when automatic context compaction is running, but the ACP mapper explicitly discarded those events. ACP clients therefore looked stalled while context-full or handoff compaction was in progress and could not present accurate progress or failure state.

## Testing

- `bun test packages/coding-agent/test/acp-event-mapper.test.ts packages/coding-agent/test/acp-agent.test.ts packages/coding-agent/test/acp/acp-canonical-payload.redteam.test.ts` (83 passed)
- `bun --cwd=packages/coding-agent run check`
- `bun check`
- independent architecture review: CLEAR

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)