### PR TITLE
Support configured Telegram forum supergroup topics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Preserved explicit Telegram forum-topic renames as durable user-owned names, immediately re-asserting delayed edits while retaining restart and rename-race recovery (#1910).
+- Allowed explicitly configured Telegram forum supergroups to use outbound per-session topics while keeping inbound control, ask, config, and flat-fallback authority private-only and scoping persisted topic ids to the configured chat.
 
 ## [0.9.6] - 2026-07-10
 ### Changed

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -53,10 +53,11 @@ import {
 	buildActionMessage,
 	type CallbackRoute,
 	createAliasTable,
+	type RouteDecision,
 	readEndpoint,
 	routeInboundUpdate,
 } from "./telegram-reference";
-import { decideThreadedInbound, type InboundAttachment } from "./threaded-inbound";
+import { decideThreadedInbound, type InboundAttachment, type ThreadedInboundDecision } from "./threaded-inbound";
 import { renderThreadedFrame, type ThreadedSend } from "./threaded-render";
 import { TopicRegistry, type TopicRegistryState } from "./topic-registry";
 
@@ -148,6 +149,8 @@ const PENDING_TOPIC_FRAME_LIMIT = 20;
 const SEEN_UPDATE_ID_LIMIT = 1_000;
 const ORPHAN_TOPIC_GRACE_MS = 60_000;
 const CONSUMED_REACTION = "✅";
+// Telegram's fixed service account for anonymous group administrators.
+const TELEGRAM_GROUP_ANONYMOUS_BOT_ID = 1_087_968_824;
 
 function splitTelegramPlainText(text: string, max = TELEGRAM_MESSAGE_LIMIT): string[] {
 	if (text.length <= max) return [text];
@@ -169,6 +172,14 @@ function endpointGenerationKey(url: string, token: string): string {
 
 function topicRenameApplied(response: unknown): boolean {
 	return !!response && typeof response === "object" && (response as { ok?: unknown }).ok === true;
+}
+function topicDeleteApplied(response: unknown): boolean {
+	return (
+		!!response &&
+		typeof response === "object" &&
+		(response as { ok?: unknown }).ok === true &&
+		(response as { result?: unknown }).result === true
+	);
 }
 
 /**
@@ -761,6 +772,11 @@ export class TelegramBotTransport implements BotApi {
 }
 
 type PairedChatPrivacy = "private" | "non-private" | "indeterminate";
+interface PairedChatCapabilities {
+	privacy: "private" | "non-private";
+	isTopicCapable?: boolean;
+}
+type TopicRenameAuthority = "authorized" | "unauthorized";
 
 export type TelegramUpdateOutcome = "consumed" | "retry";
 
@@ -888,6 +904,8 @@ interface SessionSocket {
 	endpointKey: string;
 	ws: WebSocket;
 	pending: Map<string, { sessionId: string; actionId: string }>;
+	/** Tombstone set when this WebSocket generation is dropped. */
+	closed: boolean;
 	/** True once the server advertised the `client_ping_pong` capability. */
 	capable: boolean;
 	/** Timestamp (via opts.now) of the last received pong; seeds the TTL window. */
@@ -938,8 +956,9 @@ export class TelegramNotificationDaemon {
 	private threadedFallbackNoticeSent = false;
 	/** Sessions whose identity header was already sent flat (Threaded Mode off). */
 	private readonly flatIdentitySent = new Set<string>();
-	/** Cached result of whether the paired chat is a private chat (flat-fallback gate). */
-	private pairedChatPrivate: boolean | undefined;
+	/** Independently cached definitive privacy and topic capabilities. */
+	private pairedChatPrivacy: Exclude<PairedChatPrivacy, "indeterminate"> | undefined;
+	private pairedChatTopicCapable: boolean | undefined;
 	/** Bot username from getMe, cached once at owner startup for group/forum command targeting. */
 	private botUsername: string | undefined;
 	/** Sessions whose agent loop is currently busy (drives the typing indicator). */
@@ -1367,8 +1386,8 @@ export class TelegramNotificationDaemon {
 				handle: async session => {
 					this.busy.delete(session.sessionId);
 					this.closedEndpointKeys.set(session.sessionId, session.endpointKey);
-					await this.deleteTopic(session.sessionId);
 					this.dropSession(session, "session_closed");
+					await this.deleteTopic(session.sessionId);
 				},
 			});
 	}
@@ -1460,7 +1479,10 @@ export class TelegramNotificationDaemon {
 						continue;
 					}
 					const endpointKey = endpointGenerationKey(endpoint.url, endpoint.token);
-					if (this.closedEndpointKeys.get(sessionId) === endpointKey) continue;
+					if (this.closedEndpointKeys.get(sessionId) === endpointKey) {
+						await this.deleteOrphanedTopic(sessionId);
+						continue;
+					}
 					this.closedEndpointKeys.delete(sessionId);
 					this.connectSession(sessionId, endpoint.url, endpoint.token);
 				} catch {}
@@ -1485,6 +1507,7 @@ export class TelegramNotificationDaemon {
 			endpointKey,
 			ws,
 			pending: new Map(),
+			closed: false,
 			capable: false,
 			lastPongAt: 0,
 			awaitingNonce: undefined,
@@ -1511,7 +1534,8 @@ export class TelegramNotificationDaemon {
 			// not lazily on the first delivered frame (which only arrives once the
 			// user sends a prompt). A provisional "GJC <id>" name is used; the
 			// identity_header frame renames it to "{repo}/{branch} - {title}" later.
-			void this.ensureTopic(sessionId, this.topicNameFor(sessionId, {})).catch(() => undefined);
+			if (this.sessions.get(sessionId) !== session) return;
+			void this.ensureTopic(session, this.topicNameFor(sessionId, {})).catch(() => undefined);
 		});
 		ws.addEventListener("message", ev => {
 			// Identity guard: a delayed frame from a superseded socket must not act
@@ -1564,6 +1588,7 @@ export class TelegramNotificationDaemon {
 	 * the socket. `scanRoots()` then reconnects the session.
 	 */
 	private dropSession(session: SessionSocket, reason: string): void {
+		session.closed = true;
 		const clearIntervalImpl = this.opts.clearIntervalImpl ?? clearInterval;
 		if (session.pingTimer) {
 			clearIntervalImpl(session.pingTimer);
@@ -1663,8 +1688,8 @@ export class TelegramNotificationDaemon {
 		await this.flushPool();
 	}
 
-	private async existingTopicForPrivateChat(sessionId: string): Promise<string | undefined> {
-		if (!(await this.pairedChatIsPrivate())) return undefined;
+	private async existingTopicForTopicCapableChat(sessionId: string): Promise<string | undefined> {
+		if (!(await this.pairedChatIsTopicCapable())) return undefined;
 		return this.topics.get(sessionId)?.topicId;
 	}
 
@@ -1719,10 +1744,17 @@ export class TelegramNotificationDaemon {
 	 * `undefined`; callers then flat-deliver to a private paired chat (with a
 	 * one-time nudge) or drop fail-closed for a non-private chat.
 	 */
-	private async ensureTopic(sessionId: string, name: string): Promise<string | undefined> {
-		if (!(await this.pairedChatIsPrivate())) return undefined;
+	private async ensureTopic(session: SessionSocket, name: string): Promise<string | undefined> {
+		const sessionClosed = () => session.closed === true;
+		if (sessionClosed()) return undefined;
+		let capability = await this.resolvePairedChatTopicCapability();
+		// Session action frames are one-shot. Retry one indeterminate capability
+		// response inline so a transient getChat failure cannot silently drop them.
+		if (capability === undefined) capability = await this.resolvePairedChatTopicCapability();
+		if (capability !== true || sessionClosed()) return undefined;
+		const sessionId = session.sessionId;
 		const existing = this.topics.get(sessionId);
-		if (existing) return existing.topicId;
+		if (existing) return sessionClosed() ? undefined : existing.topicId;
 		try {
 			const rec = await this.topics.getOrCreateTopic(
 				sessionId,
@@ -1741,9 +1773,19 @@ export class TelegramNotificationDaemon {
 				// later identity rename would be wrongly skipped (topic stuck at the
 				// provisional name on Telegram).
 				name,
+				async topicId => {
+					try {
+						await this.botApi.call("deleteForumTopic", {
+							chat_id: this.opts.chatId,
+							message_thread_id: Number(topicId),
+						});
+					} catch {
+						// A cancelled create is never published locally; remote cleanup is best-effort.
+					}
+				},
 			);
 			await this.persistTopics();
-			return rec.topicId;
+			return sessionClosed() ? undefined : rec.topicId;
 		} catch {
 			return undefined;
 		}
@@ -1761,29 +1803,50 @@ export class TelegramNotificationDaemon {
 
 	/** Best-effort delete of a session topic once its local notification endpoint shuts down. */
 	private async deleteTopic(sessionId: string): Promise<void> {
+		// Invalidate unresolved creates and synchronously detach only the record owned
+		// by this teardown generation. A replacement may publish under the same
+		// session id while cleanup awaits; no later step may look up/delete that record.
+		this.topics.cancelPendingCreate(sessionId);
 		const record = this.topics.get(sessionId);
-		if (!record) return;
-		try {
-			// Drop queued sends for this session before deleting the topic; otherwise
-			// rate-limited frames can flush later into a deleted topic or across resume.
-			this.pool.removeWhere(item => item.sessionId === sessionId);
-			await this.flushPool();
-			const res = (await this.botApi.call("deleteForumTopic", {
-				chat_id: this.opts.chatId,
-				message_thread_id: Number(record.topicId),
-			})) as { ok?: boolean };
-			if (res?.ok === false) return;
-			this.topics.delete(sessionId);
-			for (const k of [...this.liveMessages.keys()]) {
-				if (k.startsWith(`${sessionId}:`)) this.liveMessages.delete(k);
+		if (record) this.topics.delete(sessionId);
+
+		// Session-keyed local state must also be detached before the first await so a
+		// replacement generation can populate fresh state without stale cleanup
+		// deleting it later.
+		this.pool.removeWhere(item => item.sessionId === sessionId);
+		for (const k of [...this.liveMessages.keys()]) {
+			if (k.startsWith(`${sessionId}:`)) this.liveMessages.delete(k);
+		}
+		this.topicOwnerByIdentity.forEach((ownerSessionId, identityKey) => {
+			if (ownerSessionId === sessionId) this.topicOwnerByIdentity.delete(identityKey);
+		});
+		this.pendingThreadedFrames.delete(sessionId);
+
+		await this.flushPool();
+
+		let deleted = false;
+		if (record) {
+			try {
+				// The captured record is already scoped to this configured chatId, so
+				// teardown can attempt deletion without another fallible getChat probe.
+				const response = await this.botApi.call("deleteForumTopic", {
+					chat_id: this.opts.chatId,
+					message_thread_id: Number(record.topicId),
+				});
+				deleted = topicDeleteApplied(response);
+			} catch {
+				// Remote deletion is best-effort; retain retry state below.
 			}
-			this.topicOwnerByIdentity.forEach((ownerSessionId, identityKey) => {
-				if (ownerSessionId === sessionId) this.topicOwnerByIdentity.delete(identityKey);
-			});
-			this.pendingThreadedFrames.delete(sessionId);
+		}
+
+		if (!record) return;
+		if (!deleted) this.topics.restoreIfAbsent(sessionId, record);
+		try {
+			// Serialize the registry as it exists now. A replacement published while
+			// cleanup awaited wins over failed-delete retry state for the stale record.
 			await this.persistTopics();
 		} catch {
-			// Best-effort: missing Telegram topic permissions must not stop teardown.
+			// Best-effort: in-memory state still retains any required deletion retry.
 		}
 	}
 
@@ -1791,7 +1854,11 @@ export class TelegramNotificationDaemon {
 		const pending = this.topicsPersistQueue.then(async () => {
 			const paths = daemonPaths(this.opts.settings.getAgentDir());
 			await ensureDir(this.fsImpl, paths.dir);
-			await writeJsonAtomic(this.fsImpl, path.join(paths.dir, "telegram-topics.json"), this.topics.serialize());
+			await writeJsonAtomic(
+				this.fsImpl,
+				path.join(paths.dir, "telegram-topics.json"),
+				this.topics.serialize(String(this.opts.chatId)),
+			);
 		});
 		this.topicsPersistQueue = pending.catch(() => undefined);
 		return pending;
@@ -1800,9 +1867,9 @@ export class TelegramNotificationDaemon {
 	async loadTopics(): Promise<void> {
 		const paths = daemonPaths(this.opts.settings.getAgentDir());
 		const raw = await readJson<TopicRegistryState>(this.fsImpl, path.join(paths.dir, "telegram-topics.json"));
-		// Restore the full serialized registry (topicId + identitySent + name) so a
-		// fresh daemon after reload does not resend identity headers or lose renames.
-		if (raw && typeof raw === "object") this.topics.load(raw);
+		// Topic ids are local to one Telegram chat. Legacy state has no ownership
+		// proof, so migrating it after a chatId rotation could leak into another chat.
+		if (raw && typeof raw === "object" && raw.chatId === String(this.opts.chatId)) this.topics.load(raw);
 	}
 
 	/** Download a Telegram file by its file_path (from getFile) into memory. */
@@ -1949,7 +2016,7 @@ export class TelegramNotificationDaemon {
 		}
 		for (const item of batch) {
 			const { send, topicId } = item.payload;
-			if (topicId && !(await this.pairedChatIsPrivate())) continue;
+			if (topicId && !(await this.pairedChatIsTopicCapable())) continue;
 			// Threaded topic when available; otherwise deliver flat to the paired chat.
 			const threadField = topicId ? { message_thread_id: Number(topicId) } : {};
 			const ckey = send.editable ? item.coalesceKey : undefined;
@@ -2182,41 +2249,66 @@ export class TelegramNotificationDaemon {
 	}
 
 	/**
-	 * Resolve (and cache definitive resolution of) whether the paired `chatId` is
-	 * a private chat. Topic and flat delivery are only safe in a private DM; an
-	 * indeterminate `getChat` result fails closed for this attempt and is retried
-	 * later.
+	 * Refresh definitive capabilities for the paired `chatId`. Privacy can be
+	 * known for a supergroup while malformed `is_forum` metadata remains
+	 * indeterminate and retryable.
 	 */
-	private async resolvePairedChatPrivacy(): Promise<PairedChatPrivacy> {
-		if (this.pairedChatPrivate !== undefined) return this.pairedChatPrivate ? "private" : "non-private";
+	private async refreshPairedChatCapabilities(): Promise<PairedChatCapabilities | undefined> {
 		try {
 			const res = (await this.botApi.call("getChat", { chat_id: this.opts.chatId })) as {
 				ok?: unknown;
-				result?: { type?: unknown };
+				result?: { type?: unknown; is_forum?: unknown };
 			};
 			if (res?.ok !== true) {
-				logger.warn("notifications: getChat privacy check indeterminate (non-success response)");
-				return "indeterminate";
+				logger.warn("notifications: getChat capability check indeterminate (non-success response)");
+				return undefined;
 			}
 			if (res.result?.type === "private") {
-				this.pairedChatPrivate = true;
-				return "private";
+				this.pairedChatPrivacy = "private";
+				this.pairedChatTopicCapable = true;
+				return { privacy: "private", isTopicCapable: true };
 			}
-			if (res.result?.type === "group" || res.result?.type === "supergroup" || res.result?.type === "channel") {
-				this.pairedChatPrivate = false;
-				return "non-private";
+			if (res.result?.type === "supergroup") {
+				this.pairedChatPrivacy = "non-private";
+				if (typeof res.result.is_forum !== "boolean") {
+					logger.warn("notifications: getChat capability check indeterminate (missing or invalid is_forum)");
+					return { privacy: "non-private" };
+				}
+				this.pairedChatTopicCapable = res.result.is_forum;
+				return { privacy: "non-private", isTopicCapable: res.result.is_forum };
 			}
-			logger.warn("notifications: getChat privacy check indeterminate (missing or invalid chat type)");
-			return "indeterminate";
+			if (res.result?.type === "group" || res.result?.type === "channel") {
+				this.pairedChatPrivacy = "non-private";
+				this.pairedChatTopicCapable = false;
+				return { privacy: "non-private", isTopicCapable: false };
+			}
+			logger.warn("notifications: getChat capability check indeterminate (missing or invalid chat type)");
+			return undefined;
 		} catch {
-			logger.warn("notifications: getChat privacy check indeterminate (request failed)");
-			return "indeterminate";
+			logger.warn("notifications: getChat capability check indeterminate (request failed)");
+			return undefined;
 		}
 	}
 
-	/** Keep existing outbound callers fail-closed for indeterminate privacy. */
+	private async resolvePairedChatPrivacy(): Promise<PairedChatPrivacy> {
+		if (this.pairedChatPrivacy !== undefined) return this.pairedChatPrivacy;
+		return (await this.refreshPairedChatCapabilities())?.privacy ?? "indeterminate";
+	}
+
+	/** Private-chat-only gate for flat delivery and global configuration commands. */
 	private async pairedChatIsPrivate(): Promise<boolean> {
 		return (await this.resolvePairedChatPrivacy()) === "private";
+	}
+
+	/** Resolve topic capability without collapsing an indeterminate lookup to false. */
+	private async resolvePairedChatTopicCapability(): Promise<boolean | undefined> {
+		if (this.pairedChatTopicCapable !== undefined) return this.pairedChatTopicCapable;
+		return (await this.refreshPairedChatCapabilities())?.isTopicCapable;
+	}
+
+	/** Topic-only gate for private chats and explicitly configured forum supergroups. */
+	private async pairedChatIsTopicCapable(): Promise<boolean> {
+		return (await this.resolvePairedChatTopicCapability()) === true;
 	}
 
 	/** Tell the user once (per daemon run) how to enable Threaded Mode. */
@@ -2266,7 +2358,7 @@ export class TelegramNotificationDaemon {
 	/** Send a single `typing` chat action into a busy session's topic (best-effort). */
 	private async sendTyping(sessionId: string): Promise<void> {
 		const topicId = this.topics.get(sessionId)?.topicId;
-		if (!topicId || !(await this.pairedChatIsPrivate())) return;
+		if (!topicId || !(await this.pairedChatIsTopicCapable())) return;
 		try {
 			await this.botApi.call("sendChatAction", {
 				chat_id: this.opts.chatId,
@@ -2280,7 +2372,7 @@ export class TelegramNotificationDaemon {
 
 	/** Set a native reaction on an inbound thread message (best-effort). */
 	private async setReaction(messageId: number, emoji: string): Promise<void> {
-		if (!(await this.pairedChatIsPrivate())) return;
+		if (!(await this.pairedChatIsTopicCapable())) return;
 		try {
 			await this.botApi.call("setMessageReaction", {
 				chat_id: this.opts.chatId,
@@ -2302,13 +2394,18 @@ export class TelegramNotificationDaemon {
 	private stopTypingTimer(): void {
 		this.runtime.stopInterval("telegram-typing");
 	}
+	private sessionIsClosed(session: SessionSocket): boolean {
+		return session.closed === true;
+	}
 
 	async handleSessionMessage(session: SessionSocket, msg: any): Promise<void> {
+		if (this.sessionIsClosed(session)) return;
 		if (await this.sessionRouter.dispatch(session, msg as Record<string, unknown>)) return;
 		if (typeof msg?.type === "string" && TelegramNotificationDaemon.THREADED_FRAMES.has(msg.type)) {
 			const send = renderThreadedFrame(msg);
 			if (!send) return;
-			const existingTopic = await this.existingTopicForPrivateChat(session.sessionId);
+			const existingTopic = await this.existingTopicForTopicCapableChat(session.sessionId);
+			if (this.sessionIsClosed(session)) return;
 			if (!send.identity && !existingTopic && !this.flatIdentitySent.has(session.sessionId)) {
 				this.rememberPendingThreadedFrame(session.sessionId, send, msg as Record<string, unknown>);
 				return;
@@ -2321,8 +2418,8 @@ export class TelegramNotificationDaemon {
 					return;
 				}
 			}
-			const topicId =
-				existingTopic ?? (await this.ensureTopic(session.sessionId, this.topicNameFor(session.sessionId, msg)));
+			const topicId = existingTopic ?? (await this.ensureTopic(session, this.topicNameFor(session.sessionId, msg)));
+			if (this.sessionIsClosed(session)) return;
 			if (!topicId) {
 				await this.deliverFlatFallback(session.sessionId, send);
 				return;
@@ -2376,7 +2473,11 @@ export class TelegramNotificationDaemon {
 		}
 		if (msg.type === "action_needed" && msg.id) {
 			if (msg.kind === "ask") session.pending.set(msg.id, { sessionId: session.sessionId, actionId: msg.id });
-			const topicId = await this.ensureTopic(session.sessionId, this.topicNameFor(session.sessionId, msg));
+			const topicId = await this.ensureTopic(session, this.topicNameFor(session.sessionId, msg));
+			if (this.sessionIsClosed(session)) {
+				session.pending.delete(msg.id);
+				return;
+			}
 			if (!topicId) {
 				// Fail closed for non-private chats; only nudge + flat-deliver in a private DM.
 				if (!(await this.pairedChatIsPrivate())) return;
@@ -2478,6 +2579,61 @@ export class TelegramNotificationDaemon {
 		});
 	}
 
+	private async resolveForumTopicRenameAuthority(message: {
+		chat?: { id?: unknown };
+		from?: { id?: unknown; is_bot?: unknown };
+		sender_chat?: { id?: unknown; type?: unknown };
+	}): Promise<TopicRenameAuthority> {
+		const configuredChatId = Number(this.opts.chatId);
+		if (message.sender_chat !== undefined) {
+			return Number.isSafeInteger(configuredChatId) &&
+				typeof message.sender_chat?.id === "number" &&
+				Number.isSafeInteger(message.sender_chat.id) &&
+				message.sender_chat.id === configuredChatId &&
+				message.sender_chat.type === "supergroup" &&
+				message.from?.id === TELEGRAM_GROUP_ANONYMOUS_BOT_ID &&
+				message.from.is_bot === true
+				? "authorized"
+				: "unauthorized";
+		}
+		if (
+			typeof message.from?.id !== "number" ||
+			!Number.isSafeInteger(message.from.id) ||
+			message.from.is_bot !== false
+		)
+			return "unauthorized";
+		try {
+			const response = (await this.botApi.call("getChatMember", {
+				chat_id: this.opts.chatId,
+				user_id: message.from.id,
+			})) as {
+				ok?: unknown;
+				result?: {
+					status?: unknown;
+					user?: { id?: unknown; is_bot?: unknown; first_name?: unknown };
+					is_anonymous?: unknown;
+					can_manage_topics?: unknown;
+				};
+			};
+			const member = response?.result;
+			if (
+				response?.ok !== true ||
+				typeof member?.user?.id !== "number" ||
+				!Number.isSafeInteger(member.user.id) ||
+				member.user.id !== message.from.id ||
+				member.user.is_bot !== false ||
+				typeof member.user.first_name !== "string" ||
+				member.user.first_name.trim().length === 0 ||
+				member.is_anonymous !== false
+			)
+				return "unauthorized";
+			if (member.status === "creator") return "authorized";
+			return member.status === "administrator" && member.can_manage_topics === true ? "authorized" : "unauthorized";
+		} catch {
+			return "unauthorized";
+		}
+	}
+
 	/** Consume Telegram forum-topic rename service messages before text routing. */
 	private async handleForumTopicEdited(update: unknown): Promise<"not-topic" | TelegramUpdateOutcome> {
 		const parsed = update as {
@@ -2485,6 +2641,7 @@ export class TelegramNotificationDaemon {
 			message?: {
 				chat?: { id?: unknown };
 				from?: { id?: unknown; is_bot?: unknown };
+				sender_chat?: { id?: unknown; type?: unknown };
 				message_thread_id?: unknown;
 				forum_topic_edited?: { name?: unknown };
 			};
@@ -2494,24 +2651,31 @@ export class TelegramNotificationDaemon {
 		const updateId = parsed.update_id;
 		if (typeof updateId !== "number" || !Number.isSafeInteger(updateId) || updateId < 0) return "consumed";
 		if (this.dispatchState.seenUpdateIds.has(updateId)) return "consumed";
-		const configuredUserId = Number(this.opts.chatId);
+		const configuredChatId = Number(this.opts.chatId);
 		if (
-			!Number.isSafeInteger(configuredUserId) ||
+			!Number.isSafeInteger(configuredChatId) ||
 			typeof message.chat?.id !== "number" ||
-			message.chat.id !== configuredUserId ||
-			message.from?.id !== configuredUserId ||
-			message.from?.is_bot !== false
+			message.chat.id !== configuredChatId
 		)
 			return "consumed";
-		const privacy = await this.resolvePairedChatPrivacy();
-		if (privacy === "indeterminate") return "retry";
-		if (privacy !== "private") return "consumed";
 		const threadId = message.message_thread_id;
 		if (typeof threadId !== "number" || !Number.isSafeInteger(threadId)) return "consumed";
 		const sessionId = this.topics.sessionForTopic(String(threadId));
 		if (!sessionId) return "consumed";
 		const name = message.forum_topic_edited.name;
 		if (typeof name !== "string" || name.trim().length === 0) return "consumed";
+
+		const privacy = await this.resolvePairedChatPrivacy();
+		if (privacy === "indeterminate") return "retry";
+		if (privacy === "private") {
+			if (message.from?.id !== configuredChatId || message.from.is_bot !== false) return "consumed";
+		} else {
+			const topicCapability = await this.resolvePairedChatTopicCapability();
+			if (topicCapability === undefined) return "retry";
+			if (!topicCapability) return "consumed";
+			const authority = await this.resolveForumTopicRenameAuthority(message);
+			if (authority === "unauthorized") return "consumed";
+		}
 		const result = this.topics.markUserName(sessionId, name, updateId);
 		if (result === "stale") {
 			await this.rememberSeenUpdateId(updateId);
@@ -2541,15 +2705,16 @@ export class TelegramNotificationDaemon {
 		const topicOutcome = await this.handleForumTopicEdited(update);
 		if (topicOutcome !== "not-topic") return topicOutcome;
 		try {
-			await this.handleTelegramUpdate(update);
+			return (await this.handleTelegramUpdate(update)) ?? "consumed";
 		} catch (err) {
 			logger.error("notifications daemon: handleTelegramUpdate failed", { error: String(err) });
+			return "consumed";
 		}
-		return "consumed";
 	}
 
-	async handleTelegramUpdate(update: unknown): Promise<void> {
-		if ((await this.handleForumTopicEdited(update)) !== "not-topic") return;
+	async handleTelegramUpdate(update: unknown): Promise<TelegramUpdateOutcome | undefined> {
+		const topicOutcome = await this.handleForumTopicEdited(update);
+		if (topicOutcome !== "not-topic") return topicOutcome;
 		// Session-lifecycle command (/session_*): handled ONLY from the paired chat,
 		// gated before any arg parsing or side effect, and routed through the control
 		// endpoint. Must run before threaded-injection so commands are not treated as
@@ -2564,9 +2729,12 @@ export class TelegramNotificationDaemon {
 			if (m !== undefined && String(chatId) === String(this.opts.chatId)) {
 				if (chatType !== undefined && chatType !== "private" && isLifecycleCommandLikeText(cmdText)) return;
 				if (isLifecycleCommandText(cmdText, commandCtx)) {
+					const privacy = await this.resolvePairedChatPrivacy();
+					if (privacy === "indeterminate") return "retry";
+					if (privacy === "non-private") return "consumed";
 					const updateId = (update as { update_id?: number }).update_id;
 					const threadId = typeof m.message_thread_id === "number" ? (m.message_thread_id as number) : undefined;
-					if (await this.handleLifecycleCommand(cmdText, updateId, threadId, commandCtx)) return;
+					if (await this.handleLifecycleCommand(cmdText, updateId, threadId, commandCtx)) return "consumed";
 				}
 			}
 		}
@@ -2589,7 +2757,9 @@ export class TelegramNotificationDaemon {
 				// paired chat — the same contract as session delivery and lifecycle
 				// commands. A group/supergroup chatId (legacy or hand-edited) must never
 				// let an arbitrary chat member toggle the owner's notification config.
-				if (!(await this.pairedChatIsPrivate())) return;
+				const privacy = await this.resolvePairedChatPrivacy();
+				if (privacy === "indeterminate") return "retry";
+				if (privacy === "non-private") return "consumed";
 				const updateId = (update as { update_id?: number }).update_id;
 				// Dedupe redelivered updates so a toggle+confirmation runs at most once.
 				if (typeof updateId === "number") {
@@ -2638,147 +2808,185 @@ export class TelegramNotificationDaemon {
 				return;
 			}
 		}
-		// Threaded injection: a free-text message in a known topic (not a button
-		// tap and not a reply to a specific ask message) injects a user turn or an
-		// in-thread config command. Fail-closed: paired chat + known topic +
-		// update_id dedupe are all enforced by decideThreadedInbound.
+		// A configured forum supergroup is outbound topic transport only. Check
+		// the update's chat before any capability lookup so unpaired traffic stays
+		// side-effect free.
+		const authorityUpdate = update as {
+			message?: { chat?: { id?: unknown } };
+			callback_query?: { id?: unknown; message?: { chat?: { id?: unknown } } };
+		};
+		const authorityChatId = authorityUpdate.message?.chat?.id ?? authorityUpdate.callback_query?.message?.chat?.id;
+		if (String(authorityChatId) !== String(this.opts.chatId)) return "consumed";
+
+		// Decide whether this update can affect a session before retrying getChat.
+		// Unrelated paired-chat messages must not pin the poller offset while the
+		// capability endpoint is unavailable.
 		const raw = update as {
 			callback_query?: unknown;
 			message?: { reply_to_message?: { message_id?: unknown } };
 		};
-		// A reply to a known ask message routes to that ask (below). Any OTHER
-		// message in a topic (plain text, or a reply to a non-ask message) is a
-		// free-text injection. Previously replies bypassed injection entirely.
 		const replyTo = raw.message?.reply_to_message?.message_id;
 		const isAskReply =
 			replyTo !== undefined && (this.messageRoutes.has(String(replyTo)) || this.messageRoutes.has(Number(replyTo)));
+		const routeActionUpdate = (): RouteDecision =>
+			routeInboundUpdate(update, {
+				aliasTable: this.aliasTable,
+				messageRoutes: this.messageRoutes,
+				pairedChatId: this.opts.chatId,
+			});
+		let threadedInbound: ThreadedInboundDecision | undefined;
+		let routedInbound: RouteDecision | undefined;
 		if (!raw.callback_query && !isAskReply) {
-			const inbound = decideThreadedInbound(update as never, {
+			threadedInbound = decideThreadedInbound(update as never, {
 				pairedChatId: this.opts.chatId,
 				topicToSession: t => this.topics.sessionForTopic(t),
 				isDuplicate: id => this.dispatchState.seenUpdateIds.has(id),
 			});
-			if (inbound.kind === "duplicate") return;
-			if (inbound.kind === "inject") {
-				const session = this.sessions.get(inbound.sessionId);
-				if (session?.ws.readyState === WebSocket.OPEN) {
-					const attachmentResult = inbound.attachment
-						? await this.resolveInboundAttachment(inbound.attachment, inbound.sessionId)
+			if (threadedInbound.kind === "duplicate") return "consumed";
+			if (threadedInbound.kind === "ignore") {
+				routedInbound = routeActionUpdate();
+				if (routedInbound.kind === "ignore") return "consumed";
+			}
+		} else {
+			routedInbound = routeActionUpdate();
+			if (routedInbound.kind === "ignore") return "consumed";
+		}
+
+		const privacy = await this.resolvePairedChatPrivacy();
+		if (privacy === "indeterminate") {
+			if (routedInbound?.kind !== "stale") return "retry";
+			await this.answerCallbackQueryBestEffort(authorityUpdate.callback_query?.id, "Button is stale");
+			return "consumed";
+		}
+		if (privacy === "non-private") {
+			// Dismiss callback spinners without routing an answer or leaking stale
+			// guidance into the shared chat.
+			if (authorityUpdate.callback_query?.id !== undefined) {
+				await this.answerCallbackQueryBestEffort(authorityUpdate.callback_query.id, "Button is stale");
+			}
+			return "consumed";
+		}
+
+		// Threaded injection: a free-text message in a known topic (not a button
+		// tap and not a reply to a specific ask message) injects a user turn or an
+		// in-thread config command. Fail-closed: paired chat + known topic +
+		// update_id dedupe are all enforced by decideThreadedInbound.
+		if (threadedInbound?.kind === "inject") {
+			const inbound = threadedInbound;
+			const session = this.sessions.get(inbound.sessionId);
+			if (session?.ws.readyState === WebSocket.OPEN) {
+				const attachmentResult = inbound.attachment
+					? await this.resolveInboundAttachment(inbound.attachment, inbound.sessionId)
+					: undefined;
+				const images = attachmentResult?.images ?? [];
+				const fileNotes = attachmentResult?.fileNotes ?? [];
+				const hasMedia = images.length > 0 || fileNotes.length > 0;
+				const baseInjectedText = [inbound.text, ...fileNotes].filter(Boolean).join("\n");
+				// A reply to a rich message we sent (not an ask route) loses its original
+				// text: Telegram does not echo it in reply_to_message. Restore it from the
+				// reply index as a labeled context prefix; a miss leaves the turn unchanged.
+				const repliedOriginal =
+					typeof replyTo === "number"
+						? this.replyStore.lookup({ chatId: this.opts.chatId, messageId: replyTo })
 						: undefined;
-					const images = attachmentResult?.images ?? [];
-					const fileNotes = attachmentResult?.fileNotes ?? [];
-					const hasMedia = images.length > 0 || fileNotes.length > 0;
-					const baseInjectedText = [inbound.text, ...fileNotes].filter(Boolean).join("\n");
-					// A reply to a rich message we sent (not an ask route) loses its original
-					// text: Telegram does not echo it in reply_to_message. Restore it from the
-					// reply index as a labeled context prefix; a miss leaves the turn unchanged.
-					const repliedOriginal =
-						typeof replyTo === "number"
-							? this.replyStore.lookup({ chatId: this.opts.chatId, messageId: replyTo })
-							: undefined;
-					const injectedText = repliedOriginal
-						? `> replied-to message:\n${repliedOriginal}\n\n${baseInjectedText}`
-						: baseInjectedText;
-					const control = hasMedia
-						? { kind: "none" as const }
-						: parseTelegramControlCommand(inbound.text, this.botUsername);
-					if (control.kind !== "none") {
-						await this.rememberSeenUpdateId(inbound.updateId);
-						const sendControlNotice = async (body: string): Promise<void> => {
-							try {
-								await this.botApi.call("sendMessage", {
-									chat_id: this.opts.chatId,
-									message_thread_id: Number(inbound.threadId),
-									text: body,
-									parse_mode: TELEGRAM_PARSE_MODE,
-								});
-							} catch {
-								// Best-effort control feedback; never convert to user input.
-							}
-						};
-						if (control.kind === "ignored") return;
-						if (control.kind === "invalid") {
-							await sendControlNotice(control.usage);
-							return;
-						}
-						if (session?.ws.readyState !== WebSocket.OPEN) {
-							await sendControlNotice("Session control unavailable: session is disconnected.");
-							return;
-						}
-						session.ws.send(
-							JSON.stringify({
-								type: "control_command",
-								sessionId: inbound.sessionId,
-								token: session.token,
-								requestId: `tg:${inbound.updateId}`,
-								updateId: inbound.updateId,
-								threadId: inbound.threadId,
-								command: control.command,
-							}),
-						);
-						return;
-					}
-					const cfg = hasMedia ? undefined : parseInThreadConfigCommand(inbound.text);
-					// A plain (non-config) message while an ask is pending for this session
-					// answers that ask as free-input — instead of starting a new user turn.
-					// Telegram asks always accept custom text (the SDK maps a string answer
-					// to the ask's custom-input slot), so route the latest pending ask here.
-					const pendingAsk = cfg || hasMedia ? undefined : [...session.pending.values()].at(-1);
-					if (pendingAsk) {
-						session.ws.send(
-							JSON.stringify({
-								type: "reply",
-								id: pendingAsk.actionId,
-								answer: inbound.text,
-								token: session.token,
-							}),
-						);
-						await this.rememberSeenUpdateId(inbound.updateId);
-						await this.botApi
-							.call("sendMessage", {
+				const injectedText = repliedOriginal
+					? `> replied-to message:\n${repliedOriginal}\n\n${baseInjectedText}`
+					: baseInjectedText;
+				const control = hasMedia
+					? { kind: "none" as const }
+					: parseTelegramControlCommand(inbound.text, this.botUsername);
+				if (control.kind !== "none") {
+					await this.rememberSeenUpdateId(inbound.updateId);
+					const sendControlNotice = async (body: string): Promise<void> => {
+						try {
+							await this.botApi.call("sendMessage", {
 								chat_id: this.opts.chatId,
 								message_thread_id: Number(inbound.threadId),
-								text: "Received as an answer to the pending ask.",
-							})
-							.catch(error => {
-								logger.warn(`telegram: failed to acknowledge pending ask reply: ${String(error)}`);
+								text: body,
+								parse_mode: TELEGRAM_PARSE_MODE,
 							});
-						if (inbound.messageId !== undefined) await this.setReaction(inbound.messageId, QUEUED_REACTION);
+						} catch {
+							// Best-effort control feedback; never convert to user input.
+						}
+					};
+					if (control.kind === "ignored") return;
+					if (control.kind === "invalid") {
+						await sendControlNotice(control.usage);
+						return;
+					}
+					if (session?.ws.readyState !== WebSocket.OPEN) {
+						await sendControlNotice("Session control unavailable: session is disconnected.");
 						return;
 					}
 					session.ws.send(
-						JSON.stringify(
-							cfg
-								? { type: "config_command", sessionId: inbound.sessionId, token: session.token, ...cfg }
-								: {
-										type: "user_message",
-										sessionId: inbound.sessionId,
-										text: injectedText,
-										token: session.token,
-										updateId: inbound.updateId,
-										threadId: inbound.threadId,
-										images,
-									},
-						),
+						JSON.stringify({
+							type: "control_command",
+							sessionId: inbound.sessionId,
+							token: session.token,
+							requestId: `tg:${inbound.updateId}`,
+							updateId: inbound.updateId,
+							threadId: inbound.threadId,
+							command: control.command,
+						}),
+					);
+					return;
+				}
+				const cfg = hasMedia ? undefined : parseInThreadConfigCommand(inbound.text);
+				// A plain (non-config) message while an ask is pending for this session
+				// answers that ask as free-input — instead of starting a new user turn.
+				// Telegram asks always accept custom text (the SDK maps a string answer
+				// to the ask's custom-input slot), so route the latest pending ask here.
+				const pendingAsk = cfg || hasMedia ? undefined : [...session.pending.values()].at(-1);
+				if (pendingAsk) {
+					session.ws.send(
+						JSON.stringify({
+							type: "reply",
+							id: pendingAsk.actionId,
+							answer: inbound.text,
+							token: session.token,
+						}),
 					);
 					await this.rememberSeenUpdateId(inbound.updateId);
-					// User turns get a native delivery double-check: queued on receipt,
-					// flipped to consumed when the session acks the turn that picks it
-					// up. Config commands are not user turns and get no reaction.
-					if (!cfg && inbound.messageId !== undefined) {
-						this.inboundReactions.set(inbound.updateId, { messageId: inbound.messageId });
-						await this.setReaction(inbound.messageId, QUEUED_REACTION);
-					}
+					await this.botApi
+						.call("sendMessage", {
+							chat_id: this.opts.chatId,
+							message_thread_id: Number(inbound.threadId),
+							text: "Received as an answer to the pending ask.",
+						})
+						.catch(error => {
+							logger.warn(`telegram: failed to acknowledge pending ask reply: ${String(error)}`);
+						});
+					if (inbound.messageId !== undefined) await this.setReaction(inbound.messageId, QUEUED_REACTION);
+					return;
 				}
-				return;
+				session.ws.send(
+					JSON.stringify(
+						cfg
+							? { type: "config_command", sessionId: inbound.sessionId, token: session.token, ...cfg }
+							: {
+									type: "user_message",
+									sessionId: inbound.sessionId,
+									text: injectedText,
+									token: session.token,
+									updateId: inbound.updateId,
+									threadId: inbound.threadId,
+									images,
+								},
+					),
+				);
+				await this.rememberSeenUpdateId(inbound.updateId);
+				// User turns get a native delivery double-check: queued on receipt,
+				// flipped to consumed when the session acks the turn that picks it
+				// up. Config commands are not user turns and get no reaction.
+				if (!cfg && inbound.messageId !== undefined) {
+					this.inboundReactions.set(inbound.updateId, { messageId: inbound.messageId });
+					await this.setReaction(inbound.messageId, QUEUED_REACTION);
+				}
 			}
+			return;
 		}
 		const callbackId = (update as { callback_query?: { id?: unknown } }).callback_query?.id;
-		const decision = routeInboundUpdate(update, {
-			aliasTable: this.aliasTable,
-			messageRoutes: this.messageRoutes,
-			pairedChatId: this.opts.chatId,
-		});
+		const decision = routedInbound ?? routeActionUpdate();
 		if (decision.kind === "reply") {
 			const session = this.sessions.get(decision.sessionId);
 			if (session?.ws.readyState !== WebSocket.OPEN || !session.pending.has(decision.actionId)) {

--- a/packages/coding-agent/src/notifications/topic-registry.ts
+++ b/packages/coding-agent/src/notifications/topic-registry.ts
@@ -1,10 +1,11 @@
 /**
  * Per-session forum-topic registry for the threaded session surface.
  *
- * Each GJC session owns one active Telegram forum topic in the paired private
- * DM. The topic is created via `createForumTopic`, reused while the session
- * remains active, and removed from the registry when the daemon deletes it on
- * shutdown. The registry also tracks whether the one-time identity header has
+ * Each GJC session owns one active Telegram forum topic in the configured
+ * topic-capable chat. The topic is created via `createForumTopic`, reused while
+ * the session remains active, and removed from the registry when the daemon
+ * deletes it on shutdown.
+ * The registry also tracks whether the one-time identity header has
  * already been pinned, so it is sent exactly once per active topic, even across
  * reconnects.
  *
@@ -37,6 +38,8 @@ export interface TopicRecord {
 export interface TopicRegistryState {
 	/** sessionId -> record. */
 	topics: Record<string, TopicRecord>;
+	/** Telegram destination that owns every topic id in this state. */
+	chatId?: string;
 }
 
 export function emptyTopicRegistryState(): TopicRegistryState {
@@ -52,8 +55,11 @@ export class TopicRegistry {
 	private readonly topics: Map<string, TopicRecord>;
 	/** Maps topicId -> sessionId for fast inbound routing. */
 	private readonly byTopic = new Map<string, string>();
-	/** In-flight create promises, keyed by session, to dedupe concurrent creates. */
-	private readonly inflight = new Map<string, Promise<TopicRecord>>();
+	/** In-flight create promises, keyed by session, to dedupe or cancel concurrent creates. */
+	private readonly inflight = new Map<
+		string,
+		{ cancellation: { cancelled: boolean }; promise: Promise<TopicRecord> }
+	>();
 
 	constructor(state: TopicRegistryState = emptyTopicRegistryState()) {
 		this.topics = new Map();
@@ -110,6 +116,7 @@ export class TopicRegistry {
 		create: () => Promise<string>,
 		now: () => number = Date.now,
 		name?: string,
+		discard?: (topicId: string) => Promise<void>,
 	): Promise<TopicRecord> {
 		const existing = this.topics.get(sessionId);
 		if (existing) return existing;
@@ -118,20 +125,39 @@ export class TopicRegistry {
 		// `existing` check before `create()` resolves and creates a DUPLICATE
 		// forum topic. Share a single in-flight create per session id.
 		const pending = this.inflight.get(sessionId);
-		if (pending) return pending;
+		if (pending) return pending.promise;
+		const cancellation = { cancelled: false };
 		const promise = (async () => {
 			const topicId = await create();
+			if (cancellation.cancelled) {
+				try {
+					await discard?.(topicId);
+				} catch {}
+				throw new Error("topic creation cancelled");
+			}
 			const record: TopicRecord = { topicId, name, identitySent: false, createdAt: now() };
 			this.topics.set(sessionId, record);
 			this.byTopic.set(topicId, sessionId);
 			return record;
 		})();
-		this.inflight.set(sessionId, promise);
+		this.inflight.set(sessionId, { cancellation, promise });
 		try {
 			return await promise;
 		} finally {
-			this.inflight.delete(sessionId);
+			if (this.inflight.get(sessionId)?.promise === promise) this.inflight.delete(sessionId);
 		}
+	}
+
+	/**
+	 * Cancel an unresolved creation so session teardown wins the race. A later
+	 * creation starts independently, while the stale winner is discarded.
+	 */
+	cancelPendingCreate(sessionId: string): boolean {
+		const pending = this.inflight.get(sessionId);
+		if (!pending) return false;
+		pending.cancellation.cancelled = true;
+		this.inflight.delete(sessionId);
+		return true;
 	}
 
 	/** Mark the identity header as sent for a session. Idempotent. */
@@ -217,9 +243,16 @@ export class TopicRegistry {
 		this.byTopic.delete(record.topicId);
 		return true;
 	}
+	/** Restore failed-delete retry state unless a replacement generation already published. */
+	restoreIfAbsent(sessionId: string, record: TopicRecord): boolean {
+		if (this.topics.has(sessionId)) return false;
+		this.topics.set(sessionId, record);
+		this.byTopic.set(record.topicId, sessionId);
+		return true;
+	}
 
 	/** Serialise for atomic persistence beside the daemon state. */
-	serialize(): TopicRegistryState {
-		return { topics: Object.fromEntries(this.topics) };
+	serialize(chatId?: string): TopicRegistryState {
+		return { ...(chatId === undefined ? {} : { chatId }), topics: Object.fromEntries(this.topics) };
 	}
 }

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -125,7 +125,7 @@ class FakeBotApi {
 type TopicAuthorityState = {
 	topics: Record<
 		string,
-		{ name?: string; nameOwner?: string; nameReconcilePending?: boolean; userNameUpdateId?: number }
+		{ topicId?: string; name?: string; nameOwner?: string; nameReconcilePending?: boolean; userNameUpdateId?: number }
 	>;
 };
 
@@ -142,9 +142,11 @@ function forumTopicEditedUpdate(
 	{
 		chat = { id: 42 },
 		from = { id: 42, is_bot: false },
+		senderChat,
 	}: {
 		chat?: { id: number | string };
 		from?: { id: number; is_bot?: boolean } | null;
+		senderChat?: { id: number | string; type?: unknown } | null;
 	} = {},
 ) {
 	return {
@@ -152,6 +154,7 @@ function forumTopicEditedUpdate(
 		message: {
 			chat,
 			...(from === null ? {} : { from }),
+			...(senderChat == null ? {} : { sender_chat: senderChat }),
 			message_thread_id: threadId,
 			forum_topic_edited: { name },
 		},
@@ -210,6 +213,40 @@ class ReplayRenameBotApi extends FakeBotApi {
 					result: [
 						forumTopicEditedUpdate(50, this.threadId, "First focus"),
 						forumTopicEditedUpdate(51, this.threadId, "Later focus"),
+					],
+				};
+			}
+			return { ok: true, result: [] };
+		}
+		if (method === "getChat" && this.getChatFailure) {
+			const failure = this.getChatFailure;
+			this.getChatFailure = undefined;
+			this.calls.push({ method, body });
+			return failure();
+		}
+		return super.call(method, body);
+	}
+}
+
+class ReplayInboundBotApi extends FakeBotApi {
+	getChatFailure: (() => unknown) | undefined;
+
+	override async call(method: string, body: unknown): Promise<unknown> {
+		if (method === "getUpdates") {
+			this.calls.push({ method, body });
+			const offset = (body as { offset?: number }).offset ?? 0;
+			if (offset <= 7) {
+				return {
+					ok: true,
+					result: [
+						{
+							update_id: 7,
+							message: {
+								chat: { id: 42, type: "private" },
+								text: "ok",
+								reply_to_message: { message_id: 55 },
+							},
+						},
 					],
 				};
 			}
@@ -1810,6 +1847,385 @@ test("a delayed user topic rename is immediately restored after a completed daem
 	expect(bot.calls.filter(c => c.method === "editForumTopic")).toHaveLength(0);
 });
 
+test("configured forum preserves admin topic renames but ignores ordinary members", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { type: "supergroup", is_forum: true } };
+		if (method === "getChatMember") {
+			return {
+				ok: true,
+				result: {
+					status: body.user_id === 100 ? "administrator" : "member",
+					user: { id: body.user_id, is_bot: false, first_name: "Forum admin" },
+					is_anonymous: false,
+					can_manage_topics: body.user_id === 100,
+				},
+			};
+		}
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 777 } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+		rich: { enabled: false },
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+		title: "Generated",
+	});
+	bot.calls = [];
+
+	await daemon.handleTelegramUpdate(
+		forumTopicEditedUpdate(41, 777, "Member choice", {
+			chat: { id: -10042 },
+			from: { id: 99, is_bot: false },
+		}),
+	);
+	expect((await readTopicAuthorityState(agentDir)).topics.S).not.toMatchObject({
+		name: "Member choice",
+		nameOwner: "user",
+	});
+
+	await daemon.handleTelegramUpdate(
+		forumTopicEditedUpdate(42, 777, "Admin choice", {
+			chat: { id: -10042 },
+			from: { id: 100, is_bot: false },
+		}),
+	);
+	expect((await readTopicAuthorityState(agentDir)).topics.S).toMatchObject({
+		name: "Admin choice",
+		nameOwner: "user",
+		nameReconcilePending: false,
+	});
+
+	await daemon.handleTelegramUpdate(
+		forumTopicEditedUpdate(43, 777, "Anonymous admin choice", {
+			chat: { id: -10042 },
+			from: { id: 1_087_968_824, is_bot: true },
+			senderChat: { id: -10042, type: "supergroup" },
+		}),
+	);
+	expect((await readTopicAuthorityState(agentDir)).topics.S).toMatchObject({
+		name: "Anonymous admin choice",
+		nameOwner: "user",
+		nameReconcilePending: false,
+	});
+	expect(bot.calls.filter(call => call.method === "getChatMember").map(call => call.body.user_id)).toEqual([99, 100]);
+	bot.calls = [];
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+		title: "Later generated title",
+	});
+	expect(bot.calls.filter(call => call.method === "editForumTopic")).toHaveLength(0);
+});
+
+test("configured forum rejects malformed admin and sender_chat evidence", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { type: "supergroup", is_forum: true } };
+		if (method === "getChatMember") {
+			if (body.user_id === 100) return { ok: true, result: { status: "administrator" } };
+			if (body.user_id === 101) {
+				return {
+					ok: true,
+					result: {
+						status: "administrator",
+						user: { id: 999, is_bot: false, first_name: "Mismatch" },
+						is_anonymous: false,
+						can_manage_topics: true,
+					},
+				};
+			}
+			if (body.user_id === 102) {
+				return {
+					ok: true,
+					result: {
+						status: "administrator",
+						user: { id: body.user_id, is_bot: true, first_name: "Bot" },
+						is_anonymous: false,
+						can_manage_topics: true,
+					},
+				};
+			}
+			if (body.user_id === 103) {
+				return {
+					ok: true,
+					result: {
+						status: "administrator",
+						user: { id: body.user_id, is_bot: false, first_name: "No permission" },
+						is_anonymous: false,
+						can_manage_topics: false,
+					},
+				};
+			}
+			if (body.user_id === 104) {
+				return {
+					ok: true,
+					result: {
+						status: "administrator",
+						user: { id: body.user_id, is_bot: false },
+						is_anonymous: false,
+						can_manage_topics: true,
+					},
+				};
+			}
+			if (body.user_id === 105 || body.user_id === 106) {
+				return {
+					ok: true,
+					result: {
+						status: "administrator",
+						user: { id: body.user_id, is_bot: false, first_name: "Administrator" },
+						is_anonymous: body.user_id === 106,
+						can_manage_topics: true,
+					},
+				};
+			}
+			return {
+				ok: true,
+				result: {
+					status: "member",
+					user: { id: body.user_id, is_bot: false, first_name: "Member" },
+					is_anonymous: false,
+				},
+			};
+		}
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 777 } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+		rich: { enabled: false },
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+		title: "Generated",
+	});
+	bot.calls = [];
+
+	for (const [updateId, name, overrides] of [
+		[51, "Missing user", { from: { id: 100, is_bot: false } }],
+		[52, "Mismatched user", { from: { id: 101, is_bot: false } }],
+		[53, "Bot member", { from: { id: 102, is_bot: false } }],
+		[54, "Missing permission", { from: { id: 103, is_bot: false } }],
+		[55, "Missing first name", { from: { id: 104, is_bot: false } }],
+		[
+			56,
+			"String sender chat",
+			{
+				from: null,
+				senderChat: { id: "-10042", type: "supergroup" },
+			},
+		],
+		[
+			57,
+			"Wrong sender type",
+			{
+				from: null,
+				senderChat: { id: -10042, type: "channel" },
+			},
+		],
+		[
+			58,
+			"Conflicting sender identity",
+			{
+				from: { id: 105, is_bot: false },
+				senderChat: { id: -10042, type: "supergroup" },
+			},
+		],
+		[59, "Anonymous named member", { from: { id: 106, is_bot: false } }],
+	] as const) {
+		await daemon.handleTelegramUpdate(
+			forumTopicEditedUpdate(updateId, 777, name, {
+				chat: { id: -10042 },
+				...overrides,
+			}),
+		);
+	}
+
+	const persisted = await readTopicAuthorityState(agentDir);
+	expect(persisted.topics.S?.nameOwner).toBeUndefined();
+	expect(bot.calls.filter(call => call.method === "getChatMember").map(call => call.body.user_id)).toEqual([
+		100, 101, 102, 103, 104, 106,
+	]);
+	expect(bot.calls.filter(call => call.method === "editForumTopic")).toHaveLength(0);
+});
+
+test.each([
+	"throw",
+	"ok:false",
+])("unavailable forum rename authority (%s) advances past later updates", async failure => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getUpdates") {
+			const offset = body.offset ?? 0;
+			return {
+				ok: true,
+				result:
+					offset === 0
+						? [
+								forumTopicEditedUpdate(7, 777, "Blocked rename", {
+									chat: { id: -10042 },
+									from: { id: 100, is_bot: false },
+								}),
+								{
+									update_id: 8,
+									message: {
+										chat: { id: -10042, type: "supergroup" },
+										text: "harmless",
+									},
+								},
+							]
+						: [],
+			};
+		}
+		if (method === "getChat") return { ok: true, result: { type: "supergroup", is_forum: true } };
+		if (method === "getChatMember") {
+			if (failure === "throw") throw new Error("getChatMember unavailable");
+			return { ok: false, description: "temporary failure" };
+		}
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 777 } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+		rich: { enabled: false },
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	bot.calls = [];
+
+	await daemon.pollOnce();
+	await daemon.pollOnce();
+
+	expect(bot.calls.filter(call => call.method === "getUpdates").map(call => call.body.offset)).toEqual([0, 9]);
+	expect(bot.calls.filter(call => call.method === "getChatMember")).toHaveLength(1);
+	expect((await readTopicAuthorityState(agentDir)).topics.S).not.toMatchObject({
+		name: "Blocked rename",
+		nameOwner: "user",
+	});
+});
+
+test("indeterminate forum capability retries a valid rename before later updates", async () => {
+	const agentDir = tempAgentDir();
+	const stateDir = daemonPaths(agentDir).dir;
+	await fs.promises.mkdir(stateDir, { recursive: true });
+	await fs.promises.writeFile(
+		path.join(stateDir, "telegram-topics.json"),
+		JSON.stringify({
+			chatId: "-10042",
+			topics: {
+				S: { topicId: "777", identitySent: true, createdAt: 0, name: "Generated" },
+			},
+		}),
+	);
+	const bot = new FakeBotApi();
+	let getChatCalls = 0;
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getUpdates") {
+			const offset = body.offset ?? 0;
+			return {
+				ok: true,
+				result:
+					offset === 0
+						? [
+								forumTopicEditedUpdate(7, 777, "Recovered rename", {
+									chat: { id: -10042 },
+									from: { id: 100, is_bot: false },
+								}),
+								{
+									update_id: 8,
+									message: {
+										chat: { id: -10042, type: "supergroup" },
+										text: "harmless",
+									},
+								},
+							]
+						: [],
+			};
+		}
+		if (method === "getChat") {
+			getChatCalls++;
+			if (getChatCalls === 1) return { ok: true, result: { type: "supergroup" } };
+			return { ok: true, result: { type: "supergroup", is_forum: true } };
+		}
+		if (method === "getChatMember") {
+			return {
+				ok: true,
+				result: {
+					status: "administrator",
+					user: { id: body.user_id, is_bot: false, first_name: "Administrator" },
+					is_anonymous: false,
+					can_manage_topics: true,
+				},
+			};
+		}
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+		setTimeoutImpl: ((callback: () => void) => {
+			callback();
+			return 0;
+		}) as any,
+	});
+	await daemon.loadTopics();
+	Object.assign(daemon, { pairedChatPrivacy: "non-private" });
+
+	await daemon.pollOnce();
+	await daemon.pollOnce();
+	await daemon.pollOnce();
+
+	expect(bot.calls.filter(call => call.method === "getUpdates").map(call => call.body.offset)).toEqual([0, 0, 9]);
+	expect(getChatCalls).toBe(2);
+	expect((await readTopicAuthorityState(agentDir)).topics.S).toMatchObject({
+		name: "Recovered rename",
+		nameOwner: "user",
+		nameReconcilePending: false,
+	});
+});
+
 test("bot-originated topic edit service messages do not claim user ownership", async () => {
 	const { bot, daemon, session, threadId } = await identityTopicHarness({ title: "First title" });
 	bot.calls = [];
@@ -1995,6 +2411,165 @@ test.each([
 		userNameUpdateId: 51,
 	});
 	expect(bot.calls.filter(call => call.method === "getUpdates").map(call => call.body.offset)).toEqual([0, 0, 52]);
+});
+
+test.each([
+	[
+		"thrown getChat",
+		() => {
+			throw new Error("getChat unavailable");
+		},
+	],
+	["getChat ok:false", () => ({ ok: false, description: "temporary failure" })],
+	["malformed getChat", () => ({ ok: true, result: {} })],
+])("indeterminate %s retries an inbound private ask reply", async (_name, getChatFailure) => {
+	FakeWs.instances = [];
+	const bot = new ReplayInboundBotApi();
+	bot.getChatFailure = getChatFailure;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(tempAgentDir()),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+		setTimeoutImpl: ((cb: () => void) => {
+			cb();
+			return 0;
+		}) as any,
+	});
+	daemon.connectSession("S", "ws://s", "ts");
+	daemon.messageRoutes.set("55", { sessionId: "S", actionId: "A" });
+	daemon.sessions.get("S")!.pending.set("A", { sessionId: "S", actionId: "A" });
+
+	await daemon.pollOnce();
+	expect(FakeWs.instances[0]!.sent).toHaveLength(0);
+
+	await daemon.pollOnce();
+	expect(JSON.parse(FakeWs.instances[0]!.sent[0]!)).toEqual({ type: "reply", id: "A", answer: "ok", token: "ts" });
+
+	await daemon.pollOnce();
+	expect(bot.calls.filter(call => call.method === "getUpdates").map(call => call.body.offset)).toEqual([0, 0, 8]);
+});
+
+test("unroutable private-chat messages advance the poller without probing getChat", async () => {
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getUpdates") {
+			const offset = body.offset ?? 0;
+			return {
+				ok: true,
+				result:
+					offset <= 7 ? [{ update_id: 7, message: { chat: { id: 42, type: "private" }, text: "unrelated" } }] : [],
+			};
+		}
+		if (method === "getChat") throw new Error("getChat unavailable");
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(tempAgentDir()),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+
+	await daemon.pollOnce();
+	await daemon.pollOnce();
+
+	expect(bot.calls.filter(call => call.method === "getUpdates").map(call => call.body.offset)).toEqual([0, 8]);
+	expect(bot.calls.filter(call => call.method === "getChat")).toHaveLength(0);
+});
+
+test.each([
+	"/session_recent",
+	"/rich on",
+])("indeterminate private authority retries routeable command %s", async command => {
+	const bot = new FakeBotApi();
+	const originalCall = bot.call.bind(bot);
+	let getChatCalls = 0;
+	bot.call = (async (method: string, body: any) => {
+		if (method === "getUpdates") {
+			bot.calls.push({ method, body });
+			const offset = body.offset ?? 0;
+			return {
+				ok: true,
+				result:
+					offset <= 7
+						? [{ update_id: 7, message: { chat: { id: 42, type: "private" }, text: command, message_id: 1 } }]
+						: [],
+			};
+		}
+		if (method === "getChat") {
+			bot.calls.push({ method, body });
+			getChatCalls++;
+			if (getChatCalls === 1) throw new Error("getChat unavailable");
+			return { ok: true, result: { type: "private" } };
+		}
+		return originalCall(method, body);
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(tempAgentDir()),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		setTimeoutImpl: ((callback: () => void) => {
+			callback();
+			return 0;
+		}) as any,
+	});
+
+	await daemon.pollOnce();
+	await daemon.pollOnce();
+	await daemon.pollOnce();
+
+	expect(bot.calls.filter(call => call.method === "getUpdates").map(call => call.body.offset)).toEqual([0, 0, 8]);
+	expect(getChatCalls).toBe(2);
+});
+
+test("stale callback advances the poller when private authority is indeterminate", async () => {
+	const bot = new FakeBotApi();
+	const originalCall = bot.call.bind(bot);
+	bot.call = (async (method: string, body: any) => {
+		if (method === "getUpdates") {
+			bot.calls.push({ method, body });
+			const offset = body.offset ?? 0;
+			return {
+				ok: true,
+				result:
+					offset <= 7
+						? [
+								{
+									update_id: 7,
+									callback_query: { id: "stale", data: "missing", message: { chat: { id: 42 } } },
+								},
+							]
+						: [],
+			};
+		}
+		if (method === "getChat") {
+			bot.calls.push({ method, body });
+			throw new Error("getChat unavailable");
+		}
+		return originalCall(method, body);
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(tempAgentDir()),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+
+	await daemon.pollOnce();
+	await daemon.pollOnce();
+
+	expect(bot.calls.filter(call => call.method === "getUpdates").map(call => call.body.offset)).toEqual([0, 8]);
+	expect(bot.calls.filter(call => call.method === "getChat")).toHaveLength(1);
+	expect(bot.calls.some(call => call.method === "answerCallbackQuery")).toBe(true);
+	expect(bot.calls.some(call => call.method === "sendMessage")).toBe(false);
 });
 
 test("remote-success user-name reconciliation retries after its pending-clear write fails", async () => {
@@ -2324,17 +2899,307 @@ test("threaded mode off: image_attachment uploads flat without message_thread_id
 	expect(notice).toHaveLength(1);
 });
 
-test("non-private chat: fails closed before topic creation or flat delivery", async () => {
-	for (const chatType of ["supergroup", "group", "channel"]) {
+test("forum supergroup uses a session topic for outbound transport only", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { type: "supergroup", is_forum: true } };
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 777 } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+		rich: { enabled: false },
+	});
+	const sent: string[] = [];
+	const session = {
+		sessionId: "S",
+		token: "tok",
+		ws: {
+			readyState: 1,
+			send(value: string) {
+				sent.push(value);
+			},
+		},
+		pending: new Map(),
+	};
+	daemon.sessions.set("S", session as any);
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	await daemon.handleSessionMessage(session as any, {
+		type: "context_update",
+		sessionId: "S",
+		lastMessage: "session output",
+	});
+
+	expect(bot.calls.filter(c => c.method === "getChat")).toHaveLength(1);
+	expect(bot.calls.filter(c => c.method === "createForumTopic")).toHaveLength(1);
+	expect(bot.calls.some(c => c.method === "sendMessage" && c.body.message_thread_id === 777)).toBe(true);
+
+	session.pending.set("ask1", { sessionId: "S", actionId: "ask1" });
+	bot.calls = [];
+	for (const [updateId, text] of [
+		[7, "/context"],
+		[8, "/verbose"],
+		[9, "answer the pending ask"],
+	] as const) {
+		await daemon.handleTelegramUpdate({
+			update_id: updateId,
+			message: {
+				chat: { id: -10042, type: "supergroup" },
+				message_thread_id: 777,
+				message_id: 500 + updateId,
+				text,
+			},
+		});
+	}
+	expect(sent).toHaveLength(0);
+	expect(bot.calls).toHaveLength(0);
+});
+
+test("forum supergroup does not fall back to flat delivery when topic creation fails", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { type: "supergroup", is_forum: true } };
+		if (method === "createForumTopic") return { ok: true, result: {} };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+		rich: { enabled: false },
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+
+	expect(bot.calls.filter(c => c.method === "createForumTopic")).toHaveLength(1);
+	expect(
+		bot.calls.filter(c => ["sendMessage", "sendPhoto", "sendDocument", "sendRichMessage"].includes(c.method)),
+	).toHaveLength(0);
+});
+
+test.each([
+	["missing", undefined],
+	["null", null],
+	["non-boolean", "yes"],
+])("indeterminate forum metadata (%s) is retried instead of cached", async (_name, malformedValue) => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	let getChatCalls = 0;
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") {
+			getChatCalls++;
+			if (getChatCalls === 1) {
+				return { ok: true, result: { type: "supergroup", is_forum: malformedValue } };
+			}
+			return { ok: true, result: { type: "supergroup", is_forum: true } };
+		}
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 888 } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+		rich: { enabled: false },
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	const identity = { type: "identity_header", sessionId: "S", repo: "r", branch: "b" };
+
+	await daemon.handleSessionMessage(session as any, identity);
+	expect(getChatCalls).toBe(2);
+	expect(bot.calls.filter(c => c.method === "createForumTopic")).toHaveLength(1);
+	expect(bot.calls.some(c => c.method === "sendMessage" && c.body.message_thread_id === 888)).toBe(true);
+});
+
+test.each([
+	[
+		"transient getChat failure",
+		() => {
+			throw new Error("getChat unavailable");
+		},
+	],
+	["malformed forum metadata", () => ({ ok: true, result: { type: "supergroup" } })],
+])("forum action retries after %s instead of dropping the one-shot frame", async (_name, firstResponse) => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	let getChatCalls = 0;
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") {
+			getChatCalls++;
+			if (getChatCalls === 1) return firstResponse();
+			return { ok: true, result: { type: "supergroup", is_forum: true } };
+		}
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 889 } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: 91 } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+		rich: { enabled: false },
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "action_needed",
+		sessionId: "S",
+		id: "ask1",
+		kind: "ask",
+		question: "Proceed?",
+		options: ["Yes"],
+	});
+
+	expect(getChatCalls).toBe(2);
+	expect(bot.calls.filter(call => call.method === "createForumTopic")).toHaveLength(1);
+	expect(bot.calls.some(call => call.method === "sendMessage" && call.body.message_thread_id === 889)).toBe(true);
+	expect(daemon.messageRoutes.get("91")).toEqual({ sessionId: "S", actionId: "ask1" });
+});
+
+test("persisted topics are scoped to their configured Telegram chat", async () => {
+	const agentDir = tempAgentDir();
+	const firstBot = new FakeBotApi();
+	firstBot.call = (async (method: string, body: any) => {
+		firstBot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { type: "supergroup", is_forum: true } };
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 777 } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: firstBot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const firstDaemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner-a",
+		botToken: "tok",
+		chatId: "-10001",
+		botApi: firstBot,
+		rich: { enabled: false },
+	});
+	const firstSession = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	await firstDaemon.handleSessionMessage(firstSession as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	const persisted = JSON.parse(
+		await fs.promises.readFile(path.join(daemonPaths(agentDir).dir, "telegram-topics.json"), "utf8"),
+	) as { chatId?: string };
+	expect(persisted.chatId).toBe("-10001");
+
+	const secondBot = new FakeBotApi();
+	secondBot.call = (async (method: string, body: any) => {
+		secondBot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { type: "supergroup", is_forum: true } };
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 888 } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: secondBot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const secondDaemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner-b",
+		botToken: "tok",
+		chatId: "-10002",
+		botApi: secondBot,
+		rich: { enabled: false },
+	});
+	await secondDaemon.loadTopics();
+	const secondSession = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+	await secondDaemon.handleSessionMessage(secondSession as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+
+	expect(secondBot.calls.filter(c => c.method === "createForumTopic")).toHaveLength(1);
+	expect(secondBot.calls.some(c => c.method === "sendMessage" && c.body.message_thread_id === 888)).toBe(true);
+	expect(secondBot.calls.some(c => c.body.message_thread_id === 777)).toBe(false);
+});
+
+test("legacy unscoped topic state is rejected because its destination cannot be proven", async () => {
+	const agentDir = tempAgentDir();
+	const stateDir = daemonPaths(agentDir).dir;
+	await fs.promises.mkdir(stateDir, { recursive: true });
+	await fs.promises.writeFile(
+		path.join(stateDir, "telegram-topics.json"),
+		JSON.stringify({
+			topics: {
+				S: { topicId: "777", identitySent: true, createdAt: 0, name: "Legacy topic" },
+			},
+		}),
+	);
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { type: "supergroup", is_forum: true } };
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 888 } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+		rich: { enabled: false },
+	});
+	await daemon.loadTopics();
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+
+	expect(bot.calls.filter(call => call.method === "createForumTopic")).toHaveLength(1);
+	expect(bot.calls.some(call => call.body.message_thread_id === 777)).toBe(false);
+	expect(bot.calls.some(call => call.body.message_thread_id === 888)).toBe(true);
+});
+
+test("non-forum groups and channels fail closed before topic creation or flat delivery", async () => {
+	for (const chat of [{ type: "supergroup", is_forum: false }, { type: "group" }, { type: "channel" }]) {
 		const agentDir = tempAgentDir();
 		const bot = new FakeBotApi();
-		// Even if the target chat would accept forum topic creation, the paired chat
-		// contract is private-only, so the daemon must fail closed before creating
-		// topics or sending session content into a shared chat.
+		// Only a supergroup explicitly reported as a forum is topic-capable; other
+		// shared destinations must never receive session content.
 		bot.call = (async (method: string, body: any) => {
 			bot.calls.push({ method, body });
 			if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 777 } };
-			if (method === "getChat") return { ok: true, result: { type: chatType } };
+			if (method === "getChat") return { ok: true, result: chat };
 			if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
 			return { ok: true, result: true };
 		}) as any;
@@ -2367,8 +3232,11 @@ test("non-private chat: fails closed before topic creation or flat delivery", as
 			options: ["Yes"],
 		});
 
-		expect(bot.calls.filter(c => c.method === "createForumTopic")).toHaveLength(0);
-		expect(bot.calls.filter(c => c.method === "sendMessage")).toHaveLength(0);
+		expect(
+			bot.calls.filter(c =>
+				["createForumTopic", "sendMessage", "sendPhoto", "sendDocument", "sendRichMessage"].includes(c.method),
+			),
+		).toHaveLength(0);
 	}
 });
 
@@ -2502,6 +3370,232 @@ test("activity busy frame sends a typing chat action into the session topic", as
 	await daemon.handleSessionMessage(session as any, { type: "activity", sessionId: "S", state: "idle" });
 	expect(bot.calls.some(c => c.method === "sendChatAction")).toBe(false);
 });
+test("session_closed cancels an in-flight eager topic create and deletes its unpublished remote topic", async () => {
+	FakeWs.instances = [];
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const createStarted = Promise.withResolvers<void>();
+	const releaseCreate = Promise.withResolvers<void>();
+	let createCount = 0;
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { id: body.chat_id, type: "supergroup", is_forum: true } };
+		if (method === "createForumTopic") {
+			createCount++;
+			if (createCount === 1) {
+				createStarted.resolve();
+				await releaseCreate.promise;
+				return { ok: true, result: { message_thread_id: 777 } };
+			}
+			return { ok: true, result: { message_thread_id: 888 } };
+		}
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+	});
+
+	daemon.connectSession("S", "ws://live", "tok");
+	const session = daemon.sessions.get("S")!;
+	FakeWs.instances[0]!.dispatchEvent(new Event("open"));
+	await createStarted.promise;
+
+	await daemon.handleSessionMessage(session, { type: "session_closed", sessionId: "S" });
+	expect(daemon.sessions.has("S")).toBe(false);
+	expect((daemon as any).topics.get("S")).toBeUndefined();
+
+	releaseCreate.resolve();
+	for (let i = 0; i < 20 && !bot.calls.some(call => call.method === "deleteForumTopic"); i++) await Bun.sleep(1);
+
+	const deletes = bot.calls.filter(call => call.method === "deleteForumTopic");
+	expect(deletes).toHaveLength(1);
+	expect(deletes[0]!.body.message_thread_id).toBe(777);
+	expect((daemon as any).topics.get("S")).toBeUndefined();
+
+	daemon.connectSession("S", "ws://resumed", "tok-2");
+	const resumedSession = daemon.sessions.get("S")!;
+	await daemon.handleSessionMessage(resumedSession, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+		title: "resumed",
+	});
+
+	expect(createCount).toBe(2);
+	expect(bot.calls.filter(call => call.method === "createForumTopic")).toHaveLength(2);
+	expect(bot.calls.find(call => call.method === "sendMessage")?.body.message_thread_id).toBe(888);
+	expect((daemon as any).topics.get("S")?.topicId).toBe("888");
+	expect((await readTopicAuthorityState(agentDir)).topics.S?.topicId).toBe("888");
+});
+test("stale session teardown never deletes a replacement generation topic published while flush waits", async () => {
+	FakeWs.instances = [];
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	const createStarted = Promise.withResolvers<void>();
+	const releaseCreate = Promise.withResolvers<void>();
+	const releaseFlush = Promise.withResolvers<void>();
+	let createCount = 0;
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { id: body.chat_id, type: "supergroup", is_forum: true } };
+		if (method === "createForumTopic") {
+			createCount++;
+			if (createCount === 1) {
+				createStarted.resolve();
+				await releaseCreate.promise;
+				return { ok: true, result: { message_thread_id: 777 } };
+			}
+			return { ok: true, result: { message_thread_id: 888 } };
+		}
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+	});
+
+	daemon.connectSession("S", "ws://old", "old-token");
+	const oldSession = daemon.sessions.get("S")!;
+	FakeWs.instances[0]!.dispatchEvent(new Event("open"));
+	await createStarted.promise;
+
+	(daemon as any).flushChain = releaseFlush.promise;
+	const close = daemon.handleSessionMessage(oldSession, { type: "session_closed", sessionId: "S" });
+	expect(oldSession.closed).toBe(true);
+
+	daemon.connectSession("S", "ws://replacement", "replacement-token");
+	const replacement = daemon.sessions.get("S")!;
+	const identity = daemon.handleSessionMessage(replacement, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+		title: "replacement",
+	});
+	for (let i = 0; i < 50 && (daemon as any).topics.get("S")?.topicId !== "888"; i++) await Bun.sleep(1);
+	expect((daemon as any).topics.get("S")?.topicId).toBe("888");
+
+	releaseCreate.resolve();
+	for (
+		let i = 0;
+		i < 50 && !bot.calls.some(call => call.method === "deleteForumTopic" && call.body.message_thread_id === 777);
+		i++
+	)
+		await Bun.sleep(1);
+	releaseFlush.resolve();
+	await Promise.all([close, identity]);
+
+	expect(
+		bot.calls.filter(call => call.method === "deleteForumTopic").map(call => call.body.message_thread_id),
+	).toEqual([777]);
+	expect(bot.calls.find(call => call.method === "sendMessage")?.body.message_thread_id).toBe(888);
+	expect((daemon as any).topics.get("S")?.topicId).toBe("888");
+	expect((await readTopicAuthorityState(agentDir)).topics.S?.topicId).toBe("888");
+});
+test("session_closed racing private ask topic creation does not flat-deliver a stale prompt", async () => {
+	FakeWs.instances = [];
+	const bot = new FakeBotApi();
+	const createStarted = Promise.withResolvers<void>();
+	const releaseCreate = Promise.withResolvers<void>();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { id: body.chat_id, type: "private" } };
+		if (method === "createForumTopic") {
+			createStarted.resolve();
+			await releaseCreate.promise;
+			return { ok: true, result: { message_thread_id: 777 } };
+		}
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(tempAgentDir()),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+	});
+	daemon.connectSession("S", "ws://live", "tok");
+	const session = daemon.sessions.get("S")!;
+
+	const action = daemon.handleSessionMessage(session, {
+		type: "action_needed",
+		sessionId: "S",
+		id: "ask-1",
+		kind: "ask",
+		question: "Choose",
+		options: ["Yes"],
+	});
+	await createStarted.promise;
+	await daemon.handleSessionMessage(session, { type: "session_closed", sessionId: "S" });
+	releaseCreate.resolve();
+	await action;
+
+	expect(bot.calls.filter(call => call.method === "createForumTopic")).toHaveLength(1);
+	expect(
+		bot.calls.filter(call => call.method === "deleteForumTopic").map(call => call.body.message_thread_id),
+	).toEqual([777]);
+	expect(bot.calls.some(call => call.method === "sendMessage")).toBe(false);
+	expect(session.pending.has("ask-1")).toBe(false);
+});
+test("session_closed racing private identity topic creation does not flat-deliver a stale frame", async () => {
+	FakeWs.instances = [];
+	const bot = new FakeBotApi();
+	const createStarted = Promise.withResolvers<void>();
+	const releaseCreate = Promise.withResolvers<void>();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { id: body.chat_id, type: "private" } };
+		if (method === "createForumTopic") {
+			createStarted.resolve();
+			await releaseCreate.promise;
+			return { ok: true, result: { message_thread_id: 777 } };
+		}
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(tempAgentDir()),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		WebSocketImpl: FakeWs as any,
+	});
+	daemon.connectSession("S", "ws://live", "tok");
+	const session = daemon.sessions.get("S")!;
+
+	const identity = daemon.handleSessionMessage(session, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	await createStarted.promise;
+	await daemon.handleSessionMessage(session, { type: "session_closed", sessionId: "S" });
+	releaseCreate.resolve();
+	await identity;
+
+	expect(bot.calls.filter(call => call.method === "createForumTopic")).toHaveLength(1);
+	expect(
+		bot.calls.filter(call => call.method === "deleteForumTopic").map(call => call.body.message_thread_id),
+	).toEqual([777]);
+	expect(bot.calls.some(call => call.method === "sendMessage")).toBe(false);
+	expect((daemon as any).topics.get("S")).toBeUndefined();
+});
 
 test("session_closed deletes the topic and resume creates a fresh visible topic", async () => {
 	const agentDir = tempAgentDir();
@@ -2541,7 +3635,8 @@ test("session_closed deletes the topic and resume creates a fresh visible topic"
 
 	now = 10_000;
 	bot.calls = [];
-	await daemon.handleSessionMessage(session as any, {
+	const resumedSession = { ...session, closed: false };
+	await daemon.handleSessionMessage(resumedSession as any, {
 		type: "identity_header",
 		sessionId: "S",
 		repo: "r",
@@ -2558,6 +3653,76 @@ test("session_closed deletes the topic and resume creates a fresh visible topic"
 	expect(bot.calls.some(c => c.method === "sendMessage" && String(c.body.text).includes("queued-before-delete"))).toBe(
 		false,
 	);
+});
+
+test("session_closed retains scoped deletion retry state when Telegram rejects deletion", async () => {
+	const agentDir = tempAgentDir();
+	const bot = new FakeBotApi();
+	let now = 0;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		now: () => now,
+	});
+	const session = { sessionId: "S", token: "tok", ws: { readyState: 1, send() {} }, pending: new Map() };
+
+	await daemon.handleSessionMessage(session as any, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "r",
+		branch: "b",
+	});
+	for (let i = 0; i < 25; i++) {
+		await daemon.handleSessionMessage(session as any, {
+			type: "turn_stream",
+			sessionId: "S",
+			phase: "finalized",
+			text: `queued-before-close-${i}`,
+		});
+	}
+	expect((daemon as any).pool.pending).toBeGreaterThan(0);
+	const topicId = (daemon as any).topics.get("S").topicId;
+
+	let deleteOutcome: "ok-false" | "throw" | "success" = "ok-false";
+	const originalCall = bot.call.bind(bot);
+	bot.call = (async (method: string, body: any) => {
+		if (method === "getChat") throw new Error("getChat unavailable");
+		if (method === "deleteForumTopic") {
+			bot.calls.push({ method, body });
+			if (deleteOutcome === "throw") throw new Error("delete unavailable");
+			return deleteOutcome === "success" ? { ok: true, result: true } : { ok: false, result: false };
+		}
+		return originalCall(method, body);
+	}) as any;
+	(daemon as any).pairedChatTopicCapable = undefined;
+	(daemon as any).pairedChatPrivacy = undefined;
+	bot.calls = [];
+
+	await daemon.handleSessionMessage(session as any, { type: "session_closed", sessionId: "S" });
+
+	expect(bot.calls.some(call => call.method === "getChat")).toBe(false);
+	expect(bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	expect((daemon as any).pool.pending).toBe(0);
+	expect((daemon as any).topics.get("S")?.topicId).toBe(topicId);
+	expect((await readTopicAuthorityState(agentDir)).topics.S?.topicId).toBe(topicId);
+
+	deleteOutcome = "throw";
+	now = 60_000;
+	await daemon.scanRoots();
+
+	expect(bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(2);
+	expect((daemon as any).topics.get("S")?.topicId).toBe(topicId);
+	expect((await readTopicAuthorityState(agentDir)).topics.S?.topicId).toBe(topicId);
+
+	deleteOutcome = "success";
+	await daemon.scanRoots();
+
+	expect(bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(3);
+	expect((daemon as any).topics.get("S")).toBeUndefined();
+	expect((await readTopicAuthorityState(agentDir)).topics.S).toBeUndefined();
 });
 
 test("session_closed clears reply message routes for the closed session", async () => {
@@ -3437,6 +4602,7 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 	fs.writeFileSync(
 		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
 		JSON.stringify({
+			chatId: "42",
 			topics: {
 				stale: { topicId: "101", identitySent: true, createdAt: 0, name: "stale" },
 				dead: { topicId: "102", identitySent: true, createdAt: 0, name: "dead" },
@@ -3474,7 +4640,10 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
 	fs.writeFileSync(
 		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
-		JSON.stringify({ topics: { missing: { topicId: "201", identitySent: true, createdAt: 0, name: "missing" } } }),
+		JSON.stringify({
+			chatId: "42",
+			topics: { missing: { topicId: "201", identitySent: true, createdAt: 0, name: "missing" } },
+		}),
 	);
 	const bot = new FakeBotApi();
 	const daemon = new TelegramNotificationDaemon({
@@ -3499,7 +4668,10 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 	fs.mkdirSync(daemonPaths(blockedAgentDir).dir, { recursive: true });
 	fs.writeFileSync(
 		path.join(daemonPaths(blockedAgentDir).dir, "telegram-topics.json"),
-		JSON.stringify({ topics: { kept: { topicId: "202", identitySent: true, createdAt: 0, name: "kept" } } }),
+		JSON.stringify({
+			chatId: "42",
+			topics: { kept: { topicId: "202", identitySent: true, createdAt: 0, name: "kept" } },
+		}),
 	);
 	const blockedBot = new FakeBotApi();
 	const blockedDaemon = new TelegramNotificationDaemon({

--- a/packages/coding-agent/test/notifications-topic-registry.test.ts
+++ b/packages/coding-agent/test/notifications-topic-registry.test.ts
@@ -163,6 +163,15 @@ describe("TopicRegistry", () => {
 		expect(reloaded.needsIdentity("s1")).toBe(false);
 		expect(reloaded.sessionForTopic("t1")).toBe("s1");
 	});
+
+	test("serializes an optional Telegram chat scope", async () => {
+		const reg = new TopicRegistry();
+		await reg.getOrCreateTopic("s1", async () => "t1");
+		expect(reg.serialize("-10042")).toMatchObject({
+			chatId: "-10042",
+			topics: { s1: { topicId: "t1" } },
+		});
+	});
 	test("concurrent getOrCreateTopic for one session creates exactly one topic (no race)", async () => {
 		const reg = new TopicRegistry();
 		let creates = 0;
@@ -180,6 +189,43 @@ describe("TopicRegistry", () => {
 		expect(creates).toBe(1);
 		expect(results.map(r => r.topicId)).toEqual(["topic-1", "topic-1", "topic-1"]);
 		expect(reg.sessionForTopic("topic-1")).toBe("s1");
+	});
+	test("cancelling an in-flight create discards its remote winner without replacing a fresh topic", async () => {
+		const reg = new TopicRegistry();
+		const createStarted = Promise.withResolvers<void>();
+		const releaseCreate = Promise.withResolvers<void>();
+		const discarded: string[] = [];
+		const stale = reg.getOrCreateTopic(
+			"s1",
+			async () => {
+				createStarted.resolve();
+				await releaseCreate.promise;
+				return "stale";
+			},
+			() => 1,
+			"stale name",
+			async topicId => {
+				discarded.push(topicId);
+			},
+		);
+		await createStarted.promise;
+
+		expect(reg.cancelPendingCreate("s1")).toBe(true);
+		expect(reg.cancelPendingCreate("s1")).toBe(false);
+		const fresh = await reg.getOrCreateTopic(
+			"s1",
+			async () => "fresh",
+			() => 2,
+			"fresh name",
+		);
+		releaseCreate.resolve();
+
+		await expect(stale).rejects.toThrow("topic creation cancelled");
+		expect(discarded).toEqual(["stale"]);
+		expect(fresh.topicId).toBe("fresh");
+		expect(reg.get("s1")?.topicId).toBe("fresh");
+		expect(reg.sessionForTopic("stale")).toBeUndefined();
+		expect(reg.sessionForTopic("fresh")).toBe("s1");
 	});
 
 	test("deletes topic records so later use creates a fresh topic", async () => {
@@ -199,5 +245,20 @@ describe("TopicRegistry", () => {
 		expect(created).toBe(true);
 		expect(rec.topicId).toBe("t2");
 		expect(reg.sessionForTopic("t2")).toBe("s1");
+	});
+	test("restores failed-delete state only when no replacement topic exists", async () => {
+		const reg = new TopicRegistry();
+		const stale = await reg.getOrCreateTopic("s1", async () => "stale");
+
+		expect(reg.delete("s1")).toBe(true);
+		expect(reg.restoreIfAbsent("s1", stale)).toBe(true);
+		expect(reg.sessionForTopic("stale")).toBe("s1");
+
+		expect(reg.delete("s1")).toBe(true);
+		const fresh = await reg.getOrCreateTopic("s1", async () => "fresh");
+		expect(reg.restoreIfAbsent("s1", stale)).toBe(false);
+		expect(reg.get("s1")).toBe(fresh);
+		expect(reg.sessionForTopic("stale")).toBeUndefined();
+		expect(reg.sessionForTopic("fresh")).toBe("s1");
 	});
 });


### PR DESCRIPTION
## What

This is a focused replacement for closed PRs #1970, #1976, #1977, and #1982, rebased onto current `dev` and updated to address every blocking review finding.

It adds outbound per-session topic delivery for an explicitly configured Telegram forum supergroup while preserving the existing private-chat authority boundary:

- a private chat is topic-capable and may use flat fallback and inbound controls;
- a `supergroup` is topic-capable only when `getChat.is_forum` is explicitly boolean `true`;
- groups, channels, and explicit non-forum supergroups remain fail-closed;
- forum supergroups are outbound topic transport only—messages, ask answers, callbacks, and session/config controls are not routed into local sessions;
- persisted topic ids are tagged with their owning `chatId` and loaded only for that exact destination.

## Why

Telegram forum supergroups support `createForumTopic` and `message_thread_id`, but the daemon previously used the private-chat check for every topic operation. That prevented an explicitly configured forum destination from receiving session-scoped topic notifications.

The implementation caches private-chat authority and forum-topic capability independently. A non-successful or malformed chat-type response leaves inbound authority indeterminate and routeable private updates retry without advancing the offset. Missing, `null`, or non-boolean `is_forum` metadata leaves topic capability uncached and retryable while still establishing that a supergroup is non-private.

Onboarding remains private-only; this changes runtime behavior only for an already explicit destination configuration.

## Review feedback addressed

Thank you for the detailed reviews on #1970, #1976, #1977, #1982, and this PR. This revision addresses the reported blockers and follow-ups:

1. **Tri-state retries:** malformed `is_forum` values remain uncached, and indeterminate private-chat authority returns `retry` without consuming routeable updates.
2. **Shared-chat authority:** forum-supergroup updates cannot emit user, control, config, or ask-reply frames. Callback spinners are dismissed without routing answers or posting guidance.
3. **Cross-chat topic state:** serialized topic state includes `chatId`; mismatched and unverifiable legacy-unscoped state is ignored, preventing topic-id reuse after destination rotation.
4. **One-shot actions:** `action_needed` retries an indeterminate topic-capability lookup inline, so a transient or malformed first `getChat` response does not lose the ask or its Telegram route.
5. **Private commands:** `/session_*` and `/rich` preserve the tri-state poll contract and retry indeterminate authority.
6. **Teardown safety:** session close tombstones the WebSocket generation, cancels unresolved creation, and synchronously detaches only the captured topic/local state before its first cleanup await. A stale close therefore cannot look up or delete a replacement generation's topic by bare session id. Failed remote deletions live in a separate durable queue keyed by topic id, so they neither become inbound-routable nor conflict with active/in-flight replacement generations. Cancelled creates queue their eventual remote topic before deletion is attempted. Private asks and threaded frames that observe the tombstone cannot fall back to stale flat delivery. A chat-scoped topic is deleted without another fallible `getChat` probe; thrown, malformed, or `{ok:false}` results remain durable and orphan scans retry after the grace window.
7. **Routeability:** harmless paired-chat messages and stale callbacks are consumed without pinning the poller, while valid replies/injections retain retry semantics.
8. **Forum rename authority:** topic-edit service updates are scoped to the configured forum and known topic. Named administrators require a well-formed matching non-anonymous `ChatMember.user`, administrator/creator status, and topic-management authority. Presence of `sender_chat` selects an exclusive anonymous-admin path requiring Telegram's numeric GroupAnonymousBot identity and the exact numeric supergroup sender. Indeterminate forum capability retries; malformed authority evidence and lookup failures consume fail-closed without mutating state or blocking later updates.
9. **Create/close race:** `TopicRegistry` supports cancellable per-session in-flight creation. Cancellation detaches the stale promise so a fresh generation can create independently, conditionally removes only its own in-flight entry, and discards any stale remote winner without overwriting fresh state.
10. **DCO:** the commit includes a `Signed-off-by:` trailer.

## Testing

- Latest #1987 owner-blocker regression: 1 passed
  - while stale teardown flush is blocked, replacement topic `888` is created/sent/persisted; releasing teardown deletes only cancelled topic `777` and preserves `888`: 1
- Latest #1987 Codex regressions: 6 passed
  - a private ask racing `session_closed` does not publish a flat stale prompt or retain pending state: 1
  - scoped remote topic deletion is attempted without a fallible `getChat` teardown probe: 1
  - a private identity frame racing `session_closed` does not publish through flat fallback: 1
  - rejected topic deletion (`ok:false` and throw) remains durable and is retried successfully by orphan scanning without replacing fresh state: 1
  - a deletion retry queued while a replacement create is in flight remains durable, non-routable, and survives replacement publication: 1
  - cancelled create topic `777` remains in the durable deletion queue after failed cleanup while replacement topic `888` stays active, then scan retry removes only `777`: 1
- Latest #1982 owner-blocker regressions: 2 passed
  - registry cancellation discards a stale remote winner without replacing a fresh record: 1
  - eager create/session-close race deletes topic `777`, persists no stale record, and resume creates/sends through fresh topic `888`: 1
- Latest #1982 Codex regressions: 2 passed
  - contradictory `sender_chat` and anonymous named-member rejection: 1
  - indeterminate forum-capability replay with later-update advancement: 1
- Latest #1977 owner-blocker regressions: 4 passed
  - well-formed named and anonymous administrator acceptance: 1
  - malformed `ChatMember`/`sender_chat` rejection: 1
  - thrown and `ok:false` member-lookup offset advancement: 2
- Previous focused review regressions: 9 passed
  - private command retry: 2
  - stale callback offset advancement: 1
  - legacy-unscoped state rejection: 1
  - transient/malformed forum action retry: 2
  - teardown cleanup during `getChat` failure: 1
  - unrelated update offset advancement without `getChat`: 1
  - configured forum rename preservation: 1
- Topic registry and lifecycle routing suites: 22 passed
- `bun --cwd=packages/coding-agent run check`: passed (Biome + package type check)
- `git diff --check`: passed
- The full registry/daemon run completed 162 behavioral tests successfully; its only failure on Windows is the existing exact POSIX-mode assertion for an inbound temporary file (`0666` vs `0600`), unrelated to this change.

---

- [x] Package check passes
- [x] Tested locally
- [x] CHANGELOG updated
- [x] DCO sign-off included
