### PR TITLE
feat(coding-agent): capability-aware Gajae Pet selection UX (stacked on #2153, #2154)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Gajae Pet selection is now terminal-capability aware: unsupported terminals show an actionable warning (with multiplexer-specific guidance for tmux/screen/zellij, including the `PI_FORCE_IMAGE_PROTOCOL=sixel` expert opt-in), `/pet` and Settings disable the unavailable `RedGajae`/`BlueGajae` choices while `off` stays selectable, a saved-but-unavailable choice is identified as `(saved)`, and the public command names are consistent across execution, completion, and inline hints (`/pet RedGajae`, `/pet BlueGajae`, `/pet off`, case-insensitive).
+
 ### Changed
 
 - Renamed the notifications SDK to the Gajae-Code SDK: `docs/notifications-sdk.md` is now `docs/sdk.md`, `src/notifications/` is now `src/sdk/bus/`, and `src/sdk.ts` is now the `src/sdk/` module directory. Old deep-import specifiers no longer resolve.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Renamed the notifications SDK to the Gajae-Code SDK: `docs/notifications-sdk.md` is now `docs/sdk.md`, `src/notifications/` is now `src/sdk/bus/`, and `src/sdk.ts` is now the `src/sdk/` module directory. Old deep-import specifiers no longer resolve.
 - Moved SDK discovery from `.gjc/state/notifications/` to `.gjc/state/sdk/`. Restart sessions and daemons together when upgrading; the runtime does not dual-scan the old and new directories.
 - Removed the `--mode rpc`, `--mode rpc-ui`, and `--mode bridge` external ingress modes. Machine clients must use the SDK WebSocket interfaces documented in `docs/sdk.md`; no RPC or Bridge compatibility path remains.
+
+### Fixed
+
+- Gajae Pet overlays no longer leak images or stale pixels across lifecycle changes: each widget owns a randomized Kitty image ID (deleted on disable, replace, switch, and dispose), the previous Sixel footprint is tracked and erased on movement, resize, and narrow-terminal fallback, replaced pet widgets are disposed before their successors install, and a saved pet preference survives editor replacement while graphics are still unavailable (so a delayed Sixel capability probe can still activate it). Teardown is exception-safe and idempotent: a failed or unavailable terminal write never aborts logical disposal or steals a successor widget's overlay slot, and Sixel/Kitty cleanup authority is retained until the erase is actually delivered so a later mode switch or dispose retries it.
+
 ## [0.10.1] - 2026-07-13
 
 ### Added

--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -35,7 +35,7 @@ function buildArgumentCompletions(subcommands: SubcommandDef[]): (prefix: string
 		if (argumentPrefix.includes(" ")) return null; // past the subcommand
 		const lower = argumentPrefix.toLowerCase();
 		const matches = subcommands
-			.filter(s => s.name.startsWith(lower))
+			.filter(s => s.name.toLowerCase().startsWith(lower))
 			.map(s => ({
 				value: `${s.name} `,
 				label: s.name,
@@ -59,7 +59,7 @@ function buildSubcommandInlineHint(subcommands: SubcommandDef[]): (argumentText:
 			// Still typing subcommand name — show remaining chars + usage
 			const prefix = trimmed.toLowerCase();
 			if (prefix.length === 0) return null;
-			const match = subcommands.find(s => s.name.startsWith(prefix));
+			const match = subcommands.find(s => s.name.toLowerCase().startsWith(prefix));
 			if (!match) return null;
 			const remaining = match.name.slice(prefix.length);
 			return remaining + (match.usage ? ` ${match.usage}` : "");
@@ -68,7 +68,7 @@ function buildSubcommandInlineHint(subcommands: SubcommandDef[]): (argumentText:
 		// Subcommand typed — show remaining usage params
 		const subName = trimmed.slice(0, spaceIndex).toLowerCase();
 		const afterSub = trimmed.slice(spaceIndex + 1);
-		const sub = subcommands.find(s => s.name === subName);
+		const sub = subcommands.find(s => s.name.toLowerCase() === subName);
 		if (!sub?.usage) return null;
 
 		if (afterSub.length > 0) {

--- a/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
+++ b/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
@@ -38,6 +38,35 @@ const KITTY_DROP_FRACTION = 0.45;
 const petKittyDropPx = (cellHeightPx: number): number =>
 	Math.min(Math.max(0, cellHeightPx - 1), Math.floor(cellHeightPx * KITTY_DROP_FRACTION));
 const PET_RAISE_ROWS = 1;
+const allocatedPetKittyImageIds = new Set<number>();
+
+function allocatePetKittyImageId(): number {
+	let id = 0;
+	while (id === 0 || allocatedPetKittyImageIds.has(id)) {
+		id = crypto.getRandomValues(new Uint32Array(1))[0] ?? 0;
+	}
+	allocatedPetKittyImageIds.add(id);
+	return id;
+}
+
+interface SixelFootprint {
+	x: number;
+	y: number;
+	columns: number;
+	rows: number;
+}
+
+function sameFootprint(left: SixelFootprint, right: SixelFootprint): boolean {
+	return left.x === right.x && left.y === right.y && left.columns === right.columns && left.rows === right.rows;
+}
+
+/**
+ * Which widget currently owns each TUI's single shared post-render emitter
+ * slot. A stale or repeated dispose (or off-switch) of a predecessor widget
+ * must never clear a successor's overlay authority.
+ */
+const petOverlayEmitterOwners = new WeakMap<TUI, GajaePetWidget>();
+
 /** Working animation: the shared para-para beats looped end to end. */
 const WORK_LOOP_TOTAL = PARA_PARA_STEPS.reduce((sum, [, ms]) => sum + ms, 0);
 /** Random gap between automatic claw flexes (fires while idle AND working). */
@@ -127,6 +156,13 @@ export class GajaePetWidget {
 	/** Cell metrics the current frames were built for; a change triggers a rebuild. */
 	#builtCellW = 0;
 	#builtCellH = 0;
+	#kittyImageId: number | undefined;
+	/** True while a kitty placement may exist on screen; cleared only after the delete escape is delivered. */
+	#kittyCleanupPending = false;
+	/** Last emitted Sixel raster position; retained until an erase is actually delivered. */
+	#lastSixelFootprint: SixelFootprint | undefined;
+	/** Terminal state: a disposed widget never touches the TUI or shared slots again. */
+	#disposed = false;
 
 	constructor(options: {
 		ui: TUI;
@@ -182,14 +218,19 @@ export class GajaePetWidget {
 		}
 	}
 
+	commitPreviewMode(mode: PetMode): void {
+		this.#applyMode(mode, false);
+	}
+
 	#applyMode(mode: PetMode, mountComposer: boolean): void {
-		if (mode === this.#mode) return;
+		if (this.#disposed || mode === this.#mode) return;
 
 		if (mode === "off") {
+			this.#writeImageCleanup();
 			this.#mode = "off";
 			this.#animation?.unregister();
 			this.#animation = undefined;
-			this.#ui.setPostRenderEmitter(undefined);
+			this.#releaseOverlayEmitter();
 			this.#floorContainer.clear();
 			this.#pixel = undefined;
 			this.#framedEditor.setReserve(0);
@@ -200,6 +241,7 @@ export class GajaePetWidget {
 
 		const protocol = this.#forcedProtocol ?? GajaePetWidget.pixelProtocol();
 		if (!protocol) return;
+		if (this.#mode !== "off") this.#writeImageCleanup();
 		this.#mode = mode;
 		this.#frame = "base";
 		this.#flexUntil = 0;
@@ -210,6 +252,7 @@ export class GajaePetWidget {
 		// the composer stays pinned to the terminal bottom.
 		this.#floorContainer.clear();
 		this.#ui.setPostRenderEmitter(() => this.#overlayPayload());
+		petOverlayEmitterOwners.set(this.#ui, this);
 		this.#animation ??= registerAnimationCallback(now => this.#tick(now), 80);
 		this.#ui.requestRender(true);
 	}
@@ -220,6 +263,10 @@ export class GajaePetWidget {
 		this.#builtCellW = cell.widthPx;
 		this.#builtCellH = cell.heightPx;
 		const skin: PetSkinId = this.#mode === "off" ? "red" : this.#mode;
+		if (protocol === "kitty") {
+			this.#kittyImageId ??= allocatePetKittyImageId();
+			this.#kittyCleanupPending = true;
+		}
 		this.#pixel = buildGajaePixelFrames({
 			protocol,
 			skin,
@@ -228,17 +275,43 @@ export class GajaePetWidget {
 			targetRows: 2,
 			sixelTopPaddingPx: protocol === "sixel" ? PET_SIXEL_DROP_PX : 0,
 			kittyCellYOffsetPx: protocol === "kitty" ? petKittyDropPx(cell.heightPx) : 0,
+			kittyImageId: protocol === "kitty" ? this.#kittyImageId : undefined,
 		});
 		this.#framedEditor.setReserve(this.#pixel.columns + PET_SIDE_MARGIN);
 	}
 
 	dispose(): void {
-		this.#animation?.unregister();
-		this.#animation = undefined;
-		this.#ui.setPostRenderEmitter(undefined);
-		this.#floorContainer.clear();
-		this.#framedEditor.setReserve(0);
-		this.#mountEditor(false);
+		if (this.#disposed) return;
+		this.#disposed = true;
+		try {
+			this.#writeImageCleanup();
+		} finally {
+			// Logical teardown must reach its final state even if terminal I/O fails.
+			if (this.#kittyImageId !== undefined) {
+				allocatedPetKittyImageIds.delete(this.#kittyImageId);
+				this.#kittyImageId = undefined;
+			}
+			this.#animation?.unregister();
+			this.#animation = undefined;
+			this.#releaseOverlayEmitter();
+			this.#mode = "off";
+			this.#pixel = undefined;
+			this.#floorContainer.clear();
+			this.#framedEditor.setReserve(0);
+			// Restore the plain composer only while our framed wrapper is still
+			// mounted; a successor widget may already own the editor container.
+			if (this.#editorContainer.children.includes(this.#framedEditor)) {
+				this.#mountEditor(false);
+			}
+		}
+	}
+
+	/** Clear the shared post-render slot only while this widget still owns it. */
+	#releaseOverlayEmitter(): void {
+		if (petOverlayEmitterOwners.get(this.#ui) === this) {
+			this.#ui.setPostRenderEmitter(undefined);
+			petOverlayEmitterOwners.delete(this.#ui);
+		}
 	}
 
 	#mountEditor(framed: boolean): void {
@@ -335,14 +408,50 @@ export class GajaePetWidget {
 		return { x, y };
 	}
 
-	#clearPetPayload(x: number, y: number): string {
-		const pixel = this.#pixel;
-		if (pixel?.protocol !== "sixel") return "";
+	#clearSixelFootprint(footprint: SixelFootprint): string {
 		let out = "\x1b[0m";
-		for (let row = 0; row < pixel.rasterRows; row++) {
-			out += `\x1b[${y + row + 1};${x + 1}H\x1b[${pixel.columns}X`;
+		for (let row = 0; row < footprint.rows; row++) {
+			out += `\x1b[${footprint.y + row + 1};${footprint.x + 1}H\x1b[${footprint.columns}X`;
 		}
 		return out;
+	}
+
+	/** Pending on-screen image cleanup. Pure: authority is consumed separately, on delivery. */
+	#imageCleanupPayload(): string {
+		let out = "";
+		if (this.#kittyCleanupPending && this.#kittyImageId !== undefined) {
+			out += `\x1b_Ga=d,d=I,i=${this.#kittyImageId},q=2\x1b\\`;
+		}
+		if (this.#lastSixelFootprint) {
+			out += this.#clearSixelFootprint(this.#lastSixelFootprint);
+		}
+		return out;
+	}
+
+	#consumeCleanupAuthority(): void {
+		this.#kittyCleanupPending = false;
+		this.#lastSixelFootprint = undefined;
+	}
+
+	/**
+	 * Best-effort direct erase of the on-screen pet image. Cleanup authority is
+	 * consumed only after the write is actually delivered: an unavailable
+	 * terminal or a throwing write keeps the erase pending so a later mode
+	 * switch or dispose can retry it.
+	 */
+	#writeImageCleanup(): void {
+		if (!this.#ui.terminalAvailable) return;
+		const payload = this.#imageCleanupPayload();
+		if (!payload) return;
+		try {
+			this.#ui.terminal.write(`\x1b[?2026h\x1b7${payload}\x1b8\x1b[?2026l`);
+		} catch {
+			// Keep the footprint/placement authority; the terminal write layer
+			// reports availability separately and callers retry on the next
+			// lifecycle transition.
+			return;
+		}
+		this.#consumeCleanupAuthority();
 	}
 
 	/** Draw escape payload at the pet's absolute position. */
@@ -350,10 +459,30 @@ export class GajaePetWidget {
 		const pixel = this.#pixel;
 		if (!pixel) return null;
 		const pos = this.#petPosition();
-		if (!pos) return null;
+		if (!pos) {
+			const cleanup = this.#imageCleanupPayload();
+			if (!cleanup) return null;
+			// The returned payload is written by the TUI as part of this frame;
+			// treat that delivery like our own successful write.
+			this.#consumeCleanupAuthority();
+			return cleanup;
+		}
 		const { x, y } = pos;
+		let out = "";
 
-		let out = clearPet ? this.#clearPetPayload(x, y) : "";
+		if (pixel.protocol === "sixel") {
+			const footprint = { x, y, columns: pixel.columns, rows: pixel.rasterRows };
+			if (this.#lastSixelFootprint && !sameFootprint(this.#lastSixelFootprint, footprint)) {
+				out += this.#clearSixelFootprint(this.#lastSixelFootprint);
+			}
+			if (clearPet) out += this.#clearSixelFootprint(footprint);
+			this.#lastSixelFootprint = footprint;
+		} else {
+			// A kitty frame emitted below (re)places the image, so cleanup is
+			// pending again even if a narrow-terminal pass consumed it earlier.
+			this.#kittyCleanupPending = true;
+		}
+
 		out += `\x1b[${y + 1};${x + 1}H${pixel.frames[this.#frame]}`;
 		return out;
 	}

--- a/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
+++ b/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
@@ -6,7 +6,6 @@ import {
 	type GajaePixelFrameName,
 	type GajaePixelFrames,
 	getCellDimensions,
-	ImageProtocol,
 	PARA_PARA_STEPS,
 	PET_SKINS,
 	type PetMode,
@@ -14,10 +13,10 @@ import {
 	petBurstDurationMs,
 	petBurstFrame,
 	registerAnimationCallback,
-	TERMINAL,
 	type TUI,
 } from "@gajae-code/tui";
 import type { CustomEditor } from "./custom-editor";
+import { getPetPixelProtocol } from "./pet-capability";
 
 /** Re-exported from the tui skin registry so widget-relative imports stay valid. */
 export type { PetMode, PetSkinId };
@@ -190,9 +189,7 @@ export class GajaePetWidget {
 
 	/** Protocol available for the real-pixel pet, if any. */
 	static pixelProtocol(): "sixel" | "kitty" | null {
-		if (TERMINAL.imageProtocol === ImageProtocol.Kitty) return "kitty";
-		if (TERMINAL.imageProtocol === ImageProtocol.Sixel) return "sixel";
-		return null;
+		return getPetPixelProtocol();
 	}
 
 	get mode(): PetMode {

--- a/packages/coding-agent/src/modes/components/pet-capability.ts
+++ b/packages/coding-agent/src/modes/components/pet-capability.ts
@@ -1,0 +1,47 @@
+import { ImageProtocol, isUnderTerminalMultiplexer, type SelectItem, TERMINAL } from "@gajae-code/tui";
+
+export type PetPixelProtocol = "sixel" | "kitty";
+
+export const PET_UNAVAILABLE_DESCRIPTION = "Unavailable: requires compatible Kitty or Sixel overlay rendering";
+export const PET_SAVED_UNAVAILABLE_DESCRIPTION =
+	"Saved, unavailable — requires compatible Kitty or Sixel overlay rendering";
+export const PET_UNAVAILABLE_WARNING =
+	"⚠ Pets aren’t available in this terminal. Its image support isn’t compatible with Gajae Pet’s overlay rendering yet. Try Kitty, Ghostty, WezTerm, or a terminal with compatible Sixel support.";
+const PET_MULTIPLEXER_UNAVAILABLE_WARNING =
+	"⚠ Gajae Pet graphics are unavailable inside tmux, screen, or zellij because image escapes are not forwarded end to end. Run gjc outside the multiplexer, or set PI_FORCE_IMAGE_PROTOCOL=sixel only when the full terminal chain supports Sixel.";
+
+export function getPetUnavailableWarning(env: NodeJS.ProcessEnv = Bun.env): string {
+	return isUnderTerminalMultiplexer(env) ? PET_MULTIPLEXER_UNAVAILABLE_WARNING : PET_UNAVAILABLE_WARNING;
+}
+
+export function getPetPixelProtocol(): PetPixelProtocol | null {
+	if (TERMINAL.imageProtocol === ImageProtocol.Kitty) return "kitty";
+	if (TERMINAL.imageProtocol === ImageProtocol.Sixel) return "sixel";
+	return null;
+}
+
+export function isPetAvailable(): boolean {
+	return getPetPixelProtocol() !== null;
+}
+
+export function createPetSelectItems(
+	options: ReadonlyArray<SelectItem>,
+	currentValue: string,
+	available: boolean,
+): SelectItem[] {
+	return options.map(option => {
+		const disabled = !available && option.value !== "off";
+		const current = option.value === currentValue;
+		const savedUnavailable = disabled && current;
+		let description = `${option.description ?? ""}${current ? " (current)" : ""}`;
+		if (disabled) {
+			description = savedUnavailable ? PET_SAVED_UNAVAILABLE_DESCRIPTION : PET_UNAVAILABLE_DESCRIPTION;
+		}
+		return {
+			...option,
+			label: savedUnavailable ? `${option.label} (saved)` : option.label,
+			description,
+			disabled,
+		};
+	});
+}

--- a/packages/coding-agent/src/modes/components/pet-selector.ts
+++ b/packages/coding-agent/src/modes/components/pet-selector.ts
@@ -1,7 +1,8 @@
-import { Container, PET_SKIN_IDS, PET_SKINS, type SelectItem, SelectList } from "@gajae-code/tui";
+import { Container, PET_SKIN_IDS, PET_SKINS, SelectList } from "@gajae-code/tui";
 import { getSelectListTheme } from "../theme/theme";
 import { DynamicBorder } from "./dynamic-border";
 import type { PetMode } from "./gajae-pet-widget";
+import { createPetSelectItems } from "./pet-capability";
 
 const PET_OPTIONS: { value: PetMode; label: string; description: string }[] = [
 	{ value: "off", label: "Off", description: "No pet" },
@@ -24,14 +25,11 @@ export class PetSelectorComponent extends Container {
 		onSelect: (mode: PetMode) => void,
 		onCancel: () => void,
 		onPreview: (mode: PetMode) => void,
+		available: boolean,
 	) {
 		super();
 
-		const items: SelectItem[] = PET_OPTIONS.map(option => ({
-			value: option.value,
-			label: option.label,
-			description: option.value === current ? `${option.description} (current)` : option.description,
-		}));
+		const items = createPetSelectItems(PET_OPTIONS, current, available);
 
 		this.addChild(new DynamicBorder());
 

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -25,6 +25,7 @@ import { getCurrentThemeName, getSelectListTheme, getSettingsListTheme, theme } 
 import { matchesAppInterrupt } from "../../modes/utils/keybinding-matchers";
 import { getTabBarTheme } from "../shared";
 import { DynamicBorder } from "./dynamic-border";
+import { createPetSelectItems, isPetAvailable } from "./pet-capability";
 import { handleInputOrEscape, PluginSettingsComponent } from "./plugin-settings";
 import { getSettingsForTab, type SettingDef } from "./settings-defs";
 import type { StatusLineSegmentOptions } from "./status-line";
@@ -661,6 +662,8 @@ export interface SettingsRuntimeContext {
 	availableModelProfiles: string[];
 	/** Working directory for plugins tab */
 	cwd: string;
+	/** Whether this terminal can render the pet overlay. */
+	petAvailable?: boolean;
 }
 
 /** Status line settings subset for preview */
@@ -841,7 +844,7 @@ export class SettingsSelectorComponent extends Container {
 		currentValue: string,
 		done: (value?: string) => void,
 	): Container {
-		let options = def.options;
+		let options: ReadonlyArray<SelectItem> = def.options;
 
 		// Special case: inject runtime options for thinking level
 		if (def.path === "defaultThinkingLevel") {
@@ -856,6 +859,9 @@ export class SettingsSelectorComponent extends Container {
 		}
 		if (def.path === "statusLine.preset") {
 			options = options.filter(option => option.value !== "custom");
+		}
+		if (def.path === "pet.mode") {
+			options = createPetSelectItems(options, currentValue, this.context.petAvailable ?? isPetAvailable());
 		}
 		// Preview handlers
 		let onPreview: ((value: string) => void | Promise<void>) | undefined;

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -763,10 +763,9 @@ export class SelectorController {
 				break;
 			}
 			case "pet.mode":
-				// The settings submenu already persisted the value; apply it to the live
-				// widget via previewMode (the settings overlay is still open, so a full
-				// re-mount would tear it down — restoreComposer re-mounts on close).
-				this.ctx.previewPetMode(value as PetMode);
+				// The settings submenu already persisted the value; commit it without
+				// re-mounting the composer while the settings overlay is open.
+				this.ctx.commitPetPreviewMode(value as PetMode);
 				break;
 			case "symbolPreset": {
 				setSymbolPreset(value as "unicode" | "nerd" | "ascii").then(() => {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -79,6 +79,7 @@ import { HistorySearchComponent } from "../components/history-search";
 import { JobsOverlayComponent } from "../components/jobs-overlay";
 import { ModelSelectorComponent } from "../components/model-selector";
 import { OAuthSelectorComponent } from "../components/oauth-selector";
+import { isPetAvailable } from "../components/pet-capability";
 import { PetSelectorComponent } from "../components/pet-selector";
 import { PluginSelectorComponent } from "../components/plugin-selector";
 import {
@@ -492,6 +493,7 @@ export class SelectorController {
 						availableThemes,
 						availableModelProfiles: [...this.ctx.session.modelRegistry.getModelProfiles().keys()],
 						cwd: getProjectDir(),
+						petAvailable: isPetAvailable(),
 					},
 					{
 						onChange: (id, value) => this.handleSettingChange(id, value),
@@ -591,6 +593,7 @@ export class SelectorController {
 	showPetSelector(): void {
 		const stored = settings.get("pet.mode");
 		const initial: PetMode = isPetMode(stored) ? stored : "off";
+		const available = isPetAvailable();
 		this.showSelector(done => {
 			// Live-preview via previewMode (no editor re-mount, so the overlay stays);
 			// Enter commits + persists, Esc restores the initial skin.
@@ -607,6 +610,7 @@ export class SelectorController {
 				mode => {
 					this.ctx.previewPetMode(mode);
 				},
+				available,
 			);
 			return { component: selector, focus: selector.getSelectList() };
 		});

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -617,8 +617,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.addChild(this.hookWidgetContainerBelow);
 		this.ui.setBottomPinnedComponent(this.statusLine);
 		this.ui.setFocus(this.editor);
+		this.petWidget?.dispose();
 		this.petWidget = this.#createPetWidget(this.editor);
-		this.petWidget.setMode(settings.get("pet.mode"));
+		const configuredPetMode = settings.get("pet.mode");
+		this.petWidget.setMode(configuredPetMode);
 		// The async sixel capability probe can enable graphics after the saved
 		// pet mode was applied and dropped (no protocol yet at startup).
 		// Re-apply the configured mode when capability arrives so the pet
@@ -1086,6 +1088,11 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	previewPetMode(mode: PetMode): void {
 		this.petWidget?.previewMode(mode);
+		this.ui.requestRender();
+	}
+
+	commitPetPreviewMode(mode: PetMode): void {
+		this.petWidget?.commitPreviewMode(mode);
 		this.ui.requestRender();
 	}
 
@@ -2223,7 +2230,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		nextEditor.setText(previousText);
 		previousEditor.dispose();
 
-		const petMode = this.petWidget?.mode ?? settings.get("pet.mode");
+		const petMode = settings.get("pet.mode");
 		this.petWidget?.dispose();
 
 		this.editorContainer.clear();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -87,6 +87,7 @@ import type { HookEditorComponent } from "./components/hook-editor";
 import type { HookInputComponent } from "./components/hook-input";
 import type { HookSelectorComponent } from "./components/hook-selector";
 import { IrcSplitViewComponent } from "./components/irc-sidebar";
+import { getPetUnavailableWarning, isPetAvailable } from "./components/pet-capability";
 import { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import {
@@ -633,6 +634,9 @@ export class InteractiveMode implements InteractiveModeContext {
 				this.petWidget.setMode(saved);
 			}
 		});
+		if (configuredPetMode !== "off" && !isPetAvailable()) {
+			this.showStatus(theme.fg("warning", getPetUnavailableWarning()), { dim: false });
+		}
 
 		this.#inputController.setupKeyHandlers();
 		this.#inputController.setupEditorSubmitHandler();
@@ -1081,6 +1085,11 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	setPetMode(mode: PetMode): void {
+		if (mode !== "off" && !isPetAvailable()) {
+			this.showStatus(theme.fg("warning", getPetUnavailableWarning()), { dim: false });
+			this.ui.requestRender();
+			return;
+		}
 		this.petWidget?.setMode(mode);
 		settings.set("pet.mode", mode);
 		this.ui.requestRender();

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -179,6 +179,8 @@ export interface InteractiveModeContext {
 	setPetMode(mode: PetMode): void;
 	/** Live-preview a pet skin during a selector without persisting. */
 	previewPetMode(mode: PetMode): void;
+	/** Commit a settings-overlay pet preview without re-mounting the composer. */
+	commitPetPreviewMode(mode: PetMode): void;
 	/** Re-mount the composer (pet-aware) after an overlay/selector closes. */
 	restoreComposer(): void;
 	startPendingSubmission(input: {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -3,15 +3,7 @@ import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import { type Model, modelsAreEqual } from "@gajae-code/ai";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
-import {
-	isPetMode,
-	isUnderTerminalMultiplexer,
-	PET_MODE_IDS,
-	PET_SKIN_IDS,
-	PET_SKINS,
-	Spacer,
-	Text,
-} from "@gajae-code/tui";
+import { PET_SKINS, type PetMode, Spacer, Text } from "@gajae-code/tui";
 import { setProjectDir } from "@gajae-code/utils";
 import { jobElapsedMs } from "../async";
 import { materializeActiveModelProfileAssignments } from "../config/model-profile-activation";
@@ -30,7 +22,7 @@ import {
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../discovery/helpers.js";
 import { resolveMemoryBackend } from "../memory-backend";
 import { DynamicBorder } from "../modes/components/dynamic-border";
-import { GajaePetWidget } from "../modes/components/gajae-pet-widget";
+import { getPetUnavailableWarning, isPetAvailable } from "../modes/components/pet-capability";
 import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
 import {
@@ -72,6 +64,13 @@ export type { BuiltinSlashCommand, SubcommandDef } from "./types";
 
 /** TUI-specific runtime accepted by `executeBuiltinSlashCommand`. */
 export type BuiltinSlashCommandRuntime = TuiSlashCommandRuntime;
+
+const PET_COMMAND_OPTIONS: ReadonlyArray<{ name: string; mode: PetMode; description: string }> = [
+	{ name: "off", mode: "off", description: "Hide the pet" },
+	{ name: "RedGajae", mode: "red", description: PET_SKINS.red.description },
+	{ name: "BlueGajae", mode: "blue", description: PET_SKINS.blue.description },
+];
+const PET_COMMAND_HINT = `[${PET_COMMAND_OPTIONS.map(option => option.name).join("|")}]`;
 
 type GjcModelBatchAssignmentTargetId = "all-role-agents" | "all-targets";
 type ParsedModelCommandArgs =
@@ -570,34 +569,26 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "pet",
 		description: "Gajae pet living beside the composer",
-		subcommands: [
-			{ name: "off", description: "Hide the pet" },
-			...PET_SKIN_IDS.map(id => ({ name: id, description: PET_SKINS[id].description })),
-		],
-		inlineHint: `[${PET_MODE_IDS.join("|")}]`,
+		subcommands: PET_COMMAND_OPTIONS.map(option => ({ name: option.name, description: option.description })),
+		inlineHint: PET_COMMAND_HINT,
 		allowArgs: true,
 		handleTui: (command, runtime) => {
 			const ctx = runtime.ctx;
 			const raw = command.args?.trim().toLowerCase() ?? "";
-			const arg = raw === "on" ? "red" : raw;
-			if (!arg) {
+			const arg = PET_COMMAND_OPTIONS.find(option => option.name.toLowerCase() === raw)?.mode;
+			if (!raw) {
 				ctx.showPetSelector();
 				ctx.editor.setText("");
 				return;
 			}
-			if (arg !== "off" && !GajaePetWidget.pixelProtocol()) {
-				ctx.showStatus(
-					isUnderTerminalMultiplexer()
-						? "Gajae pet: graphics are suppressed inside tmux/screen/zellij — escapes are not forwarded end-to-end. Run gjc outside the multiplexer in a sixel/kitty-graphics terminal, or set PI_FORCE_IMAGE_PROTOCOL=sixel when your multiplexer+client chain renders sixel."
-						: "Gajae pet needs a sixel/kitty-graphics terminal (Windows Terminal 1.22+, kitty, Ghostty, WezTerm)",
-					{ dim: true },
-				);
-			} else if (isPetMode(arg)) {
+			if (arg && arg !== "off" && !isPetAvailable()) {
+				ctx.showStatus(theme.fg("warning", getPetUnavailableWarning()), { dim: false });
+			} else if (arg) {
 				ctx.setPetMode(arg);
 				const name = arg === "off" ? "Gajae pet hidden" : `${PET_SKINS[arg].label} is here`;
 				ctx.showStatus(name);
 			} else {
-				ctx.showStatus(`Usage: /pet [${PET_MODE_IDS.join("|")}]`, { dim: true });
+				ctx.showStatus(`Usage: /pet ${PET_COMMAND_HINT}`, { dim: true });
 			}
 			ctx.editor.setText("");
 		},

--- a/packages/coding-agent/test/gajae-pet-widget.test.ts
+++ b/packages/coding-agent/test/gajae-pet-widget.test.ts
@@ -24,19 +24,25 @@ function makeStubs(columns = 80, rows = 30) {
 		invalidate() {},
 	} as unknown as CustomEditor;
 	let emitter: (() => string | null) | undefined;
+	let available = true;
+	let failWrites = false;
+	const terminal = {
+		columns,
+		rows,
+		write: (data: string) => {
+			if (failWrites) throw new Error("injected terminal write failure");
+			written.push(data);
+		},
+	};
 	const ui = {
 		requestRender: () => {},
 		setPostRenderEmitter: (fn?: () => string | null) => {
 			emitter = fn;
 		},
-		terminalAvailable: true,
-		terminal: {
-			columns,
-			rows,
-			write: (data: string) => {
-				written.push(data);
-			},
+		get terminalAvailable() {
+			return available;
 		},
+		terminal,
 	} as unknown as TUI;
 	const editorContainer = new Container();
 	const floorContainer = new Container();
@@ -49,6 +55,16 @@ function makeStubs(columns = 80, rows = 30) {
 		written,
 		getEmitter: () => emitter,
 		getRenderedWidth: () => renderedWidth,
+		setTerminalSize: (nextColumns: number, nextRows: number) => {
+			terminal.columns = nextColumns;
+			terminal.rows = nextRows;
+		},
+		setTerminalAvailable: (value: boolean) => {
+			available = value;
+		},
+		setWriteFailure: (value: boolean) => {
+			failWrites = value;
+		},
 	};
 }
 
@@ -59,7 +75,7 @@ function makeWidget(
 		bottomOffset?: number;
 		isWorking?: () => boolean;
 		autoFlexGapMs?: [number, number] | null;
-		protocol?: "sixel" | "kitty";
+		protocol?: "sixel" | "kitty" | null;
 	} = {},
 ) {
 	const stubs = makeStubs(columns, rows);
@@ -70,7 +86,7 @@ function makeWidget(
 		floorContainer: stubs.floorContainer,
 		isWorking: options.isWorking ?? (() => false),
 		getComposerBottomOffset: () => stubs.floorContainer.render(columns).length + (options.bottomOffset ?? 0),
-		forcePixelProtocol: options.protocol ?? "sixel",
+		forcePixelProtocol: options.protocol === null ? undefined : (options.protocol ?? "sixel"),
 		autoFlexGapMs: options.autoFlexGapMs !== undefined ? options.autoFlexGapMs : null,
 	});
 	return { ...stubs, widget };
@@ -99,6 +115,201 @@ describe("GajaePetWidget", () => {
 		} finally {
 			widget.dispose();
 		}
+	});
+
+	it("owns and deletes a distinct Kitty image ID per widget", () => {
+		const first = makeWidget(80, 30, { protocol: "kitty" });
+		const second = makeWidget(80, 30, { protocol: "kitty" });
+		try {
+			first.widget.setMode("red");
+			second.widget.setMode("red");
+			const firstPayload = first.getEmitter()?.();
+			const secondPayload = second.getEmitter()?.();
+			const firstId = firstPayload?.match(/i=(\d+)/)?.[1];
+			const secondId = secondPayload?.match(/i=(\d+)/)?.[1];
+
+			expect(firstId).toBeDefined();
+			expect(secondId).toBeDefined();
+			expect(firstId).not.toBe(secondId);
+			expect(Number(firstId)).toBeGreaterThan(0);
+			expect(Number(secondId)).toBeGreaterThan(0);
+
+			first.written.length = 0;
+			first.widget.setMode("off");
+			expect(first.written.some(chunk => chunk.includes(`a=d,d=I,i=${firstId}`))).toBe(true);
+			expect(first.written.some(chunk => chunk.includes(`i=${secondId}`))).toBe(false);
+		} finally {
+			first.widget.dispose();
+			second.widget.dispose();
+		}
+	});
+
+	it("clears the last Sixel footprint when disabled", () => {
+		const { widget, written, getEmitter } = makeWidget();
+		try {
+			widget.setMode("red");
+			expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+			written.length = 0;
+
+			widget.setMode("off");
+
+			expect(written.some(chunk => chunk.includes("\x1b[28;76H\x1b[4X"))).toBe(true);
+		} finally {
+			widget.dispose();
+		}
+	});
+
+	it("clears the previous Sixel footprint after the terminal becomes too narrow", () => {
+		const { widget, getEmitter, setTerminalSize } = makeWidget();
+		try {
+			widget.setMode("red");
+			expect(getEmitter()?.()).toContain("\x1b[28;76H");
+			setTerminalSize(12, 30);
+
+			const cleanup = getEmitter()?.();
+
+			expect(cleanup).toContain("\x1b[28;76H\x1b[4X");
+			expect(cleanup).not.toContain("\x1bP0;1;0q");
+			expect(getEmitter()?.()).toBeNull();
+		} finally {
+			widget.dispose();
+		}
+	});
+
+	it("completes logical teardown when the cleanup write throws", () => {
+		const { widget, editorContainer, getEmitter, getRenderedWidth, setWriteFailure } = makeWidget();
+		widget.setMode("red");
+		expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+
+		setWriteFailure(true);
+		widget.dispose();
+
+		// The thrown write must not abort teardown: the shared emitter slot is
+		// released, the composer is unframed, and the widget is terminal.
+		expect(getEmitter()).toBeUndefined();
+		expect(widget.mode).toBe("off");
+		editorContainer.render(80);
+		expect(getRenderedWidth()).toBe(80);
+		widget.setMode("red");
+		expect(getEmitter()).toBeUndefined();
+	});
+
+	it("keeps a disposed widget from clearing its successor's overlay emitter", () => {
+		const stubs = makeStubs();
+		const make = () =>
+			new GajaePetWidget({
+				ui: stubs.ui,
+				editor: stubs.editor,
+				editorContainer: stubs.editorContainer,
+				floorContainer: stubs.floorContainer,
+				isWorking: () => false,
+				getComposerBottomOffset: () => stubs.floorContainer.render(80).length,
+				forcePixelProtocol: "sixel",
+				autoFlexGapMs: null,
+			});
+		const first = make();
+		first.setMode("red");
+		first.dispose();
+
+		const second = make();
+		try {
+			second.setMode("red");
+			const successorEmitter = stubs.getEmitter();
+			expect(successorEmitter).toBeDefined();
+
+			first.dispose();
+
+			expect(stubs.getEmitter()).toBe(successorEmitter);
+		} finally {
+			second.dispose();
+		}
+	});
+
+	it("keeps a stale first-time dispose from stealing a successor's emitter or composer mount", () => {
+		const stubs = makeStubs();
+		const make = () =>
+			new GajaePetWidget({
+				ui: stubs.ui,
+				editor: stubs.editor,
+				editorContainer: stubs.editorContainer,
+				floorContainer: stubs.floorContainer,
+				isWorking: () => false,
+				getComposerBottomOffset: () => stubs.floorContainer.render(80).length,
+				forcePixelProtocol: "sixel",
+				autoFlexGapMs: null,
+			});
+		// The predecessor is never disposed before the successor takes over.
+		const first = make();
+		first.setMode("red");
+		const second = make();
+		try {
+			second.setMode("red");
+			const successorEmitter = stubs.getEmitter();
+			expect(successorEmitter).toBeDefined();
+
+			first.dispose();
+
+			expect(stubs.getEmitter()).toBe(successorEmitter);
+			// The successor's framed composer stays mounted (editor still narrowed).
+			stubs.editorContainer.render(80);
+			expect(stubs.getRenderedWidth()).toBe(80 - 5);
+		} finally {
+			second.dispose();
+		}
+	});
+
+	it("re-arms Kitty cleanup when the pet is re-placed after a narrow-terminal pass consumed it", () => {
+		const { widget, written, getEmitter, setTerminalSize } = makeWidget(12, 30, { protocol: "kitty" });
+		try {
+			widget.setMode("red");
+			// Too narrow: the emitter returns the delete escape and consumes the
+			// pending cleanup.
+			expect(getEmitter()?.()).toContain("\x1b_Ga=d");
+			expect(getEmitter()?.()).toBeNull();
+
+			// Wide again: the next frame re-places the image.
+			setTerminalSize(80, 30);
+			expect(getEmitter()?.()).toContain("\x1b_G");
+			written.length = 0;
+
+			widget.dispose();
+
+			expect(written.some(chunk => chunk.includes("\x1b_Ga=d,d=I,i="))).toBe(true);
+		} finally {
+			widget.dispose();
+		}
+	});
+
+	it("retains Sixel cleanup authority while the terminal is unavailable and erases once it returns", () => {
+		const { widget, written, getEmitter, setTerminalAvailable } = makeWidget();
+		widget.setMode("red");
+		expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+		written.length = 0;
+
+		setTerminalAvailable(false);
+		widget.setMode("off");
+		expect(written).toHaveLength(0);
+
+		setTerminalAvailable(true);
+		widget.dispose();
+
+		expect(written.some(chunk => chunk.includes("\x1b[28;76H\x1b[4X"))).toBe(true);
+	});
+
+	it("retains Sixel cleanup authority when the erase write throws and retries on dispose", () => {
+		const { widget, written, getEmitter, setWriteFailure } = makeWidget();
+		widget.setMode("red");
+		expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+		written.length = 0;
+
+		setWriteFailure(true);
+		widget.setMode("off");
+		expect(written).toHaveLength(0);
+
+		setWriteFailure(false);
+		widget.dispose();
+
+		expect(written.some(chunk => chunk.includes("\x1b[28;76H\x1b[4X"))).toBe(true);
 	});
 
 	it("hides the overlay instead of covering editor text on a narrow terminal", () => {

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -3,9 +3,9 @@ import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { Agent } from "@gajae-code/agent-core";
 import type { AssistantMessage } from "@gajae-code/ai";
-import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
 import { initTheme, theme } from "@gajae-code/coding-agent/modes/theme/theme";
-import { CURSOR_MARKER, Text, visibleWidth } from "@gajae-code/tui";
+import { CURSOR_MARKER, ImageProtocol, setTerminalImageProtocol, TERMINAL, Text, visibleWidth } from "@gajae-code/tui";
 import { TempDir } from "@gajae-code/utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import type {
@@ -585,5 +585,50 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(mode.editor.onSubmit).toBeDefined();
 		expect(mode.editor.onEscape).toBeDefined();
 		expect(refreshSpy).toHaveBeenCalled();
+	});
+
+	it("preserves a pending pet mode across editor replacement", () => {
+		const originalProtocol = TERMINAL.imageProtocol;
+		vi.spyOn(mode, "refreshSlashCommandState").mockResolvedValue();
+		try {
+			setTerminalImageProtocol(null);
+			settings.set("pet.mode", "red");
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+			expect(mode.petWidget?.mode).toBe("off");
+
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+			expect(mode.petWidget?.mode).toBe("off");
+
+			expect(settings.get("pet.mode")).toBe("red");
+			setTerminalImageProtocol(ImageProtocol.Sixel);
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+			expect(mode.petWidget?.mode).toBe("red");
+		} finally {
+			setTerminalImageProtocol(originalProtocol);
+		}
+	});
+
+	it("disposes a pre-init pet widget before init replaces it", async () => {
+		const originalProtocol = TERMINAL.imageProtocol;
+		vi.spyOn(mode, "refreshSlashCommandState").mockResolvedValue();
+		try {
+			setTerminalImageProtocol(null);
+			settings.set("pet.mode", "red");
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+			const preInitWidget = mode.petWidget;
+			if (!preInitWidget) throw new Error("Expected pre-init pet widget");
+			const dispose = vi.spyOn(preInitWidget, "dispose");
+
+			await mode.init();
+
+			expect(dispose).toHaveBeenCalledTimes(1);
+			expect(mode.petWidget).not.toBe(preInitWidget);
+			expect(mode.petWidget?.mode).toBe("off");
+
+			setTerminalImageProtocol(ImageProtocol.Sixel);
+			expect(mode.petWidget?.mode).toBe("red");
+		} finally {
+			setTerminalImageProtocol(originalProtocol);
+		}
 	});
 });

--- a/packages/coding-agent/test/modes/components/pet-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/pet-selector.test.ts
@@ -1,0 +1,58 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import {
+	createPetSelectItems,
+	getPetUnavailableWarning,
+	PET_UNAVAILABLE_WARNING,
+} from "@gajae-code/coding-agent/modes/components/pet-capability";
+import { PetSelectorComponent } from "@gajae-code/coding-agent/modes/components/pet-selector";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+
+function stripAnsi(text: string): string {
+	return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+beforeAll(async () => {
+	await initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+});
+
+describe("PetSelectorComponent", () => {
+	it("shows saved named pets but keeps unavailable ones unselectable", () => {
+		const onSelect = vi.fn();
+		const onPreview = vi.fn();
+		const component = new PetSelectorComponent("red", onSelect, () => {}, onPreview, false);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		expect(rendered).toContain("RedGajae (saved)");
+		expect(rendered).toContain("BlueGajae");
+		expect(rendered).toContain("Saved, unavailable");
+		expect(stripAnsi(component.render(40).join("\n"))).toContain("RedGajae (saved)");
+		expect(component.getSelectList().getSelectedItem()?.value).toBe("off");
+
+		component.getSelectList().handleInput("\x1b[B");
+		expect(component.getSelectList().getSelectedItem()?.value).toBe("off");
+		expect(onPreview).not.toHaveBeenCalled();
+	});
+
+	it("decorates settings options through the shared capability policy", () => {
+		const items = createPetSelectItems(
+			[
+				{ value: "off", label: "Off" },
+				{ value: "red", label: "RedGajae" },
+				{ value: "blue", label: "BlueGajae" },
+			],
+			"blue",
+			false,
+		);
+
+		expect(items.find(item => item.value === "off")?.disabled).toBe(false);
+		expect(items.find(item => item.value === "red")?.disabled).toBe(true);
+		expect(items.find(item => item.value === "blue")?.description).toContain("Saved, unavailable");
+	});
+
+	it("preserves multiplexer-specific recovery guidance", () => {
+		const warning = getPetUnavailableWarning({ TMUX: "/tmp/tmux-1/default,1,0" });
+		expect(warning).toContain("outside the multiplexer");
+		expect(warning).toContain("PI_FORCE_IMAGE_PROTOCOL=sixel");
+		expect(getPetUnavailableWarning({})).toBe(PET_UNAVAILABLE_WARNING);
+	});
+});

--- a/packages/coding-agent/test/modes/components/settings-selector-pet.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-pet.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
+import { SettingsSelectorComponent } from "@gajae-code/coding-agent/modes/components/settings-selector";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+beforeEach(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+});
+
+afterEach(() => {
+	resetSettingsForTest();
+});
+
+function openPetSetting(component: SettingsSelectorComponent): void {
+	for (let attempt = 0; attempt < 100; attempt++) {
+		const rendered = stripVTControlCharacters(component.render(160).join("\n"));
+		if (rendered.includes("16x16 real-pixel gajae living beside the composer")) {
+			component.handleInput("\n");
+			return;
+		}
+		component.handleInput("\x1b[B");
+	}
+	throw new Error("Gajae Pet setting was not reachable");
+}
+
+describe("SettingsSelectorComponent pet capability", () => {
+	it("shows a saved unavailable pet but only permits Off", () => {
+		settings.set("pet.mode", "red");
+		const onChange = vi.fn();
+		const onPetPreview = vi.fn();
+		const component = new SettingsSelectorComponent(
+			{
+				availableThinkingLevels: [],
+				thinkingLevel: undefined,
+				availableThemes: ["dark"],
+				availableModelProfiles: [],
+				cwd: process.cwd(),
+				petAvailable: false,
+			},
+			{ onChange, onPetPreview, onCancel: () => {} },
+		);
+
+		openPetSetting(component);
+		const submenu = stripVTControlCharacters(component.render(80).join("\n"));
+		expect(submenu).toContain("RedGajae (saved)");
+		expect(submenu).toContain("BlueGajae");
+		expect(submenu).toContain("Saved, unavailable");
+		expect(stripVTControlCharacters(component.render(40).join("\n"))).toContain("RedGajae (saved)");
+
+		component.handleInput("\x1b[B");
+		expect(onPetPreview).not.toHaveBeenCalled();
+		component.handleInput("\n");
+
+		expect(onChange).toHaveBeenCalledWith("pet.mode", "off");
+		expect(settings.get("pet.mode")).toBe("off");
+	});
+});

--- a/packages/coding-agent/test/slash-command-builtin-registry.test.ts
+++ b/packages/coding-agent/test/slash-command-builtin-registry.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { BUILTIN_SLASH_COMMANDS } from "@gajae-code/coding-agent/extensibility/slash-commands";
+import { PET_UNAVAILABLE_WARNING } from "@gajae-code/coding-agent/modes/components/pet-capability";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
 import {
 	BUILTIN_SLASH_COMMAND_DEFS,
@@ -6,6 +9,18 @@ import {
 	executeBuiltinSlashCommand,
 	lookupBuiltinSlashCommand,
 } from "@gajae-code/coding-agent/slash-commands/builtin-registry";
+import { ImageProtocol, TERMINAL } from "@gajae-code/tui";
+
+const mutableTerminal = TERMINAL as unknown as { imageProtocol: ImageProtocol | null };
+const originalImageProtocol = mutableTerminal.imageProtocol;
+
+beforeAll(async () => {
+	await initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+});
+
+afterEach(() => {
+	mutableTerminal.imageProtocol = originalImageProtocol;
+});
 
 function createTuiRuntime() {
 	const handleCopyCommand = vi.fn();
@@ -41,11 +56,66 @@ function createClearTuiRuntime() {
 }
 
 describe("builtin /pet slash command", () => {
-	it("exposes off plus the registry-driven skin choices", () => {
+	it("exposes the named Gajae choices", () => {
 		const petCommand = BUILTIN_SLASH_COMMAND_DEFS.find(command => command.name === "pet");
 
-		expect(petCommand?.subcommands?.map(command => command.name)).toEqual(["off", "red", "blue"]);
-		expect(petCommand?.inlineHint).toBe("[off|red|blue]");
+		expect(petCommand?.subcommands?.map(command => command.name)).toEqual(["off", "RedGajae", "BlueGajae"]);
+		expect(petCommand?.inlineHint).toBe("[off|RedGajae|BlueGajae]");
+	});
+
+	it("maps named Gajae commands to their internal modes", async () => {
+		mutableTerminal.imageProtocol = ImageProtocol.Kitty;
+		const setPetMode = vi.fn();
+		const setText = vi.fn();
+		const showStatus = vi.fn();
+		const ctx = { setPetMode, showStatus, editor: { setText } } as unknown as InteractiveModeContext;
+		const runtime = { ctx, handleBackgroundCommand: () => undefined };
+
+		expect(await executeBuiltinSlashCommand("/pet redgajae", runtime)).toBe(true);
+		expect(await executeBuiltinSlashCommand("/pet BlueGajae", runtime)).toBe(true);
+
+		expect(setPetMode.mock.calls.map(call => call[0])).toEqual(["red", "blue"]);
+	});
+
+	it("rejects internal color IDs and legacy aliases as public commands", async () => {
+		mutableTerminal.imageProtocol = ImageProtocol.Kitty;
+		const setPetMode = vi.fn();
+		const showStatus = vi.fn();
+		const ctx = { setPetMode, showStatus, editor: { setText: vi.fn() } } as unknown as InteractiveModeContext;
+
+		for (const token of ["red", "blue", "on"]) {
+			expect(
+				await executeBuiltinSlashCommand(`/pet ${token}`, { ctx, handleBackgroundCommand: () => undefined }),
+			).toBe(true);
+		}
+		expect(setPetMode).not.toHaveBeenCalled();
+		expect(showStatus).toHaveBeenCalledTimes(3);
+		expect(showStatus).toHaveBeenLastCalledWith("Usage: /pet [off|RedGajae|BlueGajae]", { dim: true });
+	});
+
+	it("warns instead of enabling a named pet when overlays are unavailable", async () => {
+		mutableTerminal.imageProtocol = null;
+		const setPetMode = vi.fn();
+		const showStatus = vi.fn();
+		const ctx = { setPetMode, showStatus, editor: { setText: vi.fn() } } as unknown as InteractiveModeContext;
+
+		expect(await executeBuiltinSlashCommand("/pet RedGajae", { ctx, handleBackgroundCommand: () => undefined })).toBe(
+			true,
+		);
+		expect(setPetMode).not.toHaveBeenCalled();
+		expect(showStatus.mock.calls[0]?.[0]).toContain(PET_UNAVAILABLE_WARNING);
+		expect(showStatus.mock.calls[0]?.[1]).toEqual({ dim: false });
+	});
+
+	it("completes named pets case-insensitively", async () => {
+		const petCommand = BUILTIN_SLASH_COMMANDS.find(command => command.name === "pet");
+
+		for (const prefix of ["r", "R", "ReD"]) {
+			const completions = await petCommand?.getArgumentCompletions?.(prefix);
+			expect(completions?.map(item => item.label)).toEqual(["RedGajae"]);
+		}
+
+		expect(petCommand?.getInlineHint?.("ReD")).toBe("Gajae");
 	});
 });
 describe("builtin /copy slash command", () => {


### PR DESCRIPTION
## What

Make Gajae Pet selection terminal-capability aware. **Stacked on #2153 (exception-safe pet overlay cleanup) and #2154 (TUI disabled select-list items)** — rebased onto current `dev` and onto the corrected/documented contracts from the #2134/#2135 reviews (this branch's history contains both dependency commits until they merge; the last commit is this PR's own change). Staying draft until both dependencies land, then I will rebase so the diff shrinks to this PR's commit.

- New `pet-capability` module centralizes protocol detection, availability, unavailable-warning copy, and select-item decoration for every pet surface.
- Unsupported terminals show an actionable warning on startup (when a saved pet cannot render), on `/pet`, and in Settings — with multiplexer-specific guidance for tmux/screen/zellij, preserving the `PI_FORCE_IMAGE_PROTOCOL=sixel` expert opt-in wording that #2091 established.
- `/pet` and Settings disable the unavailable `RedGajae`/`BlueGajae` choices (dimmed, navigation-skipped via the #2154 contract) while `off` stays selectable; a saved-but-unavailable choice is labeled `(saved)` with an explanatory description.
- Canonical public command names across execution, completion, and inline hints: `/pet RedGajae`, `/pet BlueGajae`, `/pet off` (case-insensitive; subcommand completion in `slash-commands.ts` is made case-insensitive to support mixed-case names).

## Why

On terminals without Kitty/Sixel graphics, `/pet` and the Settings pet entry offer fully selectable choices that silently do nothing, and the command surface mixes naming (`/pet red` vs the skin labels). Disabling unavailable choices, identifying a saved-but-unavailable preference, and unifying the public names removes the confusing no-op behavior while keeping every selection surface consistent with the active terminal capability.

## Testing

- Focused suites on the assembled stack — **62 pass, 0 fail**: pet-selector, settings-selector-pet, slash-command-builtin-registry, gajae-pet-widget (24, incl. the new teardown/authority regressions), select-list (17, incl. the all-disabled no-selection regressions).
- `bun --cwd=packages/coding-agent run check` (biome + SDK canonicalization + tsc) — green; root gates green locally except `check:sdk-closure`, which requires the new Rust SDK natives this machine cannot build and fails identically on clean `dev` (no SDK files touched); Linux CI is authoritative.
- `git diff --check` — clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
