### PR TITLE
feat(coordinator-mcp): owner-proof idle session reaper + stop_session (supersedes #2044)

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/policy.ts
+++ b/packages/coding-agent/src/coordinator-mcp/policy.ts
@@ -1,6 +1,12 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { coordinatorMcpStateRoot, gjcRoot } from "../gjc-runtime/session-layout";
+import {
+	DEFAULT_SESSION_IDLE_TTL_MS,
+	DEFAULT_SESSION_SWEEP_INTERVAL_MS,
+	MIN_SESSION_IDLE_TTL_MS,
+	MIN_SESSION_SWEEP_INTERVAL_MS,
+} from "./session-reaper";
 
 export type CoordinatorMutationClass = "sessions" | "questions" | "reports";
 
@@ -16,6 +22,9 @@ export interface CoordinatorMcpConfig {
 	namespace: CoordinatorNamespace;
 	stateRoot: string;
 	sessionCommand: string | null;
+	sessionIdleTtlMs: number;
+	sessionSweepIntervalMs: number;
+	forceStopEnabled: boolean;
 }
 
 export interface CoordinatorMutationRequest {
@@ -31,6 +40,16 @@ const LEGACY_MUTATION_CLASS_ALIASES = new Map<string, CoordinatorMutationClass>(
 	["question", "questions"],
 	["report", "reports"],
 ]);
+
+function parsePositiveIntMs(value: string | undefined, fallback: number, floor: number): number {
+	const parsed = Number.parseInt((value ?? "").trim(), 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+	return Math.max(floor, parsed);
+}
+
+function parseBool(value: string | undefined): boolean {
+	return /^(1|true|yes|on)$/i.test((value ?? "").trim());
+}
 
 function parseList(value: string | undefined): string[] {
 	return (value ?? "")
@@ -98,6 +117,17 @@ export function buildCoordinatorMcpConfig(env: NodeJS.ProcessEnv = process.env):
 		},
 		stateRoot: path.resolve(stateRoot),
 		sessionCommand: env.GJC_COORDINATOR_MCP_SESSION_COMMAND?.trim() || null,
+		sessionIdleTtlMs: parsePositiveIntMs(
+			env.GJC_COORDINATOR_MCP_SESSION_IDLE_TTL_MS,
+			DEFAULT_SESSION_IDLE_TTL_MS,
+			MIN_SESSION_IDLE_TTL_MS,
+		),
+		sessionSweepIntervalMs: parsePositiveIntMs(
+			env.GJC_COORDINATOR_MCP_SESSION_SWEEP_INTERVAL_MS,
+			DEFAULT_SESSION_SWEEP_INTERVAL_MS,
+			MIN_SESSION_SWEEP_INTERVAL_MS,
+		),
+		forceStopEnabled: parseBool(env.GJC_COORDINATOR_MCP_FORCE_STOP),
 	};
 }
 

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -26,7 +26,7 @@ import {
 	replaceOwnerGenerationSync,
 	type TmuxServerProof,
 } from "../gjc-runtime/tmux-owner-isolation";
-
+import { forceCloseGjcTmuxSession } from "../gjc-runtime/tmux-sessions";
 import {
 	assertCoordinatorArtifactPath,
 	assertCoordinatorWorkdir,
@@ -35,6 +35,7 @@ import {
 	coordinatorNamespacePath,
 	requireCoordinatorMutation,
 } from "./policy";
+import { createSessionReaper, type ReapableSession, type SessionReaper } from "./session-reaper";
 
 export type { CoordinatorToolName };
 export { COORDINATOR_MCP_PROTOCOL_VERSION, COORDINATOR_MCP_SERVER_NAME, COORDINATOR_MCP_TOOL_NAMES };
@@ -105,6 +106,12 @@ interface CoordinatorServices {
 	listSessions?: () => unknown[] | Promise<unknown[]>;
 	startSession?: (input: SessionStartInput) => unknown | Promise<unknown>;
 	commandRunner?: CommandRunner;
+	forceCloseSession?: (
+		sessionName: string,
+		env: NodeJS.ProcessEnv,
+		expectedSessionId?: string,
+		expectedStateFile?: string,
+	) => Promise<unknown>;
 	ownerIsolationProbe?: OwnerIsolationProbe;
 }
 
@@ -215,6 +222,7 @@ interface CoordinatorSessionState {
 type CoordinatorEventKind =
 	| "session.registered"
 	| "session.started"
+	| "session.reaped"
 	| "session.state_changed"
 	| "turn.queued"
 	| "turn.delivering"
@@ -342,6 +350,26 @@ function toolSchema(name: CoordinatorToolName): {
 					allow_mutation: allowMutation,
 				},
 				required: ["cwd", "allow_mutation"],
+			},
+		};
+	}
+	if (name === "gjc_coordinator_stop_session") {
+		return {
+			name,
+			description:
+				"Reap a coordinator delegate-created (ephemeral) session: terminate its owner via the owner-proof forceCloseGjcTmuxSession, then purge its state files only on verified termination. Never touches non-ephemeral (user-registered) sessions unless force is set AND the force-stop capability is enabled.",
+			inputSchema: {
+				type: "object",
+				properties: {
+					session_id: sessionId,
+					force: {
+						type: "boolean",
+						description: "Reap a non-ephemeral session; requires the GJC_COORDINATOR_MCP_FORCE_STOP capability.",
+					},
+					reason: { type: "string", description: "Optional audit reason recorded on the session.reaped event." },
+					allow_mutation: allowMutation,
+				},
+				required: ["session_id", "allow_mutation"],
 			},
 		};
 	}
@@ -744,6 +772,7 @@ const COORDINATOR_SESSION_STATES = new Set<CoordinatorSessionStateValue>([
 const COORDINATOR_EVENT_KINDS = new Set<CoordinatorEventKind>([
 	"session.registered",
 	"session.started",
+	"session.reaped",
 	"session.state_changed",
 	"turn.queued",
 	"turn.delivering",
@@ -2993,6 +3022,98 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 	function sessionFile(sessionId: unknown): string {
 		return path.join(namespaceDir, "sessions", `${safeExternalId("session", sessionId)}.json`);
 	}
+	const forceCloseSession =
+		services.forceCloseSession ??
+		((name: string, targetEnv: NodeJS.ProcessEnv, expectedSessionId?: string, expectedStateFile?: string) =>
+			forceCloseGjcTmuxSession(name, targetEnv, expectedSessionId, expectedStateFile));
+
+	// Reap a coordinator delegate-created (ephemeral) session. Addresses the #2034 review:
+	//  - terminates via the owner-proof forceCloseGjcTmuxSession (pid + native session_id +
+	//    generation + server_key + start_time verified atomically) — never a raw process.kill,
+	//    so a recycled PID can never signal a foreign process.
+	//  - re-validates ephemeral + no-active-turn AT kill time under a per-session lock, closing
+	//    the select→kill TOCTOU and races with concurrent send_prompt / delegate / stop.
+	//  - purges state files ONLY on verified termination; on failure the record is kept for retry
+	//    and no session.reaped event is emitted (honest audit, no worse leak).
+	async function reapSession(
+		rawId: unknown,
+		opts: { force?: boolean; reason?: string } = {},
+	): Promise<{ ok: boolean; reason?: string; killed: boolean; active_turn_id?: string; detail?: string }> {
+		const id = safeExternalId("session", rawId);
+		return await withSessionMutation(`${namespaceDir}::${id}`, async () => {
+			const record = asRecord(await readJsonFile(sessionFile(id)));
+			if (!record) return { ok: false, reason: "unknown_session", killed: false };
+			if (record.ephemeral !== true && opts.force !== true) {
+				return { ok: false, reason: "not_ephemeral", killed: false };
+			}
+			const activeTurn = await readActiveTurn(namespaceDir, id);
+			if (activeTurn) {
+				return { ok: false, reason: "active_turn", killed: false, active_turn_id: activeTurn.turn_id };
+			}
+			const tmuxSession = optionalString(record.tmux_session) ?? optionalString(record.tmuxSession);
+			let killed = false;
+			if (tmuxSession) {
+				const expectedStateFile = optionalString(record.sessionStateFile) ?? undefined;
+				try {
+					await forceCloseSession(tmuxSession, env, undefined, expectedStateFile);
+					killed = true;
+				} catch (err) {
+					return {
+						ok: false,
+						reason: "terminate_failed",
+						detail: err instanceof Error ? err.message : String(err),
+						killed: false,
+					};
+				}
+			}
+			// Purge the session record FIRST so a partial rm failure can never re-list → re-reap →
+			// emit a duplicate session.reaped. `killed` is honest: false when nothing was signalled.
+			await fs.rm(sessionFile(id), { force: true });
+			await appendCoordinatorEvent(namespaceDir, {
+				kind: "session.reaped",
+				sessionId: id,
+				summary: `Session ${id} reaped${opts.reason ? ` (${opts.reason})` : ""}`,
+				metadata: { reason: opts.reason ?? null, force: opts.force === true, killed },
+			});
+			await fs.rm(sessionStateFile(namespaceDir, id), { force: true });
+			await fs.rm(activeTurnFile(namespaceDir, id), { force: true });
+			return { ok: true, killed };
+		});
+	}
+
+	const sessionReaper: SessionReaper = createSessionReaper(
+		{
+			listSessions: async (): Promise<ReapableSession[]> => {
+				const out: ReapableSession[] = [];
+				for (const raw of await listSessions()) {
+					try {
+						const rec = asRecord(raw);
+						if (rec?.ephemeral !== true) continue;
+						const sid = optionalString(rec.session_id);
+						if (!sid) continue;
+						const activeTurn = await readActiveTurn(namespaceDir, sid);
+						const state = await readSessionState(namespaceDir, sid);
+						const stamp = optionalString(state?.updated_at) ?? optionalString(rec.created_at);
+						const lastActivityMs = stamp ? Date.parse(stamp) : 0;
+						out.push({
+							sessionId: sid,
+							ephemeral: true,
+							hasActiveTurn: activeTurn !== null,
+							lastActivityMs: Number.isFinite(lastActivityMs) ? lastActivityMs : 0,
+						});
+					} catch {
+						// A single corrupt session/state file must not abort the whole sweep — skip it.
+					}
+				}
+				return out;
+			},
+			reapSession: async (sid: string): Promise<void> => {
+				await reapSession(sid, { reason: "idle_reaper" });
+			},
+			now: () => Date.now(),
+		},
+		{ idleTtlMs: config.sessionIdleTtlMs, sweepIntervalMs: config.sessionSweepIntervalMs },
+	);
 	async function compensateFailedOwnerStart(
 		session: Record<string, unknown>,
 		ownerTransaction: {
@@ -3506,6 +3627,9 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 						rollback?: () => Promise<"cleaned" | "failed" | "unverifiable">;
 					} | null;
 					session = normalizeSession(startedRecord);
+					// Delegate-created sessions are ephemeral: the idle reaper may reclaim them once
+					// idle past the TTL with no active turn. User-registered sessions are never flagged.
+					session.ephemeral = true;
 					try {
 						await writeJsonFile(sessionFile(session.session_id), session);
 						await appendCoordinatorEvent(namespaceDir, {
@@ -3532,31 +3656,43 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 				}
 
 				const sessionId = String(session.session_id);
-				const activeTurn = reusedSession ? await readActiveTurn(namespaceDir, sessionId) : null;
-				if (activeTurn && args.force !== true && args.queue !== true) {
-					return {
-						ok: false,
-						reason: "active_turn_exists",
-						session_id: sessionId,
-						active_turn_id: activeTurn.turn_id,
-					};
-				}
-				if (activeTurn && args.force === true) {
-					const timestamp = new Date().toISOString();
-					const superseded = {
-						...activeTurn,
-						status: "superseded" as const,
-						updated_at: timestamp,
-						completed_at: timestamp,
-					};
-					await writeTurnRecord(namespaceDir, superseded);
-					await clearActiveTurn(namespaceDir, superseded);
-				}
-				const shouldQueue = args.queue === true && args.force !== true && !!activeTurn;
-				const turn = shouldQueue
-					? makeTurnRecord(config, sessionId, taggedPrompt, "queued")
-					: await activateTurn(session, makeTurnRecord(config, sessionId, taggedPrompt, "active"));
-				if (shouldQueue) await writeTurnRecord(namespaceDir, turn);
+				// Serialize the reused-session read-active-turn → activate critical section on the
+				// same per-session lock the reaper/stop_session/send_prompt use, so the idle reaper
+				// can never reap a session between this read and activateTurn (lost work + orphaned
+				// turn/state files). The long await_completion poll below stays OUTSIDE the lock.
+				const turnMutation = await withSessionMutation(`${namespaceDir}::${sessionId}`, async () => {
+					const activeTurn = reusedSession ? await readActiveTurn(namespaceDir, sessionId) : null;
+					if (activeTurn && args.force !== true && args.queue !== true) {
+						return {
+							kind: "conflict" as const,
+							response: {
+								ok: false as const,
+								reason: "active_turn_exists" as const,
+								session_id: sessionId,
+								active_turn_id: activeTurn.turn_id,
+							},
+						};
+					}
+					if (activeTurn && args.force === true) {
+						const timestamp = new Date().toISOString();
+						const superseded = {
+							...activeTurn,
+							status: "superseded" as const,
+							updated_at: timestamp,
+							completed_at: timestamp,
+						};
+						await writeTurnRecord(namespaceDir, superseded);
+						await clearActiveTurn(namespaceDir, superseded);
+					}
+					const shouldQueue = args.queue === true && args.force !== true && !!activeTurn;
+					const turn = shouldQueue
+						? makeTurnRecord(config, sessionId, taggedPrompt, "queued")
+						: await activateTurn(session, makeTurnRecord(config, sessionId, taggedPrompt, "active"));
+					if (shouldQueue) await writeTurnRecord(namespaceDir, turn);
+					return { kind: "ok" as const, activeTurn, shouldQueue, turn };
+				});
+				if (turnMutation.kind === "conflict") return turnMutation.response;
+				const { activeTurn, shouldQueue, turn } = turnMutation;
 				await appendCoordinatorEvent(namespaceDir, {
 					kind: "delegation.started",
 					sessionId,
@@ -3626,6 +3762,28 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 					}
 				}
 				return base;
+			}
+			if (name === "gjc_coordinator_stop_session") {
+				requireCoordinatorMutation(config, "sessions", args);
+				const sessionId = safeExternalId("session", args.session_id);
+				const forceRequested = args.force === true;
+				// force is a capability distinct from allow_mutation: reaping a non-ephemeral
+				// (user-registered) session requires GJC_COORDINATOR_MCP_FORCE_STOP to be enabled.
+				if (forceRequested && !config.forceStopEnabled) {
+					return { ok: false, reason: "force_not_authorized", session_id: sessionId, killed: false };
+				}
+				const result = await reapSession(sessionId, {
+					force: forceRequested,
+					reason: optionalString(args.reason) ?? "stop_session",
+				});
+				return {
+					ok: result.ok,
+					session_id: sessionId,
+					killed: result.killed,
+					...(result.reason ? { reason: result.reason } : {}),
+					...(result.active_turn_id ? { active_turn_id: result.active_turn_id } : {}),
+					...(result.detail ? { detail: result.detail } : {}),
+				};
 			}
 			if (name === "gjc_coordinator_start_session") {
 				requireCoordinatorMutation(config, "sessions", args);
@@ -4065,7 +4223,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		};
 	}
 
-	return { config, callTool, handleJsonRpc, handle: handleJsonRpc };
+	return { config, callTool, handleJsonRpc, handle: handleJsonRpc, reapSession, sessionReaper };
 }
 
 function legacyToolResult(payload: unknown): {
@@ -4279,12 +4437,17 @@ export async function pumpCoordinatorMcpStream(
 
 export async function runCoordinatorMcpStdio(options: CoordinatorMcpServerOptions = {}): Promise<void> {
 	const server = createCoordinatorMcpServer(options);
-	await pumpCoordinatorMcpStream(
-		request => server.handleJsonRpc(request),
-		process.stdin,
-		line =>
-			new Promise<void>((resolve, reject) => {
-				process.stdout.write(line, err => (err ? reject(err) : resolve()));
-			}),
-	);
+	server.sessionReaper.start(); // background idle-reap of ephemeral delegate sessions
+	try {
+		await pumpCoordinatorMcpStream(
+			request => server.handleJsonRpc(request),
+			process.stdin,
+			line =>
+				new Promise<void>((resolve, reject) => {
+					process.stdout.write(line, err => (err ? reject(err) : resolve()));
+				}),
+		);
+	} finally {
+		server.sessionReaper.stop();
+	}
 }

--- a/packages/coding-agent/src/coordinator-mcp/session-reaper.ts
+++ b/packages/coding-agent/src/coordinator-mcp/session-reaper.ts
@@ -1,0 +1,129 @@
+import { logger } from "@gajae-code/utils";
+
+/**
+ * Idle reaper for coordinator-managed GJC worker sessions.
+ *
+ * Every `gjc_delegate_*` call that omits `session_id` starts a fresh tmux worker
+ * session. Nothing in the coordinator ever tore those down, so completed/crashed
+ * sessions accumulated (RAM + worktrees) until something killed them by hand.
+ *
+ * This is the automatic backstop (defense-in-depth): a periodic sweep force-closes
+ * sessions that are (a) ephemeral — coordinator delegate-created, never a user's
+ * registered resident session, (b) not mid-turn, and (c) idle past a TTL.
+ *
+ * The controller is pure + fully injectable (clock / list / reap side-effects) so
+ * it is unit-testable without tmux, the filesystem, or wall-clock waits. The
+ * scheduling mirrors the proven resource-gc controller: a recursive setTimeout
+ * with a generation guard so a stop()+start() can never leak a duplicate timer.
+ */
+
+export const DEFAULT_SESSION_IDLE_TTL_MS = 30 * 60_000; // 30 min idle → reap
+export const DEFAULT_SESSION_SWEEP_INTERVAL_MS = 5 * 60_000; // sweep every 5 min
+export const MIN_SESSION_IDLE_TTL_MS = 60_000; // never reap a <1min-idle session
+export const MIN_SESSION_SWEEP_INTERVAL_MS = 30_000;
+
+/** Minimal projection of a coordinator session the reaper needs to decide. */
+export interface ReapableSession {
+	sessionId: string;
+	/** True only for coordinator delegate-created sessions. User-registered resident sessions are false and never reaped. */
+	ephemeral: boolean;
+	/** Epoch ms of last observed activity (turn update / session-state write / session creation). */
+	lastActivityMs: number;
+	/** True while a turn is active — never reap mid-turn. */
+	hasActiveTurn: boolean;
+}
+
+export interface SessionReaperPolicy {
+	idleTtlMs: number;
+	sweepIntervalMs: number;
+}
+
+/**
+ * Pure selection: which sessions are safe to reap at `now`.
+ * A session is reapable iff ephemeral AND not mid-turn AND idle ≥ (clamped) TTL.
+ */
+export function selectReapableSessions(
+	sessions: readonly ReapableSession[],
+	now: number,
+	idleTtlMs: number,
+): ReapableSession[] {
+	const ttl = Math.max(MIN_SESSION_IDLE_TTL_MS, idleTtlMs);
+	return sessions.filter(s => s.ephemeral && !s.hasActiveTurn && now - s.lastActivityMs >= ttl);
+}
+
+/** Injectable side-effects so the controller runs in tests without tmux/fs/real time. */
+export interface SessionReaperDeps {
+	listSessions: () => Promise<ReapableSession[]>;
+	reapSession: (sessionId: string) => Promise<void>;
+	now: () => number;
+}
+
+export interface SessionReaper {
+	/** Run one sweep; returns the number of sessions successfully reaped. */
+	sweepOnce: () => Promise<number>;
+	start: () => void;
+	stop: () => void;
+	readonly running: boolean;
+}
+
+export function createSessionReaper(deps: SessionReaperDeps, policy: SessionReaperPolicy): SessionReaper {
+	const idleTtlMs = Math.max(MIN_SESSION_IDLE_TTL_MS, policy.idleTtlMs);
+	const sweepIntervalMs = Math.max(MIN_SESSION_SWEEP_INTERVAL_MS, policy.sweepIntervalMs);
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let generation = 0;
+	let inProgress = false;
+
+	async function sweepOnce(): Promise<number> {
+		if (inProgress) return 0; // never overlap sweeps
+		inProgress = true;
+		try {
+			const sessions = await deps.listSessions();
+			const targets = selectReapableSessions(sessions, deps.now(), idleTtlMs);
+			let reaped = 0;
+			for (const session of targets) {
+				try {
+					await deps.reapSession(session.sessionId);
+					reaped += 1;
+				} catch (err) {
+					// One wedged session must not abort the rest of the sweep.
+					logger.warn(
+						`session-reaper: failed to reap ${session.sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+					);
+				}
+			}
+			return reaped;
+		} finally {
+			inProgress = false;
+		}
+	}
+
+	function schedule(gen: number): void {
+		timer = setTimeout(() => {
+			if (gen !== generation) return; // stale timer from a prior start()
+			void sweepOnce().finally(() => {
+				if (gen === generation) schedule(gen);
+			});
+		}, sweepIntervalMs);
+		// The reaper must never keep the coordinator process alive by itself.
+		(timer as { unref?: () => void }).unref?.();
+	}
+
+	return {
+		sweepOnce,
+		start(): void {
+			if (timer) return; // already running
+			generation += 1;
+			schedule(generation);
+		},
+		stop(): void {
+			generation += 1; // invalidate any in-flight scheduled tick
+			if (timer) {
+				clearTimeout(timer);
+				timer = null;
+			}
+		},
+		get running(): boolean {
+			return timer !== null;
+		},
+	};
+}

--- a/packages/coding-agent/src/coordinator/contract.ts
+++ b/packages/coding-agent/src/coordinator/contract.ts
@@ -12,6 +12,7 @@ export const COORDINATOR_MCP_TOOL_NAMES = [
 	"gjc_coordinator_watch_events",
 	"gjc_coordinator_register_session",
 	"gjc_coordinator_start_session",
+	"gjc_coordinator_stop_session",
 	"gjc_coordinator_send_prompt",
 	"gjc_coordinator_submit_question_answer",
 	"gjc_coordinator_read_turn",

--- a/packages/coding-agent/test/coordinator-mcp/reaper-owner.integration.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp/reaper-owner.integration.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as crypto from "node:crypto";
+import * as fsSync from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	buildGjcTmuxExactOptionTarget,
+	buildGjcTmuxProfileCommands,
+} from "@gajae-code/coding-agent/gjc-runtime/tmux-common";
+import {
+	observeOwnerTerminal,
+	replaceOwnerGeneration,
+} from "@gajae-code/coding-agent/gjc-runtime/tmux-owner-isolation";
+import { forceCloseGjcTmuxSession } from "@gajae-code/coding-agent/gjc-runtime/tmux-sessions";
+import { createCoordinatorMcpServer } from "../../src/coordinator-mcp/server";
+
+// BLOCKER 1 (#2044): prove the reaper terminates a *genuine* GJC-managed owned session by driving
+// the reaper's real path through the coordinator's stop_session tool. The reaper's injectable
+// services.forceCloseSession forwards to the *real* forceCloseGjcTmuxSession with the same
+// owner-lifecycle deps the accepted tmux-sessions.integration.test.ts harness uses (a real TERM to
+// the real pane + the sidecar verdict observation) — this is the real destructive path, not a
+// trivial always-success double. An unrelated GJC session (no coordinator record) must survive.
+//
+// Owner isolation requires Linux + a systemd user scope, so — like the harness — this only runs
+// there and is skipped on hosts without tmux/systemd (e.g. the macOS dev host).
+const tmux = Bun.which("tmux");
+const systemdRun = Bun.which("systemd-run");
+const isLinux = process.platform === "linux";
+const userScopeAvailable =
+	isLinux &&
+	Boolean(systemdRun) &&
+	Bun.spawnSync([systemdRun!, "--user", "--scope", "--quiet", "true"], { stdout: "pipe", stderr: "pipe" }).exitCode ===
+		0;
+
+const cleanups: Array<{ env: NodeJS.ProcessEnv; stateDir: string; scopeName: string }> = [];
+
+function run(args: string[], env: NodeJS.ProcessEnv): void {
+	const result = Bun.spawnSync([env.GJC_TMUX_COMMAND!, ...args], { stdout: "pipe", stderr: "pipe", env });
+	if (result.exitCode !== 0) throw new Error(result.stderr.toString());
+}
+
+function procStartTime(pid: number): string {
+	const stat = fsSync.readFileSync(`/proc/${pid}/stat`, "utf8");
+	return stat
+		.slice(stat.lastIndexOf(")") + 2)
+		.trim()
+		.split(/\s+/)[19]!;
+}
+
+async function waitForProcessExit(pid: number): Promise<void> {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		try {
+			process.kill(pid, 0);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+			throw error;
+		}
+		await new Promise(resolve => setTimeout(resolve, 20));
+	}
+	throw new Error(`owner process did not terminate: ${pid}`);
+}
+
+describe.skipIf(!isLinux || !tmux || !userScopeAvailable)("reaper owner-proof termination integration", () => {
+	afterEach(async () => {
+		for (const c of cleanups.splice(0)) {
+			Bun.spawnSync([c.env.GJC_TMUX_COMMAND!, "kill-server"], { stdout: "pipe", stderr: "pipe", env: c.env });
+			Bun.spawnSync(["systemctl", "--user", "stop", c.scopeName], { stdout: "pipe", stderr: "pipe" });
+			await fs.rm(c.stateDir, { recursive: true, force: true });
+		}
+	});
+
+	it("stop_session drives the real forceClose to terminate a genuine owned session and purge it; an unrelated GJC session survives", async () => {
+		const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-reaper-owner-"));
+		const tmuxTmpDir = path.join(stateDir, "tmux");
+		const socketName = `gjc-reap-${crypto.randomUUID().slice(0, 8)}`;
+		const scopeName = `gjc-reaper-test-${crypto.randomUUID().slice(0, 8)}.scope`;
+		const tmuxWrapper = path.join(stateDir, "isolated-tmux");
+		const sessionName = `gjc_reap_${crypto.randomUUID().slice(0, 8)}`;
+		const siblingSessionName = `gjc_sibling_${crypto.randomUUID().slice(0, 8)}`;
+		const sessionId = crypto.randomUUID();
+		const generation = crypto.randomUUID();
+		const stateFile = path.join(stateDir, "marker");
+		await fs.mkdir(tmuxTmpDir);
+		await fs.writeFile(tmuxWrapper, `#!/usr/bin/env sh\nexec ${tmux} -L "$GJC_TEST_TMUX_SOCKET" "$@"\n`, {
+			mode: 0o700,
+		});
+		const env: NodeJS.ProcessEnv = {
+			...process.env,
+			GJC_TMUX_COMMAND: tmuxWrapper,
+			GJC_TEST_TMUX_SOCKET: socketName,
+			TMUX_TMPDIR: tmuxTmpDir,
+		};
+		cleanups.push({ env, stateDir, scopeName });
+
+		const created = Bun.spawnSync(
+			[
+				systemdRun!,
+				"--user",
+				"--scope",
+				"--quiet",
+				"--unit",
+				scopeName,
+				env.GJC_TMUX_COMMAND!,
+				"new-session",
+				"-d",
+				"-s",
+				sessionName,
+				"sh",
+				"-c",
+				"trap 'exit 0' TERM; while :; do sleep 1; done",
+			],
+			{ stdout: "pipe", stderr: "pipe", env },
+		);
+		if (created.exitCode !== 0) throw new Error(created.stderr.toString());
+
+		const target = buildGjcTmuxExactOptionTarget(sessionName, { env });
+		await replaceOwnerGeneration(stateDir, sessionId, generation);
+		for (const command of buildGjcTmuxProfileCommands(
+			target,
+			env,
+			{ sessionId, sessionStateFile: stateFile, ownerGeneration: generation, ownerServerKey: sessionName },
+			{ tmuxCommand: env.GJC_TMUX_COMMAND },
+		))
+			run(command.args, env);
+		// Keep the pane after its process dies so we prove forceClose does the explicit exact
+		// cleanup (not just the process dying on its own).
+		run(["set-option", "-t", target, "remain-on-exit", "on"], env);
+		// An unrelated GJC session with no coordinator record — must be left untouched.
+		run(
+			["new-session", "-d", "-s", siblingSessionName, "sh", "-c", "trap 'exit 0' TERM; while :; do sleep 1; done"],
+			env,
+		);
+
+		const hasSession = (name: string) =>
+			Bun.spawnSync([env.GJC_TMUX_COMMAND!, "has-session", "-t", `=${name}`], {
+				stdout: "pipe",
+				stderr: "pipe",
+				env,
+			}).exitCode === 0;
+		expect(hasSession(sessionName)).toBe(true);
+		expect(hasSession(siblingSessionName)).toBe(true);
+
+		const panePid = Number(
+			Bun.spawnSync([env.GJC_TMUX_COMMAND!, "display-message", "-p", "-t", target, "#{pane_pid}"], {
+				stdout: "pipe",
+				stderr: "pipe",
+				env,
+			})
+				.stdout.toString()
+				.trim(),
+		);
+
+		// The reaper forwards through services.forceCloseSession to the REAL forceCloseGjcTmuxSession
+		// with the same owner-lifecycle deps the accepted harness uses. termSent proves a real TERM
+		// was dispatched to the real pane; the sidecar sleep publishes the terminal verdict so the
+		// verified close path can finish its exact cleanup.
+		let termSent = false;
+		const server = createCoordinatorMcpServer({
+			env: {
+				...env,
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: stateDir,
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions,questions,reports",
+				GJC_COORDINATOR_MCP_STATE_ROOT: path.join(stateDir, ".coord"),
+				GJC_COORDINATOR_MCP_PROFILE: "reaper-owner",
+				GJC_COORDINATOR_MCP_REPO: "repo-owner",
+			},
+			services: {
+				forceCloseSession: async (name, closeEnv, _sid, expectedStateFile) => {
+					// The reaper must forward the recorded state-file identity.
+					expect(expectedStateFile).toBe(stateFile);
+					return await forceCloseGjcTmuxSession(name, closeEnv, sessionId, expectedStateFile, {
+						resolveOwner: async () => ({
+							sessionId,
+							stateDir,
+							socketKey: sessionName,
+							generation,
+							pid: panePid,
+							startTime: procStartTime(panePid),
+						}),
+						readProcessStartTime: async pid => procStartTime(pid),
+						signalTerm: pid => {
+							termSent = true;
+							process.kill(pid, "SIGTERM");
+						},
+						sleep: async () => {
+							await waitForProcessExit(panePid);
+							const intent = JSON.parse(
+								await fs.readFile(
+									path.join(stateDir, sessionId, "owner-lifecycle", `intent-${generation}.json`),
+									"utf8",
+								),
+							);
+							const verdict = await observeOwnerTerminal({
+								schema_version: 1,
+								op: "observe_terminal",
+								session_id: sessionId,
+								owner_generation: generation,
+								state_dir: stateDir,
+								socket_key: sessionName,
+								observer: "sidecar",
+								observed_at: new Date().toISOString(),
+								signal: "SIGTERM",
+								exit_code: null,
+								exit_kind: "exit",
+								reason: "integration",
+								operator_dispatch_id: intent.dispatch_id,
+							});
+							await fs.writeFile(
+								path.join(stateDir, "verdict.json"),
+								JSON.stringify({ ...verdict, owner_generation: generation }),
+							);
+						},
+					});
+				},
+			},
+		});
+
+		const ns = path.join(stateDir, ".coord", "reaper-owner", "repo-owner");
+		await fs.mkdir(path.join(ns, "sessions"), { recursive: true });
+		await fs.writeFile(
+			path.join(ns, "sessions", "owned-eph.json"),
+			JSON.stringify({
+				session_id: "owned-eph",
+				ephemeral: true,
+				tmux_session: sessionName,
+				sessionStateFile: stateFile,
+				created_at: new Date().toISOString(),
+			}),
+		);
+
+		const reaped = await server.callTool("gjc_coordinator_stop_session", {
+			session_id: "owned-eph",
+			allow_mutation: true,
+		});
+		expect(reaped).toMatchObject({ ok: true, killed: true });
+
+		expect(termSent).toBe(true); // a real TERM was dispatched to the real owned pane
+		expect(hasSession(sessionName)).toBe(false); // genuine owned session terminated via the real path
+		expect(hasSession(siblingSessionName)).toBe(true); // unrelated GJC session survives
+		const status = await server.callTool("gjc_coordinator_read_status", { session_id: "owned-eph" });
+		expect(status.session ?? null).toBeNull(); // record purged
+	}, 30_000);
+});

--- a/packages/coding-agent/test/coordinator-mcp/session-reaper.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp/session-reaper.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "bun:test";
+import {
+	createSessionReaper,
+	type ReapableSession,
+	selectReapableSessions,
+} from "../../src/coordinator-mcp/session-reaper";
+
+const TTL = 30 * 60_000;
+const NOW = 10_000_000;
+
+function sess(id: string, over: Partial<ReapableSession> = {}): ReapableSession {
+	return { sessionId: id, ephemeral: true, hasActiveTurn: false, lastActivityMs: NOW - TTL - 1, ...over };
+}
+
+describe("selectReapableSessions", () => {
+	it("reaps ephemeral, idle-past-TTL, no-active-turn sessions", () => {
+		expect(selectReapableSessions([sess("a")], NOW, TTL).map(s => s.sessionId)).toEqual(["a"]);
+	});
+	it("never reaps a non-ephemeral (user-registered resident) session", () => {
+		expect(selectReapableSessions([sess("u", { ephemeral: false })], NOW, TTL)).toEqual([]);
+	});
+	it("never reaps a session with an active turn", () => {
+		expect(selectReapableSessions([sess("t", { hasActiveTurn: true })], NOW, TTL)).toEqual([]);
+	});
+	it("keeps sessions still within the TTL", () => {
+		expect(selectReapableSessions([sess("f", { lastActivityMs: NOW - 1000 })], NOW, TTL)).toEqual([]);
+	});
+	it("clamps a too-small TTL to the floor so a just-active session is never reaped", () => {
+		expect(selectReapableSessions([sess("j", { lastActivityMs: NOW - 1000 })], NOW, 0)).toEqual([]);
+	});
+	it("reaps exactly at the TTL boundary", () => {
+		expect(
+			selectReapableSessions([sess("b", { lastActivityMs: NOW - TTL })], NOW, TTL).map(s => s.sessionId),
+		).toEqual(["b"]);
+	});
+});
+
+describe("createSessionReaper.sweepOnce", () => {
+	it("reaps every eligible session and returns the count, skipping ineligible", async () => {
+		const reaped: string[] = [];
+		const reaper = createSessionReaper(
+			{
+				listSessions: async () => [sess("a"), sess("u", { ephemeral: false }), sess("b")],
+				reapSession: async id => {
+					reaped.push(id);
+				},
+				now: () => NOW,
+			},
+			{ idleTtlMs: TTL, sweepIntervalMs: 60_000 },
+		);
+		expect(await reaper.sweepOnce()).toBe(2);
+		expect(reaped.sort()).toEqual(["a", "b"]);
+	});
+
+	it("continues the sweep when one reap throws (one wedged session cannot abort the rest)", async () => {
+		const reaped: string[] = [];
+		const reaper = createSessionReaper(
+			{
+				listSessions: async () => [sess("bad"), sess("good")],
+				reapSession: async id => {
+					if (id === "bad") throw new Error("wedged");
+					reaped.push(id);
+				},
+				now: () => NOW,
+			},
+			{ idleTtlMs: TTL, sweepIntervalMs: 60_000 },
+		);
+		expect(await reaper.sweepOnce()).toBe(1);
+		expect(reaped).toEqual(["good"]);
+	});
+
+	it("never overlaps concurrent sweeps", async () => {
+		let active = 0;
+		let maxActive = 0;
+		const reaper = createSessionReaper(
+			{
+				listSessions: async () => {
+					active += 1;
+					maxActive = Math.max(maxActive, active);
+					await new Promise(r => setTimeout(r, 10));
+					active -= 1;
+					return [];
+				},
+				reapSession: async () => {},
+				now: () => NOW,
+			},
+			{ idleTtlMs: TTL, sweepIntervalMs: 60_000 },
+		);
+		const first = reaper.sweepOnce();
+		const second = reaper.sweepOnce(); // fires while first is mid-list
+		expect(await second).toBe(0); // guarded out
+		await first;
+		expect(maxActive).toBe(1);
+	});
+});
+
+describe("createSessionReaper scheduler", () => {
+	it("start()/stop() flips running and is idempotent", () => {
+		const reaper = createSessionReaper(
+			{ listSessions: async () => [], reapSession: async () => {}, now: () => NOW },
+			{ idleTtlMs: TTL, sweepIntervalMs: 60_000 },
+		);
+		expect(reaper.running).toBe(false);
+		reaper.start();
+		reaper.start(); // idempotent, no duplicate timer
+		expect(reaper.running).toBe(true);
+		reaper.stop();
+		expect(reaper.running).toBe(false);
+	});
+
+	it("fires a sweep when the interval elapses", () => {
+		vi.useFakeTimers();
+		try {
+			let sweeps = 0;
+			const reaper = createSessionReaper(
+				{
+					listSessions: async () => {
+						sweeps += 1;
+						return [];
+					},
+					reapSession: async () => {},
+					now: () => NOW,
+				},
+				{ idleTtlMs: TTL, sweepIntervalMs: 60_000 },
+			);
+			reaper.start();
+			vi.advanceTimersByTime(60_000);
+			expect(sweeps).toBe(1);
+			reaper.stop();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("stop() cancels the pending scheduled sweep so it never fires (generation guard)", () => {
+		vi.useFakeTimers();
+		try {
+			let sweeps = 0;
+			const reaper = createSessionReaper(
+				{
+					listSessions: async () => {
+						sweeps += 1;
+						return [];
+					},
+					reapSession: async () => {},
+					now: () => NOW,
+				},
+				{ idleTtlMs: TTL, sweepIntervalMs: 60_000 },
+			);
+			reaper.start();
+			reaper.stop();
+			vi.advanceTimersByTime(300_000);
+			expect(sweeps).toBe(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/packages/coding-agent/test/coordinator-mcp/stop-session.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp/stop-session.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildCoordinatorMcpConfig, coordinatorNamespacePath } from "../../src/coordinator-mcp/policy";
+import { createCoordinatorMcpServer } from "../../src/coordinator-mcp/server";
+
+async function withTempRoot(run: (root: string) => Promise<void>): Promise<void> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-coord-stop-"));
+	try {
+		await run(root);
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}
+
+type MakeOpts = { forceStop?: boolean; forceClose?: (name: string) => Promise<unknown> };
+
+function baseEnv(root: string, forceStop?: boolean): Record<string, string> {
+	return {
+		GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+		GJC_COORDINATOR_MCP_MUTATIONS: "sessions,questions,reports",
+		GJC_COORDINATOR_MCP_STATE_ROOT: path.join(root, ".state"),
+		GJC_COORDINATOR_MCP_PROFILE: "stop-controller",
+		GJC_COORDINATOR_MCP_REPO: "repo-stop",
+		...(forceStop ? { GJC_COORDINATOR_MCP_FORCE_STOP: "1" } : {}),
+	};
+}
+
+function makeServer(root: string, opts: MakeOpts = {}) {
+	let n = 0;
+	const calls: string[] = [];
+	const env = baseEnv(root, opts.forceStop);
+	const server = createCoordinatorMcpServer({
+		env,
+		services: {
+			startSession: (input: { cwd: string }) => {
+				n += 1;
+				return {
+					name: `stop-sess-${n}`,
+					cwd: input.cwd,
+					createdAt: new Date().toISOString(),
+					tmux_session: `tmux-stop-sess-${n}`,
+				};
+			},
+			// Owner-proof termination is injected: the real forceCloseGjcTmuxSession is exercised only
+			// by the Linux-only integration test; here we drive success/failure deterministically.
+			forceCloseSession: async (name: string) => {
+				calls.push(name);
+				return opts.forceClose ? opts.forceClose(name) : {};
+			},
+		},
+	});
+	return { server, env, calls: () => calls };
+}
+
+/** Write an idle ephemeral session (no active turn) directly, matching a completed delegate worker. */
+async function writeEphemeralSession(env: Record<string, string>, id: string): Promise<void> {
+	const ns = coordinatorNamespacePath(buildCoordinatorMcpConfig(env));
+	await fs.mkdir(path.join(ns, "sessions"), { recursive: true });
+	await fs.writeFile(
+		path.join(ns, "sessions", `${id}.json`),
+		JSON.stringify({
+			session_id: id,
+			ephemeral: true,
+			tmux_session: `tmux-${id}`,
+			created_at: new Date().toISOString(),
+		}),
+	);
+}
+
+describe("gjc_coordinator_stop_session", () => {
+	it("refuses non-ephemeral without force, and never signals termination", async () => {
+		await withTempRoot(async root => {
+			const { server, calls } = makeServer(root);
+			const started = await server.callTool("gjc_coordinator_start_session", { cwd: root, allow_mutation: true });
+			const id = String((started.session as { session_id: string }).session_id);
+			const refused = await server.callTool("gjc_coordinator_stop_session", {
+				session_id: id,
+				allow_mutation: true,
+			});
+			expect(refused).toMatchObject({ ok: false, reason: "not_ephemeral", killed: false });
+			expect(calls()).toEqual([]);
+		});
+	});
+
+	it("refuses force when the force-stop capability is disabled", async () => {
+		await withTempRoot(async root => {
+			const { server, calls } = makeServer(root, { forceStop: false });
+			const started = await server.callTool("gjc_coordinator_start_session", { cwd: root, allow_mutation: true });
+			const id = String((started.session as { session_id: string }).session_id);
+			const denied = await server.callTool("gjc_coordinator_stop_session", {
+				session_id: id,
+				force: true,
+				allow_mutation: true,
+			});
+			expect(denied).toMatchObject({ ok: false, reason: "force_not_authorized", killed: false });
+			expect(calls()).toEqual([]);
+		});
+	});
+
+	it("reaps an idle ephemeral session and purges only after verified termination", async () => {
+		await withTempRoot(async root => {
+			const { server, env, calls } = makeServer(root);
+			await writeEphemeralSession(env, "idle-eph");
+			const reaped = await server.callTool("gjc_coordinator_stop_session", {
+				session_id: "idle-eph",
+				allow_mutation: true,
+			});
+			expect(reaped).toMatchObject({ ok: true, killed: true });
+			expect(calls().length).toBe(1); // owner-proof termination invoked exactly once
+			const status = await server.callTool("gjc_coordinator_read_status", { session_id: "idle-eph" });
+			expect(status.session ?? null).toBeNull(); // purged
+		});
+	});
+
+	it("force-reaps a non-ephemeral session when the capability is enabled", async () => {
+		await withTempRoot(async root => {
+			const { server, calls } = makeServer(root, { forceStop: true });
+			const started = await server.callTool("gjc_coordinator_start_session", { cwd: root, allow_mutation: true });
+			const id = String((started.session as { session_id: string }).session_id);
+			const reaped = await server.callTool("gjc_coordinator_stop_session", {
+				session_id: id,
+				force: true,
+				allow_mutation: true,
+			});
+			expect(reaped).toMatchObject({ ok: true, killed: true });
+			expect(calls().length).toBe(1);
+		});
+	});
+
+	it("keeps the record for retry when termination fails (no purge, no false reaped event)", async () => {
+		await withTempRoot(async root => {
+			const { server, env } = makeServer(root, {
+				forceClose: async () => {
+					throw new Error("gjc_tmux_owner_generation_mismatch:x");
+				},
+			});
+			await writeEphemeralSession(env, "wedged-eph");
+			const failed = await server.callTool("gjc_coordinator_stop_session", {
+				session_id: "wedged-eph",
+				allow_mutation: true,
+			});
+			expect(failed).toMatchObject({ ok: false, reason: "terminate_failed", killed: false });
+			// Record survives so a later sweep can retry — never orphan a live tmux session.
+			const status = await server.callTool("gjc_coordinator_read_status", { session_id: "wedged-eph" });
+			expect(status.session ?? null).not.toBeNull();
+		});
+	});
+
+	it("refuses to reap a session with an active turn (kill-time TOCTOU guard)", async () => {
+		await withTempRoot(async root => {
+			const { server, calls } = makeServer(root);
+			// A delegate leaves an active turn; the reaper must not kill mid-turn.
+			const d = await server.callTool("gjc_delegate_execute", { task: "x", cwd: root, allow_mutation: true });
+			const id = String((d as { session_id: string }).session_id);
+			const blocked = await server.callTool("gjc_coordinator_stop_session", {
+				session_id: id,
+				allow_mutation: true,
+			});
+			expect(blocked).toMatchObject({ ok: false, reason: "active_turn", killed: false });
+			expect(calls()).toEqual([]); // never signalled
+		});
+	});
+
+	it("returns unknown_session for a missing id", async () => {
+		await withTempRoot(async root => {
+			const { server } = makeServer(root);
+			const missing = await server.callTool("gjc_coordinator_stop_session", {
+				session_id: "nope",
+				allow_mutation: true,
+			});
+			expect(missing).toMatchObject({ ok: false, reason: "unknown_session", killed: false });
+		});
+	});
+});
+
+// Real-tmux safety: exercises the REAL forceCloseGjcTmuxSession (no injection) to prove the
+// owner-proof path refuses a foreign/non-GJC tmux session and the reaper keeps the record rather
+// than orphaning it — the core #2034 blocker (raw process.kill / PID-reuse) is gone.
+const tmuxBin = Bun.which("tmux");
+describe.skipIf(!tmuxBin)("stop_session real-tmux owner safety", () => {
+	it("real owner-proof termination refuses a foreign non-GJC session; it survives and the record is kept", async () => {
+		await withTempRoot(async root => {
+			const env = baseEnv(root);
+			// No forceCloseSession injection → the REAL forceCloseGjcTmuxSession runs.
+			const server = createCoordinatorMcpServer({ env });
+			const foreign = `verify-foreign-${Date.now()}`;
+			spawnSync("tmux", ["new-session", "-d", "-s", foreign, "sleep", "600"]);
+			try {
+				expect(spawnSync("tmux", ["has-session", "-t", foreign]).status).toBe(0);
+				// A coordinator ephemeral record that (mistakenly) points at the foreign session.
+				const ns = coordinatorNamespacePath(buildCoordinatorMcpConfig(env));
+				await fs.mkdir(path.join(ns, "sessions"), { recursive: true });
+				await fs.writeFile(
+					path.join(ns, "sessions", "eph-foreign.json"),
+					JSON.stringify({
+						session_id: "eph-foreign",
+						ephemeral: true,
+						tmux_session: foreign,
+						created_at: new Date().toISOString(),
+					}),
+				);
+
+				const res = await server.callTool("gjc_coordinator_stop_session", {
+					session_id: "eph-foreign",
+					allow_mutation: true,
+				});
+				// Owner-proof refuses a non-GJC session → no kill, record kept for inspection/retry.
+				expect(res).toMatchObject({ ok: false, reason: "terminate_failed", killed: false });
+				expect(spawnSync("tmux", ["has-session", "-t", foreign]).status).toBe(0); // foreign survives
+				const status = await server.callTool("gjc_coordinator_read_status", { session_id: "eph-foreign" });
+				expect(status.session ?? null).not.toBeNull(); // record kept
+			} finally {
+				spawnSync("tmux", ["kill-session", "-t", foreign]);
+			}
+		});
+	});
+});
+
+// BLOCKER 2 (#2044): the delegate reuse turn-activation now runs under the same per-session
+// withSessionMutation lock as the reaper/stop_session. A session the reaper already reaped can no
+// longer be silently reused (lost work), and no turn/state file is orphaned onto a killed session.
+describe("reaper ↔ delegate-reuse composition", () => {
+	it("a reaped session cleanly rejects a subsequent reused delegate and leaves no orphaned files", async () => {
+		await withTempRoot(async root => {
+			const { server, env } = makeServer(root);
+			await writeEphemeralSession(env, "eph");
+			const reaped = await server.callTool("gjc_coordinator_stop_session", {
+				session_id: "eph",
+				allow_mutation: true,
+			});
+			expect(reaped).toMatchObject({ ok: true });
+
+			// Reusing the reaped session id must fail closed — not dispatch work into a killed lane.
+			const reused = await server.callTool("gjc_delegate_execute", {
+				session_id: "eph",
+				task: "x",
+				cwd: root,
+				allow_mutation: true,
+			});
+			expect(reused).toMatchObject({ ok: false, reason: "unknown_session" });
+
+			const ns = coordinatorNamespacePath(buildCoordinatorMcpConfig(env));
+			const files = await fs.readdir(path.join(ns, "sessions")).catch(() => [] as string[]);
+			expect(files).not.toContain("eph.json"); // no orphaned session record
+		});
+	});
+});


### PR DESCRIPTION
Supersedes #2044 (closed REQUEST_CHANGES). Rebased onto current `dev`. Both re-review blockers + all four P2 items addressed. The independent re-review confirmed the code cleared the #2034 defects and all mechanical gates were green; this closes the two remaining items.

## #2044 re-review — resolved

**BLOCKER 2 (delegate reuse not under the lock) → FIXED.** The `gjc_delegate_*` reuse turn-activation (`readActiveTurn → supersede → activateTurn`) now runs inside the same `withSessionMutation(${namespaceDir}::${sessionId})` lock the reaper / `stop_session` / `send_prompt` use. The `await_completion` poll stays outside. The idle reaper can no longer reap a session between the reuse read and `activateTurn` (lost work + orphaned turn/state files). New test: a reaped session cleanly rejects a subsequent reused delegate (`unknown_session`) and leaves no orphaned record.

**BLOCKER 1 (real-tmux owned-termination) → ADDED.** `reaper-owner.integration.test.ts` creates a **genuine GJC-managed owned session** (systemd user scope + profile tags + owner generation, same harness as `tmux-sessions.integration.test.ts`) and reaps it through the coordinator's `stop_session` → the **real** `forceCloseGjcTmuxSession` (not the injected double) — asserting the owned session is terminated, its record purged, and an **unrelated GJC session survives untouched**. Gated `skipIf(!isLinux || !tmux || !userScopeAvailable)`, so it runs on Linux CI. (It skips on the macOS dev host, which has no systemd user scope — I could not execute it locally; CI is the verifier. It mirrors the proven owner-close harness exactly.)

## P2 — addressed

- **Sweep fault isolation:** the reaper's `listSessions` projection wraps each session in `try/catch`; a single corrupt session/state file can no longer abort the whole sweep.
- **Event-before-purge idempotency:** the session record is `fs.rm`'d **before** `session.reaped` is appended, so a partial rm can never re-list → re-reap → emit a duplicate event.
- **Honest `killed`:** `killed` is `true` only when a tmux session was actually terminated (`false` when nothing was signalled), and it is recorded on the event.
- **Identity bind:** the wrapper binds `forceCloseGjcTmuxSession` to the recorded `sessionStateFile` (via `services.forceCloseSession(name, env, expectedSessionId?, expectedStateFile?)`).

## Notes
- **#2009 overlap:** flagged in the re-review — `issue-2009-runtime-input-readiness` rewrites the same `server.ts`. Whichever lands second rebases; this PR is a clean rebase on the current `dev` tip and rebases cleanly today.

## Tests
- `session-reaper` (12) + `stop-session` (8) + delegate-reuse composition (1) — **21 pass** on this host; `reaper-owner.integration` runs on Linux CI (skips here).
- `bun --cwd=packages/coding-agent run check` — `biome check` (2008 files) + `tsc --noEmit` green. No regression vs `dev` baseline.

---
- [x] `bun check` passes
- [x] Tested locally (units + delegate composition + real-tmux foreign-refusal; owner-termination on Linux CI)
- [x] `Signed-off-by` (DCO) on both commits
