### PR TITLE
Fix ACP wire conformance compaction whitelist

### DIFF
--- a/packages/coding-agent/test/agent-wire-conformance.test.ts
+++ b/packages/coding-agent/test/agent-wire-conformance.test.ts
@@ -28,8 +28,6 @@ const ACP_EMPTY_WHITELIST = new Set([
 	"turn_start",
 	"turn_end",
 	"message_start",
-	"auto_compaction_start",
-	"auto_compaction_end",
 	"auto_retry_start",
 	"auto_retry_end",
 	"retry_fallback_applied",


### PR DESCRIPTION
## Summary
- Remove auto_compaction_start/end from the ACP-empty conformance whitelist now that #1927 intentionally projects compaction lifecycle metadata.
- Leave ACP mapper behavior unchanged: session_info_update metadata remains additive and transcript-free.

## Validation
- bun test packages/coding-agent/test/agent-wire-conformance.test.ts
- bun test packages/coding-agent/test/acp-event-mapper.test.ts packages/coding-agent/test/acp/acp-canonical-payload.redteam.test.ts

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*