### PR TITLE
fix(coordinator-mcp): recognize tmux ≥3.7 'error connecting to' no-server diagnostic (deterministic delegate failure)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- The coordinator MCP owner-server probe now recognizes tmux ≥3.7's missing-server diagnostic (`error connecting to <socket> (No such file or directory)`) as an absent server. tmux 3.7 changed the wording from the older `no server running on <socket>`, which the coordinator probe did not match — so a brand-new coordinator socket (which never has a server yet) was misclassified `unverifiable` instead of `absent`, and **every** `gjc_delegate_*` / session create failed closed with `coordinator_tmux_owner_server_unverifiable` on tmux ≥3.7. The coordinator and `gjc` harness probes now match the same no-server wordings the other owner-isolation probes already did.
 - Preserved explicit Telegram forum-topic renames as durable user-owned names, immediately re-asserting delayed edits while retaining restart and rename-race recovery (#1910).
 - `gjc resume` now aliases value-less `--resume`, requests confirmation before opening and continues a resumable tail once only; terminal tails open idle, and headless bare resume exits with explicit `--resume <id>` guidance (#1973).
 - Telegram answers to interactive and unattended `ask` prompts now receive a semantic, origin-bound `Selected!` acknowledgement before workflow continuation, with typed multi-select controls, no acknowledgement for toggles/clarifications/skips, at-most-once delivery attempts, and truthful failure/unknown outcomes (#1974).

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -556,7 +556,7 @@ function isBoundedNoServerDiagnostic(stderr: Uint8Array): boolean {
 	return (
 		diagnostic.length > 0 &&
 		diagnostic.length <= 512 &&
-		/^(?:no server running on |failed to connect to server)/i.test(diagnostic.trim())
+		/^(?:no server running on |failed to connect to server|error connecting to )/i.test(diagnostic.trim())
 	);
 }
 

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -2392,7 +2392,9 @@ export async function coordinatorOwnerIsolationProbe(runner: CommandRunner): Pro
 				const result = await runner(["tmux", "-L", socketKey, "list-sessions", "-F", "#{pid} #{session_name}"]);
 				if (result.exitCode !== 0) {
 					const diagnostic = `${result.stdout}\n${result.stderr}`.slice(0, 512);
-					return /(?:no server running|failed to connect to server|no sessions)/i.test(diagnostic)
+					return /(?:no server running|failed to connect to server|no sessions|error connecting to)/i.test(
+						diagnostic,
+					)
 						? { state: "absent" }
 						: { state: "unverifiable" };
 				}

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -1320,6 +1320,18 @@ describe("Coordinator MCP server protocol", () => {
 			if (platform) Object.defineProperty(process, "platform", platform);
 		}
 	});
+	it("classifies a tmux >=3.7 'error connecting to' no-server diagnostic as absent, not unverifiable", async () => {
+		// tmux 3.7 reports a missing server socket as `error connecting to <path> (No such file or
+		// directory)` instead of the older `no server running on <path>`. The coordinator probe must
+		// read that as an absent server (a fresh coordinator socket has none yet); otherwise every
+		// session create fails closed with coordinator_tmux_owner_server_unverifiable on tmux >=3.7.
+		const noServer = await coordinatorOwnerIsolationProbe(async () => ({
+			exitCode: 1,
+			stdout: "",
+			stderr: "error connecting to /private/tmp/tmux-501/gjc-coordinator-abcd1234 (No such file or directory)",
+		}));
+		expect(await noServer.probeServer("gjc-coordinator-abcd1234")).toEqual({ state: "absent" });
+	});
 	it("refuses atomic cleanup after a post-spawn coordinator server replacement", async () => {
 		const root = await tempRoot();
 		const commands: string[][] = [];


### PR DESCRIPTION
## What

The coordinator MCP owner-server probe now recognizes **tmux ≥3.7's** missing-server diagnostic (`error connecting to <socket> (No such file or directory)`) as an **absent** server.

## Why (deterministic delegate failure on tmux ≥3.7)

tmux 3.7 changed the wording it prints when a server socket doesn't exist:

| tmux | `list-sessions` on a non-existent socket |
|---|---|
| ≤3.6 | `no server running on <socket>` |
| **≥3.7** | `error connecting to <socket> (No such file or directory)` |

`coordinatorOwnerIsolationProbe.probeServer` only matched `no server running` / `failed to connect to server` / `no sessions`. A **brand-new coordinator socket never has a server yet**, so on tmux ≥3.7 the probe fell through to `unverifiable` instead of `absent`. `planTmuxOwnerIsolation` then fails closed (`server_unverifiable`), so **every** `gjc_delegate_*` / session create returned:

```
{"ok":false,"reason":"coordinator_tmux_owner_server_unverifiable"}
```

This is deterministic on any tmux ≥3.7 host (not load-related). Reproduced locally: `gjc_coordinator_start_session` returned `ok:false` before this change and `ok:true` after, driving the real owner-prove path end-to-end.

The other owner-isolation probes (`tmux-owner-isolation-cli`, `lifecycle-control-runtime`, `launch-tmux`, `tmux-sessions`) **already** recognized `error connecting to` — the coordinator probe and the `gjc` harness's `isBoundedNoServerDiagnostic` were the two sites that had drifted. This aligns them.

## Fix

Add `error connecting to` to:
- `coordinatorOwnerIsolationProbe.probeServer` (the coordinator delegate/session-create path — the observed break).
- `isBoundedNoServerDiagnostic` in the `gjc` harness (the identical latent gap on the same tmux ≥3.7 wording).

No behavior change on tmux ≤3.6, and owner isolation is unchanged: `absent` is exactly the expected state for a fresh socket, and a genuinely unverifiable server still fails closed.

## Testing

- New discriminating unit test (`coordinator-mcp-server.test.ts`): feeds the tmux 3.7 `error connecting to … (No such file or directory)` diagnostic to the probe and asserts `{ state: "absent" }`. Verified it **fails if the pattern is reverted**.
- End-to-end: `gjc_coordinator_start_session` now succeeds through the real owner-prove path on this tmux 3.7 host (`ok:true`, session created + listed).
- `bun --cwd=packages/coding-agent run check` — `biome check` (2009 files) + `tsc --noEmit` green.

## Note

Complements #2059 (already merged), which hardened the same probe against *transient* spawn throws. That was necessary but insufficient — this is the deterministic root cause of the `coordinator_tmux_owner_server_unverifiable` failures seen on tmux 3.7.

---
- [x] `bun check` passes
- [x] Tested locally (discriminating unit test + end-to-end start_session on tmux 3.7)
- [x] CHANGELOG `[Unreleased] > Fixed` updated
- [x] `Signed-off-by` (DCO)
