### PR TITLE
fix(coordinator-mcp): report --worktree runtime state via launch-authorized handoff (supersedes #2094)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added an owner-proof idle session reaper and `gjc_coordinator_stop_session` for ephemeral (delegate-created) coordinator sessions. Termination goes exclusively through the owner-proof `forceCloseGjcTmuxSession` path (pid, native session id, owner generation, server key, and start time all verified before SIGTERM) — never a raw `process.kill`. The reaper binds each close to the persisted runtime-state file, re-validates ephemeral and no-active-turn at kill time under the same per-session mutation lock as delegate reuse, and purges state only on verified termination (#2080).
 
+### Fixed
+
+- A coordinator-managed `--worktree` delegate runtime now reports its runtime state (turn_start / running / completed) back to the coordinator. The runtime executes in a git worktree whose cwd differs from the delegate cwd the coordinator recorded in its initial `source: "coordinator"` state write, so the runtime-state identity guard (keyed on cwd/workdir/session_file) threw `PreviousRuntimeStateReadError` on every agent-emitted write and the coordinator's view froze at the initial `running` (spurious ack timeouts, hung turns). The coordinator now copies its session's `launch_id` onto its own runtime-state writes, and the runtime skips the cwd/workdir/session_file check for the coordinator→agent handoff **only** when the prior record is the coordinator's own **non-terminal** write whose `launch_id` equals this runtime's `GJC_COORDINATOR_SESSION_LAUNCH_ID`. A superseded/foreign launch (including a truncated 32-bit session-id/state-file collision) and a terminal coordinator state (which a late event must not reopen) are rejected; the bypass is one-shot by construction because `writeSessionStateUnlocked` refuses to overwrite a runtime-authored (`agent_session_event`) record. Every other prior state keeps the full guard (#2094).
+
 ## [0.10.0] - 2026-07-12
 
 ### Added

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -227,6 +227,11 @@ interface CoordinatorSessionState {
 	last_turn_id: string | null;
 	updated_at: string;
 	source: "coordinator" | "agent_session_event" | "process_postmortem";
+	// The coordinator's launch id for this session, copied from the session record onto every
+	// coordinator-authored runtime-state write. It lets the coordinator-managed runtime authorize its
+	// first state write (whose worktree cwd differs from the delegate cwd the coordinator recorded)
+	// against the launch it was actually spawned for — a superseded/foreign launch is rejected.
+	launch_id?: string;
 
 	live: boolean | null;
 	reason: string | null;
@@ -1892,6 +1897,10 @@ async function writeSessionStateUnlocked(
 		last_turn_id: options.lastTurnId ?? previous?.last_turn_id ?? null,
 		updated_at: new Date().toISOString(),
 		source: options.source ?? "coordinator",
+		// Copy the launch id from the coordinator's own session record so the runtime can authorize its
+		// first state write against the launch it was spawned for. Only coordinator-created sessions have
+		// a launch id; registered/foreign sessions omit it (and never take the coordinator→agent bypass).
+		...(typeof session?.launch_id === "string" && session.launch_id.trim() ? { launch_id: session.launch_id } : {}),
 		live: options.live ?? previous?.live ?? null,
 		reason: options.reason ?? null,
 		cwd,

--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -508,6 +508,33 @@ function assertPreviousRuntimeStateIdentity(
 	input: { sessionId: string; cwd: string; sessionFile: string | null },
 ): void {
 	if (Object.keys(previous).length === 0) return;
+	// The coordinator writes the initial runtime-state (source "coordinator") with the delegate cwd,
+	// before the --worktree runtime has created its worktree; the runtime then legitimately runs in a
+	// worktree cwd (and writes its own agent session_file). The cwd/workdir/session_file guard cannot
+	// apply to that one coordinator→agent handoff. Skip it ONLY for the coordinator's own non-terminal
+	// record of THIS launch:
+	//   - session_id must match — never accept a foreign session;
+	//   - launch_id (which the coordinator copies onto its state writes from its own session record)
+	//     must equal this runtime's GJC_COORDINATOR_SESSION_LAUNCH_ID — a superseded/foreign launch, or a
+	//     truncated 32-bit session-id/state-file collision, is rejected rather than silently adopted;
+	//   - the record must not already be terminal — a late async event from a superseded runtime may not
+	//     reopen a coordinator-terminal state (which would falsely bind/ack a promoted queued turn).
+	// This is one-shot by construction: once the runtime writes agent_session_event, the coordinator's
+	// writeSessionStateUnlocked refuses to overwrite a non-coordinator record, so the runtime never sees
+	// a source "coordinator" predecessor again. Every other prior state (agent→agent, or a genuinely
+	// stale/foreign record) keeps the full cwd/workdir/session_file guard.
+	if (process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim() && previous.source === "coordinator") {
+		const launchId = process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV]?.trim();
+		if (
+			previous.session_id !== input.sessionId ||
+			previous.state === "completed" ||
+			previous.state === "errored" ||
+			!launchId ||
+			previous.launch_id !== launchId
+		)
+			throw new PreviousRuntimeStateReadError();
+		return;
+	}
 	if (
 		previous.session_id !== input.sessionId ||
 		typeof previous.cwd !== "string" ||

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../src/coordinator-mcp/server";
 import {
 	GJC_COORDINATOR_SESSION_ID_ENV,
+	GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV,
 	GJC_COORDINATOR_SESSION_STATE_FILE_ENV,
 	persistCoordinatorRuntimeStateFromPostmortem,
 } from "../src/gjc-runtime/session-state-sidecar";
@@ -29,6 +30,7 @@ import { createOwnerIntent, replaceOwnerGeneration } from "../src/gjc-runtime/tm
 const tempDirs: string[] = [];
 const ORIGINAL_RUNTIME_STATE_FILE = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV];
 const ORIGINAL_RUNTIME_SESSION_ID = process.env[GJC_COORDINATOR_SESSION_ID_ENV];
+const ORIGINAL_RUNTIME_LAUNCH_ID = process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV];
 
 async function tempRoot(): Promise<string> {
 	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-coordinator-server-"));
@@ -253,6 +255,8 @@ afterEach(async () => {
 	else process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = ORIGINAL_RUNTIME_STATE_FILE;
 	if (ORIGINAL_RUNTIME_SESSION_ID === undefined) delete process.env[GJC_COORDINATOR_SESSION_ID_ENV];
 	else process.env[GJC_COORDINATOR_SESSION_ID_ENV] = ORIGINAL_RUNTIME_SESSION_ID;
+	if (ORIGINAL_RUNTIME_LAUNCH_ID === undefined) delete process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV];
+	else process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV] = ORIGINAL_RUNTIME_LAUNCH_ID;
 	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -604,6 +608,61 @@ describe("Coordinator MCP server protocol", () => {
 		expect(commands.slice(-4).map(tmuxSubcommand)).toEqual(TMUX_PROMPT_DELIVERY_COMMANDS);
 		expect(commands.at(-2)).toEqual(["tmux", "-L", PRIVATE_SOCKET, "send-keys", "-t", "%24", "Escape"]);
 		expect(commands.at(-1)).toEqual(["tmux", "-L", PRIVATE_SOCKET, "send-keys", "-t", "%24", "Enter"]);
+	});
+
+	it("persists the session launch id onto the coordinator's own runtime-state writes", async () => {
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "state", "launch-id-persist");
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: stateRoot,
+				GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+			},
+			services: {
+				ownerIsolationProbe: privateOwnerProbe(),
+				startSession: async input =>
+					readyStart(input, {
+						sessionId: input.sessionId,
+						tmuxSession: "delegate-session",
+						tmuxTarget: "delegate-session:0.0",
+						tmuxSocketKey: PRIVATE_SOCKET,
+						tmuxOwnerServerKey: PRIVATE_SOCKET,
+						tmuxOwnerGeneration: "delegate-generation",
+						tmuxOwnerServerPid: PRIVATE_OWNER_PID,
+						tmuxOwnerServerStartTime: PRIVATE_OWNER_START_TIME,
+						tmuxNativeSessionId: "$delegate-session",
+						paneId: "%24",
+						cwd: input.cwd,
+						createdAt: "2026-06-28T00:00:00.000Z",
+					}),
+				commandRunner: async command => {
+					if (tmuxSubcommand(command) === "has-session") return { exitCode: 0, stdout: "", stderr: "" };
+					if (tmuxSubcommand(command) === "display-message")
+						return { exitCode: 0, stdout: tmuxIdentity(command), stderr: "" };
+					return { exitCode: 0, stdout: "", stderr: "" };
+				},
+			},
+		});
+
+		const start = await server.callTool("gjc_coordinator_start_session", { cwd: root, allow_mutation: true });
+		const sessionId = (start.session as { session_id: string }).session_id;
+		const sessionRecord = JSON.parse(
+			await fs.readFile(path.join(stateRoot, "local", "repo", "sessions", `${sessionId}.json`), "utf8"),
+		);
+		const runtimeState = JSON.parse(
+			await fs.readFile(path.join(stateRoot, "local", "repo", "session-states", `${sessionId}.json`), "utf8"),
+		);
+
+		// The runtime-state the --worktree runtime reads back MUST carry the session's launch id — this is
+		// the exact shape the sidecar handoff check depends on. Without this persistence the launch-id gate
+		// would reject every legitimate agent state write.
+		expect(typeof sessionRecord.launch_id).toBe("string");
+		expect((sessionRecord.launch_id as string).length).toBeGreaterThan(0);
+		expect(runtimeState.source).toBe("coordinator");
+		expect(runtimeState.launch_id).toBe(sessionRecord.launch_id);
 	});
 
 	it("fails tmux-delivered turns that never receive a runtime prompt ack", async () => {
@@ -4710,6 +4769,9 @@ setInterval(() => {}, 1000);
 		});
 		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
 		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = sessionId;
+		process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV] = JSON.parse(
+			await fs.readFile(path.join(stateRoot, "local", "repo", "sessions", `${sessionId}.json`), "utf8"),
+		).launch_id;
 		await persistCoordinatorRuntimeStateFromPostmortem(postmortem.Reason.SIGTERM, {
 			sessionId,
 			cwd: root,
@@ -4754,6 +4816,12 @@ setInterval(() => {}, 1000);
 		});
 		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
 		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = sessionId;
+		process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV] = JSON.parse(
+			await fs.readFile(
+				path.join(path.dirname(path.dirname(stateFile)), "sessions", path.basename(stateFile)),
+				"utf8",
+			),
+		).launch_id;
 		const generation = await replaceOwnerGeneration(root, sessionId, "terminal-preservation-generation");
 		await createOwnerIntent(root, {
 			generation,
@@ -4850,6 +4918,11 @@ setInterval(() => {}, 1000);
 			blockReconciliation = true;
 			process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
 			process.env[GJC_COORDINATOR_SESSION_ID_ENV] = sessionId;
+			// The real --worktree runtime always carries its launch id in the environment; mirror that so
+			// the coordinator→agent handoff authority check sees the launch the session was spawned for.
+			process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV] = JSON.parse(
+				await fs.readFile(path.join(stateRoot, "local", "repo", "sessions", `${sessionId}.json`), "utf8"),
+			).launch_id;
 			const reconcile = server.callTool("gjc_coordinator_read_turn", {
 				session_id: sessionId,
 				turn_id: turn.turn_id,

--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -143,6 +143,107 @@ describe("coordinator runtime state sidecar", () => {
 		}
 	});
 
+	// Shared setup for the coordinator→agent handoff tests: the coordinator has written an initial
+	// runtime-state (source "coordinator") with the DELEGATE cwd + this session's launch id, and the
+	// --worktree runtime now emits turn_start from a different WORKTREE cwd + its own agent session file.
+	async function coordinatorHandoff(previousOverrides: Record<string, unknown>): Promise<{
+		stateFile: string;
+		worktreeCwd: string;
+		agentSessionFile: string;
+	}> {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		const delegateCwd = path.join(root, "repo");
+		const worktreeCwd = path.join(root, "repo.gajae-code-worktrees", "wt-1");
+		await fs.mkdir(delegateCwd, { recursive: true });
+		await fs.mkdir(worktreeCwd, { recursive: true });
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "gjc-coordinator-abc";
+		await Bun.write(
+			stateFile,
+			`${JSON.stringify({
+				schema_version: 1,
+				session_id: "gjc-coordinator-abc",
+				state: "running",
+				ready_for_input: false,
+				updated_at: "2026-01-01T00:00:00.000Z",
+				current_turn_id: "turn-1",
+				last_turn_id: null,
+				live: null,
+				cwd: delegateCwd,
+				workdir: delegateCwd,
+				session_file: null,
+				source: "coordinator",
+				...previousOverrides,
+			})}\n`,
+		);
+		return { stateFile, worktreeCwd, agentSessionFile: path.join(worktreeCwd, ".gjc", "session.json") };
+	}
+
+	it("accepts the coordinator→agent handoff when the coordinator-written launch id matches this launch", async () => {
+		process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV] = "launch-1";
+		const { stateFile, worktreeCwd, agentSessionFile } = await coordinatorHandoff({ launch_id: "launch-1" });
+
+		await persistCoordinatorRuntimeStateFromEvent(
+			{ type: "turn_start" },
+			{ sessionId: "agent-internal-id", cwd: worktreeCwd, sessionFile: agentSessionFile },
+		);
+
+		// The agent write lands despite the cwd/session_file mismatch — the launch id authorized it.
+		const after = await readJson(stateFile);
+		expect(after.source).toBe("agent_session_event");
+		expect(after.session_id).toBe("gjc-coordinator-abc");
+	});
+
+	it("rejects the handoff when the coordinator record carries a different launch (superseded/foreign)", async () => {
+		process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV] = "launch-new";
+		const { stateFile, worktreeCwd, agentSessionFile } = await coordinatorHandoff({ launch_id: "launch-old" });
+
+		await expect(
+			persistCoordinatorRuntimeStateFromEvent(
+				{ type: "turn_start" },
+				{ sessionId: "agent-internal-id", cwd: worktreeCwd, sessionFile: agentSessionFile },
+			),
+		).rejects.toThrow();
+		const after = await readJson(stateFile);
+		expect(after.source).toBe("coordinator");
+		expect(after.launch_id).toBe("launch-old");
+	});
+
+	it("rejects the handoff when the coordinator record has no launch id (non-handoff coordinator write)", async () => {
+		process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV] = "launch-1";
+		const { stateFile, worktreeCwd, agentSessionFile } = await coordinatorHandoff({});
+
+		await expect(
+			persistCoordinatorRuntimeStateFromEvent(
+				{ type: "turn_start" },
+				{ sessionId: "agent-internal-id", cwd: worktreeCwd, sessionFile: agentSessionFile },
+			),
+		).rejects.toThrow();
+		expect((await readJson(stateFile)).source).toBe("coordinator");
+	});
+
+	it("rejects a late event that would reopen a coordinator-terminal state even with a matching launch", async () => {
+		process.env[GJC_COORDINATOR_SESSION_LAUNCH_ID_ENV] = "launch-1";
+		const { stateFile, worktreeCwd, agentSessionFile } = await coordinatorHandoff({
+			launch_id: "launch-1",
+			state: "completed",
+			ready_for_input: true,
+			current_turn_id: "turn-promoted-b",
+		});
+
+		await expect(
+			persistCoordinatorRuntimeStateFromEvent(
+				{ type: "turn_start" },
+				{ sessionId: "agent-internal-id", cwd: worktreeCwd, sessionFile: agentSessionFile },
+			),
+		).rejects.toThrow();
+		const after = await readJson(stateFile);
+		expect(after.source).toBe("coordinator");
+		expect(after.state).toBe("completed");
+		expect(after.current_turn_id).toBe("turn-promoted-b");
+	});
+
 	it("refreshes updated_at for duplicate same-state running writes after the heartbeat", async () => {
 		const root = await tempRoot();
 		const stateFile = path.join(root, "state.json");


### PR DESCRIPTION
Replaces the closed #2094 with a working, launch-authorized handoff. #2094 was BLOCKed because it required `previous.launch_id` but the coordinator writer never persisted `launch_id` (so the check would reject every production handoff), and its tests fabricated a payload shape the real writer does not produce. This revision fixes both.

## Root cause
A coordinator-managed `--worktree` runtime runs in a git worktree whose cwd differs from the delegate cwd the coordinator recorded in its initial `source: "coordinator"` state write. `assertPreviousRuntimeStateIdentity` keyed on cwd/workdir/session_file → every agent state write threw `PreviousRuntimeStateReadError` and the coordinator's view froze at the initial `running` (ack timeouts, hung turns). Verified: a clean-identity build times out; this patch reaches `agent_session_event` + ack against a live `--worktree` runtime.

## How
- **The coordinator now persists `launch_id`** onto its own runtime-state writes (`writeSessionStateUnlocked` copies it from the session record). This is the shape the runtime reads back — directly refuting #2094's #1 (unreachable handoff / fabricated test shape).
- The runtime skips the cwd/workdir/session_file check for the coordinator→agent handoff **only** when the prior record is the coordinator's own **non-terminal** write whose `launch_id` equals this runtime's `GJC_COORDINATOR_SESSION_LAUNCH_ID`:
  - a **superseded/foreign launch** (incl. a truncated 32-bit id/state-file collision) is rejected (#2094 #2/#3);
  - a **terminal coordinator state** (which a late event must not reopen) is rejected.
- **One-shot by construction:** `writeSessionStateUnlocked` refuses to overwrite a runtime-authored (`agent_session_event`) record, so after the first agent write the runtime never sees a `source: "coordinator"` predecessor again — no session-lifetime re-bypass.

## Testing
- **Coordinator writer test:** `start_session` persists `launch_id` onto the runtime-state (fails if the coordinator copy is removed) — the tests exercise the real writer shape.
- **Sidecar tests:** handoff accepted on matching launch; rejected on launch mismatch, missing launch id, and a terminal record (late-event reopen).
- **E2E:** live `--worktree` runtime reaches `agent_session_event` + ack (clean-identity build times out).
- `bun test`: coordinator-mcp-server **91 pass / 11 fail**, session-state-sidecar **47 pass / 4 fail** (the failures are pre-existing macOS env-dependent owner-postmortem tests).
- `tsc`: 0. `biome check .`: clean.

## Scope
This PR is limited to runtime **state reporting / ack detection**. The earlier `needs_user_input` question-relay claim (#2094 #4) is **not** claimed here.

## Checklist
- [x] Writer test proves `launch_id` is persisted (real shape)
- [x] Discriminating reject tests (launch mismatch / missing / terminal)
- [x] CHANGELOG updated (`[Unreleased] > Fixed`)
- [x] No new regressions vs baseline
- [x] `tsc` + `biome` green
- [x] DCO `Signed-off-by`
