### PR TITLE
feat(cli): beginner-safe daemon operational shortcuts (#2049)

### DIFF
--- a/packages/coding-agent/src/cli/daemon-cli.ts
+++ b/packages/coding-agent/src/cli/daemon-cli.ts
@@ -12,8 +12,14 @@ import type {
 	DaemonKind,
 	DaemonOperationOptions,
 	DaemonOperationResult,
-	DaemonStatus,
 } from "../daemon/control-types";
+import {
+	DAEMON_ACTION_TOKENS,
+	DAEMON_EXIT,
+	formatDaemonResult,
+	formatDaemonStatus,
+	resolveDaemonAction,
+} from "../daemon/operator-contract";
 
 export type DaemonCliAction = "list" | "status" | "stop" | "reload";
 
@@ -26,6 +32,8 @@ export interface DaemonCommandArgs {
 	gracefulTimeoutMs?: number;
 	killTimeoutMs?: number;
 	spawnIfStopped?: boolean;
+	/** Show runtime detail and the full roots list in human output. */
+	verbose?: boolean;
 }
 
 export interface DaemonCommandDeps {
@@ -33,18 +41,20 @@ export interface DaemonCommandDeps {
 	controllers?: BuiltInDaemonController[];
 }
 
-const KNOWN_ACTIONS: DaemonCliAction[] = ["list", "status", "stop", "reload"];
 const KNOWN_KINDS: DaemonKind[] = ["telegram"];
 
 export function parseDaemonArgs(argv: string[]): DaemonCommandArgs | undefined {
 	if (argv.length === 0 || argv[0] !== "daemon") return undefined;
 	const rest = argv.slice(1);
-	const action = (KNOWN_ACTIONS as string[]).includes(rest[0] ?? "") ? (rest[0] as DaemonCliAction) : "status";
-	const positional = (KNOWN_ACTIONS as string[]).includes(rest[0] ?? "") ? rest.slice(1) : rest;
+	const resolved = resolveDaemonAction(rest[0]);
+	const isActionToken = (DAEMON_ACTION_TOKENS as readonly string[]).includes(rest[0] ?? "");
+	const action = (resolved ?? "status") as DaemonCliAction;
+	const positional = isActionToken ? rest.slice(1) : rest;
 	const kinds: DaemonKind[] = [];
 	let all = false;
 	let json = false;
 	let force = false;
+	let verbose = false;
 	let gracefulTimeoutMs: number | undefined;
 	let killTimeoutMs: number | undefined;
 	let spawnIfStopped: boolean | undefined;
@@ -53,34 +63,14 @@ export function parseDaemonArgs(argv: string[]): DaemonCommandArgs | undefined {
 		if (arg === "--all") all = true;
 		else if (arg === "--json") json = true;
 		else if (arg === "--force") force = true;
+		else if (arg === "--verbose" || arg === "-v") verbose = true;
 		else if (arg === "--spawn-if-stopped") spawnIfStopped = true;
 		else if (arg === "--graceful-timeout-ms") gracefulTimeoutMs = Number.parseInt(positional[++i], 10);
 		else if (arg === "--kill-timeout-ms") killTimeoutMs = Number.parseInt(positional[++i], 10);
 		else if (!arg.startsWith("--") && (KNOWN_KINDS as string[]).includes(arg)) kinds.push(arg as DaemonKind);
 	}
-	return { action, kinds, all, json, force, gracefulTimeoutMs, killTimeoutMs, spawnIfStopped };
+	return { action, kinds, all, json, force, verbose, gracefulTimeoutMs, killTimeoutMs, spawnIfStopped };
 }
-
-function formatStatus(status: DaemonStatus): string {
-	const parts = [
-		`${status.kind}: ${status.health}`,
-		status.configured ? undefined : "(not configured)",
-		status.pid !== undefined ? `pid=${status.pid}` : undefined,
-		status.ownerId ? `owner=${status.ownerId}` : undefined,
-		status.rootCount !== undefined ? `roots=${status.rootCount}` : undefined,
-		`mode=${status.runtime.mode}`,
-	].filter(Boolean);
-	let line = parts.join(" ");
-	if (status.runtime.warning) line += `\n  warning: ${status.runtime.warning}`;
-	return line;
-}
-
-function formatResult(result: DaemonOperationResult): string {
-	const head = `${result.kind} ${result.action}: ${result.ok ? "ok" : "failed"} — ${result.message}`;
-	const warnings = result.warnings.map(w => `\n  warning: ${w}`).join("");
-	return head + warnings;
-}
-
 export async function runDaemonCommand(cmd: DaemonCommandArgs, deps: DaemonCommandDeps = {}): Promise<void> {
 	const unknownKinds = cmd.kinds.filter(kind => !(KNOWN_KINDS as string[]).includes(kind));
 	if (unknownKinds.length > 0) {
@@ -98,7 +88,7 @@ export async function runDaemonCommand(cmd: DaemonCommandArgs, deps: DaemonComma
 		if (cmd.json) {
 			process.stdout.write(`${JSON.stringify(statuses, null, 2)}\n`);
 		} else {
-			process.stdout.write(`${statuses.map(formatStatus).join("\n")}\n`);
+			process.stdout.write(`${statuses.map(s => formatDaemonStatus(s, { verbose: cmd.verbose })).join("\n")}\n`);
 		}
 		return;
 	}
@@ -116,7 +106,7 @@ export async function runDaemonCommand(cmd: DaemonCommandArgs, deps: DaemonComma
 	if (cmd.json) {
 		process.stdout.write(`${JSON.stringify(results, null, 2)}\n`);
 	} else {
-		process.stdout.write(`${results.map(formatResult).join("\n")}\n`);
+		process.stdout.write(`${results.map(formatDaemonResult).join("\n")}\n`);
 	}
-	if (results.some(r => !r.ok)) process.exitCode = 1;
+	if (results.some(r => !r.ok)) process.exitCode = DAEMON_EXIT.failure;
 }

--- a/packages/coding-agent/src/commands/daemon.ts
+++ b/packages/coding-agent/src/commands/daemon.ts
@@ -4,19 +4,32 @@
 import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { type DaemonCliAction, type DaemonCommandArgs, runDaemonCommand } from "../cli/daemon-cli";
 import type { DaemonKind } from "../daemon/control-types";
+import { DAEMON_ACTION_TOKENS, resolveDaemonAction } from "../daemon/operator-contract";
 import { initTheme } from "../modes/theme/theme";
 
-const ACTIONS: DaemonCliAction[] = ["list", "status", "stop", "reload"];
-
 export default class Daemon extends Command {
-	static description = "Manage GJC background daemons (status, list, stop, reload)";
+	static description =
+		"Manage GJC background daemons. Routine use: `gjc daemon status` to check, `gjc daemon restart` to reload (spawns one if none is running). `stop`/`list` and the escalation flags below are advanced primitives.";
+
+	static examples = [
+		"# Check the daemon (concise per-daemon result)\n  gjc daemon status",
+		"# Reload, spawning a fresh owner if none is running\n  gjc daemon restart",
+		"# Full runtime detail and the roots list\n  gjc daemon status --verbose",
+		"# Machine-readable output for automation\n  gjc daemon status --json",
+		"# Stop, hard-killing an unresponsive owner\n  gjc daemon stop --force",
+	];
 
 	static args = {
-		action: Args.string({ description: "Daemon action", required: false, options: ACTIONS }),
+		action: Args.string({
+			description: "Daemon action (status, restart, reload, stop, list)",
+			required: false,
+			options: DAEMON_ACTION_TOKENS as string[],
+		}),
 		kind: Args.string({ description: "Daemon kind(s) to target", required: false, multiple: true }),
 	};
 
 	static flags = {
+		verbose: Flags.boolean({ char: "v", description: "Show runtime detail and the full roots list" }),
 		all: Flags.boolean({ description: "Target all registered daemon kinds" }),
 		json: Flags.boolean({ description: "Emit JSON output" }),
 		force: Flags.boolean({ description: "Allow hard-kill escalation when graceful stop times out" }),
@@ -27,7 +40,7 @@ export default class Daemon extends Command {
 
 	async run(): Promise<void> {
 		const { args, flags } = await this.parse(Daemon);
-		const action = (args.action ?? "status") as DaemonCliAction;
+		const action = (resolveDaemonAction(args.action) ?? "status") as DaemonCliAction;
 		const kinds = (Array.isArray(args.kind) ? args.kind : args.kind ? [args.kind] : []) as DaemonKind[];
 		const flagRec = flags as Record<string, unknown>;
 		const cmd: DaemonCommandArgs = {
@@ -36,6 +49,7 @@ export default class Daemon extends Command {
 			all: Boolean(flags.all),
 			json: Boolean(flags.json),
 			force: Boolean(flags.force),
+			verbose: Boolean(flags.verbose),
 			gracefulTimeoutMs: flagRec["graceful-timeout-ms"] as number | undefined,
 			killTimeoutMs: flagRec["kill-timeout-ms"] as number | undefined,
 			spawnIfStopped: flagRec["spawn-if-stopped"] as boolean | undefined,

--- a/packages/coding-agent/src/daemon/control-types.ts
+++ b/packages/coding-agent/src/daemon/control-types.ts
@@ -47,6 +47,15 @@ export interface DaemonOperationOptions {
 	spawnIfStopped?: boolean;
 }
 
+export interface DaemonRecovery {
+	/** Machine-readable recovery category for automation branching. */
+	reason: "ownership_mismatch";
+	/** One-line human summary of why the operation could not proceed. */
+	summary: string;
+	/** Ordered, copy-pasteable remediation steps. */
+	steps: string[];
+}
+
 export interface DaemonOperationResult {
 	kind: DaemonKind;
 	action: Exclude<DaemonAction, "list">;
@@ -55,6 +64,8 @@ export interface DaemonOperationResult {
 	after?: DaemonStatus;
 	warnings: string[];
 	message: string;
+	/** Present when the operation was refused with an actionable recovery path (e.g. ownership mismatch). */
+	recovery?: DaemonRecovery;
 }
 
 export interface BuiltInDaemonController {

--- a/packages/coding-agent/src/daemon/operator-contract.ts
+++ b/packages/coding-agent/src/daemon/operator-contract.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared operator contract for the `gjc daemon` command surface.
+ *
+ * One source of truth for the beginner-safe operational vocabulary so the
+ * guided human surface and the machine-readable JSON never drift:
+ * - the terse action verbs plus operator aliases (e.g. `restart` -> `reload`),
+ * - process exit codes,
+ * - concise vs. `--verbose` human rendering of statuses and results, and
+ * - actionable recovery guidance for a token/chat ownership mismatch.
+ *
+ * The full roots/debug payload lives behind `--verbose` (human) or `--json`
+ * (automation); the default human output stays a concise per-daemon result.
+ */
+
+import type { DaemonAction, DaemonOperationResult, DaemonRecovery, DaemonStatus } from "./control-types";
+
+/** Canonical daemon actions accepted as the leading verb. */
+export const DAEMON_CANONICAL_ACTIONS: readonly DaemonAction[] = ["list", "status", "stop", "reload"];
+
+/**
+ * Operator-friendly aliases resolved to a canonical action. `restart` is the
+ * routine "reload if running, otherwise start" verb; it maps onto `reload`,
+ * whose default already spawns a fresh owner when none is running.
+ */
+export const DAEMON_ACTION_ALIASES: Readonly<Record<string, DaemonAction>> = {
+	restart: "reload",
+};
+
+/** Every token accepted in the leading action position (canonical + aliases). */
+export const DAEMON_ACTION_TOKENS: readonly string[] = [
+	...DAEMON_CANONICAL_ACTIONS,
+	...Object.keys(DAEMON_ACTION_ALIASES),
+];
+
+/** Resolve a leading verb (canonical or alias) to its canonical action. */
+export function resolveDaemonAction(token: string | undefined): DaemonAction | undefined {
+	if (token === undefined) return undefined;
+	if ((DAEMON_CANONICAL_ACTIONS as readonly string[]).includes(token)) return token as DaemonAction;
+	return DAEMON_ACTION_ALIASES[token];
+}
+
+/** Exit codes for `gjc daemon`. Backward compatible: success 0, any failure 1. */
+export const DAEMON_EXIT = { ok: 0, failure: 1 } as const;
+
+/** Human-facing headline when a spawn/reload is refused by a live foreign identity. */
+export const OWNERSHIP_MISMATCH_MESSAGE =
+	"refused: a live Telegram daemon with a different bot token or chat already owns this workspace";
+
+/** Structured, actionable recovery for a token/chat ownership mismatch. */
+export function ownershipMismatchRecovery(): DaemonRecovery {
+	return {
+		reason: "ownership_mismatch",
+		summary: "A live Telegram daemon owned by a different bot token or chat already holds this workspace.",
+		steps: [
+			"Confirm the intended bot token and chat with `gjc notify` (or edit notifications.telegram in your config).",
+			"If the running daemon is stale or unwanted, stop it with `gjc daemon stop --force`, then rerun `gjc daemon restart`.",
+			"If it is the correct daemon, no action is needed — this workspace attaches automatically once the identities match.",
+		],
+	};
+}
+
+function timestamp(ms: number | undefined): string | undefined {
+	if (ms === undefined) return undefined;
+	const date = new Date(ms);
+	return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+/**
+ * Render one daemon status. Concise by default (single head line + any
+ * actionable warning); `--verbose` adds runtime detail and the full roots list.
+ */
+export function formatDaemonStatus(status: DaemonStatus, opts: { verbose?: boolean } = {}): string {
+	const lines: string[] = [];
+	if (!status.configured) {
+		lines.push(`${status.kind}: not configured`);
+		if (status.runtime.warning) lines.push(`  warning: ${status.runtime.warning}`);
+		return lines.join("\n");
+	}
+
+	const meta: string[] = [];
+	if (status.pid !== undefined) meta.push(`pid ${status.pid}`);
+	if (status.ownerId) meta.push(`owner ${status.ownerId}`);
+	const rootCount = status.rootCount ?? status.roots?.length ?? 0;
+	if (rootCount > 0) meta.push(`${rootCount} root${rootCount === 1 ? "" : "s"}`);
+
+	let head = `${status.kind}: ${status.health}`;
+	if (meta.length > 0) head += ` (${meta.join(", ")})`;
+	if (status.detail) head += ` — ${status.detail}`;
+	lines.push(head);
+	if (status.runtime.warning) lines.push(`  warning: ${status.runtime.warning}`);
+
+	if (opts.verbose) {
+		lines.push(`  runtime: ${status.runtime.mode} (${status.runtime.execPath})`);
+		const started = timestamp(status.startedAt);
+		if (started) lines.push(`  started: ${started}`);
+		const heartbeat = timestamp(status.heartbeatAt);
+		if (heartbeat) lines.push(`  heartbeat: ${heartbeat}`);
+		const roots = status.roots ?? [];
+		lines.push(`  roots: ${rootCount}`);
+		for (const root of roots) lines.push(`    - ${root}`);
+	}
+
+	return lines.join("\n");
+}
+
+/**
+ * Render one operation result. Keeps the stable `<kind> <action>: ok|failed —
+ * <message>` head line, then any warnings, then actionable recovery steps.
+ */
+export function formatDaemonResult(result: DaemonOperationResult): string {
+	const lines = [`${result.kind} ${result.action}: ${result.ok ? "ok" : "failed"} — ${result.message}`];
+	for (const warning of result.warnings) lines.push(`  warning: ${warning}`);
+	if (result.recovery) {
+		lines.push(`  ${result.recovery.summary}`);
+		lines.push("  to recover:");
+		result.recovery.steps.forEach((step, i) => {
+			lines.push(`    ${i + 1}. ${step}`);
+		});
+	}
+	return lines.join("\n");
+}

--- a/packages/coding-agent/src/notifications/telegram-daemon-control.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-control.ts
@@ -16,9 +16,11 @@ import type {
 	DaemonHealth,
 	DaemonOperationOptions,
 	DaemonOperationResult,
+	DaemonRecovery,
 	DaemonRuntimeInfo,
 	DaemonStatus,
 } from "../daemon/control-types";
+import { OWNERSHIP_MISMATCH_MESSAGE, ownershipMismatchRecovery } from "../daemon/operator-contract";
 import { resolveGjcRuntimeSpawnInfo } from "../daemon/runtime";
 import { getNotificationConfig, isTelegramConfigured, tokenFingerprint } from "./config";
 import {
@@ -230,8 +232,9 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 		before: DaemonStatus | undefined,
 		after: DaemonStatus | undefined,
 		warnings: string[],
+		recovery?: DaemonRecovery,
 	): DaemonOperationResult {
-		return { kind: this.kind, action, ok, before, after, message, warnings };
+		return { kind: this.kind, action, ok, before, after, message, warnings, recovery };
 	}
 
 	async reload(opts: DaemonOperationOptions = {}): Promise<DaemonOperationResult> {
@@ -271,6 +274,17 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 			);
 			warnings.push(...spawned.warnings);
 			const after = await this.status();
+			if (spawned.result === "blocked") {
+				return this.result(
+					action,
+					false,
+					OWNERSHIP_MISMATCH_MESSAGE,
+					before,
+					after,
+					warnings,
+					ownershipMismatchRecovery(),
+				);
+			}
 			return this.result(
 				action,
 				spawned.result === "owner_spawned",
@@ -360,9 +374,20 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 		} else if (after.ownerId && after.ownerId === oldOwnerId) {
 			warnings.push("owner id unchanged after reload");
 		}
+		if (spawned.result === "blocked") {
+			return this.result(
+				action,
+				false,
+				OWNERSHIP_MISMATCH_MESSAGE,
+				before,
+				after,
+				warnings,
+				ownershipMismatchRecovery(),
+			);
+		}
 		return this.result(
 			action,
-			spawned.result !== "disabled" && spawned.result !== "blocked",
+			spawned.result !== "disabled",
 			`reloaded telegram daemon (${spawned.result})`,
 			before,
 			after,

--- a/packages/coding-agent/test/daemon-control.test.ts
+++ b/packages/coding-agent/test/daemon-control.test.ts
@@ -6,6 +6,14 @@ import { parseDaemonArgs, runDaemonCommand } from "../src/cli/daemon-cli";
 import { Settings } from "../src/config/settings";
 import { createBuiltInDaemonControllers, selectDaemonControllers } from "../src/daemon/builtin";
 import type { BuiltInDaemonController, DaemonOperationResult, DaemonStatus } from "../src/daemon/control-types";
+import {
+	DAEMON_ACTION_ALIASES,
+	formatDaemonResult,
+	formatDaemonStatus,
+	OWNERSHIP_MISMATCH_MESSAGE,
+	ownershipMismatchRecovery,
+	resolveDaemonAction,
+} from "../src/daemon/operator-contract";
 import { resolveGjcRuntimeSpawnInfo } from "../src/daemon/runtime";
 import { tokenFingerprint } from "../src/notifications/config";
 import { daemonPaths } from "../src/notifications/telegram-daemon";
@@ -134,6 +142,80 @@ describe("parseDaemonArgs", () => {
 	test("defaults to status and ignores non-daemon argv", () => {
 		expect(parseDaemonArgs(["notify", "status"])).toBeUndefined();
 		expect(parseDaemonArgs(["daemon"])?.action).toBe("status");
+	});
+
+	test("resolves the restart alias to reload and parses --verbose/-v", () => {
+		expect(parseDaemonArgs(["daemon", "restart"])?.action).toBe("reload");
+		expect(parseDaemonArgs(["daemon", "restart", "telegram"])?.kinds).toEqual(["telegram"]);
+		expect(parseDaemonArgs(["daemon", "status", "--verbose"])?.verbose).toBe(true);
+		expect(parseDaemonArgs(["daemon", "status", "-v"])?.verbose).toBe(true);
+		expect(parseDaemonArgs(["daemon", "status"])?.verbose).toBe(false);
+	});
+});
+
+describe("daemon operator contract", () => {
+	test("resolveDaemonAction maps canonical verbs and the restart alias", () => {
+		expect(resolveDaemonAction("status")).toBe("status");
+		expect(resolveDaemonAction("reload")).toBe("reload");
+		expect(resolveDaemonAction("restart")).toBe("reload");
+		expect(DAEMON_ACTION_ALIASES.restart).toBe("reload");
+		expect(resolveDaemonAction("bogus")).toBeUndefined();
+		expect(resolveDaemonAction(undefined)).toBeUndefined();
+	});
+
+	test("formatDaemonStatus stays concise by default and expands under verbose", () => {
+		const status: DaemonStatus = {
+			kind: "telegram",
+			configured: true,
+			health: "running",
+			pid: 7,
+			ownerId: "o1",
+			startedAt: 0,
+			heartbeatAt: 0,
+			roots: ["/a", "/b"],
+			rootCount: 2,
+			runtime: { mode: "source", execPath: "/usr/bin/node", reloadPicksUpSourceEdits: true },
+		};
+		const concise = formatDaemonStatus(status);
+		expect(concise).toBe("telegram: running (pid 7, owner o1, 2 roots)");
+		expect(concise).not.toContain("/a");
+
+		const verbose = formatDaemonStatus(status, { verbose: true });
+		expect(verbose).toContain("runtime: source (/usr/bin/node)");
+		expect(verbose).toContain("roots: 2");
+		expect(verbose).toContain("- /a");
+		expect(verbose).toContain("- /b");
+	});
+
+	test("formatDaemonStatus reports an unconfigured daemon without runtime noise", () => {
+		const status: DaemonStatus = {
+			kind: "telegram",
+			configured: false,
+			health: "not_configured",
+			runtime: { mode: "source", execPath: "/usr/bin/node", reloadPicksUpSourceEdits: true },
+		};
+		expect(formatDaemonStatus(status)).toBe("telegram: not configured");
+	});
+
+	test("formatDaemonResult renders the ownership-mismatch recovery steps", () => {
+		const recovery = ownershipMismatchRecovery();
+		expect(recovery.reason).toBe("ownership_mismatch");
+		expect(recovery.steps.length).toBeGreaterThan(0);
+
+		const result: DaemonOperationResult = {
+			kind: "telegram",
+			action: "reload",
+			ok: false,
+			warnings: [],
+			message: OWNERSHIP_MISMATCH_MESSAGE,
+			recovery,
+		};
+		const rendered = formatDaemonResult(result);
+		expect(rendered).toContain("telegram reload: failed");
+		expect(rendered).toContain(OWNERSHIP_MISMATCH_MESSAGE);
+		expect(rendered).toContain("to recover:");
+		expect(rendered).toContain("1. ");
+		for (const step of recovery.steps) expect(rendered).toContain(step);
 	});
 });
 
@@ -495,6 +577,35 @@ describe("runDaemonCommand", () => {
 		);
 		expect(out).toContain("telegram reload: ok");
 		expect(out).toContain("reloaded telegram daemon");
+	});
+
+	test("a refused reload surfaces recovery guidance and exits non-zero", async () => {
+		const prevExit = process.exitCode;
+		const status: DaemonStatus = {
+			kind: "telegram",
+			configured: true,
+			health: "stopped",
+			runtime: { mode: "source", execPath: "/usr/bin/node", reloadPicksUpSourceEdits: true },
+		};
+		const result: DaemonOperationResult = {
+			kind: "telegram",
+			action: "reload",
+			ok: false,
+			warnings: [],
+			message: OWNERSHIP_MISMATCH_MESSAGE,
+			recovery: ownershipMismatchRecovery(),
+		};
+		const out = await captureStdout(() =>
+			runDaemonCommand(
+				{ action: "reload", kinds: ["telegram"], all: false, json: false, force: false },
+				{ controllers: [fakeController(status, result)] },
+			),
+		);
+		expect(out).toContain("telegram reload: failed");
+		expect(out).toContain("to recover:");
+		expect(process.exitCode).toBe(1);
+		// Reset so this expected non-zero exitCode does not leak into the runner's exit status.
+		process.exitCode = typeof prevExit === "number" ? prevExit : 0;
 	});
 });
 


### PR DESCRIPTION
## Summary

Closes #2049. Adds a beginner-safe, terse operational surface for `gjc daemon` while keeping the existing explicit commands as advanced primitives.

A new shared operator contract (`src/daemon/operator-contract.ts`) is the single source of truth so the guided human surface and the machine-readable JSON never drift.

## What changed

- **Aliases**: `restart` resolves to `reload` (reload-if-running, otherwise spawn a fresh owner). Canonical verbs (`status`/`list`/`stop`/`reload`) are unchanged.
- **Concise by default**: human `status` output is a single per-daemon head line (health, pid, owner, root *count*). Full runtime detail and the roots list now require `--verbose`/`-v`; `--json` remains the automation path.
- **Actionable recovery**: a token/chat ownership mismatch is refused with a structured `recovery` (machine `reason: "ownership_mismatch"` + copy-pasteable steps) instead of a large payload ending in `blocked`.
- **Help text**: leads with the routine workflow (`status`, `restart`) and keeps destructive/escalation flags (`stop --force`, timeouts) explicit.
- **Backward compatible**: JSON shape is unchanged; exit codes stay 0 on success / 1 on any failure.

## Testing

- `bun test test/daemon-control.test.ts` — 28 pass (adds coverage for the `restart` alias, `--verbose`/`-v` parsing, concise vs. verbose status rendering, and ownership-mismatch recovery rendering + non-zero exit).
- `bun run check:types` — clean.
- `biome check` on touched files — clean.

Note: unrelated locally-regenerated NAPI-RS native bindings drift (`packages/natives/native/index.*`) is intentionally excluded from this PR.