### PR TITLE
fix(session): attribute cache misses by evidence, not a blanket user-side cause (#2020)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Migrated the repository type-check and release declaration pipeline to stable TypeScript 7.0.2, including the robogjc web workspace and a non-mutating publish-type gate.
 - Rebalanced GPT-5.6 Codex and combo presets around published family tiers and reasoning-effort curves. The executor assignments are informed by descriptive repeated local exact-edit evidence from selected TypeScript tasks; default, planner, architect, and critic assignments remain product judgments rather than benchmark claims.
+- Cache-miss diagnostics now separate actionable, diagnostic-only, and provider-side-suspected causes instead of asserting a user-side fix for every miss (#2020). A large, costly miss with no cache reads or writes is reported as a neutral `Cache notice` marked "provider-side suspected / not user-actionable" (with what GJC cannot determine) rather than telling the user to keep a stable prefix; a miss with reads but no writes is reported as diagnostic-only without asserting a single cause; and the "cache write without enough matching reads" warning now only fires when reads actually fail to cover the writes. The existing miss cost summary and the #1929/#1936 pricing/provenance safeguards are unchanged.
 
 ### Fixed
 

--- a/packages/coding-agent/src/session/cache-economics.ts
+++ b/packages/coding-agent/src/session/cache-economics.ts
@@ -48,10 +48,26 @@ export interface CacheMissCostSummary {
 	missPremiumUsd: number | undefined;
 }
 
+/**
+ * How a detected cache-miss pattern is attributed, per issue #2020.
+ *
+ * - `actionable`: usage evidence points to a user-controllable cause and GJC
+ *   has a concrete remediation.
+ * - `diagnostic-only`: a miss pattern is observed but the cause is not
+ *   determinable from usage alone; describe what is unknown, assert no cause.
+ * - `provider-side-suspected`: the provider returned no cache activity, so the
+ *   miss cannot be attributed to the user's prompt; not user-actionable.
+ */
+export type CacheMissAttribution = "actionable" | "diagnostic-only" | "provider-side-suspected";
+
 export interface CacheBehaviorWarning {
-	code: "expensive_cache_miss" | "cache_write_spike";
+	code: "expensive_cache_miss" | "cache_write_spike" | "provider_side_cache_miss";
+	attribution: CacheMissAttribution;
 	reason: string;
-	nextStep: string;
+	/** Concrete remediation — present only when `attribution` is `actionable`. */
+	nextStep?: string;
+	/** What GJC cannot determine — present for non-actionable attributions. */
+	unknown?: string;
 	costUsd: number;
 }
 
@@ -172,22 +188,78 @@ export function buildCacheBehaviorWarning(
 		(summary.cacheHitRate === undefined || summary.cacheHitRate < 0.25) &&
 		summary.inputCostUsd >= EXPENSIVE_MISS_COST_USD
 	) {
+		// Attribute by observable cache activity rather than asserting a cause (#2020).
+		const noCacheActivity = summary.cacheReadTokens <= 0 && summary.cacheWriteTokens <= 0;
+		if (noCacheActivity) {
+			// The provider returned zero cache read/write tokens for a large, costly
+			// prompt: the miss cannot be traced to the user's prefix, and keeping a
+			// stable prefix cannot help when nothing is being cached at all.
+			return {
+				code: "provider_side_cache_miss",
+				attribution: "provider-side-suspected",
+				reason: `large uncached input with no cache activity (${formatUsd(summary.inputCostUsd)})`,
+				unknown:
+					"the provider reported no cache reads or writes, so GJC cannot tell whether prompt caching is unsupported, missing cache-control fields, or provider-side eviction",
+				costUsd: summary.inputCostUsd,
+			};
+		}
+		if (summary.cacheWriteTokens > 0) {
+			// Writes are landing but reuse is low: the cacheable prefix is churning
+			// between turns, which is user-controllable.
+			return {
+				code: "expensive_cache_miss",
+				attribution: "actionable",
+				reason: `large uncached input with low cache reuse (${formatUsd(summary.inputCostUsd)})`,
+				nextStep: "keep the stable prefix; avoid rereading unchanged context before the next turn",
+				costUsd: summary.inputCostUsd,
+			};
+		}
+		// Reads happened but no writes this turn: part of the prefix was reused, yet
+		// the large new input was not cached. From usage alone GJC cannot tell new
+		// content apart from a provider-side gap, so it reports without asserting.
 		return {
 			code: "expensive_cache_miss",
-			reason: `large uncached input with low cache hits (${formatUsd(summary.inputCostUsd)})`,
-			nextStep: "keep the stable prefix; avoid rereading unchanged context before the next turn",
+			attribution: "diagnostic-only",
+			reason: `large uncached input with partial cache reuse (${formatUsd(summary.inputCostUsd)})`,
+			unknown:
+				"the uncached tokens may be genuinely new content or a provider-side gap; usage alone cannot attribute a single cause",
 			costUsd: summary.inputCostUsd,
 		};
 	}
-	if (summary.cacheWriteTokens >= LARGE_CACHE_WRITE_TOKENS && summary.cacheWriteCostUsd >= EXPENSIVE_MISS_COST_USD) {
+	if (
+		summary.cacheWriteTokens >= LARGE_CACHE_WRITE_TOKENS &&
+		summary.cacheWriteCostUsd >= EXPENSIVE_MISS_COST_USD &&
+		// Only claim reuse is insufficient when reads actually fail to cover the
+		// writes; a large write that is being read back is healthy, not a spike.
+		summary.cacheReadTokens < summary.cacheWriteTokens
+	) {
 		return {
 			code: "cache_write_spike",
+			attribution: "actionable",
 			reason: `large cache write without enough matching reads (${formatUsd(summary.cacheWriteCostUsd)})`,
 			nextStep: "make the next turn reuse the same context; avoid changing system or tool prefixes",
 			costUsd: summary.cacheWriteCostUsd,
 		};
 	}
 	return undefined;
+}
+
+/**
+ * Render a cache warning as a single transcript line. Actionable attributions
+ * carry a concrete next step; non-actionable ones state what is unknown and,
+ * for provider-side patterns, that the miss is not user-actionable — never
+ * asserting a cause or blaming the provider (#2020).
+ */
+export function formatCacheWarningLine(warning: CacheBehaviorWarning): string {
+	if (warning.attribution === "actionable" && warning.nextStep) {
+		return `Cache warning: ${warning.reason}; next step: ${warning.nextStep}.`;
+	}
+	if (warning.attribution === "provider-side-suspected") {
+		const detail = warning.unknown ? ` — ${warning.unknown}` : "";
+		return `Cache notice: ${warning.reason}; provider-side suspected / not user-actionable${detail}.`;
+	}
+	const detail = warning.unknown ? `; ${warning.unknown}` : "";
+	return `Cache notice: ${warning.reason}${detail}.`;
 }
 
 export function buildCacheEconomicsWarning(
@@ -199,5 +271,5 @@ export function buildCacheEconomicsWarning(
 	const warning = buildCacheBehaviorWarning(usage, model);
 	if (!warning) return undefined;
 	state.warningsEmitted += 1;
-	return `Cache warning: ${warning.reason}; next step: ${warning.nextStep}.`;
+	return formatCacheWarningLine(warning);
 }

--- a/packages/coding-agent/test/cache-economics.test.ts
+++ b/packages/coding-agent/test/cache-economics.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import type { Model, Usage } from "@gajae-code/ai";
 import {
+	buildCacheBehaviorWarning,
 	buildCacheEconomicsWarning,
 	type CacheEconomicsBasis,
 	type CacheEconomicsUsage,
 	computeCacheMissCostSummary,
+	formatCacheWarningLine,
 } from "@gajae-code/coding-agent/session/cache-economics";
 
 function usage(overrides: Partial<Usage>): Usage {
@@ -188,5 +190,70 @@ describe("cache economics", () => {
 		).toBe(true);
 		expect(warnings[3]).toBeUndefined();
 		expect(state.warningsEmitted).toBe(3);
+	});
+});
+
+const noPersistedCost = (overrides: Partial<Usage>): Usage => ({
+	...usage(overrides),
+	cost: {} as Usage["cost"],
+});
+
+describe("cache-miss attribution (#2020)", () => {
+	const model = modelWithCost(priced);
+
+	it("marks a large costly miss with zero cache activity as provider-side suspected, not user-actionable", () => {
+		const warning = buildCacheBehaviorWarning(noPersistedCost({ input: 20_000 }), model);
+
+		expect(warning?.code).toBe("provider_side_cache_miss");
+		expect(warning?.attribution).toBe("provider-side-suspected");
+		expect(warning?.nextStep).toBeUndefined();
+		expect(warning?.unknown).toBeDefined();
+
+		const line = formatCacheWarningLine(warning as NonNullable<typeof warning>);
+		expect(line).toContain("provider-side suspected / not user-actionable");
+		expect(line).not.toContain("keep the stable prefix");
+		expect(line).not.toContain("next step:");
+	});
+
+	it("reports partial reuse without writes as diagnostic-only and asserts no single cause", () => {
+		const warning = buildCacheBehaviorWarning(noPersistedCost({ input: 20_000, cacheRead: 1_000 }), model);
+
+		expect(warning?.code).toBe("expensive_cache_miss");
+		expect(warning?.attribution).toBe("diagnostic-only");
+		expect(warning?.nextStep).toBeUndefined();
+
+		const line = formatCacheWarningLine(warning as NonNullable<typeof warning>);
+		expect(line).toContain("Cache notice:");
+		expect(line).toContain("partial cache reuse");
+		expect(line).not.toContain("next step:");
+		expect(line).not.toContain("provider-side suspected");
+	});
+
+	it("keeps the actionable prefix remediation when writes land but reuse is low", () => {
+		const warning = buildCacheBehaviorWarning(
+			noPersistedCost({ input: 20_000, cacheRead: 1_000, cacheWrite: 5_000 }),
+			model,
+		);
+
+		expect(warning?.code).toBe("expensive_cache_miss");
+		expect(warning?.attribution).toBe("actionable");
+		expect(warning?.nextStep).toContain("keep the stable prefix");
+
+		const line = formatCacheWarningLine(warning as NonNullable<typeof warning>);
+		expect(line).toContain("Cache warning:");
+		expect(line).toContain("next step: keep the stable prefix");
+	});
+
+	it("does not claim a cache-write spike when reads cover the writes", () => {
+		const healthy = buildCacheBehaviorWarning(noPersistedCost({ cacheWrite: 30_000, cacheRead: 100_000 }), model);
+		expect(healthy).toBeUndefined();
+	});
+
+	it("flags a cache-write spike only when reads fail to cover the writes", () => {
+		const spike = buildCacheBehaviorWarning(noPersistedCost({ cacheWrite: 30_000, cacheRead: 0 }), model);
+
+		expect(spike?.code).toBe("cache_write_spike");
+		expect(spike?.attribution).toBe("actionable");
+		expect(spike?.nextStep).toContain("reuse the same context");
 	});
 });

--- a/packages/coding-agent/test/session-dump-format.test.ts
+++ b/packages/coding-agent/test/session-dump-format.test.ts
@@ -55,7 +55,8 @@ function cacheWarningUsage(): Usage {
 		...zeroUsage,
 		input: 20_000,
 		cacheRead: 1_000,
-		totalTokens: 21_000,
+		cacheWrite: 2_000,
+		totalTokens: 23_000,
 	};
 }
 
@@ -183,7 +184,7 @@ describe("formatSessionDumpText cache warnings", () => {
 		});
 
 		expect(dumped).toContain(
-			"assistant 1\nCache warning: large uncached input with low cache hits ($0.06); next step:",
+			"assistant 1\nCache warning: large uncached input with low cache reuse ($0.06); next step:",
 		);
 	});
 


### PR DESCRIPTION
## What

Cache-miss diagnostics attributed every large, costly miss to a user-side cause and told the operator to "keep the stable prefix", and the cache-write-spike warning claimed a write was "without enough matching reads" without ever checking reads. Both are speculative attribution.

This classifies a detected miss by **observable cache activity** and separates three cases (issue #2020):

- **actionable** — writes land but reuse is low (prefix churn): keep the stable prefix.
- **diagnostic-only** — reads but no writes this turn: report the observation, assert no single cause, say what is unknown.
- **provider-side-suspected** — no cache reads or writes at all: a neutral `Cache notice` marked *provider-side suspected / not user-actionable* that states what GJC cannot determine, instead of a false user remediation.

The cache-write-spike warning now fires **only when reads actually fail to cover the writes** (`cacheRead < cacheWrite`); a write that is being read back is healthy and no longer warns.

## Why

Per #2020, cache-miss diagnostics must cleanly separate actionable, diagnostic-only, and unknown causes, with no speculative attribution or provider blame, while preserving the #1929/#1936 pricing/provenance safeguards.

Reproduced before the fix:
- `input=20k, cacheRead=0, cacheWrite=0` → old output asserted "keep the stable prefix" even though nothing was being cached.
- `cacheWrite=30k, cacheRead=100k` → old output claimed "without enough matching reads" while reads far exceeded writes.

## Scope / safeguards

- `computeCacheMissCostSummary` and the miss cost summary lines are unchanged; the #1929/#1936 pricing/provenance safeguards are untouched.
- Change is contained to `packages/coding-agent/src/session/cache-economics.ts` (warning classification + a `formatCacheWarningLine` renderer).

## Tests / checks

- `bun test packages/coding-agent/test/cache-economics.test.ts packages/coding-agent/test/session-dump-format.test.ts` — 21 pass (adversarial coverage for each attribution + read-gated write spike).
- `bun test packages/coding-agent/test/acp-builtins.test.ts .../session-command.test.ts .../agent-session-cache-economics.test.ts` — 77 pass (summary path unchanged).
- `bun --cwd=packages/coding-agent run check` — biome + tsc clean.

Target branch: `dev`.
