### PR TITLE
feat(acp): support session deletion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -238,7 +238,7 @@
     },
   },
   "catalog": {
-    "@agentclientprotocol/sdk": "0.21.0",
+    "@agentclientprotocol/sdk": "0.22.0",
     "@anthropic-ai/sdk": "^0.94.0",
     "@babel/generator": "^7.29.1",
     "@babel/parser": "^7.29.3",
@@ -311,7 +311,7 @@
     "zod": "4.4.3",
   },
   "packages": {
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.21.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.22.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-mnkpiuEfGm7/snhWbrRhe3Hk+WDDjv7U2N/Ql0XiThl9zg7T984dPH8Tich4wlBQnaaXTV4Fl5OQSe2pa9hoFA=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.94.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-OVlCttk5MyeTGtrWX5+F3MJOfEMDuEjK8+rm9aQMDfRPWndVMbhk37QG8WLnVbcc7huyUGngVMjT7iMN2llySA=="],
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "python/robogjc/web"
     ],
     "catalog": {
-      "@agentclientprotocol/sdk": "0.21.0",
+      "@agentclientprotocol/sdk": "0.22.0",
       "@anthropic-ai/sdk": "^0.94.0",
       "@babel/generator": "^7.29.1",
       "@babel/parser": "^7.29.3",

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -10,6 +10,8 @@ import {
 	type CloseSessionRequest,
 	type CloseSessionResponse,
 	type CreateElicitationResponse,
+	type DeleteSessionRequest,
+	type DeleteSessionResponse,
 	type ElicitationContentValue,
 	type ElicitationPropertySchema,
 	type ForkSessionRequest,
@@ -71,6 +73,7 @@ import {
 	type SessionInfo as StoredSessionInfo,
 	type UsageStatistics,
 } from "../../session/session-manager";
+import { FileSessionStorage } from "../../session/session-storage";
 import { ACP_BUILTIN_SLASH_COMMANDS, executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
 import { parseThinkingLevel } from "../../thinking";
 import { toAgentWireEventPayload } from "../shared/agent-wire/event-envelope";
@@ -431,6 +434,7 @@ export class AcpAgent implements Agent {
 				},
 				sessionCapabilities: {
 					list: {},
+					delete: {},
 					fork: {},
 					resume: {},
 					close: {},
@@ -517,6 +521,29 @@ export class AcpAgent implements Agent {
 		};
 		this.#scheduleBootstrapUpdates(record.session.sessionId);
 		return response;
+	}
+
+	async unstable_deleteSession(params: DeleteSessionRequest): Promise<DeleteSessionResponse> {
+		const record = this.#sessions.get(params.sessionId);
+		let sessionPath: string;
+
+		if (record) {
+			const activeSessionPath = record.session.sessionManager.getSessionFile();
+			if (!activeSessionPath) {
+				throw new Error(`ACP session has no persisted file: ${params.sessionId}`);
+			}
+			sessionPath = activeSessionPath;
+			await this.#closeManagedSession(params.sessionId, record);
+		} else {
+			const storedSession = await this.#findStoredSessionById(params.sessionId);
+			if (!storedSession) {
+				throw new Error(`ACP session not found: ${params.sessionId}`);
+			}
+			sessionPath = storedSession.path;
+		}
+
+		await new FileSessionStorage().deleteSessionWithArtifacts(sessionPath);
+		return {};
 	}
 
 	async closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
@@ -2113,11 +2140,14 @@ export class AcpAgent implements Agent {
 				headers: this.#toNameValueMap(server.headers),
 			};
 		}
-		return {
-			type: "sse",
-			url: server.url,
-			headers: this.#toNameValueMap(server.headers),
-		};
+		if (server.type === "sse") {
+			return {
+				type: "sse",
+				url: server.url,
+				headers: this.#toNameValueMap(server.headers),
+			};
+		}
+		throw new Error(`Unsupported ACP MCP transport: ${server.type}`);
 	}
 
 	#toNameValueMap(values: Array<{ name: string; value: string }>): { [name: string]: string } {

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -11,6 +11,7 @@ import type {
 	SessionNotification,
 } from "@agentclientprotocol/sdk";
 import {
+	zDeleteSessionResponse,
 	zForkSessionResponse,
 	zLoadSessionResponse,
 	zNewSessionResponse,
@@ -533,6 +534,41 @@ describe("ACP agent", () => {
 
 		harness.abortController.abort();
 		await Bun.sleep(0);
+	});
+
+	it("deletes an active session and its artifacts", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		const sessionPath = session.sessionManager.getSessionFile()!;
+		const artifactsDir = sessionPath.slice(0, -6);
+		await fs.promises.mkdir(artifactsDir, { recursive: true });
+		await fs.promises.writeFile(path.join(artifactsDir, "artifact.txt"), "artifact");
+
+		const response = await harness.agent.unstable_deleteSession({ sessionId: created.sessionId });
+
+		expectAcpStructure(zDeleteSessionResponse, response);
+		expect(session.disposed).toBe(true);
+		expect(fs.existsSync(sessionPath)).toBe(false);
+		expect(fs.existsSync(artifactsDir)).toBe(false);
+		expect((await harness.agent.listSessions({ cwd: harness.cwdA })).sessions).toHaveLength(0);
+	});
+
+	it("deletes a closed stored session and rejects an unknown session id", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdB, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		const sessionPath = session.sessionManager.getSessionFile()!;
+		await harness.agent.closeSession({ sessionId: created.sessionId });
+		expect(fs.existsSync(sessionPath)).toBe(true);
+
+		await harness.agent.unstable_deleteSession({ sessionId: created.sessionId });
+
+		expect(fs.existsSync(sessionPath)).toBe(false);
+		expect((await harness.agent.listSessions({ cwd: harness.cwdB })).sessions).toHaveLength(0);
+		await expect(harness.agent.unstable_deleteSession({ sessionId: created.sessionId })).rejects.toThrow(
+			`ACP session not found: ${created.sessionId}`,
+		);
 	});
 
 	it("advertises plan mode and emits schema-valid mode updates", async () => {

--- a/packages/coding-agent/test/acp-initialize-conformance.test.ts
+++ b/packages/coding-agent/test/acp-initialize-conformance.test.ts
@@ -238,6 +238,7 @@ describe("ACP initialize conformance", () => {
 				promptCapabilities: expect.objectContaining({ embeddedContext: true, image: true }),
 				sessionCapabilities: expect.objectContaining({
 					list: expect.any(Object),
+					delete: expect.any(Object),
 					fork: expect.any(Object),
 					resume: expect.any(Object),
 					close: expect.any(Object),


### PR DESCRIPTION
## Summary
- upgrade `@agentclientprotocol/sdk` from 0.21.0 to 0.22.0, the first compatible release exposing session deletion
- advertise `sessionCapabilities.delete` and implement persistent deletion for active and stored sessions
- close active sessions before removing their transcript and artifact directory
- explicitly reject the newly typed but unsupported ACP MCP transport
- add lifecycle and initialize-conformance coverage

## Tests
- `bun test packages/coding-agent/test/acp-agent.test.ts packages/coding-agent/test/acp-initialize-conformance.test.ts packages/coding-agent/test/session-storage.test.ts`
- `bun run --cwd packages/coding-agent check`
- `bun run --cwd packages/coding-agent test` (8,588 passed, 358 skipped, 0 failed)