### PR TITLE
perf(coding-agent): raise codex-pro executor to Sol max

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 
 - Moved the `codex-eco`/`codex-medium`/`codex-pro` presets and the `opus-codex`/`codex-opencodego`/`fable-opus-codex` combo presets from `gpt-5.5` onto the GPT-5.6 tier family: Sol drives `default` and `architect` on every codex preset (eco `sol:medium`, medium `sol:high`, pro `sol:xhigh`/`sol:max`), with Luna/Terra covering the lighter executor/planner/critic roles by tier.
+- Raised the `codex-pro` executor from `gpt-5.6-terra:medium` to `gpt-5.6-sol:max`, aligning the performance-first preset's coding role with the highest measured GPT-5.6 coding tier.
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -85,7 +85,7 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 	}),
 	profile("codex-pro", ["openai-codex"], {
 		default: "openai-codex/gpt-5.6-sol:xhigh",
-		executor: "openai-codex/gpt-5.6-terra:medium",
+		executor: "openai-codex/gpt-5.6-sol:max",
 		planner: "openai-codex/gpt-5.6-sol:high",
 		critic: "openai-codex/gpt-5.6-sol:xhigh",
 		architect: "openai-codex/gpt-5.6-sol:max",

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -45,7 +45,7 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 		requiredProviders: ["openai-codex"],
 		mapping: {
 			default: "openai-codex/gpt-5.6-sol:xhigh",
-			executor: "openai-codex/gpt-5.6-terra:medium",
+			executor: "openai-codex/gpt-5.6-sol:max",
 			planner: "openai-codex/gpt-5.6-sol:high",
 			critic: "openai-codex/gpt-5.6-sol:xhigh",
 			architect: "openai-codex/gpt-5.6-sol:max",


### PR DESCRIPTION
## Summary

- change only the `codex-pro` executor from `openai-codex/gpt-5.6-terra:medium` to `openai-codex/gpt-5.6-sol:max`
- update the exact built-in profile matrix test
- record the performance-tier change in the coding-agent changelog

## Rationale

`codex-pro` is the performance-first Codex preset. Its default, planner, critic, and architect roles already use Sol, while the coding executor remained on Terra medium. The direct GPT-5.6 coding benchmark identifies Sol max as the highest measured coding tier, so this change makes the Pro executor follow the preset's quality ceiling.

Artificial Analysis reports the following Coding Agent pass@1 results:

| Model / effort | Components | Mean | Cost per task |
| --- | ---: | ---: | ---: |
| GPT-5.5 xhigh | 64 / 84 / 81 | 76.3 | $5.07 |
| GPT-5.6 Terra max | 67 / 84 / 81 | 77.3 | $2.76 |
| GPT-5.6 Sol max | 69 / 88 / 84 | 80.3 | $7.08 |

Against GPT-5.5 xhigh, Sol max is +4.0 mean points (+5.2%) at +39.6% measured task cost. Against Terra max, it is +3.0 mean points at a substantially higher cost. This is therefore a deliberate performance choice for `codex-pro`, not a cost-efficiency claim.

Source: [Artificial Analysis, “GPT-5.6 Has Landed”](https://artificialanalysis.ai/articles/gpt-5-6-has-landed)

### Important comparison limit

The Coding Agent chart does **not** publish a Terra medium result. It supports Sol max as the highest measured GPT-5.6 coding ceiling, but it does not establish a quantified Sol max improvement over the exact current `Terra:medium` selector.

### Nominal preset pricing

Using published per-token list prices and weighting each of the five role slots equally:

| `codex-pro` mapping | Nominal input / output per 1M tokens |
| --- | ---: |
| Current: 4× Sol + 1× Terra | $4.50 / $27.00 |
| Proposed: 5× Sol | $5.00 / $30.00 |
| Previous all-GPT-5.5 baseline | $5.00 / $30.00 |

The proposed mapping raises the nominal slot average by 11.1% from current `dev` and returns it to GPT-5.5 price parity. This is not a realized bill estimate: roles run at different frequencies, `max` can consume more reasoning tokens, and cache reads/writes materially affect cost.

## Verification

- failing-first exact profile matrix test observed the old Terra medium value before the source change
- `bun test packages/coding-agent/test/model-profiles-catalog.test.ts packages/coding-agent/test/model-profile-activation.test.ts` (29 passed)
- expanded hands-on QA across profile catalog, activation, CLI parsing, schema, and red-team tests (76 passed)
- runtime import and activation both resolved the executor to `openai-codex/gpt-5.6-sol:max`
- `bun --cwd=packages/coding-agent run check`
- five-lane post-implementation review: goal, hands-on QA, code quality, security, and repository/GitHub context all passed
