### PR TITLE
feat(coordinator-mcp): idle session reaper + stop_session tool (session-zombie leak)

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/policy.ts
+++ b/packages/coding-agent/src/coordinator-mcp/policy.ts
@@ -1,6 +1,12 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { coordinatorMcpStateRoot, gjcRoot } from "../gjc-runtime/session-layout";
+import {
+	DEFAULT_SESSION_IDLE_TTL_MS,
+	DEFAULT_SESSION_SWEEP_INTERVAL_MS,
+	MIN_SESSION_IDLE_TTL_MS,
+	MIN_SESSION_SWEEP_INTERVAL_MS,
+} from "./session-reaper";
 
 export type CoordinatorMutationClass = "sessions" | "questions" | "reports";
 
@@ -16,6 +22,8 @@ export interface CoordinatorMcpConfig {
 	namespace: CoordinatorNamespace;
 	stateRoot: string;
 	sessionCommand: string | null;
+	sessionIdleTtlMs: number;
+	sessionSweepIntervalMs: number;
 }
 
 export interface CoordinatorMutationRequest {
@@ -31,6 +39,12 @@ const LEGACY_MUTATION_CLASS_ALIASES = new Map<string, CoordinatorMutationClass>(
 	["question", "questions"],
 	["report", "reports"],
 ]);
+
+function parsePositiveIntMs(value: string | undefined, fallback: number, floor: number): number {
+	const parsed = Number.parseInt((value ?? "").trim(), 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+	return Math.max(floor, parsed);
+}
 
 function parseList(value: string | undefined): string[] {
 	return (value ?? "")
@@ -98,6 +112,16 @@ export function buildCoordinatorMcpConfig(env: NodeJS.ProcessEnv = process.env):
 		},
 		stateRoot: path.resolve(stateRoot),
 		sessionCommand: env.GJC_COORDINATOR_MCP_SESSION_COMMAND?.trim() || null,
+		sessionIdleTtlMs: parsePositiveIntMs(
+			env.GJC_COORDINATOR_MCP_SESSION_IDLE_TTL_MS,
+			DEFAULT_SESSION_IDLE_TTL_MS,
+			MIN_SESSION_IDLE_TTL_MS,
+		),
+		sessionSweepIntervalMs: parsePositiveIntMs(
+			env.GJC_COORDINATOR_MCP_SESSION_SWEEP_INTERVAL_MS,
+			DEFAULT_SESSION_SWEEP_INTERVAL_MS,
+			MIN_SESSION_SWEEP_INTERVAL_MS,
+		),
 	};
 }
 

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -26,7 +26,7 @@ import {
 	replaceOwnerGenerationSync,
 	type TmuxServerProof,
 } from "../gjc-runtime/tmux-owner-isolation";
-
+import { removeGjcTmuxSession, statusGjcTmuxSession } from "../gjc-runtime/tmux-sessions";
 import {
 	assertCoordinatorArtifactPath,
 	assertCoordinatorWorkdir,
@@ -35,6 +35,7 @@ import {
 	coordinatorNamespacePath,
 	requireCoordinatorMutation,
 } from "./policy";
+import { createSessionReaper, type ReapableSession, type SessionReaper } from "./session-reaper";
 
 export type { CoordinatorToolName };
 export { COORDINATOR_MCP_PROTOCOL_VERSION, COORDINATOR_MCP_SERVER_NAME, COORDINATOR_MCP_TOOL_NAMES };
@@ -215,6 +216,7 @@ interface CoordinatorSessionState {
 type CoordinatorEventKind =
 	| "session.registered"
 	| "session.started"
+	| "session.reaped"
 	| "session.state_changed"
 	| "turn.queued"
 	| "turn.delivering"
@@ -342,6 +344,23 @@ function toolSchema(name: CoordinatorToolName): {
 					allow_mutation: allowMutation,
 				},
 				required: ["cwd", "allow_mutation"],
+			},
+		};
+	}
+	if (name === "gjc_coordinator_stop_session") {
+		return {
+			name,
+			description:
+				"Reap a coordinator delegate-created (ephemeral) session: gracefully terminate its idle worker pane(s) and remove the tmux session, then purge its state files. Refuses non-ephemeral (user-registered) sessions unless force is set.",
+			inputSchema: {
+				type: "object",
+				properties: {
+					session_id: sessionId,
+					force: { type: "boolean", description: "Allow stopping a non-ephemeral (user-registered) session." },
+					reason: { type: "string", description: "Optional audit reason recorded on the session.reaped event." },
+					allow_mutation: allowMutation,
+				},
+				required: ["session_id", "allow_mutation"],
 			},
 		};
 	}
@@ -744,6 +763,7 @@ const COORDINATOR_SESSION_STATES = new Set<CoordinatorSessionStateValue>([
 const COORDINATOR_EVENT_KINDS = new Set<CoordinatorEventKind>([
 	"session.registered",
 	"session.started",
+	"session.reaped",
 	"session.state_changed",
 	"turn.queued",
 	"turn.delivering",
@@ -2985,6 +3005,80 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 	function sessionFile(sessionId: unknown): string {
 		return path.join(namespaceDir, "sessions", `${safeExternalId("session", sessionId)}.json`);
 	}
+	// Reap a coordinator delegate-created session: gracefully terminate the idle worker pane(s),
+	// remove the tmux session, and purge state files. dev's removeGjcTmuxSession refuses live
+	// panes by design, so idle workers are SIGTERM'd first. Never touches non-ephemeral sessions
+	// unless force is set.
+	async function reapSession(
+		rawId: unknown,
+		opts: { force?: boolean; reason?: string } = {},
+	): Promise<{ ok: boolean; reason?: string; killed: boolean }> {
+		const id = safeExternalId("session", rawId);
+		const record = asRecord(await readJsonFile(sessionFile(id)));
+		if (!record) return { ok: false, reason: "unknown_session", killed: false };
+		if (record.ephemeral !== true && opts.force !== true) {
+			return { ok: false, reason: "not_ephemeral", killed: false };
+		}
+		const tmuxSession = optionalString(record.tmux_session) ?? optionalString(record.tmuxSession);
+		let killed = false;
+		if (tmuxSession) {
+			try {
+				const status = statusGjcTmuxSession(tmuxSession, env);
+				for (const pid of status.panePids) {
+					try {
+						process.kill(pid, "SIGTERM");
+					} catch {
+						// pane process already gone
+					}
+				}
+				if (status.panePids.length > 0) await new Promise(resolve => setTimeout(resolve, 250));
+				removeGjcTmuxSession(tmuxSession, env);
+				killed = true;
+			} catch {
+				// already gone / still live / not GJC-managed — best effort; still purge our records
+			}
+		}
+		await appendCoordinatorEvent(namespaceDir, {
+			kind: "session.reaped",
+			sessionId: id,
+			summary: `Session ${id} reaped${opts.reason ? ` (${opts.reason})` : ""}`,
+			metadata: { reason: opts.reason ?? null, killed, force: opts.force === true },
+		});
+		await fs.rm(sessionFile(id), { force: true });
+		await fs.rm(sessionStateFile(namespaceDir, id), { force: true });
+		await fs.rm(activeTurnFile(namespaceDir, id), { force: true });
+		return { ok: true, killed };
+	}
+
+	const sessionReaper: SessionReaper = createSessionReaper(
+		{
+			listSessions: async (): Promise<ReapableSession[]> => {
+				const out: ReapableSession[] = [];
+				for (const raw of await listSessions()) {
+					const rec = asRecord(raw);
+					if (rec?.ephemeral !== true) continue;
+					const sid = optionalString(rec.session_id);
+					if (!sid) continue;
+					const activeTurn = await readActiveTurn(namespaceDir, sid);
+					const state = await readSessionState(namespaceDir, sid);
+					const stamp = optionalString(state?.updated_at) ?? optionalString(rec.created_at);
+					const lastActivityMs = stamp ? Date.parse(stamp) : 0;
+					out.push({
+						sessionId: sid,
+						ephemeral: true,
+						hasActiveTurn: activeTurn !== null,
+						lastActivityMs: Number.isFinite(lastActivityMs) ? lastActivityMs : 0,
+					});
+				}
+				return out;
+			},
+			reapSession: async (sid: string): Promise<void> => {
+				await reapSession(sid, { reason: "idle_reaper" });
+			},
+			now: () => Date.now(),
+		},
+		{ idleTtlMs: config.sessionIdleTtlMs, sweepIntervalMs: config.sessionSweepIntervalMs },
+	);
 	async function compensateFailedOwnerStart(
 		session: Record<string, unknown>,
 		ownerTransaction: {
@@ -3498,6 +3592,9 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 						rollback?: () => Promise<"cleaned" | "failed" | "unverifiable">;
 					} | null;
 					session = normalizeSession(startedRecord);
+					// Delegate-created sessions are ephemeral: the idle reaper may reclaim them once
+					// they are idle past the TTL with no active turn. User-registered sessions are not.
+					session.ephemeral = true;
 					try {
 						await writeJsonFile(sessionFile(session.session_id), session);
 						await appendCoordinatorEvent(namespaceDir, {
@@ -3618,6 +3715,19 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 					}
 				}
 				return base;
+			}
+			if (name === "gjc_coordinator_stop_session") {
+				requireCoordinatorMutation(config, "sessions", args);
+				const result = await reapSession(args.session_id, {
+					force: args.force === true,
+					reason: optionalString(args.reason) ?? "stop_session",
+				});
+				return {
+					ok: result.ok,
+					session_id: safeExternalId("session", args.session_id),
+					killed: result.killed,
+					...(result.reason ? { reason: result.reason } : {}),
+				};
 			}
 			if (name === "gjc_coordinator_start_session") {
 				requireCoordinatorMutation(config, "sessions", args);
@@ -4057,7 +4167,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		};
 	}
 
-	return { config, callTool, handleJsonRpc, handle: handleJsonRpc };
+	return { config, callTool, handleJsonRpc, handle: handleJsonRpc, reapSession, sessionReaper };
 }
 
 function legacyToolResult(payload: unknown): {
@@ -4271,12 +4381,17 @@ export async function pumpCoordinatorMcpStream(
 
 export async function runCoordinatorMcpStdio(options: CoordinatorMcpServerOptions = {}): Promise<void> {
 	const server = createCoordinatorMcpServer(options);
-	await pumpCoordinatorMcpStream(
-		request => server.handleJsonRpc(request),
-		process.stdin,
-		line =>
-			new Promise<void>((resolve, reject) => {
-				process.stdout.write(line, err => (err ? reject(err) : resolve()));
-			}),
-	);
+	server.sessionReaper.start(); // idle-reap ephemeral delegate sessions in the background
+	try {
+		await pumpCoordinatorMcpStream(
+			request => server.handleJsonRpc(request),
+			process.stdin,
+			line =>
+				new Promise<void>((resolve, reject) => {
+					process.stdout.write(line, err => (err ? reject(err) : resolve()));
+				}),
+		);
+	} finally {
+		server.sessionReaper.stop();
+	}
 }

--- a/packages/coding-agent/src/coordinator-mcp/session-reaper.ts
+++ b/packages/coding-agent/src/coordinator-mcp/session-reaper.ts
@@ -1,0 +1,129 @@
+import { logger } from "@gajae-code/utils";
+
+/**
+ * Idle reaper for coordinator-managed GJC worker sessions.
+ *
+ * Every `gjc_delegate_*` call that omits `session_id` starts a fresh tmux worker
+ * session. Nothing in the coordinator ever tore those down, so completed/crashed
+ * sessions accumulated (RAM + worktrees) until something killed them by hand.
+ *
+ * This is the automatic backstop (defense-in-depth): a periodic sweep force-closes
+ * sessions that are (a) ephemeral — coordinator delegate-created, never a user's
+ * registered resident session, (b) not mid-turn, and (c) idle past a TTL.
+ *
+ * The controller is pure + fully injectable (clock / list / reap side-effects) so
+ * it is unit-testable without tmux, the filesystem, or wall-clock waits. The
+ * scheduling mirrors the proven resource-gc controller: a recursive setTimeout
+ * with a generation guard so a stop()+start() can never leak a duplicate timer.
+ */
+
+export const DEFAULT_SESSION_IDLE_TTL_MS = 30 * 60_000; // 30 min idle → reap
+export const DEFAULT_SESSION_SWEEP_INTERVAL_MS = 5 * 60_000; // sweep every 5 min
+export const MIN_SESSION_IDLE_TTL_MS = 60_000; // never reap a <1min-idle session
+export const MIN_SESSION_SWEEP_INTERVAL_MS = 30_000;
+
+/** Minimal projection of a coordinator session the reaper needs to decide. */
+export interface ReapableSession {
+	sessionId: string;
+	/** True only for coordinator delegate-created sessions. User-registered resident sessions are false and never reaped. */
+	ephemeral: boolean;
+	/** Epoch ms of last observed activity (turn update / session-state write / session creation). */
+	lastActivityMs: number;
+	/** True while a turn is active — never reap mid-turn. */
+	hasActiveTurn: boolean;
+}
+
+export interface SessionReaperPolicy {
+	idleTtlMs: number;
+	sweepIntervalMs: number;
+}
+
+/**
+ * Pure selection: which sessions are safe to reap at `now`.
+ * A session is reapable iff ephemeral AND not mid-turn AND idle ≥ (clamped) TTL.
+ */
+export function selectReapableSessions(
+	sessions: readonly ReapableSession[],
+	now: number,
+	idleTtlMs: number,
+): ReapableSession[] {
+	const ttl = Math.max(MIN_SESSION_IDLE_TTL_MS, idleTtlMs);
+	return sessions.filter(s => s.ephemeral && !s.hasActiveTurn && now - s.lastActivityMs >= ttl);
+}
+
+/** Injectable side-effects so the controller runs in tests without tmux/fs/real time. */
+export interface SessionReaperDeps {
+	listSessions: () => Promise<ReapableSession[]>;
+	reapSession: (sessionId: string) => Promise<void>;
+	now: () => number;
+}
+
+export interface SessionReaper {
+	/** Run one sweep; returns the number of sessions successfully reaped. */
+	sweepOnce: () => Promise<number>;
+	start: () => void;
+	stop: () => void;
+	readonly running: boolean;
+}
+
+export function createSessionReaper(deps: SessionReaperDeps, policy: SessionReaperPolicy): SessionReaper {
+	const idleTtlMs = Math.max(MIN_SESSION_IDLE_TTL_MS, policy.idleTtlMs);
+	const sweepIntervalMs = Math.max(MIN_SESSION_SWEEP_INTERVAL_MS, policy.sweepIntervalMs);
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let generation = 0;
+	let inProgress = false;
+
+	async function sweepOnce(): Promise<number> {
+		if (inProgress) return 0; // never overlap sweeps
+		inProgress = true;
+		try {
+			const sessions = await deps.listSessions();
+			const targets = selectReapableSessions(sessions, deps.now(), idleTtlMs);
+			let reaped = 0;
+			for (const session of targets) {
+				try {
+					await deps.reapSession(session.sessionId);
+					reaped += 1;
+				} catch (err) {
+					// One wedged session must not abort the rest of the sweep.
+					logger.warn(
+						`session-reaper: failed to reap ${session.sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+					);
+				}
+			}
+			return reaped;
+		} finally {
+			inProgress = false;
+		}
+	}
+
+	function schedule(gen: number): void {
+		timer = setTimeout(() => {
+			if (gen !== generation) return; // stale timer from a prior start()
+			void sweepOnce().finally(() => {
+				if (gen === generation) schedule(gen);
+			});
+		}, sweepIntervalMs);
+		// The reaper must never keep the coordinator process alive by itself.
+		(timer as { unref?: () => void }).unref?.();
+	}
+
+	return {
+		sweepOnce,
+		start(): void {
+			if (timer) return; // already running
+			generation += 1;
+			schedule(generation);
+		},
+		stop(): void {
+			generation += 1; // invalidate any in-flight scheduled tick
+			if (timer) {
+				clearTimeout(timer);
+				timer = null;
+			}
+		},
+		get running(): boolean {
+			return timer !== null;
+		},
+	};
+}

--- a/packages/coding-agent/src/coordinator/contract.ts
+++ b/packages/coding-agent/src/coordinator/contract.ts
@@ -12,6 +12,7 @@ export const COORDINATOR_MCP_TOOL_NAMES = [
 	"gjc_coordinator_watch_events",
 	"gjc_coordinator_register_session",
 	"gjc_coordinator_start_session",
+	"gjc_coordinator_stop_session",
 	"gjc_coordinator_send_prompt",
 	"gjc_coordinator_submit_question_answer",
 	"gjc_coordinator_read_turn",

--- a/packages/coding-agent/test/coordinator-mcp/session-reaper.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp/session-reaper.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "bun:test";
+import {
+	createSessionReaper,
+	type ReapableSession,
+	selectReapableSessions,
+} from "../../src/coordinator-mcp/session-reaper";
+
+const TTL = 30 * 60_000;
+const NOW = 10_000_000;
+
+function sess(id: string, over: Partial<ReapableSession> = {}): ReapableSession {
+	return { sessionId: id, ephemeral: true, hasActiveTurn: false, lastActivityMs: NOW - TTL - 1, ...over };
+}
+
+describe("selectReapableSessions", () => {
+	it("reaps ephemeral, idle-past-TTL, no-active-turn sessions", () => {
+		expect(selectReapableSessions([sess("a")], NOW, TTL).map(s => s.sessionId)).toEqual(["a"]);
+	});
+	it("never reaps a non-ephemeral (user-registered resident) session", () => {
+		expect(selectReapableSessions([sess("u", { ephemeral: false })], NOW, TTL)).toEqual([]);
+	});
+	it("never reaps a session with an active turn", () => {
+		expect(selectReapableSessions([sess("t", { hasActiveTurn: true })], NOW, TTL)).toEqual([]);
+	});
+	it("keeps sessions still within the TTL", () => {
+		expect(selectReapableSessions([sess("f", { lastActivityMs: NOW - 1000 })], NOW, TTL)).toEqual([]);
+	});
+	it("clamps a too-small TTL to the floor so a just-active session is never reaped", () => {
+		expect(selectReapableSessions([sess("j", { lastActivityMs: NOW - 1000 })], NOW, 0)).toEqual([]);
+	});
+	it("reaps exactly at the TTL boundary", () => {
+		expect(
+			selectReapableSessions([sess("b", { lastActivityMs: NOW - TTL })], NOW, TTL).map(s => s.sessionId),
+		).toEqual(["b"]);
+	});
+});
+
+describe("createSessionReaper.sweepOnce", () => {
+	it("reaps every eligible session and returns the count, skipping ineligible", async () => {
+		const reaped: string[] = [];
+		const reaper = createSessionReaper(
+			{
+				listSessions: async () => [sess("a"), sess("u", { ephemeral: false }), sess("b")],
+				reapSession: async id => {
+					reaped.push(id);
+				},
+				now: () => NOW,
+			},
+			{ idleTtlMs: TTL, sweepIntervalMs: 60_000 },
+		);
+		expect(await reaper.sweepOnce()).toBe(2);
+		expect(reaped.sort()).toEqual(["a", "b"]);
+	});
+
+	it("continues the sweep when one reap throws (one wedged session cannot abort the rest)", async () => {
+		const reaped: string[] = [];
+		const reaper = createSessionReaper(
+			{
+				listSessions: async () => [sess("bad"), sess("good")],
+				reapSession: async id => {
+					if (id === "bad") throw new Error("wedged");
+					reaped.push(id);
+				},
+				now: () => NOW,
+			},
+			{ idleTtlMs: TTL, sweepIntervalMs: 60_000 },
+		);
+		expect(await reaper.sweepOnce()).toBe(1);
+		expect(reaped).toEqual(["good"]);
+	});
+
+	it("never overlaps concurrent sweeps", async () => {
+		let active = 0;
+		let maxActive = 0;
+		const reaper = createSessionReaper(
+			{
+				listSessions: async () => {
+					active += 1;
+					maxActive = Math.max(maxActive, active);
+					await new Promise(r => setTimeout(r, 10));
+					active -= 1;
+					return [];
+				},
+				reapSession: async () => {},
+				now: () => NOW,
+			},
+			{ idleTtlMs: TTL, sweepIntervalMs: 60_000 },
+		);
+		const first = reaper.sweepOnce();
+		const second = reaper.sweepOnce(); // fires while first is mid-list
+		expect(await second).toBe(0); // guarded out
+		await first;
+		expect(maxActive).toBe(1);
+	});
+});
+
+describe("createSessionReaper scheduler", () => {
+	it("start()/stop() flips running and is idempotent", () => {
+		const reaper = createSessionReaper(
+			{ listSessions: async () => [], reapSession: async () => {}, now: () => NOW },
+			{ idleTtlMs: TTL, sweepIntervalMs: 60_000 },
+		);
+		expect(reaper.running).toBe(false);
+		reaper.start();
+		reaper.start(); // idempotent, no duplicate timer
+		expect(reaper.running).toBe(true);
+		reaper.stop();
+		expect(reaper.running).toBe(false);
+	});
+
+	it("fires a sweep when the interval elapses", () => {
+		vi.useFakeTimers();
+		try {
+			let sweeps = 0;
+			const reaper = createSessionReaper(
+				{
+					listSessions: async () => {
+						sweeps += 1;
+						return [];
+					},
+					reapSession: async () => {},
+					now: () => NOW,
+				},
+				{ idleTtlMs: TTL, sweepIntervalMs: 60_000 },
+			);
+			reaper.start();
+			vi.advanceTimersByTime(60_000);
+			expect(sweeps).toBe(1);
+			reaper.stop();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("stop() cancels the pending scheduled sweep so it never fires (generation guard)", () => {
+		vi.useFakeTimers();
+		try {
+			let sweeps = 0;
+			const reaper = createSessionReaper(
+				{
+					listSessions: async () => {
+						sweeps += 1;
+						return [];
+					},
+					reapSession: async () => {},
+					now: () => NOW,
+				},
+				{ idleTtlMs: TTL, sweepIntervalMs: 60_000 },
+			);
+			reaper.start();
+			reaper.stop();
+			vi.advanceTimersByTime(300_000);
+			expect(sweeps).toBe(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/packages/coding-agent/test/coordinator-mcp/stop-session.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp/stop-session.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createCoordinatorMcpServer } from "../../src/coordinator-mcp/server";
+
+async function withTempRoot(run: (root: string) => Promise<void>): Promise<void> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-coord-stop-"));
+	try {
+		await run(root);
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}
+
+function makeServer(root: string) {
+	let n = 0;
+	return createCoordinatorMcpServer({
+		env: {
+			GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+			GJC_COORDINATOR_MCP_MUTATIONS: "sessions,questions,reports",
+			GJC_COORDINATOR_MCP_STATE_ROOT: path.join(root, ".state"),
+			GJC_COORDINATOR_MCP_PROFILE: "stop-controller",
+			GJC_COORDINATOR_MCP_REPO: "repo-stop",
+		},
+		services: {
+			startSession: (input: { cwd: string }) => {
+				n += 1;
+				return {
+					name: `stop-session-${n}`,
+					cwd: input.cwd,
+					createdAt: new Date().toISOString(),
+				};
+			},
+		},
+	});
+}
+
+describe("gjc_coordinator_stop_session", () => {
+	it("refuses a non-ephemeral (start_session) session unless force, then reaps and purges it", async () => {
+		await withTempRoot(async root => {
+			const server = await makeServer(root);
+			const started = await server.callTool("gjc_coordinator_start_session", { cwd: root, allow_mutation: true });
+			expect(started.ok).toBe(true);
+			const sessionId = String((started.session as { session_id: string }).session_id);
+
+			const refused = await server.callTool("gjc_coordinator_stop_session", {
+				session_id: sessionId,
+				allow_mutation: true,
+			});
+			expect(refused.ok).toBe(false);
+			expect(refused.reason).toBe("not_ephemeral");
+
+			const forced = await server.callTool("gjc_coordinator_stop_session", {
+				session_id: sessionId,
+				force: true,
+				allow_mutation: true,
+			});
+			expect(forced.ok).toBe(true);
+
+			// The session record is purged.
+			const status = await server.callTool("gjc_coordinator_read_status", { session_id: sessionId });
+			expect(status.session ?? null).toBeNull();
+		});
+	});
+
+	it("reaps a delegate-created ephemeral session without force", async () => {
+		await withTempRoot(async root => {
+			const server = await makeServer(root);
+			const delegated = await server.callTool("gjc_delegate_execute", {
+				task: "ephemeral work",
+				cwd: root,
+				allow_mutation: true,
+			});
+			expect(delegated.ok).toBe(true);
+			const sessionId = String((delegated as { session_id: string }).session_id);
+
+			const reaped = await server.callTool("gjc_coordinator_stop_session", {
+				session_id: sessionId,
+				allow_mutation: true,
+			});
+			expect(reaped.ok).toBe(true); // ephemeral → allowed without force
+
+			const status = await server.callTool("gjc_coordinator_read_status", { session_id: sessionId });
+			expect(status.session ?? null).toBeNull();
+		});
+	});
+
+	it("returns unknown_session for a missing id", async () => {
+		await withTempRoot(async root => {
+			const server = await makeServer(root);
+			const missing = await server.callTool("gjc_coordinator_stop_session", {
+				session_id: "does-not-exist",
+				allow_mutation: true,
+			});
+			expect(missing.ok).toBe(false);
+			expect(missing.reason).toBe("unknown_session");
+		});
+	});
+});


### PR DESCRIPTION
## What

Adds the missing **teardown owner + trigger** for coordinator delegate-created worker sessions. Every `gjc_delegate_*` call that omits `session_id` starts a fresh tmux worker session; nothing ever tore those down, so completed/idle sessions accumulated (RAM + worktrees) until killed by hand.

- **`gjc_coordinator_stop_session`** — explicit reap of a delegate-created (ephemeral) session: gracefully `SIGTERM` the idle worker pane(s), then `removeGjcTmuxSession`, then purge the session's state files. Refuses non-ephemeral (user-registered) sessions unless `force` is set.
- **Idle reaper** (`session-reaper.ts`) — a bounded recursive-`setTimeout` sweep (same shape as the existing `resource-gc` controller: generation guard, no-overlap, `unref`) that reaps ephemeral sessions idle past a TTL with no active turn. The controller is pure + fully injectable (clock / list / reap), so it is unit-tested without tmux, the filesystem, or wall-clock waits.
- **Ownership model** — delegate session files now carry `ephemeral: true`; the reaper and the auto-reap path never touch user-registered/resident sessions.
- Started/stopped with the stdio server lifecycle.

## Interaction with #2004 (please review)

#2004 made tmux teardown deliberately conservative — `removeGjcTmuxSession` **refuses live/attached panes** (`gjc_tmux_session_live`). An idle worker zombie still has a live pane process, so a plain remove can't reclaim it. This PR therefore **`SIGTERM`s the idle worker pane pid(s) first** (they are our own `gjc --worktree` workers, idle past the TTL), then removes the now-empty, ownership-verified session. If you'd prefer a different reclamation path (e.g. never signalling pane processes, or a graceful worker "end" handshake), I'll adjust — flagging it explicitly since it extends your teardown model.

## Config knobs (`policy.ts`)
- `GJC_COORDINATOR_MCP_SESSION_IDLE_TTL_MS` — default 30 min (floor 1 min).
- `GJC_COORDINATOR_MCP_SESSION_SWEEP_INTERVAL_MS` — default 5 min (floor 30 s).

## Testing
- `bun test packages/coding-agent/test/coordinator-mcp/session-reaper.test.ts` — **12 pass** (pure selection: ephemeral/idle/active-turn/TTL-floor/boundary; `sweepOnce`: eligibility, per-item failure isolation, no-overlap; scheduler: start/stop idempotence, interval fire, stop cancels pending tick via the generation guard).
- `bun test packages/coding-agent/test/coordinator-mcp/stop-session.test.ts` — **3 pass** (non-ephemeral refused without `force` then reaped+purged with `force`; delegate-ephemeral reaped without `force`; `unknown_session`).
- `bun --cwd=packages/coding-agent run check` — `biome check` (2006 files) + `tsc --noEmit` green.
- Pre-existing `dev` env-dependent tmux/socket/lifecycle test failures are unchanged (not introduced by this PR).

---

- [x] `bun check` passes (`biome check` + `tsc --noEmit`)
- [x] Tested locally (reaper units + stop_session integration)
- [x] CHANGELOG — internal coordinator lifecycle; happy to add an entry if preferred
