### PR TITLE
fix(tui): preserve Korean assistant prose wrapping

### DIFF
--- a/crates/pi-natives/src/text.rs
+++ b/crates/pi-natives/src/text.rs
@@ -14,7 +14,7 @@ use napi::{JsString, bindgen_prelude::*};
 use napi_derive::napi;
 use smallvec::{SmallVec, smallvec};
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthChar;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 const MIN_TAB_WIDTH: u32 = 1;
 const MAX_TAB_WIDTH: u32 = 16;
@@ -386,6 +386,11 @@ const fn ascii_cell_width_u16(u: u16, tab_width: usize) -> usize {
 
 #[inline]
 fn char_width_corrected(c: char) -> Option<usize> {
+	// U+3164 is East Asian Wide and xterm-compatible terminals occupy two
+	// cells for it even though unicode-width treats the filler as zero-width.
+	if c == '\u{3164}' {
+		return Some(2);
+	}
 	UnicodeWidthChar::width(c)
 }
 
@@ -401,19 +406,12 @@ fn grapheme_width_str(g: &str, tab_width: usize) -> usize {
 	if it.next().is_none() {
 		return char_width_corrected(c0).unwrap_or(0);
 	}
-	if g.contains('\u{200d}') {
-		return g
-			.chars()
-			.filter_map(char_width_corrected)
-			.max()
-			.unwrap_or(0);
-	}
-	// Multi-char grapheme: sum per-char widths. Conjoining Hangul jamo are
-	// kept in grapheme clusters by unicode-segmentation, and their summed
-	// width matches the NFC syllable width terminals render.
-	g.chars()
-		.map(|c| char_width_corrected(c).unwrap_or(0))
-		.sum()
+	// unicode-width's string state machine handles VS16 presentation,
+	// emoji modifiers, ZWJ sequences, and conjoining Hangul jamo as complete
+	// graphemes. Preserve the terminal-specific U+3164 correction because the
+	// crate treats Hangul Filler as zero-width.
+	let filler_correction = g.chars().filter(|c| *c == '\u{3164}').count() * 2;
+	UnicodeWidthStr::width(g) + filler_correction
 }
 
 thread_local! {
@@ -1448,6 +1446,21 @@ mod tests {
 		assert_eq!(visible_width_u16(&to_u16("a\tb"), DEFAULT_TAB_WIDTH), 1 + DEFAULT_TAB_WIDTH + 1);
 		assert_eq!(visible_width_u16(&to_u16("👨‍👩‍👧‍👦"), DEFAULT_TAB_WIDTH), 2);
 		assert_eq!(visible_width_u16(&to_u16("abcd👨‍👩‍👧‍👦wxyz"), DEFAULT_TAB_WIDTH), 10);
+	}
+
+	#[test]
+	fn test_emoji_grapheme_width() {
+		for emoji in ["❤️", "☑️", "↔️", "1️⃣", "👍🏽"] {
+			assert_eq!(visible_width_u16(&to_u16(emoji), DEFAULT_TAB_WIDTH), 2);
+		}
+		assert_eq!(truncate_string_for_test("❤️X", 2), "❤️");
+		assert_eq!(truncate_string_for_test("👍🏽X", 2), "👍🏽");
+	}
+
+	#[test]
+	fn test_hangul_filler_width() {
+		assert_eq!(visible_width_u16(&to_u16("\u{3164}"), DEFAULT_TAB_WIDTH), 2);
+		assert_eq!(truncate_string_for_test("\u{3164}X", 2), "\u{3164}");
 	}
 
 	#[test]

--- a/packages/coding-agent/test/issue-1979-korean-wrap.test.ts
+++ b/packages/coding-agent/test/issue-1979-korean-wrap.test.ts
@@ -1,0 +1,201 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { AssistantMessageComponent } from "@gajae-code/coding-agent/modes/components/assistant-message";
+import { HookSelectorComponent } from "@gajae-code/coding-agent/modes/components/hook-selector";
+import { IrcSplitViewComponent } from "@gajae-code/coding-agent/modes/components/irc-sidebar";
+import { IrcObservationLedger } from "@gajae-code/coding-agent/modes/irc-observation-ledger";
+import { getThemeByName, setThemeInstance, theme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { Container, Text, TUI, visibleWidth } from "@gajae-code/tui";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+
+const WIDTH = 20;
+const CONTENT_WIDTH = WIDTH - 2; // Assistant Markdown's left and right padding.
+const SUFFIX = "끝-ISSUE-1979-SUFFIX";
+const OPTION_LABELS = ["계속 진행", "다른 선택지를 입력"];
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+	const themeInstance = await getThemeByName("red-claw");
+	if (!themeInstance) throw new Error("Failed to load test theme");
+	setThemeInstance(themeInstance);
+});
+
+function assistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-5.5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+function stripControls(text: string): string {
+	return Bun.stripANSI(text).replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/gu, "");
+}
+
+function assertRowWidths(rows: string[], width: number): void {
+	for (const [index, row] of rows.entries()) {
+		expect(
+			visibleWidth(row),
+			`width ${width}, row ${index}: ${JSON.stringify(stripControls(row))}`,
+		).toBeLessThanOrEqual(width);
+	}
+}
+
+function compactWhitespace(text: string): string {
+	return text.replaceAll(/\s/gu, "");
+}
+
+function occurrences(text: string, needle: string): number {
+	return text.split(needle).length - 1;
+}
+
+function assertOrderedProse(rows: string[], width: number): void {
+	const rendered = compactWhitespace(stripControls(rows.join("\n")));
+	const markers = ["가나다라마바사아자", "가\u302e", "漢字,", "gpt-5.5!", "색상", "링크", "🙂‍↔️", SUFFIX];
+	let cursor = 0;
+	for (const marker of markers) {
+		const compactMarker = compactWhitespace(marker);
+		const index = rendered.indexOf(compactMarker, cursor);
+		expect(index, `width ${width} must retain ${JSON.stringify(marker)} in prose order`).toBeGreaterThanOrEqual(
+			cursor,
+		);
+		cursor = index + compactMarker.length;
+	}
+	expect(occurrences(rendered, compactWhitespace(SUFFIX)), `width ${width} must retain the complete suffix once`).toBe(
+		1,
+	);
+	for (const grapheme of ["\u302e", "漢", "字"]) {
+		expect(
+			occurrences(rendered, grapheme),
+			`width ${width} must retain ${JSON.stringify(grapheme)} exactly once`,
+		).toBe(1);
+	}
+}
+
+describe("issue #1979 Korean assistant prose wrap", () => {
+	it("keeps Korean tone-mark prose bounded and lossless through selector lifecycle and resize reflow", async () => {
+		// This is exactly one padded Markdown row at WIDTH: 9 composed Hangul syllables
+		// occupy CONTENT_WIDTH cells. The following prose exercises CJK, punctuation,
+		// ANSI/OSC input handling, the inline model name, and grapheme adjacency.
+		const exactBoundary = "가나다라마바사아자";
+		expect(visibleWidth(exactBoundary)).toBe(CONTENT_WIDTH);
+		const toneMarkedSyllable = "가\u302e";
+		expect(visibleWidth(toneMarkedSyllable)).toBe(2);
+		expect(visibleWidth(`${exactBoundary}${toneMarkedSyllable}`)).toBe(CONTENT_WIDTH + 2);
+		expect(visibleWidth(`${exactBoundary.slice(0, -1)}${toneMarkedSyllable}`)).toBe(CONTENT_WIDTH);
+		const prose = `${exactBoundary}${toneMarkedSyllable}漢字, gpt-5.5! \x1b[36m색상\x1b[0m \x1b]8;;https://example.test\x07링크\x1b]8;;\x07🙂‍↔️${SUFFIX}`;
+
+		const terminal = new VirtualTerminal(WIDTH, 24);
+		const tui = new TUI(terminal);
+		const chatContainer = new Container();
+		const assistant = new AssistantMessageComponent(assistantMessage(prose));
+		chatContainer.addChild(assistant);
+		const splitView = new IrcSplitViewComponent(chatContainer, new IrcObservationLedger(), () => theme);
+		const pendingMessagesContainer = new Container();
+		const statusContainer = new Container();
+		statusContainer.addChild(new Text("widget: ready", 1, 0));
+		const todoContainer = new Container();
+		const btwContainer = new Container();
+		const statusLine = new Text("status: connected", 1, 0);
+		const hookWidgetContainerAbove = new Container();
+		const editorContainer = new Container();
+		const editor = new Text("editor: ready", 1, 0);
+		editorContainer.addChild(editor);
+		const hookWidgetContainerBelow = new Container();
+
+		const selected: string[] = [];
+		const selector = new HookSelectorComponent(
+			"응답 선택",
+			OPTION_LABELS,
+			option => selected.push(option),
+			() => {},
+			{
+				customInput: { optionLabel: OPTION_LABELS[1]!, onSubmit: () => {} },
+				tui,
+			},
+		);
+
+		tui.addChild(splitView);
+		tui.addChild(pendingMessagesContainer);
+		tui.addChild(statusContainer);
+		tui.addChild(todoContainer);
+		tui.addChild(btwContainer);
+		tui.addChild(statusLine);
+		tui.addChild(hookWidgetContainerAbove);
+		tui.addChild(editorContainer);
+		tui.addChild(hookWidgetContainerBelow);
+		tui.setBottomPinnedComponent(statusLine);
+		try {
+			tui.start();
+			await terminal.waitForRender();
+
+			const assistantRows = assistant.render(WIDTH);
+			assertRowWidths(assistantRows, WIDTH);
+			assertOrderedProse(assistantRows, WIDTH);
+
+			const editorViewport = terminal.getViewport();
+			assertRowWidths(editorViewport, WIDTH);
+			const editorText = stripControls(editorViewport.join("\n"));
+			assertOrderedProse(editorViewport, WIDTH);
+			expect(editorText).toContain("status: connected");
+			expect(editorText).toContain("widget: ready");
+			expect(editorText).toContain("editor: ready");
+
+			// Mirror production's editor-to-selector replacement after the transcript
+			// and pinned status rail have already rendered together.
+			editorContainer.detachChild(editor);
+			editorContainer.clear();
+			editorContainer.addChild(selector);
+			tui.requestRender();
+			await terminal.waitForRender();
+
+			const initialViewport = terminal.getViewport();
+			assertRowWidths(initialViewport, WIDTH);
+			const initialText = stripControls(initialViewport.join("\n"));
+			assertOrderedProse(initialViewport, WIDTH);
+			expect(initialText).toContain("status: connected");
+			expect(initialText).toContain("widget: ready");
+			for (const label of OPTION_LABELS) expect(compactWhitespace(initialText)).toContain(compactWhitespace(label));
+
+			// Focused labels may wrap and non-focused labels may truncate; only
+			// coexistence with lossless assistant prose is asserted here.
+			selector.handleInput("\x1b[B");
+			selector.handleInput("\r");
+			expect(selector.hasActiveInlineInput()).toBe(true);
+			selector.handleInput("\x1b");
+			expect(selector.hasActiveInlineInput()).toBe(false);
+			expect(selected).toEqual([]);
+
+			terminal.resize(WIDTH - 1, 24);
+			await terminal.waitForRender();
+			const narrowedViewport = terminal.getViewport();
+			assertRowWidths(narrowedViewport, WIDTH - 1);
+			const narrowedText = stripControls(narrowedViewport.join("\n"));
+			assertOrderedProse(narrowedViewport, WIDTH - 1);
+			for (const label of OPTION_LABELS) expect(compactWhitespace(narrowedText)).toContain(compactWhitespace(label));
+			terminal.resize(WIDTH + 1, 24);
+			await terminal.waitForRender();
+			const reflowedViewport = terminal.getViewport();
+			assertRowWidths(reflowedViewport, WIDTH + 1);
+			const reflowedText = stripControls(reflowedViewport.join("\n"));
+			assertOrderedProse(reflowedViewport, WIDTH + 1);
+			for (const label of OPTION_LABELS) expect(compactWhitespace(reflowedText)).toContain(compactWhitespace(label));
+		} finally {
+			tui.stop();
+		}
+	});
+});

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Preserved two-cell terminal width for Hangul Filler (U+3164), VS16 emoji-presentation graphemes, and emoji-modifier sequences while aligning TUI display-width measurement with native wrapping and truncation (#1979).
 
 ## [0.9.1] - 2026-07-08
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## [Unreleased]
-
 ### Fixed
+
+- Unified TUI wrapping, truncation, and visible-width measurements on the native grapheme-width engine, preventing Hangul tone marks from causing Korean/CJK layout width drift (#1979).
 
 - Preserved durable transcript semantic anchors at their screen rows when completion removes transient content, including CJK/emoji/ANSI reflow, prefix eviction, provider replacement, explicit exclusion of synthetic/IRC/pinned rows, and supported SSH, tmux, Termux, and Windows terminal paths (#1969).
 

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -5,6 +5,7 @@ import {
 	sliceWithWidth as nativeSliceWithWidth,
 	truncateLinesToWidth as nativeTruncateLinesToWidth,
 	truncateToWidth as nativeTruncateToWidth,
+	visibleWidth as nativeVisibleWidth,
 	visibleWidths as nativeVisibleWidths,
 	wrapTextWithAnsi as nativeWrapTextWithAnsi,
 	type SliceResult,
@@ -279,6 +280,22 @@ function normalizeForWidth(str: string): string {
 	const normalized = str.normalize("NFC");
 	return normalized === str ? str : normalized;
 }
+
+function hasUnpairedSurrogate(str: string): boolean {
+	for (let index = 0; index < str.length; index++) {
+		const code = str.charCodeAt(index);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			const next = str.charCodeAt(index + 1);
+			if (next >= 0xdc00 && next <= 0xdfff) {
+				index += 1;
+				continue;
+			}
+			return true;
+		}
+		if (code >= 0xdc00 && code <= 0xdfff) return true;
+	}
+	return false;
+}
 export function visibleWidthRaw(str: string): number {
 	if (!str) {
 		return 0;
@@ -303,8 +320,8 @@ export function visibleWidthRaw(str: string): number {
 		return str.length + tabCount * (getCachedTabWidth() - 1);
 	}
 	const normalized = normalizeForWidth(str);
-	if (tabCount === 0) return Bun.stringWidth(normalized);
-	return Bun.stringWidth(normalized.replaceAll("\t", " ".repeat(getCachedTabWidth())));
+	const text = tabCount === 0 ? normalized : normalized.replaceAll("\t", " ".repeat(getCachedTabWidth()));
+	return nativeVisibleWidth(text, getCachedTabWidth());
 }
 
 /**
@@ -317,15 +334,18 @@ export function visibleWidth(str: string): number {
 
 export function visibleWidthsNative(lines: readonly string[]): number[] {
 	__textHelperPerfCounters.visibleWidthsCalls += 1;
-	return nativeVisibleWidths(
-		lines.map(line => (typeof line === "string" ? line : String(line ?? ""))),
-		getCachedTabWidth(),
-	);
+	const safeLines = lines.map(line => (typeof line === "string" ? line : String(line ?? "")));
+	const widths = nativeVisibleWidths(safeLines, getCachedTabWidth());
+	for (let index = 0; index < safeLines.length; index++) {
+		const line = safeLines[index]!;
+		if (hasUnpairedSurrogate(line)) widths[index] = visibleWidthRaw(line);
+	}
+	return widths;
 }
 
 export function visibleWidths(lines: readonly string[]): number[] {
-	void visibleWidthsNative(lines);
-	return lines.map(line => visibleWidth(typeof line === "string" ? line : String(line ?? "")));
+	if (!renderMetrics.enabled) return visibleWidthsNative(lines);
+	return recordTextHelper("text.visibleWidths", () => visibleWidthsNative(lines));
 }
 
 const THAI_LAO_AM_REGEX = /[\u0e33\u0eb3]/;

--- a/packages/tui/test/text-utils.test.ts
+++ b/packages/tui/test/text-utils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { type Component, TUI } from "@gajae-code/tui";
+import { type Component, renderMetrics, TUI } from "@gajae-code/tui";
 import {
 	__textHelperPerfCounters,
 	Ellipsis,
@@ -76,6 +76,21 @@ describe("text utils", () => {
 			lines.map(line => truncateToWidth(line, 8, Ellipsis.Omit)),
 		);
 		expect(visibleWidths(lines)).toEqual(lines.map(line => visibleWidth(line)));
+	});
+
+	it("records batched visible-width work when render metrics are enabled", () => {
+		const wasEnabled = renderMetrics.enabled;
+		renderMetrics.reset();
+		renderMetrics.enable();
+		try {
+			expect(visibleWidths(["한글", "❤️", "👍🏽"])).toEqual([4, 2, 2]);
+			const helper = renderMetrics.snapshot().helperStats["text.visibleWidths"];
+			expect(helper?.count).toBe(1);
+			expect(helper?.totalMs).toBeGreaterThanOrEqual(0);
+		} finally {
+			renderMetrics.reset();
+			if (!wasEnabled) renderMetrics.disable();
+		}
 	});
 
 	it("invalidates the cached tab width automatically", () => {

--- a/packages/tui/test/viewport-scroll.test.ts
+++ b/packages/tui/test/viewport-scroll.test.ts
@@ -423,17 +423,18 @@ describe("registered viewport anchor", () => {
 		}
 	});
 
-	it("emits authoritative grapheme and cell spans from production Text wrapping", () => {
+	it("emits authoritative emoji grapheme and cell spans from production Text wrapping", () => {
 		const container = new Container();
-		const text = new Text("\x1b[31m가가🙂e\u0301가\x1b[0m", 0, 0);
+		const text = new Text("\x1b[31m가가❤️👍🏽🙂e\u0301가\x1b[0m", 0, 0);
 		container.addChild(text);
 		container.setViewportAnchorSource(text, { id: "semantic-text" });
 		const rendered = container.renderWithViewportAnchors(4);
 		expect(rendered.lines.join("")).not.toContain("GJC_ANCHOR");
 		expect(rendered.anchors).toEqual([
 			{ id: "semantic-text", graphemeStart: 0, graphemeEnd: 2, cellStart: 0, cellEnd: 4 },
-			{ id: "semantic-text", graphemeStart: 2, graphemeEnd: 4, cellStart: 4, cellEnd: 7 },
-			{ id: "semantic-text", graphemeStart: 4, graphemeEnd: 5, cellStart: 7, cellEnd: 9 },
+			{ id: "semantic-text", graphemeStart: 2, graphemeEnd: 4, cellStart: 4, cellEnd: 8 },
+			{ id: "semantic-text", graphemeStart: 4, graphemeEnd: 6, cellStart: 8, cellEnd: 11 },
+			{ id: "semantic-text", graphemeStart: 6, graphemeEnd: 7, cellStart: 11, cellEnd: 13 },
 		]);
 		expect(rendered.lines).toEqual(text.render(4));
 	});

--- a/packages/tui/test/visible-width-jamo.test.ts
+++ b/packages/tui/test/visible-width-jamo.test.ts
@@ -8,10 +8,17 @@
  *
  * Conjoining jamo sequences (U+1100..U+11FF, e.g. `한`) are different:
  * terminals render each grapheme cluster like its NFC syllable, so width
- * measurement must normalize those sequences before calling Bun.stringWidth.
+ * measurement must normalize those sequences before calling the native grapheme-width engine.
  */
 import { describe, expect, it } from "bun:test";
-import { Ellipsis, sliceWithWidth, truncateToWidth, visibleWidth } from "@gajae-code/tui/utils";
+import {
+	Ellipsis,
+	sliceWithWidth,
+	truncateToWidth,
+	visibleWidth,
+	visibleWidths,
+	wrapTextWithAnsi,
+} from "@gajae-code/tui/utils";
 
 describe("visibleWidth — Hangul width parity", () => {
 	it("single compatibility jamo is 2 cells", () => {
@@ -34,7 +41,7 @@ describe("visibleWidth — Hangul width parity", () => {
 		expect(visibleWidth("\u318e")).toBe(2);
 	});
 
-	it("U+3164 HANGUL FILLER is 2 cells", () => {
+	it("U+3164 HANGUL FILLER remains 2 cells", () => {
 		expect(visibleWidth("\u3164")).toBe(2);
 	});
 
@@ -87,11 +94,49 @@ describe("visibleWidth — Hangul width parity", () => {
 		expect(visibleWidth("アイ")).toBe(4);
 	});
 
-	it("Halfwidth Hangul block is unaffected (already Narrow in Bun)", () => {
-		// U+FFA1 HALFWIDTH HANGUL LETTER KIYEOK — Bun reports 1, untouched.
+	it("Halfwidth Hangul block remains narrow", () => {
+		// U+FFA1 HALFWIDTH HANGUL LETTER KIYEOK remains narrow.
 		expect(visibleWidth("\uffa1")).toBe(1);
 		// U+FFDC HALFWIDTH HANGUL LETTER I
 		expect(visibleWidth("\uffdc")).toBe(1);
+	});
+});
+
+describe("visible-width text helper parity — Hangul tone marks", () => {
+	const toneMarkedSyllable = "가\u302e";
+	const nfdSyllable = "가";
+
+	it("uses native grapheme widths for tone marks, NFD Hangul, ANSI, and batched measurements", () => {
+		const ansiToneMarkedSyllable = `\x1b[36m${toneMarkedSyllable}\x1b[0m\x1b]8;;https://example.test\x07링크\x1b]8;;\x07`;
+		const cases = [toneMarkedSyllable, nfdSyllable, "ㅁ", ansiToneMarkedSyllable];
+
+		expect(visibleWidth(toneMarkedSyllable)).toBe(2);
+		expect(visibleWidth(nfdSyllable)).toBe(2);
+		expect(visibleWidths(cases)).toEqual(cases.map(visibleWidth));
+		expect(visibleWidth(ansiToneMarkedSyllable)).toBe(6);
+	});
+
+	it("uses the same boundary decisions as native wrapping and truncation", () => {
+		expect(wrapTextWithAnsi(`${toneMarkedSyllable}X`, 2)).toEqual([toneMarkedSyllable, "X"]);
+		expect(truncateToWidth(toneMarkedSyllable, 1, Ellipsis.Omit)).toBe("");
+		expect(truncateToWidth(toneMarkedSyllable, 2, Ellipsis.Omit)).toBe(toneMarkedSyllable);
+		expect(truncateToWidth(`${toneMarkedSyllable}X`, 3, Ellipsis.Omit)).toBe(`${toneMarkedSyllable}X`);
+	});
+});
+
+describe("visible-width text helper parity — emoji presentation", () => {
+	const emojiPresentation = ["❤️", "☑️", "↔️", "1️⃣", "👍🏽"];
+
+	it("keeps VS16 graphemes at two terminal cells", () => {
+		for (const emoji of emojiPresentation) expect(visibleWidth(emoji)).toBe(2);
+		expect(visibleWidths(emojiPresentation)).toEqual([2, 2, 2, 2, 2]);
+	});
+
+	it("uses the same VS16 boundary for wrapping and truncation", () => {
+		expect(wrapTextWithAnsi("❤️X", 2)).toEqual(["❤️", "X"]);
+		expect(truncateToWidth("❤️X", 2, Ellipsis.Omit)).toBe("❤️");
+		expect(wrapTextWithAnsi("👍🏽X", 2)).toEqual(["👍🏽", "X"]);
+		expect(truncateToWidth("👍🏽X", 2, Ellipsis.Omit)).toBe("👍🏽");
 	});
 });
 


### PR DESCRIPTION
## Summary
- align TUI scalar and batched display-width decisions with the native ANSI/grapheme-aware engine used by wrapping and truncation
- preserve Hangul Filler width and Unicode grapheme semantics for Korean tone marks, VS16 emoji presentation, ZWJ, keycaps, and emoji modifiers
- add production-shaped assistant/selector and merged-#1983 viewport-anchor regressions, plus deterministic batched render-metrics accounting

Closes #1979.

## Frozen delivery head
- exact base: `origin/dev` at `1f36f680659bffbe522f242ddf4e438515773fb3`
- exact head: `fc5fbf4e5ab1e0c602f17a62afd03866c55bdcb5`
- history: exactly one issue commit
- signature: GOOD SSH signature
- DCO: `Signed-off-by: Yeachan-Heo <hurrc04@gmail.com>`

## Verification
- focused Korean/Jamo/emoji/metrics/viewport suite: 82 passed
- deterministic `renderMetrics` proof: one `text.visibleWidths` sample for one batched call
- native package: 56 passed, 2 skipped
- TUI/native/Rust checks passed
- targeted Rust tests: Hangul Filler and emoji grapheme widths/truncation passed
- production Text viewport-anchor spans cover ❤️ and 👍🏽 across #1983 wrapping/rebuild semantics
- clean worktree/generated artifacts

## Terminal gates
- both prior Codex P2 findings fixed and replied to
- final Architect: CLEAR / APPROVE / zero findings
- final QA/red-team: PASS / zero findings
- exact-head Codex: no major issues: https://github.com/Yeachan-Heo/gajae-code/pull/1996#issuecomment-4940637791
- exact-head signed MERGE_READY: https://github.com/Yeachan-Heo/gajae-code/pull/1996#pullrequestreview-4675711159
- fresh GitHub CI for `fc5fbf4e`: all required checks succeeded; homepage check skipped by design