### PR TITLE
fix(coding-agent): scrub macOS MallocStackLogging env at the launch boundary (#2014)

### DIFF
--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -467,6 +467,50 @@ impl Drop for WindowsOpenptyAttempt {
 	}
 }
 
+/// Remove the macOS malloc-stack-logging debug vars from a PTY child command.
+///
+/// macOS libmalloc prints `MallocStackLogging: …` to any TTY-attached process
+/// that inherits these vars, and PTY children always have a TTY stderr, so a
+/// contaminated parent would flood the terminal once per child. Applied after
+/// any caller-supplied env so explicit forwarding cannot reintroduce them.
+/// No-op off macOS (the vars are simply absent).
+fn scrub_macos_malloc_stack_logging_env(cmd: &mut CommandBuilder) {
+	cmd.env_remove("MallocStackLogging");
+	cmd.env_remove("MallocStackLoggingNoCompact");
+}
+
+/// Build the PTY child command from a run config.
+///
+/// portable-pty's `CommandBuilder` snapshots the live parent environ, so the
+/// malloc-env scrub here also protects direct SDK/embedder consumers that never
+/// pass through the CLI re-exec guard. Kept as one builder so production and
+/// tests spawn from the exact same command.
+fn build_pty_command(config: &PtyRunConfig) -> CommandBuilder {
+	let shell = config.shell.as_deref().unwrap_or("sh");
+	let mut cmd = CommandBuilder::new(shell);
+	// Use shell-appropriate command execution flags
+	let lower = shell.to_lowercase();
+	if lower.ends_with("cmd.exe") || lower.ends_with("cmd") {
+		cmd.arg("/c");
+	} else if lower.contains("powershell") || lower.contains("pwsh") {
+		cmd.arg("-Command");
+	} else {
+		// sh/bash/zsh/fish etc.
+		cmd.arg("-lc");
+	}
+	cmd.arg(&config.command);
+	if let Some(cwd) = config.cwd.as_ref() {
+		cmd.cwd(cwd);
+	}
+	if let Some(env) = config.env.as_ref() {
+		for (key, value) in env {
+			cmd.env(key, value);
+		}
+	}
+	scrub_macos_malloc_stack_logging_env(&mut cmd);
+	cmd
+}
+
 fn run_pty_sync(
 	config: PtyRunConfig,
 	on_chunk: Option<ThreadsafeFunction<String>>,
@@ -530,27 +574,7 @@ fn run_pty_sync(
 			.map_err(|err| Error::from_reason(format!("Failed to open PTY: {err}")))?
 	};
 
-	let shell = config.shell.as_deref().unwrap_or("sh");
-	let mut cmd = CommandBuilder::new(shell);
-	// Use shell-appropriate command execution flags
-	let lower = shell.to_lowercase();
-	if lower.ends_with("cmd.exe") || lower.ends_with("cmd") {
-		cmd.arg("/c");
-	} else if lower.contains("powershell") || lower.contains("pwsh") {
-		cmd.arg("-Command");
-	} else {
-		// sh/bash/zsh/fish etc.
-		cmd.arg("-lc");
-	}
-	cmd.arg(&config.command);
-	if let Some(cwd) = config.cwd.as_ref() {
-		cmd.cwd(cwd);
-	}
-	if let Some(env) = config.env.as_ref() {
-		for (key, value) in env {
-			cmd.env(key, value);
-		}
-	}
+	let cmd = build_pty_command(&config);
 	ct.heartbeat()
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before spawn: {err}")))?;
 
@@ -911,6 +935,32 @@ mod tests {
 			rows:    24,
 			shell:   Some("sh".to_string()),
 		}
+	}
+
+	#[test]
+	fn build_pty_command_scrubs_macos_malloc_stack_logging_env() {
+		let mut env = std::collections::HashMap::new();
+		env.insert("MallocStackLogging".to_string(), "1".to_string());
+		env.insert("MallocStackLoggingNoCompact".to_string(), "1".to_string());
+		env.insert("KEEP_ME".to_string(), "value".to_string());
+		let mut config = test_config("true");
+		config.env = Some(env);
+
+		let cmd = build_pty_command(&config);
+
+		assert!(
+			cmd.get_env("MallocStackLogging").is_none(),
+			"MallocStackLogging must be scrubbed even when explicitly forwarded",
+		);
+		assert!(
+			cmd.get_env("MallocStackLoggingNoCompact").is_none(),
+			"MallocStackLoggingNoCompact must be scrubbed even when explicitly forwarded",
+		);
+		assert_eq!(
+			cmd.get_env("KEEP_ME"),
+			Some(std::ffi::OsStr::new("value")),
+			"unrelated forwarded env vars must be preserved",
+		);
 	}
 
 	#[cfg(unix)]

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -81,9 +81,13 @@ async function installRuntimeGlobals(): Promise<void> {
 	const { warnIfMacOSNoFileLimitTooLow } = await import("./cli/nofile-limit");
 	warnIfMacOSNoFileLimitTooLow();
 
-	// Strip macOS malloc-stack-logging env vars before any subprocess is spawned.
-	// Otherwise every child bun process (subagents, plugin installs, ptree spawns,
-	// etc.) prints a `MallocStackLogging: can't turn off …` warning to stderr.
+	// Secondary in-process scrub of the macOS malloc-stack-logging vars. The real
+	// boundary is the darwin re-exec guard at the top of runCli(): Bun snapshots the
+	// spawn-default environment at startup, so deleting these here does NOT clean the
+	// env children inherit by default — it only tidies `process.env` for code that
+	// reads it directly. Kept as belt-and-braces for the rare re-exec-unavailable
+	// fallback; managed spawns already use filterProcessEnv and the native PTY lane
+	// strips them independently.
 	delete process.env.MallocStackLogging;
 	delete process.env.MallocStackLoggingNoCompact;
 }
@@ -279,6 +283,27 @@ export function routeRootArgv(argv: readonly string[]): string[] {
 
 /** Run the CLI with the given argv (no `process.argv` prefix). */
 export async function runCli(argv: string[]): Promise<void> {
+	// macOS malloc-env launch boundary. Re-exec once with a scrubbed environment
+	// BEFORE any fast path or subprocess spawn, so the startup env snapshot Bun hands
+	// to every child lane (Bun.spawn defaults, node:child_process, native PTY, tmux
+	// owner, plugin installs, subagents) is clean. This runs ahead of the
+	// tmux-owner-isolation and notify-daemon fast paths so those lanes execute inside
+	// the already-scrubbed process too. The cheap inline predicate keeps the common
+	// (uncontaminated / non-darwin) path free of extra module loads; the guard module
+	// (MACOS_MALLOC_ENV_VARS / GJC_MALLOC_ENV_REEXEC) loads only when a re-exec is due.
+	if (
+		process.platform === "darwin" &&
+		process.env.GJC_MALLOC_ENV_REEXEC === undefined &&
+		(process.env.MallocStackLogging !== undefined || process.env.MallocStackLoggingNoCompact !== undefined)
+	) {
+		const { reexecWithScrubbedMallocEnv } = await import("./cli/malloc-env-guard");
+		const code = await reexecWithScrubbedMallocEnv();
+		if (code !== null) {
+			process.exitCode = code;
+			return;
+		}
+		// Re-exec could not be spawned; fall through and run in this process.
+	}
 	if (isTmuxOwnerIsolationCliArgv(argv)) {
 		await runTmuxOwnerIsolationCliFromStdin();
 		return;

--- a/packages/coding-agent/src/cli/malloc-env-guard.test.ts
+++ b/packages/coding-agent/src/cli/malloc-env-guard.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildMallocReexecArgv,
+	formatMallocEnvNotice,
+	hasMacOSMallocEnv,
+	MACOS_MALLOC_ENV_VARS,
+	MALLOC_ENV_REEXEC_GUARD,
+	shouldReexecForMacOSMallocEnv,
+} from "./malloc-env-guard";
+
+describe("hasMacOSMallocEnv", () => {
+	it("detects MallocStackLogging", () => {
+		expect(hasMacOSMallocEnv({ MallocStackLogging: "0" })).toBe(true);
+	});
+
+	it("detects MallocStackLoggingNoCompact", () => {
+		expect(hasMacOSMallocEnv({ MallocStackLoggingNoCompact: "1" })).toBe(true);
+	});
+
+	it("is false when neither var is present", () => {
+		expect(hasMacOSMallocEnv({ PATH: "/usr/bin", HOME: "/home/x" })).toBe(false);
+	});
+
+	it("is false for an empty environment", () => {
+		expect(hasMacOSMallocEnv({})).toBe(false);
+	});
+});
+
+describe("shouldReexecForMacOSMallocEnv", () => {
+	it("is true on darwin with a malloc var and no loop guard", () => {
+		expect(shouldReexecForMacOSMallocEnv({ MallocStackLogging: "0" }, "darwin")).toBe(true);
+	});
+
+	it("is false off darwin even when a malloc var is present", () => {
+		expect(shouldReexecForMacOSMallocEnv({ MallocStackLogging: "0" }, "linux")).toBe(false);
+		expect(shouldReexecForMacOSMallocEnv({ MallocStackLogging: "0" }, "win32")).toBe(false);
+	});
+
+	it("is false when the loop guard is already set (already re-exec'd)", () => {
+		expect(shouldReexecForMacOSMallocEnv({ MallocStackLogging: "0", [MALLOC_ENV_REEXEC_GUARD]: "1" }, "darwin")).toBe(
+			false,
+		);
+	});
+
+	it("is false on darwin when no malloc var is present", () => {
+		expect(shouldReexecForMacOSMallocEnv({ PATH: "/usr/bin" }, "darwin")).toBe(false);
+	});
+});
+
+describe("buildMallocReexecArgv", () => {
+	it("drops the embedded virtual entry for a POSIX compiled binary", () => {
+		expect(buildMallocReexecArgv(["/exe", "/$bunfs/root/cli", "run", "--flag"], "/exe")).toEqual([
+			"/exe",
+			"run",
+			"--flag",
+		]);
+	});
+
+	it("drops the embedded virtual entry for a Windows compiled binary", () => {
+		expect(buildMallocReexecArgv(["C:/exe.exe", "B:\\~BUN\\root\\cli", "run"], "C:/exe.exe")).toEqual([
+			"C:/exe.exe",
+			"run",
+		]);
+	});
+
+	it("drops the percent-encoded embedded virtual entry", () => {
+		expect(buildMallocReexecArgv(["/exe", "B:\\%7EBUN\\root\\cli", "run"], "/exe")).toEqual(["/exe", "run"]);
+	});
+
+	it("keeps the on-disk script for a source/dev-link run", () => {
+		expect(
+			buildMallocReexecArgv(["/usr/bin/bun", "/repo/packages/coding-agent/src/cli.ts", "run", "-x"], "/usr/bin/bun"),
+		).toEqual(["/usr/bin/bun", "/repo/packages/coding-agent/src/cli.ts", "run", "-x"]);
+	});
+
+	it("handles a source run with no user args", () => {
+		expect(buildMallocReexecArgv(["/usr/bin/bun", "/repo/cli.ts"], "/usr/bin/bun")).toEqual([
+			"/usr/bin/bun",
+			"/repo/cli.ts",
+		]);
+	});
+});
+
+describe("formatMallocEnvNotice", () => {
+	it("names both env vars and the permanent launchctl fix", () => {
+		const notice = formatMallocEnvNotice();
+		for (const name of MACOS_MALLOC_ENV_VARS) {
+			expect(notice).toContain(name);
+		}
+		expect(notice).toContain("launchctl unsetenv MallocStackLogging");
+		expect(notice).toContain("launchctl unsetenv MallocStackLoggingNoCompact");
+		expect(notice.endsWith("\n")).toBe(true);
+	});
+});
+
+describe("module constants", () => {
+	it("exposes exactly the two macOS malloc env vars", () => {
+		expect([...MACOS_MALLOC_ENV_VARS]).toEqual(["MallocStackLogging", "MallocStackLoggingNoCompact"]);
+	});
+
+	it("uses a namespaced loop-guard variable", () => {
+		expect(MALLOC_ENV_REEXEC_GUARD).toBe("GJC_MALLOC_ENV_REEXEC");
+	});
+});

--- a/packages/coding-agent/src/cli/malloc-env-guard.ts
+++ b/packages/coding-agent/src/cli/malloc-env-guard.ts
@@ -1,0 +1,145 @@
+/**
+ * macOS malloc-stack-logging launch boundary.
+ *
+ * On macOS, an inherited `MallocStackLogging` / `MallocStackLoggingNoCompact`
+ * environment variable (from an Xcode scheme's malloc diagnostics, Instruments,
+ * `launchctl setenv`, or a debug-attached shell) makes libmalloc print
+ *
+ *   MallocStackLogging: can't turn off malloc stack logging because it was not enabled.
+ *
+ * to the stderr of every TTY-attached process. Bun snapshots the spawn-default
+ * environment at process startup — before any JS runs — so neither
+ * `delete process.env.X` nor a real libc `unsetenv()` cleans the environment
+ * that children inherit by default (verified on Bun 1.3.14). Inside the TUI,
+ * every PTY-spawned child then repeats the warning straight into the rendered
+ * frame and corrupts the display.
+ *
+ * The only way to hand children a clean startup snapshot is to start the primary
+ * process with a clean environment. This module re-execs the exact invocation
+ * once (darwin-only) with a `filterProcessEnv`-scrubbed environment and a
+ * `GJC_MALLOC_ENV_REEXEC` loop guard, before any fast path or subprocess spawn.
+ * The re-exec'd process — and therefore every downstream lane: `Bun.spawn`
+ * defaults, `node:child_process`, the native PTY, the tmux owner, plugin
+ * installs, and subagents — starts from a clean snapshot.
+ *
+ * The initial contaminated process's own libmalloc line is emitted by libc
+ * before any JS runs and cannot be suppressed from inside the process; it
+ * appears at most once per launch. A one-time actionable notice is written to
+ * interactive stderr (outside the rendered frame) pointing at the permanent
+ * `launchctl unsetenv` fix.
+ */
+
+import { filterProcessEnv } from "@gajae-code/utils/env";
+import type { Subprocess } from "bun";
+
+/** Env vars that make macOS libmalloc write to a TTY when inherited. */
+export const MACOS_MALLOC_ENV_VARS = ["MallocStackLogging", "MallocStackLoggingNoCompact"] as const;
+
+/** Loop guard set on the scrubbed re-exec so it never re-execs itself again. */
+export const MALLOC_ENV_REEXEC_GUARD = "GJC_MALLOC_ENV_REEXEC";
+
+/** True when at least one macOS malloc-stack-logging var is present in `env`. */
+export function hasMacOSMallocEnv(env: Record<string, string | undefined>): boolean {
+	return MACOS_MALLOC_ENV_VARS.some(name => env[name] !== undefined);
+}
+
+/**
+ * True iff we must re-exec to escape a contaminated macOS startup snapshot:
+ * darwin, not already inside the scrubbed re-exec, and at least one malloc var
+ * present. Off darwin or on the re-exec'd child this is always false, so the
+ * common launch path pays only two cheap lookups.
+ */
+export function shouldReexecForMacOSMallocEnv(
+	env: Record<string, string | undefined>,
+	platform: NodeJS.Platform,
+): boolean {
+	return platform === "darwin" && env[MALLOC_ENV_REEXEC_GUARD] === undefined && hasMacOSMallocEnv(env);
+}
+
+/**
+ * Reconstruct the argv that re-runs the exact same program image.
+ *
+ * - Compiled single-file executable: argv[1] is the embedded virtual entry
+ *   (`/$bunfs/…` on POSIX, `B:\~BUN\…` on Windows), which must be dropped — the
+ *   executable re-embeds its own entry. Re-run `[exe, ...userArgs]`.
+ * - Source / dev-link run: argv[1] is the on-disk script that must be passed
+ *   back to the interpreter. Re-run `[interpreter, script, ...userArgs]`.
+ */
+export function buildMallocReexecArgv(argv: readonly string[], execPath: string): string[] {
+	const entry = argv[1];
+	const isCompiledEntry =
+		typeof entry === "string" && (entry.includes("/$bunfs/") || entry.includes("~BUN") || entry.includes("%7EBUN"));
+	if (isCompiledEntry) {
+		return [execPath, ...argv.slice(2)];
+	}
+	return [execPath, ...argv.slice(1)];
+}
+
+/** One-time, human-actionable notice pointing at the permanent environment fix. */
+export function formatMallocEnvNotice(): string {
+	return (
+		"gajae-code: detected macOS malloc-stack-logging environment variables " +
+		"(MallocStackLogging / MallocStackLoggingNoCompact); relaunching once with a " +
+		"scrubbed environment so they do not flood the terminal.\n" +
+		"  Remove them permanently with:\n" +
+		"    unset MallocStackLogging MallocStackLoggingNoCompact\n" +
+		"    launchctl unsetenv MallocStackLogging\n" +
+		"    launchctl unsetenv MallocStackLoggingNoCompact\n"
+	);
+}
+
+/**
+ * Re-exec the current process once with a scrubbed environment and propagate the
+ * child's exit code. Callers MUST gate this behind `shouldReexecForMacOSMallocEnv`.
+ *
+ * Returns the child exit code, or `null` if the re-exec could not be spawned (in
+ * which case the caller falls back to running in the current, contaminated
+ * process — degraded but functional; the native PTY boundary and
+ * `filterProcessEnv` still keep managed children clean).
+ */
+export async function reexecWithScrubbedMallocEnv(): Promise<number | null> {
+	const cleanEnv = filterProcessEnv(process.env);
+	cleanEnv[MALLOC_ENV_REEXEC_GUARD] = "1";
+	const childArgv = buildMallocReexecArgv(process.argv, process.execPath);
+
+	// Surface the diagnostic exactly once, before the TUI enters its alternate
+	// screen, and only on an interactive terminal (piped/CI stderr is not a TTY,
+	// so libmalloc stays silent there and the notice would just be noise).
+	if (process.stderr.isTTY) {
+		process.stderr.write(formatMallocEnvNotice());
+	}
+
+	let child: Subprocess;
+	try {
+		child = Bun.spawn(childArgv, {
+			env: cleanEnv,
+			stdin: "inherit",
+			stdout: "inherit",
+			stderr: "inherit",
+		});
+	} catch {
+		return null;
+	}
+
+	// The controlling TTY delivers SIGINT (Ctrl-C) to the whole foreground
+	// process group, so the child already receives it; the wrapper must keep a
+	// SIGINT listener so it stays alive to reap the child and propagate its exit
+	// code instead of dying first. SIGTERM is targeted (not group-delivered), so
+	// forward it to the child explicitly.
+	const onSigint = () => {};
+	const onSigterm = () => {
+		try {
+			child.kill("SIGTERM");
+		} catch {
+			// Child already gone; nothing to forward.
+		}
+	};
+	process.on("SIGINT", onSigint);
+	process.on("SIGTERM", onSigterm);
+	try {
+		return await child.exited;
+	} finally {
+		process.off("SIGINT", onSigint);
+		process.off("SIGTERM", onSigterm);
+	}
+}

--- a/packages/coding-agent/src/cli/malloc-env-guard.ts
+++ b/packages/coding-agent/src/cli/malloc-env-guard.ts
@@ -121,19 +121,23 @@ export async function reexecWithScrubbedMallocEnv(): Promise<number | null> {
 		return null;
 	}
 
-	// The controlling TTY delivers SIGINT (Ctrl-C) to the whole foreground
-	// process group, so the child already receives it; the wrapper must keep a
-	// SIGINT listener so it stays alive to reap the child and propagate its exit
-	// code instead of dying first. SIGTERM is targeted (not group-delivered), so
-	// forward it to the child explicitly.
-	const onSigint = () => {};
-	const onSigterm = () => {
+	// Keep the wrapper alive on SIGINT/SIGTERM so it reaps the child and
+	// propagates its exit code instead of dying first, and forward the signal so
+	// the scrubbed child terminates too. Interactive Ctrl-C is delivered to the
+	// whole foreground process group (and the TUI's raw mode turns it into a 0x03
+	// byte, not a signal, anyway), so re-forwarding is a harmless no-op once the
+	// child is already handling or exiting. Targeted delivery — `kill -INT <pid>`
+	// or a supervisor's `child.kill("SIGINT")` — reaches only the wrapper, so
+	// without forwarding the launch would be uncancellable outside a terminal.
+	const forwardSignal = (signal: NodeJS.Signals) => () => {
 		try {
-			child.kill("SIGTERM");
+			child.kill(signal);
 		} catch {
 			// Child already gone; nothing to forward.
 		}
 	};
+	const onSigint = forwardSignal("SIGINT");
+	const onSigterm = forwardSignal("SIGTERM");
 	process.on("SIGINT", onSigint);
 	process.on("SIGTERM", onSigterm);
 	try {


### PR DESCRIPTION
## Summary

Fixes the macOS `MallocStackLogging` warning flood (#2014). On macOS, an inherited
`MallocStackLogging` / `MallocStackLoggingNoCompact` environment variable (from an
Xcode scheme, Instruments, `launchctl setenv`, or a debug-attached shell) makes
libmalloc print

```
MallocStackLogging: can't turn off malloc stack logging because it was not enabled.
```

to the stderr of **every** TTY-attached child. Inside the TUI each PTY-spawned child
repeats the warning straight into the rendered frame and corrupts the display.

Bun snapshots the spawn-default environment at process startup — before any JS runs —
so neither `delete process.env.X` nor a libc `unsetenv()` cleans the environment that
children inherit by default. The only reliable fix is to start the primary process
with a clean environment.

## Changes (defense in depth)

1. **`packages/coding-agent/src/cli/malloc-env-guard.ts`** (new) — `runCli()` re-execs
   once (darwin-only, `GJC_MALLOC_ENV_REEXEC` loop guard) with a `filterProcessEnv`-scrubbed
   environment **before any fast path or subprocess spawn**, so every downstream lane
   (`Bun.spawn` defaults, `node:child_process`, native PTY, tmux owner, plugin installs,
   subagents) starts from a clean snapshot. A one-time interactive notice points at the
   permanent `launchctl unsetenv` fix. Re-exec failure falls back to running in-process
   (degraded but functional).
2. **`crates/pi-natives/src/pty.rs`** — extracted `build_pty_command` +
   `scrub_macos_malloc_stack_logging_env` so the native PTY lane removes both vars
   independently (portable-pty's `CommandBuilder` snapshots the live parent environ, so
   this also protects direct SDK/embedder consumers that bypass the CLI guard). The scrub
   runs after any caller-supplied env so explicit forwarding cannot reintroduce the vars.
3. **`packages/coding-agent/src/cli.ts`** — wires the re-exec guard into `runCli()` ahead
   of the tmux-owner and notify-daemon fast paths; keeps the in-process
   `installRuntimeGlobals` scrub as belt-and-braces for the rare re-exec-unavailable path.

The common (uncontaminated / non-darwin) launch path pays only two cheap env lookups and
loads no extra modules.

## Test plan

- `packages/coding-agent/src/cli/malloc-env-guard.test.ts` (new, 16 cases): detection,
  darwin/non-darwin/loop-guard re-exec decision, compiled-vs-source argv reconstruction,
  and the launchctl notice.
- `crates/pi-natives/src/pty.rs`: unit test asserting `build_pty_command` strips both
  malloc vars while preserving unrelated forwarded env.
- `bun test packages/coding-agent/src/cli/malloc-env-guard.test.ts` — 16 pass
- `cargo test -p pi-natives` (pty module) — 9 pass
- typecheck (`tsc --noEmit`), biome check, and `cargo fmt --check` all clean.

Closes #2014
