### PR TITLE
fix(coordinator-mcp): re-nudge prompt submit until the runtime acknowledges

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Added an owner-proof idle session reaper and `gjc_coordinator_stop_session` for ephemeral (delegate-created) coordinator sessions. Termination goes exclusively through the owner-proof `forceCloseGjcTmuxSession` path (pid, native session id, owner generation, server key, and start time all verified before SIGTERM) — never a raw `process.kill`. The reaper binds each close to the persisted runtime-state file, re-validates ephemeral and no-active-turn at kill time under the same per-session mutation lock as delegate reuse, and purges state only on verified termination (#2080).
 
+### Fixed
+
+- The coordinator MCP now re-nudges the runtime's prompt submit while a delivered turn is still unacknowledged. `--worktree` (and other TUI) runtimes can attest interactive input readiness a moment before their composer actually accepts a submit, so the single delivery `Enter` was dropped and the pasted prompt sat unsent — `tmux_keys_sent` yet never acknowledged, which failed the turn at the ack timeout (a read-only `gjc_coordinator_start_session` review would stall until the timeout and never run). Each `read_turn`/`await_turn` reconcile now re-sends only `Enter` (owner-proof gated; no re-paste so the prompt is never duplicated, no `Escape` so a turn that just started is never interrupted) while the turn is delivered-but-unacknowledged, so the prompt submits the moment the composer goes live; the ack timeout still fails a runtime that truly never comes up.
 ## [0.10.0] - 2026-07-12
 
 ### Added

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -2316,7 +2316,11 @@ async function reconcileRuntimeAcknowledgement(
 	turn: TurnRecord,
 	sessionState: CoordinatorSessionState | null,
 	ackTimeoutMs: number,
-	options: { failOnTimeout: boolean } = { failOnTimeout: true },
+	options: {
+		failOnTimeout: boolean;
+		runner?: CommandRunner;
+		ownerIsolationProbe?: OwnerIsolationProbe;
+	} = { failOnTimeout: true },
 ): Promise<TurnRecord> {
 	const session = asRecord(await readJsonFile(path.join(namespaceDir, "sessions", `${turn.session_id}.json`)));
 	if (
@@ -2330,6 +2334,16 @@ async function reconcileRuntimeAcknowledgement(
 	}
 	if (sessionState && runtimeStateAcknowledgesTurn(turn, sessionState)) {
 		return await markTurnAcknowledgedFromRuntimeState(namespaceDir, turn, sessionState);
+	}
+	if (
+		options.runner &&
+		session &&
+		turn.delivery.tmux_keys_sent === true &&
+		turn.delivery.prompt_acknowledged !== true &&
+		turn.delivery.state === "tmux_keys_sent" &&
+		ACTIVE_TURN_STATUSES.has(turn.status)
+	) {
+		await nudgeTmuxPromptSubmit(session, options.runner, options.ownerIsolationProbe);
 	}
 	if (options.failOnTimeout && turnAwaitingRuntimeAckExpired(turn, Date.now(), ackTimeoutMs)) {
 		return await markTurnFailedForUnacknowledgedDelivery(namespaceDir, turn, ackTimeoutMs);
@@ -2971,12 +2985,11 @@ async function captureTmuxTail(
 	return captured.stdout.split("\n").slice(-lines);
 }
 
-async function sendTmuxPrompt(
+async function resolveOwnerProvenTmuxPane(
 	session: Record<string, unknown>,
-	prompt: string,
-	runner: CommandRunner = runCommand,
+	runner: CommandRunner,
 	ownerIsolationProbe?: OwnerIsolationProbe,
-): Promise<boolean> {
+): Promise<{ paneId: string; socketKey: string; proveCurrentServer: () => Promise<boolean> } | null> {
 	const target = typeof session.tmux_target === "string" ? session.tmux_target : session.tmuxTarget;
 	const socketKey = typeof session.tmux_socket_key === "string" ? session.tmux_socket_key : session.tmuxSocketKey;
 	const serverKey =
@@ -2993,9 +3006,9 @@ async function sendTmuxPrompt(
 		typeof startTime !== "string" ||
 		startTime.length === 0
 	)
-		return false;
+		return null;
 	const paneId = session.pane_id ?? session.paneId;
-	if (typeof paneId !== "string" || !(await proveImmutableTmuxTarget(session, runner))) return false;
+	if (typeof paneId !== "string" || !(await proveImmutableTmuxTarget(session, runner))) return null;
 	const probe = ownerIsolationProbe ?? (await coordinatorOwnerIsolationProbe(runner));
 	const proveCurrentServer = async (): Promise<boolean> => {
 		const proof = await probe.probeServer(socketKey);
@@ -3006,7 +3019,36 @@ async function sendTmuxPrompt(
 			(process.platform !== "linux" || proof.cgroup?.classification === "safe")
 		);
 	};
-	return await sendTmuxPromptKeys(paneId, prompt, runner, socketKey, proveCurrentServer);
+	return { paneId, socketKey, proveCurrentServer };
+}
+
+async function sendTmuxPrompt(
+	session: Record<string, unknown>,
+	prompt: string,
+	runner: CommandRunner = runCommand,
+	ownerIsolationProbe?: OwnerIsolationProbe,
+): Promise<boolean> {
+	const resolved = await resolveOwnerProvenTmuxPane(session, runner, ownerIsolationProbe);
+	if (!resolved) return false;
+	return await sendTmuxPromptKeys(resolved.paneId, prompt, runner, resolved.socketKey, resolved.proveCurrentServer);
+}
+
+async function nudgeTmuxPromptSubmit(
+	session: Record<string, unknown>,
+	runner: CommandRunner = runCommand,
+	ownerIsolationProbe?: OwnerIsolationProbe,
+): Promise<boolean> {
+	// Re-submit an already-delivered-but-unacknowledged prompt. The prompt text is already pasted
+	// into the composer by the initial sendTmuxPrompt, but the runtime's TUI can attest input
+	// readiness before its composer actually accepts a submit, so that first Enter is dropped and
+	// the prompt sits unsent (tmux_keys_sent yet never acknowledged → the turn fails at the ack
+	// timeout). Re-send ONLY Enter — no re-paste (would duplicate the prompt), no Escape (could
+	// interrupt a turn that just started) — so the pasted prompt submits once the composer is live.
+	const resolved = await resolveOwnerProvenTmuxPane(session, runner, ownerIsolationProbe);
+	if (!resolved) return false;
+	if (!(await resolved.proveCurrentServer())) return false;
+	const submitted = await runner(["tmux", "-L", resolved.socketKey, "send-keys", "-t", resolved.paneId, "Enter"]);
+	return submitted.exitCode === 0;
 }
 
 async function hasTmuxSession(
@@ -3729,6 +3771,8 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 					: currentState;
 			return await reconcileRuntimeAcknowledgement(namespaceDir, current, state, promptAckTimeoutMs, {
 				failOnTimeout,
+				runner: commandRunner,
+				ownerIsolationProbe: services.ownerIsolationProbe,
 			});
 		});
 	}

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -606,6 +606,72 @@ describe("Coordinator MCP server protocol", () => {
 		expect(commands.at(-1)).toEqual(["tmux", "-L", PRIVATE_SOCKET, "send-keys", "-t", "%24", "Enter"]);
 	});
 
+	it("re-nudges Enter on reconcile when a delivered prompt is not yet acknowledged", async () => {
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "state", "renudge-delivery");
+		const commands: string[][] = [];
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+				// Long enough that read_turn's reconcile does not fail the turn — it stays active while awaiting ack.
+				GJC_COORDINATOR_MCP_PROMPT_ACK_TIMEOUT_MS: "60000",
+			},
+			services: {
+				ownerIsolationProbe: privateOwnerProbe(),
+				commandRunner: async command => {
+					commands.push(command);
+					if (tmuxSubcommand(command) === "has-session") return { exitCode: 0, stdout: "", stderr: "" };
+					if (tmuxSubcommand(command) === "display-message")
+						return { exitCode: 0, stdout: tmuxIdentity(command), stderr: "" };
+					if (isTmuxPromptDeliveryCommand(command)) return { exitCode: 0, stdout: "", stderr: "" };
+					if (tmuxSubcommand(command) === "capture-pane") return { exitCode: 0, stdout: "idle\n", stderr: "" };
+					return { exitCode: 1, stdout: "", stderr: "unexpected command" };
+				},
+			},
+		});
+
+		await server.callTool("gjc_coordinator_register_session", {
+			session_id: "visible-session",
+			cwd: root,
+			tmux_session: "visible-session",
+			tmux_target: "visible-session:0.0",
+			visible: true,
+			allow_mutation: true,
+		});
+		await persistPrivateOwnerProof(stateRoot, "visible-session");
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "do work",
+			allow_mutation: true,
+		});
+		expect(sent.delivery).toMatchObject({
+			tmux_keys_sent: true,
+			prompt_acknowledged: false,
+			state: "tmux_keys_sent",
+		});
+
+		const enterCommand = ["tmux", "-L", PRIVATE_SOCKET, "send-keys", "-t", "%24", "Enter"];
+		const enters = () => commands.filter(command => JSON.stringify(command) === JSON.stringify(enterCommand)).length;
+		// The initial delivery submitted exactly one Escape+Enter.
+		expect(enters()).toBe(1);
+
+		// The runtime never acknowledged: its TUI composer can lag behind the readiness marker, so the
+		// delivery Enter was dropped and the prompt sits unsent. A read_turn reconcile must re-nudge Enter
+		// to resubmit — without failing the still-active turn.
+		const read = await server.callTool("gjc_coordinator_read_turn", {
+			session_id: "visible-session",
+			turn_id: sent.turn_id,
+		});
+		expect(read).toMatchObject({
+			ok: true,
+			turn: { status: "active", delivery: { tmux_keys_sent: true, prompt_acknowledged: false } },
+		});
+		expect(enters()).toBeGreaterThan(1);
+	});
 	it("fails tmux-delivered turns that never receive a runtime prompt ack", async () => {
 		const root = await tempRoot();
 		const stateRoot = path.join(root, ".gjc", "state", "unacknowledged-delivery");


### PR DESCRIPTION
## What
Re-nudge the runtime's prompt submit (`Enter`) on every `read_turn`/`await_turn` reconcile while a delivered turn is still unacknowledged, so a prompt pasted before the TUI composer was submit-ready still submits.

## Why
`--worktree` (and other TUI) runtimes attest interactive input readiness a moment before their composer actually accepts a submit. The single delivery `Enter` from `sendTmuxPrompt` was then dropped, leaving the pasted prompt unsent: `tmux_keys_sent` was true but the runtime never acknowledged, so `reconcileRuntimeAcknowledgement` failed the turn at the ack timeout. Every read-only `gjc_coordinator_start_session` review stalled to the timeout and never ran — **reproduced deterministically** in an isolated coordinator against the live `--worktree` session command (delivery at 6s, `tmux_keys_sent=true`, ack never arrives → FAILED at the ack timeout). There was no re-submit path; the ack reconcile only ever failed the turn.

## How
- Extract the owner-proof pane resolution from `sendTmuxPrompt` into `resolveOwnerProvenTmuxPane` (no behavior change to the initial delivery).
- Add `nudgeTmuxPromptSubmit`: owner-proof gated, re-sends **only** `Enter` — no re-paste (would duplicate the prompt), no `Escape` (could interrupt a turn that just started).
- `reconcileRuntimeAcknowledgement` re-nudges when a turn is `tmux_keys_sent && !prompt_acknowledged && state === "tmux_keys_sent"` and still active, **before** the ack-timeout check. The ack timeout still fails a runtime that truly never comes up.

## Testing
- New discriminating unit test `re-nudges Enter on reconcile when a delivered prompt is not yet acknowledged` — **fails without the fix** (the delivered-but-unacknowledged turn receives no second `Enter`), passes with it.
- `bun test test/coordinator-mcp-server.test.ts`: **91 pass / 11 fail** — the 11 are the pre-existing macOS env-dependent owner-launch failures, **identical with and without this change** (verified by stash/compare).
- `tsc --noEmit`: 0 errors. `biome check`: clean.
- End-to-end: an isolated coordinator + live `--worktree` runtime now reaches `ack=True` at ~18s with **no manual intervention** (same harness that reproduced the stall).

## Checklist
- [x] Discriminating test added (fails without the fix)
- [x] CHANGELOG updated (`[Unreleased] > Fixed`)
- [x] No new regressions vs baseline (91/11 identical)
- [x] `tsc` + `biome` green
- [x] DCO `Signed-off-by`
