### PR TITLE
fix(model-selector): carry batch roles and effort through the reasoning menu

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - ACP permission prompts now honor `clientCapabilities._meta.gjc.permissionHandling` and the `GJC_ACP_PERMISSION_MODE` fallback, so `auto` and `always-allow` no longer emit `session/request_permission` calls while invalid values fail safely to `prompt`.
+- Model selector batch assignments ("Set for all role agents" / "Set for all targets") now open the reasoning-effort menu whenever any batch target requires an explicit choice (e.g. Anthropic reasoning models like `claude-fable-5`), and the chosen effort plus the full batch survive the menu. Previously the menu never appeared for Anthropic models (silently persisting `:off` selectors for every role agent), and for OpenAI/Codex models picking an effort collapsed the batch to a DEFAULT-only assignment.
 ### Added
 
 - ACP clients now receive GJC automatic-compaction start/end state through additive `session_info_update` metadata, including the compaction action, trigger, retry/abort/error outcome, and busy-to-idle phase transitions.

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -121,6 +121,7 @@ export type ModelSelectorSelection =
 interface PendingThinkingChoice {
 	item: ModelItem | CanonicalModelItem;
 	role: GjcModelAssignmentTargetId | null;
+	roles?: readonly GjcModelAssignmentTargetId[];
 	levels: ThinkingLevel[];
 }
 
@@ -1373,7 +1374,13 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	#renderThinkingMenu(choice: PendingThinkingChoice): void {
-		const targetLabel = choice.role === null ? "temporary model" : GJC_MODEL_ASSIGNMENT_TARGETS[choice.role].name;
+		const targetLabel = choice.roles
+			? choice.roles.includes("default")
+				? "all targets"
+				: "all role agents"
+			: choice.role === null
+				? "temporary model"
+				: GJC_MODEL_ASSIGNMENT_TARGETS[choice.role].name;
 		this.#listContainer.addChild(new Spacer(1));
 		this.#listContainer.addChild(
 			new Text(theme.fg("muted", `  Reasoning for ${targetLabel}: ${choice.item.model.id}`), 0, 0),
@@ -1700,14 +1707,16 @@ export class ModelSelectorComponent extends Container {
 			const level = choice.levels[this.#selectedThinkingIndex];
 			if (!level) return;
 			this.#pendingThinkingChoice = undefined;
-			this.#handleSelect(choice.item, choice.role, level);
+			this.#handleSelect(choice.item, choice.role, level, choice.roles);
 			return;
 		}
 		if (getKeybindings().matches(keyData, "tui.select.cancel")) {
 			this.#pendingThinkingChoice = undefined;
 			if (choice.role !== null) {
 				this.#pendingActionItem = choice.item;
-				this.#selectedActionIndex = Math.max(0, GJC_MODEL_ASSIGNMENT_TARGET_IDS.indexOf(choice.role));
+				this.#selectedActionIndex = choice.roles
+					? GJC_MODEL_ASSIGNMENT_TARGET_IDS.length + (choice.roles.includes("default") ? 1 : 0)
+					: Math.max(0, GJC_MODEL_ASSIGNMENT_TARGET_IDS.indexOf(choice.role));
 			}
 			this.#updateList();
 		}
@@ -1736,9 +1745,12 @@ export class ModelSelectorComponent extends Container {
 	): void {
 		const itemThinkingLevel = thinkingLevel ?? item.thinkingLevel;
 		const hasExplicitThinkingChoice = thinkingLevel !== undefined || item.explicitThinkingLevel === true;
-		if (!hasExplicitThinkingChoice && requiresExplicitThinkingChoice(item.model, role)) {
+		const needsExplicitThinkingChoice = roles
+			? roles.some(targetRole => requiresExplicitThinkingChoice(item.model, targetRole))
+			: requiresExplicitThinkingChoice(item.model, role);
+		if (!hasExplicitThinkingChoice && needsExplicitThinkingChoice) {
 			const levels = getSelectableThinkingLevels(item.model);
-			this.#pendingThinkingChoice = { item, role, levels };
+			this.#pendingThinkingChoice = { item, role, roles, levels };
 			this.#selectedThinkingIndex = this.#getInitialThinkingChoiceIndex(item, levels);
 			this.#updateList();
 			return;

--- a/packages/coding-agent/test/model-selector-batch-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-batch-thinking.test.ts
@@ -1,0 +1,215 @@
+import { beforeAll, describe, expect, test, vi } from "bun:test";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import { Effort, type Model } from "@gajae-code/ai";
+import type { GjcModelAssignmentTargetId, ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { TUI } from "@gajae-code/tui";
+
+const DOWN = "\x1b[B";
+
+function normalizeRenderedText(text: string): string {
+	return text
+		.replace(/\x1b\[[0-9;]*m/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+interface SelectionCapture {
+	model: Model;
+	role: GjcModelAssignmentTargetId | null;
+	thinkingLevel?: ThinkingLevel;
+	selector?: string;
+	roles?: readonly GjcModelAssignmentTargetId[];
+}
+
+type TestModelSelectorSelection = {
+	kind: "assignment";
+	model: Model;
+	role: GjcModelAssignmentTargetId | null;
+	thinkingLevel?: ThinkingLevel;
+	selector?: string;
+	roles?: readonly GjcModelAssignmentTargetId[];
+};
+
+function createSelector(
+	model: Model,
+	settings: Settings,
+	onSelect: (selection: TestModelSelectorSelection) => void,
+): ModelSelectorComponent {
+	const modelRegistry = {
+		getAll: () => [model],
+		getDiscoverableProviders: () => [],
+		getCanonicalModels: () => [],
+		resolveCanonicalModel: () => undefined,
+	} as unknown as ModelRegistry;
+	const ui = { requestRender: vi.fn() } as unknown as TUI;
+	return new ModelSelectorComponent(
+		ui,
+		model,
+		settings,
+		modelRegistry,
+		[{ model, thinkingLevel: ThinkingLevel.Off }],
+		selection => onSelect(selection as TestModelSelectorSelection),
+		() => {},
+		{},
+	);
+}
+
+/**
+ * Reasoning model whose provider alone does NOT force an explicit thinking
+ * choice for the DEFAULT target (unlike openai/openai-codex), mirroring
+ * Anthropic reasoning models such as claude-fable-5. Role-agent targets
+ * (task.agentModelOverrides) still require an explicit choice, so batch
+ * assignment must surface the reasoning menu.
+ */
+function createAnthropicReasoningModel(id: string): Model {
+	return {
+		id,
+		name: id,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: true,
+		thinking: {
+			minLevel: Effort.Low,
+			maxLevel: Effort.XHigh,
+			mode: "anthropic-adaptive",
+		},
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 64000,
+	} as Model;
+}
+
+function createCodexReasoningModel(id: string): Model {
+	return {
+		id,
+		name: id,
+		api: "openai-codex-responses",
+		provider: "openai-codex",
+		baseUrl: "https://chatgpt.com/backend-api",
+		reasoning: true,
+		thinking: {
+			minLevel: Effort.Low,
+			maxLevel: Effort.XHigh,
+			mode: "effort",
+		},
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 272_000,
+		maxTokens: 128000,
+	} as Model;
+}
+
+let testTheme = await getThemeByName("red-claw");
+
+function installTestTheme(): void {
+	if (!testTheme) throw new Error("Failed to load test theme");
+	setThemeInstance(testTheme);
+}
+
+/** Enter the action menu and move the cursor onto the requested action row. */
+function selectActionRow(selector: ModelSelectorComponent, rowIndex: number): void {
+	selector.handleInput("\n");
+	for (let i = 0; i < rowIndex; i++) selector.handleInput(DOWN);
+	selector.handleInput("\n");
+}
+
+// Action menu rows: 0..4 = default/executor/architect/planner/critic,
+// 5 = "Set for all role agents", 6 = "Set for all targets".
+const ALL_ROLE_AGENTS_ROW = 5;
+const ALL_TARGETS_ROW = 6;
+
+describe("ModelSelector batch assignment thinking menu", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("red-claw");
+		installTestTheme();
+	});
+
+	test("all role agents batch opens the reasoning menu for anthropic reasoning models", async () => {
+		installTestTheme();
+		const model = createAnthropicReasoningModel("claude-fable-5");
+		const settings = Settings.isolated();
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(model, settings, selection => {
+			if (selection.kind === "assignment") selected = selection;
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selectActionRow(selector, ALL_ROLE_AGENTS_ROW);
+
+		// The batch includes role-agent targets, so an explicit effort choice is required.
+		expect(selected).toBeUndefined();
+		const thinkingRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(thinkingRendered).toContain("Reasoning for all role agents");
+
+		// Levels are [off, low, medium, high, xhigh]; pick xhigh.
+		for (let i = 0; i < 4; i++) selector.handleInput(DOWN);
+		selector.handleInput("\n");
+
+		const selectedAfterEnter = selected;
+		if (!selectedAfterEnter) throw new Error("Expected batch selection after picking a thinking level");
+		expect(selectedAfterEnter.role).toBe("default");
+		expect(selectedAfterEnter.roles).toEqual(["executor", "architect", "planner", "critic"]);
+		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.XHigh);
+		expect(selectedAfterEnter.selector).toBe("anthropic/claude-fable-5:xhigh");
+	});
+
+	test("all targets batch keeps every target through the reasoning menu", async () => {
+		installTestTheme();
+		const model = createCodexReasoningModel("gpt-5.5");
+		const settings = Settings.isolated();
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(model, settings, selection => {
+			if (selection.kind === "assignment") selected = selection;
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selectActionRow(selector, ALL_TARGETS_ROW);
+
+		expect(selected).toBeUndefined();
+		const thinkingRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(thinkingRendered).toContain("Reasoning for all targets");
+
+		// Pick "high" (levels are [off, low, medium, high, xhigh]).
+		for (let i = 0; i < 3; i++) selector.handleInput(DOWN);
+		selector.handleInput("\n");
+
+		const selectedAfterEnter = selected;
+		if (!selectedAfterEnter) throw new Error("Expected batch selection after picking a thinking level");
+		expect(selectedAfterEnter.role).toBe("default");
+		expect(selectedAfterEnter.roles).toEqual(["default", "executor", "architect", "planner", "critic"]);
+		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.High);
+		expect(selectedAfterEnter.selector).toBe("openai-codex/gpt-5.5:high");
+	});
+
+	test("cancelling the batch reasoning menu restores the batch action row", async () => {
+		installTestTheme();
+		const model = createAnthropicReasoningModel("claude-fable-5");
+		const settings = Settings.isolated();
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(model, settings, selection => {
+			if (selection.kind === "assignment") selected = selection;
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selectActionRow(selector, ALL_TARGETS_ROW);
+		expect(normalizeRenderedText(selector.render(220).join("\n"))).toContain("Reasoning for all targets");
+
+		// Escape back to the action menu; no selection must have been emitted.
+		selector.handleInput("\x1b");
+		expect(selected).toBeUndefined();
+		const actionRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(actionRendered).toContain("Action for:");
+		expect(actionRendered).toContain("Set for all targets");
+	});
+});

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -295,10 +295,16 @@ describe("ModelSelector canonical model selection", () => {
 		for (let i = 0; i < 5; i++) selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 
+		// Batch assignment of a reasoning model requires an explicit effort choice.
+		expect(selected).toBeUndefined();
+		expect(normalizeRenderedText(selector.render(220).join("\n"))).toContain("Reasoning for all role agents");
+		selector.handleInput("\n");
+
 		const selectedAfterEnter = selected;
 		if (!selectedAfterEnter) throw new Error("Expected batch role-agent selection");
 		expect(selectedAfterEnter.role).toBe("default");
 		expect(selectedAfterEnter.roles).toEqual(["executor", "architect", "planner", "critic"]);
+		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Off);
 		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}:off`);
 	});
 
@@ -318,10 +324,16 @@ describe("ModelSelector canonical model selection", () => {
 		for (let i = 0; i < 6; i++) selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 
+		// Batch assignment of a reasoning model requires an explicit effort choice.
+		expect(selected).toBeUndefined();
+		expect(normalizeRenderedText(selector.render(220).join("\n"))).toContain("Reasoning for all targets");
+		selector.handleInput("\n");
+
 		const selectedAfterEnter = selected;
 		if (!selectedAfterEnter) throw new Error("Expected all-targets selection");
 		expect(selectedAfterEnter.role).toBe("default");
 		expect(selectedAfterEnter.roles).toEqual(["default", "executor", "architect", "planner", "critic"]);
+		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Off);
 		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}:off`);
 	});
 


### PR DESCRIPTION
## What changed

Model-selector batch assignments — "Set for all role agents" and "Set for all targets" — now handle reasoning effort correctly:

1. **The reasoning-effort menu opens for batch flows whenever any batch target requires an explicit choice.** Previously the requirement was evaluated only against the `default` role, so for Anthropic reasoning models (e.g. `anthropic/claude-fable-5`) the menu never appeared and every role agent was silently persisted with a `:off` selector. Setting all 5 targets to e.g. `claude-fable-5:xhigh` in one flow was impossible from the picker UI.
2. **The chosen effort and the batch itself survive the menu.** `PendingThinkingChoice` dropped the `roles` array, so for OpenAI/Codex models (where the menu already opened), picking an effort collapsed the batch to a DEFAULT-only assignment — the 4 role agents were never written.
3. Cancelling the menu returns to the correct batch action row, and the menu is labeled "Reasoning for all role agents" / "Reasoning for all targets".

## Why

Assigning one model + effort to all `default`/`executor`/`architect`/`planner`/`critic` targets at once is the primary use of the batch rows; both silent-degradation paths defeat it without any error surfaced to the user. (`/model all-targets <provider>/<model>:<effort>` was unaffected since the selector string carries the effort.)

## Reproduction (before this change)

1. `/model`, pick a reasoning Anthropic model (e.g. `claude-fable-5`), Enter.
2. Choose "Set for all role agents".
3. Observed: no effort menu; `task.agentModelOverrides` gets `...:off` for all 4 role agents.
4. With an openai-codex model, choose "Set for all targets", pick `xhigh`: only `modelRoles.default` is written; role agents untouched.

## Affected files

- `packages/coding-agent/src/modes/components/model-selector.ts` — batch-aware `requiresExplicitThinkingChoice`, `roles` threaded through `PendingThinkingChoice` (select + cancel paths), batch menu labels.
- `packages/coding-agent/test/model-selector-batch-thinking.test.ts` — new interactive-flow coverage (menu opens for Anthropic batch; batch + effort survive the menu for Codex; cancel restores the batch row). All three fail on `dev` without the fix.
- `packages/coding-agent/test/model-selector-role-badge-thinking.test.ts` — the two batch tests encoded the buggy immediate-`:off` behavior; updated to the new contract (menu step asserted, same final selectors).
- `packages/coding-agent/CHANGELOG.md` — Unreleased/Fixed entry.

## Tests run

```
bun test test/model-selector-batch-thinking.test.ts \
  test/model-selector-role-badge-thinking.test.ts \
  test/model-selector-controller-batch.test.ts \
  test/slash-commands/model.test.ts \
  test/model-selector-profiles.test.ts \
  test/model-selector-profiles-redteam.test.ts \
  test/model-preset-landing-redteam-qa.test.ts
# 67 pass, 0 fail
bun run check:types   # clean
biome check           # OK
```

## Remaining risks

- The selector emitted for the DEFAULT target in an all-targets batch keeps the existing controller behavior (effort suffix stripped for `modelRoles.default`, session thinking level set separately); no change there.
- Non-reasoning models are unaffected (`requiresExplicitThinkingChoice` short-circuits on `reasoning !== true`).
