### PR TITLE
fix(coding-agent): enforce durable model profile references

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Fixed
 
 - Fixed `/model` and Agent Control Center role assignments so DEFAULT, EXECUTOR, ARCHITECT, PLANNER, and CRITIC update their effective runtime/project-shadowed values, TUI badges, and persisted per-role settings without replacing sibling assignments.
-- Fixed active-profile role edits, omitted-role profile switches, role-only profile effort across restart, truthful mixed-effort output, and model-setting commands blocking on nonsettling notification transports.
+- Fixed active-profile role edits and preset-deletion rollback so inherited materialization preserves later independent role/profile choices, plus omitted-role profile switches, role-only profile effort across restart, truthful mixed-effort output, and model-setting commands blocking on nonsettling notification transports.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Fixed
 
 - Fixed `/model` and Agent Control Center role assignments so DEFAULT, EXECUTOR, ARCHITECT, PLANNER, and CRITIC update their effective runtime/project-shadowed values, TUI badges, and persisted per-role settings without replacing sibling assignments.
-- Fixed active-profile role edits and preset-deletion rollback so inherited materialization preserves later independent role/profile choices, plus omitted-role profile switches, role-only profile effort across restart, truthful mixed-effort output, and model-setting commands blocking on nonsettling notification transports.
+- Fixed active-profile role edits and preset-deletion rollback so inherited materialization preserves later independent role/profile choices, including equal-value writes, and preset deletion now aborts when durable settings persistence fails; also fixed omitted-role profile switches, role-only profile effort across restart, truthful mixed-effort output, and model-setting commands blocking on nonsettling notification transports.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed `/model` and Agent Control Center role assignments so DEFAULT, EXECUTOR, ARCHITECT, PLANNER, and CRITIC update their effective runtime/project-shadowed values, TUI badges, and persisted per-role settings without replacing sibling assignments.
+- Fixed active-profile role edits, omitted-role profile switches, role-only profile effort across restart, truthful mixed-effort output, and model-setting commands blocking on nonsettling notification transports.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Fixed `/model` and Agent Control Center role assignments so DEFAULT, EXECUTOR, ARCHITECT, PLANNER, and CRITIC update their effective runtime/project-shadowed values, TUI badges, and persisted per-role settings without replacing sibling assignments.
 - Fixed active-profile role edits and preset-deletion rollback so inherited materialization preserves later independent role/profile choices, including equal-value writes, and preset deletion now aborts when durable settings persistence fails; also fixed omitted-role profile switches, role-only profile effort across restart, truthful mixed-effort output, and model-setting commands blocking on nonsettling notification transports.
+- Fixed durable model-setting boundaries so deleted ownership metadata self-heals without wedging conditional writes, `/model` and the model selector report success only after persistence commits, and custom preset deletion refuses project references while blocking concurrent same-name reselection from leaving a dangling default.
 
 ### Changed
 

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -19,6 +19,103 @@ import type { Settings } from "./settings";
 
 const LEGACY_MODEL_PROFILE_ALIASES: ReadonlyMap<string, string> = new Map([["codex-standard", "codex-medium"]]);
 
+interface ActiveModelProfileRuntimeState {
+	baselineModel?: Model<Api>;
+	baselineThinkingLevel?: ThinkingLevel;
+	baselineSessionDefaultModel?: string;
+	persistableBaselineThinkingLevel?: ThinkingLevel;
+	baselineModelRoles: Record<string, string>;
+	baselineAgentModelOverrides: Record<string, string>;
+	persistableBaselineModelRoles: Record<string, string>;
+	persistableBaselineAgentModelOverrides: Record<string, string>;
+	appliedModelRoles: Record<string, string>;
+	appliedAgentModelOverrides: Record<string, string>;
+	defaultSelector?: string;
+}
+
+const activeModelProfileRuntimeStates = new WeakMap<object, ActiveModelProfileRuntimeState>();
+
+function deriveProfileBaseline(
+	baseline: Record<string, string>,
+	current: Record<string, string>,
+	applied: Record<string, string>,
+): Record<string, string> {
+	const next = { ...baseline };
+	for (const key of new Set([...Object.keys(baseline), ...Object.keys(current), ...Object.keys(applied)])) {
+		const currentValue = current[key];
+		const appliedValue = applied[key];
+		if (currentValue === undefined) {
+			delete next[key];
+		} else if (appliedValue === undefined || currentValue !== appliedValue) {
+			next[key] = currentValue;
+		}
+	}
+	return next;
+}
+
+function mergeAppliedProfileAssignments(
+	target: Record<string, string>,
+	current: Record<string, string>,
+	applied: Record<string, string>,
+): void {
+	for (const [key, value] of Object.entries(applied)) {
+		if (current[key] === value) {
+			target[key] = value;
+		}
+	}
+}
+
+type ModelAssignmentPersistenceSettings = Pick<
+	Settings,
+	"clearAgentModelOverride" | "clearModelRole" | "setAgentModelOverride" | "setModelRole"
+>;
+
+interface ModelAssignmentTouchedEntries {
+	modelRoles: string[];
+	agentModelOverrides: string[];
+}
+
+function persistModelAssignmentEntries(
+	settings: ModelAssignmentPersistenceSettings,
+	modelRoles: Record<string, string>,
+	agentModelOverrides: Record<string, string>,
+	previousModelRoles: Record<string, string>,
+	previousAgentModelOverrides: Record<string, string>,
+): ModelAssignmentTouchedEntries {
+	const touched: ModelAssignmentTouchedEntries = {
+		modelRoles: [],
+		agentModelOverrides: [],
+	};
+	for (const role of new Set([...Object.keys(previousModelRoles), ...Object.keys(modelRoles)])) {
+		const selector = modelRoles[role];
+		if (previousModelRoles[role] === selector) continue;
+		if (selector === undefined) {
+			settings.clearModelRole(role);
+		} else {
+			settings.setModelRole(role, selector);
+		}
+		touched.modelRoles.push(role);
+	}
+	for (const agentName of new Set([
+		...Object.keys(previousAgentModelOverrides),
+		...Object.keys(agentModelOverrides),
+	])) {
+		const selector = agentModelOverrides[agentName];
+		if (previousAgentModelOverrides[agentName] === selector) continue;
+		if (selector === undefined) {
+			settings.clearAgentModelOverride(agentName);
+		} else {
+			settings.setAgentModelOverride(agentName, selector);
+		}
+		touched.agentModelOverrides.push(agentName);
+	}
+	return touched;
+}
+
+function clearActiveModelProfileRuntimeState(session: object): void {
+	activeModelProfileRuntimeStates.delete(session);
+}
+
 type ModelProfileActivationSession = Pick<AgentSession, "model" | "thinkingLevel" | "sessionId"> & {
 	setModelTemporary?: AgentSession["setModelTemporary"];
 	setActiveModelProfile?: (name: string | undefined) => void;
@@ -40,7 +137,20 @@ export interface PrepareModelProfileActivationOptions {
 		| "getCanonicalVariants"
 		| "getCanonicalId"
 	>;
-	settings: Pick<Settings, "get">;
+	settings: Pick<
+		Settings,
+		| "clearGlobal"
+		| "clearOverride"
+		| "flushOrThrow"
+		| "flush"
+		| "get"
+		| "getGlobal"
+		| "getRuntimeOverride"
+		| "getWithoutProject"
+		| "override"
+		| "set"
+	> &
+		ModelAssignmentPersistenceSettings;
 	profileName: string;
 }
 export interface ApplyModelProfileActivationOptions {
@@ -50,13 +160,38 @@ export interface ApplyModelProfileActivationOptions {
 export interface PreparedModelProfileActivation {
 	profileName: string;
 	session: ModelProfileActivationSession & { setModelTemporary: AgentSession["setModelTemporary"] };
-	settings: Pick<Settings, "clearOverride" | "get" | "getGlobal" | "override" | "set" | "flush">;
+	settings: Pick<
+		Settings,
+		| "clearGlobal"
+		| "clearOverride"
+		| "flush"
+		| "flushOrThrow"
+		| "get"
+		| "getGlobal"
+		| "getRuntimeOverride"
+		| "override"
+		| "set"
+	> &
+		ModelAssignmentPersistenceSettings;
 	previousModel: Model<Api> | undefined;
 	previousThinkingLevel: ThinkingLevel | undefined;
 	previousAgentModelOverrides: Record<string, string>;
 	previousModelRoles: Record<string, string>;
+	previousRuntimeAgentModelOverrides: Record<string, string>;
+	previousRuntimeModelRoles: Record<string, string>;
+	baselineModel: Model<Api> | undefined;
+	baselineThinkingLevel: ThinkingLevel | undefined;
+	baselineAgentModelOverrides: Record<string, string>;
+	baselineModelRoles: Record<string, string>;
 	defaultModel: Model<Api> | undefined;
 	defaultThinkingLevel: ThinkingLevel | undefined;
+	persistedDefaultThinkingLevel: ThinkingLevel | undefined;
+	baselineSessionDefaultModel: string | undefined;
+	persistableBaselineThinkingLevel: ThinkingLevel | undefined;
+	profileDefaultSelector: string | undefined;
+	profileDefaultHasExplicitThinking: boolean;
+	persistableBaselineAgentModelOverrides: Record<string, string>;
+	persistableBaselineModelRoles: Record<string, string>;
 	modelRoles: Record<string, string>;
 	agentModelOverrides: Record<string, string>;
 	previousActiveModelProfile: string | undefined;
@@ -72,108 +207,144 @@ export interface PreparedModelProfileActivation {
 export interface MaterializeModelProfileAssignmentOptions {
 	session: Pick<
 		ModelProfileActivationSession,
-		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile"
+		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile" | "getSessionDefaultModelSelector"
 	>;
-	settings: Pick<Settings, "clearOverride" | "get" | "override" | "set">;
+	settings: Pick<
+		Settings,
+		"clearOverride" | "get" | "getGlobal" | "getRuntimeOverride" | "getWithoutProject" | "override" | "set"
+	> &
+		ModelAssignmentPersistenceSettings;
 	role: GjcModelAssignmentTargetId;
-	selector: string;
+	selector: string | undefined;
 }
 
 export interface MaterializeModelProfileAssignmentsOptions {
 	session: Pick<
 		ModelProfileActivationSession,
-		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile"
+		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile" | "getSessionDefaultModelSelector"
 	>;
-	settings: Pick<Settings, "clearOverride" | "get" | "override" | "set">;
-	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string> | Partial<Record<GjcModelAssignmentTargetId, string>>;
+	settings: Pick<
+		Settings,
+		"clearOverride" | "get" | "getGlobal" | "getRuntimeOverride" | "getWithoutProject" | "override" | "set"
+	> &
+		ModelAssignmentPersistenceSettings;
+	assignments:
+		| ReadonlyMap<GjcModelAssignmentTargetId, string | undefined>
+		| Partial<Record<GjcModelAssignmentTargetId, string | undefined>>;
 }
 
 function isReadonlyAssignmentMap(
-	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string> | Partial<Record<GjcModelAssignmentTargetId, string>>,
-): assignments is ReadonlyMap<GjcModelAssignmentTargetId, string> {
+	assignments:
+		| ReadonlyMap<GjcModelAssignmentTargetId, string | undefined>
+		| Partial<Record<GjcModelAssignmentTargetId, string | undefined>>,
+): assignments is ReadonlyMap<GjcModelAssignmentTargetId, string | undefined> {
 	return typeof (assignments as { entries?: unknown }).entries === "function";
 }
 
 function getMaterializedAssignments(
-	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string> | Partial<Record<GjcModelAssignmentTargetId, string>>,
-): Array<[GjcModelAssignmentTargetId, string]> {
+	assignments:
+		| ReadonlyMap<GjcModelAssignmentTargetId, string | undefined>
+		| Partial<Record<GjcModelAssignmentTargetId, string | undefined>>,
+): Array<[GjcModelAssignmentTargetId, string | undefined]> {
 	if (isReadonlyAssignmentMap(assignments)) return [...assignments.entries()];
-	const assignmentRecord: Partial<Record<GjcModelAssignmentTargetId, string>> = assignments;
-	const result: Array<[GjcModelAssignmentTargetId, string]> = [];
-	for (const role of Object.keys(assignmentRecord) as GjcModelAssignmentTargetId[]) {
-		const selector = assignmentRecord[role];
-		if (selector !== undefined) result.push([role, selector]);
-	}
-	return result;
+	const assignmentRecord: Partial<Record<GjcModelAssignmentTargetId, string | undefined>> = assignments;
+	return (Object.keys(assignmentRecord) as GjcModelAssignmentTargetId[]).map(role => [role, assignmentRecord[role]]);
 }
 
 export function materializeActiveModelProfileAssignment(options: MaterializeModelProfileAssignmentOptions): boolean {
-	const activeProfile = options.session.getActiveModelProfile?.() ?? options.settings.get("modelProfile.default");
-	if (!activeProfile) return false;
-
-	const nextModelRoles = { ...options.settings.get("modelRoles") };
-	const nextAgentModelOverrides = { ...options.settings.get("task.agentModelOverrides") };
-	const target = GJC_MODEL_ASSIGNMENT_TARGETS[options.role];
-
-	if (options.role === "default") {
-		nextModelRoles.default = options.selector;
-	} else if (!nextModelRoles.default && options.session.model) {
-		nextModelRoles.default = formatModelSelectorValue(
-			`${options.session.model.provider}/${options.session.model.id}`,
-			options.session.thinkingLevel,
-		);
-	}
-
-	if (target.settingsPath === "modelRoles") {
-		nextModelRoles[options.role] = options.selector;
-	} else {
-		nextAgentModelOverrides[options.role] = options.selector;
-	}
-
-	options.settings.set("modelRoles", nextModelRoles);
-	options.settings.set("task.agentModelOverrides", nextAgentModelOverrides);
-	options.settings.set("modelProfile.default", undefined);
-	options.settings.clearOverride("modelProfile.default");
-	options.settings.override("modelRoles", nextModelRoles);
-	options.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
-	options.session.setActiveModelProfile?.(undefined);
-	return true;
+	return materializeActiveModelProfileAssignments({
+		session: options.session,
+		settings: options.settings,
+		assignments: { [options.role]: options.selector },
+	});
 }
 
 export function materializeActiveModelProfileAssignments(options: MaterializeModelProfileAssignmentsOptions): boolean {
-	const activeProfile = options.session.getActiveModelProfile?.() ?? options.settings.get("modelProfile.default");
+	const activeProfile = options.session.getActiveModelProfile
+		? options.session.getActiveModelProfile()
+		: options.settings.get("modelProfile.default");
 	if (!activeProfile) return false;
 
 	const materializedAssignments = getMaterializedAssignments(options.assignments);
 	if (materializedAssignments.length === 0) return true;
+	const previousPersistedModelRoles = {
+		...(options.settings.getGlobal("modelRoles") ?? {}),
+	};
+	const previousPersistedAgentModelOverrides = {
+		...(options.settings.getGlobal("task.agentModelOverrides") ?? {}),
+	};
 
-	const nextModelRoles = { ...options.settings.get("modelRoles") };
-	const nextAgentModelOverrides = { ...options.settings.get("task.agentModelOverrides") };
-	const includesDefault = materializedAssignments.some(([role]) => role === "default");
+	const runtimeState = activeModelProfileRuntimeStates.get(options.session);
+	const currentPersistableModelRoles = {
+		...options.settings.getWithoutProject("modelRoles"),
+	};
+	const currentPersistableAgentModelOverrides = {
+		...options.settings.getWithoutProject("task.agentModelOverrides"),
+	};
+	const persistedModelRoles = runtimeState
+		? deriveProfileBaseline(
+				runtimeState.persistableBaselineModelRoles,
+				currentPersistableModelRoles,
+				runtimeState.appliedModelRoles,
+			)
+		: currentPersistableModelRoles;
+	const persistedAgentModelOverrides = runtimeState
+		? deriveProfileBaseline(
+				runtimeState.persistableBaselineAgentModelOverrides,
+				currentPersistableAgentModelOverrides,
+				runtimeState.appliedAgentModelOverrides,
+			)
+		: currentPersistableAgentModelOverrides;
+	const runtimeModelRoles = {
+		...(options.settings.getRuntimeOverride("modelRoles") ?? {}),
+	};
+	const runtimeAgentModelOverrides = {
+		...(options.settings.getRuntimeOverride("task.agentModelOverrides") ?? {}),
+	};
 
-	if (!includesDefault && !nextModelRoles.default && options.session.model) {
-		nextModelRoles.default = formatModelSelectorValue(
-			`${options.session.model.provider}/${options.session.model.id}`,
-			options.session.thinkingLevel,
+	if (runtimeState) {
+		mergeAppliedProfileAssignments(persistedModelRoles, currentPersistableModelRoles, runtimeState.appliedModelRoles);
+		mergeAppliedProfileAssignments(
+			persistedAgentModelOverrides,
+			currentPersistableAgentModelOverrides,
+			runtimeState.appliedAgentModelOverrides,
 		);
+	}
+	const authoritativeDefaultSelector =
+		runtimeState?.defaultSelector ??
+		persistedModelRoles.default ??
+		options.session.getSessionDefaultModelSelector?.();
+	if (authoritativeDefaultSelector) {
+		persistedModelRoles.default = authoritativeDefaultSelector;
+		runtimeModelRoles.default = authoritativeDefaultSelector;
 	}
 
 	for (const [role, selector] of materializedAssignments) {
 		const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
-		if (target.settingsPath === "modelRoles") {
-			nextModelRoles[role] = selector;
+		const persisted = target.settingsPath === "modelRoles" ? persistedModelRoles : persistedAgentModelOverrides;
+		const runtime = target.settingsPath === "modelRoles" ? runtimeModelRoles : runtimeAgentModelOverrides;
+		if (selector === undefined) {
+			delete persisted[role];
+			delete runtime[role];
 		} else {
-			nextAgentModelOverrides[role] = selector;
+			persisted[role] = selector;
+			runtime[role] = selector;
 		}
 	}
 
-	options.settings.set("modelRoles", nextModelRoles);
-	options.settings.set("task.agentModelOverrides", nextAgentModelOverrides);
+	options.session.setActiveModelProfile?.(undefined);
+	persistModelAssignmentEntries(
+		options.settings,
+		persistedModelRoles,
+		persistedAgentModelOverrides,
+		previousPersistedModelRoles,
+		previousPersistedAgentModelOverrides,
+	);
 	options.settings.set("modelProfile.default", undefined);
 	options.settings.clearOverride("modelProfile.default");
-	options.settings.override("modelRoles", nextModelRoles);
-	options.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
-	options.session.setActiveModelProfile?.(undefined);
+	options.settings.override("modelRoles", runtimeModelRoles);
+	options.settings.override("task.agentModelOverrides", runtimeAgentModelOverrides);
+	clearActiveModelProfileRuntimeState(options.session);
 	return true;
 }
 
@@ -187,6 +358,27 @@ function resolveModelProfileName(profileName: string, profiles: ReadonlyMap<stri
 	if (profiles.has(profileName)) return profileName;
 	const replacement = LEGACY_MODEL_PROFILE_ALIASES.get(profileName);
 	return replacement && profiles.has(replacement) ? replacement : profileName;
+}
+
+export interface ProjectModelProfileShadow {
+	profileName: string;
+	targetIds: GjcModelAssignmentTargetId[];
+}
+
+export function resolveProjectModelProfileShadow(
+	settings: Pick<Settings, "getProject">,
+	modelRegistry: Pick<ModelRegistry, "getModelProfile" | "getModelProfiles">,
+): ProjectModelProfileShadow | undefined {
+	const configuredName = settings.getProject("modelProfile.default");
+	if (!configuredName) return undefined;
+	const profiles = modelRegistry.getModelProfiles();
+	const profileName = resolveModelProfileName(configuredName, profiles);
+	const profile = profiles.get(profileName) ?? modelRegistry.getModelProfile(profileName);
+	if (!profile) return undefined;
+	const targetIds = Object.keys(profile.modelMapping).filter((targetId): targetId is GjcModelAssignmentTargetId =>
+		Object.hasOwn(GJC_MODEL_ASSIGNMENT_TARGETS, targetId),
+	);
+	return { profileName, targetIds };
 }
 
 /**
@@ -329,19 +521,109 @@ export async function prepareModelProfileActivation(
 		agentModelOverrides[role] = formatClampedModelSelector(selector, resolved.model);
 	}
 
+	const previousActiveModelProfile = options.session.getActiveModelProfile?.();
+	const previousRuntimeState = previousActiveModelProfile
+		? activeModelProfileRuntimeStates.get(options.session)
+		: undefined;
+	const previousModelRoles = { ...options.settings.get("modelRoles") };
+	const previousAgentModelOverrides = {
+		...options.settings.get("task.agentModelOverrides"),
+	};
+	const previousRuntimeModelRoles = { ...(options.settings.getRuntimeOverride("modelRoles") ?? {}) };
+	const previousRuntimeAgentModelOverrides = {
+		...(options.settings.getRuntimeOverride("task.agentModelOverrides") ?? {}),
+	};
+	const currentPersistableModelRoles = {
+		...options.settings.getWithoutProject("modelRoles"),
+	};
+	const currentPersistableAgentModelOverrides = {
+		...options.settings.getWithoutProject("task.agentModelOverrides"),
+	};
+	const persistableBaselineModelRoles = previousRuntimeState
+		? deriveProfileBaseline(
+				previousRuntimeState.persistableBaselineModelRoles,
+				currentPersistableModelRoles,
+				previousRuntimeState.appliedModelRoles,
+			)
+		: currentPersistableModelRoles;
+	const persistableBaselineAgentModelOverrides = previousRuntimeState
+		? deriveProfileBaseline(
+				previousRuntimeState.persistableBaselineAgentModelOverrides,
+				currentPersistableAgentModelOverrides,
+				previousRuntimeState.appliedAgentModelOverrides,
+			)
+		: currentPersistableAgentModelOverrides;
+	const baselineModelRoles = previousRuntimeState
+		? deriveProfileBaseline(
+				previousRuntimeState.baselineModelRoles,
+				previousRuntimeModelRoles,
+				previousRuntimeState.appliedModelRoles,
+			)
+		: previousRuntimeModelRoles;
+	const baselineAgentModelOverrides = previousRuntimeState
+		? deriveProfileBaseline(
+				previousRuntimeState.baselineAgentModelOverrides,
+				previousRuntimeAgentModelOverrides,
+				previousRuntimeState.appliedAgentModelOverrides,
+			)
+		: previousRuntimeAgentModelOverrides;
+	const baselineModel = previousRuntimeState?.baselineModel ?? options.session.model;
+	const baselineThinkingLevel = previousRuntimeState?.baselineThinkingLevel ?? options.session.thinkingLevel;
+	const baselineSessionDefaultModel =
+		previousRuntimeState?.baselineSessionDefaultModel ?? options.session.getSessionDefaultModelSelector?.();
+	const persistableBaselineThinkingLevel =
+		previousRuntimeState?.persistableBaselineThinkingLevel ??
+		options.settings.getWithoutProject("defaultThinkingLevel");
+	const profileInheritsDefaultThinking =
+		resolvedDefault !== undefined &&
+		(!resolvedDefault.explicitThinkingLevel || resolvedDefault.thinkingLevel === ThinkingLevel.Inherit);
+	const resolvedDefaultThinkingLevel = profileInheritsDefaultThinking
+		? options.settings.get("defaultThinkingLevel")
+		: resolvedDefault?.thinkingLevel;
+	const persistedDefaultThinkingLevel = resolvedDefault
+		? profileInheritsDefaultThinking
+			? persistableBaselineThinkingLevel
+			: resolvedDefault.thinkingLevel
+		: previousRuntimeState
+			? persistableBaselineThinkingLevel
+			: undefined;
+	const profileDefaultSelector = resolvedDefault?.model
+		? formatModelSelectorValue(
+				`${resolvedDefault.model.provider}/${resolvedDefault.model.id}`,
+				resolvedDefault.thinkingLevel,
+			)
+		: undefined;
+	const profileDefaultHasExplicitThinking =
+		resolvedDefault?.explicitThinkingLevel === true &&
+		resolvedDefault.thinkingLevel !== undefined &&
+		resolvedDefault.thinkingLevel !== ThinkingLevel.Inherit;
+
 	return {
 		profileName,
 		session: options.session as PreparedModelProfileActivation["session"],
 		settings: options.settings as PreparedModelProfileActivation["settings"],
 		previousModel: options.session.model,
 		previousThinkingLevel: options.session.thinkingLevel,
-		previousAgentModelOverrides: { ...options.settings.get("task.agentModelOverrides") },
-		previousModelRoles: { ...options.settings.get("modelRoles") },
-		defaultModel: resolvedDefault?.model,
-		defaultThinkingLevel: resolvedDefault?.thinkingLevel,
+		previousAgentModelOverrides,
+		previousModelRoles,
+		previousRuntimeAgentModelOverrides,
+		previousRuntimeModelRoles,
+		baselineModel,
+		baselineThinkingLevel,
+		baselineAgentModelOverrides,
+		baselineModelRoles,
+		defaultModel: resolvedDefault?.model ?? (previousRuntimeState ? baselineModel : undefined),
+		defaultThinkingLevel: resolvedDefaultThinkingLevel ?? (previousRuntimeState ? baselineThinkingLevel : undefined),
+		persistedDefaultThinkingLevel,
+		baselineSessionDefaultModel,
+		persistableBaselineThinkingLevel,
+		profileDefaultSelector,
+		profileDefaultHasExplicitThinking,
+		persistableBaselineAgentModelOverrides,
+		persistableBaselineModelRoles,
 		modelRoles,
 		agentModelOverrides,
-		previousActiveModelProfile: options.session.getActiveModelProfile?.(),
+		previousActiveModelProfile,
 		previousSessionDefaultModel: options.session.getSessionDefaultModelSelector?.(),
 	};
 }
@@ -352,87 +634,133 @@ export async function applyPreparedModelProfileActivation(
 ): Promise<void> {
 	const previousModel = prepared.previousModel;
 	const previousThinkingLevel = prepared.previousThinkingLevel;
-	const previousAgentModelOverrides = prepared.previousAgentModelOverrides;
-	const previousModelRoles = prepared.previousModelRoles;
-	const previousPersistedDefault = prepared.settings.get("modelProfile.default");
-	const previousDefaultThinkingLevel = prepared.settings.get("defaultThinkingLevel");
+	const previousAgentModelOverrides = prepared.previousRuntimeAgentModelOverrides;
+	const previousModelRoles = prepared.previousRuntimeModelRoles;
 	const previousActiveModelProfile = prepared.previousActiveModelProfile;
 	const previousSessionDefaultModel = prepared.previousSessionDefaultModel;
-	let modelChanged = false;
-	let overridesChanged = false;
-	let defaultChanged = false;
-	let modelRolesChanged = false;
-	let defaultThinkingChanged = false;
+	let modelTransitionStarted = false;
+	let persistenceStarted = false;
+	const effectiveDefaultThinkingLevel = options.thinkingLevelOverride ?? prepared.defaultThinkingLevel;
+	const persistedDefaultThinkingLevel = options.thinkingLevelOverride ?? prepared.persistedDefaultThinkingLevel;
+	const materializedDefaultSelector = prepared.profileDefaultSelector
+		? options.thinkingLevelOverride !== undefined &&
+			prepared.profileDefaultHasExplicitThinking &&
+			prepared.defaultModel
+			? formatModelSelectorValue(
+					`${prepared.defaultModel.provider}/${prepared.defaultModel.id}`,
+					effectiveDefaultThinkingLevel,
+				)
+			: prepared.profileDefaultSelector
+		: (prepared.persistableBaselineModelRoles.default ?? prepared.baselineSessionDefaultModel);
 
 	try {
 		if (prepared.defaultModel) {
-			await prepared.session.setModelTemporary(
-				prepared.defaultModel,
-				options.thinkingLevelOverride ?? prepared.defaultThinkingLevel,
-				{
-					persistAsSessionDefault: true,
-				},
-			);
-			modelChanged = true;
+			modelTransitionStarted = true;
+			await prepared.session.setModelTemporary(prepared.defaultModel, effectiveDefaultThinkingLevel, {
+				persistAsSessionDefault: prepared.profileDefaultSelector !== undefined,
+			});
+			if (!prepared.profileDefaultSelector && prepared.baselineSessionDefaultModel) {
+				prepared.session.recordResumeDefaultModel?.(prepared.baselineSessionDefaultModel);
+			}
 		}
-		if (Object.keys(prepared.modelRoles).length > 0) {
-			prepared.settings.override("modelRoles", { ...previousModelRoles, ...prepared.modelRoles });
-			modelRolesChanged = true;
+		if (prepared.previousActiveModelProfile || Object.keys(prepared.modelRoles).length > 0) {
+			prepared.settings.override("modelRoles", {
+				...prepared.baselineModelRoles,
+				...prepared.modelRoles,
+			});
 		}
-		if (Object.keys(prepared.agentModelOverrides).length > 0) {
+		if (prepared.previousActiveModelProfile || Object.keys(prepared.agentModelOverrides).length > 0) {
 			prepared.settings.override("task.agentModelOverrides", {
-				...previousAgentModelOverrides,
+				...prepared.baselineAgentModelOverrides,
 				...prepared.agentModelOverrides,
 			});
-			overridesChanged = true;
 		}
 		if (options.persistDefault) {
-			prepared.settings.set("modelRoles", {});
-			prepared.settings.set("task.agentModelOverrides", {});
-			if (prepared.defaultThinkingLevel !== undefined && prepared.defaultThinkingLevel !== ThinkingLevel.Inherit) {
-				prepared.settings.set("defaultThinkingLevel", prepared.defaultThinkingLevel);
-				defaultThinkingChanged = true;
+			persistenceStarted = true;
+			if (
+				prepared.defaultModel &&
+				persistedDefaultThinkingLevel !== undefined &&
+				persistedDefaultThinkingLevel !== ThinkingLevel.Inherit
+			) {
+				prepared.settings.set("defaultThinkingLevel", persistedDefaultThinkingLevel);
+			} else if (prepared.defaultModel) {
+				prepared.settings.clearGlobal("defaultThinkingLevel");
 			}
 			prepared.settings.set("modelProfile.default", prepared.profileName);
-			defaultChanged = true;
-			await prepared.settings.flush();
+			await prepared.settings.flushOrThrow();
 		}
 		prepared.session.setActiveModelProfile?.(prepared.profileName);
+		activeModelProfileRuntimeStates.set(prepared.session, {
+			baselineModel: prepared.baselineModel,
+			baselineThinkingLevel: prepared.baselineThinkingLevel,
+			baselineSessionDefaultModel: prepared.baselineSessionDefaultModel,
+			persistableBaselineThinkingLevel: prepared.persistableBaselineThinkingLevel,
+			baselineModelRoles: { ...prepared.baselineModelRoles },
+			baselineAgentModelOverrides: { ...prepared.baselineAgentModelOverrides },
+			persistableBaselineModelRoles: { ...prepared.persistableBaselineModelRoles },
+			persistableBaselineAgentModelOverrides: {
+				...prepared.persistableBaselineAgentModelOverrides,
+			},
+			appliedModelRoles: { ...prepared.modelRoles },
+			appliedAgentModelOverrides: { ...prepared.agentModelOverrides },
+			defaultSelector: materializedDefaultSelector,
+		});
 	} catch (error) {
-		if (defaultChanged) {
-			prepared.settings.set("modelProfile.default", previousPersistedDefault);
-			prepared.settings.set("modelRoles", previousModelRoles);
-			prepared.settings.set("task.agentModelOverrides", previousAgentModelOverrides);
-			if (defaultThinkingChanged) {
-				prepared.settings.set("defaultThinkingLevel", previousDefaultThinkingLevel);
+		const rollbackErrors: unknown[] = [];
+		const rollbackModelRoles = persistenceStarted ? prepared.baselineModelRoles : previousModelRoles;
+		const rollbackAgentModelOverrides = persistenceStarted
+			? prepared.baselineAgentModelOverrides
+			: previousAgentModelOverrides;
+		const rollbackModel = persistenceStarted ? prepared.baselineModel : previousModel;
+		const rollbackThinkingLevel = persistenceStarted ? prepared.baselineThinkingLevel : previousThinkingLevel;
+		try {
+			prepared.settings.override("modelRoles", rollbackModelRoles);
+		} catch (rollbackError) {
+			rollbackErrors.push(rollbackError);
+		}
+		try {
+			prepared.settings.override("task.agentModelOverrides", rollbackAgentModelOverrides);
+		} catch (rollbackError) {
+			rollbackErrors.push(rollbackError);
+		}
+		try {
+			if (persistenceStarted) {
+				prepared.session.setActiveModelProfile?.(undefined);
+				clearActiveModelProfileRuntimeState(prepared.session);
+			} else {
+				prepared.session.setActiveModelProfile?.(previousActiveModelProfile);
 			}
+		} catch (rollbackError) {
+			rollbackErrors.push(rollbackError);
 		}
-		if (modelRolesChanged) {
-			prepared.settings.override("modelRoles", previousModelRoles);
-		}
-		if (overridesChanged) {
-			prepared.settings.override("task.agentModelOverrides", previousAgentModelOverrides);
-		}
-		prepared.session.setActiveModelProfile?.(previousActiveModelProfile);
-		if (modelChanged) {
-			// Runtime rolls back to the pre-activation live model. That model may
-			// itself be a transient retry/fallback/context-promotion/plan switch,
-			// so it is recorded as role:"temporary" (NOT the resume default) to
-			// preserve the issue #849 protection.
-			if (previousModel) {
-				await prepared.session.setModelTemporary(previousModel, previousThinkingLevel);
+		if (modelTransitionStarted) {
+			// Ambiguous persistence detaches to the pre-profile baseline; failures
+			// before persistence restore the immediately previous live model.
+			if (rollbackModel) {
+				try {
+					await prepared.session.setModelTemporary(rollbackModel, rollbackThinkingLevel);
+				} catch (rollbackError) {
+					rollbackErrors.push(rollbackError);
+				}
 			}
-			// The happy path already appended the profile main model as the resume
-			// default (role:"default"). Re-assert the pre-activation resume default
-			// so a failed activation does not poison future resume. Fall back to the
-			// live model only when there was no explicit pre-activation default
-			// (nothing to protect). Append-only — never touches the runtime model.
+			// Re-assert the resume default matching the runtime state restored above.
 			const restoreDefaultSelector =
-				previousSessionDefaultModel ??
-				(previousModel ? `${previousModel.provider}/${previousModel.id}` : undefined);
+				(persistenceStarted ? prepared.baselineSessionDefaultModel : previousSessionDefaultModel) ??
+				(rollbackModel ? `${rollbackModel.provider}/${rollbackModel.id}` : undefined);
 			if (restoreDefaultSelector) {
-				prepared.session.recordResumeDefaultModel?.(restoreDefaultSelector);
+				try {
+					prepared.session.recordResumeDefaultModel?.(restoreDefaultSelector);
+				} catch (rollbackError) {
+					rollbackErrors.push(rollbackError);
+				}
 			}
+		}
+		if (rollbackErrors.length > 0) {
+			const activationMessage = error instanceof Error ? error.message : String(error);
+			throw new AggregateError(
+				[error, ...rollbackErrors],
+				`Model profile activation failed (${activationMessage}) and rollback also failed`,
+			);
 		}
 		throw error;
 	}

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -31,6 +31,7 @@ interface ActiveModelProfileRuntimeState {
 	appliedModelRoles: Record<string, string>;
 	appliedAgentModelOverrides: Record<string, string>;
 	defaultSelector?: string;
+	persistedModelProfile: string | undefined;
 }
 
 const activeModelProfileRuntimeStates = new WeakMap<object, ActiveModelProfileRuntimeState>();
@@ -67,7 +68,12 @@ function mergeAppliedProfileAssignments(
 
 type ModelAssignmentPersistenceSettings = Pick<
 	Settings,
-	"clearAgentModelOverride" | "clearModelRole" | "setAgentModelOverride" | "setModelRole"
+	| "clearAgentModelOverride"
+	| "clearModelRole"
+	| "setAgentModelOverride"
+	| "setAgentModelOverrideIfUnchanged"
+	| "setModelRole"
+	| "setModelRoleIfUnchanged"
 >;
 
 interface ModelAssignmentTouchedEntries {
@@ -81,6 +87,8 @@ function persistModelAssignmentEntries(
 	agentModelOverrides: Record<string, string>,
 	previousModelRoles: Record<string, string>,
 	previousAgentModelOverrides: Record<string, string>,
+	explicitModelRoles: ReadonlySet<string>,
+	explicitAgentModelOverrides: ReadonlySet<string>,
 ): ModelAssignmentTouchedEntries {
 	const touched: ModelAssignmentTouchedEntries = {
 		modelRoles: [],
@@ -89,10 +97,14 @@ function persistModelAssignmentEntries(
 	for (const role of new Set([...Object.keys(previousModelRoles), ...Object.keys(modelRoles)])) {
 		const selector = modelRoles[role];
 		if (previousModelRoles[role] === selector) continue;
-		if (selector === undefined) {
-			settings.clearModelRole(role);
+		if (explicitModelRoles.has(role)) {
+			if (selector === undefined) {
+				settings.clearModelRole(role);
+			} else {
+				settings.setModelRole(role, selector);
+			}
 		} else {
-			settings.setModelRole(role, selector);
+			settings.setModelRoleIfUnchanged(role, previousModelRoles[role], selector);
 		}
 		touched.modelRoles.push(role);
 	}
@@ -102,10 +114,14 @@ function persistModelAssignmentEntries(
 	])) {
 		const selector = agentModelOverrides[agentName];
 		if (previousAgentModelOverrides[agentName] === selector) continue;
-		if (selector === undefined) {
-			settings.clearAgentModelOverride(agentName);
+		if (explicitAgentModelOverrides.has(agentName)) {
+			if (selector === undefined) {
+				settings.clearAgentModelOverride(agentName);
+			} else {
+				settings.setAgentModelOverride(agentName, selector);
+			}
 		} else {
-			settings.setAgentModelOverride(agentName, selector);
+			settings.setAgentModelOverrideIfUnchanged(agentName, previousAgentModelOverrides[agentName], selector);
 		}
 		touched.agentModelOverrides.push(agentName);
 	}
@@ -149,6 +165,7 @@ export interface PrepareModelProfileActivationOptions {
 		| "getWithoutProject"
 		| "override"
 		| "set"
+		| "setModelProfileDefaultIfUnchanged"
 	> &
 		ModelAssignmentPersistenceSettings;
 	profileName: string;
@@ -171,6 +188,7 @@ export interface PreparedModelProfileActivation {
 		| "getRuntimeOverride"
 		| "override"
 		| "set"
+		| "setModelProfileDefaultIfUnchanged"
 	> &
 		ModelAssignmentPersistenceSettings;
 	previousModel: Model<Api> | undefined;
@@ -194,6 +212,7 @@ export interface PreparedModelProfileActivation {
 	persistableBaselineModelRoles: Record<string, string>;
 	modelRoles: Record<string, string>;
 	agentModelOverrides: Record<string, string>;
+	previousPersistedModelProfile: string | undefined;
 	previousActiveModelProfile: string | undefined;
 	/**
 	 * The session resume default ("provider/id") captured BEFORE activation —
@@ -211,7 +230,13 @@ export interface MaterializeModelProfileAssignmentOptions {
 	>;
 	settings: Pick<
 		Settings,
-		"clearOverride" | "get" | "getGlobal" | "getRuntimeOverride" | "getWithoutProject" | "override" | "set"
+		| "setModelProfileDefaultIfUnchanged"
+		| "clearOverride"
+		| "get"
+		| "getGlobal"
+		| "getRuntimeOverride"
+		| "getWithoutProject"
+		| "override"
 	> &
 		ModelAssignmentPersistenceSettings;
 	role: GjcModelAssignmentTargetId;
@@ -225,7 +250,13 @@ export interface MaterializeModelProfileAssignmentsOptions {
 	>;
 	settings: Pick<
 		Settings,
-		"clearOverride" | "get" | "getGlobal" | "getRuntimeOverride" | "getWithoutProject" | "override" | "set"
+		| "setModelProfileDefaultIfUnchanged"
+		| "clearOverride"
+		| "get"
+		| "getGlobal"
+		| "getRuntimeOverride"
+		| "getWithoutProject"
+		| "override"
 	> &
 		ModelAssignmentPersistenceSettings;
 	assignments:
@@ -273,8 +304,8 @@ export function materializeActiveModelProfileAssignments(options: MaterializeMod
 	const previousPersistedAgentModelOverrides = {
 		...(options.settings.getGlobal("task.agentModelOverrides") ?? {}),
 	};
-
 	const runtimeState = activeModelProfileRuntimeStates.get(options.session);
+	const previousPersistedModelProfile = runtimeState?.persistedModelProfile ?? activeProfile;
 	const currentPersistableModelRoles = {
 		...options.settings.getWithoutProject("modelRoles"),
 	};
@@ -295,12 +326,22 @@ export function materializeActiveModelProfileAssignments(options: MaterializeMod
 				runtimeState.appliedAgentModelOverrides,
 			)
 		: currentPersistableAgentModelOverrides;
-	const runtimeModelRoles = {
+	const currentRuntimeModelRoles = {
 		...(options.settings.getRuntimeOverride("modelRoles") ?? {}),
 	};
-	const runtimeAgentModelOverrides = {
+	const currentRuntimeAgentModelOverrides = {
 		...(options.settings.getRuntimeOverride("task.agentModelOverrides") ?? {}),
 	};
+	const runtimeModelRoles = runtimeState
+		? deriveProfileBaseline(runtimeState.baselineModelRoles, currentRuntimeModelRoles, runtimeState.appliedModelRoles)
+		: currentRuntimeModelRoles;
+	const runtimeAgentModelOverrides = runtimeState
+		? deriveProfileBaseline(
+				runtimeState.baselineAgentModelOverrides,
+				currentRuntimeAgentModelOverrides,
+				runtimeState.appliedAgentModelOverrides,
+			)
+		: currentRuntimeAgentModelOverrides;
 
 	if (runtimeState) {
 		mergeAppliedProfileAssignments(persistedModelRoles, currentPersistableModelRoles, runtimeState.appliedModelRoles);
@@ -316,13 +357,19 @@ export function materializeActiveModelProfileAssignments(options: MaterializeMod
 		options.session.getSessionDefaultModelSelector?.();
 	if (authoritativeDefaultSelector) {
 		persistedModelRoles.default = authoritativeDefaultSelector;
-		runtimeModelRoles.default = authoritativeDefaultSelector;
 	}
 
+	const explicitModelRoles = new Set<string>();
+	const explicitAgentModelOverrides = new Set<string>();
 	for (const [role, selector] of materializedAssignments) {
 		const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
 		const persisted = target.settingsPath === "modelRoles" ? persistedModelRoles : persistedAgentModelOverrides;
 		const runtime = target.settingsPath === "modelRoles" ? runtimeModelRoles : runtimeAgentModelOverrides;
+		if (target.settingsPath === "modelRoles") {
+			explicitModelRoles.add(role);
+		} else {
+			explicitAgentModelOverrides.add(role);
+		}
 		if (selector === undefined) {
 			delete persisted[role];
 			delete runtime[role];
@@ -333,14 +380,22 @@ export function materializeActiveModelProfileAssignments(options: MaterializeMod
 	}
 
 	options.session.setActiveModelProfile?.(undefined);
-	persistModelAssignmentEntries(
+	const touched = persistModelAssignmentEntries(
 		options.settings,
 		persistedModelRoles,
 		persistedAgentModelOverrides,
 		previousPersistedModelRoles,
 		previousPersistedAgentModelOverrides,
+		explicitModelRoles,
+		explicitAgentModelOverrides,
 	);
-	options.settings.set("modelProfile.default", undefined);
+	for (const role of touched.modelRoles) {
+		if (!explicitModelRoles.has(role)) delete runtimeModelRoles[role];
+	}
+	for (const agentName of touched.agentModelOverrides) {
+		if (!explicitAgentModelOverrides.has(agentName)) delete runtimeAgentModelOverrides[agentName];
+	}
+	options.settings.setModelProfileDefaultIfUnchanged(previousPersistedModelProfile, undefined);
 	options.settings.clearOverride("modelProfile.default");
 	options.settings.override("modelRoles", runtimeModelRoles);
 	options.settings.override("task.agentModelOverrides", runtimeAgentModelOverrides);
@@ -522,6 +577,7 @@ export async function prepareModelProfileActivation(
 	}
 
 	const previousActiveModelProfile = options.session.getActiveModelProfile?.();
+	const previousPersistedModelProfile = options.settings.getGlobal("modelProfile.default");
 	const previousRuntimeState = previousActiveModelProfile
 		? activeModelProfileRuntimeStates.get(options.session)
 		: undefined;
@@ -623,6 +679,7 @@ export async function prepareModelProfileActivation(
 		persistableBaselineModelRoles,
 		modelRoles,
 		agentModelOverrides,
+		previousPersistedModelProfile,
 		previousActiveModelProfile,
 		previousSessionDefaultModel: options.session.getSessionDefaultModelSelector?.(),
 	};
@@ -694,6 +751,7 @@ export async function applyPreparedModelProfileActivation(
 			baselineModel: prepared.baselineModel,
 			baselineThinkingLevel: prepared.baselineThinkingLevel,
 			baselineSessionDefaultModel: prepared.baselineSessionDefaultModel,
+			persistedModelProfile: options.persistDefault ? prepared.profileName : prepared.previousPersistedModelProfile,
 			persistableBaselineThinkingLevel: prepared.persistableBaselineThinkingLevel,
 			baselineModelRoles: { ...prepared.baselineModelRoles },
 			baselineAgentModelOverrides: { ...prepared.baselineAgentModelOverrides },
@@ -767,25 +825,72 @@ export async function applyPreparedModelProfileActivation(
 }
 
 export interface MaterializeModelProfileForDeletionResult {
+	materializedProfileName: string;
 	modelRoles: Record<string, string>;
 	agentModelOverrides: Record<string, string>;
-	previousModelRoles: Record<string, string>;
-	previousAgentModelOverrides: Record<string, string>;
-	previousDefaultProfile: string | undefined;
+	previousPersistedModelRoles: Record<string, string>;
+	previousPersistedAgentModelOverrides: Record<string, string>;
 	previousPersistedDefaultProfile: string | undefined;
+	previousRuntimeModelRoles: Record<string, string>;
+	previousRuntimeAgentModelOverrides: Record<string, string>;
+	previousRuntimeDefaultProfile: string | undefined;
 	previousActiveModelProfile: string | undefined;
+}
+
+type ModelProfileDeletionSettings = Pick<
+	Settings,
+	"clearOverride" | "flush" | "getGlobal" | "getRuntimeOverride" | "override" | "setModelProfileDefaultIfUnchanged"
+> &
+	ModelAssignmentPersistenceSettings;
+
+function restoreModelProfileDeletionRuntime(
+	settings: Pick<Settings, "clearOverride" | "override">,
+	snapshot: MaterializeModelProfileForDeletionResult,
+): void {
+	settings.override("modelRoles", snapshot.previousRuntimeModelRoles);
+	settings.override("task.agentModelOverrides", snapshot.previousRuntimeAgentModelOverrides);
+	if (snapshot.previousRuntimeDefaultProfile === undefined) {
+		settings.clearOverride("modelProfile.default");
+	} else {
+		settings.override("modelProfile.default", snapshot.previousRuntimeDefaultProfile);
+	}
+}
+
+function stageModelProfileDeletionRollback(
+	settings: ModelProfileDeletionSettings,
+	snapshot: MaterializeModelProfileForDeletionResult,
+): void {
+	const inheritedEntries = new Set<string>();
+	persistModelAssignmentEntries(
+		settings,
+		snapshot.previousPersistedModelRoles,
+		snapshot.previousPersistedAgentModelOverrides,
+		snapshot.modelRoles,
+		snapshot.agentModelOverrides,
+		inheritedEntries,
+		inheritedEntries,
+	);
+	if (snapshot.previousPersistedDefaultProfile === snapshot.materializedProfileName) {
+		settings.setModelProfileDefaultIfUnchanged(undefined, snapshot.previousPersistedDefaultProfile);
+	}
 }
 
 export async function materializeModelProfileForDeletion(
 	options: PrepareModelProfileActivationOptions & {
-		settings: Pick<Settings, "clearOverride" | "flush" | "get" | "getGlobal" | "override" | "set">;
+		settings: ModelProfileDeletionSettings;
 	},
 ): Promise<MaterializeModelProfileForDeletionResult> {
 	const prepared = await prepareModelProfileActivation(options);
-	const previousDefaultProfile = prepared.settings.get("modelProfile.default");
+	const previousPersistedModelRoles = {
+		...(prepared.settings.getGlobal("modelRoles") ?? {}),
+	};
+	const previousPersistedAgentModelOverrides = {
+		...(prepared.settings.getGlobal("task.agentModelOverrides") ?? {}),
+	};
 	const previousPersistedDefaultProfile = prepared.settings.getGlobal("modelProfile.default");
+	const previousRuntimeDefaultProfile = prepared.settings.getRuntimeOverride("modelProfile.default");
 	const nextModelRoles = {
-		...prepared.previousModelRoles,
+		...prepared.persistableBaselineModelRoles,
 		...(prepared.defaultModel
 			? {
 					default: formatModelSelectorValue(
@@ -797,52 +902,71 @@ export async function materializeModelProfileForDeletion(
 		...prepared.modelRoles,
 	};
 	const nextAgentModelOverrides = {
-		...prepared.previousAgentModelOverrides,
+		...prepared.persistableBaselineAgentModelOverrides,
 		...prepared.agentModelOverrides,
 	};
+	const snapshot: MaterializeModelProfileForDeletionResult = {
+		materializedProfileName: prepared.profileName,
+		modelRoles: nextModelRoles,
+		agentModelOverrides: nextAgentModelOverrides,
+		previousPersistedModelRoles,
+		previousPersistedAgentModelOverrides,
+		previousPersistedDefaultProfile,
+		previousRuntimeModelRoles: prepared.previousRuntimeModelRoles,
+		previousRuntimeAgentModelOverrides: prepared.previousRuntimeAgentModelOverrides,
+		previousRuntimeDefaultProfile,
+		previousActiveModelProfile: prepared.previousActiveModelProfile,
+	};
+	const inheritedEntries = new Set<string>();
 
 	try {
-		prepared.settings.set("modelRoles", nextModelRoles);
-		prepared.settings.set("task.agentModelOverrides", nextAgentModelOverrides);
-		prepared.settings.set("modelProfile.default", undefined);
+		const touched = persistModelAssignmentEntries(
+			prepared.settings,
+			nextModelRoles,
+			nextAgentModelOverrides,
+			previousPersistedModelRoles,
+			previousPersistedAgentModelOverrides,
+			inheritedEntries,
+			inheritedEntries,
+		);
+		if (previousPersistedDefaultProfile === prepared.profileName) {
+			prepared.settings.setModelProfileDefaultIfUnchanged(previousPersistedDefaultProfile, undefined);
+		}
+		const nextRuntimeModelRoles = { ...prepared.previousRuntimeModelRoles };
+		const profileOwnedModelRoles = new Set([
+			...touched.modelRoles,
+			...Object.keys(prepared.modelRoles),
+			...(prepared.profileDefaultSelector ? ["default"] : []),
+		]);
+		for (const role of profileOwnedModelRoles) delete nextRuntimeModelRoles[role];
+		const nextRuntimeAgentModelOverrides = { ...prepared.previousRuntimeAgentModelOverrides };
+		const profileOwnedAgentOverrides = new Set([
+			...touched.agentModelOverrides,
+			...Object.keys(prepared.agentModelOverrides),
+		]);
+		for (const agentName of profileOwnedAgentOverrides) delete nextRuntimeAgentModelOverrides[agentName];
 		prepared.settings.clearOverride("modelProfile.default");
-		prepared.settings.override("modelRoles", nextModelRoles);
-		prepared.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
+		prepared.settings.override("modelRoles", nextRuntimeModelRoles);
+		prepared.settings.override("task.agentModelOverrides", nextRuntimeAgentModelOverrides);
 		prepared.session.setActiveModelProfile?.(undefined);
 		await prepared.settings.flush();
 	} catch (error) {
-		prepared.settings.set("modelRoles", prepared.previousModelRoles);
-		prepared.settings.set("task.agentModelOverrides", prepared.previousAgentModelOverrides);
-		prepared.settings.set("modelProfile.default", previousPersistedDefaultProfile);
-		prepared.settings.override("modelRoles", prepared.previousModelRoles);
-		prepared.settings.override("task.agentModelOverrides", prepared.previousAgentModelOverrides);
-		prepared.settings.override("modelProfile.default", previousDefaultProfile);
+		stageModelProfileDeletionRollback(prepared.settings, snapshot);
+		restoreModelProfileDeletionRuntime(prepared.settings, snapshot);
 		prepared.session.setActiveModelProfile?.(prepared.previousActiveModelProfile);
 		throw error;
 	}
 
-	return {
-		modelRoles: nextModelRoles,
-		agentModelOverrides: nextAgentModelOverrides,
-		previousModelRoles: prepared.previousModelRoles,
-		previousAgentModelOverrides: prepared.previousAgentModelOverrides,
-		previousDefaultProfile,
-		previousPersistedDefaultProfile,
-		previousActiveModelProfile: prepared.previousActiveModelProfile,
-	};
+	return snapshot;
 }
 
 export async function restoreMaterializedModelProfileForDeletion(options: {
-	settings: Pick<Settings, "flush" | "override" | "set">;
+	settings: ModelProfileDeletionSettings;
 	session: Pick<ModelProfileActivationSession, "setActiveModelProfile">;
 	snapshot: MaterializeModelProfileForDeletionResult;
 }): Promise<void> {
-	options.settings.set("modelRoles", options.snapshot.previousModelRoles);
-	options.settings.set("task.agentModelOverrides", options.snapshot.previousAgentModelOverrides);
-	options.settings.set("modelProfile.default", options.snapshot.previousPersistedDefaultProfile);
-	options.settings.override("modelRoles", options.snapshot.previousModelRoles);
-	options.settings.override("task.agentModelOverrides", options.snapshot.previousAgentModelOverrides);
-	options.settings.override("modelProfile.default", options.snapshot.previousDefaultProfile);
+	stageModelProfileDeletionRollback(options.settings, options.snapshot);
+	restoreModelProfileDeletionRuntime(options.settings, options.snapshot);
 	options.session.setActiveModelProfile?.(options.snapshot.previousActiveModelProfile);
 	await options.settings.flush();
 }

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -32,6 +32,7 @@ interface ActiveModelProfileRuntimeState {
 	appliedAgentModelOverrides: Record<string, string>;
 	defaultSelector?: string;
 	persistedModelProfile: string | undefined;
+	persistedModelProfilePendingMutationId: number | undefined;
 }
 
 const activeModelProfileRuntimeStates = new WeakMap<object, ActiveModelProfileRuntimeState>();
@@ -94,10 +95,15 @@ function persistModelAssignmentEntries(
 		modelRoles: [],
 		agentModelOverrides: [],
 	};
-	for (const role of new Set([...Object.keys(previousModelRoles), ...Object.keys(modelRoles)])) {
+	for (const role of new Set([
+		...Object.keys(previousModelRoles),
+		...Object.keys(modelRoles),
+		...explicitModelRoles,
+	])) {
 		const selector = modelRoles[role];
-		if (previousModelRoles[role] === selector) continue;
-		if (explicitModelRoles.has(role)) {
+		const explicit = explicitModelRoles.has(role);
+		if (previousModelRoles[role] === selector && !explicit) continue;
+		if (explicit) {
 			if (selector === undefined) {
 				settings.clearModelRole(role);
 			} else {
@@ -111,10 +117,12 @@ function persistModelAssignmentEntries(
 	for (const agentName of new Set([
 		...Object.keys(previousAgentModelOverrides),
 		...Object.keys(agentModelOverrides),
+		...explicitAgentModelOverrides,
 	])) {
 		const selector = agentModelOverrides[agentName];
-		if (previousAgentModelOverrides[agentName] === selector) continue;
-		if (explicitAgentModelOverrides.has(agentName)) {
+		const explicit = explicitAgentModelOverrides.has(agentName);
+		if (previousAgentModelOverrides[agentName] === selector && !explicit) continue;
+		if (explicit) {
 			if (selector === undefined) {
 				settings.clearAgentModelOverride(agentName);
 			} else {
@@ -165,6 +173,7 @@ export interface PrepareModelProfileActivationOptions {
 		| "getWithoutProject"
 		| "override"
 		| "set"
+		| "getPendingModelProfileDefaultMutationId"
 		| "setModelProfileDefaultIfUnchanged"
 	> &
 		ModelAssignmentPersistenceSettings;
@@ -188,6 +197,7 @@ export interface PreparedModelProfileActivation {
 		| "getRuntimeOverride"
 		| "override"
 		| "set"
+		| "getPendingModelProfileDefaultMutationId"
 		| "setModelProfileDefaultIfUnchanged"
 	> &
 		ModelAssignmentPersistenceSettings;
@@ -213,6 +223,7 @@ export interface PreparedModelProfileActivation {
 	modelRoles: Record<string, string>;
 	agentModelOverrides: Record<string, string>;
 	previousPersistedModelProfile: string | undefined;
+	previousPersistedModelProfilePendingMutationId: number | undefined;
 	previousActiveModelProfile: string | undefined;
 	/**
 	 * The session resume default ("provider/id") captured BEFORE activation —
@@ -231,6 +242,7 @@ export interface MaterializeModelProfileAssignmentOptions {
 	settings: Pick<
 		Settings,
 		| "setModelProfileDefaultIfUnchanged"
+		| "getPendingModelProfileDefaultMutationId"
 		| "clearOverride"
 		| "get"
 		| "getGlobal"
@@ -251,6 +263,7 @@ export interface MaterializeModelProfileAssignmentsOptions {
 	settings: Pick<
 		Settings,
 		| "setModelProfileDefaultIfUnchanged"
+		| "getPendingModelProfileDefaultMutationId"
 		| "clearOverride"
 		| "get"
 		| "getGlobal"
@@ -305,7 +318,10 @@ export function materializeActiveModelProfileAssignments(options: MaterializeMod
 		...(options.settings.getGlobal("task.agentModelOverrides") ?? {}),
 	};
 	const runtimeState = activeModelProfileRuntimeStates.get(options.session);
-	const previousPersistedModelProfile = runtimeState?.persistedModelProfile ?? activeProfile;
+	const previousPersistedModelProfile = runtimeState ? runtimeState.persistedModelProfile : activeProfile;
+	const previousPersistedModelProfilePendingMutationId = runtimeState
+		? runtimeState.persistedModelProfilePendingMutationId
+		: options.settings.getPendingModelProfileDefaultMutationId();
 	const currentPersistableModelRoles = {
 		...options.settings.getWithoutProject("modelRoles"),
 	};
@@ -395,7 +411,11 @@ export function materializeActiveModelProfileAssignments(options: MaterializeMod
 	for (const agentName of touched.agentModelOverrides) {
 		if (!explicitAgentModelOverrides.has(agentName)) delete runtimeAgentModelOverrides[agentName];
 	}
-	options.settings.setModelProfileDefaultIfUnchanged(previousPersistedModelProfile, undefined);
+	options.settings.setModelProfileDefaultIfUnchanged(
+		previousPersistedModelProfile,
+		undefined,
+		previousPersistedModelProfilePendingMutationId,
+	);
 	options.settings.clearOverride("modelProfile.default");
 	options.settings.override("modelRoles", runtimeModelRoles);
 	options.settings.override("task.agentModelOverrides", runtimeAgentModelOverrides);
@@ -578,6 +598,7 @@ export async function prepareModelProfileActivation(
 
 	const previousActiveModelProfile = options.session.getActiveModelProfile?.();
 	const previousPersistedModelProfile = options.settings.getGlobal("modelProfile.default");
+	const previousPersistedModelProfilePendingMutationId = options.settings.getPendingModelProfileDefaultMutationId();
 	const previousRuntimeState = previousActiveModelProfile
 		? activeModelProfileRuntimeStates.get(options.session)
 		: undefined;
@@ -680,6 +701,7 @@ export async function prepareModelProfileActivation(
 		modelRoles,
 		agentModelOverrides,
 		previousPersistedModelProfile,
+		previousPersistedModelProfilePendingMutationId,
 		previousActiveModelProfile,
 		previousSessionDefaultModel: options.session.getSessionDefaultModelSelector?.(),
 	};
@@ -752,6 +774,9 @@ export async function applyPreparedModelProfileActivation(
 			baselineThinkingLevel: prepared.baselineThinkingLevel,
 			baselineSessionDefaultModel: prepared.baselineSessionDefaultModel,
 			persistedModelProfile: options.persistDefault ? prepared.profileName : prepared.previousPersistedModelProfile,
+			persistedModelProfilePendingMutationId: options.persistDefault
+				? undefined
+				: prepared.previousPersistedModelProfilePendingMutationId,
 			persistableBaselineThinkingLevel: prepared.persistableBaselineThinkingLevel,
 			baselineModelRoles: { ...prepared.baselineModelRoles },
 			baselineAgentModelOverrides: { ...prepared.baselineAgentModelOverrides },
@@ -839,7 +864,12 @@ export interface MaterializeModelProfileForDeletionResult {
 
 type ModelProfileDeletionSettings = Pick<
 	Settings,
-	"clearOverride" | "flush" | "getGlobal" | "getRuntimeOverride" | "override" | "setModelProfileDefaultIfUnchanged"
+	| "clearOverride"
+	| "flushOrThrow"
+	| "getGlobal"
+	| "getRuntimeOverride"
+	| "override"
+	| "setModelProfileDefaultIfUnchanged"
 > &
 	ModelAssignmentPersistenceSettings;
 
@@ -949,7 +979,7 @@ export async function materializeModelProfileForDeletion(
 		prepared.settings.override("modelRoles", nextRuntimeModelRoles);
 		prepared.settings.override("task.agentModelOverrides", nextRuntimeAgentModelOverrides);
 		prepared.session.setActiveModelProfile?.(undefined);
-		await prepared.settings.flush();
+		await prepared.settings.flushOrThrow();
 	} catch (error) {
 		stageModelProfileDeletionRollback(prepared.settings, snapshot);
 		restoreModelProfileDeletionRuntime(prepared.settings, snapshot);
@@ -968,7 +998,7 @@ export async function restoreMaterializedModelProfileForDeletion(options: {
 	stageModelProfileDeletionRollback(options.settings, options.snapshot);
 	restoreModelProfileDeletionRuntime(options.settings, options.snapshot);
 	options.session.setActiveModelProfile?.(options.snapshot.previousActiveModelProfile);
-	await options.settings.flush();
+	await options.settings.flushOrThrow();
 }
 
 export async function activateModelProfile(

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1702,7 +1702,7 @@ export class ModelRegistry {
 		const targetSettings = this.#modelBindingsTargetSettings;
 		if (!targetSettings) return;
 		const bindings = this.#configuredModelBindings;
-		const nextModelRoles = { ...targetSettings.get("modelRoles") };
+		const nextModelRoles = { ...(targetSettings.getRuntimeOverride("modelRoles") ?? {}) };
 		const configuredModelRoles = bindings?.modelRoles ?? {};
 		const configuredModelRoleKeys = new Set(Object.keys(configuredModelRoles));
 		for (const role of this.#appliedModelBindingRoles) {
@@ -1733,7 +1733,9 @@ export class ModelRegistry {
 		targetSettings.override("modelRoles", nextModelRoles);
 		this.#appliedModelBindingRoles = new Set(Object.keys(configuredModelRoles));
 
-		const nextAgentModelOverrides = { ...targetSettings.get("task.agentModelOverrides") };
+		const nextAgentModelOverrides = {
+			...(targetSettings.getRuntimeOverride("task.agentModelOverrides") ?? {}),
+		};
 		const configuredAgentModelOverrides = bindings?.agentModelOverrides ?? {};
 		const configuredAgentModelOverrideKeys = new Set(Object.keys(configuredAgentModelOverrides));
 		for (const agentName of this.#appliedAgentModelBindingOverrides) {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -78,6 +78,11 @@ interface DurableSettingsRevisionState {
 	entries: Record<string, DurableSettingRevisionEntry>;
 }
 
+interface LoadedSettingsRevisionState {
+	state: DurableSettingsRevisionState;
+	exists: boolean;
+}
+
 interface ConditionalMutationOutcome {
 	expectedValue: unknown;
 	desiredValue: unknown;
@@ -595,6 +600,38 @@ export class Settings {
 	}
 
 	/**
+	 * Delete a custom model profile while holding the global settings lock.
+	 *
+	 * The durable deletion marker prevents a profile selection staged by a
+	 * concurrent Settings instance from committing after object deletion.
+	 */
+	async deleteModelProfileIfUnreferenced<T>(profileName: string, deleteProfile: () => Promise<T>): Promise<T> {
+		await this.flushOrThrow();
+		if (!this.#persist || !this.#configPath) {
+			if (this.getGlobal("modelProfile.default") === profileName) {
+				throw new Error(`Model profile became the default while deletion was in progress: ${profileName}`);
+			}
+			return deleteProfile();
+		}
+		return withFileLock(this.#configPath, async () => {
+			const current = await this.#loadYaml(this.#configPath!);
+			if (getByPath(current, ["modelProfile", "default"]) === profileName) {
+				throw new Error(`Model profile became the default while deletion was in progress: ${profileName}`);
+			}
+			const deletedModelProfiles = await this.#loadDeletedModelProfiles();
+			deletedModelProfiles.add(profileName);
+			await this.#writeDeletedModelProfiles(deletedModelProfiles);
+			try {
+				return await deleteProfile();
+			} catch (error) {
+				deletedModelProfiles.delete(profileName);
+				await this.#writeDeletedModelProfiles(deletedModelProfiles);
+				throw error;
+			}
+		});
+	}
+
+	/**
 	 * Apply runtime overrides (not persisted).
 	 */
 	override<P extends SettingPath>(path: P, value: SettingValue<P>): void {
@@ -1005,10 +1042,10 @@ export class Settings {
 			this.#storage = await AgentStorage.open(getAgentDbPath(this.#agentDir));
 			await this.#migrateFromLegacy();
 			await withFileLock(this.#configPath!, async () => {
-				const revisionStateExists = this.#revisionPath ? await Bun.file(this.#revisionPath).exists() : false;
+				const loadedRevisionState = await this.#loadRevisionState();
 				this.#global = await this.#loadYaml(this.#configPath!);
-				this.#revisionState = await this.#loadRevisionState();
-				if (!revisionStateExists) {
+				this.#revisionState = loadedRevisionState.state;
+				if (!loadedRevisionState.exists) {
 					await this.#writeRevisionState(this.#revisionState);
 				}
 			});
@@ -1022,19 +1059,70 @@ export class Settings {
 		return this;
 	}
 
-	async #loadRevisionState(): Promise<DurableSettingsRevisionState> {
-		if (!this.#revisionPath) return emptySettingsRevisionState();
+	async #loadRevisionState(): Promise<LoadedSettingsRevisionState> {
+		if (!this.#revisionPath) {
+			return { state: emptySettingsRevisionState(), exists: false };
+		}
 		try {
 			const content = await Bun.file(this.#revisionPath).text();
-			return parseSettingsRevisionState(JSON.parse(content));
+			return {
+				state: parseSettingsRevisionState(JSON.parse(content)),
+				exists: true,
+			};
 		} catch (error) {
-			if (isEnoent(error)) return emptySettingsRevisionState();
+			if (isEnoent(error)) {
+				return { state: emptySettingsRevisionState(), exists: false };
+			}
 			logger.warn("Settings: failed to load revision state", {
 				path: this.#revisionPath,
 				error: String(error),
 			});
 			throw error;
 		}
+	}
+
+	#getModelProfileDeletionPath(): string | undefined {
+		return this.#configPath ? `${this.#configPath}.profile-deletions.json` : undefined;
+	}
+
+	async #loadDeletedModelProfiles(): Promise<Set<string>> {
+		const deletionPath = this.#getModelProfileDeletionPath();
+		if (!deletionPath) return new Set();
+		try {
+			const parsed: unknown = JSON.parse(await Bun.file(deletionPath).text());
+			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+				throw new Error("Invalid model profile deletion state");
+			}
+			const raw = parsed as Record<string, unknown>;
+			if (
+				raw.version !== 1 ||
+				!Array.isArray(raw.profiles) ||
+				!raw.profiles.every(profileName => typeof profileName === "string" && profileName.length > 0) ||
+				new Set(raw.profiles).size !== raw.profiles.length
+			) {
+				throw new Error("Invalid model profile deletion state");
+			}
+			return new Set(raw.profiles as string[]);
+		} catch (error) {
+			if (isEnoent(error)) return new Set();
+			logger.warn("Settings: failed to load model profile deletion state", {
+				path: deletionPath,
+				error: String(error),
+			});
+			throw error;
+		}
+	}
+
+	async #writeDeletedModelProfiles(profileNames: ReadonlySet<string>): Promise<void> {
+		const deletionPath = this.#getModelProfileDeletionPath();
+		if (!deletionPath) return;
+		await this.#atomicWrite(
+			deletionPath,
+			JSON.stringify({
+				version: 1,
+				profiles: [...profileNames].sort((left, right) => left.localeCompare(right)),
+			}),
+		);
 	}
 
 	async #atomicWrite(filePath: string, content: string): Promise<void> {
@@ -1351,6 +1439,29 @@ export class Settings {
 		}, 100);
 	}
 
+	async #customModelProfileExists(profileName: string): Promise<boolean> {
+		const modelsPath = path.join(this.#agentDir, "models.yml");
+		try {
+			const parsed = YAML.parse(await Bun.file(modelsPath).text());
+			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+			const profiles = (parsed as Record<string, unknown>).profiles;
+			return (
+				!!profiles &&
+				typeof profiles === "object" &&
+				!Array.isArray(profiles) &&
+				Object.hasOwn(profiles, profileName)
+			);
+		} catch (error) {
+			if (!isEnoent(error)) {
+				logger.warn("Settings: failed to inspect custom model profiles", {
+					path: modelsPath,
+					error: String(error),
+				});
+			}
+			return false;
+		}
+	}
+
 	async #saveNow(options: { throwOnError?: boolean } = {}): Promise<void> {
 		if (!this.#persist || !this.#configPath || this.#modified.size === 0) return;
 
@@ -1360,9 +1471,14 @@ export class Settings {
 		try {
 			await withFileLock(configPath, async () => {
 				const current = await this.#loadYaml(configPath);
-				const revisionState = await this.#loadRevisionState();
+				const loadedRevisionState = await this.#loadRevisionState();
+				const revisionState = loadedRevisionState.state;
+				if (!loadedRevisionState.exists) {
+					await this.#writeRevisionState(revisionState);
+				}
 				this.#revisionState = structuredClone(revisionState);
 				const loadedGeneration = revisionState.generation;
+				const deletedModelProfiles = await this.#loadDeletedModelProfiles();
 				const accepted: Array<{
 					modifiedPath: string;
 					mutation: PendingSettingMutation;
@@ -1371,6 +1487,18 @@ export class Settings {
 				}> = [];
 
 				for (const [modifiedPath, mutation] of initialEntries) {
+					if (
+						modifiedPath === "modelProfile.default" &&
+						typeof mutation.desiredValue === "string" &&
+						deletedModelProfiles.has(mutation.desiredValue)
+					) {
+						if (await this.#customModelProfileExists(mutation.desiredValue)) {
+							deletedModelProfiles.delete(mutation.desiredValue);
+							await this.#writeDeletedModelProfiles(deletedModelProfiles);
+						} else {
+							throw new Error(`Model profile no longer exists: ${mutation.desiredValue}`);
+						}
+					}
 					const segments = decodeModifiedPath(modifiedPath);
 					const currentValue = getByPath(current, segments);
 					const currentRevision = revisionState.entries[modifiedPath]?.revision ?? 0;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -11,9 +11,11 @@
  *   const isolated = Settings.isolated({ "compaction.enabled": false });
  */
 
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import {
 	getAgentDbPath,
 	getAgentDir,
@@ -54,19 +56,152 @@ export * from "./settings-schema";
 export interface RawSettings {
 	[key: string]: unknown;
 }
-type SettingMutationGuard = { kind: "unconditional" } | { kind: "if-unchanged"; expectedValue: unknown };
+type SettingMutationGuard =
+	| { kind: "unconditional" }
+	| {
+			kind: "if-unchanged";
+			expectedValue: unknown;
+			expectedGeneration: string;
+			expectedRevision: number;
+	  };
+
+interface DurableSettingRevisionEntry {
+	revision: number;
+	ownerId: string;
+	mutationId: number;
+}
+
+interface DurableSettingsRevisionState {
+	version: 1;
+	nextRevision: number;
+	generation: string;
+	entries: Record<string, DurableSettingRevisionEntry>;
+}
+
+interface ConditionalMutationOutcome {
+	expectedValue: unknown;
+	desiredValue: unknown;
+	applied: boolean;
+	revision: number;
+	generation: string;
+}
 
 interface PendingSettingMutation {
 	id: number;
 	desiredValue: unknown;
 	guard: SettingMutationGuard;
+	attempted: boolean;
+	predecessorGeneration?: string;
+	predecessorRevision?: number;
+	predecessorValue?: unknown;
 }
 
-function canApplySettingMutation(mutation: PendingSettingMutation, currentValue: unknown): boolean {
+const SETTINGS_REVISION_STATE_VERSION = 1 as const;
+const SETTINGS_REVISION_GENERATION_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function emptySettingsRevisionState(): DurableSettingsRevisionState {
+	return {
+		version: SETTINGS_REVISION_STATE_VERSION,
+		generation: crypto.randomUUID(),
+		nextRevision: 1,
+		entries: {},
+	};
+}
+
+function isValidRevisionPath(modifiedPath: string): boolean {
+	if (!modifiedPath.startsWith(RECORD_ENTRY_MUTATION_PREFIX)) {
+		return (
+			modifiedPath !== "modelRoles" &&
+			modifiedPath !== "task.agentModelOverrides" &&
+			Object.hasOwn(SETTINGS_SCHEMA, modifiedPath)
+		);
+	}
+	try {
+		const segments = decodeModifiedPath(modifiedPath);
+		if (segments.length === 2 && segments[0] === "modelRoles" && isValidRecordEntryMutationKey(segments[1])) {
+			return modifiedPath === encodeRecordEntryMutation("modelRoles", segments[1]);
+		}
+		if (
+			segments.length === 3 &&
+			segments[0] === "task" &&
+			segments[1] === "agentModelOverrides" &&
+			isValidRecordEntryMutationKey(segments[2])
+		) {
+			return modifiedPath === encodeRecordEntryMutation("task.agentModelOverrides", segments[2]);
+		}
+		return false;
+	} catch {
+		return false;
+	}
+}
+
+function parseSettingsRevisionState(value: unknown): DurableSettingsRevisionState {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("Invalid settings revision state");
+	}
+	const raw = value as Record<string, unknown>;
+	if (
+		raw.version !== SETTINGS_REVISION_STATE_VERSION ||
+		typeof raw.generation !== "string" ||
+		!SETTINGS_REVISION_GENERATION_PATTERN.test(raw.generation) ||
+		!Number.isSafeInteger(raw.nextRevision) ||
+		(raw.nextRevision as number) < 1
+	) {
+		throw new Error("Invalid settings revision state header");
+	}
+	if (!raw.entries || typeof raw.entries !== "object" || Array.isArray(raw.entries)) {
+		throw new Error("Invalid settings revision state entries");
+	}
+
+	const entries: Record<string, DurableSettingRevisionEntry> = {};
+	let maxRevision = 0;
+	for (const [modifiedPath, candidate] of Object.entries(raw.entries)) {
+		if (!isValidRevisionPath(modifiedPath)) {
+			throw new Error(`Invalid settings revision path: ${modifiedPath}`);
+		}
+		if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+			throw new Error(`Invalid settings revision entry: ${modifiedPath}`);
+		}
+		const entry = candidate as Record<string, unknown>;
+		if (
+			!Number.isSafeInteger(entry.revision) ||
+			(entry.revision as number) < 1 ||
+			typeof entry.ownerId !== "string" ||
+			entry.ownerId.length === 0 ||
+			!Number.isSafeInteger(entry.mutationId) ||
+			(entry.mutationId as number) < 1
+		) {
+			throw new Error(`Invalid settings revision entry: ${modifiedPath}`);
+		}
+		const revision = entry.revision as number;
+		entries[modifiedPath] = {
+			revision,
+			ownerId: entry.ownerId,
+			mutationId: entry.mutationId as number,
+		};
+		maxRevision = Math.max(maxRevision, revision);
+	}
+	if ((raw.nextRevision as number) <= maxRevision) {
+		throw new Error("Invalid settings revision ordering");
+	}
+
+	return {
+		generation: raw.generation,
+		version: SETTINGS_REVISION_STATE_VERSION,
+		nextRevision: raw.nextRevision as number,
+		entries,
+	};
+}
+
+function mutationValuesMatch(mutation: PendingSettingMutation, currentValue: unknown): boolean {
+	if (mutation.guard.kind === "unconditional") return true;
+	return Object.is(currentValue, mutation.guard.expectedValue) || Object.is(currentValue, mutation.desiredValue);
+}
+
+function mutationRetryValuesMatch(mutation: PendingSettingMutation, currentValue: unknown): boolean {
 	return (
-		mutation.guard.kind === "unconditional" ||
-		Object.is(currentValue, mutation.guard.expectedValue) ||
-		Object.is(currentValue, mutation.desiredValue)
+		isDeepStrictEqual(currentValue, mutation.predecessorValue) ||
+		isDeepStrictEqual(currentValue, mutation.desiredValue)
 	);
 }
 
@@ -94,6 +229,9 @@ function getByPath(obj: RawSettings, segments: string[]): unknown {
 		if (current === null || current === undefined || typeof current !== "object") {
 			return undefined;
 		}
+		if (!Object.hasOwn(current, segment)) {
+			return undefined;
+		}
 		current = (current as Record<string, unknown>)[segment];
 	}
 	return current;
@@ -107,7 +245,7 @@ function setByPath(obj: RawSettings, segments: string[], value: unknown): void {
 	let current = obj;
 	for (let i = 0; i < segments.length - 1; i++) {
 		const segment = segments[i];
-		if (!(segment in current) || typeof current[segment] !== "object" || current[segment] === null) {
+		if (!Object.hasOwn(current, segment) || typeof current[segment] !== "object" || current[segment] === null) {
 			current[segment] = {};
 		}
 		current = current[segment] as RawSettings;
@@ -156,13 +294,28 @@ function stringArrayFromUnknown(value: unknown): string[] {
 function shallowStringRecord(value: unknown): Record<string, string> {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
 
-	const result: Record<string, string> = {};
+	const result: Record<string, string> = Object.create(null);
 	for (const [key, item] of Object.entries(value)) {
 		if (typeof item === "string") {
 			result[key] = item;
 		}
 	}
 	return result;
+}
+
+const FORBIDDEN_RECORD_ENTRY_MUTATION_KEYS = new Set(["prototype"]);
+
+function isValidRecordEntryMutationKey(key: string): boolean {
+	return key.length > 0 && !FORBIDDEN_RECORD_ENTRY_MUTATION_KEYS.has(key) && !Object.hasOwn(Object.prototype, key);
+}
+
+function assertValidRecordEntryMutationKey(key: string): void {
+	if (key.length === 0) {
+		throw new Error("Model assignment key cannot be empty");
+	}
+	if (!isValidRecordEntryMutationKey(key)) {
+		throw new Error(`Model assignment key is not allowed: ${key}`);
+	}
 }
 
 const RECORD_ENTRY_MUTATION_PREFIX = "\0record-entry:";
@@ -227,6 +380,10 @@ export class Settings {
 	#cwd: string;
 	#agentDir: string;
 	#storage: AgentStorage | null = null;
+	#revisionPath: string | null;
+	#ownerId = crypto.randomUUID();
+	#revisionState = emptySettingsRevisionState();
+	#conditionalOutcomes = new Map<string, ConditionalMutationOutcome>();
 
 	/** Global settings from config.yml */
 	#global: RawSettings = {};
@@ -251,7 +408,24 @@ export class Settings {
 	private constructor(options: SettingsOptions = {}) {
 		this.#cwd = path.normalize(options.cwd ?? getProjectDir());
 		this.#agentDir = path.normalize(options.agentDir ?? getAgentDir());
-		this.#configPath = options.inMemory ? null : path.join(this.#agentDir, "config.yml");
+		let persistenceAgentDir = this.#agentDir;
+		try {
+			persistenceAgentDir = fs.realpathSync.native(this.#agentDir);
+		} catch {
+			try {
+				persistenceAgentDir = path.join(
+					fs.realpathSync.native(path.dirname(this.#agentDir)),
+					path.basename(this.#agentDir),
+				);
+			} catch {}
+		}
+		this.#configPath = options.inMemory ? null : path.join(persistenceAgentDir, "config.yml");
+		if (this.#configPath) {
+			try {
+				this.#configPath = fs.realpathSync.native(this.#configPath);
+			} catch {}
+		}
+		this.#revisionPath = this.#configPath ? `${this.#configPath}.revisions.json` : null;
 		this.#persist = !options.inMemory;
 
 		if (options.overrides) {
@@ -284,6 +458,7 @@ export class Settings {
 			},
 			error => {
 				globalInstance = null;
+				globalInstancePromise = null;
 				throw error;
 			},
 		);
@@ -403,9 +578,17 @@ export class Settings {
 	 * Persist or clear the default model profile only if another writer has not
 	 * changed it since this Settings instance loaded it.
 	 */
-	setModelProfileDefaultIfUnchanged(expectedProfileName: string | undefined, profileName: string | undefined): void {
+	getPendingModelProfileDefaultMutationId(): number | undefined {
+		return this.#modified.get("modelProfile.default")?.id;
+	}
+
+	setModelProfileDefaultIfUnchanged(
+		expectedProfileName: string | undefined,
+		profileName: string | undefined,
+		expectedPendingMutationId?: number,
+	): void {
 		const path = "modelProfile.default";
-		if (!this.#enqueueModifiedIfUnchanged(path, expectedProfileName, profileName, true)) return;
+		if (!this.#enqueueModifiedIfUnchanged(path, expectedProfileName, profileName, expectedPendingMutationId)) return;
 		setByPath(this.#global, path.split("."), profileName);
 		this.#rebuildMerged();
 		this.#queueSave();
@@ -479,6 +662,7 @@ export class Settings {
 		});
 		cloned.#storage = this.#storage;
 		cloned.#global = structuredClone(this.#global);
+		cloned.#revisionState = structuredClone(this.#revisionState);
 		cloned.#project = this.#persist ? await cloned.#loadProjectSettings() : structuredClone(this.#project);
 		cloned.#overrides = structuredClone(this.#overrides);
 		cloned.#rebuildMerged();
@@ -554,12 +738,20 @@ export class Settings {
 		return this.get("bashInterceptor.patterns");
 	}
 
+	#revisionFor(path: string): number {
+		return this.#revisionState.entries[path]?.revision ?? 0;
+	}
+
 	#enqueueModified(path: string, desiredValue: unknown): void {
 		this.#modified.delete(path);
 		this.#modified.set(path, {
 			id: this.#nextMutationId++,
 			desiredValue: structuredClone(desiredValue),
 			guard: { kind: "unconditional" },
+			attempted: false,
+			predecessorGeneration: undefined,
+			predecessorRevision: undefined,
+			predecessorValue: undefined,
 		});
 	}
 
@@ -570,7 +762,11 @@ export class Settings {
 		}
 		const previous = shallowStringRecord(getByPath(this.#global, path.split(".")));
 		const next = shallowStringRecord(desiredValue);
-		for (const key of new Set([...Object.keys(previous), ...Object.keys(next)])) {
+		const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
+		for (const key of keys) {
+			assertValidRecordEntryMutationKey(key);
+		}
+		for (const key of keys) {
 			this.#enqueueModified(encodeRecordEntryMutation(path, key), next[key]);
 		}
 	}
@@ -579,19 +775,34 @@ export class Settings {
 		path: string,
 		expectedValue: unknown,
 		desiredValue: unknown,
-		replaceMatchingUnconditional = false,
+		expectedPendingMutationId?: number,
 	): boolean {
 		const pending = this.#modified.get(path);
+		let expectedRevision = this.#revisionFor(path);
+		let expectedGeneration = this.#revisionState.generation;
 		if (pending) {
-			const replacesMatchingUnconditional =
-				replaceMatchingUnconditional &&
+			const replacesOwnedUnconditional =
+				expectedPendingMutationId !== undefined &&
+				pending.id === expectedPendingMutationId &&
 				pending.guard.kind === "unconditional" &&
 				Object.is(pending.desiredValue, expectedValue);
 			const reversesPendingConditional =
 				pending.guard.kind === "if-unchanged" &&
 				Object.is(pending.guard.expectedValue, desiredValue) &&
 				Object.is(pending.desiredValue, expectedValue);
-			if (!replacesMatchingUnconditional && !reversesPendingConditional) return false;
+			if (!replacesOwnedUnconditional && !reversesPendingConditional) return false;
+		} else {
+			const outcome = this.#conditionalOutcomes.get(path);
+			const reversesCompletedConditional =
+				outcome && Object.is(outcome.expectedValue, desiredValue) && Object.is(outcome.desiredValue, expectedValue);
+			if (reversesCompletedConditional) {
+				this.#conditionalOutcomes.delete(path);
+				if (!outcome.applied) return false;
+				expectedRevision = outcome.revision;
+				expectedGeneration = outcome.generation;
+			} else {
+				this.#conditionalOutcomes.delete(path);
+			}
 		}
 		const currentValue = getByPath(this.#global, decodeModifiedPath(path));
 		if (!Object.is(currentValue, expectedValue) && !Object.is(currentValue, desiredValue)) return false;
@@ -602,7 +813,13 @@ export class Settings {
 			guard: {
 				kind: "if-unchanged",
 				expectedValue: structuredClone(expectedValue),
+				expectedGeneration,
+				expectedRevision,
 			},
+			attempted: false,
+			predecessorGeneration: undefined,
+			predecessorRevision: undefined,
+			predecessorValue: undefined,
 		});
 		return true;
 	}
@@ -613,6 +830,7 @@ export class Settings {
 		value: string | undefined,
 		expectedValue?: { value: string | undefined },
 	): boolean {
+		assertValidRecordEntryMutationKey(key);
 		const segments = path.split(".");
 		const next = shallowStringRecord(getByPath(this.#global, segments));
 		if (value === undefined) {
@@ -786,7 +1004,14 @@ export class Settings {
 		if (this.#persist) {
 			this.#storage = await AgentStorage.open(getAgentDbPath(this.#agentDir));
 			await this.#migrateFromLegacy();
-			this.#global = await this.#loadYaml(this.#configPath!);
+			await withFileLock(this.#configPath!, async () => {
+				const revisionStateExists = this.#revisionPath ? await Bun.file(this.#revisionPath).exists() : false;
+				this.#global = await this.#loadYaml(this.#configPath!);
+				this.#revisionState = await this.#loadRevisionState();
+				if (!revisionStateExists) {
+					await this.#writeRevisionState(this.#revisionState);
+				}
+			});
 		}
 
 		this.#project = await projectPromise;
@@ -797,18 +1022,63 @@ export class Settings {
 		return this;
 	}
 
+	async #loadRevisionState(): Promise<DurableSettingsRevisionState> {
+		if (!this.#revisionPath) return emptySettingsRevisionState();
+		try {
+			const content = await Bun.file(this.#revisionPath).text();
+			return parseSettingsRevisionState(JSON.parse(content));
+		} catch (error) {
+			if (isEnoent(error)) return emptySettingsRevisionState();
+			logger.warn("Settings: failed to load revision state", {
+				path: this.#revisionPath,
+				error: String(error),
+			});
+			throw error;
+		}
+	}
+
+	async #atomicWrite(filePath: string, content: string): Promise<void> {
+		const tempPath = `${filePath}.${this.#ownerId}.tmp`;
+		try {
+			await Bun.write(tempPath, content);
+			const fd = fs.openSync(tempPath, "r");
+			try {
+				fs.fsyncSync(fd);
+			} finally {
+				fs.closeSync(fd);
+			}
+			fs.renameSync(tempPath, filePath);
+			if (process.platform !== "win32") {
+				const directoryFd = fs.openSync(path.dirname(filePath), "r");
+				try {
+					fs.fsyncSync(directoryFd);
+				} finally {
+					fs.closeSync(directoryFd);
+				}
+			}
+		} finally {
+			try {
+				fs.rmSync(tempPath, { force: true });
+			} catch {}
+		}
+	}
+
+	async #writeRevisionState(state: DurableSettingsRevisionState): Promise<void> {
+		if (!this.#revisionPath) return;
+		await this.#atomicWrite(this.#revisionPath, JSON.stringify(state));
+	}
 	async #loadYaml(filePath: string): Promise<RawSettings> {
 		try {
 			const content = await Bun.file(filePath).text();
 			const parsed = YAML.parse(content);
 			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-				return {};
+				throw new Error(`Settings root must be an object: ${filePath}`);
 			}
 			return this.#migrateRawSettings(parsed as RawSettings);
 		} catch (error) {
 			if (isEnoent(error)) return {};
 			logger.warn("Settings: failed to load", { path: filePath, error: String(error) });
-			return {};
+			throw error;
 		}
 	}
 
@@ -1090,29 +1360,105 @@ export class Settings {
 		try {
 			await withFileLock(configPath, async () => {
 				const current = await this.#loadYaml(configPath);
-				const processedIds = new Set<number>();
-				const processedEntries: Array<[path: string, id: number]> = [];
-				const processMutation = (modifiedPath: string, mutation: PendingSettingMutation): void => {
-					if (processedIds.has(mutation.id)) return;
-					processedIds.add(mutation.id);
-					processedEntries.push([modifiedPath, mutation.id]);
-					const segments = decodeModifiedPath(modifiedPath);
-					if (!canApplySettingMutation(mutation, getByPath(current, segments))) return;
-					setByPath(current, segments, structuredClone(mutation.desiredValue));
-				};
+				const revisionState = await this.#loadRevisionState();
+				this.#revisionState = structuredClone(revisionState);
+				const loadedGeneration = revisionState.generation;
+				const accepted: Array<{
+					modifiedPath: string;
+					mutation: PendingSettingMutation;
+					revision: number;
+					revisionChanged: boolean;
+				}> = [];
 
-				const pendingEntries = [...initialEntries, ...this.#modified].sort(
-					(left, right) => left[1].id - right[1].id,
-				);
-				for (const [modifiedPath, mutation] of pendingEntries) {
-					processMutation(modifiedPath, mutation);
+				for (const [modifiedPath, mutation] of initialEntries) {
+					const segments = decodeModifiedPath(modifiedPath);
+					const currentValue = getByPath(current, segments);
+					const currentRevision = revisionState.entries[modifiedPath]?.revision ?? 0;
+					const currentOwner = revisionState.entries[modifiedPath];
+					const sameMutation = currentOwner?.ownerId === this.#ownerId && currentOwner.mutationId === mutation.id;
+					const capturesPredecessor = !mutation.attempted && mutation.predecessorGeneration === undefined;
+					if (capturesPredecessor) {
+						mutation.predecessorGeneration = loadedGeneration;
+						mutation.predecessorRevision = currentRevision;
+						mutation.predecessorValue = structuredClone(currentValue);
+					}
+					const predecessorMatches =
+						mutation.predecessorGeneration === loadedGeneration &&
+						mutation.predecessorRevision === currentRevision;
+					const retryValueMatches = mutationRetryValuesMatch(mutation, currentValue);
+					const sameMutationRetry = sameMutation && retryValueMatches;
+					const generationMatches =
+						mutation.guard.kind === "if-unchanged" && mutation.guard.expectedGeneration === loadedGeneration;
+					const firstAttemptApplies =
+						!mutation.attempted &&
+						predecessorMatches &&
+						(capturesPredecessor || retryValueMatches) &&
+						(mutation.guard.kind === "unconditional" ||
+							(mutationValuesMatch(mutation, currentValue) &&
+								generationMatches &&
+								currentRevision === mutation.guard.expectedRevision));
+					const applies = sameMutationRetry || firstAttemptApplies;
+
+					if (!applies) {
+						if (this.#modified.get(modifiedPath)?.id === mutation.id) {
+							this.#modified.delete(modifiedPath);
+							if (mutation.guard.kind === "if-unchanged") {
+								this.#conditionalOutcomes.set(modifiedPath, {
+									expectedValue: mutation.guard.expectedValue,
+									desiredValue: mutation.desiredValue,
+									applied: false,
+									revision: currentRevision,
+									generation: loadedGeneration,
+								});
+							}
+						}
+						continue;
+					}
+
+					let revision = currentRevision;
+					if (!sameMutation) {
+						if (revisionState.nextRevision >= Number.MAX_SAFE_INTEGER) {
+							throw new Error("Settings revision state exhausted");
+						}
+						revision = revisionState.nextRevision++;
+						revisionState.entries[modifiedPath] = {
+							revision,
+							ownerId: this.#ownerId,
+							mutationId: mutation.id,
+						};
+					}
+					setByPath(current, segments, structuredClone(mutation.desiredValue));
+					accepted.push({
+						modifiedPath,
+						mutation,
+						revision,
+						revisionChanged: !sameMutation,
+					});
 				}
 
-				await Bun.write(configPath, YAML.stringify(current, null, 2));
+				if (accepted.some(entry => entry.revisionChanged)) {
+					await this.#writeRevisionState(revisionState);
+					for (const entry of accepted) {
+						if (entry.revisionChanged) entry.mutation.attempted = true;
+					}
+				}
+				this.#revisionState = structuredClone(revisionState);
 
-				for (const [modifiedPath, id] of processedEntries) {
-					if (this.#modified.get(modifiedPath)?.id === id) {
-						this.#modified.delete(modifiedPath);
+				if (accepted.length > 0) {
+					await this.#atomicWrite(configPath, YAML.stringify(current, null, 2));
+				}
+
+				for (const { modifiedPath, mutation, revision } of accepted) {
+					if (this.#modified.get(modifiedPath)?.id !== mutation.id) continue;
+					this.#modified.delete(modifiedPath);
+					if (mutation.guard.kind === "if-unchanged") {
+						this.#conditionalOutcomes.set(modifiedPath, {
+							expectedValue: mutation.guard.expectedValue,
+							desiredValue: mutation.desiredValue,
+							applied: true,
+							revision,
+							generation: revisionState.generation,
+						});
 					}
 				}
 				this.#global = current;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -150,6 +150,21 @@ function shallowStringRecord(value: unknown): Record<string, string> {
 	return result;
 }
 
+const RECORD_ENTRY_MUTATION_PREFIX = "\0record-entry:";
+
+function encodeRecordEntryMutation(path: string, key: string): string {
+	return RECORD_ENTRY_MUTATION_PREFIX + JSON.stringify([...path.split("."), key]);
+}
+
+function decodeModifiedPath(modifiedPath: string): string[] {
+	if (!modifiedPath.startsWith(RECORD_ENTRY_MUTATION_PREFIX)) return modifiedPath.split(".");
+	const parsed: unknown = JSON.parse(modifiedPath.slice(RECORD_ENTRY_MUTATION_PREFIX.length));
+	if (!Array.isArray(parsed) || !parsed.every((segment): segment is string => typeof segment === "string")) {
+		throw new Error("Invalid encoded settings record-entry mutation");
+	}
+	return parsed;
+}
+
 function resolvePathScopedStringArray(settingPath: SettingPath, value: unknown, cwd: string): string[] | undefined {
 	if (!PATH_SCOPED_ARRAY_SETTINGS.has(settingPath) || !Array.isArray(value)) return undefined;
 
@@ -308,6 +323,33 @@ export class Settings {
 		return value === undefined ? undefined : (value as SettingValue<P>);
 	}
 
+	/** Get a setting from project config only, excluding global and runtime layers. */
+	getProject<P extends SettingPath>(path: P): SettingValue<P> | undefined {
+		const value = getByPath(this.#project, path.split("."));
+		return value === undefined ? undefined : (value as SettingValue<P>);
+	}
+
+	/**
+	 * Get the user/global plus runtime value while excluding project settings.
+	 * Profile materialization uses this to preserve explicit runtime choices
+	 * without leaking project-scoped configuration into the user config.
+	 */
+	getWithoutProject<P extends SettingPath>(path: P): SettingValue<P> {
+		const merged = this.#deepMerge(this.#deepMerge({}, this.#global), this.#overrides);
+		const value = getByPath(merged, path.split("."));
+		if (value !== undefined) {
+			const pathScopedValue = resolvePathScopedStringArray(path, value, this.#cwd);
+			return (pathScopedValue ?? value) as SettingValue<P>;
+		}
+		return getDefault(path);
+	}
+
+	/** Get the raw runtime override layer for a setting, without lower-precedence values. */
+	getRuntimeOverride<P extends SettingPath>(path: P): SettingValue<P> | undefined {
+		const value = getByPath(this.#overrides, path.split("."));
+		return value === undefined ? undefined : (value as SettingValue<P>);
+	}
+
 	/** Check whether a setting is present in loaded settings/overrides rather than coming from schema defaults. */
 	has(path: SettingPath): boolean {
 		return getByPath(this.#merged, path.split(".")) !== undefined;
@@ -331,6 +373,14 @@ export class Settings {
 		if (hook) {
 			hook(value, prev);
 		}
+	}
+
+	/** Remove a user/global setting while preserving project and runtime layers. */
+	clearGlobal(path: SettingPath): void {
+		setByPath(this.#global, path.split("."), undefined);
+		this.#modified.add(path);
+		this.#rebuildMerged();
+		this.#queueSave();
 	}
 
 	/**
@@ -370,7 +420,7 @@ export class Settings {
 			await this.#savePromise;
 		}
 		if (this.#modified.size > 0) {
-			await this.#saveNow();
+			await this.#startSave();
 		}
 	}
 
@@ -389,7 +439,7 @@ export class Settings {
 			await this.#savePromise;
 		}
 		if (this.#modified.size > 0) {
-			await this.#saveNow({ throwOnError: true });
+			await this.#startSave({ throwOnError: true });
 		}
 	}
 
@@ -476,44 +526,95 @@ export class Settings {
 		return this.get("bashInterceptor.patterns");
 	}
 
+	#setStringRecordEntry(
+		path: "modelRoles" | "task.agentModelOverrides",
+		key: string,
+		value: string | undefined,
+	): void {
+		const segments = path.split(".");
+		const next = shallowStringRecord(getByPath(this.#global, segments));
+		if (value === undefined) {
+			delete next[key];
+		} else {
+			next[key] = value;
+		}
+		setByPath(this.#global, segments, next);
+		this.#modified.add(encodeRecordEntryMutation(path, key));
+		this.#rebuildMerged();
+		this.#queueSave();
+	}
+
 	/**
-	 * Set a model role (helper for modelRoles record).
+	 * Persist one model role without replacing sibling roles written by another
+	 * process, and keep a shadowing runtime/project value aligned for this session.
 	 */
 	setModelRole(role: ModelRole | string, modelId: string): void {
-		const current = shallowStringRecord(getByPath(this.#global, ["modelRoles"]));
 		const runtimeOverrides = getByPath(this.#overrides, ["modelRoles"]);
-		const updateRuntimeOverride =
+		const runtimeRoleIsSet =
 			!!runtimeOverrides &&
 			typeof runtimeOverrides === "object" &&
 			!Array.isArray(runtimeOverrides) &&
 			Object.hasOwn(runtimeOverrides, role);
 
-		this.set("modelRoles", { ...current, [role]: modelId });
+		this.#setStringRecordEntry("modelRoles", role, modelId);
 
-		if (updateRuntimeOverride) {
-			this.override("modelRoles", { ...shallowStringRecord(runtimeOverrides), [role]: modelId });
+		if (runtimeRoleIsSet || this.get("modelRoles")[role] !== modelId) {
+			const base = shallowStringRecord(runtimeOverrides);
+			this.override("modelRoles", { ...base, [role]: modelId });
 		}
 	}
+
 	/**
-	 * Set an agent model override while keeping any live runtime override aligned.
+	 * Set an agent model override while keeping any live runtime/project override aligned.
 	 *
-	 * Runtime model profiles override `task.agentModelOverrides` for the current
-	 * session. A user-selected role assignment must win immediately in that same
-	 * session, but only the explicit agent change should be persisted.
+	 * Runtime model profiles and project settings can override
+	 * `task.agentModelOverrides` for the current session. A user-selected role
+	 * assignment must win immediately, but only that explicit agent change is
+	 * persisted.
 	 */
 	setAgentModelOverride(agentName: string, modelId: string): void {
-		const current = shallowStringRecord(getByPath(this.#global, ["task", "agentModelOverrides"]));
 		const runtimeOverrides = getByPath(this.#overrides, ["task", "agentModelOverrides"]);
-		const updateRuntimeOverride =
+		const hasRuntimeOverrides =
 			!!runtimeOverrides && typeof runtimeOverrides === "object" && !Array.isArray(runtimeOverrides);
 
-		this.set("task.agentModelOverrides", { ...current, [agentName]: modelId });
+		this.#setStringRecordEntry("task.agentModelOverrides", agentName, modelId);
 
-		if (updateRuntimeOverride) {
+		if (hasRuntimeOverrides || this.get("task.agentModelOverrides")[agentName] !== modelId) {
+			const base = shallowStringRecord(runtimeOverrides);
 			this.override("task.agentModelOverrides", {
-				...shallowStringRecord(runtimeOverrides),
+				...base,
 				[agentName]: modelId,
 			});
+		}
+	}
+
+	/** Clear one persisted and live model role without replacing siblings. */
+	clearModelRole(role: ModelRole | string): void {
+		const runtimeOverrides = getByPath(this.#overrides, ["modelRoles"]);
+		const hasRuntimeOverrides =
+			!!runtimeOverrides && typeof runtimeOverrides === "object" && !Array.isArray(runtimeOverrides);
+
+		this.#setStringRecordEntry("modelRoles", role, undefined);
+
+		if (hasRuntimeOverrides) {
+			const nextRuntimeOverrides = shallowStringRecord(runtimeOverrides);
+			delete nextRuntimeOverrides[role];
+			this.override("modelRoles", nextRuntimeOverrides);
+		}
+	}
+
+	/** Clear one persisted and live agent model override without replacing siblings. */
+	clearAgentModelOverride(agentName: string): void {
+		const runtimeOverrides = getByPath(this.#overrides, ["task", "agentModelOverrides"]);
+		const hasRuntimeOverrides =
+			!!runtimeOverrides && typeof runtimeOverrides === "object" && !Array.isArray(runtimeOverrides);
+
+		this.#setStringRecordEntry("task.agentModelOverrides", agentName, undefined);
+
+		if (hasRuntimeOverrides) {
+			const nextRuntimeOverrides = shallowStringRecord(runtimeOverrides);
+			delete nextRuntimeOverrides[agentName];
+			this.override("task.agentModelOverrides", nextRuntimeOverrides);
 		}
 	}
 
@@ -821,6 +922,31 @@ export class Settings {
 	// Saving
 	// ─────────────────────────────────────────────────────────────────────────
 
+	#startSave(options: { throwOnError?: boolean } = {}): Promise<void> {
+		const previousSave = this.#savePromise;
+		const savePromise = (async () => {
+			if (previousSave) {
+				try {
+					await previousSave;
+				} catch {
+					// A failed durable flush must not prevent a later retry from
+					// persisting the paths that #saveNow re-queued.
+				}
+			}
+			await this.#saveNow(options);
+		})();
+		this.#savePromise = savePromise;
+		void savePromise.then(
+			() => {
+				if (this.#savePromise === savePromise) this.#savePromise = undefined;
+			},
+			() => {
+				if (this.#savePromise === savePromise) this.#savePromise = undefined;
+			},
+		);
+		return savePromise;
+	}
+
 	#queueSave(): void {
 		if (!this.#persist || !this.#configPath) return;
 
@@ -830,7 +956,8 @@ export class Settings {
 		}
 		this.#saveTimer = setTimeout(() => {
 			this.#saveTimer = undefined;
-			this.#saveNow().catch(err => {
+			const savePromise = this.#startSave();
+			void savePromise.catch(err => {
 				logger.warn("Settings: background save failed", { error: String(err) });
 			});
 		}, 100);
@@ -841,6 +968,12 @@ export class Settings {
 
 		const configPath = this.#configPath;
 		const modifiedPaths = [...this.#modified];
+		const modifiedValues = new Map(
+			modifiedPaths.map(modPath => {
+				const segments = decodeModifiedPath(modPath);
+				return [modPath, structuredClone(getByPath(this.#global, segments))] as const;
+			}),
+		);
 		this.#modified.clear();
 
 		try {
@@ -850,9 +983,17 @@ export class Settings {
 
 				// Apply only our modified paths
 				for (const modPath of modifiedPaths) {
-					const segments = modPath.split(".");
-					const value = getByPath(this.#global, segments);
+					const segments = decodeModifiedPath(modPath);
+					const value = modifiedValues.get(modPath);
 					setByPath(current, segments, value);
+				}
+
+				// A mutation can arrive while the file is being loaded. Overlay those
+				// still-pending leaves before replacing #global so the in-memory value
+				// survives this save and the serialized snapshot is never stale.
+				for (const pendingPath of this.#modified) {
+					const segments = decodeModifiedPath(pendingPath);
+					setByPath(current, segments, getByPath(this.#global, segments));
 				}
 
 				// Update our global with any external changes we preserved

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -54,6 +54,21 @@ export * from "./settings-schema";
 export interface RawSettings {
 	[key: string]: unknown;
 }
+type SettingMutationGuard = { kind: "unconditional" } | { kind: "if-unchanged"; expectedValue: unknown };
+
+interface PendingSettingMutation {
+	id: number;
+	desiredValue: unknown;
+	guard: SettingMutationGuard;
+}
+
+function canApplySettingMutation(mutation: PendingSettingMutation, currentValue: unknown): boolean {
+	return (
+		mutation.guard.kind === "unconditional" ||
+		Object.is(currentValue, mutation.guard.expectedValue) ||
+		Object.is(currentValue, mutation.desiredValue)
+	);
+}
 
 export interface SettingsOptions {
 	/** Current working directory for project settings discovery */
@@ -223,7 +238,8 @@ export class Settings {
 	#merged: RawSettings = {};
 
 	/** Paths modified during this session (for partial save) */
-	#modified = new Set<string>();
+	#modified = new Map<string, PendingSettingMutation>();
+	#nextMutationId = 1;
 
 	/** Pending save (debounced) */
 	#saveTimer?: NodeJS.Timeout;
@@ -363,8 +379,8 @@ export class Settings {
 	set<P extends SettingPath>(path: P, value: SettingValue<P>): void {
 		const prev = this.get(path);
 		const segments = path.split(".");
+		this.#enqueueSettingValue(path, value);
 		setByPath(this.#global, segments, value);
-		this.#modified.add(path);
 		this.#rebuildMerged();
 		this.#queueSave();
 
@@ -377,8 +393,20 @@ export class Settings {
 
 	/** Remove a user/global setting while preserving project and runtime layers. */
 	clearGlobal(path: SettingPath): void {
+		this.#enqueueSettingValue(path, undefined);
 		setByPath(this.#global, path.split("."), undefined);
-		this.#modified.add(path);
+		this.#rebuildMerged();
+		this.#queueSave();
+	}
+
+	/**
+	 * Persist or clear the default model profile only if another writer has not
+	 * changed it since this Settings instance loaded it.
+	 */
+	setModelProfileDefaultIfUnchanged(expectedProfileName: string | undefined, profileName: string | undefined): void {
+		const path = "modelProfile.default";
+		if (!this.#enqueueModifiedIfUnchanged(path, expectedProfileName, profileName, true)) return;
+		setByPath(this.#global, path.split("."), profileName);
 		this.#rebuildMerged();
 		this.#queueSave();
 	}
@@ -526,11 +554,65 @@ export class Settings {
 		return this.get("bashInterceptor.patterns");
 	}
 
+	#enqueueModified(path: string, desiredValue: unknown): void {
+		this.#modified.delete(path);
+		this.#modified.set(path, {
+			id: this.#nextMutationId++,
+			desiredValue: structuredClone(desiredValue),
+			guard: { kind: "unconditional" },
+		});
+	}
+
+	#enqueueSettingValue(path: SettingPath, desiredValue: unknown): void {
+		if (path !== "modelRoles" && path !== "task.agentModelOverrides") {
+			this.#enqueueModified(path, desiredValue);
+			return;
+		}
+		const previous = shallowStringRecord(getByPath(this.#global, path.split(".")));
+		const next = shallowStringRecord(desiredValue);
+		for (const key of new Set([...Object.keys(previous), ...Object.keys(next)])) {
+			this.#enqueueModified(encodeRecordEntryMutation(path, key), next[key]);
+		}
+	}
+
+	#enqueueModifiedIfUnchanged(
+		path: string,
+		expectedValue: unknown,
+		desiredValue: unknown,
+		replaceMatchingUnconditional = false,
+	): boolean {
+		const pending = this.#modified.get(path);
+		if (pending) {
+			const replacesMatchingUnconditional =
+				replaceMatchingUnconditional &&
+				pending.guard.kind === "unconditional" &&
+				Object.is(pending.desiredValue, expectedValue);
+			const reversesPendingConditional =
+				pending.guard.kind === "if-unchanged" &&
+				Object.is(pending.guard.expectedValue, desiredValue) &&
+				Object.is(pending.desiredValue, expectedValue);
+			if (!replacesMatchingUnconditional && !reversesPendingConditional) return false;
+		}
+		const currentValue = getByPath(this.#global, decodeModifiedPath(path));
+		if (!Object.is(currentValue, expectedValue) && !Object.is(currentValue, desiredValue)) return false;
+		this.#modified.delete(path);
+		this.#modified.set(path, {
+			id: this.#nextMutationId++,
+			desiredValue: structuredClone(desiredValue),
+			guard: {
+				kind: "if-unchanged",
+				expectedValue: structuredClone(expectedValue),
+			},
+		});
+		return true;
+	}
+
 	#setStringRecordEntry(
 		path: "modelRoles" | "task.agentModelOverrides",
 		key: string,
 		value: string | undefined,
-	): void {
+		expectedValue?: { value: string | undefined },
+	): boolean {
 		const segments = path.split(".");
 		const next = shallowStringRecord(getByPath(this.#global, segments));
 		if (value === undefined) {
@@ -538,10 +620,40 @@ export class Settings {
 		} else {
 			next[key] = value;
 		}
+		const modifiedPath = encodeRecordEntryMutation(path, key);
+		if (expectedValue) {
+			if (!this.#enqueueModifiedIfUnchanged(modifiedPath, expectedValue.value, value)) return false;
+		} else {
+			this.#enqueueModified(modifiedPath, value);
+		}
 		setByPath(this.#global, segments, next);
-		this.#modified.add(encodeRecordEntryMutation(path, key));
 		this.#rebuildMerged();
 		this.#queueSave();
+		return true;
+	}
+
+	#setModelRoleEntry(
+		role: ModelRole | string,
+		modelId: string | undefined,
+		expectedValue?: { value: string | undefined },
+	): void {
+		const runtimeOverrides = getByPath(this.#overrides, ["modelRoles"]);
+		const hasRuntimeOverrides =
+			!!runtimeOverrides && typeof runtimeOverrides === "object" && !Array.isArray(runtimeOverrides);
+		const runtimeRoleIsSet = hasRuntimeOverrides && Object.hasOwn(runtimeOverrides, role);
+
+		if (!this.#setStringRecordEntry("modelRoles", role, modelId, expectedValue)) return;
+
+		if (modelId === undefined) {
+			if (hasRuntimeOverrides) {
+				const nextRuntimeOverrides = shallowStringRecord(runtimeOverrides);
+				delete nextRuntimeOverrides[role];
+				this.override("modelRoles", nextRuntimeOverrides);
+			}
+		} else if (runtimeRoleIsSet || this.get("modelRoles")[role] !== modelId) {
+			const base = shallowStringRecord(runtimeOverrides);
+			this.override("modelRoles", { ...base, [role]: modelId });
+		}
 	}
 
 	/**
@@ -549,18 +661,44 @@ export class Settings {
 	 * process, and keep a shadowing runtime/project value aligned for this session.
 	 */
 	setModelRole(role: ModelRole | string, modelId: string): void {
-		const runtimeOverrides = getByPath(this.#overrides, ["modelRoles"]);
-		const runtimeRoleIsSet =
-			!!runtimeOverrides &&
-			typeof runtimeOverrides === "object" &&
-			!Array.isArray(runtimeOverrides) &&
-			Object.hasOwn(runtimeOverrides, role);
+		this.#setModelRoleEntry(role, modelId);
+	}
 
-		this.#setStringRecordEntry("modelRoles", role, modelId);
+	/**
+	 * Persist or clear one model role only if another writer has not changed that
+	 * leaf since this Settings instance loaded it.
+	 */
+	setModelRoleIfUnchanged(
+		role: ModelRole | string,
+		expectedModelId: string | undefined,
+		modelId: string | undefined,
+	): void {
+		this.#setModelRoleEntry(role, modelId, { value: expectedModelId });
+	}
 
-		if (runtimeRoleIsSet || this.get("modelRoles")[role] !== modelId) {
+	#setAgentModelOverrideEntry(
+		agentName: string,
+		modelId: string | undefined,
+		expectedValue?: { value: string | undefined },
+	): void {
+		const runtimeOverrides = getByPath(this.#overrides, ["task", "agentModelOverrides"]);
+		const hasRuntimeOverrides =
+			!!runtimeOverrides && typeof runtimeOverrides === "object" && !Array.isArray(runtimeOverrides);
+
+		if (!this.#setStringRecordEntry("task.agentModelOverrides", agentName, modelId, expectedValue)) return;
+
+		if (modelId === undefined) {
+			if (hasRuntimeOverrides) {
+				const nextRuntimeOverrides = shallowStringRecord(runtimeOverrides);
+				delete nextRuntimeOverrides[agentName];
+				this.override("task.agentModelOverrides", nextRuntimeOverrides);
+			}
+		} else if (hasRuntimeOverrides || this.get("task.agentModelOverrides")[agentName] !== modelId) {
 			const base = shallowStringRecord(runtimeOverrides);
-			this.override("modelRoles", { ...base, [role]: modelId });
+			this.override("task.agentModelOverrides", {
+				...base,
+				[agentName]: modelId,
+			});
 		}
 	}
 
@@ -573,49 +711,29 @@ export class Settings {
 	 * persisted.
 	 */
 	setAgentModelOverride(agentName: string, modelId: string): void {
-		const runtimeOverrides = getByPath(this.#overrides, ["task", "agentModelOverrides"]);
-		const hasRuntimeOverrides =
-			!!runtimeOverrides && typeof runtimeOverrides === "object" && !Array.isArray(runtimeOverrides);
+		this.#setAgentModelOverrideEntry(agentName, modelId);
+	}
 
-		this.#setStringRecordEntry("task.agentModelOverrides", agentName, modelId);
-
-		if (hasRuntimeOverrides || this.get("task.agentModelOverrides")[agentName] !== modelId) {
-			const base = shallowStringRecord(runtimeOverrides);
-			this.override("task.agentModelOverrides", {
-				...base,
-				[agentName]: modelId,
-			});
-		}
+	/**
+	 * Persist or clear one agent override only if another writer has not changed
+	 * that leaf since this Settings instance loaded it.
+	 */
+	setAgentModelOverrideIfUnchanged(
+		agentName: string,
+		expectedModelId: string | undefined,
+		modelId: string | undefined,
+	): void {
+		this.#setAgentModelOverrideEntry(agentName, modelId, { value: expectedModelId });
 	}
 
 	/** Clear one persisted and live model role without replacing siblings. */
 	clearModelRole(role: ModelRole | string): void {
-		const runtimeOverrides = getByPath(this.#overrides, ["modelRoles"]);
-		const hasRuntimeOverrides =
-			!!runtimeOverrides && typeof runtimeOverrides === "object" && !Array.isArray(runtimeOverrides);
-
-		this.#setStringRecordEntry("modelRoles", role, undefined);
-
-		if (hasRuntimeOverrides) {
-			const nextRuntimeOverrides = shallowStringRecord(runtimeOverrides);
-			delete nextRuntimeOverrides[role];
-			this.override("modelRoles", nextRuntimeOverrides);
-		}
+		this.#setModelRoleEntry(role, undefined);
 	}
 
 	/** Clear one persisted and live agent model override without replacing siblings. */
 	clearAgentModelOverride(agentName: string): void {
-		const runtimeOverrides = getByPath(this.#overrides, ["task", "agentModelOverrides"]);
-		const hasRuntimeOverrides =
-			!!runtimeOverrides && typeof runtimeOverrides === "object" && !Array.isArray(runtimeOverrides);
-
-		this.#setStringRecordEntry("task.agentModelOverrides", agentName, undefined);
-
-		if (hasRuntimeOverrides) {
-			const nextRuntimeOverrides = shallowStringRecord(runtimeOverrides);
-			delete nextRuntimeOverrides[agentName];
-			this.override("task.agentModelOverrides", nextRuntimeOverrides);
-		}
+		this.#setAgentModelOverrideEntry(agentName, undefined);
 	}
 
 	/**
@@ -967,45 +1085,43 @@ export class Settings {
 		if (!this.#persist || !this.#configPath || this.#modified.size === 0) return;
 
 		const configPath = this.#configPath;
-		const modifiedPaths = [...this.#modified];
-		const modifiedValues = new Map(
-			modifiedPaths.map(modPath => {
-				const segments = decodeModifiedPath(modPath);
-				return [modPath, structuredClone(getByPath(this.#global, segments))] as const;
-			}),
-		);
-		this.#modified.clear();
+		const initialEntries = [...this.#modified].sort((left, right) => left[1].id - right[1].id);
 
 		try {
 			await withFileLock(configPath, async () => {
-				// Re-read to preserve external changes
 				const current = await this.#loadYaml(configPath);
+				const processedIds = new Set<number>();
+				const processedEntries: Array<[path: string, id: number]> = [];
+				const processMutation = (modifiedPath: string, mutation: PendingSettingMutation): void => {
+					if (processedIds.has(mutation.id)) return;
+					processedIds.add(mutation.id);
+					processedEntries.push([modifiedPath, mutation.id]);
+					const segments = decodeModifiedPath(modifiedPath);
+					if (!canApplySettingMutation(mutation, getByPath(current, segments))) return;
+					setByPath(current, segments, structuredClone(mutation.desiredValue));
+				};
 
-				// Apply only our modified paths
-				for (const modPath of modifiedPaths) {
-					const segments = decodeModifiedPath(modPath);
-					const value = modifiedValues.get(modPath);
-					setByPath(current, segments, value);
+				const pendingEntries = [...initialEntries, ...this.#modified].sort(
+					(left, right) => left[1].id - right[1].id,
+				);
+				for (const [modifiedPath, mutation] of pendingEntries) {
+					processMutation(modifiedPath, mutation);
 				}
 
-				// A mutation can arrive while the file is being loaded. Overlay those
-				// still-pending leaves before replacing #global so the in-memory value
-				// survives this save and the serialized snapshot is never stale.
-				for (const pendingPath of this.#modified) {
-					const segments = decodeModifiedPath(pendingPath);
-					setByPath(current, segments, getByPath(this.#global, segments));
-				}
+				await Bun.write(configPath, YAML.stringify(current, null, 2));
 
-				// Update our global with any external changes we preserved
+				for (const [modifiedPath, id] of processedEntries) {
+					if (this.#modified.get(modifiedPath)?.id === id) {
+						this.#modified.delete(modifiedPath);
+					}
+				}
 				this.#global = current;
-				await Bun.write(configPath, YAML.stringify(this.#global, null, 2));
+				for (const [modifiedPath, mutation] of this.#modified) {
+					setByPath(this.#global, decodeModifiedPath(modifiedPath), structuredClone(mutation.desiredValue));
+				}
 			});
 		} catch (error) {
 			logger.warn("Settings: save failed", { error: String(error) });
-			// Re-add failed paths for retry
-			for (const p of modifiedPaths) {
-				this.#modified.add(p);
-			}
 			if (options.throwOnError) {
 				this.#rebuildMerged();
 				throw error;

--- a/packages/coding-agent/src/modes/components/agent-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/agent-dashboard.ts
@@ -64,6 +64,7 @@ interface SourceTab {
 interface DashboardAgent extends AgentDefinition {
 	disabled: boolean;
 	overrideModel?: string;
+	persistenceWarning?: string;
 }
 
 interface ModelResolution {
@@ -82,6 +83,8 @@ interface AgentDashboardModelContext {
 	modelRegistry?: ModelRegistry;
 	activeModelPattern?: string;
 	defaultModelPattern?: string;
+	projectModelProfileShadow?: { profileName: string; targetIds: readonly string[] };
+	onModelOverrideChange?: (agentName: string, value: string | undefined) => void | Promise<void>;
 }
 
 const SOURCE_ORDER: Record<AgentSource, number> = {
@@ -97,6 +100,28 @@ const SOURCE_LABEL: Record<AgentSource, string> = {
 };
 
 const IDENTIFIER_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+){1,5}$/;
+const MODEL_OVERRIDE_PERSISTENCE_WARNINGS = new WeakMap<Settings, Map<string, string>>();
+
+function getModelOverridePersistenceWarning(settings: Settings | null, agentName: string): string | undefined {
+	return settings ? MODEL_OVERRIDE_PERSISTENCE_WARNINGS.get(settings)?.get(agentName) : undefined;
+}
+
+function setModelOverridePersistenceWarning(
+	settings: Settings | null,
+	agentName: string,
+	warning: string | undefined,
+): void {
+	if (!settings) return;
+	const warnings = MODEL_OVERRIDE_PERSISTENCE_WARNINGS.get(settings);
+	if (warning === undefined) {
+		warnings?.delete(agentName);
+		if (warnings?.size === 0) MODEL_OVERRIDE_PERSISTENCE_WARNINGS.delete(settings);
+		return;
+	}
+	const nextWarnings = warnings ?? new Map<string, string>();
+	nextWarnings.set(agentName, warning);
+	MODEL_OVERRIDE_PERSISTENCE_WARNINGS.set(settings, nextWarnings);
+}
 
 function joinPatterns(patterns: string[]): string {
 	if (patterns.length === 0) return "(session model)";
@@ -270,6 +295,10 @@ class AgentInspectorPane implements Component {
 		lines.push(
 			`${theme.fg("muted", "Effective:")} ${this.effectiveResolution ? this.#formatResolution(this.effectiveResolution) : theme.fg("dim", "(unresolved)")}`,
 		);
+		if (this.agent.persistenceWarning) {
+			lines.push(theme.fg("warning", "Persistence: unconfirmed"));
+			lines.push(theme.fg("warning", "  Local override may not survive restart"));
+		}
 
 		if (this.agent.filePath) {
 			lines.push("");
@@ -310,6 +339,8 @@ export class AgentDashboard extends Container {
 
 	#editInput: Input | null = null;
 	#editingAgentName: string | null = null;
+	#modelOverrideSaving = false;
+	#modelOverrideGeneration = 0;
 
 	#createInput: Input | null = null;
 	#createDescription = "";
@@ -344,8 +375,22 @@ export class AgentDashboard extends Container {
 
 	async #init(): Promise<void> {
 		this.#settingsManager = this.settings ?? (await Settings.init());
+		const settingsManager = this.#settingsManager;
 		await this.#reloadData();
 		this.#buildLayout();
+
+		if (MODEL_OVERRIDE_PERSISTENCE_WARNINGS.get(settingsManager)?.size) {
+			void settingsManager
+				.flushOrThrow()
+				.then(async () => {
+					MODEL_OVERRIDE_PERSISTENCE_WARNINGS.delete(settingsManager);
+					await this.#reloadData();
+				})
+				.catch(() => {
+					// Keep the warning attached to this Settings instance until a
+					// later durable flush confirms the live value.
+				});
+		}
 	}
 
 	async #reloadData(): Promise<void> {
@@ -371,6 +416,7 @@ export class AgentDashboard extends Container {
 					...agent,
 					disabled: disabled.has(agent.name),
 					overrideModel: overrides[agent.name]?.trim() || undefined,
+					persistenceWarning: getModelOverridePersistenceWarning(this.#settingsManager, agent.name),
 				}));
 
 			this.#tabs = this.#buildTabs(this.#allAgents);
@@ -465,18 +511,6 @@ export class AgentDashboard extends Container {
 		this.#settingsManager.set("task.disabledAgents", disabled);
 	}
 
-	#persistModelOverrides(): void {
-		if (!this.#settingsManager) return;
-		const overrides: Record<string, string> = {};
-		for (const agent of this.#allAgents) {
-			const value = agent.overrideModel?.trim();
-			if (value) {
-				overrides[agent.name] = value;
-			}
-		}
-		this.#settingsManager.set("task.agentModelOverrides", overrides);
-	}
-
 	#toggleSelectedAgent(): void {
 		const selected = this.#selectedAgent();
 		if (!selected) return;
@@ -486,6 +520,7 @@ export class AgentDashboard extends Container {
 	}
 
 	#beginModelEdit(): void {
+		if (this.#modelOverrideSaving) return;
 		const selected = this.#selectedAgent();
 		if (!selected) return;
 		this.#createError = null;
@@ -495,26 +530,85 @@ export class AgentDashboard extends Container {
 			this.#editInput.setValue(selected.overrideModel);
 		}
 		this.#editInput.onSubmit = value => {
-			this.#saveModelOverride(value);
+			void this.#saveModelOverride(value);
 		};
 		this.#buildLayout();
 	}
 
-	#saveModelOverride(rawValue: string): void {
+	async #saveModelOverride(rawValue: string): Promise<void> {
 		if (!this.#editingAgentName) return;
 		const selected = this.#allAgents.find(agent => agent.name === this.#editingAgentName);
-		if (!selected) return;
+		if (!selected || this.#modelOverrideSaving) return;
+		this.#modelOverrideSaving = true;
+		const operationGeneration = ++this.#modelOverrideGeneration;
 		const value = rawValue.trim();
-		selected.overrideModel = value || undefined;
-		this.#persistModelOverrides();
+		try {
+			if (this.modelContext.onModelOverrideChange) {
+				await this.modelContext.onModelOverrideChange(selected.name, value || undefined);
+			} else if (value) {
+				this.#settingsManager?.setAgentModelOverride(selected.name, value);
+				await this.#settingsManager?.flushOrThrow();
+			} else {
+				this.#settingsManager?.clearAgentModelOverride(selected.name);
+				await this.#settingsManager?.flushOrThrow();
+			}
+		} catch (error) {
+			this.#modelOverrideSaving = false;
+			const effectiveValue = this.#settingsManager?.get("task.agentModelOverrides")[selected.name]?.trim();
+			const persistenceWarning = `Model override for ${selected.name} is ${effectiveValue || "(unset)"} locally, but persistence was not confirmed: ${error instanceof Error ? error.message : String(error)}`;
+			selected.overrideModel = effectiveValue || undefined;
+			selected.persistenceWarning = persistenceWarning;
+			setModelOverridePersistenceWarning(this.#settingsManager, selected.name, persistenceWarning);
+			if (operationGeneration !== this.#modelOverrideGeneration) {
+				this.#notice = `Background model override save for ${selected.name} was not confirmed: ${error instanceof Error ? error.message : String(error)}`;
+				this.#rebuildAndRender();
+				return;
+			}
+			this.#editingAgentName = null;
+			this.#editInput = null;
+			this.#applyFilters();
+			this.#notice = `Model override for ${selected.name} is ${effectiveValue || "(unset)"} locally, but persistence was not confirmed: ${error instanceof Error ? error.message : String(error)}`;
+			this.#rebuildAndRender();
+			return;
+		}
+
+		this.#modelOverrideSaving = false;
+		const effectiveValue = this.#settingsManager?.get("task.agentModelOverrides")[selected.name]?.trim();
+		const projectValue = this.#settingsManager?.getProject("task.agentModelOverrides")?.[selected.name]?.trim();
+		selected.overrideModel = effectiveValue || undefined;
+		selected.persistenceWarning = undefined;
+		setModelOverridePersistenceWarning(this.#settingsManager, selected.name, undefined);
+		if (operationGeneration !== this.#modelOverrideGeneration) {
+			this.#notice = `Background model override save completed for ${selected.name}`;
+			this.#rebuildAndRender();
+			return;
+		}
 		this.#editingAgentName = null;
 		this.#editInput = null;
 		this.#applyFilters();
-		this.#notice = `Updated model override for ${selected.name}`;
-		this.#buildLayout();
+		const projectProfile = this.modelContext.projectModelProfileShadow;
+		if (projectProfile?.targetIds.includes(selected.name)) {
+			const operation = value
+				? `Updated model override for ${selected.name}`
+				: `Cleared model override for ${selected.name}`;
+			this.#notice = `${operation} for this session; project model profile ${projectProfile.profileName} resumes on restart`;
+		} else if (value && projectValue && projectValue !== value) {
+			this.#notice = `Updated user override for ${selected.name} to ${value} for this session; project override ${projectValue} resumes on restart`;
+		} else if (!value && effectiveValue) {
+			this.#notice = `Cleared user override for ${selected.name}; effective override remains ${effectiveValue}`;
+		} else if (!value) {
+			this.#notice = `Cleared model override for ${selected.name}`;
+		} else {
+			this.#notice = `Updated model override for ${selected.name}`;
+		}
+		this.#rebuildAndRender();
 	}
 
 	#cancelModelEdit(): void {
+		if (this.#modelOverrideSaving) {
+			this.#modelOverrideGeneration++;
+			this.#notice = "Model override save continues in the background";
+		}
 		this.#editingAgentName = null;
 		this.#editInput = null;
 		this.#buildLayout();
@@ -719,8 +813,12 @@ export class AgentDashboard extends Container {
 	}
 
 	#effectivePatternsFor(agent: DashboardAgent, draftOverride: string | undefined): string[] {
+		const projectedOverride =
+			draftOverride !== undefined && draftOverride.trim() === ""
+				? this.#settingsManager?.getProject("task.agentModelOverrides")?.[agent.name]
+				: draftOverride;
 		return resolveAgentModelPatterns({
-			settingsOverride: draftOverride,
+			settingsOverride: projectedOverride,
 			agentModel: agent.model,
 			settings: this.#settingsManager ?? undefined,
 			activeModelPattern: this.modelContext.activeModelPattern,
@@ -1005,10 +1103,11 @@ export class AgentDashboard extends Container {
 		}
 
 		if (this.#editInput) {
-			if (matchesAppInterrupt(data)) {
+			if (matchesKey(data, "escape") || matchesKey(data, "esc") || matchesAppInterrupt(data)) {
 				this.#cancelModelEdit();
 				return;
 			}
+			if (this.#modelOverrideSaving) return;
 			this.#editInput.handleInput(data);
 			if (this.#editInput) {
 				this.#buildLayout();

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -325,6 +325,7 @@ export class ModelSelectorComponent extends Container {
 	#selectedActionIndex: number = 0;
 	#pendingThinkingChoice?: PendingThinkingChoice;
 	#selectedThinkingIndex: number = 0;
+	#selectionPending = false;
 
 	// Preset landing state
 	#viewMode: ModelSelectorViewMode = "presets";
@@ -467,10 +468,16 @@ export class ModelSelectorComponent extends Container {
 				modelRegistry: this.#modelRegistry,
 			});
 			if (resolved.model) {
+				const usesLiveDefaultEffort =
+					role === "default" &&
+					!resolved.explicitThinkingLevel &&
+					this.#currentModel?.provider === resolved.model.provider &&
+					this.#currentModel.id === resolved.model.id;
 				this.#roles[role] = {
 					model: resolved.model,
-					thinkingLevel:
-						resolved.explicitThinkingLevel && resolved.thinkingLevel !== undefined
+					thinkingLevel: usesLiveDefaultEffort
+						? (this.#currentThinkingLevel ?? ThinkingLevel.Inherit)
+						: resolved.explicitThinkingLevel && resolved.thinkingLevel !== undefined
 							? resolved.thinkingLevel
 							: ThinkingLevel.Inherit,
 				};
@@ -492,7 +499,11 @@ export class ModelSelectorComponent extends Container {
 		if ("activeModelProfile" in options) this.#activeModelProfile = options.activeModelProfile;
 		this.#roles = {};
 		this.#loadRoleModels();
-		this.#applyTabFilter();
+		if (this.#viewMode === "presets") {
+			this.#renderPresetLanding();
+		} else {
+			this.#applyTabFilter();
+		}
 	}
 
 	#sortModels(models: ModelItem[]): void {
@@ -855,14 +866,15 @@ export class ModelSelectorComponent extends Container {
 
 	#buildCustomModelProfileSnapshot(): ModelProfileConfig {
 		const modelMapping: ModelProfileConfig["model_mapping"] = {};
+		const configuredDefaultSelector = this.#resolveProfileModelSelector(this.#settings.getModelRole("default"));
+		const activeProfileDefaultSelector = this.#activeModelProfile
+			? this.#resolveProfileModelSelector(this.#getProfileByName(this.#activeModelProfile)?.modelMapping.default)
+			: undefined;
 		const currentModelSelector = this.#formatCurrentModelSelector();
-		if (currentModelSelector) {
-			modelMapping.default = currentModelSelector;
-		} else {
-			const defaultRole = this.#settings.getModelRole("default");
-			const defaultSelector = this.#resolveProfileModelSelector(defaultRole);
-			if (defaultSelector) modelMapping.default = defaultSelector;
-		}
+		const defaultSelector = this.#activeModelProfile
+			? (activeProfileDefaultSelector ?? configuredDefaultSelector ?? currentModelSelector)
+			: (configuredDefaultSelector ?? currentModelSelector);
+		if (defaultSelector) modelMapping.default = defaultSelector;
 
 		const agentOverrides = this.#settings.get("task.agentModelOverrides");
 		for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
@@ -1410,7 +1422,42 @@ export class ModelSelectorComponent extends Container {
 			: this.#filteredModels[this.#selectedIndex];
 	}
 
+	#handleSelectionFailure(error: unknown): void {
+		const message = error instanceof Error ? error.message : String(error);
+		this.#roles = {};
+		this.#loadRoleModels();
+		if (this.#viewMode === "presets") {
+			this.#presetLoginHint = message;
+			this.#renderPresetLanding();
+		} else {
+			this.#errorMessage = message;
+			this.#applyTabFilter();
+		}
+		this.#tui.requestRender();
+	}
+
+	#dispatchSelection(selection: ModelSelectorSelection): void | Promise<void> {
+		if (this.#selectionPending) return;
+		this.#selectionPending = true;
+		try {
+			const result = this.#onSelectCallback(selection);
+			if (result && typeof result.then === "function") {
+				return result
+					.catch(error => {
+						this.#handleSelectionFailure(error);
+					})
+					.finally(() => {
+						this.#selectionPending = false;
+					});
+			}
+		} catch (error) {
+			this.#handleSelectionFailure(error);
+		}
+		this.#selectionPending = false;
+	}
+
 	handleInput(keyData: string): void {
+		if (this.#selectionPending) return;
 		if (this.#pendingThinkingChoice) {
 			this.#handleThinkingMenuInput(keyData);
 			return;
@@ -1549,11 +1596,11 @@ export class ModelSelectorComponent extends Container {
 			const profile = this.#getProfileByName(this.#previewProfileName);
 			if (!profile) return;
 			if (this.#presetScopeIndex === 2 && isCustomUserProfile(profile)) {
-				this.#onSelectCallback({ kind: "renameProfile", profileName: this.#previewProfileName });
+				void this.#dispatchSelection({ kind: "renameProfile", profileName: this.#previewProfileName });
 				return;
 			}
 			if (this.#presetScopeIndex === 3 && isCustomUserProfile(profile)) {
-				this.#onSelectCallback({ kind: "deleteProfile", profileName: this.#previewProfileName });
+				void this.#dispatchSelection({ kind: "deleteProfile", profileName: this.#previewProfileName });
 				return;
 			}
 			const missing = this.#getMissingProviders(profile);
@@ -1562,7 +1609,7 @@ export class ModelSelectorComponent extends Container {
 				this.#renderPresetLanding();
 				return;
 			}
-			this.#onSelectCallback({
+			void this.#dispatchSelection({
 				kind: "profile",
 				profileName: this.#previewProfileName,
 				setDefault: this.#presetScopeIndex === 1,
@@ -1578,7 +1625,7 @@ export class ModelSelectorComponent extends Container {
 		const row = this.#getSelectedPresetRow();
 		if (!row) return;
 		if (row.kind === "create") {
-			this.#onSelectCallback({ kind: "createProfile", profile: this.#buildCustomModelProfileSnapshot() });
+			void this.#dispatchSelection({ kind: "createProfile", profile: this.#buildCustomModelProfileSnapshot() });
 			return;
 		}
 		if (row.kind === "alreadySaved" || row.kind === "createUnavailable") {
@@ -1758,7 +1805,7 @@ export class ModelSelectorComponent extends Container {
 
 		// For temporary role, don't save to settings - just notify caller
 		if (role === null) {
-			this.#onSelectCallback({
+			void this.#dispatchSelection({
 				kind: "assignment",
 				model: item.model,
 				role: null,
@@ -1781,7 +1828,7 @@ export class ModelSelectorComponent extends Container {
 		}
 
 		// Notify caller (for updating agent state if needed)
-		this.#onSelectCallback({
+		void this.#dispatchSelection({
 			kind: "assignment",
 			model: item.model,
 			role,
@@ -1798,15 +1845,15 @@ export class ModelSelectorComponent extends Container {
 		return this.#searchInput;
 	}
 	async __testSelectProfile(profileName: string, setDefault: boolean): Promise<void> {
-		await this.#onSelectCallback({ kind: "profile", profileName, setDefault });
+		await this.#dispatchSelection({ kind: "profile", profileName, setDefault });
 	}
 	async __testSelectAssignment(
 		selection: Omit<Extract<ModelSelectorSelection, { kind: "assignment" }>, "kind">,
 	): Promise<void> {
-		await this.#onSelectCallback({ kind: "assignment", ...selection });
+		await this.#dispatchSelection({ kind: "assignment", ...selection });
 	}
 	async __testSelectPresetAction(profileName: string, action: "rename" | "delete"): Promise<void> {
-		await this.#onSelectCallback({
+		await this.#dispatchSelection({
 			kind: action === "rename" ? "renameProfile" : "deleteProfile",
 			profileName,
 		});
@@ -1824,7 +1871,7 @@ function requiresExplicitThinkingChoice(model: Model, role: GjcModelAssignmentTa
 }
 
 function getSelectableThinkingLevels(model: Model): ThinkingLevel[] {
-	const levels: ThinkingLevel[] = [ThinkingLevel.Off];
+	const levels: ThinkingLevel[] = [ThinkingLevel.Inherit, ThinkingLevel.Off];
 	let efforts: readonly string[];
 	try {
 		efforts = getSupportedEfforts(model);

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -78,13 +78,14 @@ class SelectSubmenu extends Container {
 	#selectList: SelectList;
 	#previewText: Text | null = null;
 	#previewUpdateRequestId: number = 0;
+	#selectPending = false;
 
 	constructor(
 		title: string,
 		description: string,
 		options: ReadonlyArray<SelectItem>,
 		currentValue: string,
-		onSelect: (value: string) => void,
+		onSelect: (value: string) => void | Promise<void>,
 		onCancel: () => void,
 		onSelectionChange?: (value: string) => void | Promise<void>,
 		private readonly getPreview?: () => string,
@@ -121,7 +122,25 @@ class SelectSubmenu extends Container {
 		}
 
 		this.#selectList.onSelect = item => {
-			onSelect(item.value);
+			if (this.#selectPending) return;
+			this.#selectPending = true;
+			try {
+				const result = onSelect(item.value);
+				if (result && typeof (result as Promise<void>).then === "function") {
+					void (result as Promise<void>)
+						.catch(() => {
+							// The callback owns user-facing error reporting. Keep the
+							// submenu open so the prior selection remains visible.
+						})
+						.finally(() => {
+							this.#selectPending = false;
+						});
+					return;
+				}
+			} catch {
+				// The callback owns user-facing error reporting.
+			}
+			this.#selectPending = false;
 		};
 
 		this.#selectList.onCancel = onCancel;
@@ -158,6 +177,7 @@ class SelectSubmenu extends Container {
 	}
 
 	handleInput(data: string): void {
+		if (this.#selectPending) return;
 		this.#selectList.handleInput(data);
 	}
 }
@@ -677,7 +697,7 @@ export interface StatusLinePreviewSettings {
 
 export interface SettingsCallbacks {
 	/** Called when any setting value changes */
-	onChange: (path: SettingPath, newValue: unknown) => void;
+	onChange: (path: SettingPath, newValue: unknown) => void | Promise<void>;
 	/** Called for theme preview while browsing theme settings */
 	onThemePreview?: (theme: string) => void | Promise<void>;
 	/** Called to restore the rendered theme when theme settings preview is cancelled */
@@ -704,6 +724,8 @@ export class SettingsSelectorComponent extends Container {
 	#statusPreviewText: Text | null = null;
 	#currentTabId: SettingTab | "plugins" = "appearance";
 	#textInputActive = false;
+	#asyncChangePending = false;
+	#asyncChangeRequestId = 0;
 
 	constructor(
 		private readonly context: SettingsRuntimeContext,
@@ -937,8 +959,23 @@ export class SettingsSelectorComponent extends Container {
 			options,
 			currentValue,
 			value => {
-				this.#setSettingValue(def.path, value);
-				this.callbacks.onChange(def.path, value);
+				// Profile activation owns persistence so credential/model failures
+				// cannot leave a default profile selected only on disk.
+				if (def.path !== "modelProfile.default") {
+					this.#setSettingValue(def.path, value);
+				}
+				const result = this.callbacks.onChange(def.path, value);
+				if (result && typeof result.then === "function") {
+					const requestId = ++this.#asyncChangeRequestId;
+					this.#asyncChangePending = true;
+					return result
+						.then(() => {
+							if (requestId === this.#asyncChangeRequestId) done(value);
+						})
+						.finally(() => {
+							if (requestId === this.#asyncChangeRequestId) this.#asyncChangePending = false;
+						});
+				}
 				done(value);
 			},
 			() => {
@@ -1167,6 +1204,14 @@ export class SettingsSelectorComponent extends Container {
 	}
 
 	handleInput(data: string): void {
+		if (this.#asyncChangePending) {
+			if (matchesKey(data, "escape") || matchesKey(data, "esc") || matchesAppInterrupt(data)) {
+				this.#asyncChangeRequestId++;
+				this.#asyncChangePending = false;
+				this.callbacks.onCancel();
+			}
+			return;
+		}
 		// Handle tab switching — but NOT when a text input is active, since
 		// arrow keys must reach the cursor and Tab must not switch tabs.
 		if (

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -357,6 +357,10 @@ export class SelectorController {
 			modelSelector.refreshPresetProfiles(refreshedProfileName);
 		};
 		try {
+			const projectProfile = resolveProjectModelProfileShadow(this.ctx.settings, this.ctx.session.modelRegistry);
+			if (projectProfile?.profileName === profileName) {
+				throw new Error(`Cannot delete model profile referenced by the current project: ${profileName}`);
+			}
 			if (activeProfile === profileName || defaultProfile === profileName) {
 				snapshot = await materializeModelProfileForDeletion({
 					session: this.ctx.session,
@@ -365,7 +369,9 @@ export class SelectorController {
 					profileName,
 				});
 			}
-			deletedProfile = await this.ctx.session.modelRegistry.deleteCustomModelProfile(profileName);
+			deletedProfile = await this.ctx.settings.deleteModelProfileIfUnreferenced(profileName, () =>
+				this.ctx.session.modelRegistry.deleteCustomModelProfile(profileName),
+			);
 			await this.ctx.session.modelRegistry.refresh("offline");
 			refreshSelectorState();
 			this.ctx.showStatus(`Custom model preset deleted: ${profileLabel}`);
@@ -1052,6 +1058,7 @@ export class SelectorController {
 									}
 								}
 							}
+							await this.ctx.settings.flushOrThrow();
 							modelSelector.refreshRoleAssignments({
 								currentModel: this.ctx.session.model,
 								currentThinkingLevel: this.ctx.session.thinkingLevel,
@@ -1093,6 +1100,7 @@ export class SelectorController {
 							) {
 								this.ctx.session.setThinkingLevel(defaultThinking.effective);
 							}
+							await this.ctx.settings.flushOrThrow();
 							modelSelector.refreshRoleAssignments({
 								currentModel: this.ctx.session.model,
 								currentThinkingLevel: this.ctx.session.thinkingLevel,
@@ -1141,6 +1149,7 @@ export class SelectorController {
 									this.ctx.settings.setAgentModelOverride(role, value);
 								}
 							}
+							await this.ctx.settings.flushOrThrow();
 							modelSelector.refreshRoleAssignments({
 								currentModel: this.ctx.session.model,
 								currentThinkingLevel: this.ctx.session.thinkingLevel,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 
 import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import type { OAuthProvider } from "@gajae-code/ai/utils/oauth/types";
 import type { Component, OverlayHandle } from "@gajae-code/tui";
@@ -12,11 +13,12 @@ import {
 	materializeActiveModelProfileAssignment,
 	materializeActiveModelProfileAssignments,
 	materializeModelProfileForDeletion,
+	resolveProjectModelProfileShadow,
 	restoreMaterializedModelProfileForDeletion,
 } from "../../config/model-profile-activation";
 import { formatModelProfileDisplayLabel, recommendModelProfileForProvider } from "../../config/model-profiles";
 import { GJC_MODEL_ASSIGNMENT_TARGETS, type GjcModelAssignmentTargetId } from "../../config/model-registry";
-import { formatModelSelectorValue } from "../../config/model-resolver";
+import { extractExplicitThinkingSelector, formatModelSelectorValue } from "../../config/model-resolver";
 import type { ModelProfileConfig } from "../../config/models-config-schema";
 import { type Settings, settings } from "../../config/settings";
 import { DebugSelectorComponent } from "../../debug";
@@ -59,6 +61,7 @@ import {
 	MODEL_ONBOARDING_SETUP_COMMAND,
 } from "../../setup/model-onboarding-guidance";
 import { addApiCompatibleProvider, formatProviderSetupResult } from "../../setup/provider-onboarding";
+import { clampModelAssignmentThinkingLevel } from "../../thinking";
 import {
 	isConfigurableSearchProviderId,
 	isSearchProviderPreference,
@@ -280,8 +283,8 @@ export class SelectorController {
 				try {
 					const profile = await this.ctx.session.modelRegistry.saveCustomModelProfile(input.name, input.profile);
 					await this.ctx.session.modelRegistry.refresh("offline");
-					await this.ctx.notifyConfigChanged?.();
 					this.ctx.showStatus(`Custom model preset created: ${formatModelProfileDisplayLabel(profile)}`);
+					this.#notifyConfigChangedSafely();
 					done();
 					this.ctx.ui.requestRender();
 				} catch (err) {
@@ -318,9 +321,9 @@ export class SelectorController {
 		try {
 			const renamed = await this.ctx.session.modelRegistry.renameCustomModelProfile(profileName, input);
 			await this.ctx.session.modelRegistry.refresh("offline");
-			await this.ctx.notifyConfigChanged?.();
 			modelSelector.refreshPresetProfiles(renamed.name);
 			this.ctx.showStatus(`Custom model preset renamed: ${formatModelProfileDisplayLabel(renamed)}`);
+			this.#notifyConfigChangedSafely();
 			this.ctx.ui.requestRender();
 		} catch (err) {
 			this.ctx.showError(`Preset rename failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -364,9 +367,9 @@ export class SelectorController {
 			}
 			deletedProfile = await this.ctx.session.modelRegistry.deleteCustomModelProfile(profileName);
 			await this.ctx.session.modelRegistry.refresh("offline");
-			await this.ctx.notifyConfigChanged?.();
 			refreshSelectorState();
 			this.ctx.showStatus(`Custom model preset deleted: ${profileLabel}`);
+			this.#notifyConfigChangedSafely();
 			this.ctx.ui.requestRender();
 		} catch (err) {
 			let presetRestoreError: unknown;
@@ -411,8 +414,8 @@ export class SelectorController {
 				try {
 					const result = await addApiCompatibleProvider(input);
 					await this.ctx.session.modelRegistry.refresh("offline");
-					await this.ctx.notifyConfigChanged?.();
 					this.ctx.showStatus(formatProviderSetupResult(result));
+					this.#notifyConfigChangedSafely();
 					done();
 					this.ctx.ui.requestRender();
 				} catch (err) {
@@ -461,7 +464,7 @@ export class SelectorController {
 					this.ctx.statusLine.invalidate();
 					this.ctx.updateEditorBorderColor();
 					this.ctx.updateEditorTopBorder();
-					if (persistDefault) void this.ctx.notifyConfigChanged?.();
+					if (persistDefault) void this.#notifyConfigChangedSafely();
 					this.ctx.ui.requestRender();
 					const scopeLabel = persistDefault ? "Default reasoning effort" : "Reasoning effort";
 					this.ctx.showStatus(
@@ -629,6 +632,28 @@ export class SelectorController {
 			modelRegistry: this.ctx.session.modelRegistry,
 			activeModelPattern,
 			defaultModelPattern,
+			projectModelProfileShadow: resolveProjectModelProfileShadow(this.ctx.settings, this.ctx.session.modelRegistry),
+			onModelOverrideChange: async (agentName, value) => {
+				if (agentName !== "default" && Object.hasOwn(GJC_MODEL_ASSIGNMENT_TARGETS, agentName)) {
+					const role = agentName as GjcModelAssignmentTargetId;
+					const materializedProfile = materializeActiveModelProfileAssignment({
+						session: this.ctx.session,
+						settings: this.ctx.settings,
+						role,
+						selector: value,
+					});
+					if (materializedProfile) {
+						await this.ctx.settings.flushOrThrow();
+						return;
+					}
+				}
+				if (value) {
+					this.ctx.settings.setAgentModelOverride(agentName, value);
+				} else {
+					this.ctx.settings.clearAgentModelOverride(agentName);
+				}
+				await this.ctx.settings.flushOrThrow();
+			},
 		});
 		this.showSelector(done => {
 			dashboard.onClose = () => {
@@ -647,7 +672,7 @@ export class SelectorController {
 	 * Most settings are saved directly via SettingsManager in the definitions.
 	 * This handles side effects and session-specific settings.
 	 */
-	handleSettingChange(id: string, value: unknown): void {
+	handleSettingChange(id: string, value: unknown): void | Promise<void> {
 		// Discovery provider toggles
 		if (id.startsWith("discovery.")) {
 			const providerId = id.replace("discovery.", "");
@@ -686,12 +711,12 @@ export class SelectorController {
 				// running session switches immediately, not only on next startup.
 				const profileName = typeof value === "string" ? value : "";
 				if (!profileName) break;
-				this.#applyModelProfile(profileName, true)
+				return this.#applyModelProfile(profileName, true)
 					.then(() => this.ctx.ui.requestRender())
 					.catch(error => {
 						this.ctx.showError(error instanceof Error ? error.message : String(error));
+						throw error;
 					});
-				break;
 			}
 			case "clearOnShrink":
 				this.ctx.ui.setClearOnShrink(value as boolean);
@@ -849,6 +874,66 @@ export class SelectorController {
 		}
 	}
 
+	#notifyConfigChangedSafely(): void {
+		void Promise.resolve()
+			.then(() => this.ctx.notifyConfigChanged?.())
+			.catch(error => {
+				this.ctx.showError(
+					`Configuration was updated, but change notification failed: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			})
+			.catch(() => {});
+	}
+
+	#getSessionActiveModelProfile(): string | undefined {
+		const getActiveModelProfile = this.ctx.session.getActiveModelProfile;
+		return getActiveModelProfile
+			? getActiveModelProfile.call(this.ctx.session)
+			: this.ctx.settings.get("modelProfile.default");
+	}
+
+	#resolveDefaultModelThinking(
+		model: Model,
+		selectedThinkingLevel: ThinkingLevel | undefined,
+	): { effective: ThinkingLevel | undefined; persisted: ThinkingLevel | undefined } {
+		const configuredDefault = this.ctx.settings.get("defaultThinkingLevel");
+		const existingExplicit = extractExplicitThinkingSelector(
+			this.ctx.settings.getModelRole("default"),
+			this.ctx.settings,
+		);
+		const inherited =
+			this.#getSessionActiveModelProfile() !== undefined
+				? (this.ctx.session.thinkingLevel ?? configuredDefault)
+				: (existingExplicit ?? configuredDefault);
+		const persisted = clampModelAssignmentThinkingLevel(
+			model,
+			selectedThinkingLevel === undefined
+				? this.#getSessionActiveModelProfile() !== undefined
+					? inherited
+					: existingExplicit
+				: selectedThinkingLevel,
+		);
+		const effective = clampModelAssignmentThinkingLevel(
+			model,
+			selectedThinkingLevel === ThinkingLevel.Inherit ? configuredDefault : (selectedThinkingLevel ?? inherited),
+		);
+		return { effective, persisted };
+	}
+
+	#formatProjectModelRestartNotice(targetRoles: readonly GjcModelAssignmentTargetId[]): string {
+		const projectModelRoles = this.ctx.settings.getProject("modelRoles") ?? {};
+		const projectAgentOverrides = this.ctx.settings.getProject("task.agentModelOverrides") ?? {};
+		const projectProfile = resolveProjectModelProfileShadow(this.ctx.settings, this.ctx.session.modelRegistry);
+		const shadowed = targetRoles.filter(role => {
+			const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+			const direct = target.settingsPath === "modelRoles" ? projectModelRoles[role] : projectAgentOverrides[role];
+			return direct !== undefined || projectProfile?.targetIds.includes(role) === true;
+		});
+		if (shadowed.length === 0) return "";
+		const labels = shadowed.map(role => GJC_MODEL_ASSIGNMENT_TARGETS[role].tag ?? role.toUpperCase());
+		return ` Project settings for ${labels.join(", ")} resume on restart.`;
+	}
+
 	/**
 	 * Activate a model profile through the shared /model + /settings path: swap the
 	 * live session model (and, when persistDefault, persist it as the startup
@@ -870,6 +955,7 @@ export class SelectorController {
 		this.ctx.statusLine.invalidate();
 		this.ctx.updateEditorBorderColor();
 		this.ctx.showStatus(persistDefault ? `Default model profile: ${profileLabel}` : `Model profile: ${profileLabel}`);
+		this.#notifyConfigChangedSafely();
 	}
 
 	showModelSelector(options?: { temporaryOnly?: boolean }): void {
@@ -924,22 +1010,32 @@ export class SelectorController {
 									throw new Error(`No API key for ${model.provider}/${model.id}`);
 								}
 							}
-							const value =
-								selectedSelector ?? formatModelSelectorValue(`${model.provider}/${model.id}`, thinkingLevel);
+							const defaultThinking = includesDefault
+								? this.#resolveDefaultModelThinking(model, thinkingLevel)
+								: undefined;
+							const persistedThinkingLevel =
+								defaultThinking?.persisted ?? clampModelAssignmentThinkingLevel(model, thinkingLevel);
+							const selectorBase =
+								selectedSelector &&
+								thinkingLevel !== ThinkingLevel.Inherit &&
+								thinkingLevel !== undefined &&
+								selectedSelector.endsWith(`:${thinkingLevel}`)
+									? selectedSelector.slice(0, -thinkingLevel.length - 1)
+									: (selectedSelector ?? `${model.provider}/${model.id}`);
+							const value = formatModelSelectorValue(selectorBase, persistedThinkingLevel);
 							const assignments = new Map<GjcModelAssignmentTargetId, string>();
 							for (const targetRole of targetRoles) assignments.set(targetRole, value);
-							const defaultSelector =
-								selectedSelector && thinkingLevel && selectedSelector.endsWith(`:${thinkingLevel}`)
-									? selectedSelector.slice(0, -thinkingLevel.length - 1)
-									: selectedSelector;
 
 							if (includesDefault) {
 								await this.ctx.session.setModel(model, "default", {
-									selector: defaultSelector,
-									thinkingLevel,
+									selector: selectorBase,
+									thinkingLevel: persistedThinkingLevel,
 								});
-								if (thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit) {
-									this.ctx.session.setThinkingLevel(thinkingLevel);
+								if (
+									defaultThinking?.effective !== undefined &&
+									defaultThinking.effective !== ThinkingLevel.Inherit
+								) {
+									this.ctx.session.setThinkingLevel(defaultThinking.effective);
 								}
 							}
 							const materializedProfile = materializeActiveModelProfileAssignments({
@@ -948,70 +1044,73 @@ export class SelectorController {
 								assignments,
 							});
 							if (!materializedProfile) {
-								const overrides = this.ctx.settings.get("task.agentModelOverrides");
-								const nextOverrides = { ...overrides };
-								let writesOverrides = false;
 								for (const targetRole of targetRoles) {
-									const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetRole];
-									if (target.settingsPath === "modelRoles") {
+									if (targetRole === "default") {
 										this.ctx.settings.setModelRole(targetRole, value);
 									} else {
-										nextOverrides[targetRole] = value;
-										writesOverrides = true;
+										this.ctx.settings.setAgentModelOverride(targetRole, value);
 									}
-								}
-								if (writesOverrides) {
-									this.ctx.settings.set("task.agentModelOverrides", nextOverrides);
 								}
 							}
 							modelSelector.refreshRoleAssignments({
 								currentModel: this.ctx.session.model,
 								currentThinkingLevel: this.ctx.session.thinkingLevel,
-								activeModelProfile:
-									this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
+								activeModelProfile: this.#getSessionActiveModelProfile(),
 							});
 							this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
 							this.ctx.statusLine.invalidate();
 							this.ctx.updateEditorBorderColor();
-							await this.ctx.notifyConfigChanged?.();
 							const labels = targetRoles.map(
 								targetRole => GJC_MODEL_ASSIGNMENT_TARGETS[targetRole].tag ?? targetRole.toUpperCase(),
 							);
+							const projectRestartNotice = this.#formatProjectModelRestartNotice(targetRoles);
 							this.ctx.showStatus(
-								includesDefault
+								(includesDefault
 									? `All model targets set to ${value} for ${labels.join(", ")}.`
-									: `Role-agent models set to ${value} for ${labels.join(", ")}.`,
+									: `Role-agent models set to ${value} for ${labels.join(", ")}.`) + projectRestartNotice,
 							);
+							this.#notifyConfigChangedSafely();
 							done();
 							this.ctx.ui.requestRender();
 						} else if (role === "default") {
 							// Default: update agent state and persist as the active default model.
+							const defaultThinking = this.#resolveDefaultModelThinking(model, thinkingLevel);
+							const selectorBase = selectedSelector ?? `${model.provider}/${model.id}`;
 							await this.ctx.session.setModel(model, role, {
-								selector: selectedSelector,
-								thinkingLevel,
+								selector: selectorBase,
+								thinkingLevel: defaultThinking.persisted,
 							});
-							const value = formatModelSelectorValue(
-								selectedSelector ?? `${model.provider}/${model.id}`,
-								thinkingLevel,
-							);
+							const value = formatModelSelectorValue(selectorBase, defaultThinking.persisted);
 							materializeActiveModelProfileAssignment({
 								session: this.ctx.session,
 								settings: this.ctx.settings,
 								role,
 								selector: value,
 							});
-							if (thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit) {
-								this.ctx.session.setThinkingLevel(thinkingLevel);
+							if (
+								defaultThinking.effective !== undefined &&
+								defaultThinking.effective !== ThinkingLevel.Inherit
+							) {
+								this.ctx.session.setThinkingLevel(defaultThinking.effective);
 							}
 							modelSelector.refreshRoleAssignments({
 								currentModel: this.ctx.session.model,
 								currentThinkingLevel: this.ctx.session.thinkingLevel,
-								activeModelProfile:
-									this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
+								activeModelProfile: this.#getSessionActiveModelProfile(),
 							});
 							this.ctx.statusLine.invalidate();
 							this.ctx.updateEditorBorderColor();
-							this.ctx.showStatus(`Default model: ${selectedSelector ?? model.id}`);
+							const effectiveValue = formatModelSelectorValue(
+								`${model.provider}/${model.id}`,
+								defaultThinking.effective,
+							);
+							const projectRestartNotice = this.#formatProjectModelRestartNotice([role]);
+							this.ctx.showStatus(
+								(effectiveValue === value
+									? `Default model: ${value}`
+									: `Default model: ${value} (effective: ${effectiveValue})`) + projectRestartNotice,
+							);
+							this.#notifyConfigChangedSafely();
 							done();
 							this.ctx.ui.requestRender();
 						} else {
@@ -1019,8 +1118,15 @@ export class SelectorController {
 							if (!apiKey) {
 								throw new Error(`No API key for ${model.provider}/${model.id}`);
 							}
-							const value =
-								selectedSelector ?? formatModelSelectorValue(`${model.provider}/${model.id}`, thinkingLevel);
+							const clampedThinkingLevel = clampModelAssignmentThinkingLevel(model, thinkingLevel);
+							const selectorBase =
+								selectedSelector &&
+								thinkingLevel !== undefined &&
+								thinkingLevel !== ThinkingLevel.Inherit &&
+								selectedSelector.endsWith(`:${thinkingLevel}`)
+									? selectedSelector.slice(0, -thinkingLevel.length - 1)
+									: (selectedSelector ?? `${model.provider}/${model.id}`);
+							const value = formatModelSelectorValue(selectorBase, clampedThinkingLevel);
 							const assignments = new Map<GjcModelAssignmentTargetId, string>([[role, value]]);
 							const materializedProfile = materializeActiveModelProfileAssignments({
 								session: this.ctx.session,
@@ -1032,28 +1138,34 @@ export class SelectorController {
 								if (target.settingsPath === "modelRoles") {
 									this.ctx.settings.setModelRole(role, value);
 								} else {
-									this.ctx.settings.set("task.agentModelOverrides", {
-										...this.ctx.settings.get("task.agentModelOverrides"),
-										[role]: value,
-									});
+									this.ctx.settings.setAgentModelOverride(role, value);
 								}
 							}
 							modelSelector.refreshRoleAssignments({
 								currentModel: this.ctx.session.model,
 								currentThinkingLevel: this.ctx.session.thinkingLevel,
-								activeModelProfile:
-									this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
+								activeModelProfile: this.#getSessionActiveModelProfile(),
 							});
 							this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
 							this.ctx.statusLine.invalidate();
 							this.ctx.updateEditorBorderColor();
-							await this.ctx.notifyConfigChanged?.();
-							this.ctx.showStatus(`${role} agent model: ${value}`);
+							this.ctx.showStatus(
+								`${role} agent model: ${value}${this.#formatProjectModelRestartNotice([role])}`,
+							);
+							this.#notifyConfigChangedSafely();
 							done();
 							this.ctx.ui.requestRender();
 						}
 					} catch (error) {
+						modelSelector.refreshRoleAssignments({
+							currentModel: this.ctx.session.model,
+							currentThinkingLevel: this.ctx.session.thinkingLevel,
+							activeModelProfile: this.#getSessionActiveModelProfile(),
+						});
+						this.ctx.statusLine.invalidate();
+						this.ctx.updateEditorBorderColor();
 						this.ctx.showError(error instanceof Error ? error.message : String(error));
+						this.ctx.ui.requestRender();
 					}
 				},
 				() => {
@@ -1064,11 +1176,10 @@ export class SelectorController {
 					...options,
 					sessionId: this.ctx.session.sessionId,
 					currentThinkingLevel: this.ctx.session.thinkingLevel,
-					activeModelProfile:
-						this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
+					activeModelProfile: this.#getSessionActiveModelProfile(),
 					isFastForProvider: provider => this.ctx.session.isFastForProvider(provider),
 					isFastForSubagentProvider: provider => this.ctx.session.isFastForSubagentProvider(provider),
-					isCurrentModelFastModeActive: () => this.ctx.session.isFastModeActive(),
+					isCurrentModelFastModeActive: () => this.ctx.session.isFastModeActive?.() ?? false,
 				},
 			);
 			return { component: modelSelector, focus: modelSelector };
@@ -1484,7 +1595,7 @@ export class SelectorController {
 			return;
 		}
 
-		const activeProfile = this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default");
+		const activeProfile = this.#getSessionActiveModelProfile();
 		if (activeProfile) {
 			this.ctx.showStatus(`Preset ${recommendedProfile.name} is available in /model.`);
 			return;
@@ -1495,12 +1606,8 @@ export class SelectorController {
 			return;
 		}
 
-		await activateModelProfile({
-			session: this.ctx.session,
-			modelRegistry: this.ctx.session.modelRegistry,
-			settings: this.ctx.settings,
-			profileName: recommendedProfile.name,
-		});
+		await this.#applyModelProfile(recommendedProfile.name, false);
+		this.ctx.ui.requestRender();
 	}
 
 	async #handleOAuthLogin(providerId: string): Promise<void> {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -701,6 +701,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 							}
 						}
 					}
+					await runtime.settings.flushOrThrow();
 					runtime.settings.getStorage()?.recordModelUsage(`${selection.model.provider}/${selection.model.id}`);
 					const success = formatModelAssignmentSuccess(parsedArgs.targetId, assignments);
 					const projectRestartNotice = formatProjectModelRestartNotice(runtime, targetIds);

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -6,7 +6,10 @@ import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import { Spacer, Text } from "@gajae-code/tui";
 import { setProjectDir } from "@gajae-code/utils";
 import { jobElapsedMs } from "../async";
-import { materializeActiveModelProfileAssignments } from "../config/model-profile-activation";
+import {
+	materializeActiveModelProfileAssignments,
+	resolveProjectModelProfileShadow,
+} from "../config/model-profile-activation";
 import {
 	GJC_MODEL_ASSIGNMENT_TARGET_IDS,
 	GJC_MODEL_ASSIGNMENT_TARGETS,
@@ -18,6 +21,7 @@ import {
 	formatModelSelectorValue,
 	parseModelPattern,
 	parseModelString,
+	resolveModelRoleValue,
 } from "../config/model-resolver";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../discovery/helpers.js";
 import { resolveMemoryBackend } from "../memory-backend";
@@ -32,7 +36,7 @@ import {
 	formatProviderSetupResult,
 	parseProviderCompatibility,
 } from "../setup/provider-onboarding";
-import { parseThinkingLevel } from "../thinking";
+import { clampModelAssignmentThinkingLevel, parseThinkingLevel } from "../thinking";
 import { getDisplayChangelogEntries } from "../utils/changelog";
 import { buildContextReportText } from "./helpers/context-report";
 import { buildFastStatusReport } from "./helpers/fast-status-report";
@@ -172,11 +176,32 @@ function providerSetupUsage(): string {
 
 function formatModelAssignmentSummary(runtime: SlashCommandRuntime): string {
 	const agentModelOverrides = runtime.settings.get("task.agentModelOverrides");
+	const activeProfile = runtime.session.getActiveModelProfile?.();
+	const persistedDefault = runtime.settings.getModelRole("default");
+	const liveDefault = runtime.session.model
+		? formatModelSelectorValue(
+				`${runtime.session.model.provider}/${runtime.session.model.id}`,
+				runtime.session.thinkingLevel,
+			)
+		: undefined;
+	let displayedDefault = activeProfile ? liveDefault : persistedDefault;
+	if (!activeProfile && persistedDefault && liveDefault && runtime.session.model) {
+		const resolvedDefault = resolveModelRoleValue(persistedDefault, runtime.session.modelRegistry.getAll(), {
+			settings: runtime.settings,
+			modelRegistry: runtime.session.modelRegistry,
+		});
+		const inheritedEffort =
+			resolvedDefault.model &&
+			modelsAreEqual(resolvedDefault.model, runtime.session.model) &&
+			extractExplicitThinkingSelector(persistedDefault, runtime.settings) === undefined;
+		if (inheritedEffort && liveDefault !== persistedDefault) {
+			displayedDefault = `${persistedDefault} (effective: ${liveDefault})`;
+		}
+	}
 	const lines = ["Model assignments:"];
 	for (const targetId of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
 		const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetId];
-		const modelSelector =
-			target.settingsPath === "modelRoles" ? runtime.settings.getModelRole(targetId) : agentModelOverrides[targetId];
+		const modelSelector = targetId === "default" ? displayedDefault : agentModelOverrides[targetId];
 		lines.push(`  ${target.tag ?? target.id.toUpperCase()} (${target.name}): ${modelSelector ?? "(unset)"}`);
 	}
 	return lines.join("\n");
@@ -355,10 +380,64 @@ function getModelAssignmentTargetIds(
 	return [targetId];
 }
 
+function formatProjectModelRestartNotice(
+	runtime: SlashCommandRuntime,
+	targetIds: readonly GjcModelAssignmentTargetId[],
+): string {
+	const projectModelRoles = runtime.settings.getProject("modelRoles") ?? {};
+	const projectAgentOverrides = runtime.settings.getProject("task.agentModelOverrides") ?? {};
+	const projectProfile = resolveProjectModelProfileShadow(runtime.settings, runtime.session.modelRegistry);
+	const shadowed = targetIds.filter(targetId => {
+		const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetId];
+		const direct =
+			target.settingsPath === "modelRoles" ? projectModelRoles[targetId] : projectAgentOverrides[targetId];
+		return direct !== undefined || projectProfile?.targetIds.includes(targetId) === true;
+	});
+	if (shadowed.length === 0) return "";
+	const labels = shadowed.map(targetId => GJC_MODEL_ASSIGNMENT_TARGETS[targetId].tag ?? targetId.toUpperCase());
+	return `\nProject settings for ${labels.join(", ")} resume on restart.`;
+}
+
+function resolveDefaultModelThinking(
+	runtime: SlashCommandRuntime,
+	model: Model,
+	selectedThinkingLevel: ThinkingLevel | undefined,
+): { effective: ThinkingLevel | undefined; persisted: ThinkingLevel | undefined } {
+	const configuredDefault = runtime.settings.get("defaultThinkingLevel");
+	const existingExplicit = extractExplicitThinkingSelector(runtime.settings.getModelRole("default"), runtime.settings);
+	const activeProfile = runtime.session.getActiveModelProfile?.() !== undefined;
+	const inherited = activeProfile
+		? (runtime.session.thinkingLevel ?? configuredDefault)
+		: (existingExplicit ?? configuredDefault);
+	const persisted = clampModelAssignmentThinkingLevel(
+		model,
+		selectedThinkingLevel === undefined ? (activeProfile ? inherited : existingExplicit) : selectedThinkingLevel,
+	);
+	const effective = clampModelAssignmentThinkingLevel(
+		model,
+		selectedThinkingLevel === ThinkingLevel.Inherit ? configuredDefault : (selectedThinkingLevel ?? inherited),
+	);
+	return { effective, persisted };
+}
+
 function formatModelAssignmentSuccess(
 	targetId: GjcModelAssignmentTargetId | GjcModelBatchAssignmentTargetId,
-	selector: string,
+	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string>,
 ): string {
+	const targetIds = getModelAssignmentTargetIds(targetId);
+	const assigned = targetIds
+		.map(id => [id, assignments.get(id)] as const)
+		.filter((entry): entry is readonly [GjcModelAssignmentTargetId, string] => entry[1] !== undefined);
+	const selector = assigned[0]?.[1] ?? "(unset)";
+	const hasMixedSelectors = new Set(assigned.map(([, value]) => value)).size > 1;
+
+	if ((targetId === "all-role-agents" || targetId === "all-targets") && hasMixedSelectors) {
+		const heading = targetId === "all-role-agents" ? "Role-agent models updated:" : "All model targets updated:";
+		return [
+			heading,
+			...assigned.map(([id, value]) => `  ${GJC_MODEL_ASSIGNMENT_TARGETS[id].tag ?? id.toUpperCase()}: ${value}`),
+		].join("\n");
+	}
 	if (targetId === "all-role-agents") {
 		return `Role-agent models set to ${selector} for EXECUTOR, ARCHITECT, PLANNER, CRITIC.`;
 	}
@@ -367,6 +446,24 @@ function formatModelAssignmentSuccess(
 	}
 	if (targetId === "default") return `Default model set to ${selector}.`;
 	return `${targetId} agent model set to ${selector}.`;
+}
+function notifyModelAssignmentCommitted(runtime: SlashCommandRuntime, options: { titleChanged: boolean }): void {
+	const notify = (label: "title" | "config", callback: (() => Promise<void> | void) | undefined): void => {
+		if (!callback) return;
+		void Promise.resolve()
+			.then(() => callback())
+			.catch(error =>
+				Promise.resolve()
+					.then(() =>
+						runtime.output(
+							`Model settings were updated, but notification failed (${label}: ${errorMessage(error)}).`,
+						),
+					)
+					.catch(() => {}),
+			);
+	};
+	if (options.titleChanged) notify("title", runtime.notifyTitleChanged);
+	notify("config", runtime.notifyConfigChanged);
 }
 
 function modelSelectionUsage(runtime: SlashCommandRuntime, currentModelLine?: string): string {
@@ -560,13 +657,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 
 					const overrides = runtime.settings.get("task.agentModelOverrides");
 					const assignments = new Map<GjcModelAssignmentTargetId, string>();
-					const existingDefaultThinkingLevel =
-						selection.thinkingLevel !== undefined
-							? selection.thinkingLevel
-							: runtime.session.getActiveModelProfile?.()
-								? undefined
-								: extractExplicitThinkingSelector(runtime.settings.getModelRole("default"), runtime.settings);
-					const persistedSelector = formatModelSelectorValue(selection.selector, existingDefaultThinkingLevel);
+					const defaultThinking = includesDefault
+						? resolveDefaultModelThinking(runtime, selection.model, selection.thinkingLevel)
+						: undefined;
+					const persistedSelector = formatModelSelectorValue(selection.selector, defaultThinking?.persisted);
 					for (const targetId of targetIds) {
 						if (targetId === "default") {
 							assignments.set(targetId, persistedSelector);
@@ -574,16 +668,22 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						}
 						const thinkingLevel =
 							selection.thinkingLevel ?? extractExplicitThinkingSelector(overrides[targetId], runtime.settings);
-						assignments.set(targetId, formatModelSelectorValue(selection.selector, thinkingLevel));
+						assignments.set(
+							targetId,
+							formatModelSelectorValue(
+								selection.selector,
+								clampModelAssignmentThinkingLevel(selection.model, thinkingLevel),
+							),
+						);
 					}
 
 					if (includesDefault) {
 						await runtime.session.setModel(selection.model, "default", {
 							selector: selection.selector,
-							thinkingLevel: existingDefaultThinkingLevel,
+							thinkingLevel: defaultThinking?.persisted,
 						});
-						if (existingDefaultThinkingLevel) {
-							runtime.session.setThinkingLevel(existingDefaultThinkingLevel);
+						if (defaultThinking?.effective !== undefined && defaultThinking.effective !== ThinkingLevel.Inherit) {
+							runtime.session.setThinkingLevel(defaultThinking.effective);
 						}
 					}
 
@@ -594,8 +694,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 					});
 					if (!materializedProfile) {
 						for (const [targetId, selector] of assignments) {
-							const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetId];
-							if (target.settingsPath === "modelRoles") {
+							if (targetId === "default") {
 								runtime.settings.setModelRole(targetId, selector);
 							} else {
 								runtime.settings.setAgentModelOverride(targetId, selector);
@@ -603,14 +702,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						}
 					}
 					runtime.settings.getStorage()?.recordModelUsage(`${selection.model.provider}/${selection.model.id}`);
-					await runtime.output(
-						formatModelAssignmentSuccess(
-							parsedArgs.targetId,
-							assignments.get(targetIds[0] ?? "default") ?? persistedSelector,
-						),
-					);
-					if (includesDefault) await runtime.notifyTitleChanged?.();
-					await runtime.notifyConfigChanged?.();
+					const success = formatModelAssignmentSuccess(parsedArgs.targetId, assignments);
+					const projectRestartNotice = formatProjectModelRestartNotice(runtime, targetIds);
+					await runtime.output(success + projectRestartNotice);
+					notifyModelAssignmentCommitted(runtime, { titleChanged: includesDefault });
 					return commandConsumed();
 				} catch (err) {
 					return usage(`Failed to set model: ${errorMessage(err)}`, runtime);

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -57,6 +57,14 @@ export function clampExplicitThinkingLevelForModel(
 	return clampThinkingLevelForModel(model, level);
 }
 
+export function clampModelAssignmentThinkingLevel(
+	model: Model | undefined,
+	level: ThinkingLevel | undefined,
+): ThinkingLevel | undefined {
+	const clamped = clampExplicitThinkingLevelForModel(model, level);
+	return clamped ?? (model && model.reasoning !== false ? level : undefined);
+}
+
 export function formatClampedModelSelector(selector: string, model: Model | undefined): string {
 	const slashIdx = selector.indexOf("/");
 	if (slashIdx <= 0) return selector;

--- a/packages/coding-agent/test/agent-dashboard-model-override.test.ts
+++ b/packages/coding-agent/test/agent-dashboard-model-override.test.ts
@@ -1,0 +1,316 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	materializeActiveModelProfileAssignment,
+	materializeActiveModelProfileAssignments,
+} from "@gajae-code/coding-agent/config/model-profile-activation";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentDashboard } from "@gajae-code/coding-agent/modes/components/agent-dashboard";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { getProjectAgentDir } from "@gajae-code/utils";
+
+beforeAll(async () => {
+	const theme = await getThemeByName("red-claw");
+	if (!theme) throw new Error("Failed to load test theme");
+	setThemeInstance(theme);
+});
+
+async function replaceEditorValue(dashboard: AgentDashboard, value: string): Promise<void> {
+	dashboard.handleInput("\n");
+	for (let index = 0; index < 80; index++) dashboard.handleInput("\x7f");
+	if (value) dashboard.handleInput(value);
+	dashboard.handleInput("\n");
+	for (let attempt = 0; attempt < 100; attempt++) {
+		if (!dashboard.render(120).join("\n").includes("Model override:")) return;
+		await Bun.sleep(5);
+	}
+	throw new Error("Dashboard model override did not settle");
+}
+
+function renderedText(dashboard: AgentDashboard): string {
+	return dashboard
+		.render(120)
+		.join("\n")
+		.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+describe("AgentDashboard model overrides", () => {
+	test("edits and clears one live override without persisting profile siblings", async () => {
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", {
+			architect: "persisted/architect:low",
+			critic: "persisted/critic:high",
+		});
+		settings.override("task.agentModelOverrides", {
+			architect: "profile/architect:medium",
+			executor: "profile/executor:low",
+		});
+		const dashboard = await AgentDashboard.create(process.cwd(), settings, 30);
+
+		await replaceEditorValue(dashboard, "user/architect:xhigh");
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			architect: "user/architect:xhigh",
+			critic: "persisted/critic:high",
+			executor: "profile/executor:low",
+		});
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			architect: "user/architect:xhigh",
+			critic: "persisted/critic:high",
+		});
+
+		settings.override("task.agentModelOverrides", {
+			architect: "profile/architect:medium",
+			executor: "profile/executor:low",
+		});
+		await replaceEditorValue(dashboard, "");
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			critic: "persisted/critic:high",
+			executor: "profile/executor:low",
+		});
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			critic: "persisted/critic:high",
+		});
+	});
+
+	test("active-profile role edits detach the profile and survive clearing its runtime layer", async () => {
+		const settings = Settings.isolated({
+			"modelProfile.default": "profile-a",
+		});
+		settings.set("task.agentModelOverrides", { critic: "persisted/critic:high" });
+		settings.override("task.agentModelOverrides", {
+			architect: "profile/architect:medium",
+			executor: "profile/executor:low",
+		});
+		let activeProfile: string | undefined = "profile-a";
+		const session = {
+			model: undefined,
+			thinkingLevel: undefined,
+			getActiveModelProfile: () => activeProfile,
+			setActiveModelProfile: (name: string | undefined) => {
+				activeProfile = name;
+			},
+			getSessionDefaultModelSelector: () => undefined,
+		};
+		const dashboard = await AgentDashboard.create(process.cwd(), settings, 30, {
+			onModelOverrideChange: async (agentName, value) => {
+				if (!value || agentName !== "architect") throw new Error("Unexpected dashboard edit");
+				materializeActiveModelProfileAssignment({
+					session,
+					settings,
+					role: "architect",
+					selector: value,
+				});
+				await settings.flushOrThrow();
+			},
+		});
+
+		await replaceEditorValue(dashboard, "user/architect:xhigh");
+
+		expect(activeProfile).toBeUndefined();
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(settings.get("task.agentModelOverrides").architect).toBe("user/architect:xhigh");
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			architect: "user/architect:xhigh",
+			critic: "persisted/critic:high",
+			executor: "profile/executor:low",
+		});
+	});
+	test("clearing an active-profile role detaches the profile and materializes sibling roles", async () => {
+		const settings = Settings.isolated({
+			"modelProfile.default": "profile-a",
+		});
+		settings.set("task.agentModelOverrides", { critic: "persisted/critic:high" });
+		settings.override("task.agentModelOverrides", {
+			architect: "profile/architect:medium",
+			executor: "profile/executor:low",
+		});
+		let activeProfile: string | undefined = "profile-a";
+		const session = {
+			model: undefined,
+			thinkingLevel: undefined,
+			getActiveModelProfile: () => activeProfile,
+			setActiveModelProfile: (name: string | undefined) => {
+				activeProfile = name;
+			},
+			getSessionDefaultModelSelector: () => undefined,
+		};
+		const dashboard = await AgentDashboard.create(process.cwd(), settings, 30, {
+			projectModelProfileShadow: { profileName: "profile-a", targetIds: ["architect"] },
+			onModelOverrideChange: async (agentName, value) => {
+				if (agentName !== "architect" || value !== undefined) throw new Error("Unexpected dashboard edit");
+				materializeActiveModelProfileAssignments({
+					session,
+					settings,
+					assignments: { architect: undefined },
+				});
+				await settings.flushOrThrow();
+			},
+		});
+
+		await replaceEditorValue(dashboard, "");
+
+		expect(activeProfile).toBeUndefined();
+		expect(settings.getGlobal("modelProfile.default")).toBeUndefined();
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			critic: "persisted/critic:high",
+			executor: "profile/executor:low",
+		});
+		expect(settings.get("task.agentModelOverrides").architect).toBeUndefined();
+		expect(renderedText(dashboard)).toContain("Override: (none)");
+		const profileNotice = renderedText(dashboard);
+		expect(profileNotice).toContain("project model profile profile-a");
+		expect(profileNotice).toContain("resumes on restart");
+	});
+	test("does not report a partial project profile for an unbound role", async () => {
+		const settings = Settings.isolated();
+		const dashboard = await AgentDashboard.create(process.cwd(), settings, 30, {
+			projectModelProfileShadow: { profileName: "profile-a", targetIds: ["executor"] },
+		});
+
+		await replaceEditorValue(dashboard, "user/architect:high");
+
+		expect(renderedText(dashboard)).not.toContain("project model profile profile-a");
+	});
+
+	test("project-backed clears keep the effective value visible and avoid a false cleared state", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-dashboard-project-"));
+		const projectDir = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		try {
+			await fs.mkdir(getProjectAgentDir(projectDir), { recursive: true });
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "config.yml"),
+				"task:\n  agentModelOverrides:\n    architect: project/architect:medium\n",
+			);
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.setAgentModelOverride("architect", "user/architect:low");
+			await settings.flushOrThrow();
+			const dashboard = await AgentDashboard.create(projectDir, settings, 30);
+
+			await replaceEditorValue(dashboard, "");
+
+			expect(settings.getGlobal("task.agentModelOverrides")).toEqual({});
+			expect(settings.get("task.agentModelOverrides").architect).toBe("project/architect:medium");
+			const text = renderedText(dashboard);
+			expect(text).toContain("project/architect:medium");
+			expect(text).toContain(
+				"Cleared user override for architect; effective override remains project/architect:medium",
+			);
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("user role overrides take effect live but project overrides resume after restart", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-dashboard-project-restart-"));
+		const projectDir = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		try {
+			await fs.mkdir(getProjectAgentDir(projectDir), { recursive: true });
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "config.yml"),
+				"task:\n  agentModelOverrides:\n    architect: project/architect:medium\n",
+			);
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const dashboard = await AgentDashboard.create(projectDir, settings, 30);
+
+			await replaceEditorValue(dashboard, "user/architect:low");
+
+			expect(settings.get("task.agentModelOverrides").architect).toBe("user/architect:low");
+			const notice = renderedText(dashboard);
+			expect(notice).toContain("Updated user override for architect to user/architect:low for this session");
+			expect(notice).toContain("project override project/architect:medium");
+			expect(notice).toContain("resumes on restart");
+
+			resetSettingsForTest();
+			const restarted = await Settings.init({ cwd: projectDir, agentDir });
+			expect(restarted.get("task.agentModelOverrides").architect).toBe("project/architect:medium");
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("shows the local effective override when flushOrThrow cannot confirm persistence", async () => {
+		const settings = Settings.isolated();
+		settings.flushOrThrow = async () => {
+			throw new Error("disk unavailable");
+		};
+		const dashboard = await AgentDashboard.create(process.cwd(), settings, 30, {
+			onModelOverrideChange: async (agentName, value) => {
+				if (agentName !== "architect" || !value) throw new Error("Unexpected dashboard edit");
+				settings.setAgentModelOverride(agentName, value);
+				await settings.flushOrThrow();
+			},
+		});
+
+		await replaceEditorValue(dashboard, "user/architect:xhigh");
+
+		expect(settings.get("task.agentModelOverrides").architect).toBe("user/architect:xhigh");
+		const notice = renderedText(dashboard);
+		expect(notice).toContain("Model override for architect is user/architect:xhigh locally");
+		expect(notice).toContain("persistence was not confirmed: disk unavailable");
+
+		const reopened = await AgentDashboard.create(process.cwd(), settings, 30);
+		const reopenedNotice = renderedText(reopened);
+		expect(reopenedNotice).toContain("Override:");
+		expect(reopenedNotice).toContain("user/architect:xhigh");
+		expect(reopenedNotice).toContain("Persistence: unconfirmed");
+		expect(reopenedNotice).toContain("Local override may not survive restart");
+
+		const retry = Promise.withResolvers<void>();
+		settings.flushOrThrow = () => retry.promise;
+		const nonsettlingRetry = await Promise.race([
+			AgentDashboard.create(process.cwd(), settings, 30),
+			Bun.sleep(100).then(() => undefined),
+		]);
+		expect(nonsettlingRetry).toBeInstanceOf(AgentDashboard);
+		expect(renderedText(nonsettlingRetry as AgentDashboard)).toContain("Persistence: unconfirmed");
+		retry.resolve();
+		await Bun.sleep(0);
+
+		settings.flushOrThrow = async () => {};
+		const confirmed = await AgentDashboard.create(process.cwd(), settings, 30);
+		expect(renderedText(confirmed)).not.toContain("Persistence: unconfirmed");
+	});
+
+	test("keeps a pending save from accepting input or reopening an editor closed with escape", async () => {
+		const settings = Settings.isolated();
+		const save = Promise.withResolvers<void>();
+		const values: string[] = [];
+		const dashboard = await AgentDashboard.create(process.cwd(), settings, 30, {
+			onModelOverrideChange: async (agentName, value) => {
+				if (agentName !== "architect" || !value) throw new Error("Unexpected dashboard edit");
+				values.push(value);
+				await save.promise;
+			},
+		});
+		let renderRequests = 0;
+		dashboard.onRequestRender = () => {
+			renderRequests += 1;
+		};
+
+		dashboard.handleInput("\n");
+		dashboard.handleInput("user/architect:low");
+		dashboard.handleInput("\n");
+		dashboard.handleInput("ignored/architect:high");
+		dashboard.handleInput("\x1b");
+		expect(values).toEqual(["user/architect:low"]);
+		expect(renderedText(dashboard)).not.toContain("Model override:");
+
+		save.resolve();
+		await Bun.sleep(0);
+
+		const text = renderedText(dashboard);
+		expect(text).not.toContain("Model override:");
+		expect(text).toContain("Background model override save completed for architect");
+		expect(renderRequests).toBeGreaterThan(0);
+	});
+});

--- a/packages/coding-agent/test/custom-model-preset-creation.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-creation.test.ts
@@ -691,7 +691,7 @@ describe("custom model preset creation", () => {
 			},
 			getActiveModelProfile: () => activeProfiles.at(-1),
 		};
-		const flushSpy = spyOn(settings, "flush").mockRejectedValueOnce(new Error("flush failed"));
+		const flushSpy = spyOn(settings, "flushOrThrow").mockRejectedValueOnce(new Error("flush failed"));
 
 		try {
 			await expect(
@@ -710,6 +710,59 @@ describe("custom model preset creation", () => {
 		expect(settings.get("modelRoles")).toEqual({ default: "old/default" });
 		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });
 		expect(activeProfiles.at(-1)).toBe("custom-default");
+	});
+	it("rejects profile deletion materialization when config persistence fails", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "custom-default",
+			displayName: "Custom Default",
+			requiredProviders: ["my-oai"],
+			modelMapping: {
+				default: "my-oai/gpt-custom:low",
+				executor: "my-oai/gpt-custom",
+			},
+			source: "user",
+		};
+		const agentDir = path.join(tempDir, "failed-materialization-settings");
+		resetSettingsForTest();
+		try {
+			const settings = await Settings.init({ agentDir, cwd: tempDir });
+			const configPath = path.join(await fs.realpath(settings.getAgentDir()), "config.yml");
+			settings.set("modelProfile.default", customProfile.name);
+			settings.setModelRole("default", "old/default");
+			await settings.flushOrThrow();
+			const session = createDeletionSession();
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (
+					typeof args[0] === "string" &&
+					args[0].startsWith(`${configPath}.`) &&
+					args[0].endsWith(".tmp") &&
+					!args[0].startsWith(`${configPath}.revisions.json.`)
+				) {
+					throw new Error("forced config write failure");
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				await expect(
+					materializeModelProfileForDeletion({
+						session,
+						settings,
+						modelRegistry: createRegistry([[customProfile.name, customProfile]]),
+						profileName: customProfile.name,
+					}),
+				).rejects.toThrow("forced config write failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir, cwd: tempDir });
+			expect(reopened.getGlobal("modelProfile.default")).toBe(customProfile.name);
+		} finally {
+			resetSettingsForTest();
+		}
 	});
 	it("preserves later durable choices while materializing a profile for deletion", async () => {
 		const customProfile: ModelProfileDefinition = {
@@ -828,6 +881,7 @@ describe("custom model preset creation", () => {
 			const settingsB = await settingsA.cloneForCwd(tempDir);
 			settingsB.setModelRole("default", "external/default");
 			settingsB.setAgentModelOverride("architect", "external/architect");
+			settingsB.setAgentModelOverride("executor", "my-oai/gpt-custom");
 			settingsB.set("modelProfile.default", "profile-b");
 			await settingsB.flushOrThrow();
 
@@ -839,6 +893,7 @@ describe("custom model preset creation", () => {
 			expect(reopened.getGlobal("task.agentModelOverrides")).toEqual({
 				architect: "external/architect",
 				critic: "old/critic",
+				executor: "my-oai/gpt-custom",
 			});
 			expect(reopened.getGlobal("modelProfile.default")).toBe("profile-b");
 		} finally {

--- a/packages/coding-agent/test/custom-model-preset-creation.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-creation.test.ts
@@ -5,13 +5,14 @@ import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
 import {
+	activateModelProfile,
 	materializeModelProfileForDeletion,
 	restoreMaterializedModelProfileForDeletion,
 } from "@gajae-code/coding-agent/config/model-profile-activation";
 import type { ModelProfileDefinition } from "@gajae-code/coding-agent/config/model-profiles";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import type { ModelProfileConfig } from "@gajae-code/coding-agent/config/models-config-schema";
-import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { CustomModelPresetWizardComponent } from "@gajae-code/coding-agent/modes/components/custom-model-preset-wizard";
 import {
 	ModelSelectorComponent,
@@ -85,6 +86,32 @@ function createRegistry(profiles: Iterable<[string, ModelProfileDefinition]> = [
 		getModelProfile: (name: string) => profileMap.get(name),
 		getApiKeyForProvider: async (providerId: string) => options.apiKeyForProvider?.(providerId) ?? "key",
 	} as unknown as ModelRegistry;
+}
+
+function createDeletionSession() {
+	let activeProfile: string | undefined;
+	let sessionDefault = "my-oai/baseline";
+	return {
+		model: currentModel("my-oai", "baseline") as Model | undefined,
+		thinkingLevel: ThinkingLevel.Low as ThinkingLevel | undefined,
+		sessionId: "deletion-session",
+		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
+			this.model = next;
+			this.thinkingLevel = thinkingLevel;
+		},
+		setActiveModelProfile(profileName: string | undefined) {
+			activeProfile = profileName;
+		},
+		getActiveModelProfile() {
+			return activeProfile;
+		},
+		getSessionDefaultModelSelector() {
+			return sessionDefault;
+		},
+		recordResumeDefaultModel(selector: string) {
+			sessionDefault = selector;
+		},
+	};
 }
 
 describe("custom model preset creation", () => {
@@ -683,6 +710,140 @@ describe("custom model preset creation", () => {
 		expect(settings.get("modelRoles")).toEqual({ default: "old/default" });
 		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });
 		expect(activeProfiles.at(-1)).toBe("custom-default");
+	});
+	it("preserves later durable choices while materializing a profile for deletion", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "custom-default",
+			displayName: "Custom Default",
+			requiredProviders: ["my-oai"],
+			modelMapping: {
+				default: "my-oai/gpt-custom:low",
+				executor: "my-oai/gpt-custom",
+				architect: "my-oai/gpt-custom",
+			},
+			source: "user",
+		};
+		const agentDir = path.join(tempDir, "forward-settings");
+		resetSettingsForTest();
+		const { promise: releaseLookup, resolve: resolveLookup } = Promise.withResolvers<void>();
+		const { promise: lookupStarted, resolve: resolveLookupStarted } = Promise.withResolvers<void>();
+		try {
+			const settingsA = await Settings.init({ agentDir, cwd: tempDir });
+			settingsA.setModelRole("default", "old/default");
+			settingsA.setAgentModelOverride("critic", "old/critic");
+			settingsA.setAgentModelOverride("architect", "my-oai/gpt-custom");
+			settingsA.set("modelProfile.default", customProfile.name);
+			await settingsA.flushOrThrow();
+			const settingsB = await settingsA.cloneForCwd(tempDir);
+			const session = createDeletionSession();
+			const baseRegistry = createRegistry([[customProfile.name, customProfile]]);
+			await activateModelProfile({
+				session,
+				settings: settingsA,
+				modelRegistry: baseRegistry,
+				profileName: customProfile.name,
+			});
+			const originalGetApiKey = baseRegistry.getApiKeyForProvider.bind(baseRegistry);
+			const gatedRegistry = {
+				...baseRegistry,
+				getApiKeyForProvider: async (...args: Parameters<ModelRegistry["getApiKeyForProvider"]>) => {
+					resolveLookupStarted();
+					await releaseLookup;
+					return originalGetApiKey(...args);
+				},
+			} as ModelRegistry;
+
+			const materializing = materializeModelProfileForDeletion({
+				session,
+				settings: settingsA,
+				modelRegistry: gatedRegistry,
+				profileName: customProfile.name,
+			});
+			await lookupStarted;
+			settingsB.setModelRole("default", "external/default");
+			settingsB.setAgentModelOverride("architect", "external/architect");
+			settingsB.set("modelProfile.default", "profile-b");
+			await settingsB.flushOrThrow();
+			resolveLookup();
+			await materializing;
+
+			expect(settingsA.get("modelRoles")).toEqual({ default: "external/default" });
+			expect(settingsA.get("task.agentModelOverrides")).toEqual({
+				architect: "external/architect",
+				critic: "old/critic",
+				executor: "my-oai/gpt-custom",
+			});
+			expect(settingsA.get("modelProfile.default")).toBe("profile-b");
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir, cwd: tempDir });
+			expect(reopened.getGlobal("modelRoles")).toEqual({ default: "external/default" });
+			expect(reopened.getGlobal("task.agentModelOverrides")).toEqual({
+				architect: "external/architect",
+				critic: "old/critic",
+				executor: "my-oai/gpt-custom",
+			});
+			expect(reopened.getGlobal("modelProfile.default")).toBe("profile-b");
+		} finally {
+			resolveLookup();
+			resetSettingsForTest();
+		}
+	});
+	it("rolls back only deletion leaves that no later writer changed", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "custom-default",
+			displayName: "Custom Default",
+			requiredProviders: ["my-oai"],
+			modelMapping: {
+				default: "my-oai/gpt-custom:low",
+				executor: "my-oai/gpt-custom",
+				architect: "my-oai/gpt-custom",
+			},
+			source: "user",
+		};
+		const agentDir = path.join(tempDir, "rollback-settings");
+		resetSettingsForTest();
+		try {
+			const settingsA = await Settings.init({ agentDir, cwd: tempDir });
+			settingsA.setModelRole("default", "old/default");
+			settingsA.setAgentModelOverride("critic", "old/critic");
+			settingsA.set("modelProfile.default", customProfile.name);
+			await settingsA.flushOrThrow();
+			const session = createDeletionSession();
+			const registry = createRegistry([[customProfile.name, customProfile]]);
+			await activateModelProfile({
+				session,
+				settings: settingsA,
+				modelRegistry: registry,
+				profileName: customProfile.name,
+			});
+			const snapshot = await materializeModelProfileForDeletion({
+				session,
+				settings: settingsA,
+				modelRegistry: registry,
+				profileName: customProfile.name,
+			});
+			expect(snapshot.previousPersistedModelRoles).toEqual({ default: "old/default" });
+			expect(snapshot.previousPersistedAgentModelOverrides).toEqual({ critic: "old/critic" });
+			const settingsB = await settingsA.cloneForCwd(tempDir);
+			settingsB.setModelRole("default", "external/default");
+			settingsB.setAgentModelOverride("architect", "external/architect");
+			settingsB.set("modelProfile.default", "profile-b");
+			await settingsB.flushOrThrow();
+
+			await restoreMaterializedModelProfileForDeletion({ settings: settingsA, session, snapshot });
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir, cwd: tempDir });
+			expect(reopened.getGlobal("modelRoles")).toEqual({ default: "external/default" });
+			expect(reopened.getGlobal("task.agentModelOverrides")).toEqual({
+				architect: "external/architect",
+				critic: "old/critic",
+			});
+			expect(reopened.getGlobal("modelProfile.default")).toBe("profile-b");
+		} finally {
+			resetSettingsForTest();
+		}
 	});
 	it("keeps a deleted custom preset committed when post-delete notification fails", async () => {
 		const unsafeDisplayName = "Custom\x1b[31m Default\x1b[0m\nRestored";

--- a/packages/coding-agent/test/custom-model-preset-creation.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-creation.test.ts
@@ -684,7 +684,7 @@ describe("custom model preset creation", () => {
 		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });
 		expect(activeProfiles.at(-1)).toBe("custom-default");
 	});
-	it("restores a deleted custom preset when post-delete notification fails", async () => {
+	it("keeps a deleted custom preset committed when post-delete notification fails", async () => {
 		const unsafeDisplayName = "Custom\x1b[31m Default\x1b[0m\nRestored";
 		const profiles = new Map<string, ModelProfileDefinition>([
 			[
@@ -771,7 +771,7 @@ describe("custom model preset creation", () => {
 			updateEditorBorderColor: () => {},
 			showStatus: () => {},
 			showError: (message: string) => {
-				expect(message).toBe("Preset delete failed: notify failed");
+				expect(message).toBe("Configuration was updated, but change notification failed: notify failed");
 			},
 			showHookConfirm: async (title: string) => {
 				confirmTitle = title;
@@ -785,13 +785,14 @@ describe("custom model preset creation", () => {
 		new SelectorController(ctx as never).showModelSelector();
 		await Bun.sleep(0);
 		await selector?.__testSelectPresetAction("custom-default", "delete");
+		await Bun.sleep(0);
 
 		expect(confirmTitle).toBe("Delete custom model preset: Custom Default Restored");
-		expect(restoredProfile?.display_name).toBe(unsafeDisplayName);
-		expect(profiles.get("custom-default")?.displayName).toBe(unsafeDisplayName);
-		expect(settings.get("modelProfile.default")).toBe("custom-default");
-		expect(settings.get("modelRoles")).toEqual({ default: "old/default" });
+		expect(restoredProfile).toBeUndefined();
+		expect(profiles.has("custom-default")).toBe(false);
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(settings.get("modelRoles")).toEqual({ default: "my-oai/gpt-custom:low" });
 		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });
-		expect(activeProfiles.at(-1)).toBe("custom-default");
+		expect(activeProfiles.at(-1)).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/custom-model-preset-creation.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-creation.test.ts
@@ -22,6 +22,7 @@ import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/s
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import type { TUI } from "@gajae-code/tui";
+import { getProjectAgentDir } from "@gajae-code/utils";
 import { YAML } from "bun";
 
 let tempDir: string;
@@ -111,6 +112,81 @@ function createDeletionSession() {
 		recordResumeDefaultModel(selector: string) {
 			sessionDefault = selector;
 		},
+	};
+}
+
+async function createDeletionControllerHarness(
+	settings: Settings,
+	profiles: Map<string, ModelProfileDefinition>,
+	initialActiveProfile?: string,
+) {
+	let selector: ModelSelectorComponent | undefined;
+	let deleteCalls = 0;
+	const errors: string[] = [];
+	const statuses: string[] = [];
+	const registry = {
+		...createRegistry(profiles),
+		getModelProfiles: () => new Map(profiles),
+		getModelProfile: (name: string) => profiles.get(name),
+		getAvailableModelProfileNames: () => [...profiles.keys()],
+		deleteCustomModelProfile: async (name: string) => {
+			deleteCalls++;
+			const profile = profiles.get(name);
+			if (!profile) throw new Error("missing profile");
+			profiles.delete(name);
+			return {
+				display_name: profile.displayName,
+				required_providers: [...profile.requiredProviders],
+				model_mapping: { ...profile.modelMapping },
+			};
+		},
+		saveCustomModelProfile: async (name: string, config: ModelProfileConfig) => {
+			profiles.set(name, {
+				name,
+				displayName: config.display_name,
+				requiredProviders: [...config.required_providers],
+				modelMapping: { ...config.model_mapping },
+				source: "user",
+			});
+			return profiles.get(name);
+		},
+		refresh: async () => {},
+	};
+	const session = {
+		...createDeletionSession(),
+		scopedModels: [],
+		modelRegistry: registry,
+		isFastForProvider: () => false,
+		isFastForSubagentProvider: () => false,
+		isFastModeActive: () => false,
+	};
+	session.setActiveModelProfile(initialActiveProfile);
+	const ctx = {
+		ui: { setFocus: () => {}, requestRender: () => {} },
+		editorContainer: {
+			clear: () => {},
+			addChild: (child: unknown) => {
+				if (child instanceof ModelSelectorComponent) selector = child;
+			},
+		},
+		editor: {},
+		settings,
+		session,
+		statusLine: { invalidate: () => {} },
+		updateEditorBorderColor: () => {},
+		showStatus: (message: string) => statuses.push(message),
+		showError: (message: string) => errors.push(message),
+		showHookConfirm: async () => true,
+		notifyConfigChanged: async () => {},
+	};
+	new SelectorController(ctx as never).showModelSelector();
+	await Bun.sleep(0);
+	if (!selector) throw new Error("Model selector did not open");
+	return {
+		selector,
+		errors,
+		statuses,
+		getDeleteCalls: () => deleteCalls,
 	};
 }
 
@@ -896,6 +972,89 @@ describe("custom model preset creation", () => {
 				executor: "my-oai/gpt-custom",
 			});
 			expect(reopened.getGlobal("modelProfile.default")).toBe("profile-b");
+		} finally {
+			resetSettingsForTest();
+		}
+	});
+	it("refuses controller deletion when the same profile is selected after materialization", async () => {
+		const profileName = "custom-default";
+		const profile: ModelProfileDefinition = {
+			name: profileName,
+			displayName: "Custom Default",
+			requiredProviders: ["my-oai"],
+			modelMapping: { default: "my-oai/gpt-custom:low" },
+			source: "user",
+		};
+		const agentDir = path.join(tempDir, "concurrent-delete-agent");
+		resetSettingsForTest();
+		try {
+			const settingsA = await Settings.init({ agentDir, cwd: tempDir });
+			settingsA.set("modelProfile.default", profileName);
+			await settingsA.flushOrThrow();
+			const settingsB = await settingsA.cloneForCwd(tempDir);
+			const profiles = new Map([[profileName, profile]]);
+			const harness = await createDeletionControllerHarness(settingsA, profiles, profileName);
+			const deleteModelProfileIfUnreferenced = settingsA.deleteModelProfileIfUnreferenced.bind(settingsA);
+			const deletionSpy = spyOn(settingsA, "deleteModelProfileIfUnreferenced").mockImplementation(
+				async (name, deleteProfile) => {
+					settingsB.set("modelProfile.default", profileName);
+					await settingsB.flushOrThrow();
+					return deleteModelProfileIfUnreferenced(name, deleteProfile);
+				},
+			);
+			try {
+				await harness.selector.__testSelectPresetAction(profileName, "delete");
+				await Bun.sleep(0);
+			} finally {
+				deletionSpy.mockRestore();
+			}
+
+			expect(harness.getDeleteCalls()).toBe(0);
+			expect(profiles.has(profileName)).toBe(true);
+			expect(harness.statuses.some(message => message.includes("Custom model preset deleted"))).toBe(false);
+			expect(harness.errors).toContain(
+				`Preset delete failed: Model profile became the default while deletion was in progress: ${profileName}`,
+			);
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir, cwd: tempDir });
+			expect(reopened.getGlobal("modelProfile.default")).toBe(profileName);
+		} finally {
+			resetSettingsForTest();
+		}
+	});
+
+	it("refuses controller deletion while the current project references the profile", async () => {
+		const profileName = "custom-project";
+		const profile: ModelProfileDefinition = {
+			name: profileName,
+			displayName: "Custom Project",
+			requiredProviders: ["my-oai"],
+			modelMapping: { default: "my-oai/gpt-custom:low" },
+			source: "user",
+		};
+		const agentDir = path.join(tempDir, "project-reference-agent");
+		const projectDir = path.join(tempDir, "referencing-project");
+		await fs.mkdir(getProjectAgentDir(projectDir), { recursive: true });
+		await Bun.write(
+			path.join(getProjectAgentDir(projectDir), "config.yml"),
+			YAML.stringify({ modelProfile: { default: profileName } }),
+		);
+		resetSettingsForTest();
+		try {
+			const settings = await Settings.init({ agentDir, cwd: projectDir });
+			const profiles = new Map([[profileName, profile]]);
+			const harness = await createDeletionControllerHarness(settings, profiles);
+			await harness.selector.__testSelectPresetAction(profileName, "delete");
+			await Bun.sleep(0);
+
+			expect(harness.getDeleteCalls()).toBe(0);
+			expect(profiles.has(profileName)).toBe(true);
+			expect(harness.statuses.some(message => message.includes("Custom model preset deleted"))).toBe(false);
+			expect(harness.errors).toContain(
+				`Preset delete failed: Cannot delete model profile referenced by the current project: ${profileName}`,
+			);
+			expect(settings.getProject("modelProfile.default")).toBe(profileName);
 		} finally {
 			resetSettingsForTest();
 		}

--- a/packages/coding-agent/test/login-preset-recommendation.test.ts
+++ b/packages/coding-agent/test/login-preset-recommendation.test.ts
@@ -101,6 +101,9 @@ function createControllerContext(
 		showHookConfirm: vi.fn(async () => options.confirm ?? false),
 		showStatus: vi.fn(),
 		showError: vi.fn(),
+		statusLine: { invalidate: vi.fn() },
+		updateEditorBorderColor: vi.fn(),
+		notifyConfigChanged: vi.fn(async () => {}),
 	};
 	return { ctx, settings, session, setCalls };
 }
@@ -128,6 +131,7 @@ describe("login preset recommendation", () => {
 		expect(session.setActiveModelProfile).toHaveBeenCalledWith("codex-medium");
 		expect(settings.get("modelProfile.default")).toBeUndefined();
 		expect(setCalls).not.toContainEqual({ path: "modelProfile.default", value: "codex-medium" });
+		expect(ctx.notifyConfigChanged).toHaveBeenCalledTimes(1);
 	});
 
 	test("declining the post-login recommendation performs no mutation", async () => {
@@ -151,13 +155,13 @@ describe("login preset recommendation", () => {
 		expect(session.setModelTemporaryCalls).toEqual([]);
 	});
 
-	test("login with default profile setting shows hint instead of prompting", async () => {
+	test("configured startup profile does not mask an explicitly detached session", async () => {
 		const { ctx, session } = createControllerContext({ defaultProfile: "codex-eco" });
 
 		await login(ctx, "openai-codex");
 
-		expect(ctx.showHookConfirm).not.toHaveBeenCalled();
-		expect(ctx.showStatus).toHaveBeenCalledWith("Preset codex-medium is available in /model.");
+		expect(ctx.showHookConfirm).toHaveBeenCalledWith("Apply codex-medium now?", "");
+		expect(ctx.showStatus).not.toHaveBeenCalledWith("Preset codex-medium is available in /model.");
 		expect(session.setModelTemporaryCalls).toEqual([]);
 	});
 

--- a/packages/coding-agent/test/model-profile-activation-redteam.test.ts
+++ b/packages/coding-agent/test/model-profile-activation-redteam.test.ts
@@ -65,7 +65,7 @@ function instrumentSettings(settings: Settings) {
 		overrideCalls.push(path);
 		return originalOverride(path, value);
 	}) as typeof settings.override;
-	settings.flush = async () => {
+	settings.flushOrThrow = async () => {
 		flushCount += 1;
 	};
 	return {

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -453,6 +453,82 @@ describe("model profile activation", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+	test("session-only materialization preserves a later durable selection of the same profile", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-profile-materialization-same-default-"));
+		resetSettingsForTest();
+		try {
+			const settingsA = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const settingsB = await settingsA.cloneForCwd(tempDir);
+			const session = fakeSession();
+			await activateModelProfile({
+				session,
+				modelRegistry: fakeRegistry(),
+				settings: settingsA,
+				profileName: "profile-a",
+			});
+
+			settingsB.set("modelProfile.default", "profile-a");
+			await settingsB.flushOrThrow();
+			expect(
+				materializeActiveModelProfileAssignment({
+					session,
+					settings: settingsA,
+					role: "executor",
+					selector: "provider-a/manual-executor:low",
+				}),
+			).toBe(true);
+			await settingsA.flushOrThrow();
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			expect(reopened.getGlobal("modelProfile.default")).toBe("profile-a");
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("equal explicit materialization rotates ownership against stale conditional writers", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-profile-equal-explicit-owner-"));
+		resetSettingsForTest();
+		try {
+			const settingsA = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			settingsA.setAgentModelOverride("executor", "provider-a/manual-executor:low");
+			await settingsA.flushOrThrow();
+			const staleSettings = await settingsA.cloneForCwd(tempDir);
+			const session = fakeSession();
+			await activateModelProfile({
+				session,
+				modelRegistry: fakeRegistry(),
+				settings: settingsA,
+				profileName: "profile-a",
+			});
+
+			expect(
+				materializeActiveModelProfileAssignment({
+					session,
+					settings: settingsA,
+					role: "executor",
+					selector: "provider-a/manual-executor:low",
+				}),
+			).toBe(true);
+			await settingsA.flushOrThrow();
+			staleSettings.setAgentModelOverrideIfUnchanged(
+				"executor",
+				"provider-a/manual-executor:low",
+				"provider-a/stale-executor:low",
+			);
+			await staleSettings.flushOrThrow();
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			expect(reopened.getGlobal("task.agentModelOverrides")).toMatchObject({
+				executor: "provider-a/manual-executor:low",
+			});
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 
 	test("failed profile detachment retains transition state for the next activation", async () => {
 		const session = fakeSession();

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -328,6 +328,15 @@ describe("model profile activation", () => {
 			persistedAgents.push(agentName);
 			originalSetAgentModelOverride(agentName, selector);
 		};
+		const originalSetAgentModelOverrideIfUnchanged = settings.setAgentModelOverrideIfUnchanged.bind(settings);
+		settings.setAgentModelOverrideIfUnchanged = (
+			agentName: string,
+			expectedSelector: string | undefined,
+			selector: string | undefined,
+		) => {
+			persistedAgents.push(agentName);
+			originalSetAgentModelOverrideIfUnchanged(agentName, expectedSelector, selector);
+		};
 
 		materializeActiveModelProfileAssignment({
 			session,
@@ -338,6 +347,111 @@ describe("model profile activation", () => {
 
 		expect(persistedAgents).toEqual(["executor", "architect"]);
 		expect(persistedAgents).not.toContain("critic");
+	});
+	test("materialization preserves pending explicit sibling and profile choices in the same Settings instance", async () => {
+		const settings = Settings.isolated();
+		const session = fakeSession();
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+
+		settings.setAgentModelOverride("architect", "provider-a/user-architect:medium");
+		settings.set("modelProfile.default", "profile-b");
+		expect(
+			materializeActiveModelProfileAssignment({
+				session,
+				settings,
+				role: "executor",
+				selector: "provider-a/manual-executor:low",
+			}),
+		).toBe(true);
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			architect: "provider-a/user-architect:medium",
+			executor: "provider-a/manual-executor:low",
+		});
+		expect(settings.get("modelProfile.default")).toBe("profile-b");
+	});
+	test("materialization preserves an already-flushed profile choice from the same Settings instance", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-profile-materialization-owner-"));
+		resetSettingsForTest();
+		try {
+			const settings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const session = fakeSession();
+			await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+
+			settings.set("modelProfile.default", "profile-b");
+			await settings.flushOrThrow();
+			expect(
+				materializeActiveModelProfileAssignment({
+					session,
+					settings,
+					role: "executor",
+					selector: "provider-a/manual-executor:low",
+				}),
+			).toBe(true);
+			await settings.flushOrThrow();
+
+			expect(settings.get("modelProfile.default")).toBe("profile-b");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				architect: "provider-a/architect",
+				executor: "provider-a/manual-executor:low",
+			});
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("materializing one profile role preserves a later durable sibling assignment", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-profile-materialization-sibling-"));
+		resetSettingsForTest();
+		try {
+			const settingsA = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const settingsB = await settingsA.cloneForCwd(tempDir);
+			const session = fakeSession();
+
+			await activateModelProfile({
+				session,
+				modelRegistry: fakeRegistry(),
+				settings: settingsA,
+				profileName: "profile-a",
+			});
+			settingsB.setAgentModelOverride("architect", "provider-a/user-architect:medium");
+			settingsB.setAgentModelOverride("executor", "provider-a/external-executor:medium");
+			settingsB.set("modelProfile.default", "profile-b");
+			settingsB.setModelRole("default", "provider-a/external-default:medium");
+			await settingsB.flushOrThrow();
+
+			expect(
+				materializeActiveModelProfileAssignment({
+					session,
+					settings: settingsA,
+					role: "executor",
+					selector: "provider-a/manual-executor:low",
+				}),
+			).toBe(true);
+			await settingsA.flushOrThrow();
+			expect(settingsA.get("task.agentModelOverrides")).toEqual({
+				architect: "provider-a/user-architect:medium",
+				executor: "provider-a/manual-executor:low",
+			});
+			expect(settingsA.get("modelRoles")).toEqual({
+				default: "provider-a/external-default:medium",
+			});
+			expect(settingsA.get("modelProfile.default")).toBe("profile-b");
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			expect(reopened.getGlobal("task.agentModelOverrides")).toEqual({
+				architect: "provider-a/user-architect:medium",
+				executor: "provider-a/manual-executor:low",
+			});
+			expect(reopened.getGlobal("modelProfile.default")).toBe("profile-b");
+			expect(reopened.getGlobal("modelRoles")).toEqual({
+				default: "provider-a/external-default:medium",
+			});
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	test("failed profile detachment retains transition state for the next activation", async () => {
@@ -386,9 +500,10 @@ describe("model profile activation", () => {
 
 	test("role-only materialization persists the active profile default, not a transient live model", async () => {
 		const session = fakeSession(model("provider-c", "default"));
-		const settings = Settings.isolated();
-		settings.set("modelRoles", { default: "configured/default:medium" });
-		settings.set("task.agentModelOverrides", { critic: "configured/critic:high" });
+		const settings = Settings.isolated({
+			modelRoles: { default: "configured/default:medium" },
+			"task.agentModelOverrides": { critic: "configured/critic:high" },
+		});
 		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
 
 		session.model = model("provider-c", "architect");

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
 import {
@@ -8,11 +11,12 @@ import {
 	materializeActiveModelProfileAssignment,
 	materializeActiveModelProfileAssignments,
 	prepareModelProfileActivation,
+	resolveProjectModelProfileShadow,
 } from "../src/config/model-profile-activation";
 import type { ModelProfileDefinition } from "../src/config/model-profiles";
 import { BUILTIN_MODEL_PROFILES, mergeModelProfiles } from "../src/config/model-profiles";
 import type { ModelRegistry } from "../src/config/model-registry";
-import { Settings } from "../src/config/settings";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
 
 const model = (provider: string, id: string, thinking?: Model["thinking"]): Model =>
 	({
@@ -90,23 +94,40 @@ function fakeRegistry(options?: { missingProviders?: string[]; profiles?: ModelP
 	};
 }
 
-function fakeSession(initial = model("provider-a", "initial")) {
+function fakeSession(initial = model("provider-a", "initial"), initialResumeDefault?: string) {
 	let activeModelProfile: string | undefined;
+	let resumeDefault = initialResumeDefault;
 	return {
 		model: initial as Model | undefined,
 		thinkingLevel: ThinkingLevel.Low as ThinkingLevel | undefined,
 		sessionId: "session-1",
 		setModelTemporaryCalls: [] as Array<{ model: Model; thinkingLevel?: ThinkingLevel }>,
-		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
+		resumeDefaultChanges: [] as string[],
+		async setModelTemporary(
+			next: Model,
+			thinkingLevel?: ThinkingLevel,
+			options?: { persistAsSessionDefault?: boolean },
+		) {
 			this.setModelTemporaryCalls.push({ model: next, thinkingLevel });
 			this.model = next;
 			this.thinkingLevel = thinkingLevel;
+			if (options?.persistAsSessionDefault) {
+				resumeDefault = `${next.provider}/${next.id}`;
+				this.resumeDefaultChanges.push(resumeDefault);
+			}
 		},
 		setActiveModelProfile(name: string | undefined) {
 			activeModelProfile = name;
 		},
 		getActiveModelProfile() {
 			return activeModelProfile;
+		},
+		getSessionDefaultModelSelector() {
+			return resumeDefault;
+		},
+		recordResumeDefaultModel(selector: string) {
+			resumeDefault = selector;
+			this.resumeDefaultChanges.push(selector);
 		},
 	};
 }
@@ -127,6 +148,24 @@ describe("model profile activation", () => {
 		expect(prepared.agentModelOverrides).toEqual({
 			executor: "provider-b/executor",
 			architect: "provider-a/architect",
+		});
+	});
+	test("project profile shadow resolution honors fallback aliases and partial bindings", () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "codex-medium",
+				requiredProviders: ["provider-a"],
+				modelMapping: { architect: "provider-a/architect" },
+				source: "user",
+			},
+		];
+		const settings = Settings.isolated();
+		settings.getProject = ((path: string) =>
+			path === "modelProfile.default" ? "codex-standard" : undefined) as typeof settings.getProject;
+
+		expect(resolveProjectModelProfileShadow(settings, fakeRegistry({ profiles }))).toEqual({
+			profileName: "codex-medium",
+			targetIds: ["architect"],
 		});
 	});
 
@@ -202,6 +241,53 @@ describe("model profile activation", () => {
 		expect(session.getActiveModelProfile()).toBe("profile-a");
 	});
 
+	test("switching profiles drops omitted assignments back to the pre-profile baseline", async () => {
+		const session = fakeSession(model("provider-c", "default"));
+		const settings = Settings.isolated();
+		settings.set("modelRoles", { default: "provider-c/default:medium" });
+		settings.set("task.agentModelOverrides", {
+			architect: "configured/architect:low",
+			critic: "configured/critic:high",
+		});
+		const registry = fakeRegistry({
+			profiles: [
+				{
+					name: "profile-a",
+					requiredProviders: ["provider-a", "provider-b"],
+					modelMapping: {
+						default: "provider-a/default:high",
+						executor: "provider-b/executor",
+						architect: "provider-a/architect",
+					},
+					source: "user",
+				},
+				{
+					name: "profile-b",
+					requiredProviders: ["provider-c"],
+					modelMapping: {
+						default: "provider-c/default:low",
+						executor: "provider-c/executor",
+					},
+					source: "user",
+				},
+			],
+		});
+
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "profile-a" });
+		expect(settings.get("task.agentModelOverrides").architect).toBe("provider-a/architect");
+
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "profile-b" });
+
+		expect(session.model?.provider).toBe("provider-c");
+		expect(session.model?.id).toBe("default");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			architect: "configured/architect:low",
+			critic: "configured/critic:high",
+			executor: "provider-c/executor",
+		});
+		expect(session.getActiveModelProfile()).toBe("profile-b");
+	});
+
 	test("materializing a profile role override persists the full effective assignment set and clears the profile", async () => {
 		const session = fakeSession();
 		const settings = Settings.isolated({
@@ -229,6 +315,213 @@ describe("model profile activation", () => {
 		});
 		expect(settings.get("modelProfile.default")).toBeUndefined();
 		expect(session.getActiveModelProfile()).toBeUndefined();
+	});
+
+	test("materialization persists only leaves changed from the loaded global baseline", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", { critic: "configured/critic:high" });
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+		const persistedAgents: string[] = [];
+		const originalSetAgentModelOverride = settings.setAgentModelOverride.bind(settings);
+		settings.setAgentModelOverride = (agentName: string, selector: string) => {
+			persistedAgents.push(agentName);
+			originalSetAgentModelOverride(agentName, selector);
+		};
+
+		materializeActiveModelProfileAssignment({
+			session,
+			settings,
+			role: "executor",
+			selector: "provider-c/executor:medium",
+		});
+
+		expect(persistedAgents).toEqual(["executor", "architect"]);
+		expect(persistedAgents).not.toContain("critic");
+	});
+
+	test("failed profile detachment retains transition state for the next activation", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated();
+		const profileA = fakeRegistry().getModelProfile("profile-a");
+		if (!profileA) throw new Error("missing profile-a fixture");
+		const registry = fakeRegistry({
+			profiles: [
+				profileA,
+				{
+					name: "profile-b",
+					requiredProviders: ["provider-c"],
+					modelMapping: {
+						default: "provider-c/default:low",
+						executor: "provider-c/executor",
+					},
+					source: "user",
+				},
+			],
+		});
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "profile-a" });
+		const setActiveModelProfile = session.setActiveModelProfile.bind(session);
+		session.setActiveModelProfile = (name: string | undefined) => {
+			if (name === undefined) throw new Error("detach failed");
+			setActiveModelProfile(name);
+		};
+
+		expect(() =>
+			materializeActiveModelProfileAssignment({
+				session,
+				settings,
+				role: "critic",
+				selector: "provider-c/critic:low",
+			}),
+		).toThrow("detach failed");
+		expect(session.getActiveModelProfile()).toBe("profile-a");
+
+		session.setActiveModelProfile = setActiveModelProfile;
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "profile-b" });
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-c/executor",
+		});
+	});
+
+	test("role-only materialization persists the active profile default, not a transient live model", async () => {
+		const session = fakeSession(model("provider-c", "default"));
+		const settings = Settings.isolated();
+		settings.set("modelRoles", { default: "configured/default:medium" });
+		settings.set("task.agentModelOverrides", { critic: "configured/critic:high" });
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+
+		session.model = model("provider-c", "architect");
+		session.thinkingLevel = ThinkingLevel.Low;
+		const materialized = materializeActiveModelProfileAssignment({
+			session,
+			settings,
+			role: "executor",
+			selector: "provider-c/executor:medium",
+		});
+
+		expect(materialized).toBe(true);
+		expect(settings.getGlobal("modelRoles")).toEqual({
+			default: "provider-a/default:high",
+		});
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			architect: "provider-a/architect",
+			critic: "configured/critic:high",
+			executor: "provider-c/executor:medium",
+		});
+	});
+	test("materialization uses an activation effort override for the active profile DEFAULT", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated();
+		await activateModelProfile(
+			{ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" },
+			{ thinkingLevelOverride: ThinkingLevel.Low },
+		);
+
+		expect(
+			materializeActiveModelProfileAssignments({
+				session,
+				settings,
+				assignments: { executor: "provider-c/executor:medium" },
+			}),
+		).toBe(true);
+		expect(settings.getGlobal("modelRoles")).toEqual({
+			default: "provider-a/default:low",
+		});
+	});
+	test("role-only profile detach preserves the exact persisted DEFAULT selector", async () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "role-only",
+				requiredProviders: ["provider-b"],
+				modelMapping: { executor: "provider-b/executor:low" },
+				source: "user",
+			},
+		];
+		const settings = Settings.isolated();
+		settings.set("modelRoles", { default: "configured/resume:high" });
+		const session = fakeSession(model("provider-c", "default"), "provider-c/resume");
+		await activateModelProfile({
+			session,
+			modelRegistry: fakeRegistry({ profiles }),
+			settings,
+			profileName: "role-only",
+		});
+
+		expect(
+			materializeActiveModelProfileAssignment({
+				session,
+				settings,
+				role: "executor",
+				selector: "provider-c/executor:medium",
+			}),
+		).toBe(true);
+		expect(settings.getGlobal("modelRoles")).toEqual({
+			default: "configured/resume:high",
+		});
+	});
+
+	test("suffixless profile DEFAULT remains inherited when detached", async () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "inherits-effort",
+				requiredProviders: ["provider-a"],
+				modelMapping: {
+					default: "provider-a/default",
+					executor: "provider-b/executor:low",
+				},
+				source: "user",
+			},
+		];
+		const settings = Settings.isolated({ defaultThinkingLevel: ThinkingLevel.High });
+		const session = fakeSession();
+		await activateModelProfile(
+			{
+				session,
+				modelRegistry: fakeRegistry({ profiles }),
+				settings,
+				profileName: "inherits-effort",
+			},
+			{ thinkingLevelOverride: ThinkingLevel.High },
+		);
+
+		expect(
+			materializeActiveModelProfileAssignment({
+				session,
+				settings,
+				role: "executor",
+				selector: "provider-c/executor:medium",
+			}),
+		).toBe(true);
+		expect(settings.getGlobal("modelRoles")).toEqual({
+			default: "provider-a/default",
+		});
+		expect(settings.get("defaultThinkingLevel")).toBe(ThinkingLevel.High);
+	});
+
+	test("detached sessions do not re-materialize a still-configured project default", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated();
+		settings.set("modelProfile.default", "profile-a");
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+		expect(
+			materializeActiveModelProfileAssignment({
+				session,
+				settings,
+				role: "executor",
+				selector: "provider-c/executor:medium",
+			}),
+		).toBe(true);
+
+		settings.override("modelProfile.default", "profile-a");
+		expect(
+			materializeActiveModelProfileAssignment({
+				session,
+				settings,
+				role: "critic",
+				selector: "provider-c/architect:low",
+			}),
+		).toBe(false);
 	});
 
 	test("materializing a default override stores the selected default and clears the profile", async () => {
@@ -301,9 +594,168 @@ describe("model profile activation", () => {
 		expect(session.getActiveModelProfile()).toBeUndefined();
 	});
 
-	test("--default persists profile default, clears persisted assignments, and flushes", async () => {
+	test("switching profiles preserves an explicit role clear instead of resurrecting the saved baseline", async () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "profile-a",
+				requiredProviders: ["provider-a"],
+				modelMapping: { critic: "provider-a/architect" },
+				source: "user",
+			},
+			{
+				name: "profile-b",
+				requiredProviders: ["provider-b"],
+				modelMapping: { executor: "provider-b/executor" },
+				source: "user",
+			},
+		];
+		const settings = Settings.isolated();
+		settings.setAgentModelOverride("critic", "user/critic");
+		settings.override("task.agentModelOverrides", { critic: "user/critic" });
+		const session = fakeSession();
+
+		await activateModelProfile({
+			session,
+			modelRegistry: fakeRegistry({ profiles }),
+			settings,
+			profileName: "profile-a",
+		});
+		settings.clearAgentModelOverride("critic");
+		await activateModelProfile({
+			session,
+			modelRegistry: fakeRegistry({ profiles }),
+			settings,
+			profileName: "profile-b",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-b/executor" });
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({});
+	});
+
+	test("materializing one role does not restore another profile role that the user cleared", async () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "profile-a",
+				requiredProviders: ["provider-a", "provider-b"],
+				modelMapping: {
+					architect: "provider-a/architect",
+					executor: "provider-b/executor",
+				},
+				source: "user",
+			},
+		];
+		const settings = Settings.isolated();
+		const session = fakeSession();
+		await activateModelProfile({
+			session,
+			modelRegistry: fakeRegistry({ profiles }),
+			settings,
+			profileName: "profile-a",
+		});
+
+		settings.clearAgentModelOverride("architect");
+		materializeActiveModelProfileAssignment({
+			session,
+			settings,
+			role: "executor",
+			selector: "provider-c/executor:low",
+		});
+		settings.clearOverride("task.agentModelOverrides");
+
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			executor: "provider-c/executor:low",
+		});
+	});
+
+	test("failed persisted profile switch detaches to baseline and retries without omitted roles", async () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "profile-a",
+				requiredProviders: ["provider-a"],
+				modelMapping: { architect: "provider-a/architect" },
+				source: "user",
+			},
+			{
+				name: "profile-b",
+				requiredProviders: ["provider-b"],
+				modelMapping: { executor: "provider-b/executor" },
+				source: "user",
+			},
+		];
+		const registry = fakeRegistry({ profiles });
+		const settings = Settings.isolated();
+		const session = fakeSession();
+		await activateModelProfile(
+			{ session, modelRegistry: registry, settings, profileName: "profile-a" },
+			{ persistDefault: true },
+		);
+		const durableFlush = settings.flushOrThrow.bind(settings);
+		let failOnce = true;
+		settings.flushOrThrow = async () => {
+			if (failOnce) {
+				failOnce = false;
+				throw new Error("flush failed");
+			}
+			await durableFlush();
+		};
+
+		await expect(
+			activateModelProfile(
+				{ session, modelRegistry: registry, settings, profileName: "profile-b" },
+				{ persistDefault: true },
+			),
+		).rejects.toThrow("flush failed");
+		expect(session.getActiveModelProfile()).toBeUndefined();
+		expect(settings.get("task.agentModelOverrides")).toEqual({});
+
+		await activateModelProfile(
+			{ session, modelRegistry: registry, settings, profileName: "profile-b" },
+			{ persistDefault: true },
+		);
+		expect(session.getActiveModelProfile()).toBe("profile-b");
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-b/executor" });
+		expect(settings.get("task.agentModelOverrides").architect).toBeUndefined();
+	});
+
+	test("role-only switching preserves the pre-profile resume default and configured effort", async () => {
+		const transientModel = model("provider-c", "default");
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "profile-a",
+				requiredProviders: ["provider-a"],
+				modelMapping: { default: "provider-a/default:high" },
+				source: "user",
+			},
+			{
+				name: "role-only-b",
+				requiredProviders: ["provider-b"],
+				modelMapping: { executor: "provider-b/executor:low" },
+				source: "user",
+			},
+		];
+		const settings = Settings.isolated();
+		settings.set("defaultThinkingLevel", ThinkingLevel.Medium);
+		const session = fakeSession(transientModel, "provider-a/resume");
+		session.thinkingLevel = ThinkingLevel.XHigh;
+		const registry = fakeRegistry({ profiles });
+
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "profile-a" });
+		await activateModelProfile(
+			{ session, modelRegistry: registry, settings, profileName: "role-only-b" },
+			{ persistDefault: true },
+		);
+
+		expect(session.model).toBe(transientModel);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.XHigh);
+		expect(session.getSessionDefaultModelSelector()).toBe("provider-a/resume");
+		expect(settings.getGlobal("defaultThinkingLevel")).toBe(ThinkingLevel.Medium);
+	});
+
+	test("--default persists the profile while retaining inherited role defaults", async () => {
 		const session = fakeSession();
 		const settings = Settings.isolated();
+		settings.set("modelRoles", { default: "configured/default" });
+		settings.set("task.agentModelOverrides", { critic: "configured/critic" });
 		const setCalls: string[] = [];
 		const originalSet = settings.set.bind(settings);
 		settings.set = ((path: never, value: never) => {
@@ -311,7 +763,7 @@ describe("model profile activation", () => {
 			return originalSet(path, value);
 		}) as typeof settings.set;
 		let flushCount = 0;
-		settings.flush = async () => {
+		settings.flushOrThrow = async () => {
 			flushCount += 1;
 		};
 
@@ -320,16 +772,136 @@ describe("model profile activation", () => {
 			{ persistDefault: true },
 		);
 
-		expect(setCalls).toEqual([
-			"modelRoles",
-			"task.agentModelOverrides",
-			"defaultThinkingLevel",
-			"modelProfile.default",
-		]);
+		expect(setCalls).toEqual(["defaultThinkingLevel", "modelProfile.default"]);
+		expect(settings.getGlobal("modelRoles")).toEqual({ default: "configured/default" });
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({ critic: "configured/critic" });
 		expect(settings.get("defaultThinkingLevel")).toBe(ThinkingLevel.High);
 		expect(settings.get("modelProfile.default")).toBe("profile-a");
 		expect(flushCount).toBe(1);
 		expect(session.getActiveModelProfile()).toBe("profile-a");
+	});
+
+	test("role-only profile effort remains consistent after durable restart", async () => {
+		const baselineModel = model("openai-codex", "gpt-5.6-sol", {
+			mode: "effort",
+			minLevel: ThinkingLevel.Low,
+			maxLevel: ThinkingLevel.Max,
+		});
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "profile-a",
+				requiredProviders: ["openai-codex"],
+				modelMapping: { default: "openai-codex/gpt-5.6-sol:xhigh" },
+				source: "user",
+			},
+			{
+				name: "role-only-b",
+				requiredProviders: ["openai-codex"],
+				modelMapping: { executor: "openai-codex/gpt-5.6-terra:low" },
+				source: "user",
+			},
+		];
+		const registry = fakeRegistry({ profiles });
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-role-only-profile-"));
+		try {
+			const session = fakeSession(baselineModel);
+			const settings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			settings.set("defaultThinkingLevel", ThinkingLevel.Low);
+			await settings.flushOrThrow();
+
+			await activateModelProfile(
+				{ session, modelRegistry: registry, settings, profileName: "profile-a" },
+				{ persistDefault: true },
+			);
+			expect(session.thinkingLevel).toBe(ThinkingLevel.XHigh);
+
+			await activateModelProfile(
+				{ session, modelRegistry: registry, settings, profileName: "role-only-b" },
+				{ persistDefault: true },
+			);
+			expect(session.model).toBe(baselineModel);
+			expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
+			expect(settings.getGlobal("defaultThinkingLevel")).toBe(ThinkingLevel.Low);
+			expect(settings.getGlobal("modelProfile.default")).toBe("role-only-b");
+
+			resetSettingsForTest();
+			const restartedSettings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const restartedProfile = restartedSettings.getGlobal("modelProfile.default");
+			if (!restartedProfile) throw new Error("Expected persisted model profile");
+			const restartedSession = fakeSession(baselineModel);
+			restartedSession.thinkingLevel = restartedSettings.get("defaultThinkingLevel");
+			await activateModelProfile(
+				{
+					session: restartedSession,
+					modelRegistry: registry,
+					settings: restartedSettings,
+					profileName: restartedProfile,
+				},
+				{ thinkingLevelOverride: restartedSettings.get("defaultThinkingLevel") },
+			);
+
+			expect(restartedProfile).toBe("role-only-b");
+			expect(restartedSettings.getGlobal("defaultThinkingLevel")).toBe(ThinkingLevel.Low);
+			expect(restartedSession.model).toBe(baselineModel);
+			expect(restartedSession.thinkingLevel).toBe(ThinkingLevel.Low);
+			expect(restartedSession.getActiveModelProfile()).toBe("role-only-b");
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("an effort-less profile switch applies the configured default after a non-reasoning session and survives restart", async () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "implicit-effort",
+				requiredProviders: ["openai-codex"],
+				modelMapping: { default: "openai-codex/gpt-5.6-sol" },
+				source: "user",
+			},
+		];
+		const registry = fakeRegistry({ profiles });
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-implicit-profile-effort-"));
+		try {
+			const session = fakeSession(model("provider-c", "non-reasoning"));
+			session.thinkingLevel = undefined;
+			const settings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			settings.set("defaultThinkingLevel", ThinkingLevel.High);
+			await settings.flushOrThrow();
+
+			await activateModelProfile(
+				{ session, modelRegistry: registry, settings, profileName: "implicit-effort" },
+				{ persistDefault: true },
+			);
+
+			expect(session.model?.id).toBe("gpt-5.6-sol");
+			expect(session.thinkingLevel as ThinkingLevel | undefined).toBe(ThinkingLevel.High);
+			expect(settings.getGlobal("defaultThinkingLevel")).toBe(ThinkingLevel.High);
+			expect(settings.getGlobal("modelProfile.default")).toBe("implicit-effort");
+
+			resetSettingsForTest();
+			const restartedSettings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const restartedProfile = restartedSettings.getGlobal("modelProfile.default");
+			if (!restartedProfile) throw new Error("Expected persisted model profile");
+			const restartedSession = fakeSession(model("provider-c", "non-reasoning"));
+			restartedSession.thinkingLevel = undefined;
+
+			await activateModelProfile(
+				{
+					session: restartedSession,
+					modelRegistry: registry,
+					settings: restartedSettings,
+					profileName: restartedProfile,
+				},
+				{ thinkingLevelOverride: restartedSettings.get("defaultThinkingLevel") },
+			);
+
+			expect(restartedSettings.getGlobal("defaultThinkingLevel")).toBe(ThinkingLevel.High);
+			expect(restartedSession.model?.id).toBe("gpt-5.6-sol");
+			expect(restartedSession.thinkingLevel as ThinkingLevel | undefined).toBe(ThinkingLevel.High);
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	test("missing credentials hard-block before mutation", async () => {
@@ -372,7 +944,35 @@ describe("model profile activation", () => {
 		).rejects.toThrow('Unknown model profile "missing". Available profiles: alpha, beta');
 	});
 
-	test("apply rolls back runtime changes when persistence throws", async () => {
+	test("rolls back when setModelTemporary mutates before rejecting", async () => {
+		const initialModel = model("provider-c", "default");
+		const session = fakeSession(initialModel, "provider-c/resume");
+		session.thinkingLevel = ThinkingLevel.Low;
+		const originalSetModelTemporary = session.setModelTemporary.bind(session);
+		let rejectAfterMutation = true;
+		session.setModelTemporary = async (next, thinkingLevel, options) => {
+			await originalSetModelTemporary(next, thinkingLevel, options);
+			if (rejectAfterMutation) {
+				rejectAfterMutation = false;
+				throw new Error("prompt refresh failed");
+			}
+		};
+
+		await expect(
+			activateModelProfile({
+				session,
+				modelRegistry: fakeRegistry(),
+				settings: Settings.isolated(),
+				profileName: "profile-a",
+			}),
+		).rejects.toThrow("prompt refresh failed");
+
+		expect(session.model).toBe(initialModel);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
+		expect(session.getSessionDefaultModelSelector()).toBe("provider-c/resume");
+		expect(session.getActiveModelProfile()).toBeUndefined();
+	});
+	test("detaches an ambiguous persisted activation without stale compensation", async () => {
 		const session = fakeSession();
 		const settings = Settings.isolated({
 			"task.agentModelOverrides": { executor: "provider-a/original" },
@@ -384,7 +984,7 @@ describe("model profile activation", () => {
 			settings,
 			profileName: "profile-a",
 		});
-		settings.flush = async () => {
+		settings.flushOrThrow = async () => {
 			throw new Error("flush failed");
 		};
 
@@ -395,8 +995,8 @@ describe("model profile activation", () => {
 		expect(session.model?.id).toBe("initial");
 		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
 		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/original" });
-		expect(settings.get("modelProfile.default")).toBeUndefined();
-		expect(settings.get("defaultThinkingLevel")).toBe(ThinkingLevel.Low);
+		expect(settings.get("modelProfile.default")).toBe("profile-a");
+		expect(settings.getGlobal("defaultThinkingLevel")).toBe(ThinkingLevel.High);
 		expect(session.getActiveModelProfile()).toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -7,7 +7,7 @@ import { kNoAuth, MODEL_ROLE_IDS, ModelRegistry } from "@gajae-code/coding-agent
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { addApiCompatibleProvider } from "@gajae-code/coding-agent/setup/provider-onboarding";
-import { $credentialEnv, hookFetch, Snowflake } from "@gajae-code/utils";
+import { $credentialEnv, getProjectAgentDir, hookFetch, Snowflake } from "@gajae-code/utils";
 
 describe("model roles", () => {
 	test("default is the only built-in model role", () => {
@@ -2710,6 +2710,51 @@ describe("ModelRegistry", () => {
 		expect(Settings.instance.get("task.agentModelOverrides").executor).toBe("proxy/executor-selector");
 	});
 
+	test("configured bindings do not copy project-only siblings into runtime or global settings", async () => {
+		const projectDir = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		fs.mkdirSync(getProjectAgentDir(projectDir), { recursive: true });
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(getProjectAgentDir(projectDir), "config.yml"),
+			"modelRoles:\n  smol: project/smol\ntask:\n  agentModelOverrides:\n    planner: project/planner\n",
+		);
+		writeRawModelsConfig({
+			modelBindings: {
+				modelRoles: { default: "proxy/default-selector" },
+				agentModelOverrides: { executor: "proxy/executor-selector" },
+			},
+		});
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+		registry.applyConfiguredModelBindings(settings);
+		expect(settings.get("modelRoles")).toEqual({
+			default: "proxy/default-selector",
+			smol: "project/smol",
+		});
+		expect(settings.getRuntimeOverride("modelRoles")).toEqual({
+			default: "proxy/default-selector",
+		});
+		expect(settings.getWithoutProject("modelRoles")).toEqual({
+			default: "proxy/default-selector",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "proxy/executor-selector",
+			planner: "project/planner",
+		});
+		expect(settings.getRuntimeOverride("task.agentModelOverrides")).toEqual({
+			executor: "proxy/executor-selector",
+		});
+		expect(settings.getWithoutProject("task.agentModelOverrides")).toEqual({
+			executor: "proxy/executor-selector",
+		});
+
+		settings.setAgentModelOverride("architect", "user/architect");
+		await settings.flushOrThrow();
+		expect(await Bun.file(path.join(agentDir, "config.yml")).text()).not.toContain("project/planner");
+	});
 	test("defers model bindings until settings are initialized", () => {
 		writeRawModelsConfig({
 			modelBindings: {

--- a/packages/coding-agent/test/model-selector-controller-batch.test.ts
+++ b/packages/coding-agent/test/model-selector-controller-batch.test.ts
@@ -1,7 +1,10 @@
 import { beforeAll, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
-import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import type { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
 import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
@@ -37,8 +40,7 @@ const selectedModel = model("provider-a", "selected", {
 });
 const nonReasoningModel = model("provider-a", "plain");
 
-function createControllerContext() {
-	const settings = Settings.isolated();
+function createControllerContext(settings = Settings.isolated()) {
 	settings.set("modelRoles", { default: "provider-a/original-default:medium" });
 	settings.set("task.agentModelOverrides", { executor: "provider-a/original-executor:low" });
 	settings.set("modelProfile.default", undefined);
@@ -310,5 +312,50 @@ describe("SelectorController model batch assignments", () => {
 				options: { selector: "provider-a/selected:high", thinkingLevel: ThinkingLevel.High },
 			},
 		]);
+	});
+
+	test("does not report a persisted role assignment when the config write fails", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-selector-durable-model-"));
+		resetSettingsForTest();
+		try {
+			const settings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const { ctx } = createControllerContext(settings);
+			await settings.flushOrThrow();
+			const selector = await openSelector(ctx);
+			const configPath = path.join(fs.realpathSync.native(tempDir), "config.yml");
+			const originalWrite = Bun.write;
+			const writeSpy = vi.spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (
+					typeof args[0] === "string" &&
+					args[0].startsWith(`${configPath}.`) &&
+					args[0].endsWith(".tmp") &&
+					!args[0].startsWith(`${configPath}.revisions.json.`)
+				) {
+					throw new Error("forced config write failure");
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+			try {
+				await selector.__testSelectAssignment({
+					model: selectedModel,
+					role: "executor",
+					thinkingLevel: ThinkingLevel.Low,
+					selector: "provider-a/selected:low",
+				});
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			expect(ctx.showStatus).not.toHaveBeenCalled();
+			expect(ctx.notifyConfigChanged).not.toHaveBeenCalled();
+			expect(ctx.showError).toHaveBeenCalledWith("forced config write failure");
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			expect(reopened.get("task.agentModelOverrides").executor).toBe("provider-a/original-executor:low");
+		} finally {
+			resetSettingsForTest();
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/coding-agent/test/model-selector-controller-batch.test.ts
+++ b/packages/coding-agent/test/model-selector-controller-batch.test.ts
@@ -7,16 +7,35 @@ import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/s
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
 
 let testTheme = await getThemeByName("red-claw");
+function normalizeRenderedText(text: string): string {
+	return text
+		.replace(/\x1b\[[0-9;]*m/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+}
 
 function installTestTheme(): void {
 	if (!testTheme) throw new Error("Failed to load test theme");
 	setThemeInstance(testTheme);
 }
 
-const model = (provider: string, id: string): Model =>
-	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
-
-const selectedModel = model("provider-a", "selected");
+const model = (provider: string, id: string, thinking?: Model["thinking"]): Model =>
+	({
+		provider,
+		id,
+		name: id,
+		api: "openai-responses",
+		contextWindow: 1000,
+		maxTokens: 1000,
+		thinking,
+		reasoning: thinking !== undefined,
+	}) as Model;
+const selectedModel = model("provider-a", "selected", {
+	mode: "effort",
+	minLevel: ThinkingLevel.Low,
+	maxLevel: ThinkingLevel.High,
+});
+const nonReasoningModel = model("provider-a", "plain");
 
 function createControllerContext() {
 	const settings = Settings.isolated();
@@ -34,9 +53,9 @@ function createControllerContext() {
 		sessionId: "session-1",
 		scopedModels: [],
 		modelRegistry: {
-			getAvailable: () => [selectedModel],
+			getAvailable: () => [selectedModel, nonReasoningModel],
 			refresh: vi.fn(async () => {}),
-			getAll: () => [selectedModel],
+			getAll: () => [selectedModel, nonReasoningModel],
 			getError: () => undefined,
 			getCanonicalModels: () => [],
 			getDiscoverableProviders: () => [],
@@ -49,6 +68,13 @@ function createControllerContext() {
 			setModelCalls.push({ model: nextModel, role, options });
 			this.model = nextModel;
 			if (options?.thinkingLevel) this.thinkingLevel = options.thinkingLevel;
+			const selector = options?.selector ?? `${nextModel.provider}/${nextModel.id}`;
+			settings.setModelRole(
+				role,
+				options?.thinkingLevel && options.thinkingLevel !== ThinkingLevel.Inherit
+					? `${selector}:${options.thinkingLevel}`
+					: selector,
+			);
 		},
 		async setModelTemporary() {},
 		setThinkingLevel(thinkingLevel: ThinkingLevel) {
@@ -107,6 +133,7 @@ describe("SelectorController model batch assignments", () => {
 		expect(ctx.showStatus).toHaveBeenCalledWith(
 			"Role-agent models set to provider-a/selected:low for EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
 		);
+		expect(ctx.notifyConfigChanged).toHaveBeenCalledTimes(1);
 	});
 
 	test("all targets selection writes DEFAULT plus every role-agent override", async () => {
@@ -138,5 +165,150 @@ describe("SelectorController model batch assignments", () => {
 		expect(ctx.showStatus).toHaveBeenCalledWith(
 			"All model targets set to provider-a/selected:high for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
 		);
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("DEFAULT (high)");
+		expect(rendered).toContain("EXECUTOR (high)");
+		expect(rendered).toContain("ARCHITECT (high)");
+		expect(rendered).toContain("PLANNER (high)");
+		expect(rendered).toContain("CRITIC (high)");
+		expect(ctx.notifyConfigChanged).toHaveBeenCalledTimes(1);
+	});
+
+	test("all targets replace live role overrides with the selected model's clamped effort", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.override("task.agentModelOverrides", {
+			executor: "provider-a/profile-executor:medium",
+			architect: "provider-a/profile-architect:high",
+			planner: "provider-a/profile-planner:medium",
+			critic: "provider-a/profile-critic:high",
+		});
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			roles: ["default", "executor", "architect", "planner", "critic"],
+			thinkingLevel: ThinkingLevel.XHigh,
+			selector: "provider-a/selected:xhigh",
+		});
+
+		const expectedRoleOverrides = {
+			executor: "provider-a/selected:high",
+			architect: "provider-a/selected:high",
+			planner: "provider-a/selected:high",
+			critic: "provider-a/selected:high",
+		};
+		expect(settings.get("task.agentModelOverrides")).toEqual(expectedRoleOverrides);
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual(expectedRoleOverrides);
+	});
+
+	test("single role assignments clamp stale effort for a non-reasoning model", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.setAgentModelOverride("executor", "provider-a/selected:high");
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: nonReasoningModel,
+			role: "executor",
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/plain:high",
+		});
+
+		expect(settings.get("task.agentModelOverrides").executor).toBe("provider-a/plain");
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.getGlobal("task.agentModelOverrides")).toMatchObject({
+			executor: "provider-a/plain",
+		});
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("EXECUTOR (inherit)");
+		expect(rendered).not.toContain("EXECUTOR (high)");
+	});
+	test("single role status reports project settings that resume on restart", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.getProject = ((path: string) =>
+			path === "task.agentModelOverrides"
+				? { executor: "project/executor" }
+				: undefined) as typeof settings.getProject;
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "executor",
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(ctx.showStatus).toHaveBeenCalledWith(
+			"executor agent model: provider-a/selected:high Project settings for EXECUTOR resume on restart.",
+		);
+	});
+	test("single DEFAULT selection notifies configuration observers", async () => {
+		const { ctx } = createControllerContext();
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected",
+		});
+
+		expect(ctx.notifyConfigChanged).toHaveBeenCalledTimes(1);
+	});
+	test("DEFAULT inherit persists without a suffix while applying the clamped configured effort live", async () => {
+		const { ctx, settings, session, setModelCalls } = createControllerContext();
+		settings.set("defaultThinkingLevel", ThinkingLevel.High);
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			thinkingLevel: ThinkingLevel.Inherit,
+			selector: "provider-a/selected",
+		});
+
+		expect(setModelCalls).toEqual([
+			{
+				model: selectedModel,
+				role: "default",
+				options: { selector: "provider-a/selected", thinkingLevel: ThinkingLevel.Inherit },
+			},
+		]);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.High);
+		expect(settings.getModelRole("default")).toBe("provider-a/selected");
+		expect(ctx.showStatus).toHaveBeenCalledWith(
+			"Default model: provider-a/selected (effective: provider-a/selected:high)",
+		);
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("DEFAULT (high)");
+		expect(rendered).not.toContain("DEFAULT (inherit)");
+	});
+
+	test("nonsettling configuration notifications do not block selector completion", async () => {
+		const { ctx, setModelCalls } = createControllerContext();
+		const never = Promise.withResolvers<void>();
+		ctx.notifyConfigChanged = vi.fn(() => never.promise);
+		const selector = await openSelector(ctx);
+
+		const completed = await Promise.race([
+			selector.__testSelectAssignment({
+				model: selectedModel,
+				role: "default",
+				thinkingLevel: ThinkingLevel.High,
+				selector: "provider-a/selected:high",
+			}),
+			Bun.sleep(100).then(() => "timeout" as const),
+		]);
+
+		expect(completed).not.toBe("timeout");
+		expect(setModelCalls).toEqual([
+			{
+				model: selectedModel,
+				role: "default",
+				options: { selector: "provider-a/selected:high", thinkingLevel: ThinkingLevel.High },
+			},
+		]);
 	});
 });

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -87,7 +87,7 @@ function createControllerContext(options: { missingCredentials?: boolean } = {})
 		"modelProfile.default": "old-profile",
 	});
 	const flush = vi.fn(async () => {});
-	settings.flush = flush as typeof settings.flush;
+	settings.flushOrThrow = flush as typeof settings.flushOrThrow;
 	const setCalls: Array<{ path: string; value: unknown }> = [];
 	const originalSet = settings.set.bind(settings);
 	settings.set = ((path: never, value: never) => {
@@ -199,6 +199,24 @@ describe("model selector profile red-team", () => {
 		]);
 	});
 
+	test("async model selections ignore overlapping dispatches until the first settles", async () => {
+		const selections: ModelSelectorSelection[] = [];
+		const { promise: pendingSelection, resolve: releaseSelection } = Promise.withResolvers<void>();
+		const selector = createSelector(async selection => {
+			selections.push(selection);
+			await pendingSelection;
+		});
+		await renderSelector(selector);
+
+		const first = selector.__testSelectProfile("profile-a", false);
+		const overlapping = selector.__testSelectPresetAction("profile-a", "delete");
+
+		expect(selections).toEqual([{ kind: "profile", profileName: "profile-a", setDefault: false }]);
+		releaseSelection();
+		await Promise.all([first, overlapping]);
+		expect(selections).toHaveLength(1);
+	});
+
 	test("controller persists only Set as default and leaves Apply for this session non-default", async () => {
 		const sessionOnly = createControllerContext();
 		await selectProfileThroughController(new SelectorController(sessionOnly.ctx as never), false);
@@ -278,7 +296,7 @@ describe("model selector profile red-team", () => {
 	});
 });
 
-test("delete action restores the profile when post-delete notification fails", async () => {
+test("delete action remains committed when post-delete notification fails", async () => {
 	const profiles = new Map<string, ModelProfileDefinition>([[userProfile.name, { ...userProfile }]]);
 	const deletedConfigs: Record<string, { required_providers: string[]; model_mapping: Record<string, string> }> = {};
 	const registry = {
@@ -310,7 +328,7 @@ test("delete action restores the profile when post-delete notification fails", a
 		),
 		refresh: vi.fn(async () => {}),
 	};
-	const settings = Settings.isolated({ "modelProfile.default": "unrelated" });
+	const settings = Settings.isolated({ "modelProfile.default": "profile-a" });
 	const ctx = {
 		ui: { setFocus: vi.fn(), requestRender: vi.fn() },
 		editorContainer: { clear: vi.fn(), addChild: vi.fn() },
@@ -322,7 +340,6 @@ test("delete action restores the profile when post-delete notification fails", a
 			sessionId: "session-1",
 			scopedModels: [],
 			modelRegistry: registry,
-			getActiveModelProfile: () => undefined,
 			isFastForProvider: () => false,
 			isFastForSubagentProvider: () => false,
 			isFastModeActive: () => false,
@@ -343,7 +360,14 @@ test("delete action restores the profile when post-delete notification fails", a
 	await selector.__testSelectPresetAction("profile-a", "delete");
 
 	expect(registry.deleteCustomModelProfile).toHaveBeenCalledWith("profile-a");
-	expect(registry.saveCustomModelProfile).toHaveBeenCalledWith("profile-a", deletedConfigs["profile-a"]);
-	expect(profiles.has("profile-a")).toBe(true);
-	expect(ctx.showError).toHaveBeenCalledWith("Preset delete failed: notify failed");
+	expect(registry.saveCustomModelProfile).not.toHaveBeenCalled();
+	expect(profiles.has("profile-a")).toBe(false);
+	expect(ctx.showStatus).toHaveBeenCalledWith("Custom model preset deleted: Profile Alpha");
+	expect(ctx.showError).toHaveBeenCalledWith(
+		"Configuration was updated, but change notification failed: notify failed",
+	);
+	expect(settings.get("modelProfile.default")).toBeUndefined();
+	expect(settings.getRuntimeOverride("modelProfile.default")).toBeUndefined();
+	expect(settings.get("modelRoles")).toEqual({ default: "provider-a/default:high" });
+	expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/alternate" });
 });

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -95,7 +95,7 @@ function createControllerContext(options: { missingCredentials?: boolean } = {})
 		"modelProfile.default": "old-profile",
 	});
 	const flush = vi.fn(async () => {});
-	settings.flush = flush as typeof settings.flush;
+	settings.flushOrThrow = flush as typeof settings.flushOrThrow;
 	const setCalls: Array<{ path: string; value: unknown }> = [];
 	const originalSet = settings.set.bind(settings);
 	settings.set = ((path: never, value: never) => {
@@ -125,6 +125,7 @@ function createControllerContext(options: { missingCredentials?: boolean } = {})
 		updateEditorBorderColor: vi.fn(),
 		showStatus: vi.fn(),
 		showError: vi.fn(),
+		notifyConfigChanged: vi.fn(async () => {}),
 	};
 	return { ctx, settings, session, flush, setCalls };
 }
@@ -325,6 +326,7 @@ describe("model selector profiles", () => {
 		expect(settings.get("task.agentModelOverrides")).toMatchObject({ executor: "provider-a/alternate" });
 		expect(settings.get("modelProfile.default")).toBe("old-profile");
 		expect(ctx.showStatus).toHaveBeenCalledWith("Model profile: Profile Alpha");
+		expect(ctx.notifyConfigChanged).toHaveBeenCalledTimes(1);
 	});
 
 	test("Set as default persists and flushes modelProfile.default", async () => {
@@ -336,6 +338,7 @@ describe("model selector profiles", () => {
 		expect(setCalls).toContainEqual({ path: "modelProfile.default", value: "profile-a" });
 		expect(setCalls).toContainEqual({ path: "defaultThinkingLevel", value: ThinkingLevel.High });
 		expect(flush).toHaveBeenCalledTimes(1);
+		expect(ctx.notifyConfigChanged).toHaveBeenCalledTimes(1);
 		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: Profile Alpha");
 	});
 
@@ -358,8 +361,7 @@ describe("model selector profiles", () => {
 		const { ctx, session, flush, setCalls } = createControllerContext();
 		const controller = new SelectorController(ctx as never);
 
-		controller.handleSettingChange("modelProfile.default", "profile-a");
-		await Bun.sleep(10);
+		await controller.handleSettingChange("modelProfile.default", "profile-a");
 
 		expect(session.setModelTemporaryCalls).toHaveLength(1);
 		expect(session.model?.id).toBe("default");
@@ -373,8 +375,9 @@ describe("model selector profiles", () => {
 		const { ctx, settings, session } = createControllerContext({ missingCredentials: true });
 		const controller = new SelectorController(ctx as never);
 
-		controller.handleSettingChange("modelProfile.default", "profile-a");
-		await Bun.sleep(10);
+		await expect(
+			controller.handleSettingChange("modelProfile.default", "profile-a") as Promise<void>,
+		).rejects.toThrow("requires credentials for: provider-a");
 
 		expect(ctx.showError).toHaveBeenCalledWith(
 			'Model profile "Profile Alpha" requires credentials for: provider-a. Run /login and configure the missing provider(s), then retry.',

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -504,6 +504,7 @@ describe("ModelSelector canonical model selection", () => {
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 
 		const selectedAfterThinking = selected;
@@ -514,6 +515,33 @@ describe("ModelSelector canonical model selection", () => {
 		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}`);
 	});
 
+	test("can explicitly choose inherit for OpenAI reasoning default models", async () => {
+		installTestTheme();
+		const model = createOpenAIModel("openai", "gpt-reasoning-inherit-test");
+		const settings = Settings.isolated({});
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
+			},
+			{ thinkingLevel: null },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+
+		const selectedAfterThinking = selected;
+		if (!selectedAfterThinking) throw new Error("Expected OpenAI selection after inherit choice");
+		expect(selectedAfterThinking.role).toBe("default");
+		expect(selectedAfterThinking.thinkingLevel).toBe(ThinkingLevel.Inherit);
+		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}`);
+	});
 	test("can explicitly choose off for OpenAI reasoning default models", async () => {
 		installTestTheme();
 		const model = createOpenAIModel("openai", "gpt-reasoning-off-test");
@@ -533,6 +561,7 @@ describe("ModelSelector canonical model selection", () => {
 
 		selector.handleInput("\n");
 		selector.handleInput("\n");
+		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 
 		const selectedAfterThinking = selected;
@@ -567,6 +596,7 @@ describe("ModelSelector canonical model selection", () => {
 		const thinkingRendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(thinkingRendered).toContain("Reasoning for Executor");
 
+		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");

--- a/packages/coding-agent/test/modes/components/settings-selector-model-profile.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-model-profile.test.ts
@@ -18,11 +18,16 @@ afterEach(() => {
 
 type ChangedSetting = { path: string; value: unknown };
 
-function createSelector(availableModelProfiles: string[]): {
+function createSelector(
+	availableModelProfiles: string[],
+	onChange?: (path: string, value: unknown) => void | Promise<void>,
+): {
 	component: SettingsSelectorComponent;
 	changedSettings: ChangedSetting[];
+	cancelled: { count: number };
 } {
 	const changedSettings: ChangedSetting[] = [];
+	const cancelled = { count: 0 };
 	const component = new SettingsSelectorComponent(
 		{
 			availableThinkingLevels: [],
@@ -32,11 +37,16 @@ function createSelector(availableModelProfiles: string[]): {
 			cwd: process.cwd(),
 		},
 		{
-			onChange: (path, value) => changedSettings.push({ path, value }),
-			onCancel: () => {},
+			onChange: (path, value) => {
+				changedSettings.push({ path, value });
+				return onChange?.(path, value);
+			},
+			onCancel: () => {
+				cancelled.count++;
+			},
 		},
 	);
-	return { component, changedSettings };
+	return { component, changedSettings, cancelled };
 }
 
 /** SETTING_TABS puts model at index 1 (after appearance); Default Model Profile is its first row. */
@@ -59,7 +69,7 @@ describe("SettingsSelectorComponent Default Model Profile", () => {
 		expect(opened).not.toContain("No matching commands");
 	});
 
-	it("persists the chosen profile to modelProfile.default on confirmation", () => {
+	it("delegates profile persistence to activation on confirmation", () => {
 		settings.set("modelProfile.default", "orchestra");
 		const { component, changedSettings } = createSelector(["orchestra", "balanced"]);
 		focusModelTab(component);
@@ -68,8 +78,87 @@ describe("SettingsSelectorComponent Default Model Profile", () => {
 		component.handleInput("\x1b[B"); // Move to "balanced".
 		component.handleInput("\n"); // Confirm.
 
-		expect(settings.get("modelProfile.default")).toBe("balanced");
+		expect(settings.get("modelProfile.default")).toBe("orchestra");
 		expect(changedSettings).toContainEqual({ path: "modelProfile.default", value: "balanced" });
+	});
+
+	it("waits for activation and blocks overlapping profile selections", async () => {
+		settings.set("modelProfile.default", "orchestra");
+		const { promise: activation, resolve: releaseActivation } = Promise.withResolvers<void>();
+		const applied: ChangedSetting[] = [];
+		const { component } = createSelector(["orchestra", "balanced"], async (path, value) => {
+			applied.push({ path, value });
+			await activation;
+			settings.set("modelProfile.default", value as string);
+		});
+		focusModelTab(component);
+
+		component.handleInput("\n");
+		component.handleInput("\x1b[B");
+		component.handleInput("\n");
+		component.handleInput("\x1b[A");
+		component.handleInput("\n");
+
+		expect(applied).toEqual([{ path: "modelProfile.default", value: "balanced" }]);
+		expect(settings.get("modelProfile.default")).toBe("orchestra");
+		expect(component.render(120).join("\n")).toContain("orchestra");
+
+		releaseActivation();
+		await Bun.sleep(0);
+
+		expect(settings.get("modelProfile.default")).toBe("balanced");
+		expect(applied).toHaveLength(1);
+	});
+
+	it("blocks tab reconstruction while profile activation is pending and allows Escape cancellation", async () => {
+		settings.set("modelProfile.default", "orchestra");
+		const activation = Promise.withResolvers<void>();
+		const applied: ChangedSetting[] = [];
+		const { component, cancelled } = createSelector(["orchestra", "balanced"], async (path, value) => {
+			applied.push({ path, value });
+			await activation.promise;
+		});
+		focusModelTab(component);
+		component.handleInput("\n");
+		component.handleInput("\x1b[B");
+		component.handleInput("\n");
+
+		component.handleInput("\x1b[C");
+		component.handleInput("\t");
+		component.handleInput("\n");
+		expect(applied).toEqual([{ path: "modelProfile.default", value: "balanced" }]);
+
+		component.handleInput("\x1b");
+		expect(cancelled.count).toBe(1);
+		activation.resolve();
+		await Bun.sleep(0);
+		expect(applied).toHaveLength(1);
+	});
+
+	it("allows one successful retry after profile activation rejects", async () => {
+		settings.set("modelProfile.default", "orchestra");
+		let attempts = 0;
+		const { component } = createSelector(["orchestra", "balanced"], async (_path, value) => {
+			attempts++;
+			if (attempts === 1) throw new Error("activation failed");
+			settings.set("modelProfile.default", value as string);
+		});
+		focusModelTab(component);
+
+		component.handleInput("\n");
+		component.handleInput("\x1b[B");
+		component.handleInput("\n");
+		await Bun.sleep(0);
+
+		expect(settings.get("modelProfile.default")).toBe("orchestra");
+		const rendered = component.render(120).join("\n");
+		expect(rendered).toContain("orchestra");
+		expect(rendered).toContain("balanced");
+
+		component.handleInput("\n");
+		await Bun.sleep(0);
+		expect(attempts).toBe(2);
+		expect(settings.get("modelProfile.default")).toBe("balanced");
 	});
 
 	it("falls back to the empty-state message when no profiles are registered", () => {

--- a/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
@@ -44,7 +44,9 @@ function createSelector(options: SelectorOptions = {}) {
 			cwd: process.cwd(),
 		},
 		{
-			onChange: (path, value) => changedSettings.push({ path, value }),
+			onChange: (path, value) => {
+				changedSettings.push({ path, value });
+			},
 			onStatusLinePreview: preview => {
 				previews.push(preview);
 				options.onStatusLinePreview?.(preview);

--- a/packages/coding-agent/test/modes/components/thinking-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/thinking-selector.test.ts
@@ -141,7 +141,7 @@ describe("SelectorController effort selector", () => {
 		expect(ctx.ui.setFocus).toHaveBeenLastCalledWith(ctx.editor);
 	});
 
-	it("can persist the selected effort as the default", () => {
+	it("can persist the selected effort as the default", async () => {
 		const editorContainer = {
 			children: [] as unknown[],
 			clear() {
@@ -190,6 +190,7 @@ describe("SelectorController effort selector", () => {
 		selector.handleInput("\n");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
+		await Bun.sleep(0);
 
 		expect(thinkingLevelCalls).toEqual([{ level: ThinkingLevel.Low, persist: true }]);
 		expect(notifyConfigChanged).toHaveBeenCalled();

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -350,6 +350,106 @@ describe("Settings", () => {
 			});
 		});
 
+		it("applies inherited leaves only when their durable snapshot is unchanged", async () => {
+			await writeSettings({
+				modelProfile: { default: "profile-a" },
+				modelRoles: { default: "baseline/default" },
+				task: { agentModelOverrides: { architect: "baseline/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			await writeSettings({
+				modelProfile: { default: "profile-b" },
+				modelRoles: { default: "external/default" },
+				task: { agentModelOverrides: { architect: "external/architect" } },
+			});
+
+			settings.setModelRoleIfUnchanged("default", "baseline/default", "profile/default");
+			settings.setAgentModelOverrideIfUnchanged("architect", "baseline/architect", "profile/architect");
+			settings.setAgentModelOverrideIfUnchanged("critic", undefined, "profile/critic");
+			settings.setModelProfileDefaultIfUnchanged("profile-a", undefined);
+			await settings.flushOrThrow();
+
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelProfile).toEqual({ default: "profile-b" });
+			expect(savedSettings.modelRoles).toEqual({ default: "external/default" });
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: {
+					architect: "external/architect",
+					critic: "profile/critic",
+				},
+			});
+		});
+
+		it("canonicalizes whole-record and leaf model assignment writes with last-write ownership", async () => {
+			await writeSettings({
+				task: {
+					agentModelOverrides: {
+						architect: "baseline/architect",
+						planner: "baseline/planner",
+					},
+				},
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			await writeSettings({
+				task: {
+					agentModelOverrides: {
+						architect: "baseline/architect",
+						planner: "external/planner",
+					},
+				},
+			});
+
+			settings.set("task.agentModelOverrides", {
+				architect: "whole/architect-1",
+				planner: "baseline/planner",
+			});
+			settings.setAgentModelOverrideIfUnchanged("planner", "baseline/planner", "profile/planner");
+			settings.setAgentModelOverride("architect", "leaf/architect-2");
+			settings.set("task.agentModelOverrides", {
+				architect: "whole/architect-3",
+				planner: "baseline/planner",
+			});
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: {
+					architect: "whole/architect-3",
+					planner: "baseline/planner",
+				},
+			});
+		});
+
+		it("retains conditional ownership checks across a failed save retry", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "baseline/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (args[0] === getConfigPath()) {
+					throw new Error("simulated write failure");
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settings.setAgentModelOverrideIfUnchanged("architect", "baseline/architect", "profile/architect");
+				await expect(settings.flushOrThrow()).rejects.toThrow("simulated write failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "external/architect" } },
+			});
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "external/architect" },
+			});
+		});
+
 		it("preserves external siblings for dotted role and agent names", async () => {
 			await writeSettings({
 				modelRoles: {
@@ -447,6 +547,50 @@ describe("Settings", () => {
 			expect(savedSettings.modelRoles).toEqual({ default: "user/default" });
 			expect(savedSettings.task).toEqual({
 				agentModelOverrides: { executor: "user/executor" },
+			});
+		});
+
+		it("keeps newer explicit leaves across an in-flight conditional save", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const { promise: writeWait, resolve: releaseWrite } = Promise.withResolvers<void>();
+			const { promise: writeStarted, resolve: resolveWriteStarted } = Promise.withResolvers<void>();
+			const originalWrite = Bun.write;
+			let blockedConfigWrite = false;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (!blockedConfigWrite && args[0] === getConfigPath()) {
+					blockedConfigWrite = true;
+					resolveWriteStarted();
+					await writeWait;
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settings.setAgentModelOverrideIfUnchanged("architect", undefined, "profile/architect");
+				const firstFlush = settings.flushOrThrow();
+				await writeStarted;
+
+				settings.setAgentModelOverride("architect", "user/architect");
+				settings.setAgentModelOverride("planner", "user/planner");
+				settings.setAgentModelOverrideIfUnchanged("planner", "user/planner", "profile/planner");
+				expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+					architect: "user/architect",
+					planner: "user/planner",
+				});
+
+				releaseWrite();
+				await firstFlush;
+				await settings.flushOrThrow();
+			} finally {
+				releaseWrite();
+				writeSpy.mockRestore();
+			}
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: {
+					architect: "user/architect",
+					planner: "user/planner",
+				},
 			});
 		});
 	});

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -793,6 +793,97 @@ describe("Settings", () => {
 				agentModelOverrides: { architect: "equal/architect" },
 			});
 		});
+		it("regenerates a deleted sidecar without wedging later live conditional writes", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const sidecarPath = `${getConfigPath()}.revisions.json`;
+			fs.rmSync(sidecarPath);
+
+			settings.setAgentModelOverrideIfUnchanged("architect", "original/architect", "first/architect");
+			await settings.flushOrThrow();
+			expect(await Bun.file(sidecarPath).exists()).toBe(true);
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "original/architect" },
+			});
+
+			settings.setAgentModelOverrideIfUnchanged("architect", "original/architect", "second/architect");
+			await settings.flushOrThrow();
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ cwd: projectDir, agentDir });
+			expect(reopened.getGlobal("task.agentModelOverrides")).toEqual({
+				architect: "second/architect",
+			});
+		});
+		it("refuses profile deletion when a concurrent writer restored the same default", async () => {
+			const settingsA = await Settings.init({ cwd: projectDir, agentDir });
+			const settingsB = await settingsA.cloneForCwd(projectDir);
+			settingsB.set("modelProfile.default", "profile-a");
+			await settingsB.flushOrThrow();
+			let deleted = false;
+
+			await expect(
+				settingsA.deleteModelProfileIfUnreferenced("profile-a", async () => {
+					deleted = true;
+				}),
+			).rejects.toThrow("Model profile became the default while deletion was in progress: profile-a");
+
+			expect(deleted).toBe(false);
+			resetSettingsForTest();
+			const reopened = await Settings.init({ cwd: projectDir, agentDir });
+			expect(reopened.getGlobal("modelProfile.default")).toBe("profile-a");
+		});
+
+		it("rejects a staged default that commits after its custom profile was deleted", async () => {
+			const modelsPath = path.join(agentDir, "models.yml");
+			await Bun.write(
+				modelsPath,
+				YAML.stringify({
+					profiles: {
+						"profile-a": {
+							required_providers: ["provider-a"],
+							model_mapping: { default: "provider-a/model-a" },
+						},
+					},
+				}),
+			);
+			const settingsA = await Settings.init({ cwd: projectDir, agentDir });
+			const settingsB = await settingsA.cloneForCwd(projectDir);
+			settingsB.set("modelProfile.default", "profile-a");
+
+			await settingsA.deleteModelProfileIfUnreferenced("profile-a", async () => {
+				await Bun.write(modelsPath, YAML.stringify({}));
+			});
+			await expect(settingsB.flushOrThrow()).rejects.toThrow("Model profile no longer exists: profile-a");
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ cwd: projectDir, agentDir });
+			expect(reopened.getGlobal("modelProfile.default")).toBeUndefined();
+
+			fs.rmSync(`${getConfigPath()}.revisions.json`);
+			resetSettingsForTest();
+			const recovered = await Settings.init({ cwd: projectDir, agentDir });
+			recovered.set("modelProfile.default", "profile-a");
+			await expect(recovered.flushOrThrow()).rejects.toThrow("Model profile no longer exists: profile-a");
+
+			await Bun.write(
+				modelsPath,
+				YAML.stringify({
+					profiles: {
+						"profile-a": {
+							required_providers: ["provider-a"],
+							model_mapping: { default: "provider-a/model-a" },
+						},
+					},
+				}),
+			);
+			await recovered.flushOrThrow();
+			resetSettingsForTest();
+			const recreated = await Settings.init({ cwd: projectDir, agentDir });
+			expect(recreated.getGlobal("modelProfile.default")).toBe("profile-a");
+		});
 		it("preserves external siblings for dotted role and agent names", async () => {
 			await writeSettings({
 				modelRoles: {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -32,6 +32,10 @@ describe("Settings", () => {
 
 	const writeSettings = async (settings: Record<string, unknown>) => {
 		await Bun.write(getConfigPath(), YAML.stringify(settings, null, 2));
+	};
+
+	const writeProjectSettings = async (settings: Record<string, unknown>) => {
+		await Bun.write(path.join(getProjectAgentDir(projectDir), "config.yml"), YAML.stringify(settings, null, 2));
 	};
 
 	const readSettings = async (): Promise<Record<string, unknown>> => {
@@ -234,6 +238,215 @@ describe("Settings", () => {
 			expect(settings.get("task.agentModelOverrides")).toEqual({
 				executor: "persisted/executor",
 				planner: "user/planner:high",
+			});
+		});
+
+		it("lets explicit model assignments win over project settings for the live session", async () => {
+			await writeSettings({
+				modelRoles: { default: "global/default" },
+				task: { agentModelOverrides: { executor: "global/executor" } },
+			});
+			await writeProjectSettings({
+				modelRoles: { default: "project/default" },
+				task: {
+					agentModelOverrides: {
+						executor: "project/executor",
+						planner: "project/planner",
+					},
+				},
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.getProject("modelRoles")).toEqual({ default: "project/default" });
+			expect(settings.getProject("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				planner: "project/planner",
+			});
+
+			expect(settings.getWithoutProject("modelRoles")).toEqual({ default: "global/default" });
+			expect(settings.getWithoutProject("task.agentModelOverrides")).toEqual({
+				executor: "global/executor",
+			});
+
+			settings.setModelRole("default", "user/default");
+			settings.setAgentModelOverride("executor", "user/executor");
+
+			expect(settings.getWithoutProject("modelRoles")).toEqual({ default: "user/default" });
+			expect(settings.getWithoutProject("task.agentModelOverrides")).toEqual({
+				executor: "user/executor",
+			});
+
+			expect(settings.getModelRole("default")).toBe("user/default");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "user/executor",
+				planner: "project/planner",
+			});
+
+			await settings.flush();
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelRoles).toEqual({ default: "user/default" });
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: { executor: "user/executor" },
+			});
+
+			settings.clearOverride("modelRoles");
+			settings.clearOverride("task.agentModelOverrides");
+			expect(settings.getModelRole("default")).toBe("project/default");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				planner: "project/planner",
+			});
+
+			settings.clearAgentModelOverride("executor");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				planner: "project/planner",
+			});
+			expect(settings.getGlobal("task.agentModelOverrides")).toEqual({});
+			await settings.flushOrThrow();
+			expect((await readSettings()).task).toEqual({ agentModelOverrides: {} });
+		});
+
+		it("preserves externally written sibling roles when saving or clearing one assignment", async () => {
+			await writeSettings({
+				modelRoles: { default: "global/default" },
+				task: {
+					agentModelOverrides: {
+						executor: "global/executor",
+						planner: "global/planner",
+					},
+				},
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			await writeSettings({
+				modelRoles: {
+					default: "global/default",
+					smol: "external/smol",
+				},
+				task: {
+					agentModelOverrides: {
+						executor: "global/executor",
+						architect: "external/architect",
+						planner: "global/planner",
+					},
+				},
+			});
+
+			settings.setModelRole("default", "user/default");
+			settings.setAgentModelOverride("executor", "user/executor");
+			settings.clearAgentModelOverride("planner");
+			await settings.flush();
+
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelRoles).toEqual({
+				default: "user/default",
+				smol: "external/smol",
+			});
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: {
+					executor: "user/executor",
+					architect: "external/architect",
+				},
+			});
+		});
+
+		it("preserves external siblings for dotted role and agent names", async () => {
+			await writeSettings({
+				modelRoles: {
+					"review.security": "global/reviewer",
+					default: "global/default",
+				},
+				task: {
+					agentModelOverrides: {
+						"review.security": "global/reviewer",
+						planner: "global/planner",
+					},
+				},
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			await writeSettings({
+				modelRoles: {
+					"review.security": "global/reviewer",
+					default: "external/default",
+				},
+				task: {
+					agentModelOverrides: {
+						"review.security": "global/reviewer",
+						planner: "external/planner",
+					},
+				},
+			});
+			settings.setModelRole("review.security", "user/reviewer");
+			settings.setAgentModelOverride("review.security", "user/reviewer");
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).modelRoles).toEqual({
+				"review.security": "user/reviewer",
+				default: "external/default",
+			});
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: {
+					"review.security": "user/reviewer",
+					planner: "external/planner",
+				},
+			});
+
+			await writeSettings({
+				modelRoles: {
+					"review.security": "user/reviewer",
+					default: "external/default-v2",
+				},
+				task: {
+					agentModelOverrides: {
+						"review.security": "user/reviewer",
+						planner: "external/planner-v2",
+					},
+				},
+			});
+			settings.clearModelRole("review.security");
+			settings.clearAgentModelOverride("review.security");
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).modelRoles).toEqual({ default: "external/default-v2" });
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { planner: "external/planner-v2" },
+			});
+		});
+
+		it("serializes a flush behind an in-flight debounced save", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const { promise: writeWait, resolve: releaseWrite } = Promise.withResolvers<void>();
+			const { promise: writeStarted, resolve: resolveWriteStarted } = Promise.withResolvers<void>();
+			const originalWrite = Bun.write;
+			let blockedFirstWrite = false;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (!blockedFirstWrite) {
+					blockedFirstWrite = true;
+					resolveWriteStarted();
+					await writeWait;
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settings.setModelRole("default", "user/default");
+				await writeStarted;
+				settings.setAgentModelOverride("executor", "user/executor");
+				expect(settings.getGlobal("task.agentModelOverrides")).toEqual({ executor: "user/executor" });
+				const flushPromise = settings.flush();
+				releaseWrite();
+				await flushPromise;
+				expect(settings.getGlobal("task.agentModelOverrides")).toEqual({ executor: "user/executor" });
+			} finally {
+				releaseWrite();
+				writeSpy.mockRestore();
+			}
+
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelRoles).toEqual({ default: "user/default" });
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: { executor: "user/executor" },
 			});
 		});
 	});

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -28,7 +28,14 @@ describe("Settings", () => {
 		fs.mkdirSync(getProjectAgentDir(projectDir), { recursive: true });
 	});
 
-	const getConfigPath = () => path.join(agentDir, "config.yml");
+	const getConfigPath = () => path.join(fs.realpathSync.native(agentDir), "config.yml");
+	const isConfigWritePath = (value: unknown): boolean =>
+		typeof value === "string" &&
+		value.startsWith(`${getConfigPath()}.`) &&
+		value.endsWith(".tmp") &&
+		!value.startsWith(`${getConfigPath()}.revisions.json.`);
+	const isRevisionWritePath = (value: unknown): boolean =>
+		typeof value === "string" && value.startsWith(`${getConfigPath()}.revisions.json.`) && value.endsWith(".tmp");
 
 	const writeSettings = async (settings: Record<string, unknown>) => {
 		await Bun.write(getConfigPath(), YAML.stringify(settings, null, 2));
@@ -420,6 +427,77 @@ describe("Settings", () => {
 			});
 		});
 
+		it("does not roll back over a later equal-value write from another Settings instance", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settingsA = await Settings.init({ cwd: projectDir, agentDir });
+			const settingsB = await settingsA.cloneForCwd(projectDir);
+
+			settingsB.setAgentModelOverride("architect", "equal/architect");
+			await settingsB.flushOrThrow();
+			settingsA.setAgentModelOverrideIfUnchanged("architect", "original/architect", "equal/architect");
+			await settingsA.flushOrThrow();
+			settingsA.setAgentModelOverrideIfUnchanged("architect", "equal/architect", "original/architect");
+			await settingsA.flushOrThrow();
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ cwd: projectDir, agentDir });
+			expect(reopened.getGlobal("task.agentModelOverrides")).toEqual({
+				architect: "equal/architect",
+			});
+		});
+
+		it("rotates ownership for explicit equal-value writes and absent clears", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "equal/architect" } },
+			});
+			const settingsA = await Settings.init({ cwd: projectDir, agentDir });
+			const settingsB = await settingsA.cloneForCwd(projectDir);
+
+			settingsB.setAgentModelOverride("architect", "equal/architect");
+			settingsB.clearAgentModelOverride("planner");
+			await settingsB.flushOrThrow();
+			settingsA.setAgentModelOverrideIfUnchanged("architect", "equal/architect", "profile/architect");
+			settingsA.setAgentModelOverrideIfUnchanged("planner", undefined, "profile/planner");
+			await settingsA.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "equal/architect" },
+			});
+		});
+
+		it("does not invert over a later equal explicit write from the same Settings instance", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			settings.setAgentModelOverrideIfUnchanged("architect", "original/architect", "equal/architect");
+			await settings.flushOrThrow();
+			settings.setAgentModelOverride("architect", "equal/architect");
+			await settings.flushOrThrow();
+			settings.setAgentModelOverrideIfUnchanged("architect", "equal/architect", "original/architect");
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "equal/architect" },
+			});
+		});
+
+		it("does not replace a pending equal explicit profile with an inverse conditional", async () => {
+			await writeSettings({ modelProfile: { default: "original-profile" } });
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			settings.setModelProfileDefaultIfUnchanged("original-profile", "equal-profile");
+			await settings.flushOrThrow();
+			settings.set("modelProfile.default", "equal-profile");
+			settings.setModelProfileDefaultIfUnchanged("equal-profile", "original-profile");
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).modelProfile).toEqual({ default: "equal-profile" });
+		});
+
 		it("retains conditional ownership checks across a failed save retry", async () => {
 			await writeSettings({
 				task: { agentModelOverrides: { architect: "baseline/architect" } },
@@ -427,7 +505,7 @@ describe("Settings", () => {
 			const settings = await Settings.init({ cwd: projectDir, agentDir });
 			const originalWrite = Bun.write;
 			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
-				if (args[0] === getConfigPath()) {
+				if (isConfigWritePath(args[0])) {
 					throw new Error("simulated write failure");
 				}
 				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
@@ -450,6 +528,271 @@ describe("Settings", () => {
 			});
 		});
 
+		it("retries the same owned conditional mutation after a config write failure", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "baseline/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isConfigWritePath(args[0])) throw new Error("simulated config failure");
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settings.setAgentModelOverrideIfUnchanged("architect", "baseline/architect", "profile/architect");
+				await expect(settings.flushOrThrow()).rejects.toThrow("simulated config failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "profile/architect" },
+			});
+		});
+
+		it("does not let an unconditional retry reclaim a later writer", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settingsA = await Settings.init({ cwd: projectDir, agentDir });
+			const settingsB = await settingsA.cloneForCwd(projectDir);
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isConfigWritePath(args[0])) throw new Error("simulated config failure");
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settingsA.setAgentModelOverride("architect", "first/architect");
+				await expect(settingsA.flushOrThrow()).rejects.toThrow("simulated config failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+			settingsB.setAgentModelOverride("architect", "later/architect");
+			await settingsB.flushOrThrow();
+			await settingsA.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "later/architect" },
+			});
+		});
+		it("does not overwrite an external edit when retrying an unconditional mutation", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isConfigWritePath(args[0])) throw new Error("simulated config failure");
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settings.setAgentModelOverride("architect", "first/architect");
+				await expect(settings.flushOrThrow()).rejects.toThrow("simulated config failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "external/architect" } },
+			});
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "external/architect" },
+			});
+		});
+		it("does not retry past a later writer after sidecar persistence fails", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settingsA = await Settings.init({ cwd: projectDir, agentDir });
+			const settingsB = await settingsA.cloneForCwd(projectDir);
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isRevisionWritePath(args[0])) throw new Error("simulated revision failure");
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settingsA.setAgentModelOverride("architect", "first/architect");
+				await expect(settingsA.flushOrThrow()).rejects.toThrow("simulated revision failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+			settingsB.setAgentModelOverride("architect", "later/architect");
+			await settingsB.flushOrThrow();
+			await settingsA.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "later/architect" },
+			});
+		});
+		it("retries after a sidecar failure when the predecessor is unchanged", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isRevisionWritePath(args[0])) throw new Error("simulated revision failure");
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settings.setAgentModelOverride("architect", "first/architect");
+				await expect(settings.flushOrThrow()).rejects.toThrow("simulated revision failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "first/architect" },
+			});
+		});
+		it("does not overwrite siblings when the config root becomes invalid", async () => {
+			await writeSettings({
+				modelRoles: { default: "original/default" },
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const invalidConfig = "- broken-root\n";
+			await Bun.write(getConfigPath(), invalidConfig);
+
+			settings.setAgentModelOverride("planner", "user/planner");
+			await expect(settings.flushOrThrow()).rejects.toThrow("Settings root must be an object");
+			expect(await Bun.file(getConfigPath()).text()).toBe(invalidConfig);
+		});
+		it("rejects invalid model assignment keys without poisoning durable ownership", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(() => settings.setModelRole("", "invalid/default")).toThrow("Model assignment key cannot be empty");
+			expect(() => settings.setAgentModelOverride("", "invalid/agent")).toThrow(
+				"Model assignment key cannot be empty",
+			);
+			expect(() => settings.set("modelRoles", { "": "invalid/default" })).toThrow(
+				"Model assignment key cannot be empty",
+			);
+			expect(() => settings.set("task.agentModelOverrides", { "": "invalid/agent" })).toThrow(
+				"Model assignment key cannot be empty",
+			);
+
+			for (const key of ["__proto__", "prototype", "constructor", "toString", "hasOwnProperty"]) {
+				const roleRecord = Object.fromEntries([[key, "invalid/default"]]);
+				const agentRecord = Object.fromEntries([[key, "invalid/agent"]]);
+				expect(() => settings.setModelRole(key, "invalid/default")).toThrow(
+					`Model assignment key is not allowed: ${key}`,
+				);
+				expect(() => settings.setAgentModelOverride(key, "invalid/agent")).toThrow(
+					`Model assignment key is not allowed: ${key}`,
+				);
+				expect(() => settings.set("modelRoles", roleRecord)).toThrow(`Model assignment key is not allowed: ${key}`);
+				expect(() => settings.set("task.agentModelOverrides", agentRecord)).toThrow(
+					`Model assignment key is not allowed: ${key}`,
+				);
+			}
+
+			settings.setModelRole("default", "valid/default");
+			await settings.flushOrThrow();
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ cwd: projectDir, agentDir });
+			expect(reopened.getModelRole("default")).toBe("valid/default");
+		});
+
+		it("fails closed when the durable ownership sidecar is malformed", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			await Bun.write(`${getConfigPath()}.revisions.json`, "{not-json");
+
+			await expect(Settings.init({ cwd: projectDir, agentDir })).rejects.toThrow();
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "original/architect" },
+			});
+		});
+
+		it("rejects semantically invalid ownership sidecars", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			await Bun.write(
+				`${getConfigPath()}.revisions.json`,
+				JSON.stringify({
+					version: 1,
+					generation: "uninitialized",
+					nextRevision: 1,
+					entries: {},
+				}),
+			);
+
+			await expect(Settings.init({ cwd: projectDir, agentDir })).rejects.toThrow(
+				"Invalid settings revision state header",
+			);
+		});
+
+		it("rejects non-canonical ownership paths", async () => {
+			await writeSettings({
+				modelRoles: { default: "original/default" },
+			});
+			await Settings.init({ cwd: projectDir, agentDir });
+			const sidecarPath = `${getConfigPath()}.revisions.json`;
+			const state = JSON.parse(await Bun.file(sidecarPath).text()) as Record<string, unknown>;
+			const invalidPaths = [
+				"modelRoles",
+				"task.agentModelOverrides",
+				'\0record-entry:[ "modelRoles", "default" ]',
+				`\0record-entry:${JSON.stringify(["modelRoles", "__proto__"])}`,
+				`\0record-entry:${JSON.stringify(["task", "agentModelOverrides", "constructor"])}`,
+				`\0record-entry:${JSON.stringify(["modelRoles", "toString"])}`,
+			];
+
+			for (const modifiedPath of invalidPaths) {
+				resetSettingsForTest();
+				await Bun.write(
+					sidecarPath,
+					JSON.stringify({
+						...state,
+						nextRevision: 2,
+						entries: {
+							[modifiedPath]: {
+								revision: 1,
+								ownerId: "external-writer",
+								mutationId: 1,
+							},
+						},
+					}),
+				);
+				await expect(Settings.init({ cwd: projectDir, agentDir })).rejects.toThrow(
+					`Invalid settings revision path: ${modifiedPath}`,
+				);
+			}
+		});
+
+		it("rejects stale baselines after ownership sidecar regeneration", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "equal/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.setAgentModelOverride("architect", "equal/architect");
+			await settings.flushOrThrow();
+			const staleSettings = await settings.cloneForCwd(projectDir);
+			fs.rmSync(`${getConfigPath()}.revisions.json`);
+
+			resetSettingsForTest();
+			const regenerated = await Settings.init({ cwd: projectDir, agentDir });
+			regenerated.setAgentModelOverride("architect", "equal/architect");
+			await regenerated.flushOrThrow();
+			staleSettings.setAgentModelOverrideIfUnchanged("architect", "equal/architect", "profile/architect");
+			await staleSettings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "equal/architect" },
+			});
+		});
 		it("preserves external siblings for dotted role and agent names", async () => {
 			await writeSettings({
 				modelRoles: {
@@ -557,7 +900,7 @@ describe("Settings", () => {
 			const originalWrite = Bun.write;
 			let blockedConfigWrite = false;
 			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
-				if (!blockedConfigWrite && args[0] === getConfigPath()) {
+				if (!blockedConfigWrite && isConfigWritePath(args[0])) {
 					blockedConfigWrite = true;
 					resolveWriteStarted();
 					await writeWait;

--- a/packages/coding-agent/test/slash-commands/model.test.ts
+++ b/packages/coding-agent/test/slash-commands/model.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, spyOn, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
-import { Settings } from "../../src/config/settings";
+import { resetSettingsForTest, Settings } from "../../src/config/settings";
 import type { AgentSession } from "../../src/session/agent-session";
 import type { SessionManager } from "../../src/session/session-manager";
 import { executeAcpBuiltinSlashCommand } from "../../src/slash-commands/acp-builtins";
 
-function createRuntime() {
+function createRuntime(settings = Settings.isolated()) {
 	const output: string[] = [];
-	const settings = Settings.isolated();
 	let activeModelProfile: string | undefined;
 	const availableModel = {
 		provider: "anthropic",
@@ -312,6 +314,46 @@ describe("/model batch assignments", () => {
 		]);
 	});
 
+	test("does not report a persisted assignment when the config write fails", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-slash-durable-model-"));
+		resetSettingsForTest();
+		try {
+			const settings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			settings.setAgentModelOverride("executor", "anthropic/original");
+			await settings.flushOrThrow();
+			const { output, runtime } = createRuntime(settings);
+			const configPath = path.join(fs.realpathSync.native(tempDir), "config.yml");
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (
+					typeof args[0] === "string" &&
+					args[0].startsWith(`${configPath}.`) &&
+					args[0].endsWith(".tmp") &&
+					!args[0].startsWith(`${configPath}.revisions.json.`)
+				) {
+					throw new Error("forced config write failure");
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+			try {
+				await expect(
+					executeAcpBuiltinSlashCommand("/model assign executor claude-3-5-sonnet:low", runtime),
+				).resolves.toEqual({ consumed: true });
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			expect(output.some(line => line.includes("Failed to set model: forced config write failure"))).toBe(true);
+			expect(output.some(line => line.includes("Executor model set to"))).toBe(false);
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			expect(reopened.get("task.agentModelOverrides").executor).toBe("anthropic/original");
+		} finally {
+			resetSettingsForTest();
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
 	test("nonsettling notifications do not block a committed assignment", async () => {
 		const { runtime, settings } = createRuntime();
 		const never = Promise.withResolvers<void>();

--- a/packages/coding-agent/test/slash-commands/model.test.ts
+++ b/packages/coding-agent/test/slash-commands/model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, spyOn, test } from "bun:test";
+import { ThinkingLevel } from "@gajae-code/agent-core";
 import { Settings } from "../../src/config/settings";
 import type { AgentSession } from "../../src/session/agent-session";
 import type { SessionManager } from "../../src/session/session-manager";
@@ -8,7 +9,13 @@ function createRuntime() {
 	const output: string[] = [];
 	const settings = Settings.isolated();
 	let activeModelProfile: string | undefined;
-	const availableModel = { provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 };
+	const availableModel = {
+		provider: "anthropic",
+		id: "claude-3-5-sonnet",
+		contextWindow: 200_000,
+		reasoning: true,
+		thinking: { mode: "effort", minLevel: "low", maxLevel: "high" },
+	};
 	const session = {
 		sessionId: "session-1",
 		model: undefined as { provider: string; id: string; contextWindow?: number } | undefined,
@@ -21,10 +28,13 @@ function createRuntime() {
 				selector: string,
 				options?: { candidates?: Array<{ provider: string; id: string }> },
 			) => (selector === "claude-sonnet" ? options?.candidates?.[0] : undefined),
+			getAll: () => [availableModel],
+			getModelProfile: () => undefined,
 		},
 		getAvailableModels: () => [availableModel],
-		async setModel(model: { provider: string; id: string }, _role: "default", _options?: unknown) {
+		async setModel(model: { provider: string; id: string }, _role: "default", options?: { thinkingLevel?: string }) {
 			this.model = model;
+			if (options?.thinkingLevel) this.thinkingLevel = options.thinkingLevel;
 		},
 		setThinkingLevel(thinkingLevel: string) {
 			this.thinkingLevel = thinkingLevel;
@@ -137,6 +147,39 @@ describe("/model batch assignments", () => {
 		]);
 	});
 
+	test("batch success reports preserved per-role efforts instead of claiming one value", async () => {
+		const { output, runtime, settings } = createRuntime();
+		settings.setModelRole("default", "anthropic/original-default:high");
+		settings.set("task.agentModelOverrides", {
+			executor: "anthropic/original-executor:low",
+			architect: "anthropic/original-architect:medium",
+			planner: "anthropic/original-planner:high",
+			critic: "anthropic/original-critic:low",
+		});
+
+		await expect(
+			executeAcpBuiltinSlashCommand("/model assign all-targets claude-3-5-sonnet", runtime),
+		).resolves.toEqual({ consumed: true });
+
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:high");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet:low",
+			architect: "anthropic/claude-3-5-sonnet:medium",
+			planner: "anthropic/claude-3-5-sonnet:high",
+			critic: "anthropic/claude-3-5-sonnet:low",
+		});
+		expect(output).toEqual([
+			[
+				"All model targets updated:",
+				"  DEFAULT: anthropic/claude-3-5-sonnet:high",
+				"  EXECUTOR: anthropic/claude-3-5-sonnet:low",
+				"  ARCHITECT: anthropic/claude-3-5-sonnet:medium",
+				"  PLANNER: anthropic/claude-3-5-sonnet:high",
+				"  CRITIC: anthropic/claude-3-5-sonnet:low",
+			].join("\n"),
+		]);
+	});
+
 	test("/model preserves existing DEFAULT effort when selector has no explicit effort", async () => {
 		const { output, runtime, settings, session } = createRuntime();
 		settings.setModelRole("default", "anthropic/original-model:high");
@@ -148,5 +191,139 @@ describe("/model batch assignments", () => {
 		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:high");
 		expect(session.thinkingLevel).toBe("high");
 		expect(output).toEqual(["Default model set to anthropic/claude-3-5-sonnet:high."]);
+	});
+	test("explicit DEFAULT inherit applies the configured effort live without persisting a suffix", async () => {
+		const { runtime, session, settings } = createRuntime();
+		settings.set("defaultThinkingLevel", ThinkingLevel.High);
+
+		await expect(executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet:inherit", runtime)).resolves.toEqual({
+			consumed: true,
+		});
+
+		expect(session.thinkingLevel).toBe("high");
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet");
+	});
+
+	test("all-targets inherit applies the configured DEFAULT effort live without persisting it", async () => {
+		const { output, runtime, session, settings } = createRuntime();
+		settings.set("defaultThinkingLevel", ThinkingLevel.High);
+
+		await expect(
+			executeAcpBuiltinSlashCommand("/model assign all-targets claude-3-5-sonnet:inherit", runtime),
+		).resolves.toEqual({ consumed: true });
+
+		expect(session.thinkingLevel).toBe("high");
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet",
+			architect: "anthropic/claude-3-5-sonnet",
+			planner: "anthropic/claude-3-5-sonnet",
+			critic: "anthropic/claude-3-5-sonnet",
+		});
+
+		await expect(executeAcpBuiltinSlashCommand("/model roles", runtime)).resolves.toEqual({ consumed: true });
+		expect(output.at(-1)).toContain(
+			"DEFAULT (Default): anthropic/claude-3-5-sonnet (effective: anthropic/claude-3-5-sonnet:high)",
+		);
+	});
+
+	test("reports project role settings that resume on restart", async () => {
+		const { output, runtime, settings } = createRuntime();
+		settings.getProject = ((path: string) =>
+			path === "task.agentModelOverrides"
+				? { executor: "project/executor" }
+				: undefined) as typeof settings.getProject;
+
+		await expect(executeAcpBuiltinSlashCommand("/model executor claude-3-5-sonnet:high", runtime)).resolves.toEqual({
+			consumed: true,
+		});
+
+		expect(output).toEqual([
+			[
+				"executor agent model set to anthropic/claude-3-5-sonnet:high.",
+				"Project settings for EXECUTOR resume on restart.",
+			].join("\n"),
+		]);
+	});
+	test("active-profile all-targets preserves the live DEFAULT effort when effort is omitted", async () => {
+		const { output, runtime, settings, session, setActiveModelProfile } = createRuntime();
+		session.model = { provider: "anthropic", id: "profile-model" };
+		session.thinkingLevel = "high";
+		settings.setModelRole("default", "anthropic/baseline:low");
+		settings.set("modelProfile.default", "profile-a");
+		setActiveModelProfile("profile-a");
+		settings.override("task.agentModelOverrides", {
+			executor: "anthropic/profile-executor:high",
+			architect: "anthropic/profile-architect:high",
+			planner: "anthropic/profile-planner:high",
+			critic: "anthropic/profile-critic:high",
+		});
+
+		await expect(
+			executeAcpBuiltinSlashCommand("/model assign all-targets claude-3-5-sonnet", runtime),
+		).resolves.toEqual({ consumed: true });
+
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:high");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet:high",
+			architect: "anthropic/claude-3-5-sonnet:high",
+			planner: "anthropic/claude-3-5-sonnet:high",
+			critic: "anthropic/claude-3-5-sonnet:high",
+		});
+		expect(session.thinkingLevel).toBe("high");
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(output).toEqual([
+			"All model targets set to anthropic/claude-3-5-sonnet:high for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+		]);
+	});
+
+	test("summary reports the active profile's live DEFAULT model and effort", async () => {
+		const { output, runtime, settings, session, setActiveModelProfile } = createRuntime();
+		settings.setModelRole("default", "anthropic/baseline:low");
+		session.model = { provider: "anthropic", id: "profile-model" };
+		session.thinkingLevel = "high";
+		setActiveModelProfile("profile-a");
+
+		await expect(executeAcpBuiltinSlashCommand("/model roles", runtime)).resolves.toEqual({ consumed: true });
+
+		expect(output[0]).toContain("DEFAULT (Default): anthropic/profile-model:high");
+		expect(output[0]).not.toContain("DEFAULT (Default): anthropic/baseline:low");
+	});
+
+	test("notification failures do not report a committed assignment as failed", async () => {
+		const { output, runtime, settings } = createRuntime();
+		runtime.notifyTitleChanged = async () => {
+			throw new Error("title transport unavailable");
+		};
+		runtime.notifyConfigChanged = async () => {
+			throw new Error("config transport unavailable");
+		};
+
+		await expect(executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet:low", runtime)).resolves.toEqual({
+			consumed: true,
+		});
+		await Bun.sleep(0);
+
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:low");
+		expect(output).toEqual([
+			"Default model set to anthropic/claude-3-5-sonnet:low.",
+			"Model settings were updated, but notification failed (title: title transport unavailable).",
+			"Model settings were updated, but notification failed (config: config transport unavailable).",
+		]);
+	});
+
+	test("nonsettling notifications do not block a committed assignment", async () => {
+		const { runtime, settings } = createRuntime();
+		const never = Promise.withResolvers<void>();
+		runtime.notifyTitleChanged = () => never.promise;
+		runtime.notifyConfigChanged = () => never.promise;
+
+		const completed = await Promise.race([
+			executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet:low", runtime),
+			Bun.sleep(100).then(() => "timeout" as const),
+		]);
+
+		expect(completed).toEqual({ consumed: true });
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:low");
 	});
 });


### PR DESCRIPTION
## Summary

- preserve `/model` and TUI role assignments across runtime/project layers without replacing siblings
- make equal-value profile materialization and rollback ownership-safe across Settings instances
- make ownership-sidecar regeneration durable and non-wedging
- make custom-profile deletion referentially safe across concurrent default selection and current-project references
- report persisted `/model` and model-selector success only after durable settings commit

## #1978 owner findings

This supersedes #1978 and addresses all four exact-head Request Changes:

1. **Deleted sidecar wedge** — revision-state loads now return explicit presence; a missing sidecar is durably regenerated under the config lock before stale conditionals are rejected, so the next live conditional uses the new generation and succeeds.
2. **Concurrent same-profile deletion race** — deletion performs a fresh global-default check under the settings lock and writes a separate durable profile-deletion ledger before object removal. A staged/later Settings writer is rejected after deletion, including after ownership-sidecar removal; recreating the profile clears the ledger on the next commit.
3. **Project reference deletion** — the controller refuses deletion when the current project resolves the custom profile as `modelProfile.default`, preserving restart integrity.
4. **False persisted success** — all persisted model-selector branches and `/model` now await `flushOrThrow()` before status/output, notification, close, or return.

The durable profile-deletion ledger is separate from `config.yml.revisions.json`, so deleting/regenerating ownership metadata cannot erase referential-integrity state.

## Verification

- base/current `dev`: `1cab669d347f642883cf3225fa6c9be2a3adbdf8`
- changed affected suites: **356 passed across 15 files**
- ACP model tests: **20 passed**
- six exact owner/follow-up schedules: **6/6 passed, repeated 3 times**
- TypeScript native preview (`tsgo`): passed
- Biome on changed TypeScript files: passed
- `git diff --check`: passed