### PR TITLE
fix(pi-natives): treat CRLF as zero-width in grapheme_width_str

### DIFF
--- a/crates/pi-natives/src/text.rs
+++ b/crates/pi-natives/src/text.rs
@@ -399,6 +399,18 @@ fn grapheme_width_str(g: &str, tab_width: usize) -> usize {
 	if g == "\t" {
 		return tab_width;
 	}
+	// `unicode-segmentation` emits CRLF as a single grapheme, but
+	// `UnicodeWidthStr::width("\r\n") == 1` disagrees with this module's
+	// zero-width control-character policy (the ASCII fast path assigns CR and
+	// LF width 0 via `ascii_cell_width_u16`). Without this correction an
+	// unrelated non-ASCII character in the same segment would route CRLF
+	// through the grapheme path and flip its width from 0 to 1, making the
+	// width primitive context-dependent (e.g. `visibleWidth("한\r\n")`). Handle
+	// it before `UnicodeWidthStr` while leaving VS16/modifier/keycap/ZWJ
+	// grapheme handling intact.
+	if g == "\r\n" {
+		return 0;
+	}
 	let mut it = g.chars();
 	let Some(c0) = it.next() else {
 		return 0;
@@ -1461,6 +1473,54 @@ mod tests {
 	fn test_hangul_filler_width() {
 		assert_eq!(visible_width_u16(&to_u16("\u{3164}"), DEFAULT_TAB_WIDTH), 2);
 		assert_eq!(truncate_string_for_test("\u{3164}X", 2), "\u{3164}");
+	}
+
+	#[test]
+	fn test_crlf_zero_width_scalar_batch_parity() {
+		// CR and LF are zero-width under the ASCII fast path. The grapheme path
+		// (triggered by any non-ASCII scalar in the same segment) must agree so
+		// the width primitive stays context-independent.
+		assert_eq!(visible_width_u16(&to_u16("\r\n"), DEFAULT_TAB_WIDTH), 0);
+
+		// Korean (한글) and CJK ideographs are East Asian Wide (2 cells each);
+		// the adjacent CRLF must contribute 0 in every position.
+		let cases = [
+			("한\r\n", 2),
+			("\r\n한", 2),
+			("한\r\n글", 4),
+			("가\r나\n다", 6),
+			("字\r\n漢", 4),
+			("한字\r\n漢글", 8),
+			("한\r\n\r\n글", 4),
+		];
+		for (case, expected) in cases {
+			let scalar = visible_width_u16(&to_u16(case), DEFAULT_TAB_WIDTH);
+			let batch = visible_widths(vec![case.to_string()], DEFAULT_TAB_WIDTH as u32);
+			assert_eq!(scalar, expected, "scalar width mismatch for {case:?}");
+			assert_eq!(batch, vec![expected as u32], "batch width mismatch for {case:?}");
+			// The non-ASCII CRLF result must match the pure-ASCII CRLF policy:
+			// removing the CR/LF scalars leaves exactly `expected` cells.
+			let stripped = case.replace(['\r', '\n'], "");
+			assert_eq!(
+				visible_width_u16(&to_u16(&stripped), DEFAULT_TAB_WIDTH),
+				expected,
+				"CR/LF must be zero-width for {case:?}"
+			);
+		}
+	}
+
+	#[test]
+	fn test_crlf_preserves_grapheme_correctness() {
+		// The CRLF correction must not regress VS16/modifier/keycap/ZWJ widths,
+		// including when a CRLF sits next to complex graphemes.
+		let cases = [("❤️\r\n", 2), ("👍🏽\r\n", 2), ("1️⃣\r\n", 2), ("👨‍👩‍👧‍👦\r\n", 2), ("한\r\n👨‍👩‍👧‍👦", 4)];
+		for (case, expected) in cases {
+			assert_eq!(
+				visible_width_u16(&to_u16(case), DEFAULT_TAB_WIDTH),
+				expected,
+				"grapheme width regressed for {case:?}"
+			);
+		}
 	}
 
 	#[test]

--- a/packages/tui/test/visible-width-jamo.test.ts
+++ b/packages/tui/test/visible-width-jamo.test.ts
@@ -160,3 +160,42 @@ describe("native text helpers — Hangul Compatibility Jamo width parity", () =>
 		expect(sliceWithWidth(input, 0, 8, true).width).toBe(8);
 	});
 });
+
+describe("native text helpers — CRLF control-boundary width parity", () => {
+	// `unicode-segmentation` emits CRLF as a single grapheme and
+	// `UnicodeWidthStr::width("\r\n") == 1`, disagreeing with the module's
+	// zero-width control-character policy. A non-ASCII scalar in the same
+	// string routes the whole run through the grapheme path, so CRLF must be
+	// corrected to zero width to keep the width primitive context-independent.
+	const cases: Array<[string, number]> = [
+		["한\r\n", 2],
+		["\r\n한", 2],
+		["한\r\n글", 4],
+		["字\r\n漢", 4],
+		["한字\r\n漢글", 8],
+		["안녕\r\n하세요", 10],
+	];
+
+	it("scalar visibleWidth keeps CRLF zero-width next to Korean/CJK", () => {
+		for (const [input, expected] of cases) {
+			expect(visibleWidth(input)).toBe(expected);
+		}
+	});
+
+	it("batch visibleWidths matches scalar for CRLF cases", () => {
+		const inputs = cases.map(([input]) => input);
+		const expected = cases.map(([, width]) => width);
+		expect(visibleWidths(inputs)).toEqual(expected);
+		for (const [input, width] of cases) {
+			expect(visibleWidths([input])).toEqual([width]);
+		}
+	});
+
+	it("CRLF contributes no columns beyond the surrounding text", () => {
+		for (const [input, expected] of cases) {
+			const withoutCrlf = input.replaceAll(/[\r\n]/g, "");
+			expect(visibleWidth(input)).toBe(visibleWidth(withoutCrlf));
+			expect(visibleWidth(withoutCrlf)).toBe(expected);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #2032. In `grapheme_width_str` (`crates/pi-natives/src/text.rs`), `"\r\n"` is now treated as zero-width **before** `UnicodeWidthStr::width`, aligning the grapheme path with this module's zero-width control-character policy (the ASCII fast path already assigns CR/LF width 0 via `ascii_cell_width_u16`).

`unicode-segmentation` emits CRLF as a single grapheme and `UnicodeWidthStr::width("\r\n") == 1`, so an unrelated non-ASCII scalar in the same segment routed CRLF through the grapheme path and added a phantom column — making the exported width primitive context-dependent (e.g. `visibleWidth("한\r\n")`). VS16/modifier/keycap/ZWJ handling is untouched (no revert to scalar summation); the U+3164 filler correction is preserved.

## Tests

- **Rust** (`crates/pi-natives/src/text.rs`):
  - `test_crlf_zero_width_scalar_batch_parity` — scalar (`visible_width_u16`) vs batch (`visible_widths`) parity for Korean+CJK with CR/LF variants, plus CRLF-stripped equivalence.
  - `test_crlf_preserves_grapheme_correctness` — VS16/modifier/keycap/ZWJ next to CRLF.
- **TS** (`packages/tui/test/visible-width-jamo.test.ts`) — CRLF control-boundary parity block through the native-backed `visibleWidth`/`visibleWidths`.

## Verification (exact head `7ec39165`, base `a14ee84a`)

- `cargo test -p pi-natives` green (single-threaded 121/121; 2 pty/shell tests are pre-existing parallel-run flakiness — pass in isolation and on base).
- `cargo fmt -p pi-natives --check` clean; `cargo clippy -p pi-natives` clean.
- Native rebuilt; `packages/natives` `native.test.ts` 35/35.
- TS/TUI consumers 69/69: jamo, text-utils, truncate-to-width, truncated-text, wrap-ansi, g011-batched-natives-redteam, g015-debug-width-redteam.

## PR checklist

- [x] Target branch is `dev`.
- [x] Description explains what changed and why.
- [x] Focused tests listed above.
- [ ] Changelog entry — not applicable (internal width-primitive correctness fix, no user-facing behavior change).

Closes #2032

Signed-off-by: Yeachan-Heo <hurrc04@gmail.com>