### PR TITLE
fix(ai): omit tool_choice when openai-responses has empty tools

### DIFF
--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -304,7 +304,13 @@ function buildParams(
 
 	applyCommonResponsesSamplingParams(params, options, model.provider);
 
-	if (context.tools) {
+	// Use `.length` (not truthiness): empty arrays are truthy, and
+	// `AgentSession.runEphemeralTurn` (`/btw`, IRC replies) intentionally
+	// passes `context.tools = []` with `toolChoice: "none"`. Emitting
+	// `tools: []` + `tool_choice: "none"` is rejected by Responses APIs
+	// ("A tool_choice was set on the request but no tools were specified.")
+	// and mirrors the openai-completions / openai-responses #1227 fix.
+	if (context.tools?.length) {
 		params.tools = convertTools(context.tools);
 		if (options?.toolChoice) {
 			const toolChoice = resolveToolChoice(model, options.toolChoice);
@@ -318,6 +324,11 @@ function buildParams(
 			}
 			params.tool_choice = mapToOpenAIResponsesToolChoice(toolChoice.resolvedChoice);
 		}
+	}
+
+	// Defence-in-depth: drop `tool_choice: "none"` when there are no tools.
+	if (params.tool_choice === "none" && (!Array.isArray(params.tools) || params.tools.length === 0)) {
+		delete params.tool_choice;
 	}
 
 	applyResponsesReasoningParams(params, model, options, messages);

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -537,7 +537,13 @@ function buildParams(
 	// TODO: openai responses has no top-level `frequency_penalty` field as of the current SDK;
 	// `StreamOptions.frequencyPenalty` is intentionally dropped for this provider.
 
-	if (context.tools) {
+	// Use `.length` (not truthiness): empty arrays are truthy, and
+	// `AgentSession.runEphemeralTurn` (`/btw`, IRC replies) intentionally
+	// passes `context.tools = []` with `toolChoice: "none"`. Emitting
+	// `tools: []` + `tool_choice: "none"` is rejected by openai-responses
+	// proxies (e.g. grok-build: "A tool_choice was set on the request but no
+	// tools were specified.") and mirrors the openai-completions #1227 fix.
+	if (context.tools?.length) {
 		params.tools = convertTools(context.tools, supportsStrictMode(model), model);
 		if (options?.toolChoice) {
 			const toolChoice = resolveToolChoice(model, options.toolChoice);
@@ -560,6 +566,13 @@ function buildParams(
 		if (params.tools.some(t => (t as { type?: string }).type === "custom")) {
 			params.parallel_tool_calls = false;
 		}
+	}
+
+	// Defence-in-depth: `tool_choice: "none"` with no tools to gate is
+	// redundant and rejected by some Responses proxies when tools is missing
+	// or empty. Drop it whenever the resolved tools list is empty.
+	if (params.tool_choice === "none" && (!Array.isArray(params.tools) || params.tools.length === 0)) {
+		delete params.tool_choice;
 	}
 
 	applyResponsesReasoningParams(params, model, options, messages, effort =>

--- a/packages/ai/test/azure-openai-responses-tool-choice.test.ts
+++ b/packages/ai/test/azure-openai-responses-tool-choice.test.ts
@@ -151,4 +151,30 @@ describe("Azure OpenAI responses tool choice capability", () => {
 		expect(result.stopReason).toBe("error");
 		expect(getToolChoiceCapabilityOverride(testModel)).toBeUndefined();
 	});
+
+	it("omits tools and tool_choice when /btw passes empty tools + toolChoice none", async () => {
+		let payload: Record<string, unknown> | undefined;
+		const testModel = model();
+		global.fetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				payload = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+				return okResponse(testModel.id);
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+		await streamAzureOpenAIResponses(
+			testModel,
+			{
+				messages: [{ role: "user", content: "btw what is X", timestamp: 0 }],
+				tools: [],
+			},
+			{
+				apiKey: "test-key",
+				azureBaseUrl: testModel.baseUrl,
+				toolChoice: "none",
+			},
+		).result();
+		expect(payload?.tools).toBeUndefined();
+		expect(payload?.tool_choice).toBeUndefined();
+	});
 });

--- a/packages/ai/test/openai-responses-tool-choice.test.ts
+++ b/packages/ai/test/openai-responses-tool-choice.test.ts
@@ -143,4 +143,49 @@ describe("OpenAI responses tool choice capability", () => {
 		expect(result.stopReason).toBe("error");
 		expect(getToolChoiceCapabilityOverride(testModel)).toBeUndefined();
 	});
+
+	it("omits tools and tool_choice when /btw passes empty tools + toolChoice none", async () => {
+		// Mirrors AgentSession.runEphemeralTurn: context.tools = [] is truthy, so
+		// a bare `if (context.tools)` used to emit tools:[] + tool_choice:"none",
+		// which Responses proxies (including grok-build) reject with
+		// "A tool_choice was set on the request but no tools were specified."
+		let payload: Record<string, unknown> | undefined;
+		const testModel = model();
+		global.fetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				payload = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+				return okResponse(testModel.id);
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+		await streamOpenAIResponses(
+			testModel,
+			{
+				messages: [{ role: "user", content: "btw what is X", timestamp: 0 }],
+				tools: [],
+			},
+			{ apiKey: "test-key", toolChoice: "none" },
+		).result();
+		expect(payload?.tools).toBeUndefined();
+		expect(payload?.tool_choice).toBeUndefined();
+	});
+
+	it("keeps tool_choice none when real tools are present", async () => {
+		let payload: Record<string, unknown> | undefined;
+		const testModel = model();
+		global.fetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				payload = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+				return okResponse(testModel.id);
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+		await streamOpenAIResponses(testModel, testContext, {
+			apiKey: "test-key",
+			toolChoice: "none",
+		}).result();
+		expect(Array.isArray(payload?.tools)).toBe(true);
+		expect((payload?.tools as unknown[]).length).toBeGreaterThan(0);
+		expect(payload?.tool_choice).toBe("none");
+	});
 });


### PR DESCRIPTION
## Summary
- `/btw` and IRC ephemeral turns call `AgentSession.runEphemeralTurn` with `context.tools = []` and `toolChoice: "none"`.
- `openai-completions` already fixed this in #1227 by requiring `context.tools?.length` and dropping redundant `tool_choice: "none"`.
- `openai-responses` / `azure-openai-responses` still used `if (context.tools)`, so empty arrays produced `tools: []` + `tool_choice: "none"`.
- Responses proxies reject that shape with `400: A tool_choice was set on the request but no tools were specified.` (reproduced against grok-build / openai-responses).

## Changes
- `packages/ai/src/providers/openai-responses.ts`: require non-empty tools before emitting tools/tool_choice; drop `tool_choice: "none"` when tools are missing/empty.
- `packages/ai/src/providers/azure-openai-responses.ts`: same guard for Azure Responses.
- Tests covering empty-tools + `toolChoice: "none"` for both providers, plus a regression that keeps `tool_choice: "none"` when real tools are present.

## Test plan
- [x] `bun --cwd packages/ai test test/openai-responses-tool-choice.test.ts test/azure-openai-responses-tool-choice.test.ts test/issue-1227-repro.test.ts` (15 pass)
- [ ] Manual: start a tool-using session on an openai-responses model (e.g. grok-build), then send `/btw` side question and confirm no 400.