### PR TITLE
fix(coding-agent): make Gajae Pet overlay cleanup deterministic and exception-safe

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Renamed the notifications SDK to the Gajae-Code SDK: `docs/notifications-sdk.md` is now `docs/sdk.md`, `src/notifications/` is now `src/sdk/bus/`, and `src/sdk.ts` is now the `src/sdk/` module directory. Old deep-import specifiers no longer resolve.
 - Moved SDK discovery from `.gjc/state/notifications/` to `.gjc/state/sdk/`. Restart sessions and daemons together when upgrading; the runtime does not dual-scan the old and new directories.
 - Removed the `--mode rpc`, `--mode rpc-ui`, and `--mode bridge` external ingress modes. Machine clients must use the SDK WebSocket interfaces documented in `docs/sdk.md`; no RPC or Bridge compatibility path remains.
+
+### Fixed
+
+- Gajae Pet overlays no longer leak images or stale pixels across lifecycle changes: each widget owns a randomized Kitty image ID (deleted on disable, replace, switch, and dispose), the previous Sixel footprint is tracked and erased on movement, resize, and narrow-terminal fallback, replaced pet widgets are disposed before their successors install, and a saved pet preference survives editor replacement while graphics are still unavailable (so a delayed Sixel capability probe can still activate it). Teardown is exception-safe and idempotent: a failed or unavailable terminal write never aborts logical disposal or steals a successor widget's overlay slot, and Sixel/Kitty cleanup authority is retained until the erase is actually delivered so a later mode switch or dispose retries it.
+
 ## [0.10.1] - 2026-07-13
 
 ### Added

--- a/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
+++ b/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
@@ -38,6 +38,35 @@ const KITTY_DROP_FRACTION = 0.45;
 const petKittyDropPx = (cellHeightPx: number): number =>
 	Math.min(Math.max(0, cellHeightPx - 1), Math.floor(cellHeightPx * KITTY_DROP_FRACTION));
 const PET_RAISE_ROWS = 1;
+const allocatedPetKittyImageIds = new Set<number>();
+
+function allocatePetKittyImageId(): number {
+	let id = 0;
+	while (id === 0 || allocatedPetKittyImageIds.has(id)) {
+		id = crypto.getRandomValues(new Uint32Array(1))[0] ?? 0;
+	}
+	allocatedPetKittyImageIds.add(id);
+	return id;
+}
+
+interface SixelFootprint {
+	x: number;
+	y: number;
+	columns: number;
+	rows: number;
+}
+
+function sameFootprint(left: SixelFootprint, right: SixelFootprint): boolean {
+	return left.x === right.x && left.y === right.y && left.columns === right.columns && left.rows === right.rows;
+}
+
+/**
+ * Which widget currently owns each TUI's single shared post-render emitter
+ * slot. A stale or repeated dispose (or off-switch) of a predecessor widget
+ * must never clear a successor's overlay authority.
+ */
+const petOverlayEmitterOwners = new WeakMap<TUI, GajaePetWidget>();
+
 /** Working animation: the shared para-para beats looped end to end. */
 const WORK_LOOP_TOTAL = PARA_PARA_STEPS.reduce((sum, [, ms]) => sum + ms, 0);
 /** Random gap between automatic claw flexes (fires while idle AND working). */
@@ -127,6 +156,13 @@ export class GajaePetWidget {
 	/** Cell metrics the current frames were built for; a change triggers a rebuild. */
 	#builtCellW = 0;
 	#builtCellH = 0;
+	#kittyImageId: number | undefined;
+	/** True while a kitty placement may exist on screen; cleared only after the delete escape is delivered. */
+	#kittyCleanupPending = false;
+	/** Last emitted Sixel raster position; retained until an erase is actually delivered. */
+	#lastSixelFootprint: SixelFootprint | undefined;
+	/** Terminal state: a disposed widget never touches the TUI or shared slots again. */
+	#disposed = false;
 
 	constructor(options: {
 		ui: TUI;
@@ -182,14 +218,19 @@ export class GajaePetWidget {
 		}
 	}
 
+	commitPreviewMode(mode: PetMode): void {
+		this.#applyMode(mode, false);
+	}
+
 	#applyMode(mode: PetMode, mountComposer: boolean): void {
-		if (mode === this.#mode) return;
+		if (this.#disposed || mode === this.#mode) return;
 
 		if (mode === "off") {
+			this.#writeImageCleanup();
 			this.#mode = "off";
 			this.#animation?.unregister();
 			this.#animation = undefined;
-			this.#ui.setPostRenderEmitter(undefined);
+			this.#releaseOverlayEmitter();
 			this.#floorContainer.clear();
 			this.#pixel = undefined;
 			this.#framedEditor.setReserve(0);
@@ -200,6 +241,7 @@ export class GajaePetWidget {
 
 		const protocol = this.#forcedProtocol ?? GajaePetWidget.pixelProtocol();
 		if (!protocol) return;
+		if (this.#mode !== "off") this.#writeImageCleanup();
 		this.#mode = mode;
 		this.#frame = "base";
 		this.#flexUntil = 0;
@@ -210,6 +252,7 @@ export class GajaePetWidget {
 		// the composer stays pinned to the terminal bottom.
 		this.#floorContainer.clear();
 		this.#ui.setPostRenderEmitter(() => this.#overlayPayload());
+		petOverlayEmitterOwners.set(this.#ui, this);
 		this.#animation ??= registerAnimationCallback(now => this.#tick(now), 80);
 		this.#ui.requestRender(true);
 	}
@@ -220,6 +263,10 @@ export class GajaePetWidget {
 		this.#builtCellW = cell.widthPx;
 		this.#builtCellH = cell.heightPx;
 		const skin: PetSkinId = this.#mode === "off" ? "red" : this.#mode;
+		if (protocol === "kitty") {
+			this.#kittyImageId ??= allocatePetKittyImageId();
+			this.#kittyCleanupPending = true;
+		}
 		this.#pixel = buildGajaePixelFrames({
 			protocol,
 			skin,
@@ -228,17 +275,43 @@ export class GajaePetWidget {
 			targetRows: 2,
 			sixelTopPaddingPx: protocol === "sixel" ? PET_SIXEL_DROP_PX : 0,
 			kittyCellYOffsetPx: protocol === "kitty" ? petKittyDropPx(cell.heightPx) : 0,
+			kittyImageId: protocol === "kitty" ? this.#kittyImageId : undefined,
 		});
 		this.#framedEditor.setReserve(this.#pixel.columns + PET_SIDE_MARGIN);
 	}
 
 	dispose(): void {
-		this.#animation?.unregister();
-		this.#animation = undefined;
-		this.#ui.setPostRenderEmitter(undefined);
-		this.#floorContainer.clear();
-		this.#framedEditor.setReserve(0);
-		this.#mountEditor(false);
+		if (this.#disposed) return;
+		this.#disposed = true;
+		try {
+			this.#writeImageCleanup();
+		} finally {
+			// Logical teardown must reach its final state even if terminal I/O fails.
+			if (this.#kittyImageId !== undefined) {
+				allocatedPetKittyImageIds.delete(this.#kittyImageId);
+				this.#kittyImageId = undefined;
+			}
+			this.#animation?.unregister();
+			this.#animation = undefined;
+			this.#releaseOverlayEmitter();
+			this.#mode = "off";
+			this.#pixel = undefined;
+			this.#floorContainer.clear();
+			this.#framedEditor.setReserve(0);
+			// Restore the plain composer only while our framed wrapper is still
+			// mounted; a successor widget may already own the editor container.
+			if (this.#editorContainer.children.includes(this.#framedEditor)) {
+				this.#mountEditor(false);
+			}
+		}
+	}
+
+	/** Clear the shared post-render slot only while this widget still owns it. */
+	#releaseOverlayEmitter(): void {
+		if (petOverlayEmitterOwners.get(this.#ui) === this) {
+			this.#ui.setPostRenderEmitter(undefined);
+			petOverlayEmitterOwners.delete(this.#ui);
+		}
 	}
 
 	#mountEditor(framed: boolean): void {
@@ -335,14 +408,50 @@ export class GajaePetWidget {
 		return { x, y };
 	}
 
-	#clearPetPayload(x: number, y: number): string {
-		const pixel = this.#pixel;
-		if (pixel?.protocol !== "sixel") return "";
+	#clearSixelFootprint(footprint: SixelFootprint): string {
 		let out = "\x1b[0m";
-		for (let row = 0; row < pixel.rasterRows; row++) {
-			out += `\x1b[${y + row + 1};${x + 1}H\x1b[${pixel.columns}X`;
+		for (let row = 0; row < footprint.rows; row++) {
+			out += `\x1b[${footprint.y + row + 1};${footprint.x + 1}H\x1b[${footprint.columns}X`;
 		}
 		return out;
+	}
+
+	/** Pending on-screen image cleanup. Pure: authority is consumed separately, on delivery. */
+	#imageCleanupPayload(): string {
+		let out = "";
+		if (this.#kittyCleanupPending && this.#kittyImageId !== undefined) {
+			out += `\x1b_Ga=d,d=I,i=${this.#kittyImageId},q=2\x1b\\`;
+		}
+		if (this.#lastSixelFootprint) {
+			out += this.#clearSixelFootprint(this.#lastSixelFootprint);
+		}
+		return out;
+	}
+
+	#consumeCleanupAuthority(): void {
+		this.#kittyCleanupPending = false;
+		this.#lastSixelFootprint = undefined;
+	}
+
+	/**
+	 * Best-effort direct erase of the on-screen pet image. Cleanup authority is
+	 * consumed only after the write is actually delivered: an unavailable
+	 * terminal or a throwing write keeps the erase pending so a later mode
+	 * switch or dispose can retry it.
+	 */
+	#writeImageCleanup(): void {
+		if (!this.#ui.terminalAvailable) return;
+		const payload = this.#imageCleanupPayload();
+		if (!payload) return;
+		try {
+			this.#ui.terminal.write(`\x1b[?2026h\x1b7${payload}\x1b8\x1b[?2026l`);
+		} catch {
+			// Keep the footprint/placement authority; the terminal write layer
+			// reports availability separately and callers retry on the next
+			// lifecycle transition.
+			return;
+		}
+		this.#consumeCleanupAuthority();
 	}
 
 	/** Draw escape payload at the pet's absolute position. */
@@ -350,10 +459,30 @@ export class GajaePetWidget {
 		const pixel = this.#pixel;
 		if (!pixel) return null;
 		const pos = this.#petPosition();
-		if (!pos) return null;
+		if (!pos) {
+			const cleanup = this.#imageCleanupPayload();
+			if (!cleanup) return null;
+			// The returned payload is written by the TUI as part of this frame;
+			// treat that delivery like our own successful write.
+			this.#consumeCleanupAuthority();
+			return cleanup;
+		}
 		const { x, y } = pos;
+		let out = "";
 
-		let out = clearPet ? this.#clearPetPayload(x, y) : "";
+		if (pixel.protocol === "sixel") {
+			const footprint = { x, y, columns: pixel.columns, rows: pixel.rasterRows };
+			if (this.#lastSixelFootprint && !sameFootprint(this.#lastSixelFootprint, footprint)) {
+				out += this.#clearSixelFootprint(this.#lastSixelFootprint);
+			}
+			if (clearPet) out += this.#clearSixelFootprint(footprint);
+			this.#lastSixelFootprint = footprint;
+		} else {
+			// A kitty frame emitted below (re)places the image, so cleanup is
+			// pending again even if a narrow-terminal pass consumed it earlier.
+			this.#kittyCleanupPending = true;
+		}
+
 		out += `\x1b[${y + 1};${x + 1}H${pixel.frames[this.#frame]}`;
 		return out;
 	}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -763,10 +763,9 @@ export class SelectorController {
 				break;
 			}
 			case "pet.mode":
-				// The settings submenu already persisted the value; apply it to the live
-				// widget via previewMode (the settings overlay is still open, so a full
-				// re-mount would tear it down — restoreComposer re-mounts on close).
-				this.ctx.previewPetMode(value as PetMode);
+				// The settings submenu already persisted the value; commit it without
+				// re-mounting the composer while the settings overlay is open.
+				this.ctx.commitPetPreviewMode(value as PetMode);
 				break;
 			case "symbolPreset": {
 				setSymbolPreset(value as "unicode" | "nerd" | "ascii").then(() => {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -617,8 +617,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.addChild(this.hookWidgetContainerBelow);
 		this.ui.setBottomPinnedComponent(this.statusLine);
 		this.ui.setFocus(this.editor);
+		this.petWidget?.dispose();
 		this.petWidget = this.#createPetWidget(this.editor);
-		this.petWidget.setMode(settings.get("pet.mode"));
+		const configuredPetMode = settings.get("pet.mode");
+		this.petWidget.setMode(configuredPetMode);
 		// The async sixel capability probe can enable graphics after the saved
 		// pet mode was applied and dropped (no protocol yet at startup).
 		// Re-apply the configured mode when capability arrives so the pet
@@ -1086,6 +1088,11 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	previewPetMode(mode: PetMode): void {
 		this.petWidget?.previewMode(mode);
+		this.ui.requestRender();
+	}
+
+	commitPetPreviewMode(mode: PetMode): void {
+		this.petWidget?.commitPreviewMode(mode);
 		this.ui.requestRender();
 	}
 
@@ -2223,7 +2230,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		nextEditor.setText(previousText);
 		previousEditor.dispose();
 
-		const petMode = this.petWidget?.mode ?? settings.get("pet.mode");
+		const petMode = settings.get("pet.mode");
 		this.petWidget?.dispose();
 
 		this.editorContainer.clear();

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -179,6 +179,8 @@ export interface InteractiveModeContext {
 	setPetMode(mode: PetMode): void;
 	/** Live-preview a pet skin during a selector without persisting. */
 	previewPetMode(mode: PetMode): void;
+	/** Commit a settings-overlay pet preview without re-mounting the composer. */
+	commitPetPreviewMode(mode: PetMode): void;
 	/** Re-mount the composer (pet-aware) after an overlay/selector closes. */
 	restoreComposer(): void;
 	startPendingSubmission(input: {

--- a/packages/coding-agent/test/gajae-pet-widget.test.ts
+++ b/packages/coding-agent/test/gajae-pet-widget.test.ts
@@ -24,19 +24,25 @@ function makeStubs(columns = 80, rows = 30) {
 		invalidate() {},
 	} as unknown as CustomEditor;
 	let emitter: (() => string | null) | undefined;
+	let available = true;
+	let failWrites = false;
+	const terminal = {
+		columns,
+		rows,
+		write: (data: string) => {
+			if (failWrites) throw new Error("injected terminal write failure");
+			written.push(data);
+		},
+	};
 	const ui = {
 		requestRender: () => {},
 		setPostRenderEmitter: (fn?: () => string | null) => {
 			emitter = fn;
 		},
-		terminalAvailable: true,
-		terminal: {
-			columns,
-			rows,
-			write: (data: string) => {
-				written.push(data);
-			},
+		get terminalAvailable() {
+			return available;
 		},
+		terminal,
 	} as unknown as TUI;
 	const editorContainer = new Container();
 	const floorContainer = new Container();
@@ -49,6 +55,16 @@ function makeStubs(columns = 80, rows = 30) {
 		written,
 		getEmitter: () => emitter,
 		getRenderedWidth: () => renderedWidth,
+		setTerminalSize: (nextColumns: number, nextRows: number) => {
+			terminal.columns = nextColumns;
+			terminal.rows = nextRows;
+		},
+		setTerminalAvailable: (value: boolean) => {
+			available = value;
+		},
+		setWriteFailure: (value: boolean) => {
+			failWrites = value;
+		},
 	};
 }
 
@@ -59,7 +75,7 @@ function makeWidget(
 		bottomOffset?: number;
 		isWorking?: () => boolean;
 		autoFlexGapMs?: [number, number] | null;
-		protocol?: "sixel" | "kitty";
+		protocol?: "sixel" | "kitty" | null;
 	} = {},
 ) {
 	const stubs = makeStubs(columns, rows);
@@ -70,7 +86,7 @@ function makeWidget(
 		floorContainer: stubs.floorContainer,
 		isWorking: options.isWorking ?? (() => false),
 		getComposerBottomOffset: () => stubs.floorContainer.render(columns).length + (options.bottomOffset ?? 0),
-		forcePixelProtocol: options.protocol ?? "sixel",
+		forcePixelProtocol: options.protocol === null ? undefined : (options.protocol ?? "sixel"),
 		autoFlexGapMs: options.autoFlexGapMs !== undefined ? options.autoFlexGapMs : null,
 	});
 	return { ...stubs, widget };
@@ -99,6 +115,201 @@ describe("GajaePetWidget", () => {
 		} finally {
 			widget.dispose();
 		}
+	});
+
+	it("owns and deletes a distinct Kitty image ID per widget", () => {
+		const first = makeWidget(80, 30, { protocol: "kitty" });
+		const second = makeWidget(80, 30, { protocol: "kitty" });
+		try {
+			first.widget.setMode("red");
+			second.widget.setMode("red");
+			const firstPayload = first.getEmitter()?.();
+			const secondPayload = second.getEmitter()?.();
+			const firstId = firstPayload?.match(/i=(\d+)/)?.[1];
+			const secondId = secondPayload?.match(/i=(\d+)/)?.[1];
+
+			expect(firstId).toBeDefined();
+			expect(secondId).toBeDefined();
+			expect(firstId).not.toBe(secondId);
+			expect(Number(firstId)).toBeGreaterThan(0);
+			expect(Number(secondId)).toBeGreaterThan(0);
+
+			first.written.length = 0;
+			first.widget.setMode("off");
+			expect(first.written.some(chunk => chunk.includes(`a=d,d=I,i=${firstId}`))).toBe(true);
+			expect(first.written.some(chunk => chunk.includes(`i=${secondId}`))).toBe(false);
+		} finally {
+			first.widget.dispose();
+			second.widget.dispose();
+		}
+	});
+
+	it("clears the last Sixel footprint when disabled", () => {
+		const { widget, written, getEmitter } = makeWidget();
+		try {
+			widget.setMode("red");
+			expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+			written.length = 0;
+
+			widget.setMode("off");
+
+			expect(written.some(chunk => chunk.includes("\x1b[28;76H\x1b[4X"))).toBe(true);
+		} finally {
+			widget.dispose();
+		}
+	});
+
+	it("clears the previous Sixel footprint after the terminal becomes too narrow", () => {
+		const { widget, getEmitter, setTerminalSize } = makeWidget();
+		try {
+			widget.setMode("red");
+			expect(getEmitter()?.()).toContain("\x1b[28;76H");
+			setTerminalSize(12, 30);
+
+			const cleanup = getEmitter()?.();
+
+			expect(cleanup).toContain("\x1b[28;76H\x1b[4X");
+			expect(cleanup).not.toContain("\x1bP0;1;0q");
+			expect(getEmitter()?.()).toBeNull();
+		} finally {
+			widget.dispose();
+		}
+	});
+
+	it("completes logical teardown when the cleanup write throws", () => {
+		const { widget, editorContainer, getEmitter, getRenderedWidth, setWriteFailure } = makeWidget();
+		widget.setMode("red");
+		expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+
+		setWriteFailure(true);
+		widget.dispose();
+
+		// The thrown write must not abort teardown: the shared emitter slot is
+		// released, the composer is unframed, and the widget is terminal.
+		expect(getEmitter()).toBeUndefined();
+		expect(widget.mode).toBe("off");
+		editorContainer.render(80);
+		expect(getRenderedWidth()).toBe(80);
+		widget.setMode("red");
+		expect(getEmitter()).toBeUndefined();
+	});
+
+	it("keeps a disposed widget from clearing its successor's overlay emitter", () => {
+		const stubs = makeStubs();
+		const make = () =>
+			new GajaePetWidget({
+				ui: stubs.ui,
+				editor: stubs.editor,
+				editorContainer: stubs.editorContainer,
+				floorContainer: stubs.floorContainer,
+				isWorking: () => false,
+				getComposerBottomOffset: () => stubs.floorContainer.render(80).length,
+				forcePixelProtocol: "sixel",
+				autoFlexGapMs: null,
+			});
+		const first = make();
+		first.setMode("red");
+		first.dispose();
+
+		const second = make();
+		try {
+			second.setMode("red");
+			const successorEmitter = stubs.getEmitter();
+			expect(successorEmitter).toBeDefined();
+
+			first.dispose();
+
+			expect(stubs.getEmitter()).toBe(successorEmitter);
+		} finally {
+			second.dispose();
+		}
+	});
+
+	it("keeps a stale first-time dispose from stealing a successor's emitter or composer mount", () => {
+		const stubs = makeStubs();
+		const make = () =>
+			new GajaePetWidget({
+				ui: stubs.ui,
+				editor: stubs.editor,
+				editorContainer: stubs.editorContainer,
+				floorContainer: stubs.floorContainer,
+				isWorking: () => false,
+				getComposerBottomOffset: () => stubs.floorContainer.render(80).length,
+				forcePixelProtocol: "sixel",
+				autoFlexGapMs: null,
+			});
+		// The predecessor is never disposed before the successor takes over.
+		const first = make();
+		first.setMode("red");
+		const second = make();
+		try {
+			second.setMode("red");
+			const successorEmitter = stubs.getEmitter();
+			expect(successorEmitter).toBeDefined();
+
+			first.dispose();
+
+			expect(stubs.getEmitter()).toBe(successorEmitter);
+			// The successor's framed composer stays mounted (editor still narrowed).
+			stubs.editorContainer.render(80);
+			expect(stubs.getRenderedWidth()).toBe(80 - 5);
+		} finally {
+			second.dispose();
+		}
+	});
+
+	it("re-arms Kitty cleanup when the pet is re-placed after a narrow-terminal pass consumed it", () => {
+		const { widget, written, getEmitter, setTerminalSize } = makeWidget(12, 30, { protocol: "kitty" });
+		try {
+			widget.setMode("red");
+			// Too narrow: the emitter returns the delete escape and consumes the
+			// pending cleanup.
+			expect(getEmitter()?.()).toContain("\x1b_Ga=d");
+			expect(getEmitter()?.()).toBeNull();
+
+			// Wide again: the next frame re-places the image.
+			setTerminalSize(80, 30);
+			expect(getEmitter()?.()).toContain("\x1b_G");
+			written.length = 0;
+
+			widget.dispose();
+
+			expect(written.some(chunk => chunk.includes("\x1b_Ga=d,d=I,i="))).toBe(true);
+		} finally {
+			widget.dispose();
+		}
+	});
+
+	it("retains Sixel cleanup authority while the terminal is unavailable and erases once it returns", () => {
+		const { widget, written, getEmitter, setTerminalAvailable } = makeWidget();
+		widget.setMode("red");
+		expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+		written.length = 0;
+
+		setTerminalAvailable(false);
+		widget.setMode("off");
+		expect(written).toHaveLength(0);
+
+		setTerminalAvailable(true);
+		widget.dispose();
+
+		expect(written.some(chunk => chunk.includes("\x1b[28;76H\x1b[4X"))).toBe(true);
+	});
+
+	it("retains Sixel cleanup authority when the erase write throws and retries on dispose", () => {
+		const { widget, written, getEmitter, setWriteFailure } = makeWidget();
+		widget.setMode("red");
+		expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+		written.length = 0;
+
+		setWriteFailure(true);
+		widget.setMode("off");
+		expect(written).toHaveLength(0);
+
+		setWriteFailure(false);
+		widget.dispose();
+
+		expect(written.some(chunk => chunk.includes("\x1b[28;76H\x1b[4X"))).toBe(true);
 	});
 
 	it("hides the overlay instead of covering editor text on a narrow terminal", () => {

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -3,9 +3,9 @@ import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { Agent } from "@gajae-code/agent-core";
 import type { AssistantMessage } from "@gajae-code/ai";
-import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
 import { initTheme, theme } from "@gajae-code/coding-agent/modes/theme/theme";
-import { CURSOR_MARKER, Text, visibleWidth } from "@gajae-code/tui";
+import { CURSOR_MARKER, ImageProtocol, setTerminalImageProtocol, TERMINAL, Text, visibleWidth } from "@gajae-code/tui";
 import { TempDir } from "@gajae-code/utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import type {
@@ -585,5 +585,50 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(mode.editor.onSubmit).toBeDefined();
 		expect(mode.editor.onEscape).toBeDefined();
 		expect(refreshSpy).toHaveBeenCalled();
+	});
+
+	it("preserves a pending pet mode across editor replacement", () => {
+		const originalProtocol = TERMINAL.imageProtocol;
+		vi.spyOn(mode, "refreshSlashCommandState").mockResolvedValue();
+		try {
+			setTerminalImageProtocol(null);
+			settings.set("pet.mode", "red");
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+			expect(mode.petWidget?.mode).toBe("off");
+
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+			expect(mode.petWidget?.mode).toBe("off");
+
+			expect(settings.get("pet.mode")).toBe("red");
+			setTerminalImageProtocol(ImageProtocol.Sixel);
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+			expect(mode.petWidget?.mode).toBe("red");
+		} finally {
+			setTerminalImageProtocol(originalProtocol);
+		}
+	});
+
+	it("disposes a pre-init pet widget before init replaces it", async () => {
+		const originalProtocol = TERMINAL.imageProtocol;
+		vi.spyOn(mode, "refreshSlashCommandState").mockResolvedValue();
+		try {
+			setTerminalImageProtocol(null);
+			settings.set("pet.mode", "red");
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+			const preInitWidget = mode.petWidget;
+			if (!preInitWidget) throw new Error("Expected pre-init pet widget");
+			const dispose = vi.spyOn(preInitWidget, "dispose");
+
+			await mode.init();
+
+			expect(dispose).toHaveBeenCalledTimes(1);
+			expect(mode.petWidget).not.toBe(preInitWidget);
+			expect(mode.petWidget?.mode).toBe("off");
+
+			setTerminalImageProtocol(ImageProtocol.Sixel);
+			expect(mode.petWidget?.mode).toBe("red");
+		} finally {
+			setTerminalImageProtocol(originalProtocol);
+		}
 	});
 });


### PR DESCRIPTION
## What

Make Gajae Pet overlay cleanup deterministic **and exception-safe**. Fresh PR replacing #2134 per policy, rebased onto current `dev` (`d9c86aa6`), with every blocking finding from the #2134 REQUEST_CHANGES review addressed.

Original lifecycle fixes (unchanged from #2134):

- Widget-owned randomized Kitty image IDs (deleted on disable, replace, switch, dispose) instead of a shared predictable ID.
- Previous Sixel footprint tracked and erased on movement, resize, and narrow-terminal fallback.
- Replaced pet widgets disposed before successors install; editor replacement reads the pet mode from settings so a saved preference survives while graphics are unavailable (delayed Windows Sixel probe can still activate it).
- Settings-overlay pet changes commit via `commitPetPreviewMode` without re-mounting the composer.

### Review blockers addressed

**1. Thrown cleanup write no longer aborts logical teardown.** `dispose()` performs the image cleanup in `try` and completes animation unregistration, emitter release, mode/pixel terminalization, editor restore, and image-ID release in `finally`. `#writeImageCleanup` additionally never throws: a failing `terminal.write` is caught and only skips the authority consumption.

**2. Disposal is terminal, idempotent, and ownership-checked.** `#disposed` makes repeated disposal a no-op and rejects later `setMode` calls. The shared TUI post-render emitter slot is tracked in a per-TUI `WeakMap` owner registry, so **both** a repeated dispose **and** a stale first-time dispose after a successor installs leave the successor's emitter untouched. The composer is restored to the plain editor only while this widget's framed wrapper is still mounted, so a stale dispose cannot steal the successor's composer mount either. Disposed widgets terminalize `mode`/pixel state.

**3. Cleanup authority is consumed only on delivery.** `#imageCleanupPayload()` is now pure; `#lastSixelFootprint` and the Kitty pending-delete flag are consumed only after the erase write actually succeeds (or is emitted inside a TUI-rendered frame). An unavailable terminal or a thrown write retains the authority, and the next mode switch or dispose retries the erase. A Kitty re-placement after a narrow-terminal cleanup re-arms the pending delete so dispose still deletes the image.

## Why

Reproductions on `dev` before this patch:

1. Kitty terminal, `/pet RedGajae`, replace the editor — the old widget's image is never deleted and the shared predictable image ID lets one widget delete another's image.
2. Sixel terminal, `/pet RedGajae`, resize/narrow the terminal — the previous raster stays painted because only the current footprint was known.
3. Delayed Sixel probe (Windows Terminal): editor replacement persisted the widget's transient `off`, permanently losing the saved preference.
4. (Review harness) an injected `terminal.write` failure during `dispose()` escaped and left the animation registrant and shared emitter live; a repeated stale dispose cleared the successor's emitter; consuming the Sixel footprint while the terminal was unavailable made the stale raster permanently unremovable.

## Testing

- `bun test packages/coding-agent/test/gajae-pet-widget.test.ts` — **24 pass, 0 fail**, including new regression tests for: thrown-write teardown completion, repeated stale disposal vs a successor emitter, **stale first-time disposal** vs a successor emitter and composer mount, unavailable→available Sixel erase retry, thrown-write erase retry, and Kitty cleanup re-arming after a narrow-terminal pass.
- `bun test packages/coding-agent/test/interactive-mode-editor-component.test.ts` — new assertions pass (saved-preference preservation, pre-init widget disposal). Local Windows note: the file's `afterEach` temp-dir removal hits a pre-existing `EBUSY` on clean `dev` identically; Linux CI is authoritative (it was green for this file on #2134).
- `bun --cwd=packages/coding-agent run check` (biome + SDK canonicalization + tsc) — green.
- Root gates run locally: check:tools, publish-types, node20-baseline, public-sync, schemas, plugins, docker-context, gjc-ui + rebrand strict, all workspace checks — green. `check:sdk-closure` cannot run on this machine (no Rust toolchain for the new SDK natives; the same test fails identically on clean `dev` here) — CI is authoritative and this diff touches no SDK files.
- `git diff --check` — clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
