### PR TITLE
fix(coordinator-mcp): --worktree delegate runtimes report state (fresh non-terminal same-launch handoff only)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added an owner-proof idle session reaper and `gjc_coordinator_stop_session` for ephemeral (delegate-created) coordinator sessions. Termination goes exclusively through the owner-proof `forceCloseGjcTmuxSession` path (pid, native session id, owner generation, server key, and start time all verified before SIGTERM) — never a raw `process.kill`. The reaper binds each close to the persisted runtime-state file, re-validates ephemeral and no-active-turn at kill time under the same per-session mutation lock as delegate reuse, and purges state only on verified termination (#2080).
 
+### Fixed
+
+- A coordinator-managed `--worktree` delegate runtime now reports its runtime state (turn_start / running / needs_user_input / completed) back to the coordinator. The runtime executes inside a git worktree whose cwd differs from the delegate cwd the coordinator recorded in its initial `source: "coordinator"` state write, so the cwd/workdir/session_file identity guard threw `PreviousRuntimeStateReadError` on every agent-emitted write and the coordinator's view froze at the initial `running` (spurious ack timeouts, unrelayed `needs_user_input` questions, hung turns). The guard now skips the cwd/workdir/session_file check for that one coordinator→agent handoff **only** when the prior record is the coordinator's own **fresh, non-terminal** write for **this launch**: the coordinator `session_id` and `launch_id` must both match and the record must not already be terminal. This rejects a late async event from a superseded runtime reopening a coordinator-terminal state (which would otherwise falsely bind/ack a promoted queued turn and suppress its prompt-ack timeout) and rejects a stale predecessor from another launch on a truncated-id collision; agent→agent and genuinely stale/foreign prior records keep the full guard (#2085).
+
 ## [0.10.0] - 2026-07-12
 
 ### Added

--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -508,6 +508,31 @@ function assertPreviousRuntimeStateIdentity(
 	input: { sessionId: string; cwd: string; sessionFile: string | null },
 ): void {
 	if (Object.keys(previous).length === 0) return;
+	// The coordinator writes the initial state (source "coordinator") with the *delegate* cwd, before
+	// the --worktree runtime has created its worktree. The runtime then legitimately runs in a worktree
+	// cwd (and writes its own agent session_file) that differ from that initial record, so the cwd/
+	// workdir/session_file guard cannot apply to that one coordinator→agent handoff. Bypass it ONLY for
+	// the fresh, non-terminal initial record of THIS launch:
+	//   - session_id must match — never accept a foreign session;
+	//   - launch_id must match this runtime's launch — a truncated-id collision or a stale predecessor
+	//     from another launch is rejected, not silently accepted;
+	//   - the record must not already be terminal — a coordinator terminal state (written by
+	//     report_status, which also promotes a queued turn) must NOT be reopened by a late async event
+	//     from the old runtime, which would otherwise falsely bind/ack the promoted turn and suppress
+	//     its prompt-ack timeout.
+	// Every other prior state (agent→agent, or a genuinely stale/foreign record) keeps the full guard.
+	if (process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim() && previous.source === "coordinator") {
+		const launchId = process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV]?.trim();
+		if (
+			previous.session_id !== input.sessionId ||
+			previous.state === "completed" ||
+			previous.state === "errored" ||
+			!launchId ||
+			previous.launch_id !== launchId
+		)
+			throw new PreviousRuntimeStateReadError();
+		return;
+	}
 	if (
 		previous.session_id !== input.sessionId ||
 		typeof previous.cwd !== "string" ||

--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -143,6 +143,154 @@ describe("coordinator runtime state sidecar", () => {
 		}
 	});
 
+	it("persists agent state for a coordinator-managed --worktree runtime whose cwd differs from the recorded delegate cwd", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		const delegateCwd = path.join(root, "repo"); // what the coordinator recorded
+		const worktreeCwd = path.join(root, "repo.gajae-code-worktrees", "wt-1"); // where the agent runs
+		await fs.mkdir(delegateCwd, { recursive: true });
+		await fs.mkdir(worktreeCwd, { recursive: true });
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "gjc-coordinator-abc";
+		process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV] = "launch-1";
+		// The coordinator's own initial write: session_id is the coordinator id, but cwd/workdir are the
+		// DELEGATE cwd (the runtime has not yet created its worktree) and source is "coordinator".
+		await Bun.write(
+			stateFile,
+			`${JSON.stringify({
+				schema_version: 1,
+				session_id: "gjc-coordinator-abc",
+				launch_id: "launch-1",
+				state: "running",
+				ready_for_input: false,
+				updated_at: "2026-01-01T00:00:00.000Z",
+				current_turn_id: null,
+				last_turn_id: null,
+				live: null,
+				cwd: delegateCwd,
+				workdir: delegateCwd,
+				session_file: null,
+				source: "coordinator",
+			})}\n`,
+		);
+
+		// The agent, running inside the --worktree, emits turn_start with the WORKTREE cwd + its own
+		// agent session file — both differ from the coordinator's recorded delegate cwd.
+		await persistCoordinatorRuntimeStateFromEvent(
+			{ type: "turn_start" },
+			{
+				sessionId: "agent-internal-id",
+				cwd: worktreeCwd,
+				sessionFile: path.join(worktreeCwd, ".gjc", "session.json"),
+			},
+		);
+
+		// The write must land (identity is the matching coordinator session_id). Before the fix the cwd
+		// mismatch threw, so the file stayed frozen at source="coordinator" and no agent state was ever
+		// surfaced to the coordinator.
+		const after = await readJson(stateFile);
+		expect(after.source).toBe("agent_session_event");
+		expect(after.session_id).toBe("gjc-coordinator-abc");
+	});
+
+	it("rejects a late runtime event that would reopen a coordinator-terminal state", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		const delegateCwd = path.join(root, "repo");
+		const worktreeCwd = path.join(root, "repo.gajae-code-worktrees", "wt-1");
+		await fs.mkdir(delegateCwd, { recursive: true });
+		await fs.mkdir(worktreeCwd, { recursive: true });
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "gjc-coordinator-abc";
+		process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV] = "launch-1";
+		// report_status already terminalized this turn (source "coordinator", state "completed") and may
+		// have promoted a queued turn (current_turn_id). A late async turn_start from the OLD runtime must
+		// NOT reopen the terminal record — otherwise it would rebind/ack the promoted turn and suppress its
+		// prompt-ack timeout.
+		await Bun.write(
+			stateFile,
+			`${JSON.stringify({
+				schema_version: 1,
+				session_id: "gjc-coordinator-abc",
+				launch_id: "launch-1",
+				state: "completed",
+				ready_for_input: true,
+				updated_at: "2026-01-01T00:00:00.000Z",
+				current_turn_id: "turn-promoted-b",
+				last_turn_id: "turn-a",
+				live: null,
+				cwd: delegateCwd,
+				workdir: delegateCwd,
+				session_file: null,
+				source: "coordinator",
+			})}\n`,
+		);
+
+		await expect(
+			persistCoordinatorRuntimeStateFromEvent(
+				{ type: "turn_start" },
+				{
+					sessionId: "agent-internal-id",
+					cwd: worktreeCwd,
+					sessionFile: path.join(worktreeCwd, ".gjc", "session.json"),
+				},
+			),
+		).rejects.toThrow();
+
+		// The terminal record is preserved — not reopened as running, not rebound to the promoted turn.
+		const after = await readJson(stateFile);
+		expect(after.source).toBe("coordinator");
+		expect(after.state).toBe("completed");
+		expect(after.current_turn_id).toBe("turn-promoted-b");
+	});
+
+	it("rejects a coordinator predecessor from a different launch (stale record / truncated-id collision)", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		const delegateCwd = path.join(root, "repo");
+		const worktreeCwd = path.join(root, "repo.gajae-code-worktrees", "wt-1");
+		await fs.mkdir(delegateCwd, { recursive: true });
+		await fs.mkdir(worktreeCwd, { recursive: true });
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "gjc-coordinator-abc";
+		process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV] = "launch-new";
+		// Same (possibly truncated/colliding) coordinator session id, but a DIFFERENT launch than this
+		// runtime's — a stale predecessor. This runtime must not adopt it as its own initial record.
+		await Bun.write(
+			stateFile,
+			`${JSON.stringify({
+				schema_version: 1,
+				session_id: "gjc-coordinator-abc",
+				launch_id: "launch-old",
+				state: "running",
+				ready_for_input: false,
+				updated_at: "2026-01-01T00:00:00.000Z",
+				current_turn_id: null,
+				last_turn_id: null,
+				live: null,
+				cwd: delegateCwd,
+				workdir: delegateCwd,
+				session_file: null,
+				source: "coordinator",
+			})}\n`,
+		);
+
+		await expect(
+			persistCoordinatorRuntimeStateFromEvent(
+				{ type: "turn_start" },
+				{
+					sessionId: "agent-internal-id",
+					cwd: worktreeCwd,
+					sessionFile: path.join(worktreeCwd, ".gjc", "session.json"),
+				},
+			),
+		).rejects.toThrow();
+
+		const after = await readJson(stateFile);
+		expect(after.source).toBe("coordinator");
+		expect(after.launch_id).toBe("launch-old");
+	});
+
 	it("refreshes updated_at for duplicate same-state running writes after the heartbeat", async () => {
 		const root = await tempRoot();
 		const stateFile = path.join(root, "state.json");


### PR DESCRIPTION
Supersedes #2085 (reopen was blocked after the force-update). Reworked to address the HIGH blocking finding on that PR.

## What
A coordinator-managed `--worktree` runtime executes in a git worktree whose cwd differs from the delegate cwd the coordinator recorded in its initial `source: "coordinator"` state write. `assertPreviousRuntimeStateIdentity` keyed on cwd/workdir/session_file, so it threw `PreviousRuntimeStateReadError` on every agent-emitted write — the coordinator's view froze at the initial `running` (spurious ack timeouts, unrelayed `needs_user_input` questions, hung turns).

## How (scoped per the #2085 review)
The cwd/workdir/session_file check is skipped for the coordinator→agent handoff **only** when the prior record is the coordinator's own **fresh, non-terminal** write for **this launch**:
- `session_id` must match — never a foreign session;
- `launch_id` must match this runtime's launch — rejects a stale predecessor from another launch on a truncated 32-bit id/state-file collision;
- the record must not already be terminal — rejects a late async `turn_start`/`agent_start` from a superseded runtime reopening a coordinator-terminal state, which would otherwise falsely bind/ack a promoted queued turn and suppress its prompt-ack timeout.

Every other prior state (agent→agent, or a genuinely stale/foreign record) keeps the full guard.

## Testing
- **Discriminating adversarial tests** (fail against #2085's session-id-only bypass, pass here):
  - a late event may **not** reopen a coordinator-terminal state (asserts the terminal record + promoted `current_turn_id` are preserved);
  - a predecessor from a **different launch** is rejected.
- Happy path: coordinator→agent handoff with matching launch lands the agent write.
- `bun test test/session-state-sidecar.test.ts`: **46 pass / 4 fail** (the 4 are the pre-existing macOS env-dependent owner-postmortem failures, unchanged by this patch).
- `tsc --noEmit`: 0 errors. `biome check`: clean.

## Checklist
- [x] Discriminating tests for both blocking-finding races (terminal reopen, launch freshness)
- [x] CHANGELOG updated (`[Unreleased] > Fixed`)
- [x] No new regressions vs baseline
- [x] `tsc` + `biome` green
- [x] DCO `Signed-off-by`
