### PR TITLE
fix(tui): stop Kitty terminals treating anchored prose as image lines

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -179,7 +179,11 @@ export interface ViewportAnchorAnnotation {
 	token: string;
 }
 
-const VIEWPORT_ANCHOR_PREFIX = "\x1b_GJC_ANCHOR:";
+// APC marker for viewport anchors. Must NOT start with "\x1b_G": that is the
+// Kitty graphics prefix and TERMINAL.isImageLine() would misclassify every
+// annotated line as an image line, which skips wrapping (issue: assistant
+// prose overflowing the terminal on Kitty-protocol terminals).
+const VIEWPORT_ANCHOR_PREFIX = "\x1b_AGJC_ANCHOR:";
 const VIEWPORT_ANCHOR_SUFFIX = "\x1b\\";
 
 function ansiSequenceEnd(text: string, start: number): number {
@@ -249,7 +253,7 @@ export function extractViewportAnchorRows(
 	lines: readonly string[],
 	token: string,
 ): { lines: string[]; spans: Array<ViewportAnchorSpan | null> } {
-	const markerRegex = new RegExp(`\\x1b_GJC_ANCHOR:${token}:(\\d+):(\\d+):(\\d+):(\\d+)\\x1b\\\\`, "g");
+	const markerRegex = new RegExp(`\\x1b_AGJC_ANCHOR:${token}:(\\d+):(\\d+):(\\d+):(\\d+)\\x1b\\\\`, "g");
 	const cleanLines: string[] = [];
 	const spans: Array<ViewportAnchorSpan | null> = [];
 	for (const line of lines) {

--- a/packages/tui/test/viewport-scroll.test.ts
+++ b/packages/tui/test/viewport-scroll.test.ts
@@ -461,7 +461,7 @@ describe("registered viewport anchor", () => {
 	});
 
 	it("does not strip or trust user-supplied anchor-like APC content", () => {
-		const literalMarker = "\x1b_GJC_ANCHOR:0:1:0:1\x1b\\";
+		const literalMarker = "\x1b_AGJC_ANCHOR:0:1:0:1\x1b\\";
 		const container = new Container();
 		const text = new Text(`${literalMarker}visible`, 0, 0);
 		container.addChild(text);


### PR DESCRIPTION
## Problem

After #1983, assistant output-text, thinking-text, and submitted user messages stopped wrapping on Kitty-protocol terminals (kitty/ghostty/wezterm) — prose ran past the right edge of the layout.

## Root cause

The viewport-anchor APC marker introduced in 1f36f680 is `\x1b_GJC_ANCHOR:`, which begins with `\x1b_G` — the Kitty graphics protocol prefix. `TERMINAL.isImageLine()` therefore classified every anchor-annotated line as an image line, and the anchored Markdown/Text render path skips wrapping for image lines.

Only components rendered through `renderWithViewportAnchorSource` were affected (assistant text, thinking text, user messages, deep-interview renders); everything else wraps via plain `render()` and was fine. The IRC sidebar was not the cause.

## Fix

Rename the marker to `\x1b_AGJC_ANCHOR:` (annotation + extraction regex) so it can never collide with the Kitty prefix.

## Verification

- Repro under `PI_FORCE_IMAGE_PROTOCOL=kitty`: `renderWithViewportAnchorSource(60)` returned 1 unwrapped row of width 141 before; 3 rows of width 60 after. Same for the user-message shape (bg+color, paddingY=1): 5 rows of exactly 60.
- Full `packages/tui` suite: 715 pass.
- `issue-1979-korean-wrap`, assistant-streaming, completion-viewport, and modes/components suites: all pass.