### PR TITLE
fix(model): preserve role resets across runtime rewrites

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Kept `/model` and Agent Control Center role assignments visible and coherent in the running TUI when project settings, opaque runtime resets, configured-binding refresh/removal, profile rollback, cwd changes, or offline model refreshes shadow persisted global roles.
 - Preserved explicit Telegram forum-topic renames as durable user-owned names, immediately re-asserting delayed edits while retaining restart and rename-race recovery (#1910).
 - `gjc resume` now aliases value-less `--resume`, requests confirmation before opening and continues a resumable tail once only; terminal tails open idle, and headless bare resume exits with explicit `--resume <id>` guidance (#1973).
 - Telegram answers to interactive and unattended `ask` prompts now receive a semantic, origin-bound `Selected!` acknowledgement before workflow continuation, with typed multi-select controls, no acknowledgement for toggles/clarifications/skips, at-most-once delivery attempts, and truthful failure/unknown outcomes (#1974).

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -74,7 +74,7 @@ export interface MaterializeModelProfileAssignmentOptions {
 		ModelProfileActivationSession,
 		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile"
 	>;
-	settings: Pick<Settings, "clearOverride" | "get" | "override" | "set">;
+	settings: Pick<Settings, "clearOverride" | "get" | "override" | "set" | "setModelRole" | "setAgentModelOverride">;
 	role: GjcModelAssignmentTargetId;
 	selector: string;
 }
@@ -84,7 +84,7 @@ export interface MaterializeModelProfileAssignmentsOptions {
 		ModelProfileActivationSession,
 		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile"
 	>;
-	settings: Pick<Settings, "clearOverride" | "get" | "override" | "set">;
+	settings: Pick<Settings, "clearOverride" | "get" | "override" | "set" | "setModelRole" | "setAgentModelOverride">;
 	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string> | Partial<Record<GjcModelAssignmentTargetId, string>>;
 }
 
@@ -136,6 +136,11 @@ export function materializeActiveModelProfileAssignment(options: MaterializeMode
 	options.settings.clearOverride("modelProfile.default");
 	options.settings.override("modelRoles", nextModelRoles);
 	options.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
+	if (target.settingsPath === "modelRoles") {
+		options.settings.setModelRole(options.role, options.selector);
+	} else {
+		options.settings.setAgentModelOverride(options.role, options.selector);
+	}
 	options.session.setActiveModelProfile?.(undefined);
 	return true;
 }
@@ -173,6 +178,14 @@ export function materializeActiveModelProfileAssignments(options: MaterializeMod
 	options.settings.clearOverride("modelProfile.default");
 	options.settings.override("modelRoles", nextModelRoles);
 	options.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
+	for (const [role, selector] of materializedAssignments) {
+		const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
+		if (target.settingsPath === "modelRoles") {
+			options.settings.setModelRole(role, selector);
+		} else {
+			options.settings.setAgentModelOverride(role, selector);
+		}
+	}
 	options.session.setActiveModelProfile?.(undefined);
 	return true;
 }

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -149,6 +149,15 @@ function shallowStringRecord(value: unknown): Record<string, string> {
 	}
 	return result;
 }
+function isRecordObject(value: unknown): value is RawSettings {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+type RuntimeModelRecordPath = "modelRoles" | "task.agentModelOverrides";
+
+function isRuntimeModelRecordPath(path: SettingPath | string): path is RuntimeModelRecordPath {
+	return path === "modelRoles" || path === "task.agentModelOverrides";
+}
 
 function resolvePathScopedStringArray(settingPath: SettingPath, value: unknown, cwd: string): string[] | undefined {
 	if (!PATH_SCOPED_ARRAY_SETTINGS.has(settingPath) || !Array.isArray(value)) return undefined;
@@ -204,6 +213,10 @@ export class Settings {
 	#project: RawSettings = {};
 	/** Runtime overrides (not persisted) */
 	#overrides: RawSettings = {};
+	/** Opaque runtime resets that must survive sanitized internal rewrites. */
+	#runtimeModelWholeResets = new Set<RuntimeModelRecordPath>();
+	#runtimeModelResetKeys = new Map<RuntimeModelRecordPath, Set<string>>();
+	#runtimeModelWholeResetReleasedKeys = new Map<RuntimeModelRecordPath, Set<string>>();
 	/** Merged view (global + project + overrides) */
 	#merged: RawSettings = {};
 
@@ -225,7 +238,11 @@ export class Settings {
 
 		if (options.overrides) {
 			for (const [key, value] of Object.entries(options.overrides)) {
-				setByPath(this.#overrides, key.split("."), value);
+				if (isRuntimeModelRecordPath(key)) {
+					this.#storeRuntimeModelRecord(key, value);
+				} else {
+					setByPath(this.#overrides, key.split("."), value);
+				}
 			}
 		}
 	}
@@ -291,6 +308,9 @@ export class Settings {
 		const segments = path.split(".");
 		const value = getByPath(this.#merged, segments);
 		if (value !== undefined) {
+			if (path === "modelRoles" || path === "task.agentModelOverrides") {
+				return shallowStringRecord(value) as SettingValue<P>;
+			}
 			const pathScopedValue = resolvePathScopedStringArray(path, value, this.#cwd);
 			return (pathScopedValue ?? value) as SettingValue<P>;
 		}
@@ -305,7 +325,11 @@ export class Settings {
 	 */
 	getGlobal<P extends SettingPath>(path: P): SettingValue<P> | undefined {
 		const value = getByPath(this.#global, path.split("."));
-		return value === undefined ? undefined : (value as SettingValue<P>);
+		if (value === undefined) return undefined;
+		if (path === "modelRoles" || path === "task.agentModelOverrides") {
+			return shallowStringRecord(value) as SettingValue<P>;
+		}
+		return value as SettingValue<P>;
 	}
 
 	/** Check whether a setting is present in loaded settings/overrides rather than coming from schema defaults. */
@@ -337,6 +361,10 @@ export class Settings {
 	 * Apply runtime overrides (not persisted).
 	 */
 	override<P extends SettingPath>(path: P, value: SettingValue<P>): void {
+		if (isRuntimeModelRecordPath(path)) {
+			this.#replaceRuntimeModelRecord(path, value);
+			return;
+		}
 		const segments = path.split(".");
 		setByPath(this.#overrides, segments, value);
 		this.#rebuildMerged();
@@ -346,11 +374,18 @@ export class Settings {
 	 * Clear a runtime override.
 	 */
 	clearOverride(path: SettingPath): void {
+		const clearedWholeReset = isRuntimeModelRecordPath(path) && this.#runtimeModelWholeResets.delete(path);
+		const clearedResetKeys = isRuntimeModelRecordPath(path) && this.#runtimeModelResetKeys.delete(path);
+		const clearedReleasedKeys =
+			isRuntimeModelRecordPath(path) && this.#runtimeModelWholeResetReleasedKeys.delete(path);
 		const segments = path.split(".");
 		let current = this.#overrides;
 		for (let i = 0; i < segments.length - 1; i++) {
 			const segment = segments[i];
-			if (!(segment in current)) return;
+			if (!(segment in current)) {
+				if (clearedWholeReset || clearedResetKeys || clearedReleasedKeys) this.#rebuildMerged();
+				return;
+			}
 			current = current[segment] as RawSettings;
 		}
 		delete current[segments[segments.length - 1]];
@@ -403,6 +438,13 @@ export class Settings {
 		cloned.#global = structuredClone(this.#global);
 		cloned.#project = this.#persist ? await cloned.#loadProjectSettings() : structuredClone(this.#project);
 		cloned.#overrides = structuredClone(this.#overrides);
+		cloned.#runtimeModelWholeResets = new Set(this.#runtimeModelWholeResets);
+		cloned.#runtimeModelResetKeys = new Map(
+			[...this.#runtimeModelResetKeys].map(([modelPath, keys]) => [modelPath, new Set(keys)]),
+		);
+		cloned.#runtimeModelWholeResetReleasedKeys = new Map(
+			[...this.#runtimeModelWholeResetReleasedKeys].map(([modelPath, keys]) => [modelPath, new Set(keys)]),
+		);
 		cloned.#rebuildMerged();
 		cloned.#fireAllHooks();
 		return cloned;
@@ -477,7 +519,68 @@ export class Settings {
 	}
 
 	/**
-	 * Set a model role (helper for modelRoles record).
+	 * Store a runtime model record without exposing malformed/reset leaves through
+	 * public reads. Whole-record resets and reset-valued leaves live in separate
+	 * metadata so sanitized binding/profile rewrites cannot erase them.
+	 */
+	#storeRuntimeModelRecord(path: RuntimeModelRecordPath, value: unknown): void {
+		if (value === undefined) {
+			setByPath(this.#overrides, path.split("."), undefined);
+			return;
+		}
+		setByPath(this.#overrides, path.split("."), shallowStringRecord(value));
+
+		if (!isRecordObject(value)) {
+			this.#runtimeModelWholeResets.add(path);
+			this.#runtimeModelResetKeys.delete(path);
+			this.#runtimeModelWholeResetReleasedKeys.delete(path);
+			return;
+		}
+
+		const resetKeys = new Set(this.#runtimeModelResetKeys.get(path));
+		const releasedKeys = this.#runtimeModelWholeResetReleasedKeys.get(path);
+		for (const [key, item] of Object.entries(value)) {
+			if (typeof item !== "string" && item !== undefined) {
+				resetKeys.add(key);
+				releasedKeys?.delete(key);
+			}
+		}
+		if (resetKeys.size > 0) {
+			this.#runtimeModelResetKeys.set(path, resetKeys);
+		} else {
+			this.#runtimeModelResetKeys.delete(path);
+		}
+	}
+
+	/**
+	 * Replace visible runtime strings while preserving opaque reset state. This
+	 * path is used by binding/profile refreshes that only see sanitized records.
+	 */
+	#replaceRuntimeModelRecord(path: RuntimeModelRecordPath, value: unknown): void {
+		this.#storeRuntimeModelRecord(path, value);
+		this.#rebuildMerged();
+	}
+
+	/** Apply one explicit user assignment over any reset for that leaf. */
+	#overrideRuntimeModelRecord(path: RuntimeModelRecordPath, key: string, modelId: string): void {
+		const next = shallowStringRecord(getByPath(this.#overrides, path.split(".")));
+		next[key] = modelId;
+		const resetKeys = this.#runtimeModelResetKeys.get(path);
+		if (resetKeys) {
+			resetKeys.delete(key);
+			if (resetKeys.size === 0) this.#runtimeModelResetKeys.delete(path);
+		}
+		if (this.#runtimeModelWholeResets.has(path)) {
+			const releasedKeys = this.#runtimeModelWholeResetReleasedKeys.get(path) ?? new Set<string>();
+			releasedKeys.add(key);
+			this.#runtimeModelWholeResetReleasedKeys.set(path, releasedKeys);
+		}
+		setByPath(this.#overrides, path.split("."), next);
+		this.#rebuildMerged();
+	}
+
+	/**
+	 * Set a model role while keeping a project/profile-shadowed live value aligned.
 	 */
 	setModelRole(role: ModelRole | string, modelId: string): void {
 		const current = shallowStringRecord(getByPath(this.#global, ["modelRoles"]));
@@ -490,16 +593,17 @@ export class Settings {
 
 		this.set("modelRoles", { ...current, [role]: modelId });
 
-		if (updateRuntimeOverride) {
-			this.override("modelRoles", { ...shallowStringRecord(runtimeOverrides), [role]: modelId });
+		if (updateRuntimeOverride || this.get("modelRoles")[role] !== modelId) {
+			this.#overrideRuntimeModelRecord("modelRoles", role, modelId);
 		}
 	}
 	/**
-	 * Set an agent model override while keeping any live runtime override aligned.
+	 * Set an agent model override while keeping any live project/profile override aligned.
 	 *
-	 * Runtime model profiles override `task.agentModelOverrides` for the current
-	 * session. A user-selected role assignment must win immediately in that same
-	 * session, but only the explicit agent change should be persisted.
+	 * Runtime model profiles and project settings can override
+	 * `task.agentModelOverrides` for the current session. A user-selected role
+	 * assignment must win immediately in that same session, but only the explicit
+	 * agent change should be persisted.
 	 */
 	setAgentModelOverride(agentName: string, modelId: string): void {
 		const current = shallowStringRecord(getByPath(this.#global, ["task", "agentModelOverrides"]));
@@ -509,11 +613,24 @@ export class Settings {
 
 		this.set("task.agentModelOverrides", { ...current, [agentName]: modelId });
 
-		if (updateRuntimeOverride) {
-			this.override("task.agentModelOverrides", {
-				...shallowStringRecord(runtimeOverrides),
-				[agentName]: modelId,
-			});
+		if (updateRuntimeOverride || this.get("task.agentModelOverrides")[agentName] !== modelId) {
+			this.#overrideRuntimeModelRecord("task.agentModelOverrides", agentName, modelId);
+		}
+	}
+
+	/** Clear one persisted agent assignment and any matching live string override. */
+	clearAgentModelOverride(agentName: string): void {
+		const current = shallowStringRecord(getByPath(this.#global, ["task", "agentModelOverrides"]));
+		if (Object.hasOwn(current, agentName)) {
+			delete current[agentName];
+			this.set("task.agentModelOverrides", current);
+		}
+
+		const runtimeOverrides = getByPath(this.#overrides, ["task", "agentModelOverrides"]);
+		if (isRecordObject(runtimeOverrides) && typeof runtimeOverrides[agentName] === "string") {
+			const next = shallowStringRecord(runtimeOverrides);
+			delete next[agentName];
+			this.override("task.agentModelOverrides", next);
 		}
 	}
 
@@ -536,13 +653,9 @@ export class Settings {
 	 * Override model roles (helper for modelRoles record).
 	 */
 	overrideModelRoles(roles: ReadOnlyDict<string>): void {
-		const next = shallowStringRecord(getByPath(this.#overrides, ["modelRoles"]));
 		for (const [role, modelId] of Object.entries(roles)) {
-			if (modelId) {
-				next[role] = modelId;
-			}
+			if (modelId) this.#overrideRuntimeModelRecord("modelRoles", role, modelId);
 		}
-		this.override("modelRoles", next);
 	}
 
 	/**
@@ -879,8 +992,34 @@ export class Settings {
 	// ─────────────────────────────────────────────────────────────────────────
 
 	#rebuildMerged(): void {
-		this.#merged = this.#deepMerge(this.#deepMerge({}, this.#global), this.#project);
-		this.#merged = this.#deepMerge(this.#merged, this.#overrides);
+		const lower = this.#deepMerge(this.#deepMerge({}, this.#global), this.#project);
+		this.#merged = this.#deepMerge(lower, this.#overrides);
+
+		for (const modelPath of ["modelRoles", "task.agentModelOverrides"] as const) {
+			const segments = modelPath.split(".");
+			const lowerValue = getByPath(lower, segments);
+			const runtimeValue = getByPath(this.#overrides, segments);
+			const resetKeys = this.#runtimeModelResetKeys.get(modelPath);
+			const hasRuntimeState =
+				runtimeValue !== undefined || this.#runtimeModelWholeResets.has(modelPath) || resetKeys !== undefined;
+			if (lowerValue === undefined && !hasRuntimeState) continue;
+
+			const lowerRecord = shallowStringRecord(lowerValue);
+			const effective: Record<string, string> = {};
+			if (this.#runtimeModelWholeResets.has(modelPath)) {
+				for (const key of this.#runtimeModelWholeResetReleasedKeys.get(modelPath) ?? []) {
+					const value = lowerRecord[key];
+					if (value !== undefined) effective[key] = value;
+				}
+			} else {
+				Object.assign(effective, lowerRecord);
+				if (resetKeys) {
+					for (const key of resetKeys) delete effective[key];
+				}
+			}
+			Object.assign(effective, shallowStringRecord(runtimeValue));
+			setByPath(this.#merged, segments, effective);
+		}
 	}
 
 	#fireAllHooks(): void {

--- a/packages/coding-agent/src/modes/components/agent-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/agent-dashboard.ts
@@ -465,16 +465,13 @@ export class AgentDashboard extends Container {
 		this.#settingsManager.set("task.disabledAgents", disabled);
 	}
 
-	#persistModelOverrides(): void {
+	#persistModelOverride(agentName: string, value: string | undefined): void {
 		if (!this.#settingsManager) return;
-		const overrides: Record<string, string> = {};
-		for (const agent of this.#allAgents) {
-			const value = agent.overrideModel?.trim();
-			if (value) {
-				overrides[agent.name] = value;
-			}
+		if (value) {
+			this.#settingsManager.setAgentModelOverride(agentName, value);
+		} else {
+			this.#settingsManager.clearAgentModelOverride(agentName);
 		}
-		this.#settingsManager.set("task.agentModelOverrides", overrides);
 	}
 
 	#toggleSelectedAgent(): void {
@@ -504,9 +501,10 @@ export class AgentDashboard extends Container {
 		if (!this.#editingAgentName) return;
 		const selected = this.#allAgents.find(agent => agent.name === this.#editingAgentName);
 		if (!selected) return;
-		const value = rawValue.trim();
-		selected.overrideModel = value || undefined;
-		this.#persistModelOverrides();
+		const value = rawValue.trim() || undefined;
+		this.#persistModelOverride(selected.name, value);
+		selected.overrideModel =
+			this.#settingsManager?.get("task.agentModelOverrides")[selected.name]?.trim() || undefined;
 		this.#editingAgentName = null;
 		this.#editInput = null;
 		this.#applyFilters();

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -597,6 +597,8 @@ export class ModelSelectorComponent extends Container {
 		} else {
 			// Reload config and cached discovery state without blocking on live provider refresh
 			await this.#modelRegistry.refresh("offline");
+			this.#roles = {};
+			this.#loadRoleModels();
 
 			// Check for models.json errors
 			const loadError = this.#modelRegistry.getError();

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -945,20 +945,13 @@ export class SelectorController {
 								assignments,
 							});
 							if (!materializedProfile) {
-								const overrides = this.ctx.settings.get("task.agentModelOverrides");
-								const nextOverrides = { ...overrides };
-								let writesOverrides = false;
 								for (const targetRole of targetRoles) {
 									const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetRole];
 									if (target.settingsPath === "modelRoles") {
 										this.ctx.settings.setModelRole(targetRole, value);
 									} else {
-										nextOverrides[targetRole] = value;
-										writesOverrides = true;
+										this.ctx.settings.setAgentModelOverride(targetRole, value);
 									}
-								}
-								if (writesOverrides) {
-									this.ctx.settings.set("task.agentModelOverrides", nextOverrides);
 								}
 							}
 							modelSelector.refreshRoleAssignments({
@@ -1029,10 +1022,7 @@ export class SelectorController {
 								if (target.settingsPath === "modelRoles") {
 									this.ctx.settings.setModelRole(role, value);
 								} else {
-									this.ctx.settings.set("task.agentModelOverrides", {
-										...this.ctx.settings.get("task.agentModelOverrides"),
-										[role]: value,
-									});
+									this.ctx.settings.setAgentModelOverride(role, value);
 								}
 							}
 							modelSelector.refreshRoleAssignments({

--- a/packages/coding-agent/test/agent-dashboard-model-override.test.ts
+++ b/packages/coding-agent/test/agent-dashboard-model-override.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentDashboard } from "@gajae-code/coding-agent/modes/components/agent-dashboard";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { Snowflake } from "@gajae-code/utils";
+
+let testTheme = await getThemeByName("red-claw");
+const testDirs: string[] = [];
+
+function typeText(dashboard: AgentDashboard, text: string): void {
+	for (const char of text) dashboard.handleInput(char);
+}
+
+describe("AgentDashboard model overrides", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("red-claw");
+		if (!testTheme) throw new Error("Failed to load test theme");
+		setThemeInstance(testTheme);
+	});
+
+	afterEach(() => {
+		for (const dir of testDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	test("edits and clears one agent without dropping runtime resets or durable siblings", async () => {
+		const cwd = path.join(os.tmpdir(), `agent-dashboard-model-${Snowflake.next()}`);
+		testDirs.push(cwd);
+		fs.mkdirSync(cwd, { recursive: true });
+
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", {
+			executor: "durable/executor",
+			planner: "durable/planner",
+		});
+		settings.override("task.agentModelOverrides", null as never);
+
+		const dashboard = await AgentDashboard.create(cwd, settings, 24);
+		typeText(dashboard, "executor");
+		dashboard.handleInput("\n");
+		const selected = "provider/selected:high";
+		typeText(dashboard, selected);
+		dashboard.handleInput("\n");
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: selected });
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			executor: selected,
+			planner: "durable/planner",
+		});
+
+		dashboard.handleInput("\n");
+		for (let i = 0; i < selected.length; i++) dashboard.handleInput("\x7f");
+		dashboard.handleInput("\n");
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({});
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			planner: "durable/planner",
+		});
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			planner: "durable/planner",
+		});
+	});
+});

--- a/packages/coding-agent/test/custom-model-preset-creation.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-creation.test.ts
@@ -684,6 +684,57 @@ describe("custom model preset creation", () => {
 		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });
 		expect(activeProfiles.at(-1)).toBe("custom-default");
 	});
+	it("preserves malformed runtime resets through deletion materialization rollback", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "custom-default",
+			displayName: "Custom Default",
+			requiredProviders: ["my-oai"],
+			modelMapping: {
+				default: "my-oai/gpt-custom:low",
+				executor: "my-oai/gpt-custom",
+			},
+			source: "user",
+		};
+		const settings = Settings.isolated({
+			"modelProfile.default": "custom-default",
+		});
+		settings.set("task.agentModelOverrides", { critic: "durable/critic" });
+		settings.override("task.agentModelOverrides", { executor: false } as never);
+		const session = {
+			model: currentModel("other", "active"),
+			thinkingLevel: undefined,
+			sessionId: "session",
+			setActiveModelProfile: () => {},
+			getActiveModelProfile: () => "custom-default",
+		};
+		const flushSpy = spyOn(settings, "flush").mockRejectedValueOnce(new Error("flush failed"));
+
+		try {
+			await expect(
+				materializeModelProfileForDeletion({
+					session,
+					settings,
+					modelRegistry: createRegistry([[customProfile.name, customProfile]]),
+					profileName: "custom-default",
+				}),
+			).rejects.toThrow("flush failed");
+		} finally {
+			flushSpy.mockRestore();
+		}
+
+		settings.set("task.agentModelOverrides", {
+			critic: "durable/critic",
+			executor: "durable/executor-added-after-rollback",
+		});
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			critic: "durable/critic",
+		});
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			critic: "durable/critic",
+			executor: "durable/executor-added-after-rollback",
+		});
+	});
 	it("restores a deleted custom preset when post-delete notification fails", async () => {
 		const unsafeDisplayName = "Custom\x1b[31m Default\x1b[0m\nRestored";
 		const profiles = new Map<string, ModelProfileDefinition>([

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -230,6 +230,30 @@ describe("model profile activation", () => {
 		expect(settings.get("modelProfile.default")).toBeUndefined();
 		expect(session.getActiveModelProfile()).toBeUndefined();
 	});
+	test("materialized explicit assignments release only their whole-reset leaves", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({ "modelProfile.default": "profile-a" });
+		settings.override("task.agentModelOverrides", null as never);
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+
+		const materialized = materializeActiveModelProfileAssignment({
+			session,
+			settings,
+			role: "executor",
+			selector: "provider-c/executor:medium",
+		});
+		expect(materialized).toBe(true);
+		settings.clearAgentModelOverride("executor");
+		settings.set("task.agentModelOverrides", {
+			executor: "durable/executor-added-after-materialization",
+			planner: "durable/planner-added-after-materialization",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "durable/executor-added-after-materialization",
+			architect: "provider-a/architect",
+		});
+	});
 
 	test("materializing a default override stores the selected default and clears the profile", async () => {
 		const session = fakeSession();

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -2710,6 +2710,95 @@ describe("ModelRegistry", () => {
 		expect(Settings.instance.get("task.agentModelOverrides").executor).toBe("proxy/executor-selector");
 	});
 
+	test("preserves runtime record resets across binding refresh and role helper writes", async () => {
+		const settings = await Settings.init({ inMemory: true });
+		settings.set("modelRoles", {
+			default: "durable/default",
+			smol: "durable/smol",
+			slow: "durable/slow",
+		});
+		settings.set("task.agentModelOverrides", {
+			executor: "durable/executor",
+			reviewer: "durable/reviewer",
+		});
+		settings.override("modelRoles", null as never);
+		settings.override("task.agentModelOverrides", null as never);
+		settings.setModelRole("default", "selected/default");
+		settings.setAgentModelOverride("executor", "selected/executor");
+
+		writeRawModelsConfig({ providers: {} });
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		registry.applyConfiguredModelBindings(settings);
+		await registry.refresh("offline");
+
+		expect(settings.get("modelRoles")).toEqual({ default: "selected/default" });
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "selected/executor",
+		});
+
+		settings.overrideModelRoles({ plan: "selected/plan" });
+		expect(settings.get("modelRoles")).toEqual({
+			default: "selected/default",
+			plan: "selected/plan",
+		});
+
+		settings.clearOverride("modelRoles");
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("modelRoles")).toEqual({
+			default: "selected/default",
+			smol: "durable/smol",
+			slow: "durable/slow",
+		});
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "selected/executor",
+			reviewer: "durable/reviewer",
+		});
+	});
+	test("restores opaque resets instead of durable bindings after configured bindings are removed", async () => {
+		const settings = await Settings.init({ inMemory: true });
+		settings.set("modelRoles", { default: "durable/default" });
+		settings.set("task.agentModelOverrides", { executor: "durable/executor" });
+		settings.override("modelRoles", null as never);
+		settings.override("task.agentModelOverrides", { executor: false } as never);
+
+		writeRawModelsConfig({
+			modelBindings: {
+				modelRoles: { default: "proxy/local-selector:high" },
+				agentModelOverrides: { executor: "proxy/executor-selector" },
+			},
+			providers: {
+				proxy: providerConfig(
+					"https://proxy.example/v1",
+					[{ id: "local-selector", reasoning: true }],
+					"openai-completions",
+				),
+			},
+		});
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		registry.applyConfiguredModelBindings(settings);
+		expect(settings.getModelRole("default")).toBe("proxy/local-selector:high");
+		expect(settings.get("task.agentModelOverrides").executor).toBe("proxy/executor-selector");
+
+		writeRawModelsConfig({
+			providers: {
+				proxy: providerConfig(
+					"https://proxy.example/v1",
+					[{ id: "local-selector", reasoning: true }],
+					"openai-completions",
+				),
+			},
+		});
+		await Bun.sleep(5);
+		await registry.refresh("offline");
+		expect(settings.get("modelRoles")).toEqual({});
+		expect(settings.get("task.agentModelOverrides")).toEqual({});
+
+		settings.clearOverride("modelRoles");
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.getModelRole("default")).toBe("durable/default");
+		expect(settings.get("task.agentModelOverrides").executor).toBe("durable/executor");
+	});
+
 	test("defers model bindings until settings are initialized", () => {
 		writeRawModelsConfig({
 			modelBindings: {

--- a/packages/coding-agent/test/model-selector-controller-batch.test.ts
+++ b/packages/coding-agent/test/model-selector-controller-batch.test.ts
@@ -109,6 +109,131 @@ describe("SelectorController model batch assignments", () => {
 		);
 	});
 
+	test("batch selection wins over live project/profile shadows without persisting their extra keys", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.override("task.agentModelOverrides", {
+			executor: "shadow/executor",
+			architect: "shadow/architect",
+			planner: "shadow/planner",
+			critic: "shadow/critic",
+			reviewer: "shadow/reviewer",
+		});
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			roles: ["executor", "architect", "planner", "critic"],
+			thinkingLevel: ThinkingLevel.Low,
+			selector: "provider-a/selected:low",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:low",
+			architect: "provider-a/selected:low",
+			planner: "provider-a/selected:low",
+			critic: "provider-a/selected:low",
+			reviewer: "shadow/reviewer",
+		});
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:low",
+			architect: "provider-a/selected:low",
+			planner: "provider-a/selected:low",
+			critic: "provider-a/selected:low",
+		});
+	});
+
+	test("single role selection wins over a live project/profile shadow without copying siblings", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.override("task.agentModelOverrides", {
+			executor: "shadow/executor",
+			architect: "shadow/architect",
+			planner: "shadow/planner",
+			critic: "shadow/critic",
+			reviewer: "shadow/reviewer",
+		});
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "planner",
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "shadow/executor",
+			architect: "shadow/architect",
+			planner: "provider-a/selected:high",
+			critic: "shadow/critic",
+			reviewer: "shadow/reviewer",
+		});
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/original-executor:low",
+			planner: "provider-a/selected:high",
+		});
+	});
+
+	test("all-targets selection applies coherently over null reset shadows", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.setAgentModelOverride("reviewer", "provider-a/original-reviewer");
+		settings.override("modelRoles", null as never);
+		settings.override("task.agentModelOverrides", null as never);
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			roles: ["default", "executor", "architect", "planner", "critic"],
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(ctx.showError).not.toHaveBeenCalled();
+		expect(settings.getModelRole("default")).toBe("provider-a/selected:high");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:high",
+			architect: "provider-a/selected:high",
+			planner: "provider-a/selected:high",
+			critic: "provider-a/selected:high",
+		});
+		expect(ctx.showStatus).toHaveBeenCalledWith(
+			"All model targets set to provider-a/selected:high for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+		);
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:high",
+			architect: "provider-a/selected:high",
+			planner: "provider-a/selected:high",
+			critic: "provider-a/selected:high",
+			reviewer: "provider-a/original-reviewer",
+		});
+	});
+
+	test("single role selection applies without partial failure over a null reset shadow", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.override("task.agentModelOverrides", null as never);
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "planner",
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(ctx.showError).not.toHaveBeenCalled();
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			planner: "provider-a/selected:high",
+		});
+		expect(ctx.showStatus).toHaveBeenCalledWith("planner agent model: provider-a/selected:high");
+	});
+
 	test("all targets selection writes DEFAULT plus every role-agent override", async () => {
 		const { ctx, settings, setModelCalls } = createControllerContext();
 		const selector = await openSelector(ctx);

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -199,6 +199,71 @@ describe("ModelSelector canonical model selection", () => {
 		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}`);
 	});
 
+	test("keeps reset role badges coherent after offline binding refresh", async () => {
+		installTestTheme();
+		const selectedModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const hiddenModel = getBundledModel("anthropic", "claude-haiku-4-5");
+		if (!selectedModel || !hiddenModel) throw new Error("Expected bundled Anthropic models");
+
+		const selectedSelector = `${selectedModel.provider}/${selectedModel.id}`;
+		const hiddenSelector = `${hiddenModel.provider}/${hiddenModel.id}`;
+		const settings = Settings.isolated();
+		settings.set("modelRoles", { default: selectedSelector });
+		settings.set("task.agentModelOverrides", {
+			executor: selectedSelector,
+			architect: hiddenSelector,
+		});
+		settings.override("modelRoles", null as never);
+		settings.override("task.agentModelOverrides", null as never);
+		settings.setModelRole("default", selectedSelector);
+		settings.setAgentModelOverride("executor", selectedSelector);
+
+		const refreshRelease = Promise.withResolvers<void>();
+		const refreshFinished = Promise.withResolvers<void>();
+		const refresh = vi.fn(async (strategy: string) => {
+			expect(strategy).toBe("offline");
+			await refreshRelease.promise;
+			settings.override("modelRoles", { default: `${selectedSelector}:high` });
+			settings.override("task.agentModelOverrides", { executor: `${selectedSelector}:high` });
+			refreshFinished.resolve();
+		});
+		const modelRegistry = {
+			refresh,
+			getAll: () => [selectedModel, hiddenModel],
+			getAvailable: () => [selectedModel, hiddenModel],
+			getError: () => undefined,
+			getDiscoverableProviders: () => [],
+			getCanonicalModels: () => [],
+			resolveCanonicalModel: () => undefined,
+		} as unknown as ModelRegistry;
+		const ui = { requestRender: vi.fn() } as unknown as TUI;
+		const selector = new ModelSelectorComponent(
+			ui,
+			selectedModel,
+			settings,
+			modelRegistry,
+			[],
+			() => {},
+			() => {},
+			{ temporaryOnly: true },
+		);
+
+		await Bun.sleep(0);
+		expect(refresh).toHaveBeenCalledTimes(1);
+		refreshRelease.resolve();
+		await refreshFinished.promise;
+		await Bun.sleep(0);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("DEFAULT (high)");
+		expect(rendered).toContain("EXECUTOR (high)");
+		expect(rendered).not.toMatch(/ARCHITECT \((?:inherit|off|minimal|low|medium|high|xhigh|max)\)/);
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: `${selectedSelector}:high`,
+		});
+	});
+
 	test("selects role-agent assignment without using stale task role", async () => {
 		installTestTheme();
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -236,6 +236,310 @@ describe("Settings", () => {
 				planner: "user/planner:high",
 			});
 		});
+
+		it("keeps model assignments live when project settings shadow global persistence", async () => {
+			await writeSettings({
+				modelRoles: { default: "global/default" },
+				task: {
+					agentModelOverrides: {
+						executor: "global/executor",
+					},
+				},
+			});
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "config.yml"),
+				YAML.stringify(
+					{
+						modelRoles: { default: "project/default" },
+						task: {
+							agentModelOverrides: {
+								executor: "project/executor",
+								architect: "project/architect",
+								planner: "project/planner",
+								critic: "project/critic",
+							},
+						},
+					},
+					null,
+					2,
+				),
+			);
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.getModelRole("default")).toBe("project/default");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				architect: "project/architect",
+				planner: "project/planner",
+				critic: "project/critic",
+			});
+
+			settings.setModelRole("default", "openai-codex/gpt-5.6-sol:xhigh");
+			for (const role of ["executor", "architect", "planner", "critic"]) {
+				settings.setAgentModelOverride(role, "openai-codex/gpt-5.6-sol:xhigh");
+			}
+
+			expect(settings.getModelRole("default")).toBe("openai-codex/gpt-5.6-sol:xhigh");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "openai-codex/gpt-5.6-sol:xhigh",
+				architect: "openai-codex/gpt-5.6-sol:xhigh",
+				planner: "openai-codex/gpt-5.6-sol:xhigh",
+				critic: "openai-codex/gpt-5.6-sol:xhigh",
+			});
+
+			await settings.flushOrThrow();
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelRoles).toEqual({ default: "openai-codex/gpt-5.6-sol:xhigh" });
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: {
+					executor: "openai-codex/gpt-5.6-sol:xhigh",
+					architect: "openai-codex/gpt-5.6-sol:xhigh",
+					planner: "openai-codex/gpt-5.6-sol:xhigh",
+					critic: "openai-codex/gpt-5.6-sol:xhigh",
+				},
+			});
+
+			settings.clearOverride("modelRoles");
+			settings.clearOverride("task.agentModelOverrides");
+			expect(settings.getModelRole("default")).toBe("project/default");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				architect: "project/architect",
+				planner: "project/planner",
+				critic: "project/critic",
+			});
+		});
+
+		it("treats runtime null model records as resets before applying assignments", () => {
+			const settings = Settings.isolated();
+			settings.override("modelRoles", null as never);
+			settings.override("task.agentModelOverrides", null as never);
+
+			expect(settings.get("modelRoles")).toEqual({});
+			expect(settings.get("task.agentModelOverrides")).toEqual({});
+
+			settings.setModelRole("default", "provider/selected:high");
+			settings.setAgentModelOverride("executor", "provider/selected:high");
+
+			expect(settings.getModelRole("default")).toBe("provider/selected:high");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "provider/selected:high",
+			});
+			expect(settings.getGlobal("modelRoles")).toEqual({ default: "provider/selected:high" });
+			expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+				executor: "provider/selected:high",
+			});
+		});
+		it("keeps whole-record runtime resets opaque across later lower layers and cwd clones", async () => {
+			await writeSettings({
+				modelRoles: { default: "global/default" },
+				task: { agentModelOverrides: { executor: "global/executor" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.override("modelRoles", null as never);
+			settings.override("task.agentModelOverrides", [] as never);
+			settings.set("modelRoles", {
+				default: "global/default",
+				smol: "global/smol-added-after-reset",
+			});
+			settings.set("task.agentModelOverrides", {
+				executor: "global/executor",
+				planner: "global/planner-added-after-reset",
+			});
+
+			const cloneDir = path.join(testDir, "clone-project");
+			fs.mkdirSync(getProjectAgentDir(cloneDir), { recursive: true });
+			await Bun.write(
+				path.join(getProjectAgentDir(cloneDir), "config.yml"),
+				YAML.stringify(
+					{
+						modelRoles: { slow: "project/slow-added-after-reset" },
+						task: { agentModelOverrides: { critic: "project/critic-added-after-reset" } },
+					},
+					null,
+					2,
+				),
+			);
+
+			const cloned = await settings.cloneForCwd(cloneDir);
+			cloned.override("modelRoles", cloned.get("modelRoles"));
+			cloned.override("task.agentModelOverrides", cloned.get("task.agentModelOverrides"));
+			expect(cloned.get("modelRoles")).toEqual({});
+			expect(cloned.get("task.agentModelOverrides")).toEqual({});
+
+			cloned.clearOverride("modelRoles");
+			cloned.clearOverride("task.agentModelOverrides");
+			expect(cloned.get("modelRoles")).toEqual({
+				default: "global/default",
+				smol: "global/smol-added-after-reset",
+				slow: "project/slow-added-after-reset",
+			});
+			expect(cloned.get("task.agentModelOverrides")).toEqual({
+				executor: "global/executor",
+				planner: "global/planner-added-after-reset",
+				critic: "project/critic-added-after-reset",
+			});
+		});
+		it("releases only explicitly assigned leaves from a whole-record reset", () => {
+			const settings = Settings.isolated();
+			settings.set("task.agentModelOverrides", {
+				executor: "durable/executor",
+				planner: "durable/planner",
+			});
+			settings.override("task.agentModelOverrides", null as never);
+
+			settings.setAgentModelOverride("executor", "selected/executor");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "selected/executor",
+			});
+			settings.clearAgentModelOverride("executor");
+			settings.set("task.agentModelOverrides", {
+				executor: "durable/executor",
+				planner: "durable/planner",
+				critic: "durable/critic-added-later",
+			});
+
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "durable/executor",
+			});
+		});
+
+		it("keeps malformed runtime leaves hidden when lower-layer siblings change", () => {
+			const settings = Settings.isolated();
+			settings.set("task.agentModelOverrides", {
+				executor: "durable/executor",
+				planner: "durable/planner",
+			});
+			settings.override("task.agentModelOverrides", { executor: false } as never);
+			settings.set("task.agentModelOverrides", {
+				executor: "durable/executor-updated",
+				planner: "durable/planner",
+				critic: "durable/critic-added-after-reset",
+			});
+			settings.override("task.agentModelOverrides", settings.get("task.agentModelOverrides"));
+
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				planner: "durable/planner",
+				critic: "durable/critic-added-after-reset",
+			});
+			settings.clearOverride("task.agentModelOverrides");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "durable/executor-updated",
+				planner: "durable/planner",
+				critic: "durable/critic-added-after-reset",
+			});
+		});
+
+		it("treats project null model records as resets without partial assignment failures", async () => {
+			await writeSettings({
+				modelRoles: { default: "global/default" },
+				task: { agentModelOverrides: { executor: "global/executor" } },
+			});
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "config.yml"),
+				YAML.stringify(
+					{
+						modelRoles: null,
+						task: { agentModelOverrides: null },
+					},
+					null,
+					2,
+				),
+			);
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("modelRoles")).toEqual({});
+			expect(settings.get("task.agentModelOverrides")).toEqual({});
+
+			settings.setModelRole("default", "provider/selected:high");
+			for (const role of ["executor", "architect", "planner", "critic"]) {
+				settings.setAgentModelOverride(role, "provider/selected:high");
+			}
+
+			expect(settings.getModelRole("default")).toBe("provider/selected:high");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "provider/selected:high",
+				architect: "provider/selected:high",
+				planner: "provider/selected:high",
+				critic: "provider/selected:high",
+			});
+
+			await settings.flushOrThrow();
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelRoles).toEqual({ default: "provider/selected:high" });
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: {
+					executor: "provider/selected:high",
+					architect: "provider/selected:high",
+					planner: "provider/selected:high",
+					critic: "provider/selected:high",
+				},
+			});
+
+			settings.clearOverride("modelRoles");
+			settings.clearOverride("task.agentModelOverrides");
+			expect(settings.get("modelRoles")).toEqual({});
+			expect(settings.get("task.agentModelOverrides")).toEqual({});
+		});
+
+		it("preserves malformed reset leaves across unrelated runtime record writes", () => {
+			const settings = Settings.isolated();
+			settings.set("modelRoles", {
+				default: "durable/default",
+				smol: "durable/smol",
+				slow: "durable/slow",
+			});
+			settings.set("task.agentModelOverrides", {
+				executor: "durable/executor",
+				planner: "durable/planner",
+			});
+			settings.override("modelRoles", { smol: false, slow: [] } as never);
+			settings.override("task.agentModelOverrides", { executor: false } as never);
+
+			settings.setAgentModelOverride("planner", "selected/planner");
+			settings.overrideModelRoles({ plan: "selected/plan" });
+			settings.override("modelRoles", settings.get("modelRoles"));
+			settings.override("task.agentModelOverrides", settings.get("task.agentModelOverrides"));
+
+			expect(settings.get("modelRoles")).toEqual({
+				default: "durable/default",
+				plan: "selected/plan",
+			});
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				planner: "selected/planner",
+			});
+
+			settings.clearOverride("modelRoles");
+			settings.clearOverride("task.agentModelOverrides");
+			expect(settings.get("modelRoles")).toEqual({
+				default: "durable/default",
+				smol: "durable/smol",
+				slow: "durable/slow",
+			});
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "durable/executor",
+				planner: "selected/planner",
+			});
+		});
+
+		it("sanitizes malformed model leaves from global public reads", () => {
+			const settings = Settings.isolated();
+			settings.set("modelRoles", {
+				default: "valid/default",
+				smol: false,
+			} as never);
+			settings.set("task.agentModelOverrides", {
+				executor: false,
+				planner: "valid/planner",
+			} as never);
+
+			expect(settings.getGlobal("modelRoles")).toEqual({
+				default: "valid/default",
+			});
+			expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+				planner: "valid/planner",
+			});
+		});
 	});
 
 	describe("migrations", () => {

--- a/packages/coding-agent/test/slash-commands/model.test.ts
+++ b/packages/coding-agent/test/slash-commands/model.test.ts
@@ -111,6 +111,27 @@ describe("/model batch assignments", () => {
 		]);
 	});
 
+	test("assign all-targets replaces null reset shadows without a partial failure", async () => {
+		const { output, runtime, settings } = createRuntime();
+		settings.override("modelRoles", null as never);
+		settings.override("task.agentModelOverrides", null as never);
+
+		await expect(
+			executeAcpBuiltinSlashCommand("/model assign all-targets claude-3-5-sonnet:high", runtime),
+		).resolves.toEqual({ consumed: true });
+
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:high");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet:high",
+			architect: "anthropic/claude-3-5-sonnet:high",
+			planner: "anthropic/claude-3-5-sonnet:high",
+			critic: "anthropic/claude-3-5-sonnet:high",
+		});
+		expect(output).toEqual([
+			"All model targets set to anthropic/claude-3-5-sonnet:high for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+		]);
+	});
+
 	test("assign all-targets materializes an active profile exactly once", async () => {
 		const { output, runtime, session, settings, setActiveModelProfile } = createRuntime();
 		session.model = { provider: "anthropic", id: "current-model" };


### PR DESCRIPTION
## What

- Preserve whole-record and malformed-leaf model-role resets as opaque runtime state instead of lossy sanitized records.
- Keep explicit `/model` and Agent Control Center assignments live across project shadows, configured-binding refresh/removal, profile materialization/rollback, and cwd clones.
- Reload selector role badges after offline refresh and route dashboard/profile assignments through per-leaf setters.
- Keep public `get`/`getGlobal` model records string-only while retaining internal reset semantics.

## Why

Supersedes #2001 and addresses every Request Changes schedule from that PR. Sanitized internal rewrites previously erased runtime reset tombstones, so durable lower-precedence roles could resurrect after binding removal, profile rollback, malformed sibling rewrites, or later project/global additions. The selector could also render constructor-time badges after its awaited offline refresh.

The replacement keeps whole resets, reset leaves, and explicitly released leaves outside the public record. Generic binding/profile rewrites preserve that state; explicit user assignments release only their selected leaves.

## Testing

- `bun run check`
- `bun test packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/model-registry.test.ts packages/coding-agent/test/custom-model-preset-creation.test.ts packages/coding-agent/test/model-profile-activation.test.ts packages/coding-agent/test/model-selector-controller-batch.test.ts packages/coding-agent/test/slash-commands/model.test.ts packages/coding-agent/test/model-selector-role-badge-thinking.test.ts packages/coding-agent/test/agent-dashboard-model-override.test.ts` — 230 pass
- `bun test packages/coding-agent/test/acp-builtins.test.ts --test-name-pattern 'model:'` — 14 pass
- `bun --cwd=packages/coding-agent run build && packages/coding-agent/dist/gjc --smoke-test`
- Two independent adversarial architecture reviews: CLEAR; all #2001 owner findings closed

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)