### PR TITLE
fix(coding-agent): reject out-of-range numeric gate replies (#2030)

### DIFF
--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -603,18 +603,41 @@ function mapAnswerToLabel(answerJson: string, options: string[]): string | undef
 	return undefined;
 }
 
-/** Map a client answer to the workflow-gate answer shape (unattended mode). */
-function mapAnswerToGate(
-	answerJson: string,
-	options: string[],
-): { selected: string[]; other?: boolean; custom?: string } {
+/** Workflow-gate answer shape (unattended mode). */
+interface GateAnswer {
+	selected: string[];
+	other?: boolean;
+	custom?: string;
+}
+
+/**
+ * Discriminated result of mapping a client answer to a workflow-gate answer.
+ * `ok: false` means the reply is invalid and the caller must close the exact
+ * claim/receipt and reissue the interaction rather than durably accepting it.
+ */
+type GateAnswerResult = { ok: true; answer: GateAnswer } | { ok: false; reason: string };
+
+/**
+ * Map a client answer to the workflow-gate answer shape (unattended mode).
+ *
+ * The protocol defines a numeric reply as an option index, so a number outside
+ * `options` is invalid (issue #2030): it must NOT be converted into a free-text
+ * `Other` that passes the ask schema and triggers a misleading success ack.
+ * Only JSON strings enter the free-text/Other path.
+ */
+export function mapAnswerToGate(answerJson: string, options: string[]): GateAnswerResult {
 	const answer = parseAnswer(answerJson);
 	if (typeof answer === "number") {
 		const label = options[answer];
-		return label === undefined ? { selected: [], other: true, custom: String(answer) } : { selected: [label] };
+		return label === undefined
+			? { ok: false, reason: "numeric_selector_out_of_range" }
+			: { ok: true, answer: { selected: [label] } };
 	}
 	if (typeof answer === "string") {
-		return options.includes(answer) ? { selected: [answer] } : { selected: [], other: true, custom: answer };
+		return {
+			ok: true,
+			answer: options.includes(answer) ? { selected: [answer] } : { selected: [], other: true, custom: answer },
+		};
 	}
 	if (answer && typeof answer === "object") {
 		const obj = answer as { selected?: unknown; custom?: unknown };
@@ -622,9 +645,9 @@ function mapAnswerToGate(
 			? obj.selected.map(s => (typeof s === "number" ? (options[s] ?? String(s)) : String(s)))
 			: [];
 		const custom = typeof obj.custom === "string" ? obj.custom : undefined;
-		return { selected, other: custom !== undefined, custom };
+		return { ok: true, answer: { selected, other: custom !== undefined, custom } };
 	}
-	return { selected: [] };
+	return { ok: true, answer: { selected: [] } };
 }
 
 interface NotificationControlCommandPayload {
@@ -1097,7 +1120,16 @@ export function createNotificationsExtension(api: ExtensionAPI, options: { setti
 				} else if (presentation?.multi && typeof rawAnswer === "string") {
 					answer = { selected: presentation.selectedOptions, other: true, custom: rawAnswer };
 				} else {
-					answer = mapAnswerToGate(reply.answerJson, gateOptions.get(gateId) ?? []);
+					const mapped = mapAnswerToGate(reply.answerJson, gateOptions.get(gateId) ?? []);
+					if (!mapped.ok) {
+						// A numeric selector outside options is invalid (issue #2030): close the
+						// exact claim/receipt and reissue the interaction — never a success ack.
+						native.closeClaimInvalid(reply.replyReceiptId, mapped.reason);
+						gatePresentations.closeInteraction(reply.id, mapped.reason);
+						gatePresentations.reissue(gateId);
+						return;
+					}
+					answer = mapped.answer;
 				}
 				void gate
 					.resolveGateFromNotification(

--- a/packages/coding-agent/test/notifications-ask-selected-ack.test.ts
+++ b/packages/coding-agent/test/notifications-ask-selected-ack.test.ts
@@ -2,7 +2,8 @@ import { afterEach, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { RpcWorkflowGate } from "../src/modes/rpc/rpc-types";
+import type { RpcWorkflowGate, RpcWorkflowGateResolution, RpcWorkflowGateResponse } from "../src/modes/rpc/rpc-types";
+import type { NotificationGateResolutionOptions } from "../src/modes/shared/agent-wire/unattended-session";
 import { createNotificationsExtension } from "../src/notifications/index";
 import { getAskAnswerSource, notifyWorkflowGateEmitterChanged } from "../src/tools/ask-answer-registry";
 
@@ -268,5 +269,174 @@ test("attaches unattended workflow gates installed after session_start", async (
 	} finally {
 		notifyWorkflowGateEmitterChanged(harness.sessionId, undefined);
 		await harness.restore();
+	}
+}, 20_000);
+
+interface ResolveCall {
+	answer: unknown;
+}
+
+/**
+ * Stand up an unattended workflow gate over a live notification socket. The mock
+ * gate records every `resolveGateFromNotification` call so a test can assert that
+ * an invalid numeric selector never reaches the durable-accept / ack path.
+ */
+async function startUnattendedGate(opts: {
+	options: string[];
+	multi?: boolean;
+	onResolve?: (options: NotificationGateResolutionOptions) => Promise<void> | void;
+}) {
+	const harness = await startInteractiveNotifications();
+	const ws = new WebSocket(`${harness.endpoint.url}/?token=${encodeURIComponent(harness.endpoint.token)}`);
+	const messages = socketMessages(ws);
+	await new Promise<void>((resolve, reject) => {
+		ws.addEventListener("open", () => resolve(), { once: true });
+		ws.addEventListener("error", () => reject(new Error("websocket failed")), { once: true });
+	});
+	await messages.next("hello");
+	ws.send(
+		JSON.stringify({
+			type: "hello",
+			protocolVersion: 3,
+			capabilities: ["ask_controls_v1", "ask_selected_ack_v1"],
+		}),
+	);
+
+	const calls: ResolveCall[] = [];
+	let emitGate: ((gate: RpcWorkflowGate) => void) | undefined;
+	const gate = {
+		isUnattended: () => true,
+		emitGate: async () => undefined,
+		onGateEmitted: (listener: (value: RpcWorkflowGate) => void) => {
+			emitGate = listener;
+			return () => {
+				emitGate = undefined;
+			};
+		},
+		resolveGate: async () => ({ gate_id: "gate-1", status: "accepted", answer_hash: "", resolved_at: "now" }),
+		resolveGateFromNotification: async (
+			response: RpcWorkflowGateResponse,
+			resolveOptions: NotificationGateResolutionOptions,
+		): Promise<RpcWorkflowGateResolution> => {
+			calls.push({ answer: response.answer });
+			if (opts.onResolve) await opts.onResolve(resolveOptions);
+			else resolveOptions.resolveClaim();
+			return { gate_id: response.gate_id, status: "accepted", answer_hash: "", resolved_at: "now" };
+		},
+		registerGateTerminalController: () => () => {},
+		setAckRecoveryParticipant: () => {},
+	};
+	notifyWorkflowGateEmitterChanged(harness.sessionId, gate as never);
+	emitGate?.({
+		type: "workflow_gate",
+		gate_id: "gate-1",
+		stage: "deep-interview",
+		kind: "question",
+		schema: { type: "object" },
+		schema_hash: "hash",
+		options: opts.options.map(value => ({ value, label: value })),
+		context: {
+			prompt: "Proceed?",
+			stage_state: { multi: opts.multi === true, navigation_label: "Done" },
+		},
+		created_at: new Date().toISOString(),
+		required: true,
+	});
+	const first = await messages.next("action_needed");
+	return {
+		harness,
+		ws,
+		messages,
+		calls,
+		firstActionId: String(first.id),
+		token: harness.endpoint.token,
+		restore: async () => {
+			ws.close();
+			notifyWorkflowGateEmitterChanged(harness.sessionId, undefined);
+			await harness.restore();
+		},
+	};
+}
+
+test("unattended out-of-range numeric reply closes the claim and reissues without a success ack", async () => {
+	const gate = await startUnattendedGate({ options: ["yes", "no"] });
+	try {
+		gate.ws.send(JSON.stringify({ type: "reply", id: gate.firstActionId, answer: 99, token: gate.token }));
+		const resolved = await gate.messages.next("action_resolved");
+		expect(resolved).toMatchObject({ id: gate.firstActionId, resolvedBy: "client" });
+		// Invalid-claim closure carries no accepted answer; only genuine resolution does. This
+		// pins closeClaimInvalid vs a regression that resolves the claim with answer:99 and reissues.
+		expect(resolved.answer).toBeUndefined();
+		const reissued = await gate.messages.next("action_needed");
+		expect(reissued.id).not.toBe(gate.firstActionId);
+		// The invalid numeric selector must never reach durable accept / Selected! ack.
+		expect(gate.calls).toHaveLength(0);
+		expect(gate.messages.all.some(message => message.type === "ask_selected_ack_request")).toBe(false);
+	} finally {
+		await gate.restore();
+	}
+}, 20_000);
+
+test("unattended in-range numeric reply resolves the gate and requests the Selected ack", async () => {
+	const gate = await startUnattendedGate({
+		options: ["yes", "no"],
+		onResolve: async options => {
+			await options.requestSelectedAck({
+				replyReceiptId: options.replyReceiptId,
+				actionId: options.interactionActionId,
+				commitKey: "commit-1",
+				daemonDeadlineAt: Date.now() + 8_000,
+				hostTimeoutMs: 10_000,
+			});
+			options.resolveClaim();
+		},
+	});
+	try {
+		gate.ws.send(JSON.stringify({ type: "reply", id: gate.firstActionId, answer: 0, token: gate.token }));
+		const ackRequest = await gate.messages.next("ask_selected_ack_request");
+		gate.ws.send(
+			JSON.stringify({
+				type: "ask_selected_ack_result",
+				requestId: ackRequest.requestId,
+				commitKey: ackRequest.commitKey,
+				outcome: { status: "delivered", messageId: 42 },
+			}),
+		);
+		expect(await gate.messages.next("action_resolved")).toMatchObject({ id: gate.firstActionId });
+		expect(gate.calls).toEqual([{ answer: { selected: ["yes"] } }]);
+	} finally {
+		await gate.restore();
+	}
+}, 20_000);
+
+test("unattended multi-select out-of-range numeric reply closes the claim and reissues", async () => {
+	const gate = await startUnattendedGate({ options: ["a", "b"], multi: true });
+	try {
+		gate.ws.send(JSON.stringify({ type: "reply", id: gate.firstActionId, answer: 99, token: gate.token }));
+		expect(await gate.messages.next("action_resolved")).toMatchObject({ id: gate.firstActionId });
+		const reissued = await gate.messages.next("action_needed");
+		expect(reissued.id).not.toBe(gate.firstActionId);
+		expect(gate.calls).toHaveLength(0);
+	} finally {
+		await gate.restore();
+	}
+}, 20_000);
+
+test("unattended stale/replayed out-of-range reply never resolves the gate", async () => {
+	const gate = await startUnattendedGate({ options: ["yes", "no"] });
+	try {
+		// First invalid reply closes claim #1 and reissues action #2.
+		gate.ws.send(JSON.stringify({ type: "reply", id: gate.firstActionId, answer: 99, token: gate.token }));
+		expect(await gate.messages.next("action_resolved")).toMatchObject({ id: gate.firstActionId });
+		const reissued = await gate.messages.next("action_needed");
+		expect(reissued.id).not.toBe(gate.firstActionId);
+		// Replaying the stale action id (again out of range) must not durably accept anything.
+		gate.ws.send(JSON.stringify({ type: "reply", id: gate.firstActionId, answer: 99, token: gate.token }));
+		// A fresh valid reply against the reissued action still resolves cleanly.
+		gate.ws.send(JSON.stringify({ type: "reply", id: reissued.id, answer: 1, token: gate.token }));
+		expect(await gate.messages.next("action_resolved")).toMatchObject({ id: reissued.id });
+		expect(gate.calls).toEqual([{ answer: { selected: ["no"] } }]);
+	} finally {
+		await gate.restore();
 	}
 }, 20_000);

--- a/packages/coding-agent/test/notifications-map-answer-gate.test.ts
+++ b/packages/coding-agent/test/notifications-map-answer-gate.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { mapAnswerToGate } from "../src/notifications/index";
+
+const options = ["alpha", "beta", "gamma"];
+
+describe("mapAnswerToGate discriminated result (issue #2030)", () => {
+	test("in-range numeric index (zero) selects the first option", () => {
+		expect(mapAnswerToGate("0", options)).toEqual({ ok: true, answer: { selected: ["alpha"] } });
+	});
+
+	test("in-range numeric index at the upper bound selects the last option", () => {
+		expect(mapAnswerToGate(String(options.length - 1), options)).toEqual({
+			ok: true,
+			answer: { selected: ["gamma"] },
+		});
+	});
+
+	test("out-of-range numeric index (99) is invalid, never free-text Other", () => {
+		expect(mapAnswerToGate("99", options)).toEqual({ ok: false, reason: "numeric_selector_out_of_range" });
+	});
+
+	test("numeric index equal to options.length (just past the bound) is invalid", () => {
+		expect(mapAnswerToGate(String(options.length), options)).toEqual({
+			ok: false,
+			reason: "numeric_selector_out_of_range",
+		});
+	});
+
+	test("negative numeric index is invalid", () => {
+		expect(mapAnswerToGate("-1", options)).toEqual({ ok: false, reason: "numeric_selector_out_of_range" });
+	});
+
+	test("any numeric index against empty options is invalid", () => {
+		expect(mapAnswerToGate("0", [])).toEqual({ ok: false, reason: "numeric_selector_out_of_range" });
+	});
+
+	test("JSON string matching an option selects it", () => {
+		expect(mapAnswerToGate(JSON.stringify("beta"), options)).toEqual({
+			ok: true,
+			answer: { selected: ["beta"] },
+		});
+	});
+
+	test("JSON string outside options preserves the free-text/Other path", () => {
+		expect(mapAnswerToGate(JSON.stringify("something else"), options)).toEqual({
+			ok: true,
+			answer: { selected: [], other: true, custom: "something else" },
+		});
+	});
+
+	test("numeric-looking JSON string is free text, not an out-of-range index", () => {
+		expect(mapAnswerToGate(JSON.stringify("99"), options)).toEqual({
+			ok: true,
+			answer: { selected: [], other: true, custom: "99" },
+		});
+	});
+
+	test("non-JSON payload is treated as a free-text string, not a number", () => {
+		expect(mapAnswerToGate("not json", options)).toEqual({
+			ok: true,
+			answer: { selected: [], other: true, custom: "not json" },
+		});
+	});
+
+	test("structured object with selected indices maps to labels", () => {
+		expect(mapAnswerToGate(JSON.stringify({ selected: [0, 2] }), options)).toEqual({
+			ok: true,
+			answer: { selected: ["alpha", "gamma"], other: false, custom: undefined },
+		});
+	});
+
+	test("structured object with custom text keeps the Other path", () => {
+		expect(mapAnswerToGate(JSON.stringify({ selected: [], custom: "typed" }), options)).toEqual({
+			ok: true,
+			answer: { selected: [], other: true, custom: "typed" },
+		});
+	});
+
+	test("empty object yields an empty (valid) selection", () => {
+		expect(mapAnswerToGate(JSON.stringify({}), options)).toEqual({
+			ok: true,
+			answer: { selected: [], other: false, custom: undefined },
+		});
+	});
+});


### PR DESCRIPTION
Closes #2030.

## Problem
The protocol defines a numeric reply as an option index, but `mapAnswerToGate` converted an out-of-range index into free-text `Other` (`custom: String(answer)`, e.g. `"99"`). In the unattended path that object passed the ask schema, was durably accepted, and triggered a `Selected!` acknowledgement — a misleading success for malformed/stale input.

Evidence: `packages/coding-agent/src/notifications/index.ts:611-614` (pre-fix).

## Fix
- `mapAnswerToGate` now returns a discriminated result: `{ ok: true, answer } | { ok: false, reason }`.
- A top-level numeric selector outside `options` (out-of-range, negative, `options.length`, empty options) is **invalid** → the unattended reply handler closes the **exact** claim/receipt (`native.closeClaimInvalid(reply.replyReceiptId, reason)`), closes the interaction, and reissues the same durable gate under a fresh action id — returning **before** `resolveGateFromNotification`, so there is no durable accept and no `Selected!` ack.
- The JSON-string free-text/Other path is preserved unchanged (a matching string selects its option; any other string becomes `Other`/`custom`). Only JSON strings enter the free-text path.
- Multi-select: in-range numbers still toggle; out-of-range numbers fall through to the invalid branch.

Minimal by design: the structured `{ selected: [...] }` numeric fallback is unchanged (still rejected downstream by ask/schema validation); the reported defect and acceptance case concern a bare numeric `ReplyAnswer::Index`.

## Tests
- Unit (`notifications-map-answer-gate.test.ts`): zero, upper bound, `options.length`, `99`, `-1`, empty options, matching/non-matching JSON strings, numeric-looking string `"99"` (free text, not an index), structured object/custom, empty object.
- Unattended integration (`notifications-ask-selected-ack.test.ts`, analogue of the interactive `answer:99` test): out-of-range single- and multi-select close the claim (`action_resolved` with no `answer`, `resolvedBy: client`) and reissue with no resolver call and no ack request; in-range replies reach the resolver and request/settle the Selected ack; stale/replayed out-of-range ids never durably accept while the reissued action still resolves exactly once.

## Acceptance (#2030)
- ✅ Unattended `answer: 99` produces claim closure and a fresh action rather than a success ack.
- ✅ Added the unattended analogue of the existing interactive `answer: 99` test.

## Verification
- `bun run check` (biome + tsc) green.
- Affected notification/unattended/workflow-gate suites green at the exact head.
- Commit is DCO signed-off and SSH-signed.
- Independent architect review: **APPROVE** / architectural status **CLEAR** (one non-blocking NIT applied — invalid closure asserts no accepted `answer`).