### PR TITLE
fix(coding-agent): stabilize coordinator MCP late-readiness test vs session-state write race

### DIFF
--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -2004,7 +2004,7 @@ describe("Coordinator MCP server protocol", () => {
 				env: {
 					GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
 					GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
-					GJC_COORDINATOR_MCP_RUNTIME_READINESS_TIMEOUT_MS: "1000",
+					GJC_COORDINATOR_MCP_RUNTIME_READINESS_TIMEOUT_MS: "30000",
 					GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
 					GJC_COORDINATOR_MCP_PROFILE: "local",
 					GJC_COORDINATOR_MCP_REPO: winner,
@@ -2046,6 +2046,21 @@ describe("Coordinator MCP server protocol", () => {
 			const active = JSON.parse(await Bun.file(activeFile).text()) as { turn_id: string };
 			if (winner === "runtime") {
 				const sessionStateFile = path.join(stateRoot, "local", winner, "session-states", `${sessionId}.json`);
+				// The coordinator's prepareActiveTurn writes a "booting" session-state for THIS turn as its
+				// last write before awaiting readiness. Wait for that specific write (matched by current_turn_id)
+				// so the terminal state injected below is the final writer and cannot be clobbered by it.
+				await waitForCondition(async () => {
+					if (!(await Bun.file(sessionStateFile).exists())) return false;
+					try {
+						const booting = JSON.parse(await Bun.file(sessionStateFile).text()) as {
+							state?: string;
+							current_turn_id?: string | null;
+						};
+						return booting.state === "booting" && booting.current_turn_id === active.turn_id;
+					} catch {
+						return false;
+					}
+				});
 				await Bun.write(
 					sessionStateFile,
 					JSON.stringify({
@@ -2072,6 +2087,8 @@ describe("Coordinator MCP server protocol", () => {
 			}
 			let terminal: Record<string, unknown> | null = null;
 			const expectedStatus = winner === "runtime" ? "completed" : "failed";
+			// Terminalization is authoritative and observed here; keep this observation budget well below
+			// the it() timeout (20_000) so it can never collide with the readiness timeout (30_000) above.
 			await waitForCondition(async () => {
 				terminal = await server.callTool("gjc_coordinator_read_turn", {
 					session_id: sessionId,
@@ -2080,13 +2097,13 @@ describe("Coordinator MCP server protocol", () => {
 				return (
 					terminal.ok === true && (terminal.turn as { status?: string } | undefined)?.status === expectedStatus
 				);
-			});
+			}, 5_000);
 			expect(terminal).toMatchObject({ ok: true, turn: { status: expectedStatus } });
 			await writeReadyMarker(launch);
 			await sending;
 			expect(commands).toEqual([]);
 		}
-	});
+	}, 20_000);
 
 	it("fails closed for unverified origins and trusts only strict legacy registration", async () => {
 		const root = await tempRoot();


### PR DESCRIPTION
## Summary

Repairs the post-merge dev CI failure on commit `e49113408c8dbbd88db0dab7d051093da06823cb`:

- **Failed test:** `packages/coding-agent` shard 4 — `Coordinator MCP server protocol > prevents late readiness injection after runtime or liveness terminalization` (timed out / failed at 1016.76ms).
- **Determination:** **Pre-existing timing flake — NOT a deterministic regression from #2076.** `#2076` (this HEAD) is a `gjc-notifications` Rust change and touches **zero** coordinator-mcp code or this test. The readiness gating exercised here originated in `#2045`.

## Root cause (test-harness session-state write race)

The coordinator's `prepareActiveTurn` writes a `"booting"` session-state for the turn (`packages/coding-agent/src/coordinator-mcp/server.ts:3392`, reason `awaiting_runtime_readiness`) as its **last write** before awaiting readiness. The test injected the terminal `"completed"` session-state after only waiting for the active-turn **file**, so under fine-grained scheduling the coordinator's `"booting"` write could land **after** the injected `"completed"` and clobber it. `read_turn` then never observed a terminal session-state, the turn stayed `"active"`, and the terminalization poll timed out (`condition_timeout`, ~1031ms — matching CI's 1016.76ms). The 1000ms readiness timeout was only a secondary amplifier (it writes a sticky `failed` when `read_turn` has not reconciled by 1000ms).

Diagnostic proof: an instrumented poll dumped, on timeout, the winner + session-state. **9/9** sampled failures were `winner=runtime`, `lastStatus="active"`, session-state stuck at `state="booting"` (source `coordinator`) while the test had written `"completed"`. **0** liveness failures.

## Fix (test-only, invariant-preserving)

`packages/coding-agent/test/coordinator-mcp-server.test.ts` only:

1. **Root cause:** before injecting `"completed"`, wait for the coordinator's turn-specific `"booting"` write, matched by `current_turn_id === active.turn_id` (a `state`-only match is insufficient — it can match a pre-turn `booting` state). This makes the injected terminal state the final writer, so it cannot be clobbered.
2. **Hardening:** decouple the timers so the readiness-timeout can't preempt under contention — readiness `1000 → 30000`, explicit terminalization observe budget `5000`, explicit `it()` timeout `20000` (ordering `observe(5000) < it(20000) < readiness(30000)`).

No production/`server.ts` change. The shared `waitForCondition` default (`test:112`) and **all assertions** (`expect(commands).toEqual([])`; expected terminal status runtime→`completed` / liveness→`failed`) are unchanged. The invariant is preserved and its coverage is sharpened (the late-marker + terminal-guard path is now exercised deterministically).

## Verification / signed evidence

| Gate | Result |
|------|--------|
| HEAD baseline (isolated) | **7 / 200 fail (3.5%)** — signature `condition_timeout` @ `test:2075` ~1031ms (matches CI) |
| Fix (isolated) | **0 / 300 fail** |
| Fix (constrained 2-CPU contention, `taskset -c 0,1`, 4× parallel test load) | **0 / 40 fail** |
| Full `coordinator-mcp-server.test.ts` | **101 / 101 pass**, 3 consecutive runs (no sibling regression) |
| `tsc -p packages/coding-agent/tsconfig.json --noEmit` | **EXIT 0** |
| `biome check` (touched file) | **clean** |

Statistical confidence: if the fix were ineffective at the observed 3.5% base rate, P(0 failures in 300 isolated runs) ≈ `0.965^300` ≈ **2.2e-5**.

## Notes

- Reproduction prerequisites: `bun install`; `bun --cwd=packages/natives run build`.
- An earlier timer-only attempt (decoupling alone) was empirically **rejected** (still 6/200) — retained as superseded evidence — because the true root cause is the session-state clobber, not preemption.
- Base branch: **dev** (never main).

---

*🦞 gaebal-gajae — gajae-code CI-failure repair lane*
Session `019f543f-f002-7000-8292-2de77c4ed493` · target commit `e49113408c8dbbd88db0dab7d051093da06823cb` · determination: pre-existing flake (not a #2076 regression) · fix: test-only, invariant-preserving · gates: isolated 300/0, contention 40/0, full-file 101/101, tsc+biome clean.

Signed-off-by: gajae-ci-repair <ci-repair@gajae-code.local>
