### PR TITLE
fix(coding-agent): hide welcome banner after compaction

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - IRC deliveries now accept their exchange batch in the recipient's volatile current-session queue before recipient/main UI observations or sender success. Awaited deliveries generate the reply first, then accept the ordered incoming + auto-reply pair and commit the IRC roster claim before observation; provider failures and sender aborts before acceptance leave no ghost exchange, while observer failures after acceptance are isolated. This is not a durability guarantee: durable history injection remains a later flush and no fsync, recovery, persistent IDs, or deduplication was added.
 - Print mode now records terminal text-mode errors as exit status 1 (or 78 for context overflow) without bypassing output quiescence or session disposal. It retains JSON event delivery through disposal and suppresses `EPIPE` from its owned stdout; `ERR_STREAM_DESTROYED` is suppressed only after that `EPIPE` has latched, while other output failures remain errors.
 - Extension contexts now receive a defensive copy from `getSystemPrompt()` instead of the live mutable system-prompt array, so an in-place mutation by an in-process extension can no longer bypass context-revision tracking and serve stale display-only context-usage estimates.
+- Prevented the startup welcome banner from resurfacing after an interactive session compacts to a short summary.
 
 ## [0.10.0] - 2026-07-12
 

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -18,6 +18,8 @@ export type WelcomeLogoMode = "unicode" | "square" | "ascii";
 export interface WelcomeComponentOptions {
 	getViewportRows?: () => number | undefined;
 	getReservedBottomRows?: (termWidth: number) => number;
+	/** Optional gate for callers that retire the launch surface after transcript content appears. */
+	shouldRender?: () => boolean;
 	changelogMarkdown?: string;
 	collapseChangelog?: boolean;
 	buildLabel?: string;
@@ -107,6 +109,9 @@ export class WelcomeComponent implements Component {
 	}
 
 	render(termWidth: number): string[] {
+		if (this.options.shouldRender?.() === false) {
+			return [];
+		}
 		const boxWidth = Math.max(0, termWidth);
 		if (boxWidth < 4) {
 			return [];

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -594,6 +594,8 @@ export class InteractiveMode implements InteractiveModeContext {
 				{
 					getViewportRows: () => this.ui.terminal.rows,
 					getReservedBottomRows: getWelcomeReservedBottomRows,
+					// Compaction can shrink a long transcript to one summary; do not resurrect the launch logo then.
+					shouldRender: () => this.chatContainer.children.length === 0 && this.session.messages.length === 0,
 					changelogMarkdown: this.#changelogMarkdown,
 					collapseChangelog: settings.get("collapseChangelog"),
 				},

--- a/packages/coding-agent/test/welcome-viewport.test.ts
+++ b/packages/coding-agent/test/welcome-viewport.test.ts
@@ -116,6 +116,18 @@ describe("WelcomeComponent viewport sizing", () => {
 		expect(lines.some(line => line.includes("GJC Forge"))).toBe(true);
 		expect(lines.some(line => line.includes("What's New"))).toBe(true);
 	});
+	it("honors the caller render gate before consuming launch-surface rows", () => {
+		let shouldRender = true;
+		const welcome = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii", {
+			getViewportRows: () => 24,
+			getReservedBottomRows: () => 6,
+			shouldRender: () => shouldRender,
+		});
+
+		expect(welcome.render(100)).toHaveLength(18);
+		shouldRender = false;
+		expect(welcome.render(100)).toEqual([]);
+	});
 	it("integrates changelog highlights without overflowing narrow CJK content", () => {
 		const welcome = new WelcomeComponent("1.2.3", "test-model", "test-provider", [], [], "ascii", {
 			getViewportRows: () => 16,


### PR DESCRIPTION
## What

- Add an optional render gate to the startup welcome component.
- Retire the interactive welcome banner once the session has rendered chat or has provider/session messages.
- Add regression coverage for the welcome render gate and a changelog entry.

## Why

After context compaction, the rendered transcript can shrink to only the compaction summary. The startup welcome banner was still mounted and could consume the reclaimed viewport, covering the useful recent transcript area.

## Testing

- `bun test packages/coding-agent/test/welcome-viewport.test.ts packages/coding-agent/test/modes/components/redesigned-shell.test.ts packages/coding-agent/test/interactive-irc-lifecycle.test.ts`
- `bun --cwd=packages/coding-agent run check`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)