### PR TITLE
feat(ai): support GPT-5.6 Sol Terra Luna

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added GPT-5.6 Sol, Terra, and Luna catalog/parser support for OpenAI and OpenAI code transports, including `low` through canonical `max` reasoning efforts, verified pricing/limits, and GPT-5.6 cache-write pricing (#1925; OmX #3103).
 
 ## [0.9.4] - 2026-07-09
 ### Fixed

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -47,6 +47,7 @@ const DEFAULT_REASONING_EFFORTS_WITH_XHIGH_AND_MAX: readonly Effort[] = [
 const GEMINI_3_PRO_EFFORTS: readonly Effort[] = [Effort.Low, Effort.High];
 const GEMINI_3_FLASH_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
 const GPT_5_2_PLUS_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
+const GPT_5_6_PLUS_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max];
 const GPT_5_5_DEFAULT_EFFORT = Effort.XHigh;
 
 const GPT_5_1_CODEX_MINI_EFFORTS: readonly Effort[] = [Effort.Medium, Effort.High];
@@ -60,7 +61,18 @@ type SemVer = {
 
 type GeminiKind = "pro" | "flash";
 type AnthropicKind = "opus" | "sonnet";
-type OpenAIVariant = "base" | "codex" | "codex-max" | "codex-mini" | "codex-spark" | "mini" | "max" | "nano";
+type OpenAIVariant =
+	| "base"
+	| "codex"
+	| "codex-max"
+	| "codex-mini"
+	| "codex-spark"
+	| "luna"
+	| "mini"
+	| "max"
+	| "nano"
+	| "sol"
+	| "terra";
 
 const CODEX_GPT_5_4_PRIORITY_BY_VARIANT: Partial<Record<OpenAIVariant, number>> = {
 	base: 0,
@@ -465,9 +477,22 @@ function applyGpt55ContextWindow(model: ApiModel<Api>, parsedModel: OpenAIModel)
 	}
 	return false;
 }
+const GPT_5_6_TIER_VARIANTS: ReadonlySet<OpenAIVariant> = new Set(["base", "sol", "terra", "luna"]);
+
+function applyGpt56ContextWindow(model: ApiModel<Api>, parsedModel: OpenAIModel): boolean {
+	if (!semverGte(parsedModel.version, "5.6") || !GPT_5_6_TIER_VARIANTS.has(parsedModel.variant)) {
+		return false;
+	}
+	model.contextWindow =
+		model.provider === "openai-codex" || model.api === "openai-codex-responses" ? 272_000 : 1_050_000;
+	return true;
+}
 
 function applyOpenAICatalogPolicy(model: ApiModel<Api>, parsedModel: OpenAIModel): void {
 	if (applyGpt55ContextWindow(model, parsedModel)) {
+		return;
+	}
+	if (applyGpt56ContextWindow(model, parsedModel)) {
 		return;
 	}
 	// OpenAI code backend models: 400K figure includes output budget; input window is 272K.
@@ -581,6 +606,9 @@ function inferSupportedEfforts<TApi extends Api>(parsedModel: ParsedModel, model
 function inferOpenAISupportedEfforts(model: OpenAIModel): readonly Effort[] {
 	if (model.variant === "codex-mini" && semverEqual(model.version, "5.1")) {
 		return GPT_5_1_CODEX_MINI_EFFORTS;
+	}
+	if (semverGte(model.version, "5.6")) {
+		return GPT_5_6_PLUS_EFFORTS;
 	}
 	if (semverGte(model.version, "5.2")) {
 		return GPT_5_2_PLUS_EFFORTS;
@@ -714,7 +742,10 @@ function parseAnthropicModel(modelId: string): AnthropicModel | null {
 }
 
 function parseOpenAIModel(modelId: string): OpenAIModel | null {
-	const match = /gpt-(\d+(?:\.\d+){0,2})(?:-(codex-spark|codex-mini|codex-max|codex|mini|max|nano))?$/.exec(modelId);
+	const match =
+		/gpt-(\d+(?:\.\d+){0,2})(?:-(codex-spark|codex-mini|codex-max|codex|luna|mini|max|nano|sol|terra))?$/.exec(
+			modelId,
+		);
 	if (!match) {
 		return null;
 	}

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -56291,6 +56291,84 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"gpt-5.6-luna": {
+			"id": "gpt-5.6-luna",
+			"name": "GPT-5.6 Luna",
+			"api": "openai-responses",
+			"provider": "openai",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
+			},
+			"applyPatchToolType": "freeform"
+		},
+		"gpt-5.6-sol": {
+			"id": "gpt-5.6-sol",
+			"name": "GPT-5.6 Sol",
+			"api": "openai-responses",
+			"provider": "openai",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
+			},
+			"applyPatchToolType": "freeform"
+		},
+		"gpt-5.6-terra": {
+			"id": "gpt-5.6-terra",
+			"name": "GPT-5.6 Terra",
+			"api": "openai-responses",
+			"provider": "openai",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
+			},
+			"applyPatchToolType": "freeform"
+		},
 		"o1": {
 			"id": "o1",
 			"name": "o1",
@@ -56936,6 +57014,87 @@
 				"minLevel": "low",
 				"maxLevel": "xhigh",
 				"defaultLevel": "xhigh"
+			},
+			"applyPatchToolType": "freeform"
+		},
+		"gpt-5.6-luna": {
+			"id": "gpt-5.6-luna",
+			"name": "GPT-5.6 Luna",
+			"api": "openai-codex-responses",
+			"provider": "openai-codex",
+			"baseUrl": "https://chatgpt.com/backend-api",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"preferWebsockets": true,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
+			},
+			"applyPatchToolType": "freeform"
+		},
+		"gpt-5.6-sol": {
+			"id": "gpt-5.6-sol",
+			"name": "GPT-5.6 Sol",
+			"api": "openai-codex-responses",
+			"provider": "openai-codex",
+			"baseUrl": "https://chatgpt.com/backend-api",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"preferWebsockets": true,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
+			},
+			"applyPatchToolType": "freeform"
+		},
+		"gpt-5.6-terra": {
+			"id": "gpt-5.6-terra",
+			"name": "GPT-5.6 Terra",
+			"api": "openai-codex-responses",
+			"provider": "openai-codex",
+			"baseUrl": "https://chatgpt.com/backend-api",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"preferWebsockets": true,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
 			},
 			"applyPatchToolType": "freeform"
 		}

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -372,6 +372,73 @@ describe("generated model policies", () => {
 		expect(models[2]?.applyPatchToolType).toBeUndefined();
 		expect(models[3]?.applyPatchToolType).toBeUndefined();
 	});
+
+	it("stores GPT-5.6 Sol/Terra/Luna effort metadata through max", () => {
+		const models = [
+			createModel({
+				id: "gpt-5.6-sol",
+				api: "openai-responses",
+				provider: "openai",
+			}),
+			createModel({
+				id: "gpt-5.6-terra",
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+			}),
+			createModel({
+				id: "gpt-5.6-luna",
+				api: "openai-responses",
+				provider: "openai",
+			}),
+			createModel({
+				id: "gpt-5.6",
+				api: "openai-responses",
+				provider: "openai",
+			}),
+		];
+
+		for (const model of models) {
+			expect(model.thinking).toEqual({
+				mode: "effort",
+				minLevel: Effort.Low,
+				maxLevel: Effort.Max,
+			});
+			expect(requireSupportedEffort(model, Effort.Max)).toBe(Effort.Max);
+			expect(() => requireSupportedEffort(model, Effort.Minimal)).toThrow(
+				/Supported efforts: low, medium, high, xhigh, max/,
+			);
+		}
+	});
+
+	it("normalizes GPT-5.6 tier context windows by OpenAI transport", () => {
+		const models: Model<Api>[] = [
+			{
+				...createModel({
+					id: "gpt-5.6-sol",
+					api: "openai-codex-responses",
+					provider: "openai-codex",
+				}),
+				contextWindow: 1_050_000,
+				maxTokens: 128000,
+			},
+			{
+				...createModel({
+					id: "gpt-5.6-terra",
+					api: "openai-responses",
+					provider: "openai",
+				}),
+				contextWindow: 272000,
+				maxTokens: 128000,
+			},
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models[0]?.contextWindow).toBe(272_000);
+		expect(models[1]?.contextWindow).toBe(1_050_000);
+		expect(models[0]?.applyPatchToolType).toBe("freeform");
+		expect(models[1]?.applyPatchToolType).toBe("freeform");
+	});
 });
 
 describe("model thinking runtime helpers", () => {


### PR DESCRIPTION
## Summary
- Adds GPT-5.6 Sol, Terra, and Luna parser support so OpenAI catalog policies apply to the new tier suffixes.
- Adds bundled `openai` and `openai-codex` catalog entries with verified 1,050K API context, 128K max output, pricing, image input, cache-write pricing, and conservative 272K Codex transport cap.
- Exposes GPT-5.6 efforts as `low`, `medium`, `high`, `xhigh`, `max`; `ultra` remains out of scope because it is documented as a multi-agent beta setting, not a reasoning effort.
- Updates `packages/ai/CHANGELOG.md` only and cross-references #1925 / OmX #3103.

## Validation
- `bun test packages/ai/test/model-thinking.test.ts packages/ai/test/preset-catalog-models.test.ts`
- `bun --cwd=packages/ai run check`
- Catalog spot-check: all six bundled OpenAI/OpenAI-Codex GPT-5.6 entries resolve with expected context windows and `low,medium,high,xhigh,max` efforts.

Closes #1925.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
