### PR TITLE
fix(notifications): reload a stale-generation Telegram daemon instead of attaching (#2028)

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -71,6 +71,14 @@ export interface DaemonState {
 	heartbeatAt: number;
 	roots: string[];
 	version: 1;
+	/**
+	 * Operational daemon generation of the process that owns the lock, distinct
+	 * from the persisted state-schema {@link DaemonState.version}. It records the
+	 * wire generation ({@link DAEMON_GENERATION}) the owning daemon speaks so a
+	 * freshly-upgraded host can detect — and reload — a still-live pre-upgrade
+	 * daemon whose schema version is unchanged. Absent on pre-generation state.
+	 */
+	generation?: number;
 	stoppedAt?: number;
 }
 export interface TelegramDaemonFs {
@@ -100,6 +108,14 @@ export interface TelegramDaemonDeps {
 	) => SpawnResult;
 	execPath?: string;
 	randomId?: () => string;
+	/**
+	 * Signal delivery + poll timing for the stale-generation reload handoff in
+	 * {@link ensureTelegramDaemonRunning}. Defaults use real signals/timers; tests
+	 * inject them to drive the handoff deterministically.
+	 */
+	sendSignal?: (pid: number, signal: NodeJS.Signals) => void;
+	sleep?: (ms: number) => Promise<void>;
+	waitStepMs?: number;
 }
 
 export const HEARTBEAT_INTERVAL_MS = 5_000;
@@ -112,6 +128,16 @@ export const NOTIFICATION_PROTOCOL_VERSION = 3;
 /** Capability required for typed controls and semantic Selected acknowledgement frames. */
 export const ASK_SELECTED_ACK_CAPABILITY = "ask_selected_ack_v1";
 export const ASK_CONTROLS_CAPABILITY = "ask_controls_v1";
+/**
+ * Operational generation the current daemon build speaks, persisted into
+ * {@link DaemonState.generation} on ownership acquisition. It is tied to the
+ * wire {@link NOTIFICATION_PROTOCOL_VERSION} so any protocol bump (which is what
+ * gates capabilities like {@link ASK_SELECTED_ACK_CAPABILITY}) also bumps the
+ * generation, letting a freshly-upgraded host recognise an older, still-live
+ * daemon and reload it instead of silently attaching to it. Distinct from the
+ * persisted schema {@link DAEMON_VERSION}, which did not change across #1999.
+ */
+export const DAEMON_GENERATION = NOTIFICATION_PROTOCOL_VERSION;
 
 const nodeFs: TelegramDaemonFs = fs.promises as unknown as TelegramDaemonFs;
 
@@ -370,6 +396,7 @@ export async function acquireDaemonOwnership(input: {
 	attached?: boolean;
 	blocked?: boolean;
 	reason?: "identity_mismatch";
+	reloadRequired?: boolean;
 }> {
 	const fsImpl = input.fs ?? nodeFs;
 	const now = input.now ?? Date.now;
@@ -379,6 +406,28 @@ export async function acquireDaemonOwnership(input: {
 	await ensureDir(fsImpl, paths.dir);
 	const ownerId = input.randomId?.() ?? `${pid}-${now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 	const roots = input.roots ?? (await readJson<{ roots?: string[] }>(fsImpl, paths.roots))?.roots ?? [];
+
+	// A fresh, identity-matching live owner running an OLDER generation than this
+	// build cannot serve our newer wire frames; signal a reload instead of a
+	// silent attach. Newer/equal generations attach as before (no downgrade).
+	const attachDecision = (
+		state: DaemonState | undefined,
+	): { acquired: false; attached: boolean; reloadRequired?: boolean } | undefined => {
+		if (
+			!isFreshLiveOwner({
+				state,
+				now: now(),
+				tokenFingerprint: input.tokenFingerprint,
+				chatId: input.chatId,
+				pidAlive,
+			})
+		) {
+			return undefined;
+		}
+		return (state?.generation ?? 0) < DAEMON_GENERATION
+			? { acquired: false, attached: false, reloadRequired: true }
+			: { acquired: false, attached: true };
+	};
 	const existing = await readJson<DaemonState>(fsImpl, paths.state);
 	if (
 		liveOwnerUsesDifferentIdentity({
@@ -390,17 +439,8 @@ export async function acquireDaemonOwnership(input: {
 	) {
 		return { acquired: false, blocked: true, reason: "identity_mismatch" };
 	}
-	if (
-		isFreshLiveOwner({
-			state: existing,
-			now: now(),
-			tokenFingerprint: input.tokenFingerprint,
-			chatId: input.chatId,
-			pidAlive,
-		})
-	) {
-		return { acquired: false, attached: true };
-	}
+	const existingDecision = attachDecision(existing);
+	if (existingDecision) return existingDecision;
 	if (await tryOpenWx(fsImpl, paths.lock)) {
 		await writeJsonAtomic(fsImpl, paths.state, {
 			pid,
@@ -411,6 +451,7 @@ export async function acquireDaemonOwnership(input: {
 			heartbeatAt: now(),
 			roots,
 			version: DAEMON_VERSION,
+			generation: DAEMON_GENERATION,
 		} satisfies DaemonState);
 		return { acquired: true, ownerId };
 	}
@@ -425,32 +466,14 @@ export async function acquireDaemonOwnership(input: {
 	) {
 		return { acquired: false, blocked: true, reason: "identity_mismatch" };
 	}
-	if (
-		isFreshLiveOwner({
-			state: afterLock,
-			now: now(),
-			tokenFingerprint: input.tokenFingerprint,
-			chatId: input.chatId,
-			pidAlive,
-		})
-	) {
-		return { acquired: false, attached: true };
-	}
+	const afterLockDecision = attachDecision(afterLock);
+	if (afterLockDecision) return afterLockDecision;
 	if (!afterLock) return { acquired: false, attached: true };
 	if (!(await tryOpenWx(fsImpl, paths.steal))) return { acquired: false, attached: true };
 	try {
 		const rechecked = await readJson<DaemonState>(fsImpl, paths.state);
-		if (
-			isFreshLiveOwner({
-				state: rechecked,
-				now: now(),
-				tokenFingerprint: input.tokenFingerprint,
-				chatId: input.chatId,
-				pidAlive,
-			})
-		) {
-			return { acquired: false, attached: true };
-		}
+		const recheckedDecision = attachDecision(rechecked);
+		if (recheckedDecision) return recheckedDecision;
 		if (
 			liveOwnerUsesDifferentIdentity({
 				state: rechecked,
@@ -475,6 +498,7 @@ export async function acquireDaemonOwnership(input: {
 			heartbeatAt: now(),
 			roots,
 			version: DAEMON_VERSION,
+			generation: DAEMON_GENERATION,
 		} satisfies DaemonState);
 		return { acquired: true, ownerId };
 	} finally {
@@ -578,6 +602,12 @@ export interface TelegramSpawnOwnerResult {
 	ownerId?: string;
 	runtime: DaemonRuntimeInfo;
 	warnings: string[];
+	/**
+	 * Set when ownership was NOT acquired because a still-live owner is running an
+	 * older daemon generation. The caller must hand off via a reload rather than
+	 * attach; see {@link ensureTelegramDaemonRunning}.
+	 */
+	reloadRequired?: boolean;
 }
 
 /**
@@ -646,7 +676,7 @@ export async function spawnTelegramDaemonOwner(
 				warnings: ["live telegram daemon uses a different bot token or chat; refusing to attach"],
 			};
 		}
-		return { result: "attached", runtime, warnings: [] };
+		return { result: "attached", runtime, warnings: [], reloadRequired: ownership.reloadRequired };
 	}
 	const spawnImpl = deps.spawn ?? defaultDaemonSpawn;
 	const child = spawnImpl(command, args, {
@@ -674,8 +704,41 @@ export async function ensureTelegramDaemonRunning(
 		logger.warn(`notifications: failed to ensure Telegram daemon: ${spawned.warnings.join("; ")}`);
 		return spawned.result;
 	}
+	if (spawned.reloadRequired) {
+		// A still-live owner is running an OLDER daemon generation than this host
+		// (e.g. a pre-upgrade daemon reused in place across an in-place upgrade).
+		// Attaching would silently drop this host's newer ask-ack / control frames,
+		// so register this session's root first — so the replacement daemon serves
+		// it — then hand off through the tested SIGTERM/control reload path to bring
+		// up a fresh current-generation daemon.
+		await registerNotificationRoot({ ...input, fs: deps.fs });
+		await reloadStaleGenerationOwner(input.settings, deps);
+		return "owner_spawned";
+	}
 	await registerNotificationRoot({ ...input, fs: deps.fs });
 	return spawned.result;
+}
+
+/**
+ * Reload a still-live owner running an older daemon generation through the
+ * cooperative SIGTERM/control handoff. Lazily imports the controller to avoid a
+ * static import cycle (the controller module imports ownership helpers here).
+ */
+async function reloadStaleGenerationOwner(settings: Settings, deps: TelegramDaemonDeps): Promise<void> {
+	const { TelegramDaemonController } = await import("./telegram-daemon-control");
+	const controller = new TelegramDaemonController(settings, {
+		fs: deps.fs,
+		now: deps.now,
+		pidAlive: deps.pidAlive,
+		sendSignal: deps.sendSignal,
+		spawn: deps.spawn,
+		execPath: deps.execPath,
+		ownerPid: deps.pid,
+		randomId: deps.randomId,
+		sleep: deps.sleep,
+		waitStepMs: deps.waitStepMs,
+	});
+	await controller.reload();
 }
 
 export interface BotApi {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -12,6 +12,7 @@ import {
 import { deliverRichWithFallback } from "../src/notifications/rich-render";
 import {
 	acquireDaemonOwnership,
+	DAEMON_GENERATION,
 	DAEMON_VERSION,
 	daemonPaths,
 	ensureTelegramDaemonRunning,
@@ -462,6 +463,7 @@ describe("telegram daemon", () => {
 				heartbeatAt: 100,
 				roots: [],
 				version: 1,
+				generation: DAEMON_GENERATION,
 			}),
 		);
 		const result = await acquireDaemonOwnership({
@@ -515,6 +517,163 @@ describe("telegram daemon", () => {
 			tokenFingerprint: "old-fp",
 			chatId: "old-chat",
 		});
+	});
+
+	// -----------------------------------------------------------------------
+	// #2028: a rolling upgrade can leave a still-live PRE-upgrade daemon owning
+	// the lock. Its persisted schema `version` is unchanged (1), so a freshly
+	// upgraded host used to treat it as a fresh live owner and silently attach —
+	// the old daemon speaks the old protocol without ask-ack/controls, so the new
+	// host's Selected acks are dropped. The persisted operational `generation`
+	// lets the new host detect the mismatch and reload instead of attaching.
+	// -----------------------------------------------------------------------
+	function liveOwnerState(extra: Record<string, unknown> = {}): Record<string, unknown> {
+		return {
+			pid: 999,
+			ownerId: "old",
+			tokenFingerprint: "e60b05c186ca",
+			chatId: "42",
+			startedAt: 100,
+			heartbeatAt: 100,
+			roots: [],
+			version: 1,
+			...extra,
+		};
+	}
+
+	function writeLiveOwner(agentDir: string, extra: Record<string, unknown> = {}): void {
+		const paths = daemonPaths(agentDir);
+		fs.mkdirSync(paths.dir, { recursive: true });
+		fs.writeFileSync(paths.state, JSON.stringify(liveOwnerState(extra)));
+		fs.writeFileSync(paths.lock, "");
+	}
+
+	test("#2028 acquire flags a reload for a live pre-upgrade owner missing the generation field", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		writeLiveOwner(agentDir); // no generation field == pre-upgrade daemon
+		const result = await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "e60b05c186ca",
+			chatId: "42",
+			pidAlive: () => true,
+			now: () => 101,
+		});
+		expect(result).toEqual({ acquired: false, attached: false, reloadRequired: true });
+	});
+
+	test("#2028 acquire attaches to a current-generation live owner (no reload)", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION });
+		const result = await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "e60b05c186ca",
+			chatId: "42",
+			pidAlive: () => true,
+			now: () => 101,
+		});
+		expect(result).toEqual({ acquired: false, attached: true });
+	});
+
+	test("#2028 acquire does not downgrade a NEWER-generation live owner (attaches)", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION + 1 });
+		const result = await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "e60b05c186ca",
+			chatId: "42",
+			pidAlive: () => true,
+			now: () => 101,
+		});
+		expect(result).toEqual({ acquired: false, attached: true });
+	});
+
+	test("#2028 acquiring ownership stamps the current daemon generation into state", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const result = await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "e60b05c186ca",
+			chatId: "42",
+			pid: 111,
+			randomId: () => "owner",
+		});
+		expect(result.acquired).toBe(true);
+		const state = JSON.parse(fs.readFileSync(daemonPaths(agentDir).state, "utf8"));
+		expect(state.generation).toBe(DAEMON_GENERATION);
+	});
+
+	test("#2028 ensureTelegramDaemonRunning reloads a live pre-upgrade owner via a safe SIGTERM handoff", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		// Pre-upgrade daemon, still alive with a fresh heartbeat (so it is a fresh
+		// live owner that a version-only check would attach to).
+		writeLiveOwner(agentDir, { heartbeatAt: Date.now() });
+		const paths = daemonPaths(agentDir);
+		const alive = new Set<number>([999, 4242]);
+		const signals: Array<[number, string]> = [];
+		let oldAliveAtSpawn: boolean | undefined;
+		const spawns: Array<{ command: string; args: string[] }> = [];
+		const cwd = path.join(agentDir, "new-session");
+		const result = await ensureTelegramDaemonRunning(
+			{ settings: s, cwd, sessionId: "new-session" },
+			{
+				pid: 4242,
+				pidAlive: pid => alive.has(pid),
+				sendSignal: (pid, sig) => {
+					signals.push([pid, sig]);
+					if (sig === "SIGTERM") alive.delete(999);
+				},
+				sleep: async () => undefined,
+				spawn: (command, args) => {
+					oldAliveAtSpawn = alive.has(999);
+					spawns.push({ command, args });
+					return { unref() {} };
+				},
+			},
+		);
+		expect(result).toBe("owner_spawned");
+		// Cooperative handoff: the old poller is SIGTERM'd and must be dead before a
+		// replacement poller spawns (no Telegram getUpdates 409 overlap).
+		expect(signals).toContainEqual([999, "SIGTERM"]);
+		expect(signals.some(([, sig]) => sig === "SIGKILL")).toBe(false);
+		expect(spawns).toHaveLength(1);
+		expect(oldAliveAtSpawn).toBe(false);
+		const after = JSON.parse(fs.readFileSync(paths.state, "utf8"));
+		expect(after.ownerId).not.toBe("old");
+		expect(after.generation).toBe(DAEMON_GENERATION);
+		// The new session's root is persisted so the replacement daemon serves it.
+		expect(after.roots).toContain(path.join(cwd, ".gjc", "state"));
+	});
+
+	test("#2028 ensureTelegramDaemonRunning reuses a current-generation live owner without a reload", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION, heartbeatAt: Date.now() });
+		const paths = daemonPaths(agentDir);
+		const signals: Array<[number, string]> = [];
+		let spawns = 0;
+		const result = await ensureTelegramDaemonRunning(
+			{ settings: s, cwd: path.join(agentDir, "new-session"), sessionId: "new-session" },
+			{
+				pid: 4242,
+				pidAlive: () => true,
+				sendSignal: (pid, sig) => signals.push([pid, sig]),
+				sleep: async () => undefined,
+				spawn: () => {
+					spawns++;
+					return { unref() {} };
+				},
+			},
+		);
+		expect(result).toBe("attached");
+		expect(signals).toHaveLength(0);
+		expect(spawns).toBe(0);
+		// Still the original owner; the new session's root is registered onto it.
+		expect(JSON.parse(fs.readFileSync(paths.state, "utf8")).ownerId).toBe("old");
+		expect(fs.existsSync(paths.roots)).toBe(true);
 	});
 
 	test("idle self-exit after timeout releases ownership", async () => {


### PR DESCRIPTION
Fixes #2028.

## Problem
`NOTIFICATION_PROTOCOL_VERSION` was bumped to 3 (#1999) while the persisted `DAEMON_VERSION` stayed at 1. Ownership treats a still-live pre-upgrade daemon as a fresh live owner and attaches to it. That old process speaks the old wire protocol without `ask_selected_ack_v1` / `ask_controls_v1`, so the freshly-upgraded host's `Selected!` acknowledgements are silently dropped and multi-select asks can become non-completable.

## Fix
- Add an operational `DAEMON_GENERATION` (tied to `NOTIFICATION_PROTOCOL_VERSION`) persisted into `DaemonState.generation`, distinct from the unchanged schema `version`.
- `acquireDaemonOwnership` now flags `reloadRequired` when a fresh live owner runs an **older** generation; newer/equal generations still attach so a daemon is never downgraded.
- `ensureTelegramDaemonRunning` registers the new session root, then hands off through the existing cooperative SIGTERM/control reload (`TelegramDaemonController.reload`) to bring up a fresh current-generation daemon instead of attaching.

## Acceptance (from #2028)
- [x] Fresh v3 host attaching while a live v1/v2 daemon owns the lock triggers a safe reload handoff.
- [x] Rolling-upgrade regression test with an already-live v1 owner.

## Tests
Targeted #2028 cases added to `notifications-telegram-daemon.test.ts` covering the reload flag, generation stamping, the no-downgrade attach, and the SIGTERM reload handoff.

## Verification
- `bun test test/notifications-telegram-daemon.test.ts` — 139 pass / 0 fail
- `bun run check:types` — clean
- `biome check` on changed files — OK
