### PR TITLE
fix(coding-agent): reap orphaned background processes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Preserved clipboard image attachments when the interactive editor clears the composer before dispatching the submit callback, so Alt+V image placeholders still send their image blocks instead of placeholder-only text (#2126).
 - Extension contexts now receive a defensive copy from `getSystemPrompt()` instead of the live mutable system-prompt array, so an in-place mutation by an in-process extension can no longer bypass context-revision tracking and serve stale display-only context-usage estimates.
 - Completed bracketed-paste input now returns a manually paged transcript to live output before the paste is dispatched, including asynchronous consumed and unconsumed paste paths.
+- Prevented orphaned background processes by reaping failed detached harness owners and their SDK session children with bounded TERM/KILL verification, making isolated ACP wire tests own and stop their exact SDK broker before deleting temporary state, and adding a cooperative Telegram daemon watchdog that stops superseded or non-progressing owners.
 
 ## [0.10.0] - 2026-07-12
 

--- a/packages/coding-agent/src/commands/harness.ts
+++ b/packages/coding-agent/src/commands/harness.ts
@@ -545,6 +545,8 @@ interface OwnerSpawnResult {
 	socketKey: string | null;
 	fallbackReason: string | null;
 	blockerReason: string | null;
+	/** Exact-PID reap proof for a direct detached-owner child declared not-live (no orphan). */
+	detachedOwnerReaped?: { pid: number; verified: boolean } | null;
 }
 
 function shellQuote(value: string): string {
@@ -867,6 +869,38 @@ export default class Harness extends Command {
 			await new Promise(r => setTimeout(r, 50));
 		}
 		return false;
+	}
+	/**
+	 * Reap an exact detached-owner child the parent spawned but declared not-live. The parent
+	 * owns this PID's lifecycle (it spawned it), so shutdown is exact-owner scoped: SIGTERM, a
+	 * bounded grace wait, then SIGKILL, then verify the SAME PID exited via its exit promise.
+	 * Never name-based — the spawned Subprocess pins the exact owner identity, so a not-live
+	 * declaration must not orphan a daemon the parent brought into being.
+	 */
+	async #reapDetachedOwner(
+		child: Bun.Subprocess<"ignore", "ignore", "ignore">,
+	): Promise<{ pid: number; verified: boolean }> {
+		// A resolved exit promise proves the PID is gone; a rejection is NOT proof of exit (it may
+		// surface an error observing the subprocess), so map it to false and let the SIGKILL
+		// escalation + cleanup-uncertain surfacing handle the uncertainty.
+		const exited = child.exited.then(
+			() => true,
+			() => false,
+		);
+		const send = (signal: NodeJS.Signals): void => {
+			try {
+				child.kill(signal);
+			} catch {
+				// Kill may fail if the child already exited; the exited race below is authoritative.
+			}
+		};
+		send("SIGTERM");
+		let verified = await Promise.race([exited, Bun.sleep(2000).then(() => false)]);
+		if (!verified) {
+			send("SIGKILL");
+			verified = await Promise.race([exited, Bun.sleep(1000).then(() => false)]);
+		}
+		return { pid: child.pid, verified };
 	}
 
 	async #harnessOwnerIsolationProbe(tmuxCommand: string): Promise<OwnerIsolationProbe> {
@@ -1235,6 +1269,7 @@ export default class Harness extends Command {
 		});
 		child.unref();
 		const live = await this.#waitForOwner(root, sessionId);
+		const detachedOwnerReaped = live ? null : await this.#reapDetachedOwner(child);
 		return {
 			live,
 			runtime: "detached",
@@ -1242,6 +1277,7 @@ export default class Harness extends Command {
 			socketKey: null,
 			fallbackReason,
 			blockerReason: live ? null : "detached-owner-not-live",
+			...(detachedOwnerReaped ? { detachedOwnerReaped } : {}),
 		};
 	}
 
@@ -1311,6 +1347,7 @@ export default class Harness extends Command {
 		let ownerFallbackReason: string | null = null;
 		let ownerBlockerReason: string | null = null;
 		let ownerSocketKey: string | null = null;
+		let ownerDetachedReaped: { pid: number; verified: boolean } | null = null;
 		if (input.detach === true) {
 			const ownerSpawn = await this.#spawnDetachedOwner(root, sessionId, workspace);
 			ownerLive = ownerSpawn.live;
@@ -1318,6 +1355,7 @@ export default class Harness extends Command {
 			ownerFallbackReason = ownerSpawn.fallbackReason;
 			ownerBlockerReason = ownerSpawn.blockerReason;
 			ownerSocketKey = ownerSpawn.socketKey;
+			ownerDetachedReaped = ownerSpawn.detachedOwnerReaped ?? null;
 			handle.viewportHandle = {
 				kind: "event-monitor",
 				tmuxSessionName: ownerSpawn.tmuxSessionName,
@@ -1342,7 +1380,13 @@ export default class Harness extends Command {
 		// A live endpoint never proves a failed tmux launch safe: preserve the isolation/provenance blocker.
 		if (ownerBlockerReason) {
 			state.lifecycle = "blocked";
-			state.blockers = [...state.blockers, ownerBlockerReason];
+			// `detached-owner-not-live` is the lifecycle status; an unverified reap (the exact
+			// spawned child never confirmed exit after SIGKILL) is a stronger, distinct signal that
+			// must not be masked by the not-live blocker alone.
+			const ownerBlockers = [ownerBlockerReason];
+			if (ownerDetachedReaped && !ownerDetachedReaped.verified)
+				ownerBlockers.push("detached-owner-cleanup-uncertain");
+			state.blockers = [...state.blockers, ...ownerBlockers];
 			state.handle = handle;
 			state.updatedAt = nowIso();
 			await writeSessionState(root, state);
@@ -1358,6 +1402,7 @@ export default class Harness extends Command {
 					...(ownerSocketKey ? { tmuxOwnerSocketKey: ownerSocketKey } : {}),
 					...(ownerFallbackReason ? { ownerFallbackReason } : {}),
 					...(ownerBlockerReason ? { reason: ownerBlockerReason } : {}),
+					...(ownerDetachedReaped ? { detachedOwnerReaped: ownerDetachedReaped } : {}),
 				},
 				!ownerBlockerReason,
 			),

--- a/packages/coding-agent/src/harness-control-plane/owner.ts
+++ b/packages/coding-agent/src/harness-control-plane/owner.ts
@@ -651,7 +651,9 @@ export class RuntimeOwner {
 			this.#heartbeatTimer = null;
 		}
 		await this.#server.close().catch(() => {});
-		await this.#opts.transport.close().catch(() => {});
+		await this.#opts.transport.close().catch(async error => {
+			await this.#emit("critical", "owner_transport_stop_failed", { error: String(error) }).catch(() => {});
+		});
 		await releaseLease(this.#opts.root, this.#opts.sessionId, this.ownerId).catch(() => {});
 	}
 }

--- a/packages/coding-agent/src/harness-control-plane/sdk-transport.ts
+++ b/packages/coding-agent/src/harness-control-plane/sdk-transport.ts
@@ -5,6 +5,8 @@ import type { HarnessSessionTransport, SessionStateSnapshot } from "./session-tr
 
 const DISCOVERY_TIMEOUT_MS = 10_000;
 const DISCOVERY_POLL_MS = 50;
+const TERM_GRACE_MS = 2_000;
+const KILL_VERIFY_MS = 1_000;
 
 export class HarnessSdkTransportError extends Error {
 	constructor(
@@ -18,7 +20,7 @@ export class HarnessSdkTransportError extends Error {
 }
 
 export interface SpawnedHarnessSession {
-	kill(signal?: NodeJS.Signals): void;
+	stop(): Promise<void>;
 }
 
 export interface CreateSdkSessionTransportOptions {
@@ -140,14 +142,29 @@ export async function createSdkSessionTransport(
 		endpoint = await readEndpoint(options.repo, options.sessionId);
 	}
 	if (!endpoint) {
-		child?.kill("SIGTERM");
+		// Await child stop so a discovery failure never orphans the spawned session;
+		// a stop rejection propagates rather than being swallowed.
+		await child?.stop();
 		throw new HarnessSdkTransportError(
 			"endpoint_unavailable",
 			`SDK endpoint for harness session ${options.sessionId} did not appear within ${timeoutMs}ms.`,
 		);
 	}
 
-	const client = await (options.connect ?? SdkClient.connect)(endpoint.url, endpoint.token);
+	let client: SdkClient;
+	try {
+		client = await (options.connect ?? SdkClient.connect)(endpoint.url, endpoint.token);
+	} catch (error) {
+		try {
+			await child?.stop();
+		} catch (cleanupError) {
+			throw new AggregateError(
+				[error, cleanupError],
+				"SDK connection and spawned harness child cleanup both failed.",
+			);
+		}
+		throw error;
+	}
 	let cursor = 0;
 	let lastFrameAt: string | null = null;
 	let live = true;
@@ -177,7 +194,23 @@ export async function createSdkSessionTransport(
 			for (const listener of frames) listener(normalized);
 		}
 	};
-	await replay();
+	try {
+		await replay();
+	} catch (error) {
+		const failures: unknown[] = [error];
+		try {
+			await client.close();
+		} catch (cleanupError) {
+			failures.push(cleanupError);
+		}
+		try {
+			await child?.stop();
+		} catch (cleanupError) {
+			failures.push(cleanupError);
+		}
+		if (failures.length > 1) throw new AggregateError(failures, "SDK replay and harness child cleanup failed.");
+		throw error;
+	}
 
 	return {
 		async getState(): Promise<SessionStateSnapshot> {
@@ -227,13 +260,55 @@ export async function createSdkSessionTransport(
 		},
 		async close(): Promise<void> {
 			live = false;
-			await client.close();
-			child?.kill("SIGTERM");
+			try {
+				await client.close();
+			} finally {
+				// Await child stop so close never orphans the spawned session.
+				await child?.stop();
+			}
 		},
 	};
 }
 
-export function spawnNormalHarnessSession(repo: string, sessionId: string): SpawnedHarnessSession {
+interface ReapableChild {
+	kill(signal?: number | NodeJS.Signals): void;
+	readonly exited: Promise<number>;
+}
+
+/**
+ * Stop an exact spawned child: SIGTERM with bounded grace, SIGKILL escalation, then
+ * authoritative `child.exited` verification. A rejected exit promise is NOT proof of exit,
+ * so it maps to not-yet-exited and lets the SIGKILL escalation handle the uncertainty.
+ * Failure to verify exit after SIGKILL throws — the caller must not assume the child died.
+ */
+async function reapChild(child: ReapableChild, termGraceMs: number, killVerifyMs: number): Promise<void> {
+	const exited = child.exited.then(
+		() => true,
+		() => false,
+	);
+	const send = (signal: NodeJS.Signals): void => {
+		try {
+			child.kill(signal);
+		} catch {
+			// Kill may fail if the child already exited; the exited race below is authoritative.
+		}
+	};
+	send("SIGTERM");
+	let verified = await Promise.race([exited, Bun.sleep(termGraceMs).then(() => false)]);
+	if (!verified) {
+		send("SIGKILL");
+		verified = await Promise.race([exited, Bun.sleep(killVerifyMs).then(() => false)]);
+	}
+	if (!verified) {
+		throw new HarnessSdkTransportError("endpoint_unavailable", "Harness child session did not exit after SIGKILL.");
+	}
+}
+
+export function spawnNormalHarnessSession(
+	repo: string,
+	sessionId: string,
+	options: { termGraceMs?: number; killVerifyMs?: number } = {},
+): SpawnedHarnessSession {
 	const entry = process.argv[1];
 	if (process.env.GJC_SDK_DISABLE === "1") {
 		throw new HarnessSdkTransportError(
@@ -254,5 +329,9 @@ export function spawnNormalHarnessSession(repo: string, sessionId: string): Spaw
 		stderr: "ignore",
 	});
 	child.unref();
-	return { kill: signal => child.kill(signal) };
+	const termGraceMs = options.termGraceMs ?? TERM_GRACE_MS;
+	const killVerifyMs = options.killVerifyMs ?? KILL_VERIFY_MS;
+	return {
+		stop: () => reapChild(child, termGraceMs, killVerifyMs),
+	};
 }

--- a/packages/coding-agent/src/sdk/broker/ensure.ts
+++ b/packages/coding-agent/src/sdk/broker/ensure.ts
@@ -1,14 +1,56 @@
-import { spawn } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import { type BrokerDiscovery, readBrokerDiscovery } from "./discovery";
 import { resolveSdkInternalSpawnCommand } from "./runtime";
 export interface EnsureBrokerSettings {
 	agentDir: string;
 	heartbeatTtlMs?: number;
+	/**
+	 * Environment for the spawned detached broker. Defaults to `process.env`; tests
+	 * that pre-start an isolated broker pass the same sanitized child env so the
+	 * broker and the child that attaches to it share one owned root.
+	 */
+	env?: NodeJS.ProcessEnv;
 }
 
 const DISCOVERY_TIMEOUT_MS = 10_000;
+// Bounded grace windows for reaping a spawned broker on failure, mirroring the
+// owned-process teardown convention (SIGTERM -> grace -> SIGKILL -> hard cap).
+const REAP_GRACEFUL_MS = 2_000;
+const REAP_SIGKILL_CAP_MS = 2_000;
 const owners = new Map<string, { stop: () => Promise<void> }>();
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Terminate and reap a detached broker this process spawned, targeting the exact
+ * owned {@link ChildProcess} (never by name). SIGTERM escalates to SIGKILL after
+ * a bounded grace window; a child still alive after SIGKILL is surfaced rather
+ * than silently orphaned. Reaping is idempotent once the child has exited.
+ */
+async function reapSpawnedBroker(child: ChildProcess): Promise<void> {
+	const awaitExit = (): Promise<boolean> => {
+		const { promise, resolve } = Promise.withResolvers<boolean>();
+		if (child.exitCode !== null || child.signalCode !== null) resolve(true);
+		else {
+			child.once("exit", () => resolve(true));
+			child.once("error", () => resolve(true));
+		}
+		return promise;
+	};
+	const signal = (sig: NodeJS.Signals): void => {
+		try {
+			child.kill(sig);
+		} catch {
+			// already exited between the liveness check and the kill
+		}
+	};
+	signal("SIGTERM");
+	if (await Promise.race([awaitExit(), sleep(REAP_GRACEFUL_MS).then(() => false)])) return;
+	signal("SIGKILL");
+	if (await Promise.race([awaitExit(), sleep(REAP_SIGKILL_CAP_MS).then(() => false)])) return;
+	// SIGKILL is uninterruptible; a child still alive past this bounded wait is a
+	// kernel-level stuck state. Surface it rather than silently orphaning the spawn.
+	throw new Error(`Detached SDK broker (pid ${child.pid}) did not exit after SIGKILL during reap.`);
+}
 
 /** Starts the detached broker entrypoint when discovery has no live owner. */
 export async function ensureBroker(settings: EnsureBrokerSettings): Promise<BrokerDiscovery> {
@@ -18,23 +60,46 @@ export async function ensureBroker(settings: EnsureBrokerSettings): Promise<Brok
 	const child = spawn(command.file, [...command.args, "--agent-dir", settings.agentDir], {
 		detached: true,
 		stdio: "ignore",
-		env: process.env,
+		env: settings.env ?? process.env,
 	});
 	child.unref();
-	owners.set(settings.agentDir, {
-		stop: async () => {
-			try {
-				child.kill("SIGTERM");
-			} catch {}
-			owners.delete(settings.agentDir);
-		},
+	let spawnError: Error | undefined;
+	child.once("error", error => {
+		spawnError = error;
 	});
+	const stop = async (): Promise<void> => {
+		await reapSpawnedBroker(child);
+		owners.delete(settings.agentDir);
+	};
+	owners.set(settings.agentDir, { stop });
 	const deadline = Date.now() + DISCOVERY_TIMEOUT_MS;
+	let discoveryError: unknown;
 	while (Date.now() < deadline) {
-		const discovered = await readBrokerDiscovery(settings.agentDir, settings.heartbeatTtlMs);
-		if (discovered) return discovered;
+		// Fail fast: if the spawn failed or the child already exited, discovery can
+		// never succeed — stop (a no-op once dead) and surface the failure instead
+		// of running out the discovery timeout with an orphaned child.
+		if (spawnError || child.exitCode !== null || child.signalCode !== null) break;
+		try {
+			const discovered = await readBrokerDiscovery(settings.agentDir, settings.heartbeatTtlMs);
+			if (discovered) return discovered;
+		} catch (error) {
+			// A transient read failure (e.g. a half-written record) must not orphan the
+			// child; remember it and keep polling. It is surfaced if discovery fails.
+			discoveryError = error;
+		}
 		await sleep(50);
 	}
+	// Discovery failed (timeout, early child exit, spawn error, or unreadable
+	// discovery): the spawned broker never became reachable. Terminate and reap it
+	// so the failure cannot leave a detached orphan behind, then surface why.
+	const exitedBeforeDiscovery = child.exitCode !== null || child.signalCode !== null;
+	await stop();
+	if (spawnError) throw new Error(`Failed to spawn detached SDK broker: ${spawnError.message}`);
+	if (exitedBeforeDiscovery)
+		throw new Error(
+			`Detached SDK broker exited before discovery (code=${child.exitCode}, signal=${child.signalCode}).`,
+		);
+	if (discoveryError) throw discoveryError;
 	throw new Error("Timed out waiting for detached SDK broker discovery.");
 }
 /** Test hook: returns a stop handle for the detached broker this process spawned. */

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts
@@ -4,8 +4,8 @@ import { YAML } from "bun";
 import { withFileLock } from "../../config/file-lock";
 import type { Settings } from "../../config/settings";
 import { getNotificationConfig, isTelegramConfigured } from "./config";
-import { daemonPaths } from "./daemon-paths";
-import type { TelegramDaemonOptions } from "./telegram-daemon";
+import { daemonPaths, HEARTBEAT_TTL_MS } from "./daemon-paths";
+import type { DaemonState, TelegramDaemonOptions } from "./telegram-daemon";
 
 type TelegramDaemonRunner = {
 	run(): Promise<void>;
@@ -21,7 +21,18 @@ export interface RunDaemonInternalDeps {
 	DaemonImpl?: TelegramDaemonConstructor;
 	processPid?: number;
 	pidAlive?: (pid: number) => boolean;
+	/** Clock used by the ownership-progress watchdog; defaults to `Date.now`. */
+	now?: () => number;
+	/** Timer pair backing the ownership-progress watchdog; defaults to the globals. */
+	setInterval?: (callback: () => void, ms: number) => Timer;
+	clearInterval?: (timer: Timer) => void;
+	/** Reads persisted daemon ownership state; defaults to the real reader. */
+	readDaemonState?: (settings: Settings) => Promise<DaemonState | undefined>;
 }
+
+/** Ownership-watchdog cadence: re-check daemon state this often while running. */
+const OWNER_WATCHDOG_INTERVAL_MS = 5_000;
+const OWNER_STALL_MS = 3 * HEARTBEAT_TTL_MS;
 
 function argValue(argv: string[], name: string): string | undefined {
 	const i = argv.indexOf(name);
@@ -207,8 +218,10 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 	const cfg = getNotificationConfig(settings as Settings);
 	if (!isTelegramConfigured(cfg)) return;
 	const { clearTelegramControlRequest, readTelegramControlRequest } = await import("./telegram-daemon-control");
-	const Daemon: TelegramDaemonConstructor =
-		deps.DaemonImpl ?? (await import("./telegram-daemon")).TelegramNotificationDaemon;
+	const telegramDaemonModule =
+		!deps.DaemonImpl || !deps.readDaemonState ? await import("./telegram-daemon") : undefined;
+	const Daemon: TelegramDaemonConstructor = deps.DaemonImpl ?? telegramDaemonModule!.TelegramNotificationDaemon;
+	const readState = deps.readDaemonState ?? telegramDaemonModule!.readDaemonState;
 	const daemon = new Daemon({
 		settings: settings as Settings,
 		ownerId,
@@ -234,14 +247,53 @@ export async function runDaemonInternal(argv: string[], deps: RunDaemonInternalD
 			},
 		},
 	});
-	// Signals are a process concern: install them at the daemon-internal boundary,
-	// not inside the embeddable daemon class. SIGTERM is the reload wakeup path.
+	// Signals and the ownership watchdog are process concerns: keep them at the
+	// daemon-internal boundary rather than in the shared embeddable daemon.
 	const onSignal = (): void => daemon.requestStop("signal");
+	const now = deps.now ?? Date.now;
+	const schedule = deps.setInterval ?? setInterval;
+	const unschedule = deps.clearInterval ?? clearInterval;
+	let watchdogActive = true;
+	let watchdogTickInFlight = false;
+	let stopRequested = false;
+	let lastHeartbeatAt: number | undefined;
+	let stalledSince: number | undefined;
+	const watchdogTick = async (): Promise<void> => {
+		if (!watchdogActive || watchdogTickInFlight || stopRequested) return;
+		watchdogTickInFlight = true;
+		try {
+			const state = await readState(settings as Settings);
+			if (!watchdogActive || !state) return;
+			if (state.ownerId !== ownerId) {
+				stopRequested = true;
+				daemon.requestStop("stop");
+				return;
+			}
+			if (lastHeartbeatAt === undefined || state.heartbeatAt !== lastHeartbeatAt) {
+				lastHeartbeatAt = state.heartbeatAt;
+				stalledSince = now();
+				return;
+			}
+			stalledSince ??= now();
+			if (now() - stalledSince >= OWNER_STALL_MS) {
+				stopRequested = true;
+				daemon.requestStop("stop");
+			}
+		} catch {
+			// Missing, malformed, or temporarily unreadable state is ambiguous. Only
+			// positive supersession or observed heartbeat non-progress can stop.
+		} finally {
+			watchdogTickInFlight = false;
+		}
+	};
+	const watchdog = schedule(() => void watchdogTick(), OWNER_WATCHDOG_INTERVAL_MS);
 	process.once("SIGTERM", onSignal);
 	process.once("SIGINT", onSignal);
 	try {
 		await daemon.run();
 	} finally {
+		watchdogActive = false;
+		unschedule(watchdog);
 		process.off("SIGTERM", onSignal);
 		process.off("SIGINT", onSignal);
 	}

--- a/packages/coding-agent/test/acp-session-delete-wire.test.ts
+++ b/packages/coding-agent/test/acp-session-delete-wire.test.ts
@@ -30,6 +30,7 @@ import {
 	type RequestPermissionResponse,
 	type SessionNotification,
 } from "@agentclientprotocol/sdk";
+import { brokerOwnerForTest, ensureBroker } from "../src/sdk/broker/ensure";
 
 /** Minimal host→client callback impl for the SDK callbacks. */
 class OracleClient implements Client {
@@ -116,6 +117,11 @@ afterEach(async () => {
 		await teardown(oracle);
 	}
 	for (const root of cleanupRoots.splice(0)) {
+		// The broker is pre-started and owned by THIS test process for `<root>/agent`,
+		// so stop it through the exact owner handle (verified ChildProcess reap) BEFORE
+		// removing the owned root — including the failure path where `spawnOracle`
+		// threw after the pre-start but before `activeOracle` was assigned.
+		await brokerOwnerForTest(path.join(root, "agent"))?.stop();
 		await fs.promises.rm(root, { recursive: true, force: true });
 	}
 });
@@ -181,6 +187,13 @@ async function spawnOracle(): Promise<Oracle> {
 
 	const workspace = path.join(root, "workspace");
 	await fs.promises.mkdir(workspace, { recursive: true });
+
+	// Pre-start the isolated broker in THIS test process (tracked by the SDK owner
+	// map) with the same sanitized child env, so the ACP subprocess only attaches
+	// to it via discovery and never spawns — and is never orphaned — a detached
+	// broker of its own. The owned directories above already exist, so the broker
+	// can publish discovery as soon as it is ready.
+	await ensureBroker({ agentDir: path.join(root, "agent"), env });
 
 	const proc = Bun.spawn(["bun", "packages/coding-agent/src/cli.ts", "--mode", "acp", "--no-extensions"], {
 		cwd: repoRoot,

--- a/packages/coding-agent/test/harness-control-plane/owner.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/owner.test.ts
@@ -22,6 +22,7 @@ class FakeTransport implements HarnessSessionTransport {
 	ack = true;
 	accept = true;
 	agentStarts: number[] = [];
+	closeError: Error | null = null;
 	async getState(): Promise<SessionStateSnapshot> {
 		return this.state;
 	}
@@ -39,7 +40,9 @@ class FakeTransport implements HarnessSessionTransport {
 		const found = this.agentStarts.find(c => c > afterCursor);
 		return found === undefined ? null : { cursor: found };
 	}
-	async close(): Promise<void> {}
+	async close(): Promise<void> {
+		if (this.closeError) throw this.closeError;
+	}
 }
 
 let root: string;
@@ -295,6 +298,21 @@ describe("RuntimeOwner (in-process integration)", () => {
 			after = await resolveOwner(root, SID);
 		}
 		expect(after.live).toBe(false);
+	});
+	it("records transport stop failure before releasing the owner lease", async () => {
+		const transport = new FakeTransport();
+		transport.closeError = new Error("child did not exit after SIGKILL");
+		owner = new RuntimeOwner({ root, sessionId: SID, transport, acceptanceTimeoutMs: 200 });
+		await owner.start();
+
+		await owner.stop();
+		owner = null;
+
+		const events = await readEvents(root, SID, 0);
+		const failure = events.find(event => event.kind === "owner_transport_stop_failed");
+		expect(failure?.severity).toBe("critical");
+		expect(failure?.evidence.error).toContain("child did not exit after SIGKILL");
+		expect((await resolveOwner(root, SID)).live).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/harness-control-plane/sdk-transport.test.ts
+++ b/packages/coding-agent/test/harness-control-plane/sdk-transport.test.ts
@@ -123,3 +123,83 @@ describe("SDK harness transport response validation", () => {
 		await expect(sdkTransport.sendPrompt("hello")).resolves.toEqual({ commandId: "command-id", ack: true });
 	});
 });
+describe("SDK harness child lifecycle", () => {
+	it("awaits spawned-child cleanup before reporting discovery failure", async () => {
+		const releaseStop = Promise.withResolvers<void>();
+		let stopStarted = false;
+		let settled = false;
+		const pending = createSdkSessionTransport({
+			repo: "/repo",
+			sessionId: "missing",
+			discoveryTimeoutMs: 0,
+			readEndpoint: async () => null,
+			spawn: () => ({
+				async stop() {
+					stopStarted = true;
+					await releaseStop.promise;
+				},
+			}),
+		});
+		const outcome = pending.then(
+			() => undefined,
+			error => error,
+		);
+		void outcome.then(() => {
+			settled = true;
+		});
+
+		await Bun.sleep(0);
+		expect(stopStarted).toBe(true);
+		expect(settled).toBe(false);
+		releaseStop.resolve();
+		const error = await outcome;
+		expect(error).toMatchObject({ name: "HarnessSdkTransportError", code: "endpoint_unavailable" });
+	});
+
+	it("awaits spawned-child cleanup when the connected transport closes", async () => {
+		responses = validResponses();
+		const releaseStop = Promise.withResolvers<void>();
+		let endpointReads = 0;
+		let stopStarted = false;
+		const sdkTransport = await createSdkSessionTransport({
+			repo: "/repo",
+			sessionId: "session",
+			discoveryTimeoutMs: 1_000,
+			readEndpoint: async () => (endpointReads++ === 0 ? null : { url: "ws://sdk.test", token: "token" }),
+			spawn: () => ({
+				async stop() {
+					stopStarted = true;
+					await releaseStop.promise;
+				},
+			}),
+			connect: async () => client as unknown as SdkClient,
+		});
+		let closed = false;
+		const close = sdkTransport.close().then(() => {
+			closed = true;
+		});
+
+		await Bun.sleep(0);
+		expect(stopStarted).toBe(true);
+		expect(closed).toBe(false);
+		releaseStop.resolve();
+		await close;
+		expect(closed).toBe(true);
+	});
+
+	it("surfaces spawned-child cleanup failure instead of hiding an orphan", async () => {
+		const pending = createSdkSessionTransport({
+			repo: "/repo",
+			sessionId: "missing",
+			discoveryTimeoutMs: 0,
+			readEndpoint: async () => null,
+			spawn: () => ({
+				async stop() {
+					throw new Error("exact child did not exit");
+				},
+			}),
+		});
+
+		await expect(pending).rejects.toThrow("exact child did not exit");
+	});
+});

--- a/packages/coding-agent/test/harness-tmux-owner.test.ts
+++ b/packages/coding-agent/test/harness-tmux-owner.test.ts
@@ -153,6 +153,28 @@ async function runHarness(
 	return JSON.parse(output) as Record<string, unknown>;
 }
 
+const LEASE_EXIT_TIMEOUT_MS = 5_000;
+
+/**
+ * Bounded, exact-PID exit wait for a lease owner the test signalled. Returns true once `pid`
+ * is confirmed gone (ESRCH on signal-0), false on timeout. The pid is not a child of this
+ * process (the owner was detached and reparented), so there is no local zombie to reap — the
+ * kernel/init reaps it on exit and signal-0 then reports ESRCH.
+ */
+async function waitForExactExit(pid: number, timeoutMs: number): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			process.kill(pid, 0);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ESRCH") return true;
+			throw error;
+		}
+		await Bun.sleep(25);
+	}
+	return false;
+}
+
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), "harness-tmux-owner-"));
 	workspace = await mkdtemp(path.join(tmpdir(), "harness-tmux-workspace-"));
@@ -164,14 +186,23 @@ afterEach(async () => {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
 		throw error;
 	});
+	let leaseExitFailed: number | null = null;
 	if (lease?.pid) {
 		try {
 			process.kill(lease.pid, "SIGTERM");
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
 		}
+		// Bounded exact lease-PID exit wait: a live detached owner must tear down (and signal its
+		// descendants) before we delete the roots. A timeout is a real leak — fail loudly and
+		// PRESERVE the roots for inspection instead of silently rm-ing an orphaned tree.
+		if (!(await waitForExactExit(lease.pid, LEASE_EXIT_TIMEOUT_MS))) leaseExitFailed = lease.pid;
 	}
 	cliEnv.cleanup();
+	if (leaseExitFailed !== null)
+		throw new Error(
+			`detached owner lease pid ${leaseExitFailed} did not exit within ${LEASE_EXIT_TIMEOUT_MS}ms; preserving roots for inspection`,
+		);
 	await rm(root, { recursive: true, force: true });
 	await rm(workspace, { recursive: true, force: true });
 });
@@ -432,4 +463,23 @@ describe("HarnessCommand tmux-resident owner startup", () => {
 		expect((result.state as Record<string, unknown>).ownerLive).toBe(true);
 		await expect(access(path.join(root, sessionId, "owner-lifecycle", "generation.json"))).rejects.toThrow();
 	});
+	it("reaps the exact detached-owner child (no orphan) when it never becomes live", async () => {
+		// missing-tmux routes to the direct detached-owner fallback; disabling SDK hosting makes the
+		// spawned __owner child fail transport creation, so it never publishes a live lease. The
+		// parent must not orphan that exact child: reap the PID it spawned and verify bounded exit
+		// (exact-owner scoped, never a name-based broad kill, never a leftover daemon).
+		const result = await runHarness(path.join(root, "missing-tmux"), 1, { GJC_SDK_DISABLE: "1" });
+		const evidence = result.evidence as Record<string, unknown>;
+
+		expect(evidence.ownerRuntime).toBe("detached");
+		expect(evidence.ownerFallbackReason).toBe("tmux-unavailable");
+		expect((result.state as Record<string, unknown>).ownerLive).toBe(false);
+		const reaped = evidence.detachedOwnerReaped as { pid: number; verified: boolean };
+		expect(reaped).toBeDefined();
+		expect(Number.isSafeInteger(reaped.pid)).toBe(true);
+		expect(reaped.pid).toBeGreaterThan(0);
+		// `verified` derives from the child's authoritative exit promise (recycle-proof), proving
+		// the exact spawned owner was reaped within the bounded grace before the parent returned.
+		expect(reaped.verified).toBe(true);
+	}, 60_000);
 });

--- a/packages/coding-agent/test/notify-setup.test.ts
+++ b/packages/coding-agent/test/notify-setup.test.ts
@@ -6,10 +6,13 @@ import * as path from "node:path";
 import { parseNotifyArgs, promptForToken, runNotifyCliCommand, runNotifyCommand } from "../src/cli/notify-cli";
 import { Settings } from "../src/config/settings";
 import { getNotificationConfig, maskToken } from "../src/sdk/bus/config";
+import { HEARTBEAT_TTL_MS } from "../src/sdk/bus/daemon-paths";
+import type { DaemonState } from "../src/sdk/bus/telegram-daemon";
 import {
 	createLightweightDaemonSettings,
 	loadLightweightDaemonSettings,
 	ownerPidFromOwnerId,
+	type RunDaemonInternalDeps,
 	runDaemonInternal,
 } from "../src/sdk/bus/telegram-daemon-cli";
 
@@ -759,5 +762,142 @@ describe("notify daemon-internal lightweight startup", () => {
 		expect(ownerPidFromOwnerId("12345")).toBe(12345);
 		expect(ownerPidFromOwnerId("owner-12345")).toBeUndefined();
 		expect(ownerPidFromOwnerId("0-dead")).toBeUndefined();
+	});
+});
+
+describe("notify daemon-internal ownership-progress watchdog", () => {
+	function tempAgentDir(): string {
+		return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notify-daemon-agent-"));
+	}
+
+	function configuredDaemonSettings(agentDir: string) {
+		return createLightweightDaemonSettings({
+			agentDir,
+			rawConfig: { notifications: { enabled: true, telegram: { botToken: "1234:token", chatId: "999" } } },
+		});
+	}
+
+	function daemonState(ownerId: string, heartbeatAt: number): DaemonState {
+		return {
+			pid: 4242,
+			ownerId,
+			tokenFingerprint: "fingerprint",
+			chatId: "999",
+			startedAt: 1,
+			heartbeatAt,
+			roots: [],
+			version: 1,
+		};
+	}
+
+	async function startWatchdog(initialState: DaemonState | undefined) {
+		const agentDir = tempAgentDir();
+		const daemonDone = Promise.withResolvers<void>();
+		let scheduled: (() => void) | undefined;
+		let currentState = initialState;
+		let readFailure = false;
+		let currentTime = 0;
+		let cleared = false;
+		const stopReasons: Array<"reload" | "signal" | "stop" | undefined> = [];
+		class BlockingDaemon {
+			requestStop(reason?: "reload" | "signal" | "stop"): void {
+				stopReasons.push(reason);
+				daemonDone.resolve();
+			}
+			async run(): Promise<void> {
+				await daemonDone.promise;
+			}
+		}
+		const timer = {} as Timer;
+		const deps: RunDaemonInternalDeps = {
+			pidAlive: () => true,
+			now: () => currentTime,
+			SettingsImpl: {
+				async init() {
+					return configuredDaemonSettings(agentDir);
+				},
+			},
+			DaemonImpl: BlockingDaemon as never,
+			readDaemonState: async () => {
+				if (readFailure) throw new Error("state temporarily unreadable");
+				return currentState;
+			},
+			setInterval: callback => {
+				scheduled = callback;
+				return timer;
+			},
+			clearInterval: handle => {
+				expect(handle).toBe(timer);
+				cleared = true;
+			},
+		};
+		const run = runDaemonInternal(["--owner-id", "4242-current", "--agent-dir", agentDir], deps);
+		while (!scheduled) await Bun.sleep(0);
+		return {
+			run,
+			stopReasons,
+			setState(state: DaemonState | undefined) {
+				currentState = state;
+			},
+			setReadFailure(value: boolean) {
+				readFailure = value;
+			},
+			setNow(value: number) {
+				currentTime = value;
+			},
+			async tick() {
+				scheduled!();
+				await Bun.sleep(0);
+			},
+			wasCleared: () => cleared,
+		};
+	}
+
+	test("stops cooperatively when persisted ownership is superseded", async () => {
+		const harness = await startWatchdog(daemonState("4242-current", 10));
+		await harness.tick();
+		harness.setState(daemonState("9999-replacement", 20));
+		await harness.tick();
+		await harness.run;
+
+		expect(harness.stopReasons).toEqual(["stop"]);
+		expect(harness.wasCleared()).toBe(true);
+	});
+
+	test("stops only after 60 seconds without observed heartbeat progress", async () => {
+		const harness = await startWatchdog(daemonState("4242-current", 10));
+		await harness.tick();
+		harness.setNow(3 * HEARTBEAT_TTL_MS - 1);
+		await harness.tick();
+		expect(harness.stopReasons).toEqual([]);
+
+		harness.setState(daemonState("4242-current", 11));
+		await harness.tick();
+		harness.setNow(6 * HEARTBEAT_TTL_MS - 2);
+		await harness.tick();
+		expect(harness.stopReasons).toEqual([]);
+
+		harness.setNow(6 * HEARTBEAT_TTL_MS - 1);
+		await harness.tick();
+		await harness.run;
+		expect(harness.stopReasons).toEqual(["stop"]);
+		expect(harness.wasCleared()).toBe(true);
+	});
+
+	test("ignores absent and unreadable state until positive supersession", async () => {
+		const harness = await startWatchdog(undefined);
+		await harness.tick();
+		harness.setReadFailure(true);
+		await harness.tick();
+		harness.setReadFailure(false);
+		harness.setState(daemonState("4242-current", 10));
+		await harness.tick();
+		expect(harness.stopReasons).toEqual([]);
+
+		harness.setState(daemonState("9999-replacement", 20));
+		await harness.tick();
+		await harness.run;
+		expect(harness.stopReasons).toEqual(["stop"]);
+		expect(harness.wasCleared()).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -1,17 +1,18 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, vi } from "bun:test";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import { getSessionsDir } from "@gajae-code/utils";
 import { lifecycleArgs } from "../src/commands/sdk";
 import { Broker } from "../src/sdk/broker/broker";
+import * as brokerDiscovery from "../src/sdk/broker/discovery";
 import {
 	brokerDiscoveryPath,
 	readBrokerDiscovery,
 	redactBrokerDiscovery,
 	writeBrokerDiscovery,
 } from "../src/sdk/broker/discovery";
-import { ensureBroker } from "../src/sdk/broker/ensure";
+import { brokerOwnerForTest, ensureBroker } from "../src/sdk/broker/ensure";
 import { getBrokerIdentityKey } from "../src/sdk/broker/identity";
 import { readSessionLifecycleLaunchRequest } from "../src/sdk/broker/lifecycle";
 import { resolveSdkInternalSpawnCommand } from "../src/sdk/broker/runtime";
@@ -110,6 +111,57 @@ describe("SDK broker identity and discovery", () => {
 		expect(restarted.token).not.toBe(first.token);
 		const owner = (await import("../src/sdk/broker/ensure")).brokerOwnerForTest(dir);
 		await owner?.stop();
+	}, 15_000);
+	it("terminates and reaps the spawned broker when discovery times out", async () => {
+		const dir = await temp();
+		// Force ensureBroker's discovery reads to never resolve a live record so the
+		// discovery wait is doomed from the start. The real broker still spawns and
+		// stays alive as a detached daemon, which is exactly the orphan path the reap
+		// must close. Capture its pid from the discovery file (bypassing the spy)
+		// before ensureBroker times out and reaps it.
+		const spy = vi.spyOn(brokerDiscovery, "readBrokerDiscovery").mockResolvedValue(null);
+		try {
+			const { promise: gotPid, resolve: onPid } = Promise.withResolvers<number | undefined>();
+			void (async () => {
+				const deadline = Date.now() + 12_000;
+				while (Date.now() < deadline) {
+					try {
+						const raw = JSON.parse(await fs.readFile(brokerDiscovery.brokerDiscoveryPath(dir), "utf8")) as {
+							pid?: number;
+						};
+						if (typeof raw.pid === "number") return onPid(raw.pid);
+					} catch {}
+					await sleep(25);
+				}
+				onPid(undefined);
+			})();
+			await expect(ensureBroker({ agentDir: dir })).rejects.toThrow(
+				"Timed out waiting for detached SDK broker discovery.",
+			);
+			const brokerPid = await gotPid;
+			// The spawned detached broker must have been terminated + reaped, not orphaned.
+			expect(typeof brokerPid).toBe("number");
+			expect(brokerDiscovery.isPidAlive(brokerPid!)).toBe(false);
+			// No owner handle leaked for the failed agent dir.
+			expect(brokerOwnerForTest(dir)).toBeUndefined();
+		} finally {
+			spy.mockRestore();
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	}, 30_000);
+	it("fails fast and reaps the spawned broker when it exits before discovery", async () => {
+		const dir = await temp();
+		// Plant an unsupported session-index snapshot so the spawned broker's start()
+		// rejects immediately and it exits before publishing discovery. ensureBroker
+		// must take the early-exit path (not the 10s timeout) and leave no orphan.
+		await fs.mkdir(path.join(dir, "sdk", "sessions"), { recursive: true });
+		await fs.writeFile(path.join(dir, "sdk", "sessions", "index.snapshot.json"), JSON.stringify({ version: 99 }));
+		await expect(ensureBroker({ agentDir: dir })).rejects.toThrow(/exited before discovery/);
+		// No owner handle leaked for the failed agent dir.
+		expect(brokerOwnerForTest(dir)).toBeUndefined();
+		// No discovery record was published: the broker exited before writing one.
+		await expect(fs.stat(brokerDiscoveryPath(dir))).rejects.toThrow();
+		await fs.rm(dir, { recursive: true, force: true });
 	}, 15_000);
 	it("leaves exactly one live detached broker after concurrent process startup", async () => {
 		const dir = await temp();


### PR DESCRIPTION
## What

- reap failed detached harness owners and spawned SDK session children with bounded `SIGTERM` → `SIGKILL` escalation and verified exit
- surface unverified harness child reap failures as critical owner events before releasing the lease
- reap detached SDK brokers on startup failure, and make the ACP wire test pre-start/own its exact isolated broker before removing temporary state
- add an independent Telegram daemon ownership watchdog that cooperatively stops superseded owners or owners whose persisted heartbeat makes no progress for 60 seconds
- preserve intentional shared-daemon behavior: no broker parent-death coupling and no Telegram stop merely because the original spawning session exits

## Why

Three lifecycle gaps could leave GJC processes reparented under PID 1:

1. the released harness `fake-rpc` leak shape survived in fire-and-forget SDK child shutdown and in the never-live direct owner fallback
2. `acp-session-delete-wire.test.ts` terminated only its ACP subprocess while the detached SDK broker survived under a deleted `gjc-acp-delete-wire-*` root
3. a Telegram daemon blocked in network polling could stop renewing/revalidating ownership indefinitely, allowing stale daemon processes to accumulate beside the current owner

All new shutdown paths target an exact child handle or exact owner ID. Numeric process-name sweeps and production broker idle/parent coupling are intentionally avoided.

## Testing

- `bun run --cwd packages/coding-agent check` — pass
- focused lifecycle tests — **94 pass, 0 fail** across:
  - `notify-setup.test.ts`
  - `sdk-broker.test.ts`
  - `acp-session-delete-wire.test.ts`
  - `harness-tmux-owner.test.ts`
  - `harness-control-plane/sdk-transport.test.ts`
  - `harness-control-plane/owner.test.ts`
- post-suite process sweep — no matching ACP wire broker/session-host or harness owner remained
- full coding-agent suite on the first commit — **9945 pass, 352 skip, 11 fail, 1 manifest timeout/error**; failures were outside the changed surfaces (provider onboarding, Slack/Discord/chat daemon timing, workflow-gate emitter, GC red-team fixtures, resume cwd normalization, coordinator concurrency, and the 5s manifest runner budget)

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated