### PR TITLE
fix(coding-agent): harden Windows psmux coordinator

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -49,6 +49,7 @@
 
 ### Fixed
 
+- Fixed native-Windows coordinator/runtime compatibility by treating psmux's successful empty `list-sessions` response as an absent server while keeping malformed rows fail-closed, reading process incarnations through a validated PowerShell start-time query, sharing the existing BOM-free encoded PowerShell pane command, preserving multiline SDK prompts behind semantic readiness, and retaining runtime command/turn acknowledgement identity across Windows-equivalent workspace paths (#2145).
 - The coordinator MCP owner-server probe now recognizes tmux ≥3.7's missing-server diagnostic (`error connecting to <socket> (No such file or directory)`) as an absent server. tmux 3.7 changed the wording from the older `no server running on <socket>`, which the coordinator probe did not match — so a brand-new coordinator socket (which never has a server yet) was misclassified `unverifiable` instead of `absent`, and **every** `gjc_delegate_*` / session create failed closed with `coordinator_tmux_owner_server_unverifiable` on tmux ≥3.7. The coordinator and `gjc` harness probes now match the same no-server wordings the other owner-isolation probes already did.
 - Preserved explicit Telegram forum-topic renames as durable user-owned names, immediately re-asserting delayed edits while retaining restart and rename-race recovery (#1910).
 - Prevented typed provider safety stops from entering automatic retry loops and aligned ACP refusal reporting with the provider-native classification.

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -3,7 +3,7 @@ import * as nodeFs from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDir, isKnownSinkPeerClosedError } from "@gajae-code/utils";
-import { VERSION } from "@gajae-code/utils/dirs";
+import { normalizePathForComparison, VERSION } from "@gajae-code/utils/dirs";
 
 import {
 	COORDINATOR_MCP_PROTOCOL_VERSION,
@@ -80,11 +80,13 @@ interface CoordinatorServices {
 	connectSdk?: (url: string, token: string) => Promise<SdkClient>;
 	getAgentDir?: () => string;
 	resolveModelProfiles?: CoordinatorModelProfileLoader;
+	canonicalizePath?: (value: string) => Promise<string>;
 }
 
 interface CoordinatorMcpServerOptions {
 	env?: NodeJS.ProcessEnv;
 	services?: CoordinatorServices;
+	platform?: NodeJS.Platform;
 }
 
 interface LegacyHandlerOptions {
@@ -115,6 +117,8 @@ interface TurnRecord {
 		target: string | null;
 		tmux_keys_sent?: boolean;
 		prompt_acknowledged?: boolean;
+		runtime_command_id?: string;
+		runtime_turn_id?: string;
 		state?: "queued" | "tmux_keys_sent" | "acknowledged" | "unavailable" | "unacknowledged";
 		attempts: Array<{
 			delivered: boolean;
@@ -760,12 +764,60 @@ function boundedPublicResponse(response: Record<string, unknown>): Record<string
 	return asRecord(value) ?? { ok: false, error: { code: "unavailable", message: "Invalid coordinator response." } };
 }
 
-function publicSdkAcknowledgement(result: unknown): Record<string, unknown> {
+interface RuntimePromptAcknowledgement {
+	accepted: true;
+	command_id: string;
+	turn_id: string;
+}
+
+function acknowledgementPayload(result: unknown): Record<string, unknown> | null {
 	const response = asRecord(result);
+	if (!response) return null;
+	const envelope = ["ok", "result", "error"].some(key => Object.hasOwn(response, key));
+	if (!envelope) return response;
+	if (response.ok !== true || !Object.hasOwn(response, "result") || Object.hasOwn(response, "error")) return null;
+	return asRecord(response.result);
+}
+
+function runtimeAcknowledgementIdentity(
+	acknowledgement: Record<string, unknown>,
+	camelCaseKey: "commandId" | "turnId",
+	snakeCaseKey: "command_id" | "turn_id",
+): string {
+	const values = [camelCaseKey, snakeCaseKey]
+		.filter(key => Object.hasOwn(acknowledgement, key))
+		.map(key => acknowledgement[key]);
+	if (values.length === 0)
+		throw new SdkClientError("unavailable", `SDK prompt acknowledgement omitted ${snakeCaseKey}.`);
+	if (
+		values.some(value => typeof value !== "string" || !SAFE_EXTERNAL_ID_PATTERN.test(value)) ||
+		new Set(values).size !== 1
+	)
+		throw new SdkClientError("unavailable", `SDK prompt acknowledgement has invalid ${snakeCaseKey}.`);
+	return values[0] as string;
+}
+
+function normalizeRuntimePromptAcknowledgement(result: unknown): RuntimePromptAcknowledgement {
+	const acknowledgement = acknowledgementPayload(result);
+	if (acknowledgement?.accepted !== true)
+		throw new SdkClientError("unavailable", "SDK did not acknowledge prompt delivery.");
 	return {
-		...(response?.accepted === true ? { accepted: true } : {}),
-		...(typeof response?.turn_id === "string" ? { turn_id: response.turn_id } : {}),
+		accepted: true,
+		command_id: runtimeAcknowledgementIdentity(acknowledgement, "commandId", "command_id"),
+		turn_id: runtimeAcknowledgementIdentity(acknowledgement, "turnId", "turn_id"),
 	};
+}
+
+function publicSdkAcknowledgement(result: RuntimePromptAcknowledgement): Record<string, unknown> {
+	return {
+		accepted: true,
+		command_id: result.command_id,
+		turn_id: result.turn_id,
+	};
+}
+
+function publicSdkAccepted(result: unknown): Record<string, unknown> {
+	return acknowledgementPayload(result)?.accepted === true ? { accepted: true } : {};
 }
 
 async function listJsonFiles(dir: string): Promise<unknown[]> {
@@ -802,11 +854,20 @@ function brokerSessionScope(record: Record<string, unknown>): string | null {
 	return firstString(asRecord(record.locator) ?? {}, ["repo"]);
 }
 
-function scopedBrokerSessions(values: unknown[], cwd: string): Array<Record<string, unknown>> {
-	const scope = path.resolve(cwd);
+function sameCanonicalPath(left: string, right: string, platform: NodeJS.Platform): boolean {
+	return normalizePathForComparison(left, platform) === normalizePathForComparison(right, platform);
+}
+
+function scopedBrokerSessions(
+	values: unknown[],
+	cwd: string,
+	platform: NodeJS.Platform,
+): Array<Record<string, unknown>> {
+	const pathApi = platform === "win32" ? path.win32 : path;
+	const scope = pathApi.resolve(cwd);
 	return jsonRecords(values).filter(session => {
 		const sessionScope = brokerSessionScope(session);
-		return sessionScope !== null && path.resolve(sessionScope) === scope;
+		return sessionScope !== null && sameCanonicalPath(pathApi.resolve(sessionScope), scope, platform);
 	});
 }
 
@@ -1781,6 +1842,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 	const config = buildCoordinatorMcpConfig(env);
 	const promptAckTimeoutMs = boundedRuntimePromptAckTimeoutMs(env.GJC_COORDINATOR_MCP_PROMPT_ACK_TIMEOUT_MS);
 	const services = options.services ?? {};
+	const platform = options.platform ?? process.platform;
 	const loadModelProfiles = services.resolveModelProfiles ?? loadCoordinatorModelProfiles;
 	const namespaceDir = coordinatorNamespacePath(config);
 	const sessionTransitionTails = new Map<string, Promise<void>>();
@@ -1810,8 +1872,13 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			endpoint.url,
 			endpoint.token,
 		);
+		const isPromptOperation =
+			operation === "turn.prompt" || operation === "turn.follow_up" || operation === "turn.abort_and_prompt";
 		try {
-			return await client.control(operation, input, { idempotencyKey });
+			return await client.control(operation, input, {
+				idempotencyKey,
+				...(isPromptOperation ? { timeoutMs: promptAckTimeoutMs } : {}),
+			});
 		} finally {
 			await client.close();
 		}
@@ -1865,10 +1932,8 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		};
 	}
 
-	function requirePromptAcknowledgement(result: unknown): void {
-		if (asRecord(result)?.accepted !== true) {
-			throw new SdkClientError("unavailable", "SDK did not acknowledge prompt delivery.");
-		}
+	function requirePromptAcknowledgement(result: unknown): RuntimePromptAcknowledgement {
+		return normalizeRuntimePromptAcknowledgement(result);
 	}
 
 	function sdkError(error: unknown): Record<string, unknown> {
@@ -2004,7 +2069,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 
 	async function canonicalBrokerWorkspace(cwd: string): Promise<string> {
 		try {
-			return await fs.realpath(cwd);
+			return await (services.canonicalizePath ?? (value => fs.realpath(value)))(cwd);
 		} catch {
 			throw new SdkClientError("not_found", "Coordinator workspace cannot be resolved.");
 		}
@@ -2060,7 +2125,8 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			} catch {
 				continue;
 			}
-			if (canonicalWorkspace === workspace) matches.push({ session, workspace: canonicalWorkspace });
+			if (sameCanonicalPath(canonicalWorkspace, workspace, platform))
+				matches.push({ session, workspace: canonicalWorkspace });
 		}
 		if (matches.length !== 1)
 			throw new SdkClientError(
@@ -2117,7 +2183,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		if (!sessionId || !cwd || !persistedWorkspace || persistedGeneration === null || !persistedIncarnation)
 			throw new SdkClientError("not_found", "Coordinator session has no incarnation-bound broker identity.");
 		const workspace = await canonicalBrokerWorkspace(cwd);
-		if (workspace !== persistedWorkspace)
+		if (!sameCanonicalPath(workspace, persistedWorkspace, platform))
 			throw new SdkClientError("endpoint_stale", "Coordinator session workspace binding is stale.");
 		const binding = await exactBrokerSessionBinding(sessionId, workspace, idempotencyKey);
 		if (binding.endpointGeneration !== persistedGeneration || binding.endpointIncarnation !== persistedIncarnation)
@@ -2130,7 +2196,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		const listings = await Promise.all(
 			roots.map(async root => {
 				const listing = brokerResult(await brokerSession(root, "session.list", { cwd: root }));
-				return scopedBrokerSessions(Array.isArray(listing.sessions) ? listing.sessions : [], root);
+				return scopedBrokerSessions(Array.isArray(listing.sessions) ? listing.sessions : [], root, platform);
 			}),
 		);
 		return listings.flat();
@@ -2166,7 +2232,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 				workspace = await canonicalBrokerWorkspace(cwd);
 				const authority = await exactBrokerSessionAuthority(id, workspace);
 				if (
-					authority.workspace !== persistedWorkspace ||
+					!sameCanonicalPath(authority.workspace, persistedWorkspace, platform) ||
 					authority.endpointGeneration !== persistedGeneration ||
 					authority.endpointIncarnation !== persistedIncarnation
 				)
@@ -2397,6 +2463,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		prompt: string,
 		operation: "turn.prompt" | "turn.follow_up" | "turn.abort_and_prompt",
 		previousActiveTurn: TurnRecord | null,
+		acknowledgement: RuntimePromptAcknowledgement,
 	): Promise<TurnRecord> {
 		const timestamp = new Date().toISOString();
 		if (operation === "turn.abort_and_prompt" && previousActiveTurn) {
@@ -2416,6 +2483,8 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			queued,
 			target: null,
 			prompt_acknowledged: true,
+			runtime_command_id: acknowledgement.command_id,
+			runtime_turn_id: acknowledgement.turn_id,
 			state: "acknowledged",
 			attempts: [{ delivered: true, channel: "runtime_ack", created_at: timestamp, reason: null }],
 		};
@@ -2735,7 +2804,10 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 									};
 								}
 								const existingCwd = optionalString(existing.cwd);
-								if (!existingCwd || (await canonicalBrokerWorkspace(existingCwd)) !== canonicalCwd)
+								if (
+									!existingCwd ||
+									!sameCanonicalPath(await canonicalBrokerWorkspace(existingCwd), canonicalCwd, platform)
+								)
 									return {
 										ok: false,
 										error: {
@@ -2745,7 +2817,11 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 									};
 								const binding = await exactBrokerSessionBinding(sessionId, canonicalCwd, idempotencyKey);
 								if (
-									optionalString(existing.broker_workspace) !== canonicalCwd ||
+									!sameCanonicalPath(
+										optionalString(existing.broker_workspace) ?? "",
+										canonicalCwd,
+										platform,
+									) ||
 									existing.endpoint_generation !== binding.endpointGeneration ||
 									optionalString(existing.endpoint_incarnation) !== binding.endpointIncarnation
 								)
@@ -2811,8 +2887,14 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 										? "turn.follow_up"
 										: "turn.prompt";
 							const result = await controlSession(session, operation, { text: taggedPrompt }, idempotencyKey);
-							requirePromptAcknowledgement(result);
-							const turn = await recordAcceptedPrompt(sessionId, taggedPrompt, operation, previousActiveTurn);
+							const acknowledgement = requirePromptAcknowledgement(result);
+							const turn = await recordAcceptedPrompt(
+								sessionId,
+								taggedPrompt,
+								operation,
+								previousActiveTurn,
+								acknowledgement,
+							);
 							await appendCoordinatorEvent(namespaceDir, {
 								kind: "delegation.started",
 								sessionId,
@@ -2839,7 +2921,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 								session: publicCoordinatorSession(session),
 								session_state: publicCoordinatorSessionState(await readSessionState(namespaceDir, sessionId)),
 								turn: boundedPublicValue(turn, { remaining: COORDINATOR_IDEMPOTENCY_RESPONSE_BYTE_CAP }),
-								result: publicSdkAcknowledgement(result),
+								result: publicSdkAcknowledgement(acknowledgement),
 								...(hasTask && hasPrompt ? { prompt_alias_ignored: true } : {}),
 							};
 							return args.await_completion === true
@@ -2931,8 +3013,8 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 						const lifecycle = publicLifecycleReceipt(created, sessionId);
 						if (prompt) {
 							const result = await controlSession(session, "turn.prompt", { text: prompt }, idempotencyKey);
-							requirePromptAcknowledgement(result);
-							const turn = await recordAcceptedPrompt(sessionId, prompt, "turn.prompt", null);
+							const acknowledgement = requirePromptAcknowledgement(result);
+							const turn = await recordAcceptedPrompt(sessionId, prompt, "turn.prompt", null, acknowledgement);
 							return {
 								ok: true,
 								session: publicCoordinatorSession(session),
@@ -2945,6 +3027,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 								delivered: turn.delivery.delivered,
 								operation: "turn.prompt",
 								turn: boundedPublicValue(turn, { remaining: COORDINATOR_IDEMPOTENCY_RESPONSE_BYTE_CAP }),
+								result: publicSdkAcknowledgement(acknowledgement),
 								session_state: publicCoordinatorSessionState(await readSessionState(namespaceDir, sessionId)),
 							};
 						}
@@ -3011,8 +3094,14 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 										? "turn.follow_up"
 										: "turn.prompt";
 							const result = await controlSession(currentSession, operation, { text: prompt }, idempotencyKey);
-							requirePromptAcknowledgement(result);
-							const turn = await recordAcceptedPrompt(sessionId, prompt, operation, previousActiveTurn);
+							const acknowledgement = requirePromptAcknowledgement(result);
+							const turn = await recordAcceptedPrompt(
+								sessionId,
+								prompt,
+								operation,
+								previousActiveTurn,
+								acknowledgement,
+							);
 							return {
 								ok: true,
 								session_id: sessionId,
@@ -3022,7 +3111,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 								queued: turn.delivery.queued,
 								delivered: turn.delivery.delivered,
 								operation,
-								result: publicSdkAcknowledgement(result),
+								result: publicSdkAcknowledgement(acknowledgement),
 								turn: boundedPublicValue(turn, { remaining: COORDINATOR_IDEMPOTENCY_RESPONSE_BYTE_CAP }),
 								session_state: publicCoordinatorSessionState(await readSessionState(namespaceDir, sessionId)),
 							};
@@ -3067,7 +3156,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 							ok: true,
 							session_id: sessionId,
 							operation: "ask.answer",
-							result: publicSdkAcknowledgement(result),
+							result: publicSdkAccepted(result),
 						};
 					},
 				);

--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -46,18 +46,25 @@ import {
 	type GjcTmuxSessionStatus,
 	proveGjcTmuxSessionMutationTarget,
 } from "./tmux-sessions";
+import {
+	buildWindowsPowerShellInnerCommand,
+	GJC_TMUX_LAUNCHED_ENV,
+	type WindowsPowerShellInnerCommandOptions,
+} from "./windows-powershell-command";
 
+export type { WindowsPowerShellInnerCommandOptions };
 export {
 	buildGjcTmuxExactSessionTarget,
 	buildGjcTmuxProfileCommands,
+	buildWindowsPowerShellInnerCommand,
 	GJC_DEFAULT_TMUX_SESSION,
 	GJC_TMUX_COMMAND_ENV,
+	GJC_TMUX_LAUNCHED_ENV,
 	GJC_TMUX_MOUSE_ENV,
 	GJC_TMUX_PROFILE_ENV,
 	GJC_TMUX_SESSION_PREFIX,
 };
 
-export const GJC_TMUX_LAUNCHED_ENV = "GJC_TMUX_LAUNCHED";
 export const GJC_LAUNCH_POLICY_ENV = "GJC_LAUNCH_POLICY";
 export const GJC_TMUX_WINDOW_LABEL_MAX_WIDTH = 48;
 
@@ -214,20 +221,6 @@ function buildPosixTmuxExitMarkerPrefix(markerPath: string): string {
 	].join("; ");
 }
 
-function buildPowerShellTmuxExitMarkerFinally(markerPath: string): string {
-	const markerDir = path.win32.dirname(markerPath);
-	return [
-		"} finally {",
-		"\ttry {",
-		`\t\tNew-Item -ItemType Directory -Force -Path ${powershellQuote(markerDir)} -ErrorAction Stop | Out-Null`,
-		"\t\t$__gjcTmuxExitMarker = @{ schema_version = 1; source = 'tmux_inner_shell'; ended_at = (Get-Date).ToUniversalTime().ToString('o'); exit_code = $__gjcTmuxExitCode } | ConvertTo-Json -Compress",
-		`\t\tSet-Content -LiteralPath ${powershellQuote(markerPath)} -Value $__gjcTmuxExitMarker -Encoding UTF8 -ErrorAction Stop`,
-		"\t} catch {",
-		"\t}",
-		"}",
-	].join("\n");
-}
-
 interface CommandResolutionContext {
 	cwd: string;
 	argv: string[];
@@ -347,53 +340,8 @@ function buildEnvAssignments(values: Record<string, string> | undefined): string
 	const entries = Object.entries(values ?? {});
 	return entries.length === 0 ? "" : ` ${entries.map(([key, value]) => `${key}=${shellQuote(value)}`).join(" ")}`;
 }
-function powershellQuote(value: string): string {
-	return `'${value.replace(/'/g, "''")}'`;
-}
 function stripRootTmuxFlag(rawArgs: string[]): string[] {
 	return rawArgs.filter(arg => arg !== "--tmux");
-}
-
-function buildWindowsPowerShellInnerCommand(context: CommandResolutionContext, rawArgs: string[]): string {
-	const command = resolveCurrentGjcCommand(context);
-	const envLines = Object.entries({ [GJC_TMUX_LAUNCHED_ENV]: "1", ...(context.extraEnv ?? {}) }).map(
-		([key, value]) => `$env:${key} = ${powershellQuote(value)}`,
-	);
-	// Resolve the inner command and arguments. PowerShell's `&` call operator
-	// accepts a single command followed by its arguments directly (no script
-	// block needed). Wrapping the call in `& { ... }` would be invalid because
-	// adjacent single-quoted tokens inside a script block body are a parser
-	// error: `& { 'a' 'b' }` fails with "Unexpected token 'b'" because PowerShell
-	// only concatenates adjacent *double-quoted* strings, and even then only in
-	// expression position. Emitting the arguments as a comma-separated array
-	// (`& 'cmd' @('a','b')`) is also rejected because arrays are not valid as
-	// the second-and-later positional arguments to `&` in command position. The
-	// correct form is `& 'cmd' 'arg1' 'arg2'` — exactly what the joined
-	// resolvedCommand + innerArgs produces below.
-	const resolvedCommand = command.map(powershellQuote).join(" ");
-	const innerArgs = stripRootTmuxFlag(rawArgs).map(powershellQuote).join(" ");
-	const invocation = `& ${resolvedCommand} ${innerArgs}`;
-	const exitLine = "if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 }";
-	const script = context.tmuxExitMarkerPath
-		? [
-				...envLines,
-				"$__gjcTmuxExitCode = 1",
-				"try {",
-				`\t${invocation}`,
-				"\tif ($null -ne $LASTEXITCODE) { $__gjcTmuxExitCode = $LASTEXITCODE } else { $__gjcTmuxExitCode = 1 }",
-				buildPowerShellTmuxExitMarkerFinally(context.tmuxExitMarkerPath),
-				"exit $__gjcTmuxExitCode",
-			].join("\n")
-		: [...envLines, invocation, exitLine].join("\n");
-	// Encode the script as UTF-16LE base64 for pwsh -EncodedCommand. Do NOT
-	// prepend a UTF-16LE BOM (0xFF 0xFE): the BOM survives the decode and is
-	// inserted as a literal U+FEFF character in front of the first script
-	// token, which pwsh then reports as a "term not recognized" parse error
-	// (e.g. "﻿$env:GJC_TMUX_LAUNCHED"). pwsh expects the decoded buffer to
-	// start with the first character of the script, not with a BOM.
-	const body = Buffer.from(script, "utf16le");
-	const encodedCommand = body.toString("base64");
-	return `pwsh -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodedCommand}`;
 }
 
 export function applyGjcTmuxProfile(context: GjcTmuxProfileContext): GjcTmuxProfileResult {
@@ -463,7 +411,13 @@ function pathModuleForPlatform(platform: NodeJS.Platform | undefined): typeof pa
 }
 
 function buildInnerCommand(context: CommandResolutionContext, rawArgs: string[]): string {
-	if (isWindowsPlatform(context.platform)) return buildWindowsPowerShellInnerCommand(context, rawArgs);
+	if (isWindowsPlatform(context.platform))
+		return buildWindowsPowerShellInnerCommand({
+			command: resolveCurrentGjcCommand(context),
+			args: stripRootTmuxFlag(rawArgs),
+			environment: context.extraEnv,
+			tmuxExitMarkerPath: context.tmuxExitMarkerPath,
+		});
 	const command = resolveCurrentGjcCommand(context);
 	const quoted = [...command, ...stripRootTmuxFlag(rawArgs)].map(shellQuote).join(" ");
 	const invocation = `env ${GJC_TMUX_LAUNCHED_ENV}=1${buildEnvAssignments(context.extraEnv)} ${quoted}`;

--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -3,7 +3,7 @@ import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AssistantMessage } from "@gajae-code/ai";
-import { postmortem } from "@gajae-code/utils";
+import { normalizePathForComparison, postmortem } from "@gajae-code/utils";
 import { sessionRuntimeDir } from "./session-layout";
 import {
 	isValidOwnerIntent,
@@ -76,11 +76,21 @@ export interface RuntimeStateContext {
 	sessionId: string;
 	cwd: string;
 	sessionFile?: string | null;
+	/** Optional platform seam for deterministic cross-platform path identity checks. */
+	platform?: NodeJS.Platform;
 	branch?: string | null;
 	/** Public-safe owner metadata used to persist the canonical terminal verdict. */
 	ownerTerminal?: OwnerTerminalContext | null;
 	/** Internal fail-closed marker set only when managed owner metadata is malformed or missing. */
 	ownerTerminalMetadataInvalid?: boolean;
+}
+
+interface RuntimeStateIdentity {
+	sessionId: string;
+	cwd: string;
+	workdir: string;
+	sessionFile: string | null;
+	platform: NodeJS.Platform;
 }
 
 interface RuntimeStateSidecarPayload {
@@ -201,27 +211,27 @@ export async function persistCoordinatorRuntimeInputReady(): Promise<RuntimeInpu
 	}
 }
 
-function sameResolvedPath(left: string, right: string): boolean {
-	return path.resolve(left) === path.resolve(right);
+function sameResolvedPath(left: string, right: string, platform: NodeJS.Platform = process.platform): boolean {
+	return normalizePathForComparison(left, platform) === normalizePathForComparison(right, platform);
 }
 
-function normalizedIdentity(context: Pick<RuntimeStateContext, "sessionId" | "cwd" | "sessionFile">): {
-	sessionId: string;
-	cwd: string;
-	workdir: string;
-	sessionFile: string | null;
-} {
+function normalizedIdentity(
+	context: Pick<RuntimeStateContext, "sessionId" | "cwd" | "sessionFile" | "platform">,
+): RuntimeStateIdentity {
 	const explicitStateFile = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim();
 	const sessionId = explicitStateFile
 		? process.env[GJC_COORDINATOR_SESSION_ID_ENV]?.trim() || context.sessionId.trim()
 		: context.sessionId.trim();
 	const cwd = context.cwd.trim();
+	const platform = context.platform ?? process.platform;
+	const pathApi = platform === "win32" ? path.win32 : path;
 	if (!sessionId || !cwd) throw new PreviousRuntimeStateReadError();
 	return {
 		sessionId,
-		cwd: path.resolve(cwd),
-		workdir: path.resolve(cwd),
-		sessionFile: context.sessionFile == null ? null : path.resolve(context.sessionFile),
+		cwd: pathApi.resolve(cwd),
+		workdir: pathApi.resolve(cwd),
+		sessionFile: context.sessionFile == null ? null : pathApi.resolve(context.sessionFile),
+		platform,
 	};
 }
 
@@ -268,7 +278,10 @@ export async function readTerminalRuntimeStateMarker(input: {
 	sessionId?: string | null;
 	cwd?: string | null;
 	sessionFile?: string | null;
+	platform?: NodeJS.Platform;
 }): Promise<TerminalRuntimeStateStatus> {
+	const platform = input.platform ?? process.platform;
+	const pathApi = platform === "win32" ? path.win32 : path;
 	const stateFile = input.stateFile?.trim();
 	const sessionId = input.sessionId?.trim();
 	const cwd = input.cwd?.trim();
@@ -287,15 +300,18 @@ export async function readTerminalRuntimeStateMarker(input: {
 	if (!validRuntimeStateMarker(value)) return { terminal: false, reason: "invalid_state_marker" };
 	const payload = value;
 	if (payload.session_id !== sessionId) return { terminal: false, reason: "session_id_mismatch" };
-	if (!sameResolvedPath(payload.cwd as string, cwd) || !sameResolvedPath(payload.workdir as string, cwd))
+	if (
+		!sameResolvedPath(payload.cwd as string, cwd, platform) ||
+		!sameResolvedPath(payload.workdir as string, cwd, platform)
+	)
 		return { terminal: false, reason: "cwd_mismatch" };
-	const sessionFile = input.sessionFile == null ? null : path.resolve(input.sessionFile);
+	const sessionFile = input.sessionFile == null ? null : pathApi.resolve(input.sessionFile);
 	if (
 		payload.session_file !== sessionFile &&
 		!(
 			typeof payload.session_file === "string" &&
 			typeof sessionFile === "string" &&
-			sameResolvedPath(payload.session_file, sessionFile)
+			sameResolvedPath(payload.session_file, sessionFile, platform)
 		)
 	)
 		return { terminal: false, reason: "session_file_mismatch" };
@@ -484,41 +500,35 @@ function rememberWrittenPayload(stateFile: string, payload: Record<string, unkno
 		lastPayloadByStateFile.delete(stateFile);
 	}
 }
-function shouldPreserveTerminalPayload(
-	previous: RuntimeStateSidecarPayload,
-	input: { sessionId: string; cwd: string; sessionFile: string | null },
-): boolean {
+function shouldPreserveTerminalPayload(previous: RuntimeStateSidecarPayload, input: RuntimeStateIdentity): boolean {
 	if (!validRuntimeStateMarker(previous)) return false;
 	if (previous.state !== "completed" && previous.state !== "errored") return false;
 	const source = previous.final_response?.source;
 	if (source !== "agent_end" && source !== "launch_error") return false;
 	return (
 		previous.session_id === input.sessionId &&
-		sameResolvedPath(previous.cwd as string, input.cwd) &&
-		sameResolvedPath(previous.workdir as string, input.cwd) &&
+		sameResolvedPath(previous.cwd as string, input.cwd, input.platform) &&
+		sameResolvedPath(previous.workdir as string, input.cwd, input.platform) &&
 		(previous.session_file === input.sessionFile ||
 			(typeof previous.session_file === "string" &&
 				typeof input.sessionFile === "string" &&
-				sameResolvedPath(previous.session_file, input.sessionFile)))
+				sameResolvedPath(previous.session_file, input.sessionFile, input.platform)))
 	);
 }
 
-function assertPreviousRuntimeStateIdentity(
-	previous: Record<string, unknown>,
-	input: { sessionId: string; cwd: string; sessionFile: string | null },
-): void {
+function assertPreviousRuntimeStateIdentity(previous: Record<string, unknown>, input: RuntimeStateIdentity): void {
 	if (Object.keys(previous).length === 0) return;
 	if (
 		previous.session_id !== input.sessionId ||
 		typeof previous.cwd !== "string" ||
 		typeof previous.workdir !== "string" ||
-		!sameResolvedPath(previous.cwd, input.cwd) ||
-		!sameResolvedPath(previous.workdir, input.cwd) ||
+		!sameResolvedPath(previous.cwd, input.cwd, input.platform) ||
+		!sameResolvedPath(previous.workdir, input.cwd, input.platform) ||
 		(previous.session_file !== input.sessionFile &&
 			!(
 				typeof previous.session_file === "string" &&
 				typeof input.sessionFile === "string" &&
-				sameResolvedPath(previous.session_file, input.sessionFile)
+				sameResolvedPath(previous.session_file, input.sessionFile, input.platform)
 			))
 	)
 		throw new PreviousRuntimeStateReadError();

--- a/packages/coding-agent/src/gjc-runtime/tmux-owner-isolation-cli.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-owner-isolation-cli.ts
@@ -53,27 +53,63 @@ function isKnownNoServerDiagnostic(stderr: string): boolean {
 	);
 }
 
-async function tmuxServerProof(socketKey: string, tmuxControlArgv?: string[]): Promise<TmuxServerProof> {
-	void socketKey;
-	if (!tmuxControlArgv?.length) return { state: "unverifiable" };
-	const controlArgv = tmuxControlArgv;
+interface TmuxListSessionsResult {
+	exitCode: number | null;
+	stdout: string;
+	stderr: string;
+}
+
+interface TmuxServerProofOptions {
+	platform?: NodeJS.Platform;
+	runListSessions?: (argv: string[]) => TmuxListSessionsResult;
+}
+
+function runTmuxListSessions(controlArgv: string[]): TmuxListSessionsResult {
 	const subprocess = Bun.spawnSync([...controlArgv, "list-sessions", "-F", "#{pid}\t#{session_name}"], {
 		stdout: "pipe",
 		stderr: "pipe",
 	});
-	const stderr = Buffer.from(subprocess.stderr).toString();
+	return {
+		exitCode: subprocess.exitCode,
+		stdout: Buffer.from(subprocess.stdout).toString(),
+		stderr: Buffer.from(subprocess.stderr).toString(),
+	};
+}
+
+function parseTmuxSessionRows(stdout: string): { pid: number; sessionNames: string[] } | null {
+	const lines = stdout.split("\n");
+	if (lines[lines.length - 1] === "") lines.pop();
+	let pid: number | undefined;
+	const sessionNames: string[] = [];
+	for (const rawLine of lines) {
+		const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+		const columns = line.split("\t");
+		if (columns.length !== 2 || !/^[1-9]\d*$/.test(columns[0]) || !columns[1].trim()) return null;
+		const rowPid = Number(columns[0]);
+		if (!Number.isSafeInteger(rowPid) || (pid !== undefined && pid !== rowPid)) return null;
+		pid = rowPid;
+		sessionNames.push(columns[1]);
+	}
+	return pid === undefined ? null : { pid, sessionNames };
+}
+
+/** Probes a tmux server using an injectable list-sessions runner for platform-bounded callers. */
+export async function tmuxServerProof(
+	socketKey: string,
+	tmuxControlArgv?: string[],
+	options: TmuxServerProofOptions = {},
+): Promise<TmuxServerProof> {
+	void socketKey;
+	if (!tmuxControlArgv?.length) return { state: "unverifiable" };
+	const platform = options.platform ?? process.platform;
+	const subprocess = options.runListSessions?.(tmuxControlArgv) ?? runTmuxListSessions(tmuxControlArgv);
 	if (subprocess.exitCode !== 0)
-		return isKnownNoServerDiagnostic(stderr) ? { state: "absent" } : { state: "unverifiable" };
-	const lines = Buffer.from(subprocess.stdout)
-		.toString()
-		.split("\n")
-		.map(line => line.trim())
-		.filter(Boolean);
-	const [pidText] = lines[0]?.split("\t") ?? [];
-	const pid = Number(pidText);
-	const sessionNames = lines.map(line => line.split("\t")[1]).filter((name): name is string => Boolean(name));
-	if (!Number.isSafeInteger(pid) || pid <= 0) return { state: "unverifiable" };
-	if (process.platform !== "linux") {
+		return isKnownNoServerDiagnostic(subprocess.stderr) ? { state: "absent" } : { state: "unverifiable" };
+	if (!subprocess.stdout.trim()) return { state: "absent" };
+	const rows = parseTmuxSessionRows(subprocess.stdout);
+	if (!rows) return { state: "unverifiable" };
+	const { pid, sessionNames } = rows;
+	if (platform !== "linux") {
 		return {
 			state: "safe",
 			pid,
@@ -82,7 +118,7 @@ async function tmuxServerProof(socketKey: string, tmuxControlArgv?: string[]): P
 			sessionNames,
 		};
 	}
-	const cgroup = classifyCgroup({ platform: process.platform, cgroupText: await readCgroup(String(pid)) });
+	const cgroup = classifyCgroup({ platform, cgroupText: await readCgroup(String(pid)) });
 	const startTime = await readProcessStartTime(pid);
 	if (!startTime) return { state: "unverifiable", pid, cgroup, sessionNames };
 	return {

--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -49,6 +49,7 @@ import {
 	type TmuxOwnerIsolationExecutionResult,
 	type TmuxServerProof,
 } from "./tmux-owner-isolation";
+import { buildWindowsPowerShellInnerCommand } from "./windows-powershell-command";
 
 export interface GjcTmuxSessionStatus {
 	name: string;
@@ -127,6 +128,10 @@ export interface ForceCloseOwnerDependencies {
 
 const FORCE_CLOSE_VERDICT_TIMEOUT_MS = 5_000;
 const FORCE_CLOSE_VERDICT_POLL_MS = 50;
+
+export interface CreateGjcTmuxSessionOptions {
+	platform?: NodeJS.Platform;
+}
 
 export type CreateOwnerIsolationTestDependencies = {
 	probe?: Partial<OwnerIsolationProbeSync>;
@@ -354,15 +359,19 @@ export function statusGjcTmuxSession(sessionName: string, env: NodeJS.ProcessEnv
 	throw new Error(`gjc_tmux_session_not_found:${sessionName}`);
 }
 
-export function createGjcTmuxSession(env: NodeJS.ProcessEnv = process.env): GjcTmuxSessionStatus {
-	const tmuxCommand = resolveGjcTmuxCommand(env);
+export function createGjcTmuxSession(
+	env: NodeJS.ProcessEnv = process.env,
+	options: CreateGjcTmuxSessionOptions = {},
+): GjcTmuxSessionStatus {
+	const platform = options.platform ?? process.platform;
+	const tmuxCommand = resolveGjcTmuxCommand(env, platform);
 	const sessionName = buildGjcTmuxSessionName(env);
 	const cwd = process.cwd();
 	const sessionId = env[GJC_COORDINATOR_SESSION_ID_ENV]?.trim() || sessionName;
 	const stateFile =
 		env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]?.trim() ||
 		tmuxRuntimeSessionPath(cwd, env.GJC_SESSION_ID?.trim() || sessionId, buildGjcTmuxSessionSlug(sessionName));
-	const stateDir = path.dirname(stateFile);
+	const stateDir = (platform === "win32" ? path.win32 : path).dirname(stateFile);
 	const generation = crypto.randomUUID();
 	const childEnvironment: Record<string, string> = {
 		GJC_TMUX_LAUNCHED: "1",
@@ -373,12 +382,9 @@ export function createGjcTmuxSession(env: NodeJS.ProcessEnv = process.env): GjcT
 		[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]: stateFile,
 	};
 	const shellQuote = (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`;
-	const powershellQuote = (value: string): string => `'${value.replace(/'/g, "''")}'`;
 	const command =
-		process.platform === "win32"
-			? `${Object.entries(childEnvironment)
-					.map(([name, value]) => `$env:${name} = ${powershellQuote(value)}`)
-					.join("; ")}; gjc`
+		platform === "win32"
+			? buildWindowsPowerShellInnerCommand({ command: ["gjc"], environment: childEnvironment })
 			: `exec env ${Object.entries(childEnvironment)
 					.map(([name, value]) => `${name}=${shellQuote(value)}`)
 					.join(" ")} gjc`;
@@ -388,11 +394,11 @@ export function createGjcTmuxSession(env: NodeJS.ProcessEnv = process.env): GjcT
 		"-d",
 		"-s",
 		sessionName,
-		...(process.platform === "win32" ? [] : ["-P", "-F", "#{session_id}"]),
+		...(platform === "win32" ? [] : ["-P", "-F", "#{session_id}"]),
 		command,
 	];
 	function probeTmuxServer(tmuxCommand: string, env: NodeJS.ProcessEnv): TmuxServerProof {
-		if (process.platform !== "linux") {
+		if (platform !== "linux") {
 			return {
 				state: "safe",
 				pid: 1,
@@ -421,7 +427,7 @@ export function createGjcTmuxSession(env: NodeJS.ProcessEnv = process.env): GjcT
 				.split(/\s+/)[19];
 			if (!startTime) return { state: "unverifiable" };
 			const cgroup = classifyCgroup({
-				platform: process.platform,
+				platform,
 				cgroupText: fsSync.readFileSync(`/proc/${pid}/cgroup`, "utf8"),
 			});
 			return {
@@ -484,7 +490,7 @@ export function createGjcTmuxSession(env: NodeJS.ProcessEnv = process.env): GjcT
 				}
 			}),
 	};
-	if (resolveGjcTmuxBinary({ env }).isPsmux)
+	if (resolveGjcTmuxBinary({ env, platform }).isPsmux)
 		throw new Error("gjc_tmux_owner_isolation_native_session_identity_unavailable");
 
 	const baseline = captureOwnerGenerationBaselineSync(stateDir, sessionId);
@@ -492,7 +498,7 @@ export function createGjcTmuxSession(env: NodeJS.ProcessEnv = process.env): GjcT
 		{
 			schema_version: 1,
 			op: "plan",
-			platform: process.platform,
+			platform,
 			session_id: sessionId,
 			owner_generation: generation,
 			baseline,

--- a/packages/coding-agent/src/gjc-runtime/windows-powershell-command.ts
+++ b/packages/coding-agent/src/gjc-runtime/windows-powershell-command.ts
@@ -1,0 +1,58 @@
+import { Buffer } from "node:buffer";
+import * as path from "node:path";
+
+export const GJC_TMUX_LAUNCHED_ENV = "GJC_TMUX_LAUNCHED";
+
+export interface WindowsPowerShellInnerCommandOptions {
+	command: readonly string[];
+	args?: readonly string[];
+	environment?: Record<string, string>;
+	tmuxExitMarkerPath?: string;
+}
+
+function powershellQuote(value: string): string {
+	return `'${value.replace(/'/g, "''")}'`;
+}
+
+function buildPowerShellTmuxExitMarkerFinally(markerPath: string): string {
+	const markerDir = path.win32.dirname(markerPath);
+	return [
+		"} finally {",
+		"\ttry {",
+		`\t\tNew-Item -ItemType Directory -Force -Path ${powershellQuote(markerDir)} -ErrorAction Stop | Out-Null`,
+		"\t\t$__gjcTmuxExitMarker = @{ schema_version = 1; source = 'tmux_inner_shell'; ended_at = (Get-Date).ToUniversalTime().ToString('o'); exit_code = $__gjcTmuxExitCode } | ConvertTo-Json -Compress",
+		`\t\tSet-Content -LiteralPath ${powershellQuote(markerPath)} -Value $__gjcTmuxExitMarker -Encoding UTF8 -ErrorAction Stop`,
+		"\t} catch {",
+		"\t}",
+		"}",
+	].join("\n");
+}
+
+/** Builds the shared BOM-free UTF-16LE command for native Windows tmux-compatible panes. */
+export function buildWindowsPowerShellInnerCommand({
+	command,
+	args = [],
+	environment,
+	tmuxExitMarkerPath,
+}: WindowsPowerShellInnerCommandOptions): string {
+	const envLines = Object.entries({ [GJC_TMUX_LAUNCHED_ENV]: "1", ...(environment ?? {}) }).map(
+		([key, value]) => `$env:${key} = ${powershellQuote(value)}`,
+	);
+	const resolvedCommand = command.map(powershellQuote).join(" ");
+	const innerArgs = args.map(powershellQuote).join(" ");
+	const invocation = `& ${resolvedCommand} ${innerArgs}`;
+	const exitLine = "if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 }";
+	const script = tmuxExitMarkerPath
+		? [
+				...envLines,
+				"$__gjcTmuxExitCode = 1",
+				"try {",
+				`\t${invocation}`,
+				"\tif ($null -ne $LASTEXITCODE) { $__gjcTmuxExitCode = $LASTEXITCODE } else { $__gjcTmuxExitCode = 1 }",
+				buildPowerShellTmuxExitMarkerFinally(tmuxExitMarkerPath),
+				"exit $__gjcTmuxExitCode",
+			].join("\n")
+		: [...envLines, invocation, exitLine].join("\n");
+	const encodedCommand = Buffer.from(script, "utf16le").toString("base64");
+	return `pwsh -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodedCommand}`;
+}

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -26,6 +26,9 @@ const DARWIN_PROC_PIDTBSDINFO = 3;
 const DARWIN_PROC_BSDINFO_SIZE = 136;
 const DARWIN_PROC_BSDINFO_START_SECONDS_OFFSET = 120;
 const DARWIN_PROC_BSDINFO_START_MICROSECONDS_OFFSET = 128;
+const POWERSHELL_PROCESS_INCARNATION_COMMAND = "powershell.exe";
+const WIN32_PROCESS_INCARNATION_OUTPUT = /^(\d+)\t(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z)(?:\r?\n)?$/;
+
 const darwinProcLibrary =
 	process.platform === "darwin"
 		? (() => {
@@ -412,6 +415,56 @@ function processIncarnationForBroker(broker: Broker, pid: number): string | unde
 	return reader ? reader(pid) : processIncarnation(pid);
 }
 
+type ProcessIncarnationCommandResult = { exitCode: number | null; stdout: string } | undefined;
+
+export type ProcessIncarnationCommandRunner = (
+	command: string,
+	args: readonly string[],
+) => ProcessIncarnationCommandResult;
+
+export interface ProcessIncarnationOptions {
+	platform?: typeof process.platform;
+	runCommand?: ProcessIncarnationCommandRunner;
+}
+
+function runProcessIncarnationCommand(command: string, args: readonly string[]): ProcessIncarnationCommandResult {
+	try {
+		const result = Bun.spawnSync([command, ...args], { stdin: "ignore", stdout: "pipe", stderr: "ignore" });
+		return { exitCode: result.exitCode, stdout: Buffer.from(result.stdout).toString("utf8") };
+	} catch {
+		return undefined;
+	}
+}
+
+function windowsProcessIncarnationCommand(pid: number): { command: string; args: string[] } {
+	return {
+		command: POWERSHELL_PROCESS_INCARNATION_COMMAND,
+		args: [
+			"-NoLogo",
+			"-NoProfile",
+			"-NonInteractive",
+			"-Command",
+			[
+				"$ErrorActionPreference = 'Stop'",
+				"$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
+				`$process = Get-Process -Id ${pid} -ErrorAction Stop`,
+				'$startTime = $process.StartTime.ToUniversalTime().ToString("o")',
+				'[Console]::Out.WriteLine(("{0}`t{1}" -f $process.Id, $startTime))',
+			].join("; "),
+		],
+	};
+}
+
+function parseWin32ProcessIncarnation(pid: number, output: string): string | undefined {
+	const match = WIN32_PROCESS_INCARNATION_OUTPUT.exec(output);
+	if (!match) return undefined;
+	if (match[1] !== String(pid)) return undefined;
+	const startedAt = match[2];
+	const date = new Date(startedAt);
+	if (!Number.isFinite(date.getTime()) || date.toISOString() !== `${startedAt.slice(0, 23)}Z`) return undefined;
+	return `win32:${startedAt}`;
+}
+
 /** Parse the microsecond-resolution start timestamp returned by Darwin proc_pidinfo. */
 export function parseDarwinProcessIncarnation(info: Uint8Array): string | undefined {
 	if (info.byteLength < DARWIN_PROC_BSDINFO_SIZE) return undefined;
@@ -427,9 +480,10 @@ export function parseDarwinProcessIncarnation(info: Uint8Array): string | undefi
 }
 
 /** A PID is reusable; bind it to the OS-provided process start incarnation. */
-export function processIncarnation(pid: number): string | undefined {
+export function processIncarnation(pid: number, options: ProcessIncarnationOptions = {}): string | undefined {
 	if (!Number.isSafeInteger(pid) || pid <= 0) return undefined;
-	if (process.platform === "linux") {
+	const platform = options.platform ?? process.platform;
+	if (platform === "linux") {
 		try {
 			const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
 			const close = stat.lastIndexOf(")");
@@ -442,7 +496,7 @@ export function processIncarnation(pid: number): string | undefined {
 			return undefined;
 		}
 	}
-	if (process.platform === "darwin") {
+	if (platform === "darwin") {
 		const info = new Uint8Array(DARWIN_PROC_BSDINFO_SIZE);
 		try {
 			const bytesRead = darwinProcLibrary?.symbols.proc_pidinfo(
@@ -456,6 +510,18 @@ export function processIncarnation(pid: number): string | undefined {
 		} catch {
 			return undefined;
 		}
+	}
+	if (platform === "win32") {
+		const command = windowsProcessIncarnationCommand(pid);
+		let result: ProcessIncarnationCommandResult;
+		try {
+			result = (options.runCommand ?? runProcessIncarnationCommand)(command.command, command.args);
+		} catch {
+			return undefined;
+		}
+		return result?.exitCode === 0 && typeof result.stdout === "string"
+			? parseWin32ProcessIncarnation(pid, result.stdout)
+			: undefined;
 	}
 	return undefined;
 }

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -1222,8 +1222,8 @@ function sdkControlSurface(
 		throw Object.assign(new Error(`${operation} is unavailable: ${reason}`), { code: "unavailable" });
 	};
 	const bindings = new Set(ctx.sdkBindings?.() ?? []);
-	const send = (text: string, deliverAs?: "steer" | "followUp") => {
-		api.sendUserMessage(text, deliverAs ? { deliverAs } : undefined);
+	const sendSteer = (text: string) => {
+		api.sendUserMessage(text, { deliverAs: "steer" });
 		return { commandId: crypto.randomUUID(), accepted: true };
 	};
 	const resolveModel = (id: string) => {
@@ -1252,7 +1252,7 @@ function sdkControlSurface(
 			await Bun.sleep(10);
 		}
 	};
-	const submitPrompt = async (text: string, images: unknown, forceFresh = false) => {
+	const submitPrompt = async (text: string, images: unknown, forceFresh = false, deliverAs?: "steer" | "followUp") => {
 		if (forceFresh && (isBusy() || !ctx.isIdle())) {
 			throw Object.assign(new Error("Previous turn did not finish aborting before replacement prompt submission."), {
 				code: "busy",
@@ -1298,7 +1298,7 @@ function sdkControlSurface(
 		try {
 			submission = Promise.resolve(
 				api.sendUserMessage(content, {
-					...(!forceFresh && isBusy() ? { deliverAs: "steer" as const } : {}),
+					...(deliverAs ? { deliverAs } : !forceFresh && isBusy() ? { deliverAs: "steer" as const } : {}),
 					onPreflightAccepted,
 				}),
 			);
@@ -1333,8 +1333,8 @@ function sdkControlSurface(
 	};
 	const surface: ControlSurface = {
 		prompt: (text, images) => submitPrompt(text, images),
-		steer: text => send(text, "steer"),
-		followUp: text => send(text, "followUp"),
+		steer: text => sendSteer(text),
+		followUp: text => submitPrompt(text, undefined, false, "followUp"),
 		abort: () => {
 			cancelPendingPreflights();
 			ctx.abort();
@@ -1857,7 +1857,9 @@ export function createNotificationsExtension(
 			onRequest: options.onSdkRequest,
 			afterControlResponse: async (connectionId, request, response) => {
 				if (
-					(request.operation === "turn.prompt" || request.operation === "turn.abort_and_prompt") &&
+					(request.operation === "turn.prompt" ||
+						request.operation === "turn.follow_up" ||
+						request.operation === "turn.abort_and_prompt") &&
 					response.ok === true &&
 					response.result &&
 					typeof response.result === "object" &&

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { createCoordinatorMcpServer } from "../src/coordinator-mcp/server";
-import type { SdkClient } from "../src/sdk/client/client";
+import { type SdkClient, SdkClientError } from "../src/sdk/client/client";
 
 const tempDirs: string[] = [];
 
@@ -32,6 +32,13 @@ function brokerEndpointIncarnation(
 }
 
 type EndpointRequestHandler = (input: Record<string, unknown>, sessions: Array<Record<string, unknown>>) => unknown;
+type SdkControlServerOptions = {
+	platform?: NodeJS.Platform;
+	canonicalizePath?: (value: string) => Promise<string>;
+	controlResult?: (control: SdkControl) => unknown;
+	promptAckTimeoutMs?: number;
+	controlOptions?: Array<{ idempotencyKey?: string; timeoutMs?: number }>;
+};
 function lifecycleControls(controls: SdkControl[]): SdkControl[] {
 	return controls.filter(
 		control => control.operation !== "session.list" && control.operation !== "session.get_endpoint",
@@ -68,6 +75,7 @@ async function createSdkControlServer(
 	],
 	sessionCommand?: string,
 	endpointRequestHandler?: EndpointRequestHandler,
+	serverOptions: SdkControlServerOptions = {},
 ): Promise<ReturnType<typeof createCoordinatorMcpServer>> {
 	const stateRoot = path.join(root, ".gjc", "coordinator-state");
 	const agentDir = path.join(root, "agent-global");
@@ -80,19 +88,32 @@ async function createSdkControlServer(
 			GJC_COORDINATOR_MCP_PROFILE: "local",
 			GJC_COORDINATOR_MCP_REPO: "repo",
 			...(sessionCommand ? { GJC_COORDINATOR_MCP_SESSION_COMMAND: sessionCommand } : {}),
+			...(serverOptions.promptAckTimeoutMs === undefined
+				? {}
+				: { GJC_COORDINATOR_MCP_PROMPT_ACK_TIMEOUT_MS: String(serverOptions.promptAckTimeoutMs) }),
 		},
+		platform: serverOptions.platform,
 		services: {
 			getAgentDir: () => agentDir,
 			resolveModelProfiles: () => new Map([["codex-eco", { name: "codex-eco" }]]),
+			canonicalizePath: serverOptions.canonicalizePath,
 			connectSdk: async () =>
 				({
 					control: async (
 						operation: string,
 						input: Record<string, unknown>,
-						options: { idempotencyKey?: string },
+						options: { idempotencyKey?: string; timeoutMs?: number },
 					) => {
-						controls.push({ operation, input, idempotencyKey: options.idempotencyKey });
-						return { accepted: true, turn_id: `sdk-${controls.length}` };
+						const control = { operation, input, idempotencyKey: options.idempotencyKey };
+						controls.push(control);
+						serverOptions.controlOptions?.push(options);
+						return (
+							serverOptions.controlResult?.(control) ?? {
+								accepted: true,
+								command_id: `sdk-command-${controls.length}`,
+								turn_id: `sdk-turn-${controls.length}`,
+							}
+						);
 					},
 					global: async (
 						operation: string,
@@ -261,6 +282,262 @@ describe("Coordinator MCP canonical SDK controls", () => {
 			},
 			{ operation: "session.list", input: { cwd: root }, idempotencyKey: undefined },
 		]);
+	});
+	it("marks lifecycle-created sessions ready after successful SDK lifecycle binding", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const server = await createSdkControlServer(root, controls);
+
+		const started = await server.callTool("gjc_coordinator_start_session", {
+			cwd: root,
+			idempotency_key: "ready-after-binding",
+			allow_mutation: true,
+		});
+
+		expect(started).toMatchObject({
+			ok: true,
+			session: { session_id: "created-session-1" },
+			session_state: { state: "ready_for_input", ready_for_input: true },
+		});
+		expect(controls.map(control => control.operation)).toEqual([
+			"session.create",
+			"session.list",
+			"session.get_endpoint",
+		]);
+	});
+
+	it("preserves multiline delegated task text in one SDK turn.prompt control", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const server = await createSdkControlServer(root, controls);
+		await registerSdkSession(server, root);
+		const task = "first line\n\n  exact indentation\nlast line";
+
+		const delegated = await server.callTool("gjc_delegate_execute", {
+			cwd: root,
+			session_id: "visible-session",
+			task,
+			idempotency_key: "multiline-delegation",
+			allow_mutation: true,
+		});
+
+		expect(delegated).toMatchObject({ ok: true, workflow: "execute" });
+		const promptControls = controls.filter(control => control.operation === "turn.prompt");
+		expect(promptControls).toHaveLength(1);
+		expect(promptControls[0]).toEqual(
+			expect.objectContaining({
+				input: { text: expect.stringContaining(`Task:\n${task}\n\nReturn durable status`) },
+			}),
+		);
+	});
+
+	it("normalizes camelCase runtime acknowledgement identities into durable and public turns", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const server = await createSdkControlServer(root, controls, [], undefined, undefined, undefined, undefined, {
+			controlResult: () => ({
+				type: "control_response",
+				id: "runtime-ack-1",
+				ok: true,
+				result: { accepted: true, commandId: "runtime-command-1", turnId: "runtime-turn-1" },
+			}),
+		});
+		await registerSdkSession(server, root);
+
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "acknowledged work",
+			idempotency_key: "camel-ack",
+			allow_mutation: true,
+		});
+
+		expect(sent).toMatchObject({
+			ok: true,
+			result: { accepted: true, command_id: "runtime-command-1", turn_id: "runtime-turn-1" },
+			turn: {
+				delivery: { runtime_command_id: "runtime-command-1", runtime_turn_id: "runtime-turn-1" },
+			},
+		});
+		const turnId = sent.turn_id;
+		if (typeof turnId !== "string") throw new Error("missing durable coordinator turn id");
+		const persisted = JSON.parse(
+			await fs.readFile(
+				path.join(root, ".gjc", "coordinator-state", "local", "repo", "turns", `${turnId}.json`),
+				"utf8",
+			),
+		) as { delivery: Record<string, unknown> };
+		expect(persisted.delivery).toMatchObject({
+			runtime_command_id: "runtime-command-1",
+			runtime_turn_id: "runtime-turn-1",
+		});
+	});
+
+	it("accepts drive-letter and separator differences through the injected Windows platform seam", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const canonicalWorkspace = "C:\\Workspaces\\Coordinator\\Repo";
+		const server = await createSdkControlServer(
+			root,
+			controls,
+			[],
+			undefined,
+			[
+				{
+					sessionId: "visible-session",
+					locator: { repo: "c:/workspaces/coordinator/repo" },
+					live: true,
+					endpointGeneration: 1,
+					pid: 101,
+					endpointMtimeMs: 1,
+				},
+			],
+			undefined,
+			undefined,
+			{
+				platform: "win32",
+				canonicalizePath: async value => path.win32.normalize(value === root ? canonicalWorkspace : value),
+			},
+		);
+		const registered = await registerSdkSession(server, root);
+		expect(registered).toMatchObject({ ok: true, session: { cwd: canonicalWorkspace } });
+		expect(await server.callTool("gjc_coordinator_read_status", { session_id: "visible-session" })).toMatchObject({
+			ok: true,
+			status: { live: true },
+		});
+		expect(
+			await server.callTool("gjc_coordinator_send_prompt", {
+				session_id: "visible-session",
+				prompt: "case-safe workspace",
+				idempotency_key: "windows-case-safe",
+				allow_mutation: true,
+			}),
+		).toMatchObject({ ok: true });
+	});
+
+	it("fails closed before turn persistence for malformed acknowledgement envelopes and conflicting aliases", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const acknowledgements: Record<string, unknown> = {
+			"missing-acceptance": { commandId: "runtime-command-1", turnId: "runtime-turn-1" },
+			"malformed-identity": { accepted: true, commandId: "invalid/runtime-command", turnId: "runtime-turn-2" },
+			"envelope-without-ok": {
+				result: { accepted: true, commandId: "runtime-command-1", turnId: "runtime-turn-1" },
+			},
+			"envelope-without-result": {
+				ok: true,
+				accepted: true,
+				commandId: "runtime-command-1",
+				turnId: "runtime-turn-1",
+			},
+			"envelope-with-error": {
+				ok: true,
+				result: { accepted: true, commandId: "runtime-command-1", turnId: "runtime-turn-1" },
+				error: { code: "unavailable" },
+			},
+			"envelope-error-only": { error: { code: "unavailable" } },
+			"conflicting-command-aliases": {
+				ok: true,
+				result: {
+					accepted: true,
+					commandId: "runtime-command-1",
+					command_id: "runtime-command-2",
+					turnId: "runtime-turn-1",
+				},
+			},
+			"conflicting-turn-aliases": {
+				accepted: true,
+				commandId: "runtime-command-1",
+				turnId: "runtime-turn-1",
+				turn_id: "runtime-turn-2",
+			},
+			"follow-up-without-turn": { accepted: true, commandId: "runtime-command-1" },
+		};
+		const server = await createSdkControlServer(root, controls, [], undefined, undefined, undefined, undefined, {
+			controlResult: control => acknowledgements[control.idempotencyKey ?? ""],
+		});
+		await registerSdkSession(server, root);
+
+		for (const [idempotencyKey, queue] of [
+			["missing-acceptance", false],
+			["malformed-identity", false],
+			["envelope-without-ok", false],
+			["envelope-without-result", false],
+			["envelope-with-error", false],
+			["envelope-error-only", false],
+			["conflicting-command-aliases", false],
+			["conflicting-turn-aliases", false],
+			["follow-up-without-turn", true],
+		] as const) {
+			expect(
+				await server.callTool("gjc_coordinator_send_prompt", {
+					session_id: "visible-session",
+					prompt: "must not be recorded",
+					idempotency_key: idempotencyKey,
+					...(queue ? { queue: true } : {}),
+					allow_mutation: true,
+				}),
+			).toMatchObject({ ok: false, error: { code: "unavailable" } });
+		}
+		expect(controls.filter(control => control.operation === "turn.prompt")).toHaveLength(8);
+		expect(controls.filter(control => control.operation === "turn.follow_up")).toHaveLength(1);
+		await expect(
+			fs.readdir(path.join(root, ".gjc", "coordinator-state", "local", "repo", "turns")),
+		).rejects.toMatchObject({ code: "ENOENT" });
+	});
+	it("passes the bounded acknowledgement timeout to the SDK and surfaces timeout errors", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const controlOptions: Array<{ idempotencyKey?: string; timeoutMs?: number }> = [];
+		const server = await createSdkControlServer(root, controls, [], undefined, undefined, undefined, undefined, {
+			promptAckTimeoutMs: 17,
+			controlOptions,
+			controlResult: () => {
+				throw new SdkClientError("timeout", "SDK request timed out after 17ms");
+			},
+		});
+		await registerSdkSession(server, root);
+
+		expect(
+			await server.callTool("gjc_coordinator_send_prompt", {
+				session_id: "visible-session",
+				prompt: "bounded timeout",
+				idempotency_key: "bounded-timeout",
+				allow_mutation: true,
+			}),
+		).toMatchObject({ ok: false, error: { code: "timeout" } });
+		expect(controls.filter(control => control.operation === "turn.prompt")).toEqual([
+			{ operation: "turn.prompt", input: { text: "bounded timeout" }, idempotencyKey: "bounded-timeout" },
+		]);
+		expect(controlOptions).toContainEqual({ idempotencyKey: "bounded-timeout", timeoutMs: 17 });
+		await expect(
+			fs.readdir(path.join(root, ".gjc", "coordinator-state", "local", "repo", "turns")),
+		).rejects.toMatchObject({ code: "ENOENT" });
+	});
+	it("caps and defaults prompt acknowledgement timeouts passed to the SDK", async () => {
+		for (const [configuredTimeoutMs, expectedTimeoutMs] of [
+			[undefined, 10_000],
+			[300_001, 300_000],
+		] as const) {
+			const root = await tempRoot();
+			const controls: SdkControl[] = [];
+			const controlOptions: Array<{ idempotencyKey?: string; timeoutMs?: number }> = [];
+			const server = await createSdkControlServer(root, controls, [], undefined, undefined, undefined, undefined, {
+				promptAckTimeoutMs: configuredTimeoutMs,
+				controlOptions,
+			});
+			await registerSdkSession(server, root);
+			expect(
+				await server.callTool("gjc_coordinator_send_prompt", {
+					session_id: "visible-session",
+					prompt: "bounded prompt acknowledgement",
+					idempotency_key: `prompt-timeout-${expectedTimeoutMs}`,
+					allow_mutation: true,
+				}),
+			).toMatchObject({ ok: true });
+			expect(controlOptions).toEqual([
+				{ idempotencyKey: `prompt-timeout-${expectedTimeoutMs}`, timeoutMs: expectedTimeoutMs },
+			]);
+		}
 	});
 
 	it("derives aggregate liveness from scoped broker records", async () => {
@@ -892,7 +1169,11 @@ describe("Coordinator MCP canonical SDK controls", () => {
 	it("routes prompts, follow-ups, abort-and-prompts, and answers through SDK controls with caller keys", async () => {
 		const root = await tempRoot();
 		const controls: SdkControl[] = [];
-		const server = await createSdkControlServer(root, controls);
+		const controlOptions: Array<{ idempotencyKey?: string; timeoutMs?: number }> = [];
+		const server = await createSdkControlServer(root, controls, [], undefined, undefined, undefined, undefined, {
+			promptAckTimeoutMs: 17,
+			controlOptions,
+		});
 		await registerSdkSession(server, root);
 		const first = await server.callTool("gjc_coordinator_send_prompt", {
 			session_id: "visible-session",
@@ -908,7 +1189,28 @@ describe("Coordinator MCP canonical SDK controls", () => {
 			idempotency_key: "prompt-2",
 			allow_mutation: true,
 		});
-		expect(queued).toMatchObject({ ok: true, operation: "turn.follow_up", turn: { status: "queued" } });
+		expect(queued).toMatchObject({
+			ok: true,
+			operation: "turn.follow_up",
+			result: { accepted: true, command_id: expect.any(String), turn_id: expect.any(String) },
+			turn: {
+				status: "queued",
+				delivery: { runtime_command_id: expect.any(String), runtime_turn_id: expect.any(String) },
+			},
+		});
+		const queuedTurnId = queued.turn_id;
+		if (typeof queuedTurnId !== "string") throw new Error("missing queued coordinator turn id");
+		const queuedAcknowledgement = queued.result as { command_id?: unknown; turn_id?: unknown };
+		const persistedQueuedTurn = JSON.parse(
+			await fs.readFile(
+				path.join(root, ".gjc", "coordinator-state", "local", "repo", "turns", `${queuedTurnId}.json`),
+				"utf8",
+			),
+		) as { delivery: Record<string, unknown> };
+		expect(persistedQueuedTurn.delivery).toMatchObject({
+			runtime_command_id: queuedAcknowledgement.command_id,
+			runtime_turn_id: queuedAcknowledgement.turn_id,
+		});
 		expect(
 			await server.callTool("gjc_coordinator_send_prompt", {
 				session_id: "visible-session",
@@ -932,6 +1234,12 @@ describe("Coordinator MCP canonical SDK controls", () => {
 			{ operation: "turn.follow_up", input: { text: "follow up" }, idempotencyKey: "prompt-2" },
 			{ operation: "turn.abort_and_prompt", input: { text: "replace" }, idempotencyKey: "prompt-3" },
 			{ operation: "ask.answer", input: { id: "ask-1", answer: { choice: "yes" } }, idempotencyKey: "answer-1" },
+		]);
+		expect(controlOptions).toEqual([
+			{ idempotencyKey: "prompt-1", timeoutMs: 17 },
+			{ idempotencyKey: "prompt-2", timeoutMs: 17 },
+			{ idempotencyKey: "prompt-3", timeoutMs: 17 },
+			{ idempotencyKey: "answer-1" },
 		]);
 	});
 

--- a/packages/coding-agent/test/gjc-runtime/tmux-owner-isolation.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-owner-isolation.test.ts
@@ -28,7 +28,10 @@ import {
 	TMUX_OWNER_ISOLATION_MAX_LINE_BYTES,
 	tmuxOwnerIsolationBootstrapArgv,
 } from "@gajae-code/coding-agent/gjc-runtime/tmux-owner-isolation";
-import { isTmuxOwnerIsolationCliArgv } from "@gajae-code/coding-agent/gjc-runtime/tmux-owner-isolation-cli";
+import {
+	isTmuxOwnerIsolationCliArgv,
+	tmuxServerProof,
+} from "@gajae-code/coding-agent/gjc-runtime/tmux-owner-isolation-cli";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
 const ownerIsolationCliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
@@ -127,6 +130,58 @@ describe("tmux owner isolation", () => {
 		for (const argv of [[], [ownerIsolationFlag, "extra"], ["extra", ownerIsolationFlag], ["--other"]]) {
 			expect(isTmuxOwnerIsolationCliArgv(argv)).toBe(false);
 		}
+	});
+
+	it("treats successful whitespace-only list-sessions output as absent", async () => {
+		const proof = await tmuxServerProof("socket", ["psmux"], {
+			platform: "win32",
+			runListSessions: () => ({ exitCode: 0, stdout: " \r\n\t", stderr: "" }),
+		});
+		expect(proof).toEqual({ state: "absent" });
+	});
+
+	it("treats a known no-server diagnostic as absent", async () => {
+		const proof = await tmuxServerProof("socket", ["psmux"], {
+			platform: "win32",
+			runListSessions: () => ({
+				exitCode: 1,
+				stdout: "",
+				stderr: "no server running on /tmp/psmux.sock",
+			}),
+		});
+		expect(proof).toEqual({ state: "absent" });
+	});
+
+	it("accepts complete matching list-sessions rows on win32", async () => {
+		const proof = await tmuxServerProof("socket", ["psmux"], {
+			platform: "win32",
+			runListSessions: () => ({
+				exitCode: 0,
+				stdout: "4242\tfirst\n4242\tsecond\n",
+				stderr: "",
+			}),
+		});
+		expect(proof).toEqual({
+			state: "safe",
+			pid: 4242,
+			startTime: "not_applicable",
+			cgroup: { classification: "not_applicable" },
+			sessionNames: ["first", "second"],
+		});
+	});
+
+	it.each([
+		["an invalid pid", "not-a-pid\towned\n"],
+		["a missing pid", "\towned\n"],
+		["malformed columns", "42\towned\textra\n"],
+		["inconsistent pids", "42\tfirst\n43\tsecond\n"],
+		["mixed valid and invalid rows", "42\tfirst\nbroken\tsecond\n"],
+	])("fails closed on non-empty list-sessions output with %s", async (_case, stdout) => {
+		const proof = await tmuxServerProof("socket", ["psmux"], {
+			platform: "win32",
+			runListSessions: () => ({ exitCode: 0, stdout, stderr: "" }),
+		});
+		expect(proof).toEqual({ state: "unverifiable" });
 	});
 
 	it("invokes a compiled bootstrap with only the internal flag", () => {

--- a/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
@@ -3,6 +3,7 @@ import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { buildWindowsPowerShellInnerCommand } from "@gajae-code/coding-agent/gjc-runtime/launch-tmux";
 import {
 	__setBinaryResolverForTests,
 	clearPsmuxDetectionCache,
@@ -481,6 +482,77 @@ describe("GJC tmux session management", () => {
 		} finally {
 			__setBinaryResolverForTests(null);
 		}
+	});
+	it("builds a BOM-free encoded command for psmux with literal PowerShell values and arguments", () => {
+		const encoded = buildWindowsPowerShellInnerCommand({
+			command: ["C:\\Program Files\\GJC\\O'Brien\\gjc.exe"],
+			args: ["--resume", "operator's session", "--label=O'Brien"],
+			environment: {
+				GJC_PSMUX_COMMAND: "C:\\Program Files\\O'Brien\\psmux.exe",
+				GJC_TEST_VALUE: "operator's value",
+			},
+		});
+		const encodedMatch = encoded.match(/-EncodedCommand\s+(\S+)/);
+		expect(encodedMatch).not.toBeNull();
+		if (!encodedMatch) throw new Error("expected PowerShell encoded command");
+
+		const decoded = Buffer.from(encodedMatch[1], "base64");
+		expect(decoded[0]).not.toBe(0xff);
+		expect(decoded[1]).not.toBe(0xfe);
+		const script = decoded.toString("utf16le");
+		expect(script[0]).toBe("$");
+		expect(script).toContain("$env:GJC_PSMUX_COMMAND = 'C:\\Program Files\\O''Brien\\psmux.exe'");
+		expect(script).toContain("$env:GJC_TEST_VALUE = 'operator''s value'");
+		expect(script).toContain(
+			"& 'C:\\Program Files\\GJC\\O''Brien\\gjc.exe' '--resume' 'operator''s session' '--label=O''Brien'",
+		);
+	});
+
+	it("passes the shared encoded command to injected win32 session creation", () => {
+		let plannedArgv: string[] | undefined;
+		__setCreateOwnerIsolationForTests({
+			execute: plan => {
+				if (!plan.ok) throw new Error("expected owner-isolation plan");
+				plannedArgv = plan.execution.argv;
+				return { ok: false, code: "scope_bootstrap_failed", diagnostic: "test-stop" };
+			},
+		});
+		const stateFile = "C:\\Users\\O'Brien\\runtime-state.json";
+		expect(() =>
+			createGjcTmuxSession(
+				{
+					GJC_PSMUX_DETECTION: "off",
+					GJC_TMUX_COMMAND: "tmux",
+					GJC_TMUX_SESSION: "psmux-session",
+					GJC_COORDINATOR_SESSION_ID: "operator's session",
+					GJC_COORDINATOR_SESSION_STATE_FILE: stateFile,
+				},
+				{ platform: "win32" },
+			),
+		).toThrow("gjc_tmux_owner_isolation_scope_bootstrap_failed:test-stop");
+		expect(plannedArgv?.slice(0, -1)).toEqual(["tmux", "new-session", "-d", "-s", "psmux-session"]);
+
+		const innerCommand = plannedArgv?.at(-1);
+		const encodedMatch = innerCommand?.match(/-EncodedCommand\s+(\S+)/);
+		expect(encodedMatch).not.toBeNull();
+		if (!encodedMatch) throw new Error("expected session new-command encoded command");
+		const script = Buffer.from(encodedMatch[1], "base64").toString("utf16le");
+		const generation = script.match(/\$env:GJC_TMUX_OWNER_GENERATION = '([^']+)'/)?.[1];
+		expect(generation).toBeDefined();
+		if (!generation) throw new Error("expected generated owner identity");
+		expect(innerCommand).toBe(
+			buildWindowsPowerShellInnerCommand({
+				command: ["gjc"],
+				environment: {
+					GJC_TMUX_LAUNCHED: "1",
+					GJC_TMUX_OWNER_GENERATION: generation,
+					GJC_TMUX_OWNER_STATE_DIR: "C:\\Users\\O'Brien",
+					GJC_TMUX_OWNER_SERVER_KEY: "tmux",
+					GJC_COORDINATOR_SESSION_ID: "operator's session",
+					GJC_COORDINATOR_SESSION_STATE_FILE: stateFile,
+				},
+			}),
+		);
 	});
 	it("refuses psmux before attach-session mutation", () => {
 		__setBinaryResolverForTests(candidate => (candidate === "psmux" ? "/fake/psmux" : null));

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -161,6 +161,60 @@ test("broker parses Darwin kernel process start timestamps with microsecond prec
 	expect(parseDarwinProcessIncarnation(bsdInfo)).toBe("darwin:1700000000:123456");
 	expect(parseDarwinProcessIncarnation(sameSecondSuccessor)).toBe("darwin:1700000000:123457");
 });
+test("broker reads Windows process incarnations through a PowerShell query", () => {
+	let invoked = false;
+	const result = processIncarnation(4_242, {
+		platform: "win32",
+		runCommand(command, args) {
+			invoked = true;
+			expect(command).toBe("powershell.exe");
+			expect(args).toEqual([
+				"-NoLogo",
+				"-NoProfile",
+				"-NonInteractive",
+				"-Command",
+				'$ErrorActionPreference = \'Stop\'; $OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); $process = Get-Process -Id 4242 -ErrorAction Stop; $startTime = $process.StartTime.ToUniversalTime().ToString("o"); [Console]::Out.WriteLine(("{0}`t{1}" -f $process.Id, $startTime))',
+			]);
+			return { exitCode: 0, stdout: "4242\t2025-02-03T04:05:06.1234567Z\r\n" };
+		},
+	});
+	expect(invoked).toBe(true);
+	expect(result).toBe("win32:2025-02-03T04:05:06.1234567Z");
+});
+
+test("broker fails closed when a Windows process-incarnation query fails", () => {
+	const options = {
+		platform: "win32" as const,
+		runCommand: () => ({ exitCode: 1, stdout: "4242\t2025-02-03T04:05:06.1234567Z\n" }),
+	};
+	expect(processIncarnation(4_242, options)).toBeUndefined();
+	expect(
+		processIncarnation(4_242, {
+			platform: "win32",
+			runCommand() {
+				throw new Error("PowerShell unavailable");
+			},
+		}),
+	).toBeUndefined();
+});
+
+test("broker rejects empty, malformed, and mismatched Windows process-incarnation output", () => {
+	for (const stdout of [
+		"",
+		"4242\t2025-02-03T04:05:06.123Z\n",
+		"4242\t2025-02-30T04:05:06.1234567Z\n",
+		"4243\t2025-02-03T04:05:06.1234567Z\n",
+		"4242\t2025-02-03T04:05:06.1234567Z\r",
+		"4242\t2025-02-03T04:05:06.1234567Z\n\n",
+	]) {
+		expect(
+			processIncarnation(4_242, {
+				platform: "win32",
+				runCommand: () => ({ exitCode: 0, stdout }),
+			}),
+		).toBeUndefined();
+	}
+});
 
 test("broker bounds a hanging WebSocket upgrade by the lifecycle deadline and cleans its child", async () => {
 	const agentDir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-hanging-upgrade-"));

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -455,6 +455,68 @@ test("SDK host preserves ordered prompt image blocks in the host payload", async
 	]);
 });
 
+test("SDK host correlates follow-up acknowledgements with the later agent start", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-follow-up-correlation-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-follow-up-correlation-${Date.now()}`;
+	const sent: Parameters<ExtensionActions["sendUserMessage"]>[] = [];
+	const sessionContext = context(cwd, sessionId);
+	const handlers = start(sessionContext, undefined, (...args) => {
+		sent.push(args);
+	});
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const frames: Record<string, unknown>[] = [];
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+	socket.send(
+		JSON.stringify({
+			type: "control_request",
+			id: "follow-up-correlation",
+			operation: "turn.follow_up",
+			input: { text: "queued follow-up" },
+		}),
+	);
+	await waitFor(
+		() => frames.some(frame => frame.type === "control_response" && frame.id === "follow-up-correlation"),
+		"follow-up acknowledgement",
+	);
+	const acknowledgement = frames.find(
+		frame => frame.type === "control_response" && frame.id === "follow-up-correlation",
+	) as { result?: { commandId?: string; turnId?: string } };
+	const commandId = acknowledgement.result?.commandId;
+	const turnId = acknowledgement.result?.turnId;
+	expect(acknowledgement).toMatchObject({
+		ok: true,
+		result: { accepted: true, commandId: expect.any(String), turnId: expect.any(String) },
+	});
+	if (typeof commandId !== "string" || typeof turnId !== "string") throw new Error("missing follow-up correlation");
+	expect(sent).toEqual([["queued follow-up", { deliverAs: "followUp" }]]);
+	void handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+	socket.send(JSON.stringify({ type: "event_replay", id: "follow-up-replay", sinceGeneration: 1, sinceSeq: 0 }));
+	await waitFor(
+		() => frames.some(frame => frame.type === "event_replay_result" && frame.id === "follow-up-replay"),
+		"correlated agent start replay",
+	);
+	const replay = frames.find(frame => frame.type === "event_replay_result" && frame.id === "follow-up-replay");
+	expect(replay?.events).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				type: "event",
+				kind: "agent_start",
+				payload: expect.objectContaining({ type: "agent_start", sessionId, commandId, turnId }),
+			}),
+		]),
+	);
+	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+});
+
 test("SDK host delivers accepted prompt failures after their acknowledgement", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-terminal-"));
 	dirs.push(cwd);

--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -874,6 +874,108 @@ describe("coordinator runtime state sidecar", () => {
 			reason: "session_id_mismatch",
 		});
 	});
+	it("accepts case-equivalent Windows runtime-state paths", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "windows-state.json");
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "windows-session",
+				state: "completed",
+				cwd: "C:\\Users\\Operator\\Repo",
+				workdir: "C:\\Users\\Operator\\Repo\\.\\",
+				session_file: "C:\\Users\\Operator\\Repo\\.gjc\\session.jsonl",
+			}),
+		);
+
+		await expect(
+			readTerminalRuntimeStateMarker({
+				stateFile,
+				sessionId: "windows-session",
+				cwd: "c:\\users\\operator\\repo",
+				sessionFile: "c:\\users\\operator\\repo\\.gjc\\session.jsonl",
+				platform: "win32",
+			}),
+		).resolves.toEqual({ terminal: true, state: "completed" });
+		await expect(
+			readTerminalRuntimeStateMarker({
+				stateFile,
+				sessionId: "windows-session",
+				cwd: "D:\\Users\\Operator\\Repo",
+				sessionFile: "c:\\users\\operator\\repo\\.gjc\\session.jsonl",
+				platform: "win32",
+			}),
+		).resolves.toEqual({ terminal: false, reason: "cwd_mismatch" });
+	});
+	it("writes and preserves Windows case- and dot-equivalent runtime identities without accepting another drive", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "windows-runtime-state.json");
+		const sessionId = "windows-runtime-identity";
+		const initialContext = {
+			sessionId: "fallback",
+			cwd: "C:\\Users\\Operator\\Repo",
+			sessionFile: "C:\\Users\\Operator\\Repo\\.gjc\\session.jsonl",
+			platform: "win32" as const,
+		};
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = sessionId;
+
+		await persistCoordinatorRuntimeStateFromEvent({ type: "agent_start" }, initialContext);
+		await persistCoordinatorRuntimeStateFromEvent(assistantEnd("Windows terminal"), {
+			...initialContext,
+			cwd: "c:\\USERS\\OPERATOR\\REPO\\.\\",
+			sessionFile: "c:\\USERS\\OPERATOR\\REPO\\.gjc\\.\\session.jsonl",
+		});
+		const terminal = await readPayload(stateFile);
+		expect(terminal).toMatchObject({
+			session_id: sessionId,
+			state: "completed",
+			cwd: "c:\\USERS\\OPERATOR\\REPO",
+			workdir: "c:\\USERS\\OPERATOR\\REPO",
+			session_file: "c:\\USERS\\OPERATOR\\REPO\\.gjc\\session.jsonl",
+			final_response: { source: "agent_end", text: "Windows terminal" },
+		});
+
+		await persistCoordinatorRuntimeStateFromPostmortem(postmortem.Reason.SIGTERM, initialContext);
+		expect(await readPayload(stateFile)).toEqual(terminal);
+
+		const beforeRejectedWrite = await Bun.file(stateFile).text();
+		await expect(
+			persistCoordinatorRuntimeStateFromPostmortem(postmortem.Reason.SIGTERM, {
+				...initialContext,
+				cwd: "D:\\Users\\Operator\\Repo",
+				sessionFile: "D:\\Users\\Operator\\Repo\\.gjc\\session.jsonl",
+			}),
+		).rejects.toThrow("invalid or unreadable");
+		expect(await Bun.file(stateFile).text()).toBe(beforeRejectedWrite);
+	});
+	it("rejects case-different POSIX runtime-state identities", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "posix-runtime-state.json");
+		const sessionId = "posix-runtime-identity";
+		const cwd = path.join(root, "workspace");
+		const sessionFile = path.join(cwd, "session.jsonl");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = sessionId;
+
+		await persistCoordinatorRuntimeStateFromEvent(
+			{ type: "agent_start" },
+			{ sessionId: "fallback", cwd, sessionFile },
+		);
+		const beforeRejectedWrite = await Bun.file(stateFile).text();
+		await expect(
+			persistCoordinatorRuntimeStateFromEvent(
+				{ type: "turn_start" },
+				{
+					sessionId: "fallback",
+					cwd: path.join(root, "WORKSPACE"),
+					sessionFile: path.join(root, "WORKSPACE", "session.jsonl"),
+				},
+			),
+		).rejects.toThrow("invalid or unreadable");
+		expect(await Bun.file(stateFile).text()).toBe(beforeRejectedWrite);
+	});
 
 	it("rejects non-terminal and mismatched runtime markers", async () => {
 		const root = await tempRoot();

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -108,9 +108,10 @@ export function resolveEquivalentPath(inputPath: string): string {
 	}
 }
 
-export function normalizePathForComparison(inputPath: string): string {
-	const resolvedPath = resolveEquivalentPath(inputPath);
-	return process.platform === "win32" ? resolvedPath.toLowerCase() : resolvedPath;
+export function normalizePathForComparison(inputPath: string, platform: NodeJS.Platform = process.platform): string {
+	const pathApi = platform === "win32" ? path.win32 : path;
+	const resolvedPath = platform === process.platform ? resolveEquivalentPath(inputPath) : pathApi.resolve(inputPath);
+	return platform === "win32" ? resolvedPath.toLowerCase() : resolvedPath;
 }
 
 export function pathIsWithin(root: string, candidate: string): boolean {


### PR DESCRIPTION
## Summary
- treat successful empty/whitespace psmux `list-sessions` output as an absent server while malformed non-empty rows remain fail-closed
- add strict injectable native-Windows process-incarnation identity and centralize BOM-free UTF-16LE PowerShell launch construction
- preserve multiline SDK prompt delivery behind semantic readiness and retain correlated runtime command/turn acknowledgement identities, bounded prompt-only timeouts, and Windows-canonical path identity
- preserve native tmux/POSIX behavior and managed-session psmux mutation rejection

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/tmux-owner-isolation.test.ts packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts packages/coding-agent/test/gjc-runtime/launch-tmux.test.ts packages/coding-agent/test/coordinator-mcp-server.test.ts packages/coding-agent/test/coordinator-mcp-actual-runtime-readiness.test.ts packages/coding-agent/test/session-state-sidecar.test.ts packages/coding-agent/test/sdk-host-wiring.test.ts` — 333 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — passed
- `bun run check:publish-types` — passed
- `bun --cwd=packages/utils run check` — passed
- exact-head architect review: four lanes CLEAR/APPROVE
- exact-head executor QA/red-team: passed

## Evidence boundary
Native Windows and a live psmux process were unavailable in this Linux worktree. Windows/psmux behavior is covered by deterministic injected-`win32` platform/runner tests, exact PowerShell command assertions, static architecture review, and Linux package/type checks; this PR does not claim native-Windows execution evidence.

Closes #2145

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*