### PR TITLE
fix(tui): preserve viewport through completion

### DIFF
--- a/packages/coding-agent/src/deep-interview/render-middleware.ts
+++ b/packages/coding-agent/src/deep-interview/render-middleware.ts
@@ -1,4 +1,15 @@
-import { type Component, Container, Markdown, Spacer, Text } from "@gajae-code/tui";
+import {
+	type Component,
+	Container,
+	isViewportAnchorSourceRenderer,
+	Markdown,
+	Spacer,
+	Text,
+	type ViewportAnchorProvider,
+	type ViewportAnchorRender,
+	type ViewportAnchorSource,
+	type ViewportAnchorSourceRenderer,
+} from "@gajae-code/tui";
 import { getMarkdownTheme, type Theme } from "../modes/theme/theme";
 
 interface RoundQuestionModel {
@@ -47,6 +58,60 @@ interface ThresholdModel {
 }
 
 type DeepInterviewModel = RoundQuestionModel | TopologyQuestionModel | ProgressModel | ThresholdModel;
+
+class DeepInterviewSemanticContainer extends Container implements ViewportAnchorProvider, ViewportAnchorSourceRenderer {
+	#nextSource = 0;
+
+	override addChild(component: Component): void {
+		super.addChild(component);
+		if (isViewportAnchorSourceRenderer(component)) {
+			this.setViewportAnchorSource(component, { id: `deep-interview-part:${this.#nextSource++}` });
+		}
+	}
+
+	override renderWithViewportAnchors(width: number): ViewportAnchorRender {
+		const lines = super.renderWithViewportAnchors(width).lines;
+		return { lines, anchors: lines.map(() => null) };
+	}
+
+	renderWithViewportAnchorSource(width: number, source: ViewportAnchorSource): ViewportAnchorRender {
+		const rendered = super.renderWithViewportAnchors(width);
+		const extents = new Map<string, { graphemeEnd: number; cellEnd: number }>();
+		for (const anchor of rendered.anchors) {
+			if (anchor === null) continue;
+			const extent = extents.get(anchor.id);
+			if (extent) {
+				extent.graphemeEnd = Math.max(extent.graphemeEnd, anchor.graphemeEnd);
+				extent.cellEnd = Math.max(extent.cellEnd, anchor.cellEnd);
+			} else {
+				extents.set(anchor.id, { graphemeEnd: anchor.graphemeEnd, cellEnd: anchor.cellEnd });
+			}
+		}
+		const offsets = new Map<string, { grapheme: number; cell: number }>();
+		let grapheme = 0;
+		let cell = 0;
+		for (const [id, extent] of extents) {
+			offsets.set(id, { grapheme, cell });
+			grapheme += extent.graphemeEnd;
+			cell += extent.cellEnd;
+		}
+		return {
+			lines: rendered.lines,
+			anchors: rendered.anchors.map(anchor => {
+				if (anchor === null) return null;
+				const offset = offsets.get(anchor.id);
+				if (!offset) throw new Error(`Missing deep-interview anchor offset for ${anchor.id}`);
+				return {
+					id: source.id,
+					graphemeStart: offset.grapheme + anchor.graphemeStart,
+					graphemeEnd: offset.grapheme + anchor.graphemeEnd,
+					cellStart: offset.cell + anchor.cellStart,
+					cellEnd: offset.cell + anchor.cellEnd,
+				};
+			}),
+		};
+	}
+}
 
 function normalizeText(text: string): string {
 	if (typeof text !== "string") return "";
@@ -258,7 +323,7 @@ function renderPipeSummary(title: string, value: string | undefined): string | u
 }
 
 function renderModel(model: DeepInterviewModel, uiTheme: Theme): Component {
-	const container = new Container();
+	const container = new DeepInterviewSemanticContainer();
 	if (model.kind === "round-question") {
 		const meta = [
 			`Round ${model.round}`,

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -1,5 +1,16 @@
 import type { AssistantMessage, ImageContent, Usage } from "@gajae-code/ai";
-import { type Component, Container, Image, ImageProtocol, Markdown, Spacer, TERMINAL, Text } from "@gajae-code/tui";
+import {
+	type Component,
+	Container,
+	Image,
+	ImageProtocol,
+	isViewportAnchorSourceRenderer,
+	Markdown,
+	Spacer,
+	TERMINAL,
+	Text,
+	type ViewportAnchorSource,
+} from "@gajae-code/tui";
 import { formatNumber } from "@gajae-code/utils";
 import { settings } from "../../config/settings";
 import { renderDeepInterviewAssistantText } from "../../deep-interview/render-middleware";
@@ -62,6 +73,7 @@ interface AssistantMessageUpdateOptions {
 type AssistantChildDescriptor = {
 	key: string;
 	component: Component;
+	anchorSource?: ViewportAnchorSource;
 };
 
 /**
@@ -81,21 +93,29 @@ export class AssistantMessageComponent extends Container {
 	#contentBlockKeys = new WeakMap<object, string>();
 	#nextContentBlockKey = 0;
 	#reusableChildren = new WeakSet<Component>();
-
+	#viewportAnchorId?: string;
 	constructor(
 		message?: AssistantMessage,
 		private hideThinkingBlock = false,
 		private readonly onImageUpdate?: () => void,
+		viewportAnchorId?: string,
 	) {
 		super();
+		this.#viewportAnchorId = viewportAnchorId;
 
-		// Container for text/thinking content
 		this.#contentContainer = new Container();
 		this.addChild(this.#contentContainer);
 
 		if (message) {
 			this.updateContent(message);
 		}
+	}
+
+	#contentAnchorSource(
+		index: number,
+		kind: "text" | "thinking" | "thinking-hidden",
+	): ViewportAnchorSource | undefined {
+		return this.#viewportAnchorId ? { id: `${this.#viewportAnchorId}:content:${index}:${kind}` } : undefined;
 	}
 
 	override invalidate(): void {
@@ -288,6 +308,12 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	#reconcileChildren(descriptors: AssistantChildDescriptor[]): void {
+		for (const child of this.#contentContainer.children) this.#contentContainer.setViewportAnchorSource(child, null);
+		for (const descriptor of descriptors) {
+			if (descriptor.anchorSource && isViewportAnchorSourceRenderer(descriptor.component)) {
+				this.#contentContainer.setViewportAnchorSource(descriptor.component, descriptor.anchorSource);
+			}
+		}
 		const nextChildren = descriptors.map(descriptor => descriptor.component);
 		if (
 			nextChildren.length === this.#contentContainer.children.length &&
@@ -346,6 +372,7 @@ export class AssistantMessageComponent extends Container {
 				descriptors.push({
 					key: `${blockKey}:text`,
 					component: this.#renderTextBlock(content, streaming && i === activeContentIndex),
+					anchorSource: this.#contentAnchorSource(i, "text"),
 				});
 			} else if (content.type === "thinking" && content.thinking.trim()) {
 				// Add spacing only when another visible assistant content block follows.
@@ -358,11 +385,13 @@ export class AssistantMessageComponent extends Container {
 							`${blockKey}:thinking-hidden`,
 							() => new Text(theme.italic(theme.fg("thinkingText", "Thinking...")), 1, 0),
 						),
+						anchorSource: this.#contentAnchorSource(i, "thinking-hidden"),
 					});
 				} else {
 					descriptors.push({
 						key: `${blockKey}:thinking`,
 						component: this.#renderThinkingBlock(content, streaming && i === activeContentIndex),
+						anchorSource: this.#contentAnchorSource(i, "thinking"),
 					});
 				}
 				if (visibleContentAfter[i]) {

--- a/packages/coding-agent/src/modes/components/irc-sidebar.ts
+++ b/packages/coding-agent/src/modes/components/irc-sidebar.ts
@@ -1,9 +1,12 @@
 import {
 	type Component,
 	padding,
+	renderComponentWithViewportAnchors,
 	replaceTabs,
 	TERMINAL,
 	truncateToWidth,
+	type ViewportAnchorProvider,
+	type ViewportAnchorRender,
 	visibleWidth,
 	withTerminalGraphicsFallback,
 	wrapTextWithAnsi,
@@ -41,7 +44,7 @@ export interface IrcSidebarTheme {
 export type IrcSidebarThemeSource = IrcSidebarTheme | (() => IrcSidebarTheme);
 
 /** Read-only IRC history alongside the active transcript. */
-export class IrcSplitViewComponent implements Component {
+export class IrcSplitViewComponent implements ViewportAnchorProvider {
 	#visible = false;
 
 	constructor(
@@ -61,7 +64,11 @@ export class IrcSplitViewComponent implements Component {
 	}
 
 	render(width: number): string[] {
-		if (!this.#visible) return this.leftPane.render(width);
+		return this.renderWithViewportAnchors(width).lines;
+	}
+
+	renderWithViewportAnchors(width: number): ViewportAnchorRender {
+		if (!this.#visible) return renderComponentWithViewportAnchors(this.leftPane, width);
 
 		const componentTheme = typeof this.componentTheme === "function" ? this.componentTheme() : this.componentTheme;
 		const leftWidth = Math.floor(width * 0.5);
@@ -69,32 +76,30 @@ export class IrcSplitViewComponent implements Component {
 		const separatorWidth = width - leftWidth > 3 ? visibleWidth(separatorText) : 0;
 		const separator = separatorWidth > 0 ? separatorText : "";
 		const rightWidth = Math.max(0, width - leftWidth - separatorWidth);
-		// Cursor-neutral (kitty) image placements are safe inside the split:
-		// the escape anchors to its cell without moving the cursor, so the
-		// right column still composes correctly. Cursor-advancing protocols
-		// (iTerm2/SIXEL) remain suppressed by the fallback scope.
-		const leftLines = withTerminalGraphicsFallback(() => this.leftPane.render(leftWidth), {
-			allowCursorNeutralImages: true,
-		});
+		const leftRender = withTerminalGraphicsFallback(
+			() => renderComponentWithViewportAnchors(this.leftPane, leftWidth),
+			{ allowCursorNeutralImages: true },
+		);
 		const rightLines = renderSidebarRecords(this.ledger, rightWidth);
-		const lineCount = Math.max(leftLines.length, rightLines.length);
-		const output: string[] = [];
+		const lineCount = Math.max(leftRender.lines.length, rightLines.length);
+		const lines: string[] = [];
+		const anchors: ViewportAnchorRender["anchors"] = [];
 
-		const leftOffset = lineCount - leftLines.length;
+		const leftOffset = lineCount - leftRender.lines.length;
 		const rightOffset = lineCount - rightLines.length;
 		for (let index = 0; index < lineCount; index++) {
-			const leftRaw = leftLines[index - leftOffset] ?? "";
+			const leftIndex = index - leftOffset;
+			const leftRaw = leftRender.lines[leftIndex] ?? "";
 			const right = truncateToWidth(rightLines[index - rightOffset] ?? "", rightWidth);
 			if (TERMINAL.isImageLine(leftRaw)) {
-				// Never truncate/measure an image escape: it renders zero visible
-				// columns, so pad the full left width after it.
-				output.push(leftRaw + padding(leftWidth) + separator + right);
-				continue;
+				lines.push(leftRaw + padding(leftWidth) + separator + right);
+			} else {
+				const left = truncateToWidth(leftRaw, leftWidth);
+				lines.push(left + padding(Math.max(0, leftWidth - visibleWidth(left))) + separator + right);
 			}
-			const left = truncateToWidth(leftRaw, leftWidth);
-			output.push(left + padding(Math.max(0, leftWidth - visibleWidth(left))) + separator + right);
+			anchors.push(leftRender.anchors[leftIndex] ?? null);
 		}
-		return output;
+		return { lines, anchors };
 	}
 
 	invalidate(): void {

--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -1,4 +1,12 @@
-import { type Component, Container, Markdown, Spacer, Text } from "@gajae-code/tui";
+import {
+	type Component,
+	Container,
+	Markdown,
+	Spacer,
+	Text,
+	type ViewportAnchorRender,
+	type ViewportAnchorSource,
+} from "@gajae-code/tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 
 // OSC 133 shell integration: marks prompt zones for terminal multiplexers
@@ -10,8 +18,11 @@ const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
  * Component that renders a user message
  */
 export class UserMessageComponent extends Container {
-	constructor(text: string, synthetic = false) {
+	#viewportAnchorSource?: ViewportAnchorSource;
+
+	constructor(text: string, synthetic = false, viewportAnchorId?: string) {
 		super();
+		if (viewportAnchorId) this.#viewportAnchorSource = { id: viewportAnchorId };
 		const bgColor = (value: string) => theme.bg("userMessageBg", value);
 		const color = synthetic
 			? (value: string) => theme.fg("dim", value)
@@ -19,7 +30,9 @@ export class UserMessageComponent extends Container {
 		this.addChild(new Spacer(1));
 		const label = synthetic ? "replay" : "user";
 		this.addChild(new Text(theme.bold(theme.fg("accent", label)), 1, 0));
-		this.addChild(new PromptZoneMarkdown(text, bgColor, color));
+		const prompt = new PromptZoneMarkdown(text, bgColor, color);
+		this.addChild(prompt);
+		if (this.#viewportAnchorSource) this.setViewportAnchorSource(prompt, this.#viewportAnchorSource);
 	}
 }
 
@@ -37,15 +50,19 @@ class PromptZoneMarkdown implements Component {
 		this.#markdown.invalidate();
 	}
 
-	render(width: number): string[] {
-		const lines = this.#markdown.render(width);
-		if (lines.length === 0) {
-			return lines;
-		}
-
+	#withPromptZone(lines: string[]): string[] {
+		if (lines.length === 0) return lines;
 		const zoned = [...lines];
 		zoned[0] = OSC133_ZONE_START + zoned[0];
 		zoned[zoned.length - 1] = `${zoned[zoned.length - 1]}${OSC133_ZONE_END}${OSC133_ZONE_FINAL}`;
 		return zoned;
+	}
+
+	renderWithViewportAnchorSource(width: number, source: ViewportAnchorSource): ViewportAnchorRender {
+		const rendered = this.#markdown.renderWithViewportAnchorSource(width, source);
+		return { lines: this.#withPromptZone(rendered.lines), anchors: rendered.anchors };
+	}
+	render(width: number): string[] {
+		return this.#withPromptZone(this.#markdown.render(width));
 	}
 }

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -941,6 +941,7 @@ export class CommandController {
 		this.ctx.updateEditorBorderColor();
 		this.ctx.ui.requestRender();
 
+		this.ctx.ui.resetViewportAnchorIntent();
 		this.ctx.chatContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();
 		this.ctx.compactionQueuedMessages = [];
@@ -979,6 +980,7 @@ export class CommandController {
 		this.ctx.updateEditorBorderColor();
 		this.ctx.ui.requestRender();
 
+		this.ctx.ui.resetViewportAnchorIntent();
 		this.ctx.chatContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();
 		this.ctx.compactionQueuedMessages = [];
@@ -1241,6 +1243,7 @@ export class CommandController {
 					: undefined;
 			await this.ctx.session.compact(instructions, options);
 
+			this.ctx.ui.prepareViewportAnchorForTranscriptRebuild();
 			this.ctx.rebuildChatFromMessages();
 
 			this.ctx.statusLine.invalidate();
@@ -1304,6 +1307,7 @@ export class CommandController {
 			this.ctx.resetIrcSidebarSession();
 
 			// Rebuild chat from the new session (which now contains the handoff document)
+			this.ctx.ui.resetViewportAnchorIntent();
 			this.ctx.rebuildChatFromMessages();
 
 			this.ctx.statusLine.invalidate();

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -49,6 +49,7 @@ import { getDisplayChangelogEntries } from "../../utils/changelog";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openPath } from "../../utils/open";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
+import { prepareTranscriptRebuild } from "../utils/ui-helpers";
 
 function showMarkdownPanel(ctx: InteractiveModeContext, title: string, markdown: string): void {
 	ctx.chatContainer.addChild(new Spacer(1));
@@ -941,7 +942,7 @@ export class CommandController {
 		this.ctx.updateEditorBorderColor();
 		this.ctx.ui.requestRender();
 
-		this.ctx.ui.resetViewportAnchorIntent();
+		prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 		this.ctx.chatContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();
 		this.ctx.compactionQueuedMessages = [];
@@ -980,7 +981,7 @@ export class CommandController {
 		this.ctx.updateEditorBorderColor();
 		this.ctx.ui.requestRender();
 
-		this.ctx.ui.resetViewportAnchorIntent();
+		prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 		this.ctx.chatContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();
 		this.ctx.compactionQueuedMessages = [];
@@ -1243,7 +1244,7 @@ export class CommandController {
 					: undefined;
 			await this.ctx.session.compact(instructions, options);
 
-			this.ctx.ui.prepareViewportAnchorForTranscriptRebuild();
+			prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
 			this.ctx.rebuildChatFromMessages();
 
 			this.ctx.statusLine.invalidate();
@@ -1307,7 +1308,7 @@ export class CommandController {
 			this.ctx.resetIrcSidebarSession();
 
 			// Rebuild chat from the new session (which now contains the handoff document)
-			this.ctx.ui.resetViewportAnchorIntent();
+			prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 			this.ctx.rebuildChatFromMessages();
 
 			this.ctx.statusLine.invalidate();

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1244,8 +1244,7 @@ export class CommandController {
 					: undefined;
 			await this.ctx.session.compact(instructions, options);
 
-			prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
-			this.ctx.rebuildChatFromMessages();
+			this.ctx.rebuildChatFromMessages("reconcile-same-transcript");
 
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorTopBorder();
@@ -1308,8 +1307,7 @@ export class CommandController {
 			this.ctx.resetIrcSidebarSession();
 
 			// Rebuild chat from the new session (which now contains the handoff document)
-			prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
-			this.ctx.rebuildChatFromMessages();
+			this.ctx.rebuildChatFromMessages("replace-identity");
 
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorTopBorder();

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -30,7 +30,7 @@ import { consumeInjectedOptimisticSignature } from "../utils/injected-user-submi
 import { parseIrcMessage } from "../utils/irc-message";
 import { ringTerminalBell } from "../utils/terminal-bell";
 
-import { addChatChild, argsWithPartialJson } from "../utils/ui-helpers";
+import { addChatChild, argsWithPartialJson, prepareTranscriptRebuild } from "../utils/ui-helpers";
 
 type AgentSessionEventKind = AgentSessionEvent["type"];
 
@@ -839,7 +839,7 @@ export class EventController {
 		if (event.aborted) {
 			this.ctx.showStatus(isHandoffAction ? "Auto-handoff cancelled" : "Auto context-full maintenance cancelled");
 		} else if (event.result) {
-			this.ctx.ui.prepareViewportAnchorForTranscriptRebuild();
+			prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
 			this.ctx.rebuildChatFromMessages();
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorTopBorder();
@@ -854,7 +854,7 @@ export class EventController {
 			// Reset BEFORE rebuild so the new session's transcript is not replayed
 			// from the old ledger and then cleared out from under its timers.
 			this.ctx.resetIrcSidebarSession();
-			this.ctx.ui.resetViewportAnchorIntent();
+			prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 			this.ctx.chatContainer.clear();
 			this.ctx.rebuildChatFromMessages();
 			this.ctx.statusLine.invalidate();

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -21,6 +21,7 @@ import { summaryFromMessage } from "../../notifications/helpers";
 import type { PlanApprovalDetails } from "../../plan-mode/approved-plan";
 import type { AgentSessionEvent } from "../../session/agent-session";
 import { type CustomMessage, isSilentAbort, readPendingDisplayTag } from "../../session/messages";
+import { transferSessionMessageIdentity } from "../../session/session-manager";
 import type { ResolveToolDetails } from "../../tools/resolve";
 import type { IrcObservationRecord } from "../irc-observation-ledger";
 import { interruptHint } from "../shared";
@@ -345,8 +346,11 @@ export class EventController {
 			this.#resetReadGroup();
 			this.#toolIntentCache.clear();
 			this.#thinkingContentIndices.clear();
-			this.ctx.streamingComponent = new AssistantMessageComponent(undefined, this.ctx.hideThinkingBlock, () =>
-				this.ctx.ui.requestRender(),
+			this.ctx.streamingComponent = new AssistantMessageComponent(
+				undefined,
+				this.ctx.hideThinkingBlock,
+				() => this.ctx.ui.requestRender(),
+				this.ctx.getAssistantViewportAnchorId?.(event.message),
 			);
 			this.ctx.streamingMessage = event.message;
 			addChatChild(this.ctx, this.ctx.streamingComponent);
@@ -474,6 +478,9 @@ export class EventController {
 
 	async #handleMessageUpdate(event: Extract<AgentSessionEvent, { type: "message_update" }>): Promise<void> {
 		if (this.ctx.streamingComponent && event.message.role === "assistant") {
+			if (this.ctx.streamingMessage?.role === "assistant") {
+				transferSessionMessageIdentity([this.ctx.streamingMessage], [event.message]);
+			}
 			this.ctx.streamingMessage = event.message;
 			this.ctx.streamingComponent.updateContent(this.ctx.streamingMessage, { streaming: true });
 			const contentIndex = event.assistantMessageEvent?.contentIndex;
@@ -577,6 +584,9 @@ export class EventController {
 	async #handleMessageEnd(event: Extract<AgentSessionEvent, { type: "message_end" }>): Promise<void> {
 		if (event.message.role === "user") return;
 		if (this.ctx.streamingComponent && event.message.role === "assistant") {
+			if (this.ctx.streamingMessage?.role === "assistant") {
+				transferSessionMessageIdentity([this.ctx.streamingMessage], [event.message]);
+			}
 			this.ctx.streamingMessage = event.message;
 			let errorMessage: string | undefined;
 			const aborted = this.ctx.streamingMessage.stopReason === "aborted";

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -30,7 +30,7 @@ import { consumeInjectedOptimisticSignature } from "../utils/injected-user-submi
 import { parseIrcMessage } from "../utils/irc-message";
 import { ringTerminalBell } from "../utils/terminal-bell";
 
-import { addChatChild, argsWithPartialJson, prepareTranscriptRebuild } from "../utils/ui-helpers";
+import { addChatChild, argsWithPartialJson } from "../utils/ui-helpers";
 
 type AgentSessionEventKind = AgentSessionEvent["type"];
 
@@ -839,8 +839,7 @@ export class EventController {
 		if (event.aborted) {
 			this.ctx.showStatus(isHandoffAction ? "Auto-handoff cancelled" : "Auto context-full maintenance cancelled");
 		} else if (event.result) {
-			prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
-			this.ctx.rebuildChatFromMessages();
+			this.ctx.rebuildChatFromMessages("reconcile-same-transcript");
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorTopBorder();
 			if (continuationDisabled && !isHandoffAction) {
@@ -854,9 +853,7 @@ export class EventController {
 			// Reset BEFORE rebuild so the new session's transcript is not replayed
 			// from the old ledger and then cleared out from under its timers.
 			this.ctx.resetIrcSidebarSession();
-			prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
-			this.ctx.chatContainer.clear();
-			this.ctx.rebuildChatFromMessages();
+			this.ctx.rebuildChatFromMessages("replace-identity");
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorTopBorder();
 			await this.ctx.reloadTodos();

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -839,6 +839,7 @@ export class EventController {
 		if (event.aborted) {
 			this.ctx.showStatus(isHandoffAction ? "Auto-handoff cancelled" : "Auto context-full maintenance cancelled");
 		} else if (event.result) {
+			this.ctx.ui.prepareViewportAnchorForTranscriptRebuild();
 			this.ctx.rebuildChatFromMessages();
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorTopBorder();
@@ -853,6 +854,7 @@ export class EventController {
 			// Reset BEFORE rebuild so the new session's transcript is not replayed
 			// from the old ledger and then cleared out from under its timers.
 			this.ctx.resetIrcSidebarSession();
+			this.ctx.ui.resetViewportAnchorIntent();
 			this.ctx.chatContainer.clear();
 			this.ctx.rebuildChatFromMessages();
 			this.ctx.statusLine.invalidate();

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -1,5 +1,3 @@
-import * as path from "node:path";
-
 import type { Component, OverlayHandle, TUI } from "@gajae-code/tui";
 import { Container, Spacer, Text } from "@gajae-code/tui";
 import { logger } from "@gajae-code/utils";
@@ -154,9 +152,7 @@ export class ExtensionUiController {
 			waitForIdle: () => this.ctx.session.agent.waitForIdle(),
 			reload: async () => {
 				await this.ctx.session.reload();
-				prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
-				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.rebuildInitialMessages("reconcile-same-transcript");
 				await this.ctx.reloadTodos();
 				this.ctx.showStatus("Reloaded session");
 			},
@@ -215,9 +211,7 @@ export class ExtensionUiController {
 				this.ctx.resetIrcSidebarSession();
 
 				// Update UI
-				prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
-				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.rebuildInitialMessages("replace-identity");
 				await this.ctx.reloadTodos();
 				this.ctx.editor.setText(result.selectedText);
 				this.ctx.showStatus("Branched to new session");
@@ -231,9 +225,7 @@ export class ExtensionUiController {
 				}
 
 				// Update UI
-				prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
-				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.rebuildInitialMessages("reconcile-same-transcript");
 				await this.ctx.reloadTodos();
 				if (result.editorText && !this.ctx.editor.getText().trim()) {
 					this.ctx.editor.setText(result.editorText);
@@ -244,26 +236,20 @@ export class ExtensionUiController {
 			},
 			compact: async instructionsOrOptions => this.#handleInteractiveCompact(instructionsOrOptions),
 			switchSession: async sessionPath => {
-				const previousSessionFile = this.ctx.sessionManager.getSessionFile();
-				const switchingToDifferentSession = previousSessionFile
-					? path.resolve(previousSessionFile) !== path.resolve(sessionPath)
-					: true;
+				const previousSessionId = this.ctx.sessionManager.getSessionId();
 
 				this.clearHookWidgets();
 				const result = await this.ctx.session.switchSession(sessionPath);
 				if (!result) {
 					return { cancelled: true };
 				}
-				if (switchingToDifferentSession) {
-					this.ctx.resetIrcSidebarSession();
-					prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
-				} else {
-					prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
-				}
+				const switchingToDifferentSession = previousSessionId !== this.ctx.sessionManager.getSessionId();
+				if (switchingToDifferentSession) this.ctx.resetIrcSidebarSession();
 
 				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
-				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.rebuildInitialMessages(
+					switchingToDifferentSession ? "replace-identity" : "reconcile-same-transcript",
+				);
 				await this.ctx.reloadTodos();
 				return { cancelled: false };
 			},
@@ -415,9 +401,7 @@ export class ExtensionUiController {
 					return;
 				}
 				await this.ctx.session.reload();
-				prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
-				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.rebuildInitialMessages("reconcile-same-transcript");
 				await this.ctx.reloadTodos();
 				this.ctx.showStatus("Reloaded session");
 			},
@@ -474,9 +458,7 @@ export class ExtensionUiController {
 				this.ctx.resetIrcSidebarSession();
 
 				// Update UI
-				prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
-				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.rebuildInitialMessages("replace-identity");
 				await this.ctx.reloadTodos();
 				this.ctx.editor.setText(result.selectedText);
 				this.ctx.showStatus("Branched to new session");
@@ -493,9 +475,7 @@ export class ExtensionUiController {
 				}
 
 				// Update UI
-				prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
-				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.rebuildInitialMessages("reconcile-same-transcript");
 				await this.ctx.reloadTodos();
 				if (result.editorText && !this.ctx.editor.getText().trim()) {
 					this.ctx.editor.setText(result.editorText);
@@ -509,24 +489,18 @@ export class ExtensionUiController {
 				if (this.ctx.isBackgrounded) {
 					return { cancelled: true };
 				}
-				const previousSessionFile = this.ctx.sessionManager.getSessionFile();
-				const switchingToDifferentSession = previousSessionFile
-					? path.resolve(previousSessionFile) !== path.resolve(sessionPath)
-					: true;
+				const previousSessionId = this.ctx.sessionManager.getSessionId();
 
 				this.clearHookWidgets();
 				const result = await this.ctx.session.switchSession(sessionPath);
 				if (!result) {
 					return { cancelled: true };
 				}
-				if (switchingToDifferentSession) {
-					this.ctx.resetIrcSidebarSession();
-					prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
-				} else {
-					prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
-				}
-				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				const switchingToDifferentSession = previousSessionId !== this.ctx.sessionManager.getSessionId();
+				if (switchingToDifferentSession) this.ctx.resetIrcSidebarSession();
+				this.ctx.rebuildInitialMessages(
+					switchingToDifferentSession ? "replace-identity" : "reconcile-same-transcript",
+				);
 				await this.ctx.reloadTodos();
 				return { cancelled: false };
 			},
@@ -1009,7 +983,7 @@ export class ExtensionUiController {
 		// For non-streaming cases with display=true, update UI
 		// (streaming cases update via message_end event)
 		if (!this.ctx.isBackgrounded && !wasStreaming && shouldDisplay) {
-			this.ctx.rebuildChatFromMessages();
+			this.ctx.rebuildChatFromMessages("reconcile-same-transcript");
 		}
 	}
 

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -151,8 +151,11 @@ export class ExtensionUiController {
 			getContextUsage: () => this.ctx.session.getContextUsage(),
 			waitForIdle: () => this.ctx.session.agent.waitForIdle(),
 			reload: async () => {
+				const previousSessionId = this.ctx.sessionManager.getSessionId();
 				await this.ctx.session.reload();
-				this.ctx.rebuildInitialMessages("reconcile-same-transcript");
+				const sessionIdentityChanged = previousSessionId !== this.ctx.sessionManager.getSessionId();
+				if (sessionIdentityChanged) this.ctx.resetIrcSidebarSession();
+				this.ctx.rebuildInitialMessages(sessionIdentityChanged ? "replace-identity" : "reconcile-same-transcript");
 				await this.ctx.reloadTodos();
 				this.ctx.showStatus("Reloaded session");
 			},
@@ -400,8 +403,11 @@ export class ExtensionUiController {
 				if (this.ctx.isBackgrounded) {
 					return;
 				}
+				const previousSessionId = this.ctx.sessionManager.getSessionId();
 				await this.ctx.session.reload();
-				this.ctx.rebuildInitialMessages("reconcile-same-transcript");
+				const sessionIdentityChanged = previousSessionId !== this.ctx.sessionManager.getSessionId();
+				if (sessionIdentityChanged) this.ctx.resetIrcSidebarSession();
+				this.ctx.rebuildInitialMessages(sessionIdentityChanged ? "replace-identity" : "reconcile-same-transcript");
 				await this.ctx.reloadTodos();
 				this.ctx.showStatus("Reloaded session");
 			},

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -153,6 +153,7 @@ export class ExtensionUiController {
 			waitForIdle: () => this.ctx.session.agent.waitForIdle(),
 			reload: async () => {
 				await this.ctx.session.reload();
+				this.ctx.ui.prepareViewportAnchorForTranscriptRebuild();
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();
 				await this.ctx.reloadTodos();
@@ -189,6 +190,7 @@ export class ExtensionUiController {
 				this.ctx.ui.requestRender();
 
 				// Clear UI state
+				this.ctx.ui.resetViewportAnchorIntent();
 				this.ctx.chatContainer.clear();
 				this.ctx.pendingMessagesContainer.clear();
 				this.ctx.compactionQueuedMessages = [];
@@ -212,6 +214,7 @@ export class ExtensionUiController {
 				this.ctx.resetIrcSidebarSession();
 
 				// Update UI
+				this.ctx.ui.resetViewportAnchorIntent();
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();
 				await this.ctx.reloadTodos();
@@ -227,6 +230,7 @@ export class ExtensionUiController {
 				}
 
 				// Update UI
+				this.ctx.ui.prepareViewportAnchorForTranscriptRebuild();
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();
 				await this.ctx.reloadTodos();
@@ -251,6 +255,7 @@ export class ExtensionUiController {
 				}
 				if (switchingToDifferentSession) {
 					this.ctx.resetIrcSidebarSession();
+					this.ctx.ui.resetViewportAnchorIntent();
 				}
 
 				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
@@ -407,6 +412,7 @@ export class ExtensionUiController {
 					return;
 				}
 				await this.ctx.session.reload();
+				this.ctx.ui.prepareViewportAnchorForTranscriptRebuild();
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();
 				await this.ctx.reloadTodos();
@@ -438,6 +444,7 @@ export class ExtensionUiController {
 				}
 
 				// Clear UI state
+				this.ctx.ui.resetViewportAnchorIntent();
 				this.ctx.chatContainer.clear();
 				this.ctx.pendingMessagesContainer.clear();
 				this.ctx.compactionQueuedMessages = [];
@@ -464,6 +471,7 @@ export class ExtensionUiController {
 				this.ctx.resetIrcSidebarSession();
 
 				// Update UI
+				this.ctx.ui.resetViewportAnchorIntent();
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();
 				await this.ctx.reloadTodos();
@@ -482,6 +490,7 @@ export class ExtensionUiController {
 				}
 
 				// Update UI
+				this.ctx.ui.prepareViewportAnchorForTranscriptRebuild();
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();
 				await this.ctx.reloadTodos();
@@ -509,6 +518,7 @@ export class ExtensionUiController {
 				}
 				if (switchingToDifferentSession) {
 					this.ctx.resetIrcSidebarSession();
+					this.ctx.ui.resetViewportAnchorIntent();
 				}
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -27,6 +27,7 @@ import type { InteractiveModeContext } from "../../modes/types";
 import { setSessionTerminalTitle, setTerminalTitle } from "../../utils/title-generator";
 import { applyInjectedUserSubmission } from "../utils/injected-user-submission";
 import { classifyHookSelectorBellEvent, ringTerminalBell } from "../utils/terminal-bell";
+import { prepareTranscriptRebuild } from "../utils/ui-helpers";
 
 const MAX_WIDGET_LINES = 10;
 const HOOK_SELECTOR_CHROME_ROWS = 7;
@@ -153,7 +154,7 @@ export class ExtensionUiController {
 			waitForIdle: () => this.ctx.session.agent.waitForIdle(),
 			reload: async () => {
 				await this.ctx.session.reload();
-				this.ctx.ui.prepareViewportAnchorForTranscriptRebuild();
+				prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();
 				await this.ctx.reloadTodos();
@@ -190,7 +191,7 @@ export class ExtensionUiController {
 				this.ctx.ui.requestRender();
 
 				// Clear UI state
-				this.ctx.ui.resetViewportAnchorIntent();
+				prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 				this.ctx.chatContainer.clear();
 				this.ctx.pendingMessagesContainer.clear();
 				this.ctx.compactionQueuedMessages = [];
@@ -214,7 +215,7 @@ export class ExtensionUiController {
 				this.ctx.resetIrcSidebarSession();
 
 				// Update UI
-				this.ctx.ui.resetViewportAnchorIntent();
+				prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();
 				await this.ctx.reloadTodos();
@@ -230,7 +231,7 @@ export class ExtensionUiController {
 				}
 
 				// Update UI
-				this.ctx.ui.prepareViewportAnchorForTranscriptRebuild();
+				prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();
 				await this.ctx.reloadTodos();
@@ -255,7 +256,9 @@ export class ExtensionUiController {
 				}
 				if (switchingToDifferentSession) {
 					this.ctx.resetIrcSidebarSession();
-					this.ctx.ui.resetViewportAnchorIntent();
+					prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
+				} else {
+					prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
 				}
 
 				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
@@ -412,7 +415,7 @@ export class ExtensionUiController {
 					return;
 				}
 				await this.ctx.session.reload();
-				this.ctx.ui.prepareViewportAnchorForTranscriptRebuild();
+				prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();
 				await this.ctx.reloadTodos();
@@ -444,7 +447,7 @@ export class ExtensionUiController {
 				}
 
 				// Clear UI state
-				this.ctx.ui.resetViewportAnchorIntent();
+				prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 				this.ctx.chatContainer.clear();
 				this.ctx.pendingMessagesContainer.clear();
 				this.ctx.compactionQueuedMessages = [];
@@ -471,7 +474,7 @@ export class ExtensionUiController {
 				this.ctx.resetIrcSidebarSession();
 
 				// Update UI
-				this.ctx.ui.resetViewportAnchorIntent();
+				prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();
 				await this.ctx.reloadTodos();
@@ -490,7 +493,7 @@ export class ExtensionUiController {
 				}
 
 				// Update UI
-				this.ctx.ui.prepareViewportAnchorForTranscriptRebuild();
+				prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();
 				await this.ctx.reloadTodos();
@@ -518,7 +521,9 @@ export class ExtensionUiController {
 				}
 				if (switchingToDifferentSession) {
 					this.ctx.resetIrcSidebarSession();
-					this.ctx.ui.resetViewportAnchorIntent();
+					prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
+				} else {
+					prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
 				}
 				this.ctx.chatContainer.clear();
 				this.ctx.renderInitialMessages();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -21,7 +21,6 @@ import { resizeImage } from "../../utils/image-resize";
 import { formatPastedImageReference, resolvePastedImagePath } from "../../utils/pasted-image-path";
 import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
 import { type QueuedMessageMoveDirection, QueuedMessageSelectorComponent } from "../components/queued-message-selector";
-import { prepareTranscriptRebuild } from "../utils/ui-helpers";
 
 interface Expandable {
 	setExpanded(expanded: boolean): void;
@@ -1352,9 +1351,7 @@ export class InputController {
 		if (this.ctx.streamingComponent) {
 			this.ctx.chatContainer.detachChild(this.ctx.streamingComponent);
 		}
-		prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
-		this.ctx.chatContainer.clear();
-		this.ctx.rebuildChatFromMessages();
+		this.ctx.rebuildChatFromMessages("reconcile-same-transcript");
 
 		// If streaming, re-add the streaming component with updated visibility and re-render
 		if (this.ctx.streamingComponent && this.ctx.streamingMessage) {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -21,6 +21,7 @@ import { resizeImage } from "../../utils/image-resize";
 import { formatPastedImageReference, resolvePastedImagePath } from "../../utils/pasted-image-path";
 import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
 import { type QueuedMessageMoveDirection, QueuedMessageSelectorComponent } from "../components/queued-message-selector";
+import { prepareTranscriptRebuild } from "../utils/ui-helpers";
 
 interface Expandable {
 	setExpanded(expanded: boolean): void;
@@ -1351,6 +1352,7 @@ export class InputController {
 		if (this.ctx.streamingComponent) {
 			this.ctx.chatContainer.detachChild(this.ctx.streamingComponent);
 		}
+		prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
 		this.ctx.chatContainer.clear();
 		this.ctx.rebuildChatFromMessages();
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1400,6 +1400,7 @@ export class SelectorController {
 
 		this.#refreshSessionTerminalTitle();
 
+		this.ctx.ui.resetViewportAnchorIntent();
 		this.#clearTransientSessionUi();
 		this.ctx.statusLine.invalidate();
 		this.ctx.statusLine.setSessionStartTime(Date.now());
@@ -1422,6 +1423,7 @@ export class SelectorController {
 		if (!(await this.ctx.session.switchSession(sessionPath))) return;
 		if (switchingToDifferentSession) {
 			this.ctx.resetIrcSidebarSession();
+			this.ctx.ui.resetViewportAnchorIntent();
 		}
 		this.#refreshSessionTerminalTitle();
 		this.ctx.updateEditorBorderColor();

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1,5 +1,3 @@
-import * as path from "node:path";
-
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import type { OAuthProvider } from "@gajae-code/ai/utils/oauth/types";
@@ -96,7 +94,6 @@ import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
 import type { JobsObserver } from "../jobs-observer";
 import type { SessionObserverRegistry } from "../session-observer-registry";
-import { prepareTranscriptRebuild } from "../utils/ui-helpers";
 
 const CALLBACK_SERVER_PROVIDERS = new Set<string>([
 	"anthropic",
@@ -718,9 +715,7 @@ export class SelectorController {
 						child.setHideThinkingBlock(value as boolean);
 					}
 				}
-				prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
-				this.ctx.chatContainer.clear();
-				this.ctx.rebuildChatFromMessages();
+				this.ctx.rebuildChatFromMessages("reconcile-same-transcript");
 				break;
 			case "theme": {
 				setTheme(value as string, true).then(result => {
@@ -1185,9 +1180,7 @@ export class SelectorController {
 					}
 					this.ctx.resetIrcSidebarSession();
 
-					prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
-					this.ctx.chatContainer.clear();
-					this.ctx.renderInitialMessages();
+					this.ctx.rebuildInitialMessages("replace-identity");
 					this.ctx.editor.setText(result.selectedText);
 					done();
 					this.ctx.showStatus("Branched to new session");
@@ -1297,9 +1290,7 @@ export class SelectorController {
 						}
 
 						// Update UI — pass the context built by navigateTree to skip a second O(N) walk.
-						prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
-						this.ctx.chatContainer.clear();
-						this.ctx.renderInitialMessages(result.sessionContext);
+						this.ctx.rebuildInitialMessages("reconcile-same-transcript", result.sessionContext);
 						await this.ctx.reloadTodos();
 						if (result.editorText && !this.ctx.editor.getText().trim()) {
 							this.ctx.editor.setText(result.editorText);
@@ -1404,39 +1395,29 @@ export class SelectorController {
 
 		this.#refreshSessionTerminalTitle();
 
-		prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 		this.#clearTransientSessionUi();
 		this.ctx.statusLine.invalidate();
 		this.ctx.statusLine.setSessionStartTime(Date.now());
 		this.ctx.updateEditorTopBorder();
 		this.ctx.updateEditorBorderColor();
-		this.ctx.renderInitialMessages();
+		this.ctx.rebuildInitialMessages("replace-identity");
 		await this.ctx.reloadTodos();
 		this.ctx.ui.requestRender();
 		return true;
 	}
 
 	async handleResumeSession(sessionPath: string): Promise<void> {
-		const previousSessionFile = this.ctx.sessionManager.getSessionFile();
-		const switchingToDifferentSession = previousSessionFile
-			? path.resolve(previousSessionFile) !== path.resolve(sessionPath)
-			: true;
+		const previousSessionId = this.ctx.sessionManager.getSessionId();
 		this.#clearTransientSessionUi();
 
 		// Switch session via AgentSession (emits hook and tool session events)
 		if (!(await this.ctx.session.switchSession(sessionPath))) return;
-		if (switchingToDifferentSession) {
-			this.ctx.resetIrcSidebarSession();
-			prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
-		} else {
-			prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
-		}
+		const switchingToDifferentSession = previousSessionId !== this.ctx.sessionManager.getSessionId();
+		if (switchingToDifferentSession) this.ctx.resetIrcSidebarSession();
 		this.#refreshSessionTerminalTitle();
 		this.ctx.updateEditorBorderColor();
 
-		// Clear and re-render the chat
-		this.ctx.chatContainer.clear();
-		this.ctx.renderInitialMessages();
+		this.ctx.rebuildInitialMessages(switchingToDifferentSession ? "replace-identity" : "reconcile-same-transcript");
 		await this.ctx.reloadTodos();
 		this.ctx.showStatus("Resumed session");
 	}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -96,6 +96,7 @@ import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
 import type { JobsObserver } from "../jobs-observer";
 import type { SessionObserverRegistry } from "../session-observer-registry";
+import { prepareTranscriptRebuild } from "../utils/ui-helpers";
 
 const CALLBACK_SERVER_PROVIDERS = new Set<string>([
 	"anthropic",
@@ -717,6 +718,7 @@ export class SelectorController {
 						child.setHideThinkingBlock(value as boolean);
 					}
 				}
+				prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
 				this.ctx.chatContainer.clear();
 				this.ctx.rebuildChatFromMessages();
 				break;
@@ -1183,6 +1185,7 @@ export class SelectorController {
 					}
 					this.ctx.resetIrcSidebarSession();
 
+					prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 					this.ctx.chatContainer.clear();
 					this.ctx.renderInitialMessages();
 					this.ctx.editor.setText(result.selectedText);
@@ -1294,6 +1297,7 @@ export class SelectorController {
 						}
 
 						// Update UI — pass the context built by navigateTree to skip a second O(N) walk.
+						prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
 						this.ctx.chatContainer.clear();
 						this.ctx.renderInitialMessages(result.sessionContext);
 						await this.ctx.reloadTodos();
@@ -1400,7 +1404,7 @@ export class SelectorController {
 
 		this.#refreshSessionTerminalTitle();
 
-		this.ctx.ui.resetViewportAnchorIntent();
+		prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
 		this.#clearTransientSessionUi();
 		this.ctx.statusLine.invalidate();
 		this.ctx.statusLine.setSessionStartTime(Date.now());
@@ -1423,7 +1427,9 @@ export class SelectorController {
 		if (!(await this.ctx.session.switchSession(sessionPath))) return;
 		if (switchingToDifferentSession) {
 			this.ctx.resetIrcSidebarSession();
-			this.ctx.ui.resetViewportAnchorIntent();
+			prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
+		} else {
+			prepareTranscriptRebuild(this.ctx.ui, "reconcile-same-transcript");
 		}
 		this.#refreshSessionTerminalTitle();
 		this.ctx.updateEditorBorderColor();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -116,7 +116,14 @@ import {
 	onThemeChange,
 	theme,
 } from "./theme/theme";
-import type { CompactionQueuedMessage, InteractiveModeContext, SubmittedUserInput, TodoItem, TodoPhase } from "./types";
+import type {
+	CompactionQueuedMessage,
+	InteractiveModeContext,
+	SubmittedUserInput,
+	TodoItem,
+	TodoPhase,
+	TranscriptRebuildPolicy,
+} from "./types";
 import { addChatChild, prepareTranscriptRebuild, UiHelpers } from "./utils/ui-helpers";
 
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
@@ -884,8 +891,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		if (!submission.customType) {
 			this.pendingImages = submission.images ? [...submission.images] : [];
-			prepareTranscriptRebuild(this.ui, "reconcile-same-transcript");
-			this.rebuildChatFromMessages();
+			this.rebuildChatFromMessages("reconcile-same-transcript");
 			this.editor.setText(submission.text);
 		}
 		this.updateEditorChrome();
@@ -1033,7 +1039,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.editor.setTopBorder(undefined);
 	}
 
-	rebuildChatFromMessages(): void {
+	rebuildChatFromMessages(policy: TranscriptRebuildPolicy): void {
+		prepareTranscriptRebuild(this.ui, policy);
 		this.chatContainer.clear();
 		const context = this.session.buildDisplaySessionContext();
 		this.renderSessionContext(context);
@@ -2308,6 +2315,14 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#eventController.reconcileIrcExpiryTimers(this.#uiHelpers.getRenderedIrcInlineComponents());
 	}
 
+	rebuildInitialMessages(
+		policy: TranscriptRebuildPolicy,
+		prebuiltContext?: SessionContext,
+		options?: { preserveExistingChat?: boolean },
+	): void {
+		prepareTranscriptRebuild(this.ui, policy);
+		this.#uiHelpers.renderInitialMessages(prebuiltContext, options);
+	}
 	renderInitialMessages(prebuiltContext?: SessionContext, options?: { preserveExistingChat?: boolean }): void {
 		this.#uiHelpers.renderInitialMessages(prebuiltContext, options);
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -391,6 +391,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	#eventBusUnsubscribers: Array<() => void> = [];
 	#welcomeComponent?: WelcomeComponent;
 	#ircSplitView: IrcSplitViewComponent;
+	#ircSidebarAvailable = false;
+	#ircSidebarRequestedVisible = false;
 
 	constructor(
 		session: AgentSession,
@@ -568,6 +570,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		this.ui.addChild(this.#ircSplitView);
+		this.ui.setViewportAnchorComponent(this.#ircSplitView);
+
 		this.ui.addChild(this.pendingMessagesContainer);
 		this.ui.addChild(this.statusContainer);
 		this.ui.addChild(this.todoContainer);
@@ -2315,6 +2319,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#uiHelpers.findLastAssistantMessage();
 	}
 
+	getAssistantViewportAnchorId(message: AssistantMessage): string {
+		return this.#uiHelpers.assistantViewportAnchorId(message);
+	}
+
 	extractAssistantText(message: AssistantMessage): string {
 		return this.#uiHelpers.extractAssistantText(message);
 	}
@@ -2681,15 +2689,21 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	toggleIrcSidebar(): void {
-		if (this.settings.get("irc.enabled") !== true || this.settings.get("irc.sidebar.enabled") !== true) return;
-		this.#ircSplitView.setVisible(!this.#ircSplitView.visible);
+		if (
+			!this.#ircSidebarAvailable ||
+			this.settings.get("irc.enabled") !== true ||
+			this.settings.get("irc.sidebar.enabled") !== true
+		)
+			return;
+		this.#ircSidebarRequestedVisible = !this.#ircSidebarRequestedVisible;
+		this.#ircSplitView.setVisible(this.#ircSidebarRequestedVisible);
 		this.#invalidateIrcSidebarRender();
 		this.ui.requestRender();
 	}
 
 	applyIrcSidebarAvailability(enabled: boolean): void {
-		if (enabled) return;
-		this.#ircSplitView.setVisible(false);
+		this.#ircSidebarAvailable = enabled;
+		this.#ircSplitView.setVisible(enabled && this.#ircSidebarRequestedVisible);
 		this.#invalidateIrcSidebarRender();
 		this.ui.requestRender();
 	}
@@ -2697,6 +2711,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	resetIrcSidebarSession(): void {
 		this.ircLedger.reset();
 		this.#eventController.resetIrcObservations();
+		this.#ircSidebarAvailable = false;
+		this.#ircSidebarRequestedVisible = false;
 		this.#ircSplitView.setVisible(false);
 		this.#invalidateIrcSidebarRender();
 		this.ui.requestRender();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -117,7 +117,7 @@ import {
 	theme,
 } from "./theme/theme";
 import type { CompactionQueuedMessage, InteractiveModeContext, SubmittedUserInput, TodoItem, TodoPhase } from "./types";
-import { addChatChild, UiHelpers } from "./utils/ui-helpers";
+import { addChatChild, prepareTranscriptRebuild, UiHelpers } from "./utils/ui-helpers";
 
 const INTERACTIVE_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
 const COMPOSER_NEWLINE_HINT = process.platform === "win32" ? "Alt+Enter/Ctrl+J" : "Shift+Enter/Ctrl+J";
@@ -884,6 +884,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		if (!submission.customType) {
 			this.pendingImages = submission.images ? [...submission.images] : [];
+			prepareTranscriptRebuild(this.ui, "reconcile-same-transcript");
 			this.rebuildChatFromMessages();
 			this.editor.setText(submission.text);
 		}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -31,6 +31,8 @@ import type { ToolExecutionHandle } from "./components/tool-execution";
 import type { IrcObservationLedger } from "./irc-observation-ledger";
 import type { OAuthManualInputManager } from "./oauth-manual-input";
 import type { Theme } from "./theme/theme";
+
+export type TranscriptRebuildPolicy = "replace-identity" | "reconcile-same-transcript";
 export type CompactionQueuedMessage = {
 	text: string;
 	mode: "steer" | "followUp";
@@ -192,14 +194,18 @@ export interface InteractiveModeContext {
 		sessionContext: SessionContext,
 		options?: { updateFooter?: boolean; populateHistory?: boolean },
 	): void;
-	renderInitialMessages(prebuiltContext?: SessionContext, options?: { preserveExistingChat?: boolean }): void;
+	rebuildInitialMessages(
+		policy: TranscriptRebuildPolicy,
+		prebuiltContext?: SessionContext,
+		options?: { preserveExistingChat?: boolean },
+	): void;
 	getUserMessageText(message: Message): string;
 	getAssistantViewportAnchorId?(message: AssistantMessage): string;
 	findLastAssistantMessage(): AssistantMessage | undefined;
 	extractAssistantText(message: AssistantMessage): string;
 	updateEditorTopBorder(): void;
 	updateEditorBorderColor(): void;
-	rebuildChatFromMessages(): void;
+	rebuildChatFromMessages(policy: TranscriptRebuildPolicy): void;
 	setTodos(todos: TodoItem[] | TodoPhase[]): void;
 	reloadTodos(): Promise<void>;
 	toggleTodoExpansion(): void;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -194,6 +194,7 @@ export interface InteractiveModeContext {
 	): void;
 	renderInitialMessages(prebuiltContext?: SessionContext, options?: { preserveExistingChat?: boolean }): void;
 	getUserMessageText(message: Message): string;
+	getAssistantViewportAnchorId?(message: AssistantMessage): string;
 	findLastAssistantMessage(): AssistantMessage | undefined;
 	extractAssistantText(message: AssistantMessage): string;
 	updateEditorTopBorder(): void;

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -20,7 +20,7 @@ import { SkillMessageComponent } from "../../modes/components/skill-message";
 import { ToolExecutionComponent } from "../../modes/components/tool-execution";
 import { UserMessageComponent } from "../../modes/components/user-message";
 import { theme } from "../../modes/theme/theme";
-import type { CompactionQueuedMessage, InteractiveModeContext } from "../../modes/types";
+import type { CompactionQueuedMessage, InteractiveModeContext, TranscriptRebuildPolicy } from "../../modes/types";
 import {
 	type CustomMessage,
 	isSilentAbort,
@@ -37,7 +37,7 @@ import { formatBytes, formatDuration } from "../../tools/render-utils";
 import { buildAbortDisplayMessage } from "./abort-message";
 import { isIrcCustomType, type ParsedIrcMessage, parseIrcMessage } from "./irc-message";
 
-export type TranscriptRebuildPolicy = "replace-identity" | "reconcile-same-transcript";
+export type { TranscriptRebuildPolicy } from "../../modes/types";
 
 export function prepareTranscriptRebuild(ui: TUI, policy: TranscriptRebuildPolicy): void {
 	if (policy === "replace-identity") ui.resetViewportAnchorIntent();

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -27,7 +27,12 @@ import {
 	SKILL_PROMPT_MESSAGE_TYPE,
 	type SkillPromptDetails,
 } from "../../session/messages";
-import type { SessionContext } from "../../session/session-manager";
+import {
+	associateSessionMessageViewportAnchorId,
+	getSessionMessageEntryId,
+	getSessionMessageViewportAnchorId,
+	type SessionContext,
+} from "../../session/session-manager";
 import { formatBytes, formatDuration } from "../../tools/render-utils";
 import { buildAbortDisplayMessage } from "./abort-message";
 import { isIrcCustomType, type ParsedIrcMessage, parseIrcMessage } from "./irc-message";
@@ -119,8 +124,18 @@ function getChatChildTime(component: Component): number {
 	return chatChildAddedAt.get(component) ?? Date.now();
 }
 
+function stableSemanticIdPart(value: string): string {
+	let hash = 0xcbf29ce484222325n;
+	for (const char of value) {
+		hash ^= BigInt(char.codePointAt(0)!);
+		hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+	}
+	return hash.toString(36);
+}
+
 export function addChatChild(ctx: InteractiveModeContext, component: Component): void {
 	ctx.chatContainer.addChild(component);
+
 	chatChildAddedAt.set(component, Date.now());
 	trimChatChildren(ctx);
 }
@@ -187,8 +202,53 @@ export function trimChatChildren(ctx: InteractiveModeContext): void {
 }
 
 export class UiHelpers {
-	constructor(private ctx: InteractiveModeContext) {}
 	#renderedIrcInlineComponents = new Map<string, readonly Component[]>();
+	#viewportAnchorOccurrences = new WeakMap<object, { base: string; epoch: number; id: string }>();
+	#nextViewportAnchorOccurrence = new Map<string, number>();
+	#viewportAnchorOccurrenceEpoch = 0;
+
+	constructor(private ctx: InteractiveModeContext) {}
+
+	#resetViewportAnchorOccurrencePass(): void {
+		this.#viewportAnchorOccurrenceEpoch += 1;
+		this.#nextViewportAnchorOccurrence.clear();
+	}
+
+	#viewportAnchorOccurrenceId(message: object, base: string): string {
+		const existing = this.#viewportAnchorOccurrences.get(message);
+		if (existing?.base === base && existing.epoch === this.#viewportAnchorOccurrenceEpoch) return existing.id;
+		const occurrence = this.#nextViewportAnchorOccurrence.get(base) ?? 0;
+		this.#nextViewportAnchorOccurrence.set(base, occurrence + 1);
+		const id = `${base}:occurrence:${occurrence}`;
+		this.#viewportAnchorOccurrences.set(message, {
+			base,
+			epoch: this.#viewportAnchorOccurrenceEpoch,
+			id,
+		});
+		return id;
+	}
+
+	assistantViewportAnchorId(message: AssistantMessage): string {
+		const semanticId = getSessionMessageViewportAnchorId(message);
+		if (semanticId) return semanticId;
+		const entryId = getSessionMessageEntryId(message);
+		if (entryId) return `assistant:entry:${entryId}`;
+		const base = `assistant:${message.api}:${message.provider}:${message.model}:${message.timestamp}`;
+		const id = this.#viewportAnchorOccurrenceId(message, base);
+		associateSessionMessageViewportAnchorId(message, id);
+		return id;
+	}
+
+	#userViewportAnchorId(message: Extract<Message, { role: "user" }>): string {
+		const semanticId = getSessionMessageViewportAnchorId(message);
+		if (semanticId) return semanticId;
+		const entryId = getSessionMessageEntryId(message);
+		if (entryId) return `user:entry:${entryId}`;
+		const base = `user:local:${message.timestamp}:${stableSemanticIdPart(JSON.stringify(message.content))}`;
+		const id = this.#viewportAnchorOccurrenceId(message, base);
+		associateSessionMessageViewportAnchorId(message, id);
+		return id;
+	}
 
 	getRenderedIrcInlineComponents(): Map<string, readonly Component[]> {
 		return this.#renderedIrcInlineComponents;
@@ -407,7 +467,11 @@ export class UiHelpers {
 				const textContent = this.ctx.getUserMessageText(message);
 				if (textContent) {
 					const isSynthetic = message.role === "developer" ? true : (message.synthetic ?? false);
-					const userComponent = new UserMessageComponent(textContent, isSynthetic);
+					const userComponent = new UserMessageComponent(
+						textContent,
+						isSynthetic,
+						message.role === "user" && !isSynthetic ? this.#userViewportAnchorId(message) : undefined,
+					);
 					addChatChild(this.ctx, userComponent);
 					if (options?.populateHistory && message.role === "user" && !isSynthetic) {
 						this.ctx.editor.addToHistory(textContent);
@@ -416,8 +480,11 @@ export class UiHelpers {
 				break;
 			}
 			case "assistant": {
-				const assistantComponent = new AssistantMessageComponent(message, this.ctx.hideThinkingBlock, () =>
-					this.ctx.ui.requestRender(),
+				const assistantComponent = new AssistantMessageComponent(
+					message,
+					this.ctx.hideThinkingBlock,
+					() => this.ctx.ui.requestRender(),
+					this.assistantViewportAnchorId(message),
 				);
 				addChatChild(this.ctx, assistantComponent);
 				break;
@@ -457,6 +524,7 @@ export class UiHelpers {
 		const deferredMessages: AgentMessage[] = [];
 		const persistedIrcObservationIds = new Set<string>();
 		const now = Date.now();
+		this.#resetViewportAnchorOccurrencePass();
 		this.#renderedIrcInlineComponents.clear();
 		for (const message of sessionContext.messages) {
 			// Defer compaction summaries so they render at the bottom (visible after scroll)

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@gajae-code/agent-core";
 import type { AssistantMessage, ImageContent, Message } from "@gajae-code/ai";
-import { type Component, Spacer, Text, TruncatedText } from "@gajae-code/tui";
+import { type Component, Spacer, Text, TruncatedText, type TUI } from "@gajae-code/tui";
 import { settings } from "../../config/settings";
 import { resolveSubskillActivationForSkillInvocation } from "../../extensibility/gjc-plugins";
 import { buildSkillPromptMessage, parseSkillInvocations } from "../../extensibility/skills";
@@ -37,6 +37,12 @@ import { formatBytes, formatDuration } from "../../tools/render-utils";
 import { buildAbortDisplayMessage } from "./abort-message";
 import { isIrcCustomType, type ParsedIrcMessage, parseIrcMessage } from "./irc-message";
 
+export type TranscriptRebuildPolicy = "replace-identity" | "reconcile-same-transcript";
+
+export function prepareTranscriptRebuild(ui: TUI, policy: TranscriptRebuildPolicy): void {
+	if (policy === "replace-identity") ui.resetViewportAnchorIntent();
+	else ui.prepareViewportAnchorForTranscriptRebuild();
+}
 type TextBlock = { type: "text"; text: string };
 interface RenderInitialMessagesOptions {
 	preserveExistingChat?: boolean;

--- a/packages/coding-agent/src/secrets/obfuscator.ts
+++ b/packages/coding-agent/src/secrets/obfuscator.ts
@@ -1,5 +1,5 @@
 import type { Message, TextContent } from "@gajae-code/ai";
-import type { SessionContext } from "../session/session-manager";
+import { type SessionContext, transferSessionMessageIdentity } from "../session/session-manager";
 import { compileSecretRegex } from "./regex";
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -281,7 +281,9 @@ export function deobfuscateSessionContext(
 ): SessionContext {
 	if (!obfuscator?.hasSecrets()) return sessionContext;
 	const messages = obfuscator.deobfuscateObject(sessionContext.messages);
-	return messages === sessionContext.messages ? sessionContext : { ...sessionContext, messages };
+	if (messages === sessionContext.messages) return sessionContext;
+	transferSessionMessageIdentity(sessionContext.messages, messages);
+	return { ...sessionContext, messages };
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -300,7 +300,7 @@ import type {
 	SessionContext,
 	SessionManager,
 } from "./session-manager";
-import { getLatestCompactionEntry } from "./session-manager";
+import { getLatestCompactionEntry, transferSessionMessageIdentity } from "./session-manager";
 import { ToolChoiceQueue } from "./tool-choice-queue";
 import { YieldQueue } from "./yield-queue";
 
@@ -2210,7 +2210,9 @@ export class AgentSession {
 			const message = event.message;
 			const deobfuscatedContent = obfuscator.deobfuscateObject(message.content);
 			if (deobfuscatedContent !== message.content) {
-				displayEvent = { ...event, message: { ...message, content: deobfuscatedContent } };
+				const displayMessage = { ...message, content: deobfuscatedContent };
+				transferSessionMessageIdentity([message], [displayMessage]);
+				displayEvent = { ...event, message: displayMessage };
 			}
 		}
 
@@ -2225,6 +2227,15 @@ export class AgentSession {
 		}
 
 		await this.#emitSessionEvent(displayEvent);
+		if (
+			displayEvent !== event &&
+			displayEvent.type === "message_end" &&
+			displayEvent.message.role === "assistant" &&
+			event.type === "message_end" &&
+			event.message.role === "assistant"
+		) {
+			transferSessionMessageIdentity([displayEvent.message], [event.message]);
+		}
 
 		if (event.type === "turn_start") {
 			this.#resetStreamingEditState();

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -145,6 +145,39 @@ export interface SessionMessageEntry extends SessionEntryBase {
 	evictedContent?: EvictedContentMarker;
 }
 
+const sessionMessageEntryIds = new WeakMap<object, string>();
+const sessionMessageViewportAnchorIds = new WeakMap<object, string>();
+
+export function associateSessionMessageEntryId(message: AgentMessage, entryId: string): void {
+	sessionMessageEntryIds.set(message, entryId);
+}
+
+export function getSessionMessageEntryId(message: AgentMessage): string | undefined {
+	return sessionMessageEntryIds.get(message);
+}
+
+export function associateSessionMessageViewportAnchorId(message: AgentMessage, anchorId: string): void {
+	sessionMessageViewportAnchorIds.set(message, anchorId);
+}
+
+export function getSessionMessageViewportAnchorId(message: AgentMessage): string | undefined {
+	return sessionMessageViewportAnchorIds.get(message);
+}
+
+export function transferSessionMessageIdentity(source: AgentMessage[], target: AgentMessage[]): void {
+	if (source.length !== target.length) {
+		throw new Error(
+			`Cannot transfer session message identity across ${source.length} source and ${target.length} target messages`,
+		);
+	}
+	for (let index = 0; index < source.length; index++) {
+		const entryId = getSessionMessageEntryId(source[index]);
+		if (entryId) associateSessionMessageEntryId(target[index], entryId);
+		const anchorId = getSessionMessageViewportAnchorId(source[index]);
+		if (anchorId) associateSessionMessageViewportAnchorId(target[index], anchorId);
+	}
+}
+
 export interface ThinkingLevelChangeEntry extends SessionEntryBase {
 	type: "thinking_level_change";
 	thinkingLevel?: string | null;
@@ -747,6 +780,7 @@ export function buildSessionContext(
 
 	const appendMessage = (entry: SessionEntry) => {
 		if (entry.type === "message") {
+			associateSessionMessageEntryId(entry.message, entry.id);
 			messages.push(entry.message);
 		} else if (entry.type === "custom_message") {
 			messages.push(
@@ -836,9 +870,11 @@ export function buildSessionContext(
 }
 
 function cloneSessionContext(context: SessionContext): SessionContext {
+	const messages = cloneJsonSemantic(context.messages);
+	transferSessionMessageIdentity(context.messages, messages);
 	return {
 		...context,
-		messages: cloneJsonSemantic(context.messages),
+		messages,
 		models: { ...context.models },
 		injectedTtsrRules: [...context.injectedTtsrRules],
 		injectedTtsrRuleRecords: context.injectedTtsrRuleRecords?.map(record => ({ ...record })),
@@ -1605,11 +1641,13 @@ function cloneJsonSemantic<T>(value: T): T {
 }
 
 function cloneAgentMessage<T extends AgentMessage>(message: T): T {
-	return {
+	const cloned = {
 		...message,
 		...("content" in message ? { content: cloneJsonSemantic(message.content) } : {}),
 		...("providerPayload" in message ? { providerPayload: cloneJsonSemantic(message.providerPayload) } : {}),
-	};
+	} as T;
+	transferSessionMessageIdentity([message], [cloned]);
+	return cloned;
 }
 
 function cloneSessionEntry(entry: SessionEntry): SessionEntry {
@@ -3874,7 +3912,10 @@ export class SessionManager {
 			timestamp: new Date().toISOString(),
 			message,
 		};
+		associateSessionMessageEntryId(message, entry.id);
 		this.#appendEntry(entry);
+		const residentEntry = this.#byId.get(entry.id);
+		if (residentEntry?.type === "message") transferSessionMessageIdentity([message], [residentEntry.message]);
 		return entry.id;
 	}
 
@@ -4546,6 +4587,9 @@ export class SessionManager {
 			this.#residentBlobStoresForColdRehydrate(),
 		);
 		if (rehydrated !== materialized) this.#coldSpillReadCount += this.#countColdSpillPayloads(entry);
+		if (entry.type === "message" && rehydrated.type === "message") {
+			transferSessionMessageIdentity([entry.message], [rehydrated.message]);
+		}
 		return rehydrated;
 	}
 

--- a/packages/coding-agent/test/docs-index-lazy.test.ts
+++ b/packages/coding-agent/test/docs-index-lazy.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
 
 function runBunEval(script: string) {
 	const result = Bun.spawnSync({
 		cmd: [process.execPath, "-e", script],
-		cwd: process.cwd(),
+		cwd: path.join(import.meta.dir, ".."),
 		stdout: "pipe",
 		stderr: "pipe",
 	});

--- a/packages/coding-agent/test/fixtures/resume-exit-code-probe.ts
+++ b/packages/coding-agent/test/fixtures/resume-exit-code-probe.ts
@@ -1,0 +1,18 @@
+import { parseArgs } from "../../src/cli/args";
+import { runRootCommand } from "../../src/main";
+
+const requested = process.argv[2];
+const expectedExitCode = requested === "undefined" ? undefined : Number(requested);
+if (expectedExitCode !== undefined) process.exitCode = expectedExitCode;
+
+const originalExitCode = process.exitCode;
+await runRootCommand(parseArgs(["--resume"]), [], {
+	suppressProcessExit: true,
+	isResumePickerTerminal: () => false,
+});
+
+if (process.exitCode !== originalExitCode) {
+	throw new Error(`Expected process.exitCode ${String(originalExitCode)}, received ${String(process.exitCode)}`);
+}
+
+process.exitCode = 0;

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -8,7 +8,14 @@ import { initTheme, theme } from "@gajae-code/coding-agent/modes/theme/theme";
 import { CURSOR_MARKER, Text, visibleWidth } from "@gajae-code/tui";
 import { TempDir } from "@gajae-code/utils";
 import { ModelRegistry } from "../src/config/model-registry";
+import type {
+	ExtensionActions,
+	ExtensionCommandContextActions,
+	ExtensionContextActions,
+	ExtensionUIContext,
+} from "../src/extensibility/extensions";
 import { CustomEditor } from "../src/modes/components/custom-editor";
+import { ExtensionUiController } from "../src/modes/controllers/extension-ui-controller";
 import { InteractiveMode } from "../src/modes/interactive-mode";
 import { AgentSession } from "../src/session/agent-session";
 import { AuthStorage } from "../src/session/auth-storage";
@@ -68,6 +75,56 @@ describe("InteractiveMode.setEditorComponent", () => {
 		authStorage?.close();
 		tempDir?.removeSync();
 		resetSettingsForTest();
+	});
+
+	it("applies viewport policy inside the real destructive rebuild methods", () => {
+		const reset = vi.spyOn(mode.ui, "resetViewportAnchorIntent");
+		const reconcile = vi.spyOn(mode.ui, "prepareViewportAnchorForTranscriptRebuild");
+		vi.spyOn(mode, "renderSessionContext").mockImplementation(() => undefined);
+
+		mode.rebuildChatFromMessages("replace-identity");
+		expect(reset).toHaveBeenCalledTimes(1);
+		expect(reconcile).not.toHaveBeenCalled();
+
+		mode.rebuildInitialMessages("reconcile-same-transcript", {
+			messages: [],
+			thinkingLevel: "off",
+			serviceTier: undefined,
+			models: {},
+			injectedTtsrRules: [],
+			selectedMCPToolNames: [],
+			hasPersistedMCPToolSelection: false,
+			mode: "none",
+		});
+		expect(reconcile).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders an idle extension custom message through the real rebuild boundary", async () => {
+		let actions: ExtensionActions | undefined;
+		const extensionRunner = {
+			initialize(
+				capturedActions: ExtensionActions,
+				_contextActions: ExtensionContextActions,
+				_commandContextActions?: ExtensionCommandContextActions,
+				_uiContext?: ExtensionUIContext,
+			): void {
+				actions = capturedActions;
+			},
+			getMessageRenderer: () => undefined,
+		};
+		Object.defineProperty(session, "extensionRunner", {
+			configurable: true,
+			value: extensionRunner as unknown as AgentSession["extensionRunner"],
+		});
+		const reconcile = vi.spyOn(mode.ui, "prepareViewportAnchorForTranscriptRebuild");
+		new ExtensionUiController(mode).initializeHookRunner({} as ExtensionUIContext, false);
+		if (!actions) throw new Error("Extension actions were not initialized");
+
+		actions.sendMessage({ customType: "test", content: "visible extension message", display: true });
+		await Bun.sleep(0);
+
+		expect(reconcile).toHaveBeenCalledTimes(1);
+		expect(mode.chatContainer.render(80).join("\n")).toContain("visible extension message");
 	});
 
 	it("renders the default composer as a closed rounded input box", () => {

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:
 import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { Agent } from "@gajae-code/agent-core";
+import type { AssistantMessage } from "@gajae-code/ai";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { initTheme, theme } from "@gajae-code/coding-agent/modes/theme/theme";
 import { CURSOR_MARKER, Text, visibleWidth } from "@gajae-code/tui";
@@ -11,7 +12,7 @@ import { CustomEditor } from "../src/modes/components/custom-editor";
 import { InteractiveMode } from "../src/modes/interactive-mode";
 import { AgentSession } from "../src/session/agent-session";
 import { AuthStorage } from "../src/session/auth-storage";
-import { SessionManager } from "../src/session/session-manager";
+import { associateSessionMessageEntryId, type SessionContext, SessionManager } from "../src/session/session-manager";
 
 class TestModalEditor extends CustomEditor {}
 function stripRenderControls(line: string): string {
@@ -83,6 +84,191 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(lines.join("\n")).not.toContain("›");
 	});
 
+	it("keeps transcript anchoring registered across live IRC sidebar settings", () => {
+		const setViewportAnchor = vi.spyOn(mode.ui, "setViewportAnchorComponent");
+		mode.settings.set("irc.enabled", true);
+		mode.settings.set("irc.sidebar.enabled", true);
+		mode.applyIrcSidebarAvailability(true);
+		mode.toggleIrcSidebar();
+		mode.settings.set("irc.sidebar.enabled", false);
+		mode.applyIrcSidebarAvailability(false);
+		expect(setViewportAnchor).not.toHaveBeenCalled();
+	});
+
+	it("marks only durable transcript messages as viewport-anchor eligible", async () => {
+		await mode.init();
+		mode.addMessageToChat({ role: "user", content: "durable semantic user", timestamp: 1 });
+		mode.addMessageToChat({ role: "user", content: "synthetic replay row", synthetic: true, timestamp: 2 });
+		mode.showStatus("ephemeral status row");
+
+		const rendered = mode.chatContainer.renderWithViewportAnchors(48);
+		const plainLines = rendered.lines.map(line => Bun.stripANSI(line));
+		const durableRow = plainLines.findIndex(line => line.includes("durable semantic user"));
+		const syntheticRow = plainLines.findIndex(line => line.includes("synthetic replay row"));
+		const statusRow = plainLines.findIndex(line => line.includes("ephemeral status row"));
+		expect(durableRow).toBeGreaterThanOrEqual(0);
+		expect(rendered.anchors[durableRow]).not.toBeNull();
+		const durableId = rendered.anchors[durableRow]?.id;
+		expect(durableId).toBeDefined();
+		const userLabelRow = plainLines.findIndex(line => line.trim() === "user");
+		expect(userLabelRow).toBeGreaterThanOrEqual(0);
+		expect(rendered.anchors[userLabelRow]).toBeNull();
+		expect(rendered.lines.join("")).toContain("\x1b]133;A\x07");
+		expect(rendered.lines.join("")).toContain("\x1b]133;B\x07\x1b]133;C\x07");
+		expect(syntheticRow).toBeGreaterThanOrEqual(0);
+		expect(rendered.anchors[syntheticRow]).toBeNull();
+		expect(statusRow).toBeGreaterThanOrEqual(0);
+		expect(rendered.anchors[statusRow]).toBeNull();
+
+		mode.settings.set("irc.enabled", true);
+		mode.settings.set("irc.sidebar.enabled", true);
+		mode.applyIrcSidebarAvailability(true);
+		mode.toggleIrcSidebar();
+		const visibleSplit = mode.ui.renderWithViewportAnchors(80);
+		const visibleDurable = visibleSplit.anchors.findIndex(anchor => anchor?.id === durableId);
+		expect(visibleDurable).toBeGreaterThanOrEqual(0);
+		expect(visibleSplit.anchors[visibleDurable]).not.toBeNull();
+
+		mode.applyIrcSidebarAvailability(false);
+		const temporarilyUnavailable = mode.ui.renderWithViewportAnchors(80);
+		const temporaryRow = temporarilyUnavailable.anchors.findIndex(anchor => anchor?.id === durableId);
+		expect(temporaryRow).toBeGreaterThanOrEqual(0);
+		expect(temporarilyUnavailable.anchors[temporaryRow]).not.toBeNull();
+		mode.applyIrcSidebarAvailability(true);
+		const restoredVisible = mode.ui.renderWithViewportAnchors(80);
+		const restoredRow = restoredVisible.anchors.findIndex(anchor => anchor?.id === durableId);
+		expect(restoredRow).toBeGreaterThanOrEqual(0);
+		expect(restoredVisible.anchors[restoredRow]).not.toBeNull();
+
+		mode.settings.set("irc.sidebar.enabled", false);
+		mode.applyIrcSidebarAvailability(false);
+		const hiddenSplit = mode.ui.renderWithViewportAnchors(80);
+		const hiddenDurable = hiddenSplit.anchors.findIndex(anchor => anchor?.id === durableId);
+		expect(hiddenDurable).toBeGreaterThanOrEqual(0);
+		expect(hiddenSplit.anchors[hiddenDurable]).not.toBeNull();
+
+		mode.settings.set("irc.enabled", false);
+		mode.settings.set("irc.sidebar.enabled", true);
+		mode.applyIrcSidebarAvailability(false);
+		const unavailable = mode.ui.renderWithViewportAnchors(80);
+		const unavailableRow = unavailable.anchors.findIndex(anchor => anchor?.id === durableId);
+		expect(unavailableRow).toBeGreaterThanOrEqual(0);
+		expect(unavailable.anchors[unavailableRow]).not.toBeNull();
+	});
+
+	it("keeps duplicate transcript occurrences distinct and stable across rebuild", () => {
+		const userMessages = [
+			{ role: "user" as const, content: "identical user", timestamp: 42 },
+			{ role: "user" as const, content: "identical user", timestamp: 42 },
+		];
+		const assistantMessage = (): AssistantMessage => ({
+			role: "assistant",
+			content: [{ type: "text", text: "identical assistant" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "same-model",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: 42,
+		});
+		const assistantMessages = [assistantMessage(), assistantMessage()];
+		associateSessionMessageEntryId(userMessages[0], "user-a");
+		associateSessionMessageEntryId(userMessages[1], "user-b");
+		associateSessionMessageEntryId(assistantMessages[0], "assistant-a");
+		associateSessionMessageEntryId(assistantMessages[1], "assistant-b");
+		for (const message of [...userMessages, ...assistantMessages]) mode.addMessageToChat(message);
+		const orderedOccurrenceIds = (anchors: ReadonlyArray<{ id: string } | null>, prefix: string): string[] => {
+			const ids: string[] = [];
+			const seen = new Set<string>();
+			for (const anchor of anchors) {
+				if (anchor === null || !anchor.id.startsWith(prefix) || seen.has(anchor.id)) continue;
+				seen.add(anchor.id);
+				ids.push(anchor.id);
+			}
+			return ids;
+		};
+		const initial = mode.chatContainer.renderWithViewportAnchors(80).anchors;
+		const initialUserIds = orderedOccurrenceIds(initial, "user:");
+		const initialAssistantIds = orderedOccurrenceIds(initial, "assistant:");
+		expect(initialUserIds).toHaveLength(2);
+		expect(initialAssistantIds).toHaveLength(2);
+
+		mode.chatContainer.clear();
+		const insertedUser = { ...userMessages[0] };
+		const rebuiltUserA = { ...userMessages[0] };
+		const rebuiltUserB = { ...userMessages[1] };
+		const rebuiltAssistantA = assistantMessage();
+		const rebuiltAssistantB = assistantMessage();
+		associateSessionMessageEntryId(insertedUser, "user-inserted");
+		associateSessionMessageEntryId(rebuiltUserA, "user-a");
+		associateSessionMessageEntryId(rebuiltUserB, "user-b");
+		associateSessionMessageEntryId(rebuiltAssistantA, "assistant-a");
+		associateSessionMessageEntryId(rebuiltAssistantB, "assistant-b");
+		mode.renderSessionContext({
+			messages: [insertedUser, rebuiltUserA, rebuiltUserB, rebuiltAssistantA, rebuiltAssistantB],
+		} as unknown as SessionContext);
+		const inserted = mode.chatContainer.renderWithViewportAnchors(80).anchors;
+		expect(orderedOccurrenceIds(inserted, "user:")).toEqual(["user:entry:user-inserted", ...initialUserIds]);
+		expect(orderedOccurrenceIds(inserted, "assistant:")).toEqual(initialAssistantIds);
+
+		mode.chatContainer.clear();
+		mode.renderSessionContext({
+			messages: [rebuiltUserA, rebuiltUserB, rebuiltAssistantA, rebuiltAssistantB],
+		} as unknown as SessionContext);
+		const afterDeletion = mode.chatContainer.renderWithViewportAnchors(80).anchors;
+		expect(orderedOccurrenceIds(afterDeletion, "user:")).toEqual(initialUserIds);
+		expect(orderedOccurrenceIds(afterDeletion, "assistant:")).toEqual(initialAssistantIds);
+	});
+
+	it("preserves a live assistant anchor ID after persistence and transcript rebuild", () => {
+		const liveMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "live then persisted" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "same-model",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: 77,
+		};
+		const liveId = mode.getAssistantViewportAnchorId(liveMessage);
+		expect(liveId).toContain(":occurrence:");
+		mode.addMessageToChat(liveMessage);
+		expect(
+			mode.chatContainer
+				.renderWithViewportAnchors(80)
+				.anchors.some(anchor => anchor?.id === `${liveId}:content:0:text`),
+		).toBe(true);
+
+		session.sessionManager.appendMessage(liveMessage);
+		const rebuiltContext = session.sessionManager.buildSessionContext();
+		const rebuiltMessage = rebuiltContext.messages.find(message => message.role === "assistant");
+		if (rebuiltMessage?.role !== "assistant") throw new Error("Expected rebuilt assistant message");
+		expect(rebuiltMessage).not.toBe(liveMessage);
+		expect(mode.getAssistantViewportAnchorId(rebuiltMessage)).toBe(liveId);
+
+		mode.chatContainer.clear();
+		mode.renderSessionContext(rebuiltContext);
+		expect(
+			mode.chatContainer
+				.renderWithViewportAnchors(80)
+				.anchors.some(anchor => anchor?.id === `${liveId}:content:0:text`),
+		).toBe(true);
+	});
 	function expectedNewlineShortcutHint(): string {
 		const shortcut = process.platform === "win32" ? "Alt+Enter/Ctrl+J" : "Shift+Enter/Ctrl+J";
 		return `${shortcut}: New line`;

--- a/packages/coding-agent/test/modes/components/assistant-message-streaming.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-streaming.test.ts
@@ -125,6 +125,111 @@ describe("AssistantMessageComponent streaming markdown", () => {
 		expect(countChildren(component, Text)).toBe(initialTextCount);
 	});
 
+	it("does not grant semantic eligibility without an occurrence ID", () => {
+		const component = new AssistantMessageComponent(message([{ type: "text", text: "unscoped" }]));
+		expect(component.renderWithViewportAnchors(40).anchors.every(anchor => anchor === null)).toBe(true);
+	});
+
+	it("excludes tool-only and empty error assistants from semantic rows", () => {
+		const toolOnly = message([
+			{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "x" } },
+		] as AssistantMessage["content"]);
+		const toolComponent = new AssistantMessageComponent(toolOnly, false, undefined, "assistant:test:tool-only");
+		expect(toolComponent.renderWithViewportAnchors(40).anchors.every(anchor => anchor === null)).toBe(true);
+		const errorOnly = { ...message([]), stopReason: "error" as const, errorMessage: "transport failed" };
+		const errorComponent = new AssistantMessageComponent(errorOnly, false, undefined, "assistant:test:error-only");
+		expect(errorComponent.renderWithViewportAnchors(40).anchors.every(anchor => anchor === null)).toBe(true);
+	});
+
+	it("keeps semantic anchor identity stable from streaming through final content", () => {
+		const active = { type: "text" as const, text: "가나다라마바사🙂" };
+		const initial = message([active]);
+		const component = new AssistantMessageComponent(initial, false, undefined, "assistant:test:stream");
+		component.updateContent(initial, { streaming: true });
+		const streamingIds = new Set(
+			component.renderWithViewportAnchors(12).anchors.flatMap(anchor => (anchor === null ? [] : [anchor.id])),
+		);
+		const finalBlock = { type: "text" as const, text: `${active.text}카타파하끝` };
+		component.updateContent(message([finalBlock], "stop"), { streaming: false });
+		const finalRender = component.renderWithViewportAnchors(12);
+		const finalIds = new Set(finalRender.anchors.flatMap(anchor => (anchor === null ? [] : [anchor.id])));
+		expect(streamingIds.size).toBe(1);
+		expect(finalIds).toEqual(streamingIds);
+		const targetRow = finalRender.lines.findIndex(line => Bun.stripANSI(line).includes("끝"));
+		expect(targetRow).toBeGreaterThanOrEqual(0);
+		expect(finalRender.anchors[targetRow]).not.toBeNull();
+	});
+
+	it("keeps duplicate assistant blocks distinct across replacement objects", () => {
+		const initial = message([
+			{ type: "text", text: "duplicate block" },
+			{ type: "text", text: "duplicate block" },
+		] as AssistantMessage["content"]);
+		const component = new AssistantMessageComponent(initial, false, undefined, "assistant:test:duplicates");
+		const initialIds = new Set(
+			component.renderWithViewportAnchors(40).anchors.flatMap(anchor => (anchor === null ? [] : [anchor.id])),
+		);
+		expect(initialIds.size).toBe(2);
+		component.updateContent(
+			message(
+				[
+					{ type: "text", text: "duplicate block" },
+					{ type: "text", text: "duplicate block" },
+				] as AssistantMessage["content"],
+				"stop",
+			),
+			{ streaming: false },
+		);
+		const replacementIds = new Set(
+			component.renderWithViewportAnchors(12).anchors.flatMap(anchor => (anchor === null ? [] : [anchor.id])),
+		);
+		expect(replacementIds).toEqual(initialIds);
+	});
+
+	it("keeps Markdown decoration rows authoritative without leaking marker bytes", () => {
+		const component = new AssistantMessageComponent(
+			message([{ type: "text", text: "**repeat repeat** [🙂](https://example.com)  e\u0301\n\n> 가가" }]),
+			false,
+			undefined,
+			"assistant:test:markdown",
+		);
+		const rendered = component.renderWithViewportAnchors(14);
+		const anchors = rendered.anchors.flatMap(anchor => (anchor === null ? [] : [anchor]));
+		expect(rendered.lines.join("")).not.toContain("GJC_ANCHOR");
+		expect(anchors.length).toBeGreaterThan(1);
+		expect(new Set(anchors.map(anchor => anchor.id)).size).toBe(1);
+		expect(anchors[0]?.graphemeStart).toBe(0);
+		for (let index = 0; index < anchors.length; index++) {
+			const anchor = anchors[index];
+			expect(anchor.graphemeEnd).toBeGreaterThan(anchor.graphemeStart);
+			expect(anchor.cellEnd).toBeGreaterThan(anchor.cellStart);
+			if (index > 0) {
+				expect(anchor.graphemeStart).toBeGreaterThanOrEqual(anchors[index - 1].graphemeEnd);
+				expect(anchor.cellStart).toBeGreaterThanOrEqual(anchors[index - 1].cellEnd);
+			}
+		}
+	});
+
+	it("remaps cached Markdown spans to each source occurrence ID", () => {
+		const content = [{ type: "text" as const, text: "cached **가가🙂** provenance" }];
+		const first = new AssistantMessageComponent(message(content), false, undefined, "assistant:test:cache:first");
+		const firstRender = first.renderWithViewportAnchors(18);
+		const second = new AssistantMessageComponent(
+			message([{ type: "text", text: content[0].text }]),
+			false,
+			undefined,
+			"assistant:test:cache:second",
+		);
+		const secondRender = second.renderWithViewportAnchors(18);
+		expect(secondRender.lines).toEqual(firstRender.lines);
+		expect(new Set(firstRender.anchors.flatMap(anchor => (anchor === null ? [] : [anchor.id])))).toEqual(
+			new Set(["assistant:test:cache:first:content:0:text"]),
+		);
+		expect(new Set(secondRender.anchors.flatMap(anchor => (anchor === null ? [] : [anchor.id])))).toEqual(
+			new Set(["assistant:test:cache:second:content:0:text"]),
+		);
+	});
+
 	it("keeps multi-block ordering byte-identical to a fresh full render", () => {
 		const text = { type: "text" as const, text: "First text" };
 		const thinking = { type: "thinking" as const, thinking: "private reasoning" };

--- a/packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts
+++ b/packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts
@@ -113,6 +113,52 @@ describe("deep-interview assistant render middleware", () => {
 		expect(rendered).toContain("한국어 기준을 명확히 합니다");
 		expect(rendered).not.toContain("\\u");
 	});
+
+	it("keeps structured progress rows semantically anchorable", () => {
+		const raw = [
+			"Round 6 complete.",
+			"",
+			"| Dimension | Score | Weight | Weighted | Gap |",
+			"|-----------|-------|--------|----------|-----|",
+			"| Goal | 0.90 | 0.40 | 0.36 | Clear |",
+			"| Constraints | 0.70 | 0.30 | 0.21 | 한국어 기준 유지 |",
+			"| **Ambiguity** | | | **20%** | |",
+			"",
+			"**Next target:** 검토 기준",
+		].join("\n");
+		const component = new AssistantMessageComponent(
+			createAssistantMessage(raw),
+			false,
+			undefined,
+			"assistant:entry:deep-interview-progress",
+		);
+		const rendered = component.renderWithViewportAnchors(40);
+		const titleRow = rendered.lines.findIndex(line => Bun.stripANSI(line).includes("Round 6 complete"));
+		const koreanRow = rendered.lines.findIndex(line => Bun.stripANSI(line).includes("한국어 기준 유지"));
+		expect(titleRow).toBeGreaterThanOrEqual(0);
+		expect(koreanRow).toBeGreaterThanOrEqual(0);
+		expect(rendered.anchors[titleRow]?.id).toBe("assistant:entry:deep-interview-progress:content:0:text");
+		expect(rendered.anchors[koreanRow]?.id).toBe("assistant:entry:deep-interview-progress:content:0:text");
+		const semanticRows = rendered.anchors.filter(anchor => anchor !== null);
+		expect(semanticRows.length).toBeGreaterThan(3);
+		for (let index = 1; index < semanticRows.length; index++) {
+			expect(semanticRows[index].graphemeStart).toBeGreaterThanOrEqual(semanticRows[index - 1].graphemeEnd);
+			expect(semanticRows[index].cellStart).toBeGreaterThanOrEqual(semanticRows[index - 1].cellEnd);
+		}
+		const selected = rendered.anchors[koreanRow];
+		if (!selected) throw new Error("Expected semantic Korean row");
+		const narrow = component.renderWithViewportAnchors(18);
+		const resolved = narrow.anchors.find(
+			anchor =>
+				anchor?.id === selected.id &&
+				anchor.graphemeStart <= selected.graphemeStart &&
+				anchor.graphemeEnd > selected.graphemeStart &&
+				anchor.cellStart <= selected.cellStart &&
+				anchor.cellEnd > selected.cellStart,
+		);
+		expect(resolved).not.toBeNull();
+		expect(resolved).not.toBeUndefined();
+	});
 });
 
 describe("deep-interview render middleware null-safety", () => {

--- a/packages/coding-agent/test/modes/components/irc-sidebar.test.ts
+++ b/packages/coding-agent/test/modes/components/irc-sidebar.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { type IrcSidebarTheme, IrcSplitViewComponent } from "@gajae-code/coding-agent/modes/components/irc-sidebar";
 import { IrcObservationLedger } from "@gajae-code/coding-agent/modes/irc-observation-ledger";
-import { type Component, Image, ImageProtocol, isTerminalGraphicsFallbackActive, TERMINAL } from "@gajae-code/tui";
+import {
+	type Component,
+	Container,
+	Image,
+	ImageProtocol,
+	isTerminalGraphicsFallbackActive,
+	TERMINAL,
+	Text,
+} from "@gajae-code/tui";
 
 const sidebarTheme = {
 	fg: (_color: "dim", text: string) => text,
@@ -49,6 +57,43 @@ describe("IrcSplitViewComponent", () => {
 
 		expect(split.render(80)).toEqual(["transcript"]);
 		expect(pane.widths).toEqual([80]);
+	});
+
+	it("preserves transcript metadata while excluding inline and right-only IRC rows", () => {
+		const left = new Container();
+		const semantic = new Text("semantic transcript row", 0, 0);
+		const inlineIrc = new Text("inline IRC row", 0, 0);
+		left.addChild(semantic);
+		left.setViewportAnchorSource(semantic, { id: "message-1" });
+		left.addChild(inlineIrc);
+		const ledger = new IrcObservationLedger();
+		addRecord(ledger, "right one\nright two\nright three\nright four");
+		const split = new IrcSplitViewComponent(left, ledger, sidebarTheme);
+
+		const hidden = split.renderWithViewportAnchors(80);
+		const hiddenPlain = hidden.lines.map(line => Bun.stripANSI(line));
+		const hiddenSemantic = hiddenPlain.findIndex(line => line.includes("semantic transcript row"));
+		const hiddenInline = hiddenPlain.findIndex(line => line.includes("inline IRC row"));
+		expect(hidden.anchors[hiddenSemantic]?.id).toBe("message-1");
+		expect(hidden.anchors[hiddenInline]).toBeNull();
+
+		split.setVisible(true);
+		const visible = split.renderWithViewportAnchors(80);
+		const visiblePlain = visible.lines.map(line => Bun.stripANSI(line));
+		const visibleSemantic = visiblePlain.findIndex(line => line.includes("semantic transcript row"));
+		const visibleInline = visiblePlain.findIndex(line => line.includes("inline IRC row"));
+		expect(visible.anchors[visibleSemantic]?.id).toBe("message-1");
+		expect(visible.anchors[visibleInline]).toBeNull();
+		const rightOnlyRows = visiblePlain.flatMap((line, index) =>
+			line.includes("right ") && !line.includes("semantic transcript row") && !line.includes("inline IRC row")
+				? [index]
+				: [],
+		);
+		expect(rightOnlyRows.length).toBeGreaterThan(0);
+		for (const row of rightOnlyRows) expect(visible.anchors[row]).toBeNull();
+
+		split.setVisible(false);
+		expect(split.renderWithViewportAnchors(80).anchors.some(anchor => anchor?.id === "message-1")).toBe(true);
 	});
 
 	it("renders all ledger records with UTC metadata and indented continuations", () => {

--- a/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
@@ -15,7 +15,6 @@ type AutoCompactionFixture = {
 	loaderStop: Mock<() => void>;
 	statusContainerClear: Mock<() => void>;
 	rebuildChatFromMessages: Mock<(policy: "replace-identity" | "reconcile-same-transcript") => void>;
-	prepareViewportAnchorForTranscriptRebuild: Mock<() => void>;
 };
 
 function createFixture(): AutoCompactionFixture {
@@ -35,12 +34,9 @@ function createFixture(): AutoCompactionFixture {
 	const flushCompactionQueue = vi.fn(async () => {
 		order.push("flushCompactionQueue");
 	});
-	const prepareViewportAnchorForTranscriptRebuild = vi.fn(() => {
-		order.push("prepareViewportAnchorForTranscriptRebuild");
-	});
+	const prepareViewportAnchorForTranscriptRebuild = vi.fn();
 	const rebuildChatFromMessages = vi.fn((policy: "replace-identity" | "reconcile-same-transcript") => {
-		if (policy === "reconcile-same-transcript") prepareViewportAnchorForTranscriptRebuild();
-		order.push("rebuildChatFromMessages");
+		order.push(`rebuildChatFromMessages:${policy}`);
 	});
 
 	const ctx = {
@@ -87,7 +83,6 @@ function createFixture(): AutoCompactionFixture {
 		loaderStop,
 		statusContainerClear,
 		rebuildChatFromMessages,
-		prepareViewportAnchorForTranscriptRebuild,
 	};
 }
 
@@ -121,10 +116,7 @@ describe("EventController auto-compaction overflow status", () => {
 		expect(fixture.showStatus).toHaveBeenCalledWith("Context overflow maintenance completed");
 		expect(fixture.showWarning).not.toHaveBeenCalled();
 		expect(fixture.order.indexOf("loader.stop")).toBeLessThan(fixture.order.indexOf("showStatus"));
-		expect(fixture.prepareViewportAnchorForTranscriptRebuild).toHaveBeenCalledTimes(1);
-		expect(fixture.order.indexOf("prepareViewportAnchorForTranscriptRebuild")).toBeLessThan(
-			fixture.order.indexOf("rebuildChatFromMessages"),
-		);
+		expect(fixture.rebuildChatFromMessages).toHaveBeenCalledWith("reconcile-same-transcript");
 		expect(fixture.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: true });
 	});
 

--- a/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
@@ -14,7 +14,7 @@ type AutoCompactionFixture = {
 	flushCompactionQueue: Mock<(options: { willRetry: boolean }) => Promise<void>>;
 	loaderStop: Mock<() => void>;
 	statusContainerClear: Mock<() => void>;
-	rebuildChatFromMessages: Mock<() => void>;
+	rebuildChatFromMessages: Mock<(policy: "replace-identity" | "reconcile-same-transcript") => void>;
 	prepareViewportAnchorForTranscriptRebuild: Mock<() => void>;
 };
 
@@ -35,11 +35,12 @@ function createFixture(): AutoCompactionFixture {
 	const flushCompactionQueue = vi.fn(async () => {
 		order.push("flushCompactionQueue");
 	});
-	const rebuildChatFromMessages = vi.fn(() => {
-		order.push("rebuildChatFromMessages");
-	});
 	const prepareViewportAnchorForTranscriptRebuild = vi.fn(() => {
 		order.push("prepareViewportAnchorForTranscriptRebuild");
+	});
+	const rebuildChatFromMessages = vi.fn((policy: "replace-identity" | "reconcile-same-transcript") => {
+		if (policy === "reconcile-same-transcript") prepareViewportAnchorForTranscriptRebuild();
+		order.push("rebuildChatFromMessages");
 	});
 
 	const ctx = {
@@ -158,6 +159,7 @@ describe("EventController auto-compaction overflow status", () => {
 		expect(fixture.loaderStop).toHaveBeenCalledTimes(1);
 		expect(fixture.ctx.autoCompactionLoader).toBeUndefined();
 		expect(fixture.rebuildChatFromMessages).toHaveBeenCalledTimes(1);
+		expect(fixture.rebuildChatFromMessages).toHaveBeenCalledWith("reconcile-same-transcript");
 		expect(fixture.showStatus).toHaveBeenCalledWith(
 			"Context overflow recovery skipped: auto_continue_disabled_non_resumable_tail",
 		);

--- a/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts
@@ -15,6 +15,7 @@ type AutoCompactionFixture = {
 	loaderStop: Mock<() => void>;
 	statusContainerClear: Mock<() => void>;
 	rebuildChatFromMessages: Mock<() => void>;
+	prepareViewportAnchorForTranscriptRebuild: Mock<() => void>;
 };
 
 function createFixture(): AutoCompactionFixture {
@@ -36,6 +37,9 @@ function createFixture(): AutoCompactionFixture {
 	});
 	const rebuildChatFromMessages = vi.fn(() => {
 		order.push("rebuildChatFromMessages");
+	});
+	const prepareViewportAnchorForTranscriptRebuild = vi.fn(() => {
+		order.push("prepareViewportAnchorForTranscriptRebuild");
 	});
 
 	const ctx = {
@@ -60,6 +64,8 @@ function createFixture(): AutoCompactionFixture {
 			requestRender: vi.fn(() => {
 				order.push("ui.requestRender");
 			}),
+			prepareViewportAnchorForTranscriptRebuild,
+			resetViewportAnchorIntent: vi.fn(),
 		},
 		showStatus,
 		showWarning,
@@ -80,6 +86,7 @@ function createFixture(): AutoCompactionFixture {
 		loaderStop,
 		statusContainerClear,
 		rebuildChatFromMessages,
+		prepareViewportAnchorForTranscriptRebuild,
 	};
 }
 
@@ -113,6 +120,10 @@ describe("EventController auto-compaction overflow status", () => {
 		expect(fixture.showStatus).toHaveBeenCalledWith("Context overflow maintenance completed");
 		expect(fixture.showWarning).not.toHaveBeenCalled();
 		expect(fixture.order.indexOf("loader.stop")).toBeLessThan(fixture.order.indexOf("showStatus"));
+		expect(fixture.prepareViewportAnchorForTranscriptRebuild).toHaveBeenCalledTimes(1);
+		expect(fixture.order.indexOf("prepareViewportAnchorForTranscriptRebuild")).toBeLessThan(
+			fixture.order.indexOf("rebuildChatFromMessages"),
+		);
 		expect(fixture.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: true });
 	});
 

--- a/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts
@@ -1,0 +1,220 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { AssistantMessageComponent } from "@gajae-code/coding-agent/modes/components/assistant-message";
+import { IrcSplitViewComponent } from "@gajae-code/coding-agent/modes/components/irc-sidebar";
+import { EventController } from "@gajae-code/coding-agent/modes/controllers/event-controller";
+import { IrcObservationLedger } from "@gajae-code/coding-agent/modes/irc-observation-ledger";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import { UiHelpers } from "@gajae-code/coding-agent/modes/utils/ui-helpers";
+import {
+	associateSessionMessageViewportAnchorId,
+	getSessionMessageViewportAnchorId,
+} from "@gajae-code/coding-agent/session/session-manager";
+import { Container, shouldUseViewportRepaintForHost, Text, TUI } from "@gajae-code/tui";
+import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
+
+function assistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+beforeAll(async () => {
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+	await initTheme();
+});
+
+afterAll(() => resetSettingsForTest());
+
+describe("EventController completion viewport", () => {
+	const envKeys = [
+		"GJC_NOTIFY",
+		"SSH_CONNECTION",
+		"TERM",
+		"COLORTERM",
+		"WT_SESSION",
+		"TERM_PROGRAM",
+		"TMUX",
+		"TMUX_PANE",
+		"STY",
+		"ZELLIJ",
+		"GJC_TMUX_LAUNCHED",
+		"TERMUX_VERSION",
+		"PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER",
+		"PI_CLEAR_ON_SHRINK",
+		"PI_TUI_VIRTUAL_VIEWPORT",
+	] as const;
+	let previousEnv = new Map<string, string | undefined>();
+
+	function restoreEnv(snapshot: Map<string, string | undefined>): void {
+		for (const key of envKeys) {
+			const value = snapshot.get(key);
+			if (value === undefined) delete Bun.env[key];
+			else Bun.env[key] = value;
+		}
+	}
+
+	afterEach(() => restoreEnv(previousEnv));
+
+	it("preserves manual transcript rows through real completion lifecycle on supported terminal hosts", async () => {
+		previousEnv = new Map(envKeys.map(key => [key, Bun.env[key]]));
+		const cases: Array<{
+			label: string;
+			env: Partial<Record<(typeof envKeys)[number], string>>;
+			resizeHeight?: number;
+			nativeWindows?: boolean;
+		}> = [
+			{ label: "plain-ssh", env: { SSH_CONNECTION: "client server", TERM: "xterm-256color" } },
+			{ label: "tmux-default", env: { TMUX: "/tmp/tmux,1,0", TERM: "tmux-256color" } },
+			{
+				label: "tmux-legacy",
+				env: { TMUX: "/tmp/tmux,1,0", TERM: "tmux-256color", PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER: "1" },
+			},
+			{ label: "termux-height", env: { TERMUX_VERSION: "0.118", TERM: "xterm-256color" }, resizeHeight: 14 },
+			{
+				label: "windows-markers",
+				env: { WT_SESSION: "forwarded", TERM_PROGRAM: "Windows_Terminal", TERM: "xterm-256color" },
+			},
+			{ label: "native-windows-selector", env: { TERM: "xterm-256color" }, nativeWindows: true },
+		];
+
+		for (const testCase of cases) {
+			for (const clearOnShrink of [false, true]) {
+				const scenarioEnv = new Map(envKeys.map(key => [key, Bun.env[key]]));
+				for (const key of envKeys) delete Bun.env[key];
+				Object.assign(Bun.env, testCase.env);
+				Bun.env.GJC_NOTIFY = "off";
+				try {
+					if (testCase.nativeWindows) {
+						expect(shouldUseViewportRepaintForHost({}, "win32", { includeNativeWindows: true })).toBe(true);
+					}
+
+					const term = new VirtualTerminal(40, 18, { isProcessTerminal: true });
+					const ui = new TUI(term);
+					ui.setClearOnShrink(clearOnShrink);
+					const chatContainer = new Container();
+					const startMessage = assistantMessage("streaming assistant response");
+					const message = assistantMessage("final assistant response");
+					const anchorId = `assistant:test:${testCase.label}:${clearOnShrink}`;
+					associateSessionMessageViewportAnchorId(startMessage, anchorId);
+					const streamingComponent = new AssistantMessageComponent(startMessage, false, undefined, anchorId);
+					const split = new IrcSplitViewComponent(chatContainer, new IrcObservationLedger(), {
+						fg: (_color, text) => text,
+						boxSharp: { vertical: "│" },
+					});
+					const pendingMessagesContainer = new Container();
+					const statusContainer = new Container();
+					statusContainer.addChild(new Text("working", 0, 0));
+					const todoContainer = new Container();
+					const btwContainer = new Container();
+					const statusLine = new Text("status", 0, 0);
+					const editor = new Text("editor", 0, 0);
+					ui.addChild(split);
+					ui.setViewportAnchorComponent(split);
+					ui.addChild(pendingMessagesContainer);
+					ui.addChild(statusContainer);
+					ui.addChild(todoContainer);
+					ui.addChild(btwContainer);
+					ui.addChild(statusLine);
+					ui.addChild(editor);
+					ui.setBottomPinnedComponent(statusLine);
+					const stopLoading = vi.fn();
+					const ctx = {
+						isInitialized: true,
+						ui,
+						chatContainer,
+						pendingMessagesContainer,
+						statusContainer,
+						todoContainer,
+						btwContainer,
+						statusLine,
+						editor: { getText: () => "" },
+						getUserMessageText: (userMessage: { content: string }) => userMessage.content,
+						streamingComponent,
+						streamingMessage: startMessage,
+						loadingAnimation: { stop: stopLoading },
+						pendingTools: new Map(),
+						flushPendingModelSwitch: async () => {},
+						updateEditorTopBorder: () => {},
+						updateEditorBorderColor: () => {},
+						session: {
+							isTtsrAbortPending: false,
+							retryAttempt: 0,
+							isCompacting: true,
+							getLastAssistantMessage: () => message,
+						},
+						sessionManager: { getSessionName: () => "", getCwd: () => process.cwd() },
+						isBackgrounded: false,
+					} as unknown as InteractiveModeContext;
+					const uiHelpers = new UiHelpers(ctx);
+					for (let index = 0; index < 30; index++) {
+						uiHelpers.addMessageToChat({ role: "user", content: `history-${index}`, timestamp: index + 1 });
+					}
+					chatContainer.addChild(streamingComponent);
+					const controller = new EventController(ctx);
+					try {
+						ui.start();
+						await term.waitForRender();
+						expect(ui.scrollViewportPages(-1), `${testCase.label} clear=${clearOnShrink}`).toBe(true);
+						await term.flush();
+						if (testCase.resizeHeight !== undefined) {
+							term.resize(40, testCase.resizeHeight);
+							await term.waitForRender();
+						}
+						const before = term.getViewport().map(line => line.trimEnd());
+						const beforeHistory = before.flatMap((line, index) =>
+							line.includes("history-") ? [{ index, line }] : [],
+						);
+						expect(beforeHistory.length, JSON.stringify(before)).toBeGreaterThanOrEqual(3);
+						term.clearWriteLog();
+						await controller.handleEvent({ type: "message_end", message });
+						expect(getSessionMessageViewportAnchorId(message)).toBe(anchorId);
+						await term.waitForRender();
+						await controller.handleEvent({ type: "agent_end", messages: [message] });
+						await term.waitForRender();
+						expect(stopLoading, `${testCase.label} clear=${clearOnShrink}`).toHaveBeenCalledTimes(1);
+						expect(ctx.loadingAnimation, `${testCase.label} clear=${clearOnShrink}`).toBeUndefined();
+						expect(statusContainer.children, `${testCase.label} clear=${clearOnShrink}`).toHaveLength(0);
+						const after = term.getViewport().map(line => line.trimEnd());
+						for (const entry of beforeHistory) expect(after[entry.index]).toBe(entry.line);
+						const writes = term.getWriteLog().join("");
+						expect(writes).not.toContain("\x1b[2J\x1b[H");
+						expect(writes).not.toContain("\x1b[3J");
+						const visibleHistoryNumbers = beforeHistory.flatMap(entry => {
+							const match = /history-(\d+)/.exec(entry.line);
+							return match ? [Number(match[1])] : [];
+						});
+						const firstVisibleHistory = Math.min(...visibleHistoryNumbers);
+						for (let index = 0; index < firstVisibleHistory; index++) {
+							expect(writes).not.toMatch(new RegExp(`history-${index}(?!\\d)`));
+						}
+						term.clearWriteLog();
+						ui.requestRender();
+						await term.waitForRender();
+						expect(term.getWriteLog(), `${testCase.label} clear=${clearOnShrink} immediate no-op`).toEqual([]);
+					} finally {
+						ui.stop();
+					}
+				} finally {
+					restoreEnv(scenarioEnv);
+				}
+			}
+		}
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/extension-ui-transcript-policy.test.ts
+++ b/packages/coding-agent/test/modes/controllers/extension-ui-transcript-policy.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, type Mock, vi } from "bun:test";
+import { Container } from "@gajae-code/tui";
+import type {
+	ExtensionActions,
+	ExtensionCommandContextActions,
+	ExtensionContextActions,
+	ExtensionUIContext,
+} from "../../../src/extensibility/extensions";
+import { ExtensionUiController } from "../../../src/modes/controllers/extension-ui-controller";
+import type { InteractiveModeContext, TranscriptRebuildPolicy } from "../../../src/modes/types";
+
+type Fixture = {
+	controller: ExtensionUiController;
+	ctx: InteractiveModeContext;
+	getActions: () => ExtensionActions;
+	getCommandActions: () => ExtensionCommandContextActions;
+	setNextSessionId: (id: string) => void;
+	rebuildInitialMessages: Mock<(policy: TranscriptRebuildPolicy) => void>;
+	rebuildChatFromMessages: Mock<(policy: TranscriptRebuildPolicy) => void>;
+	resetIrcSidebarSession: Mock<() => void>;
+};
+
+function createFixture(initialSessionId = "session-a"): Fixture {
+	let actions: ExtensionActions | undefined;
+	let commandActions: ExtensionCommandContextActions | undefined;
+	let sessionId = initialSessionId;
+	let nextSessionId = initialSessionId;
+	const rebuildInitialMessages = vi.fn<(policy: TranscriptRebuildPolicy) => void>();
+	const rebuildChatFromMessages = vi.fn<(policy: TranscriptRebuildPolicy) => void>();
+	const resetIrcSidebarSession = vi.fn<() => void>();
+	const extensionRunner = {
+		initialize(
+			capturedActions: ExtensionActions,
+			_contextActions: ExtensionContextActions,
+			capturedCommandActions?: ExtensionCommandContextActions,
+			_uiContext?: ExtensionUIContext,
+		): void {
+			actions = capturedActions;
+			commandActions = capturedCommandActions;
+		},
+		onError: vi.fn(),
+		emit: vi.fn(async () => undefined),
+	};
+	const ctx = {
+		isBackgrounded: false,
+		session: {
+			extensionRunner,
+			isStreaming: false,
+			sendCustomMessage: vi.fn(async () => undefined),
+			switchSession: vi.fn(async () => {
+				sessionId = nextSessionId;
+				return true;
+			}),
+		},
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getSessionName: () => "Session",
+			getCwd: () => "/tmp/project",
+		},
+		hookWidgetContainerAbove: new Container(),
+		hookWidgetContainerBelow: new Container(),
+		ui: { requestRender: vi.fn() },
+		editor: { setText: vi.fn(), handleInput: vi.fn(), getText: () => "" },
+		setToolUIContext: vi.fn(),
+		setWorkingMessage: vi.fn(),
+		setEditorComponent: vi.fn(),
+		toolOutputExpanded: false,
+		setToolsExpanded: vi.fn(),
+		rebuildInitialMessages,
+		rebuildChatFromMessages,
+		resetIrcSidebarSession,
+		reloadTodos: vi.fn(async () => undefined),
+		showError: vi.fn(),
+	} as unknown as InteractiveModeContext;
+	const controller = new ExtensionUiController(ctx);
+	return {
+		controller,
+		ctx,
+		getActions: () => {
+			if (!actions) throw new Error("Extension actions were not initialized");
+			return actions;
+		},
+		getCommandActions: () => {
+			if (!commandActions) throw new Error("Extension command actions were not initialized");
+			return commandActions;
+		},
+		setNextSessionId: id => {
+			nextSessionId = id;
+		},
+		rebuildInitialMessages,
+		rebuildChatFromMessages,
+		resetIrcSidebarSession,
+	};
+}
+
+describe("ExtensionUiController transcript rebuild policy", () => {
+	it("resets identity when a hook-runner switch loads a different session id from the same path", async () => {
+		const fixture = createFixture();
+		fixture.setNextSessionId("session-b");
+		fixture.controller.initializeHookRunner({} as ExtensionUIContext, false);
+
+		await fixture.getCommandActions().switchSession("/tmp/project/session.jsonl");
+
+		expect(fixture.resetIrcSidebarSession).toHaveBeenCalledTimes(1);
+		expect(fixture.rebuildInitialMessages).toHaveBeenCalledWith("replace-identity");
+	});
+
+	it("reconciles a true same-session switch in the foreground extension path", async () => {
+		const fixture = createFixture();
+		await fixture.controller.initHooksAndCustomTools();
+
+		await fixture.getCommandActions().switchSession("/tmp/project/session.jsonl");
+
+		expect(fixture.resetIrcSidebarSession).not.toHaveBeenCalled();
+		expect(fixture.rebuildInitialMessages).toHaveBeenCalledWith("reconcile-same-transcript");
+	});
+
+	it("classifies idle custom-message display rebuilds as same-transcript reconciliation", async () => {
+		const fixture = createFixture();
+		fixture.controller.initializeHookRunner({} as ExtensionUIContext, false);
+
+		fixture.getActions().sendMessage({ customType: "test", content: "visible", display: true });
+		await Bun.sleep(0);
+
+		expect(fixture.rebuildChatFromMessages).toHaveBeenCalledWith("reconcile-same-transcript");
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/extension-ui-transcript-policy.test.ts
+++ b/packages/coding-agent/test/modes/controllers/extension-ui-transcript-policy.test.ts
@@ -51,6 +51,9 @@ function createFixture(initialSessionId = "session-a"): Fixture {
 				sessionId = nextSessionId;
 				return true;
 			}),
+			reload: vi.fn(async () => {
+				sessionId = nextSessionId;
+			}),
 		},
 		sessionManager: {
 			getSessionId: () => sessionId,
@@ -70,6 +73,7 @@ function createFixture(initialSessionId = "session-a"): Fixture {
 		rebuildChatFromMessages,
 		resetIrcSidebarSession,
 		reloadTodos: vi.fn(async () => undefined),
+		showStatus: vi.fn(),
 		showError: vi.fn(),
 	} as unknown as InteractiveModeContext;
 	const controller = new ExtensionUiController(ctx);
@@ -110,6 +114,26 @@ describe("ExtensionUiController transcript rebuild policy", () => {
 		await fixture.controller.initHooksAndCustomTools();
 
 		await fixture.getCommandActions().switchSession("/tmp/project/session.jsonl");
+
+		expect(fixture.resetIrcSidebarSession).not.toHaveBeenCalled();
+		expect(fixture.rebuildInitialMessages).toHaveBeenCalledWith("reconcile-same-transcript");
+	});
+	it("resets identity when hook-runner reload replaces the logical session", async () => {
+		const fixture = createFixture();
+		fixture.setNextSessionId("session-b");
+		fixture.controller.initializeHookRunner({} as ExtensionUIContext, false);
+
+		await fixture.getCommandActions().reload();
+
+		expect(fixture.resetIrcSidebarSession).toHaveBeenCalledTimes(1);
+		expect(fixture.rebuildInitialMessages).toHaveBeenCalledWith("replace-identity");
+	});
+
+	it("reconciles reload when the foreground extension keeps the same logical session", async () => {
+		const fixture = createFixture();
+		await fixture.controller.initHooksAndCustomTools();
+
+		await fixture.getCommandActions().reload();
 
 		expect(fixture.resetIrcSidebarSession).not.toHaveBeenCalled();
 		expect(fixture.rebuildInitialMessages).toHaveBeenCalledWith("reconcile-same-transcript");

--- a/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
@@ -64,6 +64,9 @@ function createContext(currentSessionFile: string): {
 			requestRender: vi.fn(() => {
 				calls.push("ui.requestRender");
 			}),
+			resetViewportAnchorIntent: vi.fn(() => {
+				calls.push("ui.resetViewportAnchorIntent");
+			}),
 			terminal: { columns: 120 },
 		},
 		session: {
@@ -74,6 +77,11 @@ function createContext(currentSessionFile: string): {
 			getCwd: () => "/tmp/project",
 			getSessionDir: () => "/tmp/project/sessions",
 			getSessionFile: () => sessionFile,
+		},
+		chatContainer: {
+			clear: vi.fn(() => {
+				calls.push("chatContainer.clear");
+			}),
 		},
 		statusContainer: {
 			clear: vi.fn(() => {
@@ -158,6 +166,17 @@ describe("SelectorController session deletion", () => {
 		vi.restoreAllMocks();
 	});
 
+	it("resets manual viewport intent before rendering a different session", async () => {
+		const { ctx, calls } = createContext("/tmp/project/sessions/a.jsonl");
+		const controller = new SelectorController(ctx);
+
+		await controller.handleResumeSession("/tmp/project/sessions/b.jsonl");
+
+		expect(calls).toContain("ui.resetViewportAnchorIntent");
+		expect(calls.indexOf("ui.resetViewportAnchorIntent")).toBeLessThan(calls.indexOf("chatContainer.clear"));
+		expect(calls.indexOf("chatContainer.clear")).toBeLessThan(calls.indexOf("renderInitialMessages"));
+	});
+
 	it("detaches the active session before selector deletion removes it", async () => {
 		const activeSession = makeSessionInfo("/tmp/project/sessions/active.jsonl");
 		const { ctx, calls } = createContext(activeSession.path);
@@ -189,6 +208,7 @@ describe("SelectorController session deletion", () => {
 			"ui.requestRender",
 			"session.newSession",
 			"resetIrcSidebarSession",
+			"ui.resetViewportAnchorIntent",
 			"loadingAnimation.stop",
 			"statusContainer.clear",
 			"pendingMessagesContainer.clear",
@@ -263,6 +283,7 @@ describe("SelectorController session deletion", () => {
 		expect(calls).toEqual([
 			"session.newSession",
 			"resetIrcSidebarSession",
+			"ui.resetViewportAnchorIntent",
 			"loadingAnimation.stop",
 			"statusContainer.clear",
 			"pendingMessagesContainer.clear",

--- a/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, type Mock, vi } from "bun:test";
 import { SessionSelectorComponent } from "@gajae-code/coding-agent/modes/components/session-selector";
 import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
@@ -34,11 +34,14 @@ function createContext(currentSessionFile: string): {
 	ctx: TestContext;
 	calls: string[];
 	setCurrentSessionFile: (path: string) => void;
+	setCurrentSessionId: (id: string) => void;
 	showHookConfirm: (title: string, message: string) => Promise<boolean>;
 	newSession: () => Promise<boolean>;
+	switchSession: Mock<(targetPath: string) => Promise<boolean>>;
 } {
 	const calls: string[] = [];
 	let sessionFile = currentSessionFile;
+	let sessionId = currentSessionFile;
 	const editorContainer = {
 		children: [] as unknown[],
 		clear() {
@@ -54,6 +57,12 @@ function createContext(currentSessionFile: string): {
 	const newSession = vi.fn(async () => {
 		calls.push("session.newSession");
 		sessionFile = "/tmp/project/sessions/detached.jsonl";
+		sessionId = "detached-session";
+		return true;
+	});
+	const switchSession = vi.fn(async (targetPath: string) => {
+		sessionFile = targetPath;
+		sessionId = targetPath;
 		return true;
 	});
 	const ctx = {
@@ -74,12 +83,13 @@ function createContext(currentSessionFile: string): {
 		},
 		session: {
 			newSession,
-			switchSession: vi.fn(async () => true),
+			switchSession,
 		},
 		sessionManager: {
 			getCwd: () => "/tmp/project",
 			getSessionDir: () => "/tmp/project/sessions",
 			getSessionFile: () => sessionFile,
+			getSessionId: () => sessionId,
 		},
 		chatContainer: {
 			clear: vi.fn(() => {
@@ -123,8 +133,13 @@ function createContext(currentSessionFile: string): {
 		updateEditorBorderColor: vi.fn(() => {
 			calls.push("updateEditorBorderColor");
 		}),
-		renderInitialMessages: vi.fn(() => {
-			calls.push("renderInitialMessages");
+		rebuildInitialMessages: vi.fn((policy: "replace-identity" | "reconcile-same-transcript") => {
+			calls.push(
+				policy === "replace-identity"
+					? "ui.resetViewportAnchorIntent"
+					: "ui.prepareViewportAnchorForTranscriptRebuild",
+			);
+			calls.push("chatContainer.clear", "renderInitialMessages");
 		}),
 		reloadTodos: vi.fn(async () => {
 			calls.push("reloadTodos");
@@ -147,8 +162,12 @@ function createContext(currentSessionFile: string): {
 		setCurrentSessionFile(path: string) {
 			sessionFile = path;
 		},
+		setCurrentSessionId(id: string) {
+			sessionId = id;
+		},
 		showHookConfirm,
 		newSession,
+		switchSession,
 	};
 }
 
@@ -194,6 +213,21 @@ describe("SelectorController session deletion", () => {
 		);
 	});
 
+	it("resets viewport intent when the same path loads a different session identity", async () => {
+		const sessionPath = "/tmp/project/sessions/a.jsonl";
+		const { ctx, calls, setCurrentSessionId, switchSession } = createContext(sessionPath);
+		switchSession.mockImplementation(async () => {
+			setCurrentSessionId("replacement-session-id");
+			return true;
+		});
+		const controller = new SelectorController(ctx);
+
+		await controller.handleResumeSession(sessionPath);
+
+		expect(calls).toContain("ui.resetViewportAnchorIntent");
+		expect(calls).not.toContain("ui.prepareViewportAnchorForTranscriptRebuild");
+	});
+
 	it("detaches the active session before selector deletion removes it", async () => {
 		const activeSession = makeSessionInfo("/tmp/project/sessions/active.jsonl");
 		const { ctx, calls } = createContext(activeSession.path);
@@ -225,7 +259,6 @@ describe("SelectorController session deletion", () => {
 			"ui.requestRender",
 			"session.newSession",
 			"resetIrcSidebarSession",
-			"ui.resetViewportAnchorIntent",
 			"loadingAnimation.stop",
 			"statusContainer.clear",
 			"pendingMessagesContainer.clear",
@@ -234,6 +267,8 @@ describe("SelectorController session deletion", () => {
 			"statusLine.setSessionStartTime",
 			"updateEditorTopBorder",
 			"updateEditorBorderColor",
+			"ui.resetViewportAnchorIntent",
+			"chatContainer.clear",
 			"renderInitialMessages",
 			"reloadTodos",
 			"ui.requestRender",
@@ -300,7 +335,6 @@ describe("SelectorController session deletion", () => {
 		expect(calls).toEqual([
 			"session.newSession",
 			"resetIrcSidebarSession",
-			"ui.resetViewportAnchorIntent",
 			"loadingAnimation.stop",
 			"statusContainer.clear",
 			"pendingMessagesContainer.clear",
@@ -309,6 +343,8 @@ describe("SelectorController session deletion", () => {
 			"statusLine.setSessionStartTime",
 			"updateEditorTopBorder",
 			"updateEditorBorderColor",
+			"ui.resetViewportAnchorIntent",
+			"chatContainer.clear",
 			"renderInitialMessages",
 			"reloadTodos",
 			"ui.requestRender",

--- a/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
@@ -134,12 +134,7 @@ function createContext(currentSessionFile: string): {
 			calls.push("updateEditorBorderColor");
 		}),
 		rebuildInitialMessages: vi.fn((policy: "replace-identity" | "reconcile-same-transcript") => {
-			calls.push(
-				policy === "replace-identity"
-					? "ui.resetViewportAnchorIntent"
-					: "ui.prepareViewportAnchorForTranscriptRebuild",
-			);
-			calls.push("chatContainer.clear", "renderInitialMessages");
+			calls.push(`rebuildInitialMessages:${policy}`, "chatContainer.clear", "renderInitialMessages");
 		}),
 		reloadTodos: vi.fn(async () => {
 			calls.push("reloadTodos");
@@ -194,8 +189,10 @@ describe("SelectorController session deletion", () => {
 
 		await controller.handleResumeSession("/tmp/project/sessions/b.jsonl");
 
-		expect(calls).toContain("ui.resetViewportAnchorIntent");
-		expect(calls.indexOf("ui.resetViewportAnchorIntent")).toBeLessThan(calls.indexOf("chatContainer.clear"));
+		expect(calls).toContain("rebuildInitialMessages:replace-identity");
+		expect(calls.indexOf("rebuildInitialMessages:replace-identity")).toBeLessThan(
+			calls.indexOf("chatContainer.clear"),
+		);
 		expect(calls.indexOf("chatContainer.clear")).toBeLessThan(calls.indexOf("renderInitialMessages"));
 	});
 
@@ -206,11 +203,8 @@ describe("SelectorController session deletion", () => {
 
 		await controller.handleResumeSession(sessionPath);
 
-		expect(calls).toContain("ui.prepareViewportAnchorForTranscriptRebuild");
-		expect(calls).not.toContain("ui.resetViewportAnchorIntent");
-		expect(calls.indexOf("ui.prepareViewportAnchorForTranscriptRebuild")).toBeLessThan(
-			calls.indexOf("chatContainer.clear"),
-		);
+		expect(calls).toContain("rebuildInitialMessages:reconcile-same-transcript");
+		expect(calls).not.toContain("rebuildInitialMessages:replace-identity");
 	});
 
 	it("resets viewport intent when the same path loads a different session identity", async () => {
@@ -224,8 +218,8 @@ describe("SelectorController session deletion", () => {
 
 		await controller.handleResumeSession(sessionPath);
 
-		expect(calls).toContain("ui.resetViewportAnchorIntent");
-		expect(calls).not.toContain("ui.prepareViewportAnchorForTranscriptRebuild");
+		expect(calls).toContain("rebuildInitialMessages:replace-identity");
+		expect(calls).not.toContain("rebuildInitialMessages:reconcile-same-transcript");
 	});
 
 	it("detaches the active session before selector deletion removes it", async () => {
@@ -267,7 +261,7 @@ describe("SelectorController session deletion", () => {
 			"statusLine.setSessionStartTime",
 			"updateEditorTopBorder",
 			"updateEditorBorderColor",
-			"ui.resetViewportAnchorIntent",
+			"rebuildInitialMessages:replace-identity",
 			"chatContainer.clear",
 			"renderInitialMessages",
 			"reloadTodos",
@@ -343,7 +337,7 @@ describe("SelectorController session deletion", () => {
 			"statusLine.setSessionStartTime",
 			"updateEditorTopBorder",
 			"updateEditorBorderColor",
-			"ui.resetViewportAnchorIntent",
+			"rebuildInitialMessages:replace-identity",
 			"chatContainer.clear",
 			"renderInitialMessages",
 			"reloadTodos",

--- a/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
@@ -67,6 +67,9 @@ function createContext(currentSessionFile: string): {
 			resetViewportAnchorIntent: vi.fn(() => {
 				calls.push("ui.resetViewportAnchorIntent");
 			}),
+			prepareViewportAnchorForTranscriptRebuild: vi.fn(() => {
+				calls.push("ui.prepareViewportAnchorForTranscriptRebuild");
+			}),
 			terminal: { columns: 120 },
 		},
 		session: {
@@ -175,6 +178,20 @@ describe("SelectorController session deletion", () => {
 		expect(calls).toContain("ui.resetViewportAnchorIntent");
 		expect(calls.indexOf("ui.resetViewportAnchorIntent")).toBeLessThan(calls.indexOf("chatContainer.clear"));
 		expect(calls.indexOf("chatContainer.clear")).toBeLessThan(calls.indexOf("renderInitialMessages"));
+	});
+
+	it("reconciles manual viewport intent before reloading the same session path", async () => {
+		const sessionPath = "/tmp/project/sessions/a.jsonl";
+		const { ctx, calls } = createContext(sessionPath);
+		const controller = new SelectorController(ctx);
+
+		await controller.handleResumeSession(sessionPath);
+
+		expect(calls).toContain("ui.prepareViewportAnchorForTranscriptRebuild");
+		expect(calls).not.toContain("ui.resetViewportAnchorIntent");
+		expect(calls.indexOf("ui.prepareViewportAnchorForTranscriptRebuild")).toBeLessThan(
+			calls.indexOf("chatContainer.clear"),
+		);
 	});
 
 	it("detaches the active session before selector deletion removes it", async () => {

--- a/packages/coding-agent/test/resume-confirm-continue.test.ts
+++ b/packages/coding-agent/test/resume-confirm-continue.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
 import type { Args } from "../src/cli/args";
 import { parseArgs } from "../src/cli/args";
 import {
@@ -68,6 +69,7 @@ async function captureStderr(operation: () => Promise<void>): Promise<string> {
 }
 
 async function expectEarlyBareResumeRejection(args: Args, isResumePickerTerminal: boolean): Promise<string> {
+	const originalExitCode = process.exitCode;
 	let authDiscoveries = 0;
 	let settingsInitializations = 0;
 	let stdinReads = 0;
@@ -99,7 +101,7 @@ async function expectEarlyBareResumeRejection(args: Args, isResumePickerTerminal
 	expect(settingsInitializations).toBe(0);
 	expect(stdinReads).toBe(0);
 	expect(pickerLists).toBe(0);
-	expect(process.exitCode).toBeUndefined();
+	expect(process.exitCode).toBe(originalExitCode);
 	return stderr;
 }
 
@@ -128,6 +130,22 @@ describe("bare resume startup gating", () => {
 	it("rejects TTY-backed RPC and print routes before startup work", async () => {
 		for (const args of [bareArgs({ mode: "rpc" }), bareArgs({ print: true })]) {
 			expect(await expectEarlyBareResumeRejection(args, true)).toBe(`${BARE_RESUME_INTERACTIVE_ERROR}\n`);
+		}
+	});
+
+	it("preserves undefined, zero, and nonzero exit codes in isolated route probes", async () => {
+		for (const exitCode of ["undefined", "0", "7"]) {
+			const probe = Bun.spawn(
+				[process.execPath, path.join(import.meta.dir, "fixtures/resume-exit-code-probe.ts"), exitCode],
+				{
+					cwd: path.join(import.meta.dir, ".."),
+					stdout: "pipe",
+					stderr: "pipe",
+				},
+			);
+			const [status, stderr] = await Promise.all([probe.exited, new Response(probe.stderr).text()]);
+			expect(status).toBe(0);
+			expect(stderr).toBe(`${BARE_RESUME_INTERACTIVE_ERROR}\n`);
 		}
 	});
 

--- a/packages/coding-agent/test/secrets-obfuscator.test.ts
+++ b/packages/coding-agent/test/secrets-obfuscator.test.ts
@@ -3,8 +3,15 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { SecretObfuscator } from "../src/secrets/obfuscator";
+import { deobfuscateSessionContext, SecretObfuscator } from "../src/secrets/obfuscator";
 import { compileSecretRegex } from "../src/secrets/regex";
+import {
+	associateSessionMessageEntryId,
+	associateSessionMessageViewportAnchorId,
+	getSessionMessageEntryId,
+	getSessionMessageViewportAnchorId,
+	type SessionContext,
+} from "../src/session/session-manager";
 
 describe("compileSecretRegex", () => {
 	it("adds global flag when not provided", () => {
@@ -57,6 +64,37 @@ describe("SecretObfuscator regex behavior", () => {
 			cmd: original.cmd,
 			status: original.status,
 		});
+	});
+});
+
+describe("deobfuscateSessionContext", () => {
+	it("preserves persisted entry identity on cloned messages", () => {
+		const obfuscator = new SecretObfuscator([{ type: "plain", content: "secret" }]);
+		const unchangedMessage = { role: "user" as const, content: "ordinary", timestamp: 1 };
+		const message = { role: "user" as const, content: obfuscator.obfuscate("secret"), timestamp: 2 };
+		associateSessionMessageEntryId(unchangedMessage, "entry-1");
+		associateSessionMessageEntryId(message, "entry-2");
+		associateSessionMessageViewportAnchorId(message, "live-anchor-2");
+		const context: SessionContext = {
+			messages: [unchangedMessage, message],
+			thinkingLevel: "off",
+			models: {},
+			injectedTtsrRules: [],
+			ttsrMessageCount: 0,
+			selectedMCPToolNames: [],
+			hasPersistedMCPToolSelection: false,
+			mode: "none",
+		};
+
+		const result = deobfuscateSessionContext(context, obfuscator);
+		const resultMessage = result.messages[1];
+		expect(result.messages[0]).toBe(unchangedMessage);
+		expect(getSessionMessageEntryId(result.messages[0])).toBe("entry-1");
+		expect(resultMessage).not.toBe(message);
+		if (resultMessage.role !== "user") throw new Error(`Expected user message, got ${resultMessage.role}`);
+		expect(resultMessage.content).toBe("secret");
+		expect(getSessionMessageEntryId(resultMessage)).toBe("entry-2");
+		expect(getSessionMessageViewportAnchorId(resultMessage)).toBe("live-anchor-2");
 	});
 });
 

--- a/packages/coding-agent/test/session-manager-internal-details.test.ts
+++ b/packages/coding-agent/test/session-manager-internal-details.test.ts
@@ -13,7 +13,12 @@
  */
 import { describe, expect, it } from "bun:test";
 import { type SkillPromptDetails, stripInternalDetailsFields } from "@gajae-code/coding-agent/session/messages";
-import { type CustomMessageEntry, SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import {
+	type CustomMessageEntry,
+	getSessionMessageEntryId,
+	SessionManager,
+	transferSessionMessageIdentity,
+} from "@gajae-code/coding-agent/session/session-manager";
 
 const SKILL_TYPE = "skill-prompt";
 
@@ -26,6 +31,26 @@ function readPersistedCustomMessageEntry<T>(session: SessionManager, id: string)
 	return entry as CustomMessageEntry<T>;
 }
 
+describe("SessionManager message entry identity", () => {
+	it("preserves entry IDs across cached context clones", () => {
+		const session = SessionManager.inMemory();
+		const firstEntryId = session.appendMessage({ role: "user", content: "duplicate", timestamp: 1 });
+		const secondEntryId = session.appendMessage({ role: "user", content: "duplicate", timestamp: 1 });
+		const first = session.buildSessionContext();
+		const second = session.buildSessionContext();
+
+		expect(first.messages[0]).not.toBe(second.messages[0]);
+		expect(getSessionMessageEntryId(first.messages[0])).toBe(firstEntryId);
+		expect(getSessionMessageEntryId(first.messages[1])).toBe(secondEntryId);
+		expect(getSessionMessageEntryId(second.messages[0])).toBe(firstEntryId);
+		expect(getSessionMessageEntryId(second.messages[1])).toBe(secondEntryId);
+	});
+
+	it("rejects positional transfer across different message counts", () => {
+		const message = { role: "user" as const, content: "message", timestamp: 1 };
+		expect(() => transferSessionMessageIdentity([message], [])).toThrow("1 source and 0 target messages");
+	});
+});
 describe("SessionManager.appendCustomMessageEntry (allowlist strip + persistence contract)", () => {
 	it("F1: strips __pendingDisplayTag from persisted details while preserving all other SkillPromptDetails fields", () => {
 		const session = SessionManager.inMemory();

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved durable transcript semantic anchors at their screen rows when completion removes transient content, including CJK/emoji/ANSI reflow, prefix eviction, provider replacement, explicit exclusion of synthetic/IRC/pinned rows, and supported SSH, tmux, Termux, and Windows terminal paths (#1969).
+
 ## [0.9.4] - 2026-07-09
 
 ### Fixed

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -3,7 +3,16 @@ import { Marked, marked, type Token, Tokenizer, type Tokens } from "marked";
 import type { SymbolTheme } from "../symbols";
 import { TERMINAL } from "../terminal-capabilities";
 import type { Component } from "../tui";
-import { applyBackgroundToLine, padding, replaceTabs, visibleWidth, wrapTextWithAnsi } from "../utils";
+import {
+	annotateViewportAnchorGraphemes,
+	applyBackgroundToLine,
+	extractViewportAnchorRows,
+	padding,
+	replaceTabs,
+	type ViewportAnchorSpan,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "../utils";
 
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 
@@ -39,7 +48,12 @@ markdownParser.setOptions({
 // (Rust FFI) work for content/layout combinations already seen this session.
 
 const RENDER_CACHE_MAX = 256; // sane cap: ~256 distinct message × width combos
-const renderCache = new LRUCache<string, { source: string; lines: string[] }>({ max: RENDER_CACHE_MAX });
+const renderCache = new LRUCache<
+	string,
+	{ source: string; lines: string[]; anchorSpans?: Array<ViewportAnchorSpan | null> }
+>({
+	max: RENDER_CACHE_MAX,
+});
 const PARSE_CACHE_MAX = 128;
 const parseCache = new LRUCache<string, { source: string; tokens: Token[] }>({ max: PARSE_CACHE_MAX });
 const MARKDOWN_STREAM_THROTTLE_MS = 64;
@@ -59,6 +73,14 @@ const highlightCache = new LRUCache<string, string[]>({ max: HIGHLIGHT_CACHE_MAX
 function renderedLinesBytes(lines: readonly string[]): number {
 	let bytes = 0;
 	for (const line of lines) bytes += Buffer.byteLength(line, "utf8");
+	return bytes;
+}
+
+function anchorSpansBytes(spans: readonly (ViewportAnchorSpan | null)[]): number {
+	let bytes = spans.length * 8; // Array element references
+	for (const span of spans) {
+		if (span) bytes += 4 * 8; // Four numeric offsets
+	}
 	return bytes;
 }
 
@@ -108,6 +130,7 @@ export function getRenderCacheRetainedBytes(): number {
 	for (const entry of renderCache.values()) {
 		bytes += Buffer.byteLength(entry.source, "utf8");
 		bytes += renderedLinesBytes(entry.lines);
+		if (entry.anchorSpans) bytes += anchorSpansBytes(entry.anchorSpans);
 	}
 	for (const entry of parseCache.values()) bytes += Buffer.byteLength(entry.source, "utf8");
 	for (const lines of highlightCache.values()) bytes += renderedLinesBytes(lines);
@@ -235,6 +258,7 @@ export class Markdown implements Component {
 	#cachedText?: string;
 	#cachedWidth?: number;
 	#cachedLines?: string[];
+	#cachedAnchorSpans?: Array<ViewportAnchorSpan | null>;
 
 	#streaming = false;
 	#lastFullParseAt = 0;
@@ -310,6 +334,7 @@ export class Markdown implements Component {
 		this.#cachedText = undefined;
 		this.#cachedWidth = undefined;
 		this.#cachedLines = undefined;
+		this.#cachedAnchorSpans = undefined;
 	}
 
 	#exceedsHighlightCap(code: string): boolean {
@@ -354,20 +379,35 @@ export class Markdown implements Component {
 	}
 
 	render(width: number): string[] {
+		return this.#render(width, false).lines;
+	}
+
+	#render(width: number, includeAnchors: boolean): { lines: string[]; spans?: Array<ViewportAnchorSpan | null> } {
 		// L1: per-instance cache — fastest path for repeated renders of the same
 		// instance at the same width (e.g. resize debounce, repeated redraws).
-		if (this.#cachedLines && this.#cachedText === this.#text && this.#cachedWidth === width) {
-			return this.#cachedLines;
+		if (
+			this.#cachedLines &&
+			this.#cachedText === this.#text &&
+			this.#cachedWidth === width &&
+			(!includeAnchors || this.#cachedAnchorSpans !== undefined)
+		) {
+			return { lines: this.#cachedLines, spans: this.#cachedAnchorSpans };
 		}
 
 		// Calculate available width for content (subtract horizontal padding)
 		const contentWidth = Math.max(1, width - this.#paddingX * 2);
 
-		if (this.#streaming && this.#cachedLines && this.#cachedWidth === width && this.#lastFullParseAt > 0) {
+		if (
+			this.#streaming &&
+			this.#cachedLines &&
+			this.#cachedWidth === width &&
+			this.#lastFullParseAt > 0 &&
+			(!includeAnchors || this.#cachedAnchorSpans !== undefined)
+		) {
 			const elapsedMs = markdownNow() - this.#lastFullParseAt;
 			if (elapsedMs < MARKDOWN_STREAM_THROTTLE_MS) {
 				this.#armStaleThrottleTimer(MARKDOWN_STREAM_THROTTLE_MS - elapsedMs);
-				return this.#cachedLines;
+				return { lines: this.#cachedLines, spans: this.#cachedAnchorSpans };
 			}
 		}
 
@@ -378,7 +418,8 @@ export class Markdown implements Component {
 			this.#cachedText = this.#text;
 			this.#cachedWidth = width;
 			this.#cachedLines = result;
-			return result;
+			this.#cachedAnchorSpans = includeAnchors ? [] : undefined;
+			return { lines: result, spans: this.#cachedAnchorSpans };
 		}
 
 		// Replace tabs with 3 spaces for consistent rendering
@@ -395,12 +436,17 @@ export class Markdown implements Component {
 		const headingProbe = this.#theme.heading("");
 		const cacheKey = `${contentKey}\x00${width}\x00${this.#paddingX}\x00${this.#paddingY}\x00${this.#codeBlockIndent}\x00${objectId(this.#theme)}\x00${this.#defaultTextStyle ? objectId(this.#defaultTextStyle) : -1}\x00${TERMINAL.imageProtocol ?? ""}\x00${TERMINAL.hyperlinks ? 1 : 0}\x00${bgColorProbe}\x00${headingProbe}`;
 		const cached = renderCache.get(cacheKey);
-		if (cached !== undefined && cached.source === normalizedText) {
+		if (
+			cached !== undefined &&
+			cached.source === normalizedText &&
+			(!includeAnchors || cached.anchorSpans !== undefined)
+		) {
 			// Populate L1 so subsequent calls from this instance are O(1) map lookup.
 			this.#cachedText = this.#text;
 			this.#cachedWidth = width;
 			this.#cachedLines = cached.lines;
-			return cached.lines;
+			this.#cachedAnchorSpans = cached.anchorSpans;
+			return { lines: cached.lines, spans: cached.anchorSpans };
 		}
 
 		// Parse markdown to marked tokens. Parse cache is width/theme independent,
@@ -427,13 +473,36 @@ export class Markdown implements Component {
 			renderedLines.push(...tokenLines);
 		}
 
-		// Wrap lines (NO padding, NO background yet)
-		const wrappedLines: string[] = [];
-		for (const line of renderedLines) {
-			if (TERMINAL.isImageLine(line)) {
-				wrappedLines.push(line);
-			} else {
-				wrappedLines.push(...wrapTextIfNeeded(line, contentWidth));
+		let wrappedLines: string[];
+		let wrappedSpans: Array<ViewportAnchorSpan | null> | undefined;
+		if (includeAnchors) {
+			const markedRenderedLines: string[] = [];
+			const markerToken = crypto.randomUUID();
+			let nextGrapheme = 0;
+			let nextCell = 0;
+			for (const line of renderedLines) {
+				if (TERMINAL.isImageLine(line)) {
+					markedRenderedLines.push(line);
+					continue;
+				}
+				const marked = annotateViewportAnchorGraphemes(line, nextGrapheme, nextCell, markerToken);
+				markedRenderedLines.push(marked.text);
+				nextGrapheme = marked.nextGrapheme;
+				nextCell = marked.nextCell;
+			}
+			const markedWrappedLines: string[] = [];
+			for (const line of markedRenderedLines) {
+				if (TERMINAL.isImageLine(line)) markedWrappedLines.push(line);
+				else markedWrappedLines.push(...wrapTextIfNeeded(line, contentWidth));
+			}
+			const extracted = extractViewportAnchorRows(markedWrappedLines, markerToken);
+			wrappedLines = extracted.lines;
+			wrappedSpans = extracted.spans;
+		} else {
+			wrappedLines = [];
+			for (const line of renderedLines) {
+				if (TERMINAL.isImageLine(line)) wrappedLines.push(line);
+				else wrappedLines.push(...wrapTextIfNeeded(line, contentWidth));
 			}
 		}
 
@@ -470,21 +539,42 @@ export class Markdown implements Component {
 			emptyLines.push(line);
 		}
 
-		// Combine top padding, content, and bottom padding
 		const rawResult = [...emptyLines, ...contentLines, ...emptyLines];
+		const rawAnchorSpans = wrappedSpans && [
+			...emptyLines.map(() => null),
+			...wrappedSpans,
+			...emptyLines.map(() => null),
+		];
 		const result = rawResult.length > 0 ? rawResult : [""];
+		const anchorSpans = rawResult.length > 0 ? rawAnchorSpans : wrappedSpans ? [null] : undefined;
 
 		// Update L1 per-instance cache
 		this.#cachedText = this.#text;
 		this.#cachedWidth = width;
 		this.#cachedLines = result;
+		this.#cachedAnchorSpans = anchorSpans;
 		this.#lastFullParseAt = markdownNow();
 
 		// Update L2 module-level LRU so future instances with the same key skip
 		// the marked.lexer + highlightCode (Rust FFI) work entirely.
-		renderCache.set(cacheKey, { source: normalizedText, lines: result });
+		renderCache.set(cacheKey, { source: normalizedText, lines: result, ...(anchorSpans ? { anchorSpans } : {}) });
 
-		return result;
+		return { lines: result, spans: anchorSpans };
+	}
+
+	renderWithViewportAnchorSource(
+		width: number,
+		source: { id: string },
+	): {
+		lines: string[];
+		anchors: Array<({ id: string } & ViewportAnchorSpan) | null>;
+	} {
+		const { lines, spans } = this.#render(width, true);
+		if (!spans) throw new Error("Viewport anchor source render completed without row spans");
+		return {
+			lines,
+			anchors: spans.map(span => (span ? { id: source.id, ...span } : null)),
+		};
 	}
 
 	/**

--- a/packages/tui/src/components/text.ts
+++ b/packages/tui/src/components/text.ts
@@ -1,5 +1,15 @@
 import type { Component } from "../tui";
-import { applyBackgroundToLine, padding, replaceTabs, visibleWidth, wrapTextWithAnsi } from "../utils";
+
+import {
+	annotateViewportAnchorGraphemes,
+	applyBackgroundToLine,
+	extractViewportAnchorRows,
+	padding,
+	replaceTabs,
+	type ViewportAnchorSpan,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "../utils";
 
 /**
  * Text component - displays multi-line text with word wrapping
@@ -14,6 +24,7 @@ export class Text implements Component {
 	#cachedText?: string;
 	#cachedWidth?: number;
 	#cachedLines?: string[];
+	#cachedAnchorSpans?: Array<ViewportAnchorSpan | null>;
 
 	constructor(text: string = "", paddingX: number = 1, paddingY: number = 1, customBgFn?: (text: string) => string) {
 		this.#text = text;
@@ -31,6 +42,7 @@ export class Text implements Component {
 		this.#cachedText = undefined;
 		this.#cachedWidth = undefined;
 		this.#cachedLines = undefined;
+		this.#cachedAnchorSpans = undefined;
 	}
 
 	setCustomBgFn(customBgFn?: (text: string) => string): void {
@@ -38,73 +50,85 @@ export class Text implements Component {
 		this.#cachedText = undefined;
 		this.#cachedWidth = undefined;
 		this.#cachedLines = undefined;
+		this.#cachedAnchorSpans = undefined;
 	}
 
 	invalidate(): void {
 		this.#cachedText = undefined;
 		this.#cachedWidth = undefined;
 		this.#cachedLines = undefined;
+		this.#cachedAnchorSpans = undefined;
 	}
 
 	render(width: number): string[] {
-		// Check cache
-		if (this.#cachedLines && this.#cachedText === this.#text && this.#cachedWidth === width) {
-			return this.#cachedLines;
+		return this.#render(width, false).lines;
+	}
+
+	#render(width: number, includeAnchors: boolean): { lines: string[]; spans?: Array<ViewportAnchorSpan | null> } {
+		if (
+			this.#cachedLines &&
+			this.#cachedText === this.#text &&
+			this.#cachedWidth === width &&
+			(!includeAnchors || this.#cachedAnchorSpans !== undefined)
+		) {
+			return { lines: this.#cachedLines, spans: this.#cachedAnchorSpans };
 		}
 
-		// Don't render anything if there's no actual text
 		if (!this.#text || this.#text.trim() === "") {
 			const result: string[] = [];
 			this.#cachedText = this.#text;
 			this.#cachedWidth = width;
 			this.#cachedLines = result;
-			return result;
+			this.#cachedAnchorSpans = includeAnchors ? [] : undefined;
+			return { lines: result, spans: this.#cachedAnchorSpans };
 		}
 
-		// Replace tabs with 3 spaces
 		const normalizedText = replaceTabs(this.#text);
-
-		// Calculate content width (subtract left/right margins)
 		const contentWidth = Math.max(1, width - this.#paddingX * 2);
+		let wrappedLines: string[];
+		let wrappedSpans: Array<ViewportAnchorSpan | null> | undefined;
+		if (includeAnchors) {
+			const markedText = annotateViewportAnchorGraphemes(normalizedText);
+			const extracted = extractViewportAnchorRows(wrapTextWithAnsi(markedText.text, contentWidth), markedText.token);
+			wrappedLines = extracted.lines;
+			wrappedSpans = extracted.spans;
+		} else {
+			wrappedLines = wrapTextWithAnsi(normalizedText, contentWidth);
+		}
 
-		// Wrap text (this preserves ANSI codes but does NOT pad)
-		const wrappedLines = wrapTextWithAnsi(normalizedText, contentWidth);
-
-		// Add margins and background to each line
 		const leftMargin = padding(this.#paddingX);
 		const rightMargin = padding(this.#paddingX);
 		const contentLines: string[] = [];
-
 		for (const line of wrappedLines) {
-			// Add margins
 			const lineWithMargins = leftMargin + line + rightMargin;
-
-			// Apply background if specified (this also pads to full width)
-			if (this.#customBgFn) {
-				contentLines.push(applyBackgroundToLine(lineWithMargins, width, this.#customBgFn));
-			} else {
-				// No background - just pad to width with spaces
-				const visibleLen = visibleWidth(lineWithMargins);
-				const paddingNeeded = Math.max(0, width - visibleLen);
-				contentLines.push(lineWithMargins + padding(paddingNeeded));
-			}
+			if (this.#customBgFn) contentLines.push(applyBackgroundToLine(lineWithMargins, width, this.#customBgFn));
+			else contentLines.push(lineWithMargins + padding(Math.max(0, width - visibleWidth(lineWithMargins))));
 		}
-
-		// Add top/bottom padding (empty lines)
 		const emptyLine = padding(width);
-		const emptyLines: string[] = [];
-		for (let i = 0; i < this.#paddingY; i++) {
-			const line = this.#customBgFn ? applyBackgroundToLine(emptyLine, width, this.#customBgFn) : emptyLine;
-			emptyLines.push(line);
-		}
-
+		const emptyLines = Array.from({ length: this.#paddingY }, () =>
+			this.#customBgFn ? applyBackgroundToLine(emptyLine, width, this.#customBgFn) : emptyLine,
+		);
 		const result = [...emptyLines, ...contentLines, ...emptyLines];
-
-		// Update cache
+		const spans = wrappedSpans && [...emptyLines.map(() => null), ...wrappedSpans, ...emptyLines.map(() => null)];
 		this.#cachedText = this.#text;
 		this.#cachedWidth = width;
 		this.#cachedLines = result;
+		this.#cachedAnchorSpans = spans;
+		return { lines: result.length > 0 ? result : [""], spans };
+	}
 
-		return result.length > 0 ? result : [""];
+	renderWithViewportAnchorSource(
+		width: number,
+		source: { id: string },
+	): {
+		lines: string[];
+		anchors: Array<({ id: string } & ViewportAnchorSpan) | null>;
+	} {
+		const { lines, spans } = this.#render(width, true);
+		if (!spans) throw new Error("Viewport anchor source render completed without row spans");
+		return {
+			lines,
+			anchors: spans.map(span => (span ? { id: source.id, ...span } : null)),
+		};
 	}
 }

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -574,6 +574,8 @@ export class TUI extends Container {
 	#viewportAnchorComponent: Component | null = null;
 	#viewportAnchorFrame: ViewportAnchorFrame | null = null;
 	#manualViewportAnchor: ManualViewportAnchor | null = null;
+	#manualViewportFallbackAnchors: ManualViewportAnchor[] = [];
+	#reconcileMissingViewportAnchor = false;
 	#lastCursorPosition: { row: number; col: number } | null = null;
 	#sixelProbePendingDa = false;
 	#sixelProbePendingGraphics = false;
@@ -722,6 +724,20 @@ export class TUI extends Container {
 		this.#viewportAnchorFrame = null;
 	}
 
+	/** Clear manual viewport ownership before replacing the transcript identity namespace. */
+	resetViewportAnchorIntent(): void {
+		this.#manualViewportTop = undefined;
+		this.#manualViewportAnchor = null;
+		this.#manualViewportFallbackAnchors = [];
+		this.#reconcileMissingViewportAnchor = false;
+		this.#viewportAnchorFrame = null;
+	}
+
+	/** Allow one semantic-neighbor reconciliation after a definitive same-transcript rebuild. */
+	prepareViewportAnchorForTranscriptRebuild(): void {
+		if (this.#manualViewportAnchor !== null) this.#reconcileMissingViewportAnchor = true;
+	}
+
 	scrollViewportPages(direction: -1 | 1): boolean {
 		const height = this.terminal.rows;
 		const width = this.terminal.columns;
@@ -771,6 +787,24 @@ export class TUI extends Container {
 							: Math.max(selected.anchor.cellStart, selected.anchor.cellEnd - 1),
 					desiredScreenRow: selected.row + frame.startRow - targetViewportTop,
 				};
+				const fallbacks: ManualViewportAnchor[] = [];
+				for (let row = firstCandidateRow; row < lastCandidateRow; row++) {
+					const anchor = frame.anchors[row];
+					if (anchor === null || row === selected.row) continue;
+					fallbacks.push({
+						id: anchor.id,
+						graphemeIndex:
+							direction < 0 ? anchor.graphemeStart : Math.max(anchor.graphemeStart, anchor.graphemeEnd - 1),
+						cellOffset: direction < 0 ? anchor.cellStart : Math.max(anchor.cellStart, anchor.cellEnd - 1),
+						desiredScreenRow: row + frame.startRow - targetViewportTop,
+					});
+				}
+				fallbacks.sort(
+					(a, b) =>
+						Math.abs(a.desiredScreenRow - this.#manualViewportAnchor!.desiredScreenRow) -
+						Math.abs(b.desiredScreenRow - this.#manualViewportAnchor!.desiredScreenRow),
+				);
+				this.#manualViewportFallbackAnchors = fallbacks;
 			}
 		}
 		this.#manualViewportTop = targetViewportTop;
@@ -792,6 +826,8 @@ export class TUI extends Container {
 		const liveViewportTop = Math.max(0, this.#previousLines.length - height);
 		this.#manualViewportTop = undefined;
 		this.#manualViewportAnchor = null;
+		this.#manualViewportFallbackAnchors = [];
+		this.#reconcileMissingViewportAnchor = false;
 		return this.#repaintViewportFromLines(
 			this.#previousLines,
 			width,
@@ -1801,6 +1837,40 @@ export class TUI extends Container {
 		return row < 0 ? null : Math.max(0, frame.startRow + row - anchor.desiredScreenRow);
 	}
 
+	#resolvePreparedManualAnchor(frame: ViewportAnchorFrame): number | null {
+		const previous = this.#manualViewportAnchor;
+		for (const fallback of this.#manualViewportFallbackAnchors) {
+			this.#manualViewportAnchor = fallback;
+			const resolved = this.#resolveManualAnchor(frame);
+			if (resolved !== null) return resolved;
+		}
+		const targetRow = Math.max(
+			0,
+			Math.min(
+				frame.anchors.length - 1,
+				(this.#manualViewportTop ?? 0) + (previous?.desiredScreenRow ?? 0) - frame.startRow,
+			),
+		);
+		let selectedRow = -1;
+		for (let distance = 0; distance < frame.anchors.length; distance++) {
+			for (const row of [targetRow - distance, targetRow + distance]) {
+				if (row < 0 || row >= frame.anchors.length || frame.anchors[row] === null) continue;
+				selectedRow = row;
+				break;
+			}
+			if (selectedRow >= 0) break;
+		}
+		const selected = selectedRow >= 0 ? frame.anchors[selectedRow] : null;
+		if (selected === null) return null;
+		this.#manualViewportAnchor = {
+			id: selected.id,
+			graphemeIndex: selected.graphemeStart,
+			cellOffset: selected.cellStart,
+			desiredScreenRow: previous?.desiredScreenRow ?? 0,
+		};
+		return this.#resolveManualAnchor(frame);
+	}
+
 	#repaintViewportFromLines(
 		lines: string[],
 		width: number,
@@ -1966,7 +2036,19 @@ export class TUI extends Container {
 		}
 
 		if (this.#manualViewportTop !== undefined) {
-			const resolvedAnchorTop = anchorFrame === null ? null : this.#resolveManualAnchor(anchorFrame);
+			let resolvedAnchorTop = anchorFrame === null ? null : this.#resolveManualAnchor(anchorFrame);
+			if (
+				this.#manualViewportAnchor !== null &&
+				resolvedAnchorTop === null &&
+				this.#reconcileMissingViewportAnchor
+			) {
+				resolvedAnchorTop = anchorFrame === null ? null : this.#resolvePreparedManualAnchor(anchorFrame);
+				this.#reconcileMissingViewportAnchor = false;
+				if (resolvedAnchorTop === null) {
+					this.#manualViewportAnchor = null;
+					this.#manualViewportFallbackAnchors = [];
+				}
+			}
 			if (this.#manualViewportAnchor !== null && resolvedAnchorTop === null) {
 				if (anchorRenderFailed) {
 					// Keep semantic intent armed for recovery, but render the diagnostic frame
@@ -2013,6 +2095,7 @@ export class TUI extends Container {
 				return;
 			}
 			this.#manualViewportTop = nextViewportTop;
+			this.#reconcileMissingViewportAnchor = false;
 			if (
 				this.#repaintViewportFromLines(
 					newLines,

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -539,6 +539,7 @@ type TuiRenderCounterSnapshot = {
 export class TUI extends Container {
 	terminal: Terminal;
 	#previousLines: string[] = [];
+	#latestRenderedLines: string[] = [];
 	/**
 	 * Raw (pre-normalization) lines from the previous frame, kept only when the
 	 * virtual-viewport flag is on. Used to detect whether the off-screen prefix is
@@ -823,19 +824,22 @@ export class TUI extends Container {
 		if (this.#manualViewportTop === undefined) return false;
 		const height = this.terminal.rows;
 		const width = this.terminal.columns;
-		const liveViewportTop = Math.max(0, this.#previousLines.length - height);
+		const liveLines = this.#latestRenderedLines;
+		const liveViewportTop = Math.max(0, liveLines.length - height);
 		this.#manualViewportTop = undefined;
 		this.#manualViewportAnchor = null;
 		this.#manualViewportFallbackAnchors = [];
 		this.#reconcileMissingViewportAnchor = false;
-		return this.#repaintViewportFromLines(
-			this.#previousLines,
+		const repainted = this.#repaintViewportFromLines(
+			liveLines,
 			width,
 			height,
 			liveViewportTop,
 			this.#lastCursorPosition,
 			"manual viewport follow live",
 		);
+		if (repainted) this.#previousLines = liveLines;
+		return repainted;
 	}
 
 	/**
@@ -1173,6 +1177,7 @@ export class TUI extends Container {
 		// focus/listener state is intentionally preserved so input routing survives
 		// a resume.
 		this.#previousLines = [];
+		this.#latestRenderedLines = [];
 		this.#previousRaw = [];
 		this.#lineNormalizationCache.clear();
 		this.#lineTruncationCache.clear();
@@ -1209,6 +1214,7 @@ export class TUI extends Container {
 			// A forced full redraw supersedes any queued input-priority render.
 			this.#inputRenderPending = false;
 			this.#previousLines = [];
+			this.#latestRenderedLines = [];
 			this.#previousRaw = [];
 			this.#lineNormalizationCache.clear();
 			this.#lineTruncationCache.clear();
@@ -2034,6 +2040,7 @@ export class TUI extends Container {
 			renderMetrics.recordLineCount("measured", total - diffStart);
 			if (usedWindowNormalize) renderMetrics.recordLineCount("offscreenScan", diffStart);
 		}
+		this.#latestRenderedLines = newLines;
 
 		if (this.#manualViewportTop !== undefined) {
 			let resolvedAnchorTop = anchorFrame === null ? null : this.#resolveManualAnchor(anchorFrame);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -98,6 +98,82 @@ export const CURSOR_MARKER = "\x1b_pi:c\x07";
 
 export { visibleWidth };
 
+/** Durable source identifier for a semantically anchored viewport row. */
+export type ViewportAnchorId = string;
+
+export interface ViewportAnchorRow {
+	id: ViewportAnchorId;
+	graphemeStart: number;
+	graphemeEnd: number;
+	cellStart: number;
+	cellEnd: number;
+}
+
+export interface ViewportAnchorRender {
+	lines: string[];
+	anchors: Array<ViewportAnchorRow | null>;
+}
+
+export interface ViewportAnchorProvider extends Component {
+	renderWithViewportAnchors(width: number): ViewportAnchorRender;
+}
+
+export interface ViewportAnchorSource {
+	id: ViewportAnchorId;
+}
+
+export interface ViewportAnchorSourceRenderer extends Component {
+	renderWithViewportAnchorSource(width: number, source: ViewportAnchorSource): ViewportAnchorRender;
+}
+
+export function isViewportAnchorProvider(component: Component): component is ViewportAnchorProvider {
+	if (!("renderWithViewportAnchors" in component) || typeof component.renderWithViewportAnchors !== "function") {
+		return false;
+	}
+	return !(
+		component instanceof Container &&
+		component.renderWithViewportAnchors === Container.prototype.renderWithViewportAnchors &&
+		component.render !== Container.prototype.render
+	);
+}
+
+export function isViewportAnchorSourceRenderer(component: Component): component is ViewportAnchorSourceRenderer {
+	return (
+		"renderWithViewportAnchorSource" in component && typeof component.renderWithViewportAnchorSource === "function"
+	);
+}
+
+export function renderComponentWithViewportAnchors(component: Component, width: number): ViewportAnchorRender {
+	if (isViewportAnchorProvider(component)) {
+		const rendered = component.renderWithViewportAnchors(width);
+		if (rendered.anchors.length !== rendered.lines.length) {
+			throw new Error(
+				`Viewport anchor provider returned ${rendered.anchors.length} anchors for ${rendered.lines.length} lines`,
+			);
+		}
+		return rendered;
+	}
+	const lines = component.render(width);
+	return { lines, anchors: lines.map(() => null) };
+}
+
+export function renderComponentWithViewportAnchorSource(
+	component: Component,
+	width: number,
+	source: ViewportAnchorSource,
+): ViewportAnchorRender {
+	if (!isViewportAnchorSourceRenderer(component)) {
+		throw new TypeError("Viewport anchor sources require renderer-owned row metadata");
+	}
+	const rendered = component.renderWithViewportAnchorSource(width, source);
+	if (rendered.anchors.length !== rendered.lines.length) {
+		throw new Error(
+			`Viewport anchor source renderer returned ${rendered.anchors.length} anchors for ${rendered.lines.length} lines`,
+		);
+	}
+	return rendered;
+}
+
 /**
  * Anchor position for overlays
  */
@@ -212,6 +288,17 @@ function useViewportRepaintPath(terminal: Terminal): boolean {
 	});
 }
 
+function allowsHostNeutralOverflowRepaint(
+	terminal: Terminal,
+	env: Record<string, string | undefined> = Bun.env,
+): boolean {
+	return (
+		terminal.isProcessTerminal === true &&
+		!isTermuxSession(env) &&
+		!(isMultiplexerSession(env) && useLegacyMultiplexerFullRender(env))
+	);
+}
+
 function shouldPreserveScrollbackOnFullClear(terminal: Terminal): boolean {
 	return isViewportSensitiveHost(Bun.env, process.platform, terminal.isProcessTerminal === true);
 }
@@ -271,9 +358,10 @@ export interface OverlayHandle {
 /**
  * Container - a component that contains other components
  */
-export class Container implements Component {
+export class Container implements ViewportAnchorProvider {
 	children: Component[] = [];
 	#disposed = false;
+	#viewportAnchorSources = new Map<Component, ViewportAnchorSource>();
 
 	addChild(component: Component): void {
 		this.children.push(component);
@@ -283,6 +371,7 @@ export class Container implements Component {
 		const index = this.children.indexOf(component);
 		if (index !== -1) {
 			this.children.splice(index, 1);
+			this.#viewportAnchorSources.delete(component);
 			component.dispose?.();
 		}
 	}
@@ -292,45 +381,62 @@ export class Container implements Component {
 		const index = this.children.indexOf(component);
 		if (index !== -1) {
 			this.children.splice(index, 1);
+			this.#viewportAnchorSources.delete(component);
 		}
 	}
 
 	clear(): void {
-		for (const child of this.children) {
-			child.dispose?.();
-		}
+		for (const child of this.children) child.dispose?.();
 		this.children = [];
+		this.#viewportAnchorSources.clear();
 	}
 
 	/** Remove all children without disposing them (for detach-then-readd reuse). */
 	detachAll(): void {
 		this.children = [];
+		this.#viewportAnchorSources.clear();
+	}
+
+	/** Registers a direct child as eligible for semantic viewport anchoring. */
+	setViewportAnchorSource(component: Component, source: ViewportAnchorSource | null): void {
+		if (source !== null && !isViewportAnchorSourceRenderer(component)) {
+			throw new TypeError("Viewport anchor sources require renderer-owned row metadata");
+		}
+		if (source === null) this.#viewportAnchorSources.delete(component);
+		else this.#viewportAnchorSources.set(component, source);
 	}
 
 	dispose(): void {
 		if (this.#disposed) return;
 		this.#disposed = true;
-		for (const child of this.children) {
-			child.dispose?.();
-		}
+		for (const child of this.children) child.dispose?.();
+		this.#viewportAnchorSources.clear();
 	}
 
 	invalidate(): void {
-		for (const child of this.children) {
-			child.invalidate?.();
-		}
+		for (const child of this.children) child.invalidate?.();
 	}
 
 	render(width: number): string[] {
+		return this.renderWithViewportAnchors(width).lines;
+	}
+
+	renderWithViewportAnchors(width: number): ViewportAnchorRender {
 		width = Math.max(1, width);
 		const lines: string[] = [];
+		const anchors: Array<ViewportAnchorRow | null> = [];
 		for (const child of this.children) {
-			const childLines = safeRenderComponent(child, width, "container-child");
-			for (let i = 0; i < childLines.length; i++) {
-				lines.push(childLines[i]);
+			const source = this.#viewportAnchorSources.get(child);
+			const rendered =
+				source === undefined
+					? safeRenderComponentWithViewportAnchors(child, width, "container-child")
+					: safeRenderComponentWithViewportAnchorSource(child, width, source, "container-anchor-child");
+			for (let index = 0; index < rendered.lines.length; index++) {
+				lines.push(rendered.lines[index]);
+				anchors.push(rendered.anchors[index] ?? null);
 			}
 		}
-		return lines;
+		return { lines, anchors };
 	}
 }
 
@@ -348,23 +454,58 @@ const reportedRenderErrors = new Set<string>();
  * command such as `/background`). Isolate the failure: log it once, emit a
  * visible fallback line, and keep rendering the rest of the tree.
  */
+function renderFailure(component: Component, where: string, err: unknown): string[] {
+	const name = component?.constructor?.name ?? "Component";
+	const key = `${where}:${name}:${err instanceof Error ? err.message : String(err)}`;
+	if (!reportedRenderErrors.has(key)) {
+		if (reportedRenderErrors.size >= MAX_REPORTED_RENDER_ERRORS) reportedRenderErrors.clear();
+		reportedRenderErrors.add(key);
+		logger.error("Component render failed; emitting fallback line", {
+			where,
+			component: name,
+			error: err instanceof Error ? err.message : String(err),
+			stack: err instanceof Error ? err.stack : undefined,
+		});
+	}
+	return [`[render error: ${name}]`];
+}
+
+let viewportAnchorRenderFailureCount = 0;
+
 function safeRenderComponent(component: Component, width: number, where: string): string[] {
 	try {
 		return component.render(width);
 	} catch (err) {
-		const name = component?.constructor?.name ?? "Component";
-		const key = `${where}:${name}:${err instanceof Error ? err.message : String(err)}`;
-		if (!reportedRenderErrors.has(key)) {
-			if (reportedRenderErrors.size >= MAX_REPORTED_RENDER_ERRORS) reportedRenderErrors.clear();
-			reportedRenderErrors.add(key);
-			logger.error("Component render failed; emitting fallback line", {
-				where,
-				component: name,
-				error: err instanceof Error ? err.message : String(err),
-				stack: err instanceof Error ? err.stack : undefined,
-			});
-		}
-		return [`[render error: ${name}]`];
+		return renderFailure(component, where, err);
+	}
+}
+
+function safeRenderComponentWithViewportAnchors(
+	component: Component,
+	width: number,
+	where: string,
+): ViewportAnchorRender {
+	try {
+		return renderComponentWithViewportAnchors(component, width);
+	} catch (err) {
+		viewportAnchorRenderFailureCount += 1;
+		const lines = renderFailure(component, where, err);
+		return { lines, anchors: lines.map(() => null) };
+	}
+}
+
+function safeRenderComponentWithViewportAnchorSource(
+	component: Component,
+	width: number,
+	source: ViewportAnchorSource,
+	where: string,
+): ViewportAnchorRender {
+	try {
+		return renderComponentWithViewportAnchorSource(component, width, source);
+	} catch (err) {
+		viewportAnchorRenderFailureCount += 1;
+		const lines = renderFailure(component, where, err);
+		return { lines, anchors: lines.map(() => null) };
 	}
 }
 
@@ -372,6 +513,18 @@ type LineNormalizationCacheEntry = {
 	normalized: string;
 	terminated: string;
 	width: number | undefined;
+};
+
+type ViewportAnchorFrame = {
+	startRow: number;
+	anchors: Array<ViewportAnchorRow | null>;
+};
+
+type ManualViewportAnchor = {
+	id: ViewportAnchorId;
+	graphemeIndex: number;
+	cellOffset: number;
+	desiredScreenRow: number;
 };
 
 type TuiRenderCounterSnapshot = {
@@ -418,6 +571,9 @@ export class TUI extends Container {
 	#hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
 	#viewportTopRow = 0; // Content row currently mapped to screen row 0
 	#manualViewportTop: number | undefined;
+	#viewportAnchorComponent: Component | null = null;
+	#viewportAnchorFrame: ViewportAnchorFrame | null = null;
+	#manualViewportAnchor: ManualViewportAnchor | null = null;
 	#lastCursorPosition: { row: number; col: number } | null = null;
 	#sixelProbePendingDa = false;
 	#sixelProbePendingGraphics = false;
@@ -555,15 +711,68 @@ export class TUI extends Container {
 		this.#bottomPinnedComponent = component;
 		this.requestRender();
 	}
+
+	/** Register the direct child whose rows are eligible for semantic viewport anchoring. */
+	setViewportAnchorComponent(component: Component | null): void {
+		if (component !== null && !isViewportAnchorProvider(component)) {
+			throw new TypeError("Viewport anchor components must provide renderer-owned row metadata");
+		}
+		if (this.#viewportAnchorComponent === component) return;
+		this.#viewportAnchorComponent = component;
+		this.#viewportAnchorFrame = null;
+	}
+
 	scrollViewportPages(direction: -1 | 1): boolean {
 		const height = this.terminal.rows;
 		const width = this.terminal.columns;
 		if (height <= 0 || width <= 0 || this.#previousLines.length === 0) return false;
 		const maxViewportTop = Math.max(0, this.#previousLines.length - height);
-		const currentViewportTop = Math.max(0, Math.min(maxViewportTop, this.#manualViewportTop ?? this.#viewportTopRow));
-		const pageStep = Math.max(1, height - 1);
-		const targetViewportTop = Math.max(0, Math.min(maxViewportTop, currentViewportTop + direction * pageStep));
-
+		let currentViewportTop = Math.max(0, Math.min(maxViewportTop, this.#manualViewportTop ?? this.#viewportTopRow));
+		const frame = this.#viewportAnchorFrame;
+		if (this.#manualViewportAnchor !== null) {
+			if (frame === null) return false;
+			const resolvedViewportTop = this.#resolveManualAnchor(frame);
+			if (resolvedViewportTop === null) return false;
+			currentViewportTop = Math.max(0, Math.min(maxViewportTop, resolvedViewportTop));
+		}
+		const targetViewportTop = Math.max(
+			0,
+			Math.min(maxViewportTop, currentViewportTop + direction * Math.max(1, height - 1)),
+		);
+		if (frame !== null) {
+			const desiredScreenRow = this.#manualViewportAnchor?.desiredScreenRow ?? (direction < 0 ? 0 : height - 1);
+			const targetRow = targetViewportTop + desiredScreenRow - frame.startRow;
+			let selected: { row: number; anchor: ViewportAnchorRow } | undefined;
+			const firstCandidateRow = Math.max(0, targetViewportTop - frame.startRow);
+			const lastCandidateRow = Math.min(frame.anchors.length, targetViewportTop + height - frame.startRow);
+			for (let row = firstCandidateRow; row < lastCandidateRow; row++) {
+				const anchor = frame.anchors[row];
+				if (anchor === null) continue;
+				if (
+					selected === undefined ||
+					Math.abs(row - targetRow) < Math.abs(selected.row - targetRow) ||
+					(Math.abs(row - targetRow) === Math.abs(selected.row - targetRow) &&
+						(direction < 0 ? row < selected.row : row > selected.row))
+				)
+					selected = { row, anchor };
+			}
+			if (selected === undefined) {
+				if (this.#manualViewportAnchor !== null) return false;
+			} else {
+				this.#manualViewportAnchor = {
+					id: selected.anchor.id,
+					graphemeIndex:
+						direction < 0
+							? selected.anchor.graphemeStart
+							: Math.max(selected.anchor.graphemeStart, selected.anchor.graphemeEnd - 1),
+					cellOffset:
+						direction < 0
+							? selected.anchor.cellStart
+							: Math.max(selected.anchor.cellStart, selected.anchor.cellEnd - 1),
+					desiredScreenRow: selected.row + frame.startRow - targetViewportTop,
+				};
+			}
+		}
 		this.#manualViewportTop = targetViewportTop;
 		return this.#repaintViewportFromLines(
 			this.#previousLines,
@@ -572,6 +781,7 @@ export class TUI extends Container {
 			targetViewportTop,
 			null,
 			"manual viewport scroll",
+			this.#manualViewportAnchor !== null,
 		);
 	}
 
@@ -581,6 +791,7 @@ export class TUI extends Container {
 		const width = this.terminal.columns;
 		const liveViewportTop = Math.max(0, this.#previousLines.length - height);
 		this.#manualViewportTop = undefined;
+		this.#manualViewportAnchor = null;
 		return this.#repaintViewportFromLines(
 			this.#previousLines,
 			width,
@@ -1547,7 +1758,11 @@ export class TUI extends Container {
 		return lines;
 	}
 
-	#padBeforeBottomPinnedComponent(lines: string[], height: number): string[] {
+	#padBeforeBottomPinnedComponent(
+		lines: string[],
+		height: number,
+		renderedChildren: Map<Component, string[]>,
+	): string[] {
 		const component = this.#bottomPinnedComponent;
 		if (component === null || lines.length >= height) return lines;
 
@@ -1562,7 +1777,7 @@ export class TUI extends Container {
 
 		let pinnedLineCount = 0;
 		for (let i = pinnedStart; i < this.children.length; i++) {
-			pinnedLineCount += safeRenderComponent(this.children[i], this.terminal.columns, "pinned").length;
+			pinnedLineCount += (renderedChildren.get(this.children[i]) ?? []).length;
 		}
 
 		const blankRows = height - lines.length;
@@ -1571,6 +1786,21 @@ export class TUI extends Container {
 		padded.splice(insertAt, 0, ...Array.from({ length: blankRows }, () => ""));
 		return padded;
 	}
+	#resolveManualAnchor(frame: ViewportAnchorFrame): number | null {
+		const anchor = this.#manualViewportAnchor;
+		if (anchor === null) return null;
+		const row = frame.anchors.findIndex(
+			candidate =>
+				candidate !== null &&
+				candidate.id === anchor.id &&
+				candidate.graphemeStart <= anchor.graphemeIndex &&
+				anchor.graphemeIndex < candidate.graphemeEnd &&
+				candidate.cellStart <= anchor.cellOffset &&
+				anchor.cellOffset < candidate.cellEnd,
+		);
+		return row < 0 ? null : Math.max(0, frame.startRow + row - anchor.desiredScreenRow);
+	}
+
 	#repaintViewportFromLines(
 		lines: string[],
 		width: number,
@@ -1578,9 +1808,10 @@ export class TUI extends Container {
 		viewportTop: number,
 		cursorPos: { row: number; col: number } | null,
 		reason: string,
+		allowPastLiveBottom = false,
 	): boolean {
 		if (height <= 0 || width <= 0) return false;
-		const maxViewportTop = Math.max(0, lines.length - height);
+		const maxViewportTop = Math.max(0, lines.length - (allowPastLiveBottom ? 1 : height));
 		const nextViewportTop = Math.max(0, Math.min(maxViewportTop, viewportTop));
 		const currentScreenRow = Math.max(0, Math.min(height - 1, this.#hardwareCursorRow - this.#viewportTopRow));
 		let buffer = "\x1b[?2026h";
@@ -1642,13 +1873,27 @@ export class TUI extends Container {
 			return targetScreenRow - currentScreenRow;
 		};
 
-		// Render all components to get new lines
+		// Render direct children once so the registered transcript component retains row ownership.
 		const renderTreeStart = renderMetrics.now();
-		let newLines = this.render(width);
+		const renderedLines: string[] = [];
+		const renderedChildren = new Map<Component, string[]>();
+		let anchorFrame: ViewportAnchorFrame | null = null;
+		const anchorRenderFailureCountBefore = viewportAnchorRenderFailureCount;
+		for (const child of this.children) {
+			const rendered = safeRenderComponentWithViewportAnchors(child, width, "tui-child");
+			renderedChildren.set(child, rendered.lines);
+			if (child === this.#viewportAnchorComponent && rendered.anchors.some(anchor => anchor !== null)) {
+				anchorFrame = { startRow: renderedLines.length, anchors: rendered.anchors };
+			}
+			for (const line of rendered.lines) renderedLines.push(line);
+		}
+		const anchorRenderFailed = viewportAnchorRenderFailureCount !== anchorRenderFailureCountBefore;
+		let newLines = renderedLines;
+		this.#viewportAnchorFrame = anchorFrame;
 		if (renderMetrics.enabled) renderMetrics.recordHelper("renderTree", renderMetrics.now() - renderTreeStart);
 
 		if (this.#bottomPinnedComponent !== null && height > 0) {
-			newLines = this.#padBeforeBottomPinnedComponent(newLines, height);
+			newLines = this.#padBeforeBottomPinnedComponent(newLines, height, renderedChildren);
 		}
 
 		// Composite overlays into the rendered lines (before differential compare)
@@ -1721,18 +1966,62 @@ export class TUI extends Container {
 		}
 
 		if (this.#manualViewportTop !== undefined) {
-			const maxViewportTop = Math.max(0, newLines.length - height);
-			const nextViewportTop = Math.max(0, Math.min(maxViewportTop, this.#manualViewportTop));
+			const resolvedAnchorTop = anchorFrame === null ? null : this.#resolveManualAnchor(anchorFrame);
+			if (this.#manualViewportAnchor !== null && resolvedAnchorTop === null) {
+				if (anchorRenderFailed) {
+					// Keep semantic intent armed for recovery, but render the diagnostic frame
+					// instead of masking a provider failure behind stale transcript content.
+					this.#repaintViewportFromLines(
+						newLines,
+						width,
+						height,
+						this.#manualViewportTop,
+						null,
+						"failed semantic viewport render",
+						true,
+					);
+					this.#previousLines = newLines;
+					this.#previousWidth = width;
+					this.#previousHeight = height;
+					return;
+				}
+				// A formerly valid semantic target is temporarily absent (provider removal,
+				// replacement, eviction, or object deletion). Keep the last resolved frame
+				// instead of silently reinterpreting manual intent as a numeric viewport.
+				const retainedLines = this.#previousLines.length > 0 ? this.#previousLines : newLines;
+				this.#repaintViewportFromLines(
+					retainedLines,
+					width,
+					height,
+					this.#manualViewportTop,
+					null,
+					"unresolved semantic viewport render",
+					true,
+				);
+				this.#previousWidth = width;
+				this.#previousHeight = height;
+				return;
+			}
+			const nextViewportTop = resolvedAnchorTop ?? this.#manualViewportTop;
+			if (
+				this.#previousWidth === width &&
+				this.#previousHeight === height &&
+				nextViewportTop === this.#manualViewportTop &&
+				newLines.length === this.#previousLines.length &&
+				newLines.every((line, index) => line === this.#previousLines[index])
+			) {
+				return;
+			}
 			this.#manualViewportTop = nextViewportTop;
-			const repaintCursorPos = null;
 			if (
 				this.#repaintViewportFromLines(
 					newLines,
 					width,
 					height,
 					nextViewportTop,
-					repaintCursorPos,
+					null,
 					"manual viewport render",
+					this.#manualViewportAnchor !== null,
 				)
 			) {
 				this.#previousLines = newLines;
@@ -1878,7 +2167,11 @@ export class TUI extends Container {
 		// Configurable via setClearOnShrink() or PI_CLEAR_ON_SHRINK=0 env var
 		if (this.#clearOnShrink && newLines.length < this.#previousLines.length && this.overlayStack.length === 0) {
 			logRedraw(`clearOnShrink (prev=${this.#previousLines.length}, new=${newLines.length})`);
-			if (useViewportRepaintPath(this.terminal)) {
+			if (
+				useViewportRepaintPath(this.terminal) ||
+				((this.#previousLines.length > height || newLines.length > height) &&
+					allowsHostNeutralOverflowRepaint(this.terminal))
+			) {
 				viewportRepaint(`clearOnShrink (prev=${this.#previousLines.length}, new=${newLines.length})`);
 			} else {
 				fullRender(true, "clearOnShrink");
@@ -1981,7 +2274,12 @@ export class TUI extends Container {
 		// back to live.
 		if (firstChanged < prevViewportTop) {
 			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			if (useViewportRepaintPath(this.terminal)) {
+			if (
+				useViewportRepaintPath(this.terminal) ||
+				(newLines.length <= this.#previousLines.length &&
+					(this.#previousLines.length > height || newLines.length > height) &&
+					allowsHostNeutralOverflowRepaint(this.terminal))
+			) {
 				viewportRepaint(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
 				return;
 			}

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -163,6 +163,118 @@ const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 export function getSegmenter(): Intl.Segmenter {
 	return segmenter;
 }
+
+export interface ViewportAnchorSpan {
+	graphemeStart: number;
+	graphemeEnd: number;
+	cellStart: number;
+	cellEnd: number;
+}
+
+export interface ViewportAnchorAnnotation {
+	text: string;
+	nextGrapheme: number;
+	nextCell: number;
+	token: string;
+}
+
+const VIEWPORT_ANCHOR_PREFIX = "\x1b_GJC_ANCHOR:";
+const VIEWPORT_ANCHOR_SUFFIX = "\x1b\\";
+
+function ansiSequenceEnd(text: string, start: number): number {
+	if (text[start] !== "\x1b" || start + 1 >= text.length) return start;
+	const kind = text[start + 1];
+	if (kind === "[") {
+		let index = start + 2;
+		while (index < text.length) {
+			const code = text.charCodeAt(index++);
+			if (code >= 0x40 && code <= 0x7e) return index;
+		}
+		return text.length;
+	}
+	if (kind === "]" || kind === "_" || kind === "P" || kind === "^" || kind === "X") {
+		const bel = text.indexOf("\x07", start + 2);
+		const st = text.indexOf("\x1b\\", start + 2);
+		if (bel < 0) return st < 0 ? text.length : st + 2;
+		if (st < 0) return bel + 1;
+		return Math.min(bel + 1, st + 2);
+	}
+	return Math.min(text.length, start + 2);
+}
+
+/**
+ * Tag every visible grapheme with an APC marker that survives ANSI-aware
+ * wrapping. The marker contains source grapheme and monotonic cell offsets.
+ */
+export function annotateViewportAnchorGraphemes(
+	text: string,
+	startGrapheme = 0,
+	startCell = 0,
+	token = crypto.randomUUID(),
+): ViewportAnchorAnnotation {
+	let result = "";
+	let grapheme = startGrapheme;
+	let cell = startCell;
+	let textStart = 0;
+	const appendVisible = (visible: string): void => {
+		for (const part of segmenter.segment(visible)) {
+			if (part.segment === "\n" || part.segment === "\r") {
+				result += part.segment;
+				continue;
+			}
+			const cellEnd = cell + Math.max(1, visibleWidth(part.segment));
+			result += `${part.segment}${VIEWPORT_ANCHOR_PREFIX}${token}:${grapheme}:${grapheme + 1}:${cell}:${cellEnd}${VIEWPORT_ANCHOR_SUFFIX}`;
+			grapheme += 1;
+			cell = cellEnd;
+		}
+	};
+	for (let index = 0; index < text.length; ) {
+		if (text[index] !== "\x1b") {
+			index += 1;
+			continue;
+		}
+		appendVisible(text.slice(textStart, index));
+		const end = ansiSequenceEnd(text, index);
+		result += text.slice(index, end);
+		index = end;
+		textStart = end;
+	}
+	appendVisible(text.slice(textStart));
+	return { text: result, nextGrapheme: grapheme, nextCell: cell, token };
+}
+
+/** Remove viewport anchor markers and return the exact marked span for each row. */
+export function extractViewportAnchorRows(
+	lines: readonly string[],
+	token: string,
+): { lines: string[]; spans: Array<ViewportAnchorSpan | null> } {
+	const markerRegex = new RegExp(`\\x1b_GJC_ANCHOR:${token}:(\\d+):(\\d+):(\\d+):(\\d+)\\x1b\\\\`, "g");
+	const cleanLines: string[] = [];
+	const spans: Array<ViewportAnchorSpan | null> = [];
+	for (const line of lines) {
+		let span: ViewportAnchorSpan | null = null;
+		const clean = line.replace(markerRegex, (_marker, start, end, cellStart, cellEnd) => {
+			const candidate = {
+				graphemeStart: Number(start),
+				graphemeEnd: Number(end),
+				cellStart: Number(cellStart),
+				cellEnd: Number(cellEnd),
+			};
+			if (!span) {
+				span = candidate;
+			} else {
+				span.graphemeStart = Math.min(span.graphemeStart, candidate.graphemeStart);
+				span.graphemeEnd = Math.max(span.graphemeEnd, candidate.graphemeEnd);
+				span.cellStart = Math.min(span.cellStart, candidate.cellStart);
+				span.cellEnd = Math.max(span.cellEnd, candidate.cellEnd);
+			}
+			return "";
+		});
+		cleanLines.push(clean);
+		spans.push(span);
+	}
+	return { lines: cleanLines, spans };
+}
 function normalizeForWidth(str: string): string {
 	const normalized = str.normalize("NFC");
 	return normalized === str ? str : normalized;

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -45,21 +45,28 @@ function countMatches(lines: string[], pattern: RegExp): number {
 
 describe("TUI terminal-state regressions", () => {
 	let monotonicNow = 0;
-	let previousTmux: string | undefined;
-	let previousSty: string | undefined;
-	let previousZellij: string | undefined;
-	let previousLegacyFullRender: string | undefined;
+	const hostEnvKeys = [
+		"SSH_CONNECTION",
+		"TERM",
+		"COLORTERM",
+		"WT_SESSION",
+		"TERM_PROGRAM",
+		"TMUX",
+		"TMUX_PANE",
+		"STY",
+		"ZELLIJ",
+		"GJC_TMUX_LAUNCHED",
+		"TERMUX_VERSION",
+		"PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER",
+		"PI_CLEAR_ON_SHRINK",
+		"PI_TUI_VIRTUAL_VIEWPORT",
+	] as const;
+	let previousHostEnv = new Map<string, string | undefined>();
 	// Keep TUI's 16ms render throttle deterministic without sleeping a real frame per render.
 
 	beforeEach(() => {
-		previousTmux = Bun.env.TMUX;
-		previousSty = Bun.env.STY;
-		previousZellij = Bun.env.ZELLIJ;
-		previousLegacyFullRender = Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
-		delete Bun.env.TMUX;
-		delete Bun.env.STY;
-		delete Bun.env.ZELLIJ;
-		delete Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
+		previousHostEnv = new Map(hostEnvKeys.map(key => [key, Bun.env[key]]));
+		for (const key of hostEnvKeys) delete Bun.env[key];
 		monotonicNow = 0;
 		vi.spyOn(performance, "now").mockImplementation(() => {
 			monotonicNow += 20;
@@ -69,25 +76,10 @@ describe("TUI terminal-state regressions", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
-		if (previousTmux === undefined) {
-			delete Bun.env.TMUX;
-		} else {
-			Bun.env.TMUX = previousTmux;
-		}
-		if (previousSty === undefined) {
-			delete Bun.env.STY;
-		} else {
-			Bun.env.STY = previousSty;
-		}
-		if (previousZellij === undefined) {
-			delete Bun.env.ZELLIJ;
-		} else {
-			Bun.env.ZELLIJ = previousZellij;
-		}
-		if (previousLegacyFullRender === undefined) {
-			delete Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER;
-		} else {
-			Bun.env.PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER = previousLegacyFullRender;
+		for (const key of hostEnvKeys) {
+			const value = previousHostEnv.get(key);
+			if (value === undefined) delete Bun.env[key];
+			else Bun.env[key] = value;
 		}
 	});
 
@@ -208,6 +200,32 @@ describe("TUI terminal-state regressions", () => {
 			} finally {
 				tui.stop();
 			}
+		});
+
+		describe("overflow contraction", () => {
+			it("repaints a clean process terminal instead of clearing and replaying overflow history", async () => {
+				Bun.env.SSH_CONNECTION = "203.0.113.10 54321 198.51.100.20 22";
+				Bun.env.TERM = "xterm-256color";
+				Bun.env.COLORTERM = "truecolor";
+				Bun.env.PI_TUI_VIRTUAL_VIEWPORT = "1";
+				const term = new VirtualTerminal(20, 5, { isProcessTerminal: true });
+				const tui = new TUI(term);
+				const component = new MutableLinesComponent(rows("line-", 12));
+				tui.addChild(component);
+				try {
+					tui.start();
+					await settle(term);
+					term.clearWriteLog();
+					component.setLines(rows("line-", 8));
+					tui.setClearOnShrink(true);
+					tui.requestRender();
+					await settle(term);
+					expect(visible(term)).toEqual(["line-3", "line-4", "line-5", "line-6", "line-7"]);
+					expect(term.getWriteLog().join("")).not.toContain("\x1b[2J\x1b[H");
+				} finally {
+					tui.stop();
+				}
+			});
 		});
 	});
 	describe("render line cache bounds", () => {

--- a/packages/tui/test/viewport-scroll.test.ts
+++ b/packages/tui/test/viewport-scroll.test.ts
@@ -711,6 +711,59 @@ describe("registered viewport anchor", () => {
 			tui.stop();
 		}
 	});
+	it("resets stale manual intent when the transcript identity changes", async () => {
+		const term = new VirtualTerminal(30, 6);
+		const tui = new TUI(term);
+		const transcriptA = new AnchoredTranscript();
+		for (let index = 0; index < 20; index++) transcriptA.addRow(`session-a-${index}`, `session-a-${index}`);
+		tui.addChild(transcriptA);
+		tui.setViewportAnchorComponent(transcriptA);
+		try {
+			tui.start();
+			await settle(term);
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			expect(visible(term).some(line => line.includes("session-a-"))).toBe(true);
+
+			const transcriptB = new AnchoredTranscript();
+			for (let index = 0; index < 8; index++) transcriptB.addRow(`session-b-${index}`, `session-b-${index}`);
+			tui.resetViewportAnchorIntent();
+			tui.detachChild(transcriptA);
+			tui.addChild(transcriptB);
+			tui.setViewportAnchorComponent(transcriptB);
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term).some(line => line.includes("session-b-"))).toBe(true);
+			expect(visible(term).some(line => line.includes("session-a-"))).toBe(false);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("reconciles an evicted anchor to a surviving semantic neighbor after rebuild", async () => {
+		const term = new VirtualTerminal(30, 6);
+		const tui = new TUI(term);
+		const transcript = new AnchoredTranscript();
+		for (let index = 0; index < 20; index++) transcript.addRow(`history-${index}`, `history-${index}`);
+		tui.addChild(transcript);
+		tui.setViewportAnchorComponent(transcript);
+		try {
+			tui.start();
+			await settle(term);
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			expect(visible(term)[0]).toBe("history-9");
+
+			tui.prepareViewportAnchorForTranscriptRebuild();
+			transcript.removeFirst(10);
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term).some(line => line === "history-10")).toBe(true);
+			expect(visible(term).some(line => line === "history-9")).toBe(false);
+		} finally {
+			tui.stop();
+		}
+	});
 
 	it("surfaces anchor render failures while retaining intent for recovery", async () => {
 		const term = new VirtualTerminal(30, 6);

--- a/packages/tui/test/viewport-scroll.test.ts
+++ b/packages/tui/test/viewport-scroll.test.ts
@@ -659,6 +659,33 @@ describe("registered viewport anchor", () => {
 		}
 	});
 
+	it("follows the latest transcript after an unresolved anchor", async () => {
+		const term = new VirtualTerminal(30, 6);
+		const tui = new TUI(term);
+		const transcript = new AnchoredTranscript();
+		for (let index = 0; index < 20; index++) transcript.addRow(`history-${index}`, `history-${index}`);
+		tui.addChild(transcript);
+		tui.setViewportAnchorComponent(transcript);
+		try {
+			tui.start();
+			await settle(term);
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			expect(visible(term)[0]).toBe("history-9");
+
+			transcript.removeFirst(10);
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term)[0]).toBe("history-9");
+
+			expect(tui.followLiveViewport()).toBe(true);
+			await term.flush();
+			expect(visible(term).at(-1)).toBe("history-19");
+			expect(visible(term).some(line => line === "history-9")).toBe(false);
+		} finally {
+			tui.stop();
+		}
+	});
 	it("retains unresolved intent through provider removal and resolves a replacement", async () => {
 		const term = new VirtualTerminal(30, 6);
 		const tui = new TUI(term);

--- a/packages/tui/test/viewport-scroll.test.ts
+++ b/packages/tui/test/viewport-scroll.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, it } from "bun:test";
-import { type Component, TUI } from "@gajae-code/tui";
+import {
+	type Component,
+	Container,
+	renderComponentWithViewportAnchors,
+	shouldUseViewportRepaintForHost,
+	Text,
+	TUI,
+	type ViewportAnchorRender,
+	type ViewportAnchorSource,
+} from "@gajae-code/tui";
 import { VirtualTerminal } from "./virtual-terminal";
 
 class Lines implements Component {
+	static #nextId = 0;
+	readonly id = `test-lines-${Lines.#nextId++}`;
+
 	#lines: string[];
 
 	constructor(lines: string[]) {
@@ -25,7 +37,57 @@ class Lines implements Component {
 		return this.#lines;
 	}
 
+	renderWithViewportAnchors(_width: number): ViewportAnchorRender {
+		let graphemeOffset = 0;
+		let cellOffset = 0;
+		const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+		const anchors = this.#lines.map(line => {
+			const graphemeCount = [...segmenter.segment(Bun.stripANSI(line))].length;
+			const cellCount = Bun.stringWidth(line);
+			const anchor =
+				graphemeCount === 0
+					? null
+					: {
+							id: this.id,
+							graphemeStart: graphemeOffset,
+							graphemeEnd: graphemeOffset + graphemeCount,
+							cellStart: cellOffset,
+							cellEnd: cellOffset + Math.max(1, cellCount),
+						};
+			graphemeOffset += graphemeCount + 1;
+			cellOffset += cellCount;
+			return anchor;
+		});
+		return { lines: this.#lines, anchors };
+	}
+
+	getText(): string {
+		return this.#lines.join("\n");
+	}
+
 	invalidate(): void {}
+}
+
+class AnchoredTranscript extends Container {
+	addRow(id: string, text: string): Text {
+		const component = new Text(text, 0, 0);
+		this.addChild(component);
+		this.setViewportAnchorSource(component, { id });
+		return component;
+	}
+
+	removeFirst(count: number): void {
+		for (const child of this.children.slice(0, count)) this.detachChild(child);
+	}
+}
+
+class RecoveringText extends Text {
+	fail = false;
+
+	override renderWithViewportAnchorSource(width: number, source: ViewportAnchorSource): ViewportAnchorRender {
+		if (this.fail) throw new Error("recoverable anchor render failure");
+		return super.renderWithViewportAnchorSource(width, source);
+	}
 }
 
 async function settle(term: VirtualTerminal): Promise<void> {
@@ -82,6 +144,25 @@ describe("TUI manual viewport paging", () => {
 			expect(tui.followLiveViewport()).toBe(true);
 			await term.flush();
 			expect(visible(term)).toEqual(["line-6", "line-7", "line-8", "line-9", "line-10"]);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("clamps providerless manual paging to a full viewport after shrink", async () => {
+		const term = new VirtualTerminal(30, 5);
+		const tui = new TUI(term);
+		const content = new Lines(Array.from({ length: 10 }, (_value, index) => `line-${index}`));
+		tui.addChild(content);
+		try {
+			tui.start();
+			await settle(term);
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			content.replace(["line-0", "line-1", "line-2", "line-3"]);
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term)).toEqual(["line-0", "line-1", "line-2", "line-3", ""]);
 		} finally {
 			tui.stop();
 		}
@@ -228,6 +309,537 @@ describe("TUI manual viewport paging", () => {
 				delete Bun.env.WT_SESSION;
 			} else {
 				Bun.env.WT_SESSION = previousWtSession;
+			}
+		}
+	});
+});
+
+describe("registered viewport anchor", () => {
+	it("blocks excluded PageDown targets and preserves transcript rows through contraction", async () => {
+		const envKeys = [
+			"SSH_CONNECTION",
+			"TERM",
+			"COLORTERM",
+			"WT_SESSION",
+			"TERM_PROGRAM",
+			"TMUX",
+			"TMUX_PANE",
+			"STY",
+			"ZELLIJ",
+			"GJC_TMUX_LAUNCHED",
+			"TERMUX_VERSION",
+			"PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER",
+			"PI_CLEAR_ON_SHRINK",
+			"PI_TUI_VIRTUAL_VIEWPORT",
+		] as const;
+		const previous = new Map<string, string | undefined>(envKeys.map(key => [key, Bun.env[key]]));
+		for (const key of envKeys) delete Bun.env[key];
+		Bun.env.SSH_CONNECTION = "203.0.113.10 54321 198.51.100.20 22";
+		Bun.env.TERM = "xterm-256color";
+		Bun.env.COLORTERM = "truecolor";
+		const term = new VirtualTerminal(30, 6, { isProcessTerminal: true });
+		const tui = new TUI(term);
+		const transcript = new Lines(Array.from({ length: 12 }, (_value, index) => `transcript-${index}`));
+		const transient = new Lines(Array.from({ length: 6 }, (_value, index) => `transient-${index}`));
+		const synthetic = new Lines(Array.from({ length: 4 }, (_value, index) => `synthetic-${index}`));
+		const pinned = new Lines(["status", "editor"]);
+		tui.addChild(transcript);
+		tui.addChild(transient);
+		tui.addChild(synthetic);
+		tui.addChild(pinned);
+		tui.setViewportAnchorComponent(transcript);
+		tui.setBottomPinnedComponent(pinned);
+		try {
+			tui.start();
+			await settle(term);
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			expect(visible(term)).toEqual([
+				"transcript-8",
+				"transcript-9",
+				"transcript-10",
+				"transcript-11",
+				"transient-0",
+				"transient-1",
+			]);
+			term.clearWriteLog();
+			expect(tui.scrollViewportPages(1)).toBe(false);
+			await term.flush();
+			expect(visible(term)).toEqual([
+				"transcript-8",
+				"transcript-9",
+				"transcript-10",
+				"transcript-11",
+				"transient-0",
+				"transient-1",
+			]);
+			transcript.setLine(8, "transcript-8 final");
+			for (const clearOnShrink of [false, true]) {
+				if (clearOnShrink) {
+					transient.replace(Array.from({ length: 6 }, (_value, index) => `transient-${index}`));
+					synthetic.replace(Array.from({ length: 4 }, (_value, index) => `synthetic-${index}`));
+					tui.requestRender();
+					await settle(term);
+				}
+				term.clearWriteLog();
+				transient.replace([]);
+				synthetic.replace([]);
+				tui.setClearOnShrink(clearOnShrink);
+				tui.requestRender();
+				await settle(term);
+				expect(visible(term)).toEqual([
+					"transcript-8 final",
+					"transcript-9",
+					"transcript-10",
+					"transcript-11",
+					"status",
+					"editor",
+				]);
+				const writes = term.getWriteLog().join("");
+				expect(writes).not.toContain("\x1b[2J\x1b[H");
+				expect(writes).not.toContain("\x1b[3J");
+				expect(writes).not.toContain("transcript-0");
+				term.clearWriteLog();
+				tui.requestRender();
+				await settle(term);
+				expect(visible(term)).toEqual([
+					"transcript-8 final",
+					"transcript-9",
+					"transcript-10",
+					"transcript-11",
+					"status",
+					"editor",
+				]);
+			}
+		} finally {
+			tui.stop();
+			for (const key of envKeys) {
+				const value = previous.get(key);
+				if (value === undefined) delete Bun.env[key];
+				else Bun.env[key] = value;
+			}
+		}
+	});
+
+	it("emits authoritative grapheme and cell spans from production Text wrapping", () => {
+		const container = new Container();
+		const text = new Text("\x1b[31m가가🙂e\u0301가\x1b[0m", 0, 0);
+		container.addChild(text);
+		container.setViewportAnchorSource(text, { id: "semantic-text" });
+		const rendered = container.renderWithViewportAnchors(4);
+		expect(rendered.lines.join("")).not.toContain("GJC_ANCHOR");
+		expect(rendered.anchors).toEqual([
+			{ id: "semantic-text", graphemeStart: 0, graphemeEnd: 2, cellStart: 0, cellEnd: 4 },
+			{ id: "semantic-text", graphemeStart: 2, graphemeEnd: 4, cellStart: 4, cellEnd: 7 },
+			{ id: "semantic-text", graphemeStart: 4, graphemeEnd: 5, cellStart: 7, cellEnd: 9 },
+		]);
+		expect(rendered.lines).toEqual(text.render(4));
+	});
+
+	it("explicitly excludes whitespace-only Text rows from semantic anchoring", () => {
+		const container = new Container();
+		const whitespace = new Text(" \t ", 0, 0);
+		container.addChild(whitespace);
+		container.setViewportAnchorSource(whitespace, { id: "blank" });
+		expect(container.renderWithViewportAnchors(20)).toEqual({ lines: [], anchors: [] });
+	});
+
+	it("rejects malformed or non-provider anchor registrations", () => {
+		const malformed: Component & { renderWithViewportAnchors(width: number): ViewportAnchorRender } = {
+			render: () => ["unsafe"],
+			renderWithViewportAnchors: () => ({ lines: ["unsafe"], anchors: [] }),
+			invalidate: () => {},
+		};
+		expect(() => renderComponentWithViewportAnchors(malformed, 20)).toThrow("returned 0 anchors for 1 lines");
+		const tui = new TUI(new VirtualTerminal(20, 4));
+		expect(() => tui.setViewportAnchorComponent({ render: () => ["plain"], invalidate: () => {} })).toThrow(
+			"must provide renderer-owned row metadata",
+		);
+	});
+
+	it("does not strip or trust user-supplied anchor-like APC content", () => {
+		const literalMarker = "\x1b_GJC_ANCHOR:0:1:0:1\x1b\\";
+		const container = new Container();
+		const text = new Text(`${literalMarker}visible`, 0, 0);
+		container.addChild(text);
+		container.setViewportAnchorSource(text, { id: "literal-apc" });
+		const rendered = container.renderWithViewportAnchors(80);
+		expect(rendered.lines.join("")).toContain(literalMarker);
+		expect(rendered.anchors.some(anchor => anchor?.id === "literal-apc")).toBe(true);
+	});
+
+	it("preserves a CJK emoji ANSI anchor across arbitrary repeated reflow", async () => {
+		const term = new VirtualTerminal(80, 6);
+		const tui = new TUI(term);
+		const transcript = new AnchoredTranscript();
+		for (let index = 0; index < 30; index++) {
+			transcript.addRow(
+				`prefix-${index}`,
+				`\x1b[36m접두-${index}-가나다라마바사아자차카타파하🙂-display-width-prefix-reflow\x1b[0m`,
+			);
+		}
+		transcript.addRow("target", "\x1b[35m가나다라마바사아자차카타파하🙂끝\x1b[0m");
+		tui.addChild(transcript);
+		tui.setViewportAnchorComponent(transcript);
+		try {
+			tui.start();
+			await settle(term);
+			expect(tui.scrollViewportPages(1)).toBe(true);
+			await term.flush();
+			expect(visible(term)[5]).toContain("끝");
+			for (const width of [12, 80, 8, 80, 12]) {
+				term.resize(width, 6);
+				await settle(term);
+				expect(visible(term)[5], `width=${width}`).toContain("끝");
+			}
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term)[5]).toContain("끝");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("resolves duplicate rendered text by semantic identity", async () => {
+		const term = new VirtualTerminal(30, 6);
+		const tui = new TUI(term);
+		const original = new AnchoredTranscript();
+		for (let index = 0; index < 20; index++) {
+			original.addRow(`row-${index}`, index === 10 ? "target-neighbor" : "duplicate");
+		}
+		tui.addChild(original);
+		tui.setViewportAnchorComponent(original);
+		try {
+			tui.start();
+			await settle(term);
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			expect(visible(term).slice(0, 2)).toEqual(["duplicate", "target-neighbor"]);
+
+			const replacement = new AnchoredTranscript();
+			for (let index = 0; index < 20; index++) replacement.addRow(`prefix-${index}`, "duplicate");
+			replacement.addRow("row-9", "duplicate");
+			replacement.addRow("row-10", "target-neighbor");
+			for (let index = 11; index < 20; index++) replacement.addRow(`row-${index}`, "duplicate");
+			tui.detachChild(original);
+			tui.addChild(replacement);
+			tui.setViewportAnchorComponent(replacement);
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term).slice(0, 2)).toEqual(["duplicate", "target-neighbor"]);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("preserves a production-wrapped anchor through resize loops and completion contraction", async () => {
+		const envKeys = [
+			"SSH_CONNECTION",
+			"TERM",
+			"COLORTERM",
+			"WT_SESSION",
+			"TERM_PROGRAM",
+			"TMUX",
+			"TMUX_PANE",
+			"STY",
+			"ZELLIJ",
+			"GJC_TMUX_LAUNCHED",
+			"TERMUX_VERSION",
+			"PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER",
+		] as const;
+		const previous = new Map(envKeys.map(key => [key, Bun.env[key]]));
+		try {
+			for (const key of envKeys) delete Bun.env[key];
+			Bun.env.SSH_CONNECTION = "10.0.0.1 50000 10.0.0.2 22";
+			Bun.env.TERM = "xterm-256color";
+			for (const clearOnShrink of [false, true]) {
+				const term = new VirtualTerminal(30, 6, { isProcessTerminal: true });
+				const tui = new TUI(term);
+				const transcript = new AnchoredTranscript();
+				for (let index = 0; index < 5; index++) {
+					transcript.addRow(`prefix-${index}`, `접두-${index}-가나다라마바사🙂-production-wrap`);
+				}
+				transcript.addRow("target", "\x1b[35m가나다라마바사아자차카타파하🙂끝\x1b[0m");
+				const transient = new Lines(["transient-0"]);
+				const synthetic = new Lines(["synthetic-0"]);
+				const pinned = new Lines(["status", "editor"]);
+				tui.addChild(transcript);
+				tui.addChild(transient);
+				tui.addChild(synthetic);
+				tui.addChild(pinned);
+				tui.setViewportAnchorComponent(transcript);
+				tui.setBottomPinnedComponent(pinned);
+				try {
+					tui.start();
+					await settle(term);
+					expect(visible(term).some(line => line.includes("끝"))).toBe(true);
+					expect(tui.scrollViewportPages(1)).toBe(true);
+					await term.flush();
+					const targetScreenRow = visible(term).findIndex(line => line.includes("끝"));
+					expect(targetScreenRow).toBeGreaterThanOrEqual(0);
+					for (const width of [14, 70, 10, 30]) {
+						term.resize(width, 6);
+						await settle(term);
+						expect(visible(term)[targetScreenRow], `width=${width} clear=${clearOnShrink}`).toContain("끝");
+					}
+					term.clearWriteLog();
+					transient.replace([]);
+					synthetic.replace([]);
+					tui.setClearOnShrink(clearOnShrink);
+					tui.requestRender();
+					await settle(term);
+					expect(visible(term)[targetScreenRow]).toContain("끝");
+					const writes = term.getWriteLog().join("");
+					expect(writes).not.toContain("\x1b[2J\x1b[H");
+					expect(writes).not.toContain("\x1b[3J");
+				} finally {
+					tui.stop();
+				}
+			}
+		} finally {
+			for (const [key, value] of previous) {
+				if (value === undefined) delete Bun.env[key];
+				else Bun.env[key] = value;
+			}
+		}
+	});
+
+	it("preserves a still-present semantic row after prefix scrollback eviction", async () => {
+		const term = new VirtualTerminal(30, 6);
+		const tui = new TUI(term);
+		const transcript = new AnchoredTranscript();
+		for (let index = 0; index < 40; index++) transcript.addRow(`history-${index}`, `history-${index}`);
+		tui.addChild(transcript);
+		tui.setViewportAnchorComponent(transcript);
+		try {
+			tui.start();
+			await settle(term);
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			expect(visible(term)[0]).toBe("history-29");
+			transcript.removeFirst(10);
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term)[0]).toBe("history-29");
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term)[0]).toBe("history-29");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("retains unresolved intent when the anchored object is deleted", async () => {
+		const term = new VirtualTerminal(30, 6);
+		const tui = new TUI(term);
+		const transcript = new AnchoredTranscript();
+		for (let index = 0; index < 20; index++) transcript.addRow(`history-${index}`, `history-${index}`);
+		tui.addChild(transcript);
+		tui.setViewportAnchorComponent(transcript);
+		try {
+			tui.start();
+			await settle(term);
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			expect(visible(term)[0]).toBe("history-9");
+
+			transcript.removeFirst(10);
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term)[0]).toBe("history-9");
+
+			transcript.addRow("history-9", "history-9 restored");
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term)[0]).toBe("history-9 restored");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("retains unresolved intent through provider removal and resolves a replacement", async () => {
+		const term = new VirtualTerminal(30, 6);
+		const tui = new TUI(term);
+		const original = new AnchoredTranscript();
+		for (let index = 0; index < 20; index++) original.addRow(`history-${index}`, `history-${index}`);
+		tui.addChild(original);
+		tui.setViewportAnchorComponent(original);
+		try {
+			tui.start();
+			await settle(term);
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			expect(visible(term)[0]).toBe("history-9");
+
+			tui.setViewportAnchorComponent(null);
+			original.removeFirst(10);
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term)[0]).toBe("history-9");
+
+			term.clearWriteLog();
+			const unresolvedViewport = visible(term);
+			expect(tui.scrollViewportPages(-1)).toBe(false);
+			expect(tui.scrollViewportPages(1)).toBe(false);
+			await term.flush();
+			expect(visible(term)).toEqual(unresolvedViewport);
+			expect(term.getWriteLog()).toEqual([]);
+
+			const replacement = new AnchoredTranscript();
+			for (let index = 0; index < 5; index++) replacement.addRow(`replacement-${index}`, `replacement-${index}`);
+			for (let index = 10; index < 20; index++) replacement.addRow(`history-${index}`, `history-${index}`);
+			tui.detachChild(original);
+			tui.addChild(replacement);
+			tui.setViewportAnchorComponent(replacement);
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term)[0]).toBe("history-9");
+
+			term.clearWriteLog();
+			expect(tui.scrollViewportPages(-1)).toBe(false);
+			expect(tui.scrollViewportPages(1)).toBe(false);
+			await term.flush();
+			expect(term.getWriteLog()).toEqual([]);
+
+			replacement.addRow("history-9", "history-9");
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term)[0]).toBe("history-9");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("surfaces anchor render failures while retaining intent for recovery", async () => {
+		const term = new VirtualTerminal(30, 6);
+		const tui = new TUI(term);
+		const transcript = new AnchoredTranscript();
+		for (let index = 0; index < 10; index++) transcript.addRow(`history-${index}`, `history-${index}`);
+		const recovering = new RecoveringText("history-10", 0, 0);
+		transcript.addChild(recovering);
+		transcript.setViewportAnchorSource(recovering, { id: "history-10" });
+		for (let index = 11; index < 21; index++) transcript.addRow(`history-${index}`, `history-${index}`);
+		tui.addChild(transcript);
+		tui.setViewportAnchorComponent(transcript);
+		try {
+			tui.start();
+			await settle(term);
+			expect(tui.scrollViewportPages(-1)).toBe(true);
+			await term.flush();
+			expect(visible(term)).toContain("history-10");
+
+			recovering.fail = true;
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term).some(line => line.includes("[render error: RecoveringText]"))).toBe(true);
+
+			recovering.fail = false;
+			tui.requestRender();
+			await settle(term);
+			expect(visible(term)).toContain("history-10");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("preserves manual completion anchors across supported terminal host paths", async () => {
+		const envKeys = [
+			"SSH_CONNECTION",
+			"TERM",
+			"COLORTERM",
+			"WT_SESSION",
+			"TERM_PROGRAM",
+			"TMUX",
+			"TMUX_PANE",
+			"STY",
+			"ZELLIJ",
+			"GJC_TMUX_LAUNCHED",
+			"TERMUX_VERSION",
+			"PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER",
+			"PI_CLEAR_ON_SHRINK",
+			"PI_TUI_VIRTUAL_VIEWPORT",
+		] as const;
+		const previous = new Map<string, string | undefined>(envKeys.map(key => [key, Bun.env[key]]));
+		const cases = [
+			{ label: "plain-ssh", env: { SSH_CONNECTION: "client server", TERM: "xterm-256color" } },
+			{ label: "tmux-default", env: { TMUX: "/tmp/tmux,1,0", TERM: "tmux-256color" } },
+			{
+				label: "tmux-legacy",
+				env: { TMUX: "/tmp/tmux,1,0", TERM: "tmux-256color", PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER: "1" },
+			},
+			{ label: "termux-height", env: { TERMUX_VERSION: "0.118", TERM: "xterm-256color" }, resizeHeight: 7 },
+			{
+				label: "windows-markers",
+				env: { WT_SESSION: "forwarded", TERM_PROGRAM: "Windows_Terminal", TERM: "xterm-256color" },
+			},
+			{ label: "native-windows-selector", env: { TERM: "xterm-256color" }, nativeWindows: true },
+		] as const;
+		try {
+			for (const testCase of cases) {
+				for (const clearOnShrink of [false, true]) {
+					for (const key of envKeys) delete Bun.env[key];
+					Object.assign(Bun.env, testCase.env);
+					if ("nativeWindows" in testCase) {
+						expect(
+							shouldUseViewportRepaintForHost({}, "win32", { includeNativeWindows: testCase.nativeWindows }),
+						).toBe(true);
+					}
+					const term = new VirtualTerminal(30, 6, { isProcessTerminal: true });
+					const tui = new TUI(term);
+					const transcript = new Lines(Array.from({ length: 12 }, (_value, index) => `transcript-${index}`));
+					const transient = new Lines(Array.from({ length: 6 }, (_value, index) => `transient-${index}`));
+					const synthetic = new Lines(Array.from({ length: 4 }, (_value, index) => `synthetic-${index}`));
+					const pinned = new Lines(["status", "editor"]);
+					tui.addChild(transcript);
+					tui.addChild(transient);
+					tui.addChild(synthetic);
+					tui.addChild(pinned);
+					tui.setViewportAnchorComponent(transcript);
+					tui.setBottomPinnedComponent(pinned);
+					try {
+						tui.start();
+						await settle(term);
+						expect(tui.scrollViewportPages(-1), `${testCase.label} clear=${clearOnShrink} page 1`).toBe(true);
+						await term.flush();
+						expect(tui.scrollViewportPages(-1), `${testCase.label} clear=${clearOnShrink} page 2`).toBe(true);
+						await term.flush();
+						if ("resizeHeight" in testCase) {
+							term.resize(30, testCase.resizeHeight);
+							await settle(term);
+						}
+						term.clearWriteLog();
+						transcript.setLine(8, "transcript-8 final");
+						transient.replace([]);
+						synthetic.replace([]);
+						tui.setClearOnShrink(clearOnShrink);
+						tui.requestRender();
+						await settle(term);
+						const viewport = visible(term);
+						expect(viewport.slice(0, 4), `${testCase.label} clear=${clearOnShrink}`).toEqual([
+							"transcript-8 final",
+							"transcript-9",
+							"transcript-10",
+							"transcript-11",
+						]);
+						expect(viewport).toContain("status");
+						expect(viewport).toContain("editor");
+						expect(viewport.indexOf("status")).toBeLessThan(viewport.indexOf("editor"));
+						const writes = term.getWriteLog().join("");
+						expect(writes).not.toContain("\x1b[2J\x1b[H");
+						expect(writes).not.toContain("\x1b[3J");
+						expect(writes).not.toContain("transcript-0");
+					} finally {
+						tui.stop();
+					}
+				}
+			}
+		} finally {
+			for (const key of envKeys) {
+				const value = previous.get(key);
+				if (value === undefined) delete Bun.env[key];
+				else Bun.env[key] = value;
 			}
 		}
 	});

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -16,7 +16,10 @@ export class VirtualTerminal implements Terminal {
 	private _columns: number;
 	private _rows: number;
 
-	constructor(columns = 80, rows = 24) {
+	#isProcessTerminal = false;
+
+	constructor(columns = 80, rows = 24, options: { isProcessTerminal?: boolean } = {}) {
+		this.#isProcessTerminal = options.isProcessTerminal === true;
 		this._columns = columns;
 		this._rows = rows;
 
@@ -84,6 +87,10 @@ export class VirtualTerminal implements Terminal {
 
 	get available(): boolean {
 		return true;
+	}
+
+	get isProcessTerminal(): boolean {
+		return this.#isProcessTerminal;
 	}
 
 	onAppearanceChange(_callback: (appearance: TerminalAppearance) => void): void {


### PR DESCRIPTION
## Summary

- Preserve manually visible transcript content at the same terminal screen rows when completion removes transient/status rows.
- Anchor manual viewport intent to durable semantic transcript identity plus grapheme/cell position and desired screen row.
- Reconcile same-transcript rebuilds to surviving semantic neighbors; reset obsolete intent across logical session identity replacement, including same-path switch/reload.
- Keep follow-live attached to the authoritative latest rendered transcript after unresolved anchor retention.
- Require an explicit `TranscriptRebuildPolicy` at destructive rebuild APIs and classify completion-adjacent compaction, handoff, branch, tree, thinking, switch, reload, and custom-message paths.
- Preserve IRC transcript provider ownership while distinguishing availability, requested visibility, current visibility, and provider replacement.

## Exact-head verification

Head: `05a0e61288671913908999d56eb38ca65c64806f`
Base: `4a80bac9f13316477a5912e1a6a8cf45481987d0`
Frozen diff SHA-256: `0f4db62f400a629f6d809c67d676929fbdff2cce678594f5079890a088d4968b`

- Focused centralization/viewport suite: 52 passed, 0 failed, 839 assertions.
- `packages/coding-agent` check: passed.
- Exact-head CI: 26 success, 1 expected skip, 0 failures, 0 pending.
- Independent cleanup review: CLEAR, zero blockers.
- Independent QA review: PASS, zero blockers.
- Virtual completion/reflow and real Linux OS PTY evidence passed with no clear/home/3J, offscreen transcript-head replay, anchor marker leakage, or no-op bytes.
- Evidence manifest: `/tmp/issue1969-evidence-manifest.json`, SHA-256 `06954963df21b7aa9fc1529dc9a1695cdff702d5a72c10b399aa1ee8b6ee853c`.

## Limitations

- No physical Windows/ConPTY host was available; this is advisory and no physical run is claimed.
- Issue #1979 remains separate and unclaimed.

Fixes #1969

Signed-off-by: Yeachan-Heo <hurrc04@gmail.com>