### PR TITLE
fix(coding-agent): reject malformed SQLite pagination

### DIFF
--- a/packages/coding-agent/src/tools/sqlite-reader.ts
+++ b/packages/coding-agent/src/tools/sqlite-reader.ts
@@ -150,13 +150,16 @@ function buildAsciiTable(columns: string[], rows: SqliteRow[]): string {
 	return lines.map(line => truncateToWidth(replaceTabs(line), MAX_RENDER_WIDTH)).join("\n");
 }
 
+const DECIMAL_INTEGER_PATTERN = /^[+-]?\d+$/;
+
 function parseLimit(value: string | null, fallback: number): number {
 	if (value === null || value.trim().length === 0) {
 		return fallback;
 	}
 
-	const parsed = Number.parseInt(value, 10);
-	if (!Number.isFinite(parsed) || parsed < 1) {
+	const normalizedValue = value.trim();
+	const parsed = Number(normalizedValue);
+	if (!DECIMAL_INTEGER_PATTERN.test(normalizedValue) || !Number.isFinite(parsed) || parsed < 1) {
 		throw new ToolError(`SQLite limit must be a positive integer; got '${value}'`);
 	}
 	return Math.min(parsed, MAX_QUERY_LIMIT);
@@ -167,8 +170,9 @@ function parseOffset(value: string | null): number {
 		return 0;
 	}
 
-	const parsed = Number.parseInt(value, 10);
-	if (!Number.isFinite(parsed) || parsed < 0) {
+	const normalizedValue = value.trim();
+	const parsed = Number(normalizedValue);
+	if (!DECIMAL_INTEGER_PATTERN.test(normalizedValue) || !Number.isFinite(parsed) || parsed < 0) {
 		throw new ToolError(`SQLite offset must be a non-negative integer; got '${value}'`);
 	}
 	return parsed;

--- a/packages/coding-agent/test/tools/sqlite.test.ts
+++ b/packages/coding-agent/test/tools/sqlite.test.ts
@@ -209,6 +209,33 @@ describe("SQLite tool support", () => {
 		});
 		expect(parseSqliteSelector("", "q=SELECT+1")).toEqual({ kind: "raw", sql: "SELECT 1" });
 	});
+	it("requires complete decimal integers for SQLite pagination", () => {
+		for (const value of ["2.5", "2rows", "2e1", "0x10"]) {
+			expect(() => parseSqliteSelector("users", `limit=${value}`)).toThrow(
+				`SQLite limit must be a positive integer; got '${value}'`,
+			);
+			expect(() => parseSqliteSelector("users", `offset=${value}`)).toThrow(
+				`SQLite offset must be a non-negative integer; got '${value}'`,
+			);
+		}
+
+		expect(parseSqliteSelector("users", "limit=1&offset=0")).toEqual({
+			kind: "query",
+			table: "users",
+			limit: 1,
+			offset: 0,
+			order: undefined,
+			where: undefined,
+		});
+		expect(parseSqliteSelector("users", "limit=500&offset=0")).toEqual({
+			kind: "query",
+			table: "users",
+			limit: 500,
+			offset: 0,
+			order: undefined,
+			where: undefined,
+		});
+	});
 
 	it("lists tables for a .sqlite database and excludes sqlite internal tables", async () => {
 		const result = await readTool.execute("sqlite-list", { path: sqlitePath });


### PR DESCRIPTION
## 변경 목적
SQLite 경로 선택자의 `limit`과 `offset`이 숫자 일부만 해석해 의도와 다른 조회 범위를 만들 수 있어, 정수 형식 검증을 명확히 합니다.

## 주요 변경사항
- `limit`과 `offset`에 완전한 10진수 정수 형식을 요구합니다.
- 소수, 접미사가 붙은 값, 지수 표기, 16진수 표기를 오류로 처리합니다.
- 잘못된 페이지네이션 값과 기존 최소·최대 경계값의 회귀 테스트를 추가합니다.

## 테스트
- `bunx biome check packages/coding-agent/src/tools/sqlite-reader.ts packages/coding-agent/test/tools/sqlite.test.ts`
- GitHub Actions: `packages/coding-agent/test/tools/sqlite.test.ts` 통과
- GitHub Actions: Affected path validation 통과

## 검토 포인트
- 기존에 부분 숫자 형식에 의존한 호출이 있다면 명시적 정수 값으로 변경이 필요합니다.

## 영향 범위
- SQLite 데이터베이스 읽기 도구의 페이지네이션 선택자