### PR TITLE
fix(coding-agent): allow tools without permission provider

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4524,9 +4524,10 @@ export class AgentSession {
 						throw new ToolError(`Tool call rejected by session permission policy (${target.name})`);
 					}
 					if (!requestPermission) {
-						throw new ToolError(
-							`Tool call rejected because no permission provider is connected (${target.name})`,
-						);
+						// Prompt mode is meaningful only while a live permission provider owns
+						// the interaction. Provider-less interactive sessions must remain
+						// usable instead of deadlocking every guarded tool call.
+						return await target.execute(toolCallId, args as never, signal, onUpdate, ctx);
 					}
 					// Short-circuit on persisted decisions.
 					const persisted = this.#acpPermissionDecisions.get(permissionIntent.cacheKey);

--- a/packages/coding-agent/test/agent-session-acp-permission.test.ts
+++ b/packages/coding-agent/test/agent-session-acp-permission.test.ts
@@ -834,3 +834,44 @@ it("read tool: requestPermission is never called for non-gated tools", async () 
 	expect(permissionSpy).toHaveBeenCalledTimes(0);
 	expect(readTool.executeCalls).toBe(1);
 });
+
+it("allows guarded tools when prompt mode has no permission provider", async () => {
+	const bashTool = makeFakeTool("bash");
+	session = await createSession([bashTool]);
+
+	await session.setActiveToolsByName(["bash"]);
+	const wrappedBash = session.agent.state.tools.find(tool => tool.name === "bash");
+	expect(wrappedBash).toBeDefined();
+
+	await expect(
+		wrappedBash!.execute(
+			"call-providerless-bash",
+			{ command: "git status" },
+			undefined,
+			undefined as never,
+			undefined as never,
+		),
+	).resolves.toMatchObject({ content: [{ type: "text", text: "ok" }] });
+	expect(bashTool.executeCalls).toBe(1);
+});
+
+it("keeps explicit deny fail-closed without a permission provider", async () => {
+	const bashTool = makeFakeTool("bash");
+	session = await createSession([bashTool]);
+	session.setSdkPermissionMode("deny");
+
+	await session.setActiveToolsByName(["bash"]);
+	const wrappedBash = session.agent.state.tools.find(tool => tool.name === "bash");
+	expect(wrappedBash).toBeDefined();
+
+	await expect(
+		wrappedBash!.execute(
+			"call-denied-bash",
+			{ command: "git status" },
+			undefined,
+			undefined as never,
+			undefined as never,
+		),
+	).rejects.toThrow("Tool call rejected by session permission policy (bash)");
+	expect(bashTool.executeCalls).toBe(0);
+});


### PR DESCRIPTION
## Summary
- fail open for guarded tool execution when prompt mode has no connected permission provider
- preserve explicit deny behavior
- add regression coverage for providerless Bash and explicit deny

## Verification
- `bun test packages/coding-agent/test/agent-session-acp-permission.test.ts` (25 pass)
- `bun --cwd=packages/coding-agent run check`
- `bun run build`

Owner-direct production hotfix for interactive sessions rejecting every Bash call with `Tool call rejected because no permission provider is connected (bash)`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
