### PR TITLE
fix(tui): share stdout error listener

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Shared the temporary stdout error listener across terminal instances, preventing `MaxListenersExceededWarning` during repeated TUI start/stop cycles while retaining late detached-PTY error handling.
 
 ## [0.10.1] - 2026-07-13
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -171,6 +171,20 @@ function isWindowsSubsystemForLinux(): boolean {
 	return process.platform === "linux" && (!!$env.WSL_DISTRO_NAME || !!$env.WSL_INTEROP);
 }
 const STDOUT_ERROR_HANDLER_GRACE_MS = 250;
+const stdoutErrorSubscribers = new Set<(err: Error) => void>();
+const dispatchStdoutError = (err: Error): void => {
+	for (const subscriber of stdoutErrorSubscribers) subscriber(err);
+};
+
+function subscribeToStdoutErrors(subscriber: (err: Error) => void): void {
+	if (stdoutErrorSubscribers.size === 0) process.stdout.on("error", dispatchStdoutError);
+	stdoutErrorSubscribers.add(subscriber);
+}
+
+function unsubscribeFromStdoutErrors(subscriber: (err: Error) => void): void {
+	stdoutErrorSubscribers.delete(subscriber);
+	if (stdoutErrorSubscribers.size === 0) process.stdout.removeListener("error", dispatchStdoutError);
+}
 
 /**
  * Real terminal using process.stdin/stdout
@@ -250,7 +264,7 @@ export class ProcessTerminal implements Terminal {
 			this.#stdoutErrorHandler = (err: Error) => {
 				this.#markUnavailable(err, "stdout-error");
 			};
-			process.stdout.on("error", this.#stdoutErrorHandler);
+			subscribeToStdoutErrors(this.#stdoutErrorHandler);
 		}
 
 		// Refresh terminal dimensions - they may be stale after suspend/resume
@@ -743,7 +757,7 @@ export class ProcessTerminal implements Terminal {
 		// of surfacing as uncaught exceptions that kill the tmux pane.
 		this.#stdoutErrorHandlerCleanupTimer = setTimeout(() => {
 			if (this.#stdoutErrorHandler) {
-				process.stdout.removeListener("error", this.#stdoutErrorHandler);
+				unsubscribeFromStdoutErrors(this.#stdoutErrorHandler);
 				this.#stdoutErrorHandler = undefined;
 			}
 			this.#stdoutErrorHandlerCleanupTimer = undefined;

--- a/packages/tui/test/terminal-detach.test.ts
+++ b/packages/tui/test/terminal-detach.test.ts
@@ -214,6 +214,38 @@ describe("terminal detach handling", () => {
 			pauseSpy.mockRestore();
 		}
 	});
+	it("shares one stdout error listener across terminals during cleanup grace periods", async () => {
+		const terminals = Array.from({ length: 12 }, () => new ProcessTerminal());
+		const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const resumeSpy = vi.spyOn(process.stdin, "resume").mockImplementation(() => process.stdin);
+		const pauseSpy = vi.spyOn(process.stdin, "pause").mockImplementation(() => process.stdin);
+		await Bun.sleep(300);
+		const beforeListeners = process.stdout.listenerCount("error");
+
+		try {
+			withStdoutProperty("isTTY", true, () => {
+				for (const terminal of terminals) {
+					terminal.start(
+						() => {},
+						() => {},
+					);
+					terminal.stop();
+				}
+				expect(process.stdout.listenerCount("error")).toBe(beforeListeners + 1);
+				expect(() => {
+					process.stdout.emit("error", Object.assign(new Error("shared detached stdout"), { code: "EIO" }));
+				}).not.toThrow();
+				expect(terminals.every(terminal => !terminal.available)).toBe(true);
+			});
+			await Bun.sleep(300);
+			expect(process.stdout.listenerCount("error")).toBe(beforeListeners);
+		} finally {
+			for (const terminal of terminals) terminal.stop();
+			writeSpy.mockRestore();
+			resumeSpy.mockRestore();
+			pauseSpy.mockRestore();
+		}
+	});
 
 	it("marks ProcessTerminal unavailable when stdout is already closed", () => {
 		const terminal = new ProcessTerminal();


### PR DESCRIPTION
## Summary
- share one process stdout error listener across active and grace-period terminal instances
- preserve late EIO/EPIPE handling after terminal shutdown
- add regression coverage for repeated TUI start/stop cycles without listener warnings

## Verification
- `bun run ci:test:smoke`
- `bun --cwd=packages/tui run check`
- `bun --cwd=packages/tui run test` (750 passed, 0 failed)