### PR TITLE
fix(ask): use local UI for attended asks instead of hanging on workflow gate

### DIFF
--- a/artifacts/ask-tui-hang-qa-report.json
+++ b/artifacts/ask-tui-hang-qa-report.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": 1,
+  "kind": "package-test-report",
+  "story": "G001 fix ask tool hangs indefinitely on attended TUI",
+  "surface": "package",
+  "rootCause": "BrokerWorkflowGateEmitter is constructed unconditionally per session (agent-session.ts:1684) and isUnattended() always returns true (workflow-gate-broker.ts:134). ask.ts computed canUseWorkflowGate purely from isUnattended(), so attended TUI asks routed to emitGate() and blocked forever waiting on a remote responder.",
+  "fix": "ask.ts gates canUseWorkflowGate on the absence of a local interactive UI (context.hasUI && context.ui). The workflow gate is the headless (non-TUI) answer path only; when a UI is present the local selector is used.",
+  "changedFiles": [
+    "packages/coding-agent/src/tools/ask.ts",
+    "packages/coding-agent/test/tools/ask.test.ts"
+  ],
+  "verification": [
+    {
+      "id": "ask-unit",
+      "invocation": "bun test packages/coding-agent/test/tools/ask.test.ts",
+      "observed": "66 pass / 0 fail / 263 expect() calls",
+      "verdict": "passed"
+    },
+    {
+      "id": "ultragoal-ask-guard",
+      "invocation": "bun test packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts",
+      "observed": "9 pass / 0 fail",
+      "verdict": "passed"
+    },
+    {
+      "id": "typecheck",
+      "invocation": "bunx tsc --noEmit -p packages/coding-agent/tsconfig.json",
+      "observed": "exit=0",
+      "verdict": "passed"
+    }
+  ],
+  "adversarial": [
+    {
+      "id": "attended-no-hang",
+      "scenario": "Attended context (hasUI true + ui.select present) with a durable workflow-gate emitter whose isUnattended() returns true — the exact hang condition.",
+      "expected": "Local selector is invoked; emitGate() is NOT called; ask resolves.",
+      "observed": "New regression test 'prefers the local interactive UI over the workflow gate when a UI context is present' asserts emitGate not called, select called once, result selectedOptions=[\"yes\"]. Passed.",
+      "verdict": "passed"
+    },
+    {
+      "id": "headless-still-gates",
+      "scenario": "Headless context (no ui, hasUI false) with an unattended gate emitter.",
+      "expected": "Routes to emitGate() as before.",
+      "observed": "Existing tests 'emits deep-interview question gates by default' and 'passes optional metadata for ... SDK workflow gate asks' still pass with hasUI:false expecting emitGate. Passed.",
+      "verdict": "passed"
+    }
+  ]
+}

--- a/artifacts/ask-tui-hang-quality-gate.json
+++ b/artifacts/ask-tui-hang-quality-gate.json
@@ -1,0 +1,41 @@
+{
+  "architectReview": {
+    "architectureStatus": "CLEAR",
+    "productStatus": "CLEAR",
+    "codeStatus": "CLEAR",
+    "recommendation": "APPROVE",
+    "evidence": "Architecture: the fix restores the intended layering — the workflow gate is the headless (non-TUI) answer path, the local extension UI is the attended path. Root cause traced to the SDK-canonical-bus change constructing BrokerWorkflowGateEmitter unconditionally (agent-session.ts:1684) while isUnattended() is hardcoded true (workflow-gate-broker.ts:134); gating on presence of an interactive UI is the correct, minimal decision point and matches the pre-existing 'Headless fallback' comment. Product: attended TUI asks no longer hang; headless/SDK asks still route to the gate. Code: single guard change plus explanatory comment, no dead code, no new abstraction; regression test added covering the exact hang condition and the preserved headless path.",
+    "commands": ["read packages/coding-agent/src/tools/ask.ts:760-772", "read packages/coding-agent/src/modes/shared/agent-wire/workflow-gate-broker.ts:134-145", "read packages/coding-agent/src/session/agent-session.ts:1684"],
+    "blockers": []
+  },
+  "executorQa": {
+    "status": "passed",
+    "e2eStatus": "passed",
+    "redTeamStatus": "passed",
+    "evidence": "Unit + typecheck lanes pass (ask.test.ts 66/0, ultragoal-ask-guard 9/0, tsc exit 0). Red-team: the added regression test reproduces the hang condition (attended context + always-unattended durable gate emitter) and asserts emitGate is NOT called and the local selector resolves; the preserved headless tests assert emitGate IS still called with hasUI:false.",
+    "e2eCommands": ["bun test packages/coding-agent/test/tools/ask.test.ts", "bun test packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts"],
+    "redTeamCommands": ["bun test packages/coding-agent/test/tools/ask.test.ts"],
+    "artifactRefs": [
+      { "id": "qa-report", "kind": "package-test-report", "path": "artifacts/ask-tui-hang-qa-report.json", "description": "package-surface QA + adversarial matrix for the ask TUI hang fix" }
+    ],
+    "contractCoverage": [
+      { "id": "c1", "contractRef": "ask-attended-uses-local-ui", "obligation": "When an interactive UI is present the ask tool must use the local selector, never the headless workflow gate.", "status": "covered", "surfaceEvidenceRefs": ["s1"], "adversarialCaseRefs": ["a1"] },
+      { "id": "c2", "contractRef": "ask-headless-uses-gate", "obligation": "With no interactive UI, unattended asks must still route to the workflow gate.", "status": "covered", "surfaceEvidenceRefs": ["s1"], "adversarialCaseRefs": ["a2"] }
+    ],
+    "surfaceEvidence": [
+      { "id": "s1", "contractRef": "ask tool routing (package)", "surface": "package", "invocation": "bun test packages/coding-agent/test/tools/ask.test.ts", "verdict": "passed", "artifactRefs": ["qa-report"] }
+    ],
+    "adversarialCases": [
+      { "id": "a1", "contractRef": "ask-attended-uses-local-ui", "scenario": "Attended context (hasUI true + ui.select) with a durable gate emitter whose isUnattended() is always true.", "expectedBehavior": "Local selector invoked; emitGate not called; ask resolves without hanging.", "verdict": "passed", "artifactRefs": ["qa-report"] },
+      { "id": "a2", "contractRef": "ask-headless-uses-gate", "scenario": "Headless context (no ui, hasUI false) with unattended gate emitter.", "expectedBehavior": "Routes to emitGate() as before.", "verdict": "passed", "artifactRefs": ["qa-report"] }
+    ],
+    "blockers": []
+  },
+  "iteration": {
+    "status": "passed",
+    "evidence": "No blockers surfaced; full targeted verification reran cleanly after the change.",
+    "fullRerun": true,
+    "rerunCommands": ["bun test packages/coding-agent/test/tools/ask.test.ts", "bun test packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts", "bunx tsc --noEmit -p packages/coding-agent/tsconfig.json"],
+    "blockers": []
+  }
+}

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -758,7 +758,13 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 			if (receipt) await receipt.settle(settlement);
 		};
 		const gateEmitter = this.session.getWorkflowGateEmitter?.();
-		const canUseWorkflowGate = gateEmitter?.isUnattended() === true;
+		// A durable workflow-gate emitter now exists for every session, and its
+		// isUnattended() is always true, so it can no longer signal "no local UI".
+		// The workflow gate is only the headless (non-TUI) answer path: when a real
+		// interactive UI is present, prefer it — otherwise attended TUI asks would
+		// route to emitGate() and hang forever waiting on a remote responder.
+		const hasInteractiveUi = context?.hasUI === true && !!context.ui;
+		const canUseWorkflowGate = !hasInteractiveUi && gateEmitter?.isUnattended() === true;
 		// Headless fallback: SDK workflow gates are the non-TUI answer path.
 		if (!canUseWorkflowGate && (!context?.hasUI || !context.ui)) {
 			context?.abort();

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -2450,6 +2450,30 @@ describe("AskTool deep-interview recorder persistence", () => {
 		);
 	});
 
+	it("prefers the local interactive UI over the workflow gate when a UI context is present", async () => {
+		// Regression: a durable workflow-gate emitter now exists for every session and
+		// its isUnattended() is always true. Attended TUI asks must still use the local
+		// selector instead of stranding on emitGate() waiting for a remote responder.
+		const gateEmitter = {
+			isUnattended: () => true,
+			emitGate: vi.fn(async () => ({ selected: ["no"] })),
+		};
+		const select = vi.fn(async () => "yes");
+		const context = createContext({ select });
+		const result = await new AskTool(
+			createSession({ getWorkflowGateEmitter: () => gateEmitter } as Partial<ToolSession>),
+		).execute(
+			"call-attended-no-gate",
+			{ questions: [{ id: "confirm", question: "Proceed?", options: [{ label: "yes" }, { label: "no" }] }] },
+			undefined,
+			undefined,
+			context,
+		);
+		expect(gateEmitter.emitGate).not.toHaveBeenCalled();
+		expect(select).toHaveBeenCalledTimes(1);
+		expect(result.details?.selectedOptions).toEqual(["yes"]);
+	});
+
 	it("keeps deepInterview optional and rejects malformed metadata", () => {
 		expect(
 			askSchema.safeParse({ questions: [{ id: "q", question: "Pick?", options: [{ label: "A" }] }] }).success,


### PR DESCRIPTION
## Problem
The `ask` tool hangs indefinitely on the TUI.

## Root cause
The SDK-canonical-bus change made `AgentSession` construct a `BrokerWorkflowGateEmitter` unconditionally for **every** session (`agent-session.ts:1684`), and that emitter's `isUnattended()` is hardcoded to `true` (`workflow-gate-broker.ts:134`).

`AskTool.execute` computed:
```ts
const canUseWorkflowGate = gateEmitter?.isUnattended() === true;
```
so it became **always true**. Every interactive ask — even in an attended TUI — routed to `gateEmitter.emitGate()`, which resolves only when a remote SDK responder answers. In a plain TUI no responder exists, so it blocked forever.

## Fix
The workflow gate is the headless (non-TUI) answer path only. Gate `canUseWorkflowGate` on the absence of a local interactive UI:
```ts
const hasInteractiveUi = context?.hasUI === true && !!context.ui;
const canUseWorkflowGate = !hasInteractiveUi && gateEmitter?.isUnattended() === true;
```
Attended asks now use the local selector; headless/SDK asks still route to the gate.

## Verification
- New regression test reproduces the exact hang condition (attended context + always-unattended durable emitter) and asserts `emitGate` is not called and the local selector resolves.
- `ask.test.ts` 66/0, `ultragoal-ask-guard.test.ts` 9/0, `tsc --noEmit` exit 0.
- Existing headless gate tests unchanged and passing.