### PR TITLE
fix(notifications): safely reap orphan Telegram topics

### DIFF
--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -4,7 +4,7 @@ import { isEnoent } from "@gajae-code/utils/fs-error";
 
 export interface FileLockOptions {
 	staleMs?: number;
-	retries?: number;
+	retries?: number | "forever";
 	retryDelayMs?: number;
 }
 
@@ -192,8 +192,10 @@ async function releaseLock(lockPath: string, owner: FileLockOwnerToken): Promise
 async function acquireLock(filePath: string, options: FileLockOptions = {}): Promise<() => Promise<void>> {
 	const opts = { ...DEFAULT_OPTIONS, ...options };
 	const lockPath = getLockPath(filePath);
+	const retries = opts.retries;
+	const maxAttempts = retries === "forever" ? Infinity : retries;
 
-	for (let attempt = 0; attempt < opts.retries; attempt++) {
+	for (let attempt = 0; attempt < maxAttempts; attempt++) {
 		const owner = await tryAcquireLock(lockPath);
 		if (owner) {
 			return () => releaseLock(lockPath, owner);

--- a/packages/coding-agent/src/notifications/index.ts
+++ b/packages/coding-agent/src/notifications/index.ts
@@ -55,7 +55,7 @@ import {
 	sessionTag,
 } from "./config";
 import { imageAttachmentsFromMessage, notificationActionPayload, summaryFromMessage } from "./helpers";
-import { ensureTelegramDaemonRunning } from "./telegram-daemon";
+import { ensureTelegramDaemonRunning, type EnsureDaemonResult } from "./telegram-daemon";
 
 // ===========================================================================
 // Session lifecycle control protocol (TypeScript mirror of the Rust wire
@@ -1259,6 +1259,28 @@ export function createNotificationsExtension(api: ExtensionAPI, options: { setti
 		});
 
 		try {
+			// Configured-Telegram session: a fresh daemon registration MUST succeed
+			// before this session publishes an endpoint, registers its answer source,
+			// or pins its identity header. Only `owner_spawned` / `attached` are
+			// success; `blocked`, `disabled`, a thrown registration/lock/state error,
+			// or any other result would leave the session orphaned/mis-routed, so emit
+			// the bounded diagnostic and fail before any publication. Non-Telegram
+			// sessions skip this gate entirely.
+			if (settingsAvailable && settings && isTelegramConfigured(cfg)) {
+				let daemonResult: EnsureDaemonResult;
+				try {
+					daemonResult = await ensureTelegramDaemonRunning({ settings, cwd: ctx.cwd, sessionId: id });
+				} catch (e) {
+					logger.warn(`notifications: Telegram daemon registration failed: ${String(e)}`);
+					return "failed";
+				}
+				if (daemonResult !== "owner_spawned" && daemonResult !== "attached") {
+					logger.warn(
+						`notifications: Telegram daemon registration ${daemonResult}; not publishing session endpoint`,
+					);
+					return "failed";
+				}
+			}
 			const endpoint = await server.start();
 
 			// Interactive answer source: the ask tool races the local UI against this.
@@ -1323,14 +1345,6 @@ export function createNotificationsExtension(api: ExtensionAPI, options: { setti
 				await stopSession(id);
 			});
 			logger.info(`notifications: serving session ${id} at ${endpoint.url}`);
-
-			if (settingsAvailable && settings && isTelegramConfigured(cfg)) {
-				try {
-					await ensureTelegramDaemonRunning({ settings, cwd: ctx.cwd, sessionId: id });
-				} catch (e) {
-					logger.warn(`notifications: failed to ensure Telegram daemon: ${String(e)}`);
-				}
-			}
 
 			// One-time identity header (repo/branch/machine/session) pinned at the top
 			// of the session thread by the daemon.

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -311,34 +311,333 @@ async function tryOpenWx(fsImpl: TelegramDaemonFs, file: string): Promise<boolea
 		throw error;
 	}
 }
+/**
+ * Per-session registration lease. Refreshed with a fresh random `leaseId` on
+ * every {@link registerNotificationRoot} so a same-session re-registration
+ * invalidates any deletion proof an older registration established. The daemon
+ * never reaps a topic whose candidate lease no longer matches the live lease.
+ */
+interface SessionLease {
+	leaseId: string;
+	refreshedAt: number;
+}
+
+/**
+ * Per-session orphan-topic deletion candidate. Created on the first confirmed
+ * continuous absence; a topic is reaped only once this candidate has itself
+ * survived {@link ORPHAN_TOPIC_GRACE_MS} AND its lease still matches the live
+ * session lease (no intervening registration/publication).
+ */
+interface OrphanCandidate {
+	observedAt: number;
+	leaseId: string;
+	topicId: string;
+}
+
+/**
+ * Validated, decision-only view over the raw notification-roots registry. The
+ * raw object is carried verbatim through every read-modify-write so unknown,
+ * legacy, or unrelated fields survive; only strictly-valid entries populate the
+ * decision maps — ambiguous/malformed/legacy state never authorizes deletion.
+ */
+interface RootsRegistryView {
+	raw: Record<string, unknown>;
+	roots: string[];
+	sessions: Map<string, string>;
+	sessionLeases: Map<string, SessionLease>;
+	orphanCandidates: Map<string, OrphanCandidate>;
+}
+
+/** Non-empty string scalar: every registry id (leaseId, map key) must be one. */
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0;
+}
+
+/** Non-negative safe integer scalar: every registry timestamp must be one. */
+function isNonNegativeSafeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+/**
+ * Canonical positive safe-integer string scalar: every candidate topicId must be
+ * one. Rejects zero, negatives, fractions, leading zeros, whitespace, exponents,
+ * and any non-digit, so a malformed candidate id can never match a live topic
+ * record and authorize a destructive delete.
+ */
+function isCanonicalTopicId(value: unknown): value is string {
+	if (typeof value !== "string") return false;
+	if (!/^[1-9][0-9]*$/.test(value)) return false;
+	return Number.isSafeInteger(Number(value));
+}
+
+function parseRootsList(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const roots: string[] = [];
+	for (const entry of value) {
+		if (typeof entry === "string" && entry.length > 0) roots.push(entry);
+	}
+	return roots;
+}
+
+function parseStringMap(value: unknown): Map<string, string> {
+	const map = new Map<string, string>();
+	if (!value || typeof value !== "object" || Array.isArray(value)) return map;
+	for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+		if (typeof key === "string" && key.length > 0 && typeof val === "string") map.set(key, val);
+	}
+	return map;
+}
+
+function parseSessionLeases(value: unknown): Map<string, SessionLease> {
+	const map = new Map<string, SessionLease>();
+	if (!value || typeof value !== "object" || Array.isArray(value)) return map;
+	for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+		if (!isNonEmptyString(key) || !val || typeof val !== "object" || Array.isArray(val))
+			continue;
+		const lease = val as { leaseId?: unknown; refreshedAt?: unknown };
+		if (!isNonEmptyString(lease.leaseId) || !isNonNegativeSafeInteger(lease.refreshedAt)) continue;
+		map.set(key, { leaseId: lease.leaseId, refreshedAt: lease.refreshedAt });
+	}
+	return map;
+}
+
+function parseOrphanCandidates(value: unknown): Map<string, OrphanCandidate> {
+	const map = new Map<string, OrphanCandidate>();
+	if (!value || typeof value !== "object" || Array.isArray(value)) return map;
+	for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+		if (!isNonEmptyString(key) || !val || typeof val !== "object" || Array.isArray(val))
+			continue;
+		const candidate = val as { observedAt?: unknown; leaseId?: unknown; topicId?: unknown };
+		if (
+			!isNonNegativeSafeInteger(candidate.observedAt) ||
+			!isNonEmptyString(candidate.leaseId) ||
+			!isCanonicalTopicId(candidate.topicId)
+		)
+			continue;
+		map.set(key, {
+			observedAt: candidate.observedAt,
+			leaseId: candidate.leaseId,
+			topicId: candidate.topicId,
+		});
+	}
+	return map;
+}
+
+async function readRootsRegistry(fsImpl: TelegramDaemonFs, rootsFile: string): Promise<RootsRegistryView> {
+	const parsed = await readJson<unknown>(fsImpl, rootsFile);
+	const raw: Record<string, unknown> =
+		parsed && typeof parsed === "object" ? { ...(parsed as Record<string, unknown>) } : {};
+	return {
+		raw,
+		roots: parseRootsList(raw.roots),
+		sessions: parseStringMap(raw.sessions),
+		sessionLeases: parseSessionLeases(raw.sessionLeases),
+		orphanCandidates: parseOrphanCandidates(raw.orphanCandidates),
+	};
+}
+
+/**
+ * Persist the raw roots registry verbatim; only the schema `version` is
+ * normalized. Every other key — known or unknown, well-formed or legacy — is
+ * carried through untouched. Known maps are never rebuilt here: callers patch
+ * the raw object per exact changed session (see the raw* helpers) so malformed
+ * and unrelated entries inside those maps survive every write.
+ */
+async function persistRootsRegistry(fsImpl: TelegramDaemonFs, rootsFile: string, raw: Record<string, unknown>): Promise<void> {
+	raw.version = 1;
+	await writeJsonAtomic(fsImpl, rootsFile, raw);
+}
+
+/**
+ * Return the raw object held at `key`, or a fresh object when the field is
+ * absent or not a plain object. The returned map is the live raw field, so
+ * callers mutate it in place and reassign it (a freshly-created map is recorded
+ * on reassignment). Known maps are patched per exact session, never normalized,
+ * so malformed/unknown entries inside them are preserved across every patch.
+ */
+function rawObjectField(raw: Record<string, unknown>, key: string): Record<string, unknown> {
+	const existing = raw[key];
+	if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+		return existing as Record<string, unknown>;
+	}
+	return {};
+}
+
+function setRawSessionMapping(raw: Record<string, unknown>, sessionId: string, root: string): void {
+	const map = rawObjectField(raw, "sessions");
+	map[sessionId] = root;
+	raw.sessions = map;
+}
+
+function deleteRawSessionMapping(raw: Record<string, unknown>, sessionId: string): boolean {
+	const map = rawObjectField(raw, "sessions");
+	if (!(sessionId in map)) return false;
+	delete map[sessionId];
+	raw.sessions = map;
+	return true;
+}
+
+function setRawLease(raw: Record<string, unknown>, sessionId: string, lease: SessionLease): void {
+	const map = rawObjectField(raw, "sessionLeases");
+	map[sessionId] = { leaseId: lease.leaseId, refreshedAt: lease.refreshedAt };
+	raw.sessionLeases = map;
+}
+
+function deleteRawLease(raw: Record<string, unknown>, sessionId: string): boolean {
+	const map = rawObjectField(raw, "sessionLeases");
+	if (!(sessionId in map)) return false;
+	delete map[sessionId];
+	raw.sessionLeases = map;
+	return true;
+}
+
+function setRawCandidate(raw: Record<string, unknown>, sessionId: string, candidate: OrphanCandidate): void {
+	const map = rawObjectField(raw, "orphanCandidates");
+	map[sessionId] = {
+		observedAt: candidate.observedAt,
+		leaseId: candidate.leaseId,
+		topicId: candidate.topicId,
+	};
+	raw.orphanCandidates = map;
+}
+
+function deleteRawCandidate(raw: Record<string, unknown>, sessionId: string): boolean {
+	const map = rawObjectField(raw, "orphanCandidates");
+	if (!(sessionId in map)) return false;
+	delete map[sessionId];
+	raw.orphanCandidates = map;
+	return true;
+}
+
+/** Append `root` unless already present, preserving every existing entry (incl. malformed). */
+function addRawRoot(raw: Record<string, unknown>, root: string): void {
+	const existing = raw.roots;
+	const arr = Array.isArray(existing) ? existing : [];
+	if (arr.indexOf(root) !== -1) return;
+	const next = arr.slice();
+	next.push(root);
+	raw.roots = next;
+}
+
+/** Remove exactly the `root` string, preserving every other entry (incl. malformed). */
+function removeRawRoot(raw: Record<string, unknown>, root: string): boolean {
+	const existing = raw.roots;
+	if (!Array.isArray(existing)) return false;
+	const idx = existing.indexOf(root);
+	if (idx === -1) return false;
+	const next = existing.slice();
+	next.splice(idx, 1);
+	raw.roots = next;
+	return true;
+}
+
+/** Whether any recognizable (string -> string) raw session mapping references `root`. */
+function rawRootReferenced(raw: Record<string, unknown>, root: string): boolean {
+	const map = rawObjectField(raw, "sessions");
+	for (const val of Object.values(map)) {
+		if (typeof val === "string" && val === root) return true;
+	}
+	return false;
+}
+
+
+/**
+ * Serialize notification-roots registry mutations with an opt-in forever wait.
+ * The daemon's destructive orphan-topic delete transaction holds this lock for
+ * its whole duration — including the remote Telegram call — so an in-flight
+ * deletion cannot race a fresh registration (and the endpoint publication it
+ * gates). Only this module opts into the forever wait; a wedged delete defers
+ * configured Telegram startup rather than deleting a newly-live session topic.
+ */
+function withRootsLock<T>(fsImpl: TelegramDaemonFs, rootsFile: string, fn: () => Promise<T>): Promise<T> {
+	return withFileLock(rootsFile, fn, { retries: "forever", staleMs: 10_000 });
+}
+
+/** Classified readability of a single session endpoint discovery file. */
+type EndpointEvidence =
+	| { kind: "live"; url: string; token: string }
+	| { kind: "stale"; url: string; token: string }
+	| { kind: "dead"; url: string; token: string }
+	| { kind: "malformed" };
+/**
+ * Readability of a notification root's `notifications/` directory.
+ * - `readable`: enumerated successfully.
+ * - `missing`: confirmed gone (ENOENT) — its sessions' absence is authoritative.
+ * - `ambiguous`: permission/IO error — absence is indeterminate, so fail closed.
+ */
+type RootReadStatus = "readable" | "missing" | "ambiguous";
+
+
+function classifyEndpointEvidence(
+	endpoint: { url: string; token: string; pid?: number; stale?: boolean },
+	pidAlive: (pid: number) => boolean,
+): EndpointEvidence {
+	if (endpoint.stale) return { kind: "stale", url: endpoint.url, token: endpoint.token };
+	if (endpoint.pid !== undefined && !pidAlive(endpoint.pid))
+		return { kind: "dead", url: endpoint.url, token: endpoint.token };
+	return { kind: "live", url: endpoint.url, token: endpoint.token };
+}
+
+/** Protective evidence (live or malformed/indeterminate) must never authorize deletion. */
+function endpointEvidenceIsProtective(ev: EndpointEvidence): boolean {
+	return ev.kind === "live" || ev.kind === "malformed";
+}
+
+/**
+ * Merge endpoint evidence for a session across roots. Protective readings win
+ * unconditionally: a live or malformed endpoint anywhere protects the session,
+ * so a stale/dead file in another root can never clobber a live duplicate.
+ */
+function mergeEndpointEvidence(map: Map<string, EndpointEvidence>, sessionId: string, next: EndpointEvidence): void {
+	const prev = map.get(sessionId);
+	if (!prev) {
+		map.set(sessionId, next);
+		return;
+	}
+	if (endpointEvidenceIsProtective(prev)) return;
+	if (endpointEvidenceIsProtective(next)) map.set(sessionId, next);
+}
+
 
 export async function registerNotificationRoot(input: {
 	settings: Settings;
 	cwd: string;
 	sessionId: string;
 	fs?: TelegramDaemonFs;
+	/** Clock used for lease timestamps; defaults to wall time. */
+	now?: () => number;
+	/** Random lease-id factory; defaults to a process-unique value. */
+	randomId?: () => string;
 }): Promise<string> {
 	const fsImpl = input.fs ?? nodeFs;
 	const paths = daemonPaths(input.settings.getAgentDir());
 	await ensureDir(fsImpl, paths.dir);
 	const root = notificationRootForCwd(input.cwd);
-	await withFileLock(
-		paths.roots,
-		async () => {
-			const current =
-				(await readJson<{ roots?: string[]; sessions?: Record<string, string> }>(fsImpl, paths.roots)) ?? {};
-			const roots = new Set(current.roots ?? []);
-			roots.add(root);
-			await writeJsonAtomic(fsImpl, paths.roots, {
-				version: 1,
-				roots: Array.from(roots).sort(),
-				sessions: { ...(current.sessions ?? {}), [input.sessionId]: root },
-			});
-		},
-		{ staleMs: 10_000 },
-	);
+	const now = input.now ?? Date.now;
+	const randomId = input.randomId ?? defaultRootsLeaseId;
+	// Registration completes before any endpoint publication: it is the first
+	// writer of the session lease, and it clears any orphan candidate so a
+	// re-registering session is never reaped from stale absence proof. The
+	// forever roots lock serializes this against an in-flight daemon delete.
+	await withRootsLock(fsImpl, paths.roots, async () => {
+		const view = await readRootsRegistry(fsImpl, paths.roots);
+		const raw = view.raw;
+		// Patch the raw registry per exact changed session; malformed/unknown
+		// entries inside the known maps are preserved (never normalized).
+		addRawRoot(raw, root);
+		setRawSessionMapping(raw, input.sessionId, root);
+		setRawLease(raw, input.sessionId, { leaseId: randomId(), refreshedAt: now() });
+		deleteRawCandidate(raw, input.sessionId);
+		await persistRootsRegistry(fsImpl, paths.roots, raw);
+	});
+
 	return root;
 }
+
+function defaultRootsLeaseId(): string {
+	return `${process.pid}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
 
 function notificationRootForCwd(cwd: string): string {
 	return path.join(cwd, ".gjc", "state");
@@ -694,6 +993,7 @@ export async function ensureTelegramDaemonRunning(
 ): Promise<EnsureDaemonResult> {
 	const cfg = getNotificationConfig(input.settings);
 	if (!isTelegramConfigured(cfg)) return "disabled";
+	await registerNotificationRoot({ ...input, fs: deps.fs });
 	const root = notificationRootForCwd(input.cwd);
 	const fp = tokenFingerprint(cfg.botToken);
 	const spawned = await spawnTelegramDaemonOwner(
@@ -708,14 +1008,12 @@ export async function ensureTelegramDaemonRunning(
 		// A still-live owner is running an OLDER daemon generation than this host
 		// (e.g. a pre-upgrade daemon reused in place across an in-place upgrade).
 		// Attaching would silently drop this host's newer ask-ack / control frames,
-		// so register this session's root first — so the replacement daemon serves
-		// it — then hand off through the tested SIGTERM/control reload path to bring
-		// up a fresh current-generation daemon.
-		await registerNotificationRoot({ ...input, fs: deps.fs });
+		// so hand off through the tested SIGTERM/control reload path to bring up a
+		// fresh current-generation daemon. Root registration already completed
+		// before ownership work, so the replacement daemon can serve this session.
 		await reloadStaleGenerationOwner(input.settings, deps);
 		return "owner_spawned";
 	}
-	await registerNotificationRoot({ ...input, fs: deps.fs });
 	return spawned.result;
 }
 
@@ -1025,6 +1323,16 @@ export class TelegramNotificationDaemon {
 	private readonly fsImpl: TelegramDaemonFs;
 	private readonly botApi: BotApi;
 	private readonly topics = new TopicRegistry();
+	/**
+	 * Sessions whose raw persisted topic createdAt was not a non-negative safe
+	 * integer at load. TopicRegistry.load() normalizes a non-number createdAt
+	 * to 0 — which would otherwise satisfy orphan grace and authorize a
+	 * destructive delete — so the daemon remembers these sessions and
+	 * fail-closes them in topicPastOrphanGrace for the lifetime of their topic.
+	 * The set is cleared/rebuilt on every loadTopics and cleared on legitimate
+	 * forget so a later fresh lifecycle is never poisoned.
+	 */
+	private readonly invalidCreatedAtTopics = new Set<string>();
 	/** Serializes registry snapshots so an older atomic write cannot overwrite newer rename state. */
 	private topicsPersistQueue: Promise<void> = Promise.resolve();
 	/** Daemon edit attempts that can race an accepted user service message. */
@@ -1700,48 +2008,159 @@ export class TelegramNotificationDaemon {
 
 	async scanRoots(): Promise<void> {
 		const paths = daemonPaths(this.opts.settings.getAgentDir());
-		const rootState = await readJson<{ roots?: string[] }>(this.fsImpl, paths.roots);
-		const endpointSessionIds = new Set<string>();
-		let allRootsReadable = true;
-		for (const root of rootState?.roots ?? []) {
+		const view = await readRootsRegistry(this.fsImpl, paths.roots);
+		const { evidence, rootStatus } = await this.collectEndpointEvidence(view.roots);
+
+
+		// Connect live endpoints first so an active session is never mistaken for orphaned.
+		for (const [sessionId, ev] of evidence) {
+			if (this.sessions.has(sessionId)) continue;
+			if (ev.kind !== "live") continue;
+			const endpointKey = endpointGenerationKey(ev.url, ev.token);
+			if (this.closedEndpointKeys.get(sessionId) === endpointKey) continue;
+			this.closedEndpointKeys.delete(sessionId);
+			this.connectSession(sessionId, ev.url, ev.token);
+		}
+
+		// Candidate maintenance and reaping both re-read fresh under the forever
+		// roots lock, so a concurrent registration serializes against deletion
+		// authority and cannot race endpoint publication into an unsafe delete.
+		await this.maintainOrphanCandidates(evidence, rootStatus);
+
+		await this.reapReadyOrphanCandidates();
+	}
+
+	/**
+	 * Inventory endpoint discovery files across all roots, classifying each
+	 * session as live/stale/dead/malformed. Unreadable roots contribute no
+	 * evidence (and do not globally veto cleanup); a protective reading anywhere
+	 * wins over a stale/dead one so a live duplicate is never reaped.
+	 */
+	private async collectEndpointEvidence(
+		roots: string[],
+	): Promise<{ evidence: Map<string, EndpointEvidence>; rootStatus: Map<string, RootReadStatus> }> {
+		const evidence = new Map<string, EndpointEvidence>();
+		const rootStatus = new Map<string, RootReadStatus>();
+		const pidAlive = this.opts.pidAlive ?? defaultPidAlive;
+		for (const root of roots) {
 			const dir = path.join(root, "notifications");
 			let files: string[];
 			try {
 				files = await this.fsImpl.readdir(dir);
-			} catch {
-				allRootsReadable = false;
+			} catch (error) {
+				// ENOENT confirms the mapped root is gone: its sessions' absence is
+				// authoritative. Any other error (permission/IO) is ambiguous and
+				// fails closed — it neither qualifies a session nor vetoes globally.
+				rootStatus.set(root, (error as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "ambiguous");
 				continue;
 			}
+			rootStatus.set(root, "readable");
 			for (const file of files.filter(item => item.endsWith(".json"))) {
 				const sessionId = path.basename(file, ".json");
-				endpointSessionIds.add(sessionId);
-				if (this.sessions.has(sessionId)) continue;
 				try {
 					const endpoint = readEndpoint(path.join(dir, file));
-					// Skip endpoint files whose owning process is gone or that are
-					// explicitly stale (e.g. a hard-closed session): reconnecting
-					// would chase a dead, token-bearing record forever. Once the
-					// associated topic is past the grace window, reap it through the
-					// same best-effort delete path as graceful session shutdown.
-					const pidAlive = this.opts.pidAlive ?? defaultPidAlive;
-					if (endpoint.stale || (endpoint.pid !== undefined && !pidAlive(endpoint.pid))) {
-						await this.deleteOrphanedTopic(sessionId);
-						continue;
-					}
-					const endpointKey = endpointGenerationKey(endpoint.url, endpoint.token);
-					if (this.closedEndpointKeys.get(sessionId) === endpointKey) continue;
-					this.closedEndpointKeys.delete(sessionId);
-					this.connectSession(sessionId, endpoint.url, endpoint.token);
-				} catch {}
+					mergeEndpointEvidence(evidence, sessionId, classifyEndpointEvidence(endpoint, pidAlive));
+				} catch {
+					mergeEndpointEvidence(evidence, sessionId, { kind: "malformed" });
+				}
 			}
 		}
-		if (allRootsReadable) {
+		return { evidence, rootStatus };
+	}
+
+
+	/**
+	 * Whether `sessionId` is a legitimate orphan-deletion candidate: no active
+	 * connection and only stale/dead endpoint evidence, or confirmed absence
+	 * from a registered root that is itself confirmed empty (readable) or gone
+	 * (missing/ENOENT). Live/malformed/ambiguous evidence and unknown or
+	 * ambiguous registered roots protect the session (fail closed). This is
+	 * independent of topic age — both grace windows are enforced only at
+	 * reap/delete time, never when (re)creating a candidate.
+	 */
+	private endpointOrphanQualifies(
+		sessionId: string,
+		evidence: Map<string, EndpointEvidence>,
+		rootStatus: Map<string, RootReadStatus>,
+		registeredRoot: string | undefined,
+	): boolean {
+		if (this.sessions.has(sessionId) || !registeredRoot) return false;
+		// The mapped root must itself be confirmed readable or missing. Stale/dead
+		// evidence from another root cannot override ambiguity at the authoritative
+		// root, which may still contain a live endpoint that could not be read.
+		const status = rootStatus.get(registeredRoot);
+		if (status !== "readable" && status !== "missing") return false;
+		const ev = evidence.get(sessionId);
+		return ev === undefined || ev.kind === "stale" || ev.kind === "dead";
+	}
+
+
+	/**
+	 * Under the forever roots lock, create/refresh/clear per-session orphan
+	 * candidates from the current evidence. A candidate is (re)created only when
+	 * its proof is stale — absent, or invalidated by a re-registration (lease
+	 * changed) or topic recreation (topicId changed) — restarting the grace
+	 * clock. Protected sessions clear any lingering candidate. Eligibility is
+	 * independent of topic age; both grace windows are checked at reap/delete.
+	 */
+	private async maintainOrphanCandidates(
+		evidence: Map<string, EndpointEvidence>,
+		rootStatus: Map<string, RootReadStatus>,
+	): Promise<void> {
+		const paths = daemonPaths(this.opts.settings.getAgentDir());
+		const now = this.runtime.now();
+		await withRootsLock(this.fsImpl, paths.roots, async () => {
+			const view = await readRootsRegistry(this.fsImpl, paths.roots);
+			const raw = view.raw;
+			let mutated = false;
 			for (const sessionId of this.topics.sessionIds()) {
-				if (!this.sessions.has(sessionId) && !endpointSessionIds.has(sessionId))
-					await this.deleteOrphanedTopic(sessionId);
+				const record = this.topics.get(sessionId);
+				if (!record) continue;
+				const registeredRoot = view.sessions.get(sessionId);
+				const qualifies = this.endpointOrphanQualifies(sessionId, evidence, rootStatus, registeredRoot);
+				const lease = view.sessionLeases.get(sessionId);
+				const existing = view.orphanCandidates.get(sessionId);
+				if (!qualifies || !lease) {
+					if (existing) {
+						deleteRawCandidate(raw, sessionId);
+						mutated = true;
+					}
+					continue;
+				}
+				const proofStale =
+					!existing || existing.leaseId !== lease.leaseId || existing.topicId !== record.topicId;
+				if (proofStale) {
+					setRawCandidate(raw, sessionId, {
+						observedAt: now,
+						leaseId: lease.leaseId,
+						topicId: record.topicId,
+					});
+					mutated = true;
+				}
 			}
+			if (mutated) await persistRootsRegistry(this.fsImpl, paths.roots, raw);
+		});
+	}
+
+
+	/**
+	 * Reap orphan candidates that have survived the candidate grace window. The
+	 * final exact, locked revalidation happens inside {@link deleteOrphanedTopic};
+	 * this pass only selects candidates old enough to consider.
+	 */
+	private async reapReadyOrphanCandidates(): Promise<void> {
+		const paths = daemonPaths(this.opts.settings.getAgentDir());
+		const now = this.runtime.now();
+		const view = await readRootsRegistry(this.fsImpl, paths.roots);
+		for (const [sessionId, candidate] of view.orphanCandidates) {
+			if (now - candidate.observedAt < ORPHAN_TOPIC_GRACE_MS) continue;
+			const record = this.topics.get(sessionId);
+			if (!record || record.topicId !== candidate.topicId) continue;
+			if (!this.topicPastOrphanGrace(sessionId)) continue;
+			await this.deleteOrphanedTopic(sessionId);
 		}
 	}
+
 
 	connectSession(sessionId: string, url: string, token: string): void {
 		const WS = this.opts.WebSocketImpl ?? WebSocket;
@@ -2058,12 +2477,118 @@ export class TelegramNotificationDaemon {
 
 	private topicPastOrphanGrace(sessionId: string): boolean {
 		const record = this.topics.get(sessionId);
-		return record !== undefined && this.runtime.now() - record.createdAt >= ORPHAN_TOPIC_GRACE_MS;
+		if (record === undefined) return false;
+		// Fail-closed at the daemon boundary: a persisted createdAt that is not a
+		// non-negative safe integer must never satisfy orphan deletion grace. The
+		// invalidCreatedAtTopics marker catches values TopicRegistry.load()
+		// normalized to 0 (string/null/undefined/…); the record check catches
+		// values the registry carried verbatim (negative/fractional/unsafe int).
+		if (this.invalidCreatedAtTopics.has(sessionId)) return false;
+		if (!isNonNegativeSafeInteger(record.createdAt)) return false;
+		return this.runtime.now() - record.createdAt >= ORPHAN_TOPIC_GRACE_MS;
 	}
 
+	/**
+	 * Final orphan-topic delete transaction. Runs entirely under the forever
+	 * roots lock (held across the remote Telegram call) so an in-flight deletion
+	 * cannot race a fresh registration or endpoint publication. It
+	 * fresh-reinventories the target endpoint evidence under the lock (not just
+	 * the in-memory sessions map), revalidates the candidate/lease/both grace
+	 * windows, and only on a literal Telegram `{ok:true}` PLUS successful local
+	 * topic persistence forgets in memory and selectively compacts the registry.
+	 */
 	private async deleteOrphanedTopic(sessionId: string): Promise<void> {
-		if (!this.topicPastOrphanGrace(sessionId)) return;
-		await this.deleteTopic(sessionId);
+		const record = this.topics.get(sessionId);
+		if (!record) return;
+		const paths = daemonPaths(this.opts.settings.getAgentDir());
+		await withRootsLock(this.fsImpl, paths.roots, async () => {
+			const view = await readRootsRegistry(this.fsImpl, paths.roots);
+			const raw = view.raw;
+
+			// Fresh target endpoint evidence under the forever lock — do not rely
+			// only on the in-memory sessions map. A revived session resets its
+			// stale candidate; indeterminate evidence fails closed.
+			const { evidence, rootStatus } = await this.collectEndpointEvidence(view.roots);
+			const connected = this.sessions.has(sessionId);
+			const freshEv = evidence.get(sessionId);
+			if (connected || (freshEv !== undefined && freshEv.kind === "live")) {
+				if (deleteRawCandidate(raw, sessionId)) await persistRootsRegistry(this.fsImpl, paths.roots, raw);
+				return;
+			}
+			const registeredRoot = view.sessions.get(sessionId);
+			if (!this.endpointOrphanQualifies(sessionId, evidence, rootStatus, registeredRoot)) return;
+
+			// Deletion authority: candidate + live lease + both grace windows must agree.
+			const lease = view.sessionLeases.get(sessionId);
+			const candidate = view.orphanCandidates.get(sessionId);
+			if (!lease || !candidate) return;
+			if (candidate.leaseId !== lease.leaseId) return;
+			if (candidate.topicId !== record.topicId) return;
+			const current = this.topics.get(sessionId);
+			if (!current || current.topicId !== record.topicId) return;
+			if (this.runtime.now() - candidate.observedAt < ORPHAN_TOPIC_GRACE_MS) return;
+			if (!this.topicPastOrphanGrace(sessionId)) return;
+
+			let res: { ok?: boolean } | undefined;
+			try {
+				const removed = this.pool.removeWhere(item => item.sessionId === sessionId);
+				for (const item of removed) {
+					if (item.payload.selectedAck)
+						this.finishSelectedAck(item.payload.selectedAck, { status: "failed", reason: "cancelled" });
+				}
+				await this.flushPool();
+				res = (await this.botApi.call("deleteForumTopic", {
+					chat_id: this.opts.chatId,
+					message_thread_id: Number(record.topicId),
+				})) as { ok?: boolean };
+			} catch {
+				return;
+			}
+			// Literal {ok:true} is required; ambiguous responses never compact.
+			if (res?.ok !== true) return;
+
+			// Local topic persistence MUST succeed before registry compaction and
+			// before mutating live state: a prospective snapshot is persisted first,
+			// and only on success do we forget in memory and compact. A failure
+			// retains the in-memory topic and all registry evidence for retry.
+			try {
+				await this.persistTopicsExcluding(sessionId);
+			} catch (err) {
+				logger.warn(
+					`notifications: topic persistence failed before orphan compact for ${sessionId}: ${String(err)}`,
+				);
+				return;
+			}
+			this.forgetTopicLocally(sessionId);
+
+			// Selective compaction: remove this session's candidate, lease, and
+			// mapping. Remove the registered root only when it is confirmed gone
+			// (ENOENT) and no remaining recognizable session mapping references it.
+			deleteRawCandidate(raw, sessionId);
+			deleteRawLease(raw, sessionId);
+			const compactedRoot = deleteRawSessionMapping(raw, sessionId) ? registeredRoot : undefined;
+			if (compactedRoot && rootStatus.get(compactedRoot) === "missing" && !rawRootReferenced(raw, compactedRoot)) {
+				removeRawRoot(raw, compactedRoot);
+			}
+			try {
+				await persistRootsRegistry(this.fsImpl, paths.roots, raw);
+			} catch (err) {
+				logger.warn(`notifications: failed to compact orphan registry for ${sessionId}: ${String(err)}`);
+			}
+		});
+	}
+
+
+	private forgetTopicLocally(sessionId: string): void {
+		this.topics.delete(sessionId);
+		this.invalidCreatedAtTopics.delete(sessionId);
+		for (const k of [...this.liveMessages.keys()]) {
+			if (k.startsWith(`${sessionId}:`)) this.liveMessages.delete(k);
+		}
+		this.topicOwnerByIdentity.forEach((ownerSessionId, identityKey) => {
+			if (ownerSessionId === sessionId) this.topicOwnerByIdentity.delete(identityKey);
+		});
+		this.pendingThreadedFrames.delete(sessionId);
 	}
 
 	/** Best-effort delete of a session topic once its local notification endpoint shuts down. */
@@ -2083,20 +2608,24 @@ export class TelegramNotificationDaemon {
 				chat_id: this.opts.chatId,
 				message_thread_id: Number(record.topicId),
 			})) as { ok?: boolean };
-			if (res?.ok === false) return;
-			this.topics.delete(sessionId);
-			for (const k of [...this.liveMessages.keys()]) {
-				if (k.startsWith(`${sessionId}:`)) this.liveMessages.delete(k);
+			// Exact-success: only literal {ok:true} authorizes local forgetting.
+			if (res?.ok !== true) return;
+			// Persist a prospective topic snapshot BEFORE mutating live state; a
+			// persistence failure retains the in-memory topic for a later retry.
+			try {
+				await this.persistTopicsExcluding(sessionId);
+			} catch (err) {
+				logger.warn(
+					`notifications: topic persistence failed before graceful forget for ${sessionId}: ${String(err)}`,
+				);
+				return;
 			}
-			this.topicOwnerByIdentity.forEach((ownerSessionId, identityKey) => {
-				if (ownerSessionId === sessionId) this.topicOwnerByIdentity.delete(identityKey);
-			});
-			this.pendingThreadedFrames.delete(sessionId);
-			await this.persistTopics();
+			this.forgetTopicLocally(sessionId);
 		} catch {
 			// Best-effort: missing Telegram topic permissions must not stop teardown.
 		}
 	}
+
 
 	private persistTopics(): Promise<void> {
 		const pending = this.topicsPersistQueue.then(async () => {
@@ -2108,9 +2637,51 @@ export class TelegramNotificationDaemon {
 		return pending;
 	}
 
+	/**
+	 * Persist a prospective topic-registry snapshot that excludes `sessionId`,
+	 * through the same serialization queue as {@link persistTopics}. The snapshot
+	 * is captured at queue-execution time, and callers MUST only mutate live
+	 * topic state after this resolves — so a persistence failure leaves both the
+	 * in-memory registry and the on-disk file unchanged (nothing is forgotten).
+	 */
+	private persistTopicsExcluding(sessionId: string): Promise<void> {
+		const pending = this.topicsPersistQueue.then(async () => {
+			const snapshot = this.topics.serialize();
+			const prospective: TopicRegistryState = { topics: { ...snapshot.topics } };
+			delete prospective.topics[sessionId];
+			const paths = daemonPaths(this.opts.settings.getAgentDir());
+			await ensureDir(this.fsImpl, paths.dir);
+			await writeJsonAtomic(this.fsImpl, path.join(paths.dir, "telegram-topics.json"), prospective);
+		});
+		this.topicsPersistQueue = pending.catch(() => undefined);
+		return pending;
+	}
+
 	async loadTopics(): Promise<void> {
 		const paths = daemonPaths(this.opts.settings.getAgentDir());
 		const raw = await readJson<TopicRegistryState>(this.fsImpl, path.join(paths.dir, "telegram-topics.json"));
+		// Rebuild the daemon-owned set of sessions whose raw persisted topic
+		// createdAt is not a non-negative safe integer. TopicRegistry.load()
+		// normalizes a non-number createdAt to 0 — which would otherwise satisfy
+		// orphan grace and authorize a destructive delete — so the daemon
+		// remembers these sessions and fail-closes them in topicPastOrphanGrace
+		// for the lifetime of their topic. (Negative, fractional, and unsafe
+		// integers pass the registry's typeof check and are carried verbatim, so
+		// they are caught here too.) The set is cleared/rebuilt on every load so
+		// a legitimate forget followed by a fresh lifecycle is never poisoned.
+		this.invalidCreatedAtTopics.clear();
+		const rawTopics = raw && typeof raw === "object" ? (raw as TopicRegistryState).topics : undefined;
+		if (rawTopics && typeof rawTopics === "object") {
+			for (const [sessionId, topic] of Object.entries(rawTopics)) {
+				if (
+					topic &&
+					typeof topic === "object" &&
+					!isNonNegativeSafeInteger((topic as { createdAt?: unknown }).createdAt)
+				) {
+					this.invalidCreatedAtTopics.add(sessionId);
+				}
+			}
+		}
 		// Restore the full serialized registry (topicId + identitySent + name) so a
 		// fresh daemon after reload does not resend identity headers or lose renames.
 		if (raw && typeof raw === "object") this.topics.load(raw);

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -135,6 +135,25 @@ async function readTopicAuthorityState(agentDir: string): Promise<TopicAuthority
 		await fs.promises.readFile(path.join(daemonPaths(agentDir).dir, "telegram-topics.json"), "utf8"),
 	) as TopicAuthorityState;
 }
+type RootsRegistryState = {
+	version?: number;
+	roots?: string[];
+	sessions?: Record<string, string>;
+	sessionLeases?: Record<string, { leaseId: string; refreshedAt: number }>;
+	orphanCandidates?: Record<string, { observedAt: number; leaseId: string; topicId: string }>;
+	// Unknown/legacy sibling keys are carried verbatim by the daemon's registry;
+	// the index signature lets regression tests assert they survive compaction.
+	[key: string]: unknown;
+};
+
+/** Read the persisted notification-roots registry as the daemon wrote it. */
+async function readRootsState(agentDir: string): Promise<RootsRegistryState> {
+	try {
+		return JSON.parse(await fs.promises.readFile(daemonPaths(agentDir).roots, "utf8")) as RootsRegistryState;
+	} catch {
+		return {};
+	}
+}
 
 function forumTopicEditedUpdate(
 	updateId: number,
@@ -476,7 +495,7 @@ describe("telegram daemon", () => {
 		expect(result).toEqual({ acquired: false, attached: true });
 	});
 
-	test("live owner token/chat mismatch blocks attach without registering a root", async () => {
+	test("live owner token/chat mismatch blocks attach but registration-before-ownership still writes the new session root and lease", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
 		const paths = daemonPaths(agentDir);
@@ -511,7 +530,17 @@ describe("telegram daemon", () => {
 
 		expect(result).toBe("blocked");
 		expect(spawns).toBe(0);
-		expect(fs.existsSync(paths.roots)).toBe(false);
+		expect(fs.existsSync(paths.roots)).toBe(true);
+		// Registration-before-ownership hard gate: the new session root is
+		// registered (with a fresh session lease) before ownership is attempted,
+		// so a blocked attach still leaves a roots registry the daemon can serve.
+		const newRoot = path.join(agentDir, "new-session", ".gjc", "state");
+		const registry = JSON.parse(fs.readFileSync(paths.roots, "utf8")) as RootsRegistryState;
+		expect(registry.roots).toContain(newRoot);
+		expect(registry.sessions?.["new-session"]).toBe(newRoot);
+		expect(registry.sessionLeases?.["new-session"]).toEqual(
+			expect.objectContaining({ leaseId: expect.any(String), refreshedAt: expect.any(Number) }),
+		);
 		expect(JSON.parse(fs.readFileSync(paths.state, "utf8"))).toMatchObject({
 			ownerId: "old",
 			tokenFingerprint: "old-fp",
@@ -4184,8 +4213,8 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 	const agentDir = tempAgentDir();
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);
 	const cwd = path.join(agentDir, "repo");
-	await registerNotificationRoot({ settings: s, cwd, sessionId: "stale" });
-	await registerNotificationRoot({ settings: s, cwd, sessionId: "dead" });
+	await registerNotificationRoot({ settings: s, cwd, sessionId: "stale", randomId: () => "lease-stale", now: () => 1000 });
+	await registerNotificationRoot({ settings: s, cwd, sessionId: "dead", randomId: () => "lease-dead", now: () => 1000 });
 	const endpointDir = path.join(cwd, ".gjc", "state", "notifications");
 	fs.mkdirSync(endpointDir, { recursive: true });
 	fs.writeFileSync(
@@ -4204,6 +4233,7 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 		}),
 	);
 	const bot = new FakeBotApi();
+	let now = 120_000;
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
@@ -4212,9 +4242,21 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 		botApi: bot,
 		WebSocketImpl: FakeWs as any,
 		pidAlive: () => false,
-		now: () => 120_000,
+		now: () => now,
 	});
 	await daemon.loadTopics();
+
+	// First confirmed absence records deletion candidates but reaps nothing yet.
+	await daemon.scanRoots();
+	expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	const afterFirst = await readRootsState(agentDir);
+	expect(afterFirst.orphanCandidates?.stale).toEqual({ observedAt: 120_000, leaseId: "lease-stale", topicId: "101" });
+	expect(afterFirst.orphanCandidates?.dead).toEqual({ observedAt: 120_000, leaseId: "lease-dead", topicId: "102" });
+
+	// Once each candidate has survived its own grace window, both topics are
+	// reaped and their candidate + lease evidence is compacted away.
+	now = 180_000;
+	bot.calls = [];
 	await daemon.scanRoots();
 	expect(
 		bot.calls
@@ -4223,13 +4265,21 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 			.sort(),
 	).toEqual([101, 102]);
 	expect(daemon.sessions.size).toBe(0);
+	const afterReap = await readRootsState(agentDir);
+	expect(afterReap.orphanCandidates?.stale).toBeUndefined();
+	expect(afterReap.orphanCandidates?.dead).toBeUndefined();
+	expect(afterReap.sessionLeases?.stale).toBeUndefined();
+	expect(afterReap.sessionLeases?.dead).toBeUndefined();
 });
 
-test("scanRoots reaps missing endpoint topics only when all roots are readable and grace has elapsed", async () => {
+test("scanRoots reaps missing endpoint topics from a readable-empty or definitively-gone (ENOENT) registered root after grace, and compacts the reaped missing root", async () => {
+	// A readable-empty registered root (scenario 1) and a definitively-gone
+	// ENOENT registered root (scenario 2) both authorize a candidate, then a
+	// reap across two scans past the candidate grace window.
 	const agentDir = tempAgentDir();
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);
 	const cwd = path.join(agentDir, "repo");
-	await registerNotificationRoot({ settings: s, cwd, sessionId: "missing" });
+	await registerNotificationRoot({ settings: s, cwd, sessionId: "missing", randomId: () => "lease-missing", now: () => 1000 });
 	fs.mkdirSync(path.join(cwd, ".gjc", "state", "notifications"), { recursive: true });
 	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
 	fs.writeFileSync(
@@ -4237,42 +4287,999 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 		JSON.stringify({ topics: { missing: { topicId: "201", identitySent: true, createdAt: 0, name: "missing" } } }),
 	);
 	const bot = new FakeBotApi();
+	let now = 120_000;
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
-		now: () => 120_000,
+		now: () => now,
 	});
 	await daemon.loadTopics();
 	await daemon.scanRoots();
+	expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	expect((await readRootsState(agentDir)).orphanCandidates?.missing).toMatchObject({
+		leaseId: "lease-missing",
+		topicId: "201",
+		observedAt: 120_000,
+	});
+	now = 180_000;
+	await daemon.scanRoots();
 	expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([201]);
 
-	const blockedAgentDir = tempAgentDir();
-	const blockedSettings = setPrivateAgentDir(settings(blockedAgentDir), blockedAgentDir);
+	// Own registered root is definitively gone (its notifications dir never
+	// existed → readdir raises ENOENT): confirmed-missing absence authorizes a
+	// candidate too, then a reap after grace. On the exact {ok:true} delete the
+	// session mapping/lease/candidate and the now-unreferenced missing root are
+	// compacted. (Non-ENOENT ambiguity is covered elsewhere and stays fail-closed.)
+	const goneAgentDir = tempAgentDir();
+	const goneSettings = setPrivateAgentDir(settings(goneAgentDir), goneAgentDir);
+	const goneCwd = path.join(goneAgentDir, "gone");
+	const goneRoot = path.join(goneCwd, ".gjc", "state");
 	await registerNotificationRoot({
-		settings: blockedSettings,
-		cwd: path.join(blockedAgentDir, "unreadable"),
-		sessionId: "kept",
+		settings: goneSettings,
+		cwd: goneCwd,
+		sessionId: "gone",
+		randomId: () => "lease-gone",
+		now: () => 1000,
 	});
-	fs.mkdirSync(daemonPaths(blockedAgentDir).dir, { recursive: true });
+	fs.mkdirSync(daemonPaths(goneAgentDir).dir, { recursive: true });
 	fs.writeFileSync(
-		path.join(daemonPaths(blockedAgentDir).dir, "telegram-topics.json"),
-		JSON.stringify({ topics: { kept: { topicId: "202", identitySent: true, createdAt: 0, name: "kept" } } }),
+		path.join(daemonPaths(goneAgentDir).dir, "telegram-topics.json"),
+		JSON.stringify({ topics: { gone: { topicId: "202", identitySent: true, createdAt: 0, name: "gone" } } }),
 	);
-	const blockedBot = new FakeBotApi();
-	const blockedDaemon = new TelegramNotificationDaemon({
-		settings: blockedSettings,
+	const goneBot = new FakeBotApi();
+	let goneNow = 120_000;
+	const goneDaemon = new TelegramNotificationDaemon({
+		settings: goneSettings,
 		ownerId: "owner",
 		botToken: "tok",
 		chatId: "42",
-		botApi: blockedBot,
-		now: () => 120_000,
+		botApi: goneBot,
+		now: () => goneNow,
 	});
-	await blockedDaemon.loadTopics();
-	await blockedDaemon.scanRoots();
-	expect(blockedBot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	await goneDaemon.loadTopics();
+	await goneDaemon.scanRoots();
+	expect(goneBot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+	expect((await readRootsState(goneAgentDir)).orphanCandidates?.gone).toMatchObject({
+		leaseId: "lease-gone",
+		topicId: "202",
+		observedAt: 120_000,
+	});
+	goneNow = 180_000;
+	await goneDaemon.scanRoots();
+	expect(goneBot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([202]);
+	const goneRoots = await readRootsState(goneAgentDir);
+	expect(goneRoots.orphanCandidates?.gone).toBeUndefined();
+	expect(goneRoots.sessionLeases?.gone).toBeUndefined();
+	expect(goneRoots.sessions?.gone).toBeUndefined();
+	expect(goneRoots.roots).not.toContain(goneRoot);
+});
+
+describe("telegram daemon orphan reaping (two-phase candidate-then-reap)", () => {
+	/** Seed a ready, lease-matching orphan candidate + topic so a single scan reaps it. */
+	function seedReadyOrphan(agentDir: string, sessionId: string, topicId: string, leaseId = "L"): string {
+		const rootDir = path.join(agentDir, "repo", ".gjc", "state");
+		fs.mkdirSync(path.join(rootDir, "notifications"), { recursive: true });
+		fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+			JSON.stringify({ topics: { [sessionId]: { topicId, identitySent: true, createdAt: 0, name: sessionId } } }),
+		);
+		fs.writeFileSync(
+			daemonPaths(agentDir).roots,
+			JSON.stringify(
+				{
+					version: 1,
+					roots: [rootDir],
+					sessions: { [sessionId]: rootDir },
+					sessionLeases: { [sessionId]: { leaseId, refreshedAt: 0 } },
+					orphanCandidates: { [sessionId]: { observedAt: 1000, leaseId, topicId } },
+				},
+				null,
+				2,
+			),
+		);
+		return rootDir;
+	}
+
+	/** Real fs wrapper that lets a single test intercept roots-registry I/O. */
+	function wrapFs(overrides: {
+		readFile?: TelegramDaemonFs["readFile"];
+		rename?: TelegramDaemonFs["rename"];
+	}): TelegramDaemonFs {
+		const base = fs.promises as unknown as TelegramDaemonFs;
+		return {
+			mkdir: (p, o) => base.mkdir(p, o).then(() => undefined),
+			readFile: overrides.readFile ?? ((p, e) => base.readFile(p, e)),
+			writeFile: (p, d, o) => base.writeFile(p, d, o),
+			rename: overrides.rename ?? ((a, b) => base.rename(a, b).then(() => undefined)),
+			unlink: p => base.unlink(p),
+			open: (p, f, m) => base.open(p, f, m),
+			readdir: p => base.readdir(p),
+			chmod: (p, m) => base.chmod(p, m),
+		} as TelegramDaemonFs;
+	}
+	/** Whether the session's topic is still persisted in telegram-topics.json. */
+	async function topicPersisted(agentDir: string, sessionId: string): Promise<boolean> {
+		const state = await readTopicAuthorityState(agentDir);
+		return Boolean(state.topics?.[sessionId]);
+	}
+
+	/** Read the roots registry, apply a scalar malformation, then re-write it verbatim. */
+	function patchRootsRegistry(agentDir: string, patch: (raw: RootsRegistryState) => void): void {
+		const file = daemonPaths(agentDir).roots;
+		const raw = JSON.parse(fs.readFileSync(file, "utf8")) as RootsRegistryState;
+		patch(raw);
+		fs.writeFileSync(file, JSON.stringify(raw));
+	}
+
+	class DeleteOutcomeBotApi extends FakeBotApi {
+		constructor(public outcome: "throw" | "empty" | "ok-false" | "ok-true") {
+			super();
+		}
+		async call(method: string, body: unknown): Promise<unknown> {
+			if (method === "deleteForumTopic") {
+				this.calls.push({ method, body });
+				if (this.outcome === "throw") throw new Error("telegram 500");
+				if (this.outcome === "empty") return {};
+				if (this.outcome === "ok-false") return { ok: false };
+				return { ok: true };
+			}
+			return super.call(method, body);
+		}
+	}
+
+	test("repeated registration refreshes the lease and resets the orphan candidate grace clock", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		await registerNotificationRoot({ settings: s, cwd, sessionId: "S", randomId: () => "lease-1", now: () => 1000 });
+		fs.mkdirSync(path.join(cwd, ".gjc", "state", "notifications"), { recursive: true });
+		fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+			JSON.stringify({ topics: { S: { topicId: "11", identitySent: true, createdAt: 0, name: "s" } } }),
+		);
+		const bot = new FakeBotApi();
+		let now = 120_000;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			now: () => now,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		// First absence establishes a candidate anchored to the original lease.
+		let roots = await readRootsState(agentDir);
+		expect(roots.orphanCandidates?.S).toMatchObject({ leaseId: "lease-1", topicId: "11", observedAt: 120_000 });
+
+		// Re-register: a fresh lease id is written and the candidate is cleared, so
+		// the old absence proof can never authorize a delete.
+		await registerNotificationRoot({ settings: s, cwd, sessionId: "S", randomId: () => "lease-2", now: () => 130_000 });
+		roots = await readRootsState(agentDir);
+		expect(roots.sessionLeases?.S).toEqual({ leaseId: "lease-2", refreshedAt: 130_000 });
+		expect(roots.orphanCandidates?.S).toBeUndefined();
+
+		// Far past the original grace window, but the reset candidate is freshly
+		// observed → not reaped. Only after it survives its own window is it reaped.
+		now = 200_000;
+		bot.calls = [];
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		roots = await readRootsState(agentDir);
+		expect(roots.orphanCandidates?.S).toMatchObject({ leaseId: "lease-2", topicId: "11", observedAt: 200_000 });
+		now = 260_001;
+		bot.calls = [];
+		await daemon.scanRoots();
+		expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([11]);
+	});
+
+	test("the candidate grace window is independent of topic age: 59,999 keeps, 60,000 reaps", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		await registerNotificationRoot({ settings: s, cwd, sessionId: "S", randomId: () => "L", now: () => 0 });
+		fs.mkdirSync(path.join(cwd, ".gjc", "state", "notifications"), { recursive: true });
+		fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+		// Topic is created at t=0, so it is long past its own grace window for the
+		// whole test; only the candidate's own observedAt clock gates the reap.
+		fs.writeFileSync(
+			path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+			JSON.stringify({ topics: { S: { topicId: "21", identitySent: true, createdAt: 0, name: "s" } } }),
+		);
+		const bot = new FakeBotApi();
+		let now = 120_000;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			now: () => now,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots(); // candidate observedAt = 120_000
+		now = 179_999; // candidate age 59,999ms → still under the window
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		now = 180_000; // candidate age 60,000ms → past the window
+		bot.calls = [];
+		await daemon.scanRoots();
+		expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([21]);
+	});
+
+	test("only stale and dead-PID endpoints qualify; live, malformed, and active sessions are protected", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const cwd = path.join(agentDir, "repo");
+		const endpointDir = path.join(cwd, ".gjc", "state", "notifications");
+		fs.mkdirSync(endpointDir, { recursive: true });
+		for (const sid of ["live", "malformed", "stale", "dead"]) {
+			await registerNotificationRoot({ settings: s, cwd, sessionId: sid, randomId: () => `lease-${sid}`, now: () => 0 });
+		}
+		fs.writeFileSync(path.join(endpointDir, "live.json"), JSON.stringify({ url: "ws://live", token: "t", pid: 4242 }));
+		fs.writeFileSync(path.join(endpointDir, "malformed.json"), JSON.stringify({ url: 123, token: "t" }));
+		fs.writeFileSync(path.join(endpointDir, "stale.json"), JSON.stringify({ url: "ws://stale", token: "t", stale: true }));
+		fs.writeFileSync(path.join(endpointDir, "dead.json"), JSON.stringify({ url: "ws://dead", token: "t", pid: 999999 }));
+		fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+			JSON.stringify({
+				topics: {
+					live: { topicId: "31", identitySent: true, createdAt: 0, name: "live" },
+					malformed: { topicId: "32", identitySent: true, createdAt: 0, name: "malformed" },
+					stale: { topicId: "33", identitySent: true, createdAt: 0, name: "stale" },
+					dead: { topicId: "34", identitySent: true, createdAt: 0, name: "dead" },
+					active: { topicId: "35", identitySent: true, createdAt: 0, name: "active" },
+				},
+			}),
+		);
+		const bot = new FakeBotApi();
+		let now = 120_000;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			pidAlive: pid => pid === 4242,
+			now: () => now,
+		});
+		await daemon.loadTopics();
+		// An in-memory connected session is unconditionally protected.
+		daemon.connectSession("active", "ws://active", "t");
+		await daemon.scanRoots(); // first absence: candidates only for stale + dead
+		now = 180_000;
+		bot.calls = [];
+		await daemon.scanRoots();
+		expect(
+			bot.calls
+				.filter(c => c.method === "deleteForumTopic")
+				.map(c => c.body.message_thread_id)
+				.sort(),
+		).toEqual([33, 34]);
+		expect(daemon.sessions.has("live")).toBe(true);
+		expect(daemon.sessions.has("active")).toBe(true);
+		expect(await topicPersisted(agentDir, "malformed")).toBe(true);
+		// The protective live reading reconnects the session instead of reaping it.
+		expect(FakeWs.instances.some(ws => ws.url.startsWith("ws://live"))).toBe(true);
+	});
+
+	test("a live duplicate endpoint in another root protects the session over a stale reading", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const rootA = path.join(agentDir, "repoA", ".gjc", "state");
+		const rootB = path.join(agentDir, "repoB", ".gjc", "state");
+		fs.mkdirSync(path.join(rootA, "notifications"), { recursive: true });
+		fs.mkdirSync(path.join(rootB, "notifications"), { recursive: true });
+		fs.writeFileSync(path.join(rootA, "notifications", "dup.json"), JSON.stringify({ url: "ws://stale", token: "t", stale: true }));
+		fs.writeFileSync(path.join(rootB, "notifications", "dup.json"), JSON.stringify({ url: "ws://live", token: "t", pid: 4242 }));
+		fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+			JSON.stringify({ topics: { dup: { topicId: "41", identitySent: true, createdAt: 0, name: "dup" } } }),
+		);
+		fs.writeFileSync(
+			daemonPaths(agentDir).roots,
+			JSON.stringify({
+				version: 1,
+				roots: [rootA, rootB].sort(),
+				sessions: { dup: rootA },
+				sessionLeases: { dup: { leaseId: "L", refreshedAt: 0 } },
+			}),
+		);
+		const bot = new FakeBotApi();
+		let now = 120_000;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			pidAlive: pid => pid === 4242,
+			now: () => now,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		now = 180_000;
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		expect(await topicPersisted(agentDir, "dup")).toBe(true);
+		expect(daemon.sessions.has("dup")).toBe(true);
+		expect(FakeWs.instances.some(ws => ws.url.startsWith("ws://live"))).toBe(true);
+	});
+
+	test("legacy and malformed registry mappings fail closed (no valid lease ⇒ never reaped)", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const rootDir = path.join(agentDir, "repo", ".gjc", "state");
+		fs.mkdirSync(path.join(rootDir, "notifications"), { recursive: true });
+		fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+			JSON.stringify({
+				topics: {
+					legacy: { topicId: "51", identitySent: true, createdAt: 0, name: "legacy" },
+					badlease: { topicId: "52", identitySent: true, createdAt: 0, name: "badlease" },
+				},
+			}),
+		);
+		// Legacy schema (no sessionLeases) and a malformed lease entry (non-string
+		// leaseId) are both dropped by the strict parser → no lease ⇒ fail closed.
+		fs.writeFileSync(
+			daemonPaths(agentDir).roots,
+			JSON.stringify({
+				version: 1,
+				roots: [rootDir],
+				sessions: { legacy: rootDir, badlease: rootDir },
+				sessionLeases: { badlease: { leaseId: 123, refreshedAt: "oops" } },
+			}),
+		);
+		const bot = new FakeBotApi();
+		let now = 120_000;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			now: () => now,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		now = 180_000;
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		expect(await topicPersisted(agentDir, "legacy")).toBe(true);
+		expect(await topicPersisted(agentDir, "badlease")).toBe(true);
+		const roots = await readRootsState(agentDir);
+		expect(roots.orphanCandidates?.legacy).toBeUndefined();
+		expect(roots.orphanCandidates?.badlease).toBeUndefined();
+	});
+
+	test("an unrelated unreadable root (ENOENT or non-ENOENT) does not veto reaping of a readable-root session", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const readableRoot = path.join(agentDir, "readable", ".gjc", "state");
+		const enoentRoot = path.join(agentDir, "enoent", ".gjc", "state");
+		const notDirRoot = path.join(agentDir, "notdir", ".gjc", "state");
+		fs.mkdirSync(path.join(readableRoot, "notifications"), { recursive: true });
+		// enoentRoot: its notifications dir is simply absent (ENOENT on readdir).
+		// notDirRoot: the notifications path is a regular file (ENOTDIR, non-ENOENT).
+		fs.mkdirSync(notDirRoot, { recursive: true });
+		fs.writeFileSync(path.join(notDirRoot, "notifications"), "not a dir");
+		fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+			JSON.stringify({ topics: { orphan: { topicId: "55", identitySent: true, createdAt: 0, name: "orphan" } } }),
+		);
+		fs.writeFileSync(
+			daemonPaths(agentDir).roots,
+			JSON.stringify({
+				version: 1,
+				roots: [readableRoot, enoentRoot, notDirRoot].sort(),
+				sessions: { orphan: readableRoot },
+				sessionLeases: { orphan: { leaseId: "L", refreshedAt: 0 } },
+			}),
+		);
+		const bot = new FakeBotApi();
+		let now = 120_000;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			now: () => now,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		now = 180_000;
+		await daemon.scanRoots();
+		// "orphan"'s own root is readable + empty, so it is reaped even though two
+		// unrelated roots are unreadable (one ENOENT, one non-ENOENT).
+		expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([55]);
+	});
+
+	test("array-shaped registry maps (sessions, sessionLeases, orphanCandidates) never authorize deletion", async () => {
+		// If Object.entries were applied to these arrays, their numeric-string
+		// indices ("0") would surface a ready reap candidate for session "0".
+		// Strict Array.isArray rejection drops every map, so the seeded candidate
+		// stays invisible and the topic can never be deleted.
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const rootDir = path.join(agentDir, "repo", ".gjc", "state");
+		fs.mkdirSync(path.join(rootDir, "notifications"), { recursive: true }); // readable-empty
+		fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+			JSON.stringify({ topics: { "0": { topicId: "11", identitySent: true, createdAt: 0, name: "s" } } }),
+		);
+		fs.writeFileSync(
+			daemonPaths(agentDir).roots,
+			JSON.stringify({
+				version: 1,
+				roots: [rootDir],
+				sessions: [rootDir],
+				sessionLeases: [{ leaseId: "L", refreshedAt: 0 }],
+				orphanCandidates: [{ observedAt: 1000, leaseId: "L", topicId: "11" }],
+			}),
+		);
+		const bot = new FakeBotApi();
+		let now = 120_000;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			now: () => now,
+		});
+		await daemon.loadTopics();
+		// Seeded observedAt (1000) is already far past the grace window at t=120000.
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		now = 200_000;
+		bot.calls = [];
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		expect(await topicPersisted(agentDir, "0")).toBe(true);
+	});
+
+	// A deletion candidate is only ever dropped by a strict scalar-domain check;
+	// the old type-only check let these malformed-but-type-valid scalars authorize
+	// a destructive delete. Each row seeds a candidate that is the would-be
+	// authority — a valid, lease-matching, topic-matching, already-mature absence
+	// proof (via seedReadyOrphan) — then malforms exactly one scalar so only the
+	// new domain check stands between it and a deleteForumTopic.
+	type ScalarPatch = (raw: RootsRegistryState) => void;
+	type MalformedScalarRow = [label: string, config: { seedTopicId: string; seedLeaseId: string; patch?: ScalarPatch }];
+
+	const malformedScalarRows: MalformedScalarRow[] = [
+		["empty leaseId (session lease + candidate)", { seedTopicId: "11", seedLeaseId: "" }],
+		["negative candidate observedAt", { seedTopicId: "11", seedLeaseId: "L", patch: r => { r.orphanCandidates!.S!.observedAt = -1; } }],
+		["fractional candidate observedAt", { seedTopicId: "11", seedLeaseId: "L", patch: r => { r.orphanCandidates!.S!.observedAt = 1.5; } }],
+		["negative session-lease refreshedAt", { seedTopicId: "11", seedLeaseId: "L", patch: r => { r.sessionLeases!.S!.refreshedAt = -5; } }],
+		["fractional session-lease refreshedAt", { seedTopicId: "11", seedLeaseId: "L", patch: r => { r.sessionLeases!.S!.refreshedAt = 2.5; } }],
+		["candidate topicId '0' (zero)", { seedTopicId: "0", seedLeaseId: "L" }],
+		["candidate topicId '-1' (negative)", { seedTopicId: "-1", seedLeaseId: "L" }],
+		["candidate topicId '1.5' (fraction)", { seedTopicId: "1.5", seedLeaseId: "L" }],
+		["candidate topicId ' 1 ' (whitespace)", { seedTopicId: " 1 ", seedLeaseId: "L" }],
+		["candidate topicId '1e3' (exponent)", { seedTopicId: "1e3", seedLeaseId: "L" }],
+		["candidate topicId 'abc' (non-digits)", { seedTopicId: "abc", seedLeaseId: "L" }],
+		["candidate topicId '01' (leading zero)", { seedTopicId: "01", seedLeaseId: "L" }],
+	];
+
+	test.each(malformedScalarRows)(
+		"a malformed-scalar deletion candidate that would otherwise be the authority (%s) never matures into a delete",
+		async (_label, { seedTopicId, seedLeaseId, patch }) => {
+			const agentDir = tempAgentDir();
+			const s = setPrivateAgentDir(settings(agentDir), agentDir);
+			const rootDir = seedReadyOrphan(agentDir, "S", seedTopicId, seedLeaseId);
+			if (patch) patchRootsRegistry(agentDir, patch);
+			const bot = new FakeBotApi();
+			const daemon = new TelegramNotificationDaemon({
+				settings: s,
+				ownerId: "owner",
+				botToken: "tok",
+				chatId: "42",
+				botApi: bot,
+				now: () => 120_000,
+			});
+			await daemon.loadTopics();
+			await daemon.scanRoots();
+			// No candidate maturation ⇒ no remote deleteForumTopic call.
+			expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+			// No local forget: the topic record is still persisted.
+			expect(await topicPersisted(agentDir, "S")).toBe(true);
+			// No compaction: the session mapping and its registered root survive.
+			const roots = await readRootsState(agentDir);
+			expect(roots.sessions?.S).toBe(rootDir);
+			expect(roots.roots).toEqual([rootDir]);
+		},
+	);
+
+	test("an ambiguous mapped root protects its session over stale/dead endpoint evidence in another readable root", async () => {
+		// The session's authoritative root is unreadable (non-ENOENT), so its
+		// absence is indeterminate and fail-closed. A dead-PID endpoint for the
+		// same session in a separate readable root must not override that — the
+		// mapped root may still hold an endpoint that could not be enumerated.
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const authoritativeRoot = path.join(agentDir, "auth", ".gjc", "state");
+		const evidenceRoot = path.join(agentDir, "ev", ".gjc", "state");
+		// notifications is a regular file → readdir raises ENOTDIR (ambiguous).
+		fs.mkdirSync(authoritativeRoot, { recursive: true });
+		fs.writeFileSync(path.join(authoritativeRoot, "notifications"), "not a dir");
+		fs.mkdirSync(path.join(evidenceRoot, "notifications"), { recursive: true });
+		fs.writeFileSync(
+			path.join(evidenceRoot, "notifications", "S.json"),
+			JSON.stringify({ url: "ws://dead", token: "t", pid: 999999 }),
+		);
+		fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+			JSON.stringify({ topics: { S: { topicId: "21", identitySent: true, createdAt: 0, name: "s" } } }),
+		);
+		fs.writeFileSync(
+			daemonPaths(agentDir).roots,
+			JSON.stringify({
+				version: 1,
+				roots: [authoritativeRoot, evidenceRoot].sort(),
+				sessions: { S: authoritativeRoot },
+				sessionLeases: { S: { leaseId: "L", refreshedAt: 0 } },
+			}),
+		);
+		const bot = new FakeBotApi();
+		let now = 120_000;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			pidAlive: () => false,
+			now: () => now,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		// The dead endpoint alone looks orphaned, but the mapped root's ambiguity
+		// blocks candidate creation entirely.
+		expect((await readRootsState(agentDir)).orphanCandidates?.S).toBeUndefined();
+		now = 180_000;
+		bot.calls = [];
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		expect(await topicPersisted(agentDir, "S")).toBe(true);
+	});
+
+	test("the locked delete revalidates the lease and aborts when it no longer matches the candidate", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		seedReadyOrphan(agentDir, "S", "61", "L1");
+		const rootsFile = daemonPaths(agentDir).roots;
+		// Intercept roots reads: maintain (read #2) sees the seeded, matching lease
+		// and is a no-op; from reap's unlocked read onward the on-disk lease is
+		// mutated so the locked delete's fresh re-read diverges from the candidate.
+		let rootsReads = 0;
+		const wrappedFs = wrapFs({
+			readFile: async (p, e) => {
+				if (p === rootsFile) {
+					rootsReads++;
+					if (rootsReads > 2) {
+						const raw = JSON.parse(await fs.promises.readFile(p, e)) as RootsRegistryState;
+						(raw.sessionLeases!.S as { leaseId: string }).leaseId = "L2-diverged";
+						return JSON.stringify(raw);
+					}
+				}
+				return fs.promises.readFile(p, e);
+			},
+		});
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			fs: wrappedFs,
+			now: () => 120_000,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		// Revalidation aborted the delete before the remote call; the topic survives.
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+		expect(await topicPersisted(agentDir, "S")).toBe(true);
+	});
+
+	test.each([
+		["a thrown error", "throw"],
+		["an empty object {}", "empty"],
+		["{ok:false}", "ok-false"],
+	] as const)("a non-success deleteForumTopic response (%s) leaves the topic and registry uncompacted", async (_name, outcome) => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		seedReadyOrphan(agentDir, "S", "71", "L");
+		const bot = new DeleteOutcomeBotApi(outcome);
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			now: () => 120_000,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(true);
+		// Ambiguous/failed responses never authorize local forgetting or compaction.
+		expect(await topicPersisted(agentDir, "S")).toBe(true);
+		const roots = await readRootsState(agentDir);
+		expect(roots.orphanCandidates?.S).toBeDefined();
+		expect(roots.sessionLeases?.S).toBeDefined();
+	});
+
+	test("an exact {ok:true} deleteForumTopic response compacts the registry and forgets the topic", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		seedReadyOrphan(agentDir, "S", "72", "L");
+		const bot = new DeleteOutcomeBotApi("ok-true");
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			now: () => 120_000,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([72]);
+		expect(await topicPersisted(agentDir, "S")).toBe(false);
+		const roots = await readRootsState(agentDir);
+		expect(roots.orphanCandidates?.S).toBeUndefined();
+		expect(roots.sessionLeases?.S).toBeUndefined();
+	});
+
+	test("a local registry-compaction failure retains the candidate + lease evidence", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const rootsFile = daemonPaths(agentDir).roots;
+		seedReadyOrphan(agentDir, "S", "81", "L");
+		// The atomic rename that publishes the compacted registry fails; the
+		// in-memory topic is already forgotten, but the on-disk evidence survives.
+		const wrappedFs = wrapFs({
+			rename: async (oldPath, newPath) => {
+				if (newPath === rootsFile) throw new Error("disk full");
+				await fs.promises.rename(oldPath, newPath);
+			},
+		});
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			fs: wrappedFs,
+			now: () => 120_000,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(true);
+		expect(await topicPersisted(agentDir, "S")).toBe(false);
+		const roots = await readRootsState(agentDir);
+		expect(roots.orphanCandidates?.S).toBeDefined();
+		expect(roots.sessionLeases?.S).toBeDefined();
+	});
+
+	test("a persistTopicsExcluding failure after an exact {ok:true} delete keeps the topic and every registry record", async () => {
+		// Persistence-before-forgetting contract: Telegram confirms the topic
+		// delete with literal {ok:true}, but persistTopicsExcluding(sessionId) —
+		// the atomic rename that publishes the prospective telegram-topics.json
+		// snapshot (excluding the deleted session) — fails. The daemon must not
+		// forget the topic in memory or compact the roots registry: the on-disk
+		// topic, candidate, lease, session mapping, and registered root all
+		// survive so a later scan can retry the reap. Contrast the
+		// roots-compaction failure above, where the topic publish already
+		// succeeded and the topic WAS forgotten locally.
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const topicsFile = path.join(daemonPaths(agentDir).dir, "telegram-topics.json");
+		const rootDir = seedReadyOrphan(agentDir, "S", "82", "L");
+		// Fail the atomic publish of the topics snapshot only (not the roots
+		// registry): the delete succeeded remotely, but local forgetting is gated
+		// on that publish succeeding first.
+		const wrappedFs = wrapFs({
+			rename: async (oldPath, newPath) => {
+				if (newPath === topicsFile) throw new Error("disk full");
+				await fs.promises.rename(oldPath, newPath);
+			},
+		});
+		const bot = new DeleteOutcomeBotApi("ok-true");
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			fs: wrappedFs,
+			now: () => 120_000,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		// The exact {ok:true} delete was attempted remotely, but the atomic
+		// publish failed — so the topic is still persisted on disk.
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(true);
+		expect(await topicPersisted(agentDir, "S")).toBe(true);
+		// …and still observable in daemon behavior: a fresh scan re-attempts the
+		// delete because the topic was never forgotten in memory.
+		bot.calls = [];
+		await daemon.scanRoots();
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(true);
+		// No compaction or local forgetting: every registry record survives intact.
+		const roots = await readRootsState(agentDir);
+		expect(roots.orphanCandidates?.S).toBeDefined();
+		expect(roots.sessionLeases?.S).toBeDefined();
+		expect(roots.sessions?.S).toBe(rootDir);
+		expect(roots.roots).toEqual([rootDir]);
+	});
+
+	test("registry compaction is selective: unrelated sessions, leases, and unknown fields survive", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const rootDir = path.join(agentDir, "repo", ".gjc", "state");
+		fs.mkdirSync(path.join(rootDir, "notifications"), { recursive: true });
+		fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+			JSON.stringify({
+				topics: {
+					reap: { topicId: "91", identitySent: true, createdAt: 0, name: "reap" },
+					keep: { topicId: "92", identitySent: true, createdAt: 0, name: "keep" },
+				},
+			}),
+		);
+		// "keep" is protected by a live endpoint so it is never a candidate.
+		fs.writeFileSync(path.join(rootDir, "notifications", "keep.json"), JSON.stringify({ url: "ws://keep", token: "t", pid: 4242 }));
+		fs.writeFileSync(
+			daemonPaths(agentDir).roots,
+			JSON.stringify({
+				version: 1,
+				roots: [rootDir],
+				sessions: { reap: rootDir, keep: rootDir },
+				sessionLeases: { reap: { leaseId: "Lreap", refreshedAt: 0 }, keep: { leaseId: "Lkeep", refreshedAt: 0 } },
+				orphanCandidates: { reap: { observedAt: 1000, leaseId: "Lreap", topicId: "91" } },
+				futureField: { stable: true, nested: { x: 1 } },
+			}),
+		);
+		FakeWs.instances = [];
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			WebSocketImpl: FakeWs as any,
+			pidAlive: pid => pid === 4242,
+			now: () => 120_000,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([91]);
+		expect(await topicPersisted(agentDir, "reap")).toBe(false);
+		expect(await topicPersisted(agentDir, "keep")).toBe(true);
+		const roots = await readRootsState(agentDir);
+		expect(roots.orphanCandidates?.reap).toBeUndefined();
+		expect(roots.sessionLeases?.reap).toBeUndefined();
+		expect(roots.sessionLeases?.keep).toEqual({ leaseId: "Lkeep", refreshedAt: 0 });
+		expect(roots.futureField).toEqual({ stable: true, nested: { x: 1 } });
+	});
+
+	test("a same-session registration serializes behind an in-flight delete and writes a fresh lease", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		seedReadyOrphan(agentDir, "race", "101", "L1");
+		const bot = new FakeBotApi();
+		let releaseDelete: () => void = () => {};
+		const deleteGate = new Promise<void>(resolve => {
+			releaseDelete = resolve;
+		});
+		let signalDeleteHoldingLock: () => void = () => {};
+		const deleteHoldingLock = new Promise<void>(resolve => {
+			signalDeleteHoldingLock = resolve;
+		});
+		(bot as FakeBotApi).call = (async (method: string, body: any) => {
+			bot.calls.push({ method, body });
+			if (method === "deleteForumTopic") {
+				signalDeleteHoldingLock(); // the delete is now holding the forever roots lock
+				await deleteGate; // …and keeps holding it across the remote call
+				return { ok: true };
+			}
+			return { ok: true, result: true };
+		}) as any;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			now: () => 120_000,
+		});
+		await daemon.loadTopics();
+		const scanP = daemon.scanRoots();
+		// Wait until the reap is provably holding the forever roots lock at its gated call.
+		await deleteHoldingLock;
+		// The forever lock queues this registration behind the in-flight delete.
+		const regP = registerNotificationRoot({
+			settings: s,
+			cwd: path.join(agentDir, "repo"),
+			sessionId: "race",
+			randomId: () => "L2",
+			now: () => 130_000,
+		});
+		releaseDelete();
+		await Promise.all([scanP, regP]);
+		expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(true);
+		expect(await topicPersisted(agentDir, "race")).toBe(false);
+		const roots = await readRootsState(agentDir);
+		// Delete compacted the old proof; the queued registration wrote a fresh lease.
+		expect(roots.sessionLeases?.race).toEqual({ leaseId: "L2", refreshedAt: 130_000 });
+		expect(roots.orphanCandidates?.race).toBeUndefined();
+	});
+
+	test("an unrelated registration is not compacted away by a concurrent delete of another session", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		const rootDir = path.join(agentDir, "repo", ".gjc", "state");
+		fs.mkdirSync(path.join(rootDir, "notifications"), { recursive: true });
+		fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+			JSON.stringify({ topics: { a: { topicId: "111", identitySent: true, createdAt: 0, name: "a" } } }),
+		);
+		fs.writeFileSync(
+			daemonPaths(agentDir).roots,
+			JSON.stringify({
+				version: 1,
+				roots: [rootDir],
+				sessions: { a: rootDir, b: rootDir },
+				sessionLeases: { a: { leaseId: "La", refreshedAt: 0 }, b: { leaseId: "Lb", refreshedAt: 0 } },
+				orphanCandidates: { a: { observedAt: 1000, leaseId: "La", topicId: "111" } },
+			}),
+		);
+		const bot = new FakeBotApi();
+		let releaseDelete: () => void = () => {};
+		const deleteGate = new Promise<void>(resolve => {
+			releaseDelete = resolve;
+		});
+		let signalDeleteHoldingLock: () => void = () => {};
+		const deleteHoldingLock = new Promise<void>(resolve => {
+			signalDeleteHoldingLock = resolve;
+		});
+		(bot as FakeBotApi).call = (async (method: string, body: any) => {
+			bot.calls.push({ method, body });
+			if (method === "deleteForumTopic") {
+				signalDeleteHoldingLock(); // the delete is now holding the forever roots lock
+				await deleteGate; // …and keeps holding it across the remote call
+				return { ok: true };
+			}
+			return { ok: true, result: true };
+		}) as any;
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			now: () => 120_000,
+		});
+		await daemon.loadTopics();
+		const scanP = daemon.scanRoots();
+		await deleteHoldingLock; // wait until the reap is provably holding the lock
+		const regP = registerNotificationRoot({
+			settings: s,
+			cwd: path.join(agentDir, "repo"),
+			sessionId: "b",
+			randomId: () => "Lb2",
+			now: () => 130_000,
+		});
+		releaseDelete();
+		await Promise.all([scanP, regP]);
+		expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([111]);
+		const roots = await readRootsState(agentDir);
+		// Session "a" was reaped + compacted; unrelated session "b"'s lease survives.
+		expect(roots.sessionLeases?.a).toBeUndefined();
+		expect(roots.sessionLeases?.b).toEqual({ leaseId: "Lb2", refreshedAt: 130_000 });
+		expect(roots.orphanCandidates?.b).toBeUndefined();
+	});
+	// A persisted TopicRecord.createdAt that is not a non-negative safe integer
+	// must never satisfy orphan deletion grace, even when the orphan candidate is
+	// otherwise fully valid, lease-matching, and mature. TopicRegistry.load()
+	// normalizes non-number createdAt to 0 (which would otherwise pass grace),
+	// and carries negative/fractional/unsafe integers verbatim; the daemon marks
+	// these sessions from the raw persisted JSON at loadTopics and fail-closes
+	// topicPastOrphanGrace for the lifetime of the topic.
+	const malformedCreatedAtRows: [label: string, createdAt: unknown][] = [
+		["negative createdAt", -1],
+		["fractional createdAt", 1.5],
+		["unsafe integer createdAt", Number.MAX_SAFE_INTEGER + 1],
+		["string createdAt", "oops"],
+		["null createdAt", null],
+		["omitted createdAt", undefined],
+		["object createdAt", {}],
+		["array createdAt", [1000]],
+		["boolean createdAt", true],
+	];
+
+	test.each(malformedCreatedAtRows)(
+		"a malformed persisted topic createdAt (%s) never satisfies orphan deletion grace even with a mature candidate",
+		async (_label, createdAt) => {
+			const agentDir = tempAgentDir();
+			const s = setPrivateAgentDir(settings(agentDir), agentDir);
+			// Seed a fully valid, mature, lease-matching orphan candidate — the
+			// ONLY thing standing between it and a deleteForumTopic is the
+			// malformed persisted topic createdAt.
+			const rootDir = seedReadyOrphan(agentDir, "S", "11", "L");
+			// Overwrite the seeded (valid) createdAt with the malformed value.
+			const topicsFile = path.join(daemonPaths(agentDir).dir, "telegram-topics.json");
+			const topicRaw = JSON.parse(fs.readFileSync(topicsFile, "utf8")) as { topics: Record<string, any> };
+			topicRaw.topics.S.createdAt = createdAt;
+			fs.writeFileSync(topicsFile, JSON.stringify(topicRaw));
+			const bot = new FakeBotApi();
+			const daemon = new TelegramNotificationDaemon({
+				settings: s,
+				ownerId: "owner",
+				botToken: "tok",
+				chatId: "42",
+				botApi: bot,
+				now: () => 120_000,
+			});
+			await daemon.loadTopics();
+			await daemon.scanRoots();
+			// No deleteForumTopic: the malformed createdAt fail-closes orphan grace.
+			expect(bot.calls.some(c => c.method === "deleteForumTopic")).toBe(false);
+			// The topic record is not forgotten locally.
+			expect(await topicPersisted(agentDir, "S")).toBe(true);
+			// No compaction: session mapping, lease, candidate, and root all survive.
+			const roots = await readRootsState(agentDir);
+			expect(roots.sessions?.S).toBe(rootDir);
+			expect(roots.sessionLeases?.S).toBeDefined();
+			expect(roots.orphanCandidates?.S).toBeDefined();
+			expect(roots.roots).toEqual([rootDir]);
+		},
+	);
+
+	test("a valid non-negative safe-integer createdAt still reaps after candidate grace", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		// createdAt: 0 (valid) + observedAt: 1000 (already mature at t=120000).
+		seedReadyOrphan(agentDir, "S", "11", "L");
+		const bot = new FakeBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			now: () => 120_000,
+		});
+		await daemon.loadTopics();
+		await daemon.scanRoots();
+		// Valid createdAt + mature candidate → reaped normally.
+		expect(bot.calls.filter(c => c.method === "deleteForumTopic").map(c => c.body.message_thread_id)).toEqual([11]);
+		expect(await topicPersisted(agentDir, "S")).toBe(false);
+	});
 });
 
 test("runDaemonInternal wires SIGTERM to the daemon stop method", async () => {

--- a/packages/coding-agent/test/notifications-turn-ordering.test.ts
+++ b/packages/coding-agent/test/notifications-turn-ordering.test.ts
@@ -4,6 +4,11 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { createNotificationsExtension } from "../src/notifications/index";
 import { readEndpoint } from "../src/notifications/telegram-reference";
+import { getAgentDir, setAgentDir } from "@gajae-code/utils";
+import { Settings } from "../src/config/settings";
+import { daemonPaths } from "../src/notifications/daemon-paths";
+import { tokenFingerprint } from "../src/notifications/config";
+import { DAEMON_GENERATION, DAEMON_VERSION } from "../src/notifications/telegram-daemon";
 
 /**
  * Regression for the text-before-ask ordering bug: the assistant text that
@@ -37,9 +42,13 @@ type TestModel = { id?: string };
 
 const tempDirs: string[] = [];
 const openSockets: WebSocket[] = [];
+// Telegram-gate tests re-point the module-global agent dir resolver; capture the
+// original at load and restore it after every test so it never leaks.
+const originalAgentDir = getAgentDir();
 afterEach(() => {
 	for (const ws of openSockets.splice(0)) ws.close();
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+	setAgentDir(originalAgentDir);
 });
 
 /** Boot the notifications extension against a real NotificationServer + WS client. */
@@ -428,5 +437,354 @@ test("stream-enabled final always carries a messageRef and a late message_update
 		else process.env.GJC_NOTIFICATIONS = prevN;
 		if (prevS === undefined) delete process.env.GJC_NOTIFICATIONS_STREAM;
 		else process.env.GJC_NOTIFICATIONS_STREAM = prevS;
+	}
+}, 30000);
+
+// ---------------------------------------------------------------------------
+// Telegram registration hard-gate regression coverage.
+//
+// These exercise the REAL createNotificationsExtension() / NotificationServer
+// lifecycle (no mocks of ensureTelegramDaemonRunning): a configured-Telegram
+// session must complete a fresh daemon registration BEFORE it publishes an
+// endpoint, registers its answer source, or pins its identity header. Only
+// `owner_spawned` / `attached` clear the gate; `blocked`, a thrown registration,
+// or any other result fails the session before any publication. They rely on
+// the real roots lock (withFileLock retries:"forever"), the additive roots
+// `sessionLeases` / `orphanCandidates` maps, the two-phase absence candidate,
+// registration-before-endpoint ordering, the literal `{ok:true}` requirement,
+// and selective compaction — at the observable endpoint-file / registry level.
+//
+// The configured-Telegram gate is only reached when a Settings override is
+// passed to createNotificationsExtension (otherwise settingsAvailable is false
+// and the gate is skipped, which is why the ordering tests above never hit it).
+// ---------------------------------------------------------------------------
+
+/** Make a temp dir tracked for afterEach cleanup. */
+function mkdtemp(prefix: string): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function writeJsonFile(file: string, data: unknown): void {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function readJsonFile(file: string): Record<string, unknown> | undefined {
+	try {
+		return JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+	} catch {
+		return undefined;
+	}
+}
+
+function endpointFileFor(cwd: string, sid: string): string {
+	return path.join(cwd, ".gjc", "state", "notifications", `${sid}.json`);
+}
+
+function sessionLeaseOf(rootsFile: string, sid: string): { leaseId: string; refreshedAt: number } | undefined {
+	const reg = readJsonFile(rootsFile);
+	const leases = (reg?.sessionLeases ?? {}) as Record<string, { leaseId: string; refreshedAt: number }>;
+	return leases[sid];
+}
+
+function orphanCandidateOf(rootsFile: string, sid: string): unknown {
+	const reg = readJsonFile(rootsFile);
+	const candidates = (reg?.orphanCandidates ?? {}) as Record<string, unknown>;
+	return candidates[sid];
+}
+
+/** Persist a live daemon-ownership record (telegram-daemon.state.json) under agentDir. */
+function seedDaemonOwner(agentDir: string, owner: { tokenFingerprint: string; chatId: string }): void {
+	const { dir, state } = daemonPaths(agentDir);
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(
+		state,
+		`${JSON.stringify(
+			{
+				pid: process.pid,
+				ownerId: "seeded-live-owner",
+				tokenFingerprint: owner.tokenFingerprint,
+				chatId: owner.chatId,
+				startedAt: Date.now(),
+				heartbeatAt: Date.now(),
+				roots: [],
+				version: DAEMON_VERSION,
+				generation: DAEMON_GENERATION,
+			},
+			null,
+			2,
+		)}\n`,
+	);
+}
+
+/** Pre-seed the roots registry with a stale session lease + orphan-candidate delete proof. */
+function seedRootsRegistry(rootsFile: string, sid: string, root: string, oldLeaseId: string): void {
+	const stale = Date.now() - 100_000;
+	writeJsonFile(rootsFile, {
+		version: 1,
+		roots: [root],
+		sessions: { [sid]: root },
+		sessionLeases: { [sid]: { leaseId: oldLeaseId, refreshedAt: stale } },
+		orphanCandidates: { [sid]: { observedAt: stale, leaseId: oldLeaseId, topicId: "777" } },
+	});
+}
+
+function telegramSettings(botToken: string, chatId: string): Settings {
+	return Settings.isolated({
+		"notifications.enabled": true,
+		"notifications.telegram.botToken": botToken,
+		"notifications.telegram.chatId": chatId,
+	});
+}
+
+/** Register the real notifications extension against a configured-Telegram Settings. */
+function buildTelegramHarness(settings: Settings, cwd: string, sid: string): {
+	handlers: Map<string, Handler>;
+	ctx: unknown;
+} {
+	const handlers = new Map<string, Handler>();
+	const api = {
+		on: (event: string, handler: Handler) => {
+			handlers.set(event, handler);
+		},
+		registerCommand: () => {},
+		sendUserMessage: () => {},
+	} as never;
+	createNotificationsExtension(api, { settings });
+	const ctx = {
+		cwd,
+		sessionManager: {
+			getSessionId: () => sid,
+			getSessionName: () => "Telegram Gate Test",
+			getArtifactsDir: () => cwd,
+			getCwd: () => cwd,
+		},
+		getContextUsage: () => ({ tokens: 12, contextWindow: 100 }),
+		getModel: () => ({ id: "test-model" }),
+	} as never;
+	return { handlers, ctx };
+}
+
+test("a configured-Telegram session blocked by a live owner with a different identity fails before any endpoint/runtime/identity publication", async () => {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		const agentDir = mkdtemp("gjc-tg-blocked-agent-");
+		setAgentDir(agentDir);
+		const botToken = "77:blocked-bot-token";
+		const chatId = "123456789";
+		const settings = telegramSettings(botToken, chatId);
+		// A live owner (our own pid) advertising a DIFFERENT token fingerprint and
+		// chat id -> acquireDaemonOwnership returns blocked WITHOUT spawning, so
+		// ensureTelegramDaemonRunning resolves "blocked" and the gate fails.
+		seedDaemonOwner(agentDir, { tokenFingerprint: "000000000000", chatId: "999999999" });
+
+		const cwd = mkdtemp("gjc-tg-blocked-cwd-");
+		const sid = `blocked-${process.pid}-${Date.now()}`;
+		const { handlers, ctx } = buildTelegramHarness(settings, cwd, sid);
+		const endpointFile = endpointFileFor(cwd, sid);
+
+		// session_start resolves (the gate returns "failed"); server.start() is never
+		// reached, so no endpoint / runtime / identity is published.
+		await handlers.get("session_start")!({ type: "session_start" }, ctx);
+		await sleep(300);
+		expect(fs.existsSync(endpointFile)).toBe(false);
+		// Registration now runs BEFORE ownership acquisition (the registration-first
+		// contract), so a lease IS committed even though ownership later blocks — but
+		// the blocked ownership still fails the gate, so NO endpoint is published.
+		const rootsFile = daemonPaths(agentDir).roots;
+		expect(sessionLeaseOf(rootsFile, sid)).toBeDefined();
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
+	}
+}, 30000);
+
+test("a configured-Telegram session whose daemon registration throws fails before any publication", async () => {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		const agentDir = mkdtemp("gjc-tg-throw-agent-");
+		setAgentDir(agentDir);
+		const settings = telegramSettings("55:throw-bot-token", "77777777");
+		// Registration runs first, so its ensureDir (recursive mkdir on the daemon
+		// notifications dir) throws EEXIST because that path is a regular file.
+		// registerNotificationRoot -> ensureTelegramDaemonRunning re-throw; the gate
+		// catches the throw and returns "failed" before any endpoint publication.
+		fs.writeFileSync(path.join(agentDir, "notifications"), "not-a-directory");
+
+		const cwd = mkdtemp("gjc-tg-throw-cwd-");
+		const sid = `throw-${process.pid}-${Date.now()}`;
+		const { handlers, ctx } = buildTelegramHarness(settings, cwd, sid);
+		const endpointFile = endpointFileFor(cwd, sid);
+
+		await handlers.get("session_start")!({ type: "session_start" }, ctx);
+		await sleep(300);
+		expect(fs.existsSync(endpointFile)).toBe(false);
+		// The notifications dir is a file, so no roots registry could ever be written.
+		expect(fs.existsSync(daemonPaths(agentDir).roots)).toBe(false);
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
+	}
+}, 30000);
+
+test("a notifications-enabled session with Telegram NOT configured skips the registration gate and still publishes its endpoint", async () => {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		const agentDir = mkdtemp("gjc-tg-skip-agent-");
+		setAgentDir(agentDir);
+		// Enabled but with NO boundary credentials -> isTelegramConfigured is false ->
+		// the registration gate is skipped entirely (the "disabled" EnsureDaemonResult
+		// branch is unreachable through the gate with the same cfg, so it is represented
+		// by this skip path).
+		const settings = Settings.isolated({ "notifications.enabled": true });
+
+		const cwd = mkdtemp("gjc-tg-skip-cwd-");
+		const sid = `skip-${process.pid}-${Date.now()}`;
+		const { handlers, ctx } = buildTelegramHarness(settings, cwd, sid);
+		const endpointFile = endpointFileFor(cwd, sid);
+
+		await handlers.get("session_start")!({ type: "session_start" }, ctx);
+		await waitFor(() => fs.existsSync(endpointFile), 4000, "endpoint file (non-Telegram)");
+		expect(fs.existsSync(endpointFile)).toBe(true);
+		// No Telegram registration ran -> no lease for this session.
+		const rootsFile = daemonPaths(agentDir).roots;
+		if (fs.existsSync(rootsFile)) {
+			expect(sessionLeaseOf(rootsFile, sid)).toBeUndefined();
+		}
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
+	}
+}, 30000);
+
+test("a configured-Telegram session that attaches publishes its endpoint only after registration commits the session lease", async () => {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		const agentDir = mkdtemp("gjc-tg-ok-agent-");
+		setAgentDir(agentDir);
+		const botToken = "12:ok-bot-token";
+		const chatId = "3133731337";
+		const settings = telegramSettings(botToken, chatId);
+		// A fresh, identity-MATCHING live owner (current generation) -> attaches WITHOUT
+		// spawning, then runs the real registerNotificationRoot before returning.
+		seedDaemonOwner(agentDir, { tokenFingerprint: tokenFingerprint(botToken), chatId });
+
+		const cwd = mkdtemp("gjc-tg-ok-cwd-");
+		const sid = `ok-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		const { handlers, ctx } = buildTelegramHarness(settings, cwd, sid);
+		const endpointFile = endpointFileFor(cwd, sid);
+		const rootsFile = daemonPaths(agentDir).roots;
+
+		await handlers.get("session_start")!({ type: "session_start" }, ctx);
+		await waitFor(() => fs.existsSync(endpointFile), 4000, "endpoint file (configured-Telegram success)");
+
+		// Endpoint published AND registration already committed a fresh lease for this
+		// session (registration is awaited before server.start()).
+		expect(fs.existsSync(endpointFile)).toBe(true);
+		const lease = sessionLeaseOf(rootsFile, sid);
+		expect(lease).toBeDefined();
+		expect(typeof lease?.leaseId).toBe("string");
+
+		// The published runtime is live: agent_start emits an observable activity frame.
+		// (Contrast with the blocked / throw cases, where no runtime is ever published.)
+		const { url, token } = readEndpoint(endpointFile);
+		const frames: Frame[] = [];
+		const ws = new WebSocket(`${url}/?token=${encodeURIComponent(token)}`);
+		openSockets.push(ws);
+		await new Promise<void>((resolve, reject) => {
+			ws.addEventListener("open", () => resolve());
+			ws.addEventListener("error", () => reject(new Error("ws error")));
+		});
+		ws.addEventListener("message", ev => frames.push(JSON.parse(String((ev as MessageEvent).data))));
+		await sleep(250);
+		await handlers.get("agent_start")!({ type: "agent_start" }, ctx);
+		await waitFor(() => frames.some(f => f.type === "activity"), 3000, "activity frame");
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
+	}
+}, 30000);
+
+test("configured-Telegram start waits behind a long-held roots lock, then a fresh lease commits before the endpoint and the stale delete proof is invalidated", async () => {
+	const prevEnv = process.env.GJC_NOTIFICATIONS;
+	process.env.GJC_NOTIFICATIONS = "1";
+	try {
+		// A configured-Telegram session whose ownership is a fresh identity-matching
+		// live owner attaches WITHOUT spawning, then calls the real
+		// registerNotificationRoot under the forever roots lock before publishing.
+		const agentDir = mkdtemp("gjc-tg-race-agent-");
+		setAgentDir(agentDir);
+		const botToken = "99:race-bot-token";
+		const chatId = "424242424";
+		const settings = telegramSettings(botToken, chatId);
+		seedDaemonOwner(agentDir, { tokenFingerprint: tokenFingerprint(botToken), chatId });
+
+		const cwd = mkdtemp("gjc-tg-race-cwd-");
+		const sid = `race-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		const paths = daemonPaths(agentDir);
+		const root = path.join(cwd, ".gjc", "state");
+		const OLD_LEASE = "old-lease-stale-proof";
+		// Pre-seed a stale orphan-candidate delete proof (old lease) for this session.
+		seedRootsRegistry(paths.roots, sid, root, OLD_LEASE);
+
+		const { handlers, ctx } = buildTelegramHarness(settings, cwd, sid);
+		const endpointFile = endpointFileFor(cwd, sid);
+
+		// Hold the REAL roots lock (the delete transaction's forever lock) with a LIVE
+		// owner so stale-reaping never reclaims it; registerNotificationRoot must wait.
+		const lockDir = `${paths.roots}.lock`;
+		fs.mkdirSync(lockDir);
+		fs.writeFileSync(path.join(lockDir, "info"), JSON.stringify({ pid: process.pid, timestamp: Date.now() }));
+		const heldSince = Date.now();
+
+		// Fire session_start without awaiting: the gate reaches registerNotificationRoot
+		// and blocks on the held lock, so the endpoint cannot publish.
+		const startPromise = handlers.get("session_start")!({ type: "session_start" }, ctx) as Promise<unknown>;
+		await sleep(500);
+		expect(fs.existsSync(endpointFile)).toBe(false);
+
+		// Hold well beyond the OLD finite lock budget (default 50 retries * 100ms ~= 5s).
+		await sleep(5000);
+		expect(fs.existsSync(endpointFile)).toBe(false);
+
+		// Discriminating check: under the old finite budget registration would have
+		// thrown (~5s) and startPromise resolved as "failed". Under retries:"forever" it
+		// must STILL be waiting on the lock past the 5.25s budget.
+		let resolvedEarly = false;
+		startPromise.then(() => {
+			resolvedEarly = true;
+		});
+		await sleep(300);
+		expect(resolvedEarly).toBe(false);
+		expect(fs.existsSync(endpointFile)).toBe(false);
+		expect(Date.now() - heldSince).toBeGreaterThan(5250);
+
+		// Release the lock (the in-flight delete transaction finishes). Registration
+		// acquires it, commits a FRESH lease (new leaseId) and clears the orphan
+		// candidate, THEN the gate proceeds and the endpoint publishes.
+		fs.rmSync(lockDir, { recursive: true, force: true });
+		await startPromise;
+		await waitFor(() => fs.existsSync(endpointFile), 4000, "endpoint file after lock release");
+		expect(fs.existsSync(endpointFile)).toBe(true);
+
+		// Fresh lease committed before the endpoint, and the stale delete proof is
+		// invalidated: the orphan candidate was cleared by registration, and the live
+		// leaseId no longer matches the old proof. deleteOrphanedTopic's under-lock
+		// revalidation (`!lease || !candidate`, then `candidate.leaseId !==
+		// lease.leaseId`) would now abort — the old proof cannot delete again.
+		const lease = sessionLeaseOf(paths.roots, sid);
+		expect(lease).toBeDefined();
+		expect(typeof lease?.leaseId).toBe("string");
+		expect(lease?.leaseId).not.toBe(OLD_LEASE);
+		expect(orphanCandidateOf(paths.roots, sid)).toBeUndefined();
+	} finally {
+		if (prevEnv === undefined) delete process.env.GJC_NOTIFICATIONS;
+		else process.env.GJC_NOTIFICATIONS = prevEnv;
 	}
 }, 30000);


### PR DESCRIPTION
## Summary

- replace the global all-roots-readable orphan cleanup veto with per-root, per-session evidence
- add registration leases and continuous absence candidates so a transient/mid-restart observation cannot delete a live session topic
- hard-gate Telegram endpoint publication on successful lease registration and serialize final deletion with an opt-in forever roots lock
- require literal Telegram `{ok:true}` plus successful local topic persistence before forgetting or selectively compacting registry state
- preserve legacy/unknown registry fields and fail closed on malformed maps, scalar authority, and topic creation timestamps

## Why

Deleted temporary notification roots remained in `telegram-daemon.roots.json`. Because one unreadable root disabled the daemon's entire orphan sweep, unrelated test topics accumulated indefinitely. The new flow cleans definitively missing roots without allowing ambiguous roots, live duplicates, restarts, persistence failures, or concurrent registrations to authorize unsafe deletion.

## Verification

- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts` — 187 passed
- `bun test packages/coding-agent/test/notifications-turn-ordering.test.ts` — 14 passed

The ordering suite includes a real >5.25-second held-lock race proving that a configured Telegram endpoint is not published until a fresh lease commits.

## Operational tradeoff

The destructive finalization path holds the notification-roots lock through the Telegram delete and local persistence. A stuck live delete can defer configured Telegram session startup; this is intentionally fail-closed so startup cannot race an in-flight deletion.