### PR TITLE
test(coding-agent): stabilize SDK broker heartbeat coverage

### DIFF
--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -97,11 +97,16 @@ describe("SDK broker identity and discovery", () => {
 		const dir = await temp();
 		const broker = new Broker({ agentDir: dir, heartbeatTtlMs: 45 });
 		const first = await broker.start();
-		await sleep(100);
-		expect(await readBrokerDiscovery(dir, 45)).not.toBeNull();
+		const deadline = Date.now() + 5_000;
+		let refreshed = await readBrokerDiscovery(dir);
+		while ((!refreshed || refreshed.heartbeatAt <= first.heartbeatAt) && Date.now() < deadline) {
+			await sleep(10);
+			refreshed = await readBrokerDiscovery(dir);
+		}
+		expect(refreshed?.heartbeatAt).toBeGreaterThan(first.heartbeatAt);
 		await broker.stop();
 		await expect(fs.stat(brokerDiscoveryPath(dir))).rejects.toThrow();
-		const restarted = await ensureBroker({ agentDir: dir, heartbeatTtlMs: 45 });
+		const restarted = await ensureBroker({ agentDir: dir });
 		expect(restarted.token).not.toBe(first.token);
 		const owner = (await import("../src/sdk/broker/ensure")).brokerOwnerForTest(dir);
 		await owner?.stop();


### PR DESCRIPTION
## What

- Poll until the broker discovery heartbeat actually advances instead of sampling it after a fixed 100 ms sleep with a 45 ms freshness window.
- Restart the detached broker using its production discovery TTL rather than applying the in-process broker's synthetic 45 ms TTL to a child that heartbeats on the production cadence.

## Why

Dev run [29231507654](https://github.com/Yeachan-Heo/gajae-code/actions/runs/29231507654), job [86756658411](https://github.com/Yeachan-Heo/gajae-code/actions/runs/29231507654/job/86756658411), failed at `sdk-broker.test.ts:101` because `readBrokerDiscovery(dir, 45)` sampled a still-live broker while its durable heartbeat write was briefly older than 45 ms.

The test is unchanged since SDK broker coverage was introduced in `6e147d58e`. No relevant broker or test code changed between the failing SHA `112ab8071` and succeeding dev SHA `7721aa935`; current dev run [29231730098](https://github.com/Yeachan-Heo/gajae-code/actions/runs/29231730098) passed the same test in shard 5 in 902 ms. This is a pre-existing test timing flake, not a production broker race: production uses a 15 s TTL and 5 s heartbeat interval, while the test sampled a 45 ms TTL and the detached restart reader polled every 50 ms against a child using the production heartbeat cadence.

## Signed evidence

- Pre-fix exact test, 100 repetitions: 98 passed, 2 failed at detached discovery timeout.
- Pre-fix focused first-assertion probe, 500 repetitions: 9 stale reads; maximum observed heartbeat age 335 ms, reproducing the CI failure condition.
- Pre-fix exact test pinned with same-core CPU contention: failed on repetition 21.
- Post-fix exact test, 200 repetitions: 200 passed, 0 failed.
- Post-fix exact test with same-core CPU contention, 50 repetitions: 50 passed, 0 failed.
- Post-rebase exact test, 50 repetitions: 50 passed, 0 failed.
- `bun --cwd=packages/coding-agent check`: passed Biome, SDK canonicalization, and package TypeScript typecheck.
- Signed commit: `41b378b5514fe3ee9b7cea674a68294080ddcd86`; good SSH signature, RSA fingerprint `SHA256:sMm/mlKbgfQ8MIZwP9ALVJIJujUtUjAEteVdQc03iSI`; Signed-off-by `Yeachan-Heo <yeachan-heo@gajae.dev>`.

## Testing

- [ ] `bun check` passes (not run; intentionally avoided the broad workspace check)
- [x] Tested locally
- [x] CHANGELOG not required (test-only stabilization)
