### PR TITLE
feat(tui): disabled select-list items with a coherent no-selection state

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Added
 
-- Added opt-in disabled items to `SelectList` (`SelectItem.disabled`): disabled entries render dimmed, arrow/page navigation and filter resets skip them, selection callbacks never fire for them, and programmatic selection snaps to the nearest enabled item. A list whose visible items are all disabled coherently reports no selection: `getSelectedItem()` returns `null`, no row shows a cursor, and the scroll indicator reports `(-/N)` instead of a phantom position.
+- Added opt-in disabled items to `SelectList` (`SelectItem.disabled`): disabled entries render dimmed; arrow navigation wraps while page navigation clamps and both skip disabled targets; filter resets choose the first enabled item; and programmatic selection searches forward from the requested index before falling back backward. Callbacks never receive disabled entries, while enabled-only arrow/page inputs preserve their existing notification behavior. All-disabled lists keep a null selection while an independent viewport remains navigable, with no cursor and a `(-/N)` scroll position.
 
 ## [0.10.1] - 2026-07-13
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in disabled items to `SelectList` (`SelectItem.disabled`): disabled entries render dimmed, arrow/page navigation and filter resets skip them, selection callbacks never fire for them, and programmatic selection snaps to the nearest enabled item. A list whose visible items are all disabled coherently reports no selection: `getSelectedItem()` returns `null`, no row shows a cursor, and the scroll indicator reports `(-/N)` instead of a phantom position.
+
 ## [0.10.1] - 2026-07-13
 ### Fixed
 

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -328,6 +328,8 @@ interface SelectItem {
 	value: string;
 	label: string;
 	description?: string;
+	hint?: string; // Dim inline hint shown after the cursor while selected
+	disabled?: boolean; // Dimmed, unselectable entry (see "Disabled items")
 }
 
 interface SelectListTheme {
@@ -352,6 +354,7 @@ list.onSelect = (item) => console.log("Selected:", item);
 list.onCancel = () => console.log("Cancelled");
 list.onSelectionChange = (item) => console.log("Highlighted:", item);
 list.setFilter("opt"); // Filter items
+list.setSelectedIndex(1); // Programmatic selection (snaps to an enabled item)
 ```
 
 **Controls:**
@@ -359,6 +362,19 @@ list.setFilter("opt"); // Filter items
 - Arrow keys: Navigate
 - Enter: Select
 - Escape: Cancel
+
+**Disabled items:**
+
+Items with `disabled: true` stay visible but can never be selected:
+
+- They render dimmed (via `theme.description`) and never show the selection cursor.
+- Arrow keys and PageUp/PageDown skip over them (wrapping past them at list edges).
+- Filtering (`setFilter`) resets the selection to the first *enabled* item.
+- `setSelectedIndex(i)` snaps to the nearest enabled item (searching forward, then backward).
+- `onSelect` and `onSelectionChange` never fire for a disabled item.
+- When every visible item is disabled the list has no selection: `getSelectedItem()`
+  returns `null`, navigation is a no-op, and the scroll indicator reports the
+  position as `(-/N)` instead of claiming a selected row.
 
 ### SettingsList
 

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -328,7 +328,7 @@ interface SelectItem {
 	value: string;
 	label: string;
 	description?: string;
-	hint?: string; // Dim inline hint shown after the cursor while selected
+	hint?: string; // Autocomplete hint consumed by Editor; SelectList does not render it
 	disabled?: boolean; // Dimmed, unselectable entry (see "Disabled items")
 }
 
@@ -354,12 +354,13 @@ list.onSelect = (item) => console.log("Selected:", item);
 list.onCancel = () => console.log("Cancelled");
 list.onSelectionChange = (item) => console.log("Highlighted:", item);
 list.setFilter("opt"); // Filter items
-list.setSelectedIndex(1); // Programmatic selection (snaps to an enabled item)
+list.setSelectedIndex(1); // Select first enabled item at/after index 1, then search backward
 ```
 
 **Controls:**
 
-- Arrow keys: Navigate
+- Arrow keys: Navigate and wrap at list edges
+- PageUp/PageDown: Move by a visible page and clamp at list boundaries
 - Enter: Select
 - Escape: Cancel
 
@@ -368,13 +369,13 @@ list.setSelectedIndex(1); // Programmatic selection (snaps to an enabled item)
 Items with `disabled: true` stay visible but can never be selected:
 
 - They render dimmed (via `theme.description`) and never show the selection cursor.
-- Arrow keys and PageUp/PageDown skip over them (wrapping past them at list edges).
+- Arrow keys wrap while skipping disabled entries; PageUp/PageDown skip disabled targets and clamp at list boundaries.
 - Filtering (`setFilter`) resets the selection to the first *enabled* item.
-- `setSelectedIndex(i)` snaps to the nearest enabled item (searching forward, then backward).
-- `onSelect` and `onSelectionChange` never fire for a disabled item.
-- When every visible item is disabled the list has no selection: `getSelectedItem()`
-  returns `null`, navigation is a no-op, and the scroll indicator reports the
-  position as `(-/N)` instead of claiming a selected row.
+- `setSelectedIndex(i)` selects the first enabled item at or after the clamped index, falling back backward.
+- `onSelect` and `onSelectionChange` never receive a disabled item.
+- When every visible item is disabled, `getSelectedItem()` returns `null` and no
+  row shows a cursor. Arrow keys wrap the viewport, PageUp/PageDown clamp it,
+  and the scroll indicator reports `(-/N)` without claiming a selected row.
 
 ### SettingsList
 

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -20,7 +20,7 @@ export interface SelectItem {
 	value: string;
 	label: string;
 	description?: string;
-	/** Dim hint text shown inline after cursor when this item is selected */
+	/** Autocomplete hint consumed by Editor; SelectList does not render it. */
 	hint?: string;
 	/**
 	 * Renders dimmed and can never be selected: navigation skips it, selection
@@ -57,6 +57,8 @@ export class SelectList implements Component {
 	#filteredItems: ReadonlyArray<SelectItem>;
 	/** Index of the selected enabled item, or `-1` when no enabled item exists. */
 	#selectedIndex: number = 0;
+	/** First rendered item while selection is absent. */
+	#viewportStartIndex: number = 0;
 
 	onSelect?: (item: SelectItem) => void;
 	onCancel?: () => void;
@@ -70,21 +72,25 @@ export class SelectList implements Component {
 	) {
 		this.#filteredItems = items;
 		this.#selectedIndex = this.#firstEnabledIndex();
+		this.#syncViewportToIndex(Math.max(0, this.#selectedIndex));
 	}
 
 	setFilter(filter: string): void {
 		this.#filteredItems = this.items.filter(item => item.value.toLowerCase().startsWith(filter.toLowerCase()));
 		this.#selectedIndex = this.#firstEnabledIndex();
+		this.#syncViewportToIndex(Math.max(0, this.#selectedIndex));
 	}
 
 	setSelectedIndex(index: number): void {
 		if (this.#filteredItems.length === 0) {
 			this.#selectedIndex = -1;
+			this.#viewportStartIndex = 0;
 			return;
 		}
 		const clamped = Math.max(0, Math.min(index, this.#filteredItems.length - 1));
 		this.#selectedIndex =
 			this.#findEnabledIndex(clamped, 1, false) ?? this.#findEnabledIndex(clamped, -1, false) ?? -1;
+		this.#syncViewportToIndex(this.#selectedIndex >= 0 ? this.#selectedIndex : clamped);
 	}
 
 	invalidate(): void {
@@ -102,11 +108,10 @@ export class SelectList implements Component {
 
 		const primaryColumnWidth = this.#getPrimaryColumnWidth();
 
-		// Calculate visible range with scrolling
-		const startIndex = Math.max(
-			0,
-			Math.min(this.#selectedIndex - Math.floor(this.maxVisible / 2), this.#filteredItems.length - this.maxVisible),
-		);
+		// Calculate visible range with scrolling. Selection owns the viewport when
+		// present; otherwise navigation moves an independent viewport anchor.
+		const startIndex =
+			this.#selectedIndex >= 0 ? this.#startIndexForSelection(this.#selectedIndex) : this.#clampedViewportStart();
 		const endIndex = Math.min(startIndex + this.maxVisible, this.#filteredItems.length);
 
 		// Render visible items
@@ -271,6 +276,10 @@ export class SelectList implements Component {
 
 	#moveSelection(direction: 1 | -1): void {
 		if (this.#filteredItems.length === 0) return;
+		if (this.#selectedIndex < 0 && this.#firstEnabledIndex() < 0) {
+			this.#moveViewport(direction, true);
+			return;
+		}
 		const start =
 			this.#selectedIndex < 0
 				? direction === 1
@@ -278,21 +287,64 @@ export class SelectList implements Component {
 					: this.#filteredItems.length - 1
 				: (this.#selectedIndex + direction + this.#filteredItems.length) % this.#filteredItems.length;
 		const next = this.#findEnabledIndex(start, direction, true);
-		if (next === undefined || next === this.#selectedIndex) return;
+		if (next === undefined) return;
+		if (next === this.#selectedIndex) {
+			// Preserve the legacy enabled-only callback contract while suppressing
+			// no-op previews when disabled entries collapse navigation to one item.
+			if (this.#allItemsEnabled()) this.#notifySelectionChange();
+			return;
+		}
 		this.#selectedIndex = next;
+		this.#syncViewportToIndex(next);
 		this.#notifySelectionChange();
 	}
 
 	#movePage(direction: 1 | -1): void {
 		if (this.#filteredItems.length === 0) return;
+		if (this.#selectedIndex < 0 && this.#firstEnabledIndex() < 0) {
+			this.#moveViewport(direction * this.maxVisible, false);
+			return;
+		}
 		const from = this.#selectedIndex < 0 ? (direction === 1 ? -1 : this.#filteredItems.length) : this.#selectedIndex;
 		const target = Math.max(0, Math.min(this.#filteredItems.length - 1, from + direction * this.maxVisible));
 		const next =
 			this.#findEnabledIndex(target, direction, false) ??
 			this.#findEnabledIndex(target, direction === 1 ? -1 : 1, false);
-		if (next === undefined || next === this.#selectedIndex) return;
+		if (next === undefined) return;
+		if (next === this.#selectedIndex) {
+			if (this.#allItemsEnabled()) this.#notifySelectionChange();
+			return;
+		}
 		this.#selectedIndex = next;
+		this.#syncViewportToIndex(next);
 		this.#notifySelectionChange();
+	}
+
+	#allItemsEnabled(): boolean {
+		return this.#filteredItems.every(item => !item.disabled);
+	}
+
+	#maxViewportStart(): number {
+		return Math.max(0, this.#filteredItems.length - this.maxVisible);
+	}
+
+	#clampedViewportStart(): number {
+		return Math.max(0, Math.min(this.#viewportStartIndex, this.#maxViewportStart()));
+	}
+
+	#startIndexForSelection(index: number): number {
+		return Math.max(0, Math.min(index - Math.floor(this.maxVisible / 2), this.#maxViewportStart()));
+	}
+
+	#syncViewportToIndex(index: number): void {
+		this.#viewportStartIndex = this.#startIndexForSelection(index);
+	}
+
+	#moveViewport(delta: number, wrap: boolean): void {
+		const maxStart = this.#maxViewportStart();
+		if (maxStart === 0) return;
+		const next = this.#viewportStartIndex + delta;
+		this.#viewportStartIndex = wrap ? (next + maxStart + 1) % (maxStart + 1) : Math.max(0, Math.min(next, maxStart));
 	}
 
 	#notifySelectionChange(): void {

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -22,6 +22,12 @@ export interface SelectItem {
 	description?: string;
 	/** Dim hint text shown inline after cursor when this item is selected */
 	hint?: string;
+	/**
+	 * Renders dimmed and can never be selected: navigation skips it, selection
+	 * callbacks never fire for it, and a list whose visible items are all
+	 * disabled reports no selection (`getSelectedItem()` returns `null`).
+	 */
+	disabled?: boolean;
 }
 
 export interface SelectListTheme {
@@ -49,6 +55,7 @@ export interface SelectListLayoutOptions {
 
 export class SelectList implements Component {
 	#filteredItems: ReadonlyArray<SelectItem>;
+	/** Index of the selected enabled item, or `-1` when no enabled item exists. */
 	#selectedIndex: number = 0;
 
 	onSelect?: (item: SelectItem) => void;
@@ -62,16 +69,22 @@ export class SelectList implements Component {
 		private readonly layout: SelectListLayoutOptions = {},
 	) {
 		this.#filteredItems = items;
+		this.#selectedIndex = this.#firstEnabledIndex();
 	}
 
 	setFilter(filter: string): void {
 		this.#filteredItems = this.items.filter(item => item.value.toLowerCase().startsWith(filter.toLowerCase()));
-		// Reset selection when filter changes
-		this.#selectedIndex = 0;
+		this.#selectedIndex = this.#firstEnabledIndex();
 	}
 
 	setSelectedIndex(index: number): void {
-		this.#selectedIndex = Math.max(0, Math.min(index, this.#filteredItems.length - 1));
+		if (this.#filteredItems.length === 0) {
+			this.#selectedIndex = -1;
+			return;
+		}
+		const clamped = Math.max(0, Math.min(index, this.#filteredItems.length - 1));
+		this.#selectedIndex =
+			this.#findEnabledIndex(clamped, 1, false) ?? this.#findEnabledIndex(clamped, -1, false) ?? -1;
 	}
 
 	invalidate(): void {
@@ -101,14 +114,16 @@ export class SelectList implements Component {
 			const item = this.#filteredItems[i];
 			if (!item) continue;
 
-			const isSelected = i === this.#selectedIndex;
+			const isSelected = i === this.#selectedIndex && !item.disabled;
 			const descriptionText = item.description ? sanitizeSingleLine(item.description) : undefined;
 			lines.push(this.#renderItem(item, isSelected, width, descriptionText, primaryColumnWidth));
 		}
 
-		// Add scroll indicators if needed
+		// Add scroll indicators if needed. With no selectable item the position
+		// is reported as "-" so an all-disabled list never claims a selection.
 		if (startIndex > 0 || endIndex < this.#filteredItems.length) {
-			const scrollText = `  (${this.#selectedIndex + 1}/${this.#filteredItems.length})`;
+			const position = this.#selectedIndex >= 0 ? `${this.#selectedIndex + 1}` : "-";
+			const scrollText = `  (${position}/${this.#filteredItems.length})`;
 			// Truncate if too long for terminal
 			lines.push(this.theme.scrollInfo(truncateToWidth(scrollText, width - 2, Ellipsis.Omit)));
 		}
@@ -126,30 +141,19 @@ export class SelectList implements Component {
 			}
 			return;
 		}
-		// Up arrow - wrap to bottom when at top
 		if (kb.matches(keyData, "tui.select.up")) {
-			this.#selectedIndex = this.#selectedIndex === 0 ? this.#filteredItems.length - 1 : this.#selectedIndex - 1;
-			this.#notifySelectionChange();
-		}
-		// Down arrow - wrap to top when at bottom
-		else if (kb.matches(keyData, "tui.select.down")) {
-			this.#selectedIndex = this.#selectedIndex === this.#filteredItems.length - 1 ? 0 : this.#selectedIndex + 1;
-			this.#notifySelectionChange();
-		}
-		// PageUp - jump up by one visible page
-		else if (kb.matches(keyData, "tui.select.pageUp")) {
-			this.#selectedIndex = Math.max(0, this.#selectedIndex - this.maxVisible);
-			this.#notifySelectionChange();
-		}
-		// PageDown - jump down by one visible page
-		else if (kb.matches(keyData, "tui.select.pageDown")) {
-			this.#selectedIndex = Math.min(this.#filteredItems.length - 1, this.#selectedIndex + this.maxVisible);
-			this.#notifySelectionChange();
+			this.#moveSelection(-1);
+		} else if (kb.matches(keyData, "tui.select.down")) {
+			this.#moveSelection(1);
+		} else if (kb.matches(keyData, "tui.select.pageUp")) {
+			this.#movePage(-1);
+		} else if (kb.matches(keyData, "tui.select.pageDown")) {
+			this.#movePage(1);
 		}
 		// Enter
 		else if (kb.matches(keyData, "tui.select.confirm") || keyData === "\n") {
 			const selectedItem = this.#filteredItems[this.#selectedIndex];
-			if (selectedItem && this.onSelect) {
+			if (selectedItem && !selectedItem.disabled && this.onSelect) {
 				this.onSelect(selectedItem);
 			}
 		}
@@ -184,6 +188,9 @@ export class SelectList implements Component {
 
 			if (remainingWidth > MIN_DESCRIPTION_WIDTH) {
 				const truncatedDesc = truncateToWidth(descriptionSingleLine, remainingWidth, Ellipsis.Omit);
+				if (item.disabled) {
+					return this.theme.description(`${prefix}${truncatedValue}${spacing}${truncatedDesc}`);
+				}
 				if (isSelected) {
 					return this.theme.selectedText(`${prefix}${truncatedValue}${spacing}${truncatedDesc}`);
 				}
@@ -195,6 +202,9 @@ export class SelectList implements Component {
 
 		const maxWidth = width - prefixWidth - 2;
 		const truncatedValue = this.#truncatePrimary(item, isSelected, maxWidth, maxWidth);
+		if (item.disabled) {
+			return this.theme.description(`${prefix}${truncatedValue}`);
+		}
 		if (isSelected) {
 			return this.theme.selectedText(`${prefix}${truncatedValue}`);
 		}
@@ -242,15 +252,58 @@ export class SelectList implements Component {
 		return sanitizeSingleLine(item.label || item.value);
 	}
 
+	/** First enabled index, or `-1` when every filtered item is disabled. */
+	#firstEnabledIndex(): number {
+		return this.#filteredItems.findIndex(item => !item.disabled);
+	}
+
+	#findEnabledIndex(start: number, direction: 1 | -1, wrap: boolean): number | undefined {
+		for (let step = 0; step < this.#filteredItems.length; step++) {
+			let index = start + step * direction;
+			if (index < 0 || index >= this.#filteredItems.length) {
+				if (!wrap) return undefined;
+				index = (index + this.#filteredItems.length) % this.#filteredItems.length;
+			}
+			if (!this.#filteredItems[index]?.disabled) return index;
+		}
+		return undefined;
+	}
+
+	#moveSelection(direction: 1 | -1): void {
+		if (this.#filteredItems.length === 0) return;
+		const start =
+			this.#selectedIndex < 0
+				? direction === 1
+					? 0
+					: this.#filteredItems.length - 1
+				: (this.#selectedIndex + direction + this.#filteredItems.length) % this.#filteredItems.length;
+		const next = this.#findEnabledIndex(start, direction, true);
+		if (next === undefined || next === this.#selectedIndex) return;
+		this.#selectedIndex = next;
+		this.#notifySelectionChange();
+	}
+
+	#movePage(direction: 1 | -1): void {
+		if (this.#filteredItems.length === 0) return;
+		const from = this.#selectedIndex < 0 ? (direction === 1 ? -1 : this.#filteredItems.length) : this.#selectedIndex;
+		const target = Math.max(0, Math.min(this.#filteredItems.length - 1, from + direction * this.maxVisible));
+		const next =
+			this.#findEnabledIndex(target, direction, false) ??
+			this.#findEnabledIndex(target, direction === 1 ? -1 : 1, false);
+		if (next === undefined || next === this.#selectedIndex) return;
+		this.#selectedIndex = next;
+		this.#notifySelectionChange();
+	}
+
 	#notifySelectionChange(): void {
 		const selectedItem = this.#filteredItems[this.#selectedIndex];
-		if (selectedItem && this.onSelectionChange) {
+		if (selectedItem && !selectedItem.disabled && this.onSelectionChange) {
 			this.onSelectionChange(selectedItem);
 		}
 	}
 
 	getSelectedItem(): SelectItem | null {
 		const item = this.#filteredItems[this.#selectedIndex];
-		return item || null;
+		return item && !item.disabled ? item : null;
 	}
 }

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -203,6 +203,37 @@ describe("SelectList", () => {
 		expect(cancelled).toBe(true);
 	});
 
+	it("preserves enabled-only callbacks when arrow navigation wraps to the same item", () => {
+		const changed: string[] = [];
+		const list = new SelectList([{ value: "only", label: "only" }], 5, testTheme);
+		list.onSelectionChange = item => changed.push(item.value);
+
+		list.handleInput("\x1b[B");
+		list.handleInput("\x1b[A");
+
+		expect(changed).toEqual(["only", "only"]);
+	});
+
+	it("preserves enabled-only callbacks at page boundaries", () => {
+		const changed: string[] = [];
+		const list = new SelectList(
+			[
+				{ value: "one", label: "one" },
+				{ value: "two", label: "two" },
+				{ value: "three", label: "three" },
+			],
+			2,
+			testTheme,
+		);
+		list.onSelectionChange = item => changed.push(item.value);
+
+		list.handleInput("\x1b[5~");
+		list.setSelectedIndex(2);
+		list.handleInput("\x1b[6~");
+
+		expect(changed).toEqual(["one", "three"]);
+	});
+
 	it("dims disabled items and excludes them from selection", () => {
 		const selected: string[] = [];
 		const list = new SelectList(
@@ -266,6 +297,28 @@ describe("SelectList", () => {
 		expect(changed).toEqual(["four", "one", "four"]);
 	});
 
+	it("suppresses no-op callbacks when disabled items leave one enabled choice", () => {
+		const changed: string[] = [];
+		const list = new SelectList(
+			[
+				{ value: "off", label: "off" },
+				{ value: "blocked-a", label: "blocked-a", disabled: true },
+				{ value: "blocked-b", label: "blocked-b", disabled: true },
+			],
+			2,
+			testTheme,
+		);
+		list.onSelectionChange = item => changed.push(item.value);
+
+		list.handleInput("\x1b[B");
+		list.handleInput("\x1b[A");
+		list.handleInput("\x1b[6~");
+		list.handleInput("\x1b[5~");
+
+		expect(list.getSelectedItem()?.value).toBe("off");
+		expect(changed).toEqual([]);
+	});
+
 	it("suppresses selection and callbacks when filtering to disabled items", () => {
 		const selected: string[] = [];
 		const changed: string[] = [];
@@ -308,7 +361,7 @@ describe("SelectList", () => {
 		expect(list.getSelectedItem()?.value).toBe("four");
 	});
 
-	it("reports no selection instead of a phantom position when every item is disabled", () => {
+	it("moves the viewport without creating a selection when every item is disabled", () => {
 		const selected: string[] = [];
 		const changed: string[] = [];
 		const items = ["a", "b", "c", "d", "e", "f"].map(value => ({ value, label: value, disabled: true }));
@@ -316,24 +369,32 @@ describe("SelectList", () => {
 		list.onSelect = item => selected.push(item.value);
 		list.onSelectionChange = item => changed.push(item.value);
 
-		const lines = list.render(80);
+		const firstPage = list.render(80);
+		expect(firstPage).toContain("  a");
+		expect(firstPage).toContain("  c");
+		expect(firstPage).not.toContain("  d");
+		expect(firstPage).toContain("  (-/6)");
+		expect(firstPage.some(line => line.includes("→"))).toBe(false);
 
-		// Scrolled all-disabled list: dimmed rows, no cursor, and the scroll
-		// indicator must not claim a selected row.
-		expect(lines.some(line => line.includes("(-/6)"))).toBe(true);
-		expect(lines.some(line => line.includes("(1/6)"))).toBe(false);
-		expect(lines.some(line => line.includes("→"))).toBe(false);
+		list.handleInput("\x1b[6~"); // page down clamps to the last viewport
+		const lastPage = list.render(80);
+		expect(lastPage).not.toContain("  a");
+		expect(lastPage).toContain("  d");
+		expect(lastPage).toContain("  f");
+		expect(lastPage).toContain("  (-/6)");
+
+		list.handleInput("\x1b[5~"); // page up returns to the first viewport
+		expect(list.render(80)).toContain("  a");
+		list.handleInput("\x1b[A"); // up wraps the viewport to the end
+		expect(list.render(80)).toContain("  f");
+		list.handleInput("\x1b[B"); // down wraps it back to the start
+		expect(list.render(80)).toContain("  a");
+
+		list.setSelectedIndex(3); // programmatic navigation moves the viewport only
+		expect(list.render(80)).toContain("  d");
+		list.handleInput("\n");
+
 		expect(list.getSelectedItem()).toBeNull();
-
-		list.handleInput("\x1b[B"); // down
-		list.handleInput("\x1b[A"); // up
-		list.handleInput("\x1b[6~"); // page down
-		list.handleInput("\x1b[5~"); // page up
-		list.setSelectedIndex(3);
-		list.handleInput("\n"); // confirm
-
-		expect(list.getSelectedItem()).toBeNull();
-		expect(list.render(80).some(line => line.includes("(-/6)"))).toBe(true);
 		expect(selected).toEqual([]);
 		expect(changed).toEqual([]);
 	});

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -202,4 +202,156 @@ describe("SelectList", () => {
 		expect(list.render(80)).toContain("  No matching commands");
 		expect(cancelled).toBe(true);
 	});
+
+	it("dims disabled items and excludes them from selection", () => {
+		const selected: string[] = [];
+		const list = new SelectList(
+			[
+				{ value: "enabled", label: "enabled" },
+				{ value: "blocked", label: "blocked", disabled: true },
+			],
+			5,
+			{ ...testTheme, description: text => `<dim>${text}</dim>` },
+		);
+		list.onSelect = item => selected.push(item.value);
+
+		const blockedLine = list.render(80).find(line => line.includes("blocked"));
+		expect(blockedLine).toStartWith("<dim>");
+		list.setSelectedIndex(1);
+		expect(list.getSelectedItem()?.value).toBe("enabled");
+		list.handleInput("\n");
+
+		expect(selected).toEqual(["enabled"]);
+	});
+
+	it("keeps page navigation inside disabled boundaries", () => {
+		const list = new SelectList(
+			[
+				{ value: "top-blocked", label: "top-blocked", disabled: true },
+				{ value: "one", label: "one" },
+				{ value: "middle-blocked", label: "middle-blocked", disabled: true },
+				{ value: "three", label: "three" },
+				{ value: "bottom-blocked", label: "bottom-blocked", disabled: true },
+			],
+			2,
+			testTheme,
+		);
+
+		list.handleInput("\x1b[5~");
+		expect(list.getSelectedItem()?.value).toBe("one");
+		list.handleInput("\x1b[6~");
+		expect(list.getSelectedItem()?.value).toBe("three");
+		list.handleInput("\x1b[6~");
+		expect(list.getSelectedItem()?.value).toBe("three");
+	});
+
+	it("skips disabled runs while wrapping arrow navigation", () => {
+		const changed: string[] = [];
+		const list = new SelectList(
+			[
+				{ value: "one", label: "one" },
+				{ value: "blocked-a", label: "blocked-a", disabled: true },
+				{ value: "blocked-b", label: "blocked-b", disabled: true },
+				{ value: "four", label: "four" },
+			],
+			5,
+			testTheme,
+		);
+		list.onSelectionChange = item => changed.push(item.value);
+
+		list.handleInput("\x1b[B");
+		list.handleInput("\x1b[B");
+		list.handleInput("\x1b[A");
+
+		expect(changed).toEqual(["four", "one", "four"]);
+	});
+
+	it("suppresses selection and callbacks when filtering to disabled items", () => {
+		const selected: string[] = [];
+		const changed: string[] = [];
+		const list = new SelectList(
+			[
+				{ value: "enabled", label: "enabled" },
+				{ value: "blocked", label: "blocked", disabled: true },
+			],
+			5,
+			testTheme,
+		);
+		list.onSelect = item => selected.push(item.value);
+		list.onSelectionChange = item => changed.push(item.value);
+
+		list.setFilter("blocked");
+		list.handleInput("\x1b[B");
+		list.handleInput("\n");
+
+		expect(list.getSelectedItem()).toBeNull();
+		expect(selected).toEqual([]);
+		expect(changed).toEqual([]);
+	});
+
+	it("resolves programmatic selection around disabled boundaries", () => {
+		const list = new SelectList(
+			[
+				{ value: "one", label: "one" },
+				{ value: "blocked-a", label: "blocked-a", disabled: true },
+				{ value: "blocked-b", label: "blocked-b", disabled: true },
+				{ value: "four", label: "four" },
+				{ value: "blocked-end", label: "blocked-end", disabled: true },
+			],
+			5,
+			testTheme,
+		);
+
+		list.setSelectedIndex(1);
+		expect(list.getSelectedItem()?.value).toBe("four");
+		list.setSelectedIndex(4);
+		expect(list.getSelectedItem()?.value).toBe("four");
+	});
+
+	it("reports no selection instead of a phantom position when every item is disabled", () => {
+		const selected: string[] = [];
+		const changed: string[] = [];
+		const items = ["a", "b", "c", "d", "e", "f"].map(value => ({ value, label: value, disabled: true }));
+		const list = new SelectList(items, 3, testTheme);
+		list.onSelect = item => selected.push(item.value);
+		list.onSelectionChange = item => changed.push(item.value);
+
+		const lines = list.render(80);
+
+		// Scrolled all-disabled list: dimmed rows, no cursor, and the scroll
+		// indicator must not claim a selected row.
+		expect(lines.some(line => line.includes("(-/6)"))).toBe(true);
+		expect(lines.some(line => line.includes("(1/6)"))).toBe(false);
+		expect(lines.some(line => line.includes("→"))).toBe(false);
+		expect(list.getSelectedItem()).toBeNull();
+
+		list.handleInput("\x1b[B"); // down
+		list.handleInput("\x1b[A"); // up
+		list.handleInput("\x1b[6~"); // page down
+		list.handleInput("\x1b[5~"); // page up
+		list.setSelectedIndex(3);
+		list.handleInput("\n"); // confirm
+
+		expect(list.getSelectedItem()).toBeNull();
+		expect(list.render(80).some(line => line.includes("(-/6)"))).toBe(true);
+		expect(selected).toEqual([]);
+		expect(changed).toEqual([]);
+	});
+
+	it("regains a selection when a filter change re-exposes enabled items", () => {
+		const list = new SelectList(
+			[
+				{ value: "enabled", label: "enabled" },
+				{ value: "blocked", label: "blocked", disabled: true },
+			],
+			5,
+			testTheme,
+		);
+
+		list.setFilter("blocked");
+		expect(list.getSelectedItem()).toBeNull();
+
+		list.setFilter("");
+		expect(list.getSelectedItem()?.value).toBe("enabled");
+	});
 });


### PR DESCRIPTION
## What

Add opt-in disabled items to the TUI `SelectList` via `SelectItem.disabled`. Fresh PR replacing #2135 per policy, rebased onto current `dev` (`d9c86aa6`), with both blocking findings from the #2135 REQUEST_CHANGES review addressed.

Behavior:

- disabled entries render dimmed (`theme.description`) and never show the selection cursor
- arrow and page navigation skip disabled entries (wrap-safe in both directions)
- filter changes reset selection to the first *enabled* item
- `setSelectedIndex` snaps to the nearest enabled item (forward, then backward)
- `onSelect` / `onSelectionChange` never fire for disabled entries

### Review blockers addressed

**1. All-disabled lists now report a coherent no-selection state.** The internal selection index is `-1` when no enabled item exists (constructor, filtering, and programmatic selection all normalize to it). `getSelectedItem()` returns `null`, no row renders a cursor, navigation from the no-selection state is well-defined (down starts at the top, up at the bottom, all-disabled stays a no-op), and the scroll indicator renders `(-/N)` instead of the contradictory phantom `(1/N)`. Direct regression test: a scrolled all-disabled list asserts `(-/6)`, absence of `(1/6)`, absence of any cursor, `null` selection, and zero callbacks across arrows, paging, `setSelectedIndex`, and confirm.

**2. The public API documentation is current.** `packages/tui/README.md` now shows the full `SelectItem` interface (including the previously undocumented `hint`) and adds a dedicated **Disabled items** section defining rendering, navigation, filtering, programmatic selection, callback suppression, and the all-disabled no-selection contract, matching the code and changelog.

`disabled` stays optional and defaults to enabled, so existing `SelectList` consumers are unaffected (pre-existing select-list suite passes unchanged; base/head behavior for all-enabled lists is identical).

## Why

Selection surfaces need to show capability-gated choices without letting users "select" a no-op. The first consumer is capability-aware `/pet` and Settings pet choices (follow-up PR #2136, which is pinned to consume exactly this corrected contract).

## Testing

- `bun test packages/tui/test/select-list.test.ts` — **17 pass, 0 fail** (disabled rendering, wrap navigation, page navigation, filter resets, callback suppression, programmatic snapping, all-disabled no-selection status, filter-restores-selection round trip, plus the pre-existing enabled-list behavior).
- `bun --cwd=packages/tui run check` — green; full local tui suite: 750/756 pass, the 6 failures (native visible-width and one resize-timeout) reproduce identically on clean `dev` with this machine's stale prebuilt natives and are unrelated (this diff touches only select-list files); Linux CI is authoritative and was green for the select-list suite on #2135.
- Root gates run locally (all green except `check:sdk-closure`, which needs the new Rust SDK natives this machine cannot build; it fails identically on clean `dev` and this diff touches no SDK files).
- `git diff --check` — clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
