### PR TITLE
fix(tui): render every loaded /skill invocation in chat, not just the last

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -12,7 +12,7 @@ import { theme } from "../../modes/theme/theme";
 import { scrollTmuxToPreviousUserInput as scrollTmuxPaneToPreviousUserInput } from "../../modes/tmux-scroll";
 import type { InteractiveModeContext } from "../../modes/types";
 import type { AgentSessionEvent, QueuedMessageEditEntry } from "../../session/agent-session";
-import { SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../../session/messages";
+import { type CustomMessage, SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../../session/messages";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
 import { copyToClipboard, readImageFromClipboard } from "../../utils/clipboard";
 import { getEditorCommand, openInEditor } from "../../utils/external-editor";
@@ -852,6 +852,7 @@ export class InputController {
 				});
 				const details: SkillPromptDetails = built.details;
 				const displayText = `/${invocation.commandName}${activationResult.cleanedArgs ? ` ${activationResult.cleanedArgs}` : ""}`;
+				let pendingDisplayTag: string | undefined;
 				// When the agent is streaming, register a compact slash-form text as
 				// the pending-display twin BEFORE dispatching the CustomMessage. The
 				// returned tag is embedded in details so AgentSession.#handleAgentEvent
@@ -859,31 +860,46 @@ export class InputController {
 				// message (mirrors the user-message dequeue path).
 				if (this.ctx.session.isStreaming) {
 					const tag = this.ctx.session.enqueueCustomMessageDisplay(displayText, streamingBehavior);
+					pendingDisplayTag = tag;
 					details.__pendingDisplayTag = tag;
 				}
 				const isLast = index === invocations.length - 1;
-				if (!this.ctx.session.isStreaming && !isLast) {
-					await this.ctx.session.sendCustomMessage({
-						customType: SKILL_PROMPT_MESSAGE_TYPE,
-						content: built.message,
-						display: true,
-						details,
-						attribution: "user",
-					});
-					continue;
+				try {
+					if (!this.ctx.session.isStreaming && !isLast) {
+						const liveMessage: CustomMessage<SkillPromptDetails> = {
+							role: "custom",
+							customType: SKILL_PROMPT_MESSAGE_TYPE,
+							content: built.message,
+							display: true,
+							details,
+							attribution: "user",
+							timestamp: Date.now(),
+						};
+						await this.ctx.session.sendCustomMessage(liveMessage);
+						this.ctx.addMessageToChat(liveMessage);
+						this.ctx.ui.requestRender();
+						continue;
+					}
+					await this.ctx.session.promptCustomMessage(
+						{
+							customType: SKILL_PROMPT_MESSAGE_TYPE,
+							content: built.message,
+							display: true,
+							details,
+							attribution: "user",
+						},
+						streamingBehavior === "followUp"
+							? { streamingBehavior, followUpQueuePolicy: "sequential" }
+							: { streamingBehavior },
+					);
+				} catch (err) {
+					if (pendingDisplayTag) {
+						this.ctx.session.removeQueuedCustomMessageDisplay(pendingDisplayTag);
+						this.ctx.updatePendingMessagesDisplay();
+						this.ctx.ui.requestRender();
+					}
+					throw err;
 				}
-				await this.ctx.session.promptCustomMessage(
-					{
-						customType: SKILL_PROMPT_MESSAGE_TYPE,
-						content: built.message,
-						display: true,
-						details,
-						attribution: "user",
-					},
-					streamingBehavior === "followUp"
-						? { streamingBehavior, followUpQueuePolicy: "sequential" }
-						: { streamingBehavior },
-				);
 			}
 			if (this.ctx.session.isStreaming) {
 				this.ctx.updatePendingMessagesDisplay();

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -806,13 +806,18 @@ export class UiHelpers {
 
 			const isLast = index === invocations.length - 1;
 			if (!this.ctx.session.isStreaming && !isLast) {
-				await this.ctx.session.sendCustomMessage({
+				const liveMessage: CustomMessage<SkillPromptDetails> = {
+					role: "custom",
 					customType: SKILL_PROMPT_MESSAGE_TYPE,
 					content: built.message,
 					display: true,
 					details,
 					attribution: "user",
-				});
+					timestamp: Date.now(),
+				};
+				await this.ctx.session.sendCustomMessage(liveMessage);
+				this.ctx.addMessageToChat(liveMessage);
+				this.ctx.ui.requestRender();
 				continue;
 			}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6232,6 +6232,30 @@ export class AgentSession {
 		};
 	}
 
+	/** Remove a queued custom-message display/agent entry by its private pending-display tag. */
+	removeQueuedCustomMessageDisplay(tag: string): boolean {
+		const normalizedTag = tag.trim();
+		if (!normalizedTag) return false;
+		const matchesTag = (message: CustomMessage): boolean => readPendingDisplayTag(message.details) === normalizedTag;
+		const agentRemoved = this.agent.removeQueuedMessages(
+			(message: AgentMessage): boolean => message.role === "custom" && matchesTag(message as CustomMessage),
+		);
+
+		const beforeNext = this.#pendingNextTurnMessages.length;
+		this.#pendingNextTurnMessages = this.#pendingNextTurnMessages.filter(message => !matchesTag(message));
+		const pendingNextTurn = beforeNext - this.#pendingNextTurnMessages.length;
+
+		const beforeSteering = this.#steeringMessages.length;
+		this.#steeringMessages = this.#steeringMessages.filter(entry => entry.tag !== normalizedTag);
+		const displaySteering = beforeSteering - this.#steeringMessages.length;
+
+		const beforeFollowUp = this.#followUpMessages.length;
+		this.#followUpMessages = this.#followUpMessages.filter(entry => entry.tag !== normalizedTag);
+		const displayFollowUp = beforeFollowUp - this.#followUpMessages.length;
+
+		return agentRemoved.total + pendingNextTurn + displaySteering + displayFollowUp > 0;
+	}
+
 	/**
 	 * Send a user message to the agent.
 	 * When deliverAs is set, queue the message instead of starting a new turn.

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -423,10 +423,11 @@ describe("InputController #invokeSkillCommand (E1-E3)", () => {
 			baseDir: tempDir.path(),
 			source: "test",
 		});
-		const { ctx, editor, sendCustomMessage, promptCustomMessage, addMessageToChat } = createStubInputControllerContext({
-			skillCommands,
-			isStreaming: false,
-		});
+		const { ctx, editor, sendCustomMessage, promptCustomMessage, addMessageToChat } =
+			createStubInputControllerContext({
+				skillCommands,
+				isStreaming: false,
+			});
 
 		const controller = new InputController(ctx);
 		controller.setupEditorSubmitHandler();

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -19,7 +19,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { Agent } from "@gajae-code/agent-core";
+import { Agent, type AgentMessage } from "@gajae-code/agent-core";
 import { getBundledModel } from "@gajae-code/ai/models";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
@@ -96,16 +96,24 @@ function createStubInputControllerContext(opts: {
 		},
 		addToHistory: vi.fn(),
 	};
-	const enqueueCustomMessageDisplay = vi.fn((_text: string, _mode: "steer" | "followUp") => "sk-test-0");
+	let nextTagIndex = 0;
+	const enqueueCustomMessageDisplay = vi.fn((_text: string, _mode: "steer" | "followUp") => {
+		const tag = `sk-test-${nextTagIndex}`;
+		nextTagIndex += 1;
+		return tag;
+	});
 	// Annotate parameters so `mock.calls[N]` is typed as a tuple (not `[]`) and
 	// `message` carries required skill prompt details for assertion below.
 	const promptCustomMessage = vi.fn(
 		async (_message: { content: string; details: SkillPromptDetails }, _options?: unknown) => {},
 	);
 	const sendCustomMessage = vi.fn(async (_message: { content: string; details: SkillPromptDetails }) => {});
+	const clearQueue = vi.fn();
+	const removeQueuedCustomMessageDisplay = vi.fn((_tag: string) => true);
 	const prompt = vi.fn(async (_text: string, _options?: { streamingBehavior?: "steer" | "followUp" }) => {});
 	const updatePendingMessagesDisplay = vi.fn();
 	const requestRender = vi.fn();
+	const addMessageToChat = vi.fn((_message: AgentMessage) => []);
 	const showError = vi.fn();
 
 	const ctx = {
@@ -122,6 +130,8 @@ function createStubInputControllerContext(opts: {
 			enqueueCustomMessageDisplay,
 			sendCustomMessage,
 			promptCustomMessage,
+			clearQueue,
+			removeQueuedCustomMessageDisplay,
 			prompt,
 		},
 		settings: {
@@ -140,9 +150,19 @@ function createStubInputControllerContext(opts: {
 		compactionQueuedMessages: [],
 		locallySubmittedUserSignatures: new Set<string>(),
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
+		addMessageToChat,
 	} as unknown as InteractiveModeContext;
 
-	return { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage, sendCustomMessage, prompt };
+	return {
+		ctx,
+		editor,
+		enqueueCustomMessageDisplay,
+		promptCustomMessage,
+		sendCustomMessage,
+		prompt,
+		addMessageToChat,
+		removeQueuedCustomMessageDisplay,
+	};
 }
 
 describe("InputController #invokeSkillCommand (E1-E3)", () => {
@@ -269,6 +289,94 @@ describe("InputController #invokeSkillCommand (E1-E3)", () => {
 		expect(ctx.compactionQueuedMessages).toEqual([]);
 	});
 
+	it("compaction queued chained skills direct-render non-final and prompt final sequentially", async () => {
+		const secondSkillPath = writeSkillFile(tempDir.path(), "second-skill", "Do the second thing.");
+		skillCommands.set("skill:second-skill", {
+			name: "second-skill",
+			description: "Second skill",
+			filePath: secondSkillPath,
+			baseDir: tempDir.path(),
+			source: "test",
+		});
+		const { ctx, sendCustomMessage, promptCustomMessage, addMessageToChat } = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: false,
+		});
+		ctx.compactionQueuedMessages.push({
+			text: "/skill:test-skill from compaction /skill:second-skill final args",
+			mode: "followUp",
+		});
+
+		const uiHelpers = new UiHelpers(ctx);
+		await uiHelpers.flushCompactionQueue();
+
+		expect(sendCustomMessage).toHaveBeenCalledTimes(1);
+		expect(promptCustomMessage).toHaveBeenCalledTimes(1);
+		expect(addMessageToChat).toHaveBeenCalledTimes(1);
+		const renderedMessage = addMessageToChat.mock.calls[0]?.[0];
+		if (!renderedMessage || !("content" in renderedMessage) || typeof renderedMessage.content !== "string") {
+			throw new Error("expected a rendered custom message with string content");
+		}
+		expect(renderedMessage.content).toContain("Do the thing.");
+		expect(renderedMessage.content).toContain("User: from compaction");
+		expect(renderedMessage.content).not.toContain("Do the second thing.");
+		expect(promptCustomMessage.mock.calls[0]?.[0].content).toContain("Do the second thing.");
+		expect(promptCustomMessage.mock.calls[0]?.[0].content).toContain("User: final args");
+		expect(promptCustomMessage.mock.calls[0]?.[1]).toEqual({
+			streamingBehavior: "followUp",
+			followUpQueuePolicy: "sequential",
+		});
+		expect(ctx.ui.requestRender).toHaveBeenCalledTimes(1);
+		expect(ctx.compactionQueuedMessages).toEqual([]);
+	});
+
+	it("compaction queued chained skills direct-render each successful non-final send", async () => {
+		const secondSkillPath = writeSkillFile(tempDir.path(), "second-skill", "Do the second thing.");
+		const thirdSkillPath = writeSkillFile(tempDir.path(), "third-skill", "Do the third thing.");
+		skillCommands.set("skill:second-skill", {
+			name: "second-skill",
+			description: "Second skill",
+			filePath: secondSkillPath,
+			baseDir: tempDir.path(),
+			source: "test",
+		});
+		skillCommands.set("skill:third-skill", {
+			name: "third-skill",
+			description: "Third skill",
+			filePath: thirdSkillPath,
+			baseDir: tempDir.path(),
+			source: "test",
+		});
+		const { ctx, sendCustomMessage, promptCustomMessage, addMessageToChat } = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: false,
+		});
+		sendCustomMessage
+			.mockImplementationOnce(async (_message: { content: string; details: SkillPromptDetails }) => {})
+			.mockImplementationOnce(async (_message: { content: string; details: SkillPromptDetails }) => {
+				throw new Error("send failed");
+			});
+		ctx.compactionQueuedMessages.push({
+			text: "/skill:test-skill first /skill:second-skill second /skill:third-skill third",
+			mode: "followUp",
+		});
+
+		const uiHelpers = new UiHelpers(ctx);
+		await uiHelpers.flushCompactionQueue();
+
+		expect(sendCustomMessage).toHaveBeenCalledTimes(2);
+		expect(promptCustomMessage).not.toHaveBeenCalled();
+		expect(addMessageToChat).toHaveBeenCalledTimes(1);
+		const renderedMessage = addMessageToChat.mock.calls[0]?.[0];
+		if (!renderedMessage || !("content" in renderedMessage) || typeof renderedMessage.content !== "string") {
+			throw new Error("expected a rendered custom message with string content");
+		}
+		expect(renderedMessage.content).toContain("Do the thing.");
+		expect(renderedMessage.content).toContain("User: first");
+		expect(ctx.ui.requestRender).toHaveBeenCalledTimes(1);
+		expect(ctx.showError).toHaveBeenCalledWith("Failed to send queued message: send failed");
+	});
+
 	it("E3: not streaming -> enqueueCustomMessageDisplay NOT called and tag absent", async () => {
 		const { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage } = createStubInputControllerContext({
 			skillCommands,
@@ -315,7 +423,7 @@ describe("InputController #invokeSkillCommand (E1-E3)", () => {
 			baseDir: tempDir.path(),
 			source: "test",
 		});
-		const { ctx, editor, sendCustomMessage, promptCustomMessage } = createStubInputControllerContext({
+		const { ctx, editor, sendCustomMessage, promptCustomMessage, addMessageToChat } = createStubInputControllerContext({
 			skillCommands,
 			isStreaming: false,
 		});
@@ -331,6 +439,124 @@ describe("InputController #invokeSkillCommand (E1-E3)", () => {
 		expect(sendCustomMessage.mock.calls[0]?.[0].content).toContain("User: alpha");
 		expect(promptCustomMessage.mock.calls[0]?.[0].content).toContain("Do the second thing.");
 		expect(promptCustomMessage.mock.calls[0]?.[0].content).toContain("User: beta gamma");
+		expect(addMessageToChat).toHaveBeenCalledTimes(1);
+		const renderedMessage = addMessageToChat.mock.calls[0]?.[0];
+		expect(renderedMessage).toMatchObject({
+			role: "custom",
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			display: true,
+			attribution: "user",
+		});
+		if (!renderedMessage || !("content" in renderedMessage) || typeof renderedMessage.content !== "string") {
+			throw new Error("expected a rendered custom message with string content");
+		}
+		expect(renderedMessage.content).toContain("Do the thing.");
+		expect(renderedMessage.content).not.toContain("Do the second thing.");
+		expect(ctx.ui.requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("dispatches chained canonical skill commands with distinct streaming tags and no direct render", async () => {
+		const secondSkillPath = writeSkillFile(tempDir.path(), "second-skill", "Do the second thing.");
+		skillCommands.set("skill:second-skill", {
+			name: "second-skill",
+			description: "Second skill",
+			filePath: secondSkillPath,
+			baseDir: tempDir.path(),
+			source: "test",
+		});
+		const { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage, addMessageToChat } =
+			createStubInputControllerContext({
+				skillCommands,
+				isStreaming: true,
+				busyPromptMode: "steer",
+			});
+
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+		editor.setText("/skill:test-skill alpha /skill:second-skill beta gamma");
+		await editor.onSubmit?.("/skill:test-skill alpha /skill:second-skill beta gamma");
+
+		expect(enqueueCustomMessageDisplay).toHaveBeenCalledTimes(2);
+		expect(enqueueCustomMessageDisplay).toHaveBeenNthCalledWith(1, "/skill:test-skill alpha", "steer");
+		expect(enqueueCustomMessageDisplay).toHaveBeenNthCalledWith(2, "/skill:second-skill beta gamma", "steer");
+		expect(promptCustomMessage).toHaveBeenCalledTimes(2);
+		expect(promptCustomMessage.mock.calls[0]?.[0].details.__pendingDisplayTag).toBe("sk-test-0");
+		expect(promptCustomMessage.mock.calls[1]?.[0].details.__pendingDisplayTag).toBe("sk-test-1");
+		expect(addMessageToChat).not.toHaveBeenCalled();
+	});
+
+	it("cleans up streaming skill pending display when dispatch rejects", async () => {
+		const {
+			ctx,
+			editor,
+			enqueueCustomMessageDisplay,
+			promptCustomMessage,
+			addMessageToChat,
+			removeQueuedCustomMessageDisplay,
+		} = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: true,
+			busyPromptMode: "steer",
+		});
+		promptCustomMessage.mockRejectedValueOnce(new Error("dispatch failed"));
+
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+		editor.setText("/skill:test-skill arg1 arg2");
+		await editor.onSubmit?.("/skill:test-skill arg1 arg2");
+
+		expect(enqueueCustomMessageDisplay).toHaveBeenCalledWith("/skill:test-skill arg1 arg2", "steer");
+		expect(promptCustomMessage).toHaveBeenCalledTimes(1);
+		expect(removeQueuedCustomMessageDisplay).toHaveBeenCalledWith("sk-test-0");
+		expect(ctx.updatePendingMessagesDisplay).toHaveBeenCalledTimes(1);
+		expect(ctx.ui.requestRender).toHaveBeenCalledTimes(1);
+		expect(addMessageToChat).not.toHaveBeenCalled();
+		expect(ctx.showError).toHaveBeenCalledWith("Failed to load skill: dispatch failed");
+	});
+
+	it("keeps already-rendered idle skill cards when a later non-final send fails", async () => {
+		const secondSkillPath = writeSkillFile(tempDir.path(), "second-skill", "Do the second thing.");
+		const thirdSkillPath = writeSkillFile(tempDir.path(), "third-skill", "Do the third thing.");
+		skillCommands.set("skill:second-skill", {
+			name: "second-skill",
+			description: "Second skill",
+			filePath: secondSkillPath,
+			baseDir: tempDir.path(),
+			source: "test",
+		});
+		skillCommands.set("skill:third-skill", {
+			name: "third-skill",
+			description: "Third skill",
+			filePath: thirdSkillPath,
+			baseDir: tempDir.path(),
+			source: "test",
+		});
+		const { ctx, editor, sendCustomMessage, promptCustomMessage, addMessageToChat } =
+			createStubInputControllerContext({
+				skillCommands,
+				isStreaming: false,
+			});
+		sendCustomMessage
+			.mockImplementationOnce(async (_message: { content: string; details: SkillPromptDetails }) => {})
+			.mockImplementationOnce(async (_message: { content: string; details: SkillPromptDetails }) => {
+				throw new Error("send failed");
+			});
+
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+		editor.setText("/skill:test-skill first /skill:second-skill second /skill:third-skill third");
+		await editor.onSubmit?.("/skill:test-skill first /skill:second-skill second /skill:third-skill third");
+
+		expect(sendCustomMessage).toHaveBeenCalledTimes(2);
+		expect(promptCustomMessage).not.toHaveBeenCalled();
+		expect(addMessageToChat).toHaveBeenCalledTimes(1);
+		const renderedMessage = addMessageToChat.mock.calls[0]?.[0];
+		if (!renderedMessage || !("content" in renderedMessage) || typeof renderedMessage.content !== "string") {
+			throw new Error("expected a rendered custom message with string content");
+		}
+		expect(renderedMessage.content).toContain("Do the thing.");
+		expect(renderedMessage.content).toContain("User: first");
+		expect(ctx.showError).toHaveBeenCalledWith("Failed to load skill: send failed");
 	});
 });
 


### PR DESCRIPTION
## Summary

When a user submits multiple chained `/skill:*` invocations in a single message (e.g. `/skill:a ... /skill:b ...`), all of them are parsed, loaded, and dispatched to the agent — but the TUI chat only rendered **one** `[skill] <name>` card (the last one). Every earlier skill loaded invisibly, so the user had no visual confirmation that more than one skill was actually applied.

This PR makes the TUI render **one `[skill] <name>` card per loaded skill, in source order**, without changing parsing, dispatch semantics, persistence, or ACP/headless behavior.

Before / after:

| | Before | After |
|---|---|---|
| `/skill:a first /skill:b second` (idle) | only `[skill] b` shown | `[skill] a` **and** `[skill] b`, in order |
| streaming / queued chains | unchanged | unchanged (still tag-driven) |

## Root cause

`parseSkillInvocations()` already returns every canonical invocation in source order, and both TUI dispatch loops already iterate over all of them. The gap is purely on the **display/event boundary**:

- In idle mode, every **non-final** skill is dispatched with `AgentSession.sendCustomMessage(...)` (no `triggerTurn`), which appends to agent/session state **without emitting the custom `message_start` event** that `EventController` uses to render a `[skill]` card.
- Only the **final** skill uses `promptCustomMessage(...)`, which routes through the prompt lifecycle and *does* emit `message_start`.

Net effect: the last skill produced a card; the rest were state-only appends with no renderer trigger.

## Approach

A minimal, **TUI-local render bridge** (chosen over a session-level event change to keep blast radius small):

- After a **non-final idle** `sendCustomMessage(...)` resolves successfully, build the same `CustomMessage<SkillPromptDetails>` and render it directly via `ctx.addMessageToChat(...)` + `ctx.ui.requestRender()`.
- The **final** skill is left untouched — it still renders through the existing `promptCustomMessage()` / `message_start` path, so there is **no duplicate card**.
- **Streaming / queued** skills are left untouched — they keep the existing pending-chip + `__pendingDisplayTag` dequeue mechanics.
- The same direct-render-after-success behavior is applied to the **compaction-queue** flush path (`UiHelpers.#deliverQueuedSkillMessage`) so replayed chains behave identically.

### Alternatives considered
- **Session-level append event for `sendCustomMessage()`** — rejected: much larger blast radius (persistence duplication risk in `#handleAgentEvent`, extension hook behavior, ACP/headless observers).
- **Aggregate multi-skill card** (`[skill] a + b`) — rejected: the desired UX is separate per-skill cards, and aggregation weakens per-skill args/source-order visibility and breaks the one-skill-per-`CustomMessage` model.
- **Transactional compaction-queue rollback** — deferred: out of scope; compaction flush stays intentionally best-effort/non-transactional.

## Changes

- **`modes/controllers/input-controller.ts`** — `#invokeSkillCommand` direct-renders successful non-final idle skill appends; wraps dispatch in `try/catch` so a rejected dispatch removes the queued pending-display chip (`removeQueuedCustomMessageDisplay`) before rethrowing.
- **`modes/utils/ui-helpers.ts`** — `#deliverQueuedSkillMessage` mirrors the same non-final direct-render behavior for compaction-queued chains, preserving the final `promptCustomMessage(...)` sequential follow-up policy.
- **`session/agent-session.ts`** — new `removeQueuedCustomMessageDisplay(tag)` that removes a queued custom message from the executable queues and the steering/follow-up display mirrors by its private `__pendingDisplayTag`, so a failed streaming dispatch cannot strand an orphan pending chip.
- **`test/input-controller-skill-queue.test.ts`** — new/extended focused regression tests.

## Behavior guarantees

- Idle multi-skill submissions show one card per loaded skill, in source order, each with its own args preview.
- Non-final cards render **only after** their `sendCustomMessage(...)` resolves.
- The final skill is **never** double-rendered.
- Streaming chains produce one pending chip per invocation with **distinct** `__pendingDisplayTag` values and no direct chat render; a rejected streaming dispatch cleans up its pending chip.
- Compaction-queued chains display successful non-final appends and remain **non-transactional** (a later failure does not roll back an already-rendered earlier card).
- Parser, skill discovery, `SkillPromptDetails` schema, `AgentSession.sendCustomMessage()` event/persistence semantics, active-skill HUD state, and ACP/headless dispatch are **unchanged**.

## Testing

Focused suites (all green):

```
bun test packages/coding-agent/test/input-controller-skill-queue.test.ts            # 24 pass
bun test packages/coding-agent/test/skills.test.ts \
         packages/coding-agent/test/input-controller-skill-queue.test.ts \
         packages/coding-agent/test/modes/components/skill-message-render.test.ts   # 63 pass
bun test packages/coding-agent/test/acp-agent.test.ts -t "skill commands"           # 4 pass, 44 filtered
bun --cwd=packages/coding-agent run check:types                                     # success
```

New test coverage:
- idle chained skills → first via `sendCustomMessage`, final via `promptCustomMessage`, exactly one direct-rendered non-final card, no final duplicate;
- streaming chained skills → distinct tags per invocation, no direct render;
- streaming dispatch rejection → pending-display chip removed, pending UI refreshed, error surfaced;
- compaction-queued chains → non-final direct render + final sequential prompt;
- compaction/idle later-send failure → earlier successful card preserved (non-transactional), error surfaced.

## Risk / scope

Low. Changes are confined to two TUI dispatch sites plus one additive `AgentSession` helper; no changes to the parser, persistence, ACP protocol, or streaming tag semantics.
