### PR TITLE
feat(ai): add GPT-5.6 family support (Sol, Terra, Luna)

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -47,6 +47,8 @@ const DEFAULT_REASONING_EFFORTS_WITH_XHIGH_AND_MAX: readonly Effort[] = [
 const GEMINI_3_PRO_EFFORTS: readonly Effort[] = [Effort.Low, Effort.High];
 const GEMINI_3_FLASH_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
 const GPT_5_2_PLUS_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
+// GPT-5.6 introduces `max` above `xhigh` (Sol/Terra/Luna tiers, GA 2026-07-09).
+const GPT_5_6_PLUS_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max];
 const GPT_5_5_DEFAULT_EFFORT = Effort.XHigh;
 
 const GPT_5_1_CODEX_MINI_EFFORTS: readonly Effort[] = [Effort.Medium, Effort.High];
@@ -60,7 +62,18 @@ type SemVer = {
 
 type GeminiKind = "pro" | "flash";
 type AnthropicKind = "opus" | "sonnet";
-type OpenAIVariant = "base" | "codex" | "codex-max" | "codex-mini" | "codex-spark" | "mini" | "max" | "nano";
+type OpenAIVariant =
+	| "base"
+	| "codex"
+	| "codex-max"
+	| "codex-mini"
+	| "codex-spark"
+	| "luna"
+	| "mini"
+	| "max"
+	| "nano"
+	| "sol"
+	| "terra";
 
 const CODEX_GPT_5_4_PRIORITY_BY_VARIANT: Partial<Record<OpenAIVariant, number>> = {
 	base: 0,
@@ -466,8 +479,27 @@ function applyGpt55ContextWindow(model: ApiModel<Api>, parsedModel: OpenAIModel)
 	return false;
 }
 
+/** GPT-5.6 capability tiers (Sol flagship, Terra balanced, Luna cost-efficient) plus the bare `gpt-5.6` alias. */
+const GPT_5_6_TIER_VARIANTS: ReadonlySet<OpenAIVariant> = new Set(["base", "sol", "terra", "luna"]);
+
+function applyGpt56ContextWindow(model: ApiModel<Api>, parsedModel: OpenAIModel): boolean {
+	if (!GPT_5_6_TIER_VARIANTS.has(parsedModel.variant) || !semverGte(parsedModel.version, "5.6")) {
+		return false;
+	}
+	// The GPT-5.6 API advertises a 1,050,000-token context window with 128K max
+	// output. As with GPT-5.5, the OpenAI code backend request path enforces a
+	// smaller prompt budget, so keep the conservative 272K input cap on that
+	// transport until a larger backend budget is confirmed.
+	model.contextWindow =
+		model.provider === "openai-codex" || model.api === "openai-codex-responses" ? 272_000 : 1_050_000;
+	return true;
+}
+
 function applyOpenAICatalogPolicy(model: ApiModel<Api>, parsedModel: OpenAIModel): void {
 	if (applyGpt55ContextWindow(model, parsedModel)) {
+		return;
+	}
+	if (applyGpt56ContextWindow(model, parsedModel)) {
 		return;
 	}
 	// OpenAI code backend models: 400K figure includes output budget; input window is 272K.
@@ -581,6 +613,9 @@ function inferSupportedEfforts<TApi extends Api>(parsedModel: ParsedModel, model
 function inferOpenAISupportedEfforts(model: OpenAIModel): readonly Effort[] {
 	if (model.variant === "codex-mini" && semverEqual(model.version, "5.1")) {
 		return GPT_5_1_CODEX_MINI_EFFORTS;
+	}
+	if (semverGte(model.version, "5.6")) {
+		return GPT_5_6_PLUS_EFFORTS;
 	}
 	if (semverGte(model.version, "5.2")) {
 		return GPT_5_2_PLUS_EFFORTS;
@@ -714,7 +749,10 @@ function parseAnthropicModel(modelId: string): AnthropicModel | null {
 }
 
 function parseOpenAIModel(modelId: string): OpenAIModel | null {
-	const match = /gpt-(\d+(?:\.\d+){0,2})(?:-(codex-spark|codex-mini|codex-max|codex|mini|max|nano))?$/.exec(modelId);
+	const match =
+		/gpt-(\d+(?:\.\d+){0,2})(?:-(codex-spark|codex-mini|codex-max|codex|luna|mini|max|nano|sol|terra))?$/.exec(
+			modelId,
+		);
 	if (!match) {
 		return null;
 	}

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -56291,6 +56291,84 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"gpt-5.6-luna": {
+			"id": "gpt-5.6-luna",
+			"name": "GPT-5.6 Luna",
+			"api": "openai-responses",
+			"provider": "openai",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
+			},
+			"applyPatchToolType": "freeform"
+		},
+		"gpt-5.6-sol": {
+			"id": "gpt-5.6-sol",
+			"name": "GPT-5.6 Sol",
+			"api": "openai-responses",
+			"provider": "openai",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
+			},
+			"applyPatchToolType": "freeform"
+		},
+		"gpt-5.6-terra": {
+			"id": "gpt-5.6-terra",
+			"name": "GPT-5.6 Terra",
+			"api": "openai-responses",
+			"provider": "openai",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
+			},
+			"applyPatchToolType": "freeform"
+		},
 		"o1": {
 			"id": "o1",
 			"name": "o1",
@@ -56936,6 +57014,87 @@
 				"minLevel": "low",
 				"maxLevel": "xhigh",
 				"defaultLevel": "xhigh"
+			},
+			"applyPatchToolType": "freeform"
+		},
+		"gpt-5.6-luna": {
+			"id": "gpt-5.6-luna",
+			"name": "GPT-5.6 Luna",
+			"api": "openai-codex-responses",
+			"provider": "openai-codex",
+			"baseUrl": "https://chatgpt.com/backend-api",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"preferWebsockets": true,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
+			},
+			"applyPatchToolType": "freeform"
+		},
+		"gpt-5.6-sol": {
+			"id": "gpt-5.6-sol",
+			"name": "GPT-5.6 Sol",
+			"api": "openai-codex-responses",
+			"provider": "openai-codex",
+			"baseUrl": "https://chatgpt.com/backend-api",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"preferWebsockets": true,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
+			},
+			"applyPatchToolType": "freeform"
+		},
+		"gpt-5.6-terra": {
+			"id": "gpt-5.6-terra",
+			"name": "GPT-5.6 Terra",
+			"api": "openai-codex-responses",
+			"provider": "openai-codex",
+			"baseUrl": "https://chatgpt.com/backend-api",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"preferWebsockets": true,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
 			},
 			"applyPatchToolType": "freeform"
 		}

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -372,6 +372,73 @@ describe("generated model policies", () => {
 		expect(models[2]?.applyPatchToolType).toBeUndefined();
 		expect(models[3]?.applyPatchToolType).toBeUndefined();
 	});
+
+	it("stores the GPT-5.6 effort range including max in model metadata", () => {
+		const sol = createModel({
+			id: "gpt-5.6-sol",
+			api: "openai-responses",
+			provider: "openai",
+		});
+		const terra = createModel({
+			id: "gpt-5.6-terra",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+		});
+		const luna = createModel({
+			id: "gpt-5.6-luna",
+			api: "openai-responses",
+			provider: "openai",
+		});
+		const alias = createModel({
+			id: "gpt-5.6",
+			api: "openai-responses",
+			provider: "openai",
+		});
+
+		for (const model of [sol, terra, luna, alias]) {
+			expect(model.thinking).toEqual({
+				mode: "effort",
+				minLevel: Effort.Low,
+				maxLevel: Effort.Max,
+			});
+		}
+		expect(requireSupportedEffort(sol, Effort.Max)).toBe(Effort.Max);
+		expect(() => requireSupportedEffort(sol, Effort.Minimal)).toThrow(
+			/Supported efforts: low, medium, high, xhigh, max/,
+		);
+	});
+
+	it("keeps Codex GPT-5.6 tiers at the effective 272K request cap and first-party tiers at 1,050K", () => {
+		const models: Model<Api>[] = [
+			{
+				...createModel({
+					id: "gpt-5.6-sol",
+					api: "openai-codex-responses",
+					provider: "openai-codex",
+				}),
+				// Discovery/cache can advertise the total 1,050K window, but the
+				// usable request prompt cap remains lower on this transport.
+				contextWindow: 1_050_000,
+				maxTokens: 128000,
+			},
+			{
+				...createModel({
+					id: "gpt-5.6-terra",
+					api: "openai-responses",
+					provider: "openai",
+				}),
+				contextWindow: 272000,
+				maxTokens: 128000,
+			},
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models[0]?.contextWindow).toBe(272_000);
+		expect(models[1]?.contextWindow).toBe(1_050_000);
+		expect(models[0]?.applyPatchToolType).toBe("freeform");
+		expect(models[1]?.applyPatchToolType).toBe("freeform");
+	});
 });
 
 describe("model thinking runtime helpers", () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 - ACP clients now receive GJC automatic-compaction start/end state through additive `session_info_update` metadata, including the compaction action, trigger, retry/abort/error outcome, and busy-to-idle phase transitions.
+- Added GPT-5.6 family support (Sol, Terra, Luna — GA 2026-07-09): bundled `openai` and `openai-codex` catalog entries with verified pricing/limits (1,050K context, 128K max output, cache writes billed at 1.25x input), `sol`/`terra`/`luna` variant parsing so catalog policies (freeform apply_patch, context-window normalization) apply, and a `low`–`max` reasoning-effort range including the new `max` level above `xhigh`. The bare `gpt-5.6` API alias resolves like Sol. The multi-agent `ultra` setting is a Responses API beta, not a reasoning effort, and is out of scope.
 
 ## [0.9.4] - 2026-07-09
 ### Fixed


### PR DESCRIPTION
## What changed

Adds support for the **GPT-5.6 family (Sol, Terra, Luna)**, which OpenAI moved to general availability on 2026-07-09 across ChatGPT, Codex, and the API.

- `packages/ai/src/model-thinking.ts`
  - `parseOpenAIModel` now recognizes `sol` / `terra` / `luna` variants, so `gpt-5.6-sol` etc. resolve to the `openai` family instead of `unknown`. This restores freeform `apply_patch` inference and catalog policies for these ids.
  - GPT-5.6+ effort inference returns `low..max`: the family introduces `max` above `xhigh` ("`max` gives GPT-5.6 even more time than `xhigh`" — launch post). The multi-agent `ultra` setting is a Responses API beta, **not** a reasoning effort, and is intentionally out of scope.
  - New `applyGpt56ContextWindow` policy: 1,050,000 usable input tokens on the first-party API; conservative 272K prompt cap on the `openai-codex` transport, mirroring the existing GPT-5.5 policy, until a larger backend budget is confirmed.
- `packages/ai/src/models.json`
  - Bundled `openai` and `openai-codex` entries for `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` so the models are usable before the next `generate-models` regeneration. Values verified against the API model cards:
    - Sol $5 / $30, Terra $2.50 / $15, Luna $1 / $6 per 1M tokens
    - Cached input at the 90% discount (0.5 / 0.25 / 0.1)
    - Cache writes billed at **1.25x uncached input** for GPT-5.6+ (6.25 / 3.125 / 1.25) — first OpenAI entries with non-zero `cacheWrite`
    - 1,050,000 context window, 128,000 max output tokens, text+image input
  - No `priority` set on the codex entries (semantics are discovery-owned; regeneration will assign them).
  - The bare `gpt-5.6` API alias (routes to Sol) is not added as a separate entry to avoid duplicate catalog rows; the parser handles it as the `base` variant with identical policies.

## Context / sources

- https://openai.com/index/gpt-5-6/ (GA announcement, `max`/`ultra` semantics, family tiers)
- https://developers.openai.com/api/docs/models/gpt-5.6-sol (+ `-terra`, `-luna`): ids, 1,050,000 ctx / 128K out, pricing, cache-write 1.25x
- `openai/codex` no longer hardcodes model presets (listings derive from the live catalog), so no preset sync is needed there.

## Tests run

```
bun test packages/ai/test/model-thinking.test.ts   # 21 pass (2 new GPT-5.6 cases)
bun test  # full packages/ai suite: 1608 pass, 337 skip (e2e env), 0 fail
bun run check:types  # clean
biome check          # OK
```

New cases assert the `low..max` effort metadata (including `requireSupportedEffort` boundaries) for all three tiers plus the bare alias, and the 272K-vs-1,050K context-window normalization with freeform apply_patch on both transports.

## Remaining risks / follow-ups

- The 272K codex-transport cap is a conservative mirror of the GPT-5.5 policy; if the ChatGPT backend exposes a larger prompt budget for 5.6, the cap should be lifted in `applyGpt56ContextWindow`.
- A future `generate-models` run with live credentials will replace the hand-added bundled entries with discovery output; the policy layer keeps the normalized values stable either way.
- Supporting `ultra` (Responses API multi-agent beta) would be a separate feature touching request construction, not model metadata.
