### PR TITLE
feat(tui): support disabled select-list items

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added opt-in disabled items to `SelectList` (`SelectItem.disabled`): disabled entries render dimmed, arrow/page navigation and filter resets skip them, selection callbacks never fire for them, and lists where every item is disabled stay safe to render and navigate.
+
 ### Fixed
 
 - Terminal graphics protocols are no longer assumed under terminal multiplexers: the blind Kitty fallback for `TERM=tmux-*`/`screen-*` (and detected kitty/iTerm2 protocols leaking through multiplexer env) emitted raw graphics escapes the multiplexer consumed, leaving the Gajae composer pet invisible while its out-of-band cursor writes intermittently corrupted the TUI frame. Image protocols are now unconditionally dropped under tmux/screen/zellij (shared multiplexer predicate with the renderer host policy, including `$TMUX_PANE`, `$STY`, `$ZELLIJ`, and `GJC_TMUX_LAUNCHED`) unless `PI_FORCE_IMAGE_PROTOCOL` explicitly forces a protocol, which remains an expert override.

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -22,6 +22,7 @@ export interface SelectItem {
 	description?: string;
 	/** Dim hint text shown inline after cursor when this item is selected */
 	hint?: string;
+	disabled?: boolean;
 }
 
 export interface SelectListTheme {
@@ -62,16 +63,18 @@ export class SelectList implements Component {
 		private readonly layout: SelectListLayoutOptions = {},
 	) {
 		this.#filteredItems = items;
+		this.#selectedIndex = this.#firstEnabledIndex();
 	}
 
 	setFilter(filter: string): void {
 		this.#filteredItems = this.items.filter(item => item.value.toLowerCase().startsWith(filter.toLowerCase()));
-		// Reset selection when filter changes
-		this.#selectedIndex = 0;
+		this.#selectedIndex = this.#firstEnabledIndex();
 	}
 
 	setSelectedIndex(index: number): void {
-		this.#selectedIndex = Math.max(0, Math.min(index, this.#filteredItems.length - 1));
+		const clamped = Math.max(0, Math.min(index, this.#filteredItems.length - 1));
+		this.#selectedIndex =
+			this.#findEnabledIndex(clamped, 1, false) ?? this.#findEnabledIndex(clamped, -1, false) ?? clamped;
 	}
 
 	invalidate(): void {
@@ -101,7 +104,7 @@ export class SelectList implements Component {
 			const item = this.#filteredItems[i];
 			if (!item) continue;
 
-			const isSelected = i === this.#selectedIndex;
+			const isSelected = i === this.#selectedIndex && !item.disabled;
 			const descriptionText = item.description ? sanitizeSingleLine(item.description) : undefined;
 			lines.push(this.#renderItem(item, isSelected, width, descriptionText, primaryColumnWidth));
 		}
@@ -126,30 +129,19 @@ export class SelectList implements Component {
 			}
 			return;
 		}
-		// Up arrow - wrap to bottom when at top
 		if (kb.matches(keyData, "tui.select.up")) {
-			this.#selectedIndex = this.#selectedIndex === 0 ? this.#filteredItems.length - 1 : this.#selectedIndex - 1;
-			this.#notifySelectionChange();
-		}
-		// Down arrow - wrap to top when at bottom
-		else if (kb.matches(keyData, "tui.select.down")) {
-			this.#selectedIndex = this.#selectedIndex === this.#filteredItems.length - 1 ? 0 : this.#selectedIndex + 1;
-			this.#notifySelectionChange();
-		}
-		// PageUp - jump up by one visible page
-		else if (kb.matches(keyData, "tui.select.pageUp")) {
-			this.#selectedIndex = Math.max(0, this.#selectedIndex - this.maxVisible);
-			this.#notifySelectionChange();
-		}
-		// PageDown - jump down by one visible page
-		else if (kb.matches(keyData, "tui.select.pageDown")) {
-			this.#selectedIndex = Math.min(this.#filteredItems.length - 1, this.#selectedIndex + this.maxVisible);
-			this.#notifySelectionChange();
+			this.#moveSelection(-1);
+		} else if (kb.matches(keyData, "tui.select.down")) {
+			this.#moveSelection(1);
+		} else if (kb.matches(keyData, "tui.select.pageUp")) {
+			this.#movePage(-1);
+		} else if (kb.matches(keyData, "tui.select.pageDown")) {
+			this.#movePage(1);
 		}
 		// Enter
 		else if (kb.matches(keyData, "tui.select.confirm") || keyData === "\n") {
 			const selectedItem = this.#filteredItems[this.#selectedIndex];
-			if (selectedItem && this.onSelect) {
+			if (selectedItem && !selectedItem.disabled && this.onSelect) {
 				this.onSelect(selectedItem);
 			}
 		}
@@ -184,6 +176,9 @@ export class SelectList implements Component {
 
 			if (remainingWidth > MIN_DESCRIPTION_WIDTH) {
 				const truncatedDesc = truncateToWidth(descriptionSingleLine, remainingWidth, Ellipsis.Omit);
+				if (item.disabled) {
+					return this.theme.description(`${prefix}${truncatedValue}${spacing}${truncatedDesc}`);
+				}
 				if (isSelected) {
 					return this.theme.selectedText(`${prefix}${truncatedValue}${spacing}${truncatedDesc}`);
 				}
@@ -195,6 +190,9 @@ export class SelectList implements Component {
 
 		const maxWidth = width - prefixWidth - 2;
 		const truncatedValue = this.#truncatePrimary(item, isSelected, maxWidth, maxWidth);
+		if (item.disabled) {
+			return this.theme.description(`${prefix}${truncatedValue}`);
+		}
 		if (isSelected) {
 			return this.theme.selectedText(`${prefix}${truncatedValue}`);
 		}
@@ -242,15 +240,54 @@ export class SelectList implements Component {
 		return sanitizeSingleLine(item.label || item.value);
 	}
 
+	#firstEnabledIndex(): number {
+		const index = this.#filteredItems.findIndex(item => !item.disabled);
+		return index >= 0 ? index : 0;
+	}
+
+	#findEnabledIndex(start: number, direction: 1 | -1, wrap: boolean): number | undefined {
+		for (let step = 0; step < this.#filteredItems.length; step++) {
+			let index = start + step * direction;
+			if (index < 0 || index >= this.#filteredItems.length) {
+				if (!wrap) return undefined;
+				index = (index + this.#filteredItems.length) % this.#filteredItems.length;
+			}
+			if (!this.#filteredItems[index]?.disabled) return index;
+		}
+		return undefined;
+	}
+
+	#moveSelection(direction: 1 | -1): void {
+		if (this.#filteredItems.length === 0) return;
+		const start = (this.#selectedIndex + direction + this.#filteredItems.length) % this.#filteredItems.length;
+		const next = this.#findEnabledIndex(start, direction, true);
+		if (next === undefined || next === this.#selectedIndex) return;
+		this.#selectedIndex = next;
+		this.#notifySelectionChange();
+	}
+
+	#movePage(direction: 1 | -1): void {
+		const target = Math.max(
+			0,
+			Math.min(this.#filteredItems.length - 1, this.#selectedIndex + direction * this.maxVisible),
+		);
+		const next =
+			this.#findEnabledIndex(target, direction, false) ??
+			this.#findEnabledIndex(target, direction === 1 ? -1 : 1, false);
+		if (next === undefined || next === this.#selectedIndex) return;
+		this.#selectedIndex = next;
+		this.#notifySelectionChange();
+	}
+
 	#notifySelectionChange(): void {
 		const selectedItem = this.#filteredItems[this.#selectedIndex];
-		if (selectedItem && this.onSelectionChange) {
+		if (selectedItem && !selectedItem.disabled && this.onSelectionChange) {
 			this.onSelectionChange(selectedItem);
 		}
 	}
 
 	getSelectedItem(): SelectItem | null {
 		const item = this.#filteredItems[this.#selectedIndex];
-		return item || null;
+		return item && !item.disabled ? item : null;
 	}
 }

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -202,4 +202,109 @@ describe("SelectList", () => {
 		expect(list.render(80)).toContain("  No matching commands");
 		expect(cancelled).toBe(true);
 	});
+
+	it("dims disabled items and excludes them from selection", () => {
+		const selected: string[] = [];
+		const list = new SelectList(
+			[
+				{ value: "enabled", label: "enabled" },
+				{ value: "blocked", label: "blocked", disabled: true },
+			],
+			5,
+			{ ...testTheme, description: text => `<dim>${text}</dim>` },
+		);
+		list.onSelect = item => selected.push(item.value);
+
+		const blockedLine = list.render(80).find(line => line.includes("blocked"));
+		expect(blockedLine).toStartWith("<dim>");
+		list.setSelectedIndex(1);
+		expect(list.getSelectedItem()?.value).toBe("enabled");
+		list.handleInput("\n");
+
+		expect(selected).toEqual(["enabled"]);
+	});
+
+	it("keeps page navigation inside disabled boundaries", () => {
+		const list = new SelectList(
+			[
+				{ value: "top-blocked", label: "top-blocked", disabled: true },
+				{ value: "one", label: "one" },
+				{ value: "middle-blocked", label: "middle-blocked", disabled: true },
+				{ value: "three", label: "three" },
+				{ value: "bottom-blocked", label: "bottom-blocked", disabled: true },
+			],
+			2,
+			testTheme,
+		);
+
+		list.handleInput("\x1b[5~");
+		expect(list.getSelectedItem()?.value).toBe("one");
+		list.handleInput("\x1b[6~");
+		expect(list.getSelectedItem()?.value).toBe("three");
+		list.handleInput("\x1b[6~");
+		expect(list.getSelectedItem()?.value).toBe("three");
+	});
+
+	it("skips disabled runs while wrapping arrow navigation", () => {
+		const changed: string[] = [];
+		const list = new SelectList(
+			[
+				{ value: "one", label: "one" },
+				{ value: "blocked-a", label: "blocked-a", disabled: true },
+				{ value: "blocked-b", label: "blocked-b", disabled: true },
+				{ value: "four", label: "four" },
+			],
+			5,
+			testTheme,
+		);
+		list.onSelectionChange = item => changed.push(item.value);
+
+		list.handleInput("\x1b[B");
+		list.handleInput("\x1b[B");
+		list.handleInput("\x1b[A");
+
+		expect(changed).toEqual(["four", "one", "four"]);
+	});
+
+	it("suppresses selection and callbacks when filtering to disabled items", () => {
+		const selected: string[] = [];
+		const changed: string[] = [];
+		const list = new SelectList(
+			[
+				{ value: "enabled", label: "enabled" },
+				{ value: "blocked", label: "blocked", disabled: true },
+			],
+			5,
+			testTheme,
+		);
+		list.onSelect = item => selected.push(item.value);
+		list.onSelectionChange = item => changed.push(item.value);
+
+		list.setFilter("blocked");
+		list.handleInput("\x1b[B");
+		list.handleInput("\n");
+
+		expect(list.getSelectedItem()).toBeNull();
+		expect(selected).toEqual([]);
+		expect(changed).toEqual([]);
+	});
+
+	it("resolves programmatic selection around disabled boundaries", () => {
+		const list = new SelectList(
+			[
+				{ value: "one", label: "one" },
+				{ value: "blocked-a", label: "blocked-a", disabled: true },
+				{ value: "blocked-b", label: "blocked-b", disabled: true },
+				{ value: "four", label: "four" },
+				{ value: "blocked-end", label: "blocked-end", disabled: true },
+			],
+			5,
+			testTheme,
+		);
+
+		list.setSelectedIndex(1);
+		expect(list.getSelectedItem()?.value).toBe("four");
+		list.setSelectedIndex(4);
+		expect(list.getSelectedItem()?.value).toBe("four");
+	});
 });


### PR DESCRIPTION
## What

Add opt-in disabled items to the TUI `SelectList` via a new optional `SelectItem.disabled` flag:

- disabled entries render dimmed (`theme.description`) and are never shown as selected
- arrow and page navigation skip disabled entries, with wrap-safe search in both directions
- filter changes reset selection to the first *enabled* item
- selection-change and select callbacks never fire for disabled entries
- a list where every item is disabled stays safe to render and navigate

Purely additive API — `disabled` is optional and defaults to enabled, so existing `SelectList` consumers are unaffected (verified by the existing select-list suite passing unchanged).

## Why

Selection surfaces sometimes need to show a choice that is currently not applicable (e.g. a capability-gated option) without removing it from the list, so the user can see it exists and why it cannot be chosen. `SelectList` previously had no way to render such an entry without it being selectable, which forces consumers into confusing no-op selections. First consumer: capability-aware `/pet` and Settings pet choices (follow-up PR).

## Testing

- `bun test packages/tui/test/select-list.test.ts` — 13 pass, 0 fail (disabled rendering, navigation skipping in both directions, page navigation, filtering resets, callback suppression, all-disabled handling, plus the pre-existing enabled-list behavior).
- `bun run check` (biome + tsc across all workspaces + repo gates) — green.
- `git diff --check` — clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
