### PR TITLE
fix(tui): retain final pet cleanup until delivery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fenced SDK WebSocket lifecycle callbacks and request settlement to the owning retry cycle/socket incarnation, so stale open, close, error, message, and timeout delivery cannot reject or corrupt work on a replacement connection; sent mutations remain non-replayed and deterministic race regressions cover the reconnect boundary (#2164).
 
 - Gajae Pet overlays no longer leak images or stale pixels across lifecycle changes: each widget owns a randomized Kitty image ID (deleted on disable, replace, switch, and dispose), the previous Sixel footprint is tracked and erased on movement, resize, and narrow-terminal fallback, replaced pet widgets are disposed before their successors install, and a saved pet preference survives editor replacement while graphics are still unavailable (so a delayed Sixel capability probe can still activate it). Teardown is exception-safe and idempotent: a failed or unavailable terminal write never aborts logical disposal or steals a successor widget's overlay slot, and Sixel/Kitty cleanup authority is retained until the erase is actually delivered so a later mode switch or dispose retries it.
+- Gajae Pet cleanup that fails during final widget disposal is now retained by the TUI for retry, and Kitty image IDs remain reserved until their exact-ID delete is delivered.
 
 ## [0.10.1] - 2026-07-13
 

--- a/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
+++ b/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
@@ -290,14 +290,20 @@ export class GajaePetWidget {
 	dispose(): void {
 		if (this.#disposed) return;
 		this.#disposed = true;
+		const kittyImageId = this.#kittyImageId;
+		const cleanupPayload = this.#imageCleanupPayload();
 		try {
-			this.#writeImageCleanup();
-		} finally {
-			// Logical teardown must reach its final state even if terminal I/O fails.
-			if (this.#kittyImageId !== undefined) {
-				allocatedPetKittyImageIds.delete(this.#kittyImageId);
-				this.#kittyImageId = undefined;
+			if (cleanupPayload) {
+				this.#ui.queueTerminalCleanup(
+					`\x1b[?2026h\x1b7${cleanupPayload}\x1b8\x1b[?2026l`,
+					kittyImageId === undefined ? undefined : () => allocatedPetKittyImageIds.delete(kittyImageId),
+				);
+			} else if (kittyImageId !== undefined) {
+				allocatedPetKittyImageIds.delete(kittyImageId);
 			}
+			this.#consumeCleanupAuthority();
+			this.#kittyImageId = undefined;
+		} finally {
 			this.#animation?.unregister();
 			this.#animation = undefined;
 			this.#releaseOverlayEmitter();

--- a/packages/coding-agent/test/gajae-pet-widget.test.ts
+++ b/packages/coding-agent/test/gajae-pet-widget.test.ts
@@ -26,6 +26,19 @@ function makeStubs(columns = 80, rows = 30) {
 	let emitter: (() => string | null) | undefined;
 	let available = true;
 	let failWrites = false;
+	const pendingTerminalCleanup: Array<{ payload: string; onDelivered?: () => void }> = [];
+	const flushTerminalCleanup = () => {
+		while (available && pendingTerminalCleanup.length > 0) {
+			const pending = pendingTerminalCleanup[0];
+			try {
+				terminal.write(pending.payload);
+			} catch {
+				return;
+			}
+			pendingTerminalCleanup.shift();
+			pending.onDelivered?.();
+		}
+	};
 	const terminal = {
 		columns,
 		rows,
@@ -38,6 +51,10 @@ function makeStubs(columns = 80, rows = 30) {
 		requestRender: () => {},
 		setPostRenderEmitter: (fn?: () => string | null) => {
 			emitter = fn;
+		},
+		queueTerminalCleanup: (payload: string, onDelivered?: () => void) => {
+			pendingTerminalCleanup.push({ payload, onDelivered });
+			flushTerminalCleanup();
 		},
 		get terminalAvailable() {
 			return available;
@@ -65,6 +82,8 @@ function makeStubs(columns = 80, rows = 30) {
 		setWriteFailure: (value: boolean) => {
 			failWrites = value;
 		},
+		flushTerminalCleanup,
+		getPendingTerminalCleanupCount: () => pendingTerminalCleanup.length,
 	};
 }
 
@@ -216,6 +235,73 @@ describe("GajaePetWidget", () => {
 		} finally {
 			widget.dispose();
 		}
+	});
+
+	it("retries Sixel cleanup that fails during final disposal", () => {
+		const { flushTerminalCleanup, getEmitter, getPendingTerminalCleanupCount, setWriteFailure, widget, written } =
+			makeWidget();
+		widget.setMode("red");
+		expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+		written.length = 0;
+
+		setWriteFailure(true);
+		widget.dispose();
+		expect(getPendingTerminalCleanupCount()).toBe(1);
+		expect(written).toHaveLength(0);
+
+		setWriteFailure(false);
+		flushTerminalCleanup();
+		expect(getPendingTerminalCleanupCount()).toBe(0);
+		expect(written.some(chunk => chunk.includes("\x1b[28;76H\x1b[4X"))).toBe(true);
+	});
+
+	it("reserves a Kitty image ID until failed final-disposal cleanup is delivered", () => {
+		const imageIds = [101, 101, 202, 101];
+		vi.spyOn(crypto, "getRandomValues").mockImplementation(values => {
+			if (!values) throw new Error("Expected a typed array");
+			const ids = new Uint32Array(
+				values.buffer,
+				values.byteOffset,
+				values.byteLength / Uint32Array.BYTES_PER_ELEMENT,
+			);
+			ids[0] = imageIds.shift() ?? 303;
+			return values;
+		});
+
+		const stubs = makeStubs();
+		const makeKitty = () =>
+			new GajaePetWidget({
+				ui: stubs.ui,
+				editor: stubs.editor,
+				editorContainer: stubs.editorContainer,
+				floorContainer: stubs.floorContainer,
+				isWorking: () => false,
+				getComposerBottomOffset: () => 0,
+				forcePixelProtocol: "kitty",
+				autoFlexGapMs: null,
+			});
+
+		const first = makeKitty();
+		first.setMode("red");
+		expect(stubs.getEmitter()?.()).toContain("i=101");
+		stubs.setWriteFailure(true);
+		first.dispose();
+		expect(stubs.getPendingTerminalCleanupCount()).toBe(1);
+
+		const second = makeKitty();
+		second.setMode("red");
+		expect(stubs.getEmitter()?.()).toContain("i=202");
+
+		stubs.setWriteFailure(false);
+		stubs.flushTerminalCleanup();
+		expect(stubs.getPendingTerminalCleanupCount()).toBe(0);
+		expect(stubs.written.some(chunk => chunk.includes("a=d,d=I,i=101"))).toBe(true);
+
+		const third = makeKitty();
+		third.setMode("red");
+		expect(stubs.getEmitter()?.()).toContain("i=101");
+		second.dispose();
+		third.dispose();
 	});
 
 	it("completes logical teardown when the cleanup write throws", () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Shared the temporary stdout error listener across terminal instances, preventing `MaxListenersExceededWarning` during repeated TUI start/stop cycles while retaining late detached-PTY error handling.
+- Added a TUI-lifetime terminal cleanup queue so component-owned escape cleanup can be retried after terminal recovery even when the originating component has already been disposed.
 
 ### Added
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -629,6 +629,7 @@ export class TUI extends Container {
 	#stopped = false;
 	#terminalUnavailable = false;
 	#bottomPinnedComponent: Component | null = null;
+	#pendingTerminalCleanup: Array<{ payload: string; onDelivered?: () => void }> = [];
 
 	#unsubscribeTabWidthChange?: () => void;
 	static #renderCounters: TuiRenderCounterSnapshot = {
@@ -973,6 +974,7 @@ export class TUI extends Container {
 				this.requestResizeRender();
 			},
 		);
+		this.flushTerminalCleanup();
 		this.#hideCursor();
 		this.#querySixelSupport();
 		this.#queryCellSize();
@@ -1182,6 +1184,7 @@ export class TUI extends Container {
 	}
 
 	stop(): void {
+		this.flushTerminalCleanup();
 		this.#clearSixelProbeState();
 		this.#stopped = true;
 		if (this.#renderTimer) {
@@ -2587,6 +2590,22 @@ export class TUI extends Container {
 		}
 
 		return { seq, toRow: targetRow };
+	}
+
+	/** Retain terminal cleanup until a write succeeds, even after its component is disposed. */
+	queueTerminalCleanup(payload: string, onDelivered?: () => void): void {
+		this.#pendingTerminalCleanup.push({ payload, onDelivered });
+		this.flushTerminalCleanup();
+	}
+
+	/** Retry queued terminal cleanup after terminal recovery or before shutdown. */
+	flushTerminalCleanup(): void {
+		while (this.#pendingTerminalCleanup.length > 0) {
+			const pending = this.#pendingTerminalCleanup[0];
+			if (!this.#writeTerminal(pending.payload)) return;
+			this.#pendingTerminalCleanup.shift();
+			pending.onDelivered?.();
+		}
 	}
 
 	/**

--- a/packages/tui/test/terminal-detach.test.ts
+++ b/packages/tui/test/terminal-detach.test.ts
@@ -44,6 +44,11 @@ class DetachingTerminal implements Terminal {
 		this.#hideCursorFails = fails;
 	}
 
+	setWriteFailureAt(writeFailureAt: number | undefined): void {
+		this.#writeFailureAt = writeFailureAt;
+		if (writeFailureAt === undefined) this.#available = true;
+	}
+
 	start(_onInput: (data: string) => void, _onResize: () => void): void {}
 
 	stop(): void {}
@@ -328,5 +333,21 @@ describe("terminal detach handling", () => {
 		expect(() => tui.requestRender(true)).not.toThrow();
 		await settle();
 		expect(terminal.writes.length).toBe(writesBeforeCursorFailure);
+	});
+	it("retries component cleanup after terminal recovery", async () => {
+		const terminal = new DetachingTerminal(1);
+		const tui = new TUI(terminal);
+		const delivered = vi.fn();
+
+		tui.queueTerminalCleanup("pet-cleanup", delivered);
+		expect(delivered).not.toHaveBeenCalled();
+		expect(terminal.writes).toEqual([]);
+
+		terminal.setWriteFailureAt(undefined);
+		tui.start();
+		await settle();
+		expect(delivered).toHaveBeenCalledTimes(1);
+		expect(terminal.writes).toContain("pet-cleanup");
+		tui.stop();
 	});
 });


### PR DESCRIPTION
## Summary
- add a minimal TUI-owned FIFO for terminal cleanup that must outlive a disposed component
- move only final Gajae Pet disposal cleanup into that queue
- keep Kitty image IDs reserved until the queued exact-ID delete is acknowledged
- retry pending cleanup on terminal restart and before orderly stop

This is the narrow remaining contract delta identified while closing dirty duplicate #2185 after #2182 merged. It intentionally excludes terminal error reclassification, successor serialization, structured render emissions, and the broad duplicated rewrite.

## Regression coverage
- Sixel erase write fails during final disposal, then succeeds through the retained TUI queue
- Kitty exact-ID delete fails during final disposal; the ID cannot be reused until delivery, then becomes reusable
- TUI queue survives terminal failure and acknowledges exactly once after restart

## Verification
- `bun test packages/tui/test/terminal-detach.test.ts packages/coding-agent/test/gajae-pet-widget.test.ts` (36 pass)
- `bun --cwd=packages/tui run check`
- `bun --cwd=packages/coding-agent run check:types`

Signed-off-by: GJC Maintainer Review <gjc-maintainer@gajae.dev>