### PR TITLE
fix(coding-agent): guard selector done() restoreComposer with editor-swap fallback

### DIFF
--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -160,7 +160,15 @@ export class SelectorController {
 	 */
 	showSelector(create: (done: () => void) => { component: Component; focus: Component }): void {
 		const done = () => {
-			this.ctx.restoreComposer();
+			// Prefer the pet-aware composer restore (InteractiveMode.restoreComposer); fall back
+			// to a plain editor swap for contexts that predate it (e.g. lightweight test doubles).
+			if (typeof this.ctx.restoreComposer === "function") {
+				this.ctx.restoreComposer();
+			} else {
+				this.ctx.editorContainer.clear();
+				this.ctx.editorContainer.addChild(this.ctx.editor);
+				this.ctx.ui.setFocus(this.ctx.editor);
+			}
 		};
 		const { component, focus } = create(done);
 		this.ctx.editorContainer.clear();


### PR DESCRIPTION
## Summary

Repairs Dev CI run 29162030022. PR #2021 (opt-in terminal pet widget) replaced the inline editor swap in `SelectorController.showSelector`'s `done()` callback with `this.ctx.restoreComposer()`. The lightweight test-double contexts for the `/effort` and `/theme` selectors do not implement the pet-aware `restoreComposer`, so closing a selector threw `TypeError: this.ctx.restoreComposer is not a function`.

## Fix

Smallest correct compatibility fix in `done()`: prefer the pet-aware `restoreComposer` when present, and fall back to the previous plain editor swap (`clear` + re-add `editor` + `setFocus`) otherwise. Real usage always goes through `InteractiveMode` (the only production `InteractiveModeContext` implementer), which provides `restoreComposer`, so the pet-aware path is unchanged; only partial/legacy context shapes take the fallback.

## Verification

- `bun test test/modes/components/thinking-selector.test.ts test/modes/components/theme-selector-input.test.ts` -> 10 pass (previously 4 fail)
- `bun test test/modes/components test/modes/controllers` -> 194 pass
- `bun run check:types` (tsc) -> clean
- `biome check src/modes/controllers/selector-controller.ts` -> OK

Never targets `main`.
