### PR TITLE
feat(rpc): add durable default model selection

### DIFF
--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -178,6 +178,7 @@ endpoint matrix, the default handshake advertises no accepted scopes.
 | `get_pending_workflow_gates` | `message:read` |
 | `set_capabilities` | `control` |
 | `set_model` | `model` |
+| `set_default_model_selection` | `model` |
 | `cycle_model` | `model` |
 | `get_available_models` | `model` |
 | `set_thinking_level` | `model` |

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -91,7 +91,7 @@ Important edge behavior from runtime:
 ### Model
 
 - `{ id?, type: "set_model", provider: string, modelId: string }`
-- `{ id?, type: "set_default_model_selection", provider: string, modelId: string, thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" }`
+- `{ id?, type: "set_default_model_selection", provider: string, modelId: string, thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" }`
 - `{ id?, type: "cycle_model" }`
 - `{ id?, type: "get_available_models" }`
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -91,6 +91,7 @@ Important edge behavior from runtime:
 ### Model
 
 - `{ id?, type: "set_model", provider: string, modelId: string }`
+- `{ id?, type: "set_default_model_selection", provider: string, modelId: string, thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" }`
 - `{ id?, type: "cycle_model" }`
 - `{ id?, type: "get_available_models" }`
 
@@ -143,6 +144,27 @@ All command results use `RpcResponse`:
 
 Data payloads are command-specific and defined in `rpc-types.ts`.
 
+### `set_default_model_selection` contract
+
+Request:
+
+```json
+{ "id": "model-default-1", "type": "set_default_model_selection", "provider": "openai", "modelId": "gpt-5.6", "thinkingLevel": "high" }
+```
+
+Correlated success response:
+
+```json
+{ "id": "model-default-1", "type": "response", "command": "set_default_model_selection", "success": true, "data": { "provider": "openai", "modelId": "gpt-5.6", "thinkingLevel": "high" } }
+```
+
+`thinkingLevel` may be omitted or set to a concrete level. `"inherit"` is rejected. A requested reasoning level is clamped to the selected model's supported range. A non-reasoning model always resolves to `off`. The response always reports the effective concrete level that was persisted and applied.
+
+This is an ordered mutation. It waits behind earlier mutations and, if the agent is streaming, waits for an active stream to become idle. It acknowledges success only after the machine-global selector is durably written and the selected model and effective level are recorded as the active session default. The selection therefore applies to the next message; it does not change the model of a response already being streamed.
+
+The durable setting is a fallback, not an unconditional override. Project-level model-role policy overrides the machine-global selector, and a resumed session's recorded default model overrides it. Fresh sessions without either higher-precedence source consume the machine-global selector, including its effective thinking-level suffix.
+
+`set_default_model_selection` belongs to the shared agent-wire command surface. If a Bridge command endpoint is enabled by an embedding, the command requires the `model` scope; this catalog mapping does not enable the default-disabled Bridge command endpoint.
 
 By default, `get_state` omits large static fields. Request `include: ["tools"]` to include `dumpTools`, `include: ["systemPrompt"]` to include `systemPrompt`, or both when a host needs a one-shot full session dump.
 ### `get_state` payload

--- a/packages/bridge-client/src/commands.ts
+++ b/packages/bridge-client/src/commands.ts
@@ -13,6 +13,7 @@ export const BRIDGE_CLIENT_COMMAND_TYPES = [
 	"set_capabilities",
 	"workflow_gate_response",
 	"set_model",
+	"set_default_model_selection",
 	"cycle_model",
 	"get_available_models",
 	"set_thinking_level",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added an opt-in `/pet on|off` composer companion with idle gaze, working claw motion, and occasional automatic flex animation on Sixel- and Kitty-graphics terminals.
+- RPC clients can now durably select the machine-global default model and effective thinking level for subsequent messages, while project policy and resumed session history retain precedence.
 
 - Added `notifications.sessionScope` (`all` default | `primary`). Under `primary`, the separate-process child sessions GJC spawns (team workers, harness RPC owners) no longer register their own Telegram forum topic / notification endpoint unless they explicitly opt in (`GJC_NOTIFICATIONS=1`, the `/session_create` path). The default `all` fully preserves current behavior, and user-opened CLI/tmux/headless sessions are never affected. The provenance marker is per-spawn and non-dynastic (consumed once at session startup, never inherited by grandchildren) (#1908).
 - Added `notifications.sessionScope` (`all` default | `primary`). Under `primary`, the separate-process child sessions GJC spawns (team workers, harness RPC owners) no longer register their own Telegram forum topic / notification endpoint unless they explicitly opt in (`GJC_NOTIFICATIONS=1`, the `/session_create` path). The default `all` fully preserves current behavior, and user-opened CLI/tmux/headless sessions are never affected. The provenance marker is per-spawn and non-dynastic (consumed once at session startup, never inherited by grandchildren) (#1908).

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -55,6 +55,12 @@ export interface RawSettings {
 	[key: string]: unknown;
 }
 
+type SettingsPatch = {
+	readonly path: string;
+	readonly value: unknown;
+	readonly generation: number;
+};
+
 export interface SettingsOptions {
 	/** Current working directory for project settings discovery */
 	cwd?: string;
@@ -207,12 +213,14 @@ export class Settings {
 	/** Merged view (global + project + overrides) */
 	#merged: RawSettings = {};
 
-	/** Paths modified during this session (for partial save) */
-	#modified = new Set<string>();
+	/** Latest dirty patch for each path, owned by its generation. */
+	#modified = new Map<string, SettingsPatch>();
+	#nextGeneration = 0;
 
 	/** Pending save (debounced) */
 	#saveTimer?: NodeJS.Timeout;
-	#savePromise?: Promise<void>;
+	#saveTail: Promise<void> = Promise.resolve();
+	#globalModelRoleTail: Promise<void> = Promise.resolve();
 
 	/** Whether to persist changes */
 	#persist: boolean;
@@ -320,9 +328,13 @@ export class Settings {
 	 */
 	set<P extends SettingPath>(path: P, value: SettingValue<P>): void {
 		const prev = this.get(path);
-		const segments = path.split(".");
-		setByPath(this.#global, segments, value);
-		this.#modified.add(path);
+		const patch: SettingsPatch = {
+			path,
+			value: structuredClone(value),
+			generation: ++this.#nextGeneration,
+		};
+		setByPath(this.#global, path.split("."), structuredClone(patch.value));
+		this.#modified.set(path, patch);
 		this.#rebuildMerged();
 		this.#queueSave();
 
@@ -366,12 +378,8 @@ export class Settings {
 			clearTimeout(this.#saveTimer);
 			this.#saveTimer = undefined;
 		}
-		if (this.#savePromise) {
-			await this.#savePromise;
-		}
-		if (this.#modified.size > 0) {
-			await this.#saveNow();
-		}
+		const save = this.#modified.size > 0 ? this.#saveNow() : this.#saveTail;
+		await save;
 	}
 
 	/**
@@ -385,12 +393,8 @@ export class Settings {
 			clearTimeout(this.#saveTimer);
 			this.#saveTimer = undefined;
 		}
-		if (this.#savePromise) {
-			await this.#savePromise;
-		}
-		if (this.#modified.size > 0) {
-			await this.#saveNow({ throwOnError: true });
-		}
+		const save = this.#modified.size > 0 ? this.#saveNow({ throwOnError: true }) : this.#saveTail;
+		await save;
 	}
 
 	async cloneForCwd(cwd: string): Promise<Settings> {
@@ -480,7 +484,6 @@ export class Settings {
 	 * Set a model role (helper for modelRoles record).
 	 */
 	setModelRole(role: ModelRole | string, modelId: string): void {
-		const current = shallowStringRecord(getByPath(this.#global, ["modelRoles"]));
 		const runtimeOverrides = getByPath(this.#overrides, ["modelRoles"]);
 		const updateRuntimeOverride =
 			!!runtimeOverrides &&
@@ -488,11 +491,49 @@ export class Settings {
 			!Array.isArray(runtimeOverrides) &&
 			Object.hasOwn(runtimeOverrides, role);
 
-		this.set("modelRoles", { ...current, [role]: modelId });
+		this.setGlobalModelRole(role, modelId);
 
 		if (updateRuntimeOverride) {
 			this.override("modelRoles", { ...shallowStringRecord(runtimeOverrides), [role]: modelId });
 		}
+	}
+
+	setGlobalModelRole(role: ModelRole | string, modelId: string): void {
+		const current = shallowStringRecord(getByPath(this.#global, ["modelRoles"]));
+		this.set("modelRoles", { ...current, [role]: modelId });
+	}
+
+	setGlobalModelRoleAndFlush(role: ModelRole | string, modelId: string): Promise<void> {
+		const transaction = this.#globalModelRoleTail.then(async () => {
+			const hadModelRoles = Object.hasOwn(this.#global, "modelRoles");
+			const previousModelRoles = structuredClone(this.#global.modelRoles);
+			const previousPatch = this.#modified.get("modelRoles");
+			this.setGlobalModelRole(role, modelId);
+			const generation = this.#modified.get("modelRoles")?.generation;
+			if (this.#saveTimer) {
+				clearTimeout(this.#saveTimer);
+				this.#saveTimer = undefined;
+			}
+			const save = this.#saveNow({ throwOnError: true });
+			try {
+				await save;
+			} catch (error) {
+				const currentPatch = this.#modified.get("modelRoles");
+				if (currentPatch?.generation === generation) {
+					if (hadModelRoles) this.#global.modelRoles = previousModelRoles;
+					else delete this.#global.modelRoles;
+					if (previousPatch) this.#modified.set("modelRoles", previousPatch);
+					else this.#modified.delete("modelRoles");
+					this.#rebuildMerged();
+				}
+				throw error;
+			}
+		});
+		this.#globalModelRoleTail = transaction.then(
+			() => undefined,
+			() => undefined,
+		);
+		return transaction;
 	}
 	/**
 	 * Set an agent model override while keeping any live runtime override aligned.
@@ -824,15 +865,10 @@ export class Settings {
 	#queueSave(): void {
 		if (!this.#persist || !this.#configPath) return;
 
-		// Debounce: wait 100ms for more changes
-		if (this.#saveTimer) {
-			clearTimeout(this.#saveTimer);
-		}
+		if (this.#saveTimer) clearTimeout(this.#saveTimer);
 		this.#saveTimer = setTimeout(() => {
 			this.#saveTimer = undefined;
-			this.#saveNow().catch(err => {
-				logger.warn("Settings: background save failed", { error: String(err) });
-			});
+			void this.#saveNow();
 		}, 100);
 	}
 
@@ -840,30 +876,40 @@ export class Settings {
 		if (!this.#persist || !this.#configPath || this.#modified.size === 0) return;
 
 		const configPath = this.#configPath;
-		const modifiedPaths = [...this.#modified];
-		this.#modified.clear();
+		const patches = [...this.#modified.values()];
+
+		const save = this.#saveTail.then(() =>
+			withFileLock(configPath, async () => {
+				const current = await this.#loadYaml(configPath);
+				for (const patch of patches) {
+					setByPath(current, patch.path.split("."), patch.value);
+				}
+				await Bun.write(configPath, YAML.stringify(current, null, 2));
+				for (const patch of patches) {
+					if (this.#modified.get(patch.path)?.generation === patch.generation) {
+						this.#modified.delete(patch.path);
+					}
+				}
+				this.#global = current;
+				for (const patch of this.#modified.values()) {
+					setByPath(this.#global, patch.path.split("."), structuredClone(patch.value));
+				}
+			}),
+		);
+		this.#saveTail = save.then(
+			() => undefined,
+			() => undefined,
+		);
 
 		try {
-			await withFileLock(configPath, async () => {
-				// Re-read to preserve external changes
-				const current = await this.#loadYaml(configPath);
-
-				// Apply only our modified paths
-				for (const modPath of modifiedPaths) {
-					const segments = modPath.split(".");
-					const value = getByPath(this.#global, segments);
-					setByPath(current, segments, value);
-				}
-
-				// Update our global with any external changes we preserved
-				this.#global = current;
-				await Bun.write(configPath, YAML.stringify(this.#global, null, 2));
-			});
+			await save;
 		} catch (error) {
 			logger.warn("Settings: save failed", { error: String(error) });
-			// Re-add failed paths for retry
-			for (const p of modifiedPaths) {
-				this.#modified.add(p);
+			for (const patch of patches) {
+				const currentPatch = this.#modified.get(patch.path);
+				if (!currentPatch || currentPatch.generation < patch.generation) {
+					this.#modified.set(patch.path, patch);
+				}
 			}
 			if (options.throwOnError) {
 				this.#rebuildMerged();

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -3,7 +3,13 @@
  *
  * Spawns the agent in RPC mode and provides a typed API for all operations.
  */
-import type { AgentEvent, AgentMessage, AgentToolResult, ThinkingLevel } from "@gajae-code/agent-core";
+import {
+	type AgentEvent,
+	type AgentMessage,
+	type AgentToolResult,
+	type ResolvedThinkingLevel,
+	ThinkingLevel,
+} from "@gajae-code/agent-core";
 import type { CompactionResult } from "@gajae-code/agent-core/compaction";
 import type { ImageContent, Model } from "@gajae-code/ai";
 import { isRecord, ptree, readJsonl } from "@gajae-code/utils";
@@ -64,6 +70,12 @@ export interface RpcClientOptions {
 
 export type ModelInfo = Pick<Model, "provider" | "id" | "contextWindow" | "reasoning" | "thinking">;
 
+export type RpcDefaultModelSelection = {
+	readonly provider: string;
+	readonly modelId: string;
+	readonly thinkingLevel: ResolvedThinkingLevel;
+};
+
 export type RpcEventListener = (event: AgentEvent) => void;
 export type RpcSessionEventListener = (event: AgentSessionEvent) => void;
 
@@ -106,6 +118,29 @@ const coreAgentEventTypes = new Set<AgentEvent["type"]>([
 	"tool_execution_update",
 	"tool_execution_end",
 ]);
+
+function isResolvedThinkingLevel(value: unknown): value is ResolvedThinkingLevel {
+	return (
+		value === ThinkingLevel.Off ||
+		value === ThinkingLevel.Minimal ||
+		value === ThinkingLevel.Low ||
+		value === ThinkingLevel.Medium ||
+		value === ThinkingLevel.High ||
+		value === ThinkingLevel.XHigh ||
+		value === ThinkingLevel.Max
+	);
+}
+
+function isDefaultModelSelection(value: unknown): value is RpcDefaultModelSelection {
+	return (
+		isRecord(value) &&
+		typeof value.provider === "string" &&
+		value.provider.trim().length > 0 &&
+		typeof value.modelId === "string" &&
+		value.modelId.trim().length > 0 &&
+		isResolvedThinkingLevel(value.thinkingLevel)
+	);
+}
 
 function isRpcResponse(value: unknown): value is RpcResponse {
 	if (!isRecord(value)) return false;
@@ -623,6 +658,24 @@ export class RpcClient {
 	 */
 	async setModel(provider: string, modelId: string): Promise<{ provider: string; id: string }> {
 		const response = await this.#send({ type: "set_model", provider, modelId });
+		return this.#getData(response);
+	}
+
+	async setDefaultModelSelection(
+		provider: string,
+		modelId: string,
+		thinkingLevel: ResolvedThinkingLevel,
+	): Promise<RpcDefaultModelSelection> {
+		const response = await this.#send({
+			type: "set_default_model_selection",
+			provider,
+			modelId,
+			thinkingLevel,
+		});
+		if (!response.success) return this.#getData(response);
+		if (response.command !== "set_default_model_selection" || !isDefaultModelSelection(response.data)) {
+			throw new Error("Invalid set_default_model_selection response");
+		}
 		return this.#getData(response);
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -4,7 +4,7 @@
  * Commands are sent as JSON lines on stdin.
  * Responses and events are emitted as JSON lines on stdout.
  */
-import type { AgentMessage, AgentToolResult, ThinkingLevel } from "@gajae-code/agent-core";
+import type { AgentMessage, AgentToolResult, ResolvedThinkingLevel, ThinkingLevel } from "@gajae-code/agent-core";
 import type { CompactionResult } from "@gajae-code/agent-core/compaction";
 import type { Effort, ImageContent, Model } from "@gajae-code/ai";
 import type { BashResult } from "../../exec/bash-executor";
@@ -38,6 +38,13 @@ export type RpcCommand =
 
 	// Model
 	| { id?: string; type: "set_model"; provider: string; modelId: string }
+	| {
+			id?: string;
+			type: "set_default_model_selection";
+			provider: string;
+			modelId: string;
+			thinkingLevel?: ResolvedThinkingLevel;
+	  }
 	| { id?: string; type: "cycle_model" }
 	| { id?: string; type: "get_available_models" }
 
@@ -157,6 +164,13 @@ export type RpcResponse =
 			command: "set_model";
 			success: true;
 			data: Model;
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "set_default_model_selection";
+			success: true;
+			data: { provider: string; modelId: string; thinkingLevel: ResolvedThinkingLevel };
 	  }
 	| {
 			id?: string;

--- a/packages/coding-agent/src/modes/shared/agent-wire/command-dispatch.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/command-dispatch.ts
@@ -1,4 +1,4 @@
-import type { AgentTool } from "@gajae-code/agent-core";
+import type { AgentTool, ResolvedThinkingLevel } from "@gajae-code/agent-core";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import { Snowflake } from "@gajae-code/utils";
@@ -100,6 +100,14 @@ function serializeRpcDispatchError(err: unknown): string | object {
 		return { code: err.code, message: err.message };
 	}
 	return err instanceof Error ? err.message : String(err);
+}
+
+function isConcreteThinkingLevel(value: unknown): value is ResolvedThinkingLevel {
+	return (
+		typeof value === "string" &&
+		value !== ThinkingLevel.Inherit &&
+		(Object.values(ThinkingLevel) as string[]).includes(value)
+	);
 }
 
 export async function dispatchRpcCommand(
@@ -237,6 +245,30 @@ export async function dispatchRpcCommand(
 				}
 				await session.setModel(model);
 				return rpcSuccess(id, "set_model", model);
+			}
+
+			case "set_default_model_selection": {
+				if (typeof command.provider !== "string" || !command.provider.trim()) {
+					return typedError("set_default_model_selection", "provider must be a non-empty string");
+				}
+				if (typeof command.modelId !== "string" || !command.modelId.trim()) {
+					return typedError("set_default_model_selection", "modelId must be a non-empty string");
+				}
+				const requestedLevel: unknown = command.thinkingLevel;
+				if (requestedLevel !== undefined && !isConcreteThinkingLevel(requestedLevel)) {
+					return typedError("set_default_model_selection", "thinkingLevel must be a concrete level");
+				}
+				const model = session
+					.getAvailableModels()
+					.find(candidate => candidate.provider === command.provider && candidate.id === command.modelId);
+				if (!model) {
+					return typedError(
+						"set_default_model_selection",
+						`Model not found: ${command.provider}/${command.modelId}`,
+					);
+				}
+				const selection = await session.setDefaultModelSelection(model, requestedLevel);
+				return rpcSuccess(id, "set_default_model_selection", selection);
 			}
 
 			case "cycle_model": {

--- a/packages/coding-agent/src/modes/shared/agent-wire/command-validation.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/command-validation.ts
@@ -18,6 +18,7 @@ function stringField(value: Record<string, unknown>, key: string): boolean {
 }
 
 const THINKING_LEVELS = new Set(["inherit", "off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+const RESOLVED_THINKING_LEVELS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
 const TODO_STATUSES = new Set(["pending", "in_progress", "completed", "abandoned"]);
 
 function optionalBoolean(value: unknown): boolean {
@@ -136,6 +137,15 @@ export function isRpcCommand(value: unknown): value is RpcCommand {
 			);
 		case "set_model":
 			return stringField(value, "provider") && stringField(value, "modelId");
+		case "set_default_model_selection":
+			return (
+				typeof value.provider === "string" &&
+				value.provider.trim().length > 0 &&
+				typeof value.modelId === "string" &&
+				value.modelId.trim().length > 0 &&
+				(value.thinkingLevel === undefined ||
+					(typeof value.thinkingLevel === "string" && RESOLVED_THINKING_LEVELS.has(value.thinkingLevel)))
+			);
 		case "set_thinking_level":
 			return typeof value.level === "string" && THINKING_LEVELS.has(value.level);
 		case "set_steering_mode":

--- a/packages/coding-agent/src/modes/shared/agent-wire/scopes.ts
+++ b/packages/coding-agent/src/modes/shared/agent-wire/scopes.ts
@@ -49,6 +49,7 @@ const RPC_COMMAND_SCOPE_REGISTRY: Record<RpcCommandType, BridgeCommandScope> = {
 	get_pending_workflow_gates: "message:read",
 	set_capabilities: "control",
 	set_model: "model",
+	set_default_model_selection: "model",
 	cycle_model: "model",
 	get_available_models: "model",
 	set_thinking_level: "model",

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1182,6 +1182,7 @@ export class AgentSession {
 	#scopedModels: ScopedModelSelection[];
 	#thinkingLevel: ThinkingLevel | undefined;
 	#activeModelProfile: string | undefined;
+	#defaultModelSelectionTail: Promise<void> = Promise.resolve();
 	#promptTemplates: PromptTemplate[];
 	#slashCommands: FileSlashCommand[];
 
@@ -6962,25 +6963,33 @@ export class AgentSession {
 		model: Model,
 		thinkingLevel: ThinkingLevel | undefined,
 	): Promise<DefaultModelSelectionResult> {
-		if (thinkingLevel === ThinkingLevel.Inherit) {
-			throw new Error("Default model selection cannot inherit a thinking level");
+		const predecessor = this.#defaultModelSelectionTail;
+		const transaction = Promise.withResolvers<void>();
+		this.#defaultModelSelectionTail = transaction.promise;
+		try {
+			await predecessor;
+			if (thinkingLevel === ThinkingLevel.Inherit) {
+				throw new Error("Default model selection cannot inherit a thinking level");
+			}
+			const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
+			if (!apiKey) {
+				throw new Error(`No API key for ${model.provider}/${model.id}`);
+			}
+			const resolvedLevel = resolveThinkingLevelForModel(model, thinkingLevel);
+			const effectiveLevel =
+				resolvedLevel ??
+				resolveThinkingLevelForModel(model, model.thinking?.defaultLevel ?? this.thinkingLevel) ??
+				ThinkingLevel.Off;
+			await this.waitForIdle();
+			await this.settings.setGlobalModelRoleAndFlush(
+				"default",
+				formatModelSelectorValue(`${model.provider}/${model.id}`, effectiveLevel),
+			);
+			await this.setModelTemporary(model, effectiveLevel, { persistAsSessionDefault: true });
+			return { provider: model.provider, modelId: model.id, thinkingLevel: effectiveLevel };
+		} finally {
+			transaction.resolve();
 		}
-		const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
-		if (!apiKey) {
-			throw new Error(`No API key for ${model.provider}/${model.id}`);
-		}
-		const resolvedLevel = resolveThinkingLevelForModel(model, thinkingLevel);
-		const effectiveLevel =
-			resolvedLevel ??
-			resolveThinkingLevelForModel(model, model.thinking?.defaultLevel ?? this.thinkingLevel) ??
-			ThinkingLevel.Off;
-		await this.waitForIdle();
-		await this.settings.setGlobalModelRoleAndFlush(
-			"default",
-			formatModelSelectorValue(`${model.provider}/${model.id}`, effectiveLevel),
-		);
-		await this.setModelTemporary(model, effectiveLevel, { persistAsSessionDefault: true });
-		return { provider: model.provider, modelId: model.id, thinkingLevel: effectiveLevel };
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -28,6 +28,7 @@ import {
 	type AgentTool,
 	assertImagePlaceholdersHavePayload,
 	canContinuePersistedHistory,
+	type ResolvedThinkingLevel,
 	resolveTelemetry,
 	type StablePrefixSnapshot,
 	ThinkingLevel,
@@ -523,6 +524,12 @@ export interface RoleModelCycleResult {
 	model: Model;
 	thinkingLevel: ThinkingLevel | undefined;
 	role: string;
+}
+
+export interface DefaultModelSelectionResult {
+	readonly provider: string;
+	readonly modelId: string;
+	readonly thinkingLevel: ResolvedThinkingLevel;
 }
 
 /** Session statistics for /session command */
@@ -6949,6 +6956,31 @@ export class AgentSession {
 		// configured defaultLevel; otherwise re-clamp the current level.
 		this.setThinkingLevel(thinkingLevel ?? model.thinking?.defaultLevel ?? this.thinkingLevel);
 		await this.#syncEditToolModeAfterModelChange(previousEditMode);
+	}
+
+	async setDefaultModelSelection(
+		model: Model,
+		thinkingLevel: ThinkingLevel | undefined,
+	): Promise<DefaultModelSelectionResult> {
+		if (thinkingLevel === ThinkingLevel.Inherit) {
+			throw new Error("Default model selection cannot inherit a thinking level");
+		}
+		const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
+		if (!apiKey) {
+			throw new Error(`No API key for ${model.provider}/${model.id}`);
+		}
+		const resolvedLevel = resolveThinkingLevelForModel(model, thinkingLevel);
+		const effectiveLevel =
+			resolvedLevel ??
+			resolveThinkingLevelForModel(model, model.thinking?.defaultLevel ?? this.thinkingLevel) ??
+			ThinkingLevel.Off;
+		await this.waitForIdle();
+		await this.settings.setGlobalModelRoleAndFlush(
+			"default",
+			formatModelSelectorValue(`${model.provider}/${model.id}`, effectiveLevel),
+		);
+		await this.setModelTemporary(model, effectiveLevel, { persistAsSessionDefault: true });
+		return { provider: model.provider, modelId: model.id, thinkingLevel: effectiveLevel };
 	}
 
 	/**

--- a/packages/coding-agent/test/agent-session-default-model-selection.test.ts
+++ b/packages/coding-agent/test/agent-session-default-model-selection.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent, ThinkingLevel } from "@gajae-code/agent-core";
+import { Effort, type Model } from "@gajae-code/ai";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
+
+const INITIAL_MODEL: Model = {
+	id: "initial",
+	name: "Initial",
+	api: "anthropic-messages",
+	provider: "initial-provider",
+	baseUrl: "https://example.invalid",
+	reasoning: true,
+	thinking: { mode: "effort", minLevel: Effort.Low, maxLevel: Effort.High },
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 8_192,
+	maxTokens: 2_048,
+};
+
+function targetModel(options?: { reasoning?: boolean; minLevel?: Effort; maxLevel?: Effort }): Model {
+	return {
+		...INITIAL_MODEL,
+		id: options?.reasoning === false ? "plain" : "reasoning",
+		name: "Target",
+		provider: "target-provider",
+		reasoning: options?.reasoning ?? true,
+		thinking:
+			options?.reasoning === false
+				? undefined
+				: { mode: "effort", minLevel: options?.minLevel ?? Effort.Low, maxLevel: options?.maxLevel ?? Effort.High },
+	};
+}
+
+describe("AgentSession durable default model selection", () => {
+	let tempRoot: string;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let settings: Settings;
+	let activeStream: AssistantMessageEventStream | undefined;
+	let streamCreated: PromiseWithResolvers<void>;
+
+	beforeEach(async () => {
+		streamCreated = Promise.withResolvers<void>();
+		tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-default-model-session-"));
+		authStorage = await AuthStorage.create(path.join(tempRoot, "auth.db"));
+		authStorage.setRuntimeApiKey(INITIAL_MODEL.provider, "initial-key");
+		authStorage.setRuntimeApiKey("target-provider", "target-key");
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempRoot, "models.yml"));
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: INITIAL_MODEL, systemPrompt: ["Test"], tools: [] },
+			streamFn: () => {
+				activeStream = new AssistantMessageEventStream();
+				streamCreated.resolve();
+				return activeStream;
+			},
+		});
+		sessionManager = SessionManager.inMemory(tempRoot);
+		settings = Settings.isolated({ defaultThinkingLevel: Effort.XHigh });
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			thinkingLevel: Effort.Low,
+		});
+		sessionManager.appendMessage({ role: "user", content: "existing transcript", timestamp: Date.now() });
+	});
+
+	afterEach(async () => {
+		if (activeStream) {
+			const message = createAssistantMessage("released during cleanup");
+			activeStream.push({ type: "done", reason: "stop", message });
+			activeStream.end(message);
+			activeStream = undefined;
+		}
+		await session.dispose();
+		authStorage.close();
+		vi.restoreAllMocks();
+		await fs.rm(tempRoot, { recursive: true, force: true });
+	});
+
+	it("waits for an in-flight response before any durable or session mutation", async () => {
+		// Given
+		const model = targetModel({ minLevel: Effort.Medium, maxLevel: Effort.High });
+		const preflightComplete = Promise.withResolvers<void>();
+		const originalGetApiKey = modelRegistry.getApiKey.bind(modelRegistry);
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async (...args) => {
+			const apiKey = await originalGetApiKey(...args);
+			preflightComplete.resolve();
+			return apiKey;
+		});
+		const prompt = session.prompt("in flight");
+		await streamCreated.promise;
+		const entriesBeforeSelection = sessionManager.getEntries();
+		const idleBarrierEntered = Promise.withResolvers<"idle">();
+		const originalWaitForIdle = session.waitForIdle.bind(session);
+		vi.spyOn(session, "waitForIdle").mockImplementation(async () => {
+			idleBarrierEntered.resolve("idle");
+			await originalWaitForIdle();
+		});
+		const durableAttempted = Promise.withResolvers<"durable">();
+		const originalDurableCommit = settings.setGlobalModelRoleAndFlush.bind(settings);
+		const durableCommit = vi.spyOn(settings, "setGlobalModelRoleAndFlush").mockImplementation(async (...args) => {
+			durableAttempted.resolve("durable");
+			await originalDurableCommit(...args);
+		});
+
+		// When
+		const selection = session.setDefaultModelSelection(model, Effort.XHigh);
+		await preflightComplete.promise;
+		const firstMutationBoundary = await Promise.race([idleBarrierEntered.promise, durableAttempted.promise]);
+		const durableCallsBeforeIdle = durableCommit.mock.calls.length;
+		const modelBeforeIdle = session.model;
+		const entriesWhileStreaming = sessionManager.getEntries();
+
+		// Then
+		const message = createAssistantMessage("complete");
+		activeStream?.push({ type: "done", reason: "stop", message });
+		activeStream?.end(message);
+		activeStream = undefined;
+		await prompt;
+		const result = await selection;
+		expect(firstMutationBoundary).toBe("idle");
+		expect(durableCallsBeforeIdle).toBe(0);
+		expect(modelBeforeIdle).toBe(INITIAL_MODEL);
+		expect(entriesWhileStreaming).toEqual(entriesBeforeSelection);
+		expect(result).toEqual({
+			provider: "target-provider",
+			modelId: "reasoning",
+			thinkingLevel: Effort.High,
+		});
+		expect(session.model).toBe(model);
+		expect(session.thinkingLevel).toBe(Effort.High);
+		const entriesAfterSelection = sessionManager.getEntries();
+		expect(entriesAfterSelection.slice(0, entriesBeforeSelection.length)).toEqual(entriesBeforeSelection);
+		expect(entriesAfterSelection.filter(entry => entry.type === "model_change" && entry.role === "default")).toEqual([
+			expect.objectContaining({ model: "target-provider/reasoning" }),
+		]);
+		expect(entriesAfterSelection.filter(entry => entry.type === "thinking_level_change")).toEqual([
+			expect.objectContaining({ thinkingLevel: Effort.High }),
+		]);
+		const completedAssistantIndex = entriesAfterSelection.findIndex(
+			(entry, index) =>
+				index >= entriesBeforeSelection.length && entry.type === "message" && entry.message.role === "assistant",
+		);
+		const defaultModelMarkerIndex = entriesAfterSelection.findIndex(
+			entry => entry.type === "model_change" && entry.role === "default",
+		);
+		const thinkingMarkerIndex = entriesAfterSelection.findIndex(entry => entry.type === "thinking_level_change");
+		expect(completedAssistantIndex).toBeGreaterThanOrEqual(entriesBeforeSelection.length);
+		expect(defaultModelMarkerIndex).toBeGreaterThan(completedAssistantIndex);
+		expect(thinkingMarkerIndex).toBeGreaterThan(defaultModelMarkerIndex);
+		expect(settings.getGlobal("modelRoles")).toEqual({ default: "target-provider/reasoning:high" });
+	});
+
+	it("preserves explicit off for a reasoning model", async () => {
+		// Given
+		const model = targetModel();
+		session.setThinkingLevel(ThinkingLevel.Off);
+		const entriesBeforeSelection = sessionManager.getEntries();
+
+		// When
+		const result = await session.setDefaultModelSelection(model, ThinkingLevel.Off);
+
+		// Then
+		expect(result.thinkingLevel).toBe(ThinkingLevel.Off);
+		expect(session.model).toBe(model);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Off);
+		const selectionEntries = sessionManager.getEntries().slice(entriesBeforeSelection.length);
+		expect(selectionEntries.filter(entry => entry.type === "model_change" && entry.role === "default")).toEqual([
+			expect.objectContaining({ model: "target-provider/reasoning" }),
+		]);
+		expect(selectionEntries.filter(entry => entry.type === "thinking_level_change")).toEqual([]);
+		expect(settings.getGlobal("modelRoles")).toEqual({ default: "target-provider/reasoning:off" });
+		expect(settings.get("defaultThinkingLevel")).toBe(Effort.XHigh);
+	});
+
+	it("normalizes an unspecified level to off for a non-reasoning model", async () => {
+		// Given
+		const model = targetModel({ reasoning: false });
+
+		// When
+		const result = await session.setDefaultModelSelection(model, undefined);
+
+		// Then
+		expect(result.thinkingLevel).toBe(ThinkingLevel.Off);
+		expect(session.model).toBe(model);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Off);
+		expect(settings.getGlobal("modelRoles")).toEqual({ default: "target-provider/plain:off" });
+	});
+
+	it("rejects inherit before settings or session mutation", async () => {
+		// Given
+		const entriesBefore = sessionManager.getEntries();
+
+		// When
+		const selection = session.setDefaultModelSelection(targetModel(), ThinkingLevel.Inherit);
+
+		// Then
+		await expect(selection).rejects.toThrow(/inherit/i);
+		expect(settings.getGlobal("modelRoles")).toBeUndefined();
+		expect(session.model).toBe(INITIAL_MODEL);
+		expect(sessionManager.getEntries()).toEqual(entriesBefore);
+	});
+
+	it("rejects missing credentials before waiting or mutation", async () => {
+		// Given
+		const waitForIdle = vi.spyOn(session, "waitForIdle");
+		const entriesBefore = sessionManager.getEntries();
+		const model = { ...targetModel(), provider: "missing-provider" };
+
+		// When
+		const selection = session.setDefaultModelSelection(model, Effort.Medium);
+
+		// Then
+		await expect(selection).rejects.toThrow("No API key for missing-provider/reasoning");
+		expect(waitForIdle).not.toHaveBeenCalled();
+		expect(settings.getGlobal("modelRoles")).toBeUndefined();
+		expect(sessionManager.getEntries()).toEqual(entriesBefore);
+	});
+
+	it("does not apply the live selection when the durable commit fails", async () => {
+		// Given
+		vi.spyOn(settings, "setGlobalModelRoleAndFlush").mockRejectedValue(new Error("durable write failed"));
+		const liveApply = vi.spyOn(session, "setModelTemporary");
+
+		// When
+		const selection = session.setDefaultModelSelection(targetModel(), Effort.Medium);
+
+		// Then
+		await expect(selection).rejects.toThrow("durable write failed");
+		expect(liveApply).not.toHaveBeenCalled();
+		expect(session.model).toBe(INITIAL_MODEL);
+	});
+
+	it("keeps the durable selector and rejects when post-commit live apply fails", async () => {
+		// Given
+		vi.spyOn(session, "setModelTemporary").mockRejectedValue(new Error("live apply failed"));
+
+		// When
+		const selection = session.setDefaultModelSelection(targetModel(), Effort.High);
+
+		// Then
+		await expect(selection).rejects.toThrow("live apply failed");
+		expect(settings.getGlobal("modelRoles")).toEqual({ default: "target-provider/reasoning:high" });
+		expect(session.model).toBe(INITIAL_MODEL);
+	});
+});

--- a/packages/coding-agent/test/agent-session-default-model-selection.test.ts
+++ b/packages/coding-agent/test/agent-session-default-model-selection.test.ts
@@ -201,6 +201,47 @@ describe("AgentSession durable default model selection", () => {
 		expect(settings.getGlobal("modelRoles")).toEqual({ default: "target-provider/plain:off" });
 	});
 
+	it("serializes concurrent selections so the FIFO last request owns durable, live, and resume defaults", async () => {
+		// Given
+		const firstModel = { ...targetModel(), id: "first" };
+		const lastModel = { ...targetModel(), id: "last" };
+		const firstLiveApplyEntered = Promise.withResolvers<void>();
+		const releaseFirstLiveApply = Promise.withResolvers<void>();
+		const originalLiveApply = session.setModelTemporary.bind(session);
+		vi.spyOn(session, "setModelTemporary").mockImplementation(async (model, thinkingLevel, options) => {
+			if (model.id === firstModel.id) {
+				firstLiveApplyEntered.resolve();
+				await releaseFirstLiveApply.promise;
+			}
+			await originalLiveApply(model, thinkingLevel, options);
+		});
+		const lastPreflightEntered = Promise.withResolvers<void>();
+		const originalGetApiKey = modelRegistry.getApiKey.bind(modelRegistry);
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async (model, ...args) => {
+			if (model.id === lastModel.id) lastPreflightEntered.resolve();
+			return originalGetApiKey(model, ...args);
+		});
+
+		// When
+		const firstSelection = session.setDefaultModelSelection(firstModel, Effort.Low);
+		await firstLiveApplyEntered.promise;
+		const lastSelection = session.setDefaultModelSelection(lastModel, Effort.High);
+		const preflightRace = Promise.withResolvers<boolean>();
+		void lastPreflightEntered.promise.then(() => preflightRace.resolve(true));
+		setImmediate(() => preflightRace.resolve(false));
+		const lastRequestOvertookFirst = await preflightRace.promise;
+		if (lastRequestOvertookFirst) await lastSelection;
+		releaseFirstLiveApply.resolve();
+		await Promise.all([firstSelection, lastSelection]);
+
+		// Then
+		expect(lastRequestOvertookFirst).toBeFalse();
+		expect(settings.getGlobal("modelRoles")).toEqual({ default: "target-provider/last:high" });
+		expect(session.model).toBe(lastModel);
+		expect(session.thinkingLevel).toBe(Effort.High);
+		expect(sessionManager.buildSessionContext().models.default).toBe("target-provider/last");
+	});
+
 	it("rejects inherit before settings or session mutation", async () => {
 		// Given
 		const entriesBefore = sessionManager.getEntries();
@@ -243,6 +284,31 @@ describe("AgentSession durable default model selection", () => {
 		await expect(selection).rejects.toThrow("durable write failed");
 		expect(liveApply).not.toHaveBeenCalled();
 		expect(session.model).toBe(INITIAL_MODEL);
+	});
+
+	it("continues the selection queue after a rejected operation", async () => {
+		// Given
+		const successfulModel = { ...targetModel(), id: "after-failure" };
+		const originalDurableCommit = settings.setGlobalModelRoleAndFlush.bind(settings);
+		vi.spyOn(settings, "setGlobalModelRoleAndFlush")
+			.mockImplementation(originalDurableCommit)
+			.mockRejectedValueOnce(new Error("durable write failed"));
+
+		// When
+		const failedSelection = session.setDefaultModelSelection(targetModel(), Effort.Low);
+		await expect(failedSelection).rejects.toThrow("durable write failed");
+		const successfulSelection = await session.setDefaultModelSelection(successfulModel, Effort.High);
+
+		// Then
+		expect(successfulSelection).toEqual({
+			provider: "target-provider",
+			modelId: "after-failure",
+			thinkingLevel: Effort.High,
+		});
+		expect(settings.getGlobal("modelRoles")).toEqual({ default: "target-provider/after-failure:high" });
+		expect(session.model).toBe(successfulModel);
+		expect(session.thinkingLevel).toBe(Effort.High);
+		expect(sessionManager.buildSessionContext().models.default).toBe("target-provider/after-failure");
 	});
 
 	it("keeps the durable selector and rejects when post-commit live apply fails", async () => {

--- a/packages/coding-agent/test/bridge/agent-wire-scopes.test.ts
+++ b/packages/coding-agent/test/bridge/agent-wire-scopes.test.ts
@@ -22,6 +22,7 @@ const EXPECTED_RPC_COMMAND_TYPES: readonly RpcCommand["type"][] = [
 	"get_pending_workflow_gates",
 	"set_capabilities",
 	"set_model",
+	"set_default_model_selection",
 	"cycle_model",
 	"get_available_models",
 	"set_thinking_level",
@@ -95,6 +96,7 @@ describe("agent-wire RPC command scopes", () => {
 		expect(scopeForRpcCommand("export_html")).toBe("export");
 		expect(scopeForRpcCommand("switch_session")).toBe("session");
 		expect(scopeForRpcCommand("set_model")).toBe("model");
+		expect(scopeForRpcCommand("set_default_model_selection")).toBe("model");
 		expect(scopeForRpcCommand("get_messages")).toBe("message:read");
 		expect(scopeForRpcCommand("set_todos")).toBe("control");
 		expect(scopeForRpcCommand("workflow_gate_response")).toBe("control");

--- a/packages/coding-agent/test/rpc-client-default-model-selection.test.ts
+++ b/packages/coding-agent/test/rpc-client-default-model-selection.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ThinkingLevel } from "@gajae-code/agent-core";
+import { RpcClient } from "@gajae-code/coding-agent/modes/rpc/rpc-client";
+
+const expectedCommand = {
+	type: "set_default_model_selection",
+	provider: "openai",
+	modelId: "gpt-5.2",
+	thinkingLevel: ThinkingLevel.High,
+	id: "req_1",
+} as const;
+
+async function withFakeServer(responseBody: string, run: (client: RpcClient) => Promise<void>): Promise<void> {
+	const scriptPath = path.join(os.tmpdir(), `gjc-rpc-default-model-selection-${Date.now()}-${Math.random()}.js`);
+	await Bun.write(
+		scriptPath,
+		`
+let buffer = "";
+function write(frame) { process.stdout.write(JSON.stringify(frame) + "\\n"); }
+write({ type: "ready" });
+process.stdin.on("data", chunk => {
+	buffer += chunk.toString("utf8");
+	let index = buffer.indexOf("\\n");
+	while (index !== -1) {
+		const line = buffer.slice(0, index).trim();
+		buffer = buffer.slice(index + 1);
+		if (line) {
+			const frame = JSON.parse(line);
+			if (JSON.stringify(frame) !== ${JSON.stringify(JSON.stringify(expectedCommand))}) {
+				write({ id: frame.id, type: "response", command: frame.type, success: false, error: "unexpected command: " + JSON.stringify(frame) });
+			} else {
+				${responseBody}
+			}
+		}
+		index = buffer.indexOf("\\n");
+	}
+});
+setInterval(() => {}, 1000);
+`,
+	);
+	const client = new RpcClient({ cliPath: scriptPath });
+	try {
+		await run(client);
+	} finally {
+		client.stop();
+		await fs.rm(scriptPath, { force: true });
+	}
+}
+
+describe("RpcClient.setDefaultModelSelection", () => {
+	test("sends the exact JSONL command and returns the validated selection", async () => {
+		// Given: a fake RPC server that accepts only the exact command envelope.
+		await withFakeServer(
+			`write({ id: frame.id, type: "response", command: "set_default_model_selection", success: true, data: { provider: "openai", modelId: "gpt-5.2", thinkingLevel: "high" } });`,
+			async client => {
+				await client.start();
+
+				// When: the client requests a concrete default selection.
+				const result = await client.setDefaultModelSelection("openai", "gpt-5.2", ThinkingLevel.High);
+
+				// Then: the correlated, validated tuple is returned.
+				expect(result).toEqual({ provider: "openai", modelId: "gpt-5.2", thinkingLevel: ThinkingLevel.High });
+			},
+		);
+	});
+
+	test("rejects a correlated server error", async () => {
+		// Given: a same-id error response for the requested command.
+		await withFakeServer(
+			`write({ id: frame.id, type: "response", command: "set_default_model_selection", success: false, error: "selection refused" });`,
+			async client => {
+				await client.start();
+
+				// When/Then: the client surfaces the failure instead of returning a tuple.
+				await expect(client.setDefaultModelSelection("openai", "gpt-5.2", ThinkingLevel.High)).rejects.toThrow(
+					"selection refused",
+				);
+			},
+		);
+	});
+
+	test("rejects a same-id success response for a different command", async () => {
+		// Given: a correlated success response mislabeled as another command.
+		await withFakeServer(
+			`write({ id: frame.id, type: "response", command: "set_model", success: true, data: { provider: "openai", modelId: "gpt-5.2", thinkingLevel: "high" } });`,
+			async client => {
+				await client.start();
+
+				// When/Then: command correlation is validated locally.
+				await expect(client.setDefaultModelSelection("openai", "gpt-5.2", ThinkingLevel.High)).rejects.toThrow(
+					/set_default_model_selection/,
+				);
+			},
+		);
+	});
+
+	for (const [name, data] of [
+		["blank provider", { provider: " ", modelId: "gpt-5.2", thinkingLevel: "high" }],
+		["blank modelId", { provider: "openai", modelId: "\t", thinkingLevel: "high" }],
+		["missing data", undefined],
+		["missing thinking level", { provider: "openai", modelId: "gpt-5.2" }],
+		["inherit thinking level", { provider: "openai", modelId: "gpt-5.2", thinkingLevel: "inherit" }],
+		["unknown thinking level", { provider: "openai", modelId: "gpt-5.2", thinkingLevel: "turbo" }],
+	] as const) {
+		test(`rejects malformed success data with ${name}`, async () => {
+			// Given: a same-id success response with invalid feature data.
+			await withFakeServer(
+				`write({ id: frame.id, type: "response", command: "set_default_model_selection", success: true, data: ${JSON.stringify(data)} });`,
+				async client => {
+					await client.start();
+
+					// When/Then: malformed boundary data cannot become a false success.
+					await expect(client.setDefaultModelSelection("openai", "gpt-5.2", ThinkingLevel.High)).rejects.toThrow(
+						/Invalid set_default_model_selection response/,
+					);
+				},
+			);
+		});
+	}
+
+	test("stops a pending request when the fake server stalls", async () => {
+		// Given: a server that accepts the exact request but never responds.
+		await withFakeServer("", async client => {
+			await client.start();
+			const pending = client.setDefaultModelSelection("openai", "gpt-5.2", ThinkingLevel.High);
+
+			// When: the client is stopped while the command is pending.
+			client.stop();
+
+			// Then: the request rejects promptly instead of hanging until timeout.
+			await expect(pending).rejects.toThrow(/stopped|closed/i);
+		});
+	});
+});

--- a/packages/coding-agent/test/rpc-client-uds.test.ts
+++ b/packages/coding-agent/test/rpc-client-uds.test.ts
@@ -3,12 +3,13 @@ import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import * as net from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
-import type { AgentEvent } from "@gajae-code/agent-core";
+import { type AgentEvent, ThinkingLevel } from "@gajae-code/agent-core";
 import {
 	defineRpcClientTool,
 	RpcClient,
 	type RpcSessionEventListener,
 } from "@gajae-code/coding-agent/modes/rpc/rpc-client";
+import { YAML } from "bun";
 import { AGENT_WIRE_EVENT_TYPES } from "../src/modes/shared/agent-wire/event-contract";
 import { AgentWireFrameSequencer, toAgentWireEventFrame } from "../src/modes/shared/agent-wire/event-envelope";
 import type { AgentSessionEvent } from "../src/session/agent-session";
@@ -31,6 +32,26 @@ const fixtureModelsYaml = `providers:
           output: 0
           cacheRead: 0
           cacheWrite: 0
+`;
+
+const defaultSelectionModelsYaml = `providers:
+  rpc-test:
+    auth: none
+    api: openai-responses
+    baseUrl: http://127.0.0.1:9/v1
+    models:
+      - id: rpc-test-a
+        contextWindow: 100000
+        maxTokens: 4096
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+      - id: rpc-test-b
+        contextWindow: 100000
+        maxTokens: 4096
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+      - id: rpc-test-c
+        contextWindow: 100000
+        maxTokens: 4096
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
 `;
 
 let workspace: string;
@@ -94,6 +115,64 @@ function spawnRpc(socketPath: string) {
 }
 
 describe("RpcClient UDS transport", () => {
+	test("sets a durable default model through the real UDS server", async () => {
+		await writeFile(path.join(agentDir, "models.yml"), defaultSelectionModelsYaml);
+		const socketPath = path.join(workspace, "rpc-client-default-selection.sock");
+		const proc = Bun.spawn(
+			[
+				"bun",
+				cliEntry,
+				"--mode",
+				"rpc",
+				"--provider",
+				"rpc-test",
+				"--model",
+				"rpc-test-a",
+				"--session-dir",
+				path.join(workspace, "default-selection-sessions"),
+				"--listen",
+				socketPath,
+			],
+			{
+				cwd: workspace,
+				env: { ...cliEnv.env, GJC_HARNESS_STATE_ROOT: workspace, NO_COLOR: "1", PI_NOTIFICATIONS: "off" },
+				stdin: "ignore",
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		const stderrText = new Response(proc.stderr).text();
+		const client = new RpcClient({ transport: "uds", socketPath });
+		try {
+			await waitForSocket(socketPath);
+			await client.start();
+			expect((await client.getState()).model).toMatchObject({ provider: "rpc-test", id: "rpc-test-a" });
+
+			const selection = await client.setDefaultModelSelection("rpc-test", "rpc-test-b", ThinkingLevel.Off);
+
+			expect(selection).toEqual({
+				provider: "rpc-test",
+				modelId: "rpc-test-b",
+				thinkingLevel: ThinkingLevel.Off,
+			});
+			expect(YAML.parse(await Bun.file(path.join(agentDir, "config.yml")).text())).toMatchObject({
+				modelRoles: { default: "rpc-test/rpc-test-b:off" },
+			});
+			expect(await client.getState()).toMatchObject({
+				model: { provider: "rpc-test", id: "rpc-test-b" },
+				thinkingLevel: ThinkingLevel.Off,
+			});
+		} finally {
+			client.stop();
+			proc.kill();
+			await proc.exited;
+			expect(Bun.spawnSync(["kill", "-0", String(proc.pid)]).exitCode).not.toBe(0);
+			expect(await Bun.file(socketPath).exists()).toBe(false);
+			expect((await stderrText).trim()).toBe("");
+			await rm(workspace, { recursive: true, force: true });
+		}
+	}, 45_000);
+
 	test("connects to rpc-mode UDS, correlates requests, checks pending-gate replay API, and leaves server alive on close", async () => {
 		const socketPath = path.join(workspace, "rpc.sock");
 		const proc = spawnRpc(socketPath);

--- a/packages/coding-agent/test/rpc-default-model-selection-docs.test.ts
+++ b/packages/coding-agent/test/rpc-default-model-selection-docs.test.ts
@@ -8,6 +8,21 @@ async function readRepositoryFile(relativePath: string): Promise<string> {
 }
 
 describe("durable default model selection documentation", () => {
+	test("lists every concrete thinking level in the command inventory", async () => {
+		// Given the canonical RPC reference
+		const rpcDoc = await readRepositoryFile("docs/rpc.md");
+
+		// When the durable default command inventory is inspected
+		const commandInventory = rpcDoc.match(/^- `\{ id\?, type: "set_default_model_selection"[^\n]+$/m)?.[0];
+		const documentedLevels = commandInventory
+			?.match(/thinkingLevel\?: ([^}]+) \}/)?.[1]
+			?.match(/"[^"]+"/g)
+			?.map(level => level.slice(1, -1));
+
+		// Then it enumerates the complete concrete-level contract
+		expect(documentedLevels).toEqual(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+	});
+
 	test("documents the exact request and success response fields", async () => {
 		// Given the canonical RPC reference
 		const rpcDoc = await readRepositoryFile("docs/rpc.md");

--- a/packages/coding-agent/test/rpc-default-model-selection-docs.test.ts
+++ b/packages/coding-agent/test/rpc-default-model-selection-docs.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+
+const repositoryRoot = path.resolve(import.meta.dir, "../../..");
+
+async function readRepositoryFile(relativePath: string): Promise<string> {
+	return Bun.file(path.join(repositoryRoot, relativePath)).text();
+}
+
+describe("durable default model selection documentation", () => {
+	test("documents the exact request and success response fields", async () => {
+		// Given the canonical RPC reference
+		const rpcDoc = await readRepositoryFile("docs/rpc.md");
+
+		// When the durable default command contract is inspected
+		const contract = rpcDoc.match(/### `set_default_model_selection` contract[\s\S]*?(?=\n### |\n## |$)/)?.[0];
+
+		// Then the wire shapes are explicit and correlated
+		expect(contract).toContain(
+			'{ "id": "model-default-1", "type": "set_default_model_selection", "provider": "openai", "modelId": "gpt-5.6", "thinkingLevel": "high" }',
+		);
+		expect(contract).toContain(
+			'{ "id": "model-default-1", "type": "response", "command": "set_default_model_selection", "success": true, "data": { "provider": "openai", "modelId": "gpt-5.6", "thinkingLevel": "high" } }',
+		);
+	});
+
+	test("documents concrete effective-level normalization", async () => {
+		// Given the canonical RPC reference
+		const rpcDoc = await readRepositoryFile("docs/rpc.md");
+
+		// When the thinking-level rules are inspected
+		const contract = rpcDoc.match(/### `set_default_model_selection` contract[\s\S]*?(?=\n### |\n## |$)/)?.[0];
+
+		// Then inherit, clamping, and non-reasoning normalization are unambiguous
+		expect(contract).toContain("`thinkingLevel` may be omitted or set to a concrete level");
+		expect(contract).toContain('`"inherit"` is rejected');
+		expect(contract).toContain("clamped to the selected model's supported range");
+		expect(contract).toContain("A non-reasoning model always resolves to `off`");
+	});
+
+	test("documents durability, ordering, streaming, and precedence limits", async () => {
+		// Given the canonical RPC reference
+		const rpcDoc = await readRepositoryFile("docs/rpc.md");
+
+		// When the command lifecycle is inspected
+		const contract = rpcDoc.match(/### `set_default_model_selection` contract[\s\S]*?(?=\n### |\n## |$)/)?.[0];
+
+		// Then acknowledgement and the limited durable promise are exact
+		expect(contract).toContain("acknowledges success only after the machine-global selector is durably written");
+		expect(contract).toContain("ordered mutation");
+		expect(contract).toContain("waits for an active stream to become idle");
+		expect(contract).toContain("applies to the next message");
+		expect(contract).toContain("Project-level model-role policy overrides the machine-global selector");
+		expect(contract).toContain("a resumed session's recorded default model overrides it");
+	});
+
+	test("documents Bridge authorization reachability without claiming enabled endpoints", async () => {
+		// Given the RPC and Bridge references
+		const [rpcDoc, bridgeDoc] = await Promise.all([
+			readRepositoryFile("docs/rpc.md"),
+			readRepositoryFile("docs/bridge.md"),
+		]);
+
+		// When their shared command catalog is inspected
+		const contract = rpcDoc.match(/### `set_default_model_selection` contract[\s\S]*?(?=\n### |\n## |$)/)?.[0];
+
+		// Then the consequence is limited to the authorized shared surface
+		expect(contract).toContain("shared agent-wire command surface");
+		expect(contract).toContain("Bridge command endpoint is enabled");
+		expect(contract).toContain("requires the `model` scope");
+		expect(bridgeDoc).toContain("| `set_default_model_selection` | `model` |");
+	});
+
+	test("records the limited durable default in Unreleased", async () => {
+		// Given the package changelog
+		const changelog = await readRepositoryFile("packages/coding-agent/CHANGELOG.md");
+
+		// When the Unreleased section is inspected
+		const unreleased = changelog.match(/## \[Unreleased\][\s\S]*?(?=\n## \[|$)/)?.[0];
+
+		// Then it records the durable selector without overstating precedence
+		expect(unreleased).toContain(
+			"RPC clients can now durably select the machine-global default model and effective thinking level for subsequent messages",
+		);
+		expect(unreleased).toContain("while project policy and resumed session history retain precedence");
+	});
+});

--- a/packages/coding-agent/test/rpc-dispatch-validation.test.ts
+++ b/packages/coding-agent/test/rpc-dispatch-validation.test.ts
@@ -19,6 +19,155 @@ function ctx(session: Partial<AgentSession> = {}): RpcCommandDispatchContext {
 }
 
 describe("dispatchRpcCommand validation + error correlation", () => {
+	test.each([
+		[
+			"missing provider",
+			{ id: "selection-missing-provider", type: "set_default_model_selection", modelId: "gpt-5" },
+			"provider must be a non-empty string",
+		],
+		[
+			"numeric modelId",
+			{ id: "selection-numeric-model", type: "set_default_model_selection", provider: "openai", modelId: 42 },
+			"modelId must be a non-empty string",
+		],
+		[
+			"blank provider",
+			{ id: "selection-blank-provider", type: "set_default_model_selection", provider: "  ", modelId: "gpt-5" },
+			"provider must be a non-empty string",
+		],
+		[
+			"invalid thinking level",
+			{
+				id: "selection-invalid-level",
+				type: "set_default_model_selection",
+				provider: "openai",
+				modelId: "gpt-5",
+				thinkingLevel: "extreme",
+			},
+			"thinkingLevel must be a concrete level",
+		],
+		[
+			"inherited thinking level",
+			{
+				id: "selection-inherit-level",
+				type: "set_default_model_selection",
+				provider: "openai",
+				modelId: "gpt-5",
+				thinkingLevel: ThinkingLevel.Inherit,
+			},
+			"thinkingLevel must be a concrete level",
+		],
+	] as const)("rejects a directly dispatched %s selector with correlated command identity", async (_name, frame, error) => {
+		// Given: an untrusted selector that bypassed the public wire validator.
+		const command = frame as unknown as RpcCommand;
+
+		// When: the malformed command reaches the dispatcher directly.
+		const response = await dispatchRpcCommand(command, ctx());
+
+		// Then: the real command and request id are retained rather than being mislabeled as parse.
+		expect(response).toMatchObject({
+			id: frame.id,
+			type: "response",
+			command: "set_default_model_selection",
+			success: false,
+			error,
+		});
+	});
+
+	test("returns the session operation's stable effective selector tuple", async () => {
+		// Given: one strictly matching model and a session operation that records its only invocation.
+		const target = { provider: "openai", id: "gpt-5" };
+		const calls: Array<{ model: unknown; level: unknown }> = [];
+
+		// When: a valid direct command selects that model.
+		const response = await dispatchRpcCommand(
+			{
+				id: "selection-ok",
+				type: "set_default_model_selection",
+				provider: "openai",
+				modelId: "gpt-5",
+				thinkingLevel: ThinkingLevel.High,
+			},
+			ctx({
+				getAvailableModels: (() => [target]) as AgentSession["getAvailableModels"],
+				setDefaultModelSelection: (async (model: unknown, level: unknown) => {
+					calls.push({ model, level });
+					return { provider: "openai", modelId: "gpt-5", thinkingLevel: ThinkingLevel.Medium };
+				}) as AgentSession["setDefaultModelSelection"],
+			}),
+		);
+
+		// Then: dispatch delegates once and returns the operation's effective level unchanged.
+		expect(calls).toEqual([{ model: target, level: ThinkingLevel.High }]);
+		expect(response).toEqual({
+			id: "selection-ok",
+			type: "response",
+			command: "set_default_model_selection",
+			success: true,
+			data: { provider: "openai", modelId: "gpt-5", thinkingLevel: ThinkingLevel.Medium },
+		});
+	});
+
+	test("rejects an unknown default model without invoking the session operation", async () => {
+		// Given: no available model matches the requested provider and id.
+		let invoked = false;
+
+		// When: the command requests an unavailable model.
+		const response = await dispatchRpcCommand(
+			{
+				id: "selection-unknown",
+				type: "set_default_model_selection",
+				provider: "openai",
+				modelId: "missing",
+			},
+			ctx({
+				getAvailableModels: (() => []) as AgentSession["getAvailableModels"],
+				setDefaultModelSelection: (async () => {
+					invoked = true;
+					throw new Error("must not run");
+				}) as AgentSession["setDefaultModelSelection"],
+			}),
+		);
+
+		// Then: lookup fails with correlation and no mutation marker.
+		expect(invoked).toBe(false);
+		expect(response).toMatchObject({
+			id: "selection-unknown",
+			command: "set_default_model_selection",
+			success: false,
+			error: "Model not found: openai/missing",
+		});
+	});
+
+	test("correlates a default model session-operation failure", async () => {
+		// Given: a matching model whose durable session operation fails.
+		const target = { provider: "openai", id: "gpt-5" };
+
+		// When: the operation rejects after dispatcher lookup.
+		const response = await dispatchRpcCommand(
+			{
+				id: "selection-operation-error",
+				type: "set_default_model_selection",
+				provider: "openai",
+				modelId: "gpt-5",
+			},
+			ctx({
+				getAvailableModels: (() => [target]) as AgentSession["getAvailableModels"],
+				setDefaultModelSelection: (async () => {
+					throw new Error("durable selection failed");
+				}) as AgentSession["setDefaultModelSelection"],
+			}),
+		);
+
+		// Then: the existing dispatcher error funnel retains id and command.
+		expect(response).toMatchObject({
+			id: "selection-operation-error",
+			command: "set_default_model_selection",
+			success: false,
+			error: "durable selection failed",
+		});
+	});
+
 	test("accepts a valid default model selection wire command", () => {
 		// Given: a complete selector with an explicit reasoning level.
 		const command = {

--- a/packages/coding-agent/test/rpc-dispatch-validation.test.ts
+++ b/packages/coding-agent/test/rpc-dispatch-validation.test.ts
@@ -5,6 +5,7 @@ import {
 	dispatchRpcCommand,
 	type RpcCommandDispatchContext,
 } from "@gajae-code/coding-agent/modes/shared/agent-wire/command-dispatch";
+import { isRpcCommand } from "@gajae-code/coding-agent/modes/shared/agent-wire/command-validation";
 import type { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 
 function ctx(session: Partial<AgentSession> = {}): RpcCommandDispatchContext {
@@ -18,6 +19,75 @@ function ctx(session: Partial<AgentSession> = {}): RpcCommandDispatchContext {
 }
 
 describe("dispatchRpcCommand validation + error correlation", () => {
+	test("accepts a valid default model selection wire command", () => {
+		// Given: a complete selector with an explicit reasoning level.
+		const command = {
+			id: "selection-1",
+			type: "set_default_model_selection",
+			provider: "openai",
+			modelId: "gpt-5",
+			thinkingLevel: ThinkingLevel.High,
+		};
+
+		// When: the public wire boundary validates the frame.
+		const accepted = isRpcCommand(command);
+
+		// Then: the command is accepted without dispatching it.
+		expect(accepted).toBe(true);
+	});
+
+	test("accepts a default model selection without an optional reasoning level", () => {
+		// Given: a complete model selector with no reasoning override.
+		const command = {
+			id: "selection-2",
+			type: "set_default_model_selection",
+			provider: "anthropic",
+			modelId: "claude-sonnet-4-5",
+		};
+
+		// When: the public wire boundary validates the frame.
+		const accepted = isRpcCommand(command);
+
+		// Then: omission preserves the command's optional-level contract.
+		expect(accepted).toBe(true);
+	});
+
+	test("rejects malformed default model selection wire commands", () => {
+		// Given: frames covering missing, blank, non-string, inherited, and unknown selector fields.
+		const malformed: readonly unknown[] = [
+			{ type: "set_default_model_selection", modelId: "gpt-5" },
+			{ type: "set_default_model_selection", provider: "openai" },
+			{ type: "set_default_model_selection", provider: "   ", modelId: "gpt-5" },
+			{ type: "set_default_model_selection", provider: "openai", modelId: "\t" },
+			{ type: "set_default_model_selection", provider: 42, modelId: "gpt-5" },
+			{ type: "set_default_model_selection", provider: "openai", modelId: false },
+			{
+				type: "set_default_model_selection",
+				provider: "openai",
+				modelId: "gpt-5",
+				thinkingLevel: "",
+			},
+			{
+				type: "set_default_model_selection",
+				provider: "openai",
+				modelId: "gpt-5",
+				thinkingLevel: ThinkingLevel.Inherit,
+			},
+			{
+				type: "set_default_model_selection",
+				provider: "openai",
+				modelId: "gpt-5",
+				thinkingLevel: "extreme",
+			},
+		];
+
+		// When: each untrusted frame crosses the public wire boundary.
+		const results = malformed.map(isRpcCommand);
+
+		// Then: none reaches the typed dispatcher contract.
+		expect(results).toEqual(malformed.map(() => false));
+	});
+
 	test("rejects an invalid thinking level with a correlated error (issue 02)", async () => {
 		const res = await dispatchRpcCommand(
 			{ id: "t1", type: "set_thinking_level", level: "BOGUS" } as unknown as RpcCommand,

--- a/packages/coding-agent/test/rpc-fastlane.test.ts
+++ b/packages/coding-agent/test/rpc-fastlane.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@gajae-code/coding-agent/modes/shared/agent-wire/command-dispatch";
 import type { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 
-const FAST_LANE_COMMANDS: RpcCommand["type"][] = [
+const FAST_LANE_COMMANDS = [
 	// Cancellation (must interrupt in-flight work).
 	"abort",
 	"abort_bash",
@@ -25,14 +25,15 @@ const FAST_LANE_COMMANDS: RpcCommand["type"][] = [
 	"get_last_assistant_text",
 	"get_messages",
 	"get_login_providers",
-];
+	"get_pending_workflow_gates",
+] as const satisfies readonly RpcCommand["type"][];
 
 // Commands that MUST stay on the ordered serial chain: async/long work, causally
 // significant async mutations, or synchronous mutating mode/config setters. The
 // setters are kept ordered because a fast-laned setter could overtake an
 // already-queued ordered command (e.g. a prompt submitted before it) and change
 // that command's causal semantics (#618 review).
-const ORDERED_COMMANDS: RpcCommand["type"][] = [
+const ORDERED_COMMANDS = [
 	"prompt",
 	"steer",
 	"follow_up",
@@ -45,6 +46,7 @@ const ORDERED_COMMANDS: RpcCommand["type"][] = [
 	"handoff",
 	"login",
 	"set_model",
+	"set_default_model_selection",
 	"cycle_model",
 	"set_todos",
 	"set_session_name",
@@ -61,7 +63,17 @@ const ORDERED_COMMANDS: RpcCommand["type"][] = [
 	"set_interrupt_mode",
 	"set_auto_compaction",
 	"set_auto_retry",
-];
+] as const satisfies readonly RpcCommand["type"][];
+
+const PRE_SCHEDULER_COMMANDS = ["set_capabilities"] as const satisfies readonly RpcCommand["type"][];
+
+type ClassifiedRpcCommand =
+	| (typeof FAST_LANE_COMMANDS)[number]
+	| (typeof ORDERED_COMMANDS)[number]
+	| (typeof PRE_SCHEDULER_COMMANDS)[number];
+const RPC_COMMAND_CLASSIFICATION_IS_EXHAUSTIVE: Exclude<RpcCommand["type"], ClassifiedRpcCommand> extends never
+	? true
+	: false = true;
 
 const flushMicrotasks = async (): Promise<void> => {
 	for (let i = 0; i < 8; i++) await Promise.resolve();
@@ -78,6 +90,7 @@ describe("RPC fast-lane classification (#606, issue 13)", () => {
 		for (const type of ORDERED_COMMANDS) {
 			expect(isFastLaneRpcCommand(type)).toBe(false);
 		}
+		expect(ORDERED_COMMANDS).toContain("set_default_model_selection");
 	});
 
 	test("the cancellation set is exactly the three abort commands", () => {
@@ -112,12 +125,11 @@ describe("RPC fast-lane classification (#606, issue 13)", () => {
 		}
 	});
 
-	test("classification is exhaustive — fast-lane and ordered partition every command type", () => {
-		const all = new Set<RpcCommand["type"]>([...FAST_LANE_COMMANDS, ...ORDERED_COMMANDS]);
-		// No command may appear in both lists.
-		expect(FAST_LANE_COMMANDS.filter(t => ORDERED_COMMANDS.includes(t))).toEqual([]);
-		// Guards against a new command type silently slipping through untested.
-		expect(all.size).toBe(FAST_LANE_COMMANDS.length + ORDERED_COMMANDS.length);
+	test("classification is exhaustive across fast-lane, ordered, and pre-scheduler commands", () => {
+		const classified = [...FAST_LANE_COMMANDS, ...ORDERED_COMMANDS, ...PRE_SCHEDULER_COMMANDS];
+		expect(new Set<RpcCommand["type"]>(classified).size).toBe(classified.length);
+		expect(PRE_SCHEDULER_COMMANDS).toEqual(["set_capabilities"]);
+		expect(RPC_COMMAND_CLASSIFICATION_IS_EXHAUSTIVE).toBe(true);
 	});
 });
 
@@ -208,6 +220,40 @@ describe("createRpcCommandScheduler ordering behavior", () => {
 		// The setter applies strictly AFTER the earlier queued prompt, so the prompt
 		// runs under the pre-setter mode (arrival-order / causal semantics preserved).
 		expect(order).toEqual(["bash", "prompt", "set_thinking_level"]);
+	});
+
+	test("set_default_model_selection waits behind a blocked mutation while a fast-lane read proceeds", async () => {
+		const order: string[] = [];
+		const predecessor = Promise.withResolvers<void>();
+		const tracked: Promise<void>[] = [];
+		const run = async (command: RpcCommand): Promise<void> => {
+			if (command.type === "set_model") {
+				order.push("set_model:start");
+				await predecessor.promise;
+				order.push("set_model:end");
+				return;
+			}
+			order.push(command.type);
+		};
+		const { dispatch } = createRpcCommandScheduler(run, task => {
+			tracked.push(task);
+		});
+
+		try {
+			dispatch({ type: "set_model", provider: "p", modelId: "before" });
+			dispatch({ type: "set_default_model_selection", provider: "p", modelId: "after" });
+			dispatch({ type: "get_state" });
+			await flushMicrotasks();
+
+			expect(order).toEqual(["get_state", "set_model:start"]);
+
+			predecessor.resolve();
+			await Promise.all(tracked);
+			expect(order).toEqual(["get_state", "set_model:start", "set_model:end", "set_default_model_selection"]);
+		} finally {
+			predecessor.resolve();
+			await Promise.allSettled(tracked);
+		}
 	});
 
 	test("every dispatched task is tracked for shutdown draining", async () => {

--- a/packages/coding-agent/test/rpc-socket-server.test.ts
+++ b/packages/coding-agent/test/rpc-socket-server.test.ts
@@ -28,6 +28,7 @@ interface Frame {
 	command?: string;
 	success?: boolean;
 	data?: { sessionId?: string; output?: string } & Record<string, unknown>;
+	error?: unknown;
 }
 
 let workspace: string;
@@ -58,6 +59,11 @@ interface SocketConn {
 	nextResponse(id: string, timeoutMs?: number): Promise<Frame>;
 	nextFrame(timeoutMs?: number): Promise<Frame>;
 	close(): void;
+}
+
+async function readBytesIfPresent(filePath: string): Promise<Uint8Array | undefined> {
+	const file = Bun.file(filePath);
+	return (await file.exists()) ? new Uint8Array(await file.arrayBuffer()) : undefined;
 }
 
 async function connect(socketPath: string): Promise<SocketConn> {
@@ -128,6 +134,98 @@ async function waitForSocket(socketPath: string, timeoutMs = 15_000): Promise<vo
 }
 
 describe("gjc --mode rpc --listen (UDS persistent server, issue 09)", () => {
+	it("rejects malformed raw default selectors without mutating durable bytes or losing UDS service", async () => {
+		const socketPath = path.join(workspace, "rpc-malformed.sock");
+		const proc = Bun.spawn(
+			[
+				"bun",
+				cliEntry,
+				"--mode",
+				"rpc",
+				"--provider",
+				"rpc-test",
+				"--model",
+				"rpc-test-model",
+				"--session-dir",
+				path.join(workspace, "sessions-malformed"),
+				"--listen",
+				socketPath,
+			],
+			{
+				cwd: workspace,
+				env: { ...cliEnv.env, GJC_HARNESS_STATE_ROOT: workspace, NO_COLOR: "1", PI_NOTIFICATIONS: "off" },
+				stdin: "ignore",
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		const stderrText = new Response(proc.stderr).text();
+		let connection: SocketConn | undefined;
+		const malformed = [
+			{ id: "uds-missing-provider", type: "set_default_model_selection", modelId: "rpc-test-model" },
+			{ id: "uds-numeric-model", type: "set_default_model_selection", provider: "rpc-test", modelId: 42 },
+			{ id: "uds-blank-provider", type: "set_default_model_selection", provider: " ", modelId: "rpc-test-model" },
+			{
+				id: "uds-invalid-level",
+				type: "set_default_model_selection",
+				provider: "rpc-test",
+				modelId: "rpc-test-model",
+				thinkingLevel: "extreme",
+			},
+			{
+				id: "uds-inherit-level",
+				type: "set_default_model_selection",
+				provider: "rpc-test",
+				modelId: "rpc-test-model",
+				thinkingLevel: "inherit",
+			},
+			{ id: "uds-unknown-model", type: "set_default_model_selection", provider: "rpc-test", modelId: "missing" },
+		] as const;
+		try {
+			// Given: the real socket is ready and durable baselines are captured only after initial state.
+			await waitForSocket(socketPath);
+			connection = await connect(socketPath);
+			expect(await connection.nextFrame()).toEqual({ type: "ready" });
+			connection.send({ id: "uds-baseline", type: "get_state" });
+			const initialState = await connection.nextResponse("uds-baseline");
+			expect(initialState).toMatchObject({ command: "get_state", success: true });
+			const sessionFile = initialState.data?.sessionFile;
+			if (typeof sessionFile !== "string") throw new Error("Expected UDS get_state to return a session file");
+			const configFile = path.join(agentDir, "config.yml");
+			const configBaseline = await readBytesIfPresent(configFile);
+			const sessionBaseline = await readBytesIfPresent(sessionFile);
+
+			for (const [index, command] of malformed.entries()) {
+				// When: each raw mutation response arrives before its fast-lane state probe is sent.
+				connection.send(command);
+				const failure = await connection.nextResponse(command.id);
+
+				// Then: correlation, survival, and both durable byte snapshots remain exact.
+				expect(failure).toMatchObject({
+					id: command.id,
+					command: "set_default_model_selection",
+					success: false,
+				});
+				expect(failure.command).not.toBe("parse");
+				expect(JSON.stringify(failure.error)).not.toContain("Unknown command");
+				connection.send({ id: `uds-state-after-${index}`, type: "get_state" });
+				expect(await connection.nextResponse(`uds-state-after-${index}`)).toMatchObject({
+					command: "get_state",
+					success: true,
+				});
+				expect(await readBytesIfPresent(configFile)).toEqual(configBaseline);
+				expect(await readBytesIfPresent(sessionFile)).toEqual(sessionBaseline);
+			}
+		} finally {
+			connection?.close();
+			proc.kill();
+			await proc.exited;
+			expect(Bun.spawnSync(["kill", "-0", String(proc.pid)]).exitCode).not.toBe(0);
+			expect(await Bun.file(socketPath).exists()).toBe(false);
+			expect((await stderrText).trim()).toBe("");
+		}
+	}, 45_000);
+
 	it("keeps the AgentSession alive across client reconnects", async () => {
 		const socketPath = path.join(workspace, "rpc.sock");
 		const proc = Bun.spawn(

--- a/packages/coding-agent/test/rpc-socket-server.test.ts
+++ b/packages/coding-agent/test/rpc-socket-server.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
+import { YAML } from "bun";
 import { createHarnessCliEnv, type HarnessCliEnv } from "./harness-control-plane/cli-workspace-env";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
@@ -21,6 +22,28 @@ const fixtureModelsYaml = `providers:
           cacheRead: 0
           cacheWrite: 0
 `;
+
+function liveFixtureModelsYaml(baseUrl: string): string {
+	return `providers:
+  rpc-test:
+    auth: none
+    api: openai-responses
+    baseUrl: ${baseUrl}
+    models:
+      - id: rpc-test-a
+        contextWindow: 100000
+        maxTokens: 4096
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+      - id: rpc-test-b
+        contextWindow: 100000
+        maxTokens: 4096
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+      - id: rpc-test-c
+        contextWindow: 100000
+        maxTokens: 4096
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+`;
+}
 
 interface Frame {
 	type?: string;
@@ -66,9 +89,13 @@ async function readBytesIfPresent(filePath: string): Promise<Uint8Array | undefi
 	return (await file.exists()) ? new Uint8Array(await file.arrayBuffer()) : undefined;
 }
 
-async function connect(socketPath: string): Promise<SocketConn> {
+async function connect(socketPath: string, beforeFrame?: (frame: Frame) => Promise<void>): Promise<SocketConn> {
 	const queue: Frame[] = [];
-	const waiters: Array<(frame: Frame) => void> = [];
+	const waiters: Array<{
+		matches(frame: Frame): boolean;
+		resolve(frame: Frame): void;
+		timer: Timer;
+	}> = [];
 	const decoder = new TextDecoder("utf-8", { fatal: false });
 	let buf = "";
 	const socket = await Bun.connect({
@@ -83,36 +110,45 @@ async function connect(socketPath: string): Promise<SocketConn> {
 					buf = buf.slice(nl + 1);
 					if (!line) continue;
 					const frame = JSON.parse(line) as Frame;
-					const waiter = waiters.shift();
-					if (waiter) waiter(frame);
-					else queue.push(frame);
+					const deliver = (): void => {
+						const waiterIndex = waiters.findIndex(waiter => waiter.matches(frame));
+						const waiter = waiterIndex >= 0 ? waiters.splice(waiterIndex, 1)[0] : undefined;
+						if (waiter) {
+							clearTimeout(waiter.timer);
+							waiter.resolve(frame);
+						} else queue.push(frame);
+					};
+					if (beforeFrame) void beforeFrame(frame).then(deliver);
+					else deliver();
 				}
 			},
 		},
 	});
-	const nextFrame = (timeoutMs = 12_000): Promise<Frame> => {
-		const queued = queue.shift();
-		if (queued) return Promise.resolve(queued);
-		return new Promise<Frame>((resolve, reject) => {
-			const timer = setTimeout(() => reject(new Error("timed out waiting for socket frame")), timeoutMs);
-			waiters.push(frame => {
-				clearTimeout(timer);
-				resolve(frame);
-			});
-		});
+	const nextMatchingFrame = (matches: (frame: Frame) => boolean, timeoutMs: number): Promise<Frame> => {
+		const queuedIndex = queue.findIndex(matches);
+		if (queuedIndex >= 0) return Promise.resolve(queue.splice(queuedIndex, 1)[0]);
+		const pending = Promise.withResolvers<Frame>();
+		const waiter = {
+			matches,
+			resolve: pending.resolve,
+			timer: setTimeout(() => {
+				const waiterIndex = waiters.indexOf(waiter);
+				if (waiterIndex >= 0) waiters.splice(waiterIndex, 1);
+				pending.reject(new Error("timed out waiting for socket frame"));
+			}, timeoutMs),
+		};
+		waiters.push(waiter);
+		return pending.promise;
 	};
 	return {
 		send(obj: object) {
 			socket.write(`${JSON.stringify(obj)}\n`);
 		},
-		nextFrame,
+		nextFrame(timeoutMs = 12_000) {
+			return nextMatchingFrame(() => true, timeoutMs);
+		},
 		async nextResponse(id: string, timeoutMs = 15_000): Promise<Frame> {
-			const start = Date.now();
-			while (Date.now() - start < timeoutMs) {
-				const frame = await nextFrame(timeoutMs);
-				if (frame.type === "response" && frame.id === id) return frame;
-			}
-			throw new Error(`no response for ${id}`);
+			return nextMatchingFrame(frame => frame.type === "response" && frame.id === id, timeoutMs);
 		},
 		close() {
 			socket.end();
@@ -134,6 +170,295 @@ async function waitForSocket(socketPath: string, timeoutMs = 15_000): Promise<vo
 }
 
 describe("gjc --mode rpc --listen (UDS persistent server, issue 09)", () => {
+	it("defers a durable default selection until a real streamed prompt completes", async () => {
+		const streamStarted = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const encoder = new TextEncoder();
+		const responsesServer = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch(request) {
+				if (new URL(request.url).pathname !== "/v1/responses") return new Response("not found", { status: 404 });
+				const body = new ReadableStream<Uint8Array>({
+					async start(controller) {
+						controller.enqueue(
+							encoder.encode(
+								`data: ${JSON.stringify({ type: "response.created", response: { id: "resp_rpc_test", model: "rpc-test-a", status: "in_progress" } })}\n\n`,
+							),
+						);
+						streamStarted.resolve();
+						await release.promise;
+						const events = [
+							{
+								type: "response.output_item.added",
+								output_index: 0,
+								item: { id: "msg_rpc_test", type: "message", role: "assistant", content: [] },
+							},
+							{
+								type: "response.content_part.added",
+								item_id: "msg_rpc_test",
+								output_index: 0,
+								content_index: 0,
+								part: { type: "output_text", text: "" },
+							},
+							{
+								type: "response.output_text.delta",
+								item_id: "msg_rpc_test",
+								output_index: 0,
+								content_index: 0,
+								delta: "released",
+							},
+							{
+								type: "response.output_text.done",
+								item_id: "msg_rpc_test",
+								output_index: 0,
+								content_index: 0,
+								text: "released",
+							},
+							{
+								type: "response.output_item.done",
+								output_index: 0,
+								item: {
+									id: "msg_rpc_test",
+									type: "message",
+									role: "assistant",
+									status: "completed",
+									content: [{ type: "output_text", text: "released" }],
+								},
+							},
+							{
+								type: "response.completed",
+								response: {
+									id: "resp_rpc_test",
+									model: "rpc-test-a",
+									status: "completed",
+									output: [],
+									usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+								},
+							},
+						];
+						controller.enqueue(
+							encoder.encode(`${events.map(event => `data: ${JSON.stringify(event)}`).join("\n\n")}\n\n`),
+						);
+						controller.close();
+					},
+					cancel() {
+						release.resolve();
+					},
+				});
+				return new Response(body, { headers: { "content-type": "text/event-stream" } });
+			},
+		});
+		await writeFile(path.join(agentDir, "models.yml"), liveFixtureModelsYaml(`${responsesServer.url}v1`));
+		const firstSocketPath = path.join(workspace, "rpc-default-selection.sock");
+		const restartSocketPath = path.join(workspace, "rpc-default-selection-restart.sock");
+		const sessionDir = path.join(workspace, "sessions-default-selection");
+		const configFile = path.join(agentDir, "config.yml");
+		const temporalEvents: string[] = [];
+		let selectorAtSuccessArrival: unknown;
+		const firstProc = Bun.spawn(
+			[
+				"bun",
+				cliEntry,
+				"--mode",
+				"rpc",
+				"--provider",
+				"rpc-test",
+				"--model",
+				"rpc-test-a",
+				"--session-dir",
+				sessionDir,
+				"--listen",
+				firstSocketPath,
+			],
+			{
+				cwd: workspace,
+				env: { ...cliEnv.env, GJC_HARNESS_STATE_ROOT: workspace, NO_COLOR: "1", PI_NOTIFICATIONS: "off" },
+				stdin: "ignore",
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		const firstStderrText = new Response(firstProc.stderr).text();
+		let connection: SocketConn | undefined;
+		let restartConnection: SocketConn | undefined;
+		let restartProc: Bun.Subprocess | undefined;
+		try {
+			await waitForSocket(firstSocketPath);
+			connection = await connect(firstSocketPath, async frame => {
+				if (frame.type !== "response" || frame.id !== "select-1" || frame.success !== true) return;
+				temporalEvents.push("arrival:select-1");
+				const parsed: unknown = YAML.parse(await Bun.file(configFile).text());
+				if (typeof parsed !== "object" || parsed === null || !("modelRoles" in parsed)) return;
+				const modelRoles: unknown = parsed.modelRoles;
+				if (typeof modelRoles !== "object" || modelRoles === null || !("default" in modelRoles)) return;
+				selectorAtSuccessArrival = modelRoles.default;
+			});
+			expect(await connection.nextFrame()).toEqual({ type: "ready" });
+			connection.send({ id: "state-baseline", type: "get_state" });
+			const baselineState = await connection.nextResponse("state-baseline");
+			const sessionFile = baselineState.data?.sessionFile;
+			if (typeof sessionFile !== "string") throw new Error("Expected get_state to return a session file");
+
+			connection.send({ id: "prompt-1", type: "prompt", message: "hold" });
+			const promptResponse = connection.nextResponse("prompt-1");
+			await streamStarted.promise;
+			connection.send({ id: "state-streaming", type: "get_state" });
+			expect(await connection.nextResponse("state-streaming")).toMatchObject({
+				command: "get_state",
+				success: true,
+				data: { isStreaming: true },
+			});
+
+			const configBeforeSelection = await readBytesIfPresent(configFile);
+			const sessionBeforeSelection = await readBytesIfPresent(sessionFile);
+			connection.send({
+				id: "select-1",
+				type: "set_default_model_selection",
+				provider: "rpc-test",
+				modelId: "rpc-test-b",
+				thinkingLevel: "off",
+			});
+			let selectionSettled = false;
+			const selectionResponse = connection.nextResponse("select-1").then(frame => {
+				selectionSettled = true;
+				temporalEvents.push("response:select-1");
+				return frame;
+			});
+			connection.send({ id: "state-held", type: "get_state" });
+			expect(await connection.nextResponse("state-held")).toMatchObject({
+				command: "get_state",
+				success: true,
+				data: { isStreaming: true, model: { provider: "rpc-test", id: "rpc-test-a" } },
+			});
+			expect(selectionSettled).toBe(false);
+			expect(await readBytesIfPresent(configFile)).toEqual(configBeforeSelection);
+			expect(await readBytesIfPresent(sessionFile)).toEqual(sessionBeforeSelection);
+
+			release.resolve();
+			expect(await promptResponse).toMatchObject({ id: "prompt-1", command: "prompt", success: true });
+			expect(await selectionResponse).toMatchObject({
+				id: "select-1",
+				command: "set_default_model_selection",
+				success: true,
+				data: { provider: "rpc-test", modelId: "rpc-test-b", thinkingLevel: "off" },
+			});
+			expect(temporalEvents).toEqual(["arrival:select-1", "response:select-1"]);
+			expect(selectorAtSuccessArrival).toBe("rpc-test/rpc-test-b:off");
+			expect(YAML.parse(await Bun.file(configFile).text())).toMatchObject({
+				modelRoles: { default: "rpc-test/rpc-test-b:off" },
+			});
+			connection.send({ id: "state-selected", type: "get_state" });
+			expect(await connection.nextResponse("state-selected")).toMatchObject({
+				command: "get_state",
+				success: true,
+				data: {
+					isStreaming: false,
+					model: { provider: "rpc-test", id: "rpc-test-b" },
+					thinkingLevel: "off",
+				},
+			});
+
+			const sessionEntries: Array<Record<string, unknown>> = (await Bun.file(sessionFile).text())
+				.trim()
+				.split("\n")
+				.map(line => JSON.parse(line));
+			const defaultMarkers = sessionEntries.filter(
+				entry => entry.type === "model_change" && entry.role === "default" && entry.model === "rpc-test/rpc-test-b",
+			);
+			expect(defaultMarkers).toHaveLength(1);
+			const userIndex = sessionEntries.findIndex(
+				entry =>
+					entry.type === "message" &&
+					typeof entry.message === "object" &&
+					entry.message !== null &&
+					"role" in entry.message &&
+					entry.message.role === "user",
+			);
+			const assistantIndex = sessionEntries.findIndex(
+				entry =>
+					entry.type === "message" &&
+					typeof entry.message === "object" &&
+					entry.message !== null &&
+					"role" in entry.message &&
+					entry.message.role === "assistant",
+			);
+			const markerIndex = sessionEntries.indexOf(defaultMarkers[0]);
+			expect(userIndex).toBeGreaterThanOrEqual(0);
+			expect(assistantIndex).toBeGreaterThan(userIndex);
+			expect(markerIndex).toBeGreaterThan(assistantIndex);
+
+			const configAfterSelection = await readBytesIfPresent(configFile);
+			const sessionAfterSelection = await readBytesIfPresent(sessionFile);
+			connection.send({
+				id: "select-bad",
+				type: "set_default_model_selection",
+				provider: "rpc-test",
+				modelId: "rpc-test-missing",
+				thinkingLevel: "off",
+			});
+			expect(await connection.nextResponse("select-bad")).toMatchObject({
+				id: "select-bad",
+				command: "set_default_model_selection",
+				success: false,
+			});
+			expect(await readBytesIfPresent(configFile)).toEqual(configAfterSelection);
+			expect(await readBytesIfPresent(sessionFile)).toEqual(sessionAfterSelection);
+			connection.send({ id: "state-after-bad", type: "get_state" });
+			expect(await connection.nextResponse("state-after-bad")).toMatchObject({
+				command: "get_state",
+				success: true,
+				data: { model: { provider: "rpc-test", id: "rpc-test-b" } },
+			});
+
+			connection.close();
+			connection = undefined;
+			firstProc.kill();
+			await firstProc.exited;
+			expect(Bun.spawnSync(["kill", "-0", String(firstProc.pid)]).exitCode).not.toBe(0);
+			expect(await Bun.file(firstSocketPath).exists()).toBe(false);
+			expect((await firstStderrText).trim()).toBe("");
+
+			restartProc = Bun.spawn(
+				["bun", cliEntry, "--mode", "rpc", "--session-dir", sessionDir, "--listen", restartSocketPath],
+				{
+					cwd: workspace,
+					env: { ...cliEnv.env, GJC_HARNESS_STATE_ROOT: workspace, NO_COLOR: "1", PI_NOTIFICATIONS: "off" },
+					stdin: "ignore",
+					stdout: "pipe",
+					stderr: "pipe",
+				},
+			);
+			await waitForSocket(restartSocketPath);
+			restartConnection = await connect(restartSocketPath);
+			expect(await restartConnection.nextFrame()).toEqual({ type: "ready" });
+			restartConnection.send({ id: "state-restart", type: "get_state" });
+			expect(await restartConnection.nextResponse("state-restart")).toMatchObject({
+				command: "get_state",
+				success: true,
+				data: {
+					model: { provider: "rpc-test", id: "rpc-test-b" },
+					thinkingLevel: "off",
+				},
+			});
+		} finally {
+			release.resolve();
+			connection?.close();
+			restartConnection?.close();
+			firstProc.kill();
+			await firstProc.exited;
+			if (restartProc) {
+				restartProc.kill();
+				await restartProc.exited;
+				expect(Bun.spawnSync(["kill", "-0", String(restartProc.pid)]).exitCode).not.toBe(0);
+			}
+			responsesServer.stop(true);
+			expect(await Bun.file(firstSocketPath).exists()).toBe(false);
+			expect(await Bun.file(restartSocketPath).exists()).toBe(false);
+			await rm(workspace, { recursive: true, force: true });
+		}
+	}, 60_000);
+
 	it("rejects malformed raw default selectors without mutating durable bytes or losing UDS service", async () => {
 		const socketPath = path.join(workspace, "rpc-malformed.sock");
 		const proc = Bun.spawn(

--- a/packages/coding-agent/test/rpc-stdio-redteam.test.ts
+++ b/packages/coding-agent/test/rpc-stdio-redteam.test.ts
@@ -88,6 +88,11 @@ function findResponse(frames: Frame[], id: string): Frame {
 	return frame;
 }
 
+async function readBytesIfPresent(filePath: string): Promise<Uint8Array | undefined> {
+	const file = Bun.file(filePath);
+	return (await file.exists()) ? new Uint8Array(await file.arrayBuffer()) : undefined;
+}
+
 function spawnRpcServer(options: { cwd?: string; sessionDir?: string } = {}): RpcHarness {
 	const proc = Bun.spawn(
 		[
@@ -263,6 +268,76 @@ describe("gjc --mode rpc red-team stdio lifecycle", () => {
 		});
 		expect(result.stderr.trim()).toBe("");
 	}, 30_000);
+
+	it("rejects malformed raw default selectors without mutating durable bytes or losing stdio service", async () => {
+		const harness = spawnRpcServer();
+		const malformed = [
+			{ id: "bad-missing-provider", type: "set_default_model_selection", modelId: "rpc-test-model" },
+			{ id: "bad-numeric-model", type: "set_default_model_selection", provider: "rpc-test", modelId: 42 },
+			{ id: "bad-blank-provider", type: "set_default_model_selection", provider: " ", modelId: "rpc-test-model" },
+			{
+				id: "bad-invalid-level",
+				type: "set_default_model_selection",
+				provider: "rpc-test",
+				modelId: "rpc-test-model",
+				thinkingLevel: "extreme",
+			},
+			{
+				id: "bad-inherit-level",
+				type: "set_default_model_selection",
+				provider: "rpc-test",
+				modelId: "rpc-test-model",
+				thinkingLevel: "inherit",
+			},
+			{
+				id: "bad-unknown-model",
+				type: "set_default_model_selection",
+				provider: "rpc-test",
+				modelId: "missing",
+			},
+		] as const;
+		try {
+			// Given: startup is complete and both durable files have post-ready baselines.
+			expect(await harness.nextFrame()).toEqual({ type: "ready" });
+			harness.send({ id: "baseline-state", type: "get_state" });
+			const initialState = await harness.nextFrame();
+			expect(initialState).toMatchObject({ id: "baseline-state", command: "get_state", success: true });
+			const sessionFile = frameData<{ sessionFile?: string }>(initialState).sessionFile;
+			if (!sessionFile) throw new Error("Expected a session file after initial get_state");
+			const configFile = path.join(agentDir, "config.yml");
+			const configBaseline = await readBytesIfPresent(configFile);
+			const sessionBaseline = await readBytesIfPresent(sessionFile);
+
+			for (const [index, command] of malformed.entries()) {
+				// When: each raw mutation is fully answered before the fast-lane survival probe is sent.
+				harness.send(command);
+				const failure = await harness.nextFrame();
+
+				// Then: the error is correlated to the mutation rather than parse, and service remains usable.
+				expect(failure).toMatchObject({
+					id: command.id,
+					type: "response",
+					command: "set_default_model_selection",
+					success: false,
+				});
+				expect(failure.command).not.toBe("parse");
+				expect(JSON.stringify(failure.error)).not.toContain("Unknown command");
+				harness.send({ id: `state-after-${index}`, type: "get_state" });
+				expect(await harness.nextFrame()).toMatchObject({
+					id: `state-after-${index}`,
+					command: "get_state",
+					success: true,
+				});
+				expect(await readBytesIfPresent(configFile)).toEqual(configBaseline);
+				expect(await readBytesIfPresent(sessionFile)).toEqual(sessionBaseline);
+			}
+		} finally {
+			await harness.closeStdin();
+			const exited = await Promise.race([harness.proc.exited.then(() => true), Bun.sleep(5_000).then(() => false)]);
+			if (!exited) harness.kill();
+			await harness.proc.exited;
+		}
+	}, 45_000);
 
 	it("runs independent child sessions concurrently without state bleed", async () => {
 		const alphaCwd = path.join(workspace, "alpha");

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Effort, getBundledModel, type Model } from "@gajae-code/ai";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
-import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { createAgentSession } from "@gajae-code/coding-agent/sdk";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
@@ -18,6 +18,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 	let modelRegistry: ModelRegistry;
 
 	beforeEach(async () => {
+		resetSettingsForTest();
 		tempDir = path.join(os.tmpdir(), `pi-sdk-model-selection-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
 		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
@@ -26,6 +27,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 	});
 
 	afterEach(() => {
+		resetSettingsForTest();
 		authStorage?.close();
 		if (tempDir && fs.existsSync(tempDir)) {
 			fs.rmSync(tempDir, { recursive: true, force: true });
@@ -62,15 +64,45 @@ describe("createAgentSession deferred model pattern resolution", () => {
 						defaultLevel: Effort.Low,
 					},
 				},
+				{
+					id: "runtime-global-b",
+					name: "Runtime Global B",
+					reasoning: true,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128000,
+					maxTokens: 8192,
+					thinking: {
+						minLevel: Effort.Minimal,
+						maxLevel: Effort.High,
+						mode: "effort",
+						defaultLevel: Effort.Low,
+					},
+				},
+				{
+					id: "runtime-policy-c",
+					name: "Runtime Policy C",
+					reasoning: true,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128000,
+					maxTokens: 8192,
+					thinking: {
+						minLevel: Effort.Minimal,
+						maxLevel: Effort.High,
+						mode: "effort",
+						defaultLevel: Effort.Low,
+					},
+				},
 			],
 		});
 	}
 
-	function buildSessionOptions(modelPattern: string) {
+	function buildSessionOptions(modelPattern?: string, sessionManager: SessionManager = SessionManager.inMemory()) {
 		return {
 			cwd: tempDir,
 			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager,
 			disableExtensionDiscovery: true,
 			extensions: [],
 			skills: [],
@@ -86,6 +118,74 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			modelPattern,
 		};
 	}
+
+	test("uses the machine-global default selector and its effective suffix for a fresh session", async () => {
+		// Given a durable machine-global B selector
+		await Bun.write(
+			path.join(tempDir, "config.yml"),
+			"modelRoles:\n  default: runtime-provider/runtime-global-b:high\n",
+		);
+		const settings = await Settings.init({ cwd: tempDir, agentDir: tempDir });
+
+		// When a fresh session starts without an explicit model
+		const { session } = await createAgentSession({ ...buildSessionOptions(), settings });
+
+		// Then it consumes both the global model and effective thinking suffix
+		expect(settings.getGlobal("modelRoles")).toEqual({
+			default: "runtime-provider/runtime-global-b:high",
+		});
+		expect(session.model?.id).toBe("runtime-global-b");
+		expect(session.thinkingLevel).toBe(Effort.High);
+		await session.dispose();
+	});
+
+	test("uses project default role C instead of machine-global B for a fresh session", async () => {
+		// Given global B and a project-scoped C override
+		await Bun.write(
+			path.join(tempDir, "config.yml"),
+			"modelRoles:\n  default: runtime-provider/runtime-global-b:high\n",
+		);
+		await Bun.write(
+			path.join(tempDir, ".gjc", "config.yml"),
+			"modelRoles:\n  default: runtime-provider/runtime-policy-c:low\n",
+		);
+		const settings = await Settings.init({ cwd: tempDir, agentDir: tempDir });
+
+		// When a fresh project session starts without an explicit model
+		const { session } = await createAgentSession({ ...buildSessionOptions(), settings });
+
+		// Then project C and its suffix outrank global B
+		expect(settings.getGlobal("modelRoles")).toEqual({
+			default: "runtime-provider/runtime-global-b:high",
+		});
+		expect(settings.getModelRole("default")).toBe("runtime-provider/runtime-policy-c:low");
+		expect(session.model?.id).toBe("runtime-policy-c");
+		expect(session.thinkingLevel).toBe(Effort.Low);
+		await session.dispose();
+	});
+
+	test("restores resumed transcript C instead of machine-global B", async () => {
+		// Given global B and a resumed transcript that records C with medium thinking
+		await Bun.write(
+			path.join(tempDir, "config.yml"),
+			"modelRoles:\n  default: runtime-provider/runtime-global-b:high\n",
+		);
+		const settings = await Settings.init({ cwd: tempDir, agentDir: tempDir });
+		const sessionManager = SessionManager.inMemory(tempDir);
+		sessionManager.appendModelChange("runtime-provider/runtime-policy-c", "default");
+		sessionManager.appendThinkingLevelChange(Effort.Medium);
+
+		// When the recorded transcript resumes without an explicit model
+		const { session } = await createAgentSession({ ...buildSessionOptions(undefined, sessionManager), settings });
+
+		// Then transcript C and its recorded thinking level outrank global B
+		expect(settings.getGlobal("modelRoles")).toEqual({
+			default: "runtime-provider/runtime-global-b:high",
+		});
+		expect(session.model?.id).toBe("runtime-policy-c");
+		expect(session.thinkingLevel).toBe(Effort.Medium);
+		await session.dispose();
+	});
 
 	test("resolves explicit modelPattern after runtime providers are available", async () => {
 		const { session, modelFallbackMessage } = await createAgentSession(

--- a/packages/coding-agent/test/settings-global-model-role-flush.test.ts
+++ b/packages/coding-agent/test/settings-global-model-role-flush.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Effort } from "@gajae-code/ai";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { YAML } from "bun";
+
+describe("Settings global model role durability", () => {
+	let testDir: string;
+	let agentDir: string;
+	let projectDir: string;
+	let configPath: string;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		testDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-settings-global-model-role-"));
+		agentDir = path.join(testDir, "agent");
+		projectDir = path.join(testDir, "project");
+		configPath = path.join(agentDir, "config.yml");
+		await fs.mkdir(agentDir, { recursive: true });
+		await fs.mkdir(projectDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		resetSettingsForTest();
+		await fs.rm(testDir, { recursive: true, force: true });
+	});
+
+	it("persists the canonical global selector without changing a runtime override", async () => {
+		// Given
+		await Bun.write(configPath, YAML.stringify({ modelRoles: { default: "provider/original:low" } }));
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		settings.overrideModelRoles({ default: "profile/runtime:high" });
+
+		// When
+		await settings.setGlobalModelRoleAndFlush("default", "provider/selected:medium");
+
+		// Then
+		expect(YAML.parse(await Bun.file(configPath).text())).toEqual({
+			modelRoles: { default: "provider/selected:medium" },
+		});
+		expect(settings.getModelRole("default")).toBe("profile/runtime:high");
+		expect(settings.getGlobal("modelRoles")).toEqual({ default: "provider/selected:medium" });
+	});
+
+	it("rolls back a rejected selector so an unrelated later save cannot retry it", async () => {
+		// Given
+		await Bun.write(configPath, YAML.stringify({ modelRoles: { default: "provider/original:low" } }));
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		const originalWrite = Bun.write.bind(Bun);
+		let rejectConfigWrite = true;
+		vi.spyOn(Bun, "write").mockImplementation(async (destination, input) => {
+			if (typeof destination === "string" && destination === configPath && rejectConfigWrite) {
+				rejectConfigWrite = false;
+				throw new Error("injected config write failure");
+			}
+			if (typeof destination !== "string" || typeof input !== "string") {
+				throw new Error("unexpected non-string settings write");
+			}
+			return originalWrite(destination, input);
+		});
+
+		// When
+		const rejected = settings.setGlobalModelRoleAndFlush("default", "provider/rejected:high");
+
+		// Then
+		await expect(rejected).rejects.toThrow("injected config write failure");
+		expect(settings.getGlobal("modelRoles")).toEqual({ default: "provider/original:low" });
+		expect(settings.getModelRole("default")).toBe("provider/original:low");
+
+		settings.set("defaultThinkingLevel", Effort.Medium);
+		await settings.flush();
+		expect(YAML.parse(await Bun.file(configPath).text())).toEqual({
+			modelRoles: { default: "provider/original:low" },
+			defaultThinkingLevel: Effort.Medium,
+		});
+	});
+
+	it("preserves a newer selector when an older queued selector is rejected", async () => {
+		// Given
+		await Bun.write(configPath, YAML.stringify({ modelRoles: { default: "provider/original:low" } }));
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		const originalWrite = Bun.write.bind(Bun);
+		const predecessorWrite = Promise.withResolvers<void>();
+		let configWrite = 0;
+		vi.spyOn(Bun, "write").mockImplementation(async (destination, input) => {
+			if (typeof destination !== "string" || typeof input !== "string") {
+				throw new Error("unexpected non-string settings write");
+			}
+			if (destination !== configPath) return originalWrite(destination, input);
+			configWrite += 1;
+			if (configWrite === 1) {
+				await predecessorWrite.promise;
+			} else if (configWrite === 2) {
+				throw new Error("injected older selector failure");
+			}
+			return originalWrite(destination, input);
+		});
+
+		settings.set("defaultThinkingLevel", Effort.Low);
+		const predecessor = settings.flush();
+		const older = settings.setGlobalModelRoleAndFlush("default", "provider/rejected:high");
+		const newer = settings.setGlobalModelRoleAndFlush("default", "provider/newer:medium");
+
+		// When
+		predecessorWrite.resolve();
+
+		// Then
+		await predecessor;
+		await expect(older).rejects.toThrow("injected older selector failure");
+		await newer;
+		expect(settings.getGlobal("modelRoles")).toEqual({ default: "provider/newer:medium" });
+		expect(YAML.parse(await Bun.file(configPath).text())).toEqual({
+			modelRoles: { default: "provider/newer:medium" },
+			defaultThinkingLevel: Effort.Low,
+		});
+	});
+
+	it("rolls both overlapping rejected selectors back before an unrelated save", async () => {
+		// Given
+		await Bun.write(configPath, YAML.stringify({ modelRoles: { default: "provider/original:low" } }));
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		settings.overrideModelRoles({ planner: "profile/planner:high" });
+		const originalWrite = Bun.write.bind(Bun);
+		const predecessorWrite = Promise.withResolvers<void>();
+		let configWrite = 0;
+		vi.spyOn(Bun, "write").mockImplementation(async (destination, input) => {
+			if (typeof destination !== "string" || typeof input !== "string") {
+				throw new Error("unexpected non-string settings write");
+			}
+			if (destination !== configPath) return originalWrite(destination, input);
+			configWrite += 1;
+			if (configWrite === 1) await predecessorWrite.promise;
+			if (configWrite === 2 || configWrite === 3) {
+				throw new Error(`injected selector failure ${configWrite}`);
+			}
+			return originalWrite(destination, input);
+		});
+
+		settings.set("defaultThinkingLevel", Effort.Low);
+		const predecessor = settings.flush();
+		const older = settings.setGlobalModelRoleAndFlush("default", "provider/older-rejected:high");
+		const newer = settings.setGlobalModelRoleAndFlush("default", "provider/newer-rejected:medium");
+		const selections = Promise.allSettled([older, newer]);
+
+		// When
+		predecessorWrite.resolve();
+
+		// Then
+		await predecessor;
+		expect((await selections).map(result => result.status)).toEqual(["rejected", "rejected"]);
+		settings.set("theme.dark", "red-claw");
+		await settings.flush();
+		expect(YAML.parse(await Bun.file(configPath).text())).toEqual({
+			modelRoles: { default: "provider/original:low" },
+			defaultThinkingLevel: Effort.Low,
+			theme: { dark: "red-claw" },
+		});
+		expect(settings.getGlobal("modelRoles")).toEqual({ default: "provider/original:low" });
+		expect(settings.get("modelRoles")).toEqual({
+			default: "provider/original:low",
+			planner: "profile/planner:high",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- add `set_default_model_selection` to the shared agent-wire/RPC contract under the existing `model` scope
- durably persist the machine-wide default selector as `modelRoles.default = provider/model:effectiveLevel`
- wait for the current session to become idle, then apply the same effective model and reasoning level only to subsequent messages
- serialize the complete session operation so concurrent shared callers cannot diverge durable and resumable session state

## Behavior

The command validates and resolves the requested model and reasoning level before mutation. Success is returned only after the global selector is durably flushed and the current session's forward-only default marker has been appended. Existing messages and an in-flight response are not rewritten.

Project model-role policy and a resumed session's recorded default continue to take precedence over the machine-wide fallback. Existing `set_model`, `set_thinking_level`, and `defaultThinkingLevel` behavior is unchanged.

## Scope

This intentionally leaves Bridge request parsing, body handling, scheduling, idempotency, and transport behavior unchanged. The Bridge client change is limited to the mechanically required command-name inventory entry; no Bridge helper was added. Python clients, model catalogs, CLI flags, and session serialization formats are unchanged.

## Verification

- focused feature suite: 89 tests, 456 assertions
- concurrent selection stress: 10 repeated runs, 130 tests, 640 assertions
- real held-SSE Unix-socket flow: 5 repeated clean-fixture runs
- restart, project precedence, resumed-session precedence, and `max` reasoning contract: 20 tests, 128 assertions
- upstream notification-service interaction: 21 tests, 60 assertions
- coding-agent Biome and TypeScript checks
- five independent final review lanes and three runtime debugging hypotheses

This supersedes the broader approach in #2011 and avoids the Bridge reservation-before-body mechanism that caused that PR's ordered mutation lane to wedge.

Reference notes: https://github.com/snowykr/gajae-code/issues/8
