### PR TITLE
fix(ai): neutralize leaked reserved control tokens in Codex replay history

### DIFF
--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -119,22 +119,39 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(items: Array<Record
 		return sanitized ? [sanitized] : [];
 	});
 }
+const RESERVED_CONTROL_TOKEN_RE = /<\|(?=[A-Za-z0-9_]{1,32}\|>)/g;
+/**
+ * Neutralize leaked OpenAI Harmony / control tokens (`<|channel|>`, `<|message|>`,
+ * `<|call|>`, `<|constrain|>`, `<|recipient|>`, `<|content|>`, ...) in replayed
+ * history text. A subagent whose tool-call channel degenerates can dump raw
+ * control-token scaffolding into its reply text; once that poisoned text lands in
+ * history the Codex / Responses endpoint rejects every subsequent request with
+ * `Request blocked (code=invalid_prompt)`, permanently wedging the session because
+ * the offending item is re-sent on each turn. Insert a zero-width space after `<`
+ * so the delimiter can no longer be tokenized as a reserved control token while the
+ * text stays human-readable.
+ */
+function neutralizeReservedControlTokens(text: string): string {
+	if (!text.includes("<|")) return text;
+	return text.replace(RESERVED_CONTROL_TOKEN_RE, "<\u200b|");
+}
+
 function stringifyResponsesStringParamForReplay(value: unknown): string {
-	if (typeof value === "string") return value.toWellFormed();
+	if (typeof value === "string") return neutralizeReservedControlTokens(value.toWellFormed());
 	try {
 		const encoded = JSON.stringify(value);
-		if (typeof encoded === "string") return encoded.toWellFormed();
+		if (typeof encoded === "string") return neutralizeReservedControlTokens(encoded.toWellFormed());
 	} catch {
 		// Fall through to String().
 	}
-	return String(value ?? "").toWellFormed();
+	return neutralizeReservedControlTokens(String(value ?? "").toWellFormed());
 }
 
 function normalizeResponsesMessageTextForReplay(value: unknown): string {
-	if (typeof value === "string") return value.toWellFormed();
+	if (typeof value === "string") return neutralizeReservedControlTokens(value.toWellFormed());
 	if (value && typeof value === "object") {
 		const nestedText = (value as { text?: unknown }).text;
-		if (typeof nestedText === "string") return nestedText.toWellFormed();
+		if (typeof nestedText === "string") return neutralizeReservedControlTokens(nestedText.toWellFormed());
 	}
 	return stringifyResponsesStringParamForReplay(value);
 }
@@ -163,7 +180,7 @@ function normalizeResponsesImageUrlForReplay(value: unknown): NormalizedResponse
 }
 
 function sanitizeResponsesMessageContentForReplay(content: unknown): unknown {
-	if (typeof content === "string") return content.toWellFormed();
+	if (typeof content === "string") return neutralizeReservedControlTokens(content.toWellFormed());
 	if (!Array.isArray(content)) return content;
 	return content.map(part => {
 		if (!part || typeof part !== "object") return part;
@@ -197,12 +214,11 @@ function sanitizeResponsesStringFieldsForReplay(item: Record<string, unknown>): 
 	if (item.type === "custom_tool_call" && "input" in item && typeof item.input !== "string") {
 		item.input = stringifyResponsesStringParamForReplay(item.input);
 	}
-	if (
-		(item.type === "function_call_output" || item.type === "custom_tool_call_output") &&
-		"output" in item &&
-		typeof item.output !== "string"
-	) {
-		item.output = stringifyResponsesStringParamForReplay(item.output);
+	if ((item.type === "function_call_output" || item.type === "custom_tool_call_output") && "output" in item) {
+		item.output =
+			typeof item.output === "string"
+				? neutralizeReservedControlTokens(item.output.toWellFormed())
+				: stringifyResponsesStringParamForReplay(item.output);
 	}
 }
 

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -583,6 +583,73 @@ describe("OpenAI responses history payload", () => {
 		});
 	});
 
+	it("neutralizes leaked reserved control tokens in replayed tool output and message text", async () => {
+		const model = getBundledModel("openai-codex", "gpt-5.2-codex") as Model<"openai-codex-responses">;
+		const functionCallId = "call_leaked_control_tokens";
+		// Reproduces the wedge from a subagent that dumped raw Harmony / tool-call
+		// scaffolding into its reply text. Left verbatim, these reserved tokens make
+		// the Codex endpoint reject the whole request with
+		// `Request blocked (code=invalid_prompt)`, permanently bricking the session
+		// because the poisoned item is re-sent on every subsequent turn.
+		const poisonedOutput =
+			'Not blocked; persisting now.<|channel|>analysis to=functions.bash<|constrain|>json<|message|>{"command":"gjc --help"}<|call|>';
+		const poisonedText = 'Persist and finish.<|recipient|>functions.bash<|content|>{"command":"true"}';
+		const malformedHistoryItems: Record<string, unknown>[] = [
+			{
+				type: "function_call",
+				id: "fc_leaked_control_tokens",
+				call_id: functionCallId,
+				name: "irc",
+				arguments: '{"op":"send"}',
+			},
+			{
+				type: "function_call_output",
+				call_id: functionCallId,
+				output: poisonedOutput,
+			},
+			{
+				type: "message",
+				role: "user",
+				content: [{ type: "input_text", text: poisonedText }],
+			},
+		];
+		const payload = (await captureCodexPayload(model, {
+			messages: [
+				{ role: "user", content: "generic history that should be replaced", timestamp: Date.now() },
+				makeAssistantMessage(malformedHistoryItems, false, "openai-codex", "gpt-5.2-codex"),
+				{ role: "user", content: "follow-up user", timestamp: Date.now() },
+			],
+		})) as { input?: Array<Record<string, unknown>> };
+
+		const output = payload.input?.find(item => item.type === "function_call_output") as
+			| { output?: string }
+			| undefined;
+		expect(output?.output).toBeDefined();
+		// Reserved token boundaries are broken with a zero-width space...
+		expect(output?.output).not.toContain("<|channel|>");
+		expect(output?.output).not.toContain("<|call|>");
+		expect(output?.output).toContain("<\u200b|channel|>");
+		// ...while the human-readable content survives.
+		expect(output?.output).toContain("Not blocked; persisting now.");
+
+		const message = payload.input?.find(item => {
+			const content = (item as { content?: unknown }).content;
+			return (
+				item.type === "message" &&
+				Array.isArray(content) &&
+				content.some(
+					part =>
+						typeof (part as { text?: unknown }).text === "string" &&
+						(part as { text: string }).text.includes("Persist and finish"),
+				)
+			);
+		}) as { content?: Array<{ text?: string }> } | undefined;
+		const messageText = message?.content?.[0]?.text ?? "";
+		expect(messageText).not.toContain("<|recipient|>");
+		expect(messageText).not.toContain("<|content|>");
+		expect(messageText).toContain("Persist and finish.");
+	});
+
 	it("ignores incompatible native history snapshots across providers", async () => {
 		const model = getBundledModel("github-copilot", "gpt-5.4") as Model<"openai-responses">;
 		const payload = (await captureResponsesPayload(model, codexToCopilotContext)) as { input?: unknown[] };


### PR DESCRIPTION
## Neutralize leaked reserved control tokens in Codex replay history

### Summary
A single malformed subagent reply can **permanently wedge** an `openai-codex`
(gpt-5.x / Responses) session. Once a reserved OpenAI Harmony / tool-call token
string lands in the conversation history, every subsequent request is rejected by
the endpoint with `Request blocked (code=invalid_prompt)`, and because the
poisoned item stays in history and is replayed each turn, the session can never
recover on its own.

This PR hardens the replay sanitizer (`packages/ai/src/utils.ts`) to neutralize
those reserved token strings before they are re-sent, and closes a gap where
string-valued tool outputs bypassed replay normalization entirely.

### Symptom
Every turn after the poisoned item fails instantly (~15–20 ms, 0 tokens):

```
stopReason: error
Codex response failed: Request blocked. (code=invalid_prompt, status=failed)
Codex error event:    Request blocked. (code=invalid_prompt)
```

Observed 14 consecutive identical failures across two turn-bursts; the session
was unrecoverable (even a benign follow-up user message failed for the same
reason — the tainted history is what is rejected, not the new input).

### Root cause
1. A subagent's tool-call channel degenerated and it dumped raw tool-call
   scaffolding into its **reply text** instead of clean prose — a mix of raw
   JSON args, `<tool_call>`/`<function=…>` markup, and, critically, **reserved
   Harmony control tokens**: `<|channel|>` `<|message|>` `<|call|>`
   `<|constrain|>` `<|recipient|>` `<|content|>`.
2. That reply was stored in the leader session's history as a
   `function_call_output` string and replayed verbatim.
3. The Codex/Responses endpoint rejects any request whose input carries these
   reserved token strings → `invalid_prompt` at the edge (instant, 0 tokens).
4. The offending item is never rewritten, so it is re-sent every turn →
   permanent wedge; provider-level retry correctly treats `invalid_prompt` as
   non-retryable, but the item persists in history so new turns keep failing.

### Evidence (redacted)
Leader history — the delivered subagent reply that immediately preceded the
first `invalid_prompt` (paths/ids redacted):

```
### <architect-subagent>
Not blocked; the review is being persisted now. ...
{"command":"gjc ralplan --help"}{"command":"gjc ralplan --help"}...
{"tool_uses":[{"recipient_name":"functions.bash","parameters":{"command":"gjc ralplan --help"}}]}
<tool_call name="bash">{"command":"gjc ralplan --help"}</tool_call>
to=functions.bash {"command":"gjc ralplan --help"}
<|channel|>analysis to=functions.bash <|constrain|>json<|message|>{"command":"gjc ralplan --help"}<|call|>
<|recipient|>functions.bash<|channel|>analysis<|content|>...
{"result":{"error":"Tool dispatch is unavailable after the IRC reply; review could not be persisted."}}
```

(The model even fabricated its own "tool dispatch is unavailable" error — it was
trying to invoke persistence tools from a reply context that cannot dispatch
them, and flailed through every tool-call syntax it knew, as plain text.)

Timeline (relative):

| event | detail |
|---|---|
| T-5s  | subagent reply (above) delivered into leader history |
| T+0   | first request incl. that item → `invalid_prompt` |
| T+0…5m| 14 consecutive identical `invalid_prompt` failures; session wedged |

The subagent's own transcript was clean and it later finished its real work
normally — only the *reply* generation leaked the tokens.

### The gap in the code
`sanitizeOpenAIResponsesHistoryItemsForReplay` already normalizes replayed text
(`.toWellFormed()`, stringifies object fields) but:
- never strips/neutralizes reserved `<|…|>` control tokens, and
- **skips string-valued `function_call_output`/`custom_tool_call_output` output
  entirely** (the branch only fired for non-string output), so tool-result
  strings — exactly the poisoned path here — were replayed untouched.

### The fix
- Add `neutralizeReservedControlTokens()`: for `<|name|>`-shaped tokens, insert a
  zero-width space after `<` so the string can no longer be tokenized as a
  reserved control token, while staying human-readable. No-op when `<|` is absent.
- Apply it to replayed message text, string content, stringified replay fields,
  and string-valued `function_call_output`/`custom_tool_call_output` output
  (which now also gets `.toWellFormed()`).

Narrow, at the existing sanitization seam; `<|name|>` literals are essentially
never legitimate content, and normal text (`a < b | c`, markdown `|x|y|`) is
untouched.

### Testing
- New case in `openai-responses-history-payload.test.ts`: a `function_call_output`
  string and a message text carrying `<|channel|>/<|call|>/<|recipient|>/…` are
  neutralized in the built payload, while human-readable text survives.
- `bun test packages/ai/test` → 1568 pass, 0 fail; `biome check` clean.

### Scope / limitations
- Framed as **defense-in-depth**: the exact API-side trigger is not reproduced
  here (a content-safety classifier is a competing hypothesis — earlier poisoned
  items did not always block immediately), but sending reserved control-token
  strings to a Harmony model in replayed input is unsafe regardless and strongly
  correlates with the observed wedge.
- **Follow-up (separate issue, not this PR):** a session-level circuit-breaker so
  a hard `invalid_prompt`/blocked turn does not get re-attempted against
  identical tainted history, plus an operator path to repair/trim poisoned
  history. That touches the agent-orchestration layer and needs its own design.
