### PR TITLE
tui: publish recoverable raw-terminal leases

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Published a recoverable `createRawTerminalLease` root API that transactionally adopts raw stdin and Windows VT input, restores the exact prior terminal state, and supports idempotent emergency cleanup.
+
 ### Fixed
 
 - Terminal graphics protocols are no longer assumed under terminal multiplexers: the blind Kitty fallback for `TERM=tmux-*`/`screen-*` (and detected kitty/iTerm2 protocols leaking through multiplexer env) emitted raw graphics escapes the multiplexer consumed, leaving the Gajae composer pet invisible while its out-of-band cursor writes intermittently corrupted the TUI frame. Image protocols are now unconditionally dropped under tmux/screen/zellij (shared multiplexer predicate with the renderer host policy, including `$TMUX_PANE`, `$STY`, `$ZELLIJ`, and `GJC_TMUX_LAUNCHED`) unless `PI_FORCE_IMAGE_PROTOCOL` explicitly forces a protocol, which remains an expert override.

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -29,6 +29,7 @@ export * from "./keys";
 // Renderer/runtime observability metrics (opt-in)
 export * from "./metrics";
 // Mermaid diagram support
+export * from "./raw-terminal-lease";
 // Input buffering for batch splitting
 export * from "./stdin-buffer";
 export type * from "./symbols";

--- a/packages/tui/src/raw-terminal-lease.ts
+++ b/packages/tui/src/raw-terminal-lease.ts
@@ -1,0 +1,310 @@
+import { dlopen, FFIType, ptr } from "bun:ffi";
+
+const STD_INPUT_HANDLE = -10;
+const ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200;
+interface AcquiringRawTerminalOwner {
+	acquiring: true;
+	cancelled: boolean;
+	lease?: RawTerminalLease;
+}
+
+interface PoisonedRawTerminalOwner {
+	lease: RawTerminalLease;
+}
+
+interface RestoringRawTerminalOwner {
+	lease: RawTerminalLease;
+	restoring: true;
+}
+
+let rawTerminalOwner:
+	| RawTerminalLease
+	| AcquiringRawTerminalOwner
+	| PoisonedRawTerminalOwner
+	| RestoringRawTerminalOwner
+	| undefined;
+
+/** Minimal stdin surface needed to temporarily own raw terminal input. */
+export interface RawTerminalStdin {
+	isTTY?: boolean;
+	isRaw?: boolean;
+	setRawMode?: (mode: boolean) => unknown;
+	isPaused: () => boolean;
+	readableFlowing?: boolean | null;
+	pause: () => unknown;
+	resume: () => unknown;
+}
+
+/** Injectable Windows console mode driver. */
+export interface WindowsConsoleDriver {
+	getInputMode(): number | undefined;
+	setInputMode(mode: number): boolean;
+	close(): void;
+}
+
+export interface RawTerminalLeaseOptions {
+	stdin?: RawTerminalStdin;
+	platform?: NodeJS.Platform;
+	consoleDriver?: WindowsConsoleDriver;
+}
+
+/** Owns raw stdin until closed, restoring the exact state observed at acquisition. */
+export interface RawTerminalLease {
+	close(): void;
+}
+
+/**
+ * Restore the process-wide raw-terminal owner after an interrupted acquisition
+ * or failed rollback. Safe to call repeatedly; failed restoration remains
+ * owned so a later emergency cleanup can retry it.
+ */
+export function emergencyRawTerminalRestore(): void {
+	const owner = rawTerminalOwner;
+	if (!owner || isRestoringRawTerminalOwner(owner)) return;
+	if (isAcquiringRawTerminalOwner(owner)) {
+		owner.cancelled = true;
+		owner.lease?.close();
+		return;
+	}
+	if (!isPoisonedRawTerminalOwner(owner)) {
+		owner.close();
+		return;
+	}
+	const restoringOwner: RestoringRawTerminalOwner = { lease: owner.lease, restoring: true };
+	rawTerminalOwner = restoringOwner;
+	try {
+		owner.lease.close();
+	} catch (error) {
+		if (rawTerminalOwner === restoringOwner) rawTerminalOwner = owner;
+		throw error;
+	}
+	if (rawTerminalOwner === restoringOwner) rawTerminalOwner = undefined;
+}
+
+/** A terminal capability could not be adopted without preserving its cause. */
+export class RawTerminalCapabilityError extends Error {
+	constructor(message: string, cause?: unknown) {
+		super(message, cause === undefined ? undefined : { cause });
+		this.name = "RawTerminalCapabilityError";
+	}
+}
+
+function createWindowsConsoleDriver(): WindowsConsoleDriver {
+	let close: (() => void) | undefined;
+	try {
+		const kernel32 = dlopen("kernel32.dll", {
+			GetStdHandle: { args: [FFIType.i32], returns: FFIType.ptr },
+			GetConsoleMode: { args: [FFIType.ptr, FFIType.ptr], returns: FFIType.bool },
+			SetConsoleMode: { args: [FFIType.ptr, FFIType.u32], returns: FFIType.bool },
+		});
+		const driverClose = (): void => kernel32.close();
+		close = driverClose;
+		const handle = kernel32.symbols.GetStdHandle(STD_INPUT_HANDLE);
+		const mode = new Uint32Array(1);
+		const modePtr = ptr(mode);
+		const getInputMode = (): number | undefined => {
+			if (!modePtr || !kernel32.symbols.GetConsoleMode(handle, modePtr)) return undefined;
+			return mode[0];
+		};
+		return {
+			getInputMode,
+			setInputMode: (value: number): boolean => kernel32.symbols.SetConsoleMode(handle, value),
+			close: driverClose,
+		};
+	} catch (error) {
+		try {
+			close?.();
+		} catch (closeError) {
+			throw new AggregateError([error, closeError], "Could not adopt Windows console input mode");
+		}
+		throw new RawTerminalCapabilityError("Could not adopt Windows console input mode", error);
+	}
+}
+function isAcquiringRawTerminalOwner(
+	owner: RawTerminalLease | AcquiringRawTerminalOwner | PoisonedRawTerminalOwner | RestoringRawTerminalOwner,
+): owner is AcquiringRawTerminalOwner {
+	return typeof owner === "object" && "acquiring" in owner;
+}
+function isPoisonedRawTerminalOwner(
+	owner: RawTerminalLease | AcquiringRawTerminalOwner | PoisonedRawTerminalOwner | RestoringRawTerminalOwner,
+): owner is PoisonedRawTerminalOwner {
+	return typeof owner === "object" && "lease" in owner && !("restoring" in owner);
+}
+
+function isRestoringRawTerminalOwner(
+	owner: RawTerminalLease | AcquiringRawTerminalOwner | PoisonedRawTerminalOwner | RestoringRawTerminalOwner,
+): owner is RestoringRawTerminalOwner {
+	return typeof owner === "object" && "restoring" in owner;
+}
+
+function interruptedAcquisitionError(): RawTerminalCapabilityError {
+	return new RawTerminalCapabilityError("Raw terminal input acquisition was interrupted by emergency restoration");
+}
+
+/**
+ * Acquire raw terminal input and, on Windows, the VT input console mode needed
+ * after raw mode resets the console flags. Acquisition is transactional: an
+ * unavailable capability or failed mutation leaves stdin and console mode as
+ * they were before this call.
+ */
+export function createRawTerminalLease(options: RawTerminalLeaseOptions = {}): RawTerminalLease {
+	if (rawTerminalOwner && isAcquiringRawTerminalOwner(rawTerminalOwner))
+		throw new Error("Raw terminal input is already owned");
+	if (rawTerminalOwner) {
+		if (!isPoisonedRawTerminalOwner(rawTerminalOwner)) throw new Error("Raw terminal input is already owned");
+		const poisonedOwner = rawTerminalOwner;
+		const recovery = { acquiring: true as const, cancelled: false };
+		rawTerminalOwner = recovery;
+		try {
+			poisonedOwner.lease.close();
+		} catch (error) {
+			if (rawTerminalOwner === recovery) rawTerminalOwner = poisonedOwner;
+			throw new RawTerminalCapabilityError("Could not restore previously owned raw terminal input", error);
+		}
+		if (rawTerminalOwner === recovery) rawTerminalOwner = undefined;
+		if (recovery.cancelled) throw interruptedAcquisitionError();
+	}
+	const acquisition: AcquiringRawTerminalOwner = { acquiring: true, cancelled: false };
+	rawTerminalOwner = acquisition;
+	const stdin = options.stdin ?? process.stdin;
+	const platform = options.platform ?? process.platform;
+	let wasRaw: boolean;
+	let wasFlowing: boolean | null | undefined;
+	let wasPaused: boolean;
+	try {
+		if (!stdin.isTTY || typeof stdin.setRawMode !== "function")
+			throw new RawTerminalCapabilityError("Raw terminal input requires a TTY with setRawMode support");
+		if (acquisition.cancelled) throw interruptedAcquisitionError();
+		wasRaw = stdin.isRaw === true;
+		if (acquisition.cancelled) throw interruptedAcquisitionError();
+		wasFlowing = stdin.readableFlowing;
+		if (acquisition.cancelled) throw interruptedAcquisitionError();
+		wasPaused = stdin.isPaused();
+		if (acquisition.cancelled) throw interruptedAcquisitionError();
+	} catch (error) {
+		if (rawTerminalOwner === acquisition) rawTerminalOwner = undefined;
+		if (error instanceof RawTerminalCapabilityError) throw error;
+		throw new RawTerminalCapabilityError("Could not inspect raw terminal input state", error);
+	}
+	let consoleDriver: WindowsConsoleDriver | undefined;
+	let originalConsoleMode: number | undefined;
+	try {
+		if (platform === "win32") {
+			consoleDriver = options.consoleDriver ?? createWindowsConsoleDriver();
+			originalConsoleMode = consoleDriver.getInputMode();
+			if (acquisition.cancelled) throw interruptedAcquisitionError();
+			if (originalConsoleMode === undefined) {
+				throw new RawTerminalCapabilityError("Raw terminal input requires a Windows console input mode");
+			}
+		}
+	} catch (error) {
+		const closeDriver = (): void => {
+			consoleDriver?.close();
+			if (rawTerminalOwner === acquisition) rawTerminalOwner = undefined;
+		};
+		try {
+			closeDriver();
+		} catch (closeError) {
+			rawTerminalOwner = { lease: { close: closeDriver } };
+			throw new AggregateError([error, closeError], "Could not adopt and close Windows console input mode");
+		}
+		if (error instanceof RawTerminalCapabilityError) throw error;
+		throw new RawTerminalCapabilityError("Could not read Windows console input mode", error);
+	}
+
+	let rawRestored = false;
+	let flowRestored = false;
+	let consoleRestored = originalConsoleMode === undefined;
+	let driverClosed = originalConsoleMode === undefined;
+	let closed = false;
+	let closing = false;
+	const lease: RawTerminalLease = {
+		close: (): void => {
+			if (closed || closing) return;
+			closing = true;
+			const errors: unknown[] = [];
+			const restore = (complete: () => void, operation: () => void): void => {
+				try {
+					operation();
+					complete();
+				} catch (error) {
+					errors.push(error);
+				}
+			};
+			const restoreFlow = (): void => {
+				if (wasFlowing === true) stdin.resume();
+				else if (wasFlowing === false || wasFlowing === null || wasPaused) stdin.pause();
+				else stdin.resume();
+			};
+			if (!flowRestored) restore(() => (flowRestored = true), restoreFlow);
+			if (!rawRestored)
+				restore(
+					() => (rawRestored = true),
+					() => stdin.setRawMode!(wasRaw),
+				);
+			if (originalConsoleMode !== undefined) {
+				if (rawRestored && !consoleRestored) {
+					restore(
+						() => (consoleRestored = true),
+						() => {
+							if (!consoleDriver!.setInputMode(originalConsoleMode!)) {
+								throw new Error("Could not restore Windows console input mode");
+							}
+						},
+					);
+				}
+				if (rawRestored && consoleRestored && !driverClosed)
+					restore(
+						() => (driverClosed = true),
+						() => consoleDriver!.close(),
+					);
+			}
+			closing = false;
+			if (errors.length > 0)
+				throw errors.length === 1 ? errors[0] : new AggregateError(errors, "Could not restore raw terminal input");
+			closed = true;
+			if (rawTerminalOwner === lease) rawTerminalOwner = undefined;
+		},
+	};
+
+	if (rawTerminalOwner !== acquisition || acquisition.cancelled) throw interruptedAcquisitionError();
+	acquisition.lease = lease;
+	try {
+		stdin.setRawMode(true);
+		if (acquisition.cancelled) throw interruptedAcquisitionError();
+		if (originalConsoleMode !== undefined) {
+			let rawConsoleMode: number | undefined;
+			try {
+				rawConsoleMode = consoleDriver!.getInputMode();
+			} catch (error) {
+				throw new RawTerminalCapabilityError(
+					"Could not read Windows console input mode after enabling raw input",
+					error,
+				);
+			}
+			if (acquisition.cancelled) throw interruptedAcquisitionError();
+			if (rawConsoleMode === undefined)
+				throw new RawTerminalCapabilityError("Could not read Windows console input mode after enabling raw input");
+			const vtInputMode = rawConsoleMode | ENABLE_VIRTUAL_TERMINAL_INPUT;
+			if (vtInputMode !== rawConsoleMode) {
+				if (!consoleDriver!.setInputMode(vtInputMode)) {
+					throw new RawTerminalCapabilityError("Could not enable Windows virtual terminal input");
+				}
+				if (acquisition.cancelled) throw interruptedAcquisitionError();
+			}
+		}
+		stdin.resume();
+		if (acquisition.cancelled) throw interruptedAcquisitionError();
+		rawTerminalOwner = lease;
+		return lease;
+	} catch (error) {
+		try {
+			lease.close();
+		} catch (restorationError) {
+			rawTerminalOwner = { lease };
+			throw new AggregateError([error, restorationError], "Could not acquire and restore raw terminal input");
+		}
+		rawTerminalOwner = undefined;
+		throw error;
+	}
+}

--- a/packages/tui/src/raw-terminal-lease.ts
+++ b/packages/tui/src/raw-terminal-lease.ts
@@ -2,9 +2,12 @@ import { dlopen, FFIType, ptr } from "bun:ffi";
 
 const STD_INPUT_HANDLE = -10;
 const ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200;
+const rawTerminalLeaseRegistrySymbol: unique symbol = Symbol.for("@gajae-code/tui/raw-terminal-lease.registry");
+
 interface AcquiringRawTerminalOwner {
 	acquiring: true;
 	cancelled: boolean;
+	mutationDepth: number;
 	lease?: RawTerminalLease;
 }
 
@@ -17,20 +20,35 @@ interface RestoringRawTerminalOwner {
 	restoring: true;
 }
 
-let rawTerminalOwner:
+type RawTerminalOwner =
 	| RawTerminalLease
 	| AcquiringRawTerminalOwner
 	| PoisonedRawTerminalOwner
-	| RestoringRawTerminalOwner
-	| undefined;
+	| RestoringRawTerminalOwner;
 
-/** Minimal stdin surface needed to temporarily own raw terminal input. */
+interface RawTerminalLeaseRegistry {
+	owners: Map<RawTerminalStdin, RawTerminalOwner>;
+}
+
+type GlobalWithRawTerminalLeaseRegistry = typeof globalThis & {
+	[rawTerminalLeaseRegistrySymbol]?: RawTerminalLeaseRegistry;
+};
+
+/**
+ * Minimal stdin surface needed to temporarily own raw terminal input.
+ *
+ * Boolean `readableFlowing` snapshots are restored with `resume()` or `pause()`.
+ * A `null` or `undefined` snapshot is supported only when
+ * `restoreReadableFlowing` is supplied, because Node's public pause/resume API
+ * cannot recreate either state exactly.
+ */
 export interface RawTerminalStdin {
 	isTTY?: boolean;
 	isRaw?: boolean;
 	setRawMode?: (mode: boolean) => unknown;
-	isPaused: () => boolean;
 	readableFlowing?: boolean | null;
+	/** Recreates a captured `null` or `undefined` flow state after lease close. */
+	restoreReadableFlowing?: (state: null | undefined) => unknown;
 	pause: () => unknown;
 	resume: () => unknown;
 }
@@ -48,22 +66,58 @@ export interface RawTerminalLeaseOptions {
 	consoleDriver?: WindowsConsoleDriver;
 }
 
-/** Owns raw stdin until closed, restoring the exact state observed at acquisition. */
+/** Owns raw stdin until closed, restoring the supported state observed at acquisition. */
 export interface RawTerminalLease {
 	close(): void;
 }
 
+function getRawTerminalLeaseRegistry(): RawTerminalLeaseRegistry {
+	const global = globalThis as GlobalWithRawTerminalLeaseRegistry;
+	let registry = global[rawTerminalLeaseRegistrySymbol];
+	if (!registry) {
+		registry = { owners: new Map() };
+		global[rawTerminalLeaseRegistrySymbol] = registry;
+	}
+	return registry;
+}
+
+function clearRawTerminalOwner(
+	registry: RawTerminalLeaseRegistry,
+	stdin: RawTerminalStdin,
+	owner: RawTerminalOwner,
+): void {
+	if (registry.owners.get(stdin) === owner) registry.owners.delete(stdin);
+}
+
 /**
- * Restore the process-wide raw-terminal owner after an interrupted acquisition
- * or failed rollback. Safe to call repeatedly; failed restoration remains
- * owned so a later emergency cleanup can retry it.
+ * Restore all raw-terminal resources currently owned in this JavaScript realm.
+ * If emergency restoration interrupts an in-flight external mutation, the
+ * acquisition remains owned and completes its rollback after that mutation
+ * returns. Failed restoration remains owned so a later call can retry it.
  */
 export function emergencyRawTerminalRestore(): void {
-	const owner = rawTerminalOwner;
-	if (!owner || isRestoringRawTerminalOwner(owner)) return;
+	const registry = getRawTerminalLeaseRegistry();
+	const errors: unknown[] = [];
+	for (const [stdin, owner] of [...registry.owners]) {
+		try {
+			restoreRawTerminalOwner(registry, stdin, owner);
+		} catch (error) {
+			errors.push(error);
+		}
+	}
+	if (errors.length > 0)
+		throw errors.length === 1 ? errors[0] : new AggregateError(errors, "Could not restore raw terminal input");
+}
+
+function restoreRawTerminalOwner(
+	registry: RawTerminalLeaseRegistry,
+	stdin: RawTerminalStdin,
+	owner: RawTerminalOwner,
+): void {
+	if (registry.owners.get(stdin) !== owner || isRestoringRawTerminalOwner(owner)) return;
 	if (isAcquiringRawTerminalOwner(owner)) {
 		owner.cancelled = true;
-		owner.lease?.close();
+		if (owner.mutationDepth === 0) owner.lease?.close();
 		return;
 	}
 	if (!isPoisonedRawTerminalOwner(owner)) {
@@ -71,14 +125,14 @@ export function emergencyRawTerminalRestore(): void {
 		return;
 	}
 	const restoringOwner: RestoringRawTerminalOwner = { lease: owner.lease, restoring: true };
-	rawTerminalOwner = restoringOwner;
+	registry.owners.set(stdin, restoringOwner);
 	try {
 		owner.lease.close();
 	} catch (error) {
-		if (rawTerminalOwner === restoringOwner) rawTerminalOwner = owner;
+		if (registry.owners.get(stdin) === restoringOwner) registry.owners.set(stdin, owner);
 		throw error;
 	}
-	if (rawTerminalOwner === restoringOwner) rawTerminalOwner = undefined;
+	clearRawTerminalOwner(registry, stdin, restoringOwner);
 }
 
 /** A terminal capability could not be adopted without preserving its cause. */
@@ -120,20 +174,16 @@ function createWindowsConsoleDriver(): WindowsConsoleDriver {
 		throw new RawTerminalCapabilityError("Could not adopt Windows console input mode", error);
 	}
 }
-function isAcquiringRawTerminalOwner(
-	owner: RawTerminalLease | AcquiringRawTerminalOwner | PoisonedRawTerminalOwner | RestoringRawTerminalOwner,
-): owner is AcquiringRawTerminalOwner {
+
+function isAcquiringRawTerminalOwner(owner: RawTerminalOwner): owner is AcquiringRawTerminalOwner {
 	return typeof owner === "object" && "acquiring" in owner;
 }
-function isPoisonedRawTerminalOwner(
-	owner: RawTerminalLease | AcquiringRawTerminalOwner | PoisonedRawTerminalOwner | RestoringRawTerminalOwner,
-): owner is PoisonedRawTerminalOwner {
+
+function isPoisonedRawTerminalOwner(owner: RawTerminalOwner): owner is PoisonedRawTerminalOwner {
 	return typeof owner === "object" && "lease" in owner && !("restoring" in owner);
 }
 
-function isRestoringRawTerminalOwner(
-	owner: RawTerminalLease | AcquiringRawTerminalOwner | PoisonedRawTerminalOwner | RestoringRawTerminalOwner,
-): owner is RestoringRawTerminalOwner {
+function isRestoringRawTerminalOwner(owner: RawTerminalOwner): owner is RestoringRawTerminalOwner {
 	return typeof owner === "object" && "restoring" in owner;
 }
 
@@ -148,29 +198,30 @@ function interruptedAcquisitionError(): RawTerminalCapabilityError {
  * they were before this call.
  */
 export function createRawTerminalLease(options: RawTerminalLeaseOptions = {}): RawTerminalLease {
-	if (rawTerminalOwner && isAcquiringRawTerminalOwner(rawTerminalOwner))
+	const stdin: RawTerminalStdin = options.stdin ?? process.stdin;
+	const platform = options.platform ?? process.platform;
+	const registry = getRawTerminalLeaseRegistry();
+	const currentOwner = registry.owners.get(stdin);
+	if (currentOwner && isAcquiringRawTerminalOwner(currentOwner))
 		throw new Error("Raw terminal input is already owned");
-	if (rawTerminalOwner) {
-		if (!isPoisonedRawTerminalOwner(rawTerminalOwner)) throw new Error("Raw terminal input is already owned");
-		const poisonedOwner = rawTerminalOwner;
-		const recovery = { acquiring: true as const, cancelled: false };
-		rawTerminalOwner = recovery;
+	if (currentOwner) {
+		if (!isPoisonedRawTerminalOwner(currentOwner)) throw new Error("Raw terminal input is already owned");
+		const recovery: AcquiringRawTerminalOwner = { acquiring: true, cancelled: false, mutationDepth: 0 };
+		registry.owners.set(stdin, recovery);
 		try {
-			poisonedOwner.lease.close();
+			currentOwner.lease.close();
 		} catch (error) {
-			if (rawTerminalOwner === recovery) rawTerminalOwner = poisonedOwner;
+			if (registry.owners.get(stdin) === recovery) registry.owners.set(stdin, currentOwner);
 			throw new RawTerminalCapabilityError("Could not restore previously owned raw terminal input", error);
 		}
-		if (rawTerminalOwner === recovery) rawTerminalOwner = undefined;
+		clearRawTerminalOwner(registry, stdin, recovery);
 		if (recovery.cancelled) throw interruptedAcquisitionError();
 	}
-	const acquisition: AcquiringRawTerminalOwner = { acquiring: true, cancelled: false };
-	rawTerminalOwner = acquisition;
-	const stdin = options.stdin ?? process.stdin;
-	const platform = options.platform ?? process.platform;
+
+	const acquisition: AcquiringRawTerminalOwner = { acquiring: true, cancelled: false, mutationDepth: 0 };
+	registry.owners.set(stdin, acquisition);
 	let wasRaw: boolean;
 	let wasFlowing: boolean | null | undefined;
-	let wasPaused: boolean;
 	try {
 		if (!stdin.isTTY || typeof stdin.setRawMode !== "function")
 			throw new RawTerminalCapabilityError("Raw terminal input requires a TTY with setRawMode support");
@@ -178,14 +229,18 @@ export function createRawTerminalLease(options: RawTerminalLeaseOptions = {}): R
 		wasRaw = stdin.isRaw === true;
 		if (acquisition.cancelled) throw interruptedAcquisitionError();
 		wasFlowing = stdin.readableFlowing;
-		if (acquisition.cancelled) throw interruptedAcquisitionError();
-		wasPaused = stdin.isPaused();
+		if (wasFlowing !== true && wasFlowing !== false && typeof stdin.restoreReadableFlowing !== "function") {
+			throw new RawTerminalCapabilityError(
+				"Raw terminal input requires restoreReadableFlowing support for a null or undefined readableFlowing state",
+			);
+		}
 		if (acquisition.cancelled) throw interruptedAcquisitionError();
 	} catch (error) {
-		if (rawTerminalOwner === acquisition) rawTerminalOwner = undefined;
+		clearRawTerminalOwner(registry, stdin, acquisition);
 		if (error instanceof RawTerminalCapabilityError) throw error;
 		throw new RawTerminalCapabilityError("Could not inspect raw terminal input state", error);
 	}
+
 	let consoleDriver: WindowsConsoleDriver | undefined;
 	let originalConsoleMode: number | undefined;
 	try {
@@ -200,12 +255,12 @@ export function createRawTerminalLease(options: RawTerminalLeaseOptions = {}): R
 	} catch (error) {
 		const closeDriver = (): void => {
 			consoleDriver?.close();
-			if (rawTerminalOwner === acquisition) rawTerminalOwner = undefined;
+			clearRawTerminalOwner(registry, stdin, acquisition);
 		};
 		try {
 			closeDriver();
 		} catch (closeError) {
-			rawTerminalOwner = { lease: { close: closeDriver } };
+			registry.owners.set(stdin, { lease: { close: closeDriver } });
 			throw new AggregateError([error, closeError], "Could not adopt and close Windows console input mode");
 		}
 		if (error instanceof RawTerminalCapabilityError) throw error;
@@ -233,8 +288,8 @@ export function createRawTerminalLease(options: RawTerminalLeaseOptions = {}): R
 			};
 			const restoreFlow = (): void => {
 				if (wasFlowing === true) stdin.resume();
-				else if (wasFlowing === false || wasFlowing === null || wasPaused) stdin.pause();
-				else stdin.resume();
+				else if (wasFlowing === false) stdin.pause();
+				else stdin.restoreReadableFlowing!(wasFlowing);
 			};
 			if (!flowRestored) restore(() => (flowRestored = true), restoreFlow);
 			if (!rawRestored)
@@ -263,14 +318,21 @@ export function createRawTerminalLease(options: RawTerminalLeaseOptions = {}): R
 			if (errors.length > 0)
 				throw errors.length === 1 ? errors[0] : new AggregateError(errors, "Could not restore raw terminal input");
 			closed = true;
-			if (rawTerminalOwner === lease) rawTerminalOwner = undefined;
+			clearRawTerminalOwner(registry, stdin, lease);
 		},
 	};
 
-	if (rawTerminalOwner !== acquisition || acquisition.cancelled) throw interruptedAcquisitionError();
 	acquisition.lease = lease;
+	const mutate = (operation: () => void): void => {
+		acquisition.mutationDepth++;
+		try {
+			operation();
+		} finally {
+			acquisition.mutationDepth--;
+		}
+	};
 	try {
-		stdin.setRawMode(true);
+		mutate(() => stdin.setRawMode!(true));
 		if (acquisition.cancelled) throw interruptedAcquisitionError();
 		if (originalConsoleMode !== undefined) {
 			let rawConsoleMode: number | undefined;
@@ -287,24 +349,29 @@ export function createRawTerminalLease(options: RawTerminalLeaseOptions = {}): R
 				throw new RawTerminalCapabilityError("Could not read Windows console input mode after enabling raw input");
 			const vtInputMode = rawConsoleMode | ENABLE_VIRTUAL_TERMINAL_INPUT;
 			if (vtInputMode !== rawConsoleMode) {
-				if (!consoleDriver!.setInputMode(vtInputMode)) {
+				let vtInputEnabled = false;
+				mutate(() => {
+					vtInputEnabled = consoleDriver!.setInputMode(vtInputMode);
+				});
+				if (!vtInputEnabled) {
 					throw new RawTerminalCapabilityError("Could not enable Windows virtual terminal input");
 				}
 				if (acquisition.cancelled) throw interruptedAcquisitionError();
 			}
 		}
-		stdin.resume();
+		mutate(() => stdin.resume());
 		if (acquisition.cancelled) throw interruptedAcquisitionError();
-		rawTerminalOwner = lease;
+		if (registry.owners.get(stdin) !== acquisition) throw interruptedAcquisitionError();
+		registry.owners.set(stdin, lease);
 		return lease;
 	} catch (error) {
 		try {
 			lease.close();
 		} catch (restorationError) {
-			rawTerminalOwner = { lease };
+			if (registry.owners.get(stdin) === acquisition) registry.owners.set(stdin, { lease });
 			throw new AggregateError([error, restorationError], "Could not acquire and restore raw terminal input");
 		}
-		rawTerminalOwner = undefined;
+		clearRawTerminalOwner(registry, stdin, acquisition);
 		throw error;
 	}
 }

--- a/packages/tui/test/terminal-detach.test.ts
+++ b/packages/tui/test/terminal-detach.test.ts
@@ -126,7 +126,11 @@ async function settle(): Promise<void> {
 	await new Promise<void>(resolve => process.nextTick(resolve));
 	await Bun.sleep(25);
 }
-function createRawStdin(raw: boolean, flowing: boolean | null, paused: boolean): {
+function createRawStdin(
+	raw: boolean,
+	flowing: boolean | null,
+	paused: boolean,
+): {
 	stdin: RawTerminalStdin;
 	state: { raw: boolean; flowing: boolean | null; paused: boolean };
 	calls: string[];
@@ -349,7 +353,7 @@ describe("raw terminal lease", () => {
 		);
 
 		expect(state).toEqual({ raw: false, flowing: false, paused: true });
-		expect(calls).toEqual(["raw:true", "resume", "pause", "raw:false"]);
+		expect(calls).toEqual(["raw:true", "pause", "raw:false"]);
 		expect(mode).toBe(0x0011);
 		expect(modeWrites).toEqual([0x0211, 0x0011]);
 		expect(driverClosed).toBe(true);

--- a/packages/tui/test/terminal-detach.test.ts
+++ b/packages/tui/test/terminal-detach.test.ts
@@ -7,6 +7,9 @@ import {
 } from "@gajae-code/tui";
 import { ProcessTerminal, type Terminal, type TerminalAppearance } from "@gajae-code/tui/terminal";
 import { type Component, CURSOR_MARKER, TUI } from "@gajae-code/tui/tui";
+// Bun gives this query-qualified URL a second ESM module record.
+// @ts-expect-error TypeScript does not model Bun's query-qualified source URLs.
+import * as duplicateRawTerminalLease from "../src/raw-terminal-lease.ts?duplicate-module";
 
 class StaticComponent implements Component {
 	#line: string;
@@ -126,45 +129,57 @@ async function settle(): Promise<void> {
 	await new Promise<void>(resolve => process.nextTick(resolve));
 	await Bun.sleep(25);
 }
+type ReadableFlowingState = boolean | null | undefined;
+
+interface RawStdinOptions {
+	restoreReadableFlowing?: boolean;
+	beforeSetRawMode?: (mode: boolean) => void;
+}
+
 function createRawStdin(
 	raw: boolean,
-	flowing: boolean | null,
+	flowing: ReadableFlowingState,
 	paused: boolean,
+	options: RawStdinOptions = {},
 ): {
 	stdin: RawTerminalStdin;
-	state: { raw: boolean; flowing: boolean | null; paused: boolean };
+	state: { raw: boolean; flowing: ReadableFlowingState; paused: boolean };
 	calls: string[];
 } {
 	const state = { raw, flowing, paused };
 	const calls: string[] = [];
-	return {
-		stdin: {
-			isTTY: true,
-			get isRaw(): boolean {
-				return state.raw;
-			},
-			setRawMode: (mode: boolean): void => {
-				calls.push(`raw:${mode}`);
-				state.raw = mode;
-			},
-			isPaused: (): boolean => state.paused,
-			get readableFlowing(): boolean | null {
-				return state.flowing;
-			},
-			pause: (): void => {
-				calls.push("pause");
-				state.flowing = false;
-				state.paused = true;
-			},
-			resume: (): void => {
-				calls.push("resume");
-				state.flowing = true;
-				state.paused = false;
-			},
+	const stdin: RawTerminalStdin = {
+		isTTY: true,
+		get isRaw(): boolean {
+			return state.raw;
 		},
-		state,
-		calls,
+		setRawMode: (mode: boolean): void => {
+			options.beforeSetRawMode?.(mode);
+			calls.push(`raw:${mode}`);
+			state.raw = mode;
+		},
+		get readableFlowing(): ReadableFlowingState {
+			return state.flowing;
+		},
+		pause: (): void => {
+			calls.push("pause");
+			state.flowing = false;
+			state.paused = true;
+		},
+		resume: (): void => {
+			calls.push("resume");
+			state.flowing = true;
+			state.paused = false;
+		},
 	};
+	if (options.restoreReadableFlowing) {
+		stdin.restoreReadableFlowing = (stateToRestore: null | undefined): void => {
+			calls.push(`restore-flow:${String(stateToRestore)}`);
+			state.flowing = stateToRestore;
+			state.paused = paused;
+		};
+	}
+	return { stdin, state, calls };
 }
 
 function withStdoutProperty<T>(
@@ -318,16 +333,101 @@ describe("terminal detach handling", () => {
 });
 
 describe("raw terminal lease", () => {
-	it("restores the exact raw and flow state only once", () => {
-		const { stdin, state, calls } = createRawStdin(false, false, true);
-		const lease = createRawTerminalLease({ stdin, platform: "linux" });
+	it("restores boolean flow snapshots and closes idempotently", () => {
+		const cases = [
+			{ flowing: true, paused: false, calls: ["raw:true", "resume", "resume", "raw:false"] },
+			{ flowing: false, paused: true, calls: ["raw:true", "resume", "pause", "raw:false"] },
+		] as const;
+		for (const testCase of cases) {
+			const { stdin, state, calls } = createRawStdin(false, testCase.flowing, testCase.paused);
+			const lease = createRawTerminalLease({ stdin, platform: "linux" });
 
-		expect(state).toEqual({ raw: true, flowing: true, paused: false });
-		lease.close();
-		lease.close();
+			expect(state).toEqual({ raw: true, flowing: true, paused: false });
+			lease.close();
+			lease.close();
 
+			expect(state).toEqual({ raw: false, flowing: testCase.flowing, paused: testCase.paused });
+			expect(calls).toEqual([...testCase.calls]);
+		}
+	});
+
+	it("restores null and undefined flow snapshots through an explicit seam", () => {
+		const cases: { flowing: null | undefined; label: string }[] = [
+			{ flowing: null, label: "null" },
+			{ flowing: undefined, label: "undefined" },
+		];
+		for (const testCase of cases) {
+			const { stdin, state, calls } = createRawStdin(false, testCase.flowing, false, {
+				restoreReadableFlowing: true,
+			});
+			const lease = createRawTerminalLease({ stdin, platform: "linux" });
+
+			expect(state).toEqual({ raw: true, flowing: true, paused: false });
+			lease.close();
+
+			expect(state).toEqual({ raw: false, flowing: testCase.flowing, paused: false });
+			expect(calls).toEqual(["raw:true", "resume", `restore-flow:${testCase.label}`, "raw:false"]);
+		}
+	});
+
+	it("rejects null and undefined flow snapshots without a restoration seam", () => {
+		for (const flowing of [null, undefined] as const) {
+			const { stdin, state, calls } = createRawStdin(false, flowing, false);
+
+			expect(() => createRawTerminalLease({ stdin, platform: "linux" })).toThrow(
+				"requires restoreReadableFlowing support",
+			);
+			expect(state).toEqual({ raw: false, flowing, paused: false });
+			expect(calls).toEqual([]);
+		}
+	});
+
+	it("defers reentrant emergency cleanup until raw-mode enable commits", () => {
+		let restoreRequested = true;
+		const { stdin, state, calls } = createRawStdin(false, false, true, {
+			beforeSetRawMode: (mode: boolean): void => {
+				if (mode && restoreRequested) emergencyRawTerminalRestore();
+			},
+		});
+
+		expect(() => createRawTerminalLease({ stdin, platform: "linux" })).toThrow(
+			"Raw terminal input acquisition was interrupted",
+		);
 		expect(state).toEqual({ raw: false, flowing: false, paused: true });
-		expect(calls).toEqual(["raw:true", "resume", "pause", "raw:false"]);
+		expect(calls).toEqual(["raw:true", "pause", "raw:false"]);
+
+		restoreRequested = false;
+		const successor = createRawTerminalLease({ stdin, platform: "linux" });
+		successor.close();
+	});
+
+	it("shares a resource owner across duplicate module records while keeping resources independent", () => {
+		const first = createRawStdin(false, false, true);
+		const second = createRawStdin(false, false, true);
+		const firstLease = createRawTerminalLease({ stdin: first.stdin, platform: "linux" });
+		const secondLease = duplicateRawTerminalLease.createRawTerminalLease({
+			stdin: second.stdin,
+			platform: "linux",
+		});
+
+		expect(() => duplicateRawTerminalLease.createRawTerminalLease({ stdin: first.stdin, platform: "linux" })).toThrow(
+			"Raw terminal input is already owned",
+		);
+		expect(() => createRawTerminalLease({ stdin: second.stdin, platform: "linux" })).toThrow(
+			"Raw terminal input is already owned",
+		);
+
+		firstLease.close();
+		expect(first.state).toEqual({ raw: false, flowing: false, paused: true });
+		expect(second.state).toEqual({ raw: true, flowing: true, paused: false });
+
+		const firstSuccessor = duplicateRawTerminalLease.createRawTerminalLease({
+			stdin: first.stdin,
+			platform: "linux",
+		});
+		firstSuccessor.close();
+		secondLease.close();
+		expect(second.state).toEqual({ raw: false, flowing: false, paused: true });
 	});
 
 	it("rolls back stdin and console mode when Windows VT adoption fails", () => {
@@ -358,10 +458,7 @@ describe("raw terminal lease", () => {
 		expect(modeWrites).toEqual([0x0211, 0x0011]);
 		expect(driverClosed).toBe(true);
 
-		const successor = createRawTerminalLease({
-			stdin: createRawStdin(false, false, true).stdin,
-			platform: "linux",
-		});
+		const successor = createRawTerminalLease({ stdin, platform: "linux" });
 		successor.close();
 	});
 
@@ -398,7 +495,7 @@ describe("raw terminal lease", () => {
 		expect(driverClosed).toBe(true);
 	});
 
-	it("retries emergency restoration after a partial close failure", () => {
+	it("retries emergency restoration after a partial raw-mode close failure", () => {
 		const { stdin, state } = createRawStdin(false, false, true);
 		const setRawMode = stdin.setRawMode!;
 		let rawRestoreFailures = 1;
@@ -413,10 +510,46 @@ describe("raw terminal lease", () => {
 		emergencyRawTerminalRestore();
 
 		expect(state).toEqual({ raw: false, flowing: false, paused: true });
-		const successor = createRawTerminalLease({
-			stdin: createRawStdin(false, false, true).stdin,
-			platform: "linux",
-		});
+		const successor = createRawTerminalLease({ stdin, platform: "linux" });
 		successor.close();
+	});
+
+	it("retries emergency Windows console restoration after a close failure", () => {
+		const { stdin, state } = createRawStdin(false, false, true);
+		const originalConsoleMode = 0x0011;
+		let mode = originalConsoleMode;
+		let consoleRestoreFailures = 1;
+		let driverClosed = false;
+		const modeWrites: number[] = [];
+		const consoleDriver: WindowsConsoleDriver = {
+			getInputMode: (): number => mode,
+			setInputMode: (nextMode: number): boolean => {
+				modeWrites.push(nextMode);
+				if (nextMode === originalConsoleMode && consoleRestoreFailures-- > 0) return false;
+				mode = nextMode;
+				return true;
+			},
+			close: (): void => {
+				driverClosed = true;
+			},
+		};
+		const setRawMode = stdin.setRawMode!;
+		stdin.setRawMode = (nextRaw: boolean): void => {
+			setRawMode(nextRaw);
+			if (nextRaw) mode = 0x0001;
+		};
+
+		const lease = createRawTerminalLease({ stdin, platform: "win32", consoleDriver });
+		expect(() => lease.close()).toThrow("Could not restore Windows console input mode");
+		expect(state).toEqual({ raw: false, flowing: false, paused: true });
+		expect(mode).toBe(0x0201);
+		expect(driverClosed).toBe(false);
+
+		emergencyRawTerminalRestore();
+		emergencyRawTerminalRestore();
+
+		expect(mode).toBe(originalConsoleMode);
+		expect(modeWrites).toEqual([0x0201, originalConsoleMode, originalConsoleMode]);
+		expect(driverClosed).toBe(true);
 	});
 });

--- a/packages/tui/test/terminal-detach.test.ts
+++ b/packages/tui/test/terminal-detach.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, it, vi } from "bun:test";
+import {
+	createRawTerminalLease,
+	emergencyRawTerminalRestore,
+	type RawTerminalStdin,
+	type WindowsConsoleDriver,
+} from "@gajae-code/tui";
 import { ProcessTerminal, type Terminal, type TerminalAppearance } from "@gajae-code/tui/terminal";
 import { type Component, CURSOR_MARKER, TUI } from "@gajae-code/tui/tui";
 
@@ -119,6 +125,42 @@ class DetachingTerminal implements Terminal {
 async function settle(): Promise<void> {
 	await new Promise<void>(resolve => process.nextTick(resolve));
 	await Bun.sleep(25);
+}
+function createRawStdin(raw: boolean, flowing: boolean | null, paused: boolean): {
+	stdin: RawTerminalStdin;
+	state: { raw: boolean; flowing: boolean | null; paused: boolean };
+	calls: string[];
+} {
+	const state = { raw, flowing, paused };
+	const calls: string[] = [];
+	return {
+		stdin: {
+			isTTY: true,
+			get isRaw(): boolean {
+				return state.raw;
+			},
+			setRawMode: (mode: boolean): void => {
+				calls.push(`raw:${mode}`);
+				state.raw = mode;
+			},
+			isPaused: (): boolean => state.paused,
+			get readableFlowing(): boolean | null {
+				return state.flowing;
+			},
+			pause: (): void => {
+				calls.push("pause");
+				state.flowing = false;
+				state.paused = true;
+			},
+			resume: (): void => {
+				calls.push("resume");
+				state.flowing = true;
+				state.paused = false;
+			},
+		},
+		state,
+		calls,
+	};
 }
 
 function withStdoutProperty<T>(
@@ -268,5 +310,109 @@ describe("terminal detach handling", () => {
 		expect(() => tui.requestRender(true)).not.toThrow();
 		await settle();
 		expect(terminal.writes.length).toBe(writesBeforeCursorFailure);
+	});
+});
+
+describe("raw terminal lease", () => {
+	it("restores the exact raw and flow state only once", () => {
+		const { stdin, state, calls } = createRawStdin(false, false, true);
+		const lease = createRawTerminalLease({ stdin, platform: "linux" });
+
+		expect(state).toEqual({ raw: true, flowing: true, paused: false });
+		lease.close();
+		lease.close();
+
+		expect(state).toEqual({ raw: false, flowing: false, paused: true });
+		expect(calls).toEqual(["raw:true", "resume", "pause", "raw:false"]);
+	});
+
+	it("rolls back stdin and console mode when Windows VT adoption fails", () => {
+		const { stdin, state, calls } = createRawStdin(false, false, true);
+		let mode = 0x0011;
+		let driverClosed = false;
+		const modeWrites: number[] = [];
+		const consoleDriver: WindowsConsoleDriver = {
+			getInputMode: (): number => mode,
+			setInputMode: (nextMode: number): boolean => {
+				modeWrites.push(nextMode);
+				if (nextMode === 0x0211) return false;
+				mode = nextMode;
+				return true;
+			},
+			close: (): void => {
+				driverClosed = true;
+			},
+		};
+
+		expect(() => createRawTerminalLease({ stdin, platform: "win32", consoleDriver })).toThrow(
+			"Could not enable Windows virtual terminal input",
+		);
+
+		expect(state).toEqual({ raw: false, flowing: false, paused: true });
+		expect(calls).toEqual(["raw:true", "resume", "pause", "raw:false"]);
+		expect(mode).toBe(0x0011);
+		expect(modeWrites).toEqual([0x0211, 0x0011]);
+		expect(driverClosed).toBe(true);
+
+		const successor = createRawTerminalLease({
+			stdin: createRawStdin(false, false, true).stdin,
+			platform: "linux",
+		});
+		successor.close();
+	});
+
+	it("enables Windows VT input and restores the original console mode", () => {
+		const { stdin, state } = createRawStdin(false, false, true);
+		let mode = 0x0011;
+		let driverClosed = false;
+		const modeWrites: number[] = [];
+		const consoleDriver: WindowsConsoleDriver = {
+			getInputMode: (): number => mode,
+			setInputMode: (nextMode: number): boolean => {
+				modeWrites.push(nextMode);
+				mode = nextMode;
+				return true;
+			},
+			close: (): void => {
+				driverClosed = true;
+			},
+		};
+		const originalSetRawMode = stdin.setRawMode!;
+		stdin.setRawMode = (nextRaw: boolean): void => {
+			originalSetRawMode(nextRaw);
+			if (nextRaw) mode = 0x0001;
+		};
+
+		const lease = createRawTerminalLease({ stdin, platform: "win32", consoleDriver });
+		expect(modeWrites).toEqual([0x0201]);
+
+		lease.close();
+
+		expect(state).toEqual({ raw: false, flowing: false, paused: true });
+		expect(mode).toBe(0x0011);
+		expect(modeWrites).toEqual([0x0201, 0x0011]);
+		expect(driverClosed).toBe(true);
+	});
+
+	it("retries emergency restoration after a partial close failure", () => {
+		const { stdin, state } = createRawStdin(false, false, true);
+		const setRawMode = stdin.setRawMode!;
+		let rawRestoreFailures = 1;
+		stdin.setRawMode = (mode: boolean): void => {
+			if (!mode && rawRestoreFailures-- > 0) throw new Error("raw restore failed");
+			setRawMode(mode);
+		};
+
+		const lease = createRawTerminalLease({ stdin, platform: "linux" });
+		expect(() => lease.close()).toThrow("raw restore failed");
+
+		emergencyRawTerminalRestore();
+
+		expect(state).toEqual({ raw: false, flowing: false, paused: true });
+		const successor = createRawTerminalLease({
+			stdin: createRawStdin(false, false, true).stdin,
+			platform: "linux",
+		});
+		successor.close();
 	});
 });


### PR DESCRIPTION
## What

- Publish `createRawTerminalLease` and its public types from the `@gajae-code/tui` root.
- Adopt raw stdin and Windows VT input transactionally.
- Restore the exact prior raw, flow, and console state with idempotent close and emergency retry semantics.
- Add focused public-API lifecycle tests.

## Why

Cross-package terminal attachment needs a supported ownership API instead of reaching into TUI internals.

## Testing

Verification is intentionally deferred while the remaining small PR slices are extracted. The focused commands for this PR are:

- `bun test packages/tui/test/terminal-detach.test.ts`
- `bun --cwd=packages/tui run check`
- `bun run check:publish-types`
- `bun run check:ts`
- `git diff --check`

## Reviewer note

Thank you for reviewing this narrowly scoped terminal-ownership API. The most useful review areas are exact state restoration, idempotent cleanup, Windows console-mode rollback, and the root export boundary. Visible-session attach behavior is intentionally excluded.

## Rollback

This API can be reverted before dependent attach PRs are merged. It does not migrate persistent data.
