### PR TITLE
fix(notifications): support owner-restricted Telegram forum supergroups

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -43,6 +43,9 @@
 - `NotificationServer#pushFrame` now rejects `ActionNeeded` frames; emit asks and idle notifications through `registerAsk` / `noteIdle` so controlled asks remain capability-gated per connection (#2029).
 - A rolling/in-place upgrade that left a still-live pre-upgrade Telegram daemon owning the lock is now reloaded instead of silently attached. The old daemon speaks the pre-#1999 wire protocol without ask-ack/controls, so its `Selected!` acknowledgements were dropped; an operational `DAEMON_GENERATION` (tied to `NOTIFICATION_PROTOCOL_VERSION`) now flags a fresh live owner running an older generation as reload-required, and the new host registers its session root then hands off through the cooperative SIGTERM/control path (#2028).
 - A numeric gate reply is an option index: an out-of-range index is no longer accepted as free-text `Other`. `mapAnswerToGate` returns a discriminated result and the unattended handler closes the exact claim/receipt and reissues instead of durably accepting or emitting a `Selected!` ack; the JSON-string free-text path is preserved (#2030).
+### Added
+
+- Added an explicit `GJC_TELEGRAM_FORUM_OWNER_USER_ID` opt-in for pairing notifications with an already-configured Telegram forum supergroup. Topic delivery is enabled only when Bot API confirms `type=supergroup` and `is_forum=true`, and every inbound message or callback must come from the configured owner id; the default private-chat-only fail-closed behavior is unchanged.
 
 ## [0.9.6] - 2026-07-10
 ### Changed

--- a/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
@@ -213,6 +213,7 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 		rich: cfg.rich,
 		richDraft: cfg.richDraft,
 		topics: cfg.topics,
+		forumSupergroupOwnerId: process.env.GJC_TELEGRAM_FORUM_OWNER_USER_ID?.trim() || undefined,
 		pid: deps.processPid ?? process.pid,
 		control: {
 			shouldStop: async owner => {

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -965,6 +965,11 @@ export interface TelegramDaemonOptions {
 	 * built-in `{repo}/{branch} - {title}` composition and its fallbacks.
 	 */
 	topics?: { nameTemplate?: string };
+	/**
+	 * Explicit owner allowlist for a configured Telegram forum supergroup.
+	 * When unset, the historical private-chat-only fail-closed contract remains.
+	 */
+	forumSupergroupOwnerId?: string;
 }
 
 interface SessionSocket {
@@ -1049,6 +1054,8 @@ export class TelegramNotificationDaemon {
 	private readonly flatIdentitySent = new Set<string>();
 	/** Cached result of whether the paired chat is a private chat (flat-fallback gate). */
 	private pairedChatPrivate: boolean | undefined;
+	/** Cached result of whether the paired chat may host per-session topics. */
+	private pairedChatTopicCapable: boolean | undefined;
 	/** Bot username from getMe, cached once at owner startup for group/forum command targeting. */
 	private botUsername: string | undefined;
 	/** Sessions whose agent loop is currently busy (drives the typing indicator). */
@@ -1345,7 +1352,7 @@ export class TelegramNotificationDaemon {
 		commandCtx: { chatType?: string; botUsername?: string },
 	): Promise<boolean> {
 		if (!isLifecycleCommandText(text, commandCtx)) return false;
-		if (!(await this.pairedChatIsPrivate())) return true;
+		if (!(await this.pairedChatSupportsTopics())) return true;
 		const reply = async (body: string): Promise<void> => {
 			for (const text of splitTelegramPlainText(body)) {
 				await this.botApi
@@ -1971,7 +1978,7 @@ export class TelegramNotificationDaemon {
 	}
 
 	private async existingTopicForPrivateChat(sessionId: string): Promise<string | undefined> {
-		if (!(await this.pairedChatIsPrivate())) return undefined;
+		if (!(await this.pairedChatSupportsTopics())) return undefined;
 		return this.topics.get(sessionId)?.topicId;
 	}
 
@@ -2027,7 +2034,7 @@ export class TelegramNotificationDaemon {
 	 * one-time nudge) or drop fail-closed for a non-private chat.
 	 */
 	private async ensureTopic(sessionId: string, name: string): Promise<string | undefined> {
-		if (!(await this.pairedChatIsPrivate())) return undefined;
+		if (!(await this.pairedChatSupportsTopics())) return undefined;
 		const existing = this.topics.get(sessionId);
 		if (existing) return existing.topicId;
 		try {
@@ -2310,7 +2317,7 @@ export class TelegramNotificationDaemon {
 				continue;
 			}
 			const { send, topicId } = item.payload;
-			if (topicId && !(await this.pairedChatIsPrivate())) continue;
+			if (topicId && !(await this.pairedChatSupportsTopics())) continue;
 			// Threaded topic when available; otherwise deliver flat to the paired chat.
 			const threadField = topicId ? { message_thread_id: Number(topicId) } : {};
 			const ckey = send.editable ? item.coalesceKey : undefined;
@@ -2580,6 +2587,39 @@ export class TelegramNotificationDaemon {
 		return (await this.resolvePairedChatPrivacy()) === "private";
 	}
 
+	/**
+	 * Topic delivery is allowed in a private chat, or in an explicitly opted-in
+	 * forum supergroup whose inbound updates are pinned to one Telegram owner id.
+	 */
+	private async pairedChatSupportsTopics(): Promise<boolean> {
+		if (this.pairedChatTopicCapable !== undefined) return this.pairedChatTopicCapable;
+		try {
+			const res = (await this.botApi.call("getChat", { chat_id: this.opts.chatId })) as {
+				result?: { type?: string; is_forum?: boolean };
+			};
+			const chat = res.result;
+			this.pairedChatTopicCapable =
+				chat?.type === "private" ||
+				(Boolean(this.opts.forumSupergroupOwnerId) && chat?.type === "supergroup" && chat.is_forum === true);
+			return this.pairedChatTopicCapable;
+		} catch (e) {
+			logger.warn(`notifications: getChat failed while checking Telegram topic capability: ${String(e)}`);
+			return false;
+		}
+	}
+
+	/** Forum-supergroup mode accepts input only from the configured Telegram owner. */
+	private forumUpdateIsOwned(update: unknown): boolean {
+		const ownerId = this.opts.forumSupergroupOwnerId;
+		if (!ownerId) return true;
+		const candidate = update as {
+			message?: { from?: { id?: unknown } };
+			callback_query?: { from?: { id?: unknown } };
+		};
+		const fromId = candidate.message?.from?.id ?? candidate.callback_query?.from?.id;
+		return String(fromId) === ownerId;
+	}
+
 	/** Tell the user once (per daemon run) how to enable Threaded Mode. */
 	private async notifyThreadedFallback(): Promise<void> {
 		if (this.threadedFallbackNoticeSent || !(await this.pairedChatIsPrivate())) return;
@@ -2627,7 +2667,7 @@ export class TelegramNotificationDaemon {
 	/** Send a single `typing` chat action into a busy session's topic (best-effort). */
 	private async sendTyping(sessionId: string): Promise<void> {
 		const topicId = this.topics.get(sessionId)?.topicId;
-		if (!topicId || !(await this.pairedChatIsPrivate())) return;
+		if (!topicId || !(await this.pairedChatSupportsTopics())) return;
 		try {
 			await this.botApi.call("sendChatAction", {
 				chat_id: this.opts.chatId,
@@ -2641,7 +2681,7 @@ export class TelegramNotificationDaemon {
 
 	/** Set a native reaction on an inbound thread message (best-effort). */
 	private async setReaction(messageId: number, emoji: string): Promise<void> {
-		if (!(await this.pairedChatIsPrivate())) return;
+		if (!(await this.pairedChatSupportsTopics())) return;
 		try {
 			await this.botApi.call("setMessageReaction", {
 				chat_id: this.opts.chatId,
@@ -2866,7 +2906,7 @@ export class TelegramNotificationDaemon {
 
 	private async sendStaleGuidance(callbackId: unknown): Promise<void> {
 		await this.answerCallbackQueryBestEffort(callbackId, "Button is stale");
-		if (!(await this.pairedChatIsPrivate())) return;
+		if (!(await this.pairedChatSupportsTopics())) return;
 		await this.botApi.call("sendMessage", {
 			chat_id: this.opts.chatId,
 			text: "This button is stale after notification daemon restart. Please answer locally in the GJC session or wait for a fresh notification.",
@@ -2945,6 +2985,7 @@ export class TelegramNotificationDaemon {
 	}
 
 	async handleTelegramUpdate(update: unknown): Promise<void> {
+		if (!this.forumUpdateIsOwned(update)) return;
 		if ((await this.handleForumTopicEdited(update)) !== "not-topic") return;
 		// Session-lifecycle command (/session_*): handled ONLY from the paired chat,
 		// gated before any arg parsing or side effect, and routed through the control
@@ -2958,7 +2999,13 @@ export class TelegramNotificationDaemon {
 			const cmdText = typeof m?.text === "string" ? m.text : undefined;
 			const commandCtx = { chatType, botUsername: this.botUsername };
 			if (m !== undefined && String(chatId) === String(this.opts.chatId)) {
-				if (chatType !== undefined && chatType !== "private" && isLifecycleCommandLikeText(cmdText)) return;
+				if (
+					chatType !== undefined &&
+					chatType !== "private" &&
+					!this.opts.forumSupergroupOwnerId &&
+					isLifecycleCommandLikeText(cmdText)
+				)
+					return;
 				if (isLifecycleCommandText(cmdText, commandCtx)) {
 					const updateId = (update as { update_id?: number }).update_id;
 					const threadId = typeof m.message_thread_id === "number" ? (m.message_thread_id as number) : undefined;
@@ -2985,7 +3032,7 @@ export class TelegramNotificationDaemon {
 				// paired chat — the same contract as session delivery and lifecycle
 				// commands. A group/supergroup chatId (legacy or hand-edited) must never
 				// let an arbitrary chat member toggle the owner's notification config.
-				if (!(await this.pairedChatIsPrivate())) return;
+				if (!(await this.pairedChatSupportsTopics())) return;
 				const updateId = (update as { update_id?: number }).update_id;
 				// Dedupe redelivered updates so a toggle+confirmation runs at most once.
 				if (typeof updateId === "number") {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -2227,6 +2227,72 @@ test("forum lifecycle commands fail closed even when addressed to this bot usern
 	expect(bot.calls.filter(c => c.method === "getChat")).toHaveLength(0);
 });
 
+test("explicit forum-supergroup opt-in creates topics and accepts only the configured owner", async () => {
+	FakeWs.instances = [];
+	const bot = new FakeBotApi();
+	bot.call = (async (method: string, body: any) => {
+		bot.calls.push({ method, body });
+		if (method === "getChat") return { ok: true, result: { id: body.chat_id, type: "supergroup", is_forum: true } };
+		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: 7001 } };
+		if (method === "sendMessage") return { ok: true, result: { message_id: bot.calls.length } };
+		return { ok: true, result: true };
+	}) as any;
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(tempAgentDir()),
+		ownerId: "owner",
+		botToken: "tok",
+		chatId: "-10042",
+		botApi: bot,
+		forumSupergroupOwnerId: "99",
+		WebSocketImpl: FakeWs as any,
+	});
+	daemon.connectSession("S", "ws://s", "ts");
+	const session = daemon.sessions.get("S")!;
+	await daemon.handleSessionMessage(session, { type: "identity_header", sessionId: "S", repo: "r", branch: "b" });
+	expect(bot.calls.find(c => c.method === "createForumTopic")?.body).toEqual({ chat_id: "-10042", name: "r/b" });
+
+	await daemon.handleTelegramUpdate({
+		update_id: 301,
+		message: {
+			from: { id: 100 },
+			chat: { id: -10042, type: "supergroup" },
+			message_thread_id: 7001,
+			message_id: 11,
+			text: "intruder",
+		},
+	});
+	expect(FakeWs.instances[0]!.sent).toHaveLength(0);
+
+	await daemon.handleTelegramUpdate({
+		update_id: 302,
+		callback_query: {
+			id: "intruder-callback",
+			from: { id: 100 },
+			message: { chat: { id: -10042, type: "supergroup" }, message_thread_id: 7001 },
+			data: "gjc:unknown",
+		},
+	});
+	expect(bot.calls.filter(c => c.method === "answerCallbackQuery")).toHaveLength(0);
+	expect(FakeWs.instances[0]!.sent).toHaveLength(0);
+
+	await daemon.handleTelegramUpdate({
+		update_id: 303,
+		message: {
+			from: { id: 99 },
+			chat: { id: -10042, type: "supergroup" },
+			message_thread_id: 7001,
+			message_id: 12,
+			text: "owner turn",
+		},
+	});
+	expect(FakeWs.instances[0]!.sent).toHaveLength(1);
+	expect(JSON.parse(FakeWs.instances[0]!.sent[0]!)).toMatchObject({
+		type: "user_message",
+		sessionId: "S",
+		text: "owner turn",
+	});
+});
+
 test("forum lifecycle commands fail closed when bot username is unavailable", async () => {
 	const bot = new FakeBotApi();
 	const daemon = new TelegramNotificationDaemon({


### PR DESCRIPTION
## Summary

- add an explicit `GJC_TELEGRAM_FORUM_OWNER_USER_ID` opt-in for an already-configured Telegram forum supergroup
- require Bot API confirmation that the destination is `type=supergroup` with `is_forum=true` before enabling topic delivery
- drop every inbound message and callback whose sender does not match the configured owner ID
- preserve the existing private-chat-only fail-closed behavior when the opt-in is unset

## Why

The notification daemon currently treats only `private` chats as topic-capable. A correctly configured forum supergroup can therefore appear healthy while topic creation and outbound delivery are silently rejected. This adds a narrow, explicit compatibility path without relaxing the default security boundary.

## Verification

- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts` — 148 pass, 0 fail
- `bun run check:ts` — pass
- regression coverage includes default forum fail-closed behavior, opted-in topic creation, non-owner message rejection, non-owner callback rejection, and owner message routing

## Security

No real tokens, chat IDs, user IDs, local paths, bot usernames, or deployment-specific values are included. Tests use synthetic identifiers only. The owner ID is read only from the operator-supplied environment variable.