### PR TITLE
fix(tui): stabilize markdown viewport anchors across topology-changing reflow

### DIFF
--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -477,20 +477,31 @@ export class Markdown implements Component {
 		// numbered over stable source identities instead of the rendered glyph
 		// stream (#2031).
 		const renderedLines: string[] = [];
-		const tokenBoundaries: Array<{ start: number; end: number; srcLo: number; srcHi: number }> = [];
+		const tokenBoundaries: Array<{ start: number; end: number; srcLo: number; srcHi: number; units: number[] }> = [];
 		let srcOffset = 0;
 
 		for (let i = 0; i < tokens.length; i++) {
 			const token = tokens[i];
 			const nextToken = tokens[i + 1];
 			const tokenStart = renderedLines.length;
-			const tokenLines = this.#renderToken(token, contentWidth, nextToken?.type);
+			const units: number[] | undefined = includeAnchors ? [] : undefined;
+			const tokenLines = this.#renderToken(token, contentWidth, nextToken?.type, undefined, units);
 			renderedLines.push(...tokenLines);
 			if (includeAnchors) {
 				const rawLength = "raw" in token && typeof token.raw === "string" ? token.raw.length : 0;
 				const srcLo = srcOffset;
 				srcOffset += Math.max(1, rawLength);
-				tokenBoundaries.push({ start: tokenStart, end: renderedLines.length, srcLo, srcHi: srcOffset });
+				// units must align 1:1 with the token's rendered lines; if a renderer
+				// path emitted none, treat the whole token as a single unit.
+				const lineUnits =
+					units && units.length === tokenLines.length ? units : new Array<number>(tokenLines.length).fill(0);
+				tokenBoundaries.push({
+					start: tokenStart,
+					end: renderedLines.length,
+					srcLo,
+					srcHi: srcOffset,
+					units: lineUnits,
+				});
 			}
 		}
 
@@ -501,44 +512,55 @@ export class Markdown implements Component {
 			const spans: Array<ViewportAnchorSpan | null> = [];
 			for (const boundary of tokenBoundaries) {
 				// Number this token's width-invariant source-text band [lo, hi) over its
-				// rendered lines (pre-wrap) rather than over the width-dependent count of
-				// final content rows. Each pre-wrap rendered line is a stable structural
-				// unit — a list item, a quoted line, a table row-line — so an earlier
-				// line's sub-band no longer moves when a *later* line of the same
-				// top-level token rewraps into more rows. That within-token drift was the
-				// P2 the first #2031 pass reintroduced: a page-down anchor pinned to list
-				// item 1 slid into item 2 once item 2 rewrapped, because both shared one
-				// content-row count that the later item inflated.
+				// source units — width-invariant structural spans (a list item, a table
+				// row, a blockquote child block; a simple token is one unit) — rather than
+				// over the width-dependent count of final content rows. Each unit reserves
+				// a fixed sub-band, so an earlier unit's rows no longer move when a *later*
+				// unit of the same top-level token rewraps into more rows. That
+				// within-token drift was the P2 the first #2031 pass reintroduced: a
+				// page-down anchor pinned to list item 1 (or a table header) slid into item
+				// 2 (or a data row) once the later unit rewrapped, because every unit shared
+				// one content-row count the later unit inflated.
 				const lo = boundary.srcLo * ANCHOR_SOURCE_SCALE;
 				const hi = boundary.srcHi * ANCHOR_SOURCE_SCALE;
 				const lineCount = boundary.end - boundary.start;
+				// Wrap the token's rendered lines exactly as the plain path does (so the
+				// emitted `lines` stay byte-identical to render()), recording each wrapped
+				// row's source unit and its position in `wrappedLines`.
+				const firstWrapped = wrappedLines.length;
+				const rowUnit: number[] = [];
+				let unitCount = 1;
 				for (let li = 0; li < lineCount; li++) {
 					const renderedLine = renderedLines[boundary.start + li];
-					// Each rendered line reserves its own non-overlapping sub-band.
-					const lineLo = lo + Math.floor((li * (hi - lo)) / lineCount);
-					const lineHi = li === lineCount - 1 ? hi : lo + Math.floor(((li + 1) * (hi - lo)) / lineCount);
-					// Wrap this rendered line exactly as the plain path does, so the
-					// emitted `lines` stay byte-identical to render().
+					const unit = boundary.units[li];
+					if (unit + 1 > unitCount) unitCount = unit + 1;
 					const lineWrapped = TERMINAL.isImageLine(renderedLine)
 						? [renderedLine]
 						: wrapTextIfNeeded(renderedLine, contentWidth);
-					// Distribute the line's sub-band across its content rows. Blank,
-					// decoration-only whitespace, and image rows carry no anchor.
-					const contentRows: number[] = [];
-					for (let r = 0; r < lineWrapped.length; r++) {
-						const l = lineWrapped[r];
-						if (!TERMINAL.isImageLine(l) && Bun.stripANSI(l).trim().length > 0) contentRows.push(r);
+					for (const w of lineWrapped) {
+						wrappedLines.push(w);
+						spans.push(null);
+						rowUnit.push(unit);
 					}
-					const rowSpans: Array<ViewportAnchorSpan | null> = new Array(lineWrapped.length).fill(null);
-					const count = contentRows.length;
+				}
+				// Blank, decoration-only whitespace, and image rows carry no anchor.
+				const contentRowsByUnit: number[][] = Array.from({ length: unitCount }, () => []);
+				for (let j = 0; j < rowUnit.length; j++) {
+					const globalIdx = firstWrapped + j;
+					const line = wrappedLines[globalIdx];
+					if (!TERMINAL.isImageLine(line) && Bun.stripANSI(line).trim().length > 0) {
+						contentRowsByUnit[rowUnit[j]].push(globalIdx);
+					}
+				}
+				for (let u = 0; u < unitCount; u++) {
+					const unitLo = lo + Math.floor((u * (hi - lo)) / unitCount);
+					const unitHi = u === unitCount - 1 ? hi : lo + Math.floor(((u + 1) * (hi - lo)) / unitCount);
+					const rows = contentRowsByUnit[u];
+					const count = rows.length;
 					for (let c = 0; c < count; c++) {
-						const start = lineLo + Math.floor((c * (lineHi - lineLo)) / count);
-						const end = c === count - 1 ? lineHi : lineLo + Math.floor(((c + 1) * (lineHi - lineLo)) / count);
-						rowSpans[contentRows[c]] = { graphemeStart: start, graphemeEnd: end, cellStart: start, cellEnd: end };
-					}
-					for (let r = 0; r < lineWrapped.length; r++) {
-						wrappedLines.push(lineWrapped[r]);
-						spans.push(rowSpans[r]);
+						const start = unitLo + Math.floor((c * (unitHi - unitLo)) / count);
+						const end = c === count - 1 ? unitHi : unitLo + Math.floor(((c + 1) * (unitHi - unitLo)) / count);
+						spans[rows[c]] = { graphemeStart: start, graphemeEnd: end, cellStart: start, cellEnd: end };
 					}
 				}
 			}
@@ -705,7 +727,13 @@ export class Markdown implements Component {
 		};
 	}
 
-	#renderToken(token: Token, width: number, nextTokenType?: string, styleContext?: InlineStyleContext): string[] {
+	#renderToken(
+		token: Token,
+		width: number,
+		nextTokenType?: string,
+		styleContext?: InlineStyleContext,
+		units?: number[],
+	): string[] {
 		const lines: string[] = [];
 
 		switch (token.type) {
@@ -763,7 +791,7 @@ export class Markdown implements Component {
 			}
 
 			case "list": {
-				const listLines = this.#renderList(token as ListToken, 0, styleContext);
+				const listLines = this.#renderList(token as ListToken, 0, styleContext, units);
 				lines.push(...listLines);
 				// Don't add spacing after lists if a space token follows
 				// (the space token will handle it)
@@ -771,7 +799,7 @@ export class Markdown implements Component {
 			}
 
 			case "table": {
-				const tableLines = this.#renderTable(token as TableToken, width, nextTokenType, styleContext);
+				const tableLines = this.#renderTable(token as TableToken, width, nextTokenType, styleContext, units);
 				lines.push(...tableLines);
 				break;
 			}
@@ -797,28 +825,40 @@ export class Markdown implements Component {
 				const quoteContentWidth = Math.max(1, width - 2);
 				const quoteTokens = token.tokens || [];
 				const renderedQuoteLines: string[] = [];
+				// Track which source child block produced each rendered quote line so the
+				// anchor band can be numbered over width-invariant child units rather than
+				// the width-dependent count of wrapped quote lines.
+				const quoteLineUnit: number[] = [];
 
 				for (let i = 0; i < quoteTokens.length; i++) {
 					const quoteToken = quoteTokens[i];
 					const nextQuoteToken = quoteTokens[i + 1];
-					renderedQuoteLines.push(
-						...this.#renderToken(quoteToken, quoteContentWidth, nextQuoteToken?.type, quoteInlineStyleContext),
+					const childLines = this.#renderToken(
+						quoteToken,
+						quoteContentWidth,
+						nextQuoteToken?.type,
+						quoteInlineStyleContext,
 					);
+					for (let c = 0; c < childLines.length; c++) quoteLineUnit.push(i);
+					renderedQuoteLines.push(...childLines);
 				}
 
 				while (renderedQuoteLines.length > 0 && renderedQuoteLines[renderedQuoteLines.length - 1] === "") {
 					renderedQuoteLines.pop();
+					quoteLineUnit.pop();
 				}
 
-				for (const quoteLine of renderedQuoteLines) {
-					const styledLine = applyQuoteStyle(quoteLine);
+				for (let q = 0; q < renderedQuoteLines.length; q++) {
+					const styledLine = applyQuoteStyle(renderedQuoteLines[q]);
 					const wrappedLines = wrapTextIfNeeded(styledLine, quoteContentWidth);
 					for (const wrappedLine of wrappedLines) {
 						lines.push(this.#theme.quoteBorder(`${this.#theme.symbols.quoteBorder} `) + wrappedLine);
+						units?.push(quoteLineUnit[q]);
 					}
 				}
 				if (nextTokenType && nextTokenType !== "space") {
 					lines.push(""); // Add spacing after blockquotes (unless space token follows)
+					units?.push(quoteTokens.length > 0 ? quoteTokens.length - 1 : 0);
 				}
 				break;
 			}
@@ -852,6 +892,9 @@ export class Markdown implements Component {
 				}
 		}
 
+		// Anchor units: lines a token emitted without an explicit unit (simple
+		// single-unit tokens, trailing spacing) inherit the last unit, default 0.
+		if (units) while (units.length < lines.length) units.push(units.length ? units[units.length - 1] : 0);
 		return lines;
 	}
 
@@ -955,7 +998,7 @@ export class Markdown implements Component {
 	/**
 	 * Render a list with proper nesting support
 	 */
-	#renderList(token: ListToken, depth: number, styleContext?: InlineStyleContext): string[] {
+	#renderList(token: ListToken, depth: number, styleContext?: InlineStyleContext, units?: number[]): string[] {
 		const lines: string[] = [];
 		const indent = "  ".repeat(depth);
 		// Use the list's start property (defaults to 1 for ordered lists)
@@ -998,6 +1041,9 @@ export class Markdown implements Component {
 			} else {
 				lines.push(indent + this.#theme.listBullet(bullet));
 			}
+			// Anchor units: every rendered line of this top-level item (including any
+			// nested list lines) belongs to one width-invariant unit — the item index.
+			if (units) while (units.length < lines.length) units.push(i);
 		}
 
 		return lines;
@@ -1077,6 +1123,7 @@ export class Markdown implements Component {
 		availableWidth: number,
 		nextTokenType?: string,
 		styleContext?: InlineStyleContext,
+		units?: number[],
 	): string[] {
 		const lines: string[] = [];
 		const numCols = token.header.length;
@@ -1217,6 +1264,9 @@ export class Markdown implements Component {
 		const separatorCells = columnWidths.map(w => h.repeat(w));
 		const separatorLine = `${t.teeRight}${h}${separatorCells.join(`${h}${t.cross}${h}`)}${h}${t.teeLeft}`;
 		lines.push(separatorLine);
+		// Anchor units: the whole header block (top border + header rows + separator)
+		// is unit 0; each source data row is its own width-invariant unit below.
+		if (units) while (units.length < lines.length) units.push(0);
 
 		// Render rows with wrapping
 		for (let rowIndex = 0; rowIndex < token.rows.length; rowIndex++) {
@@ -1238,6 +1288,7 @@ export class Markdown implements Component {
 			if (rowIndex < token.rows.length - 1) {
 				lines.push(separatorLine);
 			}
+			if (units) while (units.length < lines.length) units.push(rowIndex + 1);
 		}
 
 		// Render bottom border
@@ -1247,6 +1298,7 @@ export class Markdown implements Component {
 		if (nextTokenType && nextTokenType !== "space") {
 			lines.push(""); // Add spacing after table
 		}
+		if (units) while (units.length < lines.length) units.push(token.rows.length);
 		return lines;
 	}
 }

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -4,9 +4,7 @@ import type { SymbolTheme } from "../symbols";
 import { TERMINAL } from "../terminal-capabilities";
 import type { Component } from "../tui";
 import {
-	annotateViewportAnchorGraphemes,
 	applyBackgroundToLine,
-	extractViewportAnchorRows,
 	padding,
 	replaceTabs,
 	type ViewportAnchorSpan,
@@ -58,6 +56,16 @@ const PARSE_CACHE_MAX = 128;
 const parseCache = new LRUCache<string, { source: string; tokens: Token[] }>({ max: PARSE_CACHE_MAX });
 const MARKDOWN_STREAM_THROTTLE_MS = 64;
 let markdownNow = (): number => performance.now();
+
+// Viewport anchor offsets are numbered over each top-level token's width-invariant
+// source-text span (scaled to leave room for content rows) instead of the
+// width-dependent rendered glyph stream. HR fill length, per-row blockquote
+// prefixes, and boxed/raw table topology all change the rendered glyph count with
+// width; source-text spans do not, so anchors resolve to the same content after a
+// topology-changing reflow (#2031). The scale guarantees each content row a
+// positive, non-overlapping sub-span even when a token wraps into more rows than
+// its source has characters.
+const ANCHOR_SOURCE_SCALE = 1 << 16;
 
 /** Test-only clock seam for streaming throttle tests. */
 export function __setMarkdownNowForTest(now: (() => number) | undefined): void {
@@ -463,41 +471,67 @@ export class Markdown implements Component {
 			parseCache.set(contentKey, { source: normalizedText, tokens });
 		}
 
-		// Convert tokens to styled terminal output
+		// Convert tokens to styled terminal output. When anchoring, record each
+		// top-level token's rendered-line range plus a width-invariant source-text
+		// span (cumulative marked-token `raw` lengths) so viewport anchors are
+		// numbered over stable source identities instead of the rendered glyph
+		// stream (#2031).
 		const renderedLines: string[] = [];
+		const tokenBoundaries: Array<{ start: number; end: number; srcLo: number; srcHi: number }> = [];
+		let srcOffset = 0;
 
 		for (let i = 0; i < tokens.length; i++) {
 			const token = tokens[i];
 			const nextToken = tokens[i + 1];
+			const tokenStart = renderedLines.length;
 			const tokenLines = this.#renderToken(token, contentWidth, nextToken?.type);
 			renderedLines.push(...tokenLines);
+			if (includeAnchors) {
+				const rawLength = "raw" in token && typeof token.raw === "string" ? token.raw.length : 0;
+				const srcLo = srcOffset;
+				srcOffset += Math.max(1, rawLength);
+				tokenBoundaries.push({ start: tokenStart, end: renderedLines.length, srcLo, srcHi: srcOffset });
+			}
 		}
 
 		let wrappedLines: string[];
 		let wrappedSpans: Array<ViewportAnchorSpan | null> | undefined;
 		if (includeAnchors) {
-			const markedRenderedLines: string[] = [];
-			const markerToken = crypto.randomUUID();
-			let nextGrapheme = 0;
-			let nextCell = 0;
-			for (const line of renderedLines) {
-				if (TERMINAL.isImageLine(line)) {
-					markedRenderedLines.push(line);
-					continue;
+			wrappedLines = [];
+			const spans: Array<ViewportAnchorSpan | null> = [];
+			for (const boundary of tokenBoundaries) {
+				// Wrap this token's rendered lines exactly as the plain path does, so
+				// the emitted `lines` stay byte-identical to render().
+				const tokenWrapped: string[] = [];
+				for (let r = boundary.start; r < boundary.end; r++) {
+					const line = renderedLines[r];
+					if (TERMINAL.isImageLine(line)) tokenWrapped.push(line);
+					else tokenWrapped.push(...wrapTextIfNeeded(line, contentWidth));
 				}
-				const marked = annotateViewportAnchorGraphemes(line, nextGrapheme, nextCell, markerToken);
-				markedRenderedLines.push(marked.text);
-				nextGrapheme = marked.nextGrapheme;
-				nextCell = marked.nextCell;
+				// Distribute the token's width-invariant source-text band across its
+				// content rows. A content row's anchor identifies the same source
+				// position at any width, so the row survives topology-changing reflow.
+				// Blank, decoration-only whitespace, and image rows carry no anchor.
+				const contentRows: number[] = [];
+				for (let r = 0; r < tokenWrapped.length; r++) {
+					const line = tokenWrapped[r];
+					if (!TERMINAL.isImageLine(line) && Bun.stripANSI(line).trim().length > 0) contentRows.push(r);
+				}
+				const lo = boundary.srcLo * ANCHOR_SOURCE_SCALE;
+				const hi = boundary.srcHi * ANCHOR_SOURCE_SCALE;
+				const rowSpans: Array<ViewportAnchorSpan | null> = new Array(tokenWrapped.length).fill(null);
+				const count = contentRows.length;
+				for (let c = 0; c < count; c++) {
+					const start = lo + Math.floor((c * (hi - lo)) / count);
+					const end = c === count - 1 ? hi : lo + Math.floor(((c + 1) * (hi - lo)) / count);
+					rowSpans[contentRows[c]] = { graphemeStart: start, graphemeEnd: end, cellStart: start, cellEnd: end };
+				}
+				for (let r = 0; r < tokenWrapped.length; r++) {
+					wrappedLines.push(tokenWrapped[r]);
+					spans.push(rowSpans[r]);
+				}
 			}
-			const markedWrappedLines: string[] = [];
-			for (const line of markedRenderedLines) {
-				if (TERMINAL.isImageLine(line)) markedWrappedLines.push(line);
-				else markedWrappedLines.push(...wrapTextIfNeeded(line, contentWidth));
-			}
-			const extracted = extractViewportAnchorRows(markedWrappedLines, markerToken);
-			wrappedLines = extracted.lines;
-			wrappedSpans = extracted.spans;
+			wrappedSpans = spans;
 		} else {
 			wrappedLines = [];
 			for (const line of renderedLines) {

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -500,35 +500,46 @@ export class Markdown implements Component {
 			wrappedLines = [];
 			const spans: Array<ViewportAnchorSpan | null> = [];
 			for (const boundary of tokenBoundaries) {
-				// Wrap this token's rendered lines exactly as the plain path does, so
-				// the emitted `lines` stay byte-identical to render().
-				const tokenWrapped: string[] = [];
-				for (let r = boundary.start; r < boundary.end; r++) {
-					const line = renderedLines[r];
-					if (TERMINAL.isImageLine(line)) tokenWrapped.push(line);
-					else tokenWrapped.push(...wrapTextIfNeeded(line, contentWidth));
-				}
-				// Distribute the token's width-invariant source-text band across its
-				// content rows. A content row's anchor identifies the same source
-				// position at any width, so the row survives topology-changing reflow.
-				// Blank, decoration-only whitespace, and image rows carry no anchor.
-				const contentRows: number[] = [];
-				for (let r = 0; r < tokenWrapped.length; r++) {
-					const line = tokenWrapped[r];
-					if (!TERMINAL.isImageLine(line) && Bun.stripANSI(line).trim().length > 0) contentRows.push(r);
-				}
+				// Number this token's width-invariant source-text band [lo, hi) over its
+				// rendered lines (pre-wrap) rather than over the width-dependent count of
+				// final content rows. Each pre-wrap rendered line is a stable structural
+				// unit — a list item, a quoted line, a table row-line — so an earlier
+				// line's sub-band no longer moves when a *later* line of the same
+				// top-level token rewraps into more rows. That within-token drift was the
+				// P2 the first #2031 pass reintroduced: a page-down anchor pinned to list
+				// item 1 slid into item 2 once item 2 rewrapped, because both shared one
+				// content-row count that the later item inflated.
 				const lo = boundary.srcLo * ANCHOR_SOURCE_SCALE;
 				const hi = boundary.srcHi * ANCHOR_SOURCE_SCALE;
-				const rowSpans: Array<ViewportAnchorSpan | null> = new Array(tokenWrapped.length).fill(null);
-				const count = contentRows.length;
-				for (let c = 0; c < count; c++) {
-					const start = lo + Math.floor((c * (hi - lo)) / count);
-					const end = c === count - 1 ? hi : lo + Math.floor(((c + 1) * (hi - lo)) / count);
-					rowSpans[contentRows[c]] = { graphemeStart: start, graphemeEnd: end, cellStart: start, cellEnd: end };
-				}
-				for (let r = 0; r < tokenWrapped.length; r++) {
-					wrappedLines.push(tokenWrapped[r]);
-					spans.push(rowSpans[r]);
+				const lineCount = boundary.end - boundary.start;
+				for (let li = 0; li < lineCount; li++) {
+					const renderedLine = renderedLines[boundary.start + li];
+					// Each rendered line reserves its own non-overlapping sub-band.
+					const lineLo = lo + Math.floor((li * (hi - lo)) / lineCount);
+					const lineHi = li === lineCount - 1 ? hi : lo + Math.floor(((li + 1) * (hi - lo)) / lineCount);
+					// Wrap this rendered line exactly as the plain path does, so the
+					// emitted `lines` stay byte-identical to render().
+					const lineWrapped = TERMINAL.isImageLine(renderedLine)
+						? [renderedLine]
+						: wrapTextIfNeeded(renderedLine, contentWidth);
+					// Distribute the line's sub-band across its content rows. Blank,
+					// decoration-only whitespace, and image rows carry no anchor.
+					const contentRows: number[] = [];
+					for (let r = 0; r < lineWrapped.length; r++) {
+						const l = lineWrapped[r];
+						if (!TERMINAL.isImageLine(l) && Bun.stripANSI(l).trim().length > 0) contentRows.push(r);
+					}
+					const rowSpans: Array<ViewportAnchorSpan | null> = new Array(lineWrapped.length).fill(null);
+					const count = contentRows.length;
+					for (let c = 0; c < count; c++) {
+						const start = lineLo + Math.floor((c * (lineHi - lineLo)) / count);
+						const end = c === count - 1 ? lineHi : lineLo + Math.floor(((c + 1) * (lineHi - lineLo)) / count);
+						rowSpans[contentRows[c]] = { graphemeStart: start, graphemeEnd: end, cellStart: start, cellEnd: end };
+					}
+					for (let r = 0; r < lineWrapped.length; r++) {
+						wrappedLines.push(lineWrapped[r]);
+						spans.push(rowSpans[r]);
+					}
 				}
 			}
 			wrappedSpans = spans;

--- a/packages/tui/test/markdown-anchor-reflow.test.ts
+++ b/packages/tui/test/markdown-anchor-reflow.test.ts
@@ -46,6 +46,28 @@ function expectAnchorSurvivesReflow(text: string, needle: string, from: number, 
 	expect(resolveRow(target.anchors, stored), `${needle} drifted ${from}->${to}`).toBe(targetRow);
 }
 
+// The page-down capture (see TUI.scrollViewportPages) stores the END of the
+// pinned row's span (max(graphemeStart, graphemeEnd - 1)), not its start. That
+// exposes within-token drift a start-of-row capture masks: an earlier row's span
+// end must not migrate into a later sibling row when that sibling rewraps.
+function expectPageDownAnchorSurvivesReflow(text: string, needle: string, from: number, to: number, id: string): void {
+	const source = render(text, from, id);
+	const sourceRow = rowWithText(source.lines, needle);
+	expect(sourceRow, `${needle} missing at width ${from}`).toBeGreaterThanOrEqual(0);
+	const anchor = source.anchors[sourceRow];
+	if (!anchor) throw new Error(`${needle} row carried no anchor at width ${from}`);
+	const stored = {
+		id,
+		graphemeIndex: Math.max(anchor.graphemeStart, anchor.graphemeEnd - 1),
+		cellOffset: Math.max(anchor.cellStart, anchor.cellEnd - 1),
+	};
+
+	const target = render(text, to, id);
+	const targetRow = rowWithText(target.lines, needle);
+	expect(targetRow, `${needle} missing at width ${to}`).toBeGreaterThanOrEqual(0);
+	expect(resolveRow(target.anchors, stored), `${needle} drifted ${from}->${to}`).toBe(targetRow);
+}
+
 function assertAnchorContract(anchors: Array<ViewportAnchorRow | null>): void {
 	const present = anchors.filter((anchor): anchor is ViewportAnchorRow => anchor !== null);
 	expect(present.length).toBeGreaterThan(1);
@@ -91,6 +113,15 @@ const TABLE_DOC = [
 	"TARGET paragraph immediately after the table block",
 ].join("\n");
 
+// A two-item bullet list is a single top-level token. The first item is short
+// (one row at every width); the second is long and rewraps into several rows as
+// the terminal narrows. A page-down anchor pinned on the first item must not
+// drift into the second when the second item rewraps.
+const LIST_DOC = [
+	"- ITEMONE",
+	"- ITEMTWO followed by lots and lots of extra words that will wrap into several rows once the terminal is narrow enough to force multiple line wrapping here",
+].join("\n");
+
 describe("markdown viewport anchors across topology-changing reflow (#2031)", () => {
 	it("keeps the post-HR paragraph anchored wide<->narrow", () => {
 		expectAnchorSurvivesReflow(HR_DOC, "TARGET", 100, 24, "hr");
@@ -111,8 +142,16 @@ describe("markdown viewport anchors across topology-changing reflow (#2031)", ()
 		expectAnchorSurvivesReflow(TABLE_DOC, "TARGET", 100, 24, "tbl");
 	});
 
+	it("keeps an earlier list item pinned when a later item rewraps (page-down capture)", () => {
+		// At width 120 both items occupy one row; at width 30 the second item wraps
+		// across several rows. The page-down capture stores ITEMONE's span end, which
+		// must resolve back to ITEMONE — not slide into ITEMTWO — after the reflow.
+		expectPageDownAnchorSurvivesReflow(LIST_DOC, "ITEMONE", 120, 30, "list");
+		expectPageDownAnchorSurvivesReflow(LIST_DOC, "ITEMONE", 30, 120, "list");
+	});
+
 	it("preserves the monotonic, non-overlapping anchor contract and leaks no markers", () => {
-		for (const doc of [HR_DOC, BLOCKQUOTE_DOC, TABLE_DOC]) {
+		for (const doc of [HR_DOC, BLOCKQUOTE_DOC, TABLE_DOC, LIST_DOC]) {
 			for (const width of [100, 40, 24, 10]) {
 				const rendered = render(doc, width, "contract");
 				expect(rendered.anchors.length).toBe(rendered.lines.length);
@@ -125,7 +164,7 @@ describe("markdown viewport anchors across topology-changing reflow (#2031)", ()
 	});
 
 	it("keeps anchor lines byte-identical to the plain render", () => {
-		for (const doc of [HR_DOC, BLOCKQUOTE_DOC, TABLE_DOC]) {
+		for (const doc of [HR_DOC, BLOCKQUOTE_DOC, TABLE_DOC, LIST_DOC]) {
 			for (const width of [100, 40, 24, 10]) {
 				const md = new Markdown(doc, 0, 0, defaultMarkdownTheme);
 				const withAnchors = md.renderWithViewportAnchorSource(width, { id: "parity" });

--- a/packages/tui/test/markdown-anchor-reflow.test.ts
+++ b/packages/tui/test/markdown-anchor-reflow.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "bun:test";
+import { Container, Markdown, TUI, VIEWPORT_ANCHOR_PREFIX, type ViewportAnchorRow } from "@gajae-code/tui";
+import { defaultMarkdownTheme } from "./test-themes";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// Mirrors TUI #resolveManualAnchor: find the row whose span contains the stored
+// (graphemeIndex, cellOffset) for the matching source id.
+function resolveRow(
+	anchors: Array<ViewportAnchorRow | null>,
+	stored: { id: string; graphemeIndex: number; cellOffset: number },
+): number {
+	return anchors.findIndex(
+		candidate =>
+			candidate !== null &&
+			candidate.id === stored.id &&
+			candidate.graphemeStart <= stored.graphemeIndex &&
+			stored.graphemeIndex < candidate.graphemeEnd &&
+			candidate.cellStart <= stored.cellOffset &&
+			stored.cellOffset < candidate.cellEnd,
+	);
+}
+
+function rowWithText(lines: string[], needle: string): number {
+	return lines.findIndex(line => Bun.stripANSI(line).includes(needle));
+}
+
+function render(text: string, width: number, id: string) {
+	return new Markdown(text, 0, 0, defaultMarkdownTheme).renderWithViewportAnchorSource(width, { id });
+}
+
+// Render at two widths and assert that the anchor captured for `needle` at the
+// source width resolves back to the same logical row at the target width — i.e.
+// a topology-changing reflow does not drift the anchor to unrelated content or
+// drop it entirely (which would strand a stale viewport).
+function expectAnchorSurvivesReflow(text: string, needle: string, from: number, to: number, id: string): void {
+	const source = render(text, from, id);
+	const sourceRow = rowWithText(source.lines, needle);
+	expect(sourceRow, `${needle} missing at width ${from}`).toBeGreaterThanOrEqual(0);
+	const anchor = source.anchors[sourceRow];
+	if (!anchor) throw new Error(`${needle} row carried no anchor at width ${from}`);
+	const stored = { id, graphemeIndex: anchor.graphemeStart, cellOffset: anchor.cellStart };
+
+	const target = render(text, to, id);
+	const targetRow = rowWithText(target.lines, needle);
+	expect(targetRow, `${needle} missing at width ${to}`).toBeGreaterThanOrEqual(0);
+	expect(resolveRow(target.anchors, stored), `${needle} drifted ${from}->${to}`).toBe(targetRow);
+}
+
+function assertAnchorContract(anchors: Array<ViewportAnchorRow | null>): void {
+	const present = anchors.filter((anchor): anchor is ViewportAnchorRow => anchor !== null);
+	expect(present.length).toBeGreaterThan(1);
+	expect(present[0].graphemeStart).toBe(0);
+	for (let index = 0; index < present.length; index++) {
+		const anchor = present[index];
+		expect(anchor.graphemeEnd).toBeGreaterThan(anchor.graphemeStart);
+		expect(anchor.cellEnd).toBeGreaterThan(anchor.cellStart);
+		if (index > 0) {
+			expect(anchor.graphemeStart).toBeGreaterThanOrEqual(present[index - 1].graphemeEnd);
+			expect(anchor.cellStart).toBeGreaterThanOrEqual(present[index - 1].cellEnd);
+		}
+	}
+}
+
+const HR_DOC = [
+	"intro paragraph with several words so it wraps when narrow",
+	"",
+	"---",
+	"",
+	"TARGET paragraph immediately after the horizontal rule",
+	"",
+	"trailing paragraph with several words so it also wraps",
+].join("\n");
+
+const BLOCKQUOTE_DOC = [
+	"lead paragraph with several words so it wraps when the terminal narrows",
+	"",
+	"> quoted line one with several words that rewrap across widths",
+	"> quoted line two with several words that rewrap across widths",
+	"",
+	"TARGET paragraph immediately after the blockquote block",
+].join("\n");
+
+const TABLE_DOC = [
+	"heading paragraph with several words so it wraps when narrow",
+	"",
+	"| Column Alpha | Column Beta |",
+	"| --- | --- |",
+	"| alpha one | beta one |",
+	"| alpha two | beta two |",
+	"",
+	"TARGET paragraph immediately after the table block",
+].join("\n");
+
+describe("markdown viewport anchors across topology-changing reflow (#2031)", () => {
+	it("keeps the post-HR paragraph anchored wide<->narrow", () => {
+		expectAnchorSurvivesReflow(HR_DOC, "TARGET", 100, 24, "hr");
+		expectAnchorSurvivesReflow(HR_DOC, "TARGET", 24, 100, "hr");
+		expectAnchorSurvivesReflow(HR_DOC, "TARGET", 80, 40, "hr");
+	});
+
+	it("keeps the post-blockquote paragraph anchored wide<->narrow", () => {
+		expectAnchorSurvivesReflow(BLOCKQUOTE_DOC, "TARGET", 100, 20, "bq");
+		expectAnchorSurvivesReflow(BLOCKQUOTE_DOC, "TARGET", 20, 100, "bq");
+	});
+
+	it("keeps the post-table paragraph anchored across boxed<->fallback reflow", () => {
+		// width 10 forces the raw-markdown table fallback; width 100 renders boxed.
+		expectAnchorSurvivesReflow(TABLE_DOC, "TARGET", 100, 10, "tbl");
+		expectAnchorSurvivesReflow(TABLE_DOC, "TARGET", 10, 100, "tbl");
+		// boxed->boxed with cell rewrap (the off-by-one drift from the report).
+		expectAnchorSurvivesReflow(TABLE_DOC, "TARGET", 100, 24, "tbl");
+	});
+
+	it("preserves the monotonic, non-overlapping anchor contract and leaks no markers", () => {
+		for (const doc of [HR_DOC, BLOCKQUOTE_DOC, TABLE_DOC]) {
+			for (const width of [100, 40, 24, 10]) {
+				const rendered = render(doc, width, "contract");
+				expect(rendered.anchors.length).toBe(rendered.lines.length);
+				const joined = rendered.lines.join("");
+				expect(joined).not.toContain(VIEWPORT_ANCHOR_PREFIX);
+				expect(joined).not.toContain("GJC_ANCHOR");
+				assertAnchorContract(rendered.anchors);
+			}
+		}
+	});
+
+	it("keeps anchor lines byte-identical to the plain render", () => {
+		for (const doc of [HR_DOC, BLOCKQUOTE_DOC, TABLE_DOC]) {
+			for (const width of [100, 40, 24, 10]) {
+				const md = new Markdown(doc, 0, 0, defaultMarkdownTheme);
+				const withAnchors = md.renderWithViewportAnchorSource(width, { id: "parity" });
+				expect(withAnchors.lines).toEqual(new Markdown(doc, 0, 0, defaultMarkdownTheme).render(width));
+			}
+		}
+	});
+});
+
+class MarkdownTranscript extends Container {
+	constructor(text: string, id: string) {
+		super();
+		const markdown = new Markdown(text, 0, 0, defaultMarkdownTheme);
+		this.addChild(markdown);
+		this.setViewportAnchorSource(markdown, { id });
+	}
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await term.waitForRender();
+}
+
+function visible(term: VirtualTerminal): string[] {
+	return term.getViewport().map(line => line.trimEnd());
+}
+
+describe("TUI holds a Markdown viewport anchor across resize reflow (#2031)", () => {
+	// A short, unwrappable marker after each topology element must stay pinned to
+	// the same screen row while the width-dependent decoration above it reflows.
+	const doc = [
+		...Array.from({ length: 6 }, (_v, i) => `filler paragraph number ${i} with enough words to rewrap when narrow`),
+		"| Column Alpha | Column Beta |",
+		"| --- | --- |",
+		"| alpha one | beta one |",
+		"| alpha two | beta two |",
+		"> quoted context line with several words that rewrap across widths",
+		"---",
+		"ANCHORXYZ",
+		"tail-one",
+		"tail-two",
+	].join("\n\n");
+
+	it("pins a post-topology marker to a fixed screen row through a resize sweep", async () => {
+		const term = new VirtualTerminal(72, 6);
+		const tui = new TUI(term);
+		const transcript = new MarkdownTranscript(doc, "reflow");
+		tui.addChild(transcript);
+		tui.setViewportAnchorComponent(transcript);
+		try {
+			tui.start();
+			await settle(term);
+			expect(visible(term).some(line => line.includes("ANCHORXYZ"))).toBe(true);
+			expect(tui.scrollViewportPages(1)).toBe(true);
+			await term.flush();
+			const targetScreenRow = visible(term).findIndex(line => line.includes("ANCHORXYZ"));
+			expect(targetScreenRow).toBeGreaterThanOrEqual(0);
+			for (const width of [40, 60, 24, 50, 30]) {
+				term.resize(width, 6);
+				await settle(term);
+				expect(visible(term)[targetScreenRow], `width=${width}`).toContain("ANCHORXYZ");
+			}
+		} finally {
+			tui.stop();
+		}
+	});
+});

--- a/packages/tui/test/markdown-anchor-reflow.test.ts
+++ b/packages/tui/test/markdown-anchor-reflow.test.ts
@@ -122,6 +122,24 @@ const LIST_DOC = [
 	"- ITEMTWO followed by lots and lots of extra words that will wrap into several rows once the terminal is narrow enough to force multiple line wrapping here",
 ].join("\n");
 
+// A table is one top-level token; its rows are the width-invariant source units.
+// The second data cell is long and rewraps into several rows as the terminal
+// narrows. A page-down anchor pinned on the header must not drift into a data row.
+const TABLE_ROWS_DOC = [
+	"| HEADA | HEADB |",
+	"| --- | --- |",
+	"| shortcell | a very long cell body with lots and lots of extra words to force wrapping across several rows once the terminal narrows indeed yes more here |",
+].join("\n");
+
+// A blockquote with two separate paragraph blocks (blank quoted line between).
+// The second block rewraps as the terminal narrows; a page-down anchor pinned on
+// the first block must not drift into the second.
+const MULTIBLOCK_QUOTE_DOC = [
+	"> QHEAD",
+	">",
+	"> QTAIL second quoted paragraph with lots and lots of extra words that wrap into several rows once the terminal is narrow enough to force wrapping here indeed",
+].join("\n");
+
 describe("markdown viewport anchors across topology-changing reflow (#2031)", () => {
 	it("keeps the post-HR paragraph anchored wide<->narrow", () => {
 		expectAnchorSurvivesReflow(HR_DOC, "TARGET", 100, 24, "hr");
@@ -150,8 +168,17 @@ describe("markdown viewport anchors across topology-changing reflow (#2031)", ()
 		expectPageDownAnchorSurvivesReflow(LIST_DOC, "ITEMONE", 30, 120, "list");
 	});
 
+	it("keeps an earlier table row / quote block pinned when a later one rewraps (page-down capture)", () => {
+		// A table header must not slide into a data row when a data cell rewraps.
+		expectPageDownAnchorSurvivesReflow(TABLE_ROWS_DOC, "HEADA", 120, 40, "tblrows");
+		expectPageDownAnchorSurvivesReflow(TABLE_ROWS_DOC, "HEADA", 40, 120, "tblrows");
+		// The first quote block must not slide into the second when the second rewraps.
+		expectPageDownAnchorSurvivesReflow(MULTIBLOCK_QUOTE_DOC, "QHEAD", 120, 30, "bqblocks");
+		expectPageDownAnchorSurvivesReflow(MULTIBLOCK_QUOTE_DOC, "QHEAD", 30, 120, "bqblocks");
+	});
+
 	it("preserves the monotonic, non-overlapping anchor contract and leaks no markers", () => {
-		for (const doc of [HR_DOC, BLOCKQUOTE_DOC, TABLE_DOC, LIST_DOC]) {
+		for (const doc of [HR_DOC, BLOCKQUOTE_DOC, TABLE_DOC, LIST_DOC, TABLE_ROWS_DOC, MULTIBLOCK_QUOTE_DOC]) {
 			for (const width of [100, 40, 24, 10]) {
 				const rendered = render(doc, width, "contract");
 				expect(rendered.anchors.length).toBe(rendered.lines.length);
@@ -164,7 +191,7 @@ describe("markdown viewport anchors across topology-changing reflow (#2031)", ()
 	});
 
 	it("keeps anchor lines byte-identical to the plain render", () => {
-		for (const doc of [HR_DOC, BLOCKQUOTE_DOC, TABLE_DOC, LIST_DOC]) {
+		for (const doc of [HR_DOC, BLOCKQUOTE_DOC, TABLE_DOC, LIST_DOC, TABLE_ROWS_DOC, MULTIBLOCK_QUOTE_DOC]) {
 			for (const width of [100, 40, 24, 10]) {
 				const md = new Markdown(doc, 0, 0, defaultMarkdownTheme);
 				const withAnchors = md.renderWithViewportAnchorSource(width, { id: "parity" });


### PR DESCRIPTION
## Summary

Fixes #2031. Markdown viewport anchors were numbered over the **width-dependent rendered glyph stream**, so a resize that changed block topology — horizontal-rule fill length, per-row blockquote prefixes, or boxed vs. raw-fallback table layout — renumbered the anchors and drifted the pinned scroll position onto unrelated content (or stranded a stale viewport).

This numbers anchors over each top-level token's **width-invariant source-text span** instead. Each token reserves a band from the cumulative marked-token `raw` lengths (scaled by `ANCHOR_SOURCE_SCALE` so every content row gets a positive, non-overlapping sub-span even when a token wraps into more rows than its source has characters), then distributes that band across the token's content rows. Blank, decoration-only, and image rows carry no anchor. The emitted `lines` stay **byte-identical** to `render()`; only the anchor spans change.

## Changes

- `packages/tui/src/components/markdown.ts` — token-aware, source-text-span anchor numbering; drops the marker-injection path for markdown.
- `packages/tui/test/markdown-anchor-reflow.test.ts` — new regression suite.

## Verification

- New suite: **6/6 pass**. Red-on-regression confirmed (pre-fix `markdown.ts` fails 3/6 anchor-drift cases; fix passes 6/6).
- Related markdown/viewport suites: **121/121 pass**.
- `tsc --noEmit` clean; biome clean.
- Live TUI `VirtualTerminal` resize sweep (widths 40/60/24/50/30) keeps a post-topology marker pinned to a fixed screen row with no marker leakage.

Rebased onto current `dev`.

Signed-off-by: Yeachan-Heo <hurrc04@gmail.com>
