### PR TITLE
fix(coordinator-mcp): 긴 tool call이 keepalive를 굶기지 않도록 stdio 요청을 동시 처리

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Migrated the repository type-check and release declaration pipeline to stable TypeScript 7.0.2, including the robogjc web workspace and a non-mutating publish-type gate.
 
+### Fixed
+
+- Coordinator MCP stdio server now dispatches JSON-RPC requests concurrently and answers the standard `ping` utility, so a long-running tool call (e.g. `gjc_coordinator_await_turn`, which polls a delegated turn for minutes) no longer blocks keepalive on the same channel. Previously the read loop awaited each request serially, starving keepalive during long delegations until the client's heartbeat timed out and tore the connection down — stretching ~110s delegated reviews to 300–625s. Measured live: coordinator keepalive failures 33→0 and a delegated deep review 625s→136s.
+
 ## [0.9.6] - 2026-07-10
 ### Changed
 

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -2508,6 +2508,13 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		if (request.method === "resources/list") {
 			return { jsonrpc: "2.0", id, result: { resources: [] } };
 		}
+		if (request.method === "ping") {
+			// MCP ping utility: a lightweight liveness probe. Answering it keeps
+			// the client's keepalive cheap and — crucially, once the stdio read
+			// loop dispatches concurrently — answerable even while a long-running
+			// tool call (e.g. gjc_coordinator_await_turn) is still in flight.
+			return { jsonrpc: "2.0", id, result: {} };
+		}
 		if (request.method === "tools/call") {
 			const params = (request.params ?? {}) as { name?: string; arguments?: Record<string, unknown> };
 			const payload = await callTool(params.name ?? "", params.arguments ?? {});
@@ -2567,23 +2574,72 @@ export async function handleCoordinatorMcpRequest(
 	};
 }
 
-export async function runCoordinatorMcpStdio(options: CoordinatorMcpServerOptions = {}): Promise<void> {
-	const server = createCoordinatorMcpServer(options);
+/**
+ * Pump a newline-delimited JSON-RPC stream, dispatching each request
+ * CONCURRENTLY. A long-running tool call (e.g. gjc_coordinator_await_turn,
+ * which polls a delegated turn for minutes) must never block the read loop
+ * from processing keepalive pings on the same stdio channel — otherwise the
+ * client's heartbeat times out mid-delegation and tears the connection down.
+ *
+ * Responses correlate by JSON-RPC id, so they may complete out of order; only
+ * the writes are serialized so concurrent frames can't interleave on the wire.
+ * Extracted from runCoordinatorMcpStdio so the concurrency can be unit-tested.
+ */
+export async function pumpCoordinatorMcpStream(
+	handleJsonRpc: (request: JsonRpcRequest) => Promise<JsonRpcResponse>,
+	input: AsyncIterable<string | Uint8Array>,
+	writeLine: (line: string) => void | Promise<void>,
+): Promise<void> {
 	let buffer = "";
-	for await (const chunk of process.stdin) {
-		buffer += chunk.toString();
+	let writeChain: Promise<void> = Promise.resolve();
+	const emit = (response: JsonRpcResponse): void => {
+		writeChain = writeChain.then(() => writeLine(`${JSON.stringify(response)}\n`));
+	};
+	const dispatch = (request: JsonRpcRequest): void => {
+		handleJsonRpc(request)
+			.then(emit)
+			.catch((err: unknown) => {
+				emit({
+					jsonrpc: "2.0",
+					id: request.id ?? null,
+					error: { code: -32603, message: err instanceof Error ? err.message : String(err) },
+				});
+			});
+	};
+
+	for await (const chunk of input) {
+		buffer += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString();
 		let newline = buffer.indexOf("\n");
 		while (newline >= 0) {
 			const line = buffer.slice(0, newline).trim();
 			buffer = buffer.slice(newline + 1);
 			if (line.length > 0) {
-				const request = JSON.parse(line) as JsonRpcRequest;
-				if (request.id !== undefined && request.id !== null) {
-					const response = await server.handleJsonRpc(request);
-					process.stdout.write(`${JSON.stringify(response)}\n`);
+				let request: JsonRpcRequest | null = null;
+				try {
+					request = JSON.parse(line) as JsonRpcRequest;
+				} catch {
+					request = null; // ignore malformed frames rather than crashing the loop
+				}
+				// Requests without an id are notifications — no response expected.
+				if (request && request.id !== undefined && request.id !== null) {
+					dispatch(request);
 				}
 			}
 			newline = buffer.indexOf("\n");
 		}
 	}
+	// Flush any responses still queued when the input stream ends.
+	await writeChain;
+}
+
+export async function runCoordinatorMcpStdio(options: CoordinatorMcpServerOptions = {}): Promise<void> {
+	const server = createCoordinatorMcpServer(options);
+	await pumpCoordinatorMcpStream(
+		request => server.handleJsonRpc(request),
+		process.stdin,
+		line =>
+			new Promise<void>(resolve => {
+				process.stdout.write(line, () => resolve());
+			}),
+	);
 }

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -13,6 +13,7 @@ import {
 	COORDINATOR_MCP_TOOL_NAMES,
 	COORDINATOR_POLL_INTERVAL_MAX_MS,
 	createCoordinatorMcpServer,
+	pumpCoordinatorMcpStream,
 } from "../src/coordinator-mcp/server";
 
 const tempDirs: string[] = [];
@@ -63,6 +64,43 @@ describe("Coordinator MCP server protocol", () => {
 
 		const resources = await server.handleJsonRpc({ jsonrpc: "2.0", id: 21, method: "resources/list", params: {} });
 		expect(resources.result.resources).toEqual([]);
+	});
+
+	it("answers the MCP ping utility with an empty result", async () => {
+		const server = createCoordinatorMcpServer({ env: {} });
+		const res = await server.handleJsonRpc({ jsonrpc: "2.0", id: 7, method: "ping", params: {} });
+		expect(res).toEqual({ jsonrpc: "2.0", id: 7, result: {} });
+	});
+
+	it("dispatches concurrently: a slow in-flight request never blocks a later ping", async () => {
+		let releaseSlow: () => void = () => {};
+		const slowGate = new Promise<void>(resolve => {
+			releaseSlow = resolve;
+		});
+		const handle = async (request: {
+			id?: number | string | null;
+			method?: string;
+		}): Promise<{ jsonrpc: "2.0"; id: number | string | null; result: unknown }> => {
+			if (request.method === "slow") await slowGate; // stays pending until released
+			return { jsonrpc: "2.0", id: request.id ?? null, result: {} };
+		};
+
+		const writtenIds: Array<number | string | null> = [];
+		async function* input(): AsyncGenerator<string> {
+			yield `${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "slow" })}\n`;
+			yield `${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "ping" })}\n`;
+			await new Promise(resolve => setTimeout(resolve, 25)); // let ping resolve while slow is pending
+			releaseSlow(); // now let the slow request finish
+			await new Promise(resolve => setTimeout(resolve, 25));
+		}
+
+		await pumpCoordinatorMcpStream(handle as never, input(), line => {
+			writtenIds.push((JSON.parse(line) as { id: number | string | null }).id);
+		});
+
+		// The ping (id 2) must be answered before the still-pending slow request
+		// (id 1) — proving the read loop did not serialize behind the long call.
+		expect(writtenIds).toEqual([2, 1]);
 	});
 
 	it("does not read ambient coordinator MCP env when explicit env is provided", async () => {


### PR DESCRIPTION
## What

코디네이터 MCP의 stdio 루프(`runCoordinatorMcpStdio`)가 JSON-RPC 요청을 하나씩 `await`로 **직렬 처리**하고 있었다. `gjc_coordinator_await_turn`처럼 위임된 턴을 수 분간 폴링하는 긴 tool call이 도는 동안 read 루프가 그 `await`에 묶여, **같은 stdio 채널로 들어오는 클라이언트 keepalive에 응답하지 못했다.**

- read 루프에서 각 요청을 `await`하지 않고 dispatch한다. 응답은 JSON-RPC `id`로 대응되므로 완료 순서가 뒤섞여도 무방하고, **stdout write만 직렬화**해서 동시 프레임이 와이어에서 섞이지 않게 한다.
- MCP 표준 `ping` 유틸리티를 구현한다. 기존엔 `-32601 unknown_method`를 돌려줘 클라이언트가 무거운 `list_tools`를 keepalive로 대체 사용했다. 이제 keepalive가 가볍고 tool call 진행 중에도 응답 가능하다.
- 동시성 자체를 단위 테스트할 수 있도록 read/dispatch 루프를 `pumpCoordinatorMcpStream`(핸들러/입력 스트림/write 함수 주입 가능)으로 분리했다. `runCoordinatorMcpStdio`는 여기에 실제 stdin/stdout을 물리는 얇은 래퍼가 된다.

## Why (root cause)

긴 `await_turn` 동안 read 루프가 블록됨 → keepalive ping 응답 지연 → 클라이언트 하트비트 타임아웃 → 연결을 죽은 것으로 간주하고 강제 종료 → 재연결하면서 in-flight 위임이 유실 → 재시도. 그 결과 실제 ~110초짜리 위임 리뷰가 300~625초까지 늘어졌다.

핵심은 "클라이언트 타임아웃 값이 짧아서"가 아니라 **서버가 진행 중인 tool call 때문에 keepalive에 응답할 수 없는 구조**였다는 점이다. 그래서 타임아웃을 키우는 우회 대신 동시 dispatch + 표준 ping으로 전송 계층을 근본 수정했다.

## Testing

- `bun test packages/coding-agent/test/coordinator-mcp-server.test.ts` — **36 pass**. 추가한 회귀 2건:
  - `ping` 유틸리티가 `{ jsonrpc: "2.0", id, result: {} }`를 반환.
  - `pumpCoordinatorMcpStream`에 게이트로 pending을 유지하는 느린 요청을 먼저 넣고 뒤이어 `ping`을 흘리면, **느린 요청이 아직 진행 중일 때 ping이 먼저 응답된다** — read 루프가 긴 call 뒤로 직렬화되지 않음을 증명. 수정 전 코드에선 실패한다.
- `bun --cwd=packages/coding-agent run check:types` (`tsc --noEmit`) — green. 변경 파일 `biome check` clean.
- 라이브 실측(Hermes ↔ 코디네이터 MCP, GitHub PR 자동 리뷰 위임):
  - 코디네이터 keepalive 실패: **33회 → 0회** (수정본 기동 후 전무).
  - `does not implement the optional 'ping'` 경고: **소멸**(클라이언트가 ping 사용).
  - deep 리뷰 위임 `gjc_delegate_execute`: **625s → 136s** (워커 실제 작업시간 수준으로 수렴, 300s+ 스톨 소멸).

---

- [x] `bun check` passes (`biome check` + `tsc --noEmit`)
- [x] Tested locally (유닛 회귀 + 라이브 실측)
- [x] CHANGELOG updated (coding-agent `[Unreleased] > Fixed`)
