### PR TITLE
feat(session): cache-miss cost summary and transcript cache warnings

### DIFF
--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -427,7 +427,12 @@ export class CommandController {
 				info += `${theme.fg("dim", "Premium Requests:")} ${normalizedPremiumRequests.toLocaleString()}\n`;
 			}
 		}
-		const cacheMissSummary = computeCacheMissCostSummary(stats.tokens, this.ctx.session.model?.cost);
+		const cacheMissSummary = stats.costBreakdown
+			? computeCacheMissCostSummary(stats.tokens, {
+					kind: "persisted-aggregate",
+					costBreakdown: stats.costBreakdown,
+				})
+			: undefined;
 		if (cacheMissSummary) {
 			info += `\n${theme.bold("Cache Miss Cost")}`;
 			for (const line of formatCacheMissSummaryLines(cacheMissSummary)) {

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -40,6 +40,7 @@ import { buildHotkeysMarkdown } from "../../modes/utils/hotkeys-markdown";
 import { buildToolsMarkdown } from "../../modes/utils/tools-markdown";
 import type { AsyncJobSnapshotItem } from "../../session/agent-session";
 import type { AuthStorage } from "../../session/auth-storage";
+import { computeCacheMissCostSummary, formatCacheMissSummaryLines } from "../../session/cache-economics";
 import type { NewSessionOptions } from "../../session/session-manager";
 import { outputMeta } from "../../tools/output-meta";
 import { resolveToCwd, stripOuterDoubleQuotes } from "../../tools/path-utils";
@@ -425,6 +426,19 @@ export class CommandController {
 			if (normalizedPremiumRequests > 0) {
 				info += `${theme.fg("dim", "Premium Requests:")} ${normalizedPremiumRequests.toLocaleString()}\n`;
 			}
+		}
+		const cacheMissSummary = computeCacheMissCostSummary(stats.tokens, this.ctx.session.model?.cost);
+		if (cacheMissSummary) {
+			info += `\n${theme.bold("Cache Miss Cost")}`;
+			for (const line of formatCacheMissSummaryLines(cacheMissSummary)) {
+				const separator = line.indexOf(":");
+				if (separator === -1) {
+					info += `\n${line}`;
+				} else {
+					info += `\n${theme.fg("dim", `${line.slice(0, separator)}:`)}${line.slice(separator + 1)}`;
+				}
+			}
+			info += `\n`;
 		}
 
 		if (this.ctx.lspServers && this.ctx.lspServers.length > 0) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -538,6 +538,7 @@ export interface SessionStats {
 	};
 	premiumRequests: number;
 	cost: number;
+	costBreakdown?: Usage["cost"];
 }
 
 /** Internal marker for hook messages queued through the agent loop */
@@ -11085,6 +11086,52 @@ export class AgentSession {
 		let totalCacheWrite = 0;
 		let totalCost = 0;
 		let totalPremiumRequests = 0;
+		const totalCostBreakdown: Usage["cost"] = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+		let hasCompleteCostBreakdown = true;
+		const addCostBreakdown = (cost: unknown): void => {
+			if (!cost || typeof cost !== "object") {
+				hasCompleteCostBreakdown = false;
+				return;
+			}
+			const completeCost = cost as Usage["cost"];
+			if (
+				!Number.isFinite(completeCost.input) ||
+				completeCost.input < 0 ||
+				!Number.isFinite(completeCost.output) ||
+				completeCost.output < 0 ||
+				!Number.isFinite(completeCost.cacheRead) ||
+				completeCost.cacheRead < 0 ||
+				!Number.isFinite(completeCost.cacheWrite) ||
+				completeCost.cacheWrite < 0 ||
+				!Number.isFinite(completeCost.total) ||
+				completeCost.total < 0
+			) {
+				hasCompleteCostBreakdown = false;
+				return;
+			}
+			if (!hasCompleteCostBreakdown) return;
+			totalCostBreakdown.input += completeCost.input;
+			totalCostBreakdown.output += completeCost.output;
+			totalCostBreakdown.cacheRead += completeCost.cacheRead;
+			totalCostBreakdown.cacheWrite += completeCost.cacheWrite;
+			totalCostBreakdown.total += completeCost.total;
+			if (
+				!Number.isFinite(totalCostBreakdown.input) ||
+				!Number.isFinite(totalCostBreakdown.output) ||
+				!Number.isFinite(totalCostBreakdown.cacheRead) ||
+				!Number.isFinite(totalCostBreakdown.cacheWrite) ||
+				!Number.isFinite(totalCostBreakdown.total)
+			) {
+				hasCompleteCostBreakdown = false;
+			}
+		};
+		const hasCompleteTaskToolUsage = (details: unknown): boolean =>
+			Boolean(
+				details &&
+					typeof details === "object" &&
+					(details as Record<string, unknown>).usageCostBreakdownComplete === true,
+			);
+
 		const getTaskToolUsage = (details: unknown): Usage | undefined => {
 			if (!details || typeof details !== "object") return undefined;
 			const record = details as Record<string, unknown>;
@@ -11108,6 +11155,7 @@ export class AgentSession {
 				totalCacheWrite += assistantMsg.usage.cacheWrite;
 				totalPremiumRequests += assistantMsg.usage.premiumRequests ?? 0;
 				totalCost += assistantMsg.usage.cost.total;
+				addCostBreakdown(assistantMsg.usage.cost);
 			} else if (message.role === "toolResult") {
 				toolResults += 1;
 				if (message.toolName === "task") {
@@ -11119,6 +11167,11 @@ export class AgentSession {
 						totalCacheWrite += usage.cacheWrite;
 						totalPremiumRequests += usage.premiumRequests ?? 0;
 						totalCost += usage.cost.total;
+						if (hasCompleteTaskToolUsage(message.details)) {
+							addCostBreakdown(usage.cost);
+						} else {
+							hasCompleteCostBreakdown = false;
+						}
 					}
 				}
 			}
@@ -11140,6 +11193,7 @@ export class AgentSession {
 				total: totalInput + totalOutput + totalCacheRead + totalCacheWrite,
 			},
 			cost: totalCost,
+			...(hasCompleteCostBreakdown ? { costBreakdown: totalCostBreakdown } : {}),
 			premiumRequests: totalPremiumRequests,
 		};
 	}

--- a/packages/coding-agent/src/session/cache-economics.ts
+++ b/packages/coding-agent/src/session/cache-economics.ts
@@ -18,6 +18,10 @@ export interface CacheEconomicsModelCost extends CacheEconomicsPricing {
 	output: number;
 }
 
+export type CacheEconomicsBasis =
+	| { kind: "persisted-aggregate"; costBreakdown: Usage["cost"] }
+	| { kind: "current-model-estimate"; pricing: CacheEconomicsPricing };
+
 export interface CacheEconomicsUsage {
 	input: number;
 	output?: number;
@@ -55,18 +59,31 @@ export interface CacheWarningBuildState {
 	warningsEmitted: number;
 }
 
+function finiteNonNegative(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
 function positiveFinite(value: number | undefined): value is number {
 	return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
-function bucketCost(
+function currentModelBucketCost(
 	tokens: number,
-	bucketCostUsd: number | undefined,
+	persistedCostUsd: number | undefined,
 	pricePerMillionTokens: number | undefined,
-): number {
-	if (positiveFinite(bucketCostUsd)) return bucketCostUsd;
+): number | undefined {
+	if (persistedCostUsd !== undefined) {
+		return finiteNonNegative(persistedCostUsd) ? persistedCostUsd : undefined;
+	}
 	if (!positiveFinite(tokens) || !positiveFinite(pricePerMillionTokens)) return 0;
 	return (tokens / TOKENS_PER_MILLION) * pricePerMillionTokens;
+}
+
+function persistedAggregateCosts(costBreakdown: Usage["cost"] | undefined): [number, number, number] | undefined {
+	if (!costBreakdown) return undefined;
+	const { input, cacheRead, cacheWrite, output, total } = costBreakdown;
+	if (![input, cacheRead, cacheWrite, output, total].every(finiteNonNegative)) return undefined;
+	return [input, cacheRead, cacheWrite];
 }
 
 function hasMaterialEvidence(usage: CacheEconomicsUsage, costs: readonly number[]): boolean {
@@ -77,12 +94,22 @@ function hasMaterialEvidence(usage: CacheEconomicsUsage, costs: readonly number[
 
 export function computeCacheMissCostSummary(
 	usage: CacheEconomicsUsage | undefined,
-	pricing: CacheEconomicsPricing | undefined,
+	basis: CacheEconomicsBasis,
 ): CacheMissCostSummary | undefined {
-	if (!usage || !pricing) return undefined;
-	const inputCostUsd = bucketCost(usage.input, usage.cost?.input, pricing.input);
-	const cacheReadCostUsd = bucketCost(usage.cacheRead, usage.cost?.cacheRead, pricing.cacheRead);
-	const cacheWriteCostUsd = bucketCost(usage.cacheWrite, usage.cost?.cacheWrite, pricing.cacheWrite);
+	if (!usage) return undefined;
+
+	const costs =
+		basis.kind === "persisted-aggregate"
+			? persistedAggregateCosts(basis.costBreakdown)
+			: [
+					currentModelBucketCost(usage.input, usage.cost?.input, basis.pricing.input),
+					currentModelBucketCost(usage.cacheRead, usage.cost?.cacheRead, basis.pricing.cacheRead),
+					currentModelBucketCost(usage.cacheWrite, usage.cost?.cacheWrite, basis.pricing.cacheWrite),
+				];
+	if (!costs) return undefined;
+	const [inputCostUsd, cacheReadCostUsd, cacheWriteCostUsd] = costs;
+	if (inputCostUsd === undefined || cacheReadCostUsd === undefined || cacheWriteCostUsd === undefined)
+		return undefined;
 	if (usage.input <= 0 && cacheWriteCostUsd <= 0) return undefined;
 	if (!hasMaterialEvidence(usage, [inputCostUsd, cacheReadCostUsd, cacheWriteCostUsd])) return undefined;
 	if (inputCostUsd <= 0 && cacheWriteCostUsd <= 0) return undefined;
@@ -90,11 +117,12 @@ export function computeCacheMissCostSummary(
 	const totalReusableInput = usage.input + usage.cacheRead;
 	const cacheHitRate = totalReusableInput > 0 ? usage.cacheRead / totalReusableInput : undefined;
 	const missPremiumUsd =
-		positiveFinite(pricing.input) &&
-		positiveFinite(pricing.cacheRead) &&
-		pricing.input > pricing.cacheRead &&
+		basis.kind === "current-model-estimate" &&
+		positiveFinite(basis.pricing.input) &&
+		positiveFinite(basis.pricing.cacheRead) &&
+		basis.pricing.input > basis.pricing.cacheRead &&
 		usage.input > 0
-			? ((pricing.input - pricing.cacheRead) * usage.input) / TOKENS_PER_MILLION
+			? ((basis.pricing.input - basis.pricing.cacheRead) * usage.input) / TOKENS_PER_MILLION
 			: undefined;
 
 	return {
@@ -135,7 +163,9 @@ export function buildCacheBehaviorWarning(
 	usage: Usage | undefined,
 	model: { cost: CacheEconomicsModelCost } | undefined | null,
 ): CacheBehaviorWarning | undefined {
-	const summary = computeCacheMissCostSummary(usage, model?.cost);
+	const summary = model
+		? computeCacheMissCostSummary(usage, { kind: "current-model-estimate", pricing: model.cost })
+		: undefined;
 	if (!summary) return undefined;
 	if (
 		summary.inputTokens >= LARGE_INPUT_TOKENS &&

--- a/packages/coding-agent/src/session/cache-economics.ts
+++ b/packages/coding-agent/src/session/cache-economics.ts
@@ -1,0 +1,173 @@
+import type { Usage } from "@gajae-code/ai";
+
+const TOKENS_PER_MILLION = 1_000_000;
+const MATERIAL_COST_USD = 0.01;
+const MATERIAL_CACHE_TOKENS = 10_000;
+const EXPENSIVE_MISS_COST_USD = 0.05;
+const LARGE_INPUT_TOKENS = 20_000;
+const LARGE_CACHE_WRITE_TOKENS = 25_000;
+const TRANSCRIPT_WARNING_CAP = 3;
+
+export interface CacheEconomicsPricing {
+	input: number;
+	cacheRead: number;
+	cacheWrite: number;
+}
+
+export interface CacheEconomicsModelCost extends CacheEconomicsPricing {
+	output: number;
+}
+
+export interface CacheEconomicsUsage {
+	input: number;
+	output?: number;
+	cacheRead: number;
+	cacheWrite: number;
+	total?: number;
+	cost?: {
+		input?: number;
+		output?: number;
+		cacheRead?: number;
+		cacheWrite?: number;
+		total?: number;
+	};
+}
+
+export interface CacheMissCostSummary {
+	inputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	inputCostUsd: number;
+	cacheReadCostUsd: number;
+	cacheWriteCostUsd: number;
+	cacheHitRate: number | undefined;
+	missPremiumUsd: number | undefined;
+}
+
+export interface CacheBehaviorWarning {
+	code: "expensive_cache_miss" | "cache_write_spike";
+	reason: string;
+	nextStep: string;
+	costUsd: number;
+}
+
+export interface CacheWarningBuildState {
+	warningsEmitted: number;
+}
+
+function positiveFinite(value: number | undefined): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function bucketCost(
+	tokens: number,
+	bucketCostUsd: number | undefined,
+	pricePerMillionTokens: number | undefined,
+): number {
+	if (positiveFinite(bucketCostUsd)) return bucketCostUsd;
+	if (!positiveFinite(tokens) || !positiveFinite(pricePerMillionTokens)) return 0;
+	return (tokens / TOKENS_PER_MILLION) * pricePerMillionTokens;
+}
+
+function hasMaterialEvidence(usage: CacheEconomicsUsage, costs: readonly number[]): boolean {
+	const tokenEvidence = usage.input + usage.cacheRead + usage.cacheWrite >= MATERIAL_CACHE_TOKENS;
+	const costEvidence = costs.some(cost => cost >= MATERIAL_COST_USD);
+	return tokenEvidence || costEvidence;
+}
+
+export function computeCacheMissCostSummary(
+	usage: CacheEconomicsUsage | undefined,
+	pricing: CacheEconomicsPricing | undefined,
+): CacheMissCostSummary | undefined {
+	if (!usage || !pricing) return undefined;
+	const inputCostUsd = bucketCost(usage.input, usage.cost?.input, pricing.input);
+	const cacheReadCostUsd = bucketCost(usage.cacheRead, usage.cost?.cacheRead, pricing.cacheRead);
+	const cacheWriteCostUsd = bucketCost(usage.cacheWrite, usage.cost?.cacheWrite, pricing.cacheWrite);
+	if (usage.input <= 0 && cacheWriteCostUsd <= 0) return undefined;
+	if (!hasMaterialEvidence(usage, [inputCostUsd, cacheReadCostUsd, cacheWriteCostUsd])) return undefined;
+	if (inputCostUsd <= 0 && cacheWriteCostUsd <= 0) return undefined;
+
+	const totalReusableInput = usage.input + usage.cacheRead;
+	const cacheHitRate = totalReusableInput > 0 ? usage.cacheRead / totalReusableInput : undefined;
+	const missPremiumUsd =
+		positiveFinite(pricing.input) &&
+		positiveFinite(pricing.cacheRead) &&
+		pricing.input > pricing.cacheRead &&
+		usage.input > 0
+			? ((pricing.input - pricing.cacheRead) * usage.input) / TOKENS_PER_MILLION
+			: undefined;
+
+	return {
+		inputTokens: usage.input,
+		cacheReadTokens: usage.cacheRead,
+		cacheWriteTokens: usage.cacheWrite,
+		inputCostUsd,
+		cacheReadCostUsd,
+		cacheWriteCostUsd,
+		cacheHitRate,
+		missPremiumUsd: positiveFinite(missPremiumUsd) ? missPremiumUsd : undefined,
+	};
+}
+
+function formatUsd(cost: number): string {
+	return cost < 0.01 ? `$${cost.toFixed(4)}` : `$${cost.toFixed(2)}`;
+}
+
+function formatPercent(value: number): string {
+	return `${(value * 100).toFixed(1)}%`;
+}
+
+export function formatCacheMissSummaryLines(summary: CacheMissCostSummary): string[] {
+	const lines = [`Uncached Input Cost: ${formatUsd(summary.inputCostUsd)}`];
+	if (summary.missPremiumUsd !== undefined) {
+		lines.push(`Estimated Miss Premium: ${formatUsd(summary.missPremiumUsd)} vs cache-read pricing`);
+	}
+	if (summary.cacheHitRate !== undefined) {
+		lines.push(`Cache Hit Rate: ${formatPercent(summary.cacheHitRate)}`);
+	}
+	if (summary.cacheWriteCostUsd >= MATERIAL_COST_USD) {
+		lines.push(`Cache Write Cost: ${formatUsd(summary.cacheWriteCostUsd)}`);
+	}
+	return lines;
+}
+
+export function buildCacheBehaviorWarning(
+	usage: Usage | undefined,
+	model: { cost: CacheEconomicsModelCost } | undefined | null,
+): CacheBehaviorWarning | undefined {
+	const summary = computeCacheMissCostSummary(usage, model?.cost);
+	if (!summary) return undefined;
+	if (
+		summary.inputTokens >= LARGE_INPUT_TOKENS &&
+		(summary.cacheHitRate === undefined || summary.cacheHitRate < 0.25) &&
+		summary.inputCostUsd >= EXPENSIVE_MISS_COST_USD
+	) {
+		return {
+			code: "expensive_cache_miss",
+			reason: `large uncached input with low cache hits (${formatUsd(summary.inputCostUsd)})`,
+			nextStep: "keep the stable prefix; avoid rereading unchanged context before the next turn",
+			costUsd: summary.inputCostUsd,
+		};
+	}
+	if (summary.cacheWriteTokens >= LARGE_CACHE_WRITE_TOKENS && summary.cacheWriteCostUsd >= EXPENSIVE_MISS_COST_USD) {
+		return {
+			code: "cache_write_spike",
+			reason: `large cache write without enough matching reads (${formatUsd(summary.cacheWriteCostUsd)})`,
+			nextStep: "make the next turn reuse the same context; avoid changing system or tool prefixes",
+			costUsd: summary.cacheWriteCostUsd,
+		};
+	}
+	return undefined;
+}
+
+export function buildCacheEconomicsWarning(
+	usage: Usage | undefined,
+	model: { cost: CacheEconomicsModelCost } | undefined | null,
+	state: CacheWarningBuildState,
+): string | undefined {
+	if (state.warningsEmitted >= TRANSCRIPT_WARNING_CAP) return undefined;
+	const warning = buildCacheBehaviorWarning(usage, model);
+	if (!warning) return undefined;
+	state.warningsEmitted += 1;
+	return `Cache warning: ${warning.reason}; next step: ${warning.nextStep}.`;
+}

--- a/packages/coding-agent/src/session/session-dump-format.ts
+++ b/packages/coding-agent/src/session/session-dump-format.ts
@@ -4,6 +4,7 @@
 import type { AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
 import { INTENT_FIELD } from "@gajae-code/agent-core";
 import type { AssistantMessage, Model } from "@gajae-code/ai";
+import { buildCacheEconomicsWarning, type CacheWarningBuildState } from "./cache-economics";
 import {
 	type BashExecutionMessage,
 	type BranchSummaryMessage,
@@ -137,6 +138,7 @@ export function formatSessionDumpText(options: FormatSessionDumpTextOptions): st
 		lines.push("\n");
 	}
 
+	const cacheWarningState: CacheWarningBuildState = { warningsEmitted: 0 };
 	for (const msg of options.messages) {
 		if (msg.role === "user" || msg.role === "developer") {
 			lines.push(msg.role === "developer" ? "## Developer\n" : "## User\n");
@@ -171,6 +173,10 @@ export function formatSessionDumpText(options: FormatSessionDumpTextOptions): st
 					}
 					lines.push("<" + "/invoke>\n");
 				}
+			}
+			const cacheWarning = buildCacheEconomicsWarning(assistantMsg.usage, model, cacheWarningState);
+			if (cacheWarning) {
+				lines.push(cacheWarning);
 			}
 			lines.push("");
 		} else if (msg.role === "toolResult") {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -847,7 +847,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						lines.push(`Premium Requests: ${stats.premiumRequests.toLocaleString()}`);
 					}
 				}
-				const cacheMissSummary = computeCacheMissCostSummary(stats.tokens, runtime.session.model?.cost);
+				const cacheMissSummary = stats.costBreakdown
+					? computeCacheMissCostSummary(stats.tokens, {
+							kind: "persisted-aggregate",
+							costBreakdown: stats.costBreakdown,
+						})
+					: undefined;
 				if (cacheMissSummary) {
 					lines.push("", "Cache Miss Cost", ...formatCacheMissSummaryLines(cacheMissSummary));
 				}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -24,6 +24,7 @@ import { resolveMemoryBackend } from "../memory-backend";
 import { DynamicBorder } from "../modes/components/dynamic-border";
 import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
+import { computeCacheMissCostSummary, formatCacheMissSummaryLines } from "../session/cache-economics";
 import { formatModelOnboardingGuidance } from "../setup/model-onboarding-guidance";
 import {
 	addApiCompatibleProvider,
@@ -820,13 +821,37 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		allowArgs: true,
 		handle: async (command, runtime) => {
 			if (!command.args || command.args === "info") {
-				await runtime.output(
-					[
-						`Session: ${runtime.session.sessionId}`,
-						`Title: ${runtime.session.sessionName}`,
-						`CWD: ${runtime.cwd}`,
-					].join("\n"),
-				);
+				const stats = runtime.session.getSessionStats();
+				const lines = [
+					`Session: ${runtime.session.sessionId}`,
+					`Title: ${runtime.session.sessionName}`,
+					`CWD: ${runtime.cwd}`,
+					"",
+					"Tokens",
+					`Input: ${stats.tokens.input.toLocaleString()}`,
+					`Output: ${stats.tokens.output.toLocaleString()}`,
+				];
+				if (stats.tokens.cacheRead > 0) {
+					lines.push(`Cache Read: ${stats.tokens.cacheRead.toLocaleString()}`);
+				}
+				if (stats.tokens.cacheWrite > 0) {
+					lines.push(`Cache Write: ${stats.tokens.cacheWrite.toLocaleString()}`);
+				}
+				lines.push(`Total: ${stats.tokens.total.toLocaleString()}`);
+				if (stats.cost > 0 || stats.premiumRequests > 0) {
+					lines.push("", "Cost");
+					if (stats.cost > 0) {
+						lines.push(`Total: ${stats.cost.toFixed(4)}`);
+					}
+					if (stats.premiumRequests > 0) {
+						lines.push(`Premium Requests: ${stats.premiumRequests.toLocaleString()}`);
+					}
+				}
+				const cacheMissSummary = computeCacheMissCostSummary(stats.tokens, runtime.session.model?.cost);
+				if (cacheMissSummary) {
+					lines.push("", "Cache Miss Cost", ...formatCacheMissSummaryLines(cacheMissSummary));
+				}
+				await runtime.output(lines.join("\n"));
 				return commandConsumed();
 			}
 			if (command.args === "delete") {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -47,6 +47,7 @@ import { persistTaskTokenLog, taskTokenLogFromUsage } from "./token-log";
 import {
 	type AgentDefinition,
 	type AgentProgress,
+	hasCompleteUsageCostBreakdown,
 	MAX_OUTPUT_BYTES,
 	MAX_OUTPUT_LINES,
 	type ModelSubstitutionWarning,
@@ -743,6 +744,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
 	let hasUsage = false;
+	let usageCostBreakdownComplete = true;
 
 	const requestAbort = (reason: AbortReason) => {
 		if (reason === "timeout") {
@@ -1109,6 +1111,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						const usageRecord = messageUsage as Record<string, unknown>;
 						const costRecord = (messageUsage as { cost?: Record<string, unknown> }).cost;
 						hasUsage = true;
+						usageCostBreakdownComplete &&= hasCompleteUsageCostBreakdown(usageRecord);
 						accumulatedUsage.input += getNumberField(usageRecord, "input") ?? 0;
 						accumulatedUsage.output += getNumberField(usageRecord, "output") ?? 0;
 						accumulatedUsage.cacheRead += getNumberField(usageRecord, "cacheRead") ?? 0;
@@ -1866,6 +1869,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		abortReason: finalAbortReason,
 		paused,
 		usage: hasUsage ? accumulatedUsage : undefined,
+		usageCostBreakdownComplete: hasUsage && usageCostBreakdownComplete ? true : undefined,
 		outputPath,
 		extractedToolData: progress.extractedToolData,
 		retryFailure: progress.retryFailure,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -34,12 +34,14 @@ import {
 	type ForkContextMode,
 	type ForkContextPolicy,
 	getTaskSchema,
+	hasCompleteAggregateUsageCostBreakdown,
 	type SingleResult,
 	type TaskItem,
 	type TaskParams,
 	type TaskToolDetails,
 	type TaskToolSchemaInstance,
 } from "./types";
+
 // Import review tools for side effects (registers subagent tool handlers)
 import "../tools/review";
 import type { LocalProtocolOptions } from "../internal-urls";
@@ -53,6 +55,7 @@ import { getTaskIdValidationError, validateAllocatedTaskId } from "./id";
 import { AgentOutputManager } from "./output-manager";
 import { mapWithConcurrencyLimit, Semaphore } from "./parallel";
 import { assertNoRawTaskFields, buildTaskReceipt, buildTaskRoiSummary } from "./receipt";
+
 import { renderResult, renderCall as renderTaskCall } from "./render";
 import { reconcileSpawnRoi } from "./roi-reconciliation";
 import { getTaskSimpleModeCapabilities, type TaskSimpleMode } from "./simple-mode";
@@ -1529,6 +1532,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			// Aggregate usage from executor results (already accumulated incrementally)
 			const aggregatedUsage = createUsageTotals();
 			let hasAggregatedUsage = false;
+
 			for (const result of results) {
 				if (result.usage) {
 					addUsageTotals(aggregatedUsage, result.usage);
@@ -1734,6 +1738,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				results: receipts,
 				totalDurationMs: totalDuration,
 				usage: hasAggregatedUsage ? aggregatedUsage : undefined,
+				usageCostBreakdownComplete:
+					hasAggregatedUsage && hasCompleteAggregateUsageCostBreakdown(results) ? true : undefined,
 				forkContextClonedTokens: forkContextClonedTokens > 0 ? forkContextClonedTokens : undefined,
 				roiSummary,
 				roiReconciliation,

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -1,5 +1,4 @@
-import type { SingleResult, TaskToolDetails } from "./types";
-
+import { hasCompleteUsageCostBreakdown, type SingleResult, type TaskToolDetails } from "./types";
 export interface TaskRoi {
 	tokens: number;
 	contextTokens?: number;
@@ -32,6 +31,7 @@ export interface TaskResultReceipt {
 	modelSubstitutionWarning?: SingleResult["modelSubstitutionWarning"];
 	usage?: SingleResult["usage"];
 	cost?: number;
+	usageCostBreakdownComplete?: true;
 	branchName?: string;
 	retryFailure?: { attempt: number; errorSummary: string };
 	errorSummary?: string;
@@ -246,6 +246,8 @@ export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 		modelSubstitutionWarning: raw.modelSubstitutionWarning,
 		usage: raw.usage,
 		cost: raw.usage?.cost.total,
+		usageCostBreakdownComplete:
+			raw.usageCostBreakdownComplete === true && hasCompleteUsageCostBreakdown(raw.usage) ? true : undefined,
 		branchName: raw.branchName,
 		retryFailure: raw.retryFailure
 			? { attempt: raw.retryFailure.attempt, errorSummary: "Retry failure recorded." }
@@ -274,6 +276,7 @@ export interface RawTaskToolDetails {
 	results: SingleResult[];
 	totalDurationMs: number;
 	usage?: TaskToolDetails["usage"];
+	usageCostBreakdownComplete?: TaskToolDetails["usageCostBreakdownComplete"];
 	async?: TaskToolDetails["async"];
 	forkContextClonedTokens?: number;
 	roiSummary?: TaskToolDetails["roiSummary"];
@@ -286,6 +289,8 @@ export function sanitizeTaskToolDetails(raw: RawTaskToolDetails): TaskToolDetail
 		results: raw.results.map(buildTaskReceipt),
 		totalDurationMs: raw.totalDurationMs,
 		usage: raw.usage,
+		usageCostBreakdownComplete:
+			raw.usageCostBreakdownComplete === true && hasCompleteUsageCostBreakdown(raw.usage) ? true : undefined,
 		forkContextClonedTokens: raw.forkContextClonedTokens,
 		roiSummary: raw.roiSummary ?? buildTaskRoiSummary(raw.results.map(buildTaskReceipt)),
 		async: raw.async,

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -320,6 +320,8 @@ export interface SingleResult {
 	paused?: boolean;
 	/** Aggregated usage from the subprocess, accumulated incrementally from message_end events. */
 	usage?: Usage;
+	/** True only when every usage-contributing assistant supplied a complete, non-negative raw cost breakdown. */
+	usageCostBreakdownComplete?: true;
 	/** Output path for the task result */
 	outputPath?: string;
 	/** Patch path for isolated worktree output */
@@ -353,6 +355,28 @@ export interface SingleResult {
 	forkContextAdvisory?: { recommendedMode: ForkContextMode; reasons: string[] };
 }
 
+/** True only for complete, factual five-bucket cost accounting. */
+export function hasCompleteUsageCostBreakdown(usage: unknown): boolean {
+	if (!usage || typeof usage !== "object") return false;
+	const cost = (usage as { cost?: unknown }).cost;
+	if (!cost || typeof cost !== "object") return false;
+	return ["input", "output", "cacheRead", "cacheWrite", "total"].every(key => {
+		const value = (cost as Record<string, unknown>)[key];
+		return typeof value === "number" && Number.isFinite(value) && value >= 0;
+	});
+}
+
+/** True only when every usage-contributing result has explicit, complete cost provenance. */
+export function hasCompleteAggregateUsageCostBreakdown(
+	results: readonly Pick<SingleResult, "usage" | "usageCostBreakdownComplete">[],
+): boolean {
+	return results.every(
+		result =>
+			result.usage === undefined ||
+			(result.usageCostBreakdownComplete === true && hasCompleteUsageCostBreakdown(result.usage)),
+	);
+}
+
 /** Tool details for TUI rendering */
 export interface TaskToolDetails {
 	projectAgentsDir: string | null;
@@ -360,6 +384,8 @@ export interface TaskToolDetails {
 	totalDurationMs: number;
 	/** Aggregated usage across all subagents. */
 	usage?: Usage;
+	/** True only when every usage-contributing subagent supplied a complete raw cost breakdown. */
+	usageCostBreakdownComplete?: true;
 	/** Aggregate cloned tokens copied into fork-context seeds across subagents. */
 	forkContextClonedTokens?: number;
 	roiSummary?: {

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, spyOn } from "bun:test";
 import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
+import type { Usage } from "@gajae-code/ai";
 import { Settings } from "../src/config/settings";
 import { getThemeByName, setThemeInstance, theme } from "../src/modes/theme/theme";
 import type { AgentSession } from "../src/session/agent-session";
@@ -37,6 +38,7 @@ interface FakeAcpBuiltinSession {
 		tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
 		premiumRequests: number;
 		cost: number;
+		costBreakdown?: Usage["cost"];
 	};
 	getAsyncJobSnapshot: (opts?: { recentLimit?: number }) => { running: unknown[]; recent: unknown[] } | null;
 	formatSessionAsText: () => string;
@@ -871,13 +873,8 @@ describe("ACP builtin slash commands", () => {
 });
 
 describe("session lifecycle commands", () => {
-	it("/session info: includes cache miss summary for priced material cache usage", async () => {
+	it("/session info: reports persisted aggregate cache costs without selected-model repricing", async () => {
 		const { output, session, runtime } = createRuntime();
-		session.model = {
-			provider: "test",
-			id: "priced-model",
-			cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-		};
 		session.getSessionStats = () => ({
 			sessionFile: undefined,
 			sessionId: "fake-session-id",
@@ -886,35 +883,58 @@ describe("session lifecycle commands", () => {
 			toolCalls: 0,
 			toolResults: 0,
 			totalMessages: 2,
-			tokens: { input: 2_000, output: 500, cacheRead: 1_000_000, cacheWrite: 0, total: 1_002_500 },
+			tokens: { input: 2_000, output: 500, cacheRead: 1_000_000, cacheWrite: 40_000, total: 1_042_500 },
 			premiumRequests: 0,
-			cost: 0.45,
+			cost: 0.67,
+			costBreakdown: { input: 0.52, output: 0, cacheRead: 0.03, cacheWrite: 0.12, total: 0.67 },
 		});
 
 		const result = await executeAcpBuiltinSlashCommand("/session info", runtime);
 
 		expect(result).toEqual({ consumed: true });
 		expect(output[0]).toContain("Tokens\nInput: 2,000\nOutput: 500\nCache Read: 1,000,000");
-		expect(output[0]).toContain("Cost\nTotal: 0.4500");
-		expect(output[0]).toContain("Cache Miss Cost");
-		expect(output[0]).toContain("Uncached Input Cost: $0.0060");
-		expect(output[0]).toContain("Estimated Miss Premium: $0.0054 vs cache-read pricing");
+		expect(output[0]).toContain("Cost\nTotal: 0.6700");
+		expect(output[0]).toContain("Cache Miss Cost\nUncached Input Cost: $0.52");
+		expect(output[0]).toContain("Cache Write Cost: $0.12");
+		expect(output[0]).not.toContain("Estimated Miss Premium");
+
+		session.model = {
+			provider: "test",
+			id: "expensive-selected-model",
+			cost: { input: 100, output: 15, cacheRead: 0.01, cacheWrite: 100 },
+		};
+		await expect(executeAcpBuiltinSlashCommand("/session info", runtime)).resolves.toEqual({ consumed: true });
+		expect(output[1]).toBe(output[0]);
 	});
 
-	it("/session info: omits cache miss summary without material priced usage", async () => {
-		const zeroUsage = createRuntime();
-		zeroUsage.session.model = {
+	it("/session info: does not price material usage when aggregate provenance is absent", async () => {
+		const absentBreakdown = createRuntime();
+		absentBreakdown.session.getSessionStats = () => ({
+			sessionFile: undefined,
+			sessionId: "fake-session-id",
+			userMessages: 1,
+			assistantMessages: 1,
+			toolCalls: 0,
+			toolResults: 0,
+			totalMessages: 2,
+			tokens: { input: 2_000, output: 500, cacheRead: 1_000_000, cacheWrite: 40_000, total: 1_042_500 },
+			premiumRequests: 0,
+			cost: 0,
+		});
+		absentBreakdown.session.model = {
 			provider: "test",
-			id: "priced-model",
-			cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+			id: "expensive-selected-model",
+			cost: { input: 100, output: 100, cacheRead: 0.01, cacheWrite: 100 },
 		};
 
-		await expect(executeAcpBuiltinSlashCommand("/session info", zeroUsage.runtime)).resolves.toEqual({
+		await expect(executeAcpBuiltinSlashCommand("/session info", absentBreakdown.runtime)).resolves.toEqual({
 			consumed: true,
 		});
-		expect(zeroUsage.output[0]).toContain("Tokens");
-		expect(zeroUsage.output[0]).not.toContain("Cache Miss Cost");
+		expect(absentBreakdown.output[0]).toContain("Cache Read: 1,000,000");
+		expect(absentBreakdown.output[0]).not.toContain("Cache Miss Cost");
+	});
 
+	it("/session info: omits cache miss summary without a complete persisted aggregate breakdown", async () => {
 		const unpriced = createRuntime();
 		unpriced.session.getSessionStats = () => ({
 			sessionFile: undefined,
@@ -927,6 +947,7 @@ describe("session lifecycle commands", () => {
 			tokens: { input: 2_000, output: 500, cacheRead: 1_000_000, cacheWrite: 0, total: 1_002_500 },
 			premiumRequests: 0,
 			cost: 0,
+			costBreakdown: { input: 0.52, output: 0, cacheRead: 0.03, cacheWrite: Number.NaN, total: 0.67 },
 		});
 
 		await expect(executeAcpBuiltinSlashCommand("/session info", unpriced.runtime)).resolves.toEqual({

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -26,6 +26,18 @@ interface FakeAcpBuiltinSession {
 	resolveRoleModelWithThinking(role: string): { model?: { provider: string; id: string } };
 	setForcedToolChoice(toolName: string): void;
 	fetchUsageReports?: () => Promise<unknown>;
+	getSessionStats: () => {
+		sessionFile: string | undefined;
+		sessionId: string;
+		userMessages: number;
+		assistantMessages: number;
+		toolCalls: number;
+		toolResults: number;
+		totalMessages: number;
+		tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+		premiumRequests: number;
+		cost: number;
+	};
 	getAsyncJobSnapshot: (opts?: { recentLimit?: number }) => { running: unknown[]; recent: unknown[] } | null;
 	formatSessionAsText: () => string;
 	getLastAssistantText: () => string | undefined;
@@ -37,7 +49,14 @@ interface FakeAcpBuiltinSession {
 			options?: { candidates?: Array<{ provider: string; id: string; contextWindow?: number }> },
 		) => { provider: string; id: string; contextWindow?: number } | undefined;
 	};
-	model: { provider: string; id: string; contextWindow?: number } | undefined;
+	model:
+		| {
+				provider: string;
+				id: string;
+				contextWindow?: number;
+				cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
+		  }
+		| undefined;
 	agent: {
 		state: {
 			tools: Array<{ name: string; description: string; parameters: Record<string, unknown> }>;
@@ -118,6 +137,18 @@ function createRuntime() {
 		},
 		async refreshBaseSystemPrompt() {},
 		getAsyncJobSnapshot: () => null,
+		getSessionStats: () => ({
+			sessionFile: undefined,
+			sessionId: "fake-session-id",
+			userMessages: 0,
+			assistantMessages: 0,
+			toolCalls: 0,
+			toolResults: 0,
+			totalMessages: 0,
+			tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			premiumRequests: 0,
+			cost: 0,
+		}),
 		formatSessionAsText: () => "",
 		getLastAssistantText: () => undefined,
 		messages: [],
@@ -840,6 +871,71 @@ describe("ACP builtin slash commands", () => {
 });
 
 describe("session lifecycle commands", () => {
+	it("/session info: includes cache miss summary for priced material cache usage", async () => {
+		const { output, session, runtime } = createRuntime();
+		session.model = {
+			provider: "test",
+			id: "priced-model",
+			cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+		};
+		session.getSessionStats = () => ({
+			sessionFile: undefined,
+			sessionId: "fake-session-id",
+			userMessages: 1,
+			assistantMessages: 1,
+			toolCalls: 0,
+			toolResults: 0,
+			totalMessages: 2,
+			tokens: { input: 2_000, output: 500, cacheRead: 1_000_000, cacheWrite: 0, total: 1_002_500 },
+			premiumRequests: 0,
+			cost: 0.45,
+		});
+
+		const result = await executeAcpBuiltinSlashCommand("/session info", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("Tokens\nInput: 2,000\nOutput: 500\nCache Read: 1,000,000");
+		expect(output[0]).toContain("Cost\nTotal: 0.4500");
+		expect(output[0]).toContain("Cache Miss Cost");
+		expect(output[0]).toContain("Uncached Input Cost: $0.0060");
+		expect(output[0]).toContain("Estimated Miss Premium: $0.0054 vs cache-read pricing");
+	});
+
+	it("/session info: omits cache miss summary without material priced usage", async () => {
+		const zeroUsage = createRuntime();
+		zeroUsage.session.model = {
+			provider: "test",
+			id: "priced-model",
+			cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+		};
+
+		await expect(executeAcpBuiltinSlashCommand("/session info", zeroUsage.runtime)).resolves.toEqual({
+			consumed: true,
+		});
+		expect(zeroUsage.output[0]).toContain("Tokens");
+		expect(zeroUsage.output[0]).not.toContain("Cache Miss Cost");
+
+		const unpriced = createRuntime();
+		unpriced.session.getSessionStats = () => ({
+			sessionFile: undefined,
+			sessionId: "fake-session-id",
+			userMessages: 1,
+			assistantMessages: 1,
+			toolCalls: 0,
+			toolResults: 0,
+			totalMessages: 2,
+			tokens: { input: 2_000, output: 500, cacheRead: 1_000_000, cacheWrite: 0, total: 1_002_500 },
+			premiumRequests: 0,
+			cost: 0,
+		});
+
+		await expect(executeAcpBuiltinSlashCommand("/session info", unpriced.runtime)).resolves.toEqual({
+			consumed: true,
+		});
+		expect(unpriced.output[0]).toContain("Cache Read: 1,000,000");
+		expect(unpriced.output[0]).not.toContain("Cache Miss Cost");
+	});
+
 	it("/session delete: returns in-memory usage when no sessionFile", async () => {
 		const { output, runtime } = createRuntime();
 		const result = await executeAcpBuiltinSlashCommand("/session delete", runtime);

--- a/packages/coding-agent/test/agent-session-cache-economics.test.ts
+++ b/packages/coding-agent/test/agent-session-cache-economics.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "bun:test";
+import { Agent, type AgentMessage } from "@gajae-code/agent-core";
+import { type AssistantMessage, getBundledModel, type ToolResultMessage, type Usage } from "@gajae-code/ai";
+import { ModelRegistry } from "../src/config/model-registry";
+import { Settings } from "../src/config/settings";
+import { AgentSession, type SessionStats } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+import { SessionManager } from "../src/session/session-manager";
+
+function cost(input: number, output: number, cacheRead: number, cacheWrite: number, total: number): Usage["cost"] {
+	return { input, output, cacheRead, cacheWrite, total };
+}
+
+const completeCost = (amount: number): Usage["cost"] => cost(amount, amount, amount, amount, amount);
+
+function usage(cost: unknown, input = 1, output = 2, cacheRead = 3, cacheWrite = 4): Usage {
+	return {
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		totalTokens: input + output + cacheRead + cacheWrite,
+		cost: cost as Usage["cost"],
+	};
+}
+
+function assistant(cost: unknown): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "test-model",
+		usage: usage(cost),
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+function task(cost: unknown, marked = true): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "task-call",
+		toolName: "task",
+		content: [],
+		isError: false,
+		timestamp: 2,
+		details: {
+			usage: usage(cost, 10, 20, 30, 40),
+			...(marked ? { usageCostBreakdownComplete: true as const } : {}),
+		},
+	};
+}
+
+async function createSession(messages: AgentMessage[]): Promise<{ session: AgentSession; authStorage: AuthStorage }> {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled model");
+	const authStorage = await AuthStorage.create(":memory:");
+	const session = new AgentSession({
+		agent: new Agent({ initialState: { model, messages, tools: [] } }),
+		sessionManager: SessionManager.inMemory(),
+		settings: Settings.isolated({ "compaction.enabled": false }),
+		modelRegistry: new ModelRegistry(authStorage),
+	});
+	return { session, authStorage };
+}
+
+async function getStats(messages: AgentMessage[]) {
+	const { session, authStorage } = await createSession(messages);
+	try {
+		return session.getSessionStats();
+	} finally {
+		await session.dispose();
+		authStorage.close();
+	}
+}
+
+describe("AgentSession cache economics provenance", () => {
+	it("aggregates each persisted cost bucket from parent and marked task usage", async () => {
+		const parentCost = cost(0.125, 0.25, 0.5, 0.75, 1.625);
+		const taskCost = cost(1, 2, 4, 8, 15);
+		const stats = await getStats([assistant(parentCost), task(taskCost)]);
+
+		expect(stats.costBreakdown).toEqual(cost(1.125, 2.25, 4.5, 8.75, 16.625));
+		expect(stats.tokens).toEqual({ input: 11, output: 22, cacheRead: 33, cacheWrite: 44, total: 110 });
+		expect(stats.cost).toBe(16.625);
+	});
+
+	it("omits the breakdown when finite persisted buckets overflow in aggregate", async () => {
+		const stats = await getStats([
+			assistant(completeCost(Number.MAX_VALUE)),
+			assistant(completeCost(Number.MAX_VALUE)),
+		]);
+
+		expect(stats.costBreakdown).toBeUndefined();
+		expect(stats.tokens).toEqual({ input: 2, output: 4, cacheRead: 6, cacheWrite: 8, total: 20 });
+		expect(stats.cost).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it("retains an explicit all-zero persisted cost breakdown", async () => {
+		const stats = await getStats([assistant(completeCost(0)), task(completeCost(0))]);
+
+		expect(stats.costBreakdown).toEqual(completeCost(0));
+		expect(stats.cost).toBe(0);
+	});
+
+	it("reports factual zero buckets for empty and parent-only sessions", async () => {
+		const emptyStats = await getStats([]);
+		expect(emptyStats.costBreakdown).toEqual(completeCost(0));
+		expect(emptyStats.tokens).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 });
+		expect(emptyStats.cost).toBe(0);
+
+		const parentStats = await getStats([assistant(completeCost(0.02))]);
+		expect(parentStats.costBreakdown).toEqual(completeCost(0.02));
+		expect(parentStats.tokens).toEqual({ input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 });
+		expect(parentStats.cost).toBe(0.02);
+	});
+
+	it("does not suppress persisted parent facts for task results without usage", async () => {
+		const taskWithoutUsage: ToolResultMessage = {
+			...task(completeCost(0.5)),
+			details: {},
+		};
+		const stats = await getStats([assistant(completeCost(0.02)), taskWithoutUsage]);
+
+		expect(stats.costBreakdown).toEqual(completeCost(0.02));
+		expect(stats.tokens).toEqual({ input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 });
+		expect(stats.cost).toBe(0.02);
+	});
+
+	it("omits only the breakdown for malformed or legacy task provenance", async () => {
+		const taskWithFalseMarker = task(completeCost(0.5));
+		(taskWithFalseMarker.details as Record<string, unknown>).usageCostBreakdownComplete = false;
+		const cases: Array<{
+			name: string;
+			messages: AgentMessage[];
+			expectedTokens: SessionStats["tokens"];
+			expectedCost: number;
+		}> = [
+			{
+				name: "a negative parent cost bucket",
+				messages: [assistant({ ...completeCost(0.02), input: -1 })],
+				expectedTokens: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 },
+				expectedCost: 0.02,
+			},
+			{
+				name: "a parent cost bucket missing from persisted usage",
+				messages: [assistant({ output: 0.02, cacheRead: 0.02, cacheWrite: 0.02, total: 0.02 })],
+				expectedTokens: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 },
+				expectedCost: 0.02,
+			},
+			{
+				name: "a non-finite parent cost bucket",
+				messages: [assistant({ ...completeCost(0.02), cacheRead: Number.POSITIVE_INFINITY })],
+				expectedTokens: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 },
+				expectedCost: 0.02,
+			},
+			{
+				name: "a NaN parent cost bucket",
+				messages: [assistant({ ...completeCost(0.02), cacheWrite: Number.NaN })],
+				expectedTokens: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 },
+				expectedCost: 0.02,
+			},
+			{
+				name: "a negative marked task cost bucket",
+				messages: [assistant(completeCost(0.02)), task({ ...completeCost(0.5), cacheWrite: -1 })],
+				expectedTokens: { input: 11, output: 22, cacheRead: 33, cacheWrite: 44, total: 110 },
+				expectedCost: 0.52,
+			},
+			{
+				name: "a marked task with a NaN total",
+				messages: [assistant(completeCost(0.02)), task({ ...completeCost(0.5), total: Number.NaN })],
+				expectedTokens: { input: 11, output: 22, cacheRead: 33, cacheWrite: 44, total: 110 },
+				expectedCost: Number.NaN,
+			},
+			{
+				name: "a task marker other than exactly true",
+				messages: [assistant(completeCost(0.02)), taskWithFalseMarker],
+				expectedTokens: { input: 11, output: 22, cacheRead: 33, cacheWrite: 44, total: 110 },
+				expectedCost: 0.52,
+			},
+			{
+				name: "an unmarked legacy task usage",
+				messages: [assistant(completeCost(0.02)), task(completeCost(0.5), false)],
+				expectedTokens: { input: 11, output: 22, cacheRead: 33, cacheWrite: 44, total: 110 },
+				expectedCost: 0.52,
+			},
+		];
+
+		for (const testCase of cases) {
+			const stats = await getStats(testCase.messages);
+			expect(stats.costBreakdown, testCase.name).toBeUndefined();
+			expect(stats.tokens, testCase.name).toEqual(testCase.expectedTokens);
+			if (Number.isNaN(testCase.expectedCost)) {
+				expect(Number.isNaN(stats.cost), testCase.name).toBe(true);
+			} else {
+				expect(stats.cost, testCase.name).toBe(testCase.expectedCost);
+			}
+		}
+	});
+});

--- a/packages/coding-agent/test/cache-economics.test.ts
+++ b/packages/coding-agent/test/cache-economics.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 import type { Model, Usage } from "@gajae-code/ai";
 import {
 	buildCacheEconomicsWarning,
+	type CacheEconomicsBasis,
+	type CacheEconomicsUsage,
 	computeCacheMissCostSummary,
 } from "@gajae-code/coding-agent/session/cache-economics";
 
@@ -29,45 +31,138 @@ function modelWithCost(cost: Model["cost"]): Pick<Model, "cost"> {
 }
 
 const priced = { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 };
+const currentModelEstimate: CacheEconomicsBasis = { kind: "current-model-estimate", pricing: priced };
+
+function usageWithoutPersistedCosts(overrides: Partial<CacheEconomicsUsage>): CacheEconomicsUsage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		...overrides,
+	};
+}
+
+function persistedAggregate(costBreakdown: Usage["cost"]): CacheEconomicsBasis {
+	return { kind: "persisted-aggregate", costBreakdown };
+}
 
 describe("cache economics", () => {
 	it("omits zero or absent usage", () => {
-		expect(computeCacheMissCostSummary(undefined, priced)).toBeUndefined();
-		expect(computeCacheMissCostSummary(usage({}), priced)).toBeUndefined();
+		expect(computeCacheMissCostSummary(undefined, currentModelEstimate)).toBeUndefined();
+		expect(computeCacheMissCostSummary(usage({}), currentModelEstimate)).toBeUndefined();
 	});
 
-	it("uses usage.cost buckets as factual costs in material summaries", () => {
+	it("uses persisted aggregate facts without a model or miss premium", () => {
 		const summary = computeCacheMissCostSummary(
+			usageWithoutPersistedCosts({ input: 100, cacheRead: 20_000 }),
+			persistedAggregate({ input: 0.25, cacheRead: 0.02, output: 0, cacheWrite: 0, total: 0.27 }),
+		);
+
+		expect(summary?.inputCostUsd).toBe(0.25);
+		expect(summary?.cacheReadCostUsd).toBe(0.02);
+		expect(summary?.missPremiumUsd).toBeUndefined();
+	});
+
+	it("retains persisted direct costs and estimates only structurally absent buckets", () => {
+		const factual = computeCacheMissCostSummary(
 			usage({
 				input: 100,
 				cacheRead: 20_000,
 				cost: { input: 0.25, cacheRead: 0.02, output: 0, cacheWrite: 0, total: 0.27 },
 			}),
-			priced,
+			currentModelEstimate,
+		);
+		const estimated = computeCacheMissCostSummary(
+			usageWithoutPersistedCosts({ input: 20_000 }),
+			currentModelEstimate,
 		);
 
-		expect(summary?.inputCostUsd).toBe(0.25);
-		expect(summary?.cacheReadCostUsd).toBe(0.02);
-		expect(summary?.missPremiumUsd).toBeCloseTo(0.00027);
+		expect(factual?.inputCostUsd).toBe(0.25);
+		expect(factual?.cacheReadCostUsd).toBe(0.02);
+		expect(factual?.missPremiumUsd).toBeCloseTo(0.00027);
+		expect(estimated?.inputCostUsd).toBeCloseTo(0.06);
+	});
+
+	it("treats explicit zero persisted cost as factual instead of repricing it", () => {
+		const persistedZeroUsage = usage({ input: 20_000 });
+		const summary = computeCacheMissCostSummary(persistedZeroUsage, currentModelEstimate);
+		const warning = buildCacheEconomicsWarning(persistedZeroUsage, modelWithCost(priced), { warningsEmitted: 0 });
+
+		expect(summary).toBeUndefined();
+		expect(warning).toBeUndefined();
+	});
+
+	it("suppresses malformed persisted costs instead of falling back to pricing", () => {
+		const summary = computeCacheMissCostSummary(
+			usageWithoutPersistedCosts({ input: 20_000, cost: { input: Number.NaN } }),
+			currentModelEstimate,
+		);
+		const aggregate = computeCacheMissCostSummary(
+			usageWithoutPersistedCosts({ input: 20_000 }),
+			persistedAggregate({ input: 0.06, cacheRead: 0, output: 0, cacheWrite: 0, total: -0.06 }),
+		);
+
+		expect(summary).toBeUndefined();
+		expect(aggregate).toBeUndefined();
+	});
+
+	it("fails closed when any persisted aggregate cost bucket is missing or non-finite", () => {
+		const completeAggregate = { input: 0.25, output: 0.15, cacheRead: 0.02, cacheWrite: 0.08, total: 0.5 };
+		const buckets = ["input", "output", "cacheRead", "cacheWrite", "total"] as const;
+
+		const accepted = computeCacheMissCostSummary(
+			usageWithoutPersistedCosts({ input: 20_000 }),
+			persistedAggregate(completeAggregate),
+		);
+		expect(accepted).toMatchObject({
+			inputCostUsd: 0.25,
+			cacheReadCostUsd: 0.02,
+			cacheWriteCostUsd: 0.08,
+		});
+
+		for (const bucket of buckets) {
+			const missing = { ...completeAggregate } as Partial<Usage["cost"]>;
+			delete missing[bucket];
+			const infinite = { ...completeAggregate, [bucket]: Number.POSITIVE_INFINITY };
+			const negative = { ...completeAggregate, [bucket]: -0.01 };
+
+			expect(
+				computeCacheMissCostSummary(
+					usageWithoutPersistedCosts({ input: 20_000 }),
+					persistedAggregate(missing as Usage["cost"]),
+				),
+				`missing persisted aggregate ${bucket} cost`,
+			).toBeUndefined();
+			expect(
+				computeCacheMissCostSummary(usageWithoutPersistedCosts({ input: 20_000 }), persistedAggregate(infinite)),
+				`non-finite persisted aggregate ${bucket} cost`,
+			).toBeUndefined();
+			expect(
+				computeCacheMissCostSummary(usageWithoutPersistedCosts({ input: 20_000 }), persistedAggregate(negative)),
+				`negative persisted aggregate ${bucket} cost`,
+			).toBeUndefined();
+		}
 	});
 
 	it("computes miss premium only when input and cache-read prices are both positive", () => {
-		const noCacheReadPrice = computeCacheMissCostSummary(usage({ input: 20_000 }), {
-			input: 3,
-			cacheRead: 0,
-			cacheWrite: 0,
+		const noCacheReadPrice = computeCacheMissCostSummary(usageWithoutPersistedCosts({ input: 20_000 }), {
+			kind: "current-model-estimate",
+			pricing: { input: 3, cacheRead: 0, cacheWrite: 0 },
 		});
-		const withBothPrices = computeCacheMissCostSummary(usage({ input: 20_000 }), priced);
+		const withBothPrices = computeCacheMissCostSummary(
+			usageWithoutPersistedCosts({ input: 20_000 }),
+			currentModelEstimate,
+		);
 
 		expect(noCacheReadPrice?.missPremiumUsd).toBeUndefined();
 		expect(withBothPrices?.missPremiumUsd).toBeCloseTo(0.054);
 	});
 
 	it("allows cache-write-only pricing to report write cost without miss premium", () => {
-		const summary = computeCacheMissCostSummary(usage({ cacheWrite: 20_000 }), {
-			input: 0,
-			cacheRead: 0,
-			cacheWrite: 3.75,
+		const summary = computeCacheMissCostSummary(usageWithoutPersistedCosts({ cacheWrite: 20_000 }), {
+			kind: "current-model-estimate",
+			pricing: { input: 0, cacheRead: 0, cacheWrite: 3.75 },
 		});
 
 		expect(summary?.cacheWriteCostUsd).toBeCloseTo(0.075);
@@ -76,7 +171,10 @@ describe("cache economics", () => {
 
 	it("prioritizes miss premium warnings and caps transcript warnings", () => {
 		const state = { warningsEmitted: 0 };
-		const warningUsage = usage({ input: 20_000, cacheRead: 1_000, cacheWrite: 20_000 });
+		const warningUsage = {
+			...usage({ input: 20_000, cacheRead: 1_000, cacheWrite: 20_000 }),
+			cost: {} as Usage["cost"],
+		};
 		const model = modelWithCost(priced);
 		const warnings = [
 			buildCacheEconomicsWarning(warningUsage, model, state),

--- a/packages/coding-agent/test/cache-economics.test.ts
+++ b/packages/coding-agent/test/cache-economics.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import type { Model, Usage } from "@gajae-code/ai";
+import {
+	buildCacheEconomicsWarning,
+	computeCacheMissCostSummary,
+} from "@gajae-code/coding-agent/session/cache-economics";
+
+function usage(overrides: Partial<Usage>): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		...overrides,
+		cost: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			total: 0,
+			...overrides.cost,
+		},
+	};
+}
+
+function modelWithCost(cost: Model["cost"]): Pick<Model, "cost"> {
+	return { cost };
+}
+
+const priced = { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 };
+
+describe("cache economics", () => {
+	it("omits zero or absent usage", () => {
+		expect(computeCacheMissCostSummary(undefined, priced)).toBeUndefined();
+		expect(computeCacheMissCostSummary(usage({}), priced)).toBeUndefined();
+	});
+
+	it("uses usage.cost buckets as factual costs in material summaries", () => {
+		const summary = computeCacheMissCostSummary(
+			usage({
+				input: 100,
+				cacheRead: 20_000,
+				cost: { input: 0.25, cacheRead: 0.02, output: 0, cacheWrite: 0, total: 0.27 },
+			}),
+			priced,
+		);
+
+		expect(summary?.inputCostUsd).toBe(0.25);
+		expect(summary?.cacheReadCostUsd).toBe(0.02);
+		expect(summary?.missPremiumUsd).toBeCloseTo(0.00027);
+	});
+
+	it("computes miss premium only when input and cache-read prices are both positive", () => {
+		const noCacheReadPrice = computeCacheMissCostSummary(usage({ input: 20_000 }), {
+			input: 3,
+			cacheRead: 0,
+			cacheWrite: 0,
+		});
+		const withBothPrices = computeCacheMissCostSummary(usage({ input: 20_000 }), priced);
+
+		expect(noCacheReadPrice?.missPremiumUsd).toBeUndefined();
+		expect(withBothPrices?.missPremiumUsd).toBeCloseTo(0.054);
+	});
+
+	it("allows cache-write-only pricing to report write cost without miss premium", () => {
+		const summary = computeCacheMissCostSummary(usage({ cacheWrite: 20_000 }), {
+			input: 0,
+			cacheRead: 0,
+			cacheWrite: 3.75,
+		});
+
+		expect(summary?.cacheWriteCostUsd).toBeCloseTo(0.075);
+		expect(summary?.missPremiumUsd).toBeUndefined();
+	});
+
+	it("prioritizes miss premium warnings and caps transcript warnings", () => {
+		const state = { warningsEmitted: 0 };
+		const warningUsage = usage({ input: 20_000, cacheRead: 1_000, cacheWrite: 20_000 });
+		const model = modelWithCost(priced);
+		const warnings = [
+			buildCacheEconomicsWarning(warningUsage, model, state),
+			buildCacheEconomicsWarning(warningUsage, model, state),
+			buildCacheEconomicsWarning(warningUsage, model, state),
+			buildCacheEconomicsWarning(warningUsage, model, state),
+		];
+
+		expect(
+			warnings.slice(0, 3).every(text => text?.includes("large uncached input") && text.includes("next step:")),
+		).toBe(true);
+		expect(warnings[3]).toBeUndefined();
+		expect(state.warningsEmitted).toBe(3);
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/session-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/session-command.test.ts
@@ -1,0 +1,115 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { getBundledModel, type Model, type Usage } from "@gajae-code/ai";
+import { CommandController } from "@gajae-code/coding-agent/modes/controllers/command-controller";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import { Text } from "@gajae-code/tui";
+
+async function renderSessionInfo(costBreakdown?: Usage["cost"], model?: Model): Promise<string> {
+	const chatContainer = {
+		children: [] as unknown[],
+		addChild(child: unknown) {
+			this.children.push(child);
+		},
+	};
+	const ctx = {
+		session: {
+			getSessionStats: () => ({
+				sessionFile: undefined,
+				sessionId: "aggregate-session",
+				userMessages: 1,
+				assistantMessages: 1,
+				toolCalls: 0,
+				toolResults: 0,
+				totalMessages: 2,
+				tokens: { input: 2_000, output: 500, cacheRead: 1_000_000, cacheWrite: 40_000, total: 1_042_500 },
+				premiumRequests: 0,
+				cost: 0.67,
+				costBreakdown,
+			}),
+			model,
+			modelRegistry: {
+				authStorage: {
+					hasOAuth: () => false,
+					has: () => false,
+					hasAuth: () => false,
+					describeCredentialSource: () => undefined,
+				},
+			},
+			providerSessionState: undefined,
+			sessionManager: { getUsageStatistics: () => ({ premiumRequests: 0 }) },
+		},
+		settings: { get: () => undefined },
+		chatContainer,
+		ui: { requestRender: () => undefined },
+	} as unknown as InteractiveModeContext;
+
+	const controller = new CommandController(ctx);
+	await controller.handleSessionCommand();
+	const content = chatContainer.children[1];
+	if (!(content instanceof Text)) throw new Error("Expected /session to add a text panel");
+	return content.getText().replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+beforeAll(async () => {
+	const installed = await getThemeByName("red-claw");
+	if (!installed) throw new Error("Expected dark theme");
+	setThemeInstance(installed);
+});
+
+describe("/session command", () => {
+	it("uses persisted aggregate cache costs without a selected model", async () => {
+		const output = await renderSessionInfo({
+			input: 0.52,
+			output: 0,
+			cacheRead: 0.03,
+			cacheWrite: 0.12,
+			total: 0.67,
+		});
+
+		expect(output).toContain("Tokens\nInput: 2,000\nOutput: 500\nCache Read: 1,000,000\nCache Write: 40,000");
+		expect(output).toContain("Cost\nTotal: 0.6700");
+		expect(output).toContain("Cache Miss Cost\nUncached Input Cost: $0.52");
+		expect(output).toContain("Cache Write Cost: $0.12");
+		expect(output).not.toContain("Estimated Miss Premium");
+		expect(output.indexOf("Tokens")).toBeLessThan(output.indexOf("Cost\nTotal: 0.6700"));
+		expect(output.indexOf("Cost\nTotal: 0.6700")).toBeLessThan(output.indexOf("Cache Miss Cost"));
+	});
+
+	it("is invariant to the selected model's prices", async () => {
+		const selected = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!selected) throw new Error("Expected bundled model");
+		const expensive = { ...selected, cost: { input: 100, output: 100, cacheRead: 0.01, cacheWrite: 100 } };
+		const costBreakdown = { input: 0.52, output: 0, cacheRead: 0.03, cacheWrite: 0.12, total: 0.67 };
+
+		expect(await renderSessionInfo(costBreakdown, expensive)).toBe(await renderSessionInfo(costBreakdown, selected));
+	});
+
+	it("omits cache economics when aggregate provenance is absent or incomplete", async () => {
+		const absent = await renderSessionInfo();
+		expect(absent).not.toContain("Cache Miss Cost");
+
+		const incomplete = await renderSessionInfo({
+			input: 0.52,
+			output: 0,
+			cacheRead: 0.03,
+			cacheWrite: Number.NaN,
+			total: 0.67,
+		});
+		expect(incomplete).not.toContain("Cache Miss Cost");
+	});
+
+	it("does not reprice material tokens when a complete persisted aggregate is all zero", async () => {
+		const selected = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!selected) throw new Error("Expected bundled model");
+		const expensive = { ...selected, cost: { input: 100, output: 100, cacheRead: 0.01, cacheWrite: 100 } };
+		const zeroAggregate = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+
+		const output = await renderSessionInfo(zeroAggregate, expensive);
+
+		expect(output).toContain("Tokens\nInput: 2,000\nOutput: 500\nCache Read: 1,000,000\nCache Write: 40,000");
+		expect(output).toContain("Cost\nTotal: 0.6700");
+		expect(output).not.toContain("Cache Miss Cost");
+		expect(output).not.toContain("Estimated Miss Premium");
+	});
+});

--- a/packages/coding-agent/test/session-dump-format.test.ts
+++ b/packages/coding-agent/test/session-dump-format.test.ts
@@ -59,6 +59,13 @@ function cacheWarningUsage(): Usage {
 	};
 }
 
+function cacheWarningUsageWithoutInputCost(): Usage {
+	return {
+		...cacheWarningUsage(),
+		cost: { output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } as Usage["cost"],
+	};
+}
+
 function assistantWithProxyAsk(): AssistantMessage {
 	return {
 		role: "assistant",
@@ -170,7 +177,7 @@ describe("formatSessionDumpText tool calls", () => {
 describe("formatSessionDumpText cache warnings", () => {
 	it("renders a cache warning after assistant content when pricing supports it", () => {
 		const dumped = formatSessionDumpText({
-			messages: [assistantWithUsage(cacheWarningUsage(), 1)],
+			messages: [assistantWithUsage(cacheWarningUsageWithoutInputCost(), 1)],
 			model: pricedModel(),
 			thinkingLevel: null,
 		});
@@ -180,23 +187,41 @@ describe("formatSessionDumpText cache warnings", () => {
 		);
 	});
 
-	it("omits cache warnings when model pricing is unavailable", () => {
+	it("does not reprice an explicit persisted input cost of zero", () => {
 		const dumped = formatSessionDumpText({
 			messages: [assistantWithUsage(cacheWarningUsage(), 1)],
-			model: null,
+			model: pricedModel(),
 			thinkingLevel: null,
 		});
 
+		expect(dumped).not.toContain("$0.06");
 		expect(dumped).not.toContain("Cache warning:");
+	});
+
+	it("omits cache warnings when model pricing is unavailable", () => {
+		const usage = cacheWarningUsageWithoutInputCost();
+		const withPricing = formatSessionDumpText({
+			messages: [assistantWithUsage(usage, 1)],
+			model: pricedModel(),
+			thinkingLevel: null,
+		});
+		expect(withPricing).toContain("Cache warning:");
+
+		const withoutPricing = formatSessionDumpText({
+			messages: [assistantWithUsage(usage, 1)],
+			model: null,
+			thinkingLevel: null,
+		});
+		expect(withoutPricing).not.toContain("Cache warning:");
 	});
 
 	it("caps cache warnings at three assistant turns", () => {
 		const dumped = formatSessionDumpText({
 			messages: [
-				assistantWithUsage(cacheWarningUsage(), 1),
-				assistantWithUsage(cacheWarningUsage(), 2),
-				assistantWithUsage(cacheWarningUsage(), 3),
-				assistantWithUsage(cacheWarningUsage(), 4),
+				assistantWithUsage(cacheWarningUsageWithoutInputCost(), 1),
+				assistantWithUsage(cacheWarningUsageWithoutInputCost(), 2),
+				assistantWithUsage(cacheWarningUsageWithoutInputCost(), 3),
+				assistantWithUsage(cacheWarningUsageWithoutInputCost(), 4),
 			],
 			model: pricedModel(),
 			thinkingLevel: null,

--- a/packages/coding-agent/test/session-dump-format.test.ts
+++ b/packages/coding-agent/test/session-dump-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { AssistantMessage, Usage } from "@gajae-code/ai";
+import type { AssistantMessage, Model, Usage } from "@gajae-code/ai";
 import { formatSessionDumpText } from "@gajae-code/coding-agent/session/session-dump-format";
 
 const zeroUsage: Usage = {
@@ -16,6 +16,48 @@ const zeroUsage: Usage = {
 		total: 0,
 	},
 };
+
+function pricedModel(): Model {
+	return {
+		id: "claude",
+		name: "Claude",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://example.test",
+		reasoning: true,
+		input: ["text"],
+		cost: {
+			input: 3,
+			output: 15,
+			cacheRead: 0.3,
+			cacheWrite: 3.75,
+		},
+		contextWindow: 200_000,
+		maxTokens: 64_000,
+	};
+}
+
+function assistantWithUsage(usage: Usage, timestamp: number): AssistantMessage {
+	return {
+		role: "assistant",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude",
+		usage,
+		stopReason: "stop",
+		timestamp,
+		content: [{ type: "text", text: `assistant ${timestamp}` }],
+	};
+}
+
+function cacheWarningUsage(): Usage {
+	return {
+		...zeroUsage,
+		input: 20_000,
+		cacheRead: 1_000,
+		totalTokens: 21_000,
+	};
+}
 
 function assistantWithProxyAsk(): AssistantMessage {
 	return {
@@ -122,5 +164,45 @@ describe("formatSessionDumpText tool calls", () => {
 		expect(dumped).toContain('name="unsafe&lt;key"');
 		expect(dumped).toContain("readable Korean: 한글 &amp; raw &lt;tag&gt;");
 		expect(dumped).not.toContain("\\ud55c");
+	});
+});
+
+describe("formatSessionDumpText cache warnings", () => {
+	it("renders a cache warning after assistant content when pricing supports it", () => {
+		const dumped = formatSessionDumpText({
+			messages: [assistantWithUsage(cacheWarningUsage(), 1)],
+			model: pricedModel(),
+			thinkingLevel: null,
+		});
+
+		expect(dumped).toContain(
+			"assistant 1\nCache warning: large uncached input with low cache hits ($0.06); next step:",
+		);
+	});
+
+	it("omits cache warnings when model pricing is unavailable", () => {
+		const dumped = formatSessionDumpText({
+			messages: [assistantWithUsage(cacheWarningUsage(), 1)],
+			model: null,
+			thinkingLevel: null,
+		});
+
+		expect(dumped).not.toContain("Cache warning:");
+	});
+
+	it("caps cache warnings at three assistant turns", () => {
+		const dumped = formatSessionDumpText({
+			messages: [
+				assistantWithUsage(cacheWarningUsage(), 1),
+				assistantWithUsage(cacheWarningUsage(), 2),
+				assistantWithUsage(cacheWarningUsage(), 3),
+				assistantWithUsage(cacheWarningUsage(), 4),
+			],
+			model: pricedModel(),
+			thinkingLevel: null,
+		});
+
+		expect(dumped.match(/Cache warning:/g)?.length).toBe(3);
+		expect(dumped).toContain("assistant 4");
 	});
 });

--- a/packages/coding-agent/test/task/executor-wall-clock.test.ts
+++ b/packages/coding-agent/test/task/executor-wall-clock.test.ts
@@ -67,6 +67,77 @@ function mockCreateAgentSession(session: AgentSession) {
 	} satisfies CreateAgentSessionResult);
 }
 
+function createUsageSession(usages: unknown | readonly unknown[]): AgentSession {
+	const session: Partial<AgentSession> = {
+		state: { messages: [] } as never,
+		agent: { state: { systemPrompt: ["test"] } } as never,
+		extensionRunner: undefined as never,
+		sessionManager: { appendSessionInit: () => {} } as never,
+		getActiveToolNames: () => ["read", "yield"],
+		setActiveToolsByName: async () => {},
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
+			queueMicrotask(() => {
+				for (const usage of Array.isArray(usages) ? usages : [usages]) {
+					listener({
+						type: "message_end",
+						message: {
+							role: "assistant",
+							content: [{ type: "text", text: "ok" }],
+							usage,
+						},
+					} as unknown as AgentSessionEvent);
+				}
+				listener({
+					type: "tool_execution_end",
+					toolCallId: "tool-ok",
+					toolName: "yield",
+					result: { content: [{ type: "text", text: "Result submitted." }], details: { status: "success" } },
+					isError: false,
+				} as AgentSessionEvent);
+			});
+			return () => {};
+		},
+		prompt: async () => {},
+		waitForIdle: async () => {},
+		getLastAssistantMessage: () => undefined,
+		abort: async () => {},
+		dispose: async () => {},
+	};
+	return session as AgentSession;
+}
+
+const completeRawCost = { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 };
+
+type RawCostBucket = keyof typeof completeRawCost;
+
+function usageWithRawCost(cost: Record<string, unknown>, usage: Partial<Record<string, number>> = {}) {
+	return {
+		input: 10,
+		output: 2,
+		cacheRead: 3,
+		cacheWrite: 4,
+		totalTokens: 19,
+		...usage,
+		cost,
+	};
+}
+
+const invalidRawCostCases: ReadonlyArray<{
+	label: string;
+	bucket: RawCostBucket;
+	value?: number;
+}> = [
+	...(["input", "output", "cacheRead", "cacheWrite", "total"] as const).map(bucket => ({
+		label: `missing ${bucket}`,
+		bucket,
+	})),
+	...(["input", "output", "cacheRead", "cacheWrite", "total"] as const).flatMap(bucket => [
+		{ label: `negative ${bucket}`, bucket, value: -1 },
+		{ label: `NaN ${bucket}`, bucket, value: Number.NaN },
+		{ label: `infinite ${bucket}`, bucket, value: Number.POSITIVE_INFINITY },
+	]),
+];
+
 describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
@@ -314,5 +385,118 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 		// here we mock createAgentSession so it stays undefined. The async-task
 		// consumer's assignment is a straight copy, so undefined is acceptable.
 		expect(result.contextWindow).toBeUndefined();
+	});
+
+	it("marks complete raw assistant cost provenance before canonical coercion", async () => {
+		const settings = Settings.isolated({ "task.maxRuntimeMs": 0 });
+		mockCreateAgentSession(createUsageSession(usageWithRawCost({ ...completeRawCost, input: 0 })));
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-complete-cost", settings });
+
+		expect(result.usageCostBreakdownComplete).toBe(true);
+		expect(result.usage?.cost.input).toBe(0);
+	});
+
+	for (const { label, bucket, value } of invalidRawCostCases) {
+		it(`fails closed for ${label} raw assistant cost`, async () => {
+			const settings = Settings.isolated({ "task.maxRuntimeMs": 0 });
+			const cost: Record<string, unknown> = { ...completeRawCost };
+			if (value === undefined) {
+				delete cost[bucket];
+			} else {
+				cost[bucket] = value;
+			}
+			mockCreateAgentSession(createUsageSession(usageWithRawCost(cost)));
+
+			const result = await runSubprocess({ ...baseOptions, id: `subagent-${label}`, settings });
+
+			expect(result.usageCostBreakdownComplete).toBeUndefined();
+		});
+	}
+
+	for (const { label, cost } of [
+		{
+			label: "missing",
+			cost: { output: 2, cacheRead: 3, cacheWrite: 4, total: 10 },
+		},
+		{
+			label: "invalid",
+			cost: { ...completeRawCost, cacheWrite: Number.NaN },
+		},
+	]) {
+		it(`fails closed when a ${label} contributor precedes a valid contributor`, async () => {
+			const settings = Settings.isolated({ "task.maxRuntimeMs": 0 });
+			mockCreateAgentSession(createUsageSession([usageWithRawCost(cost), usageWithRawCost({ ...completeRawCost })]));
+
+			const result = await runSubprocess({ ...baseOptions, id: `subagent-${label}-then-valid-cost`, settings });
+
+			expect(result.usageCostBreakdownComplete).toBeUndefined();
+		});
+	}
+
+	it("fails closed for a legacy contributing assistant without raw cost", async () => {
+		const settings = Settings.isolated({ "task.maxRuntimeMs": 0 });
+		mockCreateAgentSession(
+			createUsageSession({ input: 10, output: 2, cacheRead: 3, cacheWrite: 4, totalTokens: 19 }),
+		);
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-legacy-cost", settings });
+
+		expect(result.usageCostBreakdownComplete).toBeUndefined();
+		expect(result.usage?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 });
+	});
+
+	for (const [label, usages] of [
+		[
+			"legacy then valid",
+			[
+				{ input: 10, output: 2, cacheRead: 3, cacheWrite: 4, totalTokens: 19 },
+				usageWithRawCost({ ...completeRawCost }),
+			],
+		],
+		[
+			"valid then legacy",
+			[
+				usageWithRawCost({ ...completeRawCost }),
+				{ input: 10, output: 2, cacheRead: 3, cacheWrite: 4, totalTokens: 19 },
+			],
+		],
+	] as const) {
+		it(`fails closed when a ${label} contributor has no raw cost`, async () => {
+			const settings = Settings.isolated({ "task.maxRuntimeMs": 0 });
+			mockCreateAgentSession(createUsageSession(usages));
+
+			const result = await runSubprocess({ ...baseOptions, id: `subagent-${label}-cost`, settings });
+
+			expect(result.usageCostBreakdownComplete).toBeUndefined();
+		});
+	}
+
+	it("preserves canonical aggregated usage and costs for valid contributors", async () => {
+		const settings = Settings.isolated({ "task.maxRuntimeMs": 0 });
+		mockCreateAgentSession(
+			createUsageSession([
+				usageWithRawCost(
+					{ input: 0, output: 2, cacheRead: 3, cacheWrite: 4, total: 9 },
+					{ input: 10, output: 2, cacheRead: 3, cacheWrite: 4, totalTokens: 19 },
+				),
+				usageWithRawCost(
+					{ input: 10, output: 20, cacheRead: 30, cacheWrite: 40, total: 100 },
+					{ input: 11, output: 5, cacheRead: 7, cacheWrite: 13, totalTokens: 36 },
+				),
+			]),
+		);
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-aggregate-valid-cost", settings });
+
+		expect(result.usageCostBreakdownComplete).toBe(true);
+		expect(result.usage).toEqual({
+			input: 21,
+			output: 7,
+			cacheRead: 10,
+			cacheWrite: 17,
+			totalTokens: 55,
+			cost: { input: 10, output: 22, cacheRead: 33, cacheWrite: 44, total: 109 },
+		});
 	});
 });

--- a/packages/coding-agent/test/task/receipt.test.ts
+++ b/packages/coding-agent/test/task/receipt.test.ts
@@ -13,7 +13,12 @@ import {
 	type RawTaskToolDetails,
 	sanitizeTaskToolDetails,
 } from "../../src/task/receipt";
-import type { SingleResult, TaskToolDetails } from "../../src/task/types";
+import {
+	hasCompleteAggregateUsageCostBreakdown,
+	hasCompleteUsageCostBreakdown,
+	type SingleResult,
+	type TaskToolDetails,
+} from "../../src/task/types";
 
 const CANONICAL_USAGE = {
 	input: 1,
@@ -217,6 +222,78 @@ describe("task result receipts", () => {
 		expect(receipt.usage?.output).toBe(2);
 		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
 		expect(() => assertNoRawTaskFields(receipt, "receipt")).not.toThrow();
+	});
+
+	it("preserves explicit complete cost provenance through receipts and sanitized task details", () => {
+		const raw = makeRaw({ usage: CANONICAL_USAGE, usageCostBreakdownComplete: true });
+		const receipt = buildTaskReceipt(raw);
+		expect(receipt.usageCostBreakdownComplete).toBe(true);
+
+		const sanitized = sanitizeTaskToolDetails({
+			projectAgentsDir: null,
+			results: [raw],
+			totalDurationMs: 10,
+			usage: CANONICAL_USAGE,
+			usageCostBreakdownComplete: true,
+		});
+		expect(sanitized.results[0]?.usageCostBreakdownComplete).toBe(true);
+		expect(sanitized.usageCostBreakdownComplete).toBe(true);
+	});
+
+	it("authorizes aggregate provenance for all-complete zero-cost children", () => {
+		const children = [
+			makeRaw({ usage: CANONICAL_USAGE, usageCostBreakdownComplete: true }),
+			makeRaw({ index: 1, id: "1-Test", usage: CANONICAL_USAGE, usageCostBreakdownComplete: true }),
+		];
+
+		expect(hasCompleteAggregateUsageCostBreakdown(children)).toBe(true);
+	});
+
+	it("fails aggregate provenance for legacy or invalid usage contributors", () => {
+		const complete = makeRaw({ usage: CANONICAL_USAGE, usageCostBreakdownComplete: true });
+		const legacy = makeRaw({ index: 1, id: "1-Test", usage: CANONICAL_USAGE });
+		const invalid = makeRaw({
+			index: 2,
+			id: "2-Test",
+			usage: { ...CANONICAL_USAGE, cost: { ...CANONICAL_USAGE.cost, total: Number.NaN } },
+			usageCostBreakdownComplete: true,
+		});
+
+		expect(hasCompleteAggregateUsageCostBreakdown([complete, legacy])).toBe(false);
+		expect(hasCompleteAggregateUsageCostBreakdown([complete, invalid])).toBe(false);
+	});
+
+	it("rejects marked usage with an invalid cost contributor", () => {
+		const invalidUsage = {
+			...CANONICAL_USAGE,
+			cost: { ...CANONICAL_USAGE.cost, cacheWrite: -1 },
+		};
+		const raw = makeRaw({ usage: invalidUsage, usageCostBreakdownComplete: true });
+
+		expect(hasCompleteUsageCostBreakdown(raw.usage)).toBe(false);
+		expect(buildTaskReceipt(raw).usageCostBreakdownComplete).toBeUndefined();
+		expect(
+			sanitizeTaskToolDetails({
+				projectAgentsDir: null,
+				results: [raw],
+				totalDurationMs: 10,
+				usage: invalidUsage,
+				usageCostBreakdownComplete: true,
+			}).usageCostBreakdownComplete,
+		).toBeUndefined();
+	});
+
+	it("fails closed for absent or legacy cost provenance despite zero-filled canonical usage", () => {
+		const legacyRaw = makeRaw({ usage: CANONICAL_USAGE });
+		expect(buildTaskReceipt(legacyRaw).usageCostBreakdownComplete).toBeUndefined();
+
+		const sanitized = sanitizeTaskToolDetails({
+			projectAgentsDir: null,
+			results: [legacyRaw],
+			totalDurationMs: 10,
+			usage: CANONICAL_USAGE,
+		});
+		expect(sanitized.usageCostBreakdownComplete).toBeUndefined();
 	});
 
 	it("preserves numeric fork-context accounting on receipts and sanitized details", () => {


### PR DESCRIPTION
Closes #1929

## Summary

- Adds `packages/coding-agent/src/session/cache-economics.ts`: a pure, shared helper that computes cache-miss cost summaries and cache behavior warnings from usage + pricing, preferring persisted `usage.cost` buckets over estimates.
- TUI `/session` and ACP `/session info` show a "Cache Miss Cost" section (uncached input cost, estimated miss premium vs cache-read pricing, cache hit rate, material cache write cost) only when pricing and material usage evidence exist.
- Plain transcript dump output (`formatSessionDumpText`) emits capped cache warnings (max 3 per dump, one per assistant turn) with a short reason and the smallest safe next step.

## Gates (low-noise by design)

- No pricing, no usage, all-zero, or immaterial data ⇒ no output at all.
- Miss premium is only estimated when both input and cache-read pricing are present for the same model context.
- Warnings fire only on material evidence: `expensive_cache_miss` (≥20k uncached input tokens, <25% hit rate, ≥$0.05) and `cache_write_spike` (≥25k cache write tokens, ≥$0.05).

## Testing

- `bun test packages/coding-agent/test/cache-economics.test.ts packages/coding-agent/test/session-dump-format.test.ts packages/coding-agent/test/acp-builtins.test.ts` — 77 pass.
- `bun run --cwd=packages/coding-agent check` (biome + tsgo) — clean.
- Rebased onto current `dev`; tests re-run green after rebase.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
