### PR TITLE
Support configured Telegram forum supergroup topics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Preserved explicit Telegram forum-topic renames as durable user-owned names, immediately re-asserting delayed edits while retaining restart and rename-race recovery (#1910).
+- Allowed explicitly configured Telegram forum supergroups to use per-session topics while preserving private-only flat fallback and fail-closed behavior for non-forum shared chats.
 
 ## [0.9.6] - 2026-07-10
 ### Changed

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -761,6 +761,10 @@ export class TelegramBotTransport implements BotApi {
 }
 
 type PairedChatPrivacy = "private" | "non-private" | "indeterminate";
+interface PairedChatCapabilities {
+	privacy: "private" | "non-private";
+	isTopicCapable: boolean;
+}
 
 export type TelegramUpdateOutcome = "consumed" | "retry";
 
@@ -938,8 +942,8 @@ export class TelegramNotificationDaemon {
 	private threadedFallbackNoticeSent = false;
 	/** Sessions whose identity header was already sent flat (Threaded Mode off). */
 	private readonly flatIdentitySent = new Set<string>();
-	/** Cached result of whether the paired chat is a private chat (flat-fallback gate). */
-	private pairedChatPrivate: boolean | undefined;
+	/** Cached definitive capabilities for the paired Telegram chat. */
+	private pairedChatCapability: PairedChatCapabilities | undefined;
 	/** Bot username from getMe, cached once at owner startup for group/forum command targeting. */
 	private botUsername: string | undefined;
 	/** Sessions whose agent loop is currently busy (drives the typing indicator). */
@@ -1663,8 +1667,8 @@ export class TelegramNotificationDaemon {
 		await this.flushPool();
 	}
 
-	private async existingTopicForPrivateChat(sessionId: string): Promise<string | undefined> {
-		if (!(await this.pairedChatIsPrivate())) return undefined;
+	private async existingTopicForTopicCapableChat(sessionId: string): Promise<string | undefined> {
+		if (!(await this.pairedChatIsTopicCapable())) return undefined;
 		return this.topics.get(sessionId)?.topicId;
 	}
 
@@ -1720,7 +1724,7 @@ export class TelegramNotificationDaemon {
 	 * one-time nudge) or drop fail-closed for a non-private chat.
 	 */
 	private async ensureTopic(sessionId: string, name: string): Promise<string | undefined> {
-		if (!(await this.pairedChatIsPrivate())) return undefined;
+		if (!(await this.pairedChatIsTopicCapable())) return undefined;
 		const existing = this.topics.get(sessionId);
 		if (existing) return existing.topicId;
 		try {
@@ -1762,7 +1766,7 @@ export class TelegramNotificationDaemon {
 	/** Best-effort delete of a session topic once its local notification endpoint shuts down. */
 	private async deleteTopic(sessionId: string): Promise<void> {
 		const record = this.topics.get(sessionId);
-		if (!record) return;
+		if (!record || !(await this.pairedChatIsTopicCapable())) return;
 		try {
 			// Drop queued sends for this session before deleting the topic; otherwise
 			// rate-limited frames can flush later into a deleted topic or across resume.
@@ -1949,7 +1953,7 @@ export class TelegramNotificationDaemon {
 		}
 		for (const item of batch) {
 			const { send, topicId } = item.payload;
-			if (topicId && !(await this.pairedChatIsPrivate())) continue;
+			if (topicId && !(await this.pairedChatIsTopicCapable())) continue;
 			// Threaded topic when available; otherwise deliver flat to the paired chat.
 			const threadField = topicId ? { message_thread_id: Number(topicId) } : {};
 			const ckey = send.editable ? item.coalesceKey : undefined;
@@ -2182,41 +2186,57 @@ export class TelegramNotificationDaemon {
 	}
 
 	/**
-	 * Resolve (and cache definitive resolution of) whether the paired `chatId` is
-	 * a private chat. Topic and flat delivery are only safe in a private DM; an
-	 * indeterminate `getChat` result fails closed for this attempt and is retried
-	 * later.
+	 * Resolve and cache definitive capabilities for the paired `chatId`.
+	 * Private chats support topic operations and flat fallback. A forum
+	 * supergroup supports topic operations only. Indeterminate responses fail
+	 * closed for this attempt and are retried later.
 	 */
-	private async resolvePairedChatPrivacy(): Promise<PairedChatPrivacy> {
-		if (this.pairedChatPrivate !== undefined) return this.pairedChatPrivate ? "private" : "non-private";
+	private async resolvePairedChatCapabilities(): Promise<PairedChatCapabilities | undefined> {
+		if (this.pairedChatCapability !== undefined) return this.pairedChatCapability;
 		try {
 			const res = (await this.botApi.call("getChat", { chat_id: this.opts.chatId })) as {
 				ok?: unknown;
-				result?: { type?: unknown };
+				result?: { type?: unknown; is_forum?: unknown };
 			};
 			if (res?.ok !== true) {
-				logger.warn("notifications: getChat privacy check indeterminate (non-success response)");
-				return "indeterminate";
+				logger.warn("notifications: getChat capability check indeterminate (non-success response)");
+				return undefined;
 			}
 			if (res.result?.type === "private") {
-				this.pairedChatPrivate = true;
-				return "private";
+				this.pairedChatCapability = { privacy: "private", isTopicCapable: true };
+				return this.pairedChatCapability;
 			}
-			if (res.result?.type === "group" || res.result?.type === "supergroup" || res.result?.type === "channel") {
-				this.pairedChatPrivate = false;
-				return "non-private";
+			if (res.result?.type === "supergroup") {
+				this.pairedChatCapability = {
+					privacy: "non-private",
+					isTopicCapable: res.result.is_forum === true,
+				};
+				return this.pairedChatCapability;
 			}
-			logger.warn("notifications: getChat privacy check indeterminate (missing or invalid chat type)");
-			return "indeterminate";
+			if (res.result?.type === "group" || res.result?.type === "channel") {
+				this.pairedChatCapability = { privacy: "non-private", isTopicCapable: false };
+				return this.pairedChatCapability;
+			}
+			logger.warn("notifications: getChat capability check indeterminate (missing or invalid chat type)");
+			return undefined;
 		} catch {
-			logger.warn("notifications: getChat privacy check indeterminate (request failed)");
-			return "indeterminate";
+			logger.warn("notifications: getChat capability check indeterminate (request failed)");
+			return undefined;
 		}
 	}
 
-	/** Keep existing outbound callers fail-closed for indeterminate privacy. */
+	private async resolvePairedChatPrivacy(): Promise<PairedChatPrivacy> {
+		return (await this.resolvePairedChatCapabilities())?.privacy ?? "indeterminate";
+	}
+
+	/** Private-chat-only gate for flat delivery and global configuration commands. */
 	private async pairedChatIsPrivate(): Promise<boolean> {
 		return (await this.resolvePairedChatPrivacy()) === "private";
+	}
+
+	/** Topic-only gate for private chats and explicitly configured forum supergroups. */
+	private async pairedChatIsTopicCapable(): Promise<boolean> {
+		return (await this.resolvePairedChatCapabilities())?.isTopicCapable === true;
 	}
 
 	/** Tell the user once (per daemon run) how to enable Threaded Mode. */
@@ -2266,7 +2286,7 @@ export class TelegramNotificationDaemon {
 	/** Send a single `typing` chat action into a busy session's topic (best-effort). */
 	private async sendTyping(sessionId: string): Promise<void> {
 		const topicId = this.topics.get(sessionId)?.topicId;
-		if (!topicId || !(await this.pairedChatIsPrivate())) return;
+		if (!topicId || !(await this.pairedChatIsTopicCapable())) return;
 		try {
 			await this.botApi.call("sendChatAction", {
 				chat_id: this.opts.chatId,
@@ -2280,7 +2300,7 @@ export class TelegramNotificationDaemon {
 
 	/** Set a native reaction on an inbound thread message (best-effort). */
 	private async setReaction(messageId: number, emoji: string): Promise<void> {
-		if (!(await this.pairedChatIsPrivate())) return;
+		if (!(await this.pairedChatIsTopicCapable())) return;
 		try {
 			await this.botApi.call("setMessageReaction", {
 				chat_id: this.opts.chatId,
@@ -2308,7 +2328,7 @@ export class TelegramNotificationDaemon {
 		if (typeof msg?.type === "string" && TelegramNotificationDaemon.THREADED_FRAMES.has(msg.type)) {
 			const send = renderThreadedFrame(msg);
 			if (!send) return;
-			const existingTopic = await this.existingTopicForPrivateChat(session.sessionId);
+			const existingTopic = await this.existingTopicForTopicCapableChat(session.sessionId);
 			if (!send.identity && !existingTopic && !this.flatIdentitySent.has(session.sessionId)) {
 				this.rememberPendingThreadedFrame(session.sessionId, send, msg as Record<string, unknown>);
 				return;

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -2324,17 +2324,115 @@ test("threaded mode off: image_attachment uploads flat without message_thread_id
 	expect(notice).toHaveLength(1);
 });
 
-test("non-private chat: fails closed before topic creation or flat delivery", async () => {
-	for (const chatType of ["supergroup", "group", "channel"]) {
+test("forum supergroup creates and uses a session topic", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { type: "supergroup", is_forum: true } };
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 777 } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+		rich: { enabled: false },
+	});
+	const sent: string[] = [];
+	const session = {
+		sessionId: "S",
+		token: "tok",
+		ws: {
+			readyState: 1,
+			send(value: string) {
+				sent.push(value);
+			},
+		},
+		pending: new Map(),
+	};
+	daemon.sessions.set("S", session as any);
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	await daemon.handleSessionMessage(session as any, {
+		type: "context_update",
+		sessionId: "S",
+		lastMessage: "session output",
+	});
+
+	expect(bot.calls.filter(c => c.method === "getChat")).toHaveLength(1);
+	expect(bot.calls.filter(c => c.method === "createForumTopic")).toHaveLength(1);
+	expect(bot.calls.some(c => c.method === "sendMessage" && c.body.message_thread_id === 777)).toBe(true);
+
+	bot.calls = [];
+	await daemon.handleTelegramUpdate({
+		update_id: 7,
+		message: {
+			chat: { id: -10042, type: "supergroup" },
+			message_thread_id: 777,
+			message_id: 555,
+			text: "forum reply",
+		},
+	});
+	expect(JSON.parse(sent[0]!)).toMatchObject({
+		type: "user_message",
+		text: "forum reply",
+		updateId: 7,
+	});
+	expect(bot.calls.some(c => c.method === "setMessageReaction" && c.body.message_id === 555)).toBe(true);
+});
+
+test("forum supergroup does not fall back to flat delivery when topic creation fails", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { type: "supergroup", is_forum: true } };
+		if (method === "createForumTopic") return { ok: true, result: {} };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+		rich: { enabled: false },
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+
+	expect(bot.calls.filter(c => c.method === "createForumTopic")).toHaveLength(1);
+	expect(
+		bot.calls.filter(c => ["sendMessage", "sendPhoto", "sendDocument", "sendRichMessage"].includes(c.method)),
+	).toHaveLength(0);
+});
+
+test("non-forum groups and channels fail closed before topic creation or flat delivery", async () => {
+	for (const chat of [{ type: "supergroup", is_forum: false }, { type: "group" }, { type: "channel" }]) {
 		const agentDir = tempAgentDir();
 		const bot = new FakeBotApi();
-		// Even if the target chat would accept forum topic creation, the paired chat
-		// contract is private-only, so the daemon must fail closed before creating
-		// topics or sending session content into a shared chat.
+		// Only a supergroup explicitly reported as a forum is topic-capable; other
+		// shared destinations must never receive session content.
 		bot.call = (async (method: string, body: any) => {
 			bot.calls.push({ method, body });
 			if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 777 } };
-			if (method === "getChat") return { ok: true, result: { type: chatType } };
+			if (method === "getChat") return { ok: true, result: chat };
 			if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
 			return { ok: true, result: true };
 		}) as any;
@@ -2367,8 +2465,11 @@ test("non-private chat: fails closed before topic creation or flat delivery", as
 			options: ["Yes"],
 		});
 
-		expect(bot.calls.filter(c => c.method === "createForumTopic")).toHaveLength(0);
-		expect(bot.calls.filter(c => c.method === "sendMessage")).toHaveLength(0);
+		expect(
+			bot.calls.filter(c =>
+				["createForumTopic", "sendMessage", "sendPhoto", "sendDocument", "sendRichMessage"].includes(c.method),
+			),
+		).toHaveLength(0);
 	}
 });
 


### PR DESCRIPTION
## What

This PR adds focused runtime support for per-session topics in an explicitly configured Telegram forum supergroup.

- Treat a `supergroup` returned by `getChat` with `is_forum: true` as topic-capable.
- Keep privacy and topic capability separate: private chats may use topics and flat fallback, while forum supergroups may use topics only.
- Preserve the current tri-state `getChat` validation and retry behavior; non-successful, malformed, or failed responses remain indeterminate and are not cached.
- Keep flat fallback, lifecycle/global commands, stale guidance, and private topic-rename ownership private-chat-only.
- Keep groups, channels, and non-forum supergroups fail-closed.
- Add regression coverage for forum topic delivery, known-topic inbound routing, failed topic creation without flat fallback, and non-forum shared chats.

## Why

This is a clean, focused follow-up to #1808, rebuilt on the current `dev` branch as requested after #1812. The earlier PR was closed because it had become conflicting; the feature itself was explicitly not rejected.

A configured forum supergroup can support `createForumTopic` and `message_thread_id` even when private-chat Threaded Mode is unavailable. The current daemon rejects that capability because it uses the private-chat check for all topic operations. This change allows the forum-topic path without weakening the existing private-only fallback and command boundaries.

Onboarding remains private-only in this PR; the change applies only to an already explicit Telegram destination configuration, keeping the scope limited to runtime forum-supergroup support.

## Testing

- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts -t "forum supergroup"`
  - 2 passed
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts -t "non-forum groups and channels"`
  - 1 passed
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts -t "indeterminate"`
  - 3 passed
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts -t "unresolvable getChat"`
  - 1 passed
- `bunx biome check packages/coding-agent/src/notifications/telegram-daemon.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts`
  - passed
- `bun run check:ts`
  - passed
- Full daemon test file on Windows: 124 passed; the existing exact POSIX mode assertion for an inbound temporary file reported 0666 instead of 0600. That platform-specific assertion is unrelated to this change and is intentionally left out of this focused follow-up.

---

- [x] `bun run check:ts` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing runtime behavior)
