### PR TITLE
test: stabilize legacy safety-stop label test under parallel load

### DIFF
--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -347,7 +347,7 @@ describe("AgentSession resilient retry", () => {
 			await session.dispose();
 			session = undefined;
 		}
-	});
+	}, 30_000);
 
 	it("surfaces deliberate request aborts without retrying", async () => {
 		session = buildSession({ responses: [{ throw: "Request was aborted." }] });


### PR DESCRIPTION
## What

Scope-raise the per-test timeout for the `it("retries errors that merely mention legacy safety-stop labels mid-sentence", …)` case in `packages/coding-agent/test/agent-session-resilient-retry.test.ts` from the default 5s cap to 30s, via the third `it()` argument.

## Why

This test runs a serial loop over ~22 incidental-message inputs (each builds an `AgentSession`, prompts, waits for idle, asserts recovery, disposes). The retry wait is mocked to resolve immediately, so the work is CPU-bound setup/teardown rather than real sleeping. Under full-suite parallel contention it can occasionally cross the default 5s per-test cap — a load flake only; it passes in isolation and in CI. Raising just this one test's ceiling removes the flake without masking a hang: 30s is far above the observed runtime (~1s isolated) yet still fails fast if the retry loop ever genuinely stalls.

The change matches the repo's existing per-test timeout convention (e.g. `}, 30_000);`, `}, 15_000);` in sibling test files). No global config, production code, sleeps, or other tests are touched.

## Tests

- `bun test packages/coding-agent/test/agent-session-resilient-retry.test.ts` → 23 pass / 0 fail (run 4x, stable)
- `bun --cwd=packages/coding-agent run check` → biome clean + tsc clean

## Context

Follows up on the non-blocking test-hygiene nit from the #2077 review: "this PR expanded that case into a 22-iteration serial loop; consider raising its timeout or sharding." Raising the scoped timeout was chosen over sharding because this file consistently uses the serial-loop pattern (4 sibling tests), and sharding via `it.each` would multiply the per-test `beforeEach` TempDir + AuthStorage setup 22x — adding I/O load to the exact parallel-contention condition that causes the flake.
