### PR TITLE
fix(coding-agent): prefer user scope evidence on cgroup v1

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 
+- Fixed cgroup v1 tmux owner isolation falsely rejecting user-session processes when a non-authoritative controller inherits a service cgroup, by preferring explicit user scope evidence across controller hierarchies.
 - The coordinator MCP owner-server probe now recognizes tmux ≥3.7's missing-server diagnostic (`error connecting to <socket> (No such file or directory)`) as an absent server. tmux 3.7 changed the wording from the older `no server running on <socket>`, which the coordinator probe did not match — so a brand-new coordinator socket (which never has a server yet) was misclassified `unverifiable` instead of `absent`, and **every** `gjc_delegate_*` / session create failed closed with `coordinator_tmux_owner_server_unverifiable` on tmux ≥3.7. The coordinator and `gjc` harness probes now match the same no-server wordings the other owner-isolation probes already did.
 - Preserved explicit Telegram forum-topic renames as durable user-owned names, immediately re-asserting delayed edits while retaining restart and rename-race recovery (#1910).
 - Prevented typed provider safety stops from entering automatic retry loops and aligned ACP refusal reporting with the provider-native classification.

--- a/packages/coding-agent/src/gjc-runtime/tmux-owner-isolation.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-owner-isolation.ts
@@ -77,6 +77,8 @@ export function classifyCgroup(input: { platform: NodeJS.Platform; cgroupText?: 
 			classification: "unverifiable",
 			diagnostic: "cgroup_metadata_malformed",
 		};
+	const scope = paths.find(value => /(?:^|\/)(?:user|session|app|init|gjc)[^/]*\.scope(?:\/|$)/.test(value));
+	if (scope) return { classification: "safe", scope };
 	const hasUnrelatedService = paths.some(value =>
 		value.split("/").some(component => component.endsWith(".service") && !/^user@\d+\.service$/.test(component)),
 	);
@@ -85,8 +87,6 @@ export function classifyCgroup(input: { platform: NodeJS.Platform; cgroupText?: 
 			classification: "unsafe_service",
 			diagnostic: "service_cgroup_inheritance",
 		};
-	const scope = paths.find(value => /(?:^|\/)(?:user|session|app|init|gjc)[^/]*\.scope(?:\/|$)/.test(value));
-	if (scope) return { classification: "safe", scope };
 	if (paths.every(value => value === "/")) return { classification: "safe", scope: "/" };
 	return {
 		classification: "unverifiable",

--- a/packages/coding-agent/test/gjc-runtime/tmux-owner-isolation.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-owner-isolation.test.ts
@@ -297,6 +297,19 @@ describe("tmux owner isolation", () => {
 			}).classification,
 		).toBe("safe");
 		expect(
+			classifyCgroup({
+				platform: "linux",
+				cgroupText: [
+					"13:blkio:/system.slice/sshd.service",
+					"11:memory:/user.slice/user-1000.slice/session-169114.scope",
+					"10:pids:/user.slice/user-1000.slice/session-169114.scope",
+				].join("\n"),
+			}),
+		).toEqual({
+			classification: "safe",
+			scope: "/user.slice/user-1000.slice/session-169114.scope",
+		});
+		expect(
 			(
 				await planTmuxOwnerIsolation(request, {
 					...probe("safe"),


### PR DESCRIPTION
## What

Fix cgroup v1 tmux owner isolation falsely rejecting a user-owned tmux server when independent controller hierarchies contain both user-session scope evidence and an inherited service path.

- evaluate recognized user/session/app/init/GJC `.scope` paths before treating unrelated `.service` components as unsafe
- add a regression case matching the mixed-controller layout seen in Podman/libpod containers reached through SSH
- document the user-facing fix under `packages/coding-agent/CHANGELOG.md` (`Unreleased > Fixed`)

## Why

`classifyCgroup()` reads every controller path from `/proc/<pid>/cgroup`. On cgroup v1, controllers have independent hierarchies: a non-systemd-managed controller such as `blkio` can retain `/system.slice/sshd.service`, while `memory`, `pids`, and `name=systemd` correctly place the same process under `session-*.scope`.

The previous order returned `unsafe_service` as soon as any controller contained an unrelated `.service`, so it never considered the stronger user-session scope evidence. That made Telegram `/session_create` fail closed with repeated `terminal_uncertain` / `spawn_failed` outcomes after the 0.10.0 tmux owner-isolation rollout.

A representative cgroup v1 layout is:

```text
13:blkio:/system.slice/sshd.service
11:memory:/user.slice/user-1000.slice/session-169114.scope
10:pids:/user.slice/user-1000.slice/session-169114.scope
```

With this change, the layout is classified as `safe` and returns the `session-169114.scope` path. A service-only path such as `0::/x.service` remains `unsafe_service`, malformed metadata still fails closed, and cgroup v2 behavior is unchanged.

## Security and compatibility

This only changes precedence when the same `/proc/<pid>/cgroup` record contains a recognized scope path. The existing allowlist remains unchanged, so arbitrary `*.scope` names do not become trusted. If no recognized scope exists, unrelated service inheritance is still rejected exactly as before.

The change is intended for cgroup v1 multi-hierarchy environments, especially Podman/libpod containers entered through SSH. cgroup v2 uses a unified hierarchy and does not exhibit this mixed-controller false positive.

## Testing

- `bun test packages/coding-agent/test/gjc-runtime/tmux-owner-isolation.test.ts` — **41 pass, 0 fail**
- `bun check` — **pass** (workspace TypeScript/Biome/declaration/Rust checks)
- Dev CI affected checks — coding-agent check, TypeScript edit benchmark check/test (**15 pass**), CLI smoke, and all four GJC state-gate groups passed
- Dev CI native builds — linux-x64 baseline and modern passed
- Dev CI coding-agent shards — shards 1-4 and 6-7 passed

Local full-shard note: on this Windows-mounted WSL `/mnt/c` checkout, shard 5 and shard 8 each hit one unrelated fixed 5-second subprocess-startup timeout (`compiled daemon smoke coverage` and `bare resume startup gating`). Shard 5 reproduced the same timeout on retry; its remaining **1500 tests passed**. Shard 8's remaining **1034 tests passed**. The changed owner-isolation suite passes completely, including its direct CLI subprocess coverage.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)