### PR TITLE
fix(agent-core): hint at tool discovery when a called tool is not found

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1093,6 +1093,17 @@ function emitAbortedAssistantMessage(
 }
 
 /**
+ * Match a tool against the model-visible call name. Tools emitted via OpenAI's
+ * custom-tool path (e.g. `apply_patch` on GPT-5) arrive under their wire-level
+ * name, which may differ from the harness-internal `name`, so dispatch and any
+ * "is this tool callable" check must consider both. Internal `name` takes
+ * precedence when a caller needs a single match.
+ */
+function toolMatchesCallName(tool: { name: string; customWireName?: string }, callName: string): boolean {
+	return tool.name === callName || (tool.customWireName !== undefined && tool.customWireName === callName);
+}
+
+/**
  * Execute tool calls from an assistant message.
  */
 async function executeToolCalls(
@@ -1273,7 +1284,22 @@ async function executeToolCalls(
 							`Re-issue the call with complete arguments, splitting the work into smaller steps if needed.`,
 					);
 				}
-				if (!tool) throw new Error(`Tool ${toolCall.name} not found`);
+				if (!tool) {
+					// A discoverable tool that hasn't been activated yet resolves to
+					// undefined here. The model often "remembers" such a tool (e.g.
+					// `task`) from earlier context and calls it by name without first
+					// re-discovering it. Point it at tool discovery so it can activate
+					// the tool and retry instead of giving up on the capability. The
+					// base wording stays byte-for-byte stable for downstream consumers;
+					// the period and hint are appended only when discovery is callable.
+					const base = `Tool ${toolCall.name} not found`;
+					const hasToolDiscovery = tools?.some(t => toolMatchesCallName(t, "search_tool_bm25")) ?? false;
+					throw new Error(
+						hasToolDiscovery
+							? `${base}. If you are unsure whether this tool exists or how to use it, call \`search_tool_bm25\` to discover and activate the matching tool, then retry.`
+							: base,
+					);
+				}
 
 				let effectiveArgs: Record<string, unknown>;
 				try {

--- a/packages/agent/test/agent-loop-tool-not-found-hint.test.ts
+++ b/packages/agent/test/agent-loop-tool-not-found-hint.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import { agentLoop } from "@gajae-code/agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool } from "@gajae-code/agent-core/types";
+import type { Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import * as z from "zod/v4";
+import { createUserMessage } from "./helpers";
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+function makeTool(name: string): AgentTool<z.ZodObject<Record<string, never>>, Record<string, never>> {
+	return {
+		name,
+		label: name,
+		description: `The ${name} tool`,
+		parameters: z.object({}),
+		async execute() {
+			return { content: [{ type: "text", text: "ok" }], details: {} };
+		},
+	};
+}
+
+async function collectToolResults(
+	tools: AgentTool<z.ZodObject<Record<string, never>>, Record<string, never>>[],
+): Promise<Array<{ isError?: boolean; text: string }>> {
+	const context: AgentContext = { systemPrompt: [""], messages: [], tools };
+	const mock = createMockModel({
+		responses: [
+			// The model "remembers" a discoverable tool and calls it by name even
+			// though it is not in the active tool set.
+			{ content: [{ type: "toolCall", id: "tc-1", name: "task", arguments: {} }] },
+			{ content: ["recovered"] },
+		],
+	});
+	const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+	const toolResults: Array<{ isError?: boolean; text: string }> = [];
+	const stream = agentLoop([createUserMessage("do the thing")], context, config, undefined, mock.stream);
+	for await (const event of stream) {
+		if (event.type === "tool_execution_end") {
+			const first = event.result.content?.[0];
+			toolResults.push({ isError: event.isError, text: first?.type === "text" ? first.text : "" });
+		}
+	}
+	return toolResults;
+}
+
+describe("agentLoop: tool-not-found discovery hint", () => {
+	it("appends a tool-discovery hint when search_tool_bm25 is in the active tools", async () => {
+		const toolResults = await collectToolResults([makeTool("search_tool_bm25"), makeTool("read")]);
+
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0].isError).toBe(true);
+		// Base wording is preserved (now followed by a period) and the full
+		// discover -> activate -> retry recovery sequence is spelled out.
+		expect(toolResults[0].text).toContain("Tool task not found.");
+		expect(toolResults[0].text).toContain("search_tool_bm25");
+		expect(toolResults[0].text).toContain("discover");
+		expect(toolResults[0].text).toContain("activate");
+		expect(toolResults[0].text).toContain("retry");
+	});
+
+	it("does not append the hint when search_tool_bm25 is absent from the active tools", async () => {
+		const toolResults = await collectToolResults([makeTool("read")]);
+
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0].isError).toBe(true);
+		// No discovery tool active: base wording stays byte-for-byte stable
+		// (no trailing period, no hint, no `undefined` leak).
+		expect(toolResults[0].text).toBe("Tool task not found");
+	});
+});

--- a/packages/agent/test/agent-loop-tool-not-found-red-team.test.ts
+++ b/packages/agent/test/agent-loop-tool-not-found-red-team.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "bun:test";
+import { agentLoop } from "@gajae-code/agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool } from "@gajae-code/agent-core/types";
+import type { Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import * as z from "zod/v4";
+import { createUserMessage } from "./helpers";
+
+type EmptySchema = z.ZodObject<Record<string, never>>;
+type TestTool = AgentTool<EmptySchema, Record<string, never>>;
+
+const DISCOVERY_HINT =
+	"If you are unsure whether this tool exists or how to use it, call `search_tool_bm25` to discover and activate the matching tool, then retry.";
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+function makeTool(name: string, options: { customWireName?: string; onExecute?: () => void } = {}): TestTool {
+	return {
+		name,
+		label: name,
+		description: `The ${name} tool`,
+		parameters: z.object({}),
+		...(options.customWireName === undefined ? {} : { customWireName: options.customWireName }),
+		async execute() {
+			options.onExecute?.();
+			return { content: [{ type: "text", text: "executed" }], details: {} };
+		},
+	};
+}
+
+async function collectToolResults(
+	tools: TestTool[] | undefined,
+	toolName: string,
+): Promise<Array<{ isError?: boolean; text: string }>> {
+	const context: AgentContext = { systemPrompt: [""], messages: [], tools };
+	const mock = createMockModel({
+		responses: [
+			{ content: [{ type: "toolCall", id: "tc-1", name: toolName, arguments: {} }] },
+			{ content: ["recovered"] },
+		],
+	});
+	const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+	const toolResults: Array<{ isError?: boolean; text: string }> = [];
+	const stream = agentLoop([createUserMessage("do the thing")], context, config, undefined, mock.stream);
+	for await (const event of stream) {
+		if (event.type === "tool_execution_end") {
+			const first = event.result.content?.[0];
+			toolResults.push({ isError: event.isError, text: first?.type === "text" ? first.text : "" });
+		}
+	}
+	return toolResults;
+}
+
+function expectBaseNotFound(result: { isError?: boolean; text: string }, toolName: string): void {
+	expect(result.isError).toBe(true);
+	expect(result.text).toContain(`Tool ${toolName} not found`);
+}
+
+describe("agentLoop: tool-not-found discovery hint red team", () => {
+	it("adds the complete discovery hint only when search_tool_bm25 is active", async () => {
+		const toolName = "remembered_discoverable_tool";
+		const toolResults = await collectToolResults([makeTool("search_tool_bm25"), makeTool("read")], toolName);
+
+		expect(toolResults).toHaveLength(1);
+		expectBaseNotFound(toolResults[0], toolName);
+		expect(toolResults[0].text).toContain(DISCOVERY_HINT);
+	});
+
+	it("keeps inactive discovery errors clean and free of undefined", async () => {
+		const toolName = "inactive_discoverable_tool";
+		const toolResults = await collectToolResults([makeTool("read")], toolName);
+
+		expect(toolResults).toHaveLength(1);
+		expectBaseNotFound(toolResults[0], toolName);
+		expect(toolResults[0].text).not.toContain("search_tool_bm25");
+		expect(toolResults[0].text).not.toContain("undefined");
+	});
+
+	it("treats a discovery tool reachable only via customWireName as active discovery", async () => {
+		const toolName = "custom_wire_discovery_tool";
+		const toolResults = await collectToolResults(
+			[makeTool("internal_discovery", { customWireName: "search_tool_bm25" })],
+			toolName,
+		);
+
+		// A tool callable as `search_tool_bm25` (via customWireName) means discovery
+		// is reachable, so the hint must fire — mirroring the dispatcher, which
+		// resolves calls by internal name OR customWireName.
+		expect(toolResults).toHaveLength(1);
+		expectBaseNotFound(toolResults[0], toolName);
+		expect(toolResults[0].text).toContain(DISCOVERY_HINT);
+	});
+
+	it("emits the base error with an empty active-tool array", async () => {
+		const toolName = "empty_tools_tool";
+		const toolResults = await collectToolResults([], toolName);
+
+		expect(toolResults).toHaveLength(1);
+		expectBaseNotFound(toolResults[0], toolName);
+		expect(toolResults[0].text).not.toContain("undefined");
+		expect(toolResults[0].text).not.toContain("search_tool_bm25");
+	});
+
+	it("emits the base error when the active-tool set is undefined", async () => {
+		const toolName = "no_active_tools_tool";
+		const toolResults = await collectToolResults(undefined, toolName);
+
+		expect(toolResults).toHaveLength(1);
+		expectBaseNotFound(toolResults[0], toolName);
+		expect(toolResults[0].text).not.toContain("undefined");
+		expect(toolResults[0].text).not.toContain("search_tool_bm25");
+	});
+
+	it("executes a tool matched solely by customWireName", async () => {
+		let executionCount = 0;
+		const toolResults = await collectToolResults(
+			[makeTool("internal_edit", { customWireName: "apply_patch", onExecute: () => executionCount++ })],
+			"apply_patch",
+		);
+
+		expect(executionCount).toBe(1);
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0].isError).toBe(false);
+		expect(toolResults[0].text).toBe("executed");
+	});
+
+	it("preserves the exact base not-found substring for downstream consumers", async () => {
+		const toolName = "legacy_client_tool";
+		const toolResults = await collectToolResults(undefined, toolName);
+
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0].text).toContain(`Tool ${toolName} not found`);
+	});
+});


### PR DESCRIPTION
## Problem

When the model calls a tool that is **not in the active tool set**, the agent loop threw a bare `Tool <name> not found`. This is common for **discoverable** tools (e.g. `task`) that get hidden behind tool discovery and were never re-activated — the model "remembers" the tool from earlier context, calls it by name, hits the error, and often **gives up on the capability** instead of re-discovering it. (Observed live as repeated `Tool task not found` failures until the operator manually ran tool discovery.)

## Fix

In `packages/agent/src/agent-loop.ts`, the tool-not-found branch of `executeToolCalls` now appends a recovery hint pointing the model at `search_tool_bm25`:

> `Tool <name> not found. If you are unsure whether this tool exists or how to use it, call \`search_tool_bm25\` to discover and activate the matching tool, then retry.`

- **Gated on availability:** the hint is appended only when a tool callable as `search_tool_bm25` is present in `currentContext.tools`, so it never appears in sessions where tool discovery is off.
- **Matches dispatch semantics:** a shared `toolMatchesCallName(tool, callName)` helper matches by internal `name` **or** `customWireName`, mirroring the dispatcher's resolution, so a discovery tool exposed only via `customWireName` still triggers the hint.
- **Base wording preserved:** `Tool <name> not found` stays **byte-for-byte stable** when discovery is unavailable (the period + hint are appended only in the discovery-present branch), so downstream consumers that match on the base substring are unaffected.

## Tests

- `packages/agent/test/agent-loop-tool-not-found-hint.test.ts` — the two primary branches (hint present with full discover/activate/retry sequence; exact-equality base message when absent).
- `packages/agent/test/agent-loop-tool-not-found-red-team.test.ts` — seven adversarial cases: discovery on/off, empty tools, undefined tools, `customWireName`-only discovery (hint fires), `customWireName`-only dispatch (executes, no false not-found), and no `undefined` leak / base-substring stability.

## Verification

- `bun test` (three agent-loop test files): **11 pass / 0 fail**
- `tsc -p tsconfig.json --noEmit`: clean
- `biome check`: clean