### PR TITLE
fix(skills): honor SKILL.md model/effort runtime preferences + preserve under config default profile

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Fixed
 
 - IRC deliveries now accept their exchange batch in the recipient's volatile current-session queue before recipient/main UI observations or sender success. Awaited deliveries generate the reply first, then accept the ordered incoming + auto-reply pair and commit the IRC roster claim before observation; provider failures and sender aborts before acceptance leave no ghost exchange, while observer failures after acceptance are isolated. This is not a durability guarantee: durable history injection remains a later flush and no fsync, recovery, persistent IDs, or deduplication was added.
+### Fixed
+
+- Project and user runtime skills now honor Claude-compatible `model` and `effort` frontmatter on slash invocation and automatic skill chaining. Context-qualified selectors such as `opus[1m]` resolve to the newest available matching family model with the requested context window, run in a fresh transient turn when chaining from an active stream, restore the prior session model afterward, and fail closed when unavailable instead of silently running on an unrelated default model.
 
 ## [0.10.0] - 2026-07-12
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Project and user runtime skills now honor Claude-compatible `model` and `effort` frontmatter on slash invocation and automatic skill chaining. Context-qualified selectors such as `opus[1m]` resolve to the newest available matching family model with the requested context window, run in a fresh transient turn when chaining from an active stream, restore the prior session model afterward, and fail closed when unavailable instead of silently running on an unrelated default model.
+- Config-driven startup activation of `modelProfile.default` no longer disables SKILL.md `model`/`effort` runtime preferences. The ambient config profile default now stays overridable by skill frontmatter for the skill turn, while explicit selections (CLI `--model`, `--mpreset`, interactive `/model` or profile activation) remain authoritative over skill frontmatter.
 
 ## [0.10.0] - 2026-07-12
 

--- a/packages/coding-agent/src/capability/skill.ts
+++ b/packages/coding-agent/src/capability/skill.ts
@@ -14,6 +14,8 @@ export interface SkillFrontmatter {
 	description?: string;
 	globs?: string[];
 	alwaysApply?: boolean;
+	model?: string;
+	effort?: string;
 	/**
 	 * When `true`, the skill is loaded and accessible via `skill://<name>` (and
 	 * `/skill:<name>` slash commands), but is omitted from the rendered system

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -46,6 +46,13 @@ export interface PrepareModelProfileActivationOptions {
 export interface ApplyModelProfileActivationOptions {
 	persistDefault?: boolean;
 	thinkingLevelOverride?: ThinkingLevel;
+	/**
+	 * Config-driven startup auto-activation sets an ambient session default and
+	 * must keep SKILL.md model/effort preferences applicable. Explicit user
+	 * activations (interactive selector, `--mpreset`) leave this unset so the
+	 * user's pick stays authoritative over skill frontmatter.
+	 */
+	preserveSkillRuntimePreferences?: boolean;
 }
 export interface PreparedModelProfileActivation {
 	profileName: string;
@@ -371,6 +378,7 @@ export async function applyPreparedModelProfileActivation(
 				options.thinkingLevelOverride ?? prepared.defaultThinkingLevel,
 				{
 					persistAsSessionDefault: true,
+					preserveSkillRuntimePreferences: options.preserveSkillRuntimePreferences,
 				},
 			);
 			modelChanged = true;

--- a/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
+++ b/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
@@ -81,6 +81,8 @@ function toRuntimeSkill(skill: CapabilitySkill, source: RuntimeSkillDiscoverySou
 		baseDir: skill.path.replace(/[\\/]SKILL\.md$/, ""),
 		source: `runtime:${source}`,
 		hide: skill.frontmatter?.hide === true,
+		model: typeof skill.frontmatter?.model === "string" ? skill.frontmatter.model : undefined,
+		effort: typeof skill.frontmatter?.effort === "string" ? skill.frontmatter.effort : undefined,
 		_source: { ...skill._source, providerName: "Runtime skill discovery" },
 	};
 }

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -17,6 +17,10 @@ export interface Skill {
 	filePath: string;
 	baseDir: string;
 	source: string;
+	/** Optional Claude-compatible model selector requested by SKILL.md frontmatter. */
+	model?: string;
+	/** Optional Claude-compatible reasoning effort requested by SKILL.md frontmatter. */
+	effort?: string;
 	/**
 	 * When `true`, the skill is loaded and reachable via `skill://<name>` and
 	 * skill slash aliases, but is excluded from the rendered system prompt's
@@ -88,6 +92,8 @@ export async function loadSkillsFromDir(options: LoadSkillsFromDirOptions): Prom
 			baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 			source: options.source,
 			hide: capSkill.frontmatter?.hide === true,
+			model: typeof capSkill.frontmatter?.model === "string" ? capSkill.frontmatter.model : undefined,
+			effort: typeof capSkill.frontmatter?.effort === "string" ? capSkill.frontmatter.effort : undefined,
 			_source: capSkill._source,
 		})),
 		warnings: (result.warnings ?? []).map(message => ({ skillPath: options.dir, message })),
@@ -196,6 +202,8 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 				baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 				source: `${capSkill._source.provider}:${capSkill.level}`,
 				hide: capSkill.frontmatter?.hide === true,
+				model: typeof capSkill.frontmatter?.model === "string" ? capSkill.frontmatter.model : undefined,
+				effort: typeof capSkill.frontmatter?.effort === "string" ? capSkill.frontmatter.effort : undefined,
 				_source: capSkill._source,
 			});
 			realPathSet.add(resolvedPath);
@@ -233,6 +241,8 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 					baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 					source: "custom:user",
 					hide: capSkill.frontmatter?.hide === true,
+					model: typeof capSkill.frontmatter?.model === "string" ? capSkill.frontmatter.model : undefined,
+					effort: typeof capSkill.frontmatter?.effort === "string" ? capSkill.frontmatter.effort : undefined,
 					_source: { ...capSkill._source, providerName: "Custom" },
 				},
 				path: capSkill.path,
@@ -407,7 +417,7 @@ export function resolveSkillSlashCommands(
 }
 
 export async function buildSkillPromptMessage(
-	skill: Pick<Skill, "name" | "filePath" | "content">,
+	skill: Pick<Skill, "name" | "filePath" | "content" | "model" | "effort">,
 	args: string,
 	context?: BuildSkillPromptMessageContext,
 ): Promise<BuiltSkillPromptMessage> {
@@ -424,6 +434,8 @@ export async function buildSkillPromptMessage(
 		path: skill.filePath,
 		args: trimmedArgs || undefined,
 		lineCount: body ? body.split("\n").length : 0,
+		requestedModel: skill.model,
+		requestedEffort: skill.effort,
 	};
 	if (context?.subskillActivationSet) {
 		details.subskillActivationSet = context.subskillActivationSet;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -291,11 +291,18 @@ export async function applyStartupModelProfiles(args: {
 	const applyProfile = async (
 		profileName: string,
 		persistDefault: boolean,
-		options: { thinkingLevelOverride?: CreateAgentSessionOptions["thinkingLevel"] } = {},
+		options: {
+			thinkingLevelOverride?: CreateAgentSessionOptions["thinkingLevel"];
+			preserveSkillRuntimePreferences?: boolean;
+		} = {},
 	): Promise<void> => {
 		await activateModelProfile(
 			{ session: args.session, modelRegistry: args.modelRegistry, settings: args.settings, profileName },
-			{ persistDefault, thinkingLevelOverride: options.thinkingLevelOverride },
+			{
+				persistDefault,
+				thinkingLevelOverride: options.thinkingLevelOverride,
+				preserveSkillRuntimePreferences: options.preserveSkillRuntimePreferences,
+			},
 		);
 	};
 
@@ -309,10 +316,14 @@ export async function applyStartupModelProfiles(args: {
 	}
 
 	if (defaultProfile) {
+		// Config-driven auto activation is an ambient default, not an explicit
+		// per-invocation model pick: skill frontmatter model/effort preferences
+		// must stay applicable for skill turns.
 		await applyProfile(defaultProfile, false, {
 			thinkingLevelOverride: args.settings.has("defaultThinkingLevel")
 				? args.settings.get("defaultThinkingLevel")
 				: undefined,
+			preserveSkillRuntimePreferences: true,
 		});
 	}
 	if (args.parsedArgs.mpreset) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2356,6 +2356,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			skillWarnings,
 			skillsSettings: settings.getGroup("skills"),
 			modelRegistry,
+			allowSkillRuntimePreferences: !hasExplicitModel,
 			taskDepth,
 			toolRegistry,
 			workflowGateToolSession: toolSession,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -143,8 +143,10 @@ import {
 	extractExplicitThinkingSelector,
 	formatModelSelectorValue,
 	formatModelString,
+	parseModelPattern,
 	parseModelString,
 	type ResolvedModelRoleValue,
+	resolveAllowedModels,
 	resolveModelRoleValue,
 	type ScopedModelSelection,
 } from "../config/model-resolver";
@@ -248,7 +250,7 @@ import {
 import { assertWorkflowMutationAllowed } from "../skill-state/deep-interview-mutation-guard";
 import { invalidateHostMetadata } from "../ssh/connection-manager";
 import { buildVolatileProjectContext } from "../system-prompt";
-import { resolveThinkingLevelForModel, toReasoningEffort } from "../thinking";
+import { parseThinkingLevel, resolveThinkingLevelForModel, toReasoningEffort } from "../thinking";
 import {
 	buildDiscoverableToolSearchIndex,
 	collectDiscoverableTools,
@@ -402,6 +404,8 @@ export interface AgentSessionConfig {
 	skillsSettings?: SkillsSettings;
 	/** Model registry for API key resolution and model discovery */
 	modelRegistry: ModelRegistry;
+	/** Whether implicit SKILL.md model/effort defaults may override this session for a skill turn. */
+	allowSkillRuntimePreferences?: boolean;
 	/** Task recursion depth for nested sessions. Top-level sessions use 0. */
 	taskDepth?: number;
 	/** Tool registry for LSP and settings */
@@ -1189,6 +1193,8 @@ export class AgentSession {
 	#thinkingLevel: ThinkingLevel | undefined;
 	#activeModelProfile: string | undefined;
 	#defaultModelSelectionTail: Promise<void> = Promise.resolve();
+	#allowSkillRuntimePreferences: boolean;
+	#skillRuntimeRestoreState: { model: Model; thinkingLevel: ThinkingLevel | undefined } | undefined;
 	#promptTemplates: PromptTemplate[];
 	#slashCommands: FileSlashCommand[];
 
@@ -1546,6 +1552,7 @@ export class AgentSession {
 		this.#ownedMcpManager = config.ownedMcpManager;
 		this.#scopedModels = config.scopedModels ?? [];
 		this.#thinkingLevel = config.thinkingLevel;
+		this.#allowSkillRuntimePreferences = config.allowSkillRuntimePreferences ?? true;
 		this.#promptTemplates = config.promptTemplates ?? [];
 		this.#slashCommands = config.slashCommands ?? [];
 		this.#extensionRunner = config.extensionRunner;
@@ -5541,6 +5548,147 @@ export class AgentSession {
 		}
 	}
 
+	#hasApplicableSkillRuntimePreferences(message: Pick<CustomMessage<unknown>, "customType" | "details">): boolean {
+		if (!this.#allowSkillRuntimePreferences || message.customType !== SKILL_PROMPT_MESSAGE_TYPE) return false;
+		if (!message.details || typeof message.details !== "object") return false;
+		const details = message.details as { requestedModel?: unknown; requestedEffort?: unknown };
+		return (
+			(typeof details.requestedModel === "string" && details.requestedModel.trim().length > 0) ||
+			(typeof details.requestedEffort === "string" && details.requestedEffort.trim().length > 0)
+		);
+	}
+
+	async #beginSkillPromptRuntimePreferences(
+		message: Pick<CustomMessage<unknown>, "customType" | "details">,
+	): Promise<boolean> {
+		if (!this.#hasApplicableSkillRuntimePreferences(message)) return false;
+		if (!message.details || typeof message.details !== "object") return false;
+		const details = message.details as {
+			name?: unknown;
+			requestedModel?: unknown;
+			requestedEffort?: unknown;
+		};
+		const skillName = typeof details.name === "string" && details.name.trim() ? details.name.trim() : "unknown";
+		const rawModel = typeof details.requestedModel === "string" ? details.requestedModel.trim() : "";
+		const rawEffort = typeof details.requestedEffort === "string" ? details.requestedEffort.trim().toLowerCase() : "";
+		if (!rawModel && !rawEffort) return false;
+
+		const ownsRestoreState = this.#skillRuntimeRestoreState === undefined;
+		const currentModel = this.model;
+		if (!currentModel) throw new Error(`Skill "${skillName}" cannot select a model before session initialization`);
+		if (ownsRestoreState) {
+			this.#skillRuntimeRestoreState = { model: currentModel, thinkingLevel: this.thinkingLevel };
+		}
+		try {
+			const requestedEffort = rawEffort ? parseThinkingLevel(rawEffort) : undefined;
+			if (rawEffort && !requestedEffort) {
+				throw new Error(`Skill "${skillName}" requested unsupported effort "${rawEffort}"`);
+			}
+
+			const inheritModel =
+				rawModel === "" || rawModel.toLowerCase() === "inherit" || rawModel.toLowerCase() === "default";
+			if (inheritModel) {
+				if (requestedEffort) this.setThinkingLevel(requestedEffort);
+				return ownsRestoreState;
+			}
+
+			const contextMatch = /\[(\d+(?:\.\d+)?)(k|m)?\]$/i.exec(rawModel);
+			const contextMultiplier = contextMatch?.[2]?.toLowerCase() === "m" ? 1_000_000 : contextMatch?.[2] ? 1_000 : 1;
+			const minimumContextWindow = contextMatch ? Number(contextMatch[1]) * contextMultiplier : 0;
+			let availableModels = await resolveAllowedModels(this.#modelRegistry, this.settings, {
+				usageOrder: this.settings.getStorage()?.getModelUsageOrder(),
+			});
+			if (minimumContextWindow > 0) {
+				availableModels = availableModels.filter(model => model.contextWindow >= minimumContextWindow);
+				if (availableModels.length === 0) {
+					throw new Error(
+						`Skill "${skillName}" requested model "${rawModel}", but no available model has that context window`,
+					);
+				}
+			}
+
+			const modelSelector = rawModel.replace(/\[(?:\d+(?:\.\d+)?(?:k|m)?)\]$/i, "").trim();
+			if (!modelSelector) {
+				throw new Error(`Skill "${skillName}" requested invalid model "${rawModel}"`);
+			}
+			const familyMatch = /^(?:claude-)?(opus|sonnet|haiku)$/i.exec(modelSelector);
+			let resolvedModel: Model | undefined;
+			let selectorThinkingLevel: ThinkingLevel | undefined;
+			let selectorHasThinkingLevel = false;
+			if (familyMatch?.[1]) {
+				const family = familyMatch[1].toLowerCase();
+				let latest: { major: number; minor: number } | undefined;
+				const familyVersionPattern = new RegExp(
+					`^claude-${family}-(\\d+)(?:[.-](\\d{1,2}))?(?=$|-(?:\\d{8}|high|low|medium|max|xhigh|thinking|fast)(?:-|:|$))`,
+					"i",
+				);
+				for (const model of availableModels) {
+					const versionMatch = familyVersionPattern.exec(model.id);
+					if (!versionMatch?.[1]) continue;
+					const attachedVersion = versionMatch[2] === undefined && versionMatch[1].length === 2;
+					const candidate = {
+						major: Number(attachedVersion ? versionMatch[1][0] : versionMatch[1]),
+						minor: Number(attachedVersion ? versionMatch[1][1] : (versionMatch[2] ?? 0)),
+					};
+					if (
+						!latest ||
+						candidate.major > latest.major ||
+						(candidate.major === latest.major && candidate.minor > latest.minor)
+					) {
+						latest = candidate;
+						resolvedModel = model;
+					}
+				}
+			}
+			if (!resolvedModel) {
+				const resolved = parseModelPattern(
+					modelSelector,
+					availableModels,
+					{ usageOrder: this.settings.getStorage()?.getModelUsageOrder() },
+					{ modelRegistry: this.#modelRegistry },
+				);
+				resolvedModel = resolved.model;
+				selectorThinkingLevel = resolved.thinkingLevel;
+				selectorHasThinkingLevel = resolved.explicitThinkingLevel;
+			}
+			if (!resolvedModel) {
+				throw new Error(`Skill "${skillName}" requested unavailable model "${rawModel}"`);
+			}
+			const thinkingLevel = selectorHasThinkingLevel ? selectorThinkingLevel : requestedEffort;
+			if (modelsAreEqual(resolvedModel, this.model)) {
+				if (thinkingLevel) {
+					this.setThinkingLevel(thinkingLevel);
+					this.emitNotice(
+						"info",
+						`Skill "${skillName}" selected ${resolvedModel.provider}/${resolvedModel.id} (${thinkingLevel}) for this turn.`,
+						"skill-runtime",
+					);
+				}
+				return ownsRestoreState;
+			}
+			await this.setModelTemporary(resolvedModel, thinkingLevel);
+			this.emitNotice(
+				"info",
+				`Skill "${skillName}" selected ${resolvedModel.provider}/${resolvedModel.id}${thinkingLevel ? ` (${thinkingLevel})` : ""} for this turn.`,
+				"skill-runtime",
+			);
+			return ownsRestoreState;
+		} catch (error) {
+			if (ownsRestoreState) await this.#restoreSkillPromptRuntimePreferences();
+			throw error;
+		}
+	}
+
+	async #restoreSkillPromptRuntimePreferences(): Promise<void> {
+		const restore = this.#skillRuntimeRestoreState;
+		if (!restore) return;
+		this.#skillRuntimeRestoreState = undefined;
+		if (!modelsAreEqual(restore.model, this.model)) {
+			await this.setModelTemporary(restore.model, restore.thinkingLevel);
+		}
+		this.setThinkingLevel(restore.thinkingLevel);
+	}
+
 	async #syncSkillPromptActiveState(
 		message: Pick<CustomMessage<unknown>, "customType" | "details">,
 		active: boolean,
@@ -5638,12 +5786,14 @@ export class AgentSession {
 			attribution: message.attribution ?? "agent",
 			timestamp: Date.now(),
 		};
+		const ownsSkillRuntimeRestore = await this.#beginSkillPromptRuntimePreferences(customMessage);
 
 		await this.#syncSkillPromptActiveStateSafely(customMessage, true);
 		try {
 			await this.#promptWithMessage(customMessage, textContent, options);
 		} finally {
 			await this.#syncSkillPromptActiveStateSafely(customMessage, false);
+			if (ownsSkillRuntimeRestore) await this.#restoreSkillPromptRuntimePreferences();
 		}
 	}
 
@@ -6160,8 +6310,26 @@ export class AgentSession {
 
 		const prependMessages = queuedMessages.slice(0, -1);
 		const textContent = this.#getCustomMessageTextContent(message);
-		await this.#syncSkillPromptActiveStateSafely(message, true);
+		let ownsSkillRuntimeRestore = false;
 		try {
+			try {
+				ownsSkillRuntimeRestore = await this.#beginSkillPromptRuntimePreferences(message);
+			} catch (error) {
+				if (!this.#hasApplicableSkillRuntimePreferences(message)) throw error;
+				const safePrependMessages = prependMessages.filter(
+					queuedMessage => !this.#hasApplicableSkillRuntimePreferences(queuedMessage),
+				);
+				this.#pendingNextTurnMessages = [...safePrependMessages, ...this.#pendingNextTurnMessages];
+				this.emitNotice(
+					"error",
+					`Deferred skill invocation was dropped because its runtime model preferences could not be applied: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+					"skill-runtime",
+				);
+				return;
+			}
+			await this.#syncSkillPromptActiveStateSafely(message, true);
 			await this.#promptWithMessage(message, textContent, {
 				prependMessages,
 				skipPostPromptRecoveryWait: true,
@@ -6171,6 +6339,7 @@ export class AgentSession {
 			throw error;
 		} finally {
 			await this.#syncSkillPromptActiveStateSafely(message, false);
+			if (ownsSkillRuntimeRestore) await this.#restoreSkillPromptRuntimePreferences();
 		}
 	}
 
@@ -6226,6 +6395,10 @@ export class AgentSession {
 			attribution: message.attribution ?? "agent",
 			timestamp: Date.now(),
 		};
+		if (this.isStreaming && this.#hasApplicableSkillRuntimePreferences(appMessage)) {
+			this.#queueHiddenNextTurnMessage(appMessage, true);
+			return;
+		}
 		if (this.isStreaming) {
 			if (options?.deliverAs === "nextTurn") {
 				this.#queueHiddenNextTurnMessage(appMessage, options?.triggerTurn ?? false);
@@ -6249,6 +6422,7 @@ export class AgentSession {
 					this.#queueHiddenNextTurnMessage(appMessage, false);
 					return;
 				}
+				const ownsSkillRuntimeRestore = await this.#beginSkillPromptRuntimePreferences(appMessage);
 				await this.#syncSkillPromptActiveStateSafely(appMessage, true);
 				try {
 					await this.#promptWithMessage(appMessage, this.#getCustomMessageTextContent(appMessage), {
@@ -6256,6 +6430,7 @@ export class AgentSession {
 					});
 				} finally {
 					await this.#syncSkillPromptActiveStateSafely(appMessage, false);
+					if (ownsSkillRuntimeRestore) await this.#restoreSkillPromptRuntimePreferences();
 				}
 				return;
 			}
@@ -6276,6 +6451,7 @@ export class AgentSession {
 				this.#queueHiddenNextTurnMessage(appMessage, false);
 				return;
 			}
+			const ownsSkillRuntimeRestore = await this.#beginSkillPromptRuntimePreferences(appMessage);
 			await this.#syncSkillPromptActiveStateSafely(appMessage, true);
 			try {
 				await this.#promptWithMessage(appMessage, this.#getCustomMessageTextContent(appMessage), {
@@ -6283,6 +6459,7 @@ export class AgentSession {
 				});
 			} finally {
 				await this.#syncSkillPromptActiveStateSafely(appMessage, false);
+				if (ownsSkillRuntimeRestore) await this.#restoreSkillPromptRuntimePreferences();
 			}
 			return;
 		}
@@ -6910,6 +7087,7 @@ export class AgentSession {
 		if (!apiKey) {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
 		}
+		if (role === "default") this.#allowSkillRuntimePreferences = false;
 
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(model);
@@ -6980,6 +7158,7 @@ export class AgentSession {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
 		}
 
+		if (options?.persistAsSessionDefault) this.#allowSkillRuntimePreferences = false;
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(model);
 		this.sessionManager.appendModelChange(

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7145,12 +7145,18 @@ export class AgentSession {
 	 * `persistAsSessionDefault: true` so the profile's main model becomes the
 	 * session default and survives resume, while still not being written to
 	 * global settings (new sessions keep the global default).
+	 *
+	 * `persistAsSessionDefault` also marks the session model as explicitly
+	 * chosen, disabling SKILL.md model/effort preferences — unless
+	 * `preserveSkillRuntimePreferences` is set, which config-driven startup
+	 * profile auto-activation uses because an ambient config default must not
+	 * silence skill frontmatter.
 	 * @throws Error if no API key available for the model
 	 */
 	async setModelTemporary(
 		model: Model,
 		thinkingLevel?: ThinkingLevel,
-		options?: { persistAsSessionDefault?: boolean },
+		options?: { persistAsSessionDefault?: boolean; preserveSkillRuntimePreferences?: boolean },
 	): Promise<void> {
 		const previousEditMode = this.#resolveActiveEditMode();
 		const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
@@ -7158,7 +7164,9 @@ export class AgentSession {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
 		}
 
-		if (options?.persistAsSessionDefault) this.#allowSkillRuntimePreferences = false;
+		if (options?.persistAsSessionDefault && !options?.preserveSkillRuntimePreferences) {
+			this.#allowSkillRuntimePreferences = false;
+		}
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(model);
 		this.sessionManager.appendModelChange(

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -38,6 +38,10 @@ export interface SkillPromptDetails {
 	path: string;
 	args?: string;
 	lineCount: number;
+	/** Raw model selector requested by the invoked SKILL.md frontmatter. */
+	requestedModel?: string;
+	/** Raw reasoning effort requested by the invoked SKILL.md frontmatter. */
+	requestedEffort?: string;
 	subskillActivation?: LoadedSubskillActivation;
 	subskillActivationSet?: LoadedSubskillActivation[];
 	/** Internal: tag used by AgentSession to remove the pending-display chip

--- a/packages/coding-agent/test/agent-session-profile-resume-default.test.ts
+++ b/packages/coding-agent/test/agent-session-profile-resume-default.test.ts
@@ -207,6 +207,38 @@ describe("AgentSession setModelTemporary persistAsSessionDefault", () => {
 		expect(requestedModels).toEqual([`${base.provider}/${base.id}`]);
 		expect(session.model).toBe(base);
 	});
+	it("keeps skill frontmatter applicable when the profile default is config-driven", async () => {
+		const { base, profileMain } = resolveModels();
+		const requestedModels: string[] = [];
+		session = makeSession(base, requestedModels);
+		// Startup auto-activation of `modelProfile.default` from config: ambient
+		// default, not an explicit user pick.
+		await session.setModelTemporary(base, undefined, {
+			persistAsSessionDefault: true,
+			preserveSkillRuntimePreferences: true,
+		});
+		// Preserving skill prefs must not weaken the resume-default recording.
+		expect(session.sessionManager.buildSessionContext().models.default).toBe("openai-codex/gpt-5.5");
+		const originalThinking = session.thinkingLevel;
+
+		await session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "# Creative\nWrite.",
+			display: true,
+			attribution: "user",
+			details: {
+				name: "creative",
+				path: "/tmp/creative/SKILL.md",
+				lineCount: 2,
+				requestedModel: "opus[1m]",
+				requestedEffort: "high",
+			},
+		});
+
+		expect(requestedModels).toEqual([`${profileMain.provider}/${profileMain.id}`]);
+		expect(session.model).toBe(base);
+		expect(session.thinkingLevel).toBe(originalThinking);
+	});
 	it("fails closed when a skill's requested context window is unavailable", async () => {
 		const { base } = resolveModels();
 		session = makeSession(base);

--- a/packages/coding-agent/test/agent-session-profile-resume-default.test.ts
+++ b/packages/coding-agent/test/agent-session-profile-resume-default.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@gajae-code/agent-core";
-import type { Model } from "@gajae-code/ai";
+import type { AssistantMessage, Model } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import {
 	applyPreparedModelProfileActivation,
 	prepareModelProfileActivation,
@@ -10,6 +12,7 @@ import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SKILL_PROMPT_MESSAGE_TYPE } from "@gajae-code/coding-agent/session/messages";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import { TempDir } from "@gajae-code/utils";
 
@@ -43,13 +46,23 @@ describe("AgentSession setModelTemporary persistAsSessionDefault", () => {
 		tempDir.removeSync();
 	});
 
-	function makeSession(startModel: Model): AgentSession {
+	function makeSession(
+		startModel: Model,
+		requestedModels?: string[],
+		allowSkillRuntimePreferences: boolean = true,
+	): AgentSession {
+		const mock = createMockModel({ responses: [{ content: ["Done"] }] });
 		const agent = new Agent({
+			getApiKey: () => "test-key",
 			initialState: {
 				model: startModel,
 				systemPrompt: ["Test"],
 				tools: [],
 				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				requestedModels?.push(`${model.provider}/${model.id}`);
+				return mock.stream(model, context, options);
 			},
 		});
 		return new AgentSession({
@@ -57,6 +70,7 @@ describe("AgentSession setModelTemporary persistAsSessionDefault", () => {
 			sessionManager: SessionManager.inMemory(),
 			settings: Settings.isolated({ "compaction.enabled": false }),
 			modelRegistry,
+			allowSkillRuntimePreferences,
 		});
 	}
 
@@ -100,7 +114,268 @@ describe("AgentSession setModelTemporary persistAsSessionDefault", () => {
 		// Resume still restores the explicit base default, not the transient model.
 		expect(session.sessionManager.buildSessionContext().models.default).toBe("openai-codex/gpt-5.5");
 	});
+	it("applies a skill's requested model and effort for its turn, then restores the session model", async () => {
+		const { base, profileMain } = resolveModels();
+		const requestedModels: string[] = [];
+		session = makeSession(base, requestedModels);
+		const originalThinking = session.thinkingLevel;
 
+		await session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "# Creative\nWrite.",
+			display: true,
+			attribution: "user",
+			details: {
+				name: "creative",
+				path: "/tmp/creative/SKILL.md",
+				lineCount: 2,
+				requestedModel: "opus[1m]",
+				requestedEffort: "high",
+			},
+		});
+
+		expect(requestedModels).toEqual([`${profileMain.provider}/${profileMain.id}`]);
+		expect(session.model).toBe(base);
+		expect(session.thinkingLevel).toBe(originalThinking);
+	});
+	it("resolves a single-integer Claude family version as the newest available model", async () => {
+		const { base } = resolveModels();
+		const sonnet5 = modelRegistry.find("anthropic", "claude-sonnet-5");
+		if (!sonnet5) throw new Error("Expected anthropic sonnet 5 model to exist");
+		const requestedModels: string[] = [];
+		session = makeSession(base, requestedModels);
+
+		await session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "# Creative\nWrite.",
+			display: true,
+			attribution: "user",
+			details: {
+				name: "creative",
+				path: "/tmp/creative/SKILL.md",
+				lineCount: 2,
+				requestedModel: "sonnet",
+			},
+		});
+
+		expect(requestedModels).toEqual([`${sonnet5.provider}/${sonnet5.id}`]);
+		expect(session.model).toBe(base);
+	});
+	it("keeps an explicit session model authoritative over skill frontmatter", async () => {
+		const { base } = resolveModels();
+		const requestedModels: string[] = [];
+		session = makeSession(base, requestedModels);
+		await session.setModel(base);
+
+		await session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "# Creative\nWrite.",
+			display: true,
+			attribution: "user",
+			details: {
+				name: "creative",
+				path: "/tmp/creative/SKILL.md",
+				lineCount: 2,
+				requestedModel: "opus[1m]",
+				requestedEffort: "high",
+			},
+		});
+
+		expect(requestedModels).toEqual([`${base.provider}/${base.id}`]);
+		expect(session.model).toBe(base);
+	});
+	it("keeps an explicit model profile authoritative over skill frontmatter", async () => {
+		const { base } = resolveModels();
+		const requestedModels: string[] = [];
+		session = makeSession(base, requestedModels);
+		await session.setModelTemporary(base, undefined, { persistAsSessionDefault: true });
+
+		await session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "# Creative\nWrite.",
+			display: true,
+			attribution: "user",
+			details: {
+				name: "creative",
+				path: "/tmp/creative/SKILL.md",
+				lineCount: 2,
+				requestedModel: "opus[1m]",
+				requestedEffort: "high",
+			},
+		});
+
+		expect(requestedModels).toEqual([`${base.provider}/${base.id}`]);
+		expect(session.model).toBe(base);
+	});
+	it("fails closed when a skill's requested context window is unavailable", async () => {
+		const { base } = resolveModels();
+		session = makeSession(base);
+
+		const invocation = session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "# Creative\nWrite.",
+			display: true,
+			attribution: "user",
+			details: {
+				name: "creative",
+				path: "/tmp/creative/SKILL.md",
+				lineCount: 2,
+				requestedModel: "opus[2m]",
+			},
+		});
+
+		await expect(invocation).rejects.toThrow(/no available model has that context window/);
+		expect(session.model).toBe(base);
+	});
+
+	it("defers a chained skill with model metadata to a fresh model turn", async () => {
+		const { base, profileMain } = resolveModels();
+		const requestedModels: string[] = [];
+		let streamCalls = 0;
+		let finishFirst: (() => void) | undefined;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: base, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: model => {
+				streamCalls += 1;
+				requestedModels.push(`${model.provider}/${model.id}`);
+				const stream = new AssistantMessageEventStream();
+				const message = {
+					role: "assistant",
+					content: [{ type: "text", text: "done" }],
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					stopReason: "stop",
+					usage: {
+						input: 1,
+						output: 1,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 2,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					timestamp: Date.now(),
+				} as AssistantMessage;
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					if (streamCalls === 1) {
+						finishFirst = () => stream.push({ type: "done", reason: "stop", message });
+					} else {
+						stream.push({ type: "done", reason: "stop", message });
+					}
+				});
+				return stream;
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+
+		const firstTurn = session.prompt("start");
+		for (let i = 0; i < 100 && !finishFirst; i += 1) await Bun.sleep(5);
+		expect(finishFirst).toBeDefined();
+
+		await session.sendCustomMessage(
+			{
+				customType: SKILL_PROMPT_MESSAGE_TYPE,
+				content: "# Interview\nContinue.",
+				display: true,
+				attribution: "user",
+				details: {
+					name: "vc-characterchat-interview",
+					path: "/tmp/interview/SKILL.md",
+					lineCount: 2,
+					requestedModel: "opus[1m]",
+					requestedEffort: "high",
+				},
+			},
+			{ triggerTurn: false },
+		);
+		finishFirst?.();
+		await firstTurn;
+		for (let i = 0; i < 200 && requestedModels.length < 2; i += 1) await Bun.sleep(5);
+
+		expect(requestedModels).toEqual([`${base.provider}/${base.id}`, `${profileMain.provider}/${profileMain.id}`]);
+		expect(session.model).toBe(base);
+	});
+	it("drops a deferred skill when its runtime model preferences cannot be applied", async () => {
+		const { base } = resolveModels();
+		const requestedModels: string[] = [];
+		let finishFirst: (() => void) | undefined;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: base, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: model => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				const stream = new AssistantMessageEventStream();
+				const message = {
+					role: "assistant",
+					content: [{ type: "text", text: "done" }],
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					stopReason: "stop",
+					usage: {
+						input: 1,
+						output: 1,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 2,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					timestamp: Date.now(),
+				} as AssistantMessage;
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					if (requestedModels.length === 1) {
+						finishFirst = () => stream.push({ type: "done", reason: "stop", message });
+					} else {
+						stream.push({ type: "done", reason: "stop", message });
+					}
+				});
+				return stream;
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+
+		const firstTurn = session.prompt("start");
+		for (let i = 0; i < 100 && !finishFirst; i += 1) await Bun.sleep(5);
+		expect(finishFirst).toBeDefined();
+
+		await session.sendCustomMessage(
+			{
+				customType: SKILL_PROMPT_MESSAGE_TYPE,
+				content: "# Interview\nContinue.",
+				display: true,
+				attribution: "user",
+				details: {
+					name: "vc-characterchat-interview",
+					path: "/tmp/interview/SKILL.md",
+					lineCount: 2,
+					requestedModel: "opus[2m]",
+				},
+			},
+			{ triggerTurn: false },
+		);
+		finishFirst?.();
+		await firstTurn;
+		await Bun.sleep(50);
+
+		expect(requestedModels).toEqual([`${base.provider}/${base.id}`]);
+		expect(JSON.stringify(agent.state.messages)).not.toContain("# Interview");
+
+		await session.prompt("after");
+		expect(requestedModels).toEqual([`${base.provider}/${base.id}`, `${base.provider}/${base.id}`]);
+	});
 	it("rollback of a failed activation restores the pre-activation resume default, not the transient live model", async () => {
 		// A = persisted resume default, B = transient live model (e.g. retry/
 		// fallback/plan switch), profileMain = the profile's main model the failed

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -39,19 +39,31 @@ function fakeRegistry(
 	return registry;
 }
 
+type SetModelTemporaryOptions = { persistAsSessionDefault?: boolean; preserveSkillRuntimePreferences?: boolean };
+
 function fakeSession(initial = model("initial-provider", "initial")) {
 	const session = {
 		model: initial as Model | undefined,
 		thinkingLevel: undefined as ThinkingLevel | undefined,
 		sessionId: "session-1",
-		setModelTemporaryCalls: [] as Array<{ model: Model; thinkingLevel?: ThinkingLevel }>,
-		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel) {
-			session.setModelTemporaryCalls.push({ model: next, thinkingLevel });
+		setModelTemporaryCalls: [] as Array<{
+			model: Model;
+			thinkingLevel?: ThinkingLevel;
+			options?: SetModelTemporaryOptions;
+		}>,
+		async setModelTemporary(next: Model, thinkingLevel?: ThinkingLevel, options?: SetModelTemporaryOptions) {
+			session.setModelTemporaryCalls.push({ model: next, thinkingLevel, options });
 			session.model = next;
 			session.thinkingLevel = thinkingLevel;
 		},
 	};
-	return session as AgentSession & { setModelTemporaryCalls: Array<{ model: Model; thinkingLevel?: ThinkingLevel }> };
+	return session as AgentSession & {
+		setModelTemporaryCalls: Array<{
+			model: Model;
+			thinkingLevel?: ThinkingLevel;
+			options?: SetModelTemporaryOptions;
+		}>;
+	};
 }
 describe("CLI model profile args", () => {
 	test("parses --mpreset with separate value", () => {
@@ -156,6 +168,40 @@ test("deferred explicit CLI --model is reapplied after --mpreset activation", as
 	).toEqual(["profile-provider/default:high", "cli-provider/explicit:undefined"]);
 	expect(session.setModelTemporaryCalls.at(-1)?.model).toBe(explicitModel);
 	expect(session.model).toBe(explicitModel);
+});
+
+test("config default profile activation preserves skill runtime preferences; --mpreset does not", async () => {
+	const settings = Settings.isolated({ "modelProfile.default": "default-profile" });
+	const session = fakeSession();
+	const registry = fakeRegistry([
+		{
+			name: "default-profile",
+			requiredProviders: ["profile-provider"],
+			modelMapping: { default: "profile-provider/default:medium" },
+			source: "user",
+		},
+		{
+			name: "session-profile",
+			requiredProviders: ["cli-provider"],
+			modelMapping: { default: "cli-provider/explicit:high" },
+			source: "user",
+		},
+	]) as never;
+
+	await applyStartupModelProfiles({
+		session,
+		settings,
+		modelRegistry: registry,
+		parsedArgs: { mpreset: "session-profile" },
+		startupModel: undefined,
+		startupThinkingLevel: undefined,
+	});
+
+	expect(
+		session.setModelTemporaryCalls.map(
+			call => `${call.model.provider}/${call.model.id}:${call.options?.preserveSkillRuntimePreferences === true}`,
+		),
+	).toEqual(["profile-provider/default:true", "cli-provider/explicit:false"]);
 });
 
 test("ACP session factory applies default profile and --mpreset before returning session", async () => {

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -92,6 +92,24 @@ describe("skills", () => {
 			expect(validSkill?.source).toBe("test");
 			expect(warnings).toHaveLength(0);
 		});
+		it("loads model and effort frontmatter for runtime execution", async () => {
+			const dir = await fs.mkdtemp(path.join(os.tmpdir(), "skill-runtime-metadata-"));
+			try {
+				const skillDir = path.join(dir, "creative");
+				await fs.mkdir(skillDir);
+				await fs.writeFile(
+					path.join(skillDir, "SKILL.md"),
+					"---\nname: creative\ndescription: Creative skill\nmodel: opus[1m]\neffort: high\n---\n\nWrite.",
+				);
+
+				const { skills } = await loadSkillsFromDir({ dir, source: "test" });
+
+				expect(skills[0]?.model).toBe("opus[1m]");
+				expect(skills[0]?.effort).toBe("high");
+			} finally {
+				await fs.rm(dir, { recursive: true, force: true });
+			}
+		});
 
 		it("should load skill when name doesn't match parent directory", async () => {
 			const { skills } = await loadFixtureRoot();
@@ -513,6 +531,19 @@ description: Skill loaded from a tilde-expanded custom directory.
 			expect(built.details.args).toBe(args);
 			expect(built.message).toContain(`User: ${args}`);
 			expect(built.message).toContain("END");
+		});
+		it("carries Claude-compatible model and effort frontmatter into runtime details", async () => {
+			const skill = {
+				...makeSkill("creative"),
+				content: "---\nname: creative\nmodel: opus[1m]\neffort: high\n---\n\n# Creative\nWrite.",
+				model: "opus[1m]",
+				effort: "high",
+			} as Skill & { model: string; effort: string };
+
+			const built = await buildSkillPromptMessage(skill, "");
+
+			expect(built.details.requestedModel).toBe("opus[1m]");
+			expect(built.details.requestedEffort).toBe("high");
 		});
 	});
 });


### PR DESCRIPTION
## Problem

Runtime-skill `SKILL.md` frontmatter (`model:`, `effort:`) was being **silently stripped** before reaching session execution — `buildSkillPromptMessage(...)` dropped the metadata, so a skill requesting `opus[1m]` + `high` ran on the ambient default model instead. Additionally, once the propagation was added, a **regression** surfaced: a user with `modelProfile.default` configured had the startup auto-activation disable skill runtime preferences for every session.

Concrete impact: `vc-autopilot` / `vc-characterchat-interview` skills request `model:"opus[1m]"`, `effort:"high"` but were running on a GPT default at `xhigh`, contributing to orchestration latency and wrong-model execution.

## Changes (2 commits, cherry-picked onto `dev`)

**1. `fix(skills): honor runtime model preferences`**
Propagate runtime skill `model`/`effort` from frontmatter to execution:
- `capability/skill.ts`, `extensibility/runtime-skill-discovery.ts`, `extensibility/skills.ts`, `session/messages.ts` — carry metadata through the prompt message (`requestedModel` / `requestedEffort` in skill-prompt details).
- `session/agent-session.ts` — apply the skill-requested model+effort for the skill turn via `#hasApplicableSkillRuntimePreferences`, then restore prior model/thinking on turn end (incl. error paths). New `#allowSkillRuntimePreferences` flag + `#skillRuntimeRestoreState`.
- `sdk.ts` — default `allowSkillRuntimePreferences: !hasExplicitModel`.

**2. `fix(skills): keep skill runtime preferences under config default model profile`**
Regression fix: config-driven `modelProfile.default` auto-activation (`applyStartupModelProfiles → activateModelProfile → setModelTemporary(persistAsSessionDefault: true)`) was setting `allowSkillRuntimePreferences = false`, silencing skill frontmatter for all users with a default profile.
- `setModelTemporary` gains `preserveSkillRuntimePreferences`; the disable fires only when `persistAsSessionDefault && !preserveSkillRuntimePreferences`.
- `main.ts` passes `preserveSkillRuntimePreferences: true` **only** for the config-driven `modelProfile.default` branch — explicit `--mpreset` and explicit model/profile selections still take precedence over skill frontmatter (unchanged).

## Precedence preserved (fail-closed)
Explicit CLI `--model` / `--mpreset`, in-session `/model`, and model-profile selection all override skill frontmatter. Unavailable context/model requests and deferred preference failures fail closed rather than silently running an unrelated default.

## Verification
- `tsc -p tsconfig.json --noEmit` → clean
- `biome check .` → clean
- Focused tests: `59 pass / 0 fail` across `agent-session-profile-resume-default.test.ts`, `cli-args-mpreset.test.ts`, `skills.test.ts`
- E2E smoke under a real `modelProfile.default: mix4` config confirmed skill-requested `opus[1m]` resolves to an opus-family model + `high` effort, then restores prior model/thinking after the skill turn.

Base: `dev` (these were originally developed on `main`; rebased here so the diff is exactly the two fix commits).