### PR TITLE
feat(coding-agent): suppress notifications for GJC-spawned children under notifications.sessionScope=primary (#1908)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Added an opt-in `/pet on|off` composer companion with idle gaze, working claw motion, and occasional automatic flex animation on Sixel- and Kitty-graphics terminals.
 
+- Added `notifications.sessionScope` (`all` default | `primary`). Under `primary`, the separate-process child sessions GJC spawns (team workers, harness RPC owners) no longer register their own Telegram forum topic / notification endpoint unless they explicitly opt in (`GJC_NOTIFICATIONS=1`, the `/session_create` path). The default `all` fully preserves current behavior, and user-opened CLI/tmux/headless sessions are never affected. The provenance marker is per-spawn and non-dynastic (consumed once at session startup, never inherited by grandchildren) (#1908).
+- Added `notifications.sessionScope` (`all` default | `primary`). Under `primary`, the separate-process child sessions GJC spawns (team workers, harness RPC owners) no longer register their own Telegram forum topic / notification endpoint unless they explicitly opt in (`GJC_NOTIFICATIONS=1`, the `/session_create` path). The default `all` fully preserves current behavior, and user-opened CLI/tmux/headless sessions are never affected. The provenance marker is per-spawn and non-dynastic (consumed once at session startup, never inherited by grandchildren) (#1908).
+
 ### Changed
 
 - Migrated the repository type-check and release declaration pipeline to stable TypeScript 7.0.2, including the robogjc web workspace and a non-mutating publish-type gate.

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -66,6 +66,7 @@ import {
 	type SessionHandle,
 	type SessionState,
 } from "../harness-control-plane/types";
+import { SPAWN_PROVENANCE_ENV } from "../notifications/config";
 
 const PRIVATE_OWNER_CONTROL_FIELDS = new Set([
 	"socket_key",
@@ -804,7 +805,14 @@ export default class Harness extends Command {
 		// Optional rpc command override (tests / non-default hosts); defaults to `gjc --mode rpc`.
 		const override = process.env.GJC_HARNESS_RPC_COMMAND;
 		const command = override ? (JSON.parse(override) as string[]) : undefined;
-		const rpc = new GajaeCodeRpc({ sessionDir, command });
+		// Mark the RPC owner as a GJC-spawned child (canonical provenance marker)
+		// so `notifications.sessionScope = "primary"` suppresses its notification
+		// endpoint/topic; default `all` preserves historical auto-on behavior.
+		const rpc = new GajaeCodeRpc({
+			sessionDir,
+			command,
+			env: { ...process.env, [SPAWN_PROVENANCE_ENV]: sessionId },
+		});
 		const owner = new RuntimeOwner({ root, sessionId, rpc });
 		const info = await owner.start();
 		writeJson({ ok: true, owner: info });

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -272,6 +272,11 @@ export const SETTINGS_SCHEMA = {
 		default: "lean",
 		validate: (value: string) => value === "lean" || value === "verbose",
 	},
+	"notifications.sessionScope": {
+		type: "string",
+		default: "all",
+		validate: (value: string) => value === "all" || value === "primary",
+	},
 	"notifications.daemon.idleTimeoutMs": {
 		type: "number",
 		default: 60000,

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getWorktreesDir } from "@gajae-code/utils/dirs";
+import { SPAWN_PROVENANCE_ENV } from "../notifications/config";
 import type { WorkflowHudSummary } from "../skill-state/active-state";
 import { buildTeamHudSummary as buildWorkflowTeamHudSummary } from "../skill-state/workflow-hud";
 import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
@@ -2083,6 +2084,11 @@ export function buildWorkerCommand(
 		envAssignment("GJC_TEAM_STATE_ROOT", config.state_root),
 		envAssignment("GJC_TEAM_LEADER_CWD", config.leader.cwd),
 		envAssignment("GJC_TEAM_DISPLAY_NAME", config.display_name),
+		// Canonical GJC spawn-provenance marker so `notifications.sessionScope =
+		// "primary"` suppresses the worker's own notification endpoint/topic. The
+		// value is informational (leader session id, falling back to the team name
+		// so it is always non-blank); presence is what marks the worker.
+		envAssignment(SPAWN_PROVENANCE_ENV, config.leader.session_id.trim() || config.team_name),
 		...(worker.worktree_path ? [envAssignment("GJC_TEAM_WORKTREE_PATH", worker.worktree_path)] : []),
 	];
 	const joined = platform === "win32" ? envLines.join(" ") : envLines.join(" ");

--- a/packages/coding-agent/src/notifications/config.ts
+++ b/packages/coding-agent/src/notifications/config.ts
@@ -1,6 +1,17 @@
 import * as crypto from "node:crypto";
 import type { Settings } from "../config/settings";
 
+/**
+ * Env marker set by GJC's own programmatic separate-process child spawn sites
+ * (team workers, harness RPC owners) and carrying the spawning session id.
+ *
+ * Presence — not the value — marks a session as GJC-spawned. It is consumed
+ * (read once, then deleted from the child's own env) at startup so it is
+ * per-spawn rather than dynastic: a grandchild is marked only if its own spawn
+ * site marks it, never by inheriting a marked ancestor's environment.
+ */
+export const SPAWN_PROVENANCE_ENV = "GJC_SPAWNED_BY_SESSION";
+
 export interface NotificationConfig {
 	enabled: boolean;
 	botToken?: string;
@@ -15,6 +26,12 @@ export interface NotificationConfig {
 	};
 	redact: boolean;
 	verbosity: "lean" | "verbose";
+	/**
+	 * Which sessions may register a notification endpoint. `all` (default)
+	 * preserves historical behavior; `primary` suppresses GJC-spawned children
+	 * (those carrying {@link SPAWN_PROVENANCE_ENV}) unless they explicitly opt in.
+	 */
+	sessionScope: "all" | "primary";
 	idleTimeoutMs: number;
 	rich: {
 		enabled: boolean;
@@ -40,6 +57,7 @@ export function getNotificationConfig(settings: Settings): NotificationConfig {
 		},
 		redact: settings.get("notifications.redact"),
 		verbosity: settings.get("notifications.verbosity") === "verbose" ? "verbose" : "lean",
+		sessionScope: settings.get("notifications.sessionScope") === "primary" ? "primary" : "all",
 		idleTimeoutMs: settings.get("notifications.daemon.idleTimeoutMs"),
 		rich: {
 			enabled: settings.get("notifications.telegram.rich.enabled"),
@@ -95,11 +113,25 @@ export function shouldRegisterNotificationsExtension(input: {
 	parentTaskPrefix?: string;
 	/** Role-agent type/name; present for task sessions even if depth metadata is lost. */
 	currentAgentType?: string;
+	/**
+	 * True when this session was launched by one of GJC's own programmatic
+	 * separate-process child spawn sites (marked via {@link SPAWN_PROVENANCE_ENV}).
+	 * Under `notifications.sessionScope = "primary"` such children are suppressed
+	 * unless they explicitly opt in, so an interactive parent that fans out work
+	 * does not flood the paired chat with topics for children the user never
+	 * asked for. User-opened sessions (CLI/tmux/headless) never carry the marker.
+	 */
+	spawnedByGjc?: boolean;
 }): boolean {
 	if ((input.taskDepth ?? 0) > 0 || input.parentTaskPrefix || input.currentAgentType) return false;
 	if (completionNotifyDisabledByEnv(input.env)) return false;
 	if (input.env.GJC_NOTIFICATIONS === "0") return false;
 	if (input.env.GJC_NOTIFICATIONS === "1" || input.env.GJC_NOTIFICATIONS_TOKEN) return true;
+	// Spawned-child suppression sits below explicit opt-in (so Telegram
+	// `/session_create` and cold `/session_resume`, which launch with
+	// GJC_NOTIFICATIONS=1, keep their fully bidirectional topic) and above global
+	// auto-on (so their children stay silent under `primary`).
+	if (input.spawnedByGjc && input.cfg?.sessionScope === "primary") return false;
 	return input.cfg ? isGloballyConfigured(input.cfg) : false;
 }
 

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -529,6 +529,7 @@ const defaultConfig: NotificationConfig = {
 	},
 	redact: false,
 	verbosity: "lean",
+	sessionScope: "all",
 	idleTimeoutMs: 60_000,
 	rich: { enabled: true },
 	richDraft: { enabled: false },

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -94,6 +94,7 @@ import { createNotificationsExtension } from "./notifications";
 import {
 	getNotificationConfig,
 	type NotificationConfig,
+	SPAWN_PROVENANCE_ENV,
 	shouldRegisterNotificationsExtension,
 } from "./notifications/config";
 import asyncResultTemplate from "./prompts/tools/async-result.md" with { type: "text" };
@@ -1615,6 +1616,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		} catch {
 			notificationCfg = undefined;
 		}
+		// Consume the GJC spawn-provenance marker: read it once, then remove it
+		// from this process's env so it is never re-inherited by children this
+		// session later spawns (marker is per-spawn, not dynastic — each GJC child
+		// spawn site sets it explicitly). Suppression under `sessionScope=primary`
+		// keeps auto-spawned children (team workers, harness RPC owners) silent
+		// while explicit `/session_create` opt-in (GJC_NOTIFICATIONS=1) still wins.
+		const spawnProvenance = process.env[SPAWN_PROVENANCE_ENV];
+		const spawnedByGjc = typeof spawnProvenance === "string" && spawnProvenance.trim().length > 0;
+		delete process.env[SPAWN_PROVENANCE_ENV];
 		if (
 			shouldRegisterNotificationsExtension({
 				env: process.env,
@@ -1622,6 +1632,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				taskDepth,
 				parentTaskPrefix: options.parentTaskPrefix,
 				currentAgentType: options.currentAgentType,
+				spawnedByGjc,
 			})
 		) {
 			inlineExtensions.push(api => createNotificationsExtension(api, { settings }));

--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -485,6 +485,55 @@ describe("native gjc team runtime", () => {
 		expect(command).toContain("'You are worker-1 in gjc team win-team.");
 	});
 
+	it("marks worker commands with the canonical GJC spawn-provenance env var", () => {
+		const base = {
+			team_name: "prov-team",
+			display_name: "prov-team",
+			requested_name: "prov-team",
+			task: "Do work",
+			agent_type: "executor",
+			worker_count: 1,
+			max_workers: 1,
+			state_root: "/state",
+			worker_command: "gjc",
+			worker_cli_plan: ["gjc"],
+			tmux_command: "tmux",
+			tmux_session: "sess",
+			tmux_session_name: "sess",
+			tmux_target: "sess:0",
+			workspace_mode: "direct",
+			dry_run: false,
+			leader: { session_id: "leader-xyz", pane_id: "%1", cwd: "/repo" },
+			leader_cwd: "/repo",
+			team_state_root: "/state",
+			workers: [],
+			created_at: "2026-01-01T00:00:00.000Z",
+			updated_at: "2026-01-01T00:00:00.000Z",
+		} satisfies GjcTeamConfig;
+		const worker = {
+			id: "worker-1",
+			name: "worker-1",
+			index: 1,
+			agent_type: "executor",
+			role: "executor",
+			status: "starting",
+			last_heartbeat: "2026-01-01T00:00:00.000Z",
+			assigned_tasks: [],
+		} satisfies GjcTeamWorker;
+
+		// POSIX: the marker carries the leader session id.
+		const posix = buildWorkerCommand(base, worker, "linux");
+		expect(posix).toContain("GJC_SPAWNED_BY_SESSION='leader-xyz'");
+
+		// Falls back to the (always non-blank) team name when the leader has no id,
+		// so presence-based suppression still marks the worker.
+		const noLeaderId = { ...base, leader: { ...base.leader, session_id: "  " } } satisfies GjcTeamConfig;
+		expect(buildWorkerCommand(noLeaderId, worker, "linux")).toContain("GJC_SPAWNED_BY_SESSION='prov-team'");
+
+		// Windows env assignment form is emitted too.
+		expect(buildWorkerCommand(base, worker, "win32")).toContain("$env:GJC_SPAWNED_BY_SESSION = 'leader-xyz';");
+	});
+
 	it("resolves Windows JavaScript entrypoints through an executable runtime", async () => {
 		const command = resolveGjcWorkerCommand(
 			"C:\\repo",

--- a/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/cli-detached-owner.test.ts
@@ -236,6 +236,20 @@ describe.skipIf(process.platform !== "linux")("gjc harness start --detach (detac
 		expect(after.live).toBe(false);
 	}, 60_000);
 
+	it("injects the GJC spawn-provenance marker into the detached RPC owner", async () => {
+		// fake-rpc records the GJC_SPAWNED_BY_SESSION value it was spawned with; a
+		// non-empty marker proves #runOwner tags the detached owner's RPC child so
+		// notifications.sessionScope=primary can suppress it.
+		const recordPath = path.join(root, "owner-spawn-marker");
+		const started = await runHarness(
+			["start", "--input", JSON.stringify({ harness: "gajae-code", workspace, sessionId: SID, detach: true })],
+			{ GJC_FAKE_RPC_ENV_RECORD: recordPath },
+		);
+		expect(started.code).toBe(0);
+		expect((started.json?.state as Record<string, unknown>).ownerLive).toBe(true);
+		expect(await readFile(recordPath, "utf8")).toBe(SID);
+	}, 60_000);
+
 	it("blocks without a detached fallback when tmux starts but never routes the owner", async () => {
 		tmuxCommand = await createFakeTmuxBin(root, { skipOwnerLaunch: true });
 		const started = await runHarness([

--- a/packages/coding-agent/test/harness-control-plane/fixtures/fake-rpc.ts
+++ b/packages/coding-agent/test/harness-control-plane/fixtures/fake-rpc.ts
@@ -7,6 +7,12 @@
  * a real subprocess, without a live model. It does NOT fake acceptance/completion inside
  * shipped code — the control plane drives this exactly as it would drive real gjc.
  */
+import { writeFileSync } from "node:fs";
+
+// When asked, record the GJC spawn-provenance marker this RPC child was spawned
+// with so the harness detached-owner e2e can prove `#runOwner` injects it.
+const envRecordPath = process.env.GJC_FAKE_RPC_ENV_RECORD;
+if (envRecordPath) writeFileSync(envRecordPath, process.env.GJC_SPAWNED_BY_SESSION ?? "");
 process.stdout.write(`${JSON.stringify({ type: "ready" })}\n`);
 
 let buffer = "";

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -37,6 +37,7 @@ const BASE_CFG: NotificationConfig = {
 	},
 	redact: false,
 	verbosity: "lean",
+	sessionScope: "all",
 	rich: {
 		enabled: true,
 	},
@@ -51,6 +52,10 @@ const GLOBAL_CFG: NotificationConfig = {
 	enabled: true,
 	botToken: "1234567890:abc",
 	chatId: "chat-1",
+};
+const PRIMARY_GLOBAL_CFG: NotificationConfig = {
+	...GLOBAL_CFG,
+	sessionScope: "primary",
 };
 const tempDirs: string[] = [];
 
@@ -90,6 +95,7 @@ describe("notifications config", () => {
 			},
 			redact: true,
 			verbosity: "lean",
+			sessionScope: "all",
 			rich: {
 				enabled: true,
 			},
@@ -233,6 +239,77 @@ describe("notifications config", () => {
 				currentAgentType: "executor",
 			}),
 		).toBe(false);
+	});
+
+	test("getNotificationConfig reads sessionScope", () => {
+		expect(getNotificationConfig(Settings.isolated()).sessionScope).toBe("all");
+		expect(getNotificationConfig(Settings.isolated({ "notifications.sessionScope": "primary" })).sessionScope).toBe(
+			"primary",
+		);
+		// Unknown / malformed values fall back to the behavior-preserving default.
+		expect(getNotificationConfig(Settings.isolated({ "notifications.sessionScope": "all" })).sessionScope).toBe(
+			"all",
+		);
+	});
+
+	test("sessionScope=primary suppresses GJC-spawned children but preserves everything else", () => {
+		// Default scope "all": a spawned child still registers (fully behavior-preserving).
+		expect(shouldRegisterNotificationsExtension({ cfg: GLOBAL_CFG, env: {}, spawnedByGjc: true })).toBe(true);
+		// scope "primary": a spawned child is suppressed.
+		expect(shouldRegisterNotificationsExtension({ cfg: PRIMARY_GLOBAL_CFG, env: {}, spawnedByGjc: true })).toBe(
+			false,
+		);
+		// scope "primary": a user-opened session (no marker) is unaffected.
+		expect(shouldRegisterNotificationsExtension({ cfg: PRIMARY_GLOBAL_CFG, env: {}, spawnedByGjc: false })).toBe(
+			true,
+		);
+		expect(shouldRegisterNotificationsExtension({ cfg: PRIMARY_GLOBAL_CFG, env: {} })).toBe(true);
+	});
+
+	test("explicit /session_create opt-in outranks sessionScope=primary suppression", () => {
+		// GJC_NOTIFICATIONS=1 is exactly what Telegram /session_create and cold
+		// /session_resume launch with, so their bidirectional topic survives.
+		expect(
+			shouldRegisterNotificationsExtension({
+				cfg: PRIMARY_GLOBAL_CFG,
+				env: { GJC_NOTIFICATIONS: "1" },
+				spawnedByGjc: true,
+			}),
+		).toBe(true);
+		expect(
+			shouldRegisterNotificationsExtension({
+				cfg: PRIMARY_GLOBAL_CFG,
+				env: { GJC_NOTIFICATIONS_TOKEN: "legacy-token" },
+				spawnedByGjc: true,
+			}),
+		).toBe(true);
+		// Hard opt-out and /notify off equivalents still outrank the marker.
+		expect(
+			shouldRegisterNotificationsExtension({
+				cfg: PRIMARY_GLOBAL_CFG,
+				env: { GJC_NOTIFICATIONS: "0" },
+				spawnedByGjc: true,
+			}),
+		).toBe(false);
+		expect(
+			shouldRegisterNotificationsExtension({
+				cfg: PRIMARY_GLOBAL_CFG,
+				env: { GJC_NOTIFY: "off" },
+				spawnedByGjc: true,
+			}),
+		).toBe(false);
+		// A spawned child that is also a subagent stays suppressed regardless.
+		expect(
+			shouldRegisterNotificationsExtension({
+				cfg: PRIMARY_GLOBAL_CFG,
+				env: {},
+				spawnedByGjc: true,
+				taskDepth: 1,
+			}),
+		).toBe(false);
+		// Without any configured adapter, a marker under primary is still off (no
+		// spurious enable, and global auto-on is never reached).
+		expect(shouldRegisterNotificationsExtension({ cfg: BASE_CFG, env: {}, spawnedByGjc: true })).toBe(false);
 	});
 	test("settings-enabled subagent sessions do not register the notifications extension", async () => {
 		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notifications-subagent-"));
@@ -390,6 +467,80 @@ describe("notifications config", () => {
 			} else {
 				process.env.GJC_NOTIFICATIONS = previous;
 			}
+			resetSettingsForTest();
+		}
+	}, 30000);
+
+	test("sessionScope=primary suppresses a GJC-spawned child endpoint end to end and consumes the marker", async () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notifications-spawned-"));
+		tempDirs.push(cwd);
+		const previousNotif = process.env.GJC_NOTIFICATIONS;
+		const previousSpawn = process.env.GJC_SPAWNED_BY_SESSION;
+		delete process.env.GJC_NOTIFICATIONS;
+		delete process.env.GJC_SPAWNED_BY_SESSION;
+		const adapterSettings = (scope: "all" | "primary"): Settings =>
+			Settings.isolated({
+				"notifications.enabled": true,
+				"notifications.discord.botToken": "discord-token",
+				"notifications.discord.channelId": "discord-channel",
+				"notifications.sessionScope": scope,
+			});
+		const primarySettings = adapterSettings("primary");
+		const allSettings = adapterSettings("all");
+		const disposers: Array<() => Promise<void>> = [];
+		const spawn = async (settings: Settings) =>
+			createAgentSession({
+				cwd,
+				agentDir: cwd,
+				sessionManager: SessionManager.inMemory(cwd),
+				settings,
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				extensions: [],
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+			});
+		const endpointFor = (sessionId: string): string =>
+			path.join(cwd, ".gjc", "state", "notifications", `${sessionId}.json`);
+		try {
+			resetSettingsForTest();
+			await Settings.init({ inMemory: true, cwd, agentDir: cwd });
+
+			// 1. Spawned child under primary: suppressed, and the marker is consumed.
+			process.env.GJC_SPAWNED_BY_SESSION = "parent-abc";
+			const suppressed = await spawn(primarySettings);
+			disposers.push(() => suppressed.session.dispose());
+			expect(process.env.GJC_SPAWNED_BY_SESSION).toBeUndefined();
+
+			// 2. Spawned child under the default "all" scope still registers.
+			process.env.GJC_SPAWNED_BY_SESSION = "parent-abc";
+			const preserved = await spawn(allSettings);
+			disposers.push(() => preserved.session.dispose());
+
+			// 3. Spawned child under primary WITH explicit opt-in keeps its endpoint.
+			process.env.GJC_SPAWNED_BY_SESSION = "parent-abc";
+			process.env.GJC_NOTIFICATIONS = "1";
+			const optedIn = await spawn(primarySettings);
+			disposers.push(() => optedIn.session.dispose());
+			delete process.env.GJC_NOTIFICATIONS;
+
+			await suppressed.session.extensionRunner?.emit({ type: "session_start" });
+			await preserved.session.extensionRunner?.emit({ type: "session_start" });
+			await optedIn.session.extensionRunner?.emit({ type: "session_start" });
+
+			expect(fs.existsSync(endpointFor(suppressed.session.sessionId))).toBe(false);
+			expect(fs.existsSync(endpointFor(preserved.session.sessionId))).toBe(true);
+			expect(fs.existsSync(endpointFor(optedIn.session.sessionId))).toBe(true);
+		} finally {
+			await Promise.all(disposers.reverse().map(dispose => dispose()));
+			if (previousNotif === undefined) delete process.env.GJC_NOTIFICATIONS;
+			else process.env.GJC_NOTIFICATIONS = previousNotif;
+			if (previousSpawn === undefined) delete process.env.GJC_SPAWNED_BY_SESSION;
+			else process.env.GJC_SPAWNED_BY_SESSION = previousSpawn;
 			resetSettingsForTest();
 		}
 	}, 30000);

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -97,6 +97,10 @@
 					"type": "string",
 					"default": "lean"
 				},
+				"sessionScope": {
+					"type": "string",
+					"default": "all"
+				},
 				"daemon": {
 					"type": "object",
 					"properties": {


### PR DESCRIPTION
Closes #1908.

## Summary

Adds the `notifications.sessionScope` setting (`all` default | `primary`). Under `primary`, the separate-process child sessions GJC spawns on its own — team workers and harness RPC owners — no longer register their own Telegram forum topic / notification endpoint, so an interactive parent that fans out work does not flood the paired chat with topics the user never asked for.

- **Explicit opt-in always wins.** `GJC_NOTIFICATIONS=1` / `GJC_NOTIFICATIONS_TOKEN` (exactly what the Telegram `/session_create` and cold `/session_resume` path launch with) keep their fully bidirectional topic. Hard opt-out (`GJC_NOTIFICATIONS=0`, `GJC_NOTIFY=off`) and subagent suppression still sit above the marker.
- **`all` is fully behavior-preserving** (the default). User-opened CLI/tmux/headless sessions never carry the marker and are never affected.
- **Provenance is per-spawn and non-dynastic.** The `GJC_SPAWNED_BY_SESSION` marker is set by the two GJC spawn sites (`buildWorkerCommand`, harness `#runOwner`), then read once and deleted at session startup so a grandchild is marked only if its own spawn site marks it — never by inheriting a marked ancestor's env.

## Changes

- `config/settings-schema.ts`: validate `notifications.sessionScope` (`all|primary`, default `all`).
- `notifications/config.ts`: surface `sessionScope` on `NotificationConfig`; `shouldRegisterNotificationsExtension` suppresses `spawnedByGjc` children only under `primary`, strictly below explicit opt-in and above global auto-on. Export `SPAWN_PROVENANCE_ENV`.
- `gjc-runtime/team-runtime.ts` and `commands/harness.ts`: set the marker at the worker / RPC-owner spawn sites.
- `sdk.ts`: consume-once the marker (read then delete) so it is non-dynastic.
- `notifications/index.ts`: default-config `sessionScope: "all"`.
- `schemas/config.schema.json`: regenerated for the new key.

## Testing

- `bun test test/notifications-config.test.ts test/gjc-runtime/team-runtime.test.ts test/harness-control-plane/cli-detached-owner.test.ts` — 97 pass (includes the Linux detached-owner e2e proving `#runOwner` injects the marker via fake-rpc).
- `bun test scripts/generate-json-schemas.test.ts` — 2 pass; `bun run check:schemas` clean.
- `tsc --noEmit -p packages/coding-agent/tsconfig.json` — clean.
