### PR TITLE
fix(model): keep shadowed role assignments coherent

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Kept `/model` DEFAULT, EXECUTOR, ARCHITECT, PLANNER, and CRITIC assignments visible in the running TUI when project settings shadow the persisted global model roles.
 - Preserved explicit Telegram forum-topic renames as durable user-owned names, immediately re-asserting delayed edits while retaining restart and rename-race recovery (#1910).
 - `gjc resume` now aliases value-less `--resume`, requests confirmation before opening and continues a resumable tail once only; terminal tails open idle, and headless bare resume exits with explicit `--resume <id>` guidance (#1973).
 - Telegram answers to interactive and unattended `ask` prompts now receive a semantic, origin-bound `Selected!` acknowledgement before workflow continuation, with typed multi-select controls, no acknowledgement for toggles/clarifications/skips, at-most-once delivery attempts, and truthful failure/unknown outcomes (#1974).

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -149,6 +149,17 @@ function shallowStringRecord(value: unknown): Record<string, string> {
 	}
 	return result;
 }
+function shallowStringOrNullRecord(value: unknown): Record<string, string | null> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+
+	const result: Record<string, string | null> = {};
+	for (const [key, item] of Object.entries(value)) {
+		if (typeof item === "string" || item === null) {
+			result[key] = item;
+		}
+	}
+	return result;
+}
 
 function resolvePathScopedStringArray(settingPath: SettingPath, value: unknown, cwd: string): string[] | undefined {
 	if (!PATH_SCOPED_ARRAY_SETTINGS.has(settingPath) || !Array.isArray(value)) return undefined;
@@ -291,6 +302,9 @@ export class Settings {
 		const segments = path.split(".");
 		const value = getByPath(this.#merged, segments);
 		if (value !== undefined) {
+			if (path === "modelRoles" || path === "task.agentModelOverrides") {
+				return shallowStringRecord(value) as SettingValue<P>;
+			}
 			const pathScopedValue = resolvePathScopedStringArray(path, value, this.#cwd);
 			return (pathScopedValue ?? value) as SettingValue<P>;
 		}
@@ -477,7 +491,33 @@ export class Settings {
 	}
 
 	/**
-	 * Set a model role (helper for modelRoles record).
+	 * Replace a null/scalar runtime record reset with leaf tombstones plus the
+	 * selected value, so lower-precedence sibling roles remain reset.
+	 */
+	#overrideRuntimeModelRecord(
+		path: "modelRoles" | "task.agentModelOverrides",
+		currentOverride: unknown,
+		key: string,
+		modelId: string,
+	): void {
+		const next: RawSettings = shallowStringOrNullRecord(currentOverride);
+		const currentOverrideIsRecord =
+			!!currentOverride && typeof currentOverride === "object" && !Array.isArray(currentOverride);
+		if (currentOverride !== undefined && !currentOverrideIsRecord) {
+			const segments = path.split(".");
+			for (const source of [this.#global, this.#project]) {
+				for (const lowerKey of Object.keys(shallowStringRecord(getByPath(source, segments)))) {
+					if (!Object.hasOwn(next, lowerKey)) next[lowerKey] = null;
+				}
+			}
+		}
+		next[key] = modelId;
+		setByPath(this.#overrides, path.split("."), next);
+		this.#rebuildMerged();
+	}
+
+	/**
+	 * Set a model role while keeping a project/profile-shadowed live value aligned.
 	 */
 	setModelRole(role: ModelRole | string, modelId: string): void {
 		const current = shallowStringRecord(getByPath(this.#global, ["modelRoles"]));
@@ -490,16 +530,17 @@ export class Settings {
 
 		this.set("modelRoles", { ...current, [role]: modelId });
 
-		if (updateRuntimeOverride) {
-			this.override("modelRoles", { ...shallowStringRecord(runtimeOverrides), [role]: modelId });
+		if (updateRuntimeOverride || this.get("modelRoles")[role] !== modelId) {
+			this.#overrideRuntimeModelRecord("modelRoles", runtimeOverrides, role, modelId);
 		}
 	}
 	/**
-	 * Set an agent model override while keeping any live runtime override aligned.
+	 * Set an agent model override while keeping any live project/profile override aligned.
 	 *
-	 * Runtime model profiles override `task.agentModelOverrides` for the current
-	 * session. A user-selected role assignment must win immediately in that same
-	 * session, but only the explicit agent change should be persisted.
+	 * Runtime model profiles and project settings can override
+	 * `task.agentModelOverrides` for the current session. A user-selected role
+	 * assignment must win immediately in that same session, but only the explicit
+	 * agent change should be persisted.
 	 */
 	setAgentModelOverride(agentName: string, modelId: string): void {
 		const current = shallowStringRecord(getByPath(this.#global, ["task", "agentModelOverrides"]));
@@ -509,11 +550,8 @@ export class Settings {
 
 		this.set("task.agentModelOverrides", { ...current, [agentName]: modelId });
 
-		if (updateRuntimeOverride) {
-			this.override("task.agentModelOverrides", {
-				...shallowStringRecord(runtimeOverrides),
-				[agentName]: modelId,
-			});
+		if (updateRuntimeOverride || this.get("task.agentModelOverrides")[agentName] !== modelId) {
+			this.#overrideRuntimeModelRecord("task.agentModelOverrides", runtimeOverrides, agentName, modelId);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -945,20 +945,13 @@ export class SelectorController {
 								assignments,
 							});
 							if (!materializedProfile) {
-								const overrides = this.ctx.settings.get("task.agentModelOverrides");
-								const nextOverrides = { ...overrides };
-								let writesOverrides = false;
 								for (const targetRole of targetRoles) {
 									const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetRole];
 									if (target.settingsPath === "modelRoles") {
 										this.ctx.settings.setModelRole(targetRole, value);
 									} else {
-										nextOverrides[targetRole] = value;
-										writesOverrides = true;
+										this.ctx.settings.setAgentModelOverride(targetRole, value);
 									}
-								}
-								if (writesOverrides) {
-									this.ctx.settings.set("task.agentModelOverrides", nextOverrides);
 								}
 							}
 							modelSelector.refreshRoleAssignments({
@@ -1029,10 +1022,7 @@ export class SelectorController {
 								if (target.settingsPath === "modelRoles") {
 									this.ctx.settings.setModelRole(role, value);
 								} else {
-									this.ctx.settings.set("task.agentModelOverrides", {
-										...this.ctx.settings.get("task.agentModelOverrides"),
-										[role]: value,
-									});
+									this.ctx.settings.setAgentModelOverride(role, value);
 								}
 							}
 							modelSelector.refreshRoleAssignments({

--- a/packages/coding-agent/test/model-selector-controller-batch.test.ts
+++ b/packages/coding-agent/test/model-selector-controller-batch.test.ts
@@ -109,6 +109,131 @@ describe("SelectorController model batch assignments", () => {
 		);
 	});
 
+	test("batch selection wins over live project/profile shadows without persisting their extra keys", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.override("task.agentModelOverrides", {
+			executor: "shadow/executor",
+			architect: "shadow/architect",
+			planner: "shadow/planner",
+			critic: "shadow/critic",
+			reviewer: "shadow/reviewer",
+		});
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			roles: ["executor", "architect", "planner", "critic"],
+			thinkingLevel: ThinkingLevel.Low,
+			selector: "provider-a/selected:low",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:low",
+			architect: "provider-a/selected:low",
+			planner: "provider-a/selected:low",
+			critic: "provider-a/selected:low",
+			reviewer: "shadow/reviewer",
+		});
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:low",
+			architect: "provider-a/selected:low",
+			planner: "provider-a/selected:low",
+			critic: "provider-a/selected:low",
+		});
+	});
+
+	test("single role selection wins over a live project/profile shadow without copying siblings", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.override("task.agentModelOverrides", {
+			executor: "shadow/executor",
+			architect: "shadow/architect",
+			planner: "shadow/planner",
+			critic: "shadow/critic",
+			reviewer: "shadow/reviewer",
+		});
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "planner",
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "shadow/executor",
+			architect: "shadow/architect",
+			planner: "provider-a/selected:high",
+			critic: "shadow/critic",
+			reviewer: "shadow/reviewer",
+		});
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/original-executor:low",
+			planner: "provider-a/selected:high",
+		});
+	});
+
+	test("all-targets selection applies coherently over null reset shadows", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.setAgentModelOverride("reviewer", "provider-a/original-reviewer");
+		settings.override("modelRoles", null as never);
+		settings.override("task.agentModelOverrides", null as never);
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			roles: ["default", "executor", "architect", "planner", "critic"],
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(ctx.showError).not.toHaveBeenCalled();
+		expect(settings.getModelRole("default")).toBe("provider-a/selected:high");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:high",
+			architect: "provider-a/selected:high",
+			planner: "provider-a/selected:high",
+			critic: "provider-a/selected:high",
+		});
+		expect(ctx.showStatus).toHaveBeenCalledWith(
+			"All model targets set to provider-a/selected:high for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+		);
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:high",
+			architect: "provider-a/selected:high",
+			planner: "provider-a/selected:high",
+			critic: "provider-a/selected:high",
+			reviewer: "provider-a/original-reviewer",
+		});
+	});
+
+	test("single role selection applies without partial failure over a null reset shadow", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.override("task.agentModelOverrides", null as never);
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "planner",
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(ctx.showError).not.toHaveBeenCalled();
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			planner: "provider-a/selected:high",
+		});
+		expect(ctx.showStatus).toHaveBeenCalledWith("planner agent model: provider-a/selected:high");
+	});
+
 	test("all targets selection writes DEFAULT plus every role-agent override", async () => {
 		const { ctx, settings, setModelCalls } = createControllerContext();
 		const selector = await openSelector(ctx);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -236,6 +236,152 @@ describe("Settings", () => {
 				planner: "user/planner:high",
 			});
 		});
+
+		it("keeps model assignments live when project settings shadow global persistence", async () => {
+			await writeSettings({
+				modelRoles: { default: "global/default" },
+				task: {
+					agentModelOverrides: {
+						executor: "global/executor",
+					},
+				},
+			});
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "config.yml"),
+				YAML.stringify(
+					{
+						modelRoles: { default: "project/default" },
+						task: {
+							agentModelOverrides: {
+								executor: "project/executor",
+								architect: "project/architect",
+								planner: "project/planner",
+								critic: "project/critic",
+							},
+						},
+					},
+					null,
+					2,
+				),
+			);
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.getModelRole("default")).toBe("project/default");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				architect: "project/architect",
+				planner: "project/planner",
+				critic: "project/critic",
+			});
+
+			settings.setModelRole("default", "openai-codex/gpt-5.6-sol:xhigh");
+			for (const role of ["executor", "architect", "planner", "critic"]) {
+				settings.setAgentModelOverride(role, "openai-codex/gpt-5.6-sol:xhigh");
+			}
+
+			expect(settings.getModelRole("default")).toBe("openai-codex/gpt-5.6-sol:xhigh");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "openai-codex/gpt-5.6-sol:xhigh",
+				architect: "openai-codex/gpt-5.6-sol:xhigh",
+				planner: "openai-codex/gpt-5.6-sol:xhigh",
+				critic: "openai-codex/gpt-5.6-sol:xhigh",
+			});
+
+			await settings.flushOrThrow();
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelRoles).toEqual({ default: "openai-codex/gpt-5.6-sol:xhigh" });
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: {
+					executor: "openai-codex/gpt-5.6-sol:xhigh",
+					architect: "openai-codex/gpt-5.6-sol:xhigh",
+					planner: "openai-codex/gpt-5.6-sol:xhigh",
+					critic: "openai-codex/gpt-5.6-sol:xhigh",
+				},
+			});
+
+			settings.clearOverride("modelRoles");
+			settings.clearOverride("task.agentModelOverrides");
+			expect(settings.getModelRole("default")).toBe("project/default");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				architect: "project/architect",
+				planner: "project/planner",
+				critic: "project/critic",
+			});
+		});
+
+		it("treats runtime null model records as resets before applying assignments", () => {
+			const settings = Settings.isolated();
+			settings.override("modelRoles", null as never);
+			settings.override("task.agentModelOverrides", null as never);
+
+			expect(settings.get("modelRoles")).toEqual({});
+			expect(settings.get("task.agentModelOverrides")).toEqual({});
+
+			settings.setModelRole("default", "provider/selected:high");
+			settings.setAgentModelOverride("executor", "provider/selected:high");
+
+			expect(settings.getModelRole("default")).toBe("provider/selected:high");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "provider/selected:high",
+			});
+			expect(settings.getGlobal("modelRoles")).toEqual({ default: "provider/selected:high" });
+			expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+				executor: "provider/selected:high",
+			});
+		});
+
+		it("treats project null model records as resets without partial assignment failures", async () => {
+			await writeSettings({
+				modelRoles: { default: "global/default" },
+				task: { agentModelOverrides: { executor: "global/executor" } },
+			});
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "config.yml"),
+				YAML.stringify(
+					{
+						modelRoles: null,
+						task: { agentModelOverrides: null },
+					},
+					null,
+					2,
+				),
+			);
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("modelRoles")).toEqual({});
+			expect(settings.get("task.agentModelOverrides")).toEqual({});
+
+			settings.setModelRole("default", "provider/selected:high");
+			for (const role of ["executor", "architect", "planner", "critic"]) {
+				settings.setAgentModelOverride(role, "provider/selected:high");
+			}
+
+			expect(settings.getModelRole("default")).toBe("provider/selected:high");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "provider/selected:high",
+				architect: "provider/selected:high",
+				planner: "provider/selected:high",
+				critic: "provider/selected:high",
+			});
+
+			await settings.flushOrThrow();
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelRoles).toEqual({ default: "provider/selected:high" });
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: {
+					executor: "provider/selected:high",
+					architect: "provider/selected:high",
+					planner: "provider/selected:high",
+					critic: "provider/selected:high",
+				},
+			});
+
+			settings.clearOverride("modelRoles");
+			settings.clearOverride("task.agentModelOverrides");
+			expect(settings.get("modelRoles")).toEqual({});
+			expect(settings.get("task.agentModelOverrides")).toEqual({});
+		});
 	});
 
 	describe("migrations", () => {

--- a/packages/coding-agent/test/slash-commands/model.test.ts
+++ b/packages/coding-agent/test/slash-commands/model.test.ts
@@ -111,6 +111,27 @@ describe("/model batch assignments", () => {
 		]);
 	});
 
+	test("assign all-targets replaces null reset shadows without a partial failure", async () => {
+		const { output, runtime, settings } = createRuntime();
+		settings.override("modelRoles", null as never);
+		settings.override("task.agentModelOverrides", null as never);
+
+		await expect(
+			executeAcpBuiltinSlashCommand("/model assign all-targets claude-3-5-sonnet:high", runtime),
+		).resolves.toEqual({ consumed: true });
+
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:high");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet:high",
+			architect: "anthropic/claude-3-5-sonnet:high",
+			planner: "anthropic/claude-3-5-sonnet:high",
+			critic: "anthropic/claude-3-5-sonnet:high",
+		});
+		expect(output).toEqual([
+			"All model targets set to anthropic/claude-3-5-sonnet:high for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+		]);
+	});
+
 	test("assign all-targets materializes an active profile exactly once", async () => {
 		const { output, runtime, session, settings, setActiveModelProfile } = createRuntime();
 		session.model = { provider: "anthropic", id: "current-model" };


### PR DESCRIPTION
## What

- keep typed and interactive `/model` role assignments live when project or profile layers shadow the persisted global values
- normalize `modelRoles` and `task.agentModelOverrides` null/scalar reset values before any role lookup
- preserve whole-record runtime resets with internal leaf tombstones while applying explicitly selected roles
- route interactive single and batch role-agent writes through the same per-role setter as typed `/model`

## Why

This replaces closed PR #2000 and closes its sole owner P1.

On exact #2000 head, `modelRoles: null` or `task.agentModelOverrides: null` caused direct indexing to throw **after** the global record had already changed and persistence had been queued. Interactive batch selection could therefore fail after partial writes and before badge refresh.

The replacement treats null as an empty effective model record. When the null came from the runtime layer, the selected role is combined with null tombstones for lower-precedence sibling keys so a single selection or sequential batch does not accidentally resurrect reset global/project roles. Removing the runtime override reveals the unchanged durable values again.

## Scope

The diff remains limited to six model/settings/TUI files. It contains none of the discarded Settings transaction, profile archive, `models.yml` writer, session lifecycle, SDK, or storage redesign from #1998 and earlier replacements.

## Regression coverage

- exact project-shadow persistence and current-session behavior
- runtime-null and project-null record resets
- typed `/model assign all-targets` over null records
- interactive single-role and all-targets selection over null records
- unrelated durable sibling stays hidden across sequential null-reset batch writes, then reappears unchanged after clearing the runtime override
- non-null project/profile sibling keys remain live without being copied into global persistence

## Verification

- focused Settings, slash `/model`, interactive selector, and role-badge suites: **56 passed**
- ACP model command tests: **14 passed**
- adjacent profile activation and selector suites: **54 passed**
- `bun --cwd=packages/coding-agent run check`
- `bun run check:ts`
- `bun run build:native`
- `bun --cwd=packages/coding-agent run build`
- `bun run ci:test:smoke`
- `git diff --check origin/dev...HEAD`
- independent final architecture review: **CLEAR**; every #2000 owner finding closed

The sole commit is based directly on current `dev` and includes a `Signed-off-by` trailer.