### PR TITLE
fix(model): keep project-shadowed role assignments live

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Kept `/model` DEFAULT, EXECUTOR, ARCHITECT, PLANNER, and CRITIC assignments visible in the running TUI when project settings shadow the persisted global model roles.
 - Preserved explicit Telegram forum-topic renames as durable user-owned names, immediately re-asserting delayed edits while retaining restart and rename-race recovery (#1910).
 - `gjc resume` now aliases value-less `--resume`, requests confirmation before opening and continues a resumable tail once only; terminal tails open idle, and headless bare resume exits with explicit `--resume <id>` guidance (#1973).
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -477,7 +477,7 @@ export class Settings {
 	}
 
 	/**
-	 * Set a model role (helper for modelRoles record).
+	 * Set a model role while keeping a project/profile-shadowed live value aligned.
 	 */
 	setModelRole(role: ModelRole | string, modelId: string): void {
 		const current = shallowStringRecord(getByPath(this.#global, ["modelRoles"]));
@@ -490,16 +490,17 @@ export class Settings {
 
 		this.set("modelRoles", { ...current, [role]: modelId });
 
-		if (updateRuntimeOverride) {
+		if (updateRuntimeOverride || this.get("modelRoles")[role] !== modelId) {
 			this.override("modelRoles", { ...shallowStringRecord(runtimeOverrides), [role]: modelId });
 		}
 	}
 	/**
-	 * Set an agent model override while keeping any live runtime override aligned.
+	 * Set an agent model override while keeping any live project/profile override aligned.
 	 *
-	 * Runtime model profiles override `task.agentModelOverrides` for the current
-	 * session. A user-selected role assignment must win immediately in that same
-	 * session, but only the explicit agent change should be persisted.
+	 * Runtime model profiles and project settings can override
+	 * `task.agentModelOverrides` for the current session. A user-selected role
+	 * assignment must win immediately in that same session, but only the explicit
+	 * agent change should be persisted.
 	 */
 	setAgentModelOverride(agentName: string, modelId: string): void {
 		const current = shallowStringRecord(getByPath(this.#global, ["task", "agentModelOverrides"]));
@@ -509,7 +510,7 @@ export class Settings {
 
 		this.set("task.agentModelOverrides", { ...current, [agentName]: modelId });
 
-		if (updateRuntimeOverride) {
+		if (updateRuntimeOverride || this.get("task.agentModelOverrides")[agentName] !== modelId) {
 			this.override("task.agentModelOverrides", {
 				...shallowStringRecord(runtimeOverrides),
 				[agentName]: modelId,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -945,20 +945,13 @@ export class SelectorController {
 								assignments,
 							});
 							if (!materializedProfile) {
-								const overrides = this.ctx.settings.get("task.agentModelOverrides");
-								const nextOverrides = { ...overrides };
-								let writesOverrides = false;
 								for (const targetRole of targetRoles) {
 									const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetRole];
 									if (target.settingsPath === "modelRoles") {
 										this.ctx.settings.setModelRole(targetRole, value);
 									} else {
-										nextOverrides[targetRole] = value;
-										writesOverrides = true;
+										this.ctx.settings.setAgentModelOverride(targetRole, value);
 									}
-								}
-								if (writesOverrides) {
-									this.ctx.settings.set("task.agentModelOverrides", nextOverrides);
 								}
 							}
 							modelSelector.refreshRoleAssignments({
@@ -1029,10 +1022,7 @@ export class SelectorController {
 								if (target.settingsPath === "modelRoles") {
 									this.ctx.settings.setModelRole(role, value);
 								} else {
-									this.ctx.settings.set("task.agentModelOverrides", {
-										...this.ctx.settings.get("task.agentModelOverrides"),
-										[role]: value,
-									});
+									this.ctx.settings.setAgentModelOverride(role, value);
 								}
 							}
 							modelSelector.refreshRoleAssignments({

--- a/packages/coding-agent/test/model-selector-controller-batch.test.ts
+++ b/packages/coding-agent/test/model-selector-controller-batch.test.ts
@@ -109,6 +109,75 @@ describe("SelectorController model batch assignments", () => {
 		);
 	});
 
+	test("batch selection wins over live project/profile shadows without persisting their extra keys", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.override("task.agentModelOverrides", {
+			executor: "shadow/executor",
+			architect: "shadow/architect",
+			planner: "shadow/planner",
+			critic: "shadow/critic",
+			reviewer: "shadow/reviewer",
+		});
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			roles: ["executor", "architect", "planner", "critic"],
+			thinkingLevel: ThinkingLevel.Low,
+			selector: "provider-a/selected:low",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:low",
+			architect: "provider-a/selected:low",
+			planner: "provider-a/selected:low",
+			critic: "provider-a/selected:low",
+			reviewer: "shadow/reviewer",
+		});
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:low",
+			architect: "provider-a/selected:low",
+			planner: "provider-a/selected:low",
+			critic: "provider-a/selected:low",
+		});
+	});
+
+	test("single role selection wins over a live project/profile shadow without copying siblings", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.override("task.agentModelOverrides", {
+			executor: "shadow/executor",
+			architect: "shadow/architect",
+			planner: "shadow/planner",
+			critic: "shadow/critic",
+			reviewer: "shadow/reviewer",
+		});
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "planner",
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "shadow/executor",
+			architect: "shadow/architect",
+			planner: "provider-a/selected:high",
+			critic: "shadow/critic",
+			reviewer: "shadow/reviewer",
+		});
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/original-executor:low",
+			planner: "provider-a/selected:high",
+		});
+	});
+
 	test("all targets selection writes DEFAULT plus every role-agent override", async () => {
 		const { ctx, settings, setModelCalls } = createControllerContext();
 		const selector = await openSelector(ctx);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -236,6 +236,79 @@ describe("Settings", () => {
 				planner: "user/planner:high",
 			});
 		});
+
+		it("keeps model assignments live when project settings shadow global persistence", async () => {
+			await writeSettings({
+				modelRoles: { default: "global/default" },
+				task: {
+					agentModelOverrides: {
+						executor: "global/executor",
+					},
+				},
+			});
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "config.yml"),
+				YAML.stringify(
+					{
+						modelRoles: { default: "project/default" },
+						task: {
+							agentModelOverrides: {
+								executor: "project/executor",
+								architect: "project/architect",
+								planner: "project/planner",
+								critic: "project/critic",
+							},
+						},
+					},
+					null,
+					2,
+				),
+			);
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.getModelRole("default")).toBe("project/default");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				architect: "project/architect",
+				planner: "project/planner",
+				critic: "project/critic",
+			});
+
+			settings.setModelRole("default", "openai-codex/gpt-5.6-sol:xhigh");
+			for (const role of ["executor", "architect", "planner", "critic"]) {
+				settings.setAgentModelOverride(role, "openai-codex/gpt-5.6-sol:xhigh");
+			}
+
+			expect(settings.getModelRole("default")).toBe("openai-codex/gpt-5.6-sol:xhigh");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "openai-codex/gpt-5.6-sol:xhigh",
+				architect: "openai-codex/gpt-5.6-sol:xhigh",
+				planner: "openai-codex/gpt-5.6-sol:xhigh",
+				critic: "openai-codex/gpt-5.6-sol:xhigh",
+			});
+
+			await settings.flushOrThrow();
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelRoles).toEqual({ default: "openai-codex/gpt-5.6-sol:xhigh" });
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: {
+					executor: "openai-codex/gpt-5.6-sol:xhigh",
+					architect: "openai-codex/gpt-5.6-sol:xhigh",
+					planner: "openai-codex/gpt-5.6-sol:xhigh",
+					critic: "openai-codex/gpt-5.6-sol:xhigh",
+				},
+			});
+
+			settings.clearOverride("modelRoles");
+			settings.clearOverride("task.agentModelOverrides");
+			expect(settings.getModelRole("default")).toBe("project/default");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				architect: "project/architect",
+				planner: "project/planner",
+				critic: "project/critic",
+			});
+		});
 	});
 
 	describe("migrations", () => {


### PR DESCRIPTION
## What

- extend the existing live role-assignment alignment from #1642 to values shadowed by project settings
- route interactive `/model` single and batch role-agent writes through the same per-role helper used by typed `/model`
- keep project/profile-only sibling keys out of global persistence while refreshing the running TUI immediately

## Why

Exact current `dev` reproduced the reported split state:

1. `.gjc/config.yml` defines EXECUTOR, ARCHITECT, PLANNER, and CRITIC overrides.
2. `/model assign all-targets openai-codex/gpt-5.6-sol:xhigh` reports all five targets changed.
3. DEFAULT changes through the live session, and all four global role values are persisted.
4. The merged live Settings view still returns the four project values, so the reopened selector/dashboard badges remain unchanged.

The setters previously promoted a selected value into the runtime layer only when a model-profile runtime override already existed. They now do the same when the post-write effective leaf is still project-shadowed.

This replaces oversized #1998. The earlier 37-file persistence/profile/session redesign has been removed rather than carried forward: no Settings transaction engine, model-profile archive, `models.yml` writer, session lifecycle, SDK, or storage changes remain.

## Testing

- focused Settings, slash `/model`, interactive selector batch, and role-badge suites: **51 passed**
- ACP model command tests: **14 passed**
- adjacent profile activation and selector suites: **54 passed**
- `bun --cwd=packages/coding-agent run check`
- `bun run check:ts`
- `bun --cwd=packages/coding-agent run build`
- `bun run ci:test:smoke`
- `git diff --check origin/dev...HEAD`
- independent final architecture review: **CLEAR**, no HIGH or MEDIUM findings

The single commit is based directly on current `dev` and includes a `Signed-off-by` trailer.