### PR TITLE
feat(ultragoal): show adaptive completion ETA

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added adaptive Ultragoal completion estimates to `gjc ultragoal status` and the active workflow HUD, including local finish ranges, elapsed/remaining time, confidence, calculation basis, blocked-state handling, and date-safe long-run formatting.
 
 ### Changed
 

--- a/packages/coding-agent/src/gjc-runtime/state-renderer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-renderer.ts
@@ -1,4 +1,5 @@
 import type { CanonicalGjcWorkflowSkill } from "../skill-state/active-state";
+import { formatUltragoalLocalRange } from "../skill-state/workflow-hud";
 import type { SkillManifest } from "./workflow-manifest";
 
 function scalar(value: unknown): string | undefined {
@@ -248,6 +249,13 @@ export function renderHistoryMarkdown(history: {
 	return `${lines.join("\n")}\n`;
 }
 
+function formatUltragoalEtaDuration(totalSeconds: number): string {
+	const seconds = Math.max(0, Math.round(totalSeconds));
+	const hours = Math.floor(seconds / 3600);
+	const minutes = Math.floor((seconds % 3600) / 60);
+	return hours > 0 ? `${hours}h${String(minutes).padStart(2, "0")}m` : `${minutes}m`;
+}
+
 export function renderUltragoalStatusMarkdown(summary: {
 	exists: boolean;
 	status: string;
@@ -261,6 +269,18 @@ export function renderUltragoalStatusMarkdown(summary: {
 	nudgeRemaining?: number;
 	nudgeGoalId?: string;
 	nudgeTargetKind?: string;
+	eta?: {
+		state: string;
+		confidence: string;
+		sampleSize: number;
+		elapsedSeconds: number;
+		remainingSecondsLow: number;
+		remainingSecondsHigh: number;
+		finishAtLow?: string;
+		finishAtHigh?: string;
+		basis: string;
+		blockedReason?: string;
+	};
 }): string {
 	if (!summary.exists)
 		return `# ultragoal status\n\n- status: missing\n- No ultragoal plan found at ${summary.paths.goalsPath}. Run \`gjc ultragoal create-goals --brief "..."\` first.\n`;
@@ -282,6 +302,23 @@ export function renderUltragoalStatusMarkdown(summary: {
 		lines.push(
 			`- nudge: ${summary.nudgeGoalId} ${used}/${summary.nudgeBudget} used (${remaining} remaining)${target}`,
 		);
+	}
+	if (summary.eta && summary.eta.state !== "complete") {
+		const elapsed = formatUltragoalEtaDuration(summary.eta.elapsedSeconds);
+		if (summary.eta.state === "blocked") {
+			lines.push(
+				`- eta: blocked${summary.eta.blockedReason ? ` (${summary.eta.blockedReason})` : ""} — elapsed=${elapsed} confidence=${summary.eta.confidence} basis=${summary.eta.basis}`,
+			);
+		} else {
+			const remaining = `${formatUltragoalEtaDuration(summary.eta.remainingSecondsLow)}\u2013${formatUltragoalEtaDuration(summary.eta.remainingSecondsHigh)}`;
+			lines.push(
+				`- eta: elapsed=${elapsed} remaining=${remaining} confidence=${summary.eta.confidence} basis=${summary.eta.basis}`,
+			);
+			if (summary.eta.finishAtLow && summary.eta.finishAtHigh) {
+				const range = formatUltragoalLocalRange(summary.eta.finishAtLow, summary.eta.finishAtHigh);
+				if (range) lines.push(`- eta_finish: ~${range} (local, estimate)`);
+			}
+		}
 	}
 	lines.push(`- goals_path: ${summary.paths.goalsPath}`);
 	if (summary.paths.ledgerPath) lines.push(`- ledger_path: ${summary.paths.ledgerPath}`);

--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -1032,6 +1032,22 @@ function buildHudForMode(
 									: undefined,
 						}
 					: undefined;
+			const rawEta = payload.eta;
+			const eta =
+				rawEta && typeof rawEta === "object" && !Array.isArray(rawEta)
+					? (() => {
+							const record = rawEta as Record<string, unknown>;
+							if (typeof record.state !== "string") return undefined;
+							return {
+								state: record.state,
+								confidence: typeof record.confidence === "string" ? record.confidence : undefined,
+								basis: typeof record.basis === "string" ? record.basis : undefined,
+								finishAtLow: typeof record.finishAtLow === "string" ? record.finishAtLow : undefined,
+								finishAtHigh: typeof record.finishAtHigh === "string" ? record.finishAtHigh : undefined,
+								blockedReason: typeof record.blockedReason === "string" ? record.blockedReason : undefined,
+							};
+						})()
+					: undefined;
 			const status = typeof payload.status === "string" ? (payload.status as string) : (phase ?? "pending");
 			return buildUltragoalHudSummary({
 				status,
@@ -1045,6 +1061,7 @@ function buildHudForMode(
 				counts,
 				goals: goals.map(g => ({ id: g.id as string, title: g.title as string, status: g.status as string })),
 				latestLedgerEvent,
+				eta,
 				updatedAt,
 			});
 		}

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -279,6 +279,7 @@ export interface UltragoalStatusSummary {
 	nudgeGoalId?: string;
 	nudgeTargetKind?: UltragoalNudgeTargetKind;
 	pipelineOverlap?: JsonObject;
+	eta?: UltragoalEtaEstimate;
 }
 
 export interface UltragoalCommandResult {
@@ -1332,6 +1333,196 @@ function emptyCounts(): Record<UltragoalGoalStatus, number> {
 		superseded: 0,
 	};
 }
+export type UltragoalEtaState = "estimating" | "blocked" | "complete";
+export type UltragoalEtaConfidence = "low" | "medium" | "high";
+export type UltragoalEtaBasis = "observed_median" | "fallback_default";
+
+export interface UltragoalEtaEstimate {
+	state: UltragoalEtaState;
+	confidence: UltragoalEtaConfidence;
+	sampleSize: number;
+	elapsedSeconds: number;
+	remainingSecondsLow: number;
+	remainingSecondsHigh: number;
+	finishAtLow?: string;
+	finishAtHigh?: string;
+	basis: UltragoalEtaBasis;
+	blockedReason?: string;
+}
+
+const ULTRAGOAL_ETA_FALLBACK_LOW_SECONDS = 15 * 60;
+const ULTRAGOAL_ETA_FALLBACK_HIGH_SECONDS = 45 * 60;
+const ULTRAGOAL_ETA_OBSERVED_LOW_FACTOR = 0.75;
+const ULTRAGOAL_ETA_OBSERVED_HIGH_FACTOR = 1.25;
+const ULTRAGOAL_ETA_MIN_REMAINING_FLOOR_SECONDS = 5 * 60;
+// When both the low and high floors would otherwise collapse onto the same value (a short
+// observed median can push `perGoalHighSeconds / 2` below the low floor), the high floor
+// must still read as a distinct, wider estimate instead of a fake-precision point value.
+const ULTRAGOAL_ETA_MIN_HIGH_SPREAD_SECONDS = 5 * 60;
+
+function parseUltragoalTimestampMs(value: string | undefined): number | undefined {
+	if (typeof value !== "string" || value.trim().length === 0) return undefined;
+	const ms = Date.parse(value);
+	return Number.isFinite(ms) ? ms : undefined;
+}
+
+interface UltragoalCompletionRecord {
+	durationMs: number;
+	completedAtMs: number;
+	completedAtIso: string;
+}
+
+/**
+ * Valid `complete`-status goals with a sane (non-reversed, parseable) start/end pair.
+ * `superseded` goals, missing timestamps, and reversed pairs never count as real samples,
+ * so both the duration statistics and the "latest finish" candidate below share one source
+ * of truth instead of drifting apart.
+ */
+function validUltragoalCompletionRecords(goals: readonly UltragoalGoal[]): UltragoalCompletionRecord[] {
+	const records: UltragoalCompletionRecord[] = [];
+	for (const goal of goals) {
+		if (goal.status !== "complete") continue;
+		const started = parseUltragoalTimestampMs(goal.startedAt);
+		const completed = parseUltragoalTimestampMs(goal.completedAt);
+		if (started === undefined || completed === undefined || typeof goal.completedAt !== "string") continue;
+		const durationMs = completed - started;
+		if (durationMs <= 0) continue;
+		records.push({ durationMs, completedAtMs: completed, completedAtIso: goal.completedAt });
+	}
+	return records;
+}
+
+/** Ascending ms durations of `complete` goals with a sane (non-reversed, parseable) start/end. */
+function validUltragoalCompletedDurationsMs(goals: readonly UltragoalGoal[]): number[] {
+	return validUltragoalCompletionRecords(goals)
+		.map(record => record.durationMs)
+		.sort((a, b) => a - b);
+}
+
+function medianOfSorted(sortedValues: readonly number[]): number {
+	const mid = Math.floor(sortedValues.length / 2);
+	return sortedValues.length % 2 === 0 ? (sortedValues[mid - 1] + sortedValues[mid]) / 2 : sortedValues[mid];
+}
+
+function ultragoalEtaConfidence(sampleSize: number): UltragoalEtaConfidence {
+	if (sampleSize <= 1) return "low";
+	if (sampleSize <= 4) return "medium";
+	return "high";
+}
+
+/** Latest observed finish time among valid completion records, or `undefined` with none. */
+function latestUltragoalCompletionIso(records: readonly UltragoalCompletionRecord[]): string | undefined {
+	let latestMs: number | undefined;
+	let latestIso: string | undefined;
+	for (const record of records) {
+		if (latestMs === undefined || record.completedAtMs > latestMs) {
+			latestMs = record.completedAtMs;
+			latestIso = record.completedAtIso;
+		}
+	}
+	return latestIso;
+}
+
+function blockedUltragoalEtaReason(goal: UltragoalGoal): string {
+	return `${goal.id} ${goal.status}: ${goal.title}`;
+}
+
+/**
+ * Pure, deterministic ETA estimator for an ultragoal run. Never asserts a single exact
+ * completion time: always a low/high range with an explicit confidence and basis.
+ * `nowMs` is caller-injected so tests can drive it without mutating global clocks.
+ * `complete`/`superseded` goals are excluded from remaining-work accounting; a required
+ * (non-superseded) `blocked`/`review_blocked` goal short-circuits to `state: "blocked"`
+ * without asserting a finish time.
+ */
+export function computeUltragoalEta(goals: readonly UltragoalGoal[], nowMs: number): UltragoalEtaEstimate | undefined {
+	if (goals.length === 0) return undefined;
+	if (goals.every(goal => TERMINAL_OR_SKIPPED_STATUSES.has(goal.status))) {
+		const completionRecords = validUltragoalCompletionRecords(goals);
+		const sampleSize = completionRecords.length;
+		const confidence = ultragoalEtaConfidence(sampleSize);
+		const basis: UltragoalEtaBasis = sampleSize > 0 ? "observed_median" : "fallback_default";
+		const finishAt = latestUltragoalCompletionIso(completionRecords);
+		return {
+			state: "complete",
+			confidence,
+			sampleSize,
+			elapsedSeconds: 0,
+			remainingSecondsLow: 0,
+			remainingSecondsHigh: 0,
+			...(finishAt ? { finishAtLow: finishAt, finishAtHigh: finishAt } : {}),
+			basis,
+		};
+	}
+
+	const required = goals.filter(goal => goal.status !== "superseded");
+	const blockedGoal = required.find(goal => goal.status === "blocked" || goal.status === "review_blocked");
+	const durations = validUltragoalCompletedDurationsMs(goals);
+	const sampleSize = durations.length;
+	const confidence = ultragoalEtaConfidence(sampleSize);
+	const basis: UltragoalEtaBasis = sampleSize > 0 ? "observed_median" : "fallback_default";
+	const medianMs = sampleSize > 0 ? medianOfSorted(durations) : undefined;
+	const perGoalLowSeconds =
+		medianMs !== undefined
+			? (medianMs * ULTRAGOAL_ETA_OBSERVED_LOW_FACTOR) / 1000
+			: ULTRAGOAL_ETA_FALLBACK_LOW_SECONDS;
+	const perGoalHighSeconds =
+		medianMs !== undefined
+			? (medianMs * ULTRAGOAL_ETA_OBSERVED_HIGH_FACTOR) / 1000
+			: ULTRAGOAL_ETA_FALLBACK_HIGH_SECONDS;
+
+	const remainingCountable = required.filter(
+		goal => goal.status === "pending" || goal.status === "active" || goal.status === "failed",
+	);
+	const activeGoal = required.find(goal => goal.status === "active");
+	const elapsedSeconds = activeGoal
+		? Math.max(0, (nowMs - (parseUltragoalTimestampMs(activeGoal.startedAt) ?? nowMs)) / 1000)
+		: 0;
+
+	// Only the current active goal's own remaining window absorbs `elapsedSeconds`; any
+	// other countable goal (pending, failed, or an additional active) keeps its full
+	// per-goal budget so an overrunning active goal can never erase a later goal's ETA.
+	const otherCountableGoals = remainingCountable.filter(goal => goal !== activeGoal);
+	let remainingSecondsLow = otherCountableGoals.length * perGoalLowSeconds;
+	let remainingSecondsHigh = otherCountableGoals.length * perGoalHighSeconds;
+	if (activeGoal) {
+		const activeLowSeconds = Math.max(perGoalLowSeconds - elapsedSeconds, ULTRAGOAL_ETA_MIN_REMAINING_FLOOR_SECONDS);
+		const activeHighFloorSeconds =
+			perGoalHighSeconds / 2 > activeLowSeconds
+				? perGoalHighSeconds / 2
+				: activeLowSeconds + ULTRAGOAL_ETA_MIN_HIGH_SPREAD_SECONDS;
+		const activeHighSeconds = Math.max(perGoalHighSeconds - elapsedSeconds, activeHighFloorSeconds);
+		remainingSecondsLow += activeLowSeconds;
+		remainingSecondsHigh += activeHighSeconds;
+	}
+	remainingSecondsLow = Math.max(0, Math.round(remainingSecondsLow));
+	remainingSecondsHigh = Math.max(remainingSecondsLow, Math.round(remainingSecondsHigh));
+
+	if (blockedGoal) {
+		return {
+			state: "blocked",
+			confidence,
+			sampleSize,
+			elapsedSeconds: Math.round(elapsedSeconds),
+			remainingSecondsLow,
+			remainingSecondsHigh,
+			basis,
+			blockedReason: blockedUltragoalEtaReason(blockedGoal),
+		};
+	}
+
+	return {
+		state: "estimating",
+		confidence,
+		sampleSize,
+		elapsedSeconds: Math.round(elapsedSeconds),
+		remainingSecondsLow,
+		remainingSecondsHigh,
+		finishAtLow: new Date(nowMs + remainingSecondsLow * 1000).toISOString(),
+		finishAtHigh: new Date(nowMs + remainingSecondsHigh * 1000).toISOString(),
+		basis,
+	};
+}
 
 export async function getUltragoalStatus(cwd: string, sessionId?: string | null): Promise<UltragoalStatusSummary> {
 	const resolvedSessionId =
@@ -1344,6 +1535,7 @@ export async function getUltragoalStatus(cwd: string, sessionId?: string | null)
 	for (const goal of plan.goals) counts[goal.status] += 1;
 	const currentGoal = plan.goals.find(goal => SCHEDULABLE_STATUSES.has(goal.status));
 	const overlap = openPipelineOverlap(plan);
+	const eta = computeUltragoalEta(plan.goals, Date.now());
 	let status: UltragoalStatusSummary["status"] = "pending";
 	if (plan.goals.length > 0 && plan.goals.every(goal => TERMINAL_OR_SKIPPED_STATUSES.has(goal.status)))
 		status = "complete";
@@ -1373,6 +1565,7 @@ export async function getUltragoalStatus(cwd: string, sessionId?: string | null)
 		counts,
 		goals: plan.goals,
 		...nudgeFields,
+		...(eta ? { eta } : {}),
 		...(overlap
 			? {
 					pipelineOverlap: {
@@ -1396,6 +1589,7 @@ export function buildUltragoalHudSummary(
 		goals: summary.goals,
 		latestLedgerEvent: latestLedger,
 		updatedAt: new Date().toISOString(),
+		eta: summary.eta,
 	});
 }
 function clampTitle(title: string): string {
@@ -5472,6 +5666,7 @@ async function reconcileUltragoalState(cwd: string): Promise<void> {
 		if (summary.nudgeGoalId !== undefined) payload.nudge_goal_id = summary.nudgeGoalId;
 		if (summary.nudgeTargetKind !== undefined) payload.nudge_target_kind = summary.nudgeTargetKind;
 		if (summary.pipelineOverlap) payload.pipeline_overlap = summary.pipelineOverlap;
+		if (summary.eta) payload.eta = summary.eta;
 		const ledgerText = await Bun.file(summary.paths.ledgerPath)
 			.text()
 			.catch(() => "");

--- a/packages/coding-agent/src/skill-state/workflow-hud.ts
+++ b/packages/coding-agent/src/skill-state/workflow-hud.ts
@@ -35,12 +35,22 @@ interface UltragoalLikeGoal {
 	status: string;
 }
 
+interface UltragoalLikeEta {
+	state: string;
+	confidence?: string;
+	basis?: string;
+	finishAtLow?: string;
+	finishAtHigh?: string;
+	blockedReason?: string;
+}
+
 interface UltragoalHudState extends WorkflowGateHudState {
 	status: string;
 	currentGoal?: UltragoalLikeGoal;
 	counts: Record<string, number>;
 	goals: UltragoalLikeGoal[];
 	latestLedgerEvent?: { event?: string; goalId?: string; timestamp?: string; kind?: string; evidence?: string };
+	eta?: UltragoalLikeEta;
 	updatedAt?: string;
 }
 
@@ -84,6 +94,129 @@ function gateChips(state: WorkflowGateHudState, gatePriority: number): Array<Wor
 
 function compactChips(chips: Array<WorkflowHudChip | null>): WorkflowHudChip[] {
 	return chips.filter((item): item is WorkflowHudChip => item !== null);
+}
+
+function pad2(value: number): string {
+	return String(value).padStart(2, "0");
+}
+
+interface LocalDateParts {
+	year: number;
+	month: number;
+	day: number;
+	hour: number;
+	minute: number;
+	second: number;
+	/** Conventional signed UTC offset in minutes (east of UTC is positive), i.e. `-date.getTimezoneOffset()`. */
+	offsetMinutes: number;
+}
+
+function localDateParts(date: Date): LocalDateParts {
+	return {
+		year: date.getFullYear(),
+		month: date.getMonth() + 1,
+		day: date.getDate(),
+		hour: date.getHours(),
+		minute: date.getMinutes(),
+		second: date.getSeconds(),
+		offsetMinutes: -date.getTimezoneOffset(),
+	};
+}
+
+function formatHm(parts: LocalDateParts): string {
+	return `${pad2(parts.hour)}:${pad2(parts.minute)}`;
+}
+
+function formatMonthDayHm(parts: LocalDateParts): string {
+	return `${pad2(parts.month)}-${pad2(parts.day)} ${formatHm(parts)}`;
+}
+
+function formatFullDateHm(parts: LocalDateParts): string {
+	return `${parts.year}-${pad2(parts.month)}-${pad2(parts.day)} ${formatHm(parts)}`;
+}
+
+function withSeconds(text: string, parts: LocalDateParts): string {
+	return `${text}:${pad2(parts.second)}`;
+}
+
+function formatUtcOffset(offsetMinutes: number): string {
+	const sign = offsetMinutes < 0 ? "-" : "+";
+	const abs = Math.abs(offsetMinutes);
+	return `UTC${sign}${pad2(Math.floor(abs / 60))}:${pad2(abs % 60)}`;
+}
+
+/**
+ * Deterministic (locale-independent, `Date` local-getter based) low\u2013high finish range.
+ * Same local calendar day: `HH:mm\u2013HH:mm`. Different day, same year: `MM-DD HH:mm\u2013MM-DD HH:mm`.
+ * Different year: `YYYY-MM-DD HH:mm\u2013YYYY-MM-DD HH:mm`. A range never silently drops the date
+ * when its endpoints fall on different local calendar days.
+ *
+ * Two distinct instants NEVER collapse to a single displayed value: a single value is only
+ * ever returned when the two ISO endpoints are the exact same instant. If minute-precision
+ * text happens to coincide (e.g. a 40s-wide range inside one displayed minute) the range
+ * widens to include seconds; if even that coincides (a DST-fold-style pair that shares the
+ * same local date/time down to the second but lands on opposite sides of a UTC-offset
+ * change) the range further annotates each endpoint with its UTC offset so the two instants
+ * stay individually identifiable.
+ */
+export function formatUltragoalLocalRange(lowIso: string, highIso: string): string | undefined {
+	const lowDate = new Date(lowIso);
+	const highDate = new Date(highIso);
+	if (Number.isNaN(lowDate.getTime()) || Number.isNaN(highDate.getTime())) return undefined;
+	if (lowDate.getTime() === highDate.getTime()) {
+		return formatHm(localDateParts(lowDate));
+	}
+	const low = localDateParts(lowDate);
+	const high = localDateParts(highDate);
+	const sameCalendarDay = low.year === high.year && low.month === high.month && low.day === high.day;
+	const sameYear = low.year === high.year;
+	const formatter = sameCalendarDay ? formatHm : sameYear ? formatMonthDayHm : formatFullDateHm;
+	let lowText = formatter(low);
+	let highText = formatter(high);
+	if (lowText === highText) {
+		lowText = withSeconds(lowText, low);
+		highText = withSeconds(highText, high);
+	}
+	if (lowText === highText) {
+		lowText = `${lowText} ${formatUtcOffset(low.offsetMinutes)}`;
+		highText = `${highText} ${formatUtcOffset(high.offsetMinutes)}`;
+	}
+	return `${lowText}\u2013${highText}`;
+}
+
+function abbreviateUltragoalConfidence(confidence: string | undefined): string | undefined {
+	if (confidence === "low" || confidence === "high") return confidence;
+	if (confidence === "medium") return "med";
+	return undefined;
+}
+
+function abbreviateUltragoalBasis(basis: string | undefined): string | undefined {
+	if (basis === "observed_median") return "observed";
+	if (basis === "fallback_default") return "fallback";
+	return undefined;
+}
+
+/**
+ * Never surfaces a single asserted timestamp: `estimating` shows a local finish-time
+ * range (marked `~`, annotated with a compact confidence/basis label), `blocked` shows
+ * the blocking reason instead of a fabricated finish time (also annotated with the same
+ * compact confidence/basis label, so a blocked run's honesty about its own uncertainty
+ * never regresses relative to an estimating one), and `complete` is omitted entirely (no
+ * ETA chip needed).
+ */
+function etaChip(eta: UltragoalLikeEta | undefined, priority: number): WorkflowHudChip | null {
+	if (!eta || eta.state === "complete") return null;
+	const confidenceLabel = abbreviateUltragoalConfidence(eta.confidence);
+	const basisLabel = abbreviateUltragoalBasis(eta.basis);
+	const suffix = confidenceLabel && basisLabel ? ` ${confidenceLabel}/${basisLabel}` : "";
+	if (eta.state === "blocked") {
+		const base = eta.blockedReason ? `blocked: ${eta.blockedReason}` : "blocked";
+		return chip("eta", `${base}${suffix}`, priority, "blocked");
+	}
+	if (!eta.finishAtLow || !eta.finishAtHigh) return null;
+	const range = formatUltragoalLocalRange(eta.finishAtLow, eta.finishAtHigh);
+	if (!range) return null;
+	return chip("eta", `~${range}${suffix}`, priority);
 }
 
 export function buildDeepInterviewHudSummary(state: DeepInterviewHudState): WorkflowHudSummary {
@@ -233,6 +366,7 @@ export function buildUltragoalHudSummary(state: UltragoalHudState): WorkflowHudS
 			blockers > 0 ? { label: "blocked", value: String(blockers), priority: 5, severity: "blocked" } : null,
 			chip("goals", `${complete}/${total}`, 10),
 			chip("current", state.currentGoal ? `${state.currentGoal.id}:${state.currentGoal.title}` : state.status, 20),
+			etaChip(state.eta, 25),
 			chip("status", state.status, 30, state.status === "complete" ? "success" : undefined),
 			chip(
 				"ledger",

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -10,13 +10,14 @@ import {
 	sessionStateDir,
 	sessionUltragoalDir,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
+import { renderUltragoalStatusMarkdown } from "@gajae-code/coding-agent/gjc-runtime/state-renderer";
 import { reconcileWorkflowSkillState } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
 import { validateCompletionReceipt } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-guard";
-
 import {
 	addUltragoalSubgoal,
 	buildUltragoalHudSummary,
 	checkpointUltragoalGoal,
+	computeUltragoalEta,
 	createUltragoalPlan,
 	getUltragoalStatus,
 	hashStructuredValue,
@@ -26,6 +27,9 @@ import {
 	runNativeUltragoalCommand,
 	startNextUltragoalGoal,
 	type UltragoalCommandResult,
+	type UltragoalEtaEstimate,
+	type UltragoalGoal,
+	type UltragoalStatusSummary,
 	validateExecutorQaRedTeamEvidenceForReview,
 	waitForReplayProcessWithTimeout,
 } from "@gajae-code/coding-agent/gjc-runtime/ultragoal-runtime";
@@ -4654,5 +4658,572 @@ describe("resolveGitBase nearest integration base", () => {
 		await commit(dir, "feature.txt", "feature work");
 
 		expect(await resolveGitBase(dir, "main")).toBe("main");
+	});
+});
+
+function etaGoal(overrides: Partial<UltragoalGoal> & Pick<UltragoalGoal, "id" | "status">): UltragoalGoal {
+	return {
+		title: overrides.id,
+		objective: overrides.id,
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		...overrides,
+	};
+}
+/** Builds an ISO timestamp from local calendar components so date-boundary tests never depend on the runner's TZ. */
+function localIso(year: number, month: number, day: number, hour: number, minute: number): string {
+	return new Date(year, month - 1, day, hour, minute, 0, 0).toISOString();
+}
+
+function fullUltragoalCounts(
+	overrides: Partial<Record<UltragoalGoal["status"], number>> = {},
+): Record<UltragoalGoal["status"], number> {
+	return {
+		pending: 0,
+		active: 0,
+		complete: 0,
+		failed: 0,
+		blocked: 0,
+		review_blocked: 0,
+		superseded: 0,
+		...overrides,
+	};
+}
+
+/** Minimal `UltragoalStatusSummary` fixture for exercising HUD/markdown rendering in isolation from the CLI. */
+function statusSummaryWithEta(eta: UltragoalEtaEstimate | undefined): UltragoalStatusSummary {
+	return {
+		exists: true,
+		status: "active",
+		paths: {
+			dir: "/tmp/ultragoal-eta-fixture",
+			briefPath: "/tmp/ultragoal-eta-fixture/BRIEF.md",
+			goalsPath: "/tmp/ultragoal-eta-fixture/goals.json",
+			ledgerPath: "/tmp/ultragoal-eta-fixture/ledger.jsonl",
+		},
+		counts: fullUltragoalCounts({ pending: 1 }),
+		goals: [etaGoal({ id: "G001", status: "pending" })],
+		eta,
+	};
+}
+
+describe("computeUltragoalEta (pure)", () => {
+	const NOW_MS = Date.parse("2026-01-01T12:00:00.000Z");
+
+	it("returns undefined for an empty goal list", () => {
+		expect(computeUltragoalEta([], NOW_MS)).toBeUndefined();
+	});
+
+	it("falls back to a wide 15-45min/goal low-confidence range with no completed samples", () => {
+		const goals = [
+			etaGoal({ id: "G001", status: "pending" }),
+			etaGoal({ id: "G002", status: "pending" }),
+			etaGoal({ id: "G003", status: "pending" }),
+		];
+		const eta = computeUltragoalEta(goals, NOW_MS);
+		expect(eta?.state).toBe("estimating");
+		expect(eta?.confidence).toBe("low");
+		expect(eta?.basis).toBe("fallback_default");
+		expect(eta?.sampleSize).toBe(0);
+		expect(eta?.elapsedSeconds).toBe(0);
+		expect(eta?.remainingSecondsLow).toBe(3 * 15 * 60);
+		expect(eta?.remainingSecondsHigh).toBe(3 * 45 * 60);
+		expect(eta!.remainingSecondsLow).toBeLessThanOrEqual(eta!.remainingSecondsHigh);
+		expect(eta?.finishAtLow).toBe(new Date(NOW_MS + 3 * 15 * 60 * 1000).toISOString());
+		expect(eta?.finishAtHigh).toBe(new Date(NOW_MS + 3 * 45 * 60 * 1000).toISOString());
+	});
+
+	it("uses the median of valid completed-goal durations once observed samples exist", () => {
+		const goals = [
+			etaGoal({
+				id: "G001",
+				status: "complete",
+				startedAt: "2026-01-01T00:00:00.000Z",
+				completedAt: "2026-01-01T00:10:00.000Z",
+			}),
+			etaGoal({
+				id: "G002",
+				status: "complete",
+				startedAt: "2026-01-01T00:00:00.000Z",
+				completedAt: "2026-01-01T00:20:00.000Z",
+			}),
+			etaGoal({
+				id: "G003",
+				status: "complete",
+				startedAt: "2026-01-01T00:00:00.000Z",
+				completedAt: "2026-01-01T00:30:00.000Z",
+			}),
+			etaGoal({ id: "G004", status: "pending" }),
+			etaGoal({ id: "G005", status: "pending" }),
+		];
+		const eta = computeUltragoalEta(goals, NOW_MS);
+		expect(eta?.state).toBe("estimating");
+		expect(eta?.basis).toBe("observed_median");
+		expect(eta?.sampleSize).toBe(3);
+		expect(eta?.confidence).toBe("medium");
+		// median duration = 1200s across the 3 samples; 2 remaining goals * [0.75, 1.25] * 1200s.
+		expect(eta?.remainingSecondsLow).toBe(Math.round(2 * 1200 * 0.75));
+		expect(eta?.remainingSecondsHigh).toBe(Math.round(2 * 1200 * 1.25));
+	});
+
+	it("ignores reversed/abnormal completed timestamps when building the sample", () => {
+		const goals = [
+			etaGoal({
+				id: "G001",
+				status: "complete",
+				startedAt: "2026-01-01T00:10:00.000Z",
+				completedAt: "2026-01-01T00:00:00.000Z",
+			}),
+			etaGoal({
+				id: "G002",
+				status: "complete",
+				startedAt: "2026-01-01T00:00:00.000Z",
+				completedAt: "2026-01-01T00:10:00.000Z",
+			}),
+			etaGoal({ id: "G003", status: "pending" }),
+		];
+		const eta = computeUltragoalEta(goals, NOW_MS);
+		expect(eta?.sampleSize).toBe(1);
+		expect(eta?.confidence).toBe("low");
+		expect(eta?.basis).toBe("observed_median");
+	});
+
+	it("returns state=blocked without asserting a finish time when a required goal is blocked", () => {
+		const goals = [
+			etaGoal({ id: "G001", status: "blocked", title: "Fix the outage" }),
+			etaGoal({ id: "G002", status: "pending" }),
+		];
+		const eta = computeUltragoalEta(goals, NOW_MS);
+		expect(eta?.state).toBe("blocked");
+		expect(eta?.blockedReason).toContain("G001");
+		expect(eta?.blockedReason).toContain("blocked");
+		expect(eta?.confidence).toBe("low");
+		expect(eta?.basis).toBe("fallback_default");
+		expect(eta?.finishAtLow).toBeUndefined();
+		expect(eta?.finishAtHigh).toBeUndefined();
+		expect(eta!.remainingSecondsLow).toBeGreaterThanOrEqual(0);
+		expect(eta!.remainingSecondsLow).toBeLessThanOrEqual(eta!.remainingSecondsHigh);
+
+		// Blocked runs never regress relative to estimating ones: the HUD chip carries the
+		// same compact confidence/basis label so the reader can judge how much to trust it.
+		const hud = buildUltragoalHudSummary(statusSummaryWithEta(eta));
+		const chip = hud.chips?.find(item => item.label === "eta");
+		expect(chip?.severity).toBe("blocked");
+		expect(chip?.value).toBe("blocked: G001 blocked: Fix the outage low/fallback");
+	});
+
+	it("returns state=complete with the actual last completion time once every required goal is terminal", () => {
+		const goals = [
+			etaGoal({
+				id: "G001",
+				status: "complete",
+				startedAt: "2026-01-01T00:00:00.000Z",
+				completedAt: "2026-01-01T00:10:00.000Z",
+			}),
+			etaGoal({
+				id: "G002",
+				status: "complete",
+				startedAt: "2026-01-01T00:10:00.000Z",
+				completedAt: "2026-01-01T00:25:00.000Z",
+			}),
+			etaGoal({ id: "G003", status: "superseded" }),
+		];
+		const eta = computeUltragoalEta(goals, NOW_MS);
+		expect(eta?.state).toBe("complete");
+		// Two valid completion samples (G001, G002); the excluded superseded G003 must not
+		// count toward the sample, and confidence/basis must reflect the real sample size
+		// instead of a hardcoded "high"/"observed_median".
+		expect(eta?.sampleSize).toBe(2);
+		expect(eta?.confidence).toBe("medium");
+		expect(eta?.basis).toBe("observed_median");
+		expect(eta?.remainingSecondsLow).toBe(0);
+		expect(eta?.remainingSecondsHigh).toBe(0);
+		expect(eta?.finishAtLow).toBe("2026-01-01T00:25:00.000Z");
+		expect(eta?.finishAtHigh).toBe("2026-01-01T00:25:00.000Z");
+	});
+
+	it("omits a fabricated finish time when no goal has a valid completion sample", () => {
+		const goals = [etaGoal({ id: "G001", status: "superseded" }), etaGoal({ id: "G002", status: "superseded" })];
+		const eta = computeUltragoalEta(goals, NOW_MS);
+		expect(eta?.state).toBe("complete");
+		expect(eta?.sampleSize).toBe(0);
+		expect(eta?.confidence).toBe("low");
+		expect(eta?.basis).toBe("fallback_default");
+		expect(eta?.finishAtLow).toBeUndefined();
+		expect(eta?.finishAtHigh).toBeUndefined();
+	});
+	it("omits a fabricated finish time when every terminal goal is `complete` but only has a reversed or missing timestamp pair", () => {
+		const goals = [
+			// Reversed pair: completedAt before startedAt.
+			etaGoal({
+				id: "G001",
+				status: "complete",
+				startedAt: "2026-01-01T00:10:00.000Z",
+				completedAt: "2026-01-01T00:00:00.000Z",
+			}),
+			// Missing completedAt entirely.
+			etaGoal({ id: "G002", status: "complete", startedAt: "2026-01-01T00:00:00.000Z" }),
+		];
+		const eta = computeUltragoalEta(goals, NOW_MS);
+		expect(eta?.state).toBe("complete");
+		// Neither goal contributes a valid sample: a `complete` status alone must never be
+		// trusted as a real duration/finish observation without a sane, parseable pair.
+		expect(eta?.sampleSize).toBe(0);
+		expect(eta?.confidence).toBe("low");
+		expect(eta?.basis).toBe("fallback_default");
+		expect(eta?.remainingSecondsLow).toBe(0);
+		expect(eta?.remainingSecondsHigh).toBe(0);
+		expect(eta?.finishAtLow).toBeUndefined();
+		expect(eta?.finishAtHigh).toBeUndefined();
+	});
+
+	it("floors an overrunning active goal's remaining estimate instead of collapsing toward zero", () => {
+		const goals = [
+			etaGoal({
+				id: "G001",
+				status: "complete",
+				startedAt: "2026-01-01T00:00:00.000Z",
+				completedAt: "2026-01-01T00:10:00.000Z",
+			}),
+			etaGoal({ id: "G002", status: "active", startedAt: "2026-01-01T11:40:00.000Z" }),
+		];
+		const eta = computeUltragoalEta(goals, NOW_MS);
+		expect(eta?.state).toBe("estimating");
+		expect(eta?.elapsedSeconds).toBe(20 * 60);
+		// perGoalLow=450s: 450-1200 overruns, floored at the 5min minimum.
+		expect(eta?.remainingSecondsLow).toBe(5 * 60);
+		// perGoalHigh=750s: 750-1200 overruns too, but high must stay wider than low —
+		// floored at half the observed per-goal high (375s), never collapsing to equal low.
+		expect(eta?.remainingSecondsHigh).toBe(375);
+		expect(eta!.remainingSecondsLow).toBeLessThan(eta!.remainingSecondsHigh);
+	});
+	it("keeps low strictly below high for an overrunning active goal even with a short (4min) observed median", () => {
+		const goals = [
+			etaGoal({
+				id: "G001",
+				status: "complete",
+				startedAt: "2026-01-01T00:00:00.000Z",
+				completedAt: "2026-01-01T00:04:00.000Z",
+			}),
+			etaGoal({ id: "G002", status: "active", startedAt: "2026-01-01T11:40:00.000Z" }),
+		];
+		const eta = computeUltragoalEta(goals, NOW_MS);
+		expect(eta?.state).toBe("estimating");
+		expect(eta?.basis).toBe("observed_median");
+		// median duration = 240s; perGoalLow=180s, perGoalHigh=300s. Both overrun the 20min
+		// elapsed active goal, so both floor — but `perGoalHigh / 2` (150s) is itself below
+		// the 5min low floor (300s), so a naive `max(perGoalHigh / 2, activeLow)` would
+		// collapse both floors onto the identical 300s value. The high floor must instead
+		// widen to `activeLow + 5min` so the estimate never asserts fake single-point
+		// precision.
+		expect(eta?.remainingSecondsLow).toBe(5 * 60);
+		expect(eta?.remainingSecondsHigh).toBe(10 * 60);
+		expect(eta!.remainingSecondsLow).toBeLessThan(eta!.remainingSecondsHigh);
+	});
+
+	it("keeps a subsequent pending goal's full eta budget after the active goal overruns", () => {
+		const goals = [
+			etaGoal({
+				id: "G001",
+				status: "complete",
+				startedAt: "2026-01-01T00:00:00.000Z",
+				completedAt: "2026-01-01T00:10:00.000Z",
+			}),
+			etaGoal({ id: "G002", status: "active", startedAt: "2026-01-01T11:40:00.000Z" }),
+			etaGoal({ id: "G003", status: "pending" }),
+		];
+		const eta = computeUltragoalEta(goals, NOW_MS);
+		expect(eta?.state).toBe("estimating");
+		expect(eta?.elapsedSeconds).toBe(20 * 60);
+		// G002 (active, overrunning) contributes its floored 300s/375s; G003 (pending) must
+		// keep its FULL 450s/750s per-goal budget — the active goal's overrun elapsed time
+		// must never be subtracted from a later goal's own estimate.
+		expect(eta?.remainingSecondsLow).toBe(300 + 450);
+		expect(eta?.remainingSecondsHigh).toBe(375 + 750);
+		// Regression guard: the pre-fix formula subtracted elapsed from the whole 2-goal sum,
+		// which floored the total at 300s and erased G003's ETA entirely.
+		expect(eta!.remainingSecondsLow).toBeGreaterThan(300);
+	});
+
+	it("excludes superseded goals but counts pending/failed goals toward the remaining estimate", () => {
+		const goals = [
+			etaGoal({ id: "G001", status: "superseded" }),
+			etaGoal({ id: "G002", status: "pending" }),
+			etaGoal({ id: "G003", status: "failed" }),
+		];
+		const eta = computeUltragoalEta(goals, NOW_MS);
+		expect(eta?.state).toBe("estimating");
+		expect(eta?.remainingSecondsLow).toBe(2 * 15 * 60);
+		expect(eta?.remainingSecondsHigh).toBe(2 * 45 * 60);
+	});
+	function completedGoalWithTenMinuteDuration(id: string): UltragoalGoal {
+		return etaGoal({
+			id,
+			status: "complete",
+			startedAt: "2026-01-01T00:00:00.000Z",
+			completedAt: "2026-01-01T00:10:00.000Z",
+		});
+	}
+
+	it.each([
+		[2, "medium", "med"],
+		[4, "medium", "med"],
+		[5, "high", "high"],
+	] as const)("confidence boundary: sampleSize=%d -> confidence=%s (HUD label %s/observed)", (sampleSize, confidence, hudConfidenceLabel) => {
+		const goals: UltragoalGoal[] = [];
+		for (let index = 0; index < sampleSize; index += 1) {
+			goals.push(completedGoalWithTenMinuteDuration(`G-done-${index}`));
+		}
+		goals.push(etaGoal({ id: "G-pending", status: "pending" }));
+		const eta = computeUltragoalEta(goals, NOW_MS);
+		expect(eta?.sampleSize).toBe(sampleSize);
+		expect(eta?.confidence).toBe(confidence);
+		expect(eta?.basis).toBe("observed_median");
+
+		const hud = buildUltragoalHudSummary(statusSummaryWithEta(eta));
+		const chip = hud.chips?.find(item => item.label === "eta");
+		expect(chip?.value).toContain(`${hudConfidenceLabel}/observed`);
+	});
+
+	it("review_blocked short-circuits to state=blocked without asserting a finish time", () => {
+		const goals = [
+			etaGoal({ id: "G001", status: "review_blocked", title: "Needs architect sign-off" }),
+			etaGoal({ id: "G002", status: "pending" }),
+		];
+		const eta = computeUltragoalEta(goals, NOW_MS);
+		expect(eta?.state).toBe("blocked");
+		expect(eta?.blockedReason).toContain("G001");
+		expect(eta?.blockedReason).toContain("review_blocked");
+		expect(eta?.finishAtLow).toBeUndefined();
+		expect(eta?.finishAtHigh).toBeUndefined();
+
+		const hud = buildUltragoalHudSummary(statusSummaryWithEta(eta));
+		const chip = hud.chips?.find(item => item.label === "eta");
+		expect(chip?.severity).toBe("blocked");
+		expect(chip?.value).toBe("blocked: G001 review_blocked: Needs architect sign-off low/fallback");
+	});
+});
+
+describe("ultragoal eta status/HUD/reconcile wiring", () => {
+	it("exposes a structured, low-confidence fallback eta in `status --json` and markdown", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: First\nDo first thing.\n\n@goal: Second\nDo second thing.",
+		});
+
+		const jsonResult = await runNativeUltragoalCommand(["status", "--json"], root);
+		expect(jsonResult.status).toBe(0);
+		const parsed = JSON.parse(jsonResult.stdout ?? "{}");
+		expect(parsed.eta).toMatchObject({
+			state: "estimating",
+			confidence: "low",
+			basis: "fallback_default",
+			sampleSize: 0,
+		});
+		expect(parsed.eta.remainingSecondsLow).toBeLessThanOrEqual(parsed.eta.remainingSecondsHigh);
+		expect(typeof parsed.eta.finishAtLow).toBe("string");
+		expect(typeof parsed.eta.finishAtHigh).toBe("string");
+
+		const markdownResult = await runNativeUltragoalCommand(["status"], root);
+		expect(markdownResult.status).toBe(0);
+		expect(markdownResult.stdout).toContain("- eta: elapsed=");
+		expect(markdownResult.stdout).toContain("confidence=low basis=fallback_default");
+		expect(markdownResult.stdout).toContain("- eta_finish: ~");
+
+		const summary = await getUltragoalStatus(root);
+		const hud = buildUltragoalHudSummary(summary);
+		const chip = hud.chips?.find(item => item.label === "eta");
+		expect(chip?.value).toContain("low/fallback");
+	});
+
+	it("reports state=blocked with a visible reason and a blocked HUD eta chip", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({
+			cwd: root,
+			brief: "@goal: First\nDo first thing.\n\n@goal: Second\nDo second thing.",
+		});
+		await startNextUltragoalGoal({ cwd: root });
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "blocked",
+			evidence: "blocked by an upstream outage",
+		});
+
+		const jsonResult = await runNativeUltragoalCommand(["status", "--json"], root);
+		const parsed = JSON.parse(jsonResult.stdout ?? "{}");
+		expect(parsed.status).toBe("blocked");
+		expect(parsed.eta.state).toBe("blocked");
+		expect(parsed.eta.blockedReason).toContain("G001");
+		expect(parsed.eta.finishAtLow).toBeUndefined();
+		expect(parsed.eta.finishAtHigh).toBeUndefined();
+
+		const summary = await getUltragoalStatus(root);
+		const hud = buildUltragoalHudSummary(summary);
+		const chip = hud.chips?.find(item => item.label === "eta");
+		expect(chip).toBeDefined();
+		expect(chip?.severity).toBe("blocked");
+		// The blocked chip must carry the same compact confidence/basis suffix as an
+		// estimating one instead of silently dropping it.
+		expect(chip?.value).toContain("low/fallback");
+
+		const markdownResult = await runNativeUltragoalCommand(["status"], root);
+		expect(markdownResult.stdout).toContain("- eta: blocked");
+	});
+
+	it("returns state=complete and omits the HUD eta chip once every goal is complete", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+		const result = await runNativeUltragoalCommand(
+			[
+				"checkpoint",
+				"--goal-id",
+				"G001",
+				"--status",
+				"complete",
+				"--evidence",
+				"tests passed",
+				"--quality-gate-json",
+				await passingLiveQualityGate(root),
+			],
+			root,
+		);
+		expect(result.status).toBe(0);
+
+		const summary = await getUltragoalStatus(root);
+		expect(summary.status).toBe("complete");
+		expect(summary.eta?.state).toBe("complete");
+		expect(summary.eta?.remainingSecondsLow).toBe(0);
+		expect(summary.eta?.remainingSecondsHigh).toBe(0);
+
+		const hud = buildUltragoalHudSummary(summary);
+		expect(hud.chips?.some(item => item.label === "eta")).toBe(false);
+
+		const markdownResult = await runNativeUltragoalCommand(["status"], root);
+		expect(markdownResult.stdout).not.toContain("- eta:");
+	});
+
+	it("threads eta through reconcile into mode-state and the active-state HUD chip", async () => {
+		const root = await tempDir();
+		const result = await runNativeUltragoalCommand(["create-goals", "--brief", "Ship the fix"], root);
+		expect(result.status).toBe(0);
+
+		const mode = (await Bun.file(sessionModeStatePath(root, TEST_SESSION_ID, "ultragoal")).json()) as Record<
+			string,
+			unknown
+		>;
+		const eta = mode.eta as Record<string, unknown>;
+		expect(eta.state).toBe("estimating");
+		expect(eta.basis).toBe("fallback_default");
+
+		const active = await readVisibleSkillActiveState(root);
+		const entry = active?.active_skills?.find(item => item.skill === "ultragoal");
+		const chip = entry?.hud?.chips?.find(item => item.label === "eta");
+		expect(chip).toBeDefined();
+		// Confidence/basis must survive the reconcile round-trip through mode-state into the
+		// durable active-state HUD chip, not just the freshly computed in-process eta.
+		expect(chip?.value).toContain("low/fallback");
+	});
+});
+describe("ultragoal eta HUD/markdown local finish formatting (cross-date)", () => {
+	function estimatingEta(finishAtLow: string, finishAtHigh: string, overrides: Partial<UltragoalEtaEstimate> = {}) {
+		return {
+			state: "estimating",
+			confidence: "low",
+			sampleSize: 0,
+			elapsedSeconds: 0,
+			remainingSecondsLow: 60,
+			remainingSecondsHigh: 120,
+			finishAtLow,
+			finishAtHigh,
+			basis: "fallback_default",
+			...overrides,
+		} satisfies UltragoalEtaEstimate;
+	}
+
+	it("keeps a bare HH:mm-HH:mm range and the exact confidence/basis label on the same local calendar day", () => {
+		const eta = estimatingEta(localIso(2026, 6, 15, 18, 20), localIso(2026, 6, 15, 19, 50));
+		const hud = buildUltragoalHudSummary(statusSummaryWithEta(eta));
+		const chip = hud.chips?.find(item => item.label === "eta");
+		expect(chip?.value).toBe("~18:20\u201319:50 low/fallback");
+
+		const markdown = renderUltragoalStatusMarkdown(statusSummaryWithEta(eta));
+		expect(markdown).toContain("- eta_finish: ~18:20\u201319:50 (local, estimate)");
+	});
+
+	it("switches to MM-DD HH:mm when the low/high finish times fall on different local calendar days", () => {
+		const eta = estimatingEta(localIso(2026, 6, 15, 23, 50), localIso(2026, 6, 16, 1, 20), {
+			confidence: "medium",
+			sampleSize: 3,
+			basis: "observed_median",
+		});
+		const hud = buildUltragoalHudSummary(statusSummaryWithEta(eta));
+		const chip = hud.chips?.find(item => item.label === "eta");
+		expect(chip?.value).toBe("~06-15 23:50\u201306-16 01:20 med/observed");
+
+		const markdown = renderUltragoalStatusMarkdown(statusSummaryWithEta(eta));
+		expect(markdown).toContain("- eta_finish: ~06-15 23:50\u201306-16 01:20 (local, estimate)");
+	});
+
+	it("switches to full YYYY-MM-DD HH:mm when the low/high finish times fall in different years", () => {
+		const eta = estimatingEta(localIso(2025, 12, 31, 23, 50), localIso(2026, 1, 1, 1, 20), {
+			confidence: "high",
+			sampleSize: 6,
+			basis: "observed_median",
+		});
+		const hud = buildUltragoalHudSummary(statusSummaryWithEta(eta));
+		const chip = hud.chips?.find(item => item.label === "eta");
+		expect(chip?.value).toBe("~2025-12-31 23:50\u20132026-01-01 01:20 high/observed");
+
+		const markdown = renderUltragoalStatusMarkdown(statusSummaryWithEta(eta));
+		expect(markdown).toContain("- eta_finish: ~2025-12-31 23:50\u20132026-01-01 01:20 (local, estimate)");
+	});
+
+	it("widens to seconds when distinct low/high instants fall in the same displayed minute", () => {
+		const finishAtLow = new Date(2026, 5, 15, 18, 20, 5, 0).toISOString();
+		const finishAtHigh = new Date(2026, 5, 15, 18, 20, 45, 0).toISOString();
+		const eta = estimatingEta(finishAtLow, finishAtHigh);
+		const hud = buildUltragoalHudSummary(statusSummaryWithEta(eta));
+		const chip = hud.chips?.find(item => item.label === "eta");
+		// Both endpoints share the same displayed HH:mm minute but are genuinely 40s
+		// apart: collapsing to a single "~18:20" would assert fake single-point precision.
+		expect(chip?.value).toBe("~18:20:05\u201318:20:45 low/fallback");
+
+		const markdown = renderUltragoalStatusMarkdown(statusSummaryWithEta(eta));
+		expect(markdown).toContain("- eta_finish: ~18:20:05\u201318:20:45 (local, estimate)");
+	});
+
+	it("distinguishes identical local wall-clock endpoints across a UTC-offset change (DST-fold style) using the offset itself", () => {
+		const lowIso = "2026-11-01T05:30:00.000Z";
+		const highIso = "2026-11-01T06:30:00.000Z";
+		const lowMs = Date.parse(lowIso);
+		const yearSpy = spyOn(Date.prototype, "getFullYear").mockReturnValue(2026);
+		const monthSpy = spyOn(Date.prototype, "getMonth").mockReturnValue(10);
+		const daySpy = spyOn(Date.prototype, "getDate").mockReturnValue(1);
+		const hourSpy = spyOn(Date.prototype, "getHours").mockReturnValue(1);
+		const minuteSpy = spyOn(Date.prototype, "getMinutes").mockReturnValue(30);
+		const secondSpy = spyOn(Date.prototype, "getSeconds").mockReturnValue(0);
+		const offsetSpy = spyOn(Date.prototype, "getTimezoneOffset").mockImplementation(function (this: Date) {
+			return this.getTime() === lowMs ? 240 : 300;
+		});
+		try {
+			const eta = estimatingEta(lowIso, highIso);
+			const hud = buildUltragoalHudSummary(statusSummaryWithEta(eta));
+			const chip = hud.chips?.find(item => item.label === "eta");
+			// Same local date/time down to the second on both sides, but genuinely different
+			// instants (a DST-fold-style pair straddling a UTC-offset change): the offset
+			// itself must disambiguate them instead of silently collapsing to one timestamp.
+			expect(chip?.value).toBe("~01:30:00 UTC-04:00\u201301:30:00 UTC-05:00 low/fallback");
+		} finally {
+			yearSpy.mockRestore();
+			monthSpy.mockRestore();
+			daySpy.mockRestore();
+			hourSpy.mockRestore();
+			minuteSpy.mockRestore();
+			secondSpy.mockRestore();
+			offsetSpy.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
Resubmission of #1952 against `dev`, as requested by the maintainer.

## Summary

- add adaptive Ultragoal completion estimates to `gjc ultragoal status` and `status --json`
- surface a compact local finish-time range in the existing workflow HUD
- show elapsed/remaining time, confidence, and calculation basis without asserting false precision
- preserve ETA data through Ultragoal state reconciliation and HUD recovery

## Estimation behavior

- before observed samples: broad 15–45 minute per-goal fallback (`low/fallback`)
- after completed goals: median observed duration with low/medium/high confidence based on sample count
- active-goal overruns retain a conservative non-zero uncertainty range without consuming successor-goal budgets
- blocked/review-blocked runs omit finish timestamps and explain the blocking goal
- completed runs omit the HUD ETA
- cross-day, cross-year, same-minute, and DST-fold ranges remain distinguishable

## UI example

```text
◆ hud ultragoal:pending goals=0/3 current=G001:API contract eta=~14:33–16:03 low/fallback status=pending

- eta: elapsed=0m remaining=45m–2h15m confidence=low basis=fallback_default
- eta_finish: ~14:33–16:03 (local, estimate)
```

## Verification on `dev`

- `bun test packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts packages/coding-agent/test/workflow-hud-summary.test.ts packages/coding-agent/test/skill-hud-bar.test.ts` — 178 passed
- `bun --cwd=packages/coding-agent run check:types` — passed with the `dev` TypeScript 7 toolchain
- Biome check on all changed TypeScript files — passed
- independent Codex review — `RESULT: CLEAR`
