### PR TITLE
fix(coding-agent): harden model role and profile persistence

### DIFF
--- a/packages/agent/src/compaction/entries.ts
+++ b/packages/agent/src/compaction/entries.ts
@@ -20,7 +20,7 @@ export interface ThinkingLevelChangeEntry extends SessionEntryBase {
 
 export interface ModelChangeEntry extends SessionEntryBase {
 	type: "model_change";
-	/** Model in "provider/modelId" format */
+	/** Model in "provider/modelId" format. */
 	model: string;
 	/** Role: "default", "smol", "slow", etc. Undefined treated as "default" */
 	role?: string;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed `/model` and Agent Control Center role assignments so DEFAULT, EXECUTOR, ARCHITECT, PLANNER, and CRITIC update their effective runtime/project-shadowed values, TUI badges, and persisted per-role settings without replacing sibling assignments.
+- Fixed active-profile role edits and preset-deletion rollback so inherited materialization preserves later independent role/profile choices, including equal-value writes, and preset deletion now aborts when durable settings persistence fails; also fixed omitted-role profile switches, role-only profile effort across restart, truthful mixed-effort output, and model-setting commands blocking on nonsettling notification transports.
+- Fixed durable model-setting boundaries so deleted ownership metadata self-heals without wedging conditional writes, failed `/model` and model-selector writes roll back instead of committing on a later flush, custom profile mutations are locked and atomic, and deleted presets remain as hidden archived fallbacks so stale global, project, and ACP references cannot break startup.
 
 ### Changed
 

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -6,6 +6,7 @@ import {
 	aggregateModelProfileRequiredProviders,
 	formatAvailableProfileNames,
 	formatModelProfileDisplayLabel,
+	type ModelProfileDefinition,
 	resolveProfileBindings,
 } from "./model-profiles";
 import {
@@ -19,6 +20,127 @@ import type { Settings } from "./settings";
 
 const LEGACY_MODEL_PROFILE_ALIASES: ReadonlyMap<string, string> = new Map([["codex-standard", "codex-medium"]]);
 
+interface ActiveModelProfileRuntimeState {
+	baselineModel?: Model<Api>;
+	baselineThinkingLevel?: ThinkingLevel;
+	baselineSessionDefaultModel?: string;
+	persistableBaselineThinkingLevel?: ThinkingLevel;
+	baselineModelRoles: Record<string, string>;
+	baselineAgentModelOverrides: Record<string, string>;
+	persistableBaselineModelRoles: Record<string, string>;
+	persistableBaselineAgentModelOverrides: Record<string, string>;
+	appliedModelRoles: Record<string, string>;
+	appliedAgentModelOverrides: Record<string, string>;
+	defaultSelector?: string;
+	persistedModelProfile: string | undefined;
+	persistedModelProfilePendingMutationId: number | undefined;
+}
+
+const activeModelProfileRuntimeStates = new WeakMap<object, ActiveModelProfileRuntimeState>();
+
+function deriveProfileBaseline(
+	baseline: Record<string, string>,
+	current: Record<string, string>,
+	applied: Record<string, string>,
+): Record<string, string> {
+	const next = { ...baseline };
+	for (const key of new Set([...Object.keys(baseline), ...Object.keys(current), ...Object.keys(applied)])) {
+		const currentValue = current[key];
+		const appliedValue = applied[key];
+		if (currentValue === undefined) {
+			delete next[key];
+		} else if (appliedValue === undefined || currentValue !== appliedValue) {
+			next[key] = currentValue;
+		}
+	}
+	return next;
+}
+
+function mergeAppliedProfileAssignments(
+	target: Record<string, string>,
+	current: Record<string, string>,
+	applied: Record<string, string>,
+): void {
+	for (const [key, value] of Object.entries(applied)) {
+		if (current[key] === value) {
+			target[key] = value;
+		}
+	}
+}
+
+type ModelAssignmentPersistenceSettings = Pick<
+	Settings,
+	| "clearAgentModelOverride"
+	| "clearModelRole"
+	| "setAgentModelOverride"
+	| "setAgentModelOverrideIfUnchanged"
+	| "setModelRole"
+	| "setModelRoleIfUnchanged"
+>;
+
+interface ModelAssignmentTouchedEntries {
+	modelRoles: string[];
+	agentModelOverrides: string[];
+}
+
+function persistModelAssignmentEntries(
+	settings: ModelAssignmentPersistenceSettings,
+	modelRoles: Record<string, string>,
+	agentModelOverrides: Record<string, string>,
+	previousModelRoles: Record<string, string>,
+	previousAgentModelOverrides: Record<string, string>,
+	explicitModelRoles: ReadonlySet<string>,
+	explicitAgentModelOverrides: ReadonlySet<string>,
+): ModelAssignmentTouchedEntries {
+	const touched: ModelAssignmentTouchedEntries = {
+		modelRoles: [],
+		agentModelOverrides: [],
+	};
+	for (const role of new Set([
+		...Object.keys(previousModelRoles),
+		...Object.keys(modelRoles),
+		...explicitModelRoles,
+	])) {
+		const selector = modelRoles[role];
+		const explicit = explicitModelRoles.has(role);
+		if (previousModelRoles[role] === selector && !explicit) continue;
+		if (explicit) {
+			if (selector === undefined) {
+				settings.clearModelRole(role);
+			} else {
+				settings.setModelRole(role, selector);
+			}
+		} else {
+			settings.setModelRoleIfUnchanged(role, previousModelRoles[role], selector);
+		}
+		touched.modelRoles.push(role);
+	}
+	for (const agentName of new Set([
+		...Object.keys(previousAgentModelOverrides),
+		...Object.keys(agentModelOverrides),
+		...explicitAgentModelOverrides,
+	])) {
+		const selector = agentModelOverrides[agentName];
+		const explicit = explicitAgentModelOverrides.has(agentName);
+		if (previousAgentModelOverrides[agentName] === selector && !explicit) continue;
+		if (explicit) {
+			if (selector === undefined) {
+				settings.clearAgentModelOverride(agentName);
+			} else {
+				settings.setAgentModelOverride(agentName, selector);
+			}
+		} else {
+			settings.setAgentModelOverrideIfUnchanged(agentName, previousAgentModelOverrides[agentName], selector);
+		}
+		touched.agentModelOverrides.push(agentName);
+	}
+	return touched;
+}
+
+function clearActiveModelProfileRuntimeState(session: object): void {
+	activeModelProfileRuntimeStates.delete(session);
+}
+
 type ModelProfileActivationSession = Pick<AgentSession, "model" | "thinkingLevel" | "sessionId"> & {
 	setModelTemporary?: AgentSession["setModelTemporary"];
 	setActiveModelProfile?: (name: string | undefined) => void;
@@ -27,20 +149,76 @@ type ModelProfileActivationSession = Pick<AgentSession, "model" | "thinkingLevel
 	recordResumeDefaultModel?: (selector: string) => void;
 };
 
+function cloneActiveModelProfileRuntimeState(
+	state: ActiveModelProfileRuntimeState | undefined,
+): ActiveModelProfileRuntimeState | undefined {
+	if (!state) return undefined;
+	return {
+		...state,
+		baselineModelRoles: { ...state.baselineModelRoles },
+		baselineAgentModelOverrides: { ...state.baselineAgentModelOverrides },
+		persistableBaselineModelRoles: { ...state.persistableBaselineModelRoles },
+		persistableBaselineAgentModelOverrides: { ...state.persistableBaselineAgentModelOverrides },
+		appliedModelRoles: { ...state.appliedModelRoles },
+		appliedAgentModelOverrides: { ...state.appliedAgentModelOverrides },
+	};
+}
+
+export function createActiveModelProfileRuntimeRollback(session: ModelProfileActivationSession): () => void {
+	const activeProfile = session.getActiveModelProfile?.();
+	const runtimeState = cloneActiveModelProfileRuntimeState(activeModelProfileRuntimeStates.get(session));
+	let active = true;
+	return () => {
+		if (!active) return;
+		active = false;
+		session.setActiveModelProfile?.(activeProfile);
+		if (runtimeState) {
+			activeModelProfileRuntimeStates.set(session, runtimeState);
+		} else {
+			activeModelProfileRuntimeStates.delete(session);
+		}
+	};
+}
+
+type ModelProfileActivationRegistry = Pick<
+	ModelRegistry,
+	| "getModelProfile"
+	| "getModelProfiles"
+	| "getAvailableModelProfileNames"
+	| "getApiKeyForProvider"
+	| "getAll"
+	| "resolveCanonicalModel"
+	| "getCanonicalVariants"
+	| "getCanonicalId"
+> &
+	Partial<Pick<ModelRegistry, "getModelProfileForReference">>;
+
+function getModelProfileForReference(
+	modelRegistry: Pick<ModelRegistry, "getModelProfile"> & Partial<Pick<ModelRegistry, "getModelProfileForReference">>,
+	profileName: string,
+): ModelProfileDefinition | undefined {
+	return modelRegistry.getModelProfileForReference?.(profileName) ?? modelRegistry.getModelProfile(profileName);
+}
+
 export interface PrepareModelProfileActivationOptions {
 	session: ModelProfileActivationSession;
-	modelRegistry: Pick<
-		ModelRegistry,
-		| "getModelProfile"
-		| "getModelProfiles"
-		| "getAvailableModelProfileNames"
-		| "getApiKeyForProvider"
-		| "getAll"
-		| "resolveCanonicalModel"
-		| "getCanonicalVariants"
-		| "getCanonicalId"
-	>;
-	settings: Pick<Settings, "get">;
+	modelRegistry: ModelProfileActivationRegistry;
+	settings: Pick<
+		Settings,
+		| "clearGlobal"
+		| "clearOverride"
+		| "flushOrThrow"
+		| "flush"
+		| "get"
+		| "getGlobal"
+		| "getRuntimeOverride"
+		| "getWithoutProject"
+		| "override"
+		| "set"
+		| "getPendingModelProfileDefaultMutationId"
+		| "setModelProfileDefaultIfUnchanged"
+	> &
+		ModelAssignmentPersistenceSettings;
 	profileName: string;
 }
 export interface ApplyModelProfileActivationOptions {
@@ -50,15 +228,44 @@ export interface ApplyModelProfileActivationOptions {
 export interface PreparedModelProfileActivation {
 	profileName: string;
 	session: ModelProfileActivationSession & { setModelTemporary: AgentSession["setModelTemporary"] };
-	settings: Pick<Settings, "clearOverride" | "get" | "getGlobal" | "override" | "set" | "flush">;
+	settings: Pick<
+		Settings,
+		| "clearGlobal"
+		| "clearOverride"
+		| "flush"
+		| "flushOrThrow"
+		| "get"
+		| "getGlobal"
+		| "getRuntimeOverride"
+		| "override"
+		| "set"
+		| "getPendingModelProfileDefaultMutationId"
+		| "setModelProfileDefaultIfUnchanged"
+	> &
+		ModelAssignmentPersistenceSettings;
 	previousModel: Model<Api> | undefined;
 	previousThinkingLevel: ThinkingLevel | undefined;
 	previousAgentModelOverrides: Record<string, string>;
 	previousModelRoles: Record<string, string>;
+	previousRuntimeAgentModelOverrides: Record<string, string>;
+	previousRuntimeModelRoles: Record<string, string>;
+	baselineModel: Model<Api> | undefined;
+	baselineThinkingLevel: ThinkingLevel | undefined;
+	baselineAgentModelOverrides: Record<string, string>;
+	baselineModelRoles: Record<string, string>;
 	defaultModel: Model<Api> | undefined;
 	defaultThinkingLevel: ThinkingLevel | undefined;
+	persistedDefaultThinkingLevel: ThinkingLevel | undefined;
+	baselineSessionDefaultModel: string | undefined;
+	persistableBaselineThinkingLevel: ThinkingLevel | undefined;
+	profileDefaultSelector: string | undefined;
+	profileDefaultHasExplicitThinking: boolean;
+	persistableBaselineAgentModelOverrides: Record<string, string>;
+	persistableBaselineModelRoles: Record<string, string>;
 	modelRoles: Record<string, string>;
 	agentModelOverrides: Record<string, string>;
+	previousPersistedModelProfile: string | undefined;
+	previousPersistedModelProfilePendingMutationId: number | undefined;
 	previousActiveModelProfile: string | undefined;
 	/**
 	 * The session resume default ("provider/id") captured BEFORE activation —
@@ -72,108 +279,189 @@ export interface PreparedModelProfileActivation {
 export interface MaterializeModelProfileAssignmentOptions {
 	session: Pick<
 		ModelProfileActivationSession,
-		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile"
+		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile" | "getSessionDefaultModelSelector"
 	>;
-	settings: Pick<Settings, "clearOverride" | "get" | "override" | "set">;
+	settings: Pick<
+		Settings,
+		| "setModelProfileDefaultIfUnchanged"
+		| "getPendingModelProfileDefaultMutationId"
+		| "clearOverride"
+		| "get"
+		| "getGlobal"
+		| "getRuntimeOverride"
+		| "getWithoutProject"
+		| "override"
+	> &
+		ModelAssignmentPersistenceSettings;
 	role: GjcModelAssignmentTargetId;
-	selector: string;
+	selector: string | undefined;
 }
 
 export interface MaterializeModelProfileAssignmentsOptions {
 	session: Pick<
 		ModelProfileActivationSession,
-		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile"
+		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile" | "getSessionDefaultModelSelector"
 	>;
-	settings: Pick<Settings, "clearOverride" | "get" | "override" | "set">;
-	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string> | Partial<Record<GjcModelAssignmentTargetId, string>>;
+	settings: Pick<
+		Settings,
+		| "setModelProfileDefaultIfUnchanged"
+		| "getPendingModelProfileDefaultMutationId"
+		| "clearOverride"
+		| "get"
+		| "getGlobal"
+		| "getRuntimeOverride"
+		| "getWithoutProject"
+		| "override"
+	> &
+		ModelAssignmentPersistenceSettings;
+	assignments:
+		| ReadonlyMap<GjcModelAssignmentTargetId, string | undefined>
+		| Partial<Record<GjcModelAssignmentTargetId, string | undefined>>;
 }
 
 function isReadonlyAssignmentMap(
-	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string> | Partial<Record<GjcModelAssignmentTargetId, string>>,
-): assignments is ReadonlyMap<GjcModelAssignmentTargetId, string> {
+	assignments:
+		| ReadonlyMap<GjcModelAssignmentTargetId, string | undefined>
+		| Partial<Record<GjcModelAssignmentTargetId, string | undefined>>,
+): assignments is ReadonlyMap<GjcModelAssignmentTargetId, string | undefined> {
 	return typeof (assignments as { entries?: unknown }).entries === "function";
 }
 
 function getMaterializedAssignments(
-	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string> | Partial<Record<GjcModelAssignmentTargetId, string>>,
-): Array<[GjcModelAssignmentTargetId, string]> {
+	assignments:
+		| ReadonlyMap<GjcModelAssignmentTargetId, string | undefined>
+		| Partial<Record<GjcModelAssignmentTargetId, string | undefined>>,
+): Array<[GjcModelAssignmentTargetId, string | undefined]> {
 	if (isReadonlyAssignmentMap(assignments)) return [...assignments.entries()];
-	const assignmentRecord: Partial<Record<GjcModelAssignmentTargetId, string>> = assignments;
-	const result: Array<[GjcModelAssignmentTargetId, string]> = [];
-	for (const role of Object.keys(assignmentRecord) as GjcModelAssignmentTargetId[]) {
-		const selector = assignmentRecord[role];
-		if (selector !== undefined) result.push([role, selector]);
-	}
-	return result;
+	const assignmentRecord: Partial<Record<GjcModelAssignmentTargetId, string | undefined>> = assignments;
+	return (Object.keys(assignmentRecord) as GjcModelAssignmentTargetId[]).map(role => [role, assignmentRecord[role]]);
 }
 
 export function materializeActiveModelProfileAssignment(options: MaterializeModelProfileAssignmentOptions): boolean {
-	const activeProfile = options.session.getActiveModelProfile?.() ?? options.settings.get("modelProfile.default");
-	if (!activeProfile) return false;
-
-	const nextModelRoles = { ...options.settings.get("modelRoles") };
-	const nextAgentModelOverrides = { ...options.settings.get("task.agentModelOverrides") };
-	const target = GJC_MODEL_ASSIGNMENT_TARGETS[options.role];
-
-	if (options.role === "default") {
-		nextModelRoles.default = options.selector;
-	} else if (!nextModelRoles.default && options.session.model) {
-		nextModelRoles.default = formatModelSelectorValue(
-			`${options.session.model.provider}/${options.session.model.id}`,
-			options.session.thinkingLevel,
-		);
-	}
-
-	if (target.settingsPath === "modelRoles") {
-		nextModelRoles[options.role] = options.selector;
-	} else {
-		nextAgentModelOverrides[options.role] = options.selector;
-	}
-
-	options.settings.set("modelRoles", nextModelRoles);
-	options.settings.set("task.agentModelOverrides", nextAgentModelOverrides);
-	options.settings.set("modelProfile.default", undefined);
-	options.settings.clearOverride("modelProfile.default");
-	options.settings.override("modelRoles", nextModelRoles);
-	options.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
-	options.session.setActiveModelProfile?.(undefined);
-	return true;
+	return materializeActiveModelProfileAssignments({
+		session: options.session,
+		settings: options.settings,
+		assignments: { [options.role]: options.selector },
+	});
 }
 
 export function materializeActiveModelProfileAssignments(options: MaterializeModelProfileAssignmentsOptions): boolean {
-	const activeProfile = options.session.getActiveModelProfile?.() ?? options.settings.get("modelProfile.default");
+	const activeProfile = options.session.getActiveModelProfile
+		? options.session.getActiveModelProfile()
+		: options.settings.get("modelProfile.default");
 	if (!activeProfile) return false;
 
 	const materializedAssignments = getMaterializedAssignments(options.assignments);
 	if (materializedAssignments.length === 0) return true;
+	const previousPersistedModelRoles = {
+		...(options.settings.getGlobal("modelRoles") ?? {}),
+	};
+	const previousPersistedAgentModelOverrides = {
+		...(options.settings.getGlobal("task.agentModelOverrides") ?? {}),
+	};
+	const runtimeState = activeModelProfileRuntimeStates.get(options.session);
+	const previousPersistedModelProfile = runtimeState ? runtimeState.persistedModelProfile : activeProfile;
+	const previousPersistedModelProfilePendingMutationId = runtimeState
+		? runtimeState.persistedModelProfilePendingMutationId
+		: options.settings.getPendingModelProfileDefaultMutationId();
+	const currentPersistableModelRoles = {
+		...options.settings.getWithoutProject("modelRoles"),
+	};
+	const currentPersistableAgentModelOverrides = {
+		...options.settings.getWithoutProject("task.agentModelOverrides"),
+	};
+	const persistedModelRoles = runtimeState
+		? deriveProfileBaseline(
+				runtimeState.persistableBaselineModelRoles,
+				currentPersistableModelRoles,
+				runtimeState.appliedModelRoles,
+			)
+		: currentPersistableModelRoles;
+	const persistedAgentModelOverrides = runtimeState
+		? deriveProfileBaseline(
+				runtimeState.persistableBaselineAgentModelOverrides,
+				currentPersistableAgentModelOverrides,
+				runtimeState.appliedAgentModelOverrides,
+			)
+		: currentPersistableAgentModelOverrides;
+	const currentRuntimeModelRoles = {
+		...(options.settings.getRuntimeOverride("modelRoles") ?? {}),
+	};
+	const currentRuntimeAgentModelOverrides = {
+		...(options.settings.getRuntimeOverride("task.agentModelOverrides") ?? {}),
+	};
+	const runtimeModelRoles = runtimeState
+		? deriveProfileBaseline(runtimeState.baselineModelRoles, currentRuntimeModelRoles, runtimeState.appliedModelRoles)
+		: currentRuntimeModelRoles;
+	const runtimeAgentModelOverrides = runtimeState
+		? deriveProfileBaseline(
+				runtimeState.baselineAgentModelOverrides,
+				currentRuntimeAgentModelOverrides,
+				runtimeState.appliedAgentModelOverrides,
+			)
+		: currentRuntimeAgentModelOverrides;
 
-	const nextModelRoles = { ...options.settings.get("modelRoles") };
-	const nextAgentModelOverrides = { ...options.settings.get("task.agentModelOverrides") };
-	const includesDefault = materializedAssignments.some(([role]) => role === "default");
-
-	if (!includesDefault && !nextModelRoles.default && options.session.model) {
-		nextModelRoles.default = formatModelSelectorValue(
-			`${options.session.model.provider}/${options.session.model.id}`,
-			options.session.thinkingLevel,
+	if (runtimeState) {
+		mergeAppliedProfileAssignments(persistedModelRoles, currentPersistableModelRoles, runtimeState.appliedModelRoles);
+		mergeAppliedProfileAssignments(
+			persistedAgentModelOverrides,
+			currentPersistableAgentModelOverrides,
+			runtimeState.appliedAgentModelOverrides,
 		);
 	}
+	const authoritativeDefaultSelector =
+		runtimeState?.defaultSelector ??
+		persistedModelRoles.default ??
+		options.session.getSessionDefaultModelSelector?.();
+	if (authoritativeDefaultSelector) {
+		persistedModelRoles.default = authoritativeDefaultSelector;
+	}
 
+	const explicitModelRoles = new Set<string>();
+	const explicitAgentModelOverrides = new Set<string>();
 	for (const [role, selector] of materializedAssignments) {
 		const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+		const persisted = target.settingsPath === "modelRoles" ? persistedModelRoles : persistedAgentModelOverrides;
+		const runtime = target.settingsPath === "modelRoles" ? runtimeModelRoles : runtimeAgentModelOverrides;
 		if (target.settingsPath === "modelRoles") {
-			nextModelRoles[role] = selector;
+			explicitModelRoles.add(role);
 		} else {
-			nextAgentModelOverrides[role] = selector;
+			explicitAgentModelOverrides.add(role);
+		}
+		if (selector === undefined) {
+			delete persisted[role];
+			delete runtime[role];
+		} else {
+			persisted[role] = selector;
+			runtime[role] = selector;
 		}
 	}
 
-	options.settings.set("modelRoles", nextModelRoles);
-	options.settings.set("task.agentModelOverrides", nextAgentModelOverrides);
-	options.settings.set("modelProfile.default", undefined);
-	options.settings.clearOverride("modelProfile.default");
-	options.settings.override("modelRoles", nextModelRoles);
-	options.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
 	options.session.setActiveModelProfile?.(undefined);
+	const touched = persistModelAssignmentEntries(
+		options.settings,
+		persistedModelRoles,
+		persistedAgentModelOverrides,
+		previousPersistedModelRoles,
+		previousPersistedAgentModelOverrides,
+		explicitModelRoles,
+		explicitAgentModelOverrides,
+	);
+	for (const role of touched.modelRoles) {
+		if (!explicitModelRoles.has(role)) delete runtimeModelRoles[role];
+	}
+	for (const agentName of touched.agentModelOverrides) {
+		if (!explicitAgentModelOverrides.has(agentName)) delete runtimeAgentModelOverrides[agentName];
+	}
+	options.settings.setModelProfileDefaultIfUnchanged(
+		previousPersistedModelProfile,
+		undefined,
+		previousPersistedModelProfilePendingMutationId,
+	);
+	options.settings.clearOverride("modelProfile.default");
+	options.settings.override("modelRoles", runtimeModelRoles);
+	options.settings.override("task.agentModelOverrides", runtimeAgentModelOverrides);
+	clearActiveModelProfileRuntimeState(options.session);
 	return true;
 }
 
@@ -187,6 +475,29 @@ function resolveModelProfileName(profileName: string, profiles: ReadonlyMap<stri
 	if (profiles.has(profileName)) return profileName;
 	const replacement = LEGACY_MODEL_PROFILE_ALIASES.get(profileName);
 	return replacement && profiles.has(replacement) ? replacement : profileName;
+}
+
+export interface ProjectModelProfileShadow {
+	profileName: string;
+	targetIds: GjcModelAssignmentTargetId[];
+}
+
+export function resolveProjectModelProfileShadow(
+	settings: Pick<Settings, "getProject">,
+	modelRegistry: Pick<ModelRegistry, "getModelProfile" | "getModelProfiles"> &
+		Partial<Pick<ModelRegistry, "getModelProfileForReference">>,
+): ProjectModelProfileShadow | undefined {
+	const configuredName = settings.getProject("modelProfile.default");
+	if (!configuredName) return undefined;
+	const profiles = modelRegistry.getModelProfiles();
+	const exactProfile = getModelProfileForReference(modelRegistry, configuredName);
+	const profileName = exactProfile ? configuredName : resolveModelProfileName(configuredName, profiles);
+	const profile = exactProfile ?? profiles.get(profileName) ?? getModelProfileForReference(modelRegistry, profileName);
+	if (!profile) return undefined;
+	const targetIds = Object.keys(profile.modelMapping).filter((targetId): targetId is GjcModelAssignmentTargetId =>
+		Object.hasOwn(GJC_MODEL_ASSIGNMENT_TARGETS, targetId),
+	);
+	return { profileName, targetIds };
 }
 
 /**
@@ -246,8 +557,10 @@ export async function prepareModelProfileActivation(
 	options: PrepareModelProfileActivationOptions,
 ): Promise<PreparedModelProfileActivation> {
 	const profiles = options.modelRegistry.getModelProfiles();
-	const profileName = resolveModelProfileName(options.profileName, profiles);
-	const profile = profiles.get(profileName) ?? options.modelRegistry.getModelProfile(profileName);
+	const exactProfile = getModelProfileForReference(options.modelRegistry, options.profileName);
+	const profileName = exactProfile ? options.profileName : resolveModelProfileName(options.profileName, profiles);
+	const profile =
+		exactProfile ?? profiles.get(profileName) ?? getModelProfileForReference(options.modelRegistry, profileName);
 	if (!profile) {
 		const available = formatAvailableProfileNames(profiles);
 		throw new Error(`Unknown model profile "${options.profileName}". Available profiles: ${available}`);
@@ -329,19 +642,113 @@ export async function prepareModelProfileActivation(
 		agentModelOverrides[role] = formatClampedModelSelector(selector, resolved.model);
 	}
 
+	const previousActiveModelProfile = options.session.getActiveModelProfile?.();
+	const previousPersistedModelProfile = options.settings.getGlobal("modelProfile.default");
+	const previousPersistedModelProfilePendingMutationId = options.settings.getPendingModelProfileDefaultMutationId();
+	const previousRuntimeState = previousActiveModelProfile
+		? activeModelProfileRuntimeStates.get(options.session)
+		: undefined;
+	const previousModelRoles = { ...options.settings.get("modelRoles") };
+	const previousAgentModelOverrides = {
+		...options.settings.get("task.agentModelOverrides"),
+	};
+	const previousRuntimeModelRoles = { ...(options.settings.getRuntimeOverride("modelRoles") ?? {}) };
+	const previousRuntimeAgentModelOverrides = {
+		...(options.settings.getRuntimeOverride("task.agentModelOverrides") ?? {}),
+	};
+	const currentPersistableModelRoles = {
+		...options.settings.getWithoutProject("modelRoles"),
+	};
+	const currentPersistableAgentModelOverrides = {
+		...options.settings.getWithoutProject("task.agentModelOverrides"),
+	};
+	const persistableBaselineModelRoles = previousRuntimeState
+		? deriveProfileBaseline(
+				previousRuntimeState.persistableBaselineModelRoles,
+				currentPersistableModelRoles,
+				previousRuntimeState.appliedModelRoles,
+			)
+		: currentPersistableModelRoles;
+	const persistableBaselineAgentModelOverrides = previousRuntimeState
+		? deriveProfileBaseline(
+				previousRuntimeState.persistableBaselineAgentModelOverrides,
+				currentPersistableAgentModelOverrides,
+				previousRuntimeState.appliedAgentModelOverrides,
+			)
+		: currentPersistableAgentModelOverrides;
+	const baselineModelRoles = previousRuntimeState
+		? deriveProfileBaseline(
+				previousRuntimeState.baselineModelRoles,
+				previousRuntimeModelRoles,
+				previousRuntimeState.appliedModelRoles,
+			)
+		: previousRuntimeModelRoles;
+	const baselineAgentModelOverrides = previousRuntimeState
+		? deriveProfileBaseline(
+				previousRuntimeState.baselineAgentModelOverrides,
+				previousRuntimeAgentModelOverrides,
+				previousRuntimeState.appliedAgentModelOverrides,
+			)
+		: previousRuntimeAgentModelOverrides;
+	const baselineModel = previousRuntimeState?.baselineModel ?? options.session.model;
+	const baselineThinkingLevel = previousRuntimeState?.baselineThinkingLevel ?? options.session.thinkingLevel;
+	const baselineSessionDefaultModel =
+		previousRuntimeState?.baselineSessionDefaultModel ?? options.session.getSessionDefaultModelSelector?.();
+	const persistableBaselineThinkingLevel =
+		previousRuntimeState?.persistableBaselineThinkingLevel ??
+		options.settings.getWithoutProject("defaultThinkingLevel");
+	const profileInheritsDefaultThinking =
+		resolvedDefault !== undefined &&
+		(!resolvedDefault.explicitThinkingLevel || resolvedDefault.thinkingLevel === ThinkingLevel.Inherit);
+	const resolvedDefaultThinkingLevel = profileInheritsDefaultThinking
+		? options.settings.get("defaultThinkingLevel")
+		: resolvedDefault?.thinkingLevel;
+	const persistedDefaultThinkingLevel = resolvedDefault
+		? profileInheritsDefaultThinking
+			? persistableBaselineThinkingLevel
+			: resolvedDefault.thinkingLevel
+		: previousRuntimeState
+			? persistableBaselineThinkingLevel
+			: undefined;
+	const profileDefaultSelector = resolvedDefault?.model
+		? formatModelSelectorValue(
+				`${resolvedDefault.model.provider}/${resolvedDefault.model.id}`,
+				resolvedDefault.thinkingLevel,
+			)
+		: undefined;
+	const profileDefaultHasExplicitThinking =
+		resolvedDefault?.explicitThinkingLevel === true &&
+		resolvedDefault.thinkingLevel !== undefined &&
+		resolvedDefault.thinkingLevel !== ThinkingLevel.Inherit;
+
 	return {
 		profileName,
 		session: options.session as PreparedModelProfileActivation["session"],
 		settings: options.settings as PreparedModelProfileActivation["settings"],
 		previousModel: options.session.model,
 		previousThinkingLevel: options.session.thinkingLevel,
-		previousAgentModelOverrides: { ...options.settings.get("task.agentModelOverrides") },
-		previousModelRoles: { ...options.settings.get("modelRoles") },
-		defaultModel: resolvedDefault?.model,
-		defaultThinkingLevel: resolvedDefault?.thinkingLevel,
+		previousAgentModelOverrides,
+		previousModelRoles,
+		previousRuntimeAgentModelOverrides,
+		previousRuntimeModelRoles,
+		baselineModel,
+		baselineThinkingLevel,
+		baselineAgentModelOverrides,
+		baselineModelRoles,
+		defaultModel: resolvedDefault?.model ?? (previousRuntimeState ? baselineModel : undefined),
+		defaultThinkingLevel: resolvedDefaultThinkingLevel ?? (previousRuntimeState ? baselineThinkingLevel : undefined),
+		persistedDefaultThinkingLevel,
+		baselineSessionDefaultModel,
+		persistableBaselineThinkingLevel,
+		profileDefaultSelector,
+		profileDefaultHasExplicitThinking,
+		persistableBaselineAgentModelOverrides,
+		persistableBaselineModelRoles,
 		modelRoles,
 		agentModelOverrides,
-		previousActiveModelProfile: options.session.getActiveModelProfile?.(),
+		previousPersistedModelProfile,
+		previousPersistedModelProfilePendingMutationId,
+		previousActiveModelProfile,
 		previousSessionDefaultModel: options.session.getSessionDefaultModelSelector?.(),
 	};
 }
@@ -352,112 +759,214 @@ export async function applyPreparedModelProfileActivation(
 ): Promise<void> {
 	const previousModel = prepared.previousModel;
 	const previousThinkingLevel = prepared.previousThinkingLevel;
-	const previousAgentModelOverrides = prepared.previousAgentModelOverrides;
-	const previousModelRoles = prepared.previousModelRoles;
-	const previousPersistedDefault = prepared.settings.get("modelProfile.default");
-	const previousDefaultThinkingLevel = prepared.settings.get("defaultThinkingLevel");
+	const previousAgentModelOverrides = prepared.previousRuntimeAgentModelOverrides;
+	const previousModelRoles = prepared.previousRuntimeModelRoles;
 	const previousActiveModelProfile = prepared.previousActiveModelProfile;
 	const previousSessionDefaultModel = prepared.previousSessionDefaultModel;
-	let modelChanged = false;
-	let overridesChanged = false;
-	let defaultChanged = false;
-	let modelRolesChanged = false;
-	let defaultThinkingChanged = false;
+	let modelTransitionStarted = false;
+	let persistenceStarted = false;
+	const effectiveDefaultThinkingLevel = options.thinkingLevelOverride ?? prepared.defaultThinkingLevel;
+	const persistedDefaultThinkingLevel = options.thinkingLevelOverride ?? prepared.persistedDefaultThinkingLevel;
+	const materializedDefaultSelector = prepared.profileDefaultSelector
+		? options.thinkingLevelOverride !== undefined &&
+			prepared.profileDefaultHasExplicitThinking &&
+			prepared.defaultModel
+			? formatModelSelectorValue(
+					`${prepared.defaultModel.provider}/${prepared.defaultModel.id}`,
+					effectiveDefaultThinkingLevel,
+				)
+			: prepared.profileDefaultSelector
+		: (prepared.persistableBaselineModelRoles.default ?? prepared.baselineSessionDefaultModel);
 
 	try {
 		if (prepared.defaultModel) {
-			await prepared.session.setModelTemporary(
-				prepared.defaultModel,
-				options.thinkingLevelOverride ?? prepared.defaultThinkingLevel,
-				{
-					persistAsSessionDefault: true,
-				},
-			);
-			modelChanged = true;
+			modelTransitionStarted = true;
+			await prepared.session.setModelTemporary(prepared.defaultModel, effectiveDefaultThinkingLevel, {
+				persistAsSessionDefault: prepared.profileDefaultSelector !== undefined,
+			});
+			if (!prepared.profileDefaultSelector && prepared.baselineSessionDefaultModel) {
+				prepared.session.recordResumeDefaultModel?.(prepared.baselineSessionDefaultModel);
+			}
 		}
-		if (Object.keys(prepared.modelRoles).length > 0) {
-			prepared.settings.override("modelRoles", { ...previousModelRoles, ...prepared.modelRoles });
-			modelRolesChanged = true;
+		if (prepared.previousActiveModelProfile || Object.keys(prepared.modelRoles).length > 0) {
+			prepared.settings.override("modelRoles", {
+				...prepared.baselineModelRoles,
+				...prepared.modelRoles,
+			});
 		}
-		if (Object.keys(prepared.agentModelOverrides).length > 0) {
+		if (prepared.previousActiveModelProfile || Object.keys(prepared.agentModelOverrides).length > 0) {
 			prepared.settings.override("task.agentModelOverrides", {
-				...previousAgentModelOverrides,
+				...prepared.baselineAgentModelOverrides,
 				...prepared.agentModelOverrides,
 			});
-			overridesChanged = true;
 		}
 		if (options.persistDefault) {
-			prepared.settings.set("modelRoles", {});
-			prepared.settings.set("task.agentModelOverrides", {});
-			if (prepared.defaultThinkingLevel !== undefined && prepared.defaultThinkingLevel !== ThinkingLevel.Inherit) {
-				prepared.settings.set("defaultThinkingLevel", prepared.defaultThinkingLevel);
-				defaultThinkingChanged = true;
+			persistenceStarted = true;
+			if (
+				prepared.defaultModel &&
+				persistedDefaultThinkingLevel !== undefined &&
+				persistedDefaultThinkingLevel !== ThinkingLevel.Inherit
+			) {
+				prepared.settings.set("defaultThinkingLevel", persistedDefaultThinkingLevel);
+			} else if (prepared.defaultModel) {
+				prepared.settings.clearGlobal("defaultThinkingLevel");
 			}
 			prepared.settings.set("modelProfile.default", prepared.profileName);
-			defaultChanged = true;
-			await prepared.settings.flush();
+			await prepared.settings.flushOrThrow();
 		}
 		prepared.session.setActiveModelProfile?.(prepared.profileName);
+		activeModelProfileRuntimeStates.set(prepared.session, {
+			baselineModel: prepared.baselineModel,
+			baselineThinkingLevel: prepared.baselineThinkingLevel,
+			baselineSessionDefaultModel: prepared.baselineSessionDefaultModel,
+			persistedModelProfile: options.persistDefault ? prepared.profileName : prepared.previousPersistedModelProfile,
+			persistedModelProfilePendingMutationId: options.persistDefault
+				? undefined
+				: prepared.previousPersistedModelProfilePendingMutationId,
+			persistableBaselineThinkingLevel: prepared.persistableBaselineThinkingLevel,
+			baselineModelRoles: { ...prepared.baselineModelRoles },
+			baselineAgentModelOverrides: { ...prepared.baselineAgentModelOverrides },
+			persistableBaselineModelRoles: { ...prepared.persistableBaselineModelRoles },
+			persistableBaselineAgentModelOverrides: {
+				...prepared.persistableBaselineAgentModelOverrides,
+			},
+			appliedModelRoles: { ...prepared.modelRoles },
+			appliedAgentModelOverrides: { ...prepared.agentModelOverrides },
+			defaultSelector: materializedDefaultSelector,
+		});
 	} catch (error) {
-		if (defaultChanged) {
-			prepared.settings.set("modelProfile.default", previousPersistedDefault);
-			prepared.settings.set("modelRoles", previousModelRoles);
-			prepared.settings.set("task.agentModelOverrides", previousAgentModelOverrides);
-			if (defaultThinkingChanged) {
-				prepared.settings.set("defaultThinkingLevel", previousDefaultThinkingLevel);
+		const rollbackErrors: unknown[] = [];
+		const rollbackModelRoles = persistenceStarted ? prepared.baselineModelRoles : previousModelRoles;
+		const rollbackAgentModelOverrides = persistenceStarted
+			? prepared.baselineAgentModelOverrides
+			: previousAgentModelOverrides;
+		const rollbackModel = persistenceStarted ? prepared.baselineModel : previousModel;
+		const rollbackThinkingLevel = persistenceStarted ? prepared.baselineThinkingLevel : previousThinkingLevel;
+		try {
+			prepared.settings.override("modelRoles", rollbackModelRoles);
+		} catch (rollbackError) {
+			rollbackErrors.push(rollbackError);
+		}
+		try {
+			prepared.settings.override("task.agentModelOverrides", rollbackAgentModelOverrides);
+		} catch (rollbackError) {
+			rollbackErrors.push(rollbackError);
+		}
+		try {
+			if (persistenceStarted) {
+				prepared.session.setActiveModelProfile?.(undefined);
+				clearActiveModelProfileRuntimeState(prepared.session);
+			} else {
+				prepared.session.setActiveModelProfile?.(previousActiveModelProfile);
 			}
+		} catch (rollbackError) {
+			rollbackErrors.push(rollbackError);
 		}
-		if (modelRolesChanged) {
-			prepared.settings.override("modelRoles", previousModelRoles);
-		}
-		if (overridesChanged) {
-			prepared.settings.override("task.agentModelOverrides", previousAgentModelOverrides);
-		}
-		prepared.session.setActiveModelProfile?.(previousActiveModelProfile);
-		if (modelChanged) {
-			// Runtime rolls back to the pre-activation live model. That model may
-			// itself be a transient retry/fallback/context-promotion/plan switch,
-			// so it is recorded as role:"temporary" (NOT the resume default) to
-			// preserve the issue #849 protection.
-			if (previousModel) {
-				await prepared.session.setModelTemporary(previousModel, previousThinkingLevel);
+		if (modelTransitionStarted) {
+			// Ambiguous persistence detaches to the pre-profile baseline; failures
+			// before persistence restore the immediately previous live model.
+			if (rollbackModel) {
+				try {
+					await prepared.session.setModelTemporary(rollbackModel, rollbackThinkingLevel);
+				} catch (rollbackError) {
+					rollbackErrors.push(rollbackError);
+				}
 			}
-			// The happy path already appended the profile main model as the resume
-			// default (role:"default"). Re-assert the pre-activation resume default
-			// so a failed activation does not poison future resume. Fall back to the
-			// live model only when there was no explicit pre-activation default
-			// (nothing to protect). Append-only — never touches the runtime model.
+			// Re-assert the resume default matching the runtime state restored above.
 			const restoreDefaultSelector =
-				previousSessionDefaultModel ??
-				(previousModel ? `${previousModel.provider}/${previousModel.id}` : undefined);
+				(persistenceStarted ? prepared.baselineSessionDefaultModel : previousSessionDefaultModel) ??
+				(rollbackModel ? `${rollbackModel.provider}/${rollbackModel.id}` : undefined);
 			if (restoreDefaultSelector) {
-				prepared.session.recordResumeDefaultModel?.(restoreDefaultSelector);
+				try {
+					prepared.session.recordResumeDefaultModel?.(restoreDefaultSelector);
+				} catch (rollbackError) {
+					rollbackErrors.push(rollbackError);
+				}
 			}
+		}
+		if (rollbackErrors.length > 0) {
+			const activationMessage = error instanceof Error ? error.message : String(error);
+			throw new AggregateError(
+				[error, ...rollbackErrors],
+				`Model profile activation failed (${activationMessage}) and rollback also failed`,
+			);
 		}
 		throw error;
 	}
 }
 
 export interface MaterializeModelProfileForDeletionResult {
+	materializedProfileName: string;
 	modelRoles: Record<string, string>;
 	agentModelOverrides: Record<string, string>;
-	previousModelRoles: Record<string, string>;
-	previousAgentModelOverrides: Record<string, string>;
-	previousDefaultProfile: string | undefined;
+	previousPersistedModelRoles: Record<string, string>;
+	previousPersistedAgentModelOverrides: Record<string, string>;
 	previousPersistedDefaultProfile: string | undefined;
+	previousRuntimeModelRoles: Record<string, string>;
+	previousRuntimeAgentModelOverrides: Record<string, string>;
+	previousRuntimeDefaultProfile: string | undefined;
 	previousActiveModelProfile: string | undefined;
+}
+
+type ModelProfileDeletionSettings = Pick<
+	Settings,
+	| "clearOverride"
+	| "flushOrThrow"
+	| "getGlobal"
+	| "getRuntimeOverride"
+	| "override"
+	| "setModelProfileDefaultIfUnchanged"
+> &
+	ModelAssignmentPersistenceSettings;
+
+function restoreModelProfileDeletionRuntime(
+	settings: Pick<Settings, "clearOverride" | "override">,
+	snapshot: MaterializeModelProfileForDeletionResult,
+): void {
+	settings.override("modelRoles", snapshot.previousRuntimeModelRoles);
+	settings.override("task.agentModelOverrides", snapshot.previousRuntimeAgentModelOverrides);
+	if (snapshot.previousRuntimeDefaultProfile === undefined) {
+		settings.clearOverride("modelProfile.default");
+	} else {
+		settings.override("modelProfile.default", snapshot.previousRuntimeDefaultProfile);
+	}
+}
+
+function stageModelProfileDeletionRollback(
+	settings: ModelProfileDeletionSettings,
+	snapshot: MaterializeModelProfileForDeletionResult,
+): void {
+	const inheritedEntries = new Set<string>();
+	persistModelAssignmentEntries(
+		settings,
+		snapshot.previousPersistedModelRoles,
+		snapshot.previousPersistedAgentModelOverrides,
+		snapshot.modelRoles,
+		snapshot.agentModelOverrides,
+		inheritedEntries,
+		inheritedEntries,
+	);
+	if (snapshot.previousPersistedDefaultProfile === snapshot.materializedProfileName) {
+		settings.setModelProfileDefaultIfUnchanged(undefined, snapshot.previousPersistedDefaultProfile);
+	}
 }
 
 export async function materializeModelProfileForDeletion(
 	options: PrepareModelProfileActivationOptions & {
-		settings: Pick<Settings, "clearOverride" | "flush" | "get" | "getGlobal" | "override" | "set">;
+		settings: ModelProfileDeletionSettings;
 	},
 ): Promise<MaterializeModelProfileForDeletionResult> {
 	const prepared = await prepareModelProfileActivation(options);
-	const previousDefaultProfile = prepared.settings.get("modelProfile.default");
+	const previousPersistedModelRoles = {
+		...(prepared.settings.getGlobal("modelRoles") ?? {}),
+	};
+	const previousPersistedAgentModelOverrides = {
+		...(prepared.settings.getGlobal("task.agentModelOverrides") ?? {}),
+	};
 	const previousPersistedDefaultProfile = prepared.settings.getGlobal("modelProfile.default");
+	const previousRuntimeDefaultProfile = prepared.settings.getRuntimeOverride("modelProfile.default");
 	const nextModelRoles = {
-		...prepared.previousModelRoles,
+		...prepared.persistableBaselineModelRoles,
 		...(prepared.defaultModel
 			? {
 					default: formatModelSelectorValue(
@@ -469,54 +978,73 @@ export async function materializeModelProfileForDeletion(
 		...prepared.modelRoles,
 	};
 	const nextAgentModelOverrides = {
-		...prepared.previousAgentModelOverrides,
+		...prepared.persistableBaselineAgentModelOverrides,
 		...prepared.agentModelOverrides,
 	};
+	const snapshot: MaterializeModelProfileForDeletionResult = {
+		materializedProfileName: prepared.profileName,
+		modelRoles: nextModelRoles,
+		agentModelOverrides: nextAgentModelOverrides,
+		previousPersistedModelRoles,
+		previousPersistedAgentModelOverrides,
+		previousPersistedDefaultProfile,
+		previousRuntimeModelRoles: prepared.previousRuntimeModelRoles,
+		previousRuntimeAgentModelOverrides: prepared.previousRuntimeAgentModelOverrides,
+		previousRuntimeDefaultProfile,
+		previousActiveModelProfile: prepared.previousActiveModelProfile,
+	};
+	const inheritedEntries = new Set<string>();
 
 	try {
-		prepared.settings.set("modelRoles", nextModelRoles);
-		prepared.settings.set("task.agentModelOverrides", nextAgentModelOverrides);
-		prepared.settings.set("modelProfile.default", undefined);
+		const touched = persistModelAssignmentEntries(
+			prepared.settings,
+			nextModelRoles,
+			nextAgentModelOverrides,
+			previousPersistedModelRoles,
+			previousPersistedAgentModelOverrides,
+			inheritedEntries,
+			inheritedEntries,
+		);
+		if (previousPersistedDefaultProfile === prepared.profileName) {
+			prepared.settings.setModelProfileDefaultIfUnchanged(previousPersistedDefaultProfile, undefined);
+		}
+		const nextRuntimeModelRoles = { ...prepared.previousRuntimeModelRoles };
+		const profileOwnedModelRoles = new Set([
+			...touched.modelRoles,
+			...Object.keys(prepared.modelRoles),
+			...(prepared.profileDefaultSelector ? ["default"] : []),
+		]);
+		for (const role of profileOwnedModelRoles) delete nextRuntimeModelRoles[role];
+		const nextRuntimeAgentModelOverrides = { ...prepared.previousRuntimeAgentModelOverrides };
+		const profileOwnedAgentOverrides = new Set([
+			...touched.agentModelOverrides,
+			...Object.keys(prepared.agentModelOverrides),
+		]);
+		for (const agentName of profileOwnedAgentOverrides) delete nextRuntimeAgentModelOverrides[agentName];
 		prepared.settings.clearOverride("modelProfile.default");
-		prepared.settings.override("modelRoles", nextModelRoles);
-		prepared.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
+		prepared.settings.override("modelRoles", nextRuntimeModelRoles);
+		prepared.settings.override("task.agentModelOverrides", nextRuntimeAgentModelOverrides);
 		prepared.session.setActiveModelProfile?.(undefined);
-		await prepared.settings.flush();
+		await prepared.settings.flushOrThrow();
 	} catch (error) {
-		prepared.settings.set("modelRoles", prepared.previousModelRoles);
-		prepared.settings.set("task.agentModelOverrides", prepared.previousAgentModelOverrides);
-		prepared.settings.set("modelProfile.default", previousPersistedDefaultProfile);
-		prepared.settings.override("modelRoles", prepared.previousModelRoles);
-		prepared.settings.override("task.agentModelOverrides", prepared.previousAgentModelOverrides);
-		prepared.settings.override("modelProfile.default", previousDefaultProfile);
+		stageModelProfileDeletionRollback(prepared.settings, snapshot);
+		restoreModelProfileDeletionRuntime(prepared.settings, snapshot);
 		prepared.session.setActiveModelProfile?.(prepared.previousActiveModelProfile);
 		throw error;
 	}
 
-	return {
-		modelRoles: nextModelRoles,
-		agentModelOverrides: nextAgentModelOverrides,
-		previousModelRoles: prepared.previousModelRoles,
-		previousAgentModelOverrides: prepared.previousAgentModelOverrides,
-		previousDefaultProfile,
-		previousPersistedDefaultProfile,
-		previousActiveModelProfile: prepared.previousActiveModelProfile,
-	};
+	return snapshot;
 }
 
 export async function restoreMaterializedModelProfileForDeletion(options: {
-	settings: Pick<Settings, "flush" | "override" | "set">;
+	settings: ModelProfileDeletionSettings;
 	session: Pick<ModelProfileActivationSession, "setActiveModelProfile">;
 	snapshot: MaterializeModelProfileForDeletionResult;
 }): Promise<void> {
-	options.settings.set("modelRoles", options.snapshot.previousModelRoles);
-	options.settings.set("task.agentModelOverrides", options.snapshot.previousAgentModelOverrides);
-	options.settings.set("modelProfile.default", options.snapshot.previousPersistedDefaultProfile);
-	options.settings.override("modelRoles", options.snapshot.previousModelRoles);
-	options.settings.override("task.agentModelOverrides", options.snapshot.previousAgentModelOverrides);
-	options.settings.override("modelProfile.default", options.snapshot.previousDefaultProfile);
+	stageModelProfileDeletionRollback(options.settings, options.snapshot);
+	restoreModelProfileDeletionRuntime(options.settings, options.snapshot);
 	options.session.setActiveModelProfile?.(options.snapshot.previousActiveModelProfile);
-	await options.settings.flush();
+	await options.settings.flushOrThrow();
 }
 
 export async function activateModelProfile(

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -389,15 +389,8 @@ export function recommendModelProfileForProvider(
 	return recommended ? profiles.get(recommended) : undefined;
 }
 
-export function mergeModelProfiles(userProfiles?: ModelsConfig["profiles"]): Map<string, ModelProfileDefinition> {
+export function mapUserModelProfiles(userProfiles?: ModelsConfig["profiles"]): Map<string, ModelProfileDefinition> {
 	const profiles = new Map<string, ModelProfileDefinition>();
-	for (const definition of BUILTIN_MODEL_PROFILES) {
-		profiles.set(definition.name, {
-			...definition,
-			requiredProviders: [...definition.requiredProviders],
-			modelMapping: { ...definition.modelMapping },
-		});
-	}
 	for (const [name, definition] of Object.entries(userProfiles ?? {})) {
 		const modelMapping = { ...definition.model_mapping };
 		profiles.set(name, {
@@ -407,6 +400,21 @@ export function mergeModelProfiles(userProfiles?: ModelsConfig["profiles"]): Map
 			modelMapping,
 			source: "user",
 		});
+	}
+	return profiles;
+}
+
+export function mergeModelProfiles(userProfiles?: ModelsConfig["profiles"]): Map<string, ModelProfileDefinition> {
+	const profiles = new Map<string, ModelProfileDefinition>();
+	for (const definition of BUILTIN_MODEL_PROFILES) {
+		profiles.set(definition.name, {
+			...definition,
+			requiredProviders: [...definition.requiredProviders],
+			modelMapping: { ...definition.modelMapping },
+		});
+	}
+	for (const [name, definition] of mapUserModelProfiles(userProfiles)) {
+		profiles.set(name, definition);
 	}
 	return profiles;
 }

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1,3 +1,5 @@
+import * as crypto from "node:crypto";
+import * as syncFs from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {
@@ -39,6 +41,7 @@ import { isValidThemeColor, type ThemeColor } from "../modes/theme/theme";
 import type { AuthStorage, OAuthCredential } from "../session/auth-storage";
 import type { ActiveSearchModelContext, WebSearchMode } from "../web/search/types";
 import { type ConfigError, ConfigFile } from "./config-file";
+import { withFileLock } from "./file-lock";
 import {
 	buildCanonicalModelIndex,
 	type CanonicalModelIndex,
@@ -50,6 +53,7 @@ import {
 import {
 	aggregateModelProfileRequiredProviders,
 	type ModelProfileDefinition,
+	mapUserModelProfiles,
 	mergeModelProfiles,
 } from "./model-profiles";
 import {
@@ -86,6 +90,148 @@ export const MODEL_ROLES: Record<ModelRole, ModelRoleInfo> = {
 export const MODEL_ROLE_IDS: ModelRole[] = ["default"];
 export const MODEL_PROFILE_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
 export const MODEL_PROFILE_NAME_PATTERN_DESCRIPTION = "lowercase letters, numbers, dots, underscores, or hyphens";
+
+const ARCHIVED_MODEL_PROFILE_NAMESPACE = "__gjc_archived_profile__";
+const ARCHIVED_MODEL_PROFILE_PREFIX = `${ARCHIVED_MODEL_PROFILE_NAMESPACE}:`;
+const ARCHIVED_MODEL_PROFILE_V1_PREFIX = `${ARCHIVED_MODEL_PROFILE_PREFIX}v1:`;
+const MAX_ARCHIVED_MODEL_PROFILE_BYTES = 64 * 1024;
+const MAX_ARCHIVED_MODEL_PROFILE_BASE64URL_LENGTH = Math.ceil((MAX_ARCHIVED_MODEL_PROFILE_BYTES * 4) / 3);
+
+type ArchivedModelProfileEnvelopeInspection =
+	| { kind: "ordinary" }
+	| { kind: "quarantined"; name?: string; reason: string }
+	| { kind: "valid"; name: string; profile: ModelProfileConfig };
+
+function decodeCanonicalBase64Url(value: string): Buffer | undefined {
+	if (!value || !/^[A-Za-z0-9_-]+$/.test(value)) return undefined;
+	const decoded = Buffer.from(value, "base64url");
+	return decoded.toString("base64url") === value ? decoded : undefined;
+}
+
+function decodeUtf8(value: Buffer): string | undefined {
+	try {
+		return new TextDecoder("utf-8", { fatal: true }).decode(value);
+	} catch {
+		return undefined;
+	}
+}
+
+function encodeArchivedModelProfile(name: string, profile: ModelProfileConfig): string {
+	if (!MODEL_PROFILE_NAME_PATTERN.test(name)) {
+		throw new Error(
+			`Cannot archive custom model profile "${name}": profile ids must use ${MODEL_PROFILE_NAME_PATTERN_DESCRIPTION}.`,
+		);
+	}
+	const checkedProfile = ProfileDefinitionSchema.parse(profile);
+	const profileJson = JSON.stringify(checkedProfile);
+	if (Buffer.byteLength(profileJson, "utf8") > MAX_ARCHIVED_MODEL_PROFILE_BYTES) {
+		throw new Error(
+			`Cannot archive custom model profile "${name}": serialized profile exceeds ${MAX_ARCHIVED_MODEL_PROFILE_BYTES} bytes.`,
+		);
+	}
+	const encodedName = Buffer.from(name, "utf8").toString("base64url");
+	const encodedProfile = Buffer.from(profileJson, "utf8").toString("base64url");
+	return `${ARCHIVED_MODEL_PROFILE_V1_PREFIX}${encodedName}:${encodedProfile}`;
+}
+
+function inspectArchivedModelProfile(value: string): ArchivedModelProfileEnvelopeInspection {
+	if (!value.startsWith(ARCHIVED_MODEL_PROFILE_PREFIX)) return { kind: "ordinary" };
+
+	const parts = value.split(":");
+	if (parts.length !== 4 || parts[0] !== ARCHIVED_MODEL_PROFILE_NAMESPACE || parts[1] !== "v1") {
+		return { kind: "quarantined", reason: "unsupported version or malformed envelope syntax" };
+	}
+
+	const nameBytes = decodeCanonicalBase64Url(parts[2]);
+	if (!nameBytes) return { kind: "quarantined", reason: "profile name is not canonical base64url" };
+	const name = decodeUtf8(nameBytes);
+	if (!name) return { kind: "quarantined", reason: "profile name is not valid UTF-8" };
+	if (!MODEL_PROFILE_NAME_PATTERN.test(name)) {
+		return { kind: "quarantined", name, reason: "profile name is invalid" };
+	}
+
+	if (parts[3].length > MAX_ARCHIVED_MODEL_PROFILE_BASE64URL_LENGTH) {
+		return { kind: "quarantined", name, reason: "profile payload exceeds the size limit" };
+	}
+	const profileBytes = decodeCanonicalBase64Url(parts[3]);
+	if (!profileBytes) {
+		return { kind: "quarantined", name, reason: "profile payload is not canonical base64url" };
+	}
+	if (profileBytes.byteLength > MAX_ARCHIVED_MODEL_PROFILE_BYTES) {
+		return { kind: "quarantined", name, reason: "profile payload exceeds the size limit" };
+	}
+	const profileJson = decodeUtf8(profileBytes);
+	if (profileJson === undefined) {
+		return { kind: "quarantined", name, reason: "profile payload is not valid UTF-8" };
+	}
+
+	let decoded: unknown;
+	try {
+		decoded = JSON.parse(profileJson);
+	} catch {
+		return { kind: "quarantined", name, reason: "profile payload is not valid JSON" };
+	}
+	const profile = ProfileDefinitionSchema.safeParse(decoded);
+	if (!profile.success) {
+		return { kind: "quarantined", name, reason: "profile payload does not match the profile schema" };
+	}
+	return { kind: "valid", name, profile: profile.data };
+}
+
+function archivedModelProfilesFromExclusions(exclusions: readonly string[] | undefined): {
+	profiles: Record<string, ModelProfileConfig>;
+	equivalenceExclusions: string[];
+} {
+	const profiles: Record<string, ModelProfileConfig> = {};
+	const equivalenceExclusions: string[] = [];
+	for (const [index, exclusion] of (exclusions ?? []).entries()) {
+		const inspected = inspectArchivedModelProfile(exclusion);
+		if (inspected.kind === "ordinary") {
+			equivalenceExclusions.push(exclusion);
+			continue;
+		}
+		if (inspected.kind === "quarantined") {
+			logger.warn("Quarantining malformed archived model profile envelope", {
+				index,
+				reason: inspected.reason,
+			});
+			continue;
+		}
+		if (profiles[inspected.name]) {
+			logger.warn("Duplicate archived model profile envelope; using the last entry", {
+				index,
+				name: inspected.name,
+			});
+		}
+		profiles[inspected.name] = inspected.profile;
+	}
+	return { profiles, equivalenceExclusions };
+}
+
+function exclusionsWithArchivedModelProfile(
+	exclusions: readonly string[] | undefined,
+	name: string,
+	profile?: ModelProfileConfig,
+): string[] | undefined {
+	const retained = (exclusions ?? []).filter(exclusion => {
+		const inspected = inspectArchivedModelProfile(exclusion);
+		return inspected.kind !== "valid" || inspected.name !== name;
+	});
+	if (profile) retained.push(encodeArchivedModelProfile(name, profile));
+	return retained.length > 0 ? retained : undefined;
+}
+
+function withArchivedModelProfile(config: ModelsConfig, name: string, profile?: ModelProfileConfig): ModelsConfig {
+	const exclude = exclusionsWithArchivedModelProfile(config.equivalence?.exclude, name, profile);
+	const equivalence =
+		exclude || config.equivalence?.overrides
+			? {
+					...(config.equivalence ?? {}),
+					exclude,
+				}
+			: undefined;
+	return { ...config, equivalence };
+}
 export type GjcModelAssignmentTargetId = "default" | "executor" | "architect" | "planner" | "critic";
 
 export interface GjcModelAssignmentTargetInfo extends ModelRoleInfo {
@@ -541,6 +687,7 @@ interface CustomModelsResult {
 	equivalence?: ModelEquivalenceConfig;
 	modelBindings?: NonNullable<ModelsConfig["modelBindings"]>;
 	profiles?: ModelsConfig["profiles"];
+	archivedProfiles?: Record<string, ModelProfileConfig>;
 	error?: ConfigError;
 	found: boolean;
 }
@@ -1016,6 +1163,7 @@ export class ModelRegistry {
 	#equivalenceConfig: ModelEquivalenceConfig | undefined;
 	#configuredModelBindings: NonNullable<ModelsConfig["modelBindings"]> | undefined;
 	#modelProfiles: Map<string, ModelProfileDefinition> = mergeModelProfiles();
+	#archivedModelProfiles = new Map<string, ModelProfileDefinition>();
 	#modelBindingsTargetSettings: Settings | undefined;
 	#appliedModelBindingRoles = new Set<string>();
 	#appliedAgentModelBindingOverrides = new Set<string>();
@@ -1025,7 +1173,6 @@ export class ModelRegistry {
 	#lastAppliedAgentModelBindingOverrides = new Map<string, string>();
 	#configError: ConfigError | undefined = undefined;
 	#modelsConfigFile: ConfigFile<ModelsConfig>;
-	#lastStaticLoadMtime: number | null = null;
 	#registeredProviderSources: Set<string> = new Set();
 	#providerDiscoveryStates: Map<string, ProviderDiscoveryState> = new Map();
 	#cacheDbPath?: string;
@@ -1049,8 +1196,20 @@ export class ModelRegistry {
 		readonly authStorage: AuthStorage,
 		modelsPath?: string,
 	) {
-		this.#modelsConfigFile = ModelsConfigFile.relocate(modelsPath);
-		this.#cacheDbPath = modelsPath ? path.join(path.dirname(modelsPath), "models.db") : undefined;
+		const configuredModelsPath = modelsPath ?? ModelsConfigFile.path();
+		let persistenceModelsPath = configuredModelsPath;
+		try {
+			persistenceModelsPath = syncFs.realpathSync.native(configuredModelsPath);
+		} catch {
+			try {
+				persistenceModelsPath = path.join(
+					syncFs.realpathSync.native(path.dirname(configuredModelsPath)),
+					path.basename(configuredModelsPath),
+				);
+			} catch {}
+		}
+		this.#modelsConfigFile = ModelsConfigFile.relocate(persistenceModelsPath);
+		this.#cacheDbPath = modelsPath ? path.join(path.dirname(persistenceModelsPath), "models.db") : undefined;
 		// Set up fallback resolver for custom provider API keys
 		this.authStorage.setFallbackResolver(provider => {
 			const keyConfig = this.#customProviderApiKeys.get(provider);
@@ -1110,11 +1269,6 @@ export class ModelRegistry {
 	}
 
 	#reloadStaticModels(): void {
-		const currentMtime = this.#modelsConfigFile.getMtimeMs();
-		if (currentMtime !== null && currentMtime === this.#lastStaticLoadMtime) {
-			// models.json unchanged since last load; reload + canonical rebuild would be redundant.
-			return;
-		}
 		this.#modelsConfigFile.invalidate();
 		this.#customProviderApiKeys.clear();
 		this.#providerWebSearchModes.clear();
@@ -1157,6 +1311,7 @@ export class ModelRegistry {
 			equivalence,
 			modelBindings,
 			profiles,
+			archivedProfiles,
 			error: configError,
 		} = this.#loadCustomModels();
 		this.#configError = configError;
@@ -1168,6 +1323,7 @@ export class ModelRegistry {
 		this.#equivalenceConfig = equivalence;
 		this.#configuredModelBindings = modelBindings;
 		this.#modelProfiles = mergeModelProfiles(profiles);
+		this.#archivedModelProfiles = mapUserModelProfiles(archivedProfiles);
 
 		this.#addImplicitDiscoverableProviders(configuredProviders);
 		const builtInModels = this.#applyHardcodedModelPolicies(this.#loadBuiltInModels(overrides));
@@ -1183,7 +1339,6 @@ export class ModelRegistry {
 		const withModelOverrides = this.#applyModelOverrides(combined, this.#modelOverrides);
 		this.#models = this.#applyRuntimeProviderOverrides(withModelOverrides);
 		this.#rebuildCanonicalIndex();
-		this.#lastStaticLoadMtime = this.#modelsConfigFile.getMtimeMs();
 	}
 
 	/** Load built-in models, applying provider-level overrides only.
@@ -1546,6 +1701,17 @@ export class ModelRegistry {
 			}
 		}
 
+		const archivedProfiles = archivedModelProfilesFromExclusions(value.equivalence?.exclude);
+		const equivalence = value.equivalence
+			? {
+					...value.equivalence,
+					exclude:
+						archivedProfiles.equivalenceExclusions.length > 0
+							? archivedProfiles.equivalenceExclusions
+							: undefined,
+				}
+			: undefined;
+
 		return {
 			models: this.#parseModels(value),
 			overrides,
@@ -1553,9 +1719,10 @@ export class ModelRegistry {
 			keylessProviders,
 			discoverableProviders,
 			configuredProviders,
-			equivalence: value.equivalence,
+			equivalence,
 			modelBindings: value.modelBindings,
 			profiles: value.profiles,
+			archivedProfiles: archivedProfiles.profiles,
 			found: true,
 		};
 	}
@@ -1568,6 +1735,10 @@ export class ModelRegistry {
 		return this.#modelProfiles.get(name);
 	}
 
+	getModelProfileForReference(name: string): ModelProfileDefinition | undefined {
+		return this.#modelProfiles.get(name) ?? this.#archivedModelProfiles.get(name);
+	}
+
 	getAvailableModelProfileNames(): string[] {
 		return [...this.#modelProfiles.keys()].sort((a, b) => a.localeCompare(b));
 	}
@@ -1575,45 +1746,48 @@ export class ModelRegistry {
 	async saveCustomModelProfile(name: string, definition: ModelProfileConfig): Promise<ModelProfileDefinition> {
 		const normalizedName = name.trim();
 		if (!normalizedName) throw new Error("Profile name is required.");
+		if (!MODEL_PROFILE_NAME_PATTERN.test(normalizedName)) {
+			throw new Error(
+				`Invalid custom model profile id "${normalizedName}": use ${MODEL_PROFILE_NAME_PATTERN_DESCRIPTION}.`,
+			);
+		}
 		const checkedDefinition = ProfileDefinitionSchema.safeParse(definition);
 		if (!checkedDefinition.success) {
 			const first = checkedDefinition.error.issues[0];
 			const where = first?.path.length ? `/${first.path.map(String).join("/")}` : "root";
 			throw new Error(`Custom model profile is invalid at ${where}: ${first?.message ?? "unknown schema error"}`);
 		}
-		const loaded = this.#modelsConfigFile.tryLoad();
-		if (loaded.status === "error") {
-			throw new Error(
-				`Cannot create custom model profile because ${this.#modelsConfigFile.path()} is invalid. Fix the existing config before saving a new preset.`,
-			);
-		}
-		const current = loaded.value ?? this.#modelsConfigFile.createDefault();
-		if (mergeModelProfiles(current.profiles).has(normalizedName)) {
-			throw new Error(`Custom model profile already exists: ${normalizedName}. Choose a unique preset id.`);
-		}
-		const next: ModelsConfig = {
-			...current,
-			profiles: {
-				...(current.profiles ?? {}),
-				[normalizedName]: definition,
-			},
-		};
-		const checkedConfig = ModelsConfigSchema.safeParse(next);
-		if (!checkedConfig.success) {
-			const first = checkedConfig.error.issues[0];
-			const where = first?.path.length ? `/${first.path.map(String).join("/")}` : "root";
-			throw new Error(`Generated models config is invalid at ${where}: ${first?.message ?? "unknown schema error"}`);
-		}
-		await this.#writeCheckedModelsConfig(checkedConfig.data);
-		const modelMapping = { ...definition.model_mapping };
-		const profile: ModelProfileDefinition = {
-			name: normalizedName,
-			displayName: definition.display_name,
-			requiredProviders: aggregateModelProfileRequiredProviders(definition.required_providers, { modelMapping }),
-			modelMapping,
-			source: "user",
-		};
-		return profile;
+		return this.#withModelsConfigMutation(async () => {
+			const loaded = this.#modelsConfigFile.tryLoad();
+			if (loaded.status === "error") {
+				throw new Error(
+					`Cannot create custom model profile because ${this.#modelsConfigFile.path()} is invalid. Fix the existing config before saving a new preset.`,
+				);
+			}
+			const current = loaded.value ?? this.#modelsConfigFile.createDefault();
+			if (mergeModelProfiles(current.profiles).has(normalizedName)) {
+				throw new Error(`Custom model profile already exists: ${normalizedName}. Choose a unique preset id.`);
+			}
+			const currentWithoutArchive = withArchivedModelProfile(current, normalizedName);
+			const checkedConfig = this.#validateGeneratedModelsConfig({
+				...currentWithoutArchive,
+				profiles: {
+					...(current.profiles ?? {}),
+					[normalizedName]: checkedDefinition.data,
+				},
+			});
+			await this.#writeCheckedModelsConfig(checkedConfig);
+			const modelMapping = { ...checkedDefinition.data.model_mapping };
+			return {
+				name: normalizedName,
+				displayName: checkedDefinition.data.display_name,
+				requiredProviders: aggregateModelProfileRequiredProviders(checkedDefinition.data.required_providers, {
+					modelMapping,
+				}),
+				modelMapping,
+				source: "user",
+			};
+		});
 	}
 
 	async renameCustomModelProfile(name: string, displayName: string): Promise<ModelProfileDefinition> {
@@ -1621,48 +1795,85 @@ export class ModelRegistry {
 		const nextDisplayName = displayName.trim();
 		if (!normalizedName) throw new Error("Profile name is required.");
 		if (!nextDisplayName) throw new Error("Profile display name is required.");
-		const { current, profile } = this.#loadCustomProfileForMutation(normalizedName, "rename");
-		const nextProfiles = {
-			...(current.profiles ?? {}),
-			[normalizedName]: {
-				...profile,
-				display_name: nextDisplayName,
-			},
-		};
-		const checkedConfig = ModelsConfigSchema.safeParse({ ...current, profiles: nextProfiles });
-		if (!checkedConfig.success) {
-			const first = checkedConfig.error.issues[0];
-			const where = first?.path.length ? `/${first.path.map(String).join("/")}` : "root";
-			throw new Error(`Generated models config is invalid at ${where}: ${first?.message ?? "unknown schema error"}`);
-		}
-		await this.#writeCheckedModelsConfig(checkedConfig.data);
-		const modelMapping = { ...profile.model_mapping };
-		return {
-			name: normalizedName,
-			displayName: nextDisplayName,
-			requiredProviders: aggregateModelProfileRequiredProviders(profile.required_providers, { modelMapping }),
-			modelMapping,
-			source: "user",
-		};
+		return this.#withModelsConfigMutation(async () => {
+			const { current, profile } = this.#loadCustomProfileForMutation(normalizedName, "rename");
+			const checkedConfig = this.#validateGeneratedModelsConfig({
+				...current,
+				profiles: {
+					...(current.profiles ?? {}),
+					[normalizedName]: {
+						...profile,
+						display_name: nextDisplayName,
+					},
+				},
+			});
+			await this.#writeCheckedModelsConfig(checkedConfig);
+			const modelMapping = { ...profile.model_mapping };
+			return {
+				name: normalizedName,
+				displayName: nextDisplayName,
+				requiredProviders: aggregateModelProfileRequiredProviders(profile.required_providers, { modelMapping }),
+				modelMapping,
+				source: "user",
+			};
+		});
 	}
 
 	async deleteCustomModelProfile(name: string): Promise<ModelProfileConfig> {
 		const normalizedName = name.trim();
 		if (!normalizedName) throw new Error("Profile name is required.");
-		const { current, profile } = this.#loadCustomProfileForMutation(normalizedName, "delete");
-		const nextProfiles = { ...(current.profiles ?? {}) };
-		delete nextProfiles[normalizedName];
-		const checkedConfig = ModelsConfigSchema.safeParse({
-			...current,
-			profiles: Object.keys(nextProfiles).length > 0 ? nextProfiles : undefined,
+		return this.#withModelsConfigMutation(async () => {
+			const { current, profile } = this.#loadCustomProfileForMutation(normalizedName, "delete");
+			const nextProfiles = { ...(current.profiles ?? {}) };
+			delete nextProfiles[normalizedName];
+			const checkedConfig = this.#validateGeneratedModelsConfig(
+				withArchivedModelProfile(
+					{
+						...current,
+						profiles: Object.keys(nextProfiles).length > 0 ? nextProfiles : undefined,
+					},
+					normalizedName,
+					profile,
+				),
+			);
+			await this.#writeCheckedModelsConfig(checkedConfig);
+			return profile;
 		});
+	}
+
+	async #withModelsConfigMutation<T>(mutation: () => Promise<T>): Promise<T> {
+		const configPath = this.#modelsConfigFile.path();
+		await fs.mkdir(path.dirname(configPath), { recursive: true });
+		this.#statModelsConfigForReplacement();
+		return withFileLock(configPath, async () => {
+			this.#statModelsConfigForReplacement();
+			this.#modelsConfigFile.invalidate();
+			return mutation();
+		});
+	}
+
+	#statModelsConfigForReplacement(): syncFs.Stats | undefined {
+		const configPath = this.#modelsConfigFile.path();
+		try {
+			const stat = syncFs.statSync(configPath);
+			if (stat.nlink > 1) {
+				throw new Error(`Refusing to replace hard-linked models config: ${configPath}`);
+			}
+			return stat;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+			throw error;
+		}
+	}
+
+	#validateGeneratedModelsConfig(candidate: ModelsConfig): ModelsConfig {
+		const checkedConfig = ModelsConfigSchema.safeParse(candidate);
 		if (!checkedConfig.success) {
 			const first = checkedConfig.error.issues[0];
 			const where = first?.path.length ? `/${first.path.map(String).join("/")}` : "root";
 			throw new Error(`Generated models config is invalid at ${where}: ${first?.message ?? "unknown schema error"}`);
 		}
-		await this.#writeCheckedModelsConfig(checkedConfig.data);
-		return profile;
+		return checkedConfig.data;
 	}
 
 	#loadCustomProfileForMutation(
@@ -1678,6 +1889,9 @@ export class ModelRegistry {
 		const current = loaded.value ?? this.#modelsConfigFile.createDefault();
 		const profile = current.profiles?.[normalizedName];
 		if (!profile) {
+			if (archivedModelProfilesFromExclusions(current.equivalence?.exclude).profiles[normalizedName]) {
+				throw new Error(`Custom model profile is already deleted: ${normalizedName}.`);
+			}
 			const existing = this.#modelProfiles.get(normalizedName);
 			if (existing && existing.source !== "user") {
 				throw new Error(`Cannot ${action} bundled model profile: ${normalizedName}.`);
@@ -1688,10 +1902,283 @@ export class ModelRegistry {
 	}
 
 	async #writeCheckedModelsConfig(config: ModelsConfig): Promise<void> {
-		await fs.mkdir(path.dirname(this.#modelsConfigFile.path()), { recursive: true });
-		await Bun.write(this.#modelsConfigFile.path(), Bun.YAML.stringify(config, null, 2));
+		const configPath = this.#modelsConfigFile.path();
+		await fs.mkdir(path.dirname(configPath), { recursive: true });
+		const existingStat = this.#statModelsConfigForReplacement();
+		const tempPath = `${configPath}.${crypto.randomUUID()}.tmp`;
+		const rollbackPath = `${configPath}.${crypto.randomUUID()}.rollback`;
+		const observedPath = `${configPath}.${crypto.randomUUID()}.observed`;
+		const verificationRecoveryPath = `${configPath}.${crypto.randomUUID()}.recovery`;
+		let fileHandle: number | undefined;
+		let originalHandle: number | undefined;
+		let rollbackCreated = false;
+		let observedCreated = false;
+		let verificationRecoveryCreated = false;
+		let preserveRecovery = false;
+		let exclusiveCommitInstalled = false;
+		try {
+			fileHandle = syncFs.openSync(tempPath, "wx", existingStat ? existingStat.mode & 0o7777 : 0o600);
+			syncFs.writeFileSync(fileHandle, Bun.YAML.stringify(config, null, 2), "utf8");
+			if (existingStat && process.platform !== "win32") {
+				syncFs.fchownSync(fileHandle, existingStat.uid, existingStat.gid);
+			}
+			syncFs.fchmodSync(fileHandle, existingStat ? existingStat.mode & 0o7777 : 0o600);
+			syncFs.fsyncSync(fileHandle);
+			syncFs.closeSync(fileHandle);
+			fileHandle = undefined;
+			const replacementStat = syncFs.statSync(tempPath);
+
+			if (existingStat) {
+				syncFs.linkSync(configPath, rollbackPath);
+				rollbackCreated = true;
+				originalHandle = syncFs.openSync(rollbackPath, "r");
+				const rollbackStat = syncFs.fstatSync(originalHandle);
+				const liveStat = syncFs.statSync(configPath);
+				const identityChanged =
+					rollbackStat.dev !== existingStat.dev ||
+					rollbackStat.ino !== existingStat.ino ||
+					liveStat.dev !== existingStat.dev ||
+					liveStat.ino !== existingStat.ino;
+				if (identityChanged || rollbackStat.nlink !== 2 || liveStat.nlink !== 2) {
+					throw new Error(`Refusing to replace models config changed during mutation: ${configPath}`);
+				}
+
+				syncFs.renameSync(configPath, observedPath);
+				observedCreated = true;
+				const observedStat = syncFs.statSync(observedPath);
+				const movedExpectedFile =
+					observedStat.dev === existingStat.dev &&
+					observedStat.ino === existingStat.ino &&
+					syncFs.fstatSync(originalHandle).nlink === 2;
+				if (!movedExpectedFile) {
+					try {
+						syncFs.linkSync(observedPath, configPath);
+						preserveRecovery = true;
+					} catch (recoveryError) {
+						preserveRecovery = true;
+						throw new Error(`Models config changed during commit and recovery failed: ${String(recoveryError)}`);
+					}
+					throw new Error(`Refusing to replace models config changed during commit: ${configPath}`);
+				}
+
+				syncFs.unlinkSync(observedPath);
+				observedCreated = false;
+				if (syncFs.fstatSync(originalHandle).nlink !== 1) {
+					try {
+						syncFs.linkSync(rollbackPath, configPath);
+						preserveRecovery = true;
+					} catch (recoveryError) {
+						preserveRecovery = true;
+						throw new Error(`Models config hard-link race recovery failed: ${String(recoveryError)}`);
+					}
+					throw new Error(`Refusing models config replacement because a hard link appeared during commit`);
+				}
+			} else {
+				try {
+					syncFs.lstatSync(configPath);
+					throw new Error(`Refusing to replace models config created during mutation: ${configPath}`);
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+				}
+			}
+
+			try {
+				syncFs.linkSync(tempPath, configPath);
+				exclusiveCommitInstalled = true;
+				syncFs.unlinkSync(tempPath);
+			} catch (commitError) {
+				if (rollbackCreated) {
+					try {
+						syncFs.linkSync(rollbackPath, configPath);
+						preserveRecovery = true;
+					} catch {
+						preserveRecovery = true;
+					}
+				}
+				throw new Error(`Models config changed at the exclusive commit boundary: ${String(commitError)}`);
+			}
+
+			const committedStat = syncFs.statSync(configPath);
+			if (committedStat.dev !== replacementStat.dev || committedStat.ino !== replacementStat.ino) {
+				preserveRecovery = rollbackCreated;
+				throw new Error(`Models config changed immediately after commit: ${configPath}`);
+			}
+
+			if (rollbackCreated && originalHandle !== undefined && existingStat) {
+				if (syncFs.fstatSync(originalHandle).nlink !== 1) {
+					preserveRecovery = true;
+					throw new Error(`Models config hard-link state became ambiguous during commit; recovery file preserved`);
+				}
+				this.#materializeModelsConfigRecovery(originalHandle, verificationRecoveryPath, existingStat);
+				verificationRecoveryCreated = true;
+				syncFs.unlinkSync(rollbackPath);
+				rollbackCreated = false;
+				let remainingLinks: number;
+				try {
+					remainingLinks = syncFs.fstatSync(originalHandle).nlink;
+				} catch (error) {
+					preserveRecovery = true;
+					throw new Error(`Models config cleanup verification failed; recovery file preserved: ${String(error)}`);
+				}
+				if (remainingLinks !== 0) {
+					preserveRecovery = true;
+					throw new Error(
+						`Models config hard-link state became ambiguous during cleanup; recovery file preserved`,
+					);
+				}
+			}
+
+			const finalStat = syncFs.statSync(configPath);
+			if (finalStat.dev !== replacementStat.dev || finalStat.ino !== replacementStat.ino) {
+				throw new Error(`Models config changed before commit verification completed: ${configPath}`);
+			}
+			if (verificationRecoveryCreated) {
+				syncFs.unlinkSync(verificationRecoveryPath);
+				verificationRecoveryCreated = false;
+			}
+			this.#fsyncModelsConfigParent(configPath);
+		} catch (error) {
+			const reportedError = exclusiveCommitInstalled
+				? new Error(
+						`Models config was committed, but verification failed; recovery evidence preserved: ${String(error)}`,
+					)
+				: error;
+			if (exclusiveCommitInstalled && (rollbackCreated || observedCreated || verificationRecoveryCreated)) {
+				preserveRecovery = true;
+			}
+			let configExists = true;
+			try {
+				syncFs.lstatSync(configPath);
+			} catch (statError) {
+				if ((statError as NodeJS.ErrnoException).code === "ENOENT") {
+					configExists = false;
+				} else {
+					preserveRecovery = true;
+				}
+			}
+			if (!configExists && observedCreated) {
+				try {
+					syncFs.linkSync(observedPath, configPath);
+					preserveRecovery = true;
+					configExists = true;
+				} catch (recoveryError) {
+					preserveRecovery = true;
+					throw new Error(
+						`Models config recovery failed after ${String(reportedError)}: ${String(recoveryError)}`,
+					);
+				}
+			}
+			if (!configExists && rollbackCreated) {
+				try {
+					syncFs.linkSync(rollbackPath, configPath);
+					preserveRecovery = true;
+				} catch (recoveryError) {
+					preserveRecovery = true;
+					throw new Error(
+						`Models config rollback failed after ${String(reportedError)}: ${String(recoveryError)}`,
+					);
+				}
+			}
+			throw reportedError;
+		} finally {
+			if (fileHandle !== undefined) {
+				try {
+					syncFs.closeSync(fileHandle);
+				} catch {}
+			}
+			if (originalHandle !== undefined) {
+				try {
+					syncFs.closeSync(originalHandle);
+				} catch {}
+			}
+			try {
+				syncFs.rmSync(tempPath, { force: true });
+			} catch (error) {
+				logger.warn("models config temp cleanup failed", {
+					path: tempPath,
+					error: String(error),
+				});
+			}
+			if (!preserveRecovery) {
+				for (const recoveryPath of [
+					observedCreated ? observedPath : undefined,
+					rollbackCreated ? rollbackPath : undefined,
+					verificationRecoveryCreated ? verificationRecoveryPath : undefined,
+				]) {
+					if (!recoveryPath) continue;
+					try {
+						syncFs.rmSync(recoveryPath, { force: true });
+					} catch (error) {
+						logger.warn("models config recovery cleanup failed", {
+							path: recoveryPath,
+							error: String(error),
+						});
+					}
+				}
+			}
+		}
 		this.#modelsConfigFile.invalidate();
 		this.#reloadStaticModels();
+	}
+
+	#materializeModelsConfigRecovery(handle: number, recoveryPath: string, existingStat: syncFs.Stats): void {
+		const content = syncFs.readFileSync(handle);
+		let recoveryHandle: number | undefined;
+		let recoveryCreated = false;
+		let recoveryComplete = false;
+		try {
+			recoveryHandle = syncFs.openSync(recoveryPath, "wx", existingStat.mode & 0o7777);
+			recoveryCreated = true;
+			syncFs.writeFileSync(recoveryHandle, content);
+			if (process.platform !== "win32") {
+				syncFs.fchownSync(recoveryHandle, existingStat.uid, existingStat.gid);
+			}
+			syncFs.fchmodSync(recoveryHandle, existingStat.mode & 0o7777);
+			syncFs.fsyncSync(recoveryHandle);
+			syncFs.closeSync(recoveryHandle);
+			recoveryHandle = undefined;
+			recoveryComplete = true;
+			this.#fsyncModelsConfigParentOrThrow(recoveryPath);
+		} catch (error) {
+			if (recoveryHandle !== undefined) {
+				try {
+					syncFs.closeSync(recoveryHandle);
+				} catch {}
+			}
+			if (recoveryCreated && !recoveryComplete) {
+				try {
+					syncFs.rmSync(recoveryPath, { force: true });
+				} catch {}
+			}
+			throw error;
+		}
+	}
+	#fsyncModelsConfigParentOrThrow(configPath: string): void {
+		if (process.platform === "win32") return;
+		const directoryHandle = syncFs.openSync(path.dirname(configPath), "r");
+		try {
+			syncFs.fsyncSync(directoryHandle);
+		} finally {
+			syncFs.closeSync(directoryHandle);
+		}
+	}
+	#fsyncModelsConfigParent(configPath: string): void {
+		if (process.platform === "win32") return;
+		try {
+			const directoryHandle = syncFs.openSync(path.dirname(configPath), "r");
+			try {
+				syncFs.fsyncSync(directoryHandle);
+			} finally {
+				syncFs.closeSync(directoryHandle);
+			}
+		} catch (error) {
+			// The rename already committed or restored a checked config. A parent
+			// fsync warning must not turn that result into a reported failure.
+			logger.warn("models config parent directory fsync failed", {
+				path: configPath,
+				error: String(error),
+			});
+		}
 	}
 	applyConfiguredModelBindings(targetSettings: Settings): void {
 		this.#modelBindingsTargetSettings = targetSettings;
@@ -1702,7 +2189,7 @@ export class ModelRegistry {
 		const targetSettings = this.#modelBindingsTargetSettings;
 		if (!targetSettings) return;
 		const bindings = this.#configuredModelBindings;
-		const nextModelRoles = { ...targetSettings.get("modelRoles") };
+		const nextModelRoles = { ...(targetSettings.getRuntimeOverride("modelRoles") ?? {}) };
 		const configuredModelRoles = bindings?.modelRoles ?? {};
 		const configuredModelRoleKeys = new Set(Object.keys(configuredModelRoles));
 		for (const role of this.#appliedModelBindingRoles) {
@@ -1733,7 +2220,9 @@ export class ModelRegistry {
 		targetSettings.override("modelRoles", nextModelRoles);
 		this.#appliedModelBindingRoles = new Set(Object.keys(configuredModelRoles));
 
-		const nextAgentModelOverrides = { ...targetSettings.get("task.agentModelOverrides") };
+		const nextAgentModelOverrides = {
+			...(targetSettings.getRuntimeOverride("task.agentModelOverrides") ?? {}),
+		};
 		const configuredAgentModelOverrides = bindings?.agentModelOverrides ?? {};
 		const configuredAgentModelOverrideKeys = new Set(Object.keys(configuredAgentModelOverrides));
 		for (const agentName of this.#appliedAgentModelBindingOverrides) {
@@ -2744,7 +3233,6 @@ export class ModelRegistry {
 			this.#runtimeProviderSourceByName.delete(providerName);
 			this.#clearRuntimeProviderState(providerName);
 		}
-		this.#lastStaticLoadMtime = null;
 		this.#reloadStaticModels();
 		this.#rebuildCanonicalIndex();
 	}
@@ -2824,7 +3312,6 @@ export class ModelRegistry {
 			this.#runtimeProviderSourceByName.set(providerName, sourceId);
 		}
 		if (sourceHandoff) {
-			this.#lastStaticLoadMtime = null;
 			this.#reloadStaticModels();
 		}
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -11,9 +11,12 @@
  *   const isolated = Settings.isolated({ "compaction.enabled": false });
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import {
 	getAgentDbPath,
 	getAgentDir,
@@ -54,6 +57,164 @@ export * from "./settings-schema";
 export interface RawSettings {
 	[key: string]: unknown;
 }
+type SettingMutationGuard =
+	| { kind: "unconditional" }
+	| {
+			kind: "if-unchanged";
+			expectedValue: unknown;
+			expectedGeneration: string;
+			expectedRevision: number;
+	  };
+
+interface DurableSettingRevisionEntry {
+	revision: number;
+	ownerId: string;
+	mutationId: number;
+}
+
+interface DurableSettingsRevisionState {
+	version: 1;
+	nextRevision: number;
+	generation: string;
+	entries: Record<string, DurableSettingRevisionEntry>;
+}
+
+interface LoadedSettingsRevisionState {
+	state: DurableSettingsRevisionState;
+	exists: boolean;
+}
+
+interface ConditionalMutationOutcome {
+	expectedValue: unknown;
+	desiredValue: unknown;
+	applied: boolean;
+	revision: number;
+	generation: string;
+}
+
+interface SettingsMutationContext {
+	id: number;
+	active: boolean;
+}
+interface PendingSettingMutation {
+	id: number;
+	desiredValue: unknown;
+	guard: SettingMutationGuard;
+	attempted: boolean;
+	predecessorGeneration?: string;
+	predecessorRevision?: number;
+	predecessorValue?: unknown;
+	checkpointId?: number;
+}
+
+const SETTINGS_REVISION_STATE_VERSION = 1 as const;
+const SETTINGS_REVISION_GENERATION_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function emptySettingsRevisionState(): DurableSettingsRevisionState {
+	return {
+		version: SETTINGS_REVISION_STATE_VERSION,
+		generation: crypto.randomUUID(),
+		nextRevision: 1,
+		entries: {},
+	};
+}
+
+function isValidRevisionPath(modifiedPath: string): boolean {
+	if (!modifiedPath.startsWith(RECORD_ENTRY_MUTATION_PREFIX)) {
+		return (
+			modifiedPath !== "modelRoles" &&
+			modifiedPath !== "task.agentModelOverrides" &&
+			Object.hasOwn(SETTINGS_SCHEMA, modifiedPath)
+		);
+	}
+	try {
+		const segments = decodeModifiedPath(modifiedPath);
+		if (segments.length === 2 && segments[0] === "modelRoles" && isValidRecordEntryMutationKey(segments[1])) {
+			return modifiedPath === encodeRecordEntryMutation("modelRoles", segments[1]);
+		}
+		if (
+			segments.length === 3 &&
+			segments[0] === "task" &&
+			segments[1] === "agentModelOverrides" &&
+			isValidRecordEntryMutationKey(segments[2])
+		) {
+			return modifiedPath === encodeRecordEntryMutation("task.agentModelOverrides", segments[2]);
+		}
+		return false;
+	} catch {
+		return false;
+	}
+}
+
+function parseSettingsRevisionState(value: unknown): DurableSettingsRevisionState {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("Invalid settings revision state");
+	}
+	const raw = value as Record<string, unknown>;
+	if (
+		raw.version !== SETTINGS_REVISION_STATE_VERSION ||
+		typeof raw.generation !== "string" ||
+		!SETTINGS_REVISION_GENERATION_PATTERN.test(raw.generation) ||
+		!Number.isSafeInteger(raw.nextRevision) ||
+		(raw.nextRevision as number) < 1
+	) {
+		throw new Error("Invalid settings revision state header");
+	}
+	if (!raw.entries || typeof raw.entries !== "object" || Array.isArray(raw.entries)) {
+		throw new Error("Invalid settings revision state entries");
+	}
+
+	const entries: Record<string, DurableSettingRevisionEntry> = {};
+	let maxRevision = 0;
+	for (const [modifiedPath, candidate] of Object.entries(raw.entries)) {
+		if (!isValidRevisionPath(modifiedPath)) {
+			throw new Error(`Invalid settings revision path: ${modifiedPath}`);
+		}
+		if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+			throw new Error(`Invalid settings revision entry: ${modifiedPath}`);
+		}
+		const entry = candidate as Record<string, unknown>;
+		if (
+			!Number.isSafeInteger(entry.revision) ||
+			(entry.revision as number) < 1 ||
+			typeof entry.ownerId !== "string" ||
+			entry.ownerId.length === 0 ||
+			!Number.isSafeInteger(entry.mutationId) ||
+			(entry.mutationId as number) < 1
+		) {
+			throw new Error(`Invalid settings revision entry: ${modifiedPath}`);
+		}
+		const revision = entry.revision as number;
+		entries[modifiedPath] = {
+			revision,
+			ownerId: entry.ownerId,
+			mutationId: entry.mutationId as number,
+		};
+		maxRevision = Math.max(maxRevision, revision);
+	}
+	if ((raw.nextRevision as number) <= maxRevision) {
+		throw new Error("Invalid settings revision ordering");
+	}
+
+	return {
+		generation: raw.generation,
+		version: SETTINGS_REVISION_STATE_VERSION,
+		nextRevision: raw.nextRevision as number,
+		entries,
+	};
+}
+
+function mutationValuesMatch(mutation: PendingSettingMutation, currentValue: unknown): boolean {
+	if (mutation.guard.kind === "unconditional") return true;
+	return Object.is(currentValue, mutation.guard.expectedValue) || Object.is(currentValue, mutation.desiredValue);
+}
+
+function mutationRetryValuesMatch(mutation: PendingSettingMutation, currentValue: unknown): boolean {
+	return (
+		isDeepStrictEqual(currentValue, mutation.predecessorValue) ||
+		isDeepStrictEqual(currentValue, mutation.desiredValue)
+	);
+}
 
 export interface SettingsOptions {
 	/** Current working directory for project settings discovery */
@@ -64,6 +225,22 @@ export interface SettingsOptions {
 	inMemory?: boolean;
 	/** Initial overrides */
 	overrides?: Partial<Record<SettingPath, unknown>>;
+}
+
+export interface SettingsMutationCheckpoint {
+	readonly ownerId: string;
+	readonly id: number;
+}
+
+interface SettingsMutationSnapshot {
+	global: RawSettings;
+	overrides: RawSettings;
+	modified: Map<string, PendingSettingMutation>;
+	conditionalOutcomes: Map<string, ConditionalMutationOutcome>;
+	context: SettingsMutationContext;
+	state: "active" | "flushing" | "flushed" | "failed";
+	flushedMutationVersion?: number;
+	release: () => void;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -79,6 +256,9 @@ function getByPath(obj: RawSettings, segments: string[]): unknown {
 		if (current === null || current === undefined || typeof current !== "object") {
 			return undefined;
 		}
+		if (!Object.hasOwn(current, segment)) {
+			return undefined;
+		}
 		current = (current as Record<string, unknown>)[segment];
 	}
 	return current;
@@ -92,7 +272,7 @@ function setByPath(obj: RawSettings, segments: string[], value: unknown): void {
 	let current = obj;
 	for (let i = 0; i < segments.length - 1; i++) {
 		const segment = segments[i];
-		if (!(segment in current) || typeof current[segment] !== "object" || current[segment] === null) {
+		if (!Object.hasOwn(current, segment) || typeof current[segment] !== "object" || current[segment] === null) {
 			current[segment] = {};
 		}
 		current = current[segment] as RawSettings;
@@ -141,13 +321,43 @@ function stringArrayFromUnknown(value: unknown): string[] {
 function shallowStringRecord(value: unknown): Record<string, string> {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
 
-	const result: Record<string, string> = {};
+	const result: Record<string, string> = Object.create(null);
 	for (const [key, item] of Object.entries(value)) {
 		if (typeof item === "string") {
 			result[key] = item;
 		}
 	}
 	return result;
+}
+
+const FORBIDDEN_RECORD_ENTRY_MUTATION_KEYS = new Set(["prototype"]);
+
+function isValidRecordEntryMutationKey(key: string): boolean {
+	return key.length > 0 && !FORBIDDEN_RECORD_ENTRY_MUTATION_KEYS.has(key) && !Object.hasOwn(Object.prototype, key);
+}
+
+function assertValidRecordEntryMutationKey(key: string): void {
+	if (key.length === 0) {
+		throw new Error("Model assignment key cannot be empty");
+	}
+	if (!isValidRecordEntryMutationKey(key)) {
+		throw new Error(`Model assignment key is not allowed: ${key}`);
+	}
+}
+
+const RECORD_ENTRY_MUTATION_PREFIX = "\0record-entry:";
+
+function encodeRecordEntryMutation(path: string, key: string): string {
+	return RECORD_ENTRY_MUTATION_PREFIX + JSON.stringify([...path.split("."), key]);
+}
+
+function decodeModifiedPath(modifiedPath: string): string[] {
+	if (!modifiedPath.startsWith(RECORD_ENTRY_MUTATION_PREFIX)) return modifiedPath.split(".");
+	const parsed: unknown = JSON.parse(modifiedPath.slice(RECORD_ENTRY_MUTATION_PREFIX.length));
+	if (!Array.isArray(parsed) || !parsed.every((segment): segment is string => typeof segment === "string")) {
+		throw new Error("Invalid encoded settings record-entry mutation");
+	}
+	return parsed;
 }
 
 function resolvePathScopedStringArray(settingPath: SettingPath, value: unknown, cwd: string): string[] | undefined {
@@ -197,6 +407,10 @@ export class Settings {
 	#cwd: string;
 	#agentDir: string;
 	#storage: AgentStorage | null = null;
+	#revisionPath: string | null;
+	#ownerId = crypto.randomUUID();
+	#revisionState = emptySettingsRevisionState();
+	#conditionalOutcomes = new Map<string, ConditionalMutationOutcome>();
 
 	/** Global settings from config.yml */
 	#global: RawSettings = {};
@@ -208,7 +422,14 @@ export class Settings {
 	#merged: RawSettings = {};
 
 	/** Paths modified during this session (for partial save) */
-	#modified = new Set<string>();
+	#modified = new Map<string, PendingSettingMutation>();
+	#nextMutationId = 1;
+	#nextMutationCheckpointId = 1;
+	#mutationCheckpoints = new Map<number, SettingsMutationSnapshot>();
+	#mutationCheckpointTail: Promise<void> = Promise.resolve();
+	#mutationCheckpointContext = new AsyncLocalStorage<SettingsMutationContext>();
+	#mutationCheckpointAcquisitions = 0;
+	#mutationVersion = 0;
 
 	/** Pending save (debounced) */
 	#saveTimer?: NodeJS.Timeout;
@@ -220,7 +441,24 @@ export class Settings {
 	private constructor(options: SettingsOptions = {}) {
 		this.#cwd = path.normalize(options.cwd ?? getProjectDir());
 		this.#agentDir = path.normalize(options.agentDir ?? getAgentDir());
-		this.#configPath = options.inMemory ? null : path.join(this.#agentDir, "config.yml");
+		let persistenceAgentDir = this.#agentDir;
+		try {
+			persistenceAgentDir = fs.realpathSync.native(this.#agentDir);
+		} catch {
+			try {
+				persistenceAgentDir = path.join(
+					fs.realpathSync.native(path.dirname(this.#agentDir)),
+					path.basename(this.#agentDir),
+				);
+			} catch {}
+		}
+		this.#configPath = options.inMemory ? null : path.join(persistenceAgentDir, "config.yml");
+		if (this.#configPath) {
+			try {
+				this.#configPath = fs.realpathSync.native(this.#configPath);
+			} catch {}
+		}
+		this.#revisionPath = this.#configPath ? `${this.#configPath}.revisions.json` : null;
 		this.#persist = !options.inMemory;
 
 		if (options.overrides) {
@@ -253,6 +491,7 @@ export class Settings {
 			},
 			error => {
 				globalInstance = null;
+				globalInstancePromise = null;
 				throw error;
 			},
 		);
@@ -308,11 +547,169 @@ export class Settings {
 		return value === undefined ? undefined : (value as SettingValue<P>);
 	}
 
+	/** Get a setting from project config only, excluding global and runtime layers. */
+	getProject<P extends SettingPath>(path: P): SettingValue<P> | undefined {
+		const value = getByPath(this.#project, path.split("."));
+		return value === undefined ? undefined : (value as SettingValue<P>);
+	}
+
+	/**
+	 * Get the user/global plus runtime value while excluding project settings.
+	 * Profile materialization uses this to preserve explicit runtime choices
+	 * without leaking project-scoped configuration into the user config.
+	 */
+	getWithoutProject<P extends SettingPath>(path: P): SettingValue<P> {
+		const merged = this.#deepMerge(this.#deepMerge({}, this.#global), this.#overrides);
+		const value = getByPath(merged, path.split("."));
+		if (value !== undefined) {
+			const pathScopedValue = resolvePathScopedStringArray(path, value, this.#cwd);
+			return (pathScopedValue ?? value) as SettingValue<P>;
+		}
+		return getDefault(path);
+	}
+
+	/** Get the raw runtime override layer for a setting, without lower-precedence values. */
+	getRuntimeOverride<P extends SettingPath>(path: P): SettingValue<P> | undefined {
+		const value = getByPath(this.#overrides, path.split("."));
+		return value === undefined ? undefined : (value as SettingValue<P>);
+	}
+
 	/** Check whether a setting is present in loaded settings/overrides rather than coming from schema defaults. */
 	has(path: SettingPath): boolean {
 		return getByPath(this.#merged, path.split(".")) !== undefined;
 	}
 
+	async createMutationCheckpoint(): Promise<SettingsMutationCheckpoint> {
+		this.#assertMutationCheckpointWaitAllowed("create a nested transaction");
+		const predecessor = this.#mutationCheckpointTail;
+		const { promise: completion, resolve: release } = Promise.withResolvers<void>();
+		this.#mutationCheckpointTail = predecessor.then(
+			() => completion,
+			() => completion,
+		);
+		this.#mutationCheckpointAcquisitions++;
+		let checkpointCreated = false;
+		try {
+			await predecessor.catch(() => {});
+			await this.#flushPending({ throwOnError: true });
+
+			const id = this.#nextMutationCheckpointId++;
+			const context: SettingsMutationContext = { id, active: true };
+			this.#mutationCheckpoints.set(id, {
+				global: structuredClone(this.#global),
+				overrides: structuredClone(this.#overrides),
+				modified: structuredClone(this.#modified),
+				conditionalOutcomes: structuredClone(this.#conditionalOutcomes),
+				context,
+				state: "active",
+				release,
+			});
+			checkpointCreated = true;
+			return { ownerId: this.#ownerId, id };
+		} catch (error) {
+			release();
+			throw error;
+		} finally {
+			this.#mutationCheckpointAcquisitions--;
+			if (!checkpointCreated && this.#modified.size > 0) this.#queueSave();
+		}
+	}
+
+	restoreMutationCheckpoint(checkpoint: SettingsMutationCheckpoint): void {
+		if (checkpoint.ownerId !== this.#ownerId) {
+			throw new Error("Settings mutation checkpoint belongs to another instance");
+		}
+		const snapshot = this.#mutationCheckpoints.get(checkpoint.id);
+		if (!snapshot) throw new Error("Settings mutation checkpoint is no longer active");
+		if (snapshot.state === "flushing") {
+			throw new Error("Settings mutation checkpoint flush is still in progress");
+		}
+		if (snapshot.state === "flushed") {
+			throw new Error("Settings mutation checkpoint was already durably flushed");
+		}
+		snapshot.context.active = false;
+		this.#mutationCheckpoints.delete(checkpoint.id);
+		try {
+			if (this.#saveTimer) {
+				clearTimeout(this.#saveTimer);
+				this.#saveTimer = undefined;
+			}
+			this.#global = structuredClone(snapshot.global);
+			this.#overrides = structuredClone(snapshot.overrides);
+			this.#modified = structuredClone(snapshot.modified);
+			this.#conditionalOutcomes = structuredClone(snapshot.conditionalOutcomes);
+			this.#rebuildMerged();
+		} finally {
+			snapshot.release();
+		}
+		if (this.#modified.size > 0) this.#queueSave();
+	}
+
+	releaseMutationCheckpoint(checkpoint: SettingsMutationCheckpoint): void {
+		const snapshot = checkpoint.ownerId === this.#ownerId ? this.#mutationCheckpoints.get(checkpoint.id) : undefined;
+		if (!snapshot) {
+			throw new Error("Settings mutation checkpoint is no longer active");
+		}
+		if (
+			snapshot.state !== "flushed" ||
+			snapshot.flushedMutationVersion === undefined ||
+			snapshot.flushedMutationVersion !== this.#mutationVersion
+		) {
+			throw new Error("Settings mutation checkpoint has unflushed transaction work");
+		}
+		snapshot.context.active = false;
+		this.#mutationCheckpoints.delete(checkpoint.id);
+		snapshot.release();
+		if (this.#modified.size > 0) this.#queueSave();
+	}
+
+	async flushMutationCheckpoint(checkpoint: SettingsMutationCheckpoint): Promise<void> {
+		const snapshot = checkpoint.ownerId === this.#ownerId ? this.#mutationCheckpoints.get(checkpoint.id) : undefined;
+		if (!snapshot) {
+			throw new Error("Settings mutation checkpoint is no longer active");
+		}
+		if (snapshot.state !== "active") {
+			throw new Error("Settings mutation checkpoint cannot be flushed more than once");
+		}
+		snapshot.state = "flushing";
+		snapshot.context.active = false;
+		const mutationVersion = this.#mutationVersion;
+		try {
+			await this.#flushPending({ throwOnError: true });
+			if (this.#mutationCheckpoints.get(checkpoint.id) !== snapshot || snapshot.state !== "flushing") {
+				throw new Error("Settings mutation checkpoint changed while its durable save was in progress");
+			}
+			if (this.#mutationVersion !== mutationVersion) {
+				throw new Error("Settings transaction changed while its durable save was in progress");
+			}
+			if (this.#persist) {
+				const hasUnflushedOwnedMutation = [...this.#modified.values()].some(
+					mutation => mutation.checkpointId === checkpoint.id,
+				);
+				if (hasUnflushedOwnedMutation) {
+					throw new Error("Settings transaction still has unflushed durable mutations");
+				}
+			}
+			snapshot.flushedMutationVersion = mutationVersion;
+			snapshot.state = "flushed";
+		} catch (error) {
+			if (this.#mutationCheckpoints.get(checkpoint.id) === snapshot && snapshot.state === "flushing") {
+				snapshot.state = "failed";
+			}
+			throw error;
+		}
+	}
+
+	runMutationCheckpoint<T>(checkpoint: SettingsMutationCheckpoint, operation: () => Promise<T>): Promise<T> {
+		const snapshot = checkpoint.ownerId === this.#ownerId ? this.#mutationCheckpoints.get(checkpoint.id) : undefined;
+		if (!snapshot) {
+			throw new Error("Settings mutation checkpoint is no longer active");
+		}
+		if (snapshot.state !== "active") {
+			throw new Error("Settings mutation checkpoint is sealed");
+		}
+		return this.#mutationCheckpointContext.run(snapshot.context, operation);
+	}
 	/**
 	 * Set a setting value (sync).
 	 * Updates global settings and queues a background save.
@@ -321,8 +718,8 @@ export class Settings {
 	set<P extends SettingPath>(path: P, value: SettingValue<P>): void {
 		const prev = this.get(path);
 		const segments = path.split(".");
+		this.#enqueueSettingValue(path, value);
 		setByPath(this.#global, segments, value);
-		this.#modified.add(path);
 		this.#rebuildMerged();
 		this.#queueSave();
 
@@ -333,10 +730,64 @@ export class Settings {
 		}
 	}
 
+	/** Remove a user/global setting while preserving project and runtime layers. */
+	clearGlobal(path: SettingPath): void {
+		this.#enqueueSettingValue(path, undefined);
+		setByPath(this.#global, path.split("."), undefined);
+		this.#rebuildMerged();
+		this.#queueSave();
+	}
+
+	/**
+	 * Persist or clear the default model profile only if another writer has not
+	 * changed it since this Settings instance loaded it.
+	 */
+	getPendingModelProfileDefaultMutationId(): number | undefined {
+		return this.#modified.get("modelProfile.default")?.id;
+	}
+
+	setModelProfileDefaultIfUnchanged(
+		expectedProfileName: string | undefined,
+		profileName: string | undefined,
+		expectedPendingMutationId?: number,
+	): void {
+		const path = "modelProfile.default";
+		if (!this.#enqueueModifiedIfUnchanged(path, expectedProfileName, profileName, expectedPendingMutationId)) return;
+		setByPath(this.#global, path.split("."), profileName);
+		this.#rebuildMerged();
+		this.#queueSave();
+	}
+
+	/**
+	 * Delete a custom model profile while holding the global settings lock.
+	 *
+	 * A fresh durable default check rejects a concurrent selection that commits
+	 * before archival; selections that commit later remain resolvable through
+	 * the registry's archived-profile fallback.
+	 */
+	async deleteModelProfileIfUnreferenced<T>(profileName: string, deleteProfile: () => Promise<T>): Promise<T> {
+		await this.flushOrThrow();
+		if (!this.#persist || !this.#configPath) {
+			if (this.getGlobal("modelProfile.default") === profileName) {
+				throw new Error(`Model profile became the default while deletion was in progress: ${profileName}`);
+			}
+			return deleteProfile();
+		}
+		return withFileLock(this.#configPath, async () => {
+			const current = await this.#loadYaml(this.#configPath!);
+			if (getByPath(current, ["modelProfile", "default"]) === profileName) {
+				throw new Error(`Model profile became the default while deletion was in progress: ${profileName}`);
+			}
+			return deleteProfile();
+		});
+	}
+
 	/**
 	 * Apply runtime overrides (not persisted).
 	 */
 	override<P extends SettingPath>(path: P, value: SettingValue<P>): void {
+		this.#assertMutationCheckpointAccess();
+		this.#mutationVersion++;
 		const segments = path.split(".");
 		setByPath(this.#overrides, segments, value);
 		this.#rebuildMerged();
@@ -346,6 +797,7 @@ export class Settings {
 	 * Clear a runtime override.
 	 */
 	clearOverride(path: SettingPath): void {
+		this.#assertMutationCheckpointAccess();
 		const segments = path.split(".");
 		let current = this.#overrides;
 		for (let i = 0; i < segments.length - 1; i++) {
@@ -353,6 +805,7 @@ export class Settings {
 			if (!(segment in current)) return;
 			current = current[segment] as RawSettings;
 		}
+		this.#mutationVersion++;
 		delete current[segments[segments.length - 1]];
 		this.#rebuildMerged();
 	}
@@ -362,16 +815,11 @@ export class Settings {
 	 * Call before exit to ensure all changes are persisted.
 	 */
 	async flush(): Promise<void> {
-		if (this.#saveTimer) {
-			clearTimeout(this.#saveTimer);
-			this.#saveTimer = undefined;
+		this.#assertMutationCheckpointWaitAllowed("flush settings");
+		if (this.#mutationCheckpointAcquisitions > 0 || this.#mutationCheckpoints.size > 0) {
+			await this.#mutationCheckpointTail;
 		}
-		if (this.#savePromise) {
-			await this.#savePromise;
-		}
-		if (this.#modified.size > 0) {
-			await this.#saveNow();
-		}
+		await this.#flushPending();
 	}
 
 	/**
@@ -381,15 +829,28 @@ export class Settings {
 	 * ({@link isolated}) short-circuit in {@link #saveNow} and never throw.
 	 */
 	async flushOrThrow(): Promise<void> {
+		this.#assertMutationCheckpointWaitAllowed("flush settings");
+		if (this.#mutationCheckpointAcquisitions > 0 || this.#mutationCheckpoints.size > 0) {
+			await this.#mutationCheckpointTail;
+		}
+		await this.#flushPending({ throwOnError: true });
+	}
+
+	async #flushPending(options: { throwOnError?: boolean } = {}): Promise<void> {
 		if (this.#saveTimer) {
 			clearTimeout(this.#saveTimer);
 			this.#saveTimer = undefined;
 		}
 		if (this.#savePromise) {
-			await this.#savePromise;
+			try {
+				await this.#savePromise;
+			} catch {
+				// A previous caller owns the prior failure. Retry whatever remains
+				// dirty and report only the attempt started below.
+			}
 		}
 		if (this.#modified.size > 0) {
-			await this.#saveNow({ throwOnError: true });
+			await this.#startSave(options);
 		}
 	}
 
@@ -400,8 +861,21 @@ export class Settings {
 			inMemory: !this.#persist,
 		});
 		cloned.#storage = this.#storage;
-		cloned.#global = structuredClone(this.#global);
-		cloned.#project = this.#persist ? await cloned.#loadProjectSettings() : structuredClone(this.#project);
+		if (this.#persist) {
+			await withFileLock(cloned.#configPath!, async () => {
+				const loadedRevisionState = await cloned.#loadRevisionState();
+				cloned.#global = await cloned.#loadYaml(cloned.#configPath!);
+				cloned.#revisionState = loadedRevisionState.state;
+				if (!loadedRevisionState.exists) {
+					await cloned.#writeRevisionState(cloned.#revisionState);
+				}
+			});
+			cloned.#project = await cloned.#loadProjectSettings();
+		} else {
+			cloned.#global = structuredClone(this.#global);
+			cloned.#revisionState = structuredClone(this.#revisionState);
+			cloned.#project = structuredClone(this.#project);
+		}
 		cloned.#overrides = structuredClone(this.#overrides);
 		cloned.#rebuildMerged();
 		cloned.#fireAllHooks();
@@ -476,45 +950,251 @@ export class Settings {
 		return this.get("bashInterceptor.patterns");
 	}
 
-	/**
-	 * Set a model role (helper for modelRoles record).
-	 */
-	setModelRole(role: ModelRole | string, modelId: string): void {
-		const current = shallowStringRecord(getByPath(this.#global, ["modelRoles"]));
-		const runtimeOverrides = getByPath(this.#overrides, ["modelRoles"]);
-		const updateRuntimeOverride =
-			!!runtimeOverrides &&
-			typeof runtimeOverrides === "object" &&
-			!Array.isArray(runtimeOverrides) &&
-			Object.hasOwn(runtimeOverrides, role);
+	#revisionFor(path: string): number {
+		return this.#revisionState.entries[path]?.revision ?? 0;
+	}
 
-		this.set("modelRoles", { ...current, [role]: modelId });
-
-		if (updateRuntimeOverride) {
-			this.override("modelRoles", { ...shallowStringRecord(runtimeOverrides), [role]: modelId });
+	#assertMutationCheckpointWaitAllowed(action: string): void {
+		const context = this.#mutationCheckpointContext.getStore();
+		if (!context) return;
+		if (!context.active) {
+			throw new Error("Settings operation belongs to a completed transaction");
+		}
+		if (this.#mutationCheckpoints.has(context.id)) {
+			throw new Error(`Cannot ${action} from inside an active Settings transaction`);
 		}
 	}
+	#assertMutationCheckpointAccess(): SettingsMutationContext | undefined {
+		const context = this.#mutationCheckpointContext.getStore();
+		if (context && !context.active) {
+			throw new Error("Settings mutation belongs to a completed transaction");
+		}
+		if (context && this.#mutationCheckpoints.has(context.id)) return context;
+		if (this.#mutationCheckpoints.size > 0) {
+			throw new Error("Settings mutation blocked by an active transaction");
+		}
+		if (this.#mutationCheckpointAcquisitions > 0) {
+			throw new Error("Settings mutation blocked while a transaction is being acquired");
+		}
+		return context;
+	}
+
+	#enqueueModified(path: string, desiredValue: unknown): void {
+		const context = this.#assertMutationCheckpointAccess();
+		this.#mutationVersion++;
+		this.#modified.delete(path);
+		this.#modified.set(path, {
+			id: this.#nextMutationId++,
+			desiredValue: structuredClone(desiredValue),
+			guard: { kind: "unconditional" },
+			attempted: false,
+			predecessorGeneration: undefined,
+			predecessorRevision: undefined,
+			predecessorValue: undefined,
+			checkpointId: context?.id,
+		});
+	}
+
+	#enqueueSettingValue(path: SettingPath, desiredValue: unknown): void {
+		if (path !== "modelRoles" && path !== "task.agentModelOverrides") {
+			this.#enqueueModified(path, desiredValue);
+			return;
+		}
+		const previous = shallowStringRecord(getByPath(this.#global, path.split(".")));
+		const next = shallowStringRecord(desiredValue);
+		const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
+		for (const key of keys) {
+			assertValidRecordEntryMutationKey(key);
+		}
+		for (const key of keys) {
+			this.#enqueueModified(encodeRecordEntryMutation(path, key), next[key]);
+		}
+	}
+
+	#enqueueModifiedIfUnchanged(
+		path: string,
+		expectedValue: unknown,
+		desiredValue: unknown,
+		expectedPendingMutationId?: number,
+	): boolean {
+		const context = this.#assertMutationCheckpointAccess();
+		const pending = this.#modified.get(path);
+		let expectedRevision = this.#revisionFor(path);
+		let expectedGeneration = this.#revisionState.generation;
+		if (pending) {
+			const replacesOwnedUnconditional =
+				expectedPendingMutationId !== undefined &&
+				pending.id === expectedPendingMutationId &&
+				pending.guard.kind === "unconditional" &&
+				Object.is(pending.desiredValue, expectedValue);
+			const reversesPendingConditional =
+				pending.guard.kind === "if-unchanged" &&
+				Object.is(pending.guard.expectedValue, desiredValue) &&
+				Object.is(pending.desiredValue, expectedValue);
+			if (!replacesOwnedUnconditional && !reversesPendingConditional) return false;
+		} else {
+			const outcome = this.#conditionalOutcomes.get(path);
+			const reversesCompletedConditional =
+				outcome && Object.is(outcome.expectedValue, desiredValue) && Object.is(outcome.desiredValue, expectedValue);
+			if (reversesCompletedConditional) {
+				this.#conditionalOutcomes.delete(path);
+				if (!outcome.applied) return false;
+				expectedRevision = outcome.revision;
+				expectedGeneration = outcome.generation;
+			} else {
+				this.#conditionalOutcomes.delete(path);
+			}
+		}
+		const currentValue = getByPath(this.#global, decodeModifiedPath(path));
+		if (!Object.is(currentValue, expectedValue) && !Object.is(currentValue, desiredValue)) return false;
+		this.#mutationVersion++;
+		this.#modified.delete(path);
+		this.#modified.set(path, {
+			id: this.#nextMutationId++,
+			desiredValue: structuredClone(desiredValue),
+			guard: {
+				kind: "if-unchanged",
+				expectedValue: structuredClone(expectedValue),
+				expectedGeneration,
+				expectedRevision,
+			},
+			attempted: false,
+			predecessorGeneration: undefined,
+			predecessorRevision: undefined,
+			predecessorValue: undefined,
+			checkpointId: context?.id,
+		});
+		return true;
+	}
+
+	#setStringRecordEntry(
+		path: "modelRoles" | "task.agentModelOverrides",
+		key: string,
+		value: string | undefined,
+		expectedValue?: { value: string | undefined },
+	): boolean {
+		assertValidRecordEntryMutationKey(key);
+		const segments = path.split(".");
+		const next = shallowStringRecord(getByPath(this.#global, segments));
+		if (value === undefined) {
+			delete next[key];
+		} else {
+			next[key] = value;
+		}
+		const modifiedPath = encodeRecordEntryMutation(path, key);
+		if (expectedValue) {
+			if (!this.#enqueueModifiedIfUnchanged(modifiedPath, expectedValue.value, value)) return false;
+		} else {
+			this.#enqueueModified(modifiedPath, value);
+		}
+		setByPath(this.#global, segments, next);
+		this.#rebuildMerged();
+		this.#queueSave();
+		return true;
+	}
+
+	#setModelRoleEntry(
+		role: ModelRole | string,
+		modelId: string | undefined,
+		expectedValue?: { value: string | undefined },
+	): void {
+		const runtimeOverrides = getByPath(this.#overrides, ["modelRoles"]);
+		const hasRuntimeOverrides =
+			!!runtimeOverrides && typeof runtimeOverrides === "object" && !Array.isArray(runtimeOverrides);
+		const runtimeRoleIsSet = hasRuntimeOverrides && Object.hasOwn(runtimeOverrides, role);
+
+		if (!this.#setStringRecordEntry("modelRoles", role, modelId, expectedValue)) return;
+
+		if (modelId === undefined) {
+			if (hasRuntimeOverrides) {
+				const nextRuntimeOverrides = shallowStringRecord(runtimeOverrides);
+				delete nextRuntimeOverrides[role];
+				this.override("modelRoles", nextRuntimeOverrides);
+			}
+		} else if (runtimeRoleIsSet || this.get("modelRoles")[role] !== modelId) {
+			const base = shallowStringRecord(runtimeOverrides);
+			this.override("modelRoles", { ...base, [role]: modelId });
+		}
+	}
+
 	/**
-	 * Set an agent model override while keeping any live runtime override aligned.
-	 *
-	 * Runtime model profiles override `task.agentModelOverrides` for the current
-	 * session. A user-selected role assignment must win immediately in that same
-	 * session, but only the explicit agent change should be persisted.
+	 * Persist one model role without replacing sibling roles written by another
+	 * process, and keep a shadowing runtime/project value aligned for this session.
 	 */
-	setAgentModelOverride(agentName: string, modelId: string): void {
-		const current = shallowStringRecord(getByPath(this.#global, ["task", "agentModelOverrides"]));
+	setModelRole(role: ModelRole | string, modelId: string): void {
+		this.#setModelRoleEntry(role, modelId);
+	}
+
+	/**
+	 * Persist or clear one model role only if another writer has not changed that
+	 * leaf since this Settings instance loaded it.
+	 */
+	setModelRoleIfUnchanged(
+		role: ModelRole | string,
+		expectedModelId: string | undefined,
+		modelId: string | undefined,
+	): void {
+		this.#setModelRoleEntry(role, modelId, { value: expectedModelId });
+	}
+
+	#setAgentModelOverrideEntry(
+		agentName: string,
+		modelId: string | undefined,
+		expectedValue?: { value: string | undefined },
+	): void {
 		const runtimeOverrides = getByPath(this.#overrides, ["task", "agentModelOverrides"]);
-		const updateRuntimeOverride =
+		const hasRuntimeOverrides =
 			!!runtimeOverrides && typeof runtimeOverrides === "object" && !Array.isArray(runtimeOverrides);
 
-		this.set("task.agentModelOverrides", { ...current, [agentName]: modelId });
+		if (!this.#setStringRecordEntry("task.agentModelOverrides", agentName, modelId, expectedValue)) return;
 
-		if (updateRuntimeOverride) {
+		if (modelId === undefined) {
+			if (hasRuntimeOverrides) {
+				const nextRuntimeOverrides = shallowStringRecord(runtimeOverrides);
+				delete nextRuntimeOverrides[agentName];
+				this.override("task.agentModelOverrides", nextRuntimeOverrides);
+			}
+		} else if (hasRuntimeOverrides || this.get("task.agentModelOverrides")[agentName] !== modelId) {
+			const base = shallowStringRecord(runtimeOverrides);
 			this.override("task.agentModelOverrides", {
-				...shallowStringRecord(runtimeOverrides),
+				...base,
 				[agentName]: modelId,
 			});
 		}
+	}
+
+	/**
+	 * Set an agent model override while keeping any live runtime/project override aligned.
+	 *
+	 * Runtime model profiles and project settings can override
+	 * `task.agentModelOverrides` for the current session. A user-selected role
+	 * assignment must win immediately, but only that explicit agent change is
+	 * persisted.
+	 */
+	setAgentModelOverride(agentName: string, modelId: string): void {
+		this.#setAgentModelOverrideEntry(agentName, modelId);
+	}
+
+	/**
+	 * Persist or clear one agent override only if another writer has not changed
+	 * that leaf since this Settings instance loaded it.
+	 */
+	setAgentModelOverrideIfUnchanged(
+		agentName: string,
+		expectedModelId: string | undefined,
+		modelId: string | undefined,
+	): void {
+		this.#setAgentModelOverrideEntry(agentName, modelId, { value: expectedModelId });
+	}
+
+	/** Clear one persisted and live model role without replacing siblings. */
+	clearModelRole(role: ModelRole | string): void {
+		this.#setModelRoleEntry(role, undefined);
+	}
+
+	/** Clear one persisted and live agent model override without replacing siblings. */
+	clearAgentModelOverride(agentName: string): void {
+		this.#setAgentModelOverrideEntry(agentName, undefined);
 	}
 
 	/**
@@ -567,7 +1247,14 @@ export class Settings {
 		if (this.#persist) {
 			this.#storage = await AgentStorage.open(getAgentDbPath(this.#agentDir));
 			await this.#migrateFromLegacy();
-			this.#global = await this.#loadYaml(this.#configPath!);
+			await withFileLock(this.#configPath!, async () => {
+				const loadedRevisionState = await this.#loadRevisionState();
+				this.#global = await this.#loadYaml(this.#configPath!);
+				this.#revisionState = loadedRevisionState.state;
+				if (!loadedRevisionState.exists) {
+					await this.#writeRevisionState(this.#revisionState);
+				}
+			});
 		}
 
 		this.#project = await projectPromise;
@@ -578,18 +1265,79 @@ export class Settings {
 		return this;
 	}
 
+	async #loadRevisionState(): Promise<LoadedSettingsRevisionState> {
+		if (!this.#revisionPath) {
+			return { state: emptySettingsRevisionState(), exists: false };
+		}
+		try {
+			const content = await Bun.file(this.#revisionPath).text();
+			return {
+				state: parseSettingsRevisionState(JSON.parse(content)),
+				exists: true,
+			};
+		} catch (error) {
+			if (isEnoent(error)) {
+				return { state: emptySettingsRevisionState(), exists: false };
+			}
+			logger.warn("Settings: failed to load revision state", {
+				path: this.#revisionPath,
+				error: String(error),
+			});
+			throw error;
+		}
+	}
+
+	async #atomicWrite(filePath: string, content: string): Promise<void> {
+		const tempPath = `${filePath}.${this.#ownerId}.tmp`;
+		try {
+			await Bun.write(tempPath, content);
+			const fd = fs.openSync(tempPath, "r");
+			try {
+				fs.fsyncSync(fd);
+			} finally {
+				fs.closeSync(fd);
+			}
+			fs.renameSync(tempPath, filePath);
+			if (process.platform !== "win32") {
+				try {
+					const directoryFd = fs.openSync(path.dirname(filePath), "r");
+					try {
+						fs.fsyncSync(directoryFd);
+					} finally {
+						fs.closeSync(directoryFd);
+					}
+				} catch (error) {
+					// rename() is the commit point. Do not report an uncommitted
+					// write after the target already contains the new bytes.
+					logger.warn("Settings: parent directory fsync failed after commit", {
+						path: filePath,
+						error: String(error),
+					});
+				}
+			}
+		} finally {
+			try {
+				fs.rmSync(tempPath, { force: true });
+			} catch {}
+		}
+	}
+
+	async #writeRevisionState(state: DurableSettingsRevisionState): Promise<void> {
+		if (!this.#revisionPath) return;
+		await this.#atomicWrite(this.#revisionPath, JSON.stringify(state));
+	}
 	async #loadYaml(filePath: string): Promise<RawSettings> {
 		try {
 			const content = await Bun.file(filePath).text();
 			const parsed = YAML.parse(content);
 			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-				return {};
+				throw new Error(`Settings root must be an object: ${filePath}`);
 			}
 			return this.#migrateRawSettings(parsed as RawSettings);
 		} catch (error) {
 			if (isEnoent(error)) return {};
 			logger.warn("Settings: failed to load", { path: filePath, error: String(error) });
-			return {};
+			throw error;
 		}
 	}
 
@@ -821,8 +1569,34 @@ export class Settings {
 	// Saving
 	// ─────────────────────────────────────────────────────────────────────────
 
+	#startSave(options: { throwOnError?: boolean } = {}): Promise<void> {
+		const previousSave = this.#savePromise;
+		const savePromise = (async () => {
+			if (previousSave) {
+				try {
+					await previousSave;
+				} catch {
+					// A failed durable flush must not prevent a later retry from
+					// persisting the paths that #saveNow re-queued.
+				}
+			}
+			await this.#saveNow(options);
+		})();
+		this.#savePromise = savePromise;
+		void savePromise.then(
+			() => {
+				if (this.#savePromise === savePromise) this.#savePromise = undefined;
+			},
+			() => {
+				if (this.#savePromise === savePromise) this.#savePromise = undefined;
+			},
+		);
+		return savePromise;
+	}
+
 	#queueSave(): void {
 		if (!this.#persist || !this.#configPath) return;
+		if (this.#mutationCheckpointAcquisitions > 0 || this.#mutationCheckpoints.size > 0) return;
 
 		// Debounce: wait 100ms for more changes
 		if (this.#saveTimer) {
@@ -830,7 +1604,9 @@ export class Settings {
 		}
 		this.#saveTimer = setTimeout(() => {
 			this.#saveTimer = undefined;
-			this.#saveNow().catch(err => {
+			if (this.#mutationCheckpointAcquisitions > 0 || this.#mutationCheckpoints.size > 0) return;
+			const savePromise = this.#startSave();
+			void savePromise.catch(err => {
 				logger.warn("Settings: background save failed", { error: String(err) });
 			});
 		}, 100);
@@ -840,31 +1616,123 @@ export class Settings {
 		if (!this.#persist || !this.#configPath || this.#modified.size === 0) return;
 
 		const configPath = this.#configPath;
-		const modifiedPaths = [...this.#modified];
-		this.#modified.clear();
+		const initialEntries = [...this.#modified].sort((left, right) => left[1].id - right[1].id);
 
 		try {
 			await withFileLock(configPath, async () => {
-				// Re-read to preserve external changes
 				const current = await this.#loadYaml(configPath);
+				const loadedRevisionState = await this.#loadRevisionState();
+				const revisionState = loadedRevisionState.state;
+				if (!loadedRevisionState.exists) {
+					await this.#writeRevisionState(revisionState);
+				}
+				this.#revisionState = structuredClone(revisionState);
+				const loadedGeneration = revisionState.generation;
+				const accepted: Array<{
+					modifiedPath: string;
+					mutation: PendingSettingMutation;
+					revision: number;
+					revisionChanged: boolean;
+				}> = [];
 
-				// Apply only our modified paths
-				for (const modPath of modifiedPaths) {
-					const segments = modPath.split(".");
-					const value = getByPath(this.#global, segments);
-					setByPath(current, segments, value);
+				for (const [modifiedPath, mutation] of initialEntries) {
+					const segments = decodeModifiedPath(modifiedPath);
+					const currentValue = getByPath(current, segments);
+					const currentRevision = revisionState.entries[modifiedPath]?.revision ?? 0;
+					const currentOwner = revisionState.entries[modifiedPath];
+					const sameMutation = currentOwner?.ownerId === this.#ownerId && currentOwner.mutationId === mutation.id;
+					const capturesPredecessor = !mutation.attempted && mutation.predecessorGeneration === undefined;
+					if (capturesPredecessor) {
+						mutation.predecessorGeneration = loadedGeneration;
+						mutation.predecessorRevision = currentRevision;
+						mutation.predecessorValue = structuredClone(currentValue);
+					}
+					const predecessorMatches =
+						mutation.predecessorGeneration === loadedGeneration &&
+						mutation.predecessorRevision === currentRevision;
+					const retryValueMatches = mutationRetryValuesMatch(mutation, currentValue);
+					const sameMutationRetry = sameMutation && retryValueMatches;
+					const generationMatches =
+						mutation.guard.kind === "if-unchanged" && mutation.guard.expectedGeneration === loadedGeneration;
+					const firstAttemptApplies =
+						!mutation.attempted &&
+						predecessorMatches &&
+						(capturesPredecessor || retryValueMatches) &&
+						(mutation.guard.kind === "unconditional" ||
+							(mutationValuesMatch(mutation, currentValue) &&
+								generationMatches &&
+								currentRevision === mutation.guard.expectedRevision));
+					const applies = sameMutationRetry || firstAttemptApplies;
+
+					if (!applies) {
+						if (this.#modified.get(modifiedPath)?.id === mutation.id) {
+							this.#modified.delete(modifiedPath);
+							if (mutation.guard.kind === "if-unchanged") {
+								this.#conditionalOutcomes.set(modifiedPath, {
+									expectedValue: mutation.guard.expectedValue,
+									desiredValue: mutation.desiredValue,
+									applied: false,
+									revision: currentRevision,
+									generation: loadedGeneration,
+								});
+							}
+						}
+						continue;
+					}
+
+					let revision = currentRevision;
+					if (!sameMutation) {
+						if (revisionState.nextRevision >= Number.MAX_SAFE_INTEGER) {
+							throw new Error("Settings revision state exhausted");
+						}
+						revision = revisionState.nextRevision++;
+						revisionState.entries[modifiedPath] = {
+							revision,
+							ownerId: this.#ownerId,
+							mutationId: mutation.id,
+						};
+					}
+					setByPath(current, segments, structuredClone(mutation.desiredValue));
+					accepted.push({
+						modifiedPath,
+						mutation,
+						revision,
+						revisionChanged: !sameMutation,
+					});
 				}
 
-				// Update our global with any external changes we preserved
+				if (accepted.some(entry => entry.revisionChanged)) {
+					await this.#writeRevisionState(revisionState);
+					for (const entry of accepted) {
+						if (entry.revisionChanged) entry.mutation.attempted = true;
+					}
+				}
+				this.#revisionState = structuredClone(revisionState);
+
+				if (accepted.length > 0) {
+					await this.#atomicWrite(configPath, YAML.stringify(current, null, 2));
+				}
+
+				for (const { modifiedPath, mutation, revision } of accepted) {
+					if (this.#modified.get(modifiedPath)?.id !== mutation.id) continue;
+					this.#modified.delete(modifiedPath);
+					if (mutation.guard.kind === "if-unchanged") {
+						this.#conditionalOutcomes.set(modifiedPath, {
+							expectedValue: mutation.guard.expectedValue,
+							desiredValue: mutation.desiredValue,
+							applied: true,
+							revision,
+							generation: revisionState.generation,
+						});
+					}
+				}
 				this.#global = current;
-				await Bun.write(configPath, YAML.stringify(this.#global, null, 2));
+				for (const [modifiedPath, mutation] of this.#modified) {
+					setByPath(this.#global, decodeModifiedPath(modifiedPath), structuredClone(mutation.desiredValue));
+				}
 			});
 		} catch (error) {
 			logger.warn("Settings: save failed", { error: String(error) });
-			// Re-add failed paths for retry
-			for (const p of modifiedPaths) {
-				this.#modified.add(p);
-			}
 			if (options.throwOnError) {
 				this.#rebuildMerged();
 				throw error;

--- a/packages/coding-agent/src/modes/components/agent-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/agent-dashboard.ts
@@ -64,6 +64,7 @@ interface SourceTab {
 interface DashboardAgent extends AgentDefinition {
 	disabled: boolean;
 	overrideModel?: string;
+	persistenceWarning?: string;
 }
 
 interface ModelResolution {
@@ -82,6 +83,8 @@ interface AgentDashboardModelContext {
 	modelRegistry?: ModelRegistry;
 	activeModelPattern?: string;
 	defaultModelPattern?: string;
+	projectModelProfileShadow?: { profileName: string; targetIds: readonly string[] };
+	onModelOverrideChange?: (agentName: string, value: string | undefined) => void | Promise<void>;
 }
 
 const SOURCE_ORDER: Record<AgentSource, number> = {
@@ -97,6 +100,28 @@ const SOURCE_LABEL: Record<AgentSource, string> = {
 };
 
 const IDENTIFIER_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+){1,5}$/;
+const MODEL_OVERRIDE_PERSISTENCE_WARNINGS = new WeakMap<Settings, Map<string, string>>();
+
+function getModelOverridePersistenceWarning(settings: Settings | null, agentName: string): string | undefined {
+	return settings ? MODEL_OVERRIDE_PERSISTENCE_WARNINGS.get(settings)?.get(agentName) : undefined;
+}
+
+function setModelOverridePersistenceWarning(
+	settings: Settings | null,
+	agentName: string,
+	warning: string | undefined,
+): void {
+	if (!settings) return;
+	const warnings = MODEL_OVERRIDE_PERSISTENCE_WARNINGS.get(settings);
+	if (warning === undefined) {
+		warnings?.delete(agentName);
+		if (warnings?.size === 0) MODEL_OVERRIDE_PERSISTENCE_WARNINGS.delete(settings);
+		return;
+	}
+	const nextWarnings = warnings ?? new Map<string, string>();
+	nextWarnings.set(agentName, warning);
+	MODEL_OVERRIDE_PERSISTENCE_WARNINGS.set(settings, nextWarnings);
+}
 
 function joinPatterns(patterns: string[]): string {
 	if (patterns.length === 0) return "(session model)";
@@ -270,6 +295,10 @@ class AgentInspectorPane implements Component {
 		lines.push(
 			`${theme.fg("muted", "Effective:")} ${this.effectiveResolution ? this.#formatResolution(this.effectiveResolution) : theme.fg("dim", "(unresolved)")}`,
 		);
+		if (this.agent.persistenceWarning) {
+			lines.push(theme.fg("warning", "Persistence: unconfirmed"));
+			lines.push(theme.fg("warning", "  Local override may not survive restart"));
+		}
 
 		if (this.agent.filePath) {
 			lines.push("");
@@ -310,6 +339,8 @@ export class AgentDashboard extends Container {
 
 	#editInput: Input | null = null;
 	#editingAgentName: string | null = null;
+	#modelOverrideSaving = false;
+	#modelOverrideGeneration = 0;
 
 	#createInput: Input | null = null;
 	#createDescription = "";
@@ -344,8 +375,22 @@ export class AgentDashboard extends Container {
 
 	async #init(): Promise<void> {
 		this.#settingsManager = this.settings ?? (await Settings.init());
+		const settingsManager = this.#settingsManager;
 		await this.#reloadData();
 		this.#buildLayout();
+
+		if (MODEL_OVERRIDE_PERSISTENCE_WARNINGS.get(settingsManager)?.size) {
+			void settingsManager
+				.flushOrThrow()
+				.then(async () => {
+					MODEL_OVERRIDE_PERSISTENCE_WARNINGS.delete(settingsManager);
+					await this.#reloadData();
+				})
+				.catch(() => {
+					// Keep the warning attached to this Settings instance until a
+					// later durable flush confirms the live value.
+				});
+		}
 	}
 
 	async #reloadData(): Promise<void> {
@@ -371,6 +416,7 @@ export class AgentDashboard extends Container {
 					...agent,
 					disabled: disabled.has(agent.name),
 					overrideModel: overrides[agent.name]?.trim() || undefined,
+					persistenceWarning: getModelOverridePersistenceWarning(this.#settingsManager, agent.name),
 				}));
 
 			this.#tabs = this.#buildTabs(this.#allAgents);
@@ -465,18 +511,6 @@ export class AgentDashboard extends Container {
 		this.#settingsManager.set("task.disabledAgents", disabled);
 	}
 
-	#persistModelOverrides(): void {
-		if (!this.#settingsManager) return;
-		const overrides: Record<string, string> = {};
-		for (const agent of this.#allAgents) {
-			const value = agent.overrideModel?.trim();
-			if (value) {
-				overrides[agent.name] = value;
-			}
-		}
-		this.#settingsManager.set("task.agentModelOverrides", overrides);
-	}
-
 	#toggleSelectedAgent(): void {
 		const selected = this.#selectedAgent();
 		if (!selected) return;
@@ -486,6 +520,7 @@ export class AgentDashboard extends Container {
 	}
 
 	#beginModelEdit(): void {
+		if (this.#modelOverrideSaving) return;
 		const selected = this.#selectedAgent();
 		if (!selected) return;
 		this.#createError = null;
@@ -495,26 +530,85 @@ export class AgentDashboard extends Container {
 			this.#editInput.setValue(selected.overrideModel);
 		}
 		this.#editInput.onSubmit = value => {
-			this.#saveModelOverride(value);
+			void this.#saveModelOverride(value);
 		};
 		this.#buildLayout();
 	}
 
-	#saveModelOverride(rawValue: string): void {
+	async #saveModelOverride(rawValue: string): Promise<void> {
 		if (!this.#editingAgentName) return;
 		const selected = this.#allAgents.find(agent => agent.name === this.#editingAgentName);
-		if (!selected) return;
+		if (!selected || this.#modelOverrideSaving) return;
+		this.#modelOverrideSaving = true;
+		const operationGeneration = ++this.#modelOverrideGeneration;
 		const value = rawValue.trim();
-		selected.overrideModel = value || undefined;
-		this.#persistModelOverrides();
+		try {
+			if (this.modelContext.onModelOverrideChange) {
+				await this.modelContext.onModelOverrideChange(selected.name, value || undefined);
+			} else if (value) {
+				this.#settingsManager?.setAgentModelOverride(selected.name, value);
+				await this.#settingsManager?.flushOrThrow();
+			} else {
+				this.#settingsManager?.clearAgentModelOverride(selected.name);
+				await this.#settingsManager?.flushOrThrow();
+			}
+		} catch (error) {
+			this.#modelOverrideSaving = false;
+			const effectiveValue = this.#settingsManager?.get("task.agentModelOverrides")[selected.name]?.trim();
+			const persistenceWarning = `Model override for ${selected.name} is ${effectiveValue || "(unset)"} locally, but persistence was not confirmed: ${error instanceof Error ? error.message : String(error)}`;
+			selected.overrideModel = effectiveValue || undefined;
+			selected.persistenceWarning = persistenceWarning;
+			setModelOverridePersistenceWarning(this.#settingsManager, selected.name, persistenceWarning);
+			if (operationGeneration !== this.#modelOverrideGeneration) {
+				this.#notice = `Background model override save for ${selected.name} was not confirmed: ${error instanceof Error ? error.message : String(error)}`;
+				this.#rebuildAndRender();
+				return;
+			}
+			this.#editingAgentName = null;
+			this.#editInput = null;
+			this.#applyFilters();
+			this.#notice = `Model override for ${selected.name} is ${effectiveValue || "(unset)"} locally, but persistence was not confirmed: ${error instanceof Error ? error.message : String(error)}`;
+			this.#rebuildAndRender();
+			return;
+		}
+
+		this.#modelOverrideSaving = false;
+		const effectiveValue = this.#settingsManager?.get("task.agentModelOverrides")[selected.name]?.trim();
+		const projectValue = this.#settingsManager?.getProject("task.agentModelOverrides")?.[selected.name]?.trim();
+		selected.overrideModel = effectiveValue || undefined;
+		selected.persistenceWarning = undefined;
+		setModelOverridePersistenceWarning(this.#settingsManager, selected.name, undefined);
+		if (operationGeneration !== this.#modelOverrideGeneration) {
+			this.#notice = `Background model override save completed for ${selected.name}`;
+			this.#rebuildAndRender();
+			return;
+		}
 		this.#editingAgentName = null;
 		this.#editInput = null;
 		this.#applyFilters();
-		this.#notice = `Updated model override for ${selected.name}`;
-		this.#buildLayout();
+		const projectProfile = this.modelContext.projectModelProfileShadow;
+		if (projectProfile?.targetIds.includes(selected.name)) {
+			const operation = value
+				? `Updated model override for ${selected.name}`
+				: `Cleared model override for ${selected.name}`;
+			this.#notice = `${operation} for this session; project model profile ${projectProfile.profileName} resumes on restart`;
+		} else if (value && projectValue && projectValue !== value) {
+			this.#notice = `Updated user override for ${selected.name} to ${value} for this session; project override ${projectValue} resumes on restart`;
+		} else if (!value && effectiveValue) {
+			this.#notice = `Cleared user override for ${selected.name}; effective override remains ${effectiveValue}`;
+		} else if (!value) {
+			this.#notice = `Cleared model override for ${selected.name}`;
+		} else {
+			this.#notice = `Updated model override for ${selected.name}`;
+		}
+		this.#rebuildAndRender();
 	}
 
 	#cancelModelEdit(): void {
+		if (this.#modelOverrideSaving) {
+			this.#modelOverrideGeneration++;
+			this.#notice = "Model override save continues in the background";
+		}
 		this.#editingAgentName = null;
 		this.#editInput = null;
 		this.#buildLayout();
@@ -719,8 +813,12 @@ export class AgentDashboard extends Container {
 	}
 
 	#effectivePatternsFor(agent: DashboardAgent, draftOverride: string | undefined): string[] {
+		const projectedOverride =
+			draftOverride !== undefined && draftOverride.trim() === ""
+				? this.#settingsManager?.getProject("task.agentModelOverrides")?.[agent.name]
+				: draftOverride;
 		return resolveAgentModelPatterns({
-			settingsOverride: draftOverride,
+			settingsOverride: projectedOverride,
 			agentModel: agent.model,
 			settings: this.#settingsManager ?? undefined,
 			activeModelPattern: this.modelContext.activeModelPattern,
@@ -1005,10 +1103,11 @@ export class AgentDashboard extends Container {
 		}
 
 		if (this.#editInput) {
-			if (matchesAppInterrupt(data)) {
+			if (matchesKey(data, "escape") || matchesKey(data, "esc") || matchesAppInterrupt(data)) {
 				this.#cancelModelEdit();
 				return;
 			}
+			if (this.#modelOverrideSaving) return;
 			this.#editInput.handleInput(data);
 			if (this.#editInput) {
 				this.#buildLayout();

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -325,6 +325,7 @@ export class ModelSelectorComponent extends Container {
 	#selectedActionIndex: number = 0;
 	#pendingThinkingChoice?: PendingThinkingChoice;
 	#selectedThinkingIndex: number = 0;
+	#selectionPending = false;
 
 	// Preset landing state
 	#viewMode: ModelSelectorViewMode = "presets";
@@ -467,10 +468,16 @@ export class ModelSelectorComponent extends Container {
 				modelRegistry: this.#modelRegistry,
 			});
 			if (resolved.model) {
+				const usesLiveDefaultEffort =
+					role === "default" &&
+					!resolved.explicitThinkingLevel &&
+					this.#currentModel?.provider === resolved.model.provider &&
+					this.#currentModel.id === resolved.model.id;
 				this.#roles[role] = {
 					model: resolved.model,
-					thinkingLevel:
-						resolved.explicitThinkingLevel && resolved.thinkingLevel !== undefined
+					thinkingLevel: usesLiveDefaultEffort
+						? (this.#currentThinkingLevel ?? ThinkingLevel.Inherit)
+						: resolved.explicitThinkingLevel && resolved.thinkingLevel !== undefined
 							? resolved.thinkingLevel
 							: ThinkingLevel.Inherit,
 				};
@@ -492,7 +499,11 @@ export class ModelSelectorComponent extends Container {
 		if ("activeModelProfile" in options) this.#activeModelProfile = options.activeModelProfile;
 		this.#roles = {};
 		this.#loadRoleModels();
-		this.#applyTabFilter();
+		if (this.#viewMode === "presets") {
+			this.#renderPresetLanding();
+		} else {
+			this.#applyTabFilter();
+		}
 	}
 
 	#sortModels(models: ModelItem[]): void {
@@ -855,14 +866,15 @@ export class ModelSelectorComponent extends Container {
 
 	#buildCustomModelProfileSnapshot(): ModelProfileConfig {
 		const modelMapping: ModelProfileConfig["model_mapping"] = {};
+		const configuredDefaultSelector = this.#resolveProfileModelSelector(this.#settings.getModelRole("default"));
+		const activeProfileDefaultSelector = this.#activeModelProfile
+			? this.#resolveProfileModelSelector(this.#getProfileByName(this.#activeModelProfile)?.modelMapping.default)
+			: undefined;
 		const currentModelSelector = this.#formatCurrentModelSelector();
-		if (currentModelSelector) {
-			modelMapping.default = currentModelSelector;
-		} else {
-			const defaultRole = this.#settings.getModelRole("default");
-			const defaultSelector = this.#resolveProfileModelSelector(defaultRole);
-			if (defaultSelector) modelMapping.default = defaultSelector;
-		}
+		const defaultSelector = this.#activeModelProfile
+			? (activeProfileDefaultSelector ?? configuredDefaultSelector ?? currentModelSelector)
+			: (configuredDefaultSelector ?? currentModelSelector);
+		if (defaultSelector) modelMapping.default = defaultSelector;
 
 		const agentOverrides = this.#settings.get("task.agentModelOverrides");
 		for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
@@ -1410,7 +1422,42 @@ export class ModelSelectorComponent extends Container {
 			: this.#filteredModels[this.#selectedIndex];
 	}
 
+	#handleSelectionFailure(error: unknown): void {
+		const message = error instanceof Error ? error.message : String(error);
+		this.#roles = {};
+		this.#loadRoleModels();
+		if (this.#viewMode === "presets") {
+			this.#presetLoginHint = message;
+			this.#renderPresetLanding();
+		} else {
+			this.#errorMessage = message;
+			this.#applyTabFilter();
+		}
+		this.#tui.requestRender();
+	}
+
+	#dispatchSelection(selection: ModelSelectorSelection): void | Promise<void> {
+		if (this.#selectionPending) return;
+		this.#selectionPending = true;
+		try {
+			const result = this.#onSelectCallback(selection);
+			if (result && typeof result.then === "function") {
+				return result
+					.catch(error => {
+						this.#handleSelectionFailure(error);
+					})
+					.finally(() => {
+						this.#selectionPending = false;
+					});
+			}
+		} catch (error) {
+			this.#handleSelectionFailure(error);
+		}
+		this.#selectionPending = false;
+	}
+
 	handleInput(keyData: string): void {
+		if (this.#selectionPending) return;
 		if (this.#pendingThinkingChoice) {
 			this.#handleThinkingMenuInput(keyData);
 			return;
@@ -1549,11 +1596,11 @@ export class ModelSelectorComponent extends Container {
 			const profile = this.#getProfileByName(this.#previewProfileName);
 			if (!profile) return;
 			if (this.#presetScopeIndex === 2 && isCustomUserProfile(profile)) {
-				this.#onSelectCallback({ kind: "renameProfile", profileName: this.#previewProfileName });
+				void this.#dispatchSelection({ kind: "renameProfile", profileName: this.#previewProfileName });
 				return;
 			}
 			if (this.#presetScopeIndex === 3 && isCustomUserProfile(profile)) {
-				this.#onSelectCallback({ kind: "deleteProfile", profileName: this.#previewProfileName });
+				void this.#dispatchSelection({ kind: "deleteProfile", profileName: this.#previewProfileName });
 				return;
 			}
 			const missing = this.#getMissingProviders(profile);
@@ -1562,7 +1609,7 @@ export class ModelSelectorComponent extends Container {
 				this.#renderPresetLanding();
 				return;
 			}
-			this.#onSelectCallback({
+			void this.#dispatchSelection({
 				kind: "profile",
 				profileName: this.#previewProfileName,
 				setDefault: this.#presetScopeIndex === 1,
@@ -1578,7 +1625,7 @@ export class ModelSelectorComponent extends Container {
 		const row = this.#getSelectedPresetRow();
 		if (!row) return;
 		if (row.kind === "create") {
-			this.#onSelectCallback({ kind: "createProfile", profile: this.#buildCustomModelProfileSnapshot() });
+			void this.#dispatchSelection({ kind: "createProfile", profile: this.#buildCustomModelProfileSnapshot() });
 			return;
 		}
 		if (row.kind === "alreadySaved" || row.kind === "createUnavailable") {
@@ -1758,7 +1805,7 @@ export class ModelSelectorComponent extends Container {
 
 		// For temporary role, don't save to settings - just notify caller
 		if (role === null) {
-			this.#onSelectCallback({
+			void this.#dispatchSelection({
 				kind: "assignment",
 				model: item.model,
 				role: null,
@@ -1781,7 +1828,7 @@ export class ModelSelectorComponent extends Container {
 		}
 
 		// Notify caller (for updating agent state if needed)
-		this.#onSelectCallback({
+		void this.#dispatchSelection({
 			kind: "assignment",
 			model: item.model,
 			role,
@@ -1798,15 +1845,15 @@ export class ModelSelectorComponent extends Container {
 		return this.#searchInput;
 	}
 	async __testSelectProfile(profileName: string, setDefault: boolean): Promise<void> {
-		await this.#onSelectCallback({ kind: "profile", profileName, setDefault });
+		await this.#dispatchSelection({ kind: "profile", profileName, setDefault });
 	}
 	async __testSelectAssignment(
 		selection: Omit<Extract<ModelSelectorSelection, { kind: "assignment" }>, "kind">,
 	): Promise<void> {
-		await this.#onSelectCallback({ kind: "assignment", ...selection });
+		await this.#dispatchSelection({ kind: "assignment", ...selection });
 	}
 	async __testSelectPresetAction(profileName: string, action: "rename" | "delete"): Promise<void> {
-		await this.#onSelectCallback({
+		await this.#dispatchSelection({
 			kind: action === "rename" ? "renameProfile" : "deleteProfile",
 			profileName,
 		});
@@ -1824,7 +1871,7 @@ function requiresExplicitThinkingChoice(model: Model, role: GjcModelAssignmentTa
 }
 
 function getSelectableThinkingLevels(model: Model): ThinkingLevel[] {
-	const levels: ThinkingLevel[] = [ThinkingLevel.Off];
+	const levels: ThinkingLevel[] = [ThinkingLevel.Inherit, ThinkingLevel.Off];
 	let efforts: readonly string[];
 	try {
 		efforts = getSupportedEfforts(model);

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -78,13 +78,14 @@ class SelectSubmenu extends Container {
 	#selectList: SelectList;
 	#previewText: Text | null = null;
 	#previewUpdateRequestId: number = 0;
+	#selectPending = false;
 
 	constructor(
 		title: string,
 		description: string,
 		options: ReadonlyArray<SelectItem>,
 		currentValue: string,
-		onSelect: (value: string) => void,
+		onSelect: (value: string) => void | Promise<void>,
 		onCancel: () => void,
 		onSelectionChange?: (value: string) => void | Promise<void>,
 		private readonly getPreview?: () => string,
@@ -121,7 +122,25 @@ class SelectSubmenu extends Container {
 		}
 
 		this.#selectList.onSelect = item => {
-			onSelect(item.value);
+			if (this.#selectPending) return;
+			this.#selectPending = true;
+			try {
+				const result = onSelect(item.value);
+				if (result && typeof (result as Promise<void>).then === "function") {
+					void (result as Promise<void>)
+						.catch(() => {
+							// The callback owns user-facing error reporting. Keep the
+							// submenu open so the prior selection remains visible.
+						})
+						.finally(() => {
+							this.#selectPending = false;
+						});
+					return;
+				}
+			} catch {
+				// The callback owns user-facing error reporting.
+			}
+			this.#selectPending = false;
 		};
 
 		this.#selectList.onCancel = onCancel;
@@ -158,6 +177,7 @@ class SelectSubmenu extends Container {
 	}
 
 	handleInput(data: string): void {
+		if (this.#selectPending) return;
 		this.#selectList.handleInput(data);
 	}
 }
@@ -677,7 +697,7 @@ export interface StatusLinePreviewSettings {
 
 export interface SettingsCallbacks {
 	/** Called when any setting value changes */
-	onChange: (path: SettingPath, newValue: unknown) => void;
+	onChange: (path: SettingPath, newValue: unknown) => void | Promise<void>;
 	/** Called for theme preview while browsing theme settings */
 	onThemePreview?: (theme: string) => void | Promise<void>;
 	/** Called to restore the rendered theme when theme settings preview is cancelled */
@@ -704,6 +724,8 @@ export class SettingsSelectorComponent extends Container {
 	#statusPreviewText: Text | null = null;
 	#currentTabId: SettingTab | "plugins" = "appearance";
 	#textInputActive = false;
+	#asyncChangePending = false;
+	#asyncChangeRequestId = 0;
 
 	constructor(
 		private readonly context: SettingsRuntimeContext,
@@ -937,8 +959,23 @@ export class SettingsSelectorComponent extends Container {
 			options,
 			currentValue,
 			value => {
-				this.#setSettingValue(def.path, value);
-				this.callbacks.onChange(def.path, value);
+				// Profile activation owns persistence so credential/model failures
+				// cannot leave a default profile selected only on disk.
+				if (def.path !== "modelProfile.default") {
+					this.#setSettingValue(def.path, value);
+				}
+				const result = this.callbacks.onChange(def.path, value);
+				if (result && typeof result.then === "function") {
+					const requestId = ++this.#asyncChangeRequestId;
+					this.#asyncChangePending = true;
+					return result
+						.then(() => {
+							if (requestId === this.#asyncChangeRequestId) done(value);
+						})
+						.finally(() => {
+							if (requestId === this.#asyncChangeRequestId) this.#asyncChangePending = false;
+						});
+				}
 				done(value);
 			},
 			() => {
@@ -1167,6 +1204,14 @@ export class SettingsSelectorComponent extends Container {
 	}
 
 	handleInput(data: string): void {
+		if (this.#asyncChangePending) {
+			if (matchesKey(data, "escape") || matchesKey(data, "esc") || matchesAppInterrupt(data)) {
+				this.#asyncChangeRequestId++;
+				this.#asyncChangePending = false;
+				this.callbacks.onCancel();
+			}
+			return;
+		}
 		// Handle tab switching — but NOT when a text input is active, since
 		// arrow keys must reach the cursor and Tab must not switch tabs.
 		if (

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 
 import { ThinkingLevel } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import type { OAuthProvider } from "@gajae-code/ai/utils/oauth/types";
 import type { Component, OverlayHandle } from "@gajae-code/tui";
@@ -8,17 +9,19 @@ import { Input, Loader, Spacer, Text } from "@gajae-code/tui";
 import { getAgentDbPath, getProjectDir } from "@gajae-code/utils";
 import {
 	activateModelProfile,
+	createActiveModelProfileRuntimeRollback,
 	type MaterializeModelProfileForDeletionResult,
 	materializeActiveModelProfileAssignment,
 	materializeActiveModelProfileAssignments,
 	materializeModelProfileForDeletion,
+	resolveProjectModelProfileShadow,
 	restoreMaterializedModelProfileForDeletion,
 } from "../../config/model-profile-activation";
 import { formatModelProfileDisplayLabel, recommendModelProfileForProvider } from "../../config/model-profiles";
 import { GJC_MODEL_ASSIGNMENT_TARGETS, type GjcModelAssignmentTargetId } from "../../config/model-registry";
-import { formatModelSelectorValue } from "../../config/model-resolver";
+import { extractExplicitThinkingSelector, formatModelSelectorValue } from "../../config/model-resolver";
 import type { ModelProfileConfig } from "../../config/models-config-schema";
-import { type Settings, settings } from "../../config/settings";
+import { type Settings, type SettingsMutationCheckpoint, settings } from "../../config/settings";
 import { DebugSelectorComponent } from "../../debug";
 import { disableProvider, enableProvider } from "../../discovery";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
@@ -59,6 +62,7 @@ import {
 	MODEL_ONBOARDING_SETUP_COMMAND,
 } from "../../setup/model-onboarding-guidance";
 import { addApiCompatibleProvider, formatProviderSetupResult } from "../../setup/provider-onboarding";
+import { clampModelAssignmentThinkingLevel } from "../../thinking";
 import {
 	isConfigurableSearchProviderId,
 	isSearchProviderPreference,
@@ -280,8 +284,8 @@ export class SelectorController {
 				try {
 					const profile = await this.ctx.session.modelRegistry.saveCustomModelProfile(input.name, input.profile);
 					await this.ctx.session.modelRegistry.refresh("offline");
-					await this.ctx.notifyConfigChanged?.();
 					this.ctx.showStatus(`Custom model preset created: ${formatModelProfileDisplayLabel(profile)}`);
+					this.#notifyConfigChangedSafely();
 					done();
 					this.ctx.ui.requestRender();
 				} catch (err) {
@@ -318,9 +322,9 @@ export class SelectorController {
 		try {
 			const renamed = await this.ctx.session.modelRegistry.renameCustomModelProfile(profileName, input);
 			await this.ctx.session.modelRegistry.refresh("offline");
-			await this.ctx.notifyConfigChanged?.();
 			modelSelector.refreshPresetProfiles(renamed.name);
 			this.ctx.showStatus(`Custom model preset renamed: ${formatModelProfileDisplayLabel(renamed)}`);
+			this.#notifyConfigChangedSafely();
 			this.ctx.ui.requestRender();
 		} catch (err) {
 			this.ctx.showError(`Preset rename failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -362,11 +366,13 @@ export class SelectorController {
 					profileName,
 				});
 			}
-			deletedProfile = await this.ctx.session.modelRegistry.deleteCustomModelProfile(profileName);
+			deletedProfile = await this.ctx.settings.deleteModelProfileIfUnreferenced(profileName, () =>
+				this.ctx.session.modelRegistry.deleteCustomModelProfile(profileName),
+			);
 			await this.ctx.session.modelRegistry.refresh("offline");
-			await this.ctx.notifyConfigChanged?.();
 			refreshSelectorState();
 			this.ctx.showStatus(`Custom model preset deleted: ${profileLabel}`);
+			this.#notifyConfigChangedSafely();
 			this.ctx.ui.requestRender();
 		} catch (err) {
 			let presetRestoreError: unknown;
@@ -411,8 +417,8 @@ export class SelectorController {
 				try {
 					const result = await addApiCompatibleProvider(input);
 					await this.ctx.session.modelRegistry.refresh("offline");
-					await this.ctx.notifyConfigChanged?.();
 					this.ctx.showStatus(formatProviderSetupResult(result));
+					this.#notifyConfigChangedSafely();
 					done();
 					this.ctx.ui.requestRender();
 				} catch (err) {
@@ -461,7 +467,7 @@ export class SelectorController {
 					this.ctx.statusLine.invalidate();
 					this.ctx.updateEditorBorderColor();
 					this.ctx.updateEditorTopBorder();
-					if (persistDefault) void this.ctx.notifyConfigChanged?.();
+					if (persistDefault) void this.#notifyConfigChangedSafely();
 					this.ctx.ui.requestRender();
 					const scopeLabel = persistDefault ? "Default reasoning effort" : "Reasoning effort";
 					this.ctx.showStatus(
@@ -629,6 +635,28 @@ export class SelectorController {
 			modelRegistry: this.ctx.session.modelRegistry,
 			activeModelPattern,
 			defaultModelPattern,
+			projectModelProfileShadow: resolveProjectModelProfileShadow(this.ctx.settings, this.ctx.session.modelRegistry),
+			onModelOverrideChange: async (agentName, value) => {
+				if (agentName !== "default" && Object.hasOwn(GJC_MODEL_ASSIGNMENT_TARGETS, agentName)) {
+					const role = agentName as GjcModelAssignmentTargetId;
+					const materializedProfile = materializeActiveModelProfileAssignment({
+						session: this.ctx.session,
+						settings: this.ctx.settings,
+						role,
+						selector: value,
+					});
+					if (materializedProfile) {
+						await this.ctx.settings.flushOrThrow();
+						return;
+					}
+				}
+				if (value) {
+					this.ctx.settings.setAgentModelOverride(agentName, value);
+				} else {
+					this.ctx.settings.clearAgentModelOverride(agentName);
+				}
+				await this.ctx.settings.flushOrThrow();
+			},
 		});
 		this.showSelector(done => {
 			dashboard.onClose = () => {
@@ -647,7 +675,7 @@ export class SelectorController {
 	 * Most settings are saved directly via SettingsManager in the definitions.
 	 * This handles side effects and session-specific settings.
 	 */
-	handleSettingChange(id: string, value: unknown): void {
+	handleSettingChange(id: string, value: unknown): void | Promise<void> {
 		// Discovery provider toggles
 		if (id.startsWith("discovery.")) {
 			const providerId = id.replace("discovery.", "");
@@ -686,12 +714,12 @@ export class SelectorController {
 				// running session switches immediately, not only on next startup.
 				const profileName = typeof value === "string" ? value : "";
 				if (!profileName) break;
-				this.#applyModelProfile(profileName, true)
+				return this.#applyModelProfile(profileName, true)
 					.then(() => this.ctx.ui.requestRender())
 					.catch(error => {
 						this.ctx.showError(error instanceof Error ? error.message : String(error));
+						throw error;
 					});
-				break;
 			}
 			case "clearOnShrink":
 				this.ctx.ui.setClearOnShrink(value as boolean);
@@ -849,6 +877,66 @@ export class SelectorController {
 		}
 	}
 
+	#notifyConfigChangedSafely(): void {
+		void Promise.resolve()
+			.then(() => this.ctx.notifyConfigChanged?.())
+			.catch(error => {
+				this.ctx.showError(
+					`Configuration was updated, but change notification failed: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			})
+			.catch(() => {});
+	}
+
+	#getSessionActiveModelProfile(): string | undefined {
+		const getActiveModelProfile = this.ctx.session.getActiveModelProfile;
+		return getActiveModelProfile
+			? getActiveModelProfile.call(this.ctx.session)
+			: this.ctx.settings.get("modelProfile.default");
+	}
+
+	#resolveDefaultModelThinking(
+		model: Model,
+		selectedThinkingLevel: ThinkingLevel | undefined,
+	): { effective: ThinkingLevel | undefined; persisted: ThinkingLevel | undefined } {
+		const configuredDefault = this.ctx.settings.get("defaultThinkingLevel");
+		const existingExplicit = extractExplicitThinkingSelector(
+			this.ctx.settings.getModelRole("default"),
+			this.ctx.settings,
+		);
+		const inherited =
+			this.#getSessionActiveModelProfile() !== undefined
+				? (this.ctx.session.thinkingLevel ?? configuredDefault)
+				: (existingExplicit ?? configuredDefault);
+		const persisted = clampModelAssignmentThinkingLevel(
+			model,
+			selectedThinkingLevel === undefined
+				? this.#getSessionActiveModelProfile() !== undefined
+					? inherited
+					: existingExplicit
+				: selectedThinkingLevel,
+		);
+		const effective = clampModelAssignmentThinkingLevel(
+			model,
+			selectedThinkingLevel === ThinkingLevel.Inherit ? configuredDefault : (selectedThinkingLevel ?? inherited),
+		);
+		return { effective, persisted };
+	}
+
+	#formatProjectModelRestartNotice(targetRoles: readonly GjcModelAssignmentTargetId[]): string {
+		const projectModelRoles = this.ctx.settings.getProject("modelRoles") ?? {};
+		const projectAgentOverrides = this.ctx.settings.getProject("task.agentModelOverrides") ?? {};
+		const projectProfile = resolveProjectModelProfileShadow(this.ctx.settings, this.ctx.session.modelRegistry);
+		const shadowed = targetRoles.filter(role => {
+			const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+			const direct = target.settingsPath === "modelRoles" ? projectModelRoles[role] : projectAgentOverrides[role];
+			return direct !== undefined || projectProfile?.targetIds.includes(role) === true;
+		});
+		if (shadowed.length === 0) return "";
+		const labels = shadowed.map(role => GJC_MODEL_ASSIGNMENT_TARGETS[role].tag ?? role.toUpperCase());
+		return ` Project settings for ${labels.join(", ")} resume on restart.`;
+	}
+
 	/**
 	 * Activate a model profile through the shared /model + /settings path: swap the
 	 * live session model (and, when persistDefault, persist it as the startup
@@ -870,6 +958,7 @@ export class SelectorController {
 		this.ctx.statusLine.invalidate();
 		this.ctx.updateEditorBorderColor();
 		this.ctx.showStatus(persistDefault ? `Default model profile: ${profileLabel}` : `Model profile: ${profileLabel}`);
+		this.#notifyConfigChangedSafely();
 	}
 
 	showModelSelector(options?: { temporaryOnly?: boolean }): void {
@@ -882,6 +971,10 @@ export class SelectorController {
 				this.ctx.session.modelRegistry,
 				this.ctx.session.scopedModels,
 				async selection => {
+					let mutationCheckpoint: SettingsMutationCheckpoint | undefined;
+					let profileRuntimeRollback: (() => void) | undefined;
+					let sessionModelStaged = false;
+					let settingsCommitted = false;
 					try {
 						if (selection.kind === "createProfile") {
 							done();
@@ -911,11 +1004,97 @@ export class SelectorController {
 							this.ctx.showStatus(`Temporary model: ${selectedSelector ?? model.id}`);
 							done();
 							this.ctx.ui.requestRender();
-						} else if (selection.roles) {
-							const targetRoles: readonly GjcModelAssignmentTargetId[] = selection.roles;
-							const includesDefault = targetRoles.includes("default");
-							const includesRoleAgent = targetRoles.some(targetRole => targetRole !== "default");
-							if (includesRoleAgent) {
+							return;
+						}
+						mutationCheckpoint = await this.ctx.settings.createMutationCheckpoint();
+						const activeMutationCheckpoint = mutationCheckpoint;
+						profileRuntimeRollback = createActiveModelProfileRuntimeRollback(this.ctx.session);
+						await this.ctx.settings.runMutationCheckpoint(activeMutationCheckpoint, async () => {
+							if (selection.roles) {
+								const targetRoles: readonly GjcModelAssignmentTargetId[] = selection.roles;
+								const includesDefault = targetRoles.includes("default");
+								const includesRoleAgent = targetRoles.some(targetRole => targetRole !== "default");
+								if (includesDefault || includesRoleAgent) {
+									const apiKey = await this.ctx.session.modelRegistry.getApiKey(
+										model,
+										this.ctx.session.sessionId,
+									);
+									if (!apiKey) {
+										throw new Error(`No API key for ${model.provider}/${model.id}`);
+									}
+								}
+								const defaultThinking = includesDefault
+									? this.#resolveDefaultModelThinking(model, thinkingLevel)
+									: undefined;
+								const persistedThinkingLevel =
+									defaultThinking?.persisted ?? clampModelAssignmentThinkingLevel(model, thinkingLevel);
+								const selectorBase =
+									selectedSelector &&
+									thinkingLevel !== ThinkingLevel.Inherit &&
+									thinkingLevel !== undefined &&
+									selectedSelector.endsWith(`:${thinkingLevel}`)
+										? selectedSelector.slice(0, -thinkingLevel.length - 1)
+										: (selectedSelector ?? `${model.provider}/${model.id}`);
+								const value = formatModelSelectorValue(selectorBase, persistedThinkingLevel);
+								const assignments = new Map<GjcModelAssignmentTargetId, string>();
+								for (const targetRole of targetRoles) assignments.set(targetRole, value);
+
+								if (includesDefault) {
+									sessionModelStaged = true;
+									const liveThinkingLevel =
+										defaultThinking?.effective !== undefined &&
+										defaultThinking.effective !== ThinkingLevel.Inherit
+											? defaultThinking.effective
+											: persistedThinkingLevel;
+									await this.ctx.session.setModelForSettingsCommit(model, liveThinkingLevel);
+								}
+								const materializedProfile = materializeActiveModelProfileAssignments({
+									session: this.ctx.session,
+									settings: this.ctx.settings,
+									assignments,
+								});
+								if (!materializedProfile) {
+									for (const targetRole of targetRoles) {
+										if (targetRole === "default") {
+											this.ctx.settings.setModelRole(targetRole, value);
+										} else {
+											this.ctx.settings.setAgentModelOverride(targetRole, value);
+										}
+									}
+								}
+								await this.ctx.settings.flushMutationCheckpoint(activeMutationCheckpoint);
+								settingsCommitted = true;
+								profileRuntimeRollback = undefined;
+								this.ctx.settings.releaseMutationCheckpoint(activeMutationCheckpoint);
+								mutationCheckpoint = undefined;
+								if (includesDefault) {
+									sessionModelStaged = false;
+									await this.ctx.session.commitSettingsModelChange(model);
+								}
+								modelSelector.refreshRoleAssignments({
+									currentModel: this.ctx.session.model,
+									currentThinkingLevel: this.ctx.session.thinkingLevel,
+									activeModelProfile: this.#getSessionActiveModelProfile(),
+								});
+								this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
+								this.ctx.statusLine.invalidate();
+								this.ctx.updateEditorBorderColor();
+								const labels = targetRoles.map(
+									targetRole => GJC_MODEL_ASSIGNMENT_TARGETS[targetRole].tag ?? targetRole.toUpperCase(),
+								);
+								const projectRestartNotice = this.#formatProjectModelRestartNotice(targetRoles);
+								this.ctx.showStatus(
+									(includesDefault
+										? `All model targets set to ${value} for ${labels.join(", ")}.`
+										: `Role-agent models set to ${value} for ${labels.join(", ")}.`) + projectRestartNotice,
+								);
+								this.#notifyConfigChangedSafely();
+								done();
+								this.ctx.ui.requestRender();
+							} else if (role === "default") {
+								// Default: update agent state and persist as the active default model.
+								const defaultThinking = this.#resolveDefaultModelThinking(model, thinkingLevel);
+								const selectorBase = selectedSelector ?? `${model.provider}/${model.id}`;
 								const apiKey = await this.ctx.session.modelRegistry.getApiKey(
 									model,
 									this.ctx.session.sessionId,
@@ -923,137 +1102,149 @@ export class SelectorController {
 								if (!apiKey) {
 									throw new Error(`No API key for ${model.provider}/${model.id}`);
 								}
-							}
-							const value =
-								selectedSelector ?? formatModelSelectorValue(`${model.provider}/${model.id}`, thinkingLevel);
-							const assignments = new Map<GjcModelAssignmentTargetId, string>();
-							for (const targetRole of targetRoles) assignments.set(targetRole, value);
-							const defaultSelector =
-								selectedSelector && thinkingLevel && selectedSelector.endsWith(`:${thinkingLevel}`)
-									? selectedSelector.slice(0, -thinkingLevel.length - 1)
-									: selectedSelector;
-
-							if (includesDefault) {
-								await this.ctx.session.setModel(model, "default", {
-									selector: defaultSelector,
-									thinkingLevel,
+								sessionModelStaged = true;
+								const liveThinkingLevel =
+									defaultThinking.effective !== undefined &&
+									defaultThinking.effective !== ThinkingLevel.Inherit
+										? defaultThinking.effective
+										: defaultThinking.persisted;
+								await this.ctx.session.setModelForSettingsCommit(model, liveThinkingLevel);
+								const value = formatModelSelectorValue(selectorBase, defaultThinking.persisted);
+								const materializedProfile = materializeActiveModelProfileAssignment({
+									session: this.ctx.session,
+									settings: this.ctx.settings,
+									role,
+									selector: value,
 								});
-								if (thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit) {
-									this.ctx.session.setThinkingLevel(thinkingLevel);
+								if (!materializedProfile) this.ctx.settings.setModelRole(role, value);
+								await this.ctx.settings.flushMutationCheckpoint(activeMutationCheckpoint);
+								settingsCommitted = true;
+								profileRuntimeRollback = undefined;
+								this.ctx.settings.releaseMutationCheckpoint(activeMutationCheckpoint);
+								mutationCheckpoint = undefined;
+								sessionModelStaged = false;
+								await this.ctx.session.commitSettingsModelChange(model);
+								this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
+								modelSelector.refreshRoleAssignments({
+									currentModel: this.ctx.session.model,
+									currentThinkingLevel: this.ctx.session.thinkingLevel,
+									activeModelProfile: this.#getSessionActiveModelProfile(),
+								});
+								this.ctx.statusLine.invalidate();
+								this.ctx.updateEditorBorderColor();
+								const effectiveValue = formatModelSelectorValue(
+									`${model.provider}/${model.id}`,
+									defaultThinking.effective,
+								);
+								const projectRestartNotice = this.#formatProjectModelRestartNotice([role]);
+								this.ctx.showStatus(
+									(effectiveValue === value
+										? `Default model: ${value}`
+										: `Default model: ${value} (effective: ${effectiveValue})`) + projectRestartNotice,
+								);
+								this.#notifyConfigChangedSafely();
+								done();
+								this.ctx.ui.requestRender();
+							} else {
+								const apiKey = await this.ctx.session.modelRegistry.getApiKey(
+									model,
+									this.ctx.session.sessionId,
+								);
+								if (!apiKey) {
+									throw new Error(`No API key for ${model.provider}/${model.id}`);
 								}
-							}
-							const materializedProfile = materializeActiveModelProfileAssignments({
-								session: this.ctx.session,
-								settings: this.ctx.settings,
-								assignments,
-							});
-							if (!materializedProfile) {
-								const overrides = this.ctx.settings.get("task.agentModelOverrides");
-								const nextOverrides = { ...overrides };
-								let writesOverrides = false;
-								for (const targetRole of targetRoles) {
-									const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetRole];
+								const clampedThinkingLevel = clampModelAssignmentThinkingLevel(model, thinkingLevel);
+								const selectorBase =
+									selectedSelector &&
+									thinkingLevel !== undefined &&
+									thinkingLevel !== ThinkingLevel.Inherit &&
+									selectedSelector.endsWith(`:${thinkingLevel}`)
+										? selectedSelector.slice(0, -thinkingLevel.length - 1)
+										: (selectedSelector ?? `${model.provider}/${model.id}`);
+								const value = formatModelSelectorValue(selectorBase, clampedThinkingLevel);
+								const assignments = new Map<GjcModelAssignmentTargetId, string>([[role, value]]);
+								const materializedProfile = materializeActiveModelProfileAssignments({
+									session: this.ctx.session,
+									settings: this.ctx.settings,
+									assignments,
+								});
+								if (!materializedProfile) {
+									const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
 									if (target.settingsPath === "modelRoles") {
-										this.ctx.settings.setModelRole(targetRole, value);
+										this.ctx.settings.setModelRole(role, value);
 									} else {
-										nextOverrides[targetRole] = value;
-										writesOverrides = true;
+										this.ctx.settings.setAgentModelOverride(role, value);
 									}
 								}
-								if (writesOverrides) {
-									this.ctx.settings.set("task.agentModelOverrides", nextOverrides);
-								}
+								await this.ctx.settings.flushMutationCheckpoint(activeMutationCheckpoint);
+								settingsCommitted = true;
+								profileRuntimeRollback = undefined;
+								this.ctx.settings.releaseMutationCheckpoint(activeMutationCheckpoint);
+								mutationCheckpoint = undefined;
+								modelSelector.refreshRoleAssignments({
+									currentModel: this.ctx.session.model,
+									currentThinkingLevel: this.ctx.session.thinkingLevel,
+									activeModelProfile: this.#getSessionActiveModelProfile(),
+								});
+								this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
+								this.ctx.statusLine.invalidate();
+								this.ctx.updateEditorBorderColor();
+								this.ctx.showStatus(
+									`${role} agent model: ${value}${this.#formatProjectModelRestartNotice([role])}`,
+								);
+								this.#notifyConfigChangedSafely();
+								done();
+								this.ctx.ui.requestRender();
 							}
-							modelSelector.refreshRoleAssignments({
-								currentModel: this.ctx.session.model,
-								currentThinkingLevel: this.ctx.session.thinkingLevel,
-								activeModelProfile:
-									this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
-							});
-							this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
-							this.ctx.statusLine.invalidate();
-							this.ctx.updateEditorBorderColor();
-							await this.ctx.notifyConfigChanged?.();
-							const labels = targetRoles.map(
-								targetRole => GJC_MODEL_ASSIGNMENT_TARGETS[targetRole].tag ?? targetRole.toUpperCase(),
-							);
-							this.ctx.showStatus(
-								includesDefault
-									? `All model targets set to ${value} for ${labels.join(", ")}.`
-									: `Role-agent models set to ${value} for ${labels.join(", ")}.`,
-							);
-							done();
-							this.ctx.ui.requestRender();
-						} else if (role === "default") {
-							// Default: update agent state and persist as the active default model.
-							await this.ctx.session.setModel(model, role, {
-								selector: selectedSelector,
-								thinkingLevel,
-							});
-							const value = formatModelSelectorValue(
-								selectedSelector ?? `${model.provider}/${model.id}`,
-								thinkingLevel,
-							);
-							materializeActiveModelProfileAssignment({
-								session: this.ctx.session,
-								settings: this.ctx.settings,
-								role,
-								selector: value,
-							});
-							if (thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit) {
-								this.ctx.session.setThinkingLevel(thinkingLevel);
-							}
-							modelSelector.refreshRoleAssignments({
-								currentModel: this.ctx.session.model,
-								currentThinkingLevel: this.ctx.session.thinkingLevel,
-								activeModelProfile:
-									this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
-							});
-							this.ctx.statusLine.invalidate();
-							this.ctx.updateEditorBorderColor();
-							this.ctx.showStatus(`Default model: ${selectedSelector ?? model.id}`);
-							done();
-							this.ctx.ui.requestRender();
-						} else {
-							const apiKey = await this.ctx.session.modelRegistry.getApiKey(model, this.ctx.session.sessionId);
-							if (!apiKey) {
-								throw new Error(`No API key for ${model.provider}/${model.id}`);
-							}
-							const value =
-								selectedSelector ?? formatModelSelectorValue(`${model.provider}/${model.id}`, thinkingLevel);
-							const assignments = new Map<GjcModelAssignmentTargetId, string>([[role, value]]);
-							const materializedProfile = materializeActiveModelProfileAssignments({
-								session: this.ctx.session,
-								settings: this.ctx.settings,
-								assignments,
-							});
-							if (!materializedProfile) {
-								const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
-								if (target.settingsPath === "modelRoles") {
-									this.ctx.settings.setModelRole(role, value);
-								} else {
-									this.ctx.settings.set("task.agentModelOverrides", {
-										...this.ctx.settings.get("task.agentModelOverrides"),
-										[role]: value,
-									});
-								}
-							}
-							modelSelector.refreshRoleAssignments({
-								currentModel: this.ctx.session.model,
-								currentThinkingLevel: this.ctx.session.thinkingLevel,
-								activeModelProfile:
-									this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
-							});
-							this.ctx.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
-							this.ctx.statusLine.invalidate();
-							this.ctx.updateEditorBorderColor();
-							await this.ctx.notifyConfigChanged?.();
-							this.ctx.showStatus(`${role} agent model: ${value}`);
-							done();
-							this.ctx.ui.requestRender();
-						}
+						});
 					} catch (error) {
-						this.ctx.showError(error instanceof Error ? error.message : String(error));
+						if (settingsCommitted) {
+							if (mutationCheckpoint) {
+								try {
+									this.ctx.settings.releaseMutationCheckpoint(mutationCheckpoint);
+								} catch {}
+								mutationCheckpoint = undefined;
+							}
+							if (sessionModelStaged) {
+								this.ctx.session.cancelSettingsModelChange();
+								sessionModelStaged = false;
+							}
+						} else {
+							if (mutationCheckpoint) {
+								this.ctx.settings.restoreMutationCheckpoint(mutationCheckpoint);
+								mutationCheckpoint = undefined;
+							}
+							profileRuntimeRollback?.();
+							profileRuntimeRollback = undefined;
+							if (sessionModelStaged) {
+								this.ctx.session.cancelSettingsModelChange();
+								sessionModelStaged = false;
+							}
+						}
+						const message = error instanceof Error ? error.message : String(error);
+						try {
+							this.ctx.showError(
+								settingsCommitted
+									? `Model settings were committed, but a session follow-up failed: ${message}`
+									: message,
+							);
+						} catch {}
+						try {
+							modelSelector.refreshRoleAssignments({
+								currentModel: this.ctx.session.model,
+								currentThinkingLevel: this.ctx.session.thinkingLevel,
+								activeModelProfile: this.#getSessionActiveModelProfile(),
+							});
+						} catch {}
+						try {
+							this.ctx.statusLine.invalidate();
+						} catch {}
+						try {
+							this.ctx.updateEditorBorderColor();
+						} catch {}
+						try {
+							this.ctx.ui.requestRender();
+						} catch {}
 					}
 				},
 				() => {
@@ -1064,11 +1255,10 @@ export class SelectorController {
 					...options,
 					sessionId: this.ctx.session.sessionId,
 					currentThinkingLevel: this.ctx.session.thinkingLevel,
-					activeModelProfile:
-						this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default"),
+					activeModelProfile: this.#getSessionActiveModelProfile(),
 					isFastForProvider: provider => this.ctx.session.isFastForProvider(provider),
 					isFastForSubagentProvider: provider => this.ctx.session.isFastForSubagentProvider(provider),
-					isCurrentModelFastModeActive: () => this.ctx.session.isFastModeActive(),
+					isCurrentModelFastModeActive: () => this.ctx.session.isFastModeActive?.() ?? false,
 				},
 			);
 			return { component: modelSelector, focus: modelSelector };
@@ -1484,7 +1674,7 @@ export class SelectorController {
 			return;
 		}
 
-		const activeProfile = this.ctx.session.getActiveModelProfile?.() ?? this.ctx.settings.get("modelProfile.default");
+		const activeProfile = this.#getSessionActiveModelProfile();
 		if (activeProfile) {
 			this.ctx.showStatus(`Preset ${recommendedProfile.name} is available in /model.`);
 			return;
@@ -1495,12 +1685,8 @@ export class SelectorController {
 			return;
 		}
 
-		await activateModelProfile({
-			session: this.ctx.session,
-			modelRegistry: this.ctx.session.modelRegistry,
-			settings: this.ctx.settings,
-			profileName: recommendedProfile.name,
-		});
+		await this.#applyModelProfile(recommendedProfile.name, false);
+		this.ctx.ui.requestRender();
 	}
 
 	async #handleOAuthLogin(providerId: string): Promise<void> {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -110,7 +110,7 @@ import { AgentSession, type ForkContextSeed } from "./session/agent-session";
 import { resolveAuthBrokerConfig } from "./session/auth-broker-config";
 import { AuthBrokerClient, AuthStorage, RemoteAuthCredentialStore } from "./session/auth-storage";
 import { type CustomMessage, convertToLlm } from "./session/messages";
-import { SessionManager } from "./session/session-manager";
+import { hasPersistedThinkingLevel, SessionManager } from "./session/session-manager";
 import { formatNoModelsAvailableFallback } from "./setup/model-onboarding-guidance";
 import { closeAllConnections } from "./ssh/connection-manager";
 import { unmountAll } from "./ssh/sshfs-mount";
@@ -1057,7 +1057,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	);
 	const existingBranch = logger.time("getSessionBranch", () => sessionManager.getBranch());
 	const hasExistingSession = existingBranch.length > 0;
-	const hasThinkingEntry = existingBranch.some(entry => entry.type === "thinking_level_change");
+	const hasThinkingEntry = hasPersistedThinkingLevel(existingBranch);
 	const hasServiceTierEntry = existingBranch.some(entry => entry.type === "service_tier_change");
 
 	const hasExplicitModel = options.model !== undefined || options.modelPattern !== undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -301,7 +301,7 @@ import type {
 	SessionContext,
 	SessionManager,
 } from "./session-manager";
-import { getLatestCompactionEntry } from "./session-manager";
+import { getLatestCompactionEntry, hasPersistedThinkingLevel } from "./session-manager";
 import { ToolChoiceQueue } from "./tool-choice-queue";
 import { YieldQueue } from "./yield-queue";
 
@@ -1172,6 +1172,12 @@ export class AgentSession {
 	#scopedModels: ScopedModelSelection[];
 	#thinkingLevel: ThinkingLevel | undefined;
 	#activeModelProfile: string | undefined;
+	#pendingSettingsModelChange:
+		| {
+				model: Model;
+				thinkingLevel: ThinkingLevel | undefined;
+		  }
+		| undefined;
 	#promptTemplates: PromptTemplate[];
 	#slashCommands: FileSlashCommand[];
 
@@ -6861,6 +6867,49 @@ export class AgentSession {
 		await this.#syncEditToolModeAfterModelChange(previousEditMode);
 	}
 
+	/**
+	 * Stage a DEFAULT model until its Settings transaction commits.
+	 * The caller must validate credentials first. Runtime provider sessions,
+	 * retry state, history, Settings, and model-usage MRU remain untouched.
+	 */
+	async setModelForSettingsCommit(model: Model, thinkingLevel?: ThinkingLevel): Promise<void> {
+		this.#pendingSettingsModelChange = { model, thinkingLevel };
+	}
+
+	cancelSettingsModelChange(): void {
+		this.#pendingSettingsModelChange = undefined;
+	}
+
+	/**
+	 * Apply runtime and session-history side effects after Settings are durable.
+	 * Errors are post-commit failures and must never trigger Settings rollback.
+	 */
+	async commitSettingsModelChange(model: Model, role: string = "default"): Promise<void> {
+		const pending = this.#pendingSettingsModelChange;
+		this.#pendingSettingsModelChange = undefined;
+		if (!pending || !modelsAreEqual(pending.model, model)) {
+			throw new Error(`Pending model settings commit does not match ${model.provider}/${model.id}`);
+		}
+
+		const previousEditMode = this.#resolveActiveEditMode();
+		const previousThinkingLevel = this.#thinkingLevel;
+		const nextThinkingLevel = resolveThinkingLevelForModel(
+			model,
+			pending.thinkingLevel ?? model.thinking?.defaultLevel ?? this.#thinkingLevel,
+		);
+		this.sessionManager.appendModelChange(`${model.provider}/${model.id}`, role, {
+			thinkingLevel: nextThinkingLevel,
+		});
+
+		this.#clearActiveRetryFallback();
+		this.#setModelWithProviderSessionReset(model);
+		this.#setThinkingLevelRuntime(nextThinkingLevel);
+		if (previousThinkingLevel !== this.#thinkingLevel) {
+			this.#emit({ type: "thinking_level_changed", thinkingLevel: this.#thinkingLevel });
+		}
+		await this.#syncEditToolModeAfterModelChange(previousEditMode);
+	}
+
 	setActiveModelProfile(name: string | undefined): void {
 		this.#activeModelProfile = name;
 	}
@@ -7106,11 +7155,7 @@ export class AgentSession {
 	 * Saves the effective metadata-clamped level to the session, and to settings when requested.
 	 */
 	setThinkingLevel(level: ThinkingLevel | undefined, persist: boolean = false): void {
-		const effectiveLevel = resolveThinkingLevelForModel(this.model, level);
-		const isChanging = effectiveLevel !== this.#thinkingLevel;
-
-		this.#thinkingLevel = effectiveLevel;
-		this.agent.setThinkingLevel(toReasoningEffort(effectiveLevel));
+		const { effectiveLevel, isChanging } = this.#setThinkingLevelRuntime(level);
 
 		if (persist && effectiveLevel !== undefined) {
 			this.settings.set("defaultThinkingLevel", effectiveLevel);
@@ -7120,6 +7165,14 @@ export class AgentSession {
 			this.sessionManager.appendThinkingLevelChange(effectiveLevel);
 			this.#emit({ type: "thinking_level_changed", thinkingLevel: effectiveLevel });
 		}
+	}
+
+	#setThinkingLevelRuntime(level: ThinkingLevel | undefined) {
+		const effectiveLevel = resolveThinkingLevelForModel(this.model, level);
+		const isChanging = effectiveLevel !== this.#thinkingLevel;
+		this.#thinkingLevel = effectiveLevel;
+		this.agent.setThinkingLevel(toReasoningEffort(effectiveLevel));
+		return { effectiveLevel, isChanging };
 	}
 
 	/**
@@ -10844,7 +10897,7 @@ export class AgentSession {
 				}
 			}
 
-			const hasThinkingEntry = this.sessionManager.getBranch().some(entry => entry.type === "thinking_level_change");
+			const hasThinkingEntry = hasPersistedThinkingLevel(this.sessionManager.getBranch());
 			const hasServiceTierEntry = this.sessionManager
 				.getBranch()
 				.some(entry => entry.type === "service_tier_change");

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -154,7 +154,7 @@ export interface ThinkingLevelChangeEntry extends SessionEntryBase {
 
 export interface ModelChangeEntry extends SessionEntryBase {
 	type: "model_change";
-	/** Model in "provider/modelId" format */
+	/** Model in "provider/modelId" format. */
 	model: string;
 	/** Role: "default" or an agent role. Undefined treated as "default" */
 	role?: string;
@@ -653,6 +653,16 @@ export function getLatestCompactionEntry(entries: SessionEntry[]): CompactionEnt
  * If leafId is provided, walks from that entry to root.
  * Handles compaction and branch summaries along the path.
  */
+export function hasPersistedThinkingLevel(entries: readonly SessionEntry[]): boolean {
+	return entries.some(
+		entry =>
+			entry.type === "thinking_level_change" ||
+			(entry.type === "model_change" &&
+				(entry.role ?? "default") === "default" &&
+				entry.thinkingLevel !== undefined),
+	);
+}
+
 export function buildSessionContext(
 	entries: SessionEntry[],
 	leafId?: string | null,
@@ -745,12 +755,14 @@ export function buildSessionContext(
 		if (entry.type === "thinking_level_change") {
 			thinkingLevel = entry.thinkingLevel ?? "off";
 		} else if (entry.type === "model_change") {
-			// New format: { model: "provider/id", role?: string }
 			if (entry.model) {
 				const role = entry.role ?? "default";
 				models[role] = entry.model;
 				if (role === "default") {
 					hasExplicitDefaultModel = true;
+					if (entry.thinkingLevel !== undefined) {
+						thinkingLevel = entry.thinkingLevel ?? "off";
+					}
 				}
 			}
 		} else if (entry.type === "service_tier_change") {
@@ -2977,6 +2989,7 @@ export class SessionManager {
 	#persistChain: Promise<void> = Promise.resolve();
 	#persistError: Error | undefined;
 	#persistErrorReported = false;
+	#activeCloseOperations = 0;
 	#artifactManager: ArtifactManager | null = null;
 	#artifactManagerSessionFile: string | null = null;
 	// When set, take precedence over the lazily-derived per-session manager.
@@ -3811,14 +3824,25 @@ export class SessionManager {
 
 	/** Close the persistent writer after flushing all pending data. */
 	async close(): Promise<void> {
-		await this.#queuePersistTask(async () => {
-			if (this.#persistWriter) {
-				await this.#closePersistWriterInternal();
-				this.#flushed = true;
-			}
-		});
-		this.#disposeResidentTextBlobStore();
-		if (this.#persistError) throw this.#persistError;
+		this.#activeCloseOperations++;
+		try {
+			await this.#queuePersistTask(async () => {
+				if (this.#persistWriter) {
+					await this.#closePersistWriterInternal();
+					this.#flushed = true;
+				}
+			});
+			const materializedEntries = materializeResidentEntriesForReadSync(
+				this.#fileEntries,
+				this.#residentBlobStores(),
+			);
+			this.#disposeResidentTextBlobStore();
+			this.#fileEntries = materializedEntries;
+			this.#buildIndex();
+			if (this.#persistError) throw this.#persistError;
+		} finally {
+			this.#activeCloseOperations--;
+		}
 	}
 
 	getCwd(): string {
@@ -4096,15 +4120,31 @@ export class SessionManager {
 	}
 
 	#appendEntry(entry: SessionEntry): void {
+		if (this.#activeCloseOperations > 0) throw new Error("Session manager close is in progress");
 		const normalizedEntry = normalizeSessionEntryForStorage(entry);
 		const residentEntry = prepareEntryForResidentSync(normalizedEntry, this.#residentBlobStores()) as SessionEntry;
+		const previousLeafId = this.#leafId;
+		const previousEntryRevision = this.#entryRevision;
+		const previousLeafRevision = this.#leafRevision;
+		const previousLabelRevision = this.#labelRevision;
 		this.#fileEntries.push(residentEntry);
 		this.#byId.set(residentEntry.id, residentEntry);
 		this.#leafId = residentEntry.id;
 		this.#bumpEntryRevision();
 		this.#leafRevision++;
 		if (entry.type === "label") this.#labelRevision++;
-		this._persist(residentEntry);
+		try {
+			this._persist(residentEntry);
+		} catch (error) {
+			this.#fileEntries.pop();
+			this.#byId.delete(residentEntry.id);
+			this.#leafId = previousLeafId;
+			this.#entryRevision = previousEntryRevision;
+			this.#leafRevision = previousLeafRevision;
+			this.#labelRevision = previousLabelRevision;
+			this.#resetMaterializedCaches();
+			throw error;
+		}
 		if (entry.type === "message" && entry.message.role === "assistant") {
 			const usage = entry.message.usage;
 			this.#usageStatistics.input += usage.input;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -6,7 +6,11 @@ import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import { Spacer, Text } from "@gajae-code/tui";
 import { setProjectDir } from "@gajae-code/utils";
 import { jobElapsedMs } from "../async";
-import { materializeActiveModelProfileAssignments } from "../config/model-profile-activation";
+import {
+	createActiveModelProfileRuntimeRollback,
+	materializeActiveModelProfileAssignments,
+	resolveProjectModelProfileShadow,
+} from "../config/model-profile-activation";
 import {
 	GJC_MODEL_ASSIGNMENT_TARGET_IDS,
 	GJC_MODEL_ASSIGNMENT_TARGETS,
@@ -18,6 +22,7 @@ import {
 	formatModelSelectorValue,
 	parseModelPattern,
 	parseModelString,
+	resolveModelRoleValue,
 } from "../config/model-resolver";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../discovery/helpers.js";
 import { resolveMemoryBackend } from "../memory-backend";
@@ -32,7 +37,7 @@ import {
 	formatProviderSetupResult,
 	parseProviderCompatibility,
 } from "../setup/provider-onboarding";
-import { parseThinkingLevel } from "../thinking";
+import { clampModelAssignmentThinkingLevel, parseThinkingLevel } from "../thinking";
 import { getDisplayChangelogEntries } from "../utils/changelog";
 import { buildContextReportText } from "./helpers/context-report";
 import { buildFastStatusReport } from "./helpers/fast-status-report";
@@ -58,6 +63,10 @@ type GjcModelBatchAssignmentTargetId = "all-role-agents" | "all-targets";
 type ParsedModelCommandArgs =
 	| { kind: "summary" }
 	| { kind: "assign"; targetId: GjcModelAssignmentTargetId | GjcModelBatchAssignmentTargetId; selector: string };
+
+class ModelSettingsCommittedFollowUpError extends Error {
+	override name = "ModelSettingsCommittedFollowUpError";
+}
 
 const GJC_MODEL_ROLE_AGENT_TARGET_IDS: GjcModelAssignmentTargetId[] = ["executor", "architect", "planner", "critic"];
 
@@ -172,11 +181,32 @@ function providerSetupUsage(): string {
 
 function formatModelAssignmentSummary(runtime: SlashCommandRuntime): string {
 	const agentModelOverrides = runtime.settings.get("task.agentModelOverrides");
+	const activeProfile = runtime.session.getActiveModelProfile?.();
+	const persistedDefault = runtime.settings.getModelRole("default");
+	const liveDefault = runtime.session.model
+		? formatModelSelectorValue(
+				`${runtime.session.model.provider}/${runtime.session.model.id}`,
+				runtime.session.thinkingLevel,
+			)
+		: undefined;
+	let displayedDefault = activeProfile ? liveDefault : persistedDefault;
+	if (!activeProfile && persistedDefault && liveDefault && runtime.session.model) {
+		const resolvedDefault = resolveModelRoleValue(persistedDefault, runtime.session.modelRegistry.getAll(), {
+			settings: runtime.settings,
+			modelRegistry: runtime.session.modelRegistry,
+		});
+		const inheritedEffort =
+			resolvedDefault.model &&
+			modelsAreEqual(resolvedDefault.model, runtime.session.model) &&
+			extractExplicitThinkingSelector(persistedDefault, runtime.settings) === undefined;
+		if (inheritedEffort && liveDefault !== persistedDefault) {
+			displayedDefault = `${persistedDefault} (effective: ${liveDefault})`;
+		}
+	}
 	const lines = ["Model assignments:"];
 	for (const targetId of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
 		const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetId];
-		const modelSelector =
-			target.settingsPath === "modelRoles" ? runtime.settings.getModelRole(targetId) : agentModelOverrides[targetId];
+		const modelSelector = targetId === "default" ? displayedDefault : agentModelOverrides[targetId];
 		lines.push(`  ${target.tag ?? target.id.toUpperCase()} (${target.name}): ${modelSelector ?? "(unset)"}`);
 	}
 	return lines.join("\n");
@@ -355,10 +385,64 @@ function getModelAssignmentTargetIds(
 	return [targetId];
 }
 
+function formatProjectModelRestartNotice(
+	runtime: SlashCommandRuntime,
+	targetIds: readonly GjcModelAssignmentTargetId[],
+): string {
+	const projectModelRoles = runtime.settings.getProject("modelRoles") ?? {};
+	const projectAgentOverrides = runtime.settings.getProject("task.agentModelOverrides") ?? {};
+	const projectProfile = resolveProjectModelProfileShadow(runtime.settings, runtime.session.modelRegistry);
+	const shadowed = targetIds.filter(targetId => {
+		const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetId];
+		const direct =
+			target.settingsPath === "modelRoles" ? projectModelRoles[targetId] : projectAgentOverrides[targetId];
+		return direct !== undefined || projectProfile?.targetIds.includes(targetId) === true;
+	});
+	if (shadowed.length === 0) return "";
+	const labels = shadowed.map(targetId => GJC_MODEL_ASSIGNMENT_TARGETS[targetId].tag ?? targetId.toUpperCase());
+	return `\nProject settings for ${labels.join(", ")} resume on restart.`;
+}
+
+function resolveDefaultModelThinking(
+	runtime: SlashCommandRuntime,
+	model: Model,
+	selectedThinkingLevel: ThinkingLevel | undefined,
+): { effective: ThinkingLevel | undefined; persisted: ThinkingLevel | undefined } {
+	const configuredDefault = runtime.settings.get("defaultThinkingLevel");
+	const existingExplicit = extractExplicitThinkingSelector(runtime.settings.getModelRole("default"), runtime.settings);
+	const activeProfile = runtime.session.getActiveModelProfile?.() !== undefined;
+	const inherited = activeProfile
+		? (runtime.session.thinkingLevel ?? configuredDefault)
+		: (existingExplicit ?? configuredDefault);
+	const persisted = clampModelAssignmentThinkingLevel(
+		model,
+		selectedThinkingLevel === undefined ? (activeProfile ? inherited : existingExplicit) : selectedThinkingLevel,
+	);
+	const effective = clampModelAssignmentThinkingLevel(
+		model,
+		selectedThinkingLevel === ThinkingLevel.Inherit ? configuredDefault : (selectedThinkingLevel ?? inherited),
+	);
+	return { effective, persisted };
+}
+
 function formatModelAssignmentSuccess(
 	targetId: GjcModelAssignmentTargetId | GjcModelBatchAssignmentTargetId,
-	selector: string,
+	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string>,
 ): string {
+	const targetIds = getModelAssignmentTargetIds(targetId);
+	const assigned = targetIds
+		.map(id => [id, assignments.get(id)] as const)
+		.filter((entry): entry is readonly [GjcModelAssignmentTargetId, string] => entry[1] !== undefined);
+	const selector = assigned[0]?.[1] ?? "(unset)";
+	const hasMixedSelectors = new Set(assigned.map(([, value]) => value)).size > 1;
+
+	if ((targetId === "all-role-agents" || targetId === "all-targets") && hasMixedSelectors) {
+		const heading = targetId === "all-role-agents" ? "Role-agent models updated:" : "All model targets updated:";
+		return [
+			heading,
+			...assigned.map(([id, value]) => `  ${GJC_MODEL_ASSIGNMENT_TARGETS[id].tag ?? id.toUpperCase()}: ${value}`),
+		].join("\n");
+	}
 	if (targetId === "all-role-agents") {
 		return `Role-agent models set to ${selector} for EXECUTOR, ARCHITECT, PLANNER, CRITIC.`;
 	}
@@ -367,6 +451,24 @@ function formatModelAssignmentSuccess(
 	}
 	if (targetId === "default") return `Default model set to ${selector}.`;
 	return `${targetId} agent model set to ${selector}.`;
+}
+function notifyModelAssignmentCommitted(runtime: SlashCommandRuntime, options: { titleChanged: boolean }): void {
+	const notify = (label: "title" | "config", callback: (() => Promise<void> | void) | undefined): void => {
+		if (!callback) return;
+		void Promise.resolve()
+			.then(() => callback())
+			.catch(error =>
+				Promise.resolve()
+					.then(() =>
+						runtime.output(
+							`Model settings were updated, but notification failed (${label}: ${errorMessage(error)}).`,
+						),
+					)
+					.catch(() => {}),
+			);
+	};
+	if (options.titleChanged) notify("title", runtime.notifyTitleChanged);
+	notify("config", runtime.notifyConfigChanged);
 }
 
 function modelSelectionUsage(runtime: SlashCommandRuntime, currentModelLine?: string): string {
@@ -545,74 +647,121 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 					return usage(modelSelectionUsage(runtime, resolution.failure.message), runtime);
 				}
 				const { selection } = resolution;
+				const mutationCheckpoint = await runtime.settings.createMutationCheckpoint();
+				let mutationCheckpointActive = true;
+				const profileRuntimeRollback = createActiveModelProfileRuntimeRollback(runtime.session);
+				let profileRuntimeRollbackActive = true;
+				let sessionModelStaged = false;
+				let settingsCommitted = false;
 				try {
-					const includesDefault = targetIds.includes("default");
-					const includesRoleAgent = targetIds.some(role => role !== "default");
-					if (includesRoleAgent) {
-						const apiKey = await runtime.session.modelRegistry.getApiKey(
-							selection.model,
-							runtime.session.sessionId,
-						);
-						if (!apiKey) {
-							throw new Error(`No API key for ${selection.model.provider}/${selection.model.id}`);
-						}
-					}
-
-					const overrides = runtime.settings.get("task.agentModelOverrides");
-					const assignments = new Map<GjcModelAssignmentTargetId, string>();
-					const existingDefaultThinkingLevel =
-						selection.thinkingLevel !== undefined
-							? selection.thinkingLevel
-							: runtime.session.getActiveModelProfile?.()
-								? undefined
-								: extractExplicitThinkingSelector(runtime.settings.getModelRole("default"), runtime.settings);
-					const persistedSelector = formatModelSelectorValue(selection.selector, existingDefaultThinkingLevel);
-					for (const targetId of targetIds) {
-						if (targetId === "default") {
-							assignments.set(targetId, persistedSelector);
-							continue;
-						}
-						const thinkingLevel =
-							selection.thinkingLevel ?? extractExplicitThinkingSelector(overrides[targetId], runtime.settings);
-						assignments.set(targetId, formatModelSelectorValue(selection.selector, thinkingLevel));
-					}
-
-					if (includesDefault) {
-						await runtime.session.setModel(selection.model, "default", {
-							selector: selection.selector,
-							thinkingLevel: existingDefaultThinkingLevel,
-						});
-						if (existingDefaultThinkingLevel) {
-							runtime.session.setThinkingLevel(existingDefaultThinkingLevel);
-						}
-					}
-
-					const materializedProfile = materializeActiveModelProfileAssignments({
-						session: runtime.session,
-						settings: runtime.settings,
-						assignments,
-					});
-					if (!materializedProfile) {
-						for (const [targetId, selector] of assignments) {
-							const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetId];
-							if (target.settingsPath === "modelRoles") {
-								runtime.settings.setModelRole(targetId, selector);
-							} else {
-								runtime.settings.setAgentModelOverride(targetId, selector);
+					return await runtime.settings.runMutationCheckpoint(mutationCheckpoint, async () => {
+						const includesDefault = targetIds.includes("default");
+						const includesRoleAgent = targetIds.some(role => role !== "default");
+						if (includesDefault || includesRoleAgent) {
+							const apiKey = await runtime.session.modelRegistry.getApiKey(
+								selection.model,
+								runtime.session.sessionId,
+							);
+							if (!apiKey) {
+								throw new Error(`No API key for ${selection.model.provider}/${selection.model.id}`);
 							}
 						}
-					}
-					runtime.settings.getStorage()?.recordModelUsage(`${selection.model.provider}/${selection.model.id}`);
-					await runtime.output(
-						formatModelAssignmentSuccess(
-							parsedArgs.targetId,
-							assignments.get(targetIds[0] ?? "default") ?? persistedSelector,
-						),
-					);
-					if (includesDefault) await runtime.notifyTitleChanged?.();
-					await runtime.notifyConfigChanged?.();
-					return commandConsumed();
+
+						const overrides = runtime.settings.get("task.agentModelOverrides");
+						const assignments = new Map<GjcModelAssignmentTargetId, string>();
+						const defaultThinking = includesDefault
+							? resolveDefaultModelThinking(runtime, selection.model, selection.thinkingLevel)
+							: undefined;
+						const persistedSelector = formatModelSelectorValue(selection.selector, defaultThinking?.persisted);
+						for (const targetId of targetIds) {
+							if (targetId === "default") {
+								assignments.set(targetId, persistedSelector);
+								continue;
+							}
+							const thinkingLevel =
+								selection.thinkingLevel ??
+								extractExplicitThinkingSelector(overrides[targetId], runtime.settings);
+							assignments.set(
+								targetId,
+								formatModelSelectorValue(
+									selection.selector,
+									clampModelAssignmentThinkingLevel(selection.model, thinkingLevel),
+								),
+							);
+						}
+
+						if (includesDefault) {
+							sessionModelStaged = true;
+							const liveThinkingLevel =
+								defaultThinking?.effective !== undefined && defaultThinking.effective !== ThinkingLevel.Inherit
+									? defaultThinking.effective
+									: defaultThinking?.persisted;
+							await runtime.session.setModelForSettingsCommit(selection.model, liveThinkingLevel);
+						}
+
+						const materializedProfile = materializeActiveModelProfileAssignments({
+							session: runtime.session,
+							settings: runtime.settings,
+							assignments,
+						});
+						if (!materializedProfile) {
+							for (const [targetId, selector] of assignments) {
+								if (targetId === "default") {
+									runtime.settings.setModelRole(targetId, selector);
+								} else {
+									runtime.settings.setAgentModelOverride(targetId, selector);
+								}
+							}
+						}
+						await runtime.settings.flushMutationCheckpoint(mutationCheckpoint);
+						settingsCommitted = true;
+						profileRuntimeRollbackActive = false;
+						runtime.settings.releaseMutationCheckpoint(mutationCheckpoint);
+						mutationCheckpointActive = false;
+						if (includesDefault) {
+							sessionModelStaged = false;
+							await runtime.session.commitSettingsModelChange(selection.model);
+						}
+						runtime.settings.getStorage()?.recordModelUsage(`${selection.model.provider}/${selection.model.id}`);
+						const success = formatModelAssignmentSuccess(parsedArgs.targetId, assignments);
+						const projectRestartNotice = formatProjectModelRestartNotice(runtime, targetIds);
+						await runtime.output(success + projectRestartNotice);
+						notifyModelAssignmentCommitted(runtime, { titleChanged: includesDefault });
+						return commandConsumed();
+					});
 				} catch (err) {
+					if (settingsCommitted) {
+						if (mutationCheckpointActive) {
+							try {
+								runtime.settings.releaseMutationCheckpoint(mutationCheckpoint);
+							} catch {}
+							mutationCheckpointActive = false;
+						}
+						if (sessionModelStaged) {
+							runtime.session.cancelSettingsModelChange();
+							sessionModelStaged = false;
+						}
+						const committedMessage = `Model settings were committed, but a session follow-up failed: ${errorMessage(err)}`;
+						try {
+							return await usage(committedMessage, runtime);
+						} catch (reportError) {
+							throw new ModelSettingsCommittedFollowUpError(
+								`${committedMessage} Reporting that committed state also failed: ${errorMessage(reportError)}`,
+							);
+						}
+					}
+					if (mutationCheckpointActive) {
+						runtime.settings.restoreMutationCheckpoint(mutationCheckpoint);
+						mutationCheckpointActive = false;
+					}
+					if (profileRuntimeRollbackActive) {
+						profileRuntimeRollback();
+						profileRuntimeRollbackActive = false;
+					}
+					if (sessionModelStaged) {
+						runtime.session.cancelSettingsModelChange();
+						sessionModelStaged = false;
+					}
 					return usage(`Failed to set model: ${errorMessage(err)}`, runtime);
 				}
 			}
@@ -628,14 +777,47 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 		handleTui: async (command, runtime) => {
 			if (command.args.trim()) {
-				const result = await BUILTIN_SLASH_COMMAND_LOOKUP.get(command.name)?.handle?.(
-					command,
-					toSlashCommandRuntime(runtime),
-				);
-				runtime.ctx.statusLine.invalidate();
-				runtime.ctx.updateEditorBorderColor();
-				runtime.ctx.editor.setText("");
-				runtime.ctx.ui.requestRender();
+				let result: SlashCommandResult | undefined;
+				try {
+					result = await BUILTIN_SLASH_COMMAND_LOOKUP.get(command.name)?.handle?.(
+						command,
+						toSlashCommandRuntime(runtime),
+					);
+				} catch (error) {
+					if (!(error instanceof ModelSettingsCommittedFollowUpError)) throw error;
+					try {
+						runtime.ctx.showError(error.message);
+					} catch {}
+					result = commandConsumed();
+				}
+				let refreshError: unknown;
+				try {
+					runtime.ctx.statusLine.invalidate();
+				} catch (error) {
+					refreshError = error;
+				}
+				try {
+					runtime.ctx.updateEditorBorderColor();
+				} catch (error) {
+					refreshError ??= error;
+				}
+				try {
+					runtime.ctx.editor.setText("");
+				} catch (error) {
+					refreshError ??= error;
+				}
+				try {
+					runtime.ctx.ui.requestRender();
+				} catch (error) {
+					refreshError ??= error;
+				}
+				if (refreshError) {
+					try {
+						runtime.ctx.showError(
+							`Model command result is unchanged, but refreshing the TUI failed: ${errorMessage(refreshError)}`,
+						);
+					} catch {}
+				}
 				return result;
 			}
 			runtime.ctx.showModelSelector();

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -57,6 +57,14 @@ export function clampExplicitThinkingLevelForModel(
 	return clampThinkingLevelForModel(model, level);
 }
 
+export function clampModelAssignmentThinkingLevel(
+	model: Model | undefined,
+	level: ThinkingLevel | undefined,
+): ThinkingLevel | undefined {
+	const clamped = clampExplicitThinkingLevelForModel(model, level);
+	return clamped ?? (model && model.reasoning !== false ? level : undefined);
+}
+
 export function formatClampedModelSelector(selector: string, model: Model | undefined): string {
 	const slashIdx = selector.indexOf("/");
 	if (slashIdx <= 0) return selector;

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -82,11 +82,17 @@ interface FakeAcpBuiltinSession {
 	getAvailableThinkingLevels(): ThinkingLevel[];
 	setModel(model: unknown): Promise<void>;
 	setThinkingLevel(thinkingLevel: ThinkingLevel | undefined, persist?: boolean): void;
+	setModelForSettingsCommit(model: FakeAcpBuiltinSession["model"], thinkingLevel?: ThinkingLevel): Promise<void>;
+	commitSettingsModelChange(model: NonNullable<FakeAcpBuiltinSession["model"]>): Promise<void>;
+	cancelSettingsModelChange(): void;
+	getSessionDefaultModelSelector(): string | undefined;
 }
 
 function createRuntime() {
 	const output: string[] = [];
 	const settings = Settings.isolated();
+	let pendingSettingsModel: FakeAcpBuiltinSession["model"];
+	let pendingSettingsThinkingLevel: ThinkingLevel | undefined;
 	const session: FakeAcpBuiltinSession = {
 		fastMode: false,
 		forcedToolChoice: undefined as string | undefined,
@@ -170,10 +176,27 @@ function createRuntime() {
 		getAvailableModels: () => [] as Array<{ provider: string; id: string; contextWindow?: number }>,
 		getAvailableThinkingLevels: () => [ThinkingLevel.Low, ThinkingLevel.Medium, ThinkingLevel.High],
 		async setModel(_model: unknown) {},
+		async setModelForSettingsCommit(model, thinkingLevel) {
+			pendingSettingsModel = model;
+			pendingSettingsThinkingLevel = thinkingLevel;
+		},
+		async commitSettingsModelChange(model) {
+			if (pendingSettingsModel === model) {
+				this.model = model;
+				this.thinkingLevel = pendingSettingsThinkingLevel;
+				pendingSettingsModel = undefined;
+				pendingSettingsThinkingLevel = undefined;
+			}
+		},
+		cancelSettingsModelChange() {
+			pendingSettingsModel = undefined;
+			pendingSettingsThinkingLevel = undefined;
+		},
 		setThinkingLevel(thinkingLevel: ThinkingLevel | undefined, persist?: boolean) {
 			this.thinkingLevel = thinkingLevel;
 			this.thinkingLevelCalls.push({ thinkingLevel, persist });
 		},
+		getSessionDefaultModelSelector: () => undefined,
 		async refreshSshTool(_options?: { activateIfAvailable?: boolean }) {},
 	};
 	const typedSession = session as unknown as AgentSession & FakeAcpBuiltinSession;
@@ -492,15 +515,12 @@ describe("ACP builtin slash commands", () => {
 		runtime.notifyConfigChanged = () => {
 			configNotified++;
 		};
-		const setModelSpy = spyOn(session, "setModel").mockResolvedValue(undefined);
+		const setModelSpy = spyOn(session, "setModelForSettingsCommit").mockResolvedValue(undefined);
 
 		const result = await executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet", runtime);
 
 		expect(result).toEqual({ consumed: true });
-		expect(setModelSpy).toHaveBeenCalledWith(available[0], "default", {
-			selector: "anthropic/claude-3-5-sonnet",
-			thinkingLevel: undefined,
-		});
+		expect(setModelSpy).toHaveBeenCalledWith(available[0], "high");
 		expect(output[0]).toContain("Default model set to anthropic/claude-3-5-sonnet");
 		expect(titleNotified).toBe(1);
 		expect(configNotified).toBe(1);
@@ -510,34 +530,24 @@ describe("ACP builtin slash commands", () => {
 		const { runtime, session } = createRuntime();
 		const available = [{ provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 }];
 		session.getAvailableModels = () => available;
-		const setModelSpy = spyOn(session, "setModel").mockResolvedValue(undefined);
-		const setThinkingLevelSpy = spyOn(session, "setThinkingLevel");
+		const setModelSpy = spyOn(session, "setModelForSettingsCommit").mockResolvedValue(undefined);
 
 		const result = await executeAcpBuiltinSlashCommand("/model anthropic/claude-3-5-sonnet:low", runtime);
 
 		expect(result).toEqual({ consumed: true });
-		expect(setModelSpy).toHaveBeenCalledWith(available[0], "default", {
-			selector: "anthropic/claude-3-5-sonnet",
-			thinkingLevel: "low",
-		});
-		expect(setThinkingLevelSpy).toHaveBeenCalledWith("low");
+		expect(setModelSpy).toHaveBeenCalledWith(available[0], "low");
 	});
 
 	it("model: applies explicit thinking level from a bare model id", async () => {
 		const { output, runtime, session } = createRuntime();
 		const available = [{ provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 }];
 		session.getAvailableModels = () => available;
-		const setModelSpy = spyOn(session, "setModel").mockResolvedValue(undefined);
-		const setThinkingLevelSpy = spyOn(session, "setThinkingLevel");
+		const setModelSpy = spyOn(session, "setModelForSettingsCommit").mockResolvedValue(undefined);
 
 		const result = await executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet:low", runtime);
 
 		expect(result).toEqual({ consumed: true });
-		expect(setModelSpy).toHaveBeenCalledWith(available[0], "default", {
-			selector: "anthropic/claude-3-5-sonnet",
-			thinkingLevel: "low",
-		});
-		expect(setThinkingLevelSpy).toHaveBeenCalledWith("low");
+		expect(setModelSpy).toHaveBeenCalledWith(available[0], "low");
 		expect(output[0]).toContain("Default model set to anthropic/claude-3-5-sonnet:low");
 	});
 

--- a/packages/coding-agent/test/agent-dashboard-model-override.test.ts
+++ b/packages/coding-agent/test/agent-dashboard-model-override.test.ts
@@ -1,0 +1,316 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	materializeActiveModelProfileAssignment,
+	materializeActiveModelProfileAssignments,
+} from "@gajae-code/coding-agent/config/model-profile-activation";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentDashboard } from "@gajae-code/coding-agent/modes/components/agent-dashboard";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { getProjectAgentDir } from "@gajae-code/utils";
+
+beforeAll(async () => {
+	const theme = await getThemeByName("red-claw");
+	if (!theme) throw new Error("Failed to load test theme");
+	setThemeInstance(theme);
+});
+
+async function replaceEditorValue(dashboard: AgentDashboard, value: string): Promise<void> {
+	dashboard.handleInput("\n");
+	for (let index = 0; index < 80; index++) dashboard.handleInput("\x7f");
+	if (value) dashboard.handleInput(value);
+	dashboard.handleInput("\n");
+	for (let attempt = 0; attempt < 100; attempt++) {
+		if (!dashboard.render(120).join("\n").includes("Model override:")) return;
+		await Bun.sleep(5);
+	}
+	throw new Error("Dashboard model override did not settle");
+}
+
+function renderedText(dashboard: AgentDashboard): string {
+	return dashboard
+		.render(120)
+		.join("\n")
+		.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+describe("AgentDashboard model overrides", () => {
+	test("edits and clears one live override without persisting profile siblings", async () => {
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", {
+			architect: "persisted/architect:low",
+			critic: "persisted/critic:high",
+		});
+		settings.override("task.agentModelOverrides", {
+			architect: "profile/architect:medium",
+			executor: "profile/executor:low",
+		});
+		const dashboard = await AgentDashboard.create(process.cwd(), settings, 30);
+
+		await replaceEditorValue(dashboard, "user/architect:xhigh");
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			architect: "user/architect:xhigh",
+			critic: "persisted/critic:high",
+			executor: "profile/executor:low",
+		});
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			architect: "user/architect:xhigh",
+			critic: "persisted/critic:high",
+		});
+
+		settings.override("task.agentModelOverrides", {
+			architect: "profile/architect:medium",
+			executor: "profile/executor:low",
+		});
+		await replaceEditorValue(dashboard, "");
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			critic: "persisted/critic:high",
+			executor: "profile/executor:low",
+		});
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			critic: "persisted/critic:high",
+		});
+	});
+
+	test("active-profile role edits detach the profile and survive clearing its runtime layer", async () => {
+		const settings = Settings.isolated({
+			"modelProfile.default": "profile-a",
+		});
+		settings.set("task.agentModelOverrides", { critic: "persisted/critic:high" });
+		settings.override("task.agentModelOverrides", {
+			architect: "profile/architect:medium",
+			executor: "profile/executor:low",
+		});
+		let activeProfile: string | undefined = "profile-a";
+		const session = {
+			model: undefined,
+			thinkingLevel: undefined,
+			getActiveModelProfile: () => activeProfile,
+			setActiveModelProfile: (name: string | undefined) => {
+				activeProfile = name;
+			},
+			getSessionDefaultModelSelector: () => undefined,
+		};
+		const dashboard = await AgentDashboard.create(process.cwd(), settings, 30, {
+			onModelOverrideChange: async (agentName, value) => {
+				if (!value || agentName !== "architect") throw new Error("Unexpected dashboard edit");
+				materializeActiveModelProfileAssignment({
+					session,
+					settings,
+					role: "architect",
+					selector: value,
+				});
+				await settings.flushOrThrow();
+			},
+		});
+
+		await replaceEditorValue(dashboard, "user/architect:xhigh");
+
+		expect(activeProfile).toBeUndefined();
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(settings.get("task.agentModelOverrides").architect).toBe("user/architect:xhigh");
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			architect: "user/architect:xhigh",
+			critic: "persisted/critic:high",
+			executor: "profile/executor:low",
+		});
+	});
+	test("clearing an active-profile role detaches the profile and materializes sibling roles", async () => {
+		const settings = Settings.isolated({
+			"modelProfile.default": "profile-a",
+		});
+		settings.set("task.agentModelOverrides", { critic: "persisted/critic:high" });
+		settings.override("task.agentModelOverrides", {
+			architect: "profile/architect:medium",
+			executor: "profile/executor:low",
+		});
+		let activeProfile: string | undefined = "profile-a";
+		const session = {
+			model: undefined,
+			thinkingLevel: undefined,
+			getActiveModelProfile: () => activeProfile,
+			setActiveModelProfile: (name: string | undefined) => {
+				activeProfile = name;
+			},
+			getSessionDefaultModelSelector: () => undefined,
+		};
+		const dashboard = await AgentDashboard.create(process.cwd(), settings, 30, {
+			projectModelProfileShadow: { profileName: "profile-a", targetIds: ["architect"] },
+			onModelOverrideChange: async (agentName, value) => {
+				if (agentName !== "architect" || value !== undefined) throw new Error("Unexpected dashboard edit");
+				materializeActiveModelProfileAssignments({
+					session,
+					settings,
+					assignments: { architect: undefined },
+				});
+				await settings.flushOrThrow();
+			},
+		});
+
+		await replaceEditorValue(dashboard, "");
+
+		expect(activeProfile).toBeUndefined();
+		expect(settings.getGlobal("modelProfile.default")).toBeUndefined();
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			critic: "persisted/critic:high",
+			executor: "profile/executor:low",
+		});
+		expect(settings.get("task.agentModelOverrides").architect).toBeUndefined();
+		expect(renderedText(dashboard)).toContain("Override: (none)");
+		const profileNotice = renderedText(dashboard);
+		expect(profileNotice).toContain("project model profile profile-a");
+		expect(profileNotice).toContain("resumes on restart");
+	});
+	test("does not report a partial project profile for an unbound role", async () => {
+		const settings = Settings.isolated();
+		const dashboard = await AgentDashboard.create(process.cwd(), settings, 30, {
+			projectModelProfileShadow: { profileName: "profile-a", targetIds: ["executor"] },
+		});
+
+		await replaceEditorValue(dashboard, "user/architect:high");
+
+		expect(renderedText(dashboard)).not.toContain("project model profile profile-a");
+	});
+
+	test("project-backed clears keep the effective value visible and avoid a false cleared state", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-dashboard-project-"));
+		const projectDir = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		try {
+			await fs.mkdir(getProjectAgentDir(projectDir), { recursive: true });
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "config.yml"),
+				"task:\n  agentModelOverrides:\n    architect: project/architect:medium\n",
+			);
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.setAgentModelOverride("architect", "user/architect:low");
+			await settings.flushOrThrow();
+			const dashboard = await AgentDashboard.create(projectDir, settings, 30);
+
+			await replaceEditorValue(dashboard, "");
+
+			expect(settings.getGlobal("task.agentModelOverrides")).toEqual({});
+			expect(settings.get("task.agentModelOverrides").architect).toBe("project/architect:medium");
+			const text = renderedText(dashboard);
+			expect(text).toContain("project/architect:medium");
+			expect(text).toContain(
+				"Cleared user override for architect; effective override remains project/architect:medium",
+			);
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("user role overrides take effect live but project overrides resume after restart", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-dashboard-project-restart-"));
+		const projectDir = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		try {
+			await fs.mkdir(getProjectAgentDir(projectDir), { recursive: true });
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "config.yml"),
+				"task:\n  agentModelOverrides:\n    architect: project/architect:medium\n",
+			);
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const dashboard = await AgentDashboard.create(projectDir, settings, 30);
+
+			await replaceEditorValue(dashboard, "user/architect:low");
+
+			expect(settings.get("task.agentModelOverrides").architect).toBe("user/architect:low");
+			const notice = renderedText(dashboard);
+			expect(notice).toContain("Updated user override for architect to user/architect:low for this session");
+			expect(notice).toContain("project override project/architect:medium");
+			expect(notice).toContain("resumes on restart");
+
+			resetSettingsForTest();
+			const restarted = await Settings.init({ cwd: projectDir, agentDir });
+			expect(restarted.get("task.agentModelOverrides").architect).toBe("project/architect:medium");
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("shows the local effective override when flushOrThrow cannot confirm persistence", async () => {
+		const settings = Settings.isolated();
+		settings.flushOrThrow = async () => {
+			throw new Error("disk unavailable");
+		};
+		const dashboard = await AgentDashboard.create(process.cwd(), settings, 30, {
+			onModelOverrideChange: async (agentName, value) => {
+				if (agentName !== "architect" || !value) throw new Error("Unexpected dashboard edit");
+				settings.setAgentModelOverride(agentName, value);
+				await settings.flushOrThrow();
+			},
+		});
+
+		await replaceEditorValue(dashboard, "user/architect:xhigh");
+
+		expect(settings.get("task.agentModelOverrides").architect).toBe("user/architect:xhigh");
+		const notice = renderedText(dashboard);
+		expect(notice).toContain("Model override for architect is user/architect:xhigh locally");
+		expect(notice).toContain("persistence was not confirmed: disk unavailable");
+
+		const reopened = await AgentDashboard.create(process.cwd(), settings, 30);
+		const reopenedNotice = renderedText(reopened);
+		expect(reopenedNotice).toContain("Override:");
+		expect(reopenedNotice).toContain("user/architect:xhigh");
+		expect(reopenedNotice).toContain("Persistence: unconfirmed");
+		expect(reopenedNotice).toContain("Local override may not survive restart");
+
+		const retry = Promise.withResolvers<void>();
+		settings.flushOrThrow = () => retry.promise;
+		const nonsettlingRetry = await Promise.race([
+			AgentDashboard.create(process.cwd(), settings, 30),
+			Bun.sleep(100).then(() => undefined),
+		]);
+		expect(nonsettlingRetry).toBeInstanceOf(AgentDashboard);
+		expect(renderedText(nonsettlingRetry as AgentDashboard)).toContain("Persistence: unconfirmed");
+		retry.resolve();
+		await Bun.sleep(0);
+
+		settings.flushOrThrow = async () => {};
+		const confirmed = await AgentDashboard.create(process.cwd(), settings, 30);
+		expect(renderedText(confirmed)).not.toContain("Persistence: unconfirmed");
+	});
+
+	test("keeps a pending save from accepting input or reopening an editor closed with escape", async () => {
+		const settings = Settings.isolated();
+		const save = Promise.withResolvers<void>();
+		const values: string[] = [];
+		const dashboard = await AgentDashboard.create(process.cwd(), settings, 30, {
+			onModelOverrideChange: async (agentName, value) => {
+				if (agentName !== "architect" || !value) throw new Error("Unexpected dashboard edit");
+				values.push(value);
+				await save.promise;
+			},
+		});
+		let renderRequests = 0;
+		dashboard.onRequestRender = () => {
+			renderRequests += 1;
+		};
+
+		dashboard.handleInput("\n");
+		dashboard.handleInput("user/architect:low");
+		dashboard.handleInput("\n");
+		dashboard.handleInput("ignored/architect:high");
+		dashboard.handleInput("\x1b");
+		expect(values).toEqual(["user/architect:low"]);
+		expect(renderedText(dashboard)).not.toContain("Model override:");
+
+		save.resolve();
+		await Bun.sleep(0);
+
+		const text = renderedText(dashboard);
+		expect(text).not.toContain("Model override:");
+		expect(text).toContain("Background model override save completed for architect");
+		expect(renderRequests).toBeGreaterThan(0);
+	});
+});

--- a/packages/coding-agent/test/agent-session-profile-resume-default.test.ts
+++ b/packages/coding-agent/test/agent-session-profile-resume-default.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as path from "node:path";
-import { Agent } from "@gajae-code/agent-core";
+import { Agent, ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
 import {
 	applyPreparedModelProfileActivation,
@@ -98,6 +98,50 @@ describe("AgentSession setModelTemporary persistAsSessionDefault", () => {
 		expect(session.model?.provider).toBe("anthropic");
 		expect(session.model?.id).toBe("claude-opus-4-8");
 		// Resume still restores the explicit base default, not the transient model.
+		expect(session.sessionManager.buildSessionContext().models.default).toBe("openai-codex/gpt-5.5");
+	});
+
+	it("stages settings model changes without durable history until commit", async () => {
+		const { base, profileMain } = resolveModels();
+		session = makeSession(base);
+		await session.setModel(base);
+		const entriesBefore = session.sessionManager.getEntries().length;
+		const thinkingBefore = session.thinkingLevel;
+
+		await session.setModelForSettingsCommit(profileMain);
+		expect(session.model?.id).toBe("gpt-5.5");
+		expect(session.sessionManager.getEntries()).toHaveLength(entriesBefore);
+
+		session.cancelSettingsModelChange();
+		expect(session.model?.id).toBe("gpt-5.5");
+		expect(session.thinkingLevel).toBe(thinkingBefore);
+		expect(session.sessionManager.getEntries()).toHaveLength(entriesBefore);
+		expect(session.sessionManager.buildSessionContext().models.default).toBe("openai-codex/gpt-5.5");
+
+		await session.setModelForSettingsCommit(profileMain, ThinkingLevel.High);
+		await session.commitSettingsModelChange(profileMain);
+		expect(session.model?.id).toBe("claude-opus-4-8");
+		expect(session.sessionManager.getEntries()).toHaveLength(entriesBefore + 1);
+		expect(session.sessionManager.buildSessionContext().models.default).toBe("anthropic/claude-opus-4-8");
+		expect(session.sessionManager.buildSessionContext().thinkingLevel).toBe(ThinkingLevel.High);
+	});
+	it("leaves runtime and history unchanged when session-history commit fails", async () => {
+		const { base, profileMain } = resolveModels();
+		session = makeSession(base);
+		await session.setModel(base);
+		const entriesBefore = session.sessionManager.getEntries().length;
+		const appendSpy = spyOn(session.sessionManager, "appendModelChange").mockImplementation(() => {
+			throw new Error("forced session history failure");
+		});
+		try {
+			await session.setModelForSettingsCommit(profileMain);
+			await expect(session.commitSettingsModelChange(profileMain)).rejects.toThrow("forced session history failure");
+		} finally {
+			appendSpy.mockRestore();
+		}
+
+		expect(session.model?.id).toBe("gpt-5.5");
+		expect(session.sessionManager.getEntries()).toHaveLength(entriesBefore);
 		expect(session.sessionManager.buildSessionContext().models.default).toBe("openai-codex/gpt-5.5");
 	});
 

--- a/packages/coding-agent/test/custom-model-preset-creation.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-creation.test.ts
@@ -1,17 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import * as syncFs from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
 import {
+	activateModelProfile,
 	materializeModelProfileForDeletion,
 	restoreMaterializedModelProfileForDeletion,
 } from "@gajae-code/coding-agent/config/model-profile-activation";
 import type { ModelProfileDefinition } from "@gajae-code/coding-agent/config/model-profiles";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
-import type { ModelProfileConfig } from "@gajae-code/coding-agent/config/models-config-schema";
-import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { type ModelProfileConfig, ModelsConfigSchema } from "@gajae-code/coding-agent/config/models-config-schema";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { CustomModelPresetWizardComponent } from "@gajae-code/coding-agent/modes/components/custom-model-preset-wizard";
 import {
 	ModelSelectorComponent,
@@ -21,6 +23,7 @@ import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/s
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import type { TUI } from "@gajae-code/tui";
+import { getProjectAgentDir } from "@gajae-code/utils";
 import { YAML } from "bun";
 
 let tempDir: string;
@@ -33,6 +36,11 @@ const snapshot: ModelProfileConfig = {
 	required_providers: ["my-oai"],
 	model_mapping: { default: "my-oai/gpt-custom:low" },
 };
+const archivedProfilePrefix = "__gjc_archived_profile__:v1:";
+
+function archivedProfileEnvelope(name: string, profile: unknown): string {
+	return `${archivedProfilePrefix}${Buffer.from(name, "utf8").toString("base64url")}:${Buffer.from(JSON.stringify(profile), "utf8").toString("base64url")}`;
+}
 
 const placeholderProfile: ModelProfileDefinition = {
 	name: "placeholder",
@@ -85,6 +93,112 @@ function createRegistry(profiles: Iterable<[string, ModelProfileDefinition]> = [
 		getModelProfile: (name: string) => profileMap.get(name),
 		getApiKeyForProvider: async (providerId: string) => options.apiKeyForProvider?.(providerId) ?? "key",
 	} as unknown as ModelRegistry;
+}
+
+function createDeletionSession() {
+	let activeProfile: string | undefined;
+	let sessionDefault = "my-oai/baseline";
+	return {
+		model: currentModel("my-oai", "baseline") as Model | undefined,
+		thinkingLevel: ThinkingLevel.Low as ThinkingLevel | undefined,
+		sessionId: "deletion-session",
+		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
+			this.model = next;
+			this.thinkingLevel = thinkingLevel;
+		},
+		setActiveModelProfile(profileName: string | undefined) {
+			activeProfile = profileName;
+		},
+		getActiveModelProfile() {
+			return activeProfile;
+		},
+		getSessionDefaultModelSelector() {
+			return sessionDefault;
+		},
+		recordResumeDefaultModel(selector: string) {
+			sessionDefault = selector;
+		},
+	};
+}
+
+async function createDeletionControllerHarness(
+	settings: Settings,
+	profiles: Map<string, ModelProfileDefinition>,
+	initialActiveProfile?: string,
+) {
+	let selector: ModelSelectorComponent | undefined;
+	let deleteCalls = 0;
+	const errors: string[] = [];
+	const statuses: string[] = [];
+	const archivedProfiles = new Map<string, ModelProfileDefinition>();
+	const registry = {
+		...createRegistry(profiles),
+		getModelProfiles: () => new Map(profiles),
+		getModelProfile: (name: string) => profiles.get(name),
+		getModelProfileForReference: (name: string) => profiles.get(name) ?? archivedProfiles.get(name),
+		getAvailableModelProfileNames: () => [...profiles.keys()],
+		deleteCustomModelProfile: async (name: string) => {
+			deleteCalls++;
+			const profile = profiles.get(name);
+			if (!profile) throw new Error("missing profile");
+			profiles.delete(name);
+			archivedProfiles.set(name, profile);
+			return {
+				display_name: profile.displayName,
+				required_providers: [...profile.requiredProviders],
+				model_mapping: { ...profile.modelMapping },
+			};
+		},
+		saveCustomModelProfile: async (name: string, config: ModelProfileConfig) => {
+			archivedProfiles.delete(name);
+			profiles.set(name, {
+				name,
+				displayName: config.display_name,
+				requiredProviders: [...config.required_providers],
+				modelMapping: { ...config.model_mapping },
+				source: "user",
+			});
+			return profiles.get(name);
+		},
+		refresh: async () => {},
+	};
+	const session = {
+		...createDeletionSession(),
+		scopedModels: [],
+		modelRegistry: registry,
+		isFastForProvider: () => false,
+		isFastForSubagentProvider: () => false,
+		isFastModeActive: () => false,
+	};
+	session.setActiveModelProfile(initialActiveProfile);
+	const ctx = {
+		ui: { setFocus: () => {}, requestRender: () => {} },
+		editorContainer: {
+			clear: () => {},
+			addChild: (child: unknown) => {
+				if (child instanceof ModelSelectorComponent) selector = child;
+			},
+		},
+		editor: {},
+		settings,
+		session,
+		statusLine: { invalidate: () => {} },
+		updateEditorBorderColor: () => {},
+		showStatus: (message: string) => statuses.push(message),
+		showError: (message: string) => errors.push(message),
+		showHookConfirm: async () => true,
+		notifyConfigChanged: async () => {},
+	};
+	new SelectorController(ctx as never).showModelSelector();
+	await Bun.sleep(0);
+	if (!selector) throw new Error("Model selector did not open");
+	return {
+		selector,
+		errors,
+		statuses,
+		getDeleteCalls: () => deleteCalls,
+		getArchivedProfile: (name: string) => archivedProfiles.get(name),
+	};
 }
 
 describe("custom model preset creation", () => {
@@ -191,13 +305,685 @@ describe("custom model preset creation", () => {
 			model_mapping: { default: "my-oai/gpt-custom" },
 		});
 
+		expect(registry.getModelProfiles().has("first")).toBe(false);
+		expect(registry.getAvailableModelProfileNames()).not.toContain("first");
 		expect(registry.getModelProfile("first")).toBeUndefined();
+		expect(registry.getModelProfileForReference("first")?.displayName).toBe("first");
 		expect(registry.getModelProfile("second")?.displayName).toBe("second");
+		const parsed: unknown = YAML.parse(await Bun.file(modelsPath).text());
+		expect(ModelsConfigSchema.safeParse(parsed).success).toBe(true);
+		const config = parsed as {
+			profiles: Record<string, { display_name?: string }>;
+			equivalence?: { exclude?: string[] };
+		};
+		expect(config.profiles.first).toBeUndefined();
+		expect(config.profiles.second?.display_name).toBe("second");
+		expect(config.equivalence?.exclude?.some(value => value.startsWith(archivedProfilePrefix))).toBe(true);
+	});
+
+	it("quarantines a malformed hidden archive without invalidating active config", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		await Bun.write(
+			modelsPath,
+			Bun.YAML.stringify({
+				equivalence: {
+					exclude: ["anthropic/excluded", "__gjc_archived_profile__:v1:not-json"],
+				},
+				profiles: {
+					active: {
+						required_providers: ["anthropic"],
+						model_mapping: { default: "anthropic/active" },
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		expect(registry.getError()).toBeUndefined();
+		expect(registry.getModelProfile("active")).toBeDefined();
+		expect(registry.getModelProfileForReference("not-json")).toBeUndefined();
+	});
+	it("isolates malformed archives, uses the last duplicate, and preserves quarantine bytes", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const encodedName = (name: string) => Buffer.from(name, "utf8").toString("base64url");
+		const encodedPayload = (payload: Uint8Array | string) =>
+			(typeof payload === "string" ? Buffer.from(payload, "utf8") : Buffer.from(payload)).toString("base64url");
+		const validFirst = archivedProfileEnvelope("archived", {
+			display_name: "First",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/first" },
+		});
+		const validLast = archivedProfileEnvelope("archived", {
+			display_name: "Last",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/last" },
+		});
+		const malformedForRecreatedName = `${archivedProfilePrefix}${encodedName("recreate-me")}:${encodedPayload("{}")}`;
+		const quarantined = [
+			"__gjc_archived_profile__:v1:only-name",
+			`__gjc_archived_profile__:v2:${encodedName("future")}:${encodedPayload("{}")}`,
+			`__gjc_archived_profile__:v1:abc=:${encodedPayload("{}")}`,
+			`__gjc_archived_profile__:v1:${Buffer.from([0xff]).toString("base64url")}:${encodedPayload("{}")}`,
+			`__gjc_archived_profile__:v1:${encodedName("Invalid")}:${encodedPayload("{}")}`,
+			`__gjc_archived_profile__:v1:${encodedName("bad-base64")}:***`,
+			`__gjc_archived_profile__:v1:${encodedName("bad-utf8")}:${Buffer.from([0xff]).toString("base64url")}`,
+			`__gjc_archived_profile__:v1:${encodedName("oversized")}:${Buffer.alloc(64 * 1024 + 1, "x").toString("base64url")}`,
+			`__gjc_archived_profile__:v1:${encodedName("bad-json")}:${encodedPayload("{")}`,
+			`__gjc_archived_profile__:v1:${encodedName("bad-schema")}:${encodedPayload("{}")}`,
+			malformedForRecreatedName,
+		];
+		const exclusions = ["anthropic/excluded", ...quarantined, validFirst, validLast];
+		await Bun.write(
+			modelsPath,
+			Bun.YAML.stringify({
+				equivalence: { exclude: exclusions },
+				profiles: {
+					active: {
+						required_providers: ["anthropic"],
+						model_mapping: { default: "anthropic/active" },
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		expect(registry.getError()).toBeUndefined();
+		expect(registry.getModelProfile("active")).toBeDefined();
+		expect(registry.getModelProfileForReference("archived")?.displayName).toBe("Last");
+		expect(registry.getAvailableModelProfileNames()).not.toContain("archived");
+
+		await registry.saveCustomModelProfile("recreate-me", {
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/recreated" },
+		});
+		const saved = YAML.parse(await Bun.file(modelsPath).text()) as {
+			equivalence?: { exclude?: string[] };
+			profiles?: Record<string, ModelProfileConfig>;
+		};
+		expect(ModelsConfigSchema.safeParse(saved).success).toBe(true);
+		expect(saved.profiles?.["recreate-me"]?.model_mapping.default).toBe("my-oai/recreated");
+		expect(saved.equivalence?.exclude).toEqual(["anthropic/excluded", ...quarantined, validFirst, validLast]);
+	});
+
+	it("rejects invalid profile ids before first persistence", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+
+		await expect(registry.saveCustomModelProfile("Bad Name", snapshot)).rejects.toThrow(
+			'Invalid custom model profile id "Bad Name"',
+		);
+		expect(await Bun.file(modelsPath).exists()).toBe(false);
+	});
+
+	it("round-trips the archive payload limit and rejects an oversized archive before deletion", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const profileWithSerializedBytes = (targetBytes: number): ModelProfileConfig => {
+			const createProfile = (displayName: string): ModelProfileConfig => ({
+				required_providers: ["my-oai"],
+				display_name: displayName,
+				model_mapping: { default: "my-oai/model" },
+			});
+			const overhead = Buffer.byteLength(JSON.stringify(createProfile("")), "utf8");
+			const profile = createProfile("x".repeat(targetBytes - overhead));
+			expect(Buffer.byteLength(JSON.stringify(profile), "utf8")).toBe(targetBytes);
+			return profile;
+		};
+
+		await registry.saveCustomModelProfile("boundary", profileWithSerializedBytes(64 * 1024));
+		await registry.deleteCustomModelProfile("boundary");
+		const reopened = new ModelRegistry(authStorage, modelsPath);
+		expect(reopened.getModelProfileForReference("boundary")?.displayName).toHaveLength(
+			profileWithSerializedBytes(64 * 1024).display_name?.length ?? 0,
+		);
+
+		await registry.saveCustomModelProfile("oversized", profileWithSerializedBytes(64 * 1024 + 1));
+		await expect(registry.deleteCustomModelProfile("oversized")).rejects.toThrow(
+			"serialized profile exceeds 65536 bytes",
+		);
+		const afterRejectedDelete = new ModelRegistry(authStorage, modelsPath);
+		expect(afterRejectedDelete.getModelProfile("oversized")).toBeDefined();
+		expect(afterRejectedDelete.getModelProfileForReference("boundary")).toBeDefined();
+	});
+	it("serializes concurrent profile saves without losing either update", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registryA = new ModelRegistry(authStorage, modelsPath);
+		const registryB = new ModelRegistry(authStorage, modelsPath);
+
+		await Promise.all([
+			registryA.saveCustomModelProfile("profile-a", {
+				display_name: "Profile A",
+				required_providers: ["my-oai"],
+				model_mapping: { default: "my-oai/model-a" },
+			}),
+			registryB.saveCustomModelProfile("profile-b", {
+				display_name: "Profile B",
+				required_providers: ["anthropic"],
+				model_mapping: { default: "anthropic/model-b" },
+			}),
+		]);
+
 		const parsed = YAML.parse(await Bun.file(modelsPath).text()) as {
 			profiles: Record<string, { display_name?: string }>;
 		};
-		expect(parsed.profiles.first).toBeUndefined();
-		expect(parsed.profiles.second?.display_name).toBe("second");
+		expect(parsed.profiles["profile-a"]?.display_name).toBe("Profile A");
+		expect(parsed.profiles["profile-b"]?.display_name).toBe("Profile B");
+	});
+
+	it("rejects profile mutation through hard-linked models config aliases", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const aliasPath = path.join(tempDir, "models-alias.yml");
+		const seedRegistry = new ModelRegistry(authStorage, modelsPath);
+		await seedRegistry.saveCustomModelProfile("seed", {
+			display_name: "Seed",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/seed" },
+		});
+		await fs.link(modelsPath, aliasPath);
+
+		const [first, second] = await Promise.allSettled([
+			new ModelRegistry(authStorage, modelsPath).saveCustomModelProfile("profile-a", {
+				display_name: "Profile A",
+				required_providers: ["my-oai"],
+				model_mapping: { default: "my-oai/model-a" },
+			}),
+			new ModelRegistry(authStorage, aliasPath).saveCustomModelProfile("profile-b", {
+				display_name: "Profile B",
+				required_providers: ["anthropic"],
+				model_mapping: { default: "anthropic/model-b" },
+			}),
+		]);
+
+		expect(first.status).toBe("rejected");
+		expect(second.status).toBe("rejected");
+		expect(String(first.status === "rejected" ? first.reason : "")).toContain(
+			"Refusing to replace hard-linked models config",
+		);
+		expect(String(second.status === "rejected" ? second.reason : "")).toContain(
+			"Refusing to replace hard-linked models config",
+		);
+		const parsed = YAML.parse(await Bun.file(modelsPath).text()) as { profiles: Record<string, unknown> };
+		expect(Object.keys(parsed.profiles)).toEqual(["seed"]);
+		expect(await Bun.file(aliasPath).text()).toBe(await Bun.file(modelsPath).text());
+	});
+	it("reports an ambiguous hard link created during rollback cleanup", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const aliasPath = path.join(tempDir, "models-raced-alias.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("seed", {
+			display_name: "Seed",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/seed" },
+		});
+		const originalText = await Bun.file(modelsPath).text();
+		const originalLink = syncFs.linkSync;
+		let rollbackPath: string | undefined;
+		let injected = false;
+		const linkSpy = spyOn(syncFs, "linkSync").mockImplementation((source, destination) => {
+			if (String(destination).endsWith(".rollback")) rollbackPath = String(destination);
+			if (
+				!injected &&
+				String(source).endsWith(".tmp") &&
+				String(destination).endsWith("models.yml") &&
+				rollbackPath
+			) {
+				originalLink(rollbackPath, aliasPath);
+				injected = true;
+			}
+			return originalLink(source, destination);
+		});
+		try {
+			await expect(
+				registry.saveCustomModelProfile("profile-a", {
+					display_name: "Profile A",
+					required_providers: ["my-oai"],
+					model_mapping: { default: "my-oai/model-a" },
+				}),
+			).rejects.toThrow("hard-link state became ambiguous during commit");
+		} finally {
+			linkSpy.mockRestore();
+		}
+
+		expect(injected).toBe(true);
+		expect(await Bun.file(aliasPath).text()).toBe(originalText);
+		expect(await Bun.file(modelsPath).text()).not.toBe(originalText);
+		expect((await fs.readdir(tempDir)).some(name => name.endsWith(".rollback"))).toBe(true);
+	});
+
+	it("recreates discoverable recovery evidence for an unlink-window hardlink race", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const aliasPath = path.join(tempDir, "models-unlink-race-alias.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("seed", snapshot);
+		const originalText = await Bun.file(modelsPath).text();
+		const originalUnlink = syncFs.unlinkSync;
+		const originalLink = syncFs.linkSync;
+		let injected = false;
+		const unlinkSpy = spyOn(syncFs, "unlinkSync").mockImplementation(target => {
+			if (!injected && String(target).endsWith(".rollback")) {
+				originalLink(target, aliasPath);
+				injected = true;
+			}
+			return originalUnlink(target);
+		});
+		try {
+			await expect(registry.saveCustomModelProfile("profile-a", snapshot)).rejects.toThrow(
+				"hard-link state became ambiguous during cleanup; recovery file preserved",
+			);
+		} finally {
+			unlinkSpy.mockRestore();
+		}
+
+		expect(injected).toBe(true);
+		expect(await Bun.file(aliasPath).text()).toBe(originalText);
+		const recoveryName = (await fs.readdir(tempDir)).find(name => name.endsWith(".recovery"));
+		expect(recoveryName).toBeDefined();
+		expect(await Bun.file(path.join(tempDir, recoveryName ?? "")).text()).toBe(originalText);
+	});
+	it("retains original rollback when verification recovery creation fails", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("seed", snapshot);
+		const originalText = await Bun.file(modelsPath).text();
+		const originalOpen = syncFs.openSync;
+		const openSpy = spyOn(syncFs, "openSync").mockImplementation((target, flags, mode) => {
+			if (String(target).endsWith(".recovery")) throw new Error("forced recovery creation failure");
+			return originalOpen(target, flags, mode);
+		});
+		try {
+			await expect(registry.saveCustomModelProfile("profile-a", snapshot)).rejects.toThrow(
+				"Models config was committed, but verification failed",
+			);
+		} finally {
+			openSpy.mockRestore();
+		}
+
+		const rollbackName = (await fs.readdir(tempDir)).find(name => name.endsWith(".rollback"));
+		expect(rollbackName).toBeDefined();
+		expect(await Bun.file(path.join(tempDir, rollbackName ?? "")).text()).toBe(originalText);
+	});
+
+	it("retains durable recovery when its parent fsync fails", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("seed", snapshot);
+		const originalText = await Bun.file(modelsPath).text();
+		const originalOpen = syncFs.openSync;
+		const originalFsync = syncFs.fsyncSync;
+		let recoveryOpened = false;
+		const openSpy = spyOn(syncFs, "openSync").mockImplementation((target, flags, mode) => {
+			const fd = originalOpen(target, flags, mode);
+			if (String(target).endsWith(".recovery")) recoveryOpened = true;
+			return fd;
+		});
+		const fsyncSpy = spyOn(syncFs, "fsyncSync").mockImplementation(fd => {
+			if (recoveryOpened && syncFs.fstatSync(fd).isDirectory()) {
+				throw new Error("forced recovery parent fsync failure");
+			}
+			return originalFsync(fd);
+		});
+		try {
+			await expect(registry.saveCustomModelProfile("profile-a", snapshot)).rejects.toThrow(
+				"Models config was committed, but verification failed",
+			);
+		} finally {
+			fsyncSpy.mockRestore();
+			openSpy.mockRestore();
+		}
+
+		const recoveryNames = (await fs.readdir(tempDir)).filter(
+			name => name.endsWith(".rollback") || name.endsWith(".recovery"),
+		);
+		expect(recoveryNames.length).toBeGreaterThan(0);
+		for (const recoveryName of recoveryNames) {
+			expect(await Bun.file(path.join(tempDir, recoveryName)).text()).toBe(originalText);
+		}
+	});
+	it("preserves a competing existing-file replacement at the commit boundary", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const competingPath = path.join(tempDir, "competing.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("seed", snapshot);
+		const competingText = Bun.YAML.stringify({
+			profiles: {
+				competing: {
+					required_providers: ["my-oai"],
+					model_mapping: { default: "my-oai/competing" },
+				},
+			},
+		});
+		syncFs.writeFileSync(competingPath, competingText);
+		const originalRename = syncFs.renameSync;
+		let injected = false;
+		const renameSpy = spyOn(syncFs, "renameSync").mockImplementation((source, destination) => {
+			if (!injected && String(source).endsWith("models.yml") && String(destination).endsWith(".observed")) {
+				originalRename(competingPath, source);
+				injected = true;
+			}
+			return originalRename(source, destination);
+		});
+		try {
+			await expect(registry.saveCustomModelProfile("profile-a", snapshot)).rejects.toThrow(
+				"Refusing to replace models config changed during commit",
+			);
+		} finally {
+			renameSpy.mockRestore();
+		}
+		expect(injected).toBe(true);
+		expect(await Bun.file(modelsPath).text()).toBe(competingText);
+		expect((await fs.readdir(tempDir)).some(name => name.endsWith(".observed"))).toBe(true);
+		expect((await fs.readdir(tempDir)).some(name => name.endsWith(".rollback"))).toBe(true);
+	});
+
+	it("preserves a competing first-file creation at the exclusive commit boundary", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const competingText = Bun.YAML.stringify({
+			profiles: {
+				competing: {
+					required_providers: ["my-oai"],
+					model_mapping: { default: "my-oai/competing" },
+				},
+			},
+		});
+		const originalLink = syncFs.linkSync;
+		let injected = false;
+		const linkSpy = spyOn(syncFs, "linkSync").mockImplementation((source, destination) => {
+			if (!injected && String(source).endsWith(".tmp") && String(destination).endsWith("models.yml")) {
+				syncFs.writeFileSync(destination, competingText, { flag: "wx" });
+				injected = true;
+			}
+			return originalLink(source, destination);
+		});
+		try {
+			await expect(registry.saveCustomModelProfile("profile-a", snapshot)).rejects.toThrow(
+				"exclusive commit boundary",
+			);
+		} finally {
+			linkSpy.mockRestore();
+		}
+		expect(injected).toBe(true);
+		expect(await Bun.file(modelsPath).text()).toBe(competingText);
+	});
+	it("reports post-commit verification failure and preserves rollback evidence", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("seed", snapshot);
+		const originalLink = syncFs.linkSync;
+		const originalStat = syncFs.statSync;
+		let committed = false;
+		let failedVerification = false;
+		const linkSpy = spyOn(syncFs, "linkSync").mockImplementation((source, destination) => {
+			const result = originalLink(source, destination);
+			if (String(source).endsWith(".tmp") && String(destination).endsWith("models.yml")) committed = true;
+			return result;
+		});
+		const statSpy = spyOn(syncFs, "statSync").mockImplementation(((target: Parameters<typeof syncFs.statSync>[0]) => {
+			if (committed && !failedVerification && String(target).endsWith("models.yml")) {
+				failedVerification = true;
+				throw Object.assign(new Error("forced verification EIO"), { code: "EIO" });
+			}
+			return originalStat(target);
+		}) as typeof syncFs.statSync);
+		try {
+			await expect(registry.saveCustomModelProfile("profile-a", snapshot)).rejects.toThrow(
+				"Models config was committed, but verification failed",
+			);
+		} finally {
+			statSpy.mockRestore();
+			linkSpy.mockRestore();
+		}
+		expect(failedVerification).toBe(true);
+		expect((await fs.readdir(tempDir)).some(name => name.endsWith(".rollback"))).toBe(true);
+		const parsed = YAML.parse(await Bun.file(modelsPath).text()) as { profiles?: Record<string, unknown> };
+		expect(parsed.profiles?.["profile-a"]).toBeDefined();
+	});
+
+	it("keeps original recovery bytes through final pathname verification", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("seed", snapshot);
+		const originalText = await Bun.file(modelsPath).text();
+		const originalLink = syncFs.linkSync;
+		const originalStat = syncFs.statSync;
+		let committed = false;
+		let committedStatCalls = 0;
+		const linkSpy = spyOn(syncFs, "linkSync").mockImplementation((source, destination) => {
+			const result = originalLink(source, destination);
+			if (String(source).endsWith(".tmp") && String(destination).endsWith("models.yml")) committed = true;
+			return result;
+		});
+		const statSpy = spyOn(syncFs, "statSync").mockImplementation(((target: Parameters<typeof syncFs.statSync>[0]) => {
+			if (committed && String(target).endsWith("models.yml") && ++committedStatCalls === 2) {
+				throw Object.assign(new Error("forced final verification EIO"), { code: "EIO" });
+			}
+			return originalStat(target);
+		}) as typeof syncFs.statSync);
+		try {
+			await expect(registry.saveCustomModelProfile("profile-a", snapshot)).rejects.toThrow(
+				"Models config was committed, but verification failed",
+			);
+		} finally {
+			statSpy.mockRestore();
+			linkSpy.mockRestore();
+		}
+
+		expect(committedStatCalls).toBe(2);
+		const recoveryName = (await fs.readdir(tempDir)).find(name => name.endsWith(".recovery"));
+		expect(recoveryName).toBeDefined();
+		expect(await Bun.file(path.join(tempDir, recoveryName ?? "")).text()).toBe(originalText);
+	});
+	it("preserves models config mode and ownership across atomic replacement", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("profile-a", {
+			display_name: "Profile A",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/model-a" },
+		});
+		await fs.chmod(modelsPath, 0o600);
+		const before = await fs.stat(modelsPath);
+
+		await registry.saveCustomModelProfile("profile-b", {
+			display_name: "Profile B",
+			required_providers: ["anthropic"],
+			model_mapping: { default: "anthropic/model-b" },
+		});
+
+		const after = await fs.stat(modelsPath);
+		expect(after.mode & 0o7777).toBe(before.mode & 0o7777);
+		expect(after.uid).toBe(before.uid);
+		expect(after.gid).toBe(before.gid);
+	});
+
+	it("refreshes profile maps after a same-mtime config replacement", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		await Bun.write(
+			modelsPath,
+			Bun.YAML.stringify({
+				profiles: {
+					"old-profile": {
+						required_providers: ["anthropic"],
+						model_mapping: { default: "anthropic/old-model" },
+					},
+				},
+			}),
+		);
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		expect(registry.getModelProfile("old-profile")).toBeDefined();
+		const originalStat = await fs.stat(modelsPath);
+
+		await Bun.write(
+			modelsPath,
+			Bun.YAML.stringify({
+				profiles: {
+					"new-profile": {
+						required_providers: ["anthropic"],
+						model_mapping: { default: "anthropic/new-model" },
+					},
+				},
+			}),
+		);
+		await fs.utimes(modelsPath, originalStat.atime, originalStat.mtime);
+		await registry.refresh("offline");
+
+		expect(registry.getModelProfile("old-profile")).toBeUndefined();
+		expect(registry.getModelProfile("new-profile")).toBeDefined();
+	});
+
+	it("keeps the prior models config intact when an atomic profile write fails", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const canonicalModelsPath = path.join(await fs.realpath(tempDir), "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("profile-a", {
+			display_name: "Profile A",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/model-a" },
+		});
+		const before = await Bun.file(modelsPath).text();
+		const originalOpen = syncFs.openSync;
+		const openSpy = spyOn(syncFs, "openSync").mockImplementation((...args) => {
+			if (typeof args[0] === "string" && args[0].startsWith(`${canonicalModelsPath}.`) && args[0].endsWith(".tmp")) {
+				throw new Error("forced models write failure");
+			}
+			return originalOpen(...args);
+		});
+		try {
+			await expect(
+				registry.saveCustomModelProfile("profile-b", {
+					display_name: "Profile B",
+					required_providers: ["anthropic"],
+					model_mapping: { default: "anthropic/model-b" },
+				}),
+			).rejects.toThrow("forced models write failure");
+		} finally {
+			openSpy.mockRestore();
+		}
+
+		expect(await Bun.file(modelsPath).text()).toBe(before);
+		const reopened = new ModelRegistry(authStorage, modelsPath);
+		expect(reopened.getModelProfile("profile-a")?.displayName).toBe("Profile A");
+		expect(reopened.getModelProfile("profile-b")).toBeUndefined();
+	});
+
+	it("keeps a renamed models config committed when parent directory fsync fails", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const originalFsync = syncFs.fsyncSync;
+		const fsyncSpy = spyOn(syncFs, "fsyncSync").mockImplementation(fd => {
+			if (syncFs.fstatSync(fd).isDirectory()) {
+				throw new Error("simulated models parent fsync failure");
+			}
+			return originalFsync(fd);
+		});
+		try {
+			await expect(
+				registry.saveCustomModelProfile("profile-a", {
+					display_name: "Profile A",
+					required_providers: ["my-oai"],
+					model_mapping: { default: "my-oai/model-a" },
+				}),
+			).resolves.toMatchObject({ displayName: "Profile A" });
+		} finally {
+			fsyncSpy.mockRestore();
+		}
+
+		const reopened = new ModelRegistry(authStorage, modelsPath);
+		expect(reopened.getModelProfile("profile-a")?.displayName).toBe("Profile A");
+	});
+
+	it("keeps an archived fallback across repeated deletion and clears it on recreation", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		const registryA = new ModelRegistry(authStorage, modelsPath);
+		const registryB = new ModelRegistry(authStorage, modelsPath);
+		await registryA.saveCustomModelProfile("profile-a", {
+			display_name: "Original A",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/model-a" },
+		});
+		await registryA.deleteCustomModelProfile("profile-a");
+
+		await expect(registryB.deleteCustomModelProfile("profile-a")).rejects.toThrow(
+			"Custom model profile is already deleted: profile-a.",
+		);
+		const archivedRegistry = new ModelRegistry(authStorage, modelsPath);
+		expect(archivedRegistry.getModelProfile("profile-a")).toBeUndefined();
+		expect(archivedRegistry.getModelProfileForReference("profile-a")?.displayName).toBe("Original A");
+		expect(archivedRegistry.getAvailableModelProfileNames()).not.toContain("profile-a");
+
+		await registryB.saveCustomModelProfile("profile-a", {
+			display_name: "Recreated A",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/model-a-v2" },
+		});
+		const recreatedConfig = YAML.parse(await Bun.file(modelsPath).text()) as {
+			profiles: Record<string, { display_name?: string }>;
+			equivalence?: { exclude?: string[] };
+		};
+		expect(recreatedConfig.profiles["profile-a"]?.display_name).toBe("Recreated A");
+		expect(
+			recreatedConfig.equivalence?.exclude?.some(value => value.startsWith(archivedProfilePrefix)) ?? false,
+		).toBe(false);
+
+		const recreatedRegistry = new ModelRegistry(authStorage, modelsPath);
+		expect(recreatedRegistry.getModelProfile("profile-a")?.displayName).toBe("Recreated A");
+		await recreatedRegistry.deleteCustomModelProfile("profile-a");
+		const rearchivedRegistry = new ModelRegistry(authStorage, modelsPath);
+		expect(rearchivedRegistry.getModelProfile("profile-a")).toBeUndefined();
+		expect(rearchivedRegistry.getModelProfileForReference("profile-a")?.displayName).toBe("Recreated A");
+		const rearchivedConfig = YAML.parse(await Bun.file(modelsPath).text()) as {
+			equivalence?: { exclude?: string[] };
+		};
+		expect(
+			rearchivedConfig.equivalence?.exclude?.filter(value => value.startsWith(archivedProfilePrefix)),
+		).toHaveLength(1);
+	});
+
+	it("keeps stale global and cross-project references resolvable after archival", async () => {
+		const agentDir = path.join(tempDir, "archived-reference-agent");
+		const modelsPath = path.join(agentDir, "models.yml");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		await registry.saveCustomModelProfile("profile-a", {
+			display_name: "Profile A",
+			required_providers: ["my-oai"],
+			model_mapping: { default: "my-oai/model-a" },
+		});
+		const projectX = path.join(tempDir, "project-x");
+		await fs.mkdir(getProjectAgentDir(projectX), { recursive: true });
+		await Bun.write(
+			path.join(getProjectAgentDir(projectX), "config.yml"),
+			YAML.stringify({ modelProfile: { default: "profile-a" } }),
+		);
+
+		resetSettingsForTest();
+		try {
+			const settingsA = await Settings.init({ agentDir, cwd: tempDir });
+			const settingsB = await settingsA.cloneForCwd(tempDir);
+			settingsB.set("modelProfile.default", "profile-a");
+
+			await settingsA.deleteModelProfileIfUnreferenced("profile-a", () =>
+				registry.deleteCustomModelProfile("profile-a"),
+			);
+			const projectY = path.join(tempDir, "project-y");
+			await fs.mkdir(getProjectAgentDir(projectY), { recursive: true });
+			await Bun.write(
+				path.join(getProjectAgentDir(projectY), "config.yml"),
+				YAML.stringify({ modelProfile: { default: "profile-a" } }),
+			);
+			await settingsB.flushOrThrow();
+
+			resetSettingsForTest();
+			const projectSettings = await Settings.init({ agentDir, cwd: projectX });
+			const reopenedRegistry = new ModelRegistry(authStorage, modelsPath);
+			expect(projectSettings.getGlobal("modelProfile.default")).toBe("profile-a");
+			expect(projectSettings.getProject("modelProfile.default")).toBe("profile-a");
+			const lateProjectSettings = await projectSettings.cloneForCwd(projectY);
+			expect(lateProjectSettings.getProject("modelProfile.default")).toBe("profile-a");
+			expect(reopenedRegistry.getModelProfileForReference("profile-a")?.displayName).toBe("Profile A");
+			expect(reopenedRegistry.getAvailableModelProfileNames()).not.toContain("profile-a");
+		} finally {
+			resetSettingsForTest();
+		}
 	});
 
 	it("rejects empty rename input and built-in delete without mutating config", async () => {
@@ -664,7 +1450,7 @@ describe("custom model preset creation", () => {
 			},
 			getActiveModelProfile: () => activeProfiles.at(-1),
 		};
-		const flushSpy = spyOn(settings, "flush").mockRejectedValueOnce(new Error("flush failed"));
+		const flushSpy = spyOn(settings, "flushOrThrow").mockRejectedValueOnce(new Error("flush failed"));
 
 		try {
 			await expect(
@@ -684,7 +1470,278 @@ describe("custom model preset creation", () => {
 		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });
 		expect(activeProfiles.at(-1)).toBe("custom-default");
 	});
-	it("restores a deleted custom preset when post-delete notification fails", async () => {
+	it("rejects profile deletion materialization when config persistence fails", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "custom-default",
+			displayName: "Custom Default",
+			requiredProviders: ["my-oai"],
+			modelMapping: {
+				default: "my-oai/gpt-custom:low",
+				executor: "my-oai/gpt-custom",
+			},
+			source: "user",
+		};
+		const agentDir = path.join(tempDir, "failed-materialization-settings");
+		resetSettingsForTest();
+		try {
+			const settings = await Settings.init({ agentDir, cwd: tempDir });
+			const configPath = path.join(await fs.realpath(settings.getAgentDir()), "config.yml");
+			settings.set("modelProfile.default", customProfile.name);
+			settings.setModelRole("default", "old/default");
+			await settings.flushOrThrow();
+			const session = createDeletionSession();
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (
+					typeof args[0] === "string" &&
+					args[0].startsWith(`${configPath}.`) &&
+					args[0].endsWith(".tmp") &&
+					!args[0].startsWith(`${configPath}.revisions.json.`)
+				) {
+					throw new Error("forced config write failure");
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				await expect(
+					materializeModelProfileForDeletion({
+						session,
+						settings,
+						modelRegistry: createRegistry([[customProfile.name, customProfile]]),
+						profileName: customProfile.name,
+					}),
+				).rejects.toThrow("forced config write failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir, cwd: tempDir });
+			expect(reopened.getGlobal("modelProfile.default")).toBe(customProfile.name);
+		} finally {
+			resetSettingsForTest();
+		}
+	});
+	it("preserves later durable choices while materializing a profile for deletion", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "custom-default",
+			displayName: "Custom Default",
+			requiredProviders: ["my-oai"],
+			modelMapping: {
+				default: "my-oai/gpt-custom:low",
+				executor: "my-oai/gpt-custom",
+				architect: "my-oai/gpt-custom",
+			},
+			source: "user",
+		};
+		const agentDir = path.join(tempDir, "forward-settings");
+		resetSettingsForTest();
+		const { promise: releaseLookup, resolve: resolveLookup } = Promise.withResolvers<void>();
+		const { promise: lookupStarted, resolve: resolveLookupStarted } = Promise.withResolvers<void>();
+		try {
+			const settingsA = await Settings.init({ agentDir, cwd: tempDir });
+			settingsA.setModelRole("default", "old/default");
+			settingsA.setAgentModelOverride("critic", "old/critic");
+			settingsA.setAgentModelOverride("architect", "my-oai/gpt-custom");
+			settingsA.set("modelProfile.default", customProfile.name);
+			await settingsA.flushOrThrow();
+			const settingsB = await settingsA.cloneForCwd(tempDir);
+			const session = createDeletionSession();
+			const baseRegistry = createRegistry([[customProfile.name, customProfile]]);
+			await activateModelProfile({
+				session,
+				settings: settingsA,
+				modelRegistry: baseRegistry,
+				profileName: customProfile.name,
+			});
+			const originalGetApiKey = baseRegistry.getApiKeyForProvider.bind(baseRegistry);
+			const gatedRegistry = {
+				...baseRegistry,
+				getApiKeyForProvider: async (...args: Parameters<ModelRegistry["getApiKeyForProvider"]>) => {
+					resolveLookupStarted();
+					await releaseLookup;
+					return originalGetApiKey(...args);
+				},
+			} as ModelRegistry;
+
+			const materializing = materializeModelProfileForDeletion({
+				session,
+				settings: settingsA,
+				modelRegistry: gatedRegistry,
+				profileName: customProfile.name,
+			});
+			await lookupStarted;
+			settingsB.setModelRole("default", "external/default");
+			settingsB.setAgentModelOverride("architect", "external/architect");
+			settingsB.set("modelProfile.default", "profile-b");
+			await settingsB.flushOrThrow();
+			resolveLookup();
+			await materializing;
+
+			expect(settingsA.get("modelRoles")).toEqual({ default: "external/default" });
+			expect(settingsA.get("task.agentModelOverrides")).toEqual({
+				architect: "external/architect",
+				critic: "old/critic",
+				executor: "my-oai/gpt-custom",
+			});
+			expect(settingsA.get("modelProfile.default")).toBe("profile-b");
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir, cwd: tempDir });
+			expect(reopened.getGlobal("modelRoles")).toEqual({ default: "external/default" });
+			expect(reopened.getGlobal("task.agentModelOverrides")).toEqual({
+				architect: "external/architect",
+				critic: "old/critic",
+				executor: "my-oai/gpt-custom",
+			});
+			expect(reopened.getGlobal("modelProfile.default")).toBe("profile-b");
+		} finally {
+			resolveLookup();
+			resetSettingsForTest();
+		}
+	});
+	it("rolls back only deletion leaves that no later writer changed", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "custom-default",
+			displayName: "Custom Default",
+			requiredProviders: ["my-oai"],
+			modelMapping: {
+				default: "my-oai/gpt-custom:low",
+				executor: "my-oai/gpt-custom",
+				architect: "my-oai/gpt-custom",
+			},
+			source: "user",
+		};
+		const agentDir = path.join(tempDir, "rollback-settings");
+		resetSettingsForTest();
+		try {
+			const settingsA = await Settings.init({ agentDir, cwd: tempDir });
+			settingsA.setModelRole("default", "old/default");
+			settingsA.setAgentModelOverride("critic", "old/critic");
+			settingsA.set("modelProfile.default", customProfile.name);
+			await settingsA.flushOrThrow();
+			const session = createDeletionSession();
+			const registry = createRegistry([[customProfile.name, customProfile]]);
+			await activateModelProfile({
+				session,
+				settings: settingsA,
+				modelRegistry: registry,
+				profileName: customProfile.name,
+			});
+			const snapshot = await materializeModelProfileForDeletion({
+				session,
+				settings: settingsA,
+				modelRegistry: registry,
+				profileName: customProfile.name,
+			});
+			expect(snapshot.previousPersistedModelRoles).toEqual({ default: "old/default" });
+			expect(snapshot.previousPersistedAgentModelOverrides).toEqual({ critic: "old/critic" });
+			const settingsB = await settingsA.cloneForCwd(tempDir);
+			settingsB.setModelRole("default", "external/default");
+			settingsB.setAgentModelOverride("architect", "external/architect");
+			settingsB.setAgentModelOverride("executor", "my-oai/gpt-custom");
+			settingsB.set("modelProfile.default", "profile-b");
+			await settingsB.flushOrThrow();
+
+			await restoreMaterializedModelProfileForDeletion({ settings: settingsA, session, snapshot });
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir, cwd: tempDir });
+			expect(reopened.getGlobal("modelRoles")).toEqual({ default: "external/default" });
+			expect(reopened.getGlobal("task.agentModelOverrides")).toEqual({
+				architect: "external/architect",
+				critic: "old/critic",
+				executor: "my-oai/gpt-custom",
+			});
+			expect(reopened.getGlobal("modelProfile.default")).toBe("profile-b");
+		} finally {
+			resetSettingsForTest();
+		}
+	});
+	it("refuses controller deletion when the same profile is selected after materialization", async () => {
+		const profileName = "custom-default";
+		const profile: ModelProfileDefinition = {
+			name: profileName,
+			displayName: "Custom Default",
+			requiredProviders: ["my-oai"],
+			modelMapping: { default: "my-oai/gpt-custom:low" },
+			source: "user",
+		};
+		const agentDir = path.join(tempDir, "concurrent-delete-agent");
+		resetSettingsForTest();
+		try {
+			const settingsA = await Settings.init({ agentDir, cwd: tempDir });
+			settingsA.set("modelProfile.default", profileName);
+			await settingsA.flushOrThrow();
+			const settingsB = await settingsA.cloneForCwd(tempDir);
+			const profiles = new Map([[profileName, profile]]);
+			const harness = await createDeletionControllerHarness(settingsA, profiles, profileName);
+			const deleteModelProfileIfUnreferenced = settingsA.deleteModelProfileIfUnreferenced.bind(settingsA);
+			const deletionSpy = spyOn(settingsA, "deleteModelProfileIfUnreferenced").mockImplementation(
+				async (name, deleteProfile) => {
+					settingsB.set("modelProfile.default", profileName);
+					await settingsB.flushOrThrow();
+					return deleteModelProfileIfUnreferenced(name, deleteProfile);
+				},
+			);
+			try {
+				await harness.selector.__testSelectPresetAction(profileName, "delete");
+				await Bun.sleep(0);
+			} finally {
+				deletionSpy.mockRestore();
+			}
+
+			expect(harness.getDeleteCalls()).toBe(0);
+			expect(profiles.has(profileName)).toBe(true);
+			expect(harness.statuses.some(message => message.includes("Custom model preset deleted"))).toBe(false);
+			expect(harness.errors).toContain(
+				`Preset delete failed: Model profile became the default while deletion was in progress: ${profileName}`,
+			);
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir, cwd: tempDir });
+			expect(reopened.getGlobal("modelProfile.default")).toBe(profileName);
+		} finally {
+			resetSettingsForTest();
+		}
+	});
+
+	it("archives a deleted preset so current-project references remain resolvable", async () => {
+		const profileName = "custom-project";
+		const profile: ModelProfileDefinition = {
+			name: profileName,
+			displayName: "Custom Project",
+			requiredProviders: ["my-oai"],
+			modelMapping: { default: "my-oai/gpt-custom:low" },
+			source: "user",
+		};
+		const agentDir = path.join(tempDir, "project-reference-agent");
+		const projectDir = path.join(tempDir, "referencing-project");
+		await fs.mkdir(getProjectAgentDir(projectDir), { recursive: true });
+		await Bun.write(
+			path.join(getProjectAgentDir(projectDir), "config.yml"),
+			YAML.stringify({ modelProfile: { default: profileName } }),
+		);
+		resetSettingsForTest();
+		try {
+			const settings = await Settings.init({ agentDir, cwd: projectDir });
+			const profiles = new Map([[profileName, profile]]);
+			const harness = await createDeletionControllerHarness(settings, profiles);
+			await harness.selector.__testSelectPresetAction(profileName, "delete");
+			await Bun.sleep(0);
+
+			expect(harness.getDeleteCalls()).toBe(1);
+			expect(profiles.has(profileName)).toBe(false);
+			expect(harness.getArchivedProfile(profileName)?.displayName).toBe("Custom Project");
+			expect(harness.statuses).toContain("Custom model preset deleted: Custom Project");
+			expect(harness.errors).toEqual([]);
+			expect(settings.getProject("modelProfile.default")).toBe(profileName);
+		} finally {
+			resetSettingsForTest();
+		}
+	});
+	it("keeps a deleted custom preset committed when post-delete notification fails", async () => {
 		const unsafeDisplayName = "Custom\x1b[31m Default\x1b[0m\nRestored";
 		const profiles = new Map<string, ModelProfileDefinition>([
 			[
@@ -771,7 +1828,7 @@ describe("custom model preset creation", () => {
 			updateEditorBorderColor: () => {},
 			showStatus: () => {},
 			showError: (message: string) => {
-				expect(message).toBe("Preset delete failed: notify failed");
+				expect(message).toBe("Configuration was updated, but change notification failed: notify failed");
 			},
 			showHookConfirm: async (title: string) => {
 				confirmTitle = title;
@@ -785,13 +1842,14 @@ describe("custom model preset creation", () => {
 		new SelectorController(ctx as never).showModelSelector();
 		await Bun.sleep(0);
 		await selector?.__testSelectPresetAction("custom-default", "delete");
+		await Bun.sleep(0);
 
 		expect(confirmTitle).toBe("Delete custom model preset: Custom Default Restored");
-		expect(restoredProfile?.display_name).toBe(unsafeDisplayName);
-		expect(profiles.get("custom-default")?.displayName).toBe(unsafeDisplayName);
-		expect(settings.get("modelProfile.default")).toBe("custom-default");
-		expect(settings.get("modelRoles")).toEqual({ default: "old/default" });
+		expect(restoredProfile).toBeUndefined();
+		expect(profiles.has("custom-default")).toBe(false);
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(settings.get("modelRoles")).toEqual({ default: "my-oai/gpt-custom:low" });
 		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });
-		expect(activeProfiles.at(-1)).toBe("custom-default");
+		expect(activeProfiles.at(-1)).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/login-preset-recommendation.test.ts
+++ b/packages/coding-agent/test/login-preset-recommendation.test.ts
@@ -101,6 +101,9 @@ function createControllerContext(
 		showHookConfirm: vi.fn(async () => options.confirm ?? false),
 		showStatus: vi.fn(),
 		showError: vi.fn(),
+		statusLine: { invalidate: vi.fn() },
+		updateEditorBorderColor: vi.fn(),
+		notifyConfigChanged: vi.fn(async () => {}),
 	};
 	return { ctx, settings, session, setCalls };
 }
@@ -128,6 +131,7 @@ describe("login preset recommendation", () => {
 		expect(session.setActiveModelProfile).toHaveBeenCalledWith("codex-medium");
 		expect(settings.get("modelProfile.default")).toBeUndefined();
 		expect(setCalls).not.toContainEqual({ path: "modelProfile.default", value: "codex-medium" });
+		expect(ctx.notifyConfigChanged).toHaveBeenCalledTimes(1);
 	});
 
 	test("declining the post-login recommendation performs no mutation", async () => {
@@ -151,13 +155,13 @@ describe("login preset recommendation", () => {
 		expect(session.setModelTemporaryCalls).toEqual([]);
 	});
 
-	test("login with default profile setting shows hint instead of prompting", async () => {
+	test("configured startup profile does not mask an explicitly detached session", async () => {
 		const { ctx, session } = createControllerContext({ defaultProfile: "codex-eco" });
 
 		await login(ctx, "openai-codex");
 
-		expect(ctx.showHookConfirm).not.toHaveBeenCalled();
-		expect(ctx.showStatus).toHaveBeenCalledWith("Preset codex-medium is available in /model.");
+		expect(ctx.showHookConfirm).toHaveBeenCalledWith("Apply codex-medium now?", "");
+		expect(ctx.showStatus).not.toHaveBeenCalledWith("Preset codex-medium is available in /model.");
 		expect(session.setModelTemporaryCalls).toEqual([]);
 	});
 

--- a/packages/coding-agent/test/model-profile-activation-redteam.test.ts
+++ b/packages/coding-agent/test/model-profile-activation-redteam.test.ts
@@ -65,7 +65,7 @@ function instrumentSettings(settings: Settings) {
 		overrideCalls.push(path);
 		return originalOverride(path, value);
 	}) as typeof settings.override;
-	settings.flush = async () => {
+	settings.flushOrThrow = async () => {
 		flushCount += 1;
 	};
 	return {

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
 import {
@@ -8,11 +11,12 @@ import {
 	materializeActiveModelProfileAssignment,
 	materializeActiveModelProfileAssignments,
 	prepareModelProfileActivation,
+	resolveProjectModelProfileShadow,
 } from "../src/config/model-profile-activation";
 import type { ModelProfileDefinition } from "../src/config/model-profiles";
 import { BUILTIN_MODEL_PROFILES, mergeModelProfiles } from "../src/config/model-profiles";
 import type { ModelRegistry } from "../src/config/model-registry";
-import { Settings } from "../src/config/settings";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
 
 const model = (provider: string, id: string, thinking?: Model["thinking"]): Model =>
 	({
@@ -26,7 +30,11 @@ const model = (provider: string, id: string, thinking?: Model["thinking"]): Mode
 		reasoning: thinking !== undefined,
 	}) as Model;
 
-function fakeRegistry(options?: { missingProviders?: string[]; profiles?: ModelProfileDefinition[] }) {
+function fakeRegistry(options?: {
+	missingProviders?: string[];
+	profiles?: ModelProfileDefinition[];
+	archivedProfiles?: ModelProfileDefinition[];
+}) {
 	const profiles = new Map<string, ModelProfileDefinition>();
 	for (const profile of options?.profiles ?? [
 		{
@@ -42,9 +50,11 @@ function fakeRegistry(options?: { missingProviders?: string[]; profiles?: ModelP
 	]) {
 		profiles.set(profile.name, profile);
 	}
+	const archivedProfiles = new Map((options?.archivedProfiles ?? []).map(profile => [profile.name, profile]));
 	const missing = new Set(options?.missingProviders ?? []);
 	return {
 		getModelProfile: (name: string) => profiles.get(name),
+		getModelProfileForReference: (name: string) => profiles.get(name) ?? archivedProfiles.get(name),
 		getModelProfiles: () => new Map(profiles),
 		getAvailableModelProfileNames: () => [...profiles.keys()].sort(),
 		getApiKeyForProvider: async (provider: string) => (missing.has(provider) ? undefined : `key-${provider}`),
@@ -90,17 +100,27 @@ function fakeRegistry(options?: { missingProviders?: string[]; profiles?: ModelP
 	};
 }
 
-function fakeSession(initial = model("provider-a", "initial")) {
+function fakeSession(initial = model("provider-a", "initial"), initialResumeDefault?: string) {
 	let activeModelProfile: string | undefined;
+	let resumeDefault = initialResumeDefault;
 	return {
 		model: initial as Model | undefined,
 		thinkingLevel: ThinkingLevel.Low as ThinkingLevel | undefined,
 		sessionId: "session-1",
 		setModelTemporaryCalls: [] as Array<{ model: Model; thinkingLevel?: ThinkingLevel }>,
-		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
+		resumeDefaultChanges: [] as string[],
+		async setModelTemporary(
+			next: Model,
+			thinkingLevel?: ThinkingLevel,
+			options?: { persistAsSessionDefault?: boolean },
+		) {
 			this.setModelTemporaryCalls.push({ model: next, thinkingLevel });
 			this.model = next;
 			this.thinkingLevel = thinkingLevel;
+			if (options?.persistAsSessionDefault) {
+				resumeDefault = `${next.provider}/${next.id}`;
+				this.resumeDefaultChanges.push(resumeDefault);
+			}
 		},
 		setActiveModelProfile(name: string | undefined) {
 			activeModelProfile = name;
@@ -108,10 +128,41 @@ function fakeSession(initial = model("provider-a", "initial")) {
 		getActiveModelProfile() {
 			return activeModelProfile;
 		},
+		getSessionDefaultModelSelector() {
+			return resumeDefault;
+		},
+		recordResumeDefaultModel(selector: string) {
+			resumeDefault = selector;
+			this.resumeDefaultChanges.push(selector);
+		},
 	};
 }
 
 describe("model profile activation", () => {
+	test("activates an archived profile fallback that is hidden from selectable profiles", async () => {
+		const baseRegistry = fakeRegistry();
+		const registry = {
+			...baseRegistry,
+			getModelProfile: () => undefined,
+			getModelProfileForReference: baseRegistry.getModelProfile,
+			getModelProfiles: () => new Map<string, ModelProfileDefinition>(),
+			getAvailableModelProfileNames: () => [],
+		};
+		const session = fakeSession();
+		const settings = Settings.isolated();
+
+		await activateModelProfile({
+			session,
+			modelRegistry: registry,
+			settings,
+			profileName: "profile-a",
+		});
+
+		expect(session.getActiveModelProfile()).toBe("profile-a");
+		expect(session.model?.provider).toBe("provider-a");
+		expect(session.model?.id).toBe("default");
+		expect(registry.getModelProfiles().has("profile-a")).toBe(false);
+	});
 	test("prepared activation resolves default and agent selectors", async () => {
 		const prepared = await prepareModelProfileActivation({
 			session: fakeSession(),
@@ -127,6 +178,55 @@ describe("model profile activation", () => {
 		expect(prepared.agentModelOverrides).toEqual({
 			executor: "provider-b/executor",
 			architect: "provider-a/architect",
+		});
+	});
+	test("project profile shadow resolution honors fallback aliases and partial bindings", () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "codex-medium",
+				requiredProviders: ["provider-a"],
+				modelMapping: { architect: "provider-a/architect" },
+				source: "user",
+			},
+		];
+		const settings = Settings.isolated();
+		settings.getProject = ((path: string) =>
+			path === "modelProfile.default" ? "codex-standard" : undefined) as typeof settings.getProject;
+
+		expect(resolveProjectModelProfileShadow(settings, fakeRegistry({ profiles }))).toEqual({
+			profileName: "codex-medium",
+			targetIds: ["architect"],
+		});
+	});
+	test("project profile shadow resolves an archived exact name before a legacy alias", () => {
+		const archivedProfile: ModelProfileDefinition = {
+			name: "codex-standard",
+			requiredProviders: ["provider-a"],
+			modelMapping: { executor: "provider-a/archived" },
+			source: "user",
+		};
+		const settings = Settings.isolated();
+		settings.getProject = ((path: string) =>
+			path === "modelProfile.default" ? "codex-standard" : undefined) as typeof settings.getProject;
+
+		expect(
+			resolveProjectModelProfileShadow(
+				settings,
+				fakeRegistry({
+					profiles: [
+						{
+							name: "codex-medium",
+							requiredProviders: ["provider-a"],
+							modelMapping: { architect: "provider-a/alias" },
+							source: "user",
+						},
+					],
+					archivedProfiles: [archivedProfile],
+				}),
+			),
+		).toEqual({
+			profileName: "codex-standard",
+			targetIds: ["executor"],
 		});
 	});
 
@@ -202,6 +302,53 @@ describe("model profile activation", () => {
 		expect(session.getActiveModelProfile()).toBe("profile-a");
 	});
 
+	test("switching profiles drops omitted assignments back to the pre-profile baseline", async () => {
+		const session = fakeSession(model("provider-c", "default"));
+		const settings = Settings.isolated();
+		settings.set("modelRoles", { default: "provider-c/default:medium" });
+		settings.set("task.agentModelOverrides", {
+			architect: "configured/architect:low",
+			critic: "configured/critic:high",
+		});
+		const registry = fakeRegistry({
+			profiles: [
+				{
+					name: "profile-a",
+					requiredProviders: ["provider-a", "provider-b"],
+					modelMapping: {
+						default: "provider-a/default:high",
+						executor: "provider-b/executor",
+						architect: "provider-a/architect",
+					},
+					source: "user",
+				},
+				{
+					name: "profile-b",
+					requiredProviders: ["provider-c"],
+					modelMapping: {
+						default: "provider-c/default:low",
+						executor: "provider-c/executor",
+					},
+					source: "user",
+				},
+			],
+		});
+
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "profile-a" });
+		expect(settings.get("task.agentModelOverrides").architect).toBe("provider-a/architect");
+
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "profile-b" });
+
+		expect(session.model?.provider).toBe("provider-c");
+		expect(session.model?.id).toBe("default");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			architect: "configured/architect:low",
+			critic: "configured/critic:high",
+			executor: "provider-c/executor",
+		});
+		expect(session.getActiveModelProfile()).toBe("profile-b");
+	});
+
 	test("materializing a profile role override persists the full effective assignment set and clears the profile", async () => {
 		const session = fakeSession();
 		const settings = Settings.isolated({
@@ -229,6 +376,404 @@ describe("model profile activation", () => {
 		});
 		expect(settings.get("modelProfile.default")).toBeUndefined();
 		expect(session.getActiveModelProfile()).toBeUndefined();
+	});
+
+	test("materialization persists only leaves changed from the loaded global baseline", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", { critic: "configured/critic:high" });
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+		const persistedAgents: string[] = [];
+		const originalSetAgentModelOverride = settings.setAgentModelOverride.bind(settings);
+		settings.setAgentModelOverride = (agentName: string, selector: string) => {
+			persistedAgents.push(agentName);
+			originalSetAgentModelOverride(agentName, selector);
+		};
+		const originalSetAgentModelOverrideIfUnchanged = settings.setAgentModelOverrideIfUnchanged.bind(settings);
+		settings.setAgentModelOverrideIfUnchanged = (
+			agentName: string,
+			expectedSelector: string | undefined,
+			selector: string | undefined,
+		) => {
+			persistedAgents.push(agentName);
+			originalSetAgentModelOverrideIfUnchanged(agentName, expectedSelector, selector);
+		};
+
+		materializeActiveModelProfileAssignment({
+			session,
+			settings,
+			role: "executor",
+			selector: "provider-c/executor:medium",
+		});
+
+		expect(persistedAgents).toEqual(["executor", "architect"]);
+		expect(persistedAgents).not.toContain("critic");
+	});
+	test("materialization preserves pending explicit sibling and profile choices in the same Settings instance", async () => {
+		const settings = Settings.isolated();
+		const session = fakeSession();
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+
+		settings.setAgentModelOverride("architect", "provider-a/user-architect:medium");
+		settings.set("modelProfile.default", "profile-b");
+		expect(
+			materializeActiveModelProfileAssignment({
+				session,
+				settings,
+				role: "executor",
+				selector: "provider-a/manual-executor:low",
+			}),
+		).toBe(true);
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			architect: "provider-a/user-architect:medium",
+			executor: "provider-a/manual-executor:low",
+		});
+		expect(settings.get("modelProfile.default")).toBe("profile-b");
+	});
+	test("materialization preserves an already-flushed profile choice from the same Settings instance", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-profile-materialization-owner-"));
+		resetSettingsForTest();
+		try {
+			const settings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const session = fakeSession();
+			await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+
+			settings.set("modelProfile.default", "profile-b");
+			await settings.flushOrThrow();
+			expect(
+				materializeActiveModelProfileAssignment({
+					session,
+					settings,
+					role: "executor",
+					selector: "provider-a/manual-executor:low",
+				}),
+			).toBe(true);
+			await settings.flushOrThrow();
+
+			expect(settings.get("modelProfile.default")).toBe("profile-b");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				architect: "provider-a/architect",
+				executor: "provider-a/manual-executor:low",
+			});
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("materializing one profile role preserves a later durable sibling assignment", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-profile-materialization-sibling-"));
+		resetSettingsForTest();
+		try {
+			const settingsA = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const settingsB = await settingsA.cloneForCwd(tempDir);
+			const session = fakeSession();
+
+			await activateModelProfile({
+				session,
+				modelRegistry: fakeRegistry(),
+				settings: settingsA,
+				profileName: "profile-a",
+			});
+			settingsB.setAgentModelOverride("architect", "provider-a/user-architect:medium");
+			settingsB.setAgentModelOverride("executor", "provider-a/external-executor:medium");
+			settingsB.set("modelProfile.default", "profile-b");
+			settingsB.setModelRole("default", "provider-a/external-default:medium");
+			await settingsB.flushOrThrow();
+
+			expect(
+				materializeActiveModelProfileAssignment({
+					session,
+					settings: settingsA,
+					role: "executor",
+					selector: "provider-a/manual-executor:low",
+				}),
+			).toBe(true);
+			await settingsA.flushOrThrow();
+			expect(settingsA.get("task.agentModelOverrides")).toEqual({
+				architect: "provider-a/user-architect:medium",
+				executor: "provider-a/manual-executor:low",
+			});
+			expect(settingsA.get("modelRoles")).toEqual({
+				default: "provider-a/external-default:medium",
+			});
+			expect(settingsA.get("modelProfile.default")).toBe("profile-b");
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			expect(reopened.getGlobal("task.agentModelOverrides")).toEqual({
+				architect: "provider-a/user-architect:medium",
+				executor: "provider-a/manual-executor:low",
+			});
+			expect(reopened.getGlobal("modelProfile.default")).toBe("profile-b");
+			expect(reopened.getGlobal("modelRoles")).toEqual({
+				default: "provider-a/external-default:medium",
+			});
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("session-only materialization preserves a later durable selection of the same profile", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-profile-materialization-same-default-"));
+		resetSettingsForTest();
+		try {
+			const settingsA = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const settingsB = await settingsA.cloneForCwd(tempDir);
+			const session = fakeSession();
+			await activateModelProfile({
+				session,
+				modelRegistry: fakeRegistry(),
+				settings: settingsA,
+				profileName: "profile-a",
+			});
+
+			settingsB.set("modelProfile.default", "profile-a");
+			await settingsB.flushOrThrow();
+			expect(
+				materializeActiveModelProfileAssignment({
+					session,
+					settings: settingsA,
+					role: "executor",
+					selector: "provider-a/manual-executor:low",
+				}),
+			).toBe(true);
+			await settingsA.flushOrThrow();
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			expect(reopened.getGlobal("modelProfile.default")).toBe("profile-a");
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("equal explicit materialization rotates ownership against stale conditional writers", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-profile-equal-explicit-owner-"));
+		resetSettingsForTest();
+		try {
+			const settingsA = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			settingsA.setAgentModelOverride("executor", "provider-a/manual-executor:low");
+			await settingsA.flushOrThrow();
+			const staleSettings = await settingsA.cloneForCwd(tempDir);
+			const session = fakeSession();
+			await activateModelProfile({
+				session,
+				modelRegistry: fakeRegistry(),
+				settings: settingsA,
+				profileName: "profile-a",
+			});
+
+			expect(
+				materializeActiveModelProfileAssignment({
+					session,
+					settings: settingsA,
+					role: "executor",
+					selector: "provider-a/manual-executor:low",
+				}),
+			).toBe(true);
+			await settingsA.flushOrThrow();
+			staleSettings.setAgentModelOverrideIfUnchanged(
+				"executor",
+				"provider-a/manual-executor:low",
+				"provider-a/stale-executor:low",
+			);
+			await staleSettings.flushOrThrow();
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			expect(reopened.getGlobal("task.agentModelOverrides")).toMatchObject({
+				executor: "provider-a/manual-executor:low",
+			});
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("failed profile detachment retains transition state for the next activation", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated();
+		const profileA = fakeRegistry().getModelProfile("profile-a");
+		if (!profileA) throw new Error("missing profile-a fixture");
+		const registry = fakeRegistry({
+			profiles: [
+				profileA,
+				{
+					name: "profile-b",
+					requiredProviders: ["provider-c"],
+					modelMapping: {
+						default: "provider-c/default:low",
+						executor: "provider-c/executor",
+					},
+					source: "user",
+				},
+			],
+		});
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "profile-a" });
+		const setActiveModelProfile = session.setActiveModelProfile.bind(session);
+		session.setActiveModelProfile = (name: string | undefined) => {
+			if (name === undefined) throw new Error("detach failed");
+			setActiveModelProfile(name);
+		};
+
+		expect(() =>
+			materializeActiveModelProfileAssignment({
+				session,
+				settings,
+				role: "critic",
+				selector: "provider-c/critic:low",
+			}),
+		).toThrow("detach failed");
+		expect(session.getActiveModelProfile()).toBe("profile-a");
+
+		session.setActiveModelProfile = setActiveModelProfile;
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "profile-b" });
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-c/executor",
+		});
+	});
+
+	test("role-only materialization persists the active profile default, not a transient live model", async () => {
+		const session = fakeSession(model("provider-c", "default"));
+		const settings = Settings.isolated({
+			modelRoles: { default: "configured/default:medium" },
+			"task.agentModelOverrides": { critic: "configured/critic:high" },
+		});
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+
+		session.model = model("provider-c", "architect");
+		session.thinkingLevel = ThinkingLevel.Low;
+		const materialized = materializeActiveModelProfileAssignment({
+			session,
+			settings,
+			role: "executor",
+			selector: "provider-c/executor:medium",
+		});
+
+		expect(materialized).toBe(true);
+		expect(settings.getGlobal("modelRoles")).toEqual({
+			default: "provider-a/default:high",
+		});
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			architect: "provider-a/architect",
+			critic: "configured/critic:high",
+			executor: "provider-c/executor:medium",
+		});
+	});
+	test("materialization uses an activation effort override for the active profile DEFAULT", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated();
+		await activateModelProfile(
+			{ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" },
+			{ thinkingLevelOverride: ThinkingLevel.Low },
+		);
+
+		expect(
+			materializeActiveModelProfileAssignments({
+				session,
+				settings,
+				assignments: { executor: "provider-c/executor:medium" },
+			}),
+		).toBe(true);
+		expect(settings.getGlobal("modelRoles")).toEqual({
+			default: "provider-a/default:low",
+		});
+	});
+	test("role-only profile detach preserves the exact persisted DEFAULT selector", async () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "role-only",
+				requiredProviders: ["provider-b"],
+				modelMapping: { executor: "provider-b/executor:low" },
+				source: "user",
+			},
+		];
+		const settings = Settings.isolated();
+		settings.set("modelRoles", { default: "configured/resume:high" });
+		const session = fakeSession(model("provider-c", "default"), "provider-c/resume");
+		await activateModelProfile({
+			session,
+			modelRegistry: fakeRegistry({ profiles }),
+			settings,
+			profileName: "role-only",
+		});
+
+		expect(
+			materializeActiveModelProfileAssignment({
+				session,
+				settings,
+				role: "executor",
+				selector: "provider-c/executor:medium",
+			}),
+		).toBe(true);
+		expect(settings.getGlobal("modelRoles")).toEqual({
+			default: "configured/resume:high",
+		});
+	});
+
+	test("suffixless profile DEFAULT remains inherited when detached", async () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "inherits-effort",
+				requiredProviders: ["provider-a"],
+				modelMapping: {
+					default: "provider-a/default",
+					executor: "provider-b/executor:low",
+				},
+				source: "user",
+			},
+		];
+		const settings = Settings.isolated({ defaultThinkingLevel: ThinkingLevel.High });
+		const session = fakeSession();
+		await activateModelProfile(
+			{
+				session,
+				modelRegistry: fakeRegistry({ profiles }),
+				settings,
+				profileName: "inherits-effort",
+			},
+			{ thinkingLevelOverride: ThinkingLevel.High },
+		);
+
+		expect(
+			materializeActiveModelProfileAssignment({
+				session,
+				settings,
+				role: "executor",
+				selector: "provider-c/executor:medium",
+			}),
+		).toBe(true);
+		expect(settings.getGlobal("modelRoles")).toEqual({
+			default: "provider-a/default",
+		});
+		expect(settings.get("defaultThinkingLevel")).toBe(ThinkingLevel.High);
+	});
+
+	test("detached sessions do not re-materialize a still-configured project default", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated();
+		settings.set("modelProfile.default", "profile-a");
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+		expect(
+			materializeActiveModelProfileAssignment({
+				session,
+				settings,
+				role: "executor",
+				selector: "provider-c/executor:medium",
+			}),
+		).toBe(true);
+
+		settings.override("modelProfile.default", "profile-a");
+		expect(
+			materializeActiveModelProfileAssignment({
+				session,
+				settings,
+				role: "critic",
+				selector: "provider-c/architect:low",
+			}),
+		).toBe(false);
 	});
 
 	test("materializing a default override stores the selected default and clears the profile", async () => {
@@ -301,9 +846,168 @@ describe("model profile activation", () => {
 		expect(session.getActiveModelProfile()).toBeUndefined();
 	});
 
-	test("--default persists profile default, clears persisted assignments, and flushes", async () => {
+	test("switching profiles preserves an explicit role clear instead of resurrecting the saved baseline", async () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "profile-a",
+				requiredProviders: ["provider-a"],
+				modelMapping: { critic: "provider-a/architect" },
+				source: "user",
+			},
+			{
+				name: "profile-b",
+				requiredProviders: ["provider-b"],
+				modelMapping: { executor: "provider-b/executor" },
+				source: "user",
+			},
+		];
+		const settings = Settings.isolated();
+		settings.setAgentModelOverride("critic", "user/critic");
+		settings.override("task.agentModelOverrides", { critic: "user/critic" });
+		const session = fakeSession();
+
+		await activateModelProfile({
+			session,
+			modelRegistry: fakeRegistry({ profiles }),
+			settings,
+			profileName: "profile-a",
+		});
+		settings.clearAgentModelOverride("critic");
+		await activateModelProfile({
+			session,
+			modelRegistry: fakeRegistry({ profiles }),
+			settings,
+			profileName: "profile-b",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-b/executor" });
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({});
+	});
+
+	test("materializing one role does not restore another profile role that the user cleared", async () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "profile-a",
+				requiredProviders: ["provider-a", "provider-b"],
+				modelMapping: {
+					architect: "provider-a/architect",
+					executor: "provider-b/executor",
+				},
+				source: "user",
+			},
+		];
+		const settings = Settings.isolated();
+		const session = fakeSession();
+		await activateModelProfile({
+			session,
+			modelRegistry: fakeRegistry({ profiles }),
+			settings,
+			profileName: "profile-a",
+		});
+
+		settings.clearAgentModelOverride("architect");
+		materializeActiveModelProfileAssignment({
+			session,
+			settings,
+			role: "executor",
+			selector: "provider-c/executor:low",
+		});
+		settings.clearOverride("task.agentModelOverrides");
+
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			executor: "provider-c/executor:low",
+		});
+	});
+
+	test("failed persisted profile switch detaches to baseline and retries without omitted roles", async () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "profile-a",
+				requiredProviders: ["provider-a"],
+				modelMapping: { architect: "provider-a/architect" },
+				source: "user",
+			},
+			{
+				name: "profile-b",
+				requiredProviders: ["provider-b"],
+				modelMapping: { executor: "provider-b/executor" },
+				source: "user",
+			},
+		];
+		const registry = fakeRegistry({ profiles });
+		const settings = Settings.isolated();
+		const session = fakeSession();
+		await activateModelProfile(
+			{ session, modelRegistry: registry, settings, profileName: "profile-a" },
+			{ persistDefault: true },
+		);
+		const durableFlush = settings.flushOrThrow.bind(settings);
+		let failOnce = true;
+		settings.flushOrThrow = async () => {
+			if (failOnce) {
+				failOnce = false;
+				throw new Error("flush failed");
+			}
+			await durableFlush();
+		};
+
+		await expect(
+			activateModelProfile(
+				{ session, modelRegistry: registry, settings, profileName: "profile-b" },
+				{ persistDefault: true },
+			),
+		).rejects.toThrow("flush failed");
+		expect(session.getActiveModelProfile()).toBeUndefined();
+		expect(settings.get("task.agentModelOverrides")).toEqual({});
+
+		await activateModelProfile(
+			{ session, modelRegistry: registry, settings, profileName: "profile-b" },
+			{ persistDefault: true },
+		);
+		expect(session.getActiveModelProfile()).toBe("profile-b");
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-b/executor" });
+		expect(settings.get("task.agentModelOverrides").architect).toBeUndefined();
+	});
+
+	test("role-only switching preserves the pre-profile resume default and configured effort", async () => {
+		const transientModel = model("provider-c", "default");
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "profile-a",
+				requiredProviders: ["provider-a"],
+				modelMapping: { default: "provider-a/default:high" },
+				source: "user",
+			},
+			{
+				name: "role-only-b",
+				requiredProviders: ["provider-b"],
+				modelMapping: { executor: "provider-b/executor:low" },
+				source: "user",
+			},
+		];
+		const settings = Settings.isolated();
+		settings.set("defaultThinkingLevel", ThinkingLevel.Medium);
+		const session = fakeSession(transientModel, "provider-a/resume");
+		session.thinkingLevel = ThinkingLevel.XHigh;
+		const registry = fakeRegistry({ profiles });
+
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "profile-a" });
+		await activateModelProfile(
+			{ session, modelRegistry: registry, settings, profileName: "role-only-b" },
+			{ persistDefault: true },
+		);
+
+		expect(session.model).toBe(transientModel);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.XHigh);
+		expect(session.getSessionDefaultModelSelector()).toBe("provider-a/resume");
+		expect(settings.getGlobal("defaultThinkingLevel")).toBe(ThinkingLevel.Medium);
+	});
+
+	test("--default persists the profile while retaining inherited role defaults", async () => {
 		const session = fakeSession();
 		const settings = Settings.isolated();
+		settings.set("modelRoles", { default: "configured/default" });
+		settings.set("task.agentModelOverrides", { critic: "configured/critic" });
 		const setCalls: string[] = [];
 		const originalSet = settings.set.bind(settings);
 		settings.set = ((path: never, value: never) => {
@@ -311,7 +1015,7 @@ describe("model profile activation", () => {
 			return originalSet(path, value);
 		}) as typeof settings.set;
 		let flushCount = 0;
-		settings.flush = async () => {
+		settings.flushOrThrow = async () => {
 			flushCount += 1;
 		};
 
@@ -320,16 +1024,136 @@ describe("model profile activation", () => {
 			{ persistDefault: true },
 		);
 
-		expect(setCalls).toEqual([
-			"modelRoles",
-			"task.agentModelOverrides",
-			"defaultThinkingLevel",
-			"modelProfile.default",
-		]);
+		expect(setCalls).toEqual(["defaultThinkingLevel", "modelProfile.default"]);
+		expect(settings.getGlobal("modelRoles")).toEqual({ default: "configured/default" });
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({ critic: "configured/critic" });
 		expect(settings.get("defaultThinkingLevel")).toBe(ThinkingLevel.High);
 		expect(settings.get("modelProfile.default")).toBe("profile-a");
 		expect(flushCount).toBe(1);
 		expect(session.getActiveModelProfile()).toBe("profile-a");
+	});
+
+	test("role-only profile effort remains consistent after durable restart", async () => {
+		const baselineModel = model("openai-codex", "gpt-5.6-sol", {
+			mode: "effort",
+			minLevel: ThinkingLevel.Low,
+			maxLevel: ThinkingLevel.Max,
+		});
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "profile-a",
+				requiredProviders: ["openai-codex"],
+				modelMapping: { default: "openai-codex/gpt-5.6-sol:xhigh" },
+				source: "user",
+			},
+			{
+				name: "role-only-b",
+				requiredProviders: ["openai-codex"],
+				modelMapping: { executor: "openai-codex/gpt-5.6-terra:low" },
+				source: "user",
+			},
+		];
+		const registry = fakeRegistry({ profiles });
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-role-only-profile-"));
+		try {
+			const session = fakeSession(baselineModel);
+			const settings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			settings.set("defaultThinkingLevel", ThinkingLevel.Low);
+			await settings.flushOrThrow();
+
+			await activateModelProfile(
+				{ session, modelRegistry: registry, settings, profileName: "profile-a" },
+				{ persistDefault: true },
+			);
+			expect(session.thinkingLevel).toBe(ThinkingLevel.XHigh);
+
+			await activateModelProfile(
+				{ session, modelRegistry: registry, settings, profileName: "role-only-b" },
+				{ persistDefault: true },
+			);
+			expect(session.model).toBe(baselineModel);
+			expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
+			expect(settings.getGlobal("defaultThinkingLevel")).toBe(ThinkingLevel.Low);
+			expect(settings.getGlobal("modelProfile.default")).toBe("role-only-b");
+
+			resetSettingsForTest();
+			const restartedSettings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const restartedProfile = restartedSettings.getGlobal("modelProfile.default");
+			if (!restartedProfile) throw new Error("Expected persisted model profile");
+			const restartedSession = fakeSession(baselineModel);
+			restartedSession.thinkingLevel = restartedSettings.get("defaultThinkingLevel");
+			await activateModelProfile(
+				{
+					session: restartedSession,
+					modelRegistry: registry,
+					settings: restartedSettings,
+					profileName: restartedProfile,
+				},
+				{ thinkingLevelOverride: restartedSettings.get("defaultThinkingLevel") },
+			);
+
+			expect(restartedProfile).toBe("role-only-b");
+			expect(restartedSettings.getGlobal("defaultThinkingLevel")).toBe(ThinkingLevel.Low);
+			expect(restartedSession.model).toBe(baselineModel);
+			expect(restartedSession.thinkingLevel).toBe(ThinkingLevel.Low);
+			expect(restartedSession.getActiveModelProfile()).toBe("role-only-b");
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("an effort-less profile switch applies the configured default after a non-reasoning session and survives restart", async () => {
+		const profiles: ModelProfileDefinition[] = [
+			{
+				name: "implicit-effort",
+				requiredProviders: ["openai-codex"],
+				modelMapping: { default: "openai-codex/gpt-5.6-sol" },
+				source: "user",
+			},
+		];
+		const registry = fakeRegistry({ profiles });
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-implicit-profile-effort-"));
+		try {
+			const session = fakeSession(model("provider-c", "non-reasoning"));
+			session.thinkingLevel = undefined;
+			const settings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			settings.set("defaultThinkingLevel", ThinkingLevel.High);
+			await settings.flushOrThrow();
+
+			await activateModelProfile(
+				{ session, modelRegistry: registry, settings, profileName: "implicit-effort" },
+				{ persistDefault: true },
+			);
+
+			expect(session.model?.id).toBe("gpt-5.6-sol");
+			expect(session.thinkingLevel as ThinkingLevel | undefined).toBe(ThinkingLevel.High);
+			expect(settings.getGlobal("defaultThinkingLevel")).toBe(ThinkingLevel.High);
+			expect(settings.getGlobal("modelProfile.default")).toBe("implicit-effort");
+
+			resetSettingsForTest();
+			const restartedSettings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const restartedProfile = restartedSettings.getGlobal("modelProfile.default");
+			if (!restartedProfile) throw new Error("Expected persisted model profile");
+			const restartedSession = fakeSession(model("provider-c", "non-reasoning"));
+			restartedSession.thinkingLevel = undefined;
+
+			await activateModelProfile(
+				{
+					session: restartedSession,
+					modelRegistry: registry,
+					settings: restartedSettings,
+					profileName: restartedProfile,
+				},
+				{ thinkingLevelOverride: restartedSettings.get("defaultThinkingLevel") },
+			);
+
+			expect(restartedSettings.getGlobal("defaultThinkingLevel")).toBe(ThinkingLevel.High);
+			expect(restartedSession.model?.id).toBe("gpt-5.6-sol");
+			expect(restartedSession.thinkingLevel as ThinkingLevel | undefined).toBe(ThinkingLevel.High);
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	test("missing credentials hard-block before mutation", async () => {
@@ -372,7 +1196,35 @@ describe("model profile activation", () => {
 		).rejects.toThrow('Unknown model profile "missing". Available profiles: alpha, beta');
 	});
 
-	test("apply rolls back runtime changes when persistence throws", async () => {
+	test("rolls back when setModelTemporary mutates before rejecting", async () => {
+		const initialModel = model("provider-c", "default");
+		const session = fakeSession(initialModel, "provider-c/resume");
+		session.thinkingLevel = ThinkingLevel.Low;
+		const originalSetModelTemporary = session.setModelTemporary.bind(session);
+		let rejectAfterMutation = true;
+		session.setModelTemporary = async (next, thinkingLevel, options) => {
+			await originalSetModelTemporary(next, thinkingLevel, options);
+			if (rejectAfterMutation) {
+				rejectAfterMutation = false;
+				throw new Error("prompt refresh failed");
+			}
+		};
+
+		await expect(
+			activateModelProfile({
+				session,
+				modelRegistry: fakeRegistry(),
+				settings: Settings.isolated(),
+				profileName: "profile-a",
+			}),
+		).rejects.toThrow("prompt refresh failed");
+
+		expect(session.model).toBe(initialModel);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
+		expect(session.getSessionDefaultModelSelector()).toBe("provider-c/resume");
+		expect(session.getActiveModelProfile()).toBeUndefined();
+	});
+	test("detaches an ambiguous persisted activation without stale compensation", async () => {
 		const session = fakeSession();
 		const settings = Settings.isolated({
 			"task.agentModelOverrides": { executor: "provider-a/original" },
@@ -384,7 +1236,7 @@ describe("model profile activation", () => {
 			settings,
 			profileName: "profile-a",
 		});
-		settings.flush = async () => {
+		settings.flushOrThrow = async () => {
 			throw new Error("flush failed");
 		};
 
@@ -395,8 +1247,8 @@ describe("model profile activation", () => {
 		expect(session.model?.id).toBe("initial");
 		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
 		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/original" });
-		expect(settings.get("modelProfile.default")).toBeUndefined();
-		expect(settings.get("defaultThinkingLevel")).toBe(ThinkingLevel.Low);
+		expect(settings.get("modelProfile.default")).toBe("profile-a");
+		expect(settings.getGlobal("defaultThinkingLevel")).toBe(ThinkingLevel.High);
 		expect(session.getActiveModelProfile()).toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/model-profile-legacy-alias.test.ts
+++ b/packages/coding-agent/test/model-profile-legacy-alias.test.ts
@@ -153,4 +153,29 @@ describe("legacy model profile aliases", () => {
 		expect(prepared.profileName).toBe("codex-standard");
 		expect(prepared.defaultThinkingLevel).toBe(ThinkingLevel.XHigh);
 	});
+
+	test("resolves an archived exact codex-standard before the retired-name alias", async () => {
+		const archivedCodexStandard: ModelProfileDefinition = {
+			name: "codex-standard",
+			requiredProviders: ["openai-codex"],
+			modelMapping: { default: "openai-codex/gpt-5.5:xhigh" },
+			source: "user",
+		};
+		const activeRegistry = fakeRegistry();
+		const archivedRegistry = {
+			...activeRegistry,
+			getModelProfileForReference: (name: string) =>
+				name === "codex-standard" ? archivedCodexStandard : activeRegistry.getModelProfile(name),
+		};
+
+		const prepared = await prepareModelProfileActivation({
+			session: fakeSession(),
+			modelRegistry: archivedRegistry,
+			settings: Settings.isolated(),
+			profileName: "codex-standard",
+		});
+
+		expect(prepared.profileName).toBe("codex-standard");
+		expect(prepared.defaultThinkingLevel).toBe(ThinkingLevel.XHigh);
+	});
 });

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -7,7 +7,7 @@ import { kNoAuth, MODEL_ROLE_IDS, ModelRegistry } from "@gajae-code/coding-agent
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { addApiCompatibleProvider } from "@gajae-code/coding-agent/setup/provider-onboarding";
-import { $credentialEnv, hookFetch, Snowflake } from "@gajae-code/utils";
+import { $credentialEnv, getProjectAgentDir, hookFetch, Snowflake } from "@gajae-code/utils";
 
 describe("model roles", () => {
 	test("default is the only built-in model role", () => {
@@ -2710,6 +2710,51 @@ describe("ModelRegistry", () => {
 		expect(Settings.instance.get("task.agentModelOverrides").executor).toBe("proxy/executor-selector");
 	});
 
+	test("configured bindings do not copy project-only siblings into runtime or global settings", async () => {
+		const projectDir = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		fs.mkdirSync(getProjectAgentDir(projectDir), { recursive: true });
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(getProjectAgentDir(projectDir), "config.yml"),
+			"modelRoles:\n  smol: project/smol\ntask:\n  agentModelOverrides:\n    planner: project/planner\n",
+		);
+		writeRawModelsConfig({
+			modelBindings: {
+				modelRoles: { default: "proxy/default-selector" },
+				agentModelOverrides: { executor: "proxy/executor-selector" },
+			},
+		});
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+		registry.applyConfiguredModelBindings(settings);
+		expect(settings.get("modelRoles")).toEqual({
+			default: "proxy/default-selector",
+			smol: "project/smol",
+		});
+		expect(settings.getRuntimeOverride("modelRoles")).toEqual({
+			default: "proxy/default-selector",
+		});
+		expect(settings.getWithoutProject("modelRoles")).toEqual({
+			default: "proxy/default-selector",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "proxy/executor-selector",
+			planner: "project/planner",
+		});
+		expect(settings.getRuntimeOverride("task.agentModelOverrides")).toEqual({
+			executor: "proxy/executor-selector",
+		});
+		expect(settings.getWithoutProject("task.agentModelOverrides")).toEqual({
+			executor: "proxy/executor-selector",
+		});
+
+		settings.setAgentModelOverride("architect", "user/architect");
+		await settings.flushOrThrow();
+		expect(await Bun.file(path.join(agentDir, "config.yml")).text()).not.toContain("project/planner");
+	});
 	test("defers model bindings until settings are initialized", () => {
 		writeRawModelsConfig({
 			modelBindings: {

--- a/packages/coding-agent/test/model-selector-controller-batch.test.ts
+++ b/packages/coding-agent/test/model-selector-controller-batch.test.ts
@@ -1,25 +1,46 @@
 import { beforeAll, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
-import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import type { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
 import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
 
 let testTheme = await getThemeByName("red-claw");
+function normalizeRenderedText(text: string): string {
+	return text
+		.replace(/\x1b\[[0-9;]*m/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+}
 
 function installTestTheme(): void {
 	if (!testTheme) throw new Error("Failed to load test theme");
 	setThemeInstance(testTheme);
 }
 
-const model = (provider: string, id: string): Model =>
-	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
+const model = (provider: string, id: string, thinking?: Model["thinking"]): Model =>
+	({
+		provider,
+		id,
+		name: id,
+		api: "openai-responses",
+		contextWindow: 1000,
+		maxTokens: 1000,
+		thinking,
+		reasoning: thinking !== undefined,
+	}) as Model;
+const selectedModel = model("provider-a", "selected", {
+	mode: "effort",
+	minLevel: ThinkingLevel.Low,
+	maxLevel: ThinkingLevel.High,
+});
+const nonReasoningModel = model("provider-a", "plain");
 
-const selectedModel = model("provider-a", "selected");
-
-function createControllerContext() {
-	const settings = Settings.isolated();
+function createControllerContext(settings = Settings.isolated()) {
 	settings.set("modelRoles", { default: "provider-a/original-default:medium" });
 	settings.set("task.agentModelOverrides", { executor: "provider-a/original-executor:low" });
 	settings.set("modelProfile.default", undefined);
@@ -28,15 +49,19 @@ function createControllerContext() {
 		role: string;
 		options?: { selector?: string; thinkingLevel?: ThinkingLevel };
 	}> = [];
+	let activeModelProfile: string | undefined;
+	let resumeDefaultModelSelector: string | undefined;
+	let pendingSettingsModel: Model | undefined;
+	let pendingSettingsThinkingLevel: ThinkingLevel | undefined;
 	const session = {
 		model: model("provider-a", "current") as Model | undefined,
 		thinkingLevel: ThinkingLevel.Medium as ThinkingLevel | undefined,
 		sessionId: "session-1",
 		scopedModels: [],
 		modelRegistry: {
-			getAvailable: () => [selectedModel],
+			getAvailable: () => [selectedModel, nonReasoningModel],
 			refresh: vi.fn(async () => {}),
-			getAll: () => [selectedModel],
+			getAll: () => [selectedModel, nonReasoningModel],
 			getError: () => undefined,
 			getCanonicalModels: () => [],
 			getDiscoverableProviders: () => [],
@@ -49,12 +74,42 @@ function createControllerContext() {
 			setModelCalls.push({ model: nextModel, role, options });
 			this.model = nextModel;
 			if (options?.thinkingLevel) this.thinkingLevel = options.thinkingLevel;
+			const selector = options?.selector ?? `${nextModel.provider}/${nextModel.id}`;
+			settings.setModelRole(
+				role,
+				options?.thinkingLevel && options.thinkingLevel !== ThinkingLevel.Inherit
+					? `${selector}:${options.thinkingLevel}`
+					: selector,
+			);
+			if (role === "default") resumeDefaultModelSelector = `${nextModel.provider}/${nextModel.id}`;
+		},
+		async setModelForSettingsCommit(nextModel: Model, thinkingLevel?: ThinkingLevel) {
+			setModelCalls.push({ model: nextModel, role: "default", options: { thinkingLevel } });
+			pendingSettingsModel = nextModel;
+			pendingSettingsThinkingLevel = thinkingLevel;
+		},
+		async commitSettingsModelChange(nextModel: Model) {
+			if (pendingSettingsModel === nextModel) {
+				this.model = nextModel;
+				this.thinkingLevel = pendingSettingsThinkingLevel;
+				resumeDefaultModelSelector = `${nextModel.provider}/${nextModel.id}`;
+				pendingSettingsModel = undefined;
+				pendingSettingsThinkingLevel = undefined;
+			}
+		},
+		cancelSettingsModelChange() {
+			pendingSettingsModel = undefined;
+			pendingSettingsThinkingLevel = undefined;
 		},
 		async setModelTemporary() {},
 		setThinkingLevel(thinkingLevel: ThinkingLevel) {
 			this.thinkingLevel = thinkingLevel;
 		},
-		getActiveModelProfile: () => undefined,
+		getActiveModelProfile: () => activeModelProfile,
+		setActiveModelProfile: (profileName: string | undefined) => {
+			activeModelProfile = profileName;
+		},
+		getSessionDefaultModelSelector: () => resumeDefaultModelSelector,
 		isFastForProvider: () => false,
 		isFastForSubagentProvider: () => false,
 		isFastModeActive: () => false,
@@ -107,6 +162,7 @@ describe("SelectorController model batch assignments", () => {
 		expect(ctx.showStatus).toHaveBeenCalledWith(
 			"Role-agent models set to provider-a/selected:low for EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
 		);
+		expect(ctx.notifyConfigChanged).toHaveBeenCalledTimes(1);
 	});
 
 	test("all targets selection writes DEFAULT plus every role-agent override", async () => {
@@ -125,7 +181,7 @@ describe("SelectorController model batch assignments", () => {
 			{
 				model: selectedModel,
 				role: "default",
-				options: { selector: "provider-a/selected", thinkingLevel: ThinkingLevel.High },
+				options: { thinkingLevel: ThinkingLevel.High },
 			},
 		]);
 		expect(settings.getModelRole("default")).toBe("provider-a/selected:high");
@@ -138,5 +194,243 @@ describe("SelectorController model batch assignments", () => {
 		expect(ctx.showStatus).toHaveBeenCalledWith(
 			"All model targets set to provider-a/selected:high for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
 		);
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("DEFAULT (high)");
+		expect(rendered).toContain("EXECUTOR (high)");
+		expect(rendered).toContain("ARCHITECT (high)");
+		expect(rendered).toContain("PLANNER (high)");
+		expect(rendered).toContain("CRITIC (high)");
+		expect(ctx.notifyConfigChanged).toHaveBeenCalledTimes(1);
+	});
+	test("reports post-commit session failure without rolling back selector settings", async () => {
+		const { ctx, settings, session } = createControllerContext();
+		session.commitSettingsModelChange = async () => {
+			throw new Error("forced session history failure");
+		};
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			roles: ["default", "executor"],
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(settings.getModelRole("default")).toBe("provider-a/selected:high");
+		expect(settings.get("task.agentModelOverrides").executor).toBe("provider-a/selected:high");
+		expect(ctx.showError).toHaveBeenCalledWith(
+			"Model settings were committed, but a session follow-up failed: forced session history failure",
+		);
+	});
+	test("preserves committed diagnostic when selector refresh also fails", async () => {
+		const { ctx, settings } = createControllerContext();
+		const selector = await openSelector(ctx);
+		const refreshSpy = vi.spyOn(selector, "refreshRoleAssignments").mockImplementation(() => {
+			throw new Error("forced selector refresh failure");
+		});
+		try {
+			await selector.__testSelectAssignment({
+				model: selectedModel,
+				role: "default",
+				roles: ["default", "executor"],
+				thinkingLevel: ThinkingLevel.High,
+				selector: "provider-a/selected:high",
+			});
+		} finally {
+			refreshSpy.mockRestore();
+		}
+
+		expect(settings.getModelRole("default")).toBe("provider-a/selected:high");
+		expect(ctx.showError).toHaveBeenCalledWith(
+			"Model settings were committed, but a session follow-up failed: forced selector refresh failure",
+		);
+	});
+
+	test("all targets replace live role overrides with the selected model's clamped effort", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.override("task.agentModelOverrides", {
+			executor: "provider-a/profile-executor:medium",
+			architect: "provider-a/profile-architect:high",
+			planner: "provider-a/profile-planner:medium",
+			critic: "provider-a/profile-critic:high",
+		});
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			roles: ["default", "executor", "architect", "planner", "critic"],
+			thinkingLevel: ThinkingLevel.XHigh,
+			selector: "provider-a/selected:xhigh",
+		});
+
+		const expectedRoleOverrides = {
+			executor: "provider-a/selected:high",
+			architect: "provider-a/selected:high",
+			planner: "provider-a/selected:high",
+			critic: "provider-a/selected:high",
+		};
+		expect(settings.get("task.agentModelOverrides")).toEqual(expectedRoleOverrides);
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual(expectedRoleOverrides);
+	});
+
+	test("single role assignments clamp stale effort for a non-reasoning model", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.setAgentModelOverride("executor", "provider-a/selected:high");
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: nonReasoningModel,
+			role: "executor",
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/plain:high",
+		});
+
+		expect(settings.get("task.agentModelOverrides").executor).toBe("provider-a/plain");
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.getGlobal("task.agentModelOverrides")).toMatchObject({
+			executor: "provider-a/plain",
+		});
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("EXECUTOR (inherit)");
+		expect(rendered).not.toContain("EXECUTOR (high)");
+	});
+	test("single role status reports project settings that resume on restart", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.getProject = ((path: string) =>
+			path === "task.agentModelOverrides"
+				? { executor: "project/executor" }
+				: undefined) as typeof settings.getProject;
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "executor",
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(ctx.showStatus).toHaveBeenCalledWith(
+			"executor agent model: provider-a/selected:high Project settings for EXECUTOR resume on restart.",
+		);
+	});
+	test("single DEFAULT selection notifies configuration observers", async () => {
+		const { ctx } = createControllerContext();
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected",
+		});
+
+		expect(ctx.notifyConfigChanged).toHaveBeenCalledTimes(1);
+	});
+	test("DEFAULT inherit persists without a suffix while applying the clamped configured effort live", async () => {
+		const { ctx, settings, session, setModelCalls } = createControllerContext();
+		settings.set("defaultThinkingLevel", ThinkingLevel.High);
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			thinkingLevel: ThinkingLevel.Inherit,
+			selector: "provider-a/selected",
+		});
+
+		expect(setModelCalls).toEqual([
+			{
+				model: selectedModel,
+				role: "default",
+				options: { thinkingLevel: ThinkingLevel.High },
+			},
+		]);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.High);
+		expect(settings.getModelRole("default")).toBe("provider-a/selected");
+		expect(ctx.showStatus).toHaveBeenCalledWith(
+			"Default model: provider-a/selected (effective: provider-a/selected:high)",
+		);
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("DEFAULT (high)");
+		expect(rendered).not.toContain("DEFAULT (inherit)");
+	});
+
+	test("nonsettling configuration notifications do not block selector completion", async () => {
+		const { ctx, setModelCalls } = createControllerContext();
+		const never = Promise.withResolvers<void>();
+		ctx.notifyConfigChanged = vi.fn(() => never.promise);
+		const selector = await openSelector(ctx);
+
+		const completed = await Promise.race([
+			selector.__testSelectAssignment({
+				model: selectedModel,
+				role: "default",
+				thinkingLevel: ThinkingLevel.High,
+				selector: "provider-a/selected:high",
+			}),
+			Bun.sleep(100).then(() => "timeout" as const),
+		]);
+
+		expect(completed).not.toBe("timeout");
+		expect(setModelCalls).toEqual([
+			{
+				model: selectedModel,
+				role: "default",
+				options: { thinkingLevel: ThinkingLevel.High },
+			},
+		]);
+	});
+
+	test("does not report a persisted role assignment when the config write fails", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-selector-durable-model-"));
+		resetSettingsForTest();
+		try {
+			const settings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const { ctx } = createControllerContext(settings);
+			await settings.flushOrThrow();
+			const selector = await openSelector(ctx);
+			ctx.session.setActiveModelProfile("profile-a");
+			const configPath = path.join(fs.realpathSync.native(tempDir), "config.yml");
+			const originalWrite = Bun.write;
+			const writeSpy = vi.spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (
+					typeof args[0] === "string" &&
+					args[0].startsWith(`${configPath}.`) &&
+					args[0].endsWith(".tmp") &&
+					!args[0].startsWith(`${configPath}.revisions.json.`)
+				) {
+					throw new Error("forced config write failure");
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+			try {
+				await selector.__testSelectAssignment({
+					model: selectedModel,
+					role: "executor",
+					thinkingLevel: ThinkingLevel.Low,
+					selector: "provider-a/selected:low",
+				});
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			expect(ctx.showStatus).not.toHaveBeenCalled();
+			expect(ctx.notifyConfigChanged).not.toHaveBeenCalled();
+			expect(ctx.showError).toHaveBeenCalledWith("forced config write failure");
+			expect(settings.get("task.agentModelOverrides").executor).toBe("provider-a/original-executor:low");
+			await settings.flushOrThrow();
+			expect(ctx.session.getActiveModelProfile()).toBe("profile-a");
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			expect(reopened.get("task.agentModelOverrides").executor).toBe("provider-a/original-executor:low");
+		} finally {
+			resetSettingsForTest();
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -87,7 +87,7 @@ function createControllerContext(options: { missingCredentials?: boolean } = {})
 		"modelProfile.default": "old-profile",
 	});
 	const flush = vi.fn(async () => {});
-	settings.flush = flush as typeof settings.flush;
+	settings.flushOrThrow = flush as typeof settings.flushOrThrow;
 	const setCalls: Array<{ path: string; value: unknown }> = [];
 	const originalSet = settings.set.bind(settings);
 	settings.set = ((path: never, value: never) => {
@@ -199,6 +199,24 @@ describe("model selector profile red-team", () => {
 		]);
 	});
 
+	test("async model selections ignore overlapping dispatches until the first settles", async () => {
+		const selections: ModelSelectorSelection[] = [];
+		const { promise: pendingSelection, resolve: releaseSelection } = Promise.withResolvers<void>();
+		const selector = createSelector(async selection => {
+			selections.push(selection);
+			await pendingSelection;
+		});
+		await renderSelector(selector);
+
+		const first = selector.__testSelectProfile("profile-a", false);
+		const overlapping = selector.__testSelectPresetAction("profile-a", "delete");
+
+		expect(selections).toEqual([{ kind: "profile", profileName: "profile-a", setDefault: false }]);
+		releaseSelection();
+		await Promise.all([first, overlapping]);
+		expect(selections).toHaveLength(1);
+	});
+
 	test("controller persists only Set as default and leaves Apply for this session non-default", async () => {
 		const sessionOnly = createControllerContext();
 		await selectProfileThroughController(new SelectorController(sessionOnly.ctx as never), false);
@@ -278,7 +296,7 @@ describe("model selector profile red-team", () => {
 	});
 });
 
-test("delete action restores the profile when post-delete notification fails", async () => {
+test("delete action remains committed when post-delete notification fails", async () => {
 	const profiles = new Map<string, ModelProfileDefinition>([[userProfile.name, { ...userProfile }]]);
 	const deletedConfigs: Record<string, { required_providers: string[]; model_mapping: Record<string, string> }> = {};
 	const registry = {
@@ -310,7 +328,7 @@ test("delete action restores the profile when post-delete notification fails", a
 		),
 		refresh: vi.fn(async () => {}),
 	};
-	const settings = Settings.isolated({ "modelProfile.default": "unrelated" });
+	const settings = Settings.isolated({ "modelProfile.default": "profile-a" });
 	const ctx = {
 		ui: { setFocus: vi.fn(), requestRender: vi.fn() },
 		editorContainer: { clear: vi.fn(), addChild: vi.fn() },
@@ -322,7 +340,6 @@ test("delete action restores the profile when post-delete notification fails", a
 			sessionId: "session-1",
 			scopedModels: [],
 			modelRegistry: registry,
-			getActiveModelProfile: () => undefined,
 			isFastForProvider: () => false,
 			isFastForSubagentProvider: () => false,
 			isFastModeActive: () => false,
@@ -343,7 +360,14 @@ test("delete action restores the profile when post-delete notification fails", a
 	await selector.__testSelectPresetAction("profile-a", "delete");
 
 	expect(registry.deleteCustomModelProfile).toHaveBeenCalledWith("profile-a");
-	expect(registry.saveCustomModelProfile).toHaveBeenCalledWith("profile-a", deletedConfigs["profile-a"]);
-	expect(profiles.has("profile-a")).toBe(true);
-	expect(ctx.showError).toHaveBeenCalledWith("Preset delete failed: notify failed");
+	expect(registry.saveCustomModelProfile).not.toHaveBeenCalled();
+	expect(profiles.has("profile-a")).toBe(false);
+	expect(ctx.showStatus).toHaveBeenCalledWith("Custom model preset deleted: Profile Alpha");
+	expect(ctx.showError).toHaveBeenCalledWith(
+		"Configuration was updated, but change notification failed: notify failed",
+	);
+	expect(settings.get("modelProfile.default")).toBeUndefined();
+	expect(settings.getRuntimeOverride("modelProfile.default")).toBeUndefined();
+	expect(settings.get("modelRoles")).toEqual({ default: "provider-a/default:high" });
+	expect(settings.get("task.agentModelOverrides")).toEqual({ executor: "provider-a/alternate" });
 });

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -95,7 +95,7 @@ function createControllerContext(options: { missingCredentials?: boolean } = {})
 		"modelProfile.default": "old-profile",
 	});
 	const flush = vi.fn(async () => {});
-	settings.flush = flush as typeof settings.flush;
+	settings.flushOrThrow = flush as typeof settings.flushOrThrow;
 	const setCalls: Array<{ path: string; value: unknown }> = [];
 	const originalSet = settings.set.bind(settings);
 	settings.set = ((path: never, value: never) => {
@@ -125,6 +125,7 @@ function createControllerContext(options: { missingCredentials?: boolean } = {})
 		updateEditorBorderColor: vi.fn(),
 		showStatus: vi.fn(),
 		showError: vi.fn(),
+		notifyConfigChanged: vi.fn(async () => {}),
 	};
 	return { ctx, settings, session, flush, setCalls };
 }
@@ -325,6 +326,7 @@ describe("model selector profiles", () => {
 		expect(settings.get("task.agentModelOverrides")).toMatchObject({ executor: "provider-a/alternate" });
 		expect(settings.get("modelProfile.default")).toBe("old-profile");
 		expect(ctx.showStatus).toHaveBeenCalledWith("Model profile: Profile Alpha");
+		expect(ctx.notifyConfigChanged).toHaveBeenCalledTimes(1);
 	});
 
 	test("Set as default persists and flushes modelProfile.default", async () => {
@@ -336,6 +338,7 @@ describe("model selector profiles", () => {
 		expect(setCalls).toContainEqual({ path: "modelProfile.default", value: "profile-a" });
 		expect(setCalls).toContainEqual({ path: "defaultThinkingLevel", value: ThinkingLevel.High });
 		expect(flush).toHaveBeenCalledTimes(1);
+		expect(ctx.notifyConfigChanged).toHaveBeenCalledTimes(1);
 		expect(ctx.showStatus).toHaveBeenCalledWith("Default model profile: Profile Alpha");
 	});
 
@@ -358,8 +361,7 @@ describe("model selector profiles", () => {
 		const { ctx, session, flush, setCalls } = createControllerContext();
 		const controller = new SelectorController(ctx as never);
 
-		controller.handleSettingChange("modelProfile.default", "profile-a");
-		await Bun.sleep(10);
+		await controller.handleSettingChange("modelProfile.default", "profile-a");
 
 		expect(session.setModelTemporaryCalls).toHaveLength(1);
 		expect(session.model?.id).toBe("default");
@@ -373,8 +375,9 @@ describe("model selector profiles", () => {
 		const { ctx, settings, session } = createControllerContext({ missingCredentials: true });
 		const controller = new SelectorController(ctx as never);
 
-		controller.handleSettingChange("modelProfile.default", "profile-a");
-		await Bun.sleep(10);
+		await expect(
+			controller.handleSettingChange("modelProfile.default", "profile-a") as Promise<void>,
+		).rejects.toThrow("requires credentials for: provider-a");
 
 		expect(ctx.showError).toHaveBeenCalledWith(
 			'Model profile "Profile Alpha" requires credentials for: provider-a. Run /login and configure the missing provider(s), then retry.',

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -504,6 +504,7 @@ describe("ModelSelector canonical model selection", () => {
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 
 		const selectedAfterThinking = selected;
@@ -514,6 +515,33 @@ describe("ModelSelector canonical model selection", () => {
 		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}`);
 	});
 
+	test("can explicitly choose inherit for OpenAI reasoning default models", async () => {
+		installTestTheme();
+		const model = createOpenAIModel("openai", "gpt-reasoning-inherit-test");
+		const settings = Settings.isolated({});
+
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(
+			model,
+			settings,
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
+			},
+			{ thinkingLevel: null },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+
+		const selectedAfterThinking = selected;
+		if (!selectedAfterThinking) throw new Error("Expected OpenAI selection after inherit choice");
+		expect(selectedAfterThinking.role).toBe("default");
+		expect(selectedAfterThinking.thinkingLevel).toBe(ThinkingLevel.Inherit);
+		expect(selectedAfterThinking.selector).toBe(`${model.provider}/${model.id}`);
+	});
 	test("can explicitly choose off for OpenAI reasoning default models", async () => {
 		installTestTheme();
 		const model = createOpenAIModel("openai", "gpt-reasoning-off-test");
@@ -533,6 +561,7 @@ describe("ModelSelector canonical model selection", () => {
 
 		selector.handleInput("\n");
 		selector.handleInput("\n");
+		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 
 		const selectedAfterThinking = selected;
@@ -567,6 +596,7 @@ describe("ModelSelector canonical model selection", () => {
 		const thinkingRendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(thinkingRendered).toContain("Reasoning for Executor");
 
+		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");

--- a/packages/coding-agent/test/modes/components/settings-selector-model-profile.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-model-profile.test.ts
@@ -18,11 +18,16 @@ afterEach(() => {
 
 type ChangedSetting = { path: string; value: unknown };
 
-function createSelector(availableModelProfiles: string[]): {
+function createSelector(
+	availableModelProfiles: string[],
+	onChange?: (path: string, value: unknown) => void | Promise<void>,
+): {
 	component: SettingsSelectorComponent;
 	changedSettings: ChangedSetting[];
+	cancelled: { count: number };
 } {
 	const changedSettings: ChangedSetting[] = [];
+	const cancelled = { count: 0 };
 	const component = new SettingsSelectorComponent(
 		{
 			availableThinkingLevels: [],
@@ -32,11 +37,16 @@ function createSelector(availableModelProfiles: string[]): {
 			cwd: process.cwd(),
 		},
 		{
-			onChange: (path, value) => changedSettings.push({ path, value }),
-			onCancel: () => {},
+			onChange: (path, value) => {
+				changedSettings.push({ path, value });
+				return onChange?.(path, value);
+			},
+			onCancel: () => {
+				cancelled.count++;
+			},
 		},
 	);
-	return { component, changedSettings };
+	return { component, changedSettings, cancelled };
 }
 
 /** SETTING_TABS puts model at index 1 (after appearance); Default Model Profile is its first row. */
@@ -59,7 +69,7 @@ describe("SettingsSelectorComponent Default Model Profile", () => {
 		expect(opened).not.toContain("No matching commands");
 	});
 
-	it("persists the chosen profile to modelProfile.default on confirmation", () => {
+	it("delegates profile persistence to activation on confirmation", () => {
 		settings.set("modelProfile.default", "orchestra");
 		const { component, changedSettings } = createSelector(["orchestra", "balanced"]);
 		focusModelTab(component);
@@ -68,8 +78,87 @@ describe("SettingsSelectorComponent Default Model Profile", () => {
 		component.handleInput("\x1b[B"); // Move to "balanced".
 		component.handleInput("\n"); // Confirm.
 
-		expect(settings.get("modelProfile.default")).toBe("balanced");
+		expect(settings.get("modelProfile.default")).toBe("orchestra");
 		expect(changedSettings).toContainEqual({ path: "modelProfile.default", value: "balanced" });
+	});
+
+	it("waits for activation and blocks overlapping profile selections", async () => {
+		settings.set("modelProfile.default", "orchestra");
+		const { promise: activation, resolve: releaseActivation } = Promise.withResolvers<void>();
+		const applied: ChangedSetting[] = [];
+		const { component } = createSelector(["orchestra", "balanced"], async (path, value) => {
+			applied.push({ path, value });
+			await activation;
+			settings.set("modelProfile.default", value as string);
+		});
+		focusModelTab(component);
+
+		component.handleInput("\n");
+		component.handleInput("\x1b[B");
+		component.handleInput("\n");
+		component.handleInput("\x1b[A");
+		component.handleInput("\n");
+
+		expect(applied).toEqual([{ path: "modelProfile.default", value: "balanced" }]);
+		expect(settings.get("modelProfile.default")).toBe("orchestra");
+		expect(component.render(120).join("\n")).toContain("orchestra");
+
+		releaseActivation();
+		await Bun.sleep(0);
+
+		expect(settings.get("modelProfile.default")).toBe("balanced");
+		expect(applied).toHaveLength(1);
+	});
+
+	it("blocks tab reconstruction while profile activation is pending and allows Escape cancellation", async () => {
+		settings.set("modelProfile.default", "orchestra");
+		const activation = Promise.withResolvers<void>();
+		const applied: ChangedSetting[] = [];
+		const { component, cancelled } = createSelector(["orchestra", "balanced"], async (path, value) => {
+			applied.push({ path, value });
+			await activation.promise;
+		});
+		focusModelTab(component);
+		component.handleInput("\n");
+		component.handleInput("\x1b[B");
+		component.handleInput("\n");
+
+		component.handleInput("\x1b[C");
+		component.handleInput("\t");
+		component.handleInput("\n");
+		expect(applied).toEqual([{ path: "modelProfile.default", value: "balanced" }]);
+
+		component.handleInput("\x1b");
+		expect(cancelled.count).toBe(1);
+		activation.resolve();
+		await Bun.sleep(0);
+		expect(applied).toHaveLength(1);
+	});
+
+	it("allows one successful retry after profile activation rejects", async () => {
+		settings.set("modelProfile.default", "orchestra");
+		let attempts = 0;
+		const { component } = createSelector(["orchestra", "balanced"], async (_path, value) => {
+			attempts++;
+			if (attempts === 1) throw new Error("activation failed");
+			settings.set("modelProfile.default", value as string);
+		});
+		focusModelTab(component);
+
+		component.handleInput("\n");
+		component.handleInput("\x1b[B");
+		component.handleInput("\n");
+		await Bun.sleep(0);
+
+		expect(settings.get("modelProfile.default")).toBe("orchestra");
+		const rendered = component.render(120).join("\n");
+		expect(rendered).toContain("orchestra");
+		expect(rendered).toContain("balanced");
+
+		component.handleInput("\n");
+		await Bun.sleep(0);
+		expect(attempts).toBe(2);
+		expect(settings.get("modelProfile.default")).toBe("balanced");
 	});
 
 	it("falls back to the empty-state message when no profiles are registered", () => {

--- a/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
@@ -44,7 +44,9 @@ function createSelector(options: SelectorOptions = {}) {
 			cwd: process.cwd(),
 		},
 		{
-			onChange: (path, value) => changedSettings.push({ path, value }),
+			onChange: (path, value) => {
+				changedSettings.push({ path, value });
+			},
 			onStatusLinePreview: preview => {
 				previews.push(preview);
 				options.onStatusLinePreview?.(preview);

--- a/packages/coding-agent/test/modes/components/thinking-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/thinking-selector.test.ts
@@ -141,7 +141,7 @@ describe("SelectorController effort selector", () => {
 		expect(ctx.ui.setFocus).toHaveBeenLastCalledWith(ctx.editor);
 	});
 
-	it("can persist the selected effort as the default", () => {
+	it("can persist the selected effort as the default", async () => {
 		const editorContainer = {
 			children: [] as unknown[],
 			clear() {
@@ -190,6 +190,7 @@ describe("SelectorController effort selector", () => {
 		selector.handleInput("\n");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
+		await Bun.sleep(0);
 
 		expect(thinkingLevelCalls).toEqual([{ level: ThinkingLevel.Low, persist: true }]);
 		expect(notifyConfigChanged).toHaveBeenCalled();

--- a/packages/coding-agent/test/session-manager-close-race.test.ts
+++ b/packages/coding-agent/test/session-manager-close-race.test.ts
@@ -203,15 +203,15 @@ describe("SessionManager close/appendMessage race", () => {
 		}
 		expect(storage.hasPendingClose()).toBe(true);
 
-		// Synchronous append in the yield window — must not record a
-		// persistError. Pre-fix this stashes Error("Writer closed").
+		// Synchronous append in the yield window is rejected before resident
+		// state or the closing writer can be touched.
 		expect(() => {
 			sm.appendMessage({
 				role: "user",
 				content: "during-close",
 				timestamp: Date.now(),
 			});
-		}).not.toThrow();
+		}).toThrow("Session manager close is in progress");
 
 		// Drain everything.
 		await settle(closePromise, storage);

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -3,11 +3,14 @@ import {
 	type BranchSummaryEntry,
 	buildSessionContext,
 	type CompactionEntry,
+	hasPersistedThinkingLevel,
 	type ModelChangeEntry,
 	type SessionEntry,
+	SessionManager,
 	type SessionMessageEntry,
 	type ThinkingLevelChangeEntry,
 } from "@gajae-code/coding-agent/session/session-manager";
+import { MemorySessionStorage, type SessionStorageWriter } from "@gajae-code/coding-agent/session/session-storage";
 
 function msg(id: string, parentId: string | null, role: "user" | "assistant", text: string): SessionMessageEntry {
 	const base = { type: "message" as const, id, parentId, timestamp: "2025-01-01T00:00:00Z" };
@@ -58,6 +61,31 @@ function thinkingLevel(id: string, parentId: string | null, level: string): Thin
 
 function modelChange(id: string, parentId: string | null, provider: string, modelId: string): ModelChangeEntry {
 	return { type: "model_change", id, parentId, timestamp: "2025-01-01T00:00:00Z", model: `${provider}/${modelId}` };
+}
+
+class FailingAppendStorage extends MemorySessionStorage {
+	failWrites = false;
+
+	override openWriter(
+		path: string,
+		options?: { flags?: "a" | "w"; onError?: (err: Error) => void },
+	): SessionStorageWriter {
+		const writer = super.openWriter(path, options);
+		return {
+			writeLine: async line => {
+				if (this.failWrites) throw new Error("forced session write failure");
+				await writer.writeLine(line);
+			},
+			writeLineSync: line => {
+				if (this.failWrites) throw new Error("forced session write failure");
+				writer.writeLineSync(line);
+			},
+			flush: () => writer.flush(),
+			fsync: () => writer.fsync(),
+			close: () => writer.close(),
+			getError: () => writer.getError(),
+		};
+	}
 }
 
 describe("buildSessionContext", () => {
@@ -156,6 +184,51 @@ describe("buildSessionContext", () => {
 			// different model id. Temporary fallbacks and provider-side
 			// downgrades both produce such mismatched messages.
 			expect(ctx.models.default).toBe("openai/gpt-4");
+		});
+	});
+
+	describe("atomic model history", () => {
+		it("applies model and thinking level from one model change entry", () => {
+			const entry = modelChange("1", null, "anthropic", "claude") as ModelChangeEntry;
+			entry.thinkingLevel = "high";
+
+			const context = buildSessionContext([entry]);
+
+			expect(context.models.default).toBe("anthropic/claude");
+			expect(context.thinkingLevel).toBe("high");
+			expect(hasPersistedThinkingLevel([entry])).toBe(true);
+			expect(hasPersistedThinkingLevel([{ ...entry, role: "temporary" }])).toBe(false);
+		});
+
+		it("rolls back resident history and poisons later appends after writer failure", async () => {
+			const storage = new FailingAppendStorage();
+			const manager = SessionManager.create("/project", "/sessions", storage);
+			await manager.ensureOnDisk();
+			const entriesBefore = manager.getEntries();
+			storage.failWrites = true;
+
+			expect(() => manager.appendModelChange("anthropic/claude", "default", { thinkingLevel: "high" })).toThrow(
+				"forced session write failure",
+			);
+			expect(manager.getEntries()).toEqual(entriesBefore);
+			expect(manager.buildSessionContext().models.default).toBeUndefined();
+			expect(() => manager.appendModelChange("anthropic/other", "default")).toThrow("forced session write failure");
+		});
+
+		it("rejects appends synchronously once close starts", async () => {
+			const manager = SessionManager.inMemory();
+			const largeContent = "x".repeat(4096);
+			manager.appendMessage({ role: "user", content: largeContent, timestamp: Date.now() });
+			const closePromise = manager.close();
+
+			expect(() => manager.appendModelChange("anthropic/claude", "default", { thinkingLevel: "high" })).toThrow(
+				"Session manager close is in progress",
+			);
+			await closePromise;
+			const restoredMessage = manager.buildSessionContext().messages[0];
+			expect(restoredMessage?.role).toBe("user");
+			if (restoredMessage?.role === "user") expect(restoredMessage.content).toBe(largeContent);
+			expect(() => manager.appendModelChange("anthropic/after-close", "default")).not.toThrow();
 		});
 	});
 

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1,9 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Effort } from "@gajae-code/ai";
-import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import {
+	resetSettingsForTest,
+	Settings,
+	type SettingsMutationCheckpoint,
+} from "@gajae-code/coding-agent/config/settings";
 import { getCustomThemesDir, getProjectAgentDir, Snowflake } from "@gajae-code/utils";
 import { YAML } from "bun";
 
@@ -28,10 +32,21 @@ describe("Settings", () => {
 		fs.mkdirSync(getProjectAgentDir(projectDir), { recursive: true });
 	});
 
-	const getConfigPath = () => path.join(agentDir, "config.yml");
+	const getConfigPath = () => path.join(fs.realpathSync.native(agentDir), "config.yml");
+	const isConfigWritePath = (value: unknown): boolean =>
+		typeof value === "string" &&
+		value.startsWith(`${getConfigPath()}.`) &&
+		value.endsWith(".tmp") &&
+		!value.startsWith(`${getConfigPath()}.revisions.json.`);
+	const isRevisionWritePath = (value: unknown): boolean =>
+		typeof value === "string" && value.startsWith(`${getConfigPath()}.revisions.json.`) && value.endsWith(".tmp");
 
 	const writeSettings = async (settings: Record<string, unknown>) => {
 		await Bun.write(getConfigPath(), YAML.stringify(settings, null, 2));
+	};
+
+	const writeProjectSettings = async (settings: Record<string, unknown>) => {
+		await Bun.write(path.join(getProjectAgentDir(projectDir), "config.yml"), YAML.stringify(settings, null, 2));
 	};
 
 	const readSettings = async (): Promise<Record<string, unknown>> => {
@@ -234,6 +249,1088 @@ describe("Settings", () => {
 			expect(settings.get("task.agentModelOverrides")).toEqual({
 				executor: "persisted/executor",
 				planner: "user/planner:high",
+			});
+		});
+
+		it("lets explicit model assignments win over project settings for the live session", async () => {
+			await writeSettings({
+				modelRoles: { default: "global/default" },
+				task: { agentModelOverrides: { executor: "global/executor" } },
+			});
+			await writeProjectSettings({
+				modelRoles: { default: "project/default" },
+				task: {
+					agentModelOverrides: {
+						executor: "project/executor",
+						planner: "project/planner",
+					},
+				},
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.getProject("modelRoles")).toEqual({ default: "project/default" });
+			expect(settings.getProject("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				planner: "project/planner",
+			});
+
+			expect(settings.getWithoutProject("modelRoles")).toEqual({ default: "global/default" });
+			expect(settings.getWithoutProject("task.agentModelOverrides")).toEqual({
+				executor: "global/executor",
+			});
+
+			settings.setModelRole("default", "user/default");
+			settings.setAgentModelOverride("executor", "user/executor");
+
+			expect(settings.getWithoutProject("modelRoles")).toEqual({ default: "user/default" });
+			expect(settings.getWithoutProject("task.agentModelOverrides")).toEqual({
+				executor: "user/executor",
+			});
+
+			expect(settings.getModelRole("default")).toBe("user/default");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "user/executor",
+				planner: "project/planner",
+			});
+
+			await settings.flush();
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelRoles).toEqual({ default: "user/default" });
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: { executor: "user/executor" },
+			});
+
+			settings.clearOverride("modelRoles");
+			settings.clearOverride("task.agentModelOverrides");
+			expect(settings.getModelRole("default")).toBe("project/default");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				planner: "project/planner",
+			});
+
+			settings.clearAgentModelOverride("executor");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				planner: "project/planner",
+			});
+			expect(settings.getGlobal("task.agentModelOverrides")).toEqual({});
+			await settings.flushOrThrow();
+			expect((await readSettings()).task).toEqual({ agentModelOverrides: {} });
+		});
+
+		it("preserves externally written sibling roles when saving or clearing one assignment", async () => {
+			await writeSettings({
+				modelRoles: { default: "global/default" },
+				task: {
+					agentModelOverrides: {
+						executor: "global/executor",
+						planner: "global/planner",
+					},
+				},
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			await writeSettings({
+				modelRoles: {
+					default: "global/default",
+					smol: "external/smol",
+				},
+				task: {
+					agentModelOverrides: {
+						executor: "global/executor",
+						architect: "external/architect",
+						planner: "global/planner",
+					},
+				},
+			});
+
+			settings.setModelRole("default", "user/default");
+			settings.setAgentModelOverride("executor", "user/executor");
+			settings.clearAgentModelOverride("planner");
+			await settings.flush();
+
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelRoles).toEqual({
+				default: "user/default",
+				smol: "external/smol",
+			});
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: {
+					executor: "user/executor",
+					architect: "external/architect",
+				},
+			});
+		});
+
+		it("applies inherited leaves only when their durable snapshot is unchanged", async () => {
+			await writeSettings({
+				modelProfile: { default: "profile-a" },
+				modelRoles: { default: "baseline/default" },
+				task: { agentModelOverrides: { architect: "baseline/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			await writeSettings({
+				modelProfile: { default: "profile-b" },
+				modelRoles: { default: "external/default" },
+				task: { agentModelOverrides: { architect: "external/architect" } },
+			});
+
+			settings.setModelRoleIfUnchanged("default", "baseline/default", "profile/default");
+			settings.setAgentModelOverrideIfUnchanged("architect", "baseline/architect", "profile/architect");
+			settings.setAgentModelOverrideIfUnchanged("critic", undefined, "profile/critic");
+			settings.setModelProfileDefaultIfUnchanged("profile-a", undefined);
+			await settings.flushOrThrow();
+
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelProfile).toEqual({ default: "profile-b" });
+			expect(savedSettings.modelRoles).toEqual({ default: "external/default" });
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: {
+					architect: "external/architect",
+					critic: "profile/critic",
+				},
+			});
+		});
+
+		it("canonicalizes whole-record and leaf model assignment writes with last-write ownership", async () => {
+			await writeSettings({
+				task: {
+					agentModelOverrides: {
+						architect: "baseline/architect",
+						planner: "baseline/planner",
+					},
+				},
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			await writeSettings({
+				task: {
+					agentModelOverrides: {
+						architect: "baseline/architect",
+						planner: "external/planner",
+					},
+				},
+			});
+
+			settings.set("task.agentModelOverrides", {
+				architect: "whole/architect-1",
+				planner: "baseline/planner",
+			});
+			settings.setAgentModelOverrideIfUnchanged("planner", "baseline/planner", "profile/planner");
+			settings.setAgentModelOverride("architect", "leaf/architect-2");
+			settings.set("task.agentModelOverrides", {
+				architect: "whole/architect-3",
+				planner: "baseline/planner",
+			});
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: {
+					architect: "whole/architect-3",
+					planner: "baseline/planner",
+				},
+			});
+		});
+
+		it("does not roll back over a later equal-value write from another Settings instance", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settingsA = await Settings.init({ cwd: projectDir, agentDir });
+			const settingsB = await settingsA.cloneForCwd(projectDir);
+
+			settingsB.setAgentModelOverride("architect", "equal/architect");
+			await settingsB.flushOrThrow();
+			settingsA.setAgentModelOverrideIfUnchanged("architect", "original/architect", "equal/architect");
+			await settingsA.flushOrThrow();
+			settingsA.setAgentModelOverrideIfUnchanged("architect", "equal/architect", "original/architect");
+			await settingsA.flushOrThrow();
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ cwd: projectDir, agentDir });
+			expect(reopened.getGlobal("task.agentModelOverrides")).toEqual({
+				architect: "equal/architect",
+			});
+		});
+
+		it("rotates ownership for explicit equal-value writes and absent clears", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "equal/architect" } },
+			});
+			const settingsA = await Settings.init({ cwd: projectDir, agentDir });
+			const settingsB = await settingsA.cloneForCwd(projectDir);
+
+			settingsB.setAgentModelOverride("architect", "equal/architect");
+			settingsB.clearAgentModelOverride("planner");
+			await settingsB.flushOrThrow();
+			settingsA.setAgentModelOverrideIfUnchanged("architect", "equal/architect", "profile/architect");
+			settingsA.setAgentModelOverrideIfUnchanged("planner", undefined, "profile/planner");
+			await settingsA.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "equal/architect" },
+			});
+		});
+
+		it("does not invert over a later equal explicit write from the same Settings instance", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			settings.setAgentModelOverrideIfUnchanged("architect", "original/architect", "equal/architect");
+			await settings.flushOrThrow();
+			settings.setAgentModelOverride("architect", "equal/architect");
+			await settings.flushOrThrow();
+			settings.setAgentModelOverrideIfUnchanged("architect", "equal/architect", "original/architect");
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "equal/architect" },
+			});
+		});
+
+		it("does not replace a pending equal explicit profile with an inverse conditional", async () => {
+			await writeSettings({ modelProfile: { default: "original-profile" } });
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			settings.setModelProfileDefaultIfUnchanged("original-profile", "equal-profile");
+			await settings.flushOrThrow();
+			settings.set("modelProfile.default", "equal-profile");
+			settings.setModelProfileDefaultIfUnchanged("equal-profile", "original-profile");
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).modelProfile).toEqual({ default: "equal-profile" });
+		});
+
+		it("retains conditional ownership checks across a failed save retry", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "baseline/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isConfigWritePath(args[0])) {
+					throw new Error("simulated write failure");
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settings.setAgentModelOverrideIfUnchanged("architect", "baseline/architect", "profile/architect");
+				await expect(settings.flushOrThrow()).rejects.toThrow("simulated write failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "external/architect" } },
+			});
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "external/architect" },
+			});
+		});
+
+		it("retries the same owned conditional mutation after a config write failure", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "baseline/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isConfigWritePath(args[0])) throw new Error("simulated config failure");
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settings.setAgentModelOverrideIfUnchanged("architect", "baseline/architect", "profile/architect");
+				await expect(settings.flushOrThrow()).rejects.toThrow("simulated config failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "profile/architect" },
+			});
+		});
+
+		it("does not let an unconditional retry reclaim a later writer", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settingsA = await Settings.init({ cwd: projectDir, agentDir });
+			const settingsB = await settingsA.cloneForCwd(projectDir);
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isConfigWritePath(args[0])) throw new Error("simulated config failure");
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settingsA.setAgentModelOverride("architect", "first/architect");
+				await expect(settingsA.flushOrThrow()).rejects.toThrow("simulated config failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+			settingsB.setAgentModelOverride("architect", "later/architect");
+			await settingsB.flushOrThrow();
+			await settingsA.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "later/architect" },
+			});
+		});
+		it("does not overwrite an external edit when retrying an unconditional mutation", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isConfigWritePath(args[0])) throw new Error("simulated config failure");
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settings.setAgentModelOverride("architect", "first/architect");
+				await expect(settings.flushOrThrow()).rejects.toThrow("simulated config failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "external/architect" } },
+			});
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "external/architect" },
+			});
+		});
+		it("restores a failed mutation checkpoint without a later silent commit", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { executor: "original/executor" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const checkpoint = await settings.createMutationCheckpoint();
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isConfigWritePath(args[0])) throw new Error("simulated config failure");
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+			try {
+				await settings.runMutationCheckpoint(checkpoint, async () => {
+					settings.setAgentModelOverride("executor", "failed/executor");
+					await expect(settings.flushMutationCheckpoint(checkpoint)).rejects.toThrow("simulated config failure");
+				});
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			settings.restoreMutationCheckpoint(checkpoint);
+			expect(settings.get("task.agentModelOverrides").executor).toBe("original/executor");
+			await settings.flushOrThrow();
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ cwd: projectDir, agentDir });
+			expect(reopened.get("task.agentModelOverrides").executor).toBe("original/executor");
+		});
+
+		it("does not start a background save while a mutation checkpoint is active", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { executor: "original/executor" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const checkpoint = await settings.createMutationCheckpoint();
+
+			await settings.runMutationCheckpoint(checkpoint, async () => {
+				settings.setAgentModelOverride("executor", "uncommitted/executor");
+				await Bun.sleep(150);
+				expect((await readSettings()).task).toEqual({
+					agentModelOverrides: { executor: "original/executor" },
+				});
+			});
+
+			settings.restoreMutationCheckpoint(checkpoint);
+			await Bun.sleep(150);
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { executor: "original/executor" },
+			});
+		});
+
+		it("blocks unrelated mutations while a checkpoint baseline is being acquired", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { executor: "original/executor" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.setAgentModelOverride("executor", "baseline/executor");
+			const configWriteStarted = Promise.withResolvers<void>();
+			const releaseConfigWrite = Promise.withResolvers<void>();
+			const originalWrite = Bun.write;
+			let gated = false;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isConfigWritePath(args[0]) && !gated) {
+					gated = true;
+					configWriteStarted.resolve();
+					await releaseConfigWrite.promise;
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			const checkpointPromise = settings.createMutationCheckpoint();
+			await configWriteStarted.promise;
+			expect(() => settings.setAgentModelOverride("planner", "during-acquisition/planner")).toThrow(
+				"Settings mutation blocked while a transaction is being acquired",
+			);
+			await Bun.sleep(150);
+			releaseConfigWrite.resolve();
+			let checkpoint: SettingsMutationCheckpoint;
+			try {
+				checkpoint = await checkpointPromise;
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { executor: "baseline/executor" },
+			});
+			await settings.runMutationCheckpoint(checkpoint, async () => {
+				settings.setAgentModelOverride("critic", "transaction/critic");
+			});
+			await settings.flushMutationCheckpoint(checkpoint);
+			settings.releaseMutationCheckpoint(checkpoint);
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: {
+					executor: "baseline/executor",
+					critic: "transaction/critic",
+				},
+			});
+		});
+
+		it("rejects unrelated synchronous mutations during an active checkpoint", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { executor: "original/executor" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const checkpoint = await settings.createMutationCheckpoint();
+
+			expect(() => settings.setAgentModelOverride("planner", "unrelated/planner")).toThrow(
+				"Settings mutation blocked by an active transaction",
+			);
+			settings.restoreMutationCheckpoint(checkpoint);
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "original/executor",
+			});
+		});
+		it("rejects nested checkpoint acquisition and general flush from transaction context", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const checkpoint = await settings.createMutationCheckpoint();
+
+			await settings.runMutationCheckpoint(checkpoint, async () => {
+				await expect(settings.createMutationCheckpoint()).rejects.toThrow(
+					"Cannot create a nested transaction from inside an active Settings transaction",
+				);
+				await expect(settings.flush()).rejects.toThrow(
+					"Cannot flush settings from inside an active Settings transaction",
+				);
+				await expect(settings.flushOrThrow()).rejects.toThrow(
+					"Cannot flush settings from inside an active Settings transaction",
+				);
+			});
+
+			settings.restoreMutationCheckpoint(checkpoint);
+		});
+
+		it("revokes detached transaction work after rollback", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { planner: "original/planner" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const checkpoint = await settings.createMutationCheckpoint();
+			const detachedResult = Promise.withResolvers<unknown>();
+
+			await settings.runMutationCheckpoint(checkpoint, async () => {
+				setTimeout(() => {
+					try {
+						settings.setAgentModelOverride("planner", "detached/planner");
+						detachedResult.resolve(undefined);
+					} catch (error) {
+						detachedResult.resolve(error);
+					}
+				}, 10);
+			});
+			settings.restoreMutationCheckpoint(checkpoint);
+
+			await expect(detachedResult.promise).resolves.toEqual(
+				expect.objectContaining({ message: "Settings mutation belongs to a completed transaction" }),
+			);
+			await settings.flushOrThrow();
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { planner: "original/planner" },
+			});
+		});
+		it("seals mutations and rejects rollback while checkpoint flush is in progress", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { executor: "original/executor" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const checkpoint = await settings.createMutationCheckpoint();
+			const triggerDetached = Promise.withResolvers<void>();
+			const detachedResult = Promise.withResolvers<unknown>();
+			await settings.runMutationCheckpoint(checkpoint, async () => {
+				settings.setAgentModelOverride("executor", "transaction/executor");
+				void triggerDetached.promise.then(() => {
+					try {
+						settings.setAgentModelOverride("planner", "late/planner");
+						detachedResult.resolve(undefined);
+					} catch (error) {
+						detachedResult.resolve(error);
+					}
+				});
+			});
+
+			const configWriteStarted = Promise.withResolvers<void>();
+			const releaseConfigWrite = Promise.withResolvers<void>();
+			const originalWrite = Bun.write;
+			let gated = false;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isConfigWritePath(args[0]) && !gated) {
+					gated = true;
+					configWriteStarted.resolve();
+					await releaseConfigWrite.promise;
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+			try {
+				const flush = settings.flushMutationCheckpoint(checkpoint);
+				await configWriteStarted.promise;
+				triggerDetached.resolve();
+				await expect(detachedResult.promise).resolves.toEqual(
+					expect.objectContaining({ message: "Settings mutation belongs to a completed transaction" }),
+				);
+				expect(() => settings.restoreMutationCheckpoint(checkpoint)).toThrow(
+					"Settings mutation checkpoint flush is still in progress",
+				);
+				await expect(settings.flushMutationCheckpoint(checkpoint)).rejects.toThrow(
+					"Settings mutation checkpoint cannot be flushed more than once",
+				);
+				releaseConfigWrite.resolve();
+				await flush;
+			} finally {
+				writeSpy.mockRestore();
+			}
+			settings.releaseMutationCheckpoint(checkpoint);
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { executor: "transaction/executor" },
+			});
+		});
+
+		it("treats parent directory fsync failure after rename as a committed write", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { executor: "original/executor" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const originalFsync = fs.fsyncSync;
+			const fsyncSpy = spyOn(fs, "fsyncSync").mockImplementation(fd => {
+				if (fs.fstatSync(fd).isDirectory()) {
+					throw new Error("simulated parent fsync failure");
+				}
+				return originalFsync(fd);
+			});
+			try {
+				settings.setAgentModelOverride("executor", "committed/executor");
+				await expect(settings.flushOrThrow()).resolves.toBeUndefined();
+			} finally {
+				fsyncSpy.mockRestore();
+			}
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { executor: "committed/executor" },
+			});
+		});
+
+		it("retries current mutations after an overlapping throw-on-error save fails", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { executor: "original/executor" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const firstConfigWriteStarted = Promise.withResolvers<void>();
+			const releaseFirstConfigWrite = Promise.withResolvers<void>();
+			const originalWrite = Bun.write;
+			let configWriteCount = 0;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isConfigWritePath(args[0]) && configWriteCount++ === 0) {
+					firstConfigWriteStarted.resolve();
+					await releaseFirstConfigWrite.promise;
+					throw new Error("simulated first config failure");
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+			try {
+				settings.setAgentModelOverride("executor", "failed/executor");
+				const firstFlush = settings.flushOrThrow();
+				await firstConfigWriteStarted.promise;
+
+				settings.setAgentModelOverride("planner", "current/planner");
+				const overlappingFlush = settings.flushOrThrow();
+				releaseFirstConfigWrite.resolve();
+
+				await expect(firstFlush).rejects.toThrow("simulated first config failure");
+				await expect(overlappingFlush).resolves.toBeUndefined();
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: {
+					executor: "failed/executor",
+					planner: "current/planner",
+				},
+			});
+		});
+
+		it("serializes mutation checkpoints so a later rollback cannot revive a failed command", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { executor: "original/executor" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const firstCheckpoint = await settings.createMutationCheckpoint();
+			const firstConfigWriteStarted = Promise.withResolvers<void>();
+			const releaseFirstConfigWrite = Promise.withResolvers<void>();
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isConfigWritePath(args[0])) {
+					firstConfigWriteStarted.resolve();
+					await releaseFirstConfigWrite.promise;
+					throw new Error("simulated config failure");
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			const firstFlush = settings.runMutationCheckpoint(firstCheckpoint, async () => {
+				settings.setAgentModelOverride("executor", "failed/executor");
+				await settings.flushMutationCheckpoint(firstCheckpoint);
+			});
+			await firstConfigWriteStarted.promise;
+
+			let secondCheckpointAcquired = false;
+			const secondCheckpointPromise = settings.createMutationCheckpoint().then(checkpoint => {
+				secondCheckpointAcquired = true;
+				return checkpoint;
+			});
+			await Bun.sleep(10);
+			expect(secondCheckpointAcquired).toBe(false);
+
+			releaseFirstConfigWrite.resolve();
+			try {
+				await expect(firstFlush).rejects.toThrow("simulated config failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+			settings.restoreMutationCheckpoint(firstCheckpoint);
+
+			const secondCheckpoint = await secondCheckpointPromise;
+			await settings.runMutationCheckpoint(secondCheckpoint, async () => {
+				settings.setAgentModelOverride("planner", "current/planner");
+				await settings.flushMutationCheckpoint(secondCheckpoint);
+			});
+			settings.releaseMutationCheckpoint(secondCheckpoint);
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: {
+					executor: "original/executor",
+					planner: "current/planner",
+				},
+			});
+		});
+
+		it("reloads durable global settings when cloning for another cwd", async () => {
+			await writeSettings({ modelProfile: { default: "profile-a" } });
+			const staleSettings = await Settings.init({ cwd: projectDir, agentDir });
+
+			resetSettingsForTest();
+			const currentSettings = await Settings.init({ cwd: projectDir, agentDir });
+			currentSettings.clearGlobal("modelProfile.default");
+			await currentSettings.flushOrThrow();
+
+			const cloned = await staleSettings.cloneForCwd(projectDir);
+			expect(cloned.getGlobal("modelProfile.default")).toBeUndefined();
+		});
+		it("does not retry past a later writer after sidecar persistence fails", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settingsA = await Settings.init({ cwd: projectDir, agentDir });
+			const settingsB = await settingsA.cloneForCwd(projectDir);
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isRevisionWritePath(args[0])) throw new Error("simulated revision failure");
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settingsA.setAgentModelOverride("architect", "first/architect");
+				await expect(settingsA.flushOrThrow()).rejects.toThrow("simulated revision failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+			settingsB.setAgentModelOverride("architect", "later/architect");
+			await settingsB.flushOrThrow();
+			await settingsA.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "later/architect" },
+			});
+		});
+		it("retries after a sidecar failure when the predecessor is unchanged", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (isRevisionWritePath(args[0])) throw new Error("simulated revision failure");
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settings.setAgentModelOverride("architect", "first/architect");
+				await expect(settings.flushOrThrow()).rejects.toThrow("simulated revision failure");
+			} finally {
+				writeSpy.mockRestore();
+			}
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "first/architect" },
+			});
+		});
+		it("does not overwrite siblings when the config root becomes invalid", async () => {
+			await writeSettings({
+				modelRoles: { default: "original/default" },
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const invalidConfig = "- broken-root\n";
+			await Bun.write(getConfigPath(), invalidConfig);
+
+			settings.setAgentModelOverride("planner", "user/planner");
+			await expect(settings.flushOrThrow()).rejects.toThrow("Settings root must be an object");
+			expect(await Bun.file(getConfigPath()).text()).toBe(invalidConfig);
+		});
+		it("rejects invalid model assignment keys without poisoning durable ownership", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(() => settings.setModelRole("", "invalid/default")).toThrow("Model assignment key cannot be empty");
+			expect(() => settings.setAgentModelOverride("", "invalid/agent")).toThrow(
+				"Model assignment key cannot be empty",
+			);
+			expect(() => settings.set("modelRoles", { "": "invalid/default" })).toThrow(
+				"Model assignment key cannot be empty",
+			);
+			expect(() => settings.set("task.agentModelOverrides", { "": "invalid/agent" })).toThrow(
+				"Model assignment key cannot be empty",
+			);
+
+			for (const key of ["__proto__", "prototype", "constructor", "toString", "hasOwnProperty"]) {
+				const roleRecord = Object.fromEntries([[key, "invalid/default"]]);
+				const agentRecord = Object.fromEntries([[key, "invalid/agent"]]);
+				expect(() => settings.setModelRole(key, "invalid/default")).toThrow(
+					`Model assignment key is not allowed: ${key}`,
+				);
+				expect(() => settings.setAgentModelOverride(key, "invalid/agent")).toThrow(
+					`Model assignment key is not allowed: ${key}`,
+				);
+				expect(() => settings.set("modelRoles", roleRecord)).toThrow(`Model assignment key is not allowed: ${key}`);
+				expect(() => settings.set("task.agentModelOverrides", agentRecord)).toThrow(
+					`Model assignment key is not allowed: ${key}`,
+				);
+			}
+
+			settings.setModelRole("default", "valid/default");
+			await settings.flushOrThrow();
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ cwd: projectDir, agentDir });
+			expect(reopened.getModelRole("default")).toBe("valid/default");
+		});
+
+		it("fails closed when the durable ownership sidecar is malformed", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			await Bun.write(`${getConfigPath()}.revisions.json`, "{not-json");
+
+			await expect(Settings.init({ cwd: projectDir, agentDir })).rejects.toThrow();
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "original/architect" },
+			});
+		});
+
+		it("rejects semantically invalid ownership sidecars", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			await Bun.write(
+				`${getConfigPath()}.revisions.json`,
+				JSON.stringify({
+					version: 1,
+					generation: "uninitialized",
+					nextRevision: 1,
+					entries: {},
+				}),
+			);
+
+			await expect(Settings.init({ cwd: projectDir, agentDir })).rejects.toThrow(
+				"Invalid settings revision state header",
+			);
+		});
+
+		it("rejects non-canonical ownership paths", async () => {
+			await writeSettings({
+				modelRoles: { default: "original/default" },
+			});
+			await Settings.init({ cwd: projectDir, agentDir });
+			const sidecarPath = `${getConfigPath()}.revisions.json`;
+			const state = JSON.parse(await Bun.file(sidecarPath).text()) as Record<string, unknown>;
+			const invalidPaths = [
+				"modelRoles",
+				"task.agentModelOverrides",
+				'\0record-entry:[ "modelRoles", "default" ]',
+				`\0record-entry:${JSON.stringify(["modelRoles", "__proto__"])}`,
+				`\0record-entry:${JSON.stringify(["task", "agentModelOverrides", "constructor"])}`,
+				`\0record-entry:${JSON.stringify(["modelRoles", "toString"])}`,
+			];
+
+			for (const modifiedPath of invalidPaths) {
+				resetSettingsForTest();
+				await Bun.write(
+					sidecarPath,
+					JSON.stringify({
+						...state,
+						nextRevision: 2,
+						entries: {
+							[modifiedPath]: {
+								revision: 1,
+								ownerId: "external-writer",
+								mutationId: 1,
+							},
+						},
+					}),
+				);
+				await expect(Settings.init({ cwd: projectDir, agentDir })).rejects.toThrow(
+					`Invalid settings revision path: ${modifiedPath}`,
+				);
+			}
+		});
+
+		it("rejects stale baselines after ownership sidecar regeneration", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "equal/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.setAgentModelOverride("architect", "equal/architect");
+			await settings.flushOrThrow();
+			const staleSettings = await settings.cloneForCwd(projectDir);
+			fs.rmSync(`${getConfigPath()}.revisions.json`);
+
+			resetSettingsForTest();
+			const regenerated = await Settings.init({ cwd: projectDir, agentDir });
+			regenerated.setAgentModelOverride("architect", "equal/architect");
+			await regenerated.flushOrThrow();
+			staleSettings.setAgentModelOverrideIfUnchanged("architect", "equal/architect", "profile/architect");
+			await staleSettings.flushOrThrow();
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "equal/architect" },
+			});
+		});
+		it("regenerates a deleted sidecar without wedging later live conditional writes", async () => {
+			await writeSettings({
+				task: { agentModelOverrides: { architect: "original/architect" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const sidecarPath = `${getConfigPath()}.revisions.json`;
+			fs.rmSync(sidecarPath);
+
+			settings.setAgentModelOverrideIfUnchanged("architect", "original/architect", "first/architect");
+			await settings.flushOrThrow();
+			expect(await Bun.file(sidecarPath).exists()).toBe(true);
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { architect: "original/architect" },
+			});
+
+			settings.setAgentModelOverrideIfUnchanged("architect", "original/architect", "second/architect");
+			await settings.flushOrThrow();
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ cwd: projectDir, agentDir });
+			expect(reopened.getGlobal("task.agentModelOverrides")).toEqual({
+				architect: "second/architect",
+			});
+		});
+		it("refuses profile deletion when a concurrent writer restored the same default", async () => {
+			const settingsA = await Settings.init({ cwd: projectDir, agentDir });
+			const settingsB = await settingsA.cloneForCwd(projectDir);
+			settingsB.set("modelProfile.default", "profile-a");
+			await settingsB.flushOrThrow();
+			let deleted = false;
+
+			await expect(
+				settingsA.deleteModelProfileIfUnreferenced("profile-a", async () => {
+					deleted = true;
+				}),
+			).rejects.toThrow("Model profile became the default while deletion was in progress: profile-a");
+
+			expect(deleted).toBe(false);
+			resetSettingsForTest();
+			const reopened = await Settings.init({ cwd: projectDir, agentDir });
+			expect(reopened.getGlobal("modelProfile.default")).toBe("profile-a");
+		});
+
+		it("preserves external siblings for dotted role and agent names", async () => {
+			await writeSettings({
+				modelRoles: {
+					"review.security": "global/reviewer",
+					default: "global/default",
+				},
+				task: {
+					agentModelOverrides: {
+						"review.security": "global/reviewer",
+						planner: "global/planner",
+					},
+				},
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			await writeSettings({
+				modelRoles: {
+					"review.security": "global/reviewer",
+					default: "external/default",
+				},
+				task: {
+					agentModelOverrides: {
+						"review.security": "global/reviewer",
+						planner: "external/planner",
+					},
+				},
+			});
+			settings.setModelRole("review.security", "user/reviewer");
+			settings.setAgentModelOverride("review.security", "user/reviewer");
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).modelRoles).toEqual({
+				"review.security": "user/reviewer",
+				default: "external/default",
+			});
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: {
+					"review.security": "user/reviewer",
+					planner: "external/planner",
+				},
+			});
+
+			await writeSettings({
+				modelRoles: {
+					"review.security": "user/reviewer",
+					default: "external/default-v2",
+				},
+				task: {
+					agentModelOverrides: {
+						"review.security": "user/reviewer",
+						planner: "external/planner-v2",
+					},
+				},
+			});
+			settings.clearModelRole("review.security");
+			settings.clearAgentModelOverride("review.security");
+			await settings.flushOrThrow();
+
+			expect((await readSettings()).modelRoles).toEqual({ default: "external/default-v2" });
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: { planner: "external/planner-v2" },
+			});
+		});
+
+		it("serializes a flush behind an in-flight debounced save", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const { promise: writeWait, resolve: releaseWrite } = Promise.withResolvers<void>();
+			const { promise: writeStarted, resolve: resolveWriteStarted } = Promise.withResolvers<void>();
+			const originalWrite = Bun.write;
+			let blockedFirstWrite = false;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (!blockedFirstWrite) {
+					blockedFirstWrite = true;
+					resolveWriteStarted();
+					await writeWait;
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settings.setModelRole("default", "user/default");
+				await writeStarted;
+				settings.setAgentModelOverride("executor", "user/executor");
+				expect(settings.getGlobal("task.agentModelOverrides")).toEqual({ executor: "user/executor" });
+				const flushPromise = settings.flush();
+				releaseWrite();
+				await flushPromise;
+				expect(settings.getGlobal("task.agentModelOverrides")).toEqual({ executor: "user/executor" });
+			} finally {
+				releaseWrite();
+				writeSpy.mockRestore();
+			}
+
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelRoles).toEqual({ default: "user/default" });
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: { executor: "user/executor" },
+			});
+		});
+
+		it("keeps newer explicit leaves across an in-flight conditional save", async () => {
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const { promise: writeWait, resolve: releaseWrite } = Promise.withResolvers<void>();
+			const { promise: writeStarted, resolve: resolveWriteStarted } = Promise.withResolvers<void>();
+			const originalWrite = Bun.write;
+			let blockedConfigWrite = false;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (!blockedConfigWrite && isConfigWritePath(args[0])) {
+					blockedConfigWrite = true;
+					resolveWriteStarted();
+					await writeWait;
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+
+			try {
+				settings.setAgentModelOverrideIfUnchanged("architect", undefined, "profile/architect");
+				const firstFlush = settings.flushOrThrow();
+				await writeStarted;
+
+				settings.setAgentModelOverride("architect", "user/architect");
+				settings.setAgentModelOverride("planner", "user/planner");
+				settings.setAgentModelOverrideIfUnchanged("planner", "user/planner", "profile/planner");
+				expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+					architect: "user/architect",
+					planner: "user/planner",
+				});
+
+				releaseWrite();
+				await firstFlush;
+				await settings.flushOrThrow();
+			} finally {
+				releaseWrite();
+				writeSpy.mockRestore();
+			}
+
+			expect((await readSettings()).task).toEqual({
+				agentModelOverrides: {
+					architect: "user/architect",
+					planner: "user/planner",
+				},
 			});
 		});
 	});

--- a/packages/coding-agent/test/slash-commands/model.test.ts
+++ b/packages/coding-agent/test/slash-commands/model.test.ts
@@ -1,30 +1,68 @@
 import { describe, expect, spyOn, test } from "bun:test";
-import { Settings } from "../../src/config/settings";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import { resetSettingsForTest, Settings } from "../../src/config/settings";
 import type { AgentSession } from "../../src/session/agent-session";
 import type { SessionManager } from "../../src/session/session-manager";
 import { executeAcpBuiltinSlashCommand } from "../../src/slash-commands/acp-builtins";
+import { lookupBuiltinSlashCommand } from "../../src/slash-commands/builtin-registry";
 
-function createRuntime() {
+function createRuntime(settings = Settings.isolated()) {
 	const output: string[] = [];
-	const settings = Settings.isolated();
 	let activeModelProfile: string | undefined;
-	const availableModel = { provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 };
+	let resumeDefaultModelSelector: string | undefined;
+	let pendingSettingsModel: { provider: string; id: string } | undefined;
+	let pendingSettingsThinkingLevel: string | undefined;
+	const availableModel = {
+		provider: "anthropic",
+		id: "claude-3-5-sonnet",
+		contextWindow: 200_000,
+		reasoning: true,
+		thinking: { mode: "effort", minLevel: "low", maxLevel: "high" },
+	};
 	const session = {
 		sessionId: "session-1",
 		model: undefined as { provider: string; id: string; contextWindow?: number } | undefined,
 		thinkingLevel: undefined as string | undefined,
 		modelRegistry: {
-			async getApiKey(_model: { provider: string; id: string }, _sessionId?: string) {
+			async getApiKey(_model: { provider: string; id: string }, _sessionId?: string): Promise<string | undefined> {
 				return "test-api-key";
 			},
 			resolveCanonicalModel: (
 				selector: string,
 				options?: { candidates?: Array<{ provider: string; id: string }> },
 			) => (selector === "claude-sonnet" ? options?.candidates?.[0] : undefined),
+			getAll: () => [availableModel],
+			getModelProfile: () => undefined,
 		},
 		getAvailableModels: () => [availableModel],
-		async setModel(model: { provider: string; id: string }, _role: "default", _options?: unknown) {
+		async setModel(model: { provider: string; id: string }, _role: "default", options?: { thinkingLevel?: string }) {
 			this.model = model;
+			if (options?.thinkingLevel) this.thinkingLevel = options.thinkingLevel;
+			resumeDefaultModelSelector = `${model.provider}/${model.id}`;
+		},
+		async setModelForSettingsCommit(model: { provider: string; id: string }, thinkingLevel?: string) {
+			pendingSettingsModel = model;
+			pendingSettingsThinkingLevel = thinkingLevel;
+		},
+		async commitSettingsModelChange(model: { provider: string; id: string }) {
+			if (pendingSettingsModel === model) {
+				this.model = model;
+				this.thinkingLevel = pendingSettingsThinkingLevel;
+				resumeDefaultModelSelector = `${model.provider}/${model.id}`;
+				pendingSettingsModel = undefined;
+				pendingSettingsThinkingLevel = undefined;
+			}
+		},
+		cancelSettingsModelChange() {
+			pendingSettingsModel = undefined;
+			pendingSettingsThinkingLevel = undefined;
+		},
+		async setModelTemporary(model: { provider: string; id: string }, thinkingLevel?: string) {
+			this.model = model;
+			this.thinkingLevel = thinkingLevel;
 		},
 		setThinkingLevel(thinkingLevel: string) {
 			this.thinkingLevel = thinkingLevel;
@@ -34,6 +72,9 @@ function createRuntime() {
 		},
 		setActiveModelProfile(name: string | undefined) {
 			activeModelProfile = name;
+		},
+		getSessionDefaultModelSelector() {
+			return resumeDefaultModelSelector;
 		},
 	};
 	const sessionManager = {
@@ -66,6 +107,9 @@ function createRuntime() {
 		},
 		setActiveModelProfile(name: string | undefined) {
 			activeModelProfile = name;
+		},
+		setSessionDefaultModelSelector(selector: string | undefined) {
+			resumeDefaultModelSelector = selector;
 		},
 	};
 }
@@ -137,6 +181,39 @@ describe("/model batch assignments", () => {
 		]);
 	});
 
+	test("batch success reports preserved per-role efforts instead of claiming one value", async () => {
+		const { output, runtime, settings } = createRuntime();
+		settings.setModelRole("default", "anthropic/original-default:high");
+		settings.set("task.agentModelOverrides", {
+			executor: "anthropic/original-executor:low",
+			architect: "anthropic/original-architect:medium",
+			planner: "anthropic/original-planner:high",
+			critic: "anthropic/original-critic:low",
+		});
+
+		await expect(
+			executeAcpBuiltinSlashCommand("/model assign all-targets claude-3-5-sonnet", runtime),
+		).resolves.toEqual({ consumed: true });
+
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:high");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet:low",
+			architect: "anthropic/claude-3-5-sonnet:medium",
+			planner: "anthropic/claude-3-5-sonnet:high",
+			critic: "anthropic/claude-3-5-sonnet:low",
+		});
+		expect(output).toEqual([
+			[
+				"All model targets updated:",
+				"  DEFAULT: anthropic/claude-3-5-sonnet:high",
+				"  EXECUTOR: anthropic/claude-3-5-sonnet:low",
+				"  ARCHITECT: anthropic/claude-3-5-sonnet:medium",
+				"  PLANNER: anthropic/claude-3-5-sonnet:high",
+				"  CRITIC: anthropic/claude-3-5-sonnet:low",
+			].join("\n"),
+		]);
+	});
+
 	test("/model preserves existing DEFAULT effort when selector has no explicit effort", async () => {
 		const { output, runtime, settings, session } = createRuntime();
 		settings.setModelRole("default", "anthropic/original-model:high");
@@ -148,5 +225,347 @@ describe("/model batch assignments", () => {
 		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:high");
 		expect(session.thinkingLevel).toBe("high");
 		expect(output).toEqual(["Default model set to anthropic/claude-3-5-sonnet:high."]);
+	});
+	test("explicit DEFAULT inherit applies the configured effort live without persisting a suffix", async () => {
+		const { runtime, session, settings } = createRuntime();
+		settings.set("defaultThinkingLevel", ThinkingLevel.High);
+
+		await expect(executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet:inherit", runtime)).resolves.toEqual({
+			consumed: true,
+		});
+
+		expect(session.thinkingLevel).toBe("high");
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet");
+	});
+
+	test("all-targets inherit applies the configured DEFAULT effort live without persisting it", async () => {
+		const { output, runtime, session, settings } = createRuntime();
+		settings.set("defaultThinkingLevel", ThinkingLevel.High);
+
+		await expect(
+			executeAcpBuiltinSlashCommand("/model assign all-targets claude-3-5-sonnet:inherit", runtime),
+		).resolves.toEqual({ consumed: true });
+
+		expect(session.thinkingLevel).toBe("high");
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet",
+			architect: "anthropic/claude-3-5-sonnet",
+			planner: "anthropic/claude-3-5-sonnet",
+			critic: "anthropic/claude-3-5-sonnet",
+		});
+
+		await expect(executeAcpBuiltinSlashCommand("/model roles", runtime)).resolves.toEqual({ consumed: true });
+		expect(output.at(-1)).toContain(
+			"DEFAULT (Default): anthropic/claude-3-5-sonnet (effective: anthropic/claude-3-5-sonnet:high)",
+		);
+	});
+
+	test("reports project role settings that resume on restart", async () => {
+		const { output, runtime, settings } = createRuntime();
+		settings.getProject = ((path: string) =>
+			path === "task.agentModelOverrides"
+				? { executor: "project/executor" }
+				: undefined) as typeof settings.getProject;
+
+		await expect(executeAcpBuiltinSlashCommand("/model executor claude-3-5-sonnet:high", runtime)).resolves.toEqual({
+			consumed: true,
+		});
+
+		expect(output).toEqual([
+			[
+				"executor agent model set to anthropic/claude-3-5-sonnet:high.",
+				"Project settings for EXECUTOR resume on restart.",
+			].join("\n"),
+		]);
+	});
+	test("active-profile all-targets preserves the live DEFAULT effort when effort is omitted", async () => {
+		const { output, runtime, settings, session, setActiveModelProfile } = createRuntime();
+		session.model = { provider: "anthropic", id: "profile-model" };
+		session.thinkingLevel = "high";
+		settings.setModelRole("default", "anthropic/baseline:low");
+		settings.set("modelProfile.default", "profile-a");
+		setActiveModelProfile("profile-a");
+		settings.override("task.agentModelOverrides", {
+			executor: "anthropic/profile-executor:high",
+			architect: "anthropic/profile-architect:high",
+			planner: "anthropic/profile-planner:high",
+			critic: "anthropic/profile-critic:high",
+		});
+
+		await expect(
+			executeAcpBuiltinSlashCommand("/model assign all-targets claude-3-5-sonnet", runtime),
+		).resolves.toEqual({ consumed: true });
+
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:high");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet:high",
+			architect: "anthropic/claude-3-5-sonnet:high",
+			planner: "anthropic/claude-3-5-sonnet:high",
+			critic: "anthropic/claude-3-5-sonnet:high",
+		});
+		expect(session.thinkingLevel).toBe("high");
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(output).toEqual([
+			"All model targets set to anthropic/claude-3-5-sonnet:high for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+		]);
+	});
+
+	test("summary reports the active profile's live DEFAULT model and effort", async () => {
+		const { output, runtime, settings, session, setActiveModelProfile } = createRuntime();
+		settings.setModelRole("default", "anthropic/baseline:low");
+		session.model = { provider: "anthropic", id: "profile-model" };
+		session.thinkingLevel = "high";
+		setActiveModelProfile("profile-a");
+
+		await expect(executeAcpBuiltinSlashCommand("/model roles", runtime)).resolves.toEqual({ consumed: true });
+
+		expect(output[0]).toContain("DEFAULT (Default): anthropic/profile-model:high");
+		expect(output[0]).not.toContain("DEFAULT (Default): anthropic/baseline:low");
+	});
+
+	test("notification failures do not report a committed assignment as failed", async () => {
+		const { output, runtime, settings } = createRuntime();
+		runtime.notifyTitleChanged = async () => {
+			throw new Error("title transport unavailable");
+		};
+		runtime.notifyConfigChanged = async () => {
+			throw new Error("config transport unavailable");
+		};
+
+		await expect(executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet:low", runtime)).resolves.toEqual({
+			consumed: true,
+		});
+		await Bun.sleep(0);
+
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:low");
+		expect(output).toEqual([
+			"Default model set to anthropic/claude-3-5-sonnet:low.",
+			"Model settings were updated, but notification failed (title: title transport unavailable).",
+			"Model settings were updated, but notification failed (config: config transport unavailable).",
+		]);
+	});
+
+	test("missing credentials do not start a runtime or session model transition", async () => {
+		const { output, runtime, session } = createRuntime();
+		session.modelRegistry.getApiKey = async () => undefined;
+		const stageSpy = spyOn(session, "setModelForSettingsCommit");
+
+		await expect(executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet:low", runtime)).resolves.toEqual({
+			consumed: true,
+		});
+
+		expect(stageSpy).not.toHaveBeenCalled();
+		expect(session.model).toBeUndefined();
+		expect(session.getSessionDefaultModelSelector()).toBeUndefined();
+		expect(output.some(line => line.includes("No API key for anthropic/claude-3-5-sonnet"))).toBe(true);
+	});
+
+	test("does not report a persisted assignment when the config write fails", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-slash-durable-model-"));
+		resetSettingsForTest();
+		try {
+			const settings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			settings.setAgentModelOverride("executor", "anthropic/original");
+			await settings.flushOrThrow();
+			const usageOrderBefore = settings.getStorage()?.getModelUsageOrder() ?? [];
+			const { output, runtime, session, setActiveModelProfile, setSessionDefaultModelSelector } =
+				createRuntime(settings);
+			setActiveModelProfile("profile-a");
+			session.model = { provider: "anthropic", id: "original-model" };
+			setSessionDefaultModelSelector("anthropic/resume-original");
+			const configPath = path.join(fs.realpathSync.native(tempDir), "config.yml");
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (
+					typeof args[0] === "string" &&
+					args[0].startsWith(`${configPath}.`) &&
+					args[0].endsWith(".tmp") &&
+					!args[0].startsWith(`${configPath}.revisions.json.`)
+				) {
+					throw new Error("forced config write failure");
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+			try {
+				await expect(
+					executeAcpBuiltinSlashCommand("/model assign all-targets claude-3-5-sonnet:low", runtime),
+				).resolves.toEqual({ consumed: true });
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			expect(output.some(line => line.includes("Failed to set model: forced config write failure"))).toBe(true);
+			expect(output.some(line => line.startsWith("All model targets set to"))).toBe(false);
+			expect(settings.get("task.agentModelOverrides").executor).toBe("anthropic/original");
+			await settings.flushOrThrow();
+			expect(session.getActiveModelProfile()).toBe("profile-a");
+			expect(session.model?.id).toBe("original-model");
+			expect(session.getSessionDefaultModelSelector()).toBe("anthropic/resume-original");
+			expect(settings.getStorage()?.getModelUsageOrder() ?? []).toEqual(usageOrderBefore);
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			expect(reopened.get("task.agentModelOverrides").executor).toBe("anthropic/original");
+		} finally {
+			resetSettingsForTest();
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("reports a session follow-up failure without rolling back committed settings", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-slash-postcommit-model-"));
+		resetSettingsForTest();
+		try {
+			const settings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const { output, runtime, session } = createRuntime(settings);
+			session.commitSettingsModelChange = async () => {
+				throw new Error("forced session history failure");
+			};
+
+			await expect(executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet:low", runtime)).resolves.toEqual({
+				consumed: true,
+			});
+
+			expect(
+				output.some(line => line.includes("Model settings were committed, but a session follow-up failed")),
+			).toBe(true);
+			expect(output.some(line => line.startsWith("Failed to set model:"))).toBe(false);
+			expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:low");
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			expect(reopened.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:low");
+		} finally {
+			resetSettingsForTest();
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("reports MRU failure as post-commit without rolling back role settings", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-slash-postcommit-mru-"));
+		resetSettingsForTest();
+		try {
+			const settings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			const storage = settings.getStorage();
+			if (!storage) throw new Error("Expected durable settings storage");
+			const originalRecordModelUsage = storage.recordModelUsage.bind(storage);
+			const recordSpy = spyOn(storage, "recordModelUsage").mockImplementation(selector => {
+				originalRecordModelUsage(selector);
+				throw new Error("forced MRU failure");
+			});
+			const { output, runtime } = createRuntime(settings);
+			try {
+				await expect(
+					executeAcpBuiltinSlashCommand("/model assign executor claude-3-5-sonnet:low", runtime),
+				).resolves.toEqual({ consumed: true });
+			} finally {
+				recordSpy.mockRestore();
+			}
+
+			expect(
+				output.some(line => line.includes("Model settings were committed, but a session follow-up failed")),
+			).toBe(true);
+			expect(settings.get("task.agentModelOverrides").executor).toBe("anthropic/claude-3-5-sonnet:low");
+			expect(storage.getModelUsageOrder()[0]).toBe("anthropic/claude-3-5-sonnet");
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			expect(reopened.get("task.agentModelOverrides").executor).toBe("anthropic/claude-3-5-sonnet:low");
+		} finally {
+			resetSettingsForTest();
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("uses independent TUI error reporting when committed status output fails", async () => {
+		const { runtime, session, settings } = createRuntime();
+		const errors: string[] = [];
+		const command = lookupBuiltinSlashCommand("model");
+		if (!command?.handleTui) throw new Error("Expected TUI model command");
+		const ctx = {
+			session,
+			sessionManager: runtime.sessionManager,
+			settings,
+			showStatus: () => {
+				throw new Error("forced status output failure");
+			},
+			showError: (message: string) => errors.push(message),
+			statusLine: { invalidate: () => {} },
+			updateEditorBorderColor: () => {},
+			ui: { requestRender: () => {} },
+			editor: { setText: () => {} },
+			refreshSlashCommandState: async () => {},
+			notifyConfigChanged: () => {},
+		};
+
+		await expect(
+			command.handleTui({ name: "model", args: "claude-3-5-sonnet:low", text: "/model claude-3-5-sonnet:low" }, {
+				ctx,
+			} as never),
+		).resolves.toEqual({ consumed: true });
+
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:low");
+		expect(errors.some(message => message.includes("Model settings were committed"))).toBe(true);
+		expect(errors.some(message => message.includes("Reporting that committed state also failed"))).toBe(true);
+	});
+	test("leaves an initially unselected runtime untouched after a config failure", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-slash-empty-model-"));
+		resetSettingsForTest();
+		try {
+			const settings = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			settings.setModelRole("default", "anthropic/original-default");
+			await settings.flushOrThrow();
+			const { output, runtime, session } = createRuntime(settings);
+			expect(session.model).toBeUndefined();
+
+			const configPath = path.join(fs.realpathSync.native(tempDir), "config.yml");
+			const originalWrite = Bun.write;
+			const writeSpy = spyOn(Bun, "write").mockImplementation((async (...args: unknown[]) => {
+				if (
+					typeof args[0] === "string" &&
+					args[0].startsWith(`${configPath}.`) &&
+					args[0].endsWith(".tmp") &&
+					!args[0].startsWith(`${configPath}.revisions.json.`)
+				) {
+					throw new Error("forced empty-model config failure");
+				}
+				return (originalWrite as (...writeArgs: unknown[]) => Promise<number>)(...args);
+			}) as typeof Bun.write);
+			try {
+				await expect(executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet:low", runtime)).resolves.toEqual({
+					consumed: true,
+				});
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			expect(output.some(line => line.includes("Failed to set model: forced empty-model config failure"))).toBe(
+				true,
+			);
+			expect(session.model).toBeUndefined();
+			expect(session.thinkingLevel).toBeUndefined();
+			expect(session.getSessionDefaultModelSelector()).toBeUndefined();
+			expect(settings.getModelRole("default")).toBe("anthropic/original-default");
+			await settings.flushOrThrow();
+
+			resetSettingsForTest();
+			const reopened = await Settings.init({ agentDir: tempDir, cwd: tempDir });
+			expect(reopened.getModelRole("default")).toBe("anthropic/original-default");
+		} finally {
+			resetSettingsForTest();
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("nonsettling notifications do not block a committed assignment", async () => {
+		const { runtime, settings } = createRuntime();
+		const never = Promise.withResolvers<void>();
+		runtime.notifyTitleChanged = () => never.promise;
+		runtime.notifyConfigChanged = () => never.promise;
+
+		const completed = await Promise.race([
+			executeAcpBuiltinSlashCommand("/model claude-3-5-sonnet:low", runtime),
+			Bun.sleep(100).then(() => "timeout" as const),
+		]);
+
+		expect(completed).toEqual({ consumed: true });
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:low");
 	});
 });


### PR DESCRIPTION
## Summary

Replaces closed PR #1989 with a single commit rebuilt on current `dev`.

- keeps `/model` and the TUI selector synchronized across DEFAULT, EXECUTOR, ARCHITECT, PLANNER, and CRITIC without replacing sibling assignments
- makes Settings mutations ownership-scoped and transactional, including detached-work revocation, sealed single flushes, acquisition blocking, and self-deadlock rejection
- defers model runtime/history/MRU side effects until Settings are durable and reports every later failure as a committed follow-up
- keeps deleted custom profiles as hidden, downgrade-safe archive envelopes inside existing `equivalence.exclude`; malformed envelopes are quarantined byte-for-byte
- reloads model/profile state without mtime-only shortcuts
- serializes custom-profile writes with metadata preservation, observed-path CAS, exclusive install, hardlink ambiguity detection, and durable recovery evidence
- stores model plus effective thinking in one session entry and keeps close/reuse resident state coherent

## PR #1989 Request Changes

1. Detached transaction work is sealed/revoked and cannot mutate after flush, restore, or release.
2. Hardlink aliases cannot split silently; existing aliases are rejected and commit races preserve competing writes or explicit durable recovery evidence. Mode, uid, and gid are preserved.
3. Registry refresh reparses config even when mtime is unchanged.
4. Failed model commands do not touch runtime provider state, session history, or MRU before durability. Post-commit failures are reported truthfully.
5. Exact active and archived names resolve before legacy aliases.
6. Archive metadata uses a current-dev-valid strict-schema surface and malformed archive payloads are isolated instead of invalidating providers or active profiles.

## Additional hardening

- nested transaction/general flush self-deadlocks fail fast
- session-history persistence failures leave runtime and history aligned
- model plus thinking resume is atomic across AgentSession and SDK startup
- appends are rejected during writer close; post-close reuse retains historical resident data and still cleans the ephemeral cache
- competing existing-file and first-file writes are preserved at the commit boundary

## Verification

- changed non-ACP regression suites: **428 passed, 0 failed across 19 files**
- ACP model command tests: **20 passed, 0 failed**
- `bun run check:ts`
- `bun --cwd=packages/coding-agent run build`
- `bun run ci:test:smoke`
- `git diff --check`

Supersedes #1989 and the earlier closed replacements referenced there.