### PR TITLE
feat(coding-agent): shared notification service for CLI and /notify (#2050)

### DIFF
--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -7,9 +7,19 @@ import { createInterface } from "node:readline/promises";
 import { APP_NAME } from "@gajae-code/utils/dirs";
 import chalk from "chalk";
 import type { Settings } from "../config/settings";
-import { getNotificationConfig, maskToken } from "../notifications/config";
+import { maskToken } from "../notifications/config";
+import {
+	buildNotificationStatusReport,
+	checkNotificationHealth,
+	formatNotificationHealthReport,
+	formatNotificationRecoveryReport,
+	formatNotificationStatusReport,
+	formatNotificationTestResult,
+	recoverNotifications,
+	sendNotificationTest,
+} from "../notifications/notification-service";
 
-export type NotifyAction = "setup" | "status" | "daemon-internal";
+export type NotifyAction = "setup" | "status" | "health" | "test" | "recovery" | "daemon-internal";
 
 export interface NotifyCommandArgs {
 	action: NotifyAction;
@@ -18,6 +28,8 @@ export interface NotifyCommandArgs {
 	token?: string;
 	chatId?: string;
 	redact?: boolean;
+	probe?: boolean;
+	message?: string;
 }
 
 export interface NotifyCommandDeps {
@@ -93,6 +105,19 @@ export function parseNotifyArgs(args: string[]): NotifyCommandArgs | undefined {
 			redact: rest.includes("--redact"),
 		};
 	}
+	if (action === "health" || action === "test" || action === "recovery") {
+		const rest = args.slice(2);
+		const flag = (name: string): string | undefined => {
+			const i = rest.indexOf(name);
+			return i >= 0 ? rest[i + 1] : undefined;
+		};
+		return {
+			action,
+			rawArgs: rest,
+			probe: rest.includes("--probe"),
+			message: flag("--message"),
+		};
+	}
 	if (action === "daemon-internal") {
 		return {
 			action,
@@ -116,6 +141,15 @@ export async function runNotifyCommand(cmd: NotifyCommandArgs, deps: NotifyComma
 			return;
 		case "status":
 			await runStatus(deps);
+			return;
+		case "health":
+			await runHealth(deps, cmd);
+			return;
+		case "test":
+			await runTest(deps, cmd);
+			return;
+		case "recovery":
+			await runRecovery(deps);
 			return;
 		case "daemon-internal": {
 			const m = await import("../notifications/telegram-daemon-cli");
@@ -411,18 +445,40 @@ async function verifyThreadedMode(
 
 async function runStatus(deps: NotifyCommandDeps): Promise<void> {
 	const settings = await getSettings(deps);
-	const cfg = getNotificationConfig(settings);
+	const report = buildNotificationStatusReport(settings);
 	process.stdout.write(
-		`${chalk.bold("Notifications")}\n` +
-			`  enabled: ${cfg.enabled}\n` +
-			`  telegram.botToken: ${maskToken(cfg.botToken)}\n` +
-			`  telegram.chatId: ${cfg.chatId ?? "(unset)"}\n` +
-			`  discord.botToken: ${maskToken(cfg.discord.botToken)}\n` +
-			`  discord.channelId: ${cfg.discord.channelId ?? "(unset)"}\n` +
-			`  slack.botToken: ${maskToken(cfg.slack.botToken)}\n` +
-			`  slack.channelId: ${cfg.slack.channelId ?? "(unset)"}\n` +
-			`  redact: ${cfg.redact}\n`,
+		`${chalk.bold("Notifications")}\n${formatNotificationStatusReport(report).split("\n").slice(1).join("\n")}\n`,
 	);
+}
+
+async function runHealth(deps: NotifyCommandDeps, cmd: NotifyCommandArgs): Promise<void> {
+	const settings = await getSettings(deps);
+	const report = await checkNotificationHealth({
+		settings,
+		probe: cmd.probe,
+		deps: { fetchImpl: deps.fetchImpl, apiBase: deps.apiBase },
+	});
+	process.stdout.write(`${formatNotificationHealthReport(report)}\n`);
+	if (report.overall === "error" && deps.setExitCode) deps.setExitCode(1);
+	else if (report.overall === "error") process.exitCode = 1;
+}
+
+async function runTest(deps: NotifyCommandDeps, cmd: NotifyCommandArgs): Promise<void> {
+	const settings = await getSettings(deps);
+	const result = await sendNotificationTest({
+		settings,
+		text: cmd.message,
+		deps: { fetchImpl: deps.fetchImpl, apiBase: deps.apiBase },
+	});
+	process.stdout.write(`${formatNotificationTestResult(result)}\n`);
+	if (!result.ok && deps.setExitCode) deps.setExitCode(1);
+	else if (!result.ok) process.exitCode = 1;
+}
+
+async function runRecovery(deps: NotifyCommandDeps): Promise<void> {
+	const settings = await getSettings(deps);
+	const report = await recoverNotifications({ settings });
+	process.stdout.write(`${formatNotificationRecoveryReport(report)}\n`);
 }
 
 async function waitForPrivateChat(
@@ -514,15 +570,23 @@ ${chalk.bold("Usage:")}
   ${APP_NAME} notify setup
   ${APP_NAME} notify setup --token <botToken> --chat-id <chatId> [--redact]
   ${APP_NAME} notify status
+  ${APP_NAME} notify health [--probe]
+  ${APP_NAME} notify test [--message <text>]
+  ${APP_NAME} notify recovery
 
 ${chalk.bold("Subcommands:")}
   setup     Pair a Telegram bot token with a private chat and verify Threaded Mode capability
   status    Show notification configuration without secrets
+  health    Report config, daemon-ownership and endpoint health (--probe adds a Telegram reachability check)
+  test      Send a one-off test notification through the configured Telegram adapter
+  recovery  Clear dead-owner daemon locks and stale per-session endpoint files (never touches a live owner)
 
 ${chalk.bold("Examples:")}
   ${APP_NAME} notify setup
-  ${APP_NAME} notify setup --token <botToken> --chat-id <chatId> [--redact]
   ${APP_NAME} notify status
+  ${APP_NAME} notify health --probe
+  ${APP_NAME} notify test --message "hello from gjc"
+  ${APP_NAME} notify recovery
 
 ${chalk.bold("Threaded Mode:")}
   GJC uses Telegram private-chat topics for per-session threads. Setup verifies the bot

--- a/packages/coding-agent/src/commands/notify.ts
+++ b/packages/coding-agent/src/commands/notify.ts
@@ -5,7 +5,7 @@ import { Args, Command, Flags } from "@gajae-code/utils/cli";
 import { type NotifyAction, type NotifyCommandArgs, runNotifyCliCommand } from "../cli/notify-cli";
 import { initTheme } from "../modes/theme/theme";
 
-const ACTIONS: NotifyAction[] = ["setup", "status", "daemon-internal"];
+const ACTIONS: NotifyAction[] = ["setup", "status", "health", "test", "recovery", "daemon-internal"];
 
 export default class Notify extends Command {
 	static description = "Configure Telegram notifications";
@@ -28,6 +28,8 @@ export default class Notify extends Command {
 		token: Flags.string({ description: "Telegram bot token (non-interactive setup)" }),
 		"chat-id": Flags.string({ description: "Telegram chat id to pair (non-interactive setup)" }),
 		redact: Flags.boolean({ description: "Enable redaction of remote notification content" }),
+		probe: Flags.boolean({ description: "notify health: probe Telegram reachability (getMe)" }),
+		message: Flags.string({ description: "notify test: custom message body" }),
 		"owner-id": Flags.string({ description: "Internal: daemon owner id" }),
 		"agent-dir": Flags.string({ description: "Internal: agent dir for the daemon" }),
 	};
@@ -53,6 +55,8 @@ export default class Notify extends Command {
 			token: flags.token as string | undefined,
 			chatId: (flags as Record<string, unknown>)["chat-id"] as string | undefined,
 			redact: Boolean(flags.redact),
+			probe: Boolean(flags.probe),
+			message: flags.message as string | undefined,
 		};
 
 		if (action !== "daemon-internal") await initTheme();

--- a/packages/coding-agent/src/notifications/daemon-paths.ts
+++ b/packages/coding-agent/src/notifications/daemon-paths.ts
@@ -1,5 +1,13 @@
 import * as path from "node:path";
 
+/**
+ * Owner heartbeat freshness window. A daemon ownership record older than this
+ * (without a live pid) is considered stale. Lives here, in the lightweight
+ * paths module, so secret-safe consumers (e.g. the notification service) can
+ * reuse it without importing the heavy daemon runtime.
+ */
+export const HEARTBEAT_TTL_MS = 20_000;
+
 export interface DaemonPaths {
 	dir: string;
 	lock: string;

--- a/packages/coding-agent/src/notifications/notification-service.ts
+++ b/packages/coding-agent/src/notifications/notification-service.ts
@@ -21,22 +21,57 @@ import {
 	type NotificationConfig,
 	tokenFingerprint,
 } from "./config";
-import { daemonPaths, HEARTBEAT_TTL_MS } from "./daemon-paths";
+import { type DaemonPaths, daemonPaths, HEARTBEAT_TTL_MS } from "./daemon-paths";
 import type { DaemonState } from "./telegram-daemon";
 
 const DEFAULT_API_BASE = "https://api.telegram.org";
+
+/**
+ * Telegram bot-token shape: `<digits>:<base64url-ish>`. Used to redact a
+ * token-shaped substring from a diagnostic even when the exact configured token
+ * is not known to the caller (e.g. a token echoed inside a fetch error URL).
+ */
+const TELEGRAM_TOKEN_PATTERN = /\d{6,}:[A-Za-z0-9_-]{20,}/g;
+
+/**
+ * Strip secrets from a human-facing diagnostic string. Redacts the configured
+ * bot token (exact match) and any token-shaped substring so health/test details
+ * can never leak a credential regardless of where the string originated.
+ */
+export function sanitizeDiagnostic(text: string, token?: string): string {
+	let out = text;
+	const trimmed = token?.trim();
+	if (trimmed) out = out.split(trimmed).join("<redacted>");
+	return out.replace(TELEGRAM_TOKEN_PATTERN, "<redacted>");
+}
 
 /** Minimal filesystem surface the service needs; injectable for tests. */
 export interface NotificationServiceFs {
 	readdir(dir: string): Promise<string[]>;
 	readFile(file: string, encoding: "utf8"): Promise<string>;
 	unlink(file: string): Promise<void>;
+	/**
+	 * Atomically create `file` with O_EXCL semantics: resolves `true` when this
+	 * call created it, `false` when it already existed. Used to hold the daemon
+	 * steal-mutex ({@link DaemonPaths.steal}) during owner-bound lock removal so
+	 * recovery and a concurrent daemon takeover are mutually exclusive.
+	 */
+	createExclusive(file: string): Promise<boolean>;
 }
 
 const nodeServiceFs: NotificationServiceFs = {
 	readdir: dir => fsPromises.readdir(dir),
 	readFile: (file, encoding) => fsPromises.readFile(file, encoding),
 	unlink: file => fsPromises.unlink(file),
+	createExclusive: async file => {
+		try {
+			const handle = await fsPromises.open(file, "wx", 0o600);
+			await handle.close();
+			return true;
+		} catch {
+			return false;
+		}
+	},
 };
 
 /** Injectable dependencies shared across service operations. */
@@ -141,7 +176,21 @@ interface EndpointView {
 	sessionId: string;
 	pid: number | undefined;
 	stale: boolean;
-	updatedAt: number | undefined;
+}
+
+type EndpointLiveness = "live" | "dead" | "unknown";
+
+/**
+ * Classify an endpoint using owner-proof semantics. An endpoint is only `dead`
+ * with positive proof: an explicit `stale` tombstone, or a recorded pid that is
+ * confirmed not alive. A PID-less endpoint is `unknown` (not provably dead) and
+ * must never be treated as dead — removing it could delete a live session's
+ * discovery file that simply omitted a pid.
+ */
+function endpointLiveness(view: EndpointView, pidAlive: (pid: number) => boolean): EndpointLiveness {
+	if (view.stale) return "dead";
+	if (view.pid === undefined) return "unknown";
+	return pidAlive(view.pid) ? "live" : "dead";
 }
 
 async function readEndpointView(fs: NotificationServiceFs, file: string): Promise<EndpointView | undefined> {
@@ -159,12 +208,10 @@ async function readEndpointView(fs: NotificationServiceFs, file: string): Promis
 	}
 	if (!parsed || typeof parsed !== "object") return undefined;
 	const rec = parsed as Record<string, unknown>;
-	const sessionId = typeof rec.sessionId === "string" ? rec.sessionId : path.basename(file, ".json");
 	return {
-		sessionId,
+		sessionId: typeof rec.sessionId === "string" ? rec.sessionId : path.basename(file, ".json"),
 		pid: typeof rec.pid === "number" ? rec.pid : undefined,
 		stale: rec.stale === true,
-		updatedAt: typeof rec.updatedAt === "number" ? rec.updatedAt : undefined,
 	};
 }
 
@@ -220,7 +267,8 @@ export interface DaemonHealth {
 export interface EndpointHealth {
 	total: number;
 	live: number;
-	stale: number;
+	dead: number;
+	unknown: number;
 	unreadable: number;
 }
 
@@ -259,9 +307,12 @@ async function probeTelegramReachability(
 			const username = payload.result?.username;
 			return { ok: true, detail: username ? `reachable as @${username}` : "reachable" };
 		}
-		return { ok: false, detail: payload?.description ?? `Telegram getMe failed (HTTP ${response.status})` };
+		return {
+			ok: false,
+			detail: sanitizeDiagnostic(payload?.description ?? `Telegram getMe failed (HTTP ${response.status})`, token),
+		};
 	} catch (err) {
-		return { ok: false, detail: err instanceof Error ? err.message : "network error" };
+		return { ok: false, detail: sanitizeDiagnostic(err instanceof Error ? err.message : "network error", token) };
 	}
 }
 
@@ -335,7 +386,8 @@ export async function checkNotificationHealth(opts: HealthOptions): Promise<Noti
 	const dir = endpointDir(stateRoot);
 	const files = await listEndpointFiles(fs, dir);
 	let live = 0;
-	let stale = 0;
+	let dead = 0;
+	let unknownEndpoints = 0;
 	let unreadable = 0;
 	for (const name of files) {
 		const view = await readEndpointView(fs, path.join(dir, name));
@@ -343,19 +395,31 @@ export async function checkNotificationHealth(opts: HealthOptions): Promise<Noti
 			unreadable += 1;
 			continue;
 		}
-		const dead = view.pid === undefined || !pidAlive(view.pid);
-		if (view.stale || dead) stale += 1;
-		else live += 1;
+		switch (endpointLiveness(view, pidAlive)) {
+			case "live":
+				live += 1;
+				break;
+			case "dead":
+				dead += 1;
+				break;
+			default:
+				unknownEndpoints += 1;
+				break;
+		}
 	}
-	const endpoints: EndpointHealth = { total: files.length, live, stale, unreadable };
-	if (stale > 0 || unreadable > 0) {
+	const endpoints: EndpointHealth = { total: files.length, live, dead, unknown: unknownEndpoints, unreadable };
+	if (dead > 0 || unreadable > 0) {
 		checks.push({
 			name: "endpoints",
 			level: "warn",
-			detail: `${stale} stale / ${unreadable} unreadable of ${files.length} endpoint file(s); run recovery`,
+			detail: `${dead} dead / ${unreadable} unreadable of ${files.length} endpoint file(s); run recovery`,
 		});
 	} else {
-		checks.push({ name: "endpoints", level: "ok", detail: `${live} live endpoint file(s)` });
+		checks.push({
+			name: "endpoints",
+			level: "ok",
+			detail: `${live} live, ${unknownEndpoints} unverified endpoint file(s)`,
+		});
 	}
 
 	// Optional network reachability probe.
@@ -434,14 +498,17 @@ export async function sendNotificationTest(opts: TestOptions): Promise<Notificat
 			ok: false,
 			adapter: "telegram",
 			chatId: cfg.chatId,
-			detail: payload?.description ?? `Telegram sendMessage failed (HTTP ${response.status})`,
+			detail: sanitizeDiagnostic(
+				payload?.description ?? `Telegram sendMessage failed (HTTP ${response.status})`,
+				cfg.botToken,
+			),
 		};
 	} catch (err) {
 		return {
 			ok: false,
 			adapter: "telegram",
 			chatId: cfg.chatId,
-			detail: err instanceof Error ? err.message : "network error",
+			detail: sanitizeDiagnostic(err instanceof Error ? err.message : "network error", cfg.botToken),
 		};
 	}
 }
@@ -459,7 +526,13 @@ export interface RecoveredEndpoint {
 	reason: "stale-flag" | "dead-pid";
 }
 
-export type DaemonRecoveryAction = "none" | "cleared-dead-owner-lock" | "left-active" | "orphan-lock-left";
+export type DaemonRecoveryAction =
+	| "none"
+	| "cleared-dead-owner-lock"
+	| "left-active"
+	| "left-contended"
+	| "owner-superseded"
+	| "orphan-lock-left";
 
 export interface NotificationRecoveryReport {
 	endpointsScanned: number;
@@ -481,10 +554,47 @@ export interface RecoveryOptions {
 }
 
 /**
+ * Owner-bound removal of a dead daemon's lock. Closes the classic
+ * check-then-unlink TOCTOU: a naive `unlink(lock)` after observing a dead owner
+ * can delete a *new* live owner's lock if a daemon took over in between. This
+ * primitive re-checks ownership while holding the same steal-mutex the daemon's
+ * own takeover path uses ({@link DaemonPaths.steal}), so the two are mutually
+ * exclusive, and unlinks only when the recorded owner is still the same
+ * confirmed-dead process.
+ */
+async function removeDeadOwnerLock(
+	fs: NotificationServiceFs,
+	paths: DaemonPaths,
+	pidAlive: (pid: number) => boolean,
+	expected: DaemonState,
+): Promise<"cleared" | "contended" | "superseded" | "now-alive" | "unlink-failed"> {
+	if (!(await fs.createExclusive(paths.steal))) return "contended";
+	try {
+		const current = await readDaemonStateFile(fs, paths.state);
+		if (!current || current.ownerId !== expected.ownerId || current.pid !== expected.pid) {
+			return "superseded";
+		}
+		if (pidAlive(current.pid)) return "now-alive";
+		try {
+			await fs.unlink(paths.lock);
+			return "cleared";
+		} catch {
+			return "unlink-failed";
+		}
+	} finally {
+		await fs.unlink(paths.steal).catch(() => undefined);
+	}
+}
+
+/**
  * Ownership-protected cleanup. Removes only DEAD-owner artifacts:
- * per-session endpoint files flagged stale or whose pid is dead, and a daemon
- * lock whose recorded owner pid is confirmed dead. Never removes a live owner's
- * lock, never deletes unreadable files, and never kills a process.
+ * per-session endpoint files with positive proof of death (a stale tombstone or
+ * a dead recorded pid), and a daemon lock whose recorded owner is confirmed
+ * dead. A PID-less endpoint is treated as unknown (not dead) and kept. The
+ * daemon lock is removed through {@link removeDeadOwnerLock}, an owner-bound
+ * primitive that re-checks ownership under the daemon steal-mutex so it can
+ * never race a concurrent takeover. Never removes a live owner's lock, never
+ * deletes unreadable files, and never kills a process.
  */
 export async function recoverNotifications(opts: RecoveryOptions): Promise<NotificationRecoveryReport> {
 	const deps = opts.deps ?? {};
@@ -504,8 +614,9 @@ export async function recoverNotifications(opts: RecoveryOptions): Promise<Notif
 			unreadable += 1;
 			continue;
 		}
-		const dead = view.pid === undefined || !pidAlive(view.pid);
-		if (!view.stale && !dead) {
+		if (endpointLiveness(view, pidAlive) !== "dead") {
+			// Keep live AND unknown (PID-less) endpoints: only positive proof of
+			// death (a stale tombstone or a dead pid) authorizes removal.
 			kept += 1;
 			continue;
 		}
@@ -545,22 +656,28 @@ export async function recoverNotifications(opts: RecoveryOptions): Promise<Notif
 			pid: state.pid,
 		};
 	} else if (hasLock) {
-		try {
-			await fs.unlink(paths.lock);
-			daemon = {
-				action: "cleared-dead-owner-lock",
-				detail: `cleared lock of dead owner pid ${state.pid}`,
-				ownerId: state.ownerId,
-				pid: state.pid,
-			};
-		} catch {
-			daemon = {
-				action: "orphan-lock-left",
-				detail: `could not remove lock of dead owner pid ${state.pid}`,
-				ownerId: state.ownerId,
-				pid: state.pid,
-			};
-		}
+		const outcome = await removeDeadOwnerLock(fs, paths, pidAlive, state);
+		const action: DaemonRecoveryAction =
+			outcome === "cleared"
+				? "cleared-dead-owner-lock"
+				: outcome === "now-alive"
+					? "left-active"
+					: outcome === "superseded"
+						? "owner-superseded"
+						: outcome === "contended"
+							? "left-contended"
+							: "orphan-lock-left";
+		const detail =
+			outcome === "cleared"
+				? `cleared lock of dead owner pid ${state.pid}`
+				: outcome === "now-alive"
+					? `owner pid ${state.pid} became live during recovery; lock left untouched`
+					: outcome === "superseded"
+						? "a new daemon owner took over during recovery; lock left untouched"
+						: outcome === "contended"
+							? "another daemon is starting or stealing the lock; lock left untouched"
+							: `could not remove lock of dead owner pid ${state.pid}`;
+		daemon = { action, detail, ownerId: state.ownerId, pid: state.pid };
 	} else {
 		daemon = {
 			action: "none",

--- a/packages/coding-agent/src/notifications/notification-service.ts
+++ b/packages/coding-agent/src/notifications/notification-service.ts
@@ -1,0 +1,593 @@
+/**
+ * Shared notification service contract.
+ *
+ * Transport-agnostic, secret-safe operations consumed by BOTH the `gjc notify`
+ * CLI and the cross-mode `/notify` slash command (TUI + ACP). Every result is
+ * free of raw secrets: bot tokens are only ever shown masked (`maskToken`) or
+ * as a non-reversible fingerprint (`tokenFingerprint`).
+ *
+ * Daemon-ownership protection: `recoverNotifications` only ever removes
+ * artifacts belonging to a DEAD owner (dead-PID / explicitly-stale). It never
+ * touches a live owner's lock/state and never kills a process.
+ */
+import * as fsPromises from "node:fs/promises";
+import * as path from "node:path";
+import type { Settings } from "../config/settings";
+import {
+	getNotificationConfig,
+	isGloballyConfigured,
+	isTelegramConfigured,
+	maskToken,
+	type NotificationConfig,
+	tokenFingerprint,
+} from "./config";
+import { daemonPaths, HEARTBEAT_TTL_MS } from "./daemon-paths";
+import type { DaemonState } from "./telegram-daemon";
+
+const DEFAULT_API_BASE = "https://api.telegram.org";
+
+/** Minimal filesystem surface the service needs; injectable for tests. */
+export interface NotificationServiceFs {
+	readdir(dir: string): Promise<string[]>;
+	readFile(file: string, encoding: "utf8"): Promise<string>;
+	unlink(file: string): Promise<void>;
+}
+
+const nodeServiceFs: NotificationServiceFs = {
+	readdir: dir => fsPromises.readdir(dir),
+	readFile: (file, encoding) => fsPromises.readFile(file, encoding),
+	unlink: file => fsPromises.unlink(file),
+};
+
+/** Injectable dependencies shared across service operations. */
+export interface NotificationServiceDeps {
+	fs?: NotificationServiceFs;
+	now?: () => number;
+	pidAlive?: (pid: number) => boolean;
+	fetchImpl?: typeof fetch;
+	apiBase?: string;
+}
+
+function defaultPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		// EPERM means the process exists but is owned by another user: still alive.
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+function defaultStateRoot(): string {
+	return path.join(process.cwd(), ".gjc", "state");
+}
+
+function endpointDir(stateRoot: string): string {
+	return path.join(stateRoot, "notifications");
+}
+
+// --- status -------------------------------------------------------------
+
+export interface AdapterConfigView {
+	botTokenMasked: string;
+	channel: string | undefined;
+	configured: boolean;
+}
+
+export interface NotificationStatusReport {
+	enabled: boolean;
+	redact: boolean;
+	verbosity: "lean" | "verbose";
+	globallyConfigured: boolean;
+	telegram: AdapterConfigView & { tokenFingerprint: string | undefined };
+	discord: AdapterConfigView;
+	slack: AdapterConfigView;
+}
+
+function adapterConfigured(token: string | undefined, channel: string | undefined): boolean {
+	return Boolean(token?.trim()) && Boolean(channel?.trim());
+}
+
+/** Build a secret-safe structured status snapshot from settings. */
+export function buildNotificationStatusReport(settings: Settings): NotificationStatusReport {
+	const cfg = getNotificationConfig(settings);
+	return {
+		enabled: cfg.enabled,
+		redact: cfg.redact,
+		verbosity: cfg.verbosity,
+		globallyConfigured: isGloballyConfigured(cfg),
+		telegram: {
+			botTokenMasked: maskToken(cfg.botToken),
+			channel: cfg.chatId,
+			configured: isTelegramConfigured(cfg),
+			tokenFingerprint: cfg.botToken?.trim() ? tokenFingerprint(cfg.botToken) : undefined,
+		},
+		discord: {
+			botTokenMasked: maskToken(cfg.discord.botToken),
+			channel: cfg.discord.channelId,
+			configured: adapterConfigured(cfg.discord.botToken, cfg.discord.channelId),
+		},
+		slack: {
+			botTokenMasked: maskToken(cfg.slack.botToken),
+			channel: cfg.slack.channelId,
+			configured: adapterConfigured(cfg.slack.botToken, cfg.slack.channelId),
+		},
+	};
+}
+
+/** Render a status report as human-readable lines (no secrets). */
+export function formatNotificationStatusReport(report: NotificationStatusReport): string {
+	const yesNo = (v: boolean): string => (v ? "yes" : "no");
+	return [
+		"Notifications",
+		`  enabled: ${report.enabled}`,
+		`  globally configured: ${yesNo(report.globallyConfigured)}`,
+		`  redact: ${report.redact}`,
+		`  verbosity: ${report.verbosity}`,
+		`  telegram.botToken: ${report.telegram.botTokenMasked}`,
+		`  telegram.chatId: ${report.telegram.channel ?? "(unset)"}`,
+		`  telegram.fingerprint: ${report.telegram.tokenFingerprint ?? "(unset)"}`,
+		`  telegram.configured: ${yesNo(report.telegram.configured)}`,
+		`  discord.botToken: ${report.discord.botTokenMasked}`,
+		`  discord.channelId: ${report.discord.channel ?? "(unset)"}`,
+		`  slack.botToken: ${report.slack.botTokenMasked}`,
+		`  slack.channelId: ${report.slack.channel ?? "(unset)"}`,
+	].join("\n");
+}
+
+// --- endpoint / daemon file readers -------------------------------------
+
+interface EndpointView {
+	sessionId: string;
+	pid: number | undefined;
+	stale: boolean;
+	updatedAt: number | undefined;
+}
+
+async function readEndpointView(fs: NotificationServiceFs, file: string): Promise<EndpointView | undefined> {
+	let raw: string;
+	try {
+		raw = await fs.readFile(file, "utf8");
+	} catch {
+		return undefined;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+	if (!parsed || typeof parsed !== "object") return undefined;
+	const rec = parsed as Record<string, unknown>;
+	const sessionId = typeof rec.sessionId === "string" ? rec.sessionId : path.basename(file, ".json");
+	return {
+		sessionId,
+		pid: typeof rec.pid === "number" ? rec.pid : undefined,
+		stale: rec.stale === true,
+		updatedAt: typeof rec.updatedAt === "number" ? rec.updatedAt : undefined,
+	};
+}
+
+function parseDaemonState(raw: string): DaemonState | undefined {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+	if (!parsed || typeof parsed !== "object") return undefined;
+	const rec = parsed as Record<string, unknown>;
+	if (typeof rec.pid !== "number" || typeof rec.ownerId !== "string") return undefined;
+	return parsed as DaemonState;
+}
+
+async function readDaemonStateFile(fs: NotificationServiceFs, file: string): Promise<DaemonState | undefined> {
+	try {
+		return parseDaemonState(await fs.readFile(file, "utf8"));
+	} catch {
+		return undefined;
+	}
+}
+
+async function listEndpointFiles(fs: NotificationServiceFs, dir: string): Promise<string[]> {
+	try {
+		return (await fs.readdir(dir)).filter(name => name.endsWith(".json"));
+	} catch {
+		return [];
+	}
+}
+
+// --- health -------------------------------------------------------------
+
+export type HealthLevel = "ok" | "warn" | "error";
+
+export interface HealthCheck {
+	name: string;
+	level: HealthLevel;
+	detail: string;
+}
+
+export interface DaemonHealth {
+	present: boolean;
+	ownerId: string | undefined;
+	pid: number | undefined;
+	alive: boolean;
+	heartbeatFresh: boolean;
+	identityMatches: boolean;
+	stopped: boolean;
+}
+
+export interface EndpointHealth {
+	total: number;
+	live: number;
+	stale: number;
+	unreadable: number;
+}
+
+export interface NotificationHealthReport {
+	overall: HealthLevel;
+	configured: boolean;
+	checks: HealthCheck[];
+	daemon: DaemonHealth;
+	endpoints: EndpointHealth;
+	reachability: { probed: boolean; ok: boolean; detail: string };
+}
+
+export interface HealthOptions {
+	settings: Settings;
+	stateRoot?: string;
+	deps?: NotificationServiceDeps;
+	/** When true and Telegram is configured, probe the Bot API (getMe) for reachability. */
+	probe?: boolean;
+}
+
+async function probeTelegramReachability(
+	fetchImpl: typeof fetch,
+	apiBase: string,
+	token: string,
+): Promise<{ ok: boolean; detail: string }> {
+	try {
+		const response = await fetchImpl(`${apiBase.replace(/\/$/, "")}/bot${token}/getMe`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: "{}",
+		});
+		const payload = (await response.json().catch(() => undefined)) as
+			| { ok?: boolean; description?: string; result?: { username?: string } }
+			| undefined;
+		if (response.ok && payload?.ok) {
+			const username = payload.result?.username;
+			return { ok: true, detail: username ? `reachable as @${username}` : "reachable" };
+		}
+		return { ok: false, detail: payload?.description ?? `Telegram getMe failed (HTTP ${response.status})` };
+	} catch (err) {
+		return { ok: false, detail: err instanceof Error ? err.message : "network error" };
+	}
+}
+
+function worst(a: HealthLevel, b: HealthLevel): HealthLevel {
+	const rank: Record<HealthLevel, number> = { ok: 0, warn: 1, error: 2 };
+	return rank[a] >= rank[b] ? a : b;
+}
+
+/** Structural (offline-by-default) health of the notification subsystem. */
+export async function checkNotificationHealth(opts: HealthOptions): Promise<NotificationHealthReport> {
+	const deps = opts.deps ?? {};
+	const fs = deps.fs ?? nodeServiceFs;
+	const now = (deps.now ?? Date.now)();
+	const pidAlive = deps.pidAlive ?? defaultPidAlive;
+	const stateRoot = opts.stateRoot ?? defaultStateRoot();
+
+	const cfg: NotificationConfig = getNotificationConfig(opts.settings);
+	const configured = isGloballyConfigured(cfg);
+	const telegramConfigured = isTelegramConfigured(cfg);
+	const checks: HealthCheck[] = [];
+
+	if (!cfg.enabled) {
+		checks.push({
+			name: "config",
+			level: "warn",
+			detail: "notifications are disabled (notifications.enabled=false)",
+		});
+	} else if (!configured) {
+		checks.push({ name: "config", level: "warn", detail: "no notification adapter is fully configured" });
+	} else {
+		checks.push({ name: "config", level: "ok", detail: "enabled with at least one configured adapter" });
+	}
+
+	// Daemon ownership state (offline; read the persisted state file directly).
+	const paths = daemonPaths(opts.settings.getAgentDir());
+	const state = await readDaemonStateFile(fs, paths.state);
+	const daemon: DaemonHealth = {
+		present: Boolean(state),
+		ownerId: state?.ownerId,
+		pid: state?.pid,
+		alive: state ? pidAlive(state.pid) : false,
+		heartbeatFresh: state ? now - state.heartbeatAt <= HEARTBEAT_TTL_MS : false,
+		identityMatches:
+			Boolean(state) &&
+			telegramConfigured &&
+			state?.tokenFingerprint === tokenFingerprint(cfg.botToken) &&
+			state?.chatId === cfg.chatId,
+		stopped: typeof state?.stoppedAt === "number",
+	};
+	if (!state) {
+		checks.push({ name: "daemon", level: "ok", detail: "no daemon ownership record (none running)" });
+	} else if (!daemon.alive) {
+		checks.push({
+			name: "daemon",
+			level: "warn",
+			detail: `daemon owner pid ${daemon.pid} is not alive; run recovery to clear the stale lock`,
+		});
+	} else if (!daemon.heartbeatFresh) {
+		checks.push({ name: "daemon", level: "warn", detail: `daemon pid ${daemon.pid} heartbeat is stale` });
+	} else if (telegramConfigured && !daemon.identityMatches) {
+		checks.push({
+			name: "daemon",
+			level: "warn",
+			detail: "a live daemon owns a different bot token or chat id",
+		});
+	} else {
+		checks.push({ name: "daemon", level: "ok", detail: `daemon pid ${daemon.pid} alive with a fresh heartbeat` });
+	}
+
+	// Per-session endpoint discovery files.
+	const dir = endpointDir(stateRoot);
+	const files = await listEndpointFiles(fs, dir);
+	let live = 0;
+	let stale = 0;
+	let unreadable = 0;
+	for (const name of files) {
+		const view = await readEndpointView(fs, path.join(dir, name));
+		if (!view) {
+			unreadable += 1;
+			continue;
+		}
+		const dead = view.pid === undefined || !pidAlive(view.pid);
+		if (view.stale || dead) stale += 1;
+		else live += 1;
+	}
+	const endpoints: EndpointHealth = { total: files.length, live, stale, unreadable };
+	if (stale > 0 || unreadable > 0) {
+		checks.push({
+			name: "endpoints",
+			level: "warn",
+			detail: `${stale} stale / ${unreadable} unreadable of ${files.length} endpoint file(s); run recovery`,
+		});
+	} else {
+		checks.push({ name: "endpoints", level: "ok", detail: `${live} live endpoint file(s)` });
+	}
+
+	// Optional network reachability probe.
+	let reachability = { probed: false, ok: false, detail: "not probed" };
+	if (opts.probe && telegramConfigured) {
+		const result = await probeTelegramReachability(
+			deps.fetchImpl ?? globalThis.fetch,
+			deps.apiBase ?? DEFAULT_API_BASE,
+			cfg.botToken,
+		);
+		reachability = { probed: true, ...result };
+		checks.push({
+			name: "reachability",
+			level: result.ok ? "ok" : "error",
+			detail: `Telegram: ${result.detail}`,
+		});
+	}
+
+	const overall = checks.reduce<HealthLevel>((acc, check) => worst(acc, check.level), "ok");
+	return { overall, configured, checks, daemon, endpoints, reachability };
+}
+
+/** Render a health report as human-readable lines (no secrets). */
+export function formatNotificationHealthReport(report: NotificationHealthReport): string {
+	const icon: Record<HealthLevel, string> = { ok: "[ok]", warn: "[warn]", error: "[error]" };
+	const lines = [`Notification health: ${report.overall.toUpperCase()}`];
+	for (const check of report.checks) {
+		lines.push(`  ${icon[check.level]} ${check.name}: ${check.detail}`);
+	}
+	return lines.join("\n");
+}
+
+// --- test ---------------------------------------------------------------
+
+export interface NotificationTestResult {
+	ok: boolean;
+	adapter: "telegram";
+	chatId: string | undefined;
+	detail: string;
+}
+
+export interface TestOptions {
+	settings: Settings;
+	deps?: NotificationServiceDeps;
+	text?: string;
+}
+
+/** Send a one-off test notification through the configured Telegram adapter. */
+export async function sendNotificationTest(opts: TestOptions): Promise<NotificationTestResult> {
+	const deps = opts.deps ?? {};
+	const cfg = getNotificationConfig(opts.settings);
+	if (!isTelegramConfigured(cfg)) {
+		return {
+			ok: false,
+			adapter: "telegram",
+			chatId: cfg.chatId,
+			detail: "Telegram is not configured (need notifications.enabled + botToken + chatId). Run `gjc notify setup`.",
+		};
+	}
+	const fetchImpl = deps.fetchImpl ?? globalThis.fetch;
+	const apiBase = (deps.apiBase ?? DEFAULT_API_BASE).replace(/\/$/, "");
+	const text = opts.text ?? "GJC notifications test message. If you can read this, delivery works.";
+	try {
+		const response = await fetchImpl(`${apiBase}/bot${cfg.botToken}/sendMessage`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ chat_id: cfg.chatId, text }),
+		});
+		const payload = (await response.json().catch(() => undefined)) as
+			| { ok?: boolean; description?: string }
+			| undefined;
+		if (response.ok && payload?.ok) {
+			return { ok: true, adapter: "telegram", chatId: cfg.chatId, detail: `delivered to chat ${cfg.chatId}` };
+		}
+		return {
+			ok: false,
+			adapter: "telegram",
+			chatId: cfg.chatId,
+			detail: payload?.description ?? `Telegram sendMessage failed (HTTP ${response.status})`,
+		};
+	} catch (err) {
+		return {
+			ok: false,
+			adapter: "telegram",
+			chatId: cfg.chatId,
+			detail: err instanceof Error ? err.message : "network error",
+		};
+	}
+}
+
+/** Render a test result as a single human-readable line (no secrets). */
+export function formatNotificationTestResult(result: NotificationTestResult): string {
+	return `Notification test (${result.adapter}): ${result.ok ? "OK" : "FAILED"} — ${result.detail}`;
+}
+
+// --- recovery -----------------------------------------------------------
+
+export interface RecoveredEndpoint {
+	sessionId: string;
+	pid: number | undefined;
+	reason: "stale-flag" | "dead-pid";
+}
+
+export type DaemonRecoveryAction = "none" | "cleared-dead-owner-lock" | "left-active" | "orphan-lock-left";
+
+export interface NotificationRecoveryReport {
+	endpointsScanned: number;
+	endpointsRemoved: RecoveredEndpoint[];
+	endpointsKept: number;
+	endpointsUnreadable: number;
+	daemon: {
+		action: DaemonRecoveryAction;
+		detail: string;
+		ownerId: string | undefined;
+		pid: number | undefined;
+	};
+}
+
+export interface RecoveryOptions {
+	settings: Settings;
+	stateRoot?: string;
+	deps?: NotificationServiceDeps;
+}
+
+/**
+ * Ownership-protected cleanup. Removes only DEAD-owner artifacts:
+ * per-session endpoint files flagged stale or whose pid is dead, and a daemon
+ * lock whose recorded owner pid is confirmed dead. Never removes a live owner's
+ * lock, never deletes unreadable files, and never kills a process.
+ */
+export async function recoverNotifications(opts: RecoveryOptions): Promise<NotificationRecoveryReport> {
+	const deps = opts.deps ?? {};
+	const fs = deps.fs ?? nodeServiceFs;
+	const pidAlive = deps.pidAlive ?? defaultPidAlive;
+	const stateRoot = opts.stateRoot ?? defaultStateRoot();
+
+	const dir = endpointDir(stateRoot);
+	const files = await listEndpointFiles(fs, dir);
+	const removed: RecoveredEndpoint[] = [];
+	let kept = 0;
+	let unreadable = 0;
+	for (const name of files) {
+		const view = await readEndpointView(fs, path.join(dir, name));
+		if (!view) {
+			// Leave unparseable files untouched: they may be mid-write by a live server.
+			unreadable += 1;
+			continue;
+		}
+		const dead = view.pid === undefined || !pidAlive(view.pid);
+		if (!view.stale && !dead) {
+			kept += 1;
+			continue;
+		}
+		try {
+			await fs.unlink(path.join(dir, name));
+			removed.push({ sessionId: view.sessionId, pid: view.pid, reason: view.stale ? "stale-flag" : "dead-pid" });
+		} catch {
+			kept += 1;
+		}
+	}
+
+	// Daemon lock: clear only when the recorded owner process is dead.
+	const paths = daemonPaths(opts.settings.getAgentDir());
+	let daemonFiles: string[] = [];
+	try {
+		daemonFiles = await fs.readdir(paths.dir);
+	} catch {
+		// directory absent: nothing to recover
+	}
+	const hasLock = daemonFiles.includes(path.basename(paths.lock));
+	const state = await readDaemonStateFile(fs, paths.state);
+	let daemon: NotificationRecoveryReport["daemon"];
+	if (!state) {
+		daemon = hasLock
+			? {
+					action: "orphan-lock-left",
+					detail: "daemon lock present without an ownership record; left untouched to protect a starting owner",
+					ownerId: undefined,
+					pid: undefined,
+				}
+			: { action: "none", detail: "no daemon ownership record", ownerId: undefined, pid: undefined };
+	} else if (pidAlive(state.pid)) {
+		daemon = {
+			action: "left-active",
+			detail: `live daemon owned by pid ${state.pid} left untouched`,
+			ownerId: state.ownerId,
+			pid: state.pid,
+		};
+	} else if (hasLock) {
+		try {
+			await fs.unlink(paths.lock);
+			daemon = {
+				action: "cleared-dead-owner-lock",
+				detail: `cleared lock of dead owner pid ${state.pid}`,
+				ownerId: state.ownerId,
+				pid: state.pid,
+			};
+		} catch {
+			daemon = {
+				action: "orphan-lock-left",
+				detail: `could not remove lock of dead owner pid ${state.pid}`,
+				ownerId: state.ownerId,
+				pid: state.pid,
+			};
+		}
+	} else {
+		daemon = {
+			action: "none",
+			detail: `dead owner pid ${state.pid} recorded but no lock present`,
+			ownerId: state.ownerId,
+			pid: state.pid,
+		};
+	}
+
+	return {
+		endpointsScanned: files.length,
+		endpointsRemoved: removed,
+		endpointsKept: kept,
+		endpointsUnreadable: unreadable,
+		daemon,
+	};
+}
+
+/** Render a recovery report as human-readable lines (no secrets). */
+export function formatNotificationRecoveryReport(report: NotificationRecoveryReport): string {
+	const lines = ["Notification recovery"];
+	lines.push(
+		`  endpoints: scanned ${report.endpointsScanned}, removed ${report.endpointsRemoved.length}, kept ${report.endpointsKept}, unreadable ${report.endpointsUnreadable}`,
+	);
+	for (const ep of report.endpointsRemoved) {
+		lines.push(`    - removed ${ep.sessionId} (pid ${ep.pid ?? "?"}, ${ep.reason})`);
+	}
+	lines.push(`  daemon: ${report.daemon.action} — ${report.daemon.detail}`);
+	return lines.join("\n");
+}

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -10,7 +10,7 @@ import type { DaemonRuntimeInfo } from "../daemon/control-types";
 import { resolveGjcRuntimeSpawnInfo } from "../daemon/runtime";
 import { getNotificationConfig, isTelegramConfigured, tokenFingerprint } from "./config";
 import { parseInThreadConfigCommand, parseRichToggleCommand, parseTelegramControlCommand } from "./config-commands";
-import { daemonPaths } from "./daemon-paths";
+import { daemonPaths, HEARTBEAT_TTL_MS } from "./daemon-paths";
 import {
 	buildCompactChoiceGrid,
 	code,
@@ -119,7 +119,7 @@ export interface TelegramDaemonDeps {
 }
 
 export const HEARTBEAT_INTERVAL_MS = 5_000;
-export const HEARTBEAT_TTL_MS = 20_000;
+export { HEARTBEAT_TTL_MS };
 export const DAEMON_VERSION = 1;
 /** Capability token advertised when the server supports app-level ping/pong. */
 export const CLIENT_PING_PONG_CAPABILITY = "client_ping_pong";

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -485,21 +485,33 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "notify",
 		priority: 30,
-		description: "Notification status, health, test and recovery",
-		acpDescription: "Notification status, health, test and recovery",
+		description: "Notification status, health, test, recovery, and session on/off",
+		acpDescription: "Notification status, health, test, recovery, and session on/off",
 		subcommands: [
+			{ name: "on", description: "Enable notifications for this session" },
+			{ name: "off", description: "Disable notifications for this session" },
 			{ name: "status", description: "Show notification configuration (no secrets)" },
 			{ name: "health", description: "Config, daemon-ownership and endpoint health" },
 			{ name: "test", description: "Send a test notification", usage: "[message]" },
 			{ name: "recovery", description: "Clear dead-owner locks and stale endpoint files" },
 			{ name: "setup", description: "How to pair a Telegram bot (run in a terminal)" },
 		],
-		inlineHint: "[status|health|test|recovery|setup]",
-		acpInputHint: "[status|health|test|recovery|setup]",
+		inlineHint: "[on|off|status|health|test|recovery|setup]",
+		acpInputHint: "[on|off|status|health|test|recovery|setup]",
 		allowArgs: true,
 		handle: async (command, runtime) => {
 			const { verb, rest } = parseSubcommand(command.args);
 			const action = verb || "status";
+			// `on`/`off` are session-local runtime controls owned by the
+			// notifications extension command (`api.registerCommand("notify")`),
+			// which holds the live per-session server/disable state. Pass them
+			// through untouched — never consume them — so this builtin cannot
+			// shadow that control. Everything below is config/service diagnostics
+			// the extension does not implement, so the builtin owns them exclusively
+			// (and the extension therefore never consumes them).
+			if (action === "on" || action === "off") {
+				return { prompt: command.text };
+			}
 			const stateRoot = path.join(runtime.cwd, ".gjc", "state");
 			switch (action) {
 				case "status":
@@ -526,7 +538,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						runtime,
 					);
 				default:
-					return usage(`Usage: /notify [status|health|test|recovery|setup] (got "${action}")`, runtime);
+					return usage(`Usage: /notify [on|off|status|health|test|recovery|setup] (got "${action}")`, runtime);
 			}
 		},
 	},

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -25,6 +25,16 @@ import { DynamicBorder } from "../modes/components/dynamic-border";
 import { GajaePetWidget } from "../modes/components/gajae-pet-widget";
 import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
+import {
+	buildNotificationStatusReport,
+	checkNotificationHealth,
+	formatNotificationHealthReport,
+	formatNotificationRecoveryReport,
+	formatNotificationStatusReport,
+	formatNotificationTestResult,
+	recoverNotifications,
+	sendNotificationTest,
+} from "../notifications/notification-service";
 import { computeCacheMissCostSummary, formatCacheMissSummaryLines } from "../session/cache-economics";
 import { formatModelOnboardingGuidance } from "../setup/model-onboarding-guidance";
 import {
@@ -38,7 +48,7 @@ import { getDisplayChangelogEntries } from "../utils/changelog";
 import { buildContextReportText } from "./helpers/context-report";
 import { buildFastStatusReport } from "./helpers/fast-status-report";
 import { formatDuration } from "./helpers/format";
-import { commandConsumed, errorMessage, parseSlashCommand, usage } from "./helpers/parse";
+import { commandConsumed, errorMessage, parseSlashCommand, parseSubcommand, usage } from "./helpers/parse";
 import { handleSshAcp } from "./helpers/ssh";
 import { buildUsageReportText } from "./helpers/usage-report";
 import type {
@@ -472,6 +482,54 @@ const shutdownHandlerTui = (_command: ParsedSlashCommand, runtime: TuiSlashComma
 };
 
 const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
+	{
+		name: "notify",
+		priority: 30,
+		description: "Notification status, health, test and recovery",
+		acpDescription: "Notification status, health, test and recovery",
+		subcommands: [
+			{ name: "status", description: "Show notification configuration (no secrets)" },
+			{ name: "health", description: "Config, daemon-ownership and endpoint health" },
+			{ name: "test", description: "Send a test notification", usage: "[message]" },
+			{ name: "recovery", description: "Clear dead-owner locks and stale endpoint files" },
+			{ name: "setup", description: "How to pair a Telegram bot (run in a terminal)" },
+		],
+		inlineHint: "[status|health|test|recovery|setup]",
+		acpInputHint: "[status|health|test|recovery|setup]",
+		allowArgs: true,
+		handle: async (command, runtime) => {
+			const { verb, rest } = parseSubcommand(command.args);
+			const action = verb || "status";
+			const stateRoot = path.join(runtime.cwd, ".gjc", "state");
+			switch (action) {
+				case "status":
+					await runtime.output(formatNotificationStatusReport(buildNotificationStatusReport(runtime.settings)));
+					return commandConsumed();
+				case "health": {
+					const report = await checkNotificationHealth({ settings: runtime.settings, stateRoot });
+					await runtime.output(formatNotificationHealthReport(report));
+					return commandConsumed();
+				}
+				case "test": {
+					const result = await sendNotificationTest({ settings: runtime.settings, text: rest || undefined });
+					await runtime.output(formatNotificationTestResult(result));
+					return commandConsumed();
+				}
+				case "recovery": {
+					const report = await recoverNotifications({ settings: runtime.settings, stateRoot });
+					await runtime.output(formatNotificationRecoveryReport(report));
+					return commandConsumed();
+				}
+				case "setup":
+					return usage(
+						"Run `gjc notify setup` in a terminal to pair a Telegram bot token with a private chat (interactive; requires a TTY).",
+						runtime,
+					);
+				default:
+					return usage(`Usage: /notify [status|health|test|recovery|setup] (got "${action}")`, runtime);
+			}
+		},
+	},
 	{
 		name: "settings",
 		priority: 40,

--- a/packages/coding-agent/test/notifications-service.test.ts
+++ b/packages/coding-agent/test/notifications-service.test.ts
@@ -10,6 +10,7 @@ import {
 	formatNotificationRecoveryReport,
 	formatNotificationStatusReport,
 	recoverNotifications,
+	sanitizeDiagnostic,
 	sendNotificationTest,
 } from "../src/notifications/notification-service";
 
@@ -18,10 +19,18 @@ const TOKEN = "1234567890:ABCDEFghijkLmnOpQrsTuvWxYz012345678";
 /** In-memory NotificationServiceFs backed by an absolute-path -> content map. */
 function mockFs(
 	files: Record<string, string>,
-	opts: { failUnlink?: Set<string> } = {},
-): { fs: NotificationServiceFs; unlinked: string[]; store: Map<string, string> } {
+	opts: {
+		failUnlink?: Set<string>;
+		/**
+		 * Fires the instant the steal-mutex file is exclusively created, letting a
+		 * test simulate a concurrent daemon takeover happening mid-recovery.
+		 */
+		onAcquireExclusive?: (file: string, store: Map<string, string>) => void;
+	} = {},
+): { fs: NotificationServiceFs; unlinked: string[]; created: string[]; store: Map<string, string> } {
 	const store = new Map(Object.entries(files));
 	const unlinked: string[] = [];
+	const created: string[] = [];
 	const enoent = (): NodeJS.ErrnoException => Object.assign(new Error("ENOENT"), { code: "ENOENT" });
 	const fs: NotificationServiceFs = {
 		async readdir(dir) {
@@ -48,8 +57,15 @@ function mockFs(
 			store.delete(file);
 			unlinked.push(file);
 		},
+		async createExclusive(file) {
+			if (store.has(file)) return false;
+			store.set(file, "");
+			created.push(file);
+			opts.onAcquireExclusive?.(file, store);
+			return true;
+		},
 	};
-	return { fs, unlinked, store };
+	return { fs, unlinked, created, store };
 }
 
 function daemonStateJson(over: Record<string, unknown>): string {
@@ -217,5 +233,136 @@ describe("notification-service recovery", () => {
 		});
 		expect(report.daemon.action).toBe("cleared-dead-owner-lock");
 		expect(unlinked).toContain(paths.lock);
+	});
+});
+describe("notification-service endpoint liveness (owner-proof)", () => {
+	const settings = Settings.isolated({
+		"notifications.enabled": true,
+		"notifications.telegram.botToken": TOKEN,
+		"notifications.telegram.chatId": "12345",
+	});
+	const stateRoot = "/tmp/gjc-liveness-state";
+	const epDir = path.join(stateRoot, "notifications");
+
+	test("health treats a PID-less endpoint as unknown, never dead", async () => {
+		const { fs } = mockFs({
+			[path.join(epDir, "pidless.json")]: JSON.stringify({ url: "ws://x", token: "t" }),
+		});
+		const report = await checkNotificationHealth({
+			settings,
+			stateRoot,
+			deps: { fs, now: () => 1_500, pidAlive: () => false },
+		});
+		expect(report.endpoints.dead).toBe(0);
+		expect(report.endpoints.unknown).toBe(1);
+		expect(report.checks.find(c => c.name === "endpoints")?.level).toBe("ok");
+	});
+
+	test("recovery keeps a PID-less endpoint (no positive proof of death)", async () => {
+		const { fs, unlinked } = mockFs({
+			[path.join(epDir, "pidless.json")]: JSON.stringify({ url: "ws://x", token: "t" }),
+		});
+		const report = await recoverNotifications({
+			settings,
+			stateRoot,
+			deps: { fs, pidAlive: () => false },
+		});
+		expect(report.endpointsRemoved).toEqual([]);
+		expect(report.endpointsKept).toBe(1);
+		expect(unlinked).toEqual([]);
+	});
+});
+
+describe("notification-service recovery lock TOCTOU (owner-bound)", () => {
+	const settings = Settings.isolated({
+		"notifications.enabled": true,
+		"notifications.telegram.botToken": TOKEN,
+		"notifications.telegram.chatId": "12345",
+	});
+	const paths = daemonPaths(settings.getAgentDir());
+
+	test("leaves the lock when the steal-mutex is already held (contended)", async () => {
+		const { fs, unlinked } = mockFs({
+			[paths.state]: daemonStateJson({ pid: 555, ownerId: "owner-a" }),
+			[paths.lock]: "lock",
+			[paths.steal]: "held-by-another",
+		});
+		const report = await recoverNotifications({
+			settings,
+			stateRoot: "/tmp/gjc-contended",
+			deps: { fs, pidAlive: () => false },
+		});
+		expect(report.daemon.action).toBe("left-contended");
+		expect(unlinked).not.toContain(paths.lock);
+	});
+
+	test("never clobbers a new owner that took over during recovery (superseded)", async () => {
+		// The dead owner A is observed first; while recovery holds the steal-mutex
+		// a fresh live owner B has already rewritten the ownership record. The
+		// owner-bound re-check must abort rather than unlink B's live lock.
+		const { fs, unlinked } = mockFs(
+			{
+				[paths.state]: daemonStateJson({ pid: 555, ownerId: "owner-a" }),
+				[paths.lock]: "lock",
+			},
+			{
+				onAcquireExclusive: (file, store) => {
+					if (file === paths.steal) {
+						store.set(paths.state, daemonStateJson({ pid: 1000, ownerId: "owner-b" }));
+					}
+				},
+			},
+		);
+		const report = await recoverNotifications({
+			settings,
+			stateRoot: "/tmp/gjc-superseded",
+			deps: { fs, pidAlive: pid => pid === 1000 },
+		});
+		expect(report.daemon.action).toBe("owner-superseded");
+		expect(unlinked).not.toContain(paths.lock);
+	});
+});
+
+describe("notification-service diagnostic sanitization (secret-safe)", () => {
+	test("sanitizeDiagnostic redacts the exact token and token-shaped substrings", () => {
+		expect(sanitizeDiagnostic(`fetch failed: https://api.telegram.org/bot${TOKEN}/getMe`, TOKEN)).not.toContain(
+			TOKEN,
+		);
+		// Redacts a token-shaped substring even without the exact token supplied.
+		expect(sanitizeDiagnostic("leaked 998877665:ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")).toContain("<redacted>");
+	});
+
+	test("test delivery never leaks the token in an error detail", async () => {
+		const settings = Settings.isolated({
+			"notifications.enabled": true,
+			"notifications.telegram.botToken": TOKEN,
+			"notifications.telegram.chatId": "12345",
+		});
+		const fetchImpl = (async (_url: string | URL | Request) => {
+			throw new Error(`request to https://api.telegram.org/bot${TOKEN}/sendMessage failed`);
+		}) as unknown as typeof fetch;
+		const result = await sendNotificationTest({ settings, deps: { fetchImpl } });
+		expect(result.ok).toBe(false);
+		expect(result.detail).not.toContain(TOKEN);
+		expect(result.detail).toContain("<redacted>");
+	});
+
+	test("health probe never leaks the token in a reachability error", async () => {
+		const settings = Settings.isolated({
+			"notifications.enabled": true,
+			"notifications.telegram.botToken": TOKEN,
+			"notifications.telegram.chatId": "12345",
+		});
+		const fetchImpl = (async (_url: string | URL | Request) => {
+			throw new Error(`connect ECONNREFUSED https://api.telegram.org/bot${TOKEN}/getMe`);
+		}) as unknown as typeof fetch;
+		const report = await checkNotificationHealth({
+			settings,
+			stateRoot: "/tmp/gjc-probe",
+			probe: true,
+			deps: { fs: mockFs({}).fs, now: () => 1, pidAlive: () => false, fetchImpl },
+		});
+		expect(report.reachability.detail).not.toContain(TOKEN);
+		expect(report.reachability.detail).toContain("<redacted>");
 	});
 });

--- a/packages/coding-agent/test/notifications-service.test.ts
+++ b/packages/coding-agent/test/notifications-service.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import { Settings } from "../src/config/settings";
+import { tokenFingerprint } from "../src/notifications/config";
+import { daemonPaths } from "../src/notifications/daemon-paths";
+import type { NotificationServiceFs } from "../src/notifications/notification-service";
+import {
+	buildNotificationStatusReport,
+	checkNotificationHealth,
+	formatNotificationRecoveryReport,
+	formatNotificationStatusReport,
+	recoverNotifications,
+	sendNotificationTest,
+} from "../src/notifications/notification-service";
+
+const TOKEN = "1234567890:ABCDEFghijkLmnOpQrsTuvWxYz012345678";
+
+/** In-memory NotificationServiceFs backed by an absolute-path -> content map. */
+function mockFs(
+	files: Record<string, string>,
+	opts: { failUnlink?: Set<string> } = {},
+): { fs: NotificationServiceFs; unlinked: string[]; store: Map<string, string> } {
+	const store = new Map(Object.entries(files));
+	const unlinked: string[] = [];
+	const enoent = (): NodeJS.ErrnoException => Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+	const fs: NotificationServiceFs = {
+		async readdir(dir) {
+			const prefix = dir.endsWith(path.sep) ? dir : dir + path.sep;
+			const names = new Set<string>();
+			let exists = false;
+			for (const key of store.keys()) {
+				if (!key.startsWith(prefix)) continue;
+				exists = true;
+				const rest = key.slice(prefix.length);
+				if (!rest.includes(path.sep)) names.add(rest);
+			}
+			if (!exists) throw enoent();
+			return [...names];
+		},
+		async readFile(file) {
+			const value = store.get(file);
+			if (value === undefined) throw enoent();
+			return value;
+		},
+		async unlink(file) {
+			if (opts.failUnlink?.has(file)) throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+			if (!store.has(file)) throw enoent();
+			store.delete(file);
+			unlinked.push(file);
+		},
+	};
+	return { fs, unlinked, store };
+}
+
+function daemonStateJson(over: Record<string, unknown>): string {
+	return JSON.stringify({
+		pid: 4242,
+		ownerId: "owner-a",
+		tokenFingerprint: tokenFingerprint(TOKEN),
+		chatId: "12345",
+		startedAt: 0,
+		heartbeatAt: 1_000,
+		roots: [],
+		version: 1,
+		...over,
+	});
+}
+
+describe("notification-service status", () => {
+	test("status report is secret-safe and shows a fingerprint", () => {
+		const settings = Settings.isolated({
+			"notifications.enabled": true,
+			"notifications.telegram.botToken": TOKEN,
+			"notifications.telegram.chatId": "12345",
+			"notifications.redact": true,
+		});
+		const report = buildNotificationStatusReport(settings);
+		const text = formatNotificationStatusReport(report);
+
+		expect(text).not.toContain(TOKEN);
+		expect(report.telegram.tokenFingerprint).toBe(tokenFingerprint(TOKEN));
+		expect(report.telegram.configured).toBe(true);
+		expect(text).toContain("redact: true");
+		expect(text).toContain(`telegram.fingerprint: ${tokenFingerprint(TOKEN)}`);
+	});
+});
+
+describe("notification-service health", () => {
+	const settings = Settings.isolated({
+		"notifications.enabled": true,
+		"notifications.telegram.botToken": TOKEN,
+		"notifications.telegram.chatId": "12345",
+	});
+	const statePath = daemonPaths(settings.getAgentDir()).state;
+
+	test("dead daemon owner is flagged and recommends recovery", async () => {
+		const { fs } = mockFs({ [statePath]: daemonStateJson({ pid: 999 }) });
+		const report = await checkNotificationHealth({
+			settings,
+			stateRoot: "/tmp/gjc-none",
+			deps: { fs, now: () => 1_500, pidAlive: () => false },
+		});
+		expect(report.daemon.present).toBe(true);
+		expect(report.daemon.alive).toBe(false);
+		expect(report.overall).toBe("warn");
+		expect(report.checks.find(c => c.name === "daemon")?.detail).toContain("recovery");
+	});
+
+	test("a live daemon owning a different identity is flagged", async () => {
+		const { fs } = mockFs({
+			[statePath]: daemonStateJson({ pid: 1000, chatId: "99999", heartbeatAt: 1_490 }),
+		});
+		const report = await checkNotificationHealth({
+			settings,
+			stateRoot: "/tmp/gjc-none",
+			deps: { fs, now: () => 1_500, pidAlive: pid => pid === 1000 },
+		});
+		expect(report.daemon.alive).toBe(true);
+		expect(report.daemon.identityMatches).toBe(false);
+		expect(report.checks.find(c => c.name === "daemon")?.detail).toContain("different bot token or chat");
+	});
+
+	test("healthy daemon with fresh heartbeat and matching identity is ok", async () => {
+		const { fs } = mockFs({ [statePath]: daemonStateJson({ pid: 1000, heartbeatAt: 1_490 }) });
+		const report = await checkNotificationHealth({
+			settings,
+			stateRoot: "/tmp/gjc-none",
+			deps: { fs, now: () => 1_500, pidAlive: pid => pid === 1000 },
+		});
+		expect(report.daemon.identityMatches).toBe(true);
+		expect(report.overall).toBe("ok");
+	});
+});
+
+describe("notification-service test delivery", () => {
+	test("reports not-configured without touching the network", async () => {
+		const settings = Settings.isolated({ "notifications.enabled": false });
+		let called = false;
+		const fetchImpl = (async (_url: string | URL | Request) => {
+			called = true;
+			return new Response("{}");
+		}) as typeof fetch;
+		const result = await sendNotificationTest({ settings, deps: { fetchImpl } });
+		expect(result.ok).toBe(false);
+		expect(called).toBe(false);
+		expect(result.detail).toContain("not configured");
+	});
+
+	test("delivers through the configured Telegram adapter", async () => {
+		const settings = Settings.isolated({
+			"notifications.enabled": true,
+			"notifications.telegram.botToken": TOKEN,
+			"notifications.telegram.chatId": "12345",
+		});
+		const calls: string[] = [];
+		const fetchImpl = (async (url: string | URL | Request) => {
+			calls.push(String(url));
+			return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), {
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+		const result = await sendNotificationTest({
+			settings,
+			text: "hi",
+			deps: { fetchImpl, apiBase: "https://api.telegram.org" },
+		});
+		expect(result.ok).toBe(true);
+		expect(result.chatId).toBe("12345");
+		expect(calls[0]).toContain(`/bot${TOKEN}/sendMessage`);
+	});
+});
+
+describe("notification-service recovery", () => {
+	const settings = Settings.isolated({
+		"notifications.enabled": true,
+		"notifications.telegram.botToken": TOKEN,
+		"notifications.telegram.chatId": "12345",
+	});
+	const paths = daemonPaths(settings.getAgentDir());
+	const stateRoot = "/tmp/gjc-recovery-state";
+	const epDir = path.join(stateRoot, "notifications");
+
+	test("removes only dead/stale endpoints and never a live owner's lock", async () => {
+		const { fs, unlinked } = mockFs({
+			[path.join(epDir, "live.json")]: JSON.stringify({ sessionId: "live", pid: 1000, stale: false }),
+			[path.join(epDir, "stale.json")]: JSON.stringify({ sessionId: "stale", pid: 1000, stale: true }),
+			[path.join(epDir, "dead.json")]: JSON.stringify({ sessionId: "dead", pid: 777, stale: false }),
+			[path.join(epDir, "broken.json")]: "not json",
+			[paths.state]: daemonStateJson({ pid: 1000 }),
+			[paths.lock]: "lock",
+		});
+		const report = await recoverNotifications({
+			settings,
+			stateRoot,
+			deps: { fs, pidAlive: pid => pid === 1000 },
+		});
+
+		const removedSessions = report.endpointsRemoved.map(e => e.sessionId).sort();
+		expect(removedSessions).toEqual(["dead", "stale"]);
+		expect(report.endpointsKept).toBe(1);
+		expect(report.endpointsUnreadable).toBe(1);
+		// Live owner is protected: its lock must survive.
+		expect(report.daemon.action).toBe("left-active");
+		expect(unlinked).not.toContain(paths.lock);
+		expect(formatNotificationRecoveryReport(report)).toContain("left-active");
+	});
+
+	test("clears the lock of a confirmed-dead owner", async () => {
+		const { fs, unlinked } = mockFs({
+			[paths.state]: daemonStateJson({ pid: 555 }),
+			[paths.lock]: "lock",
+		});
+		const report = await recoverNotifications({
+			settings,
+			stateRoot: "/tmp/gjc-empty",
+			deps: { fs, pidAlive: () => false },
+		});
+		expect(report.daemon.action).toBe("cleared-dead-owner-lock");
+		expect(unlinked).toContain(paths.lock);
+	});
+});

--- a/packages/coding-agent/test/notify-slash-command.test.ts
+++ b/packages/coding-agent/test/notify-slash-command.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { Settings } from "../src/config/settings";
+import { lookupBuiltinSlashCommand } from "../src/slash-commands/builtin-registry";
+import { parseSlashCommand } from "../src/slash-commands/helpers/parse";
+import type { SlashCommandResult, SlashCommandRuntime } from "../src/slash-commands/types";
+
+/**
+ * Blocker #1: the builtin `/notify` command must NOT shadow the notifications
+ * extension's session-local `on`/`off` controls (registered via
+ * `api.registerCommand("notify")`). It passes those through untouched while
+ * exclusively owning the config/service diagnostics (status/health/test/
+ * recovery/setup), which the extension never implements.
+ */
+
+const TOKEN = "1234567890:ABCDEFghijkLmnOpQrsTuvWxYz012345678";
+
+function makeRuntime(): { runtime: SlashCommandRuntime; outputs: string[] } {
+	const outputs: string[] = [];
+	const settings = Settings.isolated({
+		"notifications.enabled": true,
+		"notifications.telegram.botToken": TOKEN,
+		"notifications.telegram.chatId": "12345",
+	});
+	const runtime = {
+		settings,
+		cwd: "/tmp/gjc-notify-slash-does-not-exist",
+		output: (text: string) => {
+			outputs.push(text);
+		},
+	} as unknown as SlashCommandRuntime;
+	return { runtime, outputs };
+}
+
+async function invoke(input: string): Promise<{ result: SlashCommandResult; outputs: string[] }> {
+	const spec = lookupBuiltinSlashCommand("notify");
+	if (!spec?.handle) throw new Error("notify builtin command or its handle is missing");
+	const parsed = parseSlashCommand(input);
+	if (!parsed) throw new Error(`could not parse ${input}`);
+	const { runtime, outputs } = makeRuntime();
+	const result = await spec.handle(parsed, runtime);
+	return { result, outputs };
+}
+
+describe("/notify builtin dispatch (extension passthrough)", () => {
+	test("passes `on` through to the extension without consuming it", async () => {
+		const { result, outputs } = await invoke("/notify on");
+		expect(result).toEqual({ prompt: "/notify on" });
+		expect(outputs).toEqual([]);
+	});
+
+	test("passes `off` through to the extension without consuming it", async () => {
+		const { result, outputs } = await invoke("/notify off");
+		expect(result).toEqual({ prompt: "/notify off" });
+		expect(outputs).toEqual([]);
+	});
+
+	test("consumes `status` in the builtin (extension never sees it)", async () => {
+		const { result, outputs } = await invoke("/notify status");
+		expect(result).toEqual({ consumed: true });
+		expect(outputs.length).toBe(1);
+		expect(outputs[0]).toContain("Notifications");
+		expect(outputs[0]).not.toContain(TOKEN);
+	});
+
+	test("bare `/notify` defaults to the builtin status (not a passthrough)", async () => {
+		const { result, outputs } = await invoke("/notify");
+		expect(result).toEqual({ consumed: true });
+		expect(outputs.length).toBe(1);
+	});
+
+	test("rejects an unknown verb with a usage listing on|off", async () => {
+		const { result, outputs } = await invoke("/notify bogus");
+		expect(result).toEqual({ consumed: true });
+		expect(outputs[0]).toContain("on|off");
+	});
+
+	test("advertises on/off/health among its subcommands for discoverability", () => {
+		const spec = lookupBuiltinSlashCommand("notify");
+		const names = (spec?.subcommands ?? []).map(s => s.name);
+		expect(names).toContain("on");
+		expect(names).toContain("off");
+		expect(names).toContain("health");
+	});
+});


### PR DESCRIPTION
## Summary

Introduces a transport-agnostic, secret-safe **notification service layer** so notification onboarding and daemon recovery stop being split across ad-hoc CLI/doc flows. Both the `gjc notify` CLI and the cross-mode `/notify` slash command (TUI + ACP) now share the same validated operations instead of duplicating daemon/config logic per surface.

Towards #2050 (shared service layer / validation contract; the interactive settings surface builds on this).

## What's included

- **`notifications/notification-service.ts`** — shared operations, each returning secret-safe structured results (tokens only ever masked or shown as a non-reversible fingerprint):
  - `buildNotificationStatusReport` / `formatNotificationStatusReport`
  - `checkNotificationHealth` — config, daemon generation/ownership, last-heartbeat freshness, identity match, per-session endpoint health, optional Telegram reachability probe (`getMe`)
  - `sendNotificationTest` — one-off delivery through the configured Telegram adapter
  - `recoverNotifications` — **ownership-protected** cleanup that only ever clears DEAD-owner artifacts (dead-PID / explicitly-stale). Never touches a live owner's lock/state, never deletes unreadable (possibly mid-write) files, never kills a process.
- **`cli/notify-cli.ts`** — new `health` / `test` / `recovery` actions built on the shared service; existing `setup`/`status` behavior preserved (CLI output contract unchanged, incl. `redact:` line).
- **`commands/notify.ts`** — exposes the new actions plus `--probe` / `--message` flags.
- **`slash-commands/builtin-registry.ts`** — adds `/notify [status|health|test|recovery|setup]`.
- **`notifications/daemon-paths.ts`** — hosts `HEARTBEAT_TTL_MS` so secret-safe consumers can reuse the freshness window without importing the heavy daemon runtime; `telegram-daemon.ts` re-exports it (no behavior change).

## Tests

- New `test/notifications-service.test.ts`: secret-safe status, health (dead owner → warn, live identity mismatch → warn, healthy → ok), test delivery (not-configured short-circuit + success), and recovery (live-owner lock protected + stale/dead endpoints removed; dead-owner lock cleared).
- Full `notifications-*` + slash-command suites pass locally; `tsc --noEmit` and `biome check` clean on touched files.

## Notes

- Non-interactive/automation path (`gjc notify …`) and TUI/ACP path share one service + validation contract.
- No accidental foreign-daemon takeover: recovery is strictly dead-owner scoped.
