### PR TITLE
fix(coding-agent): isolate local URL resolver ownership

### DIFF
--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -145,37 +145,56 @@ export class LocalProtocolHandler implements ProtocolHandler {
 	readonly immutable = false;
 
 	static #override: LocalProtocolOptions | undefined;
+	static #ownedOverrides: Array<{ options: LocalProtocolOptions }> = [];
 
 	/**
-	 * Install a process-global override that wins over the AgentRegistry-based
-	 * derivation. Used by SDK consumers that wire `localProtocolOptions` on
-	 * `createAgentSession` and by subagents that share their parent's root.
+	 * Install an explicit local-protocol mapping owned by the caller.
+	 *
+	 * The most recently installed live mapping wins. The returned disposer removes
+	 * only this registration and is safe to call more than once.
+	 */
+	static installOverride(value: LocalProtocolOptions): () => void {
+		const registration = { options: value };
+		LocalProtocolHandler.#ownedOverrides.push(registration);
+		let disposed = false;
+		return () => {
+			if (disposed) return;
+			disposed = true;
+			const index = LocalProtocolHandler.#ownedOverrides.indexOf(registration);
+			if (index !== -1) LocalProtocolHandler.#ownedOverrides.splice(index, 1);
+		};
+	}
+
+	/**
+	 * Install a process-global test override that wins over owned and registry
+	 * mappings. Prefer {@link installOverride} for lifecycle-bound production use.
 	 */
 	static setOverride(value: LocalProtocolOptions | undefined): void {
 		LocalProtocolHandler.#override = value;
 	}
 
-	/** Reset the process-global override. Test-only. */
+	/** Reset all process-global local-protocol overrides. Test-only. */
 	static resetOverrideForTests(): void {
 		LocalProtocolHandler.#override = undefined;
+		LocalProtocolHandler.#ownedOverrides = [];
 	}
 
 	/**
 	 * Returns the active local-protocol options.
 	 *
 	 * Resolution order:
-	 * 1. Explicit override installed via {@link setOverride} (used by subagents
-	 *    that share their parent's root and by SDK consumers with a custom
-	 *    artifacts/session id mapping).
-	 * 2. The main session in `AgentRegistry.global()`. Its `SessionManager`
-	 *    supplies both `getArtifactsDir` and `getSessionId`.
+	 * 1. Direct test override installed via {@link setOverride}.
+	 * 2. The most recently installed live owned override.
+	 * 3. A live main session in `AgentRegistry.global()`.
 	 */
 	static resolveOptions(): LocalProtocolOptions | undefined {
 		const override = LocalProtocolHandler.#override;
 		if (override) return override;
+		const ownedOverride = LocalProtocolHandler.#ownedOverrides.at(-1)?.options;
+		if (ownedOverride) return ownedOverride;
 		const main = AgentRegistry.global()
 			.list()
-			.find(ref => ref.kind === "main");
+			.find(ref => ref.kind === "main" && ref.session && (ref.status === "running" || ref.status === "idle"));
 		const sessionManager = main?.session?.sessionManager;
 		if (!sessionManager) return undefined;
 		return {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1272,6 +1272,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const isSubSession = taskDepth > 0 || Boolean(options.parentTaskPrefix) || Boolean(options.currentAgentType);
 	const resolvedAgentDisplayName = options.agentDisplayName ?? (isSubSession ? "sub" : "main");
 	const evalKernelOwnerId = `agent-session:${Snowflake.next()}`;
+	let disposeLocalProtocolOverride: (() => void) | undefined;
+	let localProtocolOverrideReleased = false;
+	const releaseLocalProtocolOverride = (): void => {
+		if (localProtocolOverrideReleased) return;
+		localProtocolOverrideReleased = true;
+		disposeLocalProtocolOverride?.();
+	};
 
 	try {
 		const getActiveModelString = (): string | undefined => {
@@ -1401,7 +1408,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			if (asyncJobManager) AsyncJobManager.setInstance(asyncJobManager);
 		}
 		if (options.localProtocolOptions) {
-			LocalProtocolHandler.setOverride(options.localProtocolOptions);
+			disposeLocalProtocolOverride = LocalProtocolHandler.installOverride(options.localProtocolOptions);
 		}
 		toolSession.getArtifactsDir = getArtifactsDir;
 		toolSession.agentOutputManager = new AgentOutputManager(
@@ -2371,6 +2378,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				} finally {
 					agentRegistry.unregister(resolvedAgentId);
 					unsubscribeCredentialDisabled?.();
+					releaseLocalProtocolOverride();
 				}
 			};
 		}
@@ -2535,6 +2543,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			logger.warn("Failed to clean up createAgentSession resources after startup error", {
 				error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
 			});
+		} finally {
+			releaseLocalProtocolOverride();
 		}
 		throw error;
 	}

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -8,6 +8,8 @@ import {
 	resolveLocalRoot,
 	resolveLocalUrlToPath,
 } from "@gajae-code/coding-agent/internal-urls";
+import { AgentRegistry } from "@gajae-code/coding-agent/registry/agent-registry";
+import type { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
 	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "local-protocol-"));
@@ -21,12 +23,95 @@ async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
 describe("LocalProtocolHandler", () => {
 	beforeEach(() => {
 		LocalProtocolHandler.resetOverrideForTests();
+		AgentRegistry.resetGlobalForTests();
 		InternalUrlRouter.resetForTests();
 	});
 
 	afterEach(() => {
 		LocalProtocolHandler.resetOverrideForTests();
+		AgentRegistry.resetGlobalForTests();
 		InternalUrlRouter.resetForTests();
+	});
+
+	it("prefers explicit owned mappings over a live main registry session", () => {
+		AgentRegistry.global().register({
+			id: "main",
+			displayName: "main",
+			kind: "main",
+			status: "running",
+			session: {
+				sessionManager: {
+					getArtifactsDir: () => "/registry-artifacts",
+					getSessionId: () => "registry-session",
+				},
+			} as unknown as AgentSession,
+		});
+		const owned = { getArtifactsDir: () => "/owned-artifacts", getSessionId: () => "owned-session" };
+		const dispose = LocalProtocolHandler.installOverride(owned);
+
+		expect(LocalProtocolHandler.resolveOptions()).toBe(owned);
+
+		dispose();
+		const fallback = LocalProtocolHandler.resolveOptions();
+		expect(fallback?.getArtifactsDir?.()).toBe("/registry-artifacts");
+		expect(fallback?.getSessionId?.()).toBe("registry-session");
+	});
+
+	it("uses only live main registry sessions as the fallback", () => {
+		const session = {
+			sessionManager: {
+				getArtifactsDir: () => "/registry-artifacts",
+				getSessionId: () => "registry-session",
+			},
+		} as unknown as AgentSession;
+		const resolveForStatus = (status: "idle" | "completed" | "aborted") => {
+			AgentRegistry.resetGlobalForTests();
+			AgentRegistry.global().register({
+				id: "main",
+				displayName: "main",
+				kind: "main",
+				status,
+				session,
+			});
+			return LocalProtocolHandler.resolveOptions();
+		};
+
+		const idle = resolveForStatus("idle");
+		expect(idle?.getArtifactsDir?.()).toBe("/registry-artifacts");
+		expect(idle?.getSessionId?.()).toBe("registry-session");
+		expect(resolveForStatus("completed")).toBeUndefined();
+		expect(resolveForStatus("aborted")).toBeUndefined();
+	});
+
+	it("keeps the newest owned mapping live until its exact disposer runs", () => {
+		const first = { getArtifactsDir: () => "/first", getSessionId: () => "first" };
+		const second = { getArtifactsDir: () => "/second", getSessionId: () => "second" };
+		const third = { getArtifactsDir: () => "/third", getSessionId: () => "third" };
+		const disposeFirst = LocalProtocolHandler.installOverride(first);
+		const disposeSecond = LocalProtocolHandler.installOverride(second);
+		const disposeThird = LocalProtocolHandler.installOverride(third);
+
+		expect(LocalProtocolHandler.resolveOptions()).toBe(third);
+		disposeSecond();
+		expect(LocalProtocolHandler.resolveOptions()).toBe(third);
+		disposeSecond();
+		expect(LocalProtocolHandler.resolveOptions()).toBe(third);
+		disposeThird();
+		expect(LocalProtocolHandler.resolveOptions()).toBe(first);
+		disposeFirst();
+		expect(LocalProtocolHandler.resolveOptions()).toBeUndefined();
+		disposeFirst();
+		expect(LocalProtocolHandler.resolveOptions()).toBeUndefined();
+	});
+
+	it("reset clears direct and owned overrides", () => {
+		const owned = { getArtifactsDir: () => "/owned", getSessionId: () => "owned" };
+		LocalProtocolHandler.installOverride(owned);
+		LocalProtocolHandler.setOverride({ getArtifactsDir: () => "/direct", getSessionId: () => "direct" });
+
+		LocalProtocolHandler.resetOverrideForTests();
+
+		expect(LocalProtocolHandler.resolveOptions()).toBeUndefined();
 	});
 
 	it("lists files at local://", async () => {

--- a/packages/coding-agent/test/sdk-session-isolation.test.ts
+++ b/packages/coding-agent/test/sdk-session-isolation.test.ts
@@ -5,8 +5,12 @@ import * as path from "node:path";
 import { type AssistantMessage, getBundledModel } from "@gajae-code/ai";
 import type { Rule } from "@gajae-code/coding-agent/capability/rule";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
+import type { ExtensionFactory } from "@gajae-code/coding-agent/extensibility/extensions";
+import { LocalProtocolHandler, resolveLocalUrlToPath } from "@gajae-code/coding-agent/internal-urls";
+import { AgentRegistry } from "@gajae-code/coding-agent/registry/agent-registry";
 import { createAgentSession } from "@gajae-code/coding-agent/sdk";
 import { SecretObfuscator } from "@gajae-code/coding-agent/secrets";
+import type { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import { getSessionsDir, Snowflake } from "@gajae-code/utils";
 
@@ -57,6 +61,8 @@ describe("createAgentSession session storage isolation", () => {
 	const tempDirs: string[] = [];
 
 	afterEach(async () => {
+		LocalProtocolHandler.resetOverrideForTests();
+		AgentRegistry.resetGlobalForTests();
 		for (const tempDir of tempDirs.splice(0)) {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -93,6 +99,103 @@ describe("createAgentSession session storage isolation", () => {
 		} finally {
 			await session.dispose();
 		}
+	});
+
+	it("releases each session's owned local:// override on dispose", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-sdk-local-protocol-${Snowflake.next()}-`));
+		tempDirs.push(tempDir);
+		const cwd = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		const firstArtifactsDir = path.join(tempDir, "first-artifacts");
+		const secondArtifactsDir = path.join(tempDir, "second-artifacts");
+		fs.mkdirSync(cwd, { recursive: true });
+		const sessionOptions = {
+			cwd,
+			agentDir,
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		};
+		let firstSession: AgentSession | undefined;
+		let secondSession: AgentSession | undefined;
+		try {
+			firstSession = (
+				await createAgentSession({
+					...sessionOptions,
+					localProtocolOptions: {
+						getArtifactsDir: () => firstArtifactsDir,
+						getSessionId: () => "first-local-session",
+					},
+				})
+			).session;
+			expect(resolveLocalUrlToPath("local://note.md", LocalProtocolHandler.resolveOptions()!)).toBe(
+				path.join(firstArtifactsDir, "local", "note.md"),
+			);
+
+			secondSession = (
+				await createAgentSession({
+					...sessionOptions,
+					localProtocolOptions: {
+						getArtifactsDir: () => secondArtifactsDir,
+						getSessionId: () => "second-local-session",
+					},
+				})
+			).session;
+			expect(resolveLocalUrlToPath("local://note.md", LocalProtocolHandler.resolveOptions()!)).toBe(
+				path.join(secondArtifactsDir, "local", "note.md"),
+			);
+
+			await secondSession.dispose();
+			secondSession = undefined;
+			expect(resolveLocalUrlToPath("local://note.md", LocalProtocolHandler.resolveOptions()!)).toBe(
+				path.join(firstArtifactsDir, "local", "note.md"),
+			);
+			await firstSession.dispose();
+			firstSession = undefined;
+			expect(LocalProtocolHandler.resolveOptions()).toBeUndefined();
+		} finally {
+			await secondSession?.dispose();
+			await firstSession?.dispose();
+		}
+	});
+
+	it("releases an owned local:// override when startup fails", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-sdk-local-protocol-failure-${Snowflake.next()}-`));
+		tempDirs.push(tempDir);
+		const cwd = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		const artifactsDir = path.join(tempDir, "artifacts");
+		fs.mkdirSync(cwd, { recursive: true });
+		const throwingExtension: ExtensionFactory = () => {
+			throw new Error("simulated local protocol startup failure");
+		};
+
+		await expect(
+			createAgentSession({
+				cwd,
+				agentDir,
+				settings: Settings.isolated(),
+				disableExtensionDiscovery: true,
+				extensions: [throwingExtension],
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				localProtocolOptions: {
+					getArtifactsDir: () => artifactsDir,
+					getSessionId: () => "failed-local-session",
+				},
+			}),
+		).rejects.toThrow("simulated local protocol startup failure");
+
+		expect(LocalProtocolHandler.resolveOptions()).toBeUndefined();
 	});
 	it("wires the discovered TTSR manager into the created session", async () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-sdk-ttsr-${Snowflake.next()}-`));

--- a/packages/coding-agent/test/tui/hyperlink.test.ts
+++ b/packages/coding-agent/test/tui/hyperlink.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
+import { LocalProtocolHandler } from "@gajae-code/coding-agent/internal-urls";
+import { AgentRegistry } from "@gajae-code/coding-agent/registry/agent-registry";
 import { fileHyperlink, isHyperlinkEnabled, tryResolveInternalUrlSync } from "@gajae-code/coding-agent/tui/hyperlink";
 import * as terminalCaps from "@gajae-code/tui";
 
@@ -27,15 +29,21 @@ function setHyperlinkMode(mode: "off" | "auto" | "always"): void {
 
 beforeAll(async () => {
 	resetSettingsForTest();
+	LocalProtocolHandler.resetOverrideForTests();
+	AgentRegistry.resetGlobalForTests();
 	await Settings.init({ inMemory: true });
 });
 
 afterAll(() => {
 	resetSettingsForTest();
+	LocalProtocolHandler.resetOverrideForTests();
+	AgentRegistry.resetGlobalForTests();
 });
 
 afterEach(() => {
 	settings.clearOverride("tui.hyperlinks");
+	LocalProtocolHandler.resetOverrideForTests();
+	AgentRegistry.resetGlobalForTests();
 	if (ORIGINAL_NO_COLOR === undefined) {
 		delete Bun.env.NO_COLOR;
 	} else {


### PR DESCRIPTION
## Summary
- replace the unowned process-global `/home/bellman/.gjc/agent/sessions/-Workspace-gajae-code/2026-07-10T06-22-51-067Z_019f4ab1-72bb-7000-b29b-7a02eff9060c/local` SDK override with exact owner registrations and idempotent disposers
- release each registration on normal session disposal and partial startup failure without clearing another live session/subagent mapping
- isolate hyperlink tests from `LocalProtocolHandler` and `AgentRegistry` state while preserving the unchanged no-owner assertion
- add owner ordering, out-of-order disposal, registry liveness, SDK disposal, and startup-failure regression coverage

## Root cause
`createAgentSession({ localProtocolOptions })` installed a static override that survived session teardown. A prior shard-2 test could therefore leave `/tmp/gjc-local/<session-id>` visible to `tryResolveInternalUrlSync(/home/bellman/.gjc/agent/sessions/-Workspace-gajae-code/2026-07-10T06-22-51-067Z_019f4ab1-72bb-7000-b29b-7a02eff9060c/local/foo.md)` in `test/tui/hyperlink.test.ts`.

## Regression lineage
- Initial dev failure: https://github.com/Yeachan-Heo/gajae-code/actions/runs/29073429888
- Post-TypeScript-7 dev failure: https://github.com/Yeachan-Heo/gajae-code/actions/runs/29075715027
- Failing job: https://github.com/Yeachan-Heo/gajae-code/actions/runs/29075715027/job/86307911701
- Base: `dev@2a0aec7830d49c27f630f940856a71079cfea330`
- Head: `2c74724208c4cbe2cb6be73e11c22651f0db540d` (one DCO-signed commit)

## Verification
- `bun --cwd=packages/coding-agent test test/tui/hyperlink.test.ts` — 18 pass
- `bun --cwd=packages/coding-agent test test/internal-urls/local-protocol.test.ts` — 9 pass
- `bun --cwd=packages/coding-agent test test/sdk-session-isolation.test.ts` — 6 pass
- combined focused suite repeated 3x — 33 pass each run
- `bun --cwd=packages/coding-agent test --shard=2/8` — 834 pass, 64 skip, 0 fail
- `bun --cwd=packages/coding-agent test` — 8673 pass, 357 skip, 0 fail
- `bun --cwd=packages/coding-agent run check` — Biome + TypeScript 7 `tsc --noEmit` pass
- AI slop cleanup sweep — PASS, zero blocking findings
- Independent GJC architect review — CLEAR/CLEAR/CLEAR, APPROVE
- Independent executor QA/red-team — passed, zero blockers

## Delivery boundary
Internal tracking label 1958 only; no GitHub issue was created. Do not merge until exact-head CI is green and the independent GJC review evidence remains valid.