### PR TITLE
fix(coordinator-mcp): settle Escape before Enter so tmux prompt submit is not coalesced into Alt+Enter

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed Coordinator MCP prompt delivery failing with `runtime_prompt_ack_timeout` on driven tmux sessions (`start_session`, `send_prompt`, and every `delegate_*`). The autocomplete-dismiss `Escape` added in #1480 and the submit `Enter` were sent as back-to-back `send-keys`, so the driven session's terminal (`escape-time 0`) coalesced them into a single `ESC`+`CR` = `Alt+Enter` (a newline); the prompt piled up unsubmitted in the composer and the runtime never emitted `turn_start`. A brief settle delay between the two keystrokes lets the standalone `Escape` land first, restoring submission. Reproduces independently of the host tmux config (`tmux -f /dev/null`).
 
 ## [0.9.6] - 2026-07-10
 ### Changed

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -1310,6 +1310,12 @@ async function runCommand(command: string[]): Promise<{ exitCode: number; stdout
 
 type CommandRunner = (command: string[]) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
 
+// Gap between the autocomplete-dismiss Escape and the submit Enter. Sent back-to-back
+// they are coalesced by the driven session's terminal (escape-time 0) into a single
+// ESC+CR = Alt+Enter (a newline), so the prompt never submits — a regression of the
+// #1480 autocomplete-dismiss fix. A brief pause lets the standalone Escape settle first.
+const SUBMIT_KEY_ESCAPE_SETTLE_MS = 120;
+
 async function sendTmuxPromptKeys(
 	target: string,
 	prompt: string,
@@ -1329,6 +1335,9 @@ async function sendTmuxPromptKeys(
 	// prompt instead of selecting the highlighted completion.
 	const dismissedAutocomplete = await runner(["tmux", "send-keys", "-t", target, "Escape"]);
 	if (dismissedAutocomplete.exitCode !== 0) return false;
+	// Let the standalone Escape land before Enter so the terminal does not read the pair
+	// as ESC+CR (Alt+Enter). See SUBMIT_KEY_ESCAPE_SETTLE_MS.
+	await new Promise(resolve => setTimeout(resolve, SUBMIT_KEY_ESCAPE_SETTLE_MS));
 	const submitted = await runner(["tmux", "send-keys", "-t", target, "Enter"]);
 	return submitted.exitCode === 0;
 }


### PR DESCRIPTION
## What changed and why

Coordinator MCP prompt delivery over tmux regressed on 0.9.x: `start_session`, `send_prompt`, and every `delegate_*` fail with `runtime_prompt_ack_timeout`. The prompt is pasted into the forge TUI composer but **never submits**, so the runtime never emits `turn_start`.

Root cause is in `sendTmuxPromptKeys()`. The autocomplete-dismiss `Escape` added in #1480 and the submit `Enter` are two separate `send-keys` calls issued back-to-back:

```
tmux send-keys … Escape
tmux send-keys … Enter
```

With no gap, the driven session's terminal (`escape-time 0`) coalesces `ESC` + `CR` into a single **`Alt+Enter` (a newline)**, not two keys. The prompt piles up unsubmitted in the composer. This fix inserts a brief settle delay (`SUBMIT_KEY_ESCAPE_SETTLE_MS = 120`) so the standalone `Escape` lands before `Enter`.

## Regression lineage

- #1371 — `sendTmuxPromptKeys` sent Ctrl+Enter CSI-u (`\x1b[13;5u`) → never submitted.
- #1409 — `C-m` didn't submit; switched to `Enter`.
- #1417 — multiline prompts via paste-buffer + `Enter`.
- #1480 — added `Escape` before `Enter` to dismiss autocomplete.
- **this PR** — that `Escape`, sent back-to-back with `Enter`, coalesces into `Alt+Enter` and again never submits.

## Reproduction (config-independent)

Reproduces with a bare tmux server (`-f /dev/null`, so independent of extended-keys / escape-time host config):

```bash
D=$(mktemp -d); (cd "$D" && git init -q && git commit -q --allow-empty -m init)
tmux -L rep -f /dev/null new-session -d -s x -x 200 -y 50 -c "$D" 'gjc'
sleep 14
tmux -L rep set-buffer -b b1 -- "reply one line: current git branch"
tmux -L rep paste-buffer -d -b b1 -t x
tmux -L rep send-keys -t x Escape
tmux -L rep send-keys -t x Enter          # -> stuck in composer, unsubmitted
```

Contrast (both submit): inserting `sleep 0.12` between `Escape` and `Enter`, or sending `Enter` alone. Applying this patch makes `start_session` / `send_prompt` / `delegate_*` all reach a terminal state on 0.9.3 (verified end-to-end against real coordinator sessions).

Note: this is a terminal-level timing effect, so it can't be reproduced through the unit tests' mocked `commandRunner` — the existing delivery-sequence tests (which lock `set-buffer → paste-buffer → Escape → Enter`) remain green because the command sequence is unchanged.

## Tests / checks

```
bun install
bun --cwd=packages/natives run build
bun test packages/coding-agent/test/coordinator-mcp-server.test.ts   # 34 pass, 0 fail
```

## Notes

- Target branch: `dev` (per CONTRIBUTING).
- Changelog: entry added under `packages/coding-agent/CHANGELOG.md` `[Unreleased] / Fixed`.
- Supersedes the report in #1957 (closed as needing the supported contribution path).
- A separate, independent finding — the coordinator delivers the initial prompt ~160 ms after spawn, while the TUI is still cold-booting, dropping those keystrokes — is intentionally left out of this PR to keep it focused; happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
