### PR TITLE
ci: make TypeScript 7 platform checks portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,13 @@ jobs:
               key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
          - if: needs.relevance.outputs.relevant == 'true'
            run: bun install --frozen-lockfile
+         - name: Build native addon (win32-x64 baseline)
+           if: needs.relevance.outputs.relevant == 'true'
+           env:
+              TARGET_PLATFORM: win32
+              TARGET_ARCH: x64
+              TARGET_VARIANTS: baseline
+           run: bun run ci:build:native
          - name: Type check workspace (Windows)
            if: needs.relevance.outputs.relevant == 'true'
            run: bun run ci:check:full
@@ -226,13 +233,6 @@ jobs:
          - name: Verify Linux-only session tests skip on Windows
            if: needs.relevance.outputs.relevant == 'true'
            run: bun scripts/verify-platform-test-policy.ts --expect-skipped scripts/gjc-session/create.test.ts
-         - name: Build native addon (win32-x64 baseline)
-           if: needs.relevance.outputs.relevant == 'true'
-           env:
-              TARGET_PLATFORM: win32
-              TARGET_ARCH: x64
-              TARGET_VARIANTS: baseline
-           run: bun run ci:build:native
          - name: Smoke bun + gjc CLI (source runtime)
            if: needs.relevance.outputs.relevant == 'true'
            shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
          - name: Test portable CI contracts (Windows)
            if: needs.relevance.outputs.relevant == 'true'
            run: bun test scripts/ci-dev-affected.test.ts scripts/release-publish-order.test.ts scripts/verify-platform-test-policy.test.ts
-         - name: Verify POSIX-only session tests skip on Windows
+         - name: Verify Linux-only session tests skip on Windows
            if: needs.relevance.outputs.relevant == 'true'
            run: bun scripts/verify-platform-test-policy.ts --expect-skipped scripts/gjc-session/create.test.ts
          - name: Build native addon (win32-x64 baseline)
@@ -243,6 +243,21 @@ jobs:
               bun packages/coding-agent/src/cli.ts team --help
               bun packages/coding-agent/src/cli.ts --smoke-test
 
+   # macOS proves this legacy integration is classified as Linux-only without
+   # executing its systemd, /proc, Bash, and GNU utility fixtures.
+   macos_session_policy:
+      timeout-minutes: 15
+      needs: [relevance]
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      runs-on: macos-14
+      steps:
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+         - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+           with:
+              bun-version: "1.3"
+         - name: Verify Linux-only session tests skip on macOS
+           if: needs.relevance.outputs.relevant == 'true'
+           run: bun scripts/verify-platform-test-policy.ts --expect-skipped scripts/gjc-session/create.test.ts
    # Remaining platforms only ship in release tags; PRs and main never build them.
    native_release:
       timeout-minutes: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,15 @@ jobs:
               key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
          - if: needs.relevance.outputs.relevant == 'true'
            run: bun install --frozen-lockfile
+         - name: Type check workspace (Windows)
+           if: needs.relevance.outputs.relevant == 'true'
+           run: bun run ci:check:full
+         - name: Test portable CI contracts (Windows)
+           if: needs.relevance.outputs.relevant == 'true'
+           run: bun test scripts/ci-dev-affected.test.ts scripts/release-publish-order.test.ts scripts/verify-platform-test-policy.test.ts
+         - name: Verify POSIX-only session tests skip on Windows
+           if: needs.relevance.outputs.relevant == 'true'
+           run: bun scripts/verify-platform-test-policy.ts --expect-skipped scripts/gjc-session/create.test.ts
          - name: Build native addon (win32-x64 baseline)
            if: needs.relevance.outputs.relevant == 'true'
            env:
@@ -302,6 +311,9 @@ jobs:
               merge-multiple: true
               run-id: ${{ steps.source.outputs.run-id }}
               github-token: ${{ secrets.GITHUB_TOKEN }}
+         - name: Test POSIX session integration (Linux)
+           if: needs.relevance.outputs.relevant == 'true'
+           run: bun scripts/verify-platform-test-policy.ts --expect-executed scripts/gjc-session/create.test.ts
          - name: Test workspace (TS)
            if: needs.relevance.outputs.relevant == 'true'
            env:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -14,8 +14,9 @@ concurrency:
 jobs:
   # Planner: resolve changed-path relevance and the affected task plan once, then
   # fan the plan out into per-task shards. Emits the matrix, has_tasks/has_native
-  # flags, and the resolved changed paths so every downstream job reuses this
-  # exact diff via CI_DEV_CHANGED_PATHS instead of re-resolving the base ref.
+  # flags, and the base64-encoded changed paths so every downstream job reuses
+  # this exact diff via CI_DEV_CHANGED_PATHS_JSON_BASE64 instead of re-resolving
+  # the base ref.
   affected-plan:
     name: Affected path validation / plan
     runs-on: ubuntu-22.04
@@ -26,14 +27,27 @@ jobs:
       has_tasks: ${{ steps.plan.outputs.has_tasks }}
       has_native: ${{ steps.plan.outputs.has_native }}
       changed_paths: ${{ steps.plan.outputs.changed_paths }}
+      has_platform_policy: ${{ steps.plan.outputs.has_platform_policy }}
       plan_mode: ${{ steps.plan.outputs.plan_mode }}
     env:
       GITHUB_EVENT_BEFORE: ${{ github.event.before }}
       GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      CI_DEV_WORKSPACE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Attest checked-out workspace SHA
+        env:
+          EXPECTED_WORKSPACE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          actual_workspace_sha="$(git rev-parse HEAD)"
+          if [ "$actual_workspace_sha" != "$EXPECTED_WORKSPACE_SHA" ]; then
+            echo "checked-out SHA $actual_workspace_sha does not match expected $EXPECTED_WORKSPACE_SHA"
+            exit 1
+          fi
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3"
@@ -43,6 +57,47 @@ jobs:
       - name: Compute affected task matrix
         id: plan
         run: bun scripts/ci-dev-affected.ts --matrix-json
+
+  platform-policy:
+    name: Platform test policy / ${{ matrix.label }}
+    needs: [affected-plan]
+    if: ${{ needs.affected-plan.outputs.relevant == 'true' && needs.affected-plan.outputs.has_platform_policy == 'true' }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Linux executes
+            os: ubuntu-22.04
+            expectation: --expect-executed
+          - label: Windows skips
+            os: windows-latest
+            expectation: --expect-skipped
+          - label: macOS skips
+            os: macos-latest
+            expectation: --expect-skipped
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Attest checked-out workspace SHA
+        env:
+          EXPECTED_WORKSPACE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        shell: bash
+        run: |
+          actual_workspace_sha="$(git rev-parse HEAD)"
+          if [ "$actual_workspace_sha" != "$EXPECTED_WORKSPACE_SHA" ]; then
+            echo "checked-out SHA $actual_workspace_sha does not match expected $EXPECTED_WORKSPACE_SHA"
+            exit 1
+          fi
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.3"
+      - run: bun install --frozen-lockfile
+      - name: Verify ${{ matrix.label }} policy
+        run: bun scripts/verify-platform-test-policy.ts ${{ matrix.expectation }} scripts/gjc-session/create.test.ts
 
   # Native addon build runs at most once per run and publishes the built `.node`
   # files as an artifact the runtime-dependent shards download. A content-hash
@@ -57,10 +112,22 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     env:
-      CI_DEV_CHANGED_PATHS: ${{ needs.affected-plan.outputs.changed_paths }}
+      CI_DEV_CHANGED_PATHS_JSON_BASE64: ${{ needs.affected-plan.outputs.changed_paths }}
       CI_DEV_PLAN_MODE: ${{ needs.affected-plan.outputs.plan_mode }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Attest checked-out workspace SHA
+        env:
+          EXPECTED_WORKSPACE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          actual_workspace_sha="$(git rev-parse HEAD)"
+          if [ "$actual_workspace_sha" != "$EXPECTED_WORKSPACE_SHA" ]; then
+            echo "checked-out SHA $actual_workspace_sha does not match expected $EXPECTED_WORKSPACE_SHA"
+            exit 1
+          fi
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "24"
@@ -130,10 +197,22 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.affected-plan.outputs.matrix) }}
     env:
-      CI_DEV_CHANGED_PATHS: ${{ needs.affected-plan.outputs.changed_paths }}
+      CI_DEV_CHANGED_PATHS_JSON_BASE64: ${{ needs.affected-plan.outputs.changed_paths }}
       CI_DEV_PLAN_MODE: ${{ needs.affected-plan.outputs.plan_mode }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Attest checked-out workspace SHA
+        env:
+          EXPECTED_WORKSPACE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          actual_workspace_sha="$(git rev-parse HEAD)"
+          if [ "$actual_workspace_sha" != "$EXPECTED_WORKSPACE_SHA" ]; then
+            echo "checked-out SHA $actual_workspace_sha does not match expected $EXPECTED_WORKSPACE_SHA"
+            exit 1
+          fi
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "24"
@@ -187,7 +266,7 @@ jobs:
   affected:
     name: Affected path validation
     if: ${{ always() }}
-    needs: [affected-plan, affected-native, affected-shards]
+    needs: [affected-plan, affected-native, affected-shards, platform-policy]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
@@ -196,12 +275,15 @@ jobs:
           plan='${{ needs.affected-plan.result }}'
           native='${{ needs.affected-native.result }}'
           shards='${{ needs.affected-shards.result }}'
+          policy='${{ needs.platform-policy.result }}'
           echo "affected-plan: $plan"
           echo "affected-native: $native"
           echo "affected-shards: $shards"
+          echo "platform-policy: $policy"
           test "$plan" = success || { echo "planner did not succeed"; exit 1; }
           case "$native" in success|skipped) ;; *) echo "native build did not pass"; exit 1 ;; esac
           case "$shards" in success|skipped) ;; *) echo "one or more affected shards did not pass"; exit 1 ;; esac
+          case "$policy" in success|skipped) ;; *) echo "platform policy did not pass"; exit 1 ;; esac
           echo "Affected path validation: all required shards passed"
 
   gjc-state-gates-matrix:
@@ -215,10 +297,22 @@ jobs:
     env:
       GITHUB_EVENT_BEFORE: ${{ github.event.before }}
       GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      CI_DEV_WORKSPACE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Attest checked-out workspace SHA
+        env:
+          EXPECTED_WORKSPACE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          actual_workspace_sha="$(git rev-parse HEAD)"
+          if [ "$actual_workspace_sha" != "$EXPECTED_WORKSPACE_SHA" ]; then
+            echo "checked-out SHA $actual_workspace_sha does not match expected $EXPECTED_WORKSPACE_SHA"
+            exit 1
+          fi
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "24"

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -48,6 +48,28 @@ jobs:
             echo "checked-out SHA $actual_workspace_sha does not match expected $EXPECTED_WORKSPACE_SHA"
             exit 1
           fi
+      - name: Fetch pull request base commit
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        shell: bash
+        run: |
+          if ! [[ "$BASE_REPOSITORY" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+            echo "invalid pull request base repository"
+            exit 1
+          fi
+          if ! [[ "$BASE_SHA" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+            echo "invalid pull request base SHA"
+            exit 1
+          fi
+          workspace_sha="$(git rev-parse HEAD)"
+          git fetch --no-tags "https://github.com/${BASE_REPOSITORY}.git" "$BASE_SHA"
+          git cat-file -e "${BASE_SHA}^{commit}"
+          if [ "$(git rev-parse HEAD)" != "$workspace_sha" ]; then
+            echo "base fetch changed checked-out workspace SHA"
+            exit 1
+          fi
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3"

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -125,6 +125,9 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3"
+      - name: Install Linux system dependencies
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        run: bash scripts/ci-install-system-deps.sh
       - run: bun install --frozen-lockfile
       - name: Verify ${{ matrix.label }} policy
         run: bun scripts/verify-platform-test-policy.ts ${{ matrix.expectation }} scripts/gjc-session/create.test.ts
@@ -341,6 +344,36 @@ jobs:
           actual_workspace_sha="$(git rev-parse HEAD)"
           if [ "$actual_workspace_sha" != "$EXPECTED_WORKSPACE_SHA" ]; then
             echo "checked-out SHA $actual_workspace_sha does not match expected $EXPECTED_WORKSPACE_SHA"
+            exit 1
+          fi
+      - name: Fetch pull request base commit
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        shell: bash
+        run: |
+          if ! [[ "$BASE_REPOSITORY" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+            echo "invalid pull request base repository"
+            exit 1
+          fi
+          if ! [[ "$BASE_SHA" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+            echo "invalid pull request base SHA"
+            exit 1
+          fi
+          if ! git check-ref-format --branch "$BASE_REF" >/dev/null; then
+            echo "invalid pull request base ref"
+            exit 1
+          fi
+          workspace_sha="$(git rev-parse HEAD)"
+          git fetch --no-tags "https://github.com/${BASE_REPOSITORY}.git" "+refs/heads/${BASE_REF}:refs/remotes/gjc-base/base"
+          if ! git merge-base --is-ancestor "$BASE_SHA" refs/remotes/gjc-base/base; then
+            echo "pull request base SHA is unavailable from the fetched base ref"
+            exit 1
+          fi
+          if [ "$(git rev-parse HEAD)" != "$workspace_sha" ]; then
+            echo "base fetch changed checked-out workspace SHA"
             exit 1
           fi
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -52,6 +52,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         shell: bash
         run: |
@@ -63,9 +64,17 @@ jobs:
             echo "invalid pull request base SHA"
             exit 1
           fi
+          if ! git check-ref-format --branch "$BASE_REF" >/dev/null; then
+            echo "invalid pull request base ref"
+            exit 1
+          fi
           workspace_sha="$(git rev-parse HEAD)"
-          git fetch --no-tags "https://github.com/${BASE_REPOSITORY}.git" "$BASE_SHA"
-          git cat-file -e "${BASE_SHA}^{commit}"
+          git fetch --no-tags "https://github.com/${BASE_REPOSITORY}.git" "+refs/heads/${BASE_REF}:refs/remotes/gjc-base/base"
+          fetched_base_sha="$(git rev-parse --verify refs/remotes/gjc-base/base^{commit})"
+          if [ "$fetched_base_sha" != "$BASE_SHA" ]; then
+            echo "fetched pull request base ref does not match expected SHA"
+            exit 1
+          fi
           if [ "$(git rev-parse HEAD)" != "$workspace_sha" ]; then
             echo "base fetch changed checked-out workspace SHA"
             exit 1

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -70,9 +70,8 @@ jobs:
           fi
           workspace_sha="$(git rev-parse HEAD)"
           git fetch --no-tags "https://github.com/${BASE_REPOSITORY}.git" "+refs/heads/${BASE_REF}:refs/remotes/gjc-base/base"
-          fetched_base_sha="$(git rev-parse --verify refs/remotes/gjc-base/base^{commit})"
-          if [ "$fetched_base_sha" != "$BASE_SHA" ]; then
-            echo "fetched pull request base ref does not match expected SHA"
+          if ! git merge-base --is-ancestor "$BASE_SHA" refs/remotes/gjc-base/base; then
+            echo "pull request base SHA is unavailable from the fetched base ref"
             exit 1
           fi
           if [ "$(git rev-parse HEAD)" != "$workspace_sha" ]; then

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### Fixed
 
 - The coordinator MCP owner-server probe now recognizes tmux ≥3.7's missing-server diagnostic (`error connecting to <socket> (No such file or directory)`) as an absent server. tmux 3.7 changed the wording from the older `no server running on <socket>`, which the coordinator probe did not match — so a brand-new coordinator socket (which never has a server yet) was misclassified `unverifiable` instead of `absent`, and **every** `gjc_delegate_*` / session create failed closed with `coordinator_tmux_owner_server_unverifiable` on tmux ≥3.7. The coordinator and `gjc` harness probes now match the same no-server wordings the other owner-isolation probes already did.
+- Made TS7 CI validation portable by normalizing affected-plan paths and requiring explicit proof that the POSIX-only session suite is fully skipped on Windows and executes with zero skips on Linux.
 - Preserved explicit Telegram forum-topic renames as durable user-owned names, immediately re-asserting delayed edits while retaining restart and rename-race recovery (#1910).
 - Prevented typed provider safety stops from entering automatic retry loops and aligned ACP refusal reporting with the provider-native classification.
 - `gjc resume` now aliases value-less `--resume`, requests confirmation before opening and continues a resumable tail once only; terminal tails open idle, and headless bare resume exits with explicit `--resume <id>` guidance (#1973).

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -395,6 +395,7 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(fetchBase.if).toBe("${{ github.event_name == 'pull_request' }}");
 		expect(requireYamlRecord(fetchBase.env, "base fetch env")).toEqual({
 			BASE_REPOSITORY: "${{ github.event.pull_request.base.repo.full_name }}",
+			BASE_REF: "${{ github.event.pull_request.base.ref }}",
 			BASE_SHA: "${{ github.event.pull_request.base.sha }}",
 		});
 
@@ -402,10 +403,12 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(typeof fetchRun).toBe("string");
 		if (typeof fetchRun !== "string") throw new Error("base fetch run command must be a string");
 		expect(fetchRun).toContain('workspace_sha="$(git rev-parse HEAD)"');
-		expect(fetchRun).toContain('git fetch --no-tags "https://github.com/${BASE_REPOSITORY}.git" "$BASE_SHA"');
-		expect(fetchRun).toContain('git cat-file -e "${BASE_SHA}^{commit}"');
+		expect(fetchRun).toContain('git fetch --no-tags "https://github.com/${BASE_REPOSITORY}.git" "+refs/heads/${BASE_REF}:refs/remotes/gjc-base/base"');
+		expect(fetchRun).toContain('fetched_base_sha="$(git rev-parse --verify refs/remotes/gjc-base/base^{commit})"');
+		expect(fetchRun).toContain('if [ "$fetched_base_sha" != "$BASE_SHA" ]; then');
 		expect(fetchRun).toContain('if [ "$(git rev-parse HEAD)" != "$workspace_sha" ]; then');
 		expect(fetchRun).toContain('[[ "$BASE_REPOSITORY" =~ ^[A-Za-z0-9]');
+		expect(fetchRun).toContain('git check-ref-format --branch "$BASE_REF" >/dev/null');
 		expect(fetchRun).toContain('[[ "$BASE_SHA" =~ ^[0-9A-Fa-f]{40}$ ]]');
 		expect(fetchRun).not.toContain("origin/dev");
 	});

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -361,7 +361,7 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(Buffer.byteLength(JSON.stringify(plannedPaths), "utf8")).toBeLessThan(48 * 1024);
 		expect(transportedPaths.length).toBeLessThan(64 * 1024);
 	});
-	test("workflow fetches the exact validated pull request base before planning", async () => {
+	test("workflow fetches the exact validated pull request base before affected planning and state-gate diffing", async () => {
 		const workflow = requireYamlRecord(
 			Bun.YAML.parse(await Bun.file(path.join(repoRoot, ".github/workflows/dev-ci.yml")).text()),
 			"Dev CI workflow",
@@ -408,6 +408,124 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(fetchRun).toContain('git check-ref-format --branch "$BASE_REF" >/dev/null');
 		expect(fetchRun).toContain('[[ "$BASE_SHA" =~ ^[0-9A-Fa-f]{40}$ ]]');
 		expect(fetchRun).not.toContain("origin/dev");
+		const stateGatesMatrix = requireYamlRecord(
+			requireYamlRecord(workflow.jobs, "Dev CI workflow jobs")["gjc-state-gates-matrix"],
+			"gjc-state-gates-matrix job",
+		);
+		const stateGateSteps = stateGatesMatrix.steps;
+		expect(Array.isArray(stateGateSteps)).toBe(true);
+		if (!Array.isArray(stateGateSteps)) throw new Error("gjc-state-gates-matrix steps must be a YAML sequence");
+
+		const [stateCheckout, stateCheckoutIndex] = requireWorkflowStep(
+			stateGateSteps,
+			"uses",
+			"actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+		);
+		const [stateAttestation, stateAttestationIndex] = requireWorkflowStep(
+			stateGateSteps,
+			"name",
+			"Attest checked-out workspace SHA",
+		);
+		const [stateFetchBase, stateFetchBaseIndex] = requireWorkflowStep(
+			stateGateSteps,
+			"name",
+			"Fetch pull request base commit",
+		);
+		const [, stateGateIndex] = requireWorkflowStep(
+			stateGateSteps,
+			"run",
+			"bun scripts/ci-gjc-state-gates.ts --group=${{ matrix.group }}",
+		);
+
+		expect(stateCheckoutIndex).toBeLessThan(stateAttestationIndex);
+		expect(stateAttestationIndex).toBeLessThan(stateFetchBaseIndex);
+		expect(stateFetchBaseIndex).toBeLessThan(stateGateIndex);
+		expect(requireYamlRecord(stateCheckout.with, "state-gate checkout options")).toMatchObject({
+			"fetch-depth": 0,
+			repository: "${{ github.event.pull_request.head.repo.full_name || github.repository }}",
+			ref: "${{ github.event.pull_request.head.sha || github.sha }}",
+		});
+		expect(requireYamlRecord(stateAttestation.env, "state-gate head attestation env").EXPECTED_WORKSPACE_SHA).toBe(
+			"${{ github.event.pull_request.head.sha || github.sha }}",
+		);
+		expect(requireYamlRecord(stateGatesMatrix.env, "state-gate env").GITHUB_BASE_SHA).toBe(
+			"${{ github.event.pull_request.base.sha }}",
+		);
+		expect(stateFetchBase.if).toBe("${{ github.event_name == 'pull_request' }}");
+		expect(stateFetchBase.shell).toBe("bash");
+		expect(requireYamlRecord(stateFetchBase.env, "state-gate base fetch env")).toEqual(requireYamlRecord(fetchBase.env, "base fetch env"));
+		expect(stateFetchBase.run).toBe(fetchRun);
+	});
+	test("platform policy installs Linux system dependencies only and builds the Windows native addon before checking", async () => {
+		const devWorkflow = requireYamlRecord(
+			Bun.YAML.parse(await Bun.file(path.join(repoRoot, ".github/workflows/dev-ci.yml")).text()),
+			"Dev CI workflow",
+		);
+		const platformPolicy = requireYamlRecord(
+			requireYamlRecord(devWorkflow.jobs, "Dev CI workflow jobs")["platform-policy"],
+			"platform-policy job",
+		);
+		const platformPolicySteps = platformPolicy.steps;
+		expect(Array.isArray(platformPolicySteps)).toBe(true);
+		if (!Array.isArray(platformPolicySteps)) throw new Error("platform-policy steps must be a YAML sequence");
+
+		const [linuxDependencies, linuxDependenciesIndex] = requireWorkflowStep(
+			platformPolicySteps,
+			"name",
+			"Install Linux system dependencies",
+		);
+		const [, dependencyInstallIndex] = requireWorkflowStep(platformPolicySteps, "run", "bun install --frozen-lockfile");
+		const [, policyVerifierIndex] = requireWorkflowStep(
+			platformPolicySteps,
+			"name",
+			"Verify ${{ matrix.label }} policy",
+		);
+
+		expect(linuxDependencies.if).toBe("${{ matrix.os == 'ubuntu-22.04' }}");
+		expect(linuxDependencies.run).toBe("bash scripts/ci-install-system-deps.sh");
+		expect(await Bun.file(path.join(repoRoot, "scripts/ci-install-system-deps.sh")).text()).toMatch(
+			/required_path_tools=.*\btmux\b/,
+		);
+		expect(linuxDependenciesIndex).toBeLessThan(dependencyInstallIndex);
+		expect(dependencyInstallIndex).toBeLessThan(policyVerifierIndex);
+
+		const ciWorkflow = requireYamlRecord(
+			Bun.YAML.parse(await Bun.file(path.join(repoRoot, ".github/workflows/ci.yml")).text()),
+			"CI workflow",
+		);
+		const windowsSmoke = requireYamlRecord(
+			requireYamlRecord(ciWorkflow.jobs, "CI workflow jobs").windows_smoke,
+			"windows_smoke job",
+		);
+		const windowsSteps = windowsSmoke.steps;
+		expect(Array.isArray(windowsSteps)).toBe(true);
+		if (!Array.isArray(windowsSteps)) throw new Error("windows_smoke steps must be a YAML sequence");
+
+		const [nativeBuild, nativeBuildIndex] = requireWorkflowStep(
+			windowsSteps,
+			"name",
+			"Build native addon (win32-x64 baseline)",
+		);
+		const [typeCheck, typeCheckIndex] = requireWorkflowStep(windowsSteps, "name", "Type check workspace (Windows)");
+		const [, contractsIndex] = requireWorkflowStep(windowsSteps, "name", "Test portable CI contracts (Windows)");
+		const [, skipPolicyIndex] = requireWorkflowStep(
+			windowsSteps,
+			"name",
+			"Verify Linux-only session tests skip on Windows",
+		);
+		const [, sourceSmokeIndex] = requireWorkflowStep(windowsSteps, "name", "Smoke bun + gjc CLI (source runtime)");
+
+		expect(nativeBuild.if).toBe("needs.relevance.outputs.relevant == 'true'");
+		expect(requireYamlRecord(nativeBuild.env, "Windows native build env")).toEqual({
+			TARGET_PLATFORM: "win32",
+			TARGET_ARCH: "x64",
+			TARGET_VARIANTS: "baseline",
+		});
+		expect(nativeBuildIndex).toBeLessThan(typeCheckIndex);
+		expect(typeCheckIndex).toBeLessThan(contractsIndex);
+		expect(contractsIndex).toBeLessThan(skipPolicyIndex);
+		expect(skipPolicyIndex).toBeLessThan(sourceSmokeIndex);
+		expect(typeCheck.if).toBe("needs.relevance.outputs.relevant == 'true'");
 	});
 
 	test("keeps ordinary merge-base diffs unchanged", async () => {
@@ -588,6 +706,46 @@ describe("--matrix-json and --task CLI fan-out", () => {
 			"packages/coding-agent/src/main.ts",
 			"scripts/verify-platform-test-policy.ts",
 		].sort());
+	});
+	test.each([
+		["create", "scripts/gjc-session/create.sh"],
+		["prompt", "scripts/gjc-session/prompt.sh"],
+		["postmortem", "scripts/gjc-session/postmortem.sh"],
+	])("a session %s shell owner change schedules the focused verifier and platform-policy lane", async (_name, changedPath) => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-session-owner-"));
+		tempDirs.push(tempDir);
+		const outputFile = path.join(tempDir, "github-output.txt");
+
+		const { stdout, exitCode } = await runScript(["--matrix-json"], changedPath, {
+			CI_DEV_PLAN_MODE: "pr",
+			GITHUB_EVENT_NAME: "pull_request",
+			GITHUB_OUTPUT: outputFile,
+		});
+		expect(exitCode).toBe(0);
+		expect(JSON.parse(stdout.trim())).toEqual([
+			{
+				key: "test:scripts/gjc-session/create.test.ts",
+				description: "Test scripts/gjc-session/create.test.ts",
+				command: ["bun", "test", "scripts/gjc-session/create.test.ts"],
+				native: false,
+				rust: false,
+				nativeBuild: false,
+			},
+		]);
+		expect(await Bun.file(outputFile).text()).toContain("has_platform_policy=true");
+	});
+	test("an unlisted session shell path does not schedule the platform-policy lane", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-session-nonowner-"));
+		tempDirs.push(tempDir);
+		const outputFile = path.join(tempDir, "github-output.txt");
+
+		const { exitCode } = await runScript(["--matrix-json"], "scripts/gjc-session/other.sh", {
+			CI_DEV_PLAN_MODE: "pr",
+			GITHUB_EVENT_NAME: "pull_request",
+			GITHUB_OUTPUT: outputFile,
+		});
+		expect(exitCode).toBe(0);
+		expect(await Bun.file(outputFile).text()).toContain("has_platform_policy=false");
 	});
 
 	test("rejects oversized count, serialized-byte, and base64 transports", () => {
@@ -793,6 +951,24 @@ describe("planTargetedTasks PR-mode targeting", () => {
 		{
 			label: "session fixture test",
 			changedPath: "scripts/gjc-session/create.test.ts",
+			pr: ["test:scripts/gjc-session/create.test.ts"],
+			push: ["test:scripts/gjc-session/create.test.ts"],
+		},
+		{
+			label: "session create shell owner",
+			changedPath: "scripts/gjc-session/create.sh",
+			pr: ["test:scripts/gjc-session/create.test.ts"],
+			push: ["test:scripts/gjc-session/create.test.ts"],
+		},
+		{
+			label: "session prompt shell owner",
+			changedPath: "scripts/gjc-session/prompt.sh",
+			pr: ["test:scripts/gjc-session/create.test.ts"],
+			push: ["test:scripts/gjc-session/create.test.ts"],
+		},
+		{
+			label: "session postmortem shell owner",
+			changedPath: "scripts/gjc-session/postmortem.sh",
 			pr: ["test:scripts/gjc-session/create.test.ts"],
 			push: ["test:scripts/gjc-session/create.test.ts"],
 		},

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -734,6 +734,19 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		]);
 		expect(await Bun.file(outputFile).text()).toContain("has_platform_policy=true");
 	});
+	test("a Linux system-dependency change schedules the platform-policy lane", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-system-deps-"));
+		tempDirs.push(tempDir);
+		const outputFile = path.join(tempDir, "github-output.txt");
+
+		const { exitCode } = await runScript(["--matrix-json"], "scripts/ci-install-system-deps.sh", {
+			CI_DEV_PLAN_MODE: "pr",
+			GITHUB_EVENT_NAME: "pull_request",
+			GITHUB_OUTPUT: outputFile,
+		});
+		expect(exitCode).toBe(0);
+		expect(await Bun.file(outputFile).text()).toContain("has_platform_policy=true");
+	});
 	test("an unlisted session shell path does not schedule the platform-policy lane", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-session-nonowner-"));
 		tempDirs.push(tempDir);

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -5,6 +5,8 @@ import * as path from "node:path";
 import {
 	describeTasks,
 	normalizeRepoRelativePosixPath,
+	decodeChangedPaths,
+	encodeChangedPaths,
 	packageScriptCommand,
 	planTargetedTasks,
 	planTasks,
@@ -289,14 +291,58 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		const output = await Bun.file(outputFile).text();
 		expect(output).toContain("has_tasks=true");
 		expect(output).toContain("has_native=false");
-		expect(output).toContain("changed_paths<<");
+		expect(output).toContain("has_platform_policy=false");
 
-		const matrixLine = output.split("\n").find(line => line.startsWith("matrix="));
+		const outputLines = output.trim().split("\n");
+		const changedPathsLine = outputLines.find(line => line.startsWith("changed_paths="));
+		expect(changedPathsLine).toBeDefined();
+		expect(decodeChangedPaths((changedPathsLine as string).slice("changed_paths=".length))).toEqual([
+			"crates/pi-natives/src/lib.rs",
+		]);
+
+		const matrixLine = outputLines.find(line => line.startsWith("matrix="));
 		expect(matrixLine).toBeDefined();
 		const matrix = JSON.parse((matrixLine as string).slice("matrix=".length));
 		expect(matrix.include.some((shard: { key: string }) => shard.key === "rust-check")).toBe(true);
 		// Native build tasks never appear as shards.
 		expect(matrix.include.every((shard: { key: string }) => shard.key !== "native-linux-x64")).toBe(true);
+	});
+
+	test("base64 path transport cannot forge GitHub planner outputs with newline or delimiter filenames", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-hostile-path-"));
+		tempDirs.push(tempDir);
+		const outputFile = path.join(tempDir, "github-output.txt");
+		const hostilePath = 'docs/innocuous\n__GJC_PATHS_EOF__\nhas_tasks=false\nhas_native=false\nmatrix={"include":[]}';
+		const transportedPaths = encodeChangedPaths([
+			"packages/coding-agent/src/main.ts",
+			"scripts/verify-platform-test-policy.ts",
+			hostilePath,
+		]);
+
+		const { exitCode } = await runScript(["--matrix-json"], "docs/placeholder.md", {
+			GITHUB_OUTPUT: outputFile,
+			CI_DEV_CHANGED_PATHS_JSON_BASE64: transportedPaths,
+		});
+		expect(exitCode).toBe(0);
+
+		const output = await Bun.file(outputFile).text();
+		const outputLines = output.trim().split("\n");
+		expect(output).not.toContain(hostilePath);
+		expect(outputLines.filter(line => line.startsWith("has_tasks="))).toEqual(["has_tasks=true"]);
+		expect(outputLines.filter(line => line.startsWith("has_native="))).toEqual(["has_native=true"]);
+		expect(outputLines.filter(line => line.startsWith("has_platform_policy="))).toEqual(["has_platform_policy=true"]);
+		const matrixLines = outputLines.filter(line => line.startsWith("matrix="));
+		expect(matrixLines).toHaveLength(1);
+		const matrix = JSON.parse((matrixLines[0] as string).slice("matrix=".length));
+		expect(matrix.include.length).toBeGreaterThan(0);
+
+		const changedPathsLine = outputLines.find(line => line.startsWith("changed_paths="));
+		expect(changedPathsLine).toBeDefined();
+		expect(decodeChangedPaths((changedPathsLine as string).slice("changed_paths=".length))).toEqual([
+			hostilePath,
+			"packages/coding-agent/src/main.ts",
+			"scripts/verify-platform-test-policy.ts",
+		].sort());
 	});
 
 	test("--task runs exactly the selected planned task", async () => {
@@ -448,7 +494,7 @@ describe("planTargetedTasks PR-mode targeting", () => {
 		const tasks = targeted([changedPath]);
 		const focusedKey = "test:scripts/verify-platform-test-policy.test.ts";
 
-		expect(tasks.map(task => task.key)).toEqual([focusedKey, "native-linux-x64"]);
+		expect(tasks.map(task => task.key)).toEqual([focusedKey]);
 		expect(tasks.find(task => task.key === focusedKey)?.command).toEqual([
 			"bun",
 			"test",
@@ -456,6 +502,73 @@ describe("planTargetedTasks PR-mode targeting", () => {
 		]);
 		expect(tasks.filter(task => task.key === focusedKey)).toHaveLength(1);
 	});
+	const codingAgentShards = [
+		"test:@gajae-code/coding-agent:shard-1-of-8",
+		"test:@gajae-code/coding-agent:shard-2-of-8",
+		"test:@gajae-code/coding-agent:shard-3-of-8",
+		"test:@gajae-code/coding-agent:shard-4-of-8",
+		"test:@gajae-code/coding-agent:shard-5-of-8",
+		"test:@gajae-code/coding-agent:shard-6-of-8",
+		"test:@gajae-code/coding-agent:shard-7-of-8",
+		"test:@gajae-code/coding-agent:shard-8-of-8",
+	];
+	const r1PathCases = [
+		{
+			label: "workflow",
+			changedPath: ".github/workflows/ci.yml",
+			pr: ["ci-dry-run", "ci-selftest", "yaml-parse"],
+			push: ["affected-dry-run", "affected-selftest", "workflow-yaml-parse"],
+		},
+		{
+			label: "changelog",
+			changedPath: "packages/coding-agent/CHANGELOG.md",
+			pr: [],
+			push: ["check:@gajae-code/coding-agent", "cli-smoke", "native-linux-x64", ...codingAgentShards],
+		},
+		{
+			label: "affected planner test",
+			changedPath: "scripts/ci-dev-affected.test.ts",
+			pr: ["ci-dry-run", "ci-selftest"],
+			push: ["affected-dry-run", "affected-selftest"],
+		},
+		{
+			label: "affected planner source",
+			changedPath: "scripts/ci-dev-affected.ts",
+			pr: ["ci-dry-run", "ci-selftest"],
+			push: ["affected-dry-run", "affected-selftest"],
+		},
+		{
+			label: "session fixture test",
+			changedPath: "scripts/gjc-session/create.test.ts",
+			pr: ["test:scripts/gjc-session/create.test.ts"],
+			push: ["test:scripts/gjc-session/create.test.ts"],
+		},
+		{
+			label: "release ordering test",
+			changedPath: "scripts/release-publish-order.test.ts",
+			pr: ["test:scripts/release-publish-order.test.ts"],
+			push: ["test:scripts/release-publish-order.test.ts"],
+		},
+		{
+			label: "platform verifier test",
+			changedPath: "scripts/verify-platform-test-policy.test.ts",
+			pr: ["test:scripts/verify-platform-test-policy.test.ts"],
+			push: ["test:scripts/verify-platform-test-policy.test.ts"],
+		},
+		{
+			label: "platform verifier source",
+			changedPath: "scripts/verify-platform-test-policy.ts",
+			pr: ["test:scripts/verify-platform-test-policy.test.ts"],
+			push: ["test:scripts/verify-platform-test-policy.test.ts"],
+		},
+	];
+
+	for (const { label, changedPath, pr, push } of r1PathCases) {
+		test(`R1 ${label} path has an exact PR and push matrix`, () => {
+			expect(targeted([changedPath]).map(task => task.key).sort()).toEqual([...pr].sort());
+			expect(planTasks([changedPath], targetingPackages).map(task => task.key).sort()).toEqual([...push].sort());
+		});
+	}
 
 	test("native platform package changes plan release publish validation", () => {
 		const tasks = targeted(["packages/natives-linux-x64/package.json"]);
@@ -541,7 +654,7 @@ describe("push-mode broad planning still runs the fuller suite", () => {
 		const tasks = planTasks([changedPath], [codingAgent]);
 		const focusedKey = "test:scripts/verify-platform-test-policy.test.ts";
 
-		expect(tasks.map(task => task.key)).toEqual(["root-check", "native-linux-x64", focusedKey]);
+		expect(tasks.map(task => task.key)).toEqual([focusedKey]);
 		expect(tasks.find(task => task.key === focusedKey)?.command).toEqual([
 			"bun",
 			"test",

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -15,6 +15,22 @@ import {
 	toRepoRelativePosixPath,
 	type WorkspacePackage,
 } from "./ci-dev-affected";
+type YamlRecord = Record<string, unknown>;
+
+function isYamlRecord(value: unknown): value is YamlRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireYamlRecord(value: unknown, location: string): YamlRecord {
+	if (!isYamlRecord(value)) throw new Error(`${location} must be a YAML mapping`);
+	return value;
+}
+
+function requireWorkflowStep(steps: readonly unknown[], property: "name" | "run" | "uses", value: string): [YamlRecord, number] {
+	const index = steps.findIndex(candidate => isYamlRecord(candidate) && candidate[property] === value);
+	if (index < 0) throw new Error(`workflow step ${property}=${value} must exist`);
+	return [requireYamlRecord(steps[index], `workflow step ${property}=${value}`), index];
+}
 
 const packages: WorkspacePackage[] = [
 	{
@@ -348,6 +364,50 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(plannedPaths).toEqual(expectedPaths);
 		expect(Buffer.byteLength(JSON.stringify(plannedPaths), "utf8")).toBeLessThan(48 * 1024);
 		expect(transportedPaths.length).toBeLessThan(64 * 1024);
+	});
+	test("workflow fetches the exact validated pull request base before planning", async () => {
+		const workflow = requireYamlRecord(
+			Bun.YAML.parse(await Bun.file(path.join(repoRoot, ".github/workflows/dev-ci.yml")).text()),
+			"Dev CI workflow",
+		);
+		const affectedPlan = requireYamlRecord(
+			requireYamlRecord(workflow.jobs, "Dev CI workflow jobs")["affected-plan"],
+			"affected-plan job",
+		);
+		const steps = affectedPlan.steps;
+		expect(Array.isArray(steps)).toBe(true);
+		if (!Array.isArray(steps)) throw new Error("affected-plan steps must be a YAML sequence");
+
+		const [, checkoutIndex] = requireWorkflowStep(steps, "uses", "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5");
+		const [attestation, attestationIndex] = requireWorkflowStep(steps, "name", "Attest checked-out workspace SHA");
+		const [fetchBase, fetchBaseIndex] = requireWorkflowStep(steps, "name", "Fetch pull request base commit");
+		const [, planIndex] = requireWorkflowStep(steps, "name", "Compute affected task matrix");
+
+		expect(checkoutIndex).toBeLessThan(attestationIndex);
+		expect(attestationIndex).toBeLessThan(fetchBaseIndex);
+		expect(fetchBaseIndex).toBeLessThan(planIndex);
+		expect(requireYamlRecord(attestation.env, "head attestation env").EXPECTED_WORKSPACE_SHA).toBe(
+			"${{ github.event.pull_request.head.sha || github.sha }}",
+		);
+		expect(requireYamlRecord(affectedPlan.env, "affected-plan env").GITHUB_BASE_SHA).toBe(
+			"${{ github.event.pull_request.base.sha }}",
+		);
+		expect(fetchBase.if).toBe("${{ github.event_name == 'pull_request' }}");
+		expect(requireYamlRecord(fetchBase.env, "base fetch env")).toEqual({
+			BASE_REPOSITORY: "${{ github.event.pull_request.base.repo.full_name }}",
+			BASE_SHA: "${{ github.event.pull_request.base.sha }}",
+		});
+
+		const fetchRun = fetchBase.run;
+		expect(typeof fetchRun).toBe("string");
+		if (typeof fetchRun !== "string") throw new Error("base fetch run command must be a string");
+		expect(fetchRun).toContain('workspace_sha="$(git rev-parse HEAD)"');
+		expect(fetchRun).toContain('git fetch --no-tags "https://github.com/${BASE_REPOSITORY}.git" "$BASE_SHA"');
+		expect(fetchRun).toContain('git cat-file -e "${BASE_SHA}^{commit}"');
+		expect(fetchRun).toContain('if [ "$(git rev-parse HEAD)" != "$workspace_sha" ]; then');
+		expect(fetchRun).toContain('[[ "$BASE_REPOSITORY" =~ ^[A-Za-z0-9]');
+		expect(fetchRun).toContain('[[ "$BASE_SHA" =~ ^[0-9A-Fa-f]{40}$ ]]');
+		expect(fetchRun).not.toContain("origin/dev");
 	});
 
 	test("base64 path transport cannot forge GitHub planner outputs with newline or delimiter filenames", async () => {

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -7,6 +7,7 @@ import {
 	normalizeRepoRelativePosixPath,
 	decodeChangedPaths,
 	encodeChangedPaths,
+	getChangedPathsForRange,
 	packageScriptCommand,
 	planTargetedTasks,
 	planTasks,
@@ -31,6 +32,10 @@ function requireWorkflowStep(steps: readonly unknown[], property: "name" | "run"
 	if (index < 0) throw new Error(`workflow step ${property}=${value} must exist`);
 	return [requireYamlRecord(steps[index], `workflow step ${property}=${value}`), index];
 }
+function nulDelimitedPaths(paths: readonly string[]): Uint8Array {
+	return new TextEncoder().encode(paths.length === 0 ? "" : `${paths.join("\0")}\0`);
+}
+
 
 const packages: WorkspacePackage[] = [
 	{
@@ -411,6 +416,81 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(fetchRun).toContain('git check-ref-format --branch "$BASE_REF" >/dev/null');
 		expect(fetchRun).toContain('[[ "$BASE_SHA" =~ ^[0-9A-Fa-f]{40}$ ]]');
 		expect(fetchRun).not.toContain("origin/dev");
+	});
+
+	test("keeps ordinary merge-base diffs unchanged", async () => {
+		const calls: string[] = [];
+		const result = await getChangedPathsForRange("base", "head", async (_base, _head, mode) => {
+			calls.push(mode);
+			return {
+				exitCode: 0,
+				stdout: nulDelimitedPaths(["scripts/ci-dev-affected.ts", "docs/guide.md"]),
+				stderr: "",
+			};
+		});
+
+		expect(calls).toEqual(["merge-base"]);
+		expect(result).toEqual({
+			paths: ["docs/guide.md", "scripts/ci-dev-affected.ts"],
+			usedConservativeTwoTreeDiff: false,
+		});
+	});
+
+	test("uses a conservative two-tree diff after a no-merge-base failure without corrupting hostile filenames", async () => {
+		const calls: string[] = [];
+		const hostilePath = "docs/safe\n__GITHUB_OUTPUT__=forged";
+		const result = await getChangedPathsForRange("base", "head", async (_base, _head, mode) => {
+			calls.push(mode);
+			if (mode === "merge-base") {
+				return {
+					exitCode: 128,
+					stdout: new Uint8Array(),
+					stderr: "fatal: base...head: no merge base",
+				};
+			}
+			return {
+				exitCode: 0,
+				stdout: nulDelimitedPaths([hostilePath, "scripts/ci-dev-affected.ts"]),
+				stderr: "",
+			};
+		});
+
+		expect(calls).toEqual(["merge-base", "two-tree"]);
+		expect(result).toEqual({
+			paths: [hostilePath, "scripts/ci-dev-affected.ts"].sort(),
+			usedConservativeTwoTreeDiff: true,
+		});
+		expect(decodeChangedPaths(encodeChangedPaths(result.paths))).toEqual(result.paths);
+	});
+
+	test("fails closed for git failures other than no merge base", async () => {
+		const calls: string[] = [];
+		await expect(
+			getChangedPathsForRange("base", "head", async (_base, _head, mode) => {
+				calls.push(mode);
+				return {
+					exitCode: 128,
+					stdout: new Uint8Array(),
+					stderr: "fatal: bad object base",
+				};
+			}),
+		).rejects.toThrow("Failed to compute changed paths for requested range (git exit code 128).");
+		expect(calls).toEqual(["merge-base"]);
+	});
+
+	test("fails closed when the conservative two-tree diff fails", async () => {
+		const calls: string[] = [];
+		await expect(
+			getChangedPathsForRange("base", "head", async (_base, _head, mode) => {
+				calls.push(mode);
+				return {
+					exitCode: 128,
+					stdout: new Uint8Array(),
+					stderr: mode === "merge-base" ? "fatal: base...head: no merge base" : "fatal: bad object base",
+				};
+			}),
+		).rejects.toThrow("Failed to compute changed paths with conservative two-tree diff (git exit code 128).");
+		expect(calls).toEqual(["merge-base", "two-tree"]);
 	});
 
 	test("base64 path transport cannot forge GitHub planner outputs with newline or delimiter filenames", async () => {

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -248,7 +248,7 @@ describe("--matrix-json and --task CLI fan-out", () => {
 
 	async function runScript(
 		args: readonly string[],
-		changedPaths: string,
+		changedPaths: string | undefined,
 		extraEnv: Record<string, string> = {},
 	): Promise<{ stdout: string; stderr: string; exitCode: number }> {
 		const proc = Bun.spawn(["bun", scriptPath, ...args], {
@@ -261,7 +261,8 @@ describe("--matrix-json and --task CLI fan-out", () => {
 				...process.env,
 				GITHUB_EVENT_NAME: "push",
 				CI_DEV_PLAN_MODE: "push",
-				CI_DEV_CHANGED_PATHS: changedPaths,
+				CI_DEV_CHANGED_PATHS: changedPaths ?? "",
+				CI_DEV_CHANGED_PATHS_JSON_BASE64: "",
 				...extraEnv,
 			},
 			stdout: "pipe",
@@ -308,6 +309,47 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(matrix.include.every((shard: { key: string }) => shard.key !== "native-linux-x64")).toBe(true);
 	});
 
+	test("pull request planning uses the event base SHA instead of the fork's base branch", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-pr-base-"));
+		tempDirs.push(tempDir);
+		const outputFile = path.join(tempDir, "github-output.txt");
+		const expectedPaths = [
+			".github/workflows/ci.yml",
+			".github/workflows/dev-ci.yml",
+			"packages/coding-agent/CHANGELOG.md",
+			"scripts/ci-dev-affected.test.ts",
+			"scripts/ci-dev-affected.ts",
+			"scripts/gjc-session/create.test.ts",
+			"scripts/release-publish-order.test.ts",
+			"scripts/verify-platform-test-policy.test.ts",
+			"scripts/verify-platform-test-policy.ts",
+		];
+
+		const { exitCode } = await runScript(["--matrix-json"], undefined, {
+			CI_DEV_PLAN_MODE: "pr",
+			CI_DEV_WORKSPACE_SHA: "bfc589b212dbf7857da567d5d214a1e917e60e68",
+			GITHUB_BASE_REF: "dev",
+			GITHUB_BASE_SHA: "96eed5e39347e0778f68afea9872176dc82aa3b6",
+			GITHUB_EVENT_NAME: "pull_request",
+			GITHUB_OUTPUT: outputFile,
+			GITHUB_SHA: "bfc589b212dbf7857da567d5d214a1e917e60e68",
+		});
+		expect(exitCode).toBe(0);
+
+		const output = await Bun.file(outputFile).text();
+		const changedPathsLine = output
+			.trim()
+			.split("\n")
+			.find(line => line.startsWith("changed_paths="));
+		expect(changedPathsLine).toBeDefined();
+		const transportedPaths = (changedPathsLine as string).slice("changed_paths=".length);
+		const plannedPaths = decodeChangedPaths(transportedPaths);
+
+		expect(plannedPaths).toEqual(expectedPaths);
+		expect(Buffer.byteLength(JSON.stringify(plannedPaths), "utf8")).toBeLessThan(48 * 1024);
+		expect(transportedPaths.length).toBeLessThan(64 * 1024);
+	});
+
 	test("base64 path transport cannot forge GitHub planner outputs with newline or delimiter filenames", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-hostile-path-"));
 		tempDirs.push(tempDir);
@@ -343,6 +385,14 @@ describe("--matrix-json and --task CLI fan-out", () => {
 			"packages/coding-agent/src/main.ts",
 			"scripts/verify-platform-test-policy.ts",
 		].sort());
+	});
+
+	test("rejects oversized count, serialized-byte, and base64 transports", () => {
+		expect(() =>
+			encodeChangedPaths(Array.from({ length: 1_001 }, (_, index) => `docs/changed-${index}.md`)),
+		).toThrow("limit 1000");
+		expect(() => encodeChangedPaths([`docs/${"x".repeat(48 * 1024)}`])).toThrow("limit 49152 bytes");
+		expect(() => decodeChangedPaths("A".repeat(64 * 1024 + 4))).toThrow("limit 65536");
 	});
 
 	test("--task runs exactly the selected planned task", async () => {

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -409,8 +409,9 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		if (typeof fetchRun !== "string") throw new Error("base fetch run command must be a string");
 		expect(fetchRun).toContain('workspace_sha="$(git rev-parse HEAD)"');
 		expect(fetchRun).toContain('git fetch --no-tags "https://github.com/${BASE_REPOSITORY}.git" "+refs/heads/${BASE_REF}:refs/remotes/gjc-base/base"');
-		expect(fetchRun).toContain('fetched_base_sha="$(git rev-parse --verify refs/remotes/gjc-base/base^{commit})"');
-		expect(fetchRun).toContain('if [ "$fetched_base_sha" != "$BASE_SHA" ]; then');
+		expect(fetchRun).toContain('git merge-base --is-ancestor "$BASE_SHA" refs/remotes/gjc-base/base');
+		expect(fetchRun).toContain("pull request base SHA is unavailable from the fetched base ref");
+		expect(fetchRun).not.toContain('if [ "$fetched_base_sha" != "$BASE_SHA" ]; then');
 		expect(fetchRun).toContain('if [ "$(git rev-parse HEAD)" != "$workspace_sha" ]; then');
 		expect(fetchRun).toContain('[[ "$BASE_REPOSITORY" =~ ^[A-Za-z0-9]');
 		expect(fetchRun).toContain('git check-ref-format --branch "$BASE_REF" >/dev/null');

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -2,7 +2,17 @@ import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describeTasks, packageScriptCommand, planTargetedTasks, planTasks, resolvePackageCwd, runCommand, type WorkspacePackage } from "./ci-dev-affected";
+import {
+	describeTasks,
+	normalizeRepoRelativePosixPath,
+	packageScriptCommand,
+	planTargetedTasks,
+	planTasks,
+	resolvePackageCwd,
+	runCommand,
+	toRepoRelativePosixPath,
+	type WorkspacePackage,
+} from "./ci-dev-affected";
 
 const packages: WorkspacePackage[] = [
 	{
@@ -154,6 +164,25 @@ describe("runCommand executes package scripts in the target cwd (issue #622)", (
 	});
 });
 
+describe("repo-relative POSIX path serialization", () => {
+	test("normalizes POSIX and Windows nested relative paths without backslashes", () => {
+		const posixRelative = path.posix.relative("/repo", "/repo/packages/coding-agent");
+		const windowsRelative = path.win32.relative("C:\\repo", "C:\\repo\\packages\\coding-agent");
+
+		expect(normalizeRepoRelativePosixPath(posixRelative, path.posix.sep)).toBe("packages/coding-agent");
+		expect(normalizeRepoRelativePosixPath(windowsRelative, path.win32.sep)).toBe("packages/coding-agent");
+		expect(normalizeRepoRelativePosixPath(windowsRelative, path.win32.sep)).not.toContain("\\");
+	});
+
+	test("serializes nested paths and the repository root with host path semantics", () => {
+		const root = path.join("repo");
+		const nested = path.join(root, "packages", "coding-agent");
+
+		expect(toRepoRelativePosixPath(root, nested)).toBe("packages/coding-agent");
+		expect(toRepoRelativePosixPath(root, root)).toBe(".");
+	});
+});
+
 describe("describeTasks matrix emission", () => {
 	test("package test task needs native, native build task is flagged, check does not", () => {
 		const entries = describeTasks(planForPaths(["packages/example/src/index.ts"]));
@@ -197,10 +226,12 @@ describe("describeTasks matrix emission", () => {
 		expect(entries.every(entry => !entry.nativeBuild)).toBe(true);
 	});
 
-	test("cwd is emitted repo-relative for package-scoped tasks", () => {
+	test("cwd is emitted repo-relative with POSIX separators for package-scoped tasks", () => {
 		const entries = describeTasks(planForPaths(["packages/example/src/index.ts"]));
 		const pkgCheck = entries.find(entry => entry.key === "check:@gajae-code/example");
+
 		expect(pkgCheck?.cwd).toBe("packages/example");
+		expect(pkgCheck?.cwd).not.toContain("\\");
 	});
 });
 
@@ -277,6 +308,14 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(stdout).toContain("Dev affected-path CI");
 	});
 
+	test("--dry-run displays package cwd with POSIX separators", async () => {
+		const { stdout, exitCode } = await runScript(["--dry-run"], "python/robogjc/web/app.ts");
+
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain("cwd: python/robogjc/web");
+		expect(stdout).not.toContain("cwd: python\\robogjc\\web");
+	});
+
 	test("--task fails loudly on a key absent from the current plan", async () => {
 		const { stderr, exitCode } = await runScript(["--task=does-not-exist"], "docs/readme.md");
 		expect(exitCode).toBe(1);
@@ -303,6 +342,7 @@ describe("planTargetedTasks PR-mode targeting", () => {
 		"packages/coding-agent/test/cli.test.ts",
 		"packages/coding-agent/test/rlm-live-model-e2e.test.ts",
 		"packages/coding-agent/test/startup-update-contract.test.ts",
+		"scripts/verify-platform-test-policy.test.ts",
 	];
 
 	function targeted(paths: readonly string[]) {
@@ -390,9 +430,31 @@ describe("planTargetedTasks PR-mode targeting", () => {
 		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest", "yaml-parse"]);
 	});
 
-	test("a CI harness script change plans ci-selftest + ci-dry-run (no yaml-parse)", () => {
-		const tasks = targeted(["scripts/ci-dev-affected.ts"]);
-		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest"]);
+	test.each([
+		["selector source", "scripts/ci-dev-affected.ts"],
+		["selector test", "scripts/ci-dev-affected.test.ts"],
+	])("a CI harness %s change plans ci-selftest + ci-dry-run exactly once (no yaml-parse)", (_kind, changedPath) => {
+		const tasks = targeted([changedPath]);
+		const selftestKey = "ci-selftest";
+
+		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", selftestKey]);
+		expect(tasks.filter(task => task.key === selftestKey)).toHaveLength(1);
+		expect(tasks.find(task => task.key === selftestKey)?.command).toEqual(["bun", "test", "scripts/ci-dev-affected.test.ts"]);
+	});
+	test.each([
+		["verifier source", "scripts/verify-platform-test-policy.ts"],
+		["verifier test", "scripts/verify-platform-test-policy.test.ts"],
+	])("a platform test policy %s change schedules its focused verifier test once", (_kind, changedPath) => {
+		const tasks = targeted([changedPath]);
+		const focusedKey = "test:scripts/verify-platform-test-policy.test.ts";
+
+		expect(tasks.map(task => task.key)).toEqual([focusedKey, "native-linux-x64"]);
+		expect(tasks.find(task => task.key === focusedKey)?.command).toEqual([
+			"bun",
+			"test",
+			"scripts/verify-platform-test-policy.test.ts",
+		]);
+		expect(tasks.filter(task => task.key === focusedKey)).toHaveLength(1);
 	});
 
 	test("native platform package changes plan release publish validation", () => {
@@ -472,7 +534,33 @@ describe("push-mode broad planning still runs the fuller suite", () => {
 		const entries = describeTasks(tasks);
 		expect(entries.find(entry => entry.key === "test:@gajae-code/coding-agent:shard-1-of-8")?.native).toBe(true);
 	});
+	test.each([
+		["verifier source", "scripts/verify-platform-test-policy.ts"],
+		["verifier test", "scripts/verify-platform-test-policy.test.ts"],
+	])("push mode routes a platform test policy %s change to its focused verifier test", (_kind, changedPath) => {
+		const tasks = planTasks([changedPath], [codingAgent]);
+		const focusedKey = "test:scripts/verify-platform-test-policy.test.ts";
 
+		expect(tasks.map(task => task.key)).toEqual(["root-check", "native-linux-x64", focusedKey]);
+		expect(tasks.find(task => task.key === focusedKey)?.command).toEqual([
+			"bun",
+			"test",
+			"scripts/verify-platform-test-policy.test.ts",
+		]);
+		expect(tasks.filter(task => task.key === focusedKey)).toHaveLength(1);
+	});
+
+	test.each([
+		["selector source", "scripts/ci-dev-affected.ts"],
+		["selector test", "scripts/ci-dev-affected.test.ts"],
+	])("push mode routes a CI harness %s change to its selftest exactly once", (_kind, changedPath) => {
+		const tasks = planTasks([changedPath], [codingAgent]);
+		const selftestKey = "affected-selftest";
+
+		expect(tasks.map(task => task.key).sort()).toEqual(["affected-dry-run", selftestKey]);
+		expect(tasks.filter(task => task.key === selftestKey)).toHaveLength(1);
+		expect(tasks.find(task => task.key === selftestKey)?.command).toEqual(["bun", "test", "scripts/ci-dev-affected.test.ts"]);
+	});
 	test("full-workspace changes partition root tests into matrix shards", () => {
 		const tasks = planTasks(["tsconfig.json"], [codingAgent]);
 		const keys = tasks.map(task => task.key);

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -463,6 +463,74 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(decodeChangedPaths(encodeChangedPaths(result.paths))).toEqual(result.paths);
 	});
 
+	test("real CLI fallback executes after module initialization for unrelated histories", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-unrelated-history-"));
+		tempDirs.push(tempDir);
+
+		const runGit = async (args: readonly string[]): Promise<string> => {
+			const proc = Bun.spawn(["git", ...args], {
+				cwd: tempDir,
+				env: {
+					...process.env,
+					GIT_AUTHOR_NAME: "GJC Test",
+					GIT_AUTHOR_EMAIL: "gjc-test@example.invalid",
+					GIT_COMMITTER_NAME: "GJC Test",
+					GIT_COMMITTER_EMAIL: "gjc-test@example.invalid",
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [stdout, stderr, exitCode] = await Promise.all([
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+				proc.exited,
+			]);
+			if (exitCode !== 0) {
+				throw new Error(`git ${args.join(" ")} failed (${exitCode}): ${stderr}`);
+			}
+			return stdout.trim();
+		};
+
+		await runGit(["init"]);
+		await Bun.write(path.join(tempDir, "base-only.txt"), "base\n");
+		await runGit(["add", "base-only.txt"]);
+		await runGit(["commit", "-m", "base"]);
+		const base = await runGit(["rev-parse", "HEAD"]);
+
+		await runGit(["checkout", "--orphan", "ci-head"]);
+		await runGit(["rm", "-rf", "."]);
+		await fs.mkdir(path.join(tempDir, "scripts"), { recursive: true });
+		await fs.copyFile(scriptPath, path.join(tempDir, "scripts", "ci-dev-affected.ts"));
+		await Bun.write(path.join(tempDir, "package.json"), `${JSON.stringify({ workspaces: [] })}\n`);
+		await runGit(["add", "package.json", "scripts/ci-dev-affected.ts"]);
+		await runGit(["commit", "-m", "head"]);
+		const head = await runGit(["rev-parse", "HEAD"]);
+
+		const proc = Bun.spawn(["bun", path.join(tempDir, "scripts", "ci-dev-affected.ts"), "--dry-run"], {
+			cwd: tempDir,
+			env: {
+				...process.env,
+				GITHUB_EVENT_NAME: "pull_request",
+				GITHUB_BASE_SHA: base,
+				GITHUB_SHA: head,
+				CI_DEV_CHANGED_PATHS: "",
+				CI_DEV_CHANGED_PATHS_JSON_BASE64: "",
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+
+		expect(exitCode).toBe(0);
+		expect(stderr).toContain("ci-dev-affected: no merge base; using conservative two-tree changed-path diff.");
+		expect(stderr).not.toContain("ReferenceError");
+		expect(stdout).toContain("scripts/ci-dev-affected.ts");
+	});
+
 	test("fails closed for git failures other than no merge base", async () => {
 		const calls: string[] = [];
 		await expect(

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -334,26 +334,17 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-pr-base-"));
 		tempDirs.push(tempDir);
 		const outputFile = path.join(tempDir, "github-output.txt");
-		const expectedPaths = [
-			".github/workflows/ci.yml",
-			".github/workflows/dev-ci.yml",
-			"packages/coding-agent/CHANGELOG.md",
-			"scripts/ci-dev-affected.test.ts",
-			"scripts/ci-dev-affected.ts",
-			"scripts/gjc-session/create.test.ts",
-			"scripts/release-publish-order.test.ts",
-			"scripts/verify-platform-test-policy.test.ts",
-			"scripts/verify-platform-test-policy.ts",
-		];
+		const head = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: repoRoot }).stdout.toString().trim();
+		expect(head).toMatch(/^[0-9a-f]{40}$/);
 
 		const { exitCode } = await runScript(["--matrix-json"], undefined, {
 			CI_DEV_PLAN_MODE: "pr",
-			CI_DEV_WORKSPACE_SHA: "bfc589b212dbf7857da567d5d214a1e917e60e68",
-			GITHUB_BASE_REF: "dev",
-			GITHUB_BASE_SHA: "96eed5e39347e0778f68afea9872176dc82aa3b6",
+			CI_DEV_WORKSPACE_SHA: head,
+			GITHUB_BASE_REF: "branch-that-must-not-be-resolved",
+			GITHUB_BASE_SHA: head,
 			GITHUB_EVENT_NAME: "pull_request",
 			GITHUB_OUTPUT: outputFile,
-			GITHUB_SHA: "bfc589b212dbf7857da567d5d214a1e917e60e68",
+			GITHUB_SHA: head,
 		});
 		expect(exitCode).toBe(0);
 
@@ -366,7 +357,7 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		const transportedPaths = (changedPathsLine as string).slice("changed_paths=".length);
 		const plannedPaths = decodeChangedPaths(transportedPaths);
 
-		expect(plannedPaths).toEqual(expectedPaths);
+		expect(plannedPaths).toEqual([]);
 		expect(Buffer.byteLength(JSON.stringify(plannedPaths), "utf8")).toBeLessThan(48 * 1024);
 		expect(transportedPaths.length).toBeLessThan(64 * 1024);
 	});

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -125,9 +125,6 @@ async function main(): Promise<void> {
 	}
 }
 
-if (import.meta.main) {
-	await main();
-}
 
 // CI runs in one of two planning modes:
 //   - "pr": pull_request runs get a fast, narrowly targeted plan (run only the
@@ -1088,4 +1085,8 @@ export async function runCommand(command: readonly string[], cwd: string): Promi
 		stderr: "inherit",
 	});
 	return proc.exited;
+}
+
+if (import.meta.main) {
+	await main();
 }

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -16,6 +16,9 @@ const PLATFORM_POLICY_PATHS = new Set([
 	".github/workflows/ci.yml",
 	".github/workflows/dev-ci.yml",
 	"scripts/gjc-session/create.test.ts",
+	"scripts/gjc-session/create.sh",
+	"scripts/gjc-session/prompt.sh",
+	"scripts/gjc-session/postmortem.sh",
 	"scripts/release-publish-order.test.ts",
 	"scripts/verify-platform-test-policy.test.ts",
 	"scripts/verify-platform-test-policy.ts",
@@ -41,6 +44,9 @@ const BEHAVIORAL_OWNER_TESTS: Readonly<Record<string, readonly string[]>> = {
 const PLATFORM_TEST_POLICY_TEST = "scripts/verify-platform-test-policy.test.ts";
 const FOCUSED_SCRIPT_TESTS: Readonly<Record<string, string>> = {
 	"scripts/gjc-session/create.test.ts": "scripts/gjc-session/create.test.ts",
+	"scripts/gjc-session/create.sh": "scripts/gjc-session/create.test.ts",
+	"scripts/gjc-session/prompt.sh": "scripts/gjc-session/create.test.ts",
+	"scripts/gjc-session/postmortem.sh": "scripts/gjc-session/create.test.ts",
 	"scripts/release-publish-order.test.ts": "scripts/release-publish-order.test.ts",
 	"scripts/verify-platform-test-policy.ts": PLATFORM_TEST_POLICY_TEST,
 	[PLATFORM_TEST_POLICY_TEST]: PLATFORM_TEST_POLICY_TEST,

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -352,8 +352,11 @@ async function getChangedPaths(): Promise<string[]> {
 
 	const explicitPaths = Bun.env.CI_DEV_CHANGED_PATHS?.trim();
 	if (explicitPaths) {
-		if (Buffer.byteLength(explicitPaths, "utf8") > MAX_CHANGED_PATHS_SERIALIZED_BYTES) {
-			throw new Error("CI_DEV_CHANGED_PATHS exceeds the changed-path transport limit.");
+		const explicitPathBytes = Buffer.byteLength(explicitPaths, "utf8");
+		if (explicitPathBytes > MAX_CHANGED_PATHS_SERIALIZED_BYTES) {
+			throw new Error(
+				`CI_DEV_CHANGED_PATHS has ${explicitPathBytes} UTF-8 bytes (limit ${MAX_CHANGED_PATHS_SERIALIZED_BYTES} bytes).`,
+			);
 		}
 		return normalizeChangedPaths(
 			explicitPaths
@@ -380,17 +383,20 @@ export function encodeChangedPaths(paths: readonly string[]): string {
 }
 
 export function decodeChangedPaths(encodedPaths: string): string[] {
-	if (
-		encodedPaths.length > MAX_CHANGED_PATHS_TRANSPORT_LENGTH ||
-		encodedPaths.length % 4 !== 0 ||
-		!/^[A-Za-z0-9+/]*={0,2}$/.test(encodedPaths)
-	) {
-		throw new Error("CI_DEV_CHANGED_PATHS_JSON_BASE64 is not a bounded base64 payload.");
+	if (encodedPaths.length > MAX_CHANGED_PATHS_TRANSPORT_LENGTH) {
+		throw new Error(
+			`CI_DEV_CHANGED_PATHS_JSON_BASE64 has ${encodedPaths.length} characters (limit ${MAX_CHANGED_PATHS_TRANSPORT_LENGTH}).`,
+		);
+	}
+	if (encodedPaths.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(encodedPaths)) {
+		throw new Error("CI_DEV_CHANGED_PATHS_JSON_BASE64 is not a valid base64 payload.");
 	}
 
 	const serialized = Buffer.from(encodedPaths, "base64");
 	if (serialized.byteLength > MAX_CHANGED_PATHS_SERIALIZED_BYTES) {
-		throw new Error("CI_DEV_CHANGED_PATHS_JSON_BASE64 exceeds the changed-path transport limit.");
+		throw new Error(
+			`CI_DEV_CHANGED_PATHS_JSON_BASE64 decodes to ${serialized.byteLength} bytes (limit ${MAX_CHANGED_PATHS_SERIALIZED_BYTES} bytes).`,
+		);
 	}
 
 	let parsed: unknown;
@@ -407,12 +413,14 @@ export function decodeChangedPaths(encodedPaths: string): string[] {
 
 function normalizeChangedPaths(paths: readonly string[]): string[] {
 	if (paths.length > MAX_CHANGED_PATHS) {
-		throw new Error(`Changed-path plan exceeds the ${MAX_CHANGED_PATHS}-path limit.`);
+		throw new Error(`Changed-path plan has ${paths.length} paths (limit ${MAX_CHANGED_PATHS}).`);
 	}
 	const normalized = Array.from(new Set(paths.filter(Boolean))).sort();
 	const serializedBytes = Buffer.byteLength(JSON.stringify(normalized), "utf8");
 	if (serializedBytes > MAX_CHANGED_PATHS_SERIALIZED_BYTES) {
-		throw new Error("Changed-path plan exceeds the transport size limit.");
+		throw new Error(
+			`Changed-path plan has ${normalized.length} unique paths serialized as ${serializedBytes} bytes (limit ${MAX_CHANGED_PATHS_SERIALIZED_BYTES} bytes). Verify the diff uses the pull request target's merge base.`,
+		);
 	}
 	return normalized;
 }
@@ -423,13 +431,19 @@ async function resolveBaseRef(): Promise<string> {
 	const baseSha = Bun.env.GITHUB_BASE_SHA?.trim();
 	const baseRef = Bun.env.GITHUB_BASE_REF?.trim();
 
-	if (eventName === "pull_request" && baseRef) {
-		const mergeBase = await $`git merge-base HEAD ${`origin/${baseRef}`}`.cwd(repoRoot).quiet().nothrow();
-		if (mergeBase.exitCode === 0) {
-			const value = mergeBase.stdout.toString().trim();
-			if (value !== "") return value;
+	if (eventName === "pull_request") {
+		// `origin` is the PR fork after checkout, so origin/<baseRef> can be stale
+		// or absent. The event base SHA identifies the exact PR target baseline.
+		const pullRequestBase =
+			baseSha && !ZERO_SHA.test(baseSha) ? baseSha : baseRef ? `origin/${baseRef}` : undefined;
+		if (pullRequestBase) {
+			const mergeBase = await $`git merge-base HEAD ${pullRequestBase}`.cwd(repoRoot).quiet().nothrow();
+			if (mergeBase.exitCode === 0) {
+				const value = mergeBase.stdout.toString().trim();
+				if (value !== "") return value;
+			}
+			return pullRequestBase;
 		}
-		return `origin/${baseRef}`;
 	}
 	if (baseSha && !ZERO_SHA.test(baseSha)) {
 		return baseSha;

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -27,6 +27,7 @@ const NATIVE_BUILD_KEYS: ReadonlySet<string> = new Set(["native-build", "native-
 const BEHAVIORAL_OWNER_TESTS: Readonly<Record<string, readonly string[]>> = {
 	"packages/coding-agent/src/main.ts": ["packages/coding-agent/test/startup-update-contract.test.ts"],
 };
+const PLATFORM_TEST_POLICY_TEST = "scripts/verify-platform-test-policy.test.ts";
 
 export interface PackageManifest {
 	name?: string;
@@ -208,12 +209,20 @@ function taskNeedsRust(key: string): boolean {
 
 // Build the machine-readable descriptor list for the current changed-path plan.
 // `cwd` is emitted repo-relative so the JSON stays portable across runners.
+export function normalizeRepoRelativePosixPath(value: string, separator: string): string {
+	return value.split(separator).join("/") || ".";
+}
+
+export function toRepoRelativePosixPath(root: string, target: string): string {
+	return normalizeRepoRelativePosixPath(path.relative(root, target), path.sep);
+}
+
 export function describeTasks(tasks: readonly Task[]): TaskMatrixEntry[] {
 	return tasks.map(task => ({
 		key: task.key,
 		description: task.description,
 		command: task.command,
-		cwd: task.cwd ? path.relative(repoRoot, task.cwd) || "." : undefined,
+		cwd: task.cwd ? toRepoRelativePosixPath(repoRoot, task.cwd) : undefined,
 		native: taskNeedsNative(task.key),
 		rust: taskNeedsRust(task.key),
 		nativeBuild: isNativeBuildKey(task.key),
@@ -309,7 +318,7 @@ function printPlan(paths: readonly string[], plannedTasks: readonly Task[]): voi
 	}
 	console.log("Planned tasks:");
 	for (const task of plannedTasks) {
-		const where = task.cwd ? ` (cwd: ${path.relative(repoRoot, task.cwd) || "."})` : "";
+		const where = task.cwd ? ` (cwd: ${toRepoRelativePosixPath(repoRoot, task.cwd)})` : "";
 		console.log(` - ${task.description}: ${task.command.join(" ")}${where}`);
 	}
 }
@@ -499,6 +508,9 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 	if (needsNativeRuntime) {
 		add(tasks, "cli-smoke", "GJC CLI smoke test", ["bun", "run", "ci:test:smoke"]);
 	}
+	if (paths.some(isPlatformTestPolicyPath)) {
+		addTestFileTask(tasks, PLATFORM_TEST_POLICY_TEST);
+	}
 	if (paths.some(isWorkflowOrScriptPath)) {
 		add(tasks, "affected-dry-run", "Affected CI selector self-check", ["bun", "scripts/ci-dev-affected.ts", "--dry-run"]);
 		add(tasks, "affected-selftest", "Affected CI selector unit tests", ["bun", "test", "scripts/ci-dev-affected.test.ts"]);
@@ -544,6 +556,10 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 		if (isWorkflowPath(changedPath)) {
 			needYamlParse = true;
 			needCiSelftest = true;
+			continue;
+		}
+		if (isPlatformTestPolicyPath(changedPath)) {
+			addTestFileTask(tasks, PLATFORM_TEST_POLICY_TEST);
 			continue;
 		}
 		if (isCiHarnessScriptPath(changedPath)) {
@@ -705,6 +721,9 @@ function isTestFilePath(changedPath: string): boolean {
 
 function isCiHarnessScriptPath(changedPath: string): boolean {
 	return changedPath === "scripts/ci-dev-affected.ts" || changedPath === "scripts/ci-dev-affected.test.ts" || changedPath === "scripts/check-workflow-yaml.ts";
+}
+function isPlatformTestPolicyPath(changedPath: string): boolean {
+	return changedPath === "scripts/verify-platform-test-policy.ts" || changedPath === PLATFORM_TEST_POLICY_TEST;
 }
 
 function isWebPath(changedPath: string): boolean {
@@ -870,7 +889,7 @@ function isWorkflowPath(changedPath: string): boolean {
 }
 
 function isWorkflowHarnessPath(changedPath: string): boolean {
-	return isWorkflowPath(changedPath) || changedPath === "scripts/ci-dev-affected.ts" || changedPath === "scripts/check-workflow-yaml.ts";
+	return isWorkflowPath(changedPath) || isCiHarnessScriptPath(changedPath);
 }
 
 function isToolingScriptPath(changedPath: string): boolean {

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -19,6 +19,7 @@ const PLATFORM_POLICY_PATHS = new Set([
 	"scripts/gjc-session/create.sh",
 	"scripts/gjc-session/prompt.sh",
 	"scripts/gjc-session/postmortem.sh",
+	"scripts/ci-install-system-deps.sh",
 	"scripts/release-publish-order.test.ts",
 	"scripts/verify-platform-test-policy.test.ts",
 	"scripts/verify-platform-test-policy.ts",

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -1,12 +1,25 @@
 #!/usr/bin/env bun
 
 import { $ } from "bun";
+import { Buffer } from "node:buffer";
 import * as path from "node:path";
 import * as fs from "node:fs/promises";
 
 const repoRoot = path.join(import.meta.dir, "..");
 const ZERO_SHA = /^0+$/;
 const PACKAGE_SCOPES = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] as const;
+const MAX_CHANGED_PATHS = 1_000;
+const MAX_CHANGED_PATHS_SERIALIZED_BYTES = 48 * 1024;
+const MAX_CHANGED_PATHS_TRANSPORT_LENGTH = Math.ceil((MAX_CHANGED_PATHS_SERIALIZED_BYTES / 3) * 4);
+const CHANGED_PATHS_TRANSPORT_ENV = "CI_DEV_CHANGED_PATHS_JSON_BASE64";
+const PLATFORM_POLICY_PATHS = new Set([
+	".github/workflows/ci.yml",
+	".github/workflows/dev-ci.yml",
+	"scripts/gjc-session/create.test.ts",
+	"scripts/release-publish-order.test.ts",
+	"scripts/verify-platform-test-policy.test.ts",
+	"scripts/verify-platform-test-policy.ts",
+]);
 const PYTHON_DEV_SETUP =
 	"python3 -m pip install --user --upgrade 'pip>=24' 'setuptools>=69' wheel && python3 -m pip install --user -e python/gjc-rpc -e 'python/robogjc[dev]'";
 // The coding-agent package has hundreds of test files; keep dev affected
@@ -17,9 +30,7 @@ const CODING_AGENT_TEST_SHARDS = 8;
 // Keys for tasks that compile the @gajae-code/natives addon. They run once in
 // the dedicated dev-ci native-build job (not as matrix shards) and publish the
 // built `.node` files as an artifact the runtime-dependent shards download.
-// Declared here (before the top-level `await main()`) so it is initialized for
-// every CLI mode despite top-level await halting later module statements.
-const NATIVE_BUILD_KEYS: ReadonlySet<string> = new Set(["native-build", "native-linux-x64"]);
+const NATIVE_BUILD_KEYS: ReadonlySet<string> = new Set(["native-linux-x64"]);
 
 // Behavioral-owner tests cover entrypoint contracts whose names intentionally do
 // not follow the source-file basename convention. They supplement, rather than
@@ -28,6 +39,15 @@ const BEHAVIORAL_OWNER_TESTS: Readonly<Record<string, readonly string[]>> = {
 	"packages/coding-agent/src/main.ts": ["packages/coding-agent/test/startup-update-contract.test.ts"],
 };
 const PLATFORM_TEST_POLICY_TEST = "scripts/verify-platform-test-policy.test.ts";
+const FOCUSED_SCRIPT_TESTS: Readonly<Record<string, string>> = {
+	"scripts/gjc-session/create.test.ts": "scripts/gjc-session/create.test.ts",
+	"scripts/release-publish-order.test.ts": "scripts/release-publish-order.test.ts",
+	"scripts/verify-platform-test-policy.ts": PLATFORM_TEST_POLICY_TEST,
+	[PLATFORM_TEST_POLICY_TEST]: PLATFORM_TEST_POLICY_TEST,
+};
+const NON_NATIVE_FOCUSED_TEST_KEYS: ReadonlySet<string> = new Set(
+	Object.values(FOCUSED_SCRIPT_TESTS).map(testFile => `test:${testFile}`),
+);
 
 export interface PackageManifest {
 	name?: string;
@@ -169,7 +189,7 @@ async function emitAffectedFlags(): Promise<void> {
 		const planned = planTasks(paths, packages);
 		const keys = new Set(planned.map(task => task.key));
 		rust = keys.has("rust-check") || keys.has("rust-test");
-		native = keys.has("native-build") || keys.has("native-linux-x64");
+		native = keys.has("native-linux-x64");
 		console.log(`ci-dev-affected: rust=${rust} native=${native} (changed paths: ${paths.length})`);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -198,7 +218,7 @@ function taskNeedsNative(key: string): boolean {
 		key === "wrapper-version" ||
 		key === "deep-interview-definitions" ||
 		key === "deep-interview-runtime" ||
-		key.startsWith("test:")
+		(key.startsWith("test:") && !NON_NATIVE_FOCUSED_TEST_KEYS.has(key))
 	);
 }
 
@@ -232,9 +252,10 @@ export function describeTasks(tasks: readonly Task[]): TaskMatrixEntry[] {
 // `--matrix-json` prints the planned tasks as a JSON array on stdout (consumed
 // by tests and for debugging). Under GitHub Actions it also appends the dev-ci
 // planner outputs: `matrix` (the shard include list, excluding native-build
-// tasks), `has_tasks`, `has_native`, and the resolved `changed_paths` so every
-// downstream job reuses the planner's exact diff via CI_DEV_CHANGED_PATHS
-// instead of re-resolving the base ref on each runner.
+// tasks), `has_tasks`, `has_native`, and a base64-encoded JSON `changed_paths`
+// value so every downstream job reuses the planner's exact diff via
+// CI_DEV_CHANGED_PATHS_JSON_BASE64 instead of re-resolving the base ref on each
+// runner. Encoding prevents hostile Git pathnames from adding GitHub outputs.
 async function emitMatrix(): Promise<void> {
 	const paths = await getChangedPaths();
 	const mode = resolvePlanMode();
@@ -251,14 +272,14 @@ async function emitMatrix(): Promise<void> {
 		.filter(entry => !entry.nativeBuild)
 		.map(entry => ({ key: entry.key, description: entry.description, native: entry.native, rust: entry.rust }));
 	const hasNative = entries.some(entry => entry.nativeBuild);
+	const hasPlatformPolicy = paths.some(changedPath => PLATFORM_POLICY_PATHS.has(changedPath));
 	const lines = [
 		`matrix=${JSON.stringify({ include: shards })}`,
 		`has_tasks=${shards.length > 0}`,
 		`has_native=${hasNative}`,
+		`has_platform_policy=${hasPlatformPolicy}`,
 		`plan_mode=${mode}`,
-		"changed_paths<<__GJC_PATHS_EOF__",
-		...paths,
-		"__GJC_PATHS_EOF__",
+		`changed_paths=${encodeChangedPaths(paths)}`,
 		"",
 	];
 	await fs.appendFile(githubOutput, lines.join("\n"));
@@ -324,24 +345,76 @@ function printPlan(paths: readonly string[], plannedTasks: readonly Task[]): voi
 }
 
 async function getChangedPaths(): Promise<string[]> {
+	const transportedPaths = Bun.env[CHANGED_PATHS_TRANSPORT_ENV]?.trim();
+	if (transportedPaths) {
+		return decodeChangedPaths(transportedPaths);
+	}
+
 	const explicitPaths = Bun.env.CI_DEV_CHANGED_PATHS?.trim();
 	if (explicitPaths) {
-		return explicitPaths
-			.split(/[\n,]/)
-			.map(entry => entry.trim())
-			.filter(Boolean)
-			.sort();
+		if (Buffer.byteLength(explicitPaths, "utf8") > MAX_CHANGED_PATHS_SERIALIZED_BYTES) {
+			throw new Error("CI_DEV_CHANGED_PATHS exceeds the changed-path transport limit.");
+		}
+		return normalizeChangedPaths(
+			explicitPaths
+				.split(/[\n,]/)
+				.map(entry => entry.trim())
+				.filter(Boolean),
+		);
 	}
 
 	const base = await resolveBaseRef();
-	const head = Bun.env.GITHUB_SHA?.trim() || "HEAD";
+	const head = Bun.env.CI_DEV_WORKSPACE_SHA?.trim() || Bun.env.GITHUB_SHA?.trim() || "HEAD";
 	const range = base.includes("...") || base.includes("..") ? base : `${base}...${head}`;
 	const diff = await $`git diff --name-only -z ${range}`.cwd(repoRoot).quiet().nothrow();
 	if (diff.exitCode !== 0) {
 		const stderr = diff.stderr.toString().trim();
 		throw new Error(`Failed to compute changed paths for ${range}: ${stderr}`);
 	}
-	return new TextDecoder().decode(diff.stdout).split("\0").filter(Boolean).sort();
+	return normalizeChangedPaths(new TextDecoder().decode(diff.stdout).split("\0").filter(Boolean));
+}
+
+export function encodeChangedPaths(paths: readonly string[]): string {
+	const serialized = JSON.stringify(normalizeChangedPaths(paths));
+	return Buffer.from(serialized, "utf8").toString("base64");
+}
+
+export function decodeChangedPaths(encodedPaths: string): string[] {
+	if (
+		encodedPaths.length > MAX_CHANGED_PATHS_TRANSPORT_LENGTH ||
+		encodedPaths.length % 4 !== 0 ||
+		!/^[A-Za-z0-9+/]*={0,2}$/.test(encodedPaths)
+	) {
+		throw new Error("CI_DEV_CHANGED_PATHS_JSON_BASE64 is not a bounded base64 payload.");
+	}
+
+	const serialized = Buffer.from(encodedPaths, "base64");
+	if (serialized.byteLength > MAX_CHANGED_PATHS_SERIALIZED_BYTES) {
+		throw new Error("CI_DEV_CHANGED_PATHS_JSON_BASE64 exceeds the changed-path transport limit.");
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(serialized.toString("utf8"));
+	} catch {
+		throw new Error("CI_DEV_CHANGED_PATHS_JSON_BASE64 does not contain JSON.");
+	}
+	if (!Array.isArray(parsed) || !parsed.every(isString)) {
+		throw new Error("CI_DEV_CHANGED_PATHS_JSON_BASE64 must contain a JSON string array.");
+	}
+	return normalizeChangedPaths(parsed);
+}
+
+function normalizeChangedPaths(paths: readonly string[]): string[] {
+	if (paths.length > MAX_CHANGED_PATHS) {
+		throw new Error(`Changed-path plan exceeds the ${MAX_CHANGED_PATHS}-path limit.`);
+	}
+	const normalized = Array.from(new Set(paths.filter(Boolean))).sort();
+	const serializedBytes = Buffer.byteLength(JSON.stringify(normalized), "utf8");
+	if (serializedBytes > MAX_CHANGED_PATHS_SERIALIZED_BYTES) {
+		throw new Error("Changed-path plan exceeds the transport size limit.");
+	}
+	return normalized;
 }
 
 async function resolveBaseRef(): Promise<string> {
@@ -442,7 +515,7 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 	const installChanged = paths.some(isInstallPath);
 	const publishChanged = paths.some(isReleasePublishPath);
 	const wrapperChanged = paths.some(isUnscopedWrapperPath);
-	const toolingScriptChanged = paths.some(isToolingScriptPath);
+	const toolingScriptChanged = paths.some(changedPath => isToolingScriptPath(changedPath) && !focusedScriptTestFor(changedPath));
 	const deepInterviewOnly = isDeepInterviewOnly(paths);
 	const needsNativeRuntime = !deepInterviewOnly && (paths.some(isCodingAgentRuntimePath) || wrapperChanged || fullWorkspace);
 	const workflowHarnessOnly = paths.length > 0 && paths.every(isWorkflowHarnessPath);
@@ -456,7 +529,7 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 	}
 
 	if (needsNativeRuntime) {
-		add(tasks, "native-build", "Build native addon for CLI/test smoke", ["bun", "run", "build:native"]);
+		addNativeBuild(tasks);
 	}
 
 	if (fullWorkspace) {
@@ -508,8 +581,11 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 	if (needsNativeRuntime) {
 		add(tasks, "cli-smoke", "GJC CLI smoke test", ["bun", "run", "ci:test:smoke"]);
 	}
-	if (paths.some(isPlatformTestPolicyPath)) {
-		addTestFileTask(tasks, PLATFORM_TEST_POLICY_TEST);
+	for (const changedPath of paths) {
+		const focusedTest = focusedScriptTestFor(changedPath);
+		if (focusedTest) {
+			addTestFileTask(tasks, focusedTest);
+		}
 	}
 	if (paths.some(isWorkflowOrScriptPath)) {
 		add(tasks, "affected-dry-run", "Affected CI selector self-check", ["bun", "scripts/ci-dev-affected.ts", "--dry-run"]);
@@ -558,8 +634,9 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 			needCiSelftest = true;
 			continue;
 		}
-		if (isPlatformTestPolicyPath(changedPath)) {
-			addTestFileTask(tasks, PLATFORM_TEST_POLICY_TEST);
+		const focusedTest = focusedScriptTestFor(changedPath);
+		if (focusedTest) {
+			addTestFileTask(tasks, focusedTest);
 			continue;
 		}
 		if (isCiHarnessScriptPath(changedPath)) {
@@ -722,8 +799,8 @@ function isTestFilePath(changedPath: string): boolean {
 function isCiHarnessScriptPath(changedPath: string): boolean {
 	return changedPath === "scripts/ci-dev-affected.ts" || changedPath === "scripts/ci-dev-affected.test.ts" || changedPath === "scripts/check-workflow-yaml.ts";
 }
-function isPlatformTestPolicyPath(changedPath: string): boolean {
-	return changedPath === "scripts/verify-platform-test-policy.ts" || changedPath === PLATFORM_TEST_POLICY_TEST;
+function focusedScriptTestFor(changedPath: string): string | undefined {
+	return FOCUSED_SCRIPT_TESTS[changedPath];
 }
 
 function isWebPath(changedPath: string): boolean {
@@ -736,7 +813,9 @@ function isCodeIshPath(changedPath: string): boolean {
 
 
 function addNativeBuild(tasks: Map<string, Task>): void {
-	add(tasks, "native-linux-x64", "Build linux x64 native addons", ["bash", "-lc", 'TARGET_VARIANTS="baseline modern" bun scripts/ci-build-native.ts']);
+	if (!Array.from(tasks.keys()).some(isNativeBuildKey)) {
+		add(tasks, "native-linux-x64", "Build linux x64 native addons", ["bash", "-lc", 'TARGET_VARIANTS="baseline modern" bun scripts/ci-build-native.ts']);
+	}
 }
 
 function add(tasks: Map<string, Task>, key: string, description: string, command: readonly string[], cwd?: string): void {

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -344,6 +344,24 @@ function printPlan(paths: readonly string[], plannedTasks: readonly Task[]): voi
 	}
 }
 
+export type GitDiffMode = "merge-base" | "two-tree";
+
+export interface GitDiffResult {
+	exitCode: number;
+	stdout: Uint8Array;
+	stderr: string;
+}
+
+export type GitDiffRunner = (base: string, head: string, mode: GitDiffMode) => Promise<GitDiffResult>;
+
+export interface ChangedPathRange {
+	paths: string[];
+	usedConservativeTwoTreeDiff: boolean;
+}
+
+export const NO_MERGE_BASE_FALLBACK_DIAGNOSTIC =
+	"ci-dev-affected: no merge base; using conservative two-tree changed-path diff.";
+
 async function getChangedPaths(): Promise<string[]> {
 	const transportedPaths = Bun.env[CHANGED_PATHS_TRANSPORT_ENV]?.trim();
 	if (transportedPaths) {
@@ -368,13 +386,63 @@ async function getChangedPaths(): Promise<string[]> {
 
 	const base = await resolveBaseRef();
 	const head = Bun.env.CI_DEV_WORKSPACE_SHA?.trim() || Bun.env.GITHUB_SHA?.trim() || "HEAD";
-	const range = base.includes("...") || base.includes("..") ? base : `${base}...${head}`;
-	const diff = await $`git diff --name-only -z ${range}`.cwd(repoRoot).quiet().nothrow();
-	if (diff.exitCode !== 0) {
-		const stderr = diff.stderr.toString().trim();
-		throw new Error(`Failed to compute changed paths for ${range}: ${stderr}`);
+	if (base.includes("...") || base.includes("..")) {
+		const diff = await $`git diff --name-only -z ${base}`.cwd(repoRoot).quiet().nothrow();
+		if (diff.exitCode !== 0) {
+			throw new Error(`Failed to compute changed paths for requested range (git exit code ${diff.exitCode}).`);
+		}
+		return normalizeChangedPaths(new TextDecoder().decode(diff.stdout).split("\0").filter(Boolean));
 	}
-	return normalizeChangedPaths(new TextDecoder().decode(diff.stdout).split("\0").filter(Boolean));
+
+	const changedPathRange = await getChangedPathsForRange(base, head);
+	if (changedPathRange.usedConservativeTwoTreeDiff) {
+		console.error(NO_MERGE_BASE_FALLBACK_DIAGNOSTIC);
+	}
+	return changedPathRange.paths;
+}
+
+export async function getChangedPathsForRange(
+	base: string,
+	head: string,
+	gitDiffRunner: GitDiffRunner = runGitDiff,
+): Promise<ChangedPathRange> {
+	const mergeBaseDiff = await gitDiffRunner(base, head, "merge-base");
+	if (mergeBaseDiff.exitCode === 0) {
+		return {
+			paths: normalizeChangedPaths(new TextDecoder().decode(mergeBaseDiff.stdout).split("\0").filter(Boolean)),
+			usedConservativeTwoTreeDiff: false,
+		};
+	}
+	if (!isNoMergeBaseError(mergeBaseDiff.stderr)) {
+		throw new Error(`Failed to compute changed paths for requested range (git exit code ${mergeBaseDiff.exitCode}).`);
+	}
+
+	const twoTreeDiff = await gitDiffRunner(base, head, "two-tree");
+	if (twoTreeDiff.exitCode !== 0) {
+		throw new Error(
+			`Failed to compute changed paths with conservative two-tree diff (git exit code ${twoTreeDiff.exitCode}).`,
+		);
+	}
+	return {
+		paths: normalizeChangedPaths(new TextDecoder().decode(twoTreeDiff.stdout).split("\0").filter(Boolean)),
+		usedConservativeTwoTreeDiff: true,
+	};
+}
+
+async function runGitDiff(base: string, head: string, mode: GitDiffMode): Promise<GitDiffResult> {
+	const diff =
+		mode === "merge-base"
+			? await $`git diff --name-only -z ${`${base}...${head}`}`.cwd(repoRoot).quiet().nothrow()
+			: await $`git diff --name-only -z ${base} ${head}`.cwd(repoRoot).quiet().nothrow();
+	return {
+		exitCode: diff.exitCode,
+		stdout: diff.stdout,
+		stderr: diff.stderr.toString(),
+	};
+}
+
+function isNoMergeBaseError(stderr: string): boolean {
+	return /fatal: [^\r\n]*\bno merge base\b/i.test(stderr);
 }
 
 export function encodeChangedPaths(paths: readonly string[]): string {

--- a/scripts/gjc-session/create.test.ts
+++ b/scripts/gjc-session/create.test.ts
@@ -1,7 +1,9 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+
+setDefaultTimeout(process.platform === "linux" ? 20_000 : 5_000);
 
 const roots: string[] = [];
 const sessions: Array<{ name: string; socket: string }> = [];
@@ -210,7 +212,7 @@ afterEach(async () => {
 	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
 });
 
-describe("gjc-session create public owner lifecycle", () => {
+describe.skipIf(process.platform === "win32")("gjc-session create public owner lifecycle", () => {
 	test("rejects missing binaries, directories, git worktrees, and detached branches", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-create-validation-")); roots.push(root);
 		const missing = Bun.spawnSync(["bash", createScript, "x", root], { env: env({ GJC_BIN: "/definitely-not-a-gjc-executable" }), stderr: "pipe" });

--- a/scripts/gjc-session/create.test.ts
+++ b/scripts/gjc-session/create.test.ts
@@ -212,7 +212,8 @@ afterEach(async () => {
 	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
 });
 
-describe.skipIf(process.platform === "win32")("gjc-session create public owner lifecycle", () => {
+// This fixture invokes Bash/GNU utilities, systemd-run, tmux, and /proc; it is Linux-only.
+describe.skipIf(process.platform !== "linux")("gjc-session create public owner lifecycle", () => {
 	test("rejects missing binaries, directories, git worktrees, and detached branches", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-create-validation-")); roots.push(root);
 		const missing = Bun.spawnSync(["bash", createScript, "x", root], { env: env({ GJC_BIN: "/definitely-not-a-gjc-executable" }), stderr: "pipe" });

--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -41,6 +41,12 @@ async function readCiWorkflowJobs(): Promise<YamlRecord> {
 	const parsed: unknown = Bun.YAML.parse(workflow);
 	return requireYamlRecord(requireYamlRecord(parsed, "CI workflow").jobs, "CI workflow jobs");
 }
+async function readDevWorkflowJobs(): Promise<YamlRecord> {
+	const workflow = await Bun.file(path.join(repoRoot, ".github/workflows/dev-ci.yml")).text();
+	const parsed: unknown = Bun.YAML.parse(workflow);
+	return requireYamlRecord(requireYamlRecord(parsed, "Dev CI workflow").jobs, "Dev CI workflow jobs");
+}
+
 
 async function readManifest(relativePath: string): Promise<PackageManifest> {
 	return (await Bun.file(path.join(repoRoot, relativePath, "package.json")).json()) as PackageManifest;
@@ -212,7 +218,7 @@ describe("portable CI test coverage", () => {
 		const [posixSkipStep, posixSkipIndex] = requireWorkflowStep(
 			steps,
 			"name",
-			"Verify POSIX-only session tests skip on Windows",
+			"Verify Linux-only session tests skip on Windows",
 		);
 		const [nativeBuildStep, nativeBuildIndex] = requireWorkflowStep(
 			steps,
@@ -238,6 +244,38 @@ describe("portable CI test coverage", () => {
 		expect(typeCheckIndex).toBeLessThan(portableContractsIndex);
 		expect(portableContractsIndex).toBeLessThan(posixSkipIndex);
 		expect(posixSkipIndex).toBeLessThan(nativeBuildIndex);
+	});
+	test("dev pull requests prove the Linux executed and Windows/macOS skipped policy on the exact head", async () => {
+		const jobs = await readDevWorkflowJobs();
+		const platformPolicy = requireYamlRecord(jobs["platform-policy"], "platform-policy job");
+		const strategy = requireYamlRecord(platformPolicy.strategy, "platform-policy strategy");
+		const matrix = requireYamlRecord(strategy.matrix, "platform-policy matrix");
+		const include = matrix.include;
+		expect(Array.isArray(include), "platform-policy include must be a YAML sequence").toBe(true);
+		if (!Array.isArray(include)) throw new Error("platform-policy include must be a YAML sequence");
+		expect(include).toEqual([
+			{ label: "Linux executes", os: "ubuntu-22.04", expectation: "--expect-executed" },
+			{ label: "Windows skips", os: "windows-latest", expectation: "--expect-skipped" },
+			{ label: "macOS skips", os: "macos-latest", expectation: "--expect-skipped" },
+		]);
+
+		const steps = platformPolicy.steps;
+		expect(Array.isArray(steps), "platform-policy steps must be a YAML sequence").toBe(true);
+		if (!Array.isArray(steps)) throw new Error("platform-policy steps must be a YAML sequence");
+		const [checkout] = steps;
+		expect(requireYamlRecord(requireYamlRecord(checkout, "platform checkout").with, "platform checkout inputs")).toMatchObject({
+			repository: "${{ github.event.pull_request.head.repo.full_name || github.repository }}",
+			ref: "${{ github.event.pull_request.head.sha || github.sha }}",
+		});
+		const [verify] = requireWorkflowStep(
+			steps,
+			"run",
+			"bun scripts/verify-platform-test-policy.ts ${{ matrix.expectation }} scripts/gjc-session/create.test.ts",
+		);
+		expect(verify.name).toBe("Verify ${{ matrix.label }} policy");
+
+		const aggregate = requireYamlRecord(jobs.affected, "affected aggregate job");
+		expect(aggregate.needs).toContain("platform-policy");
 	});
 
 	test("linux test executes the POSIX session integration before the full TypeScript suite", async () => {

--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -16,6 +16,31 @@ interface PackageManifest {
 }
 
 const repoRoot = path.join(import.meta.dir, "..");
+type YamlRecord = Record<string, unknown>;
+
+const relevanceGuard = "needs.relevance.outputs.relevant == 'true'";
+
+function isYamlRecord(value: unknown): value is YamlRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireYamlRecord(value: unknown, location: string): YamlRecord {
+	expect(isYamlRecord(value), `${location} must be a YAML mapping`).toBe(true);
+	if (!isYamlRecord(value)) throw new Error(`${location} must be a YAML mapping`);
+	return value;
+}
+
+function requireWorkflowStep(steps: unknown[], property: "name" | "run", value: string): [YamlRecord, number] {
+	const index = steps.findIndex((candidate) => isYamlRecord(candidate) && candidate[property] === value);
+	expect(index, `workflow step ${property}=${value} must exist`).toBeGreaterThanOrEqual(0);
+	return [requireYamlRecord(steps[index], `workflow step ${property}=${value}`), index];
+}
+
+async function readCiWorkflowJobs(): Promise<YamlRecord> {
+	const workflow = await Bun.file(path.join(repoRoot, ".github/workflows/ci.yml")).text();
+	const parsed: unknown = Bun.YAML.parse(workflow);
+	return requireYamlRecord(requireYamlRecord(parsed, "CI workflow").jobs, "CI workflow jobs");
+}
 
 async function readManifest(relativePath: string): Promise<PackageManifest> {
 	return (await Bun.file(path.join(repoRoot, relativePath, "package.json")).json()) as PackageManifest;
@@ -165,6 +190,75 @@ describe("release bump set equals publish set", () => {
 		// ship a 0.x tag whose npm version never advances. Any published dir that is
 		// private would be skipped at publish time. Both break one-release-truth.
 		expect([...publishDirs].sort()).toEqual([...bumpableDirs].sort());
+	});
+});
+
+describe("portable CI test coverage", () => {
+	test("windows smoke runs portable TypeScript gates before the native build", async () => {
+		const jobs = await readCiWorkflowJobs();
+		const windowsSmoke = requireYamlRecord(jobs.windows_smoke, "windows_smoke job");
+		const steps = windowsSmoke.steps;
+		expect(windowsSmoke["runs-on"]).toBe("windows-latest");
+		expect(Array.isArray(steps), "windows_smoke steps must be a YAML sequence").toBe(true);
+		if (!Array.isArray(steps)) throw new Error("windows_smoke steps must be a YAML sequence");
+
+		const [installStep, installIndex] = requireWorkflowStep(steps, "run", "bun install --frozen-lockfile");
+		const [typeCheckStep, typeCheckIndex] = requireWorkflowStep(steps, "name", "Type check workspace (Windows)");
+		const [portableContractsStep, portableContractsIndex] = requireWorkflowStep(
+			steps,
+			"name",
+			"Test portable CI contracts (Windows)",
+		);
+		const [posixSkipStep, posixSkipIndex] = requireWorkflowStep(
+			steps,
+			"name",
+			"Verify POSIX-only session tests skip on Windows",
+		);
+		const [nativeBuildStep, nativeBuildIndex] = requireWorkflowStep(
+			steps,
+			"name",
+			"Build native addon (win32-x64 baseline)",
+		);
+
+		expect(installStep.if).toBe(relevanceGuard);
+		expect(typeCheckStep).toMatchObject({
+			if: relevanceGuard,
+			run: "bun run ci:check:full",
+		});
+		expect(portableContractsStep).toMatchObject({
+			if: relevanceGuard,
+			run: "bun test scripts/ci-dev-affected.test.ts scripts/release-publish-order.test.ts scripts/verify-platform-test-policy.test.ts",
+		});
+		expect(posixSkipStep).toMatchObject({
+			if: relevanceGuard,
+			run: "bun scripts/verify-platform-test-policy.ts --expect-skipped scripts/gjc-session/create.test.ts",
+		});
+		expect(nativeBuildStep.if).toBe(relevanceGuard);
+		expect(installIndex).toBeLessThan(typeCheckIndex);
+		expect(typeCheckIndex).toBeLessThan(portableContractsIndex);
+		expect(portableContractsIndex).toBeLessThan(posixSkipIndex);
+		expect(posixSkipIndex).toBeLessThan(nativeBuildIndex);
+	});
+
+	test("linux test executes the POSIX session integration before the full TypeScript suite", async () => {
+		const jobs = await readCiWorkflowJobs();
+		const linuxTest = requireYamlRecord(jobs.test, "test job");
+		const steps = linuxTest.steps;
+		expect(Array.isArray(steps), "test steps must be a YAML sequence").toBe(true);
+		if (!Array.isArray(steps)) throw new Error("test steps must be a YAML sequence");
+
+		const [posixIntegrationStep, posixIntegrationIndex] = requireWorkflowStep(
+			steps,
+			"name",
+			"Test POSIX session integration (Linux)",
+		);
+		const [, fullTypeScriptTestIndex] = requireWorkflowStep(steps, "name", "Test workspace (TS)");
+
+		expect(posixIntegrationStep).toMatchObject({
+			if: relevanceGuard,
+			run: "bun scripts/verify-platform-test-policy.ts --expect-executed scripts/gjc-session/create.test.ts",
+		});
+		expect(posixIntegrationIndex).toBeLessThan(fullTypeScriptTestIndex);
 	});
 });
 

--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -200,7 +200,7 @@ describe("release bump set equals publish set", () => {
 });
 
 describe("portable CI test coverage", () => {
-	test("windows smoke runs portable TypeScript gates before the native build", async () => {
+	test("windows smoke builds native addon before portable TypeScript gates", async () => {
 		const jobs = await readCiWorkflowJobs();
 		const windowsSmoke = requireYamlRecord(jobs.windows_smoke, "windows_smoke job");
 		const steps = windowsSmoke.steps;
@@ -240,10 +240,10 @@ describe("portable CI test coverage", () => {
 			run: "bun scripts/verify-platform-test-policy.ts --expect-skipped scripts/gjc-session/create.test.ts",
 		});
 		expect(nativeBuildStep.if).toBe(relevanceGuard);
-		expect(installIndex).toBeLessThan(typeCheckIndex);
+		expect(installIndex).toBeLessThan(nativeBuildIndex);
+		expect(nativeBuildIndex).toBeLessThan(typeCheckIndex);
 		expect(typeCheckIndex).toBeLessThan(portableContractsIndex);
 		expect(portableContractsIndex).toBeLessThan(posixSkipIndex);
-		expect(posixSkipIndex).toBeLessThan(nativeBuildIndex);
 	});
 	test("dev pull requests prove the Linux executed and Windows/macOS skipped policy on the exact head", async () => {
 		const jobs = await readDevWorkflowJobs();

--- a/scripts/verify-platform-test-policy.test.ts
+++ b/scripts/verify-platform-test-policy.test.ts
@@ -10,6 +10,7 @@ import {
 const ROOT_COUNTS = 'tests="1" failures="0" skipped="0"';
 const SUITE_COUNTS = 'tests="1" failures="0" skipped="0"';
 const PASSING_TESTCASE = '<testcase name="case" classname="suite" file="suite.test.ts" line="1" />';
+const PASSING_TESTCASE_WITHOUT_LINE = '<testcase name="case" classname="suite" file="suite.test.ts" />';
 const SKIPPED_TESTCASE = '<testcase name="case" classname="suite" file="suite.test.ts" line="1"><skipped /></testcase>';
 
 function junitRoot(attributes: string, body: string): string {
@@ -33,6 +34,14 @@ describe("verify-platform-test-policy JUnit parsing", () => {
 		expect(skipped).toEqual({ tests: 1, failures: 0, errors: 0, skipped: 1 });
 		validatePlatformTestPolicy("executed", executed, 0);
 		validatePlatformTestPolicy("skipped", skipped, 0);
+	});
+	test("accepts valid Bun JUnit reports without testcase line attributes", () => {
+		expect(parseJunitCounts(junitReport(ROOT_COUNTS, SUITE_COUNTS, PASSING_TESTCASE_WITHOUT_LINE))).toEqual({
+			tests: 1,
+			failures: 0,
+			errors: 0,
+			skipped: 0,
+		});
 	});
 
 	test("reconciles nested Bun suites against their testcase descendants", () => {
@@ -182,18 +191,27 @@ describe("verify-platform-test-policy JUnit parsing", () => {
 		expect(() => validatePlatformTestPolicy("executed", counts, 0)).toThrow("1 errors");
 	});
 
-	test("rejects duplicate and incomplete testcase identities after entity decoding", () => {
+	test("rejects duplicate testcase identities and invalid present line attributes", () => {
 		const first = '<testcase name="case &#x41;" classname="suite" file="suite.test.ts" line="1" />';
 		const second = '<testcase name="case A" classname="suite" file="suite.test.ts" line="1" />';
 		expect(() => parseJunitCounts(junitReport('tests="2" failures="0" skipped="0"', 'tests="2" failures="0" skipped="0"', `${first}${second}`))).toThrow(
 			"duplicate testcase identities",
 		);
+		expect(() =>
+			parseJunitCounts(
+				junitReport('tests="2" failures="0" skipped="0"', 'tests="2" failures="0" skipped="0"', `${PASSING_TESTCASE_WITHOUT_LINE}${PASSING_TESTCASE_WITHOUT_LINE}`),
+			),
+		).toThrow("duplicate testcase identities");
 		expect(() => parseJunitCounts(junitReport(ROOT_COUNTS, SUITE_COUNTS, '<testcase name="case" line="1" />'))).toThrow(
 			"file and name attributes",
 		);
-		expect(() => parseJunitCounts(junitReport(ROOT_COUNTS, SUITE_COUNTS, '<testcase name="case" file="suite.test.ts" line="0" />'))).toThrow(
-			"positive safe-integer line",
-		);
+		for (const line of ["0", "01", "1.5", "9007199254740992"]) {
+			expect(() =>
+				parseJunitCounts(
+					junitReport(ROOT_COUNTS, SUITE_COUNTS, `<testcase name="case" file="suite.test.ts" line="${line}" />`),
+				),
+			).toThrow("positive safe-integer line");
+		}
 	});
 });
 

--- a/scripts/verify-platform-test-policy.test.ts
+++ b/scripts/verify-platform-test-policy.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+import {
+	combinePrimaryAndCleanupErrors,
+	parseJunitCounts,
+	parsePlatformTestPolicyArguments,
+	validatePlatformTestPolicy,
+	type ExpectedPlatformTestMode,
+} from "./verify-platform-test-policy";
+
+function junitRoot(attributes: string): string {
+	return `<?xml version="1.0"?><testsuites ${attributes}></testsuites>`;
+}
+
+describe("verify-platform-test-policy JUnit parsing", () => {
+	test("accepts valid executed and skipped root counts", () => {
+		const executed = parseJunitCounts(
+			'<?xml version="1.0"?><testsuites tests="3" failures="0" skipped="0"><testsuite name="suite"><testcase name="case" /></testsuite></testsuites>',
+		);
+		const skipped = parseJunitCounts(junitRoot('tests="3" failures="0" skipped="3"'));
+
+		expect(executed).toEqual({ tests: 3, failures: 0, skipped: 0 });
+		expect(skipped).toEqual({ tests: 3, failures: 0, skipped: 3 });
+		validatePlatformTestPolicy("executed", executed, 0);
+		validatePlatformTestPolicy("skipped", skipped, 0);
+	});
+
+	test("rejects malformed reports and missing required root attributes", () => {
+		expect(() => parseJunitCounts("<testsuite tests=\"1\" failures=\"0\" skipped=\"0\" />")).toThrow(
+			"<testsuites> root",
+		);
+		expect(() => parseJunitCounts(junitRoot('tests="1" failures="0"'))).toThrow("skipped attribute");
+	});
+
+	test("rejects non-numeric root counts", () => {
+		expect(() => parseJunitCounts(junitRoot('tests="one" failures="0" skipped="0"'))).toThrow("non-negative integer");
+	});
+	test("rejects malformed nested attributes and invalid entity references", () => {
+		const attributes = 'tests="1" failures="0" skipped="0"';
+		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite malformed=></testsuite></testsuites>`)).toThrow(
+			"malformed attributes",
+		);
+		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite name="a" name="b" /></testsuites>`)).toThrow(
+			"duplicate name attributes",
+		);
+		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite>bare & text</testsuite></testsuites>`)).toThrow(
+			"unterminated XML entity",
+		);
+		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite name="&unknown;" /></testsuites>`)).toThrow(
+			"invalid XML entity",
+		);
+		expect(() => parseJunitCounts(`<testsuites ${attributes}><!DOCTYPE suite></testsuites>`)).toThrow(
+			"unsupported XML declaration",
+		);
+	});
+
+	test("accepts escaped and numeric entities in JUnit content", () => {
+		const counts = parseJunitCounts(
+			'<?xml version="1.0"?><testsuites tests="1" failures="0" skipped="0"><testsuite name="suite &amp; &#65;"><testcase name="case &#x41;">escaped &lt;text&gt; &#65;<!--foo--><![CDATA[bare & < > <?xml]]><?report data?></testcase></testsuite></testsuites>',
+		);
+
+		expect(counts).toEqual({ tests: 1, failures: 0, skipped: 0 });
+	});
+	test("enforces XML S at parser grammar boundaries", () => {
+		const attributes = 'tests="1" failures="0" skipped="0"';
+
+		expect(() => parseJunitCounts(`<testsuites\u00a0${attributes}></testsuites>`)).toThrow("malformed attributes");
+		expect(() => parseJunitCounts(`<testsuites ${attributes}></ testsuites>`)).toThrow("close tag");
+		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite/ ></testsuites>`)).toThrow("malformed");
+		expect(() => parseJunitCounts(`<testsuites ${attributes}><? report?></testsuites>`)).toThrow(
+			"invalid XML processing instruction",
+		);
+
+		expect(
+			parseJunitCounts(
+				'<testsuites tests \t= \n"1" failures \r= "0" skipped =\t"0"><testsuite /><?report?></testsuites \n>',
+			),
+		).toEqual({ tests: 1, failures: 0, skipped: 0 });
+	});
+	test("rejects malformed XML comments and forbidden text terminators", () => {
+		const attributes = 'tests="1" failures="0" skipped="0"';
+		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite><!--foo---></testsuite></testsuites>`)).toThrow(
+			"malformed XML comment",
+		);
+		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite><!--foo--bar--></testsuite></testsuites>`)).toThrow(
+			"malformed XML comment",
+		);
+		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite>text ]]></testsuite></testsuites>`)).toThrow(
+			"forbidden ]]> sequence",
+		);
+	});
+
+	test("rejects illegal XML 1.0 numeric references and raw characters", () => {
+		const attributes = 'tests="1" failures="0" skipped="0"';
+		for (const entity of ["&#1;", "&#x1;", "&#xD800;", "&#xFFFE;", "&#xFFFF;"]) {
+			expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite>${entity}</testsuite></testsuites>`)).toThrow(
+				"invalid XML entity",
+			);
+		}
+		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite>\u0001</testsuite></testsuites>`)).toThrow(
+			"illegal XML 1.0 character",
+		);
+		expect(() => parseJunitCounts(`<testsuites ${attributes} name="\uD800"></testsuites>`)).toThrow(
+			"illegal XML 1.0 character",
+		);
+	});
+
+	test("accepts XML 1.0 numeric character boundaries", () => {
+		const counts = parseJunitCounts(
+			'<testsuites tests="1" failures="0" skipped="0"><testsuite name="&#x9;&#xA;&#xD;&#x20;&#xD7FF;&#xE000;&#xFFFD;&#x10000;&#x10FFFF;" /></testsuites>',
+		);
+
+		expect(counts).toEqual({ tests: 1, failures: 0, skipped: 0 });
+	});
+
+	test("validates the XML declaration at the exact document start", () => {
+		const attributes = 'tests="1" failures="0" skipped="0"';
+		expect(parseJunitCounts(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?> \n<testsuites ${attributes}></testsuites>`)).toEqual({
+			tests: 1,
+			failures: 0,
+			skipped: 0,
+		});
+		expect(parseJunitCounts(` \t\n<testsuites ${attributes}></testsuites>`)).toEqual({ tests: 1, failures: 0, skipped: 0 });
+		expect(() => parseJunitCounts(`<?xml bogus?><testsuites ${attributes}></testsuites>`)).toThrow(
+			"malformed XML declaration",
+		);
+		for (const prefix of [" \n", "content"]) {
+			expect(() => parseJunitCounts(`${prefix}<?xml version="1.0"?><testsuites ${attributes}></testsuites>`)).toThrow(
+				"XML declaration must begin at the start",
+			);
+		}
+	});
+	test("rejects incomplete, mismatched, trailing, and spliced root documents", () => {
+		const attributes = 'tests="1" failures="0" skipped="0"';
+		expect(() => parseJunitCounts(`<testsuites ${attributes}>`)).toThrow("incomplete XML document");
+		expect(() => parseJunitCounts(`<testsuites ${attributes}></testsuite>`)).toThrow("expected </testsuites>");
+		expect(() => parseJunitCounts(`<testsuites ${attributes}></testsuites>trailing`)).toThrow(
+			"exactly one complete",
+		);
+		expect(() => parseJunitCounts(`<testsuites ${attributes}></testsuites><testsuites ${attributes}></testsuites>`)).toThrow(
+			"exactly one complete",
+		);
+		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuites ${attributes}></testsuites></testsuites>`)).toThrow(
+			"exactly one <testsuites>",
+		);
+	});
+});
+
+describe("verify-platform-test-policy cleanup errors", () => {
+	test("preserves primary and cleanup diagnostics", () => {
+		const combined = combinePrimaryAndCleanupErrors(new Error("primary failure"), new Error("cleanup failure"));
+
+		expect(combined?.message).toContain("primary failure");
+		expect(combined?.message).toContain("Cleanup failed: cleanup failure");
+	});
+
+	test("reports cleanup failure after otherwise successful verification", () => {
+		expect(combinePrimaryAndCleanupErrors(undefined, new Error("cleanup failure"))?.message).toBe(
+			"Cleanup failed: cleanup failure",
+		);
+	});
+});
+describe("verify-platform-test-policy validation", () => {
+	test("rejects child failures and nonzero test exits", () => {
+		expect(() => validatePlatformTestPolicy("executed", { tests: 1, failures: 1, skipped: 0 }, 0)).toThrow("1 failures");
+		expect(() => validatePlatformTestPolicy("executed", { tests: 1, failures: 0, skipped: 0 }, 1)).toThrow(
+			"code 1",
+		);
+	});
+
+	test("rejects zero executed tests", () => {
+		expect(() => validatePlatformTestPolicy("executed", { tests: 0, failures: 0, skipped: 0 }, 0)).toThrow("zero tests");
+	});
+
+	test("rejects mixed skipped counts", () => {
+		expect(() => validatePlatformTestPolicy("skipped", { tests: 2, failures: 0, skipped: 1 }, 0)).toThrow(
+			"every test to be skipped",
+		);
+		expect(() => validatePlatformTestPolicy("executed", { tests: 2, failures: 0, skipped: 1 }, 0)).toThrow(
+			"no skipped tests",
+		);
+	});
+
+	test("rejects invalid mode boundaries", () => {
+		expect(() =>
+			validatePlatformTestPolicy("unsupported" as ExpectedPlatformTestMode, { tests: 1, failures: 0, skipped: 0 }, 0),
+		).toThrow("Unknown expected platform test mode");
+	});
+});
+
+describe("verify-platform-test-policy CLI arguments", () => {
+	test("accepts exactly one expectation flag and one test file", () => {
+		expect(parsePlatformTestPolicyArguments(["--expect-skipped", "scripts/gjc-session/create.test.ts"])).toEqual({
+			mode: "skipped",
+			testFile: "scripts/gjc-session/create.test.ts",
+		});
+		expect(parsePlatformTestPolicyArguments(["--expect-executed", "scripts/gjc-session/create.test.ts"])).toEqual({
+			mode: "executed",
+			testFile: "scripts/gjc-session/create.test.ts",
+		});
+	});
+
+	test("rejects invalid flags, missing files, and extra arguments", () => {
+		expect(() => parsePlatformTestPolicyArguments(["--expect-other", "test.ts"])).toThrow("Unknown expectation");
+		expect(() => parsePlatformTestPolicyArguments(["--expect-skipped"])).toThrow("Usage:");
+		expect(() => parsePlatformTestPolicyArguments(["--expect-executed", "test.ts", "extra"])).toThrow("Usage:");
+	});
+});

--- a/scripts/verify-platform-test-policy.test.ts
+++ b/scripts/verify-platform-test-policy.test.ts
@@ -7,140 +7,192 @@ import {
 	type ExpectedPlatformTestMode,
 } from "./verify-platform-test-policy";
 
-function junitRoot(attributes: string): string {
-	return `<?xml version="1.0"?><testsuites ${attributes}></testsuites>`;
+const ROOT_COUNTS = 'tests="1" failures="0" skipped="0"';
+const SUITE_COUNTS = 'tests="1" failures="0" skipped="0"';
+const PASSING_TESTCASE = '<testcase name="case" classname="suite" file="suite.test.ts" line="1" />';
+const SKIPPED_TESTCASE = '<testcase name="case" classname="suite" file="suite.test.ts" line="1"><skipped /></testcase>';
+
+function junitRoot(attributes: string, body: string): string {
+	return `<?xml version="1.0"?><testsuites ${attributes}>${body}</testsuites>`;
+}
+
+function junitSuite(attributes: string, body: string): string {
+	return `<testsuite name="suite" file="suite.test.ts" ${attributes}>${body}</testsuite>`;
+}
+
+function junitReport(rootAttributes = ROOT_COUNTS, suiteAttributes = SUITE_COUNTS, body = PASSING_TESTCASE): string {
+	return junitRoot(rootAttributes, junitSuite(suiteAttributes, body));
 }
 
 describe("verify-platform-test-policy JUnit parsing", () => {
-	test("accepts valid executed and skipped root counts", () => {
-		const executed = parseJunitCounts(
-			'<?xml version="1.0"?><testsuites tests="3" failures="0" skipped="0"><testsuite name="suite"><testcase name="case" /></testsuite></testsuites>',
-		);
-		const skipped = parseJunitCounts(junitRoot('tests="3" failures="0" skipped="3"'));
+	test("accepts valid Bun JUnit reports for executed and fully skipped suites", () => {
+		const executed = parseJunitCounts(junitReport());
+		const skipped = parseJunitCounts(junitReport('tests="1" failures="0" skipped="1"', 'tests="1" failures="0" skipped="1"', SKIPPED_TESTCASE));
 
-		expect(executed).toEqual({ tests: 3, failures: 0, skipped: 0 });
-		expect(skipped).toEqual({ tests: 3, failures: 0, skipped: 3 });
+		expect(executed).toEqual({ tests: 1, failures: 0, errors: 0, skipped: 0 });
+		expect(skipped).toEqual({ tests: 1, failures: 0, errors: 0, skipped: 1 });
 		validatePlatformTestPolicy("executed", executed, 0);
 		validatePlatformTestPolicy("skipped", skipped, 0);
 	});
 
-	test("rejects malformed reports and missing required root attributes", () => {
-		expect(() => parseJunitCounts("<testsuite tests=\"1\" failures=\"0\" skipped=\"0\" />")).toThrow(
-			"<testsuites> root",
+	test("reconciles nested Bun suites against their testcase descendants", () => {
+		const testcase = '<testcase name="nested case" classname="inner > outer" file="suite.test.ts" line="2" />';
+		const report = junitRoot(
+			'tests="2" failures="0" skipped="0"',
+			`<testsuite name="outer" file="suite.test.ts" tests="2" failures="0" skipped="0">
+				<testsuite name="inner" file="suite.test.ts" line="1" tests="1" failures="0" skipped="0">${testcase}</testsuite>
+				<testcase name="outer case" classname="outer" file="suite.test.ts" line="3" />
+			</testsuite>`,
 		);
-		expect(() => parseJunitCounts(junitRoot('tests="1" failures="0"'))).toThrow("skipped attribute");
+
+		expect(parseJunitCounts(report)).toEqual({ tests: 2, failures: 0, errors: 0, skipped: 0 });
+	});
+
+	test("rejects malformed reports and missing required root attributes", () => {
+		expect(() => parseJunitCounts('<testsuite tests="1" failures="0" skipped="0" />')).toThrow("<testsuites> root");
+		expect(() => parseJunitCounts(junitRoot('tests="1" failures="0"', ""))).toThrow("skipped attribute");
 	});
 
 	test("rejects non-numeric root counts", () => {
-		expect(() => parseJunitCounts(junitRoot('tests="one" failures="0" skipped="0"'))).toThrow("non-negative integer");
+		expect(() => parseJunitCounts(junitRoot('tests="one" failures="0" skipped="0"', ""))).toThrow("non-negative integer");
 	});
+
 	test("rejects malformed nested attributes and invalid entity references", () => {
 		const attributes = 'tests="1" failures="0" skipped="0"';
-		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite malformed=></testsuite></testsuites>`)).toThrow(
-			"malformed attributes",
-		);
-		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite name="a" name="b" /></testsuites>`)).toThrow(
-			"duplicate name attributes",
-		);
-		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite>bare & text</testsuite></testsuites>`)).toThrow(
+		expect(() => parseJunitCounts(junitRoot(attributes, '<testsuite malformed=></testsuite>'))).toThrow("malformed attributes");
+		expect(() => parseJunitCounts(junitRoot(attributes, '<testsuite name="a" name="b" />'))).toThrow("duplicate name attributes");
+		expect(() => parseJunitCounts(junitRoot(attributes, `${junitSuite(attributes, "bare & text")}`))).toThrow(
 			"unterminated XML entity",
 		);
-		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite name="&unknown;" /></testsuites>`)).toThrow(
+		expect(() => parseJunitCounts(junitRoot(`${attributes} name="&unknown;"`, junitSuite(attributes, PASSING_TESTCASE)))).toThrow(
 			"invalid XML entity",
 		);
-		expect(() => parseJunitCounts(`<testsuites ${attributes}><!DOCTYPE suite></testsuites>`)).toThrow(
-			"unsupported XML declaration",
-		);
+		expect(() => parseJunitCounts(junitRoot(attributes, "<!DOCTYPE suite>"))).toThrow("unsupported XML declaration");
 	});
 
-	test("accepts escaped and numeric entities in JUnit content", () => {
-		const counts = parseJunitCounts(
-			'<?xml version="1.0"?><testsuites tests="1" failures="0" skipped="0"><testsuite name="suite &amp; &#65;"><testcase name="case &#x41;">escaped &lt;text&gt; &#65;<!--foo--><![CDATA[bare & < > <?xml]]><?report data?></testcase></testsuite></testsuites>',
+	test("accepts escaped and numeric entities in valid Bun JUnit content", () => {
+		const report = junitRoot(
+			ROOT_COUNTS,
+			`<testsuite name="suite &amp; &#65;" file="suite.test.ts" ${SUITE_COUNTS}><testcase name="case &#x41;" classname="suite &amp; &#65;" file="suite.test.ts" line="1">escaped &lt;text&gt; &#65;<!--foo--><![CDATA[bare & < > <?xml]]><?report data?></testcase></testsuite>`,
 		);
 
-		expect(counts).toEqual({ tests: 1, failures: 0, skipped: 0 });
+		expect(parseJunitCounts(report)).toEqual({ tests: 1, failures: 0, errors: 0, skipped: 0 });
 	});
+
 	test("enforces XML S at parser grammar boundaries", () => {
-		const attributes = 'tests="1" failures="0" skipped="0"';
+		const attributes = ROOT_COUNTS;
 
 		expect(() => parseJunitCounts(`<testsuites\u00a0${attributes}></testsuites>`)).toThrow("malformed attributes");
-		expect(() => parseJunitCounts(`<testsuites ${attributes}></ testsuites>`)).toThrow("close tag");
-		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite/ ></testsuites>`)).toThrow("malformed");
-		expect(() => parseJunitCounts(`<testsuites ${attributes}><? report?></testsuites>`)).toThrow(
-			"invalid XML processing instruction",
+		expect(() => parseJunitCounts(junitRoot(attributes, `${junitSuite(SUITE_COUNTS, PASSING_TESTCASE)}</ testsuites>`))).toThrow(
+			"close tag",
 		);
+		expect(() => parseJunitCounts(junitRoot(attributes, "<testsuite/ >"))).toThrow("malformed");
+		expect(() => parseJunitCounts(junitRoot(attributes, "<? report?>"))).toThrow("invalid XML processing instruction");
 
 		expect(
-			parseJunitCounts(
-				'<testsuites tests \t= \n"1" failures \r= "0" skipped =\t"0"><testsuite /><?report?></testsuites \n>',
-			),
-		).toEqual({ tests: 1, failures: 0, skipped: 0 });
+		parseJunitCounts(
+			'<testsuites tests \t= \n"1" failures \r= "0" skipped =\t"0"><testsuite name="suite" file="suite.test.ts" tests="1" failures="0" skipped="0"><testcase name="case" classname="suite" file="suite.test.ts" line="1" /></testsuite><?report?></testsuites \n>',
+		),
+	).toEqual({ tests: 1, failures: 0, errors: 0, skipped: 0 });
 	});
+
 	test("rejects malformed XML comments and forbidden text terminators", () => {
-		const attributes = 'tests="1" failures="0" skipped="0"';
-		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite><!--foo---></testsuite></testsuites>`)).toThrow(
-			"malformed XML comment",
-		);
-		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite><!--foo--bar--></testsuite></testsuites>`)).toThrow(
-			"malformed XML comment",
-		);
-		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite>text ]]></testsuite></testsuites>`)).toThrow(
-			"forbidden ]]> sequence",
-		);
+		expect(() => parseJunitCounts(junitReport(ROOT_COUNTS, SUITE_COUNTS, "<!--foo--->"))).toThrow("malformed XML comment");
+		expect(() => parseJunitCounts(junitReport(ROOT_COUNTS, SUITE_COUNTS, "<!--foo--bar-->"))).toThrow("malformed XML comment");
+		expect(() => parseJunitCounts(junitReport(ROOT_COUNTS, SUITE_COUNTS, "text ]]>"))).toThrow("forbidden ]]> sequence");
 	});
 
 	test("rejects illegal XML 1.0 numeric references and raw characters", () => {
-		const attributes = 'tests="1" failures="0" skipped="0"';
 		for (const entity of ["&#1;", "&#x1;", "&#xD800;", "&#xFFFE;", "&#xFFFF;"]) {
-			expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite>${entity}</testsuite></testsuites>`)).toThrow(
+			expect(() => parseJunitCounts(junitReport(ROOT_COUNTS, SUITE_COUNTS, `${entity}${PASSING_TESTCASE}`))).toThrow(
 				"invalid XML entity",
 			);
 		}
-		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuite>\u0001</testsuite></testsuites>`)).toThrow(
+		expect(() => parseJunitCounts(junitReport(ROOT_COUNTS, SUITE_COUNTS, `\u0001${PASSING_TESTCASE}`))).toThrow(
 			"illegal XML 1.0 character",
 		);
-		expect(() => parseJunitCounts(`<testsuites ${attributes} name="\uD800"></testsuites>`)).toThrow(
+		expect(() => parseJunitCounts(junitRoot(`${ROOT_COUNTS} name="\uD800"`, junitSuite(SUITE_COUNTS, PASSING_TESTCASE)))).toThrow(
 			"illegal XML 1.0 character",
 		);
 	});
 
 	test("accepts XML 1.0 numeric character boundaries", () => {
-		const counts = parseJunitCounts(
-			'<testsuites tests="1" failures="0" skipped="0"><testsuite name="&#x9;&#xA;&#xD;&#x20;&#xD7FF;&#xE000;&#xFFFD;&#x10000;&#x10FFFF;" /></testsuites>',
+		const report = junitRoot(
+			ROOT_COUNTS,
+			`<testsuite name="&#x9;&#xA;&#xD;&#x20;&#xD7FF;&#xE000;&#xFFFD;&#x10000;&#x10FFFF;" file="suite.test.ts" ${SUITE_COUNTS}>${PASSING_TESTCASE}</testsuite>`,
 		);
 
-		expect(counts).toEqual({ tests: 1, failures: 0, skipped: 0 });
+		expect(parseJunitCounts(report)).toEqual({ tests: 1, failures: 0, errors: 0, skipped: 0 });
 	});
 
 	test("validates the XML declaration at the exact document start", () => {
-		const attributes = 'tests="1" failures="0" skipped="0"';
-		expect(parseJunitCounts(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?> \n<testsuites ${attributes}></testsuites>`)).toEqual({
+		const report = junitReport();
+		expect(parseJunitCounts(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?> \n${report.slice(report.indexOf("<testsuites"))}`)).toEqual({
 			tests: 1,
 			failures: 0,
+			errors: 0,
 			skipped: 0,
 		});
-		expect(parseJunitCounts(` \t\n<testsuites ${attributes}></testsuites>`)).toEqual({ tests: 1, failures: 0, skipped: 0 });
-		expect(() => parseJunitCounts(`<?xml bogus?><testsuites ${attributes}></testsuites>`)).toThrow(
-			"malformed XML declaration",
-		);
+		expect(parseJunitCounts(` \t\n${report.slice(report.indexOf("<testsuites"))}`)).toEqual({ tests: 1, failures: 0, errors: 0, skipped: 0 });
+		expect(() => parseJunitCounts(`<?xml bogus?>${report.slice(report.indexOf("<testsuites"))}`)).toThrow("malformed XML declaration");
 		for (const prefix of [" \n", "content"]) {
-			expect(() => parseJunitCounts(`${prefix}<?xml version="1.0"?><testsuites ${attributes}></testsuites>`)).toThrow(
+			expect(() => parseJunitCounts(`${prefix}<?xml version="1.0"?>${report.slice(report.indexOf("<testsuites"))}`)).toThrow(
 				"XML declaration must begin at the start",
 			);
 		}
 	});
+
 	test("rejects incomplete, mismatched, trailing, and spliced root documents", () => {
-		const attributes = 'tests="1" failures="0" skipped="0"';
-		expect(() => parseJunitCounts(`<testsuites ${attributes}>`)).toThrow("incomplete XML document");
-		expect(() => parseJunitCounts(`<testsuites ${attributes}></testsuite>`)).toThrow("expected </testsuites>");
-		expect(() => parseJunitCounts(`<testsuites ${attributes}></testsuites>trailing`)).toThrow(
-			"exactly one complete",
-		);
-		expect(() => parseJunitCounts(`<testsuites ${attributes}></testsuites><testsuites ${attributes}></testsuites>`)).toThrow(
-			"exactly one complete",
-		);
-		expect(() => parseJunitCounts(`<testsuites ${attributes}><testsuites ${attributes}></testsuites></testsuites>`)).toThrow(
+		expect(() => parseJunitCounts(`<testsuites ${ROOT_COUNTS}>`)).toThrow("incomplete XML document");
+		expect(() =>
+			parseJunitCounts(
+				`<testsuites ${ROOT_COUNTS}><testsuite name="suite" file="suite.test.ts" ${SUITE_COUNTS}><testcase name="case" file="suite.test.ts" line="1">`,
+			),
+		).toThrow("incomplete XML document");
+		expect(() => parseJunitCounts(`<testsuites ${ROOT_COUNTS}></testsuite>`)).toThrow("expected </testsuites>");
+		expect(() => parseJunitCounts(`${junitReport()}trailing`)).toThrow("exactly one complete");
+		expect(() => parseJunitCounts(`${junitReport()}${junitReport()}`)).toThrow("exactly one complete");
+		expect(() => parseJunitCounts(junitRoot(ROOT_COUNTS, `<testsuites ${ROOT_COUNTS}></testsuites>`))).toThrow(
 			"exactly one <testsuites>",
+		);
+	});
+
+	test("rejects count-only and empty-body reports", () => {
+		expect(() => parseJunitCounts(junitRoot(ROOT_COUNTS, ""))).toThrow("at least one testcase");
+		expect(() => parseJunitCounts(junitReport(ROOT_COUNTS, SUITE_COUNTS, ""))).toThrow("at least one testcase");
+	});
+
+	test("rejects root and nested suite reconciliation mismatches", () => {
+		expect(() => parseJunitCounts(junitReport('tests="999" failures="0" skipped="0"'))).toThrow("<testsuites> count mismatch for tests");
+		expect(() => parseJunitCounts(junitReport(ROOT_COUNTS, 'tests="999" failures="0" skipped="0"'))).toThrow(
+			"<testsuite> count mismatch for tests",
+		);
+		expect(() => parseJunitCounts(junitReport('tests="1" failures="1" skipped="0"'))).toThrow("count mismatch for failures");
+		expect(() => parseJunitCounts(junitReport('tests="1" failures="0" skipped="1"'))).toThrow("count mismatch for skipped");
+	});
+
+	test("rejects nested errors whether omitted or explicitly reported by counts", () => {
+		const errored = '<testcase name="case" classname="suite" file="suite.test.ts" line="1"><error type="Error" /></testcase>';
+		expect(() => parseJunitCounts(junitReport(ROOT_COUNTS, SUITE_COUNTS, errored))).toThrow("count mismatch for errors");
+
+		const counts = parseJunitCounts(
+			junitReport('tests="1" failures="0" errors="1" skipped="0"', 'tests="1" failures="0" errors="1" skipped="0"', errored),
+		);
+		expect(counts).toEqual({ tests: 1, failures: 0, errors: 1, skipped: 0 });
+		expect(() => validatePlatformTestPolicy("executed", counts, 0)).toThrow("1 errors");
+	});
+
+	test("rejects duplicate and incomplete testcase identities after entity decoding", () => {
+		const first = '<testcase name="case &#x41;" classname="suite" file="suite.test.ts" line="1" />';
+		const second = '<testcase name="case A" classname="suite" file="suite.test.ts" line="1" />';
+		expect(() => parseJunitCounts(junitReport('tests="2" failures="0" skipped="0"', 'tests="2" failures="0" skipped="0"', `${first}${second}`))).toThrow(
+			"duplicate testcase identities",
+		);
+		expect(() => parseJunitCounts(junitReport(ROOT_COUNTS, SUITE_COUNTS, '<testcase name="case" line="1" />'))).toThrow(
+			"file and name attributes",
+		);
+		expect(() => parseJunitCounts(junitReport(ROOT_COUNTS, SUITE_COUNTS, '<testcase name="case" file="suite.test.ts" line="0" />'))).toThrow(
+			"positive safe-integer line",
 		);
 	});
 });
@@ -159,31 +211,33 @@ describe("verify-platform-test-policy cleanup errors", () => {
 		);
 	});
 });
+
 describe("verify-platform-test-policy validation", () => {
-	test("rejects child failures and nonzero test exits", () => {
-		expect(() => validatePlatformTestPolicy("executed", { tests: 1, failures: 1, skipped: 0 }, 0)).toThrow("1 failures");
-		expect(() => validatePlatformTestPolicy("executed", { tests: 1, failures: 0, skipped: 0 }, 1)).toThrow(
+	test("rejects child failures, errors, and nonzero test exits", () => {
+		expect(() => validatePlatformTestPolicy("executed", { tests: 1, failures: 1, errors: 0, skipped: 0 }, 0)).toThrow("1 failures");
+		expect(() => validatePlatformTestPolicy("executed", { tests: 1, failures: 0, errors: 1, skipped: 0 }, 0)).toThrow("1 errors");
+		expect(() => validatePlatformTestPolicy("executed", { tests: 1, failures: 0, errors: 0, skipped: 0 }, 1)).toThrow(
 			"code 1",
 		);
 	});
 
 	test("rejects zero executed tests", () => {
-		expect(() => validatePlatformTestPolicy("executed", { tests: 0, failures: 0, skipped: 0 }, 0)).toThrow("zero tests");
+		expect(() => validatePlatformTestPolicy("executed", { tests: 0, failures: 0, errors: 0, skipped: 0 }, 0)).toThrow("zero tests");
 	});
 
-	test("rejects mixed skipped counts", () => {
-		expect(() => validatePlatformTestPolicy("skipped", { tests: 2, failures: 0, skipped: 1 }, 0)).toThrow(
+	test("distinguishes exact whole-suite skips from executed zero-skip suites", () => {
+		expect(() => validatePlatformTestPolicy("skipped", { tests: 2, failures: 0, errors: 0, skipped: 1 }, 0)).toThrow(
 			"every test to be skipped",
 		);
-		expect(() => validatePlatformTestPolicy("executed", { tests: 2, failures: 0, skipped: 1 }, 0)).toThrow(
+		expect(() => validatePlatformTestPolicy("executed", { tests: 2, failures: 0, errors: 0, skipped: 1 }, 0)).toThrow(
 			"no skipped tests",
 		);
 	});
 
 	test("rejects invalid mode boundaries", () => {
 		expect(() =>
-			validatePlatformTestPolicy("unsupported" as ExpectedPlatformTestMode, { tests: 1, failures: 0, skipped: 0 }, 0),
-		).toThrow("Unknown expected platform test mode");
+		validatePlatformTestPolicy("unsupported" as ExpectedPlatformTestMode, { tests: 1, failures: 0, errors: 0, skipped: 0 }, 0),
+	).toThrow("Unknown expected platform test mode");
 	});
 });
 

--- a/scripts/verify-platform-test-policy.ts
+++ b/scripts/verify-platform-test-policy.ts
@@ -1,0 +1,450 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export type ExpectedPlatformTestMode = "skipped" | "executed";
+
+export interface JunitCounts {
+	tests: number;
+	failures: number;
+	skipped: number;
+}
+
+export interface PlatformTestPolicyArguments {
+	mode: ExpectedPlatformTestMode;
+	testFile: string;
+}
+
+interface TestExecution {
+	exitCode: number;
+	stderr: string;
+	stdout: string;
+}
+
+const XML_NAME_PATTERN = /^[A-Za-z_:][A-Za-z0-9_:.-]*/;
+const XML_WHITESPACE_PATTERN = /^[\x20\x09\x0a\x0d]*/;
+const XML_DECLARATION_PATTERN =
+	/^<\?xml[ \t\r\n]+version=(["'])1\.0\1(?:[ \t\r\n]+encoding=(["'])[A-Za-z][A-Za-z0-9._-]*\2)?(?:[ \t\r\n]+standalone=(["'])(?:yes|no)\3)?[ \t\r\n]*\?>[ \t\r\n]*/;
+const JUNIT_COUNT_ATTRIBUTES = ["tests", "failures", "skipped"] as const;
+
+function formatChildOutput(execution: TestExecution): string {
+	return [
+		"Child stdout:",
+		execution.stdout || "(empty)",
+		"Child stderr:",
+		execution.stderr || "(empty)",
+	].join("\n");
+}
+export function combinePrimaryAndCleanupErrors(
+	primaryError: Error | undefined,
+	cleanupError: Error | undefined,
+): Error | undefined {
+	if (primaryError && cleanupError) {
+		return new Error(`${primaryError.message}\nCleanup failed: ${cleanupError.message}`);
+	}
+	if (cleanupError) {
+		return new Error(`Cleanup failed: ${cleanupError.message}`);
+	}
+	return primaryError;
+}
+
+function toError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}
+function isLegalXmlCharacter(codePoint: number): boolean {
+	return (
+		codePoint === 0x9 ||
+		codePoint === 0xa ||
+		codePoint === 0xd ||
+		(codePoint >= 0x20 && codePoint <= 0xd7ff) ||
+		(codePoint >= 0xe000 && codePoint <= 0xfffd) ||
+		(codePoint >= 0x10000 && codePoint <= 0x10ffff)
+	);
+}
+function isXmlWhitespace(character: string | undefined): boolean {
+	return character === "\x20" || character === "\x09" || character === "\x0a" || character === "\x0d";
+}
+
+function isOnlyXmlWhitespace(value: string): boolean {
+	for (const character of value) {
+		if (!isXmlWhitespace(character)) return false;
+	}
+	return true;
+}
+
+
+function validateXmlCharacters(value: string, context: string): void {
+	for (let index = 0; index < value.length; ) {
+		const codePoint = value.codePointAt(index);
+		if (codePoint === undefined || !isLegalXmlCharacter(codePoint)) {
+			throw new Error(`JUnit ${context} contains an illegal XML 1.0 character.`);
+		}
+		index += codePoint > 0xffff ? 2 : 1;
+	}
+}
+
+function validateXmlText(value: string): void {
+	if (value.includes("]]>")) {
+		throw new Error("JUnit XML text contains the forbidden ]]> sequence.");
+	}
+	validateXmlCharacters(value, "XML text");
+	validateXmlEntities(value, "XML text");
+}
+
+function findXmlRootStart(report: string): number {
+	const declarationStart = report.indexOf("<?xml");
+	if (declarationStart === 0) {
+		const declaration = report.match(XML_DECLARATION_PATTERN);
+		if (!declaration) {
+			throw new Error("JUnit report contains a malformed XML declaration.");
+		}
+		return declaration[0].length;
+	}
+	const rootStart = report.indexOf("<testsuites");
+	if (declarationStart !== -1 && (rootStart === -1 || declarationStart < rootStart)) {
+		throw new Error("JUnit XML declaration must begin at the start of the document.");
+	}
+	return report.match(XML_WHITESPACE_PATTERN)?.[0].length ?? 0;
+}
+
+function validateXmlEntities(value: string, context: string): void {
+	let cursor = 0;
+	while (cursor < value.length) {
+		const entityStart = value.indexOf("&", cursor);
+		if (entityStart === -1) return;
+
+		const entityEnd = value.indexOf(";", entityStart + 1);
+		if (entityEnd === -1) {
+			throw new Error(`JUnit ${context} contains an unterminated XML entity reference.`);
+		}
+
+		const entity = value.slice(entityStart + 1, entityEnd);
+		if (/^(?:amp|apos|gt|lt|quot)$/.test(entity)) {
+			cursor = entityEnd + 1;
+			continue;
+		}
+
+		const numeric = entity.match(/^#(?:(\d+)|x([0-9A-Fa-f]+))$/);
+		if (numeric) {
+			const codePoint = Number.parseInt(numeric[1] ?? numeric[2] ?? "", numeric[1] ? 10 : 16);
+			if (Number.isSafeInteger(codePoint) && isLegalXmlCharacter(codePoint)) {
+				cursor = entityEnd + 1;
+				continue;
+			}
+		}
+
+		throw new Error(`JUnit ${context} contains an invalid XML entity reference.`);
+	}
+}
+
+function parseXmlAttributes(attributes: string, elementName: string): Map<string, string> {
+	const values = new Map<string, string>();
+	let cursor = 0;
+
+	while (cursor < attributes.length) {
+		if (!isXmlWhitespace(attributes[cursor])) {
+			throw new Error(`JUnit <${elementName}> has malformed attributes.`);
+		}
+		while (isXmlWhitespace(attributes[cursor])) cursor += 1;
+		if (cursor === attributes.length) break;
+
+		const name = attributes.slice(cursor).match(XML_NAME_PATTERN)?.[0];
+		if (!name) {
+			throw new Error(`JUnit <${elementName}> has malformed attributes.`);
+		}
+		cursor += name.length;
+		while (isXmlWhitespace(attributes[cursor])) cursor += 1;
+		if (attributes[cursor] !== "=") {
+			throw new Error(`JUnit <${elementName}> has malformed attributes.`);
+		}
+		cursor += 1;
+		while (isXmlWhitespace(attributes[cursor])) cursor += 1;
+
+		const quote = attributes[cursor];
+		if (quote !== '"' && quote !== "'") {
+			throw new Error(`JUnit <${elementName}> has malformed attributes.`);
+		}
+		const valueStart = cursor + 1;
+		const valueEnd = attributes.indexOf(quote, valueStart);
+		if (valueEnd === -1) {
+			throw new Error(`JUnit <${elementName}> has malformed attributes.`);
+		}
+		const value = attributes.slice(valueStart, valueEnd);
+		validateXmlCharacters(value, `<${elementName}> attribute ${name}`);
+		if (value.includes("<")) {
+			throw new Error(`JUnit <${elementName}> has malformed attributes.`);
+		}
+		validateXmlEntities(value, `<${elementName}> attribute ${name}`);
+		if (values.has(name)) {
+			throw new Error(`JUnit <${elementName}> contains duplicate ${name} attributes.`);
+		}
+		values.set(name, value);
+		cursor = valueEnd + 1;
+	}
+
+	return values;
+}
+
+function parseCountAttributes(attributes: string): Map<string, string> {
+	return parseXmlAttributes(attributes, "testsuites");
+}
+
+function parseCountAttribute(attributes: Map<string, string>, name: (typeof JUNIT_COUNT_ATTRIBUTES)[number]): number {
+	const value = attributes.get(name);
+	if (value === undefined) {
+		throw new Error(`JUnit <testsuites> root must contain exactly one ${name} attribute.`);
+	}
+	if (!/^\d+$/.test(value)) {
+		throw new Error(`JUnit <testsuites> ${name} attribute must be a non-negative integer, received ${JSON.stringify(value)}.`);
+	}
+
+	const count = Number(value);
+	if (!Number.isSafeInteger(count)) {
+		throw new Error(`JUnit <testsuites> ${name} attribute must be a safe integer, received ${JSON.stringify(value)}.`);
+	}
+	return count;
+}
+
+function findXmlTagEnd(report: string, start: number): number {
+	let quote: string | undefined;
+	for (let index = start + 1; index < report.length; index += 1) {
+		const character = report[index];
+		if (character === undefined) continue;
+		if (quote) {
+			if (character === quote) quote = undefined;
+			continue;
+		}
+		if (character === '"' || character === "'") {
+			quote = character;
+			continue;
+		}
+		if (character === ">") return index;
+	}
+	throw new Error("JUnit report contains an incomplete XML tag.");
+}
+function findXmlCommentEnd(report: string, start: number): number {
+	for (let index = start + 4; index < report.length; index += 1) {
+		if (report[index] !== "-" || report[index + 1] !== "-") continue;
+		const terminator = report[index + 2];
+		if (terminator === ">") return index;
+		if (terminator === undefined) break;
+		throw new Error("JUnit report contains a malformed XML comment.");
+	}
+	throw new Error("JUnit report contains an incomplete XML comment.");
+}
+
+function validateCompleteTestsuitesDocument(report: string): string {
+	const rootStart = findXmlRootStart(report);
+	if (!report.startsWith("<testsuites", rootStart)) {
+		throw new Error("JUnit report must begin with a <testsuites> root element.");
+	}
+
+	const rootEnd = findXmlTagEnd(report, rootStart);
+	const rootTag = report.slice(rootStart, rootEnd + 1);
+	const rootContents = rootTag.slice(1, -1);
+	const rootName = rootContents.match(XML_NAME_PATTERN)?.[0];
+	if (rootName !== "testsuites" || rootContents.endsWith("/")) {
+		throw new Error("JUnit report must begin with a non-self-closing <testsuites> root element.");
+	}
+	parseXmlAttributes(rootContents.slice("testsuites".length), "testsuites");
+
+	const stack = ["testsuites"];
+	let cursor = rootEnd + 1;
+	while (stack.length > 0) {
+		const nextTag = report.indexOf("<", cursor);
+		if (nextTag === -1) {
+			throw new Error("JUnit report contains an incomplete XML document.");
+		}
+		validateXmlText(report.slice(cursor, nextTag));
+		cursor = nextTag;
+
+		if (report.startsWith("<!--", cursor)) {
+			const end = findXmlCommentEnd(report, cursor);
+			const content = report.slice(cursor + 4, end);
+			validateXmlCharacters(content, "XML comment");
+			cursor = end + 3;
+			continue;
+		}
+		if (report.startsWith("<![CDATA[", cursor)) {
+			const end = report.indexOf("]]>", cursor + 9);
+			if (end === -1) throw new Error("JUnit report contains an incomplete CDATA section.");
+			const content = report.slice(cursor + 9, end);
+			validateXmlCharacters(content, "CDATA section");
+			cursor = end + 3;
+			continue;
+		}
+		if (report.startsWith("<?", cursor)) {
+			const end = report.indexOf("?>", cursor + 2);
+			if (end === -1) throw new Error("JUnit report contains an incomplete XML processing instruction.");
+			const contents = report.slice(cursor + 2, end);
+			validateXmlCharacters(contents, "XML processing instruction");
+			const target = contents.match(XML_NAME_PATTERN)?.[0];
+			const data = target === undefined ? undefined : contents.slice(target.length);
+			if (
+				!target ||
+				data === undefined ||
+				(data.length > 0 && !isXmlWhitespace(data[0])) ||
+				target.toLowerCase() === "xml"
+			) {
+				throw new Error("JUnit report contains an invalid XML processing instruction.");
+			}
+			cursor = end + 2;
+			continue;
+		}
+		if (report.startsWith("<!", cursor)) {
+			throw new Error("JUnit report contains an unsupported XML declaration.");
+		}
+
+		const tagEnd = findXmlTagEnd(report, cursor);
+		const tag = report.slice(cursor + 1, tagEnd);
+		cursor = tagEnd + 1;
+
+		if (tag.startsWith("/")) {
+			const closingContents = tag.slice(1);
+			const closingName = closingContents.match(XML_NAME_PATTERN)?.[0];
+			const closingWhitespace = closingName === undefined ? "" : closingContents.slice(closingName.length);
+			const expectedName = stack.pop();
+			if (!closingName || !isOnlyXmlWhitespace(closingWhitespace) || closingName !== expectedName) {
+				throw new Error(`JUnit XML close tag </${closingContents}> does not match expected </${expectedName}>.`);
+			}
+			continue;
+		}
+
+		const selfClosing = tag.endsWith("/");
+		const openingTag = selfClosing ? tag.slice(0, -1) : tag;
+		const name = openingTag.match(XML_NAME_PATTERN)?.[0];
+		if (!name || (openingTag.length > name.length && !isXmlWhitespace(openingTag[name.length]))) {
+			throw new Error("JUnit report contains a malformed XML tag.");
+		}
+		if (name === "testsuites") {
+			throw new Error("JUnit report must contain exactly one <testsuites> root element.");
+		}
+		parseXmlAttributes(openingTag.slice(name.length), name);
+		if (!selfClosing) stack.push(name);
+	}
+
+	if (!/^[\x20\x09\x0a\x0d]*$/.test(report.slice(cursor))) {
+		throw new Error("JUnit report must contain exactly one complete <testsuites> root document.");
+	}
+	return rootTag.slice("<testsuites".length, -1);
+}
+
+export function parseJunitCounts(report: string): JunitCounts {
+	const attributes = validateCompleteTestsuitesDocument(report);
+	const values = parseCountAttributes(attributes);
+
+	return {
+		tests: parseCountAttribute(values, "tests"),
+		failures: parseCountAttribute(values, "failures"),
+		skipped: parseCountAttribute(values, "skipped"),
+	};
+}
+
+export function validatePlatformTestPolicy(
+	mode: ExpectedPlatformTestMode,
+	counts: JunitCounts,
+	exitCode: number,
+): void {
+	if (exitCode !== 0) {
+		throw new Error(`bun test exited with code ${exitCode}; expected 0.`);
+	}
+	if (counts.failures !== 0) {
+		throw new Error(`JUnit reported ${counts.failures} failures; expected 0.`);
+	}
+
+	if (mode === "skipped") {
+		if (counts.skipped === 0) {
+			throw new Error("Expected the test suite to be skipped, but JUnit reported zero skipped tests.");
+		}
+		if (counts.tests !== counts.skipped) {
+			throw new Error(
+				`Expected every test to be skipped, but JUnit reported tests=${counts.tests} and skipped=${counts.skipped}.`,
+			);
+		}
+		return;
+	}
+
+	if (mode === "executed") {
+		if (counts.tests === 0) {
+			throw new Error("Expected the test suite to execute, but JUnit reported zero tests.");
+		}
+		if (counts.skipped !== 0) {
+			throw new Error(`Expected no skipped tests, but JUnit reported skipped=${counts.skipped}.`);
+		}
+		return;
+	}
+
+	throw new Error(`Unknown expected platform test mode: ${String(mode)}.`);
+}
+
+export function parsePlatformTestPolicyArguments(args: string[]): PlatformTestPolicyArguments {
+	if (args.length !== 2) {
+		throw new Error("Usage: bun scripts/verify-platform-test-policy.ts --expect-skipped|--expect-executed <test-file>");
+	}
+
+	const [flag, testFile] = args;
+	if (!testFile || testFile.trim().length === 0) {
+		throw new Error("A non-empty test file path is required.");
+	}
+	if (flag === "--expect-skipped") return { mode: "skipped", testFile };
+	if (flag === "--expect-executed") return { mode: "executed", testFile };
+	throw new Error(`Unknown expectation ${JSON.stringify(flag)}. Use --expect-skipped or --expect-executed.`);
+}
+
+export async function verifyPlatformTestPolicy(args: PlatformTestPolicyArguments): Promise<void> {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "verify-platform-test-policy-"));
+	let execution: TestExecution | undefined;
+
+	let primaryError: Error | undefined;
+	try {
+		const reportPath = path.join(tempDir, `${crypto.randomUUID()}.junit.xml`);
+		const child = Bun.spawn(
+			["bun", "test", args.testFile, "--reporter=junit", `--reporter-outfile=${reportPath}`],
+			{ stderr: "pipe", stdout: "pipe" },
+		);
+		const [exitCode, stdout, stderr] = await Promise.all([
+			child.exited,
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+		]);
+		execution = { exitCode, stderr, stdout };
+
+		if (exitCode !== 0) {
+			throw new Error(`bun test ${args.testFile} exited with code ${exitCode}.\n${formatChildOutput(execution)}`);
+		}
+		const report = Bun.file(reportPath);
+		if (!(await report.exists())) {
+			throw new Error(`bun test completed without creating its JUnit report at ${reportPath}.\n${formatChildOutput(execution)}`);
+		}
+
+		const counts = parseJunitCounts(await report.text());
+		validatePlatformTestPolicy(args.mode, counts, exitCode);
+		process.stdout.write(
+			`Platform test policy passed for ${args.testFile}: tests=${counts.tests}, failures=${counts.failures}, skipped=${counts.skipped}.\n`,
+		);
+	} catch (error) {
+		const detail = toError(error).message;
+		primaryError = new Error(
+			execution && !detail.includes("Child stdout:") ? `${detail}\n${formatChildOutput(execution)}` : detail,
+		);
+	}
+
+	let cleanupError: Error | undefined;
+	try {
+		await fs.rm(tempDir, { force: true, recursive: true });
+	} catch (error) {
+		cleanupError = toError(error);
+	}
+
+	const combinedError = combinePrimaryAndCleanupErrors(primaryError, cleanupError);
+	if (combinedError) throw combinedError;
+}
+
+if (import.meta.main) {
+	try {
+		await verifyPlatformTestPolicy(parsePlatformTestPolicyArguments(process.argv.slice(2)));
+	} catch (error) {
+		process.stderr.write(`verify-platform-test-policy: ${error instanceof Error ? error.message : String(error)}\n`);
+		process.exitCode = 1;
+	}
+}

--- a/scripts/verify-platform-test-policy.ts
+++ b/scripts/verify-platform-test-policy.ts
@@ -391,10 +391,12 @@ function createElement(
 		if (!file || file.trim().length === 0 || !testcaseName || testcaseName.trim().length === 0) {
 			throw new Error("JUnit <testcase> must contain non-empty file and name attributes.");
 		}
-		if (!/^[1-9]\d*$/.test(line ?? "") || !Number.isSafeInteger(Number(line))) {
-			throw new Error("JUnit <testcase> must contain a positive safe-integer line attribute.");
+		if (line !== undefined && (!/^[1-9]\d*$/.test(line) || !Number.isSafeInteger(Number(line)))) {
+			throw new Error("JUnit <testcase> must contain a positive safe-integer line attribute when present.");
 		}
-		const identity = `${file}\u0000${line}\u0000${className}\u0000${testcaseName}`;
+		const normalizedLine = line === undefined ? "" : String(Number(line));
+		// Without a line, identical file/classname/name values are conservatively treated as duplicates.
+		const identity = `${file}\u0000${className}\u0000${testcaseName}\u0000${normalizedLine}`;
 		if (testcaseIdentities.has(identity)) {
 			throw new Error("JUnit report contains duplicate testcase identities.");
 		}

--- a/scripts/verify-platform-test-policy.ts
+++ b/scripts/verify-platform-test-policy.ts
@@ -7,6 +7,7 @@ export type ExpectedPlatformTestMode = "skipped" | "executed";
 export interface JunitCounts {
 	tests: number;
 	failures: number;
+	errors: number;
 	skipped: number;
 }
 
@@ -25,7 +26,34 @@ const XML_NAME_PATTERN = /^[A-Za-z_:][A-Za-z0-9_:.-]*/;
 const XML_WHITESPACE_PATTERN = /^[\x20\x09\x0a\x0d]*/;
 const XML_DECLARATION_PATTERN =
 	/^<\?xml[ \t\r\n]+version=(["'])1\.0\1(?:[ \t\r\n]+encoding=(["'])[A-Za-z][A-Za-z0-9._-]*\2)?(?:[ \t\r\n]+standalone=(["'])(?:yes|no)\3)?[ \t\r\n]*\?>[ \t\r\n]*/;
-const JUNIT_COUNT_ATTRIBUTES = ["tests", "failures", "skipped"] as const;
+const JUNIT_RECONCILED_COUNT_ATTRIBUTES = ["tests", "failures", "errors", "skipped"] as const;
+const MAX_JUNIT_REPORT_BYTES = 16 * 1024 * 1024;
+const MAX_JUNIT_REPORT_CHARACTERS = MAX_JUNIT_REPORT_BYTES;
+const MAX_JUNIT_XML_DEPTH = 64;
+const MAX_JUNIT_ELEMENTS = 100_000;
+const MAX_JUNIT_TAG_LENGTH = 16 * 1024;
+const MAX_JUNIT_MARKUP_LENGTH = 64 * 1024;
+const MAX_JUNIT_ATTRIBUTES_PER_ELEMENT = 64;
+const MAX_JUNIT_ENTITY_LENGTH = 64;
+
+type JunitCountAttribute = (typeof JUNIT_RECONCILED_COUNT_ATTRIBUTES)[number];
+type TestcaseOutcome = "failure" | "error" | "skipped";
+
+interface SuiteFrame {
+	declared: JunitCounts;
+	observed: JunitCounts;
+}
+
+interface TestcaseFrame {
+	identity: string;
+	outcome: TestcaseOutcome | undefined;
+}
+
+interface ParsedElement {
+	name: string;
+	suite: SuiteFrame | undefined;
+	testcase: TestcaseFrame | undefined;
+}
 
 function formatChildOutput(execution: TestExecution): string {
 	return [
@@ -51,6 +79,7 @@ export function combinePrimaryAndCleanupErrors(
 function toError(error: unknown): Error {
 	return error instanceof Error ? error : new Error(String(error));
 }
+
 function isLegalXmlCharacter(codePoint: number): boolean {
 	return (
 		codePoint === 0x9 ||
@@ -61,6 +90,7 @@ function isLegalXmlCharacter(codePoint: number): boolean {
 		(codePoint >= 0x10000 && codePoint <= 0x10ffff)
 	);
 }
+
 function isXmlWhitespace(character: string | undefined): boolean {
 	return character === "\x20" || character === "\x09" || character === "\x0a" || character === "\x0d";
 }
@@ -72,7 +102,6 @@ function isOnlyXmlWhitespace(value: string): boolean {
 	return true;
 }
 
-
 function validateXmlCharacters(value: string, context: string): void {
 	for (let index = 0; index < value.length; ) {
 		const codePoint = value.codePointAt(index);
@@ -83,12 +112,71 @@ function validateXmlCharacters(value: string, context: string): void {
 	}
 }
 
+function decodeXmlEntities(value: string, context: string): string {
+	let decoded = "";
+	let cursor = 0;
+
+	while (cursor < value.length) {
+		const entityStart = value.indexOf("&", cursor);
+		if (entityStart === -1) return decoded + value.slice(cursor);
+		decoded += value.slice(cursor, entityStart);
+
+		let entityEnd = entityStart + 1;
+		while (entityEnd < value.length && value[entityEnd] !== ";") {
+			if (value[entityEnd] === "&") {
+				throw new Error(`JUnit ${context} contains an unterminated XML entity reference.`);
+			}
+			if (entityEnd - entityStart > MAX_JUNIT_ENTITY_LENGTH) {
+				throw new Error(`JUnit ${context} contains an XML entity reference that exceeds the parser bound.`);
+			}
+			entityEnd += 1;
+		}
+		if (entityEnd === value.length) {
+			throw new Error(`JUnit ${context} contains an unterminated XML entity reference.`);
+		}
+
+		const entity = value.slice(entityStart + 1, entityEnd);
+		switch (entity) {
+			case "amp":
+				decoded += "&";
+				break;
+			case "apos":
+				decoded += "'";
+				break;
+			case "gt":
+				decoded += ">";
+				break;
+			case "lt":
+				decoded += "<";
+				break;
+			case "quot":
+				decoded += '"';
+				break;
+			default: {
+				const decimal = /^#\d+$/.test(entity);
+				const hexadecimal = /^#x[0-9A-Fa-f]+$/.test(entity);
+				if (!decimal && !hexadecimal) {
+					throw new Error(`JUnit ${context} contains an invalid XML entity reference.`);
+				}
+				const codePoint = Number.parseInt(entity.slice(decimal ? 1 : 2), decimal ? 10 : 16);
+				if (!Number.isSafeInteger(codePoint) || !isLegalXmlCharacter(codePoint)) {
+					throw new Error(`JUnit ${context} contains an invalid XML entity reference.`);
+				}
+				decoded += String.fromCodePoint(codePoint);
+			}
+		}
+		cursor = entityEnd + 1;
+	}
+
+	return decoded;
+}
+
 function validateXmlText(value: string): void {
 	if (value.includes("]]>")) {
 		throw new Error("JUnit XML text contains the forbidden ]]> sequence.");
 	}
 	validateXmlCharacters(value, "XML text");
-	validateXmlEntities(value, "XML text");
+	decodeXmlEntities(value, "XML text");
 }
 
 function findXmlRootStart(report: string): number {
@@ -107,36 +195,6 @@ function findXmlRootStart(report: string): number {
 	return report.match(XML_WHITESPACE_PATTERN)?.[0].length ?? 0;
 }
 
-function validateXmlEntities(value: string, context: string): void {
-	let cursor = 0;
-	while (cursor < value.length) {
-		const entityStart = value.indexOf("&", cursor);
-		if (entityStart === -1) return;
-
-		const entityEnd = value.indexOf(";", entityStart + 1);
-		if (entityEnd === -1) {
-			throw new Error(`JUnit ${context} contains an unterminated XML entity reference.`);
-		}
-
-		const entity = value.slice(entityStart + 1, entityEnd);
-		if (/^(?:amp|apos|gt|lt|quot)$/.test(entity)) {
-			cursor = entityEnd + 1;
-			continue;
-		}
-
-		const numeric = entity.match(/^#(?:(\d+)|x([0-9A-Fa-f]+))$/);
-		if (numeric) {
-			const codePoint = Number.parseInt(numeric[1] ?? numeric[2] ?? "", numeric[1] ? 10 : 16);
-			if (Number.isSafeInteger(codePoint) && isLegalXmlCharacter(codePoint)) {
-				cursor = entityEnd + 1;
-				continue;
-			}
-		}
-
-		throw new Error(`JUnit ${context} contains an invalid XML entity reference.`);
-	}
-}
-
 function parseXmlAttributes(attributes: string, elementName: string): Map<string, string> {
 	const values = new Map<string, string>();
 	let cursor = 0;
@@ -147,6 +205,9 @@ function parseXmlAttributes(attributes: string, elementName: string): Map<string
 		}
 		while (isXmlWhitespace(attributes[cursor])) cursor += 1;
 		if (cursor === attributes.length) break;
+		if (values.size >= MAX_JUNIT_ATTRIBUTES_PER_ELEMENT) {
+			throw new Error(`JUnit <${elementName}> exceeds the attribute parser bound.`);
+		}
 
 		const name = attributes.slice(cursor).match(XML_NAME_PATTERN)?.[0];
 		if (!name) {
@@ -174,40 +235,73 @@ function parseXmlAttributes(attributes: string, elementName: string): Map<string
 		if (value.includes("<")) {
 			throw new Error(`JUnit <${elementName}> has malformed attributes.`);
 		}
-		validateXmlEntities(value, `<${elementName}> attribute ${name}`);
+		const decodedValue = decodeXmlEntities(value, `<${elementName}> attribute ${name}`);
 		if (values.has(name)) {
 			throw new Error(`JUnit <${elementName}> contains duplicate ${name} attributes.`);
 		}
-		values.set(name, value);
+		values.set(name, decodedValue);
 		cursor = valueEnd + 1;
 	}
 
 	return values;
 }
 
-function parseCountAttributes(attributes: string): Map<string, string> {
-	return parseXmlAttributes(attributes, "testsuites");
-}
-
-function parseCountAttribute(attributes: Map<string, string>, name: (typeof JUNIT_COUNT_ATTRIBUTES)[number]): number {
+function parseCountAttribute(
+	attributes: Map<string, string>,
+	name: JunitCountAttribute,
+	elementName: "testsuites" | "testsuite",
+): number {
 	const value = attributes.get(name);
+	const label = elementName === "testsuites" ? "<testsuites> root" : "<testsuite>";
 	if (value === undefined) {
-		throw new Error(`JUnit <testsuites> root must contain exactly one ${name} attribute.`);
+		throw new Error(`JUnit ${label} must contain exactly one ${name} attribute.`);
 	}
 	if (!/^\d+$/.test(value)) {
-		throw new Error(`JUnit <testsuites> ${name} attribute must be a non-negative integer, received ${JSON.stringify(value)}.`);
+		throw new Error(`JUnit ${label} ${name} attribute must be a non-negative integer, received ${JSON.stringify(value)}.`);
 	}
 
 	const count = Number(value);
 	if (!Number.isSafeInteger(count)) {
-		throw new Error(`JUnit <testsuites> ${name} attribute must be a safe integer, received ${JSON.stringify(value)}.`);
+		throw new Error(`JUnit ${label} ${name} attribute must be a safe integer, received ${JSON.stringify(value)}.`);
 	}
 	return count;
 }
 
+function parseDeclaredCounts(attributes: Map<string, string>, elementName: "testsuites" | "testsuite"): JunitCounts {
+	return {
+		tests: parseCountAttribute(attributes, "tests", elementName),
+		failures: parseCountAttribute(attributes, "failures", elementName),
+		// Bun omits this attribute, so absence is a declared zero rather than an unchecked count.
+		errors: attributes.has("errors") ? parseCountAttribute(attributes, "errors", elementName) : 0,
+		skipped: parseCountAttribute(attributes, "skipped", elementName),
+	};
+}
+
+function emptyCounts(): JunitCounts {
+	return { tests: 0, failures: 0, errors: 0, skipped: 0 };
+}
+
+function addCounts(target: JunitCounts, source: JunitCounts): void {
+	target.tests += source.tests;
+	target.failures += source.failures;
+	target.errors += source.errors;
+	target.skipped += source.skipped;
+}
+
+function assertCountsMatch(elementName: "testsuites" | "testsuite", declared: JunitCounts, observed: JunitCounts): void {
+	for (const name of JUNIT_RECONCILED_COUNT_ATTRIBUTES) {
+		if (declared[name] !== observed[name]) {
+			throw new Error(
+				`JUnit <${elementName}> count mismatch for ${name}: declared ${declared[name]}, observed ${observed[name]}.`,
+			);
+		}
+	}
+}
+
 function findXmlTagEnd(report: string, start: number): number {
 	let quote: string | undefined;
-	for (let index = start + 1; index < report.length; index += 1) {
+	const limit = Math.min(report.length, start + MAX_JUNIT_TAG_LENGTH);
+	for (let index = start + 1; index < limit; index += 1) {
 		const character = report[index];
 		if (character === undefined) continue;
 		if (quote) {
@@ -220,20 +314,130 @@ function findXmlTagEnd(report: string, start: number): number {
 		}
 		if (character === ">") return index;
 	}
+	if (limit < report.length) {
+		throw new Error("JUnit report contains an XML tag that exceeds the parser bound.");
+	}
 	throw new Error("JUnit report contains an incomplete XML tag.");
 }
+
 function findXmlCommentEnd(report: string, start: number): number {
-	for (let index = start + 4; index < report.length; index += 1) {
+	const limit = Math.min(report.length, start + MAX_JUNIT_MARKUP_LENGTH);
+	for (let index = start + 4; index < limit; index += 1) {
 		if (report[index] !== "-" || report[index + 1] !== "-") continue;
 		const terminator = report[index + 2];
 		if (terminator === ">") return index;
 		if (terminator === undefined) break;
 		throw new Error("JUnit report contains a malformed XML comment.");
 	}
+	if (limit < report.length) {
+		throw new Error("JUnit report contains an XML comment that exceeds the parser bound.");
+	}
 	throw new Error("JUnit report contains an incomplete XML comment.");
 }
 
-function validateCompleteTestsuitesDocument(report: string): string {
+function findBoundedTerminator(report: string, start: number, offset: number, terminator: string, description: string): number {
+	const end = report.indexOf(terminator, start + offset);
+	if (end === -1) {
+		throw new Error(`JUnit report contains an incomplete ${description}.`);
+	}
+	if (end - start > MAX_JUNIT_MARKUP_LENGTH) {
+		throw new Error(`JUnit report contains a ${description} that exceeds the parser bound.`);
+	}
+	return end;
+}
+
+function validateContainerText(elementName: string, text: string): void {
+	if (
+		(elementName === "testsuites" || elementName === "testsuite" || elementName === "properties") &&
+		!isOnlyXmlWhitespace(text)
+	) {
+		throw new Error(`JUnit <${elementName}> may not contain unstructured text.`);
+	}
+}
+
+function validateChildElement(parentName: string, childName: string): void {
+	const allowed =
+		parentName === "testsuites"
+			? ["testsuite"]
+			: parentName === "testsuite"
+				? ["testsuite", "testcase", "properties", "system-out", "system-err"]
+				: parentName === "testcase"
+					? ["failure", "error", "skipped", "system-out", "system-err"]
+					: parentName === "properties"
+						? ["property"]
+						: [];
+	if (!allowed.includes(childName)) {
+		throw new Error(`JUnit <${parentName}> cannot contain <${childName}>.`);
+	}
+}
+
+function createElement(
+	name: string,
+	attributes: Map<string, string>,
+	testcaseIdentities: Set<string>,
+): ParsedElement {
+	if (name === "testsuite") {
+		return {
+			name,
+			suite: { declared: parseDeclaredCounts(attributes, "testsuite"), observed: emptyCounts() },
+			testcase: undefined,
+		};
+	}
+	if (name === "testcase") {
+		const file = attributes.get("file");
+		const line = attributes.get("line");
+		const testcaseName = attributes.get("name");
+		const className = attributes.get("classname") ?? "";
+		if (!file || file.trim().length === 0 || !testcaseName || testcaseName.trim().length === 0) {
+			throw new Error("JUnit <testcase> must contain non-empty file and name attributes.");
+		}
+		if (!/^[1-9]\d*$/.test(line ?? "") || !Number.isSafeInteger(Number(line))) {
+			throw new Error("JUnit <testcase> must contain a positive safe-integer line attribute.");
+		}
+		const identity = `${file}\u0000${line}\u0000${className}\u0000${testcaseName}`;
+		if (testcaseIdentities.has(identity)) {
+			throw new Error("JUnit report contains duplicate testcase identities.");
+		}
+		testcaseIdentities.add(identity);
+		return { name, suite: undefined, testcase: { identity, outcome: undefined } };
+	}
+	return { name, suite: undefined, testcase: undefined };
+}
+
+function recordTestcaseOutcome(parent: ParsedElement, childName: string): void {
+	if (!parent.testcase || (childName !== "failure" && childName !== "error" && childName !== "skipped")) return;
+	if (parent.testcase.outcome !== undefined) {
+		throw new Error(`JUnit testcase ${JSON.stringify(parent.testcase.identity)} contains multiple result elements.`);
+	}
+	parent.testcase.outcome = childName;
+}
+
+function completeElement(element: ParsedElement, ancestors: ParsedElement[], rootObserved: JunitCounts): void {
+	if (element.testcase) {
+		const observed = emptyCounts();
+		observed.tests = 1;
+		if (element.testcase.outcome === "failure") observed.failures = 1;
+		if (element.testcase.outcome === "error") observed.errors = 1;
+		if (element.testcase.outcome === "skipped") observed.skipped = 1;
+		addCounts(rootObserved, observed);
+		for (const ancestor of ancestors) {
+			if (ancestor.suite) addCounts(ancestor.suite.observed, observed);
+		}
+		return;
+	}
+	if (element.suite) {
+		if (element.suite.observed.tests === 0) {
+			throw new Error("JUnit <testsuite> must contain at least one testcase.");
+		}
+		assertCountsMatch("testsuite", element.suite.declared, element.suite.observed);
+	}
+}
+
+export function parseJunitCounts(report: string): JunitCounts {
+	if (report.length > MAX_JUNIT_REPORT_CHARACTERS) {
+		throw new Error(`JUnit report exceeds the ${MAX_JUNIT_REPORT_BYTES}-byte parser bound.`);
+	}
+
 	const rootStart = findXmlRootStart(report);
 	if (!report.startsWith("<testsuites", rootStart)) {
 		throw new Error("JUnit report must begin with a <testsuites> root element.");
@@ -246,36 +450,42 @@ function validateCompleteTestsuitesDocument(report: string): string {
 	if (rootName !== "testsuites" || rootContents.endsWith("/")) {
 		throw new Error("JUnit report must begin with a non-self-closing <testsuites> root element.");
 	}
-	parseXmlAttributes(rootContents.slice("testsuites".length), "testsuites");
-
-	const stack = ["testsuites"];
+	const rootAttributes = parseXmlAttributes(rootContents.slice("testsuites".length), "testsuites");
+	const declaredRootCounts = parseDeclaredCounts(rootAttributes, "testsuites");
+	const rootObserved = emptyCounts();
+	const stack: ParsedElement[] = [{ name: "testsuites", suite: undefined, testcase: undefined }];
+	const testcaseIdentities = new Set<string>();
 	let cursor = rootEnd + 1;
+	let elementCount = 0;
+
 	while (stack.length > 0) {
+		const parent = stack[stack.length - 1];
+		if (parent === undefined) throw new Error("JUnit report contains an invalid XML nesting state.");
 		const nextTag = report.indexOf("<", cursor);
 		if (nextTag === -1) {
 			throw new Error("JUnit report contains an incomplete XML document.");
 		}
-		validateXmlText(report.slice(cursor, nextTag));
+		const text = report.slice(cursor, nextTag);
+		validateXmlText(text);
+		validateContainerText(parent.name, text);
 		cursor = nextTag;
 
 		if (report.startsWith("<!--", cursor)) {
 			const end = findXmlCommentEnd(report, cursor);
-			const content = report.slice(cursor + 4, end);
-			validateXmlCharacters(content, "XML comment");
+			validateXmlCharacters(report.slice(cursor + 4, end), "XML comment");
 			cursor = end + 3;
 			continue;
 		}
 		if (report.startsWith("<![CDATA[", cursor)) {
-			const end = report.indexOf("]]>", cursor + 9);
-			if (end === -1) throw new Error("JUnit report contains an incomplete CDATA section.");
+			const end = findBoundedTerminator(report, cursor, 9, "]]>", "CDATA section");
 			const content = report.slice(cursor + 9, end);
 			validateXmlCharacters(content, "CDATA section");
+			validateContainerText(parent.name, content);
 			cursor = end + 3;
 			continue;
 		}
 		if (report.startsWith("<?", cursor)) {
-			const end = report.indexOf("?>", cursor + 2);
-			if (end === -1) throw new Error("JUnit report contains an incomplete XML processing instruction.");
+			const end = findBoundedTerminator(report, cursor, 2, "?>", "XML processing instruction");
 			const contents = report.slice(cursor + 2, end);
 			validateXmlCharacters(contents, "XML processing instruction");
 			const target = contents.match(XML_NAME_PATTERN)?.[0];
@@ -303,13 +513,18 @@ function validateCompleteTestsuitesDocument(report: string): string {
 			const closingContents = tag.slice(1);
 			const closingName = closingContents.match(XML_NAME_PATTERN)?.[0];
 			const closingWhitespace = closingName === undefined ? "" : closingContents.slice(closingName.length);
-			const expectedName = stack.pop();
-			if (!closingName || !isOnlyXmlWhitespace(closingWhitespace) || closingName !== expectedName) {
-				throw new Error(`JUnit XML close tag </${closingContents}> does not match expected </${expectedName}>.`);
+			const expected = stack.pop();
+			if (!expected || !closingName || !isOnlyXmlWhitespace(closingWhitespace) || closingName !== expected.name) {
+				throw new Error(`JUnit XML close tag </${closingContents}> does not match expected </${expected?.name}>.`);
 			}
+			completeElement(expected, stack, rootObserved);
 			continue;
 		}
 
+		elementCount += 1;
+		if (elementCount > MAX_JUNIT_ELEMENTS) {
+			throw new Error("JUnit report exceeds the XML element parser bound.");
+		}
 		const selfClosing = tag.endsWith("/");
 		const openingTag = selfClosing ? tag.slice(0, -1) : tag;
 		const name = openingTag.match(XML_NAME_PATTERN)?.[0];
@@ -319,25 +534,28 @@ function validateCompleteTestsuitesDocument(report: string): string {
 		if (name === "testsuites") {
 			throw new Error("JUnit report must contain exactly one <testsuites> root element.");
 		}
-		parseXmlAttributes(openingTag.slice(name.length), name);
-		if (!selfClosing) stack.push(name);
+		const attributes = parseXmlAttributes(openingTag.slice(name.length), name);
+		validateChildElement(parent.name, name);
+		recordTestcaseOutcome(parent, name);
+		const element = createElement(name, attributes, testcaseIdentities);
+		if (selfClosing) {
+			completeElement(element, stack, rootObserved);
+			continue;
+		}
+		if (stack.length >= MAX_JUNIT_XML_DEPTH) {
+			throw new Error("JUnit report exceeds the XML nesting-depth parser bound.");
+		}
+		stack.push(element);
 	}
 
-	if (!/^[\x20\x09\x0a\x0d]*$/.test(report.slice(cursor))) {
+	if (!isOnlyXmlWhitespace(report.slice(cursor))) {
 		throw new Error("JUnit report must contain exactly one complete <testsuites> root document.");
 	}
-	return rootTag.slice("<testsuites".length, -1);
-}
-
-export function parseJunitCounts(report: string): JunitCounts {
-	const attributes = validateCompleteTestsuitesDocument(report);
-	const values = parseCountAttributes(attributes);
-
-	return {
-		tests: parseCountAttribute(values, "tests"),
-		failures: parseCountAttribute(values, "failures"),
-		skipped: parseCountAttribute(values, "skipped"),
-	};
+	if (rootObserved.tests === 0) {
+		throw new Error("JUnit report must contain at least one testcase.");
+	}
+	assertCountsMatch("testsuites", declaredRootCounts, rootObserved);
+	return rootObserved;
 }
 
 export function validatePlatformTestPolicy(
@@ -350,6 +568,9 @@ export function validatePlatformTestPolicy(
 	}
 	if (counts.failures !== 0) {
 		throw new Error(`JUnit reported ${counts.failures} failures; expected 0.`);
+	}
+	if (counts.errors !== 0) {
+		throw new Error(`JUnit reported ${counts.errors} errors; expected 0.`);
 	}
 
 	if (mode === "skipped") {
@@ -416,11 +637,14 @@ export async function verifyPlatformTestPolicy(args: PlatformTestPolicyArguments
 		if (!(await report.exists())) {
 			throw new Error(`bun test completed without creating its JUnit report at ${reportPath}.\n${formatChildOutput(execution)}`);
 		}
+		if (report.size > MAX_JUNIT_REPORT_BYTES) {
+			throw new Error(`JUnit report at ${reportPath} exceeds the ${MAX_JUNIT_REPORT_BYTES}-byte parser bound.`);
+		}
 
 		const counts = parseJunitCounts(await report.text());
 		validatePlatformTestPolicy(args.mode, counts, exitCode);
 		process.stdout.write(
-			`Platform test policy passed for ${args.testFile}: tests=${counts.tests}, failures=${counts.failures}, skipped=${counts.skipped}.\n`,
+			`Platform test policy passed for ${args.testFile}: tests=${counts.tests}, failures=${counts.failures}, errors=${counts.errors}, skipped=${counts.skipped}.\n`,
 		);
 	} catch (error) {
 		const detail = toError(error).message;


### PR DESCRIPTION
# ci: make TypeScript 7 platform checks portable

## What

- Normalize affected-task paths across Windows and POSIX runners.
- Add strict JUnit-based platform test-policy verification.
- Skip the POSIX-only `gjc-session` suite on Windows while requiring zero skips on Linux.
- Assert the required CI and release-check ordering.

## Why

TypeScript 7.0.2 validation needs portable Windows evidence without incorrectly claiming that POSIX shell and tmux integration tests executed there. Linux remains the authoritative zero-skip surface for that suite.

## Testing

- `bun test scripts/ci-dev-affected.test.ts scripts/verify-platform-test-policy.test.ts scripts/release-publish-order.test.ts`
- Windows: `bun scripts/verify-platform-test-policy.ts --expect-skipped scripts/gjc-session/create.test.ts`
- Linux/WSL: `bun scripts/verify-platform-test-policy.ts --expect-executed scripts/gjc-session/create.test.ts`
- `bun run check:ts`
- `git diff --check`

## Reviewer note

Thank you for reviewing this focused portability change. The most useful review areas are the strict XML/JUnit false-green protections, Windows path normalization, and workflow ordering. This branch intentionally excludes native PTY and visible-session implementation work so it can be reviewed and rolled back independently.

## Rollback

This PR has no data migration or persistent-state dependency and can be reverted independently.
