### PR TITLE
fix(sdk): fence stale WebSocket callbacks during reconnect

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Renamed the notifications SDK to the Gajae-Code SDK: `docs/notifications-sdk.md` is now `docs/sdk.md`, `src/notifications/` is now `src/sdk/bus/`, and `src/sdk.ts` is now the `src/sdk/` module directory. Old deep-import specifiers no longer resolve.
 - Moved SDK discovery from `.gjc/state/notifications/` to `.gjc/state/sdk/`. Restart sessions and daemons together when upgrading; the runtime does not dual-scan the old and new directories.
 - Removed the `--mode rpc`, `--mode rpc-ui`, and `--mode bridge` external ingress modes. Machine clients must use the SDK WebSocket interfaces documented in `docs/sdk.md`; no RPC or Bridge compatibility path remains.
+### Fixed
+
+- Fenced SDK WebSocket lifecycle callbacks and request settlement to the owning retry cycle/socket incarnation, so stale open, close, error, message, and timeout delivery cannot reject or corrupt work on a replacement connection; sent mutations remain non-replayed and deterministic race regressions cover the reconnect boundary (#2164).
+
 ## [0.10.1] - 2026-07-13
 
 ### Added

--- a/packages/coding-agent/src/sdk/client/client.ts
+++ b/packages/coding-agent/src/sdk/client/client.ts
@@ -42,15 +42,35 @@ export type SdkReconnectHandler = () => void;
 export type SdkReconnectFailedHandler = (error: SdkClientError) => void;
 
 type Frame = SdkFrame;
+type Cycle = {
+	readonly generation: number;
+	phase: "opening" | "backoff" | "complete" | "aborted";
+	candidate: Incarnation | null;
+	promise?: Promise<Incarnation>;
+	backoffTimer?: ReturnType<typeof setTimeout>;
+	rejectBackoff?: (error: Error) => void;
+};
+type Incarnation = {
+	readonly generation: number;
+	readonly cycle: Cycle;
+	readonly socket: WebSocket;
+	phase: "opening" | "hello" | "active" | "retired";
+	tornDown: boolean;
+	openTimer?: ReturnType<typeof setTimeout>;
+	failure?: Error;
+	helloTimer?: ReturnType<typeof setTimeout>;
+	resolveOpen?: () => void;
+	rejectOpen?: (error: Error) => void;
+	resolveHello?: () => void;
+	rejectHello?: (error: Error) => void;
+	listeners: Array<["open" | "error" | "close" | "message", EventListener]>;
+};
 type Pending = {
+	readonly incarnation: Incarnation;
 	resolve: (value: unknown) => void;
 	reject: (error: Error) => void;
 	timer: ReturnType<typeof setTimeout>;
 };
-
-function sleep(ms: number): Promise<void> {
-	return new Promise(resolve => setTimeout(resolve, ms));
-}
 
 function errorFrom(frame: Frame): SdkClientError {
 	const error = frame.error;
@@ -83,23 +103,18 @@ export class SdkClient {
 	readonly #reconnectAttempts: number;
 	readonly #reconnectBackoffMs: number;
 	readonly #deadline?: number;
-
-	#socket: WebSocket | null = null;
-	#opening: Promise<WebSocket> | null = null;
+	#currentSocketRecord: Incarnation | null = null;
+	#opening: Cycle | null = null;
+	#cycleGeneration = 0;
+	#incarnationGeneration = 0;
 	#pending = new Map<string, Pending>();
 	#frameHandlers = new Set<SdkFrameHandler>();
 	#reconnectHandlers = new Set<SdkReconnectHandler>();
 	#reconnectFailedHandlers = new Set<SdkReconnectFailedHandler>();
 
-	#helloSocket: WebSocket | null = null;
-	#helloPromise: Promise<void> | null = null;
-	#helloReceived = new WeakSet<WebSocket>();
-	#resolveHello?: () => void;
-	#rejectHello?: (error: Error) => void;
-	#helloTimer?: ReturnType<typeof setTimeout>;
-
 	#closed = false;
 	connectionId?: string;
+
 	constructor(url: string, token: string, options: SdkClientOptions = {}) {
 		this.#url = url;
 		this.#token = token;
@@ -144,12 +159,14 @@ export class SdkClient {
 	send(frame: SdkFrame): void {
 		if (this.#closed) throw new SdkClientError("connection_closed", "SDK client closed");
 		this.#throwIfDeadlineElapsed();
-
-		const socket = this.#socket;
-		if (!socket || socket.readyState !== WebSocket.OPEN)
+		const current = this.#currentSocketRecord ?? this.#opening?.candidate;
+		const authoritative =
+			this.#isActive(current ?? null) ||
+			(!!current && current.phase === "hello" && this.#isCandidate(current.cycle, current));
+		if (!current || !authoritative || current.socket.readyState !== WebSocket.OPEN)
 			throw new SdkClientError("connection_closed", "SDK WebSocket is not connected");
 		try {
-			socket.send(JSON.stringify(frame));
+			current.socket.send(JSON.stringify(frame));
 		} catch (error) {
 			throw new SdkClientError("unavailable", "SDK WebSocket send failed", error);
 		}
@@ -161,16 +178,22 @@ export class SdkClient {
 	}
 
 	async close(): Promise<void> {
+		if (this.#closed) return;
 		this.#closed = true;
-		this.#socket?.close();
-		this.#socket = null;
-		this.#rejectHello?.(new SdkClientError("connection_closed", "SDK client closed"));
-		this.#clearHello();
-		for (const pending of this.#pending.values()) {
-			clearTimeout(pending.timer);
-			pending.reject(new SdkClientError("connection_closed", "SDK client closed"));
+		const cycle = this.#opening;
+		if (cycle) {
+			cycle.phase = "aborted";
+			if (cycle.backoffTimer) clearTimeout(cycle.backoffTimer);
+			if (cycle.candidate)
+				this.#retire(cycle.candidate, new SdkClientError("connection_closed", "SDK client closed"), true);
+			cycle.rejectBackoff?.(new SdkClientError("connection_closed", "SDK client closed"));
+			cycle.rejectBackoff = undefined;
+			if (this.#opening === cycle) this.#opening = null;
 		}
-		this.#pending.clear();
+		const current = this.#currentSocketRecord;
+		if (current) this.#retire(current, new SdkClientError("connection_closed", "SDK client closed"), true);
+		for (const [id, pending] of this.#pending)
+			this.#settlePending(id, pending, new SdkClientError("connection_closed", "SDK client closed"));
 	}
 
 	async control(
@@ -188,6 +211,7 @@ export class SdkClient {
 			options,
 		);
 	}
+
 	async query(
 		query: string,
 		input: Record<string, unknown> = {},
@@ -199,6 +223,7 @@ export class SdkClient {
 			options,
 		);
 	}
+
 	async global(
 		operation: string,
 		input: Record<string, unknown> = {},
@@ -206,25 +231,46 @@ export class SdkClient {
 	): Promise<unknown> {
 		return await this.#request({ type: "broker_request", operation, input }, options);
 	}
+
 	async #request(frame: Frame, options: SdkRequestOptions): Promise<unknown> {
 		if (this.#closed) throw new SdkClientError("connection_closed", "SDK client closed");
 		this.#throwIfDeadlineElapsed();
-		await this.#connect();
+		const incarnation = await this.#connect();
 		const timeoutMs = this.#remainingTimeout(options.timeoutMs ?? this.#timeoutMs);
 		if (timeoutMs <= 0) throw this.#deadlineError();
 		const id = randomUUID();
 		return await new Promise<unknown>((resolve, reject) => {
-			const timer = setTimeout(() => {
-				this.#pending.delete(id);
-				reject(new SdkClientError("timeout", `SDK request timed out after ${timeoutMs}ms`));
-			}, timeoutMs);
-			this.#pending.set(id, { resolve, reject, timer });
+			const pending: Pending = {
+				incarnation,
+				resolve,
+				reject,
+				timer: setTimeout(
+					() =>
+						this.#settlePending(
+							id,
+							pending,
+							new SdkClientError("timeout", `SDK request timed out after ${timeoutMs}ms`),
+						),
+					timeoutMs,
+				),
+			};
+			this.#pending.set(id, pending);
+			if (!this.#isActive(incarnation) || incarnation.socket.readyState !== WebSocket.OPEN) {
+				this.#settlePending(id, pending, new SdkClientError("unavailable", "SDK WebSocket is not connected"));
+				return;
+			}
 			try {
-				this.send({ ...frame, id, ...(options.idempotencyKey ? { idempotencyKey: options.idempotencyKey } : {}) });
+				incarnation.socket.send(
+					JSON.stringify({
+						...frame,
+						id,
+						...(options.idempotencyKey ? { idempotencyKey: options.idempotencyKey } : {}),
+					}),
+				);
 			} catch (error) {
-				clearTimeout(timer);
-				this.#pending.delete(id);
-				reject(
+				this.#settlePending(
+					id,
+					pending,
 					error instanceof SdkClientError
 						? error
 						: new SdkClientError("unavailable", "SDK WebSocket send failed", error),
@@ -246,207 +292,295 @@ export class SdkClient {
 		if (this.#deadline !== undefined && Date.now() >= this.#deadline) throw this.#deadlineError();
 	}
 
-	async #connect(): Promise<WebSocket> {
+	async #connect(): Promise<Incarnation> {
 		this.#throwIfDeadlineElapsed();
-		if (this.#socket?.readyState === WebSocket.OPEN) {
-			await this.#waitForHello(this.#socket);
-			return this.#socket;
+		const current = this.#currentSocketRecord;
+		if (current && this.#isActive(current) && current.socket.readyState === WebSocket.OPEN) return current;
+		if (current)
+			this.#retire(current, new SdkClientError("connection_closed", "SDK WebSocket connection closed"), true);
+		let cycle = this.#opening;
+		if (!cycle) {
+			cycle = { generation: ++this.#cycleGeneration, phase: "opening", candidate: null };
+			this.#opening = cycle;
+			cycle.promise = this.#openWithRetry(cycle);
 		}
-		if (this.#opening) return await this.#opening;
-		this.#opening = this.#openWithRetry();
-		try {
-			return await this.#opening;
-		} finally {
-			this.#opening = null;
-		}
+		return await cycle.promise!;
 	}
 
-	async #openWithRetry(): Promise<WebSocket> {
+	async #openWithRetry(cycle: Cycle): Promise<Incarnation> {
 		let lastError: unknown;
 		for (let attempt = 0; attempt <= this.#reconnectAttempts; attempt++) {
 			this.#throwIfDeadlineElapsed();
-			let socket: WebSocket | undefined;
+			if (!this.#isOpening(cycle)) throw new SdkClientError("connection_closed", "SDK client closed");
 			try {
-				socket = await this.#open();
-				await this.#waitForHello(socket);
-				return socket;
+				const incarnation = await this.#open(cycle);
+				if (!this.#isActive(incarnation) && (!this.#isOpening(cycle) || cycle.candidate !== incarnation))
+					throw new SdkClientError("connection_closed", "SDK WebSocket is not connected");
+				await this.#waitForHello(incarnation);
+				if (this.#isActive(incarnation)) return incarnation;
+				throw new SdkClientError("connection_closed", "SDK WebSocket is not connected");
 			} catch (error) {
 				lastError = error;
-				socket?.close();
+				if (!this.#isOpening(cycle)) throw error;
+				const candidate = cycle.candidate;
+				if (candidate && candidate.phase !== "active")
+					this.#retire(
+						candidate,
+						error instanceof SdkClientError
+							? error
+							: new SdkClientError("unavailable", "SDK WebSocket connection failed", error),
+						true,
+					);
 				if (attempt < this.#reconnectAttempts) {
 					const backoffMs = this.#remainingTimeout(this.#reconnectBackoffMs * 2 ** attempt);
 					if (backoffMs <= 0) break;
-					await sleep(backoffMs);
+					cycle.phase = "backoff";
+					await new Promise<void>((resolve, reject) => {
+						cycle.rejectBackoff = reject;
+						cycle.backoffTimer = setTimeout(resolve, backoffMs);
+					});
+					cycle.rejectBackoff = undefined;
+					cycle.backoffTimer = undefined;
+					if (!this.#isOpening(cycle)) throw new SdkClientError("connection_closed", "SDK client closed");
+					cycle.phase = "opening";
 				}
 			}
 		}
+		if (!this.#isOpening(cycle)) throw new SdkClientError("connection_closed", "SDK client closed");
 		if (this.#deadline !== undefined && Date.now() >= this.#deadline) throw this.#deadlineError();
+		cycle.phase = "complete";
+		if (this.#opening === cycle) this.#opening = null;
 		const error = new SdkClientError("reconnect_exhausted", "SDK WebSocket reconnect attempts exhausted", lastError);
 		for (const handler of this.#reconnectFailedHandlers) handler(error);
 		throw error;
 	}
 
-	#open(): Promise<WebSocket> {
+	#open(cycle: Cycle): Promise<Incarnation> {
 		const timeoutMs = this.#remainingTimeout();
 		if (timeoutMs <= 0) return Promise.reject(this.#deadlineError());
 		return new Promise((resolve, reject) => {
 			const url = new URL(this.#url);
 			url.searchParams.set("token", this.#token);
 			const socket = new WebSocket(url);
-			let timer: NodeJS.Timeout | undefined;
-			const onOpen = () => {
-				cleanup();
-				if (this.#closed) {
-					try {
-						socket.close();
-					} catch {}
-					reject(new SdkClientError("connection_closed", "SDK client closed"));
-					return;
-				}
-				this.#socket = socket;
-				this.#beginHello(socket);
-				resolve(socket);
+			const incarnation: Incarnation = {
+				generation: ++this.#incarnationGeneration,
+				cycle,
+				socket,
+				phase: "opening",
+				tornDown: false,
+				listeners: [],
+				resolveOpen: () => resolve(incarnation),
+				rejectOpen: reject,
 			};
-			const onError = (event: Event) => {
-				cleanup();
-				const eventWithDetail = event as Event & { error?: unknown; message?: unknown };
-				const detail = eventWithDetail.error;
-				reject(
-					detail instanceof Error
-						? detail
-						: new Error(
-								typeof eventWithDetail.message === "string"
-									? eventWithDetail.message
-									: "SDK WebSocket connection failed",
-							),
-				);
+			cycle.candidate = incarnation;
+			const add = (type: "open" | "error" | "close" | "message", listener: EventListener, once = false) => {
+				incarnation.listeners.push([type, listener]);
+				socket.addEventListener(type, listener, once ? { once: true } : undefined);
 			};
-			const cleanup = () => {
-				socket.removeEventListener("open", onOpen);
-				socket.removeEventListener("error", onError);
-				if (timer !== undefined) {
-					clearTimeout(timer);
-					timer = undefined;
-				}
-			};
-			socket.addEventListener("open", onOpen, { once: true });
-			socket.addEventListener("error", onError, { once: true });
-			socket.addEventListener("message", event => this.#onMessage(event.data, socket));
-			socket.addEventListener("close", () => {
-				if (this.#socket !== socket) return;
-				this.#socket = null;
-				if (this.#helloSocket === socket) {
-					this.#rejectHello?.(
-						new SdkClientError("connection_closed", "SDK WebSocket closed before server hello."),
-					);
-					this.#clearHello();
-				}
-				this.#rejectPending(new SdkClientError("connection_closed", "SDK WebSocket connection closed"));
-			});
-			timer = setTimeout(() => {
-				cleanup();
-				try {
-					socket.close();
-				} catch {}
-				reject(new SdkClientError("timeout", `SDK WebSocket connection timed out after ${timeoutMs}ms`));
-			}, timeoutMs);
-			timer.unref?.();
+			add(
+				"open",
+				(() => {
+					if (!this.#isCandidate(cycle, incarnation) || incarnation.phase !== "opening") return;
+					if (incarnation.openTimer) clearTimeout(incarnation.openTimer);
+					incarnation.phase = "hello";
+					this.#beginHello(incarnation);
+					incarnation.resolveOpen?.();
+					incarnation.resolveOpen = undefined;
+					incarnation.rejectOpen = undefined;
+				}) as EventListener,
+				true,
+			);
+			add("error", ((event: Event) => this.#onSocketFailure(incarnation, event)) as EventListener);
+			add("close", (() => this.#onSocketFailure(incarnation)) as EventListener);
+			add("message", ((event: MessageEvent) => this.#onMessage(event.data, incarnation)) as EventListener);
+			incarnation.openTimer = setTimeout(() => this.#onOpenTimeout(incarnation, timeoutMs), timeoutMs);
+			incarnation.openTimer.unref?.();
 		});
 	}
 
-	#rejectPending(error: SdkClientError): void {
-		for (const pending of this.#pending.values()) {
-			clearTimeout(pending.timer);
-			pending.reject(error);
-		}
-		this.#pending.clear();
-	}
-
-	#beginHello(socket: WebSocket): void {
-		this.#helloSocket = socket;
+	#beginHello(incarnation: Incarnation): void {
 		const timeoutMs = this.#remainingTimeout();
-		this.#helloPromise = new Promise<void>((resolve, reject) => {
-			this.#resolveHello = resolve;
-			this.#rejectHello = reject;
-			if (timeoutMs <= 0) {
-				reject(this.#deadlineError());
-				return;
-			}
-			// A server that never sends its hello must fail typed instead of
-			// hanging the caller until the request timeout.
-			const timer = setTimeout(() => {
-				if (this.#helloSocket !== socket) return;
-				this.#rejectHello?.(
-					this.#deadline !== undefined && Date.now() >= this.#deadline
-						? this.#deadlineError()
-						: new SdkClientError("protocol_error", "SDK server did not send a hello frame."),
-				);
-				this.#clearHello();
-			}, timeoutMs);
-			this.#helloTimer = timer;
-			timer.unref?.();
-		});
-	}
-
-	async #waitForHello(socket: WebSocket): Promise<void> {
-		this.#throwIfDeadlineElapsed();
-		if (this.#helloReceived.has(socket)) return;
-		if (this.#helloSocket === socket && this.#helloPromise) {
-			await this.#helloPromise;
+		if (timeoutMs <= 0) {
+			this.#retire(incarnation, this.#deadlineError(), true);
 			return;
 		}
-		throw new SdkClientError("connection_closed", "SDK WebSocket is not connected");
+		incarnation.helloTimer = setTimeout(() => {
+			if (!this.#isCandidate(incarnation.cycle, incarnation) || incarnation.phase !== "hello") return;
+			const error =
+				this.#deadline !== undefined && Date.now() >= this.#deadline
+					? this.#deadlineError()
+					: new SdkClientError("protocol_error", "SDK server did not send a hello frame.");
+			incarnation.rejectHello?.(error);
+			this.#retire(incarnation, error, true);
+		}, timeoutMs);
+		incarnation.helloTimer.unref?.();
 	}
 
-	#clearHello(): void {
-		if (this.#helloTimer !== undefined) {
-			clearTimeout(this.#helloTimer);
-			this.#helloTimer = undefined;
-		}
-		this.#helloSocket = null;
-		this.#helloPromise = null;
-		this.#resolveHello = undefined;
-		this.#rejectHello = undefined;
+	#waitForHello(incarnation: Incarnation): Promise<void> {
+		if (incarnation.failure) return Promise.reject(incarnation.failure);
+		if (this.#isActive(incarnation)) return Promise.resolve();
+		if (!this.#isCandidate(incarnation.cycle, incarnation) || incarnation.phase !== "hello")
+			return Promise.reject(new SdkClientError("connection_closed", "SDK WebSocket is not connected"));
+		return new Promise((resolve, reject) => {
+			incarnation.resolveHello = resolve;
+			incarnation.rejectHello = reject;
+		});
 	}
 
-	#onMessage(value: unknown, socket: WebSocket): void {
-		if (this.#socket !== socket) return;
+	#onOpenTimeout(incarnation: Incarnation, timeoutMs: number): void {
+		if (!this.#isCandidate(incarnation.cycle, incarnation) || incarnation.phase !== "opening") return;
+		const error =
+			this.#deadline !== undefined && Date.now() >= this.#deadline
+				? this.#deadlineError()
+				: new SdkClientError("timeout", `SDK WebSocket connection timed out after ${timeoutMs}ms`);
+		incarnation.rejectOpen?.(error);
+		this.#retire(incarnation, error, true);
+	}
+
+	#onSocketFailure(incarnation: Incarnation, event?: Event): void {
+		if (!this.#isCandidate(incarnation.cycle, incarnation) && !this.#isActive(incarnation)) return;
+		const detail = event as (Event & { error?: unknown; message?: unknown }) | undefined;
+		const error =
+			detail?.error instanceof Error
+				? detail.error
+				: new SdkClientError(
+						"connection_closed",
+						typeof detail?.message === "string" ? detail.message : "SDK WebSocket connection closed",
+					);
+		if (incarnation.phase === "opening") incarnation.rejectOpen?.(error);
+		if (incarnation.phase === "hello") incarnation.rejectHello?.(error);
+		this.#retire(
+			incarnation,
+			error instanceof SdkClientError
+				? error
+				: new SdkClientError("unavailable", "SDK WebSocket connection failed", error),
+			true,
+		);
+	}
+
+	#onMessage(value: unknown, incarnation: Incarnation): void {
+		if (!this.#isCandidate(incarnation.cycle, incarnation) && !this.#isActive(incarnation)) return;
 		let frame: Frame;
 		try {
 			frame = parseFrame(value);
 			if (frame.type === "control_command_result" && typeof frame.message === "string")
 				frame = parseFrame(frame.message);
 		} catch (error) {
-			this.#rejectPending(
+			this.#rejectPendingFor(
+				incarnation,
 				error instanceof SdkClientError
 					? error
-					: new SdkClientError("protocol_error", "SDK server sent a malformed frame.", error),
+					: new SdkClientError("protocol_error", "SDK server sent malformed frame.", error),
 			);
 			return;
 		}
 		if (frame.type === "hello" || frame.type === "server_hello" || frame.type === "broker_hello") {
-			// Per-session hosts advertise connectionId; the broker's hello carries
-			// only protocolVersion. Both mark the connection as ready.
-			if (typeof frame.connectionId === "string") {
-				const reconnecting = this.connectionId !== undefined && this.connectionId !== frame.connectionId;
-				this.connectionId = frame.connectionId;
-				if (reconnecting) for (const handler of this.#reconnectHandlers) handler();
+			if (incarnation.phase === "hello" && this.#isCandidate(incarnation.cycle, incarnation)) {
+				this.#acceptHello(incarnation, frame);
+				if (this.#isActive(incarnation)) for (const handler of this.#frameHandlers) handler(frame);
+				return;
 			}
-			this.#helloReceived.add(socket);
-			if (this.#helloSocket === socket) {
-				this.#resolveHello?.();
-				this.#clearHello();
-			}
+			if (!this.#isActive(incarnation)) return;
+			if (
+				typeof frame.connectionId !== "string" ||
+				frame.connectionId.length === 0 ||
+				frame.connectionId === this.connectionId
+			)
+				return;
+			this.connectionId = frame.connectionId;
+			for (const handler of this.#reconnectHandlers) handler();
 		}
+		if (!this.#isActive(incarnation)) return;
 		for (const handler of this.#frameHandlers) handler(frame);
 		const id =
 			typeof frame.id === "string" ? frame.id : typeof frame.requestId === "string" ? frame.requestId : undefined;
 		if (!id) return;
 		const pending = this.#pending.get(id);
-		if (!pending) return;
+		if (!pending || pending.incarnation !== incarnation) return;
+		this.#settlePending(id, pending, frame.ok === false || frame.status === "error" ? errorFrom(frame) : frame);
+	}
+
+	#acceptHello(incarnation: Incarnation, frame: Frame): void {
+		if (!this.#isCandidate(incarnation.cycle, incarnation) || incarnation.phase !== "hello") return;
+		if (incarnation.helloTimer) clearTimeout(incarnation.helloTimer);
+		const reconnecting =
+			typeof frame.connectionId === "string" &&
+			frame.connectionId.length > 0 &&
+			this.connectionId !== undefined &&
+			this.connectionId !== frame.connectionId;
+		if (typeof frame.connectionId === "string" && frame.connectionId.length > 0)
+			this.connectionId = frame.connectionId;
+		incarnation.phase = "active";
+		this.#currentSocketRecord = incarnation;
+		incarnation.cycle.phase = "complete";
+		if (this.#opening === incarnation.cycle) this.#opening = null;
+		const resolveHello = incarnation.resolveHello;
+		incarnation.resolveHello = undefined;
+		incarnation.rejectHello = undefined;
+		resolveHello?.();
+		if (reconnecting) for (const handler of this.#reconnectHandlers) handler();
+	}
+
+	#settlePending(id: string, pending: Pending, result: unknown): void {
+		if (this.#pending.get(id) !== pending) return;
 		this.#pending.delete(id);
 		clearTimeout(pending.timer);
-		if (frame.ok === false || frame.status === "error") pending.reject(errorFrom(frame));
-		else pending.resolve(frame);
+		if (result instanceof Error) pending.reject(result);
+		else pending.resolve(result);
+	}
+	#rejectPendingFor(incarnation: Incarnation, error: SdkClientError): void {
+		for (const [id, pending] of this.#pending)
+			if (pending.incarnation === incarnation) this.#settlePending(id, pending, error);
+	}
+	#retire(incarnation: Incarnation, error: SdkClientError, closeSocket: boolean): void {
+		if (incarnation.tornDown) return;
+		const phase = incarnation.phase;
+		incarnation.phase = "retired";
+		incarnation.failure = error;
+		if (phase === "opening") incarnation.rejectOpen?.(error);
+		if (phase === "hello") incarnation.rejectHello?.(error);
+		incarnation.resolveOpen = undefined;
+		incarnation.rejectOpen = undefined;
+		incarnation.resolveHello = undefined;
+		incarnation.rejectHello = undefined;
+		this.#rejectPendingFor(incarnation, error);
+		if (this.#currentSocketRecord === incarnation) this.#currentSocketRecord = null;
+		if (incarnation.cycle.candidate === incarnation) incarnation.cycle.candidate = null;
+		this.#teardown(incarnation, closeSocket);
+	}
+	#teardown(incarnation: Incarnation, closeSocket: boolean): void {
+		if (incarnation.tornDown) return;
+		incarnation.tornDown = true;
+		if (incarnation.openTimer) clearTimeout(incarnation.openTimer);
+		if (incarnation.helloTimer) clearTimeout(incarnation.helloTimer);
+		for (const [type, listener] of incarnation.listeners) incarnation.socket.removeEventListener(type, listener);
+		incarnation.listeners = [];
+		if (closeSocket)
+			try {
+				incarnation.socket.close();
+			} catch {}
+	}
+	#isCandidate(cycle: Cycle, incarnation: Incarnation): boolean {
+		return (
+			!this.#closed &&
+			this.#opening === cycle &&
+			cycle.candidate === incarnation &&
+			cycle.generation > 0 &&
+			incarnation.generation > 0 &&
+			incarnation.cycle === cycle &&
+			(cycle.phase === "opening" || cycle.phase === "backoff")
+		);
+	}
+	#isOpening(cycle: Cycle): boolean {
+		return !this.#closed && this.#opening === cycle && (cycle.phase === "opening" || cycle.phase === "backoff");
+	}
+	#isActive(incarnation: Incarnation | null): boolean {
+		return (
+			!!incarnation &&
+			incarnation.generation > 0 &&
+			!this.#closed &&
+			this.#currentSocketRecord === incarnation &&
+			incarnation.phase === "active"
+		);
 	}
 }

--- a/packages/coding-agent/src/sdk/client/client.ts
+++ b/packages/coding-agent/src/sdk/client/client.ts
@@ -310,7 +310,11 @@ export class SdkClient {
 	async #openWithRetry(cycle: Cycle): Promise<Incarnation> {
 		let lastError: unknown;
 		for (let attempt = 0; attempt <= this.#reconnectAttempts; attempt++) {
-			this.#throwIfDeadlineElapsed();
+			if (this.#deadline !== undefined && Date.now() >= this.#deadline) {
+				const error = this.#deadlineError();
+				this.#completeCycle(cycle, error);
+				throw error;
+			}
 			if (!this.#isOpening(cycle)) throw new SdkClientError("connection_closed", "SDK client closed");
 			try {
 				const incarnation = await this.#open(cycle);
@@ -347,12 +351,28 @@ export class SdkClient {
 			}
 		}
 		if (!this.#isOpening(cycle)) throw new SdkClientError("connection_closed", "SDK client closed");
-		if (this.#deadline !== undefined && Date.now() >= this.#deadline) throw this.#deadlineError();
+		if (this.#deadline !== undefined && Date.now() >= this.#deadline) {
+			const error = this.#deadlineError();
+			this.#completeCycle(cycle, error);
+			throw error;
+		}
 		cycle.phase = "complete";
 		if (this.#opening === cycle) this.#opening = null;
 		const error = new SdkClientError("reconnect_exhausted", "SDK WebSocket reconnect attempts exhausted", lastError);
 		for (const handler of this.#reconnectFailedHandlers) handler(error);
 		throw error;
+	}
+
+	#completeCycle(cycle: Cycle, error: SdkClientError): void {
+		if (cycle.backoffTimer) clearTimeout(cycle.backoffTimer);
+		cycle.rejectBackoff?.(error);
+		cycle.rejectBackoff = undefined;
+		cycle.backoffTimer = undefined;
+		const candidate = cycle.candidate;
+		if (candidate) this.#retire(candidate, error, true);
+		cycle.candidate = null;
+		cycle.phase = "complete";
+		if (this.#opening === cycle) this.#opening = null;
 	}
 
 	#open(cycle: Cycle): Promise<Incarnation> {
@@ -383,10 +403,10 @@ export class SdkClient {
 					if (!this.#isCandidate(cycle, incarnation) || incarnation.phase !== "opening") return;
 					if (incarnation.openTimer) clearTimeout(incarnation.openTimer);
 					incarnation.phase = "hello";
-					this.#beginHello(incarnation);
 					incarnation.resolveOpen?.();
 					incarnation.resolveOpen = undefined;
 					incarnation.rejectOpen = undefined;
+					this.#beginHello(incarnation);
 				}) as EventListener,
 				true,
 			);

--- a/packages/coding-agent/test/sdk-client.test.ts
+++ b/packages/coding-agent/test/sdk-client.test.ts
@@ -328,14 +328,21 @@ class FakeWebSocket {
 }
 
 type FakeTimerHandle = { readonly id: number; unref: () => FakeTimerHandle };
+type FakeTimerTask = { readonly callback: () => void; readonly due: number; readonly order: number };
 
 class FakeClock {
 	#nextId = 1;
-	readonly tasks = new Map<FakeTimerHandle, () => void>();
+	#nextOrder = 1;
+	now = 1_000;
+	readonly tasks = new Map<FakeTimerHandle, FakeTimerTask>();
 
-	setTimeout(callback: (...args: unknown[]) => void, _delay?: number, ...args: unknown[]): FakeTimerHandle {
+	setTimeout(callback: (...args: unknown[]) => void, delay = 0, ...args: unknown[]): FakeTimerHandle {
 		const handle: FakeTimerHandle = { id: this.#nextId++, unref: () => handle };
-		this.tasks.set(handle, () => callback(...args));
+		this.tasks.set(handle, {
+			callback: () => callback(...args),
+			due: this.now + Math.max(0, delay),
+			order: this.#nextOrder++,
+		});
 		return handle;
 	}
 
@@ -343,17 +350,41 @@ class FakeClock {
 		this.tasks.delete(handle);
 	}
 
+	elapse(milliseconds: number): void {
+		this.now += milliseconds;
+	}
+
+	advanceBy(milliseconds: number): void {
+		this.advanceTo(this.now + milliseconds);
+	}
+
+	advanceTo(target: number): void {
+		if (target < this.now) throw new Error("Fake clock cannot move backwards");
+		for (;;) {
+			const entry = [...this.tasks.entries()]
+				.filter(([, task]) => task.due <= target)
+				.sort((left, right) => left[1].due - right[1].due || left[1].order - right[1].order)[0];
+			if (!entry) break;
+			this.now = entry[1].due;
+			this.tasks.delete(entry[0]);
+			entry[1].callback();
+		}
+		this.now = target;
+	}
+
 	runNext(): void {
-		const entry = this.tasks.entries().next().value as [FakeTimerHandle, () => void] | undefined;
+		const entry = [...this.tasks.entries()].sort(
+			(left, right) => left[1].due - right[1].due || left[1].order - right[1].order,
+		)[0];
 		if (!entry) throw new Error("No fake timer is pending");
-		this.tasks.delete(entry[0]);
-		entry[1]();
+		this.advanceTo(entry[1].due);
 	}
 }
 
 async function withFakeTimers(run: (clock: FakeClock) => Promise<void>): Promise<void> {
 	const setTimeoutDescriptor = Object.getOwnPropertyDescriptor(globalThis, "setTimeout");
 	const clearTimeoutDescriptor = Object.getOwnPropertyDescriptor(globalThis, "clearTimeout");
+	const dateNowDescriptor = Object.getOwnPropertyDescriptor(Date, "now");
 	const clock = new FakeClock();
 	Object.defineProperty(globalThis, "setTimeout", {
 		configurable: true,
@@ -363,11 +394,13 @@ async function withFakeTimers(run: (clock: FakeClock) => Promise<void>): Promise
 		configurable: true,
 		value: clock.clearTimeout.bind(clock) as unknown as typeof clearTimeout,
 	});
+	Object.defineProperty(Date, "now", { configurable: true, value: () => clock.now });
 	try {
 		await run(clock);
 	} finally {
 		if (setTimeoutDescriptor) Object.defineProperty(globalThis, "setTimeout", setTimeoutDescriptor);
 		if (clearTimeoutDescriptor) Object.defineProperty(globalThis, "clearTimeout", clearTimeoutDescriptor);
+		if (dateNowDescriptor) Object.defineProperty(Date, "now", dateNowDescriptor);
 	}
 }
 
@@ -487,12 +520,28 @@ test("SdkClient deterministically owns open, hello, request, and backoff timers"
 			requestSocket.open();
 			requestSocket.message({ type: "hello", connectionId: "request-timeout" });
 			await requestConnected;
-			const requestTimeout = requestTimeoutClient.control("timeout", {}, { timeoutMs: 50 });
-			await flush();
-			clock.runNext();
-			await expect(requestTimeout).rejects.toMatchObject({ code: "timeout" });
-			await requestTimeoutClient.close();
 
+			const beforeDeadline = requestTimeoutClient.control("before-deadline", {}, { timeoutMs: 50 });
+			await flush();
+			const beforeDeadlineId = (JSON.parse(requestSocket.sent[0]) as { id: string }).id;
+			expect([...clock.tasks.values()].map(task => task.due - clock.now)).toEqual([50]);
+			clock.setTimeout(
+				() => requestSocket.message({ type: "control_response", id: beforeDeadlineId, ok: true }),
+				49,
+			);
+			clock.advanceBy(49);
+			await expect(beforeDeadline).resolves.toMatchObject({ ok: true });
+			expect(clock.tasks.size).toBe(0);
+
+			const atDeadline = requestTimeoutClient.control("at-deadline", {}, { timeoutMs: 50 });
+			await flush();
+			const atDeadlineId = (JSON.parse(requestSocket.sent[1]) as { id: string }).id;
+			expect([...clock.tasks.values()].map(task => task.due - clock.now)).toEqual([50]);
+			clock.advanceBy(50);
+			await expect(atDeadline).rejects.toMatchObject({ code: "timeout" });
+			requestSocket.message({ type: "control_response", id: atDeadlineId, ok: true });
+			expect(clock.tasks.size).toBe(0);
+			await requestTimeoutClient.close();
 			const backoffClient = new SdkClient("ws://fake", "token", {
 				reconnectAttempts: 1,
 				reconnectBackoffMs: 100,
@@ -507,6 +556,28 @@ test("SdkClient deterministically owns open, hello, request, and backoff timers"
 			replacement.message({ type: "hello", connectionId: "after-backoff" });
 			await backoff;
 			await backoffClient.close();
+		});
+	});
+});
+
+test("SdkClient settles an open-to-hello deadline crossover and releases the retry cycle", async () => {
+	await withFakeWebSockets(async () => {
+		await withFakeTimers(async clock => {
+			const client = new SdkClient("ws://fake", "token", {
+				deadline: clock.now + 10,
+				reconnectAttempts: 0,
+			});
+			const connecting = client.connect();
+			const socket = FakeWebSocket.instances[0];
+			clock.elapse(10);
+			socket.open();
+			await expect(connecting).rejects.toMatchObject({ code: "timeout", message: "SDK client deadline elapsed." });
+			expect(clock.tasks.size).toBe(0);
+			expect(socket.closeCalls).toHaveLength(1);
+			expect([...socket.listeners.values()].every(listeners => listeners.size === 0)).toBe(true);
+			socket.emit("message", new MessageEvent("message", { data: JSON.stringify({ type: "hello" }) }));
+			await expect(client.connect()).rejects.toMatchObject({ code: "timeout" });
+			await client.close();
 		});
 	});
 });

--- a/packages/coding-agent/test/sdk-client.test.ts
+++ b/packages/coding-agent/test/sdk-client.test.ts
@@ -158,7 +158,8 @@ test("SdkClient ignores a stale failed socket while a retried request is in flig
 			},
 			message(socket, raw) {
 				const frame = JSON.parse(String(raw)) as Record<string, unknown>;
-				setTimeout(() => socket.send(JSON.stringify({ type: "control_response", id: frame.id, ok: true })), 10);
+				firstSocket?.close(1000, "late first connection close");
+				socket.send(JSON.stringify({ type: "control_response", id: frame.id, ok: true }));
 			},
 		},
 	});
@@ -168,8 +169,7 @@ test("SdkClient ignores a stale failed socket while a retried request is in flig
 		reconnectAttempts: 1,
 		reconnectBackoffMs: 1,
 	});
-	const response = client.control("turn.prompt", { text: "still connected" });
-	setTimeout(() => firstSocket?.close(1000, "late first connection close"), 2);
+	const response = client.control("turn.prompt", { text: "still connected" }, { timeoutMs: 1_000 });
 	await expect(response).resolves.toMatchObject({ ok: true });
 	expect(connections).toBe(2);
 	await client.close();
@@ -225,4 +225,385 @@ test("SdkClient bounds a peer that accepts TCP but never completes the WebSocket
 	} finally {
 		hangingUpgrade.stop(true);
 	}
+});
+
+test("SdkClient never replays sent work onto a replacement connection", async () => {
+	const token = "sdk-client-no-replay-token";
+	const received: Array<{ connection: number; frame: Record<string, unknown> }> = [];
+	let connection = 0;
+	const server = Bun.serve({
+		hostname: "127.0.0.1",
+		port: 0,
+		fetch(request) {
+			if (new URL(request.url).searchParams.get("token") !== token)
+				return new Response("Unauthorized", { status: 401 });
+			if (!server.upgrade(request, { data: undefined })) return new Response("Upgrade failed", { status: 400 });
+		},
+		websocket: {
+			open(socket) {
+				connection++;
+				socket.send(JSON.stringify({ type: "hello", connectionId: `no-replay-${connection}` }));
+			},
+			message(socket, raw) {
+				const frame = JSON.parse(String(raw)) as Record<string, unknown>;
+				received.push({ connection, frame });
+				if (frame.operation === "mutate") socket.close(1000, "close after accept");
+				else socket.send(JSON.stringify({ type: "control_response", id: frame.id, ok: true }));
+			},
+		},
+	});
+	servers.push(server);
+	const client = await SdkClient.connect(`ws://127.0.0.1:${server.port}`, token);
+	await expect(client.control("mutate", { value: 1 })).rejects.toMatchObject({ code: "connection_closed" });
+	await expect(client.control("after_close", { value: 2 })).resolves.toMatchObject({ ok: true });
+	expect(received.filter(entry => entry.frame.operation === "mutate")).toHaveLength(1);
+	expect(received.filter(entry => entry.frame.operation === "after_close")).toHaveLength(1);
+	expect(received.map(entry => entry.frame.id)).toEqual(
+		expect.arrayContaining([expect.any(String), expect.any(String)]),
+	);
+	expect(received[0].frame.id).not.toBe(received[1].frame.id);
+	await client.close();
+});
+
+type FakeListener = ((event: Event) => void) | { handleEvent(event: Event): void };
+type FakeListenerOptions = { once?: boolean };
+
+class FakeWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: FakeWebSocket[] = [];
+	readonly listeners = new Map<string, Map<FakeListener, FakeListenerOptions>>();
+	readonly sent: string[] = [];
+	readonly closeCalls: unknown[][] = [];
+	readyState = FakeWebSocket.CONNECTING;
+	throwOnSend: Error | undefined;
+
+	constructor(readonly url: string | URL) {
+		FakeWebSocket.instances.push(this);
+	}
+
+	addEventListener(type: string, listener: FakeListener, options?: FakeListenerOptions): void {
+		const listeners = this.listeners.get(type) ?? new Map<FakeListener, FakeListenerOptions>();
+		listeners.set(listener, options ?? {});
+		this.listeners.set(type, listeners);
+	}
+
+	removeEventListener(type: string, listener: FakeListener): void {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	close(...args: unknown[]): void {
+		this.closeCalls.push(args);
+		this.readyState = FakeWebSocket.CLOSED;
+	}
+
+	send(value: string): void {
+		if (this.throwOnSend) throw this.throwOnSend;
+		this.sent.push(value);
+	}
+
+	snapshot(type: string): FakeListener[] {
+		return [...(this.listeners.get(type)?.keys() ?? [])];
+	}
+
+	emit(type: string, event = new Event(type)): void {
+		for (const [listener, options] of [...(this.listeners.get(type) ?? [])]) {
+			if (options.once) this.removeEventListener(type, listener);
+			if (typeof listener === "function") listener.call(this, event);
+			else listener.handleEvent(event);
+		}
+	}
+
+	open(): void {
+		this.readyState = FakeWebSocket.OPEN;
+		this.emit("open");
+	}
+
+	message(frame: unknown): void {
+		const event = new MessageEvent("message", { data: typeof frame === "string" ? frame : JSON.stringify(frame) });
+		this.emit("message", event);
+	}
+}
+
+type FakeTimerHandle = { readonly id: number; unref: () => FakeTimerHandle };
+
+class FakeClock {
+	#nextId = 1;
+	readonly tasks = new Map<FakeTimerHandle, () => void>();
+
+	setTimeout(callback: (...args: unknown[]) => void, _delay?: number, ...args: unknown[]): FakeTimerHandle {
+		const handle: FakeTimerHandle = { id: this.#nextId++, unref: () => handle };
+		this.tasks.set(handle, () => callback(...args));
+		return handle;
+	}
+
+	clearTimeout(handle: FakeTimerHandle): void {
+		this.tasks.delete(handle);
+	}
+
+	runNext(): void {
+		const entry = this.tasks.entries().next().value as [FakeTimerHandle, () => void] | undefined;
+		if (!entry) throw new Error("No fake timer is pending");
+		this.tasks.delete(entry[0]);
+		entry[1]();
+	}
+}
+
+async function withFakeTimers(run: (clock: FakeClock) => Promise<void>): Promise<void> {
+	const setTimeoutDescriptor = Object.getOwnPropertyDescriptor(globalThis, "setTimeout");
+	const clearTimeoutDescriptor = Object.getOwnPropertyDescriptor(globalThis, "clearTimeout");
+	const clock = new FakeClock();
+	Object.defineProperty(globalThis, "setTimeout", {
+		configurable: true,
+		value: clock.setTimeout.bind(clock) as unknown as typeof setTimeout,
+	});
+	Object.defineProperty(globalThis, "clearTimeout", {
+		configurable: true,
+		value: clock.clearTimeout.bind(clock) as unknown as typeof clearTimeout,
+	});
+	try {
+		await run(clock);
+	} finally {
+		if (setTimeoutDescriptor) Object.defineProperty(globalThis, "setTimeout", setTimeoutDescriptor);
+		if (clearTimeoutDescriptor) Object.defineProperty(globalThis, "clearTimeout", clearTimeoutDescriptor);
+	}
+}
+
+async function withFakeWebSockets(run: () => Promise<void>): Promise<void> {
+	const descriptor = Object.getOwnPropertyDescriptor(globalThis, "WebSocket");
+	FakeWebSocket.instances = [];
+	Object.defineProperty(globalThis, "WebSocket", { configurable: true, value: FakeWebSocket });
+	try {
+		await run();
+	} finally {
+		if (descriptor) Object.defineProperty(globalThis, "WebSocket", descriptor);
+		else Reflect.deleteProperty(globalThis, "WebSocket");
+	}
+}
+
+const flush = () => new Promise<void>(resolve => queueMicrotask(resolve));
+
+test("SdkClient fences queued stale callbacks with a colliding replacement request ID", async () => {
+	await withFakeWebSockets(async () => {
+		const client = new SdkClient("ws://fake", "token", { reconnectAttempts: 0 });
+		const opening = client.connect();
+		const first = FakeWebSocket.instances[0];
+		const firstOpen = first.snapshot("open");
+		first.open();
+		first.message({ type: "hello", connectionId: "first" });
+		await opening;
+
+		const firstClose = first.snapshot("close");
+		const firstError = first.snapshot("error");
+		const firstMessage = first.snapshot("message");
+		first.readyState = FakeWebSocket.CLOSED;
+		for (const listener of firstClose) {
+			if (typeof listener === "function") listener(new Event("close"));
+			else listener.handleEvent(new Event("close"));
+		}
+
+		const replacementRequest = client.control("replacement");
+		for (let index = 0; index < 4; index++) await flush();
+		const second = FakeWebSocket.instances[1];
+		second.open();
+		second.message({ type: "hello", connectionId: "second" });
+		for (let index = 0; index < 4; index++) await flush();
+		for (const listener of firstOpen) {
+			if (typeof listener === "function") listener(new Event("open"));
+			else listener.handleEvent(new Event("open"));
+		}
+		const replacementId = (JSON.parse(second.sent[0]) as { id: string }).id;
+
+		for (const listener of firstError) {
+			if (typeof listener === "function") listener(new Event("error"));
+			else listener.handleEvent(new Event("error"));
+		}
+		for (const listener of firstMessage) {
+			if (typeof listener === "function") listener(new MessageEvent("message", { data: "not-json" }));
+			else listener.handleEvent(new MessageEvent("message", { data: "not-json" }));
+		}
+		for (const listener of firstMessage) {
+			if (typeof listener === "function")
+				listener(
+					new MessageEvent("message", {
+						data: JSON.stringify({ type: "control_response", id: replacementId, ok: true }),
+					}),
+				);
+			else
+				listener.handleEvent(
+					new MessageEvent("message", {
+						data: JSON.stringify({ type: "control_response", id: replacementId, ok: true }),
+					}),
+				);
+		}
+
+		second.message({ type: "control_response", id: replacementId, ok: true });
+		await expect(replacementRequest).resolves.toMatchObject({ ok: true });
+		await client.close();
+	});
+});
+
+test("SdkClient terminal close rejects opening, hello, and backoff waiters without resurrection", async () => {
+	await withFakeWebSockets(async () => {
+		const openingClient = new SdkClient("ws://fake", "token", { reconnectAttempts: 1 });
+		const opening = openingClient.connect();
+		await openingClient.close();
+		await expect(opening).rejects.toMatchObject({ code: "connection_closed" });
+
+		const helloClient = new SdkClient("ws://fake", "token", { reconnectAttempts: 1 });
+		const hello = helloClient.connect();
+		FakeWebSocket.instances[1].open();
+		await helloClient.close();
+		await expect(hello).rejects.toMatchObject({ code: "connection_closed" });
+
+		const backoffClient = new SdkClient("ws://fake", "token", { reconnectAttempts: 1, reconnectBackoffMs: 1_000 });
+		const backoff = backoffClient.connect();
+		FakeWebSocket.instances[2].emit("error");
+		for (let index = 0; index < 4; index++) await flush();
+		await backoffClient.close();
+		await expect(backoff).rejects.toMatchObject({ code: "connection_closed" });
+	});
+});
+
+test("SdkClient deterministically owns open, hello, request, and backoff timers", async () => {
+	await withFakeWebSockets(async () => {
+		await withFakeTimers(async clock => {
+			const openTimeoutClient = new SdkClient("ws://fake", "token", { reconnectAttempts: 0 });
+			const openTimeout = openTimeoutClient.connect();
+			clock.runNext();
+			await expect(openTimeout).rejects.toMatchObject({ code: "reconnect_exhausted" });
+
+			const helloTimeoutClient = new SdkClient("ws://fake", "token", { reconnectAttempts: 0 });
+			const helloTimeout = helloTimeoutClient.connect();
+			FakeWebSocket.instances[1].open();
+			clock.runNext();
+			await expect(helloTimeout).rejects.toMatchObject({ code: "reconnect_exhausted" });
+
+			const requestTimeoutClient = new SdkClient("ws://fake", "token");
+			const requestConnected = requestTimeoutClient.connect();
+			const requestSocket = FakeWebSocket.instances[2];
+			requestSocket.open();
+			requestSocket.message({ type: "hello", connectionId: "request-timeout" });
+			await requestConnected;
+			const requestTimeout = requestTimeoutClient.control("timeout", {}, { timeoutMs: 50 });
+			await flush();
+			clock.runNext();
+			await expect(requestTimeout).rejects.toMatchObject({ code: "timeout" });
+			await requestTimeoutClient.close();
+
+			const backoffClient = new SdkClient("ws://fake", "token", {
+				reconnectAttempts: 1,
+				reconnectBackoffMs: 100,
+			});
+			const backoff = backoffClient.connect();
+			FakeWebSocket.instances[3].emit("error");
+			for (let index = 0; index < 4; index++) await flush();
+			clock.runNext();
+			for (let index = 0; index < 4; index++) await flush();
+			const replacement = FakeWebSocket.instances[4];
+			replacement.open();
+			replacement.message({ type: "hello", connectionId: "after-backoff" });
+			await backoff;
+			await backoffClient.close();
+		});
+	});
+});
+
+test("SdkClient settles response-versus-close races exactly once", async () => {
+	await withFakeWebSockets(async () => {
+		const responseFirstClient = new SdkClient("ws://fake", "token");
+		const responseFirstConnected = responseFirstClient.connect();
+		const responseFirstSocket = FakeWebSocket.instances[0];
+		responseFirstSocket.open();
+		responseFirstSocket.message({ type: "hello", connectionId: "response-first" });
+		await responseFirstConnected;
+		const responseFirst = responseFirstClient.control("response-first");
+		await flush();
+		const responseFirstId = (JSON.parse(responseFirstSocket.sent[0]) as { id: string }).id;
+		responseFirstSocket.message({ type: "control_response", id: responseFirstId, ok: true });
+		responseFirstSocket.emit("close");
+		await expect(responseFirst).resolves.toMatchObject({ ok: true });
+		await responseFirstClient.close();
+
+		const closeFirstClient = new SdkClient("ws://fake", "token");
+		const closeFirstConnected = closeFirstClient.connect();
+		const closeFirstSocket = FakeWebSocket.instances[1];
+		closeFirstSocket.open();
+		closeFirstSocket.message({ type: "hello", connectionId: "close-first" });
+		await closeFirstConnected;
+		const closeFirst = closeFirstClient.control("close-first");
+		await flush();
+		const closeFirstId = (JSON.parse(closeFirstSocket.sent[0]) as { id: string }).id;
+		closeFirstSocket.emit("close");
+		closeFirstSocket.message({ type: "control_response", id: closeFirstId, ok: true });
+		await expect(closeFirst).rejects.toMatchObject({ code: "connection_closed" });
+		await closeFirstClient.close();
+	});
+});
+
+test("SdkClient permits direct send on the authoritative open socket before hello", async () => {
+	await withFakeWebSockets(async () => {
+		const client = new SdkClient("ws://fake", "token");
+		const connected = client.connect();
+		const socket = FakeWebSocket.instances[0];
+		socket.open();
+		client.send({ type: "provider_heartbeat" });
+		expect(JSON.parse(socket.sent[0])).toMatchObject({ type: "provider_heartbeat" });
+		socket.message({ type: "hello", connectionId: "send-before-hello" });
+		await connected;
+		await client.close();
+	});
+});
+test("SdkClient rolls back a failed direct incarnation send", async () => {
+	await withFakeWebSockets(async () => {
+		const client = new SdkClient("ws://fake", "token");
+		const connected = client.connect();
+		const socket = FakeWebSocket.instances[0];
+		socket.open();
+		socket.message({ type: "hello", connectionId: "send" });
+		await connected;
+		socket.throwOnSend = new Error("send failed");
+		await expect(client.control("send")).rejects.toMatchObject({ code: "unavailable" });
+		expect(socket.sent).toHaveLength(0);
+		await client.close();
+	});
+});
+
+test("SdkClient delivers the authoritative initial hello to pre-connect frame handlers", async () => {
+	await withFakeWebSockets(async () => {
+		const client = new SdkClient("ws://fake", "token");
+		const frames: Array<Record<string, unknown>> = [];
+		client.onFrame(frame => frames.push(frame));
+		const connected = client.connect();
+		const socket = FakeWebSocket.instances[0];
+		socket.open();
+		socket.message({ type: "hello", connectionId: "initial-frame" });
+		await connected;
+		expect(frames).toEqual([{ type: "hello", connectionId: "initial-frame" }]);
+		await client.close();
+	});
+});
+
+test("SdkClient ignores duplicate and empty hellos while preserving changed-ID rotation", async () => {
+	await withFakeWebSockets(async () => {
+		const client = new SdkClient("ws://fake", "token");
+		let reconnects = 0;
+		client.onReconnect(() => reconnects++);
+		const connected = client.connect();
+		const socket = FakeWebSocket.instances[0];
+		socket.open();
+		socket.message({ type: "hello", connectionId: "stable" });
+		await connected;
+		socket.message({ type: "hello", connectionId: "stable" });
+		socket.message({ type: "hello", connectionId: "" });
+		expect(client.connectionId).toBe("stable");
+		expect(reconnects).toBe(0);
+		socket.message({ type: "hello", connectionId: "changed" });
+		socket.message({ type: "hello", connectionId: "changed" });
+		expect(client.connectionId).toBe("changed");
+		expect(reconnects).toBe(1);
+		await client.close();
+	});
 });


### PR DESCRIPTION
## Summary
- bind retry cycles, socket incarnations, callbacks, timers, and pending requests to explicit monotonic ownership records
- fence stale open/close/error/message/timeout delivery and linearize request registration/send on the authoritative incarnation
- preserve current-dev absolute deadline and missing-hello semantics, direct pre-hello send compatibility, initial hello frame delivery, ACP changed-ID rotation, and no request replay
- add deterministic fake-socket/fake-clock adversarial coverage plus real transport no-replay regression

Closes #2164.

## Verification
- `bun test packages/coding-agent/test/sdk-client.test.ts` — 17 pass
- `bun test --rerun-each 20 packages/coding-agent/test/sdk-client.test.ts` — 340 pass
- `bun test packages/coding-agent/test/sdk-acp-adapter.test.ts packages/coding-agent/test/sdk-acp-provider-reconnect.test.ts` — 10 pass
- `bun test packages/coding-agent/test/sdk-acp-two-client-race.test.ts --rerun-each 20` — 20 pass
- `bun --cwd=packages/coding-agent run check` — pass
- fresh exact-head architecture review — CLEAR/CLEAR/CLEAR, APPROVE
- fresh exact-head QA/red-team — passed

## Broader gate notes
- `bun run check:sdk-closure` progressed past the previously flaky provider-conflict race, then three unrelated `sdk-adapter-dispositions.test.ts` ACP disposition cases exceeded the 60s lane budget in this constrained workstation run.
- `bun run ci:test:full` reports the same seven `release-publish-order.test.ts` failures on untouched `origin/dev`; baseline reproduction is recorded and no success is claimed.
- These results are recorded, not suppressed or misrepresented.

## Merge gate
Do not merge or enable auto-merge. A separate fresh GJC session must review the final PR head and final `dev` base, inspect terminal CI and evidence, and issue a new exact-head signed verdict. Any head/base/evidence change invalidates prior approval.