### PR TITLE
Fail fast instead of hanging forever on non-TTY stdin interactive launches

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -120,6 +120,46 @@ async function readPipedInput(): Promise<string | undefined> {
 	}
 }
 
+export interface LaunchDisposition {
+	autoPrint: boolean;
+	isInteractive: boolean;
+	/** Set when an interactive launch is impossible (non-TTY stdin, nothing to run). */
+	nonInteractiveError?: string;
+}
+
+/**
+ * Decides between interactive, auto-print, and fail-fast launches.
+ *
+ * A non-TTY stdin means the TUI can never receive input, so an interactive
+ * launch would execute the initial prompt (real token spend) and then block in
+ * the event loop forever — observed as orphaned `gjc <words> </dev/null`
+ * processes holding session transcripts and sqlite handles for hours. With
+ * command-line messages we degrade to print mode (same as piped input);
+ * without any work to run we fail fast instead of hanging. Explicit `--print`
+ * and `--mode` launches (rpc/acp/bridge run over non-TTY stdio) are untouched.
+ */
+export function resolveLaunchDisposition(args: {
+	stdinIsTTY: boolean;
+	pipedInput: string | undefined;
+	hasMessages: boolean;
+	print: boolean;
+	mode: string | undefined;
+}): LaunchDisposition {
+	const modeSet = args.mode !== undefined;
+	const nonTtyWithPrompt = !args.stdinIsTTY && args.hasMessages;
+	const autoPrint = (args.pipedInput !== undefined || nonTtyWithPrompt) && !args.print && !modeSet;
+	const isInteractive = !args.print && !autoPrint && !modeSet;
+	if (isInteractive && !args.stdinIsTTY) {
+		return {
+			autoPrint: false,
+			isInteractive: false,
+			nonInteractiveError:
+				"stdin is not a TTY and no prompt was provided; use -p/--print (or pass a prompt) for non-interactive runs.",
+		};
+	}
+	return { autoPrint, isInteractive };
+}
+
 export interface InteractiveModeNotify {
 	kind: "warn" | "error" | "info";
 	message: string;
@@ -858,8 +898,18 @@ export async function runRootCommand(
 		fileImages,
 		stdinContent: pipedInput,
 	});
-	const autoPrint = pipedInput !== undefined && !parsedArgs.print && parsedArgs.mode === undefined;
-	const isInteractive = !parsedArgs.print && !autoPrint && parsedArgs.mode === undefined;
+	const disposition = resolveLaunchDisposition({
+		stdinIsTTY: process.stdin.isTTY === true,
+		pipedInput,
+		hasMessages: parsedArgs.messages.length > 0,
+		print: Boolean(parsedArgs.print),
+		mode: parsedArgs.mode,
+	});
+	if (disposition.nonInteractiveError) {
+		process.stderr.write(`${chalk.red(disposition.nonInteractiveError)}\n`);
+		process.exit(1);
+	}
+	const isInteractive = disposition.isInteractive;
 	const mode = parsedArgs.mode || "text";
 
 	// Initialize discovery system with settings for provider persistence

--- a/packages/coding-agent/test/launch-disposition.test.ts
+++ b/packages/coding-agent/test/launch-disposition.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { resolveLaunchDisposition } from "@gajae-code/coding-agent/main";
+
+const base = {
+	stdinIsTTY: true,
+	pipedInput: undefined as string | undefined,
+	hasMessages: false,
+	print: false,
+	mode: undefined as string | undefined,
+};
+
+describe("resolveLaunchDisposition", () => {
+	it("launches interactive on a TTY with no flags", () => {
+		expect(resolveLaunchDisposition({ ...base })).toEqual({ autoPrint: false, isInteractive: true });
+	});
+
+	it("auto-prints piped stdin content (existing behavior)", () => {
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, pipedInput: "review this" })).toEqual({
+			autoPrint: true,
+			isInteractive: false,
+		});
+	});
+
+	it("auto-prints when stdin is non-TTY but EMPTY and a prompt was passed (the `gjc <words> </dev/null` orphan case)", () => {
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, hasMessages: true })).toEqual({
+			autoPrint: true,
+			isInteractive: false,
+		});
+	});
+
+	it("fails fast when stdin is non-TTY and there is nothing to run (previously: forever-hang in the TUI event loop)", () => {
+		const disposition = resolveLaunchDisposition({ ...base, stdinIsTTY: false });
+		expect(disposition.isInteractive).toBe(false);
+		expect(disposition.autoPrint).toBe(false);
+		expect(disposition.nonInteractiveError).toContain("stdin is not a TTY");
+	});
+
+	it("leaves explicit --print untouched on non-TTY stdin", () => {
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, print: true })).toEqual({
+			autoPrint: false,
+			isInteractive: false,
+		});
+	});
+
+	it("leaves --mode launches untouched (rpc/acp/bridge legitimately run over non-TTY stdio)", () => {
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, mode: "rpc" })).toEqual({
+			autoPrint: false,
+			isInteractive: false,
+		});
+	});
+
+	it("explicit --print wins over piped-input auto-print", () => {
+		expect(resolveLaunchDisposition({ ...base, stdinIsTTY: false, pipedInput: "x", print: true })).toEqual({
+			autoPrint: false,
+			isInteractive: false,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

A non-TTY invocation with **empty** stdin silently enters INTERACTIVE mode: the TUI event loop starts, the initial prompt (if any) is executed against the configured model — real token spend — and the process then blocks forever waiting for input that can never arrive.

Real-world incident that motivated this: `gjc models list` (user error — `models` is not a subcommand, so it's parsed as a prompt) was run in a pipeline. The process ran one model turn, then sat orphaned (ppid 1, stdin=`/dev/null`, `ep_poll`) for **22+ hours**, holding `agent.db`/`models.db`/`history.db` handles and two session transcripts open — the stuck transcripts surfaced as ghost "live" sessions in downstream tooling.

## Root cause

`main.ts`:

- `readPipedInput()` returns `undefined` for empty/whitespace non-TTY stdin — indistinguishable from "stdin is a TTY".
- `autoPrint = pipedInput !== undefined && !print && mode === undefined` → `/dev/null` stdin never triggers auto-print.
- `isInteractive` therefore ends up `true`, and nothing ever checks `process.stdin.isTTY` on the interactive path.

## Fix

Extracted the launch decision into an exported pure function `resolveLaunchDisposition` and made it TTY-aware:

- non-TTY stdin **with** command-line messages → auto-print (same degradation as piped input),
- non-TTY stdin with **nothing to run** → fail fast with a clear error (exit 1) instead of hanging,
- explicit `--print` and `--mode` launches (rpc/acp/bridge legitimately run over non-TTY stdio) are untouched,
- TTY behavior unchanged.

## Repro (before → after)

```sh
timeout 15 gjc --no-session < /dev/null > /tmp/out 2>&1; echo $?
# before: 124 (hangs forever; /tmp/out is empty)
# after:  1   ("stdin is not a TTY and no prompt was provided; use -p/--print …")
```

```sh
timeout 60 gjc "say OK" < /dev/null
# before: runs the turn, then hangs forever (orphanable)
# after:  routes to print mode and exits
```

## Verification

- `bun test packages/coding-agent/test/launch-disposition.test.ts` — 7 new cases (TTY interactive, piped auto-print, non-TTY+prompt auto-print, non-TTY fail-fast, `--print`/`--mode`/precedence untouched).
- `bun test packages/coding-agent/test/main-interactive-input.test.ts` — untouched neighbor suite still green.
- Manual rc evidence above reproduced on Linux against the release binary (v0.9.6) and re-verified on this branch from source.
