### PR TITLE
test(tui): cover Kitty anchored-wrap + persisted IRC-sidebar lifecycle (#2033)

### DIFF
--- a/packages/coding-agent/test/interactive-mode-irc-sidebar-lifecycle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-irc-sidebar-lifecycle.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { TempDir } from "@gajae-code/utils";
+import { ModelRegistry } from "../src/config/model-registry";
+import { IrcSplitViewComponent } from "../src/modes/components/irc-sidebar";
+import { InteractiveMode } from "../src/modes/interactive-mode";
+import { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+import { SessionManager } from "../src/session/session-manager";
+
+function getSplitView(mode: InteractiveMode): IrcSplitViewComponent {
+	const split = mode.ui.children.find(
+		(child): child is IrcSplitViewComponent => child instanceof IrcSplitViewComponent,
+	);
+	if (!split) throw new Error("IRC split view component is not registered on the TUI");
+	return split;
+}
+
+describe("InteractiveMode IRC sidebar startup/reset lifecycle", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let mode: InteractiveMode;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-irc-lifecycle-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		}
+
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		mode?.stop();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	it("syncs availability at startup so the toggle opens the split with no live settings change", async () => {
+		// Persisted settings (as if restored from a prior session), both enabled.
+		mode.settings.set("irc.enabled", true);
+		mode.settings.set("irc.sidebar.enabled", true);
+
+		// init() must sync availability from persisted settings — no live setter fires.
+		await mode.init();
+		const split = getSplitView(mode);
+		expect(split.visible).toBe(false); // enabled-but-closed
+
+		// Without the startup sync this toggle is inert (the "inert Alt+I" regression).
+		mode.toggleIrcSidebar();
+		expect(split.visible).toBe(true);
+
+		// A session reset (fork / handoff / new) closes the split...
+		mode.resetIrcSidebarSession();
+		expect(split.visible).toBe(false);
+
+		// ...and its availability re-sync keeps the toggle live afterward, again with
+		// no live settings change.
+		mode.toggleIrcSidebar();
+		expect(split.visible).toBe(true);
+	});
+
+	it("re-derives availability on reset after a settings change with no live callback", async () => {
+		// Start disabled so the startup sync leaves the sidebar unavailable.
+		mode.settings.set("irc.enabled", true);
+		mode.settings.set("irc.sidebar.enabled", false);
+		await mode.init();
+		const split = getSplitView(mode);
+
+		mode.toggleIrcSidebar();
+		expect(split.visible).toBe(false); // inert while disabled
+
+		// Enable the setting WITHOUT the live selector callback: availability is now
+		// stale-false even though both predicates read true.
+		mode.settings.set("irc.sidebar.enabled", true);
+		mode.toggleIrcSidebar();
+		expect(split.visible).toBe(false); // still inert until a sync runs
+
+		// resetIrcSidebarSession() re-derives availability from current settings; drop
+		// its sync and the toggle stays inert here.
+		mode.resetIrcSidebarSession();
+		mode.toggleIrcSidebar();
+		expect(split.visible).toBe(true);
+	});
+
+	const disabledCombinations: Array<{ ircEnabled: boolean; sidebarEnabled: boolean }> = [
+		{ ircEnabled: true, sidebarEnabled: false },
+		{ ircEnabled: false, sidebarEnabled: true },
+		{ ircEnabled: false, sidebarEnabled: false },
+	];
+	for (const { ircEnabled, sidebarEnabled } of disabledCombinations) {
+		it(`keeps the split unavailable and the toggle inert (irc.enabled=${ircEnabled}, irc.sidebar.enabled=${sidebarEnabled})`, async () => {
+			mode.settings.set("irc.enabled", ircEnabled);
+			mode.settings.set("irc.sidebar.enabled", sidebarEnabled);
+			await mode.init();
+			const split = getSplitView(mode);
+
+			expect(split.visible).toBe(false);
+			mode.toggleIrcSidebar();
+			expect(split.visible).toBe(false);
+
+			// A reset must not resurrect an unavailable sidebar either.
+			mode.resetIrcSidebarSession();
+			mode.toggleIrcSidebar();
+			expect(split.visible).toBe(false);
+		});
+	}
+});

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -183,7 +183,7 @@ export interface ViewportAnchorAnnotation {
 // Kitty graphics prefix and TERMINAL.isImageLine() would misclassify every
 // annotated line as an image line, which skips wrapping (issue: assistant
 // prose overflowing the terminal on Kitty-protocol terminals).
-const VIEWPORT_ANCHOR_PREFIX = "\x1b_AGJC_ANCHOR:";
+export const VIEWPORT_ANCHOR_PREFIX = "\x1b_AGJC_ANCHOR:";
 const VIEWPORT_ANCHOR_SUFFIX = "\x1b\\";
 
 function ansiSequenceEnd(text: string, start: number): number {

--- a/packages/tui/test/viewport-scroll.test.ts
+++ b/packages/tui/test/viewport-scroll.test.ts
@@ -2,13 +2,20 @@ import { describe, expect, it } from "bun:test";
 import {
 	type Component,
 	Container,
+	ImageProtocol,
+	Markdown,
 	renderComponentWithViewportAnchors,
+	setTerminalImageProtocol,
 	shouldUseViewportRepaintForHost,
+	TERMINAL,
 	Text,
 	TUI,
+	VIEWPORT_ANCHOR_PREFIX,
 	type ViewportAnchorRender,
 	type ViewportAnchorSource,
+	visibleWidth,
 } from "@gajae-code/tui";
+import { defaultMarkdownTheme } from "./test-themes";
 import { VirtualTerminal } from "./virtual-terminal";
 
 class Lines implements Component {
@@ -469,6 +476,56 @@ describe("registered viewport anchor", () => {
 		const rendered = container.renderWithViewportAnchors(80);
 		expect(rendered.lines.join("")).toContain(literalMarker);
 		expect(rendered.anchors.some(anchor => anchor?.id === "literal-apc")).toBe(true);
+	});
+
+	it("wraps Kitty-protocol anchored prose into bounded rows without marker leakage while a genuine Kitty line bypasses", () => {
+		const previousProtocol = TERMINAL.imageProtocol;
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		try {
+			// The anchor marker must never begin with (or contain) the Kitty graphics
+			// prefix. Otherwise TERMINAL.isImageLine() misclassifies every annotated
+			// prose row as an image line and skips wrapping (the #2012 regression).
+			expect(VIEWPORT_ANCHOR_PREFIX.startsWith(ImageProtocol.Kitty)).toBe(false);
+			expect(VIEWPORT_ANCHOR_PREFIX.includes(ImageProtocol.Kitty)).toBe(false);
+
+			const width = 24;
+			const prose = "the quick brown fox jumps over the lazy dog ".repeat(6).trim();
+			// renderWithViewportAnchorSource runs the real annotate -> isImageLine-gated
+			// wrap -> extract pipeline, which is exactly where the old marker collided.
+			const rendered = new Markdown(prose, 0, 0, defaultMarkdownTheme).renderWithViewportAnchorSource(width, {
+				id: "kitty-prose",
+			});
+
+			// Wrapping still happens under an active Kitty classification: many bounded rows.
+			expect(rendered.lines.length).toBeGreaterThan(1);
+			for (const line of rendered.lines) {
+				expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+				expect(TERMINAL.isImageLine(line)).toBe(false);
+			}
+
+			// Anchors stay row-aligned and carry the shared source id.
+			expect(rendered.anchors.length).toBe(rendered.lines.length);
+			expect(rendered.anchors.some(anchor => anchor?.id === "kitty-prose")).toBe(true);
+
+			// No anchor marker (or stray Kitty prefix) leaks into the visible output.
+			const joined = rendered.lines.join("");
+			expect(joined).not.toContain(VIEWPORT_ANCHOR_PREFIX);
+			expect(joined).not.toContain("GJC_ANCHOR");
+			expect(joined).not.toContain(ImageProtocol.Kitty);
+
+			// A genuine Kitty graphics line is still classified as an image and bypasses
+			// wrapping: it survives the same pipeline verbatim as a single unwrapped row.
+			const kittyImageLine = `${ImageProtocol.Kitty}f=100,a=T,t=d;${"QUJD".repeat(64)}\x1b\\`;
+			expect(TERMINAL.isImageLine(kittyImageLine)).toBe(true);
+			expect(kittyImageLine.length).toBeGreaterThan(width);
+			const bypassed = new Markdown(kittyImageLine, 0, 0, defaultMarkdownTheme).renderWithViewportAnchorSource(
+				width,
+				{ id: "kitty-image" },
+			);
+			expect(bypassed.lines).toEqual([kittyImageLine]);
+		} finally {
+			setTerminalImageProtocol(previousProtocol);
+		}
 	});
 
 	it("preserves a CJK emoji ANSI anchor across arbitrary repeated reflow", async () => {


### PR DESCRIPTION
## What

Add two focused regression-test families flagged by the TUI/viewport architect audit (issue #2033). **Tests only** — the sole production edit is exporting an existing constant.

- **Gap 1 — Kitty anchored-wrap (#2012).** `packages/tui/test/viewport-scroll.test.ts`: with `setTerminalImageProtocol(ImageProtocol.Kitty)` active, render long anchored prose at a narrow width through the real `Markdown.renderWithViewportAnchorSource` pipeline (annotate → `isImageLine`-gated wrap → extract). Assert multiple bounded rows, no anchor-marker leakage, and that a genuine `\x1b_G…` line is still classified as an image and bypasses wrapping verbatim. The collision guard asserts against the shared `VIEWPORT_ANCHOR_PREFIX` constant, now `export`ed from `packages/tui/src/utils.ts` so a future rename cannot silently diverge producer/consumer.
- **Gap 2 — persisted IRC-sidebar lifecycle (#2013).** `packages/coding-agent/test/interactive-mode-irc-sidebar-lifecycle.test.ts`: drive the real `InteractiveMode.init()` and `resetIrcSidebarSession()` availability-sync paths — no manual `applyIrcSidebarAvailability()`, no live settings change — across the both-enabled case and every disabled predicate combination.

## Why

Both regressions are already fixed on `dev`, but nothing pins them: the existing anchored-prose tests never enable Kitty classification, and the IRC tests either call `applyIrcSidebarAvailability()` manually or only assert `resetIrcSidebarSession()` is invoked. Removing the marker-prefix fix or either availability sync would silently reintroduce prose overflow / the inert-Alt+I bug without failing CI.

## Testing

Verified each family is **red on the regression, green on the fix**:

- Gap 1: restoring the old colliding `\x1b_G` marker collapses the prose to a single 263-col overflow row → test fails (prefix guard + bounded-row assertions). Reverting to `\x1b_A…` → green.
- Gap 2: removing the `init()` startup sync fails the startup test; removing the `resetIrcSidebarSession()` sync fails the reset test. Both present → green.

Green at the exact head (`4c36ac48`, one signed commit over `origin/dev` `d9dcffd0`):

- `packages/tui` suite: 716 pass / 0 fail
- `packages/coding-agent` suite: 9103 pass / 357 skip / 0 fail
- `bun run --cwd packages/tui check:types` + `bun run --cwd packages/coding-agent check:types`: clean
- `biome check` on changed files: clean
- `bun run check:schemas`: clean

## Coordination with #2018

Independent of PR #2018 (IRC chat-room redesign): this PR targets `dev` and exercises only current-`dev` IRC APIs (`toggleIrcSidebar` / `applyIrcSidebarAvailability` / `resetIrcSidebarSession` / `IrcSplitViewComponent.visible` / `irc.enabled` + `irc.sidebar.enabled`). Kept as one PR for issue #2033; if #2018 lands first I will rebase.

---

- [x] Target branch is `dev`
- [x] `bun check` (biome + tsc) passes
- [x] Tested locally (focused red/green + full suites)
- [ ] CHANGELOG — not applicable (test-only; no user-facing behavior change)

Closes #2033

Signed-off-by: Yeachan-Heo <hurrc04@gmail.com>
