### PR TITLE
fix(docker): install tmux and gh in pi-base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        git curl ca-certificates unzip openssh-client tini sqlite3 \
+        git curl ca-certificates unzip openssh-client tini sqlite3 tmux gh \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \


### PR DESCRIPTION
## Summary
The official `pi-base` image documents tmux-backed workflows (`team` / Coordinator) and a GitHub tool that requires the `gh` CLI, but the Docker image only installed `git`/`curl`/`ssh`/`sqlite`. Default `pi-runtime` containers therefore shipped without those runtime dependencies.

## Change
Install distro packages `tmux` and `gh` in the shared `pi-base` apt layer so `pi-runtime`, `pi-dev`, and derived images (e.g. robogjc via `PI_BASE`) inherit them.

```dockerfile
git curl ca-certificates unzip openssh-client tini sqlite3 tmux gh \
```

## Why apt packages
- Minimal one-line change, no extra apt sources/keyrings
- Debian Bookworm currently ships `tmux 3.3a` and `gh 2.23.0`
- New enough for documented basic usage; users needing bleeding-edge `gh` can still install from GitHub's apt repo

## Verification
Built and ran the image locally:

- `command -v tmux gh` → `/usr/bin/tmux`, `/usr/bin/gh`
- `tmux -V` → `tmux 3.3a`
- `gh --version` → `gh version 2.23.0`
- `gh auth status` works with `GH_TOKEN` injected at runtime (token is not baked into the image)

## Notes
- No application code changes
- No focused unit tests apply; verification is image package presence
- Target branch: `dev` per CONTRIBUTING.md
