### PR TITLE
feat(coding-agent): capability-aware Gajae Pet selection UX

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added the additive SDK Q10 model-catalog DTO: `Q10`, `models.list/current`, `models.list`, and `models.current` now return the same paged registry rows with reasoning/thinking capability metadata and current-model readback. `thinking.validLevels` is an `off`-first canonical menu; sparse raw reasoning descriptors remain available for inspection. The public DTO types are exported from `@gajae-code/coding-agent/sdk`, while undocumented `/sdk/models` deep imports remain unavailable. `inherit` is readback-only and malformed descriptors fail with a safe internal SDK error (#2163).
+- Gajae Pet selection is now terminal-capability aware: unsupported terminals show an actionable warning (with multiplexer-specific guidance for tmux/screen/zellij, including the `PI_FORCE_IMAGE_PROTOCOL=sixel` expert opt-in), `/pet` and Settings disable the unavailable `RedGajae`/`BlueGajae` choices while `off` stays selectable, a saved-but-unavailable choice is identified as `(saved)`, and the public command names are consistent across execution, completion, and inline hints (`/pet RedGajae`, `/pet BlueGajae`, `/pet off`, case-insensitive).
 
 ### Changed
 

--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -35,7 +35,7 @@ function buildArgumentCompletions(subcommands: SubcommandDef[]): (prefix: string
 		if (argumentPrefix.includes(" ")) return null; // past the subcommand
 		const lower = argumentPrefix.toLowerCase();
 		const matches = subcommands
-			.filter(s => s.name.startsWith(lower))
+			.filter(s => s.name.toLowerCase().startsWith(lower))
 			.map(s => ({
 				value: `${s.name} `,
 				label: s.name,
@@ -59,7 +59,7 @@ function buildSubcommandInlineHint(subcommands: SubcommandDef[]): (argumentText:
 			// Still typing subcommand name — show remaining chars + usage
 			const prefix = trimmed.toLowerCase();
 			if (prefix.length === 0) return null;
-			const match = subcommands.find(s => s.name.startsWith(prefix));
+			const match = subcommands.find(s => s.name.toLowerCase().startsWith(prefix));
 			if (!match) return null;
 			const remaining = match.name.slice(prefix.length);
 			return remaining + (match.usage ? ` ${match.usage}` : "");
@@ -68,7 +68,7 @@ function buildSubcommandInlineHint(subcommands: SubcommandDef[]): (argumentText:
 		// Subcommand typed — show remaining usage params
 		const subName = trimmed.slice(0, spaceIndex).toLowerCase();
 		const afterSub = trimmed.slice(spaceIndex + 1);
-		const sub = subcommands.find(s => s.name === subName);
+		const sub = subcommands.find(s => s.name.toLowerCase() === subName);
 		if (!sub?.usage) return null;
 
 		if (afterSub.length > 0) {

--- a/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
+++ b/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
@@ -6,7 +6,6 @@ import {
 	type GajaePixelFrameName,
 	type GajaePixelFrames,
 	getCellDimensions,
-	ImageProtocol,
 	PARA_PARA_STEPS,
 	PET_SKINS,
 	type PetMode,
@@ -14,10 +13,10 @@ import {
 	petBurstDurationMs,
 	petBurstFrame,
 	registerAnimationCallback,
-	TERMINAL,
 	type TUI,
 } from "@gajae-code/tui";
 import type { CustomEditor } from "./custom-editor";
+import { getPetPixelProtocol } from "./pet-capability";
 
 /** Re-exported from the tui skin registry so widget-relative imports stay valid. */
 export type { PetMode, PetSkinId };
@@ -197,9 +196,7 @@ export class GajaePetWidget {
 
 	/** Protocol available for the real-pixel pet, if any. */
 	static pixelProtocol(): "sixel" | "kitty" | null {
-		if (TERMINAL.imageProtocol === ImageProtocol.Kitty) return "kitty";
-		if (TERMINAL.imageProtocol === ImageProtocol.Sixel) return "sixel";
-		return null;
+		return getPetPixelProtocol();
 	}
 
 	get mode(): PetMode {

--- a/packages/coding-agent/src/modes/components/pet-capability.ts
+++ b/packages/coding-agent/src/modes/components/pet-capability.ts
@@ -1,4 +1,11 @@
-import { ImageProtocol, isUnderTerminalMultiplexer, type SelectItem, TERMINAL } from "@gajae-code/tui";
+import {
+	ImageProtocol,
+	isUnderTerminalMultiplexer,
+	onImageProtocolChanged,
+	type SelectItem,
+	shouldProbeSixelCapability,
+	TERMINAL,
+} from "@gajae-code/tui";
 
 export type PetPixelProtocol = "sixel" | "kitty";
 
@@ -44,4 +51,65 @@ export function createPetSelectItems(
 			disabled,
 		};
 	});
+}
+
+/**
+ * Grace period before declaring the terminal pet-incapable at startup. The
+ * asynchronous Sixel capability probe starts inside `TUI.start()` and answers
+ * within its own 250 ms deadline; this margin covers probe scheduling so a
+ * supported terminal is never told it is incompatible while the probe is
+ * still in flight.
+ */
+export const PET_CAPABILITY_SETTLE_MS = 1_000;
+
+/**
+ * Whether the asynchronous startup Sixel capability probe may still enable
+ * graphics for this session, meaning current unavailability is not final.
+ */
+export function isPetCapabilityProbePending(
+	env: NodeJS.ProcessEnv = Bun.env,
+	platform: NodeJS.Platform = process.platform,
+): boolean {
+	if (TERMINAL.imageProtocol !== null) return false;
+	if (!process.stdin.isTTY || !process.stdout.isTTY) return false;
+	return shouldProbeSixelCapability(env, platform);
+}
+
+/**
+ * Deliver the pet-unavailable startup warning only once the capability
+ * question is settled. With no probe pending, unavailability is final and
+ * `onUnavailable` fires immediately. While a probe may still enable
+ * graphics, the warning is deferred: a protocol-change event cancels it (the
+ * saved pet re-applies through the existing subscription), and only the
+ * settle deadline passing with the terminal still unavailable emits it.
+ * Returns a disposer that cancels the pending decision.
+ */
+export function warnWhenPetCapabilitySettled(options: {
+	probePending: boolean;
+	isAvailable?: () => boolean;
+	onUnavailable: () => void;
+	settleMs?: number;
+}): () => void {
+	if (!options.probePending) {
+		options.onUnavailable();
+		return () => {};
+	}
+	const isAvailable = options.isAvailable ?? isPetAvailable;
+	let settled = false;
+	const finish = () => {
+		if (settled) return;
+		settled = true;
+		clearTimeout(timer);
+		unsubscribe();
+	};
+	const unsubscribe = onImageProtocolChanged(protocol => {
+		if (!protocol) return;
+		finish();
+	});
+	const timer = setTimeout(() => {
+		finish();
+		if (!isAvailable()) options.onUnavailable();
+	}, options.settleMs ?? PET_CAPABILITY_SETTLE_MS);
+	timer.unref?.();
+	return finish;
 }

--- a/packages/coding-agent/src/modes/components/pet-capability.ts
+++ b/packages/coding-agent/src/modes/components/pet-capability.ts
@@ -1,0 +1,47 @@
+import { ImageProtocol, isUnderTerminalMultiplexer, type SelectItem, TERMINAL } from "@gajae-code/tui";
+
+export type PetPixelProtocol = "sixel" | "kitty";
+
+export const PET_UNAVAILABLE_DESCRIPTION = "Unavailable: requires compatible Kitty or Sixel overlay rendering";
+export const PET_SAVED_UNAVAILABLE_DESCRIPTION =
+	"Saved, unavailable — requires compatible Kitty or Sixel overlay rendering";
+export const PET_UNAVAILABLE_WARNING =
+	"⚠ Pets aren’t available in this terminal. Its image support isn’t compatible with Gajae Pet’s overlay rendering yet. Try Kitty, Ghostty, WezTerm, or a terminal with compatible Sixel support.";
+const PET_MULTIPLEXER_UNAVAILABLE_WARNING =
+	"⚠ Gajae Pet graphics are unavailable inside tmux, screen, or zellij because image escapes are not forwarded end to end. Run gjc outside the multiplexer, or set PI_FORCE_IMAGE_PROTOCOL=sixel only when the full terminal chain supports Sixel.";
+
+export function getPetUnavailableWarning(env: NodeJS.ProcessEnv = Bun.env): string {
+	return isUnderTerminalMultiplexer(env) ? PET_MULTIPLEXER_UNAVAILABLE_WARNING : PET_UNAVAILABLE_WARNING;
+}
+
+export function getPetPixelProtocol(): PetPixelProtocol | null {
+	if (TERMINAL.imageProtocol === ImageProtocol.Kitty) return "kitty";
+	if (TERMINAL.imageProtocol === ImageProtocol.Sixel) return "sixel";
+	return null;
+}
+
+export function isPetAvailable(): boolean {
+	return getPetPixelProtocol() !== null;
+}
+
+export function createPetSelectItems(
+	options: ReadonlyArray<SelectItem>,
+	currentValue: string,
+	available: boolean,
+): SelectItem[] {
+	return options.map(option => {
+		const disabled = !available && option.value !== "off";
+		const current = option.value === currentValue;
+		const savedUnavailable = disabled && current;
+		let description = `${option.description ?? ""}${current ? " (current)" : ""}`;
+		if (disabled) {
+			description = savedUnavailable ? PET_SAVED_UNAVAILABLE_DESCRIPTION : PET_UNAVAILABLE_DESCRIPTION;
+		}
+		return {
+			...option,
+			label: savedUnavailable ? `${option.label} (saved)` : option.label,
+			description,
+			disabled,
+		};
+	});
+}

--- a/packages/coding-agent/src/modes/components/pet-selector.ts
+++ b/packages/coding-agent/src/modes/components/pet-selector.ts
@@ -1,7 +1,8 @@
-import { Container, PET_SKIN_IDS, PET_SKINS, type SelectItem, SelectList } from "@gajae-code/tui";
+import { Container, PET_SKIN_IDS, PET_SKINS, SelectList } from "@gajae-code/tui";
 import { getSelectListTheme } from "../theme/theme";
 import { DynamicBorder } from "./dynamic-border";
 import type { PetMode } from "./gajae-pet-widget";
+import { createPetSelectItems } from "./pet-capability";
 
 const PET_OPTIONS: { value: PetMode; label: string; description: string }[] = [
 	{ value: "off", label: "Off", description: "No pet" },
@@ -24,14 +25,11 @@ export class PetSelectorComponent extends Container {
 		onSelect: (mode: PetMode) => void,
 		onCancel: () => void,
 		onPreview: (mode: PetMode) => void,
+		available: boolean,
 	) {
 		super();
 
-		const items: SelectItem[] = PET_OPTIONS.map(option => ({
-			value: option.value,
-			label: option.label,
-			description: option.value === current ? `${option.description} (current)` : option.description,
-		}));
+		const items = createPetSelectItems(PET_OPTIONS, current, available);
 
 		this.addChild(new DynamicBorder());
 

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -25,6 +25,7 @@ import { getCurrentThemeName, getSelectListTheme, getSettingsListTheme, theme } 
 import { matchesAppInterrupt } from "../../modes/utils/keybinding-matchers";
 import { getTabBarTheme } from "../shared";
 import { DynamicBorder } from "./dynamic-border";
+import { createPetSelectItems, getPetUnavailableWarning, isPetAvailable } from "./pet-capability";
 import { handleInputOrEscape, PluginSettingsComponent } from "./plugin-settings";
 import { getSettingsForTab, type SettingDef } from "./settings-defs";
 import type { StatusLineSegmentOptions } from "./status-line";
@@ -661,6 +662,8 @@ export interface SettingsRuntimeContext {
 	availableModelProfiles: string[];
 	/** Working directory for plugins tab */
 	cwd: string;
+	/** Whether this terminal can render the pet overlay. */
+	petAvailable?: boolean;
 }
 
 /** Status line settings subset for preview */
@@ -684,6 +687,13 @@ export interface SettingsCallbacks {
 	onThemePreviewCancel?: (theme: string) => void | Promise<void>;
 	/** Called to live-preview the gajae pet skin while browsing the pet setting. */
 	onPetPreview?: (mode: string) => void;
+	/**
+	 * Commit a pet mode through the shared result-returning policy. The policy
+	 * rechecks capability immediately before mutation and owns persistence, so
+	 * the settings surface never persists `pet.mode` ahead of acceptance.
+	 * Returns whether the commit was accepted.
+	 */
+	onPetCommit?: (mode: string) => boolean;
 	/** Called for status line preview while configuring */
 	onStatusLinePreview?: (settings: StatusLinePreviewSettings) => void;
 	/** Get current rendered status line for inline preview */
@@ -841,7 +851,7 @@ export class SettingsSelectorComponent extends Container {
 		currentValue: string,
 		done: (value?: string) => void,
 	): Container {
-		let options = def.options;
+		let options: ReadonlyArray<SelectItem> = def.options;
 
 		// Special case: inject runtime options for thinking level
 		if (def.path === "defaultThinkingLevel") {
@@ -856,6 +866,14 @@ export class SettingsSelectorComponent extends Container {
 		}
 		if (def.path === "statusLine.preset") {
 			options = options.filter(option => option.value !== "custom");
+		}
+		let description = def.description;
+		if (def.path === "pet.mode") {
+			const petAvailable = this.context.petAvailable ?? isPetAvailable();
+			options = createPetSelectItems(options, currentValue, petAvailable);
+			// Unsupported terminals must see the same actionable guidance the
+			// startup notice and /pet show, not only dimmed option descriptions.
+			if (!petAvailable) description = getPetUnavailableWarning();
 		}
 		// Preview handlers
 		let onPreview: ((value: string) => void | Promise<void>) | undefined;
@@ -943,10 +961,18 @@ export class SettingsSelectorComponent extends Container {
 
 		return new SelectSubmenu(
 			def.label,
-			def.description,
+			description,
 			options,
 			currentValue,
 			value => {
+				if (def.path === "pet.mode") {
+					// The shared pet commit policy rechecks capability immediately
+					// before mutation and persists only on acceptance; the settings
+					// surface must not persist ahead of that result.
+					const accepted = this.callbacks.onPetCommit?.(value) ?? false;
+					done(accepted ? value : undefined);
+					return;
+				}
 				this.#setSettingValue(def.path, value);
 				this.callbacks.onChange(def.path, value);
 				done(value);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -79,6 +79,7 @@ import { HistorySearchComponent } from "../components/history-search";
 import { JobsOverlayComponent } from "../components/jobs-overlay";
 import { ModelSelectorComponent } from "../components/model-selector";
 import { OAuthSelectorComponent } from "../components/oauth-selector";
+import { isPetAvailable } from "../components/pet-capability";
 import { PetSelectorComponent } from "../components/pet-selector";
 import { PluginSelectorComponent } from "../components/plugin-selector";
 import {
@@ -492,6 +493,7 @@ export class SelectorController {
 						availableThemes,
 						availableModelProfiles: [...this.ctx.session.modelRegistry.getModelProfiles().keys()],
 						cwd: getProjectDir(),
+						petAvailable: isPetAvailable(),
 					},
 					{
 						onChange: (id, value) => this.handleSettingChange(id, value),
@@ -514,6 +516,7 @@ export class SelectorController {
 						onPetPreview: mode => {
 							this.ctx.previewPetMode(mode as PetMode);
 						},
+						onPetCommit: mode => this.ctx.commitPetPreviewMode(mode as PetMode),
 						onStatusLinePreview: previewSettings => {
 							// Update status line with preview settings
 							this.ctx.statusLine.updateSettings({
@@ -591,6 +594,7 @@ export class SelectorController {
 	showPetSelector(): void {
 		const stored = settings.get("pet.mode");
 		const initial: PetMode = isPetMode(stored) ? stored : "off";
+		const available = isPetAvailable();
 		this.showSelector(done => {
 			// Live-preview via previewMode (no editor re-mount, so the overlay stays);
 			// Enter commits + persists, Esc restores the initial skin.
@@ -607,6 +611,7 @@ export class SelectorController {
 				mode => {
 					this.ctx.previewPetMode(mode);
 				},
+				available,
 			);
 			return { component: selector, focus: selector.getSelectList() };
 		});
@@ -762,11 +767,6 @@ export class SelectorController {
 				});
 				break;
 			}
-			case "pet.mode":
-				// The settings submenu already persisted the value; commit it without
-				// re-mounting the composer while the settings overlay is open.
-				this.ctx.commitPetPreviewMode(value as PetMode);
-				break;
 			case "symbolPreset": {
 				setSymbolPreset(value as "unicode" | "nerd" | "ascii").then(() => {
 					this.ctx.statusLine.invalidate();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -87,7 +87,12 @@ import type { HookEditorComponent } from "./components/hook-editor";
 import type { HookInputComponent } from "./components/hook-input";
 import type { HookSelectorComponent } from "./components/hook-selector";
 import { IrcSplitViewComponent } from "./components/irc-sidebar";
-import { getPetUnavailableWarning, isPetAvailable } from "./components/pet-capability";
+import {
+	getPetUnavailableWarning,
+	isPetAvailable,
+	isPetCapabilityProbePending,
+	warnWhenPetCapabilitySettled,
+} from "./components/pet-capability";
 import { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import {
@@ -390,6 +395,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	#cleanupUnsubscribe?: () => void;
 	#subprocessTeardownUnsubscribe?: () => void;
 	#petProtocolUnsubscribe?: () => void;
+	/** Cancels a startup pet-unavailable warning still awaiting probe settlement. */
+	#petUnavailableWarningDisposer?: () => void;
 	readonly #version: string;
 	readonly #changelogMarkdown: string | undefined;
 	#planModePreviousTools: string[] | undefined;
@@ -635,7 +642,17 @@ export class InteractiveMode implements InteractiveModeContext {
 			}
 		});
 		if (configuredPetMode !== "off" && !isPetAvailable()) {
-			this.showStatus(theme.fg("warning", getPetUnavailableWarning()), { dim: false });
+			// The async Sixel capability probe (started by TUI.start()) may still
+			// enable graphics; warn only once the capability question is settled
+			// so a supported terminal is never told it is incompatible.
+			this.#petUnavailableWarningDisposer?.();
+			this.#petUnavailableWarningDisposer = warnWhenPetCapabilitySettled({
+				probePending: isPetCapabilityProbePending(),
+				onUnavailable: () => {
+					this.showStatus(theme.fg("warning", getPetUnavailableWarning()), { dim: false });
+					this.ui.requestRender();
+				},
+			});
 		}
 
 		this.#inputController.setupKeyHandlers();
@@ -2116,6 +2133,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	stop(): void {
 		this.#petProtocolUnsubscribe?.();
 		this.#petProtocolUnsubscribe = undefined;
+		this.#petUnavailableWarningDisposer?.();
+		this.#petUnavailableWarningDisposer = undefined;
 		this.petWidget?.dispose();
 		this.petWidget = undefined;
 		if (this.loadingAnimation) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -87,6 +87,7 @@ import type { HookEditorComponent } from "./components/hook-editor";
 import type { HookInputComponent } from "./components/hook-input";
 import type { HookSelectorComponent } from "./components/hook-selector";
 import { IrcSplitViewComponent } from "./components/irc-sidebar";
+import { getPetUnavailableWarning, isPetAvailable } from "./components/pet-capability";
 import { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import {
@@ -633,6 +634,9 @@ export class InteractiveMode implements InteractiveModeContext {
 				this.petWidget.setMode(saved);
 			}
 		});
+		if (configuredPetMode !== "off" && !isPetAvailable()) {
+			this.showStatus(theme.fg("warning", getPetUnavailableWarning()), { dim: false });
+		}
 
 		this.#inputController.setupKeyHandlers();
 		this.#inputController.setupEditorSubmitHandler();
@@ -1080,10 +1084,26 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.editor.setTopBorder(undefined);
 	}
 
-	setPetMode(mode: PetMode): void {
-		this.petWidget?.setMode(mode);
+	/**
+	 * Single result-returning pet commit policy shared by every entry path
+	 * (`/pet`, the pet selector, and the Settings submenu). Capability is
+	 * rechecked immediately before mutation, and the preference persists only
+	 * after the commit is accepted.
+	 */
+	#commitPetMode(mode: PetMode, apply: (mode: PetMode) => void): boolean {
+		if (mode !== "off" && !isPetAvailable()) {
+			this.showStatus(theme.fg("warning", getPetUnavailableWarning()), { dim: false });
+			this.ui.requestRender();
+			return false;
+		}
+		apply(mode);
 		settings.set("pet.mode", mode);
 		this.ui.requestRender();
+		return true;
+	}
+
+	setPetMode(mode: PetMode): boolean {
+		return this.#commitPetMode(mode, next => this.petWidget?.setMode(next));
 	}
 
 	previewPetMode(mode: PetMode): void {
@@ -1091,9 +1111,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.requestRender();
 	}
 
-	commitPetPreviewMode(mode: PetMode): void {
-		this.petWidget?.commitPreviewMode(mode);
-		this.ui.requestRender();
+	commitPetPreviewMode(mode: PetMode): boolean {
+		return this.#commitPetMode(mode, next => this.petWidget?.commitPreviewMode(next));
 	}
 
 	restoreComposer(): void {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -176,11 +176,19 @@ export interface InteractiveModeContext {
 	setWorkingMessage(message?: string): void;
 	applyPendingWorkingMessage(): void;
 	ensureLoadingAnimation(): void;
-	setPetMode(mode: PetMode): void;
+	/**
+	 * Commit a pet mode through the shared result-returning policy: capability
+	 * is rechecked immediately before mutation and the preference persists only
+	 * on acceptance. Returns whether the commit was accepted.
+	 */
+	setPetMode(mode: PetMode): boolean;
 	/** Live-preview a pet skin during a selector without persisting. */
 	previewPetMode(mode: PetMode): void;
-	/** Commit a settings-overlay pet preview without re-mounting the composer. */
-	commitPetPreviewMode(mode: PetMode): void;
+	/**
+	 * Commit a settings-overlay pet change without re-mounting the composer.
+	 * Same shared commit policy and result semantics as `setPetMode`.
+	 */
+	commitPetPreviewMode(mode: PetMode): boolean;
 	/** Re-mount the composer (pet-aware) after an overlay/selector closes. */
 	restoreComposer(): void;
 	startPendingSubmission(input: {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -3,15 +3,7 @@ import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import { type Model, modelsAreEqual } from "@gajae-code/ai";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
-import {
-	isPetMode,
-	isUnderTerminalMultiplexer,
-	PET_MODE_IDS,
-	PET_SKIN_IDS,
-	PET_SKINS,
-	Spacer,
-	Text,
-} from "@gajae-code/tui";
+import { PET_SKINS, type PetMode, Spacer, Text } from "@gajae-code/tui";
 import { setProjectDir } from "@gajae-code/utils";
 import { jobElapsedMs } from "../async";
 import { materializeActiveModelProfileAssignments } from "../config/model-profile-activation";
@@ -30,7 +22,6 @@ import {
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../discovery/helpers.js";
 import { resolveMemoryBackend } from "../memory-backend";
 import { DynamicBorder } from "../modes/components/dynamic-border";
-import { GajaePetWidget } from "../modes/components/gajae-pet-widget";
 import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
 import {
@@ -72,6 +63,22 @@ export type { BuiltinSlashCommand, SubcommandDef } from "./types";
 
 /** TUI-specific runtime accepted by `executeBuiltinSlashCommand`. */
 export type BuiltinSlashCommandRuntime = TuiSlashCommandRuntime;
+
+const PET_COMMAND_OPTIONS: ReadonlyArray<{ name: string; mode: PetMode; description: string }> = [
+	{ name: "off", mode: "off", description: "Hide the pet" },
+	{ name: "RedGajae", mode: "red", description: PET_SKINS.red.description },
+	{ name: "BlueGajae", mode: "blue", description: PET_SKINS.blue.description },
+];
+const PET_COMMAND_HINT = `[${PET_COMMAND_OPTIONS.map(option => option.name).join("|")}]`;
+/**
+ * Deprecated inputs kept accepted for compatibility (`/pet on|red|blue`).
+ * Display, completion, and inline hints stay canonical (`PET_COMMAND_OPTIONS`).
+ */
+const PET_COMMAND_DEPRECATED_INPUTS: Readonly<Record<string, PetMode>> = {
+	on: "red",
+	red: "red",
+	blue: "blue",
+};
 
 type GjcModelBatchAssignmentTargetId = "all-role-agents" | "all-targets";
 type ParsedModelCommandArgs =
@@ -570,34 +577,29 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "pet",
 		description: "Gajae pet living beside the composer",
-		subcommands: [
-			{ name: "off", description: "Hide the pet" },
-			...PET_SKIN_IDS.map(id => ({ name: id, description: PET_SKINS[id].description })),
-		],
-		inlineHint: `[${PET_MODE_IDS.join("|")}]`,
+		subcommands: PET_COMMAND_OPTIONS.map(option => ({ name: option.name, description: option.description })),
+		inlineHint: PET_COMMAND_HINT,
 		allowArgs: true,
 		handleTui: (command, runtime) => {
 			const ctx = runtime.ctx;
 			const raw = command.args?.trim().toLowerCase() ?? "";
-			const arg = raw === "on" ? "red" : raw;
-			if (!arg) {
+			const arg =
+				PET_COMMAND_OPTIONS.find(option => option.name.toLowerCase() === raw)?.mode ??
+				PET_COMMAND_DEPRECATED_INPUTS[raw];
+			if (!raw) {
 				ctx.showPetSelector();
 				ctx.editor.setText("");
 				return;
 			}
-			if (arg !== "off" && !GajaePetWidget.pixelProtocol()) {
-				ctx.showStatus(
-					isUnderTerminalMultiplexer()
-						? "Gajae pet: graphics are suppressed inside tmux/screen/zellij — escapes are not forwarded end-to-end. Run gjc outside the multiplexer in a sixel/kitty-graphics terminal, or set PI_FORCE_IMAGE_PROTOCOL=sixel when your multiplexer+client chain renders sixel."
-						: "Gajae pet needs a sixel/kitty-graphics terminal (Windows Terminal 1.22+, kitty, Ghostty, WezTerm)",
-					{ dim: true },
-				);
-			} else if (isPetMode(arg)) {
-				ctx.setPetMode(arg);
-				const name = arg === "off" ? "Gajae pet hidden" : `${PET_SKINS[arg].label} is here`;
-				ctx.showStatus(name);
+			if (arg) {
+				// The shared commit policy rechecks capability, persists only on
+				// acceptance, and surfaces the actionable warning on rejection.
+				if (ctx.setPetMode(arg)) {
+					const name = arg === "off" ? "Gajae pet hidden" : `${PET_SKINS[arg].label} is here`;
+					ctx.showStatus(name);
+				}
 			} else {
-				ctx.showStatus(`Usage: /pet [${PET_MODE_IDS.join("|")}]`, { dim: true });
+				ctx.showStatus(`Usage: /pet ${PET_COMMAND_HINT}`, { dim: true });
 			}
 			ctx.editor.setText("");
 		},

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -631,4 +631,35 @@ describe("InteractiveMode.setEditorComponent", () => {
 			setTerminalImageProtocol(originalProtocol);
 		}
 	});
+
+	it("commits pet modes through the shared result-returning policy", () => {
+		const originalProtocol = TERMINAL.imageProtocol;
+		vi.spyOn(mode, "refreshSlashCommandState").mockResolvedValue();
+		try {
+			settings.set("pet.mode", "off");
+			const showStatus = vi.spyOn(mode, "showStatus").mockImplementation(() => {});
+
+			// Capability is rechecked immediately before mutation: a rejected
+			// commit surfaces the warning and never persists.
+			setTerminalImageProtocol(null);
+			expect(mode.setPetMode("red")).toBe(false);
+			expect(settings.get("pet.mode")).toBe("off");
+			expect(mode.petWidget?.mode ?? "off").toBe("off");
+			expect(showStatus).toHaveBeenCalledTimes(1);
+
+			expect(mode.commitPetPreviewMode("red")).toBe(false);
+			expect(settings.get("pet.mode")).toBe("off");
+			expect(showStatus).toHaveBeenCalledTimes(2);
+
+			// An accepted commit persists only after the widget mutation applies.
+			setTerminalImageProtocol(ImageProtocol.Sixel);
+			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+			expect(mode.setPetMode("red")).toBe(true);
+			expect(settings.get("pet.mode")).toBe("red");
+			expect(mode.commitPetPreviewMode("off")).toBe(true);
+			expect(settings.get("pet.mode")).toBe("off");
+		} finally {
+			setTerminalImageProtocol(originalProtocol);
+		}
+	});
 });

--- a/packages/coding-agent/test/modes/components/pet-capability.test.ts
+++ b/packages/coding-agent/test/modes/components/pet-capability.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import {
+	PET_CAPABILITY_SETTLE_MS,
+	warnWhenPetCapabilitySettled,
+} from "@gajae-code/coding-agent/modes/components/pet-capability";
+import { ImageProtocol, setTerminalImageProtocol, TERMINAL } from "@gajae-code/tui";
+
+const originalProtocol = TERMINAL.imageProtocol;
+
+afterEach(() => {
+	setTerminalImageProtocol(originalProtocol);
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("warnWhenPetCapabilitySettled", () => {
+	it("warns immediately when no probe can change the answer", () => {
+		const onUnavailable = vi.fn();
+
+		warnWhenPetCapabilitySettled({ probePending: false, onUnavailable });
+
+		expect(onUnavailable).toHaveBeenCalledTimes(1);
+	});
+
+	it("never warns when the pending probe enables graphics before the deadline", () => {
+		vi.useFakeTimers();
+		setTerminalImageProtocol(null);
+		const onUnavailable = vi.fn();
+
+		const dispose = warnWhenPetCapabilitySettled({ probePending: true, onUnavailable });
+		try {
+			// Startup ordering: no warning may fire while the probe is in flight.
+			expect(onUnavailable).not.toHaveBeenCalled();
+
+			// The probe succeeds (e.g. Windows Terminal answering XTSMGRAPHICS).
+			setTerminalImageProtocol(ImageProtocol.Sixel);
+			vi.advanceTimersByTime(PET_CAPABILITY_SETTLE_MS * 2);
+
+			expect(onUnavailable).not.toHaveBeenCalled();
+		} finally {
+			dispose();
+		}
+	});
+
+	it("warns exactly once when the settle deadline passes with the terminal still unavailable", () => {
+		vi.useFakeTimers();
+		setTerminalImageProtocol(null);
+		const onUnavailable = vi.fn();
+
+		const dispose = warnWhenPetCapabilitySettled({ probePending: true, onUnavailable });
+		try {
+			expect(onUnavailable).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(PET_CAPABILITY_SETTLE_MS * 2);
+
+			expect(onUnavailable).toHaveBeenCalledTimes(1);
+		} finally {
+			dispose();
+		}
+	});
+
+	it("stays silent when disposed before settlement", () => {
+		vi.useFakeTimers();
+		setTerminalImageProtocol(null);
+		const onUnavailable = vi.fn();
+
+		const dispose = warnWhenPetCapabilitySettled({ probePending: true, onUnavailable });
+		dispose();
+		vi.advanceTimersByTime(PET_CAPABILITY_SETTLE_MS * 2);
+
+		expect(onUnavailable).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/modes/components/pet-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/pet-selector.test.ts
@@ -1,0 +1,58 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import {
+	createPetSelectItems,
+	getPetUnavailableWarning,
+	PET_UNAVAILABLE_WARNING,
+} from "@gajae-code/coding-agent/modes/components/pet-capability";
+import { PetSelectorComponent } from "@gajae-code/coding-agent/modes/components/pet-selector";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+
+function stripAnsi(text: string): string {
+	return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+beforeAll(async () => {
+	await initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+});
+
+describe("PetSelectorComponent", () => {
+	it("shows saved named pets but keeps unavailable ones unselectable", () => {
+		const onSelect = vi.fn();
+		const onPreview = vi.fn();
+		const component = new PetSelectorComponent("red", onSelect, () => {}, onPreview, false);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+
+		expect(rendered).toContain("RedGajae (saved)");
+		expect(rendered).toContain("BlueGajae");
+		expect(rendered).toContain("Saved, unavailable");
+		expect(stripAnsi(component.render(40).join("\n"))).toContain("RedGajae (saved)");
+		expect(component.getSelectList().getSelectedItem()?.value).toBe("off");
+
+		component.getSelectList().handleInput("\x1b[B");
+		expect(component.getSelectList().getSelectedItem()?.value).toBe("off");
+		expect(onPreview).not.toHaveBeenCalled();
+	});
+
+	it("decorates settings options through the shared capability policy", () => {
+		const items = createPetSelectItems(
+			[
+				{ value: "off", label: "Off" },
+				{ value: "red", label: "RedGajae" },
+				{ value: "blue", label: "BlueGajae" },
+			],
+			"blue",
+			false,
+		);
+
+		expect(items.find(item => item.value === "off")?.disabled).toBe(false);
+		expect(items.find(item => item.value === "red")?.disabled).toBe(true);
+		expect(items.find(item => item.value === "blue")?.description).toContain("Saved, unavailable");
+	});
+
+	it("preserves multiplexer-specific recovery guidance", () => {
+		const warning = getPetUnavailableWarning({ TMUX: "/tmp/tmux-1/default,1,0" });
+		expect(warning).toContain("outside the multiplexer");
+		expect(warning).toContain("PI_FORCE_IMAGE_PROTOCOL=sixel");
+		expect(getPetUnavailableWarning({})).toBe(PET_UNAVAILABLE_WARNING);
+	});
+});

--- a/packages/coding-agent/test/modes/components/settings-selector-pet.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-pet.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
+import { SettingsSelectorComponent } from "@gajae-code/coding-agent/modes/components/settings-selector";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+beforeEach(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+});
+
+afterEach(() => {
+	resetSettingsForTest();
+});
+
+function makeComponent(petAvailable: boolean, callbacks: Record<string, unknown>): SettingsSelectorComponent {
+	return new SettingsSelectorComponent(
+		{
+			availableThinkingLevels: [],
+			thinkingLevel: undefined,
+			availableThemes: ["dark"],
+			availableModelProfiles: [],
+			cwd: process.cwd(),
+			petAvailable,
+		},
+		{ onChange: () => {}, onCancel: () => {}, ...callbacks },
+	);
+}
+
+function openPetSetting(component: SettingsSelectorComponent): void {
+	for (let attempt = 0; attempt < 100; attempt++) {
+		const rendered = stripVTControlCharacters(component.render(160).join("\n"));
+		if (rendered.includes("16x16 real-pixel gajae living beside the composer")) {
+			component.handleInput("\n");
+			return;
+		}
+		component.handleInput("\x1b[B");
+	}
+	throw new Error("Gajae Pet setting was not reachable");
+}
+
+describe("SettingsSelectorComponent pet capability", () => {
+	it("shows a saved unavailable pet, permits only Off, and routes the commit through the shared policy", () => {
+		settings.set("pet.mode", "red");
+		const onChange = vi.fn();
+		const onPetPreview = vi.fn();
+		const onPetCommit = vi.fn((mode: string) => {
+			// Simulate the InteractiveMode policy: accept and persist on acceptance.
+			settings.set("pet.mode", mode as never);
+			return true;
+		});
+		const component = makeComponent(false, { onChange, onPetPreview, onPetCommit });
+
+		openPetSetting(component);
+		const submenu = stripVTControlCharacters(component.render(80).join("\n"));
+		expect(submenu).toContain("RedGajae (saved)");
+		expect(submenu).toContain("BlueGajae");
+		expect(submenu).toContain("Saved, unavailable");
+		expect(stripVTControlCharacters(component.render(40).join("\n"))).toContain("RedGajae (saved)");
+
+		component.handleInput("\x1b[B");
+		expect(onPetPreview).not.toHaveBeenCalled();
+		component.handleInput("\n");
+
+		// The settings surface never persists pet.mode itself and never routes
+		// it through the generic onChange path; the shared policy owns both.
+		expect(onPetCommit).toHaveBeenCalledWith("off");
+		expect(onChange).not.toHaveBeenCalled();
+		expect(settings.get("pet.mode")).toBe("off");
+	});
+
+	it("shows the actionable unavailable warning inside the pet submenu", () => {
+		settings.set("pet.mode", "red");
+		const component = makeComponent(false, {});
+
+		openPetSetting(component);
+		const submenu = stripVTControlCharacters(component.render(200).join("\n"));
+
+		// Same guidance as startup and /pet (normal-terminal variant in tests);
+		// dimmed option descriptions alone are not sufficient.
+		expect(submenu).toContain("Ghostty");
+	});
+
+	it("does not persist pet.mode when the commit policy rejects at select time", () => {
+		settings.set("pet.mode", "off");
+		const onChange = vi.fn();
+		// The submenu was built while the capability looked available, but the
+		// policy rechecks at commit time and rejects (TOCTOU race).
+		const onPetCommit = vi.fn(() => false);
+		const component = makeComponent(true, { onChange, onPetCommit });
+
+		openPetSetting(component);
+		component.handleInput("\x1b[B"); // move to an enabled skin choice
+		component.handleInput("\n");
+
+		expect(onPetCommit).toHaveBeenCalledTimes(1);
+		expect(onChange).not.toHaveBeenCalled();
+		expect(settings.get("pet.mode")).toBe("off");
+	});
+});

--- a/packages/coding-agent/test/slash-command-builtin-registry.test.ts
+++ b/packages/coding-agent/test/slash-command-builtin-registry.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { BUILTIN_SLASH_COMMANDS } from "@gajae-code/coding-agent/extensibility/slash-commands";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
 import {
 	BUILTIN_SLASH_COMMAND_DEFS,
@@ -6,6 +8,18 @@ import {
 	executeBuiltinSlashCommand,
 	lookupBuiltinSlashCommand,
 } from "@gajae-code/coding-agent/slash-commands/builtin-registry";
+import { ImageProtocol, TERMINAL } from "@gajae-code/tui";
+
+const mutableTerminal = TERMINAL as unknown as { imageProtocol: ImageProtocol | null };
+const originalImageProtocol = mutableTerminal.imageProtocol;
+
+beforeAll(async () => {
+	await initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+});
+
+afterEach(() => {
+	mutableTerminal.imageProtocol = originalImageProtocol;
+});
 
 function createTuiRuntime() {
 	const handleCopyCommand = vi.fn();
@@ -41,11 +55,77 @@ function createClearTuiRuntime() {
 }
 
 describe("builtin /pet slash command", () => {
-	it("exposes off plus the registry-driven skin choices", () => {
+	it("exposes the named Gajae choices", () => {
 		const petCommand = BUILTIN_SLASH_COMMAND_DEFS.find(command => command.name === "pet");
 
-		expect(petCommand?.subcommands?.map(command => command.name)).toEqual(["off", "red", "blue"]);
-		expect(petCommand?.inlineHint).toBe("[off|red|blue]");
+		expect(petCommand?.subcommands?.map(command => command.name)).toEqual(["off", "RedGajae", "BlueGajae"]);
+		expect(petCommand?.inlineHint).toBe("[off|RedGajae|BlueGajae]");
+	});
+
+	it("maps named Gajae commands to their internal modes", async () => {
+		mutableTerminal.imageProtocol = ImageProtocol.Kitty;
+		const setPetMode = vi.fn((_mode: string) => true);
+		const setText = vi.fn();
+		const showStatus = vi.fn();
+		const ctx = { setPetMode, showStatus, editor: { setText } } as unknown as InteractiveModeContext;
+		const runtime = { ctx, handleBackgroundCommand: () => undefined };
+
+		expect(await executeBuiltinSlashCommand("/pet redgajae", runtime)).toBe(true);
+		expect(await executeBuiltinSlashCommand("/pet BlueGajae", runtime)).toBe(true);
+
+		expect(setPetMode.mock.calls.map(call => call[0])).toEqual(["red", "blue"]);
+	});
+
+	it("keeps deprecated on/red/blue inputs accepted while display stays canonical", async () => {
+		mutableTerminal.imageProtocol = ImageProtocol.Kitty;
+		const setPetMode = vi.fn((_mode: string) => true);
+		const showStatus = vi.fn();
+		const ctx = { setPetMode, showStatus, editor: { setText: vi.fn() } } as unknown as InteractiveModeContext;
+
+		for (const token of ["red", "blue", "on"]) {
+			expect(
+				await executeBuiltinSlashCommand(`/pet ${token}`, { ctx, handleBackgroundCommand: () => undefined }),
+			).toBe(true);
+		}
+
+		// Deprecated inputs still commit, mapped to their canonical modes.
+		expect(setPetMode.mock.calls.map(call => call[0])).toEqual(["red", "blue", "red"]);
+		// The public surface stays canonical: no deprecated names in subcommands.
+		const petCommand = BUILTIN_SLASH_COMMAND_DEFS.find(command => command.name === "pet");
+		expect(petCommand?.subcommands?.map(command => command.name)).toEqual(["off", "RedGajae", "BlueGajae"]);
+
+		// Unknown tokens still fall through to usage guidance.
+		expect(await executeBuiltinSlashCommand("/pet purple", { ctx, handleBackgroundCommand: () => undefined })).toBe(
+			true,
+		);
+		expect(showStatus).toHaveBeenLastCalledWith("Usage: /pet [off|RedGajae|BlueGajae]", { dim: true });
+		expect(setPetMode).toHaveBeenCalledTimes(3);
+	});
+
+	it("suppresses the success status when the shared commit policy rejects", async () => {
+		mutableTerminal.imageProtocol = null;
+		const setPetMode = vi.fn((_mode: string) => false);
+		const showStatus = vi.fn();
+		const ctx = { setPetMode, showStatus, editor: { setText: vi.fn() } } as unknown as InteractiveModeContext;
+
+		expect(await executeBuiltinSlashCommand("/pet RedGajae", { ctx, handleBackgroundCommand: () => undefined })).toBe(
+			true,
+		);
+		// The commit policy owns the rejection warning; the handler must not
+		// claim success or bypass the policy with its own capability check.
+		expect(setPetMode).toHaveBeenCalledWith("red");
+		expect(showStatus).not.toHaveBeenCalled();
+	});
+
+	it("completes named pets case-insensitively", async () => {
+		const petCommand = BUILTIN_SLASH_COMMANDS.find(command => command.name === "pet");
+
+		for (const prefix of ["r", "R", "ReD"]) {
+			const completions = await petCommand?.getArgumentCompletions?.(prefix);
+			expect(completions?.map(item => item.label)).toEqual(["RedGajae"]);
+		}
+
+		expect(petCommand?.getInlineHint?.("ReD")).toBe("Gajae");
 	});
 });
 describe("builtin /copy slash command", () => {


### PR DESCRIPTION
## What

Make every Gajae Pet selection surface capability-aware, reconstructed exactly as the #2136 closure prescribed: a **single intentional commit directly on current `dev`** (`5523b722`, which contains both merged dependencies — the #2154 disabled-SelectList contract and the #2182 exception-safe overlay cleanup). All #2136 review blockers are addressed.

- New `pet-capability` module centralizes protocol detection, availability, unavailable-warning copy, and select-item decoration for every pet surface.
- Unsupported terminals show an actionable warning on startup (when a saved pet cannot render), on `/pet`, and **inside the Settings pet submenu** (same normal-terminal/multiplexer guidance as the other surfaces — not just dimmed option descriptions).
- `/pet` and Settings disable the unavailable `RedGajae`/`BlueGajae` choices via the merged SelectList `disabled` contract while `off` stays selectable; a saved-but-unavailable choice is labeled `(saved)`.
- **Single result-returning commit policy** shared by `/pet`, the pet selector, and the Settings submenu: capability is rechecked immediately before mutation and `pet.mode` persists only after acceptance. The Settings surface no longer snapshots capability, persists first, or invokes an unvalidated commit callback — the TOCTOU identified in the #2136 review is closed (`setPetMode`/`commitPetPreviewMode` return the commit result; the Settings submenu routes through `onPetCommit` and never pre-persists).
- **Deprecated `on`/`red`/`blue` inputs stay accepted** for compatibility, mapped to canonical modes, while display, completion, and inline hints stay canonical (`/pet off|RedGajae|BlueGajae`, matched case-insensitively).

## Why

On terminals without Kitty/Sixel graphics, `/pet` and the Settings pet entry offer fully selectable choices that silently do nothing, and the command surface mixes naming (`/pet red` vs the skin labels). This makes every selection surface consistent with the active terminal capability without breaking existing muscle memory, and closes the Settings persist-before-validate race.

## Testing

On this exact head (base `5523b722`):

- Focused suites — **69 pass, 0 fail**:
  - `settings-selector-pet` (shared-policy routing with no pre-persist and no generic `onChange` for `pet.mode`, in-submenu actionable warning, TOCTOU rejection leaves the setting untouched)
  - `slash-command-builtin-registry` (canonical surface, deprecated `on`/`red`/`blue` acceptance mapped to canonical modes, unknown-token usage guidance, policy-rejection suppresses the success status, case-insensitive completion)
  - `interactive-mode-editor-component` (policy accept/reject persistence and warning; pre-existing Windows temp-dir `EBUSY` in this file reproduces identically on clean `dev` locally — Linux CI is authoritative and has been green for it on #2134/#2153/#2182)
  - `gajae-pet-widget` (26; unchanged lifecycle coverage on top of merged #2182)
  - `select-list` (17; merged #2154 contract consumed unchanged)
- `bun --cwd=packages/coding-agent run check` (biome + SDK canonicalization + tsc) — green.
- `git diff --check` — clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
