### PR TITLE
fix(coding-agent): make pet cleanup TUI-owned and delivery-safe

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Renamed the notifications SDK to the Gajae-Code SDK: `docs/notifications-sdk.md` is now `docs/sdk.md`, `src/notifications/` is now `src/sdk/bus/`, and `src/sdk.ts` is now the `src/sdk/` module directory. Old deep-import specifiers no longer resolve.
 - Moved SDK discovery from `.gjc/state/notifications/` to `.gjc/state/sdk/`. Restart sessions and daemons together when upgrading; the runtime does not dual-scan the old and new directories.
 - Removed the `--mode rpc`, `--mode rpc-ui`, and `--mode bridge` external ingress modes. Machine clients must use the SDK WebSocket interfaces documented in `docs/sdk.md`; no RPC or Bridge compatibility path remains.
+
+### Fixed
+
+- Gajae Pet overlays no longer leak images or stale pixels across lifecycle changes: each widget owns a randomized Kitty image ID (deleted on disable, replace, switch, and dispose), the previous Sixel footprint is tracked and erased on movement, resize, and narrow-terminal fallback, replaced pet widgets are disposed before their successors install, and a saved pet preference survives editor replacement while graphics are still unavailable (so a delayed Sixel capability probe can still activate it). Teardown is exception-safe and idempotent: a failed or unavailable terminal write never aborts logical disposal or steals a successor widget's overlay slot, and Sixel/Kitty cleanup authority is retained until the erase is actually delivered so a later mode switch or dispose retries it.
+
 ## [0.10.1] - 2026-07-13
 
 ### Added

--- a/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
+++ b/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
@@ -38,6 +38,35 @@ const KITTY_DROP_FRACTION = 0.45;
 const petKittyDropPx = (cellHeightPx: number): number =>
 	Math.min(Math.max(0, cellHeightPx - 1), Math.floor(cellHeightPx * KITTY_DROP_FRACTION));
 const PET_RAISE_ROWS = 1;
+const allocatedPetKittyImageIds = new Set<number>();
+
+function allocatePetKittyImageId(): number {
+	let id = 0;
+	while (id === 0 || allocatedPetKittyImageIds.has(id)) {
+		id = crypto.getRandomValues(new Uint32Array(1))[0] ?? 0;
+	}
+	allocatedPetKittyImageIds.add(id);
+	return id;
+}
+
+interface SixelFootprint {
+	x: number;
+	y: number;
+	columns: number;
+	rows: number;
+}
+
+function sameFootprint(left: SixelFootprint, right: SixelFootprint): boolean {
+	return left.x === right.x && left.y === right.y && left.columns === right.columns && left.rows === right.rows;
+}
+
+/**
+ * Which widget currently owns each TUI's single shared post-render emitter
+ * slot. A stale or repeated dispose (or off-switch) of a predecessor widget
+ * must never clear a successor's overlay authority.
+ */
+const petOverlayEmitterOwners = new WeakMap<TUI, GajaePetWidget>();
+
 /** Working animation: the shared para-para beats looped end to end. */
 const WORK_LOOP_TOTAL = PARA_PARA_STEPS.reduce((sum, [, ms]) => sum + ms, 0);
 /** Random gap between automatic claw flexes (fires while idle AND working). */
@@ -127,6 +156,13 @@ export class GajaePetWidget {
 	/** Cell metrics the current frames were built for; a change triggers a rebuild. */
 	#builtCellW = 0;
 	#builtCellH = 0;
+	#kittyImageId: number | undefined;
+	/** True while a kitty placement may exist on screen; cleared only after the delete escape is delivered. */
+	#kittyCleanupPending = false;
+	/** Last emitted Sixel raster position; retained until an erase is actually delivered. */
+	#lastSixelFootprint: SixelFootprint | undefined;
+	/** Terminal state: a disposed widget never touches the TUI or shared slots again. */
+	#disposed = false;
 
 	constructor(options: {
 		ui: TUI;
@@ -182,14 +218,19 @@ export class GajaePetWidget {
 		}
 	}
 
+	commitPreviewMode(mode: PetMode): void {
+		this.#applyMode(mode, false);
+	}
+
 	#applyMode(mode: PetMode, mountComposer: boolean): void {
-		if (mode === this.#mode) return;
+		if (this.#disposed || mode === this.#mode) return;
 
 		if (mode === "off") {
+			this.#writeImageCleanup();
 			this.#mode = "off";
 			this.#animation?.unregister();
 			this.#animation = undefined;
-			this.#ui.setPostRenderEmitter(undefined);
+			this.#releaseOverlayEmitter();
 			this.#floorContainer.clear();
 			this.#pixel = undefined;
 			this.#framedEditor.setReserve(0);
@@ -200,6 +241,7 @@ export class GajaePetWidget {
 
 		const protocol = this.#forcedProtocol ?? GajaePetWidget.pixelProtocol();
 		if (!protocol) return;
+		if (this.#mode !== "off") this.#writeImageCleanup();
 		this.#mode = mode;
 		this.#frame = "base";
 		this.#flexUntil = 0;
@@ -210,6 +252,7 @@ export class GajaePetWidget {
 		// the composer stays pinned to the terminal bottom.
 		this.#floorContainer.clear();
 		this.#ui.setPostRenderEmitter(() => this.#overlayPayload());
+		petOverlayEmitterOwners.set(this.#ui, this);
 		this.#animation ??= registerAnimationCallback(now => this.#tick(now), 80);
 		this.#ui.requestRender(true);
 	}
@@ -220,6 +263,10 @@ export class GajaePetWidget {
 		this.#builtCellW = cell.widthPx;
 		this.#builtCellH = cell.heightPx;
 		const skin: PetSkinId = this.#mode === "off" ? "red" : this.#mode;
+		if (protocol === "kitty") {
+			this.#kittyImageId ??= allocatePetKittyImageId();
+			this.#kittyCleanupPending = true;
+		}
 		this.#pixel = buildGajaePixelFrames({
 			protocol,
 			skin,
@@ -228,17 +275,43 @@ export class GajaePetWidget {
 			targetRows: 2,
 			sixelTopPaddingPx: protocol === "sixel" ? PET_SIXEL_DROP_PX : 0,
 			kittyCellYOffsetPx: protocol === "kitty" ? petKittyDropPx(cell.heightPx) : 0,
+			kittyImageId: protocol === "kitty" ? this.#kittyImageId : undefined,
 		});
 		this.#framedEditor.setReserve(this.#pixel.columns + PET_SIDE_MARGIN);
 	}
 
 	dispose(): void {
-		this.#animation?.unregister();
-		this.#animation = undefined;
-		this.#ui.setPostRenderEmitter(undefined);
-		this.#floorContainer.clear();
-		this.#framedEditor.setReserve(0);
-		this.#mountEditor(false);
+		if (this.#disposed) return;
+		this.#disposed = true;
+		try {
+			this.#writeImageCleanup();
+		} finally {
+			// Logical teardown must reach its final state even if terminal I/O fails.
+			if (this.#kittyImageId !== undefined) {
+				allocatedPetKittyImageIds.delete(this.#kittyImageId);
+				this.#kittyImageId = undefined;
+			}
+			this.#animation?.unregister();
+			this.#animation = undefined;
+			this.#releaseOverlayEmitter();
+			this.#mode = "off";
+			this.#pixel = undefined;
+			this.#floorContainer.clear();
+			this.#framedEditor.setReserve(0);
+			// Restore the plain composer only while our framed wrapper is still
+			// mounted; a successor widget may already own the editor container.
+			if (this.#editorContainer.children.includes(this.#framedEditor)) {
+				this.#mountEditor(false);
+			}
+		}
+	}
+
+	/** Clear the shared post-render slot only while this widget still owns it. */
+	#releaseOverlayEmitter(): void {
+		if (petOverlayEmitterOwners.get(this.#ui) === this) {
+			this.#ui.setPostRenderEmitter(undefined);
+			petOverlayEmitterOwners.delete(this.#ui);
+		}
 	}
 
 	#mountEditor(framed: boolean): void {
@@ -335,14 +408,50 @@ export class GajaePetWidget {
 		return { x, y };
 	}
 
-	#clearPetPayload(x: number, y: number): string {
-		const pixel = this.#pixel;
-		if (pixel?.protocol !== "sixel") return "";
+	#clearSixelFootprint(footprint: SixelFootprint): string {
 		let out = "\x1b[0m";
-		for (let row = 0; row < pixel.rasterRows; row++) {
-			out += `\x1b[${y + row + 1};${x + 1}H\x1b[${pixel.columns}X`;
+		for (let row = 0; row < footprint.rows; row++) {
+			out += `\x1b[${footprint.y + row + 1};${footprint.x + 1}H\x1b[${footprint.columns}X`;
 		}
 		return out;
+	}
+
+	/** Pending on-screen image cleanup. Pure: authority is consumed separately, on delivery. */
+	#imageCleanupPayload(): string {
+		let out = "";
+		if (this.#kittyCleanupPending && this.#kittyImageId !== undefined) {
+			out += `\x1b_Ga=d,d=I,i=${this.#kittyImageId},q=2\x1b\\`;
+		}
+		if (this.#lastSixelFootprint) {
+			out += this.#clearSixelFootprint(this.#lastSixelFootprint);
+		}
+		return out;
+	}
+
+	#consumeCleanupAuthority(): void {
+		this.#kittyCleanupPending = false;
+		this.#lastSixelFootprint = undefined;
+	}
+
+	/**
+	 * Best-effort direct erase of the on-screen pet image. Cleanup authority is
+	 * consumed only after the write is actually delivered: an unavailable
+	 * terminal or a throwing write keeps the erase pending so a later mode
+	 * switch or dispose can retry it.
+	 */
+	#writeImageCleanup(): void {
+		if (!this.#ui.terminalAvailable) return;
+		const payload = this.#imageCleanupPayload();
+		if (!payload) return;
+		try {
+			this.#ui.terminal.write(`\x1b[?2026h\x1b7${payload}\x1b8\x1b[?2026l`);
+		} catch {
+			// Keep the footprint/placement authority; the terminal write layer
+			// reports availability separately and callers retry on the next
+			// lifecycle transition.
+			return;
+		}
+		this.#consumeCleanupAuthority();
 	}
 
 	/** Draw escape payload at the pet's absolute position. */
@@ -350,10 +459,30 @@ export class GajaePetWidget {
 		const pixel = this.#pixel;
 		if (!pixel) return null;
 		const pos = this.#petPosition();
-		if (!pos) return null;
+		if (!pos) {
+			const cleanup = this.#imageCleanupPayload();
+			if (!cleanup) return null;
+			// The returned payload is written by the TUI as part of this frame;
+			// treat that delivery like our own successful write.
+			this.#consumeCleanupAuthority();
+			return cleanup;
+		}
 		const { x, y } = pos;
+		let out = "";
 
-		let out = clearPet ? this.#clearPetPayload(x, y) : "";
+		if (pixel.protocol === "sixel") {
+			const footprint = { x, y, columns: pixel.columns, rows: pixel.rasterRows };
+			if (this.#lastSixelFootprint && !sameFootprint(this.#lastSixelFootprint, footprint)) {
+				out += this.#clearSixelFootprint(this.#lastSixelFootprint);
+			}
+			if (clearPet) out += this.#clearSixelFootprint(footprint);
+			this.#lastSixelFootprint = footprint;
+		} else {
+			// A kitty frame emitted below (re)places the image, so cleanup is
+			// pending again even if a narrow-terminal pass consumed it earlier.
+			this.#kittyCleanupPending = true;
+		}
+
 		out += `\x1b[${y + 1};${x + 1}H${pixel.frames[this.#frame]}`;
 		return out;
 	}

--- a/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
+++ b/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
@@ -11,12 +11,15 @@ import {
 	PET_SKINS,
 	type PetMode,
 	type PetSkinId,
+	type PostRenderEmission,
 	petBurstDurationMs,
 	petBurstFrame,
 	registerAnimationCallback,
 	TERMINAL,
+	type TerminalCleanupParticipant,
 	type TUI,
 } from "@gajae-code/tui";
+
 import type { CustomEditor } from "./custom-editor";
 
 /** Re-exported from the tui skin registry so widget-relative imports stay valid. */
@@ -66,6 +69,65 @@ function sameFootprint(left: SixelFootprint, right: SixelFootprint): boolean {
  * must never clear a successor's overlay authority.
  */
 const petOverlayEmitterOwners = new WeakMap<TUI, GajaePetWidget>();
+
+interface PetCleanupCoordinator extends TerminalCleanupParticipant {
+	active: GajaePetWidget | undefined;
+	queueKitty(imageId: number, releaseReservation?: boolean): void;
+
+	hasPendingKitty(imageId: number): boolean;
+	queueSixel(footprint: SixelFootprint): void;
+}
+
+const petCleanupCoordinators = new WeakMap<TUI, PetCleanupCoordinator>();
+
+function getPetCleanupCoordinator(ui: TUI): PetCleanupCoordinator {
+	const existing = petCleanupCoordinators.get(ui);
+	if (existing) return existing;
+	const kittyDeletes = new Map<number, boolean>();
+
+	const sixelFootprints: SixelFootprint[] = [];
+	const coordinator: PetCleanupCoordinator = {
+		active: undefined,
+		queueKitty: (imageId, releaseReservation = false) => {
+			kittyDeletes.set(imageId, (kittyDeletes.get(imageId) ?? false) || releaseReservation);
+		},
+		hasPendingKitty: imageId => kittyDeletes.has(imageId),
+
+		queueSixel: footprint => {
+			if (!sixelFootprints.some(current => sameFootprint(current, footprint))) sixelFootprints.push(footprint);
+		},
+		flush: () => {
+			if (kittyDeletes.size === 0 && sixelFootprints.length === 0) return true;
+			let payload = "";
+			for (const imageId of kittyDeletes.keys()) payload += `\x1b_Ga=d,d=I,i=${imageId},q=2\x1b\\`;
+			for (const footprint of sixelFootprints) payload += clearSixelFootprint(footprint);
+			if (!ui.terminalAvailable || !ui.writeTerminalCleanup(`\x1b[?2026h\x1b7${payload}\x1b8\x1b[?2026l`)) {
+				return false;
+			}
+			for (const [imageId, releaseReservation] of kittyDeletes) {
+				if (releaseReservation) allocatedPetKittyImageIds.delete(imageId);
+			}
+			kittyDeletes.clear();
+			sixelFootprints.length = 0;
+			return true;
+		},
+		pendingDiagnostic: () =>
+			kittyDeletes.size === 0 && sixelFootprints.length === 0
+				? null
+				: `Undeliverable Gajae Pet cleanup at terminal shutdown (Kitty images: ${kittyDeletes.size}, Sixel footprints: ${sixelFootprints.length}).`,
+	};
+	ui.registerTerminalCleanup(coordinator);
+	petCleanupCoordinators.set(ui, coordinator);
+	return coordinator;
+}
+
+function clearSixelFootprint(footprint: SixelFootprint): string {
+	let out = "\x1b[0m";
+	for (let row = 0; row < footprint.rows; row++) {
+		out += `\x1b[${footprint.y + row + 1};${footprint.x + 1}H\x1b[${footprint.columns}X`;
+	}
+	return out;
+}
 
 /** Working animation: the shared para-para beats looped end to end. */
 const WORK_LOOP_TOTAL = PARA_PARA_STEPS.reduce((sum, [, ms]) => sum + ms, 0);
@@ -163,6 +225,8 @@ export class GajaePetWidget {
 	#lastSixelFootprint: SixelFootprint | undefined;
 	/** Terminal state: a disposed widget never touches the TUI or shared slots again. */
 	#disposed = false;
+	#cleanupCoordinator: PetCleanupCoordinator;
+	#placementBlocked = false;
 
 	constructor(options: {
 		ui: TUI;
@@ -186,6 +250,7 @@ export class GajaePetWidget {
 		this.#forcedProtocol = options.forcePixelProtocol;
 		this.#autoFlexGapMs =
 			options.autoFlexGapMs === undefined ? [AUTO_FLEX_MIN_GAP_MS, AUTO_FLEX_MAX_GAP_MS] : options.autoFlexGapMs;
+		this.#cleanupCoordinator = getPetCleanupCoordinator(this.#ui);
 	}
 
 	/** Protocol available for the real-pixel pet, if any. */
@@ -251,6 +316,13 @@ export class GajaePetWidget {
 		// The pet overlays the composer's bottom rows; no floor row is reserved, so
 		// the composer stays pinned to the terminal bottom.
 		this.#floorContainer.clear();
+		// Serialize predecessor Sixel erasure before this widget can place a successor.
+		const predecessorCleared = this.#cleanupCoordinator.active
+			? this.#cleanupCoordinator.active.prepareSuccessor()
+			: this.#cleanupCoordinator.flush();
+		this.#placementBlocked = protocol === "sixel" && !predecessorCleared;
+		this.#cleanupCoordinator.active = this;
+
 		this.#ui.setPostRenderEmitter(() => this.#overlayPayload());
 		petOverlayEmitterOwners.set(this.#ui, this);
 		this.#animation ??= registerAnimationCallback(now => this.#tick(now), 80);
@@ -281,16 +353,20 @@ export class GajaePetWidget {
 	}
 
 	dispose(): void {
-		if (this.#disposed) return;
+		if (this.#disposed) {
+			this.#cleanupCoordinator.flush();
+			return;
+		}
 		this.#disposed = true;
 		try {
-			this.#writeImageCleanup();
+			this.#writeImageCleanup(true);
 		} finally {
-			// Logical teardown must reach its final state even if terminal I/O fails.
-			if (this.#kittyImageId !== undefined) {
+			// A Kitty ID remains reserved until the coordinator confirms its exact-ID
+			// delete; otherwise a successor could reuse it before stale cleanup arrives.
+			if (this.#kittyImageId !== undefined && !this.#cleanupCoordinator.hasPendingKitty(this.#kittyImageId)) {
 				allocatedPetKittyImageIds.delete(this.#kittyImageId);
-				this.#kittyImageId = undefined;
 			}
+			this.#kittyImageId = undefined;
 			this.#animation?.unregister();
 			this.#animation = undefined;
 			this.#releaseOverlayEmitter();
@@ -303,6 +379,9 @@ export class GajaePetWidget {
 			if (this.#editorContainer.children.includes(this.#framedEditor)) {
 				this.#mountEditor(false);
 			}
+			// Disposal is also a recovery signal for coordinator-owned cleanup queued
+			// by an earlier off-switch; it never reclaims widget-local authority.
+			this.#cleanupCoordinator.flush();
 		}
 	}
 
@@ -312,6 +391,13 @@ export class GajaePetWidget {
 			this.#ui.setPostRenderEmitter(undefined);
 			petOverlayEmitterOwners.delete(this.#ui);
 		}
+		if (this.#cleanupCoordinator.active === this) this.#cleanupCoordinator.active = undefined;
+	}
+
+	/** Queue visual cleanup before a successor takes this TUI's overlay authority. */
+	prepareSuccessor(): boolean {
+		this.#writeImageCleanup();
+		return this.#cleanupCoordinator.flush();
 	}
 
 	#mountEditor(framed: boolean): void {
@@ -386,9 +472,11 @@ export class GajaePetWidget {
 		this.#frame = frame;
 		// Write directly: a frame swap changes no component line, so the TUI
 		// would skip the render write (and with it the post-render emitter).
-		const payload = this.#overlayPayload(true) ?? "";
-		if (payload && this.#ui.terminalAvailable) {
-			this.#ui.terminal.write(`\x1b[?2026h\x1b7${payload}\x1b8\x1b[?2026l`);
+		const emission = this.#overlayPayload(true);
+		if (emission && this.#ui.terminalAvailable) {
+			if (this.#ui.writeTerminalCleanup(`\x1b[?2026h\x1b7${emission.payload}\x1b8\x1b[?2026l`)) {
+				emission.onDelivered?.();
+			}
 		}
 	}
 
@@ -409,11 +497,7 @@ export class GajaePetWidget {
 	}
 
 	#clearSixelFootprint(footprint: SixelFootprint): string {
-		let out = "\x1b[0m";
-		for (let row = 0; row < footprint.rows; row++) {
-			out += `\x1b[${footprint.y + row + 1};${footprint.x + 1}H\x1b[${footprint.columns}X`;
-		}
-		return out;
+		return clearSixelFootprint(footprint);
 	}
 
 	/** Pending on-screen image cleanup. Pure: authority is consumed separately, on delivery. */
@@ -439,51 +523,69 @@ export class GajaePetWidget {
 	 * terminal or a throwing write keeps the erase pending so a later mode
 	 * switch or dispose can retry it.
 	 */
-	#writeImageCleanup(): void {
-		if (!this.#ui.terminalAvailable) return;
-		const payload = this.#imageCleanupPayload();
-		if (!payload) return;
-		try {
-			this.#ui.terminal.write(`\x1b[?2026h\x1b7${payload}\x1b8\x1b[?2026l`);
-		} catch {
-			// Keep the footprint/placement authority; the terminal write layer
-			// reports availability separately and callers retry on the next
-			// lifecycle transition.
-			return;
+	#writeImageCleanup(releaseKittyReservation = false): void {
+		if (
+			releaseKittyReservation &&
+			this.#kittyImageId !== undefined &&
+			this.#cleanupCoordinator.hasPendingKitty(this.#kittyImageId)
+		) {
+			// A stale owner may only upgrade the durable release metadata; it must
+			// never emit or clear a successor's terminal resources itself.
+			this.#cleanupCoordinator.queueKitty(this.#kittyImageId, true);
 		}
-		this.#consumeCleanupAuthority();
+		if (this.#cleanupCoordinator.active !== this) return;
+		if (this.#kittyImageId !== undefined && (this.#kittyCleanupPending || releaseKittyReservation)) {
+			this.#cleanupCoordinator.queueKitty(this.#kittyImageId, releaseKittyReservation);
+			this.#kittyCleanupPending = false;
+		}
+		if (this.#lastSixelFootprint) {
+			this.#cleanupCoordinator.queueSixel(this.#lastSixelFootprint);
+			this.#lastSixelFootprint = undefined;
+		}
+		this.#cleanupCoordinator.flush();
 	}
 
 	/** Draw escape payload at the pet's absolute position. */
-	#overlayPayload(clearPet = false): string | null {
+	#overlayPayload(clearPet = false): PostRenderEmission | null {
+		if (this.#placementBlocked) {
+			if (!this.#cleanupCoordinator.flush()) return null;
+			this.#placementBlocked = false;
+		}
 		const pixel = this.#pixel;
 		if (!pixel) return null;
 		const pos = this.#petPosition();
 		if (!pos) {
 			const cleanup = this.#imageCleanupPayload();
 			if (!cleanup) return null;
-			// The returned payload is written by the TUI as part of this frame;
-			// treat that delivery like our own successful write.
-			this.#consumeCleanupAuthority();
-			return cleanup;
+			return {
+				payload: cleanup,
+				onDelivered: () => this.#consumeCleanupAuthority(),
+			};
 		}
 		const { x, y } = pos;
 		let out = "";
+		let sixelFootprint: SixelFootprint | undefined;
 
 		if (pixel.protocol === "sixel") {
-			const footprint = { x, y, columns: pixel.columns, rows: pixel.rasterRows };
-			if (this.#lastSixelFootprint && !sameFootprint(this.#lastSixelFootprint, footprint)) {
+			sixelFootprint = {
+				x,
+				y,
+				columns: pixel.columns,
+				rows: pixel.rasterRows,
+			};
+			if (this.#lastSixelFootprint && !sameFootprint(this.#lastSixelFootprint, sixelFootprint)) {
 				out += this.#clearSixelFootprint(this.#lastSixelFootprint);
 			}
-			if (clearPet) out += this.#clearSixelFootprint(footprint);
-			this.#lastSixelFootprint = footprint;
-		} else {
-			// A kitty frame emitted below (re)places the image, so cleanup is
-			// pending again even if a narrow-terminal pass consumed it earlier.
-			this.#kittyCleanupPending = true;
+			if (clearPet) out += this.#clearSixelFootprint(sixelFootprint);
 		}
 
 		out += `\x1b[${y + 1};${x + 1}H${pixel.frames[this.#frame]}`;
-		return out;
+		return {
+			payload: out,
+			onDelivered: () => {
+				if (sixelFootprint) this.#lastSixelFootprint = sixelFootprint;
+				else this.#kittyCleanupPending = true;
+			},
+		};
 	}
 }

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -763,10 +763,9 @@ export class SelectorController {
 				break;
 			}
 			case "pet.mode":
-				// The settings submenu already persisted the value; apply it to the live
-				// widget via previewMode (the settings overlay is still open, so a full
-				// re-mount would tear it down — restoreComposer re-mounts on close).
-				this.ctx.previewPetMode(value as PetMode);
+				// The settings submenu already persisted the value; commit it without
+				// re-mounting the composer while the settings overlay is open.
+				this.ctx.commitPetPreviewMode(value as PetMode);
 				break;
 			case "symbolPreset": {
 				setSymbolPreset(value as "unicode" | "nerd" | "ascii").then(() => {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -617,8 +617,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.addChild(this.hookWidgetContainerBelow);
 		this.ui.setBottomPinnedComponent(this.statusLine);
 		this.ui.setFocus(this.editor);
+		this.petWidget?.dispose();
 		this.petWidget = this.#createPetWidget(this.editor);
-		this.petWidget.setMode(settings.get("pet.mode"));
+		const configuredPetMode = settings.get("pet.mode");
+		this.petWidget.setMode(configuredPetMode);
 		// The async sixel capability probe can enable graphics after the saved
 		// pet mode was applied and dropped (no protocol yet at startup).
 		// Re-apply the configured mode when capability arrives so the pet
@@ -1086,6 +1088,11 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	previewPetMode(mode: PetMode): void {
 		this.petWidget?.previewMode(mode);
+		this.ui.requestRender();
+	}
+
+	commitPetPreviewMode(mode: PetMode): void {
+		this.petWidget?.commitPreviewMode(mode);
 		this.ui.requestRender();
 	}
 
@@ -2223,7 +2230,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		nextEditor.setText(previousText);
 		previousEditor.dispose();
 
-		const petMode = this.petWidget?.mode ?? settings.get("pet.mode");
+		const petMode = settings.get("pet.mode");
 		this.petWidget?.dispose();
 
 		this.editorContainer.clear();

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -179,6 +179,8 @@ export interface InteractiveModeContext {
 	setPetMode(mode: PetMode): void;
 	/** Live-preview a pet skin during a selector without persisting. */
 	previewPetMode(mode: PetMode): void;
+	/** Commit a settings-overlay pet preview without re-mounting the composer. */
+	commitPetPreviewMode(mode: PetMode): void;
 	/** Re-mount the composer (pet-aware) after an overlay/selector closes. */
 	restoreComposer(): void;
 	startPendingSubmission(input: {

--- a/packages/coding-agent/test/gajae-pet-widget.test.ts
+++ b/packages/coding-agent/test/gajae-pet-widget.test.ts
@@ -3,6 +3,7 @@ import {
 	__animationSchedulerTestHooks,
 	Container,
 	getCellDimensions,
+	type PostRenderEmission,
 	setCellDimensions,
 	type TUI,
 } from "@gajae-code/tui";
@@ -23,7 +24,18 @@ function makeStubs(columns = 80, rows = 30) {
 		},
 		invalidate() {},
 	} as unknown as CustomEditor;
-	let emitter: (() => string | null) | undefined;
+	let emitter: (() => PostRenderEmission | null) | undefined;
+	const emitOverlay = (): string | null => {
+		const emission = emitter?.();
+		emission?.onDelivered?.();
+		return emission?.payload ?? null;
+	};
+
+	const cleanupParticipants = new Set<{
+		flush(): boolean;
+		pendingDiagnostic(): string | null;
+	}>();
+
 	let available = true;
 	let failWrites = false;
 	const terminal = {
@@ -36,9 +48,19 @@ function makeStubs(columns = 80, rows = 30) {
 	};
 	const ui = {
 		requestRender: () => {},
-		setPostRenderEmitter: (fn?: () => string | null) => {
+		setPostRenderEmitter: (fn?: () => PostRenderEmission | null) => {
 			emitter = fn;
 		},
+		registerTerminalCleanup: (participant: { flush(): boolean; pendingDiagnostic(): string | null }) => {
+			cleanupParticipants.add(participant);
+			return () => cleanupParticipants.delete(participant);
+		},
+		writeTerminalCleanup: (data: string) => {
+			if (!available || failWrites) return false;
+			written.push(data);
+			return true;
+		},
+
 		get terminalAvailable() {
 			return available;
 		},
@@ -53,7 +75,19 @@ function makeStubs(columns = 80, rows = 30) {
 		editorContainer,
 		floorContainer,
 		written,
-		getEmitter: () => emitter,
+		getEmitter: () => (emitter ? emitOverlay : undefined),
+		getRawEmitter: () => emitter,
+		deliverPostRender: () => {
+			const emission = emitter?.();
+			if (!emission || !available) return false;
+			try {
+				terminal.write(emission.payload);
+			} catch {
+				return false;
+			}
+			emission.onDelivered?.();
+			return true;
+		},
 		getRenderedWidth: () => renderedWidth,
 		setTerminalSize: (nextColumns: number, nextRows: number) => {
 			terminal.columns = nextColumns;
@@ -65,6 +99,11 @@ function makeStubs(columns = 80, rows = 30) {
 		setWriteFailure: (value: boolean) => {
 			failWrites = value;
 		},
+		flushCleanup: () => {
+			for (const participant of cleanupParticipants) participant.flush();
+		},
+		cleanupDiagnostics: () =>
+			[...cleanupParticipants].map(participant => participant.pendingDiagnostic()).filter(Boolean),
 	};
 }
 
@@ -310,6 +349,275 @@ describe("GajaePetWidget", () => {
 		widget.dispose();
 
 		expect(written.some(chunk => chunk.includes("\x1b[28;76H\x1b[4X"))).toBe(true);
+	});
+
+	it("flushes queued Kitty and Sixel cleanup records together without protocol conflation", () => {
+		const stubs = makeStubs();
+		const sixel = new GajaePetWidget({
+			ui: stubs.ui,
+			editor: stubs.editor,
+			editorContainer: stubs.editorContainer,
+			floorContainer: stubs.floorContainer,
+			isWorking: () => false,
+			getComposerBottomOffset: () => 0,
+			forcePixelProtocol: "sixel",
+			autoFlexGapMs: null,
+		});
+		sixel.setMode("red");
+		expect(stubs.deliverPostRender()).toBe(true);
+
+		stubs.setWriteFailure(true);
+		const kitty = new GajaePetWidget({
+			ui: stubs.ui,
+			editor: stubs.editor,
+			editorContainer: stubs.editorContainer,
+			floorContainer: stubs.floorContainer,
+			isWorking: () => false,
+			getComposerBottomOffset: () => 0,
+			forcePixelProtocol: "kitty",
+			autoFlexGapMs: null,
+		});
+		kitty.setMode("red");
+		stubs.setWriteFailure(false);
+		const kittyPayload = stubs.getRawEmitter()?.()?.payload;
+		const kittyId = kittyPayload?.match(/i=(\d+)/)?.[1];
+		expect(kittyId).toBeDefined();
+		expect(stubs.deliverPostRender()).toBe(true);
+
+		stubs.setWriteFailure(true);
+		kitty.setMode("off");
+		stubs.setWriteFailure(false);
+		stubs.written.length = 0;
+		kitty.dispose();
+
+		const cleanup = stubs.written.join("");
+		expect(cleanup).toContain(`\x1b_Ga=d,d=I,i=${kittyId},q=2\x1b\\`);
+		expect(cleanup).toContain("\x1b[28;76H\x1b[4X");
+
+		expect(cleanup).not.toContain("\x1b_Ga=d,d=I,i=undefined");
+		sixel.dispose();
+	});
+
+	it("retains failed final-dispose Kitty cleanup for diagnostics and a later retry", () => {
+		const { cleanupDiagnostics, deliverPostRender, getRawEmitter, setWriteFailure, widget, written } = makeWidget(
+			80,
+			30,
+			{ protocol: "kitty" },
+		);
+		widget.setMode("red");
+		expect(deliverPostRender()).toBe(true);
+		const imageId = getRawEmitter()?.()?.payload.match(/i=(\d+)/)?.[1];
+		expect(imageId).toBeDefined();
+
+		setWriteFailure(true);
+		widget.dispose();
+		expect(cleanupDiagnostics()).toEqual([
+			"Undeliverable Gajae Pet cleanup at terminal shutdown (Kitty images: 1, Sixel footprints: 0).",
+		]);
+
+		setWriteFailure(false);
+		written.length = 0;
+		widget.dispose();
+		expect(written.filter(chunk => chunk.includes(`a=d,d=I,i=${imageId}`))).toHaveLength(1);
+
+		expect(cleanupDiagnostics()).toEqual([]);
+	});
+
+	it("keeps a pending Kitty delete ID reserved until the coordinator delivers it", () => {
+		const imageIds = [101, 101, 202, 101];
+		vi.spyOn(crypto, "getRandomValues").mockImplementation(values => {
+			if (!values) throw new Error("Expected a typed array");
+			const ids = new Uint32Array(
+				values.buffer,
+				values.byteOffset,
+				values.byteLength / Uint32Array.BYTES_PER_ELEMENT,
+			);
+			ids[0] = imageIds.shift() ?? 303;
+			return values;
+		});
+
+		const stubs = makeStubs();
+		const makeKitty = () =>
+			new GajaePetWidget({
+				ui: stubs.ui,
+				editor: stubs.editor,
+				editorContainer: stubs.editorContainer,
+				floorContainer: stubs.floorContainer,
+				isWorking: () => false,
+				getComposerBottomOffset: () => 0,
+				forcePixelProtocol: "kitty",
+				autoFlexGapMs: null,
+			});
+		const predecessor = makeKitty();
+		predecessor.setMode("red");
+		expect(stubs.deliverPostRender()).toBe(true);
+		stubs.setWriteFailure(true);
+		predecessor.dispose();
+
+		const successor = makeKitty();
+		successor.setMode("red");
+		expect(stubs.getRawEmitter()?.()?.payload).toContain("i=202");
+
+		stubs.setWriteFailure(false);
+		predecessor.dispose();
+		const afterCleanup = makeKitty();
+		afterCleanup.setMode("red");
+		expect(stubs.getRawEmitter()?.()?.payload).toContain("i=101");
+		successor.dispose();
+		afterCleanup.dispose();
+	});
+
+	it("keeps a Kitty ID reserved across a skin replacement until final disposal", () => {
+		const imageIds = [501, 501, 502, 501];
+		vi.spyOn(crypto, "getRandomValues").mockImplementation(values => {
+			if (!values) throw new Error("Expected a typed array");
+			const ids = new Uint32Array(
+				values.buffer,
+				values.byteOffset,
+				values.byteLength / Uint32Array.BYTES_PER_ELEMENT,
+			);
+			ids[0] = imageIds.shift() ?? 503;
+			return values;
+		});
+		const stubs = makeStubs();
+		const makeKitty = () =>
+			new GajaePetWidget({
+				ui: stubs.ui,
+				editor: stubs.editor,
+				editorContainer: stubs.editorContainer,
+				floorContainer: stubs.floorContainer,
+				isWorking: () => false,
+				getComposerBottomOffset: () => 0,
+				forcePixelProtocol: "kitty",
+				autoFlexGapMs: null,
+			});
+		const owner = makeKitty();
+		owner.setMode("red");
+		expect(stubs.deliverPostRender()).toBe(true);
+		owner.setMode("blue");
+		const contender = makeKitty();
+		contender.setMode("red");
+		expect(stubs.getRawEmitter()?.()?.payload).toContain("i=502");
+
+		owner.dispose();
+		const released = makeKitty();
+		released.setMode("red");
+		expect(stubs.getRawEmitter()?.()?.payload).toContain("i=501");
+		contender.dispose();
+		released.dispose();
+	});
+
+	it("keeps a Kitty ID reserved across off and on until final disposal", () => {
+		const imageIds = [601, 601, 602, 601];
+		vi.spyOn(crypto, "getRandomValues").mockImplementation(values => {
+			if (!values) throw new Error("Expected a typed array");
+			const ids = new Uint32Array(
+				values.buffer,
+				values.byteOffset,
+				values.byteLength / Uint32Array.BYTES_PER_ELEMENT,
+			);
+			ids[0] = imageIds.shift() ?? 603;
+			return values;
+		});
+		const stubs = makeStubs();
+		const makeKitty = () =>
+			new GajaePetWidget({
+				ui: stubs.ui,
+				editor: stubs.editor,
+				editorContainer: stubs.editorContainer,
+				floorContainer: stubs.floorContainer,
+				isWorking: () => false,
+				getComposerBottomOffset: () => 0,
+				forcePixelProtocol: "kitty",
+				autoFlexGapMs: null,
+			});
+		const owner = makeKitty();
+		owner.setMode("red");
+		expect(stubs.deliverPostRender()).toBe(true);
+		owner.setMode("off");
+		owner.setMode("red");
+		const contender = makeKitty();
+		contender.setMode("red");
+		expect(stubs.getRawEmitter()?.()?.payload).toContain("i=602");
+
+		owner.dispose();
+		const released = makeKitty();
+		released.setMode("red");
+		expect(stubs.getRawEmitter()?.()?.payload).toContain("i=601");
+		contender.dispose();
+		released.dispose();
+	});
+
+	it("acknowledges post-render cleanup only after the TUI delivers its frame", () => {
+		const { deliverPostRender, getRawEmitter, setTerminalSize, setWriteFailure, widget } = makeWidget();
+
+		try {
+			widget.setMode("red");
+			expect(deliverPostRender()).toBe(true);
+			setTerminalSize(12, 30);
+
+			const pending = getRawEmitter()?.();
+			expect(pending?.payload).toContain("\x1b[28;76H\x1b[4X");
+			setWriteFailure(true);
+			expect(deliverPostRender()).toBe(false);
+			expect(getRawEmitter()?.()?.payload).toContain("\x1b[28;76H\x1b[4X");
+
+			setWriteFailure(false);
+			expect(deliverPostRender()).toBe(true);
+			expect(getRawEmitter()?.()).toBeNull();
+		} finally {
+			widget.dispose();
+		}
+	});
+
+	it("delivers final-dispose cleanup through the TUI coordinator when a successor installs after recovery", () => {
+		const stubs = makeStubs();
+		const first = new GajaePetWidget({
+			ui: stubs.ui,
+			editor: stubs.editor,
+			editorContainer: stubs.editorContainer,
+			floorContainer: stubs.floorContainer,
+			isWorking: () => false,
+			getComposerBottomOffset: () => 0,
+			forcePixelProtocol: "sixel",
+			autoFlexGapMs: null,
+		});
+		first.setMode("red");
+		expect(stubs.getEmitter()?.()).toContain("\x1bP0;1;0q");
+		stubs.setTerminalAvailable(false);
+		first.dispose();
+		stubs.setTerminalAvailable(true);
+		stubs.written.length = 0;
+
+		const successor = new GajaePetWidget({
+			ui: stubs.ui,
+			editor: stubs.editor,
+			editorContainer: stubs.editorContainer,
+			floorContainer: stubs.floorContainer,
+			isWorking: () => false,
+			getComposerBottomOffset: () => 0,
+			forcePixelProtocol: "sixel",
+			autoFlexGapMs: null,
+		});
+		try {
+			successor.setMode("blue");
+			const erase = stubs.written.findIndex(chunk => chunk.includes("\x1b[28;76H\x1b[4X"));
+			expect(erase).toBeGreaterThanOrEqual(0);
+			expect(stubs.getEmitter()?.()).toContain("\x1bP0;1;0q");
+		} finally {
+			successor.dispose();
+		}
+	});
+
+	it("retains protocol-specific diagnostics when final-dispose cleanup remains undeliverable", () => {
+		const { widget, getEmitter, setTerminalAvailable, cleanupDiagnostics } = makeWidget();
+		widget.setMode("red");
+		expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+		setTerminalAvailable(false);
+		widget.dispose();
+		expect(cleanupDiagnostics()).toEqual([
+			"Undeliverable Gajae Pet cleanup at terminal shutdown (Kitty images: 0, Sixel footprints: 1).",
+		]);
 	});
 
 	it("hides the overlay instead of covering editor text on a narrow terminal", () => {

--- a/packages/coding-agent/test/gajae-pet-widget.test.ts
+++ b/packages/coding-agent/test/gajae-pet-widget.test.ts
@@ -24,19 +24,25 @@ function makeStubs(columns = 80, rows = 30) {
 		invalidate() {},
 	} as unknown as CustomEditor;
 	let emitter: (() => string | null) | undefined;
+	let available = true;
+	let failWrites = false;
+	const terminal = {
+		columns,
+		rows,
+		write: (data: string) => {
+			if (failWrites) throw new Error("injected terminal write failure");
+			written.push(data);
+		},
+	};
 	const ui = {
 		requestRender: () => {},
 		setPostRenderEmitter: (fn?: () => string | null) => {
 			emitter = fn;
 		},
-		terminalAvailable: true,
-		terminal: {
-			columns,
-			rows,
-			write: (data: string) => {
-				written.push(data);
-			},
+		get terminalAvailable() {
+			return available;
 		},
+		terminal,
 	} as unknown as TUI;
 	const editorContainer = new Container();
 	const floorContainer = new Container();
@@ -49,6 +55,16 @@ function makeStubs(columns = 80, rows = 30) {
 		written,
 		getEmitter: () => emitter,
 		getRenderedWidth: () => renderedWidth,
+		setTerminalSize: (nextColumns: number, nextRows: number) => {
+			terminal.columns = nextColumns;
+			terminal.rows = nextRows;
+		},
+		setTerminalAvailable: (value: boolean) => {
+			available = value;
+		},
+		setWriteFailure: (value: boolean) => {
+			failWrites = value;
+		},
 	};
 }
 
@@ -59,7 +75,7 @@ function makeWidget(
 		bottomOffset?: number;
 		isWorking?: () => boolean;
 		autoFlexGapMs?: [number, number] | null;
-		protocol?: "sixel" | "kitty";
+		protocol?: "sixel" | "kitty" | null;
 	} = {},
 ) {
 	const stubs = makeStubs(columns, rows);
@@ -70,7 +86,7 @@ function makeWidget(
 		floorContainer: stubs.floorContainer,
 		isWorking: options.isWorking ?? (() => false),
 		getComposerBottomOffset: () => stubs.floorContainer.render(columns).length + (options.bottomOffset ?? 0),
-		forcePixelProtocol: options.protocol ?? "sixel",
+		forcePixelProtocol: options.protocol === null ? undefined : (options.protocol ?? "sixel"),
 		autoFlexGapMs: options.autoFlexGapMs !== undefined ? options.autoFlexGapMs : null,
 	});
 	return { ...stubs, widget };
@@ -99,6 +115,201 @@ describe("GajaePetWidget", () => {
 		} finally {
 			widget.dispose();
 		}
+	});
+
+	it("owns and deletes a distinct Kitty image ID per widget", () => {
+		const first = makeWidget(80, 30, { protocol: "kitty" });
+		const second = makeWidget(80, 30, { protocol: "kitty" });
+		try {
+			first.widget.setMode("red");
+			second.widget.setMode("red");
+			const firstPayload = first.getEmitter()?.();
+			const secondPayload = second.getEmitter()?.();
+			const firstId = firstPayload?.match(/i=(\d+)/)?.[1];
+			const secondId = secondPayload?.match(/i=(\d+)/)?.[1];
+
+			expect(firstId).toBeDefined();
+			expect(secondId).toBeDefined();
+			expect(firstId).not.toBe(secondId);
+			expect(Number(firstId)).toBeGreaterThan(0);
+			expect(Number(secondId)).toBeGreaterThan(0);
+
+			first.written.length = 0;
+			first.widget.setMode("off");
+			expect(first.written.some(chunk => chunk.includes(`a=d,d=I,i=${firstId}`))).toBe(true);
+			expect(first.written.some(chunk => chunk.includes(`i=${secondId}`))).toBe(false);
+		} finally {
+			first.widget.dispose();
+			second.widget.dispose();
+		}
+	});
+
+	it("clears the last Sixel footprint when disabled", () => {
+		const { widget, written, getEmitter } = makeWidget();
+		try {
+			widget.setMode("red");
+			expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+			written.length = 0;
+
+			widget.setMode("off");
+
+			expect(written.some(chunk => chunk.includes("\x1b[28;76H\x1b[4X"))).toBe(true);
+		} finally {
+			widget.dispose();
+		}
+	});
+
+	it("clears the previous Sixel footprint after the terminal becomes too narrow", () => {
+		const { widget, getEmitter, setTerminalSize } = makeWidget();
+		try {
+			widget.setMode("red");
+			expect(getEmitter()?.()).toContain("\x1b[28;76H");
+			setTerminalSize(12, 30);
+
+			const cleanup = getEmitter()?.();
+
+			expect(cleanup).toContain("\x1b[28;76H\x1b[4X");
+			expect(cleanup).not.toContain("\x1bP0;1;0q");
+			expect(getEmitter()?.()).toBeNull();
+		} finally {
+			widget.dispose();
+		}
+	});
+
+	it("completes logical teardown when the cleanup write throws", () => {
+		const { widget, editorContainer, getEmitter, getRenderedWidth, setWriteFailure } = makeWidget();
+		widget.setMode("red");
+		expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+
+		setWriteFailure(true);
+		widget.dispose();
+
+		// The thrown write must not abort teardown: the shared emitter slot is
+		// released, the composer is unframed, and the widget is terminal.
+		expect(getEmitter()).toBeUndefined();
+		expect(widget.mode).toBe("off");
+		editorContainer.render(80);
+		expect(getRenderedWidth()).toBe(80);
+		widget.setMode("red");
+		expect(getEmitter()).toBeUndefined();
+	});
+
+	it("keeps a disposed widget from clearing its successor's overlay emitter", () => {
+		const stubs = makeStubs();
+		const make = () =>
+			new GajaePetWidget({
+				ui: stubs.ui,
+				editor: stubs.editor,
+				editorContainer: stubs.editorContainer,
+				floorContainer: stubs.floorContainer,
+				isWorking: () => false,
+				getComposerBottomOffset: () => stubs.floorContainer.render(80).length,
+				forcePixelProtocol: "sixel",
+				autoFlexGapMs: null,
+			});
+		const first = make();
+		first.setMode("red");
+		first.dispose();
+
+		const second = make();
+		try {
+			second.setMode("red");
+			const successorEmitter = stubs.getEmitter();
+			expect(successorEmitter).toBeDefined();
+
+			first.dispose();
+
+			expect(stubs.getEmitter()).toBe(successorEmitter);
+		} finally {
+			second.dispose();
+		}
+	});
+
+	it("keeps a stale first-time dispose from stealing a successor's emitter or composer mount", () => {
+		const stubs = makeStubs();
+		const make = () =>
+			new GajaePetWidget({
+				ui: stubs.ui,
+				editor: stubs.editor,
+				editorContainer: stubs.editorContainer,
+				floorContainer: stubs.floorContainer,
+				isWorking: () => false,
+				getComposerBottomOffset: () => stubs.floorContainer.render(80).length,
+				forcePixelProtocol: "sixel",
+				autoFlexGapMs: null,
+			});
+		// The predecessor is never disposed before the successor takes over.
+		const first = make();
+		first.setMode("red");
+		const second = make();
+		try {
+			second.setMode("red");
+			const successorEmitter = stubs.getEmitter();
+			expect(successorEmitter).toBeDefined();
+
+			first.dispose();
+
+			expect(stubs.getEmitter()).toBe(successorEmitter);
+			// The successor's framed composer stays mounted (editor still narrowed).
+			stubs.editorContainer.render(80);
+			expect(stubs.getRenderedWidth()).toBe(80 - 5);
+		} finally {
+			second.dispose();
+		}
+	});
+
+	it("re-arms Kitty cleanup when the pet is re-placed after a narrow-terminal pass consumed it", () => {
+		const { widget, written, getEmitter, setTerminalSize } = makeWidget(12, 30, { protocol: "kitty" });
+		try {
+			widget.setMode("red");
+			// Too narrow: the emitter returns the delete escape and consumes the
+			// pending cleanup.
+			expect(getEmitter()?.()).toContain("\x1b_Ga=d");
+			expect(getEmitter()?.()).toBeNull();
+
+			// Wide again: the next frame re-places the image.
+			setTerminalSize(80, 30);
+			expect(getEmitter()?.()).toContain("\x1b_G");
+			written.length = 0;
+
+			widget.dispose();
+
+			expect(written.some(chunk => chunk.includes("\x1b_Ga=d,d=I,i="))).toBe(true);
+		} finally {
+			widget.dispose();
+		}
+	});
+
+	it("retains Sixel cleanup authority while the terminal is unavailable and erases once it returns", () => {
+		const { widget, written, getEmitter, setTerminalAvailable } = makeWidget();
+		widget.setMode("red");
+		expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+		written.length = 0;
+
+		setTerminalAvailable(false);
+		widget.setMode("off");
+		expect(written).toHaveLength(0);
+
+		setTerminalAvailable(true);
+		widget.dispose();
+
+		expect(written.some(chunk => chunk.includes("\x1b[28;76H\x1b[4X"))).toBe(true);
+	});
+
+	it("retains Sixel cleanup authority when the erase write throws and retries on dispose", () => {
+		const { widget, written, getEmitter, setWriteFailure } = makeWidget();
+		widget.setMode("red");
+		expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+		written.length = 0;
+
+		setWriteFailure(true);
+		widget.setMode("off");
+		expect(written).toHaveLength(0);
+
+		setWriteFailure(false);
+		widget.dispose();
+
+		expect(written.some(chunk => chunk.includes("\x1b[28;76H\x1b[4X"))).toBe(true);
 	});
 
 	it("hides the overlay instead of covering editor text on a narrow terminal", () => {

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -3,9 +3,9 @@ import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { Agent } from "@gajae-code/agent-core";
 import type { AssistantMessage } from "@gajae-code/ai";
-import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
 import { initTheme, theme } from "@gajae-code/coding-agent/modes/theme/theme";
-import { CURSOR_MARKER, Text, visibleWidth } from "@gajae-code/tui";
+import { CURSOR_MARKER, ImageProtocol, setTerminalImageProtocol, TERMINAL, Text, visibleWidth } from "@gajae-code/tui";
 import { TempDir } from "@gajae-code/utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import type {
@@ -585,5 +585,50 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(mode.editor.onSubmit).toBeDefined();
 		expect(mode.editor.onEscape).toBeDefined();
 		expect(refreshSpy).toHaveBeenCalled();
+	});
+
+	it("preserves a pending pet mode across editor replacement", () => {
+		const originalProtocol = TERMINAL.imageProtocol;
+		vi.spyOn(mode, "refreshSlashCommandState").mockResolvedValue();
+		try {
+			setTerminalImageProtocol(null);
+			settings.set("pet.mode", "red");
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+			expect(mode.petWidget?.mode).toBe("off");
+
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+			expect(mode.petWidget?.mode).toBe("off");
+
+			expect(settings.get("pet.mode")).toBe("red");
+			setTerminalImageProtocol(ImageProtocol.Sixel);
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+			expect(mode.petWidget?.mode).toBe("red");
+		} finally {
+			setTerminalImageProtocol(originalProtocol);
+		}
+	});
+
+	it("disposes a pre-init pet widget before init replaces it", async () => {
+		const originalProtocol = TERMINAL.imageProtocol;
+		vi.spyOn(mode, "refreshSlashCommandState").mockResolvedValue();
+		try {
+			setTerminalImageProtocol(null);
+			settings.set("pet.mode", "red");
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+			const preInitWidget = mode.petWidget;
+			if (!preInitWidget) throw new Error("Expected pre-init pet widget");
+			const dispose = vi.spyOn(preInitWidget, "dispose");
+
+			await mode.init();
+
+			expect(dispose).toHaveBeenCalledTimes(1);
+			expect(mode.petWidget).not.toBe(preInitWidget);
+			expect(mode.petWidget?.mode).toBe("off");
+
+			setTerminalImageProtocol(ImageProtocol.Sixel);
+			expect(mode.petWidget?.mode).toBe("red");
+		} finally {
+			setTerminalImageProtocol(originalProtocol);
+		}
 	});
 });

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -40,6 +40,19 @@ const SEGMENT_RESET = "\x1b[0m";
 const LINE_TERMINATOR = "\x1b[0m\x1b]8;;\x07";
 
 type InputListenerResult = { consume?: boolean; data?: string } | undefined;
+
+/** An overlay payload whose state transition is acknowledged only after its frame writes. */
+export interface PostRenderEmission {
+	payload: string;
+	onDelivered?: () => void;
+}
+
+/** TUI-lifetime cleanup participant for terminal artifacts that outlive UI components. */
+export interface TerminalCleanupParticipant {
+	flush(): boolean;
+	pendingDiagnostic(): string | null;
+}
+
 type InputListener = (data: string) => InputListenerResult;
 
 /**
@@ -470,6 +483,14 @@ export class Container implements ViewportAnchorProvider {
 	}
 }
 
+function isTerminalDetachError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const code = (error as NodeJS.ErrnoException).code;
+	return (
+		code === "EIO" || code === "EPIPE" || code === "ERR_STREAM_DESTROYED" || code === "ERR_STREAM_WRITE_AFTER_END"
+	);
+}
+
 const MAX_REPORTED_RENDER_ERRORS = 200;
 const reportedRenderErrors = new Set<string>();
 
@@ -629,6 +650,8 @@ export class TUI extends Container {
 	#stopped = false;
 	#terminalUnavailable = false;
 	#bottomPinnedComponent: Component | null = null;
+
+	#terminalCleanupParticipants = new Set<TerminalCleanupParticipant>();
 
 	#unsubscribeTabWidthChange?: () => void;
 	static #renderCounters: TuiRenderCounterSnapshot = {
@@ -976,6 +999,8 @@ export class TUI extends Container {
 		this.#hideCursor();
 		this.#querySixelSupport();
 		this.#queryCellSize();
+		this.flushTerminalCleanup();
+
 		this.requestRender(true);
 	}
 
@@ -1014,9 +1039,15 @@ export class TUI extends Container {
 		}
 		try {
 			operation();
-		} catch {
-			this.#markTerminalUnavailable();
-			return false;
+		} catch (error) {
+			if (isTerminalDetachError(error) || !this.terminal.available) {
+				this.#markTerminalUnavailable();
+				return false;
+			}
+			logger.error("Unexpected terminal operation failure", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+			throw error;
 		}
 		if (!this.terminal.available) {
 			this.#markTerminalUnavailable();
@@ -1182,6 +1213,8 @@ export class TUI extends Container {
 	}
 
 	stop(): void {
+		this.flushTerminalCleanup();
+
 		this.#clearSixelProbeState();
 		this.#stopped = true;
 		if (this.#renderTimer) {
@@ -1206,6 +1239,7 @@ export class TUI extends Container {
 		}
 		this.#showCursor();
 		try {
+			this.#reportUndeliverableTerminalCleanup();
 			this.terminal.stop();
 		} catch {
 			this.#markTerminalUnavailable();
@@ -2589,24 +2623,48 @@ export class TUI extends Container {
 		return { seq, toRow: targetRow };
 	}
 
+	/** Register cleanup work whose delivery must survive a component's disposal. */
+	registerTerminalCleanup(participant: TerminalCleanupParticipant): () => void {
+		this.#terminalCleanupParticipants.add(participant);
+		return () => this.#terminalCleanupParticipants.delete(participant);
+	}
+
+	/** Retry durable cleanup after recovery or before an orderly terminal stop. */
+	flushTerminalCleanup(): void {
+		for (const participant of this.#terminalCleanupParticipants) participant.flush();
+	}
+
+	/** Write cleanup directly and report actual terminal delivery. */
+	writeTerminalCleanup(payload: string): boolean {
+		return this.#writeTerminal(payload);
+	}
+
+	/** Report cleanup that cannot be delivered because this TUI is permanently stopping. */
+	#reportUndeliverableTerminalCleanup(): void {
+		for (const participant of this.#terminalCleanupParticipants) {
+			const diagnostic = participant.pendingDiagnostic();
+			if (diagnostic) console.warn(diagnostic);
+		}
+	}
+
 	/**
 	 * Register an emitter whose escape payload is appended to every render
 	 * write (inside its own synchronized-output block, cursor saved/restored).
 	 * Used for absolute-positioned overlays such as pixel-image pets that live
 	 * outside the line-based component model. Return null to emit nothing.
 	 */
-	setPostRenderEmitter(emitter: (() => string | null) | undefined): void {
+	setPostRenderEmitter(emitter: (() => string | PostRenderEmission | null) | undefined): void {
 		this.#postRenderEmitter = emitter;
 	}
 
-	#postRenderEmitter: (() => string | null) | undefined;
-
+	#postRenderEmitter: (() => string | PostRenderEmission | null) | undefined;
 	#writeRenderBufferAndReanchorImeCursor(
 		buffer: string,
 		cursorPos: { row: number; col: number } | null,
 		totalLines: number,
 	): boolean {
-		const overlay = this.#postRenderEmitter?.();
+		const emitted = this.#postRenderEmitter?.();
+		const overlay = typeof emitted === "string" ? emitted : emitted?.payload;
 		if (overlay) {
 			// DECSC/DECRC keep the hardware cursor stable; the dedicated
 			// synchronized block prevents visible tearing while the overlay
@@ -2614,8 +2672,9 @@ export class TUI extends Container {
 			buffer += `\x1b[?2026h\x1b7${overlay}\x1b8\x1b[?2026l`;
 		}
 		if (!this.#writeTerminal(buffer)) return false;
-		if (!this.#imeCursorActive) return true;
-		return this.#writeCursorPosition(cursorPos, totalLines);
+		if (this.#imeCursorActive && !this.#writeCursorPosition(cursorPos, totalLines)) return false;
+		if (typeof emitted !== "string") emitted?.onDelivered?.();
+		return true;
 	}
 
 	/**

--- a/packages/tui/test/terminal-detach.test.ts
+++ b/packages/tui/test/terminal-detach.test.ts
@@ -38,6 +38,15 @@ class DetachingTerminal implements Terminal {
 		this.#hideCursorFails = fails;
 	}
 
+	setWriteFailureAt(writeFailureAt: number | undefined): void {
+		this.#writeFailureAt = writeFailureAt;
+		if (writeFailureAt === undefined) this.#available = true;
+	}
+
+	failNextWrite(): void {
+		this.#writeFailureAt = this.#writes.length + 1;
+	}
+
 	start(_onInput: (data: string) => void, _onResize: () => void): void {}
 
 	stop(): void {}
@@ -113,6 +122,12 @@ class DetachingTerminal implements Terminal {
 
 	setProgress(active: boolean): void {
 		this.write(active ? "\x1b]9;4;3\x07" : "\x1b]9;4;0;\x07");
+	}
+}
+
+class UnexpectedErrorTerminal extends DetachingTerminal {
+	override write(_data: string): void {
+		throw new Error("unexpected terminal failure");
 	}
 }
 
@@ -249,6 +264,35 @@ describe("terminal detach handling", () => {
 		expect(terminal.writes.length).toBe(writesAfterDetach);
 	});
 
+	it("preserves an unexpected terminal operation error", () => {
+		const tui = new TUI(new UnexpectedErrorTerminal());
+		tui.addChild(new StaticComponent("hello"));
+		expect(() => tui.start()).toThrow("unexpected terminal failure");
+	});
+
+	it("acknowledges structured post-render emissions only after a successful frame write", async () => {
+		const terminal = new DetachingTerminal();
+		const tui = new TUI(terminal);
+		const component = new StaticComponent("hello");
+		const delivered = vi.fn();
+		tui.addChild(component);
+		tui.start();
+		await settle();
+
+		tui.setPostRenderEmitter(() => ({ payload: "overlay", onDelivered: delivered }));
+		terminal.failNextWrite();
+		component.setLine("changed");
+		tui.requestRender(true);
+		await settle();
+		expect(delivered).not.toHaveBeenCalled();
+
+		terminal.setWriteFailureAt(undefined);
+		tui.start();
+		await settle();
+		expect(delivered).toHaveBeenCalledTimes(1);
+		tui.stop();
+	});
+
 	it("swallows cursor cleanup failures and suppresses later renders", async () => {
 		const terminal = new DetachingTerminal();
 		const tui = new TUI(terminal, true);
@@ -268,5 +312,28 @@ describe("terminal detach handling", () => {
 		expect(() => tui.requestRender(true)).not.toThrow();
 		await settle();
 		expect(terminal.writes.length).toBe(writesBeforeCursorFailure);
+	});
+
+	it("reports undeliverable registered cleanup during TUI.stop", () => {
+		const tui = new TUI(new DetachingTerminal());
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const flush = vi.fn(() => false);
+
+		try {
+			tui.registerTerminalCleanup({
+				flush,
+				pendingDiagnostic: () =>
+					"Undeliverable Gajae Pet cleanup at terminal shutdown (Kitty images: 1, Sixel footprints: 1).",
+			});
+
+			tui.stop();
+
+			expect(warn).toHaveBeenCalledWith(
+				"Undeliverable Gajae Pet cleanup at terminal shutdown (Kitty images: 1, Sixel footprints: 1).",
+			);
+			expect(flush).toHaveBeenCalledTimes(1);
+		} finally {
+			warn.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Maintainer repair for the cleanup-lifecycle blockers found in #2153 and the exact-head review of closed #2136.

- move pending Kitty/Sixel cleanup authority to the TUI lifetime
- acknowledge cleanup only after successful terminal/frame delivery
- serialize predecessor cleanup before successor placement
- retain protocol-specific cleanup through recovery, successor installation, and shutdown diagnostics
- preserve Kitty ID reservations until final-owner deletion is actually delivered
- preserve unexpected terminal errors while still treating recognized detach/I/O loss as a fail-safe detach

## Verification

- `bun test packages/coding-agent/test/gajae-pet-widget.test.ts` — 32 pass
- `bun test packages/tui/test/terminal-detach.test.ts` — 9 pass
- `bun --cwd=packages/tui run check` — pass
- `bun --cwd=packages/coding-agent run check` — pass
- mandatory cleanup sweep — PASS
- architect review — CLEAR / APPROVE
- executor red-team QA — PASS (`/tmp/pr2153-cleanup-qa-report.json`)

## Provenance

Based on #2153 exact head `dffa70b9cf5aac75f155bc8edba4ef5209778756`. This draft replacement is intentionally not merge-ready until CI and a fresh independent review pass on this exact head complete.

Replaces the blocked cleanup design in #2153; follow-up capability-selection work from #2136 remains separate and closed pending a clean base.