### PR TITLE
fix(session): serialize prompts with default model selection

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Renamed the notifications SDK to the Gajae-Code SDK: `docs/notifications-sdk.md` is now `docs/sdk.md`, `src/notifications/` is now `src/sdk/bus/`, and `src/sdk.ts` is now the `src/sdk/` module directory. Old deep-import specifiers no longer resolve.
 - Moved SDK discovery from `.gjc/state/notifications/` to `.gjc/state/sdk/`. Restart sessions and daemons together when upgrading; the runtime does not dual-scan the old and new directories.
 - Removed the `--mode rpc`, `--mode rpc-ui`, and `--mode bridge` external ingress modes. Machine clients must use the SDK WebSocket interfaces documented in `docs/sdk.md`; no RPC or Bridge compatibility path remains.
+
+### Fixed
+
+- Serialized prompt preflight and durable default-model changes in one abort-safe FIFO so neither operation can overtake the other.
+
 ## [0.10.1] - 2026-07-13
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -670,7 +670,10 @@ export class ExtensionRunner {
 		}
 	}
 
-	async emit<TEvent extends RunnerEmitEvent>(event: TEvent): Promise<RunnerEmitResult<TEvent>> {
+	async emit<TEvent extends RunnerEmitEvent>(
+		event: TEvent,
+		wrapHandler?: <T>(invoke: () => Promise<T>) => Promise<T>,
+	): Promise<RunnerEmitResult<TEvent>> {
 		const handlers = this.#handlersByEvent.get(event.type) ?? [];
 		if (handlers.length === 0) return undefined as RunnerEmitResult<TEvent>;
 
@@ -678,7 +681,8 @@ export class ExtensionRunner {
 		let result: SessionBeforeEventResult | SessionCompactingResult | undefined;
 
 		for (const { ext, handler } of handlers) {
-			const handlerResult = await this.#runHandlerWithTimeout(handler, event, ctx, ext, extensionHandlerTimeoutMs);
+			const invoke = () => this.#runHandlerWithTimeout(handler, event, ctx, ext, extensionHandlerTimeoutMs);
+			const handlerResult = wrapHandler ? await wrapHandler(invoke) : await invoke();
 
 			if (this.#isSessionBeforeEvent(event) && handlerResult) {
 				result = handlerResult as SessionBeforeEventResult;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -13,6 +13,7 @@
  * Modes use this class and add their own I/O layer on top.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -283,7 +284,11 @@ import { type EditMode, resolveEditMode } from "../utils/edit-mode";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import { extractFileMentions, generateFileMentionMessages } from "../utils/file-mentions";
 import { buildNamedToolChoice, buildNamedToolChoiceResult } from "../utils/tool-choice";
-import { buildWorkflowIntentDiff, WORKFLOW_INTENT_DIFF_CUSTOM_TYPE } from "../workflow/workflow-intent-diff";
+import {
+	buildWorkflowIntentDiff,
+	WORKFLOW_INTENT_DIFF_CUSTOM_TYPE,
+	type WorkflowIntentDiff,
+} from "../workflow/workflow-intent-diff";
 import { buildWorkspaceTree, type WorkspaceTree } from "../workspace-tree";
 import type { AuthStorage } from "./auth-storage";
 import {
@@ -1017,6 +1022,35 @@ export type BeforeAgentStartContributor = (event: {
 	sessionId: string | undefined;
 }) => Promise<BeforeAgentStartInternalMessage | undefined>;
 
+type PromptCallbackOriginMarker = {
+	readonly session: AgentSession;
+	active: boolean;
+};
+
+type DisposeCallbackOriginMarker = {
+	readonly session: AgentSession;
+	active: boolean;
+};
+
+type SessionAdmissionState = "queued" | "admitted" | "cancelled" | "released";
+
+type SessionAdmissionNode = {
+	readonly id: number;
+	readonly kind: "prompt" | "selection";
+	state: SessionAdmissionState;
+	readonly admitted: PromiseWithResolvers<void>;
+	readonly generation?: number;
+	readonly signal?: AbortSignal;
+	abortListener?: () => void;
+	inFlight: boolean;
+	continuesQueuedMessages?: boolean;
+};
+
+type PromptAdmissionReuse = {
+	readonly generation: number;
+	readonly mode: "continuation" | "sequential";
+};
+
 export class WorkerIntegrationRequestScheduler {
 	#inFlight: Promise<void> | undefined = undefined;
 	#pending = false;
@@ -1223,8 +1257,14 @@ export class AgentSession {
 	#scopedModels: ScopedModelSelection[];
 	#thinkingLevel: ThinkingLevel | undefined;
 	#activeModelProfile: string | undefined;
-	#defaultModelSelectionTail: Promise<void> = Promise.resolve();
+	#admissionQueue: SessionAdmissionNode[] = [];
+	#admissionOwner: SessionAdmissionNode | undefined;
+	#admissionPumpActive = false;
+	#admissionLaneClosed = false;
+	#nextAdmissionId = 0;
+	#pendingPromptAdmissionId: number | undefined;
 	#defaultModelSelectionMutationRevision = 0;
+	#defaultModelSelectionSideEffectsSettled: Promise<void> | undefined;
 	#promptTemplates: PromptTemplate[];
 	#slashCommands: FileSlashCommand[];
 
@@ -1349,6 +1389,8 @@ export class AgentSession {
 	#providerSessionId: string | undefined;
 	#providerCacheSessionId: string | undefined;
 	#isDisposed = false;
+	#disposePromise: Promise<void> | undefined;
+	#disposeCallbackOriginStorage = new AsyncLocalStorage<DisposeCallbackOriginMarker>();
 	// Extension system
 	#extensionRunner: ExtensionRunner | undefined = undefined;
 	#turnIndex = 0;
@@ -1359,6 +1401,7 @@ export class AgentSession {
 	});
 	// First-party internal before-agent-start contributors (not user hooks).
 	#beforeAgentStartContributors: BeforeAgentStartContributor[] = [];
+	#promptCallbackOriginStorage = new AsyncLocalStorage<PromptCallbackOriginMarker>();
 
 	#skills: Skill[];
 	#skillWarnings: SkillWarning[];
@@ -1455,6 +1498,7 @@ export class AgentSession {
 	#postPromptTasksPromise: Promise<void> | undefined = undefined;
 	#postPromptTasksResolve: (() => void) | undefined = undefined;
 	#postPromptTasksAbortController = new AbortController();
+	#scheduledQueuedMessageContinuation: Promise<void> | undefined = undefined;
 
 	#streamingEditAbortTriggered = false;
 	#streamingEditCheckedLineCounts = new Map<string, number>();
@@ -1485,6 +1529,8 @@ export class AgentSession {
 	};
 	#promptInFlightCount = 0;
 	#agentEventHandlersInFlight = 0;
+	#agentEventHandlersIdle: Promise<void> = Promise.resolve();
+	#resolveAgentEventHandlersIdle: (() => void) | undefined;
 	#queuedExtensionEventCount = 0;
 	// Wire-level agent_end emission is deferred until both the prompt finalizer and
 	// async event handlers settle. Subscribers treat agent_end as readiness, so
@@ -1548,7 +1594,228 @@ export class AgentSession {
 		}
 	}
 
-	#beginInFlight(): void {
+	#enqueueSelectionAdmission(): SessionAdmissionNode {
+		if (this.#admissionLaneClosed) {
+			throw new AgentBusyError("Agent session has been disposed.");
+		}
+		const node: SessionAdmissionNode = {
+			id: ++this.#nextAdmissionId,
+			kind: "selection",
+			state: "queued",
+			admitted: Promise.withResolvers<void>(),
+			inFlight: false,
+		};
+		this.#admissionQueue.push(node);
+		this.#pumpAdmissionQueue();
+		return node;
+	}
+
+	#enqueuePromptAdmission(): SessionAdmissionNode {
+		if (this.#admissionLaneClosed) {
+			throw new AgentBusyError("Agent session has been disposed.");
+		}
+		if (this.#pendingPromptAdmissionId !== undefined) {
+			throw new AgentBusyError();
+		}
+		const signal = this.#promptPreflightAbortController.signal;
+		const node: SessionAdmissionNode = {
+			id: ++this.#nextAdmissionId,
+			kind: "prompt",
+			state: "queued",
+			admitted: Promise.withResolvers<void>(),
+			generation: this.#promptGeneration,
+			signal,
+			inFlight: false,
+		};
+		this.#pendingPromptAdmissionId = node.id;
+		const cancel = () => {
+			if (node.state !== "queued") return;
+			node.state = "cancelled";
+			signal.removeEventListener("abort", cancel);
+			node.abortListener = undefined;
+			this.#clearPendingPromptAdmissionClaim(node);
+			node.admitted.reject(promptPreflightCancelledError());
+			this.#pumpAdmissionQueue();
+		};
+		node.abortListener = cancel;
+		this.#admissionQueue.push(node);
+		signal.addEventListener("abort", cancel, { once: true });
+		if (signal.aborted) cancel();
+		this.#pumpAdmissionQueue();
+		return node;
+	}
+
+	#clearPendingPromptAdmissionClaim(node: SessionAdmissionNode): void {
+		if (node.kind === "prompt" && this.#pendingPromptAdmissionId === node.id) {
+			this.#pendingPromptAdmissionId = undefined;
+		}
+	}
+
+	#getPendingPromptAdmission(): SessionAdmissionNode | undefined {
+		const pendingId = this.#pendingPromptAdmissionId;
+		if (pendingId === undefined) return undefined;
+		return this.#admissionQueue.find(
+			node =>
+				node.id === pendingId && node.kind === "prompt" && (node.state === "queued" || node.state === "admitted"),
+		);
+	}
+
+	#pumpAdmissionQueue(): void {
+		if (this.#admissionLaneClosed || this.#admissionPumpActive) return;
+		this.#admissionPumpActive = true;
+		try {
+			if (this.#admissionOwner) return;
+			while (true) {
+				const head = this.#admissionQueue[0];
+				if (!head) return;
+				if (head.state === "cancelled") {
+					head.state = "released";
+					this.#admissionQueue.shift();
+					continue;
+				}
+				if (head.state !== "queued") return;
+				head.state = "admitted";
+				this.#admissionOwner = head;
+				if (head.abortListener && head.signal) {
+					head.signal.removeEventListener("abort", head.abortListener);
+					head.abortListener = undefined;
+				}
+				head.admitted.resolve();
+				return;
+			}
+		} finally {
+			this.#admissionPumpActive = false;
+		}
+	}
+
+	#releaseAdmission(node: SessionAdmissionNode): void {
+		const continuesQueuedMessages = node.continuesQueuedMessages === true;
+		node.continuesQueuedMessages = false;
+		const shouldContinueQueuedMessages =
+			continuesQueuedMessages && !this.#admissionLaneClosed && this.agent.hasQueuedMessages();
+		if (
+			shouldContinueQueuedMessages &&
+			node.kind === "prompt" &&
+			node.state === "admitted" &&
+			this.#admissionOwner === node &&
+			!node.inFlight &&
+			this.#scheduleQueuedMessageContinuation(node)
+		) {
+			return;
+		}
+		if (node.state === "admitted" && this.#admissionOwner === node) {
+			node.state = "released";
+			this.#admissionOwner = undefined;
+			if (this.#admissionQueue[0] === node) this.#admissionQueue.shift();
+			this.#clearPendingPromptAdmissionClaim(node);
+			this.#pumpAdmissionQueue();
+		}
+		if (shouldContinueQueuedMessages) {
+			this.#scheduleQueuedMessageContinuation();
+		}
+	}
+
+	#closeAdmissionLane(): void {
+		if (this.#admissionLaneClosed) return;
+		this.#admissionLaneClosed = true;
+		this.#promptPreflightAbortController.abort();
+		const disposedError = new AgentBusyError("Agent session has been disposed.");
+		for (const node of this.#admissionQueue) {
+			if (node.abortListener && node.signal) {
+				node.signal.removeEventListener("abort", node.abortListener);
+				node.abortListener = undefined;
+			}
+			if (node.state === "queued") {
+				node.state = "cancelled";
+				node.admitted.reject(node.kind === "prompt" ? promptPreflightCancelledError() : disposedError);
+			} else if (node.state === "admitted") {
+				node.state = "cancelled";
+				this.#endInFlight(node);
+			}
+			this.#clearPendingPromptAdmissionClaim(node);
+		}
+		this.#admissionOwner = undefined;
+		this.#admissionQueue = [];
+	}
+
+	#throwIfSelectionAdmissionInactive(node: SessionAdmissionNode): void {
+		if (this.#admissionLaneClosed || node.state !== "admitted" || this.#admissionOwner !== node) {
+			throw new AgentBusyError("Agent session has been disposed.");
+		}
+	}
+
+	#isCurrentPromptAdmission(node: SessionAdmissionNode, generation: number): boolean {
+		return this.#isCurrentPromptAdmissionOwner(node, generation) && node.inFlight;
+	}
+
+	#isCurrentPromptAdmissionOwner(node: SessionAdmissionNode, generation: number): boolean {
+		return (
+			node.kind === "prompt" &&
+			node.state === "admitted" &&
+			node.generation === generation &&
+			this.#admissionOwner === node
+		);
+	}
+
+	#getCurrentPromptAdmission(generation: number): SessionAdmissionNode | undefined {
+		const owner = this.#admissionOwner;
+		return owner && this.#isCurrentPromptAdmission(owner, generation) ? owner : undefined;
+	}
+
+	async #awaitPromptAdmission(node: SessionAdmissionNode, requireAcceptance: boolean): Promise<boolean> {
+		try {
+			await node.admitted.promise;
+			return true;
+		} catch (error) {
+			if (isPromptPreflightCancelledError(error) && !requireAcceptance) return false;
+			throw error;
+		}
+	}
+
+	async #runWithPromptAdmission(
+		operation: (admission: SessionAdmissionNode) => Promise<void>,
+		requireAcceptance = false,
+	): Promise<void> {
+		const admission = this.#enqueuePromptAdmission();
+		try {
+			if (!(await this.#awaitPromptAdmission(admission, requireAcceptance))) return;
+			await operation(admission);
+		} finally {
+			this.#releaseAdmission(admission);
+		}
+	}
+
+	async #runExactMessagePrompt(messages: AgentMessage[], options?: { toolChoice?: ToolChoice }): Promise<void> {
+		const admission = this.#enqueuePromptAdmission();
+		try {
+			if (!(await this.#awaitPromptAdmission(admission, false))) return;
+			this.#beginInFlight(admission);
+			try {
+				await this.#promptAgentWithIdleRetry(messages, options, () =>
+					this.#clearPendingPromptAdmissionClaim(admission),
+				);
+			} finally {
+				this.#endInFlight(admission);
+			}
+		} finally {
+			this.#releaseAdmission(admission);
+		}
+	}
+
+	async #runInPromptCallbackFrame<T>(callback: () => Promise<T>): Promise<T> {
+		const marker: PromptCallbackOriginMarker = { session: this, active: true };
+		try {
+			return await this.#promptCallbackOriginStorage.run(marker, callback);
+		} finally {
+			marker.active = false;
+		}
+	}
+
+	#beginInFlight(node: SessionAdmissionNode): void {
+		if (node.kind !== "prompt" || node.state !== "admitted" || this.#admissionOwner !== node || node.inFlight) {
+			throw new AgentBusyError();
+		}
+		node.inFlight = true;
 		this.#promptInFlightCount++;
 		// A successor that starts before a deferred terminal event is published keeps
 		// the session continuously busy; emitting the predecessor's idle boundary later
@@ -1587,7 +1854,9 @@ export class AgentSession {
 		this.#pendingAgentEndEmit = undefined;
 	}
 
-	#endInFlight(): void {
+	#endInFlight(node: SessionAdmissionNode): void {
+		if (!node.inFlight) return;
+		node.inFlight = false;
 		this.#promptInFlightCount = Math.max(0, this.#promptInFlightCount - 1);
 		if (this.#promptInFlightCount === 0) {
 			this.#releasePowerAssertion();
@@ -1693,9 +1962,7 @@ export class AgentSession {
 			isStreaming: () => this.isStreaming,
 			injectStreaming: message => this.agent.followUp(message),
 			injectIdle: async messages => {
-				const first = messages[0];
-				if (!first) return;
-				await this.agent.prompt(messages.length === 1 ? first : messages);
+				await this.#runExactMessagePrompt(messages);
 			},
 			scheduleIdleFlush: run => {
 				this.#schedulePostPromptTask(
@@ -2223,6 +2490,11 @@ export class AgentSession {
 	}
 
 	#trackAgentEvent = async (event: AgentEvent): Promise<void> => {
+		if (this.#agentEventHandlersInFlight === 0) {
+			const { promise, resolve } = Promise.withResolvers<void>();
+			this.#agentEventHandlersIdle = promise;
+			this.#resolveAgentEventHandlersIdle = resolve;
+		}
 		this.#agentEventHandlersInFlight++;
 		try {
 			await this.#handleAgentEvent(event);
@@ -2230,9 +2502,21 @@ export class AgentSession {
 			logger.warn("Agent event handler failed", { event: event.type, error: String(error) });
 		} finally {
 			this.#agentEventHandlersInFlight = Math.max(0, this.#agentEventHandlersInFlight - 1);
+			if (this.#agentEventHandlersInFlight === 0) {
+				this.#resolveAgentEventHandlersIdle?.();
+				this.#resolveAgentEventHandlersIdle = undefined;
+			}
 			this.#flushPendingAgentEnd();
 		}
 	};
+
+	async #waitForAgentEventHandlersToStabilize(): Promise<void> {
+		while (true) {
+			const idle = this.#agentEventHandlersIdle;
+			await idle;
+			if (this.#agentEventHandlersInFlight === 0 && idle === this.#agentEventHandlersIdle) return;
+		}
+	}
 
 	#persistRuntimeStateInBackground(event: AgentSessionEvent): void {
 		void persistCoordinatorRuntimeStateFromEvent(event, {
@@ -2283,7 +2567,7 @@ export class AgentSession {
 		// sinks, so they must not delay or suppress local delivery.
 		this.#emit(event);
 		void persistRuntimeState();
-		await this.#emitExtensionEvent(event);
+		await this.#runInPromptCallbackFrame(() => this.#emitExtensionEvent(event));
 	}
 
 	// Track last assistant message for auto-compaction check
@@ -2864,6 +3148,7 @@ export class AgentSession {
 				try {
 					await scheduler.wait(delayMs, { signal });
 				} catch {
+					options?.onSkip?.();
 					return;
 				}
 			}
@@ -2884,47 +3169,141 @@ export class AgentSession {
 	#scheduleAgentContinue(options?: {
 		delayMs?: number;
 		generation?: number;
+		inheritedAdmission?: SessionAdmissionNode;
+		reservedAdmission?: SessionAdmissionNode;
+		beforeContinue?: () => void;
 		skipCompactionCheck?: boolean;
+		skipRetryFallbackRestore?: boolean;
 		suppressPredecessorAgentEnd?: boolean;
 		shouldContinue?: () => boolean;
 		onSkip?: (reason: "generation_changed" | "aborted_signal" | "queue_drained") => void;
 		onError?: (error: unknown) => void;
+		propagateError?: boolean;
 	}): Promise<void> {
 		if (options?.suppressPredecessorAgentEnd) {
 			this.#suppressDeferredAgentEndForContinuation();
 		}
 
 		const scheduledGeneration = options?.generation;
+		const inheritedAdmission =
+			options?.inheritedAdmission ?? this.#getCurrentPromptAdmission(scheduledGeneration ?? this.#promptGeneration);
+		const reservedAdmission =
+			options?.reservedAdmission ?? (inheritedAdmission ? undefined : this.#enqueuePromptAdmission());
+		if (reservedAdmission) void reservedAdmission.admitted.promise.catch(() => {});
 		const signal = this.#postPromptTasksAbortController.signal;
 		return this.#schedulePostPromptTask(
 			async () => {
-				if (signal.aborted) {
-					options?.onSkip?.("aborted_signal");
-					return;
-				}
-				if (scheduledGeneration !== undefined && this.#promptGeneration !== scheduledGeneration) {
-					options?.onSkip?.("generation_changed");
-					return;
-				}
-				if (options?.shouldContinue && !options.shouldContinue()) {
-					options.onSkip?.("queue_drained");
-					return;
-				}
+				let reservedInFlight = false;
 				try {
-					await this.#maybeRestoreRetryFallbackPrimary();
+					if (reservedAdmission) {
+						if (
+							reservedAdmission.state !== "admitted" &&
+							!(await this.#awaitPromptAdmission(reservedAdmission, false))
+						) {
+							options?.onSkip?.("aborted_signal");
+							return;
+						}
+					}
+					if (signal.aborted) {
+						options?.onSkip?.("aborted_signal");
+						return;
+					}
+					if (scheduledGeneration !== undefined && this.#promptGeneration !== scheduledGeneration) {
+						options?.onSkip?.("generation_changed");
+						return;
+					}
+					if (
+						inheritedAdmission &&
+						!this.#isCurrentPromptAdmission(
+							inheritedAdmission,
+							scheduledGeneration ?? inheritedAdmission.generation ?? this.#promptGeneration,
+						)
+					) {
+						options?.onSkip?.("generation_changed");
+						return;
+					}
+					if (options?.shouldContinue && !options.shouldContinue()) {
+						options.onSkip?.("queue_drained");
+						return;
+					}
+					if (!options?.skipRetryFallbackRestore) {
+						await this.#maybeRestoreRetryFallbackPrimary();
+					}
 					if (!options?.skipCompactionCheck) {
 						await this.#checkEstimatedContextBeforePrompt();
 					}
-					await this.agent.continue();
+					if (
+						reservedAdmission &&
+						!this.#isCurrentPromptAdmissionOwner(
+							reservedAdmission,
+							reservedAdmission.generation ?? this.#promptGeneration,
+						)
+					) {
+						options?.onSkip?.("aborted_signal");
+						return;
+					}
+					if (reservedAdmission) {
+						this.#beginInFlight(reservedAdmission);
+						reservedInFlight = true;
+					}
+					options?.beforeContinue?.();
+					const continuation = this.agent.continue();
+					if (reservedAdmission) {
+						this.#clearPendingPromptAdmissionClaim(reservedAdmission);
+					}
+					await continuation;
 				} catch (error) {
+					if (reservedAdmission && isPromptPreflightCancelledError(error)) {
+						options?.onSkip?.("aborted_signal");
+						return;
+					}
 					logger.warn("agent.continue failed after scheduling", {
 						error: error instanceof Error ? error.message : String(error),
 					});
 					options?.onError?.(error);
+					if (options?.propagateError) throw error;
+				} finally {
+					if (reservedAdmission) {
+						if (reservedInFlight) this.#endInFlight(reservedAdmission);
+						this.#releaseAdmission(reservedAdmission);
+					}
 				}
 			},
-			{ delayMs: options?.delayMs },
+			{
+				delayMs: options?.delayMs,
+				onSkip: reservedAdmission ? () => this.#releaseAdmission(reservedAdmission) : undefined,
+			},
 		);
+	}
+
+	#scheduleQueuedMessageContinuation(reservedAdmission?: SessionAdmissionNode): boolean {
+		if (this.#scheduledQueuedMessageContinuation) return false;
+		const pendingAdmission = reservedAdmission ? undefined : this.#getPendingPromptAdmission();
+		if (pendingAdmission) {
+			pendingAdmission.continuesQueuedMessages = true;
+			return true;
+		}
+		let scheduled: Promise<void> | undefined;
+		scheduled = this.#scheduleAgentContinue({
+			reservedAdmission,
+			beforeContinue: () => {
+				if (this.#scheduledQueuedMessageContinuation === scheduled) {
+					this.#scheduledQueuedMessageContinuation = undefined;
+				}
+			},
+			shouldContinue: () =>
+				(this.#canAutoContinueForSteer() && this.agent.hasQueuedSteering()) ||
+				(this.#canAutoContinueForFollowUp() && this.agent.hasQueuedMessages()),
+		});
+		this.#scheduledQueuedMessageContinuation = scheduled;
+		void scheduled
+			.finally(() => {
+				if (this.#scheduledQueuedMessageContinuation === scheduled) {
+					this.#scheduledQueuedMessageContinuation = undefined;
+				}
+			})
+			.catch(() => {});
+		return true;
 	}
 
 	#logCompactionContinuationSkipped(
@@ -2966,11 +3345,13 @@ export class AgentSession {
 	}
 
 	#scheduleOverflowRetryContinuation(generation: number): void {
+		const inheritedAdmission = this.#getCurrentPromptAdmission(generation);
 		this.#stripOverflowFailedTurnForRetry();
 		if (this.#isResumableAgentTail()) {
 			this.#scheduleAgentContinue({
 				delayMs: 100,
 				generation,
+				inheritedAdmission,
 				suppressPredecessorAgentEnd: true,
 
 				onSkip: reason => this.#logCompactionContinuationSkipped("overflow_retry", reason),
@@ -2994,17 +3375,42 @@ export class AgentSession {
 		// predecessor before the post-prompt flush can leak an idle boundary; the
 		// continuation emits the authoritative terminal agent_end when it settles.
 		this.#suppressDeferredAgentEndForContinuation();
+		const inheritedAdmission = this.#getCurrentPromptAdmission(generation);
 		const continuePrompt = async () => {
-			await this.#promptWithMessage(
-				{
-					role: "developer",
-					content: [{ type: "text", text: autoContinuePrompt }],
-					attribution: "agent",
-					timestamp: Date.now(),
-				},
-				autoContinuePrompt,
-				{ skipPostPromptRecoveryWait: true, skipCompactionCheck: true },
-			);
+			if (inheritedAdmission) {
+				if (!this.#isCurrentPromptAdmission(inheritedAdmission, generation)) {
+					throw new AgentBusyError();
+				}
+				await this.#promptWithMessage(
+					inheritedAdmission,
+					{
+						role: "developer",
+						content: [{ type: "text", text: autoContinuePrompt }],
+						attribution: "agent",
+						timestamp: Date.now(),
+					},
+					autoContinuePrompt,
+					{
+						skipPostPromptRecoveryWait: true,
+						skipCompactionCheck: true,
+						reuseAdmission: { generation, mode: "continuation" },
+					},
+				);
+				return;
+			}
+			await this.#runWithPromptAdmission(async admission => {
+				await this.#promptWithMessage(
+					admission,
+					{
+						role: "developer",
+						content: [{ type: "text", text: autoContinuePrompt }],
+						attribution: "agent",
+						timestamp: Date.now(),
+					},
+					autoContinuePrompt,
+					{ skipPostPromptRecoveryWait: true, skipCompactionCheck: true },
+				);
+			});
 		};
 		const scheduledGeneration = generation;
 		const signal = this.#postPromptTasksAbortController.signal;
@@ -3061,6 +3467,7 @@ export class AgentSession {
 	 */
 	async #waitForPostPromptRecovery(): Promise<void> {
 		while (true) {
+			await this.#waitForAgentEventHandlersToStabilize();
 			if (this.#retryPromise) {
 				await this.#retryPromise;
 				continue;
@@ -3943,15 +4350,37 @@ export class AgentSession {
 	 * Remove all listeners, flush pending writes, and disconnect from agent.
 	 * Call this when completely done with the session.
 	 */
-	async dispose(): Promise<void> {
+	dispose(): Promise<void> {
+		if (this.#disposePromise) {
+			const callbackOrigin = this.#disposeCallbackOriginStorage.getStore();
+			if (callbackOrigin?.active && callbackOrigin.session === this) return Promise.resolve();
+			return this.#disposePromise;
+		}
 		this.#isDisposed = true;
+		this.#closeAdmissionLane();
+		this.#pendingNextTurnMessages = [];
+		this.#scheduledHiddenNextTurnGeneration = undefined;
+		this.#disposePromise = this.#dispose();
+		return this.#disposePromise;
+	}
+
+	async #dispose(): Promise<void> {
+		await this.#defaultModelSelectionSideEffectsSettled;
 		this.#pendingBackgroundExchanges = [];
 		this.yieldQueue.clear();
 		this.agent.setOnBeforeYield(undefined);
 		this.#evalExecutionDisposing = true;
 		try {
-			if (this.#extensionRunner?.hasHandlers("session_shutdown")) {
-				await this.#extensionRunner.emit({ type: "session_shutdown" });
+			const extensionRunner = this.#extensionRunner;
+			if (extensionRunner?.hasHandlers("session_shutdown")) {
+				await extensionRunner.emit({ type: "session_shutdown" }, async invoke => {
+					const callbackOrigin: DisposeCallbackOriginMarker = { session: this, active: true };
+					try {
+						return await this.#disposeCallbackOriginStorage.run(callbackOrigin, invoke);
+					} finally {
+						callbackOrigin.active = false;
+					}
+				});
 			}
 		} catch (error) {
 			logger.warn("Failed to emit session_shutdown event", { error: String(error) });
@@ -5196,7 +5625,11 @@ export class AgentSession {
 		if (!canContinuePersistedHistory(this.agent.state.messages)) {
 			throw new Error("Cannot continue from persisted message history");
 		}
-		await this.agent.continue();
+		await this.#scheduleAgentContinue({
+			skipCompactionCheck: true,
+			skipRetryFallbackRestore: true,
+			propagateError: true,
+		});
 	}
 
 	buildDisplaySessionContext(): SessionContext {
@@ -5846,45 +6279,51 @@ export class AgentSession {
 			return;
 		}
 
-		if (workflowIntentDiff) {
-			this.sessionManager.appendCustomEntry(WORKFLOW_INTENT_DIFF_CUSTOM_TYPE, workflowIntentDiff);
-		}
+		await this.#runWithPromptAdmission(async admission => {
+			// Skip eager todo prelude when the user has already queued a directive
+			const hasPendingUserDirective = this.#toolChoiceQueue.inspect().includes("user-force");
+			const eagerTodoPrelude =
+				!options?.synthetic && !hasPendingUserDirective ? this.#createEagerTodoPrelude(expandedText) : undefined;
 
-		// Skip eager todo prelude when the user has already queued a directive
-		const hasPendingUserDirective = this.#toolChoiceQueue.inspect().includes("user-force");
-		const eagerTodoPrelude =
-			!options?.synthetic && !hasPendingUserDirective ? this.#createEagerTodoPrelude(expandedText) : undefined;
+			const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: expandedText }];
+			if (options?.images) {
+				userContent.push(...options.images);
+			}
 
-		const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: expandedText }];
-		if (options?.images) {
-			userContent.push(...options.images);
-		}
+			const promptAttribution = options?.attribution ?? (options?.synthetic ? "agent" : "user");
+			const message = options?.synthetic
+				? {
+						role: "developer" as const,
+						content: userContent,
+						attribution: promptAttribution,
+						timestamp: Date.now(),
+					}
+				: { role: "user" as const, content: userContent, attribution: promptAttribution, timestamp: Date.now() };
+			await this.refreshGjcSubskillTools();
 
-		const promptAttribution = options?.attribution ?? (options?.synthetic ? "agent" : "user");
-		const message = options?.synthetic
-			? { role: "developer" as const, content: userContent, attribution: promptAttribution, timestamp: Date.now() }
-			: { role: "user" as const, content: userContent, attribution: promptAttribution, timestamp: Date.now() };
-		await this.refreshGjcSubskillTools();
+			if (eagerTodoPrelude?.toolChoice) {
+				this.#toolChoiceQueue.pushOnce(eagerTodoPrelude.toolChoice, {
+					label: "eager-todo",
+				});
+			}
 
-		if (eagerTodoPrelude?.toolChoice) {
-			this.#toolChoiceQueue.pushOnce(eagerTodoPrelude.toolChoice, {
-				label: "eager-todo",
-			});
-		}
-
-		try {
-			await this.#promptWithMessage(message, expandedText, {
-				...options,
-				prependMessages: eagerTodoPrelude ? [eagerTodoPrelude.message] : undefined,
-			});
-		} finally {
-			// Clean up residual eager-todo directive if the prompt never consumed it
-			// (e.g., compaction aborted, validation failed).
-			this.#toolChoiceQueue.removeByLabel("eager-todo");
-		}
-		if (!options?.synthetic) {
-			await this.#enforcePlanModeToolDecision();
-		}
+			try {
+				await this.#promptWithMessage(admission, message, expandedText, {
+					...options,
+					prependMessages: eagerTodoPrelude ? [eagerTodoPrelude.message] : undefined,
+					workflowIntentDiff,
+				});
+			} finally {
+				// Clean up residual eager-todo directive if the prompt never consumed it
+				// (e.g., compaction aborted, validation failed).
+				this.#toolChoiceQueue.removeByLabel("eager-todo");
+			}
+			if (!options?.synthetic) {
+				const generation = admission.generation;
+				if (generation === undefined) throw new AgentBusyError();
+				await this.#enforcePlanModeToolDecision(admission, generation);
+			}
+		}, options?.onPreflightAccepted !== undefined);
 	}
 
 	async #syncSkillPromptActiveState(
@@ -5985,25 +6424,44 @@ export class AgentSession {
 			timestamp: Date.now(),
 		};
 
-		await this.#syncSkillPromptActiveStateSafely(customMessage, true);
-		try {
-			await this.#promptWithMessage(customMessage, textContent, options);
-		} finally {
-			await this.#syncSkillPromptActiveStateSafely(customMessage, false);
-		}
+		await this.#runWithPromptAdmission(async admission => {
+			await this.#syncSkillPromptActiveStateSafely(customMessage, true);
+			try {
+				await this.#promptWithMessage(admission, customMessage, textContent, options);
+			} finally {
+				await this.#syncSkillPromptActiveStateSafely(customMessage, false);
+			}
+		});
 	}
 
 	async #promptWithMessage(
+		admission: SessionAdmissionNode,
 		message: AgentMessage,
 		expandedText: string,
 		options?: Pick<PromptOptions, "toolChoice" | "images" | "skipCompactionCheck" | "onPreflightAccepted"> & {
 			prependMessages?: AgentMessage[];
 			skipPostPromptRecoveryWait?: boolean;
+			workflowIntentDiff?: WorkflowIntentDiff | null;
+			reuseAdmission?: PromptAdmissionReuse;
 		},
 	): Promise<void> {
-		this.#beginInFlight();
-		const generation = this.#promptGeneration;
-		const preflightSignal = this.#promptPreflightAbortController.signal;
+		const reuseAdmission = options?.reuseAdmission;
+		const generation = reuseAdmission?.generation ?? admission.generation ?? this.#promptGeneration;
+		let ownsInFlightSegment = false;
+		if (reuseAdmission) {
+			if (!this.#isCurrentPromptAdmissionOwner(admission, generation)) throw new AgentBusyError();
+			if (reuseAdmission.mode === "continuation") {
+				if (!admission.inFlight) throw new AgentBusyError();
+			} else {
+				if (admission.inFlight) throw new AgentBusyError();
+				this.#beginInFlight(admission);
+				ownsInFlightSegment = true;
+			}
+		} else {
+			this.#beginInFlight(admission);
+			ownsInFlightSegment = true;
+		}
+		const preflightSignal = admission.signal ?? this.#promptPreflightAbortController.signal;
 
 		const rosterClaim = this.#claimIrcRosterCandidate();
 		try {
@@ -6121,11 +6579,14 @@ export class AgentSession {
 
 			// Emit before_agent_start extension event. Race hook completion with prompt
 			// cancellation so a wedged hook cannot retain SDK prompt authority.
-			if (this.#extensionRunner) {
-				const result = await this.#awaitPromptPreflight(
-					generation,
-					preflightSignal,
-					this.#extensionRunner.emitBeforeAgentStart(expandedText, options?.images, beforeAgentStartSystemPrompt),
+			const extensionRunner = this.#extensionRunner;
+			if (extensionRunner) {
+				const result = await this.#runInPromptCallbackFrame(() =>
+					this.#awaitPromptPreflight(
+						generation,
+						preflightSignal,
+						extensionRunner.emitBeforeAgentStart(expandedText, options?.images, beforeAgentStartSystemPrompt),
+					),
 				);
 				if (result?.messages) {
 					this.#appendBeforeAgentStartCustomMessages(messages, result.messages, promptAttribution, message.role);
@@ -6144,25 +6605,28 @@ export class AgentSession {
 			// alongside the extension runner (not via user-loaded hooks) and append
 			// through the same custom-message attribution path. Errors are nonfatal.
 			if (this.#beforeAgentStartContributors.length > 0) {
-				const contributed: BeforeAgentStartInternalMessage[] = [];
-				for (const contributor of this.#beforeAgentStartContributors) {
-					try {
-						const msg = await this.#awaitPromptPreflight(
-							generation,
-							preflightSignal,
-							contributor({
-								prompt: expandedText,
-								images: options?.images,
-								sessionId: this.sessionId,
-							}),
-						);
-						if (msg) contributed.push(msg);
-					} catch (err) {
-						if (this.#isPromptPreflightCancelled(generation, preflightSignal))
-							throw promptPreflightCancelledError();
-						logger.debug("before_agent_start contributor failed", { error: String(err) });
+				const contributed = await this.#runInPromptCallbackFrame(async () => {
+					const messages: BeforeAgentStartInternalMessage[] = [];
+					for (const contributor of this.#beforeAgentStartContributors) {
+						try {
+							const msg = await this.#awaitPromptPreflight(
+								generation,
+								preflightSignal,
+								contributor({
+									prompt: expandedText,
+									images: options?.images,
+									sessionId: this.sessionId,
+								}),
+							);
+							if (msg) messages.push(msg);
+						} catch (err) {
+							if (this.#isPromptPreflightCancelled(generation, preflightSignal))
+								throw promptPreflightCancelledError();
+							logger.debug("before_agent_start contributor failed", { error: String(err) });
+						}
 					}
-				}
+					return messages;
+				});
 				this.#appendBeforeAgentStartCustomMessages(messages, contributed, promptAttribution, message.role);
 			}
 
@@ -6177,8 +6641,21 @@ export class AgentSession {
 			}
 
 			const agentPromptOptions = options?.toolChoice ? { toolChoice: options.toolChoice } : undefined;
+			if (options?.workflowIntentDiff) {
+				this.sessionManager.appendCustomEntry(WORKFLOW_INTENT_DIFF_CUSTOM_TYPE, options.workflowIntentDiff);
+			}
 			options?.onPreflightAccepted?.();
-			await this.#promptAgentWithIdleRetry(messages, agentPromptOptions);
+			if (
+				options?.onPreflightAccepted &&
+				(!this.#isCurrentPromptAdmission(admission, generation) ||
+					this.#isPromptPreflightCancelled(generation, preflightSignal))
+			) {
+				this.#resetInjectedContextSignatures();
+				throw promptPreflightCancelledError();
+			}
+			await this.#promptAgentWithIdleRetry(messages, agentPromptOptions, () =>
+				this.#clearPendingPromptAdmissionClaim(admission),
+			);
 			const terminalAssistant = this.#findLastAssistantMessage();
 			if (
 				rosterClaim &&
@@ -6206,7 +6683,7 @@ export class AgentSession {
 				);
 				this.#releaseIrcRosterClaim(rosterClaim.token, rosterClaim.epoch);
 			}
-			this.#endInFlight();
+			if (ownsInFlightSegment) this.#endInFlight(admission);
 		}
 	}
 
@@ -6449,9 +6926,7 @@ export class AgentSession {
 		// continue so the steer is delivered promptly. A live loop (or an
 		// already-drained queue) makes the scheduled continue a no-op.
 		if (this.#canAutoContinueForSteer()) {
-			this.#scheduleAgentContinue({
-				shouldContinue: () => this.#canAutoContinueForSteer() && this.agent.hasQueuedSteering(),
-			});
+			this.#scheduleQueuedMessageContinuation();
 		}
 	}
 
@@ -6484,9 +6959,7 @@ export class AgentSession {
 		// resuming from user/toolResult state runs an extra model call on the
 		// stale prompt before draining the queue.
 		if (this.#canAutoContinueForFollowUp()) {
-			this.#scheduleAgentContinue({
-				shouldContinue: () => this.#canAutoContinueForFollowUp() && this.agent.hasQueuedMessages(),
-			});
+			this.#scheduleQueuedMessageContinuation();
 		}
 	}
 
@@ -6528,6 +7001,7 @@ export class AgentSession {
 		this.#pendingNextTurnMessages.push(message);
 		if (!triggerTurn) return;
 		const generation = this.#promptGeneration;
+		const inheritedAdmission = this.#getCurrentPromptAdmission(generation);
 		if (this.#scheduledHiddenNextTurnGeneration === generation) {
 			return;
 		}
@@ -6541,7 +7015,7 @@ export class AgentSession {
 					return;
 				}
 				try {
-					await this.#promptQueuedHiddenNextTurnMessages();
+					await this.#promptQueuedHiddenNextTurnMessages(inheritedAdmission, generation);
 				} catch {
 					// Leave the hidden next-turn messages queued for the next explicit prompt.
 				}
@@ -6557,32 +7031,42 @@ export class AgentSession {
 		);
 	}
 
-	async #promptQueuedHiddenNextTurnMessages(): Promise<void> {
+	async #promptQueuedHiddenNextTurnMessages(
+		inheritedAdmission?: SessionAdmissionNode,
+		generation?: number,
+	): Promise<void> {
 		if (this.#pendingNextTurnMessages.length === 0) {
 			return;
 		}
 
-		const queuedMessages = [...this.#pendingNextTurnMessages];
-		this.#pendingNextTurnMessages = [];
-		const message = queuedMessages[queuedMessages.length - 1];
-		if (!message) {
+		const promptQueuedMessages = async (admission: SessionAdmissionNode, reuseAdmission?: PromptAdmissionReuse) => {
+			const queuedMessages = [...this.#pendingNextTurnMessages];
+			this.#pendingNextTurnMessages = [];
+			const message = queuedMessages[queuedMessages.length - 1];
+			if (!message) return;
+
+			const prependMessages = queuedMessages.slice(0, -1);
+			const textContent = this.#getCustomMessageTextContent(message);
+			await this.#syncSkillPromptActiveStateSafely(message, true);
+			try {
+				await this.#promptWithMessage(admission, message, textContent, {
+					prependMessages,
+					skipPostPromptRecoveryWait: true,
+					reuseAdmission,
+				});
+			} catch (error) {
+				this.#pendingNextTurnMessages = [...queuedMessages, ...this.#pendingNextTurnMessages];
+				throw error;
+			} finally {
+				await this.#syncSkillPromptActiveStateSafely(message, false);
+			}
+		};
+
+		if (inheritedAdmission && generation !== undefined) {
+			await promptQueuedMessages(inheritedAdmission, { generation, mode: "continuation" });
 			return;
 		}
-
-		const prependMessages = queuedMessages.slice(0, -1);
-		const textContent = this.#getCustomMessageTextContent(message);
-		await this.#syncSkillPromptActiveStateSafely(message, true);
-		try {
-			await this.#promptWithMessage(message, textContent, {
-				prependMessages,
-				skipPostPromptRecoveryWait: true,
-			});
-		} catch (error) {
-			this.#pendingNextTurnMessages = [...queuedMessages, ...this.#pendingNextTurnMessages];
-			throw error;
-		} finally {
-			await this.#syncSkillPromptActiveStateSafely(message, false);
-		}
+		await this.#runWithPromptAdmission(admission => promptQueuedMessages(admission));
 	}
 
 	#getCustomMessageTextContent(message: Pick<CustomMessage, "content">): string {
@@ -6660,14 +7144,16 @@ export class AgentSession {
 					this.#queueHiddenNextTurnMessage(appMessage, false);
 					return;
 				}
-				await this.#syncSkillPromptActiveStateSafely(appMessage, true);
-				try {
-					await this.#promptWithMessage(appMessage, this.#getCustomMessageTextContent(appMessage), {
-						skipPostPromptRecoveryWait: true,
-					});
-				} finally {
-					await this.#syncSkillPromptActiveStateSafely(appMessage, false);
-				}
+				await this.#runWithPromptAdmission(async admission => {
+					await this.#syncSkillPromptActiveStateSafely(appMessage, true);
+					try {
+						await this.#promptWithMessage(admission, appMessage, this.#getCustomMessageTextContent(appMessage), {
+							skipPostPromptRecoveryWait: true,
+						});
+					} finally {
+						await this.#syncSkillPromptActiveStateSafely(appMessage, false);
+					}
+				});
 				return;
 			}
 			this.agent.appendMessage(appMessage);
@@ -6687,14 +7173,16 @@ export class AgentSession {
 				this.#queueHiddenNextTurnMessage(appMessage, false);
 				return;
 			}
-			await this.#syncSkillPromptActiveStateSafely(appMessage, true);
-			try {
-				await this.#promptWithMessage(appMessage, this.#getCustomMessageTextContent(appMessage), {
-					skipPostPromptRecoveryWait: true,
-				});
-			} finally {
-				await this.#syncSkillPromptActiveStateSafely(appMessage, false);
-			}
+			await this.#runWithPromptAdmission(async admission => {
+				await this.#syncSkillPromptActiveStateSafely(appMessage, true);
+				try {
+					await this.#promptWithMessage(admission, appMessage, this.#getCustomMessageTextContent(appMessage), {
+						skipPostPromptRecoveryWait: true,
+					});
+				} finally {
+					await this.#syncSkillPromptActiveStateSafely(appMessage, false);
+				}
+			});
 			return;
 		}
 
@@ -7462,10 +7950,10 @@ export class AgentSession {
 	async #throwDefaultModelSelectionRecovery(
 		error: Error,
 		stage: DefaultModelSelectionStage,
-		commit: GlobalDefaultModelRoleCommit,
+		commit?: GlobalDefaultModelRoleCommit,
 	): Promise<never> {
 		const sessionFailure = await this.#discardDefaultModelSelectionStage(stage);
-		const durableFailure = await this.#restoreDefaultModelSelectionCommit(commit);
+		const durableFailure = commit ? await this.#restoreDefaultModelSelectionCommit(commit) : undefined;
 		const failures = [sessionFailure, durableFailure].filter(
 			(failure): failure is { readonly stage: DefaultModelSelectionRollbackStage; readonly message: string } =>
 				failure !== undefined,
@@ -7513,15 +8001,20 @@ export class AgentSession {
 		model: Model,
 		thinkingLevel: ThinkingLevel | undefined,
 	): Promise<DefaultModelSelectionResult> {
-		const predecessor = this.#defaultModelSelectionTail;
-		const transaction = Promise.withResolvers<void>();
-		this.#defaultModelSelectionTail = transaction.promise;
+		const callbackOrigin = this.#promptCallbackOriginStorage.getStore();
+		if (callbackOrigin?.active && callbackOrigin.session === this) {
+			throw new AgentBusyError("Default model selection cannot run from a prompt callback in the same session.");
+		}
+		const admission = this.#enqueueSelectionAdmission();
 		try {
-			await predecessor;
+			await admission.admitted.promise;
+			this.#throwIfSelectionAdmissionInactive(admission);
 			if (thinkingLevel === ThinkingLevel.Inherit) {
 				throw new Error("Default model selection cannot inherit a thinking level");
 			}
+			this.#throwIfSelectionAdmissionInactive(admission);
 			const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
+			this.#throwIfSelectionAdmissionInactive(admission);
 			if (!apiKey) {
 				throw new Error(`No API key for ${model.provider}/${model.id}`);
 			}
@@ -7530,65 +8023,99 @@ export class AgentSession {
 				resolvedLevel ??
 				resolveThinkingLevelForModel(model, model.thinking?.defaultLevel ?? this.thinkingLevel) ??
 				ThinkingLevel.Off;
-			await this.waitForIdle();
+			await this.agent.waitForIdle();
+			this.#throwIfSelectionAdmissionInactive(admission);
 			await this.sessionManager.flush();
+			this.#throwIfSelectionAdmissionInactive(admission);
 			await this.#waitForAdmittedBaseSystemPromptRebuilds();
+			this.#throwIfSelectionAdmissionInactive(admission);
 			const expectedMutationRevision = this.#defaultModelSelectionMutationRevision;
 			const preparedSystemPrompt = await this.#prepareDefaultModelSelectionPrompt(model);
-			const stage = await this.sessionManager.stageDefaultModelSelection(
-				`${model.provider}/${model.id}`,
-				effectiveLevel,
-				{ appendThinkingLevel: true },
-			);
-			let durableCommit: GlobalDefaultModelRoleCommit;
+			this.#throwIfSelectionAdmissionInactive(admission);
+			const sideEffectsSettled = Promise.withResolvers<void>();
+			this.#defaultModelSelectionSideEffectsSettled = sideEffectsSettled.promise;
+			let stage: DefaultModelSelectionStage | undefined;
+			let durableCommit: GlobalDefaultModelRoleCommit | undefined;
 			try {
-				durableCommit = await this.settings.setGlobalModelRoleAndFlush(
-					"default",
-					formatModelSelectorValue(`${model.provider}/${model.id}`, effectiveLevel),
+				stage = await this.sessionManager.stageDefaultModelSelection(
+					`${model.provider}/${model.id}`,
+					effectiveLevel,
+					{ appendThinkingLevel: true },
 				);
-			} catch (error) {
-				await this.sessionManager.discardDefaultModelSelectionStage(stage);
-				throw error;
-			}
-			if (this.#defaultModelSelectionMutationRevision !== expectedMutationRevision) {
-				await this.#throwDefaultModelSelectionRecovery(
-					new Error("Default model selection was superseded before session promotion"),
-					stage,
-					durableCommit,
-				);
-			}
-			const promotion = this.sessionManager.promoteDefaultModelSelection(stage);
-			switch (promotion.kind) {
-				case "promoted": {
-					this.#publishDefaultModelSelection(model, effectiveLevel, preparedSystemPrompt);
-					break;
+				this.#throwIfSelectionAdmissionInactive(admission);
+				try {
+					this.#throwIfSelectionAdmissionInactive(admission);
+					durableCommit = await this.settings.setGlobalModelRoleAndFlush(
+						"default",
+						formatModelSelectorValue(`${model.provider}/${model.id}`, effectiveLevel),
+					);
+				} catch (error) {
+					if (this.#admissionLaneClosed) {
+						await this.#throwDefaultModelSelectionRecovery(
+							error instanceof Error ? error : new Error(String(error)),
+							stage,
+						);
+					}
+					await this.sessionManager.discardDefaultModelSelectionStage(stage);
+					throw error;
 				}
-				case "not_promoted": {
-					return this.#throwDefaultModelSelectionRecovery(
-						promotion.error ?? new Error("Default model selection was superseded before session promotion"),
+				this.#throwIfSelectionAdmissionInactive(admission);
+				if (this.#defaultModelSelectionMutationRevision !== expectedMutationRevision) {
+					await this.#throwDefaultModelSelectionRecovery(
+						new Error("Default model selection was superseded before session promotion"),
 						stage,
 						durableCommit,
 					);
 				}
-				case "unknown": {
-					const message = "Session replacement outcome could not be determined.";
-					throw new DefaultModelSelectionRecoveryError(message, {
-						message,
-						rollback: {
-							disposition: "unknown",
-							failures: [
-								{
-									stage: "session",
-									message: "Session replacement outcome could not be determined.",
-								},
-							],
-						},
-					});
+				this.#throwIfSelectionAdmissionInactive(admission);
+				const promotion = this.sessionManager.promoteDefaultModelSelection(stage);
+				switch (promotion.kind) {
+					case "promoted": {
+						this.#throwIfSelectionAdmissionInactive(admission);
+						this.#publishDefaultModelSelection(model, effectiveLevel, preparedSystemPrompt);
+						break;
+					}
+					case "not_promoted": {
+						return await this.#throwDefaultModelSelectionRecovery(
+							promotion.error ?? new Error("Default model selection was superseded before session promotion"),
+							stage,
+							durableCommit,
+						);
+					}
+					case "unknown": {
+						const message = "Session replacement outcome could not be determined.";
+						throw new DefaultModelSelectionRecoveryError(message, {
+							message,
+							rollback: {
+								disposition: "unknown",
+								failures: [
+									{
+										stage: "session",
+										message: "Session replacement outcome could not be determined.",
+									},
+								],
+							},
+						});
+					}
+				}
+			} catch (error) {
+				if (this.#admissionLaneClosed && stage && !(error instanceof DefaultModelSelectionRecoveryError)) {
+					await this.#throwDefaultModelSelectionRecovery(
+						error instanceof Error ? error : new Error(String(error)),
+						stage,
+						durableCommit,
+					);
+				}
+				throw error;
+			} finally {
+				sideEffectsSettled.resolve();
+				if (this.#defaultModelSelectionSideEffectsSettled === sideEffectsSettled.promise) {
+					this.#defaultModelSelectionSideEffectsSettled = undefined;
 				}
 			}
 			return { provider: model.provider, modelId: model.id, thinkingLevel: effectiveLevel };
 		} finally {
-			transaction.resolve();
+			this.#releaseAdmission(admission);
 		}
 	}
 	/**
@@ -8703,7 +9230,7 @@ export class AgentSession {
 		this.#checkpointState = undefined;
 		this.#pendingRewindReport = undefined;
 	}
-	async #enforcePlanModeToolDecision(): Promise<void> {
+	async #enforcePlanModeToolDecision(admission: SessionAdmissionNode, generation: number): Promise<void> {
 		if (!this.#planModeState?.enabled) {
 			return;
 		}
@@ -8733,11 +9260,18 @@ export class AgentSession {
 			askToolName: "ask",
 		});
 
-		await this.prompt(reminder, {
-			synthetic: true,
-			expandPromptTemplates: false,
-			toolChoice: "required",
-		});
+		await this.refreshGjcSubskillTools();
+		await this.#promptWithMessage(
+			admission,
+			{
+				role: "developer",
+				content: [{ type: "text", text: reminder }],
+				attribution: "agent",
+				timestamp: Date.now(),
+			},
+			reminder,
+			{ toolChoice: "required", reuseAdmission: { generation, mode: "sequential" } },
+		);
 	}
 
 	#createEagerTodoPrelude(promptText: string): { message: AgentMessage; toolChoice?: ToolChoice } | undefined {
@@ -10506,6 +11040,7 @@ export class AgentSession {
 		this.#scheduleAgentContinue({
 			delayMs: 1,
 			generation,
+			inheritedAdmission: this.#getCurrentPromptAdmission(generation),
 			onError: () => this.#failRetryRecovery("Retry continuation failed to start"),
 			onSkip: () => this.#failRetryRecovery("Retry continuation was superseded"),
 		});
@@ -10555,11 +11090,17 @@ export class AgentSession {
 		this.#resolveRetry();
 	}
 
-	async #promptAgentWithIdleRetry(messages: AgentMessage[], options?: { toolChoice?: ToolChoice }): Promise<void> {
+	async #promptAgentWithIdleRetry(
+		messages: AgentMessage[],
+		options: { toolChoice?: ToolChoice } | undefined,
+		onStarted: () => void,
+	): Promise<void> {
 		const deadline = Date.now() + 30_000;
 		for (;;) {
 			try {
-				await this.agent.prompt(messages, options);
+				const prompt = this.agent.prompt(messages, options);
+				onStarted();
+				await prompt;
 				return;
 			} catch (err) {
 				if (!(err instanceof AgentBusyError)) {
@@ -10614,34 +11155,43 @@ export class AgentSession {
 	 * @returns true if retry/resume was initiated, false if no retryable tail exists or agent is busy
 	 */
 	async retry(): Promise<boolean> {
-		if (this.isStreaming || this.isCompacting || this.isRetrying) return false;
+		if (this.#admissionLaneClosed || this.isStreaming || this.isCompacting || this.isRetrying) return false;
 
 		const messages = this.agent.state.messages;
 		const lastMsg = messages[messages.length - 1];
 		if (!lastMsg) return false;
 
+		let dropAssistant = false;
 		if (lastMsg.role !== "assistant") {
 			if (!this.#isInterruptedRetryTail(lastMsg)) return false;
-			this.#retryAttempt = 0;
-			this.#scheduleAgentContinue({ delayMs: 1 });
-			return true;
+		} else {
+			const assistantMsg = lastMsg as AssistantMessage;
+			dropAssistant =
+				assistantMsg.stopReason === "error" ||
+				assistantMsg.stopReason === "aborted" ||
+				this.#isUnresolvedToolUseAssistant(assistantMsg);
+			if (!dropAssistant) return false;
 		}
 
-		const assistantMsg = lastMsg as AssistantMessage;
-		const shouldDropAssistant =
-			assistantMsg.stopReason === "error" ||
-			assistantMsg.stopReason === "aborted" ||
-			this.#isUnresolvedToolUseAssistant(assistantMsg);
-		if (!shouldDropAssistant) return false;
+		let reservedAdmission: SessionAdmissionNode;
+		try {
+			reservedAdmission = this.#enqueuePromptAdmission();
+		} catch (error) {
+			if (error instanceof AgentBusyError) return false;
+			throw error;
+		}
+		void reservedAdmission.admitted.promise.catch(() => {});
+		if (dropAssistant) {
+			this.agent.replaceMessages(messages.slice(0, -1));
+		}
 
-		// Remove the failed/aborted/incomplete assistant message before re-attempting.
-		this.agent.replaceMessages(messages.slice(0, -1));
-
-		// Reset retry budget for a fresh attempt
-		this.#retryAttempt = 0;
-
-		// Re-attempt the turn
-		this.#scheduleAgentContinue({ delayMs: 1 });
+		this.#scheduleAgentContinue({
+			delayMs: 1,
+			reservedAdmission,
+			beforeContinue: () => {
+				this.#retryAttempt = 0;
+			},
+		});
 
 		return true;
 	}

--- a/packages/coding-agent/test/agent-session-default-model-selection.test.ts
+++ b/packages/coding-agent/test/agent-session-default-model-selection.test.ts
@@ -2,14 +2,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Agent, type AgentTool, ThinkingLevel } from "@gajae-code/agent-core";
-import { Effort, type Model } from "@gajae-code/ai";
+import { scheduler } from "node:timers/promises";
+import { Agent, AgentBusyError, type AgentTool, ThinkingLevel } from "@gajae-code/agent-core";
+import { Effort, type Message, type Model } from "@gajae-code/ai";
 import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import type { CustomTool } from "@gajae-code/coding-agent/extensibility/custom-tools/types";
+import { ExtensionRuntime } from "@gajae-code/coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@gajae-code/coding-agent/extensibility/extensions/runner";
+import type { Extension, ExtensionUIContext } from "@gajae-code/coding-agent/extensibility/extensions/types";
+import { ExtensionUiController } from "@gajae-code/coding-agent/modes/controllers/extension-ui-controller";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
 import { AgentSession, DefaultModelSelectionRecoveryError } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { convertToLlm } from "@gajae-code/coding-agent/session/messages";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import {
 	MemorySessionStorage,
@@ -273,9 +280,16 @@ describe("AgentSession durable default model selection", () => {
 	let settings: Settings;
 	let activeStream: AssistantMessageEventStream | undefined;
 	let streamCreated: PromiseWithResolvers<void>;
+	let secondStreamCreated: PromiseWithResolvers<void> | undefined;
+	let streamCount: number;
+	let providerSignalAborted: boolean | undefined;
+	const getActiveStream = (): AssistantMessageEventStream | undefined => activeStream;
 
 	beforeEach(async () => {
 		streamCreated = Promise.withResolvers<void>();
+		secondStreamCreated = undefined;
+		streamCount = 0;
+		providerSignalAborted = undefined;
 		tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-default-model-session-"));
 		authStorage = await AuthStorage.create(path.join(tempRoot, "auth.db"));
 		authStorage.setRuntimeApiKey(INITIAL_MODEL.provider, "initial-key");
@@ -284,9 +298,12 @@ describe("AgentSession durable default model selection", () => {
 		const agent = new Agent({
 			getApiKey: () => "test-key",
 			initialState: { model: INITIAL_MODEL, systemPrompt: ["Test"], tools: [] },
-			streamFn: () => {
+			streamFn: (_model, _context, options) => {
+				providerSignalAborted = options?.signal?.aborted;
 				activeStream = new AssistantMessageEventStream();
-				streamCreated.resolve();
+				streamCount++;
+				if (streamCount === 1) streamCreated.resolve();
+				if (streamCount === 2) secondStreamCreated?.resolve();
 				return activeStream;
 			},
 		});
@@ -318,33 +335,17 @@ describe("AgentSession durable default model selection", () => {
 	it("waits for an in-flight response before any durable or session mutation", async () => {
 		// Given
 		const model = targetModel({ minLevel: Effort.Medium, maxLevel: Effort.High });
-		const preflightComplete = Promise.withResolvers<void>();
-		const originalGetApiKey = modelRegistry.getApiKey.bind(modelRegistry);
-		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async (...args) => {
-			const apiKey = await originalGetApiKey(...args);
-			preflightComplete.resolve();
-			return apiKey;
-		});
 		const prompt = session.prompt("in flight");
 		await streamCreated.promise;
 		const entriesBeforeSelection = sessionManager.getEntries();
-		const idleBarrierEntered = Promise.withResolvers<"idle">();
-		const originalWaitForIdle = session.waitForIdle.bind(session);
-		vi.spyOn(session, "waitForIdle").mockImplementation(async () => {
-			idleBarrierEntered.resolve("idle");
-			await originalWaitForIdle();
-		});
-		const durableAttempted = Promise.withResolvers<"durable">();
 		const originalDurableCommit = settings.setGlobalModelRoleAndFlush.bind(settings);
 		const durableCommit = vi.spyOn(settings, "setGlobalModelRoleAndFlush").mockImplementation(async (...args) => {
-			durableAttempted.resolve("durable");
 			return originalDurableCommit(...args);
 		});
 
 		// When
 		const selection = session.setDefaultModelSelection(model, Effort.XHigh);
-		await preflightComplete.promise;
-		const firstMutationBoundary = await Promise.race([idleBarrierEntered.promise, durableAttempted.promise]);
+		await new Promise<void>(resolve => setImmediate(resolve));
 		const durableCallsBeforeIdle = durableCommit.mock.calls.length;
 		const modelBeforeIdle = session.model;
 		const entriesWhileStreaming = sessionManager.getEntries();
@@ -356,7 +357,6 @@ describe("AgentSession durable default model selection", () => {
 		activeStream = undefined;
 		await prompt;
 		const result = await selection;
-		expect(firstMutationBoundary).toBe("idle");
 		expect(durableCallsBeforeIdle).toBe(0);
 		expect(modelBeforeIdle).toBe(INITIAL_MODEL);
 		expect(entriesWhileStreaming).toEqual(entriesBeforeSelection);
@@ -576,6 +576,2490 @@ describe("AgentSession durable default model selection", () => {
 		expect(session.model).toBe(lastModel);
 		expect(session.thinkingLevel).toBe(Effort.High);
 		expect(sessionManager.buildSessionContext().models.default).toBe("target-provider/last");
+	});
+
+	it("[A] keeps selection validation and mutation behind an admitted before_agent_start prompt", async () => {
+		// Given
+		const contributorEntered = Promise.withResolvers<void>();
+		const inspectSelection = Promise.withResolvers<void>();
+		const contributorInspectionComplete = Promise.withResolvers<void>();
+		const releaseContributor = Promise.withResolvers<void>();
+		const releaseSelectionValidation = Promise.withResolvers<void>();
+		const unregister = session.registerBeforeAgentStartContributor(async () => {
+			contributorEntered.resolve();
+			await inspectSelection.promise;
+			contributorInspectionComplete.resolve();
+			await releaseContributor.promise;
+			return undefined;
+		});
+		const originalGetApiKey = modelRegistry.getApiKey.bind(modelRegistry);
+		const getApiKey = vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async (model, ...args) => {
+			if (model.provider === "target-provider") await releaseSelectionValidation.promise;
+			return originalGetApiKey(model, ...args);
+		});
+		const stageSelection = vi.spyOn(sessionManager, "stageDefaultModelSelection");
+		const durableSelection = vi.spyOn(settings, "setGlobalModelRoleAndFlush");
+		const setLiveModel = vi.spyOn(session.agent, "setModel");
+		const entriesBefore = sessionManager.getEntries();
+		const prompt = session.prompt("prompt admitted before selection");
+		let selection: Promise<unknown> | undefined;
+
+		try {
+			await contributorEntered.promise;
+
+			// When
+			selection = session.setDefaultModelSelection(targetModel(), Effort.High);
+			inspectSelection.resolve();
+			await contributorInspectionComplete.promise;
+
+			// Then
+			expect(getApiKey.mock.calls.filter(([model]) => model.provider === "target-provider")).toHaveLength(0);
+			expect(stageSelection).not.toHaveBeenCalled();
+			expect(durableSelection).not.toHaveBeenCalled();
+			expect(setLiveModel).not.toHaveBeenCalled();
+			expect(settings.getGlobal("modelRoles")).toBeUndefined();
+			expect(session.model).toBe(INITIAL_MODEL);
+			expect(sessionManager.getEntries()).toEqual(entriesBefore);
+		} finally {
+			inspectSelection.resolve();
+			releaseSelectionValidation.resolve();
+			releaseContributor.resolve();
+			unregister();
+			await streamCreated.promise;
+			const message = createAssistantMessage("case A cleanup");
+			activeStream?.push({ type: "done", reason: "stop", message });
+			activeStream?.end(message);
+			activeStream = undefined;
+			await Promise.allSettled([prompt, ...(selection ? [selection] : [])]);
+		}
+	});
+
+	it("[K] keeps selection mutation behind a real file-mention preflight read", async () => {
+		// Given
+		const mentionName = "preflight-default-selection-mention.txt";
+		const mentionPath = path.join(tempRoot, mentionName);
+		await Bun.write(mentionPath, "file mention body\n");
+		const fileReadEntered = Promise.withResolvers<void>();
+		const releaseFileRead = Promise.withResolvers<void>();
+		const originalFile = Bun.file.bind(Bun);
+		const fileSpy = vi.spyOn(Bun, "file").mockImplementation((filePath, options) => {
+			const file =
+				typeof filePath === "number"
+					? originalFile(filePath, options)
+					: typeof filePath === "string" || filePath instanceof URL
+						? originalFile(filePath, options)
+						: originalFile(filePath, options);
+			if (filePath.toString() !== mentionPath) return file;
+			return new Proxy(file, {
+				get(target, property) {
+					if (property === "text") {
+						return async (): Promise<string> => {
+							fileReadEntered.resolve();
+							await releaseFileRead.promise;
+							return target.text();
+						};
+					}
+					const value = Reflect.get(target, property, target);
+					return typeof value === "function" ? value.bind(target) : value;
+				},
+			});
+		});
+		const prepareSelection = vi.spyOn(session.agent, "setSystemPrompt");
+		const stageSelection = vi.spyOn(sessionManager, "stageDefaultModelSelection");
+		const durableSelection = vi.spyOn(settings, "setGlobalModelRoleAndFlush");
+		const setLiveModel = vi.spyOn(session.agent, "setModel");
+		const entriesBefore = sessionManager.getEntries();
+		const prompt = session.prompt(`@${mentionName}`);
+		let selection: Promise<unknown> | undefined;
+
+		try {
+			await fileReadEntered.promise;
+
+			// When
+			selection = session.setDefaultModelSelection(targetModel(), Effort.High);
+			await new Promise<void>(resolve => setImmediate(resolve));
+
+			// Then
+			expect(prepareSelection).not.toHaveBeenCalled();
+			expect(stageSelection).not.toHaveBeenCalled();
+			expect(durableSelection).not.toHaveBeenCalled();
+			expect(setLiveModel).not.toHaveBeenCalled();
+			expect(settings.getGlobal("modelRoles")).toBeUndefined();
+			expect(session.model).toBe(INITIAL_MODEL);
+			expect(sessionManager.getEntries()).toEqual(entriesBefore);
+		} finally {
+			releaseFileRead.resolve();
+			fileSpy.mockRestore();
+			await streamCreated.promise;
+			const message = createAssistantMessage("case K cleanup");
+			activeStream?.push({ type: "done", reason: "stop", message });
+			activeStream?.end(message);
+			activeStream = undefined;
+			await Promise.allSettled([prompt, ...(selection ? [selection] : [])]);
+			await fs.rm(mentionPath, { force: true });
+		}
+	});
+
+	it("[B] blocks prompt caller-side mutation while selection owns drain-to-stage", async () => {
+		// Given
+		const selectionFlushEntered = Promise.withResolvers<void>();
+		const releaseSelectionFlush = Promise.withResolvers<void>();
+		const originalFlush = sessionManager.flush.bind(sessionManager);
+		vi.spyOn(sessionManager, "flush").mockImplementation(async () => {
+			selectionFlushEntered.resolve();
+			await releaseSelectionFlush.promise;
+			return originalFlush();
+		});
+		const refreshSubskills = vi.spyOn(session, "refreshGjcSubskillTools");
+		const appendWorkflowIntent = vi.spyOn(sessionManager, "appendCustomEntry");
+		const entriesBefore = sessionManager.getEntries();
+		const transcriptBefore = session.agent.state.messages;
+		const toolChoicesBefore = session.toolChoiceQueue.inspect();
+		const activeSkillBefore = session.getActiveSkillState();
+		const selection = session.setDefaultModelSelection(targetModel(), Effort.High);
+		let prompt: Promise<void> | undefined;
+
+		try {
+			await selectionFlushEntered.promise;
+
+			// When
+			prompt = session.prompt("plan an architecture migration regression");
+
+			// Then
+			expect(appendWorkflowIntent).not.toHaveBeenCalled();
+			expect(sessionManager.getEntries()).toEqual(entriesBefore);
+			expect(session.agent.state.messages).toEqual(transcriptBefore);
+			expect(session.toolChoiceQueue.inspect()).toEqual(toolChoicesBefore);
+			expect(refreshSubskills).not.toHaveBeenCalled();
+			expect(session.getActiveSkillState()).toEqual(activeSkillBefore);
+			expect(streamCount).toBe(0);
+		} finally {
+			releaseSelectionFlush.resolve();
+			await selection.catch(() => {});
+			if (prompt) {
+				await streamCreated.promise;
+				const message = createAssistantMessage("case B cleanup");
+				activeStream?.push({ type: "done", reason: "stop", message });
+				activeStream?.end(message);
+				activeStream = undefined;
+				await prompt.catch(() => {});
+			}
+		}
+	});
+
+	it("keeps plan-mode enforcement inside the outer prompt admission before a queued selector", async () => {
+		// Given
+		await session.dispose();
+		settings.set("compaction.enabled", false);
+		const requiredTools: AgentTool[] = ["ask", "resolve"].map(name => ({
+			name,
+			label: name,
+			description: `${name} test tool`,
+			parameters: z.object({}),
+			execute: async () => ({ content: [{ type: "text" as const, text: `${name} complete` }] }),
+		}));
+		const callMessages: Message[][] = [];
+		const callToolChoices: unknown[] = [];
+		const order: string[] = [];
+		let firstStream: AssistantMessageEventStream | undefined;
+		const firstCallCreated = Promise.withResolvers<void>();
+		const planAgent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: INITIAL_MODEL, systemPrompt: ["Test"], tools: requiredTools },
+			convertToLlm,
+			streamFn: (_model, context, options) => {
+				callMessages.push([...context.messages]);
+				callToolChoices.push(options?.toolChoice);
+				const callNumber = callMessages.length;
+				order.push(callNumber === 1 ? "outer provider call" : "enforcement provider call");
+				const stream = new AssistantMessageEventStream();
+				activeStream = stream;
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: createAssistantMessage("") });
+					if (callNumber === 1) {
+						firstStream = stream;
+						firstCallCreated.resolve();
+						return;
+					}
+					const message = createAssistantMessage("plan decision requested");
+					stream.push({ type: "done", reason: "stop", message });
+					stream.end(message);
+					if (activeStream === stream) activeStream = undefined;
+				});
+				return stream;
+			},
+		});
+		session = new AgentSession({
+			agent: planAgent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			toolRegistry: new Map(requiredTools.map(tool => [tool.name, tool])),
+			thinkingLevel: Effort.Low,
+		});
+		session.setPlanModeState({ enabled: true, planFilePath: path.join(tempRoot, "PLAN.md") });
+		const originalGetApiKey = modelRegistry.getApiKey.bind(modelRegistry);
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async (model, ...args) => {
+			if (model.provider === "target-provider") order.push("selector validate");
+			return originalGetApiKey(model, ...args);
+		});
+		const originalStage = sessionManager.stageDefaultModelSelection.bind(sessionManager);
+		vi.spyOn(sessionManager, "stageDefaultModelSelection").mockImplementation(async (...args) => {
+			order.push("selector stage");
+			return originalStage(...args);
+		});
+		const originalCommit = settings.setGlobalModelRoleAndFlush.bind(settings);
+		vi.spyOn(settings, "setGlobalModelRoleAndFlush").mockImplementation(async (...args) => {
+			order.push("selector commit");
+			return originalCommit(...args);
+		});
+		const prompt = session.prompt("prepare the migration plan");
+		let selection: Promise<unknown> | undefined;
+
+		try {
+			await firstCallCreated.promise;
+			selection = session.setDefaultModelSelection(targetModel(), Effort.High);
+			const firstMessage = createAssistantMessage("drafted a plan without asking or resolving");
+
+			// When
+			firstStream?.push({ type: "done", reason: "stop", message: firstMessage });
+			firstStream?.end(firstMessage);
+			firstStream = undefined;
+			if (activeStream) activeStream = undefined;
+
+			// Then
+			let promptFailure: unknown;
+			try {
+				await prompt;
+			} catch (error) {
+				promptFailure = error;
+			}
+			await expect(selection).resolves.toEqual({
+				provider: "target-provider",
+				modelId: "reasoning",
+				thinkingLevel: Effort.High,
+			});
+			expect({
+				promptErrorName: promptFailure instanceof Error ? promptFailure.name : undefined,
+				providerCallCount: callMessages.length,
+			}).toEqual({ promptErrorName: undefined, providerCallCount: 2 });
+			expect(callToolChoices).toEqual([undefined, "required"]);
+			const secondCall = callMessages[1];
+			if (!secondCall) throw new Error("Expected plan-mode enforcement provider call");
+			expect(secondCall.slice(-3)).toMatchObject([
+				{ role: "assistant", content: [{ type: "text", text: "drafted a plan without asking or resolving" }] },
+				{ role: "user", content: [{ type: "text", text: expect.stringContaining("current working directory") }] },
+				{
+					role: "developer",
+					content: [
+						{
+							type: "text",
+							text: [
+								"<system-reminder>",
+								"Plan mode turn ended without a required tool call.",
+								"",
+								"You MUST choose exactly one next action now:",
+								"1. Call `ask` to gather required clarification, OR",
+								'2. Call `resolve` with `action: "apply"`, `reason`, and `extra: { title: "<PLAN_TITLE>" }` to finish planning and request approval',
+								"",
+								"You NEVER output plain text in this turn.",
+								"</system-reminder>",
+							].join("\n"),
+						},
+					],
+				},
+			]);
+			expect(order).toEqual([
+				"outer provider call",
+				"enforcement provider call",
+				"selector validate",
+				"selector stage",
+				"selector commit",
+			]);
+		} finally {
+			if (firstStream) {
+				const cleanupMessage = createAssistantMessage("plan enforcement cleanup");
+				firstStream.push({ type: "done", reason: "stop", message: cleanupMessage });
+				firstStream.end(cleanupMessage);
+			}
+			await Promise.allSettled([prompt, ...(selection ? [selection] : [])]);
+		}
+	});
+
+	it("[C] preserves exact mixed FIFO order S1 then S2 then prompt", async () => {
+		// Given
+		const firstModel = { ...targetModel(), id: "matrix-s1" };
+		const secondModel = { ...targetModel(), id: "matrix-s2" };
+		const firstCommitEntered = Promise.withResolvers<void>();
+		const releaseFirstCommit = Promise.withResolvers<void>();
+		const promptContributorEntered = Promise.withResolvers<void>();
+		const releasePromptContributor = Promise.withResolvers<void>();
+		const order: string[] = [];
+		const refreshSubskills = vi.spyOn(session, "refreshGjcSubskillTools");
+		const originalCommit = settings.setGlobalModelRoleAndFlush.bind(settings);
+		vi.spyOn(settings, "setGlobalModelRoleAndFlush").mockImplementation(async (role, selector) => {
+			if (selector === undefined) throw new Error("Expected durable model selector");
+			if (selector.includes("matrix-s1")) {
+				order.push("S1");
+				firstCommitEntered.resolve();
+				await releaseFirstCommit.promise;
+			}
+			if (selector.includes("matrix-s2")) order.push("S2");
+			return originalCommit(role, selector);
+		});
+		const unregister = session.registerBeforeAgentStartContributor(async () => {
+			order.push("P");
+			promptContributorEntered.resolve();
+			await releasePromptContributor.promise;
+			return undefined;
+		});
+		const first = session.setDefaultModelSelection(firstModel, Effort.Low);
+		void first.catch(() => {});
+		let second: Promise<unknown> | undefined;
+		let prompt: Promise<void> | undefined;
+
+		try {
+			await firstCommitEntered.promise;
+
+			// When
+			second = session.setDefaultModelSelection(secondModel, Effort.High);
+			void second.catch(() => {});
+			prompt = session.prompt("mixed FIFO prompt");
+			void prompt.catch(() => {});
+
+			// Then
+			expect(refreshSubskills).not.toHaveBeenCalled();
+			expect(order).toEqual(["S1"]);
+			releaseFirstCommit.resolve();
+			await Promise.all([first, second]);
+			await promptContributorEntered.promise;
+			expect(order).toEqual(["S1", "S2", "P"]);
+		} finally {
+			releaseFirstCommit.resolve();
+			releasePromptContributor.resolve();
+			unregister();
+			if (prompt) await streamCreated.promise;
+			const message = createAssistantMessage("case C cleanup");
+			activeStream?.push({ type: "done", reason: "stop", message });
+			activeStream?.end(message);
+			activeStream = undefined;
+			await Promise.allSettled([first, ...(second ? [second] : []), ...(prompt ? [prompt] : [])]);
+		}
+	});
+
+	it("[D] keeps one pending prompt claim behind a selector and rejects a second prompt as busy", async () => {
+		// Given
+		const selectionFlushEntered = Promise.withResolvers<void>();
+		const releaseSelectionFlush = Promise.withResolvers<void>();
+		const originalFlush = sessionManager.flush.bind(sessionManager);
+		vi.spyOn(sessionManager, "flush").mockImplementation(async () => {
+			selectionFlushEntered.resolve();
+			await releaseSelectionFlush.promise;
+			return originalFlush();
+		});
+		const refreshSubskills = vi.spyOn(session, "refreshGjcSubskillTools");
+		const releaseRefresh = Promise.withResolvers<void>();
+		const promptContributorEntered = Promise.withResolvers<void>();
+		const releasePromptContributor = Promise.withResolvers<void>();
+		refreshSubskills.mockImplementation(async () => {
+			await releaseRefresh.promise;
+		});
+		const unregister = session.registerBeforeAgentStartContributor(async () => {
+			promptContributorEntered.resolve();
+			await releasePromptContributor.promise;
+			return undefined;
+		});
+		const selection = session.setDefaultModelSelection(targetModel(), Effort.High);
+		let firstPrompt: Promise<void> | undefined;
+		let secondPrompt: Promise<void> | undefined;
+
+		try {
+			await selectionFlushEntered.promise;
+
+			// When
+			firstPrompt = session.prompt("first pending prompt");
+			secondPrompt = session.prompt("second pending prompt");
+			void firstPrompt.catch(() => {});
+			void secondPrompt.catch(() => {});
+
+			// Then
+			expect(refreshSubskills).not.toHaveBeenCalled();
+			await expect(secondPrompt).rejects.toBeInstanceOf(AgentBusyError);
+		} finally {
+			if (refreshSubskills.mock.calls.length > 0) {
+				releaseRefresh.resolve();
+				await promptContributorEntered.promise;
+				await session.abort();
+			} else {
+				await session.abort();
+				releaseRefresh.resolve();
+			}
+			releasePromptContributor.resolve();
+			releaseSelectionFlush.resolve();
+			unregister();
+			await Promise.allSettled([
+				selection,
+				...(firstPrompt ? [firstPrompt] : []),
+				...(secondPrompt ? [secondPrompt] : []),
+			]);
+		}
+	});
+
+	it("keeps an admitted preflight prompt claimed until its provider starts and admits an agent_end successor", async () => {
+		// Given
+		const preflightEntered = Promise.withResolvers<void>();
+		const releasePreflight = Promise.withResolvers<void>();
+		secondStreamCreated = Promise.withResolvers<void>();
+		vi.spyOn(session, "refreshGjcSubskillTools").mockImplementation(async () => {
+			preflightEntered.resolve();
+			await releasePreflight.promise;
+		});
+		let successorPrompt: Promise<void> | undefined;
+		const unsubscribe = session.subscribe(event => {
+			if (event.type !== "agent_end" || successorPrompt) return;
+			successorPrompt = session.prompt("agent_end successor prompt");
+		});
+		const firstPrompt = session.prompt("admitted preflight owner");
+		let secondPrompt: Promise<void> | undefined;
+
+		try {
+			await preflightEntered.promise;
+
+			// When
+			secondPrompt = session.prompt("same-tick competing prompt");
+			const sameTickBoundary = Promise.withResolvers<"pending">();
+			setImmediate(() => sameTickBoundary.resolve("pending"));
+			const secondOutcome = await Promise.race([
+				secondPrompt.then(
+					() => "resolved" as const,
+					error => error,
+				),
+				sameTickBoundary.promise,
+			]);
+
+			// Then
+			expect(secondOutcome).toBeInstanceOf(AgentBusyError);
+			releasePreflight.resolve();
+			await streamCreated.promise;
+			const firstMessage = createAssistantMessage("first provider complete");
+			activeStream?.push({ type: "done", reason: "stop", message: firstMessage });
+			activeStream?.end(firstMessage);
+			activeStream = undefined;
+			await firstPrompt;
+			await secondStreamCreated.promise;
+			const successorMessage = createAssistantMessage("successor provider complete");
+			getActiveStream()?.push({ type: "done", reason: "stop", message: successorMessage });
+			getActiveStream()?.end(successorMessage);
+			activeStream = undefined;
+			await successorPrompt;
+			expect(streamCount).toBe(2);
+		} finally {
+			releasePreflight.resolve();
+			unsubscribe();
+			await session.abort();
+			await Promise.allSettled([
+				firstPrompt,
+				...(secondPrompt ? [secondPrompt] : []),
+				...(successorPrompt ? [successorPrompt] : []),
+			]);
+		}
+	});
+
+	it("[E] rejects same-session contributor reentrant selection with the stable busy contract", async () => {
+		// Given
+		let reentrantError: unknown;
+		const reentrantSettled = Promise.withResolvers<void>();
+		const entriesBefore = sessionManager.getEntries();
+		const unregister = session.registerBeforeAgentStartContributor(async () => {
+			try {
+				await session.setDefaultModelSelection(targetModel(), Effort.High);
+			} catch (error) {
+				reentrantError = error;
+			} finally {
+				reentrantSettled.resolve();
+			}
+			return undefined;
+		});
+		const prompt = session.prompt("reentrant contributor prompt");
+
+		try {
+			// When
+			await reentrantSettled.promise;
+
+			// Then
+			expect(reentrantError).toBeInstanceOf(AgentBusyError);
+			expect(reentrantError).toMatchObject({
+				name: "AgentBusyError",
+				message: "Default model selection cannot run from a prompt callback in the same session.",
+			});
+			expect(reentrantError).not.toHaveProperty("code");
+			expect(settings.getGlobal("modelRoles")).toBeUndefined();
+			expect(session.model).toBe(INITIAL_MODEL);
+			expect(sessionManager.getEntries()).toEqual(entriesBefore);
+		} finally {
+			unregister();
+			await session.abort();
+			await prompt.catch(() => {});
+		}
+	});
+
+	it("[E event] marks only an awaited same-session extension model.set callback", async () => {
+		// Given
+		const initialModel = { ...INITIAL_MODEL, contextWindow: 1_000_000 };
+		const reentrantModel = { ...targetModel(), id: "event-reentrant", contextWindow: 1_000_000 };
+		const externalModel = { ...targetModel(), id: "event-external", contextWindow: 1_000_000 };
+		const detachedModel = { ...targetModel(), id: "event-detached", contextWindow: 1_000_000 };
+		const laterModel = { ...targetModel(), id: "event-later", contextWindow: 1_000_000 };
+		modelRegistry.registerProvider("target-provider", {
+			baseUrl: "https://example.invalid/v1",
+			apiKey: "target-key",
+			api: "anthropic-messages",
+			models: [reentrantModel, externalModel, detachedModel, laterModel],
+		});
+		const handlerEntered = Promise.withResolvers<void>();
+		const releaseHandler = Promise.withResolvers<void>();
+		let reentrantError: unknown;
+		let detachedCall: (() => Promise<unknown>) | undefined;
+		const otherManager = SessionManager.inMemory(path.join(tempRoot, "other-session"));
+		const otherSettings = Settings.isolated();
+		const otherSession = new AgentSession({
+			agent: new Agent({
+				getApiKey: () => "test-key",
+				initialState: { model: initialModel, systemPrompt: ["Other"], tools: [] },
+			}),
+			sessionManager: otherManager,
+			settings: otherSettings,
+			modelRegistry,
+			thinkingLevel: Effort.Low,
+		});
+		let otherResult: unknown;
+		const handler = async (...args: unknown[]): Promise<unknown> => {
+			const context = args[1];
+			if (
+				typeof context !== "object" ||
+				context === null ||
+				!("sdkControl" in context) ||
+				typeof context.sdkControl !== "function"
+			) {
+				throw new Error("Expected extension SDK control context");
+			}
+			const sdkControl = context.sdkControl;
+			handlerEntered.resolve();
+			await releaseHandler.promise;
+			const otherSelection = otherSession.setDefaultModelSelection(reentrantModel, Effort.Low);
+			try {
+				await sdkControl("model.set", { id: "target-provider/event-reentrant", thinkingLevel: "high" });
+			} catch (error) {
+				reentrantError = error;
+			}
+			otherResult = await otherSelection;
+			detachedCall = () =>
+				sdkControl("model.set", {
+					id: "target-provider/event-detached",
+					thinkingLevel: "low",
+				});
+			return undefined;
+		};
+		const extension: Extension = {
+			path: "test:event-reentrant",
+			resolvedPath: "test:event-reentrant",
+			handlers: new Map([["before_agent_start", [handler]]]),
+			tools: new Map(),
+			messageRenderers: new Map(),
+			commands: new Map(),
+			flags: new Map(),
+			shortcuts: new Map(),
+		};
+		const extensionRunner = new ExtensionRunner(
+			[extension],
+			new ExtensionRuntime(),
+			tempRoot,
+			sessionManager,
+			modelRegistry,
+		);
+		await session.dispose();
+		session = new AgentSession({
+			agent: new Agent({
+				getApiKey: () => "test-key",
+				initialState: { model: initialModel, systemPrompt: ["Test"], tools: [] },
+				streamFn: () => {
+					activeStream = new AssistantMessageEventStream();
+					streamCount++;
+					if (streamCount === 1) streamCreated.resolve();
+					return activeStream;
+				},
+			}),
+			sessionManager,
+			settings,
+			modelRegistry,
+			thinkingLevel: Effort.Low,
+			extensionRunner,
+		});
+		const controller = new ExtensionUiController({
+			session,
+			sessionManager,
+			isBackgrounded: true,
+			shutdownRequested: false,
+		} as unknown as InteractiveModeContext);
+		controller.initializeHookRunner({} as ExtensionUIContext, false);
+		const stageSelection = vi.spyOn(sessionManager, "stageDefaultModelSelection");
+		const durableSelection = vi.spyOn(settings, "setGlobalModelRoleAndFlush");
+		const setLiveModel = vi.spyOn(session.agent, "setModel");
+		const prompt = session.prompt("extension reentrant prompt");
+		void prompt.catch(() => {});
+		let externalSelection: Promise<unknown> | undefined;
+
+		try {
+			await handlerEntered.promise;
+			externalSelection = session.setDefaultModelSelection(externalModel, Effort.High);
+			void externalSelection.catch(() => {});
+
+			// When
+			releaseHandler.resolve();
+			await streamCreated.promise;
+
+			// Then
+			expect(reentrantError).toBeInstanceOf(AgentBusyError);
+			expect(reentrantError).toMatchObject({
+				name: "AgentBusyError",
+				message: "Default model selection cannot run from a prompt callback in the same session.",
+			});
+			expect(reentrantError).not.toHaveProperty("code");
+			expect(stageSelection).not.toHaveBeenCalled();
+			expect(durableSelection).not.toHaveBeenCalled();
+			expect(setLiveModel).not.toHaveBeenCalled();
+			expect(settings.getGlobal("modelRoles")).toBeUndefined();
+			expect(session.model).toBe(initialModel);
+			expect(otherResult).toEqual({
+				provider: "target-provider",
+				modelId: "event-reentrant",
+				thinkingLevel: Effort.Low,
+			});
+			const message = createAssistantMessage("event prompt complete");
+			activeStream?.push({ type: "done", reason: "stop", message });
+			activeStream?.end(message);
+			activeStream = undefined;
+			await expect(externalSelection).resolves.toEqual({
+				provider: "target-provider",
+				modelId: "event-external",
+				thinkingLevel: Effort.High,
+			});
+			await prompt;
+			expect(streamCount).toBe(1);
+			const callDetached = detachedCall;
+			if (!callDetached) throw new Error("Expected detached model selection callback");
+			await expect(callDetached()).resolves.toEqual({
+				provider: "target-provider",
+				modelId: "event-detached",
+				thinkingLevel: Effort.Low,
+			});
+			await expect(session.setDefaultModelSelection(laterModel, Effort.High)).resolves.toEqual({
+				provider: "target-provider",
+				modelId: "event-later",
+				thinkingLevel: Effort.High,
+			});
+		} finally {
+			releaseHandler.resolve();
+			await session.abort();
+			await Promise.allSettled([prompt, ...(externalSelection ? [externalSelection] : [])]);
+			await otherSession.dispose();
+		}
+	});
+
+	it("rejects same-session model.set from an awaited message_end extension handler", async () => {
+		// Given
+		const initialModel = { ...INITIAL_MODEL, contextWindow: 1_000_000 };
+		const eventModel = { ...targetModel(), id: "message-end-reentrant", contextWindow: 1_000_000 };
+		modelRegistry.registerProvider("target-provider", {
+			baseUrl: "https://example.invalid/v1",
+			apiKey: "target-key",
+			api: "anthropic-messages",
+			models: [eventModel],
+		});
+		const handlerEntered = Promise.withResolvers<void>();
+		const handlerSettled = Promise.withResolvers<unknown>();
+		const handler = async (...args: unknown[]): Promise<unknown> => {
+			const event = args[0];
+			if (
+				typeof event !== "object" ||
+				event === null ||
+				!("message" in event) ||
+				typeof event.message !== "object" ||
+				event.message === null ||
+				!("role" in event.message) ||
+				event.message.role !== "assistant"
+			) {
+				return undefined;
+			}
+			const context = args[1];
+			if (
+				typeof context !== "object" ||
+				context === null ||
+				!("sdkControl" in context) ||
+				typeof context.sdkControl !== "function"
+			) {
+				throw new Error("Expected extension SDK control context");
+			}
+			handlerEntered.resolve();
+			try {
+				await context.sdkControl("model.set", {
+					id: "target-provider/message-end-reentrant",
+					thinkingLevel: "high",
+				});
+				handlerSettled.resolve(undefined);
+			} catch (error) {
+				handlerSettled.resolve(error);
+			}
+			return undefined;
+		};
+		const extension: Extension = {
+			path: "test:message-end-reentrant",
+			resolvedPath: "test:message-end-reentrant",
+			handlers: new Map([["message_end", [handler]]]),
+			tools: new Map(),
+			messageRenderers: new Map(),
+			commands: new Map(),
+			flags: new Map(),
+			shortcuts: new Map(),
+		};
+		const extensionRunner = new ExtensionRunner(
+			[extension],
+			new ExtensionRuntime(),
+			tempRoot,
+			sessionManager,
+			modelRegistry,
+		);
+		await session.dispose();
+		session = new AgentSession({
+			agent: new Agent({
+				getApiKey: () => "test-key",
+				initialState: { model: initialModel, systemPrompt: ["Test"], tools: [] },
+				streamFn: () => {
+					activeStream = new AssistantMessageEventStream();
+					streamCreated.resolve();
+					return activeStream;
+				},
+			}),
+			sessionManager,
+			settings,
+			modelRegistry,
+			thinkingLevel: Effort.Low,
+			extensionRunner,
+		});
+		const controller = new ExtensionUiController({
+			session,
+			sessionManager,
+			isBackgrounded: true,
+			shutdownRequested: false,
+		} as unknown as InteractiveModeContext);
+		controller.initializeHookRunner({} as ExtensionUIContext, false);
+		const stageSelection = vi.spyOn(sessionManager, "stageDefaultModelSelection");
+		const durableSelection = vi.spyOn(settings, "setGlobalModelRoleAndFlush");
+		const setLiveModel = vi.spyOn(session.agent, "setModel");
+		const prompt = session.prompt("awaited message_end selection");
+		void prompt.catch(() => {});
+
+		try {
+			await streamCreated.promise;
+
+			// When
+			const message = createAssistantMessage("message_end selection attempt");
+			activeStream?.push({ type: "done", reason: "stop", message });
+			activeStream?.end(message);
+			activeStream = undefined;
+			await handlerEntered.promise;
+			const eventLoopBoundary = Promise.withResolvers<"pending">();
+			setImmediate(() => eventLoopBoundary.resolve("pending"));
+			const outcome = await Promise.race([handlerSettled.promise, eventLoopBoundary.promise]);
+
+			// Then
+			expect(outcome).toBeInstanceOf(AgentBusyError);
+			expect(outcome).toMatchObject({
+				name: "AgentBusyError",
+				message: "Default model selection cannot run from a prompt callback in the same session.",
+			});
+			expect(outcome).not.toHaveProperty("code");
+			expect(stageSelection).not.toHaveBeenCalled();
+			expect(durableSelection).not.toHaveBeenCalled();
+			expect(setLiveModel).not.toHaveBeenCalled();
+			expect(settings.getGlobal("modelRoles")).toBeUndefined();
+			expect(session.model).toBe(initialModel);
+			await prompt;
+		} finally {
+			await session.dispose();
+			await prompt.catch(() => {});
+		}
+	});
+
+	it("[F] aborts an active preflight caller and releases its queued selector", async () => {
+		// Given
+		const contributorEntered = Promise.withResolvers<void>();
+		const releaseContributor = Promise.withResolvers<void>();
+		const stageEntered = Promise.withResolvers<void>();
+		const releaseStage = Promise.withResolvers<void>();
+		const unregister = session.registerBeforeAgentStartContributor(async () => {
+			contributorEntered.resolve();
+			await releaseContributor.promise;
+			return undefined;
+		});
+		const originalStage = sessionManager.stageDefaultModelSelection.bind(sessionManager);
+		const stageSelection = vi
+			.spyOn(sessionManager, "stageDefaultModelSelection")
+			.mockImplementation(async (...args) => {
+				stageEntered.resolve();
+				await releaseStage.promise;
+				return originalStage(...args);
+			});
+		const prompt = session.sendUserMessage("abort active preflight", { onPreflightAccepted: () => {} });
+		void prompt.catch(() => {});
+		let selection: Promise<unknown> | undefined;
+
+		try {
+			await contributorEntered.promise;
+			selection = session.setDefaultModelSelection({ ...targetModel(), id: "abort-successor" }, Effort.High);
+			void selection.catch(() => {});
+			await new Promise<void>(resolve => setImmediate(resolve));
+			const stageCallsBeforeAbort = stageSelection.mock.calls.length;
+
+			// When
+			await session.abort();
+
+			// Then
+			await expect(prompt).rejects.toMatchObject({
+				code: "busy",
+				message: "Prompt preflight was cancelled before execution.",
+			});
+			await stageEntered.promise;
+			expect(stageCallsBeforeAbort).toBe(0);
+			releaseStage.resolve();
+			await expect(selection).resolves.toEqual({
+				provider: "target-provider",
+				modelId: "abort-successor",
+				thinkingLevel: Effort.High,
+			});
+		} finally {
+			releaseContributor.resolve();
+			releaseStage.resolve();
+			unregister();
+			await Promise.allSettled([prompt, ...(selection ? [selection] : [])]);
+		}
+	});
+
+	for (const callbackAction of [
+		{ verb: "aborts", invoke: (currentSession: AgentSession) => currentSession.abort() },
+		{ verb: "disposes", invoke: (currentSession: AgentSession) => currentSession.dispose() },
+	] as const) {
+		it(`rejects an accepted preflight when its callback ${callbackAction.verb} the same session before provider transport`, async () => {
+			// Given
+			let callbackOperation: Promise<void> | undefined;
+			const prompt = session.prompt(`${callbackAction.verb} from accepted preflight`, {
+				onPreflightAccepted: () => {
+					callbackOperation = callbackAction.invoke(session);
+				},
+			});
+			const promptOutcome = prompt.then(
+				() => ({ kind: "fulfilled" as const }),
+				(error: unknown) => ({ kind: "rejected" as const, error }),
+			);
+
+			// When
+			const firstOutcome = await Promise.race([
+				promptOutcome,
+				streamCreated.promise.then(() => ({
+					kind: "provider_started" as const,
+					signalAborted: providerSignalAborted,
+				})),
+			]);
+
+			// Then
+			if (firstOutcome.kind === "provider_started" && activeStream) {
+				const message = createAssistantMessage("provider should not have started after callback cancellation");
+				activeStream.push({ type: "done", reason: "stop", message });
+				activeStream.end(message);
+				activeStream = undefined;
+			}
+			await prompt.catch(() => {});
+			await callbackOperation;
+			expect(firstOutcome).toMatchObject({
+				kind: "rejected",
+				error: {
+					code: "busy",
+					message: "Prompt preflight was cancelled before execution.",
+				},
+			});
+			expect(streamCount).toBe(0);
+		});
+	}
+
+	it("[G] promptly cancels a prompt queued behind selection without mutation or overtaking", async () => {
+		// Given
+		const selectionFlushEntered = Promise.withResolvers<void>();
+		const releaseSelectionFlush = Promise.withResolvers<void>();
+		const originalFlush = sessionManager.flush.bind(sessionManager);
+		vi.spyOn(sessionManager, "flush").mockImplementation(async () => {
+			selectionFlushEntered.resolve();
+			await releaseSelectionFlush.promise;
+			return originalFlush();
+		});
+		const entriesBefore = sessionManager.getEntries();
+		const transcriptBefore = session.agent.state.messages;
+		const refreshSubskills = vi.spyOn(session, "refreshGjcSubskillTools");
+		const terminalRuntimePersisted = Promise.withResolvers<void>();
+		const originalWrite = Bun.write.bind(Bun);
+		vi.spyOn(Bun, "write").mockImplementation(async (destination, input, options) => {
+			const bytesWritten: number = await Reflect.apply(originalWrite, Bun, [destination, input, options]);
+			if (
+				typeof destination === "string" &&
+				destination.startsWith(tempRoot) &&
+				typeof input === "string" &&
+				input.includes('"event":"agent_end"')
+			) {
+				terminalRuntimePersisted.resolve();
+			}
+			return bytesWritten;
+		});
+		const promptContributors: string[] = [];
+		const order: string[] = [];
+		const unregister = session.registerBeforeAgentStartContributor(async event => {
+			promptContributors.push(event.prompt);
+			return undefined;
+		});
+		const originalCommit = settings.setGlobalModelRoleAndFlush.bind(settings);
+		vi.spyOn(settings, "setGlobalModelRoleAndFlush").mockImplementation(async (role, selector) => {
+			if (selector?.includes("cancel-owner")) order.push("S1");
+			if (selector?.includes("cancel-successor")) order.push("S2");
+			return originalCommit(role, selector);
+		});
+		const firstSelection = session.setDefaultModelSelection({ ...targetModel(), id: "cancel-owner" }, Effort.Low);
+		let cancelledPrompt: Promise<void> | undefined;
+		let laterSelection: Promise<unknown> | undefined;
+		let laterPrompt: Promise<void> | undefined;
+
+		try {
+			await selectionFlushEntered.promise;
+			cancelledPrompt = session.prompt("architecture migration queued cancellation");
+			laterSelection = session.setDefaultModelSelection({ ...targetModel(), id: "cancel-successor" }, Effort.High);
+
+			// When
+			await session.abort();
+			await cancelledPrompt;
+
+			// Then
+			expect(sessionManager.getEntries()).toEqual(entriesBefore);
+			expect(session.agent.state.messages).toEqual(transcriptBefore);
+			expect(refreshSubskills).not.toHaveBeenCalled();
+			expect(promptContributors).toEqual([]);
+			expect(streamCount).toBe(0);
+			expect(order).toEqual([]);
+
+			releaseSelectionFlush.resolve();
+			await firstSelection;
+			await laterSelection;
+			expect(order).toEqual(["S1", "S2"]);
+			expect(promptContributors).toEqual([]);
+
+			laterPrompt = session.prompt("prompt after cancelled admission tombstone");
+			await streamCreated.promise;
+			const message = createAssistantMessage("case G later prompt complete");
+			activeStream?.push({ type: "done", reason: "stop", message });
+			activeStream?.end(message);
+			activeStream = undefined;
+			await laterPrompt;
+			await terminalRuntimePersisted.promise;
+			expect(promptContributors).toEqual(["prompt after cancelled admission tombstone"]);
+		} finally {
+			releaseSelectionFlush.resolve();
+			unregister();
+			await firstSelection;
+			if (cancelledPrompt) await cancelledPrompt;
+			if (laterSelection) await laterSelection;
+			if (laterPrompt) await laterPrompt;
+		}
+	});
+
+	it("[L] keeps a selector behind its predecessor prompt's recovery continuation", async () => {
+		// Given
+		settings.set("compaction.enabled", false);
+		settings.set("retry.baseDelayMs", 1);
+		secondStreamCreated = Promise.withResolvers<void>();
+		const retryBackoffEntered = Promise.withResolvers<void>();
+		const releaseRetryBackoff = Promise.withResolvers<void>();
+		const continuationDelayEntered = Promise.withResolvers<void>();
+		const releaseContinuationDelay = Promise.withResolvers<void>();
+		let schedulerCall = 0;
+		vi.spyOn(scheduler, "wait").mockImplementation(async () => {
+			schedulerCall++;
+			if (schedulerCall === 1) {
+				retryBackoffEntered.resolve();
+				await releaseRetryBackoff.promise;
+				return;
+			}
+			if (schedulerCall === 2) {
+				continuationDelayEntered.resolve();
+				await releaseContinuationDelay.promise;
+				return;
+			}
+			throw new Error("Unexpected recovery scheduler wait");
+		});
+		const order: string[] = [];
+		const originalContinue = session.agent.continue.bind(session.agent);
+		vi.spyOn(session.agent, "continue").mockImplementation(async () => {
+			order.push("P1 recovery start");
+			await originalContinue();
+		});
+		const unsubscribe = session.subscribe(event => {
+			if (event.type === "auto_retry_start") order.push("P1 recovery scheduled");
+			if (event.type === "auto_retry_end" && event.success) order.push("P1 recovery complete");
+		});
+		const originalGetApiKey = modelRegistry.getApiKey.bind(modelRegistry);
+		let selectionValidationRecorded = false;
+		const validateSelection = vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async (model, ...args) => {
+			if (model.provider === "target-provider" && !selectionValidationRecorded) {
+				selectionValidationRecorded = true;
+				order.push("S1 validate");
+			}
+			return originalGetApiKey(model, ...args);
+		});
+		const originalStage = sessionManager.stageDefaultModelSelection.bind(sessionManager);
+		const stageSelection = vi
+			.spyOn(sessionManager, "stageDefaultModelSelection")
+			.mockImplementation(async (...args) => {
+				order.push("S1 stage");
+				return originalStage(...args);
+			});
+		const originalCommit = settings.setGlobalModelRoleAndFlush.bind(settings);
+		const commitSelection = vi.spyOn(settings, "setGlobalModelRoleAndFlush").mockImplementation(async (...args) => {
+			order.push("S1 commit");
+			return originalCommit(...args);
+		});
+		const originalSetModel = session.agent.setModel.bind(session.agent);
+		const publishSelection = vi.spyOn(session.agent, "setModel").mockImplementation(model => {
+			order.push("S1 publish");
+			originalSetModel(model);
+		});
+		const prompt = session.prompt("P1 schedules one recovery continuation");
+		await streamCreated.promise;
+		const selection = session.setDefaultModelSelection(targetModel(), Effort.High);
+		const retryableMessage = createAssistantMessage("P1 retryable provider failure");
+		retryableMessage.stopReason = "error";
+		retryableMessage.errorMessage = "503 service unavailable: overloaded_error";
+
+		try {
+			// When
+			activeStream?.push({ type: "error", reason: "error", error: retryableMessage });
+			activeStream?.end(retryableMessage);
+			activeStream = undefined;
+			await retryBackoffEntered.promise;
+			releaseRetryBackoff.resolve();
+			await continuationDelayEntered.promise;
+			releaseContinuationDelay.resolve();
+			await secondStreamCreated.promise;
+
+			// Then
+			expect(order).toEqual(["P1 recovery scheduled", "P1 recovery start"]);
+			expect(session.model).toBe(INITIAL_MODEL);
+			expect(validateSelection.mock.calls.filter(([model]) => model.provider === "target-provider")).toHaveLength(0);
+			expect(stageSelection).not.toHaveBeenCalled();
+			expect(commitSelection).not.toHaveBeenCalled();
+			expect(publishSelection).not.toHaveBeenCalled();
+
+			const recoveredMessage = createAssistantMessage("P1 recovery complete");
+			getActiveStream()?.push({ type: "done", reason: "stop", message: recoveredMessage });
+			getActiveStream()?.end(recoveredMessage);
+			activeStream = undefined;
+			await prompt;
+			await selection;
+			expect(order).toEqual([
+				"P1 recovery scheduled",
+				"P1 recovery start",
+				"P1 recovery complete",
+				"S1 validate",
+				"S1 stage",
+				"S1 commit",
+				"S1 publish",
+			]);
+		} finally {
+			releaseRetryBackoff.resolve();
+			releaseContinuationDelay.resolve();
+			if (activeStream) {
+				const message =
+					streamCount === 1 ? retryableMessage : createAssistantMessage("case L recovery cleanup complete");
+				if (message.stopReason === "error") {
+					activeStream.push({ type: "error", reason: "error", error: message });
+				} else {
+					activeStream.push({ type: "done", reason: "stop", message });
+				}
+				activeStream.end(message);
+				activeStream = undefined;
+			}
+			if (streamCount === 1) {
+				await secondStreamCreated.promise;
+				const message = createAssistantMessage("case L recovery cleanup complete");
+				getActiveStream()?.push({ type: "done", reason: "stop", message });
+				getActiveStream()?.end(message);
+				activeStream = undefined;
+			}
+			await prompt;
+			await selection;
+			unsubscribe();
+		}
+	});
+
+	it("[H2] orders a failed selector before its queued prompt and later selector", async () => {
+		// Given
+		const failureEntered = Promise.withResolvers<void>();
+		const releaseFailure = Promise.withResolvers<void>();
+		const failure = new Error("matrix selector failure");
+		const promptContributorEntered = Promise.withResolvers<void>();
+		const releasePromptContributor = Promise.withResolvers<void>();
+		const order: string[] = [];
+		const refreshSubskills = vi.spyOn(session, "refreshGjcSubskillTools");
+		const originalCommit = settings.setGlobalModelRoleAndFlush.bind(settings);
+		vi.spyOn(settings, "setGlobalModelRoleAndFlush")
+			.mockImplementationOnce(async () => {
+				order.push("S1 failure");
+				failureEntered.resolve();
+				await releaseFailure.promise;
+				throw failure;
+			})
+			.mockImplementation(async (role, selector) => {
+				order.push("S2");
+				return originalCommit(role, selector);
+			});
+		const unregister = session.registerBeforeAgentStartContributor(async () => {
+			order.push("P");
+			promptContributorEntered.resolve();
+			await releasePromptContributor.promise;
+			return undefined;
+		});
+		const first = session.setDefaultModelSelection({ ...targetModel(), id: "failure-owner" }, Effort.Low);
+		void first.catch(() => {});
+		let prompt: Promise<void> | undefined;
+		let second: Promise<unknown> | undefined;
+
+		try {
+			await failureEntered.promise;
+			prompt = session.prompt("prompt after failed selector");
+			second = session.setDefaultModelSelection({ ...targetModel(), id: "failure-successor" }, Effort.High);
+			void prompt.catch(() => {});
+			void second.catch(() => {});
+
+			// When / Then
+			expect(refreshSubskills).not.toHaveBeenCalled();
+			expect(order).toEqual(["S1 failure"]);
+			releaseFailure.resolve();
+			await expect(first).rejects.toBe(failure);
+			await promptContributorEntered.promise;
+			expect(order).toEqual(["S1 failure", "P"]);
+			releasePromptContributor.resolve();
+			await streamCreated.promise;
+			const message = createAssistantMessage("case H2 provider complete");
+			activeStream?.push({ type: "done", reason: "stop", message });
+			activeStream?.end(message);
+			activeStream = undefined;
+			await second;
+			expect(order).toEqual(["S1 failure", "P", "S2"]);
+		} finally {
+			releaseFailure.resolve();
+			releasePromptContributor.resolve();
+			unregister();
+			if (prompt) await streamCreated.promise;
+			const message = createAssistantMessage("case H2 cleanup");
+			activeStream?.push({ type: "done", reason: "stop", message });
+			activeStream?.end(message);
+			activeStream = undefined;
+			await Promise.allSettled([first, ...(prompt ? [prompt] : []), ...(second ? [second] : [])]);
+		}
+	});
+
+	it("keeps a queued selector behind promotion recovery until staged discard settles", async () => {
+		// Given
+		const recoveryEntered = Promise.withResolvers<void>();
+		const releaseRecovery = Promise.withResolvers<void>();
+		const promotionError = new Error("S1 promotion failed");
+		const order: string[] = [];
+		const originalDiscard = sessionManager.discardDefaultModelSelectionStage.bind(sessionManager);
+		vi.spyOn(sessionManager, "discardDefaultModelSelectionStage").mockImplementation(async stage => {
+			order.push("S1 recovery start");
+			recoveryEntered.resolve();
+			await releaseRecovery.promise;
+			await originalDiscard(stage);
+			order.push("S1 recovery settled");
+		});
+		vi.spyOn(sessionManager, "promoteDefaultModelSelection").mockReturnValueOnce({
+			kind: "not_promoted",
+			error: promotionError,
+		});
+		const originalGetApiKey = modelRegistry.getApiKey.bind(modelRegistry);
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async (model, ...args) => {
+			if (model.id === "recovery-successor") order.push("S2 validate");
+			return originalGetApiKey(model, ...args);
+		});
+		const first = session.setDefaultModelSelection({ ...targetModel(), id: "recovery-owner" }, Effort.Low);
+		void first.catch(() => {});
+		let second: Promise<unknown> | undefined;
+
+		try {
+			await recoveryEntered.promise;
+
+			// When
+			second = session.setDefaultModelSelection({ ...targetModel(), id: "recovery-successor" }, Effort.High);
+			void second.catch(() => {});
+			await new Promise<void>(resolve => setImmediate(resolve));
+
+			// Then
+			expect(order).toEqual(["S1 recovery start"]);
+			releaseRecovery.resolve();
+			await expectPostDurableSelectionRecovery(first, {
+				message: promotionError.message,
+				rollback: { disposition: "restored", failures: [] },
+			});
+			await second;
+			expect(order).toEqual(["S1 recovery start", "S1 recovery settled", "S2 validate"]);
+		} finally {
+			releaseRecovery.resolve();
+			await Promise.allSettled([first, ...(second ? [second] : [])]);
+		}
+	});
+
+	it("[I] preserves public waitForIdle semantics while selection owns admission", async () => {
+		// Given
+		const selectionFlushEntered = Promise.withResolvers<void>();
+		const releaseSelectionFlush = Promise.withResolvers<void>();
+		const refreshEntered = Promise.withResolvers<void>();
+		const releaseRefresh = Promise.withResolvers<void>();
+		const promptContributorEntered = Promise.withResolvers<void>();
+		const releasePromptContributor = Promise.withResolvers<void>();
+		const originalFlush = sessionManager.flush.bind(sessionManager);
+		vi.spyOn(sessionManager, "flush").mockImplementation(async () => {
+			selectionFlushEntered.resolve();
+			await releaseSelectionFlush.promise;
+			return originalFlush();
+		});
+		vi.spyOn(session, "refreshGjcSubskillTools").mockImplementation(async () => {
+			refreshEntered.resolve();
+			await releaseRefresh.promise;
+		});
+		const unregister = session.registerBeforeAgentStartContributor(async () => {
+			promptContributorEntered.resolve();
+			await releasePromptContributor.promise;
+			return undefined;
+		});
+		const selection = session.setDefaultModelSelection(targetModel(), Effort.High);
+		let prompt: Promise<void> | undefined;
+
+		try {
+			await selectionFlushEntered.promise;
+			prompt = session.prompt("queued prompt ignored by public idle waiter");
+
+			// When / Then
+			await session.waitForIdle();
+			expect(streamCount).toBe(0);
+		} finally {
+			releaseSelectionFlush.resolve();
+			await refreshEntered.promise;
+			releaseRefresh.resolve();
+			await promptContributorEntered.promise;
+			await session.abort();
+			releasePromptContributor.resolve();
+			unregister();
+			await Promise.allSettled([selection, ...(prompt ? [prompt] : [])]);
+		}
+	});
+
+	it("[J1] drains an earlier streaming steer before committing a later selector", async () => {
+		// Given
+		secondStreamCreated = Promise.withResolvers<void>();
+		const order: string[] = [];
+		const originalCommit = settings.setGlobalModelRoleAndFlush.bind(settings);
+		vi.spyOn(settings, "setGlobalModelRoleAndFlush").mockImplementation(async (...args) => {
+			order.push("selection committed");
+			return originalCommit(...args);
+		});
+		const providerPrompt = session.prompt("provider stream owner");
+		await streamCreated.promise;
+
+		// When
+		await session.prompt("streaming steer before selector", { streamingBehavior: "steer" });
+		order.push("steer diverted");
+		const selection = session.setDefaultModelSelection({ ...targetModel(), id: "after-steer" }, Effort.High);
+
+		// Then
+		expect(session.getQueuedMessages()).toEqual({
+			steering: ["streaming steer before selector"],
+			followUp: [],
+		});
+		expect(order).toEqual(["steer diverted"]);
+		const firstMessage = createAssistantMessage("first stream complete");
+		activeStream?.push({ type: "done", reason: "stop", message: firstMessage });
+		activeStream?.end(firstMessage);
+		activeStream = undefined;
+		await secondStreamCreated.promise;
+		expect(order).toEqual(["steer diverted"]);
+		const steeredMessage = createAssistantMessage("steer complete");
+		getActiveStream()?.push({ type: "done", reason: "stop", message: steeredMessage });
+		getActiveStream()?.end(steeredMessage);
+		activeStream = undefined;
+		await providerPrompt;
+		await expect(selection).resolves.toEqual({
+			provider: "target-provider",
+			modelId: "after-steer",
+			thinkingLevel: Effort.High,
+		});
+		expect(order).toEqual(["steer diverted", "selection committed"]);
+	});
+
+	it("[J2] keeps a later streaming follow-up outside selector admission and drains it before commit", async () => {
+		// Given
+		secondStreamCreated = Promise.withResolvers<void>();
+		const order: string[] = [];
+		const originalCommit = settings.setGlobalModelRoleAndFlush.bind(settings);
+		vi.spyOn(settings, "setGlobalModelRoleAndFlush").mockImplementation(async (...args) => {
+			order.push("selection committed");
+			return originalCommit(...args);
+		});
+		const providerPrompt = session.prompt("provider stream owner");
+		await streamCreated.promise;
+		const selection = session.setDefaultModelSelection({ ...targetModel(), id: "after-follow-up" }, Effort.High);
+
+		// When
+		await session.prompt("streaming follow-up after selector", { streamingBehavior: "followUp" });
+		order.push("follow-up diverted");
+
+		// Then
+		expect(session.getQueuedMessages()).toEqual({
+			steering: [],
+			followUp: ["streaming follow-up after selector"],
+		});
+		expect(order).toEqual(["follow-up diverted"]);
+		const firstMessage = createAssistantMessage("first stream complete");
+		activeStream?.push({ type: "done", reason: "stop", message: firstMessage });
+		activeStream?.end(firstMessage);
+		activeStream = undefined;
+		await secondStreamCreated.promise;
+		expect(order).toEqual(["follow-up diverted"]);
+		const followUpMessage = createAssistantMessage("follow-up complete");
+		getActiveStream()?.push({ type: "done", reason: "stop", message: followUpMessage });
+		getActiveStream()?.end(followUpMessage);
+		activeStream = undefined;
+		await providerPrompt;
+		await expect(selection).resolves.toEqual({
+			provider: "target-provider",
+			modelId: "after-follow-up",
+			thinkingLevel: Effort.High,
+		});
+		expect(order).toEqual(["follow-up diverted", "selection committed"]);
+	});
+
+	it("keeps an idle follow-up queued behind an earlier selector", async () => {
+		// Given
+		session.agent.appendMessage(createAssistantMessage("idle follow-up predecessor"));
+		const stageEntered = Promise.withResolvers<void>();
+		const releaseStage = Promise.withResolvers<void>();
+		const originalStage = sessionManager.stageDefaultModelSelection.bind(sessionManager);
+		vi.spyOn(sessionManager, "stageDefaultModelSelection").mockImplementation(async (...args) => {
+			stageEntered.resolve();
+			await releaseStage.promise;
+			return originalStage(...args);
+		});
+		const selection = session.setDefaultModelSelection(
+			{ ...targetModel(), id: "idle-follow-up-selector-owner" },
+			Effort.High,
+		);
+
+		try {
+			await stageEntered.promise;
+
+			// When
+			await session.followUp("idle follow-up after selector");
+			await new Promise<void>(resolve => setImmediate(resolve));
+
+			// Then
+			expect(streamCount).toBe(0);
+			releaseStage.resolve();
+			await selection;
+			await streamCreated.promise;
+			const message = createAssistantMessage("idle follow-up after selector complete");
+			activeStream?.push({ type: "done", reason: "stop", message });
+			activeStream?.end(message);
+			activeStream = undefined;
+			await session.waitForIdle();
+		} finally {
+			releaseStage.resolve();
+			if (activeStream) {
+				const message = createAssistantMessage("idle follow-up selector-first cleanup");
+				activeStream.push({ type: "done", reason: "stop", message });
+				activeStream.end(message);
+				activeStream = undefined;
+			}
+			await Promise.allSettled([selection]);
+		}
+	});
+
+	it("coalesces an idle follow-up behind a prompt already queued after a selector", async () => {
+		// Given
+		session.agent.appendMessage(createAssistantMessage("pending prompt queue predecessor"));
+		secondStreamCreated = Promise.withResolvers<void>();
+		const stageEntered = Promise.withResolvers<void>();
+		const releaseStage = Promise.withResolvers<void>();
+		const order: string[] = [];
+		const originalStage = sessionManager.stageDefaultModelSelection.bind(sessionManager);
+		vi.spyOn(sessionManager, "stageDefaultModelSelection").mockImplementation(async (...args) => {
+			stageEntered.resolve();
+			await releaseStage.promise;
+			return originalStage(...args);
+		});
+		const originalCommit = settings.setGlobalModelRoleAndFlush.bind(settings);
+		vi.spyOn(settings, "setGlobalModelRoleAndFlush").mockImplementation(async (...args) => {
+			order.push("selector");
+			return originalCommit(...args);
+		});
+		const selection = session.setDefaultModelSelection(
+			{ ...targetModel(), id: "selector-before-prompt-and-follow-up" },
+			Effort.High,
+		);
+		let prompt: Promise<void> | undefined;
+
+		try {
+			await stageEntered.promise;
+			prompt = session.prompt("normal prompt behind selector");
+			void prompt.catch(() => {});
+
+			// When
+			const followUpOutcome = await Promise.allSettled([session.followUp("idle follow-up behind pending prompt")]);
+
+			// Then
+			expect(streamCount).toBe(0);
+			expect(session.getQueuedMessages()).toEqual({
+				steering: [],
+				followUp: ["idle follow-up behind pending prompt"],
+			});
+
+			releaseStage.resolve();
+			await selection;
+			await streamCreated.promise;
+			order.push("prompt");
+			expect(streamCount).toBe(1);
+			const promptMessage = createAssistantMessage("normal prompt complete");
+			activeStream?.push({ type: "done", reason: "stop", message: promptMessage });
+			activeStream?.end(promptMessage);
+			activeStream = undefined;
+			await secondStreamCreated.promise;
+			order.push("follow-up");
+			expect(streamCount).toBe(2);
+			const followUpMessage = createAssistantMessage("idle follow-up complete");
+			getActiveStream()?.push({ type: "done", reason: "stop", message: followUpMessage });
+			getActiveStream()?.end(followUpMessage);
+			activeStream = undefined;
+			await prompt;
+			expect(followUpOutcome).toEqual([{ status: "fulfilled", value: undefined }]);
+			expect(order).toEqual(["selector", "prompt", "follow-up"]);
+			expect(
+				session.agent.state.messages.filter(message => message.role === "user").map(message => message.content),
+			).toEqual([
+				[{ type: "text", text: "normal prompt behind selector" }],
+				[{ type: "text", text: "idle follow-up behind pending prompt" }],
+			]);
+		} finally {
+			releaseStage.resolve();
+			if (activeStream) {
+				const message = createAssistantMessage("pending prompt coalescing cleanup");
+				activeStream.push({ type: "done", reason: "stop", message });
+				activeStream.end(message);
+				activeStream = undefined;
+			}
+			await Promise.allSettled([selection, ...(prompt ? [prompt] : [])]);
+		}
+	});
+
+	it("transfers a coalesced follow-up before a later selector when its pending prompt is cancelled", async () => {
+		// Given
+		session.agent.appendMessage(createAssistantMessage("transferred follow-up predecessor"));
+		const firstStageEntered = Promise.withResolvers<void>();
+		const releaseFirstStage = Promise.withResolvers<void>();
+		const promptPreflightEntered = Promise.withResolvers<void>();
+		const releasePromptPreflight = Promise.withResolvers<void>();
+		const unregister = session.registerBeforeAgentStartContributor(async () => {
+			promptPreflightEntered.resolve();
+			await releasePromptPreflight.promise;
+			return undefined;
+		});
+		const originalStage = sessionManager.stageDefaultModelSelection.bind(sessionManager);
+		vi.spyOn(sessionManager, "stageDefaultModelSelection").mockImplementation(async (...args) => {
+			firstStageEntered.resolve();
+			await releaseFirstStage.promise;
+			return originalStage(...args);
+		});
+		const laterSelectionValidationEntered = Promise.withResolvers<void>();
+		const originalGetApiKey = modelRegistry.getApiKey.bind(modelRegistry);
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation((model, ...args) => {
+			if (model.id === "later-selector-after-transferred-follow-up") {
+				laterSelectionValidationEntered.resolve();
+			}
+			return originalGetApiKey(model, ...args);
+		});
+		const firstSelection = session.setDefaultModelSelection(
+			{ ...targetModel(), id: "selector-holding-prompt-admission" },
+			Effort.Low,
+		);
+		let prompt: Promise<void> | undefined;
+		let laterSelection: Promise<unknown> | undefined;
+
+		try {
+			await firstStageEntered.promise;
+			prompt = session.prompt("normal prompt carrying an idle follow-up");
+			void prompt.catch(() => {});
+			await session.followUp("follow-up submitted before later selector");
+			laterSelection = session.setDefaultModelSelection(
+				{ ...targetModel(), id: "later-selector-after-transferred-follow-up" },
+				Effort.High,
+			);
+			void laterSelection.catch(() => {});
+			releaseFirstStage.resolve();
+			await firstSelection;
+			await promptPreflightEntered.promise;
+
+			// When
+			await session.abort();
+			await prompt;
+			const firstSuccessor = await Promise.race([
+				streamCreated.promise.then(() => "follow-up-provider" as const),
+				laterSelectionValidationEntered.promise.then(() => "later-selector-validation" as const),
+			]);
+			await streamCreated.promise;
+			const followUpMessage = createAssistantMessage("transferred follow-up complete");
+			activeStream?.push({ type: "done", reason: "stop", message: followUpMessage });
+			activeStream?.end(followUpMessage);
+			activeStream = undefined;
+			await laterSelection;
+
+			// Then
+			expect(firstSuccessor).toBe("follow-up-provider");
+			expect(streamCount).toBe(1);
+		} finally {
+			releaseFirstStage.resolve();
+			releasePromptPreflight.resolve();
+			unregister();
+			if (activeStream) {
+				const message = createAssistantMessage("transferred follow-up cleanup");
+				activeStream.push({ type: "done", reason: "stop", message });
+				activeStream.end(message);
+				activeStream = undefined;
+			}
+			await Promise.allSettled([
+				firstSelection,
+				...(prompt ? [prompt] : []),
+				...(laterSelection ? [laterSelection] : []),
+			]);
+		}
+	});
+
+	it("transfers idle follow-up delivery when its pending prompt is cancelled", async () => {
+		// Given
+		session.agent.appendMessage(createAssistantMessage("cancelled pending prompt predecessor"));
+		const stageEntered = Promise.withResolvers<void>();
+		const releaseStage = Promise.withResolvers<void>();
+		const originalStage = sessionManager.stageDefaultModelSelection.bind(sessionManager);
+		vi.spyOn(sessionManager, "stageDefaultModelSelection").mockImplementation(async (...args) => {
+			stageEntered.resolve();
+			await releaseStage.promise;
+			return originalStage(...args);
+		});
+		const selection = session.setDefaultModelSelection(
+			{ ...targetModel(), id: "selector-before-cancelled-prompt" },
+			Effort.High,
+		);
+		let prompt: Promise<void> | undefined;
+
+		try {
+			await stageEntered.promise;
+			prompt = session.prompt("pending prompt cancelled before admission");
+			void prompt.catch(() => {});
+			await session.followUp("follow-up surviving pending prompt cancellation");
+
+			// When
+			await session.abort();
+			await prompt;
+			releaseStage.resolve();
+			await selection;
+			await streamCreated.promise;
+
+			// Then
+			expect(streamCount).toBe(1);
+			const message = createAssistantMessage("surviving follow-up complete");
+			activeStream?.push({ type: "done", reason: "stop", message });
+			activeStream?.end(message);
+			activeStream = undefined;
+			await session.waitForIdle();
+			expect(
+				session.agent.state.messages.filter(message => message.role === "user").map(message => message.content),
+			).toEqual([[{ type: "text", text: "follow-up surviving pending prompt cancellation" }]]);
+		} finally {
+			releaseStage.resolve();
+			if (activeStream) {
+				const message = createAssistantMessage("pending prompt cancellation cleanup");
+				activeStream.push({ type: "done", reason: "stop", message });
+				activeStream.end(message);
+				activeStream = undefined;
+			}
+			await Promise.allSettled([selection, ...(prompt ? [prompt] : [])]);
+		}
+	});
+
+	it("keeps a later selector behind an idle follow-up reservation", async () => {
+		// Given
+		session.agent.appendMessage(createAssistantMessage("idle follow-up predecessor"));
+		const continueEntered = Promise.withResolvers<void>();
+		const continueSettled = Promise.withResolvers<void>();
+		const originalContinue = session.agent.continue.bind(session.agent);
+		vi.spyOn(session.agent, "continue").mockImplementation(async () => {
+			continueEntered.resolve();
+			await originalContinue();
+			continueSettled.resolve();
+		});
+		const originalGetApiKey = modelRegistry.getApiKey.bind(modelRegistry);
+		const validateSelection = vi
+			.spyOn(modelRegistry, "getApiKey")
+			.mockImplementation((model, ...args) => originalGetApiKey(model, ...args));
+
+		// When
+		await session.followUp("idle follow-up before selector");
+		const selection = session.setDefaultModelSelection(
+			{ ...targetModel(), id: "idle-follow-up-selector-successor" },
+			Effort.Low,
+		);
+		void selection.catch(() => {});
+
+		try {
+			await continueEntered.promise;
+			await streamCreated.promise;
+
+			// Then
+			expect(validateSelection.mock.calls.filter(([model]) => model.provider === "target-provider")).toHaveLength(0);
+			const message = createAssistantMessage("idle follow-up before selector complete");
+			activeStream?.push({ type: "done", reason: "stop", message });
+			activeStream?.end(message);
+			activeStream = undefined;
+			await continueSettled.promise;
+			await expect(selection).resolves.toEqual({
+				provider: "target-provider",
+				modelId: "idle-follow-up-selector-successor",
+				thinkingLevel: Effort.Low,
+			});
+		} finally {
+			if (activeStream) {
+				const message = createAssistantMessage("idle follow-up-first cleanup");
+				activeStream.push({ type: "done", reason: "stop", message });
+				activeStream.end(message);
+				activeStream = undefined;
+			}
+			await Promise.allSettled([selection]);
+		}
+	});
+
+	it("coalesces rapid idle follow-ups behind one continuation reservation", async () => {
+		// Given
+		session.agent.appendMessage(createAssistantMessage("rapid idle follow-up predecessor"));
+		secondStreamCreated = Promise.withResolvers<void>();
+		const continuationSettled = Promise.withResolvers<void>();
+		const order: string[] = [];
+		const originalContinue = session.agent.continue.bind(session.agent);
+		const continueCall = vi.spyOn(session.agent, "continue").mockImplementation(async () => {
+			order.push("continuation start");
+			await originalContinue();
+			order.push("continuation complete");
+			continuationSettled.resolve();
+		});
+		const originalGetApiKey = modelRegistry.getApiKey.bind(modelRegistry);
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation((model, ...args) => {
+			if (model.provider === "target-provider") order.push("selector validate");
+			return originalGetApiKey(model, ...args);
+		});
+
+		// When
+		const firstFollowUp = session.followUp("rapid idle follow-up one");
+		const secondFollowUp = session.followUp("rapid idle follow-up two");
+		const selection = session.setDefaultModelSelection(
+			{ ...targetModel(), id: "selector-after-rapid-idle-follow-ups" },
+			Effort.High,
+		);
+		void selection.catch(() => {});
+		const followUpOutcomes = await Promise.allSettled([firstFollowUp, secondFollowUp]);
+
+		try {
+			await streamCreated.promise;
+
+			// Then
+			expect(streamCount).toBe(1);
+			expect(order).toEqual(["continuation start"]);
+			const firstMessage = createAssistantMessage("rapid idle follow-up one complete");
+			activeStream?.push({ type: "done", reason: "stop", message: firstMessage });
+			activeStream?.end(firstMessage);
+			activeStream = undefined;
+			await secondStreamCreated.promise;
+			expect(streamCount).toBe(2);
+			expect(order).toEqual(["continuation start"]);
+			const secondMessage = createAssistantMessage("rapid idle follow-up two complete");
+			getActiveStream()?.push({ type: "done", reason: "stop", message: secondMessage });
+			getActiveStream()?.end(secondMessage);
+			activeStream = undefined;
+			await continuationSettled.promise;
+			await expect(selection).resolves.toEqual({
+				provider: "target-provider",
+				modelId: "selector-after-rapid-idle-follow-ups",
+				thinkingLevel: Effort.High,
+			});
+			expect(followUpOutcomes).toEqual([
+				{ status: "fulfilled", value: undefined },
+				{ status: "fulfilled", value: undefined },
+			]);
+			expect(continueCall).toHaveBeenCalledTimes(1);
+			expect(
+				session.agent.state.messages
+					.filter(message => message.role === "user")
+					.map(message => ({ role: message.role, content: message.content, attribution: message.attribution })),
+			).toEqual([
+				{
+					role: "user",
+					content: [{ type: "text", text: "rapid idle follow-up one" }],
+					attribution: "user",
+				},
+				{
+					role: "user",
+					content: [{ type: "text", text: "rapid idle follow-up two" }],
+					attribution: "user",
+				},
+			]);
+			expect(order).toEqual(["continuation start", "continuation complete", "selector validate"]);
+		} finally {
+			if (activeStream) {
+				const message = createAssistantMessage("rapid idle follow-up cleanup");
+				activeStream.push({ type: "done", reason: "stop", message });
+				activeStream.end(message);
+				activeStream = undefined;
+			}
+			await Promise.allSettled([selection]);
+		}
+	});
+
+	it("[Y] serializes idle async-result delivery with selector admission in both arrival orders", async () => {
+		// Given
+		const idleFlushDelayEntered = Promise.withResolvers<void>();
+		const releaseIdleFlushDelay = Promise.withResolvers<void>();
+		vi.spyOn(scheduler, "wait").mockImplementation(async () => {
+			idleFlushDelayEntered.resolve();
+			await releaseIdleFlushDelay.promise;
+		});
+		const unregisterYield = session.yieldQueue.register<string>("selection-admission-async-result", {
+			build: entries => ({
+				role: "custom",
+				customType: "async-result",
+				content: entries.join("\n"),
+				display: true,
+				attribution: "agent",
+				timestamp: 0,
+			}),
+		});
+		const firstStageEntered = Promise.withResolvers<void>();
+		const releaseFirstStage = Promise.withResolvers<void>();
+		const originalStage = sessionManager.stageDefaultModelSelection.bind(sessionManager);
+		let stageCall = 0;
+		const stageSelection = vi
+			.spyOn(sessionManager, "stageDefaultModelSelection")
+			.mockImplementation(async (...args) => {
+				stageCall++;
+				if (stageCall === 1) {
+					firstStageEntered.resolve();
+					await releaseFirstStage.promise;
+				}
+				return originalStage(...args);
+			});
+		const durableSelection = vi.spyOn(settings, "setGlobalModelRoleAndFlush");
+		const publishSelection = vi.spyOn(session.agent, "setModel");
+		const transcriptBefore = session.agent.state.messages;
+		const entriesBefore = sessionManager.getEntries();
+		const firstSelection = session.setDefaultModelSelection(
+			{ ...targetModel(), id: "yield-selector-owner" },
+			Effort.High,
+		);
+		let inverseSelection: Promise<unknown> | undefined;
+
+		try {
+			await firstStageEntered.promise;
+
+			// When
+			session.yieldQueue.enqueue("selection-admission-async-result", "async result after selector idle sample");
+			await idleFlushDelayEntered.promise;
+			releaseIdleFlushDelay.resolve();
+			await new Promise<void>(resolve => setImmediate(resolve));
+
+			// Then
+			expect(streamCount).toBe(0);
+			expect(session.agent.state.messages).toEqual(transcriptBefore);
+			expect(sessionManager.getEntries()).toEqual(entriesBefore);
+			expect(durableSelection).not.toHaveBeenCalled();
+			expect(publishSelection).not.toHaveBeenCalled();
+
+			releaseFirstStage.resolve();
+			await firstSelection;
+			await streamCreated.promise;
+			expect(stageSelection).toHaveBeenCalledTimes(1);
+			expect(durableSelection).toHaveBeenCalledTimes(1);
+			expect(publishSelection).toHaveBeenCalledTimes(1);
+			const firstYieldMessage = createAssistantMessage("selector-first idle yield complete");
+			activeStream?.push({ type: "done", reason: "stop", message: firstYieldMessage });
+			activeStream?.end(firstYieldMessage);
+			activeStream = undefined;
+			await session.waitForIdle();
+
+			secondStreamCreated = Promise.withResolvers<void>();
+			session.yieldQueue.enqueue("selection-admission-async-result", "async result before selector");
+			await secondStreamCreated.promise;
+			inverseSelection = session.setDefaultModelSelection(
+				{ ...targetModel(), id: "yield-selector-successor" },
+				Effort.Low,
+			);
+			await new Promise<void>(resolve => setImmediate(resolve));
+			expect(stageSelection).toHaveBeenCalledTimes(1);
+			expect(durableSelection).toHaveBeenCalledTimes(1);
+			expect(publishSelection).toHaveBeenCalledTimes(1);
+
+			const inverseYieldMessage = createAssistantMessage("yield-first idle turn complete");
+			getActiveStream()?.push({ type: "done", reason: "stop", message: inverseYieldMessage });
+			getActiveStream()?.end(inverseYieldMessage);
+			activeStream = undefined;
+			await expect(inverseSelection).resolves.toEqual({
+				provider: "target-provider",
+				modelId: "yield-selector-successor",
+				thinkingLevel: Effort.Low,
+			});
+			expect(stageSelection).toHaveBeenCalledTimes(2);
+			expect(durableSelection).toHaveBeenCalledTimes(2);
+			expect(publishSelection).toHaveBeenCalledTimes(2);
+		} finally {
+			releaseIdleFlushDelay.resolve();
+			releaseFirstStage.resolve();
+			unregisterYield();
+			if (activeStream) {
+				const message = createAssistantMessage("case Y cleanup");
+				activeStream.push({ type: "done", reason: "stop", message });
+				activeStream.end(message);
+				activeStream = undefined;
+			}
+			await Promise.allSettled([firstSelection, ...(inverseSelection ? [inverseSelection] : [])]);
+		}
+	});
+
+	it("[R] keeps a public retry continuation ahead of a later selector", async () => {
+		// Given
+		const retryDelayEntered = Promise.withResolvers<void>();
+		const releaseRetryDelay = Promise.withResolvers<void>();
+		vi.spyOn(scheduler, "wait").mockImplementation(async () => {
+			retryDelayEntered.resolve();
+			await releaseRetryDelay.promise;
+		});
+		session.agent.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "retry predecessor" }],
+			timestamp: 0,
+		});
+		const failedMessage = createAssistantMessage("retryable predecessor failure");
+		failedMessage.stopReason = "error";
+		failedMessage.errorMessage = "retry predecessor failed";
+		session.agent.appendMessage(failedMessage);
+		const retryContinueEntered = Promise.withResolvers<void>();
+		const retryContinueCompleted = Promise.withResolvers<void>();
+		const order: string[] = [];
+		const originalContinue = session.agent.continue.bind(session.agent);
+		vi.spyOn(session.agent, "continue").mockImplementation(async () => {
+			order.push("retry start");
+			retryContinueEntered.resolve();
+			await originalContinue();
+			order.push("retry complete");
+			retryContinueCompleted.resolve();
+		});
+		const selectionFlushEntered = Promise.withResolvers<void>();
+		const releaseSelectionFlush = Promise.withResolvers<void>();
+		const originalFlush = sessionManager.flush.bind(sessionManager);
+		vi.spyOn(sessionManager, "flush").mockImplementation(async () => {
+			order.push("selector flush");
+			selectionFlushEntered.resolve();
+			await releaseSelectionFlush.promise;
+			return originalFlush();
+		});
+		const originalGetApiKey = modelRegistry.getApiKey.bind(modelRegistry);
+		let selectionValidationRecorded = false;
+		const validateSelection = vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async (model, ...args) => {
+			if (model.provider === "target-provider" && !selectionValidationRecorded) {
+				selectionValidationRecorded = true;
+				order.push("selector validate");
+			}
+			return originalGetApiKey(model, ...args);
+		});
+		const originalStage = sessionManager.stageDefaultModelSelection.bind(sessionManager);
+		const stageSelection = vi
+			.spyOn(sessionManager, "stageDefaultModelSelection")
+			.mockImplementation(async (...args) => {
+				order.push("selector stage");
+				return originalStage(...args);
+			});
+		const originalCommit = settings.setGlobalModelRoleAndFlush.bind(settings);
+		const durableSelection = vi.spyOn(settings, "setGlobalModelRoleAndFlush").mockImplementation(async (...args) => {
+			order.push("selector durable");
+			return originalCommit(...args);
+		});
+		const originalSetModel = session.agent.setModel.bind(session.agent);
+		const publishSelection = vi.spyOn(session.agent, "setModel").mockImplementation(model => {
+			order.push("selector live");
+			originalSetModel(model);
+		});
+		expect(await session.retry()).toBe(true);
+		await retryDelayEntered.promise;
+		const selection = session.setDefaultModelSelection({ ...targetModel(), id: "after-public-retry" }, Effort.High);
+
+		try {
+			// When
+			await new Promise<void>(resolve => setImmediate(resolve));
+
+			// Then
+			expect(order).toEqual([]);
+			expect(validateSelection.mock.calls.filter(([model]) => model.provider === "target-provider")).toHaveLength(0);
+			expect(stageSelection).not.toHaveBeenCalled();
+			expect(durableSelection).not.toHaveBeenCalled();
+			expect(publishSelection).not.toHaveBeenCalled();
+
+			releaseRetryDelay.resolve();
+			await retryContinueEntered.promise;
+			await streamCreated.promise;
+			expect(order).toEqual(["retry start"]);
+			expect(stageSelection).not.toHaveBeenCalled();
+			expect(durableSelection).not.toHaveBeenCalled();
+			expect(publishSelection).not.toHaveBeenCalled();
+
+			const retryMessage = createAssistantMessage("public retry continuation complete");
+			activeStream?.push({ type: "done", reason: "stop", message: retryMessage });
+			activeStream?.end(retryMessage);
+			activeStream = undefined;
+			await retryContinueCompleted.promise;
+			await selectionFlushEntered.promise;
+			expect(order).toEqual(["retry start", "retry complete", "selector validate", "selector flush"]);
+			expect(stageSelection).not.toHaveBeenCalled();
+			expect(durableSelection).not.toHaveBeenCalled();
+			expect(publishSelection).not.toHaveBeenCalled();
+
+			releaseSelectionFlush.resolve();
+			await expect(selection).resolves.toEqual({
+				provider: "target-provider",
+				modelId: "after-public-retry",
+				thinkingLevel: Effort.High,
+			});
+			expect(order).toEqual([
+				"retry start",
+				"retry complete",
+				"selector validate",
+				"selector flush",
+				"selector stage",
+				"selector durable",
+				"selector live",
+			]);
+		} finally {
+			releaseRetryDelay.resolve();
+			releaseSelectionFlush.resolve();
+			if (!activeStream) {
+				await new Promise<void>(resolve => setImmediate(resolve));
+			}
+			if (activeStream) {
+				const message = createAssistantMessage("case R cleanup");
+				activeStream.push({ type: "done", reason: "stop", message });
+				activeStream.end(message);
+				activeStream = undefined;
+			}
+			await Promise.allSettled([selection]);
+		}
+	});
+
+	it("drops a failed assistant tail before retry preflight estimates context", async () => {
+		// Given
+		settings.set("compaction.thresholdTokens", 5_000);
+		session.setResourceSampler(() => ({ heapUsedBytes: 0, providerBytes: 0, messageCount: 0, imageBytes: 0 }));
+		session.agent.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "retry this request" }],
+			timestamp: 0,
+		});
+		const failedMessage = createAssistantMessage("failed retry tail ".repeat(2_000));
+		failedMessage.stopReason = "error";
+		failedMessage.errorMessage = "retryable failure";
+		session.agent.appendMessage(failedMessage);
+		const compactionReasons: string[] = [];
+		const unsubscribe = session.subscribe(event => {
+			if (event.type === "auto_compaction_start") compactionReasons.push(event.reason);
+		});
+
+		try {
+			// When
+			expect(await session.retry()).toBe(true);
+			await streamCreated.promise;
+
+			// Then
+			expect(compactionReasons).toEqual([]);
+			const message = createAssistantMessage("retry completed without unnecessary compaction");
+			activeStream?.push({ type: "done", reason: "stop", message });
+			activeStream?.end(message);
+			activeStream = undefined;
+			await session.waitForIdle();
+		} finally {
+			unsubscribe();
+		}
+	});
+
+	it("releases a public retry admission when abort cancels its delayed continuation", async () => {
+		// Given
+		const retryDelayEntered = Promise.withResolvers<void>();
+		const originalWait = scheduler.wait.bind(scheduler);
+		vi.spyOn(scheduler, "wait").mockImplementation(async (_delay, options) => {
+			retryDelayEntered.resolve();
+			await originalWait(60_000, options);
+		});
+		session.agent.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "retry predecessor before abort" }],
+			timestamp: 0,
+		});
+		const failedMessage = createAssistantMessage("retry failure before abort");
+		failedMessage.stopReason = "error";
+		failedMessage.errorMessage = "retry failed before abort";
+		session.agent.appendMessage(failedMessage);
+		const continueCall = vi.spyOn(session.agent, "continue");
+		expect(await session.retry()).toBe(true);
+		await retryDelayEntered.promise;
+
+		// When
+		await session.abort();
+		const laterPrompt = session.prompt("prompt after aborted public retry");
+		void laterPrompt.catch(() => {});
+		const laterSelection = session.setDefaultModelSelection(
+			{ ...targetModel(), id: "selector-after-aborted-public-retry" },
+			Effort.High,
+		);
+		void laterSelection.catch(() => {});
+		const promptOutcome = await Promise.race([
+			streamCreated.promise.then(() => "streaming" as const),
+			laterPrompt.then(
+				() => "settled" as const,
+				error => error,
+			),
+		]);
+
+		// Then
+		expect(continueCall).not.toHaveBeenCalled();
+		expect(promptOutcome).toBe("streaming");
+		const message = createAssistantMessage("prompt after aborted retry complete");
+		activeStream?.push({ type: "done", reason: "stop", message });
+		activeStream?.end(message);
+		activeStream = undefined;
+		await laterPrompt;
+		await expect(laterSelection).resolves.toEqual({
+			provider: "target-provider",
+			modelId: "selector-after-aborted-public-retry",
+			thinkingLevel: Effort.High,
+		});
+	});
+
+	it("keeps persisted-history continuation ahead of a later selector", async () => {
+		// Given
+		session.agent.appendMessage({ role: "user", content: "persisted continuation", timestamp: 0 });
+		const continueEntered = Promise.withResolvers<void>();
+		const releaseContinue = Promise.withResolvers<void>();
+		const originalContinue = session.agent.continue.bind(session.agent);
+		vi.spyOn(session.agent, "continue").mockImplementation(async () => {
+			continueEntered.resolve();
+			await releaseContinue.promise;
+			await originalContinue();
+		});
+		const originalGetApiKey = modelRegistry.getApiKey.bind(modelRegistry);
+		const validateSelection = vi
+			.spyOn(modelRegistry, "getApiKey")
+			.mockImplementation((model, ...args) => originalGetApiKey(model, ...args));
+		const continuation = session.continuePersistedHistory();
+		void continuation.catch(() => {});
+		await continueEntered.promise;
+
+		// When
+		const selection = session.setDefaultModelSelection(
+			{ ...targetModel(), id: "persisted-continuation-successor" },
+			Effort.High,
+		);
+		void selection.catch(() => {});
+
+		try {
+			await new Promise<void>(resolve => setImmediate(resolve));
+
+			// Then
+			expect(validateSelection.mock.calls.filter(([model]) => model.provider === "target-provider")).toHaveLength(0);
+			releaseContinue.resolve();
+			await streamCreated.promise;
+			const message = createAssistantMessage("persisted continuation complete");
+			activeStream?.push({ type: "done", reason: "stop", message });
+			activeStream?.end(message);
+			activeStream = undefined;
+			await continuation;
+			await expect(selection).resolves.toEqual({
+				provider: "target-provider",
+				modelId: "persisted-continuation-successor",
+				thinkingLevel: Effort.High,
+			});
+		} finally {
+			releaseContinue.resolve();
+			await Promise.race([streamCreated.promise, continuation]);
+			if (activeStream) {
+				const message = createAssistantMessage("persisted continuation cleanup");
+				activeStream.push({ type: "done", reason: "stop", message });
+				activeStream.end(message);
+				activeStream = undefined;
+			}
+			await Promise.allSettled([continuation, selection]);
+		}
+	});
+
+	it("[X] dispose cancels hidden next-turn admission queued behind a selector", async () => {
+		// Given
+		const selectionValidationEntered = Promise.withResolvers<void>();
+		const releaseSelectionValidation = Promise.withResolvers<void>();
+		const originalGetApiKey = modelRegistry.getApiKey.bind(modelRegistry);
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async (model, ...args) => {
+			if (model.provider === "target-provider") {
+				selectionValidationEntered.resolve();
+				await releaseSelectionValidation.promise;
+			}
+			return originalGetApiKey(model, ...args);
+		});
+		const appendCustomEntry = vi.spyOn(sessionManager, "appendCustomMessageEntry");
+		const transcriptBefore = session.agent.state.messages;
+		const closeEntered = Promise.withResolvers<void>();
+		const originalClose = sessionManager.close.bind(sessionManager);
+		vi.spyOn(sessionManager, "close").mockImplementation(async () => {
+			closeEntered.resolve();
+			return originalClose();
+		});
+		const selection = session.setDefaultModelSelection(
+			{ ...targetModel(), id: "dispose-selector-owner" },
+			Effort.High,
+		);
+		void selection.catch(() => {});
+		await selectionValidationEntered.promise;
+		session.queueDeferredMessageForTests(
+			{
+				role: "custom",
+				customType: "dispose-hidden-next-turn",
+				content: "must be cancelled during dispose",
+				display: false,
+				attribution: "agent",
+				timestamp: 0,
+			},
+			true,
+		);
+		expect(session.hasPostPromptWork).toBe(true);
+		const disposal = session.dispose();
+		void disposal.catch(() => {});
+
+		try {
+			// When
+			const checkpoint = Promise.withResolvers<void>();
+			setImmediate(checkpoint.resolve);
+			const disposeProgress = await Promise.race([
+				closeEntered.promise.then(() => "queued task settled" as const),
+				checkpoint.promise.then(() => "checkpoint reached" as const),
+			]);
+
+			// Then
+			expect(disposeProgress).toBe("queued task settled");
+			expect(session.hasPostPromptWork).toBe(false);
+			expect(streamCount).toBe(0);
+			expect(session.agent.state.messages).toEqual(transcriptBefore);
+			expect(
+				appendCustomEntry.mock.calls.filter(([customType]) => customType === "dispose-hidden-next-turn"),
+			).toHaveLength(0);
+
+			releaseSelectionValidation.resolve();
+			await Promise.allSettled([selection]);
+			await new Promise<void>(resolve => setImmediate(resolve));
+			expect(streamCount).toBe(0);
+			expect(session.agent.state.messages).toEqual(transcriptBefore);
+			expect(
+				appendCustomEntry.mock.calls.filter(([customType]) => customType === "dispose-hidden-next-turn"),
+			).toHaveLength(0);
+			await disposal;
+		} finally {
+			releaseSelectionValidation.resolve();
+			await Promise.allSettled([selection]);
+			const lateWork = await Promise.race([
+				streamCreated.promise.then(() => "provider started" as const),
+				closeEntered.promise.then(() => "dispose advanced" as const),
+			]);
+			if (lateWork === "provider started" && activeStream) {
+				const message = createAssistantMessage("case X cleanup");
+				activeStream.push({ type: "done", reason: "stop", message });
+				activeStream.end(message);
+				activeStream = undefined;
+			}
+			await Promise.allSettled([disposal]);
+		}
+	});
+
+	it("settles recursive same-session dispose inside session_shutdown without self-waiting", async () => {
+		// Given
+		await session.dispose();
+		const recursiveDisposeOutcome = Promise.withResolvers<"recursive dispose settled" | "checkpoint reached">();
+		const runDetachedDispose = Promise.withResolvers<void>();
+		const detachedDisposeCalled = Promise.withResolvers<void>();
+		const secondHandlerEntered = Promise.withResolvers<void>();
+		const releaseSecondHandler = Promise.withResolvers<void>();
+		let detachedDisposal: Promise<void> | undefined;
+		const firstHandler = async (): Promise<unknown> => {
+			const recursiveDisposal = session.dispose();
+			const checkpoint = Promise.withResolvers<void>();
+			setImmediate(checkpoint.resolve);
+			recursiveDisposeOutcome.resolve(
+				await Promise.race([
+					recursiveDisposal.then(() => "recursive dispose settled" as const),
+					checkpoint.promise.then(() => "checkpoint reached" as const),
+				]),
+			);
+			void (async () => {
+				await runDetachedDispose.promise;
+				detachedDisposal = session.dispose();
+				detachedDisposeCalled.resolve();
+			})();
+			return undefined;
+		};
+		const secondHandler = async (): Promise<unknown> => {
+			secondHandlerEntered.resolve();
+			await releaseSecondHandler.promise;
+			return undefined;
+		};
+		const extension: Extension = {
+			path: "test:recursive-session-shutdown-dispose",
+			resolvedPath: "test:recursive-session-shutdown-dispose",
+			handlers: new Map([["session_shutdown", [firstHandler, secondHandler]]]),
+			tools: new Map(),
+			messageRenderers: new Map(),
+			commands: new Map(),
+			flags: new Map(),
+			shortcuts: new Map(),
+		};
+		const extensionRunner = new ExtensionRunner(
+			[extension],
+			new ExtensionRuntime(),
+			tempRoot,
+			sessionManager,
+			modelRegistry,
+		);
+		session = new AgentSession({
+			agent: new Agent({
+				getApiKey: () => "test-key",
+				initialState: { model: INITIAL_MODEL, systemPrompt: ["Test"], tools: [] },
+			}),
+			sessionManager,
+			settings,
+			modelRegistry,
+			thinkingLevel: Effort.Low,
+			extensionRunner,
+		});
+
+		// When
+		const disposal = session.dispose();
+		await secondHandlerEntered.promise;
+		const concurrentDisposal = session.dispose();
+		runDetachedDispose.resolve();
+		await detachedDisposeCalled.promise;
+		if (!detachedDisposal) throw new Error("Expected detached disposal call");
+		const shutdownCheckpoint = Promise.withResolvers<void>();
+		setImmediate(shutdownCheckpoint.resolve);
+
+		// Then
+		try {
+			expect(concurrentDisposal).toBe(disposal);
+			expect(detachedDisposal).toBe(disposal);
+			expect(await recursiveDisposeOutcome.promise).toBe("recursive dispose settled");
+			expect(
+				await Promise.race([
+					detachedDisposal.then(() => "disposed" as const),
+					shutdownCheckpoint.promise.then(() => "shutdown handler pending" as const),
+				]),
+			).toBe("shutdown handler pending");
+		} finally {
+			releaseSecondHandler.resolve();
+			await Promise.all([disposal, detachedDisposal]);
+		}
+	});
+
+	it("dispose waits for staged selection cleanup before closing the session", async () => {
+		// Given
+		const agentDir = path.join(tempRoot, "dispose-stage-agent");
+		const configPath = path.join(agentDir, "config.yml");
+		await fs.mkdir(agentDir, { recursive: true });
+		await Bun.write(configPath, "modelRoles:\n  default: initial-provider/initial:low\n");
+		resetSettingsForTest();
+		const durableSettings = await Settings.init({ cwd: tempRoot, agentDir });
+		const persistentManager = SessionManager.create(tempRoot, path.join(tempRoot, "dispose-stage-sessions"));
+		const persistentSession = new AgentSession({
+			agent: new Agent({
+				getApiKey: () => "test-key",
+				initialState: { model: INITIAL_MODEL, systemPrompt: ["Test"], tools: [] },
+			}),
+			sessionManager: persistentManager,
+			settings: durableSettings,
+			modelRegistry,
+			thinkingLevel: Effort.Low,
+		});
+		persistentManager.appendMessage({ role: "user", content: "persisted transcript", timestamp: 0 });
+		await persistentManager.rewriteEntries();
+		const entriesBefore = persistentManager.getEntries();
+		let stagedTempPath: string | undefined;
+		const originalStage = persistentManager.stageDefaultModelSelection.bind(persistentManager);
+		vi.spyOn(persistentManager, "stageDefaultModelSelection").mockImplementation(async (...args) => {
+			const stage = await originalStage(...args);
+			stagedTempPath = stage.tempPath;
+			return stage;
+		});
+		const durableEntered = Promise.withResolvers<void>();
+		const releaseDurable = Promise.withResolvers<void>();
+		const disposalError = new AgentBusyError("Agent session has been disposed.");
+		vi.spyOn(durableSettings, "setGlobalModelRoleAndFlush").mockImplementation(async () => {
+			durableEntered.resolve();
+			await releaseDurable.promise;
+			throw disposalError;
+		});
+		const closeEntered = Promise.withResolvers<void>();
+		const originalClose = persistentManager.close.bind(persistentManager);
+		vi.spyOn(persistentManager, "close").mockImplementation(async () => {
+			closeEntered.resolve();
+			await originalClose();
+		});
+		const selection = persistentSession.setDefaultModelSelection(targetModel(), Effort.High);
+		void selection.catch(() => {});
+		await durableEntered.promise;
+		if (!stagedTempPath) throw new Error("Expected staged default selection path");
+		expect(await Bun.file(stagedTempPath).exists()).toBeTrue();
+
+		try {
+			// When
+			const disposal = persistentSession.dispose();
+			void disposal.catch(() => {});
+			const checkpoint = Promise.withResolvers<void>();
+			setImmediate(checkpoint.resolve);
+
+			// Then
+			expect(
+				await Promise.race([
+					closeEntered.promise.then(() => "closed" as const),
+					checkpoint.promise.then(() => "cleanup pending" as const),
+				]),
+			).toBe("cleanup pending");
+			releaseDurable.resolve();
+			await expectPostDurableSelectionRecovery(selection, {
+				message: disposalError.message,
+				rollback: { disposition: "restored", failures: [] },
+			});
+			await disposal;
+			expect(await Bun.file(stagedTempPath).exists()).toBeFalse();
+			expect(durableSettings.getGlobal("modelRoles")).toEqual({ default: "initial-provider/initial:low" });
+			expect(await Bun.file(configPath).text()).toContain("default: initial-provider/initial:low");
+			expect(persistentSession.model).toBe(INITIAL_MODEL);
+			expect(persistentSession.thinkingLevel).toBe(Effort.Low);
+			expect(persistentManager.getEntries()).toEqual(entriesBefore);
+		} finally {
+			releaseDurable.resolve();
+			await Promise.allSettled([selection, persistentSession.dispose()]);
+			await persistentManager.close();
+			resetSettingsForTest();
+		}
+	});
+
+	it("dispose restores an applied durable selection before closing the session", async () => {
+		// Given
+		const agentDir = path.join(tempRoot, "dispose-durable-agent");
+		const configPath = path.join(agentDir, "config.yml");
+		await fs.mkdir(agentDir, { recursive: true });
+		await Bun.write(configPath, "modelRoles:\n  default: initial-provider/initial:low\n");
+		resetSettingsForTest();
+		const durableSettings = await Settings.init({ cwd: tempRoot, agentDir });
+		const persistentManager = SessionManager.create(tempRoot, path.join(tempRoot, "dispose-durable-sessions"));
+		const persistentSession = new AgentSession({
+			agent: new Agent({
+				getApiKey: () => "test-key",
+				initialState: { model: INITIAL_MODEL, systemPrompt: ["Test"], tools: [] },
+			}),
+			sessionManager: persistentManager,
+			settings: durableSettings,
+			modelRegistry,
+			thinkingLevel: Effort.Low,
+		});
+		persistentManager.appendMessage({ role: "user", content: "persisted transcript", timestamp: 0 });
+		await persistentManager.rewriteEntries();
+		const entriesBefore = persistentManager.getEntries();
+		let stagedTempPath: string | undefined;
+		const originalStage = persistentManager.stageDefaultModelSelection.bind(persistentManager);
+		vi.spyOn(persistentManager, "stageDefaultModelSelection").mockImplementation(async (...args) => {
+			const stage = await originalStage(...args);
+			stagedTempPath = stage.tempPath;
+			return stage;
+		});
+		const durableApplied = Promise.withResolvers<void>();
+		const releaseDurableResult = Promise.withResolvers<void>();
+		const originalCommit = durableSettings.setGlobalModelRoleAndFlush.bind(durableSettings);
+		vi.spyOn(durableSettings, "setGlobalModelRoleAndFlush").mockImplementation(async (...args) => {
+			const commit = await originalCommit(...args);
+			durableApplied.resolve();
+			await releaseDurableResult.promise;
+			return commit;
+		});
+		const closeEntered = Promise.withResolvers<void>();
+		const originalClose = persistentManager.close.bind(persistentManager);
+		vi.spyOn(persistentManager, "close").mockImplementation(async () => {
+			closeEntered.resolve();
+			await originalClose();
+		});
+		const selection = persistentSession.setDefaultModelSelection(targetModel(), Effort.High);
+		void selection.catch(() => {});
+		await durableApplied.promise;
+		if (!stagedTempPath) throw new Error("Expected staged default selection path");
+		expect(await Bun.file(stagedTempPath).exists()).toBeTrue();
+		expect(await Bun.file(configPath).text()).toContain("default: target-provider/reasoning:high");
+
+		try {
+			// When
+			const disposal = persistentSession.dispose();
+			void disposal.catch(() => {});
+			const checkpoint = Promise.withResolvers<void>();
+			setImmediate(checkpoint.resolve);
+
+			// Then
+			expect(
+				await Promise.race([
+					closeEntered.promise.then(() => "closed" as const),
+					checkpoint.promise.then(() => "recovery pending" as const),
+				]),
+			).toBe("recovery pending");
+			releaseDurableResult.resolve();
+			await expectPostDurableSelectionRecovery(selection, {
+				message: "Agent session has been disposed.",
+				rollback: { disposition: "restored", failures: [] },
+			});
+			await disposal;
+			expect(await Bun.file(stagedTempPath).exists()).toBeFalse();
+			expect(durableSettings.getGlobal("modelRoles")).toEqual({ default: "initial-provider/initial:low" });
+			expect(await Bun.file(configPath).text()).toContain("default: initial-provider/initial:low");
+			expect(persistentSession.model).toBe(INITIAL_MODEL);
+			expect(persistentSession.thinkingLevel).toBe(Effort.Low);
+			expect(persistentManager.getEntries()).toEqual(entriesBefore);
+		} finally {
+			releaseDurableResult.resolve();
+			await Promise.allSettled([selection, persistentSession.dispose()]);
+			await persistentManager.close();
+			resetSettingsForTest();
+		}
 	});
 
 	it("rejects inherit before settings or session mutation", async () => {
@@ -1086,7 +3570,7 @@ describe("AgentSession durable default model selection", () => {
 		expect(sessionManager.buildSessionContext()).toEqual(contextBeforeSelection);
 	});
 
-	it("continues the selection queue after a rejected operation", async () => {
+	it("[H1] continues the selector-only queue after a durable failure", async () => {
 		// Given
 		const successfulModel = { ...targetModel(), id: "after-failure" };
 		const originalDurableCommit = settings.setGlobalModelRoleAndFlush.bind(settings);


### PR DESCRIPTION
## Summary

- Serialize prompt admission, including preflight, provider work, and logical-turn recovery, with durable default-model selection through one abort-safe per-session FIFO.
- Keep the pending prompt claim until the provider actually starts, so competing prompt behavior remains stable while terminal successors and internal continuations retain their owning admission.
- Route provider-starting continuations such as idle yield delivery, retry, follow-up, persisted-history continuation, plan enforcement, and hidden turns through the same admission boundary, including rollback and disposal cleanup.

## Why

PR #2093 made default selection wait for the underlying agent to become idle. A prompt can still be admitted and blocked in preflight before the agent reports streaming, allowing model validation, staging, durable persistence, and live publication to overtake that earlier prompt. This change closes that ordering gap at the session boundary instead of broadening the public idle contract.

## Review scope

- Addresses only [discussion_r3568828235](https://github.com/Yeachan-Heo/gajae-code/pull/2093#discussion_r3568828235) from #2093.
- Deliberately excludes [discussion_r3568828242](https://github.com/Yeachan-Heo/gajae-code/pull/2093#discussion_r3568828242) and legacy model-only extension compatibility.
- Public waitForIdle behavior remains unchanged. Same-session prompt-callback selection rejects before enqueue to prevent self-deadlock.
- #2140 is still open and changes adjacent continuation ownership; if it lands first, this branch will need semantic reconciliation during rebase.

## Verification

- Focused default-model-selection suite: 67 passed, 0 failed
- Final affected regression set: 9 passed, 0 failed
- Targeted Biome check: passed
- packages/coding-agent type check: passed
- git diff --check: passed