### PR TITLE
notifications: settle Telegram topic deletion exactly once

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - IRC deliveries now accept their exchange batch in the recipient's volatile current-session queue before recipient/main UI observations or sender success. Awaited deliveries generate the reply first, then accept the ordered incoming + auto-reply pair and commit the IRC roster claim before observation; provider failures and sender aborts before acceptance leave no ghost exchange, while observer failures after acceptance are isolated. This is not a durability guarantee: durable history injection remains a later flush and no fsync, recovery, persistent IDs, or deduplication was added.
 - Print mode now records terminal text-mode errors as exit status 1 (or 78 for context overflow) without bypassing output quiescence or session disposal. It retains JSON event delivery through disposal and suppresses `EPIPE` from its owned stdout; `ERR_STREAM_DESTROYED` is suppressed only after that `EPIPE` has latched, while other output failures remain errors.
+- Telegram topic teardown now durably claims deletion under the daemon owner epoch, makes exactly one no-retry deletion request, and retains rejected or ambiguous outcomes for secret-safe diagnosis instead of retrying an irreversible action.
 
 ## [0.10.0] - 2026-07-12
 

--- a/packages/coding-agent/src/notifications/telegram-custody-epoch.test.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-epoch.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "bun:test";
+import type * as nodeFs from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	allocateTelegramCustodyEpoch,
+	TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES,
+	TelegramCustodyEpochError,
+	type TelegramCustodyEpochFs,
+	telegramCustodyEpochPath,
+	readTelegramCustodyEpoch,
+	withCurrentTelegramCustodyEpoch,
+} from "./telegram-custody-epoch";
+
+class FailingEpochFs implements TelegramCustodyEpochFs {
+	readonly #delegate: TelegramCustodyEpochFs = fs as unknown as TelegramCustodyEpochFs;
+	readonly chmodCalls: { file: string; mode: number }[] = [];
+	readonly renameCalls: { from: string; to: string }[] = [];
+	readonly writeCalls: { file: string; mode: number | undefined }[] = [];
+	readonly openCalls: { file: string; flags: string }[] = [];
+	failWrite = false;
+	failRename = false;
+	failSyncAt: number | undefined;
+	failSyncCode: string | undefined;
+	#syncCalls = 0;
+
+	async mkdir(file: string, options?: nodeFs.MakeDirectoryOptions): Promise<unknown> {
+		return this.#delegate.mkdir(file, options);
+	}
+
+	async readFile(file: string, encoding: BufferEncoding): Promise<string> {
+		return this.#delegate.readFile(file, encoding);
+	}
+
+	async writeFile(file: string, data: string, options?: nodeFs.WriteFileOptions): Promise<void> {
+		this.writeCalls.push({
+			file,
+			mode: typeof options === "object" && options !== null ? (options.mode as number | undefined) : undefined,
+		});
+		if (this.failWrite) throw new Error("simulated write failure");
+		await this.#delegate.writeFile(file, data, options);
+	}
+
+	async rename(oldPath: string, newPath: string): Promise<void> {
+		this.renameCalls.push({ from: oldPath, to: newPath });
+		if (this.failRename) throw new Error("simulated rename failure");
+		await this.#delegate.rename(oldPath, newPath);
+	}
+
+	async chmod(file: string, mode: number): Promise<void> {
+		this.chmodCalls.push({ file, mode });
+		await this.#delegate.chmod(file, mode);
+	}
+
+	async unlink(file: string): Promise<void> {
+		await this.#delegate.unlink(file);
+	}
+
+	async open(file: string, flags: string, mode?: number): Promise<{ sync(): Promise<void>; close(): Promise<void> }> {
+		this.openCalls.push({ file, flags });
+		const handle = await this.#delegate.open(file, flags, mode);
+		return {
+			sync: async () => {
+				this.#syncCalls++;
+				if (this.#syncCalls === this.failSyncAt) {
+					throw Object.assign(new Error("simulated sync failure"), { code: this.failSyncCode });
+				}
+				await handle.sync();
+			},
+			close: async () => handle.close(),
+		};
+	}
+}
+
+async function withAgentDirectory(operation: (agentDir: string) => Promise<void>): Promise<void> {
+	const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-telegram-custody-epoch-"));
+	try {
+		await operation(agentDir);
+	} finally {
+		await fs.rm(agentDir, { recursive: true, force: true });
+	}
+}
+
+async function expectFailure(
+	operation: Promise<unknown>,
+	reason: TelegramCustodyEpochError["reason"],
+): Promise<void> {
+	await expect(operation).rejects.toMatchObject({ name: "TelegramCustodyEpochError", reason });
+}
+
+describe("Telegram custody epoch", () => {
+	test("allocates durable positive epochs monotonically across restarts", async () => {
+		await withAgentDirectory(async agentDir => {
+			const first = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
+			const second = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-b" });
+
+			expect(first).toEqual({ ownerId: "owner-a", custodyEpoch: 1 });
+			expect(second).toEqual({ ownerId: "owner-b", custodyEpoch: 2 });
+			expect(await readTelegramCustodyEpoch({ agentDir })).toEqual(second);
+		});
+	});
+
+	test("serializes concurrent contenders into unique monotonically increasing bindings", async () => {
+		await withAgentDirectory(async agentDir => {
+			const bindings = await Promise.all(
+				["owner-a", "owner-b", "owner-c", "owner-d", "owner-e"].map(ownerId =>
+					allocateTelegramCustodyEpoch({ agentDir, ownerId }),
+				),
+			);
+
+			expect(bindings.map(binding => binding.custodyEpoch).sort((left, right) => left - right)).toEqual([1, 2, 3, 4, 5]);
+			expect(new Set(bindings.map(binding => binding.ownerId))).toEqual(
+				new Set(["owner-a", "owner-b", "owner-c", "owner-d", "owner-e"]),
+			);
+		});
+	});
+
+	test("fences stale bindings, including owner-id ABA reuse", async () => {
+		await withAgentDirectory(async agentDir => {
+			const first = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
+			const second = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-b" });
+			const third = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
+			let called = false;
+
+			expect(await withCurrentTelegramCustodyEpoch({ agentDir, binding: first }, async () => {
+				called = true;
+			})).toEqual({ ok: false, reason: "fenced" });
+			expect(await withCurrentTelegramCustodyEpoch({ agentDir, binding: second }, async () => undefined)).toEqual({
+				ok: false,
+				reason: "fenced",
+			});
+			expect(await withCurrentTelegramCustodyEpoch({ agentDir, binding: third }, async () => "current")).toEqual({
+				ok: true,
+				value: "current",
+			});
+			expect(called).toBe(false);
+		});
+	});
+
+	test("rejects malformed, duplicate, extra, invalid, forward, and oversized snapshots without rewriting bytes", async () => {
+		await withAgentDirectory(async agentDir => {
+			const epochPath = telegramCustodyEpochPath(agentDir);
+			const corruptSources = [
+				"{ not json",
+				'{"version":1,"version":1,"custodyEpoch":1,"ownerId":"owner"}',
+				'{"version":1,"custodyEpoch":1,"ownerId":"owner","extra":true}',
+				'{"version":1,"custodyEpoch":1}',
+				'{"version":0,"custodyEpoch":1,"ownerId":"owner"}',
+				'{"version":1.5,"custodyEpoch":1,"ownerId":"owner"}',
+				'{"version":1,"custodyEpoch":0,"ownerId":"owner"}',
+				'{"version":1,"custodyEpoch":-1,"ownerId":"owner"}',
+				'{"version":1,"custodyEpoch":1.5,"ownerId":"owner"}',
+				`{"version":1,"custodyEpoch":${Number.MAX_SAFE_INTEGER + 1},"ownerId":"owner"}`,
+				'{"version":1,"custodyEpoch":1,"ownerId":""}',
+				" ".repeat(TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES + 1),
+			];
+			for (const source of corruptSources) {
+				await fs.mkdir(path.dirname(epochPath), { recursive: true });
+				await fs.writeFile(epochPath, source);
+				await expectFailure(readTelegramCustodyEpoch({ agentDir }), "corrupt");
+				await expectFailure(allocateTelegramCustodyEpoch({ agentDir, ownerId: "next-owner" }), "corrupt");
+				expect(await fs.readFile(epochPath, "utf8")).toBe(source);
+			}
+
+			const forward = '{"version":2,"custodyEpoch":1,"ownerId":"owner"}';
+			await fs.writeFile(epochPath, forward);
+			await expectFailure(readTelegramCustodyEpoch({ agentDir }), "forward_version");
+			await expectFailure(allocateTelegramCustodyEpoch({ agentDir, ownerId: "next-owner" }), "forward_version");
+			expect(await fs.readFile(epochPath, "utf8")).toBe(forward);
+		});
+	});
+	test("rejects an oversized owner allocation before publishing a target or temporary file", async () => {
+		await withAgentDirectory(async agentDir => {
+			const epochPath = telegramCustodyEpochPath(agentDir);
+			const fakeFs = new FailingEpochFs();
+
+			await expectFailure(
+				allocateTelegramCustodyEpoch({
+					agentDir,
+					ownerId: "x".repeat(TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES),
+					fs: fakeFs,
+				}),
+				"corrupt",
+			);
+
+			await expect(fs.access(epochPath)).rejects.toMatchObject({ code: "ENOENT" });
+			expect(fakeFs.writeCalls).toEqual([]);
+			expect((await fs.readdir(path.dirname(epochPath))).some(entry => entry.endsWith(".tmp"))).toBe(false);
+		});
+	});
+
+	test("preserves an exhausted source and does not reset or reuse its epoch", async () => {
+		await withAgentDirectory(async agentDir => {
+			const epochPath = telegramCustodyEpochPath(agentDir);
+			const source = `{"version":1,"custodyEpoch":${Number.MAX_SAFE_INTEGER},"ownerId":"owner"}\n`;
+			await fs.mkdir(path.dirname(epochPath), { recursive: true });
+			await fs.writeFile(epochPath, source);
+
+			await expectFailure(allocateTelegramCustodyEpoch({ agentDir, ownerId: "next-owner" }), "exhausted");
+			expect(await fs.readFile(epochPath, "utf8")).toBe(source);
+		});
+	});
+
+	test("uses same-directory 0600 temporary writes and never returns a binding after write barriers fail", async () => {
+		await withAgentDirectory(async agentDir => {
+			const epochPath = telegramCustodyEpochPath(agentDir);
+			for (const failure of ["write", "temp-sync", "rename", "target-sync", "target-sync-eperm"] as const) {
+				const fakeFs = new FailingEpochFs();
+				if (failure === "write") fakeFs.failWrite = true;
+				if (failure === "rename") fakeFs.failRename = true;
+				if (failure === "temp-sync") fakeFs.failSyncAt = 1;
+				if (failure === "target-sync" || failure === "target-sync-eperm") {
+					fakeFs.failSyncAt = 2;
+					fakeFs.failSyncCode = failure === "target-sync-eperm" ? "EPERM" : undefined;
+				}
+				await expect(allocateTelegramCustodyEpoch({ agentDir, ownerId: `owner-${failure}`, fs: fakeFs })).rejects.toThrow(
+					"simulated",
+				);
+				const entries = await fs.readdir(path.dirname(epochPath));
+				expect(entries.some(entry => entry.endsWith(".tmp"))).toBe(false);
+			}
+
+			const fakeFs = new FailingEpochFs();
+			const binding = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-ok", fs: fakeFs });
+			expect(binding.custodyEpoch).toBeGreaterThan(0);
+			expect(fakeFs.writeCalls[0]?.mode).toBe(0o600);
+			expect(fakeFs.chmodCalls.some(call => call.file !== path.dirname(epochPath) && call.mode === 0o600)).toBe(true);
+			expect(path.dirname(fakeFs.renameCalls[0]!.from)).toBe(path.dirname(fakeFs.renameCalls[0]!.to));
+			expect(fakeFs.openCalls.map(call => call.flags)).toEqual(["r+", "r+", "r"]);
+		});
+	});
+});

--- a/packages/coding-agent/src/notifications/telegram-custody-epoch.test.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-epoch.test.ts
@@ -5,11 +5,11 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
 	allocateTelegramCustodyEpoch,
+	readTelegramCustodyEpoch,
 	TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES,
-	TelegramCustodyEpochError,
+	type TelegramCustodyEpochError,
 	type TelegramCustodyEpochFs,
 	telegramCustodyEpochPath,
-	readTelegramCustodyEpoch,
 	withCurrentTelegramCustodyEpoch,
 } from "./telegram-custody-epoch";
 
@@ -82,10 +82,7 @@ async function withAgentDirectory(operation: (agentDir: string) => Promise<void>
 	}
 }
 
-async function expectFailure(
-	operation: Promise<unknown>,
-	reason: TelegramCustodyEpochError["reason"],
-): Promise<void> {
+async function expectFailure(operation: Promise<unknown>, reason: TelegramCustodyEpochError["reason"]): Promise<void> {
 	await expect(operation).rejects.toMatchObject({ name: "TelegramCustodyEpochError", reason });
 }
 
@@ -109,7 +106,9 @@ describe("Telegram custody epoch", () => {
 				),
 			);
 
-			expect(bindings.map(binding => binding.custodyEpoch).sort((left, right) => left - right)).toEqual([1, 2, 3, 4, 5]);
+			expect(bindings.map(binding => binding.custodyEpoch).sort((left, right) => left - right)).toEqual([
+				1, 2, 3, 4, 5,
+			]);
 			expect(new Set(bindings.map(binding => binding.ownerId))).toEqual(
 				new Set(["owner-a", "owner-b", "owner-c", "owner-d", "owner-e"]),
 			);
@@ -123,9 +122,11 @@ describe("Telegram custody epoch", () => {
 			const third = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
 			let called = false;
 
-			expect(await withCurrentTelegramCustodyEpoch({ agentDir, binding: first }, async () => {
-				called = true;
-			})).toEqual({ ok: false, reason: "fenced" });
+			expect(
+				await withCurrentTelegramCustodyEpoch({ agentDir, binding: first }, async () => {
+					called = true;
+				}),
+			).toEqual({ ok: false, reason: "fenced" });
 			expect(await withCurrentTelegramCustodyEpoch({ agentDir, binding: second }, async () => undefined)).toEqual({
 				ok: false,
 				reason: "fenced",
@@ -214,9 +215,9 @@ describe("Telegram custody epoch", () => {
 					fakeFs.failSyncAt = 2;
 					fakeFs.failSyncCode = failure === "target-sync-eperm" ? "EPERM" : undefined;
 				}
-				await expect(allocateTelegramCustodyEpoch({ agentDir, ownerId: `owner-${failure}`, fs: fakeFs })).rejects.toThrow(
-					"simulated",
-				);
+				await expect(
+					allocateTelegramCustodyEpoch({ agentDir, ownerId: `owner-${failure}`, fs: fakeFs }),
+				).rejects.toThrow("simulated");
 				const entries = await fs.readdir(path.dirname(epochPath));
 				expect(entries.some(entry => entry.endsWith(".tmp"))).toBe(false);
 			}
@@ -225,7 +226,9 @@ describe("Telegram custody epoch", () => {
 			const binding = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-ok", fs: fakeFs });
 			expect(binding.custodyEpoch).toBeGreaterThan(0);
 			expect(fakeFs.writeCalls[0]?.mode).toBe(0o600);
-			expect(fakeFs.chmodCalls.some(call => call.file !== path.dirname(epochPath) && call.mode === 0o600)).toBe(true);
+			expect(fakeFs.chmodCalls.some(call => call.file !== path.dirname(epochPath) && call.mode === 0o600)).toBe(
+				true,
+			);
 			expect(path.dirname(fakeFs.renameCalls[0]!.from)).toBe(path.dirname(fakeFs.renameCalls[0]!.to));
 			expect(fakeFs.openCalls.map(call => call.flags)).toEqual(["r+", "r+", "r"]);
 		});

--- a/packages/coding-agent/src/notifications/telegram-custody-epoch.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-epoch.ts
@@ -1,0 +1,298 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { withFileLock } from "../config/file-lock";
+import { daemonPaths } from "./daemon-paths";
+
+export const TELEGRAM_CUSTODY_EPOCH_SCHEMA_VERSION = 1;
+export const TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES = 4_096;
+
+export interface TelegramCustodyEpochBinding {
+	ownerId: string;
+	custodyEpoch: number;
+}
+
+export type TelegramCustodyEpochFailureReason = "corrupt" | "forward_version" | "exhausted";
+
+export class TelegramCustodyEpochError extends Error {
+	readonly reason: TelegramCustodyEpochFailureReason;
+
+	constructor(reason: TelegramCustodyEpochFailureReason) {
+		super(`Telegram custody epoch is ${reason}`);
+		this.name = "TelegramCustodyEpochError";
+		this.reason = reason;
+	}
+}
+
+export interface TelegramCustodyEpochFs {
+	mkdir(path: string, opts?: fs.MakeDirectoryOptions): Promise<unknown>;
+	readFile(path: string, encoding: BufferEncoding): Promise<string>;
+	writeFile(path: string, data: string, opts?: fs.WriteFileOptions): Promise<void>;
+	rename(oldPath: string, newPath: string): Promise<void>;
+	chmod(path: string, mode: number): Promise<void>;
+	unlink(path: string): Promise<void>;
+	open(path: string, flags: string, mode?: number): Promise<{ sync(): Promise<void>; close(): Promise<void> }>;
+}
+
+const EPOCH_FILENAME = "telegram-custody-epoch.json";
+const nodeFs: TelegramCustodyEpochFs = fs.promises as unknown as TelegramCustodyEpochFs;
+const UNSUPPORTED_DIRECTORY_SYNC_CODES = new Set(["EISDIR", "EINVAL", "ENOSYS", "ENOTSUP", "EPERM"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isBinding(value: unknown): value is TelegramCustodyEpochBinding {
+	return (
+		isPlainObject(value) &&
+		typeof value.ownerId === "string" &&
+		value.ownerId.length > 0 &&
+		isPositiveSafeInteger(value.custodyEpoch)
+	);
+}
+
+function findStringEnd(source: string, start: number): number | undefined {
+	for (let position = start + 1; position < source.length; position++) {
+		const character = source[position];
+		if (character === "\\") {
+			position++;
+			continue;
+		}
+		if (character === '"') return position + 1;
+	}
+	return undefined;
+}
+
+/** JSON.parse intentionally accepts duplicate object members; epoch files do not. */
+function hasDuplicateObjectKeys(source: string): boolean {
+	function skipWhitespace(position: number): number {
+		while (/\s/.test(source[position] ?? "")) position++;
+		return position;
+	}
+
+	function scanString(position: number): { value: string; end: number } | undefined {
+		const end = findStringEnd(source, position);
+		if (end === undefined) return undefined;
+		try {
+			return { value: JSON.parse(source.slice(position, end)) as string, end };
+		} catch {
+			return undefined;
+		}
+	}
+
+	function scanValue(position: number): number | undefined {
+		position = skipWhitespace(position);
+		const character = source[position];
+		if (character === '"') return scanString(position)?.end;
+		if (character === "{") {
+			position = skipWhitespace(position + 1);
+			const keys = new Set<string>();
+			if (source[position] === "}") return position + 1;
+			while (true) {
+				if (source[position] !== '"') return undefined;
+				const key = scanString(position);
+				if (!key || keys.has(key.value)) return undefined;
+				keys.add(key.value);
+				position = skipWhitespace(key.end);
+				if (source[position] !== ":") return undefined;
+				const valueEnd = scanValue(position + 1);
+				if (valueEnd === undefined) return undefined;
+				position = skipWhitespace(valueEnd);
+				if (source[position] === "}") return position + 1;
+				if (source[position] !== ",") return undefined;
+				position = skipWhitespace(position + 1);
+			}
+		}
+		if (character === "[") {
+			position = skipWhitespace(position + 1);
+			if (source[position] === "]") return position + 1;
+			while (true) {
+				const valueEnd = scanValue(position);
+				if (valueEnd === undefined) return undefined;
+				position = skipWhitespace(valueEnd);
+				if (source[position] === "]") return position + 1;
+				if (source[position] !== ",") return undefined;
+				position = skipWhitespace(position + 1);
+			}
+		}
+		while (position < source.length && !/[\s,}\]]/.test(source[position]!)) position++;
+		return position;
+	}
+
+	const end = scanValue(0);
+	return end === undefined || skipWhitespace(end) !== source.length;
+}
+
+function parseTelegramCustodyEpoch(source: string): TelegramCustodyEpochBinding {
+	if (Buffer.byteLength(source, "utf8") > TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES || hasDuplicateObjectKeys(source)) {
+		throw new TelegramCustodyEpochError("corrupt");
+	}
+
+	let document: unknown;
+	try {
+		document = JSON.parse(source) as unknown;
+	} catch {
+		throw new TelegramCustodyEpochError("corrupt");
+	}
+
+	if (!isPlainObject(document)) throw new TelegramCustodyEpochError("corrupt");
+	const version = document.version;
+	if (typeof version !== "number" || !Number.isSafeInteger(version) || version < 1) {
+		throw new TelegramCustodyEpochError("corrupt");
+	}
+	if (version > TELEGRAM_CUSTODY_EPOCH_SCHEMA_VERSION) {
+		throw new TelegramCustodyEpochError("forward_version");
+	}
+
+	const keys = Object.keys(document);
+	if (
+		keys.length !== 3 ||
+		!Object.hasOwn(document, "version") ||
+		!Object.hasOwn(document, "custodyEpoch") ||
+		!Object.hasOwn(document, "ownerId")
+	) {
+		throw new TelegramCustodyEpochError("corrupt");
+	}
+	const binding = { ownerId: document.ownerId, custodyEpoch: document.custodyEpoch };
+	if (!isBinding(binding)) throw new TelegramCustodyEpochError("corrupt");
+	return binding;
+}
+
+function isUnsupportedDirectorySyncError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException).code;
+	return typeof code === "string" && UNSUPPORTED_DIRECTORY_SYNC_CODES.has(code);
+}
+
+async function syncFile(fsImpl: TelegramCustodyEpochFs, filePath: string): Promise<void> {
+	const handle = await fsImpl.open(filePath, "r+");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+async function syncDirectory(fsImpl: TelegramCustodyEpochFs, directoryPath: string): Promise<void> {
+	const handle = await fsImpl.open(directoryPath, "r");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+async function ensureEpochDirectory(fsImpl: TelegramCustodyEpochFs, agentDir: string): Promise<string> {
+	const directory = daemonPaths(agentDir).dir;
+	await fsImpl.mkdir(directory, { recursive: true, mode: 0o700 });
+	return directory;
+}
+
+async function writeTelegramCustodyEpoch(
+	fsImpl: TelegramCustodyEpochFs,
+	filePath: string,
+	binding: TelegramCustodyEpochBinding,
+): Promise<void> {
+	const data = `${JSON.stringify({
+		version: TELEGRAM_CUSTODY_EPOCH_SCHEMA_VERSION,
+		custodyEpoch: binding.custodyEpoch,
+		ownerId: binding.ownerId,
+	})}\n`;
+	if (Buffer.byteLength(data, "utf8") > TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES) {
+		throw new TelegramCustodyEpochError("corrupt");
+	}
+	const temporaryPath = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`);
+
+	try {
+		await fsImpl.writeFile(temporaryPath, data, { mode: 0o600 });
+		await fsImpl.chmod(temporaryPath, 0o600);
+		await syncFile(fsImpl, temporaryPath);
+		await fsImpl.rename(temporaryPath, filePath);
+		await syncFile(fsImpl, filePath);
+		try {
+			await syncDirectory(fsImpl, path.dirname(filePath));
+		} catch (error) {
+			if (!isUnsupportedDirectorySyncError(error)) throw error;
+		}
+	} catch (error) {
+		await fsImpl.unlink(temporaryPath).catch(() => undefined);
+		throw error;
+	}
+}
+
+export function telegramCustodyEpochPath(agentDir: string): string {
+	return path.join(daemonPaths(agentDir).dir, EPOCH_FILENAME);
+}
+
+export async function readTelegramCustodyEpoch(input: {
+	agentDir: string;
+	fs?: TelegramCustodyEpochFs;
+}): Promise<TelegramCustodyEpochBinding> {
+	const fsImpl = input.fs ?? nodeFs;
+	const filePath = telegramCustodyEpochPath(input.agentDir);
+	let source: string;
+	try {
+		source = await fsImpl.readFile(filePath, "utf8");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") throw new TelegramCustodyEpochError("corrupt");
+		throw error;
+	}
+	return parseTelegramCustodyEpoch(source);
+}
+
+export async function allocateTelegramCustodyEpoch(input: {
+	agentDir: string;
+	ownerId: string;
+	fs?: TelegramCustodyEpochFs;
+}): Promise<TelegramCustodyEpochBinding> {
+	if (typeof input.ownerId !== "string" || input.ownerId.length === 0) throw new TelegramCustodyEpochError("corrupt");
+
+	const fsImpl = input.fs ?? nodeFs;
+	const directory = await ensureEpochDirectory(fsImpl, input.agentDir);
+	const filePath = telegramCustodyEpochPath(input.agentDir);
+	return withFileLock(filePath, async () => {
+		await fsImpl.mkdir(directory, { recursive: true, mode: 0o700 });
+		await fsImpl.chmod(directory, 0o700);
+
+		let previous: TelegramCustodyEpochBinding | undefined;
+		try {
+			previous = parseTelegramCustodyEpoch(await fsImpl.readFile(filePath, "utf8"));
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+
+		if (previous?.custodyEpoch === Number.MAX_SAFE_INTEGER) {
+			throw new TelegramCustodyEpochError("exhausted");
+		}
+		const binding: TelegramCustodyEpochBinding = {
+			ownerId: input.ownerId,
+			custodyEpoch: previous === undefined ? 1 : previous.custodyEpoch + 1,
+		};
+		await writeTelegramCustodyEpoch(fsImpl, filePath, binding);
+		return binding;
+	});
+}
+
+export async function withCurrentTelegramCustodyEpoch<T>(
+	input: { agentDir: string; binding: TelegramCustodyEpochBinding; fs?: TelegramCustodyEpochFs },
+	operation: () => Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false; reason: "fenced" }> {
+	if (!isBinding(input.binding)) return { ok: false, reason: "fenced" };
+
+	const fsImpl = input.fs ?? nodeFs;
+	await ensureEpochDirectory(fsImpl, input.agentDir);
+	const filePath = telegramCustodyEpochPath(input.agentDir);
+	return withFileLock(filePath, async () => {
+		const current = await readTelegramCustodyEpoch({ agentDir: input.agentDir, fs: fsImpl });
+		if (
+			current.ownerId !== input.binding.ownerId ||
+			current.custodyEpoch !== input.binding.custodyEpoch
+		) {
+			return { ok: false, reason: "fenced" };
+		}
+		return { ok: true, value: await operation() };
+	});
+}

--- a/packages/coding-agent/src/notifications/telegram-custody-epoch.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-epoch.ts
@@ -204,7 +204,10 @@ async function writeTelegramCustodyEpoch(
 	if (Buffer.byteLength(data, "utf8") > TELEGRAM_CUSTODY_EPOCH_MAX_FILE_BYTES) {
 		throw new TelegramCustodyEpochError("corrupt");
 	}
-	const temporaryPath = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`);
+	const temporaryPath = path.join(
+		path.dirname(filePath),
+		`.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+	);
 
 	try {
 		await fsImpl.writeFile(temporaryPath, data, { mode: 0o600 });
@@ -287,10 +290,7 @@ export async function withCurrentTelegramCustodyEpoch<T>(
 	const filePath = telegramCustodyEpochPath(input.agentDir);
 	return withFileLock(filePath, async () => {
 		const current = await readTelegramCustodyEpoch({ agentDir: input.agentDir, fs: fsImpl });
-		if (
-			current.ownerId !== input.binding.ownerId ||
-			current.custodyEpoch !== input.binding.custodyEpoch
-		) {
+		if (current.ownerId !== input.binding.ownerId || current.custodyEpoch !== input.binding.custodyEpoch) {
 			return { ok: false, reason: "fenced" };
 		}
 		return { ok: true, value: await operation() };

--- a/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type * as fs from "node:fs";
 import * as path from "node:path";
+import * as fsPromises from "node:fs/promises";
+import * as os from "node:os";
 import { daemonPaths } from "./daemon-paths";
+import { allocateTelegramCustodyEpoch } from "./telegram-custody-epoch";
 import {
 	TELEGRAM_CUSTODY_MAX_FILE_BYTES,
 	TELEGRAM_CUSTODY_MAX_RECORDS,
@@ -370,5 +373,53 @@ describe("TelegramCustodyStore", () => {
 		expect(telegramCustodyKey("1", "23")).toBe("1:23");
 		expect(telegramCustodyKey("12", "3")).toBe("12:3");
 		expect(() => telegramCustodyKey("01", "3")).toThrow("Invalid Telegram custody identifier");
+	});
+	test("stamps active fence epochs and leaves stale or mismatched writes unchanged", async () => {
+		const agentDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "gjc-telegram-custody-store-"));
+		try {
+			const fakeFs = new FakeFs();
+			const binding = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
+			const custodyPath = path.join(daemonPaths(agentDir).dir, "telegram-deletion-custody.json");
+			const store = new TelegramCustodyStore({
+				agentDir,
+				fs: fakeFs,
+				now: () => 1,
+				fence: { binding },
+			});
+			await store.load();
+
+			expect(await store.put(custodyRecord())).toEqual({ ok: true });
+			expect(await store.put(custodyRecord({ topicId: "8", custodyEpoch: binding.custodyEpoch }))).toEqual({
+				ok: true,
+			});
+			const stamped = JSON.parse(fakeFs.files.get(custodyPath)!) as {
+				records: Record<string, TelegramCustodyRecord>;
+			};
+			expect(stamped.records["42:77"]?.custodyEpoch).toBe(binding.custodyEpoch);
+			expect(stamped.records["42:8"]?.custodyEpoch).toBe(binding.custodyEpoch);
+
+			const beforeMismatch = fakeFs.files.get(custodyPath);
+			const recordsBeforeMismatch = store.list();
+			const writesBeforeMismatch = fakeFs.writeCalls.length;
+			expect(await store.put(custodyRecord({ topicId: "9", custodyEpoch: binding.custodyEpoch + 1 }))).toEqual({
+				ok: false,
+				reason: "fenced",
+			});
+			expect(fakeFs.files.get(custodyPath)).toBe(beforeMismatch);
+			expect(store.list()).toEqual(recordsBeforeMismatch);
+			expect(fakeFs.writeCalls).toHaveLength(writesBeforeMismatch);
+
+			await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
+			const beforeStale = fakeFs.files.get(custodyPath);
+			const recordsBeforeStale = store.list();
+			const writesBeforeStale = fakeFs.writeCalls.length;
+			expect(await store.put(custodyRecord({ topicId: "9" }))).toEqual({ ok: false, reason: "fenced" });
+			expect(await store.remove({ chatId: "42", topicId: "77" })).toEqual({ ok: false, reason: "fenced" });
+			expect(fakeFs.files.get(custodyPath)).toBe(beforeStale);
+			expect(store.list()).toEqual(recordsBeforeStale);
+			expect(fakeFs.writeCalls).toHaveLength(writesBeforeStale);
+		} finally {
+			await fsPromises.rm(agentDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type * as fs from "node:fs";
-import * as path from "node:path";
 import * as fsPromises from "node:fs/promises";
 import * as os from "node:os";
+import * as path from "node:path";
 import { daemonPaths } from "./daemon-paths";
 import { allocateTelegramCustodyEpoch } from "./telegram-custody-epoch";
 import {

--- a/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, test } from "bun:test";
+import type * as fs from "node:fs";
+import * as path from "node:path";
+import { daemonPaths } from "./daemon-paths";
+import {
+	TELEGRAM_CUSTODY_MAX_FILE_BYTES,
+	TELEGRAM_CUSTODY_MAX_RECORDS,
+	type TelegramCustodyRecord,
+	TelegramCustodyStore,
+	type TelegramCustodyStoreFs,
+	telegramCustodyKey,
+} from "./telegram-custody-store";
+
+const AGENT_DIR = "/virtual/agent";
+const CUSTODY_PATH = path.join(daemonPaths(AGENT_DIR).dir, "telegram-deletion-custody.json");
+
+function numericMode(mode: fs.Mode | undefined): number | undefined {
+	return typeof mode === "number" ? mode : undefined;
+}
+
+function writeMode(options: fs.WriteFileOptions | undefined): number | undefined {
+	if (!options || typeof options === "string") return undefined;
+	return numericMode(options.mode);
+}
+
+class FakeFs implements TelegramCustodyStoreFs {
+	readonly files = new Map<string, string>();
+	readonly mkdirCalls: { path: string; mode: number | undefined }[] = [];
+	readonly chmodCalls: { path: string; mode: number }[] = [];
+	readonly writeCalls: { path: string; data: string; mode: number | undefined }[] = [];
+	readonly renameCalls: { from: string; to: string }[] = [];
+	readonly unlinkCalls: string[] = [];
+	failRename = false;
+	failWrite = false;
+
+	async mkdir(file: string, options?: fs.MakeDirectoryOptions): Promise<undefined> {
+		this.mkdirCalls.push({ path: file, mode: numericMode(options?.mode) });
+		return undefined;
+	}
+
+	async readFile(file: string): Promise<string> {
+		const contents = this.files.get(file);
+		if (contents === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+		return contents;
+	}
+
+	async writeFile(file: string, data: string, options?: fs.WriteFileOptions): Promise<void> {
+		this.writeCalls.push({ path: file, data, mode: writeMode(options) });
+		if (this.failWrite) throw new Error("simulated write failure");
+		this.files.set(file, data);
+	}
+
+	async chmod(file: string, mode: number): Promise<void> {
+		this.chmodCalls.push({ path: file, mode });
+	}
+
+	async rename(from: string, to: string): Promise<void> {
+		this.renameCalls.push({ from, to });
+		if (this.failRename) throw new Error("simulated rename failure");
+		const contents = this.files.get(from);
+		if (contents === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+		this.files.delete(from);
+		this.files.set(to, contents);
+	}
+
+	async unlink(file: string): Promise<void> {
+		this.unlinkCalls.push(file);
+		this.files.delete(file);
+	}
+}
+
+function storeWith(fakeFs: FakeFs): TelegramCustodyStore {
+	return new TelegramCustodyStore({ agentDir: AGENT_DIR, fs: fakeFs, now: () => 1 });
+}
+
+function custodyRecord(overrides: Partial<TelegramCustodyRecord> = {}): TelegramCustodyRecord {
+	return {
+		chatId: "42",
+		topicId: "77",
+		state: "queued",
+		updatedAt: 1,
+		...overrides,
+	};
+}
+
+function serialized(fakeFs: FakeFs): { version: number; records: Record<string, TelegramCustodyRecord> } {
+	return JSON.parse(fakeFs.files.get(CUSTODY_PATH)!) as {
+		version: number;
+		records: Record<string, TelegramCustodyRecord>;
+	};
+}
+
+describe("TelegramCustodyStore", () => {
+	test("loads a missing file as an empty writable store", async () => {
+		const store = storeWith(new FakeFs());
+		expect(await store.load()).toEqual({ mode: "writable", migrated: false, records: [] });
+		expect(store.list()).toEqual([]);
+	});
+
+	test("round-trips all states with deterministic composite key order and separate chats", async () => {
+		const fakeFs = new FakeFs();
+		const store = storeWith(fakeFs);
+		await store.load();
+		await store.put(custodyRecord({ chatId: "2", topicId: "7", state: "queued" }));
+		await store.put(custodyRecord({ chatId: "10", topicId: "7", state: "in_flight" }));
+		await store.put(custodyRecord({ chatId: "2", topicId: "1", state: "unknown" }));
+
+		expect(Object.keys(serialized(fakeFs).records)).toEqual(["10:7", "2:1", "2:7"]);
+		expect(serialized(fakeFs).records["10:7"]?.state).toBe("in_flight");
+		expect(store.get({ chatId: "2", topicId: "7" })).toEqual(custodyRecord({ chatId: "2", topicId: "7" }));
+		expect(store.get({ chatId: "10", topicId: "7" })).toEqual(
+			custodyRecord({ chatId: "10", topicId: "7", state: "in_flight" }),
+		);
+
+		const reader = storeWith(fakeFs);
+		const loaded = await reader.load();
+		expect(loaded).toEqual({
+			mode: "writable",
+			migrated: false,
+			records: [
+				custodyRecord({ chatId: "10", topicId: "7", state: "unknown" }),
+				custodyRecord({ chatId: "2", topicId: "1", state: "unknown" }),
+				custodyRecord({ chatId: "2", topicId: "7" }),
+			],
+		});
+		expect(serialized(fakeFs).records["10:7"]?.state).toBe("unknown");
+	});
+
+	test("strictly migrates a v1 single-chat record object and preserves an optional epoch", async () => {
+		const fakeFs = new FakeFs();
+		fakeFs.files.set(
+			CUSTODY_PATH,
+			JSON.stringify({
+				version: 1,
+				chatId: "-100123",
+				records: {
+					"9": { state: "in_flight", updatedAt: 20, custodyEpoch: 3 },
+					"2": { state: "queued", updatedAt: 10 },
+				},
+			}),
+		);
+
+		const result = await storeWith(fakeFs).load();
+		expect(result).toEqual({
+			mode: "writable",
+			migrated: true,
+			records: [
+				custodyRecord({ chatId: "-100123", topicId: "2", updatedAt: 10 }),
+				custodyRecord({ chatId: "-100123", topicId: "9", state: "unknown", updatedAt: 20, custodyEpoch: 3 }),
+			],
+		});
+		expect(serialized(fakeFs)).toEqual({
+			version: 2,
+			records: {
+				"-100123:2": custodyRecord({ chatId: "-100123", topicId: "2", updatedAt: 10 }),
+				"-100123:9": custodyRecord({
+					chatId: "-100123",
+					topicId: "9",
+					state: "unknown",
+					updatedAt: 20,
+					custodyEpoch: 3,
+				}),
+			},
+		});
+	});
+
+	test("converts loaded v2 in_flight custody to unknown and atomically rewrites it", async () => {
+		const fakeFs = new FakeFs();
+		fakeFs.files.set(
+			CUSTODY_PATH,
+			JSON.stringify({
+				version: 2,
+				records: { "42:7": custodyRecord({ topicId: "7", state: "in_flight", custodyEpoch: 8 }) },
+			}),
+		);
+
+		const result = await storeWith(fakeFs).load();
+		expect(result).toEqual({
+			mode: "writable",
+			migrated: false,
+			records: [custodyRecord({ topicId: "7", state: "unknown", custodyEpoch: 8 })],
+		});
+		expect(serialized(fakeFs).records["42:7"]?.state).toBe("unknown");
+		expect(fakeFs.renameCalls).toHaveLength(1);
+	});
+
+	test("rejects malformed JSON, duplicate members, key mismatches, and unknown states without rewrite", async () => {
+		const invalidDocuments = [
+			"{ not JSON",
+			'{"version":2,"version":2,"records":{}}',
+			JSON.stringify({ version: 2, records: { "42:8": custodyRecord({ topicId: "7" }) } }),
+			JSON.stringify({ version: 2, records: { "42:7": { ...custodyRecord(), state: "sent" } } }),
+		];
+
+		for (const source of invalidDocuments) {
+			const fakeFs = new FakeFs();
+			fakeFs.files.set(CUSTODY_PATH, source);
+			const store = storeWith(fakeFs);
+			expect(await store.load()).toEqual({ mode: "read_only", reason: "corrupt", migrated: false, records: [] });
+			expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+			expect(fakeFs.writeCalls).toHaveLength(0);
+			expect(await store.put(custodyRecord())).toEqual({ ok: false, reason: "read_only" });
+		}
+	});
+
+	test("rejects invalid IDs, timestamps, epochs, and excess record properties", async () => {
+		const invalidRecords: unknown[] = [
+			{ chatId: "+1", topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "01", topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "-0", topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "0", topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "1".repeat(33), topicId: "7", state: "queued", updatedAt: 1 },
+			{ chatId: "1", topicId: "0", state: "queued", updatedAt: 1 },
+			{ chatId: "1", topicId: "-7", state: "queued", updatedAt: 1 },
+			{ chatId: "1", topicId: "1".repeat(21), state: "queued", updatedAt: 1 },
+			{ chatId: "1", topicId: "7", state: "queued", updatedAt: -1 },
+			{ chatId: "1", topicId: "7", state: "queued", updatedAt: Number.MAX_SAFE_INTEGER + 1 },
+			{ chatId: "1", topicId: "7", state: "queued", updatedAt: 1, custodyEpoch: -1 },
+			{ chatId: "1", topicId: "7", state: "queued", updatedAt: 1, unexpected: true },
+		];
+		for (const record of invalidRecords) {
+			const fakeFs = new FakeFs();
+			fakeFs.files.set(CUSTODY_PATH, JSON.stringify({ version: 2, records: { "1:7": record } }));
+			expect(await storeWith(fakeFs).load()).toEqual({
+				mode: "read_only",
+				reason: "corrupt",
+				migrated: false,
+				records: [],
+			});
+		}
+
+		const writableFs = new FakeFs();
+		const writableStore = storeWith(writableFs);
+		await writableStore.load();
+		await expect(
+			writableStore.put({ ...custodyRecord(), topicId: "01" } as unknown as TelegramCustodyRecord),
+		).rejects.toThrow("Invalid Telegram custody record");
+		await expect(
+			writableStore.put({ ...custodyRecord(), custodyEpoch: undefined } as unknown as TelegramCustodyRecord),
+		).rejects.toThrow("Invalid Telegram custody record");
+		expect(writableFs.writeCalls).toHaveLength(0);
+	});
+
+	test("honors the 1,000-record and file-size boundaries without touching oversized source bytes", async () => {
+		const exactlyAtLimit = Object.fromEntries(
+			Array.from({ length: TELEGRAM_CUSTODY_MAX_RECORDS }, (_, index) => [
+				`42:${index + 1}`,
+				custodyRecord({ topicId: String(index + 1) }),
+			]),
+		);
+		const validFs = new FakeFs();
+		validFs.files.set(CUSTODY_PATH, JSON.stringify({ version: 2, records: exactlyAtLimit }));
+		const validStore = storeWith(validFs);
+		const validResult = await validStore.load();
+		expect(validResult.mode).toBe("writable");
+		expect(validResult.records).toHaveLength(TELEGRAM_CUSTODY_MAX_RECORDS);
+		await expect(
+			validStore.put(custodyRecord({ topicId: String(TELEGRAM_CUSTODY_MAX_RECORDS + 1) })),
+		).rejects.toThrow("Telegram custody record limit exceeded");
+		expect(validFs.writeCalls).toHaveLength(0);
+		const atFileLimit = JSON.stringify({ version: 2, records: {} });
+		const paddedAtLimit = `${atFileLimit}${" ".repeat(TELEGRAM_CUSTODY_MAX_FILE_BYTES - Buffer.byteLength(atFileLimit, "utf8"))}`;
+		const fileLimitFs = new FakeFs();
+		fileLimitFs.files.set(CUSTODY_PATH, paddedAtLimit);
+		expect(await storeWith(fileLimitFs).load()).toEqual({ mode: "writable", migrated: false, records: [] });
+
+		const tooMany = Object.fromEntries(
+			Array.from({ length: TELEGRAM_CUSTODY_MAX_RECORDS + 1 }, (_, index) => [
+				`42:${index + 1}`,
+				custodyRecord({ topicId: String(index + 1) }),
+			]),
+		);
+		for (const source of [
+			JSON.stringify({ version: 2, records: tooMany }),
+			" ".repeat(TELEGRAM_CUSTODY_MAX_FILE_BYTES + 1),
+		]) {
+			const fakeFs = new FakeFs();
+			fakeFs.files.set(CUSTODY_PATH, source);
+			const store = storeWith(fakeFs);
+			expect(await store.load()).toEqual({ mode: "read_only", reason: "bounds", migrated: false, records: [] });
+			expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+			expect(fakeFs.writeCalls).toHaveLength(0);
+		}
+	});
+
+	test("preserves forward-version bytes and disables mutation", async () => {
+		const fakeFs = new FakeFs();
+		const source = '{"version":3,"future":"preserve exactly"}\n';
+		fakeFs.files.set(CUSTODY_PATH, source);
+		const store = storeWith(fakeFs);
+		expect(await store.load()).toEqual({
+			mode: "read_only",
+			reason: "forward_version",
+			migrated: false,
+			records: [],
+		});
+		expect(await store.remove({ chatId: "42", topicId: "7" })).toEqual({ ok: false, reason: "read_only" });
+		expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+		expect(fakeFs.writeCalls).toHaveLength(0);
+	});
+
+	test("classifies a failed v1 migration as read-only and does not promote memory to writable", async () => {
+		const fakeFs = new FakeFs();
+		const source = JSON.stringify({
+			version: 1,
+			chatId: "42",
+			records: { "7": { state: "queued", updatedAt: 1 } },
+		});
+		fakeFs.files.set(CUSTODY_PATH, source);
+		fakeFs.failRename = true;
+		const store = storeWith(fakeFs);
+
+		expect(await store.load()).toEqual({
+			mode: "read_only",
+			reason: "migration_write_failed",
+			migrated: false,
+			records: [custodyRecord({ topicId: "7" })],
+		});
+		expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+		expect(store.list()).toEqual([custodyRecord({ topicId: "7" })]);
+		expect(await store.put(custodyRecord({ topicId: "8" }))).toEqual({ ok: false, reason: "read_only" });
+		expect(fakeFs.unlinkCalls).toHaveLength(1);
+	});
+
+	test("uses restrictive permissions, same-directory atomic renames, and cleans temporary writes on failure", async () => {
+		const fakeFs = new FakeFs();
+		const store = storeWith(fakeFs);
+		await store.load();
+		await store.put(custodyRecord());
+		expect(fakeFs.mkdirCalls).toEqual([{ path: daemonPaths(AGENT_DIR).dir, mode: 0o700 }]);
+		expect(fakeFs.chmodCalls[0]).toEqual({ path: daemonPaths(AGENT_DIR).dir, mode: 0o700 });
+		expect(fakeFs.writeCalls[0]?.mode).toBe(0o600);
+		expect(fakeFs.chmodCalls[1]?.mode).toBe(0o600);
+		expect(path.dirname(fakeFs.renameCalls[0]!.from)).toBe(path.dirname(fakeFs.renameCalls[0]!.to));
+
+		const before = fakeFs.files.get(CUSTODY_PATH);
+		fakeFs.failWrite = true;
+		await expect(store.put(custodyRecord({ topicId: "8" }))).rejects.toThrow("simulated write failure");
+		expect(store.get({ chatId: "42", topicId: "8" })).toBeUndefined();
+		expect(fakeFs.files.get(CUSTODY_PATH)).toBe(before);
+		expect([...fakeFs.files.keys()].some(file => file.endsWith(".tmp"))).toBe(false);
+		expect(fakeFs.unlinkCalls).toHaveLength(1);
+	});
+
+	test("serializes overlapping puts and removes and returns copies from read APIs", async () => {
+		const fakeFs = new FakeFs();
+		const store = storeWith(fakeFs);
+		await store.load();
+		const first = store.put(custodyRecord({ topicId: "1" }));
+		const second = store.put(custodyRecord({ topicId: "2" }));
+		const third = store.remove({ chatId: "42", topicId: "1" });
+		expect(await Promise.all([first, second, third])).toEqual([{ ok: true }, { ok: true }, { ok: true }]);
+		expect(store.list()).toEqual([custodyRecord({ topicId: "2" })]);
+
+		const fromGet = store.get({ chatId: "42", topicId: "2" })!;
+		fromGet.state = "unknown";
+		const fromList = store.list()[0]!;
+		fromList.state = "unknown";
+		expect(store.get({ chatId: "42", topicId: "2" })?.state).toBe("queued");
+	});
+
+	test("serializes only custody fields and validates delimiter-safe decimal keys", async () => {
+		const fakeFs = new FakeFs();
+		const store = storeWith(fakeFs);
+		await store.load();
+		await store.put(custodyRecord({ chatId: "-100123", topicId: "77", custodyEpoch: 9 }));
+		const data = fakeFs.files.get(CUSTODY_PATH)!;
+		expect(data).toContain('"-100123:77"');
+		expect(data).not.toMatch(/token|session|endpoint|fingerprint|messageText/i);
+		expect(telegramCustodyKey("1", "23")).toBe("1:23");
+		expect(telegramCustodyKey("12", "3")).toBe("12:3");
+		expect(() => telegramCustodyKey("01", "3")).toThrow("Invalid Telegram custody identifier");
+	});
+});

--- a/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
@@ -4,10 +4,12 @@ import * as fsPromises from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { daemonPaths } from "./daemon-paths";
-import { allocateTelegramCustodyEpoch } from "./telegram-custody-epoch";
+import { allocateTelegramCustodyEpoch, type TelegramCustodyEpochBinding } from "./telegram-custody-epoch";
 import {
 	TELEGRAM_CUSTODY_MAX_FILE_BYTES,
 	TELEGRAM_CUSTODY_MAX_RECORDS,
+	TELEGRAM_CUSTODY_SCHEMA_VERSION,
+	type TelegramCustodyDiagnostic,
 	type TelegramCustodyRecord,
 	TelegramCustodyStore,
 	type TelegramCustodyStoreFs,
@@ -75,7 +77,26 @@ class FakeFs implements TelegramCustodyStoreFs {
 function storeWith(fakeFs: FakeFs): TelegramCustodyStore {
 	return new TelegramCustodyStore({ agentDir: AGENT_DIR, fs: fakeFs, now: () => 1 });
 }
+async function fencedStoreWith(
+	fakeFs: FakeFs,
+	agentDir: string,
+	now: () => number = () => 1,
+): Promise<{ binding: TelegramCustodyEpochBinding; store: TelegramCustodyStore }> {
+	const binding = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
+	return {
+		binding,
+		store: new TelegramCustodyStore({
+			agentDir,
+			fs: fakeFs,
+			now,
+			fence: { binding },
+		}),
+	};
+}
 
+function dynamicCustodyPath(agentDir: string): string {
+	return path.join(daemonPaths(agentDir).dir, "telegram-deletion-custody.json");
+}
 function custodyRecord(overrides: Partial<TelegramCustodyRecord> = {}): TelegramCustodyRecord {
 	return {
 		chatId: "42",
@@ -105,14 +126,31 @@ describe("TelegramCustodyStore", () => {
 		const store = storeWith(fakeFs);
 		await store.load();
 		await store.put(custodyRecord({ chatId: "2", topicId: "7", state: "queued" }));
-		await store.put(custodyRecord({ chatId: "10", topicId: "7", state: "in_flight" }));
-		await store.put(custodyRecord({ chatId: "2", topicId: "1", state: "unknown" }));
+		await store.put(custodyRecord({ chatId: "10", topicId: "7", state: "in_flight", custodyEpoch: 2 }));
+		await store.put(
+			custodyRecord({
+				chatId: "2",
+				topicId: "1",
+				state: "unknown",
+				custodyEpoch: 3,
+				diagnostic: { kind: "transport_ambiguous", transport: "network" },
+			}),
+		);
+		await store.put(
+			custodyRecord({
+				chatId: "2",
+				topicId: "8",
+				state: "confirmed",
+				custodyEpoch: 4,
+				diagnostic: { kind: "telegram_ok" },
+			}),
+		);
 
-		expect(Object.keys(serialized(fakeFs).records)).toEqual(["10:7", "2:1", "2:7"]);
+		expect(Object.keys(serialized(fakeFs).records)).toEqual(["10:7", "2:1", "2:7", "2:8"]);
 		expect(serialized(fakeFs).records["10:7"]?.state).toBe("in_flight");
 		expect(store.get({ chatId: "2", topicId: "7" })).toEqual(custodyRecord({ chatId: "2", topicId: "7" }));
 		expect(store.get({ chatId: "10", topicId: "7" })).toEqual(
-			custodyRecord({ chatId: "10", topicId: "7", state: "in_flight" }),
+			custodyRecord({ chatId: "10", topicId: "7", state: "in_flight", custodyEpoch: 2 }),
 		);
 
 		const reader = storeWith(fakeFs);
@@ -121,12 +159,34 @@ describe("TelegramCustodyStore", () => {
 			mode: "writable",
 			migrated: false,
 			records: [
-				custodyRecord({ chatId: "10", topicId: "7", state: "unknown" }),
-				custodyRecord({ chatId: "2", topicId: "1", state: "unknown" }),
+				custodyRecord({
+					chatId: "10",
+					topicId: "7",
+					state: "unknown",
+					custodyEpoch: 2,
+					diagnostic: { kind: "restart_after_claim" },
+				}),
+				custodyRecord({
+					chatId: "2",
+					topicId: "1",
+					state: "unknown",
+					custodyEpoch: 3,
+					diagnostic: { kind: "transport_ambiguous", transport: "network" },
+				}),
 				custodyRecord({ chatId: "2", topicId: "7" }),
+				custodyRecord({
+					chatId: "2",
+					topicId: "8",
+					state: "confirmed",
+					custodyEpoch: 4,
+					diagnostic: { kind: "telegram_ok" },
+				}),
 			],
 		});
-		expect(serialized(fakeFs).records["10:7"]?.state).toBe("unknown");
+		expect(serialized(fakeFs).records["10:7"]).toMatchObject({
+			state: "unknown",
+			diagnostic: { kind: "restart_after_claim" },
+		});
 	});
 
 	test("strictly migrates a v1 single-chat record object and preserves an optional epoch", async () => {
@@ -149,11 +209,18 @@ describe("TelegramCustodyStore", () => {
 			migrated: true,
 			records: [
 				custodyRecord({ chatId: "-100123", topicId: "2", updatedAt: 10 }),
-				custodyRecord({ chatId: "-100123", topicId: "9", state: "unknown", updatedAt: 20, custodyEpoch: 3 }),
+				custodyRecord({
+					chatId: "-100123",
+					topicId: "9",
+					state: "unknown",
+					updatedAt: 20,
+					custodyEpoch: 3,
+					diagnostic: { kind: "restart_after_claim" },
+				}),
 			],
 		});
 		expect(serialized(fakeFs)).toEqual({
-			version: 2,
+			version: TELEGRAM_CUSTODY_SCHEMA_VERSION,
 			records: {
 				"-100123:2": custodyRecord({ chatId: "-100123", topicId: "2", updatedAt: 10 }),
 				"-100123:9": custodyRecord({
@@ -162,29 +229,103 @@ describe("TelegramCustodyStore", () => {
 					state: "unknown",
 					updatedAt: 20,
 					custodyEpoch: 3,
+					diagnostic: { kind: "restart_after_claim" },
 				}),
 			},
 		});
 	});
 
-	test("converts loaded v2 in_flight custody to unknown and atomically rewrites it", async () => {
+	test("strictly migrates v2 queued and unknown custody and marks prior claims as unknown", async () => {
 		const fakeFs = new FakeFs();
 		fakeFs.files.set(
 			CUSTODY_PATH,
 			JSON.stringify({
 				version: 2,
-				records: { "42:7": custodyRecord({ topicId: "7", state: "in_flight", custodyEpoch: 8 }) },
+				records: {
+					"42:7": custodyRecord({ topicId: "7", state: "in_flight", custodyEpoch: 8 }),
+					"42:8": custodyRecord({ topicId: "8", state: "unknown", custodyEpoch: 4 }),
+					"42:9": custodyRecord({ topicId: "9", state: "queued" }),
+				},
 			}),
 		);
 
 		const result = await storeWith(fakeFs).load();
 		expect(result).toEqual({
 			mode: "writable",
-			migrated: false,
-			records: [custodyRecord({ topicId: "7", state: "unknown", custodyEpoch: 8 })],
+			migrated: true,
+			records: [
+				custodyRecord({
+					topicId: "7",
+					state: "unknown",
+					custodyEpoch: 8,
+					diagnostic: { kind: "restart_after_claim" },
+				}),
+				custodyRecord({
+					topicId: "8",
+					state: "unknown",
+					custodyEpoch: 4,
+					diagnostic: { kind: "legacy_unknown" },
+				}),
+				custodyRecord({ topicId: "9", state: "queued" }),
+			],
 		});
-		expect(serialized(fakeFs).records["42:7"]?.state).toBe("unknown");
+		expect(serialized(fakeFs)).toMatchObject({
+			version: TELEGRAM_CUSTODY_SCHEMA_VERSION,
+			records: {
+				"42:7": { state: "unknown", diagnostic: { kind: "restart_after_claim" } },
+				"42:8": { state: "unknown", diagnostic: { kind: "legacy_unknown" } },
+			},
+		});
 		expect(fakeFs.renameCalls).toHaveLength(1);
+	});
+	test("converts a recovered v3 claim to restart-after-claim before it can be reused", async () => {
+		const fakeFs = new FakeFs();
+		fakeFs.files.set(
+			CUSTODY_PATH,
+			JSON.stringify({
+				version: TELEGRAM_CUSTODY_SCHEMA_VERSION,
+				records: {
+					"42:7": {
+						chatId: "42",
+						topicId: "7",
+						state: "in_flight",
+						updatedAt: 1,
+						custodyEpoch: 8,
+						trigger: "session_closed",
+					},
+				},
+			}),
+		);
+
+		const store = storeWith(fakeFs);
+		expect(await store.load()).toEqual({
+			mode: "writable",
+			migrated: false,
+			records: [
+				custodyRecord({
+					topicId: "7",
+					state: "unknown",
+					custodyEpoch: 8,
+					trigger: "session_closed",
+					diagnostic: { kind: "restart_after_claim" },
+				}),
+			],
+		});
+		expect(await store.claimDeletion({ chatId: "42", topicId: "7" })).toEqual({
+			ok: true,
+			status: "blocked",
+			record: custodyRecord({
+				topicId: "7",
+				state: "unknown",
+				custodyEpoch: 8,
+				trigger: "session_closed",
+				diagnostic: { kind: "restart_after_claim" },
+			}),
+		});
+		expect(serialized(fakeFs).records["42:7"]).toMatchObject({
+			state: "unknown",
+			diagnostic: { kind: "restart_after_claim" },
+		});
 	});
 
 	test("rejects malformed JSON, duplicate members, key mismatches, and unknown states without rewrite", async () => {
@@ -203,6 +344,43 @@ describe("TelegramCustodyStore", () => {
 			expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
 			expect(fakeFs.writeCalls).toHaveLength(0);
 			expect(await store.put(custodyRecord())).toEqual({ ok: false, reason: "read_only" });
+		}
+	});
+	test("rejects state-invalid and raw diagnostic shapes without rewriting v3 bytes", async () => {
+		const base = { chatId: "42", topicId: "7", updatedAt: 1, custodyEpoch: 1 };
+		const invalidRecords: unknown[] = [
+			{ ...base, state: "queued", diagnostic: { kind: "legacy_unknown" } },
+			{ ...base, state: "confirmed", diagnostic: { kind: "telegram_rejected", rejection: "other" } },
+			{ ...base, state: "unknown", diagnostic: { kind: "telegram_ok" } },
+			{
+				...base,
+				state: "unknown",
+				diagnostic: { kind: "transport_ambiguous", transport: "network", message: "secret message" },
+			},
+			{
+				...base,
+				state: "unknown",
+				diagnostic: { kind: "telegram_rejected", rejection: "other", errorCode: "400" },
+			},
+			{
+				...base,
+				state: "unknown",
+				diagnostic: { kind: "telegram_rejected", rejection: "other", description: "bot-token" },
+			},
+		];
+
+		for (const record of invalidRecords) {
+			const fakeFs = new FakeFs();
+			const source = JSON.stringify({ version: TELEGRAM_CUSTODY_SCHEMA_VERSION, records: { "42:7": record } });
+			fakeFs.files.set(CUSTODY_PATH, source);
+			expect(await storeWith(fakeFs).load()).toEqual({
+				mode: "read_only",
+				reason: "corrupt",
+				migrated: false,
+				records: [],
+			});
+			expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+			expect(fakeFs.writeCalls).toHaveLength(0);
 		}
 	});
 
@@ -257,11 +435,12 @@ describe("TelegramCustodyStore", () => {
 		const validResult = await validStore.load();
 		expect(validResult.mode).toBe("writable");
 		expect(validResult.records).toHaveLength(TELEGRAM_CUSTODY_MAX_RECORDS);
+		const writesBeforeOverLimit = validFs.writeCalls.length;
 		await expect(
 			validStore.put(custodyRecord({ topicId: String(TELEGRAM_CUSTODY_MAX_RECORDS + 1) })),
 		).rejects.toThrow("Telegram custody record limit exceeded");
-		expect(validFs.writeCalls).toHaveLength(0);
-		const atFileLimit = JSON.stringify({ version: 2, records: {} });
+		expect(validFs.writeCalls).toHaveLength(writesBeforeOverLimit);
+		const atFileLimit = JSON.stringify({ version: TELEGRAM_CUSTODY_SCHEMA_VERSION, records: {} });
 		const paddedAtLimit = `${atFileLimit}${" ".repeat(TELEGRAM_CUSTODY_MAX_FILE_BYTES - Buffer.byteLength(atFileLimit, "utf8"))}`;
 		const fileLimitFs = new FakeFs();
 		fileLimitFs.files.set(CUSTODY_PATH, paddedAtLimit);
@@ -288,7 +467,7 @@ describe("TelegramCustodyStore", () => {
 
 	test("preserves forward-version bytes and disables mutation", async () => {
 		const fakeFs = new FakeFs();
-		const source = '{"version":3,"future":"preserve exactly"}\n';
+		const source = '{"version":4,"future":"preserve exactly"}\n';
 		fakeFs.files.set(CUSTODY_PATH, source);
 		const store = storeWith(fakeFs);
 		expect(await store.load()).toEqual({
@@ -298,6 +477,11 @@ describe("TelegramCustodyStore", () => {
 			records: [],
 		});
 		expect(await store.remove({ chatId: "42", topicId: "7" })).toEqual({ ok: false, reason: "read_only" });
+		expect(await store.queueDeletion({ chatId: "42", topicId: "7", trigger: "session_closed" })).toEqual({
+			ok: false,
+			reason: "read_only",
+		});
+		expect(await store.removeConfirmed({ chatId: "42", topicId: "7" })).toEqual({ ok: true });
 		expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
 		expect(fakeFs.writeCalls).toHaveLength(0);
 	});
@@ -373,6 +557,280 @@ describe("TelegramCustodyStore", () => {
 		expect(telegramCustodyKey("1", "23")).toBe("1:23");
 		expect(telegramCustodyKey("12", "3")).toBe("12:3");
 		expect(() => telegramCustodyKey("01", "3")).toThrow("Invalid Telegram custody identifier");
+	});
+	test("queues, claims, settles, and removes only a durable confirmed deletion", async () => {
+		const agentDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "gjc-telegram-custody-store-"));
+		try {
+			const fakeFs = new FakeFs();
+			const { binding, store } = await fencedStoreWith(fakeFs, agentDir);
+			await store.load();
+
+			expect(await store.queueDeletion({ chatId: "42", topicId: "77", trigger: "session_closed" })).toEqual({
+				ok: true,
+				status: "queued",
+				record: {
+					chatId: "42",
+					topicId: "77",
+					state: "queued",
+					updatedAt: 1,
+					custodyEpoch: binding.custodyEpoch,
+					trigger: "session_closed",
+				},
+			});
+			expect(await store.claimDeletion({ chatId: "42", topicId: "77" })).toEqual({
+				ok: true,
+				status: "claimed",
+				record: {
+					chatId: "42",
+					topicId: "77",
+					state: "in_flight",
+					updatedAt: 1,
+					custodyEpoch: binding.custodyEpoch,
+					trigger: "session_closed",
+				},
+			});
+			expect(
+				await store.settleDeletion({
+					chatId: "42",
+					topicId: "77",
+					diagnostic: { kind: "telegram_ok" },
+				}),
+			).toEqual({ ok: true });
+			expect(store.get({ chatId: "42", topicId: "77" })).toEqual({
+				chatId: "42",
+				topicId: "77",
+				state: "confirmed",
+				updatedAt: 1,
+				custodyEpoch: binding.custodyEpoch,
+				trigger: "session_closed",
+				diagnostic: { kind: "telegram_ok" },
+			});
+			expect(await store.claimDeletion({ chatId: "42", topicId: "77" })).toEqual({
+				ok: true,
+				status: "blocked",
+				record: store.get({ chatId: "42", topicId: "77" })!,
+			});
+			expect(await store.removeConfirmed({ chatId: "42", topicId: "77" })).toEqual({ ok: true });
+			expect(await store.removeConfirmed({ chatId: "42", topicId: "77" })).toEqual({ ok: true });
+
+			const diagnostics: readonly TelegramCustodyDiagnostic[] = [
+				{ kind: "telegram_rejected", rejection: "not_found", errorCode: 400 },
+				{ kind: "malformed_response" },
+				{ kind: "transport_ambiguous", transport: "connection_reset" },
+				{ kind: "restart_after_claim" },
+				{ kind: "legacy_unknown" },
+			];
+			for (const [index, diagnostic] of diagnostics.entries()) {
+				const topicId = String(80 + index);
+				await store.queueDeletion({ chatId: "42", topicId, trigger: "orphan_reap" });
+				await store.claimDeletion({ chatId: "42", topicId });
+				expect(await store.settleDeletion({ chatId: "42", topicId, diagnostic })).toEqual({ ok: true });
+				expect(store.get({ chatId: "42", topicId })).toMatchObject({
+					state: "unknown",
+					custodyEpoch: binding.custodyEpoch,
+					trigger: "orphan_reap",
+					diagnostic,
+				});
+				expect(await store.removeConfirmed({ chatId: "42", topicId })).toEqual({ ok: false, reason: "fenced" });
+			}
+			expect(fakeFs.files.get(dynamicCustodyPath(agentDir))).not.toMatch(
+				/token|description|message|stack|endpoint/i,
+			);
+		} finally {
+			await fsPromises.rm(agentDir, { recursive: true, force: true });
+		}
+	});
+
+	test("serializes concurrent claims and fences same-owner ABA before every mutation", async () => {
+		const concurrentAgentDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "gjc-telegram-custody-store-"));
+		try {
+			const fakeFs = new FakeFs();
+			const { store } = await fencedStoreWith(fakeFs, concurrentAgentDir);
+			await store.load();
+			await store.queueDeletion({ chatId: "42", topicId: "77", trigger: "session_closed" });
+			const claims = await Promise.all(
+				Array.from({ length: 4 }, () => store.claimDeletion({ chatId: "42", topicId: "77" })),
+			);
+			expect(claims.filter(claim => claim.ok && claim.status === "claimed")).toHaveLength(1);
+			expect(claims.filter(claim => claim.ok && claim.status === "blocked")).toHaveLength(3);
+			expect(store.get({ chatId: "42", topicId: "77" })?.state).toBe("in_flight");
+		} finally {
+			await fsPromises.rm(concurrentAgentDir, { recursive: true, force: true });
+		}
+
+		const abaAgentDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "gjc-telegram-custody-store-"));
+		try {
+			const fakeFs = new FakeFs();
+			const { binding: firstBinding, store: firstStore } = await fencedStoreWith(fakeFs, abaAgentDir);
+			const custodyPath = dynamicCustodyPath(abaAgentDir);
+			await firstStore.load();
+			await firstStore.queueDeletion({ chatId: "42", topicId: "77", trigger: "session_closed" });
+
+			const secondBinding = await allocateTelegramCustodyEpoch({ agentDir: abaAgentDir, ownerId: "owner-a" });
+			const beforeOldMutation = fakeFs.files.get(custodyPath);
+			const recordsBeforeOldMutation = firstStore.list();
+			const writesBeforeOldMutation = fakeFs.writeCalls.length;
+			expect(firstBinding.custodyEpoch).toBeLessThan(secondBinding.custodyEpoch);
+			expect(await firstStore.queueDeletion({ chatId: "42", topicId: "77", trigger: "orphan_reap" })).toEqual({
+				ok: false,
+				reason: "fenced",
+			});
+			expect(await firstStore.claimDeletion({ chatId: "42", topicId: "77" })).toEqual({
+				ok: false,
+				reason: "fenced",
+			});
+			expect(fakeFs.files.get(custodyPath)).toBe(beforeOldMutation);
+			expect(firstStore.list()).toEqual(recordsBeforeOldMutation);
+			expect(fakeFs.writeCalls).toHaveLength(writesBeforeOldMutation);
+
+			const secondStore = new TelegramCustodyStore({
+				agentDir: abaAgentDir,
+				fs: fakeFs,
+				now: () => 2,
+				fence: { binding: secondBinding },
+			});
+			await secondStore.load();
+			expect(await secondStore.claimDeletion({ chatId: "42", topicId: "77" })).toMatchObject({
+				ok: true,
+				status: "claimed",
+				record: { custodyEpoch: secondBinding.custodyEpoch },
+			});
+
+			await allocateTelegramCustodyEpoch({ agentDir: abaAgentDir, ownerId: "owner-a" });
+			const beforeStaleSettle = fakeFs.files.get(custodyPath);
+			const recordsBeforeStaleSettle = secondStore.list();
+			const writesBeforeStaleSettle = fakeFs.writeCalls.length;
+			expect(
+				await secondStore.settleDeletion({
+					chatId: "42",
+					topicId: "77",
+					diagnostic: { kind: "telegram_ok" },
+				}),
+			).toEqual({ ok: false, reason: "fenced" });
+			expect(await secondStore.removeConfirmed({ chatId: "42", topicId: "77" })).toEqual({
+				ok: false,
+				reason: "fenced",
+			});
+			expect(fakeFs.files.get(custodyPath)).toBe(beforeStaleSettle);
+			expect(secondStore.list()).toEqual(recordsBeforeStaleSettle);
+			expect(fakeFs.writeCalls).toHaveLength(writesBeforeStaleSettle);
+		} finally {
+			await fsPromises.rm(abaAgentDir, { recursive: true, force: true });
+		}
+	});
+
+	test("keeps memory and disk unchanged when guarded queue, claim, settlement, or removal persistence fails", async () => {
+		const agentDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "gjc-telegram-custody-store-"));
+		try {
+			const fakeFs = new FakeFs();
+			const { store } = await fencedStoreWith(fakeFs, agentDir);
+			const custodyPath = dynamicCustodyPath(agentDir);
+			await store.load();
+
+			fakeFs.failWrite = true;
+			await expect(store.queueDeletion({ chatId: "42", topicId: "77", trigger: "session_closed" })).rejects.toThrow(
+				"simulated write failure",
+			);
+			expect(store.get({ chatId: "42", topicId: "77" })).toBeUndefined();
+			expect(fakeFs.files.get(custodyPath)).toBeUndefined();
+
+			fakeFs.failWrite = false;
+			await store.queueDeletion({ chatId: "42", topicId: "77", trigger: "session_closed" });
+			const beforeClaim = fakeFs.files.get(custodyPath);
+			fakeFs.failWrite = true;
+			await expect(store.claimDeletion({ chatId: "42", topicId: "77" })).rejects.toThrow("simulated write failure");
+			expect(store.get({ chatId: "42", topicId: "77" })?.state).toBe("queued");
+			expect(fakeFs.files.get(custodyPath)).toBe(beforeClaim);
+
+			fakeFs.failWrite = false;
+			await store.claimDeletion({ chatId: "42", topicId: "77" });
+			const beforeUnknown = fakeFs.files.get(custodyPath);
+			fakeFs.failWrite = true;
+			await expect(
+				store.settleDeletion({
+					chatId: "42",
+					topicId: "77",
+					diagnostic: { kind: "transport_ambiguous", transport: "timeout" },
+				}),
+			).rejects.toThrow("simulated write failure");
+			expect(store.get({ chatId: "42", topicId: "77" })?.state).toBe("in_flight");
+			expect(fakeFs.files.get(custodyPath)).toBe(beforeUnknown);
+
+			fakeFs.failWrite = false;
+			await store.queueDeletion({ chatId: "42", topicId: "78", trigger: "orphan_reap" });
+			await store.claimDeletion({ chatId: "42", topicId: "78" });
+			const beforeConfirmed = fakeFs.files.get(custodyPath);
+			fakeFs.failWrite = true;
+			await expect(
+				store.settleDeletion({
+					chatId: "42",
+					topicId: "78",
+					diagnostic: { kind: "telegram_ok" },
+				}),
+			).rejects.toThrow("simulated write failure");
+			expect(store.get({ chatId: "42", topicId: "78" })?.state).toBe("in_flight");
+			expect(fakeFs.files.get(custodyPath)).toBe(beforeConfirmed);
+
+			fakeFs.failWrite = false;
+			await store.settleDeletion({ chatId: "42", topicId: "78", diagnostic: { kind: "telegram_ok" } });
+			const beforeRemoval = fakeFs.files.get(custodyPath);
+			fakeFs.failWrite = true;
+			await expect(store.removeConfirmed({ chatId: "42", topicId: "78" })).rejects.toThrow(
+				"simulated write failure",
+			);
+			expect(store.get({ chatId: "42", topicId: "78" })?.state).toBe("confirmed");
+			expect(fakeFs.files.get(custodyPath)).toBe(beforeRemoval);
+		} finally {
+			await fsPromises.rm(agentDir, { recursive: true, force: true });
+		}
+	});
+
+	test("permits a newer current epoch to perform confirmed local-only cleanup", async () => {
+		const agentDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "gjc-telegram-custody-store-"));
+		try {
+			const fakeFs = new FakeFs();
+			const { store: firstStore } = await fencedStoreWith(fakeFs, agentDir);
+			await firstStore.load();
+			await firstStore.queueDeletion({ chatId: "42", topicId: "77", trigger: "session_closed" });
+			await firstStore.claimDeletion({ chatId: "42", topicId: "77" });
+			await firstStore.settleDeletion({ chatId: "42", topicId: "77", diagnostic: { kind: "telegram_ok" } });
+
+			const secondBinding = await allocateTelegramCustodyEpoch({ agentDir, ownerId: "owner-a" });
+			const secondStore = new TelegramCustodyStore({
+				agentDir,
+				fs: fakeFs,
+				now: () => 1,
+				fence: { binding: secondBinding },
+			});
+			await secondStore.load();
+			expect(await secondStore.claimDeletion({ chatId: "42", topicId: "77" })).toMatchObject({
+				ok: true,
+				status: "blocked",
+				record: { state: "confirmed" },
+			});
+			expect(await secondStore.removeConfirmed({ chatId: "42", topicId: "77" })).toEqual({ ok: true });
+			expect(secondStore.get({ chatId: "42", topicId: "77" })).toBeUndefined();
+		} finally {
+			await fsPromises.rm(agentDir, { recursive: true, force: true });
+		}
+	});
+	test("requires a positive active fence for new deletion mutations", async () => {
+		const fakeFs = new FakeFs();
+		const store = storeWith(fakeFs);
+		await store.load();
+		expect(await store.queueDeletion({ chatId: "42", topicId: "77", trigger: "session_closed" })).toEqual({
+			ok: false,
+			reason: "fenced",
+		});
+		expect(await store.claimDeletion({ chatId: "42", topicId: "77" })).toEqual({ ok: false, reason: "fenced" });
+		expect(
+			await store.settleDeletion({
+				chatId: "42",
+				topicId: "77",
+				diagnostic: { kind: "telegram_ok" },
+			}),
+		).toEqual({ ok: false, reason: "fenced" });
+		expect(fakeFs.writeCalls).toHaveLength(0);
 	});
 	test("stamps active fence epochs and leaves stale or mismatched writes unchanged", async () => {
 		const agentDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "gjc-telegram-custody-store-"));

--- a/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.test.ts
@@ -35,10 +35,22 @@ class FakeFs implements TelegramCustodyStoreFs {
 	readonly writeCalls: { path: string; data: string; mode: number | undefined }[] = [];
 	readonly renameCalls: { from: string; to: string }[] = [];
 	readonly unlinkCalls: string[] = [];
+	readonly openCalls: { path: string; flags: string }[] = [];
+	readonly operations: string[] = [];
 	failRename = false;
 	failWrite = false;
+	failOpenAt: number | undefined;
+	failOpenCode: string | undefined;
+	failSyncAt: number | undefined;
+	failSyncCode: string | undefined;
+	failCloseAt: number | undefined;
+	failCloseCode: string | undefined;
+	#openCount = 0;
+	#syncCount = 0;
+	#closeCount = 0;
 
 	async mkdir(file: string, options?: fs.MakeDirectoryOptions): Promise<undefined> {
+		this.operations.push("mkdir");
 		this.mkdirCalls.push({ path: file, mode: numericMode(options?.mode) });
 		return undefined;
 	}
@@ -50,16 +62,19 @@ class FakeFs implements TelegramCustodyStoreFs {
 	}
 
 	async writeFile(file: string, data: string, options?: fs.WriteFileOptions): Promise<void> {
+		this.operations.push("write");
 		this.writeCalls.push({ path: file, data, mode: writeMode(options) });
 		if (this.failWrite) throw new Error("simulated write failure");
 		this.files.set(file, data);
 	}
 
 	async chmod(file: string, mode: number): Promise<void> {
+		this.operations.push("chmod");
 		this.chmodCalls.push({ path: file, mode });
 	}
 
 	async rename(from: string, to: string): Promise<void> {
+		this.operations.push("rename");
 		this.renameCalls.push({ from, to });
 		if (this.failRename) throw new Error("simulated rename failure");
 		const contents = this.files.get(from);
@@ -69,8 +84,36 @@ class FakeFs implements TelegramCustodyStoreFs {
 	}
 
 	async unlink(file: string): Promise<void> {
+		this.operations.push("unlink");
 		this.unlinkCalls.push(file);
 		this.files.delete(file);
+	}
+
+	async open(file: string, flags: string, _mode?: number): Promise<{ sync(): Promise<void>; close(): Promise<void> }> {
+		this.operations.push(`open:${flags}`);
+		this.openCalls.push({ path: file, flags });
+		this.#openCount++;
+		if (this.failOpenAt === this.#openCount) throw this.#failure("simulated open failure", this.failOpenCode);
+		return {
+			sync: async () => {
+				this.operations.push("sync");
+				this.#syncCount++;
+				if (this.failSyncAt === this.#syncCount) {
+					throw this.#failure("simulated sync failure", this.failSyncCode);
+				}
+			},
+			close: async () => {
+				this.operations.push("close");
+				this.#closeCount++;
+				if (this.failCloseAt === this.#closeCount) {
+					throw this.#failure("simulated close failure", this.failCloseCode);
+				}
+			},
+		};
+	}
+
+	#failure(message: string, code: string | undefined): Error {
+		return code === undefined ? new Error(message) : Object.assign(new Error(message), { code });
 	}
 }
 
@@ -519,6 +562,28 @@ describe("TelegramCustodyStore", () => {
 		expect(fakeFs.writeCalls[0]?.mode).toBe(0o600);
 		expect(fakeFs.chmodCalls[1]?.mode).toBe(0o600);
 		expect(path.dirname(fakeFs.renameCalls[0]!.from)).toBe(path.dirname(fakeFs.renameCalls[0]!.to));
+		const temporaryFile = fakeFs.writeCalls[0]!.path;
+		expect(fakeFs.operations).toEqual([
+			"mkdir",
+			"chmod",
+			"write",
+			"chmod",
+			"open:r+",
+			"sync",
+			"close",
+			"rename",
+			"open:r+",
+			"sync",
+			"close",
+			"open:r",
+			"sync",
+			"close",
+		]);
+		expect(fakeFs.openCalls).toEqual([
+			{ path: temporaryFile, flags: "r+" },
+			{ path: CUSTODY_PATH, flags: "r+" },
+			{ path: daemonPaths(AGENT_DIR).dir, flags: "r" },
+		]);
 
 		const before = fakeFs.files.get(CUSTODY_PATH);
 		fakeFs.failWrite = true;
@@ -527,6 +592,91 @@ describe("TelegramCustodyStore", () => {
 		expect(fakeFs.files.get(CUSTODY_PATH)).toBe(before);
 		expect([...fakeFs.files.keys()].some(file => file.endsWith(".tmp"))).toBe(false);
 		expect(fakeFs.unlinkCalls).toHaveLength(1);
+	});
+	test("fails closed before rename when temporary durability barriers cannot open, sync, or close", async () => {
+		const failures = [
+			(fakeFs: FakeFs) => {
+				fakeFs.failOpenAt = 1;
+			},
+			(fakeFs: FakeFs) => {
+				fakeFs.failSyncAt = 1;
+			},
+			(fakeFs: FakeFs) => {
+				fakeFs.failCloseAt = 1;
+			},
+		];
+
+		for (const configureFailure of failures) {
+			const fakeFs = new FakeFs();
+			const source = JSON.stringify({
+				version: TELEGRAM_CUSTODY_SCHEMA_VERSION,
+				records: { [telegramCustodyKey("42", "77")]: custodyRecord() },
+			});
+			fakeFs.files.set(CUSTODY_PATH, source);
+			const store = storeWith(fakeFs);
+			expect(await store.load()).toEqual({
+				mode: "writable",
+				migrated: false,
+				records: [custodyRecord()],
+			});
+
+			configureFailure(fakeFs);
+			await expect(store.put(custodyRecord({ topicId: "8" }))).rejects.toThrow("simulated");
+			expect(store.list()).toEqual([custodyRecord()]);
+			expect(fakeFs.files.get(CUSTODY_PATH)).toBe(source);
+			expect(fakeFs.renameCalls).toEqual([]);
+			expect([...fakeFs.files.keys()].some(file => file.endsWith(".tmp"))).toBe(false);
+		}
+	});
+
+	test("does not promote memory after installed-file or supported parent-directory durability failures", async () => {
+		const failures = [
+			(fakeFs: FakeFs) => {
+				fakeFs.failSyncAt = 2;
+			},
+			(fakeFs: FakeFs) => {
+				fakeFs.failSyncAt = 2;
+				fakeFs.failSyncCode = "EPERM";
+			},
+			(fakeFs: FakeFs) => {
+				fakeFs.failCloseAt = 2;
+			},
+			(fakeFs: FakeFs) => {
+				fakeFs.failOpenAt = 3;
+			},
+			(fakeFs: FakeFs) => {
+				fakeFs.failSyncAt = 3;
+			},
+			(fakeFs: FakeFs) => {
+				fakeFs.failCloseAt = 3;
+			},
+		];
+
+		for (const configureFailure of failures) {
+			const fakeFs = new FakeFs();
+			const store = storeWith(fakeFs);
+			await store.load();
+			configureFailure(fakeFs);
+
+			await expect(store.put(custodyRecord())).rejects.toThrow("simulated");
+			expect(store.list()).toEqual([]);
+			expect(fakeFs.renameCalls).toHaveLength(1);
+			expect(fakeFs.files.get(CUSTODY_PATH)).toBe(fakeFs.writeCalls[0]?.data);
+			expect([...fakeFs.files.keys()].some(file => file.endsWith(".tmp"))).toBe(false);
+		}
+	});
+
+	test("continues after a documented unsupported parent-directory sync error", async () => {
+		const fakeFs = new FakeFs();
+		fakeFs.failSyncAt = 3;
+		fakeFs.failSyncCode = "ENOTSUP";
+		const store = storeWith(fakeFs);
+		await store.load();
+
+		expect(await store.put(custodyRecord())).toEqual({ ok: true });
+		expect(store.get({ chatId: "42", topicId: "77" })).toEqual(custodyRecord());
+		expect(serialized(fakeFs).records["42:77"]).toEqual(custodyRecord());
+		expect(fakeFs.openCalls.map(call => call.flags)).toEqual(["r+", "r+", "r"]);
 	});
 
 	test("serializes overlapping puts and removes and returns copies from read APIs", async () => {

--- a/packages/coding-agent/src/notifications/telegram-custody-store.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.ts
@@ -1,0 +1,484 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { daemonPaths } from "./daemon-paths";
+
+export const TELEGRAM_CUSTODY_SCHEMA_VERSION = 2;
+export const TELEGRAM_CUSTODY_MAX_RECORDS = 1_000;
+export const TELEGRAM_CUSTODY_MAX_FILE_BYTES = 1_048_576;
+
+export type TelegramCustodyState = "queued" | "in_flight" | "unknown";
+
+export interface TelegramCustodyRecord {
+	chatId: string;
+	topicId: string;
+	state: TelegramCustodyState;
+	updatedAt: number;
+	custodyEpoch?: number;
+}
+
+export type TelegramCustodyReadOnlyReason = "corrupt" | "forward_version" | "bounds" | "migration_write_failed";
+
+export interface TelegramCustodyLoadResult {
+	mode: "writable" | "read_only";
+	reason?: TelegramCustodyReadOnlyReason;
+	migrated: boolean;
+	records: readonly TelegramCustodyRecord[];
+}
+
+export type TelegramCustodyWriteResult = { ok: true } | { ok: false; reason: "read_only" };
+
+export interface TelegramCustodyStoreFs {
+	mkdir(path: string, opts?: fs.MakeDirectoryOptions): Promise<unknown>;
+	readFile(path: string, encoding: BufferEncoding): Promise<string>;
+	writeFile(path: string, data: string, opts?: fs.WriteFileOptions): Promise<void>;
+	rename(oldPath: string, newPath: string): Promise<void>;
+	chmod(path: string, mode: number): Promise<void>;
+	unlink(path: string): Promise<void>;
+}
+
+const CUSTODY_FILENAME = "telegram-deletion-custody.json";
+const nodeFs: TelegramCustodyStoreFs = fs.promises as unknown as TelegramCustodyStoreFs;
+
+type StoreMode = "writable" | "read_only";
+
+type ParseResult<T> = { ok: true; value: T } | { ok: false; reason: "corrupt" | "bounds" };
+
+interface TelegramCustodyV1Record {
+	state: TelegramCustodyState;
+	updatedAt: number;
+	custodyEpoch?: number;
+}
+
+interface TelegramCustodyV1Snapshot {
+	chatId: string;
+	records: TelegramCustodyRecord[];
+}
+
+interface ParsedV2Snapshot {
+	records: TelegramCustodyRecord[];
+	hasInFlight: boolean;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function hasExactKeys(
+	value: Record<string, unknown>,
+	required: readonly string[],
+	optional: readonly string[] = [],
+): boolean {
+	const keys = Object.keys(value);
+	if (keys.length < required.length || keys.length > required.length + optional.length) return false;
+	return (
+		required.every(key => Object.hasOwn(value, key)) &&
+		keys.every(key => required.includes(key) || optional.includes(key))
+	);
+}
+
+function isCanonicalChatId(value: unknown): value is string {
+	return typeof value === "string" && value.length >= 1 && value.length <= 32 && /^-?[1-9]\d*$/.test(value);
+}
+
+function isCanonicalTopicId(value: unknown): value is string {
+	return typeof value === "string" && value.length <= 20 && /^[1-9]\d*$/.test(value);
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isTelegramCustodyState(value: unknown): value is TelegramCustodyState {
+	return value === "queued" || value === "in_flight" || value === "unknown";
+}
+
+function compareKeys(left: string, right: string): number {
+	if (left < right) return -1;
+	if (left > right) return 1;
+	return 0;
+}
+
+function cloneRecord(record: TelegramCustodyRecord): TelegramCustodyRecord {
+	return record.custodyEpoch === undefined
+		? {
+				chatId: record.chatId,
+				topicId: record.topicId,
+				state: record.state,
+				updatedAt: record.updatedAt,
+			}
+		: {
+				chatId: record.chatId,
+				topicId: record.topicId,
+				state: record.state,
+				updatedAt: record.updatedAt,
+				custodyEpoch: record.custodyEpoch,
+			};
+}
+
+function cloneRecords(records: Iterable<TelegramCustodyRecord>): TelegramCustodyRecord[] {
+	return Array.from(records, cloneRecord);
+}
+
+function readRecord(value: unknown): TelegramCustodyRecord | undefined {
+	if (!isPlainObject(value) || !hasExactKeys(value, ["chatId", "topicId", "state", "updatedAt"], ["custodyEpoch"])) {
+		return undefined;
+	}
+	if (
+		!isCanonicalChatId(value.chatId) ||
+		!isCanonicalTopicId(value.topicId) ||
+		!isTelegramCustodyState(value.state) ||
+		!isNonNegativeSafeInteger(value.updatedAt)
+	) {
+		return undefined;
+	}
+	if (!Object.hasOwn(value, "custodyEpoch")) {
+		return { chatId: value.chatId, topicId: value.topicId, state: value.state, updatedAt: value.updatedAt };
+	}
+	if (!isNonNegativeSafeInteger(value.custodyEpoch)) return undefined;
+	return {
+		chatId: value.chatId,
+		topicId: value.topicId,
+		state: value.state,
+		updatedAt: value.updatedAt,
+		custodyEpoch: value.custodyEpoch,
+	};
+}
+
+function readV1Record(value: unknown): TelegramCustodyV1Record | undefined {
+	if (!isPlainObject(value) || !hasExactKeys(value, ["state", "updatedAt"], ["custodyEpoch"])) return undefined;
+	if (!isTelegramCustodyState(value.state) || !isNonNegativeSafeInteger(value.updatedAt)) return undefined;
+	if (!Object.hasOwn(value, "custodyEpoch")) return { state: value.state, updatedAt: value.updatedAt };
+	if (!isNonNegativeSafeInteger(value.custodyEpoch)) return undefined;
+	return { state: value.state, updatedAt: value.updatedAt, custodyEpoch: value.custodyEpoch };
+}
+
+/** Validate decimal-only ID segments and form their unambiguous composite storage key. */
+export function telegramCustodyKey(chatId: string, topicId: string): string {
+	if (!isCanonicalChatId(chatId) || !isCanonicalTopicId(topicId)) {
+		throw new Error("Invalid Telegram custody identifier");
+	}
+	return `${chatId}:${topicId}`;
+}
+
+function parseV2(value: unknown): ParseResult<ParsedV2Snapshot> {
+	if (
+		!isPlainObject(value) ||
+		!hasExactKeys(value, ["version", "records"]) ||
+		value.version !== TELEGRAM_CUSTODY_SCHEMA_VERSION
+	) {
+		return { ok: false, reason: "corrupt" };
+	}
+	if (!isPlainObject(value.records)) return { ok: false, reason: "corrupt" };
+
+	const entries = Object.entries(value.records);
+	if (entries.length > TELEGRAM_CUSTODY_MAX_RECORDS) return { ok: false, reason: "bounds" };
+
+	const records: TelegramCustodyRecord[] = [];
+	let hasInFlight = false;
+	for (const [key, rawRecord] of entries) {
+		const record = readRecord(rawRecord);
+		if (!record) return { ok: false, reason: "corrupt" };
+		if (key !== telegramCustodyKey(record.chatId, record.topicId)) return { ok: false, reason: "corrupt" };
+		records.push(record);
+		hasInFlight ||= record.state === "in_flight";
+	}
+	return {
+		ok: true,
+		value: {
+			records: records.sort((left, right) =>
+				compareKeys(telegramCustodyKey(left.chatId, left.topicId), telegramCustodyKey(right.chatId, right.topicId)),
+			),
+			hasInFlight,
+		},
+	};
+}
+
+function parseV1(value: unknown): ParseResult<TelegramCustodyV1Snapshot> {
+	if (!isPlainObject(value) || !hasExactKeys(value, ["version", "chatId", "records"]) || value.version !== 1) {
+		return { ok: false, reason: "corrupt" };
+	}
+	if (!isCanonicalChatId(value.chatId) || !isPlainObject(value.records)) return { ok: false, reason: "corrupt" };
+
+	const entries = Object.entries(value.records);
+	if (entries.length > TELEGRAM_CUSTODY_MAX_RECORDS) return { ok: false, reason: "bounds" };
+
+	const records: TelegramCustodyRecord[] = [];
+	for (const [topicId, rawRecord] of entries) {
+		if (!isCanonicalTopicId(topicId)) return { ok: false, reason: "corrupt" };
+		const record = readV1Record(rawRecord);
+		if (!record) return { ok: false, reason: "corrupt" };
+		records.push(
+			record.custodyEpoch === undefined
+				? {
+						chatId: value.chatId,
+						topicId,
+						state: record.state === "in_flight" ? "unknown" : record.state,
+						updatedAt: record.updatedAt,
+					}
+				: {
+						chatId: value.chatId,
+						topicId,
+						state: record.state === "in_flight" ? "unknown" : record.state,
+						updatedAt: record.updatedAt,
+						custodyEpoch: record.custodyEpoch,
+					},
+		);
+	}
+	return { ok: true, value: { chatId: value.chatId, records } };
+}
+
+function classifyV2Records(records: readonly TelegramCustodyRecord[]): TelegramCustodyRecord[] {
+	return records.map(record =>
+		record.state === "in_flight" ? { ...cloneRecord(record), state: "unknown" } : cloneRecord(record),
+	);
+}
+
+function canonicalRecordsObject(records: Iterable<TelegramCustodyRecord>): Record<string, TelegramCustodyRecord> {
+	const entries = Array.from(
+		records,
+		record => [telegramCustodyKey(record.chatId, record.topicId), cloneRecord(record)] as const,
+	).sort((left, right) => compareKeys(left[0], right[0]));
+	return Object.fromEntries(entries);
+}
+
+function serialize(records: Iterable<TelegramCustodyRecord>): string {
+	return `${JSON.stringify(
+		{ version: TELEGRAM_CUSTODY_SCHEMA_VERSION, records: canonicalRecordsObject(records) },
+		null,
+		2,
+	)}\n`;
+}
+
+function findStringEnd(source: string, start: number): number | undefined {
+	for (let position = start + 1; position < source.length; position++) {
+		const character = source[position];
+		if (character === "\\") {
+			position++;
+			continue;
+		}
+		if (character === '"') return position + 1;
+	}
+	return undefined;
+}
+
+/** JSON.parse intentionally accepts duplicate object members; custody files do not. */
+function hasDuplicateObjectKeys(source: string): boolean {
+	function skipWhitespace(position: number): number {
+		while (/\s/.test(source[position] ?? "")) position++;
+		return position;
+	}
+
+	function scanString(position: number): { value: string; end: number } | undefined {
+		const end = findStringEnd(source, position);
+		if (end === undefined) return undefined;
+		try {
+			return { value: JSON.parse(source.slice(position, end)) as string, end };
+		} catch {
+			return undefined;
+		}
+	}
+
+	function scanValue(position: number): number | undefined {
+		position = skipWhitespace(position);
+		const character = source[position];
+		if (character === '"') return scanString(position)?.end;
+		if (character === "{") {
+			position = skipWhitespace(position + 1);
+			const keys = new Set<string>();
+			if (source[position] === "}") return position + 1;
+			while (true) {
+				if (source[position] !== '"') return undefined;
+				const key = scanString(position);
+				if (!key || keys.has(key.value)) return undefined;
+				keys.add(key.value);
+				position = skipWhitespace(key.end);
+				if (source[position] !== ":") return undefined;
+				const valueEnd = scanValue(position + 1);
+				if (valueEnd === undefined) return undefined;
+				position = skipWhitespace(valueEnd);
+				if (source[position] === "}") return position + 1;
+				if (source[position] !== ",") return undefined;
+				position = skipWhitespace(position + 1);
+			}
+		}
+		if (character === "[") {
+			position = skipWhitespace(position + 1);
+			if (source[position] === "]") return position + 1;
+			while (true) {
+				const valueEnd = scanValue(position);
+				if (valueEnd === undefined) return undefined;
+				position = skipWhitespace(valueEnd);
+				if (source[position] === "]") return position + 1;
+				if (source[position] !== ",") return undefined;
+				position = skipWhitespace(position + 1);
+			}
+		}
+		while (position < source.length && !/[\s,}\]]/.test(source[position]!)) position++;
+		return position;
+	}
+
+	const end = scanValue(0);
+	return end === undefined || skipWhitespace(end) !== source.length;
+}
+
+export class TelegramCustodyStore {
+	readonly #dir: string;
+	readonly #file: string;
+	readonly #fsImpl: TelegramCustodyStoreFs;
+	readonly #now: () => number;
+	#mode: StoreMode = "writable";
+	#records = new Map<string, TelegramCustodyRecord>();
+	#operations: Promise<void> = Promise.resolve();
+
+	constructor(input: { agentDir: string; fs?: TelegramCustodyStoreFs; now?: () => number }) {
+		this.#dir = daemonPaths(input.agentDir).dir;
+		this.#file = path.join(this.#dir, CUSTODY_FILENAME);
+		this.#fsImpl = input.fs ?? nodeFs;
+		this.#now = input.now ?? Date.now;
+	}
+
+	async load(): Promise<TelegramCustodyLoadResult> {
+		return this.#serializeOperation<TelegramCustodyLoadResult>(async () => this.#load());
+	}
+
+	list(): readonly TelegramCustodyRecord[] {
+		return cloneRecords(this.#records.values()).sort((left, right) =>
+			compareKeys(telegramCustodyKey(left.chatId, left.topicId), telegramCustodyKey(right.chatId, right.topicId)),
+		);
+	}
+
+	get(input: { chatId: string; topicId: string }): TelegramCustodyRecord | undefined {
+		const record = this.#records.get(telegramCustodyKey(input.chatId, input.topicId));
+		return record === undefined ? undefined : cloneRecord(record);
+	}
+
+	async put(record: TelegramCustodyRecord): Promise<TelegramCustodyWriteResult> {
+		const validated = readRecord(record);
+		if (!validated) throw new Error("Invalid Telegram custody record");
+		const copy = cloneRecord(validated);
+		return this.#serializeOperation<TelegramCustodyWriteResult>(async () => {
+			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
+			const next = new Map(this.#records);
+			next.set(telegramCustodyKey(copy.chatId, copy.topicId), copy);
+			if (next.size > TELEGRAM_CUSTODY_MAX_RECORDS) throw new Error("Telegram custody record limit exceeded");
+			await this.#persist(next.values());
+			this.#records = next;
+			return { ok: true };
+		});
+	}
+
+	async remove(input: { chatId: string; topicId: string }): Promise<TelegramCustodyWriteResult> {
+		const key = telegramCustodyKey(input.chatId, input.topicId);
+		return this.#serializeOperation<TelegramCustodyWriteResult>(async () => {
+			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
+			const next = new Map(this.#records);
+			next.delete(key);
+			await this.#persist(next.values());
+			this.#records = next;
+			return { ok: true };
+		});
+	}
+
+	async #load(): Promise<TelegramCustodyLoadResult> {
+		let source: string;
+		try {
+			source = await this.#fsImpl.readFile(this.#file, "utf8");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			this.#mode = "writable";
+			this.#records = new Map();
+			return { mode: "writable", migrated: false, records: [] };
+		}
+
+		if (Buffer.byteLength(source, "utf8") > TELEGRAM_CUSTODY_MAX_FILE_BYTES) return this.#readOnly("bounds", []);
+
+		let document: unknown;
+		try {
+			if (hasDuplicateObjectKeys(source)) return this.#readOnly("corrupt", []);
+			document = JSON.parse(source) as unknown;
+		} catch {
+			return this.#readOnly("corrupt", []);
+		}
+
+		if (
+			isPlainObject(document) &&
+			typeof document.version === "number" &&
+			document.version > TELEGRAM_CUSTODY_SCHEMA_VERSION
+		) {
+			return this.#readOnly("forward_version", []);
+		}
+
+		const v2 = parseV2(document);
+		if (v2.ok) {
+			const records = classifyV2Records(v2.value.records);
+			if (v2.value.hasInFlight) {
+				try {
+					await this.#persist(records);
+				} catch {
+					return this.#readOnly("migration_write_failed", records);
+				}
+			}
+			this.#mode = "writable";
+			this.#setRecords(records);
+			return { mode: "writable", migrated: false, records: this.list() };
+		}
+
+		const v1 = parseV1(document);
+		if (!v1.ok) return this.#readOnly(v2.reason === "bounds" || v1.reason === "bounds" ? "bounds" : "corrupt", []);
+
+		try {
+			await this.#persist(v1.value.records);
+		} catch {
+			return this.#readOnly("migration_write_failed", v1.value.records);
+		}
+		this.#mode = "writable";
+		this.#setRecords(v1.value.records);
+		return { mode: "writable", migrated: true, records: this.list() };
+	}
+
+	#readOnly(
+		reason: TelegramCustodyReadOnlyReason,
+		records: readonly TelegramCustodyRecord[],
+	): TelegramCustodyLoadResult {
+		this.#mode = "read_only";
+		this.#setRecords(records);
+		return { mode: "read_only", reason, migrated: false, records: this.list() };
+	}
+
+	#setRecords(records: Iterable<TelegramCustodyRecord>): void {
+		this.#records = new Map(
+			Array.from(
+				records,
+				record => [telegramCustodyKey(record.chatId, record.topicId), cloneRecord(record)] as const,
+			),
+		);
+	}
+
+	async #persist(records: Iterable<TelegramCustodyRecord>): Promise<void> {
+		const data = serialize(records);
+		if (Buffer.byteLength(data, "utf8") > TELEGRAM_CUSTODY_MAX_FILE_BYTES) {
+			throw new Error("Telegram custody snapshot exceeds the maximum file size");
+		}
+
+		await this.#fsImpl.mkdir(this.#dir, { recursive: true, mode: 0o700 });
+		await this.#fsImpl.chmod(this.#dir, 0o700);
+		const temporaryFile = `${this.#file}.${process.pid}.${this.#now()}.${Math.random().toString(36).slice(2)}.tmp`;
+		try {
+			await this.#fsImpl.writeFile(temporaryFile, data, { mode: 0o600 });
+			await this.#fsImpl.chmod(temporaryFile, 0o600);
+			await this.#fsImpl.rename(temporaryFile, this.#file);
+		} catch (error) {
+			await this.#fsImpl.unlink(temporaryFile).catch(() => undefined);
+			throw error;
+		}
+	}
+
+	async #serializeOperation<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.#operations.then(operation, operation);
+		this.#operations = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	}
+}

--- a/packages/coding-agent/src/notifications/telegram-custody-store.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.ts
@@ -1,11 +1,11 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { daemonPaths } from "./daemon-paths";
 import {
 	type TelegramCustodyEpochBinding,
 	type TelegramCustodyEpochFs,
 	withCurrentTelegramCustodyEpoch,
 } from "./telegram-custody-epoch";
-import { daemonPaths } from "./daemon-paths";
 
 export const TELEGRAM_CUSTODY_SCHEMA_VERSION = 2;
 export const TELEGRAM_CUSTODY_MAX_RECORDS = 1_000;

--- a/packages/coding-agent/src/notifications/telegram-custody-store.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.ts
@@ -7,11 +7,21 @@ import {
 	withCurrentTelegramCustodyEpoch,
 } from "./telegram-custody-epoch";
 
-export const TELEGRAM_CUSTODY_SCHEMA_VERSION = 2;
+export const TELEGRAM_CUSTODY_SCHEMA_VERSION = 3;
 export const TELEGRAM_CUSTODY_MAX_RECORDS = 1_000;
 export const TELEGRAM_CUSTODY_MAX_FILE_BYTES = 1_048_576;
 
-export type TelegramCustodyState = "queued" | "in_flight" | "unknown";
+export type TelegramCustodyState = "queued" | "in_flight" | "confirmed" | "unknown";
+export type TelegramDeletionTrigger = "session_closed" | "orphan_reap";
+export type TelegramTransportDiagnostic = "connection_reset" | "timeout" | "aborted" | "network" | "other";
+export type TelegramRejectionClass = "not_found" | "forbidden" | "rate_limited" | "server_error" | "other";
+export type TelegramCustodyDiagnostic =
+	| { kind: "telegram_ok" }
+	| { kind: "telegram_rejected"; rejection: TelegramRejectionClass; errorCode?: number }
+	| { kind: "malformed_response" }
+	| { kind: "transport_ambiguous"; transport: TelegramTransportDiagnostic }
+	| { kind: "restart_after_claim" }
+	| { kind: "legacy_unknown" };
 
 export interface TelegramCustodyRecord {
 	chatId: string;
@@ -19,6 +29,8 @@ export interface TelegramCustodyRecord {
 	state: TelegramCustodyState;
 	updatedAt: number;
 	custodyEpoch?: number;
+	trigger?: TelegramDeletionTrigger;
+	diagnostic?: TelegramCustodyDiagnostic;
 }
 
 export type TelegramCustodyReadOnlyReason = "corrupt" | "forward_version" | "bounds" | "migration_write_failed";
@@ -30,7 +42,16 @@ export interface TelegramCustodyLoadResult {
 	records: readonly TelegramCustodyRecord[];
 }
 
-export type TelegramCustodyWriteResult = { ok: true } | { ok: false; reason: "read_only" | "fenced" };
+export type TelegramCustodyMutationFailure = { ok: false; reason: "read_only" | "fenced" };
+export type TelegramCustodyWriteResult = { ok: true } | TelegramCustodyMutationFailure;
+export type TelegramCustodyQueueResult =
+	| { ok: true; status: "queued"; record: TelegramCustodyRecord }
+	| { ok: true; status: "blocked"; record: TelegramCustodyRecord }
+	| TelegramCustodyMutationFailure;
+export type TelegramCustodyClaimResult =
+	| { ok: true; status: "claimed"; record: TelegramCustodyRecord }
+	| { ok: true; status: "blocked"; record: TelegramCustodyRecord }
+	| TelegramCustodyMutationFailure;
 
 export interface TelegramCustodyStoreFs {
 	mkdir(path: string, opts?: fs.MakeDirectoryOptions): Promise<unknown>;
@@ -45,21 +66,32 @@ const CUSTODY_FILENAME = "telegram-deletion-custody.json";
 const nodeFs: TelegramCustodyStoreFs = fs.promises as unknown as TelegramCustodyStoreFs;
 
 type StoreMode = "writable" | "read_only";
-
+type LegacyTelegramCustodyState = "queued" | "in_flight" | "unknown";
 type ParseResult<T> = { ok: true; value: T } | { ok: false; reason: "corrupt" | "bounds" };
 
 interface TelegramCustodyV1Record {
-	state: TelegramCustodyState;
+	state: LegacyTelegramCustodyState;
 	updatedAt: number;
 	custodyEpoch?: number;
 }
 
 interface TelegramCustodyV1Snapshot {
+	records: TelegramCustodyV2Record[];
+}
+
+interface TelegramCustodyV2Record {
 	chatId: string;
-	records: TelegramCustodyRecord[];
+	topicId: string;
+	state: LegacyTelegramCustodyState;
+	updatedAt: number;
+	custodyEpoch?: number;
 }
 
 interface ParsedV2Snapshot {
+	records: TelegramCustodyV2Record[];
+}
+
+interface ParsedV3Snapshot {
 	records: TelegramCustodyRecord[];
 	hasInFlight: boolean;
 }
@@ -92,9 +124,44 @@ function isCanonicalTopicId(value: unknown): value is string {
 function isNonNegativeSafeInteger(value: unknown): value is number {
 	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
+function isSafeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value);
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
 
 function isTelegramCustodyState(value: unknown): value is TelegramCustodyState {
+	return value === "queued" || value === "in_flight" || value === "confirmed" || value === "unknown";
+}
+
+function isLegacyTelegramCustodyState(value: unknown): value is LegacyTelegramCustodyState {
 	return value === "queued" || value === "in_flight" || value === "unknown";
+}
+
+function isTelegramDeletionTrigger(value: unknown): value is TelegramDeletionTrigger {
+	return value === "session_closed" || value === "orphan_reap";
+}
+
+function isTelegramTransportDiagnostic(value: unknown): value is TelegramTransportDiagnostic {
+	return (
+		value === "connection_reset" ||
+		value === "timeout" ||
+		value === "aborted" ||
+		value === "network" ||
+		value === "other"
+	);
+}
+
+function isTelegramRejectionClass(value: unknown): value is TelegramRejectionClass {
+	return (
+		value === "not_found" ||
+		value === "forbidden" ||
+		value === "rate_limited" ||
+		value === "server_error" ||
+		value === "other"
+	);
 }
 
 function compareKeys(left: string, right: string): number {
@@ -103,35 +170,129 @@ function compareKeys(left: string, right: string): number {
 	return 0;
 }
 
+function cloneDiagnostic(diagnostic: TelegramCustodyDiagnostic): TelegramCustodyDiagnostic {
+	switch (diagnostic.kind) {
+		case "telegram_ok":
+		case "malformed_response":
+		case "restart_after_claim":
+		case "legacy_unknown":
+			return { kind: diagnostic.kind };
+		case "telegram_rejected":
+			return diagnostic.errorCode === undefined
+				? { kind: "telegram_rejected", rejection: diagnostic.rejection }
+				: { kind: "telegram_rejected", rejection: diagnostic.rejection, errorCode: diagnostic.errorCode };
+		case "transport_ambiguous":
+			return { kind: "transport_ambiguous", transport: diagnostic.transport };
+	}
+}
+
 function cloneRecord(record: TelegramCustodyRecord): TelegramCustodyRecord {
-	return record.custodyEpoch === undefined
-		? {
-				chatId: record.chatId,
-				topicId: record.topicId,
-				state: record.state,
-				updatedAt: record.updatedAt,
-			}
-		: {
-				chatId: record.chatId,
-				topicId: record.topicId,
-				state: record.state,
-				updatedAt: record.updatedAt,
-				custodyEpoch: record.custodyEpoch,
-			};
+	const copy: TelegramCustodyRecord = {
+		chatId: record.chatId,
+		topicId: record.topicId,
+		state: record.state,
+		updatedAt: record.updatedAt,
+	};
+	if (record.custodyEpoch !== undefined) copy.custodyEpoch = record.custodyEpoch;
+	if (record.trigger !== undefined) copy.trigger = record.trigger;
+	if (record.diagnostic !== undefined) copy.diagnostic = cloneDiagnostic(record.diagnostic);
+	return copy;
 }
 
 function cloneRecords(records: Iterable<TelegramCustodyRecord>): TelegramCustodyRecord[] {
 	return Array.from(records, cloneRecord);
 }
 
+function readDiagnostic(value: unknown): TelegramCustodyDiagnostic | undefined {
+	if (!isPlainObject(value) || typeof value.kind !== "string") return undefined;
+	switch (value.kind) {
+		case "telegram_ok":
+			return hasExactKeys(value, ["kind"]) ? { kind: "telegram_ok" } : undefined;
+		case "telegram_rejected":
+			if (!hasExactKeys(value, ["kind", "rejection"], ["errorCode"]) || !isTelegramRejectionClass(value.rejection)) {
+				return undefined;
+			}
+			if (!Object.hasOwn(value, "errorCode")) return { kind: "telegram_rejected", rejection: value.rejection };
+			if (!isSafeInteger(value.errorCode)) return undefined;
+			return { kind: "telegram_rejected", rejection: value.rejection, errorCode: value.errorCode };
+		case "malformed_response":
+			return hasExactKeys(value, ["kind"]) ? { kind: "malformed_response" } : undefined;
+		case "transport_ambiguous":
+			return hasExactKeys(value, ["kind", "transport"]) && isTelegramTransportDiagnostic(value.transport)
+				? { kind: "transport_ambiguous", transport: value.transport }
+				: undefined;
+		case "restart_after_claim":
+			return hasExactKeys(value, ["kind"]) ? { kind: "restart_after_claim" } : undefined;
+		case "legacy_unknown":
+			return hasExactKeys(value, ["kind"]) ? { kind: "legacy_unknown" } : undefined;
+		default:
+			return undefined;
+	}
+}
+
 function readRecord(value: unknown): TelegramCustodyRecord | undefined {
-	if (!isPlainObject(value) || !hasExactKeys(value, ["chatId", "topicId", "state", "updatedAt"], ["custodyEpoch"])) {
+	if (
+		!isPlainObject(value) ||
+		!hasExactKeys(value, ["chatId", "topicId", "state", "updatedAt"], ["custodyEpoch", "trigger", "diagnostic"])
+	) {
 		return undefined;
 	}
 	if (
 		!isCanonicalChatId(value.chatId) ||
 		!isCanonicalTopicId(value.topicId) ||
 		!isTelegramCustodyState(value.state) ||
+		!isNonNegativeSafeInteger(value.updatedAt)
+	) {
+		return undefined;
+	}
+	let custodyEpoch: number | undefined;
+	if (Object.hasOwn(value, "custodyEpoch")) {
+		if (!isNonNegativeSafeInteger(value.custodyEpoch)) return undefined;
+		custodyEpoch = value.custodyEpoch;
+	}
+	let trigger: TelegramDeletionTrigger | undefined;
+	if (Object.hasOwn(value, "trigger")) {
+		if (!isTelegramDeletionTrigger(value.trigger)) return undefined;
+		trigger = value.trigger;
+	}
+	const diagnostic = Object.hasOwn(value, "diagnostic") ? readDiagnostic(value.diagnostic) : undefined;
+	if (Object.hasOwn(value, "diagnostic") && diagnostic === undefined) return undefined;
+	if (value.state === "queued") {
+		if (diagnostic !== undefined) return undefined;
+	} else if (value.state === "in_flight") {
+		if (diagnostic !== undefined || !isPositiveSafeInteger(custodyEpoch)) return undefined;
+	} else if (value.state === "confirmed") {
+		if (diagnostic?.kind !== "telegram_ok" || !isPositiveSafeInteger(custodyEpoch)) return undefined;
+	} else if (
+		diagnostic === undefined ||
+		diagnostic.kind === "telegram_ok" ||
+		(diagnostic.kind !== "legacy_unknown" &&
+			diagnostic.kind !== "restart_after_claim" &&
+			!isPositiveSafeInteger(custodyEpoch))
+	) {
+		return undefined;
+	}
+
+	const record: TelegramCustodyRecord = {
+		chatId: value.chatId,
+		topicId: value.topicId,
+		state: value.state,
+		updatedAt: value.updatedAt,
+	};
+	if (custodyEpoch !== undefined) record.custodyEpoch = custodyEpoch;
+	if (trigger !== undefined) record.trigger = trigger;
+	if (diagnostic !== undefined) record.diagnostic = diagnostic;
+	return record;
+}
+
+function readV2Record(value: unknown): TelegramCustodyV2Record | undefined {
+	if (!isPlainObject(value) || !hasExactKeys(value, ["chatId", "topicId", "state", "updatedAt"], ["custodyEpoch"])) {
+		return undefined;
+	}
+	if (
+		!isCanonicalChatId(value.chatId) ||
+		!isCanonicalTopicId(value.topicId) ||
+		!isLegacyTelegramCustodyState(value.state) ||
 		!isNonNegativeSafeInteger(value.updatedAt)
 	) {
 		return undefined;
@@ -151,7 +312,7 @@ function readRecord(value: unknown): TelegramCustodyRecord | undefined {
 
 function readV1Record(value: unknown): TelegramCustodyV1Record | undefined {
 	if (!isPlainObject(value) || !hasExactKeys(value, ["state", "updatedAt"], ["custodyEpoch"])) return undefined;
-	if (!isTelegramCustodyState(value.state) || !isNonNegativeSafeInteger(value.updatedAt)) return undefined;
+	if (!isLegacyTelegramCustodyState(value.state) || !isNonNegativeSafeInteger(value.updatedAt)) return undefined;
 	if (!Object.hasOwn(value, "custodyEpoch")) return { state: value.state, updatedAt: value.updatedAt };
 	if (!isNonNegativeSafeInteger(value.custodyEpoch)) return undefined;
 	return { state: value.state, updatedAt: value.updatedAt, custodyEpoch: value.custodyEpoch };
@@ -165,12 +326,8 @@ export function telegramCustodyKey(chatId: string, topicId: string): string {
 	return `${chatId}:${topicId}`;
 }
 
-function parseV2(value: unknown): ParseResult<ParsedV2Snapshot> {
-	if (
-		!isPlainObject(value) ||
-		!hasExactKeys(value, ["version", "records"]) ||
-		value.version !== TELEGRAM_CUSTODY_SCHEMA_VERSION
-	) {
+function parseV3(value: unknown): ParseResult<ParsedV3Snapshot> {
+	if (!isPlainObject(value) || !hasExactKeys(value, ["version", "records"]) || value.version !== 3) {
 		return { ok: false, reason: "corrupt" };
 	}
 	if (!isPlainObject(value.records)) return { ok: false, reason: "corrupt" };
@@ -198,6 +355,32 @@ function parseV2(value: unknown): ParseResult<ParsedV2Snapshot> {
 	};
 }
 
+function parseV2(value: unknown): ParseResult<ParsedV2Snapshot> {
+	if (!isPlainObject(value) || !hasExactKeys(value, ["version", "records"]) || value.version !== 2) {
+		return { ok: false, reason: "corrupt" };
+	}
+	if (!isPlainObject(value.records)) return { ok: false, reason: "corrupt" };
+
+	const entries = Object.entries(value.records);
+	if (entries.length > TELEGRAM_CUSTODY_MAX_RECORDS) return { ok: false, reason: "bounds" };
+
+	const records: TelegramCustodyV2Record[] = [];
+	for (const [key, rawRecord] of entries) {
+		const record = readV2Record(rawRecord);
+		if (!record) return { ok: false, reason: "corrupt" };
+		if (key !== telegramCustodyKey(record.chatId, record.topicId)) return { ok: false, reason: "corrupt" };
+		records.push(record);
+	}
+	return {
+		ok: true,
+		value: {
+			records: records.sort((left, right) =>
+				compareKeys(telegramCustodyKey(left.chatId, left.topicId), telegramCustodyKey(right.chatId, right.topicId)),
+			),
+		},
+	};
+}
+
 function parseV1(value: unknown): ParseResult<TelegramCustodyV1Snapshot> {
 	if (!isPlainObject(value) || !hasExactKeys(value, ["version", "chatId", "records"]) || value.version !== 1) {
 		return { ok: false, reason: "corrupt" };
@@ -207,34 +390,34 @@ function parseV1(value: unknown): ParseResult<TelegramCustodyV1Snapshot> {
 	const entries = Object.entries(value.records);
 	if (entries.length > TELEGRAM_CUSTODY_MAX_RECORDS) return { ok: false, reason: "bounds" };
 
-	const records: TelegramCustodyRecord[] = [];
+	const records: TelegramCustodyV2Record[] = [];
 	for (const [topicId, rawRecord] of entries) {
 		if (!isCanonicalTopicId(topicId)) return { ok: false, reason: "corrupt" };
 		const record = readV1Record(rawRecord);
 		if (!record) return { ok: false, reason: "corrupt" };
-		records.push(
-			record.custodyEpoch === undefined
-				? {
-						chatId: value.chatId,
-						topicId,
-						state: record.state === "in_flight" ? "unknown" : record.state,
-						updatedAt: record.updatedAt,
-					}
-				: {
-						chatId: value.chatId,
-						topicId,
-						state: record.state === "in_flight" ? "unknown" : record.state,
-						updatedAt: record.updatedAt,
-						custodyEpoch: record.custodyEpoch,
-					},
-		);
+		records.push({ ...record, chatId: value.chatId, topicId });
 	}
-	return { ok: true, value: { chatId: value.chatId, records } };
+	return { ok: true, value: { records } };
 }
 
-function classifyV2Records(records: readonly TelegramCustodyRecord[]): TelegramCustodyRecord[] {
+function migrateLegacyRecord(record: TelegramCustodyV2Record): TelegramCustodyRecord {
+	const migrated: TelegramCustodyRecord = {
+		chatId: record.chatId,
+		topicId: record.topicId,
+		state: record.state === "queued" ? "queued" : "unknown",
+		updatedAt: record.updatedAt,
+	};
+	if (record.custodyEpoch !== undefined) migrated.custodyEpoch = record.custodyEpoch;
+	if (record.state === "in_flight") migrated.diagnostic = { kind: "restart_after_claim" };
+	if (record.state === "unknown") migrated.diagnostic = { kind: "legacy_unknown" };
+	return migrated;
+}
+
+function classifyV3Records(records: readonly TelegramCustodyRecord[]): TelegramCustodyRecord[] {
 	return records.map(record =>
-		record.state === "in_flight" ? { ...cloneRecord(record), state: "unknown" } : cloneRecord(record),
+		record.state === "in_flight"
+			? { ...cloneRecord(record), state: "unknown", diagnostic: { kind: "restart_after_claim" } }
+			: cloneRecord(record),
 	);
 }
 
@@ -410,6 +593,121 @@ export class TelegramCustodyStore {
 		});
 	}
 
+	async queueDeletion(input: {
+		chatId: string;
+		topicId: string;
+		trigger: TelegramDeletionTrigger;
+	}): Promise<TelegramCustodyQueueResult> {
+		const key = telegramCustodyKey(input.chatId, input.topicId);
+		if (!isTelegramDeletionTrigger(input.trigger)) throw new Error("Invalid Telegram deletion trigger");
+		return this.#serializeOperation<TelegramCustodyQueueResult>(async () => {
+			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
+			const existing = this.#records.get(key);
+			if (existing !== undefined && existing.state !== "queued") {
+				return { ok: true, status: "blocked", record: cloneRecord(existing) };
+			}
+			const custodyEpoch = this.#activeFenceEpoch();
+			if (custodyEpoch === undefined) return { ok: false, reason: "fenced" };
+			const record: TelegramCustodyRecord = {
+				chatId: input.chatId,
+				topicId: input.topicId,
+				state: "queued",
+				updatedAt: this.#timestamp(),
+				custodyEpoch,
+				trigger: input.trigger,
+			};
+			const next = new Map(this.#records);
+			next.set(key, record);
+			if (next.size > TELEGRAM_CUSTODY_MAX_RECORDS) throw new Error("Telegram custody record limit exceeded");
+			const persisted = await this.#persist(next.values());
+			if (!persisted.ok) return persisted;
+			this.#records = next;
+			return { ok: true, status: "queued", record: cloneRecord(record) };
+		});
+	}
+
+	async claimDeletion(input: { chatId: string; topicId: string }): Promise<TelegramCustodyClaimResult> {
+		const key = telegramCustodyKey(input.chatId, input.topicId);
+		return this.#serializeOperation<TelegramCustodyClaimResult>(async () => {
+			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
+			const existing = this.#records.get(key);
+			if (existing === undefined) return { ok: false, reason: "fenced" };
+			if (existing.state !== "queued") return { ok: true, status: "blocked", record: cloneRecord(existing) };
+			const custodyEpoch = this.#activeFenceEpoch();
+			if (custodyEpoch === undefined) return { ok: false, reason: "fenced" };
+			const record: TelegramCustodyRecord = {
+				chatId: existing.chatId,
+				topicId: existing.topicId,
+				state: "in_flight",
+				updatedAt: this.#timestamp(),
+				custodyEpoch,
+			};
+			if (existing.trigger !== undefined) record.trigger = existing.trigger;
+			const next = new Map(this.#records);
+			next.set(key, record);
+			const persisted = await this.#persist(next.values());
+			if (!persisted.ok) return persisted;
+			this.#records = next;
+			return { ok: true, status: "claimed", record: cloneRecord(record) };
+		});
+	}
+
+	async settleDeletion(input: {
+		chatId: string;
+		topicId: string;
+		diagnostic: TelegramCustodyDiagnostic;
+	}): Promise<TelegramCustodyWriteResult> {
+		const key = telegramCustodyKey(input.chatId, input.topicId);
+		const diagnostic = readDiagnostic(input.diagnostic);
+		if (diagnostic === undefined) throw new Error("Invalid Telegram custody diagnostic");
+		return this.#serializeOperation<TelegramCustodyWriteResult>(async () => {
+			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
+			const existing = this.#records.get(key);
+			const custodyEpoch = this.#activeFenceEpoch();
+			if (
+				existing === undefined ||
+				existing.state !== "in_flight" ||
+				custodyEpoch === undefined ||
+				existing.custodyEpoch !== custodyEpoch
+			) {
+				return { ok: false, reason: "fenced" };
+			}
+			const record: TelegramCustodyRecord = {
+				chatId: existing.chatId,
+				topicId: existing.topicId,
+				state: diagnostic.kind === "telegram_ok" ? "confirmed" : "unknown",
+				updatedAt: this.#timestamp(),
+				custodyEpoch,
+				diagnostic,
+			};
+			if (existing.trigger !== undefined) record.trigger = existing.trigger;
+			const next = new Map(this.#records);
+			next.set(key, record);
+			const persisted = await this.#persist(next.values());
+			if (!persisted.ok) return persisted;
+			this.#records = next;
+			return { ok: true };
+		});
+	}
+
+	async removeConfirmed(input: { chatId: string; topicId: string }): Promise<TelegramCustodyWriteResult> {
+		const key = telegramCustodyKey(input.chatId, input.topicId);
+		return this.#serializeOperation<TelegramCustodyWriteResult>(async () => {
+			const existing = this.#records.get(key);
+			if (existing === undefined) return { ok: true };
+			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
+			if (existing.state !== "confirmed" || this.#activeFenceEpoch() === undefined) {
+				return { ok: false, reason: "fenced" };
+			}
+			const next = new Map(this.#records);
+			next.delete(key);
+			const persisted = await this.#persist(next.values());
+			if (!persisted.ok) return persisted;
+			this.#records = next;
+			return { ok: true };
+		});
+	}
+
 	async #load(): Promise<TelegramCustodyLoadResult> {
 		let source: string;
 		try {
@@ -434,19 +732,18 @@ export class TelegramCustodyStore {
 		if (
 			isPlainObject(document) &&
 			typeof document.version === "number" &&
+			Number.isSafeInteger(document.version) &&
 			document.version > TELEGRAM_CUSTODY_SCHEMA_VERSION
 		) {
 			return this.#readOnly("forward_version", []);
 		}
 
-		const v2 = parseV2(document);
-		if (v2.ok) {
-			const records = classifyV2Records(v2.value.records);
-			if (v2.value.hasInFlight) {
+		const v3 = parseV3(document);
+		if (v3.ok) {
+			const records = classifyV3Records(v3.value.records);
+			if (v3.value.hasInFlight) {
 				try {
-					if (!(await this.#persist(records)).ok) {
-						return this.#readOnly("migration_write_failed", records);
-					}
+					if (!(await this.#persist(records)).ok) return this.#readOnly("migration_write_failed", records);
 				} catch {
 					return this.#readOnly("migration_write_failed", records);
 				}
@@ -456,19 +753,53 @@ export class TelegramCustodyStore {
 			return { mode: "writable", migrated: false, records: this.list() };
 		}
 
-		const v1 = parseV1(document);
-		if (!v1.ok) return this.#readOnly(v2.reason === "bounds" || v1.reason === "bounds" ? "bounds" : "corrupt", []);
-
-		try {
-			if (!(await this.#persist(v1.value.records)).ok) {
-				return this.#readOnly("migration_write_failed", v1.value.records);
+		const v2 = parseV2(document);
+		if (v2.ok) {
+			const records = v2.value.records.map(migrateLegacyRecord);
+			try {
+				if (!(await this.#persist(records)).ok) return this.#readOnly("migration_write_failed", records);
+			} catch {
+				return this.#readOnly("migration_write_failed", records);
 			}
+			this.#mode = "writable";
+			this.#setRecords(records);
+			return { mode: "writable", migrated: true, records: this.list() };
+		}
+
+		const v1 = parseV1(document);
+		if (!v1.ok) {
+			return this.#readOnly(
+				v3.reason === "bounds" || v2.reason === "bounds" || v1.reason === "bounds" ? "bounds" : "corrupt",
+				[],
+			);
+		}
+		const records = v1.value.records.map(migrateLegacyRecord);
+		try {
+			if (!(await this.#persist(records)).ok) return this.#readOnly("migration_write_failed", records);
 		} catch {
-			return this.#readOnly("migration_write_failed", v1.value.records);
+			return this.#readOnly("migration_write_failed", records);
 		}
 		this.#mode = "writable";
-		this.#setRecords(v1.value.records);
+		this.#setRecords(records);
 		return { mode: "writable", migrated: true, records: this.list() };
+	}
+
+	#activeFenceEpoch(): number | undefined {
+		if (
+			this.#fence === undefined ||
+			typeof this.#fence.binding.ownerId !== "string" ||
+			this.#fence.binding.ownerId.length === 0 ||
+			!isPositiveSafeInteger(this.#fence.binding.custodyEpoch)
+		) {
+			return undefined;
+		}
+		return this.#fence.binding.custodyEpoch;
+	}
+
+	#timestamp(): number {
+		const timestamp = this.#now();
+		if (!isNonNegativeSafeInteger(timestamp)) throw new Error("Invalid Telegram custody timestamp");
+		return timestamp;
 	}
 
 	#readOnly(

--- a/packages/coding-agent/src/notifications/telegram-custody-store.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.ts
@@ -60,10 +60,12 @@ export interface TelegramCustodyStoreFs {
 	rename(oldPath: string, newPath: string): Promise<void>;
 	chmod(path: string, mode: number): Promise<void>;
 	unlink(path: string): Promise<void>;
+	open(path: string, flags: string, mode?: number): Promise<{ sync(): Promise<void>; close(): Promise<void> }>;
 }
 
 const CUSTODY_FILENAME = "telegram-deletion-custody.json";
 const nodeFs: TelegramCustodyStoreFs = fs.promises as unknown as TelegramCustodyStoreFs;
+const UNSUPPORTED_DIRECTORY_SYNC_CODES = new Set(["EISDIR", "EINVAL", "ENOSYS", "ENOTSUP", "EPERM"]);
 
 type StoreMode = "writable" | "read_only";
 type LegacyTelegramCustodyState = "queued" | "in_flight" | "unknown";
@@ -508,6 +510,28 @@ function hasDuplicateObjectKeys(source: string): boolean {
 	const end = scanValue(0);
 	return end === undefined || skipWhitespace(end) !== source.length;
 }
+function isUnsupportedDirectorySyncError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException).code;
+	return typeof code === "string" && UNSUPPORTED_DIRECTORY_SYNC_CODES.has(code);
+}
+
+async function syncFile(fsImpl: TelegramCustodyStoreFs, filePath: string): Promise<void> {
+	const handle = await fsImpl.open(filePath, "r+");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+async function syncDirectory(fsImpl: TelegramCustodyStoreFs, directoryPath: string): Promise<void> {
+	const handle = await fsImpl.open(directoryPath, "r");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
 
 export class TelegramCustodyStore {
 	readonly #agentDir: string;
@@ -849,7 +873,14 @@ export class TelegramCustodyStore {
 		try {
 			await this.#fsImpl.writeFile(temporaryFile, data, { mode: 0o600 });
 			await this.#fsImpl.chmod(temporaryFile, 0o600);
+			await syncFile(this.#fsImpl, temporaryFile);
 			await this.#fsImpl.rename(temporaryFile, this.#file);
+			await syncFile(this.#fsImpl, this.#file);
+			try {
+				await syncDirectory(this.#fsImpl, this.#dir);
+			} catch (error) {
+				if (!isUnsupportedDirectorySyncError(error)) throw error;
+			}
 		} catch (error) {
 			await this.#fsImpl.unlink(temporaryFile).catch(() => undefined);
 			throw error;

--- a/packages/coding-agent/src/notifications/telegram-custody-store.ts
+++ b/packages/coding-agent/src/notifications/telegram-custody-store.ts
@@ -1,5 +1,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import {
+	type TelegramCustodyEpochBinding,
+	type TelegramCustodyEpochFs,
+	withCurrentTelegramCustodyEpoch,
+} from "./telegram-custody-epoch";
 import { daemonPaths } from "./daemon-paths";
 
 export const TELEGRAM_CUSTODY_SCHEMA_VERSION = 2;
@@ -25,7 +30,7 @@ export interface TelegramCustodyLoadResult {
 	records: readonly TelegramCustodyRecord[];
 }
 
-export type TelegramCustodyWriteResult = { ok: true } | { ok: false; reason: "read_only" };
+export type TelegramCustodyWriteResult = { ok: true } | { ok: false; reason: "read_only" | "fenced" };
 
 export interface TelegramCustodyStoreFs {
 	mkdir(path: string, opts?: fs.MakeDirectoryOptions): Promise<unknown>;
@@ -322,19 +327,37 @@ function hasDuplicateObjectKeys(source: string): boolean {
 }
 
 export class TelegramCustodyStore {
+	readonly #agentDir: string;
 	readonly #dir: string;
 	readonly #file: string;
 	readonly #fsImpl: TelegramCustodyStoreFs;
 	readonly #now: () => number;
+	readonly #fence: { binding: TelegramCustodyEpochBinding; fs?: TelegramCustodyEpochFs } | undefined;
 	#mode: StoreMode = "writable";
 	#records = new Map<string, TelegramCustodyRecord>();
 	#operations: Promise<void> = Promise.resolve();
 
-	constructor(input: { agentDir: string; fs?: TelegramCustodyStoreFs; now?: () => number }) {
+	constructor(input: {
+		agentDir: string;
+		fs?: TelegramCustodyStoreFs;
+		now?: () => number;
+		fence?: { binding: TelegramCustodyEpochBinding; fs?: TelegramCustodyEpochFs };
+	}) {
+		this.#agentDir = input.agentDir;
 		this.#dir = daemonPaths(input.agentDir).dir;
 		this.#file = path.join(this.#dir, CUSTODY_FILENAME);
 		this.#fsImpl = input.fs ?? nodeFs;
 		this.#now = input.now ?? Date.now;
+		this.#fence =
+			input.fence === undefined
+				? undefined
+				: {
+						binding: {
+							ownerId: input.fence.binding.ownerId,
+							custodyEpoch: input.fence.binding.custodyEpoch,
+						},
+						fs: input.fence.fs,
+					};
 	}
 
 	async load(): Promise<TelegramCustodyLoadResult> {
@@ -358,10 +381,17 @@ export class TelegramCustodyStore {
 		const copy = cloneRecord(validated);
 		return this.#serializeOperation<TelegramCustodyWriteResult>(async () => {
 			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
+			if (this.#fence) {
+				if (copy.custodyEpoch !== undefined && copy.custodyEpoch !== this.#fence.binding.custodyEpoch) {
+					return { ok: false, reason: "fenced" };
+				}
+				copy.custodyEpoch = this.#fence.binding.custodyEpoch;
+			}
 			const next = new Map(this.#records);
 			next.set(telegramCustodyKey(copy.chatId, copy.topicId), copy);
 			if (next.size > TELEGRAM_CUSTODY_MAX_RECORDS) throw new Error("Telegram custody record limit exceeded");
-			await this.#persist(next.values());
+			const persisted = await this.#persist(next.values());
+			if (!persisted.ok) return persisted;
 			this.#records = next;
 			return { ok: true };
 		});
@@ -373,7 +403,8 @@ export class TelegramCustodyStore {
 			if (this.#mode === "read_only") return { ok: false, reason: "read_only" };
 			const next = new Map(this.#records);
 			next.delete(key);
-			await this.#persist(next.values());
+			const persisted = await this.#persist(next.values());
+			if (!persisted.ok) return persisted;
 			this.#records = next;
 			return { ok: true };
 		});
@@ -413,7 +444,9 @@ export class TelegramCustodyStore {
 			const records = classifyV2Records(v2.value.records);
 			if (v2.value.hasInFlight) {
 				try {
-					await this.#persist(records);
+					if (!(await this.#persist(records)).ok) {
+						return this.#readOnly("migration_write_failed", records);
+					}
 				} catch {
 					return this.#readOnly("migration_write_failed", records);
 				}
@@ -427,7 +460,9 @@ export class TelegramCustodyStore {
 		if (!v1.ok) return this.#readOnly(v2.reason === "bounds" || v1.reason === "bounds" ? "bounds" : "corrupt", []);
 
 		try {
-			await this.#persist(v1.value.records);
+			if (!(await this.#persist(v1.value.records)).ok) {
+				return this.#readOnly("migration_write_failed", v1.value.records);
+			}
 		} catch {
 			return this.#readOnly("migration_write_failed", v1.value.records);
 		}
@@ -454,12 +489,29 @@ export class TelegramCustodyStore {
 		);
 	}
 
-	async #persist(records: Iterable<TelegramCustodyRecord>): Promise<void> {
+	async #persist(records: Iterable<TelegramCustodyRecord>): Promise<TelegramCustodyWriteResult> {
 		const data = serialize(records);
 		if (Buffer.byteLength(data, "utf8") > TELEGRAM_CUSTODY_MAX_FILE_BYTES) {
 			throw new Error("Telegram custody snapshot exceeds the maximum file size");
 		}
+		if (!this.#fence) {
+			await this.#persistAtomically(data);
+			return { ok: true };
+		}
+		const result = await withCurrentTelegramCustodyEpoch(
+			{
+				agentDir: this.#agentDir,
+				binding: this.#fence.binding,
+				fs: this.#fence.fs,
+			},
+			async () => {
+				await this.#persistAtomically(data);
+			},
+		);
+		return result.ok ? { ok: true } : result;
+	}
 
+	async #persistAtomically(data: string): Promise<void> {
 		await this.#fsImpl.mkdir(this.#dir, { recursive: true, mode: 0o700 });
 		await this.#fsImpl.chmod(this.#dir, 0o700);
 		const temporaryFile = `${this.#file}.${process.pid}.${this.#now()}.${Math.random().toString(36).slice(2)}.tmp`;

--- a/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
@@ -5,7 +5,19 @@ import { withFileLock } from "../config/file-lock";
 import type { Settings } from "../config/settings";
 import { getNotificationConfig, isTelegramConfigured } from "./config";
 import { daemonPaths } from "./daemon-paths";
-import type { TelegramDaemonOptions } from "./telegram-daemon";
+import {
+	readDaemonState,
+	type TelegramDaemonOptions,
+} from "./telegram-daemon";
+import {
+	clearTelegramControlRequest,
+	readTelegramControlRequest,
+} from "./telegram-daemon-control";
+import {
+	readTelegramCustodyEpoch,
+	withCurrentTelegramCustodyEpoch,
+	type TelegramCustodyEpochBinding,
+} from "./telegram-custody-epoch";
 
 type TelegramDaemonRunner = {
 	run(): Promise<void>;
@@ -26,6 +38,43 @@ export interface RunDaemonInternalDeps {
 function argValue(argv: string[], name: string): string | undefined {
 	const i = argv.indexOf(name);
 	return i >= 0 ? argv[i + 1] : undefined;
+}
+function parseCustodyEpochArg(argv: string[]): number {
+	const indices = argv.reduce<number[]>((found, value, index) => {
+		if (value === "--custody-epoch") found.push(index);
+		return found;
+	}, []);
+	if (indices.length !== 1) throw new Error("missing or duplicate --custody-epoch");
+	const raw = argv[indices[0]! + 1];
+	if (typeof raw !== "string" || !/^[1-9]\d*$/.test(raw)) {
+		throw new Error("invalid --custody-epoch");
+	}
+	const custodyEpoch = Number(raw);
+	if (!Number.isSafeInteger(custodyEpoch) || String(custodyEpoch) !== raw) {
+		throw new Error("invalid --custody-epoch");
+	}
+	return custodyEpoch;
+}
+
+async function withCurrentDaemonBinding<T>(
+	settings: Settings,
+	binding: TelegramCustodyEpochBinding,
+	operation: () => Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false }> {
+	return await withFileLock(daemonPaths(settings.getAgentDir()).state, async () => {
+		const guarded = await withCurrentTelegramCustodyEpoch(
+			{ agentDir: settings.getAgentDir(), binding },
+			async () => {
+				const state = await readDaemonState(settings);
+				if (state?.ownerId !== binding.ownerId || state.custodyEpoch !== binding.custodyEpoch) {
+					return { ok: false } as const;
+				}
+				return { ok: true, value: await operation() } as const;
+			},
+		);
+		if (!guarded.ok || !guarded.value.ok) return { ok: false };
+		return guarded.value;
+	});
 }
 
 function getByPath(obj: unknown, pathSegments: string[]): unknown {
@@ -193,20 +242,30 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 	if (smoke) return runDaemonSmoke({ agentDir });
 	const ownerId = argValue(argv, "--owner-id");
 	if (!ownerId) throw new Error("missing --owner-id");
+	const custodyEpoch = parseCustodyEpochArg(argv);
 	if (!ownerProcessIsAlive(ownerId, deps)) {
 		process.stderr.write(`GJC notify daemon exiting: owner process from --owner-id ${ownerId} is not alive.\n`);
 		return;
 	}
 	const resolvedAgentDir = agentDir ?? process.env.GJC_CODING_AGENT_DIR ?? path.join(process.cwd(), ".gjc", "agent");
 	const settings = await resolveDaemonSettings(resolvedAgentDir, deps);
+	const binding = { ownerId, custodyEpoch };
+	const state = await readDaemonState(settings as Settings);
+	if (state?.ownerId !== binding.ownerId || state.custodyEpoch !== binding.custodyEpoch) {
+		throw new Error("Telegram daemon ownership state does not match --owner-id and --custody-epoch");
+	}
+	const currentEpoch = await readTelegramCustodyEpoch({ agentDir: resolvedAgentDir });
+	if (currentEpoch.ownerId !== binding.ownerId || currentEpoch.custodyEpoch !== binding.custodyEpoch) {
+		throw new Error("Telegram custody epoch does not match daemon ownership state");
+	}
 	const cfg = getNotificationConfig(settings as Settings);
 	if (!isTelegramConfigured(cfg)) return;
-	const { clearTelegramControlRequest, readTelegramControlRequest } = await import("./telegram-daemon-control");
 	const Daemon: TelegramDaemonConstructor =
 		deps.DaemonImpl ?? (await import("./telegram-daemon")).TelegramNotificationDaemon;
 	const daemon = new Daemon({
 		settings: settings as Settings,
 		ownerId,
+		custodyEpoch,
 		botToken: cfg.botToken,
 		chatId: cfg.chatId,
 		idleTimeoutMs: cfg.idleTimeoutMs,
@@ -215,17 +274,38 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 		topics: cfg.topics,
 		pid: deps.processPid ?? process.pid,
 		control: {
-			shouldStop: async owner => {
-				const req = await readTelegramControlRequest(settings as Settings);
-				return Boolean(req && (!req.ownerId || req.ownerId === owner));
+			shouldStop: async (requestOwnerId, requestCustodyEpoch) => {
+				const current = await withCurrentDaemonBinding(
+					settings as Settings,
+					{ ownerId: requestOwnerId, custodyEpoch: requestCustodyEpoch },
+					async () => await readTelegramControlRequest(settings as Settings),
+				);
+				return Boolean(
+					current.ok &&
+						current.value !== undefined &&
+						current.value.ownerId === requestOwnerId &&
+						current.value.custodyEpoch === requestCustodyEpoch,
+				);
 			},
-			clear: async owner => {
-				const req = await readTelegramControlRequest(settings as Settings);
-				// Only clear a request that targets this daemon owner, so an exiting
-				// daemon never erases a newer request meant for a different owner.
-				if (req && (!req.ownerId || req.ownerId === owner)) {
-					await clearTelegramControlRequest(settings as Settings, req.requestId);
-				}
+			clear: async (requestOwnerId, requestCustodyEpoch) => {
+				await withCurrentDaemonBinding(
+					settings as Settings,
+					{ ownerId: requestOwnerId, custodyEpoch: requestCustodyEpoch },
+					async () => {
+						const request = await readTelegramControlRequest(settings as Settings);
+						if (
+							request?.ownerId === requestOwnerId &&
+							request.custodyEpoch === requestCustodyEpoch
+						) {
+							await clearTelegramControlRequest(
+								settings as Settings,
+								request.requestId,
+								undefined,
+								{ ownerId: requestOwnerId, custodyEpoch: requestCustodyEpoch },
+							);
+						}
+					},
+				);
 			},
 		},
 	});

--- a/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-cli.ts
@@ -6,18 +6,12 @@ import type { Settings } from "../config/settings";
 import { getNotificationConfig, isTelegramConfigured } from "./config";
 import { daemonPaths } from "./daemon-paths";
 import {
-	readDaemonState,
-	type TelegramDaemonOptions,
-} from "./telegram-daemon";
-import {
-	clearTelegramControlRequest,
-	readTelegramControlRequest,
-} from "./telegram-daemon-control";
-import {
 	readTelegramCustodyEpoch,
-	withCurrentTelegramCustodyEpoch,
 	type TelegramCustodyEpochBinding,
+	withCurrentTelegramCustodyEpoch,
 } from "./telegram-custody-epoch";
+import { readDaemonState, type TelegramDaemonOptions } from "./telegram-daemon";
+import { clearTelegramControlRequest, readTelegramControlRequest } from "./telegram-daemon-control";
 
 type TelegramDaemonRunner = {
 	run(): Promise<void>;
@@ -62,16 +56,13 @@ async function withCurrentDaemonBinding<T>(
 	operation: () => Promise<T>,
 ): Promise<{ ok: true; value: T } | { ok: false }> {
 	return await withFileLock(daemonPaths(settings.getAgentDir()).state, async () => {
-		const guarded = await withCurrentTelegramCustodyEpoch(
-			{ agentDir: settings.getAgentDir(), binding },
-			async () => {
-				const state = await readDaemonState(settings);
-				if (state?.ownerId !== binding.ownerId || state.custodyEpoch !== binding.custodyEpoch) {
-					return { ok: false } as const;
-				}
-				return { ok: true, value: await operation() } as const;
-			},
-		);
+		const guarded = await withCurrentTelegramCustodyEpoch({ agentDir: settings.getAgentDir(), binding }, async () => {
+			const state = await readDaemonState(settings);
+			if (state?.ownerId !== binding.ownerId || state.custodyEpoch !== binding.custodyEpoch) {
+				return { ok: false } as const;
+			}
+			return { ok: true, value: await operation() } as const;
+		});
 		if (!guarded.ok || !guarded.value.ok) return { ok: false };
 		return guarded.value;
 	});
@@ -293,16 +284,11 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 					{ ownerId: requestOwnerId, custodyEpoch: requestCustodyEpoch },
 					async () => {
 						const request = await readTelegramControlRequest(settings as Settings);
-						if (
-							request?.ownerId === requestOwnerId &&
-							request.custodyEpoch === requestCustodyEpoch
-						) {
-							await clearTelegramControlRequest(
-								settings as Settings,
-								request.requestId,
-								undefined,
-								{ ownerId: requestOwnerId, custodyEpoch: requestCustodyEpoch },
-							);
+						if (request?.ownerId === requestOwnerId && request.custodyEpoch === requestCustodyEpoch) {
+							await clearTelegramControlRequest(settings as Settings, request.requestId, undefined, {
+								ownerId: requestOwnerId,
+								custodyEpoch: requestCustodyEpoch,
+							});
 						}
 					},
 				);

--- a/packages/coding-agent/src/notifications/telegram-daemon-control.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-control.ts
@@ -24,6 +24,7 @@ import type {
 import { OWNERSHIP_MISMATCH_MESSAGE, ownershipMismatchRecovery } from "../daemon/operator-contract";
 import { resolveGjcRuntimeSpawnInfo } from "../daemon/runtime";
 import { getNotificationConfig, isTelegramConfigured, tokenFingerprint } from "./config";
+import { type TelegramCustodyEpochBinding, withCurrentTelegramCustodyEpoch } from "./telegram-custody-epoch";
 import {
 	daemonPaths,
 	isFreshLiveOwner,
@@ -33,7 +34,6 @@ import {
 	type TelegramDaemonDeps,
 	type TelegramDaemonFs,
 } from "./telegram-daemon";
-import { withCurrentTelegramCustodyEpoch, type TelegramCustodyEpochBinding } from "./telegram-custody-epoch";
 
 const nodeFs: TelegramDaemonFs = fs.promises as unknown as TelegramDaemonFs;
 const DEFAULT_GRACEFUL_TIMEOUT_MS = 8_000;
@@ -71,11 +71,7 @@ function controlRequestMatchesBinding(
 	request: TelegramDaemonControlRequestRead | undefined,
 	binding: TelegramCustodyEpochBinding,
 ): boolean {
-	return Boolean(
-		request &&
-			request.ownerId === binding.ownerId &&
-			request.custodyEpoch === binding.custodyEpoch,
-	);
+	return Boolean(request && request.ownerId === binding.ownerId && request.custodyEpoch === binding.custodyEpoch);
 }
 
 function isControlRequest(value: unknown): value is TelegramDaemonControlRequestRead {
@@ -380,7 +376,14 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 		const captured = await readDaemonState(this.settings, this.fsImpl);
 		if (!captured || captured.ownerId !== oldOwnerId || captured.pid !== oldPid) {
 			const after = await this.status();
-			return this.result(action, false, "telegram daemon ownership changed before control request", before, after, warnings);
+			return this.result(
+				action,
+				false,
+				"telegram daemon ownership changed before control request",
+				before,
+				after,
+				warnings,
+			);
 		}
 		if (captured.custodyEpoch !== undefined && !isCustodyEpoch(captured.custodyEpoch)) {
 			const after = await this.status();
@@ -508,21 +511,11 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 				ownershipMismatchRecovery(),
 			);
 		}
-		return this.result(
-			action,
-			true,
-			`reloaded telegram daemon (${spawned.result})`,
-			before,
-			after,
-			warnings,
-		);
+		return this.result(action, true, `reloaded telegram daemon (${spawned.result})`, before, after, warnings);
 	}
 
 	/** Clear only the exact pair-bound request for a still-current owner binding. */
-	private async clearOwnRequest(
-		requestId: string,
-		binding: TelegramCustodyEpochBinding | undefined,
-	): Promise<void> {
+	private async clearOwnRequest(requestId: string, binding: TelegramCustodyEpochBinding | undefined): Promise<void> {
 		if (!binding || !(await this.hasCurrentBinding(binding))) return;
 		await clearTelegramControlRequest(this.settings, requestId, this.fsImpl, binding);
 	}

--- a/packages/coding-agent/src/notifications/telegram-daemon-control.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon-control.ts
@@ -10,6 +10,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { withFileLock } from "../config/file-lock";
 import type { Settings } from "../config/settings";
 import type {
 	BuiltInDaemonController,
@@ -32,6 +33,7 @@ import {
 	type TelegramDaemonDeps,
 	type TelegramDaemonFs,
 } from "./telegram-daemon";
+import { withCurrentTelegramCustodyEpoch, type TelegramCustodyEpochBinding } from "./telegram-custody-epoch";
 
 const nodeFs: TelegramDaemonFs = fs.promises as unknown as TelegramDaemonFs;
 const DEFAULT_GRACEFUL_TIMEOUT_MS = 8_000;
@@ -44,7 +46,50 @@ export interface TelegramDaemonControlRequest {
 	action: "reload" | "stop";
 	ownerId: string;
 	pid: number;
+	custodyEpoch: number;
 	createdAt: number;
+}
+
+/** A v1 request written before custody epochs existed; never targets a T2 daemon. */
+interface LegacyTelegramDaemonControlRequest {
+	version: 1;
+	requestId: string;
+	action: "reload" | "stop";
+	ownerId: string;
+	pid: number;
+	createdAt: number;
+	custodyEpoch?: undefined;
+}
+
+type TelegramDaemonControlRequestRead = TelegramDaemonControlRequest | LegacyTelegramDaemonControlRequest;
+
+function isCustodyEpoch(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function controlRequestMatchesBinding(
+	request: TelegramDaemonControlRequestRead | undefined,
+	binding: TelegramCustodyEpochBinding,
+): boolean {
+	return Boolean(
+		request &&
+			request.ownerId === binding.ownerId &&
+			request.custodyEpoch === binding.custodyEpoch,
+	);
+}
+
+function isControlRequest(value: unknown): value is TelegramDaemonControlRequestRead {
+	if (!value || typeof value !== "object") return false;
+	const request = value as Record<string, unknown>;
+	return (
+		request.version === 1 &&
+		typeof request.requestId === "string" &&
+		(request.action === "reload" || request.action === "stop") &&
+		typeof request.ownerId === "string" &&
+		typeof request.pid === "number" &&
+		typeof request.createdAt === "number" &&
+		(request.custodyEpoch === undefined || isCustodyEpoch(request.custodyEpoch))
+	);
 }
 
 export function telegramControlRequestPath(agentDir: string): string {
@@ -54,21 +99,21 @@ export function telegramControlRequestPath(agentDir: string): string {
 export async function readTelegramControlRequest(
 	settings: Settings,
 	fsImpl: TelegramDaemonFs = nodeFs,
-): Promise<TelegramDaemonControlRequest | undefined> {
+): Promise<TelegramDaemonControlRequestRead | undefined> {
 	const file = telegramControlRequestPath(settings.getAgentDir());
 	try {
-		const parsed = JSON.parse(await fsImpl.readFile(file, "utf8")) as TelegramDaemonControlRequest;
-		return parsed?.version === 1 ? parsed : undefined;
+		const parsed: unknown = JSON.parse(await fsImpl.readFile(file, "utf8"));
+		return isControlRequest(parsed) ? parsed : undefined;
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
 		return undefined;
 	}
 }
 
-export async function writeTelegramControlRequest(
+async function writeTelegramControlRequestAtomic(
 	settings: Settings,
 	request: TelegramDaemonControlRequest,
-	fsImpl: TelegramDaemonFs = nodeFs,
+	fsImpl: TelegramDaemonFs,
 ): Promise<void> {
 	const dir = daemonPaths(settings.getAgentDir()).dir;
 	await fsImpl.mkdir(dir, { recursive: true, mode: 0o700 });
@@ -79,17 +124,33 @@ export async function writeTelegramControlRequest(
 	await fsImpl.rename(tmp, file);
 }
 
+export async function writeTelegramControlRequest(
+	settings: Settings,
+	request: TelegramDaemonControlRequest,
+	fsImpl: TelegramDaemonFs = nodeFs,
+): Promise<void> {
+	const dir = daemonPaths(settings.getAgentDir()).dir;
+	await fsImpl.mkdir(dir, { recursive: true, mode: 0o700 });
+	const file = telegramControlRequestPath(settings.getAgentDir());
+	await withFileLock(file, async () => {
+		await writeTelegramControlRequestAtomic(settings, request, fsImpl);
+	});
+}
+
 export async function clearTelegramControlRequest(
 	settings: Settings,
 	requestId?: string,
 	fsImpl: TelegramDaemonFs = nodeFs,
+	binding?: TelegramCustodyEpochBinding,
 ): Promise<void> {
 	const file = telegramControlRequestPath(settings.getAgentDir());
-	if (requestId) {
+	await withFileLock(file, async () => {
 		const current = await readTelegramControlRequest(settings, fsImpl);
-		if (current && current.requestId !== requestId) return;
-	}
-	await fsImpl.unlink(file).catch(() => undefined);
+		if (!current) return;
+		if (requestId && current.requestId !== requestId) return;
+		if (binding && !controlRequestMatchesBinding(current, binding)) return;
+		await fsImpl.unlink(file).catch(() => undefined);
+	});
 }
 
 export interface TelegramDaemonControlDeps {
@@ -156,6 +217,24 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 			reloadPicksUpSourceEdits: rt.reloadPicksUpSourceEdits,
 			warning: rt.warning,
 		};
+	}
+	private async hasCurrentBinding(binding: TelegramCustodyEpochBinding, pid?: number): Promise<boolean> {
+		const statePath = daemonPaths(this.settings.getAgentDir()).state;
+		return await withFileLock(statePath, async () => {
+			const guarded = await withCurrentTelegramCustodyEpoch(
+				{ agentDir: this.settings.getAgentDir(), binding },
+				async () => {
+					const state = await readDaemonState(this.settings, this.fsImpl);
+					return Boolean(
+						state &&
+							state.ownerId === binding.ownerId &&
+							state.custodyEpoch === binding.custodyEpoch &&
+							(pid === undefined || state.pid === pid),
+					);
+				},
+			);
+			return guarded.ok && guarded.value;
+		});
 	}
 
 	async status(): Promise<DaemonStatus> {
@@ -295,16 +374,57 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 			);
 		}
 
-		// Running owner: capture identity, request cooperative stop, signal, wait.
+		// Running owner: capture the complete binding before every control action.
 		const oldOwnerId = before.ownerId as string;
 		const oldPid = before.pid as number;
+		const captured = await readDaemonState(this.settings, this.fsImpl);
+		if (!captured || captured.ownerId !== oldOwnerId || captured.pid !== oldPid) {
+			const after = await this.status();
+			return this.result(action, false, "telegram daemon ownership changed before control request", before, after, warnings);
+		}
+		if (captured.custodyEpoch !== undefined && !isCustodyEpoch(captured.custodyEpoch)) {
+			const after = await this.status();
+			return this.result(action, false, "telegram daemon has an invalid custody epoch", before, after, warnings);
+		}
+		const oldBinding =
+			captured.custodyEpoch === undefined
+				? undefined
+				: { ownerId: captured.ownerId, custodyEpoch: captured.custodyEpoch };
 		const requestId = this.deps.randomId?.() ?? `${this.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-		await writeTelegramControlRequest(
-			this.settings,
-			{ version: 1, requestId, action, ownerId: oldOwnerId, pid: oldPid, createdAt: this.now() },
-			this.fsImpl,
-		);
-		if (this.pidAlive(oldPid)) this.sendSignal(oldPid, "SIGTERM");
+		if (oldBinding) {
+			if (!(await this.hasCurrentBinding(oldBinding, oldPid))) {
+				const after = await this.status();
+				return this.result(
+					action,
+					false,
+					"telegram daemon ownership changed before control request",
+					before,
+					after,
+					warnings,
+				);
+			}
+			await writeTelegramControlRequest(
+				this.settings,
+				{
+					version: 1,
+					requestId,
+					action,
+					ownerId: oldBinding.ownerId,
+					custodyEpoch: oldBinding.custodyEpoch,
+					pid: oldPid,
+					createdAt: this.now(),
+				},
+				this.fsImpl,
+			);
+		} else {
+			// Pre-T2 state is intentionally never assigned epoch zero. SIGTERM still
+			// reaches the legacy process, but it gets no pair-bound request and cannot
+			// participate in T2 force-kill/cleanup paths.
+			warnings.push("legacy telegram daemon lacks custody epoch; using signal-only reload handoff");
+		}
+		if (this.pidAlive(oldPid) && (!oldBinding || (await this.hasCurrentBinding(oldBinding, oldPid)))) {
+			this.sendSignal(oldPid, "SIGTERM");
+		}
 
 		let dead = await this.waitForPidDeath(oldPid, gracefulTimeoutMs);
 		if (!dead) {
@@ -312,7 +432,9 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 			const current = await readDaemonState(this.settings, this.fsImpl);
 			const changedToLiveOwner =
 				current !== undefined &&
-				current.ownerId !== oldOwnerId &&
+				(oldBinding
+					? current.ownerId !== oldBinding.ownerId || current.custodyEpoch !== oldBinding.custodyEpoch
+					: current.ownerId !== oldOwnerId || current.custodyEpoch !== undefined) &&
 				isFreshLiveOwner({
 					state: current,
 					now: this.now(),
@@ -321,9 +443,10 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 					pidAlive: this.pidAlive,
 				});
 			if (changedToLiveOwner) {
-				// A different, fresh-live owner already supersedes the old one. Do not
-				// kill it or spawn another; attach to the running daemon.
-				await this.clearOwnRequest(requestId, oldOwnerId);
+				// A fresh binding already supersedes the captured one. Do not kill it
+				// or spawn another; a stale ownerId with a different epoch is equally
+				// protected here.
+				await this.clearOwnRequest(requestId, oldBinding);
 				const after = await this.status();
 				warnings.push("ownership changed to a live owner; attached without spawning");
 				return this.result(
@@ -337,15 +460,15 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 					warnings,
 				);
 			}
-			// No live replacement. Escalate to SIGKILL only with --force and only when
-			// the captured owner/pid still matches, so we never kill a different owner.
-			const stillSameOwner = current !== undefined && current.ownerId === oldOwnerId && current.pid === oldPid;
+			// No live replacement. Escalate only when the captured owner, epoch, and
+			// pid are still current; legacy state deliberately cannot enter this path.
+			const stillSameOwner = oldBinding ? await this.hasCurrentBinding(oldBinding, oldPid) : false;
 			if (opts.force && stillSameOwner && this.pidAlive(oldPid)) {
 				this.sendSignal(oldPid, "SIGKILL");
 				dead = await this.waitForPidDeath(oldPid, killTimeoutMs);
 			}
 			if (!dead) {
-				await this.clearOwnRequest(requestId, oldOwnerId);
+				await this.clearOwnRequest(requestId, oldBinding);
 				const after = await this.status();
 				const message = opts.force
 					? "old daemon did not exit after SIGKILL; refusing to spawn to avoid a Telegram 409 conflict"
@@ -354,8 +477,8 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 			}
 		}
 
-		// Old pid is dead: safe to clear our request and proceed.
-		await this.clearOwnRequest(requestId, oldOwnerId);
+		// Old pid is dead: safe to clear only the exact control request and binding.
+		await this.clearOwnRequest(requestId, oldBinding);
 
 		if (action === "stop") {
 			const after = await this.status();
@@ -387,7 +510,7 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 		}
 		return this.result(
 			action,
-			spawned.result !== "disabled",
+			true,
 			`reloaded telegram daemon (${spawned.result})`,
 			before,
 			after,
@@ -395,12 +518,12 @@ export class TelegramDaemonController implements BuiltInDaemonController {
 		);
 	}
 
-	/** Clear our own control request unless a newer owner-scoped request replaced it. */
-	private async clearOwnRequest(requestId: string, oldOwnerId: string): Promise<void> {
-		const current = await readTelegramControlRequest(this.settings, this.fsImpl);
-		if (!current) return;
-		if (current.requestId === requestId || current.ownerId === oldOwnerId) {
-			await clearTelegramControlRequest(this.settings, current.requestId, this.fsImpl);
-		}
+	/** Clear only the exact pair-bound request for a still-current owner binding. */
+	private async clearOwnRequest(
+		requestId: string,
+		binding: TelegramCustodyEpochBinding | undefined,
+	): Promise<void> {
+		if (!binding || !(await this.hasCurrentBinding(binding))) return;
+		await clearTelegramControlRequest(this.settings, requestId, this.fsImpl, binding);
 	}
 }

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -108,7 +108,7 @@ export interface TelegramDaemonFs {
 	writeFile(path: string, data: string, opts?: fs.WriteFileOptions): Promise<void>;
 	rename(oldPath: string, newPath: string): Promise<void>;
 	unlink(path: string): Promise<void>;
-	open(path: string, flags: string, mode?: number): Promise<{ close(): Promise<void> }>;
+	open(path: string, flags: string, mode?: number): Promise<{ sync(): Promise<void>; close(): Promise<void> }>;
 	readdir(path: string): Promise<string[]>;
 	chmod(path: string, mode: number): Promise<void>;
 }
@@ -161,6 +161,8 @@ export const ASK_CONTROLS_CAPABILITY = "ask_controls_v1";
 export const DAEMON_GENERATION = NOTIFICATION_PROTOCOL_VERSION;
 
 const nodeFs: TelegramDaemonFs = fs.promises as unknown as TelegramDaemonFs;
+const UNSUPPORTED_DIRECTORY_SYNC_CODES = new Set(["EISDIR", "EINVAL", "ENOSYS", "ENOTSUP", "EPERM"]);
+const TOPIC_STATE_SCHEMA_VERSION = 1;
 
 /**
  * Durably persist a `/rich` toggle. A real {@link Settings} exposes
@@ -315,12 +317,130 @@ async function readJson<T>(fsImpl: TelegramDaemonFs, file: string): Promise<T | 
 	}
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function hasExactKeys(
+	value: Record<string, unknown>,
+	required: readonly string[],
+	optional: readonly string[] = [],
+): boolean {
+	const keys = Object.keys(value);
+	return (
+		keys.length >= required.length &&
+		keys.length <= required.length + optional.length &&
+		required.every(key => Object.hasOwn(value, key)) &&
+		keys.every(key => required.includes(key) || optional.includes(key))
+	);
+}
+
+function isTopicRecord(value: unknown): value is TopicRegistryState["topics"][string] {
+	if (
+		!isPlainObject(value) ||
+		!hasExactKeys(
+			value,
+			["topicId", "identitySent", "createdAt"],
+			["name", "nameOwner", "nameReconcilePending", "userNameUpdateId", "identityKey"],
+		)
+	) {
+		return false;
+	}
+	const hasUserNameUpdateId = Object.hasOwn(value, "userNameUpdateId");
+	const userOwned = value.nameOwner === "user";
+	if (
+		(userOwned &&
+			(typeof value.name !== "string" ||
+				value.name.trim().length === 0 ||
+				!hasUserNameUpdateId ||
+				typeof value.userNameUpdateId !== "number" ||
+				!Number.isSafeInteger(value.userNameUpdateId) ||
+				value.userNameUpdateId < 0)) ||
+		(!userOwned && (hasUserNameUpdateId || value.nameReconcilePending === true))
+	) {
+		return false;
+	}
+	return (
+		typeof value.topicId === "string" &&
+		value.topicId.length > 0 &&
+		typeof value.identitySent === "boolean" &&
+		typeof value.createdAt === "number" &&
+		Number.isSafeInteger(value.createdAt) &&
+		value.createdAt >= 0 &&
+		(!Object.hasOwn(value, "name") || typeof value.name === "string") &&
+		(!Object.hasOwn(value, "nameOwner") || value.nameOwner === "user") &&
+		(!Object.hasOwn(value, "nameReconcilePending") || typeof value.nameReconcilePending === "boolean") &&
+		(!hasUserNameUpdateId ||
+			(typeof value.userNameUpdateId === "number" &&
+				Number.isSafeInteger(value.userNameUpdateId) &&
+				value.userNameUpdateId >= 0)) &&
+		(!Object.hasOwn(value, "identityKey") || typeof value.identityKey === "string")
+	);
+}
+
+function parseTopicStateEnvelope(
+	value: unknown,
+	identity: { chatId: string; tokenFingerprint: string },
+): TopicRegistryState | undefined {
+	if (!isPlainObject(value) || !hasExactKeys(value, ["version", "chatId", "tokenFingerprint", "topics"])) {
+		return undefined;
+	}
+	const rawTopics = value.topics;
+	if (
+		value.version !== TOPIC_STATE_SCHEMA_VERSION ||
+		value.chatId !== identity.chatId ||
+		value.tokenFingerprint !== identity.tokenFingerprint ||
+		!isPlainObject(rawTopics)
+	) {
+		return undefined;
+	}
+
+	const topics: TopicRegistryState["topics"] = {};
+	const topicIds = new Set<string>();
+	for (const [sessionId, record] of Object.entries(rawTopics)) {
+		if (!sessionId || !isTopicRecord(record) || topicIds.has(record.topicId)) return undefined;
+		topicIds.add(record.topicId);
+		topics[sessionId] = record;
+	}
+	return { topics };
+}
+
+function isUnsupportedDirectorySyncError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException).code;
+	return typeof code === "string" && UNSUPPORTED_DIRECTORY_SYNC_CODES.has(code);
+}
+
+async function syncFile(fsImpl: TelegramDaemonFs, filePath: string): Promise<void> {
+	const handle = await fsImpl.open(filePath, "r+");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+async function syncDirectory(fsImpl: TelegramDaemonFs, directoryPath: string): Promise<void> {
+	const handle = await fsImpl.open(directoryPath, "r");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
 async function writeJsonAtomic(fsImpl: TelegramDaemonFs, file: string, data: unknown): Promise<void> {
 	const tmp = `${file}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
 	try {
 		await fsImpl.writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o600 });
 		await fsImpl.chmod(tmp, 0o600).catch(() => undefined);
+		await syncFile(fsImpl, tmp);
 		await fsImpl.rename(tmp, file);
+		await syncFile(fsImpl, file);
+		try {
+			await syncDirectory(fsImpl, path.dirname(file));
+		} catch (error) {
+			if (!isUnsupportedDirectorySyncError(error)) throw error;
+		}
 	} catch (error) {
 		await fsImpl.unlink(tmp).catch(() => undefined);
 		throw error;
@@ -1191,6 +1311,7 @@ export class TelegramNotificationDaemon {
 	#custodyLoadPromise: Promise<TelegramCustodyLoadResult> | undefined;
 	readonly #topicDeletionPromises = new Map<string, Promise<void>>();
 	private readonly topics = new TopicRegistry();
+	#topicStateLoadFailed = false;
 	/** Serializes registry snapshots so an older atomic write cannot overwrite newer rename state. */
 	private topicsPersistQueue: Promise<void> = Promise.resolve();
 	/** Daemon edit attempts that can race an accepted user service message. */
@@ -2424,11 +2545,18 @@ export class TelegramNotificationDaemon {
 					try {
 						await this.persistTopics();
 					} catch {
-						if (previousTopic !== undefined) this.topics.load({ topics: { [sessionId]: previousTopic } });
+						const replacement = this.topics.get(sessionId);
+						// A write can race a new topic for this same session.
+						// Never overwrite its record or reverse index.
+						if (previousTopic !== undefined && replacement === undefined) {
+							this.topics.load({ topics: { [sessionId]: previousTopic } });
+						}
 						logger.warn("notifications: Telegram topic deletion local persistence failed");
 						return false;
 					}
-					if (current !== undefined) this.clearDeletedTopicRuntimeState(sessionId);
+					if (current !== undefined && this.topics.get(sessionId) === undefined) {
+						this.clearDeletedTopicRuntimeState(sessionId);
+					}
 					return true;
 				},
 			);
@@ -2458,10 +2586,18 @@ export class TelegramNotificationDaemon {
 	}
 
 	private persistTopics(): Promise<void> {
+		if (this.#topicStateLoadFailed) {
+			return Promise.reject(new Error("Telegram topic persistence is disabled after an untrusted topic state load"));
+		}
 		const pending = this.topicsPersistQueue.then(async () => {
 			const paths = daemonPaths(this.opts.settings.getAgentDir());
 			await ensureDir(this.fsImpl, paths.dir);
-			await writeJsonAtomic(this.fsImpl, path.join(paths.dir, "telegram-topics.json"), this.topics.serialize());
+			await writeJsonAtomic(this.fsImpl, path.join(paths.dir, "telegram-topics.json"), {
+				version: TOPIC_STATE_SCHEMA_VERSION,
+				chatId: this.opts.chatId,
+				tokenFingerprint: tokenFingerprint(this.opts.botToken),
+				...this.topics.serialize(),
+			});
 		});
 		this.topicsPersistQueue = pending.catch(() => undefined);
 		return pending;
@@ -2469,8 +2605,27 @@ export class TelegramNotificationDaemon {
 
 	async loadTopics(): Promise<void> {
 		const paths = daemonPaths(this.opts.settings.getAgentDir());
-		const raw = await readJson<TopicRegistryState>(this.fsImpl, path.join(paths.dir, "telegram-topics.json"));
-		if (raw && typeof raw === "object") this.topics.load(raw);
+		let raw: unknown;
+		try {
+			raw = await readJson<unknown>(this.fsImpl, path.join(paths.dir, "telegram-topics.json"));
+		} catch (error) {
+			this.#topicStateLoadFailed = true;
+			for (const sessionId of this.topics.sessionIds()) this.topics.delete(sessionId);
+			throw error;
+		}
+		if (raw === undefined) return;
+		const state = parseTopicStateEnvelope(raw, {
+			chatId: this.opts.chatId,
+			tokenFingerprint: tokenFingerprint(this.opts.botToken),
+		});
+		if (state === undefined) {
+			this.#topicStateLoadFailed = true;
+			for (const sessionId of this.topics.sessionIds()) this.topics.delete(sessionId);
+			throw new Error(
+				"Telegram topic state is malformed, unsupported, or does not match the current Telegram identity",
+			);
+		}
+		this.topics.load(state);
 	}
 	private ensureCustodyLoaded(): Promise<TelegramCustodyLoadResult> {
 		if (!this.#custodyLoadPromise) {

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -50,8 +50,8 @@ import { deliverRichActionWithFallback, deliverRichWithFallback, shouldPromoteRi
 import {
 	allocateTelegramCustodyEpoch,
 	readTelegramCustodyEpoch,
-	withCurrentTelegramCustodyEpoch,
 	type TelegramCustodyEpochBinding,
+	withCurrentTelegramCustodyEpoch,
 } from "./telegram-custody-epoch";
 import { type TelegramCustodyLoadResult, TelegramCustodyStore } from "./telegram-custody-store";
 import {
@@ -425,9 +425,7 @@ function ownerBindingMatches(
 	state: DaemonState | undefined,
 	binding: TelegramCustodyEpochBinding,
 ): state is DaemonState & { custodyEpoch: number } {
-	return Boolean(
-		state && state.ownerId === binding.ownerId && state.custodyEpoch === binding.custodyEpoch,
-	);
+	return Boolean(state && state.ownerId === binding.ownerId && state.custodyEpoch === binding.custodyEpoch);
 }
 
 function assertValidPersistedStateEpoch(state: DaemonState | undefined): void {

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -2471,6 +2471,7 @@ export class TelegramNotificationDaemon {
 
 		for (const record of this.#custodyStore.list()) {
 			if (record.state !== "confirmed") continue;
+			if (record.chatId !== this.opts.chatId) continue;
 			const sessionId = this.topics
 				.sessionIds()
 				.find(candidate => this.topics.get(candidate)?.topicId === record.topicId);

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -53,7 +53,16 @@ import {
 	type TelegramCustodyEpochBinding,
 	withCurrentTelegramCustodyEpoch,
 } from "./telegram-custody-epoch";
-import { type TelegramCustodyLoadResult, TelegramCustodyStore } from "./telegram-custody-store";
+import {
+	type TelegramCustodyClaimResult,
+	type TelegramCustodyDiagnostic,
+	type TelegramCustodyLoadResult,
+	type TelegramCustodyQueueResult,
+	TelegramCustodyStore,
+	type TelegramCustodyWriteResult,
+	type TelegramDeletionTrigger,
+	type TelegramRejectionClass,
+} from "./telegram-custody-store";
 import {
 	type AliasTable,
 	buildActionMarkdown,
@@ -1179,6 +1188,8 @@ export class TelegramNotificationDaemon {
 	readonly #custodyStore: TelegramCustodyStore;
 	/** Startup custody result retained for later deletion-recovery phases. */
 	#custodyLoadResult: TelegramCustodyLoadResult | undefined;
+	#custodyLoadPromise: Promise<TelegramCustodyLoadResult> | undefined;
+	readonly #topicDeletionPromises = new Map<string, Promise<void>>();
 	private readonly topics = new TopicRegistry();
 	/** Serializes registry snapshots so an older atomic write cannot overwrite newer rename state. */
 	private topicsPersistQueue: Promise<void> = Promise.resolve();
@@ -1799,7 +1810,7 @@ export class TelegramNotificationDaemon {
 				handle: async session => {
 					this.busy.delete(session.sessionId);
 					this.closedEndpointKeys.set(session.sessionId, session.endpointKey);
-					await this.deleteTopic(session.sessionId);
+					await this.deleteTopic(session.sessionId, "session_closed");
 					this.dropSession(session, "session_closed");
 				},
 			});
@@ -2226,39 +2237,198 @@ export class TelegramNotificationDaemon {
 
 	private async deleteOrphanedTopic(sessionId: string): Promise<void> {
 		if (!this.topicPastOrphanGrace(sessionId)) return;
-		await this.deleteTopic(sessionId);
+		await this.deleteTopic(sessionId, "orphan_reap");
 	}
 
-	/** Best-effort delete of a session topic once its local notification endpoint shuts down. */
-	private async deleteTopic(sessionId: string): Promise<void> {
+	private async deleteTopic(sessionId: string, trigger: TelegramDeletionTrigger): Promise<void> {
 		const record = this.topics.get(sessionId);
 		if (!record) return;
+
+		const key = `${this.opts.chatId}:${record.topicId}`;
+		const existing = this.#topicDeletionPromises.get(key);
+		if (existing) {
+			await existing;
+			return;
+		}
+
+		const deletion = this.claimAndCallTopicDeletion({ sessionId, topicId: record.topicId, trigger });
+		this.#topicDeletionPromises.set(key, deletion);
 		try {
-			// Drop queued sends for this session before deleting the topic; otherwise
-			// rate-limited frames can flush later into a deleted topic or across resume.
-			const removed = this.pool.removeWhere(item => item.sessionId === sessionId);
-			for (const item of removed) {
-				if (item.payload.selectedAck)
-					this.finishSelectedAck(item.payload.selectedAck, { status: "failed", reason: "cancelled" });
-			}
-			await this.flushPool();
-			const res = (await this.botApi.call("deleteForumTopic", {
-				chat_id: this.opts.chatId,
-				message_thread_id: Number(record.topicId),
-			})) as { ok?: boolean };
-			if (res?.ok === false) return;
-			this.topics.delete(sessionId);
-			for (const k of [...this.liveMessages.keys()]) {
-				if (k.startsWith(`${sessionId}:`)) this.liveMessages.delete(k);
-			}
-			this.topicOwnerByIdentity.forEach((ownerSessionId, identityKey) => {
-				if (ownerSessionId === sessionId) this.topicOwnerByIdentity.delete(identityKey);
+			await deletion;
+		} finally {
+			if (this.#topicDeletionPromises.get(key) === deletion) this.#topicDeletionPromises.delete(key);
+		}
+	}
+
+	private async claimAndCallTopicDeletion(input: {
+		sessionId: string;
+		topicId: string;
+		trigger: TelegramDeletionTrigger;
+	}): Promise<void> {
+		let load: TelegramCustodyLoadResult;
+		try {
+			load = await this.ensureCustodyLoaded();
+		} catch {
+			logger.warn("notifications: Telegram topic deletion custody load failed");
+			return;
+		}
+		if (load.mode !== "writable") return;
+
+		let queued: TelegramCustodyQueueResult;
+		try {
+			queued = await this.#custodyStore.queueDeletion({
+				chatId: this.opts.chatId,
+				topicId: input.topicId,
+				trigger: input.trigger,
 			});
-			this.pendingThreadedFrames.delete(sessionId);
+		} catch {
+			logger.warn("notifications: Telegram topic deletion queue failed");
+			return;
+		}
+		if (!queued.ok) return;
+		if (queued.status === "blocked") {
+			if (queued.record.state === "confirmed")
+				await this.finishConfirmedTopicDeletion(input.sessionId, input.topicId);
+			return;
+		}
+
+		const removed = this.pool.removeWhere(item => item.sessionId === input.sessionId);
+		for (const item of removed) {
+			if (item.payload.selectedAck)
+				this.finishSelectedAck(item.payload.selectedAck, { status: "failed", reason: "cancelled" });
+		}
+		try {
+			await this.flushPool();
+		} catch {
+			logger.warn("notifications: Telegram topic deletion pool flush failed");
+			return;
+		}
+
+		let claimed: TelegramCustodyClaimResult;
+		try {
+			claimed = await this.#custodyStore.claimDeletion({ chatId: this.opts.chatId, topicId: input.topicId });
+		} catch {
+			logger.warn("notifications: Telegram topic deletion claim failed");
+			return;
+		}
+		if (!claimed.ok || claimed.status !== "claimed" || claimed.record.custodyEpoch !== this.opts.custodyEpoch) return;
+
+		let diagnostic: TelegramCustodyDiagnostic;
+		try {
+			const guarded = await withCurrentTelegramCustodyEpoch(
+				{
+					agentDir: this.opts.settings.getAgentDir(),
+					binding: { ownerId: this.opts.ownerId, custodyEpoch: this.opts.custodyEpoch },
+				},
+				() =>
+					this.botApi.call(
+						"deleteForumTopic",
+						{ chat_id: this.opts.chatId, message_thread_id: Number(input.topicId) },
+						{ noRetry: true },
+					),
+			);
+			if (!guarded.ok) return;
+			diagnostic = this.classifyDeleteResponse(guarded.value);
+		} catch (error) {
+			diagnostic = this.classifyDeleteError(error);
+		}
+
+		let settled: TelegramCustodyWriteResult;
+		try {
+			settled = await this.#custodyStore.settleDeletion({
+				chatId: this.opts.chatId,
+				topicId: input.topicId,
+				diagnostic,
+			});
+		} catch {
+			logger.warn("notifications: Telegram topic deletion settlement failed");
+			return;
+		}
+		if (!settled.ok || diagnostic.kind !== "telegram_ok") return;
+		await this.finishConfirmedTopicDeletion(input.sessionId, input.topicId);
+	}
+
+	private classifyDeleteResponse(response: unknown): TelegramCustodyDiagnostic {
+		if (
+			typeof response !== "object" ||
+			response === null ||
+			Array.isArray(response) ||
+			Object.getPrototypeOf(response) !== Object.prototype
+		) {
+			return { kind: "malformed_response" };
+		}
+		const value = response as { ok?: unknown; error_code?: unknown };
+		if (value.ok === true) return { kind: "telegram_ok" };
+		if (value.ok !== false) return { kind: "malformed_response" };
+
+		const errorCode =
+			typeof value.error_code === "number" && Number.isSafeInteger(value.error_code) ? value.error_code : undefined;
+		let rejection: TelegramRejectionClass = "other";
+		if (errorCode === 404) rejection = "not_found";
+		else if (errorCode === 403) rejection = "forbidden";
+		else if (errorCode === 429) rejection = "rate_limited";
+		else if (errorCode !== undefined && errorCode >= 500 && errorCode <= 599) rejection = "server_error";
+		return {
+			kind: "telegram_rejected",
+			rejection,
+			...(errorCode === undefined ? {} : { errorCode }),
+		};
+	}
+
+	private classifyDeleteError(error: unknown): TelegramCustodyDiagnostic {
+		if (isAbortError(error)) return { kind: "transport_ambiguous", transport: "aborted" };
+
+		const value = error as { code?: unknown; name?: unknown; message?: unknown };
+		const code = typeof value?.code === "string" ? value.code : "";
+		const name = typeof value?.name === "string" ? value.name : "";
+		const message = typeof value?.message === "string" ? value.message.slice(0, 256).toLowerCase() : "";
+		if (code === "ECONNRESET" || name === "ECONNRESET" || /connection reset/i.test(message)) {
+			return { kind: "transport_ambiguous", transport: "connection_reset" };
+		}
+		if (code === "ETIMEDOUT" || name === "TimeoutError" || /timeout|timed out/i.test(message)) {
+			return { kind: "transport_ambiguous", transport: "timeout" };
+		}
+		if (
+			code === "ENOTFOUND" ||
+			code === "ECONNREFUSED" ||
+			code === "EAI_AGAIN" ||
+			name === "TypeError" ||
+			/network|dns|fetch failed/i.test(message)
+		) {
+			return { kind: "transport_ambiguous", transport: "network" };
+		}
+		return { kind: "transport_ambiguous", transport: "other" };
+	}
+
+	private async finishConfirmedTopicDeletion(sessionId: string, topicId: string): Promise<void> {
+		const current = this.topics.get(sessionId);
+		if (current !== undefined && current.topicId !== topicId) return;
+		const previousTopics = this.topics.serialize();
+		if (current !== undefined) this.topics.delete(sessionId);
+		try {
 			await this.persistTopics();
 		} catch {
-			// Best-effort: missing Telegram topic permissions must not stop teardown.
+			if (current !== undefined) this.topics.load(previousTopics);
+			logger.warn("notifications: Telegram topic deletion local persistence failed");
+			return;
 		}
+		if (current !== undefined) this.clearDeletedTopicRuntimeState(sessionId);
+		try {
+			const removed = await this.#custodyStore.removeConfirmed({ chatId: this.opts.chatId, topicId });
+			if (!removed.ok) return;
+		} catch {
+			logger.warn("notifications: Telegram topic deletion custody cleanup failed");
+		}
+	}
+
+	private clearDeletedTopicRuntimeState(sessionId: string): void {
+		for (const key of [...this.liveMessages.keys()]) {
+			if (key.startsWith(`${sessionId}:`)) this.liveMessages.delete(key);
+		}
+		this.topicOwnerByIdentity.forEach((ownerSessionId, identityKey) => {
+			if (ownerSessionId === sessionId) this.topicOwnerByIdentity.delete(identityKey);
+		});
+		this.pendingThreadedFrames.delete(sessionId);
 	}
 
 	private persistTopics(): Promise<void> {
@@ -2274,18 +2444,37 @@ export class TelegramNotificationDaemon {
 	async loadTopics(): Promise<void> {
 		const paths = daemonPaths(this.opts.settings.getAgentDir());
 		const raw = await readJson<TopicRegistryState>(this.fsImpl, path.join(paths.dir, "telegram-topics.json"));
-		// Restore the full serialized registry (topicId + identitySent + name) so a
-		// fresh daemon after reload does not resend identity headers or lose renames.
 		if (raw && typeof raw === "object") this.topics.load(raw);
 	}
+	private ensureCustodyLoaded(): Promise<TelegramCustodyLoadResult> {
+		if (!this.#custodyLoadPromise) {
+			this.#custodyLoadPromise = this.#custodyStore.load().then(result => {
+				this.#custodyLoadResult = result;
+				return result;
+			});
+		}
+		return this.#custodyLoadPromise;
+	}
+
 	get custodyLoadResult(): TelegramCustodyLoadResult | undefined {
 		return this.#custodyLoadResult;
 	}
 
 	async loadCustody(): Promise<TelegramCustodyLoadResult> {
-		const result = await this.#custodyStore.load();
-		this.#custodyLoadResult = result;
-		return result;
+		const result = await this.ensureCustodyLoaded();
+		if (result.mode !== "writable") return result;
+
+		for (const record of this.#custodyStore.list()) {
+			if (record.state !== "confirmed") continue;
+			const sessionId = this.topics
+				.sessionIds()
+				.find(candidate => this.topics.get(candidate)?.topicId === record.topicId);
+			await this.finishConfirmedTopicDeletion(sessionId ?? "", record.topicId);
+		}
+
+		const updated = { ...result, records: this.#custodyStore.list() };
+		this.#custodyLoadResult = updated;
+		return updated;
 	}
 
 	/** Download a Telegram file by its file_path (from getFile) into memory. */
@@ -3392,9 +3581,6 @@ export class TelegramNotificationDaemon {
 		});
 		if (!this.running) return;
 		this.runtime.start();
-		this.startFlushTimer();
-		this.startScanTimer();
-		this.startTypingTimer();
 		try {
 			await this.refreshBotIdentity();
 			await this.registerBotCommands();
@@ -3403,6 +3589,9 @@ export class TelegramNotificationDaemon {
 			await this.loadCustody();
 			await this.loadSeenUpdateIds();
 			await this.replyStore.load();
+			this.startFlushTimer();
+			this.startScanTimer();
+			this.startTypingTimer();
 			await this.runScan();
 			// Owner-only: start the session-lifecycle control server now that
 			// ownership is confirmed (singleton-safe). Best-effort; degrades.

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -2288,7 +2288,7 @@ export class TelegramNotificationDaemon {
 		if (!queued.ok) return;
 		if (queued.status === "blocked") {
 			if (queued.record.state === "confirmed")
-				await this.finishConfirmedTopicDeletion(input.sessionId, input.topicId);
+				await this.finishConfirmedTopicDeletion({ sessionId: input.sessionId, topicId: input.topicId });
 			return;
 		}
 
@@ -2345,7 +2345,7 @@ export class TelegramNotificationDaemon {
 			return;
 		}
 		if (!settled.ok || diagnostic.kind !== "telegram_ok") return;
-		await this.finishConfirmedTopicDeletion(input.sessionId, input.topicId);
+		await this.finishConfirmedTopicDeletion({ sessionId: input.sessionId, topicId: input.topicId });
 	}
 
 	private classifyDeleteResponse(response: unknown): TelegramCustodyDiagnostic {
@@ -2405,7 +2405,7 @@ export class TelegramNotificationDaemon {
 		return { kind: "transport_ambiguous", transport: "other" };
 	}
 
-	private async finishConfirmedTopicDeletion(sessionId: string, topicId: string): Promise<void> {
+	private async finishConfirmedTopicDeletion(input: { sessionId?: string; topicId: string }): Promise<void> {
 		let localCleanup = false;
 		try {
 			const guarded = await withCurrentTelegramCustodyEpoch(
@@ -2414,8 +2414,11 @@ export class TelegramNotificationDaemon {
 					binding: { ownerId: this.opts.ownerId, custodyEpoch: this.opts.custodyEpoch },
 				},
 				async () => {
+					const sessionId = input.sessionId ?? this.topics.sessionForTopic(input.topicId);
+					if (sessionId === undefined) return true;
+
 					const current = this.topics.get(sessionId);
-					if (current !== undefined && current.topicId !== topicId) return false;
+					if (current !== undefined && current.topicId !== input.topicId) return false;
 					const previousTopic = current === undefined ? undefined : Object.freeze({ ...current });
 					if (current !== undefined) this.topics.delete(sessionId);
 					try {
@@ -2437,7 +2440,7 @@ export class TelegramNotificationDaemon {
 		}
 		if (!localCleanup) return;
 		try {
-			const removed = await this.#custodyStore.removeConfirmed({ chatId: this.opts.chatId, topicId });
+			const removed = await this.#custodyStore.removeConfirmed({ chatId: this.opts.chatId, topicId: input.topicId });
 			if (!removed.ok) return;
 		} catch {
 			logger.warn("notifications: Telegram topic deletion custody cleanup failed");
@@ -2490,10 +2493,7 @@ export class TelegramNotificationDaemon {
 		for (const record of this.#custodyStore.list()) {
 			if (record.state !== "confirmed") continue;
 			if (record.chatId !== this.opts.chatId) continue;
-			const sessionId = this.topics
-				.sessionIds()
-				.find(candidate => this.topics.get(candidate)?.topicId === record.topicId);
-			await this.finishConfirmedTopicDeletion(sessionId ?? "", record.topicId);
+			await this.finishConfirmedTopicDeletion({ topicId: record.topicId });
 		}
 
 		const updated = { ...result, records: this.#custodyStore.list() };

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -47,6 +47,12 @@ import { listRecentSessions } from "./recent-activity";
 import { ReplySentStore } from "./reply-sent-store";
 import { DraftStreamState, deliverDraft, shouldStreamDraft } from "./rich-draft";
 import { deliverRichActionWithFallback, deliverRichWithFallback, shouldPromoteRich } from "./rich-render";
+import {
+	allocateTelegramCustodyEpoch,
+	readTelegramCustodyEpoch,
+	withCurrentTelegramCustodyEpoch,
+	type TelegramCustodyEpochBinding,
+} from "./telegram-custody-epoch";
 import { type TelegramCustodyLoadResult, TelegramCustodyStore } from "./telegram-custody-store";
 import {
 	type AliasTable,
@@ -66,6 +72,11 @@ export type EnsureDaemonResult = "owner_spawned" | "attached" | "disabled" | "bl
 export interface DaemonState {
 	pid: number;
 	ownerId: string;
+	/**
+	 * Required on all T2 writes. Optional only so a pre-T2 state can be routed
+	 * through the generation-reload handoff; it is never treated as epoch zero.
+	 */
+	custodyEpoch?: number;
 	tokenFingerprint: string;
 	chatId: string;
 	startedAt: number;
@@ -297,9 +308,14 @@ async function readJson<T>(fsImpl: TelegramDaemonFs, file: string): Promise<T | 
 
 async function writeJsonAtomic(fsImpl: TelegramDaemonFs, file: string, data: unknown): Promise<void> {
 	const tmp = `${file}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
-	await fsImpl.writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o600 });
-	await fsImpl.chmod(tmp, 0o600).catch(() => undefined);
-	await fsImpl.rename(tmp, file);
+	try {
+		await fsImpl.writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o600 });
+		await fsImpl.chmod(tmp, 0o600).catch(() => undefined);
+		await fsImpl.rename(tmp, file);
+	} catch (error) {
+		await fsImpl.unlink(tmp).catch(() => undefined);
+		throw error;
+	}
 }
 
 async function tryOpenWx(fsImpl: TelegramDaemonFs, file: string): Promise<boolean> {
@@ -381,6 +397,45 @@ export function isFreshLiveOwner(input: {
 	);
 }
 
+export type DaemonOwnershipResult =
+	| {
+			acquired: true;
+			ownerId: string;
+			custodyEpoch: number;
+			attached?: false;
+			blocked?: false;
+			reason?: never;
+			reloadRequired?: never;
+	  }
+	| {
+			acquired: false;
+			ownerId?: undefined;
+			custodyEpoch?: undefined;
+			attached?: boolean;
+			blocked?: boolean;
+			reason?: "identity_mismatch";
+			reloadRequired?: boolean;
+	  };
+
+function isCustodyEpoch(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function ownerBindingMatches(
+	state: DaemonState | undefined,
+	binding: TelegramCustodyEpochBinding,
+): state is DaemonState & { custodyEpoch: number } {
+	return Boolean(
+		state && state.ownerId === binding.ownerId && state.custodyEpoch === binding.custodyEpoch,
+	);
+}
+
+function assertValidPersistedStateEpoch(state: DaemonState | undefined): void {
+	if (state?.custodyEpoch !== undefined && !isCustodyEpoch(state.custodyEpoch)) {
+		throw new Error("invalid Telegram daemon custody epoch in persisted ownership state");
+	}
+}
+
 export async function acquireDaemonOwnership(input: {
 	settings: Settings;
 	roots?: string[];
@@ -391,14 +446,7 @@ export async function acquireDaemonOwnership(input: {
 	pid?: number;
 	pidAlive?: (pid: number) => boolean;
 	randomId?: () => string;
-}): Promise<{
-	acquired: boolean;
-	ownerId?: string;
-	attached?: boolean;
-	blocked?: boolean;
-	reason?: "identity_mismatch";
-	reloadRequired?: boolean;
-}> {
+}): Promise<DaemonOwnershipResult> {
 	const fsImpl = input.fs ?? nodeFs;
 	const now = input.now ?? Date.now;
 	const pid = input.pid ?? process.pid;
@@ -408,76 +456,85 @@ export async function acquireDaemonOwnership(input: {
 	const ownerId = input.randomId?.() ?? `${pid}-${now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 	const roots = input.roots ?? (await readJson<{ roots?: string[] }>(fsImpl, paths.roots))?.roots ?? [];
 
-	// A fresh, identity-matching live owner running an OLDER generation than this
-	// build cannot serve our newer wire frames; signal a reload instead of a
-	// silent attach. Newer/equal generations attach as before (no downgrade).
-	const attachDecision = (
-		state: DaemonState | undefined,
-	): { acquired: false; attached: boolean; reloadRequired?: boolean } | undefined => {
-		if (
-			!isFreshLiveOwner({
-				state,
-				now: now(),
+	return await withFileLock(paths.state, async () => {
+		// A fresh, identity-matching live owner running an OLDER generation than this
+		// build cannot serve our newer wire frames; signal a reload instead of a
+		// silent attach. Newer/equal generations attach as before (no downgrade).
+		const attachDecision = async (
+			state: DaemonState | undefined,
+		): Promise<{ acquired: false; attached: boolean; reloadRequired?: boolean } | undefined> => {
+			assertValidPersistedStateEpoch(state);
+			if (
+				!isFreshLiveOwner({
+					state,
+					now: now(),
+					tokenFingerprint: input.tokenFingerprint,
+					chatId: input.chatId,
+					pidAlive,
+				})
+			) {
+				return undefined;
+			}
+			// A legacy owner has no fence token. Treat it exactly like a stale
+			// generation: reload it rather than inventing custody epoch zero.
+			if (state?.custodyEpoch === undefined) {
+				return { acquired: false, attached: false, reloadRequired: true };
+			}
+			const binding = await readTelegramCustodyEpoch({ agentDir: input.settings.getAgentDir() });
+			if (!ownerBindingMatches(state, binding)) {
+				throw new Error("Telegram daemon custody epoch does not match persisted ownership state");
+			}
+			return (state.generation ?? 0) < DAEMON_GENERATION
+				? { acquired: false, attached: false, reloadRequired: true }
+				: { acquired: false, attached: true };
+		};
+
+		const publishOwnership = async (): Promise<DaemonOwnershipResult> => {
+			let binding: TelegramCustodyEpochBinding;
+			try {
+				binding = await allocateTelegramCustodyEpoch({
+					agentDir: input.settings.getAgentDir(),
+					ownerId,
+				});
+			} catch (error) {
+				// We own the physical lock while the state mutex is held. Allocation
+				// may have durably consumed an epoch before a later barrier failed;
+				// unlock without attempting to reset or reuse that epoch.
+				await fsImpl.unlink(paths.lock).catch(() => undefined);
+				throw error;
+			}
+			const state: DaemonState = {
+				pid,
+				ownerId: binding.ownerId,
+				custodyEpoch: binding.custodyEpoch,
 				tokenFingerprint: input.tokenFingerprint,
 				chatId: input.chatId,
-				pidAlive,
-			})
-		) {
-			return undefined;
-		}
-		return (state?.generation ?? 0) < DAEMON_GENERATION
-			? { acquired: false, attached: false, reloadRequired: true }
-			: { acquired: false, attached: true };
-	};
-	const existing = await readJson<DaemonState>(fsImpl, paths.state);
-	if (
-		liveOwnerUsesDifferentIdentity({
-			state: existing,
-			tokenFingerprint: input.tokenFingerprint,
-			chatId: input.chatId,
-			pidAlive,
-		})
-	) {
-		return { acquired: false, blocked: true, reason: "identity_mismatch" };
-	}
-	const existingDecision = attachDecision(existing);
-	if (existingDecision) return existingDecision;
-	if (await tryOpenWx(fsImpl, paths.lock)) {
-		await writeJsonAtomic(fsImpl, paths.state, {
-			pid,
-			ownerId,
-			tokenFingerprint: input.tokenFingerprint,
-			chatId: input.chatId,
-			startedAt: now(),
-			heartbeatAt: now(),
-			roots,
-			version: DAEMON_VERSION,
-			generation: DAEMON_GENERATION,
-		} satisfies DaemonState);
-		return { acquired: true, ownerId };
-	}
-	const afterLock = await readJson<DaemonState>(fsImpl, paths.state);
-	if (
-		liveOwnerUsesDifferentIdentity({
-			state: afterLock,
-			tokenFingerprint: input.tokenFingerprint,
-			chatId: input.chatId,
-			pidAlive,
-		})
-	) {
-		return { acquired: false, blocked: true, reason: "identity_mismatch" };
-	}
-	const afterLockDecision = attachDecision(afterLock);
-	if (afterLockDecision) return afterLockDecision;
-	if (!afterLock) return { acquired: false, attached: true };
-	if (!(await tryOpenWx(fsImpl, paths.steal))) return { acquired: false, attached: true };
-	try {
-		const rechecked = await readJson<DaemonState>(fsImpl, paths.state);
-		const recheckedDecision = attachDecision(rechecked);
-		if (recheckedDecision) return recheckedDecision;
+				startedAt: now(),
+				heartbeatAt: now(),
+				roots,
+				version: DAEMON_VERSION,
+				generation: DAEMON_GENERATION,
+			};
+			try {
+				await writeJsonAtomic(fsImpl, paths.state, state);
+			} catch (error) {
+				// The physical lock is ours while this state mutex is held. If the
+				// daemon-state publication never appeared, or still names this exact
+				// binding, remove it so the next attempt consumes a higher epoch.
+				const current = await readJson<DaemonState>(fsImpl, paths.state).catch(() => undefined);
+				if (!current || ownerBindingMatches(current, binding)) {
+					await fsImpl.unlink(paths.lock).catch(() => undefined);
+				}
+				throw error;
+			}
+			return { acquired: true, ownerId: binding.ownerId, custodyEpoch: binding.custodyEpoch };
+		};
+
+		const existing = await readJson<DaemonState>(fsImpl, paths.state);
+		assertValidPersistedStateEpoch(existing);
 		if (
 			liveOwnerUsesDifferentIdentity({
-				state: rechecked,
+				state: existing,
 				tokenFingerprint: input.tokenFingerprint,
 				chatId: input.chatId,
 				pidAlive,
@@ -485,59 +542,109 @@ export async function acquireDaemonOwnership(input: {
 		) {
 			return { acquired: false, blocked: true, reason: "identity_mismatch" };
 		}
-		if (rechecked && pidAlive(rechecked.pid)) {
-			return { acquired: false, attached: true };
+		const existingDecision = await attachDecision(existing);
+		if (existingDecision) return existingDecision;
+		if (await tryOpenWx(fsImpl, paths.lock)) return await publishOwnership();
+
+		const afterLock = await readJson<DaemonState>(fsImpl, paths.state);
+		assertValidPersistedStateEpoch(afterLock);
+		if (
+			liveOwnerUsesDifferentIdentity({
+				state: afterLock,
+				tokenFingerprint: input.tokenFingerprint,
+				chatId: input.chatId,
+				pidAlive,
+			})
+		) {
+			return { acquired: false, blocked: true, reason: "identity_mismatch" };
 		}
-		await fsImpl.unlink(paths.lock).catch(() => undefined);
-		if (!(await tryOpenWx(fsImpl, paths.lock))) return { acquired: false, attached: true };
-		await writeJsonAtomic(fsImpl, paths.state, {
-			pid,
-			ownerId,
-			tokenFingerprint: input.tokenFingerprint,
-			chatId: input.chatId,
-			startedAt: now(),
-			heartbeatAt: now(),
-			roots,
-			version: DAEMON_VERSION,
-			generation: DAEMON_GENERATION,
-		} satisfies DaemonState);
-		return { acquired: true, ownerId };
-	} finally {
-		await fsImpl.unlink(paths.steal).catch(() => undefined);
-	}
+		const afterLockDecision = await attachDecision(afterLock);
+		if (afterLockDecision) return afterLockDecision;
+		// A process can crash after durable epoch publication but before state
+		// publication. Under the state mutex, no state means this orphaned physical
+		// lock has no live owner and can be reclaimed; the next allocation skips it.
+		if (!afterLock) {
+			await fsImpl.unlink(paths.lock).catch(() => undefined);
+			if (!(await tryOpenWx(fsImpl, paths.lock))) return { acquired: false, attached: true };
+			return await publishOwnership();
+		}
+		if (!(await tryOpenWx(fsImpl, paths.steal))) return { acquired: false, attached: true };
+		try {
+			const rechecked = await readJson<DaemonState>(fsImpl, paths.state);
+			assertValidPersistedStateEpoch(rechecked);
+			if (
+				liveOwnerUsesDifferentIdentity({
+					state: rechecked,
+					tokenFingerprint: input.tokenFingerprint,
+					chatId: input.chatId,
+					pidAlive,
+				})
+			) {
+				return { acquired: false, blocked: true, reason: "identity_mismatch" };
+			}
+			const recheckedDecision = await attachDecision(rechecked);
+			if (recheckedDecision) return recheckedDecision;
+			if (rechecked && pidAlive(rechecked.pid)) return { acquired: false, attached: true };
+			await fsImpl.unlink(paths.lock).catch(() => undefined);
+			if (!(await tryOpenWx(fsImpl, paths.lock))) return { acquired: false, attached: true };
+			return await publishOwnership();
+		} finally {
+			await fsImpl.unlink(paths.steal).catch(() => undefined);
+		}
+	});
 }
 
 export async function renewDaemonHeartbeat(input: {
 	settings: Settings;
 	ownerId: string;
+	custodyEpoch: number;
 	fs?: TelegramDaemonFs;
 	now?: () => number;
 	pid?: number;
 }): Promise<boolean> {
 	const fsImpl = input.fs ?? nodeFs;
 	const paths = daemonPaths(input.settings.getAgentDir());
-	const state = await readJson<DaemonState>(fsImpl, paths.state);
-	if (!state || state.ownerId !== input.ownerId) return false;
-	await writeJsonAtomic(fsImpl, paths.state, {
-		...state,
-		pid: input.pid ?? state.pid,
-		heartbeatAt: (input.now ?? Date.now)(),
+	const binding = { ownerId: input.ownerId, custodyEpoch: input.custodyEpoch };
+	return await withFileLock(paths.state, async () => {
+		const guarded = await withCurrentTelegramCustodyEpoch(
+			{ agentDir: input.settings.getAgentDir(), binding },
+			async () => {
+				const state = await readJson<DaemonState>(fsImpl, paths.state);
+				if (!ownerBindingMatches(state, binding)) return false;
+				await writeJsonAtomic(fsImpl, paths.state, {
+					...state,
+					pid: input.pid ?? state.pid,
+					heartbeatAt: (input.now ?? Date.now)(),
+				});
+				return true;
+			},
+		);
+		return guarded.ok ? guarded.value : false;
 	});
-	return true;
 }
 
 export async function releaseDaemonOwnership(input: {
 	settings: Settings;
 	ownerId: string;
+	custodyEpoch: number;
 	fs?: TelegramDaemonFs;
 	now?: () => number;
 }): Promise<void> {
 	const fsImpl = input.fs ?? nodeFs;
 	const paths = daemonPaths(input.settings.getAgentDir());
-	const state = await readJson<DaemonState>(fsImpl, paths.state);
-	if (state?.ownerId !== input.ownerId) return;
-	await writeJsonAtomic(fsImpl, paths.state, { ...state, stoppedAt: (input.now ?? Date.now)() });
-	await fsImpl.unlink(paths.lock).catch(() => undefined);
+	const binding = { ownerId: input.ownerId, custodyEpoch: input.custodyEpoch };
+	await withFileLock(paths.state, async () => {
+		const guarded = await withCurrentTelegramCustodyEpoch(
+			{ agentDir: input.settings.getAgentDir(), binding },
+			async () => {
+				const state = await readJson<DaemonState>(fsImpl, paths.state);
+				if (!ownerBindingMatches(state, binding)) return;
+				await writeJsonAtomic(fsImpl, paths.state, { ...state, stoppedAt: (input.now ?? Date.now)() });
+				await fsImpl.unlink(paths.lock).catch(() => undefined);
+			},
+		);
+		void guarded;
+	});
 }
 
 /** Read the persisted daemon ownership state (or undefined when absent). */
@@ -598,29 +705,45 @@ export interface TelegramSpawnOwnerInput {
 	chatId: string;
 }
 
-export interface TelegramSpawnOwnerResult {
-	result: EnsureDaemonResult;
-	ownerId?: string;
-	runtime: DaemonRuntimeInfo;
-	warnings: string[];
-	/**
-	 * Set when ownership was NOT acquired because a still-live owner is running an
-	 * older daemon generation. The caller must hand off via a reload rather than
-	 * attach; see {@link ensureTelegramDaemonRunning}.
-	 */
-	reloadRequired?: boolean;
-}
+export type TelegramSpawnOwnerResult =
+	| {
+			result: "owner_spawned";
+			ownerId: string;
+			custodyEpoch: number;
+			runtime: DaemonRuntimeInfo;
+			warnings: string[];
+			reloadRequired?: false;
+	  }
+	| {
+			result: "attached" | "blocked";
+			ownerId?: undefined;
+			custodyEpoch?: undefined;
+			runtime: DaemonRuntimeInfo;
+			warnings: string[];
+			/**
+			 * Set when ownership was NOT acquired because a still-live owner is
+			 * running an older daemon generation. The caller must hand off via a
+			 * reload rather than attach; see {@link ensureTelegramDaemonRunning}.
+			 */
+			reloadRequired?: boolean;
+	  };
 
 /**
  * Build the detached spawn command/args for the daemon-internal entrypoint.
  * Source mode prepends the entry script so the respawn loads edited source;
  * a compiled binary self-spawns its own subcommand directly.
  */
-export function buildTelegramDaemonSpawnArgs(input: { execPath?: string; ownerId: string; agentDir: string }): {
+export function buildTelegramDaemonSpawnArgs(input: {
+	execPath?: string;
+	ownerId: string;
+	custodyEpoch: number;
+	agentDir: string;
+}): {
 	command: string;
 	args: string[];
 	runtime: DaemonRuntimeInfo;
 } {
+	if (!isCustodyEpoch(input.custodyEpoch)) throw new Error("invalid Telegram daemon custody epoch");
 	const rt = resolveGjcRuntimeSpawnInfo(input.execPath ?? process.execPath);
 	const args = [
 		...rt.argsPrefix,
@@ -628,6 +751,8 @@ export function buildTelegramDaemonSpawnArgs(input: { execPath?: string; ownerId
 		"daemon-internal",
 		"--owner-id",
 		input.ownerId,
+		"--custody-epoch",
+		String(input.custodyEpoch),
 		"--agent-dir",
 		input.agentDir,
 	];
@@ -663,13 +788,17 @@ export async function spawnTelegramDaemonOwner(
 		pidAlive: deps.pidAlive,
 		randomId: deps.randomId,
 	});
-	// One source of truth for runtime detection + spawn args (no duplicate resolve).
-	const { command, args, runtime } = buildTelegramDaemonSpawnArgs({
-		execPath,
-		ownerId: ownership.ownerId ?? "",
-		agentDir,
-	});
+	const runtimeInfo = (): DaemonRuntimeInfo => {
+		const rt = resolveGjcRuntimeSpawnInfo(execPath);
+		return {
+			mode: rt.mode,
+			execPath: rt.execPath,
+			reloadPicksUpSourceEdits: rt.reloadPicksUpSourceEdits,
+			warning: rt.warning,
+		};
+	};
 	if (!ownership.acquired) {
+		const runtime = runtimeInfo();
 		if (ownership.blocked) {
 			return {
 				result: "blocked",
@@ -679,14 +808,37 @@ export async function spawnTelegramDaemonOwner(
 		}
 		return { result: "attached", runtime, warnings: [], reloadRequired: ownership.reloadRequired };
 	}
-	const spawnImpl = deps.spawn ?? defaultDaemonSpawn;
-	const child = spawnImpl(command, args, {
-		detached: true,
-		stdio: "ignore",
-		logPath: path.join(daemonPaths(agentDir).dir, "daemon.log"),
+	const { command, args, runtime } = buildTelegramDaemonSpawnArgs({
+		execPath,
+		ownerId: ownership.ownerId,
+		custodyEpoch: ownership.custodyEpoch,
+		agentDir,
 	});
-	child?.unref?.();
-	return { result: "owner_spawned", ownerId: ownership.ownerId, runtime, warnings: [] };
+	const spawnImpl = deps.spawn ?? defaultDaemonSpawn;
+	try {
+		const child = spawnImpl(command, args, {
+			detached: true,
+			stdio: "ignore",
+			logPath: path.join(daemonPaths(agentDir).dir, "daemon.log"),
+		});
+		child?.unref?.();
+	} catch (error) {
+		await releaseDaemonOwnership({
+			settings: input.settings,
+			ownerId: ownership.ownerId,
+			custodyEpoch: ownership.custodyEpoch,
+			fs: deps.fs,
+			now: deps.now,
+		});
+		throw error;
+	}
+	return {
+		result: "owner_spawned",
+		ownerId: ownership.ownerId,
+		custodyEpoch: ownership.custodyEpoch,
+		runtime,
+		warnings: [],
+	};
 }
 
 export async function ensureTelegramDaemonRunning(
@@ -922,15 +1074,16 @@ export class TelegramEventDispatchState {
  * file so the daemon does not import the control module directly.
  */
 export interface DaemonControlHooks {
-	/** Returns true when a stop/reload has been requested for this owner. */
-	shouldStop(ownerId: string): Promise<boolean>;
-	/** Clear a consumed control request (best-effort). */
-	clear?(ownerId: string): Promise<void>;
+	/** Returns true when a stop/reload has been requested for this owner binding. */
+	shouldStop(ownerId: string, custodyEpoch: number): Promise<boolean>;
+	/** Clear a consumed control request (best-effort) for this owner binding. */
+	clear?(ownerId: string, custodyEpoch: number): Promise<void>;
 }
 
 export interface TelegramDaemonOptions {
 	settings: Settings;
 	ownerId: string;
+	custodyEpoch: number;
 	botToken: string;
 	chatId: string;
 	apiBase?: string;
@@ -1438,6 +1591,9 @@ export class TelegramNotificationDaemon {
 			agentDir: opts.settings.getAgentDir(),
 			fs: opts.fs,
 			now: opts.now,
+			fence: {
+				binding: { ownerId: opts.ownerId, custodyEpoch: opts.custodyEpoch },
+			},
 		});
 		this.aliasTable = createAliasTable();
 		this.botApi =
@@ -3231,6 +3387,7 @@ export class TelegramNotificationDaemon {
 		this.running = await renewDaemonHeartbeat({
 			settings: this.opts.settings,
 			ownerId: this.opts.ownerId,
+			custodyEpoch: this.opts.custodyEpoch,
 			fs: this.fsImpl,
 			now: this.opts.now,
 			pid: this.opts.pid ?? process.pid,
@@ -3259,6 +3416,7 @@ export class TelegramNotificationDaemon {
 					!(await renewDaemonHeartbeat({
 						settings: this.opts.settings,
 						ownerId: this.opts.ownerId,
+						custodyEpoch: this.opts.custodyEpoch,
 						fs: this.fsImpl,
 						now: this.opts.now,
 						pid: this.opts.pid ?? process.pid,
@@ -3308,10 +3466,11 @@ export class TelegramNotificationDaemon {
 			await this.persistAliases().catch(() => undefined);
 			await this.persistTopics().catch(() => undefined);
 			await this.persistSeenUpdateIds().catch(() => undefined);
-			await this.opts.control?.clear?.(this.opts.ownerId).catch(() => undefined);
+			await this.opts.control?.clear?.(this.opts.ownerId, this.opts.custodyEpoch).catch(() => undefined);
 			await releaseDaemonOwnership({
 				settings: this.opts.settings,
 				ownerId: this.opts.ownerId,
+				custodyEpoch: this.opts.custodyEpoch,
 				fs: this.fsImpl,
 				now: this.opts.now,
 			});
@@ -3323,7 +3482,7 @@ export class TelegramNotificationDaemon {
 		if (this.runtime.stopRequested) return true;
 		if (!this.opts.control) return false;
 		try {
-			return await this.opts.control.shouldStop(this.opts.ownerId);
+			return await this.opts.control.shouldStop(this.opts.ownerId, this.opts.custodyEpoch);
 		} catch {
 			return false;
 		}

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -2406,18 +2406,36 @@ export class TelegramNotificationDaemon {
 	}
 
 	private async finishConfirmedTopicDeletion(sessionId: string, topicId: string): Promise<void> {
-		const current = this.topics.get(sessionId);
-		if (current !== undefined && current.topicId !== topicId) return;
-		const previousTopic = current === undefined ? undefined : Object.freeze({ ...current });
-		if (current !== undefined) this.topics.delete(sessionId);
+		let localCleanup = false;
 		try {
-			await this.persistTopics();
+			const guarded = await withCurrentTelegramCustodyEpoch(
+				{
+					agentDir: this.opts.settings.getAgentDir(),
+					binding: { ownerId: this.opts.ownerId, custodyEpoch: this.opts.custodyEpoch },
+				},
+				async () => {
+					const current = this.topics.get(sessionId);
+					if (current !== undefined && current.topicId !== topicId) return false;
+					const previousTopic = current === undefined ? undefined : Object.freeze({ ...current });
+					if (current !== undefined) this.topics.delete(sessionId);
+					try {
+						await this.persistTopics();
+					} catch {
+						if (previousTopic !== undefined) this.topics.load({ topics: { [sessionId]: previousTopic } });
+						logger.warn("notifications: Telegram topic deletion local persistence failed");
+						return false;
+					}
+					if (current !== undefined) this.clearDeletedTopicRuntimeState(sessionId);
+					return true;
+				},
+			);
+			if (!guarded.ok) return;
+			localCleanup = guarded.value;
 		} catch {
-			if (previousTopic !== undefined) this.topics.load({ topics: { [sessionId]: previousTopic } });
-			logger.warn("notifications: Telegram topic deletion local persistence failed");
+			logger.warn("notifications: Telegram topic deletion local cleanup fence failed");
 			return;
 		}
-		if (current !== undefined) this.clearDeletedTopicRuntimeState(sessionId);
+		if (!localCleanup) return;
 		try {
 			const removed = await this.#custodyStore.removeConfirmed({ chatId: this.opts.chatId, topicId });
 			if (!removed.ok) return;

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -47,6 +47,7 @@ import { listRecentSessions } from "./recent-activity";
 import { ReplySentStore } from "./reply-sent-store";
 import { DraftStreamState, deliverDraft, shouldStreamDraft } from "./rich-draft";
 import { deliverRichActionWithFallback, deliverRichWithFallback, shouldPromoteRich } from "./rich-render";
+import { type TelegramCustodyLoadResult, TelegramCustodyStore } from "./telegram-custody-store";
 import {
 	type AliasTable,
 	buildActionMarkdown,
@@ -1024,6 +1025,9 @@ export class TelegramNotificationDaemon {
 	private running = false;
 	private readonly fsImpl: TelegramDaemonFs;
 	private readonly botApi: BotApi;
+	readonly #custodyStore: TelegramCustodyStore;
+	/** Startup custody result retained for later deletion-recovery phases. */
+	#custodyLoadResult: TelegramCustodyLoadResult | undefined;
 	private readonly topics = new TopicRegistry();
 	/** Serializes registry snapshots so an older atomic write cannot overwrite newer rename state. */
 	private topicsPersistQueue: Promise<void> = Promise.resolve();
@@ -1430,6 +1434,11 @@ export class TelegramNotificationDaemon {
 	constructor(private readonly opts: TelegramDaemonOptions) {
 		this.fsImpl = opts.fs ?? nodeFs;
 		this.replyStore = new ReplySentStore({ agentDir: opts.settings.getAgentDir(), fs: opts.fs });
+		this.#custodyStore = new TelegramCustodyStore({
+			agentDir: opts.settings.getAgentDir(),
+			fs: opts.fs,
+			now: opts.now,
+		});
 		this.aliasTable = createAliasTable();
 		this.botApi =
 			opts.botApi ??
@@ -2114,6 +2123,15 @@ export class TelegramNotificationDaemon {
 		// Restore the full serialized registry (topicId + identitySent + name) so a
 		// fresh daemon after reload does not resend identity headers or lose renames.
 		if (raw && typeof raw === "object") this.topics.load(raw);
+	}
+	get custodyLoadResult(): TelegramCustodyLoadResult | undefined {
+		return this.#custodyLoadResult;
+	}
+
+	async loadCustody(): Promise<TelegramCustodyLoadResult> {
+		const result = await this.#custodyStore.load();
+		this.#custodyLoadResult = result;
+		return result;
 	}
 
 	/** Download a Telegram file by its file_path (from getFile) into memory. */
@@ -3227,6 +3245,7 @@ export class TelegramNotificationDaemon {
 			await this.registerBotCommands();
 			await this.loadAliases();
 			await this.loadTopics();
+			await this.loadCustody();
 			await this.loadSeenUpdateIds();
 			await this.replyStore.load();
 			await this.runScan();

--- a/packages/coding-agent/src/notifications/telegram-daemon.ts
+++ b/packages/coding-agent/src/notifications/telegram-daemon.ts
@@ -1896,7 +1896,7 @@ export class TelegramNotificationDaemon {
 					// explicitly stale (e.g. a hard-closed session): reconnecting
 					// would chase a dead, token-bearing record forever. Once the
 					// associated topic is past the grace window, reap it through the
-					// same best-effort delete path as graceful session shutdown.
+					// same durable custody settlement path as graceful session shutdown.
 					const pidAlive = this.opts.pidAlive ?? defaultPidAlive;
 					if (endpoint.stale || (endpoint.pid !== undefined && !pidAlive(endpoint.pid))) {
 						await this.deleteOrphanedTopic(sessionId);
@@ -2357,12 +2357,17 @@ export class TelegramNotificationDaemon {
 		) {
 			return { kind: "malformed_response" };
 		}
-		const value = response as { ok?: unknown; error_code?: unknown };
-		if (value.ok === true) return { kind: "telegram_ok" };
-		if (value.ok !== false) return { kind: "malformed_response" };
+		const descriptors = Object.getOwnPropertyDescriptors(response);
+		if (Object.values(descriptors).some(descriptor => !Object.hasOwn(descriptor, "value"))) {
+			return { kind: "malformed_response" };
+		}
+		const ok = descriptors.ok?.value;
+		if (ok === true) return { kind: "telegram_ok" };
+		if (ok !== false) return { kind: "malformed_response" };
 
+		const errorCodeValue = descriptors.error_code?.value;
 		const errorCode =
-			typeof value.error_code === "number" && Number.isSafeInteger(value.error_code) ? value.error_code : undefined;
+			typeof errorCodeValue === "number" && Number.isSafeInteger(errorCodeValue) ? errorCodeValue : undefined;
 		let rejection: TelegramRejectionClass = "other";
 		if (errorCode === 404) rejection = "not_found";
 		else if (errorCode === 403) rejection = "forbidden";
@@ -2403,12 +2408,12 @@ export class TelegramNotificationDaemon {
 	private async finishConfirmedTopicDeletion(sessionId: string, topicId: string): Promise<void> {
 		const current = this.topics.get(sessionId);
 		if (current !== undefined && current.topicId !== topicId) return;
-		const previousTopics = this.topics.serialize();
+		const previousTopic = current === undefined ? undefined : Object.freeze({ ...current });
 		if (current !== undefined) this.topics.delete(sessionId);
 		try {
 			await this.persistTopics();
 		} catch {
-			if (current !== undefined) this.topics.load(previousTopics);
+			if (previousTopic !== undefined) this.topics.load({ topics: { [sessionId]: previousTopic } });
 			logger.warn("notifications: Telegram topic deletion local persistence failed");
 			return;
 		}

--- a/packages/coding-agent/test/daemon-control.test.ts
+++ b/packages/coding-agent/test/daemon-control.test.ts
@@ -62,6 +62,7 @@ function freshState(extra: Partial<Record<string, unknown>> = {}): Record<string
 	return {
 		pid: 999,
 		ownerId: "old",
+		custodyEpoch: 1,
 		tokenFingerprint: tokenFingerprint(BOT_TOKEN),
 		chatId: "42",
 		startedAt: Date.now(),
@@ -229,11 +230,13 @@ describe("control request helpers", () => {
 			action: "reload",
 			ownerId: "owner-a",
 			pid: 123,
+			custodyEpoch: 1,
 			createdAt: Date.now(),
 		});
 		const read = await readTelegramControlRequest(s);
 		expect(read?.requestId).toBe("r1");
 		expect(read?.ownerId).toBe("owner-a");
+		expect(read?.custodyEpoch).toBe(1);
 
 		// Clearing with a mismatched requestId must not remove a newer request.
 		await clearTelegramControlRequest(s, "different-id");

--- a/packages/coding-agent/test/daemon-control.test.ts
+++ b/packages/coding-agent/test/daemon-control.test.ts
@@ -16,6 +16,10 @@ import {
 } from "../src/daemon/operator-contract";
 import { resolveGjcRuntimeSpawnInfo } from "../src/daemon/runtime";
 import { tokenFingerprint } from "../src/notifications/config";
+import {
+	TELEGRAM_CUSTODY_EPOCH_SCHEMA_VERSION,
+	telegramCustodyEpochPath,
+} from "../src/notifications/telegram-custody-epoch";
 import { daemonPaths } from "../src/notifications/telegram-daemon";
 import {
 	clearTelegramControlRequest,
@@ -52,10 +56,28 @@ function settings(agentDir: string): Settings {
 	);
 }
 
-function writeState(agentDir: string, state: Record<string, unknown>): void {
+function writeState(
+	agentDir: string,
+	state: Record<string, unknown>,
+	{ writeEpoch = true }: { writeEpoch?: boolean } = {},
+): void {
 	const paths = daemonPaths(agentDir);
 	fs.mkdirSync(paths.dir, { recursive: true });
 	fs.writeFileSync(paths.state, JSON.stringify(state));
+	const { ownerId, custodyEpoch } = state;
+	if (
+		writeEpoch &&
+		typeof ownerId === "string" &&
+		ownerId.length > 0 &&
+		typeof custodyEpoch === "number" &&
+		Number.isSafeInteger(custodyEpoch) &&
+		custodyEpoch > 0
+	) {
+		fs.writeFileSync(
+			telegramCustodyEpochPath(agentDir),
+			`${JSON.stringify({ version: TELEGRAM_CUSTODY_EPOCH_SCHEMA_VERSION, custodyEpoch, ownerId })}\n`,
+		);
+	}
 }
 
 function freshState(extra: Partial<Record<string, unknown>> = {}): Record<string, unknown> {

--- a/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
+++ b/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
@@ -147,13 +147,21 @@ describe("compiled daemon smoke coverage", () => {
 		const { command, args, runtime } = buildTelegramDaemonSpawnArgs({
 			execPath: "/opt/gjc/gjc",
 			ownerId: "owner-1",
+			custodyEpoch: 1,
 			agentDir: "/tmp/agent",
 		});
 		expect(command).toBe("/opt/gjc/gjc");
 		// No bun/node entry-script prefix in compiled mode: the binary self-spawns its subcommand.
-		expect(args[0]).toBe("notify");
-		expect(args).toContain("daemon-internal");
-		expect(args).toEqual(expect.arrayContaining(["--owner-id", "owner-1", "--agent-dir", "/tmp/agent"]));
+		expect(args).toEqual([
+			"notify",
+			"daemon-internal",
+			"--owner-id",
+			"owner-1",
+			"--custody-epoch",
+			"1",
+			"--agent-dir",
+			"/tmp/agent",
+		]);
 		expect(runtime.mode).toBe("compiled");
 		expect(runtime.reloadPicksUpSourceEdits).toBe(false);
 		expect(runtime.warning).toContain("Rebuild");

--- a/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
+++ b/packages/coding-agent/test/notifications-compiled-daemon-smoke.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import nativesPackageJson from "../../natives/package.json" with { type: "json" };
 import { devEntrypoints, releaseEntrypoints } from "../scripts/compile-args";
 import { buildTelegramDaemonSpawnArgs, daemonPaths } from "../src/notifications/telegram-daemon";
 
@@ -14,7 +15,7 @@ describe("compiled daemon smoke coverage", () => {
 
 	async function runWithTimeout(
 		command: string[],
-		opts: { cwd: string },
+		opts: { cwd: string; env?: Record<string, string | undefined> },
 		timeoutMs: number,
 	): Promise<{
 		exitCode: number | null;
@@ -42,6 +43,26 @@ describe("compiled daemon smoke coverage", () => {
 			new Response(proc.stderr).text(),
 		]);
 		return { exitCode, stdout, stderr, timedOut };
+	}
+
+	function stageCompiledNativeAddons(dataHome: string): void {
+		const nativeDir = path.join(repoRoot, "packages/natives/native");
+		const filenamePrefix = `pi_natives.${process.platform}-${process.arch}`;
+		const addonFilenames = fs
+			.readdirSync(nativeDir)
+			.filter(
+				filename =>
+					filename === `${filenamePrefix}.node` ||
+					filename === `${filenamePrefix}-baseline.node` ||
+					filename === `${filenamePrefix}-modern.node`,
+			);
+		expect(addonFilenames).not.toHaveLength(0);
+
+		const stagedNativeDir = path.join(dataHome, "gjc", "natives", nativesPackageJson.version);
+		fs.mkdirSync(stagedNativeDir, { recursive: true });
+		for (const filename of addonFilenames) {
+			fs.copyFileSync(path.join(nativeDir, filename), path.join(stagedNativeDir, filename));
+		}
 	}
 
 	async function buildCompiledDaemonSmokeBinary(outPath: string): Promise<void> {
@@ -120,15 +141,22 @@ describe("compiled daemon smoke coverage", () => {
 	test("compiled binary with daemon CLI entrypoint starts root version and daemon smoke", async () => {
 		const temp = tempDir("gjc-compiled-daemon-binary-");
 		const binaryPath = path.join(temp, "gjc-repro");
+		const nativeDataHome = path.join(temp, "xdg-data");
+		const isolatedEnv = {
+			...process.env,
+			XDG_DATA_HOME: nativeDataHome,
+			...(process.platform === "win32" ? { LOCALAPPDATA: path.join(temp, "local-app-data") } : {}),
+		};
 		try {
+			stageCompiledNativeAddons(nativeDataHome);
 			await buildCompiledDaemonSmokeBinary(binaryPath);
-			const version = await runWithTimeout([binaryPath, "--version"], { cwd: temp }, 10_000);
+			const version = await runWithTimeout([binaryPath, "--version"], { cwd: temp, env: isolatedEnv }, 10_000);
 			expect(version.timedOut).toBe(false);
 			expect(`${version.exitCode}\n${version.stdout}\n${version.stderr}`).toStartWith("0\ngjc/");
 
 			const smoke = await runWithTimeout(
 				[binaryPath, "notify", "daemon-internal", "--smoke"],
-				{ cwd: temp },
+				{ cwd: temp, env: isolatedEnv },
 				10_000,
 			);
 			expect(smoke.timedOut).toBe(false);
@@ -136,7 +164,7 @@ describe("compiled daemon smoke coverage", () => {
 		} finally {
 			fs.rmSync(temp, { recursive: true, force: true });
 		}
-	});
+	}, 30_000);
 
 	test("compile entrypoint lists preserve the dynamic daemon entrypoint for compiled binaries", () => {
 		expect(devEntrypoints).toContain("./src/notifications/telegram-daemon-cli.ts");

--- a/packages/coding-agent/test/notifications-html-format.test.ts
+++ b/packages/coding-agent/test/notifications-html-format.test.ts
@@ -293,6 +293,7 @@ function makeDaemon(
 	return new TelegramNotificationDaemon({
 		settings: isolatedSettings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot as any,
@@ -423,6 +424,7 @@ describe("default multipart sendPhoto forwards parse_mode (AC1 amendment)", () =
 		const daemon = new TelegramNotificationDaemon({
 			settings: isolatedSettings(Bun.env.TMPDIR ?? "/tmp"),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			fetchImpl,

--- a/packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts
@@ -43,6 +43,7 @@ function makeDaemon(agentDir: string, bot: never): TelegramNotificationDaemon {
 	return new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,

--- a/packages/coding-agent/test/notifications-lifecycle-daemon-ownership.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-daemon-ownership.test.ts
@@ -92,6 +92,7 @@ function makeDaemon(s: Settings, factory: LifecycleControlServerFactory | null):
 	return new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: fakeBot,

--- a/packages/coding-agent/test/notifications-live-stream.test.ts
+++ b/packages/coding-agent/test/notifications-live-stream.test.ts
@@ -228,6 +228,7 @@ async function bootDaemon() {
 	const daemon = new TelegramNotificationDaemon({
 		settings: daemonSettings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot as never,

--- a/packages/coding-agent/test/notifications-rich-draft.test.ts
+++ b/packages/coding-agent/test/notifications-rich-draft.test.ts
@@ -342,6 +342,7 @@ function makeDraftDaemon(
 	return new TelegramNotificationDaemon({
 		settings: draftSettings(tempAgentDir()),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot as any,

--- a/packages/coding-agent/test/notifications-rich-e2e.test.ts
+++ b/packages/coding-agent/test/notifications-rich-e2e.test.ts
@@ -140,6 +140,7 @@ async function connectRealPipeline(rich?: { enabled: boolean }): Promise<Harness
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,

--- a/packages/coding-agent/test/notifications-rich-redteam.test.ts
+++ b/packages/coding-agent/test/notifications-rich-redteam.test.ts
@@ -113,6 +113,7 @@ function makeRichDaemon(bot: BotApi, rich?: { enabled: boolean }): TelegramNotif
 	return new TelegramNotificationDaemon({
 		settings: settings(tempAgentDir()),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot as any,

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -10,6 +10,7 @@ import {
 	TELEGRAM_PARSE_MODE,
 } from "../src/notifications/html-format";
 import { deliverRichWithFallback } from "../src/notifications/rich-render";
+import { telegramCustodyEpochPath } from "../src/notifications/telegram-custody-epoch";
 import {
 	acquireDaemonOwnership,
 	buildTelegramDaemonSpawnArgs,
@@ -17,23 +18,22 @@ import {
 	DAEMON_VERSION,
 	daemonPaths,
 	ensureTelegramDaemonRunning,
-	spawnTelegramDaemonOwner,
 	registerNotificationRoot,
 	releaseDaemonOwnership,
 	renewDaemonHeartbeat,
+	spawnTelegramDaemonOwner,
 	TelegramBotTransport,
 	type TelegramDaemonFs,
 	TelegramEventDispatchState,
 	TelegramNotificationDaemon,
 	TelegramUpdatePoller,
 } from "../src/notifications/telegram-daemon";
+import { runDaemonInternal, runDaemonSmoke } from "../src/notifications/telegram-daemon-cli";
 import {
 	clearTelegramControlRequest,
 	readTelegramControlRequest,
 	writeTelegramControlRequest,
 } from "../src/notifications/telegram-daemon-control";
-import { telegramCustodyEpochPath } from "../src/notifications/telegram-custody-epoch";
-import { runDaemonInternal, runDaemonSmoke } from "../src/notifications/telegram-daemon-cli";
 
 const THREADED_FALLBACK_NOTICE =
 	"Flat Telegram private chat supports outbound notifications and inline ask buttons only. Enable Threaded Mode in @BotFather > Bot Settings > Threads Settings for free-text replies and session commands.";

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -10,7 +10,7 @@ import {
 	TELEGRAM_PARSE_MODE,
 } from "../src/notifications/html-format";
 import { deliverRichWithFallback } from "../src/notifications/rich-render";
-import { telegramCustodyEpochPath } from "../src/notifications/telegram-custody-epoch";
+import { allocateTelegramCustodyEpoch, telegramCustodyEpochPath } from "../src/notifications/telegram-custody-epoch";
 import {
 	acquireDaemonOwnership,
 	buildTelegramDaemonSpawnArgs,
@@ -65,6 +65,9 @@ function setPrivateAgentDir(s: Settings, agentDir: string) {
 		},
 	}) as Settings;
 }
+async function allocateTestCustodyEpoch(agentDir: string, ownerId = "owner"): Promise<number> {
+	return (await allocateTelegramCustodyEpoch({ agentDir, ownerId })).custodyEpoch;
+}
 
 function topicStateFs(onTopicStateWrite: () => Promise<void>): TelegramDaemonFs {
 	return {
@@ -75,6 +78,33 @@ function topicStateFs(onTopicStateWrite: () => Promise<void>): TelegramDaemonFs 
 			await fs.promises.writeFile(file, data, opts);
 		},
 		rename: (oldPath, newPath) => fs.promises.rename(oldPath, newPath).then(() => undefined),
+		unlink: file => fs.promises.unlink(file),
+		open: async (file, flags, mode) => fs.promises.open(file, flags, mode),
+		readdir: file => fs.promises.readdir(file),
+		chmod: (file, mode) => fs.promises.chmod(file, mode),
+	};
+}
+function trackedDaemonFs(input: {
+	commits?: string[];
+	failCustodyWriteAt?: number;
+	failTopicWrite?: () => boolean;
+}): TelegramDaemonFs {
+	let custodyWrites = 0;
+	return {
+		mkdir: (file, opts) => fs.promises.mkdir(file, opts).then(() => undefined),
+		readFile: (file, encoding) => fs.promises.readFile(file, encoding),
+		writeFile: async (file, data, opts) => {
+			if (file.includes("telegram-deletion-custody.json")) {
+				custodyWrites += 1;
+				if (custodyWrites === input.failCustodyWriteAt) throw new Error("custody write failed");
+			}
+			if (file.includes("telegram-topics.json") && input.failTopicWrite?.()) throw new Error("topic write failed");
+			await fs.promises.writeFile(file, data, opts);
+		},
+		rename: async (from, to) => {
+			input.commits?.push(path.basename(to));
+			await fs.promises.rename(from, to);
+		},
 		unlink: file => fs.promises.unlink(file),
 		open: async (file, flags, mode) => fs.promises.open(file, flags, mode),
 		readdir: file => fs.promises.readdir(file),
@@ -104,13 +134,16 @@ class FakeWs extends EventTarget {
 }
 
 class FakeBotApi {
-	calls: Array<{ method: string; body: any }> = [];
+	calls: Array<{ method: string; body: any; opts?: { signal?: AbortSignal; noRetry?: boolean } }> = [];
 	updates: any[] = [];
 	activeGetUpdates = 0;
 	maxConcurrentGetUpdates = 0;
 	botUsername: string | undefined = undefined;
-	async call(method: string, body: unknown): Promise<unknown> {
-		this.calls.push({ method, body });
+	deleteResponse: unknown | undefined;
+	deleteError: unknown | undefined;
+
+	async call(method: string, body: unknown, opts?: { signal?: AbortSignal; noRetry?: boolean }): Promise<unknown> {
+		this.calls.push({ method, body, opts });
 		if (method === "getUpdates") {
 			this.activeGetUpdates++;
 			this.maxConcurrentGetUpdates = Math.max(this.maxConcurrentGetUpdates, this.activeGetUpdates);
@@ -127,8 +160,90 @@ class FakeBotApi {
 		if (method === "getFile") return { ok: true, result: { file_path: "docs/file_7.bin" } };
 		if (method === "createForumTopic") return { ok: true, result: { message_thread_id: this.calls.length } };
 		if (method === "sendMessage") return { ok: true, result: { message_id: this.calls.length } };
+		if (method === "deleteForumTopic") {
+			if (this.deleteError !== undefined) throw this.deleteError;
+			if (this.deleteResponse !== undefined) return this.deleteResponse;
+		}
 		return { ok: true, result: true };
 	}
+}
+type CustodySnapshot = {
+	version: number;
+	records: Record<
+		string,
+		{
+			state: string;
+			trigger?: string;
+			diagnostic?: { kind: string; rejection?: string; transport?: string; errorCode?: number };
+		}
+	>;
+};
+
+function readCustodySnapshot(agentDir: string): CustodySnapshot {
+	return JSON.parse(
+		fs.readFileSync(path.join(daemonPaths(agentDir).dir, "telegram-deletion-custody.json"), "utf8"),
+	) as CustodySnapshot;
+}
+
+function currentTopicId(agentDir: string, sessionId: string): string {
+	const state = JSON.parse(fs.readFileSync(path.join(daemonPaths(agentDir).dir, "telegram-topics.json"), "utf8")) as {
+		topics: Record<string, { topicId: string }>;
+	};
+	return state.topics[sessionId]!.topicId;
+}
+
+async function createTopicDeletionHarness(
+	bot = new FakeBotApi(),
+	ownerId = "owner",
+	fsImpl: TelegramDaemonFs | undefined = undefined,
+) {
+	const agentDir = tempAgentDir();
+	const custodyEpoch = await allocateTestCustodyEpoch(agentDir, ownerId);
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId,
+		custodyEpoch,
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		fs: fsImpl,
+	});
+	const session: {
+		sessionId: string;
+		token: string;
+		endpointKey: string;
+		ws: { readyState: number; send(): void };
+		pending: Map<unknown, unknown>;
+	} = {
+		sessionId: "S",
+		token: "tok",
+		endpointKey: "endpoint",
+		ws: { readyState: 1, send() {} },
+		pending: new Map(),
+	};
+	await daemon.handleSessionMessage(session as never, {
+		type: "identity_header",
+		sessionId: "S",
+		repo: "repo",
+		branch: "branch",
+	});
+	return { agentDir, custodyEpoch, bot, daemon, session };
+}
+
+async function closeTopicSession(input: {
+	daemon: TelegramNotificationDaemon;
+	session: {
+		sessionId: string;
+		token: string;
+		endpointKey: string;
+		ws: { readyState: number; send(): void };
+		pending: Map<unknown, unknown>;
+	};
+}): Promise<void> {
+	await input.daemon.handleSessionMessage(input.session as never, {
+		type: "session_closed",
+		sessionId: input.session.sessionId,
+	});
 }
 
 type TopicAuthorityState = {
@@ -3390,12 +3505,13 @@ test("activity busy frame sends a typing chat action into the session topic", as
 
 test("session_closed deletes the topic and resume creates a fresh visible topic", async () => {
 	const agentDir = tempAgentDir();
+	const custodyEpoch = await allocateTestCustodyEpoch(agentDir);
 	const bot = new FakeBotApi();
 	let now = 0;
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
-		custodyEpoch: 1,
+		custodyEpoch,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3424,6 +3540,9 @@ test("session_closed deletes the topic and resume creates a fresh visible topic"
 	const deleted = bot.calls.find(c => c.method === "deleteForumTopic");
 	expect(deleted).toBeTruthy();
 	expect(deleted!.body.message_thread_id).toBe(threadId);
+	expect(deleted!.body).toEqual({ chat_id: "42", message_thread_id: threadId });
+	expect(deleted!.opts).toEqual({ noRetry: true });
+	expect(bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
 
 	now = 10_000;
 	bot.calls = [];
@@ -3446,6 +3565,200 @@ test("session_closed deletes the topic and resume creates a fresh visible topic"
 	);
 });
 
+test("concurrent session-close triggers join one claimed topic deletion", async () => {
+	const harness = await createTopicDeletionHarness();
+	const topicId = currentTopicId(harness.agentDir, "S");
+	harness.bot.calls = [];
+
+	await Promise.all([closeTopicSession(harness), closeTopicSession(harness)]);
+
+	const deletions = harness.bot.calls.filter(call => call.method === "deleteForumTopic");
+	expect(deletions).toEqual([
+		{
+			method: "deleteForumTopic",
+			body: { chat_id: "42", message_thread_id: Number(topicId) },
+			opts: { noRetry: true },
+		},
+	]);
+	expect(readCustodySnapshot(harness.agentDir).records).toEqual({});
+});
+
+test("rejected, malformed, and reset topic deletion outcomes remain unknown without retries", async () => {
+	const reset = Object.assign(new Error("connection reset secret-reset"), { code: "ECONNRESET" });
+	const cases: Array<{
+		response?: unknown;
+		error?: unknown;
+		diagnostic: { kind: string; rejection?: string; transport?: string; errorCode?: number };
+		forbidden: string;
+	}> = [
+		{
+			response: { ok: false, error_code: 429, description: "too many requests secret-description" },
+			diagnostic: { kind: "telegram_rejected", rejection: "rate_limited", errorCode: 429 },
+			forbidden: "secret-description",
+		},
+		{
+			response: { ok: "true" },
+			diagnostic: { kind: "malformed_response" },
+			forbidden: "true",
+		},
+		{
+			error: reset,
+			diagnostic: { kind: "transport_ambiguous", transport: "connection_reset" },
+			forbidden: "secret-reset",
+		},
+	];
+
+	for (const entry of cases) {
+		const bot = new FakeBotApi();
+		const harness = await createTopicDeletionHarness(bot);
+		const topicId = currentTopicId(harness.agentDir, "S");
+		bot.deleteResponse = entry.response;
+		bot.deleteError = entry.error;
+		bot.calls = [];
+
+		await closeTopicSession(harness);
+
+		expect(bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+		expect(readCustodySnapshot(harness.agentDir).records[`42:${topicId}`]).toMatchObject({
+			state: "unknown",
+			trigger: "session_closed",
+			diagnostic: entry.diagnostic,
+		});
+		expect(
+			fs.readFileSync(path.join(daemonPaths(harness.agentDir).dir, "telegram-deletion-custody.json"), "utf8"),
+		).not.toContain(entry.forbidden);
+
+		await closeTopicSession(harness);
+		expect(bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	}
+});
+
+test("same-owner ABA and read-only custody block a topic deletion before the call", async () => {
+	const aba = await createTopicDeletionHarness(new FakeBotApi(), "same-owner");
+	await allocateTestCustodyEpoch(aba.agentDir, "same-owner");
+	aba.bot.calls = [];
+	await closeTopicSession(aba);
+	expect(aba.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(0);
+
+	const readOnly = await createTopicDeletionHarness();
+	fs.writeFileSync(path.join(daemonPaths(readOnly.agentDir).dir, "telegram-deletion-custody.json"), "{");
+	readOnly.bot.calls = [];
+	await closeTopicSession(readOnly);
+	expect(readOnly.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(0);
+});
+
+test("claim persistence failure leaves the topic queued and makes no deletion request", async () => {
+	const harness = await createTopicDeletionHarness(
+		new FakeBotApi(),
+		"owner",
+		trackedDaemonFs({ failCustodyWriteAt: 2 }),
+	);
+	const topicId = currentTopicId(harness.agentDir, "S");
+	harness.bot.calls = [];
+
+	await closeTopicSession(harness);
+
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(0);
+	expect(readCustodySnapshot(harness.agentDir).records[`42:${topicId}`]).toMatchObject({ state: "queued" });
+});
+
+test("pool flush failure leaves deletion queued before the claim", async () => {
+	const harness = await createTopicDeletionHarness();
+	const topicId = currentTopicId(harness.agentDir, "S");
+	const daemon = harness.daemon as unknown as { flushPool(): Promise<void> };
+	daemon.flushPool = async () => {
+		throw new Error("pool flush failed");
+	};
+	harness.bot.calls = [];
+
+	await closeTopicSession(harness);
+
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(0);
+	expect(readCustodySnapshot(harness.agentDir).records[`42:${topicId}`]).toMatchObject({ state: "queued" });
+});
+test("confirmed custody precedes local topic persistence and custody cleanup", async () => {
+	const commits: string[] = [];
+	const harness = await createTopicDeletionHarness(new FakeBotApi(), "owner", trackedDaemonFs({ commits }));
+	commits.length = 0;
+	harness.bot.calls = [];
+
+	await closeTopicSession(harness);
+
+	expect(commits).toEqual([
+		"telegram-deletion-custody.json",
+		"telegram-deletion-custody.json",
+		"telegram-deletion-custody.json",
+		"telegram-topics.json",
+		"telegram-deletion-custody.json",
+	]);
+});
+
+test("settlement and local persistence failures never issue a second deletion request", async () => {
+	const settlementFs = trackedDaemonFs({ failCustodyWriteAt: 3 });
+	const settlement = await createTopicDeletionHarness(new FakeBotApi(), "owner", settlementFs);
+	const settlementTopicId = currentTopicId(settlement.agentDir, "S");
+	settlement.bot.calls = [];
+	await closeTopicSession(settlement);
+	expect(settlement.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	expect(readCustodySnapshot(settlement.agentDir).records[`42:${settlementTopicId}`]).toMatchObject({
+		state: "in_flight",
+	});
+	await closeTopicSession(settlement);
+	expect(settlement.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+
+	const recovered = new TelegramNotificationDaemon({
+		settings: settings(settlement.agentDir),
+		ownerId: "owner",
+		custodyEpoch: settlement.custodyEpoch,
+		botToken: "tok",
+		chatId: "42",
+		botApi: settlement.bot,
+		fs: settlementFs,
+	});
+	await recovered.loadTopics();
+	await closeTopicSession({ daemon: recovered, session: settlement.session });
+	expect(settlement.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+
+	let failTopicWrite = false;
+	const topicFs = trackedDaemonFs({ failTopicWrite: () => failTopicWrite });
+	const topic = await createTopicDeletionHarness(new FakeBotApi(), "owner", topicFs);
+	const topicId = currentTopicId(topic.agentDir, "S");
+	failTopicWrite = true;
+	topic.bot.calls = [];
+	await closeTopicSession(topic);
+	expect(topic.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	expect(readCustodySnapshot(topic.agentDir).records[`42:${topicId}`]).toMatchObject({ state: "confirmed" });
+	await closeTopicSession(topic);
+	expect(topic.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+
+	failTopicWrite = false;
+	await closeTopicSession(topic);
+	expect(topic.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	expect(readCustodySnapshot(topic.agentDir).records).toEqual({});
+
+	const cleanupFs = trackedDaemonFs({ failCustodyWriteAt: 4 });
+	const cleanup = await createTopicDeletionHarness(new FakeBotApi(), "owner", cleanupFs);
+	const cleanupTopicId = currentTopicId(cleanup.agentDir, "S");
+	cleanup.bot.calls = [];
+	await closeTopicSession(cleanup);
+	expect(cleanup.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	expect(readCustodySnapshot(cleanup.agentDir).records[`42:${cleanupTopicId}`]).toMatchObject({
+		state: "confirmed",
+	});
+	const cleanupRecovered = new TelegramNotificationDaemon({
+		settings: settings(cleanup.agentDir),
+		ownerId: "owner",
+		custodyEpoch: cleanup.custodyEpoch,
+		botToken: "tok",
+		chatId: "42",
+		botApi: cleanup.bot,
+		fs: cleanupFs,
+	});
+	await cleanupRecovered.loadTopics();
+	await cleanupRecovered.loadCustody();
+	expect(cleanup.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	expect(readCustodySnapshot(cleanup.agentDir).records).toEqual({});
+});
 test("session_closed clears reply message routes for the closed session", async () => {
 	FakeWs.instances = [];
 	const agentDir = tempAgentDir();
@@ -3475,6 +3788,7 @@ test("session_closed clears reply message routes for the closed session", async 
 test("session_closed tombstones its endpoint generation so scans do not recreate an empty topic", async () => {
 	FakeWs.instances = [];
 	const agentDir = tempAgentDir();
+	const custodyEpoch = await allocateTestCustodyEpoch(agentDir);
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);
 	const cwd = path.join(agentDir, "repo");
 	await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
@@ -3486,7 +3800,7 @@ test("session_closed tombstones its endpoint generation so scans do not recreate
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
-		custodyEpoch: 1,
+		custodyEpoch,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4192,16 +4506,23 @@ test("run() persists aliases before releasing ownership on exit", async () => {
 	expect(fs.existsSync(daemonPaths(agentDir).aliases)).toBe(true);
 });
 describe("telegram custody loading", () => {
-	test("migrates custody before the first scan without Telegram deletion or delivery", async () => {
+	test("recovers in-flight custody before the first scan without Telegram deletion or delivery", async () => {
 		const agentDir = tempAgentDir();
 		const custodyPath = path.join(agentDir, "notifications", "telegram-deletion-custody.json");
 		fs.mkdirSync(path.dirname(custodyPath), { recursive: true });
 		fs.writeFileSync(
 			custodyPath,
 			JSON.stringify({
-				version: 1,
-				chatId: "42",
-				records: { "7": { state: "in_flight", updatedAt: 1 } },
+				version: 3,
+				records: {
+					"42:7": {
+						chatId: "42",
+						topicId: "7",
+						state: "in_flight",
+						updatedAt: 1,
+						custodyEpoch: 1,
+					},
+				},
 			}),
 		);
 
@@ -4247,13 +4568,29 @@ describe("telegram custody loading", () => {
 		expect(events).toEqual(["topics", "custody", "scan"]);
 		expect(daemon.custodyLoadResult).toEqual({
 			mode: "writable",
-			migrated: true,
-			records: [{ chatId: "42", topicId: "7", state: "unknown", updatedAt: 1 }],
+			migrated: false,
+			records: [
+				{
+					chatId: "42",
+					topicId: "7",
+					state: "unknown",
+					updatedAt: 1,
+					custodyEpoch: 1,
+					diagnostic: { kind: "restart_after_claim" },
+				},
+			],
 		});
 		expect(JSON.parse(fs.readFileSync(custodyPath, "utf8"))).toEqual({
-			version: 2,
+			version: 3,
 			records: {
-				"42:7": { chatId: "42", topicId: "7", state: "unknown", updatedAt: 1 },
+				"42:7": {
+					chatId: "42",
+					topicId: "7",
+					state: "unknown",
+					updatedAt: 1,
+					custodyEpoch: 1,
+					diagnostic: { kind: "restart_after_claim" },
+				},
 			},
 		});
 		expect(bot.calls.filter(call => call.method === "deleteForumTopic" || call.method === "sendMessage")).toEqual([]);
@@ -4394,9 +4731,55 @@ test("scanRoots connects only live endpoints (skips stale + dead-PID records)", 
 	expect(FakeWs.instances.every(ws => ws.url.startsWith("ws://live"))).toBe(true);
 });
 
+test("orphan reaping records its trigger and retains a rejected topic deletion", async () => {
+	const agentDir = tempAgentDir();
+	const custodyEpoch = await allocateTestCustodyEpoch(agentDir);
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const cwd = path.join(agentDir, "repo");
+	await registerNotificationRoot({ settings: s, cwd, sessionId: "orphan" });
+	const endpointDir = path.join(cwd, ".gjc", "state", "notifications");
+	fs.mkdirSync(endpointDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(endpointDir, "orphan.json"),
+		JSON.stringify({ url: "ws://orphan", token: "t", stale: true }),
+	);
+	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+		JSON.stringify({ topics: { orphan: { topicId: "301", identitySent: true, createdAt: 0, name: "orphan" } } }),
+	);
+
+	const bot = new FakeBotApi();
+	bot.deleteResponse = { ok: false, error_code: 404, description: "topic is gone" };
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		custodyEpoch,
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		now: () => 120_000,
+	});
+	await daemon.loadTopics();
+	await daemon.scanRoots();
+
+	expect(bot.calls.filter(call => call.method === "deleteForumTopic")).toEqual([
+		{
+			method: "deleteForumTopic",
+			body: { chat_id: "42", message_thread_id: 301 },
+			opts: { noRetry: true },
+		},
+	]);
+	expect(readCustodySnapshot(agentDir).records["42:301"]).toMatchObject({
+		state: "unknown",
+		trigger: "orphan_reap",
+		diagnostic: { kind: "telegram_rejected", rejection: "not_found", errorCode: 404 },
+	});
+});
 test("scanRoots reaps stale and dead-PID session topics after the orphan grace window", async () => {
 	FakeWs.instances = [];
 	const agentDir = tempAgentDir();
+	const custodyEpoch = await allocateTestCustodyEpoch(agentDir);
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);
 	const cwd = path.join(agentDir, "repo");
 	await registerNotificationRoot({ settings: s, cwd, sessionId: "stale" });
@@ -4422,7 +4805,7 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
-		custodyEpoch: 1,
+		custodyEpoch,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4443,6 +4826,7 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 
 test("scanRoots reaps missing endpoint topics only when all roots are readable and grace has elapsed", async () => {
 	const agentDir = tempAgentDir();
+	const custodyEpoch = await allocateTestCustodyEpoch(agentDir);
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);
 	const cwd = path.join(agentDir, "repo");
 	await registerNotificationRoot({ settings: s, cwd, sessionId: "missing" });
@@ -4456,7 +4840,7 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
-		custodyEpoch: 1,
+		custodyEpoch,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -10,7 +10,11 @@ import {
 	TELEGRAM_PARSE_MODE,
 } from "../src/notifications/html-format";
 import { deliverRichWithFallback } from "../src/notifications/rich-render";
-import { allocateTelegramCustodyEpoch, telegramCustodyEpochPath } from "../src/notifications/telegram-custody-epoch";
+import {
+	allocateTelegramCustodyEpoch,
+	telegramCustodyEpochPath,
+	withCurrentTelegramCustodyEpoch,
+} from "../src/notifications/telegram-custody-epoch";
 import {
 	acquireDaemonOwnership,
 	buildTelegramDaemonSpawnArgs,
@@ -3920,6 +3924,104 @@ test("same-owner epoch advance after confirmed settlement fences stale local cle
 	) as { topics: Record<string, { topicId: string }> };
 	expect(recoveredTopics.topics.S).toBeUndefined();
 	expect(readCustodySnapshot(harness.agentDir).records).toEqual({});
+});
+test("confirmed recovery resolves a topic only after acquiring the current custody epoch", async () => {
+	const agentDir = tempAgentDir();
+	const custodyEpoch = await allocateTestCustodyEpoch(agentDir);
+	const topicId = "77";
+	fs.writeFileSync(
+		path.join(daemonPaths(agentDir).dir, "telegram-deletion-custody.json"),
+		JSON.stringify({
+			version: 3,
+			records: {
+				[`42:${topicId}`]: {
+					chatId: "42",
+					topicId,
+					state: "confirmed",
+					updatedAt: 0,
+					custodyEpoch,
+					trigger: "session_closed",
+					diagnostic: { kind: "telegram_ok" },
+				},
+			},
+		}),
+	);
+
+	const bot = new FakeBotApi();
+	const recovery = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		custodyEpoch,
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	await recovery.loadTopics();
+
+	const internals = recovery as unknown as {
+		topics: {
+			load(state: { topics: Record<string, { topicId: string; identitySent: boolean; createdAt: number }> }): void;
+			sessionIds(): string[];
+		};
+		persistTopics(): Promise<void>;
+		finishConfirmedTopicDeletion(input: unknown, topicId?: string): Promise<void>;
+	};
+	const sessionIds = internals.topics.sessionIds.bind(internals.topics);
+	let sessionIdsBeforeEpochProof = 0;
+	internals.topics.sessionIds = () => {
+		sessionIdsBeforeEpochProof += 1;
+		return sessionIds();
+	};
+	const helperEntered = Promise.withResolvers<void>();
+	const finishConfirmedTopicDeletion = internals.finishConfirmedTopicDeletion.bind(recovery);
+	internals.finishConfirmedTopicDeletion = async (input, confirmedTopicId) => {
+		helperEntered.resolve();
+		await finishConfirmedTopicDeletion(input, confirmedTopicId);
+	};
+
+	const epochGuardEntered = Promise.withResolvers<void>();
+	const releaseEpochGuard = Promise.withResolvers<void>();
+	const epochGuard = withCurrentTelegramCustodyEpoch(
+		{
+			agentDir,
+			binding: { ownerId: "owner", custodyEpoch },
+		},
+		async () => {
+			epochGuardEntered.resolve();
+			await releaseEpochGuard.promise;
+		},
+	);
+	await epochGuardEntered.promise;
+
+	let recoveryLoad: Promise<unknown> | undefined;
+	try {
+		recoveryLoad = recovery.loadCustody();
+		await helperEntered.promise;
+		expect(sessionIdsBeforeEpochProof).toBe(0);
+
+		internals.topics.load({
+			topics: {
+				S: { topicId, identitySent: true, createdAt: 0 },
+			},
+		});
+		await internals.persistTopics();
+		expect(currentTopicId(agentDir, "S")).toBe(topicId);
+
+		releaseEpochGuard.resolve();
+		expect((await epochGuard).ok).toBe(true);
+		await recoveryLoad;
+
+		const persistedTopics = JSON.parse(
+			fs.readFileSync(path.join(daemonPaths(agentDir).dir, "telegram-topics.json"), "utf8"),
+		) as { topics: Record<string, { topicId: string }> };
+		expect(persistedTopics.topics.S).toBeUndefined();
+		expect(readCustodySnapshot(agentDir).records).toEqual({});
+		expect(bot.calls).toHaveLength(0);
+	} finally {
+		releaseEpochGuard.resolve();
+		await epochGuard;
+		await recoveryLoad;
+	}
 });
 
 test("pool flush failure leaves deletion queued before the claim", async () => {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -3842,6 +3842,86 @@ test("an epoch advance after a durable claim fences the deletion call and restar
 	});
 });
 
+test("same-owner epoch advance after confirmed settlement fences stale local cleanup", async () => {
+	let agentDir = "";
+	let nextCustodyEpoch = 0;
+	let advanced = false;
+	const commits: string[] = [];
+	const fsImpl = trackedDaemonFs({
+		commits,
+		onCustodyCommit: data => {
+			const snapshot = JSON.parse(data) as CustodySnapshot;
+			if (!Object.values(snapshot.records).some(record => record.state === "confirmed")) return;
+			advanced = true;
+			fs.writeFileSync(
+				telegramCustodyEpochPath(agentDir),
+				JSON.stringify({ version: 1, ownerId: "owner", custodyEpoch: nextCustodyEpoch }),
+			);
+		},
+	});
+	const harness = await createTopicDeletionHarness(new FakeBotApi(), "owner", fsImpl);
+	agentDir = harness.agentDir;
+	nextCustodyEpoch = harness.custodyEpoch + 1;
+	const topicId = currentTopicId(harness.agentDir, "S");
+	commits.length = 0;
+	harness.bot.calls = [];
+
+	await closeTopicSession(harness);
+
+	expect(advanced).toBe(true);
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	expect(commits).toEqual([
+		"telegram-deletion-custody.json",
+		"telegram-deletion-custody.json",
+		"telegram-deletion-custody.json",
+	]);
+	expect(currentTopicId(harness.agentDir, "S")).toBe(topicId);
+	expect(readCustodySnapshot(harness.agentDir).records[`42:${topicId}`]).toMatchObject({
+		state: "confirmed",
+		custodyEpoch: harness.custodyEpoch,
+	});
+	const staleTopics = fs.readFileSync(path.join(daemonPaths(harness.agentDir).dir, "telegram-topics.json"), "utf8");
+	const staleCustody = fs.readFileSync(
+		path.join(daemonPaths(harness.agentDir).dir, "telegram-deletion-custody.json"),
+		"utf8",
+	);
+
+	await closeTopicSession(harness);
+
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	expect(commits).toEqual([
+		"telegram-deletion-custody.json",
+		"telegram-deletion-custody.json",
+		"telegram-deletion-custody.json",
+	]);
+	expect(fs.readFileSync(path.join(daemonPaths(harness.agentDir).dir, "telegram-topics.json"), "utf8")).toBe(
+		staleTopics,
+	);
+	expect(fs.readFileSync(path.join(daemonPaths(harness.agentDir).dir, "telegram-deletion-custody.json"), "utf8")).toBe(
+		staleCustody,
+	);
+
+	const currentOwner = new TelegramNotificationDaemon({
+		settings: settings(harness.agentDir),
+		ownerId: "owner",
+		custodyEpoch: nextCustodyEpoch,
+		botToken: "tok",
+		chatId: "42",
+		botApi: harness.bot,
+		fs: fsImpl,
+	});
+	const callsBeforeRecovery = harness.bot.calls.length;
+	await currentOwner.loadTopics();
+	await currentOwner.loadCustody();
+
+	expect(harness.bot.calls).toHaveLength(callsBeforeRecovery);
+	const recoveredTopics = JSON.parse(
+		fs.readFileSync(path.join(daemonPaths(harness.agentDir).dir, "telegram-topics.json"), "utf8"),
+	) as { topics: Record<string, { topicId: string }> };
+	expect(recoveredTopics.topics.S).toBeUndefined();
+	expect(readCustodySnapshot(harness.agentDir).records).toEqual({});
+});
+
 test("pool flush failure leaves deletion queued before the claim", async () => {
 	const harness = await createTopicDeletionHarness();
 	const topicId = currentTopicId(harness.agentDir, "S");
@@ -3938,7 +4018,7 @@ test("settlement and local persistence failures never issue a second deletion re
 	await cleanupRecovered.loadCustody();
 	expect(cleanup.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
 	expect(readCustodySnapshot(cleanup.agentDir).records).toEqual({});
-});
+}, 15_000);
 test("foreign confirmed custody does not clean up a colliding current-chat topic on restart", async () => {
 	const harness = await createTopicDeletionHarness();
 	const topicId = currentTopicId(harness.agentDir, "S");

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -3683,7 +3683,7 @@ test("deterministic two-topic cleanup rollback restores only its failed session"
 
 	await closeTopicSession({ daemon: harness.daemon, session: secondSession });
 	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
-});
+}, 15_000);
 
 test("rejected, malformed, and reset topic deletion outcomes remain unknown without retries", async () => {
 	const reset = Object.assign(new Error("connection reset secret-reset"), { code: "ECONNRESET" });

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -3601,7 +3601,6 @@ test("concurrent session-close triggers join one claimed topic deletion", async 
 test("deterministic two-topic cleanup rollback restores only its failed session", async () => {
 	const firstTopicWrite = Promise.withResolvers<void>();
 	const releaseFirstTopicWrite = Promise.withResolvers<void>();
-	const secondTopicDeleted = Promise.withResolvers<void>();
 	let holdFirstCleanupWrite = false;
 	let heldTopicWrite = false;
 	let failHeldTopicWrite = false;
@@ -3639,36 +3638,51 @@ test("deterministic two-topic cleanup rollback restores only its failed session"
 	});
 	const firstTopicId = currentTopicId(harness.agentDir, "S");
 	const secondTopicId = currentTopicId(harness.agentDir, "T");
-	const registry = harness.daemon as unknown as { topics: { delete(sessionId: string): boolean } };
-	const deleteTopicRecord = registry.topics.delete.bind(registry.topics);
-	registry.topics.delete = sessionId => {
-		const deleted = deleteTopicRecord(sessionId);
-		if (sessionId === "T") secondTopicDeleted.resolve();
-		return deleted;
+	const registry = harness.daemon as unknown as {
+		topics: {
+			delete(sessionId: string): boolean;
+			get(sessionId: string): { topicId: string } | undefined;
+		};
+		persistTopics(): Promise<void>;
 	};
 	harness.bot.calls = [];
 	holdFirstCleanupWrite = true;
 
 	const firstClose = closeTopicSession(harness);
 	await firstTopicWrite.promise;
-	const secondClose = closeTopicSession({ daemon: harness.daemon, session: secondSession });
-	await secondTopicDeleted.promise;
+
+	// Confirmed local cleanups serialize under the epoch guard. Mutate T directly
+	// through the private registry seam rather than wait for a second cleanup lock.
+	expect(registry.topics.delete("T")).toBe(true);
+	expect(registry.topics.get("T")).toBeUndefined();
 	releaseFirstTopicWrite.resolve();
-	await Promise.all([firstClose, secondClose]);
+	await firstClose;
 
 	expect(heldTopicWrite).toBe(true);
 	expect(failHeldTopicWrite).toBe(false);
-	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(2);
+	expect(registry.topics.get("S")?.topicId).toBe(firstTopicId);
+	expect(registry.topics.get("T")).toBeUndefined();
+
+	// Persist after S releases the guard: targeted rollback must retain T's mutation.
+	await registry.persistTopics();
 	const persistedTopics = JSON.parse(
 		fs.readFileSync(path.join(daemonPaths(harness.agentDir).dir, "telegram-topics.json"), "utf8"),
 	) as { topics: Record<string, { topicId: string }> };
 	expect(persistedTopics.topics.S?.topicId).toBe(firstTopicId);
 	expect(persistedTopics.topics.T).toBeUndefined();
+
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toEqual([
+		{
+			method: "deleteForumTopic",
+			body: { chat_id: "42", message_thread_id: Number(firstTopicId) },
+			opts: { noRetry: true },
+		},
+	]);
 	expect(readCustodySnapshot(harness.agentDir).records[`42:${firstTopicId}`]).toMatchObject({ state: "confirmed" });
 	expect(readCustodySnapshot(harness.agentDir).records[`42:${secondTopicId}`]).toBeUndefined();
 
 	await closeTopicSession({ daemon: harness.daemon, session: secondSession });
-	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(2);
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
 });
 
 test("rejected, malformed, and reset topic deletion outcomes remain unknown without retries", async () => {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "../src/config/settings";
+import { tokenFingerprint } from "../src/notifications/config";
 import {
 	markdownToTelegramHtml,
 	splitTelegramHtml,
@@ -69,6 +70,26 @@ function setPrivateAgentDir(s: Settings, agentDir: string) {
 		},
 	}) as Settings;
 }
+function topicStateEnvelope(
+	topics: Record<string, unknown>,
+	identity: { chatId?: string; botToken?: string } = {},
+): { version: number; chatId: string; tokenFingerprint: string; topics: Record<string, unknown> } {
+	const chatId = identity.chatId ?? "42";
+	return {
+		version: 1,
+		chatId,
+		tokenFingerprint: tokenFingerprint(identity.botToken ?? "tok"),
+		topics,
+	};
+}
+async function openDaemonFsHandle(
+	file: string,
+	flags: string,
+	mode?: number,
+): Promise<{ sync(): Promise<void>; close(): Promise<void> }> {
+	const handle = await fs.promises.open(file, flags, mode);
+	return { sync: () => handle.sync(), close: () => handle.close() };
+}
 async function allocateTestCustodyEpoch(agentDir: string, ownerId = "owner"): Promise<number> {
 	return (await allocateTelegramCustodyEpoch({ agentDir, ownerId })).custodyEpoch;
 }
@@ -83,7 +104,7 @@ function topicStateFs(onTopicStateWrite: () => Promise<void>): TelegramDaemonFs 
 		},
 		rename: (oldPath, newPath) => fs.promises.rename(oldPath, newPath).then(() => undefined),
 		unlink: file => fs.promises.unlink(file),
-		open: async (file, flags, mode) => fs.promises.open(file, flags, mode),
+		open: openDaemonFsHandle,
 		readdir: file => fs.promises.readdir(file),
 		chmod: (file, mode) => fs.promises.chmod(file, mode),
 	};
@@ -122,7 +143,7 @@ function trackedDaemonFs(input: {
 			}
 		},
 		unlink: file => fs.promises.unlink(file),
-		open: async (file, flags, mode) => fs.promises.open(file, flags, mode),
+		open: openDaemonFsHandle,
 		readdir: file => fs.promises.readdir(file),
 		chmod: (file, mode) => fs.promises.chmod(file, mode),
 	};
@@ -449,6 +470,50 @@ describe("telegram daemon", () => {
 			expect(registry.sessions[`s${i}`]).toBe(path.join(agentDir, `cwd-${i}`, ".gjc", "state"));
 		}
 	});
+	test("atomic daemon persistence syncs temporary and installed files before tolerating unsupported directory sync", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const paths = daemonPaths(agentDir);
+		const syncs: Array<{ file: string; flags: string }> = [];
+		const fsImpl: TelegramDaemonFs = {
+			mkdir: (file, opts) => fs.promises.mkdir(file, opts).then(() => undefined),
+			readFile: (file, encoding) => fs.promises.readFile(file, encoding),
+			writeFile: (file, data, opts) => fs.promises.writeFile(file, data, opts),
+			rename: (from, to) => fs.promises.rename(from, to).then(() => undefined),
+			unlink: file => fs.promises.unlink(file),
+			open: async (file, flags, mode) => {
+				if (file === paths.dir && flags === "r") {
+					return {
+						sync: async () => {
+							syncs.push({ file, flags });
+							const error = new Error("directory sync unavailable") as NodeJS.ErrnoException;
+							error.code = "EPERM";
+							throw error;
+						},
+						close: async () => undefined,
+					};
+				}
+				const handle = await fs.promises.open(file, flags, mode);
+				return {
+					sync: async () => {
+						syncs.push({ file, flags });
+						await handle.sync();
+					},
+					close: () => handle.close(),
+				};
+			},
+			readdir: file => fs.promises.readdir(file),
+			chmod: (file, mode) => fs.promises.chmod(file, mode),
+		};
+
+		await registerNotificationRoot({ settings: s, cwd: path.join(agentDir, "repo"), sessionId: "S", fs: fsImpl });
+
+		expect(syncs).toHaveLength(3);
+		expect(syncs[0]).toMatchObject({ flags: "r+" });
+		expect(syncs[0]!.file).toStartWith(`${paths.roots}.`);
+		expect(syncs[1]).toEqual({ file: paths.roots, flags: "r+" });
+		expect(syncs[2]).toEqual({ file: paths.dir, flags: "r" });
+	});
 
 	test("fake Bot API observes one getUpdates loop", async () => {
 		const agentDir = tempAgentDir();
@@ -527,20 +592,34 @@ describe("telegram daemon", () => {
 		expect(requests[1].init.body).toBeInstanceOf(FormData);
 	});
 
-	test("TelegramBotTransport noRetry performs one application request", async () => {
-		let attempts = 0;
-		const transport = new TelegramBotTransport({
+	test("TelegramBotTransport retries recognized transient errors by default but honors noRetry", async () => {
+		let noRetryAttempts = 0;
+		const noRetryTransport = new TelegramBotTransport({
 			botToken: "tok",
 			apiBase: "https://telegram.test",
 			fetchImpl: (async () => {
-				attempts++;
-				throw new Error("connection reset after write");
+				noRetryAttempts++;
+				throw Object.assign(new Error("connection reset after write"), { code: "ECONNRESET" });
 			}) as unknown as typeof fetch,
 		});
 		await expect(
-			transport.call("sendMessage", { chat_id: "42", text: "Selected!" }, { noRetry: true }),
+			noRetryTransport.call("deleteForumTopic", { chat_id: "42", message_thread_id: 301 }, { noRetry: true }),
 		).rejects.toThrow("connection reset");
-		expect(attempts).toBe(1);
+		expect(noRetryAttempts).toBe(1);
+
+		let defaultRetryAttempts = 0;
+		const defaultRetryTransport = new TelegramBotTransport({
+			botToken: "tok",
+			apiBase: "https://telegram.test",
+			fetchImpl: (async () => {
+				defaultRetryAttempts++;
+				throw Object.assign(new Error("connection reset after write"), { code: "ECONNRESET" });
+			}) as unknown as typeof fetch,
+		});
+		await expect(
+			defaultRetryTransport.call("deleteForumTopic", { chat_id: "42", message_thread_id: 301 }),
+		).rejects.toThrow("connection reset");
+		expect(defaultRetryAttempts).toBe(3);
 	});
 
 	test("TelegramEventDispatchState groups dispatch state without changing maps", () => {
@@ -3211,6 +3290,106 @@ test("stale identity after loadTopics reuses the persisted repo branch owner", a
 	expect(threadedSends).toHaveLength(1);
 	expect(Number(threadedSends[0])).toBeGreaterThan(0);
 });
+test("persisted topics use and load a matching versioned Telegram identity envelope", async () => {
+	const { agentDir } = await identityTopicHarness();
+	const topicPath = path.join(daemonPaths(agentDir).dir, "telegram-topics.json");
+	const persisted = JSON.parse(fs.readFileSync(topicPath, "utf8")) as {
+		version: number;
+		chatId: string;
+		tokenFingerprint: string;
+		topics: Record<string, { topicId: string }>;
+	};
+	expect(persisted).toMatchObject({
+		version: 1,
+		chatId: "42",
+		tokenFingerprint: tokenFingerprint("tok"),
+	});
+	const topicId = persisted.topics.S!.topicId;
+
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		custodyEpoch: 1,
+		botToken: "tok",
+		chatId: "42",
+		botApi: new FakeBotApi(),
+	});
+	await daemon.loadTopics();
+
+	const internals = daemon as unknown as {
+		topics: {
+			get(sessionId: string): { topicId: string } | undefined;
+			sessionForTopic(topicId: string): string | undefined;
+		};
+	};
+	expect(internals.topics.get("S")?.topicId).toBe(topicId);
+	expect(internals.topics.sessionForTopic(topicId)).toBe("S");
+});
+
+test.each([
+	["legacy", () => JSON.stringify({ topics: { S: { topicId: "301", identitySent: true, createdAt: 0 } } })],
+	[
+		"malformed",
+		() =>
+			JSON.stringify({
+				version: 1,
+				chatId: "42",
+				tokenFingerprint: tokenFingerprint("tok"),
+				topics: ["not-a-registry"],
+			}),
+	],
+	[
+		"forward-version",
+		() =>
+			JSON.stringify({
+				...topicStateEnvelope({ S: { topicId: "301", identitySent: true, createdAt: 0 } }),
+				version: 2,
+			}),
+	],
+	[
+		"cross-chat collision",
+		() =>
+			JSON.stringify(
+				topicStateEnvelope({ S: { topicId: "301", identitySent: true, createdAt: 0 } }, { chatId: "43" }),
+			),
+	],
+	[
+		"token-rotation collision",
+		() =>
+			JSON.stringify(
+				topicStateEnvelope(
+					{ S: { topicId: "301", identitySent: true, createdAt: 0 } },
+					{ botToken: "rotated-token" },
+				),
+			),
+	],
+])("loadTopics fails closed for %s state before scan/deletion", async (_name, serialize) => {
+	const agentDir = tempAgentDir();
+	const custodyEpoch = await allocateTestCustodyEpoch(agentDir);
+	const topicPath = path.join(daemonPaths(agentDir).dir, "telegram-topics.json");
+	fs.mkdirSync(path.dirname(topicPath), { recursive: true });
+	const persisted = serialize();
+	fs.writeFileSync(topicPath, persisted);
+
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(agentDir),
+		ownerId: "owner",
+		custodyEpoch,
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+	});
+	await expect(daemon.loadTopics()).rejects.toThrow("Telegram topic state");
+
+	const internals = daemon as unknown as {
+		topics: { sessionForTopic(topicId: string): string | undefined };
+	};
+	expect(internals.topics.sessionForTopic("301")).toBeUndefined();
+	await daemon.scanRoots();
+	expect(bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(0);
+	expect(fs.readFileSync(topicPath, "utf8")).toBe(persisted);
+});
 
 test("threaded mode off: frames fall back to the flat paired chat with a one-time notice", async () => {
 	const agentDir = tempAgentDir();
@@ -3684,6 +3863,210 @@ test("deterministic two-topic cleanup rollback restores only its failed session"
 	await closeTopicSession({ daemon: harness.daemon, session: secondSession });
 	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
 }, 15_000);
+test("held cleanup persistence failure preserves a same-session topic replacement", async () => {
+	const cleanupWriteStarted = Promise.withResolvers<void>();
+	const releaseCleanupWrite = Promise.withResolvers<void>();
+	let holdCleanupWrite = false;
+	let cleanupWriteHeld = false;
+	let failCleanupWrite = false;
+	const harness = await createTopicDeletionHarness(
+		new FakeBotApi(),
+		"owner",
+		trackedDaemonFs({
+			onTopicWrite: async data => {
+				if (!holdCleanupWrite || cleanupWriteHeld) return;
+				const snapshot = JSON.parse(data) as { topics: Record<string, unknown> };
+				if (Object.hasOwn(snapshot.topics, "S")) return;
+				cleanupWriteHeld = true;
+				failCleanupWrite = true;
+				cleanupWriteStarted.resolve();
+				await releaseCleanupWrite.promise;
+			},
+			failTopicWrite: () => {
+				if (!failCleanupWrite) return false;
+				failCleanupWrite = false;
+				return true;
+			},
+		}),
+	);
+	const originalTopicId = currentTopicId(harness.agentDir, "S");
+	const registry = harness.daemon as unknown as {
+		topics: {
+			get(sessionId: string): { topicId: string } | undefined;
+			getOrCreateTopic(
+				sessionId: string,
+				create: () => Promise<string>,
+				now?: () => number,
+				name?: string,
+			): Promise<{ topicId: string }>;
+			sessionForTopic(topicId: string): string | undefined;
+		};
+		persistTopics(): Promise<void>;
+	};
+	harness.bot.calls = [];
+	holdCleanupWrite = true;
+
+	const close = closeTopicSession(harness);
+	await cleanupWriteStarted.promise;
+	const replacement = await registry.topics.getOrCreateTopic(
+		"S",
+		async () => "302",
+		() => 1,
+		"replacement",
+	);
+	expect(registry.topics.sessionForTopic(originalTopicId)).toBeUndefined();
+	expect(registry.topics.sessionForTopic(replacement.topicId)).toBe("S");
+
+	releaseCleanupWrite.resolve();
+	await close;
+
+	expect(cleanupWriteHeld).toBe(true);
+	expect(failCleanupWrite).toBe(false);
+	expect(registry.topics.get("S")?.topicId).toBe(replacement.topicId);
+	expect(registry.topics.sessionForTopic(originalTopicId)).toBeUndefined();
+	expect(registry.topics.sessionForTopic(replacement.topicId)).toBe("S");
+
+	await registry.persistTopics();
+	expect(currentTopicId(harness.agentDir, "S")).toBe(replacement.topicId);
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toEqual([
+		{
+			method: "deleteForumTopic",
+			body: { chat_id: "42", message_thread_id: Number(originalTopicId) },
+			opts: { noRetry: true },
+		},
+	]);
+}, 15_000);
+test("held successful cleanup preserves a same-session replacement and its runtime state", async () => {
+	const cleanupWriteStarted = Promise.withResolvers<void>();
+	const releaseCleanupWrite = Promise.withResolvers<void>();
+	let holdCleanupWrite = false;
+	let cleanupWriteHeld = false;
+	const harness = await createTopicDeletionHarness(
+		new FakeBotApi(),
+		"owner",
+		trackedDaemonFs({
+			onTopicWrite: async data => {
+				if (!holdCleanupWrite || cleanupWriteHeld) return;
+				const snapshot = JSON.parse(data) as { topics: Record<string, unknown> };
+				if (Object.hasOwn(snapshot.topics, "S")) return;
+				cleanupWriteHeld = true;
+				cleanupWriteStarted.resolve();
+				await releaseCleanupWrite.promise;
+			},
+		}),
+	);
+	const originalTopicId = currentTopicId(harness.agentDir, "S");
+	const internals = harness.daemon as unknown as {
+		topics: {
+			get(sessionId: string): { topicId: string } | undefined;
+			getOrCreateTopic(
+				sessionId: string,
+				create: () => Promise<string>,
+				now?: () => number,
+				name?: string,
+			): Promise<{ topicId: string }>;
+			sessionForTopic(topicId: string): string | undefined;
+		};
+		liveMessages: Map<string, number>;
+		topicOwnerByIdentity: Map<string, string>;
+		pendingThreadedFrames: Map<string, unknown>;
+	};
+	harness.bot.calls = [];
+	holdCleanupWrite = true;
+
+	const close = closeTopicSession(harness);
+	await cleanupWriteStarted.promise;
+	const replacement = await internals.topics.getOrCreateTopic(
+		"S",
+		async () => "302",
+		() => 1,
+		"replacement",
+	);
+	const replacementIdentity = "replacement-repo\0replacement-branch";
+	const replacementFrames = [{ send: { method: "sendMessage" }, msg: { type: "turn_stream" } }];
+	internals.liveMessages.set("S:replacement", 9001);
+	internals.topicOwnerByIdentity.set(replacementIdentity, "S");
+	internals.pendingThreadedFrames.set("S", replacementFrames);
+
+	releaseCleanupWrite.resolve();
+	await close;
+
+	expect(cleanupWriteHeld).toBe(true);
+	expect(internals.topics.get("S")?.topicId).toBe(replacement.topicId);
+	expect(internals.topics.sessionForTopic(originalTopicId)).toBeUndefined();
+	expect(internals.topics.sessionForTopic(replacement.topicId)).toBe("S");
+	expect(internals.liveMessages.get("S:replacement")).toBe(9001);
+	expect(internals.topicOwnerByIdentity.get(replacementIdentity)).toBe("S");
+	expect(internals.pendingThreadedFrames.get("S")).toBe(replacementFrames);
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toEqual([
+		{
+			method: "deleteForumTopic",
+			body: { chat_id: "42", message_thread_id: Number(originalTopicId) },
+			opts: { noRetry: true },
+		},
+	]);
+}, 15_000);
+test.each([
+	["installed-file"],
+	["parent-directory"],
+] as const)("confirmed cleanup keeps custody and local topic state when %s sync fails", async failurePoint => {
+	let agentDir = "";
+	let topicFile = "";
+	let armed = false;
+	let failTopicParentSync = false;
+	const fsImpl = trackedDaemonFs({});
+	const open = fsImpl.open;
+	fsImpl.open = async (file, flags, mode) => {
+		const paths = daemonPaths(agentDir);
+		const failSync = async (): Promise<never> => {
+			const error = new Error(`${failurePoint} topic sync failed`) as NodeJS.ErrnoException;
+			error.code = "EIO";
+			throw error;
+		};
+		if (armed && failurePoint === "parent-directory" && failTopicParentSync && file === paths.dir && flags === "r") {
+			failTopicParentSync = false;
+			return { sync: failSync, close: async () => undefined };
+		}
+		const handle = await open(file, flags, mode);
+		return {
+			sync: async () => {
+				if (armed && failurePoint === "installed-file" && file === topicFile && flags === "r+") {
+					await failSync();
+				}
+				await handle.sync();
+				if (armed && failurePoint === "parent-directory" && file === topicFile && flags === "r+") {
+					failTopicParentSync = true;
+				}
+			},
+			close: () => handle.close(),
+		};
+	};
+
+	const harness = await createTopicDeletionHarness(new FakeBotApi(), "owner", fsImpl);
+	agentDir = harness.agentDir;
+	topicFile = path.join(daemonPaths(agentDir).dir, "telegram-topics.json");
+	const topicId = currentTopicId(agentDir, "S");
+	const internals = harness.daemon as unknown as {
+		topics: {
+			get(sessionId: string): { topicId: string } | undefined;
+			sessionForTopic(topicId: string): string | undefined;
+		};
+	};
+	harness.bot.calls = [];
+	armed = true;
+
+	await closeTopicSession(harness);
+
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	expect(readCustodySnapshot(agentDir).records[`42:${topicId}`]).toMatchObject({ state: "confirmed" });
+	expect(internals.topics.get("S")?.topicId).toBe(topicId);
+	expect(internals.topics.sessionForTopic(topicId)).toBe("S");
+
+	await closeTopicSession(harness);
+
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	expect(readCustodySnapshot(agentDir).records[`42:${topicId}`]).toMatchObject({ state: "confirmed" });
+});
 
 test("rejected, malformed, and reset topic deletion outcomes remain unknown without retries", async () => {
 	const reset = Object.assign(new Error("connection reset secret-reset"), { code: "ECONNRESET" });
@@ -3975,16 +4358,16 @@ test("confirmed recovery resolves a topic only after acquiring the current custo
 	const internals = recovery as unknown as {
 		topics: {
 			load(state: { topics: Record<string, { topicId: string; identitySent: boolean; createdAt: number }> }): void;
-			sessionIds(): string[];
+			sessionForTopic(topicId: string): string | undefined;
 		};
 		persistTopics(): Promise<void>;
 		finishConfirmedTopicDeletion(input: unknown, topicId?: string): Promise<void>;
 	};
-	const sessionIds = internals.topics.sessionIds.bind(internals.topics);
-	let sessionIdsBeforeEpochProof = 0;
-	internals.topics.sessionIds = () => {
-		sessionIdsBeforeEpochProof += 1;
-		return sessionIds();
+	const sessionForTopic = internals.topics.sessionForTopic.bind(internals.topics);
+	let sessionLookupBeforeEpochProof = 0;
+	internals.topics.sessionForTopic = candidateTopicId => {
+		sessionLookupBeforeEpochProof += 1;
+		return sessionForTopic(candidateTopicId);
 	};
 	const helperEntered = Promise.withResolvers<void>();
 	const finishConfirmedTopicDeletion = internals.finishConfirmedTopicDeletion.bind(recovery);
@@ -4011,7 +4394,7 @@ test("confirmed recovery resolves a topic only after acquiring the current custo
 	try {
 		recoveryLoad = recovery.loadCustody();
 		await helperEntered.promise;
-		expect(sessionIdsBeforeEpochProof).toBe(0);
+		expect(sessionLookupBeforeEpochProof).toBe(0);
 
 		internals.topics.load({
 			topics: {
@@ -5166,7 +5549,9 @@ test("orphan reaping records its trigger and retains a rejected topic deletion",
 	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
 	fs.writeFileSync(
 		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
-		JSON.stringify({ topics: { orphan: { topicId: "301", identitySent: true, createdAt: 0, name: "orphan" } } }),
+		JSON.stringify(
+			topicStateEnvelope({ orphan: { topicId: "301", identitySent: true, createdAt: 0, name: "orphan" } }),
+		),
 	);
 
 	const bot = new FakeBotApi();
@@ -5208,7 +5593,7 @@ test("concurrent session close and orphan reaping join one durable topic teardow
 	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
 	fs.writeFileSync(
 		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
-		JSON.stringify({ topics: { S: { topicId: "301", identitySent: true, createdAt: 0, name: "S" } } }),
+		JSON.stringify(topicStateEnvelope({ S: { topicId: "301", identitySent: true, createdAt: 0, name: "S" } })),
 	);
 
 	const bot = new FakeBotApi();
@@ -5262,12 +5647,12 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
 	fs.writeFileSync(
 		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
-		JSON.stringify({
-			topics: {
+		JSON.stringify(
+			topicStateEnvelope({
 				stale: { topicId: "101", identitySent: true, createdAt: 0, name: "stale" },
 				dead: { topicId: "102", identitySent: true, createdAt: 0, name: "dead" },
-			},
-		}),
+			}),
+		),
 	);
 	const bot = new FakeBotApi();
 	const daemon = new TelegramNotificationDaemon({
@@ -5302,7 +5687,9 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
 	fs.writeFileSync(
 		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
-		JSON.stringify({ topics: { missing: { topicId: "201", identitySent: true, createdAt: 0, name: "missing" } } }),
+		JSON.stringify(
+			topicStateEnvelope({ missing: { topicId: "201", identitySent: true, createdAt: 0, name: "missing" } }),
+		),
 	);
 	const bot = new FakeBotApi();
 	const daemon = new TelegramNotificationDaemon({
@@ -5328,7 +5715,7 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 	fs.mkdirSync(daemonPaths(blockedAgentDir).dir, { recursive: true });
 	fs.writeFileSync(
 		path.join(daemonPaths(blockedAgentDir).dir, "telegram-topics.json"),
-		JSON.stringify({ topics: { kept: { topicId: "202", identitySent: true, createdAt: 0, name: "kept" } } }),
+		JSON.stringify(topicStateEnvelope({ kept: { topicId: "202", identitySent: true, createdAt: 0, name: "kept" } })),
 	);
 	const blockedBot = new FakeBotApi();
 	const blockedDaemon = new TelegramNotificationDaemon({
@@ -6531,7 +6918,7 @@ describe("telegram daemon custody epoch fencing", () => {
 				await fs.promises.rename(from, to);
 			},
 			unlink: async file => await fs.promises.unlink(file),
-			open: async (file, flags, mode) => await fs.promises.open(file, flags, mode),
+			open: openDaemonFsHandle,
 			readdir: async file => await fs.promises.readdir(file),
 			chmod: async (file, mode) => await fs.promises.chmod(file, mode),
 		};

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -4048,6 +4048,73 @@ test("run() persists aliases before releasing ownership on exit", async () => {
 	await daemon.run();
 	expect(fs.existsSync(daemonPaths(agentDir).aliases)).toBe(true);
 });
+describe("telegram custody loading", () => {
+	test("migrates custody before the first scan without Telegram deletion or delivery", async () => {
+		const agentDir = tempAgentDir();
+		const custodyPath = path.join(agentDir, "notifications", "telegram-deletion-custody.json");
+		fs.mkdirSync(path.dirname(custodyPath), { recursive: true });
+		fs.writeFileSync(
+			custodyPath,
+			JSON.stringify({
+				version: 1,
+				chatId: "42",
+				records: { "7": { state: "in_flight", updatedAt: 1 } },
+			}),
+		);
+
+		const s = settings(agentDir);
+		const events: string[] = [];
+		await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "e60b05c186ca",
+			chatId: "42",
+			pid: process.pid,
+			randomId: () => "owner",
+		});
+		class CustodyOrderDaemon extends TelegramNotificationDaemon {
+			override async loadTopics(): Promise<void> {
+				events.push("topics");
+			}
+
+			override async loadCustody() {
+				const result = await super.loadCustody();
+				events.push("custody");
+				return result;
+			}
+
+			override async scanRoots(): Promise<void> {
+				events.push("scan");
+				this.requestStop();
+			}
+		}
+		const bot = new FakeBotApi();
+		const daemon = new CustodyOrderDaemon({
+			settings: s,
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			createLifecycleControlServer: null,
+			scanIntervalMs: 2_147_483_647,
+		});
+
+		await daemon.run();
+
+		expect(events).toEqual(["topics", "custody", "scan"]);
+		expect(daemon.custodyLoadResult).toEqual({
+			mode: "writable",
+			migrated: true,
+			records: [{ chatId: "42", topicId: "7", state: "unknown", updatedAt: 1 }],
+		});
+		expect(JSON.parse(fs.readFileSync(custodyPath, "utf8"))).toEqual({
+			version: 2,
+			records: {
+				"42:7": { chatId: "42", topicId: "7", state: "unknown", updatedAt: 1 },
+			},
+		});
+		expect(bot.calls.filter(call => call.method === "deleteForumTopic" || call.method === "sendMessage")).toEqual([]);
+	});
+});
 
 test("a fresh daemon scanRoots reconnects an existing session endpoint", async () => {
 	FakeWs.instances = [];

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -12,10 +12,12 @@ import {
 import { deliverRichWithFallback } from "../src/notifications/rich-render";
 import {
 	acquireDaemonOwnership,
+	buildTelegramDaemonSpawnArgs,
 	DAEMON_GENERATION,
 	DAEMON_VERSION,
 	daemonPaths,
 	ensureTelegramDaemonRunning,
+	spawnTelegramDaemonOwner,
 	registerNotificationRoot,
 	releaseDaemonOwnership,
 	renewDaemonHeartbeat,
@@ -25,6 +27,12 @@ import {
 	TelegramNotificationDaemon,
 	TelegramUpdatePoller,
 } from "../src/notifications/telegram-daemon";
+import {
+	clearTelegramControlRequest,
+	readTelegramControlRequest,
+	writeTelegramControlRequest,
+} from "../src/notifications/telegram-daemon-control";
+import { telegramCustodyEpochPath } from "../src/notifications/telegram-custody-epoch";
 import { runDaemonInternal, runDaemonSmoke } from "../src/notifications/telegram-daemon-cli";
 
 const THREADED_FALLBACK_NOTICE =
@@ -175,6 +183,7 @@ async function identityTopicHarness({
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId,
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -317,6 +326,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -438,7 +448,7 @@ describe("telegram daemon", () => {
 					settings: s,
 					tokenFingerprint: "fp",
 					chatId: "42",
-					pidAlive: () => false,
+					pidAlive: pid => pid === 222,
 					pid: 222,
 				}),
 			),
@@ -464,7 +474,12 @@ describe("telegram daemon", () => {
 				roots: [],
 				version: 1,
 				generation: DAEMON_GENERATION,
+				custodyEpoch: 1,
 			}),
+		);
+		fs.writeFileSync(
+			telegramCustodyEpochPath(agentDir),
+			JSON.stringify({ version: 1, ownerId: "old", custodyEpoch: 1 }),
 		);
 		const result = await acquireDaemonOwnership({
 			settings: s,
@@ -474,6 +489,24 @@ describe("telegram daemon", () => {
 			now: () => 101,
 		});
 		expect(result).toEqual({ acquired: false, attached: true });
+	});
+	test("fresh live ownership with a mismatched durable epoch fails closed", async () => {
+		const agentDir = tempAgentDir();
+		const s = setPrivateAgentDir(settings(agentDir), agentDir);
+		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION, custodyEpoch: 1 });
+		fs.writeFileSync(
+			telegramCustodyEpochPath(agentDir),
+			JSON.stringify({ version: 1, ownerId: "old", custodyEpoch: 2 }),
+		);
+		await expect(
+			acquireDaemonOwnership({
+				settings: s,
+				tokenFingerprint: "e60b05c186ca",
+				chatId: "42",
+				pidAlive: () => true,
+				now: () => 101,
+			}),
+		).rejects.toThrow("custody epoch does not match");
 	});
 
 	test("live owner token/chat mismatch blocks attach without registering a root", async () => {
@@ -543,8 +576,15 @@ describe("telegram daemon", () => {
 
 	function writeLiveOwner(agentDir: string, extra: Record<string, unknown> = {}): void {
 		const paths = daemonPaths(agentDir);
+		const state = liveOwnerState(extra);
 		fs.mkdirSync(paths.dir, { recursive: true });
-		fs.writeFileSync(paths.state, JSON.stringify(liveOwnerState(extra)));
+		fs.writeFileSync(paths.state, JSON.stringify(state));
+		if (typeof state.custodyEpoch === "number") {
+			fs.writeFileSync(
+				telegramCustodyEpochPath(agentDir),
+				JSON.stringify({ version: 1, ownerId: state.ownerId, custodyEpoch: state.custodyEpoch }),
+			);
+		}
 		fs.writeFileSync(paths.lock, "");
 	}
 
@@ -565,7 +605,7 @@ describe("telegram daemon", () => {
 	test("#2028 acquire attaches to a current-generation live owner (no reload)", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
-		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION });
+		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION, custodyEpoch: 1 });
 		const result = await acquireDaemonOwnership({
 			settings: s,
 			tokenFingerprint: "e60b05c186ca",
@@ -579,7 +619,7 @@ describe("telegram daemon", () => {
 	test("#2028 acquire does not downgrade a NEWER-generation live owner (attaches)", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
-		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION + 1 });
+		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION + 1, custodyEpoch: 1 });
 		const result = await acquireDaemonOwnership({
 			settings: s,
 			tokenFingerprint: "e60b05c186ca",
@@ -651,7 +691,7 @@ describe("telegram daemon", () => {
 	test("#2028 ensureTelegramDaemonRunning reuses a current-generation live owner without a reload", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
-		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION, heartbeatAt: Date.now() });
+		writeLiveOwner(agentDir, { generation: DAEMON_GENERATION, custodyEpoch: 1, heartbeatAt: Date.now() });
 		const paths = daemonPaths(agentDir);
 		const signals: Array<[number, string]> = [];
 		let spawns = 0;
@@ -690,6 +730,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: new FakeBotApi(),
@@ -707,21 +748,25 @@ describe("telegram daemon", () => {
 	test("runDaemonInternal rewrites persisted owner pid to daemon process pid", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
-		await acquireDaemonOwnership({
+		const ownership = await acquireDaemonOwnership({
 			settings: s,
 			tokenFingerprint: "e60b05c186ca",
 			chatId: "42",
 			pid: 111,
 			randomId: () => "owner",
 		});
+		if (!ownership.acquired) throw new Error("ownership acquisition failed");
 		class OneShotDaemon extends TelegramNotificationDaemon {
 			override async scanRoots(): Promise<void> {}
 		}
-		await runDaemonInternal(["--agent-dir", agentDir, "--owner-id", "owner"], {
-			SettingsImpl: { init: async () => s },
-			DaemonImpl: OneShotDaemon,
-			processPid: 222,
-		});
+		await runDaemonInternal(
+			["--agent-dir", agentDir, "--owner-id", ownership.ownerId, "--custody-epoch", String(ownership.custodyEpoch)],
+			{
+				SettingsImpl: { init: async () => s },
+				DaemonImpl: OneShotDaemon,
+				processPid: 222,
+			},
+		);
 		const state = JSON.parse(fs.readFileSync(daemonPaths(agentDir).state, "utf8")) as {
 			pid: number;
 			ownerId: string;
@@ -751,11 +796,13 @@ describe("telegram daemon", () => {
 			requestStop(): void {}
 		}
 
-		await runDaemonInternal(["--agent-dir", agentDir, "--owner-id", "owner"], {
-			SettingsImpl: { init: async () => s },
-			DaemonImpl: StubDaemon,
-			pidAlive: () => true,
-		});
+		await expect(
+			runDaemonInternal(["--agent-dir", agentDir, "--owner-id", "owner"], {
+				SettingsImpl: { init: async () => s },
+				DaemonImpl: StubDaemon,
+				pidAlive: () => true,
+			}),
+		).rejects.toThrow("custody-epoch");
 
 		expect(daemonConstructed).toBe(false);
 	});
@@ -768,6 +815,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -802,6 +850,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -836,6 +885,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -866,6 +916,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "-10042",
 			botApi: bot,
@@ -890,6 +941,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -927,6 +979,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -957,6 +1010,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -993,6 +1047,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1039,6 +1094,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1066,6 +1122,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1126,6 +1183,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1177,6 +1235,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1245,6 +1304,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1297,6 +1357,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1336,6 +1397,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1377,6 +1439,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1396,6 +1459,7 @@ describe("telegram daemon", () => {
 		const restarted = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner-restarted",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1453,6 +1517,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1528,6 +1593,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1597,6 +1663,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: setPrivateAgentDir(settings(agentDir), agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1650,6 +1717,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1683,6 +1751,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1719,6 +1788,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1760,6 +1830,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1797,6 +1868,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1835,6 +1907,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -1865,6 +1938,7 @@ describe("telegram daemon", () => {
 		const restarted = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner-2",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: new FakeBotApi(),
@@ -1888,21 +1962,42 @@ describe("telegram daemon", () => {
 		expect(fs.readdirSync(daemonPaths(agentDir).dir).join("\n")).not.toContain("secret-token");
 	});
 
-	test("heartbeat renew and release helpers honor owner id", async () => {
+	test("heartbeat renew and release helpers honor the complete owner binding", async () => {
 		const agentDir = tempAgentDir();
 		const s = setPrivateAgentDir(settings(agentDir), agentDir);
-		await acquireDaemonOwnership({
+		const ownership = await acquireDaemonOwnership({
 			settings: s,
 			tokenFingerprint: "fp",
 			chatId: "42",
 			pid: process.pid,
 			randomId: () => "owner",
 		});
-		expect(await renewDaemonHeartbeat({ settings: s, ownerId: "other" })).toBe(false);
-		expect(await renewDaemonHeartbeat({ settings: s, ownerId: "owner" })).toBe(true);
-		await releaseDaemonOwnership({ settings: s, ownerId: "other" });
+		if (!ownership.acquired) throw new Error("ownership acquisition failed");
+		expect(
+			await renewDaemonHeartbeat({
+				settings: s,
+				ownerId: "other",
+				custodyEpoch: ownership.custodyEpoch,
+			}),
+		).toBe(false);
+		expect(
+			await renewDaemonHeartbeat({
+				settings: s,
+				ownerId: ownership.ownerId,
+				custodyEpoch: ownership.custodyEpoch,
+			}),
+		).toBe(true);
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: "other",
+			custodyEpoch: ownership.custodyEpoch,
+		});
 		expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(true);
-		await releaseDaemonOwnership({ settings: s, ownerId: "owner" });
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: ownership.ownerId,
+			custodyEpoch: ownership.custodyEpoch,
+		});
 		expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(false);
 	});
 
@@ -1952,6 +2047,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: gatedBot,
@@ -2006,6 +2102,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -2037,6 +2134,7 @@ describe("telegram daemon", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			fetchImpl,
@@ -2076,6 +2174,7 @@ describe("telegram daemon connection-drop resilience (repro-first)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: new FakeBotApi(),
@@ -2148,6 +2247,7 @@ describe("telegram daemon connection-drop resilience (repro-first)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -2174,6 +2274,7 @@ test("daemon registers in-thread config and lifecycle commands and drops stale r
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2204,6 +2305,7 @@ test("forum lifecycle commands fail closed even when addressed to this bot usern
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(tempAgentDir()),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "-10042",
 		botApi: bot,
@@ -2232,6 +2334,7 @@ test("forum lifecycle commands fail closed when bot username is unavailable", as
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(tempAgentDir()),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "-10042",
 		botApi: bot,
@@ -2254,6 +2357,7 @@ test("non-addressable forum lifecycle commands in known topics are dropped", asy
 		const daemon = new TelegramNotificationDaemon({
 			settings: settings(tempAgentDir()),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "-10042",
 			botApi: bot,
@@ -2315,6 +2419,7 @@ test("image_attachment frame uploads via sendPhoto into an identified session to
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2357,6 +2462,7 @@ describe("telegram topic name template (#1909)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: settings(agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -2428,6 +2534,7 @@ describe("telegram topic name template (#1909)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: settings(agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -2460,6 +2567,7 @@ test("identity-less threaded frames wait for identity instead of creating fallba
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2508,6 +2616,7 @@ test("transient topic rename failure is retried on the next identity header", as
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2735,6 +2844,7 @@ test.each([
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "retry",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2789,6 +2899,7 @@ test("remote-success user-name reconciliation retries after its pending-clear wr
 	const restarted = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner-2",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: retryBot,
@@ -2838,6 +2949,7 @@ test.each([
 	const restarted = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner-2",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: retryBot,
@@ -2858,6 +2970,7 @@ test("live sessions with the same repo branch create distinct topics", async () 
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2901,6 +3014,7 @@ test("transient identity for an existing repo branch does not create a duplicate
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2931,6 +3045,7 @@ test("stale identity after loadTopics reuses the persisted repo branch owner", a
 	const firstDaemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2946,6 +3061,7 @@ test("stale identity after loadTopics reuses the persisted repo branch owner", a
 	const restartedDaemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -2980,6 +3096,7 @@ test("threaded mode off: frames fall back to the flat paired chat with a one-tim
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3033,6 +3150,7 @@ test("threaded mode off: multiple sessions share a single fallback notice", asyn
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3062,6 +3180,7 @@ test("threaded mode off: image_attachment uploads flat without message_thread_id
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3101,6 +3220,7 @@ test("non-private chat: fails closed before topic creation or flat delivery", as
 		const daemon = new TelegramNotificationDaemon({
 			settings: settings(agentDir),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -3145,6 +3265,7 @@ test("threaded off + unresolvable getChat: fails closed", async () => {
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3161,6 +3282,7 @@ test("identity_header without a title names the topic repo/branch", async () => 
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3188,6 +3310,7 @@ test("identity_header with repo/branch and a title composes repo/branch - title"
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3216,6 +3339,7 @@ test("identity_header without title or repo falls back to the GJC session label"
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3240,6 +3364,7 @@ test("activity busy frame sends a typing chat action into the session topic", as
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3270,6 +3395,7 @@ test("session_closed deletes the topic and resume creates a fresh visible topic"
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3328,6 +3454,7 @@ test("session_closed clears reply message routes for the closed session", async 
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3359,6 +3486,7 @@ test("session_closed tombstones its endpoint generation so scans do not recreate
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3415,6 +3543,7 @@ test("inbound thread message gets a queued reaction, flipped to consumed on ack"
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3462,6 +3591,7 @@ test("inbound photo is downloaded and forwarded as an image in the user_message"
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3503,6 +3633,7 @@ test("inbound document is saved to a tmp file and its path injected into the tex
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3556,6 +3687,7 @@ test("inbound document with a path-traversal filename stays sandboxed in the pri
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3606,6 +3738,7 @@ test("daemon attachment temp dirs are removed by the shutdown cleanup path", asy
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3643,6 +3776,7 @@ test("outbound file_attachment frame triggers a sendDocument upload to the topic
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3694,6 +3828,7 @@ describe("telegram daemon reconnect reconciliation", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -3736,6 +3871,7 @@ describe("telegram daemon reconnect reconciliation", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: new FakeBotApi(),
@@ -3772,6 +3908,7 @@ describe("telegram daemon reconnect reconciliation", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -3837,6 +3974,7 @@ describe("telegram daemon reconnect answer routing", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -3892,6 +4030,7 @@ test("pollOnce resolves to 0 when the in-flight getUpdates is aborted", async ()
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3916,6 +4055,7 @@ test("pollOnce backs off on a Telegram 409 conflict instead of processing update
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -3967,6 +4107,7 @@ test("requestStop aborts the active long poll and run() exits, releasing ownersh
 	const daemon = new NoScan({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4001,6 +4142,7 @@ test("run() loop exits when an owner-scoped control request asks it to stop", as
 	const daemon = new NoScan({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: new FakeBotApi(),
@@ -4034,6 +4176,7 @@ test("run() persists aliases before releasing ownership on exit", async () => {
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: new FakeBotApi(),
@@ -4091,6 +4234,7 @@ describe("telegram custody loading", () => {
 		const daemon = new CustodyOrderDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot,
@@ -4128,6 +4272,7 @@ test("a fresh daemon scanRoots reconnects an existing session endpoint", async (
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: new FakeBotApi(),
@@ -4146,6 +4291,7 @@ test("connectSession eagerly creates a Telegram topic on connect (before any fra
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4184,6 +4330,7 @@ test("identity_header during an in-flight eager create still renames the topic",
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4232,6 +4379,7 @@ test("scanRoots connects only live endpoints (skips stale + dead-PID records)", 
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: new FakeBotApi(),
@@ -4274,6 +4422,7 @@ test("scanRoots reaps stale and dead-PID session topics after the orphan grace w
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4307,6 +4456,7 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 	const daemon = new TelegramNotificationDaemon({
 		settings: s,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4332,6 +4482,7 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 	const blockedDaemon = new TelegramNotificationDaemon({
 		settings: blockedSettings,
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: blockedBot,
@@ -4345,10 +4496,34 @@ test("scanRoots reaps missing endpoint topics only when all roots are readable a
 test("runDaemonInternal wires SIGTERM to the daemon stop method", async () => {
 	const agentDir = tempAgentDir();
 	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const ownership = await acquireDaemonOwnership({
+		settings: s,
+		tokenFingerprint: "e60b05c186ca",
+		chatId: "42",
+		pid: 111,
+		randomId: () => "owner",
+	});
+	if (!ownership.acquired) throw new Error("ownership acquisition failed");
+	const persistedState = JSON.parse(fs.readFileSync(daemonPaths(agentDir).state, "utf8"));
+	const persistedEpoch = JSON.parse(fs.readFileSync(telegramCustodyEpochPath(agentDir), "utf8"));
+	expect(persistedState).toMatchObject({
+		ownerId: ownership.ownerId,
+		custodyEpoch: ownership.custodyEpoch,
+	});
+	expect(persistedEpoch).toEqual({
+		version: 1,
+		ownerId: ownership.ownerId,
+		custodyEpoch: ownership.custodyEpoch,
+	});
 	let stopped = false;
 	let resolveRun: (() => void) | undefined;
+	const daemonConstructed = Promise.withResolvers<void>();
+	let daemonOptions: { ownerId?: unknown; custodyEpoch?: unknown } | undefined;
 	class StubDaemon {
-		constructor(public opts: unknown) {}
+		constructor(opts: unknown) {
+			daemonOptions = opts as { ownerId?: unknown; custodyEpoch?: unknown };
+			daemonConstructed.resolve();
+		}
 		requestStop(): void {
 			stopped = true;
 			resolveRun?.();
@@ -4369,11 +4544,18 @@ test("runDaemonInternal wires SIGTERM to the daemon stop method", async () => {
 	};
 	(process as any).off = () => process;
 	try {
-		const runPromise = runDaemonInternal(["--agent-dir", agentDir, "--owner-id", "owner"], {
-			SettingsImpl: { init: async () => s },
-			DaemonImpl: StubDaemon as any,
+		const runPromise = runDaemonInternal(
+			["--agent-dir", agentDir, "--owner-id", ownership.ownerId, "--custody-epoch", String(ownership.custodyEpoch)],
+			{
+				SettingsImpl: { init: async () => s },
+				DaemonImpl: StubDaemon as any,
+			},
+		);
+		await daemonConstructed.promise;
+		expect(daemonOptions).toMatchObject({
+			ownerId: ownership.ownerId,
+			custodyEpoch: ownership.custodyEpoch,
 		});
-		await new Promise(resolve => setTimeout(resolve, 5));
 		expect(sigtermHandler).toBeTruthy();
 		sigtermHandler?.();
 		await runPromise;
@@ -4391,6 +4573,7 @@ test("a long finalized turn is scheduled through the pool, not burst in one gran
 	const daemon = new TelegramNotificationDaemon({
 		settings: settings(agentDir),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot,
@@ -4477,6 +4660,7 @@ function makeRichDaemon(bot: FakeBotApi, rich?: { enabled: boolean }): TelegramN
 	return new TelegramNotificationDaemon({
 		settings: settings(tempAgentDir()),
 		ownerId: "owner",
+		custodyEpoch: 1,
 		botToken: "tok",
 		chatId: "42",
 		botApi: bot as any,
@@ -4878,6 +5062,7 @@ describe("telegram daemon rich final-answer promotion (Rev 3 verification)", () 
 		const daemon = new TelegramNotificationDaemon({
 			settings: settings(tempAgentDir()),
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: transport,
@@ -5034,6 +5219,7 @@ describe("telegram daemon action-needed rich delivery (G004)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot as any,
@@ -5167,6 +5353,7 @@ describe("telegram daemon /rich toggle (G005)", () => {
 		return new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot as any,
@@ -5242,6 +5429,7 @@ describe("telegram daemon /rich toggle (G005)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot as any,
@@ -5317,6 +5505,7 @@ describe("telegram daemon /rich toggle (G005)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot as any,
@@ -5361,6 +5550,7 @@ describe("telegram daemon /rich toggle (G005)", () => {
 		const daemon = new TelegramNotificationDaemon({
 			settings: s,
 			ownerId: "owner",
+			custodyEpoch: 1,
 			botToken: "tok",
 			chatId: "42",
 			botApi: bot as any,
@@ -5377,5 +5567,244 @@ describe("telegram daemon /rich toggle (G005)", () => {
 			),
 		).toBe(true);
 		expect(bot.calls.some(c => c.method === "sendMessage" && c.body.text === "Rich messages: off")).toBe(false);
+	});
+});
+describe("telegram daemon custody epoch fencing", () => {
+	test("allocates epoch one then fences a same-owner ABA restart at epoch two", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const first = await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "fp",
+			chatId: "42",
+			pid: 101,
+			randomId: () => "reused-owner",
+		});
+		if (!first.acquired) throw new Error("first ownership acquisition failed");
+		expect(first.custodyEpoch).toBe(1);
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: first.ownerId,
+			custodyEpoch: first.custodyEpoch,
+		});
+
+		const second = await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "fp",
+			chatId: "42",
+			pid: 202,
+			randomId: () => "reused-owner",
+		});
+		if (!second.acquired) throw new Error("second ownership acquisition failed");
+		expect(second.custodyEpoch).toBe(2);
+		expect(
+			await renewDaemonHeartbeat({
+				settings: s,
+				ownerId: first.ownerId,
+				custodyEpoch: first.custodyEpoch,
+			}),
+		).toBe(false);
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: first.ownerId,
+			custodyEpoch: first.custodyEpoch,
+		});
+		expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(true);
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: second.ownerId,
+			custodyEpoch: second.custodyEpoch,
+		});
+	});
+
+	test("rejects noncanonical spawn epochs and preserves adjacent canonical argv", () => {
+		const spawned = buildTelegramDaemonSpawnArgs({
+			execPath: process.execPath,
+			ownerId: "owner",
+			custodyEpoch: 2,
+			agentDir: "agent-dir",
+		});
+		const epochFlag = spawned.args.indexOf("--custody-epoch");
+		expect(spawned.args.slice(epochFlag, epochFlag + 2)).toEqual(["--custody-epoch", "2"]);
+		expect(() =>
+			buildTelegramDaemonSpawnArgs({
+				execPath: process.execPath,
+				ownerId: "owner",
+				custodyEpoch: 0,
+				agentDir: "agent-dir",
+			}),
+		).toThrow("custody epoch");
+	});
+
+	test("spawn failure releases only its pair and retry consumes a higher epoch", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		await expect(
+			spawnTelegramDaemonOwner(
+				{ settings: s, tokenFingerprint: "fp", chatId: "42" },
+				{
+					pid: 111,
+					randomId: () => "owner",
+					spawn: () => {
+						throw new Error("spawn failed");
+					},
+				},
+			),
+		).rejects.toThrow("spawn failed");
+		expect(fs.existsSync(daemonPaths(agentDir).lock)).toBe(false);
+
+		const retried = await spawnTelegramDaemonOwner(
+			{ settings: s, tokenFingerprint: "fp", chatId: "42" },
+			{ pid: 222, randomId: () => "owner", spawn: () => ({ unref() {} }) },
+		);
+		expect(retried.result).toBe("owner_spawned");
+		if (retried.result !== "owner_spawned") throw new Error("retry did not acquire ownership");
+		expect(retried.custodyEpoch).toBe(2);
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: retried.ownerId,
+			custodyEpoch: retried.custodyEpoch,
+		});
+	});
+	test("state-publication failure leaves no physical lock and retry skips the consumed epoch", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		const paths = daemonPaths(agentDir);
+		const failingFs: TelegramDaemonFs = {
+			mkdir: async (file, opts) => await fs.promises.mkdir(file, opts).then(() => undefined),
+			readFile: async (file, encoding) => await fs.promises.readFile(file, encoding),
+			writeFile: async (file, data, opts) => await fs.promises.writeFile(file, data, opts),
+			rename: async (from, to) => {
+				if (to === paths.state) throw new Error("state write failed");
+				await fs.promises.rename(from, to);
+			},
+			unlink: async file => await fs.promises.unlink(file),
+			open: async (file, flags, mode) => await fs.promises.open(file, flags, mode),
+			readdir: async file => await fs.promises.readdir(file),
+			chmod: async (file, mode) => await fs.promises.chmod(file, mode),
+		};
+		await expect(
+			acquireDaemonOwnership({
+				settings: s,
+				tokenFingerprint: "fp",
+				chatId: "42",
+				pid: 101,
+				randomId: () => "owner",
+				fs: failingFs,
+			}),
+		).rejects.toThrow("state write failed");
+		expect(fs.existsSync(paths.lock)).toBe(false);
+
+		const retried = await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "fp",
+			chatId: "42",
+			pid: 202,
+			randomId: () => "owner",
+		});
+		if (!retried.acquired) throw new Error("retry ownership acquisition failed");
+		expect(retried.custodyEpoch).toBe(2);
+		await releaseDaemonOwnership({
+			settings: s,
+			ownerId: retried.ownerId,
+			custodyEpoch: retried.custodyEpoch,
+		});
+	});
+
+	test("pair-bound control cleanup cannot clear a successor request", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		await writeTelegramControlRequest(s, {
+			version: 1,
+			requestId: "successor",
+			action: "stop",
+			ownerId: "same-owner",
+			custodyEpoch: 2,
+			pid: 202,
+			createdAt: 1,
+		});
+		await clearTelegramControlRequest(s, "successor", undefined, { ownerId: "same-owner", custodyEpoch: 1 });
+		expect((await readTelegramControlRequest(s))?.custodyEpoch).toBe(2);
+		await clearTelegramControlRequest(s, "successor", undefined, { ownerId: "same-owner", custodyEpoch: 2 });
+		expect(await readTelegramControlRequest(s)).toBeUndefined();
+	});
+
+	test("CLI rejects malformed, mismatched, and future custody epochs before daemon construction", async () => {
+		const agentDir = tempAgentDir();
+		const s = settings(agentDir);
+		let constructed = false;
+		class StubDaemon {
+			constructor() {
+				constructed = true;
+			}
+			async run(): Promise<void> {}
+			requestStop(): void {}
+		}
+		const deps = {
+			SettingsImpl: { init: async () => s },
+			DaemonImpl: StubDaemon,
+			pidAlive: () => true,
+		};
+		await expect(
+			runDaemonInternal(["--agent-dir", agentDir, "--owner-id", "owner", "--custody-epoch", "01"], deps),
+		).rejects.toThrow("invalid --custody-epoch");
+		expect(constructed).toBe(false);
+
+		const ownership = await acquireDaemonOwnership({
+			settings: s,
+			tokenFingerprint: "fp",
+			chatId: "42",
+			pid: 303,
+			randomId: () => "owner",
+		});
+		if (!ownership.acquired) throw new Error("ownership acquisition failed");
+		await expect(
+			runDaemonInternal(
+				[
+					"--agent-dir",
+					agentDir,
+					"--owner-id",
+					ownership.ownerId,
+					"--custody-epoch",
+					String(ownership.custodyEpoch + 1),
+				],
+				deps,
+			),
+		).rejects.toThrow("ownership state");
+		expect(constructed).toBe(false);
+
+		fs.writeFileSync(
+			telegramCustodyEpochPath(agentDir),
+			JSON.stringify({ version: 2, ownerId: ownership.ownerId, custodyEpoch: ownership.custodyEpoch }),
+		);
+		await expect(
+			runDaemonInternal(
+				[
+					"--agent-dir",
+					agentDir,
+					"--owner-id",
+					ownership.ownerId,
+					"--custody-epoch",
+					String(ownership.custodyEpoch),
+				],
+				deps,
+			),
+		).rejects.toThrow();
+		expect(constructed).toBe(false);
+		fs.writeFileSync(telegramCustodyEpochPath(agentDir), "{not-json");
+		await expect(
+			runDaemonInternal(
+				[
+					"--agent-dir",
+					agentDir,
+					"--owner-id",
+					ownership.ownerId,
+					"--custody-epoch",
+					String(ownership.custodyEpoch),
+				],
+				deps,
+			),
+		).rejects.toThrow();
+		expect(constructed).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -87,9 +87,12 @@ function topicStateFs(onTopicStateWrite: () => Promise<void>): TelegramDaemonFs 
 function trackedDaemonFs(input: {
 	commits?: string[];
 	failCustodyWriteAt?: number;
-	failTopicWrite?: () => boolean;
+	failTopicWrite?: (data: string) => boolean;
+	onTopicWrite?: (data: string) => Promise<void>;
+	onCustodyCommit?: (data: string) => void;
 }): TelegramDaemonFs {
 	let custodyWrites = 0;
+	const pendingCustodyWrites = new Map<string, string>();
 	return {
 		mkdir: (file, opts) => fs.promises.mkdir(file, opts).then(() => undefined),
 		readFile: (file, encoding) => fs.promises.readFile(file, encoding),
@@ -97,13 +100,22 @@ function trackedDaemonFs(input: {
 			if (file.includes("telegram-deletion-custody.json")) {
 				custodyWrites += 1;
 				if (custodyWrites === input.failCustodyWriteAt) throw new Error("custody write failed");
+				pendingCustodyWrites.set(file, data);
 			}
-			if (file.includes("telegram-topics.json") && input.failTopicWrite?.()) throw new Error("topic write failed");
+			if (file.includes("telegram-topics.json")) {
+				await input.onTopicWrite?.(data);
+				if (input.failTopicWrite?.(data)) throw new Error("topic write failed");
+			}
 			await fs.promises.writeFile(file, data, opts);
 		},
 		rename: async (from, to) => {
-			input.commits?.push(path.basename(to));
 			await fs.promises.rename(from, to);
+			input.commits?.push(path.basename(to));
+			if (to.includes("telegram-deletion-custody.json")) {
+				const data = pendingCustodyWrites.get(from);
+				pendingCustodyWrites.delete(from);
+				if (data !== undefined) input.onCustodyCommit?.(data);
+			}
 		},
 		unlink: file => fs.promises.unlink(file),
 		open: async (file, flags, mode) => fs.promises.open(file, flags, mode),
@@ -3582,6 +3594,78 @@ test("concurrent session-close triggers join one claimed topic deletion", async 
 	]);
 	expect(readCustodySnapshot(harness.agentDir).records).toEqual({});
 });
+test("deterministic two-topic cleanup rollback restores only its failed session", async () => {
+	const firstTopicWrite = Promise.withResolvers<void>();
+	const releaseFirstTopicWrite = Promise.withResolvers<void>();
+	const secondTopicDeleted = Promise.withResolvers<void>();
+	let holdFirstCleanupWrite = false;
+	let heldTopicWrite = false;
+	let failHeldTopicWrite = false;
+	const harness = await createTopicDeletionHarness(
+		new FakeBotApi(),
+		"owner",
+		trackedDaemonFs({
+			onTopicWrite: async data => {
+				if (!holdFirstCleanupWrite || heldTopicWrite) return;
+				const topics = JSON.parse(data) as { topics: Record<string, unknown> };
+				if (!Object.hasOwn(topics.topics, "T")) return;
+				heldTopicWrite = true;
+				failHeldTopicWrite = true;
+				firstTopicWrite.resolve();
+				await releaseFirstTopicWrite.promise;
+			},
+			failTopicWrite: () => {
+				if (!failHeldTopicWrite) return false;
+				failHeldTopicWrite = false;
+				return true;
+			},
+		}),
+	);
+	const secondSession = {
+		...harness.session,
+		sessionId: "T",
+		endpointKey: "endpoint-t",
+		pending: new Map<unknown, unknown>(),
+	};
+	await harness.daemon.handleSessionMessage(secondSession as never, {
+		type: "identity_header",
+		sessionId: "T",
+		repo: "repo-t",
+		branch: "branch-t",
+	});
+	const firstTopicId = currentTopicId(harness.agentDir, "S");
+	const secondTopicId = currentTopicId(harness.agentDir, "T");
+	const registry = harness.daemon as unknown as { topics: { delete(sessionId: string): boolean } };
+	const deleteTopicRecord = registry.topics.delete.bind(registry.topics);
+	registry.topics.delete = sessionId => {
+		const deleted = deleteTopicRecord(sessionId);
+		if (sessionId === "T") secondTopicDeleted.resolve();
+		return deleted;
+	};
+	harness.bot.calls = [];
+	holdFirstCleanupWrite = true;
+
+	const firstClose = closeTopicSession(harness);
+	await firstTopicWrite.promise;
+	const secondClose = closeTopicSession({ daemon: harness.daemon, session: secondSession });
+	await secondTopicDeleted.promise;
+	releaseFirstTopicWrite.resolve();
+	await Promise.all([firstClose, secondClose]);
+
+	expect(heldTopicWrite).toBe(true);
+	expect(failHeldTopicWrite).toBe(false);
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(2);
+	const persistedTopics = JSON.parse(
+		fs.readFileSync(path.join(daemonPaths(harness.agentDir).dir, "telegram-topics.json"), "utf8"),
+	) as { topics: Record<string, { topicId: string }> };
+	expect(persistedTopics.topics.S?.topicId).toBe(firstTopicId);
+	expect(persistedTopics.topics.T).toBeUndefined();
+	expect(readCustodySnapshot(harness.agentDir).records[`42:${firstTopicId}`]).toMatchObject({ state: "confirmed" });
+	expect(readCustodySnapshot(harness.agentDir).records[`42:${secondTopicId}`]).toBeUndefined();
+
+	await closeTopicSession({ daemon: harness.daemon, session: secondSession });
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(2);
+});
 
 test("rejected, malformed, and reset topic deletion outcomes remain unknown without retries", async () => {
 	const reset = Object.assign(new Error("connection reset secret-reset"), { code: "ECONNRESET" });
@@ -3627,10 +3711,34 @@ test("rejected, malformed, and reset topic deletion outcomes remain unknown with
 		expect(
 			fs.readFileSync(path.join(daemonPaths(harness.agentDir).dir, "telegram-deletion-custody.json"), "utf8"),
 		).not.toContain(entry.forbidden);
+		expect(currentTopicId(harness.agentDir, "S")).toBe(topicId);
 
 		await closeTopicSession(harness);
 		expect(bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+		expect(currentTopicId(harness.agentDir, "S")).toBe(topicId);
 	}
+});
+test("accessor-bearing deletion responses fail closed without invoking accessors", async () => {
+	let accessed = false;
+	const response = {
+		get ok(): boolean {
+			accessed = true;
+			return true;
+		},
+	};
+	const harness = await createTopicDeletionHarness();
+	const topicId = currentTopicId(harness.agentDir, "S");
+	harness.bot.deleteResponse = response;
+	harness.bot.calls = [];
+
+	await closeTopicSession(harness);
+
+	expect(accessed).toBe(false);
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
+	expect(readCustodySnapshot(harness.agentDir).records[`42:${topicId}`]).toMatchObject({
+		state: "unknown",
+		diagnostic: { kind: "malformed_response" },
+	});
 });
 
 test("same-owner ABA and read-only custody block a topic deletion before the call", async () => {
@@ -3660,6 +3768,78 @@ test("claim persistence failure leaves the topic queued and makes no deletion re
 
 	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(0);
 	expect(readCustodySnapshot(harness.agentDir).records[`42:${topicId}`]).toMatchObject({ state: "queued" });
+});
+test("first queue persistence failure retains the topic and does not retry deletion on restart", async () => {
+	const fsImpl = trackedDaemonFs({ failCustodyWriteAt: 1 });
+	const harness = await createTopicDeletionHarness(new FakeBotApi(), "owner", fsImpl);
+	const topicId = currentTopicId(harness.agentDir, "S");
+	harness.bot.calls = [];
+
+	await closeTopicSession(harness);
+
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(0);
+	expect(currentTopicId(harness.agentDir, "S")).toBe(topicId);
+	const restarted = new TelegramNotificationDaemon({
+		settings: settings(harness.agentDir),
+		ownerId: "owner",
+		custodyEpoch: harness.custodyEpoch,
+		botToken: "tok",
+		chatId: "42",
+		botApi: harness.bot,
+		fs: fsImpl,
+	});
+	await restarted.loadTopics();
+	await restarted.loadCustody();
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(0);
+	expect(currentTopicId(harness.agentDir, "S")).toBe(topicId);
+});
+
+test("an epoch advance after a durable claim fences the deletion call and restart retry", async () => {
+	let agentDir = "";
+	let nextCustodyEpoch = 0;
+	let advanced = false;
+	const fsImpl = trackedDaemonFs({
+		onCustodyCommit: data => {
+			const snapshot = JSON.parse(data) as CustodySnapshot;
+			if (!Object.values(snapshot.records).some(record => record.state === "in_flight")) return;
+			advanced = true;
+			fs.writeFileSync(
+				telegramCustodyEpochPath(agentDir),
+				JSON.stringify({ version: 1, ownerId: "owner", custodyEpoch: nextCustodyEpoch }),
+			);
+		},
+	});
+	const harness = await createTopicDeletionHarness(new FakeBotApi(), "owner", fsImpl);
+	agentDir = harness.agentDir;
+	nextCustodyEpoch = harness.custodyEpoch + 1;
+	const topicId = currentTopicId(harness.agentDir, "S");
+	harness.bot.calls = [];
+
+	await closeTopicSession(harness);
+
+	expect(advanced).toBe(true);
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(0);
+	expect(readCustodySnapshot(harness.agentDir).records[`42:${topicId}`]).toMatchObject({
+		state: "in_flight",
+		custodyEpoch: harness.custodyEpoch,
+	});
+	const restarted = new TelegramNotificationDaemon({
+		settings: settings(harness.agentDir),
+		ownerId: "owner",
+		custodyEpoch: nextCustodyEpoch,
+		botToken: "tok",
+		chatId: "42",
+		botApi: harness.bot,
+		fs: fsImpl,
+	});
+	await restarted.loadTopics();
+	await restarted.loadCustody();
+	await closeTopicSession({ daemon: restarted, session: harness.session });
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(0);
+	expect(readCustodySnapshot(harness.agentDir).records[`42:${topicId}`]).toMatchObject({
+		state: "unknown",
+		diagnostic: { kind: "restart_after_claim" },
+	});
 });
 
 test("pool flush failure leaves deletion queued before the claim", async () => {
@@ -4775,6 +4955,54 @@ test("orphan reaping records its trigger and retains a rejected topic deletion",
 		trigger: "orphan_reap",
 		diagnostic: { kind: "telegram_rejected", rejection: "not_found", errorCode: 404 },
 	});
+});
+test("concurrent session close and orphan reaping join one durable topic teardown", async () => {
+	const agentDir = tempAgentDir();
+	const custodyEpoch = await allocateTestCustodyEpoch(agentDir);
+	const s = setPrivateAgentDir(settings(agentDir), agentDir);
+	const cwd = path.join(agentDir, "repo");
+	await registerNotificationRoot({ settings: s, cwd, sessionId: "S" });
+	const endpointDir = path.join(cwd, ".gjc", "state", "notifications");
+	fs.mkdirSync(endpointDir, { recursive: true });
+	fs.writeFileSync(path.join(endpointDir, "S.json"), JSON.stringify({ url: "ws://s", token: "tok", stale: true }));
+	fs.mkdirSync(daemonPaths(agentDir).dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(daemonPaths(agentDir).dir, "telegram-topics.json"),
+		JSON.stringify({ topics: { S: { topicId: "301", identitySent: true, createdAt: 0, name: "S" } } }),
+	);
+
+	const bot = new FakeBotApi();
+	const daemon = new TelegramNotificationDaemon({
+		settings: s,
+		ownerId: "owner",
+		custodyEpoch,
+		botToken: "tok",
+		chatId: "42",
+		botApi: bot,
+		now: () => 120_000,
+	});
+	const session = {
+		sessionId: "S",
+		token: "tok",
+		endpointKey: "endpoint",
+		ws: { readyState: 1, send() {} },
+		pending: new Map<unknown, unknown>(),
+	};
+	await daemon.loadTopics();
+
+	await Promise.all([
+		daemon.handleSessionMessage(session as never, { type: "session_closed", sessionId: "S" }),
+		daemon.scanRoots(),
+	]);
+
+	expect(bot.calls.filter(call => call.method === "deleteForumTopic")).toEqual([
+		{
+			method: "deleteForumTopic",
+			body: { chat_id: "42", message_thread_id: 301 },
+			opts: { noRetry: true },
+		},
+	]);
+	expect(readCustodySnapshot(agentDir).records).toEqual({});
 });
 test("scanRoots reaps stale and dead-PID session topics after the orphan grace window", async () => {
 	FakeWs.instances = [];

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -3939,6 +3939,50 @@ test("settlement and local persistence failures never issue a second deletion re
 	expect(cleanup.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(1);
 	expect(readCustodySnapshot(cleanup.agentDir).records).toEqual({});
 });
+test("foreign confirmed custody does not clean up a colliding current-chat topic on restart", async () => {
+	const harness = await createTopicDeletionHarness();
+	const topicId = currentTopicId(harness.agentDir, "S");
+	const custodyPath = path.join(daemonPaths(harness.agentDir).dir, "telegram-deletion-custody.json");
+	fs.writeFileSync(
+		custodyPath,
+		JSON.stringify({
+			version: 3,
+			records: {
+				[`-100:${topicId}`]: {
+					chatId: "-100",
+					topicId,
+					state: "confirmed",
+					updatedAt: 1,
+					custodyEpoch: harness.custodyEpoch,
+					trigger: "session_closed",
+					diagnostic: { kind: "telegram_ok" },
+				},
+			},
+		}),
+	);
+
+	const restarted = new TelegramNotificationDaemon({
+		settings: settings(harness.agentDir),
+		ownerId: "owner",
+		custodyEpoch: harness.custodyEpoch,
+		botToken: "tok",
+		chatId: "42",
+		botApi: harness.bot,
+	});
+	await restarted.loadTopics();
+	harness.bot.calls = [];
+	await restarted.loadCustody();
+
+	expect(harness.bot.calls).toHaveLength(0);
+	expect(harness.bot.calls.filter(call => call.method === "deleteForumTopic")).toHaveLength(0);
+	expect(currentTopicId(harness.agentDir, "S")).toBe(topicId);
+	expect(readCustodySnapshot(harness.agentDir).records[`-100:${topicId}`]).toMatchObject({
+		chatId: "-100",
+		topicId,
+		state: "confirmed",
+		diagnostic: { kind: "telegram_ok" },
+	});
+});
 test("session_closed clears reply message routes for the closed session", async () => {
 	FakeWs.instances = [];
 	const agentDir = tempAgentDir();


### PR DESCRIPTION
## What
- durably queue and claim Telegram topic deletion under the daemon owner and custody epoch
- invoke `deleteForumTopic` once with `{ noRetry: true }`
- persist confirmed success before local topic cleanup and retain rejected or ambiguous outcomes as `unknown`
- preserve protocol 3, generation, capabilities, Selected behavior, and non-deletion transport behavior

## Why
Telegram topic deletion is irreversible. A retry after a connection reset or crash can duplicate the operation, while deleting local state before durable confirmation can lose the only evidence needed for safe recovery. This change makes the callsite current-epoch guarded and keeps irreducible remote ambiguity explicit.

## Safety contract
- no deletion call without a durable current-epoch claim
- no automatic retry or fallback after an in-flight claim
- connection-reset-after-write and crash-before-settlement remain unknown
- TopicRegistry is removed only after durable confirmation; confirmed recovery is local-only
- diagnostics retain fixed enums and safe numeric codes, never tokens, URLs, bodies, descriptions, messages, or stacks

## Testing
- `bun test packages/coding-agent/src/notifications/telegram-custody-store.test.ts packages/coding-agent/src/notifications/telegram-custody-epoch.test.ts packages/coding-agent/test/notifications-telegram-daemon.test.ts packages/coding-agent/test/notifications-telegram-reference.test.ts packages/coding-agent/test/telegram-send-tool.test.ts` — 212 passed; one unrelated pre-existing Windows mode-bit assertion remains in the inbound-document test
- focused T3 deletion adversarial selection — 10 passed, 51 assertions
- `bun --cwd=packages/coding-agent run check:types`
- exact five-file diff and `git diff --check`

Dependency: #2129. This draft intentionally remains stacked until that custody-epoch parent is accepted; its owning diff against commit `613c9e40` is exactly five files.

Reviewer focus: the single claimed `deleteForumTopic` callsite, owner/epoch validity at call time, crash windows, unknown classification, and confirmed → TopicRegistry → custody cleanup ordering.