### PR TITLE
Document launch-time update contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ retry:
 
 ### Launch-time updates
 
-Interactive startup checks the npm registry for a newer GJC version in the background by default. This check is notify-only and non-mutating: GJC never installs or replaces itself during launch. Use `gjc update` explicitly when you want to install an update.
+Interactive startup checks the npm registry for a newer GJC version in the background by default. This check is notify-only and non-mutating: GJC never installs or replaces itself during launch. For a recognized Bun global install, use `gjc update` or `bun install -g @gajae-code/coding-agent@latest`. For a recognized Windows npm install, use `gjc update` or the original npm package workflow. For a supported standalone binary installed by the bundled installer, use `gjc update` or rerun the documented platform installer. For a source checkout or `dev:link` executable, update, pull, build, and link through that checkout's original workflow. For unrecognized npm, pnpm, other package-manager installs, or unknown PATH targets, use the original package manager or install method.
 
 Run `gjc config set startup.checkUpdate false` to disable the launch-time check. Registry or network failures are ignored so they do not block startup.
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,12 @@ retry:
 
 `requestMaxRetries` applies before a stream is established. `streamMaxRetries` applies only to replay-safe transient stream failures. Invalid auth, unsupported models/providers, malformed requests, context overflow, user aborts, and permanent quota failures remain fail-fast.
 
+### Launch-time updates
+
+Interactive startup checks the npm registry for a newer GJC version in the background by default. This check is notify-only and non-mutating: GJC never installs or replaces itself during launch. Use `gjc update` explicitly when you want to install an update.
+
+Run `gjc config set startup.checkUpdate false` to disable the launch-time check. Registry or network failures are ignored so they do not block startup.
+
 ### Good to read together
 
 - [GJC multivendor setup guide](https://github.com/project820/gjc-multivendor-setup-guide) — a community guide for role-based provider/profile selection across Anthropic, OpenAI/Codex, Google/Gemini, xAI/Grok, and opencode-go. Treat its presets as user-level configuration guidance rather than bundled defaults; verify model availability and provider auth in your own environment before adopting them.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 
 - Moved the `codex-eco`/`codex-medium`/`codex-pro` presets and the `opus-codex`/`codex-opencodego`/`fable-opus-codex` combo presets from `gpt-5.5` onto the GPT-5.6 tier family: Sol drives `default` and `architect` on every codex preset (eco `sol:medium`, medium `sol:high`, pro `sol:xhigh`/`sol:max`), with Luna/Terra covering the lighter executor/planner/critic roles by tier.
+- Documented that interactive startup update checks are notify-only and never install updates; `gjc update` remains the sole self-update mutation path.
 
 ## [0.9.5] - 2026-07-09
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,9 @@
 ### Changed
 
 - Moved the `codex-eco`/`codex-medium`/`codex-pro` presets and the `opus-codex`/`codex-opencodego`/`fable-opus-codex` combo presets from `gpt-5.5` onto the GPT-5.6 tier family: Sol drives `default` and `architect` on every codex preset (eco `sol:medium`, medium `sol:high`, pro `sol:xhigh`/`sol:max`), with Luna/Terra covering the lighter executor/planner/critic roles by tier.
-- Documented that interactive startup update checks are notify-only and never install updates; `gjc update` remains the sole self-update mutation path.
+### Fixed
+
+- Corrected launch-update guidance: only recognized Bun global installs, recognized Windows npm installs, and supported bundled-installer binaries may use `gjc update`; source checkouts and dev links must use their checkout workflow, while unrecognized package-manager or PATH installs must use their original update method. Successful updates require authoritative post-update version and smoke verification.
 
 ## [0.9.5] - 2026-07-09
 ### Fixed

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -45,7 +45,6 @@ export interface PackageManagerUpdateOptions {
 	expectedVersion: string;
 	runInstall: PackageManagerUpdateRunner;
 	verifyInstalledRuntime: (expectedVersion: string) => Promise<InstalledVersionVerification>;
-	printVerificationResult?: (expectedVersion: string) => Promise<void>;
 	printRecoveredVerification?: (expectedVersion: string) => void;
 }
 
@@ -122,8 +121,11 @@ function isPathInDirectory(filePath: string, directoryPath: string): boolean {
 	return isPathInDirectoryLexical(resolvedFile, dirReal);
 }
 
-type PackageManagerTarget = { manager: "npm"; packageName: string };
-type UpdateTarget = { method: "bun" } | { method: "npm"; packageName: string } | { method: "binary"; path: string };
+export type PackageManagerTarget = { manager: "npm"; packageName: string };
+export type UpdateTarget =
+	| { method: "bun" }
+	| { method: "npm"; packageName: string }
+	| { method: "binary"; path: string };
 
 type PathPlatform = NodeJS.Platform;
 type PackageExists = (packageName: string, packageRoot: string) => boolean;
@@ -423,19 +425,6 @@ export function formatVerificationFailureForTest(
 	return formatVerificationFailure(result, expectedVersion);
 }
 
-/**
- * Print post-update verification result.
- */
-async function printVerification(expectedVersion: string): Promise<void> {
-	const result = await verifyInstalledRuntime(expectedVersion);
-	if (result.ok) {
-		printSuccessfulVerification(expectedVersion);
-		return;
-	}
-	console.log(chalk.yellow(`\nWarning: ${formatVerificationFailure(result, expectedVersion)}`));
-	console.log(chalk.yellow(formatManualUpdateInstructions()));
-}
-
 async function unlinkIfExists(filePath: string): Promise<void> {
 	try {
 		await fs.promises.unlink(filePath);
@@ -499,6 +488,14 @@ function formatPackageManagerInstallFailure(
 	return `${managerName} install failed with exit code ${result.exitCode ?? "unknown"}${outputSuffix}. ${formatVerificationFailure(verification, expectedVersion)}`;
 }
 
+function formatPackageManagerVerificationFailure(
+	managerName: string,
+	verification: InstalledVersionVerification,
+	expectedVersion: string,
+): string {
+	return `${managerName} install exited successfully, but the selected ${APP_NAME} runtime failed verification: ${formatVerificationFailure(verification, expectedVersion)}`;
+}
+
 export async function runPackageManagerUpdateForTest(
 	options: PackageManagerUpdateOptions,
 ): Promise<InstalledVersionVerification> {
@@ -508,8 +505,14 @@ export async function runPackageManagerUpdateForTest(
 async function updateViaPackageManager(options: PackageManagerUpdateOptions): Promise<InstalledVersionVerification> {
 	const result = await options.runInstall(options.expectedVersion);
 	if (result.exitCode === 0) {
-		await (options.printVerificationResult ?? printVerification)(options.expectedVersion);
-		return await options.verifyInstalledRuntime(options.expectedVersion);
+		const verification = await options.verifyInstalledRuntime(options.expectedVersion);
+		if (!verification.ok) {
+			throw new Error(
+				formatPackageManagerVerificationFailure(options.managerName, verification, options.expectedVersion),
+			);
+		}
+		printSuccessfulVerification(options.expectedVersion);
+		return verification;
 	}
 
 	const verification = await options.verifyInstalledRuntime(options.expectedVersion);
@@ -661,16 +664,42 @@ async function updateViaBinaryAt(targetPath: string, expectedVersion: string): P
 /**
  * Run the update command.
  */
-export async function runUpdateCommand(opts: { force: boolean; check: boolean }): Promise<void> {
+export interface UpdateCommandDependencies {
+	getLatestRelease?: () => Promise<ReleaseInfo>;
+	resolveUpdateTarget?: () => Promise<UpdateTarget>;
+	performUpdate?: (target: UpdateTarget, expectedVersion: string) => Promise<void>;
+	refreshInstalledDefaultSkills?: () => Promise<void>;
+	exit?: (code: number) => never;
+}
+
+async function performUpdate(target: UpdateTarget, expectedVersion: string): Promise<void> {
+	if (target.method === "bun") {
+		await updateViaBun(expectedVersion);
+	} else if (target.method === "npm") {
+		await updateViaNpm(target.packageName, expectedVersion);
+	} else {
+		await updateViaBinaryAt(target.path, expectedVersion);
+	}
+}
+
+export async function runUpdateCommand(
+	opts: { force: boolean; check: boolean },
+	deps: UpdateCommandDependencies = {},
+): Promise<void> {
+	const lookupRelease = deps.getLatestRelease ?? getLatestRelease;
+	const resolveTarget = deps.resolveUpdateTarget ?? resolveUpdateTarget;
+	const update = deps.performUpdate ?? performUpdate;
+	const refreshDefaults = deps.refreshInstalledDefaultSkills ?? refreshInstalledDefaultSkills;
+	const exit = deps.exit ?? process.exit;
+
 	console.log(chalk.dim(`Current version: ${VERSION}`));
 
-	// Check for updates
 	let release: ReleaseInfo;
 	try {
-		release = await getLatestRelease();
+		release = await lookupRelease();
 	} catch (err) {
 		console.error(chalk.red(`Failed to check for updates: ${err}`));
-		process.exit(1);
+		return exit(1);
 	}
 
 	const comparison = compareVersions(release.version, VERSION);
@@ -686,27 +715,17 @@ export async function runUpdateCommand(opts: { force: boolean; check: boolean })
 		console.log(chalk.yellow(`Forcing reinstall of ${release.version}`));
 	}
 
-	if (opts.check) {
-		// Just check, don't install
-		return;
-	}
+	if (opts.check) return;
 
-	// Choose update method based on the prioritized gjc binary in PATH
 	try {
-		const target = await resolveUpdateTarget();
-		if (target.method === "bun") {
-			await updateViaBun(release.version);
-		} else if (target.method === "npm") {
-			await updateViaNpm(target.packageName, release.version);
-		} else {
-			await updateViaBinaryAt(target.path, release.version);
-		}
+		const target = await resolveTarget();
+		await update(target, release.version);
 	} catch (err) {
 		console.error(chalk.red(`Update failed: ${err}`));
-		process.exit(1);
+		return exit(1);
 	}
 
-	await refreshInstalledDefaultSkills();
+	await refreshDefaults();
 }
 
 /**

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1224,7 +1224,8 @@ export const SETTINGS_SCHEMA = {
 		ui: {
 			tab: "interaction",
 			label: "Check for Updates",
-			description: "If false, skip update check",
+			description:
+				"Check for newer versions at interactive startup and show a notification. Startup never installs updates; run `gjc update` explicitly. If false, skip the check.",
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1225,7 +1225,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "interaction",
 			label: "Check for Updates",
 			description:
-				"Check for newer versions at interactive startup and show a notification. Startup never installs updates; run `gjc update` explicitly. If false, skip the check.",
+				"At interactive startup, notify of newer versions; never install. Use `gjc update` only for recognized Bun global, Windows npm, or bundled-installer binaries; source, linked, and unrecognized installs use their original method.",
 		},
 	},
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -35,6 +35,7 @@ import { initializeWithSettings } from "./discovery";
 import { exportFromFile } from "./export/html";
 import type { ExtensionUIContext } from "./extensibility/extensions/types";
 import type { InteractiveMode } from "./modes/interactive-mode";
+import type { PrintModeOptions } from "./modes/print-mode";
 import { initTheme, stopThemeWatcher } from "./modes/theme/theme";
 import type { SubmittedUserInput } from "./modes/types";
 import { applyCliRuntimeApiKeyOverride } from "./runtime-api-key";
@@ -59,9 +60,6 @@ import { getDisplayChangelogEntries, getInstalledVersionChangelogEntry, getNewEn
 import type { EventBus } from "./utils/event-bus";
 
 async function checkForNewVersion(currentVersion: string): Promise<string | undefined> {
-	if (!settings.get("startup.checkUpdate")) {
-		return;
-	}
 	try {
 		const response = await fetch("https://registry.npmjs.org/@gajae-code/coding-agent/latest");
 		if (!response.ok) return undefined;
@@ -77,6 +75,69 @@ async function checkForNewVersion(currentVersion: string): Promise<string | unde
 	} catch {
 		return undefined;
 	}
+}
+
+export type StartupUpdateRoute = "interactive" | "print" | "text" | "json" | "rpc" | "rpc-ui" | "acp" | "bridge";
+
+export function classifyStartupUpdateRoute(
+	parsed: Pick<Args, "print" | "mode">,
+	autoPrint: boolean,
+): StartupUpdateRoute {
+	if (!parsed.print && !autoPrint && parsed.mode === undefined) {
+		return "interactive";
+	}
+	if (parsed.print) {
+		return "print";
+	}
+	return parsed.mode ?? "text";
+}
+
+/** Coordinates the non-blocking update check around the interactive UI lifecycle. */
+export class StartupUpdateOrchestrator {
+	#versionCheckPromise: Promise<string | undefined> | undefined;
+	readonly #route: StartupUpdateRoute;
+	readonly #enabled: () => boolean;
+	readonly #check: () => Promise<string | undefined>;
+
+	constructor(route: StartupUpdateRoute, enabled: () => boolean, check: () => Promise<string | undefined>) {
+		this.#route = route;
+		this.#enabled = enabled;
+		this.#check = check;
+	}
+
+	startBeforeInteractiveInitialization(): void {
+		if (this.#route !== "interactive" || !this.#enabled() || this.#versionCheckPromise) {
+			return;
+		}
+		try {
+			this.#versionCheckPromise = this.#check().catch(() => undefined);
+		} catch {
+			this.#versionCheckPromise = Promise.resolve(undefined);
+		}
+	}
+
+	attachAfterInteractiveInitialization(notify: (version: string) => void): void {
+		this.#versionCheckPromise
+			?.then(version => {
+				if (version && this.#enabled()) {
+					notify(version);
+				}
+			})
+			.catch(() => {});
+	}
+}
+
+export interface StartupUpdateInteractiveMode {
+	init: () => Promise<void>;
+	showNewVersionNotification: (version: string) => void;
+}
+
+export async function initializeInteractiveModeWithStartupUpdate(
+	mode: StartupUpdateInteractiveMode,
+	startupUpdate: StartupUpdateOrchestrator,
+): Promise<void> {
+	await mode.init();
+	startupUpdate.attachAfterInteractiveInitialization(version => mode.showNewVersionNotification(version));
 }
 
 const RPC_DEFAULTED_SETTING_PATHS: SettingPath[] = [
@@ -313,12 +374,24 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 	};
 }
 
-async function runInteractiveMode(
+interface InteractiveModeFactoryOptions {
+	session: AgentSession;
+	version: string;
+	changelogMarkdown: string | undefined;
+	setExtensionUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void;
+	lspServers: LspStartupServerInfo[] | undefined;
+	mcpManager: MCPManager | undefined;
+	eventBus?: EventBus;
+}
+
+type CreateInteractiveMode = (options: InteractiveModeFactoryOptions) => InteractiveMode;
+
+export async function runInteractiveMode(
 	session: AgentSession,
 	version: string,
 	changelogMarkdown: string | undefined,
 	notifs: (InteractiveModeNotify | null)[],
-	versionCheckPromise: Promise<string | undefined>,
+	startupUpdate: StartupUpdateOrchestrator,
 	initialMessages: string[],
 	setExtensionUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void,
 	lspServers: LspStartupServerInfo[] | undefined,
@@ -326,30 +399,29 @@ async function runInteractiveMode(
 	eventBus?: EventBus,
 	initialMessage?: string,
 	initialImages?: ImageContent[],
+	createInteractiveMode?: CreateInteractiveMode,
 ): Promise<void> {
-	const { InteractiveMode } = await import("./modes/interactive-mode");
-	const mode = new InteractiveMode(
-		session,
-		version,
-		changelogMarkdown,
-		setExtensionUIContext,
-		lspServers,
-		mcpManager,
-		eventBus,
-	);
+	const mode = createInteractiveMode
+		? createInteractiveMode({
+				session,
+				version,
+				changelogMarkdown,
+				setExtensionUIContext,
+				lspServers,
+				mcpManager,
+				eventBus,
+			})
+		: new (await import("./modes/interactive-mode")).InteractiveMode(
+				session,
+				version,
+				changelogMarkdown,
+				setExtensionUIContext,
+				lspServers,
+				mcpManager,
+				eventBus,
+			);
 
-	await mode.init();
-
-	versionCheckPromise
-		.then(newVersion => {
-			if (!settings.get("startup.checkUpdate")) {
-				return;
-			}
-			if (newVersion) {
-				mode.showNewVersionNotification(newVersion);
-			}
-		})
-		.catch(() => {});
+	await initializeInteractiveModeWithStartupUpdate(mode, startupUpdate);
 
 	mode.renderInitialMessages(undefined, { preserveExistingChat: true });
 
@@ -746,13 +818,33 @@ export interface RlmPreset {
 	onSessionCreated?: (session: AgentSession) => void | Promise<void>;
 }
 
-interface RunRootCommandDependencies {
+type RunRpcMode = (
+	session: AgentSession,
+	setToolUIContext?: CreateAgentSessionResult["setToolUIContext"],
+	options?: { listen?: string },
+) => Promise<void>;
+type RunBridgeMode = (
+	session: AgentSession,
+	setToolUIContext?: CreateAgentSessionResult["setToolUIContext"],
+) => Promise<void>;
+type RunPrintMode = (session: AgentSession, options: PrintModeOptions) => Promise<void>;
+
+export interface RunRootCommandDependencies {
 	createAgentSession?: typeof createAgentSession;
 	discoverAuthStorage?: typeof discoverAuthStorage;
 	runAcpMode?: (createSession: AcpSessionFactory) => Promise<void>;
 	settings?: Settings;
 	rlmPreset?: RlmPreset;
 	suppressProcessExit?: boolean;
+	startupUpdate?: { check: () => Promise<string | undefined> };
+	initTheme?: typeof initTheme;
+	readPipedInput?: typeof readPipedInput;
+	runStartupCredentialAutoImportIfNeeded?: typeof runStartupCredentialAutoImportIfNeeded;
+	getChangelogForDisplay?: typeof getChangelogForDisplay;
+	runRpcMode?: RunRpcMode;
+	runBridgeMode?: RunBridgeMode;
+	createInteractiveMode?: CreateInteractiveMode;
+	runPrintMode?: RunPrintMode;
 }
 
 export async function runRootCommand(
@@ -764,7 +856,7 @@ export async function runRootCommand(
 
 	// Initialize theme early with defaults (CLI commands need symbols)
 	// Will be re-initialized with user preferences later
-	await logger.time("initTheme:initial", initTheme);
+	await logger.time("initTheme:initial", deps.initTheme ?? initTheme);
 
 	const parsedArgs = parsed;
 	await logger.time("maybeAutoChdir", maybeAutoChdir, parsedArgs);
@@ -843,7 +935,7 @@ export async function runRootCommand(
 		Bun.env.PI_NO_TITLE = "1";
 	}
 	const { pipedInput, fileText, fileImages } = await logger.time("prepareInitialMessage", async () => {
-		const pipedInput = await readPipedInput();
+		const pipedInput = await (deps.readPipedInput ?? readPipedInput)();
 		if (parsedArgs.fileArgs.length === 0) {
 			return { pipedInput, fileText: undefined, fileImages: undefined };
 		}
@@ -859,7 +951,13 @@ export async function runRootCommand(
 		stdinContent: pipedInput,
 	});
 	const autoPrint = pipedInput !== undefined && !parsedArgs.print && parsedArgs.mode === undefined;
-	const isInteractive = !parsedArgs.print && !autoPrint && parsedArgs.mode === undefined;
+	const startupUpdateRoute = classifyStartupUpdateRoute(parsedArgs, autoPrint);
+	const startupUpdate = new StartupUpdateOrchestrator(
+		startupUpdateRoute,
+		() => settingsInstance.get("startup.checkUpdate"),
+		deps.startupUpdate?.check ?? (() => checkForNewVersion(VERSION)),
+	);
+	const isInteractive = startupUpdateRoute === "interactive";
 	const mode = parsedArgs.mode || "text";
 
 	// Initialize discovery system with settings for provider persistence
@@ -879,7 +977,7 @@ export async function runRootCommand(
 
 	await logger.time(
 		"initTheme:final",
-		initTheme,
+		deps.initTheme ?? initTheme,
 		isInteractive,
 		settingsInstance.get("symbolPreset"),
 		settingsInstance.get("colorBlindMode"),
@@ -888,11 +986,15 @@ export async function runRootCommand(
 	);
 
 	const credentialAutoImportNotice = isInteractive
-		? await logger.time("credentialAutoImport", runStartupCredentialAutoImportIfNeeded, {
-				authStorage,
-				modelRegistry,
-				agentDir: settingsInstance.getAgentDir(),
-			})
+		? await logger.time(
+				"credentialAutoImport",
+				deps.runStartupCredentialAutoImportIfNeeded ?? runStartupCredentialAutoImportIfNeeded,
+				{
+					authStorage,
+					modelRegistry,
+					agentDir: settingsInstance.getAgentDir(),
+				},
+			)
 		: undefined;
 
 	let scopedModels: ScopedModel[] = [];
@@ -1114,8 +1216,9 @@ export async function runRootCommand(
 
 		if (mode === "rpc" || mode === "rpc-ui") {
 			const { RpcListenRefusedError, runRpcMode } = await import("./modes/rpc/rpc-mode");
+			const runRpc = deps.runRpcMode ?? runRpcMode;
 			try {
-				await runRpcMode(session, mode === "rpc-ui" ? setToolUIContext : undefined, {
+				await runRpc(session, mode === "rpc-ui" ? setToolUIContext : undefined, {
 					listen: parsedArgs.rpcListen,
 				});
 			} catch (error) {
@@ -1128,11 +1231,15 @@ export async function runRootCommand(
 				process.exit(1);
 			}
 		} else if (mode === "bridge") {
-			const { runBridgeMode } = await import("./modes/bridge/bridge-mode");
-			await runBridgeMode(session, setToolUIContext);
+			const runBridge = deps.runBridgeMode ?? (await import("./modes/bridge/bridge-mode")).runBridgeMode;
+			await runBridge(session, setToolUIContext);
 		} else if (isInteractive) {
-			const versionCheckPromise = checkForNewVersion(VERSION).catch(() => undefined);
-			const changelogMarkdown = await logger.time("main:getChangelogForDisplay", getChangelogForDisplay, parsedArgs);
+			startupUpdate.startBeforeInteractiveInitialization();
+			const changelogMarkdown = await logger.time(
+				"main:getChangelogForDisplay",
+				deps.getChangelogForDisplay ?? getChangelogForDisplay,
+				parsedArgs,
+			);
 
 			const scopedModelsForDisplay = sessionOptions.scopedModels ?? scopedModels;
 			if (scopedModelsForDisplay.length > 0) {
@@ -1158,7 +1265,7 @@ export async function runRootCommand(
 				VERSION,
 				changelogMarkdown,
 				notifs,
-				versionCheckPromise,
+				startupUpdate,
 				parsedArgs.messages,
 				setToolUIContext,
 				lspServers,
@@ -1166,10 +1273,11 @@ export async function runRootCommand(
 				eventBus,
 				initialMessage,
 				initialImages,
+				deps.createInteractiveMode,
 			);
 		} else {
-			const { runPrintMode } = await import("./modes/print-mode");
-			await runPrintMode(session, {
+			const runPrint = deps.runPrintMode ?? (await import("./modes/print-mode")).runPrintMode;
+			await runPrint(session, {
 				mode,
 				messages: parsedArgs.messages,
 				initialMessage,

--- a/packages/coding-agent/test/startup-update-contract.test.ts
+++ b/packages/coding-agent/test/startup-update-contract.test.ts
@@ -1,14 +1,409 @@
 import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { getBundledModel } from "@gajae-code/ai";
+import { TempDir } from "@gajae-code/utils";
+import type { Args } from "../src/cli/args";
+import { Settings } from "../src/config/settings";
 import { SETTINGS_SCHEMA } from "../src/config/settings-schema";
+import {
+	classifyStartupUpdateRoute,
+	initializeInteractiveModeWithStartupUpdate,
+	runRootCommand,
+	StartupUpdateOrchestrator,
+	type StartupUpdateRoute,
+} from "../src/main";
+import type { InteractiveMode } from "../src/modes/interactive-mode";
+import type { CreateAgentSessionResult } from "../src/sdk";
+import type { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+import { EventBus } from "../src/utils/event-bus";
+
+const alternateRoutes: Array<{
+	name: StartupUpdateRoute;
+	parsed: { print?: boolean; mode?: "text" | "json" | "rpc" | "rpc-ui" | "acp" | "bridge" };
+	autoPrint: boolean;
+}> = [
+	{ name: "print", parsed: { print: true }, autoPrint: false },
+	{ name: "text", parsed: { mode: "text" }, autoPrint: false },
+	{ name: "json", parsed: { mode: "json" }, autoPrint: false },
+	{ name: "rpc", parsed: { mode: "rpc" }, autoPrint: false },
+	{ name: "rpc-ui", parsed: { mode: "rpc-ui" }, autoPrint: false },
+	{ name: "acp", parsed: { mode: "acp" }, autoPrint: false },
+	{ name: "bridge", parsed: { mode: "bridge" }, autoPrint: false },
+	{ name: "text", parsed: {}, autoPrint: true },
+];
+
+const testModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+if (!testModel) throw new Error("Expected bundled test model");
+
+function rootArgs(overrides: Partial<Args> = {}): Args {
+	return {
+		messages: [],
+		fileArgs: [],
+		unknownFlags: new Map(),
+		noSession: true,
+		noSkills: true,
+		noRules: true,
+		noTools: true,
+		noLsp: true,
+		...overrides,
+	};
+}
+
+function fakeSessionResult(): CreateAgentSessionResult {
+	const session = {
+		model: testModel,
+		extensionRunner: undefined,
+		dispose: async () => {},
+	} as unknown as AgentSession;
+	return {
+		session,
+		extensionsResult: {},
+		setToolUIContext: () => {},
+		eventBus: new EventBus(),
+	} as unknown as CreateAgentSessionResult;
+}
 
 describe("startup update contract", () => {
-	it("keeps launch-time checks notify-only and explicit updates opt-in", () => {
+	it("keeps the concise startup-check metadata accurate", () => {
 		const setting = SETTINGS_SCHEMA["startup.checkUpdate"];
 
 		expect(setting.default).toBe(true);
-		expect(setting.ui.description).toContain("show a notification");
-		expect(setting.ui.description).toContain("Startup never installs updates");
-		expect(setting.ui.description).toContain("run `gjc update` explicitly");
-		expect(setting.ui.description).toContain("If false, skip the check");
+		expect(setting.ui.description).toContain("At interactive startup, notify");
+		expect(setting.ui.description).toContain("never install");
+		expect(setting.ui.description).toContain("Use `gjc update` only");
+		expect(setting.ui.description).toContain("source, linked, and unrecognized installs use their original method");
+	});
+
+	it("classifies every noninteractive launch route and starts no checker for them", () => {
+		for (const { name, parsed, autoPrint } of alternateRoutes) {
+			let checks = 0;
+			let notifications = 0;
+			expect(classifyStartupUpdateRoute(parsed, autoPrint)).toBe(name);
+
+			const startupUpdate = new StartupUpdateOrchestrator(
+				classifyStartupUpdateRoute(parsed, autoPrint),
+				() => true,
+				async () => {
+					checks++;
+					return "999.0.0";
+				},
+			);
+			startupUpdate.startBeforeInteractiveInitialization();
+			startupUpdate.attachAfterInteractiveInitialization(() => notifications++);
+
+			expect(checks).toBe(0);
+			expect(notifications).toBe(0);
+		}
+	});
+
+	it("does not check or notify when interactive startup checking is disabled", () => {
+		let checks = 0;
+		let notifications = 0;
+		const startupUpdate = new StartupUpdateOrchestrator(
+			"interactive",
+			() => false,
+			async () => {
+				checks++;
+				return "999.0.0";
+			},
+		);
+
+		startupUpdate.startBeforeInteractiveInitialization();
+		startupUpdate.attachAfterInteractiveInitialization(() => notifications++);
+
+		expect(checks).toBe(0);
+		expect(notifications).toBe(0);
+	});
+
+	it("reaches real mode initialization while the interactive check remains pending", async () => {
+		expect(classifyStartupUpdateRoute({}, false)).toBe("interactive");
+		const versionCheck = Promise.withResolvers<string | undefined>();
+		const initReached = Promise.withResolvers<void>();
+		const releaseInit = Promise.withResolvers<void>();
+		const events: string[] = [];
+		const startupUpdate = new StartupUpdateOrchestrator(
+			"interactive",
+			() => true,
+			async () => {
+				events.push("check-start");
+				return await versionCheck.promise;
+			},
+		);
+		const mode = {
+			init: async () => {
+				events.push("mode-init");
+				initReached.resolve();
+				await releaseInit.promise;
+			},
+			showNewVersionNotification: (version: string) => {
+				events.push(`notify:${version}`);
+			},
+		};
+
+		startupUpdate.startBeforeInteractiveInitialization();
+		const initialized = initializeInteractiveModeWithStartupUpdate(mode, startupUpdate);
+		await initReached.promise;
+		expect(events).toEqual(["check-start", "mode-init"]);
+
+		releaseInit.resolve();
+		await initialized;
+		expect(events).toEqual(["check-start", "mode-init"]);
+
+		const notified = Promise.withResolvers<void>();
+		mode.showNewVersionNotification = version => {
+			events.push(`notify:${version}`);
+			notified.resolve();
+		};
+		versionCheck.resolve("999.0.0");
+		await notified.promise;
+		expect(events).toEqual(["check-start", "mode-init", "notify:999.0.0"]);
+	});
+
+	it("does not attach notification delivery until real mode initialization completes", async () => {
+		const versionCheck = Promise.withResolvers<string | undefined>();
+		const releaseInit = Promise.withResolvers<void>();
+		const notified = Promise.withResolvers<void>();
+		const events: string[] = [];
+		const startupUpdate = new StartupUpdateOrchestrator(
+			"interactive",
+			() => true,
+			() => versionCheck.promise,
+		);
+		const mode = {
+			init: async () => {
+				events.push("mode-init");
+				await releaseInit.promise;
+			},
+			showNewVersionNotification: (version: string) => {
+				events.push(`notify:${version}`);
+				notified.resolve();
+			},
+		};
+
+		startupUpdate.startBeforeInteractiveInitialization();
+		const initialized = initializeInteractiveModeWithStartupUpdate(mode, startupUpdate);
+		versionCheck.resolve("999.0.0");
+		await Promise.resolve();
+		expect(events).toEqual(["mode-init"]);
+
+		releaseInit.resolve();
+		await initialized;
+		await notified.promise;
+		expect(events).toEqual(["mode-init", "notify:999.0.0"]);
+	});
+
+	it("consumes rejected checks without blocking real initialization or notifying", async () => {
+		const deferred = Promise.withResolvers<string | undefined>();
+		let initialized = false;
+		let notifications = 0;
+		const startupUpdate = new StartupUpdateOrchestrator(
+			"interactive",
+			() => true,
+			async () => await deferred.promise,
+		);
+		const mode = {
+			init: async () => {
+				initialized = true;
+			},
+			showNewVersionNotification: () => {
+				notifications += 1;
+			},
+		};
+
+		startupUpdate.startBeforeInteractiveInitialization();
+		await initializeInteractiveModeWithStartupUpdate(mode, startupUpdate);
+		expect(initialized).toBe(true);
+
+		deferred.reject(new Error("registry unavailable"));
+		await Bun.sleep(0);
+		expect(notifications).toBe(0);
+	});
+
+	it("routes every noninteractive launch through runRootCommand without starting the checker", async () => {
+		const cases: Array<{
+			name: string;
+			args: Partial<Args>;
+			pipedInput?: string;
+			expectedRunner: "acp" | "bridge" | "print" | "rpc";
+		}> = [
+			{ name: "print", args: { print: true }, expectedRunner: "print" },
+			{ name: "text", args: { mode: "text" }, expectedRunner: "print" },
+			{ name: "json", args: { mode: "json" }, expectedRunner: "print" },
+			{ name: "rpc", args: { mode: "rpc" }, expectedRunner: "rpc" },
+			{ name: "rpc-ui", args: { mode: "rpc-ui" }, expectedRunner: "rpc" },
+			{ name: "acp", args: { mode: "acp" }, expectedRunner: "acp" },
+			{ name: "bridge", args: { mode: "bridge" }, expectedRunner: "bridge" },
+			{ name: "auto-print", args: {}, pipedInput: "piped prompt", expectedRunner: "print" },
+		];
+
+		for (const testCase of cases) {
+			using tempDir = TempDir.createSync("@gjc-startup-route-");
+			const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+			const originalNoTitle = Bun.env.PI_NO_TITLE;
+			let checks = 0;
+			const runners: string[] = [];
+			try {
+				await runRootCommand(rootArgs(testCase.args), [], {
+					createAgentSession: async () => fakeSessionResult(),
+					discoverAuthStorage: async () => authStorage,
+					settings: Settings.isolated({ "marketplace.autoUpdate": "off", "startup.checkUpdate": true }),
+					suppressProcessExit: true,
+					startupUpdate: {
+						check: async () => {
+							checks += 1;
+							return "999.0.0";
+						},
+					},
+					initTheme: async () => {},
+					readPipedInput: async () => testCase.pipedInput,
+					runStartupCredentialAutoImportIfNeeded: async () => undefined,
+					runAcpMode: async () => {
+						runners.push("acp");
+					},
+					runRpcMode: async () => {
+						runners.push("rpc");
+					},
+					runBridgeMode: async () => {
+						runners.push("bridge");
+					},
+					runPrintMode: async () => {
+						runners.push("print");
+					},
+				});
+				expect(checks, testCase.name).toBe(0);
+				expect(runners, testCase.name).toEqual([testCase.expectedRunner]);
+			} finally {
+				authStorage.close();
+				if (originalNoTitle === undefined) delete Bun.env.PI_NO_TITLE;
+				else Bun.env.PI_NO_TITLE = originalNoTitle;
+			}
+		}
+	}, 30_000);
+
+	it("runs the real root and interactive-mode path without awaiting the version check", async () => {
+		using tempDir = TempDir.createSync("@gjc-startup-interactive-");
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const versionCheck = Promise.withResolvers<string | undefined>();
+		const changelogReached = Promise.withResolvers<void>();
+		const releaseChangelog = Promise.withResolvers<void>();
+		const initReached = Promise.withResolvers<void>();
+		const releaseInit = Promise.withResolvers<void>();
+		const notified = Promise.withResolvers<void>();
+		const stop = new Error("stop interactive harness");
+		const events: string[] = [];
+		try {
+			const root = runRootCommand(rootArgs(), [], {
+				createAgentSession: async () => fakeSessionResult(),
+				discoverAuthStorage: async () => authStorage,
+				settings: Settings.isolated({ "marketplace.autoUpdate": "off", "startup.checkUpdate": true }),
+				startupUpdate: {
+					check: async () => {
+						events.push("check-start");
+						return await versionCheck.promise;
+					},
+				},
+				initTheme: async () => {},
+				readPipedInput: async () => undefined,
+				runStartupCredentialAutoImportIfNeeded: async () => undefined,
+				getChangelogForDisplay: async () => {
+					events.push("changelog-start");
+					changelogReached.resolve();
+					await releaseChangelog.promise;
+					return undefined;
+				},
+				createInteractiveMode: () =>
+					({
+						init: async () => {
+							events.push("mode-init");
+							initReached.resolve();
+							await releaseInit.promise;
+						},
+						showNewVersionNotification: (version: string) => {
+							events.push(`notify:${version}`);
+							notified.resolve();
+						},
+						renderInitialMessages: () => {},
+						getUserInput: async () => {
+							events.push("user-input");
+							throw stop;
+						},
+					}) as unknown as InteractiveMode,
+			});
+
+			await changelogReached.promise;
+			expect(events).toEqual(["check-start", "changelog-start"]);
+			releaseChangelog.resolve();
+			await initReached.promise;
+			versionCheck.resolve("999.0.0");
+			await Bun.sleep(0);
+			expect(events).toEqual(["check-start", "changelog-start", "mode-init"]);
+
+			releaseInit.resolve();
+			await expect(root).rejects.toBe(stop);
+			await notified.promise;
+			expect(events).toEqual(["check-start", "changelog-start", "mode-init", "notify:999.0.0", "user-input"]);
+		} finally {
+			authStorage.close();
+		}
+	}, 15_000);
+
+	it("keeps real interactive startup disabled and rejected checks non-blocking", async () => {
+		for (const testCase of [
+			{ enabled: false, check: async () => "999.0.0" },
+			{ enabled: true, check: async () => await Promise.reject(new Error("registry unavailable")) },
+		]) {
+			using tempDir = TempDir.createSync("@gjc-startup-disabled-");
+			const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+			const stop = new Error("stop interactive harness");
+			let checks = 0;
+			let notifications = 0;
+			try {
+				await expect(
+					runRootCommand(rootArgs(), [], {
+						createAgentSession: async () => fakeSessionResult(),
+						discoverAuthStorage: async () => authStorage,
+						settings: Settings.isolated({
+							"marketplace.autoUpdate": "off",
+							"startup.checkUpdate": testCase.enabled,
+						}),
+						startupUpdate: {
+							check: async () => {
+								checks += 1;
+								return await testCase.check();
+							},
+						},
+						initTheme: async () => {},
+						readPipedInput: async () => undefined,
+						runStartupCredentialAutoImportIfNeeded: async () => undefined,
+						getChangelogForDisplay: async () => undefined,
+						createInteractiveMode: () =>
+							({
+								init: async () => {},
+								showNewVersionNotification: () => {
+									notifications += 1;
+								},
+								renderInitialMessages: () => {},
+								getUserInput: async () => {
+									throw stop;
+								},
+							}) as unknown as InteractiveMode,
+					}),
+				).rejects.toBe(stop);
+				await Bun.sleep(0);
+				expect(checks).toBe(testCase.enabled ? 1 : 0);
+				expect(notifications).toBe(0);
+			} finally {
+				authStorage.close();
+			}
+		}
+	}, 15_000);
+	it("keeps updater and default-installer APIs outside startup wiring", async () => {
+		const source = await Bun.file(new URL("../src/main.ts", import.meta.url)).text();
+
+		expect(source).not.toMatch(/["']\.\/cli\/update-cli["']/);
+		expect(source).not.toMatch(/["']\.\/defaults\/gjc-defaults["']/);
+		expect(source).toContain("startupUpdate.startBeforeInteractiveInitialization()");
+		expect(source).toContain("startupUpdate.attachAfterInteractiveInitialization");
 	});
 });

--- a/packages/coding-agent/test/startup-update-contract.test.ts
+++ b/packages/coding-agent/test/startup-update-contract.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { SETTINGS_SCHEMA } from "../src/config/settings-schema";
+
+describe("startup update contract", () => {
+	it("keeps launch-time checks notify-only and explicit updates opt-in", () => {
+		const setting = SETTINGS_SCHEMA["startup.checkUpdate"];
+
+		expect(setting.default).toBe(true);
+		expect(setting.ui.description).toContain("show a notification");
+		expect(setting.ui.description).toContain("Startup never installs updates");
+		expect(setting.ui.description).toContain("run `gjc update` explicitly");
+		expect(setting.ui.description).toContain("If false, skip the check");
+	});
+});

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -15,7 +15,9 @@ import {
 	resolveUpdateMethodForTest,
 	runBinaryUpdateFlow,
 	runPackageManagerUpdateForTest,
+	runUpdateCommand,
 } from "../src/cli/update-cli";
+import { initTheme } from "../src/modes/theme/theme";
 
 const tempDirs: string[] = [];
 const repoRoot = path.resolve(import.meta.dir, "../../..");
@@ -207,6 +209,60 @@ describe("update-cli package-manager verification", () => {
 		}
 	});
 
+	it("verifies a zero-exit install once and prints success and restart guidance once", async () => {
+		await initTheme();
+		const output: string[] = [];
+		const logSpy = vi.spyOn(console, "log").mockImplementation(message => {
+			output.push(String(message));
+		});
+		let verificationCalls = 0;
+		try {
+			const result = await runPackageManagerUpdateForTest({
+				managerName: "bun",
+				expectedVersion: "0.7.8",
+				runInstall: async () => ({ exitCode: 0, text: () => "installed" }),
+				verifyInstalledRuntime: async expectedVersion => {
+					verificationCalls += 1;
+					return { ok: true, actual: expectedVersion, path: "/Users/test/.bun/bin/gjc" };
+				},
+			});
+
+			expect(result.ok).toBe(true);
+			expect(verificationCalls).toBe(1);
+			expect(output.filter(line => line.includes("Updated to 0.7.8"))).toHaveLength(1);
+			expect(output.filter(line => line.includes("Restart gjc to use the new version"))).toHaveLength(1);
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it("rejects a zero-exit stale install with verification-specific diagnostics and no success output", async () => {
+		const output: string[] = [];
+		const logSpy = vi.spyOn(console, "log").mockImplementation(message => {
+			output.push(String(message));
+		});
+		let verificationCalls = 0;
+		try {
+			await expect(
+				runPackageManagerUpdateForTest({
+					managerName: "bun",
+					expectedVersion: "0.7.8",
+					runInstall: async () => ({ exitCode: 0, text: () => "installed" }),
+					verifyInstalledRuntime: async () => {
+						verificationCalls += 1;
+						return { ok: false, actual: "0.7.7", path: "/Users/test/.bun/bin/gjc" };
+					},
+				}),
+			).rejects.toThrow("bun install exited successfully, but the selected gjc runtime failed verification");
+			expect(verificationCalls).toBe(1);
+			expect(output.join("\n")).not.toContain("install failed with exit code 0");
+			expect(output.filter(line => line.includes("Updated to"))).toHaveLength(0);
+			expect(output.filter(line => line.includes("Restart gjc"))).toHaveLength(0);
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
 	it("keeps package-manager nonzero failures hard when runtime verification does not prove the update landed", async () => {
 		await expect(
 			runPackageManagerUpdateForTest({
@@ -223,6 +279,127 @@ describe("update-cli package-manager verification", () => {
 				}),
 			}),
 		).rejects.toThrow("Fail extracting tarball");
+	});
+});
+
+describe("update-cli command verification failures", () => {
+	it("exits without refreshing defaults when a zero-exit install leaves a stale runtime", async () => {
+		const output: string[] = [];
+		const errors: string[] = [];
+		const exitCodes: number[] = [];
+		const sentinel = new Error("exit");
+		const logSpy = vi.spyOn(console, "log").mockImplementation(message => {
+			output.push(String(message));
+		});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(message => {
+			errors.push(String(message));
+		});
+		let verificationCalls = 0;
+		let refreshCalls = 0;
+		try {
+			await expect(
+				runUpdateCommand(
+					{ force: false, check: false },
+					{
+						getLatestRelease: async () => ({ tag: "v999.0.0", version: "999.0.0" }),
+						resolveUpdateTarget: async () => ({ method: "bun" }),
+						performUpdate: async (_target, expectedVersion) => {
+							await runPackageManagerUpdateForTest({
+								managerName: "bun",
+								expectedVersion,
+								runInstall: async () => ({ exitCode: 0, text: () => "installed" }),
+								verifyInstalledRuntime: async () => {
+									verificationCalls += 1;
+									return { ok: false, actual: "0.0.1", path: "/test/gjc" };
+								},
+							});
+						},
+						refreshInstalledDefaultSkills: async () => {
+							refreshCalls += 1;
+						},
+						exit: code => {
+							exitCodes.push(code);
+							throw sentinel;
+						},
+					},
+				),
+			).rejects.toBe(sentinel);
+			expect(verificationCalls).toBe(1);
+			expect(exitCodes).toEqual([1]);
+			expect(refreshCalls).toBe(0);
+			expect(errors.join("\n")).toContain(
+				"install exited successfully, but the selected gjc runtime failed verification",
+			);
+			expect(errors.join("\n")).toContain("still reports 0.0.1 (expected 999.0.0)");
+			expect(errors.join("\n")).not.toContain("install failed with exit code 0");
+			expect(output.filter(line => line.includes("Updated to") || line.includes("Restart gjc"))).toHaveLength(0);
+		} finally {
+			logSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+
+	it("exits without refreshing defaults when a zero-exit install fails its smoke test", async () => {
+		const output: string[] = [];
+		const errors: string[] = [];
+		const exitCodes: number[] = [];
+		const sentinel = new Error("exit");
+		const logSpy = vi.spyOn(console, "log").mockImplementation(message => {
+			output.push(String(message));
+		});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(message => {
+			errors.push(String(message));
+		});
+		let verificationCalls = 0;
+		let refreshCalls = 0;
+		try {
+			await expect(
+				runUpdateCommand(
+					{ force: false, check: false },
+					{
+						getLatestRelease: async () => ({ tag: "v999.0.0", version: "999.0.0" }),
+						resolveUpdateTarget: async () => ({ method: "bun" }),
+						performUpdate: async (_target, expectedVersion) => {
+							await runPackageManagerUpdateForTest({
+								managerName: "bun",
+								expectedVersion,
+								runInstall: async () => ({ exitCode: 0, text: () => "installed" }),
+								verifyInstalledRuntime: async () => {
+									verificationCalls += 1;
+									return {
+										ok: false,
+										actual: "999.0.0",
+										path: "/test/gjc",
+										smokeTestFailed: true,
+										smokeTestOutput: "native addon mismatch",
+									};
+								},
+							});
+						},
+						refreshInstalledDefaultSkills: async () => {
+							refreshCalls += 1;
+						},
+						exit: code => {
+							exitCodes.push(code);
+							throw sentinel;
+						},
+					},
+				),
+			).rejects.toBe(sentinel);
+			expect(verificationCalls).toBe(1);
+			expect(exitCodes).toEqual([1]);
+			expect(refreshCalls).toBe(0);
+			expect(errors.join("\n")).toContain("--smoke-test failed");
+			expect(errors.join("\n")).toContain("native addon mismatch");
+			expect(errors.join("\n")).toContain(
+				"install exited successfully, but the selected gjc runtime failed verification",
+			);
+			expect(errors.join("\n")).not.toContain("install failed with exit code 0");
+			expect(output.filter(line => line.includes("Updated to") || line.includes("Restart gjc"))).toHaveLength(0);
+		} finally {
+			logSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
 	});
 });
 

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -844,7 +844,7 @@
 				},
 				"checkUpdate": {
 					"type": "boolean",
-					"description": "If false, skip update check",
+					"description": "Check for newer versions at interactive startup and show a notification. Startup never installs updates; run `gjc update` explicitly. If false, skip the check.",
 					"default": true
 				}
 			},

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -844,7 +844,7 @@
 				},
 				"checkUpdate": {
 					"type": "boolean",
-					"description": "Check for newer versions at interactive startup and show a notification. Startup never installs updates; run `gjc update` explicitly. If false, skip the check.",
+					"description": "At interactive startup, notify of newer versions; never install. Use `gjc update` only for recognized Bun global, Windows npm, or bundled-installer binaries; source, linked, and unrecognized installs use their original method.",
 					"default": true
 				}
 			},

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -302,6 +302,7 @@ describe("planTargetedTasks PR-mode targeting", () => {
 		"packages/coding-agent/test/edit/bar.test.ts",
 		"packages/coding-agent/test/cli.test.ts",
 		"packages/coding-agent/test/rlm-live-model-e2e.test.ts",
+		"packages/coding-agent/test/startup-update-contract.test.ts",
 	];
 
 	function targeted(paths: readonly string[]) {
@@ -350,12 +351,12 @@ describe("planTargetedTasks PR-mode targeting", () => {
 		expect(entries.find(entry => entry.key === "native-linux-x64")?.nativeBuild).toBe(true);
 	});
 
-	test("a source file with a directly-named test maps to exactly that test", () => {
+	test("a source file with a directly-named test maps exclusively to that test", () => {
 		const tasks = targeted(["packages/coding-agent/src/edit/foo.ts"]);
-		const keys = tasks.map(task => task.key);
-		expect(keys).toContain("test:packages/coding-agent/test/edit/foo.test.ts");
-		expect(keys).not.toContain("test:@gajae-code/coding-agent");
-		expect(keys).not.toContain("check:@gajae-code/coding-agent");
+		expect(tasks.map(task => task.key)).toEqual([
+			"test:packages/coding-agent/test/edit/foo.test.ts",
+			"native-linux-x64",
+		]);
 	});
 
 	test("a source file with no mapped test runs the owning package check, not its test suite", () => {
@@ -364,6 +365,24 @@ describe("planTargetedTasks PR-mode targeting", () => {
 		expect(keys).toContain("check:@gajae-code/coding-agent");
 		expect(keys).toContain("cli-smoke"); // coding-agent runtime smoke
 		expect(keys.some(key => key.startsWith("test:"))).toBe(false);
+	});
+
+	test("main entrypoint adds its behavioral contract test without replacing owner fallback coverage", () => {
+		const tasks = targeted(["packages/coding-agent/src/main.ts"]);
+		const keys = tasks.map(task => task.key);
+		expect(keys).toEqual([
+			"test:packages/coding-agent/test/startup-update-contract.test.ts",
+			"check:@gajae-code/coding-agent",
+			"cli-smoke",
+			"native-linux-x64",
+		]);
+		expect(tasks[0]?.command).toEqual(["bun", "test", "packages/coding-agent/test/startup-update-contract.test.ts"]);
+		expect(tasks[1]).toMatchObject({
+			command: ["bun", "run", "check"],
+			cwd: resolvePackageCwd("packages/coding-agent"),
+		});
+		expect(tasks[2]?.command).toEqual(["bun", "run", "ci:test:smoke"]);
+		expect(keys.filter(key => key === "native-linux-x64")).toHaveLength(1);
 	});
 
 	test("a CI workflow change plans yaml-parse + ci-selftest + ci-dry-run only", () => {

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -20,6 +20,14 @@ const CODING_AGENT_TEST_SHARDS = 8;
 // Declared here (before the top-level `await main()`) so it is initialized for
 // every CLI mode despite top-level await halting later module statements.
 const NATIVE_BUILD_KEYS: ReadonlySet<string> = new Set(["native-build", "native-linux-x64"]);
+
+// Behavioral-owner tests cover entrypoint contracts whose names intentionally do
+// not follow the source-file basename convention. They supplement, rather than
+// replace, direct-basename test selection and owner fallback tasks.
+const BEHAVIORAL_OWNER_TESTS: Readonly<Record<string, readonly string[]>> = {
+	"packages/coding-agent/src/main.ts": ["packages/coding-agent/test/startup-update-contract.test.ts"],
+};
+
 export interface PackageManifest {
 	name?: string;
 	scripts?: Record<string, string>;
@@ -572,10 +580,13 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 
 
 		const mappedTests = mappedTestsFor(changedPath, packages, testFiles);
+		for (const testFile of mappedTests) {
+			addTestFileTask(tasks, testFile);
+		}
+		for (const testFile of behavioralTestsFor(changedPath)) {
+			addTestFileTask(tasks, testFile);
+		}
 		if (mappedTests.length > 0) {
-			for (const testFile of mappedTests) {
-				addTestFileTask(tasks, testFile);
-			}
 			continue;
 		}
 
@@ -661,6 +672,13 @@ function mappedTestsFor(changedPath: string, packages: readonly WorkspacePackage
 	const owner = owningPackage(changedPath, packages);
 	const scopePrefix = owner ? `${owner.dir}/` : `${path.posix.dirname(changedPath)}/`;
 	return testFiles.filter(testFile => wanted.has(path.posix.basename(testFile)) && testFile.startsWith(scopePrefix));
+}
+
+// Resolve explicit behavioral-owner tests. Unlike mappedTestsFor(), these tests
+// are additive because an entrypoint's package-level check and smoke coverage
+// remain necessary even when it owns a dedicated contract test.
+function behavioralTestsFor(changedPath: string): readonly string[] {
+	return BEHAVIORAL_OWNER_TESTS[changedPath] ?? [];
 }
 
 function owningPackage(changedPath: string, packages: readonly WorkspacePackage[]): WorkspacePackage | undefined {


### PR DESCRIPTION
## Summary
- document that interactive launch update checks are notify-only and non-mutating
- clarify that `gjc update` is the sole self-update installation path
- expose the same contract in settings metadata and the generated config schema
- add focused regression coverage for the setting contract

## Verification
- `bun test packages/coding-agent/test/startup-update-contract.test.ts packages/coding-agent/test/config-cli.test.ts`
- `bun run check:schemas`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`

Closes #1935

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*