### PR TITLE
fix(ci): isolate merged-dev lifecycle fixture

### DIFF
--- a/packages/coding-agent/test/coordinator-mcp/stop-session.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp/stop-session.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { createCoordinatorMcpServer } from "../../src/coordinator-mcp/server";
+import { writeBrokerDiscovery } from "../../src/sdk/broker/discovery";
 import type { SdkClient } from "../../src/sdk/client/client";
 
 const tempDirs: string[] = [];
@@ -63,23 +64,19 @@ async function createServer(
 		);
 		return sessions.filter(session => !closedSessionIds.has(session.sessionId as string));
 	}
-	await fs.mkdir(path.join(agentDir, "sdk"), { recursive: true });
-	await Bun.write(
-		path.join(agentDir, "sdk", "broker.json"),
-		JSON.stringify({
-			version: 1,
-			protocolVersion: 3,
-			packageGeneration: "test",
-			ownerId: "test",
-			pid: process.pid,
-			host: "127.0.0.1",
-			port: 1,
-			url: "ws://sdk.example.test",
-			token: "test-token",
-			startedAt: Date.now(),
-			heartbeatAt: Date.now(),
-		}),
-	);
+	await writeBrokerDiscovery(agentDir, {
+		version: 1,
+		protocolVersion: 3,
+		packageGeneration: "test",
+		ownerId: "test",
+		pid: process.pid,
+		host: "127.0.0.1",
+		port: 1,
+		url: "ws://sdk.example.test",
+		token: "test-token",
+		startedAt: Date.now(),
+		heartbeatAt: Date.now(),
+	});
 	const server = createCoordinatorMcpServer({
 		env: {
 			GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,


### PR DESCRIPTION
## Summary
- write the coordinator stop-session broker fixture through the canonical discovery writer
- include the required process incarnation introduced by stale-owner fencing
- keep the production coordinator contract unchanged

## Root cause
Exact merged dev `366c1d150` deterministically rejected the hand-written broker discovery as `not_found` because it omitted the process incarnation now required by `readBrokerDiscovery()`. This was independent of the #2180 workflow-gate failure; that pre-existing ask fixture is already repaired on merged dev by #2162.

## Verification
- `bun test packages/coding-agent/test/coordinator-mcp/stop-session.test.ts` — 7 pass
- `bun test packages/coding-agent/test/sdk-workflow-gate-emitter.test.ts` — 4 pass
- `bun --cwd=packages/coding-agent run check` — pass
- `bun test --shard=3/8` — 1187 pass, 24 skip
- `bun test --shard=8/8` — 1063 pass, 39 skip

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*