### PR TITLE
notifications: fence Telegram custody ownership epochs

### DIFF
--- a/packages/coding-agent/src/notifications/telegram-custody-epoch.test.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-epoch.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "bun:test";
+import type * as nodeFs from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	allocateTelegramCustodyEpoch,
+	TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES,
+	TelegramCustodyEpochError,
+	type TelegramCustodyEpochFs,
+	telegramCustodyEpochPath,
+	readTelegramCustodyEpoch,
+	withCurrentTelegramCustodyEpoch,
+} from "./telegram-custody-epoch";
+
+class FailingEpochFs implements TelegramCustodyEpochFs {
+	readonly #delegate: TelegramCustodyEpochFs = fs as unknown as TelegramCustodyEpochFs;
+	readonly chmodCalls: { file: string; mode: number }[] = [];
+	readonly renameCalls: { from: string; to: string }[] = [];
+	readonly writeCalls: { file: string; mode: number | undefined }[] = [];
+	readonly openCalls: { file: string; flags: string }[] = [];
+	failWrite = false;
+	failRename = false;
+	failSyncAt: number | undefined;
+	failSyncCode: string | undefined;
+	#syncCalls = 0;
+
+	async mkdir(file: string, options?: nodeFs.MakeDirectoryOptions): Promise<unknown> {
+		return this.#delegate.mkdir(file, options);
+	}
+
+	async readFile(file: string, encoding: BufferEncoding): Promise<string> {
+		return this.#delegate.readFile(file, encoding);
+	}
+
+	async writeFile(file: string, data: string, options?: nodeFs.WriteFileOptions): Promise<void> {
+		this.writeCalls.push({
+			file,
+			mode: typeof options === "object" && options !== null ? (options.mode as number | undefined) : undefined,
+		});
+		if (this.failWrite) throw new Error("simulated write failure");
+		await this.#delegate.writeFile(file, data, options);
+	}
+
+	async rename(oldPath: string, newPath: string): Promise<void> {
+		this.renameCalls.push({ from: oldPath, to: newPath });
+		if (this.failRename) throw new Error("simulated rename failure");
+		await this.#delegate.rename(oldPath, newPath);
+	}
+
+	async chmod(file: string, mode: number): Promise<void> {
+		this.chmodCalls.push({ file, mode });
+		await this.#delegate.chmod(file, mode);
+	}
+
+	async unlink(file: string): Promise<void> {
+		await this.#delegate.unlink(file);
+	}
+
+	async open(file: string, flags: string, mode?: number): Promise<{ sync(): Promise<void>; close(): Promise<void> }> {
+		this.openCalls.push({ file, flags });
+		const handle = await this.#delegate.open(file, flags, mode);
+		return {
+			sync: async () => {
+				this.#syncCalls++;
+				if (this.#syncCalls === this.failSyncAt) {
+					throw Object.assign(new Error("simulated sync failure"), { code: this.failSyncCode });
+				}
+				await handle.sync();
+			},
+			close: async () => handle.close(),
+		};
+	}
+}
+
+async function withAgentDirectory(operation: (agentDir: string) => Promise<void>): Promise<void> {
+	const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-telegram-custody-epoch-"));
+	try {
+		await operation(agentDir);
+	} finally {
+		await fs.rm(agentDir, { recursive: true, force: true });
+	}
+}
+
+async function expectFailure(
+	operation: Promise<unknown>,
+	reason: TelegramCustodyEpochError["reason"],
+): Promise<void> {
+	await expect(operation).rejects.toMatchObject({ name: "TelegramCustodyEpochError", reason });
+}
+
+describe("Telegram custody epoch", () => {
+	test("allocates durable positive epochs monotonically across restarts", async () => {
+		await withAgentDirectory(async agentDir => {
+			const first = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
+			const second = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-b" });
+
+			expect(first).toEqual({ ownerId: "owner-a", custodyEpoch: 1 });
+			expect(second).toEqual({ ownerId: "owner-b", custodyEpoch: 2 });
+			expect(await readTelegramCustodyEpoch({ agentDir })).toEqual(second);
+		});
+	});
+
+	test("serializes concurrent contenders into unique monotonically increasing bindings", async () => {
+		await withAgentDirectory(async agentDir => {
+			const bindings = await Promise.all(
+				["owner-a", "owner-b", "owner-c", "owner-d", "owner-e"].map(ownerId =>
+					allocateTelegramCustodyEpoch({ agentDir, ownerId }),
+				),
+			);
+
+			expect(bindings.map(binding => binding.custodyEpoch).sort((left, right) => left - right)).toEqual([1, 2, 3, 4, 5]);
+			expect(new Set(bindings.map(binding => binding.ownerId))).toEqual(
+				new Set(["owner-a", "owner-b", "owner-c", "owner-d", "owner-e"]),
+			);
+		});
+	});
+
+	test("fences stale bindings, including owner-id ABA reuse", async () => {
+		await withAgentDirectory(async agentDir => {
+			const first = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
+			const second = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-b" });
+			const third = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
+			let called = false;
+
+			expect(await withCurrentTelegramCustodyEpoch({ agentDir, binding: first }, async () => {
+				called = true;
+			})).toEqual({ ok: false, reason: "fenced" });
+			expect(await withCurrentTelegramCustodyEpoch({ agentDir, binding: second }, async () => undefined)).toEqual({
+				ok: false,
+				reason: "fenced",
+			});
+			expect(await withCurrentTelegramCustodyEpoch({ agentDir, binding: third }, async () => "current")).toEqual({
+				ok: true,
+				value: "current",
+			});
+			expect(called).toBe(false);
+		});
+	});
+
+	test("rejects malformed, duplicate, extra, invalid, forward, and oversized snapshots without rewriting bytes", async () => {
+		await withAgentDirectory(async agentDir => {
+			const epochPath = telegramCustodyEpochPath(agentDir);
+			const corruptSources = [
+				"{ not json",
+				'{"version":1,"version":1,"custodyEpoch":1,"ownerId":"owner"}',
+				'{"version":1,"custodyEpoch":1,"ownerId":"owner","extra":true}',
+				'{"version":1,"custodyEpoch":1}',
+				'{"version":0,"custodyEpoch":1,"ownerId":"owner"}',
+				'{"version":1.5,"custodyEpoch":1,"ownerId":"owner"}',
+				'{"version":1,"custodyEpoch":0,"ownerId":"owner"}',
+				'{"version":1,"custodyEpoch":-1,"ownerId":"owner"}',
+				'{"version":1,"custodyEpoch":1.5,"ownerId":"owner"}',
+				`{"version":1,"custodyEpoch":${Number.MAX_SAFE_INTEGER + 1},"ownerId":"owner"}`,
+				'{"version":1,"custodyEpoch":1,"ownerId":""}',
+				" ".repeat(TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES + 1),
+			];
+			for (const source of corruptSources) {
+				await fs.mkdir(path.dirname(epochPath), { recursive: true });
+				await fs.writeFile(epochPath, source);
+				await expectFailure(readTelegramCustodyEpoch({ agentDir }), "corrupt");
+				await expectFailure(allocateTelegramCustodyEpoch({ agentDir, ownerId: "next-owner" }), "corrupt");
+				expect(await fs.readFile(epochPath, "utf8")).toBe(source);
+			}
+
+			const forward = '{"version":2,"custodyEpoch":1,"ownerId":"owner"}';
+			await fs.writeFile(epochPath, forward);
+			await expectFailure(readTelegramCustodyEpoch({ agentDir }), "forward_version");
+			await expectFailure(allocateTelegramCustodyEpoch({ agentDir, ownerId: "next-owner" }), "forward_version");
+			expect(await fs.readFile(epochPath, "utf8")).toBe(forward);
+		});
+	});
+	test("rejects an oversized owner allocation before publishing a target or temporary file", async () => {
+		await withAgentDirectory(async agentDir => {
+			const epochPath = telegramCustodyEpochPath(agentDir);
+			const fakeFs = new FailingEpochFs();
+
+			await expectFailure(
+				allocateTelegramCustodyEpoch({
+					agentDir,
+					ownerId: "x".repeat(TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES),
+					fs: fakeFs,
+				}),
+				"corrupt",
+			);
+
+			await expect(fs.access(epochPath)).rejects.toMatchObject({ code: "ENOENT" });
+			expect(fakeFs.writeCalls).toEqual([]);
+			expect((await fs.readdir(path.dirname(epochPath))).some(entry => entry.endsWith(".tmp"))).toBe(false);
+		});
+	});
+
+	test("preserves an exhausted source and does not reset or reuse its epoch", async () => {
+		await withAgentDirectory(async agentDir => {
+			const epochPath = telegramCustodyEpochPath(agentDir);
+			const source = `{"version":1,"custodyEpoch":${Number.MAX_SAFE_INTEGER},"ownerId":"owner"}\n`;
+			await fs.mkdir(path.dirname(epochPath), { recursive: true });
+			await fs.writeFile(epochPath, source);
+
+			await expectFailure(allocateTelegramCustodyEpoch({ agentDir, ownerId: "next-owner" }), "exhausted");
+			expect(await fs.readFile(epochPath, "utf8")).toBe(source);
+		});
+	});
+
+	test("uses same-directory 0600 temporary writes and never returns a binding after write barriers fail", async () => {
+		await withAgentDirectory(async agentDir => {
+			const epochPath = telegramCustodyEpochPath(agentDir);
+			for (const failure of ["write", "temp-sync", "rename", "target-sync", "target-sync-eperm"] as const) {
+				const fakeFs = new FailingEpochFs();
+				if (failure === "write") fakeFs.failWrite = true;
+				if (failure === "rename") fakeFs.failRename = true;
+				if (failure === "temp-sync") fakeFs.failSyncAt = 1;
+				if (failure === "target-sync" || failure === "target-sync-eperm") {
+					fakeFs.failSyncAt = 2;
+					fakeFs.failSyncCode = failure === "target-sync-eperm" ? "EPERM" : undefined;
+				}
+				await expect(allocateTelegramCustodyEpoch({ agentDir, ownerId: `owner-${failure}`, fs: fakeFs })).rejects.toThrow(
+					"simulated",
+				);
+				const entries = await fs.readdir(path.dirname(epochPath));
+				expect(entries.some(entry => entry.endsWith(".tmp"))).toBe(false);
+			}
+
+			const fakeFs = new FailingEpochFs();
+			const binding = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-ok", fs: fakeFs });
+			expect(binding.custodyEpoch).toBeGreaterThan(0);
+			expect(fakeFs.writeCalls[0]?.mode).toBe(0o600);
+			expect(fakeFs.chmodCalls.some(call => call.file !== path.dirname(epochPath) && call.mode === 0o600)).toBe(true);
+			expect(path.dirname(fakeFs.renameCalls[0]!.from)).toBe(path.dirname(fakeFs.renameCalls[0]!.to));
+			expect(fakeFs.openCalls.map(call => call.flags)).toEqual(["r+", "r+", "r"]);
+		});
+	});
+});

--- a/packages/coding-agent/src/notifications/telegram-custody-epoch.test.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-epoch.test.ts
@@ -5,11 +5,11 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
 	allocateTelegramCustodyEpoch,
+	readTelegramCustodyEpoch,
 	TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES,
-	TelegramCustodyEpochError,
+	type TelegramCustodyEpochError,
 	type TelegramCustodyEpochFs,
 	telegramCustodyEpochPath,
-	readTelegramCustodyEpoch,
 	withCurrentTelegramCustodyEpoch,
 } from "./telegram-custody-epoch";
 
@@ -82,10 +82,7 @@ async function withAgentDirectory(operation: (agentDir: string) => Promise<void>
 	}
 }
 
-async function expectFailure(
-	operation: Promise<unknown>,
-	reason: TelegramCustodyEpochError["reason"],
-): Promise<void> {
+async function expectFailure(operation: Promise<unknown>, reason: TelegramCustodyEpochError["reason"]): Promise<void> {
 	await expect(operation).rejects.toMatchObject({ name: "TelegramCustodyEpochError", reason });
 }
 
@@ -109,7 +106,9 @@ describe("Telegram custody epoch", () => {
 				),
 			);
 
-			expect(bindings.map(binding => binding.custodyEpoch).sort((left, right) => left - right)).toEqual([1, 2, 3, 4, 5]);
+			expect(bindings.map(binding => binding.custodyEpoch).sort((left, right) => left - right)).toEqual([
+				1, 2, 3, 4, 5,
+			]);
 			expect(new Set(bindings.map(binding => binding.ownerId))).toEqual(
 				new Set(["owner-a", "owner-b", "owner-c", "owner-d", "owner-e"]),
 			);
@@ -123,9 +122,11 @@ describe("Telegram custody epoch", () => {
 			const third = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
 			let called = false;
 
-			expect(await withCurrentTelegramCustodyEpoch({ agentDir, binding: first }, async () => {
-				called = true;
-			})).toEqual({ ok: false, reason: "fenced" });
+			expect(
+				await withCurrentTelegramCustodyEpoch({ agentDir, binding: first }, async () => {
+					called = true;
+				}),
+			).toEqual({ ok: false, reason: "fenced" });
 			expect(await withCurrentTelegramCustodyEpoch({ agentDir, binding: second }, async () => undefined)).toEqual({
 				ok: false,
 				reason: "fenced",
@@ -214,9 +215,9 @@ describe("Telegram custody epoch", () => {
 					fakeFs.failSyncAt = 2;
 					fakeFs.failSyncCode = failure === "target-sync-eperm" ? "EPERM" : undefined;
 				}
-				await expect(allocateTelegramCustodyEpoch({ agentDir, ownerId: `owner-${failure}`, fs: fakeFs })).rejects.toThrow(
-					"simulated",
-				);
+				await expect(
+					allocateTelegramCustodyEpoch({ agentDir, ownerId: `owner-${failure}`, fs: fakeFs }),
+				).rejects.toThrow("simulated");
 				const entries = await fs.readdir(path.dirname(epochPath));
 				expect(entries.some(entry => entry.endsWith(".tmp"))).toBe(false);
 			}
@@ -225,7 +226,9 @@ describe("Telegram custody epoch", () => {
 			const binding = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-ok", fs: fakeFs });
 			expect(binding.custodyEpoch).toBeGreaterThan(0);
 			expect(fakeFs.writeCalls[0]?.mode).toBe(0o600);
-			expect(fakeFs.chmodCalls.some(call => call.file !== path.dirname(epochPath) && call.mode === 0o600)).toBe(true);
+			expect(fakeFs.chmodCalls.some(call => call.file !== path.dirname(epochPath) && call.mode === 0o600)).toBe(
+				true,
+			);
 			expect(path.dirname(fakeFs.renameCalls[0]!.from)).toBe(path.dirname(fakeFs.renameCalls[0]!.to));
 			expect(fakeFs.openCalls.map(call => call.flags)).toEqual(["r+", "r+", "r"]);
 		});

--- a/packages/coding-agent/src/notifications/telegram-custody-epoch.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-epoch.ts
@@ -1,0 +1,298 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { withFileLock } from "../config/file-lock";
+import { daemonPaths } from "./daemon-paths";
+
+export const TELEGRAM_CUSTODY_EPOCH_SCHEMA_VERSION = 1;
+export const TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES = 4_096;
+
+export interface TelegramCustodyEpochBinding {
+	ownerId: string;
+	custodyEpoch: number;
+}
+
+export type TelegramCustodyEpochFailureReason = "corrupt" | "forward_version" | "exhausted";
+
+export class TelegramCustodyEpochError extends Error {
+	readonly reason: TelegramCustodyEpochFailureReason;
+
+	constructor(reason: TelegramCustodyEpochFailureReason) {
+		super(`Telegram custody epoch is ${reason}`);
+		this.name = "TelegramCustodyEpochError";
+		this.reason = reason;
+	}
+}
+
+export interface TelegramCustodyEpochFs {
+	mkdir(path: string, opts?: fs.MakeDirectoryOptions): Promise<unknown>;
+	readFile(path: string, encoding: BufferEncoding): Promise<string>;
+	writeFile(path: string, data: string, opts?: fs.WriteFileOptions): Promise<void>;
+	rename(oldPath: string, newPath: string): Promise<void>;
+	chmod(path: string, mode: number): Promise<void>;
+	unlink(path: string): Promise<void>;
+	open(path: string, flags: string, mode?: number): Promise<{ sync(): Promise<void>; close(): Promise<void> }>;
+}
+
+const EPOCH_FILENAME = "telegram-custody-epoch.json";
+const nodeFs: TelegramCustodyEpochFs = fs.promises as unknown as TelegramCustodyEpochFs;
+const UNSUPPORTED_DIRECTORY_SYNC_CODES = new Set(["EISDIR", "EINVAL", "ENOSYS", "ENOTSUP", "EPERM"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isBinding(value: unknown): value is TelegramCustodyEpochBinding {
+	return (
+		isPlainObject(value) &&
+		typeof value.ownerId === "string" &&
+		value.ownerId.length > 0 &&
+		isPositiveSafeInteger(value.custodyEpoch)
+	);
+}
+
+function findStringEnd(source: string, start: number): number | undefined {
+	for (let position = start + 1; position < source.length; position++) {
+		const character = source[position];
+		if (character === "\\") {
+			position++;
+			continue;
+		}
+		if (character === '"') return position + 1;
+	}
+	return undefined;
+}
+
+/** JSON.parse intentionally accepts duplicate object members; epoch files do not. */
+function hasDuplicateObjectKeys(source: string): boolean {
+	function skipWhitespace(position: number): number {
+		while (/\s/.test(source[position] ?? "")) position++;
+		return position;
+	}
+
+	function scanString(position: number): { value: string; end: number } | undefined {
+		const end = findStringEnd(source, position);
+		if (end === undefined) return undefined;
+		try {
+			return { value: JSON.parse(source.slice(position, end)) as string, end };
+		} catch {
+			return undefined;
+		}
+	}
+
+	function scanValue(position: number): number | undefined {
+		position = skipWhitespace(position);
+		const character = source[position];
+		if (character === '"') return scanString(position)?.end;
+		if (character === "{") {
+			position = skipWhitespace(position + 1);
+			const keys = new Set<string>();
+			if (source[position] === "}") return position + 1;
+			while (true) {
+				if (source[position] !== '"') return undefined;
+				const key = scanString(position);
+				if (!key || keys.has(key.value)) return undefined;
+				keys.add(key.value);
+				position = skipWhitespace(key.end);
+				if (source[position] !== ":") return undefined;
+				const valueEnd = scanValue(position + 1);
+				if (valueEnd === undefined) return undefined;
+				position = skipWhitespace(valueEnd);
+				if (source[position] === "}") return position + 1;
+				if (source[position] !== ",") return undefined;
+				position = skipWhitespace(position + 1);
+			}
+		}
+		if (character === "[") {
+			position = skipWhitespace(position + 1);
+			if (source[position] === "]") return position + 1;
+			while (true) {
+				const valueEnd = scanValue(position);
+				if (valueEnd === undefined) return undefined;
+				position = skipWhitespace(valueEnd);
+				if (source[position] === "]") return position + 1;
+				if (source[position] !== ",") return undefined;
+				position = skipWhitespace(position + 1);
+			}
+		}
+		while (position < source.length && !/[\s,}\]]/.test(source[position]!)) position++;
+		return position;
+	}
+
+	const end = scanValue(0);
+	return end === undefined || skipWhitespace(end) !== source.length;
+}
+
+function parseTelegramCustodyEpoch(source: string): TelegramCustodyEpochBinding {
+	if (Buffer.byteLength(source, "utf8") > TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES || hasDuplicateObjectKeys(source)) {
+		throw new TelegramCustodyEpochError("corrupt");
+	}
+
+	let document: unknown;
+	try {
+		document = JSON.parse(source) as unknown;
+	} catch {
+		throw new TelegramCustodyEpochError("corrupt");
+	}
+
+	if (!isPlainObject(document)) throw new TelegramCustodyEpochError("corrupt");
+	const version = document.version;
+	if (typeof version !== "number" || !Number.isSafeInteger(version) || version < 1) {
+		throw new TelegramCustodyEpochError("corrupt");
+	}
+	if (version > TELEGRAM_CUSTODY_EPOCH_SCHEMA_VERSION) {
+		throw new TelegramCustodyEpochError("forward_version");
+	}
+
+	const keys = Object.keys(document);
+	if (
+		keys.length !== 3 ||
+		!Object.hasOwn(document, "version") ||
+		!Object.hasOwn(document, "custodyEpoch") ||
+		!Object.hasOwn(document, "ownerId")
+	) {
+		throw new TelegramCustodyEpochError("corrupt");
+	}
+	const binding = { ownerId: document.ownerId, custodyEpoch: document.custodyEpoch };
+	if (!isBinding(binding)) throw new TelegramCustodyEpochError("corrupt");
+	return binding;
+}
+
+function isUnsupportedDirectorySyncError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException).code;
+	return typeof code === "string" && UNSUPPORTED_DIRECTORY_SYNC_CODES.has(code);
+}
+
+async function syncFile(fsImpl: TelegramCustodyEpochFs, filePath: string): Promise<void> {
+	const handle = await fsImpl.open(filePath, "r+");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+async function syncDirectory(fsImpl: TelegramCustodyEpochFs, directoryPath: string): Promise<void> {
+	const handle = await fsImpl.open(directoryPath, "r");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+async function ensureEpochDirectory(fsImpl: TelegramCustodyEpochFs, agentDir: string): Promise<string> {
+	const directory = daemonPaths(agentDir).dir;
+	await fsImpl.mkdir(directory, { recursive: true, mode: 0o700 });
+	return directory;
+}
+
+async function writeTelegramCustodyEpoch(
+	fsImpl: TelegramCustodyEpochFs,
+	filePath: string,
+	binding: TelegramCustodyEpochBinding,
+): Promise<void> {
+	const data = `${JSON.stringify({
+		version: TELEGRAM_CUSTODY_EPOCH_SCHEMA_VERSION,
+		custodyEpoch: binding.custodyEpoch,
+		ownerId: binding.ownerId,
+	})}\n`;
+	if (Buffer.byteLength(data, "utf8") > TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES) {
+		throw new TelegramCustodyEpochError("corrupt");
+	}
+	const temporaryPath = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`);
+
+	try {
+		await fsImpl.writeFile(temporaryPath, data, { mode: 0o600 });
+		await fsImpl.chmod(temporaryPath, 0o600);
+		await syncFile(fsImpl, temporaryPath);
+		await fsImpl.rename(temporaryPath, filePath);
+		await syncFile(fsImpl, filePath);
+		try {
+			await syncDirectory(fsImpl, path.dirname(filePath));
+		} catch (error) {
+			if (!isUnsupportedDirectorySyncError(error)) throw error;
+		}
+	} catch (error) {
+		await fsImpl.unlink(temporaryPath).catch(() => undefined);
+		throw error;
+	}
+}
+
+export function telegramCustodyEpochPath(agentDir: string): string {
+	return path.join(daemonPaths(agentDir).dir, EPOCH_FILENAME);
+}
+
+export async function readTelegramCustodyEpoch(input: {
+	agentDir: string;
+	fs?: TelegramCustodyEpochFs;
+}): Promise<TelegramCustodyEpochBinding> {
+	const fsImpl = input.fs ?? nodeFs;
+	const filePath = telegramCustodyEpochPath(input.agentDir);
+	let source: string;
+	try {
+		source = await fsImpl.readFile(filePath, "utf8");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") throw new TelegramCustodyEpochError("corrupt");
+		throw error;
+	}
+	return parseTelegramCustodyEpoch(source);
+}
+
+export async function allocateTelegramCustodyEpoch(input: {
+	agentDir: string;
+	ownerId: string;
+	fs?: TelegramCustodyEpochFs;
+}): Promise<TelegramCustodyEpochBinding> {
+	if (typeof input.ownerId !== "string" || input.ownerId.length === 0) throw new TelegramCustodyEpochError("corrupt");
+
+	const fsImpl = input.fs ?? nodeFs;
+	const directory = await ensureEpochDirectory(fsImpl, input.agentDir);
+	const filePath = telegramCustodyEpochPath(input.agentDir);
+	return withFileLock(filePath, async () => {
+		await fsImpl.mkdir(directory, { recursive: true, mode: 0o700 });
+		await fsImpl.chmod(directory, 0o700);
+
+		let previous: TelegramCustodyEpochBinding | undefined;
+		try {
+			previous = parseTelegramCustodyEpoch(await fsImpl.readFile(filePath, "utf8"));
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+
+		if (previous?.custodyEpoch === Number.MAX_SAFE_INTEGER) {
+			throw new TelegramCustodyEpochError("exhausted");
+		}
+		const binding: TelegramCustodyEpochBinding = {
+			ownerId: input.ownerId,
+			custodyEpoch: previous === undefined ? 1 : previous.custodyEpoch + 1,
+		};
+		await writeTelegramCustodyEpoch(fsImpl, filePath, binding);
+		return binding;
+	});
+}
+
+export async function withCurrentTelegramCustodyEpoch<T>(
+	input: { agentDir: string; binding: TelegramCustodyEpochBinding; fs?: TelegramCustodyEpochFs },
+	operation: () => Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false; reason: "fenced" }> {
+	if (!isBinding(input.binding)) return { ok: false, reason: "fenced" };
+
+	const fsImpl = input.fs ?? nodeFs;
+	await ensureEpochDirectory(fsImpl, input.agentDir);
+	const filePath = telegramCustodyEpochPath(input.agentDir);
+	return withFileLock(filePath, async () => {
+		const current = await readTelegramCustodyEpoch({ agentDir: input.agentDir, fs: fsImpl });
+		if (
+			current.ownerId !== input.binding.ownerId ||
+			current.custodyEpoch !== input.binding.custodyEpoch
+		) {
+			return { ok: false, reason: "fenced" };
+		}
+		return { ok: true, value: await operation() };
+	});
+}

--- a/packages/coding-agent/src/notifications/telegram-custody-epoch.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-epoch.ts
@@ -204,7 +204,10 @@ async function writeTelegramCustodyEpoch(
 	if (Buffer.byteLength(data, "utf8") > TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES) {
 		throw new TelegramCustodyEpochError("corrupt");
 	}
-	const temporaryPath = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`);
+	const temporaryPath = path.join(
+		path.dirname(filePath),
+		`.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+	);
 
 	try {
 		await fsImpl.writeFile(temporaryPath, data, { mode: 0o600 });
@@ -287,10 +290,7 @@ export async function withCurrentTelegramCustodyEpoch<T>(
 	const filePath = telegramCustodyEpochPath(input.agentDir);
 	return withFileLock(filePath, async () => {
 		const current = await readTelegramCustodyEpoch({ agentDir: input.agentDir, fs: fsImpl });
-		if (
-			current.ownerId !== input.binding.ownerId ||
-			current.custodyEpoch !== input.binding.custodyEpoch
-		) {
+		if (current.ownerId !== input.binding.ownerId || current.custodyEpoch !== input.binding.custodyEpoch) {
 			return { ok: false, reason: "fenced" };
 		}
 		return { ok: true, value: await operation() };

--- a/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type * as fs from "node:fs";
 import * as path from "node:path";
+import * as fsPromises from "node:fs/promises";
+import * as os from "node:os";
 import { daemonPaths } from "./daemon-paths";
+import { allocateTelegramCustodyEpoch } from "./telegram-custody-epoch";
 import {
 	TELEGRAM_CUSTODY_MAX_FILE_BYTES,
 	TELEGRAM_CUSTODY_MAX_RECORDS,
@@ -370,5 +373,53 @@ describe("TelegramCustodyStore", () => {
 		expect(telegramCustodyKey("1", "23")).toBe("1:23");
 		expect(telegramCustodyKey("12", "3")).toBe("12:3");
 		expect(() => telegramCustodyKey("01", "3")).toThrow("Invalid Telegram custody identifier");
+	});
+	test("stamps active fence epochs and leaves stale or mismatched writes unchanged", async () => {
+		const agentDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "gjc-telegram-custody-store-"));
+		try {
+			const fakeFs = new FakeFs();
+			const binding = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
+			const custodyPath = path.join(daemonPaths(agentDir).dir, "telegram-deletion-custody.json");
+			const store = new TelegramCustodyStore({
+				agentDir,
+				fs: fakeFs,
+				now: () => 1,
+				fence: { binding },
+			});
+			await store.load();
+
+			expect(await store.put(custodyRecord())).toEqual({ ok: true });
+			expect(await store.put(custodyRecord({ topicId: "8", custodyEpoch: binding.custodyEpoch }))).toEqual({
+				ok: true,
+			});
+			const stamped = JSON.parse(fakeFs.files.get(custodyPath)!) as {
+				records: Record<string, TelegramCustodyRecord>;
+			};
+			expect(stamped.records["42:77"]?.custodyEpoch).toBe(binding.custodyEpoch);
+			expect(stamped.records["42:8"]?.custodyEpoch).toBe(binding.custodyEpoch);
+
+			const beforeMismatch = fakeFs.files.get(custodyPath);
+			const recordsBeforeMismatch = store.list();
+			const writesBeforeMismatch = fakeFs.writeCalls.length;
+			expect(await store.put(custodyRecord({ topicId: "9", custodyEpoch: binding.custodyEpoch + 1 }))).toEqual({
+				ok: false,
+				reason: "fenced",
+			});
+			expect(fakeFs.files.get(custodyPath)).toBe(beforeMismatch);
+			expect(store.list()).toEqual(recordsBeforeMismatch);
+			expect(fakeFs.writeCalls).toHaveLength(writesBeforeMismatch);
+
+			await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
+			const beforeStale = fakeFs.files.get(custodyPath);
+			const recordsBeforeStale = store.list();
+			const writesBeforeStale = fakeFs.writeCalls.length;
+			expect(await store.put(custodyRecord({ topicId: "9" }))).toEqual({ ok: false, reason: "fenced" });
+			expect(await store.remove({ chatId: "42", topicId: "77" })).toEqual({ ok: false, reason: "fenced" });
+			expect(fakeFs.files.get(custodyPath)).toBe(beforeStale);
+			expect(store.list()).toEqual(recordsBeforeStale);
+			expect(fakeFs.writeCalls).toHaveLength(writesBeforeStale);
+		} finally {
+			await fsPromises.rm(agentDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type * as fs from "node:fs";
-import * as path from "node:path";
 import * as fsPromises from "node:fs/promises";
 import * as os from "node:os";
+import * as path from "node:path";
 import { daemonPaths } from "./daemon-paths";
 import { allocateTelegramCustodyEpoch } from "./telegram-custody-epoch";
 import {

--- a/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, test } from "bun:test";
+import type * as fs from "node:fs";
+import * as path from "node:path";
+import { daemonPaths } from "./daemon-paths";
+import {
+	TELEGRAM_CUSTODY_MAX_FILE_BYTES,
+	TELEGRAM_CUSTODY_MAX_RECORDS,
+	type TelegramCustodyRecord,
+	TelegramCustodyStore,
+	type TelegramCustodyStoreFs,
+	telegramCustodyKey,
+} from "./telegram-custody-store";
+
+const AGENT_DIR = "/virtual/agent";
+const CUSTODY_PATH = path.join(daemonPaths(AGENT_DIR).dir, "telegram-deletion-custody.json");
+
+function numericMode(mode: fs.Mode | undefined): number | undefined {
+	return typeof mode === "number" ? mode : undefined;
+}
+
+function writeMode(options: fs.WriteFileOptions | undefined): number | undefined {
+	if (!options || typeof options === "string") return undefined;
+	return numericMode(options.mode);
+}
+
+class FakeFs implements TelegramCustodyStoreFs {
+	readonly files = new Map<string, string>();
+	readonly mkdirCalls: { path: string; mode: number | undefined }[] = [];
+	readonly chmodCalls: { path: string; mode: number }[] = [];
+	readonly writeCalls: { path: string; data: string; mode: number | undefined }[] = [];
+	readonly renameCalls: { from: string; to: string }[] = [];
+	readonly unlinkCalls: string[] = [];
+	failRename = false;
+	failWrite = false;
+
+	async mkdir(file: string, options?: fs.MakeDirectoryOptions): Promise<undefined> {
+		this.mkdirCalls.push({ path: file, mode: numericMode(options?.mode) });
+		return undefined;
+	}
+
+	async readFile(file: string): Promise<string> {
+		const contents = this.files.get(file);
+		if (contents === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+		return contents;
+	}
+
+	async writeFile(file: string, data: string, options?: fs.WriteFileOptions): Promise<void> {
+		this.writeCalls.push({ path: file, data, mode: writeMode(options) });
+		if (this.failWrite) throw new Error("simulated write failure");
+		this.files.set(file, data);
+	}
+
+	async chmod(file: string, mode: number): Promise<void> {
+		this.chmodCalls.push({ path: file, mode });
+	}
+
+	async rename(from: string, to: string): Promise<void> {
+		this.renameCalls.push({ from, to });
+		if (this.failRename) throw new Error("simulated rename failure");
+		const contents = this.files.get(from);
+		if (contents === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+		this.files.delete(from);
+		this.files.set(to, contents);
+	}
+
+	async unlink(file: string): Promise<void> {
+		this.unlinkCalls.push(file);
+		this.files.delete(file);
+	}
+}
+
+function storeWith(fakeFs: FakeFs): TelegramCustodyStore {
+	return new TelegramCustodyStore({ agentDir: AGENT_DIR, fs: fakeFs, now: () => 1 });
+}
+
+function custodyRecord(overrides: Partial<TelegramCustodyRecord> = {}): TelegramCustodyRecord {
+	return {
+		chatId: "42",
+		topicId: "77",
+		state: "queued",
+		updatedAt: 1,
+		...overrides,
+	};
+}
+
+function serialized(fakeFs: FakeFs): { version: number; records: Record<string, TelegramCustodyRecord> } {
+	return JSON.parse(fakeFs.files.get(CUSTODY_PATH)!) as {
+		version: number;
+		records: Record<string, TelegramCustodyRecord>;
+	};
+}
+
+describe("TelegramCustodyStore", () => {
+	test("loads a missing file as an empty writable store", async () => {
+		const store = storeWith(new FakeFs());
+		expect(await store.load()).toEqual({ mode: "writable", migrated: false, records: [] });
+		expect(store.list()).toEqual([]);
+	});
+
+	test("round-trips all states with deterministic composite key order and separate chats", async () => {
+		const fakeFs = new FakeFs();
+		const store = storeWith(fakeFs);
+		await store.load();
+		await store.put(custodyRecord({ chatId: "2", topicId: "7", state: "queued" }));
+		await store.put(custodyRecord({ chatId: "10", topicId: "7", state: "in_flight" }));
+		await store.put(custodyRecord({ chatId: "2", topicId: "1", state: "unknown" }));
+
+		expect(Object.keys(serialized(fakeFs).records)).toEqual(["10:7", "2:1", "2:7"]);
+		expect(serialized(fakeFs).records["10:7"]?.state).toBe("in_flight");
+		expect(store.get({ chatId: "2", topicId: "7" })).toEqual(custodyRecord({ chatId: "2", topicId: "7" }));
+		expect(store.get({ chatId: "10", topicId: "7" })).toEqual(
+			custodyRecord({ chatId: "10", topicId: "7", state: "in_flight" }),
+		);
+
+		const reader = storeWith(fakeFs);
+		const loaded = await reader.load();
+		expect(loaded).toEqual({
+			mode: "writable",
+			migrated: false,
+			records: [
+				custodyRecord({ chatId: "10", topicId: "7", state: "unknown" }),
+				custodyRecord({ chatId: "2", topicId: "1", state: "unknown" }),
+				custodyRecord({ chatId: "2", topicId: "7" }),
+			],
+		});
+		expect(serialized(fakeFs).records["10:7"]?.state).toBe("unknown");
+	});
+
+	test("strictly migrates a v1 single-chat record object and preserves an optional epoch", async () => {
+		const fakeFs = new FakeFs();
+		fakeFs.files.set(
+			CUSTODY_PATH,
+			JSON.stringify({
+				version: 1,
+				chatId: "-100123",
+				records: {
+					"9": { state: "in_flight", updatedAt: 20, custodyEpoch: 3 },
+					"2": { state: "queued", updatedAt: 10 },
+				},
+			}),
+		);
+
+		const result = await storeWith(fakeFs).load();
+		expect(result).toEqual({
+			mode: "writable",
+			migrated: true,
+			records: [
+				custodyRecord({ chatId: "-100123", topicId: "2", updatedAt: 10 }),
+				custodyRecord({ chatId: "-100123", topicId: "9", state: "unknown", updatedAt: 20, custodyEpoch: 3 }),
+			],
+		});
+		expect(serialized(fakeFs)).toEqual({
+			version: 2,
+			records: {
+				"-100123:2": custodyRecord({ chatId: "-100123", topicId: "2", updatedAt: 10 }),
+				"-100123:9": custodyRecord({
+					chatId: "-100123",
+					topicId: "9",
+					state: "unknown",
+					updatedAt: 20,
+					custodyEpoch: 3,
+				}),
+			},
+		});
+	});
+
+	test("converts loaded v2 in_flight custody to unknown and atomically rewrites it", async () => {
+		const fakeFs = new FakeFs();
+		fakeFs.files.set(
+			CUSTODY_PATH,
+			JSON.stringify({
+				version: 2,
+				records: { "42:7": custodyRecord({ topicId: "7", state: "in_flight", custodyEpoch: 8 }) },
+			}),
+		);
+
+		const result = await storeWith(fakeFs).load();
+		expect(result).toEqual({
+			mode: "writable",
+			migrated: false,
+			records: [custodyRecord({ topicId: "7", state: "unknown", custodyEpoch: 8 })],
+		});
+		expect(serialized(fakeFs).records["42:7"]?.state).toBe("unknown");
+		expect(fakeFs.renameCalls).toHaveLength(1);
+	});
+
+	test("rejects malformed JSON, duplicate members, key mismatches, and unknown states without rewrite", async () => {
+		const invalidDocuments = [
+			"{ not JSON",
+			'{"version":2,"version":2,"records":{}}',
+			JSON.stringify({ version: 2, records: { "42:8": custodyRecord({ topicId: "7" }) } }),
+			JSON.stringify({ version: 2, records: { "42:7": { ...custodyRecord(), state: "sent" } } }),
+		];
+
+		for (const source of invalidDocuments) {
+			const fakeFs = new FakeFs();
+			fakeFs.files.set(CUSTODY_PATH, source);
+			const store = storeWith(fakeFs);
+			expect(await store.load()).toEqual({ mode: "read_only", reason: "corrupt", migrated: false, records: [] });
+			expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+			expect(fakeFs.writeCalls).toHaveLength(0);
+			expect(await store.put(custodyRecord())).toEqual({ ok: false, reason: "read_only" });
+		}
+	});
+
+	test("rejects invalid IDs, timestamps, epochs, and excess record properties", async () => {
+		const invalidRecords: unknown[] = [
+			{ chatId: "+1", topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "01", topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "-0", topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "0", topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "1".repeat(33), topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "1", topicId: "0", state: "queued", updatedAt: 1 },
+			{ chatId: "1", topicId: "-7", state: "queued", updatedAt: 1 },
+			{ chatId: "1", topicId: "1".repeat(21), state: "queued", updatedAt: 1 },
+			{ chatId: "1", topicId: "7", state: "queued", updatedAt: -1 },
+			{ chatId: "1", topicId: "7", state: "queued", updatedAt: Number.MAX_SAFE_INTEGER + 1 },
+			{ chatId: "1", topicId: "7", state: "queued", updatedAt: 1, custodyEpoch: -1 },
+			{ chatId: "1", topicId: "7", state: "queued", updatedAt: 1, unexpected: true },
+		];
+		for (const record of invalidRecords) {
+			const fakeFs = new FakeFs();
+			fakeFs.files.set(CUSTODY_PATH, JSON.stringify({ version: 2, records: { "1:7": record } }));
+			expect(await storeWith(fakeFs).load()).toEqual({
+				mode: "read_only",
+				reason: "corrupt",
+				migrated: false,
+				records: [],
+			});
+		}
+
+		const writableFs = new FakeFs();
+		const writableStore = storeWith(writableFs);
+		await writableStore.load();
+		await expect(
+			writableStore.put({ ...custodyRecord(), topicId: "01" } as unknown as TelegramCustodyRecord),
+		).rejects.toThrow("Invalid Telegram custody record");
+		await expect(
+			writableStore.put({ ...custodyRecord(), custodyEpoch: undefined } as unknown as TelegramCustodyRecord),
+		).rejects.toThrow("Invalid Telegram custody record");
+		expect(writableFs.writeCalls).toHaveLength(0);
+	});
+
+	test("honors the 1,000-record and file-size boundaries without touching oversized source bytes", async () => {
+		const exactlyAtLimit = Object.fromEntries(
+			Array.from({ length: TELEGRAM_CUSTODY_MAX_RECORDS }, (_, index) => [
+				`42:${index + 1}`,
+				custodyRecord({ topicId: String(index + 1) }),
+			]),
+		);
+		const validFs = new FakeFs();
+		validFs.files.set(CUSTODY_PATH, JSON.stringify({ version: 2, records: exactlyAtLimit }));
+		const validStore = storeWith(validFs);
+		const validResult = await validStore.load();
+		expect(validResult.mode).toBe("writable");
+		expect(validResult.records).toHaveLength(TELEGRAM_CUSTODY_MAX_RECORDS);
+		await expect(
+			validStore.put(custodyRecord({ topicId: String(TELEGRAM_CUSTODY_MAX_RECORDS + 1) })),
+		).rejects.toThrow("Telegram custody record limit exceeded");
+		expect(validFs.writeCalls).toHaveLength(0);
+		const atFileLimit = JSON.stringify({ version: 2, records: {} });
+		const paddedAtLimit = `${atFileLimit}${" ".repeat(TELEGRAM_CUSTODY_MAX_FILE_BYTES - Buffer.byteLength(atFileLimit, "utf8"))}`;
+		const fileLimitFs = new FakeFs();
+		fileLimitFs.files.set(CUSTODY_PATH, paddedAtLimit);
+		expect(await storeWith(fileLimitFs).load()).toEqual({ mode: "writable", migrated: false, records: [] });
+
+		const tooMany = Object.fromEntries(
+			Array.from({ length: TELEGRAM_CUSTODY_MAX_RECORDS + 1 }, (_, index) => [
+				`42:${index + 1}`,
+				custodyRecord({ topicId: String(index + 1) }),
+			]),
+		);
+		for (const source of [
+			JSON.stringify({ version: 2, records: tooMany }),
+			" ".repeat(TELEGRAM_CUSTODY_MAX_FILE_BYTES + 1),
+		]) {
+			const fakeFs = new FakeFs();
+			fakeFs.files.set(CUSTODY_PATH, source);
+			const store = storeWith(fakeFs);
+			expect(await store.load()).toEqual({ mode: "read_only", reason: "bounds", migrated: false, records: [] });
+			expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+			expect(fakeFs.writeCalls).toHaveLength(0);
+		}
+	});
+
+	test("preserves forward-version bytes and disables mutation", async () => {
+		const fakeFs = new FakeFs();
+		const source = '{"version":3,"future":"preserve exactly"}\n';
+		fakeFs.files.set(CUSTODY_PATH, source);
+		const store = storeWith(fakeFs);
+		expect(await store.load()).toEqual({
+			mode: "read_only",
+			reason: "forward_version",
+			migrated: false,
+			records: [],
+		});
+		expect(await store.remove({ chatId: "42", topicId: "7" })).toEqual({ ok: false, reason: "read_only" });
+		expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+		expect(fakeFs.writeCalls).toHaveLength(0);
+	});
+
+	test("classifies a failed v1 migration as read-only and does not promote memory to writable", async () => {
+		const fakeFs = new FakeFs();
+		const source = JSON.stringify({
+			version: 1,
+			chatId: "42",
+			records: { "7": { state: "queued", updatedAt: 1 } },
+		});
+		fakeFs.files.set(CUSTODY_PATH, source);
+		fakeFs.failRename = true;
+		const store = storeWith(fakeFs);
+
+		expect(await store.load()).toEqual({
+			mode: "read_only",
+			reason: "migration_write_failed",
+			migrated: false,
+			records: [custodyRecord({ topicId: "7" })],
+		});
+		expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+		expect(store.list()).toEqual([custodyRecord({ topicId: "7" })]);
+		expect(await store.put(custodyRecord({ topicId: "8" }))).toEqual({ ok: false, reason: "read_only" });
+		expect(fakeFs.unlinkCalls).toHaveLength(1);
+	});
+
+	test("uses restrictive permissions, same-directory atomic renames, and cleans temporary writes on failure", async () => {
+		const fakeFs = new FakeFs();
+		const store = storeWith(fakeFs);
+		await store.load();
+		await store.put(custodyRecord());
+		expect(fakeFs.mkdirCalls).toEqual([{ path: daemonPaths(AGENT_DIR).dir, mode: 0o700 }]);
+		expect(fakeFs.chmodCalls[0]).toEqual({ path: daemonPaths(AGENT_DIR).dir, mode: 0o700 });
+		expect(fakeFs.writeCalls[0]?.mode).toBe(0o600);
+		expect(fakeFs.chmodCalls[1]?.mode).toBe(0o600);
+		expect(path.dirname(fakeFs.renameCalls[0]!.from)).toBe(path.dirname(fakeFs.renameCalls[0]!.to));
+
+		const before = fakeFs.files.get(CUSTODY_PATH);
+		fakeFs.failWrite = true;
+		await expect(store.put(custodyRecord({ topicId: "8" }))).rejects.toThrow("simulated write failure");
+		expect(store.get({ chatId: "42", topicId: "8" })).toBeUndefined();
+		expect(fakeFs.files.get(CUSTODY_PATH)).toBe(before);
+		expect([...fakeFs.files.keys()].some(file => file.endsWith(".tmp"))).toBe(false);
+		expect(fakeFs.unlinkCalls).toHaveLength(1);
+	});
+
+	test("serializes overlapping puts and removes and returns copies from read APIs", async () => {
+		const fakeFs = new FakeFs();
+		const store = storeWith(fakeFs);
+		await store.load();
+		const first = store.put(custodyRecord({ topicId: "1" }));
+		const second = store.put(custodyRecord({ topicId: "2" }));
+		const third = store.remove({ chatId: "42", topicId: "1" });
+		expect(await Promise.all([first, second, third])).toEqual([{ ok: true }, { ok: true }, { ok: true }]);
+		expect(store.list()).toEqual([custodyRecord({ topicId: "2" })]);
+
+		const fromGet = store.get({ chatId: "42", topicId: "2" })!;
+		fromGet.state = "unknown";
+		const fromList = store.list()[0]!;
+		fromList.state = "unknown";
+		expect(store.get({ chatId: "42", topicId: "2" })?.state).toBe("queued");
+	});
+
+	test("serializes only custody fields and validates delimiter-safe decimal keys", async () => {
+		const fakeFs = new FakeFs();
+		const store = storeWith(fakeFs);
+		await store.load();
+		await store.put(custodyRecord({ chatId: "-100123", topicId: "77", custodyEpoch: 9 }));
+		const data = fakeFs.files.get(CUSTODY_PATH)!;
+		expect(data).toContain('"-100123:77"');
+		expect(data).not.toMatch(/token|session|endpoint|fingerprint|messageText/i);
+		expect(telegramCustodyKey("1", "23")).toBe("1:23");
+		expect(telegramCustodyKey("12", "3")).toBe("12:3");
+		expect(() => telegramCustodyKey("01", "3")).toThrow("Invalid Telegram custody identifier");
+	});
+});

--- a/packages/coding-agent/src/notifications/telegram-custody-store.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.ts
@@ -1,0 +1,484 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { daemonPaths } from "./daemon-paths";
+
+export const TELEGRAM_CUSTODY_SCHEMA_VERSION = 2;
+export const TELEGRAM_CUSTODY_MAX_RECORDS = 1_000;
+export const TELEGRAM_CUSTODY_MAX_FILE_BYTES = 1_048_576;
+
+export type TelegramCustodyState = "queued" | "in_flight" | "unknown";
+
+export interface TelegramCustodyRecord {
+	chatId: string;
+	topicId: string;
+	state: TelegramCustodyState;
+	updatedAt: number;
+	custodyEpoch?: number;
+}
+
+export type TelegramCustodyReadOnlyReason = "corrupt" | "forward_version" | "bounds" | "migration_write_failed";
+
+export interface TelegramCustodyLoadResult {
+	mode: "writable" | "read_only";
+	reason?: TelegramCustodyReadOnlyReason;
+	migrated: boolean;
+	records: readonly TelegramCustodyRecord[];
+}
+
+export type TelegramCustodyWriteResult = { ok: true } | { ok: false; reason: "read_only" };
+
+export interface TelegramCustodyStoreFs {
+	mkdir(path: string, opts?: fs.MakeDirectoryOptions): Promise<unknown>;
+	readFile(path: string, encoding: BufferEncoding): Promise<string>;
+	writeFile(path: string, data: string, opts?: fs.WriteFileOptions): Promise<void>;
+	rename(oldPath: string, newPath: string): Promise<void>;
+	chmod(path: string, mode: number): Promise<void>;
+	unlink(path: string): Promise<void>;
+}
+
+const CUSTODY_FILENAME = "telegram-deletion-custody.json";
+const nodeFs: TelegramCustodyStoreFs = fs.promises as unknown as TelegramCustodyStoreFs;
+
+type StoreMode = "writable" | "read_only";
+
+type ParseResult<T> = { ok: true; value: T } | { ok: false; reason: "corrupt" | "bounds" };
+
+interface TelegramCustodyV1Record {
+	state: TelegramCustodyState;
+	updatedAt: number;
+	custodyEpoch?: number;
+}
+
+interface TelegramCustodyV1Snapshot {
+	chatId: string;
+	records: TelegramCustodyRecord[];
+}
+
+interface ParsedV2Snapshot {
+	records: TelegramCustodyRecord[];
+	hasInFlight: boolean;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function hasExactKeys(
+	value: Record<string, unknown>,
+	required: readonly string[],
+	optional: readonly string[] = [],
+): boolean {
+	const keys = Object.keys(value);
+	if (keys.length < required.length || keys.length > required.length + optional.length) return false;
+	return (
+		required.every(key => Object.hasOwn(value, key)) &&
+		keys.every(key => required.includes(key) || optional.includes(key))
+	);
+}
+
+function isCanonicalChatId(value: unknown): value is string {
+	return typeof value === "string" && value.length >= 1 && value.length <= 32 && /^-?[1-9]\d*$/.test(value);
+}
+
+function isCanonicalTopicId(value: unknown): value is string {
+	return typeof value === "string" && value.length <= 20 && /^[1-9]\d*$/.test(value);
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isTelegramCustodyState(value: unknown): value is TelegramCustodyState {
+	return value === "queued" || value === "in_flight" || value === "unknown";
+}
+
+function compareKeys(left: string, right: string): number {
+	if (left < right) return -1;
+	if (left > right) return 1;
+	return 0;
+}
+
+function cloneRecord(record: TelegramCustodyRecord): TelegramCustodyRecord {
+	return record.custodyEpoch === undefined
+		? {
+				chatId: record.chatId,
+				topicId: record.topicId,
+				state: record.state,
+				updatedAt: record.updatedAt,
+			}
+		: {
+				chatId: record.chatId,
+				topicId: record.topicId,
+				state: record.state,
+				updatedAt: record.updatedAt,
+				custodyEpoch: record.custodyEpoch,
+			};
+}
+
+function cloneRecords(records: Iterable<TelegramCustodyRecord>): TelegramCustodyRecord[] {
+	return Array.from(records, cloneRecord);
+}
+
+function readRecord(value: unknown): TelegramCustodyRecord | undefined {
+	if (!isPlainObject(value) || !hasExactKeys(value, ["chatId", "topicId", "state", "updatedAt"], ["custodyEpoch"])) {
+		return undefined;
+	}
+	if (
+		!isCanonicalChatId(value.chatId) ||
+		!isCanonicalTopicId(value.topicId) ||
+		!isTelegramCustodyState(value.state) ||
+		!isNonNegativeSafeInteger(value.updatedAt)
+	) {
+		return undefined;
+	}
+	if (!Object.hasOwn(value, "custodyEpoch")) {
+		return { chatId: value.chatId, topicId: value.topicId, state: value.state, updatedAt: value.updatedAt };
+	}
+	if (!isNonNegativeSafeInteger(value.custodyEpoch)) return undefined;
+	return {
+		chatId: value.chatId,
+		topicId: value.topicId,
+		state: value.state,
+		updatedAt: value.updatedAt,
+		custodyEpoch: value.custodyEpoch,
+	};
+}
+
+function readV1Record(value: unknown): TelegramCustodyV1Record | undefined {
+	if (!isPlainObject(value) || !hasExactKeys(value, ["state", "updatedAt"], ["custodyEpoch"])) return undefined;
+	if (!isTelegramCustodyState(value.state) || !isNonNegativeSafeInteger(value.updatedAt)) return undefined;
+	if (!Object.hasOwn(value, "custodyEpoch")) return { state: value.state, updatedAt: value.updatedAt };
+	if (!isNonNegativeSafeInteger(value.custodyEpoch)) return undefined;
+	return { state: value.state, updatedAt: value.updatedAt, custodyEpoch: value.custodyEpoch };
+}
+
+/** Validate decimal-only ID segments and form their unambiguous composite storage key. */
+export function telegramCustodyKey(chatId: string, topicId: string): string {
+	if (!isCanonicalChatId(chatId) || !isCanonicalTopicId(topicId)) {
+		throw new Error("Invalid Telegram custody identifier");
+	}
+	return `${chatId}:${topicId}`;
+}
+
+function parseV2(value: unknown): ParseResult<ParsedV2Snapshot> {
+	if (
+		!isPlainObject(value) ||
+		!hasExactKeys(value, ["version", "records"]) ||
+		value.version !== TELEGRAM_CUSTODY_SCHEMA_VERSION
+	) {
+		return { ok: false, reason: "corrupt" };
+	}
+	if (!isPlainObject(value.records)) return { ok: false, reason: "corrupt" };
+
+	const entries = Object.entries(value.records);
+	if (entries.length > TELEGRAM_CUSTODY_MAX_RECORDS) return { ok: false, reason: "bounds" };
+
+	const records: TelegramCustodyRecord[] = [];
+	let hasInFlight = false;
+	for (const [key, rawRecord] of entries) {
+		const record = readRecord(rawRecord);
+		if (!record) return { ok: false, reason: "corrupt" };
+		if (key !== telegramCustodyKey(record.chatId, record.topicId)) return { ok: false, reason: "corrupt" };
+		records.push(record);
+		hasInFlight ||= record.state === "in_flight";
+	}
+	return {
+		ok: true,
+		value: {
+			records: records.sort((left, right) =>
+				compareKeys(telegramCustodyKey(left.chatId, left.topicId), telegramCustodyKey(right.chatId, right.topicId)),
+			),
+			hasInFlight,
+		},
+	};
+}
+
+function parseV1(value: unknown): ParseResult<TelegramCustodyV1Snapshot> {
+	if (!isPlainObject(value) || !hasExactKeys(value, ["version", "chatId", "records"]) || value.version !== 1) {
+		return { ok: false, reason: "corrupt" };
+	}
+	if (!isCanonicalChatId(value.chatId) || !isPlainObject(value.records)) return { ok: false, reason: "corrupt" };
+
+	const entries = Object.entries(value.records);
+	if (entries.length > TELEGRAM_CUSTODY_MAX_RECORDS) return { ok: false, reason: "bounds" };
+
+	const records: TelegramCustodyRecord[] = [];
+	for (const [topicId, rawRecord] of entries) {
+		if (!isCanonicalTopicId(topicId)) return { ok: false, reason: "corrupt" };
+		const record = readV1Record(rawRecord);
+		if (!record) return { ok: false, reason: "corrupt" };
+		records.push(
+			record.custodyEpoch === undefined
+				? {
+						chatId: value.chatId,
+						topicId,
+						state: record.state === "in_flight" ? "unknown" : record.state,
+						updatedAt: record.updatedAt,
+					}
+				: {
+						chatId: value.chatId,
+						topicId,
+						state: record.state === "in_flight" ? "unknown" : record.state,
+						updatedAt: record.updatedAt,
+						custodyEpoch: record.custodyEpoch,
+					},
+		);
+	}
+	return { ok: true, value: { chatId: value.chatId, records } };
+}
+
+function classifyV2Records(records: readonly TelegramCustodyRecord[]): TelegramCustodyRecord[] {
+	return records.map(record =>
+		record.state === "in_flight" ? { ...cloneRecord(record), state: "unknown" } : cloneRecord(record),
+	);
+}
+
+function canonicalRecordsObject(records: Iterable<TelegramCustodyRecord>): Record<string, TelegramCustodyRecord> {
+	const entries = Array.from(
+		records,
+		record => [telegramCustodyKey(record.chatId, record.topicId), cloneRecord(record)] as const,
+	).sort((left, right) => compareKeys(left[0], right[0]));
+	return Object.fromEntries(entries);
+}
+
+function serialize(records: Iterable<TelegramCustodyRecord>): string {
+	return `${JSON.stringify(
+		{ version: TELEGRAM_CUSTODY_SCHEMA_VERSION, records: canonicalRecordsObject(records) },
+		null,
+		2,
+	)}\n`;
+}
+
+function findStringEnd(source: string, start: number): number | undefined {
+	for (let position = start + 1; position < source.length; position++) {
+		const character = source[position];
+		if (character === "\\") {
+			position++;
+			continue;
+		}
+		if (character === '"') return position + 1;
+	}
+	return undefined;
+}
+
+/** JSON.parse intentionally accepts duplicate object members; custody files do not. */
+function hasDuplicateObjectKeys(source: string): boolean {
+	function skipWhitespace(position: number): number {
+		while (/\s/.test(source[position] ?? "")) position++;
+		return position;
+	}
+
+	function scanString(position: number): { value: string; end: number } | undefined {
+		const end = findStringEnd(source, position);
+		if (end === undefined) return undefined;
+		try {
+			return { value: JSON.parse(source.slice(position, end)) as string, end };
+		} catch {
+			return undefined;
+		}
+	}
+
+	function scanValue(position: number): number | undefined {
+		position = skipWhitespace(position);
+		const character = source[position];
+		if (character === '"') return scanString(position)?.end;
+		if (character === "{") {
+			position = skipWhitespace(position + 1);
+			const keys = new Set<string>();
+			if (source[position] === "}") return position + 1;
+			while (true) {
+				if (source[position] !== '"') return undefined;
+				const key = scanString(position);
+				if (!key || keys.has(key.value)) return undefined;
+				keys.add(key.value);
+				position = skipWhitespace(key.end);
+				if (source[position] !== ":") return undefined;
+				const valueEnd = scanValue(position + 1);
+				if (valueEnd === undefined) return undefined;
+				position = skipWhitespace(valueEnd);
+				if (source[position] === "}") return position + 1;
+				if (source[position] !== ",") return undefined;
+				position = skipWhitespace(position + 1);
+			}
+		}
+		if (character === "[") {
+			position = skipWhitespace(position + 1);
+			if (source[position] === "]") return position + 1;
+			while (true) {
+				const valueEnd = scanValue(position);
+				if (valueEnd === undefined) return undefined;
+				position = skipWhitespace(valueEnd);
+				if (source[position] === "]") return position + 1;
+				if (source[position] !== ",") return undefined;
+				position = skipWhitespace(position + 1);
+			}
+		}
+		while (position < source.length && !/[\s,}\]]/.test(source[position]!)) position++;
+		return position;
+	}
+
+	const end = scanValue(0);
+	return end === undefined || skipWhitespace(end) !== source.length;
+}
+
+export class TelegramCustodyStore {
+	readonly #dir: string;
+	readonly #file: string;
+	readonly #fsImpl: TelegramCustodyStoreFs;
+	readonly #now: () => number;
+	#mode: StoreMode = "writable";
+	#records = new Map<string, TelegramCustodyRecord>();
+	#operations: Promise<void> = Promise.resolve();
+
+	constructor(input: { agentDir: string; fs?: TelegramCustodyStoreFs; now?: () => number }) {
+		this.#dir = daemonPaths(input.agentDir).dir;
+		this.#file = path.join(this.#dir, CUSTODY_FILENAME);
+		this.#fsImpl = input.fs ?? nodeFs;
+		this.#now = input.now ?? Date.now;
+	}
+
+	async load(): Promise<TelegramCustodyLoadResult> {
+		return this.#serializeOperation<TelegramCustodyLoadResult>(async () => this.#load());
+	}
+
+	list(): readonly TelegramCustodyRecord[] {
+		return cloneRecords(this.#records.values()).sort((left, right) =>
+			compareKeys(telegramCustodyKey(left.chatId, left.topicId), telegramCustodyKey(right.chatId, right.topicId)),
+		);
+	}
+
+	get(input: { chatId: string; topicId: string }): TelegramCustodyRecord | undefined {
+		const record = this.#records.get(telegramCustodyKey(input.chatId, input.topicId));
+		return record === undefined ? undefined : cloneRecord(record);
+	}
+
+	async put(record: TelegramCustodyRecord): Promise<TelegramCustodyWriteResult> {
+		const validated = readRecord(record);
+		if (!validated) throw new Error("Invalid Telegram custody record");
+		const copy = cloneRecord(validated);
+		return this.#serializeOperation<TelegramCustodyWriteResult>(async () => {
+			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
+			const next = new Map(this.#records);
+			next.set(telegramCustodyKey(copy.chatId, copy.topicId), copy);
+			if (next.size > TELEGRAM_CUSTODY_MAX_RECORDS) throw new Error("Telegram custody record limit exceeded");
+			await this.#persist(next.values());
+			this.#records = next;
+			return { ok: true };
+		});
+	}
+
+	async remove(input: { chatId: string; topicId: string }): Promise<TelegramCustodyWriteResult> {
+		const key = telegramCustodyKey(input.chatId, input.topicId);
+		return this.#serializeOperation<TelegramCustodyWriteResult>(async () => {
+			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
+			const next = new Map(this.#records);
+			next.delete(key);
+			await this.#persist(next.values());
+			this.#records = next;
+			return { ok: true };
+		});
+	}
+
+	async #load(): Promise<TelegramCustodyLoadResult> {
+		let source: string;
+		try {
+			source = await this.#fsImpl.readFile(this.#file, "utf8");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			this.#mode = "writable";
+			this.#records = new Map();
+			return { mode: "writable", migrated: false, records: [] };
+		}
+
+		if (Buffer.byteLength(source, "utf8") > TELEGRAM_CUSTODY_MAX_FILE_BYTES) return this.#readOnly("bounds", []);
+
+		let document: unknown;
+		try {
+			if (hasDuplicateObjectKeys(source)) return this.#readOnly("corrupt", []);
+			document = JSON.parse(source) as unknown;
+		} catch {
+			return this.#readOnly("corrupt", []);
+		}
+
+		if (
+			isPlainObject(document) &&
+			typeof document.version === "number" &&
+			document.version > TELEGRAM_CUSTODY_SCHEMA_VERSION
+		) {
+			return this.#readOnly("forward_version", []);
+		}
+
+		const v2 = parseV2(document);
+		if (v2.ok) {
+			const records = classifyV2Records(v2.value.records);
+			if (v2.value.hasInFlight) {
+				try {
+					await this.#persist(records);
+				} catch {
+					return this.#readOnly("migration_write_failed", records);
+				}
+			}
+			this.#mode = "writable";
+			this.#setRecords(records);
+			return { mode: "writable", migrated: false, records: this.list() };
+		}
+
+		const v1 = parseV1(document);
+		if (!v1.ok) return this.#readOnly(v2.reason === "bounds" || v1.reason === "bounds" ? "bounds" : "corrupt", []);
+
+		try {
+			await this.#persist(v1.value.records);
+		} catch {
+			return this.#readOnly("migration_write_failed", v1.value.records);
+		}
+		this.#mode = "writable";
+		this.#setRecords(v1.value.records);
+		return { mode: "writable", migrated: true, records: this.list() };
+	}
+
+	#readOnly(
+		reason: TelegramCustodyReadOnlyReason,
+		records: readonly TelegramCustodyRecord[],
+	): TelegramCustodyLoadResult {
+		this.#mode = "read_only";
+		this.#setRecords(records);
+		return { mode: "read_only", reason, migrated: false, records: this.list() };
+	}
+
+	#setRecords(records: Iterable<TelegramCustodyRecord>): void {
+		this.#records = new Map(
+			Array.from(
+				records,
+				record => [telegramCustodyKey(record.chatId, record.topicId), cloneRecord(record)] as const,
+			),
+		);
+	}
+
+	async #persist(records: Iterable<TelegramCustodyRecord>): Promise<void> {
+		const data = serialize(records);
+		if (Buffer.byteLength(data, "utf8") > TELEGRAM_CUSTODY_MAX_FILE_BYTES) {
+			throw new Error("Telegram custody snapshot exceeds the maximum file size");
+		}
+
+		await this.#fsImpl.mkdir(this.#dir, { recursive: true, mode: 0o700 });
+		await this.#fsImpl.chmod(this.#dir, 0o700);
+		const temporaryFile = `${this.#file}.${process.pid}.${this.#now()}.${Math.random().toString(36).slice(2)}.tmp`;
+		try {
+			await this.#fsImpl.writeFile(temporaryFile, data, { mode: 0o600 });
+			await this.#fsImpl.chmod(temporaryFile, 0o600);
+			await this.#fsImpl.rename(temporaryFile, this.#file);
+		} catch (error) {
+			await this.#fsImpl.unlink(temporaryFile).catch(() => undefined);
+			throw error;
+		}
+	}
+
+	async #serializeOperation<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.#operations.then(operation, operation);
+		this.#operations = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	}
+}

--- a/packages/coding-agent/src/notifications/telegram-custody-store.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.ts
@@ -1,11 +1,11 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { daemonPaths } from "./daemon-paths";
 import {
 	type TelegramCustodyEpochBinding,
 	type TelegramCustodyEpochFs,
 	withCurrentTelegramCustodyEpoch,
 } from "./telegram-custody-epoch";
-import { daemonPaths } from "./daemon-paths";
 
 export const TELEGRAM_CUSTODY_SCHEMA_VERSION = 2;
 export const TELEGRAM_CUSTODY_MAX_RECORDS = 1_000;

--- a/packages/coding-agent/src/notifications/telegram-custody-store.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.ts
@@ -1,5 +1,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import {
+	type TelegramCustodyEpochBinding,
+	type TelegramCustodyEpochFs,
+	withCurrentTelegramCustodyEpoch,
+} from "./telegram-custody-epoch";
 import { daemonPaths } from "./daemon-paths";
 
 export const TELEGRAM_CUSTODY_SCHEMA_VERSION = 2;
@@ -25,7 +30,7 @@ export interface TelegramCustodyLoadResult {
 	records: readonly TelegramCustodyRecord[];
 }
 
-export type TelegramCustodyWriteResult = { ok: true } | { ok: false; reason: "read_only" };
+export type TelegramCustodyWriteResult = { ok: true } | { ok: false; reason: "read_only" | "fenced" };
 
 export interface TelegramCustodyStoreFs {
 	mkdir(path: string, opts?: fs.MakeDirectoryOptions): Promise<unknown>;
@@ -322,19 +327,37 @@ function hasDuplicateObjectKeys(source: string): boolean {
 }
 
 export class TelegramCustodyStore {
+	readonly #agentDir: string;
 	readonly #dir: string;
 	readonly #file: string;
 	readonly #fsImpl: TelegramCustodyStoreFs;
 	readonly #now: () => number;
+	readonly #fence: { binding: TelegramCustodyEpochBinding; fs?: TelegramCustodyEpochFs } | undefined;
 	#mode: StoreMode = "writable";
 	#records = new Map<string, TelegramCustodyRecord>();
 	#operations: Promise<void> = Promise.resolve();
 
-	constructor(input: { agentDir: string; fs?: TelegramCustodyStoreFs; now?: () => number }) {
+	constructor(input: {
+		agentDir: string;
+		fs?: TelegramCustodyStoreFs;
+		now?: () => number;
+		fence?: { binding: TelegramCustodyEpochBinding; fs?: TelegramCustodyEpochFs };
+	}) {
+		this.#agentDir = input.agentDir;
 		this.#dir = daemonPaths(input.agentDir).dir;
 		this.#file = path.join(this.#dir, CUSTODY_FILENAME);
 		this.#fsImpl = input.fs ?? nodeFs;
 		this.#now = input.now ?? Date.now;
+		this.#fence =
+			input.fence === undefined
+				? undefined
+				: {
+						binding: {
+							ownerId: input.fence.binding.ownerId,
+							custodyEpoch: input.fence.binding.custodyEpoch,
+						},
+						fs: input.fence.fs,
+					};
 	}
 
 	async load(): Promise<TelegramCustodyLoadResult> {
@@ -358,10 +381,17 @@ export class TelegramCustodyStore {
 		const copy = cloneRecord(validated);
 		return this.#serializeOperation<TelegramCustodyWriteResult>(async () => {
 			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
+			if (this.#fence) {
+				if (copy.custodyEpoch !== undefined && copy.custodyEpoch !== this.#fence.binding.custodyEpoch) {
+					return { ok: false, reason: "fenced" };
+				}
+				copy.custodyEpoch = this.#fence.binding.custodyEpoch;
+			}
 			const next = new Map(this.#records);
 			next.set(telegramCustodyKey(copy.chatId, copy.topicId), copy);
 			if (next.size > TELEGRAM_CUSTODY_MAX_RECORDS) throw new Error("Telegram custody record limit exceeded");
-			await this.#persist(next.values());
+			const persisted = await this.#persist(next.values());
+			if (!persisted.ok) return persisted;
 			this.#records = next;
 			return { ok: true };
 		});
@@ -373,7 +403,8 @@ export class TelegramCustodyStore {
 			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
 			const next = new Map(this.#records);
 			next.delete(key);
-			await this.#persist(next.values());
+			const persisted = await this.#persist(next.values());
+			if (!persisted.ok) return persisted;
 			this.#records = next;
 			return { ok: true };
 		});
@@ -413,7 +444,9 @@ export class TelegramCustodyStore {
 			const records = classifyV2Records(v2.value.records);
 			if (v2.value.hasInFlight) {
 				try {
-					await this.#persist(records);
+					if (!(await this.#persist(records)).ok) {
+						return this.#readOnly("migration_write_failed", records);
+					}
 				} catch {
 					return this.#readOnly("migration_write_failed", records);
 				}
@@ -427,7 +460,9 @@ export class TelegramCustodyStore {
 		if (!v1.ok) return this.#readOnly(v2.reason === "bounds" || v1.reason === "bounds" ? "bounds" : "corrupt", []);
 
 		try {
-			await this.#persist(v1.value.records);
+			if (!(await this.#persist(v1.value.records)).ok) {
+				return this.#readOnly("migration_write_failed", v1.value.records);
+			}
 		} catch {
 			return this.#readOnly("migration_write_failed", v1.value.records);
 		}
@@ -454,12 +489,29 @@ export class TelegramCustodyStore {
 		);
 	}
 
-	async #persist(records: Iterable<TelegramCustodyRecord>): Promise<void> {
+	async #persist(records: Iterable<TelegramCustodyRecord>): Promise<TelegramCustodyWriteResult> {
 		const data = serialize(records);
 		if (Buffer.byteLength(data, "utf8") > TELEGRAM_CUSTODY_MAX_FILE_BYTES) {
 			throw new Error("Telegram custody snapshot exceeds the maximum file size");
 		}
+		if (!this.#fence) {
+			await this.#persistAtomically(data);
+			return { ok: true };
+		}
+		const result = await withCurrentTelegramCustodyEpoch(
+			{
+				agentDir: this.#agentDir,
+				binding: this.#fence.binding,
+				fs: this.#fence.fs,
+			},
+			async () => {
+				await this.#persistAtomically(data);
+			},
+		);
+		return result.ok ? { ok: true } : result;
+	}
 
+	async #persistAtomically(data: string): Promise<void> {
 		await this.#fsImpl.mkdir(this.#dir, { recursive: true, mode: 0o700 });
 		await this.#fsImpl.chmod(this.#dir, 0o700);
 		const temporaryFile = `${this.#file}.${process.pid}.${this.#now()}.${Math.random().toString(36).slice(2)}.tmp`;

--- a/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
@@ -5,7 +5,19 @@ import { withFileLock } from "../config/file-lock";
 import type { Settings } from "../config/settings";
 import { getNotificationConfig, isTelegramConfigured } from "./config";
 import { daemonPaths } from "./daemon-paths";
-import type { TelegramDaemonOptions } from "./telegram-daemon";
+import {
+	readDaemonState,
+	type TelegramDaemonOptions,
+} from "./telegram-daemon";
+import {
+	clearTelegramControlRequest,
+	readTelegramControlRequest,
+} from "./telegram-daemon-control";
+import {
+	readTelegramCustodyEpoch,
+	withCurrentTelegramCustodyEpoch,
+	type TelegramCustodyEpochBinding,
+} from "./telegram-custody-epoch";
 
 type TelegramDaemonRunner = {
 	run(): Promise<void>;
@@ -26,6 +38,43 @@ export interface RunDaemonInternalDeps {
 function argValue(argv: string[], name: string): string | undefined {
 	const i = argv.indexOf(name);
 	return i >= 0 ? argv[i + 1] : undefined;
+}
+function parseCustodyEpochArg(argv: string[]): number {
+	const indices = argv.reduce<number[]>((found, value, index) => {
+		if (value === "--custody-epoch") found.push(index);
+		return found;
+	}, []);
+	if (indices.length !== 1) throw new Error("missing or duplicate --custody-epoch");
+	const raw = argv[indices[0]! + 1];
+	if (typeof raw !== "string" || !/^[1-9]\d*$/.test(raw)) {
+		throw new Error("invalid --custody-epoch");
+	}
+	const custodyEpoch = Number(raw);
+	if (!Number.isSafeInteger(custodyEpoch) || String(custodyEpoch) !== raw) {
+		throw new Error("invalid --custody-epoch");
+	}
+	return custodyEpoch;
+}
+
+async function withCurrentDaemonBinding<T>(
+	settings: Settings,
+	binding: TelegramCustodyEpochBinding,
+	operation: () => Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false }> {
+	return await withFileLock(daemonPaths(settings.getAgentDir()).state, async () => {
+		const guarded = await withCurrentTelegramCustodyEpoch(
+			{ agentDir: settings.getAgentDir(), binding },
+			async () => {
+				const state = await readDaemonState(settings);
+				if (state?.ownerId !== binding.ownerId || state.custodyEpoch !== binding.custodyEpoch) {
+					return { ok: false } as const;
+				}
+				return { ok: true, value: await operation() } as const;
+			},
+		);
+		if (!guarded.ok || !guarded.value.ok) return { ok: false };
+		return guarded.value;
+	});
 }
 
 function getByPath(obj: unknown, pathSegments: string[]): unknown {
@@ -193,20 +242,30 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 	if (smoke) return runDaemonSmoke({ agentDir });
 	const ownerId = argValue(argv, "--owner-id");
 	if (!ownerId) throw new Error("missing --owner-id");
+	const custodyEpoch = parseCustodyEpochArg(argv);
 	if (!ownerProcessIsAlive(ownerId, deps)) {
 		process.stderr.write(`GJC notify daemon exiting: owner process from --owner-id ${ownerId} is not alive.\n`);
 		return;
 	}
 	const resolvedAgentDir = agentDir ?? process.env.GJC_CODING_AGENT_DIR ?? path.join(process.cwd(), ".gjc", "agent");
 	const settings = await resolveDaemonSettings(resolvedAgentDir, deps);
+	const binding = { ownerId, custodyEpoch };
+	const state = await readDaemonState(settings as Settings);
+	if (state?.ownerId !== binding.ownerId || state.custodyEpoch !== binding.custodyEpoch) {
+		throw new Error("Telegram daemon ownership state does not match --owner-id and --custody-epoch");
+	}
+	const currentEpoch = await readTelegramCustodyEpoch({ agentDir: resolvedAgentDir });
+	if (currentEpoch.ownerId !== binding.ownerId || currentEpoch.custodyEpoch !== binding.custodyEpoch) {
+		throw new Error("Telegram custody epoch does not match daemon ownership state");
+	}
 	const cfg = getNotificationConfig(settings as Settings);
 	if (!isTelegramConfigured(cfg)) return;
-	const { clearTelegramControlRequest, readTelegramControlRequest } = await import("./telegram-daemon-control");
 	const Daemon: TelegramDaemonConstructor =
 		deps.DaemonImpl ?? (await import("./telegram-daemon")).TelegramNotificationDaemon;
 	const daemon = new Daemon({
 		settings: settings as Settings,
 		ownerId,
+		custodyEpoch,
 		botToken: cfg.botToken,
 		chatId: cfg.chatId,
 		idleTimeoutMs: cfg.idleTimeoutMs,
@@ -215,17 +274,38 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 		topics: cfg.topics,
 		pid: deps.processPid ?? process.pid,
 		control: {
-			shouldStop: async owner => {
-				const req = await readTelegramControlRequest(settings as Settings);
-				return Boolean(req && (!req.ownerId || req.ownerId === owner));
+			shouldStop: async (requestOwnerId, requestCustodyEpoch) => {
+				const current = await withCurrentDaemonBinding(
+					settings as Settings,
+					{ ownerId: requestOwnerId, custodyEpoch: requestCustodyEpoch },
+					async () => await readTelegramControlRequest(settings as Settings),
+				);
+				return Boolean(
+					current.ok &&
+						current.value !== undefined &&
+						current.value.ownerId === requestOwnerId &&
+						current.value.custodyEpoch === requestCustodyEpoch,
+				);
 			},
-			clear: async owner => {
-				const req = await readTelegramControlRequest(settings as Settings);
-				// Only clear a request that targets this daemon owner, so an exiting
-				// daemon never erases a newer request meant for a different owner.
-				if (req && (!req.ownerId || req.ownerId === owner)) {
-					await clearTelegramControlRequest(settings as Settings, req.requestId);
-				}
+			clear: async (requestOwnerId, requestCustodyEpoch) => {
+				await withCurrentDaemonBinding(
+					settings as Settings,
+					{ ownerId: requestOwnerId, custodyEpoch: requestCustodyEpoch },
+					async () => {
+						const request = await readTelegramControlRequest(settings as Settings);
+						if (
+							request?.ownerId === requestOwnerId &&
+							request.custodyEpoch === requestCustodyEpoch
+						) {
+							await clearTelegramControlRequest(
+								settings as Settings,
+								request.requestId,
+								undefined,
+								{ ownerId: requestOwnerId, custodyEpoch: requestCustodyEpoch },
+							);
+						}
+					},
+				);
 			},
 		},
 	});

--- a/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
@@ -6,18 +6,12 @@ import type { Settings } from "../config/settings";
 import { getNotificationConfig, isTelegramConfigured } from "./config";
 import { daemonPaths } from "./daemon-paths";
 import {
-	readDaemonState,
-	type TelegramDaemonOptions,
-} from "./telegram-daemon";
-import {
-	clearTelegramControlRequest,
-	readTelegramControlRequest,
-} from "./telegram-daemon-control";
-import {
 	readTelegramCustodyEpoch,
-	withCurrentTelegramCustodyEpoch,
 	type TelegramCustodyEpochBinding,
+	withCurrentTelegramCustodyEpoch,
 } from "./telegram-custody-epoch";
+import { readDaemonState, type TelegramDaemonOptions } from "./telegram-daemon";
+import { clearTelegramControlRequest, readTelegramControlRequest } from "./telegram-daemon-control";
 
 type TelegramDaemonRunner = {
 	run(): Promise<void>;
@@ -62,16 +56,13 @@ async function withCurrentDaemonBinding<T>(
 	operation: () => Promise<T>,
 ): Promise<{ ok: true; value: T } | { ok: false }> {
 	return await withFileLock(daemonPaths(settings.getAgentDir()).state, async () => {
-		const guarded = await withCurrentTelegramCustodyEpoch(
-			{ agentDir: settings.getAgentDir(), binding },
-			async () => {
-				const state = await readDaemonState(settings);
-				if (state?.ownerId !== binding.ownerId || state.custodyEpoch !== binding.custodyEpoch) {
-					return { ok: false } as const;
-				}
-				return { ok: true, value: await operation() } as const;
-			},
-		);
+		const guarded = await withCurrentTelegramCustodyEpoch({ agentDir: settings.getAgentDir(), binding }, async () => {
+			const state = await readDaemonState(settings);
+			if (state?.ownerId !== binding.ownerId || state.custodyEpoch !== binding.custodyEpoch) {
+				return { ok: false } as const;
+			}
+			return { ok: true, value: await operation() } as const;
+		});
 		if (!guarded.ok || !guarded.value.ok) return { ok: false };
 		return guarded.value;
 	});
@@ -293,16 +284,11 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 					{ ownerId: requestOwnerId, custodyEpoch: requestCustodyEpoch },
 					async () => {
 						const request = await readTelegramControlRequest(settings as Settings);
-						if (
-							request?.ownerId === requestOwnerId &&
-							request.custodyEpoch === requestCustodyEpoch
-						) {
-							await clearTelegramControlRequest(
-								settings as Settings,
-								request.requestId,
-								undefined,
-								{ ownerId: requestOwnerId, custodyEpoch: requestCustodyEpoch },
-							);
+						if (request?.ownerId === requestOwnerId && request.custodyEpoch === requestCustodyEpoch) {
+							await clearTelegramControlRequest(settings as Settings, request.requestId, undefined, {
+								ownerId: requestOwnerId,
+								custodyEpoch: requestCustodyEpoch,
+							});
 						}
 					},
 				);

--- a/packages/coding-agent/src/notifications/telegram-daemon-control.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-control.ts
@@ -24,6 +24,7 @@ import type {
 import { OWNERSHIP_MISMATCH_MESSAGE, ownershipMismatchRecovery } from "../daemon/operator-contract";
 import { resolveGjcRuntimeSpawnInfo } from "../daemon/runtime";
 import { getNotificationConfig, isTelegramConfigured, tokenFingerprint } from "./config";
+import { type TelegramCustodyEpochBinding, withCurrentTelegramCustodyEpoch } from "./telegram-custody-epoch";
 import {
 	daemonPaths,
 	isFreshLiveOwner,
@@ -33,7 +34,6 @@ import {
 	type TelegramDaemonDeps,
 	type TelegramDaemonFs,
 } from "./telegram-daemon";
-import { withCurrentTelegramCustodyEpoch, type TelegramCustodyEpochBinding } from "./telegram-custody-epoch";
 
 const nodeFs: TelegramDaemonFs = fs.promises as unknown as TelegramDaemonFs;
 const DEFAULT_GRACEFUL_TIMEOUT_MS = 8_000;
@@ -71,11 +71,7 @@ function controlRequestMatchesBinding(
 	request: TelegramDaemonControlRequestRead | undefined,
 	binding: TelegramCustodyEpochBinding,
 ): boolean {
-	return Boolean(
-		request &&
-			request.ownerId === binding.ownerId &&
-			request.custodyEpoch === binding.custodyEpoch,
-	);
+	return Boolean(request && request.ownerId === binding.ownerId && request.custodyEpoch === binding.custodyEpoch);
 }
 
 function isControlRequest(value: unknown): value is TelegramDaemonControlRequestRead {
@@ -380,7 +376,14 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 		const captured = await readDaemonState(this.settings, this.fsImpl);
 		if (!captured || captured.ownerId !== oldOwnerId || captured.pid !== oldPid) {
 			const after = await this.status();
-			return this.result(action, false, "telegram daemon ownership changed before control request", before, after, warnings);
+			return this.result(
+				action,
+				false,
+				"telegram daemon ownership changed before control request",
+				before,
+				after,
+				warnings,
+			);
 		}
 		if (captured.custodyEpoch !== undefined && !isCustodyEpoch(captured.custodyEpoch)) {
 			const after = await this.status();
@@ -508,21 +511,11 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 				ownershipMismatchRecovery(),
 			);
 		}
-		return this.result(
-			action,
-			true,
-			`reloaded telegram daemon (${spawned.result})`,
-			before,
-			after,
-			warnings,
-		);
+		return this.result(action, true, `reloaded telegram daemon (${spawned.result})`, before, after, warnings);
 	}
 
 	/** Clear only the exact pair-bound request for a still-current owner binding. */
-	private async clearOwnRequest(
-		requestId: string,
-		binding: TelegramCustodyEpochBinding | undefined,
-	): Promise<void> {
+	private async clearOwnRequest(requestId: string, binding: TelegramCustodyEpochBinding | undefined): Promise<void> {
 		if (!binding || !(await this.hasCurrentBinding(binding))) return;
 		await clearTelegramControlRequest(this.settings, requestId, this.fsImpl, binding);
 	}

--- a/packages/coding-agent/src/notifications/telegram-daemon-control.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-control.ts
@@ -10,6 +10,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { withFileLock } from "../config/file-lock";
 import type { Settings } from "../config/settings";
 import type {
 	BuiltInDaemonController,
@@ -32,6 +33,7 @@ import {
 	type TelegramDaemonDeps,
 	type TelegramDaemonFs,
 } from "./telegram-daemon";
+import { withCurrentTelegramCustodyEpoch, type TelegramCustodyEpochBinding } from "./telegram-custody-epoch";
 
 const nodeFs: TelegramDaemonFs = fs.promises as unknown as TelegramDaemonFs;
 const DEFAULT_GRACEFUL_TIMEOUT_MS = 8_000;
@@ -44,7 +46,50 @@ export interface TelegramDaemonControlRequest {
 	action: "reload" | "stop";
 	ownerId: string;
 	pid: number;
+	custodyEpoch: number;
 	createdAt: number;
+}
+
+/** A v1 request written before custody epochs existed; never targets a T2 daemon. */
+interface LegacyTelegramDaemonControlRequest {
+	version: 1;
+	requestId: string;
+	action: "reload" | "stop";
+	ownerId: string;
+	pid: number;
+	createdAt: number;
+	custodyEpoch?: undefined;
+}
+
+type TelegramDaemonControlRequestRead = TelegramDaemonControlRequest | LegacyTelegramDaemonControlRequest;
+
+function isCustodyEpoch(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function controlRequestMatchesBinding(
+	request: TelegramDaemonControlRequestRead | undefined,
+	binding: TelegramCustodyEpochBinding,
+): boolean {
+	return Boolean(
+		request &&
+			request.ownerId === binding.ownerId &&
+			request.custodyEpoch === binding.custodyEpoch,
+	);
+}
+
+function isControlRequest(value: unknown): value is TelegramDaemonControlRequestRead {
+	if (!value || typeof value !== "object") return false;
+	const request = value as Record<string, unknown>;
+	return (
+		request.version === 1 &&
+		typeof request.requestId === "string" &&
+		(request.action === "reload" || request.action === "stop") &&
+		typeof request.ownerId === "string" &&
+		typeof request.pid === "number" &&
+		typeof request.createdAt === "number" &&
+		(request.custodyEpoch === undefined || isCustodyEpoch(request.custodyEpoch))
+	);
 }
 
 export function telegramControlRequestPath(agentDir: string): string {
@@ -54,21 +99,21 @@ export function telegramControlRequestPath(agentDir: string): string {
 export async function readTelegramControlRequest(
 	settings: Settings,
 	fsImpl: TelegramDaemonFs = nodeFs,
-): Promise<TelegramDaemonControlRequest | undefined> {
+): Promise<TelegramDaemonControlRequestRead | undefined> {
 	const file = telegramControlRequestPath(settings.getAgentDir());
 	try {
-		const parsed = JSON.parse(await fsImpl.readFile(file, "utf8")) as TelegramDaemonControlRequest;
-		return parsed?.version === 1 ? parsed : undefined;
+		const parsed: unknown = JSON.parse(await fsImpl.readFile(file, "utf8"));
+		return isControlRequest(parsed) ? parsed : undefined;
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
 		return undefined;
 	}
 }
 
-export async function writeTelegramControlRequest(
+async function writeTelegramControlRequestAtomic(
 	settings: Settings,
 	request: TelegramDaemonControlRequest,
-	fsImpl: TelegramDaemonFs = nodeFs,
+	fsImpl: TelegramDaemonFs,
 ): Promise<void> {
 	const dir = daemonPaths(settings.getAgentDir()).dir;
 	await fsImpl.mkdir(dir, { recursive: true, mode: 0o700 });
@@ -79,17 +124,33 @@ export async function writeTelegramControlRequest(
 	await fsImpl.rename(tmp, file);
 }
 
+export async function writeTelegramControlRequest(
+	settings: Settings,
+	request: TelegramDaemonControlRequest,
+	fsImpl: TelegramDaemonFs = nodeFs,
+): Promise<void> {
+	const dir = daemonPaths(settings.getAgentDir()).dir;
+	await fsImpl.mkdir(dir, { recursive: true, mode: 0o700 });
+	const file = telegramControlRequestPath(settings.getAgentDir());
+	await withFileLock(file, async () => {
+		await writeTelegramControlRequestAtomic(settings, request, fsImpl);
+	});
+}
+
 export async function clearTelegramControlRequest(
 	settings: Settings,
 	requestId?: string,
 	fsImpl: TelegramDaemonFs = nodeFs,
+	binding?: TelegramCustodyEpochBinding,
 ): Promise<void> {
 	const file = telegramControlRequestPath(settings.getAgentDir());
-	if (requestId) {
+	await withFileLock(file, async () => {
 		const current = await readTelegramControlRequest(settings, fsImpl);
-		if (current && current.requestId !== requestId) return;
-	}
-	await fsImpl.unlink(file).catch(() => undefined);
+		if (!current) return;
+		if (requestId && current.requestId !== requestId) return;
+		if (binding && !controlRequestMatchesBinding(current, binding)) return;
+		await fsImpl.unlink(file).catch(() => undefined);
+	});
 }
 
 export interface TelegramDaemonControlDeps {
@@ -156,6 +217,24 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 			reloadPicksUpSourceEdits: rt.reloadPicksUpSourceEdits,
 			warning: rt.warning,
 		};
+	}
+	private async hasCurrentBinding(binding: TelegramCustodyEpochBinding, pid?: number): Promise<boolean> {
+		const statePath = daemonPaths(this.settings.getAgentDir()).state;
+		return await withFileLock(statePath, async () => {
+			const guarded = await withCurrentTelegramCustodyEpoch(
+				{ agentDir: this.settings.getAgentDir(), binding },
+				async () => {
+					const state = await readDaemonState(this.settings, this.fsImpl);
+					return Boolean(
+						state &&
+							state.ownerId === binding.ownerId &&
+							state.custodyEpoch === binding.custodyEpoch &&
+							(pid === undefined || state.pid === pid),
+					);
+				},
+			);
+			return guarded.ok && guarded.value;
+		});
 	}
 
 	async status(): Promise<DaemonStatus> {
@@ -295,16 +374,57 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 			);
 		}
 
-		// Running owner: capture identity, request cooperative stop, signal, wait.
+		// Running owner: capture the complete binding before every control action.
 		const oldOwnerId = before.ownerId as string;
 		const oldPid = before.pid as number;
+		const captured = await readDaemonState(this.settings, this.fsImpl);
+		if (!captured || captured.ownerId !== oldOwnerId || captured.pid !== oldPid) {
+			const after = await this.status();
+			return this.result(action, false, "telegram daemon ownership changed before control request", before, after, warnings);
+		}
+		if (captured.custodyEpoch !== undefined && !isCustodyEpoch(captured.custodyEpoch)) {
+			const after = await this.status();
+			return this.result(action, false, "telegram daemon has an invalid custody epoch", before, after, warnings);
+		}
+		const oldBinding =
+			captured.custodyEpoch === undefined
+				? undefined
+				: { ownerId: captured.ownerId, custodyEpoch: captured.custodyEpoch };
 		const requestId = this.deps.randomId?.() ?? `${this.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-		await writeTelegramControlRequest(
-			this.settings,
-			{ version: 1, requestId, action, ownerId: oldOwnerId, pid: oldPid, createdAt: this.now() },
-			this.fsImpl,
-		);
-		if (this.pidAlive(oldPid)) this.sendSignal(oldPid, "SIGTERM");
+		if (oldBinding) {
+			if (!(await this.hasCurrentBinding(oldBinding, oldPid))) {
+				const after = await this.status();
+				return this.result(
+					action,
+					false,
+					"telegram daemon ownership changed before control request",
+					before,
+					after,
+					warnings,
+				);
+			}
+			await writeTelegramControlRequest(
+				this.settings,
+				{
+					version: 1,
+					requestId,
+					action,
+					ownerId: oldBinding.ownerId,
+					custodyEpoch: oldBinding.custodyEpoch,
+					pid: oldPid,
+					createdAt: this.now(),
+				},
+				this.fsImpl,
+			);
+		} else {
+			// Pre-T2 state is intentionally never assigned epoch zero. SIGTERM still
+			// reaches the legacy process, but it gets no pair-bound request and cannot
+			// participate in T2 force-kill/cleanup paths.
+			warnings.push("legacy telegram daemon lacks custody epoch; using signal-only reload handoff");
+		}
+		if (this.pidAlive(oldPid) && (!oldBinding || (await this.hasCurrentBinding(oldBinding, oldPid)))) {
+			this.sendSignal(oldPid, "SIGTERM");
+		}
 
 		let dead = await this.waitForPidDeath(oldPid, gracefulTimeoutMs);
 		if (!dead) {
@@ -312,7 +432,9 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 			const current = await readDaemonState(this.settings, this.fsImpl);
 			const changedToLiveOwner =
 				current !== undefined &&
-				current.ownerId !== oldOwnerId &&
+				(oldBinding
+					? current.ownerId !== oldBinding.ownerId || current.custodyEpoch !== oldBinding.custodyEpoch
+					: current.ownerId !== oldOwnerId || current.custodyEpoch !== undefined) &&
 				isFreshLiveOwner({
 					state: current,
 					now: this.now(),
@@ -321,9 +443,10 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 					pidAlive: this.pidAlive,
 				});
 			if (changedToLiveOwner) {
-				// A different, fresh-live owner already supersedes the old one. Do not
-				// kill it or spawn another; attach to the running daemon.
-				await this.clearOwnRequest(requestId, oldOwnerId);
+				// A fresh binding already supersedes the captured one. Do not kill it
+				// or spawn another; a stale ownerId with a different epoch is equally
+				// protected here.
+				await this.clearOwnRequest(requestId, oldBinding);
 				const after = await this.status();
 				warnings.push("ownership changed to a live owner; attached without spawning");
 				return this.result(
@@ -337,15 +460,15 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 					warnings,
 				);
 			}
-			// No live replacement. Escalate to SIGKILL only with --force and only when
-			// the captured owner/pid still matches, so we never kill a different owner.
-			const stillSameOwner = current !== undefined && current.ownerId === oldOwnerId && current.pid === oldPid;
+			// No live replacement. Escalate only when the captured owner, epoch, and
+			// pid are still current; legacy state deliberately cannot enter this path.
+			const stillSameOwner = oldBinding ? await this.hasCurrentBinding(oldBinding, oldPid) : false;
 			if (opts.force && stillSameOwner && this.pidAlive(oldPid)) {
 				this.sendSignal(oldPid, "SIGKILL");
 				dead = await this.waitForPidDeath(oldPid, killTimeoutMs);
 			}
 			if (!dead) {
-				await this.clearOwnRequest(requestId, oldOwnerId);
+				await this.clearOwnRequest(requestId, oldBinding);
 				const after = await this.status();
 				const message = opts.force
 					? "old daemon did not exit after SIGKILL; refusing to spawn to avoid a Telegram 409 conflict"
@@ -354,8 +477,8 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 			}
 		}
 
-		// Old pid is dead: safe to clear our request and proceed.
-		await this.clearOwnRequest(requestId, oldOwnerId);
+		// Old pid is dead: safe to clear only the exact control request and binding.
+		await this.clearOwnRequest(requestId, oldBinding);
 
 		if (action === "stop") {
 			const after = await this.status();
@@ -387,7 +510,7 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 		}
 		return this.result(
 			action,
-			spawned.result !== "disabled",
+			true,
 			`reloaded telegram daemon (${spawned.result})`,
 			before,
 			after,
@@ -395,12 +518,12 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 		);
 	}
 
-	/** Clear our own control request unless a newer owner-scoped request replaced it. */
-	private async clearOwnRequest(requestId: string, oldOwnerId: string): Promise<void> {
-		const current = await readTelegramControlRequest(this.settings, this.fsImpl);
-		if (!current) return;
-		if (current.requestId === requestId || current.ownerId === oldOwnerId) {
-			await clearTelegramControlRequest(this.settings, current.requestId, this.fsImpl);
-		}
+	/** Clear only the exact pair-bound request for a still-current owner binding. */
+	private async clearOwnRequest(
+		requestId: string,
+		binding: TelegramCustodyEpochBinding | undefined,
+	): Promise<void> {
+		if (!binding || !(await this.hasCurrentBinding(binding))) return;
+		await clearTelegramControlRequest(this.settings, requestId, this.fsImpl, binding);
 	}
 }

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -50,8 +50,8 @@ import { deliverRichActionWithFallback, deliverRichWithFallback, shouldPromoteRi
 import {
 	allocateTelegramCustodyEpoch,
 	readTelegramCustodyEpoch,
-	withCurrentTelegramCustodyEpoch,
 	type TelegramCustodyEpochBinding,
+	withCurrentTelegramCustodyEpoch,
 } from "./telegram-custody-epoch";
 import { type TelegramCustodyLoadResult, TelegramCustodyStore } from "./telegram-custody-store";
 import {
@@ -425,9 +425,7 @@ function ownerBindingMatches(
 	state: DaemonState | undefined,
 	binding: TelegramCustodyEpochBinding,
 ): state is DaemonState & { custodyEpoch: number } {
-	return Boolean(
-		state && state.ownerId === binding.ownerId && state.custodyEpoch === binding.custodyEpoch,
-	);
+	return Boolean(state && state.ownerId === binding.ownerId && state.custodyEpoch === binding.custodyEpoch);
 }
 
 function assertValidPersistedStateEpoch(state: DaemonState | undefined): void {

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -47,6 +47,12 @@ import { listRecentSessions } from "./recent-activity";
 import { ReplySentStore } from "./reply-sent-store";
 import { DraftStreamState, deliverDraft, shouldStreamDraft } from "./rich-draft";
 import { deliverRichActionWithFallback, deliverRichWithFallback, shouldPromoteRich } from "./rich-render";
+import {
+	allocateTelegramCustodyEpoch,
+	readTelegramCustodyEpoch,
+	withCurrentTelegramCustodyEpoch,
+	type TelegramCustodyEpochBinding,
+} from "./telegram-custody-epoch";
 import { type TelegramCustodyLoadResult, TelegramCustodyStore } from "./telegram-custody-store";
 import {
 	type AliasTable,
@@ -66,6 +72,11 @@ export type EnsureDaemonResult = "owner_spawned" | "attached" | "disabled" | "bl
 export interface DaemonState {
 	pid: number;
 	ownerId: string;
+	/**
+	 * Required on all T2 writes. Optional only so a pre-T2 state can be routed
+	 * through the generation-reload handoff; it is never treated as epoch zero.
+	 */
+	custodyEpoch?: number;
 	tokenFingerprint: string;
 	chatId: string;
 	startedAt: number;
@@ -297,9 +308,14 @@ async function readJson<T>(fsImpl: TelegramDaemonFs, file: string): Promise<T | 
 
 async function writeJsonAtomic(fsImpl: TelegramDaemonFs, file: string, data: unknown): Promise<void> {
 	const tmp = `${file}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
-	await fsImpl.writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o600 });
-	await fsImpl.chmod(tmp, 0o600).catch(() => undefined);
-	await fsImpl.rename(tmp, file);
+	try {
+		await fsImpl.writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o600 });
+		await fsImpl.chmod(tmp, 0o600).catch(() => undefined);
+		await fsImpl.rename(tmp, file);
+	} catch (error) {
+		await fsImpl.unlink(tmp).catch(() => undefined);
+		throw error;
+	}
 }
 
 async function tryOpenWx(fsImpl: TelegramDaemonFs, file: string): Promise<boolean> {
@@ -381,6 +397,45 @@ export function isFreshLiveOwner(input: {
 	);
 }
 
+export type DaemonOwnershipResult =
+	| {
+			acquired: true;
+			ownerId: string;
+			custodyEpoch: number;
+			attached?: false;
+			blocked?: false;
+			reason?: never;
+			reloadRequired?: never;
+	  }
+	| {
+			acquired: false;
+			ownerId?: undefined;
+			custodyEpoch?: undefined;
+			attached?: boolean;
+			blocked?: boolean;
+			reason?: "identity_mismatch";
+			reloadRequired?: boolean;
+	  };
+
+function isCustodyEpoch(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function ownerBindingMatches(
+	state: DaemonState | undefined,
+	binding: TelegramCustodyEpochBinding,
+): state is DaemonState & { custodyEpoch: number } {
+	return Boolean(
+		state && state.ownerId === binding.ownerId && state.custodyEpoch === binding.custodyEpoch,
+	);
+}
+
+function assertValidPersistedStateEpoch(state: DaemonState | undefined): void {
+	if (state?.custodyEpoch !== undefined && !isCustodyEpoch(state.custodyEpoch)) {
+		throw new Error("invalid Telegram daemon custody epoch in persisted ownership state");
+	}
+}
+
 export async function acquireDaemonOwnership(input: {
 	settings: Settings;
 	roots?: string[];
@@ -391,14 +446,7 @@ export async function acquireDaemonOwnership(input: {
 	pid?: number;
 	pidAlive?: (pid: number) => boolean;
 	randomId?: () => string;
-}): Promise<{
-	acquired: boolean;
-	ownerId?: string;
-	attached?: boolean;
-	blocked?: boolean;
-	reason?: "identity_mismatch";
-	reloadRequired?: boolean;
-}> {
+}): Promise<DaemonOwnershipResult> {
 	const fsImpl = input.fs ?? nodeFs;
 	const now = input.now ?? Date.now;
 	const pid = input.pid ?? process.pid;
@@ -408,76 +456,85 @@ export async function acquireDaemonOwnership(input: {
 	const ownerId = input.randomId?.() ?? `${pid}-${now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 	const roots = input.roots ?? (await readJson<{ roots?: string[] }>(fsImpl, paths.roots))?.roots ?? [];
 
-	// A fresh, identity-matching live owner running an OLDER generation than this
-	// build cannot serve our newer wire frames; signal a reload instead of a
-	// silent attach. Newer/equal generations attach as before (no downgrade).
-	const attachDecision = (
-		state: DaemonState | undefined,
-	): { acquired: false; attached: boolean; reloadRequired?: boolean } | undefined => {
-		if (
-			!isFreshLiveOwner({
-				state,
-				now: now(),
+	return await withFileLock(paths.state, async () => {
+		// A fresh, identity-matching live owner running an OLDER generation than this
+		// build cannot serve our newer wire frames; signal a reload instead of a
+		// silent attach. Newer/equal generations attach as before (no downgrade).
+		const attachDecision = async (
+			state: DaemonState | undefined,
+		): Promise<{ acquired: false; attached: boolean; reloadRequired?: boolean } | undefined> => {
+			assertValidPersistedStateEpoch(state);
+			if (
+				!isFreshLiveOwner({
+					state,
+					now: now(),
+					tokenFingerprint: input.tokenFingerprint,
+					chatId: input.chatId,
+					pidAlive,
+				})
+			) {
+				return undefined;
+			}
+			// A legacy owner has no fence token. Treat it exactly like a stale
+			// generation: reload it rather than inventing custody epoch zero.
+			if (state?.custodyEpoch === undefined) {
+				return { acquired: false, attached: false, reloadRequired: true };
+			}
+			const binding = await readTelegramCustodyEpoch({ agentDir: input.settings.getAgentDir() });
+			if (!ownerBindingMatches(state, binding)) {
+				throw new Error("Telegram daemon custody epoch does not match persisted ownership state");
+			}
+			return (state.generation ?? 0) < DAEMON_GENERATION
+				? { acquired: false, attached: false, reloadRequired: true }
+				: { acquired: false, attached: true };
+		};
+
+		const publishOwnership = async (): Promise<DaemonOwnershipResult> => {
+			let binding: TelegramCustodyEpochBinding;
+			try {
+				binding = await allocateTelegramCustodyEpoch({
+					agentDir: input.settings.getAgentDir(),
+					ownerId,
+				});
+			} catch (error) {
+				// We own the physical lock while the state mutex is held. Allocation
+				// may have durably consumed an epoch before a later barrier failed;
+				// unlock without attempting to reset or reuse that epoch.
+				await fsImpl.unlink(paths.lock).catch(() => undefined);
+				throw error;
+			}
+			const state: DaemonState = {
+				pid,
+				ownerId: binding.ownerId,
+				custodyEpoch: binding.custodyEpoch,
 				tokenFingerprint: input.tokenFingerprint,
 				chatId: input.chatId,
-				pidAlive,
-			})
-		) {
-			return undefined;
-		}
-		return (state?.generation ?? 0) < DAEMON_GENERATION
-			? { acquired: false, attached: false, reloadRequired: true }
-			: { acquired: false, attached: true };
-	};
-	const existing = await readJson<DaemonState>(fsImpl, paths.state);
-	if (
-		liveOwnerUsesDifferentIdentity({
-			state: existing,
-			tokenFingerprint: input.tokenFingerprint,
-			chatId: input.chatId,
-			pidAlive,
-		})
-	) {
-		return { acquired: false, blocked: true, reason: "identity_mismatch" };
-	}
-	const existingDecision = attachDecision(existing);
-	if (existingDecision) return existingDecision;
-	if (await tryOpenWx(fsImpl, paths.lock)) {
-		await writeJsonAtomic(fsImpl, paths.state, {
-			pid,
-			ownerId,
-			tokenFingerprint: input.tokenFingerprint,
-			chatId: input.chatId,
-			startedAt: now(),
-			heartbeatAt: now(),
-			roots,
-			version: DAEMON_VERSION,
-			generation: DAEMON_GENERATION,
-		} satisfies DaemonState);
-		return { acquired: true, ownerId };
-	}
-	const afterLock = await readJson<DaemonState>(fsImpl, paths.state);
-	if (
-		liveOwnerUsesDifferentIdentity({
-			state: afterLock,
-			tokenFingerprint: input.tokenFingerprint,
-			chatId: input.chatId,
-			pidAlive,
-		})
-	) {
-		return { acquired: false, blocked: true, reason: "identity_mismatch" };
-	}
-	const afterLockDecision = attachDecision(afterLock);
-	if (afterLockDecision) return afterLockDecision;
-	if (!afterLock) return { acquired: false, attached: true };
-	if (!(await tryOpenWx(fsImpl, paths.steal))) return { acquired: false, attached: true };
-	try {
-		const rechecked = await readJson<DaemonState>(fsImpl, paths.state);
-		const recheckedDecision = attachDecision(rechecked);
-		if (recheckedDecision) return recheckedDecision;
+				startedAt: now(),
+				heartbeatAt: now(),
+				roots,
+				version: DAEMON_VERSION,
+				generation: DAEMON_GENERATION,
+			};
+			try {
+				await writeJsonAtomic(fsImpl, paths.state, state);
+			} catch (error) {
+				// The physical lock is ours while this state mutex is held. If the
+				// daemon-state publication never appeared, or still names this exact
+				// binding, remove it so the next attempt consumes a higher epoch.
+				const current = await readJson<DaemonState>(fsImpl, paths.state).catch(() => undefined);
+				if (!current || ownerBindingMatches(current, binding)) {
+					await fsImpl.unlink(paths.lock).catch(() => undefined);
+				}
+				throw error;
+			}
+			return { acquired: true, ownerId: binding.ownerId, custodyEpoch: binding.custodyEpoch };
+		};
+
+		const existing = await readJson<DaemonState>(fsImpl, paths.state);
+		assertValidPersistedStateEpoch(existing);
 		if (
 			liveOwnerUsesDifferentIdentity({
-				state: rechecked,
+				state: existing,
 				tokenFingerprint: input.tokenFingerprint,
 				chatId: input.chatId,
 				pidAlive,
@@ -485,59 +542,109 @@ export async function acquireDaemonOwnership(input: {
 		) {
 			return { acquired: false, blocked: true, reason: "identity_mismatch" };
 		}
-		if (rechecked && pidAlive(rechecked.pid)) {
-			return { acquired: false, attached: true };
+		const existingDecision = await attachDecision(existing);
+		if (existingDecision) return existingDecision;
+		if (await tryOpenWx(fsImpl, paths.lock)) return await publishOwnership();
+
+		const afterLock = await readJson<DaemonState>(fsImpl, paths.state);
+		assertValidPersistedStateEpoch(afterLock);
+		if (
+			liveOwnerUsesDifferentIdentity({
+				state: afterLock,
+				tokenFingerprint: input.tokenFingerprint,
+				chatId: input.chatId,
+				pidAlive,
+			})
+		) {
+			return { acquired: false, blocked: true, reason: "identity_mismatch" };
 		}
-		await fsImpl.unlink(paths.lock).catch(() => undefined);
-		if (!(await tryOpenWx(fsImpl, paths.lock))) return { acquired: false, attached: true };
-		await writeJsonAtomic(fsImpl, paths.state, {
-			pid,
-			ownerId,
-			tokenFingerprint: input.tokenFingerprint,
-			chatId: input.chatId,
-			startedAt: now(),
-			heartbeatAt: now(),
-			roots,
-			version: DAEMON_VERSION,
-			generation: DAEMON_GENERATION,
-		} satisfies DaemonState);
-		return { acquired: true, ownerId };
-	} finally {
-		await fsImpl.unlink(paths.steal).catch(() => undefined);
-	}
+		const afterLockDecision = await attachDecision(afterLock);
+		if (afterLockDecision) return afterLockDecision;
+		// A process can crash after durable epoch publication but before state
+		// publication. Under the state mutex, no state means this orphaned physical
+		// lock has no live owner and can be reclaimed; the next allocation skips it.
+		if (!afterLock) {
+			await fsImpl.unlink(paths.lock).catch(() => undefined);
+			if (!(await tryOpenWx(fsImpl, paths.lock))) return { acquired: false, attached: true };
+			return await publishOwnership();
+		}
+		if (!(await tryOpenWx(fsImpl, paths.steal))) return { acquired: false, attached: true };
+		try {
+			const rechecked = await readJson<DaemonState>(fsImpl, paths.state);
+			assertValidPersistedStateEpoch(rechecked);
+			if (
+				liveOwnerUsesDifferentIdentity({
+					state: rechecked,
+					tokenFingerprint: input.tokenFingerprint,
+					chatId: input.chatId,
+					pidAlive,
+				})
+			) {
+				return { acquired: false, blocked: true, reason: "identity_mismatch" };
+			}
+			const recheckedDecision = await attachDecision(rechecked);
+			if (recheckedDecision) return recheckedDecision;
+			if (rechecked && pidAlive(rechecked.pid)) return { acquired: false, attached: true };
+			await fsImpl.unlink(paths.lock).catch(() => undefined);
+			if (!(await tryOpenWx(fsImpl, paths.lock))) return { acquired: false, attached: true };
+			return await publishOwnership();
+		} finally {
+			await fsImpl.unlink(paths.steal).catch(() => undefined);
+		}
+	});
 }
 
 export async function renewDaemonHeartbeat(input: {
 	settings: Settings;
 	ownerId: string;
+	custodyEpoch: number;
 	fs?: TelegramDaemonFs;
 	now?: () => number;
 	pid?: number;
 }): Promise<boolean> {
 	const fsImpl = input.fs ?? nodeFs;
 	const paths = daemonPaths(input.settings.getAgentDir());
-	const state = await readJson<DaemonState>(fsImpl, paths.state);
-	if (!state || state.ownerId !== input.ownerId) return false;
-	await writeJsonAtomic(fsImpl, paths.state, {
-		...state,
-		pid: input.pid ?? state.pid,
-		heartbeatAt: (input.now ?? Date.now)(),
+	const binding = { ownerId: input.ownerId, custodyEpoch: input.custodyEpoch };
+	return await withFileLock(paths.state, async () => {
+		const guarded = await withCurrentTelegramCustodyEpoch(
+			{ agentDir: input.settings.getAgentDir(), binding },
+			async () => {
+				const state = await readJson<DaemonState>(fsImpl, paths.state);
+				if (!ownerBindingMatches(state, binding)) return false;
+				await writeJsonAtomic(fsImpl, paths.state, {
+					...state,
+					pid: input.pid ?? state.pid,
+					heartbeatAt: (input.now ?? Date.now)(),
+				});
+				return true;
+			},
+		);
+		return guarded.ok ? guarded.value : false;
 	});
-	return true;
 }
 
 export async function releaseDaemonOwnership(input: {
 	settings: Settings;
 	ownerId: string;
+	custodyEpoch: number;
 	fs?: TelegramDaemonFs;
 	now?: () => number;
 }): Promise<void> {
 	const fsImpl = input.fs ?? nodeFs;
 	const paths = daemonPaths(input.settings.getAgentDir());
-	const state = await readJson<DaemonState>(fsImpl, paths.state);
-	if (state?.ownerId !== input.ownerId) return;
-	await writeJsonAtomic(fsImpl, paths.state, { ...state, stoppedAt: (input.now ?? Date.now)() });
-	await fsImpl.unlink(paths.lock).catch(() => undefined);
+	const binding = { ownerId: input.ownerId, custodyEpoch: input.custodyEpoch };
+	await withFileLock(paths.state, async () => {
+		const guarded = await withCurrentTelegramCustodyEpoch(
+			{ agentDir: input.settings.getAgentDir(), binding },
+			async () => {
+				const state = await readJson<DaemonState>(fsImpl, paths.state);
+				if (!ownerBindingMatches(state, binding)) return;
+				await writeJsonAtomic(fsImpl, paths.state, { ...state, stoppedAt: (input.now ?? Date.now)() });
+				await fsImpl.unlink(paths.lock).catch(() => undefined);
+			},
+		);
+		void guarded;
+	});
 }
 
 /** Read the persisted daemon ownership state (or undefined when absent). */
@@ -598,29 +705,45 @@ export interface TelegramSpawnOwnerInput {
 	chatId: string;
 }
 
-export interface TelegramSpawnOwnerResult {
-	result: EnsureDaemonResult;
-	ownerId?: string;
-	runtime: DaemonRuntimeInfo;
-	warnings: string[];
-	/**
-	 * Set when ownership was NOT acquired because a still-live owner is running an
-	 * older daemon generation. The caller must hand off via a reload rather than
-	 * attach; see {@link ensureTelegramDaemonRunning}.
-	 */
-	reloadRequired?: boolean;
-}
+export type TelegramSpawnOwnerResult =
+	| {
+			result: "owner_spawned";
+			ownerId: string;
+			custodyEpoch: number;
+			runtime: DaemonRuntimeInfo;
+			warnings: string[];
+			reloadRequired?: false;
+	  }
+	| {
+			result: "attached" | "blocked";
+			ownerId?: undefined;
+			custodyEpoch?: undefined;
+			runtime: DaemonRuntimeInfo;
+			warnings: string[];
+			/**
+			 * Set when ownership was NOT acquired because a still-live owner is
+			 * running an older daemon generation. The caller must hand off via a
+			 * reload rather than attach; see {@link ensureTelegramDaemonRunning}.
+			 */
+			reloadRequired?: boolean;
+	  };
 
 /**
  * Build the detached spawn command/args for the daemon-internal entrypoint.
  * Source mode prepends the entry script so the respawn loads edited source;
  * a compiled binary self-spawns its own subcommand directly.
  */
-export function buildTelegramDaemonSpawnArgs(input: { execPath?: string; ownerId: string; agentDir: string }): {
+export function buildTelegramDaemonSpawnArgs(input: {
+	execPath?: string;
+	ownerId: string;
+	custodyEpoch: number;
+	agentDir: string;
+}): {
 	command: string;
 	args: string[];
 	runtime: DaemonRuntimeInfo;
 } {
+	if (!isCustodyEpoch(input.custodyEpoch)) throw new Error("invalid Telegram daemon custody epoch");
 	const rt = resolveGjcRuntimeSpawnInfo(input.execPath ?? process.execPath);
 	const args = [
 		...rt.argsPrefix,
@@ -628,6 +751,8 @@ export function buildTelegramDaemonSpawnArgs(input: { execPath?: string; ownerId
 		"daemon-internal",
 		"--owner-id",
 		input.ownerId,
+		"--custody-epoch",
+		String(input.custodyEpoch),
 		"--agent-dir",
 		input.agentDir,
 	];
@@ -663,13 +788,17 @@ export async function spawnTelegramDaemonOwner(
 		pidAlive: deps.pidAlive,
 		randomId: deps.randomId,
 	});
-	// One source of truth for runtime detection + spawn args (no duplicate resolve).
-	const { command, args, runtime } = buildTelegramDaemonSpawnArgs({
-		execPath,
-		ownerId: ownership.ownerId ?? "",
-		agentDir,
-	});
+	const runtimeInfo = (): DaemonRuntimeInfo => {
+		const rt = resolveGjcRuntimeSpawnInfo(execPath);
+		return {
+			mode: rt.mode,
+			execPath: rt.execPath,
+			reloadPicksUpSourceEdits: rt.reloadPicksUpSourceEdits,
+			warning: rt.warning,
+		};
+	};
 	if (!ownership.acquired) {
+		const runtime = runtimeInfo();
 		if (ownership.blocked) {
 			return {
 				result: "blocked",
@@ -679,14 +808,37 @@ export async function spawnTelegramDaemonOwner(
 		}
 		return { result: "attached", runtime, warnings: [], reloadRequired: ownership.reloadRequired };
 	}
-	const spawnImpl = deps.spawn ?? defaultDaemonSpawn;
-	const child = spawnImpl(command, args, {
-		detached: true,
-		stdio: "ignore",
-		logPath: path.join(daemonPaths(agentDir).dir, "daemon.log"),
+	const { command, args, runtime } = buildTelegramDaemonSpawnArgs({
+		execPath,
+		ownerId: ownership.ownerId,
+		custodyEpoch: ownership.custodyEpoch,
+		agentDir,
 	});
-	child?.unref?.();
-	return { result: "owner_spawned", ownerId: ownership.ownerId, runtime, warnings: [] };
+	const spawnImpl = deps.spawn ?? defaultDaemonSpawn;
+	try {
+		const child = spawnImpl(command, args, {
+			detached: true,
+			stdio: "ignore",
+			logPath: path.join(daemonPaths(agentDir).dir, "daemon.log"),
+		});
+		child?.unref?.();
+	} catch (error) {
+		await releaseDaemonOwnership({
+			settings: input.settings,
+			ownerId: ownership.ownerId,
+			custodyEpoch: ownership.custodyEpoch,
+			fs: deps.fs,
+			now: deps.now,
+		});
+		throw error;
+	}
+	return {
+		result: "owner_spawned",
+		ownerId: ownership.ownerId,
+		custodyEpoch: ownership.custodyEpoch,
+		runtime,
+		warnings: [],
+	};
 }
 
 export async function ensureTelegramDaemonRunning(
@@ -922,15 +1074,16 @@ export class TelegramEventDispatchState {
  * file so the daemon does not import the control module directly.
  */
 export interface DaemonControlHooks {
-	/** Returns true when a stop/reload has been requested for this owner. */
-	shouldStop(ownerId: string): Promise<boolean>;
-	/** Clear a consumed control request (best-effort). */
-	clear?(ownerId: string): Promise<void>;
+	/** Returns true when a stop/reload has been requested for this owner binding. */
+	shouldStop(ownerId: string, custodyEpoch: number): Promise<boolean>;
+	/** Clear a consumed control request (best-effort) for this owner binding. */
+	clear?(ownerId: string, custodyEpoch: number): Promise<void>;
 }
 
 export interface TelegramDaemonOptions {
 	settings: Settings;
 	ownerId: string;
+	custodyEpoch: number;
 	botToken: string;
 	chatId: string;
 	apiBase?: string;
@@ -1438,6 +1591,9 @@ export class TelegramNotificationDaemon {
 			agentDir: opts.settings.getAgentDir(),
 			fs: opts.fs,
 			now: opts.now,
+			fence: {
+				binding: { ownerId: opts.ownerId, custodyEpoch: opts.custodyEpoch },
+			},
 		});
 		this.aliasTable = createAliasTable();
 		this.botApi =
@@ -3231,6 +3387,7 @@ export class TelegramNotificationDaemon {
 		this.running = await renewDaemonHeartbeat({
 			settings: this.opts.settings,
 			ownerId: this.opts.ownerId,
+			custodyEpoch: this.opts.custodyEpoch,
 			fs: this.fsImpl,
 			now: this.opts.now,
 			pid: this.opts.pid ?? process.pid,
@@ -3259,6 +3416,7 @@ export class TelegramNotificationDaemon {
 					!(await renewDaemonHeartbeat({
 						settings: this.opts.settings,
 						ownerId: this.opts.ownerId,
+						custodyEpoch: this.opts.custodyEpoch,
 						fs: this.fsImpl,
 						now: this.opts.now,
 						pid: this.opts.pid ?? process.pid,
@@ -3308,10 +3466,11 @@ export class TelegramNotificationDaemon {
 			await this.persistAliases().catch(() => undefined);
 			await this.persistTopics().catch(() => undefined);
 			await this.persistSeenUpdateIds().catch(() => undefined);
-			await this.opts.control?.clear?.(this.opts.ownerId).catch(() => undefined);
+			await this.opts.control?.clear?.(this.opts.ownerId, this.opts.custodyEpoch).catch(() => undefined);
 			await releaseDaemonOwnership({
 				settings: this.opts.settings,
 				ownerId: this.opts.ownerId,
+				custodyEpoch: this.opts.custodyEpoch,
 				fs: this.fsImpl,
 				now: this.opts.now,
 			});
@@ -3323,7 +3482,7 @@ export class TelegramNotificationDaemon {
 		if (this.runtime.stopRequested) return true;
 		if (!this.opts.control) return false;
 		try {
-			return await this.opts.control.shouldStop(this.opts.ownerId);
+			return await this.opts.control.shouldStop(this.opts.ownerId, this.opts.custodyEpoch);
 		} catch {
 			return false;
 		}

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -47,6 +47,7 @@ import { listRecentSessions } from "./recent-activity";
 import { ReplySentStore } from "./reply-sent-store";
 import { DraftStreamState, deliverDraft, shouldStreamDraft } from "./rich-draft";
 import { deliverRichActionWithFallback, deliverRichWithFallback, shouldPromoteRich } from "./rich-render";
+import { type TelegramCustodyLoadResult, TelegramCustodyStore } from "./telegram-custody-store";
 import {
 	type AliasTable,
 	buildActionMarkdown,
@@ -1024,6 +1025,9 @@ export class TelegramNotificationDaemon {
 	private running = false;
 	private readonly fsImpl: TelegramDaemonFs;
 	private readonly botApi: BotApi;
+	readonly #custodyStore: TelegramCustodyStore;
+	/** Startup custody result retained for later deletion-recovery phases. */
+	#custodyLoadResult: TelegramCustodyLoadResult | undefined;
 	private readonly topics = new TopicRegistry();
 	/** Serializes registry snapshots so an older atomic write cannot overwrite newer rename state. */
 	private topicsPersistQueue: Promise<void> = Promise.resolve();
@@ -1430,6 +1434,11 @@ export class TelegramNotificationDaemon {
 	constructor(private readonly opts: TelegramDaemonOptions) {
 		this.fsImpl = opts.fs ?? nodeFs;
 		this.replyStore = new ReplySentStore({ agentDir: opts.settings.getAgentDir(), fs: opts.fs });
+		this.#custodyStore = new TelegramCustodyStore({
+			agentDir: opts.settings.getAgentDir(),
+			fs: opts.fs,
+			now: opts.now,
+		});
 		this.aliasTable = createAliasTable();
 		this.botApi =
 			opts.botApi ??
@@ -2114,6 +2123,15 @@ export class TelegramNotificationDaemon {
 		// Restore the full serialized registry (topicId + identitySent + name) so a
 		// fresh daemon after reload does not resend identity headers or lose renames.
 		if (raw && typeof raw === "object") this.topics.load(raw);
+	}
+	get custodyLoadResult(): TelegramCustodyLoadResult | undefined {
+		return this.#custodyLoadResult;
+	}
+
+	async loadCustody(): Promise<TelegramCustodyLoadResult> {
+		const result = await this.#custodyStore.load();
+		this.#custodyLoadResult = result;
+		return result;
 	}
 
 	/** Download a Telegram file by its file_path (from getFile) into memory. */
@@ -3227,6 +3245,7 @@ export class TelegramNotificationDaemon {
 			await this.registerBotCommands();
 			await this.loadAliases();
 			await this.loadTopics();
+			await this.loadCustody();
 			await this.loadSeenUpdateIds();
 			await this.replyStore.load();
 			await this.runScan();

--- a/packages/coding-agent/test/daemon-control.test.ts
+++ b/packages/coding-agent/test/daemon-control.test.ts
@@ -62,6 +62,7 @@ function freshState(extra: Partial<Record<string, unknown>> = {}): Record<string
 	return {
 		pid: 999,
 		ownerId: "old",
+		custodyEpoch: 1,
 		tokenFingerprint: tokenFingerprint(BOT_TOKEN),
 		chatId: "42",
 		startedAt: Date.now(),
@@ -229,11 +230,13 @@ describe("control request helpers", () => {
 			action: "reload",
 			ownerId: "owner-a",
 			pid: 123,
+			custodyEpoch: 1,
 			createdAt: Date.now(),
 		});
 		const read = await readTelegramControlRequest(s);
 		expect(read?.requestId).toBe("r1");
 		expect(read?.ownerId).toBe("owner-a");
+		expect(read?.custodyEpoch).toBe(1);
 
 		// Clearing with a mismatched requestId must not remove a newer request.
 		await clearTelegramControlRequest(s, "different-id");

--- a/packages/coding-agent/test/daemon-control.test.ts
+++ b/packages/coding-agent/test/daemon-control.test.ts
@@ -16,6 +16,10 @@ import {
 } from "../src/daemon/operator-contract";
 import { resolveGjcRuntimeSpawnInfo } from "../src/daemon/runtime";
 import { tokenFingerprint } from "../src/notifications/config";
+import {
+	TELEGRAM_CUSTODY_EPOCH_SCHEMA_VERSION,
+	telegramCustodyEpochPath,
+} from "../src/notifications/telegram-custody-epoch";
 import { daemonPaths } from "../src/notifications/telegram-daemon";
 import {
 	clearTelegramControlRequest,
@@ -52,10 +56,28 @@ function settings(agentDir: string): Settings {
 	);
 }
 
-function writeState(agentDir: string, state: Record<string, unknown>): void {
+function writeState(
+	agentDir: string,
+	state: Record<string, unknown>,
+	{ writeEpoch = true }: { writeEpoch?: boolean } = {},
+): void {
 	const paths = daemonPaths(agentDir);
 	fs.mkdirSync(paths.dir, { recursive: true });
 	fs.writeFileSync(paths.state, JSON.stringify(state));
+	const { ownerId, custodyEpoch } = state;
+	if (
+		writeEpoch &&
+		typeof ownerId === "string" &&
+		ownerId.length > 0 &&
+		typeof custodyEpoch === "number" &&
+		Number.isSafeInteger(custodyEpoch) &&
+		custodyEpoch > 0
+	) {
+		fs.writeFileSync(
+			telegramCustodyEpochPath(agentDir),
+			`${JSON.stringify({ version: TELEGRAM_CUSTODY_EPOCH_SCHEMA_VERSION, custodyEpoch, ownerId })}\n`,
+		);
+	}
 }
 
 function freshState(extra: Partial<Record<string, unknown>> = {}): Record<string, unknown> {

--- a/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
+++ b/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
@@ -147,13 +147,21 @@ describe("compiled daemon smoke coverage", () => {
 		const { command, args, runtime } = buildTelegramDaemonSpawnArgs({
 			execPath: "/opt/gjc/gjc",
 			ownerId: "owner-1",
+			custodyEpoch: 1,
 			agentDir: "/tmp/agent",
 		});
 		expect(command).toBe("/opt/gjc/gjc");
 		// No bun/node entry-script prefix in compiled mode: the binary self-spawns its subcommand.
-		expect(args[0]).toBe("notify");
-		expect(args).toContain("daemon-internal");
-		expect(args).toEqual(expect.arrayContaining(["--owner-id", "owner-1", "--agent-dir", "/tmp/agent"]));
+		expect(args).toEqual([
+			"notify",
+			"daemon-internal",
+			"--owner-id",
+			"owner-1",
+			"--custody-epoch",
+			"1",
+			"--agent-dir",
+			"/tmp/agent",
+		]);
 		expect(runtime.mode).toBe("compiled");
 		expect(runtime.reloadPicksUpSourceEdits).toBe(false);
 		expect(runtime.warning).toContain("Rebuild");

--- a/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
+++ b/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import nativesPackageJson from "../../natives/package.json" with { type: "json" };
 import { devEntrypoints, releaseEntrypoints } from "../scripts/compile-args";
 import { buildTelegramDaemonSpawnArgs, daemonPaths } from "../src/notifications/telegram-daemon";
 
@@ -14,7 +15,7 @@ describe("compiled daemon smoke coverage", () => {
 
 	async function runWithTimeout(
 		command: string[],
-		opts: { cwd: string },
+		opts: { cwd: string; env?: Record<string, string | undefined> },
 		timeoutMs: number,
 	): Promise<{
 		exitCode: number | null;
@@ -42,6 +43,26 @@ describe("compiled daemon smoke coverage", () => {
 			new Response(proc.stderr).text(),
 		]);
 		return { exitCode, stdout, stderr, timedOut };
+	}
+
+	function stageCompiledNativeAddons(dataHome: string): void {
+		const nativeDir = path.join(repoRoot, "packages/natives/native");
+		const filenamePrefix = `pi_natives.${process.platform}-${process.arch}`;
+		const addonFilenames = fs
+			.readdirSync(nativeDir)
+			.filter(
+				filename =>
+					filename === `${filenamePrefix}.node` ||
+					filename === `${filenamePrefix}-baseline.node` ||
+					filename === `${filenamePrefix}-modern.node`,
+			);
+		expect(addonFilenames).not.toHaveLength(0);
+
+		const stagedNativeDir = path.join(dataHome, "gjc", "natives", nativesPackageJson.version);
+		fs.mkdirSync(stagedNativeDir, { recursive: true });
+		for (const filename of addonFilenames) {
+			fs.copyFileSync(path.join(nativeDir, filename), path.join(stagedNativeDir, filename));
+		}
 	}
 
 	async function buildCompiledDaemonSmokeBinary(outPath: string): Promise<void> {
@@ -120,15 +141,22 @@ describe("compiled daemon smoke coverage", () => {
 	test("compiled binary with daemon CLI entrypoint starts root version and daemon smoke", async () => {
 		const temp = tempDir("gjc-compiled-daemon-binary-");
 		const binaryPath = path.join(temp, "gjc-repro");
+		const nativeDataHome = path.join(temp, "xdg-data");
+		const isolatedEnv = {
+			...process.env,
+			XDG_DATA_HOME: nativeDataHome,
+			...(process.platform === "win32" ? { LOCALAPPDATA: path.join(temp, "local-app-data") } : {}),
+		};
 		try {
+			stageCompiledNativeAddons(nativeDataHome);
 			await buildCompiledDaemonSmokeBinary(binaryPath);
-			const version = await runWithTimeout([binaryPath, "--version"], { cwd: temp }, 10_000);
+			const version = await runWithTimeout([binaryPath, "--version"], { cwd: temp, env: isolatedEnv }, 10_000);
 			expect(version.timedOut).toBe(false);
 			expect(`${version.exitCode}\n${version.stdout}\n${version.stderr}`).toStartWith("0\ngjc/");
 
 			const smoke = await runWithTimeout(
 				[binaryPath, "notify", "daemon-internal", "--smoke"],
-				{ cwd: temp },
+				{ cwd: temp, env: isolatedEnv },
 				10_000,
 			);
 			expect(smoke.timedOut).toBe(false);
@@ -136,7 +164,7 @@ describe("compiled daemon smoke coverage", () => {
 		} finally {
 			fs.rmSync(temp, { recursive: true, force: true });
 		}
-	});
+	}, 30_000);
 
 	test("compile entrypoint lists preserve the dynamic daemon entrypoint for compiled binaries", () => {
 		expect(devEntrypoints).toContain("./src/notifications/telegram-daemon-cli.ts");

--- a/packages/coding-agent/test/notifications-html-format.test.ts
+++ b/packages/coding-agent/test/notifications-html-format.test.ts
@@ -293,6 +293,7 @@ function makeDaemon(
 	return new TelegramNotificationDaemon({
 		settings: isolatedSettings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot as any,
@@ -423,6 +424,7 @@ describe("default multipart sendPhoto forwards parse_mode (AC1 amendment)", () =
 		const daemon = new TelegramNotificationDaemon({
 			settings: isolatedSettings(Bun.env.TMPDIR ?? "/tmp"),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			fetchImpl,

--- a/packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts
@@ -43,6 +43,7 @@ function makeDaemon(agentDir: string, bot: never): TelegramNotificationDaemon {
 	return new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,

--- a/packages/coding-agent/test/notifications-lifecycle-daemon-ownership.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-daemon-ownership.test.ts
@@ -92,6 +92,7 @@ function makeDaemon(s: Settings, factory: LifecycleControlServerFactory | null):
 	return new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: fakeBot,

--- a/packages/coding-agent/test/notifications-live-stream.test.ts
+++ b/packages/coding-agent/test/notifications-live-stream.test.ts
@@ -228,6 +228,7 @@ async function bootDaemon() {
 	const daemon = new TelegramNotificationDaemon({
 		settings: daemonSettings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot as never,

--- a/packages/coding-agent/test/notifications-rich-draft.test.ts
+++ b/packages/coding-agent/test/notifications-rich-draft.test.ts
@@ -342,6 +342,7 @@ function makeDraftDaemon(
 	return new TelegramNotificationDaemon({
 		settings: draftSettings(tempAgentDir()),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot as any,

--- a/packages/coding-agent/test/notifications-rich-e2e.test.ts
+++ b/packages/coding-agent/test/notifications-rich-e2e.test.ts
@@ -140,6 +140,7 @@ async function connectRealPipeline(rich?: { enabled: boolean }): Promise<Harness
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,

--- a/packages/coding-agent/test/notifications-rich-redteam.test.ts
+++ b/packages/coding-agent/test/notifications-rich-redteam.test.ts
@@ -113,6 +113,7 @@ function makeRichDaemon(bot: BotApi, rich?: { enabled: boolean }): TelegramNotif
 	return new TelegramNotificationDaemon({
 		settings: settings(tempAgentDir()),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot as any,

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -10,6 +10,7 @@ import {
 	TELEGRAM_PARSE_MODE,
 } from "../src/notifications/html-format";
 import { deliverRichWithFallback } from "../src/notifications/rich-render";
+import { telegramCustodyEpochPath } from "../src/notifications/telegram-custody-epoch";
 import {
 	acquireDaemonOwnership,
 	buildTelegramDaemonSpawnArgs,
@@ -17,23 +18,22 @@ import {
 	DAEMON_VERSION,
 	daemonPaths,
 	ensureTelegramDaemonRunning,
-	spawnTelegramDaemonOwner,
 	registerNotificationRoot,
 	releaseDaemonOwnership,
 	renewDaemonHeartbeat,
+	spawnTelegramDaemonOwner,
 	TelegramBotTransport,
 	type TelegramDaemonFs,
 	TelegramEventDispatchState,
 	TelegramNotificationDaemon,
 	TelegramUpdatePoller,
 } from "../src/notifications/telegram-daemon";
+import { runDaemonInternal, runDaemonSmoke } from "../src/notifications/telegram-daemon-cli";
 import {
 	clearTelegramControlRequest,
 	readTelegramControlRequest,
 	writeTelegramControlRequest,
 } from "../src/notifications/telegram-daemon-control";
-import { telegramCustodyEpochPath } from "../src/notifications/telegram-custody-epoch";
-import { runDaemonInternal, runDaemonSmoke } from "../src/notifications/telegram-daemon-cli";
 
 const THREADED_FALLBACK_NOTICE =
 	"Flat Telegram private chat supports outbound notifications and inline ask buttons only. Enable Threaded Mode in @BotFather > Bot Settings > Threads Settings for free-text replies and session commands.";

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -4048,6 +4048,73 @@ test("run() persists aliases before releasing ownership on exit", async () => {
 	await daemon.run();
 	expect(fs.existsSync(daemonPaths(agentDir).aliases)).toBe(true);
 });
+describe("telegram custody loading", () => {
+	test("migrates custody before the first scan without Telegram deletion or delivery", async () => {
+		const agentDir = tempAgentDir();
+		const custodyPath = path.join(agentDir, "notifications", "telegram-deletion-custody.json");
+		fs.mkdirSync(path.dirname(custodyPath), { recursive: true });
+		fs.writeFileSync(
+			custodyPath,
+			JSON.stringify({
+				version: 1,
+				chatId: "42",
+				records: { "7": { state: "in_flight", updatedAt: 1 } },
+			}),
+		);
+
+		const s = settings(agentDir);
+		const events: string[] = [];
+		await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "e60b05c186ca",
+			chatId: "42",
+			pid: process.pid,
+			randomId: () => "owner",
+		});
+		class CustodyOrderDaemon extends TelegramNotificationDaemon {
+			override async loadTopics(): Promise<void> {
+				events.push("topics");
+			}
+
+			override async loadCustody() {
+				const result = await super.loadCustody();
+				events.push("custody");
+				return result;
+			}
+
+			override async scanRoots(): Promise<void> {
+				events.push("scan");
+				this.requestStop();
+			}
+		}
+		const bot = new FakeBotApi();
+		const daemon = new CustodyOrderDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			createLifecycleControlServer: null,
+			scanIntervalMs: 2_147_483_647,
+		});
+
+		await daemon.run();
+
+		expect(events).toEqual(["topics", "custody", "scan"]);
+		expect(daemon.custodyLoadResult).toEqual({
+			mode: "writable",
+			migrated: true,
+			records: [{ chatId: "42", topicId: "7", state: "unknown", updatedAt: 1 }],
+		});
+		expect(JSON.parse(fs.readFileSync(custodyPath, "utf8"))).toEqual({
+			version: 2,
+			records: {
+				"42:7": { chatId: "42", topicId: "7", state: "unknown", updatedAt: 1 },
+			},
+		});
+		expect(bot.calls.filter(call => call.method === "deleteForumTopic" || call.method === "sendMessage")).toEqual([]);
+	});
+});
 
 test("a fresh daemon scanRoots reconnects an existing session endpoint", async () => {
 	FakeWs.instances = [];

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -12,10 +12,12 @@ import {
 import { deliverRichWithFallback } from "../src/notifications/rich-render";
 import {
 	acquireDaemonOwnership,
+	buildTelegramDaemonSpawnArgs,
 	DAEMON_GENERATION,
 	DAEMON_VERSION,
 	daemonPaths,
 	ensureTelegramDaemonRunning,
+	spawnTelegramDaemonOwner,
 	registerNotificationRoot,
 	releaseDaemonOwnership,
 	renewDaemonHeartbeat,
@@ -25,6 +27,12 @@ import {
 	TelegramNotificationDaemon,
 	TelegramUpdatePoller,
 } from "../src/notifications/telegram-daemon";
+import {
+	clearTelegramControlRequest,
+	readTelegramControlRequest,
+	writeTelegramControlRequest,
+} from "../src/notifications/telegram-daemon-control";
+import { telegramCustodyEpochPath } from "../src/notifications/telegram-custody-epoch";
 import { runDaemonInternal, runDaemonSmoke } from "../src/notifications/telegram-daemon-cli";
 
 const THREADED_FALLBACK_NOTICE =
@@ -175,6 +183,7 @@ async function identityTopicHarness({
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId,
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -317,6 +326,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -438,7 +448,7 @@ describe("telegram daemon", () => {
 					settings: s,
 					tokenFingerprint: "fp",
 					chatId: "42",
-					pidAlive: () => false,
+					pidAlive: pid => pid === 222,
 					pid: 222,
 				}),
 			),
@@ -464,7 +474,12 @@ describe("telegram daemon", () => {
 				roots: [],
 				version: 1,
 				generation: DAEMON_GENERATION,
+				custodyEpoch: 1,
 			}),
+		);
+		fs.writeFileSync(
+			telegramCustodyEpochPath(agentDir),
+			JSON.stringify({ version: 1, ownerId: "old", custodyEpoch: 1 }),
 		);
 		const result = await acquireDaemonOwnership({
 			settings: s,
@@ -474,6 +489,24 @@ describe("telegram daemon", () => {
 			now: () => 101,
 		});
 		expect(result).toEqual({ acquired: false, attached: true });
+	});
+	test("fresh live ownership with a mismatched durable epoch fails closed", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION, custodyEpoch: 1 });
+		fs.writeFileSync(
+			telegramCustodyEpochPath(agentDir),
+			JSON.stringify({ version: 1, ownerId: "old", custodyEpoch: 2 }),
+		);
+		await expect(
+			acquireDaemonOwnership({
+				settings: s,
+				tokenFingerprint: "e60b05c186ca",
+				chatId: "42",
+				pidAlive: () => true,
+				now: () => 101,
+			}),
+		).rejects.toThrow("custody epoch does not match");
 	});
 
 	test("live owner token/chat mismatch blocks attach without registering a root", async () => {
@@ -543,8 +576,15 @@ describe("telegram daemon", () => {
 
 	function writeLiveOwner(agentDir: string, extra: Record<string, unknown> = {}): void {
 		const paths = daemonPaths(agentDir);
+		const state = liveOwnerState(extra);
 		fs.mkdirSync(paths.dir, { recursive: true });
-		fs.writeFileSync(paths.state, JSON.stringify(liveOwnerState(extra)));
+		fs.writeFileSync(paths.state, JSON.stringify(state));
+		if (typeof state.custodyEpoch === "number") {
+			fs.writeFileSync(
+				telegramCustodyEpochPath(agentDir),
+				JSON.stringify({ version: 1, ownerId: state.ownerId, custodyEpoch: state.custodyEpoch }),
+			);
+		}
 		fs.writeFileSync(paths.lock, "");
 	}
 
@@ -565,7 +605,7 @@ describe("telegram daemon", () => {
 	test("#2028 acquire attaches to a current-generation live owner (no reload)", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
-		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION });
+		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION, custodyEpoch: 1 });
 		const result = await acquireDaemonOwnership({
 			settings: s,
 			tokenFingerprint: "e60b05c186ca",
@@ -579,7 +619,7 @@ describe("telegram daemon", () => {
 	test("#2028 acquire does not downgrade a NEWER-generation live owner (attaches)", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
-		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION + 1 });
+		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION + 1, custodyEpoch: 1 });
 		const result = await acquireDaemonOwnership({
 			settings: s,
 			tokenFingerprint: "e60b05c186ca",
@@ -651,7 +691,7 @@ describe("telegram daemon", () => {
 	test("#2028 ensureTelegramDaemonRunning reuses a current-generation live owner without a reload", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
-		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION, heartbeatAt: Date.now() });
+		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION, custodyEpoch: 1, heartbeatAt: Date.now() });
 		const paths = daemonPaths(agentDir);
 		const signals: Array<[number, string]> = [];
 		let spawns = 0;
@@ -690,6 +730,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: new FakeBotApi(),
@@ -707,21 +748,25 @@ describe("telegram daemon", () => {
 	test("runDaemonInternal rewrites persisted owner pid to daemon process pid", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
-		await acquireDaemonOwnership({
+		const ownership = await acquireDaemonOwnership({
 			settings: s,
 			tokenFingerprint: "e60b05c186ca",
 			chatId: "42",
 			pid: 111,
 			randomId: () => "owner",
 		});
+		if (!ownership.acquired) throw new Error("ownership acquisition failed");
 		class OneShotDaemon extends TelegramNotificationDaemon {
 			override async scanRoots(): Promise<void> {}
 		}
-		await runDaemonInternal(["--agent-dir", agentDir, "--owner-id", "owner"], {
-			SettingsImpl: { init: async () => s },
-			DaemonImpl: OneShotDaemon,
-			processPid: 222,
-		});
+		await runDaemonInternal(
+			["--agent-dir", agentDir, "--owner-id", ownership.ownerId, "--custody-epoch", String(ownership.custodyEpoch)],
+			{
+				SettingsImpl: { init: async () => s },
+				DaemonImpl: OneShotDaemon,
+				processPid: 222,
+			},
+		);
 		const state = JSON.parse(fs.readFileSync(daemonPaths(agentDir).state, "utf8")) as {
 			pid: number;
 			ownerId: string;
@@ -751,11 +796,13 @@ describe("telegram daemon", () => {
 			requestStop(): void {}
 		}
 
-		await runDaemonInternal(["--agent-dir", agentDir, "--owner-id", "owner"], {
-			SettingsImpl: { init: async () => s },
-			DaemonImpl: StubDaemon,
-			pidAlive: () => true,
-		});
+		await expect(
+			runDaemonInternal(["--agent-dir", agentDir, "--owner-id", "owner"], {
+				SettingsImpl: { init: async () => s },
+				DaemonImpl: StubDaemon,
+				pidAlive: () => true,
+			}),
+		).rejects.toThrow("custody-epoch");
 
 		expect(daemonConstructed).toBe(false);
 	});
@@ -768,6 +815,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -802,6 +850,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -836,6 +885,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -866,6 +916,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "-10042",
 			botApi: bot,
@@ -890,6 +941,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -927,6 +979,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -957,6 +1010,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -993,6 +1047,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1039,6 +1094,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1066,6 +1122,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1126,6 +1183,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1177,6 +1235,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1245,6 +1304,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1297,6 +1357,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1336,6 +1397,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1377,6 +1439,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1396,6 +1459,7 @@ describe("telegram daemon", () => {
 		const restarted = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner-restarted",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1453,6 +1517,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1528,6 +1593,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1597,6 +1663,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1650,6 +1717,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1683,6 +1751,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1719,6 +1788,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1760,6 +1830,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1797,6 +1868,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1835,6 +1907,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1865,6 +1938,7 @@ describe("telegram daemon", () => {
 		const restarted = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner-2",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: new FakeBotApi(),
@@ -1888,21 +1962,42 @@ describe("telegram daemon", () => {
 		expect(fs.readdirSync(daemonPaths(agentDir).dir).join("\n")).not.toContain("secret-token");
 	});
 
-	test("heartbeat renew and release helpers honor owner id", async () => {
+	test("heartbeat renew and release helpers honor the complete owner binding", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
-		await acquireDaemonOwnership({
+		const ownership = await acquireDaemonOwnership({
 			settings: s,
 			tokenFingerprint: "fp",
 			chatId: "42",
 			pid: process.pid,
 			randomId: () => "owner",
 		});
-		expect(await renewDaemonHeartbeat({ settings: s, ownerId: "other" })).toBe(false);
-		expect(await renewDaemonHeartbeat({ settings: s, ownerId: "owner" })).toBe(true);
-		await releaseDaemonOwnership({ settings: s, ownerId: "other" });
+		if (!ownership.acquired) throw new Error("ownership acquisition failed");
+		expect(
+			await renewDaemonHeartbeat({
+				settings: s,
+				ownerId: "other",
+				custodyEpoch: ownership.custodyEpoch,
+			}),
+		).toBe(false);
+		expect(
+			await renewDaemonHeartbeat({
+				settings: s,
+				ownerId: ownership.ownerId,
+				custodyEpoch: ownership.custodyEpoch,
+			}),
+		).toBe(true);
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: "other",
+			custodyEpoch: ownership.custodyEpoch,
+		});
 		expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(true);
-		await releaseDaemonOwnership({ settings: s, ownerId: "owner" });
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: ownership.ownerId,
+			custodyEpoch: ownership.custodyEpoch,
+		});
 		expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(false);
 	});
 
@@ -1952,6 +2047,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: gatedBot,
@@ -2006,6 +2102,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -2037,6 +2134,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			fetchImpl,
@@ -2076,6 +2174,7 @@ describe("telegram daemon connection-drop resilience (repro-first)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: new FakeBotApi(),
@@ -2148,6 +2247,7 @@ describe("telegram daemon connection-drop resilience (repro-first)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -2174,6 +2274,7 @@ test("daemon registers in-thread config and lifecycle commands and drops stale r
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2204,6 +2305,7 @@ test("forum lifecycle commands fail closed even when addressed to this bot usern
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(tempAgentDir()),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "-10042",
 		botApi: bot,
@@ -2232,6 +2334,7 @@ test("forum lifecycle commands fail closed when bot username is unavailable", as
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(tempAgentDir()),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "-10042",
 		botApi: bot,
@@ -2254,6 +2357,7 @@ test("non-addressable forum lifecycle commands in known topics are dropped", asy
 		const daemon = new TelegramNotificationDaemon({
 			settings: settings(tempAgentDir()),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "-10042",
 			botApi: bot,
@@ -2315,6 +2419,7 @@ test("image_attachment frame uploads via sendPhoto into an identified session to
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2357,6 +2462,7 @@ describe("telegram topic name template (#1909)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: settings(agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -2428,6 +2534,7 @@ describe("telegram topic name template (#1909)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: settings(agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -2460,6 +2567,7 @@ test("identity-less threaded frames wait for identity instead of creating fallba
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2508,6 +2616,7 @@ test("transient topic rename failure is retried on the next identity header", as
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2735,6 +2844,7 @@ test.each([
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "retry",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2789,6 +2899,7 @@ test("remote-success user-name reconciliation retries after its pending-clear wr
 	const restarted = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner-2",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: retryBot,
@@ -2838,6 +2949,7 @@ test.each([
 	const restarted = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner-2",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: retryBot,
@@ -2858,6 +2970,7 @@ test("live sessions with the same repo branch create distinct topics", async () 
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2901,6 +3014,7 @@ test("transient identity for an existing repo branch does not create a duplicate
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2931,6 +3045,7 @@ test("stale identity after loadTopics reuses the persisted repo branch owner", a
 	const firstDaemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2946,6 +3061,7 @@ test("stale identity after loadTopics reuses the persisted repo branch owner", a
 	const restartedDaemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2980,6 +3096,7 @@ test("threaded mode off: frames fall back to the flat paired chat with a one-tim
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3033,6 +3150,7 @@ test("threaded mode off: multiple sessions share a single fallback notice", asyn
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3062,6 +3180,7 @@ test("threaded mode off: image_attachment uploads flat without message_thread_id
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3101,6 +3220,7 @@ test("non-private chat: fails closed before topic creation or flat delivery", as
 		const daemon = new TelegramNotificationDaemon({
 			settings: settings(agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -3145,6 +3265,7 @@ test("threaded off + unresolvable getChat: fails closed", async () => {
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3161,6 +3282,7 @@ test("identity_header without a title names the topic repo/branch", async () => 
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3188,6 +3310,7 @@ test("identity_header with repo/branch and a title composes repo/branch - title"
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3216,6 +3339,7 @@ test("identity_header without title or repo falls back to the GJC session label"
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3240,6 +3364,7 @@ test("activity busy frame sends a typing chat action into the session topic", as
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3270,6 +3395,7 @@ test("session_closed deletes the topic and resume creates a fresh visible topic"
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3328,6 +3454,7 @@ test("session_closed clears reply message routes for the closed session", async 
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3359,6 +3486,7 @@ test("session_closed tombstones its endpoint generation so scans do not recreate
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3415,6 +3543,7 @@ test("inbound thread message gets a queued reaction, flipped to consumed on ack"
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3462,6 +3591,7 @@ test("inbound photo is downloaded and forwarded as an image in the user_message"
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3503,6 +3633,7 @@ test("inbound document is saved to a tmp file and its path injected into the tex
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3556,6 +3687,7 @@ test("inbound document with a path-traversal filename stays sandboxed in the pri
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3606,6 +3738,7 @@ test("daemon attachment temp dirs are removed by the shutdown cleanup path", asy
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3643,6 +3776,7 @@ test("outbound file_attachment frame triggers a sendDocument upload to the topic
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3694,6 +3828,7 @@ describe("telegram daemon reconnect reconciliation", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -3736,6 +3871,7 @@ describe("telegram daemon reconnect reconciliation", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: new FakeBotApi(),
@@ -3772,6 +3908,7 @@ describe("telegram daemon reconnect reconciliation", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -3837,6 +3974,7 @@ describe("telegram daemon reconnect answer routing", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -3892,6 +4030,7 @@ test("pollOnce resolves to 0 when the in-flight getUpdates is aborted", async ()
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3916,6 +4055,7 @@ test("pollOnce backs off on a Telegram 409 conflict instead of processing update
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3967,6 +4107,7 @@ test("requestStop aborts the active long poll and run() exits, releasing ownersh
 	const daemon = new NoScan({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4001,6 +4142,7 @@ test("run() loop exits when an owner-scoped control request asks it to stop", as
 	const daemon = new NoScan({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: new FakeBotApi(),
@@ -4034,6 +4176,7 @@ test("run() persists aliases before releasing ownership on exit", async () => {
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: new FakeBotApi(),
@@ -4091,6 +4234,7 @@ describe("telegram custody loading", () => {
 		const daemon = new CustodyOrderDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -4128,6 +4272,7 @@ test("a fresh daemon scanRoots reconnects an existing session endpoint", async (
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: new FakeBotApi(),
@@ -4146,6 +4291,7 @@ test("connectSession eagerly creates a Telegram topic on connect (before any fra
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4184,6 +4330,7 @@ test("identity_header during an in-flight eager create still renames the topic",
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4232,6 +4379,7 @@ test("scanRoots connects only live endpoints (skips stale + dead-PID records)", 
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: new FakeBotApi(),
@@ -4274,6 +4422,7 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4307,6 +4456,7 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4332,6 +4482,7 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 	const blockedDaemon = new TelegramNotificationDaemon({
 		settings: blockedSettings,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: blockedBot,
@@ -4345,10 +4496,34 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 test("runDaemonInternal wires SIGTERM to the daemon stop method", async () => {
 	const agentDir = tempAgentDir();
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const ownership = await acquireDaemonOwnership({
+		settings: s,
+		tokenFingerprint: "e60b05c186ca",
+		chatId: "42",
+		pid: 111,
+		randomId: () => "owner",
+	});
+	if (!ownership.acquired) throw new Error("ownership acquisition failed");
+	const persistedState = JSON.parse(fs.readFileSync(daemonPaths(agentDir).state, "utf8"));
+	const persistedEpoch = JSON.parse(fs.readFileSync(telegramCustodyEpochPath(agentDir), "utf8"));
+	expect(persistedState).toMatchObject({
+		ownerId: ownership.ownerId,
+		custodyEpoch: ownership.custodyEpoch,
+	});
+	expect(persistedEpoch).toEqual({
+		version: 1,
+		ownerId: ownership.ownerId,
+		custodyEpoch: ownership.custodyEpoch,
+	});
 	let stopped = false;
 	let resolveRun: (() => void) | undefined;
+	const daemonConstructed = Promise.withResolvers<void>();
+	let daemonOptions: { ownerId?: unknown; custodyEpoch?: unknown } | undefined;
 	class StubDaemon {
-		constructor(public opts: unknown) {}
+		constructor(opts: unknown) {
+			daemonOptions = opts as { ownerId?: unknown; custodyEpoch?: unknown };
+			daemonConstructed.resolve();
+		}
 		requestStop(): void {
 			stopped = true;
 			resolveRun?.();
@@ -4369,11 +4544,18 @@ test("runDaemonInternal wires SIGTERM to the daemon stop method", async () => {
 	};
 	(process as any).off = () => process;
 	try {
-		const runPromise = runDaemonInternal(["--agent-dir", agentDir, "--owner-id", "owner"], {
-			SettingsImpl: { init: async () => s },
-			DaemonImpl: StubDaemon as any,
+		const runPromise = runDaemonInternal(
+			["--agent-dir", agentDir, "--owner-id", ownership.ownerId, "--custody-epoch", String(ownership.custodyEpoch)],
+			{
+				SettingsImpl: { init: async () => s },
+				DaemonImpl: StubDaemon as any,
+			},
+		);
+		await daemonConstructed.promise;
+		expect(daemonOptions).toMatchObject({
+			ownerId: ownership.ownerId,
+			custodyEpoch: ownership.custodyEpoch,
 		});
-		await new Promise(resolve => setTimeout(resolve, 5));
 		expect(sigtermHandler).toBeTruthy();
 		sigtermHandler?.();
 		await runPromise;
@@ -4391,6 +4573,7 @@ test("a long finalized turn is scheduled through the pool, not burst in one gran
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4477,6 +4660,7 @@ function makeRichDaemon(bot: FakeBotApi, rich?: { enabled: boolean }): TelegramN
 	return new TelegramNotificationDaemon({
 		settings: settings(tempAgentDir()),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot as any,
@@ -4878,6 +5062,7 @@ describe("telegram daemon rich final-answer promotion (Rev 3 verification)", () 
 		const daemon = new TelegramNotificationDaemon({
 			settings: settings(tempAgentDir()),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: transport,
@@ -5034,6 +5219,7 @@ describe("telegram daemon action-needed rich delivery (G004)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot as any,
@@ -5167,6 +5353,7 @@ describe("telegram daemon /rich toggle (G005)", () => {
 		return new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot as any,
@@ -5242,6 +5429,7 @@ describe("telegram daemon /rich toggle (G005)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot as any,
@@ -5317,6 +5505,7 @@ describe("telegram daemon /rich toggle (G005)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot as any,
@@ -5361,6 +5550,7 @@ describe("telegram daemon /rich toggle (G005)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot as any,
@@ -5377,5 +5567,244 @@ describe("telegram daemon /rich toggle (G005)", () => {
 			),
 		).toBe(true);
 		expect(bot.calls.some(c => c.method === "sendMessage" && c.body.text === "Rich messages: off")).toBe(false);
+	});
+});
+describe("telegram daemon custody epoch fencing", () => {
+	test("allocates epoch one then fences a same-owner ABA restart at epoch two", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const first = await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "fp",
+			chatId: "42",
+			pid: 101,
+			randomId: () => "reused-owner",
+		});
+		if (!first.acquired) throw new Error("first ownership acquisition failed");
+		expect(first.custodyEpoch).toBe(1);
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: first.ownerId,
+			custodyEpoch: first.custodyEpoch,
+		});
+
+		const second = await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "fp",
+			chatId: "42",
+			pid: 202,
+			randomId: () => "reused-owner",
+		});
+		if (!second.acquired) throw new Error("second ownership acquisition failed");
+		expect(second.custodyEpoch).toBe(2);
+		expect(
+			await renewDaemonHeartbeat({
+				settings: s,
+				ownerId: first.ownerId,
+				custodyEpoch: first.custodyEpoch,
+			}),
+		).toBe(false);
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: first.ownerId,
+			custodyEpoch: first.custodyEpoch,
+		});
+		expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(true);
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: second.ownerId,
+			custodyEpoch: second.custodyEpoch,
+		});
+	});
+
+	test("rejects noncanonical spawn epochs and preserves adjacent canonical argv", () => {
+		const spawned = buildTelegramDaemonSpawnArgs({
+			execPath: process.execPath,
+			ownerId: "owner",
+			custodyEpoch: 2,
+			agentDir: "agent-dir",
+		});
+		const epochFlag = spawned.args.indexOf("--custody-epoch");
+		expect(spawned.args.slice(epochFlag, epochFlag + 2)).toEqual(["--custody-epoch", "2"]);
+		expect(() =>
+			buildTelegramDaemonSpawnArgs({
+				execPath: process.execPath,
+				ownerId: "owner",
+				custodyEpoch: 0,
+				agentDir: "agent-dir",
+			}),
+		).toThrow("custody epoch");
+	});
+
+	test("spawn failure releases only its pair and retry consumes a higher epoch", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		await expect(
+			spawnTelegramDaemonOwner(
+				{ settings: s, tokenFingerprint: "fp", chatId: "42" },
+				{
+					pid: 111,
+					randomId: () => "owner",
+					spawn: () => {
+						throw new Error("spawn failed");
+					},
+				},
+			),
+		).rejects.toThrow("spawn failed");
+		expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(false);
+
+		const retried = await spawnTelegramDaemonOwner(
+			{ settings: s, tokenFingerprint: "fp", chatId: "42" },
+			{ pid: 222, randomId: () => "owner", spawn: () => ({ unref() {} }) },
+		);
+		expect(retried.result).toBe("owner_spawned");
+		if (retried.result !== "owner_spawned") throw new Error("retry did not acquire ownership");
+		expect(retried.custodyEpoch).toBe(2);
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: retried.ownerId,
+			custodyEpoch: retried.custodyEpoch,
+		});
+	});
+	test("state-publication failure leaves no physical lock and retry skips the consumed epoch", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const paths = daemonPaths(agentDir);
+		const failingFs: TelegramDaemonFs = {
+			mkdir: async (file, opts) => await fs.promises.mkdir(file, opts).then(() => undefined),
+			readFile: async (file, encoding) => await fs.promises.readFile(file, encoding),
+			writeFile: async (file, data, opts) => await fs.promises.writeFile(file, data, opts),
+			rename: async (from, to) => {
+				if (to === paths.state) throw new Error("state write failed");
+				await fs.promises.rename(from, to);
+			},
+			unlink: async file => await fs.promises.unlink(file),
+			open: async (file, flags, mode) => await fs.promises.open(file, flags, mode),
+			readdir: async file => await fs.promises.readdir(file),
+			chmod: async (file, mode) => await fs.promises.chmod(file, mode),
+		};
+		await expect(
+			acquireDaemonOwnership({
+				settings: s,
+				tokenFingerprint: "fp",
+				chatId: "42",
+				pid: 101,
+				randomId: () => "owner",
+				fs: failingFs,
+			}),
+		).rejects.toThrow("state write failed");
+		expect(fs.existsSync(paths.lock)).toBe(false);
+
+		const retried = await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "fp",
+			chatId: "42",
+			pid: 202,
+			randomId: () => "owner",
+		});
+		if (!retried.acquired) throw new Error("retry ownership acquisition failed");
+		expect(retried.custodyEpoch).toBe(2);
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: retried.ownerId,
+			custodyEpoch: retried.custodyEpoch,
+		});
+	});
+
+	test("pair-bound control cleanup cannot clear a successor request", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		await writeTelegramControlRequest(s, {
+			version: 1,
+			requestId: "successor",
+			action: "stop",
+			ownerId: "same-owner",
+			custodyEpoch: 2,
+			pid: 202,
+			createdAt: 1,
+		});
+		await clearTelegramControlRequest(s, "successor", undefined, { ownerId: "same-owner", custodyEpoch: 1 });
+		expect((await readTelegramControlRequest(s))?.custodyEpoch).toBe(2);
+		await clearTelegramControlRequest(s, "successor", undefined, { ownerId: "same-owner", custodyEpoch: 2 });
+		expect(await readTelegramControlRequest(s)).toBeUndefined();
+	});
+
+	test("CLI rejects malformed, mismatched, and future custody epochs before daemon construction", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		let constructed = false;
+		class StubDaemon {
+			constructor() {
+				constructed = true;
+			}
+			async run(): Promise<void> {}
+			requestStop(): void {}
+		}
+		const deps = {
+			SettingsImpl: { init: async () => s },
+			DaemonImpl: StubDaemon,
+			pidAlive: () => true,
+		};
+		await expect(
+			runDaemonInternal(["--agent-dir", agentDir, "--owner-id", "owner", "--custody-epoch", "01"], deps),
+		).rejects.toThrow("invalid --custody-epoch");
+		expect(constructed).toBe(false);
+
+		const ownership = await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "fp",
+			chatId: "42",
+			pid: 303,
+			randomId: () => "owner",
+		});
+		if (!ownership.acquired) throw new Error("ownership acquisition failed");
+		await expect(
+			runDaemonInternal(
+				[
+					"--agent-dir",
+					agentDir,
+					"--owner-id",
+					ownership.ownerId,
+					"--custody-epoch",
+					String(ownership.custodyEpoch + 1),
+				],
+				deps,
+			),
+		).rejects.toThrow("ownership state");
+		expect(constructed).toBe(false);
+
+		fs.writeFileSync(
+			telegramCustodyEpochPath(agentDir),
+			JSON.stringify({ version: 2, ownerId: ownership.ownerId, custodyEpoch: ownership.custodyEpoch }),
+		);
+		await expect(
+			runDaemonInternal(
+				[
+					"--agent-dir",
+					agentDir,
+					"--owner-id",
+					ownership.ownerId,
+					"--custody-epoch",
+					String(ownership.custodyEpoch),
+				],
+				deps,
+			),
+		).rejects.toThrow();
+		expect(constructed).toBe(false);
+		fs.writeFileSync(telegramCustodyEpochPath(agentDir), "{not-json");
+		await expect(
+			runDaemonInternal(
+				[
+					"--agent-dir",
+					agentDir,
+					"--owner-id",
+					ownership.ownerId,
+					"--custody-epoch",
+					String(ownership.custodyEpoch),
+				],
+				deps,
+			),
+		).rejects.toThrow();
+		expect(constructed).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

This draft adds the second, narrowly scoped Telegram custody layer on top of #2127. It introduces a durable, monotonically increasing `custodyEpoch` and binds daemon ownership, heartbeat renewal, release, control requests, and custody mutations to the exact `(ownerId, custodyEpoch)` pair.

## What changed

- add a strict, bounded epoch snapshot with atomic 0600 publication and file/directory durability barriers
- allocate positive safe-integer epochs monotonically; corruption, forward versions, and exhaustion fail closed without reset or reuse
- fence custody `put`/`remove` operations and stamp new records with the active epoch
- carry the epoch through daemon state, detached spawn argv, CLI validation, control requests, reload/stop, renewal, and release
- prevent stale same-owner ABA operations from renewing, clearing, killing, or unlocking a successor
- preserve notification protocol 3, daemon generation, capability ordering, Selected acknowledgements/deduplication, and existing Bot API/no-retry behavior

No Telegram topic deletion or settlement behavior is added here; that remains a separate follow-up after durable fencing.

## Stack and review boundary

- prerequisite: #2127
- unique T2 commit: `e8b77545cea4a34f7103e6edf61ced3560105032`
- please review the T2 delta after #2127; the cumulative GitHub diff includes the prerequisite custody-store commit because both branches are in a contributor fork

## Verification

- `bun test ...telegram-custody-epoch.test.ts ...telegram-custody-store.test.ts` — 20 passed, 0 failed, 164 assertions
- focused custody-epoch daemon regressions — 6 passed, 0 failed, 23 assertions
- full Telegram daemon file — 154 passed; one unrelated, pre-existing Windows mode-bit assertion remains (`0600` observed as `0666`) and was already reproduced outside this T2 change
- `bun run check:types` in `packages/coding-agent` — passed
- `git diff --check` — passed

Thank you for reviewing this as a draft. I will keep it unmerged and address feedback within this epoch-fencing boundary.