### PR TITLE
chore(prompt): sync git base before changes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+
+- The default coding-agent prompt now requires safe remote synchronization before non-trivial Git mutations: inspect branch/upstream state, fast-forward the intended base with `git pull --ff-only`, re-sync high-churn repositories before integration, and never overwrite dirty or unowned work to force an update.
 
 ## [0.9.6] - 2026-07-10
 ### Changed

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -258,6 +258,8 @@ For image understanding, call `{{toolRefs.read}}` on the image path; the image i
 
 <before-editing>
 - Reuse existing patterns; parallel conventions are prohibited.
+- Before non-trivial mutation in a Git repository, inspect repo-local instructions, status, current branch, and upstream; then, while the intended base is checked out cleanly, fetch the remote and fast-forward it with `git pull --ff-only` (or the repository-approved equivalent) before creating a task branch/worktree or editing.
+- In high-churn repositories, fetch again immediately before commit or integration and reconcile the task branch with the refreshed base through the repository-approved non-destructive workflow. Never rebase, reset, stash, switch branches, or overwrite dirty/unowned work to force synchronization; stop and report the blocker.
 {{#has tools "lsp"}}- Run `{{toolRefs.lsp}} references` before modifying exported symbols.{{/has}}
 - Re-read before acting if a tool fails or a file may have changed.
 </before-editing>

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -232,6 +232,21 @@ describe("system Handlebars prompt templates", () => {
 		const reduction = 1 - subBytes / fullBytes;
 		expect(reduction).toBeGreaterThanOrEqual(0.25);
 	});
+	test("system-prompt requires safe base synchronization before editing", async () => {
+		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+
+		for (const subagent of [false, true]) {
+			const rendered = prompt.render(template, { ...baseRenderContext, subagent });
+			expect(rendered).toContain("Before non-trivial mutation");
+			expect(rendered).toContain("fetch again immediately before commit or integration");
+			expect(rendered).toContain("git pull --ff-only");
+			expect(rendered).toContain("while the intended base is checked out cleanly");
+			expect(rendered).toContain("repository-approved non-destructive workflow");
+			expect(rendered).toContain("before creating a task branch/worktree or editing");
+			expect(rendered).toContain("Never rebase, reset, stash, switch branches, or overwrite dirty/unowned work");
+		}
+	});
 	test("system-prompt renders MCP discovery hint when enabled", async () => {
 		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
 		const template = await Bun.file(templatePath).text();


### PR DESCRIPTION
## Summary
- require a clean intended base to be fetched and fast-forwarded before non-trivial Git mutations
- require high-churn repositories to re-fetch before commit/integration without touching dirty or unowned work
- regression-test the contract for top-level and subagent prompts

## Verification
- bun test packages/coding-agent/test/system-prompt-templates.test.ts (18 passed)
- bun check
- independent architect review: CLEAR