### PR TITLE
feat(models): add xAI Grok 4.5 to the bundled catalog

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+
+### Added
+
+- Added the xAI `grok-4.5` model to the bundled `xai` catalog: 500K context, $2 / $6 input/output, $0.50 cached input, reasoning with text + image input. Fields per authoritative xAI docs (https://docs.x.ai/developers/models/grok-4.5, https://docs.x.ai/developers/pricing).
+
 ### Fixed
 
 - Made Bedrock model visibility reflect credential-only static/shared AWS sources with supported profile shapes, authenticated real bearer-token requests, and stopped advertising unsupported ECS/IRSA sources (#1934).

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -75329,6 +75329,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "xai",
+			"baseUrl": "https://api.x.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 30000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"grok-beta": {
 			"id": "grok-beta",
 			"name": "Grok Beta",


### PR DESCRIPTION
## What

Adds the xAI **Grok 4.5** model to the bundled `xai` catalog (`packages/ai/src/models.json`). Catalog-only — **the default Grok model profiles are unchanged.**

## Authoritative field sources

Every field is taken from xAI's published documentation (no estimates):

| Field | Value | Source |
| --- | --- | --- |
| Context window | 500,000 | https://docs.x.ai/developers/models/grok-4.5 |
| Input | $2.00 / 1M | https://docs.x.ai/developers/pricing |
| Cached input | $0.50 / 1M | https://docs.x.ai/developers/models/grok-4.5 |
| Output | $6.00 / 1M | https://docs.x.ai/developers/pricing |
| Reasoning | Yes | https://docs.x.ai/developers/models/grok-4.5 |
| Modalities | text + image → text | https://docs.x.ai/developers/models/grok-4.5 |
| Endpoint | xai / api.x.ai/v1 | existing xai catalog convention |

`maxTokens` (30000) and the effort `thinking` config follow the existing grok-4.x entries (`grok-4.3`, `grok-4.20-*`); xAI does not publish a distinct max-output value.

## Addresses prior review

Supersedes the earlier catalog+profile change (#2006 / #2007), which was closed for estimated pricing and default-profile edits. This revision uses only authoritative, doc-cited values, does **not** change the default `grok-eco` / `grok-medium` / `grok-pro` profiles, and does not touch the Grok Build fallback catalog.

## Verification

Against `api.x.ai`: `gjc -p --no-session --no-tools --model xai/grok-4.5 "Reply OK"` returns `OK`, and `xai/grok-4.5:high` returns for the effort variant. An unknown xai model id errors instead of falling back, confirming the selector resolves to grok-4.5.