### PR TITLE
Fix VTE tmux owner cgroup isolation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Gajae Pet overlays no longer leak images or stale pixels across lifecycle changes: each widget owns a randomized Kitty image ID (deleted on disable, replace, switch, and dispose), the previous Sixel footprint is tracked and erased on movement, resize, and narrow-terminal fallback, replaced pet widgets are disposed before their successors install, and a saved pet preference survives editor replacement while graphics are still unavailable (so a delayed Sixel capability probe can still activate it). Teardown is exception-safe and idempotent: a failed or unavailable terminal write never aborts logical disposal or steals a successor widget's overlay slot, and Sixel/Kitty cleanup authority is retained until the erase is actually delivered so a later mode switch or dispose retries it.
 - Gajae Pet cleanup that fails during final widget disposal is now retained by the TUI for retry, and Kitty image IDs remain reserved until their exact-ID delete is delivered.
+- Fixed `gjc --tmux` startup from GNOME and other VTE terminals by recognizing `vte-spawn-*.scope` only when cgroup metadata proves matching user-manager ancestry (#2159).
 
 ## [0.10.1] - 2026-07-13
 

--- a/packages/coding-agent/src/gjc-runtime/tmux-owner-isolation.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-owner-isolation.ts
@@ -86,7 +86,10 @@ export function classifyCgroup(input: { platform: NodeJS.Platform; cgroupText?: 
 			diagnostic: "service_cgroup_inheritance",
 		};
 	const scope = paths.find(value => /(?:^|\/)(?:user|session|app|init|gjc)[^/]*\.scope(?:\/|$)/.test(value));
-	if (scope) return { classification: "safe", scope };
+	const vteScope = paths.find(value =>
+		/^\/user\.slice\/user-(\d+)\.slice\/user@\1\.service(?:\/[^/]+)*\/vte-spawn-[A-Za-z0-9_.-]+\.scope$/.test(value),
+	);
+	if (scope || vteScope) return { classification: "safe", scope: scope ?? vteScope };
 	if (paths.every(value => value === "/")) return { classification: "safe", scope: "/" };
 	return {
 		classification: "unverifiable",

--- a/packages/coding-agent/test/gjc-runtime/tmux-owner-isolation.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-owner-isolation.test.ts
@@ -352,6 +352,37 @@ describe("tmux owner isolation", () => {
 			}).classification,
 		).toBe("safe");
 		expect(
+			classifyCgroup({
+				platform: "linux",
+				cgroupText:
+					"0::/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-4006c3d1-0f5c-4ddb-b522-7b73d1f1fb59.scope",
+			}),
+		).toEqual({
+			classification: "safe",
+			scope: "/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-4006c3d1-0f5c-4ddb-b522-7b73d1f1fb59.scope",
+		});
+		expect(
+			classifyCgroup({
+				platform: "linux",
+				cgroupText: "0::/user.slice/user-1001.slice/user@1000.service/app.slice/vte-spawn-4006c3d1.scope",
+			}).classification,
+		).toBe("unverifiable");
+		expect(
+			classifyCgroup({
+				platform: "linux",
+				cgroupText: "0::/system.slice/vte-spawn-4006c3d1.scope",
+			}).classification,
+		).toBe("unverifiable");
+		expect(
+			await planTmuxOwnerIsolation(
+				request,
+				probe(
+					"absent",
+					"0::/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-4006c3d1.scope",
+				),
+			),
+		).toMatchObject({ ok: true, code: "not_required", classification: { classification: "safe" } });
+		expect(
 			(
 				await planTmuxOwnerIsolation(request, {
 					...probe("safe"),


### PR DESCRIPTION
## Summary

- recognize canonical VTE `vte-spawn-*.scope` cgroups only under root-anchored matching `user-<uid>.slice/user@<uid>.service` ancestry
- keep mismatched user-manager ancestry and system-slice lookalikes fail-closed
- cover both existing classification and fresh-no-server `gjc --tmux` planning
- preserve all current `dev` lifecycle, process-incarnation, Windows psmux, launch, and detached-owner contracts unchanged

## Verification

- `bun test packages/coding-agent/test/gjc-runtime/tmux-owner-isolation.test.ts` — 49 passed
- `bun --cwd=packages/coding-agent run check` passed on base `09e406b85`; after final rebase to `632b8a434`, the same command reaches unrelated pre-existing formatter failures in `test/model-profile-activation.test.ts` and `test/model-profiles-catalog.test.ts`
- exact-head CI required before merge

Closes #2159

Signed-off-by: GJC <gjc@local>