### PR TITLE
fix(session): default permission mode to allow when no provider is connected

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1253,8 +1253,9 @@ export class AgentSession {
 	#allowAcpAgentInitiatedTurns = false;
 	/** Per-session memory of allow_always / reject_always decisions for gated tools. */
 	#acpPermissionDecisions: Map<string, "allow_always" | "reject_always"> = new Map();
-	/** SDK-controlled permission policy applied before ACP client prompting. */
-	#sdkPermissionMode: "prompt" | "allow" | "deny" = "prompt";
+	/** SDK-controlled permission policy applied before ACP client prompting. Defaults to `allow` so callers
+	 * without a reverse permission provider (TUI, print/headless) run guarded tools; ACP/SDK set this explicitly. */
+	#sdkPermissionMode: "prompt" | "allow" | "deny" = "allow";
 	/** Permission provider registered by a live SDK reverse lease. */
 	#sdkPermissionProvider:
 		| ((

--- a/packages/coding-agent/test/agent-session-acp-permission.test.ts
+++ b/packages/coding-agent/test/agent-session-acp-permission.test.ts
@@ -99,6 +99,8 @@ async function createSession(tools: AgentTool[], bridge?: ClientBridge): Promise
 		toolRegistry: new Map(tools.map(t => [t.name, t])),
 	});
 
+	// Session default is `allow`; ACP registers a prompt bridge alongside prompt mode (see acp-agent).
+	sess.setSdkPermissionMode("prompt");
 	if (bridge) sess.setClientBridge(bridge);
 	return sess;
 }
@@ -130,6 +132,7 @@ async function createSessionWithMockModel(
 		modelRegistry: { getApiKey: () => "test-key" } as never,
 		toolRegistry: new Map(tools.map(t => [t.name, t])),
 	});
+	sess.setSdkPermissionMode("prompt");
 	sess.setClientBridge(bridge);
 	return sess;
 }


### PR DESCRIPTION
## Problem

Guarded tools (bash/monitor/edit/delete/move) fail-closed in the permission wrapper when `#sdkPermissionMode` is `prompt` and no reverse permission provider is wired: `Tool call rejected because no permission provider is connected (bash)`.

The TUI and print/headless callers never register an ACP client bridge or an SDK reverse permission provider (only the ACP and SDK-bus paths do). Since the mode defaulted to `prompt`, every guarded tool was rejected in the TUI.

## Fix

Default `AgentSession.#sdkPermissionMode` to `allow`. TUI/print/headless run guarded tools; ACP still sets its mode explicitly via `permission_mode.set` (acp-agent.ts:472) and SDK via the reverse lease. `prompt` now means 'a provider must exist' (fail-closed on disconnect); `allow` is the default for callers not using the ACP/SDK permission seam.

## Tests

Updated the two ACP-permission test helpers to set `prompt` explicitly (matching production ACP). All 23 ACP-permission tests pass, plus acp-client-bridge / acp-startup-options / sdk-host-wiring. Package typecheck clean.