### PR TITLE
fix(model): preserve role state across profile edits

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Kept `/model` and Agent Control Center role assignments visible and coherent in the running TUI when project settings, opaque runtime resets, configured-binding refresh/removal, profile rollback, cwd changes, or offline model refreshes shadow persisted global roles.
 - Preserved explicit Telegram forum-topic renames as durable user-owned names, immediately re-asserting delayed edits while retaining restart and rename-race recovery (#1910).
 - `gjc resume` now aliases value-less `--resume`, requests confirmation before opening and continues a resumable tail once only; terminal tails open idle, and headless bare resume exits with explicit `--resume <id>` guidance (#1973).
 - Telegram answers to interactive and unattended `ask` prompts now receive a semantic, origin-bound `Selected!` acknowledgement before workflow continuation, with typed multi-select controls, no acknowledgement for toggles/clarifications/skips, at-most-once delivery attempts, and truthful failure/unknown outcomes (#1974).

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -15,7 +15,7 @@ import {
 	type ModelRegistry,
 } from "./model-registry";
 import { formatModelSelectorValue, resolveModelRoleValue } from "./model-resolver";
-import type { Settings } from "./settings";
+import type { RuntimeModelProfileDefaultState, Settings } from "./settings";
 
 const LEGACY_MODEL_PROFILE_ALIASES: ReadonlyMap<string, string> = new Map([["codex-standard", "codex-medium"]]);
 
@@ -40,7 +40,15 @@ export interface PrepareModelProfileActivationOptions {
 		| "getCanonicalVariants"
 		| "getCanonicalId"
 	>;
-	settings: Pick<Settings, "get">;
+	settings: Pick<
+		Settings,
+		| "get"
+		| "getGlobal"
+		| "getRuntimeModelProfileDefaultState"
+		| "getRuntimeModelRoles"
+		| "getRuntimeAgentModelOverrides"
+		| "getPersistedModelProfileDefaultState"
+	>;
 	profileName: string;
 }
 export interface ApplyModelProfileActivationOptions {
@@ -50,11 +58,37 @@ export interface ApplyModelProfileActivationOptions {
 export interface PreparedModelProfileActivation {
 	profileName: string;
 	session: ModelProfileActivationSession & { setModelTemporary: AgentSession["setModelTemporary"] };
-	settings: Pick<Settings, "clearOverride" | "get" | "getGlobal" | "override" | "set" | "flush">;
+	settings: Pick<
+		Settings,
+		| "clearOverride"
+		| "flushOrThrow"
+		| "get"
+		| "getGlobal"
+		| "getRuntimeAgentModelOverrides"
+		| "getRuntimeModelRoles"
+		| "override"
+		| "set"
+		| "persistAgentModelOverride"
+		| "persistModelRole"
+		| "replacePersistedAgentModelOverrides"
+		| "replacePersistedModelRoles"
+		| "persistModelProfileDefaultSuppression"
+		| "restorePersistedModelProfileDefault"
+		| "getPersistedModelProfileDefaultState"
+		| "getRuntimeModelProfileDefaultState"
+		| "restoreRuntimeModelProfileDefault"
+		| "suppressModelProfileDefault"
+	>;
 	previousModel: Model<Api> | undefined;
 	previousThinkingLevel: ThinkingLevel | undefined;
 	previousAgentModelOverrides: Record<string, string>;
 	previousModelRoles: Record<string, string>;
+	previousPersistedAgentModelOverrides: Record<string, string> | undefined;
+	previousPersistedModelRoles: Record<string, string> | undefined;
+	previousRuntimeAgentModelOverrides: Record<string, string>;
+	previousRuntimeModelRoles: Record<string, string>;
+	previousRuntimeModelProfileDefault: RuntimeModelProfileDefaultState;
+	previousPersistedModelProfileDefault: RuntimeModelProfileDefaultState;
 	defaultModel: Model<Api> | undefined;
 	defaultThinkingLevel: ThinkingLevel | undefined;
 	modelRoles: Record<string, string>;
@@ -74,7 +108,22 @@ export interface MaterializeModelProfileAssignmentOptions {
 		ModelProfileActivationSession,
 		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile"
 	>;
-	settings: Pick<Settings, "clearOverride" | "get" | "override" | "set">;
+	settings: Pick<
+		Settings,
+		| "clearOverride"
+		| "get"
+		| "getGlobal"
+		| "getRuntimeAgentModelOverrides"
+		| "getRuntimeModelRoles"
+		| "override"
+		| "set"
+		| "persistAgentModelOverride"
+		| "persistModelRole"
+		| "setModelRole"
+		| "setAgentModelOverride"
+		| "suppressModelProfileDefault"
+		| "persistModelProfileDefaultSuppression"
+	>;
 	role: GjcModelAssignmentTargetId;
 	selector: string;
 }
@@ -84,40 +133,69 @@ export interface MaterializeModelProfileAssignmentsOptions {
 		ModelProfileActivationSession,
 		"model" | "thinkingLevel" | "setActiveModelProfile" | "getActiveModelProfile"
 	>;
-	settings: Pick<Settings, "clearOverride" | "get" | "override" | "set">;
-	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string> | Partial<Record<GjcModelAssignmentTargetId, string>>;
+	settings: Pick<
+		Settings,
+		| "clearOverride"
+		| "get"
+		| "getGlobal"
+		| "getRuntimeAgentModelOverrides"
+		| "getRuntimeModelRoles"
+		| "override"
+		| "set"
+		| "persistAgentModelOverride"
+		| "persistModelRole"
+		| "setModelRole"
+		| "setAgentModelOverride"
+		| "suppressModelProfileDefault"
+		| "persistModelProfileDefaultSuppression"
+	>;
+	assignments: ReadonlyMap<string, string> | Readonly<Record<string, string>>;
 }
 
 function isReadonlyAssignmentMap(
-	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string> | Partial<Record<GjcModelAssignmentTargetId, string>>,
-): assignments is ReadonlyMap<GjcModelAssignmentTargetId, string> {
+	assignments: ReadonlyMap<string, string> | Readonly<Record<string, string>>,
+): assignments is ReadonlyMap<string, string> {
 	return typeof (assignments as { entries?: unknown }).entries === "function";
 }
 
 function getMaterializedAssignments(
-	assignments: ReadonlyMap<GjcModelAssignmentTargetId, string> | Partial<Record<GjcModelAssignmentTargetId, string>>,
-): Array<[GjcModelAssignmentTargetId, string]> {
+	assignments: ReadonlyMap<string, string> | Readonly<Record<string, string>>,
+): Array<[string, string]> {
 	if (isReadonlyAssignmentMap(assignments)) return [...assignments.entries()];
-	const assignmentRecord: Partial<Record<GjcModelAssignmentTargetId, string>> = assignments;
-	const result: Array<[GjcModelAssignmentTargetId, string]> = [];
-	for (const role of Object.keys(assignmentRecord) as GjcModelAssignmentTargetId[]) {
-		const selector = assignmentRecord[role];
+	const result: Array<[string, string]> = [];
+	for (const [role, selector] of Object.entries(assignments)) {
 		if (selector !== undefined) result.push([role, selector]);
 	}
 	return result;
+}
+
+function assignmentSettingsPath(role: string): "modelRoles" | "task.agentModelOverrides" {
+	return role === "default" ||
+		GJC_MODEL_ASSIGNMENT_TARGETS[role as GjcModelAssignmentTargetId]?.settingsPath === "modelRoles"
+		? "modelRoles"
+		: "task.agentModelOverrides";
+}
+function setAssignment(record: Record<string, string>, key: string, selector: string): void {
+	Object.defineProperty(record, key, {
+		value: selector,
+		enumerable: true,
+		configurable: true,
+		writable: true,
+	});
 }
 
 export function materializeActiveModelProfileAssignment(options: MaterializeModelProfileAssignmentOptions): boolean {
 	const activeProfile = options.session.getActiveModelProfile?.() ?? options.settings.get("modelProfile.default");
 	if (!activeProfile) return false;
 
-	const nextModelRoles = { ...options.settings.get("modelRoles") };
-	const nextAgentModelOverrides = { ...options.settings.get("task.agentModelOverrides") };
+	const nextModelRoles = { ...options.settings.getRuntimeModelRoles() };
+	const nextAgentModelOverrides = { ...options.settings.getRuntimeAgentModelOverrides() };
+	const effectiveModelRoles = options.settings.get("modelRoles");
 	const target = GJC_MODEL_ASSIGNMENT_TARGETS[options.role];
 
 	if (options.role === "default") {
 		nextModelRoles.default = options.selector;
-	} else if (!nextModelRoles.default && options.session.model) {
+	} else if (!effectiveModelRoles.default && !nextModelRoles.default && options.session.model) {
 		nextModelRoles.default = formatModelSelectorValue(
 			`${options.session.model.provider}/${options.session.model.id}`,
 			options.session.thinkingLevel,
@@ -125,17 +203,26 @@ export function materializeActiveModelProfileAssignment(options: MaterializeMode
 	}
 
 	if (target.settingsPath === "modelRoles") {
-		nextModelRoles[options.role] = options.selector;
+		setAssignment(nextModelRoles, options.role, options.selector);
 	} else {
-		nextAgentModelOverrides[options.role] = options.selector;
+		setAssignment(nextAgentModelOverrides, options.role, options.selector);
 	}
 
-	options.settings.set("modelRoles", nextModelRoles);
-	options.settings.set("task.agentModelOverrides", nextAgentModelOverrides);
-	options.settings.set("modelProfile.default", undefined);
-	options.settings.clearOverride("modelProfile.default");
+	for (const [role, selector] of Object.entries(nextModelRoles)) {
+		options.settings.persistModelRole(role, selector);
+	}
+	for (const [agentName, selector] of Object.entries(nextAgentModelOverrides)) {
+		options.settings.persistAgentModelOverride(agentName, selector);
+	}
+	options.settings.persistModelProfileDefaultSuppression();
+	options.settings.suppressModelProfileDefault();
 	options.settings.override("modelRoles", nextModelRoles);
 	options.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
+	if (target.settingsPath === "modelRoles") {
+		options.settings.setModelRole(options.role, options.selector);
+	} else {
+		options.settings.setAgentModelOverride(options.role, options.selector);
+	}
 	options.session.setActiveModelProfile?.(undefined);
 	return true;
 }
@@ -145,13 +232,13 @@ export function materializeActiveModelProfileAssignments(options: MaterializeMod
 	if (!activeProfile) return false;
 
 	const materializedAssignments = getMaterializedAssignments(options.assignments);
-	if (materializedAssignments.length === 0) return true;
 
-	const nextModelRoles = { ...options.settings.get("modelRoles") };
-	const nextAgentModelOverrides = { ...options.settings.get("task.agentModelOverrides") };
+	const nextModelRoles = { ...options.settings.getRuntimeModelRoles() };
+	const nextAgentModelOverrides = { ...options.settings.getRuntimeAgentModelOverrides() };
+	const effectiveModelRoles = options.settings.get("modelRoles");
 	const includesDefault = materializedAssignments.some(([role]) => role === "default");
 
-	if (!includesDefault && !nextModelRoles.default && options.session.model) {
+	if (!includesDefault && !effectiveModelRoles.default && !nextModelRoles.default && options.session.model) {
 		nextModelRoles.default = formatModelSelectorValue(
 			`${options.session.model.provider}/${options.session.model.id}`,
 			options.session.thinkingLevel,
@@ -159,20 +246,30 @@ export function materializeActiveModelProfileAssignments(options: MaterializeMod
 	}
 
 	for (const [role, selector] of materializedAssignments) {
-		const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
-		if (target.settingsPath === "modelRoles") {
-			nextModelRoles[role] = selector;
+		if (assignmentSettingsPath(role) === "modelRoles") {
+			setAssignment(nextModelRoles, role, selector);
 		} else {
-			nextAgentModelOverrides[role] = selector;
+			setAssignment(nextAgentModelOverrides, role, selector);
 		}
 	}
 
-	options.settings.set("modelRoles", nextModelRoles);
-	options.settings.set("task.agentModelOverrides", nextAgentModelOverrides);
-	options.settings.set("modelProfile.default", undefined);
-	options.settings.clearOverride("modelProfile.default");
+	for (const [role, selector] of Object.entries(nextModelRoles)) {
+		options.settings.persistModelRole(role, selector);
+	}
+	for (const [agentName, selector] of Object.entries(nextAgentModelOverrides)) {
+		options.settings.persistAgentModelOverride(agentName, selector);
+	}
+	options.settings.persistModelProfileDefaultSuppression();
+	options.settings.suppressModelProfileDefault();
 	options.settings.override("modelRoles", nextModelRoles);
 	options.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
+	for (const [role, selector] of materializedAssignments) {
+		if (assignmentSettingsPath(role) === "modelRoles") {
+			options.settings.setModelRole(role, selector);
+		} else {
+			options.settings.setAgentModelOverride(role, selector);
+		}
+	}
 	options.session.setActiveModelProfile?.(undefined);
 	return true;
 }
@@ -337,6 +434,18 @@ export async function prepareModelProfileActivation(
 		previousThinkingLevel: options.session.thinkingLevel,
 		previousAgentModelOverrides: { ...options.settings.get("task.agentModelOverrides") },
 		previousModelRoles: { ...options.settings.get("modelRoles") },
+		previousPersistedAgentModelOverrides:
+			options.settings.getGlobal("task.agentModelOverrides") === undefined
+				? undefined
+				: { ...options.settings.getGlobal("task.agentModelOverrides") },
+		previousPersistedModelRoles:
+			options.settings.getGlobal("modelRoles") === undefined
+				? undefined
+				: { ...options.settings.getGlobal("modelRoles") },
+		previousRuntimeAgentModelOverrides: { ...options.settings.getRuntimeAgentModelOverrides() },
+		previousRuntimeModelRoles: { ...options.settings.getRuntimeModelRoles() },
+		previousRuntimeModelProfileDefault: options.settings.getRuntimeModelProfileDefaultState(),
+		previousPersistedModelProfileDefault: options.settings.getPersistedModelProfileDefaultState(),
 		defaultModel: resolvedDefault?.model,
 		defaultThinkingLevel: resolvedDefault?.thinkingLevel,
 		modelRoles,
@@ -352,10 +461,12 @@ export async function applyPreparedModelProfileActivation(
 ): Promise<void> {
 	const previousModel = prepared.previousModel;
 	const previousThinkingLevel = prepared.previousThinkingLevel;
-	const previousAgentModelOverrides = prepared.previousAgentModelOverrides;
-	const previousModelRoles = prepared.previousModelRoles;
-	const previousPersistedDefault = prepared.settings.get("modelProfile.default");
-	const previousDefaultThinkingLevel = prepared.settings.get("defaultThinkingLevel");
+	const previousPersistedAgentModelOverrides = prepared.previousPersistedAgentModelOverrides;
+	const previousPersistedModelRoles = prepared.previousPersistedModelRoles;
+	const previousRuntimeAgentModelOverrides = prepared.previousRuntimeAgentModelOverrides;
+	const previousRuntimeModelRoles = prepared.previousRuntimeModelRoles;
+	const previousPersistedDefault = prepared.previousPersistedModelProfileDefault;
+	const previousDefaultThinkingLevel = prepared.settings.getGlobal("defaultThinkingLevel");
 	const previousActiveModelProfile = prepared.previousActiveModelProfile;
 	const previousSessionDefaultModel = prepared.previousSessionDefaultModel;
 	let modelChanged = false;
@@ -376,12 +487,12 @@ export async function applyPreparedModelProfileActivation(
 			modelChanged = true;
 		}
 		if (Object.keys(prepared.modelRoles).length > 0) {
-			prepared.settings.override("modelRoles", { ...previousModelRoles, ...prepared.modelRoles });
+			prepared.settings.override("modelRoles", { ...previousRuntimeModelRoles, ...prepared.modelRoles });
 			modelRolesChanged = true;
 		}
 		if (Object.keys(prepared.agentModelOverrides).length > 0) {
 			prepared.settings.override("task.agentModelOverrides", {
-				...previousAgentModelOverrides,
+				...previousRuntimeAgentModelOverrides,
 				...prepared.agentModelOverrides,
 			});
 			overridesChanged = true;
@@ -393,25 +504,27 @@ export async function applyPreparedModelProfileActivation(
 				prepared.settings.set("defaultThinkingLevel", prepared.defaultThinkingLevel);
 				defaultThinkingChanged = true;
 			}
+			prepared.settings.clearOverride("modelProfile.default");
 			prepared.settings.set("modelProfile.default", prepared.profileName);
 			defaultChanged = true;
-			await prepared.settings.flush();
+			await prepared.settings.flushOrThrow();
 		}
 		prepared.session.setActiveModelProfile?.(prepared.profileName);
 	} catch (error) {
 		if (defaultChanged) {
-			prepared.settings.set("modelProfile.default", previousPersistedDefault);
-			prepared.settings.set("modelRoles", previousModelRoles);
-			prepared.settings.set("task.agentModelOverrides", previousAgentModelOverrides);
+			prepared.settings.restorePersistedModelProfileDefault(previousPersistedDefault);
+			prepared.settings.replacePersistedModelRoles(previousPersistedModelRoles);
+			prepared.settings.replacePersistedAgentModelOverrides(previousPersistedAgentModelOverrides);
+			prepared.settings.restoreRuntimeModelProfileDefault(prepared.previousRuntimeModelProfileDefault);
 			if (defaultThinkingChanged) {
-				prepared.settings.set("defaultThinkingLevel", previousDefaultThinkingLevel);
+				prepared.settings.set("defaultThinkingLevel", previousDefaultThinkingLevel as never);
 			}
 		}
 		if (modelRolesChanged) {
-			prepared.settings.override("modelRoles", previousModelRoles);
+			prepared.settings.override("modelRoles", previousRuntimeModelRoles);
 		}
 		if (overridesChanged) {
-			prepared.settings.override("task.agentModelOverrides", previousAgentModelOverrides);
+			prepared.settings.override("task.agentModelOverrides", previousRuntimeAgentModelOverrides);
 		}
 		prepared.session.setActiveModelProfile?.(previousActiveModelProfile);
 		if (modelChanged) {
@@ -443,21 +556,49 @@ export interface MaterializeModelProfileForDeletionResult {
 	agentModelOverrides: Record<string, string>;
 	previousModelRoles: Record<string, string>;
 	previousAgentModelOverrides: Record<string, string>;
+	previousPersistedModelRoles: Record<string, string> | undefined;
+	previousPersistedAgentModelOverrides: Record<string, string> | undefined;
+	previousRuntimeModelRoles: Record<string, string>;
+	previousRuntimeAgentModelOverrides: Record<string, string>;
 	previousDefaultProfile: string | undefined;
 	previousPersistedDefaultProfile: string | undefined;
+	previousRuntimeModelProfileDefault: RuntimeModelProfileDefaultState;
+	previousPersistedModelProfileDefault: RuntimeModelProfileDefaultState;
 	previousActiveModelProfile: string | undefined;
 }
 
 export async function materializeModelProfileForDeletion(
 	options: PrepareModelProfileActivationOptions & {
-		settings: Pick<Settings, "clearOverride" | "flush" | "get" | "getGlobal" | "override" | "set">;
+		settings: Pick<
+			Settings,
+			| "clearOverride"
+			| "flushOrThrow"
+			| "get"
+			| "getGlobal"
+			| "getRuntimeAgentModelOverrides"
+			| "getRuntimeModelRoles"
+			| "override"
+			| "set"
+			| "persistAgentModelOverride"
+			| "persistModelRole"
+			| "replacePersistedAgentModelOverrides"
+			| "replacePersistedModelRoles"
+			| "getRuntimeModelProfileDefaultState"
+			| "restoreRuntimeModelProfileDefault"
+			| "suppressModelProfileDefault"
+			| "getPersistedModelProfileDefaultState"
+			| "persistModelProfileDefaultSuppression"
+			| "restorePersistedModelProfileDefault"
+		>;
 	},
 ): Promise<MaterializeModelProfileForDeletionResult> {
 	const prepared = await prepareModelProfileActivation(options);
 	const previousDefaultProfile = prepared.settings.get("modelProfile.default");
 	const previousPersistedDefaultProfile = prepared.settings.getGlobal("modelProfile.default");
-	const nextModelRoles = {
-		...prepared.previousModelRoles,
+	const previousRuntimeModelProfileDefault = prepared.settings.getRuntimeModelProfileDefaultState();
+	const previousPersistedModelProfileDefault = prepared.settings.getPersistedModelProfileDefaultState();
+	const nextRuntimeModelRoles = {
+		...prepared.previousRuntimeModelRoles,
 		...(prepared.defaultModel
 			? {
 					default: formatModelSelectorValue(
@@ -468,27 +609,51 @@ export async function materializeModelProfileForDeletion(
 			: {}),
 		...prepared.modelRoles,
 	};
-	const nextAgentModelOverrides = {
-		...prepared.previousAgentModelOverrides,
+	const nextRuntimeAgentModelOverrides = {
+		...prepared.previousRuntimeAgentModelOverrides,
 		...prepared.agentModelOverrides,
+	};
+	const durableProfileModelRoles = {
+		...(prepared.defaultModel
+			? {
+					default: formatModelSelectorValue(
+						`${prepared.defaultModel.provider}/${prepared.defaultModel.id}`,
+						prepared.defaultThinkingLevel,
+					),
+				}
+			: {}),
+		...prepared.modelRoles,
+	};
+	const durableProfileAgentModelOverrides = { ...prepared.agentModelOverrides };
+	const nextModelRoles = {
+		...(prepared.previousPersistedModelRoles ?? {}),
+		...durableProfileModelRoles,
+	};
+	const nextAgentModelOverrides = {
+		...(prepared.previousPersistedAgentModelOverrides ?? {}),
+		...durableProfileAgentModelOverrides,
 	};
 
 	try {
-		prepared.settings.set("modelRoles", nextModelRoles);
-		prepared.settings.set("task.agentModelOverrides", nextAgentModelOverrides);
-		prepared.settings.set("modelProfile.default", undefined);
-		prepared.settings.clearOverride("modelProfile.default");
-		prepared.settings.override("modelRoles", nextModelRoles);
-		prepared.settings.override("task.agentModelOverrides", nextAgentModelOverrides);
+		for (const [role, selector] of Object.entries(durableProfileModelRoles)) {
+			prepared.settings.persistModelRole(role, selector);
+		}
+		for (const [agentName, selector] of Object.entries(durableProfileAgentModelOverrides)) {
+			prepared.settings.persistAgentModelOverride(agentName, selector);
+		}
+		prepared.settings.persistModelProfileDefaultSuppression();
+		prepared.settings.suppressModelProfileDefault();
+		prepared.settings.override("modelRoles", nextRuntimeModelRoles);
+		prepared.settings.override("task.agentModelOverrides", nextRuntimeAgentModelOverrides);
 		prepared.session.setActiveModelProfile?.(undefined);
-		await prepared.settings.flush();
+		await prepared.settings.flushOrThrow();
 	} catch (error) {
-		prepared.settings.set("modelRoles", prepared.previousModelRoles);
-		prepared.settings.set("task.agentModelOverrides", prepared.previousAgentModelOverrides);
-		prepared.settings.set("modelProfile.default", previousPersistedDefaultProfile);
-		prepared.settings.override("modelRoles", prepared.previousModelRoles);
-		prepared.settings.override("task.agentModelOverrides", prepared.previousAgentModelOverrides);
-		prepared.settings.override("modelProfile.default", previousDefaultProfile);
+		prepared.settings.replacePersistedModelRoles(prepared.previousPersistedModelRoles);
+		prepared.settings.replacePersistedAgentModelOverrides(prepared.previousPersistedAgentModelOverrides);
+		prepared.settings.restorePersistedModelProfileDefault(previousPersistedModelProfileDefault);
+		prepared.settings.override("modelRoles", prepared.previousRuntimeModelRoles);
+		prepared.settings.override("task.agentModelOverrides", prepared.previousRuntimeAgentModelOverrides);
+		prepared.settings.restoreRuntimeModelProfileDefault(previousRuntimeModelProfileDefault);
 		prepared.session.setActiveModelProfile?.(prepared.previousActiveModelProfile);
 		throw error;
 	}
@@ -498,25 +663,64 @@ export async function materializeModelProfileForDeletion(
 		agentModelOverrides: nextAgentModelOverrides,
 		previousModelRoles: prepared.previousModelRoles,
 		previousAgentModelOverrides: prepared.previousAgentModelOverrides,
+		previousPersistedModelRoles: prepared.previousPersistedModelRoles,
+		previousPersistedAgentModelOverrides: prepared.previousPersistedAgentModelOverrides,
+		previousRuntimeModelRoles: prepared.previousRuntimeModelRoles,
+		previousRuntimeAgentModelOverrides: prepared.previousRuntimeAgentModelOverrides,
 		previousDefaultProfile,
 		previousPersistedDefaultProfile,
+		previousRuntimeModelProfileDefault,
+		previousPersistedModelProfileDefault,
 		previousActiveModelProfile: prepared.previousActiveModelProfile,
 	};
 }
 
 export async function restoreMaterializedModelProfileForDeletion(options: {
-	settings: Pick<Settings, "flush" | "override" | "set">;
-	session: Pick<ModelProfileActivationSession, "setActiveModelProfile">;
+	settings: Pick<
+		Settings,
+		| "flushOrThrow"
+		| "getGlobal"
+		| "getRuntimeAgentModelOverrides"
+		| "getRuntimeModelProfileDefaultState"
+		| "getRuntimeModelRoles"
+		| "override"
+		| "replacePersistedAgentModelOverrides"
+		| "replacePersistedModelRoles"
+		| "restoreRuntimeModelProfileDefault"
+		| "set"
+		| "getPersistedModelProfileDefaultState"
+		| "restorePersistedModelProfileDefault"
+	>;
+	session: Pick<ModelProfileActivationSession, "getActiveModelProfile" | "setActiveModelProfile">;
 	snapshot: MaterializeModelProfileForDeletionResult;
 }): Promise<void> {
-	options.settings.set("modelRoles", options.snapshot.previousModelRoles);
-	options.settings.set("task.agentModelOverrides", options.snapshot.previousAgentModelOverrides);
-	options.settings.set("modelProfile.default", options.snapshot.previousPersistedDefaultProfile);
-	options.settings.override("modelRoles", options.snapshot.previousModelRoles);
-	options.settings.override("task.agentModelOverrides", options.snapshot.previousAgentModelOverrides);
-	options.settings.override("modelProfile.default", options.snapshot.previousDefaultProfile);
-	options.session.setActiveModelProfile?.(options.snapshot.previousActiveModelProfile);
-	await options.settings.flush();
+	const currentPersistedModelRoles = options.settings.getGlobal("modelRoles");
+	const currentPersistedAgentModelOverrides = options.settings.getGlobal("task.agentModelOverrides");
+	const currentPersistedModelProfileDefault = options.settings.getPersistedModelProfileDefaultState();
+	const currentRuntimeModelRoles = options.settings.getRuntimeModelRoles();
+	const currentRuntimeAgentModelOverrides = options.settings.getRuntimeAgentModelOverrides();
+	const currentRuntimeModelProfileDefault = options.settings.getRuntimeModelProfileDefaultState();
+	const currentActiveModelProfile = options.session.getActiveModelProfile?.();
+
+	try {
+		options.settings.replacePersistedModelRoles(options.snapshot.previousPersistedModelRoles);
+		options.settings.replacePersistedAgentModelOverrides(options.snapshot.previousPersistedAgentModelOverrides);
+		options.settings.restorePersistedModelProfileDefault(options.snapshot.previousPersistedModelProfileDefault);
+		options.settings.override("modelRoles", options.snapshot.previousRuntimeModelRoles);
+		options.settings.override("task.agentModelOverrides", options.snapshot.previousRuntimeAgentModelOverrides);
+		options.settings.restoreRuntimeModelProfileDefault(options.snapshot.previousRuntimeModelProfileDefault);
+		await options.settings.flushOrThrow();
+		options.session.setActiveModelProfile?.(options.snapshot.previousActiveModelProfile);
+	} catch (error) {
+		options.settings.replacePersistedModelRoles(currentPersistedModelRoles);
+		options.settings.replacePersistedAgentModelOverrides(currentPersistedAgentModelOverrides);
+		options.settings.restorePersistedModelProfileDefault(currentPersistedModelProfileDefault);
+		options.settings.override("modelRoles", currentRuntimeModelRoles);
+		options.settings.override("task.agentModelOverrides", currentRuntimeAgentModelOverrides);
+		options.settings.restoreRuntimeModelProfileDefault(currentRuntimeModelProfileDefault);
+		options.session.setActiveModelProfile?.(currentActiveModelProfile);
+		throw error;
+	}
 }
 
 export async function activateModelProfile(

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -129,6 +129,19 @@ export const GJC_MODEL_ASSIGNMENT_TARGETS: Record<GjcModelAssignmentTargetId, Gj
 
 /** Alias for ModelRoleInfo - used for both built-in and custom roles */
 export type RoleInfo = ModelRoleInfo;
+function getOwnString(record: Record<string, string>, key: string): string | undefined {
+	const value = Object.hasOwn(record, key) ? record[key] : undefined;
+	return typeof value === "string" ? value : undefined;
+}
+
+function setOwnString(record: Record<string, string>, key: string, value: string): void {
+	Object.defineProperty(record, key, {
+		value,
+		enumerable: true,
+		configurable: true,
+		writable: true,
+	});
+}
 
 /**
  * Return the canonical set of known roles for selector/carousel UI.
@@ -1702,18 +1715,18 @@ export class ModelRegistry {
 		const targetSettings = this.#modelBindingsTargetSettings;
 		if (!targetSettings) return;
 		const bindings = this.#configuredModelBindings;
-		const nextModelRoles = { ...targetSettings.get("modelRoles") };
+		const nextModelRoles = { ...targetSettings.getRuntimeModelRoles() };
 		const configuredModelRoles = bindings?.modelRoles ?? {};
 		const configuredModelRoleKeys = new Set(Object.keys(configuredModelRoles));
 		for (const role of this.#appliedModelBindingRoles) {
 			if (configuredModelRoleKeys.has(role)) continue;
 			const lastApplied = this.#lastAppliedModelBindingRoles.get(role);
-			if (lastApplied !== undefined && nextModelRoles[role] === lastApplied) {
+			if (lastApplied !== undefined && getOwnString(nextModelRoles, role) === lastApplied) {
 				const baseline = this.#modelBindingRoleBaselines.get(role);
 				if (baseline === undefined) {
 					delete nextModelRoles[role];
 				} else {
-					nextModelRoles[role] = baseline;
+					setOwnString(nextModelRoles, role, baseline);
 				}
 			}
 			this.#modelBindingRoleBaselines.delete(role);
@@ -1723,28 +1736,28 @@ export class ModelRegistry {
 			if (!modelId) continue;
 			const previousApplied = this.#lastAppliedModelBindingRoles.get(role);
 			if (!this.#modelBindingRoleBaselines.has(role)) {
-				this.#modelBindingRoleBaselines.set(role, nextModelRoles[role]);
+				this.#modelBindingRoleBaselines.set(role, getOwnString(nextModelRoles, role));
 			}
-			if (previousApplied === undefined || nextModelRoles[role] === previousApplied) {
-				nextModelRoles[role] = modelId;
+			if (previousApplied === undefined || getOwnString(nextModelRoles, role) === previousApplied) {
+				setOwnString(nextModelRoles, role, modelId);
 				this.#lastAppliedModelBindingRoles.set(role, modelId);
 			}
 		}
 		targetSettings.override("modelRoles", nextModelRoles);
 		this.#appliedModelBindingRoles = new Set(Object.keys(configuredModelRoles));
 
-		const nextAgentModelOverrides = { ...targetSettings.get("task.agentModelOverrides") };
+		const nextAgentModelOverrides = { ...targetSettings.getRuntimeAgentModelOverrides() };
 		const configuredAgentModelOverrides = bindings?.agentModelOverrides ?? {};
 		const configuredAgentModelOverrideKeys = new Set(Object.keys(configuredAgentModelOverrides));
 		for (const agentName of this.#appliedAgentModelBindingOverrides) {
 			if (configuredAgentModelOverrideKeys.has(agentName)) continue;
 			const lastApplied = this.#lastAppliedAgentModelBindingOverrides.get(agentName);
-			if (lastApplied !== undefined && nextAgentModelOverrides[agentName] === lastApplied) {
+			if (lastApplied !== undefined && getOwnString(nextAgentModelOverrides, agentName) === lastApplied) {
 				const baseline = this.#agentModelBindingBaselines.get(agentName);
 				if (baseline === undefined) {
 					delete nextAgentModelOverrides[agentName];
 				} else {
-					nextAgentModelOverrides[agentName] = baseline;
+					setOwnString(nextAgentModelOverrides, agentName, baseline);
 				}
 			}
 			this.#agentModelBindingBaselines.delete(agentName);
@@ -1754,10 +1767,10 @@ export class ModelRegistry {
 			if (!modelId) continue;
 			const previousApplied = this.#lastAppliedAgentModelBindingOverrides.get(agentName);
 			if (!this.#agentModelBindingBaselines.has(agentName)) {
-				this.#agentModelBindingBaselines.set(agentName, nextAgentModelOverrides[agentName]);
+				this.#agentModelBindingBaselines.set(agentName, getOwnString(nextAgentModelOverrides, agentName));
 			}
-			if (previousApplied === undefined || nextAgentModelOverrides[agentName] === previousApplied) {
-				nextAgentModelOverrides[agentName] = modelId;
+			if (previousApplied === undefined || getOwnString(nextAgentModelOverrides, agentName) === previousApplied) {
+				setOwnString(nextAgentModelOverrides, agentName, modelId);
 				this.#lastAppliedAgentModelBindingOverrides.set(agentName, modelId);
 			}
 		}

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -77,9 +77,38 @@ const RequestTransformSchema = z
 	})
 	.strict();
 
+function setOwnValue(target: Record<string, unknown>, key: string, value: unknown): void {
+	Object.defineProperty(target, key, {
+		value,
+		writable: true,
+		enumerable: true,
+		configurable: true,
+	});
+}
+
+const SAFE_RECORD_KEY_PREFIX = "binding:";
+
+const SafeNonEmptyStringRecordSchema = z.preprocess(
+	value => {
+		if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+		const encoded: Record<string, unknown> = {};
+		for (const [key, item] of Object.entries(value)) {
+			setOwnValue(encoded, `${SAFE_RECORD_KEY_PREFIX}${key}`, item);
+		}
+		return encoded;
+	},
+	z.record(z.string(), z.string().min(1)).overwrite(encoded => {
+		const decoded: Record<string, string> = {};
+		for (const [key, item] of Object.entries(encoded)) {
+			setOwnValue(decoded, key.slice(SAFE_RECORD_KEY_PREFIX.length), item);
+		}
+		return decoded;
+	}),
+);
+
 const ModelBindingsSchema = z.object({
-	modelRoles: z.record(z.string(), z.string().min(1)).optional(),
-	agentModelOverrides: z.record(z.string(), z.string().min(1)).optional(),
+	modelRoles: SafeNonEmptyStringRecordSchema.optional(),
+	agentModelOverrides: SafeNonEmptyStringRecordSchema.optional(),
 });
 export const ProfileRoleSchema = z.enum(["default", "executor", "architect", "planner", "critic"]);
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -146,6 +146,7 @@ interface BooleanDef {
 interface StringDef {
 	type: "string";
 	default: string | undefined;
+	nullable?: boolean;
 	ui?: UiString;
 }
 
@@ -382,6 +383,7 @@ export const SETTINGS_SCHEMA = {
 	"modelProfile.default": {
 		type: "string",
 		default: undefined,
+		nullable: true,
 		ui: {
 			tab: "model",
 			label: "Default Model Profile",

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -65,6 +65,10 @@ export interface SettingsOptions {
 	/** Initial overrides */
 	overrides?: Partial<Record<SettingPath, unknown>>;
 }
+export interface RuntimeModelProfileDefaultState {
+	suppressed: boolean;
+	value: string | undefined;
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Path Utilities
@@ -88,16 +92,29 @@ function getByPath(obj: RawSettings, segments: string[]): unknown {
  * Set a nested value in an object by path segments.
  * Creates intermediate objects as needed.
  */
+function setOwnValue(target: RawSettings, key: string, value: unknown): void {
+	Object.defineProperty(target, key, {
+		value,
+		enumerable: true,
+		configurable: true,
+		writable: true,
+	});
+}
+
+function assignStringRecord(target: Record<string, string>, source: Record<string, string>): void {
+	for (const [key, value] of Object.entries(source)) setOwnValue(target, key, value);
+}
+
 function setByPath(obj: RawSettings, segments: string[], value: unknown): void {
 	let current = obj;
 	for (let i = 0; i < segments.length - 1; i++) {
 		const segment = segments[i];
 		if (!(segment in current) || typeof current[segment] !== "object" || current[segment] === null) {
-			current[segment] = {};
+			setOwnValue(current, segment, {});
 		}
 		current = current[segment] as RawSettings;
 	}
-	current[segments[segments.length - 1]] = value;
+	setOwnValue(current, segments[segments.length - 1], value);
 }
 
 const PATH_SCOPED_ARRAY_SETTINGS = new Set<SettingPath>(["enabledModels", "disabledProviders"]);
@@ -143,11 +160,18 @@ function shallowStringRecord(value: unknown): Record<string, string> {
 
 	const result: Record<string, string> = {};
 	for (const [key, item] of Object.entries(value)) {
-		if (typeof item === "string") {
-			result[key] = item;
-		}
+		if (typeof item === "string") setOwnValue(result, key, item);
 	}
 	return result;
+}
+function isRecordObject(value: unknown): value is RawSettings {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+type RuntimeModelRecordPath = "modelRoles" | "task.agentModelOverrides";
+
+function isRuntimeModelRecordPath(path: SettingPath | string): path is RuntimeModelRecordPath {
+	return path === "modelRoles" || path === "task.agentModelOverrides";
 }
 
 function resolvePathScopedStringArray(settingPath: SettingPath, value: unknown, cwd: string): string[] | undefined {
@@ -204,6 +228,11 @@ export class Settings {
 	#project: RawSettings = {};
 	/** Runtime overrides (not persisted) */
 	#overrides: RawSettings = {};
+	/** Opaque runtime resets that must survive sanitized internal rewrites. */
+	#runtimeModelWholeResets = new Set<RuntimeModelRecordPath>();
+	#runtimeModelResetKeys = new Map<RuntimeModelRecordPath, Set<string>>();
+	#runtimeModelWholeResetReleasedKeys = new Map<RuntimeModelRecordPath, Set<string>>();
+	#runtimeModelProfileDefaultSuppressed = false;
 	/** Merged view (global + project + overrides) */
 	#merged: RawSettings = {};
 
@@ -225,7 +254,11 @@ export class Settings {
 
 		if (options.overrides) {
 			for (const [key, value] of Object.entries(options.overrides)) {
-				setByPath(this.#overrides, key.split("."), value);
+				if (isRuntimeModelRecordPath(key)) {
+					this.#storeRuntimeModelRecord(key, value);
+				} else {
+					setByPath(this.#overrides, key.split("."), value);
+				}
 			}
 		}
 	}
@@ -291,6 +324,9 @@ export class Settings {
 		const segments = path.split(".");
 		const value = getByPath(this.#merged, segments);
 		if (value !== undefined) {
+			if (path === "modelRoles" || path === "task.agentModelOverrides") {
+				return shallowStringRecord(value) as SettingValue<P>;
+			}
 			const pathScopedValue = resolvePathScopedStringArray(path, value, this.#cwd);
 			return (pathScopedValue ?? value) as SettingValue<P>;
 		}
@@ -305,7 +341,14 @@ export class Settings {
 	 */
 	getGlobal<P extends SettingPath>(path: P): SettingValue<P> | undefined {
 		const value = getByPath(this.#global, path.split("."));
-		return value === undefined ? undefined : (value as SettingValue<P>);
+		if (value === undefined) return undefined;
+		if (path === "modelProfile.default") {
+			return (typeof value === "string" ? value : undefined) as SettingValue<P> | undefined;
+		}
+		if (path === "modelRoles" || path === "task.agentModelOverrides") {
+			return shallowStringRecord(value) as SettingValue<P>;
+		}
+		return value as SettingValue<P>;
 	}
 
 	/** Check whether a setting is present in loaded settings/overrides rather than coming from schema defaults. */
@@ -337,6 +380,11 @@ export class Settings {
 	 * Apply runtime overrides (not persisted).
 	 */
 	override<P extends SettingPath>(path: P, value: SettingValue<P>): void {
+		if (isRuntimeModelRecordPath(path)) {
+			this.#replaceRuntimeModelRecord(path, value);
+			return;
+		}
+		if (path === "modelProfile.default") this.#runtimeModelProfileDefaultSuppressed = false;
 		const segments = path.split(".");
 		setByPath(this.#overrides, segments, value);
 		this.#rebuildMerged();
@@ -346,11 +394,22 @@ export class Settings {
 	 * Clear a runtime override.
 	 */
 	clearOverride(path: SettingPath): void {
+		const clearedWholeReset = isRuntimeModelRecordPath(path) && this.#runtimeModelWholeResets.delete(path);
+		const clearedResetKeys = isRuntimeModelRecordPath(path) && this.#runtimeModelResetKeys.delete(path);
+		const clearedReleasedKeys =
+			isRuntimeModelRecordPath(path) && this.#runtimeModelWholeResetReleasedKeys.delete(path);
+		const clearedProfileSuppression = path === "modelProfile.default" && this.#runtimeModelProfileDefaultSuppressed;
+		if (path === "modelProfile.default") this.#runtimeModelProfileDefaultSuppressed = false;
 		const segments = path.split(".");
 		let current = this.#overrides;
 		for (let i = 0; i < segments.length - 1; i++) {
 			const segment = segments[i];
-			if (!(segment in current)) return;
+			if (!(segment in current)) {
+				if (clearedWholeReset || clearedResetKeys || clearedReleasedKeys || clearedProfileSuppression) {
+					this.#rebuildMerged();
+				}
+				return;
+			}
 			current = current[segment] as RawSettings;
 		}
 		delete current[segments[segments.length - 1]];
@@ -403,6 +462,14 @@ export class Settings {
 		cloned.#global = structuredClone(this.#global);
 		cloned.#project = this.#persist ? await cloned.#loadProjectSettings() : structuredClone(this.#project);
 		cloned.#overrides = structuredClone(this.#overrides);
+		cloned.#runtimeModelWholeResets = new Set(this.#runtimeModelWholeResets);
+		cloned.#runtimeModelResetKeys = new Map(
+			[...this.#runtimeModelResetKeys].map(([modelPath, keys]) => [modelPath, new Set(keys)]),
+		);
+		cloned.#runtimeModelWholeResetReleasedKeys = new Map(
+			[...this.#runtimeModelWholeResetReleasedKeys].map(([modelPath, keys]) => [modelPath, new Set(keys)]),
+		);
+		cloned.#runtimeModelProfileDefaultSuppressed = this.#runtimeModelProfileDefaultSuppressed;
 		cloned.#rebuildMerged();
 		cloned.#fireAllHooks();
 		return cloned;
@@ -477,10 +544,99 @@ export class Settings {
 	}
 
 	/**
-	 * Set a model role (helper for modelRoles record).
+	 * Store a runtime model record without exposing malformed/reset leaves through
+	 * public reads. Whole-record resets and reset-valued leaves live in separate
+	 * metadata so sanitized binding/profile rewrites cannot erase them.
+	 */
+	#storeRuntimeModelRecord(path: RuntimeModelRecordPath, value: unknown): void {
+		if (value === undefined) {
+			setByPath(this.#overrides, path.split("."), undefined);
+			return;
+		}
+		setByPath(this.#overrides, path.split("."), shallowStringRecord(value));
+
+		if (!isRecordObject(value)) {
+			this.#runtimeModelWholeResets.add(path);
+			this.#runtimeModelResetKeys.delete(path);
+			this.#runtimeModelWholeResetReleasedKeys.delete(path);
+			return;
+		}
+
+		const resetKeys = new Set(this.#runtimeModelResetKeys.get(path));
+		const releasedKeys = this.#runtimeModelWholeResetReleasedKeys.get(path);
+		for (const [key, item] of Object.entries(value)) {
+			if (typeof item !== "string" && item !== undefined) {
+				resetKeys.add(key);
+				releasedKeys?.delete(key);
+			}
+		}
+		if (resetKeys.size > 0) {
+			this.#runtimeModelResetKeys.set(path, resetKeys);
+		} else {
+			this.#runtimeModelResetKeys.delete(path);
+		}
+	}
+
+	/**
+	 * Replace visible runtime strings while preserving opaque reset state. This
+	 * path is used by binding/profile refreshes that only see sanitized records.
+	 */
+	#replaceRuntimeModelRecord(path: RuntimeModelRecordPath, value: unknown): void {
+		this.#storeRuntimeModelRecord(path, value);
+		this.#rebuildMerged();
+	}
+
+	/** Apply one explicit user assignment over any reset for that leaf. */
+	#overrideRuntimeModelRecord(path: RuntimeModelRecordPath, key: string, modelId: string): void {
+		const next = shallowStringRecord(getByPath(this.#overrides, path.split(".")));
+		setOwnValue(next, key, modelId);
+		const resetKeys = this.#runtimeModelResetKeys.get(path);
+		if (resetKeys) {
+			resetKeys.delete(key);
+			if (resetKeys.size === 0) this.#runtimeModelResetKeys.delete(path);
+		}
+		if (this.#runtimeModelWholeResets.has(path)) {
+			const releasedKeys = this.#runtimeModelWholeResetReleasedKeys.get(path) ?? new Set<string>();
+			releasedKeys.add(key);
+			this.#runtimeModelWholeResetReleasedKeys.set(path, releasedKeys);
+		}
+		setByPath(this.#overrides, path.split("."), next);
+		this.#rebuildMerged();
+	}
+
+	/** Persist one model role without changing runtime reset/override state. */
+	persistModelRole(role: ModelRole | string, modelId: string): void {
+		const current = shallowStringRecord(getByPath(this.#global, ["modelRoles"]));
+		setOwnValue(current, role, modelId);
+		this.set("modelRoles", current);
+	}
+
+	/** Persist one agent model without changing runtime reset/override state. */
+	persistAgentModelOverride(agentName: string, modelId: string): void {
+		const current = shallowStringRecord(getByPath(this.#global, ["task", "agentModelOverrides"]));
+		setOwnValue(current, agentName, modelId);
+		this.set("task.agentModelOverrides", current);
+	}
+	/** Replace the durable model-role record exactly, preserving prior absence. */
+	replacePersistedModelRoles(value: Record<string, string> | undefined): void {
+		setByPath(this.#global, ["modelRoles"], value);
+		this.#modified.add("modelRoles");
+		this.#rebuildMerged();
+		this.#queueSave();
+	}
+
+	/** Replace the durable agent-model record exactly, preserving prior absence. */
+	replacePersistedAgentModelOverrides(value: Record<string, string> | undefined): void {
+		setByPath(this.#global, ["task", "agentModelOverrides"], value);
+		this.#modified.add("task.agentModelOverrides");
+		this.#rebuildMerged();
+		this.#queueSave();
+	}
+
+	/**
+	 * Set a model role while keeping a project/profile-shadowed live value aligned.
 	 */
 	setModelRole(role: ModelRole | string, modelId: string): void {
-		const current = shallowStringRecord(getByPath(this.#global, ["modelRoles"]));
 		const runtimeOverrides = getByPath(this.#overrides, ["modelRoles"]);
 		const updateRuntimeOverride =
 			!!runtimeOverrides &&
@@ -488,32 +644,52 @@ export class Settings {
 			!Array.isArray(runtimeOverrides) &&
 			Object.hasOwn(runtimeOverrides, role);
 
-		this.set("modelRoles", { ...current, [role]: modelId });
+		this.persistModelRole(role, modelId);
 
-		if (updateRuntimeOverride) {
-			this.override("modelRoles", { ...shallowStringRecord(runtimeOverrides), [role]: modelId });
+		if (updateRuntimeOverride || this.get("modelRoles")[role] !== modelId) {
+			this.#overrideRuntimeModelRecord("modelRoles", role, modelId);
 		}
 	}
 	/**
-	 * Set an agent model override while keeping any live runtime override aligned.
+	 * Set an agent model override while keeping any live project/profile override aligned.
 	 *
-	 * Runtime model profiles override `task.agentModelOverrides` for the current
-	 * session. A user-selected role assignment must win immediately in that same
-	 * session, but only the explicit agent change should be persisted.
+	 * Runtime model profiles and project settings can override
+	 * `task.agentModelOverrides` for the current session. A user-selected role
+	 * assignment must win immediately in that same session, but only the explicit
+	 * agent change should be persisted.
 	 */
 	setAgentModelOverride(agentName: string, modelId: string): void {
-		const current = shallowStringRecord(getByPath(this.#global, ["task", "agentModelOverrides"]));
 		const runtimeOverrides = getByPath(this.#overrides, ["task", "agentModelOverrides"]);
 		const updateRuntimeOverride =
 			!!runtimeOverrides && typeof runtimeOverrides === "object" && !Array.isArray(runtimeOverrides);
 
-		this.set("task.agentModelOverrides", { ...current, [agentName]: modelId });
+		this.persistAgentModelOverride(agentName, modelId);
 
-		if (updateRuntimeOverride) {
-			this.override("task.agentModelOverrides", {
-				...shallowStringRecord(runtimeOverrides),
-				[agentName]: modelId,
-			});
+		if (updateRuntimeOverride || this.get("task.agentModelOverrides")[agentName] !== modelId) {
+			this.#overrideRuntimeModelRecord("task.agentModelOverrides", agentName, modelId);
+		}
+	}
+
+	/** Clear one persisted agent assignment and any matching live string override. */
+	clearAgentModelOverride(agentName: string): void {
+		const runtimeOverrides = getByPath(this.#overrides, ["task", "agentModelOverrides"]);
+		const runtimeModelId =
+			isRecordObject(runtimeOverrides) && typeof runtimeOverrides[agentName] === "string"
+				? runtimeOverrides[agentName]
+				: undefined;
+		const current = shallowStringRecord(getByPath(this.#global, ["task", "agentModelOverrides"]));
+		if (
+			Object.hasOwn(current, agentName) &&
+			(runtimeModelId === undefined || current[agentName] === runtimeModelId)
+		) {
+			delete current[agentName];
+			this.set("task.agentModelOverrides", current);
+		}
+
+		if (runtimeModelId !== undefined) {
+			const next = shallowStringRecord(runtimeOverrides);
+			delete next[agentName];
+			this.override("task.agentModelOverrides", next);
 		}
 	}
 
@@ -531,18 +707,68 @@ export class Settings {
 	getModelRoles(): ReadOnlyDict<string> {
 		return { ...this.get("modelRoles") };
 	}
+	/** Get visible runtime-only role strings without lower-precedence layers. */
+	getRuntimeModelRoles(): Record<string, string> {
+		return shallowStringRecord(getByPath(this.#overrides, ["modelRoles"]));
+	}
+
+	/** Get visible runtime-only agent strings without lower-precedence layers. */
+	getRuntimeAgentModelOverrides(): Record<string, string> {
+		return shallowStringRecord(getByPath(this.#overrides, ["task", "agentModelOverrides"]));
+	}
+	getPersistedModelProfileDefaultState(): RuntimeModelProfileDefaultState {
+		const value = getByPath(this.#global, ["modelProfile", "default"]);
+		return {
+			suppressed: value === null,
+			value: typeof value === "string" ? value : undefined,
+		};
+	}
+
+	persistModelProfileDefaultSuppression(): void {
+		setByPath(this.#global, ["modelProfile", "default"], null);
+		this.#modified.add("modelProfile.default");
+		this.#rebuildMerged();
+		this.#queueSave();
+	}
+
+	restorePersistedModelProfileDefault(state: RuntimeModelProfileDefaultState): void {
+		setByPath(this.#global, ["modelProfile", "default"], state.suppressed ? null : state.value);
+		this.#modified.add("modelProfile.default");
+		this.#rebuildMerged();
+		this.#queueSave();
+	}
+
+	getRuntimeModelProfileDefaultState(): RuntimeModelProfileDefaultState {
+		const value = getByPath(this.#overrides, ["modelProfile", "default"]);
+		return {
+			suppressed: this.#runtimeModelProfileDefaultSuppressed,
+			value: typeof value === "string" ? value : undefined,
+		};
+	}
+
+	suppressModelProfileDefault(): void {
+		this.clearOverride("modelProfile.default");
+		this.#runtimeModelProfileDefaultSuppressed = true;
+		this.#rebuildMerged();
+	}
+
+	restoreRuntimeModelProfileDefault(state: RuntimeModelProfileDefaultState): void {
+		this.clearOverride("modelProfile.default");
+		if (state.suppressed) {
+			this.#runtimeModelProfileDefaultSuppressed = true;
+			this.#rebuildMerged();
+		} else if (state.value !== undefined) {
+			this.override("modelProfile.default", state.value);
+		}
+	}
 
 	/*
 	 * Override model roles (helper for modelRoles record).
 	 */
 	overrideModelRoles(roles: ReadOnlyDict<string>): void {
-		const next = shallowStringRecord(getByPath(this.#overrides, ["modelRoles"]));
 		for (const [role, modelId] of Object.entries(roles)) {
-			if (modelId) {
-				next[role] = modelId;
-			}
+			if (modelId) this.#overrideRuntimeModelRecord("modelRoles", role, modelId);
 		}
-		this.override("modelRoles", next);
 	}
 
 	/**
@@ -879,8 +1105,46 @@ export class Settings {
 	// ─────────────────────────────────────────────────────────────────────────
 
 	#rebuildMerged(): void {
-		this.#merged = this.#deepMerge(this.#deepMerge({}, this.#global), this.#project);
-		this.#merged = this.#deepMerge(this.#merged, this.#overrides);
+		const lower = this.#deepMerge(this.#deepMerge({}, this.#global), this.#project);
+		this.#merged = this.#deepMerge(lower, this.#overrides);
+
+		for (const modelPath of ["modelRoles", "task.agentModelOverrides"] as const) {
+			const segments = modelPath.split(".");
+			const lowerValue = getByPath(lower, segments);
+			const runtimeValue = getByPath(this.#overrides, segments);
+			const resetKeys = this.#runtimeModelResetKeys.get(modelPath);
+			const hasRuntimeState =
+				runtimeValue !== undefined || this.#runtimeModelWholeResets.has(modelPath) || resetKeys !== undefined;
+			if (lowerValue === undefined && !hasRuntimeState) continue;
+
+			const lowerRecord = shallowStringRecord(lowerValue);
+			const effective: Record<string, string> = {};
+			if (this.#runtimeModelWholeResets.has(modelPath)) {
+				for (const key of this.#runtimeModelWholeResetReleasedKeys.get(modelPath) ?? []) {
+					const value = lowerRecord[key];
+					if (value !== undefined) setOwnValue(effective, key, value);
+				}
+			} else {
+				assignStringRecord(effective, lowerRecord);
+				if (resetKeys) {
+					for (const key of resetKeys) delete effective[key];
+				}
+			}
+			assignStringRecord(effective, shallowStringRecord(runtimeValue));
+			setByPath(this.#merged, segments, effective);
+		}
+		const runtimeProfileDefault = getByPath(this.#overrides, ["modelProfile", "default"]);
+		if (runtimeProfileDefault === undefined) {
+			const globalProfileDefault = getByPath(this.#global, ["modelProfile", "default"]);
+			if (globalProfileDefault === null) {
+				setByPath(this.#merged, ["modelProfile", "default"], undefined);
+			} else if (typeof globalProfileDefault === "string") {
+				setByPath(this.#merged, ["modelProfile", "default"], globalProfileDefault);
+			}
+		}
+		if (this.#runtimeModelProfileDefaultSuppressed) {
+			setByPath(this.#merged, ["modelProfile", "default"], undefined);
+		}
 	}
 
 	#fireAllHooks(): void {
@@ -897,22 +1161,13 @@ export class Settings {
 		const result = { ...base };
 		for (const key of Object.keys(overrides)) {
 			const override = overrides[key];
-			const baseVal = base[key];
-
 			if (override === undefined) continue;
 
-			if (
-				typeof override === "object" &&
-				override !== null &&
-				!Array.isArray(override) &&
-				typeof baseVal === "object" &&
-				baseVal !== null &&
-				!Array.isArray(baseVal)
-			) {
-				result[key] = this.#deepMerge(baseVal as RawSettings, override as RawSettings);
-			} else {
-				result[key] = override;
-			}
+			const baseValue = base[key];
+			const mergedValue = isRecordObject(override)
+				? this.#deepMerge(isRecordObject(baseValue) ? baseValue : {}, override)
+				: override;
+			setOwnValue(result, key, mergedValue);
 		}
 		return result;
 	}

--- a/packages/coding-agent/src/modes/components/agent-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/agent-dashboard.ts
@@ -82,6 +82,7 @@ interface AgentDashboardModelContext {
 	modelRegistry?: ModelRegistry;
 	activeModelPattern?: string;
 	defaultModelPattern?: string;
+	persistModelOverride?: (agentName: string, value: string | undefined) => void;
 }
 
 const SOURCE_ORDER: Record<AgentSource, number> = {
@@ -465,16 +466,17 @@ export class AgentDashboard extends Container {
 		this.#settingsManager.set("task.disabledAgents", disabled);
 	}
 
-	#persistModelOverrides(): void {
-		if (!this.#settingsManager) return;
-		const overrides: Record<string, string> = {};
-		for (const agent of this.#allAgents) {
-			const value = agent.overrideModel?.trim();
-			if (value) {
-				overrides[agent.name] = value;
-			}
+	#persistModelOverride(agentName: string, value: string | undefined): void {
+		if (this.modelContext.persistModelOverride) {
+			this.modelContext.persistModelOverride(agentName, value);
+			return;
 		}
-		this.#settingsManager.set("task.agentModelOverrides", overrides);
+		if (!this.#settingsManager) return;
+		if (value) {
+			this.#settingsManager.setAgentModelOverride(agentName, value);
+		} else {
+			this.#settingsManager.clearAgentModelOverride(agentName);
+		}
 	}
 
 	#toggleSelectedAgent(): void {
@@ -504,9 +506,10 @@ export class AgentDashboard extends Container {
 		if (!this.#editingAgentName) return;
 		const selected = this.#allAgents.find(agent => agent.name === this.#editingAgentName);
 		if (!selected) return;
-		const value = rawValue.trim();
-		selected.overrideModel = value || undefined;
-		this.#persistModelOverrides();
+		const value = rawValue.trim() || undefined;
+		this.#persistModelOverride(selected.name, value);
+		selected.overrideModel =
+			this.#settingsManager?.get("task.agentModelOverrides")[selected.name]?.trim() || undefined;
 		this.#editingAgentName = null;
 		this.#editInput = null;
 		this.#applyFilters();

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -597,6 +597,8 @@ export class ModelSelectorComponent extends Container {
 		} else {
 			// Reload config and cached discovery state without blocking on live provider refresh
 			await this.#modelRegistry.refresh("offline");
+			this.#roles = {};
+			this.#loadRoleModels();
 
 			// Check for models.json errors
 			const loadError = this.#modelRegistry.getError();
@@ -1737,6 +1739,28 @@ export class ModelSelectorComponent extends Container {
 		return undefined;
 	}
 
+	#reloadRoleModelsFromSettings(): void {
+		this.#roles = {};
+		this.#loadRoleModels();
+		this.#updateList();
+	}
+
+	#commitAssignment(selection: Extract<ModelSelectorSelection, { kind: "assignment" }>): void {
+		try {
+			const result = this.#onSelectCallback(selection);
+			if (result) {
+				void result.then(
+					() => this.#reloadRoleModelsFromSettings(),
+					() => this.#reloadRoleModelsFromSettings(),
+				);
+			} else {
+				this.#reloadRoleModelsFromSettings();
+			}
+		} catch {
+			this.#reloadRoleModelsFromSettings();
+		}
+	}
+
 	#handleSelect(
 		item: ModelItem | CanonicalModelItem,
 		role: GjcModelAssignmentTargetId | null,
@@ -1758,7 +1782,7 @@ export class ModelSelectorComponent extends Container {
 
 		// For temporary role, don't save to settings - just notify caller
 		if (role === null) {
-			this.#onSelectCallback({
+			this.#commitAssignment({
 				kind: "assignment",
 				model: item.model,
 				role: null,
@@ -1775,13 +1799,7 @@ export class ModelSelectorComponent extends Container {
 				? item.selector
 				: formatModelSelectorValue(item.selector, selectedThinkingLevel);
 
-		// Update local state for UI
-		for (const targetRole of roles ?? [role]) {
-			this.#roles[targetRole] = { model: item.model, thinkingLevel: selectedThinkingLevel };
-		}
-
-		// Notify caller (for updating agent state if needed)
-		this.#onSelectCallback({
+		this.#commitAssignment({
 			kind: "assignment",
 			model: item.model,
 			role,
@@ -1789,9 +1807,6 @@ export class ModelSelectorComponent extends Container {
 			thinkingLevel: selectedThinkingLevel,
 			selector: selectorValue,
 		});
-
-		// Update list to show new badges
-		this.#updateList();
 	}
 
 	getSearchInput(): Input {

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -704,6 +704,7 @@ export class SettingsSelectorComponent extends Container {
 	#statusPreviewText: Text | null = null;
 	#currentTabId: SettingTab | "plugins" = "appearance";
 	#textInputActive = false;
+	#modelProfileSelectionPending = false;
 
 	constructor(
 		private readonly context: SettingsRuntimeContext,
@@ -937,11 +938,29 @@ export class SettingsSelectorComponent extends Container {
 			options,
 			currentValue,
 			value => {
-				this.#setSettingValue(def.path, value);
-				this.callbacks.onChange(def.path, value);
-				done(value);
+				if (this.#modelProfileSelectionPending) return;
+				if (def.path === "modelProfile.default") this.#modelProfileSelectionPending = true;
+				if (def.path !== "modelProfile.default") {
+					this.#setSettingValue(def.path, value);
+					this.callbacks.onChange(def.path, value);
+					done(value);
+					return;
+				}
+
+				const settle = () => {
+					this.#modelProfileSelectionPending = false;
+					const committedValue = this.#getSubmenuCurrentValue(def.path, settings.get(def.path));
+					done(committedValue);
+				};
+				const result = this.callbacks.onChange(def.path, value) as unknown;
+				if (result instanceof Promise) {
+					void result.then(settle, settle);
+				} else {
+					settle();
+				}
 			},
 			() => {
+				if (this.#modelProfileSelectionPending) return;
 				onPreviewCancel?.();
 				done();
 			},
@@ -1167,6 +1186,7 @@ export class SettingsSelectorComponent extends Container {
 	}
 
 	handleInput(data: string): void {
+		if (this.#modelProfileSelectionPending) return;
 		// Handle tab switching — but NOT when a text input is active, since
 		// arrow keys must reach the cursor and Tab must not switch tabs.
 		if (

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -627,6 +627,19 @@ export class SelectorController {
 			modelRegistry: this.ctx.session.modelRegistry,
 			activeModelPattern,
 			defaultModelPattern,
+			persistModelOverride: (agentName, value) => {
+				const assignments = value ? new Map([[agentName, value]]) : new Map<string, string>();
+				const materializedProfile = materializeActiveModelProfileAssignments({
+					session: this.ctx.session,
+					settings: this.ctx.settings,
+					assignments,
+				});
+				if (!materializedProfile && value) {
+					this.ctx.settings.setAgentModelOverride(agentName, value);
+				} else if (!value) {
+					this.ctx.settings.clearAgentModelOverride(agentName);
+				}
+			},
 		});
 		this.showSelector(done => {
 			dashboard.onClose = () => {
@@ -645,7 +658,7 @@ export class SelectorController {
 	 * Most settings are saved directly via SettingsManager in the definitions.
 	 * This handles side effects and session-specific settings.
 	 */
-	handleSettingChange(id: string, value: unknown): void {
+	handleSettingChange(id: string, value: unknown): void | Promise<void> {
 		// Discovery provider toggles
 		if (id.startsWith("discovery.")) {
 			const providerId = id.replace("discovery.", "");
@@ -680,16 +693,19 @@ export class SelectorController {
 				break;
 
 			case "modelProfile.default": {
-				// Applying the default profile live mirrors the /model preset flow so the
-				// running session switches immediately, not only on next startup.
+				// Profile activation owns the durable write. The settings selector must
+				// only emit intent so failed validation cannot become the restart default.
 				const profileName = typeof value === "string" ? value : "";
 				if (!profileName) break;
-				this.#applyModelProfile(profileName, true)
-					.then(() => this.ctx.ui.requestRender())
-					.catch(error => {
+				return this.#applyModelProfile(profileName, true).then(
+					() => {
+						this.ctx.ui.requestRender();
+					},
+					error => {
 						this.ctx.showError(error instanceof Error ? error.message : String(error));
-					});
-				break;
+						this.ctx.ui.requestRender();
+					},
+				);
 			}
 			case "clearOnShrink":
 				this.ctx.ui.setClearOnShrink(value as boolean);
@@ -945,20 +961,13 @@ export class SelectorController {
 								assignments,
 							});
 							if (!materializedProfile) {
-								const overrides = this.ctx.settings.get("task.agentModelOverrides");
-								const nextOverrides = { ...overrides };
-								let writesOverrides = false;
 								for (const targetRole of targetRoles) {
 									const target = GJC_MODEL_ASSIGNMENT_TARGETS[targetRole];
 									if (target.settingsPath === "modelRoles") {
 										this.ctx.settings.setModelRole(targetRole, value);
 									} else {
-										nextOverrides[targetRole] = value;
-										writesOverrides = true;
+										this.ctx.settings.setAgentModelOverride(targetRole, value);
 									}
-								}
-								if (writesOverrides) {
-									this.ctx.settings.set("task.agentModelOverrides", nextOverrides);
 								}
 							}
 							modelSelector.refreshRoleAssignments({
@@ -1029,10 +1038,7 @@ export class SelectorController {
 								if (target.settingsPath === "modelRoles") {
 									this.ctx.settings.setModelRole(role, value);
 								} else {
-									this.ctx.settings.set("task.agentModelOverrides", {
-										...this.ctx.settings.get("task.agentModelOverrides"),
-										[role]: value,
-									});
+									this.ctx.settings.setAgentModelOverride(role, value);
 								}
 							}
 							modelSelector.refreshRoleAssignments({

--- a/packages/coding-agent/test/agent-dashboard-model-override.test.ts
+++ b/packages/coding-agent/test/agent-dashboard-model-override.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { materializeActiveModelProfileAssignments } from "@gajae-code/coding-agent/config/model-profile-activation";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentDashboard } from "@gajae-code/coding-agent/modes/components/agent-dashboard";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { Snowflake } from "@gajae-code/utils";
+
+let testTheme = await getThemeByName("red-claw");
+const testDirs: string[] = [];
+
+function typeText(dashboard: AgentDashboard, text: string): void {
+	for (const char of text) dashboard.handleInput(char);
+}
+
+describe("AgentDashboard model overrides", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("red-claw");
+		if (!testTheme) throw new Error("Failed to load test theme");
+		setThemeInstance(testTheme);
+	});
+
+	afterEach(() => {
+		for (const dir of testDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	test("edits and clears one agent without dropping runtime resets or durable siblings", async () => {
+		const cwd = path.join(os.tmpdir(), `agent-dashboard-model-${Snowflake.next()}`);
+		testDirs.push(cwd);
+		fs.mkdirSync(cwd, { recursive: true });
+
+		const settings = Settings.isolated();
+		settings.set("task.agentModelOverrides", {
+			executor: "durable/executor",
+			planner: "durable/planner",
+		});
+		settings.override("task.agentModelOverrides", null as never);
+
+		const dashboard = await AgentDashboard.create(cwd, settings, 24);
+		typeText(dashboard, "executor");
+		dashboard.handleInput("\n");
+		const selected = "provider/selected:high";
+		typeText(dashboard, selected);
+		dashboard.handleInput("\n");
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({ executor: selected });
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			executor: selected,
+			planner: "durable/planner",
+		});
+
+		dashboard.handleInput("\n");
+		for (let i = 0; i < selected.length; i++) dashboard.handleInput("\x7f");
+		dashboard.handleInput("\n");
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({});
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			planner: "durable/planner",
+		});
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			planner: "durable/planner",
+		});
+	});
+	test("materializes an active profile before saving a dashboard override", async () => {
+		const cwd = path.join(os.tmpdir(), `agent-dashboard-profile-${Snowflake.next()}`);
+		testDirs.push(cwd);
+		fs.mkdirSync(cwd, { recursive: true });
+
+		const settings = Settings.isolated();
+		settings.set("modelProfile.default", "profile-a");
+		settings.set("task.agentModelOverrides", { planner: "durable/planner" });
+		settings.override("task.agentModelOverrides", {
+			executor: "profile/executor",
+			architect: "profile/architect",
+		});
+		let activeProfile: string | undefined = "profile-a";
+		const session = {
+			model: undefined,
+			thinkingLevel: undefined,
+			getActiveModelProfile: () => activeProfile,
+			setActiveModelProfile: (profile: string | undefined) => {
+				activeProfile = profile;
+			},
+		};
+
+		const dashboard = await AgentDashboard.create(cwd, settings, 24, {
+			persistModelOverride: (agentName, value) => {
+				const materialized = materializeActiveModelProfileAssignments({
+					session,
+					settings,
+					assignments: value ? new Map([[agentName, value]]) : new Map(),
+				});
+				if (!materialized && value) settings.setAgentModelOverride(agentName, value);
+				else if (!value) settings.clearAgentModelOverride(agentName);
+			},
+		});
+		typeText(dashboard, "executor");
+		dashboard.handleInput("\n");
+		for (let i = 0; i < "profile/executor".length; i++) dashboard.handleInput("\x7f");
+		const selected = "provider/dashboard-selected:high";
+		typeText(dashboard, selected);
+		dashboard.handleInput("\n");
+
+		expect(activeProfile).toBeUndefined();
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			planner: "durable/planner",
+			executor: selected,
+			architect: "profile/architect",
+		});
+	});
+	test("materializes an active profile before clearing a dashboard override", async () => {
+		const cwd = path.join(os.tmpdir(), `agent-dashboard-profile-clear-${Snowflake.next()}`);
+		testDirs.push(cwd);
+		fs.mkdirSync(cwd, { recursive: true });
+
+		const settings = Settings.isolated();
+		settings.set("modelProfile.default", "profile-a");
+		settings.set("task.agentModelOverrides", { planner: "durable/planner" });
+		settings.override("task.agentModelOverrides", {
+			executor: "profile/executor",
+			architect: "profile/architect",
+		});
+		let activeProfile: string | undefined = "profile-a";
+		const session = {
+			model: undefined,
+			thinkingLevel: undefined,
+			getActiveModelProfile: () => activeProfile,
+			setActiveModelProfile: (profile: string | undefined) => {
+				activeProfile = profile;
+			},
+		};
+		const dashboard = await AgentDashboard.create(cwd, settings, 24, {
+			persistModelOverride: (agentName, value) => {
+				const materialized = materializeActiveModelProfileAssignments({
+					session,
+					settings,
+					assignments: value ? new Map([[agentName, value]]) : new Map(),
+				});
+				if (!materialized && value) settings.setAgentModelOverride(agentName, value);
+				else if (!value) settings.clearAgentModelOverride(agentName);
+			},
+		});
+
+		typeText(dashboard, "executor");
+		dashboard.handleInput("\n");
+		for (let i = 0; i < "profile/executor".length; i++) dashboard.handleInput("\x7f");
+		dashboard.handleInput("\n");
+
+		expect(activeProfile).toBeUndefined();
+		expect(settings.get("modelProfile.default")).toBeUndefined();
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			planner: "durable/planner",
+			architect: "profile/architect",
+		});
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			planner: "durable/planner",
+			architect: "profile/architect",
+		});
+	});
+});

--- a/packages/coding-agent/test/custom-model-preset-creation.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-creation.test.ts
@@ -633,6 +633,12 @@ describe("custom model preset creation", () => {
 		expect(settings.get("modelRoles").default).toBe("my-oai/gpt-custom:low");
 		expect(settings.get("task.agentModelOverrides").executor).toBe("my-oai/gpt-custom");
 		expect(activeProfiles.at(-1)).toBeUndefined();
+		expect(settings.getGlobal("modelRoles")).toEqual({
+			default: "my-oai/gpt-custom:low",
+		});
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			executor: "my-oai/gpt-custom",
+		});
 
 		await restoreMaterializedModelProfileForDeletion({ settings, session, snapshot });
 
@@ -640,6 +646,63 @@ describe("custom model preset creation", () => {
 		expect(settings.get("modelRoles")).toEqual({ default: "old/default" });
 		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });
 		expect(activeProfiles.at(-1)).toBe("other-session");
+		expect(settings.getGlobal("modelProfile.default")).toBeUndefined();
+		expect(settings.getGlobal("modelRoles")).toBeUndefined();
+		expect(settings.getGlobal("task.agentModelOverrides")).toBeUndefined();
+	});
+	it("keeps materialized state inactive when later settings restoration cannot commit", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "custom-default",
+			displayName: "Custom Default",
+			requiredProviders: ["my-oai"],
+			modelMapping: {
+				default: "my-oai/gpt-custom:low",
+				executor: "my-oai/gpt-custom",
+			},
+			source: "user",
+		};
+		const settings = Settings.isolated({
+			"modelProfile.default": "custom-default",
+			"task.agentModelOverrides": { critic: "runtime/critic" },
+		});
+		let activeProfile: string | undefined = "custom-default";
+		const session = {
+			model: currentModel("other", "active"),
+			thinkingLevel: undefined,
+			sessionId: "session",
+			setActiveModelProfile: (profileName: string | undefined) => {
+				activeProfile = profileName;
+			},
+			getActiveModelProfile: () => activeProfile,
+		};
+		const snapshot = await materializeModelProfileForDeletion({
+			session,
+			settings,
+			modelRegistry: createRegistry([[customProfile.name, customProfile]]),
+			profileName: "custom-default",
+		});
+		const materializedGlobalRoles = settings.getGlobal("modelRoles");
+		const materializedGlobalAgents = settings.getGlobal("task.agentModelOverrides");
+		const materializedRuntimeRoles = settings.getRuntimeModelRoles();
+		const materializedRuntimeAgents = settings.getRuntimeAgentModelOverrides();
+		const materializedProfileState = settings.getRuntimeModelProfileDefaultState();
+		const flushSpy = spyOn(settings, "flushOrThrow").mockRejectedValueOnce(new Error("restore flush failed"));
+
+		try {
+			await expect(restoreMaterializedModelProfileForDeletion({ settings, session, snapshot })).rejects.toThrow(
+				"restore flush failed",
+			);
+		} finally {
+			flushSpy.mockRestore();
+		}
+
+		expect(activeProfile).toBeUndefined();
+		expect(settings.getGlobal("modelRoles")).toEqual(materializedGlobalRoles);
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual(materializedGlobalAgents);
+		expect(settings.getRuntimeModelRoles()).toEqual(materializedRuntimeRoles);
+		expect(settings.getRuntimeAgentModelOverrides()).toEqual(materializedRuntimeAgents);
+		expect(settings.getRuntimeModelProfileDefaultState()).toEqual(materializedProfileState);
+		expect(settings.get("modelProfile.default")).toBeUndefined();
 	});
 	it("rolls back deletion materialization when settings flush fails", async () => {
 		const customProfile: ModelProfileDefinition = {
@@ -664,7 +727,7 @@ describe("custom model preset creation", () => {
 			},
 			getActiveModelProfile: () => activeProfiles.at(-1),
 		};
-		const flushSpy = spyOn(settings, "flush").mockRejectedValueOnce(new Error("flush failed"));
+		const flushSpy = spyOn(settings, "flushOrThrow").mockRejectedValueOnce(new Error("flush failed"));
 
 		try {
 			await expect(
@@ -683,6 +746,64 @@ describe("custom model preset creation", () => {
 		expect(settings.get("modelRoles")).toEqual({ default: "old/default" });
 		expect(settings.get("task.agentModelOverrides")).toEqual({ critic: "old/critic" });
 		expect(activeProfiles.at(-1)).toBe("custom-default");
+	});
+	it("preserves malformed runtime resets through deletion materialization rollback", async () => {
+		const customProfile: ModelProfileDefinition = {
+			name: "custom-default",
+			displayName: "Custom Default",
+			requiredProviders: ["my-oai"],
+			modelMapping: {
+				default: "my-oai/gpt-custom:low",
+				executor: "my-oai/gpt-custom",
+			},
+			source: "user",
+		};
+		const settings = Settings.isolated({
+			"modelProfile.default": "custom-default",
+		});
+		settings.set("task.agentModelOverrides", {
+			critic: "durable/critic",
+			executor: "durable/executor-hidden-by-reset",
+		});
+		settings.override("task.agentModelOverrides", { executor: false } as never);
+		const session = {
+			model: currentModel("other", "active"),
+			thinkingLevel: undefined,
+			sessionId: "session",
+			setActiveModelProfile: () => {},
+			getActiveModelProfile: () => "custom-default",
+		};
+		const flushSpy = spyOn(settings, "flushOrThrow").mockRejectedValueOnce(new Error("flush failed"));
+
+		try {
+			await expect(
+				materializeModelProfileForDeletion({
+					session,
+					settings,
+					modelRegistry: createRegistry([[customProfile.name, customProfile]]),
+					profileName: "custom-default",
+				}),
+			).rejects.toThrow("flush failed");
+		} finally {
+			flushSpy.mockRestore();
+		}
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			critic: "durable/critic",
+			executor: "durable/executor-hidden-by-reset",
+		});
+
+		settings.set("task.agentModelOverrides", {
+			critic: "durable/critic",
+			executor: "durable/executor-added-after-rollback",
+		});
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			critic: "durable/critic",
+		});
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			critic: "durable/critic",
+			executor: "durable/executor-added-after-rollback",
+		});
 	});
 	it("restores a deleted custom preset when post-delete notification fails", async () => {
 		const unsafeDisplayName = "Custom\x1b[31m Default\x1b[0m\nRestored";

--- a/packages/coding-agent/test/login-preset-recommendation.test.ts
+++ b/packages/coding-agent/test/login-preset-recommendation.test.ts
@@ -55,7 +55,7 @@ function createControllerContext(
 		setCalls.push({ path: path as string, value });
 		return originalSet(path, value);
 	}) as typeof settings.set;
-	settings.flush = vi.fn(async () => {}) as typeof settings.flush;
+	settings.flushOrThrow = vi.fn(async () => {}) as typeof settings.flushOrThrow;
 
 	const profiles = new Map((options.profiles ?? [codexProfile, minimaxProfile]).map(entry => [entry.name, entry]));
 	let activeProfile = options.activeProfile;

--- a/packages/coding-agent/test/model-profile-activation-redteam.test.ts
+++ b/packages/coding-agent/test/model-profile-activation-redteam.test.ts
@@ -65,7 +65,7 @@ function instrumentSettings(settings: Settings) {
 		overrideCalls.push(path);
 		return originalOverride(path, value);
 	}) as typeof settings.override;
-	settings.flush = async () => {
+	settings.flushOrThrow = async () => {
 		flushCount += 1;
 	};
 	return {

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -230,6 +230,97 @@ describe("model profile activation", () => {
 		expect(settings.get("modelProfile.default")).toBeUndefined();
 		expect(session.getActiveModelProfile()).toBeUndefined();
 	});
+	test("materialization preserves durable siblings hidden by a whole runtime reset", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({ "modelProfile.default": "profile-a" });
+		settings.set("task.agentModelOverrides", { planner: "durable/planner" });
+		settings.override("task.agentModelOverrides", null as never);
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+
+		const materialized = materializeActiveModelProfileAssignment({
+			session,
+			settings,
+			role: "executor",
+			selector: "provider-c/executor:medium",
+		});
+		expect(materialized).toBe(true);
+		settings.clearOverride("task.agentModelOverrides");
+
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			planner: "durable/planner",
+			executor: "provider-c/executor:medium",
+			architect: "provider-a/architect",
+		});
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			planner: "durable/planner",
+			executor: "provider-c/executor:medium",
+			architect: "provider-a/architect",
+		});
+	});
+	test("batch materialization preserves hidden durable model and agent siblings", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({ "modelProfile.default": "profile-a" });
+		settings.set("modelRoles", { smol: "durable/smol" });
+		settings.set("task.agentModelOverrides", { planner: "durable/planner" });
+		settings.override("modelRoles", null as never);
+		settings.override("task.agentModelOverrides", null as never);
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+
+		const materialized = materializeActiveModelProfileAssignments({
+			session,
+			settings,
+			assignments: new Map([
+				["default", "provider-c/default:low"],
+				["executor", "provider-c/executor:medium"],
+			]),
+		});
+		expect(materialized).toBe(true);
+		expect(settings.getGlobal("modelRoles")).toEqual({
+			smol: "durable/smol",
+			default: "provider-c/default:low",
+		});
+		expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+			planner: "durable/planner",
+			executor: "provider-c/executor:medium",
+			architect: "provider-a/architect",
+		});
+
+		settings.clearOverride("modelRoles");
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("modelRoles")).toEqual({
+			smol: "durable/smol",
+			default: "provider-c/default:low",
+		});
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			planner: "durable/planner",
+			executor: "provider-c/executor:medium",
+			architect: "provider-a/architect",
+		});
+	});
+	test("materialized explicit assignments release only their whole-reset leaves", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({ "modelProfile.default": "profile-a" });
+		settings.override("task.agentModelOverrides", null as never);
+		await activateModelProfile({ session, modelRegistry: fakeRegistry(), settings, profileName: "profile-a" });
+
+		const materialized = materializeActiveModelProfileAssignment({
+			session,
+			settings,
+			role: "executor",
+			selector: "provider-c/executor:medium",
+		});
+		expect(materialized).toBe(true);
+		settings.clearAgentModelOverride("executor");
+		settings.set("task.agentModelOverrides", {
+			executor: "durable/executor-added-after-materialization",
+			planner: "durable/planner-added-after-materialization",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "durable/executor-added-after-materialization",
+			architect: "provider-a/architect",
+		});
+	});
 
 	test("materializing a default override stores the selected default and clears the profile", async () => {
 		const session = fakeSession();
@@ -311,7 +402,7 @@ describe("model profile activation", () => {
 			return originalSet(path, value);
 		}) as typeof settings.set;
 		let flushCount = 0;
-		settings.flush = async () => {
+		settings.flushOrThrow = async () => {
 			flushCount += 1;
 		};
 
@@ -384,7 +475,7 @@ describe("model profile activation", () => {
 			settings,
 			profileName: "profile-a",
 		});
-		settings.flush = async () => {
+		settings.flushOrThrow = async () => {
 			throw new Error("flush failed");
 		};
 
@@ -398,6 +489,13 @@ describe("model profile activation", () => {
 		expect(settings.get("modelProfile.default")).toBeUndefined();
 		expect(settings.get("defaultThinkingLevel")).toBe(ThinkingLevel.Low);
 		expect(session.getActiveModelProfile()).toBeUndefined();
+		expect(settings.getGlobal("modelRoles")).toBeUndefined();
+		expect(settings.getGlobal("task.agentModelOverrides")).toBeUndefined();
+		expect(settings.getGlobal("defaultThinkingLevel")).toBeUndefined();
+		expect(settings.getRuntimeModelRoles()).toEqual({});
+		expect(settings.getRuntimeAgentModelOverrides()).toEqual({
+			executor: "provider-a/original",
+		});
 	});
 
 	test("precedence composes configured, default, mpreset, and explicit overrides", async () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -2709,6 +2709,135 @@ describe("ModelRegistry", () => {
 		expect(Settings.instance.getModelRole("default")).toBe("proxy/local-selector:high");
 		expect(Settings.instance.get("task.agentModelOverrides").executor).toBe("proxy/executor-selector");
 	});
+	test("does not copy lower-precedence assignments into runtime when no bindings exist", async () => {
+		const settings = await Settings.init({ inMemory: true });
+		settings.set("modelRoles", { default: "durable/default" });
+		settings.set("task.agentModelOverrides", { planner: "project-or-global/planner" });
+
+		writeRawModelsConfig({ providers: {} });
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		registry.applyConfiguredModelBindings(settings);
+
+		expect(settings.getRuntimeModelRoles()).toEqual({});
+		expect(settings.getRuntimeAgentModelOverrides()).toEqual({});
+		expect(settings.get("modelRoles")).toEqual({ default: "durable/default" });
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			planner: "project-or-global/planner",
+		});
+	});
+	test("preserves prototype-like configured agent binding keys across removal", async () => {
+		const settings = await Settings.init({ inMemory: true });
+		const agentModelOverrides = Object.fromEntries([["__proto__", "proxy/prototype-selector"]]);
+		writeRawModelsConfig({
+			modelBindings: { agentModelOverrides },
+			providers: {},
+		});
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		registry.applyConfiguredModelBindings(settings);
+
+		let runtime = settings.getRuntimeAgentModelOverrides();
+		expect(Object.hasOwn(runtime, "__proto__")).toBe(true);
+		expect(Object.getOwnPropertyDescriptor(runtime, "__proto__")?.value).toBe("proxy/prototype-selector");
+		expect(Object.getOwnPropertyDescriptor(settings.get("task.agentModelOverrides"), "__proto__")?.value).toBe(
+			"proxy/prototype-selector",
+		);
+
+		writeRawModelsConfig({ providers: {} });
+		await Bun.sleep(5);
+		await registry.refresh("offline");
+		runtime = settings.getRuntimeAgentModelOverrides();
+		expect(Object.hasOwn(runtime, "__proto__")).toBe(false);
+		expect(Object.hasOwn(settings.get("task.agentModelOverrides"), "__proto__")).toBe(false);
+	});
+
+	test("preserves runtime record resets across binding refresh and role helper writes", async () => {
+		const settings = await Settings.init({ inMemory: true });
+		settings.set("modelRoles", {
+			default: "durable/default",
+			smol: "durable/smol",
+			slow: "durable/slow",
+		});
+		settings.set("task.agentModelOverrides", {
+			executor: "durable/executor",
+			reviewer: "durable/reviewer",
+		});
+		settings.override("modelRoles", null as never);
+		settings.override("task.agentModelOverrides", null as never);
+		settings.setModelRole("default", "selected/default");
+		settings.setAgentModelOverride("executor", "selected/executor");
+
+		writeRawModelsConfig({ providers: {} });
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		registry.applyConfiguredModelBindings(settings);
+		await registry.refresh("offline");
+
+		expect(settings.get("modelRoles")).toEqual({ default: "selected/default" });
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "selected/executor",
+		});
+
+		settings.overrideModelRoles({ plan: "selected/plan" });
+		expect(settings.get("modelRoles")).toEqual({
+			default: "selected/default",
+			plan: "selected/plan",
+		});
+
+		settings.clearOverride("modelRoles");
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("modelRoles")).toEqual({
+			default: "selected/default",
+			smol: "durable/smol",
+			slow: "durable/slow",
+		});
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "selected/executor",
+			reviewer: "durable/reviewer",
+		});
+	});
+	test("restores opaque resets instead of durable bindings after configured bindings are removed", async () => {
+		const settings = await Settings.init({ inMemory: true });
+		settings.set("modelRoles", { default: "durable/default" });
+		settings.set("task.agentModelOverrides", { executor: "durable/executor" });
+		settings.override("modelRoles", null as never);
+		settings.override("task.agentModelOverrides", { executor: false } as never);
+
+		writeRawModelsConfig({
+			modelBindings: {
+				modelRoles: { default: "proxy/local-selector:high" },
+				agentModelOverrides: { executor: "proxy/executor-selector" },
+			},
+			providers: {
+				proxy: providerConfig(
+					"https://proxy.example/v1",
+					[{ id: "local-selector", reasoning: true }],
+					"openai-completions",
+				),
+			},
+		});
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		registry.applyConfiguredModelBindings(settings);
+		expect(settings.getModelRole("default")).toBe("proxy/local-selector:high");
+		expect(settings.get("task.agentModelOverrides").executor).toBe("proxy/executor-selector");
+
+		writeRawModelsConfig({
+			providers: {
+				proxy: providerConfig(
+					"https://proxy.example/v1",
+					[{ id: "local-selector", reasoning: true }],
+					"openai-completions",
+				),
+			},
+		});
+		await Bun.sleep(5);
+		await registry.refresh("offline");
+		expect(settings.get("modelRoles")).toEqual({});
+		expect(settings.get("task.agentModelOverrides")).toEqual({});
+
+		settings.clearOverride("modelRoles");
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.getModelRole("default")).toBe("durable/default");
+		expect(settings.get("task.agentModelOverrides").executor).toBe("durable/executor");
+	});
 
 	test("defers model bindings until settings are initialized", () => {
 		writeRawModelsConfig({

--- a/packages/coding-agent/test/model-selector-controller-batch.test.ts
+++ b/packages/coding-agent/test/model-selector-controller-batch.test.ts
@@ -109,6 +109,131 @@ describe("SelectorController model batch assignments", () => {
 		);
 	});
 
+	test("batch selection wins over live project/profile shadows without persisting their extra keys", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.override("task.agentModelOverrides", {
+			executor: "shadow/executor",
+			architect: "shadow/architect",
+			planner: "shadow/planner",
+			critic: "shadow/critic",
+			reviewer: "shadow/reviewer",
+		});
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			roles: ["executor", "architect", "planner", "critic"],
+			thinkingLevel: ThinkingLevel.Low,
+			selector: "provider-a/selected:low",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:low",
+			architect: "provider-a/selected:low",
+			planner: "provider-a/selected:low",
+			critic: "provider-a/selected:low",
+			reviewer: "shadow/reviewer",
+		});
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:low",
+			architect: "provider-a/selected:low",
+			planner: "provider-a/selected:low",
+			critic: "provider-a/selected:low",
+		});
+	});
+
+	test("single role selection wins over a live project/profile shadow without copying siblings", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.override("task.agentModelOverrides", {
+			executor: "shadow/executor",
+			architect: "shadow/architect",
+			planner: "shadow/planner",
+			critic: "shadow/critic",
+			reviewer: "shadow/reviewer",
+		});
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "planner",
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "shadow/executor",
+			architect: "shadow/architect",
+			planner: "provider-a/selected:high",
+			critic: "shadow/critic",
+			reviewer: "shadow/reviewer",
+		});
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/original-executor:low",
+			planner: "provider-a/selected:high",
+		});
+	});
+
+	test("all-targets selection applies coherently over null reset shadows", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.setAgentModelOverride("reviewer", "provider-a/original-reviewer");
+		settings.override("modelRoles", null as never);
+		settings.override("task.agentModelOverrides", null as never);
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "default",
+			roles: ["default", "executor", "architect", "planner", "critic"],
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(ctx.showError).not.toHaveBeenCalled();
+		expect(settings.getModelRole("default")).toBe("provider-a/selected:high");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:high",
+			architect: "provider-a/selected:high",
+			planner: "provider-a/selected:high",
+			critic: "provider-a/selected:high",
+		});
+		expect(ctx.showStatus).toHaveBeenCalledWith(
+			"All model targets set to provider-a/selected:high for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+		);
+
+		settings.clearOverride("task.agentModelOverrides");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "provider-a/selected:high",
+			architect: "provider-a/selected:high",
+			planner: "provider-a/selected:high",
+			critic: "provider-a/selected:high",
+			reviewer: "provider-a/original-reviewer",
+		});
+	});
+
+	test("single role selection applies without partial failure over a null reset shadow", async () => {
+		const { ctx, settings } = createControllerContext();
+		settings.override("task.agentModelOverrides", null as never);
+		const selector = await openSelector(ctx);
+
+		await selector.__testSelectAssignment({
+			model: selectedModel,
+			role: "planner",
+			thinkingLevel: ThinkingLevel.High,
+			selector: "provider-a/selected:high",
+		});
+
+		expect(ctx.showError).not.toHaveBeenCalled();
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			planner: "provider-a/selected:high",
+		});
+		expect(ctx.showStatus).toHaveBeenCalledWith("planner agent model: provider-a/selected:high");
+	});
+
 	test("all targets selection writes DEFAULT plus every role-agent override", async () => {
 		const { ctx, settings, setModelCalls } = createControllerContext();
 		const selector = await openSelector(ctx);

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -87,7 +87,7 @@ function createControllerContext(options: { missingCredentials?: boolean } = {})
 		"modelProfile.default": "old-profile",
 	});
 	const flush = vi.fn(async () => {});
-	settings.flush = flush as typeof settings.flush;
+	settings.flushOrThrow = flush as typeof settings.flushOrThrow;
 	const setCalls: Array<{ path: string; value: unknown }> = [];
 	const originalSet = settings.set.bind(settings);
 	settings.set = ((path: never, value: never) => {

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -1,12 +1,16 @@
 import { beforeAll, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import type { Model } from "@gajae-code/ai";
 import type { ModelProfileDefinition } from "@gajae-code/coding-agent/config/model-profiles";
-import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import {
 	ModelSelectorComponent,
 	type ModelSelectorSelection,
 } from "@gajae-code/coding-agent/modes/components/model-selector";
+import type { SettingsSelectorComponent } from "@gajae-code/coding-agent/modes/components/settings-selector";
 import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { TUI } from "@gajae-code/tui";
@@ -89,13 +93,19 @@ function createSelector(
 	);
 }
 
-function createControllerContext(options: { missingCredentials?: boolean } = {}) {
-	const settings = Settings.isolated({
-		"task.agentModelOverrides": { executor: "provider-a/original-executor" },
-		"modelProfile.default": "old-profile",
-	});
+function createControllerContext(
+	options: { missingCredentials?: boolean; settings?: Settings; mockFlush?: boolean } = {},
+) {
+	const settings =
+		options.settings ??
+		Settings.isolated({
+			"task.agentModelOverrides": { executor: "provider-a/original-executor" },
+			"modelProfile.default": "old-profile",
+		});
 	const flush = vi.fn(async () => {});
-	settings.flush = flush as typeof settings.flush;
+	if (options.mockFlush !== false) {
+		settings.flushOrThrow = flush as typeof settings.flushOrThrow;
+	}
 	const setCalls: Array<{ path: string; value: unknown }> = [];
 	const originalSet = settings.set.bind(settings);
 	settings.set = ((path: never, value: never) => {
@@ -109,6 +119,7 @@ function createControllerContext(options: { missingCredentials?: boolean } = {})
 		scopedModels: [],
 		modelRegistry: createRegistry(options),
 		setModelTemporaryCalls: [] as Array<{ model: Model; thinkingLevel?: ThinkingLevel }>,
+		getAvailableThinkingLevels: () => [],
 		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
 			this.setModelTemporaryCalls.push({ model: next, thinkingLevel });
 			this.model = next;
@@ -116,13 +127,14 @@ function createControllerContext(options: { missingCredentials?: boolean } = {})
 		},
 	};
 	const ctx = {
-		ui: { setFocus: vi.fn(), requestRender: vi.fn() },
+		ui: { setFocus: vi.fn(), requestRender: vi.fn(), terminal: { columns: 120 } },
 		editorContainer: { clear: vi.fn(), addChild: vi.fn() },
-		editor: {},
+		editor: { getTopBorderAvailableWidth: () => 120 },
 		settings,
 		session,
-		statusLine: { invalidate: vi.fn() },
+		statusLine: { invalidate: vi.fn(), getPreviewContent: () => "preview", updateSettings: vi.fn() },
 		updateEditorBorderColor: vi.fn(),
+		updateEditorTopBorder: vi.fn(),
 		showStatus: vi.fn(),
 		showError: vi.fn(),
 	};
@@ -382,5 +394,49 @@ describe("model selector profiles", () => {
 		expect(session.setModelTemporaryCalls).toEqual([]);
 		expect(session.model).toBe(alternateModel);
 		expect(settings.get("modelProfile.default")).toBe("old-profile");
+	});
+	test("settings selector validates before committing the restart default", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-settings-profile-"));
+		const cwd = path.join(root, "project");
+		const agentDir = path.join(root, "agent");
+		await fs.mkdir(cwd, { recursive: true });
+		resetSettingsForTest();
+
+		try {
+			const persisted = await Settings.init({ cwd, agentDir });
+			persisted.set("modelProfile.default", "old-profile");
+			await persisted.flushOrThrow();
+
+			const { ctx, settings, session } = createControllerContext({
+				missingCredentials: true,
+				settings: persisted,
+				mockFlush: false,
+			});
+			const controller = new SelectorController(ctx as never);
+			controller.showSettingsSelector();
+			await Bun.sleep(20);
+
+			const component = ctx.editorContainer.addChild.mock.calls.at(-1)?.[0] as SettingsSelectorComponent;
+			component.handleInput("\x1b[C"); // Model tab.
+			component.handleInput("\n"); // Open Default Model Profile.
+			component.handleInput("\n"); // Request profile-a.
+
+			expect(settings.get("modelProfile.default")).toBe("old-profile");
+			await Bun.sleep(10);
+			expect(ctx.showError).toHaveBeenCalledWith(
+				'Model profile "Profile Alpha" requires credentials for: provider-a. Run /login and configure the missing provider(s), then retry.',
+			);
+			expect(session.setModelTemporaryCalls).toEqual([]);
+			expect(settings.get("modelProfile.default")).toBe("old-profile");
+			expect(component.render(120).join("\n")).toContain("old-profile");
+
+			await settings.flushOrThrow();
+			resetSettingsForTest();
+			const fresh = await Settings.init({ cwd, agentDir });
+			expect(fresh.get("modelProfile.default")).toBe("old-profile");
+		} finally {
+			resetSettingsForTest();
+			await fs.rm(root, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -51,7 +51,7 @@ interface CreateSelectorOptions {
 function createSelector(
 	model: Model,
 	settings: Settings,
-	onSelect: (selection: TestModelSelectorSelection) => void = () => {},
+	onSelect: (selection: TestModelSelectorSelection) => void | Promise<void> = () => {},
 	options: CreateSelectorOptions = {},
 ): ModelSelectorComponent {
 	const modelRegistry =
@@ -197,6 +197,171 @@ describe("ModelSelector canonical model selection", () => {
 		expect(selectedAfterEnter.role).toBe("default");
 		expect(selectedAfterEnter.thinkingLevel).toBe(ThinkingLevel.Off);
 		expect(selectedAfterEnter.selector).toBe(`${model.provider}/${model.id}`);
+	});
+
+	test("keeps reset role badges coherent after offline binding refresh", async () => {
+		installTestTheme();
+		const selectedModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const hiddenModel = getBundledModel("anthropic", "claude-haiku-4-5");
+		if (!selectedModel || !hiddenModel) throw new Error("Expected bundled Anthropic models");
+
+		const selectedSelector = `${selectedModel.provider}/${selectedModel.id}`;
+		const hiddenSelector = `${hiddenModel.provider}/${hiddenModel.id}`;
+		const settings = Settings.isolated();
+		settings.set("modelRoles", { default: selectedSelector });
+		settings.set("task.agentModelOverrides", {
+			executor: selectedSelector,
+			architect: hiddenSelector,
+		});
+		settings.override("modelRoles", null as never);
+		settings.override("task.agentModelOverrides", null as never);
+		settings.setModelRole("default", selectedSelector);
+		settings.setAgentModelOverride("executor", selectedSelector);
+
+		const refreshRelease = Promise.withResolvers<void>();
+		const refreshFinished = Promise.withResolvers<void>();
+		const refresh = vi.fn(async (strategy: string) => {
+			expect(strategy).toBe("offline");
+			await refreshRelease.promise;
+			settings.override("modelRoles", { default: `${selectedSelector}:high` });
+			settings.override("task.agentModelOverrides", { executor: `${selectedSelector}:high` });
+			refreshFinished.resolve();
+		});
+		const modelRegistry = {
+			refresh,
+			getAll: () => [selectedModel, hiddenModel],
+			getAvailable: () => [selectedModel, hiddenModel],
+			getError: () => undefined,
+			getDiscoverableProviders: () => [],
+			getCanonicalModels: () => [],
+			resolveCanonicalModel: () => undefined,
+		} as unknown as ModelRegistry;
+		const ui = { requestRender: vi.fn() } as unknown as TUI;
+		const selector = new ModelSelectorComponent(
+			ui,
+			selectedModel,
+			settings,
+			modelRegistry,
+			[],
+			() => {},
+			() => {},
+			{ temporaryOnly: true },
+		);
+
+		await Bun.sleep(0);
+		expect(refresh).toHaveBeenCalledTimes(1);
+		refreshRelease.resolve();
+		await refreshFinished.promise;
+		await Bun.sleep(0);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("DEFAULT (high)");
+		expect(rendered).toContain("EXECUTOR (high)");
+		expect(rendered).not.toMatch(/ARCHITECT \((?:inherit|off|minimal|low|medium|high|xhigh|max)\)/);
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: `${selectedSelector}:high`,
+		});
+	});
+	test("does not commit optimistic role badges when an async assignment fails", async () => {
+		installTestTheme();
+		const selectedModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const existingModel = getBundledModel("anthropic", "claude-haiku-4-5");
+		if (!selectedModel || !existingModel) throw new Error("Expected bundled Anthropic models");
+
+		const settings = Settings.isolated({
+			"task.agentModelOverrides": {
+				executor: `${existingModel.provider}/${existingModel.id}:high`,
+			},
+		});
+		const callbackStarted = Promise.withResolvers<void>();
+		const callbackRelease = Promise.withResolvers<void>();
+		const selector = createSelector(
+			selectedModel,
+			settings,
+			async () => {
+				callbackStarted.resolve();
+				await callbackRelease.promise;
+				throw new Error("missing API key");
+			},
+			{
+				modelRegistry: {
+					getAll: () => [selectedModel, existingModel],
+					getDiscoverableProviders: () => [],
+					getCanonicalModels: () => [],
+					resolveCanonicalModel: () => undefined,
+				} as unknown as ModelRegistry,
+			},
+		);
+		await Bun.sleep(0);
+
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+		await callbackStarted.promise;
+
+		let rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).not.toMatch(/EXECUTOR \((?:inherit|off|minimal|low|medium|high|xhigh|max)\)/);
+
+		callbackRelease.resolve();
+		await Bun.sleep(0);
+		rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).not.toMatch(/EXECUTOR \((?:inherit|off|minimal|low|medium|high|xhigh|max)\)/);
+		expect(settings.get("task.agentModelOverrides").executor).toBe(
+			`${existingModel.provider}/${existingModel.id}:high`,
+		);
+	});
+	test("commits role badges only after an async assignment succeeds", async () => {
+		installTestTheme();
+		const selectedModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const existingModel = getBundledModel("anthropic", "claude-haiku-4-5");
+		if (!selectedModel || !existingModel) throw new Error("Expected bundled Anthropic models");
+
+		const settings = Settings.isolated({
+			"task.agentModelOverrides": {
+				executor: `${existingModel.provider}/${existingModel.id}:high`,
+			},
+		});
+		const callbackStarted = Promise.withResolvers<void>();
+		const callbackRelease = Promise.withResolvers<void>();
+		const callbackFinished = Promise.withResolvers<void>();
+		const selector = createSelector(
+			selectedModel,
+			settings,
+			async selection => {
+				callbackStarted.resolve();
+				await callbackRelease.promise;
+				settings.setAgentModelOverride(
+					"executor",
+					selection.selector ?? `${selectedModel.provider}/${selectedModel.id}`,
+				);
+				callbackFinished.resolve();
+			},
+			{
+				modelRegistry: {
+					getAll: () => [selectedModel, existingModel],
+					getDiscoverableProviders: () => [],
+					getCanonicalModels: () => [],
+					resolveCanonicalModel: () => undefined,
+				} as unknown as ModelRegistry,
+			},
+		);
+		await Bun.sleep(0);
+
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+		await callbackStarted.promise;
+		let rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).not.toMatch(/EXECUTOR \((?:inherit|off|minimal|low|medium|high|xhigh|max)\)/);
+
+		callbackRelease.resolve();
+		await callbackFinished.promise;
+		await Bun.sleep(0);
+		rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("EXECUTOR (off)");
 	});
 
 	test("selects role-agent assignment without using stale task role", async () => {

--- a/packages/coding-agent/test/modes/components/settings-selector-model-profile.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-model-profile.test.ts
@@ -18,7 +18,10 @@ afterEach(() => {
 
 type ChangedSetting = { path: string; value: unknown };
 
-function createSelector(availableModelProfiles: string[]): {
+function createSelector(
+	availableModelProfiles: string[],
+	onChange?: (path: string, value: unknown) => void | Promise<void>,
+): {
 	component: SettingsSelectorComponent;
 	changedSettings: ChangedSetting[];
 } {
@@ -32,7 +35,10 @@ function createSelector(availableModelProfiles: string[]): {
 			cwd: process.cwd(),
 		},
 		{
-			onChange: (path, value) => changedSettings.push({ path, value }),
+			onChange: (path, value) => {
+				changedSettings.push({ path, value });
+				return onChange?.(path, value);
+			},
 			onCancel: () => {},
 		},
 	);
@@ -59,7 +65,7 @@ describe("SettingsSelectorComponent Default Model Profile", () => {
 		expect(opened).not.toContain("No matching commands");
 	});
 
-	it("persists the chosen profile to modelProfile.default on confirmation", () => {
+	it("emits profile intent without changing the committed default", () => {
 		settings.set("modelProfile.default", "orchestra");
 		const { component, changedSettings } = createSelector(["orchestra", "balanced"]);
 		focusModelTab(component);
@@ -68,8 +74,102 @@ describe("SettingsSelectorComponent Default Model Profile", () => {
 		component.handleInput("\x1b[B"); // Move to "balanced".
 		component.handleInput("\n"); // Confirm.
 
-		expect(settings.get("modelProfile.default")).toBe("balanced");
+		expect(settings.get("modelProfile.default")).toBe("orchestra");
 		expect(changedSettings).toContainEqual({ path: "modelProfile.default", value: "balanced" });
+	});
+	it("shows only the committed profile after asynchronous validation fails", async () => {
+		settings.set("modelProfile.default", "orchestra");
+		const { component } = createSelector(["orchestra", "balanced"], async () => {
+			throw new Error("profile validation failed");
+		});
+		focusModelTab(component);
+
+		component.handleInput("\n");
+		component.handleInput("\x1b[B");
+		component.handleInput("\n");
+		await Bun.sleep(0);
+
+		expect(settings.get("modelProfile.default")).toBe("orchestra");
+		expect(component.render(120).join("\n")).toContain("orchestra");
+	});
+	it("refreshes to the profile committed by asynchronous validation", async () => {
+		settings.set("modelProfile.default", "orchestra");
+		const pending = Promise.withResolvers<void>();
+		const { component } = createSelector(["orchestra", "balanced"], async (_path, value) => {
+			await pending.promise;
+			settings.set("modelProfile.default", value as string);
+		});
+		focusModelTab(component);
+
+		component.handleInput("\n");
+		component.handleInput("\x1b[B");
+		component.handleInput("\n");
+		expect(settings.get("modelProfile.default")).toBe("orchestra");
+
+		pending.resolve();
+		await pending.promise;
+		await Bun.sleep(0);
+
+		expect(settings.get("modelProfile.default")).toBe("balanced");
+		expect(component.render(120).join("\n")).toContain("balanced");
+	});
+	it("locks profile submissions until the committed selection settles", async () => {
+		settings.set("modelProfile.default", "orchestra");
+		const pending = Promise.withResolvers<void>();
+		const requests: string[] = [];
+		const { component } = createSelector(["orchestra", "balanced"], async (_path, value) => {
+			requests.push(value as string);
+			await pending.promise;
+			settings.set("modelProfile.default", value as string);
+		});
+		focusModelTab(component);
+
+		component.handleInput("\n");
+		component.handleInput("\x1b[B");
+		component.handleInput("\n"); // Submit balanced.
+		component.handleInput("\x1b[A");
+		component.handleInput("\n"); // Ignored while balanced is pending.
+		component.handleInput("\x1b"); // Cancellation is also ignored while commit is pending.
+		component.handleInput("\x1b[C"); // Tab switching is ignored while commit is pending.
+
+		expect(requests).toEqual(["balanced"]);
+		expect(settings.get("modelProfile.default")).toBe("orchestra");
+		expect(component.render(120).join("\n")).toContain("balanced");
+
+		pending.resolve();
+		await pending.promise;
+		await Bun.sleep(0);
+
+		expect(settings.get("modelProfile.default")).toBe("balanced");
+		expect(component.render(120).join("\n")).toContain("balanced");
+	});
+	it("keeps tab switching locked until a failed profile selection settles", async () => {
+		settings.set("modelProfile.default", "orchestra");
+		const pending = Promise.withResolvers<void>();
+		const requests: string[] = [];
+		const { component } = createSelector(["orchestra", "balanced"], async (_path, value) => {
+			requests.push(value as string);
+			await pending.promise;
+		});
+		focusModelTab(component);
+
+		component.handleInput("\n");
+		component.handleInput("\x1b[B");
+		component.handleInput("\n");
+		component.handleInput("\x1b[C");
+		component.handleInput("\t");
+		component.handleInput("\n");
+
+		expect(requests).toEqual(["balanced"]);
+		expect(component.render(120).join("\n")).toContain("balanced");
+
+		pending.reject(new Error("profile validation failed"));
+		await pending.promise.catch(() => {});
+		await Bun.sleep(0);
+
+		expect(requests).toEqual(["balanced"]);
+		expect(settings.get("modelProfile.default")).toBe("orchestra");
+		expect(component.render(120).join("\n")).toContain("orchestra");
 	});
 
 	it("falls back to the empty-state message when no profiles are registered", () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -236,6 +236,430 @@ describe("Settings", () => {
 				planner: "user/planner:high",
 			});
 		});
+
+		it("keeps model assignments live when project settings shadow global persistence", async () => {
+			await writeSettings({
+				modelRoles: { default: "global/default" },
+				task: {
+					agentModelOverrides: {
+						executor: "global/executor",
+					},
+				},
+			});
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "config.yml"),
+				YAML.stringify(
+					{
+						modelRoles: { default: "project/default" },
+						task: {
+							agentModelOverrides: {
+								executor: "project/executor",
+								architect: "project/architect",
+								planner: "project/planner",
+								critic: "project/critic",
+							},
+						},
+					},
+					null,
+					2,
+				),
+			);
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.getModelRole("default")).toBe("project/default");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				architect: "project/architect",
+				planner: "project/planner",
+				critic: "project/critic",
+			});
+
+			settings.setModelRole("default", "openai-codex/gpt-5.6-sol:xhigh");
+			for (const role of ["executor", "architect", "planner", "critic"]) {
+				settings.setAgentModelOverride(role, "openai-codex/gpt-5.6-sol:xhigh");
+			}
+
+			expect(settings.getModelRole("default")).toBe("openai-codex/gpt-5.6-sol:xhigh");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "openai-codex/gpt-5.6-sol:xhigh",
+				architect: "openai-codex/gpt-5.6-sol:xhigh",
+				planner: "openai-codex/gpt-5.6-sol:xhigh",
+				critic: "openai-codex/gpt-5.6-sol:xhigh",
+			});
+
+			await settings.flushOrThrow();
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelRoles).toEqual({ default: "openai-codex/gpt-5.6-sol:xhigh" });
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: {
+					executor: "openai-codex/gpt-5.6-sol:xhigh",
+					architect: "openai-codex/gpt-5.6-sol:xhigh",
+					planner: "openai-codex/gpt-5.6-sol:xhigh",
+					critic: "openai-codex/gpt-5.6-sol:xhigh",
+				},
+			});
+
+			settings.clearOverride("modelRoles");
+			settings.clearOverride("task.agentModelOverrides");
+			expect(settings.getModelRole("default")).toBe("project/default");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "project/executor",
+				architect: "project/architect",
+				planner: "project/planner",
+				critic: "project/critic",
+			});
+		});
+
+		it("treats runtime null model records as resets before applying assignments", () => {
+			const settings = Settings.isolated();
+			settings.override("modelRoles", null as never);
+			settings.override("task.agentModelOverrides", null as never);
+
+			expect(settings.get("modelRoles")).toEqual({});
+			expect(settings.get("task.agentModelOverrides")).toEqual({});
+
+			settings.setModelRole("default", "provider/selected:high");
+			settings.setAgentModelOverride("executor", "provider/selected:high");
+
+			expect(settings.getModelRole("default")).toBe("provider/selected:high");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "provider/selected:high",
+			});
+			expect(settings.getGlobal("modelRoles")).toEqual({ default: "provider/selected:high" });
+			expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+				executor: "provider/selected:high",
+			});
+		});
+		it("keeps whole-record runtime resets opaque across later lower layers and cwd clones", async () => {
+			await writeSettings({
+				modelRoles: { default: "global/default" },
+				task: { agentModelOverrides: { executor: "global/executor" } },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.override("modelRoles", null as never);
+			settings.override("task.agentModelOverrides", [] as never);
+			settings.set("modelRoles", {
+				default: "global/default",
+				smol: "global/smol-added-after-reset",
+			});
+			settings.set("task.agentModelOverrides", {
+				executor: "global/executor",
+				planner: "global/planner-added-after-reset",
+			});
+
+			const cloneDir = path.join(testDir, "clone-project");
+			fs.mkdirSync(getProjectAgentDir(cloneDir), { recursive: true });
+			await Bun.write(
+				path.join(getProjectAgentDir(cloneDir), "config.yml"),
+				YAML.stringify(
+					{
+						modelRoles: { slow: "project/slow-added-after-reset" },
+						task: { agentModelOverrides: { critic: "project/critic-added-after-reset" } },
+					},
+					null,
+					2,
+				),
+			);
+
+			const cloned = await settings.cloneForCwd(cloneDir);
+			cloned.override("modelRoles", cloned.get("modelRoles"));
+			cloned.override("task.agentModelOverrides", cloned.get("task.agentModelOverrides"));
+			expect(cloned.get("modelRoles")).toEqual({});
+			expect(cloned.get("task.agentModelOverrides")).toEqual({});
+
+			cloned.clearOverride("modelRoles");
+			cloned.clearOverride("task.agentModelOverrides");
+			expect(cloned.get("modelRoles")).toEqual({
+				default: "global/default",
+				smol: "global/smol-added-after-reset",
+				slow: "project/slow-added-after-reset",
+			});
+			expect(cloned.get("task.agentModelOverrides")).toEqual({
+				executor: "global/executor",
+				planner: "global/planner-added-after-reset",
+				critic: "project/critic-added-after-reset",
+			});
+		});
+		it("releases only explicitly assigned leaves from a whole-record reset", () => {
+			const settings = Settings.isolated();
+			settings.set("task.agentModelOverrides", {
+				executor: "durable/executor",
+				planner: "durable/planner",
+			});
+			settings.override("task.agentModelOverrides", null as never);
+
+			settings.setAgentModelOverride("executor", "selected/executor");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "selected/executor",
+			});
+			settings.clearAgentModelOverride("executor");
+			settings.set("task.agentModelOverrides", {
+				executor: "durable/executor",
+				planner: "durable/planner",
+				critic: "durable/critic-added-later",
+			});
+
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "durable/executor",
+			});
+		});
+		it("preserves a newer durable replacement when clearing a released runtime leaf", () => {
+			const settings = Settings.isolated();
+			settings.override("task.agentModelOverrides", null as never);
+			settings.setAgentModelOverride("executor", "selected/executor");
+			settings.set("task.agentModelOverrides", {
+				executor: "durable/new-executor",
+				planner: "durable/planner",
+			});
+
+			settings.clearAgentModelOverride("executor");
+
+			expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+				executor: "durable/new-executor",
+				planner: "durable/planner",
+			});
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "durable/new-executor",
+			});
+		});
+
+		it("keeps malformed runtime leaves hidden when lower-layer siblings change", () => {
+			const settings = Settings.isolated();
+			settings.set("task.agentModelOverrides", {
+				executor: "durable/executor",
+				planner: "durable/planner",
+			});
+			settings.override("task.agentModelOverrides", { executor: false } as never);
+			settings.set("task.agentModelOverrides", {
+				executor: "durable/executor-updated",
+				planner: "durable/planner",
+				critic: "durable/critic-added-after-reset",
+			});
+			settings.override("task.agentModelOverrides", settings.get("task.agentModelOverrides"));
+
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				planner: "durable/planner",
+				critic: "durable/critic-added-after-reset",
+			});
+			settings.clearOverride("task.agentModelOverrides");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "durable/executor-updated",
+				planner: "durable/planner",
+				critic: "durable/critic-added-after-reset",
+			});
+		});
+		it("does not mutate project-only nested resets while rebuilding the merged view", async () => {
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "config.yml"),
+				YAML.stringify(
+					{
+						modelRoles: null,
+						task: { agentModelOverrides: null },
+					},
+					null,
+					2,
+				),
+			);
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("task.agentModelOverrides")).toEqual({});
+
+			settings.set("modelRoles", {
+				default: "durable/default-added-after-project-reset",
+			});
+			settings.set("task.agentModelOverrides", {
+				executor: "durable/added-after-project-reset",
+			});
+			settings.set("modelRoles", {
+				default: "durable/default-updated-again",
+				smol: "durable/smol-added-later",
+			});
+			settings.set("task.agentModelOverrides", {
+				executor: "durable/updated-again",
+				planner: "durable/planner-added-later",
+			});
+
+			expect(settings.get("modelRoles")).toEqual({});
+			expect(settings.get("task.agentModelOverrides")).toEqual({});
+			const cloned = await settings.cloneForCwd(projectDir);
+			expect(cloned.get("modelRoles")).toEqual({});
+			expect(cloned.get("task.agentModelOverrides")).toEqual({});
+		});
+		it("persists project-default suppression and explicit replacement across fresh settings", async () => {
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "config.yml"),
+				YAML.stringify(
+					{
+						modelProfile: { default: "project-profile" },
+					},
+					null,
+					2,
+				),
+			);
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const previousPersistedState = settings.getPersistedModelProfileDefaultState();
+			const previousRuntimeState = settings.getRuntimeModelProfileDefaultState();
+			expect(settings.get("modelProfile.default")).toBe("project-profile");
+
+			settings.persistModelProfileDefaultSuppression();
+			settings.suppressModelProfileDefault();
+			await settings.flushOrThrow();
+			expect(settings.get("modelProfile.default")).toBeUndefined();
+			const cloned = await settings.cloneForCwd(projectDir);
+			expect(cloned.get("modelProfile.default")).toBeUndefined();
+
+			resetSettingsForTest();
+			const fresh = await Settings.init({ cwd: projectDir, agentDir });
+			expect(fresh.get("modelProfile.default")).toBeUndefined();
+
+			fresh.restorePersistedModelProfileDefault(previousPersistedState);
+			fresh.restoreRuntimeModelProfileDefault(previousRuntimeState);
+			expect(fresh.get("modelProfile.default")).toBe("project-profile");
+			fresh.set("modelProfile.default", "user-new-default");
+			await fresh.flushOrThrow();
+
+			resetSettingsForTest();
+			const replaced = await Settings.init({ cwd: projectDir, agentDir });
+			expect(replaced.get("modelProfile.default")).toBe("user-new-default");
+		});
+
+		it("treats project null model records as resets without partial assignment failures", async () => {
+			await writeSettings({
+				modelRoles: { default: "global/default" },
+				task: { agentModelOverrides: { executor: "global/executor" } },
+			});
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "config.yml"),
+				YAML.stringify(
+					{
+						modelRoles: null,
+						task: { agentModelOverrides: null },
+					},
+					null,
+					2,
+				),
+			);
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("modelRoles")).toEqual({});
+			expect(settings.get("task.agentModelOverrides")).toEqual({});
+
+			settings.setModelRole("default", "provider/selected:high");
+			for (const role of ["executor", "architect", "planner", "critic"]) {
+				settings.setAgentModelOverride(role, "provider/selected:high");
+			}
+
+			expect(settings.getModelRole("default")).toBe("provider/selected:high");
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "provider/selected:high",
+				architect: "provider/selected:high",
+				planner: "provider/selected:high",
+				critic: "provider/selected:high",
+			});
+
+			await settings.flushOrThrow();
+			const savedSettings = await readSettings();
+			expect(savedSettings.modelRoles).toEqual({ default: "provider/selected:high" });
+			expect(savedSettings.task).toEqual({
+				agentModelOverrides: {
+					executor: "provider/selected:high",
+					architect: "provider/selected:high",
+					planner: "provider/selected:high",
+					critic: "provider/selected:high",
+				},
+			});
+
+			settings.clearOverride("modelRoles");
+			settings.clearOverride("task.agentModelOverrides");
+			expect(settings.get("modelRoles")).toEqual({});
+			expect(settings.get("task.agentModelOverrides")).toEqual({});
+		});
+
+		it("preserves malformed reset leaves across unrelated runtime record writes", () => {
+			const settings = Settings.isolated();
+			settings.set("modelRoles", {
+				default: "durable/default",
+				smol: "durable/smol",
+				slow: "durable/slow",
+			});
+			settings.set("task.agentModelOverrides", {
+				executor: "durable/executor",
+				planner: "durable/planner",
+			});
+			settings.override("modelRoles", { smol: false, slow: [] } as never);
+			settings.override("task.agentModelOverrides", { executor: false } as never);
+
+			settings.setAgentModelOverride("planner", "selected/planner");
+			settings.overrideModelRoles({ plan: "selected/plan" });
+			settings.override("modelRoles", settings.get("modelRoles"));
+			settings.override("task.agentModelOverrides", settings.get("task.agentModelOverrides"));
+
+			expect(settings.get("modelRoles")).toEqual({
+				default: "durable/default",
+				plan: "selected/plan",
+			});
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				planner: "selected/planner",
+			});
+
+			settings.clearOverride("modelRoles");
+			settings.clearOverride("task.agentModelOverrides");
+			expect(settings.get("modelRoles")).toEqual({
+				default: "durable/default",
+				smol: "durable/smol",
+				slow: "durable/slow",
+			});
+			expect(settings.get("task.agentModelOverrides")).toEqual({
+				executor: "durable/executor",
+				planner: "selected/planner",
+			});
+		});
+
+		it("sanitizes malformed model leaves from global public reads", () => {
+			const settings = Settings.isolated();
+			settings.set("modelRoles", {
+				default: "valid/default",
+				smol: false,
+			} as never);
+			settings.set("task.agentModelOverrides", {
+				executor: false,
+				planner: "valid/planner",
+			} as never);
+
+			expect(settings.getGlobal("modelRoles")).toEqual({
+				default: "valid/default",
+			});
+			expect(settings.getGlobal("task.agentModelOverrides")).toEqual({
+				planner: "valid/planner",
+			});
+		});
+		it("preserves prototype-like custom agent names through runtime rewrites and cwd clones", async () => {
+			const settings = Settings.isolated();
+
+			settings.setAgentModelOverride("__proto__", "provider/model");
+
+			const effective = settings.get("task.agentModelOverrides");
+			const global = settings.getGlobal("task.agentModelOverrides");
+			expect(Object.hasOwn(effective, "__proto__")).toBe(true);
+			expect(Object.getOwnPropertyDescriptor(effective, "__proto__")?.value).toBe("provider/model");
+			const runtimeRecord = Object.fromEntries([["__proto__", "runtime/model"]]);
+			settings.override("task.agentModelOverrides", runtimeRecord);
+			expect(Object.getOwnPropertyDescriptor(settings.get("task.agentModelOverrides"), "__proto__")?.value).toBe(
+				"runtime/model",
+			);
+
+			const cloned = await settings.cloneForCwd(projectDir);
+			expect(Object.getOwnPropertyDescriptor(cloned.get("task.agentModelOverrides"), "__proto__")?.value).toBe(
+				"runtime/model",
+			);
+
+			settings.clearAgentModelOverride("__proto__");
+			expect(Object.getOwnPropertyDescriptor(settings.get("task.agentModelOverrides"), "__proto__")?.value).toBe(
+				"provider/model",
+			);
+			expect(Object.hasOwn(global ?? {}, "__proto__")).toBe(true);
+			expect(Object.getOwnPropertyDescriptor(global, "__proto__")?.value).toBe("provider/model");
+		});
 	});
 
 	describe("migrations", () => {

--- a/packages/coding-agent/test/slash-commands/model.test.ts
+++ b/packages/coding-agent/test/slash-commands/model.test.ts
@@ -111,6 +111,27 @@ describe("/model batch assignments", () => {
 		]);
 	});
 
+	test("assign all-targets replaces null reset shadows without a partial failure", async () => {
+		const { output, runtime, settings } = createRuntime();
+		settings.override("modelRoles", null as never);
+		settings.override("task.agentModelOverrides", null as never);
+
+		await expect(
+			executeAcpBuiltinSlashCommand("/model assign all-targets claude-3-5-sonnet:high", runtime),
+		).resolves.toEqual({ consumed: true });
+
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:high");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/claude-3-5-sonnet:high",
+			architect: "anthropic/claude-3-5-sonnet:high",
+			planner: "anthropic/claude-3-5-sonnet:high",
+			critic: "anthropic/claude-3-5-sonnet:high",
+		});
+		expect(output).toEqual([
+			"All model targets set to anthropic/claude-3-5-sonnet:high for DEFAULT, EXECUTOR, ARCHITECT, PLANNER, CRITIC.",
+		]);
+	});
+
 	test("assign all-targets materializes an active profile exactly once", async () => {
 		const { output, runtime, session, settings, setActiveModelProfile } = createRuntime();
 		session.model = { provider: "anthropic", id: "current-model" };

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -208,7 +208,10 @@
 			"type": "object",
 			"properties": {
 				"default": {
-					"type": "string",
+					"type": [
+						"string",
+						"null"
+					],
 					"description": "Model profile applied automatically at startup"
 				}
 			},

--- a/scripts/generate-json-schemas.test.ts
+++ b/scripts/generate-json-schemas.test.ts
@@ -21,4 +21,8 @@ describe("generated JSON Schemas", () => {
 		const providerSchema = modelsSchema.properties.providers.additionalProperties;
 		expect(providerSchema.properties.webSearch.enum).toEqual(["on", "off", "auto"]);
 	});
+	it("allows the durable model profile suppression tombstone", () => {
+		const configSchema = JSON_SCHEMA_OUTPUTS.find(output => output.path === "schemas/config.schema.json")?.schema as any;
+		expect(configSchema.properties.modelProfile.properties.default.type).toEqual(["string", "null"]);
+	});
 });

--- a/scripts/generate-json-schemas.ts
+++ b/scripts/generate-json-schemas.ts
@@ -13,7 +13,7 @@ type JsonSchemaObject = {
 	$id?: string;
 	title?: string;
 	description?: string;
-	type?: string;
+	type?: string | readonly string[];
 	properties?: Record<string, JsonSchema>;
 	additionalProperties?: JsonSchema;
 	items?: JsonSchema;
@@ -109,7 +109,7 @@ function settingTypeToJsonSchema(definition: SettingDefinition): JsonSchemaObjec
 		case "boolean":
 			return { type: "boolean" };
 		case "string":
-			return { type: "string" };
+			return { type: "nullable" in definition && definition.nullable ? ["string", "null"] : "string" };
 		case "number":
 			return { type: "number" };
 		case "enum":


### PR DESCRIPTION
## What

- Preserve opaque whole-record and malformed-leaf runtime resets without mutating project/global source objects.
- Separate effective, durable, and runtime-only profile state so materialization and rollback update only owned leaves.
- Keep dashboard, `/model`, configured bindings, profile deletion, and cwd clones on the same source-aware assignment lifecycle.
- Commit selector badges and Settings default-profile UI only after validated durable writes settle.
- Preserve arbitrary agent keys such as `__proto__` while keeping generated `models.yml` JSON Schema object-shaped.
- Persist project-default profile suppression as a schema-valid nullable tombstone that survives restart.

## Why

Supersedes #2002 and addresses all six exact-head Request Changes findings plus the follow-up state-machine blockers found during adversarial review:

1. Deep merge now clones project-only nested branches before merged-view normalization.
2. Profile materialization/rollback uses exact durable and runtime-only snapshots; hidden siblings are never replaced by sanitized effective records.
3. Clearing an assignment removes a durable leaf only when it still owns the same value, preserving newer writers.
4. Agent Control Center edits materialize active/default profiles before changing or clearing a role.
5. Settings, profile mappings, and model bindings use safe own-property writes for arbitrary custom-agent keys.
6. Async model-selector badges reload from authoritative settings after success or failure.

Additional closure:

- Configured binding refresh starts from runtime-only state instead of promoting lower-precedence values.
- Profile deletion/restore and persist-default activation use `flushOrThrow` transaction boundaries and exact rollback.
- A durable `modelProfile.default: null` tombstone suppresses project defaults after restart; the source schema, generated public schema, and tests all permit `string | null`.
- `/settings` emits default-profile intent without prewriting it. Validation owns the only durable write, failure restores the committed value, and an instance-wide pending lock prevents duplicate submissions, cancellation, or tab-switch races until settlement.

## Verification

Exact replacement head: `c56bf7f09e05ced970c942258ffcac43706174df`, one signed-off commit on current `dev` `f194900ec2d0e4847cd88c50ff70e747ba2a66c2`.

- `bun run check`
- Owner/follow-up focused suites: 287 passed, 0 failed across 13 files
- Adjacent profile suites: 70 passed, 0 failed across 8 files
- `bun test packages/coding-agent/test/acp-builtins.test.ts --test-name-pattern 'model:'`: 14 passed, 0 failed
- `bun --cwd=packages/coding-agent run build && packages/coding-agent/dist/gjc --smoke-test`
- `bun run ci:test:smoke`
- `git diff --check origin/dev...HEAD`
- Two independent adversarial architecture reviews on the final worktree: CLEAR; owner findings closed

---

- [x] `bun run check` passes
- [x] Focused and adjacent behavior tests pass
- [x] Generated schemas are synchronized
- [x] CHANGELOG updated
- [x] DCO trailer present