### PR TITLE
notifications: persist Telegram deletion custody safely

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, test } from "bun:test";
+import type * as fs from "node:fs";
+import * as path from "node:path";
+import { daemonPaths } from "./daemon-paths";
+import {
+	TELEGRAM_CUSTODY_MAX_FILE_BYTES,
+	TELEGRAM_CUSTODY_MAX_RECORDS,
+	type TelegramCustodyRecord,
+	TelegramCustodyStore,
+	type TelegramCustodyStoreFs,
+	telegramCustodyKey,
+} from "./telegram-custody-store";
+
+const AGENT_DIR = "/virtual/agent";
+const CUSTODY_PATH = path.join(daemonPaths(AGENT_DIR).dir, "telegram-deletion-custody.json");
+
+function numericMode(mode: fs.Mode | undefined): number | undefined {
+	return typeof mode === "number" ? mode : undefined;
+}
+
+function writeMode(options: fs.WriteFileOptions | undefined): number | undefined {
+	if (!options || typeof options === "string") return undefined;
+	return numericMode(options.mode);
+}
+
+class FakeFs implements TelegramCustodyStoreFs {
+	readonly files = new Map<string, string>();
+	readonly mkdirCalls: { path: string; mode: number | undefined }[] = [];
+	readonly chmodCalls: { path: string; mode: number }[] = [];
+	readonly writeCalls: { path: string; data: string; mode: number | undefined }[] = [];
+	readonly renameCalls: { from: string; to: string }[] = [];
+	readonly unlinkCalls: string[] = [];
+	failRename = false;
+	failWrite = false;
+
+	async mkdir(file: string, options?: fs.MakeDirectoryOptions): Promise<undefined> {
+		this.mkdirCalls.push({ path: file, mode: numericMode(options?.mode) });
+		return undefined;
+	}
+
+	async readFile(file: string): Promise<string> {
+		const contents = this.files.get(file);
+		if (contents === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+		return contents;
+	}
+
+	async writeFile(file: string, data: string, options?: fs.WriteFileOptions): Promise<void> {
+		this.writeCalls.push({ path: file, data, mode: writeMode(options) });
+		if (this.failWrite) throw new Error("simulated write failure");
+		this.files.set(file, data);
+	}
+
+	async chmod(file: string, mode: number): Promise<void> {
+		this.chmodCalls.push({ path: file, mode });
+	}
+
+	async rename(from: string, to: string): Promise<void> {
+		this.renameCalls.push({ from, to });
+		if (this.failRename) throw new Error("simulated rename failure");
+		const contents = this.files.get(from);
+		if (contents === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+		this.files.delete(from);
+		this.files.set(to, contents);
+	}
+
+	async unlink(file: string): Promise<void> {
+		this.unlinkCalls.push(file);
+		this.files.delete(file);
+	}
+}
+
+function storeWith(fakeFs: FakeFs): TelegramCustodyStore {
+	return new TelegramCustodyStore({ agentDir: AGENT_DIR, fs: fakeFs, now: () => 1 });
+}
+
+function custodyRecord(overrides: Partial<TelegramCustodyRecord> = {}): TelegramCustodyRecord {
+	return {
+		chatId: "42",
+		topicId: "77",
+		state: "queued",
+		updatedAt: 1,
+		...overrides,
+	};
+}
+
+function serialized(fakeFs: FakeFs): { version: number; records: Record<string, TelegramCustodyRecord> } {
+	return JSON.parse(fakeFs.files.get(CUSTODY_PATH)!) as {
+		version: number;
+		records: Record<string, TelegramCustodyRecord>;
+	};
+}
+
+describe("TelegramCustodyStore", () => {
+	test("loads a missing file as an empty writable store", async () => {
+		const store = storeWith(new FakeFs());
+		expect(await store.load()).toEqual({ mode: "writable", migrated: false, records: [] });
+		expect(store.list()).toEqual([]);
+	});
+
+	test("round-trips all states with deterministic composite key order and separate chats", async () => {
+		const fakeFs = new FakeFs();
+		const store = storeWith(fakeFs);
+		await store.load();
+		await store.put(custodyRecord({ chatId: "2", topicId: "7", state: "queued" }));
+		await store.put(custodyRecord({ chatId: "10", topicId: "7", state: "in_flight" }));
+		await store.put(custodyRecord({ chatId: "2", topicId: "1", state: "unknown" }));
+
+		expect(Object.keys(serialized(fakeFs).records)).toEqual(["10:7", "2:1", "2:7"]);
+		expect(serialized(fakeFs).records["10:7"]?.state).toBe("in_flight");
+		expect(store.get({ chatId: "2", topicId: "7" })).toEqual(custodyRecord({ chatId: "2", topicId: "7" }));
+		expect(store.get({ chatId: "10", topicId: "7" })).toEqual(
+			custodyRecord({ chatId: "10", topicId: "7", state: "in_flight" }),
+		);
+
+		const reader = storeWith(fakeFs);
+		const loaded = await reader.load();
+		expect(loaded).toEqual({
+			mode: "writable",
+			migrated: false,
+			records: [
+				custodyRecord({ chatId: "10", topicId: "7", state: "unknown" }),
+				custodyRecord({ chatId: "2", topicId: "1", state: "unknown" }),
+				custodyRecord({ chatId: "2", topicId: "7" }),
+			],
+		});
+		expect(serialized(fakeFs).records["10:7"]?.state).toBe("unknown");
+	});
+
+	test("strictly migrates a v1 single-chat record object and preserves an optional epoch", async () => {
+		const fakeFs = new FakeFs();
+		fakeFs.files.set(
+			CUSTODY_PATH,
+			JSON.stringify({
+				version: 1,
+				chatId: "-100123",
+				records: {
+					"9": { state: "in_flight", updatedAt: 20, custodyEpoch: 3 },
+					"2": { state: "queued", updatedAt: 10 },
+				},
+			}),
+		);
+
+		const result = await storeWith(fakeFs).load();
+		expect(result).toEqual({
+			mode: "writable",
+			migrated: true,
+			records: [
+				custodyRecord({ chatId: "-100123", topicId: "2", updatedAt: 10 }),
+				custodyRecord({ chatId: "-100123", topicId: "9", state: "unknown", updatedAt: 20, custodyEpoch: 3 }),
+			],
+		});
+		expect(serialized(fakeFs)).toEqual({
+			version: 2,
+			records: {
+				"-100123:2": custodyRecord({ chatId: "-100123", topicId: "2", updatedAt: 10 }),
+				"-100123:9": custodyRecord({
+					chatId: "-100123",
+					topicId: "9",
+					state: "unknown",
+					updatedAt: 20,
+					custodyEpoch: 3,
+				}),
+			},
+		});
+	});
+
+	test("converts loaded v2 in_flight custody to unknown and atomically rewrites it", async () => {
+		const fakeFs = new FakeFs();
+		fakeFs.files.set(
+			CUSTODY_PATH,
+			JSON.stringify({
+				version: 2,
+				records: { "42:7": custodyRecord({ topicId: "7", state: "in_flight", custodyEpoch: 8 }) },
+			}),
+		);
+
+		const result = await storeWith(fakeFs).load();
+		expect(result).toEqual({
+			mode: "writable",
+			migrated: false,
+			records: [custodyRecord({ topicId: "7", state: "unknown", custodyEpoch: 8 })],
+		});
+		expect(serialized(fakeFs).records["42:7"]?.state).toBe("unknown");
+		expect(fakeFs.renameCalls).toHaveLength(1);
+	});
+
+	test("rejects malformed JSON, duplicate members, key mismatches, and unknown states without rewrite", async () => {
+		const invalidDocuments = [
+			"{ not JSON",
+			'{"version":2,"version":2,"records":{}}',
+			JSON.stringify({ version: 2, records: { "42:8": custodyRecord({ topicId: "7" }) } }),
+			JSON.stringify({ version: 2, records: { "42:7": { ...custodyRecord(), state: "sent" } } }),
+		];
+
+		for (const source of invalidDocuments) {
+			const fakeFs = new FakeFs();
+			fakeFs.files.set(CUSTODY_PATH, source);
+			const store = storeWith(fakeFs);
+			expect(await store.load()).toEqual({ mode: "read_only", reason: "corrupt", migrated: false, records: [] });
+			expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+			expect(fakeFs.writeCalls).toHaveLength(0);
+			expect(await store.put(custodyRecord())).toEqual({ ok: false, reason: "read_only" });
+		}
+	});
+
+	test("rejects invalid IDs, timestamps, epochs, and excess record properties", async () => {
+		const invalidRecords: unknown[] = [
+			{ chatId: "+1", topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "01", topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "-0", topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "0", topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "1".repeat(33), topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "1", topicId: "0", state: "queued", updatedAt: 1 },
+			{ chatId: "1", topicId: "-7", state: "queued", updatedAt: 1 },
+			{ chatId: "1", topicId: "1".repeat(21), state: "queued", updatedAt: 1 },
+			{ chatId: "1", topicId: "7", state: "queued", updatedAt: -1 },
+			{ chatId: "1", topicId: "7", state: "queued", updatedAt: Number.MAX_SAFE_INTEGER + 1 },
+			{ chatId: "1", topicId: "7", state: "queued", updatedAt: 1, custodyEpoch: -1 },
+			{ chatId: "1", topicId: "7", state: "queued", updatedAt: 1, unexpected: true },
+		];
+		for (const record of invalidRecords) {
+			const fakeFs = new FakeFs();
+			fakeFs.files.set(CUSTODY_PATH, JSON.stringify({ version: 2, records: { "1:7": record } }));
+			expect(await storeWith(fakeFs).load()).toEqual({
+				mode: "read_only",
+				reason: "corrupt",
+				migrated: false,
+				records: [],
+			});
+		}
+
+		const writableFs = new FakeFs();
+		const writableStore = storeWith(writableFs);
+		await writableStore.load();
+		await expect(
+			writableStore.put({ ...custodyRecord(), topicId: "01" } as unknown as TelegramCustodyRecord),
+		).rejects.toThrow("Invalid Telegram custody record");
+		await expect(
+			writableStore.put({ ...custodyRecord(), custodyEpoch: undefined } as unknown as TelegramCustodyRecord),
+		).rejects.toThrow("Invalid Telegram custody record");
+		expect(writableFs.writeCalls).toHaveLength(0);
+	});
+
+	test("honors the 1,000-record and file-size boundaries without touching oversized source bytes", async () => {
+		const exactlyAtLimit = Object.fromEntries(
+			Array.from({ length: TELEGRAM_CUSTODY_MAX_RECORDS }, (_, index) => [
+				`42:${index + 1}`,
+				custodyRecord({ topicId: String(index + 1) }),
+			]),
+		);
+		const validFs = new FakeFs();
+		validFs.files.set(CUSTODY_PATH, JSON.stringify({ version: 2, records: exactlyAtLimit }));
+		const validStore = storeWith(validFs);
+		const validResult = await validStore.load();
+		expect(validResult.mode).toBe("writable");
+		expect(validResult.records).toHaveLength(TELEGRAM_CUSTODY_MAX_RECORDS);
+		await expect(
+			validStore.put(custodyRecord({ topicId: String(TELEGRAM_CUSTODY_MAX_RECORDS + 1) })),
+		).rejects.toThrow("Telegram custody record limit exceeded");
+		expect(validFs.writeCalls).toHaveLength(0);
+		const atFileLimit = JSON.stringify({ version: 2, records: {} });
+		const paddedAtLimit = `${atFileLimit}${" ".repeat(TELEGRAM_CUSTODY_MAX_FILE_BYTES - Buffer.byteLength(atFileLimit, "utf8"))}`;
+		const fileLimitFs = new FakeFs();
+		fileLimitFs.files.set(CUSTODY_PATH, paddedAtLimit);
+		expect(await storeWith(fileLimitFs).load()).toEqual({ mode: "writable", migrated: false, records: [] });
+
+		const tooMany = Object.fromEntries(
+			Array.from({ length: TELEGRAM_CUSTODY_MAX_RECORDS + 1 }, (_, index) => [
+				`42:${index + 1}`,
+				custodyRecord({ topicId: String(index + 1) }),
+			]),
+		);
+		for (const source of [
+			JSON.stringify({ version: 2, records: tooMany }),
+			" ".repeat(TELEGRAM_CUSTODY_MAX_FILE_BYTES + 1),
+		]) {
+			const fakeFs = new FakeFs();
+			fakeFs.files.set(CUSTODY_PATH, source);
+			const store = storeWith(fakeFs);
+			expect(await store.load()).toEqual({ mode: "read_only", reason: "bounds", migrated: false, records: [] });
+			expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+			expect(fakeFs.writeCalls).toHaveLength(0);
+		}
+	});
+
+	test("preserves forward-version bytes and disables mutation", async () => {
+		const fakeFs = new FakeFs();
+		const source = '{"version":3,"future":"preserve exactly"}\n';
+		fakeFs.files.set(CUSTODY_PATH, source);
+		const store = storeWith(fakeFs);
+		expect(await store.load()).toEqual({
+			mode: "read_only",
+			reason: "forward_version",
+			migrated: false,
+			records: [],
+		});
+		expect(await store.remove({ chatId: "42", topicId: "7" })).toEqual({ ok: false, reason: "read_only" });
+		expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+		expect(fakeFs.writeCalls).toHaveLength(0);
+	});
+
+	test("classifies a failed v1 migration as read-only and does not promote memory to writable", async () => {
+		const fakeFs = new FakeFs();
+		const source = JSON.stringify({
+			version: 1,
+			chatId: "42",
+			records: { "7": { state: "queued", updatedAt: 1 } },
+		});
+		fakeFs.files.set(CUSTODY_PATH, source);
+		fakeFs.failRename = true;
+		const store = storeWith(fakeFs);
+
+		expect(await store.load()).toEqual({
+			mode: "read_only",
+			reason: "migration_write_failed",
+			migrated: false,
+			records: [custodyRecord({ topicId: "7" })],
+		});
+		expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+		expect(store.list()).toEqual([custodyRecord({ topicId: "7" })]);
+		expect(await store.put(custodyRecord({ topicId: "8" }))).toEqual({ ok: false, reason: "read_only" });
+		expect(fakeFs.unlinkCalls).toHaveLength(1);
+	});
+
+	test("uses restrictive permissions, same-directory atomic renames, and cleans temporary writes on failure", async () => {
+		const fakeFs = new FakeFs();
+		const store = storeWith(fakeFs);
+		await store.load();
+		await store.put(custodyRecord());
+		expect(fakeFs.mkdirCalls).toEqual([{ path: daemonPaths(AGENT_DIR).dir, mode: 0o700 }]);
+		expect(fakeFs.chmodCalls[0]).toEqual({ path: daemonPaths(AGENT_DIR).dir, mode: 0o700 });
+		expect(fakeFs.writeCalls[0]?.mode).toBe(0o600);
+		expect(fakeFs.chmodCalls[1]?.mode).toBe(0o600);
+		expect(path.dirname(fakeFs.renameCalls[0]!.from)).toBe(path.dirname(fakeFs.renameCalls[0]!.to));
+
+		const before = fakeFs.files.get(CUSTODY_PATH);
+		fakeFs.failWrite = true;
+		await expect(store.put(custodyRecord({ topicId: "8" }))).rejects.toThrow("simulated write failure");
+		expect(store.get({ chatId: "42", topicId: "8" })).toBeUndefined();
+		expect(fakeFs.files.get(CUSTODY_PATH)).toBe(before);
+		expect([...fakeFs.files.keys()].some(file => file.endsWith(".tmp"))).toBe(false);
+		expect(fakeFs.unlinkCalls).toHaveLength(1);
+	});
+
+	test("serializes overlapping puts and removes and returns copies from read APIs", async () => {
+		const fakeFs = new FakeFs();
+		const store = storeWith(fakeFs);
+		await store.load();
+		const first = store.put(custodyRecord({ topicId: "1" }));
+		const second = store.put(custodyRecord({ topicId: "2" }));
+		const third = store.remove({ chatId: "42", topicId: "1" });
+		expect(await Promise.all([first, second, third])).toEqual([{ ok: true }, { ok: true }, { ok: true }]);
+		expect(store.list()).toEqual([custodyRecord({ topicId: "2" })]);
+
+		const fromGet = store.get({ chatId: "42", topicId: "2" })!;
+		fromGet.state = "unknown";
+		const fromList = store.list()[0]!;
+		fromList.state = "unknown";
+		expect(store.get({ chatId: "42", topicId: "2" })?.state).toBe("queued");
+	});
+
+	test("serializes only custody fields and validates delimiter-safe decimal keys", async () => {
+		const fakeFs = new FakeFs();
+		const store = storeWith(fakeFs);
+		await store.load();
+		await store.put(custodyRecord({ chatId: "-100123", topicId: "77", custodyEpoch: 9 }));
+		const data = fakeFs.files.get(CUSTODY_PATH)!;
+		expect(data).toContain('"-100123:77"');
+		expect(data).not.toMatch(/token|session|endpoint|fingerprint|messageText/i);
+		expect(telegramCustodyKey("1", "23")).toBe("1:23");
+		expect(telegramCustodyKey("12", "3")).toBe("12:3");
+		expect(() => telegramCustodyKey("01", "3")).toThrow("Invalid Telegram custody identifier");
+	});
+});

--- a/packages/coding-agent/src/notifications/telegram-custody-store.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.ts
@@ -1,0 +1,484 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { daemonPaths } from "./daemon-paths";
+
+export const TELEGRAM_CUSTODY_SCHEMA_VERSION = 2;
+export const TELEGRAM_CUSTODY_MAX_RECORDS = 1_000;
+export const TELEGRAM_CUSTODY_MAX_FILE_BYTES = 1_048_576;
+
+export type TelegramCustodyState = "queued" | "in_flight" | "unknown";
+
+export interface TelegramCustodyRecord {
+	chatId: string;
+	topicId: string;
+	state: TelegramCustodyState;
+	updatedAt: number;
+	custodyEpoch?: number;
+}
+
+export type TelegramCustodyReadOnlyReason = "corrupt" | "forward_version" | "bounds" | "migration_write_failed";
+
+export interface TelegramCustodyLoadResult {
+	mode: "writable" | "read_only";
+	reason?: TelegramCustodyReadOnlyReason;
+	migrated: boolean;
+	records: readonly TelegramCustodyRecord[];
+}
+
+export type TelegramCustodyWriteResult = { ok: true } | { ok: false; reason: "read_only" };
+
+export interface TelegramCustodyStoreFs {
+	mkdir(path: string, opts?: fs.MakeDirectoryOptions): Promise<unknown>;
+	readFile(path: string, encoding: BufferEncoding): Promise<string>;
+	writeFile(path: string, data: string, opts?: fs.WriteFileOptions): Promise<void>;
+	rename(oldPath: string, newPath: string): Promise<void>;
+	chmod(path: string, mode: number): Promise<void>;
+	unlink(path: string): Promise<void>;
+}
+
+const CUSTODY_FILENAME = "telegram-deletion-custody.json";
+const nodeFs: TelegramCustodyStoreFs = fs.promises as unknown as TelegramCustodyStoreFs;
+
+type StoreMode = "writable" | "read_only";
+
+type ParseResult<T> = { ok: true; value: T } | { ok: false; reason: "corrupt" | "bounds" };
+
+interface TelegramCustodyV1Record {
+	state: TelegramCustodyState;
+	updatedAt: number;
+	custodyEpoch?: number;
+}
+
+interface TelegramCustodyV1Snapshot {
+	chatId: string;
+	records: TelegramCustodyRecord[];
+}
+
+interface ParsedV2Snapshot {
+	records: TelegramCustodyRecord[];
+	hasInFlight: boolean;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function hasExactKeys(
+	value: Record<string, unknown>,
+	required: readonly string[],
+	optional: readonly string[] = [],
+): boolean {
+	const keys = Object.keys(value);
+	if (keys.length < required.length || keys.length > required.length + optional.length) return false;
+	return (
+		required.every(key => Object.hasOwn(value, key)) &&
+		keys.every(key => required.includes(key) || optional.includes(key))
+	);
+}
+
+function isCanonicalChatId(value: unknown): value is string {
+	return typeof value === "string" && value.length >= 1 && value.length <= 32 && /^-?[1-9]\d*$/.test(value);
+}
+
+function isCanonicalTopicId(value: unknown): value is string {
+	return typeof value === "string" && value.length <= 20 && /^[1-9]\d*$/.test(value);
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isTelegramCustodyState(value: unknown): value is TelegramCustodyState {
+	return value === "queued" || value === "in_flight" || value === "unknown";
+}
+
+function compareKeys(left: string, right: string): number {
+	if (left < right) return -1;
+	if (left > right) return 1;
+	return 0;
+}
+
+function cloneRecord(record: TelegramCustodyRecord): TelegramCustodyRecord {
+	return record.custodyEpoch === undefined
+		? {
+				chatId: record.chatId,
+				topicId: record.topicId,
+				state: record.state,
+				updatedAt: record.updatedAt,
+			}
+		: {
+				chatId: record.chatId,
+				topicId: record.topicId,
+				state: record.state,
+				updatedAt: record.updatedAt,
+				custodyEpoch: record.custodyEpoch,
+			};
+}
+
+function cloneRecords(records: Iterable<TelegramCustodyRecord>): TelegramCustodyRecord[] {
+	return Array.from(records, cloneRecord);
+}
+
+function readRecord(value: unknown): TelegramCustodyRecord | undefined {
+	if (!isPlainObject(value) || !hasExactKeys(value, ["chatId", "topicId", "state", "updatedAt"], ["custodyEpoch"])) {
+		return undefined;
+	}
+	if (
+		!isCanonicalChatId(value.chatId) ||
+		!isCanonicalTopicId(value.topicId) ||
+		!isTelegramCustodyState(value.state) ||
+		!isNonNegativeSafeInteger(value.updatedAt)
+	) {
+		return undefined;
+	}
+	if (!Object.hasOwn(value, "custodyEpoch")) {
+		return { chatId: value.chatId, topicId: value.topicId, state: value.state, updatedAt: value.updatedAt };
+	}
+	if (!isNonNegativeSafeInteger(value.custodyEpoch)) return undefined;
+	return {
+		chatId: value.chatId,
+		topicId: value.topicId,
+		state: value.state,
+		updatedAt: value.updatedAt,
+		custodyEpoch: value.custodyEpoch,
+	};
+}
+
+function readV1Record(value: unknown): TelegramCustodyV1Record | undefined {
+	if (!isPlainObject(value) || !hasExactKeys(value, ["state", "updatedAt"], ["custodyEpoch"])) return undefined;
+	if (!isTelegramCustodyState(value.state) || !isNonNegativeSafeInteger(value.updatedAt)) return undefined;
+	if (!Object.hasOwn(value, "custodyEpoch")) return { state: value.state, updatedAt: value.updatedAt };
+	if (!isNonNegativeSafeInteger(value.custodyEpoch)) return undefined;
+	return { state: value.state, updatedAt: value.updatedAt, custodyEpoch: value.custodyEpoch };
+}
+
+/** Validate decimal-only ID segments and form their unambiguous composite storage key. */
+export function telegramCustodyKey(chatId: string, topicId: string): string {
+	if (!isCanonicalChatId(chatId) || !isCanonicalTopicId(topicId)) {
+		throw new Error("Invalid Telegram custody identifier");
+	}
+	return `${chatId}:${topicId}`;
+}
+
+function parseV2(value: unknown): ParseResult<ParsedV2Snapshot> {
+	if (
+		!isPlainObject(value) ||
+		!hasExactKeys(value, ["version", "records"]) ||
+		value.version !== TELEGRAM_CUSTODY_SCHEMA_VERSION
+	) {
+		return { ok: false, reason: "corrupt" };
+	}
+	if (!isPlainObject(value.records)) return { ok: false, reason: "corrupt" };
+
+	const entries = Object.entries(value.records);
+	if (entries.length > TELEGRAM_CUSTODY_MAX_RECORDS) return { ok: false, reason: "bounds" };
+
+	const records: TelegramCustodyRecord[] = [];
+	let hasInFlight = false;
+	for (const [key, rawRecord] of entries) {
+		const record = readRecord(rawRecord);
+		if (!record) return { ok: false, reason: "corrupt" };
+		if (key !== telegramCustodyKey(record.chatId, record.topicId)) return { ok: false, reason: "corrupt" };
+		records.push(record);
+		hasInFlight ||= record.state === "in_flight";
+	}
+	return {
+		ok: true,
+		value: {
+			records: records.sort((left, right) =>
+				compareKeys(telegramCustodyKey(left.chatId, left.topicId), telegramCustodyKey(right.chatId, right.topicId)),
+			),
+			hasInFlight,
+		},
+	};
+}
+
+function parseV1(value: unknown): ParseResult<TelegramCustodyV1Snapshot> {
+	if (!isPlainObject(value) || !hasExactKeys(value, ["version", "chatId", "records"]) || value.version !== 1) {
+		return { ok: false, reason: "corrupt" };
+	}
+	if (!isCanonicalChatId(value.chatId) || !isPlainObject(value.records)) return { ok: false, reason: "corrupt" };
+
+	const entries = Object.entries(value.records);
+	if (entries.length > TELEGRAM_CUSTODY_MAX_RECORDS) return { ok: false, reason: "bounds" };
+
+	const records: TelegramCustodyRecord[] = [];
+	for (const [topicId, rawRecord] of entries) {
+		if (!isCanonicalTopicId(topicId)) return { ok: false, reason: "corrupt" };
+		const record = readV1Record(rawRecord);
+		if (!record) return { ok: false, reason: "corrupt" };
+		records.push(
+			record.custodyEpoch === undefined
+				? {
+						chatId: value.chatId,
+						topicId,
+						state: record.state === "in_flight" ? "unknown" : record.state,
+						updatedAt: record.updatedAt,
+					}
+				: {
+						chatId: value.chatId,
+						topicId,
+						state: record.state === "in_flight" ? "unknown" : record.state,
+						updatedAt: record.updatedAt,
+						custodyEpoch: record.custodyEpoch,
+					},
+		);
+	}
+	return { ok: true, value: { chatId: value.chatId, records } };
+}
+
+function classifyV2Records(records: readonly TelegramCustodyRecord[]): TelegramCustodyRecord[] {
+	return records.map(record =>
+		record.state === "in_flight" ? { ...cloneRecord(record), state: "unknown" } : cloneRecord(record),
+	);
+}
+
+function canonicalRecordsObject(records: Iterable<TelegramCustodyRecord>): Record<string, TelegramCustodyRecord> {
+	const entries = Array.from(
+		records,
+		record => [telegramCustodyKey(record.chatId, record.topicId), cloneRecord(record)] as const,
+	).sort((left, right) => compareKeys(left[0], right[0]));
+	return Object.fromEntries(entries);
+}
+
+function serialize(records: Iterable<TelegramCustodyRecord>): string {
+	return `${JSON.stringify(
+		{ version: TELEGRAM_CUSTODY_SCHEMA_VERSION, records: canonicalRecordsObject(records) },
+		null,
+		2,
+	)}\n`;
+}
+
+function findStringEnd(source: string, start: number): number | undefined {
+	for (let position = start + 1; position < source.length; position++) {
+		const character = source[position];
+		if (character === "\\") {
+			position++;
+			continue;
+		}
+		if (character === '"') return position + 1;
+	}
+	return undefined;
+}
+
+/** JSON.parse intentionally accepts duplicate object members; custody files do not. */
+function hasDuplicateObjectKeys(source: string): boolean {
+	function skipWhitespace(position: number): number {
+		while (/\s/.test(source[position] ?? "")) position++;
+		return position;
+	}
+
+	function scanString(position: number): { value: string; end: number } | undefined {
+		const end = findStringEnd(source, position);
+		if (end === undefined) return undefined;
+		try {
+			return { value: JSON.parse(source.slice(position, end)) as string, end };
+		} catch {
+			return undefined;
+		}
+	}
+
+	function scanValue(position: number): number | undefined {
+		position = skipWhitespace(position);
+		const character = source[position];
+		if (character === '"') return scanString(position)?.end;
+		if (character === "{") {
+			position = skipWhitespace(position + 1);
+			const keys = new Set<string>();
+			if (source[position] === "}") return position + 1;
+			while (true) {
+				if (source[position] !== '"') return undefined;
+				const key = scanString(position);
+				if (!key || keys.has(key.value)) return undefined;
+				keys.add(key.value);
+				position = skipWhitespace(key.end);
+				if (source[position] !== ":") return undefined;
+				const valueEnd = scanValue(position + 1);
+				if (valueEnd === undefined) return undefined;
+				position = skipWhitespace(valueEnd);
+				if (source[position] === "}") return position + 1;
+				if (source[position] !== ",") return undefined;
+				position = skipWhitespace(position + 1);
+			}
+		}
+		if (character === "[") {
+			position = skipWhitespace(position + 1);
+			if (source[position] === "]") return position + 1;
+			while (true) {
+				const valueEnd = scanValue(position);
+				if (valueEnd === undefined) return undefined;
+				position = skipWhitespace(valueEnd);
+				if (source[position] === "]") return position + 1;
+				if (source[position] !== ",") return undefined;
+				position = skipWhitespace(position + 1);
+			}
+		}
+		while (position < source.length && !/[\s,}\]]/.test(source[position]!)) position++;
+		return position;
+	}
+
+	const end = scanValue(0);
+	return end === undefined || skipWhitespace(end) !== source.length;
+}
+
+export class TelegramCustodyStore {
+	readonly #dir: string;
+	readonly #file: string;
+	readonly #fsImpl: TelegramCustodyStoreFs;
+	readonly #now: () => number;
+	#mode: StoreMode = "writable";
+	#records = new Map<string, TelegramCustodyRecord>();
+	#operations: Promise<void> = Promise.resolve();
+
+	constructor(input: { agentDir: string; fs?: TelegramCustodyStoreFs; now?: () => number }) {
+		this.#dir = daemonPaths(input.agentDir).dir;
+		this.#file = path.join(this.#dir, CUSTODY_FILENAME);
+		this.#fsImpl = input.fs ?? nodeFs;
+		this.#now = input.now ?? Date.now;
+	}
+
+	async load(): Promise<TelegramCustodyLoadResult> {
+		return this.#serializeOperation<TelegramCustodyLoadResult>(async () => this.#load());
+	}
+
+	list(): readonly TelegramCustodyRecord[] {
+		return cloneRecords(this.#records.values()).sort((left, right) =>
+			compareKeys(telegramCustodyKey(left.chatId, left.topicId), telegramCustodyKey(right.chatId, right.topicId)),
+		);
+	}
+
+	get(input: { chatId: string; topicId: string }): TelegramCustodyRecord | undefined {
+		const record = this.#records.get(telegramCustodyKey(input.chatId, input.topicId));
+		return record === undefined ? undefined : cloneRecord(record);
+	}
+
+	async put(record: TelegramCustodyRecord): Promise<TelegramCustodyWriteResult> {
+		const validated = readRecord(record);
+		if (!validated) throw new Error("Invalid Telegram custody record");
+		const copy = cloneRecord(validated);
+		return this.#serializeOperation<TelegramCustodyWriteResult>(async () => {
+			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
+			const next = new Map(this.#records);
+			next.set(telegramCustodyKey(copy.chatId, copy.topicId), copy);
+			if (next.size > TELEGRAM_CUSTODY_MAX_RECORDS) throw new Error("Telegram custody record limit exceeded");
+			await this.#persist(next.values());
+			this.#records = next;
+			return { ok: true };
+		});
+	}
+
+	async remove(input: { chatId: string; topicId: string }): Promise<TelegramCustodyWriteResult> {
+		const key = telegramCustodyKey(input.chatId, input.topicId);
+		return this.#serializeOperation<TelegramCustodyWriteResult>(async () => {
+			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
+			const next = new Map(this.#records);
+			next.delete(key);
+			await this.#persist(next.values());
+			this.#records = next;
+			return { ok: true };
+		});
+	}
+
+	async #load(): Promise<TelegramCustodyLoadResult> {
+		let source: string;
+		try {
+			source = await this.#fsImpl.readFile(this.#file, "utf8");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			this.#mode = "writable";
+			this.#records = new Map();
+			return { mode: "writable", migrated: false, records: [] };
+		}
+
+		if (Buffer.byteLength(source, "utf8") > TELEGRAM_CUSTODY_MAX_FILE_BYTES) return this.#readOnly("bounds", []);
+
+		let document: unknown;
+		try {
+			if (hasDuplicateObjectKeys(source)) return this.#readOnly("corrupt", []);
+			document = JSON.parse(source) as unknown;
+		} catch {
+			return this.#readOnly("corrupt", []);
+		}
+
+		if (
+			isPlainObject(document) &&
+			typeof document.version === "number" &&
+			document.version > TELEGRAM_CUSTODY_SCHEMA_VERSION
+		) {
+			return this.#readOnly("forward_version", []);
+		}
+
+		const v2 = parseV2(document);
+		if (v2.ok) {
+			const records = classifyV2Records(v2.value.records);
+			if (v2.value.hasInFlight) {
+				try {
+					await this.#persist(records);
+				} catch {
+					return this.#readOnly("migration_write_failed", records);
+				}
+			}
+			this.#mode = "writable";
+			this.#setRecords(records);
+			return { mode: "writable", migrated: false, records: this.list() };
+		}
+
+		const v1 = parseV1(document);
+		if (!v1.ok) return this.#readOnly(v2.reason === "bounds" || v1.reason === "bounds" ? "bounds" : "corrupt", []);
+
+		try {
+			await this.#persist(v1.value.records);
+		} catch {
+			return this.#readOnly("migration_write_failed", v1.value.records);
+		}
+		this.#mode = "writable";
+		this.#setRecords(v1.value.records);
+		return { mode: "writable", migrated: true, records: this.list() };
+	}
+
+	#readOnly(
+		reason: TelegramCustodyReadOnlyReason,
+		records: readonly TelegramCustodyRecord[],
+	): TelegramCustodyLoadResult {
+		this.#mode = "read_only";
+		this.#setRecords(records);
+		return { mode: "read_only", reason, migrated: false, records: this.list() };
+	}
+
+	#setRecords(records: Iterable<TelegramCustodyRecord>): void {
+		this.#records = new Map(
+			Array.from(
+				records,
+				record => [telegramCustodyKey(record.chatId, record.topicId), cloneRecord(record)] as const,
+			),
+		);
+	}
+
+	async #persist(records: Iterable<TelegramCustodyRecord>): Promise<void> {
+		const data = serialize(records);
+		if (Buffer.byteLength(data, "utf8") > TELEGRAM_CUSTODY_MAX_FILE_BYTES) {
+			throw new Error("Telegram custody snapshot exceeds the maximum file size");
+		}
+
+		await this.#fsImpl.mkdir(this.#dir, { recursive: true, mode: 0o700 });
+		await this.#fsImpl.chmod(this.#dir, 0o700);
+		const temporaryFile = `${this.#file}.${process.pid}.${this.#now()}.${Math.random().toString(36).slice(2)}.tmp`;
+		try {
+			await this.#fsImpl.writeFile(temporaryFile, data, { mode: 0o600 });
+			await this.#fsImpl.chmod(temporaryFile, 0o600);
+			await this.#fsImpl.rename(temporaryFile, this.#file);
+		} catch (error) {
+			await this.#fsImpl.unlink(temporaryFile).catch(() => undefined);
+			throw error;
+		}
+	}
+
+	async #serializeOperation<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.#operations.then(operation, operation);
+		this.#operations = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	}
+}

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -47,6 +47,7 @@ import { listRecentSessions } from "./recent-activity";
 import { ReplySentStore } from "./reply-sent-store";
 import { DraftStreamState, deliverDraft, shouldStreamDraft } from "./rich-draft";
 import { deliverRichActionWithFallback, deliverRichWithFallback, shouldPromoteRich } from "./rich-render";
+import { type TelegramCustodyLoadResult, TelegramCustodyStore } from "./telegram-custody-store";
 import {
 	type AliasTable,
 	buildActionMarkdown,
@@ -1024,6 +1025,9 @@ export class TelegramNotificationDaemon {
 	private running = false;
 	private readonly fsImpl: TelegramDaemonFs;
 	private readonly botApi: BotApi;
+	readonly #custodyStore: TelegramCustodyStore;
+	/** Startup custody result retained for later deletion-recovery phases. */
+	#custodyLoadResult: TelegramCustodyLoadResult | undefined;
 	private readonly topics = new TopicRegistry();
 	/** Serializes registry snapshots so an older atomic write cannot overwrite newer rename state. */
 	private topicsPersistQueue: Promise<void> = Promise.resolve();
@@ -1430,6 +1434,11 @@ export class TelegramNotificationDaemon {
 	constructor(private readonly opts: TelegramDaemonOptions) {
 		this.fsImpl = opts.fs ?? nodeFs;
 		this.replyStore = new ReplySentStore({ agentDir: opts.settings.getAgentDir(), fs: opts.fs });
+		this.#custodyStore = new TelegramCustodyStore({
+			agentDir: opts.settings.getAgentDir(),
+			fs: opts.fs,
+			now: opts.now,
+		});
 		this.aliasTable = createAliasTable();
 		this.botApi =
 			opts.botApi ??
@@ -2114,6 +2123,15 @@ export class TelegramNotificationDaemon {
 		// Restore the full serialized registry (topicId + identitySent + name) so a
 		// fresh daemon after reload does not resend identity headers or lose renames.
 		if (raw && typeof raw === "object") this.topics.load(raw);
+	}
+	get custodyLoadResult(): TelegramCustodyLoadResult | undefined {
+		return this.#custodyLoadResult;
+	}
+
+	async loadCustody(): Promise<TelegramCustodyLoadResult> {
+		const result = await this.#custodyStore.load();
+		this.#custodyLoadResult = result;
+		return result;
 	}
 
 	/** Download a Telegram file by its file_path (from getFile) into memory. */
@@ -3227,6 +3245,7 @@ export class TelegramNotificationDaemon {
 			await this.registerBotCommands();
 			await this.loadAliases();
 			await this.loadTopics();
+			await this.loadCustody();
 			await this.loadSeenUpdateIds();
 			await this.replyStore.load();
 			await this.runScan();

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -4048,6 +4048,73 @@ test("run() persists aliases before releasing ownership on exit", async () => {
 	await daemon.run();
 	expect(fs.existsSync(daemonPaths(agentDir).aliases)).toBe(true);
 });
+describe("telegram custody loading", () => {
+	test("migrates custody before the first scan without Telegram deletion or delivery", async () => {
+		const agentDir = tempAgentDir();
+		const custodyPath = path.join(agentDir, "notifications", "telegram-deletion-custody.json");
+		fs.mkdirSync(path.dirname(custodyPath), { recursive: true });
+		fs.writeFileSync(
+			custodyPath,
+			JSON.stringify({
+				version: 1,
+				chatId: "42",
+				records: { "7": { state: "in_flight", updatedAt: 1 } },
+			}),
+		);
+
+		const s = settings(agentDir);
+		const events: string[] = [];
+		await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "e60b05c186ca",
+			chatId: "42",
+			pid: process.pid,
+			randomId: () => "owner",
+		});
+		class CustodyOrderDaemon extends TelegramNotificationDaemon {
+			override async loadTopics(): Promise<void> {
+				events.push("topics");
+			}
+
+			override async loadCustody() {
+				const result = await super.loadCustody();
+				events.push("custody");
+				return result;
+			}
+
+			override async scanRoots(): Promise<void> {
+				events.push("scan");
+				this.requestStop();
+			}
+		}
+		const bot = new FakeBotApi();
+		const daemon = new CustodyOrderDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			createLifecycleControlServer: null,
+			scanIntervalMs: 2_147_483_647,
+		});
+
+		await daemon.run();
+
+		expect(events).toEqual(["topics", "custody", "scan"]);
+		expect(daemon.custodyLoadResult).toEqual({
+			mode: "writable",
+			migrated: true,
+			records: [{ chatId: "42", topicId: "7", state: "unknown", updatedAt: 1 }],
+		});
+		expect(JSON.parse(fs.readFileSync(custodyPath, "utf8"))).toEqual({
+			version: 2,
+			records: {
+				"42:7": { chatId: "42", topicId: "7", state: "unknown", updatedAt: 1 },
+			},
+		});
+		expect(bot.calls.filter(call => call.method === "deleteForumTopic" || call.method === "sendMessage")).toEqual([]);
+	});
+});
 
 test("a fresh daemon scanRoots reconnects an existing session endpoint", async () => {
 	FakeWs.instances = [];


### PR DESCRIPTION
## What

This draft adds the storage-only foundation for safe Telegram forum-topic deletion custody.

- persist strict schema-v2 custody records keyed by canonical chat/topic identity
- support `queued`, `in_flight`, and fail-closed `unknown` states across multiple chats
- migrate one strict legacy single-chat schema atomically
- classify stale `in_flight` records as `unknown` before daemon scanning
- disable writes without rewriting corrupt, oversized, or forward-version state
- serialize mutations with bounded records/file size, private permissions, atomic rename, and copy-out readers
- load custody after topic state and before the first daemon scan

This PR intentionally does not add or redirect any Telegram deletion request. Existing `deleteForumTopic`, protocol 3, daemon generation, capabilities, Selected acknowledgements, and Bot API retry behavior remain unchanged.

## Why

Topic deletion is irreversible. Before a later PR can fence and settle a single deletion attempt, the daemon needs a durable, multi-chat, forward-safe custody boundary that cannot silently downgrade or treat an uncertain attempt as success.

## Testing

- `bun test packages/coding-agent/src/notifications/telegram-custody-store.test.ts` — 12 passed, 0 failed, 82 assertions
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts -t "telegram custody loading"` — 1 passed, 147 filtered, 0 failed
- `bun --cwd=packages/coding-agent run check:types` — passed
- `git diff --check` — passed

The combined focused run completed 159 tests and reported one unrelated Windows file-mode assertion (`0600` observed as `0666`). The same assertion fails unchanged on the custody-free source worktree, so this draft does not hide or claim that baseline issue as fixed.

## Dependency / rollback

This is an independent Telegram root based on `dev@96eed5e3`. Later custody-epoch and exact-settlement PRs will stack on it. Rollback is disable/read-only: once a schema-v2 file exists, retain this reader until all records are resolved or archived; never downgrade v2 in place.

## Reviewer note

Thank you for reviewing this storage boundary. I would especially appreciate scrutiny of the strict parser, crash classification, atomic write ordering, forward-version behavior, and proof that custody loading itself performs no network deletion.

Reviewed scope: commit `e8b2a8260cbbd3f5c31feb644ea9977ff433a47b`, four files, 944 added lines.