### PR TITLE
fix(coordinator-mcp): settle the delivery Escape before the submit Enter (fixes the ESC+CR prompt-drop)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added an owner-proof idle session reaper and `gjc_coordinator_stop_session` for ephemeral (delegate-created) coordinator sessions. Termination goes exclusively through the owner-proof `forceCloseGjcTmuxSession` path (pid, native session id, owner generation, server key, and start time all verified before SIGTERM) — never a raw `process.kill`. The reaper binds each close to the persisted runtime-state file, re-validates ephemeral and no-active-turn at kill time under the same per-session mutation lock as delegate reuse, and purges state only on verified termination (#2080).
 
+### Fixed
+
+- The coordinator MCP prompt delivery now waits briefly between the autocomplete-dismiss `Escape` and the submit `Enter`. A lone `Escape` (`\x1b`) sent immediately before `Enter` (`\r`) is parsed by the runtime's terminal input as a single ESC-prefixed sequence (the ESC-timeout ambiguity), which swallowed the `Enter` — the pasted prompt was never submitted, so a delegate turn hung with `tmux_keys_sent` set but never acknowledged and failed at the ack timeout (reproduced deterministically against a live `--worktree` runtime: removing the `Escape` or separating it from the `Enter` makes the prompt submit; the delivered keys are otherwise dropped). `sendTmuxPromptKeys` now lets the `Escape` register as a standalone keypress before sending `Enter`, so a single delivery submits reliably with no re-send needed.
+
 ## [0.10.0] - 2026-07-12
 
 ### Added

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -2470,6 +2470,12 @@ async function runCommand(
 	return { exitCode, stdout, stderr };
 }
 
+// A lone Escape (\x1b) delivered immediately before Enter (\r) is parsed by the runtime's terminal
+// input as a single ESC-prefixed sequence (the classic ESC-timeout ambiguity), which swallows the
+// Enter — the pasted prompt is then never submitted and the turn hangs until the ack timeout. This
+// settle window lets the Escape register as a standalone keypress before Enter is sent.
+export const PROMPT_SUBMIT_KEY_SETTLE_MS = 150;
+
 async function sendTmuxPromptKeys(
 	target: string,
 	prompt: string,
@@ -2501,6 +2507,7 @@ async function sendTmuxPromptKeys(
 	}
 	const dismissedAutocomplete = await runMutation([...tmux, "send-keys", "-t", target, "Escape"]);
 	if (dismissedAutocomplete?.exitCode !== 0) return false;
+	await new Promise(resolve => setTimeout(resolve, PROMPT_SUBMIT_KEY_SETTLE_MS));
 	const submitted = await runMutation([...tmux, "send-keys", "-t", target, "Enter"]);
 	return submitted?.exitCode === 0;
 }

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -18,6 +18,7 @@ import {
 	COORDINATOR_RUNTIME_READINESS_TIMEOUT_MAX_MS,
 	coordinatorOwnerIsolationProbe,
 	createCoordinatorMcpServer,
+	PROMPT_SUBMIT_KEY_SETTLE_MS,
 } from "../src/coordinator-mcp/server";
 import {
 	GJC_COORDINATOR_SESSION_ID_ENV,
@@ -604,6 +605,61 @@ describe("Coordinator MCP server protocol", () => {
 		expect(commands.slice(-4).map(tmuxSubcommand)).toEqual(TMUX_PROMPT_DELIVERY_COMMANDS);
 		expect(commands.at(-2)).toEqual(["tmux", "-L", PRIVATE_SOCKET, "send-keys", "-t", "%24", "Escape"]);
 		expect(commands.at(-1)).toEqual(["tmux", "-L", PRIVATE_SOCKET, "send-keys", "-t", "%24", "Enter"]);
+	});
+
+	it("waits between the Escape and the submit Enter so the runtime does not parse ESC+CR as one sequence", async () => {
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "state", "esc-cr-settle");
+		const timeline: Array<{ command: string[]; at: number }> = [];
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+			},
+			services: {
+				ownerIsolationProbe: privateOwnerProbe(),
+				commandRunner: async command => {
+					timeline.push({ command, at: Date.now() });
+					if (tmuxSubcommand(command) === "has-session") return { exitCode: 0, stdout: "", stderr: "" };
+					if (tmuxSubcommand(command) === "display-message")
+						return { exitCode: 0, stdout: tmuxIdentity(command), stderr: "" };
+					if (isTmuxPromptDeliveryCommand(command)) return { exitCode: 0, stdout: "", stderr: "" };
+					return { exitCode: 1, stdout: "", stderr: "unexpected command" };
+				},
+			},
+		});
+
+		await server.callTool("gjc_coordinator_register_session", {
+			session_id: "visible-session",
+			cwd: root,
+			tmux_session: "visible-session",
+			tmux_target: "visible-session:0.0",
+			visible: true,
+			allow_mutation: true,
+		});
+		await persistPrivateOwnerProof(stateRoot, "visible-session");
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "do work",
+			allow_mutation: true,
+		});
+		expect(sent.delivery).toMatchObject({ tmux_keys_sent: true, state: "tmux_keys_sent" });
+
+		const isSendKey = (entry: { command: string[] }, key: string) =>
+			entry.command.at(-1) === key && tmuxSubcommand(entry.command) === "send-keys";
+		const escapeKey = timeline.findLast(entry => isSendKey(entry, "Escape"));
+		const enterKey = timeline.findLast(entry => isSendKey(entry, "Enter"));
+		expect(escapeKey).toBeDefined();
+		expect(enterKey).toBeDefined();
+		// The submit Enter is sent, but only after the Escape has had time to register as a standalone
+		// keypress — otherwise ESC (\x1b) immediately followed by CR (\r) is parsed as one sequence and
+		// the Enter is swallowed, so the pasted prompt never submits.
+		expect((enterKey as { at: number }).at - (escapeKey as { at: number }).at).toBeGreaterThanOrEqual(
+			PROMPT_SUBMIT_KEY_SETTLE_MS - 20,
+		);
 	});
 
 	it("fails tmux-delivered turns that never receive a runtime prompt ack", async () => {


### PR DESCRIPTION
Replaces the closed #2090 with the actual root fix. #2090 tried to re-send `Enter` from `reconcileRuntimeAcknowledgement`; the reviewer correctly rejected it (read-only APIs mutating the TUI, unbounded Enter flooding, unsafe timeout ordering, ack-absence false positives). This PR fixes the real cause instead, so no re-send is needed at all.

## Root cause (reproduced deterministically against a live `--worktree` runtime)
`sendTmuxPromptKeys` sent `send-keys Escape` immediately followed by `send-keys Enter`. A lone `Escape` (`\x1b`) delivered right before `Enter` (`\r`) is parsed by the runtime's terminal input as **one** ESC-prefixed sequence (the ESC-timeout ambiguity), so the `Enter` is swallowed and the pasted prompt never submits — the delegate turn hangs with `tmux_keys_sent` set but no ack, and fails at the ack timeout.

With an isolated coordinator + the live `--worktree` session command and **no polling**, a delivered prompt is never acknowledged (rules out lock/read starvation). Removing the `Escape`, or inserting a short wait between `Escape` and `Enter`, makes the prompt submit immediately — no polling, no re-send, no extra keys. So it is the ESC+CR sequence ambiguity, not readiness timing.

## Fix
Wait `PROMPT_SUBMIT_KEY_SETTLE_MS` (150ms) after the autocomplete-dismiss `Escape` before `Enter`, so the `Escape` lands as a standalone keypress. Single delivery, single submit — none of the #2090 hazards exist because there is no reconciliation-time re-send.

## Testing
- New test asserts the submit `Enter` is issued at least `PROMPT_SUBMIT_KEY_SETTLE_MS` after the `Escape` (fails if the settle is removed).
- Existing delivery test unchanged.
- `bun test test/coordinator-mcp-server.test.ts`: **91 pass / 11 fail** (the 11 are the pre-existing macOS env-dependent owner-launch failures, unchanged).
- `tsc --noEmit`: 0 errors. `biome check`: clean.

## Checklist
- [x] Test added (discriminating)
- [x] CHANGELOG updated (`[Unreleased] > Fixed`)
- [x] No new regressions vs baseline
- [x] `tsc` + `biome` green
- [x] DCO `Signed-off-by`
