### PR TITLE
feat(grok-build): add Grok 4.5 model

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/models/catalog.ts
+++ b/packages/coding-agent/src/defaults/gjc/extensions/grok-cli-vendor/src/models/catalog.ts
@@ -7,6 +7,7 @@
 const COST_BUILD = { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0.2 };
 const COST_COMPOSER_FAST = { input: 3, output: 15, cacheRead: 0.5, cacheWrite: 0 };
 const COST_43 = { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 };
+const COST_45 = { input: 2, output: 6, cacheRead: 0.2, cacheWrite: 0 };
 const COST_420 = { input: 2, output: 6, cacheRead: 0.2, cacheWrite: 0 };
 
 // ─── Model type ───────────────────────────────────────────────────────────────
@@ -70,6 +71,15 @@ const FALLBACK_MODELS: GrokCliModelConfig[] = [
     maxTokens: 30_000,
   },
   {
+    id: 'grok-4.5',
+    name: 'Grok 4.5',
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: COST_45,
+    contextWindow: 500_000,
+    maxTokens: 30_000,
+  },
+  {
     id: 'grok-4.20-0309-reasoning',
     name: 'Grok 4.20 Reasoning',
     reasoning: true,
@@ -106,7 +116,7 @@ const FALLBACK_MODELS: GrokCliModelConfig[] = [
   },
 ];
 
-const EFFORT_CAPABLE_PREFIXES = ['grok-3-mini', 'grok-4.20-multi-agent', 'grok-4.3'];
+const EFFORT_CAPABLE_PREFIXES = ['grok-3-mini', 'grok-4.20-multi-agent', 'grok-4.3', 'grok-4.5'];
 
 export function supportsReasoningEffort(modelId: string): boolean {
   const parts = modelId.split('/');

--- a/packages/coding-agent/test/grok-cli-defaults-install.test.ts
+++ b/packages/coding-agent/test/grok-cli-defaults-install.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import {
+	resolveModels,
+	supportsReasoningEffort,
+} from "../src/defaults/gjc/extensions/grok-cli-vendor/src/models/catalog";
+import {
 	assertBundledGrokCliDefaults,
 	getBundledGrokBuildExtensionFactory,
 	getBundledGrokCliModelDefaults,
@@ -10,5 +14,20 @@ describe("bundled Grok CLI defaults", () => {
 		await expect(assertBundledGrokCliDefaults()).resolves.toBeUndefined();
 		expect(typeof getBundledGrokBuildExtensionFactory()).toBe("function");
 		expect(getBundledGrokCliModelDefaults()).toContain("grok-composer-2.5-fast");
+	});
+
+	it("registers Grok 4.5 with its public model metadata", () => {
+		const model = resolveModels().find(candidate => candidate.id === "grok-4.5");
+
+		expect(model).toEqual({
+			id: "grok-4.5",
+			name: "Grok 4.5",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 2, output: 6, cacheRead: 0.2, cacheWrite: 0 },
+			contextWindow: 500_000,
+			maxTokens: 30_000,
+		});
+		expect(supportsReasoningEffort("grok-build/grok-4.5")).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary
- add `grok-4.5` to the bundled Grok Build fallback catalog
- register its public pricing, 500K context window, image input, and reasoning-effort support
- add a focused regression test for catalog metadata and effort routing

## Context
xAI documents `grok-4.5` as available through Grok Build and the xAI API: https://docs.x.ai/developers/grok-4-5

The model was also verified through an authenticated Grok Build session with:

```text
gjc -p --no-session --no-tools --model grok-build/grok-4.5 "Reply with exactly: GROK45_OK"
```

Result: `GROK45_OK`.

## Tests
```text
bun test packages/coding-agent/test/grok-cli-defaults-install.test.ts packages/coding-agent/test/grok-cli-sanitize.test.ts packages/coding-agent/test/grok-build-stream.test.ts
```

Result: 4 passed, 0 failed.