### PR TITLE
fix(gjc-rpc): clean up failed post-ready startup

### DIFF
--- a/python/gjc-rpc/src/gjc_rpc/client.py
+++ b/python/gjc-rpc/src/gjc_rpc/client.py
@@ -465,10 +465,14 @@ class RpcClient:
                 raise RpcProcessExitError(f"RPC process stopped before ready: {error}. Stderr: {stderr}") from error
             raise RpcTimeoutError(f"Timed out waiting for RPC ready signal. Stderr: {stderr}")
 
-        if self._custom_tools:
-            self.set_custom_tools(self._custom_tools)
-        if self._host_uris:
-            self.set_host_uris(self._host_uris)
+        try:
+            if self._custom_tools:
+                self.set_custom_tools(self._custom_tools)
+            if self._host_uris:
+                self.set_host_uris(self._host_uris)
+        except BaseException:
+            self.stop()
+            raise
         return self
 
     def stop(self) -> None:

--- a/python/gjc-rpc/tests/test_client.py
+++ b/python/gjc-rpc/tests/test_client.py
@@ -7,7 +7,7 @@ import threading
 import time
 import unittest
 
-from gjc_rpc import RpcClient, RpcCommandError, RpcConcurrencyError, RpcError, host_tool
+from gjc_rpc import RpcClient, RpcCommandError, RpcConcurrencyError, RpcError, host_tool, host_uri
 
 
 FAKE_SERVER = textwrap.dedent(
@@ -496,6 +496,35 @@ HEADLESS_UI_ECHO_SERVER = textwrap.dedent(
     """
 )
 
+POST_READY_SETUP_FAILURE_SERVER = textwrap.dedent(
+    """
+    import json
+    import sys
+
+    print(json.dumps({"type": "ready"}), flush=True)
+
+    for raw_line in sys.stdin:
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+
+        command = json.loads(raw_line)
+        if command["type"] in {"set_host_tools", "set_host_uri_schemes"}:
+            print(
+                json.dumps(
+                    {
+                        "id": command["id"],
+                        "type": "response",
+                        "command": command["type"],
+                        "success": False,
+                        "error": "post-ready setup failed",
+                    }
+                ),
+                flush=True,
+            )
+    """
+)
+
 IDLESS_ERROR_SERVER = textwrap.dedent(
     """
     import json
@@ -749,6 +778,60 @@ class RpcClientTests(unittest.TestCase):
             self.assertEqual(len(end_events), 1)
             self.assertEqual(end_events[0].result["content"][0]["text"], "host:hello")
 
+    def test_post_ready_setup_failure_stops_process_and_clears_client_state(self) -> None:
+        setups = (
+            (
+                "custom_tools",
+                "set_host_tools",
+                {
+                    "custom_tools": (
+                        host_tool(
+                            name="startup_tool",
+                            description="Fails during startup registration",
+                            parameters={"type": "object"},
+                            execute=lambda _args, _context: "unused",
+                        ),
+                    )
+                },
+            ),
+            (
+                "host_uris",
+                "set_host_uri_schemes",
+                {
+                    "host_uris": (
+                        host_uri(
+                            scheme="startup",
+                            read=lambda _url, _context: "unused",
+                        ),
+                    )
+                },
+            ),
+        )
+
+        for setup, command, kwargs in setups:
+            with self.subTest(setup=setup):
+                client = self.make_client(server=POST_READY_SETUP_FAILURE_SERVER, **kwargs)
+                stopped_processes = []
+                stop = client.stop
+
+                def capture_stop() -> None:
+                    if client._process is not None:
+                        stopped_processes.append(client._process)
+                    stop()
+
+                client.stop = capture_stop  # type: ignore[method-assign]
+
+                with self.assertRaises(RpcCommandError) as ctx:
+                    client.start()
+
+                self.assertEqual(ctx.exception.command, command)
+                self.assertEqual(ctx.exception.error, "post-ready setup failed")
+                self.assertEqual(len(stopped_processes), 1)
+                self.assertIsNotNone(stopped_processes[0].poll())
+                self.assertIsNone(client._process)
+                self.assertIsNone(client._stdout_thread)
+                self.assertIsNone(client._stderr_thread)
+                self.assertEqual(client._pending, {})
     def test_extension_ui_round_trip(self) -> None:
         with self.make_client() as client:
             client.prompt("needs ui")


### PR DESCRIPTION
## 변경 목적
RPC 클라이언트가 준비 완료 후 호스트 도구 또는 URI 등록에 실패하면 실행 중인 하위 프로세스와 reader thread가 남을 수 있어 정리 경로를 보완합니다.

## 주요 변경사항
- 호스트 도구 등록 실패 시 기존 종료 절차를 실행합니다.
- 호스트 URI 등록 실패 시 기존 종료 절차를 실행합니다.
- 두 실패 경로에서 프로세스 종료와 클라이언트 상태 초기화를 검증하는 fake server 테스트를 추가합니다.

## 테스트
- `PYTHONPATH=src python -m unittest tests.test_client.RpcClientTests.test_post_ready_setup_failure_stops_process_and_clears_client_state`
- `python -m py_compile src/gjc_rpc/client.py tests/test_client.py`
- 전체 `tests.test_client` 실행: Windows 경로 구분자 차이로 기존 `test_model_mode_and_session_commands` 1건 실패
- GitHub Actions: Affected path validation 통과

## 검토 포인트
- 등록 실패 시 원래 예외가 유지되고 중복 종료 호출이 없는지 확인이 필요합니다.
- Python 변경 경로가 현재 affected-task 매트릭스에서 별도 테스트 작업으로 분류되지 않는 점을 확인이 필요합니다.

## 영향 범위
- Python RPC 클라이언트의 시작 및 호스트 확장 등록 흐름