### PR TITLE
fix(coding-agent): preserve Telegram topic user renames

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Migrated the repository type-check and release declaration pipeline to stable TypeScript 7.0.2, including the robogjc web workspace and a non-mutating publish-type gate.
 
+### Fixed
+
+- Preserved explicit Telegram forum-topic renames as durable user-owned names, immediately re-asserting delayed edits while retaining restart and rename-race recovery (#1910).
+
 ## [0.9.6] - 2026-07-10
 ### Changed
 

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -167,6 +167,10 @@ function endpointGenerationKey(url: string, token: string): string {
 	return `${url}\0${token}`;
 }
 
+function topicRenameApplied(response: unknown): boolean {
+	return !!response && typeof response === "object" && (response as { ok?: unknown }).ok === true;
+}
+
 /**
  * Whether `err` is a transient network failure worth retrying. Telegram API
  * calls over HTTP/2 occasionally surface mid-stream `ECONNRESET` (and similar)
@@ -756,11 +760,15 @@ export class TelegramBotTransport implements BotApi {
 	}
 }
 
+type PairedChatPrivacy = "private" | "non-private" | "indeterminate";
+
+export type TelegramUpdateOutcome = "consumed" | "retry";
+
 export interface TelegramUpdatePollerOptions {
 	botApi: BotApi;
 	runtime: NotificationOperatorRuntime;
 	backoff: OperatorBackoffPolicy;
-	processUpdate: (update: unknown) => Promise<void>;
+	processUpdate: (update: unknown) => Promise<TelegramUpdateOutcome>;
 }
 
 /** Owns getUpdates offset, conflict backoff, and per-update error isolation. */
@@ -805,11 +813,16 @@ export class TelegramUpdatePoller {
 		}
 		this.#opts.backoff.reset();
 		for (const update of body.result ?? []) {
-			this.#offset = update.update_id + 1;
 			try {
-				await this.#opts.processUpdate(update);
+				const outcome = await this.#opts.processUpdate(update);
+				if (outcome === "retry") {
+					await this.#opts.runtime.sleep(this.#opts.backoff.next(), signal);
+					break;
+				}
+				this.#offset = update.update_id + 1;
 			} catch (err) {
 				logger.error("notifications daemon: handleTelegramUpdate failed", { error: String(err) });
+				this.#offset = update.update_id + 1;
 			}
 		}
 		return body.result?.length ?? 0;
@@ -904,6 +917,10 @@ export class TelegramNotificationDaemon {
 	private readonly fsImpl: TelegramDaemonFs;
 	private readonly botApi: BotApi;
 	private readonly topics = new TopicRegistry();
+	/** Serializes registry snapshots so an older atomic write cannot overwrite newer rename state. */
+	private topicsPersistQueue: Promise<void> = Promise.resolve();
+	/** Daemon edit attempts that can race an accepted user service message. */
+	private readonly daemonRenameAttempts = new Map<string, number>();
 	private readonly pool: RateLimitPool<{ send: ThreadedSend; topicId?: string }>;
 	private readonly poller: TelegramUpdatePoller;
 	private readonly dispatchState = new TelegramEventDispatchState();
@@ -1294,7 +1311,7 @@ export class TelegramNotificationDaemon {
 			botApi: this.botApi,
 			runtime: this.runtime,
 			backoff: this.pollConflictBackoff,
-			processUpdate: update => this.handleTelegramUpdate(update),
+			processUpdate: update => this.processTelegramUpdate(update),
 		});
 	}
 
@@ -1615,11 +1632,13 @@ export class TelegramNotificationDaemon {
 		const identityKey = this.topicIdentityKey(msg);
 		const remembered = identityKey ? this.topicOwnerByIdentity.get(identityKey) : undefined;
 		if (remembered && this.topics.get(remembered)) return remembered;
+		if (!identityKey) return undefined;
 		const base = this.topicIdentityBase(msg);
-		if (!identityKey || !base) return undefined;
 		for (const sessionId of this.topics.sessionIds()) {
-			const name = this.topics.get(sessionId)?.name;
-			if (name === base || name?.startsWith(`${base} - `)) {
+			const topic = this.topics.get(sessionId);
+			const nameMatchesLegacyIdentity =
+				base !== undefined && (topic?.name === base || topic?.name?.startsWith(`${base} - `));
+			if (topic?.identityKey === identityKey || nameMatchesLegacyIdentity) {
 				this.topicOwnerByIdentity.set(identityKey, sessionId);
 				return sessionId;
 			}
@@ -1647,6 +1666,37 @@ export class TelegramNotificationDaemon {
 	private async existingTopicForPrivateChat(sessionId: string): Promise<string | undefined> {
 		if (!(await this.pairedChatIsPrivate())) return undefined;
 		return this.topics.get(sessionId)?.topicId;
+	}
+
+	/** Best-effort re-assertion for a durable user-owned topic name. */
+	private async reconcileUserTopicName(sessionId: string, topicId: string): Promise<void> {
+		if ((this.daemonRenameAttempts.get(sessionId) ?? 0) > 0) return;
+		let userName = this.topics.userNameToReconcile(sessionId);
+		while (userName) {
+			try {
+				const response = await this.botApi.call("editForumTopic", {
+					chat_id: this.opts.chatId,
+					message_thread_id: Number(topicId),
+					name: userName,
+				});
+				if (!topicRenameApplied(response)) return;
+				const latestUserName = this.topics.userOwnedName(sessionId);
+				if (latestUserName === userName) {
+					if (this.topics.markUserNameReconciled(sessionId, userName)) {
+						try {
+							await this.persistTopics();
+						} catch {
+							this.topics.markUserNamePending(sessionId, userName);
+						}
+					}
+					return;
+				}
+				userName = this.topics.userNameToReconcile(sessionId);
+			} catch {
+				// Keep the durable pending flag so the next identity frame retries.
+				return;
+			}
+		}
 	}
 
 	private rememberPendingThreadedFrame(sessionId: string, send: ThreadedSend, msg: Record<string, unknown>): void {
@@ -1737,10 +1787,14 @@ export class TelegramNotificationDaemon {
 		}
 	}
 
-	private async persistTopics(): Promise<void> {
-		const paths = daemonPaths(this.opts.settings.getAgentDir());
-		await ensureDir(this.fsImpl, paths.dir);
-		await writeJsonAtomic(this.fsImpl, path.join(paths.dir, "telegram-topics.json"), this.topics.serialize());
+	private persistTopics(): Promise<void> {
+		const pending = this.topicsPersistQueue.then(async () => {
+			const paths = daemonPaths(this.opts.settings.getAgentDir());
+			await ensureDir(this.fsImpl, paths.dir);
+			await writeJsonAtomic(this.fsImpl, path.join(paths.dir, "telegram-topics.json"), this.topics.serialize());
+		});
+		this.topicsPersistQueue = pending.catch(() => undefined);
+		return pending;
 	}
 
 	async loadTopics(): Promise<void> {
@@ -2128,23 +2182,41 @@ export class TelegramNotificationDaemon {
 	}
 
 	/**
-	 * Resolve (and cache successful resolution of) whether the paired `chatId` is a
-	 * private chat. Topic and flat delivery are only safe in a private DM; any
-	 * non-private chat fails closed, while a transient `getChat` failure fails closed
-	 * for the current attempt and is retried later.
+	 * Resolve (and cache definitive resolution of) whether the paired `chatId` is
+	 * a private chat. Topic and flat delivery are only safe in a private DM; an
+	 * indeterminate `getChat` result fails closed for this attempt and is retried
+	 * later.
 	 */
-	private async pairedChatIsPrivate(): Promise<boolean> {
-		if (this.pairedChatPrivate !== undefined) return this.pairedChatPrivate;
+	private async resolvePairedChatPrivacy(): Promise<PairedChatPrivacy> {
+		if (this.pairedChatPrivate !== undefined) return this.pairedChatPrivate ? "private" : "non-private";
 		try {
 			const res = (await this.botApi.call("getChat", { chat_id: this.opts.chatId })) as {
-				result?: { type?: string };
+				ok?: unknown;
+				result?: { type?: unknown };
 			};
-			this.pairedChatPrivate = res.result?.type === "private";
-			return this.pairedChatPrivate;
-		} catch (e) {
-			logger.warn(`notifications: getChat failed while checking Telegram chat privacy: ${String(e)}`);
-			return false;
+			if (res?.ok !== true) {
+				logger.warn("notifications: getChat privacy check indeterminate (non-success response)");
+				return "indeterminate";
+			}
+			if (res.result?.type === "private") {
+				this.pairedChatPrivate = true;
+				return "private";
+			}
+			if (res.result?.type === "group" || res.result?.type === "supergroup" || res.result?.type === "channel") {
+				this.pairedChatPrivate = false;
+				return "non-private";
+			}
+			logger.warn("notifications: getChat privacy check indeterminate (missing or invalid chat type)");
+			return "indeterminate";
+		} catch {
+			logger.warn("notifications: getChat privacy check indeterminate (request failed)");
+			return "indeterminate";
 		}
+	}
+
+	/** Keep existing outbound callers fail-closed for indeterminate privacy. */
+	private async pairedChatIsPrivate(): Promise<boolean> {
+		return (await this.resolvePairedChatPrivacy()) === "private";
 	}
 
 	/** Tell the user once (per daemon run) how to enable Threaded Mode. */
@@ -2257,26 +2329,37 @@ export class TelegramNotificationDaemon {
 			}
 			if (send.identity) {
 				const identityKey = this.topicIdentityKey(msg);
-				if (identityKey) this.topicOwnerByIdentity.set(identityKey, session.sessionId);
-				// Rename the topic if the title changed (e.g. the session title was
-				// auto-generated after the topic was first created). This runs on
-				// every identity frame, but does NOT re-send the bulleted message.
-				// Only commit the new registry name after Telegram accepts the edit:
-				// a transient editForumTopic failure must remain retryable on the
-				// next identity re-assert instead of leaving the remote topic stuck
-				// at the provisional "GJC <id>" name forever.
+				if (identityKey) {
+					this.topicOwnerByIdentity.set(identityKey, session.sessionId);
+					if (this.topics.markIdentityKey(session.sessionId, identityKey)) await this.persistTopics();
+				}
+				// Explicit Telegram-side user renames own the topic title. Pending user
+				// reconciliation runs before daemon identity naming, so retries and daemon
+				// restarts cannot silently replace the preserved name.
+				await this.reconcileUserTopicName(session.sessionId, topicId);
 				const name = this.topicNameFor(session.sessionId, msg);
 				if (this.topics.needsRename(session.sessionId, name)) {
+					this.daemonRenameAttempts.set(
+						session.sessionId,
+						(this.daemonRenameAttempts.get(session.sessionId) ?? 0) + 1,
+					);
 					try {
-						await this.botApi.call("editForumTopic", {
+						const response = await this.botApi.call("editForumTopic", {
 							chat_id: this.opts.chatId,
 							message_thread_id: Number(topicId),
 							name,
 						});
-						this.topics.markNameApplied(session.sessionId, name);
+						if (topicRenameApplied(response)) this.topics.markNameApplied(session.sessionId, name);
 					} catch {
-						// Best-effort rename; never block delivery. Leave the old
-						// registry name intact so a later identity frame retries.
+						// Best-effort rename; leave daemon-owned names unchanged so a
+						// later identity frame retries.
+					} finally {
+						const remaining = (this.daemonRenameAttempts.get(session.sessionId) ?? 1) - 1;
+						if (remaining > 0) this.daemonRenameAttempts.set(session.sessionId, remaining);
+						else {
+							this.daemonRenameAttempts.delete(session.sessionId);
+							await this.reconcileUserTopicName(session.sessionId, topicId);
+						}
 					}
 				}
 				// Send the full bulleted identity header EXACTLY ONCE per topic.
@@ -2395,7 +2478,78 @@ export class TelegramNotificationDaemon {
 		});
 	}
 
+	/** Consume Telegram forum-topic rename service messages before text routing. */
+	private async handleForumTopicEdited(update: unknown): Promise<"not-topic" | TelegramUpdateOutcome> {
+		const parsed = update as {
+			update_id?: unknown;
+			message?: {
+				chat?: { id?: unknown };
+				from?: { id?: unknown; is_bot?: unknown };
+				message_thread_id?: unknown;
+				forum_topic_edited?: { name?: unknown };
+			};
+		};
+		const message = parsed.message;
+		if (!message?.forum_topic_edited) return "not-topic";
+		const updateId = parsed.update_id;
+		if (typeof updateId !== "number" || !Number.isSafeInteger(updateId) || updateId < 0) return "consumed";
+		if (this.dispatchState.seenUpdateIds.has(updateId)) return "consumed";
+		const configuredUserId = Number(this.opts.chatId);
+		if (
+			!Number.isSafeInteger(configuredUserId) ||
+			typeof message.chat?.id !== "number" ||
+			message.chat.id !== configuredUserId ||
+			message.from?.id !== configuredUserId ||
+			message.from?.is_bot !== false
+		)
+			return "consumed";
+		const privacy = await this.resolvePairedChatPrivacy();
+		if (privacy === "indeterminate") return "retry";
+		if (privacy !== "private") return "consumed";
+		const threadId = message.message_thread_id;
+		if (typeof threadId !== "number" || !Number.isSafeInteger(threadId)) return "consumed";
+		const sessionId = this.topics.sessionForTopic(String(threadId));
+		if (!sessionId) return "consumed";
+		const name = message.forum_topic_edited.name;
+		if (typeof name !== "string" || name.trim().length === 0) return "consumed";
+		const result = this.topics.markUserName(sessionId, name, updateId);
+		if (result === "stale") {
+			await this.rememberSeenUpdateId(updateId);
+			return "consumed";
+		}
+		if (result === "duplicate") {
+			try {
+				await this.persistTopics();
+			} catch {
+				return "retry";
+			}
+			await this.reconcileUserTopicName(sessionId, String(threadId));
+			await this.rememberSeenUpdateId(updateId);
+			return "consumed";
+		}
+		try {
+			await this.persistTopics();
+		} catch {
+			return "retry";
+		}
+		await this.reconcileUserTopicName(sessionId, String(threadId));
+		await this.rememberSeenUpdateId(updateId);
+		return "consumed";
+	}
+
+	private async processTelegramUpdate(update: unknown): Promise<TelegramUpdateOutcome> {
+		const topicOutcome = await this.handleForumTopicEdited(update);
+		if (topicOutcome !== "not-topic") return topicOutcome;
+		try {
+			await this.handleTelegramUpdate(update);
+		} catch (err) {
+			logger.error("notifications daemon: handleTelegramUpdate failed", { error: String(err) });
+		}
+		return "consumed";
+	}
+
 	async handleTelegramUpdate(update: unknown): Promise<void> {
+		if ((await this.handleForumTopicEdited(update)) !== "not-topic") return;
 		// Session-lifecycle command (/session_*): handled ONLY from the paired chat,
 		// gated before any arg parsing or side effect, and routed through the control
 		// endpoint. Must run before threaded-injection so commands are not treated as

--- a/packages/coding-agent/src/notifications/topic-registry.ts
+++ b/packages/coding-agent/src/notifications/topic-registry.ts
@@ -21,8 +21,16 @@ export interface TopicRecord {
 	identitySent: boolean;
 	/** Creation timestamp (ms epoch). */
 	createdAt: number;
-	/** Last applied topic title (for rename detection). */
+	/** Last applied or observed Telegram topic title. */
 	name?: string;
+	/** Naming authority. Missing values are legacy daemon-owned records. */
+	nameOwner?: "user";
+	/** Whether a user-owned name still needs a best-effort Telegram re-assert. */
+	nameReconcilePending?: boolean;
+	/** Last accepted Telegram update id for a user-owned name. */
+	userNameUpdateId?: number;
+	/** Stable repo/branch identity used when topic names are user-owned or customized. */
+	identityKey?: string;
 }
 
 /** Serialisable shape persisted to disk. */
@@ -48,13 +56,31 @@ export class TopicRegistry {
 	private readonly inflight = new Map<string, Promise<TopicRecord>>();
 
 	constructor(state: TopicRegistryState = emptyTopicRegistryState()) {
-		this.topics = new Map(Object.entries(state.topics ?? {}));
-		for (const [sessionId, record] of this.topics) this.byTopic.set(record.topicId, sessionId);
+		this.topics = new Map();
+		this.load(state);
 	}
 
-	/** Merge a serialized state into this registry, preserving all persisted fields. */
+	/** Merge serialized state and normalize authority fields from older releases. */
 	load(state: TopicRegistryState): void {
-		for (const [sessionId, record] of Object.entries(state.topics ?? {})) {
+		for (const [sessionId, raw] of Object.entries(state.topics ?? {})) {
+			if (!raw || typeof raw.topicId !== "string") continue;
+			const hasValidUserAuthority =
+				raw.nameOwner === "user" &&
+				typeof raw.name === "string" &&
+				raw.name.trim().length > 0 &&
+				typeof raw.userNameUpdateId === "number" &&
+				Number.isSafeInteger(raw.userNameUpdateId) &&
+				raw.userNameUpdateId >= 0;
+			const record: TopicRecord = {
+				topicId: raw.topicId,
+				identitySent: raw.identitySent === true,
+				createdAt: typeof raw.createdAt === "number" ? raw.createdAt : 0,
+				...(typeof raw.name === "string" ? { name: raw.name } : {}),
+				...(hasValidUserAuthority ? { nameOwner: "user" as const } : {}),
+				...(hasValidUserAuthority && raw.nameReconcilePending === true ? { nameReconcilePending: true } : {}),
+				...(hasValidUserAuthority ? { userNameUpdateId: raw.userNameUpdateId } : {}),
+				...(typeof raw.identityKey === "string" ? { identityKey: raw.identityKey } : {}),
+			};
 			this.topics.set(sessionId, record);
 			this.byTopic.set(record.topicId, sessionId);
 		}
@@ -120,16 +146,67 @@ export class TopicRegistry {
 		return record ? !record.identitySent : true;
 	}
 
-	/** Whether a known session topic's applied title differs from `name`. */
-	needsRename(sessionId: string, name: string): boolean {
+	/** Remember stable repo/branch identity independently of the displayed name. */
+	markIdentityKey(sessionId: string, identityKey: string): boolean {
 		const record = this.topics.get(sessionId);
-		return record !== undefined && record.name !== name;
+		if (!record || record.identityKey === identityKey) return false;
+		record.identityKey = identityKey;
+		return true;
 	}
 
-	/** Commit a successfully-applied Telegram topic title. */
+	/** Whether daemon identity reconciliation should apply `name`. */
+	needsRename(sessionId: string, name: string): boolean {
+		const record = this.topics.get(sessionId);
+		return record !== undefined && record.nameOwner !== "user" && record.name !== name;
+	}
+
+	/** The user-owned name that must be preserved, when one exists. */
+	userOwnedName(sessionId: string): string | undefined {
+		const record = this.topics.get(sessionId);
+		return record?.nameOwner === "user" ? record.name : undefined;
+	}
+
+	/** A user-owned name whose Telegram reconciliation is still pending. */
+	userNameToReconcile(sessionId: string): string | undefined {
+		const record = this.topics.get(sessionId);
+		return record?.nameOwner === "user" && record.nameReconcilePending ? record.name : undefined;
+	}
+
+	/** Record an explicit Telegram-side user rename, rejecting stale update ids. */
+	markUserName(sessionId: string, name: string, updateId: number): "updated" | "duplicate" | "stale" {
+		const record = this.topics.get(sessionId);
+		if (!record) return "stale";
+		if (record.userNameUpdateId !== undefined && updateId < record.userNameUpdateId) return "stale";
+		if (record.userNameUpdateId === updateId) return "duplicate";
+		record.name = name;
+		record.nameOwner = "user";
+		record.nameReconcilePending = true;
+		record.userNameUpdateId = updateId;
+		return "updated";
+	}
+
+	/** Mark the matching preserved user name as reconciled with Telegram. */
+	markUserNameReconciled(sessionId: string, name: string): boolean {
+		const record = this.topics.get(sessionId);
+		if (record?.nameOwner !== "user" || record.name !== name || !record.nameReconcilePending) return false;
+		record.nameReconcilePending = false;
+		return true;
+	}
+
+	/** Restore retryable reconciliation after a failed pending-clear persistence. */
+	markUserNamePending(sessionId: string, name: string): boolean {
+		const record = this.topics.get(sessionId);
+		if (record?.nameOwner !== "user" || record.name !== name || record.nameReconcilePending) return false;
+		record.nameReconcilePending = true;
+		return true;
+	}
+
+	/** Commit a successfully-applied daemon topic title. */
 	markNameApplied(sessionId: string, name: string): void {
 		const record = this.topics.get(sessionId);
-		if (record) record.name = name;
+		if (!record || record.nameOwner === "user") return;
+		record.name = name;
+		record.nameReconcilePending = false;
 	}
 
 	/** Remove a session topic record after Telegram deletes the topic. */

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -19,6 +19,7 @@ import {
 	releaseDaemonOwnership,
 	renewDaemonHeartbeat,
 	TelegramBotTransport,
+	type TelegramDaemonFs,
 	TelegramEventDispatchState,
 	TelegramNotificationDaemon,
 	TelegramUpdatePoller,
@@ -54,6 +55,22 @@ function setPrivateAgentDir(s: Settings, agentDir: string) {
 			return typeof value === "function" ? value.bind(target) : value;
 		},
 	}) as Settings;
+}
+
+function topicStateFs(onTopicStateWrite: () => Promise<void>): TelegramDaemonFs {
+	return {
+		mkdir: (file, opts) => fs.promises.mkdir(file, opts).then(() => undefined),
+		readFile: (file, encoding) => fs.promises.readFile(file, encoding),
+		writeFile: async (file, data, opts) => {
+			if (file.includes("telegram-topics.json")) await onTopicStateWrite();
+			await fs.promises.writeFile(file, data, opts);
+		},
+		rename: (oldPath, newPath) => fs.promises.rename(oldPath, newPath).then(() => undefined),
+		unlink: file => fs.promises.unlink(file),
+		open: async (file, flags, mode) => fs.promises.open(file, flags, mode),
+		readdir: file => fs.promises.readdir(file),
+		chmod: (file, mode) => fs.promises.chmod(file, mode),
+	};
 }
 
 class FakeWs extends EventTarget {
@@ -102,6 +119,109 @@ class FakeBotApi {
 		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: this.calls.length } };
 		if (method === "sendMessage") return { ok: true, result: { message_id: this.calls.length } };
 		return { ok: true, result: true };
+	}
+}
+
+type TopicAuthorityState = {
+	topics: Record<
+		string,
+		{ name?: string; nameOwner?: string; nameReconcilePending?: boolean; userNameUpdateId?: number }
+	>;
+};
+
+async function readTopicAuthorityState(agentDir: string): Promise<TopicAuthorityState> {
+	return JSON.parse(
+		await fs.promises.readFile(path.join(daemonPaths(agentDir).dir, "telegram-topics.json"), "utf8"),
+	) as TopicAuthorityState;
+}
+
+function forumTopicEditedUpdate(
+	updateId: number,
+	threadId: number,
+	name: string,
+	{
+		chat = { id: 42 },
+		from = { id: 42, is_bot: false },
+	}: {
+		chat?: { id: number | string };
+		from?: { id: number; is_bot?: boolean } | null;
+	} = {},
+) {
+	return {
+		update_id: updateId,
+		message: {
+			chat,
+			...(from === null ? {} : { from }),
+			message_thread_id: threadId,
+			forum_topic_edited: { name },
+		},
+	};
+}
+
+async function identityTopicHarness({
+	agentDir = tempAgentDir(),
+	bot = new FakeBotApi(),
+	fs: fsImpl,
+	ownerId = "owner",
+	title = "Generated title",
+}: {
+	agentDir?: string;
+	bot?: FakeBotApi;
+	fs?: TelegramDaemonFs;
+	ownerId?: string;
+	title?: string;
+} = {}) {
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId,
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		fs: fsImpl,
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	await daemon.handleSessionMessage(session as never, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+		title,
+	});
+	return {
+		agentDir,
+		bot,
+		daemon,
+		session,
+		threadId: bot.calls.find(call => call.method === "sendMessage")!.body.message_thread_id as number,
+	};
+}
+
+class ReplayRenameBotApi extends FakeBotApi {
+	threadId: number | undefined;
+	getChatFailure: (() => unknown) | undefined;
+
+	override async call(method: string, body: unknown): Promise<unknown> {
+		if (method === "getUpdates") {
+			this.calls.push({ method, body });
+			const offset = (body as { offset?: number }).offset ?? 0;
+			if (this.threadId !== undefined && offset <= 50) {
+				return {
+					ok: true,
+					result: [
+						forumTopicEditedUpdate(50, this.threadId, "First focus"),
+						forumTopicEditedUpdate(51, this.threadId, "Later focus"),
+					],
+				};
+			}
+			return { ok: true, result: [] };
+		}
+		if (method === "getChat" && this.getChatFailure) {
+			const failure = this.getChatFailure;
+			this.getChatFailure = undefined;
+			this.calls.push({ method, body });
+			return failure();
+		}
+		return super.call(method, body);
 	}
 }
 
@@ -205,9 +325,10 @@ describe("telegram daemon", () => {
 		expect(bot.maxConcurrentGetUpdates).toBe(1);
 	});
 
-	test("TelegramUpdatePoller owns offset and isolates update failures", async () => {
+	test("TelegramUpdatePoller isolates handler failures and backs off before retrying an update", async () => {
 		const calls: Array<{ method: string; body: any }> = [];
-		const processed: unknown[] = [];
+		const processed: string[] = [];
+		const sleeps: number[] = [];
 		const bot = {
 			async call(method: string, body: unknown): Promise<unknown> {
 				calls.push({ method, body });
@@ -216,7 +337,8 @@ describe("telegram daemon", () => {
 						ok: true,
 						result: [
 							{ update_id: 10, value: "bad" },
-							{ update_id: 11, value: "good" },
+							{ update_id: 11, value: "retry" },
+							{ update_id: 12, value: "later" },
 						],
 					};
 				}
@@ -225,18 +347,21 @@ describe("telegram daemon", () => {
 		};
 		const poller = new TelegramUpdatePoller({
 			botApi: bot,
-			runtime: { sleep: async () => undefined } as any,
+			runtime: { sleep: async (ms: number) => void sleeps.push(ms) } as any,
 			backoff: { next: () => 500, reset() {} } as any,
 			processUpdate: async update => {
-				processed.push(update);
-				if ((update as { value?: string }).value === "bad") throw new Error("boom");
+				const value = (update as { value: string }).value;
+				processed.push(value);
+				if (value === "bad") throw new Error("boom");
+				return value === "retry" ? "retry" : "consumed";
 			},
 		});
 
-		expect(await poller.pollOnce()).toBe(2);
+		expect(await poller.pollOnce()).toBe(3);
 		expect(await poller.pollOnce()).toBe(0);
-		expect(calls.map(call => call.body.offset)).toEqual([0, 12]);
-		expect(processed).toHaveLength(2);
+		expect(calls.map(call => call.body.offset)).toEqual([0, 11]);
+		expect(processed).toEqual(["bad", "retry"]);
+		expect(sleeps).toEqual([500]);
 	});
 
 	test("TelegramBotTransport keeps JSON and multipart Bot API details outside daemon", async () => {
@@ -1658,6 +1783,315 @@ test("transient topic rename failure is retried on the next identity header", as
 	expect(edits.map(c => c.body.name)).toEqual(["gajae-code/dev - Readable title", "gajae-code/dev - Readable title"]);
 });
 
+test("a delayed user topic rename is immediately restored after a completed daemon edit", async () => {
+	const { agentDir, bot, daemon, session, threadId } = await identityTopicHarness({ title: "First title" });
+	await daemon.handleSessionMessage(session as never, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+		title: "Generated title",
+	});
+	bot.calls = [];
+
+	await daemon.handleTelegramUpdate(forumTopicEditedUpdate(41, threadId, "My focus"));
+	const persisted = await readTopicAuthorityState(agentDir);
+	expect(bot.calls.filter(c => c.method === "editForumTopic").map(c => c.body.name)).toEqual(["My focus"]);
+	expect(persisted.topics.S).toMatchObject({ name: "My focus", nameOwner: "user", nameReconcilePending: false });
+
+	bot.calls = [];
+	await daemon.handleSessionMessage(session as never, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+		title: "Later generated title",
+	});
+	expect(bot.calls.filter(c => c.method === "editForumTopic")).toHaveLength(0);
+});
+
+test("bot-originated topic edit service messages do not claim user ownership", async () => {
+	const { bot, daemon, session, threadId } = await identityTopicHarness({ title: "First title" });
+	bot.calls = [];
+
+	for (const [updateId, name, overrides] of [
+		[42, "Bot echo", { from: { id: 42, is_bot: true } }],
+		[43, "Wrong user", { from: { id: 7, is_bot: false } }],
+		[44, "String chat", { chat: { id: "42" } }],
+		[45, "Unknown bot status", { from: { id: 42 } }],
+		[46, "Missing sender", { from: null }],
+	] as const) {
+		await daemon.handleTelegramUpdate(forumTopicEditedUpdate(updateId, threadId, name, overrides));
+	}
+	expect(bot.calls.filter(c => c.method === "editForumTopic")).toHaveLength(0);
+	await daemon.handleSessionMessage(session as never, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+		title: "Second title",
+	});
+	expect(bot.calls.filter(c => c.method === "editForumTopic").map(c => c.body.name)).toEqual([
+		"gajae-code/dev - Second title",
+	]);
+});
+
+test("a user rename racing an in-flight daemon edit is restored after the daemon edit", async () => {
+	class RacingRenameBotApi extends FakeBotApi {
+		readonly daemonEditStarted = Promise.withResolvers<void>();
+		readonly releaseDaemonEdit = Promise.withResolvers<void>();
+
+		override async call(method: string, body: unknown): Promise<unknown> {
+			const name = (body as { name?: unknown } | null)?.name;
+			if (method === "editForumTopic" && name === "gajae-code/dev - Generated title") {
+				this.calls.push({ method, body });
+				this.daemonEditStarted.resolve();
+				await this.releaseDaemonEdit.promise;
+				return { ok: true, result: true };
+			}
+			return super.call(method, body);
+		}
+	}
+
+	const bot = new RacingRenameBotApi();
+	const { daemon, session, threadId } = await identityTopicHarness({ bot, title: "First title" });
+	bot.calls = [];
+
+	const identityUpdate = daemon.handleSessionMessage(session as never, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+		title: "Generated title",
+	});
+	await bot.daemonEditStarted.promise;
+	await daemon.handleTelegramUpdate(forumTopicEditedUpdate(43, threadId, "My focus"));
+	const laterIdentity = daemon.handleSessionMessage(session as never, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+		title: "Later generated title",
+	});
+	await laterIdentity;
+	expect(bot.calls.filter(c => c.method === "editForumTopic").map(c => c.body.name)).toEqual([
+		"gajae-code/dev - Generated title",
+	]);
+	bot.releaseDaemonEdit.resolve();
+	await identityUpdate;
+
+	expect(bot.calls.filter(c => c.method === "editForumTopic").map(c => c.body.name)).toEqual([
+		"gajae-code/dev - Generated title",
+		"My focus",
+	]);
+	bot.calls = [];
+	await daemon.handleSessionMessage(session as never, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+		title: "Another generated title",
+	});
+	expect(bot.calls.some(c => c.method === "editForumTopic")).toBe(false);
+});
+
+test("concurrent user renames persist the newest pending ownership state", async () => {
+	const firstWriteStarted = Promise.withResolvers<void>();
+	const releaseFirstWrite = Promise.withResolvers<void>();
+	let blockNextTopicWrite = false;
+	const fsImpl = topicStateFs(async () => {
+		if (blockNextTopicWrite) {
+			blockNextTopicWrite = false;
+			firstWriteStarted.resolve();
+			await releaseFirstWrite.promise;
+		}
+	});
+	const { agentDir, daemon, threadId } = await identityTopicHarness({ fs: fsImpl });
+
+	blockNextTopicWrite = true;
+	const firstRename = daemon.handleTelegramUpdate(forumTopicEditedUpdate(45, threadId, "First focus"));
+	await firstWriteStarted.promise;
+	const secondRename = daemon.handleTelegramUpdate(forumTopicEditedUpdate(46, threadId, "Latest focus"));
+	releaseFirstWrite.resolve();
+	await Promise.all([firstRename, secondRename]);
+
+	const state = await readTopicAuthorityState(agentDir);
+	expect(state.topics.S).toMatchObject({
+		name: "Latest focus",
+		nameOwner: "user",
+		nameReconcilePending: false,
+	});
+});
+
+test("topic-state write failure retries the rename before later Telegram updates", async () => {
+	let failNextTopicWrite = false;
+	const fsImpl = topicStateFs(async () => {
+		if (failNextTopicWrite) {
+			failNextTopicWrite = false;
+			throw new Error("injected topic-state write failure");
+		}
+	});
+	const bot = new ReplayRenameBotApi();
+	const { agentDir, daemon, threadId } = await identityTopicHarness({ bot, fs: fsImpl });
+	bot.threadId = threadId;
+	failNextTopicWrite = true;
+
+	await daemon.pollOnce();
+	const failedState = await readTopicAuthorityState(agentDir);
+	expect(failedState.topics.S).not.toMatchObject({ name: "First focus", nameOwner: "user" });
+
+	await daemon.pollOnce();
+	await daemon.pollOnce();
+	const persistedState = await readTopicAuthorityState(agentDir);
+	expect(persistedState.topics.S).toMatchObject({
+		name: "Later focus",
+		nameOwner: "user",
+		nameReconcilePending: false,
+		userNameUpdateId: 51,
+	});
+	expect(bot.calls.filter(call => call.method === "getUpdates").map(call => call.body.offset)).toEqual([0, 0, 52]);
+	expect(bot.calls.filter(call => call.method === "editForumTopic").map(call => call.body.name)).toEqual([
+		"First focus",
+		"Later focus",
+	]);
+});
+
+test.each([
+	[
+		"thrown getChat",
+		() => {
+			throw new Error("getChat unavailable");
+		},
+	],
+	["getChat ok:false", () => ({ ok: false, description: "temporary failure" })],
+	["malformed getChat", () => ({ ok: true, result: {} })],
+])("indeterminate %s retries a forum rename before dispatching later updates", async (_name, getChatFailure) => {
+	const bot = new ReplayRenameBotApi();
+	const { agentDir } = await identityTopicHarness({ bot, ownerId: "creator" });
+	bot.threadId = bot.calls.find(call => call.method === "sendMessage")!.body.message_thread_id;
+	bot.calls = [];
+	bot.getChatFailure = getChatFailure;
+
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "retry",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	await daemon.loadTopics();
+
+	await daemon.pollOnce();
+	const beforePrivacySucceeds = await readTopicAuthorityState(agentDir);
+	expect(beforePrivacySucceeds.topics.S).not.toMatchObject({ nameOwner: "user" });
+	expect(bot.calls.filter(call => call.method === "getUpdates").map(call => call.body.offset)).toEqual([0]);
+
+	await daemon.pollOnce();
+	await daemon.pollOnce();
+	const durableState = await readTopicAuthorityState(agentDir);
+	expect(durableState.topics.S).toMatchObject({
+		name: "Later focus",
+		nameOwner: "user",
+		userNameUpdateId: 51,
+	});
+	expect(bot.calls.filter(call => call.method === "getUpdates").map(call => call.body.offset)).toEqual([0, 0, 52]);
+});
+
+test("remote-success user-name reconciliation retries after its pending-clear write fails", async () => {
+	let successfulTopicWritesBeforeFailure: number | undefined;
+	const fsImpl = topicStateFs(async () => {
+		if (successfulTopicWritesBeforeFailure === undefined) return;
+		if (successfulTopicWritesBeforeFailure > 0) {
+			successfulTopicWritesBeforeFailure--;
+			return;
+		}
+		successfulTopicWritesBeforeFailure = undefined;
+		throw new Error("injected pending-clear write failure");
+	});
+	const firstBot = new FakeBotApi();
+	const {
+		agentDir,
+		daemon: firstDaemon,
+		session,
+		threadId,
+	} = await identityTopicHarness({ bot: firstBot, fs: fsImpl });
+	successfulTopicWritesBeforeFailure = 1;
+	await firstDaemon.handleTelegramUpdate(forumTopicEditedUpdate(44, threadId, "My focus"));
+	expect(firstBot.calls.filter(c => c.method === "editForumTopic").map(c => c.body.name)).toEqual(["My focus"]);
+	const persistedState = await readTopicAuthorityState(agentDir);
+	expect(persistedState.topics.S).toMatchObject({
+		name: "My focus",
+		nameOwner: "user",
+		nameReconcilePending: true,
+	});
+
+	const retryBot = new FakeBotApi();
+	const restarted = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner-2",
+		botToken: "tok",
+		chatId: "42",
+		botApi: retryBot,
+	});
+	await restarted.loadTopics();
+	await restarted.handleSessionMessage(session as never, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+		title: "Later generated title",
+	});
+	expect(retryBot.calls.filter(c => c.method === "editForumTopic").map(c => c.body.name)).toEqual(["My focus"]);
+});
+
+test.each([
+	[
+		"throw",
+		() => {
+			throw new Error("temporary reconciliation failure");
+		},
+	],
+	["ok:false", () => ({ ok: false, description: "temporary reconciliation failure" })],
+])("user-name reconciliation %s remains retryable after restart", async (_name, failure) => {
+	class FailingUserRenameBotApi extends FakeBotApi {
+		override async call(method: string, body: unknown): Promise<unknown> {
+			if (method === "editForumTopic" && (body as { name?: unknown }).name === "My focus") {
+				this.calls.push({ method, body });
+				return failure();
+			}
+			return super.call(method, body);
+		}
+	}
+
+	const failingBot = new FailingUserRenameBotApi();
+	const { agentDir, daemon: firstDaemon, session, threadId } = await identityTopicHarness({ bot: failingBot });
+	await firstDaemon.handleTelegramUpdate(forumTopicEditedUpdate(47, threadId, "My focus"));
+	await firstDaemon.handleSessionMessage(session as never, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+		title: "Later generated title",
+	});
+
+	const retryBot = new FakeBotApi();
+	const restarted = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner-2",
+		botToken: "tok",
+		chatId: "42",
+		botApi: retryBot,
+	});
+	await restarted.loadTopics();
+	await restarted.handleSessionMessage(session as never, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "gajae-code",
+		branch: "dev",
+		title: "Later generated title",
+	});
+	expect(retryBot.calls.filter(c => c.method === "editForumTopic").map(c => c.body.name)).toEqual(["My focus"]);
+});
 test("live sessions with the same repo branch create distinct topics", async () => {
 	const agentDir = tempAgentDir();
 	const bot = new FakeBotApi();

--- a/packages/coding-agent/test/notifications-topic-registry.test.ts
+++ b/packages/coding-agent/test/notifications-topic-registry.test.ts
@@ -49,6 +49,92 @@ describe("TopicRegistry", () => {
 		reg.markNameApplied("s1", "repo/main");
 		expect(reg.needsRename("s1", "repo/main")).toBe(false);
 		expect(reg.get("s1")?.name).toBe("repo/main");
+		expect(reg.get("s1")?.nameOwner).toBeUndefined();
+	});
+
+	test("user-owned names block daemon renames and survive serialization", async () => {
+		const reg = new TopicRegistry();
+		await reg.getOrCreateTopic(
+			"s1",
+			async () => "t1",
+			() => 1000,
+			"repo/main",
+		);
+		reg.markIdentityKey("s1", "repo\0main");
+
+		expect(reg.markUserName("s1", "My focus", 1)).toBe("updated");
+		expect(reg.needsRename("s1", "repo/main - Generated title")).toBe(false);
+		expect(reg.userOwnedName("s1")).toBe("My focus");
+		expect(reg.userNameToReconcile("s1")).toBe("My focus");
+		reg.markNameApplied("s1", "repo/main - Generated title");
+		expect(reg.userOwnedName("s1")).toBe("My focus");
+		expect(reg.markUserName("s1", "Latest focus", 2)).toBe("updated");
+		expect(reg.markUserName("s1", "Duplicate focus", 2)).toBe("duplicate");
+		expect(reg.markUserName("s1", "Stale focus", 1)).toBe("stale");
+		expect(reg.markUserNameReconciled("s1", "My focus")).toBe(false);
+		expect(reg.userNameToReconcile("s1")).toBe("Latest focus");
+		expect(reg.markUserName("s1", "My focus", 3)).toBe("updated");
+
+		expect(reg.markUserNameReconciled("s1", "My focus")).toBe(true);
+		const reloaded = new TopicRegistry(reg.serialize());
+		expect(reloaded.userOwnedName("s1")).toBe("My focus");
+		expect(reloaded.userNameToReconcile("s1")).toBeUndefined();
+		expect(reloaded.get("s1")?.identityKey).toBe("repo\0main");
+		expect(reloaded.needsRename("s1", "repo/main - Another title")).toBe(false);
+	});
+
+	test.each([
+		["empty name", { name: "", userNameUpdateId: 3 }],
+		["whitespace name", { name: " \t\n ", userNameUpdateId: 3 }],
+		["negative update id", { name: "Blocked name", userNameUpdateId: -1 }],
+		["missing update id", { name: "Missing source id" }],
+	])("malformed persisted user authority (%s) falls back to daemon naming", (_name, fields) => {
+		const reg = new TopicRegistry({
+			topics: {
+				bad: {
+					topicId: "bad",
+					identitySent: false,
+					createdAt: 1,
+					nameOwner: "user",
+					nameReconcilePending: true,
+					...fields,
+				},
+			},
+		});
+		expect(reg.needsRename("bad", "Generated name")).toBe(true);
+		expect(reg.get("bad")?.nameOwner).toBeUndefined();
+		expect(reg.get("bad")?.nameReconcilePending).toBeUndefined();
+		expect(reg.get("bad")?.userNameUpdateId).toBeUndefined();
+	});
+
+	test("retains valid user authority and normalizes legacy name state", () => {
+		const reg = new TopicRegistry({
+			topics: {
+				legacy: {
+					topicId: "legacy",
+					identitySent: false,
+					createdAt: 1,
+					name: "Legacy name",
+					userNameUpdateId: 99,
+					identityKey: "repo\0legacy",
+				},
+				user: {
+					topicId: "user",
+					identitySent: false,
+					createdAt: 1,
+					name: "Preserved name",
+					nameOwner: "user",
+					nameReconcilePending: true,
+					userNameUpdateId: 3,
+				},
+			},
+		});
+		expect(reg.needsRename("legacy", "Generated name")).toBe(true);
+		expect(reg.get("legacy")?.userNameUpdateId).toBeUndefined();
+		expect(reg.get("legacy")?.identityKey).toBe("repo\0legacy");
+		expect(reg.markUserName("legacy", "Another user name", 1)).toBe("updated");
+		expect(reg.userOwnedName("user")).toBe("Preserved name");
+		expect(reg.userNameToReconcile("user")).toBe("Preserved name");
 	});
 
 	test("resolves session for a topic id (inbound routing)", async () => {


### PR DESCRIPTION
## Summary
- treat positively authenticated Telegram `forum_topic_edited` names as durable user-owned topic authority
- preserve user names across identity re-assertion, delayed service events, daemon edit races, persistence failures, and restarts
- retain daemon auto-naming for untouched/legacy topics and keep #1909/#1943 template scope out of this change

## Validation
- `bun test packages/coding-agent/test/notifications-topic-registry.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts` — 138 pass, 0 fail, 539 assertions
- `bun --cwd=packages/coding-agent run check:types` — TypeScript 7 pass
- `bun --cwd=packages/coding-agent biome lint src/notifications/telegram-daemon.ts src/notifications/topic-registry.ts test/notifications-telegram-daemon.test.ts test/notifications-topic-registry.test.ts` — pass
- `git diff --check origin/dev...HEAD` — clean
- exact remote head `e819c79046fdf2468dc61125d6cd246472044857`; one Signed-off-by commit

Closes #1910

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*