### PR TITLE
test(coding-agent): isolate resume exit code assertions

### DIFF
--- a/packages/coding-agent/test/fixtures/resume-exit-code-probe.ts
+++ b/packages/coding-agent/test/fixtures/resume-exit-code-probe.ts
@@ -1,0 +1,18 @@
+import { parseArgs } from "../../src/cli/args";
+import { runRootCommand } from "../../src/main";
+
+const requested = process.argv[2];
+const expectedExitCode = requested === "undefined" ? undefined : Number(requested);
+if (expectedExitCode !== undefined) process.exitCode = expectedExitCode;
+
+const originalExitCode = process.exitCode;
+await runRootCommand(parseArgs(["--resume"]), [], {
+	suppressProcessExit: true,
+	isResumePickerTerminal: () => false,
+});
+
+if (process.exitCode !== originalExitCode) {
+	throw new Error(`Expected process.exitCode ${String(originalExitCode)}, received ${String(process.exitCode)}`);
+}
+
+process.exitCode = 0;

--- a/packages/coding-agent/test/resume-confirm-continue.test.ts
+++ b/packages/coding-agent/test/resume-confirm-continue.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
 import type { Args } from "../src/cli/args";
 import { parseArgs } from "../src/cli/args";
 import {
@@ -68,6 +69,7 @@ async function captureStderr(operation: () => Promise<void>): Promise<string> {
 }
 
 async function expectEarlyBareResumeRejection(args: Args, isResumePickerTerminal: boolean): Promise<string> {
+	const originalExitCode = process.exitCode;
 	let authDiscoveries = 0;
 	let settingsInitializations = 0;
 	let stdinReads = 0;
@@ -99,7 +101,7 @@ async function expectEarlyBareResumeRejection(args: Args, isResumePickerTerminal
 	expect(settingsInitializations).toBe(0);
 	expect(stdinReads).toBe(0);
 	expect(pickerLists).toBe(0);
-	expect(process.exitCode).toBeUndefined();
+	expect(process.exitCode).toBe(originalExitCode);
 	return stderr;
 }
 
@@ -128,6 +130,22 @@ describe("bare resume startup gating", () => {
 	it("rejects TTY-backed RPC and print routes before startup work", async () => {
 		for (const args of [bareArgs({ mode: "rpc" }), bareArgs({ print: true })]) {
 			expect(await expectEarlyBareResumeRejection(args, true)).toBe(`${BARE_RESUME_INTERACTIVE_ERROR}\n`);
+		}
+	});
+
+	it("preserves undefined, zero, and nonzero exit codes in isolated route probes", async () => {
+		for (const exitCode of ["undefined", "0", "7"]) {
+			const probe = Bun.spawn(
+				[process.execPath, path.join(import.meta.dir, "fixtures/resume-exit-code-probe.ts"), exitCode],
+				{
+					cwd: path.join(import.meta.dir, ".."),
+					stdout: "pipe",
+					stderr: "pipe",
+				},
+			);
+			const [status, stderr] = await Promise.all([probe.exited, new Response(probe.stderr).text()]);
+			expect(status).toBe(0);
+			expect(stderr).toBe(`${BARE_RESUME_INTERACTIVE_ERROR}\n`);
 		}
 	});
 


### PR DESCRIPTION
## What
- make the bare-resume startup-gating assertions verify that `suppressProcessExit` preserves the caller's existing `process.exitCode`
- add isolated route probes for pre-existing `undefined`, zero, and nonzero exit-code states without leaking state into the parent test process

## Why
Dev CI run 29122614614, shard 7 (job 86461084862), exposed an order-dependent test failure after #1991: the focused file passed alone, but the full shard inherited `process.exitCode = 0` from an earlier test and incorrectly required it to be `undefined`. The production route gate did not mutate the value. This follow-up completes the #1973 delivery without reopening the closed issue.

## Testing
- `bun --cwd=packages/coding-agent test test/resume-confirm-continue.test.ts` — 8 passed, 102 expectations
- `bun scripts/ci-dev-affected.ts --task=test:@gajae-code/coding-agent:shard-7-of-8` with the failed run's affected-path environment — 998 passed, 57 skipped, 0 failed, 13,144 expectations
- `bun --cwd=packages/coding-agent run check` — passed
- `bun --cwd=packages/coding-agent run build` — passed
- `bunx biome check packages/coding-agent/test/resume-confirm-continue.test.ts packages/coding-agent/test/fixtures/resume-exit-code-probe.ts` — passed
- `git diff --check` — passed

Follow-up to #1991 and #1973.

—

*[repo owner's gaebal-gajae (clawdbot) 🦞]*