### PR TITLE
fix: exit quietly on broken output pipes instead of crashing (EPIPE)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - IRC deliveries now accept their exchange batch in the recipient's volatile current-session queue before recipient/main UI observations or sender success. Awaited deliveries generate the reply first, then accept the ordered incoming + auto-reply pair and commit the IRC roster claim before observation; provider failures and sender aborts before acceptance leave no ghost exchange, while observer failures after acceptance are isolated. This is not a durability guarantee: durable history injection remains a later flush and no fsync, recovery, persistent IDs, or deduplication was added.
-- Piping gjc output to a consumer that exits early (`gjc --help | head -1`, `gjc -p ... | jq -e`, an RPC host that dies) no longer crashes the process with a fatal `EPIPE` uncaught-exception dump and exit code 1. Print mode latches stdout writes to a no-op once the pipe is broken (the run still completes and persists), RPC mode drops frames whose sink peer vanished instead of tearing down the server (without latching the swappable `--listen` sink dead), and the process-level postmortem policy exits quietly with 141 (128 + SIGPIPE) for any remaining unhandled broken-pipe write, including socket `send` variants that previously killed live interactive sessions.
+- Print mode now records terminal text-mode errors as exit status 1 (or 78 for context overflow) without bypassing output quiescence or session disposal. It retains JSON event delivery through disposal and suppresses `EPIPE` from its owned stdout; `ERR_STREAM_DESTROYED` is suppressed only after that `EPIPE` has latched, while other output failures remain errors.
 
 ## [0.10.0] - 2026-07-12
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - IRC deliveries now accept their exchange batch in the recipient's volatile current-session queue before recipient/main UI observations or sender success. Awaited deliveries generate the reply first, then accept the ordered incoming + auto-reply pair and commit the IRC roster claim before observation; provider failures and sender aborts before acceptance leave no ghost exchange, while observer failures after acceptance are isolated. This is not a durability guarantee: durable history injection remains a later flush and no fsync, recovery, persistent IDs, or deduplication was added.
+- Piping gjc output to a consumer that exits early (`gjc --help | head -1`, `gjc -p ... | jq -e`, an RPC host that dies) no longer crashes the process with a fatal `EPIPE` uncaught-exception dump and exit code 1. Print mode latches stdout writes to a no-op once the pipe is broken (the run still completes and persists), RPC mode drops frames whose sink peer vanished instead of tearing down the server (without latching the swappable `--listen` sink dead), and the process-level postmortem policy exits quietly with 141 (128 + SIGPIPE) for any remaining unhandled broken-pipe write, including socket `send` variants that previously killed live interactive sessions.
 
 ## [0.10.0] - 2026-07-12
 

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -4,6 +4,7 @@
  * CLI entry point — registers all commands explicitly and delegates to the
  * lightweight CLI runner from pi-utils.
  */
+import "@gajae-code/utils/postmortem";
 import { Args, type CliConfig, Command, type CommandEntry, Flags, run } from "@gajae-code/utils/cli";
 import { APP_NAME, formatBunRuntimeError, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
 import { runFixtureReport } from "./cli/fixture-report";

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -2,7 +2,9 @@ import { randomUUID } from "node:crypto";
 import * as nodeFs from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { isKnownSinkPeerClosedError } from "@gajae-code/utils";
 import { VERSION } from "@gajae-code/utils/dirs";
+
 import {
 	COORDINATOR_MCP_PROTOCOL_VERSION,
 	COORDINATOR_MCP_SERVER_NAME,
@@ -63,6 +65,16 @@ interface JsonRpcResponse {
 	id: string | number | null;
 	result?: JsonRpcResult;
 	error?: { code: number; message: string; data?: unknown };
+}
+
+function sinkErrorCode(error: unknown): string | undefined {
+	if (error === null || (typeof error !== "object" && typeof error !== "function")) return undefined;
+	try {
+		const code = Reflect.get(error, "code");
+		return typeof code === "string" ? code : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 interface SessionStartInput {
@@ -4829,11 +4841,10 @@ export interface PumpCoordinatorOptions {
  *    answerable even while data handlers saturate.
  *  - Data handlers are capped at `maxDataConcurrency`; excess is queued up to
  *    `maxQueueDepth`, then rejected as `server_busy` (bounded memory / fanout).
- *  - `writeLine` failures move the writer to a terminal closed state instead of
- *    poisoning the serialized write chain or escaping as an unhandled rejection;
- *    no writes happen after close.
- *  - On EOF the pump drains in-flight handlers (bounded by `drainTimeoutMs`) and
- *    flushes queued writes before returning, so shutdown never races live work.
+ *  - A coded local `EPIPE` terminalizes writer and dispatch together; other
+ *    writer faults reject the pump without poisoning the serialized write chain.
+ *  - On EOF or a closed peer the pump drains already-running handlers (bounded
+ *    by `drainTimeoutMs`) and never promotes queued work.
  *  - Byte chunks are decoded with a streaming decoder so multibyte characters
  *    split across chunks are not corrupted.
  */
@@ -4845,45 +4856,81 @@ export async function pumpCoordinatorMcpStream(
 ): Promise<void> {
 	const maxDataConcurrency = Math.max(1, options.maxDataConcurrency ?? 32);
 	const maxQueueDepth = Math.max(0, options.maxQueueDepth ?? 256);
-	const drainTimeoutMs = Math.max(0, options.drainTimeoutMs ?? 30_000);
+	const drainTimeoutMs = Math.max(1, options.drainTimeoutMs ?? 30_000);
 
-	let writeClosed = false;
+	let writerState: "open" | "terminalizing" | "closed" = "open";
 	let draining = false;
 	let writeChain: Promise<void> = Promise.resolve();
 	const inFlight = new Set<Promise<void>>();
 	let activeData = 0;
 	const dataQueue: JsonRpcRequest[] = [];
+	const peerClosed = Promise.withResolvers<void>();
+	const writerFailure = Promise.withResolvers<never>();
+	void writerFailure.promise.catch(() => {});
+	const inputIterator = input[Symbol.asyncIterator]();
+	let inputDetached = false;
+	let fatalWriterFailure: { value: unknown } | undefined;
 
-	const emit = (response: JsonRpcResponse): void => {
+	const detachInput = (): void => {
+		if (inputDetached) return;
+		inputDetached = true;
+		const detached = inputIterator.return?.();
+		if (detached) void detached.catch(() => {});
+	};
+	const terminalizePeer = (): void => {
+		if (writerState !== "open") return;
+		writerState = "terminalizing";
+		draining = true;
+		dataQueue.length = 0;
+		detachInput();
+		peerClosed.resolve();
+	};
+	const failWriter = (failure: unknown): void => {
+		if (writerState === "closed") return;
+		writerState = "closed";
+		draining = true;
+		dataQueue.length = 0;
+		detachInput();
+		fatalWriterFailure = { value: failure };
+
+		writerFailure.reject(failure);
+	};
+	const isExpectedPeerClosure = (failure: unknown): boolean =>
+		isKnownSinkPeerClosedError(failure) && sinkErrorCode(failure) === "EPIPE";
+
+	const emit = (response: JsonRpcResponse): Promise<void> => {
 		writeChain = writeChain.then(async () => {
-			if (writeClosed) return;
+			if (writerState !== "open") return;
 			try {
 				await writeLine(`${JSON.stringify(response)}\n`);
-			} catch {
-				writeClosed = true; // terminal writer error: stop, but never poison the chain
+			} catch (failure) {
+				if (isExpectedPeerClosure(failure)) terminalizePeer();
+				else failWriter(failure);
 			}
 		});
+		return writeChain;
 	};
 
 	const launch = (request: JsonRpcRequest, control: boolean): void => {
 		const task = (async () => {
+			let response: JsonRpcResponse;
 			try {
-				emit(await handleJsonRpc(request));
-			} catch (err) {
-				emit({
+				response = await handleJsonRpc(request);
+			} catch (failure) {
+				response = {
 					jsonrpc: "2.0",
 					id: request.id ?? null,
-					error: { code: -32603, message: publicCoordinatorError(err) },
-				});
-			} finally {
-				if (!control) {
-					activeData -= 1;
-					if (!draining) {
-						const next = dataQueue.shift();
-						if (next) {
-							activeData += 1;
-							launch(next, false);
-						}
+					error: { code: -32603, message: publicCoordinatorError(failure) },
+				};
+			}
+			await emit(response);
+			if (!control) {
+				activeData -= 1;
+				if (!draining && writerState === "open") {
+					const next = dataQueue.shift();
+					if (next) {
+						activeData += 1;
+						launch(next, false);
 					}
 				}
 			}
@@ -4893,6 +4940,7 @@ export async function pumpCoordinatorMcpStream(
 	};
 
 	const dispatch = (request: JsonRpcRequest): void => {
+		if (writerState !== "open") return;
 		// Notifications (no id) get no response; the coordinator has no side-effecting ones.
 		if (request.id === undefined || request.id === null) return;
 		if (request.method === "ping") {
@@ -4908,51 +4956,75 @@ export async function pumpCoordinatorMcpStream(
 			dataQueue.push(request);
 			return;
 		}
-		emit({
+		void emit({
 			jsonrpc: "2.0",
 			id: request.id,
 			error: { code: -32000, message: "server_busy: coordinator request queue is full" },
 		});
 	};
 
+	const drainInFlightAndWrites = async (): Promise<void> => {
+		let timer: NodeJS.Timeout | undefined;
+		const timeout = new Promise<"timed_out">(resolve => {
+			timer = setTimeout(() => resolve("timed_out"), drainTimeoutMs);
+			(timer as { unref?: () => void }).unref?.();
+		});
+		const drain = async (): Promise<"drained"> => {
+			while (true) {
+				if (inFlight.size > 0) await Promise.allSettled([...inFlight]);
+				const writes = writeChain;
+				await writes;
+				if (inFlight.size === 0 && writes === writeChain) return "drained";
+			}
+		};
+		try {
+			if ((await Promise.race([drain(), timeout])) === "timed_out") {
+				writerState = "closed";
+				draining = true;
+				dataQueue.length = 0;
+				detachInput();
+			}
+		} finally {
+			if (timer) clearTimeout(timer);
+		}
+	};
+
 	const decoder = new TextDecoder();
 	let buffer = "";
-	for await (const chunk of input) {
-		buffer += typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
-		let newline = buffer.indexOf("\n");
-		while (newline >= 0) {
-			const line = buffer.slice(0, newline).trim();
-			buffer = buffer.slice(newline + 1);
-			if (line.length > 0) {
-				let request: JsonRpcRequest | null = null;
-				try {
-					request = JSON.parse(line) as JsonRpcRequest;
-				} catch {
-					request = null; // ignore malformed frames rather than crashing the loop
+	let inputFailure: unknown;
+	try {
+		while (writerState === "open") {
+			const next = await Promise.race([inputIterator.next(), peerClosed.promise, writerFailure.promise]);
+			if (!next || next.done) break;
+			buffer += typeof next.value === "string" ? next.value : decoder.decode(next.value, { stream: true });
+			let newline = buffer.indexOf("\n");
+			while (newline >= 0 && writerState === "open") {
+				const line = buffer.slice(0, newline).trim();
+				buffer = buffer.slice(newline + 1);
+				if (line.length > 0) {
+					let request: JsonRpcRequest | null = null;
+					try {
+						request = JSON.parse(line) as JsonRpcRequest;
+					} catch {
+						request = null; // ignore malformed frames rather than crashing the loop
+					}
+					if (request) dispatch(request);
 				}
-				if (request) dispatch(request);
+				newline = buffer.indexOf("\n");
 			}
-			newline = buffer.indexOf("\n");
 		}
+	} catch (failure) {
+		inputFailure = failure;
 	}
 
-	// EOF: stop promoting queued work, then drain in-flight handlers under a bound.
+	// Input EOF or a closed peer stops promotion. One deadline bounds both the
+	// active handlers and the serialized writes they have already queued.
 	draining = true;
-	if (inFlight.size > 0) {
-		const drain = Promise.allSettled(Array.from(inFlight)).then(() => undefined);
-		if (drainTimeoutMs > 0) {
-			let timer: ReturnType<typeof setTimeout> | undefined;
-			const timeout = new Promise<void>(resolve => {
-				timer = setTimeout(resolve, drainTimeoutMs);
-				(timer as { unref?: () => void }).unref?.();
-			});
-			await Promise.race([drain, timeout]);
-			if (timer) clearTimeout(timer);
-		} else {
-			await drain;
-		}
-	}
-	await writeChain;
+	dataQueue.length = 0;
+	await drainInFlightAndWrites();
+	if (fatalWriterFailure) throw fatalWriterFailure.value;
+	if (inputFailure !== undefined) throw inputFailure;
+	writerState = "closed";
 }
 
 export async function runCoordinatorMcpStdio(options: CoordinatorMcpServerOptions = {}): Promise<void> {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1398,12 +1398,10 @@ export async function runRootCommand(
 			if ($env.PI_TIMING) {
 				logger.printTimings();
 			}
+			stopThemeWatcher();
 			if (!deps.suppressProcessExit) {
-				await session.dispose();
-				stopThemeWatcher();
-				await postmortem.quit(0);
-			} else {
-				stopThemeWatcher();
+				const exitCode = typeof process.exitCode === "number" ? process.exitCode : 0;
+				await postmortem.quit(exitCode);
 			}
 		}
 	}

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -6,7 +6,7 @@
  * - `gjc --mode json "prompt"` - JSON event stream
  */
 import { type AssistantMessage, type ImageContent, isContextOverflow } from "@gajae-code/ai";
-import { isBrokenPipeError, logger, sanitizeText } from "@gajae-code/utils";
+import { isKnownSinkPeerClosedError, logger, sanitizeText } from "@gajae-code/utils";
 import type { AgentSession } from "../session/agent-session";
 import { isSilentAbort } from "../session/messages";
 import { initializeExtensions } from "./runtime-init";
@@ -24,9 +24,8 @@ export interface PrintModeOptions {
 	/** Images to attach to the initial message */
 	initialImages?: ImageContent[];
 	/**
-	 * When true, an assistant error/abort does not call process.exit(); print mode
-	 * returns instead so the caller (e.g. RLM autonomous mode) can run its own
-	 * finalization/cleanup before the process exits.
+	 * When true, a terminal assistant error/abort leaves process exit status
+	 * untouched so the caller can run its own finalization and status handling.
 	 */
 	suppressProcessExit?: boolean;
 }
@@ -42,7 +41,7 @@ export interface PrintModeOptions {
  * events from the subscription and does not run this terminal-error branch, so
  * it is intentionally NOT covered by this exit code.
  */
-export const CONTEXT_OVERFLOW_EXIT_CODE = 2;
+export const CONTEXT_OVERFLOW_EXIT_CODE = 78;
 
 /**
  * Build an actionable stderr diagnostic for a terminal context-overflow error in
@@ -59,136 +58,249 @@ function formatContextOverflowError(message: AssistantMessage, autoCompactionEna
 }
 
 /**
+ * Own process stdout only while print mode is actively writing. This lets this
+ * mode absorb a peer-closing its output pipe without changing error-listener
+ * ownership for the interactive/TUI and clipboard paths.
+ */
+function createPrintStdoutOwner(): {
+	write(chunk: string): void;
+	flush(): Promise<void>;
+	dispose(): void;
+} {
+	let epipeLatched = false;
+	let writeError: unknown;
+	let hasWriteError = false;
+	const pendingWrites = new Set<{ done: Promise<void>; settle(): void }>();
+
+	const isEpipe = (error: unknown): boolean => {
+		try {
+			return (error as NodeJS.ErrnoException | null | undefined)?.code === "EPIPE";
+		} catch {
+			return false;
+		}
+	};
+
+	const settlePendingWrites = (): void => {
+		for (const pending of [...pendingWrites]) pending.settle();
+	};
+
+	const handleWriteError = (error: unknown): void => {
+		// An EPIPE from this owned stdout sink proves its peer closed. A destroyed
+		// stream does not prove that independently, so it is tolerated only after
+		// this owner has already observed and latched an EPIPE.
+		if (isEpipe(error)) {
+			epipeLatched = true;
+			settlePendingWrites();
+			return;
+		}
+		if (epipeLatched && isKnownSinkPeerClosedError(error)) {
+			settlePendingWrites();
+			return;
+		}
+
+		if (!hasWriteError) {
+			writeError = error;
+			hasWriteError = true;
+		}
+		settlePendingWrites();
+	};
+
+	const onStdoutError = (error: Error): void => {
+		handleWriteError(error);
+	};
+	process.stdout.on("error", onStdoutError);
+
+	const waitForWrites = async (): Promise<void> => {
+		while (pendingWrites.size > 0) {
+			await Promise.all([...pendingWrites].map(pending => pending.done));
+		}
+	};
+
+	return {
+		write(chunk: string): void {
+			if (epipeLatched || hasWriteError) return;
+
+			let settled = false;
+			const completion = Promise.withResolvers<void>();
+			let pending: { done: Promise<void>; settle(): void };
+			pending = {
+				done: completion.promise,
+				settle: (): void => {
+					if (settled) return;
+					settled = true;
+					pendingWrites.delete(pending);
+					completion.resolve();
+				},
+			};
+			const complete = (error?: Error | null): void => {
+				if (settled) return;
+				if (error) handleWriteError(error);
+				pending.settle();
+			};
+
+			pendingWrites.add(pending);
+			try {
+				process.stdout.write(chunk, complete);
+			} catch (error) {
+				handleWriteError(error);
+				pending.settle();
+			}
+		},
+
+		async flush(): Promise<void> {
+			await waitForWrites();
+			if (!epipeLatched && !hasWriteError) {
+				this.write("");
+				await waitForWrites();
+			}
+			if (hasWriteError) throw writeError;
+		},
+
+		dispose(): void {
+			process.stdout.removeListener("error", onStdoutError);
+		},
+	};
+}
+
+async function writeStderrAndQuiesce(chunk: string): Promise<void> {
+	const completion = Promise.withResolvers<void>();
+	let settled = false;
+	const complete = (error?: unknown): void => {
+		if (settled) return;
+		settled = true;
+		if (error === undefined || error === null) completion.resolve();
+		else completion.reject(error);
+	};
+
+	try {
+		process.stderr.write(chunk, complete);
+	} catch (error) {
+		complete(error);
+	}
+	await completion.promise;
+}
+
+function throwCollectedErrors(errors: unknown[]): void {
+	const uniqueErrors = [...new Set(errors)];
+	if (uniqueErrors.length === 0) return;
+	if (uniqueErrors.length === 1) throw uniqueErrors[0];
+	throw new AggregateError(uniqueErrors, "Print mode failed while flushing output and disposing the session");
+}
+
+/**
  * Run in print (single-shot) mode.
  * Sends prompts to the agent and outputs the result.
  */
 export async function runPrintMode(session: AgentSession, options: PrintModeOptions): Promise<void> {
 	const { mode, messages = [], initialMessage, initialImages } = options;
+	const stdout = createPrintStdoutOwner();
+	const failures: unknown[] = [];
+	let unsubscribe: (() => void) | undefined;
 
-	// Print-mode stdout is routinely piped onward (`gjc -p ... | jq`, `| head`).
-	// When that consumer exits early, Bun surfaces the next write as a
-	// synchronous EPIPE throw. Inside the agent-event subscription below such a
-	// throw would rip through event dispatch (and become a fatal uncaught
-	// exception), so once the pipe is known-broken all further stdout writes
-	// latch to a no-op: the run still completes and the session persists.
-	let stdoutBroken = false;
-	const writeStdout = (chunk: string): void => {
-		if (stdoutBroken) return;
-		try {
-			process.stdout.write(chunk);
-		} catch (err) {
-			if (!isBrokenPipeError(err)) throw err;
-			stdoutBroken = true;
-		}
-	};
-
-	// Emit session header for JSON mode
-	if (mode === "json") {
-		const header = session.sessionManager.getHeader();
-		if (header) {
-			writeStdout(`${JSON.stringify(header)}\n`);
-		}
-	}
-	// Set up extensions for print mode (no UI, no command context)
-	await initializeExtensions(session, {
-		reportSendError: (action, err) => {
-			process.stderr.write(
-				`Extension ${action === "extension_send" ? "sendMessage" : "sendUserMessage"} failed: ${err.message}\n`,
-			);
-		},
-		reportRuntimeError: err => {
-			process.stderr.write(`Extension error (${err.extensionPath}): ${err.error}\n`);
-		},
-	});
-
-	// Always subscribe to enable session persistence via _handleAgentEvent
-	session.subscribe(event => {
-		// In JSON mode, output all events
+	try {
+		// Emit session header for JSON mode.
 		if (mode === "json") {
-			writeStdout(`${JSON.stringify(event)}\n`);
+			const header = session.sessionManager.getHeader();
+			if (header) stdout.write(`${JSON.stringify(header)}\n`);
 		}
-	});
 
-	// Send initial message with attachments
-	if (initialMessage !== undefined) {
-		await logger.time("print:prompt:initial", () => session.prompt(initialMessage, { images: initialImages }));
-	}
+		// Set up extensions for print mode (no UI, no command context).
+		await initializeExtensions(session, {
+			reportSendError: (action, err) => {
+				process.stderr.write(
+					`Extension ${action === "extension_send" ? "sendMessage" : "sendUserMessage"} failed: ${err.message}\n`,
+				);
+			},
+			reportRuntimeError: err => {
+				process.stderr.write(`Extension error (${err.extensionPath}): ${err.error}\n`);
+			},
+		});
 
-	// Send remaining messages
-	for (const message of messages) {
-		await logger.time("print:prompt:next", () => session.prompt(message));
-	}
+		// AgentSession persists events internally. Print mode only needs a listener
+		// when it must render the JSON event stream.
+		if (mode === "json") {
+			unsubscribe = session.subscribe(event => {
+				stdout.write(`${JSON.stringify(event)}\n`);
+			});
+		}
 
-	// In text mode, output final response
-	if (mode === "text") {
-		const state = session.state;
-		const lastMessage = state.messages.findLast(message => message.role === "assistant");
+		// Send initial message with attachments.
+		if (initialMessage !== undefined) {
+			await logger.time("print:prompt:initial", () => session.prompt(initialMessage, { images: initialImages }));
+		}
 
-		if (lastMessage?.role === "assistant") {
-			const assistantMsg = lastMessage as AssistantMessage;
+		// Send remaining messages.
+		for (const message of messages) {
+			await logger.time("print:prompt:next", () => session.prompt(message));
+		}
 
-			// Check for error/aborted — skip silent-abort (plan-mode compaction transition)
-			if (
-				(assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") &&
-				!isSilentAbort(assistantMsg.errorMessage)
-			) {
-				// Context-overflow is an expected, recoverable-in-principle condition — not
-				// an opaque crash. Auto-compaction has already run inside session.prompt();
-				// if we still land here the request could not be made to fit. In this
-				// text-mode final-response path, surface an actionable diagnostic and a
-				// distinct exit code so text-mode (`gjc -p`) callers can detect context
-				// exhaustion instead of parsing the raw provider error string. (JSON mode
-				// does not reach this branch and is intentionally out of scope.)
-				const isOverflow =
-					assistantMsg.stopReason === "error" && isContextOverflow(assistantMsg, session.model?.contextWindow);
-				const errorLine = isOverflow
-					? formatContextOverflowError(assistantMsg, session.autoCompactionEnabled)
-					: sanitizeText(assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`);
-				const exitCode = isOverflow ? CONTEXT_OVERFLOW_EXIT_CODE : 1;
-				const flushed = process.stderr.write(`${errorLine}\n`);
-				// When the caller owns finalization (RLM autonomous), return instead of
-				// exiting so its cleanup runs; the caller surfaces a non-zero exit itself.
-				if (!options.suppressProcessExit) {
-					if (flushed) {
-						process.exit(exitCode);
-					} else {
-						process.stderr.once("drain", () => process.exit(exitCode));
+		// In text mode, output final response.
+		if (mode === "text") {
+			const lastMessage = session.state.messages.findLast(message => message.role === "assistant");
+			if (lastMessage?.role === "assistant") {
+				const assistantMsg = lastMessage as AssistantMessage;
+				let printContent = true;
+
+				// Check for error/aborted — skip silent-abort (plan-mode compaction transition).
+				if (
+					(assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") &&
+					!isSilentAbort(assistantMsg.errorMessage)
+				) {
+					const isOverflow =
+						assistantMsg.stopReason === "error" && isContextOverflow(assistantMsg, session.model?.contextWindow);
+					const errorLine = isOverflow
+						? formatContextOverflowError(assistantMsg, session.autoCompactionEnabled)
+						: sanitizeText(assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`);
+					const exitCode = isOverflow ? CONTEXT_OVERFLOW_EXIT_CODE : 1;
+
+					if (!options.suppressProcessExit) process.exitCode = exitCode;
+					await writeStderrAndQuiesce(`${errorLine}\n`);
+					printContent = false;
+				}
+
+				if (
+					assistantMsg.errorMessage &&
+					assistantMsg.stopReason !== "error" &&
+					assistantMsg.stopReason !== "aborted"
+				) {
+					await writeStderrAndQuiesce(`${sanitizeText(assistantMsg.errorMessage)}\n`);
+				}
+
+				if (printContent) {
+					for (const content of assistantMsg.content) {
+						if (content.type === "text") stdout.write(`${sanitizeText(content.text)}\n`);
 					}
 				}
 			}
+		}
 
-			if (
-				assistantMsg.errorMessage &&
-				assistantMsg.stopReason !== "error" &&
-				assistantMsg.stopReason !== "aborted"
-			) {
-				process.stderr.write(`${sanitizeText(assistantMsg.errorMessage)}\n`);
-			}
+		// Observe callback and stream errors from every preceding print-mode write.
+		await stdout.flush();
+	} catch (error) {
+		failures.push(error);
+	} finally {
+		// The JSON subscriber remains live while disposal emits its final events.
+		try {
+			await session.dispose();
+		} catch (error) {
+			failures.push(error);
+		}
 
-			// Output text content
-			for (const content of assistantMsg.content) {
-				if (content.type === "text") {
-					writeStdout(`${sanitizeText(content.text)}\n`);
-				}
-			}
+		// Disposal may have written JSON or delivered a late stdout error.
+		try {
+			await stdout.flush();
+		} catch (error) {
+			failures.push(error);
+		}
+
+		try {
+			unsubscribe?.();
+		} catch (error) {
+			failures.push(error);
+		} finally {
+			stdout.dispose();
 		}
 	}
 
-	// Ensure stdout is fully flushed before returning
-	// This prevents race conditions where the process exits before all output is written
-	await new Promise<void>((resolve, reject) => {
-		try {
-			process.stdout.write("", err => {
-				if (err && !isBrokenPipeError(err)) reject(err);
-				else resolve();
-			});
-		} catch (err) {
-			// Bun throws synchronously when the pipe consumer is already gone;
-			// there is nothing left to flush to, so this is not an error.
-			if (isBrokenPipeError(err)) resolve();
-			else reject(err);
-		}
-	});
-
-	await session.dispose();
+	throwCollectedErrors(failures);
 }

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -6,7 +6,7 @@
  * - `gjc --mode json "prompt"` - JSON event stream
  */
 import { type AssistantMessage, type ImageContent, isContextOverflow } from "@gajae-code/ai";
-import { logger, sanitizeText } from "@gajae-code/utils";
+import { isBrokenPipeError, logger, sanitizeText } from "@gajae-code/utils";
 import type { AgentSession } from "../session/agent-session";
 import { isSilentAbort } from "../session/messages";
 import { initializeExtensions } from "./runtime-init";
@@ -65,11 +65,28 @@ function formatContextOverflowError(message: AssistantMessage, autoCompactionEna
 export async function runPrintMode(session: AgentSession, options: PrintModeOptions): Promise<void> {
 	const { mode, messages = [], initialMessage, initialImages } = options;
 
+	// Print-mode stdout is routinely piped onward (`gjc -p ... | jq`, `| head`).
+	// When that consumer exits early, Bun surfaces the next write as a
+	// synchronous EPIPE throw. Inside the agent-event subscription below such a
+	// throw would rip through event dispatch (and become a fatal uncaught
+	// exception), so once the pipe is known-broken all further stdout writes
+	// latch to a no-op: the run still completes and the session persists.
+	let stdoutBroken = false;
+	const writeStdout = (chunk: string): void => {
+		if (stdoutBroken) return;
+		try {
+			process.stdout.write(chunk);
+		} catch (err) {
+			if (!isBrokenPipeError(err)) throw err;
+			stdoutBroken = true;
+		}
+	};
+
 	// Emit session header for JSON mode
 	if (mode === "json") {
 		const header = session.sessionManager.getHeader();
 		if (header) {
-			process.stdout.write(`${JSON.stringify(header)}\n`);
+			writeStdout(`${JSON.stringify(header)}\n`);
 		}
 	}
 	// Set up extensions for print mode (no UI, no command context)
@@ -88,7 +105,7 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 	session.subscribe(event => {
 		// In JSON mode, output all events
 		if (mode === "json") {
-			process.stdout.write(`${JSON.stringify(event)}\n`);
+			writeStdout(`${JSON.stringify(event)}\n`);
 		}
 	});
 
@@ -151,7 +168,7 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 			// Output text content
 			for (const content of assistantMsg.content) {
 				if (content.type === "text") {
-					process.stdout.write(`${sanitizeText(content.text)}\n`);
+					writeStdout(`${sanitizeText(content.text)}\n`);
 				}
 			}
 		}
@@ -160,10 +177,17 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 	// Ensure stdout is fully flushed before returning
 	// This prevents race conditions where the process exits before all output is written
 	await new Promise<void>((resolve, reject) => {
-		process.stdout.write("", err => {
-			if (err) reject(err);
-			else resolve();
-		});
+		try {
+			process.stdout.write("", err => {
+				if (err && !isBrokenPipeError(err)) reject(err);
+				else resolve();
+			});
+		} catch (err) {
+			// Bun throws synchronously when the pipe consumer is already gone;
+			// there is nothing left to flush to, so this is not an error.
+			if (isBrokenPipeError(err)) resolve();
+			else reject(err);
+		}
 	});
 
 	await session.dispose();

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -11,7 +11,7 @@
  * - Extension UI: Extension UI requests are emitted, client responds with extension_ui_response
  */
 
-import { $pickenv, isBrokenPipeError, logger, readLines, Snowflake } from "@gajae-code/utils";
+import { $pickenv, isKnownSinkPeerClosedError, logger, readLines, Snowflake } from "@gajae-code/utils";
 import type {
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
@@ -64,7 +64,18 @@ type RpcOutput = (
 		| RpcHostUriRequest
 		| RpcHostUriCancelRequest
 		| object,
-) => void;
+) => Promise<void>;
+type StdioTransportState = "open" | "terminalizing" | "closed";
+
+function sinkErrorCode(error: unknown): string | undefined {
+	if (error === null || (typeof error !== "object" && typeof error !== "function")) return undefined;
+	try {
+		const code = Reflect.get(error, "code");
+		return typeof code === "string" ? code : undefined;
+	} catch {
+		return undefined;
+	}
+}
 
 function parseValueDialogResponse(
 	response: RpcExtensionUIResponse,
@@ -150,16 +161,23 @@ export function isFastLaneRpcCommand(type: RpcCommand["type"]): boolean {
 export function createRpcCommandScheduler(
 	run: (command: RpcCommand) => Promise<void>,
 	track: (task: Promise<void>) => void,
-): { dispatch: (command: RpcCommand) => void } {
+): { dispatch: (command: RpcCommand) => void; close: () => void } {
 	let orderedChain: Promise<void> = Promise.resolve();
+	let accepting = true;
 	return {
 		dispatch(command: RpcCommand): void {
+			if (!accepting) return;
 			if (isFastLaneRpcCommand(command.type)) {
 				track(run(command));
 				return;
 			}
-			orderedChain = orderedChain.then(() => run(command));
+			orderedChain = orderedChain.then(async () => {
+				if (accepting) await run(command);
+			});
 			track(orderedChain);
+		},
+		close(): void {
+			accepting = false;
 		},
 	};
 }
@@ -283,27 +301,94 @@ export async function runRpcMode(
 	// may write there.
 	process.env.PI_NOTIFICATIONS = "off";
 
-	// Frames go to a swappable sink: stdout for stdio, the active client socket for a
-	// persistent --listen (UDS) server. Defaults to stdout, so the stdio path is unchanged.
-	let frameSink = (line: string): void => {
-		process.stdout.write(line);
+	// Frames route to stdout for stdio and to the active client for --listen. A
+	// socket server begins with no peer, so it must never leak frames to stdout.
+	const noopSink = (_line: string): void => {};
+	let stdioTransportState: StdioTransportState = options?.listen ? "closed" : "open";
+	let beginStdioTerminalization: (() => void) | undefined;
+	const stdioFatalFailure = Promise.withResolvers<never>();
+	void stdioFatalFailure.promise.catch(() => {});
+	let hasStdioWriteFailure = false;
+	let stdioWriteFailure: unknown;
+	let stdioPeerClosed = false;
+	const pendingStdioWrites = new Set<{
+		completion: Promise<void>;
+		settle: (failed: boolean, failure?: unknown) => void;
+	}>();
+	const settlePendingStdioWrites = (failed: boolean, failure?: unknown): void => {
+		for (const pending of [...pendingStdioWrites]) pending.settle(failed, failure);
 	};
-	const output = (obj: RpcResponse | RpcExtensionUIRequest | object) => {
-		try {
-			frameSink(`${JSON.stringify(obj)}\n`);
-		} catch (err) {
-			// The frame consumer (stdio parent or UDS client) vanished mid-write.
-			// Dropping the frame beats crashing the whole RPC server; the sink is
-			// swappable (--listen serves later clients), so do not latch it dead —
-			// just skip frames while the current peer is gone.
-			if (!isBrokenPipeError(err)) throw err;
-			logger.debug("RPC frame dropped: sink pipe is broken", { type: (obj as { type?: string }).type });
+	const waitForStdioWrites = async (): Promise<void> => {
+		while (pendingStdioWrites.size > 0) {
+			await Promise.allSettled([...pendingStdioWrites].map(pending => pending.completion));
 		}
 	};
-	// stdio announces readiness immediately; the UDS server announces it per client connection.
-	if (!options?.listen) {
-		output({ type: "ready" });
-	}
+	const handleStdioWriteFailure = (failure: unknown): boolean => {
+		const code = sinkErrorCode(failure);
+		if (
+			isKnownSinkPeerClosedError(failure) &&
+			(code === "EPIPE" || (stdioPeerClosed && code === "ERR_STREAM_DESTROYED"))
+		) {
+			stdioPeerClosed = true;
+			if (stdioTransportState === "open") stdioTransportState = "terminalizing";
+			settlePendingStdioWrites(false);
+			beginStdioTerminalization?.();
+			return false;
+		}
+		if (!hasStdioWriteFailure) {
+			hasStdioWriteFailure = true;
+			stdioWriteFailure = failure;
+			stdioTransportState = "terminalizing";
+			stdioFatalFailure.reject(failure);
+			settlePendingStdioWrites(true, failure);
+			beginStdioTerminalization?.();
+		}
+		return true;
+	};
+	const onStdioError = (failure: Error): void => {
+		handleStdioWriteFailure(failure);
+	};
+	if (!options?.listen) process.stdout.on("error", onStdioError);
+	const writeStdioFrame = (line: string): Promise<void> => {
+		if (stdioTransportState !== "open") return Promise.resolve();
+		const completion = Promise.withResolvers<void>();
+		let settled = false;
+		let pending: { completion: Promise<void>; settle: (failed: boolean, failure?: unknown) => void };
+		pending = {
+			completion: completion.promise,
+			settle: (failed, failure) => {
+				if (settled) return;
+				settled = true;
+				pendingStdioWrites.delete(pending);
+				if (failed) completion.reject(failure);
+				else completion.resolve();
+			},
+		};
+		pendingStdioWrites.add(pending);
+		try {
+			process.stdout.write(line, writeError => {
+				if (settled) return;
+				if (writeError) pending.settle(handleStdioWriteFailure(writeError), writeError);
+				else pending.settle(false);
+			});
+		} catch (failure) {
+			pending.settle(handleStdioWriteFailure(failure), failure);
+		}
+		return completion.promise;
+	};
+	let frameSink: (line: string) => void | Promise<void> = options?.listen ? noopSink : writeStdioFrame;
+	const output: RpcOutput = obj => {
+		if (!options?.listen && stdioTransportState !== "open") return Promise.resolve();
+		let emission: Promise<void>;
+		try {
+			emission = Promise.resolve(frameSink(`${JSON.stringify(obj)}\n`));
+		} catch (failure) {
+			emission = Promise.reject(failure);
+			if (!options?.listen) handleStdioWriteFailure(failure);
+		}
+		void emission.catch(() => {});
+		return emission;
+	};
 	const emitRpcTitles = shouldEmitRpcTitles();
 	const rpcCapabilities = { compactMessageUpdate: false };
 	const decodeError = (err: unknown): string => (err instanceof Error ? err.message : String(err));
@@ -350,7 +435,9 @@ export async function runRpcMode(
 	const unattendedControlPlane = new UnattendedSessionControlPlane({
 		runId: session.sessionId,
 		sessionId: session.sessionId,
-		emitFrame: gate => output(gate),
+		emitFrame: gate => {
+			void output(gate);
+		},
 		store: gateStore,
 		audit: recordAudit,
 		providerSupportsTokenCostMetrics: modelSupportsTokenCostMetrics(session.model),
@@ -359,45 +446,71 @@ export async function runRpcMode(
 			return { tokens: stats.tokens.total, costUsd: stats.cost };
 		},
 	});
-	unattendedControlPlane
-		.recover()
-		.catch(err =>
-			output(error(undefined, "workflow_gate_recover", err instanceof Error ? err.message : String(err))),
-		);
+	unattendedControlPlane.recover().catch(err => {
+		void output(error(undefined, "workflow_gate_recover", err instanceof Error ? err.message : String(err)));
+	});
 	session.setWorkflowGateEmitter(unattendedControlPlane);
 
 	// Shutdown request flag (wrapped in object to allow mutation with const)
 	const shutdownState = { requested: false };
-	let shutdownStarted = false;
+	let detachStdioInput: (() => void) | undefined;
+	let closeCommandScheduler: (() => void) | undefined;
+	let shutdownPromise: Promise<never> | undefined;
+	let shutdownExitCode = 0;
+	let suppressShutdownProtocolOutput = false;
+	let shutdownDispatchStopped = false;
 	// Tracks in-flight non-blocking command handlers so shutdown can drain them.
 	const inFlightCommands = new Set<Promise<void>>();
-	async function shutdown(exitCode: number, reason: string): Promise<never> {
-		if (shutdownStarted) {
-			process.exit(exitCode);
+	function shutdown(
+		exitCode: number,
+		reason: string,
+		suppressProtocolOutput = false,
+		stopDispatch = true,
+	): Promise<never> {
+		shutdownExitCode = Math.max(shutdownExitCode, exitCode);
+		suppressShutdownProtocolOutput ||= suppressProtocolOutput;
+		if (stopDispatch && !shutdownDispatchStopped) {
+			shutdownDispatchStopped = true;
+			closeCommandScheduler?.();
+			detachStdioInput?.();
 		}
-		shutdownStarted = true;
-		// Let in-flight non-blocking commands (bash/compact/handoff) finish and emit
-		// their responses before teardown, bounded so a never-resolving login cannot
-		// wedge shutdown (issue 13).
-		if (inFlightCommands.size > 0) {
-			await Promise.race([Promise.allSettled([...inFlightCommands]), Bun.sleep(5000)]);
-		}
-		await unregisterRpcSession(session.sessionId).catch(() => {});
-		hostToolBridge.rejectAllPending(`${reason} before host tool execution completed`);
-		hostUriBridge.clear(`${reason} before host URI request completed`);
-		try {
-			await session.sessionManager.ensureOnDisk();
-		} catch (err) {
-			output(error(undefined, "shutdown", decodeError(err)));
-			process.exit(1);
-		}
-		try {
-			await session.dispose();
-		} catch (err) {
-			output(error(undefined, "shutdown", decodeError(err)));
-			process.exit(1);
-		}
-		process.exit(exitCode);
+		if (shutdownPromise) return shutdownPromise;
+		shutdownPromise = (async () => {
+			// Let in-flight non-blocking commands (bash/compact/handoff) finish and emit
+			// their responses before teardown, bounded so a never-resolving login cannot
+			// wedge shutdown (issue 13).
+			if (inFlightCommands.size > 0) {
+				await Promise.race([Promise.allSettled([...inFlightCommands]), Bun.sleep(5000)]);
+			}
+			if (!options?.listen) await waitForStdioWrites();
+			await unregisterRpcSession(session.sessionId).catch(() => {});
+			hostToolBridge.rejectAllPending(`${reason} before host tool execution completed`);
+			hostUriBridge.clear(`${reason} before host URI request completed`);
+			let cleanupFailure: unknown;
+			try {
+				await session.sessionManager.ensureOnDisk();
+			} catch (failure) {
+				cleanupFailure = failure;
+			}
+			try {
+				await session.dispose();
+			} catch (failure) {
+				if (cleanupFailure === undefined) cleanupFailure = failure;
+			}
+			if (cleanupFailure !== undefined && !suppressShutdownProtocolOutput) {
+				await output(error(undefined, "shutdown", decodeError(cleanupFailure))).catch(() => {});
+			}
+			if (!options?.listen) {
+				await waitForStdioWrites();
+				process.stdout.removeListener("error", onStdioError);
+				stdioTransportState = "closed";
+			}
+			const terminalFailure = hasStdioWriteFailure ? stdioWriteFailure : cleanupFailure;
+			const finalExitCode = terminalFailure !== undefined || hasStdioWriteFailure ? 1 : shutdownExitCode;
+			process.exit(finalExitCode);
+			return await new Promise<never>(() => {});
+		})();
+		return shutdownPromise;
 	}
 
 	/**
@@ -406,7 +519,7 @@ export async function runRpcMode(
 	class RpcExtensionUIContext implements ExtensionUIContext {
 		constructor(
 			private pendingRequests: Map<string, PendingExtensionRequest>,
-			private output: (obj: RpcResponse | RpcExtensionUIRequest | object) => void,
+			private output: RpcOutput,
 		) {}
 
 		/** Helper for dialog methods with signal/timeout support */
@@ -674,17 +787,38 @@ export async function runRpcMode(
 	// fast-lane command reach a long-running `bash`/`compact`/`handoff`/`login`
 	// instead of being head-of-line-blocked behind it (issue 13).
 	const runCommand = async (command: RpcCommand): Promise<void> => {
+		let response: RpcResponse;
 		try {
-			output(await handleCommand(command));
+			response = await handleCommand(command);
 		} catch (err) {
-			output(error(command.id, command.type, decodeError(err)));
+			response = error(command.id, command.type, decodeError(err));
 		}
+		await output(response);
 	};
 	const trackCommand = (task: Promise<void>): void => {
 		inFlightCommands.add(task);
-		void task.finally(() => inFlightCommands.delete(task));
+		void task.then(
+			() => inFlightCommands.delete(task),
+			() => inFlightCommands.delete(task),
+		);
 	};
-	const { dispatch: dispatchCommand } = createRpcCommandScheduler(runCommand, trackCommand);
+	const scheduler = createRpcCommandScheduler(runCommand, trackCommand);
+	const dispatchCommand = scheduler.dispatch;
+	closeCommandScheduler = scheduler.close;
+	let stdioTerminalizationStarted = false;
+	beginStdioTerminalization = () => {
+		if (options?.listen || stdioTerminalizationStarted) return;
+		stdioTerminalizationStarted = true;
+		closeCommandScheduler?.();
+		detachStdioInput?.();
+		void session.abort({ timeoutMs: 5000, cause: "internal", silent: true }).catch(() => {});
+		void shutdown(
+			hasStdioWriteFailure ? 1 : 0,
+			hasStdioWriteFailure ? "RPC stdout write failed" : "RPC stdout peer disconnected",
+			true,
+		).catch(() => {});
+	};
+	if (stdioTransportState !== "open") beginStdioTerminalization();
 
 	/**
 	 * Check if shutdown was requested and perform shutdown if so.
@@ -699,17 +833,24 @@ export async function runRpcMode(
 	// persistent UDS server so both transports use the same command surface.
 	const inputDecoder = new TextDecoder("utf-8", { fatal: false });
 	async function handleInboundLine(text: string): Promise<void> {
+		if (!options?.listen && stdioTransportState !== "open") return;
 		let parsed: unknown;
+		let parseFailure: RpcResponse | undefined;
 		try {
 			parsed = JSON.parse(text);
 		} catch (err) {
-			output(error(undefined, "parse", `Failed to parse command: ${decodeError(err)}`));
+			parseFailure = error(undefined, "parse", `Failed to parse command: ${decodeError(err)}`);
+		}
+		if (parseFailure) {
+			output(parseFailure);
 			return;
 		}
+
+		let response: RpcResponse | undefined;
 		try {
 			if ((parsed as RpcExtensionUIResponse).type === "extension_ui_response") {
-				const response = parsed as RpcExtensionUIResponse;
-				pendingExtensionRequests.get(response.id)?.resolve(response);
+				const extensionResponse = parsed as RpcExtensionUIResponse;
+				pendingExtensionRequests.get(extensionResponse.id)?.resolve(extensionResponse);
 				return;
 			}
 			if (isRpcHostToolResult(parsed)) {
@@ -731,22 +872,21 @@ export async function runRpcMode(
 				const requested = Array.isArray(command.capabilities) ? command.capabilities : [];
 				const acceptedCapabilities = requested.filter(capability => capability === "compact_message_update");
 				rpcCapabilities.compactMessageUpdate = acceptedCapabilities.includes("compact_message_update");
-				output(
-					rpcSuccess(command.id, "set_capabilities", {
-						acceptedCapabilities,
-						unsupported: requested.filter(capability => capability !== "compact_message_update"),
-					}),
-				);
-				return;
+				response = rpcSuccess(command.id, "set_capabilities", {
+					acceptedCapabilities,
+					unsupported: requested.filter(capability => capability !== "compact_message_update"),
+				});
+			} else {
+				// Ordered commands run through a serial chain to preserve causal order; the
+				// reader never blocks, so cancellation commands stay responsive even while a
+				// long command is in flight (issue 13).
+				dispatchCommand(parsed as RpcCommand);
+				await checkShutdownRequested();
 			}
-			// Ordered commands run through a serial chain to preserve causal order; the
-			// reader never blocks, so cancellation commands stay responsive even while a
-			// long command is in flight (issue 13).
-			dispatchCommand(parsed as RpcCommand);
-			await checkShutdownRequested();
 		} catch (err) {
-			output(error(undefined, "parse", `Failed to parse command: ${decodeError(err)}`));
+			response = error(undefined, "parse", `Failed to parse command: ${decodeError(err)}`);
 		}
+		if (response) output(response);
 	}
 
 	// Persistent UDS server (issue 09): keep the AgentSession alive across client
@@ -766,9 +906,24 @@ export async function runRpcMode(
 			endpoint: socketPath,
 		}).catch(() => {});
 
-		const noopSink = (_line: string): void => {};
-		let currentSocket: object | undefined;
+		let currentSocket: Bun.Socket | undefined;
 		let buf = "";
+		const detachCurrentSocket = (socket: Bun.Socket): void => {
+			if (socket !== currentSocket) return;
+			currentSocket = undefined;
+			frameSink = noopSink;
+		};
+		const socketIsLocallyTerminal = (socket: Bun.Socket): boolean => socket.readyState <= 0;
+		const handleSocketFailure = (socket: Bun.Socket, failure: unknown): void => {
+			if (socket !== currentSocket) return;
+			const code = sinkErrorCode(failure);
+			const peerClosed =
+				isKnownSinkPeerClosedError(failure) &&
+				(code === "EPIPE" || (code === "ERR_STREAM_DESTROYED" && socketIsLocallyTerminal(socket)));
+			detachCurrentSocket(socket);
+			if (peerClosed) return;
+			void shutdown(1, "RPC socket output failed", true).catch(() => {});
+		};
 		const server = Bun.listen({
 			unix: socketPath,
 			socket: {
@@ -776,9 +931,23 @@ export async function runRpcMode(
 					currentSocket = socket;
 					buf = "";
 					frameSink = (line: string) => {
-						socket.write(line);
+						if (socket !== currentSocket) return;
+						try {
+							const written = socket.write(line);
+							if (written >= 0) return;
+							if (socketIsLocallyTerminal(socket)) {
+								detachCurrentSocket(socket);
+								return;
+							}
+							handleSocketFailure(
+								socket,
+								Object.assign(new Error("RPC socket write failed"), { code: "ERR_STREAM_DESTROYED" }),
+							);
+						} catch (failure) {
+							handleSocketFailure(socket, failure);
+						}
 					};
-					output({ type: "ready" });
+					void output({ type: "ready" });
 				},
 				data(socket, data) {
 					if (socket !== currentSocket) return;
@@ -792,12 +961,11 @@ export async function runRpcMode(
 					}
 				},
 				close(socket) {
-					if (socket === currentSocket) {
-						currentSocket = undefined;
-						frameSink = noopSink;
-					}
+					detachCurrentSocket(socket);
 				},
-				error() {},
+				error(socket, failure) {
+					handleSocketFailure(socket, failure);
+				},
 			},
 		});
 		await verifyRpcSocketAfterListen(socketPath);
@@ -825,13 +993,37 @@ export async function runRpcMode(
 
 	// Listen for JSONL input using Bun's stdin. Parse frame-by-frame so a malformed
 	// command reports a parse error without poisoning the whole long-lived RPC session.
-	for await (const line of readLines(Bun.stdin.stream())) {
-		const text = inputDecoder.decode(line).trim();
-		if (!text) continue;
-		await handleInboundLine(text);
+	const inputLines = readLines(Bun.stdin.stream());
+	const inputIterator = inputLines[Symbol.asyncIterator]();
+	detachStdioInput = () => {
+		const detached = inputIterator.return?.(undefined);
+		if (detached) void detached.catch(() => {});
+	};
+	let inputFailure: unknown;
+	try {
+		await output({ type: "ready" });
+		while (stdioTransportState === "open") {
+			const next = await Promise.race([inputIterator.next(), stdioFatalFailure.promise]);
+			if (next.done) break;
+			const text = inputDecoder.decode(next.value).trim();
+			if (text) await handleInboundLine(text);
+		}
+	} catch (failure) {
+		inputFailure = failure;
+	} finally {
+		detachStdioInput = undefined;
 	}
-
-	// stdin closed — RPC client is gone, flush durable state and exit cleanly
-	await shutdown(0, "RPC client disconnected");
-	throw new Error("RPC shutdown returned unexpectedly");
+	if (inputFailure !== undefined) {
+		return await shutdown(
+			1,
+			hasStdioWriteFailure ? "RPC stdout write failed" : "RPC stdin failed",
+			hasStdioWriteFailure,
+		);
+	}
+	if (stdioTransportState === "open") return await shutdown(0, "RPC client disconnected", false, false);
+	return await shutdown(
+		hasStdioWriteFailure ? 1 : 0,
+		hasStdioWriteFailure ? "RPC stdout write failed" : "RPC stdout peer disconnected",
+		true,
+	);
 }

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -11,7 +11,7 @@
  * - Extension UI: Extension UI requests are emitted, client responds with extension_ui_response
  */
 
-import { $pickenv, logger, readLines, Snowflake } from "@gajae-code/utils";
+import { $pickenv, isBrokenPipeError, logger, readLines, Snowflake } from "@gajae-code/utils";
 import type {
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
@@ -289,7 +289,16 @@ export async function runRpcMode(
 		process.stdout.write(line);
 	};
 	const output = (obj: RpcResponse | RpcExtensionUIRequest | object) => {
-		frameSink(`${JSON.stringify(obj)}\n`);
+		try {
+			frameSink(`${JSON.stringify(obj)}\n`);
+		} catch (err) {
+			// The frame consumer (stdio parent or UDS client) vanished mid-write.
+			// Dropping the frame beats crashing the whole RPC server; the sink is
+			// swappable (--listen serves later clients), so do not latch it dead —
+			// just skip frames while the current peer is gone.
+			if (!isBrokenPipeError(err)) throw err;
+			logger.debug("RPC frame dropped: sink pipe is broken", { type: (obj as { type?: string }).type });
+		}
 	};
 	// stdio announces readiness immediately; the UDS server announces it per client connection.
 	if (!options?.listen) {

--- a/packages/coding-agent/test/coordinator-mcp/pump.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp/pump.test.ts
@@ -14,10 +14,12 @@ const line = (id: number, method = "data") => `${JSON.stringify({ jsonrpc: "2.0"
 
 function deferred<T = void>() {
 	let resolve!: (v: T) => void;
-	const promise = new Promise<T>(r => {
-		resolve = r;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
 	});
-	return { promise, resolve };
+	return { promise, resolve, reject };
 }
 
 /** Controllable async-iterable stdin: push frames, then close() to signal EOF. */
@@ -178,19 +180,141 @@ describe("pumpCoordinatorMcpStream — EOF drain", () => {
 });
 
 describe("pumpCoordinatorMcpStream — writer robustness", () => {
-	it("treats a writeLine failure as terminal without unhandled rejection or chain poisoning", async () => {
+	it("quietly terminalizes on a coded structural EPIPE without waiting for input EOF", async () => {
 		let writeCalls = 0;
+		const epipe = Object.assign(new Error("peer closed"), { code: "EPIPE" });
 		const writeLine = () => {
 			writeCalls += 1;
-			throw new Error("EPIPE");
+			throw epipe;
 		};
 		const handler = async (req: Rpc): Promise<Rpc> => ({ jsonrpc: "2.0", id: req.id ?? null, result: {} });
 		const ch = channel();
+		const pump = pumpCoordinatorMcpStream(handler as never, ch, writeLine);
+		ch.push(line(1));
+		await expect(
+			Promise.race([pump, Bun.sleep(100).then(() => Promise.reject(new Error("pump waited for EOF")))]),
+		).resolves.toBeUndefined();
+		expect(writeCalls).toBe(1); // terminalized after the first failed owned-sink write
+	});
+
+	it("does not promote queued side-effecting work after the peer closes", async () => {
+		const gate = deferred();
+		const dispatched: Array<string | number | null | undefined> = [];
+		const epipe = Object.assign(new Error("peer closed"), { code: "EPIPE" });
+		const handler = async (req: Rpc): Promise<Rpc> => {
+			dispatched.push(req.id);
+			if (req.id === 1) await gate.promise;
+			return { jsonrpc: "2.0", id: req.id ?? null, result: {} };
+		};
+		const ch = channel();
+		const pump = pumpCoordinatorMcpStream(
+			handler as never,
+			ch,
+			() => {
+				throw epipe;
+			},
+			{ maxDataConcurrency: 1 },
+		);
+		ch.push(line(1));
+		ch.push(line(2));
+		await tick();
+		expect(dispatched).toEqual([1]);
+		gate.resolve();
+		await pump;
+		expect(dispatched).toEqual([1]);
+	});
+
+	it("suppresses writes from already-running work after a coded peer closure", async () => {
+		const first = deferred();
+		const second = deferred();
+		let writeCalls = 0;
+		const epipe = Object.assign(new Error("peer closed"), { code: "EPIPE" });
+		const handler = async (req: Rpc): Promise<Rpc> => {
+			if (req.id === 1) await first.promise;
+			else await second.promise;
+			return { jsonrpc: "2.0", id: req.id ?? null, result: {} };
+		};
+		const ch = channel();
+		const pump = pumpCoordinatorMcpStream(
+			handler as never,
+			ch,
+			() => {
+				writeCalls += 1;
+				throw epipe;
+			},
+			{ maxDataConcurrency: 2 },
+		);
+		ch.push(line(1));
+		ch.push(line(2));
+		await tick();
+		first.resolve();
+		await tick();
+		second.resolve();
+		await pump;
+		expect(writeCalls).toBe(1);
+	});
+
+	it("propagates non-pipe writer faults", async () => {
+		const failure = Object.assign(new Error("write failed"), { code: "EIO" });
+		const handler = async (req: Rpc): Promise<Rpc> => ({ jsonrpc: "2.0", id: req.id ?? null, result: {} });
+		const ch = channel();
+		const pump = pumpCoordinatorMcpStream(handler as never, ch, () => {
+			throw failure;
+		});
+		ch.push(line(1));
+		await expect(pump).rejects.toBe(failure);
+	});
+
+	it("propagates a deferred asynchronous writer failure", async () => {
+		const failure = Object.assign(new Error("write failed"), { code: "EIO" });
+		const completion = deferred<void>();
+		const handler = async (req: Rpc): Promise<Rpc> => ({ jsonrpc: "2.0", id: req.id ?? null, result: {} });
+		const ch = channel();
+		const pump = pumpCoordinatorMcpStream(handler as never, ch, () => completion.promise);
+		ch.push(line(1));
+		await tick();
+		completion.reject(failure);
+		await expect(pump).rejects.toBe(failure);
+	});
+
+	it("bounds a never-settling writer and suppresses queued late emissions", async () => {
+		const firstWrite = deferred<void>();
+		let writeCalls = 0;
+		const handler = async (req: Rpc): Promise<Rpc> => ({ jsonrpc: "2.0", id: req.id ?? null, result: {} });
+		const ch = channel();
+		const pump = pumpCoordinatorMcpStream(
+			handler as never,
+			ch,
+			() => {
+				writeCalls += 1;
+				return firstWrite.promise;
+			},
+			{ maxDataConcurrency: 2, drainTimeoutMs: 20 },
+		);
 		ch.push(line(1));
 		ch.push(line(2));
 		ch.close();
-		await expect(pumpCoordinatorMcpStream(handler as never, ch, writeLine)).resolves.toBeUndefined();
-		expect(writeCalls).toBe(1); // closed after the first failure; no write-after-close
+		await expect(
+			Promise.race([
+				pump,
+				Bun.sleep(250).then(() => Promise.reject(new Error("pump waited for a never-settling write"))),
+			]),
+		).resolves.toBeUndefined();
+		expect(writeCalls).toBe(1);
+		firstWrite.resolve();
+		await tick();
+		expect(writeCalls).toBe(1);
+	});
+
+	it("does not treat ERR_STREAM_DESTROYED as a peer closure before terminality is proven", async () => {
+		const failure = Object.assign(new Error("destroyed"), { code: "ERR_STREAM_DESTROYED" });
+		const handler = async (req: Rpc): Promise<Rpc> => ({ jsonrpc: "2.0", id: req.id ?? null, result: {} });
+		const ch = channel();
+		const pump = pumpCoordinatorMcpStream(handler as never, ch, () => {
+			throw failure;
+		});
+		ch.push(line(1));
+		await expect(pump).rejects.toBe(failure);
 	});
 });
 

--- a/packages/coding-agent/test/rpc-listen-socket-guard.test.ts
+++ b/packages/coding-agent/test/rpc-listen-socket-guard.test.ts
@@ -1,18 +1,137 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { chmod, mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import * as net from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { isUnixSocketAlive, RpcListenRefusedError } from "@gajae-code/coding-agent/modes/rpc/rpc-mode";
 import { prepareRpcSocketPath } from "@gajae-code/coding-agent/modes/rpc/rpc-socket-security";
+import { createHarnessCliEnv, type HarnessCliEnv } from "./harness-control-plane/cli-workspace-env";
 
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+const fixtureModelsYaml = `providers:
+  rpc-test:
+    auth: none
+    api: openai-responses
+    baseUrl: http://127.0.0.1:9/v1
+    models:
+      - id: rpc-test-model
+        contextWindow: 100000
+        maxTokens: 4096
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+`;
+
+type Frame = { type?: string; id?: string; success?: boolean; command?: string };
+
+interface SocketClient {
+	send(frame: object): void;
+	nextFrame(timeoutMs?: number): Promise<Frame>;
+	close(): void;
+}
+
+async function connectRpcSocket(socketPath: string): Promise<SocketClient> {
+	const frames: Frame[] = [];
+	const waiters: Array<(frame: Frame) => void> = [];
+	const decoder = new TextDecoder();
+	let buffer = "";
+	const socket = await Bun.connect({
+		unix: socketPath,
+		socket: {
+			data(_socket, bytes) {
+				buffer += decoder.decode(bytes);
+				while (true) {
+					const newline = buffer.indexOf("\n");
+					if (newline < 0) break;
+					const line = buffer.slice(0, newline).trim();
+					buffer = buffer.slice(newline + 1);
+					if (!line) continue;
+					const frame = JSON.parse(line) as Frame;
+					const waiter = waiters.shift();
+					if (waiter) waiter(frame);
+					else frames.push(frame);
+				}
+			},
+		},
+	});
+	return {
+		send(frame: object): void {
+			socket.write(`${JSON.stringify(frame)}\n`);
+		},
+		nextFrame(timeoutMs = 10_000): Promise<Frame> {
+			const queued = frames.shift();
+			if (queued) return Promise.resolve(queued);
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			return new Promise<Frame>((resolve, reject) => {
+				timer = setTimeout(() => reject(new Error("Timed out waiting for RPC socket frame")), timeoutMs);
+				waiters.push(frame => {
+					if (timer) clearTimeout(timer);
+					resolve(frame);
+				});
+			});
+		},
+		close(): void {
+			socket.end();
+		},
+	};
+}
+
+async function waitForSocket(socketPath: string): Promise<void> {
+	const deadline = Date.now() + 15_000;
+	while (Date.now() < deadline) {
+		try {
+			await stat(socketPath);
+			return;
+		} catch {
+			await Bun.sleep(25);
+		}
+	}
+	throw new Error(`Timed out waiting for RPC socket ${socketPath}`);
+}
+
+function spawnRpcSocketServer(socketPath: string) {
+	return Bun.spawn(
+		[
+			"bun",
+			cliEntry,
+			"--mode",
+			"rpc",
+			"--provider",
+			"rpc-test",
+			"--model",
+			"rpc-test-model",
+			"--session-dir",
+			path.join(dir, "sessions"),
+			"--listen",
+			socketPath,
+		],
+		{
+			cwd: dir,
+			env: { ...cliEnv.env, GJC_HARNESS_STATE_ROOT: dir, NO_COLOR: "1", PI_NOTIFICATIONS: "off" },
+			stdin: "ignore",
+			stdout: "pipe",
+			stderr: "pipe",
+		},
+	);
+}
 let dir: string;
+let cliEnv: HarnessCliEnv;
 
 beforeEach(async () => {
 	dir = await mkdtemp(path.join(tmpdir(), "rpc-listen-guard-"));
+	cliEnv = createHarnessCliEnv(repoRoot);
+	const agentDir = path.join(dir, ".gjc", "agent");
+	await mkdir(agentDir, { recursive: true });
+	await writeFile(path.join(agentDir, "models.yml"), fixtureModelsYaml);
+	cliEnv.env.GJC_CODING_AGENT_DIR = agentDir;
+	cliEnv.env.PI_CODING_AGENT_DIR = agentDir;
 });
 
 afterEach(async () => {
+	cliEnv.cleanup();
 	await rm(dir, { recursive: true, force: true });
 });
 
@@ -86,4 +205,56 @@ describe("--listen duplicate refusal boundary (issue 19)", () => {
 			await new Promise<void>(resolve => server.close(() => resolve()));
 		}
 	});
+});
+
+describe("--listen active-socket sink lifecycle", () => {
+	it("keeps a newer socket after stale closure and survives a current-client response race", async () => {
+		const socketPath = path.join(dir, "sink-lifecycle.sock");
+		const proc = spawnRpcSocketServer(socketPath);
+		let first: SocketClient | undefined;
+		let second: SocketClient | undefined;
+		let third: SocketClient | undefined;
+		try {
+			await waitForSocket(socketPath);
+			first = await connectRpcSocket(socketPath);
+			expect(await first.nextFrame()).toEqual({ type: "ready" });
+
+			second = await connectRpcSocket(socketPath);
+			expect(await second.nextFrame()).toEqual({ type: "ready" });
+			first.close(); // Its later close callback must not detach the newer sink.
+			await Bun.sleep(50);
+
+			second.send({ id: "second-state", type: "get_state" });
+			expect(await second.nextFrame()).toMatchObject({
+				id: "second-state",
+				type: "response",
+				command: "get_state",
+				success: true,
+			});
+			second.send({ id: "current-close", type: "get_state" });
+			second.close();
+			await Bun.sleep(50);
+			expect(
+				await Promise.race([
+					proc.exited.then(() => "exited" as const),
+					Bun.sleep(50).then(() => "running" as const),
+				]),
+			).toBe("running");
+
+			third = await connectRpcSocket(socketPath);
+			expect(await third.nextFrame()).toEqual({ type: "ready" });
+			third.send({ id: "third-state", type: "get_state" });
+			expect(await third.nextFrame()).toMatchObject({
+				id: "third-state",
+				type: "response",
+				command: "get_state",
+				success: true,
+			});
+		} finally {
+			first?.close();
+			second?.close();
+			third?.close();
+			proc.kill();
+		}
+	}, 45_000);
 });

--- a/packages/coding-agent/test/rpc-stdio-redteam.test.ts
+++ b/packages/coding-agent/test/rpc-stdio-redteam.test.ts
@@ -39,6 +39,8 @@ interface RpcHarness {
 	nextFrame(timeoutMs?: number): Promise<Frame>;
 	send(command: object | string): void;
 	closeStdin(): Promise<void>;
+	closeStdout(): Promise<void>;
+
 	kill(): void;
 }
 
@@ -137,6 +139,11 @@ function spawnRpcServer(options: { cwd?: string; sessionDir?: string } = {}): Rp
 				if (timer) clearTimeout(timer);
 			}
 		},
+		async closeStdout(): Promise<void> {
+			const closed = lines.return?.(undefined);
+			if (closed) await closed;
+		},
+
 		send(command: object | string): void {
 			const line = typeof command === "string" ? command : JSON.stringify(command);
 			proc.stdin.write(`${line}\n`);
@@ -219,6 +226,23 @@ describe("gjc --mode rpc red-team stdio lifecycle", () => {
 		}
 	}, 30_000);
 
+	it("terminalizes quietly after stdout closes without waiting for stdin EOF", async () => {
+		const harness = spawnRpcServer();
+		try {
+			expect(await harness.nextFrame()).toEqual({ type: "ready" });
+			await harness.closeStdout();
+			harness.send({ id: "trigger-epipe", type: "get_state" });
+			const exitCode = await Promise.race([
+				harness.proc.exited,
+				Bun.sleep(10_000).then(() => Promise.reject(new Error("RPC waited for stdin EOF after stdout closed"))),
+			]);
+			expect(exitCode).toBe(0);
+			expect((await harness.stderrText).trim()).toBe("");
+		} finally {
+			harness.kill();
+		}
+	}, 30_000);
+
 	it("flushes durable session state on EOF and reloads it in a new RPC process", async () => {
 		const marker = "RPC_PERSISTENCE_MARKER";
 		const firstRun = await driveRpcServer([
@@ -247,6 +271,20 @@ describe("gjc --mode rpc red-team stdio lifecycle", () => {
 		]);
 		expect(secondRun.exitCode, secondRun.stderr).toBe(0);
 		expect(findResponse(secondRun.frames, "switch")).toMatchObject({ success: true, data: { cancelled: false } });
+	}, 30_000);
+
+	it("drains ordered mutation responses before immediate stdin EOF", async () => {
+		const result = await driveRpcServer([
+			{ id: "first-name", type: "set_session_name", name: "first" },
+			{ id: "second-name", type: "set_session_name", name: "second" },
+		]);
+		expect(result.exitCode, result.stderr).toBe(0);
+		const firstIndex = result.frames.findIndex(frame => frame.type === "response" && frame.id === "first-name");
+		const secondIndex = result.frames.findIndex(frame => frame.type === "response" && frame.id === "second-name");
+		expect(firstIndex).toBeGreaterThanOrEqual(0);
+		expect(secondIndex).toBeGreaterThan(firstIndex);
+		expect(findResponse(result.frames, "first-name")).toMatchObject({ success: true, command: "set_session_name" });
+		expect(findResponse(result.frames, "second-name")).toMatchObject({ success: true, command: "set_session_name" });
 	}, 30_000);
 
 	it("survives a malformed JSONL frame and accepts the next command", async () => {

--- a/packages/coding-agent/test/silent-abort-print-mode.test.ts
+++ b/packages/coding-agent/test/silent-abort-print-mode.test.ts
@@ -1,10 +1,4 @@
-/**
- * Regression: print-mode must not write SILENT_ABORT_MARKER to stderr.
- *
- * OpenAI code backend review flagged that `print-mode.ts` renders `errorMessage` verbatim
- * when stopReason is "aborted", which would surface the sentinel to stderr
- * (and exit with code 1). This test verifies the guard skips silent-abort.
- */
+/** Print-mode output, terminal-status, and stdout-ownership regressions. */
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { AssistantMessage, Message, ToolResultMessage } from "@gajae-code/ai";
 import type { AgentSession } from "../src/session/agent-session";
@@ -31,7 +25,40 @@ function makeAssistantMessage(overrides: Partial<AssistantMessage> = {}): Assist
 	};
 }
 
-/** Minimal mock of AgentSession for print-mode text output path */
+function makeToolResultMessage(): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "call_1",
+		toolName: "read",
+		content: [{ type: "text", text: "file contents" }],
+		isError: false,
+		timestamp: Date.now(),
+	} as ToolResultMessage;
+}
+
+function invokeWriteCallback(args: unknown[], error?: Error): void {
+	const callback = args[args.length - 1];
+	if (typeof callback === "function") callback(error);
+}
+
+function installImmediateStderrMock(output: string[]): void {
+	vi.spyOn(process.stderr, "write").mockImplementation((...args: unknown[]) => {
+		output.push(String(args[0]));
+		invokeWriteCallback(args);
+		return true;
+	});
+}
+
+function installImmediateStdoutMock(output: string[] = []): void {
+	vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
+		const chunk = args[0];
+		if (typeof chunk === "string" && chunk.length > 0) output.push(chunk);
+		invokeWriteCallback(args);
+		return true;
+	});
+}
+
+/** Minimal mock of the AgentSession text-output path. */
 function createMockSession(
 	messages: Message[],
 	opts?: { contextWindow?: number; autoCompactionEnabled?: boolean },
@@ -50,31 +77,90 @@ function createMockSession(
 	} as unknown as AgentSession;
 }
 
-describe("Print-mode silent-abort regression", () => {
-	let exitSpy: ReturnType<typeof vi.spyOn>;
-	let stderrOutput: string[];
+function eventName(event: unknown): string {
+	if (typeof event === "object" && event !== null && "type" in event) return String(event.type);
+	return String(event);
+}
+
+function createPrintModeTrackingSession(
+	options: {
+		messages?: Message[];
+		header?: unknown;
+		events?: unknown[];
+		disposeEvents?: unknown[];
+		disposeError?: unknown;
+		onDispose?: () => void;
+	} = {},
+) {
+	const { messages = [], header, events = [], disposeEvents = [], disposeError, onDispose } = options;
+	const lifecycle: string[] = [];
+	let onEvent: ((event: unknown) => void) | undefined;
+	let unsubscribeCount = 0;
+	const emit = (event: unknown): void => {
+		lifecycle.push(`emit:${eventName(event)}`);
+		onEvent?.(event);
+	};
+	const dispose = vi.fn(async () => {
+		lifecycle.push("dispose:start");
+		for (const event of disposeEvents) emit(event);
+		onDispose?.();
+		lifecycle.push("dispose:end");
+		if (disposeError !== undefined) throw disposeError;
+	});
+	const prompt = vi.fn(async () => {
+		lifecycle.push("prompt:start");
+		for (const event of events) emit(event);
+		lifecycle.push("prompt:end");
+	});
+	const session = {
+		state: { messages },
+		sessionManager: { getHeader: () => header },
+		extensionRunner: undefined,
+		subscribe: (listener: (event: unknown) => void) => {
+			lifecycle.push("subscribe");
+			onEvent = listener;
+			return () => {
+				lifecycle.push("unsubscribe");
+				onEvent = undefined;
+				unsubscribeCount += 1;
+			};
+		},
+		prompt,
+		dispose,
+	} as unknown as AgentSession;
+
+	return {
+		session,
+		dispose,
+		prompt,
+		lifecycle,
+		unsubscribeCount: () => unsubscribeCount,
+	};
+}
+
+function stdoutError(code: string): Error & { code: string } {
+	return Object.assign(new Error(`stdout ${code}`), { code });
+}
+
+describe("Print mode", () => {
+	let previousExitCode: number | string | null | undefined;
 
 	beforeEach(() => {
-		stderrOutput = [];
-		vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
-			stderrOutput.push(String(chunk));
-			return true;
-		});
-		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-		vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
-			// Invoke callback if present (runPrintMode flushes stdout before returning)
-			const last = args[args.length - 1];
-			if (typeof last === "function") last();
-			return true;
-		});
+		previousExitCode = process.exitCode;
+		process.exitCode = 0;
 	});
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+		process.exitCode = previousExitCode ?? 0;
 	});
 
-	it("does not write silent-abort marker to stderr or exit non-zero", async () => {
+	it("does not render a silent-abort marker or overwrite a caller status", async () => {
 		const { runPrintMode } = await import("../src/modes/print-mode");
+		const stderrOutput: string[] = [];
+		installImmediateStderrMock(stderrOutput);
+		installImmediateStdoutMock();
+		process.exitCode = 19;
 
 		const silentAbortMsg = makeAssistantMessage({
 			stopReason: "aborted",
@@ -82,188 +168,349 @@ describe("Print-mode silent-abort regression", () => {
 			content: [],
 		});
 
-		const session = createMockSession([silentAbortMsg]);
-		await runPrintMode(session, { mode: "text" });
+		await runPrintMode(createMockSession([silentAbortMsg]), { mode: "text" });
 
-		// The silent-abort marker MUST NOT appear in stderr
-		const stderrText = stderrOutput.join("");
-		expect(stderrText).not.toContain(SILENT_ABORT_MARKER);
-		// process.exit MUST NOT have been called (clean termination)
+		expect(stderrOutput.join("")).not.toContain(SILENT_ABORT_MARKER);
+		expect(process.exitCode).toBe(19);
+	});
+
+	it("sets ordinary terminal errors to status 1 without calling process.exit", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+		const stderrOutput: string[] = [];
+		installImmediateStderrMock(stderrOutput);
+		installImmediateStdoutMock();
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+		await runPrintMode(
+			createMockSession([
+				makeAssistantMessage({ stopReason: "error", errorMessage: "Rate limit exceeded", content: [] }),
+			]),
+			{ mode: "text" },
+		);
+
+		expect(stderrOutput.join("")).toContain("Rate limit exceeded");
+		expect(process.exitCode).toBe(1);
 		expect(exitSpy).not.toHaveBeenCalled();
 	});
 
-	it("writes real error messages to stderr and exits non-zero", async () => {
+	it("leaves terminal status unchanged when the caller suppresses print-mode status handling", async () => {
 		const { runPrintMode } = await import("../src/modes/print-mode");
+		const stderrOutput: string[] = [];
+		installImmediateStderrMock(stderrOutput);
+		installImmediateStdoutMock();
+		process.exitCode = 23;
 
-		const errorMsg = makeAssistantMessage({
-			stopReason: "error",
-			errorMessage: "Rate limit exceeded",
-			content: [],
-		});
+		await runPrintMode(
+			createMockSession([
+				makeAssistantMessage({ stopReason: "error", errorMessage: "delegated failure", content: [] }),
+			]),
+			{ mode: "text", suppressProcessExit: true },
+		);
 
-		const session = createMockSession([errorMsg]);
-		await runPrintMode(session, { mode: "text" });
-
-		// A real error SHOULD be written to stderr
-		const stderrText = stderrOutput.join("");
-		expect(stderrText).toContain("Rate limit exceeded");
-		// process.exit(1) SHOULD have been called
-		expect(exitSpy).toHaveBeenCalledWith(1);
-	});
-});
-
-function makeToolResultMessage(): ToolResultMessage {
-	return {
-		role: "toolResult",
-		toolCallId: "call_1",
-		toolName: "read",
-		content: [{ type: "text", text: "file contents" }],
-		isError: false,
-		timestamp: Date.now(),
-	} as ToolResultMessage;
-}
-
-describe("Print-mode last-assistant output regression (#484)", () => {
-	let stdoutOutput: string[];
-
-	beforeEach(() => {
-		stdoutOutput = [];
-		vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-		vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-		vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
-			const chunk = args[0];
-			if (typeof chunk === "string" && chunk.length > 0) stdoutOutput.push(chunk);
-			const last = args[args.length - 1];
-			if (typeof last === "function") last();
-			return true;
-		});
+		expect(stderrOutput.join("")).toContain("delegated failure");
+		expect(process.exitCode).toBe(23);
 	});
 
-	afterEach(() => {
-		vi.restoreAllMocks();
-	});
-
-	it("prints last assistant text even when a toolResult trails it", async () => {
+	it("prints the last assistant text after a trailing tool result without changing an existing success-path status", async () => {
 		const { runPrintMode } = await import("../src/modes/print-mode");
+		const stdoutOutput: string[] = [];
+		installImmediateStderrMock([]);
+		installImmediateStdoutMock(stdoutOutput);
+		process.exitCode = 0;
 
-		const assistantMsg = makeAssistantMessage({
-			content: [{ type: "text", text: "@gajae-code/coding-agent" }],
-		});
-		// Cursor native tool execution can append a toolResult after the assistant reply.
-		const session = createMockSession([assistantMsg, makeToolResultMessage()]);
-		await runPrintMode(session, { mode: "text" });
+		const assistantMsg = makeAssistantMessage({ content: [{ type: "text", text: "@gajae-code/coding-agent" }] });
+		await runPrintMode(createMockSession([assistantMsg, makeToolResultMessage()]), { mode: "text" });
 
-		const stdoutText = stdoutOutput.join("");
-		expect(stdoutText).toContain("@gajae-code/coding-agent");
-	});
-});
-
-/**
- * Contract: in TEXT mode only, a terminal context-overflow assistant message is
- * surfaced with an actionable diagnostic and a distinct exit code
- * (CONTEXT_OVERFLOW_EXIT_CODE) so `gjc -p` callers can detect context exhaustion.
- * JSON mode is intentionally out of scope (it streams events and never runs this
- * terminal branch) — the last test documents that boundary.
- */
-describe("Print-mode context-overflow terminal handling (text mode)", () => {
-	let exitSpy: ReturnType<typeof vi.spyOn>;
-	let stderrOutput: string[];
-
-	beforeEach(() => {
-		stderrOutput = [];
-		vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
-			stderrOutput.push(String(chunk));
-			return true;
-		});
-		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-		vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
-			const last = args[args.length - 1];
-			if (typeof last === "function") last();
-			return true;
-		});
+		expect(stdoutOutput.join("")).toContain("@gajae-code/coding-agent");
+		expect(process.exitCode).toBe(0);
 	});
 
-	afterEach(() => {
-		vi.restoreAllMocks();
-	});
-
-	it("emits an actionable diagnostic and a distinct exit code on context overflow", async () => {
+	it("sets context overflow to status 78 after an immediate stderr write without calling process.exit", async () => {
 		const { runPrintMode, CONTEXT_OVERFLOW_EXIT_CODE } = await import("../src/modes/print-mode");
-
-		// The exact string a Codex/OpenAI-code backend surfaces on context_length_exceeded.
-		const overflowMsg = makeAssistantMessage({
+		const stderrOutput: string[] = [];
+		installImmediateStderrMock(stderrOutput);
+		installImmediateStdoutMock();
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+		const overflow = makeAssistantMessage({
 			stopReason: "error",
 			errorMessage:
 				"Codex error event: Your input exceeds the context window of this model. Please adjust your input and try again. (code=context_length_exceeded)",
 			content: [],
 		});
 
-		const session = createMockSession([overflowMsg], { contextWindow: 272000, autoCompactionEnabled: true });
-		await runPrintMode(session, { mode: "text" });
+		await runPrintMode(createMockSession([overflow], { contextWindow: 272000, autoCompactionEnabled: true }), {
+			mode: "text",
+		});
 
-		const stderrText = stderrOutput.join("");
-		// Actionable guidance replaces the opaque provider crash line.
-		expect(stderrText).toContain("Context window exhausted");
-		expect(stderrText).toContain("larger-context model");
-		// Raw provider detail is preserved for debugging.
-		expect(stderrText).toContain("context_length_exceeded");
-		// Distinct exit code so text-mode automation can detect context exhaustion.
-		expect(exitSpy).toHaveBeenCalledWith(CONTEXT_OVERFLOW_EXIT_CODE);
-		expect(exitSpy).not.toHaveBeenCalledWith(1);
+		expect(CONTEXT_OVERFLOW_EXIT_CODE).toBe(78);
+		expect(stderrOutput.join("")).toContain("Context window exhausted");
+		expect(stderrOutput.join("")).toContain("context_length_exceeded");
+		expect(process.exitCode).toBe(78);
+		expect(exitSpy).not.toHaveBeenCalled();
 	});
 
-	it("tells the operator to enable auto-compaction when it is disabled", async () => {
+	it("waits for a backpressured stderr write before disposal while retaining status 1", async () => {
 		const { runPrintMode } = await import("../src/modes/print-mode");
-
-		const overflowMsg = makeAssistantMessage({
-			stopReason: "error",
-			errorMessage: "prompt is too long: 300000 tokens > 272000 maximum",
-			content: [],
+		const stderrOutput: string[] = [];
+		let stderrQuiesced = false;
+		let stderrQuiescedWhenDisposed: boolean | undefined;
+		vi.spyOn(process.stderr, "write").mockImplementation((...args: unknown[]) => {
+			stderrOutput.push(String(args[0]));
+			queueMicrotask(() => {
+				stderrQuiesced = true;
+				invokeWriteCallback(args);
+			});
+			return false;
+		});
+		installImmediateStdoutMock();
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+		const tracking = createPrintModeTrackingSession({
+			messages: [makeAssistantMessage({ stopReason: "error", errorMessage: "temporary failure", content: [] })],
+			onDispose: () => {
+				stderrQuiescedWhenDisposed = stderrQuiesced;
+			},
 		});
 
-		const session = createMockSession([overflowMsg], { contextWindow: 272000, autoCompactionEnabled: false });
-		await runPrintMode(session, { mode: "text" });
+		await runPrintMode(tracking.session, { mode: "text" });
 
-		const stderrText = stderrOutput.join("");
-		expect(stderrText).toContain("automatic compaction is disabled");
+		expect(stderrOutput.join("")).toContain("temporary failure");
+		expect(stderrQuiescedWhenDisposed).toBe(true);
+		expect(process.exitCode).toBe(1);
+		expect(exitSpy).not.toHaveBeenCalled();
 	});
 
-	it("still exits 1 with the raw message for non-overflow errors", async () => {
+	it("keeps context-overflow terminal handling out of JSON mode", async () => {
 		const { runPrintMode, CONTEXT_OVERFLOW_EXIT_CODE } = await import("../src/modes/print-mode");
-
-		const errorMsg = makeAssistantMessage({
-			stopReason: "error",
-			errorMessage: "Internal server error (status=500)",
-			content: [],
-		});
-
-		const session = createMockSession([errorMsg], { contextWindow: 272000, autoCompactionEnabled: true });
-		await runPrintMode(session, { mode: "text" });
-
-		const stderrText = stderrOutput.join("");
-		expect(stderrText).toContain("Internal server error");
-		expect(stderrText).not.toContain("Context window exhausted");
-		expect(exitSpy).toHaveBeenCalledWith(1);
-		expect(exitSpy).not.toHaveBeenCalledWith(CONTEXT_OVERFLOW_EXIT_CODE);
-	});
-
-	it("scope boundary: JSON mode does not apply the context-overflow exit code", async () => {
-		const { runPrintMode, CONTEXT_OVERFLOW_EXIT_CODE } = await import("../src/modes/print-mode");
-
-		// Same terminal overflow message, but JSON mode streams events and never runs
-		// the text-mode terminal-error branch, so the exit code is intentionally not applied.
-		const overflowMsg = makeAssistantMessage({
+		const stderrOutput: string[] = [];
+		installImmediateStderrMock(stderrOutput);
+		installImmediateStdoutMock();
+		const overflow = makeAssistantMessage({
 			stopReason: "error",
 			errorMessage:
 				"Codex error event: Your input exceeds the context window of this model. (code=context_length_exceeded)",
 			content: [],
 		});
 
-		const session = createMockSession([overflowMsg], { contextWindow: 272000, autoCompactionEnabled: true });
-		await runPrintMode(session, { mode: "json" });
+		await runPrintMode(createMockSession([overflow], { contextWindow: 272000, autoCompactionEnabled: true }), {
+			mode: "json",
+		});
 
-		const stderrText = stderrOutput.join("");
-		expect(stderrText).not.toContain("Context window exhausted");
-		expect(exitSpy).not.toHaveBeenCalledWith(CONTEXT_OVERFLOW_EXIT_CODE);
+		expect(stderrOutput.join("")).not.toContain("Context window exhausted");
+		expect(process.exitCode).not.toBe(CONTEXT_OVERFLOW_EXIT_CODE);
+	});
+
+	it("does not install a text-mode session listener", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+		installImmediateStderrMock([]);
+		installImmediateStdoutMock();
+		const tracking = createPrintModeTrackingSession({
+			messages: [makeAssistantMessage({ content: [{ type: "text", text: "text only" }] })],
+		});
+
+		await runPrintMode(tracking.session, { mode: "text" });
+
+		expect(tracking.lifecycle).toEqual(["dispose:start", "dispose:end"]);
+		expect(tracking.unsubscribeCount()).toBe(0);
+	});
+
+	it("continues JSON event processing after a callback EPIPE and disposes before unsubscribing", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+		installImmediateStderrMock([]);
+		const tracking = createPrintModeTrackingSession({
+			header: { type: "session", id: "header" },
+			events: [
+				{ type: "message_update", id: "first" },
+				{ type: "message_update", id: "second" },
+			],
+		});
+		const output: string[] = [];
+		let writeCount = 0;
+		const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
+			writeCount += 1;
+			output.push(String(args[0]));
+			invokeWriteCallback(args, writeCount === 2 ? stdoutError("EPIPE") : undefined);
+			return true;
+		});
+
+		await runPrintMode(tracking.session, { mode: "json", initialMessage: "continue" });
+
+		expect(tracking.prompt).toHaveBeenCalledTimes(1);
+		expect(tracking.lifecycle).toEqual([
+			"subscribe",
+			"prompt:start",
+			"emit:message_update",
+			"emit:message_update",
+			"prompt:end",
+			"dispose:start",
+			"dispose:end",
+			"unsubscribe",
+		]);
+		expect(writeSpy).toHaveBeenCalledTimes(2);
+		expect(output).toEqual(['{"type":"session","id":"header"}\n', '{"type":"message_update","id":"first"}\n']);
+		expect(tracking.dispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("continues JSON event processing after an owned stdout EPIPE event", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+		installImmediateStderrMock([]);
+		const tracking = createPrintModeTrackingSession({
+			header: { type: "session", id: "header" },
+			events: [
+				{ type: "message_update", id: "first" },
+				{ type: "message_update", id: "second" },
+			],
+		});
+		let writeCount = 0;
+		const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
+			writeCount += 1;
+			if (writeCount === 2) process.stdout.emit("error", stdoutError("EPIPE"));
+			else invokeWriteCallback(args);
+			return true;
+		});
+
+		await runPrintMode(tracking.session, { mode: "json", initialMessage: "continue" });
+
+		expect(tracking.prompt).toHaveBeenCalledTimes(1);
+		expect(tracking.lifecycle.filter(entry => entry === "emit:message_update")).toHaveLength(2);
+		expect(writeSpy).toHaveBeenCalledTimes(2);
+		expect(tracking.dispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("propagates a non-pipe stdout callback failure after session disposal", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+		installImmediateStderrMock([]);
+		const failure = new Error("stdout callback failed");
+		const tracking = createPrintModeTrackingSession({
+			messages: [makeAssistantMessage({ content: [{ type: "text", text: "draft" }] })],
+		});
+		vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
+			invokeWriteCallback(args, failure);
+			return true;
+		});
+
+		await expect(runPrintMode(tracking.session, { mode: "text" })).rejects.toBe(failure);
+
+		expect(tracking.dispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("propagates a non-pipe stdout EventEmitter failure after session disposal", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+		installImmediateStderrMock([]);
+		const failure = new Error("stdout event failed");
+		const tracking = createPrintModeTrackingSession({
+			messages: [makeAssistantMessage({ content: [{ type: "text", text: "draft" }] })],
+		});
+		vi.spyOn(process.stdout, "write").mockImplementation(() => {
+			process.stdout.emit("error", failure);
+			return true;
+		});
+
+		await expect(runPrintMode(tracking.session, { mode: "text" })).rejects.toBe(failure);
+
+		expect(tracking.dispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps the JSON subscriber through disposal-time output and late stdout errors", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+		installImmediateStderrMock([]);
+		const tracking = createPrintModeTrackingSession({
+			disposeEvents: [{ type: "session_disposed", id: "final" }],
+		});
+		const output: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
+			const chunk = String(args[0]);
+			output.push(chunk);
+			if (chunk.includes("session_disposed")) process.stdout.emit("error", stdoutError("EPIPE"));
+			else invokeWriteCallback(args);
+			return true;
+		});
+
+		await runPrintMode(tracking.session, { mode: "json" });
+
+		expect(output).toContain('{"type":"session_disposed","id":"final"}\n');
+		expect(tracking.lifecycle).toEqual([
+			"subscribe",
+			"dispose:start",
+			"emit:session_disposed",
+			"dispose:end",
+			"unsubscribe",
+		]);
+		expect(tracking.dispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not suppress ERR_STREAM_DESTROYED before an EPIPE has latched", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+		installImmediateStderrMock([]);
+		const destroyed = stdoutError("ERR_STREAM_DESTROYED");
+		const tracking = createPrintModeTrackingSession({
+			messages: [makeAssistantMessage({ content: [{ type: "text", text: "draft" }] })],
+		});
+		vi.spyOn(process.stdout, "write").mockImplementation(() => {
+			throw destroyed;
+		});
+
+		await expect(runPrintMode(tracking.session, { mode: "text" })).rejects.toBe(destroyed);
+
+		expect(tracking.dispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("suppresses a destroyed-stream error only after an owned EPIPE latches", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+		installImmediateStderrMock([]);
+		const tracking = createPrintModeTrackingSession({
+			messages: [makeAssistantMessage({ content: [{ type: "text", text: "draft" }] })],
+			onDispose: () => {
+				process.stdout.emit("error", stdoutError("ERR_STREAM_DESTROYED"));
+			},
+		});
+		vi.spyOn(process.stdout, "write").mockImplementation(() => {
+			throw stdoutError("EPIPE");
+		});
+
+		await runPrintMode(tracking.session, { mode: "text" });
+
+		expect(tracking.dispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves both a stdout failure and a disposal failure", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+		installImmediateStderrMock([]);
+		const writeFailure = new Error("stdout write failed");
+		const disposeFailure = new Error("dispose failed");
+		const tracking = createPrintModeTrackingSession({
+			messages: [makeAssistantMessage({ content: [{ type: "text", text: "draft" }] })],
+			disposeError: disposeFailure,
+		});
+		vi.spyOn(process.stdout, "write").mockImplementation(() => {
+			throw writeFailure;
+		});
+
+		let caught: unknown;
+		try {
+			await runPrintMode(tracking.session, { mode: "text" });
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(AggregateError);
+		expect((caught as AggregateError).errors).toEqual([writeFailure, disposeFailure]);
+		expect(tracking.dispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("removes only the stdout listener it owns", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+		installImmediateStderrMock([]);
+		const externalListener = () => {};
+		process.stdout.on("error", externalListener);
+		const listenerCount = process.stdout.listenerCount("error");
+		installImmediateStdoutMock();
+
+		try {
+			await runPrintMode(createPrintModeTrackingSession().session, { mode: "text" });
+			expect(process.stdout.listenerCount("error")).toBe(listenerCount);
+			expect(process.stdout.listeners("error")).toContain(externalListener);
+		} finally {
+			process.stdout.removeListener("error", externalListener);
+		}
 	});
 });

--- a/packages/coding-agent/test/startup-update-contract.test.ts
+++ b/packages/coding-agent/test/startup-update-contract.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { getBundledModel } from "@gajae-code/ai";
-import { TempDir } from "@gajae-code/utils";
+import { postmortem, TempDir } from "@gajae-code/utils";
 import type { Args } from "../src/cli/args";
 import { Settings } from "../src/config/settings";
 import { SETTINGS_SCHEMA } from "../src/config/settings-schema";
@@ -280,6 +280,44 @@ describe("startup update contract", () => {
 			}
 		}
 	}, 30_000);
+
+	it("preserves print-mode status and does not dispose the session twice", async () => {
+		using tempDir = TempDir.createSync("@gjc-print-exit-");
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const originalNoTitle = Bun.env.PI_NO_TITLE;
+		const originalExitCode = process.exitCode;
+		let disposeCalls = 0;
+		const quitSpy = vi.spyOn(postmortem, "quit").mockResolvedValue(undefined);
+		const sessionResult = fakeSessionResult();
+		sessionResult.session.dispose = async () => {
+			disposeCalls += 1;
+		};
+
+		try {
+			process.exitCode = 0;
+			await runRootCommand(rootArgs({ mode: "text" }), [], {
+				createAgentSession: async () => sessionResult,
+				discoverAuthStorage: async () => authStorage,
+				settings: Settings.isolated({ "marketplace.autoUpdate": "off", "startup.checkUpdate": false }),
+				initTheme: async () => {},
+				readPipedInput: async () => undefined,
+				runStartupCredentialAutoImportIfNeeded: async () => undefined,
+				runPrintMode: async session => {
+					process.exitCode = 78;
+					await session.dispose();
+				},
+			});
+
+			expect(disposeCalls).toBe(1);
+			expect(quitSpy).toHaveBeenCalledWith(78);
+		} finally {
+			vi.restoreAllMocks();
+			process.exitCode = originalExitCode ?? 0;
+			authStorage.close();
+			if (originalNoTitle === undefined) delete Bun.env.PI_NO_TITLE;
+			else Bun.env.PI_NO_TITLE = originalNoTitle;
+		}
+	});
 
 	it("runs the real root and interactive-mode path without awaiting the version check", async () => {
 		using tempDir = TempDir.createSync("@gjc-startup-interactive-");

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Broken output pipes no longer crash the process with a fatal internal-error dump. When an uncaught exception or unhandled rejection carries `EPIPE`/`ERR_STREAM_DESTROYED` (the consumer of stdout/stderr or another pipe exited early, e.g. `gjc --help | head -1`), the postmortem handlers now run cleanup and exit quietly with code 141 (128 + SIGPIPE), matching standard CLI pipeline semantics. Non-pipe fatal errors keep the existing dump and exit code 1. A shared `isBrokenPipeError` / `BROKEN_PIPE_EXIT_CODE` is exported for stream writers.
+- Broken stdout pipes no longer crash early CLI output with a fatal internal-error dump. The process-level fallback exits quietly with numeric status 141 only for `EPIPE` observed directly from `process.stdout.write` or carrying `syscall: "write"` with an open descriptor matching stdout or the same unchanged pipe identity; unrelated socket/child-pipe errors, unattributed `EPIPE`, and process-level `ERR_STREAM_DESTROYED` keep the existing fatal diagnostics and status 1. Local output owners use separate sink-aware classification so expected peer closure does not become a universal process policy.
 
 ## [0.9.6] - 2026-07-10
 ### Fixed

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Broken output pipes no longer crash the process with a fatal internal-error dump. When an uncaught exception or unhandled rejection carries `EPIPE`/`ERR_STREAM_DESTROYED` (the consumer of stdout/stderr or another pipe exited early, e.g. `gjc --help | head -1`), the postmortem handlers now run cleanup and exit quietly with code 141 (128 + SIGPIPE), matching standard CLI pipeline semantics. Non-pipe fatal errors keep the existing dump and exit code 1. A shared `isBrokenPipeError` / `BROKEN_PIPE_EXIT_CODE` is exported for stream writers.
+
 ## [0.9.6] - 2026-07-10
 ### Fixed
 

--- a/packages/utils/src/broken-pipe.ts
+++ b/packages/utils/src/broken-pipe.ts
@@ -1,21 +1,127 @@
 /**
- * Broken-pipe (EPIPE) classification shared by output-stream writers.
+ * Broken-pipe classification for writers that own a local output sink and for
+ * the process-wide postmortem fallback.
  *
- * Under Bun a non-TTY `process.stdout`/`process.stderr` is an fs write stream
- * over a pipe fd; once the consumer exits (`gjc --help | head -1`), the next
- * write throws EPIPE synchronously. Node surfaces the same condition as an
- * async stream `'error'` event (`EPIPE` / `ERR_STREAM_DESTROYED`). Either way
- * it means "the reader went away" — a normal CLI shutdown condition, not an
- * internal error.
+ * A local writer may classify its own sink closure from the error code. The
+ * process-wide fallback is deliberately stricter: an `EPIPE` must be
+ * attributable to process stdout before it receives SIGPIPE-style shutdown.
  */
+import * as fs from "node:fs";
 
-const BROKEN_PIPE_ERROR_CODES = new Set(["EPIPE", "ERR_STREAM_DESTROYED"]);
+const KNOWN_SINK_PEER_CLOSED_CODES = new Set(["EPIPE", "ERR_STREAM_DESTROYED"]);
 
-/** True when `error` reports a write against a pipe/stream whose peer is gone. */
+type ErrorProperty = "code" | "fd" | "syscall";
+
+interface ErrorPropertyRead {
+	available: boolean;
+	value: unknown;
+}
+
+function isObjectLike(value: unknown): value is object {
+	return value !== null && (typeof value === "object" || typeof value === "function");
+}
+
+function readErrorProperty(error: object, property: ErrorProperty): ErrorPropertyRead {
+	try {
+		return { available: true, value: Reflect.get(error, property) };
+	} catch {
+		return { available: false, value: undefined };
+	}
+}
+
+function isUsableFileDescriptor(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+interface FileIdentity {
+	dev: number | bigint;
+	ino: number | bigint;
+}
+
+function fileIdentity(fd: number): FileIdentity | undefined {
+	try {
+		const stat = fs.fstatSync(fd);
+		return { dev: stat.dev, ino: stat.ino };
+	} catch {
+		return undefined;
+	}
+}
+
+function sameFileIdentity(left: FileIdentity, right: FileIdentity): boolean {
+	return left.dev === right.dev && left.ino === right.ino;
+}
+
+/**
+ * True when an error from a writer that owns its sink reports that the peer
+ * closed that sink. This intentionally accepts structural error objects rather
+ * than requiring an `Error` instance.
+ */
+export function isKnownSinkPeerClosedError(error: unknown): boolean {
+	if (!isObjectLike(error)) return false;
+	const code = readErrorProperty(error, "code");
+	return code.available && typeof code.value === "string" && KNOWN_SINK_PEER_CLOSED_CODES.has(code.value);
+}
+
+/**
+ * Backward-compatible local-sink classifier for output writers. Callers must
+ * use it only when they own the sink that produced the error.
+ */
 export function isBrokenPipeError(error: unknown): boolean {
-	if (!(error instanceof Error) || !("code" in error)) return false;
-	const code = (error as NodeJS.ErrnoException).code;
-	return typeof code === "string" && BROKEN_PIPE_ERROR_CODES.has(code);
+	return isKnownSinkPeerClosedError(error);
+}
+
+/**
+ * A classifier for process-level stdout `EPIPE` errors. Its direct-write
+ * evidence is private to each factory instance, so only the owner that
+ * intercepted `process.stdout.write` can mark an error for this classifier.
+ */
+export interface ProcessStdoutEpipeClassifier {
+	markDirectProcessStdoutWriteError(error: unknown): void;
+	isAttributableProcessStdoutEpipe(error: unknown): boolean;
+}
+
+export function createProcessStdoutEpipeClassifier(): ProcessStdoutEpipeClassifier {
+	const directProcessStdoutWriteErrors = new WeakSet<object>();
+	const initialStdoutIdentity = isUsableFileDescriptor(process.stdout.fd)
+		? fileIdentity(process.stdout.fd)
+		: undefined;
+
+	const hasCurrentStdoutIdentity = (fd: number): boolean => {
+		if (!initialStdoutIdentity) return false;
+		let stdoutFd: number;
+		try {
+			stdoutFd = process.stdout.fd;
+		} catch {
+			return false;
+		}
+		if (!isUsableFileDescriptor(stdoutFd)) return false;
+		const currentStdoutIdentity = fileIdentity(stdoutFd);
+		const errorFdIdentity = fileIdentity(fd);
+		if (!currentStdoutIdentity || !errorFdIdentity) return false;
+		if (!sameFileIdentity(currentStdoutIdentity, initialStdoutIdentity)) return false;
+		return fd === stdoutFd || sameFileIdentity(errorFdIdentity, currentStdoutIdentity);
+	};
+
+	return {
+		markDirectProcessStdoutWriteError(error: unknown): void {
+			if (isObjectLike(error)) directProcessStdoutWriteErrors.add(error);
+		},
+		isAttributableProcessStdoutEpipe(error: unknown): boolean {
+			if (!isObjectLike(error)) return false;
+
+			const code = readErrorProperty(error, "code");
+			if (!code.available || code.value !== "EPIPE") return false;
+
+			if (directProcessStdoutWriteErrors.has(error)) return true;
+
+			const syscall = readErrorProperty(error, "syscall");
+			if (!syscall.available || syscall.value !== "write") return false;
+
+			const fd = readErrorProperty(error, "fd");
+			if (!fd.available || !isUsableFileDescriptor(fd.value)) return false;
+
+			return hasCurrentStdoutIdentity(fd.value);
+		},
+	};
 }
 
 /**

--- a/packages/utils/src/broken-pipe.ts
+++ b/packages/utils/src/broken-pipe.ts
@@ -1,0 +1,26 @@
+/**
+ * Broken-pipe (EPIPE) classification shared by output-stream writers.
+ *
+ * Under Bun a non-TTY `process.stdout`/`process.stderr` is an fs write stream
+ * over a pipe fd; once the consumer exits (`gjc --help | head -1`), the next
+ * write throws EPIPE synchronously. Node surfaces the same condition as an
+ * async stream `'error'` event (`EPIPE` / `ERR_STREAM_DESTROYED`). Either way
+ * it means "the reader went away" — a normal CLI shutdown condition, not an
+ * internal error.
+ */
+
+const BROKEN_PIPE_ERROR_CODES = new Set(["EPIPE", "ERR_STREAM_DESTROYED"]);
+
+/** True when `error` reports a write against a pipe/stream whose peer is gone. */
+export function isBrokenPipeError(error: unknown): boolean {
+	if (!(error instanceof Error) || !("code" in error)) return false;
+	const code = (error as NodeJS.ErrnoException).code;
+	return typeof code === "string" && BROKEN_PIPE_ERROR_CODES.has(code);
+}
+
+/**
+ * Exit code for a producer terminated because its output pipe broke:
+ * 128 + SIGPIPE (13), matching what shells report for SIGPIPE-killed tools
+ * in `foo | head`-style pipelines.
+ */
+export const BROKEN_PIPE_EXIT_CODE = 141;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,6 @@
 export { createAbortableStream, once, untilAborted } from "./abortable";
 export * from "./async";
+export * from "./broken-pipe";
 export * from "./color";
 export * from "./dirs";
 export * from "./env";

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -167,10 +167,12 @@ async function handleFatalError(label: string, reason: unknown, cleanupReason: R
 	process.exitCode = 1;
 	const err = errorForDiagnostic(reason);
 	safeStderrWrite(formatFatalError(label, err));
-	logger.error(label === "Uncaught Exception" ? "Uncaught exception" : "Unhandled rejection", {
-		err,
-		stack: err.stack,
-	});
+	if (!quietShutdownStarted) {
+		logger.error(label === "Uncaught Exception" ? "Uncaught exception" : "Unhandled rejection", {
+			err,
+			stack: err.stack,
+		});
+	}
 	await runCleanupAndWait(cleanupReason);
 	process.exit(1);
 }

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -7,7 +7,7 @@
  */
 import inspector from "node:inspector";
 import { isMainThread } from "node:worker_threads";
-import { BROKEN_PIPE_EXIT_CODE, isBrokenPipeError } from "./broken-pipe";
+import { BROKEN_PIPE_EXIT_CODE, createProcessStdoutEpipeClassifier } from "./broken-pipe";
 import * as logger from "./logger";
 import { safeStderrWrite } from "./safe-stderr";
 
@@ -23,10 +23,24 @@ export enum Reason {
 	MANUAL = "manual", // Manual cleanup (not triggered by process)
 }
 
+interface CleanupOptions {
+	quiet?: boolean;
+}
+
+type StdoutWriteCallback = (error?: Error | null) => void;
+
 // Internal list of active cleanup callbacks (in registration order)
 const callbackList: ((reason: Reason) => Promise<void> | void)[] = [];
 // Tracks cleanup run state (to prevent recursion/reentry issues)
 let cleanupStage: "idle" | "running" | "complete" = "idle";
+let cleanupPromise: Promise<void> | undefined;
+let quietShutdownStarted = false;
+let ordinaryFatalStarted = false;
+const stdoutEpipeClassifier = createProcessStdoutEpipeClassifier();
+
+function shouldSuppressCleanupLogging(quiet: boolean): boolean {
+	return quiet || quietShutdownStarted;
+}
 
 /**
  * Internal: runs all registered cleanup callbacks for the given reason.
@@ -34,36 +48,87 @@ let cleanupStage: "idle" | "running" | "complete" = "idle";
  *
  * Returns a Promise that settles after all cleanups complete or error out.
  */
-function runCleanup(reason: Reason): Promise<void> {
+function runCleanup(reason: Reason, options: CleanupOptions = {}): Promise<void> {
+	const quiet = options.quiet === true;
 	switch (cleanupStage) {
 		case "idle":
 			cleanupStage = "running";
 			break;
 		case "running":
-			if (reason === Reason.EXIT) {
-				return Promise.resolve();
+			if (reason !== Reason.EXIT && !shouldSuppressCleanupLogging(quiet)) {
+				logger.error("Cleanup invoked recursively", { stack: new Error().stack });
 			}
-			logger.error("Cleanup invoked recursively", { stack: new Error().stack });
 			return Promise.resolve();
 		case "complete":
 			return Promise.resolve();
 	}
 
+	const { promise, resolve } = Promise.withResolvers<void>();
+	cleanupPromise = promise;
+
 	// Call .cleanup() for each callback that is still "armed".
-	// Use Promise.try to handle sync/async, but only those armed.
+	// Assign the shared completion promise first so synchronous re-entry joins it.
 	const promises = callbackList.toReversed().map(callback => {
 		return Promise.try(() => callback(reason));
 	});
 
-	return Promise.allSettled(promises).then(results => {
-		for (const result of results) {
-			if (result.status === "rejected") {
-				const err = result.reason instanceof Error ? result.reason : new Error(String(result.reason));
-				logger.error("Cleanup callback failed", { err, stack: err.stack });
+	void Promise.allSettled(promises).then(results => {
+		try {
+			if (!shouldSuppressCleanupLogging(quiet)) {
+				for (const result of results) {
+					if (result.status === "rejected") {
+						const err = result.reason instanceof Error ? result.reason : new Error(String(result.reason));
+						logger.error("Cleanup callback failed", { err, stack: err.stack });
+					}
+				}
 			}
+		} finally {
+			cleanupStage = "complete";
+			resolve();
 		}
-		cleanupStage = "complete";
 	});
+	return promise;
+}
+
+async function runCleanupAndWait(reason: Reason, options: CleanupOptions = {}): Promise<void> {
+	void runCleanup(reason, options);
+	await (cleanupPromise ?? Promise.resolve());
+}
+
+function installProcessStdoutWriteClassifier(): void {
+	const originalWrite = process.stdout.write.bind(process.stdout);
+	const markCallback = (callback: StdoutWriteCallback): StdoutWriteCallback => {
+		return error => {
+			stdoutEpipeClassifier.markDirectProcessStdoutWriteError(error);
+			callback(error);
+		};
+	};
+
+	const markedWrite = (
+		chunk: string | Uint8Array,
+		encoding?: BufferEncoding | StdoutWriteCallback,
+		callback?: StdoutWriteCallback,
+	): boolean => {
+		try {
+			if (typeof encoding === "function") return originalWrite(chunk, markCallback(encoding));
+			if (callback) {
+				return typeof chunk === "string"
+					? originalWrite(chunk, encoding, markCallback(callback))
+					: originalWrite(chunk, markCallback(callback));
+			}
+			if (encoding === undefined) return originalWrite(chunk);
+			return typeof chunk === "string" ? originalWrite(chunk, encoding) : originalWrite(chunk);
+		} catch (error) {
+			stdoutEpipeClassifier.markDirectProcessStdoutWriteError(error);
+			throw error;
+		}
+	};
+
+	process.stdout.write = markedWrite as typeof process.stdout.write;
+}
+
+function errorForDiagnostic(reason: unknown): Error {
+	return reason instanceof Error ? reason : new Error(String(reason));
 }
 
 // Register signal and error event handlers to trigger cleanup before exit.
@@ -80,10 +145,41 @@ function formatFatalError(label: string, err: Error): string {
 	return `\n[${label}] ${name}: ${message}${formattedStack}\n`;
 }
 
+async function exitQuietlyForAttributableStdoutEpipe(reason: Reason): Promise<void> {
+	if (ordinaryFatalStarted || quietShutdownStarted) return;
+	quietShutdownStarted = true;
+	// Set the observable status before cleanup can await or trigger another error.
+	process.exitCode = BROKEN_PIPE_EXIT_CODE;
+	await runCleanupAndWait(reason, { quiet: true });
+	// An ordinary fatal that arrived during quiet cleanup takes precedence.
+	if (process.exitCode === BROKEN_PIPE_EXIT_CODE) process.exit(BROKEN_PIPE_EXIT_CODE);
+}
+
+async function handleFatalError(label: string, reason: unknown, cleanupReason: Reason): Promise<void> {
+	if (stdoutEpipeClassifier.isAttributableProcessStdoutEpipe(reason)) {
+		await exitQuietlyForAttributableStdoutEpipe(cleanupReason);
+		return;
+	}
+
+	// A distinct ordinary fatal must retain its normal diagnostic and status-1
+	// contract, including when it arrives while quiet cleanup is still pending.
+	ordinaryFatalStarted = true;
+	process.exitCode = 1;
+	const err = errorForDiagnostic(reason);
+	safeStderrWrite(formatFatalError(label, err));
+	logger.error(label === "Uncaught Exception" ? "Uncaught exception" : "Unhandled rejection", {
+		err,
+		stack: err.stack,
+	});
+	await runCleanupAndWait(cleanupReason);
+	process.exit(1);
+}
+
 if (isMainThread) {
+	installProcessStdoutWriteClassifier();
 	process
 		.on("SIGINT", async () => {
-			await runCleanup(Reason.SIGINT);
+			await runCleanupAndWait(Reason.SIGINT);
 			process.exit(130); // 128 + SIGINT (2)
 		})
 		.on("SIGUSR1", () => {
@@ -93,48 +189,21 @@ if (isMainThread) {
 			const url = inspector.url();
 			safeStderrWrite(`Inspector opened: ${url}\n`);
 		})
-		.on("uncaughtException", async err => {
-			if (isBrokenPipeError(err)) {
-				// The peer of one of our output pipes exited before we finished
-				// writing — typically a shell consumer of stdout, e.g.
-				// `gjc --help | head -1`. Standard CLI behavior is SIGPIPE
-				// semantics: terminate quietly instead of dumping a fatal
-				// internal-error report and failing with exit code 1. No logging
-				// here: a console log transport would write to the same broken
-				// pipe and re-enter this handler.
-				await runCleanup(Reason.UNCAUGHT_EXCEPTION);
-				process.exit(BROKEN_PIPE_EXIT_CODE);
-				return;
-			}
-			safeStderrWrite(formatFatalError("Uncaught Exception", err));
-			logger.error("Uncaught exception", { err, stack: err.stack });
-			await runCleanup(Reason.UNCAUGHT_EXCEPTION);
-			process.exit(1);
+		.on("uncaughtException", async error => {
+			await handleFatalError("Uncaught Exception", error, Reason.UNCAUGHT_EXCEPTION);
 		})
 		.on("unhandledRejection", async reason => {
-			const err = reason instanceof Error ? reason : new Error(String(reason));
-			if (isBrokenPipeError(err)) {
-				// A broken output pipe surfacing through a rejected write promise
-				// gets the same quiet-shutdown (and no-logging) policy as the
-				// uncaughtException broken-pipe branch above.
-				await runCleanup(Reason.UNHANDLED_REJECTION);
-				process.exit(BROKEN_PIPE_EXIT_CODE);
-				return;
-			}
-			safeStderrWrite(formatFatalError("Unhandled Rejection", err));
-			logger.error("Unhandled rejection", { err, stack: err.stack });
-			await runCleanup(Reason.UNHANDLED_REJECTION);
-			process.exit(1);
+			await handleFatalError("Unhandled Rejection", reason, Reason.UNHANDLED_REJECTION);
 		})
 		.on("exit", async () => {
 			void runCleanup(Reason.EXIT); // fire and forget (exit imminent)
 		})
 		.on("SIGTERM", async () => {
-			await runCleanup(Reason.SIGTERM);
+			await runCleanupAndWait(Reason.SIGTERM);
 			process.exit(143); // 128 + SIGTERM (15)
 		})
 		.on("SIGHUP", async () => {
-			await runCleanup(Reason.SIGHUP);
+			await runCleanupAndWait(Reason.SIGHUP);
 			process.exit(129); // 128 + SIGHUP (1)
 		});
 } else {
@@ -160,8 +229,9 @@ export function register(id: string, callback: (reason: Reason) => void | Promis
 		done = true;
 		try {
 			return callback(reason);
-		} catch (e) {
-			const err = e instanceof Error ? e : new Error(String(e));
+		} catch (error) {
+			if (quietShutdownStarted) return;
+			const err = error instanceof Error ? error : new Error(String(error));
 			logger.error("Cleanup callback failed", { err, id, stack: err.stack });
 		}
 	};
@@ -175,12 +245,20 @@ export function register(id: string, callback: (reason: Reason) => void | Promis
 	};
 
 	if (cleanupStage !== "idle") {
+		if (quietShutdownStarted) {
+			queueMicrotask(() => {
+				void Promise.try(() => exec(Reason.MANUAL)).catch(() => {});
+			});
+			return () => {
+				done = true;
+			};
+		}
 		// If cleanup is already running/completed, warn and run on microtask.
 		logger.warn("Cleanup invoked recursively", { id });
 		try {
 			callback(Reason.MANUAL);
-		} catch (e) {
-			const err = e instanceof Error ? e : new Error(String(e));
+		} catch (error) {
+			const err = error instanceof Error ? error : new Error(String(error));
 			logger.error("Cleanup callback failed", { err, id, stack: err.stack });
 		}
 		return () => {};
@@ -206,16 +284,28 @@ export function cleanup(): Promise<void> {
  * In workers: runs cleanup only (process.exit would kill entire process).
  */
 export async function quit(code: number = 0): Promise<void> {
-	await runCleanup(Reason.MANUAL);
+	const cleanupWasRunning = cleanupStage === "running";
+	void runCleanup(Reason.MANUAL);
+	const completion = cleanupPromise ?? Promise.resolve();
 
 	if (!isMainThread) {
-		return; // Workers: cleanup done, let worker exit naturally
+		if (!cleanupWasRunning) await completion;
+		return;
 	}
 
-	if (process.stdout.writableLength > 0) {
-		const { promise, resolve } = Promise.withResolvers<void>();
-		process.stdout.once("drain", resolve);
-		await Promise.race([promise, Bun.sleep(5000)]);
+	const exitAfterCleanup = async (): Promise<void> => {
+		await completion;
+		if (process.stdout.writableLength > 0) {
+			const { promise, resolve } = Promise.withResolvers<void>();
+			process.stdout.once("drain", resolve);
+			await Promise.race([promise, Bun.sleep(5000)]);
+		}
+		process.exit(code);
+	};
+
+	if (cleanupWasRunning) {
+		void exitAfterCleanup();
+		return;
 	}
-	process.exit(code);
+	await exitAfterCleanup();
 }

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -7,6 +7,7 @@
  */
 import inspector from "node:inspector";
 import { isMainThread } from "node:worker_threads";
+import { BROKEN_PIPE_EXIT_CODE, isBrokenPipeError } from "./broken-pipe";
 import * as logger from "./logger";
 import { safeStderrWrite } from "./safe-stderr";
 
@@ -93,6 +94,18 @@ if (isMainThread) {
 			safeStderrWrite(`Inspector opened: ${url}\n`);
 		})
 		.on("uncaughtException", async err => {
+			if (isBrokenPipeError(err)) {
+				// The peer of one of our output pipes exited before we finished
+				// writing — typically a shell consumer of stdout, e.g.
+				// `gjc --help | head -1`. Standard CLI behavior is SIGPIPE
+				// semantics: terminate quietly instead of dumping a fatal
+				// internal-error report and failing with exit code 1. No logging
+				// here: a console log transport would write to the same broken
+				// pipe and re-enter this handler.
+				await runCleanup(Reason.UNCAUGHT_EXCEPTION);
+				process.exit(BROKEN_PIPE_EXIT_CODE);
+				return;
+			}
 			safeStderrWrite(formatFatalError("Uncaught Exception", err));
 			logger.error("Uncaught exception", { err, stack: err.stack });
 			await runCleanup(Reason.UNCAUGHT_EXCEPTION);
@@ -100,6 +113,14 @@ if (isMainThread) {
 		})
 		.on("unhandledRejection", async reason => {
 			const err = reason instanceof Error ? reason : new Error(String(reason));
+			if (isBrokenPipeError(err)) {
+				// A broken output pipe surfacing through a rejected write promise
+				// gets the same quiet-shutdown (and no-logging) policy as the
+				// uncaughtException broken-pipe branch above.
+				await runCleanup(Reason.UNHANDLED_REJECTION);
+				process.exit(BROKEN_PIPE_EXIT_CODE);
+				return;
+			}
 			safeStderrWrite(formatFatalError("Unhandled Rejection", err));
 			logger.error("Unhandled rejection", { err, stack: err.stack });
 			await runCleanup(Reason.UNHANDLED_REJECTION);

--- a/packages/utils/test/postmortem-fixture.ts
+++ b/packages/utils/test/postmortem-fixture.ts
@@ -1,9 +1,16 @@
+import * as fs from "node:fs";
+
 import * as logger from "../src/logger";
 import * as postmortem from "../src/postmortem";
 
 logger.setTransports({ console: true, file: false });
 
 type ExitListener = (code?: number) => unknown;
+
+interface EpipeDetails {
+	fd?: number;
+	syscall?: string;
+}
 
 function getPostmortemExitListener(): ExitListener {
 	const listener = process.rawListeners("exit").at(-1);
@@ -15,6 +22,23 @@ function getPostmortemExitListener(): ExitListener {
 
 function writeResult(result: Record<string, unknown>): void {
 	process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+function epipeError(message: string, details: EpipeDetails): Error {
+	return Object.assign(new Error(message), { code: "EPIPE", ...details });
+}
+
+async function throwFromTimer(error: Error): Promise<void> {
+	setTimeout(() => {
+		throw error;
+	}, 10);
+	await Bun.sleep(2_000);
+}
+
+function writeUntilStdoutPipeBreaks(): void {
+	for (let i = 0; i < 256; i++) {
+		process.stdout.write(`${"x".repeat(8192)}\n`);
+	}
 }
 
 async function runExitReentryWhileRunning(): Promise<void> {
@@ -32,14 +56,42 @@ async function runExitReentryWhileRunning(): Promise<void> {
 
 async function runNonExitRecursiveCleanup(): Promise<void> {
 	let count = 0;
-	postmortem.register("fixture-non-exit-recursion", () => {
+	postmortem.register("fixture-non-exit-recursion", async () => {
 		count++;
-		void postmortem.cleanup();
+		await postmortem.cleanup();
 	});
 
 	await postmortem.cleanup();
 	await Bun.sleep(20);
 	writeResult({ count });
+}
+
+async function runQuitReentryWaitsForCleanup(): Promise<void> {
+	let count = 0;
+	let cleanupFinished = false;
+	let exitBeforeCleanupFinished = false;
+	const originalExit = process.exit;
+	process.exit = (() => {
+		exitBeforeCleanupFinished = !cleanupFinished;
+	}) as typeof process.exit;
+
+	try {
+		postmortem.register("fixture-quit-reentry-slow", async () => {
+			count++;
+			await Bun.sleep(20);
+			cleanupFinished = true;
+		});
+		postmortem.register("fixture-quit-reentry", () => {
+			count++;
+			void postmortem.quit();
+		});
+
+		await postmortem.cleanup();
+	} finally {
+		process.exit = originalExit;
+	}
+
+	writeResult({ count, exitBeforeCleanupFinished });
 }
 
 async function runCompletedCleanupExitNoop(): Promise<void> {
@@ -58,32 +110,143 @@ async function runCompletedCleanupExitNoop(): Promise<void> {
 async function runBrokenPipeStdoutWrite(): Promise<void> {
 	// The test harness runs this scenario as `bun fixture.ts ... | true`, so the
 	// stdout pipe's read end is closed almost immediately. Under Bun the write
-	// below then throws a synchronous EPIPE from an async tick, which must reach
-	// the postmortem uncaughtException handler — NOT be caught here.
-	await Bun.sleep(50); // let `true` exit and close the pipe's read end
-	setTimeout(async () => {
-		await Promise.resolve();
-		for (let i = 0; i < 256; i++) {
-			process.stdout.write(`${"x".repeat(8192)}\n`);
-		}
-	}, 10);
+	// below throws EPIPE synchronously from a timer and reaches the postmortem
+	// uncaughtException handler without a fixture-side catch.
+	await Bun.sleep(50);
+	setTimeout(writeUntilStdoutPipeBreaks, 10);
 	await Bun.sleep(2_000);
 }
 
 async function runBrokenPipeUnhandledRejection(): Promise<void> {
-	const epipe = Object.assign(new Error("EPIPE: broken pipe, write"), {
-		code: "EPIPE",
-		syscall: "write",
-		errno: -32,
-	});
-	void Promise.reject(epipe);
+	// A synchronous stdout EPIPE inside a promise continuation becomes an
+	// unhandled rejection. The postmortem stdout marker must preserve ownership.
+	await Bun.sleep(50);
+	setTimeout(() => {
+		void Promise.resolve().then(writeUntilStdoutPipeBreaks);
+	}, 10);
 	await Bun.sleep(2_000);
 }
 
+async function runStdoutFdUnhandledRejection(): Promise<void> {
+	const error = {
+		code: "EPIPE",
+		fd: process.stdout.fd,
+		syscall: "write",
+	};
+	void Promise.reject(error);
+	await Bun.sleep(2_000);
+}
+
+async function runStdoutFdMissingSyscallEpipe(): Promise<void> {
+	await throwFromTimer(epipeError("fixture: stdout fd EPIPE without syscall", { fd: process.stdout.fd }));
+}
+
+async function runQuietCleanupFailure(resultPath: string | undefined): Promise<void> {
+	if (!resultPath) throw new Error("quiet cleanup fixture requires a result path");
+
+	let count = 0;
+	postmortem.register("fixture-quiet-cleanup-failure", async () => {
+		count++;
+		await Bun.write(resultPath, JSON.stringify({ count }));
+		// This second real stdout EPIPE arrives while the first quiet handler is
+		// awaiting cleanup. It must be ignored without diagnostic recursion.
+		setTimeout(() => {
+			process.stdout.write("repeat quiet cleanup EPIPE\n");
+		}, 0);
+		await Bun.sleep(20);
+		throw new Error("fixture: quiet cleanup failure");
+	});
+	await runBrokenPipeStdoutWrite();
+}
+
+async function runQuietCleanupThenOrdinaryFatal(resultPath: string | undefined): Promise<void> {
+	if (!resultPath) throw new Error("quiet cleanup fixture requires a result path");
+
+	let count = 0;
+	postmortem.register("fixture-quiet-cleanup-ordinary-fatal", async () => {
+		count++;
+		await Bun.write(resultPath, JSON.stringify({ count }));
+		setTimeout(() => {
+			throw new Error("fixture: ordinary fatal during quiet cleanup");
+		}, 0);
+		await Bun.sleep(20);
+	});
+	await runBrokenPipeStdoutWrite();
+}
+
+async function runQuietCleanupLateRegistration(resultPath: string | undefined): Promise<void> {
+	if (!resultPath) throw new Error("quiet cleanup fixture requires a result path");
+
+	let count = 0;
+	postmortem.register("fixture-quiet-cleanup-late-registration", async () => {
+		count++;
+		postmortem.register("fixture-quiet-late-registration", () => {
+			count++;
+		});
+		await Bun.sleep(20);
+		await Bun.write(resultPath, JSON.stringify({ count }));
+	});
+	await runBrokenPipeStdoutWrite();
+}
+
+async function runOrdinaryFatalThenBrokenPipe(resultPath: string | undefined): Promise<void> {
+	if (!resultPath) throw new Error("ordinary fatal fixture requires a result path");
+
+	let count = 0;
+	postmortem.register("fixture-ordinary-fatal-then-broken-pipe", async () => {
+		count++;
+		await Bun.write(resultPath, JSON.stringify({ count }));
+		setTimeout(writeUntilStdoutPipeBreaks, 0);
+		await Bun.sleep(20);
+		throw new Error("fixture: ordinary cleanup failure");
+	});
+	await throwFromTimer(new Error("fixture: ordinary fatal before quiet EPIPE"));
+}
+
+async function runSocketSendEpipe(): Promise<void> {
+	await throwFromTimer(epipeError("fixture: socket send EPIPE", { fd: process.stdout.fd, syscall: "send" }));
+}
+
+async function runUnrelatedFdWriteEpipe(): Promise<void> {
+	await throwFromTimer(epipeError("fixture: unrelated fd write EPIPE", { fd: process.stderr.fd, syscall: "write" }));
+}
+
+async function runMissingFdWriteEpipe(): Promise<void> {
+	await throwFromTimer(epipeError("fixture: missing fd write EPIPE", { syscall: "write" }));
+}
+
+async function runInvalidFdWriteEpipe(): Promise<void> {
+	await throwFromTimer(epipeError("fixture: invalid fd write EPIPE", { fd: -1, syscall: "write" }));
+}
+
+async function runClosedFdWriteEpipe(): Promise<void> {
+	const fd = fs.openSync("/dev/null", "r");
+	fs.closeSync(fd);
+	await throwFromTimer(epipeError("fixture: closed fd write EPIPE", { fd, syscall: "write" }));
+}
+
+async function runReusedFdWriteEpipe(): Promise<void> {
+	const staleFd = fs.openSync("/dev/null", "r");
+	fs.closeSync(staleFd);
+	const reusedFd = fs.openSync("/dev/null", "r");
+	await throwFromTimer(epipeError("fixture: reused fd write EPIPE", { fd: reusedFd, syscall: "write" }));
+}
+
+async function runDestroyedStreamError(): Promise<void> {
+	const error = Object.assign(new Error("fixture: destroyed stream"), {
+		code: "ERR_STREAM_DESTROYED",
+		fd: process.stdout.fd,
+		syscall: "write",
+	});
+	await throwFromTimer(error);
+}
+
 async function runNonPipeUncaughtException(): Promise<void> {
-	setTimeout(() => {
-		throw new Error("fixture: genuine fatal error");
-	}, 10);
+	await throwFromTimer(new Error("fixture: genuine fatal error"));
+}
+
+async function runNonPipeUnhandledRejection(): Promise<void> {
+	void Promise.reject(new Error("fixture: genuine rejected fatal error"));
 	await Bun.sleep(2_000);
 }
 
@@ -95,6 +258,9 @@ switch (scenario) {
 	case "non-exit-recursive-cleanup":
 		await runNonExitRecursiveCleanup();
 		break;
+	case "quit-reentry-waits-for-cleanup":
+		await runQuitReentryWaitsForCleanup();
+		break;
 	case "completed-cleanup-exit-noop":
 		await runCompletedCleanupExitNoop();
 		break;
@@ -104,8 +270,50 @@ switch (scenario) {
 	case "broken-pipe-unhandled-rejection":
 		await runBrokenPipeUnhandledRejection();
 		break;
+	case "stdout-fd-unhandled-rejection":
+		await runStdoutFdUnhandledRejection();
+		break;
+	case "stdout-fd-missing-syscall-epipe":
+		await runStdoutFdMissingSyscallEpipe();
+		break;
+	case "quiet-cleanup-failure":
+		await runQuietCleanupFailure(process.argv[3]);
+		break;
+	case "quiet-cleanup-ordinary-fatal":
+		await runQuietCleanupThenOrdinaryFatal(process.argv[3]);
+		break;
+	case "quiet-cleanup-late-registration":
+		await runQuietCleanupLateRegistration(process.argv[3]);
+		break;
+	case "ordinary-fatal-then-broken-pipe":
+		await runOrdinaryFatalThenBrokenPipe(process.argv[3]);
+		break;
+	case "socket-send-epipe":
+		await runSocketSendEpipe();
+		break;
+	case "unrelated-fd-write-epipe":
+		await runUnrelatedFdWriteEpipe();
+		break;
+	case "missing-fd-write-epipe":
+		await runMissingFdWriteEpipe();
+		break;
+	case "invalid-fd-write-epipe":
+		await runInvalidFdWriteEpipe();
+		break;
+	case "closed-fd-write-epipe":
+		await runClosedFdWriteEpipe();
+		break;
+	case "reused-fd-write-epipe":
+		await runReusedFdWriteEpipe();
+		break;
+	case "destroyed-stream-error":
+		await runDestroyedStreamError();
+		break;
 	case "non-pipe-uncaught-exception":
 		await runNonPipeUncaughtException();
+		break;
+	case "non-pipe-unhandled-rejection":
+		await runNonPipeUnhandledRejection();
 		break;
 	default:
 		throw new Error(`unknown postmortem fixture scenario: ${scenario ?? "(missing)"}`);

--- a/packages/utils/test/postmortem-fixture.ts
+++ b/packages/utils/test/postmortem-fixture.ts
@@ -55,6 +55,38 @@ async function runCompletedCleanupExitNoop(): Promise<void> {
 	writeResult({ count });
 }
 
+async function runBrokenPipeStdoutWrite(): Promise<void> {
+	// The test harness runs this scenario as `bun fixture.ts ... | true`, so the
+	// stdout pipe's read end is closed almost immediately. Under Bun the write
+	// below then throws a synchronous EPIPE from an async tick, which must reach
+	// the postmortem uncaughtException handler — NOT be caught here.
+	await Bun.sleep(50); // let `true` exit and close the pipe's read end
+	setTimeout(async () => {
+		await Promise.resolve();
+		for (let i = 0; i < 256; i++) {
+			process.stdout.write(`${"x".repeat(8192)}\n`);
+		}
+	}, 10);
+	await Bun.sleep(2_000);
+}
+
+async function runBrokenPipeUnhandledRejection(): Promise<void> {
+	const epipe = Object.assign(new Error("EPIPE: broken pipe, write"), {
+		code: "EPIPE",
+		syscall: "write",
+		errno: -32,
+	});
+	void Promise.reject(epipe);
+	await Bun.sleep(2_000);
+}
+
+async function runNonPipeUncaughtException(): Promise<void> {
+	setTimeout(() => {
+		throw new Error("fixture: genuine fatal error");
+	}, 10);
+	await Bun.sleep(2_000);
+}
+
 const scenario = process.argv[2];
 switch (scenario) {
 	case "exit-reentry-while-running":
@@ -65,6 +97,15 @@ switch (scenario) {
 		break;
 	case "completed-cleanup-exit-noop":
 		await runCompletedCleanupExitNoop();
+		break;
+	case "broken-pipe-stdout-write":
+		await runBrokenPipeStdoutWrite();
+		break;
+	case "broken-pipe-unhandled-rejection":
+		await runBrokenPipeUnhandledRejection();
+		break;
+	case "non-pipe-uncaught-exception":
+		await runNonPipeUncaughtException();
 		break;
 	default:
 		throw new Error(`unknown postmortem fixture scenario: ${scenario ?? "(missing)"}`);

--- a/packages/utils/test/postmortem.test.ts
+++ b/packages/utils/test/postmortem.test.ts
@@ -174,6 +174,7 @@ describe("postmortem process stdout EPIPE policy", () => {
 
 			expect(JSON.parse(await fs.readFile(resultPath, "utf8"))).toEqual({ count: 1 });
 			expectOrdinaryFatal(result, "Uncaught Exception", "fixture: ordinary fatal during quiet cleanup");
+			expect(combinedOutput(result)).not.toContain('"message":"Uncaught exception"');
 		} finally {
 			await fs.rm(temporaryDirectory, { recursive: true, force: true });
 		}

--- a/packages/utils/test/postmortem.test.ts
+++ b/packages/utils/test/postmortem.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
+import { isKnownSinkPeerClosedError } from "../src/broken-pipe";
 
 interface ScenarioResult {
 	stdout: string;
@@ -7,11 +10,17 @@ interface ScenarioResult {
 	exitCode: number;
 }
 
-const fixturePath = path.join(import.meta.dir, "postmortem-fixture.ts");
+interface FixtureResult {
+	count: number;
+	exitBeforeCleanupFinished?: boolean;
+}
 
-async function runScenario(scenario: string): Promise<ScenarioResult> {
-	const proc = Bun.spawn([process.execPath, fixturePath, scenario], {
-		cwd: path.join(import.meta.dir, ".."),
+const fixturePath = path.join(import.meta.dir, "postmortem-fixture.ts");
+const utilsDirectory = path.join(import.meta.dir, "..");
+
+async function captureProcess(command: string[], cwd: string): Promise<ScenarioResult> {
+	const proc = Bun.spawn(command, {
+		cwd,
 		stdout: "pipe",
 		stderr: "pipe",
 	});
@@ -23,12 +32,27 @@ async function runScenario(scenario: string): Promise<ScenarioResult> {
 	return { stdout, stderr, exitCode };
 }
 
-function parseResult(stdout: string): { count: number } {
+async function runScenario(scenario: string): Promise<ScenarioResult> {
+	return captureProcess([process.execPath, fixturePath, scenario], utilsDirectory);
+}
+
+async function runPipelineCommand(command: readonly string[]): Promise<ScenarioResult> {
+	return captureProcess(
+		["bash", "-o", "pipefail", "-c", '"$@" | true', "postmortem-pipeline", ...command],
+		utilsDirectory,
+	);
+}
+
+async function runPipelineScenario(scenario: string, extraArgs: readonly string[] = []): Promise<ScenarioResult> {
+	return runPipelineCommand([process.execPath, fixturePath, scenario, ...extraArgs]);
+}
+
+function parseResult(stdout: string): FixtureResult {
 	const line = stdout.trim().split("\n").at(-1);
 	if (!line) {
 		throw new Error("postmortem fixture produced no JSON result");
 	}
-	return JSON.parse(line) as { count: number };
+	return JSON.parse(line) as FixtureResult;
 }
 
 function combinedOutput(result: ScenarioResult): string {
@@ -37,6 +61,12 @@ function combinedOutput(result: ScenarioResult): string {
 
 function hasRecursiveCleanupError(stderr: string): boolean {
 	return stderr.includes('"level":"error"') && stderr.includes('"message":"Cleanup invoked recursively"');
+}
+
+function expectOrdinaryFatal(result: ScenarioResult, label: string, message: string): void {
+	expect(result.exitCode).toBe(1);
+	expect(result.stderr).toContain(`[${label}]`);
+	expect(result.stderr).toContain(message);
 }
 
 describe("postmortem cleanup re-entry", () => {
@@ -57,6 +87,13 @@ describe("postmortem cleanup re-entry", () => {
 		expect(combinedOutput(result)).toContain('"stack"');
 	});
 
+	it("waits for cleanup when synchronous re-entry calls quit", async () => {
+		const result = await runScenario("quit-reentry-waits-for-cleanup");
+
+		expect(result.exitCode).toBe(0);
+		expect(parseResult(result.stdout)).toEqual({ count: 2, exitBeforeCleanupFinished: false });
+	});
+
 	it("keeps completed cleanup a no-op when the exit handler fires", async () => {
 		const result = await runScenario("completed-cleanup-exit-noop");
 
@@ -66,32 +103,16 @@ describe("postmortem cleanup re-entry", () => {
 	});
 });
 
-describe("postmortem broken-pipe policy", () => {
-	// Regression for the `gjc --help | true` crash: a consumer that closes our
-	// stdout pipe must terminate the process quietly (SIGPIPE semantics, exit
-	// 141) instead of crashing with a fatal "Uncaught Exception" dump.
-	async function runPipelineScenario(scenario: string): Promise<ScenarioResult> {
-		const proc = Bun.spawn(
-			[
-				"bash",
-				"-c",
-				`${JSON.stringify(process.execPath)} ${JSON.stringify(fixturePath)} ${JSON.stringify(scenario)} | true; exit \${PIPESTATUS[0]}`,
-			],
-			{
-				cwd: path.join(import.meta.dir, ".."),
-				stdout: "pipe",
-				stderr: "pipe",
-			},
-		);
-		const [stdout, stderr, exitCode] = await Promise.all([
-			new Response(proc.stdout).text(),
-			new Response(proc.stderr).text(),
-			proc.exited,
-		]);
-		return { stdout, stderr, exitCode };
-	}
+describe("known-sink peer closure classification", () => {
+	it("accepts structural errors without requiring Error instances", () => {
+		expect(isKnownSinkPeerClosedError({ code: "EPIPE" })).toBe(true);
+		expect(isKnownSinkPeerClosedError({ code: "ERR_STREAM_DESTROYED" })).toBe(true);
+		expect(isKnownSinkPeerClosedError({ code: "ECONNRESET" })).toBe(false);
+	});
+});
 
-	it("exits quietly with 141 when the stdout pipe consumer is gone (uncaughtException path)", async () => {
+describe("postmortem process stdout EPIPE policy", () => {
+	it("exits quietly with 141 for a synchronous actual stdout pipe EPIPE", async () => {
 		const result = await runPipelineScenario("broken-pipe-stdout-write");
 
 		expect(result.exitCode).toBe(141); // 128 + SIGPIPE
@@ -99,18 +120,115 @@ describe("postmortem broken-pipe policy", () => {
 		expect(result.stderr).not.toContain("EPIPE");
 	}, 15_000);
 
-	it("exits quietly with 141 when a broken-pipe write surfaces as an unhandled rejection", async () => {
-		const result = await runScenario("broken-pipe-unhandled-rejection");
+	it("exits quietly with 141 for an attributed stdout EPIPE unhandled rejection", async () => {
+		const result = await runPipelineScenario("broken-pipe-unhandled-rejection");
+
+		expect(result.exitCode).toBe(141);
+		expect(result.stderr).not.toContain("[Unhandled Rejection]");
+		expect(result.stderr).not.toContain("EPIPE");
+	}, 15_000);
+
+	it("accepts an unmarked structural rejection only with process stdout's exact write descriptor", async () => {
+		const result = await runScenario("stdout-fd-unhandled-rejection");
 
 		expect(result.exitCode).toBe(141);
 		expect(result.stderr).not.toContain("[Unhandled Rejection]");
 	}, 15_000);
 
-	it("keeps the fatal dump and exit code 1 for non-pipe uncaught exceptions", async () => {
-		const result = await runScenario("non-pipe-uncaught-exception");
+	it("runs quiet cleanup once and suppresses cleanup-failure logging", async () => {
+		const temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "postmortem-quiet-cleanup-"));
+		const resultPath = path.join(temporaryDirectory, "result.json");
+		try {
+			const result = await runPipelineScenario("quiet-cleanup-failure", [resultPath]);
 
-		expect(result.exitCode).toBe(1);
-		expect(result.stderr).toContain("[Uncaught Exception]");
-		expect(result.stderr).toContain("fixture: genuine fatal error");
+			expect(result.exitCode).toBe(141);
+			expect(JSON.parse(await fs.readFile(resultPath, "utf8"))).toEqual({ count: 1 });
+			expect(result.stderr).not.toContain("Cleanup callback failed");
+			expect(result.stderr).not.toContain("Cleanup invoked recursively");
+			expect(result.stderr).not.toContain("EPIPE");
+		} finally {
+			await fs.rm(temporaryDirectory, { recursive: true, force: true });
+		}
+	}, 15_000);
+
+	it("runs late quiet-cleanup registrations without diagnostics", async () => {
+		const temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "postmortem-quiet-late-registration-"));
+		const resultPath = path.join(temporaryDirectory, "result.json");
+		try {
+			const result = await runPipelineScenario("quiet-cleanup-late-registration", [resultPath]);
+
+			expect(result.exitCode).toBe(141);
+			expect(JSON.parse(await fs.readFile(resultPath, "utf8"))).toEqual({ count: 2 });
+			expect(result.stderr).not.toContain("Cleanup callback failed");
+			expect(result.stderr).not.toContain("Cleanup invoked recursively");
+		} finally {
+			await fs.rm(temporaryDirectory, { recursive: true, force: true });
+		}
+	}, 15_000);
+
+	it("keeps a later ordinary fatal diagnostic and status 1 without rerunning quiet cleanup", async () => {
+		const temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "postmortem-ordinary-fatal-"));
+		const resultPath = path.join(temporaryDirectory, "result.json");
+		try {
+			const result = await runPipelineScenario("quiet-cleanup-ordinary-fatal", [resultPath]);
+
+			expect(JSON.parse(await fs.readFile(resultPath, "utf8"))).toEqual({ count: 1 });
+			expectOrdinaryFatal(result, "Uncaught Exception", "fixture: ordinary fatal during quiet cleanup");
+		} finally {
+			await fs.rm(temporaryDirectory, { recursive: true, force: true });
+		}
+	}, 15_000);
+
+	it("keeps an earlier ordinary fatal status and cleanup behavior when stdout EPIPE arrives later", async () => {
+		const temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "postmortem-ordinary-first-"));
+		const resultPath = path.join(temporaryDirectory, "result.json");
+		try {
+			const result = await runPipelineScenario("ordinary-fatal-then-broken-pipe", [resultPath]);
+
+			expect(JSON.parse(await fs.readFile(resultPath, "utf8"))).toEqual({ count: 1 });
+			expectOrdinaryFatal(result, "Uncaught Exception", "fixture: ordinary fatal before quiet EPIPE");
+		} finally {
+			await fs.rm(temporaryDirectory, { recursive: true, force: true });
+		}
+	}, 15_000);
+
+	it("keeps a socket send EPIPE fatal even when its fd is process stdout", async () => {
+		const result = await runScenario("socket-send-epipe");
+
+		expectOrdinaryFatal(result, "Uncaught Exception", "fixture: socket send EPIPE");
+	}, 15_000);
+
+	it("keeps an unrelated write EPIPE with another open fd fatal", async () => {
+		const result = await runScenario("unrelated-fd-write-epipe");
+
+		expectOrdinaryFatal(result, "Uncaught Exception", "fixture: unrelated fd write EPIPE");
+	}, 15_000);
+
+	it("keeps missing syscall and invalid descriptor evidence fatal", async () => {
+		const missingSyscall = await runScenario("stdout-fd-missing-syscall-epipe");
+		const missingFd = await runScenario("missing-fd-write-epipe");
+		const invalid = await runScenario("invalid-fd-write-epipe");
+		const closed = await runScenario("closed-fd-write-epipe");
+		const reused = await runScenario("reused-fd-write-epipe");
+
+		expectOrdinaryFatal(missingSyscall, "Uncaught Exception", "fixture: stdout fd EPIPE without syscall");
+		expectOrdinaryFatal(missingFd, "Uncaught Exception", "fixture: missing fd write EPIPE");
+		expectOrdinaryFatal(invalid, "Uncaught Exception", "fixture: invalid fd write EPIPE");
+		expectOrdinaryFatal(closed, "Uncaught Exception", "fixture: closed fd write EPIPE");
+		expectOrdinaryFatal(reused, "Uncaught Exception", "fixture: reused fd write EPIPE");
+	}, 15_000);
+
+	it("keeps ERR_STREAM_DESTROYED fatal at process scope", async () => {
+		const result = await runScenario("destroyed-stream-error");
+
+		expectOrdinaryFatal(result, "Uncaught Exception", "fixture: destroyed stream");
+	}, 15_000);
+
+	it("keeps non-pipe exceptions and rejections unchanged", async () => {
+		const exception = await runScenario("non-pipe-uncaught-exception");
+		const rejection = await runScenario("non-pipe-unhandled-rejection");
+
+		expectOrdinaryFatal(exception, "Uncaught Exception", "fixture: genuine fatal error");
+		expectOrdinaryFatal(rejection, "Unhandled Rejection", "fixture: genuine rejected fatal error");
 	}, 15_000);
 });

--- a/packages/utils/test/postmortem.test.ts
+++ b/packages/utils/test/postmortem.test.ts
@@ -65,3 +65,52 @@ describe("postmortem cleanup re-entry", () => {
 		expect(hasRecursiveCleanupError(combinedOutput(result))).toBe(false);
 	});
 });
+
+describe("postmortem broken-pipe policy", () => {
+	// Regression for the `gjc --help | true` crash: a consumer that closes our
+	// stdout pipe must terminate the process quietly (SIGPIPE semantics, exit
+	// 141) instead of crashing with a fatal "Uncaught Exception" dump.
+	async function runPipelineScenario(scenario: string): Promise<ScenarioResult> {
+		const proc = Bun.spawn(
+			[
+				"bash",
+				"-c",
+				`${JSON.stringify(process.execPath)} ${JSON.stringify(fixturePath)} ${JSON.stringify(scenario)} | true; exit \${PIPESTATUS[0]}`,
+			],
+			{
+				cwd: path.join(import.meta.dir, ".."),
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+		return { stdout, stderr, exitCode };
+	}
+
+	it("exits quietly with 141 when the stdout pipe consumer is gone (uncaughtException path)", async () => {
+		const result = await runPipelineScenario("broken-pipe-stdout-write");
+
+		expect(result.exitCode).toBe(141); // 128 + SIGPIPE
+		expect(result.stderr).not.toContain("[Uncaught Exception]");
+		expect(result.stderr).not.toContain("EPIPE");
+	}, 15_000);
+
+	it("exits quietly with 141 when a broken-pipe write surfaces as an unhandled rejection", async () => {
+		const result = await runScenario("broken-pipe-unhandled-rejection");
+
+		expect(result.exitCode).toBe(141);
+		expect(result.stderr).not.toContain("[Unhandled Rejection]");
+	}, 15_000);
+
+	it("keeps the fatal dump and exit code 1 for non-pipe uncaught exceptions", async () => {
+		const result = await runScenario("non-pipe-uncaught-exception");
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain("[Uncaught Exception]");
+		expect(result.stderr).toContain("fixture: genuine fatal error");
+	}, 15_000);
+});


### PR DESCRIPTION
Fixes #2098.

## Problem

Any gjc process whose output pipe loses its reader crashes with a fatal `Uncaught Exception: EPIPE` dump and exit code 1:

```console
$ gjc --help | true; echo "exit=${PIPESTATUS[0]}"
EPIPE: broken pipe, write
      ...
      at writeFast (internal:fs/streams:345:38)
exit=1
```

Observed twice in one day of dogfooding (details in #2098): a piped batch run (uncaughtException, `syscall:"write"`, pipe fd) and a **live interactive session** killed by a background socket peer vanishing (unhandledRejection, `syscall:"send"`). Under Bun a non-TTY stdout is an fs stream over a pipe fd; once the reader closes, the next write throws from an async tick where no user `try/catch` is in scope, and the postmortem fail-fast handlers treat it as fatal.

PR #1039 fixed this for coordinator-mcp only and was closed for targeting `main`; this lands the general fix on `dev`.

## Fix (three layers, all minimal)

1. **`packages/utils/src/postmortem.ts`** — process-level policy: an uncaught exception / unhandled rejection carrying `EPIPE`/`ERR_STREAM_DESTROYED` now runs cleanup and exits quietly with **141** (128 + SIGPIPE), matching what shells report for SIGPIPE-killed producers in `foo | head` pipelines. No stderr dump and deliberately **no logging** in this path: a console log transport (used by supervised services) would write into the same broken pipe and re-enter the handler. Non-pipe fatals keep the existing dump + exit 1 unchanged.
2. **`packages/coding-agent/src/modes/print-mode.ts`** — stdout writes (JSON header, event stream, final text) go through a latching guard: once the pipe is known-broken, writes become no-ops so a synchronous EPIPE cannot rip through agent event dispatch; the run still completes and the session persists. The final flush treats a broken pipe as "nothing left to flush", not an error.
3. **`packages/coding-agent/src/modes/rpc/rpc-mode.ts`** — `output()` drops frames whose sink peer vanished instead of tearing down the whole RPC server. The sink is swappable (`--listen` serves later UDS clients), so it is intentionally **not** latched dead — frames are skipped only while the current peer is gone. Non-pipe errors still propagate.

New shared helper `isBrokenPipeError` / `BROKEN_PIPE_EXIT_CODE` in `packages/utils/src/broken-pipe.ts` (exported from the utils barrel).

## Tests

`packages/utils/test/postmortem.test.ts` + fixture, following the existing spawn-fixture harness in that file:

- **`broken-pipe-stdout-write`** — runs the fixture as a real shell pipeline (`bun fixture.ts ... | true; exit ${PIPESTATUS[0]}`), reproducing the exact `gjc --help | true` shape: asserts exit **141**, no `[Uncaught Exception]` dump, no raw `EPIPE` on stderr.
- **`broken-pipe-unhandled-rejection`** — EPIPE surfacing through a rejected promise: exits 141 with no `[Unhandled Rejection]` dump.
- **`non-pipe-uncaught-exception`** — guard against over-matching: a genuine fatal keeps the dump and exit code 1.

## Verification

- `bun test packages/utils/` — 132 pass, 0 fail (includes the 3 new + 3 pre-existing postmortem tests)
- `bun test packages/coding-agent/test/silent-abort-print-mode.test.ts packages/coding-agent/test/rpc.test.ts packages/coding-agent/test/rpc-stdio-redteam.test.ts packages/coding-agent/test/coordinator-mcp/pump.test.ts` — 27 pass, 13 skip, 0 fail
- `bun test packages/coding-agent/test/rpc-client.start.test.ts packages/coding-agent/test/rpc-client-uds.test.ts packages/coding-agent/test/rpc-listen-socket-guard.test.ts packages/coding-agent/test/rpc-unattended-stdio.test.ts` — 15 pass, 0 fail
- `bun --cwd=packages/utils run check` and `bun --cwd=packages/coding-agent run check` — biome + `tsc --noEmit` clean

## Scope notes

- Behavior change is limited to *unhandled* broken-pipe errors; any code that already handles EPIPE locally (safe-stderr, clipboard OSC 52, tui terminal, coordinator pump) is untouched.
- Follow-up candidate (out of scope): long-lived socket writers handling peer disappearance locally so a background socket death doesn't end an interactive session at all — #2098 tracks the rationale.
- Changelog entries added under `## [Unreleased]` for `packages/utils` and `packages/coding-agent`.
