### PR TITLE
test(coding-agent): compare retry fallback models semantically

### DIFF
--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -888,7 +888,7 @@ describe("AgentSession retry fallback", () => {
 			`${primaryModel.provider}/${primaryModel.id}`,
 			`${fallbackModel.provider}/${fallbackModel.id}`,
 		]);
-		expect(session.model).toBe(fallbackModel);
+		expect(session.model).toMatchObject({ provider: fallbackModel.provider, id: fallbackModel.id });
 
 		const latePromotionError = new Error("late default selection failure");
 		vi.spyOn(sessionManager, "promoteDefaultModelSelection").mockReturnValue({
@@ -903,7 +903,7 @@ describe("AgentSession retry fallback", () => {
 		} catch (error) {
 			selectionFailure = error;
 		}
-		expect(session.model).toBe(fallbackModel);
+		expect(session.model).toMatchObject({ provider: fallbackModel.provider, id: fallbackModel.id });
 		expect(selectionFailure).toBeInstanceOf(DefaultModelSelectionRecoveryError);
 		if (!(selectionFailure instanceof DefaultModelSelectionRecoveryError)) {
 			throw new Error("Expected typed default-selection recovery failure");
@@ -923,7 +923,7 @@ describe("AgentSession retry fallback", () => {
 			`${fallbackModel.provider}/${fallbackModel.id}`,
 			`${primaryModel.provider}/${primaryModel.id}`,
 		]);
-		expect(session.model).toBe(primaryModel);
+		expect(session.model).toMatchObject({ provider: primaryModel.provider, id: primaryModel.id });
 	});
 
 	it("preserves thinking on bare fallback selectors and does not overwrite user thinking on restore", async () => {


### PR DESCRIPTION
## Failure evidence

- Post-merge dev run: https://github.com/Yeachan-Heo/gajae-code/actions/runs/29232766994
- Failed job: https://github.com/Yeachan-Heo/gajae-code/actions/runs/29232766994/job/86760551903
- Exact failed dev head: `3d23eb88bbf2a30dcce41749e36c85673114a941`
- Failure: `AgentSession retry fallback > restores the active retry fallback after a late default selection failure so cooldown expiry returns to primary`
- CI failed at `packages/coding-agent/test/agent-session-retry-fallback.test.ts:891`: expected and received models serialized identically but were different object references after model-registry enrichment.

## Fix

Replace the three reference-identity assertions in the cooldown recovery regression with semantic `provider`/`id` assertions. This preserves the test's behavior contract while avoiding dependence on model object allocation or registry enrichment. No production logic or unrelated PR #2093 behavior changes.

## Verification

- Named retry regression: 25 consecutive passes, 0 failures.
- Entire `agent-session-retry-fallback.test.ts`: 15 passed, 0 failed, 100 assertions.
- Relevant late-promotion/default-selection rollback tests: 3 passed, 0 failed.
- SDK default-selection E2E: 1 passed, 0 failed.
- `bun --cwd=packages/coding-agent run check`: passed (Biome, SDK canonicalization, TypeScript).
- `git diff --check`: passed.

## Signed evidence

- Commit: `fc6d8151ef0ab05ca491d61bb212e9dccd92992d`
- Git signature: Good RSA signature for `hurrc04@gmail.com`, key `SHA256:sMm/mlKbgfQ8MIZwP9ALVJIJujUtUjAEteVdQc03iSI`.

Signed-off-by: Yeachan-Heo <yeachan-heo@gajae.dev>