### PR TITLE
fix(sdk): expose model thinking capabilities

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Renamed the notifications SDK to the Gajae-Code SDK: `docs/notifications-sdk.md` is now `docs/sdk.md`, `src/notifications/` is now `src/sdk/bus/`, and `src/sdk.ts` is now the `src/sdk/` module directory. Old deep-import specifiers no longer resolve.
 - Moved SDK discovery from `.gjc/state/notifications/` to `.gjc/state/sdk/`. Restart sessions and daemons together when upgrading; the runtime does not dual-scan the old and new directories.
 - Removed the `--mode rpc`, `--mode rpc-ui`, and `--mode bridge` external ingress modes. Machine clients must use the SDK WebSocket interfaces documented in `docs/sdk.md`; no RPC or Bridge compatibility path remains.
+
+### Fixed
+
+- SDK `models.list/current` now includes each model's `reasoning` flag and thinking capability metadata so external clients can derive valid `model.set` thinking-level selections (#2163).
+
 ## [0.10.1] - 2026-07-13
 
 ### Added

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -65,6 +65,7 @@ import {
 	sessionTag,
 } from "./config";
 import { imageAttachmentsFromMessage, notificationActionPayload, summaryFromMessage } from "./helpers";
+import { toSdkModelCatalogEntry } from "./model-catalog";
 import { ensureTelegramDaemonRunning } from "./telegram-daemon";
 
 // ===========================================================================
@@ -1161,14 +1162,7 @@ function sdkQuerySurface(
 			typeof (ctx as Partial<ExtensionContext>).getTodoState === "function" ? ctx.getTodoState() : [],
 		getDiff,
 		getUsage: () => ctx.sessionManager.getUsageStatistics(),
-		getModels: () =>
-			ctx.modelRegistry.getAll().map(model => ({
-				provider: model.provider,
-				id: model.id,
-				name: model.name,
-				contextWindow: model.contextWindow,
-				maxTokens: model.maxTokens,
-			})),
+		getModels: () => ctx.modelRegistry.getAll().map(toSdkModelCatalogEntry),
 		getSkillState: () => ctx.getSkillState(),
 		getGates: () => ctx.workflowGate?.listPendingGates?.() ?? [],
 		getConfigItems: () => {

--- a/packages/coding-agent/src/sdk/bus/model-catalog.ts
+++ b/packages/coding-agent/src/sdk/bus/model-catalog.ts
@@ -1,0 +1,43 @@
+import type { Api, Model, ThinkingConfig } from "@gajae-code/ai";
+
+type ThinkingLevel = ThinkingConfig["minLevel"];
+
+export interface SdkModelThinkingCapability {
+	minLevel: ThinkingLevel;
+	maxLevel: ThinkingLevel;
+	levels?: ThinkingLevel[];
+	defaultLevel?: ThinkingLevel;
+	mode: ThinkingConfig["mode"];
+}
+
+export interface SdkModelCatalogEntry {
+	provider: string;
+	id: string;
+	name: string;
+	contextWindow: number;
+	maxTokens: number;
+	reasoning: boolean;
+	thinking?: SdkModelThinkingCapability;
+}
+
+export function toSdkModelCatalogEntry(model: Model<Api>): SdkModelCatalogEntry {
+	return {
+		provider: model.provider,
+		id: model.id,
+		name: model.name,
+		contextWindow: model.contextWindow,
+		maxTokens: model.maxTokens,
+		reasoning: model.reasoning,
+		...(model.thinking
+			? {
+					thinking: {
+						minLevel: model.thinking.minLevel,
+						maxLevel: model.thinking.maxLevel,
+						...(model.thinking.levels ? { levels: [...model.thinking.levels] } : {}),
+						...(model.thinking.defaultLevel ? { defaultLevel: model.thinking.defaultLevel } : {}),
+						mode: model.thinking.mode,
+					},
+				}
+			: {}),
+	};
+}

--- a/packages/coding-agent/test/sdk-default-model-selection-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-default-model-selection-e2e.test.ts
@@ -94,6 +94,47 @@ test("model.set atomically promotes an explicit thinking level for the active an
 	const client = await SdkClient.connect(endpoint.url, endpoint.token, { timeoutMs: 4_000, reconnectAttempts: 0 });
 
 	try {
+		type SdkModelCatalogItem = {
+			provider: string;
+			id: string;
+			name: string;
+			contextWindow: number;
+			maxTokens: number;
+			reasoning: boolean;
+			thinking?: {
+				minLevel: Effort;
+				maxLevel: Effort;
+				levels?: Effort[];
+				defaultLevel?: Effort;
+				mode: string;
+			};
+		};
+		const modelsFrame = (await client.query("models.list/current")) as {
+			page?: { items?: SdkModelCatalogItem[] };
+		};
+		const catalog = modelsFrame.page?.items ?? [];
+		expect(catalog.find(model => model.id === "initial-model")).toMatchObject({
+			provider: "runtime-provider",
+			id: "initial-model",
+			name: "Initial Model",
+			contextWindow: 128_000,
+			maxTokens: 8_192,
+			reasoning: false,
+		});
+		expect(catalog.find(model => model.id === "reasoning-model")).toMatchObject({
+			provider: "runtime-provider",
+			id: "reasoning-model",
+			name: "Reasoning Model",
+			contextWindow: 128_000,
+			maxTokens: 8_192,
+			reasoning: true,
+			thinking: {
+				minLevel: Effort.Minimal,
+				maxLevel: Effort.High,
+				defaultLevel: Effort.Low,
+				mode: "effort",
+			},
+		});
 		await expect(
 			client.control("model.set", {
 				id: "runtime-provider/initial-model",

--- a/packages/coding-agent/test/sdk-model-catalog.test.ts
+++ b/packages/coding-agent/test/sdk-model-catalog.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test";
+import type { Api, Effort, Model } from "@gajae-code/ai";
+import { toSdkModelCatalogEntry } from "../src/sdk/bus/model-catalog";
+
+const MINIMAL = "minimal" as Effort;
+const LOW = "low" as Effort;
+const HIGH = "high" as Effort;
+function modelFixture(overrides: Partial<Model<Api>>): Model<Api> {
+	return {
+		id: "plain-model",
+		name: "Plain Model",
+		api: "openai-completions",
+		provider: "runtime-provider",
+		baseUrl: "http://127.0.0.1:9/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+		...overrides,
+	};
+}
+
+test("SDK model catalog exposes reasoning and thinking capabilities", () => {
+	const entry = toSdkModelCatalogEntry(
+		modelFixture({
+			id: "reasoning-model",
+			name: "Reasoning Model",
+			reasoning: true,
+			thinking: {
+				minLevel: MINIMAL,
+				maxLevel: HIGH,
+				levels: [MINIMAL, LOW, HIGH],
+				defaultLevel: LOW,
+				mode: "effort",
+			},
+		}),
+	);
+
+	expect(entry).toEqual({
+		provider: "runtime-provider",
+		id: "reasoning-model",
+		name: "Reasoning Model",
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+		reasoning: true,
+		thinking: {
+			minLevel: MINIMAL,
+			maxLevel: HIGH,
+			levels: [MINIMAL, LOW, HIGH],
+			defaultLevel: LOW,
+			mode: "effort",
+		},
+	});
+});
+
+test("SDK model catalog keeps non-reasoning models explicit without fake thinking metadata", () => {
+	const entry = toSdkModelCatalogEntry(modelFixture({}));
+
+	expect(entry).toEqual({
+		provider: "runtime-provider",
+		id: "plain-model",
+		name: "Plain Model",
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+		reasoning: false,
+	});
+});


### PR DESCRIPTION
## Summary
- expose `reasoning` on SDK `models.list/current` catalog entries
- add `thinking` capability metadata (`minLevel`, `maxLevel`, optional `levels`, `defaultLevel`, `mode`) so clients can derive valid `model.set` thinking-level selections
- add focused mapper coverage for reasoning-capable and non-reasoning catalog entries

Fixes #2163

## Verification
- `bun test packages/coding-agent/test/sdk-model-catalog.test.ts` — 2 pass
- `bun --cwd=packages/coding-agent run check` — pass
