### PR TITLE
fix(coding-agent): trim CRLF from editor output

### DIFF
--- a/packages/coding-agent/src/utils/external-editor.ts
+++ b/packages/coding-agent/src/utils/external-editor.ts
@@ -21,6 +21,11 @@ export interface OpenInEditorOptions {
 	trimTrailingNewline?: boolean;
 }
 
+/** Remove one platform-standard trailing line terminator from editor content. */
+export function trimEditorTrailingNewline(text: string): string {
+	return text.replace(/\r?\n$/, "");
+}
+
 /**
  * Opens `content` in the user's external editor and returns the edited text.
  * Returns `null` if the editor exits with a non-zero code.
@@ -52,7 +57,7 @@ export async function openInEditor(
 			if (options?.trimTrailingNewline === false) {
 				return text;
 			}
-			return text.replace(/\n$/, "");
+			return trimEditorTrailingNewline(text);
 		}
 		return null;
 	} finally {

--- a/packages/coding-agent/test/utils/external-editor.test.ts
+++ b/packages/coding-agent/test/utils/external-editor.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+import { trimEditorTrailingNewline } from "../../src/utils/external-editor";
+
+describe("trimEditorTrailingNewline", () => {
+	it("removes a single CRLF terminator completely", () => {
+		expect(trimEditorTrailingNewline("edited\r\n")).toBe("edited");
+	});
+
+	it("preserves existing LF and unterminated text behavior", () => {
+		expect(trimEditorTrailingNewline("edited\n")).toBe("edited");
+		expect(trimEditorTrailingNewline("edited")).toBe("edited");
+	});
+
+	it("removes only one trailing line terminator", () => {
+		expect(trimEditorTrailingNewline("edited\r\n\r\n")).toBe("edited\r\n");
+	});
+});


### PR DESCRIPTION
## 변경 목적
외부 편집기가 CRLF 줄바꿈으로 저장한 내용에서 마지막 `\r` 문자가 남는 문제를 방지합니다.

## 주요 변경사항
- 외부 편집기 출력의 마지막 CRLF 줄바꿈을 하나의 종료 문자로 처리합니다.
- 기존 LF 줄바꿈과 줄바꿈 없는 내용의 처리 결과를 유지합니다.
- 줄바꿈 정규화 단위 테스트를 추가합니다.

## 테스트
- `bunx biome check packages/coding-agent/src/utils/external-editor.ts packages/coding-agent/test/utils/external-editor.test.ts`
- GitHub Actions: `packages/coding-agent/test/utils/external-editor.test.ts` 통과
- GitHub Actions: Affected path validation 통과

## 검토 포인트
- 마지막 줄바꿈을 하나만 제거하는 기존 동작이 유지되는지 확인이 필요합니다.

## 영향 범위
- 외부 편집기 연동
- 할 일 편집 흐름